### PR TITLE
feat(mobile): Timer bar, ticket-detail start/stop, and weekly timesheet (#3206 W05)

### DIFF
--- a/apps/mobile/src/components/TabIcons.tsx
+++ b/apps/mobile/src/components/TabIcons.tsx
@@ -74,3 +74,22 @@ export function SettingsIcon({ color, size }: Props) {
   );
 }
 
+
+// Clock face for the Time tab: a ring with hour and minute hands. Deliberately
+// not a stopwatch — the tab is the weekly timesheet, and the running-timer
+// affordance is the TimerBar sitting directly above it.
+export function TimeIcon({ color, size }: Props) {
+  return (
+    <Svg width={size} height={size} viewBox="0 0 24 24">
+      <Circle cx={12} cy={12} r={8.5} stroke={color} strokeWidth={1.75} fill="none" />
+      <Path
+        d="M12 7 L12 12 L15.5 14"
+        stroke={color}
+        strokeWidth={1.75}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+      />
+    </Svg>
+  );
+}

--- a/apps/mobile/src/components/TimerBar.tsx
+++ b/apps/mobile/src/components/TimerBar.tsx
@@ -1,0 +1,532 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { palette, radii, spacing, type } from '../theme';
+import { useAppDispatch, useAppSelector } from '../store';
+import {
+  elapsedSeconds,
+  needsAttentionChanged,
+  pendingWritesChanged,
+  runningTimerAdopted,
+  stoppedTimer,
+  timeAccessDenied,
+} from '../store/timeSlice';
+import {
+  createTimeEntry,
+  getRunningTimer,
+  getTimesheet,
+  stopTimer,
+  updateTimeEntry,
+} from '../services/timeEntries';
+import {
+  drain,
+  enqueue,
+  parkNeedsAttention,
+  readNeedsAttention,
+  readQueue,
+  reconcileQueueOwner,
+  type QueuedWrite,
+} from '../services/timeEntryQueue';
+import { makeReplaySender } from '../services/timeEntryReplay';
+import { serverNowMs } from '../services/serverClock';
+import {
+  clearLocalTimer,
+  readLocalTimer,
+  stampNow,
+  writeLocalTimer,
+} from '../services/localTimer';
+import {
+  makeReconciledSender,
+  needsReconciliation,
+  planReconciliation,
+  type ReconcilePlan,
+} from '../services/timerReconcile';
+import { weekStartFor } from '../screens/time/timesheetWeek';
+import { classifyTimeEntryDenial, isAccountLevelDenial } from '../services/timeEntryAccess';
+import { stopRunningTimer } from '../screens/tickets/timerActions';
+import { stopOutcomeEffects } from '../screens/tickets/timerOutcomeEffects';
+import { isQueueWedged, isTimerBarVisible, shouldReplayNow } from './timerBarLogic';
+import { useNetworkConnected } from '../lib/useNetworkConnected';
+import { formatElapsed } from '../lib/timeFormat';
+import { ticketRef } from '../screens/tickets/ticketCopy';
+import { Toast } from './Toast';
+
+/**
+ * Persistent running-timer affordance, mounted above the tab bar.
+ *
+ * It is also the app's single queue-replay owner: it is the one component
+ * alive for the whole signed-in session, so subscribing here means a
+ * reconnection replays the backlog no matter which tab the technician is on.
+ */
+export function TimerBar({ onOpenTimesheet }: { onOpenTimesheet?: () => void } = {}) {
+  const dispatch = useAppDispatch();
+  const connected = useNetworkConnected();
+  const running = useAppSelector((state) => state.time.running);
+  const pendingCount = useAppSelector((state) => state.time.pendingCount);
+  const denial = useAppSelector((state) => state.time.denial);
+  const tickets = useAppSelector((state) => state.tickets.tickets);
+  const userId = useAppSelector((state) => state.auth.user?.id ?? null);
+  /**
+   * Standing count, not a toast. A toast for work that could not be saved is
+   * gone in four seconds and takes the only notice of unbilled minutes with it.
+   * It lives in the store because the ticket screen can park a row too.
+   */
+  const needsAttentionCount = useAppSelector((state) => state.time.needsAttentionCount);
+
+  const [now, setNow] = useState(() => new Date());
+  const [busy, setBusy] = useState(false);
+  const [toast, setToast] = useState<{ kind: 'success' | 'error'; text: string } | null>(null);
+  /**
+   * The head write keeps failing on a status the queue (correctly) retains —
+   * usually a 403, which issue #4251 makes the ORDINARY state for a default
+   * Partner Technician, not an exotic one. `headAttempts` was added as this
+   * signal and had no consumer, so a wedged queue replayed silently forever.
+   */
+  const [wedged, setWedged] = useState(false);
+  /** A local timer whose start request may also have landed on the server. */
+  const [startUnconfirmed, setStartUnconfirmed] = useState(false);
+
+  const mounted = useRef(true);
+  const stopInFlight = useRef(false);
+  const wasConnected = useRef(connected);
+  // Read by the cold-start effect, which must not re-run on every reconnection.
+  const connectedRef = useRef(connected);
+  /**
+   * No drain may run before the queue's owner has been established. Otherwise a
+   * reconnection landing first would replay the PREVIOUS technician's unsent
+   * writes under this session's bearer token — the leak that keeping the queue
+   * across an involuntary session loss would otherwise open.
+   */
+  const ownerReady = useRef(false);
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  /** Returns the depth, or null when storage could not be read. */
+  const refreshQueueDepth = useCallback(async (): Promise<number | null> => {
+    try {
+      const queued = await readQueue();
+      if (mounted.current) dispatch(pendingWritesChanged(queued.length));
+      return queued.length;
+    } catch {
+      // QueueStorageError — keep the last known depth. Reporting zero would
+      // tell the technician their unsent minutes are already saved.
+      return null;
+    }
+  }, [dispatch]);
+
+  // 1s tick, only while something is actually running.
+  useEffect(() => {
+    if (running === null) return;
+    setNow(new Date());
+    const interval = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(interval);
+  }, [running]);
+
+  const refreshNeedsAttention = useCallback(async (): Promise<void> => {
+    const rows = await readNeedsAttention().catch(() => null);
+    if (rows !== null && mounted.current) dispatch(needsAttentionChanged(rows.length));
+  }, [dispatch]);
+
+  /**
+   * Resolves what the server actually has before replaying anything that could
+   * duplicate it.
+   *
+   * Only runs when this device is holding something ambiguous — an unconfirmed
+   * local start, or a queued `create` flagged `unconfirmedStart` — so the
+   * ordinary reconnect still costs exactly one drain.
+   */
+  const reconcile = useCallback(async (queue: QueuedWrite[]): Promise<ReconcilePlan> => {
+    const empty: ReconcilePlan = { adopt: null, substitute: null };
+    const localTimer = await readLocalTimer().catch(() => null);
+    if (mounted.current) setStartUnconfirmed(localTimer !== null && !localTimer.startConfirmed);
+    if (!needsReconciliation(localTimer, queue)) return empty;
+
+    let server;
+    try {
+      server = await getRunningTimer();
+    } catch {
+      // Never block a drain on the reconciliation probe: the writes are safe to
+      // send, and the worst case is a duplicate the technician can delete.
+      return empty;
+    }
+
+    const plan = planReconciliation({ localTimer, queue, server });
+    if (plan.adopt !== null && localTimer !== null) {
+      const adopted = {
+        ...localTimer,
+        serverEntryId: plan.adopt.serverEntryId,
+        startedAtWall: plan.adopt.startedAt,
+        startConfirmed: true,
+      };
+      await writeLocalTimer(adopted).catch(() => undefined);
+      if (mounted.current) {
+        setStartUnconfirmed(false);
+        dispatch(
+          runningTimerAdopted({
+            id: plan.adopt.serverEntryId,
+            localId: null,
+            ticketId: adopted.ticketId,
+            startedAt: plan.adopt.startedAt,
+            description: adopted.description,
+          })
+        );
+      }
+    }
+    return plan;
+  }, [dispatch]);
+
+  const replay = useCallback(async () => {
+    let queue: QueuedWrite[];
+    try {
+      queue = await readQueue();
+    } catch {
+      // QueueStorageError: the queue is intact and untouched, so the next
+      // reconnect tries again rather than draining a view we could not read.
+      return;
+    }
+    const plan = await reconcile(queue);
+
+    const base = makeReplaySender({
+      createTimeEntry,
+      updateTimeEntry,
+      serverNow: () => serverNowMs().ms,
+    });
+    const send = makeReconciledSender({
+      base,
+      plan,
+      updateTimeEntry,
+      lookupWeekEntries: async (write) => {
+        const startedAt = write.payload.startedAt;
+        if (typeof startedAt !== 'string') return null;
+        const week = await getTimesheet(weekStartFor(new Date(startedAt))).catch(() => null);
+        return week === null ? null : week.days.flatMap((day) => day.entries);
+      },
+    });
+
+    try {
+      const result = await drain(send);
+      if (!mounted.current) return;
+      dispatch(pendingWritesChanged(result.remaining));
+      dispatch(needsAttentionChanged(result.needsAttentionTotal));
+      // A retained failure that has burned several attempts is not "offline":
+      // nothing behind it can move until somebody acts.
+      setWedged(isQueueWedged(result));
+      if (result.needsAttention.length > 0) {
+        setToast({
+          kind: 'error',
+          text:
+            result.needsAttention.length === 1
+              ? '1 time entry needs attention. Re-enter it from the timesheet.'
+              : `${result.needsAttention.length} time entries need attention. Re-enter them from the timesheet.`,
+        });
+      } else if (result.sent > 0) {
+        // Only writes that actually reached the server are reported as synced —
+        // never ones that merely moved to needs-attention.
+        setToast({ kind: 'success', text: `Synced ${result.sent} offline time ${result.sent === 1 ? 'entry' : 'entries'}` });
+      }
+      // A reconciled or externally started entry can be running without the
+      // store knowing, so the server stays the authority on what is live.
+      try {
+        const timer = await getRunningTimer();
+        if (mounted.current && timer !== null) dispatch(runningTimerAdopted(timer));
+        else if (mounted.current && timer === null) {
+          const stillLocal = await readLocalTimer().catch(() => null);
+          // Do NOT clear a device-only timer just because the server has none:
+          // it is not supposed to be there yet.
+          if (stillLocal === null) dispatch(runningTimerAdopted(null));
+        }
+      } catch {
+        // Leave the local view alone rather than clearing a real timer.
+      }
+    } catch {
+      await refreshQueueDepth();
+      await refreshNeedsAttention();
+    }
+  }, [dispatch, reconcile, refreshQueueDepth, refreshNeedsAttention]);
+
+  useEffect(() => {
+    const previous = wasConnected.current;
+    wasConnected.current = connected;
+    connectedRef.current = connected;
+    if (
+      ownerReady.current &&
+      shouldReplayNow({ coldStart: false, previousConnected: previous, connected, pendingCount })
+    ) {
+      void replay();
+    }
+  }, [connected, pendingCount, replay]);
+
+  // Cold start: the authority on "is a timer running" is the server, not this
+  // process. A timer started from the web dashboard, or before a reinstall,
+  // must appear here rather than being invisible until the next start 409s.
+  //
+  // It is also the only chance a backlog from a PREVIOUS launch gets to drain:
+  // `useNetworkConnected` seeds `true`, so an app relaunched at the office on
+  // strong WiFi never sees the false -> true edge the effect above waits for,
+  // and the unsent entries would sit behind their badge indefinitely. Declared
+  // after that effect so `connectedRef` already holds this render's value.
+  useEffect(() => {
+    let cancelled = false;
+    ownerReady.current = false;
+    void (async () => {
+      // Claim the queue for THIS account before anything can replay it. An
+      // unowned queue is adopted; one left by a different technician is parked
+      // and cleared. This — not the sign-out hook — is what makes a
+      // cross-account replay impossible, because it runs on every path into a
+      // session, including a re-login after a token expiry.
+      if (userId !== null) await reconcileQueueOwner(userId).catch(() => null);
+      ownerReady.current = true;
+      const depth = await refreshQueueDepth();
+      await refreshNeedsAttention();
+      // A device-only timer survives a relaunch, and nothing on the server can
+      // reveal it — without this the bar would be blank until the next tap.
+      const localTimer = await readLocalTimer().catch(() => null);
+      if (localTimer !== null && localTimer.serverEntryId === null && !cancelled && mounted.current) {
+        setStartUnconfirmed(!localTimer.startConfirmed);
+        dispatch(
+          runningTimerAdopted({
+            id: null,
+            localId: localTimer.localId,
+            ticketId: localTimer.ticketId,
+            startedAt: localTimer.startedAtWall,
+            description: localTimer.description,
+          })
+        );
+      }
+      try {
+        const timer = await getRunningTimer();
+        // A null answer must not clear a device-only timer: the server is not
+        // supposed to know about one yet.
+        if (!cancelled && mounted.current && (timer !== null || localTimer === null)) {
+          dispatch(runningTimerAdopted(timer));
+        }
+      } catch (error) {
+        const denied = classifyTimeEntryDenial(error);
+        // Only an account-shaped verdict is a wall. Recording a per-row 403
+        // here would withdraw time tracking app-wide until sign-out.
+        if (denied !== null && isAccountLevelDenial(denied) && !cancelled && mounted.current) {
+          // Record it once so every time surface reports the same explicit
+          // reason instead of a blank screen.
+          dispatch(timeAccessDenied(denied));
+        }
+        // Any other failure is transient; the bar simply stays hidden.
+      }
+      if (
+        !cancelled &&
+        mounted.current &&
+        shouldReplayNow({
+          coldStart: true,
+          previousConnected: wasConnected.current,
+          connected: connectedRef.current,
+          pendingCount: depth ?? 0,
+        })
+      ) {
+        await replay();
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [dispatch, refreshQueueDepth, refreshNeedsAttention, replay, userId]);
+
+  const onStop = useCallback(async () => {
+    if (stopInFlight.current) return;
+    stopInFlight.current = true;
+    setBusy(true);
+    try {
+      const outcome = await stopRunningTimer(
+        { running },
+        {
+          stopTimer,
+          enqueue,
+          readLocalTimer,
+          clearLocalTimer,
+          parkNeedsAttention,
+          isConnected: () => connected,
+          stamp: stampNow,
+        }
+      );
+      if (!mounted.current) return;
+      // One decision table, shared with TicketDetailScreen — see
+      // screens/tickets/timerOutcomeEffects.ts.
+      const effects = stopOutcomeEffects(outcome);
+      if (effects.clearRunning) {
+        dispatch(stoppedTimer());
+        setStartUnconfirmed(false);
+      }
+      if (effects.accountDenial !== null) dispatch(timeAccessDenied(effects.accountDenial));
+      if (effects.refreshQueueDepth) await refreshQueueDepth();
+      if (effects.refreshNeedsAttention) await refreshNeedsAttention();
+      if (mounted.current) setToast(effects.toast);
+    } finally {
+      stopInFlight.current = false;
+      if (mounted.current) setBusy(false);
+    }
+  }, [connected, dispatch, refreshQueueDepth, refreshNeedsAttention, running]);
+
+  // The toast is a child of this bar, not a portal: unmounting on an emptied
+  // queue would swallow the "N offline time entries could not be saved"
+  // warning in exactly the case it exists for.
+  const visible = isTimerBarVisible({
+    hasRunningTimer: running !== null,
+    // A standing "needs attention" count keeps the bar mounted on its own: it
+    // is the only place unbilled work is reported once the toast has gone.
+    pendingCount: pendingCount + needsAttentionCount,
+    hasToast: toast !== null,
+  });
+  if (!visible) return null;
+
+  const ticket = running?.ticketId
+    ? tickets.find((candidate) => candidate.id === running.ticketId)
+    : undefined;
+  const label = running?.ticketId
+    ? ticketRef({ id: running.ticketId, internalNumber: ticket?.internalNumber ?? null })
+    : 'No ticket';
+
+  const bar = (
+    <View style={styles.bar} accessibilityRole="summary">
+      <View style={styles.left}>
+        {running !== null ? (
+          <>
+            <Text style={styles.clock} accessibilityLabel="Elapsed time">
+              {formatElapsed(elapsedSeconds(running, now))}
+            </Text>
+            <Text style={styles.ticket} numberOfLines={1}>
+              {label}
+            </Text>
+            {running.id === null ? (
+              <Text style={styles.chip} accessibilityLabel="Not yet synced">
+                Not yet synced
+              </Text>
+            ) : null}
+          </>
+        ) : (
+          <Text style={styles.ticket}>Time entries waiting to sync</Text>
+        )}
+      </View>
+
+      {pendingCount > 0 ? (
+        <View style={styles.badge} accessibilityLabel={`${pendingCount} unsent time entries`}>
+          <Text style={styles.badgeText}>{pendingCount}</Text>
+        </View>
+      ) : null}
+
+      {running !== null && denial === null ? (
+        <Pressable
+          onPress={() => void onStop()}
+          disabled={busy}
+          accessibilityRole="button"
+          accessibilityLabel="Stop timer"
+          accessibilityState={{ disabled: busy }}
+          style={[styles.stop, busy && styles.stopDisabled]}
+        >
+          <Text style={styles.stopText}>{busy ? '…' : 'Stop'}</Text>
+        </Pressable>
+      ) : null}
+
+      <Toast
+        visible={toast !== null}
+        text={toast?.text ?? ''}
+        kind={toast?.kind ?? 'success'}
+        onHidden={() => setToast(null)}
+        bottomOffset={spacing['16']}
+      />
+    </View>
+  );
+
+  const notices = (
+    <>
+      {startUnconfirmed ? (
+        <Text style={styles.notice}>
+          Start not confirmed — a timer may also be running on the server.
+        </Text>
+      ) : null}
+      {needsAttentionCount > 0 ? (
+        <Pressable
+          onPress={onOpenTimesheet}
+          disabled={onOpenTimesheet === undefined}
+          accessibilityRole="button"
+          accessibilityLabel={`${needsAttentionCount} time ${needsAttentionCount === 1 ? 'entry needs' : 'entries need'} attention`}
+        >
+          <Text style={styles.noticeAlarm}>
+            {needsAttentionCount === 1
+              ? '1 time entry needs attention — open the timesheet'
+              : `${needsAttentionCount} time entries need attention — open the timesheet`}
+          </Text>
+        </Pressable>
+      ) : null}
+      {wedged ? (
+        <Text style={styles.noticeAlarm}>
+          Time entries are not syncing. Your role may be missing the time-entries permission.
+        </Text>
+      ) : null}
+    </>
+  );
+
+  return (
+    <View>
+      {notices}
+      {bar}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  bar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing['3'],
+    paddingHorizontal: spacing['4'],
+    paddingVertical: spacing['2'],
+    backgroundColor: palette.dark.bg1,
+    borderTopWidth: 1,
+    borderTopColor: palette.dark.border,
+  },
+  left: { flex: 1, flexDirection: 'row', alignItems: 'center', gap: spacing['2'] },
+  clock: { ...type.monoMd, color: palette.dark.textHi },
+  ticket: { ...type.meta, color: palette.dark.textMd, flexShrink: 1 },
+  badge: {
+    minWidth: 22,
+    paddingHorizontal: spacing['2'],
+    paddingVertical: 2,
+    borderRadius: radii.full,
+    backgroundColor: palette.warning.base,
+    alignItems: 'center',
+  },
+  badgeText: { ...type.meta, color: palette.dark.bg0 },
+  stop: {
+    paddingHorizontal: spacing['3'],
+    paddingVertical: spacing['2'],
+    borderRadius: radii.md,
+    backgroundColor: palette.deny.base,
+  },
+  stopDisabled: { opacity: 0.5 },
+  chip: {
+    ...type.meta,
+    color: palette.warning.base,
+    borderWidth: 1,
+    borderColor: palette.warning.base,
+    borderRadius: radii.full,
+    paddingHorizontal: spacing['2'],
+  },
+  notice: {
+    ...type.meta,
+    color: palette.dark.textMd,
+    backgroundColor: palette.dark.bg1,
+    paddingHorizontal: spacing['4'],
+    paddingVertical: spacing['1'],
+  },
+  noticeAlarm: {
+    ...type.meta,
+    color: palette.deny.base,
+    backgroundColor: palette.dark.bg1,
+    paddingHorizontal: spacing['4'],
+    paddingVertical: spacing['1'],
+  },
+  stopText: { ...type.meta, color: palette.deny.onBase },
+});

--- a/apps/mobile/src/components/timerBarLogic.test.ts
+++ b/apps/mobile/src/components/timerBarLogic.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+
+import { isQueueWedged, isTimerBarVisible, shouldReplayNow, WEDGED_ATTEMPTS } from './timerBarLogic';
+
+describe('isTimerBarVisible', () => {
+  it('stays mounted while a toast is pending even with an empty queue and no timer', () => {
+    // The replay result toast lives inside the bar. After a drain that empties
+    // the queue by DROPPING writes, remaining is 0 and running is null, so a
+    // visibility rule of "running || pending" unmounts the bar in the very
+    // render that would have shown "N offline time entries could not be saved".
+    // Discarded billable work would vanish with no signal anywhere.
+    expect(isTimerBarVisible({ hasRunningTimer: false, pendingCount: 0, hasToast: true })).toBe(true);
+  });
+
+  it('is hidden only when there is nothing running, nothing queued and nothing to say', () => {
+    expect(isTimerBarVisible({ hasRunningTimer: false, pendingCount: 0, hasToast: false })).toBe(false);
+  });
+
+  it('is visible for a running timer and for an unsent backlog', () => {
+    expect(isTimerBarVisible({ hasRunningTimer: true, pendingCount: 0, hasToast: false })).toBe(true);
+    expect(isTimerBarVisible({ hasRunningTimer: false, pendingCount: 2, hasToast: false })).toBe(true);
+  });
+});
+
+describe('shouldReplayNow', () => {
+  it('drains a backlog left by a previous launch when the app starts online', () => {
+    // useNetworkConnected seeds `true`, so an app relaunched at the office on
+    // strong WiFi never sees a false->true edge. Without a cold-start drain the
+    // "2" badge sits there until connectivity happens to drop and return.
+    expect(
+      shouldReplayNow({ coldStart: true, previousConnected: true, connected: true, pendingCount: 2 })
+    ).toBe(true);
+  });
+
+  it('does not drain an empty queue on cold start', () => {
+    expect(
+      shouldReplayNow({ coldStart: true, previousConnected: true, connected: true, pendingCount: 0 })
+    ).toBe(false);
+  });
+
+  it('does not drain on cold start while offline', () => {
+    expect(
+      shouldReplayNow({ coldStart: true, previousConnected: true, connected: false, pendingCount: 2 })
+    ).toBe(false);
+  });
+
+  it('drains on a false -> true reconnection regardless of the known depth', () => {
+    // The depth cached in the store can be stale (a storage read failed), and a
+    // reconnect is the one moment worth spending a drain on.
+    expect(
+      shouldReplayNow({ coldStart: false, previousConnected: false, connected: true, pendingCount: 0 })
+    ).toBe(true);
+  });
+
+  it('does not re-drain on a true -> true report', () => {
+    // Replaying on every render would race drain's own serialisation for no gain.
+    expect(
+      shouldReplayNow({ coldStart: false, previousConnected: true, connected: true, pendingCount: 3 })
+    ).toBe(false);
+  });
+
+  it('does not drain on losing the connection', () => {
+    expect(
+      shouldReplayNow({ coldStart: false, previousConnected: true, connected: false, pendingCount: 3 })
+    ).toBe(false);
+  });
+});
+
+describe('isQueueWedged', () => {
+  it('is false for a first failed attempt — that is just being offline', () => {
+    expect(isQueueWedged({ remaining: 3, headAttempts: 1 })).toBe(false);
+  });
+
+  it('is true once the head write has failed repeatedly and is blocking the rest', () => {
+    // The state issue #4251 makes ordinary: a default Partner Technician lacks
+    // time_entries:write, so every replay 403s. The queue correctly RETAINS
+    // those writes, which means nothing behind them can ever move — and before
+    // this predicate had a consumer, that happened in total silence.
+    expect(isQueueWedged({ remaining: 3, headAttempts: WEDGED_ATTEMPTS })).toBe(true);
+    expect(isQueueWedged({ remaining: 1, headAttempts: 50 })).toBe(true);
+  });
+
+  it('is false once the queue has drained, however many attempts it took', () => {
+    expect(isQueueWedged({ remaining: 0, headAttempts: 99 })).toBe(false);
+  });
+});

--- a/apps/mobile/src/components/timerBarLogic.ts
+++ b/apps/mobile/src/components/timerBarLogic.ts
@@ -1,0 +1,70 @@
+/**
+ * The two rules that decide when the timer bar is on screen and when it
+ * replays the offline backlog.
+ *
+ * Pure module (no React, no React Native) because the app has no component
+ * test runtime: both rules had a defect that only a test could pin, and both
+ * defects were silent.
+ */
+
+/**
+ * The replay-result toast is a child of the bar, not a portal, so the bar must
+ * outlive the queue to report on it. A drain that empties the queue by
+ * DROPPING writes returns `remaining: 0`; with no timer running, a rule of
+ * "running || pending" unmounts the bar in the very render that would have
+ * said "N offline time entries could not be saved" — discarded billable work
+ * vanishing with no signal anywhere in the UI.
+ */
+export function isTimerBarVisible(input: {
+  hasRunningTimer: boolean;
+  pendingCount: number;
+  hasToast: boolean;
+}): boolean {
+  return input.hasRunningTimer || input.pendingCount > 0 || input.hasToast;
+}
+
+/**
+ * When to drain.
+ *
+ * `useNetworkConnected` seeds `true` (it treats "unknown" as connected), so an
+ * app relaunched on strong WiFi never sees a false -> true edge: a backlog
+ * queued in a previous launch would sit behind its badge until connectivity
+ * happened to drop and return. Hence the explicit cold-start pass — gated on a
+ * non-empty queue so an ordinary launch spends no round trip.
+ *
+ * After that, only a false -> true transition: replaying on every render (or on
+ * a true -> true report) would race `drain`'s own serialisation for no gain.
+ */
+export function shouldReplayNow(input: {
+  coldStart: boolean;
+  previousConnected: boolean;
+  connected: boolean;
+  pendingCount: number;
+}): boolean {
+  if (!input.connected) return false;
+  if (input.coldStart) return input.pendingCount > 0;
+  return !input.previousConnected;
+}
+
+/**
+ * Attempts on the head write beyond which the queue is wedged, not merely
+ * behind a bad connection. Low deliberately: the retained statuses (401, 403,
+ * 408, 429) are exactly the ones that do not clear themselves, and three failed
+ * reconnects is already a technician who will otherwise see a badge that never
+ * goes down and never learn why.
+ */
+export const WEDGED_ATTEMPTS = 3;
+
+/**
+ * Whether the queue is stuck rather than waiting.
+ *
+ * `headAttempts` was added in round one precisely as this signal and had no
+ * consumer, so a queue wedged on a retained 403 replayed silently forever. That
+ * is not an exotic state: issue #4251 means a default Partner Technician
+ * genuinely lacks `time_entries:write`, so a permanent 403 is the EXPECTED
+ * outcome for many users. Surfacing it is the whole point — the writes are
+ * still there, and dropping them to unwedge the queue would destroy real work.
+ */
+export function isQueueWedged(input: { remaining: number; headAttempts: number }): boolean {
+  return input.remaining > 0 && input.headAttempts >= WEDGED_ATTEMPTS;
+}

--- a/apps/mobile/src/lib/timeFormat.test.ts
+++ b/apps/mobile/src/lib/timeFormat.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+
+import { formatElapsed, formatMinutes } from './timeFormat';
+
+describe('formatElapsed', () => {
+  it('renders HH:MM:SS zero-padded', () => {
+    expect(formatElapsed(0)).toBe('00:00:00');
+    expect(formatElapsed(9)).toBe('00:00:09');
+    expect(formatElapsed(150)).toBe('00:02:30');
+    expect(formatElapsed(3661)).toBe('01:01:01');
+  });
+
+  it('keeps counting past a day rather than wrapping to zero', () => {
+    // A timer left running overnight is a real (and expensive) field mistake.
+    // Wrapping to 00:00:0x would hide it at the exact moment it matters.
+    expect(formatElapsed(90000)).toBe('25:00:00');
+  });
+
+  it('never renders a negative clock', () => {
+    expect(formatElapsed(-30)).toBe('00:00:00');
+    expect(formatElapsed(Number.NaN)).toBe('00:00:00');
+  });
+});
+
+describe('formatMinutes', () => {
+  it('renders bare minutes under an hour', () => {
+    expect(formatMinutes(0)).toBe('0m');
+    expect(formatMinutes(45)).toBe('45m');
+  });
+
+  it('renders hours and zero-padded minutes at or above an hour', () => {
+    expect(formatMinutes(60)).toBe('1h 00m');
+    expect(formatMinutes(65)).toBe('1h 05m');
+    expect(formatMinutes(605)).toBe('10h 05m');
+  });
+
+  it('treats a missing duration as a dash, not as zero', () => {
+    // A running entry has durationMinutes: null. Showing "0m" would claim the
+    // technician has logged nothing on it.
+    expect(formatMinutes(null)).toBe('—');
+    expect(formatMinutes(undefined)).toBe('—');
+  });
+});

--- a/apps/mobile/src/lib/timeFormat.ts
+++ b/apps/mobile/src/lib/timeFormat.ts
@@ -1,0 +1,36 @@
+/**
+ * Duration formatting for the time-tracking surfaces.
+ *
+ * Pure module (no React Native imports) so both the timer bar and the
+ * timesheet share one implementation and it stays unit-testable.
+ */
+
+function pad2(value: number): string {
+  return value < 10 ? `0${value}` : String(value);
+}
+
+/**
+ * Running-timer clock, HH:MM:SS.
+ *
+ * Hours are NOT wrapped at 24: a timer left running overnight is a real and
+ * expensive field mistake, and rolling back to 00:00:0x would hide it at
+ * exactly the moment the technician needs to see it.
+ */
+export function formatElapsed(seconds: number): string {
+  const safe = Number.isFinite(seconds) ? Math.max(0, Math.floor(seconds)) : 0;
+  const hours = Math.floor(safe / 3600);
+  const minutes = Math.floor((safe % 3600) / 60);
+  return `${pad2(hours)}:${pad2(minutes)}:${pad2(safe % 60)}`;
+}
+
+/**
+ * Logged duration. `null`/`undefined` renders as an em dash rather than "0m":
+ * a still-running entry has `durationMinutes: null`, and showing zero would
+ * claim the technician has logged nothing on it.
+ */
+export function formatMinutes(minutes: number | null | undefined): string {
+  if (minutes === null || minutes === undefined || !Number.isFinite(minutes)) return '—';
+  const safe = Math.max(0, Math.round(minutes));
+  if (safe < 60) return `${safe}m`;
+  return `${Math.floor(safe / 60)}h ${pad2(safe % 60)}m`;
+}

--- a/apps/mobile/src/navigation/AppLockGate.tsx
+++ b/apps/mobile/src/navigation/AppLockGate.tsx
@@ -195,7 +195,7 @@ export function AppLockGate({ children }: Props) {
           onUnlock={attemptUnlock}
           onSignOut={() => {
             send({ type: 'signOutRequested', now: Date.now() });
-            void dispatch(logoutAsync());
+            void dispatch(logoutAsync({ deliberate: true }));
           }}
         />
       ) : lock.obscured || (lock.phase === 'booting' && Boolean(token)) ? (

--- a/apps/mobile/src/navigation/ApprovalGate.tsx
+++ b/apps/mobile/src/navigation/ApprovalGate.tsx
@@ -110,7 +110,7 @@ export function ApprovalGate({ children }: Props) {
           onDismiss={() => setDismissedApprover(true)}
           onSignOut={() => {
             setDismissedApprover(true);
-            void dispatch(logoutAsync());
+            void dispatch(logoutAsync({ deliberate: true }));
           }}
         />
       ) : null}

--- a/apps/mobile/src/navigation/MainNavigator.tsx
+++ b/apps/mobile/src/navigation/MainNavigator.tsx
@@ -1,5 +1,10 @@
+import { View } from 'react-native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import {
+  BottomTabBar,
+  createBottomTabNavigator,
+  type BottomTabBarProps,
+} from '@react-navigation/bottom-tabs';
 
 import { AlertDetailScreen } from '../screens/alerts/AlertDetailScreen';
 import { DeviceDetailScreen } from '../screens/devices/DeviceDetailScreen';
@@ -8,7 +13,9 @@ import { HomeScreen } from '../screens/chat/HomeScreen';
 import { SystemsScreen } from '../screens/systems/SystemsScreen';
 import { TicketsScreen } from '../screens/tickets/TicketsScreen';
 import { TicketDetailScreen } from '../screens/tickets/TicketDetailScreen';
-import { HomeIcon, SystemsIcon, TicketsIcon } from '../components/TabIcons';
+import { TimesheetScreen } from '../screens/time/TimesheetScreen';
+import { HomeIcon, SystemsIcon, TicketsIcon, TimeIcon } from '../components/TabIcons';
+import { TimerBar } from '../components/TimerBar';
 import { palette, fontFamily } from '../theme';
 import type { Alert, Device } from '../services/api';
 
@@ -28,6 +35,7 @@ export type MainTabParamList = {
   HomeTab: undefined;
   SystemsTab: undefined;
   TicketsTab: undefined;
+  TimeTab: undefined;
 };
 
 const Tab = createBottomTabNavigator<MainTabParamList>();
@@ -102,9 +110,28 @@ function SystemsStackNavigator() {
   );
 }
 
+/**
+ * The timer bar rides directly above the tab bar rather than inside any one
+ * screen: a running timer has to stay visible (and stoppable) wherever the
+ * technician navigates, and this is also the mount point that owns replaying
+ * the offline queue on reconnect. It renders nothing when no timer is running
+ * and nothing is queued, so it costs no vertical space in the common case.
+ */
+function TabBarWithTimer(props: BottomTabBarProps) {
+  return (
+    <View>
+      {/* The "N time entries need attention" row is only useful if it goes
+          somewhere: the timesheet is where the technician re-enters them. */}
+      <TimerBar onOpenTimesheet={() => props.navigation.navigate('TimeTab')} />
+      <BottomTabBar {...props} />
+    </View>
+  );
+}
+
 export function MainNavigator() {
   return (
     <Tab.Navigator
+      tabBar={(props: BottomTabBarProps) => <TabBarWithTimer {...props} />}
       screenOptions={{
         headerShown: false,
         tabBarActiveTintColor: palette.brand.base,
@@ -147,6 +174,16 @@ export function MainNavigator() {
           tabBarLabel: 'Tickets',
           tabBarIcon: ({ color, size }: { color: string; size: number }) => (
             <TicketsIcon color={color} size={size} />
+          ),
+        }}
+      />
+      <Tab.Screen
+        name="TimeTab"
+        component={TimesheetScreen}
+        options={{
+          tabBarLabel: 'Time',
+          tabBarIcon: ({ color, size }: { color: string; size: number }) => (
+            <TimeIcon color={color} size={size} />
           ),
         }}
       />

--- a/apps/mobile/src/navigation/RootNavigator.tsx
+++ b/apps/mobile/src/navigation/RootNavigator.tsx
@@ -52,7 +52,9 @@ export function RootNavigator() {
       if (blockedHandledRef.current) return;
       blockedHandledRef.current = true;
       setBlockedReason(reason);
-      void dispatch(logoutAsync());
+      // A blocked device is an INVOLUNTARY invalidation: the unsent
+      // time-entry backlog is kept (services/auth.ts).
+      void dispatch(logoutAsync({ deliberate: false }));
     });
     return off;
   }, [dispatch]);

--- a/apps/mobile/src/screens/chat/components/SettingsSheet.tsx
+++ b/apps/mobile/src/screens/chat/components/SettingsSheet.tsx
@@ -247,7 +247,7 @@ export function SettingsSheet({ visible, onCancel }: Props) {
         style: 'destructive',
         onPress: () => {
           onCancel();
-          dispatch(logoutAsync());
+          dispatch(logoutAsync({ deliberate: true }));
         },
       },
     ]);

--- a/apps/mobile/src/screens/tickets/TicketDetailScreen.tsx
+++ b/apps/mobile/src/screens/tickets/TicketDetailScreen.tsx
@@ -14,8 +14,29 @@ import type { RouteProp } from '@react-navigation/native';
 import { useRoute } from '@react-navigation/native';
 
 import { palette, radii, spacing, type } from '../../theme';
-import { useAppDispatch } from '../../store';
+import { useAppDispatch, useAppSelector } from '../../store';
 import { applyStatusChange, syncTicketFromDetail } from '../../store/ticketsSlice';
+import {
+  needsAttentionChanged,
+  pendingWritesChanged,
+  runningTimerAdopted,
+  stoppedTimer,
+  timeAccessDenied,
+} from '../../store/timeSlice';
+import { startTimer, stopTimer } from '../../services/timeEntries';
+import {
+  enqueue,
+  parkNeedsAttention,
+  readNeedsAttention,
+  readQueue,
+} from '../../services/timeEntryQueue';
+import {
+  clearLocalTimer,
+  readLocalTimer,
+  stampNow,
+  writeLocalTimer,
+} from '../../services/localTimer';
+import { useNetworkConnected } from '../../lib/useNetworkConnected';
 import {
   addTicketComment,
   allowedQuickStatuses,
@@ -32,6 +53,8 @@ import { relativeTime } from '../../lib/relativeTime';
 import { reportInternalError } from '../../lib/errorReporting';
 
 import { priorityColor, priorityLabel, statusLabel, ticketRef } from './ticketCopy';
+import { startForTicket, stopRunningTimer } from './timerActions';
+import { startOutcomeEffects, stopOutcomeEffects } from './timerOutcomeEffects';
 
 type DetailRoute = RouteProp<TicketsStackParamList, 'TicketDetail'>;
 
@@ -56,6 +79,15 @@ export function TicketDetailScreen() {
   const [pendingStatus, setPendingStatus] = useState<TicketStatus | null>(null);
   const [busy, setBusy] = useState(false);
   const [toast, setToast] = useState<{ kind: 'success' | 'error'; text: string } | null>(null);
+  const [timerNotice, setTimerNotice] = useState<string | null>(null);
+  const [timerBusy, setTimerBusy] = useState(false);
+
+  const connected = useNetworkConnected();
+  const running = useAppSelector((state) => state.time.running);
+  // Sticky for the session: once the server has refused this account the
+  // control is withdrawn rather than re-offered and failing (see timeSlice).
+  const timeDenial = useAppSelector((state) => state.time.denial);
+  const timerInFlight = useRef(false);
 
   // `busy` is render-captured, so two taps before React commits can both see
   // false and fire duplicate requests. This ref is the synchronous lock.
@@ -208,6 +240,96 @@ export function TicketDetailScreen() {
     [resolutionNote, ticketId, dispatch, load]
   );
 
+  /**
+   * The queue is the source of truth for "how much is unsent", so the depth is
+   * re-read from storage rather than incremented locally. On a storage failure
+   * the previous depth is kept: reporting zero pending writes would tell a
+   * technician their billable minutes are safe when they may not be.
+   */
+  const refreshQueueDepth = useCallback(async () => {
+    try {
+      const queued = await readQueue();
+      if (mounted.current) dispatch(pendingWritesChanged(queued.length));
+    } catch {
+      // QueueStorageError — leave the last known depth in place.
+    }
+  }, [dispatch]);
+
+  const onStartTimer = useCallback(async () => {
+    if (timerInFlight.current) return;
+    timerInFlight.current = true;
+    setTimerBusy(true);
+    setTimerNotice(null);
+    try {
+      const outcome = await startForTicket(ticketId, {
+        startTimer,
+        writeLocalTimer,
+        clearLocalTimer,
+        isConnected: () => connected,
+        stamp: stampNow,
+      });
+      if (!mounted.current) return;
+      // One decision table, shared with the TimerBar — see timerOutcomeEffects.ts.
+      const effects = startOutcomeEffects(outcome);
+      // `startRunning` may carry a null id: a timer started offline exists only
+      // on this device until its span is created, and it still has to tick.
+      if (effects.startRunning !== null) dispatch(runningTimerAdopted(effects.startRunning));
+      if (effects.accountDenial !== null) dispatch(timeAccessDenied(effects.accountDenial));
+      if (effects.refreshQueueDepth) await refreshQueueDepth();
+      if (!mounted.current) return;
+      setTimerNotice(effects.notice);
+      setToast(effects.toast);
+    } finally {
+      timerInFlight.current = false;
+      if (mounted.current) setTimerBusy(false);
+    }
+  }, [ticketId, connected, dispatch, refreshQueueDepth]);
+
+  const onStopTimer = useCallback(async () => {
+    if (timerInFlight.current) return;
+    timerInFlight.current = true;
+    setTimerBusy(true);
+    setTimerNotice(null);
+    try {
+      const outcome = await stopRunningTimer(
+        { running },
+        {
+          stopTimer,
+          enqueue,
+          readLocalTimer,
+          clearLocalTimer,
+          parkNeedsAttention,
+          isConnected: () => connected,
+          stamp: stampNow,
+        }
+      );
+      if (!mounted.current) return;
+      const effects = stopOutcomeEffects(outcome);
+      // A QUEUED stop clears the local timer too: the technician has said the
+      // timer is over and the queued write is what makes the server agree.
+      if (effects.clearRunning) dispatch(stoppedTimer());
+      if (effects.accountDenial !== null) dispatch(timeAccessDenied(effects.accountDenial));
+      if (effects.reload) {
+        // The stop writes a time-entry activity comment server-side, so the
+        // activity list below is stale until this lands.
+        void load();
+      }
+      if (effects.refreshQueueDepth) await refreshQueueDepth();
+      // A stop whose clock ran backwards parks a row from THIS screen, so the
+      // standing count has to be updated here — not at the next reconnect.
+      if (effects.refreshNeedsAttention) {
+        const parked = await readNeedsAttention().catch(() => null);
+        if (parked !== null && mounted.current) dispatch(needsAttentionChanged(parked.length));
+      }
+      if (!mounted.current) return;
+      setTimerNotice(effects.notice);
+      setToast(effects.toast);
+    } finally {
+      timerInFlight.current = false;
+      if (mounted.current) setTimerBusy(false);
+    }
+  }, [connected, dispatch, refreshQueueDepth, load, running]);
+
   if (loading && !ticket) {
     return (
       <View style={styles.centered}>
@@ -303,6 +425,49 @@ export function TicketDetailScreen() {
             accessibilityLabel="Resolution note"
           />
         ) : null}
+
+        <Text style={styles.sectionHeader}>TIME</Text>
+        {timeDenial ? (
+          // Not a generic failure: the technician is told which wall they hit
+          // and whether an administrator can move it.
+          <Text style={styles.timeDenied} accessibilityRole="text">
+            {timeDenial.message}
+          </Text>
+        ) : (
+          <>
+            <Pressable
+              onPress={() => (running ? void onStopTimer() : void onStartTimer())}
+              disabled={timerBusy}
+              accessibilityRole="button"
+              accessibilityLabel={running ? 'Stop timer' : 'Start timer on this ticket'}
+              accessibilityState={{ disabled: timerBusy }}
+              style={[styles.timerButton, timerBusy && styles.submitDisabled]}
+            >
+              <Text style={styles.timerButtonText}>
+                {timerBusy ? 'Working…' : running ? 'Stop timer' : 'Start timer'}
+              </Text>
+            </Pressable>
+            {running && running.ticketId !== ticketId ? (
+              // `startTimer` auto-stops the caller's previous timer before
+              // inserting (timeEntryService.ts), so starting here silently
+              // closes the other ticket's entry. Say so before the tap.
+              <Text style={styles.metaDim}>
+                A timer is running on another ticket. Starting here stops that one.
+              </Text>
+            ) : null}
+            {running && running.ticketId === ticketId ? (
+              <Text style={styles.metaDim}>
+                {running.id === null
+                  ? 'Timer running on this ticket — not yet synced.'
+                  : 'Timer running on this ticket.'}
+              </Text>
+            ) : null}
+            {!connected ? (
+              <Text style={styles.metaDim}>Offline — time is saved and synced later.</Text>
+            ) : null}
+            {timerNotice ? <Text style={styles.timerNotice}>{timerNotice}</Text> : null}
+          </>
+        )}
 
         <Text style={styles.sectionHeader}>
           ACTIVITY{commentCount ? ` (${commentCount})` : ''}
@@ -451,6 +616,18 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   submitDisabled: { opacity: 0.5 },
+  timerButton: {
+    marginTop: spacing['2'],
+    paddingVertical: spacing['3'],
+    borderRadius: radii.md,
+    borderWidth: 1,
+    borderColor: palette.brand.base,
+    backgroundColor: palette.brand.deep,
+    alignItems: 'center',
+  },
+  timerButtonText: { ...type.bodyMd, color: palette.dark.textHi },
+  timerNotice: { ...type.meta, color: palette.deny.base, marginTop: spacing['2'] },
+  timeDenied: { ...type.meta, color: palette.warning.base, marginTop: spacing['1'] },
   submitText: { ...type.bodyMd, color: palette.dark.textHi },
   error: { ...type.body, color: palette.deny.base, textAlign: 'center' },
   retry: {

--- a/apps/mobile/src/screens/tickets/timerActions.test.ts
+++ b/apps/mobile/src/screens/tickets/timerActions.test.ts
@@ -1,0 +1,346 @@
+import { describe, it, expect, vi, type Mock } from 'vitest';
+
+// `timeEntries` pulls in `../../services/api`, which imports
+// @sentry/react-native — Flow syntax Vitest's node environment cannot parse.
+vi.mock('../../services/api', () => ({ coreRequest: vi.fn() }));
+vi.mock('@sentry/react-native', () => ({ captureException: vi.fn(), captureMessage: vi.fn() }));
+
+import { startForTicket, stopRunningTimer, type Stamp } from './timerActions';
+import { TimeEntryError, type RunningTimer } from '../../services/timeEntries';
+import type { LocalTimer } from '../../services/localTimer';
+
+const START_MS = Date.parse('2026-08-30T09:00:00.000Z');
+const STOP_MS = Date.parse('2026-08-30T09:40:00.000Z');
+const EPOCH = 'launch-1';
+
+const entry = {
+  id: 'e1',
+  ticketId: 'k1',
+  startedAt: '2026-08-30T09:00:03.000Z',
+  endedAt: null,
+  durationMinutes: null,
+  isBillable: true,
+  billingStatus: 'not_billed' as const,
+  isApproved: false,
+  description: null,
+};
+
+function stampAt(wallMs: number, monoMs: number | null = wallMs): () => Stamp {
+  return () => ({ localId: 'l1', wallMs, monoMs, monoEpochId: EPOCH });
+}
+
+interface StartMocks {
+  startTimer: Mock;
+  writeLocalTimer: Mock;
+  clearLocalTimer: Mock;
+  isConnected: () => boolean;
+  stamp: () => Stamp;
+}
+
+function startDeps(overrides: Record<string, unknown> = {}): StartMocks {
+  return {
+    startTimer: vi.fn().mockResolvedValue(entry),
+    writeLocalTimer: vi.fn().mockResolvedValue(undefined),
+    clearLocalTimer: vi.fn().mockResolvedValue(undefined),
+    isConnected: () => true,
+    stamp: stampAt(START_MS),
+    ...overrides,
+  } as StartMocks;
+}
+
+function localTimer(overrides: Partial<LocalTimer> = {}): LocalTimer {
+  return {
+    localId: 'l1',
+    ticketId: 'k1',
+    serverEntryId: null,
+    startedAtWall: '2026-08-30T09:00:00.000Z',
+    startedAtMono: START_MS,
+    monoEpochId: EPOCH,
+    startConfirmed: true,
+    description: null,
+    ...overrides,
+  };
+}
+
+interface StopMocks {
+  stopTimer: Mock;
+  enqueue: Mock;
+  readLocalTimer: Mock;
+  clearLocalTimer: Mock;
+  parkNeedsAttention: Mock;
+  isConnected: () => boolean;
+  stamp: () => Stamp;
+}
+
+function stopDeps(overrides: Record<string, unknown> = {}): StopMocks {
+  return {
+    stopTimer: vi.fn().mockResolvedValue({ ...entry, endedAt: '2026-08-30T09:40:00.000Z' }),
+    enqueue: vi.fn().mockResolvedValue(undefined),
+    readLocalTimer: vi.fn().mockResolvedValue(null),
+    clearLocalTimer: vi.fn().mockResolvedValue(undefined),
+    parkNeedsAttention: vi.fn().mockResolvedValue(true),
+    isConnected: () => true,
+    stamp: stampAt(STOP_MS),
+    ...overrides,
+  } as StopMocks;
+}
+
+const serverRunning: RunningTimer = {
+  id: 'E',
+  localId: null,
+  ticketId: 'k1',
+  startedAt: '2026-08-30T09:00:03.000Z',
+  description: null,
+};
+
+describe('startForTicket', () => {
+  it('never enqueues anything, on any path', async () => {
+    // The invariant this whole design buys: a queued write always carries its
+    // own timestamps, and a start has no end yet, so a start is never queued.
+    const offline = startDeps({ isConnected: () => false, startTimer: vi.fn() });
+    await startForTicket('k1', offline);
+    const dropped = startDeps({
+      startTimer: vi.fn().mockRejectedValue(new Error('offline')),
+    });
+    await startForTicket('k1', dropped);
+    for (const deps of [offline, dropped]) {
+      expect(Object.prototype.hasOwnProperty.call(deps, 'enqueue')).toBe(false);
+    }
+  });
+
+  it('returns the entry on success and records the server identity locally', async () => {
+    const deps = startDeps();
+    await expect(startForTicket('k1', deps)).resolves.toEqual({ ok: true, entry });
+    const saved = deps.writeLocalTimer.mock.calls.at(-1)?.[0] as LocalTimer;
+    expect(saved).toMatchObject({
+      serverEntryId: 'e1',
+      startConfirmed: true,
+      startedAtWall: entry.startedAt,
+    });
+  });
+
+  it('persists the local timer BEFORE the network call', async () => {
+    const order: string[] = [];
+    const deps = startDeps({
+      writeLocalTimer: vi.fn().mockImplementation(async () => {
+        order.push('write');
+      }),
+      startTimer: vi.fn().mockImplementation(async () => {
+        order.push('network');
+        return entry;
+      }),
+    });
+    await startForTicket('k1', deps);
+    expect(order[0]).toBe('write');
+  });
+
+  it('ticks locally when offline, with the start confirmed absent', async () => {
+    const deps = startDeps({ isConnected: () => false, startTimer: vi.fn() });
+    const outcome = await startForTicket('k1', deps);
+    expect(deps.startTimer).not.toHaveBeenCalled();
+    expect(outcome).toMatchObject({ ok: 'local' });
+    // No request was made, so no server entry can exist — as certain as a
+    // confirmed one, and it saves a reconciliation round-trip.
+    expect((outcome as { timer: LocalTimer }).timer).toMatchObject({
+      startConfirmed: true,
+      serverEntryId: null,
+      startedAtWall: '2026-08-30T09:00:00.000Z',
+    });
+  });
+
+  it('keeps ticking locally, UNconfirmed, when the transport failed with no status', async () => {
+    const deps = startDeps({ startTimer: vi.fn().mockRejectedValue(new Error('network down')) });
+    const outcome = await startForTicket('k1', deps);
+    expect(outcome).toMatchObject({ ok: 'local' });
+    // A start may have landed; the reconciler resolves that, not a guess here.
+    expect((outcome as { timer: LocalTimer }).timer.startConfirmed).toBe(false);
+    expect(deps.clearLocalTimer).not.toHaveBeenCalled();
+  });
+
+  it('reports a failed local save instead of pretending the timer started', async () => {
+    const deps = startDeps({ writeLocalTimer: vi.fn().mockRejectedValue(new Error('SQLITE_FULL')) });
+    expect(await startForTicket('k1', deps)).toMatchObject({ ok: false, reason: 'unknown' });
+  });
+
+  it('reports an existing timer as a recoverable outcome, not a crash', async () => {
+    const deps = startDeps({
+      startTimer: vi.fn().mockRejectedValue(new TimeEntryError('conflict', 'ENTRY_RUNNING', 409)),
+    });
+    expect(await startForTicket('k1', deps)).toMatchObject({ ok: false, reason: 'already-running' });
+    expect(deps.clearLocalTimer).toHaveBeenCalled();
+  });
+
+  it('clears the local timer on a verdict, so nothing ticks for an entry that does not exist', async () => {
+    const deps = startDeps({
+      startTimer: vi.fn().mockRejectedValue(new TimeEntryError('nope', undefined, 403)),
+    });
+    expect(await startForTicket('k1', deps)).toMatchObject({ ok: false, reason: 'denied' });
+    expect(deps.clearLocalTimer).toHaveBeenCalled();
+  });
+
+  it('carries the classified denial so the screen can name the reason', async () => {
+    // The W02 gate: an org-scoped login is walled off by requireScope, a
+    // default technician by the missing time_entries:write permission. Those
+    // need different copy — one is unfixable in-app, the other is one admin
+    // grant away.
+    const deps = startDeps({
+      startTimer: vi
+        .fn()
+        .mockRejectedValue(new TimeEntryError('Permission denied: time_entries:write', undefined, 403)),
+    });
+    const outcome = await startForTicket('k1', deps);
+    expect(outcome).toMatchObject({ ok: false, reason: 'denied' });
+    expect((outcome as { denial?: { reason: string } }).denial?.reason).toBe('permission');
+  });
+});
+
+describe('stopRunningTimer — a timer the server does not have', () => {
+  it('enqueues ONE create carrying the real offline span, online or offline', async () => {
+    for (const connected of [true, false]) {
+      const deps = stopDeps({
+        isConnected: () => connected,
+        readLocalTimer: vi.fn().mockResolvedValue(localTimer()),
+      });
+      const outcome = await stopRunningTimer(
+        { running: { id: null, localId: 'l1', ticketId: 'k1', startedAt: '2026-08-30T09:00:00.000Z', description: null } },
+        deps
+      );
+      expect(outcome).toEqual({ ok: 'queued' });
+      // `/stop` cannot close an entry the server never created.
+      expect(deps.stopTimer).not.toHaveBeenCalled();
+      expect(deps.enqueue).toHaveBeenCalledTimes(1);
+      expect(deps.enqueue).toHaveBeenCalledWith({
+        kind: 'create',
+        payload: {
+          startedAt: '2026-08-30T09:00:00.000Z',
+          endedAt: '2026-08-30T09:40:00.000Z',
+          ticketId: 'k1',
+        },
+      });
+      expect(deps.clearLocalTimer).toHaveBeenCalled();
+    }
+  });
+
+  it('flags the create as unconfirmed when the start may have landed', async () => {
+    const deps = stopDeps({
+      readLocalTimer: vi.fn().mockResolvedValue(localTimer({ startConfirmed: false })),
+    });
+    await stopRunningTimer({ running: null }, deps);
+    expect(deps.enqueue.mock.calls[0][0].payload).toMatchObject({ unconfirmedStart: true });
+  });
+
+  it('does NOT flag a confirmed offline start, so no needless reconciliation round-trip', async () => {
+    const deps = stopDeps({ readLocalTimer: vi.fn().mockResolvedValue(localTimer()) });
+    await stopRunningTimer({ running: null }, deps);
+    expect(
+      Object.prototype.hasOwnProperty.call(deps.enqueue.mock.calls[0][0].payload, 'unconfirmedStart')
+    ).toBe(false);
+  });
+
+  it('parks the work instead of inventing a duration when the clock ran backwards', async () => {
+    const deps = stopDeps({
+      readLocalTimer: vi.fn().mockResolvedValue(localTimer({ startedAtMono: null, monoEpochId: null })),
+      stamp: stampAt(Date.parse('2026-08-30T08:00:00.000Z'), null),
+    });
+    const outcome = await stopRunningTimer({ running: null }, deps);
+    expect(outcome).toMatchObject({ ok: false, reason: 'unusable-clock' });
+    expect(deps.enqueue).not.toHaveBeenCalled();
+    expect(deps.parkNeedsAttention).toHaveBeenCalledTimes(1);
+    expect(deps.parkNeedsAttention.mock.calls[0][0]).toMatchObject({ code: 'CLOCK_WENT_BACKWARDS' });
+  });
+
+  it('reports a failed enqueue instead of rejecting into a silent no-op', async () => {
+    // Removing the try/catch around `enqueue` turns this into an unhandled
+    // rejection out of a `void onStop()` call site: the busy flag clears, no
+    // toast appears, and the technician works the job believing it was saved.
+    const deps = stopDeps({
+      readLocalTimer: vi.fn().mockResolvedValue(localTimer()),
+      enqueue: vi.fn().mockRejectedValue(new Error('time-entry queue storage is unreadable')),
+    });
+    const outcome = await stopRunningTimer({ running: null }, deps);
+    expect(outcome).toMatchObject({ ok: false, reason: 'unknown' });
+    expect((outcome as { message: string }).message).toMatch(/re-enter it from the timesheet/i);
+    // The local timer survives a failed save, so the minutes are still on screen.
+    expect(deps.clearLocalTimer).not.toHaveBeenCalled();
+  });
+
+  it('says nothing is running when there is no local timer and no running state', async () => {
+    const deps = stopDeps();
+    expect(await stopRunningTimer({ running: null }, deps)).toMatchObject({
+      ok: false,
+      reason: 'not-running',
+    });
+  });
+});
+
+describe('stopRunningTimer — a timer the server owns', () => {
+  it('stops through the API when connected, so the server stamps the tap moment', async () => {
+    const deps = stopDeps();
+    const outcome = await stopRunningTimer({ running: serverRunning, isBillable: true }, deps);
+    expect(outcome).toMatchObject({ ok: true });
+    expect(deps.stopTimer).toHaveBeenCalledWith({ isBillable: true });
+    expect(deps.enqueue).not.toHaveBeenCalled();
+  });
+
+  it('queues a closeEntry at the TAP time when offline, never a stop', async () => {
+    const deps = stopDeps({ isConnected: () => false });
+    const outcome = await stopRunningTimer({ running: serverRunning, isBillable: false }, deps);
+    expect(outcome).toEqual({ ok: 'queued' });
+    expect(deps.stopTimer).not.toHaveBeenCalled();
+    expect(deps.enqueue).toHaveBeenCalledWith({
+      kind: 'closeEntry',
+      payload: { id: 'E', endedAt: '2026-08-30T09:40:00.000Z', isBillable: false },
+    });
+  });
+
+  it('queues a closeEntry when the stop request failed with no status', async () => {
+    const deps = stopDeps({ stopTimer: vi.fn().mockRejectedValue(new Error('network down')) });
+    expect(await stopRunningTimer({ running: serverRunning }, deps)).toEqual({ ok: 'queued' });
+    expect(deps.enqueue.mock.calls[0][0]).toMatchObject({
+      kind: 'closeEntry',
+      payload: { id: 'E', endedAt: '2026-08-30T09:40:00.000Z' },
+    });
+  });
+
+  it('reports a failed offline enqueue instead of rejecting into a silent no-op', async () => {
+    const deps = stopDeps({
+      isConnected: () => false,
+      enqueue: vi.fn().mockRejectedValue(new Error('time-entry queue storage is unreadable')),
+    });
+    expect(await stopRunningTimer({ running: serverRunning }, deps)).toMatchObject({
+      ok: false,
+      reason: 'unknown',
+    });
+  });
+
+  it('treats NO_RUNNING_TIMER as routine, not an error state', async () => {
+    const deps = stopDeps({
+      stopTimer: vi.fn().mockRejectedValue(new TimeEntryError('nope', 'NO_RUNNING_TIMER', 404)),
+    });
+    expect(await stopRunningTimer({ running: serverRunning }, deps)).toMatchObject({
+      ok: false,
+      reason: 'not-running',
+    });
+  });
+
+  it('classifies a 403 on stop the same way start does', async () => {
+    const deps = stopDeps({
+      stopTimer: vi
+        .fn()
+        .mockRejectedValue(new TimeEntryError('Permission denied: time_entries:write', undefined, 403)),
+    });
+    expect(await stopRunningTimer({ running: serverRunning }, deps)).toMatchObject({
+      ok: false,
+      reason: 'denied',
+    });
+  });
+
+  it('falls back to the local record\'s server id when the store has no running timer', async () => {
+    const deps = stopDeps({
+      isConnected: () => false,
+      readLocalTimer: vi.fn().mockResolvedValue(localTimer({ serverEntryId: 'E2' })),
+    });
+    await stopRunningTimer({ running: null }, deps);
+    expect(deps.enqueue.mock.calls[0][0]).toMatchObject({ kind: 'closeEntry', payload: { id: 'E2' } });
+  });
+});

--- a/apps/mobile/src/screens/tickets/timerActions.ts
+++ b/apps/mobile/src/screens/tickets/timerActions.ts
@@ -1,0 +1,368 @@
+import type { RunningTimer, TimeEntry } from '../../services/timeEntries';
+import type { LocalTimer } from '../../services/localTimer';
+import type { NeedsAttentionRow } from '../../services/timeEntryQueue';
+import { closeLocalSpan, type SpanStop } from '../../services/timeSpan';
+import {
+  classifyTimeEntryDenial,
+  type TimeEntryDenial,
+} from '../../services/timeEntryAccess';
+
+/**
+ * Start/stop, decided once, outside React.
+ *
+ * The load-bearing rule: NOTHING is enqueued at start time, ever, and a `stop`
+ * is never enqueued at all. `POST /time-entries/start` and `/stop` stamp their
+ * timestamps server-side at request time, so a queued one records when the
+ * phone reconnected rather than when the technician worked. A timer started
+ * offline is therefore a purely local record (services/localTimer.ts) that
+ * becomes exactly one `create` — carrying its real bounds — when Stop is
+ * tapped, and a timer the SERVER started is closed by PATCHing the true end
+ * time onto its own row.
+ */
+
+export type StartOutcome =
+  | { ok: true; entry: TimeEntry }
+  /** Ticking on this device only. It is not queued; stopping it is what queues it. */
+  | { ok: 'local'; timer: LocalTimer }
+  | {
+      ok: false;
+      reason: 'already-running' | 'denied' | 'unknown';
+      message: string;
+      denial?: TimeEntryDenial;
+    };
+
+export type StopOutcome =
+  | { ok: true; entry: TimeEntry }
+  | { ok: 'queued' }
+  | {
+      ok: false;
+      reason: 'not-running' | 'denied' | 'unknown' | 'unusable-clock';
+      message: string;
+      denial?: TimeEntryDenial;
+    };
+
+export interface Stamp {
+  localId: string;
+  wallMs: number;
+  monoMs: number | null;
+  monoEpochId: string;
+}
+
+export interface StartDeps {
+  startTimer: (input: { ticketId?: string }) => Promise<TimeEntry>;
+  writeLocalTimer: (timer: LocalTimer) => Promise<void>;
+  clearLocalTimer: () => Promise<void>;
+  isConnected: () => boolean;
+  stamp: () => Stamp;
+}
+
+export interface StopDeps {
+  stopTimer: (input: { description?: string; isBillable?: boolean }) => Promise<TimeEntry>;
+  enqueue: (w: {
+    kind: 'create' | 'closeEntry';
+    payload: Record<string, unknown>;
+  }) => Promise<unknown>;
+  readLocalTimer: () => Promise<LocalTimer | null>;
+  clearLocalTimer: () => Promise<void>;
+  parkNeedsAttention: (row: NeedsAttentionRow) => Promise<boolean>;
+  isConnected: () => boolean;
+  stamp: () => Stamp;
+}
+
+const SAVE_FAILED_START =
+  'Could not save the timer on this device. Note the time and enter it from the timesheet.';
+const SAVE_FAILED_STOP =
+  'Could not save the stop offline. Note the time and re-enter it from the timesheet.';
+const CLOCK_MOVED =
+  'The device clock changed while this timer ran, so its length is unknown. Enter it manually from the timesheet.';
+
+function errorField(error: unknown, field: string): unknown {
+  if (typeof error !== 'object' || error === null) {
+    return undefined;
+  }
+
+  return (error as Record<string, unknown>)[field];
+}
+
+function getStatus(error: unknown): number | undefined {
+  const status = errorField(error, 'status');
+  if (typeof status === 'number') {
+    return status;
+  }
+
+  const statusCode = errorField(error, 'statusCode');
+  return typeof statusCode === 'number' ? statusCode : undefined;
+}
+
+function getCode(error: unknown): string | undefined {
+  const code = errorField(error, 'code');
+  return typeof code === 'string' ? code : undefined;
+}
+
+function getMessage(error: unknown, fallback: string): string {
+  const message = errorField(error, 'message');
+  return typeof message === 'string' && message.length > 0 ? message : fallback;
+}
+
+function stopStop(stamp: Stamp): SpanStop {
+  return { wallMs: stamp.wallMs, monoMs: stamp.monoMs, monoEpochId: stamp.monoEpochId };
+}
+
+export async function startForTicket(
+  ticketId: string,
+  deps: StartDeps
+): Promise<StartOutcome> {
+  const stamp = deps.stamp();
+  const timer: LocalTimer = {
+    localId: stamp.localId,
+    ticketId,
+    serverEntryId: null,
+    startedAtWall: new Date(stamp.wallMs).toISOString(),
+    startedAtMono: stamp.monoMs,
+    monoEpochId: stamp.monoEpochId,
+    // Nothing has been asked of the server yet, so a start MAY be about to land.
+    startConfirmed: false,
+    description: null,
+  };
+
+  // Persisted BEFORE any network call. If the app is killed between the tap and
+  // the response, the record of when the technician started still exists.
+  try {
+    await deps.writeLocalTimer(timer);
+  } catch {
+    return { ok: false, reason: 'unknown', message: SAVE_FAILED_START };
+  }
+
+  if (!deps.isConnected()) {
+    // No request was made, so no server entry can exist: the start is confirmed
+    // absent, which is exactly as certain as confirmed present.
+    const offline: LocalTimer = { ...timer, startConfirmed: true };
+    try {
+      await deps.writeLocalTimer(offline);
+    } catch {
+      return { ok: false, reason: 'unknown', message: SAVE_FAILED_START };
+    }
+    return { ok: 'local', timer: offline };
+  }
+
+  try {
+    const entry = await deps.startTimer({ ticketId });
+    // The server's stamp is authoritative from here on.
+    const owned: LocalTimer = {
+      ...timer,
+      serverEntryId: entry.id,
+      startedAtWall: entry.startedAt,
+      startConfirmed: true,
+      description: entry.description,
+    };
+    try {
+      await deps.writeLocalTimer(owned);
+    } catch {
+      // The entry exists on the server and the store adopts it either way; the
+      // only loss is the offline `closeEntry` shortcut, which falls back to the
+      // running timer's own id.
+    }
+    return { ok: true, entry };
+  } catch (error) {
+    const code = getCode(error);
+    if (code === 'ENTRY_RUNNING') {
+      await deps.clearLocalTimer().catch(() => undefined);
+      return {
+        ok: false,
+        reason: 'already-running',
+        // `startTimer` auto-stops the caller's previous timer before
+        // inserting, so this 409 is only ever a lost insert race — never the
+        // ordinary "a timer is already running" case. Telling the technician
+        // to stop something first would send them after a phantom.
+        message: 'Another timer change landed first. Try again.',
+      };
+    }
+
+    const status = getStatus(error);
+    if (status === undefined) {
+      // The request may or may not have reached the server. The timer keeps
+      // ticking locally with `startConfirmed: false`, and the reconciler
+      // (services/timerReconcile.ts) resolves the ambiguity against
+      // GET /time-entries/running rather than guessing.
+      return { ok: 'local', timer };
+    }
+
+    // A verdict: no server entry was created, so neither is a local one.
+    await deps.clearLocalTimer().catch(() => undefined);
+
+    if (status === 403) {
+      const denial = classifyTimeEntryDenial(error);
+      if (denial !== null) {
+        return { ok: false, reason: 'denied', denial, message: denial.message };
+      }
+    }
+
+    return {
+      ok: false,
+      reason: 'unknown',
+      message: getMessage(error, 'Could not start the timer.'),
+    };
+  }
+}
+
+export async function stopRunningTimer(
+  input: { description?: string; isBillable?: boolean; running: RunningTimer | null },
+  deps: StopDeps
+): Promise<StopOutcome> {
+  const stamp = deps.stamp();
+  const local = await deps.readLocalTimer().catch(() => null);
+  const serverEntryId = input.running?.id ?? local?.serverEntryId ?? null;
+
+  return serverEntryId === null
+    ? closeLocalTimer(input, deps, stamp, local)
+    : closeServerTimer(input, deps, stamp, serverEntryId);
+}
+
+/**
+ * A timer the server does not have. `/time-entries/stop` cannot close it — it
+ * is a CAS on "whatever entry this user has running", which is either nothing
+ * or somebody else's row — so this path is identical online and offline: one
+ * `create` carrying the real span, replayed by the drain.
+ */
+async function closeLocalTimer(
+  input: { description?: string; isBillable?: boolean; running: RunningTimer | null },
+  deps: StopDeps,
+  stamp: Stamp,
+  local: LocalTimer | null
+): Promise<StopOutcome> {
+  const startedAtWall = local?.startedAtWall ?? input.running?.startedAt ?? null;
+  if (startedAtWall === null) {
+    return { ok: false, reason: 'not-running', message: 'No timer is running.' };
+  }
+
+  const span = closeLocalSpan(
+    {
+      startedAtWall,
+      startedAtMono: local?.startedAtMono ?? null,
+      monoEpochId: local?.monoEpochId ?? null,
+    },
+    stopStop(stamp)
+  );
+
+  const ticketId = local?.ticketId ?? input.running?.ticketId ?? null;
+  const description = input.description ?? local?.description ?? undefined;
+
+  if ('unusable' in span) {
+    // Inventing a duration would be inventing a bill. Park the record so the
+    // work is still visible and the technician can enter it by hand.
+    await deps
+      .parkNeedsAttention({
+        write: {
+          id: local?.localId ?? `local-${stamp.wallMs}`,
+          kind: 'create',
+          payload: {
+            startedAtWall,
+            ...(ticketId === null ? {} : { ticketId }),
+            ...(description === undefined ? {} : { description }),
+          },
+          queuedAt: new Date(stamp.wallMs).toISOString(),
+          attempts: 0,
+        },
+        status: 0,
+        code: 'CLOCK_WENT_BACKWARDS',
+        message: CLOCK_MOVED,
+        failedAt: new Date(stamp.wallMs).toISOString(),
+      })
+      .catch(() => false);
+    await deps.clearLocalTimer().catch(() => undefined);
+    return { ok: false, reason: 'unusable-clock', message: CLOCK_MOVED };
+  }
+
+  try {
+    // An unguarded rejection here is a silent no-op that loses the whole entry:
+    // `readQueue` really does reject on an AsyncStorage failure by design, and
+    // every caller invokes this as `void onStop()` inside try/finally with no
+    // catch, so the technician would work the job believing time was tracked.
+    await deps.enqueue({
+      kind: 'create',
+      payload: {
+        startedAt: span.startedAt,
+        endedAt: span.endedAt,
+        ...(ticketId === null ? {} : { ticketId }),
+        ...(description === undefined ? {} : { description }),
+        ...(input.isBillable === undefined ? {} : { isBillable: input.isBillable }),
+        // The reconciler needs to know a start request may have landed before
+        // it posts what could be a second entry for the same work.
+        ...(local !== null && !local.startConfirmed ? { unconfirmedStart: true } : {}),
+      },
+    });
+  } catch {
+    return { ok: false, reason: 'unknown', message: SAVE_FAILED_STOP };
+  }
+
+  await deps.clearLocalTimer().catch(() => undefined);
+  return { ok: 'queued' };
+}
+
+/** A timer the server owns, closed either now or by a targeted PATCH later. */
+async function closeServerTimer(
+  input: { description?: string; isBillable?: boolean },
+  deps: StopDeps,
+  stamp: Stamp,
+  serverEntryId: string
+): Promise<StopOutcome> {
+  const queueClose = async (): Promise<StopOutcome> => {
+    try {
+      // NOT a `stop`: the server stamps `endedAt = now` on that endpoint, so a
+      // 15:00 stop replayed at 18:00 bills three extra hours. A targeted PATCH
+      // is also effect-idempotent, where a retried `/stop` 404s and is reported
+      // to the technician as work that could not be saved when in fact it was.
+      await deps.enqueue({
+        kind: 'closeEntry',
+        payload: {
+          id: serverEntryId,
+          endedAt: new Date(stamp.wallMs).toISOString(),
+          ...(input.description === undefined ? {} : { description: input.description }),
+          ...(input.isBillable === undefined ? {} : { isBillable: input.isBillable }),
+        },
+      });
+    } catch {
+      return { ok: false, reason: 'unknown', message: SAVE_FAILED_STOP };
+    }
+    await deps.clearLocalTimer().catch(() => undefined);
+    return { ok: 'queued' };
+  };
+
+  if (!deps.isConnected()) return queueClose();
+
+  try {
+    const entry = await deps.stopTimer({
+      ...(input.description === undefined ? {} : { description: input.description }),
+      ...(input.isBillable === undefined ? {} : { isBillable: input.isBillable }),
+    });
+    await deps.clearLocalTimer().catch(() => undefined);
+    return { ok: true, entry };
+  } catch (error) {
+    const code = getCode(error);
+    if (code === 'NO_RUNNING_TIMER') {
+      await deps.clearLocalTimer().catch(() => undefined);
+      return { ok: false, reason: 'not-running', message: 'No timer is running.' };
+    }
+
+    const status = getStatus(error);
+    if (status === 403) {
+      const denial = classifyTimeEntryDenial(error);
+      if (denial !== null) {
+        return { ok: false, reason: 'denied', denial, message: denial.message };
+      }
+    }
+
+    if (status === undefined) {
+      // Only a transport failure is safe to replay. Queued 4xx verdicts would
+      // be parked or wedge the queue head, while a technician's billable
+      // minutes must survive a failed connection.
+      return queueClose();
+    }
+
+    return {
+      ok: false,
+      reason: 'unknown',
+      message: getMessage(error, 'Could not stop the timer.'),
+    };
+  }
+}

--- a/apps/mobile/src/screens/tickets/timerOutcomeEffects.test.ts
+++ b/apps/mobile/src/screens/tickets/timerOutcomeEffects.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// `timeEntries` pulls in `../../services/api`, which imports @sentry/react-native.
+vi.mock('../../services/api', () => ({ coreRequest: vi.fn() }));
+
+import { startOutcomeEffects, stopOutcomeEffects } from './timerOutcomeEffects';
+import type { TimeEntry } from '../../services/timeEntries';
+import type { LocalTimer } from '../../services/localTimer';
+
+const entry: TimeEntry = {
+  id: 'e1',
+  ticketId: 'k1',
+  startedAt: '2026-08-23T10:00:00Z',
+  endedAt: null,
+  durationMinutes: null,
+  isBillable: true,
+  billingStatus: 'not_billed',
+  isApproved: false,
+  description: null,
+};
+
+describe('stopOutcomeEffects', () => {
+  it('clears the running timer when the stop was queued offline', () => {
+    // The technician has stated the timer is over and the queued write is what
+    // makes the server agree. Leaving `running` populated keeps the bar ticking
+    // past a stop that reported success, and invites a duplicate stop that
+    // replays as 404 and is dropped with a false "could not be saved" alarm.
+    const effects = stopOutcomeEffects({ ok: 'queued' });
+
+    expect(effects.clearRunning).toBe(true);
+    expect(effects.refreshQueueDepth).toBe(true);
+    expect(effects.toast).toEqual({
+      kind: 'success',
+      text: 'Saved offline — it will sync when you reconnect.',
+    });
+  });
+
+  it('clears the running timer on a successful stop', () => {
+    const effects = stopOutcomeEffects({ ok: true, entry });
+    expect(effects.clearRunning).toBe(true);
+    expect(effects.reload).toBe(true);
+  });
+
+  it('clears the running timer when the server says nothing was running', () => {
+    const effects = stopOutcomeEffects({
+      ok: false,
+      reason: 'not-running',
+      message: 'No timer is running.',
+    });
+    expect(effects.clearRunning).toBe(true);
+    expect(effects.toast).toEqual({ kind: 'error', text: 'No timer is running.' });
+  });
+
+  it('records an account-level denial as sticky', () => {
+    const effects = stopOutcomeEffects({
+      ok: false,
+      reason: 'denied',
+      message: 'wall',
+      denial: { reason: 'scope', message: 'wall' },
+    });
+    expect(effects.accountDenial).toEqual({ reason: 'scope', message: 'wall' });
+  });
+
+  it('does NOT record a per-entry denial as an account-level wall', () => {
+    // A verdict about one row must never withdraw time tracking app-wide: the
+    // Stop control disappears from a running timer and the Time tab is replaced
+    // until sign-out.
+    const effects = stopOutcomeEffects({
+      ok: false,
+      reason: 'denied',
+      message: 'that entry is approved',
+      denial: { reason: 'entry', message: 'that entry is approved' },
+    });
+    expect(effects.accountDenial).toBeNull();
+    expect(effects.toast).toEqual({ kind: 'error', text: 'that entry is approved' });
+    expect(effects.clearRunning).toBe(false);
+  });
+});
+
+const timer: LocalTimer = {
+  localId: 'l1',
+  ticketId: 'k1',
+  serverEntryId: null,
+  startedAtWall: '2026-08-30T09:00:00.000Z',
+  startedAtMono: 0,
+  monoEpochId: 'launch-1',
+  startConfirmed: true,
+  description: null,
+};
+
+describe('startOutcomeEffects', () => {
+  it('adopts the started entry under its server id', () => {
+    const effects = startOutcomeEffects({ ok: true, entry });
+    expect(effects.startRunning).toEqual({
+      id: 'e1',
+      localId: null,
+      ticketId: 'k1',
+      startedAt: '2026-08-23T10:00:00Z',
+      description: null,
+    });
+    expect(effects.toast).toEqual({ kind: 'success', text: 'Timer started' });
+  });
+
+  it('DOES adopt a local timer, so both surfaces offer Stop offline', () => {
+    // The regression this pins: returning null here left `state.time.running`
+    // null, so TicketDetailScreen kept rendering "Start timer" and the TimerBar
+    // rendered no Stop control at all. A timer started offline could therefore
+    // never be stopped offline, and the offline span was lost.
+    const effects = startOutcomeEffects({ ok: 'local', timer });
+    expect(effects.startRunning).not.toBeNull();
+    expect(effects.startRunning).toEqual({
+      id: null,
+      localId: 'l1',
+      ticketId: 'k1',
+      startedAt: '2026-08-30T09:00:00.000Z',
+      description: null,
+    });
+  });
+
+  it('parks a stop whose clock ran backwards and clears the bar', () => {
+    const effects = stopOutcomeEffects({
+      ok: false,
+      reason: 'unusable-clock',
+      message: 'The device clock changed while this timer ran.',
+    });
+    expect(effects.clearRunning).toBe(true);
+    expect(effects.refreshNeedsAttention).toBe(true);
+    expect(effects.toast.kind).toBe('error');
+  });
+
+  it('keeps an ownership denial off the account-level wall', () => {
+    const effects = startOutcomeEffects({
+      ok: false,
+      reason: 'denied',
+      message: 'someone else owns it',
+      denial: { reason: 'ownership', message: 'someone else owns it' },
+    });
+    expect(effects.accountDenial).toBeNull();
+    expect(effects.notice).toBe('someone else owns it');
+  });
+
+  it('keeps a role-grant denial ON the account-level wall', () => {
+    const effects = startOutcomeEffects({
+      ok: false,
+      reason: 'denied',
+      message: 'ask an admin',
+      denial: { reason: 'permission', message: 'ask an admin' },
+    });
+    expect(effects.accountDenial).toEqual({ reason: 'permission', message: 'ask an admin' });
+  });
+});

--- a/apps/mobile/src/screens/tickets/timerOutcomeEffects.ts
+++ b/apps/mobile/src/screens/tickets/timerOutcomeEffects.ts
@@ -1,0 +1,140 @@
+import type { RunningTimer } from '../../services/timeEntries';
+import { isAccountLevelDenial, type TimeEntryDenial } from '../../services/timeEntryAccess';
+
+import type { StartOutcome, StopOutcome } from './timerActions';
+
+/**
+ * What a screen must do with a timer outcome.
+ *
+ * The two surfaces that start and stop timers (TicketDetailScreen and the
+ * TimerBar) were making these decisions independently, and drifted: neither
+ * cleared the local running timer on a QUEUED stop, and both escalated every
+ * classified 403 — including per-row verdicts — into the sticky account-level
+ * wall. Deciding once, in a pure module, is also the only way this is testable:
+ * the app has no React Native test runtime.
+ */
+export interface TimerEffects {
+  /** Drop the local running timer. */
+  clearRunning: boolean;
+  /**
+   * Adopt this as the running timer. `id === null` means it exists only on this
+   * device (started offline) — it still ticks, and stopping it is what turns it
+   * into a queued `create` carrying the real span.
+   */
+  startRunning: RunningTimer | null;
+  /** Remember this denial for the session. Only account-level denials qualify. */
+  accountDenial: TimeEntryDenial | null;
+  /** Re-read the queue depth from storage. */
+  refreshQueueDepth: boolean;
+  /** Re-read the needs-attention list: something was parked for manual entry. */
+  refreshNeedsAttention: boolean;
+  /** Re-read the ticket: a completed stop writes a server-side activity comment. */
+  reload: boolean;
+  toast: { kind: 'success' | 'error'; text: string };
+  /** Inline note next to the control, or null to clear it. */
+  notice: string | null;
+}
+
+const QUEUED_TOAST = 'Saved offline — it will sync when you reconnect.';
+const LOCAL_START_TOAST = 'Timer started — it will sync when you reconnect.';
+
+function base(): TimerEffects {
+  return {
+    clearRunning: false,
+    startRunning: null,
+    accountDenial: null,
+    refreshQueueDepth: false,
+    refreshNeedsAttention: false,
+    reload: false,
+    toast: { kind: 'success', text: '' },
+    notice: null,
+  };
+}
+
+function failure(
+  outcome: { reason: string; message: string; denial?: TimeEntryDenial },
+  extra: Partial<TimerEffects> = {}
+): TimerEffects {
+  const denial = outcome.denial;
+  return {
+    ...base(),
+    // A verdict about one entry (approved, billed, owned by someone else) is
+    // NOT a reason to withdraw time tracking app-wide until sign-out.
+    accountDenial: denial !== undefined && isAccountLevelDenial(denial) ? denial : null,
+    toast: { kind: 'error', text: outcome.message },
+    notice: outcome.message,
+    ...extra,
+  };
+}
+
+export function startOutcomeEffects(outcome: StartOutcome): TimerEffects {
+  if (outcome.ok === true) {
+    return {
+      ...base(),
+      startRunning: {
+        id: outcome.entry.id,
+        localId: null,
+        ticketId: outcome.entry.ticketId,
+        startedAt: outcome.entry.startedAt,
+        description: outcome.entry.description,
+      },
+      toast: { kind: 'success', text: 'Timer started' },
+    };
+  }
+
+  if (outcome.ok === 'local') {
+    // A local timer DOES tick. Withholding it was the defect: with no running
+    // timer in the store, no surface offered Stop, so a timer started offline
+    // could never be stopped offline — and the span the whole offline design
+    // exists to record was lost.
+    return {
+      ...base(),
+      startRunning: {
+        id: null,
+        localId: outcome.timer.localId,
+        ticketId: outcome.timer.ticketId,
+        startedAt: outcome.timer.startedAtWall,
+        description: outcome.timer.description,
+      },
+      toast: { kind: 'success', text: LOCAL_START_TOAST },
+    };
+  }
+
+  return failure(outcome);
+}
+
+export function stopOutcomeEffects(outcome: StopOutcome): TimerEffects {
+  if (outcome.ok === true) {
+    return {
+      ...base(),
+      clearRunning: true,
+      reload: true,
+      toast: { kind: 'success', text: 'Timer stopped' },
+    };
+  }
+
+  if (outcome.ok === 'queued') {
+    // Unlike a queued start, the local state here is unambiguous: the
+    // technician has said the timer is over and the queued write is what makes
+    // the server agree. Leaving `running` populated keeps the bar counting past
+    // a stop that reported success, and invites a second tap whose duplicate
+    // stop replays as a 404 — dropped, and reported as work that "could not be
+    // saved" when it was.
+    return {
+      ...base(),
+      clearRunning: true,
+      refreshQueueDepth: true,
+      toast: { kind: 'success', text: QUEUED_TOAST },
+    };
+  }
+
+  if (outcome.reason === 'unusable-clock') {
+    // The span could not be measured, so nothing was queued. The timer is gone
+    // from the bar either way — it has no honest elapsed time left to show —
+    // and the work is parked where the technician can re-enter it.
+    return failure(outcome, { clearRunning: true, refreshNeedsAttention: true });
+  }
+
+  // The server is authoritative: nothing was running, so neither is the bar.
+  return failure(outcome, { clearRunning: outcome.reason === 'not-running' });
+}

--- a/apps/mobile/src/screens/time/TimesheetScreen.tsx
+++ b/apps/mobile/src/screens/time/TimesheetScreen.tsx
@@ -1,0 +1,488 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+
+import { palette, radii, spacing, type } from '../../theme';
+import { useAppDispatch, useAppSelector } from '../../store';
+import { timeAccessDenied } from '../../store/timeSlice';
+import {
+  getTimesheet,
+  updateTimeEntry,
+  type TimeEntry,
+  type TimesheetWeek,
+} from '../../services/timeEntries';
+import { classifyTimeEntryDenial, isAccountLevelDenial } from '../../services/timeEntryAccess';
+import { Toast } from '../../components/Toast';
+import { formatMinutes } from '../../lib/timeFormat';
+import { reportInternalError } from '../../lib/errorReporting';
+import { ticketRef } from '../tickets/ticketCopy';
+
+import { dayLabel, daysOfWeek, shiftWeek, weekRangeLabel, weekStartFor } from './timesheetWeek';
+import { entryLock } from './entryLock';
+import { buildLocalWeek, neighbourWeekOffsets } from './timesheetLocalDays';
+import { entriesForWeek, timesheetPhase, type LoadedWeek } from './timesheetLoadState';
+
+function flattenWeek(week: TimesheetWeek | null): TimeEntry[] {
+  return week?.days.flatMap((day) => day.entries) ?? [];
+}
+
+function startTimeLabel(startedAt: string): string {
+  const date = new Date(startedAt);
+  if (Number.isNaN(date.getTime())) return '';
+  const hours = date.getHours();
+  const minutes = date.getMinutes();
+  return `${hours < 10 ? `0${hours}` : hours}:${minutes < 10 ? `0${minutes}` : minutes}`;
+}
+
+export function TimesheetScreen() {
+  const dispatch = useAppDispatch();
+  const tickets = useAppSelector((state) => state.tickets.tickets);
+  // Set once by whichever time surface hit the wall first; a denied account
+  // should never see an empty timesheet that looks like "no work logged".
+  const denial = useAppSelector((state) => state.time.denial);
+
+  const [weekStart, setWeekStart] = useState(() => weekStartFor(new Date()));
+  /**
+   * Raw entries rather than the server's day buckets (those are keyed by UTC
+   * while this screen's week, day rows and start-time labels are all local),
+   * TAGGED with the week they were loaded for.
+   *
+   * The tag is what makes a failed load visible: without it, entries from the
+   * previously-shown week survived a failure on the new one, `entries !== null`
+   * kept the error branch unreachable, and `buildLocalWeek` filtered every row
+   * out — rendering a confident empty week with a 0m total for what was
+   * actually a network failure.
+   */
+  const [loaded, setLoaded] = useState<LoadedWeek | null>(null);
+  /** The overlapping neighbour week could not be fetched; boundary rows are missing. */
+  const [boundaryIncomplete, setBoundaryIncomplete] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [draftDescription, setDraftDescription] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [toast, setToast] = useState<{ kind: 'success' | 'error'; text: string } | null>(null);
+
+  const mounted = useRef(true);
+  const saveInFlight = useRef(false);
+  // Only the newest load may publish: two week changes in quick succession can
+  // land out of order and leave the header and the rows describing different weeks.
+  const loadGeneration = useRef(0);
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  const load = useCallback(
+    async (target: string) => {
+      const generation = ++loadGeneration.current;
+      const isCurrent = () => mounted.current && loadGeneration.current === generation;
+      setLoading(true);
+      setLoadError(null);
+      setBoundaryIncomplete(false);
+      try {
+        const fetched = await getTimesheet(target);
+        // `getTimesheet` windows on [weekStartUTC, +7d) and buckets by
+        // toISOString(), so one edge of the technician's LOCAL week always
+        // falls in the neighbouring server week: in New York a Sunday 20:00
+        // callout is 00:00Z Monday and is missing from both the rows and the
+        // weekly total. The endpoint takes no timezone, so the overlap is
+        // fetched and re-filed locally. Which neighbour overlaps is derived
+        // from THIS week's own boundaries — reading today's UTC offset gives
+        // the wrong answer for any week across a DST change.
+        const overlaps: TimesheetWeek[] = [];
+        let missedBoundary = false;
+        for (const offset of neighbourWeekOffsets(target)) {
+          try {
+            overlaps.push(await getTimesheet(shiftWeek(target, offset)));
+          } catch (error: unknown) {
+            // A correction, not the payload: losing it must not fail the whole
+            // week — but it must not be silent either. Degrading quietly here
+            // reintroduces the exact local-day bug this fetch exists to fix,
+            // and the timesheet is then simply wrong with no sign of it.
+            missedBoundary = true;
+            reportInternalError(error, 'timesheet-neighbour-week');
+          }
+        }
+        if (!isCurrent()) return;
+        setBoundaryIncomplete(missedBoundary);
+        setLoaded({
+          week: target,
+          entries: [...flattenWeek(fetched), ...overlaps.flatMap((week) => flattenWeek(week))],
+        });
+      } catch (error: unknown) {
+        const denied = classifyTimeEntryDenial(error);
+        if (denied !== null && isAccountLevelDenial(denied)) {
+          dispatch(timeAccessDenied(denied));
+          if (isCurrent()) setLoaded(null);
+          return;
+        }
+        reportInternalError(error, 'timesheet-load');
+        if (!isCurrent()) return;
+        const apiError = error as { message?: string };
+        setLoadError(denied?.message ?? apiError.message ?? 'Could not load your timesheet.');
+      } finally {
+        if (isCurrent()) setLoading(false);
+      }
+    },
+    [dispatch]
+  );
+
+  useEffect(() => {
+    void load(weekStart);
+  }, [load, weekStart]);
+
+  const days = useMemo(() => daysOfWeek(weekStart), [weekStart]);
+  // Only data actually loaded FOR the displayed week counts. Anything else is
+  // "no data yet", which is what keeps the error branch reachable.
+  const entries = entriesForWeek(loaded, weekStart);
+  // Every entry re-filed onto the local calendar, with totals recomputed from
+  // exactly the rows on screen so the header cannot disagree with them.
+  const view = useMemo(() => buildLocalWeek(entries ?? [], days), [entries, days]);
+
+  const beginEdit = useCallback((entry: TimeEntry) => {
+    setEditingId(entry.id);
+    setDraftDescription(entry.description ?? '');
+  }, []);
+
+  const applyEdit = useCallback(
+    async (entry: TimeEntry, patch: { description?: string | null; isBillable?: boolean }) => {
+      if (saveInFlight.current) return;
+      saveInFlight.current = true;
+      setSaving(true);
+      try {
+        await updateTimeEntry(entry.id, patch);
+        if (!mounted.current) return;
+        setEditingId(null);
+        // Re-read rather than patching in place: the server recomputes
+        // durations and day totals, and a locally-edited row would disagree
+        // with the weekly total sitting right above it.
+        await load(weekStart);
+        if (mounted.current) setToast({ kind: 'success', text: 'Time entry updated' });
+      } catch (error: unknown) {
+        const denied = classifyTimeEntryDenial(error);
+        if (denied !== null) {
+          // Only an account-shaped verdict is a wall. APPROVED_IMMUTABLE and
+          // NOT_OWN_ENTRY are 403s about ONE ROW: recorded as a sticky denial
+          // they replace the whole Time tab and strip the Stop button off a
+          // running timer, for a manager having approved a week from the web.
+          if (isAccountLevelDenial(denied)) dispatch(timeAccessDenied(denied));
+          if (mounted.current) setToast({ kind: 'error', text: denied.message });
+          // Our copy of the row is stale — that is how the tap was offered at
+          // all — so re-read rather than leaving the chips inviting a retry.
+          if (!isAccountLevelDenial(denied)) await load(weekStart);
+          return;
+        }
+        reportInternalError(error, 'timesheet-edit');
+        if (mounted.current) {
+          // ENTRY_BILLED is a 409, so it never reaches the classifier above.
+          const apiError = error as { message?: string; code?: string };
+          const text =
+            apiError.code === 'ENTRY_BILLED'
+              ? 'That entry is on an invoice; only its description can still be changed.'
+              : apiError.message || 'Could not update the time entry.';
+          setToast({ kind: 'error', text });
+        }
+      } finally {
+        saveInFlight.current = false;
+        if (mounted.current) setSaving(false);
+      }
+    },
+    [dispatch, load, weekStart]
+  );
+
+  if (denial !== null) {
+    // Explicit, non-generic, and never an empty week.
+    return (
+      <View style={styles.centered}>
+        <Text style={styles.deniedHeadline}>Time tracking unavailable</Text>
+        <Text style={styles.deniedBody}>{denial.message}</Text>
+      </View>
+    );
+  }
+
+  const renderEntry = (entry: TimeEntry) => {
+    const lock = entryLock(entry);
+    const ticket = entry.ticketId
+      ? tickets.find((candidate) => candidate.id === entry.ticketId)
+      : undefined;
+    const isEditing = editingId === entry.id;
+
+    return (
+      <View key={entry.id} style={styles.entry}>
+        <View style={styles.entryHeader}>
+          <Text style={styles.entryRef}>
+            {entry.ticketId
+              ? ticketRef({ id: entry.ticketId, internalNumber: ticket?.internalNumber ?? null })
+              : 'No ticket'}
+          </Text>
+          <Text style={styles.entryDuration}>{formatMinutes(entry.durationMinutes)}</Text>
+        </View>
+        <Text style={styles.entryMeta}>
+          {startTimeLabel(entry.startedAt)}
+          {entry.isBillable ? ' · Billable' : ' · Non-billable'}
+          {lock.badge !== null ? ` · ${lock.badge}` : ''}
+        </Text>
+
+        {isEditing ? (
+          <>
+            <TextInput
+              value={draftDescription}
+              onChangeText={setDraftDescription}
+              placeholder="What did you do?"
+              placeholderTextColor={palette.dark.textLo}
+              multiline
+              style={styles.input}
+              accessibilityLabel="Time entry description"
+            />
+            <View style={styles.editRow}>
+              <Pressable
+                onPress={() => void applyEdit(entry, { description: draftDescription.trim() || null })}
+                disabled={saving}
+                accessibilityRole="button"
+                accessibilityState={{ disabled: saving }}
+                style={[styles.chip, styles.chipPrimary, saving && styles.disabled]}
+              >
+                <Text style={styles.chipTextPrimary}>{saving ? 'Saving…' : 'Save'}</Text>
+              </Pressable>
+              <Pressable
+                onPress={() => setEditingId(null)}
+                accessibilityRole="button"
+                style={styles.chip}
+              >
+                <Text style={styles.chipText}>Cancel</Text>
+              </Pressable>
+            </View>
+          </>
+        ) : (
+          <>
+            <Text style={styles.entryBody}>{entry.description || 'No description'}</Text>
+            {lock.canEditDescription || lock.canToggleBillable ? (
+              <View style={styles.editRow}>
+                {lock.canEditDescription ? (
+                  <Pressable
+                    onPress={() => beginEdit(entry)}
+                    accessibilityRole="button"
+                    accessibilityLabel="Edit description"
+                    style={styles.chip}
+                  >
+                    <Text style={styles.chipText}>Edit</Text>
+                  </Pressable>
+                ) : null}
+                {lock.canToggleBillable ? (
+                  <Pressable
+                    onPress={() => void applyEdit(entry, { isBillable: !entry.isBillable })}
+                    disabled={saving}
+                    accessibilityRole="button"
+                    accessibilityLabel={entry.isBillable ? 'Mark non-billable' : 'Mark billable'}
+                    accessibilityState={{ disabled: saving }}
+                    style={[styles.chip, saving && styles.disabled]}
+                  >
+                    <Text style={styles.chipText}>
+                      {entry.isBillable ? 'Mark non-billable' : 'Mark billable'}
+                    </Text>
+                  </Pressable>
+                ) : null}
+              </View>
+            ) : null}
+            {lock.note !== null ? <Text style={styles.lockNote}>{lock.note}</Text> : null}
+          </>
+        )}
+      </View>
+    );
+  };
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.screen}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    >
+      <View style={styles.weekBar}>
+        <Pressable
+          onPress={() => setWeekStart((current) => shiftWeek(current, -1))}
+          accessibilityRole="button"
+          accessibilityLabel="Previous week"
+          style={styles.chip}
+        >
+          <Text style={styles.chipText}>‹</Text>
+        </Pressable>
+        <View style={styles.weekLabels}>
+          <Text style={styles.weekRange}>{weekRangeLabel(weekStart)}</Text>
+          <Text style={styles.weekTotal}>
+            {formatMinutes(view.totals.totalMinutes)} total ·{' '}
+            {formatMinutes(view.totals.billableMinutes)} billable
+          </Text>
+        </View>
+        <Pressable
+          onPress={() => setWeekStart((current) => shiftWeek(current, 1))}
+          accessibilityRole="button"
+          accessibilityLabel="Next week"
+          style={styles.chip}
+        >
+          <Text style={styles.chipText}>›</Text>
+        </Pressable>
+      </View>
+
+      {timesheetPhase({ loading, loadError, entries }) === 'spinner' ? (
+        <View style={styles.centered}>
+          <ActivityIndicator color={palette.brand.soft} />
+        </View>
+      ) : timesheetPhase({ loading, loadError, entries }) === 'error' ? (
+        <View style={styles.centered}>
+          <Text style={styles.error}>{loadError}</Text>
+          <Pressable
+            onPress={() => void load(weekStart)}
+            accessibilityRole="button"
+            style={styles.retry}
+          >
+            <Text style={styles.chipText}>Try again</Text>
+          </Pressable>
+        </View>
+      ) : (
+        <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
+          {boundaryIncomplete ? (
+            // The overlap fetch is what re-files entries that the server filed
+            // under the neighbouring UTC week. Without it the week is missing
+            // rows AND minutes, so saying nothing would leave a wrong timesheet
+            // looking authoritative.
+            <Text style={styles.warning}>
+              Some entries at the edges of this week could not be loaded. The total may be low.
+            </Text>
+          ) : null}
+          {loadError !== null ? (
+            <Text style={styles.warning}>{loadError}</Text>
+          ) : null}
+          {days.map((day) => {
+            const dayEntries = view.byDay.get(day) ?? [];
+            return (
+              <View key={day} style={styles.day}>
+                <View style={styles.dayHeader}>
+                  <Text style={styles.dayLabel}>{dayLabel(day)}</Text>
+                  <Text style={styles.dayTotal}>{formatMinutes(view.dayTotals.get(day) ?? 0)}</Text>
+                </View>
+                {dayEntries.length === 0 ? (
+                  <Text style={styles.dayEmpty}>No time logged.</Text>
+                ) : (
+                  dayEntries.map(renderEntry)
+                )}
+              </View>
+            );
+          })}
+        </ScrollView>
+      )}
+
+      <Toast
+        visible={toast !== null}
+        text={toast?.text ?? ''}
+        kind={toast?.kind ?? 'success'}
+        onHidden={() => setToast(null)}
+      />
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: { flex: 1, backgroundColor: palette.dark.bg0 },
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: palette.dark.bg0,
+    padding: spacing['6'],
+  },
+  content: { padding: spacing['4'], paddingBottom: spacing['8'] },
+  weekBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing['3'],
+    paddingHorizontal: spacing['4'],
+    paddingVertical: spacing['3'],
+    borderBottomWidth: 1,
+    borderBottomColor: palette.dark.border,
+  },
+  weekLabels: { flex: 1, alignItems: 'center' },
+  weekRange: { ...type.bodyMd, color: palette.dark.textHi },
+  weekTotal: { ...type.meta, color: palette.dark.textMd, marginTop: spacing['1'] },
+  day: { marginBottom: spacing['5'] },
+  dayHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: spacing['2'],
+  },
+  dayLabel: { ...type.metaCaps, color: palette.dark.textLo },
+  dayTotal: { ...type.meta, color: palette.dark.textMd },
+  dayEmpty: { ...type.meta, color: palette.dark.textLo },
+  entry: {
+    backgroundColor: palette.dark.bg1,
+    borderRadius: radii.md,
+    borderWidth: 1,
+    borderColor: palette.dark.border,
+    padding: spacing['3'],
+    marginBottom: spacing['2'],
+  },
+  entryHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
+  entryRef: { ...type.monoMd, color: palette.dark.textMd },
+  entryDuration: { ...type.bodyMd, color: palette.dark.textHi },
+  entryMeta: { ...type.meta, color: palette.dark.textLo, marginTop: spacing['1'] },
+  entryBody: { ...type.body, color: palette.dark.textHi, marginTop: spacing['2'] },
+  lockNote: { ...type.meta, color: palette.warning.base, marginTop: spacing['2'] },
+  editRow: { flexDirection: 'row', gap: spacing['2'], marginTop: spacing['2'], flexWrap: 'wrap' },
+  chip: {
+    paddingHorizontal: spacing['3'],
+    paddingVertical: spacing['2'],
+    borderRadius: radii.full,
+    borderWidth: 1,
+    borderColor: palette.dark.border,
+    backgroundColor: palette.dark.bg1,
+  },
+  chipPrimary: { backgroundColor: palette.brand.deep, borderColor: palette.brand.base },
+  chipText: { ...type.meta, color: palette.dark.textMd },
+  chipTextPrimary: { ...type.meta, color: palette.dark.textHi },
+  disabled: { opacity: 0.5 },
+  input: {
+    ...type.body,
+    color: palette.dark.textHi,
+    backgroundColor: palette.dark.bg0,
+    borderRadius: radii.md,
+    borderWidth: 1,
+    borderColor: palette.dark.border,
+    padding: spacing['3'],
+    marginTop: spacing['2'],
+    minHeight: 72,
+    textAlignVertical: 'top',
+  },
+  deniedHeadline: { ...type.title, color: palette.dark.textHi, textAlign: 'center' },
+  deniedBody: {
+    ...type.body,
+    color: palette.dark.textMd,
+    textAlign: 'center',
+    marginTop: spacing['3'],
+  },
+  warning: {
+    ...type.meta,
+    color: palette.warning.base,
+    marginBottom: spacing['3'],
+  },
+  error: { ...type.body, color: palette.deny.base, textAlign: 'center' },
+  retry: {
+    marginTop: spacing['4'],
+    paddingHorizontal: spacing['4'],
+    paddingVertical: spacing['2'],
+    borderRadius: radii.md,
+    borderWidth: 1,
+    borderColor: palette.dark.border,
+  },
+});

--- a/apps/mobile/src/screens/time/entryLock.test.ts
+++ b/apps/mobile/src/screens/time/entryLock.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../services/api', () => ({ coreRequest: vi.fn() }));
+
+import { entryLock } from './entryLock';
+import type { BillingStatus, TimeEntry } from '../../services/timeEntries';
+
+function entry(overrides: Partial<TimeEntry> = {}): TimeEntry {
+  return {
+    id: 'e1',
+    ticketId: 'k1',
+    startedAt: '2026-08-23T10:00:00Z',
+    endedAt: '2026-08-23T11:00:00Z',
+    durationMinutes: 60,
+    isBillable: true,
+    billingStatus: 'not_billed',
+    isApproved: false,
+    description: 'onsite',
+    ...overrides,
+  };
+}
+
+describe('entryLock', () => {
+  it('lets a billed entry keep its description editable, as the server does', () => {
+    // BILLED_LOCKED_ENTRY_FIELDS (timeEntryService.ts) deliberately excludes
+    // `description`, and the 409 says "only its description can change". Hiding
+    // Edit here strands a technician who cannot fix a typo the API accepts.
+    const lock = entryLock(entry({ billingStatus: 'billed' }));
+
+    expect(lock.canEditDescription).toBe(true);
+    expect(lock.canToggleBillable).toBe(false);
+    expect(lock.badge).toBe('Billed');
+    expect(lock.note).toMatch(/description/i);
+  });
+
+  it('locks an approved entry completely — assertCanMutate rejects every field', () => {
+    const lock = entryLock(entry({ isApproved: true }));
+
+    expect(lock.canEditDescription).toBe(false);
+    expect(lock.canToggleBillable).toBe(false);
+    expect(lock.badge).toBe('Approved');
+    expect(lock.note).toMatch(/approv/i);
+  });
+
+  it('keeps approval as the stronger lock when an entry is both approved and billed', () => {
+    const lock = entryLock(entry({ isApproved: true, billingStatus: 'billed' }));
+    expect(lock.canEditDescription).toBe(false);
+    expect(lock.badge).toBe('Approved');
+  });
+
+  it('leaves an ordinary entry fully editable', () => {
+    const lock = entryLock(entry());
+    expect(lock).toEqual({
+      canEditDescription: true,
+      canToggleBillable: true,
+      badge: null,
+      note: null,
+    });
+  });
+
+  it.each<BillingStatus>(['not_billed', 'no_charge', 'contract'])(
+    'does not lock billingStatus %s — only an issued invoice freezes an entry',
+    (billingStatus) => {
+      const lock = entryLock(entry({ billingStatus }));
+      expect(lock.canEditDescription).toBe(true);
+      expect(lock.canToggleBillable).toBe(true);
+      expect(lock.badge).toBeNull();
+    }
+  );
+});

--- a/apps/mobile/src/screens/time/entryLock.ts
+++ b/apps/mobile/src/screens/time/entryLock.ts
@@ -1,0 +1,46 @@
+import type { TimeEntry } from '../../services/timeEntries';
+
+/**
+ * Which edits the server will still accept on a timesheet row.
+ *
+ * Rendering a control the API refuses wastes the technician's time and reads as
+ * a bug — but hiding one the API allows strands them, which is the mistake this
+ * module fixes. `BILLED_LOCKED_ENTRY_FIELDS` (apps/api/src/services/
+ * timeEntryService.ts) is `startedAt, endedAt, isBillable, hourlyRate,
+ * billingStatus, ticketId`: `description` is deliberately excluded, and the
+ * 409 says so in as many words — "This entry has been invoiced; only its
+ * description can change". An approved row is different: `assertCanMutate`
+ * rejects EVERY field for a non-approver, so it is fully read-only.
+ *
+ * Pure module so the affordance matrix is unit-testable.
+ */
+export interface EntryLock {
+  canEditDescription: boolean;
+  canToggleBillable: boolean;
+  /** Short badge for the row's meta line, or null when nothing is locked. */
+  badge: string | null;
+  /** Sentence explaining what is still possible, or null. */
+  note: string | null;
+}
+
+export function entryLock(entry: Pick<TimeEntry, 'isApproved' | 'billingStatus'>): EntryLock {
+  if (entry.isApproved) {
+    return {
+      canEditDescription: false,
+      canToggleBillable: false,
+      badge: 'Approved',
+      note: 'Approved — locked. Ask an approver to reopen it.',
+    };
+  }
+
+  if (entry.billingStatus === 'billed') {
+    return {
+      canEditDescription: true,
+      canToggleBillable: false,
+      badge: 'Billed',
+      note: 'Invoiced — the times and billable flag are frozen, but the description can still be corrected.',
+    };
+  }
+
+  return { canEditDescription: true, canToggleBillable: true, badge: null, note: null };
+}

--- a/apps/mobile/src/screens/time/timesheetLoadState.test.ts
+++ b/apps/mobile/src/screens/time/timesheetLoadState.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../services/api', () => ({ coreRequest: vi.fn() }));
+
+import { entriesForWeek, timesheetPhase } from './timesheetLoadState';
+import type { TimeEntry } from '../../services/timeEntries';
+
+const entry: TimeEntry = {
+  id: 'e1',
+  ticketId: 'k1',
+  startedAt: '2026-08-24T09:00:00.000Z',
+  endedAt: '2026-08-24T09:40:00.000Z',
+  durationMinutes: 40,
+  isBillable: true,
+  billingStatus: 'not_billed',
+  isApproved: false,
+  description: null,
+};
+
+describe('entriesForWeek', () => {
+  it('returns the entries when they were fetched for this week', () => {
+    expect(entriesForWeek({ week: '2026-08-24', entries: [entry] }, '2026-08-24')).toEqual([entry]);
+  });
+
+  it('refuses entries fetched for a DIFFERENT week', () => {
+    // The T7 defect: the previous week's rows made `entries !== null`, so the
+    // error branch was unreachable and the failed week rendered as empty.
+    expect(entriesForWeek({ week: '2026-08-17', entries: [entry] }, '2026-08-24')).toBeNull();
+  });
+
+  it('has nothing to show before the first load', () => {
+    expect(entriesForWeek(null, '2026-08-24')).toBeNull();
+  });
+});
+
+describe('timesheetPhase', () => {
+  it('shows the error when a load failed and this week has no data', () => {
+    // Renders "Could not load your timesheet" + Try again, NOT a week of zeroes.
+    expect(
+      timesheetPhase({ loading: false, loadError: 'Could not load your timesheet.', entries: null })
+    ).toBe('error');
+  });
+
+  it('shows the spinner while the first load of a week is in flight', () => {
+    expect(timesheetPhase({ loading: true, loadError: null, entries: null })).toBe('spinner');
+  });
+
+  it('keeps the rows when a REFRESH of an already-loaded week fails', () => {
+    // The failure is a banner over real data, not a blanked screen.
+    expect(timesheetPhase({ loading: false, loadError: 'boom', entries: [entry] })).toBe('week');
+  });
+
+  it('shows a genuinely empty week as a week', () => {
+    expect(timesheetPhase({ loading: false, loadError: null, entries: [] })).toBe('week');
+  });
+});

--- a/apps/mobile/src/screens/time/timesheetLoadState.ts
+++ b/apps/mobile/src/screens/time/timesheetLoadState.ts
@@ -1,0 +1,36 @@
+import type { TimeEntry } from '../../services/timeEntries';
+
+/**
+ * What the timesheet should be showing right now.
+ *
+ * Pulled out of the screen because the defect it fixes is invisible in the
+ * screen: entries fetched for the PREVIOUS week survived a failed load of the
+ * new one, so `entries !== null` kept the error branch unreachable while
+ * `buildLocalWeek` filtered every stale row out. The result was a confident
+ * empty week with a 0m total where the truth was "the request failed" — the
+ * worst possible rendering of a network error on a billing surface.
+ */
+
+export interface LoadedWeek {
+  week: string;
+  entries: TimeEntry[];
+}
+
+/** Entries only count for the week they were actually fetched for. */
+export function entriesForWeek(loaded: LoadedWeek | null, weekStart: string): TimeEntry[] | null {
+  return loaded !== null && loaded.week === weekStart ? loaded.entries : null;
+}
+
+export type TimesheetPhase = 'spinner' | 'error' | 'week';
+
+export function timesheetPhase(input: {
+  loading: boolean;
+  loadError: string | null;
+  entries: readonly TimeEntry[] | null;
+}): TimesheetPhase {
+  // Data for THIS week wins: a failed refresh over a week already on screen
+  // keeps the rows and shows the failure as a banner rather than blanking them.
+  if (input.entries !== null) return 'week';
+  if (input.loading) return 'spinner';
+  return input.loadError === null ? 'week' : 'error';
+}

--- a/apps/mobile/src/screens/time/timesheetLocalDays.test.ts
+++ b/apps/mobile/src/screens/time/timesheetLocalDays.test.ts
@@ -1,0 +1,169 @@
+// The whole point of this suite is the local/UTC seam, so the zone must be
+// pinned. It is pinned in vitest.config.ts, NOT here: assigning process.env.TZ
+// inside a test file does not take effect under the threads pool (Node does not
+// re-read TZ in a worker), which made this suite pass under the default forks
+// pool and fail on the documented `--pool=threads` invocation. The first
+// describe below asserts the pin actually applied.
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../services/api', () => ({ coreRequest: vi.fn() }));
+
+import { buildLocalWeek, localDayKey, neighbourWeekOffsets } from './timesheetLocalDays';
+import { daysOfWeek } from './timesheetWeek';
+import type { TimeEntry } from '../../services/timeEntries';
+
+function entry(overrides: Partial<TimeEntry> & Pick<TimeEntry, 'id' | 'startedAt'>): TimeEntry {
+  return {
+    ticketId: 'k1',
+    endedAt: null,
+    durationMinutes: 60,
+    isBillable: true,
+    billingStatus: 'not_billed',
+    isApproved: false,
+    description: null,
+    ...overrides,
+  };
+}
+
+describe('the pinned zone actually took effect', () => {
+  it('is UTC-4 in August, so the assertions below are not vacuous', () => {
+    expect(new Date('2026-08-30T12:00:00Z').getTimezoneOffset()).toBe(240);
+  });
+});
+
+describe('localDayKey', () => {
+  it('files a Sunday-evening callout under Sunday, not the UTC Monday', () => {
+    // 20:00 Sunday in New York is already 00:00 Monday in UTC. The server keys
+    // its day buckets off toISOString(), so trusting them shows a Sunday
+    // evening as Monday work.
+    expect(localDayKey('2026-08-31T00:00:00.000Z')).toBe('2026-08-30');
+  });
+
+  it('returns null for an unparseable timestamp rather than a fabricated day', () => {
+    expect(localDayKey('not a date')).toBeNull();
+  });
+});
+
+/**
+ * Stand-in local calendars, so the DST behaviour is deterministic rather than
+ * dependent on whatever zone the runner happens to be in. Offsets are in
+ * minutes AHEAD of UTC (the opposite sign to `getTimezoneOffset`).
+ */
+function zone(offsetMinutesFor: (dateOnly: string) => number) {
+  return (dateOnly: string): number =>
+    Date.parse(`${dateOnly}T00:00:00.000Z`) - offsetMinutesFor(dateOnly) * 60_000;
+}
+
+/** Europe/London: UTC+1 in summer, UTC+0 in winter. */
+const london = zone((dateOnly) => (dateOnly >= '2026-03-29' && dateOnly < '2026-10-25' ? 60 : 0));
+/** America/New_York: UTC-4 in summer, UTC-5 in winter. */
+const newYork = zone((dateOnly) => (dateOnly >= '2026-03-08' && dateOnly < '2026-11-01' ? -240 : -300));
+
+describe('neighbourWeekOffsets', () => {
+  it('asks for the NEXT server week west of Greenwich', () => {
+    // Local late-Sunday work lands in the following UTC week, which the
+    // requested week's window ([weekStartUTC, +7d)) excludes entirely — the
+    // entry is missing from both the rows and the weekly total.
+    expect(neighbourWeekOffsets('2026-08-24', newYork)).toEqual([1]);
+  });
+
+  it('asks for the PREVIOUS server week east of Greenwich', () => {
+    // Local early-Monday work sits in the previous UTC week.
+    expect(neighbourWeekOffsets('2026-08-24', london)).toEqual([-1]);
+  });
+
+  it('asks for nothing extra where the local week aligns with UTC', () => {
+    // A London week in January: the two calendars agree exactly.
+    expect(neighbourWeekOffsets('2026-01-05', london)).toEqual([]);
+  });
+
+  it('answers for the DISPLAYED week, not for today', () => {
+    // The defect: the offset was read from `new Date().getTimezoneOffset()`, so
+    // paging from a January week to a July one in London kept answering "no
+    // neighbour" and the July week silently lost its Sunday-23:00 boundary
+    // entries — from the rows AND the total. Two weeks, one runner, different
+    // answers is exactly what a today-derived offset cannot produce.
+    expect(neighbourWeekOffsets('2026-01-05', london)).toEqual([]);
+    expect(neighbourWeekOffsets('2026-07-06', london)).toEqual([-1]);
+  });
+
+  it('handles the week the clocks go back', () => {
+    // 2026-10-25 in London and 2026-11-01 in New York. The week straddling the
+    // change has one boundary in each offset, so a single "today" answer is
+    // wrong for one of its two ends by construction.
+    expect(neighbourWeekOffsets('2026-10-19', london)).toEqual([-1]);
+    expect(neighbourWeekOffsets('2026-10-26', newYork)).toEqual([1]);
+  });
+
+  it('agrees with the real local calendar in the pinned zone', () => {
+    // Ties the injectable resolver to the actual one, so the stand-ins above
+    // cannot drift into testing only themselves.
+    expect(neighbourWeekOffsets('2026-08-24')).toEqual([1]);
+  });
+});
+
+describe('buildLocalWeek', () => {
+  const days = daysOfWeek('2026-08-24');
+
+  it('keeps a local Sunday-evening entry in the local week it belongs to', () => {
+    const view = buildLocalWeek([entry({ id: 'a', startedAt: '2026-08-31T00:00:00.000Z' })], days);
+
+    expect(view.byDay.get('2026-08-30')?.map((e) => e.id)).toEqual(['a']);
+    expect(view.byDay.get('2026-08-31')).toBeUndefined();
+    expect(view.totals.totalMinutes).toBe(60);
+  });
+
+  it('drops the previous local week, which the server window includes west of UTC', () => {
+    // 2026-08-23 20:00 New York = 2026-08-24T00:00Z, inside the requested
+    // server window but outside the technician's local week.
+    const view = buildLocalWeek([entry({ id: 'old', startedAt: '2026-08-24T00:00:00.000Z' })], days);
+
+    expect(view.totals.totalMinutes).toBe(0);
+    expect([...view.byDay.keys()]).toEqual([]);
+  });
+
+  it('sums day and week totals from the entries actually shown', () => {
+    const view = buildLocalWeek(
+      [
+        entry({ id: 'a', startedAt: '2026-08-24T14:00:00.000Z', durationMinutes: 30 }),
+        entry({ id: 'b', startedAt: '2026-08-24T18:00:00.000Z', durationMinutes: 45, isBillable: false }),
+        entry({ id: 'c', startedAt: '2026-08-26T14:00:00.000Z', durationMinutes: 15 }),
+      ],
+      days
+    );
+
+    expect(view.dayTotals.get('2026-08-24')).toBe(75);
+    expect(view.dayTotals.get('2026-08-26')).toBe(15);
+    expect(view.totals).toEqual({ totalMinutes: 90, billableMinutes: 45 });
+  });
+
+  it('counts a still-running entry as zero rather than NaN', () => {
+    const view = buildLocalWeek(
+      [entry({ id: 'a', startedAt: '2026-08-24T14:00:00.000Z', durationMinutes: null })],
+      days
+    );
+    expect(view.totals.totalMinutes).toBe(0);
+    expect(view.byDay.get('2026-08-24')).toHaveLength(1);
+  });
+
+  it('de-duplicates an entry returned by both the week and its neighbour', () => {
+    // The two fetches overlap by design; counting the overlap twice would
+    // inflate the weekly total.
+    const shared = entry({ id: 'a', startedAt: '2026-08-24T14:00:00.000Z', durationMinutes: 30 });
+    const view = buildLocalWeek([shared, { ...shared }], days);
+
+    expect(view.byDay.get('2026-08-24')).toHaveLength(1);
+    expect(view.totals.totalMinutes).toBe(30);
+  });
+
+  it('orders each day by start time so the column reads chronologically', () => {
+    const view = buildLocalWeek(
+      [
+        entry({ id: 'late', startedAt: '2026-08-24T18:00:00.000Z' }),
+        entry({ id: 'early', startedAt: '2026-08-24T13:00:00.000Z' }),
+      ],
+      days
+    );
+    expect(view.byDay.get('2026-08-24')?.map((e) => e.id)).toEqual(['early', 'late']);
+  });
+});

--- a/apps/mobile/src/screens/time/timesheetLocalDays.ts
+++ b/apps/mobile/src/screens/time/timesheetLocalDays.ts
@@ -1,0 +1,119 @@
+import type { TimeEntry } from '../../services/timeEntries';
+
+import { localMidnightMs as defaultLocalMidnightMs, shiftWeek } from './timesheetWeek';
+
+/**
+ * Re-files a fetched timesheet onto the technician's LOCAL calendar.
+ *
+ * The seam this closes: the client asks for a week derived from local calendar
+ * fields (`timesheetWeek.ts`) and sends it as a date-only string, but
+ * `timesheetQuerySchema` coerces that to UTC midnight, so `getTimesheet`
+ * windows on `[weekStartUTC, +7d)` and buckets each row by
+ * `startedAt.toISOString().slice(0,10)` — all UTC. The seven day-key STRINGS
+ * coincide with the local ones, so the grid renders cleanly and nothing looks
+ * broken; only the attribution is wrong. In America/New_York a Sunday 20:00
+ * callout is stamped 00:00Z Monday, so it falls outside the requested window
+ * entirely (missing from the rows AND the weekly total) and reappears the next
+ * week filed under Monday with a "20:00" start label.
+ *
+ * The endpoint takes no timezone parameter, and this wave adds no API changes,
+ * so the fix is client-side: fetch the adjacent server week that overlaps the
+ * local one, bucket every entry by its own local day, and total what is
+ * actually shown.
+ *
+ * Pure module: no React Native imports, so the local/UTC edge is unit-testable
+ * with the zone pinned in vitest.config.ts (see the note there — a
+ * `process.env.TZ` assignment inside a test file does NOT take effect under the
+ * threads pool).
+ */
+
+function pad2(value: number): string {
+  return value < 10 ? `0${value}` : String(value);
+}
+
+/** Local `YYYY-MM-DD` for an ISO timestamp, or null if it cannot be parsed. */
+export function localDayKey(iso: string): string | null {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return null;
+  return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`;
+}
+
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Which neighbouring server week(s) also overlap the LOCAL week starting at
+ * `weekStart`.
+ *
+ * Derived from the displayed week's own boundaries, never from today's UTC
+ * offset. Those differ across a DST change: in Europe/London a July week starts
+ * at 23:00Z the previous Sunday and needs the PREVIOUS server week, while a
+ * January week aligns with UTC and needs none. Asking "what is the offset
+ * today" therefore fetched the wrong neighbour — or none at all — for any week
+ * on the other side of the change, and the boundary entries silently vanished
+ * from both the rows and the weekly total.
+ *
+ * `localMidnightMs` is injectable so the DST behaviour is testable without an
+ * ambient timezone.
+ */
+export function neighbourWeekOffsets(
+  weekStart: string,
+  localMidnightMs: (dateOnly: string) => number = defaultLocalMidnightMs
+): Array<-1 | 1> {
+  const serverStartMs = Date.parse(`${weekStart}T00:00:00.000Z`);
+  if (Number.isNaN(serverStartMs)) return [];
+
+  const localStartMs = localMidnightMs(weekStart);
+  const localEndMs = localMidnightMs(shiftWeek(weekStart, 1));
+  if (Number.isNaN(localStartMs) || Number.isNaN(localEndMs)) return [];
+
+  const offsets: Array<-1 | 1> = [];
+  if (localStartMs < serverStartMs) offsets.push(-1);
+  if (localEndMs > serverStartMs + WEEK_MS) offsets.push(1);
+  return offsets;
+}
+
+export interface LocalWeekView {
+  byDay: Map<string, TimeEntry[]>;
+  dayTotals: Map<string, number>;
+  totals: { totalMinutes: number; billableMinutes: number };
+}
+
+/**
+ * Buckets entries onto `days` (local `YYYY-MM-DD`), dropping anything outside
+ * the local week and de-duplicating the overlap between the two fetches.
+ *
+ * Totals are recomputed from the entries actually shown rather than taken from
+ * the server's UTC-windowed `totals`, which would disagree with the rows.
+ */
+export function buildLocalWeek(entries: readonly TimeEntry[], days: readonly string[]): LocalWeekView {
+  const wanted = new Set(days);
+  const seen = new Set<string>();
+  const byDay = new Map<string, TimeEntry[]>();
+  const dayTotals = new Map<string, number>();
+  let totalMinutes = 0;
+  let billableMinutes = 0;
+
+  for (const entry of entries) {
+    if (seen.has(entry.id)) continue;
+    const day = localDayKey(entry.startedAt);
+    if (day === null || !wanted.has(day)) continue;
+    seen.add(entry.id);
+
+    const bucket = byDay.get(day);
+    if (bucket === undefined) byDay.set(day, [entry]);
+    else bucket.push(entry);
+
+    // A still-running entry has no duration yet; counting it as NaN would wipe
+    // out the whole week's total.
+    const minutes = entry.durationMinutes ?? 0;
+    dayTotals.set(day, (dayTotals.get(day) ?? 0) + minutes);
+    totalMinutes += minutes;
+    if (entry.isBillable) billableMinutes += minutes;
+  }
+
+  for (const bucket of byDay.values()) {
+    bucket.sort((a, b) => a.startedAt.localeCompare(b.startedAt));
+  }
+
+  return { byDay, dayTotals, totals: { totalMinutes, billableMinutes } };
+}

--- a/apps/mobile/src/screens/time/timesheetWeek.test.ts
+++ b/apps/mobile/src/screens/time/timesheetWeek.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+
+import { dayLabel, daysOfWeek, shiftWeek, weekRangeLabel, weekStartFor } from './timesheetWeek';
+
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+describe('weekStartFor', () => {
+  it('returns the Monday of the week containing the date', () => {
+    // 2026-08-30 is a Sunday; its week began Monday 2026-08-24.
+    expect(weekStartFor(new Date(2026, 7, 30))).toBe('2026-08-24');
+    expect(weekStartFor(new Date(2026, 7, 26))).toBe('2026-08-24');
+  });
+
+  it('returns a Monday unchanged', () => {
+    expect(weekStartFor(new Date(2026, 7, 24))).toBe('2026-08-24');
+  });
+
+  it('emits a date-only value, never a full ISO timestamp', () => {
+    // The server treats weekStart as a calendar date. Sending
+    // "2026-08-24T00:00:00.000Z" shifts the day boundary by the phone's offset
+    // and silently moves entries between weeks.
+    expect(weekStartFor(new Date(2026, 7, 30, 23, 45))).toMatch(DATE_ONLY);
+  });
+
+  it('uses the local calendar day, not UTC', () => {
+    // 23:45 local on a Sunday is already Monday in UTC for eastward offsets.
+    // Deriving the week from UTC would jump a whole week forward.
+    expect(weekStartFor(new Date(2026, 7, 30, 23, 45))).toBe('2026-08-24');
+    expect(weekStartFor(new Date(2026, 7, 31, 0, 15))).toBe('2026-08-31');
+  });
+});
+
+describe('shiftWeek', () => {
+  it('steps a whole week in either direction', () => {
+    expect(shiftWeek('2026-08-24', -1)).toBe('2026-08-17');
+    expect(shiftWeek('2026-08-24', 1)).toBe('2026-08-31');
+  });
+
+  it('crosses month and year boundaries', () => {
+    expect(shiftWeek('2026-01-04', -1)).toBe('2025-12-28');
+    expect(shiftWeek('2025-12-29', 1)).toBe('2026-01-05');
+  });
+});
+
+describe('daysOfWeek', () => {
+  it('returns the seven date-only days from the week start', () => {
+    expect(daysOfWeek('2026-08-24')).toEqual([
+      '2026-08-24',
+      '2026-08-25',
+      '2026-08-26',
+      '2026-08-27',
+      '2026-08-28',
+      '2026-08-29',
+      '2026-08-30',
+    ]);
+  });
+});
+
+describe('dayLabel', () => {
+  it('labels a date-only string with a fixed weekday and month name', () => {
+    // Deliberately not toLocaleDateString: its output varies by device locale
+    // and by JS engine (Hermes ships a reduced ICU), which makes the header
+    // unpredictable across the fleet.
+    expect(dayLabel('2026-08-24')).toBe('Mon 24 Aug');
+    expect(dayLabel('2026-08-30')).toBe('Sun 30 Aug');
+  });
+});
+
+describe('weekRangeLabel', () => {
+  it('names both ends of the week', () => {
+    expect(weekRangeLabel('2026-08-24')).toBe('24 Aug – 30 Aug 2026');
+  });
+});

--- a/apps/mobile/src/screens/time/timesheetWeek.ts
+++ b/apps/mobile/src/screens/time/timesheetWeek.ts
@@ -1,0 +1,81 @@
+/**
+ * Calendar arithmetic for the weekly timesheet.
+ *
+ * Everything here is date-only (`YYYY-MM-DD`) and computed from LOCAL calendar
+ * fields. `GET /time-entries/timesheet?weekStart=` takes a calendar date, so
+ * sending a full ISO timestamp shifts the day boundary by the phone's UTC
+ * offset and silently moves entries between weeks — 23:45 on a Sunday in
+ * London is already Monday in UTC.
+ *
+ * Pure module: no React Native imports, so it is unit-testable.
+ */
+
+const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const;
+const MONTHS = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+] as const;
+
+function pad2(value: number): string {
+  return value < 10 ? `0${value}` : String(value);
+}
+
+function toDateOnly(date: Date): string {
+  return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`;
+}
+
+/**
+ * Parses `YYYY-MM-DD` into a LOCAL midnight Date. `new Date('2026-08-24')`
+ * parses as UTC midnight, which is the previous day west of Greenwich — the
+ * exact off-by-one this module exists to avoid.
+ */
+export function localMidnightMs(dateOnly: string): number {
+  return fromDateOnly(dateOnly).getTime();
+}
+
+function fromDateOnly(dateOnly: string): Date {
+  const [year, month, day] = dateOnly.split('-').map((part) => Number(part));
+  return new Date(year, month - 1, day);
+}
+
+/** Monday of the week containing `date`, as a local calendar date. */
+export function weekStartFor(date: Date): string {
+  const local = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  // getDay(): 0 = Sunday. Monday-based weeks put Sunday six days after the start.
+  const offset = (local.getDay() + 6) % 7;
+  local.setDate(local.getDate() - offset);
+  return toDateOnly(local);
+}
+
+/** Steps `weeks` whole weeks from a week start, crossing month/year boundaries. */
+export function shiftWeek(weekStart: string, weeks: number): string {
+  const date = fromDateOnly(weekStart);
+  date.setDate(date.getDate() + weeks * 7);
+  return toDateOnly(date);
+}
+
+/** The seven calendar days of the week, so empty days still render a row. */
+export function daysOfWeek(weekStart: string): string[] {
+  const start = fromDateOnly(weekStart);
+  return Array.from({ length: 7 }, (_, index) => {
+    const day = new Date(start.getFullYear(), start.getMonth(), start.getDate() + index);
+    return toDateOnly(day);
+  });
+}
+
+/**
+ * Fixed English weekday/month names rather than `toLocaleDateString`: Hermes
+ * ships a reduced ICU, so locale formatting varies by device and engine and the
+ * header becomes unpredictable across the fleet.
+ */
+export function dayLabel(dateOnly: string): string {
+  const date = fromDateOnly(dateOnly);
+  return `${WEEKDAYS[date.getDay()]} ${date.getDate()} ${MONTHS[date.getMonth()]}`;
+}
+
+export function weekRangeLabel(weekStart: string): string {
+  const start = fromDateOnly(weekStart);
+  const end = fromDateOnly(shiftWeek(weekStart, 0));
+  end.setDate(end.getDate() + 6);
+  return `${start.getDate()} ${MONTHS[start.getMonth()]} – ${end.getDate()} ${MONTHS[end.getMonth()]} ${end.getFullYear()}`;
+}

--- a/apps/mobile/src/services/api.ts
+++ b/apps/mobile/src/services/api.ts
@@ -16,6 +16,7 @@ import {
   currentSessionGeneration,
 } from './sessionGeneration';
 import { beginSessionInvalidation } from './sessionAuthority';
+import { noteServerDate } from './serverClock';
 import { AUTH_TOKEN_KEY, NATIVE_AUTH_BINDING_KEY } from './authSessionKeys';
 
 export const FALLBACK_API_BASE_URL =
@@ -284,6 +285,11 @@ async function requestWithPrefix<T>(
       { ...options, headers, credentials: 'include' },
       timeoutMs
     );
+    // Anchor the server clock from every response, INCLUDING failures: a phone
+    // whose clock runs fast has its offline time entries rejected as too far in
+    // the future (createTimeEntrySchema refines startedAt with notFarFuture),
+    // and that 400 is permanent. Synchronous, never throws.
+    noteServerDate(response.headers.get('date'));
     assertCurrentSession(capturedGeneration);
 
     if (nativeAuthIssuer && response.status === 428 && !retriedBindingBootstrap) {

--- a/apps/mobile/src/services/auth.test.ts
+++ b/apps/mobile/src/services/auth.test.ts
@@ -29,8 +29,31 @@ vi.mock('./csrfToken', () => ({
   clearCsrfToken: (...a: unknown[]) => csrf.clearCsrfToken(...a),
 }));
 
+// The unsent time-entry queue lives in AsyncStorage, not SecureStore, so it is
+// invisible to the deleteItemAsync assertions and needs its own mock. Mocking
+// the owning module also keeps the native AsyncStorage binding out of this
+// node-environment suite.
+const timeQueue = {
+  clearQueueForSignOut: vi.fn(),
+};
+vi.mock('./timeEntryQueue', () => ({
+  QUEUE_KEY: 'breeze.timeEntryQueue.v2',
+  clearQueueForSignOut: (...a: unknown[]) => timeQueue.clearQueueForSignOut(...a),
+}));
+
+// A locally-ticking timer is cleared on every session end, deliberate or not.
+const localTimer = {
+  clearLocalTimer: vi.fn(),
+};
+vi.mock('./localTimer', () => ({
+  LOCAL_TIMER_KEY: 'breeze.localTimer.v1',
+  clearLocalTimer: (...a: unknown[]) => localTimer.clearLocalTimer(...a),
+}));
+
 beforeEach(() => {
   secureStore.deleteItemAsync.mockReset().mockResolvedValue(undefined);
+  timeQueue.clearQueueForSignOut.mockReset().mockResolvedValue(undefined);
+  localTimer.clearLocalTimer.mockReset().mockResolvedValue(undefined);
   sentry.captureException.mockReset();
   csrf.clearCsrfToken.mockReset().mockResolvedValue(undefined);
 });
@@ -142,5 +165,38 @@ describe('clearAuthData', () => {
       failedKeys: ['breeze_auth_token', 'breeze_user'],
     });
     expect(sentry.captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it('discards the unsent time-entry queue on a DELIBERATE sign-out', async () => {
+    // `breeze.timeEntryQueue.v2` is a single un-namespaced AsyncStorage key and
+    // the replay sends with whatever bearer token the CURRENT session holds. On
+    // a shared field phone that writes technician A's queued minutes under
+    // technician B.
+    await clearAuthData({ deliberate: true });
+
+    expect(timeQueue.clearQueueForSignOut).toHaveBeenCalledTimes(1);
+  });
+
+  it('KEEPS the queue on an involuntary session loss', async () => {
+    // A 401 on the cold-start revalidation, a locked keychain and a blocked
+    // device all reach here. A technician who worked offline all day and whose
+    // token expired must not lose the backlog through no action of their own;
+    // `reconcileQueueOwner` protects the next account at sign-in instead.
+    await clearAuthData();
+    await clearAuthData({ deliberate: false });
+
+    expect(timeQueue.clearQueueForSignOut).not.toHaveBeenCalled();
+    // The session-owned local timer still goes, on every path: it holds an
+    // in-progress span, not unsent work.
+    expect(localTimer.clearLocalTimer).toHaveBeenCalledTimes(2);
+  });
+
+  it('names the time-entry queue when its wipe fails, rather than reporting a clean sign-out', async () => {
+    timeQueue.clearQueueForSignOut.mockRejectedValue(new Error('SQLite busy'));
+
+    await expect(clearAuthData({ deliberate: true })).rejects.toMatchObject({
+      name: 'SecureWipeError',
+      failedKeys: ['breeze.timeEntryQueue.v2'],
+    });
   });
 });

--- a/apps/mobile/src/services/auth.ts
+++ b/apps/mobile/src/services/auth.ts
@@ -4,6 +4,8 @@ import type { User } from './api';
 import { APPROVAL_CACHE_KEY, clearApprovalCacheOrThrow } from './approvalCache';
 import { APP_LOCK_STATE_KEY } from './appLockState';
 import { CSRF_TOKEN_KEY, clearCsrfToken } from './csrfToken';
+import { LOCAL_TIMER_KEY, clearLocalTimer } from './localTimer';
+import { QUEUE_KEY, clearQueueForSignOut } from './timeEntryQueue';
 import {
   AUTH_TOKEN_KEY,
   AUTH_USER_KEY,
@@ -96,6 +98,15 @@ export class SecureWipeError extends Error {
  * Clear all authentication data.
  *
  * Also clears the persistent approvals cache (`breeze.approvals.cache.v1`).
+ *
+ * `deliberate` distinguishes the technician tapping Sign out from an
+ * INVOLUNTARY session loss — a 401/403 on the cold-start revalidation, a locked
+ * keychain, a device block. Both land here, but only the former may discard
+ * unsent work: a technician who worked offline all day and whose token expired
+ * would otherwise lose the entire time-entry backlog on relaunch, through no
+ * action of their own. It defaults to FALSE so a new call site cannot destroy
+ * that backlog by omission; cross-account replay is prevented on every other
+ * path by `reconcileQueueOwner` at sign-in.
  * The in-memory Redux reset (store/resettable.ts) drops session state on
  * sign-out, but the approval queue is additionally persisted to SecureStore
  * for offline cold-open. Without clearing it here, the next account signing in
@@ -113,7 +124,9 @@ export class SecureWipeError extends Error {
  *   - throw a `SecureWipeError` naming the surviving keys so callers can react
  *     (e.g. retry on next keychain-unlock) instead of assuming a clean wipe.
  */
-export async function clearAuthData(): Promise<void> {
+export async function clearAuthData(
+  options: Readonly<{ deliberate?: boolean }> = {}
+): Promise<void> {
   const deletions: Array<{ key: string; run: () => Promise<unknown> }> = [
     { key: AUTH_TOKEN_KEY, run: () => SecureStore.deleteItemAsync(AUTH_TOKEN_KEY) },
     { key: AUTH_USER_KEY, run: () => SecureStore.deleteItemAsync(AUTH_USER_KEY) },
@@ -131,6 +144,18 @@ export async function clearAuthData(): Promise<void> {
     // The CSRF token is account-scoped: leaving it behind would hand the next
     // account a stale double-submit value that fails every write.
     { key: CSRF_TOKEN_KEY, run: () => clearCsrfToken() },
+    // A locally-ticking timer is session-owned: left behind, the next account's
+    // TimerBar ticks the previous technician's job and stopping it enqueues
+    // that work under the new identity. Safe to clear on ANY session end — it
+    // holds no unsent work, only an in-progress span the technician can restart.
+    { key: LOCAL_TIMER_KEY, run: () => clearLocalTimer() },
+    // Unsent time-entry writes ARE unsent work, so they are parked-and-cleared
+    // only on a deliberate sign-out (see the doc comment above). The park has
+    // to land first: `clearQueueForSignOut` rejects rather than delete rows it
+    // could not copy aside, and that reaches the user as a partial wipe.
+    ...(options.deliberate === true
+      ? [{ key: QUEUE_KEY, run: () => clearQueueForSignOut() }]
+      : []),
   ];
 
   const results = await Promise.allSettled(deletions.map((d) => d.run()));

--- a/apps/mobile/src/services/localTimer.test.ts
+++ b/apps/mobile/src/services/localTimer.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const store = new Map<string, string>();
+vi.mock('@react-native-async-storage/async-storage', () => ({
+  default: {
+    getItem: async (k: string) => store.get(k) ?? null,
+    setItem: async (k: string, v: string) => {
+      store.set(k, v);
+    },
+    removeItem: async (k: string) => {
+      store.delete(k);
+    },
+  },
+}));
+
+import {
+  clearLocalTimer,
+  currentMonoEpochId,
+  LOCAL_TIMER_KEY,
+  readLocalTimer,
+  stampNow,
+  writeLocalTimer,
+  type LocalTimer,
+} from './localTimer';
+
+const timer: LocalTimer = {
+  localId: 'l1',
+  ticketId: 'k1',
+  serverEntryId: null,
+  startedAtWall: '2026-08-30T09:00:00.000Z',
+  startedAtMono: 1234,
+  monoEpochId: 'launch-1',
+  startConfirmed: true,
+  description: null,
+};
+
+beforeEach(() => {
+  store.clear();
+});
+
+describe('localTimer', () => {
+  it('round-trips a timer through storage', async () => {
+    await writeLocalTimer(timer);
+    await expect(readLocalTimer()).resolves.toEqual(timer);
+    await clearLocalTimer();
+    await expect(readLocalTimer()).resolves.toBeNull();
+  });
+
+  it('treats a persisted row with no startConfirmed as UNconfirmed', async () => {
+    // The safe direction: an extra getRunningTimer() call costs one request,
+    // where assuming "confirmed" leaves a real server timer running forever.
+    store.set(
+      LOCAL_TIMER_KEY,
+      JSON.stringify({ localId: 'l1', startedAtWall: '2026-08-30T09:00:00.000Z' })
+    );
+    const read = await readLocalTimer();
+    expect(read?.startConfirmed).toBe(false);
+  });
+
+  it('rejects a row with no usable start time rather than ticking from NaN', async () => {
+    store.set(LOCAL_TIMER_KEY, JSON.stringify({ localId: 'l1', startedAtWall: 'nonsense' }));
+    await expect(readLocalTimer()).resolves.toBeNull();
+    store.set(LOCAL_TIMER_KEY, '{not json');
+    await expect(readLocalTimer()).resolves.toBeNull();
+  });
+
+  it('stamps a stable per-launch monotonic epoch and distinct local ids', () => {
+    const a = stampNow();
+    const b = stampNow();
+    expect(a.monoEpochId).toBe(currentMonoEpochId());
+    expect(b.monoEpochId).toBe(a.monoEpochId);
+    expect(a.localId).not.toBe(b.localId);
+    expect(typeof a.wallMs).toBe('number');
+  });
+});

--- a/apps/mobile/src/services/localTimer.ts
+++ b/apps/mobile/src/services/localTimer.ts
@@ -1,0 +1,104 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+/**
+ * The one timer that exists only on this device.
+ *
+ * A timer the technician starts offline has no server entry and no
+ * server-stamped `startedAt`, so it cannot live in the queue: the queue holds
+ * only writes with explicit bounds, and a start has no end yet. It lives here
+ * instead, is what the TimerBar ticks, and becomes exactly one queued `create`
+ * at the moment Stop is tapped.
+ *
+ * Session-owned, exactly like a queued write: cleared on sign-out.
+ */
+export const LOCAL_TIMER_KEY = 'breeze.localTimer.v1';
+
+export interface LocalTimer {
+  localId: string;
+  ticketId: string | null;
+  /** Set once the server owns this timer; null while it is device-only. */
+  serverEntryId: string | null;
+  startedAtWall: string;
+  /** `performance.now()` at the tap, or null where it is unavailable. */
+  startedAtMono: number | null;
+  /** Which JS launch the mono anchor belongs to (see services/timeSpan.ts). */
+  monoEpochId: string | null;
+  /**
+   * False means a start request MAY have landed on the server before the
+   * transport failed. The reconciler resolves that against
+   * `GET /time-entries/running` rather than guessing.
+   */
+  startConfirmed: boolean;
+  description: string | null;
+}
+
+/**
+ * Regenerated on every JS launch. `performance.now()` is measured from an
+ * arbitrary per-launch origin, so two anchors are only comparable when they
+ * carry the same epoch id.
+ */
+const MONO_EPOCH_ID = `${Date.now().toString(36)}-${Math.floor(Math.random() * 1e9).toString(36)}`;
+
+export function currentMonoEpochId(): string {
+  return MONO_EPOCH_ID;
+}
+
+function monoNow(): number | null {
+  const perf = (globalThis as { performance?: { now?: () => number } }).performance;
+  return typeof perf?.now === 'function' ? perf.now() : null;
+}
+
+/** Everything a tap needs to record about "now", captured in one place. */
+export function stampNow(): {
+  localId: string;
+  wallMs: number;
+  monoMs: number | null;
+  monoEpochId: string;
+} {
+  return {
+    localId: `${Date.now()}-${Math.floor(Math.random() * Number.MAX_SAFE_INTEGER).toString(36)}`,
+    wallMs: Date.now(),
+    monoMs: monoNow(),
+    monoEpochId: MONO_EPOCH_ID,
+  };
+}
+
+function asLocalTimer(value: unknown): LocalTimer | null {
+  if (typeof value !== 'object' || value === null) return null;
+  const candidate = value as Partial<LocalTimer>;
+  if (typeof candidate.localId !== 'string' || candidate.localId.length === 0) return null;
+  if (typeof candidate.startedAtWall !== 'string') return null;
+  if (Number.isNaN(Date.parse(candidate.startedAtWall))) return null;
+  return {
+    localId: candidate.localId,
+    ticketId: typeof candidate.ticketId === 'string' ? candidate.ticketId : null,
+    serverEntryId: typeof candidate.serverEntryId === 'string' ? candidate.serverEntryId : null,
+    startedAtWall: candidate.startedAtWall,
+    startedAtMono: typeof candidate.startedAtMono === 'number' ? candidate.startedAtMono : null,
+    monoEpochId: typeof candidate.monoEpochId === 'string' ? candidate.monoEpochId : null,
+    // Defaulting to FALSE is the safe direction: it costs one extra
+    // `getRunningTimer()` call, where defaulting to true would leave a real
+    // server timer running forever.
+    startConfirmed: candidate.startConfirmed === true,
+    description: typeof candidate.description === 'string' ? candidate.description : null,
+  };
+}
+
+export async function readLocalTimer(): Promise<LocalTimer | null> {
+  try {
+    const stored = await AsyncStorage.getItem(LOCAL_TIMER_KEY);
+    if (stored === null) return null;
+    return asLocalTimer(JSON.parse(stored));
+  } catch {
+    return null;
+  }
+}
+
+/** Rejects on a storage failure — a timer the caller believes was saved but was not is a lost shift. */
+export async function writeLocalTimer(timer: LocalTimer): Promise<void> {
+  await AsyncStorage.setItem(LOCAL_TIMER_KEY, JSON.stringify(timer));
+}
+
+export async function clearLocalTimer(): Promise<void> {
+  await AsyncStorage.removeItem(LOCAL_TIMER_KEY);
+}

--- a/apps/mobile/src/services/offlineSpan.test.ts
+++ b/apps/mobile/src/services/offlineSpan.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+/**
+ * End-to-end through the pure modules: tap Start offline, tap Stop, reconnect,
+ * drain. This is the plan's Task-3 scenario and the one the previous design
+ * could not express — a queued start had no local running timer, so no surface
+ * ever offered Stop, and the offline span was lost.
+ *
+ * Every clock here is `vi.setSystemTime` plus explicit UTC ISO strings, so no
+ * ambient timezone is involved. Elapsed time is advanced with
+ * `vi.advanceTimersByTime`, which moves the faked `performance.now()` as well
+ * as `Date.now()` — a bare `setSystemTime` would move only the wall clock,
+ * which is exactly the clock-jump case `closeLocalSpan` refuses to bill.
+ */
+
+const store = new Map<string, string>();
+vi.mock('@react-native-async-storage/async-storage', () => ({
+  default: {
+    getItem: async (k: string) => store.get(k) ?? null,
+    setItem: async (k: string, v: string) => {
+      store.set(k, v);
+    },
+    removeItem: async (k: string) => {
+      store.delete(k);
+    },
+  },
+}));
+vi.mock('@sentry/react-native', () => ({ captureException: vi.fn(), captureMessage: vi.fn() }));
+vi.mock('./api', () => ({ coreRequest: vi.fn() }));
+
+import {
+  clearLocalTimer,
+  readLocalTimer,
+  stampNow,
+  writeLocalTimer,
+} from './localTimer';
+import {
+  drain,
+  enqueue,
+  parkNeedsAttention,
+  readNeedsAttention,
+  readQueue,
+  QUEUE_KEY,
+} from './timeEntryQueue';
+import { makeReplaySender } from './timeEntryReplay';
+import { makeReconciledSender, needsReconciliation, planReconciliation } from './timerReconcile';
+import { startForTicket, stopRunningTimer } from '../screens/tickets/timerActions';
+import { startOutcomeEffects, stopOutcomeEffects } from '../screens/tickets/timerOutcomeEffects';
+import type { RunningTimer } from './timeEntries';
+
+const startTimer = vi.fn();
+const stopTimer = vi.fn();
+const createTimeEntry = vi.fn().mockResolvedValue({ id: 'created' });
+const updateTimeEntry = vi.fn().mockResolvedValue({ id: 'updated' });
+
+function startDeps(connected: boolean) {
+  return {
+    startTimer,
+    writeLocalTimer,
+    clearLocalTimer,
+    isConnected: () => connected,
+    stamp: stampNow,
+  };
+}
+
+function stopDeps(connected: boolean) {
+  return {
+    stopTimer,
+    enqueue,
+    readLocalTimer,
+    clearLocalTimer,
+    parkNeedsAttention,
+    isConnected: () => connected,
+    stamp: stampNow,
+  };
+}
+
+/** The whole replay path the TimerBar composes, minus React. */
+async function replay(serverNowMs: number, server: RunningTimer | null = null) {
+  const queue = await readQueue();
+  const localTimer = await readLocalTimer();
+  const plan = needsReconciliation(localTimer, queue)
+    ? planReconciliation({ localTimer, queue, server })
+    : { adopt: null, substitute: null };
+  const send = makeReconciledSender({
+    base: makeReplaySender({ createTimeEntry, updateTimeEntry, serverNow: () => serverNowMs }),
+    plan,
+    updateTimeEntry,
+    lookupWeekEntries: async () => null,
+  });
+  return drain(send);
+}
+
+beforeEach(() => {
+  store.clear();
+  vi.clearAllMocks();
+  createTimeEntry.mockResolvedValue({ id: 'created' });
+  updateTimeEntry.mockResolvedValue({ id: 'updated' });
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('an offline shift', () => {
+  it('records the real 40 minutes as ONE create, replayed hours later unchanged', async () => {
+    vi.setSystemTime(new Date('2026-08-30T09:00:00.000Z'));
+    const started = await startForTicket('T', startDeps(false));
+    expect(started).toMatchObject({ ok: 'local' });
+
+    // The regression that made the whole span unrecordable: with no running
+    // timer in the store, neither surface offers Stop.
+    const running = startOutcomeEffects(started).startRunning;
+    expect(running).not.toBeNull();
+    expect(running?.id).toBeNull();
+
+    vi.advanceTimersByTime(40 * 60_000);
+    const stopped = await stopRunningTimer({ running }, stopDeps(false));
+    expect(stopped).toEqual({ ok: 'queued' });
+    expect(stopOutcomeEffects(stopped).clearRunning).toBe(true);
+
+    const queued = await readQueue();
+    expect(queued).toHaveLength(1);
+    expect(queued[0].kind).toBe('create');
+    expect(queued[0].payload).toMatchObject({
+      startedAt: '2026-08-30T09:00:00.000Z',
+      endedAt: '2026-08-30T09:40:00.000Z',
+      ticketId: 'T',
+    });
+
+    // Back at the office, three hours later.
+    vi.advanceTimersByTime(2 * 3600_000 + 20 * 60_000);
+    const result = await replay(Date.parse('2026-08-30T12:00:00.000Z'));
+    expect(result).toMatchObject({ sent: 1, remaining: 0 });
+    expect(createTimeEntry).toHaveBeenCalledWith({
+      startedAt: '2026-08-30T09:00:00.000Z',
+      endedAt: '2026-08-30T09:40:00.000Z',
+      ticketId: 'T',
+    });
+    // Either verb would have let the server stamp 12:00 over the real work.
+    expect(startTimer).not.toHaveBeenCalled();
+    expect(stopTimer).not.toHaveBeenCalled();
+  });
+
+  it('closes a SERVER timer at the tap time, not the reconnect time', async () => {
+    // The over-billing defect: `/time-entries/stop` stamps endedAt = now, so a
+    // 15:00 stop replayed at 18:00 billed three extra hours to the customer.
+    const server: RunningTimer = {
+      id: 'E',
+      localId: null,
+      ticketId: 'T',
+      startedAt: '2026-08-30T14:00:00.000Z',
+      description: null,
+    };
+    vi.setSystemTime(new Date('2026-08-30T15:00:00.000Z'));
+    expect(await stopRunningTimer({ running: server }, stopDeps(false))).toEqual({ ok: 'queued' });
+
+    vi.setSystemTime(new Date('2026-08-30T18:00:00.000Z'));
+    const result = await replay(Date.parse('2026-08-30T18:00:00.000Z'));
+    expect(result).toMatchObject({ sent: 1, remaining: 0 });
+    expect(updateTimeEntry).toHaveBeenCalledWith('E', { endedAt: '2026-08-30T15:00:00.000Z' });
+    expect(stopTimer).not.toHaveBeenCalled();
+    expect(createTimeEntry).not.toHaveBeenCalled();
+  });
+
+  it('sends a fast phone\'s span shifted into the past, with its duration exact', async () => {
+    // Device clock is three hours ahead of the server. Unshifted, the create is
+    // a permanent 400 (notFarFuture) and the technician's real work is parked.
+    vi.setSystemTime(new Date('2026-08-30T12:00:00.000Z'));
+    const started = await startForTicket('T', startDeps(false));
+    vi.advanceTimersByTime(40 * 60_000);
+    await stopRunningTimer({ running: startOutcomeEffects(started).startRunning }, stopDeps(false));
+
+    const serverNow = Date.parse('2026-08-30T09:41:00.000Z');
+    await replay(serverNow);
+
+    const sent = createTimeEntry.mock.calls[0][0] as { startedAt: string; endedAt: string };
+    expect(Date.parse(sent.startedAt)).toBeLessThanOrEqual(serverNow);
+    expect(Date.parse(sent.endedAt) - Date.parse(sent.startedAt)).toBe(40 * 60_000);
+  });
+
+  it('parks a rejected create where it can be read back, and clears it from the queue', async () => {
+    vi.setSystemTime(new Date('2026-08-30T09:00:00.000Z'));
+    const started = await startForTicket('T', startDeps(false));
+    vi.advanceTimersByTime(40 * 60_000);
+    await stopRunningTimer({ running: startOutcomeEffects(started).startRunning }, stopDeps(false));
+
+    createTimeEntry.mockRejectedValue(
+      Object.assign(new Error('startedAt must not be in the future'), { status: 400 })
+    );
+    const result = await replay(Date.parse('2026-08-30T09:41:00.000Z'));
+
+    expect(result.needsAttentionTotal).toBe(1);
+    await expect(readQueue()).resolves.toEqual([]);
+    expect(JSON.parse(store.get(QUEUE_KEY) ?? '[]')).toEqual([]);
+    const parked = await readNeedsAttention();
+    expect(parked).toHaveLength(1);
+    expect(parked[0]).toMatchObject({ status: 400, message: 'startedAt must not be in the future' });
+    expect(parked[0].write.payload).toMatchObject({ ticketId: 'T' });
+  });
+});
+
+describe('a start whose response was lost', () => {
+  async function queueUnconfirmedSpan() {
+    vi.setSystemTime(new Date('2026-08-30T09:00:00.000Z'));
+    startTimer.mockRejectedValue(new Error('network down'));
+    const started = await startForTicket('T', startDeps(true));
+    expect(started).toMatchObject({ ok: 'local' });
+
+    vi.advanceTimersByTime(40 * 60_000);
+    await stopRunningTimer({ running: startOutcomeEffects(started).startRunning }, stopDeps(false));
+    const [queued] = await readQueue();
+    expect(queued.payload).toMatchObject({ unconfirmedStart: true });
+  }
+
+  it('closes the phantom instead of posting a second entry for the same work', async () => {
+    await queueUnconfirmedSpan();
+    const server: RunningTimer = {
+      id: 'E',
+      localId: null,
+      ticketId: 'T',
+      startedAt: '2026-08-30T09:00:02.000Z',
+      description: null,
+    };
+
+    vi.advanceTimersByTime(2 * 3600_000 + 20 * 60_000);
+    const result = await replay(Date.parse('2026-08-30T12:00:00.000Z'), server);
+
+    expect(result).toMatchObject({ sent: 1, remaining: 0 });
+    expect(updateTimeEntry).toHaveBeenCalledWith('E', { endedAt: '2026-08-30T09:40:00.000Z' });
+    expect(createTimeEntry).not.toHaveBeenCalled();
+  });
+
+  it('sends the create unchanged when the running timer is somebody else\'s work', async () => {
+    await queueUnconfirmedSpan();
+    const unrelated: RunningTimer = {
+      id: 'OTHER',
+      localId: null,
+      ticketId: 'DIFFERENT',
+      startedAt: '2026-08-30T09:00:02.000Z',
+      description: null,
+    };
+
+    vi.advanceTimersByTime(2 * 3600_000 + 20 * 60_000);
+    await replay(Date.parse('2026-08-30T12:00:00.000Z'), unrelated);
+
+    expect(updateTimeEntry).not.toHaveBeenCalled();
+    expect(createTimeEntry).toHaveBeenCalledWith({
+      startedAt: '2026-08-30T09:00:00.000Z',
+      endedAt: '2026-08-30T09:40:00.000Z',
+      ticketId: 'T',
+    });
+  });
+});

--- a/apps/mobile/src/services/serverClock.test.ts
+++ b/apps/mobile/src/services/serverClock.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const store = new Map<string, string>();
+vi.mock('@react-native-async-storage/async-storage', () => ({
+  default: {
+    getItem: async (k: string) => store.get(k) ?? null,
+    setItem: async (k: string, v: string) => {
+      store.set(k, v);
+    },
+    removeItem: async (k: string) => {
+      store.delete(k);
+    },
+  },
+}));
+
+import {
+  loadServerClock,
+  noteServerDate,
+  resetServerClock,
+  serverNowMs,
+  SERVER_CLOCK_KEY,
+} from './serverClock';
+
+beforeEach(() => {
+  store.clear();
+  resetServerClock();
+  vi.useFakeTimers();
+  // The device clock is three hours fast; the server is the truth.
+  vi.setSystemTime(new Date('2026-08-30T12:00:00.000Z'));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('serverClock', () => {
+  it('reports the device clock, untrusted, before any anchor is seen', () => {
+    expect(serverNowMs()).toEqual({ ms: Date.parse('2026-08-30T12:00:00.000Z'), trusted: false });
+  });
+
+  it('corrects the device clock once a Date header has been seen', () => {
+    noteServerDate('Sun, 30 Aug 2026 09:00:00 GMT');
+    expect(serverNowMs()).toEqual({ ms: Date.parse('2026-08-30T09:00:00.000Z'), trusted: true });
+  });
+
+  it('keeps correcting while the phone is offline, because it stores an offset', () => {
+    noteServerDate('Sun, 30 Aug 2026 09:00:00 GMT');
+    vi.setSystemTime(new Date('2026-08-30T12:40:00.000Z'));
+    // 40 device-minutes later, so 40 server-minutes later — not a frozen stamp.
+    expect(serverNowMs().ms).toBe(Date.parse('2026-08-30T09:40:00.000Z'));
+  });
+
+  it('ignores a missing or unparseable header rather than poisoning the offset', () => {
+    noteServerDate(null);
+    expect(serverNowMs().trusted).toBe(false);
+    noteServerDate('not a date');
+    expect(serverNowMs().trusted).toBe(false);
+  });
+
+  it('rehydrates the offset a previous launch persisted', async () => {
+    noteServerDate('Sun, 30 Aug 2026 09:00:00 GMT');
+    expect(store.has(SERVER_CLOCK_KEY)).toBe(true);
+
+    resetServerClock();
+    expect(serverNowMs().trusted).toBe(false);
+    await loadServerClock();
+    expect(serverNowMs()).toEqual({ ms: Date.parse('2026-08-30T09:00:00.000Z'), trusted: true });
+  });
+
+  it('treats a corrupt persisted anchor as no anchor', async () => {
+    store.set(SERVER_CLOCK_KEY, '{not json');
+    await loadServerClock();
+    expect(serverNowMs().trusted).toBe(false);
+  });
+});

--- a/apps/mobile/src/services/serverClock.ts
+++ b/apps/mobile/src/services/serverClock.ts
@@ -1,0 +1,65 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+/**
+ * The phone's best estimate of the SERVER's clock.
+ *
+ * Why it exists: `createTimeEntrySchema.startedAt` is refined `notFarFuture`
+ * with five minutes of tolerance, and the queue treats the resulting 400 as
+ * permanent. A phone whose clock runs fast would therefore have every offline
+ * entry parked for manual re-entry — the technician's minutes lost to a device
+ * setting they never touched. Anchoring to the `Date` response header lets the
+ * replay translate a future-dated span back into the past before sending it.
+ *
+ * The anchor is an OFFSET, not a timestamp, so it stays useful while the phone
+ * is offline: `Date.now()` still advances, and the offset corrects it. Its
+ * resolution is one second (RFC 9110 `Date`), which is far inside the five
+ * minutes it protects.
+ */
+export const SERVER_CLOCK_KEY = 'breeze.serverClock.v1';
+
+let offsetMs = 0;
+let trusted = false;
+
+/**
+ * Records the offset from one response's `Date` header. Never throws and never
+ * awaits storage: this runs on every API response and must not add latency or
+ * turn a working request into a failed one.
+ */
+export function noteServerDate(header: string | null): void {
+  if (header === null) return;
+  const serverMs = Date.parse(header);
+  if (Number.isNaN(serverMs)) return;
+
+  offsetMs = serverMs - Date.now();
+  trusted = true;
+  void AsyncStorage.setItem(SERVER_CLOCK_KEY, JSON.stringify({ offsetMs })).catch(() => undefined);
+}
+
+/**
+ * `trusted: false` means no anchor has ever been seen (a cold install that has
+ * been offline since launch). The caller gets the device clock unchanged, which
+ * is the only thing available — but it knows not to present it as authoritative.
+ */
+export function serverNowMs(): { ms: number; trusted: boolean } {
+  return { ms: Date.now() + (trusted ? offsetMs : 0), trusted };
+}
+
+/** Hydrates the offset persisted by a previous launch. Never throws. */
+export async function loadServerClock(): Promise<void> {
+  try {
+    const stored = await AsyncStorage.getItem(SERVER_CLOCK_KEY);
+    if (stored === null) return;
+    const parsed = JSON.parse(stored) as { offsetMs?: unknown };
+    if (typeof parsed?.offsetMs !== 'number' || !Number.isFinite(parsed.offsetMs)) return;
+    offsetMs = parsed.offsetMs;
+    trusted = true;
+  } catch {
+    // An unreadable anchor is the same as never having had one.
+  }
+}
+
+/** Drops the in-memory anchor. Exported for tests; the persisted value stays. */
+export function resetServerClock(): void {
+  offsetMs = 0;
+  trusted = false;
+}

--- a/apps/mobile/src/services/sessionAuthority.ts
+++ b/apps/mobile/src/services/sessionAuthority.ts
@@ -12,11 +12,18 @@ export interface SessionInvalidation {
 /**
  * Synchronously supersede every request/write from the old session, then put
  * the complete secure wipe on the same serialized queue as authority writes.
+ *
+ * `deliberate` is threaded through to `clearAuthData` and decides whether the
+ * unsent time-entry backlog is discarded. It defaults to false: an involuntary
+ * session loss (token expiry, locked keychain, device block) must not cost a
+ * technician a day of offline work.
  */
-export function beginSessionInvalidation(): SessionInvalidation {
+export function beginSessionInvalidation(
+  options: Readonly<{ deliberate?: boolean }> = {}
+): SessionInvalidation {
   const generation = advanceSessionGeneration();
   return {
     generation,
-    cleanup: commitIfCurrent(generation, clearAuthData),
+    cleanup: commitIfCurrent(generation, () => clearAuthData(options)),
   };
 }

--- a/apps/mobile/src/services/timeEntries.test.ts
+++ b/apps/mobile/src/services/timeEntries.test.ts
@@ -10,6 +10,7 @@ import {
   startTimer,
   stopTimer,
   TimeEntryError,
+  updateTimeEntry,
 } from './timeEntries';
 
 const ENTRY = {
@@ -36,7 +37,15 @@ describe('getRunningTimer', () => {
       data: { id: 't1', ticketId: 'k1', startedAt: '2026-08-23T10:00:00Z', description: 'onsite', extra: 'ignored' },
     });
     const timer = await getRunningTimer();
-    expect(timer).toEqual({ id: 't1', ticketId: 'k1', startedAt: '2026-08-23T10:00:00Z', description: 'onsite' });
+    // `localId: null` is the marker that the SERVER owns this timer, as
+    // opposed to one this device is ticking that has no entry yet.
+    expect(timer).toEqual({
+      id: 't1',
+      localId: null,
+      ticketId: 'k1',
+      startedAt: '2026-08-23T10:00:00Z',
+      description: 'onsite',
+    });
   });
 });
 
@@ -159,5 +168,35 @@ describe('getTimesheet', () => {
     expect(week.days).toHaveLength(1);
     expect(week.days[0]).toMatchObject({ date: '2026-08-17', totalMinutes: 60, billableMinutes: 30 });
     expect(week.days[0].entries[0]).toEqual({ ...ENTRY, endedAt: 'x', durationMinutes: 60 });
+  });
+});
+
+describe('updateTimeEntry', () => {
+  it('PATCHes only the fields the caller passed', async () => {
+    coreRequest.mockResolvedValue({ data: { ...ENTRY, description: 'fixed' } });
+    await updateTimeEntry('e1', { description: 'fixed' });
+    const [path, options] = coreRequest.mock.calls[0];
+    expect(path).toBe('/time-entries/e1');
+    expect((options as { method: string }).method).toBe('PATCH');
+    expect(JSON.parse((options as { body: string }).body)).toEqual({ description: 'fixed' });
+  });
+
+  it('sends an explicit false for isBillable rather than dropping it', async () => {
+    // `compact` drops undefined, and `false` is a legitimate value here — a
+    // dropped one silently leaves the entry billable.
+    coreRequest.mockResolvedValue({ data: { ...ENTRY, isBillable: false } });
+    await updateTimeEntry('e1', { isBillable: false });
+    const [, options] = coreRequest.mock.calls[0];
+    expect(JSON.parse((options as { body: string }).body)).toEqual({ isBillable: false });
+  });
+
+  it('surfaces a locked row as a typed error the screen can name', async () => {
+    coreRequest.mockRejectedValue(
+      Object.assign(new Error('Entry is billed'), { statusCode: 409, code: 'ENTRY_BILLED' })
+    );
+    await expect(updateTimeEntry('e1', { description: 'x' })).rejects.toMatchObject({
+      code: 'ENTRY_BILLED',
+      status: 409,
+    });
   });
 });

--- a/apps/mobile/src/services/timeEntries.ts
+++ b/apps/mobile/src/services/timeEntries.ts
@@ -16,7 +16,16 @@ import { coreRequest } from './api';
 export type BillingStatus = 'not_billed' | 'billed' | 'no_charge' | 'contract';
 
 export interface RunningTimer {
-  id: string;
+  /**
+   * The server entry id, or null for a timer that exists only on this device
+   * because it was started while offline (see services/localTimer.ts). A null
+   * id is what tells every surface that this timer has not been created yet:
+   * it can be stopped and enqueued as a `create`, but never stopped through
+   * `/time-entries/stop`, which would close somebody else's running entry.
+   */
+  id: string | null;
+  /** Set while the timer is device-only; null once the server owns it. */
+  localId: string | null;
   ticketId: string | null;
   startedAt: string;
   description: string | null;
@@ -104,6 +113,7 @@ function compact(input: object): Record<string, unknown> {
 function narrowRunningTimer(row: ServerTimeEntry): RunningTimer {
   return {
     id: row.id,
+    localId: null,
     ticketId: row.ticketId ?? null,
     startedAt: row.startedAt,
     description: row.description ?? null,
@@ -204,6 +214,44 @@ export async function getTimesheet(weekStart: string): Promise<TimesheetWeek> {
         billableMinutes: response.data.totals.billableMinutes,
       },
     };
+  } catch (error) {
+    throw asTimeEntryError(error);
+  }
+}
+
+/**
+ * Fields the phone is allowed to correct after the fact.
+ *
+ * Deliberately narrower than `updateTimeEntrySchema`: `hourlyRate` is never
+ * computed or sent from a phone, and `startedAt` is absent because moving the
+ * START of an entry needs a date picker the timesheet does not have — a
+ * mistyped boundary is worse than an uncorrected one. The TIMESHEET UI still
+ * offers no boundary editing at all.
+ *
+ * `endedAt` exists for exactly one caller: the `closeEntry` replay path
+ * (services/timeEntryReplay.ts). A timer the SERVER started can only be closed
+ * at its true tap time by PATCHing that timestamp onto the running row —
+ * `POST /time-entries/stop` stamps `endedAt = now`, which bills a 15:00 stop
+ * to whenever the phone reconnected. `updateTimeEntrySchema.endedAt` carries no
+ * `notFarFuture` refine and the service recomputes `durationMinutes`, so this
+ * closes the row correctly with no backend change.
+ */
+export interface UpdateTimeEntryInput {
+  description?: string | null;
+  isBillable?: boolean;
+  endedAt?: string;
+}
+
+export async function updateTimeEntry(
+  id: string,
+  input: UpdateTimeEntryInput
+): Promise<TimeEntry> {
+  try {
+    const response = await coreRequest<{ data: ServerTimeEntry }>(
+      `/time-entries/${encodeURIComponent(id)}`,
+      { method: 'PATCH', body: JSON.stringify(compact(input)) }
+    );
+    return narrowTimeEntry(response.data);
   } catch (error) {
     throw asTimeEntryError(error);
   }

--- a/apps/mobile/src/services/timeEntryAccess.test.ts
+++ b/apps/mobile/src/services/timeEntryAccess.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// `timeEntries` pulls in `./api`, which imports @sentry/react-native — Flow
+// syntax Vitest's node environment cannot parse. Mock the transport, not the
+// network, exactly as timeEntries.test.ts does.
+vi.mock('./api', () => ({ coreRequest: vi.fn() }));
+
+import { classifyTimeEntryDenial, isAccountLevelDenial } from './timeEntryAccess';
+import { TimeEntryError } from './timeEntries';
+
+describe('classifyTimeEntryDenial', () => {
+  it('returns null for anything that is not a 403', () => {
+    expect(classifyTimeEntryDenial(new TimeEntryError('conflict', 'ENTRY_RUNNING', 409))).toBeNull();
+    expect(classifyTimeEntryDenial(new Error('offline'))).toBeNull();
+    expect(classifyTimeEntryDenial(undefined)).toBeNull();
+  });
+
+  it('reads the scope rejection the route emits for an organization-scoped token', () => {
+    // requireScope('partner','system') throws exactly this message
+    // (apps/api/src/middleware/auth.ts), and time_entries has no org-axis RLS
+    // policy, so an org-scoped login can never reach the feature.
+    const denial = classifyTimeEntryDenial(
+      new TimeEntryError('Insufficient permissions', undefined, 403)
+    );
+    expect(denial?.reason).toBe('scope');
+    expect(denial?.message).toMatch(/organization/i);
+    expect(denial?.message).not.toMatch(/an error occurred/i);
+  });
+
+  it('reads a role/permission rejection distinctly from a scope rejection', () => {
+    const denied = classifyTimeEntryDenial(new TimeEntryError('Permission denied', undefined, 403));
+    expect(denied?.reason).toBe('permission');
+    expect(denied?.message).toMatch(/role/i);
+
+    const missing = classifyTimeEntryDenial(
+      new TimeEntryError('No permissions found', undefined, 403)
+    );
+    expect(missing?.reason).toBe('permission');
+  });
+
+  it('maps NOT_OWN_ENTRY to an ownership denial rather than a role problem', () => {
+    const denial = classifyTimeEntryDenial(new TimeEntryError('nope', 'NOT_OWN_ENTRY', 403));
+    expect(denial?.reason).toBe('ownership');
+    expect(denial?.message).toMatch(/someone else|another/i);
+  });
+
+  it('maps ADMIN_REQUIRED to a permission denial that names the administrator', () => {
+    const denial = classifyTimeEntryDenial(new TimeEntryError('nope', 'ADMIN_REQUIRED', 403));
+    expect(denial?.reason).toBe('permission');
+    expect(denial?.message).toMatch(/administrator/i);
+  });
+
+  it('never falls back to a generic message on an unclassifiable 403', () => {
+    // A blank "Something went wrong" here is the exact failure the W02 gate
+    // called out: the technician cannot tell a scope wall from a role gap.
+    const denial = classifyTimeEntryDenial(new TimeEntryError('teapot', undefined, 403));
+    expect(denial?.reason).toBe('unknown');
+    expect(denial?.message).toMatch(/time tracking/i);
+    expect(denial?.message).toMatch(/teapot/);
+  });
+
+  it('accepts a bare ApiError shape from coreRequest, not just TimeEntryError', () => {
+    const denial = classifyTimeEntryDenial({
+      message: 'Insufficient permissions',
+      statusCode: 403,
+    });
+    expect(denial?.reason).toBe('scope');
+  });
+
+  it('maps APPROVED_IMMUTABLE to a per-entry verdict, not a role problem', () => {
+    // assertCanMutate raises this 403 about ONE ROW. Classified as anything
+    // account-shaped it becomes a sticky wall that removes the Stop button from
+    // a running timer and replaces the whole Time tab until sign-out.
+    const denial = classifyTimeEntryDenial(
+      new TimeEntryError('Approved entries can only be changed by an approver', 'APPROVED_IMMUTABLE', 403)
+    );
+    expect(denial?.reason).toBe('entry');
+    expect(denial?.message).toMatch(/approv/i);
+  });
+});
+
+describe('isAccountLevelDenial', () => {
+  it('treats the scope wall and a missing role grant as account-level', () => {
+    // Both stay true for the whole session: an org-scoped token can never read
+    // the table, and a missing time_entries:write grant needs an administrator.
+    expect(isAccountLevelDenial({ reason: 'scope', message: '' })).toBe(true);
+    expect(isAccountLevelDenial({ reason: 'permission', message: '' })).toBe(true);
+  });
+
+  it('refuses to escalate a per-row verdict into an app-wide wall', () => {
+    // The bug this closes: a manager approves the week from the web while the
+    // timesheet is open, one "Mark billable" tap returns 403 APPROVED_IMMUTABLE,
+    // and time tracking is withdrawn app-wide until the technician signs out.
+    expect(isAccountLevelDenial({ reason: 'entry', message: '' })).toBe(false);
+    expect(isAccountLevelDenial({ reason: 'ownership', message: '' })).toBe(false);
+    expect(isAccountLevelDenial({ reason: 'unknown', message: '' })).toBe(false);
+  });
+});

--- a/apps/mobile/src/services/timeEntryAccess.ts
+++ b/apps/mobile/src/services/timeEntryAccess.ts
@@ -1,0 +1,103 @@
+/**
+ * The scope and permission middleware both return uncoded 403 responses, so
+ * their messages are currently the only signal that distinguishes an
+ * organization-scoped account from a role grant problem. Prefer machine codes
+ * if the API adds them later.
+ */
+
+/**
+ * `scope` and `permission` are facts about the ACCOUNT and stay true for the
+ * whole session. `ownership`, `entry` and `unknown` are verdicts about ONE ROW
+ * and must never be escalated into an app-wide wall — see `isAccountLevelDenial`.
+ */
+export type TimeEntryDenialReason = 'scope' | 'permission' | 'ownership' | 'entry' | 'unknown';
+
+export interface TimeEntryDenial {
+  reason: TimeEntryDenialReason;
+  message: string;
+}
+
+function errorField(error: unknown, field: string): unknown {
+  if (typeof error !== 'object' || error === null) {
+    return undefined;
+  }
+
+  return (error as Record<string, unknown>)[field];
+}
+
+function getStatus(error: unknown): number | undefined {
+  const status = errorField(error, 'status');
+  if (typeof status === 'number') {
+    return status;
+  }
+
+  const statusCode = errorField(error, 'statusCode');
+  return typeof statusCode === 'number' ? statusCode : undefined;
+}
+
+function getStringField(error: unknown, field: string): string | undefined {
+  const value = errorField(error, field);
+  return typeof value === 'string' ? value : undefined;
+}
+
+export function classifyTimeEntryDenial(error: unknown): TimeEntryDenial | null {
+  if (getStatus(error) !== 403) {
+    return null;
+  }
+
+  const code = getStringField(error, 'code');
+  const serverMessage = getStringField(error, 'message') ?? 'No reason was provided by the server.';
+
+  if (code === 'NOT_OWN_ENTRY') {
+    return {
+      reason: 'ownership',
+      message: 'This time entry belongs to another technician. Only an administrator can change it.',
+    };
+  }
+
+  if (code === 'APPROVED_IMMUTABLE') {
+    return {
+      reason: 'entry',
+      message: 'That entry has been approved and can no longer be changed. Ask an approver to reopen it.',
+    };
+  }
+
+  if (code === 'ADMIN_REQUIRED') {
+    return {
+      reason: 'permission',
+      message: 'An administrator is required to make this time-entry change.',
+    };
+  }
+
+  if (/insufficient permissions/i.test(serverMessage)) {
+    return {
+      reason: 'scope',
+      message: 'This account is organization-scoped. Time tracking requires an MSP/partner login, so retrying with this account will not work.',
+    };
+  }
+
+  if (/permission denied|no permissions found/i.test(serverMessage)) {
+    return {
+      reason: 'permission',
+      message: 'Your role does not include the time-entries permission. An administrator can grant it.',
+    };
+  }
+
+  return {
+    reason: 'unknown',
+    message: `Time tracking was denied by the server: ${serverMessage}`,
+  };
+}
+
+/**
+ * Whether a denial justifies withdrawing time tracking for the rest of the
+ * session (`timeAccessDenied` is deliberately sticky until sign-out).
+ *
+ * Only an account-shaped verdict qualifies. Treating a per-row 403 as an
+ * account wall removes the Stop button from a RUNNING timer and replaces the
+ * whole Time tab with "Time tracking unavailable" — for a manager having
+ * approved one week from the web dashboard.
+ */
+export function isAccountLevelDenial(denial: TimeEntryDenial): boolean {
+  return denial.reason === 'scope' || denial.reason === 'permission';
+}

--- a/apps/mobile/src/services/timeEntryQueue.test.ts
+++ b/apps/mobile/src/services/timeEntryQueue.test.ts
@@ -8,6 +8,8 @@ let getItemFailures = 0;
  * callback to target the re-read at the end of a drain specifically.
  */
 let failNextQueueRead = false;
+/** Same, for the parked-rows blob, which the sign-out park reads third. */
+let failNextNeedsAttentionRead = false;
 /** Keys whose setItem rejects, so a failed quarantine copy can be exercised. */
 const setItemFailKeys = new Set<string>();
 vi.mock('@react-native-async-storage/async-storage', () => ({
@@ -16,6 +18,10 @@ vi.mock('@react-native-async-storage/async-storage', () => ({
       // Literal, not the imported const: this factory is hoisted above imports.
       if (failNextQueueRead && k === 'breeze.timeEntryQueue.v2') {
         failNextQueueRead = false;
+        throw new Error('SQLite busy');
+      }
+      if (failNextNeedsAttentionRead && k === 'breeze.timeEntryQueue.v2.needsAttention') {
+        failNextNeedsAttentionRead = false;
         throw new Error('SQLite busy');
       }
       if (getItemFailures > 0) {
@@ -48,9 +54,15 @@ import {
   readNeedsAttention,
   clearNeedsAttention,
   parkNeedsAttention,
+  clearQueueForSignOut,
+  reconcileQueueOwner,
+  readOrphanedQueues,
+  QUEUE_ORPHANED_KEY,
+  QUEUE_OWNER_KEY,
   QUEUE_KEY,
   QUEUE_CORRUPT_KEY,
   QUEUE_NEEDS_ATTENTION_KEY,
+  QUEUE_TOMBSTONE_KEY,
   QUEUED_KINDS,
 } from './timeEntryQueue';
 import type { QueuedWrite } from './timeEntryQueue';
@@ -59,6 +71,7 @@ beforeEach(() => {
   store.clear();
   getItemFailures = 0;
   failNextQueueRead = false;
+  failNextNeedsAttentionRead = false;
   setItemFailKeys.clear();
   vi.clearAllMocks();
 });
@@ -633,5 +646,151 @@ describe('timeEntryQueue', () => {
     await expect(readQueue()).resolves.toEqual([]);
     expect(lastSentryExtra()).toMatchObject({ reason: 'unparseable-queue', parked: true });
     expect(store.get(QUEUE_CORRUPT_KEY)).toBe('[{"id":"a","kind":"cre');
+  });
+
+  // --- Sign-out, session loss, and the drain that outlives both ---
+
+  it('parks and clears the queue on a deliberate sign-out', async () => {
+    await enqueue({ kind: 'create', payload: { ...SPAN, ticketId: 'k1' } });
+    const outcome = await clearQueueForSignOut();
+
+    expect(outcome).toMatchObject({ cleared: 1, parked: true });
+    await expect(readQueue()).resolves.toEqual([]);
+    const orphaned = await readOrphanedQueues();
+    expect(orphaned).toHaveLength(1);
+    expect(orphaned[0].writes[0].payload).toMatchObject({ ticketId: 'k1' });
+  });
+
+  it('APPENDS to the orphan park, so a second sign-out cannot destroy the first', async () => {
+    // The park is the only remaining copy of unsent billable work. Overwriting
+    // it turns "recoverable by hand" into a claim nobody can act on.
+    await enqueue({ kind: 'create', payload: { ...SPAN, ticketId: 'first' } });
+    await clearQueueForSignOut();
+    await enqueue({ kind: 'create', payload: { ...SPAN, ticketId: 'second' } });
+    await clearQueueForSignOut();
+
+    const orphaned = await readOrphanedQueues();
+    expect(orphaned).toHaveLength(2);
+    expect(orphaned.flatMap((batch) => batch.writes.map((w) => w.payload.ticketId))).toEqual([
+      'first',
+      'second',
+    ]);
+  });
+
+  it('refuses to delete the queue when the park did not happen', async () => {
+    // Deleting anyway was the defect: the failure was swallowed while the only
+    // copy of the work was destroyed. Keeping it leaves the (already narrow)
+    // cross-account window to `reconcileQueueOwner`, which closes it at the
+    // next sign-in without losing anything.
+    setItemFailKeys.add(QUEUE_ORPHANED_KEY);
+    await enqueue({ kind: 'create', payload: { ...SPAN, ticketId: 'k1' } });
+
+    await expect(clearQueueForSignOut()).rejects.toThrow(/could not be parked/i);
+    await expect(readQueue()).resolves.toHaveLength(1);
+    expect(lastSentryExtra()).toMatchObject({ reason: 'sign-out', parked: false });
+  });
+
+  it('refuses the sign-out when the parked rows cannot be read', async () => {
+    // The last act of the park is `setItem(QUEUE_NEEDS_ATTENTION_KEY, '[]')`.
+    // Rows that could not be read were never copied into the orphan batch, so
+    // proceeding would wipe them — the same rule as a failed park: never delete
+    // what you could not back up first.
+    await enqueue({ kind: 'create', payload: { ...SPAN } });
+    await drain(async () => {
+      throw Object.assign(new Error('bad'), { status: 400 });
+    });
+    await expect(readNeedsAttention()).resolves.toHaveLength(1);
+
+    failNextNeedsAttentionRead = true;
+    await expect(clearQueueForSignOut()).rejects.toThrow(/could not be parked/i);
+
+    await expect(readNeedsAttention()).resolves.toHaveLength(1);
+  });
+
+  it('parks the needs-attention rows too — they are the previous account\'s work as well', async () => {
+    await enqueue({ kind: 'create', payload: { ...SPAN } });
+    await drain(async () => {
+      throw Object.assign(new Error('bad'), { status: 400 });
+    });
+    await expect(readNeedsAttention()).resolves.toHaveLength(1);
+
+    await clearQueueForSignOut();
+    await expect(readNeedsAttention()).resolves.toEqual([]);
+    expect((await readOrphanedQueues())[0].needsAttention).toHaveLength(1);
+  });
+
+  it('an in-flight drain cannot write the queue back after a sign-out cleared it', async () => {
+    // The drain holds a snapshot taken before the sign-out. Persisting it would
+    // hand the previous technician's unsent entries straight to the next
+    // account — re-opening the exact leak the sign-out wipe exists to close.
+    await enqueue({ kind: 'create', payload: { ...SPAN, ticketId: 'a' } });
+    await enqueue({ kind: 'create', payload: { ...SPAN, ticketId: 'b' } });
+
+    const result = await drain(async (write) => {
+      if (write.payload.ticketId === 'a') await clearQueueForSignOut();
+      // 'b' fails transiently, so the pre-fix code would persist it back.
+      if (write.payload.ticketId === 'b') throw new Error('offline');
+    });
+
+    expect(result.remaining).toBe(0);
+    await expect(readQueue()).resolves.toEqual([]);
+    expect(JSON.parse(store.get(QUEUE_KEY) ?? '[]')).toEqual([]);
+  });
+
+  it('an in-flight drain does not leave a tombstone behind a sign-out either', async () => {
+    // Same race on the storage-failure path: the tombstone names ids from a
+    // queue that no longer exists, and applying it to the NEXT account's queue
+    // could silently swallow their writes if an id ever collided.
+    await enqueue({ kind: 'create', payload: { ...SPAN, ticketId: 'a' } });
+    await drain(async () => {
+      await clearQueueForSignOut();
+      failNextQueueRead = true;
+    });
+    expect(store.has(QUEUE_TOMBSTONE_KEY)).toBe(false);
+  });
+
+  it('keeps the queue for an INVOLUNTARY session loss — that is a token expiry, not a sign-out', async () => {
+    // A technician who worked offline all day and whose token expired must not
+    // lose the backlog: `clearQueueForSignOut` is only reached on a deliberate
+    // sign-out now, and ownership is what protects the next account.
+    await enqueue({ kind: 'create', payload: { ...SPAN, ticketId: 'k1' } });
+    await reconcileQueueOwner('user-a');
+    // The same technician signs back in after the token expiry.
+    const outcome = await reconcileQueueOwner('user-a');
+    expect(outcome).toBeNull();
+    await expect(readQueue()).resolves.toHaveLength(1);
+  });
+
+  it('parks and clears a queue owned by a DIFFERENT account at sign-in', async () => {
+    await enqueue({ kind: 'create', payload: { ...SPAN, ticketId: 'k1' } });
+    await reconcileQueueOwner('user-a');
+
+    const outcome = await reconcileQueueOwner('user-b');
+    expect(outcome).toMatchObject({ cleared: 1 });
+    await expect(readQueue()).resolves.toEqual([]);
+    expect((await readOrphanedQueues())[0].owner).toBe('user-a');
+    expect(store.get(QUEUE_OWNER_KEY)).toBe('user-b');
+  });
+
+  it('adopts an unowned queue rather than destroying it', async () => {
+    // A queue written before the owner stamp existed, or by this same account
+    // before the first reconcile. Deleting it would lose real work for no gain.
+    await enqueue({ kind: 'create', payload: { ...SPAN, ticketId: 'k1' } });
+    expect(await reconcileQueueOwner('user-a')).toBeNull();
+    await expect(readQueue()).resolves.toHaveLength(1);
+    expect(store.get(QUEUE_OWNER_KEY)).toBe('user-a');
+  });
+
+  it('a drain that started before an owner switch cannot restore the old queue', async () => {
+    await enqueue({ kind: 'create', payload: { ...SPAN, ticketId: 'a' } });
+    await enqueue({ kind: 'create', payload: { ...SPAN, ticketId: 'b' } });
+    await reconcileQueueOwner('user-a');
+
+    const result = await drain(async (write) => {
+      if (write.payload.ticketId === 'a') await reconcileQueueOwner('user-b');
+      if (write.payload.ticketId === 'b') throw new Error('offline');
+    });
+    expect(result.remaining).toBe(0);
+    await expect(readQueue()).resolves.toEqual([]);
   });
 });

--- a/apps/mobile/src/services/timeEntryQueue.ts
+++ b/apps/mobile/src/services/timeEntryQueue.ts
@@ -109,6 +109,20 @@ export class QueueStorageError extends Error {
   }
 }
 
+/**
+ * The unsent rows could not be copied aside, so they were NOT deleted.
+ *
+ * Distinct from QueueStorageError: nothing is lost, but the cross-account
+ * window stays open until `reconcileQueueOwner` closes it, and `clearAuthData`
+ * reports it as a partial wipe rather than a clean sign-out.
+ */
+export class QueueParkError extends Error {
+  constructor() {
+    super('unsent time entries could not be parked, so the queue was left in place');
+    this.name = 'QueueParkError';
+  }
+}
+
 let storageChain: Promise<void> = Promise.resolve();
 let drainChain: Promise<void> = Promise.resolve();
 
@@ -287,6 +301,193 @@ export async function enqueue(
   });
 }
 
+/**
+ * Where a queue that belonged to a previous session is parked instead of being
+ * deleted. An APPENDED list of batches: overwriting it would let a second
+ * sign-out destroy the first technician's only remaining copy.
+ */
+export const QUEUE_ORPHANED_KEY = 'breeze.timeEntryQueue.v2.orphaned';
+/** The user id whose session produced the rows currently in QUEUE_KEY. */
+export const QUEUE_OWNER_KEY = 'breeze.timeEntryQueue.v2.owner';
+
+/**
+ * Bumped whenever the queue is deliberately emptied. A drain that started
+ * before the bump holds a snapshot of the PREVIOUS account's rows; persisting
+ * it would write them straight back and re-open the leak the clear closed.
+ */
+let queueGeneration = 0;
+
+export interface OrphanedBatch {
+  parkedAt: string;
+  owner: string | null;
+  writes: QueuedWrite[];
+  needsAttention: NeedsAttentionRow[];
+}
+
+export async function readOrphanedQueues(): Promise<OrphanedBatch[]> {
+  let stored: string | null;
+  try {
+    stored = await AsyncStorage.getItem(QUEUE_ORPHANED_KEY);
+  } catch {
+    return [];
+  }
+  if (stored === null) return [];
+  try {
+    const parsed: unknown = JSON.parse(stored);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.map((value) => {
+      const batch = (typeof value === 'object' && value !== null ? value : {}) as Partial<OrphanedBatch>;
+      return {
+        parkedAt: typeof batch.parkedAt === 'string' ? batch.parkedAt : new Date(0).toISOString(),
+        owner: typeof batch.owner === 'string' ? batch.owner : null,
+        writes: (Array.isArray(batch.writes) ? batch.writes : [])
+          .map(asQueuedWrite)
+          .filter((write): write is QueuedWrite => write !== null),
+        needsAttention: (Array.isArray(batch.needsAttention) ? batch.needsAttention : [])
+          .map(asNeedsAttentionRow)
+          .filter((row): row is NeedsAttentionRow => row !== null),
+      };
+    });
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Empties the queue into the orphan park. Assumes the storage lock is held.
+ *
+ * Returns how many writes moved. THROWS if the park did not land: deleting the
+ * rows anyway is what turned "recoverable by hand" into a claim nobody could
+ * act on, and keeping them costs only the (already narrow) window until
+ * `reconcileQueueOwner` runs at the next sign-in.
+ */
+async function parkAndEmptyQueue(reason: string, owner: string | null): Promise<number> {
+  const storedQueue = await AsyncStorage.getItem(QUEUE_KEY);
+  const parsedQueue = ((): QueuedWrite[] => {
+    if (storedQueue === null) return [];
+    try {
+      const parsed: unknown = JSON.parse(storedQueue);
+      return Array.isArray(parsed)
+        ? parsed.map(asQueuedWrite).filter((write): write is QueuedWrite => write !== null)
+        : [];
+    } catch {
+      return [];
+    }
+  })();
+  const parkedAttention = await readNeedsAttentionUnlocked();
+  // The last act of this function is `setItem(QUEUE_NEEDS_ATTENTION_KEY, '[]')`.
+  // Rows that could not be READ were never copied into the orphan batch, so
+  // continuing would delete them — the same rule the park below follows: never
+  // destroy what could not be backed up first. A storage failure is transient,
+  // and the next sign-out or `reconcileQueueOwner` retries the whole park.
+  if (parkedAttention === null) {
+    Sentry.captureException(new Error(`unsent time entries orphaned at ${reason}`), {
+      tags: { area: 'time-entry-queue' },
+      extra: { reason, parked: false, parkError: 'needs-attention-unreadable' },
+    });
+    throw new QueueParkError();
+  }
+  const count = parsedQueue.length + parkedAttention.length;
+
+  // Nothing to preserve: emptying is unconditional and cannot fail.
+  if (count === 0) {
+    queueGeneration += 1;
+    await AsyncStorage.removeItem(QUEUE_KEY).catch(() => undefined);
+    await AsyncStorage.removeItem(QUEUE_TOMBSTONE_KEY).catch(() => undefined);
+    return 0;
+  }
+
+  let parked = true;
+  let parkError: string | undefined;
+  try {
+    const batches = await readOrphanedQueues();
+    batches.push({
+      parkedAt: new Date().toISOString(),
+      owner,
+      writes: parsedQueue,
+      needsAttention: parkedAttention,
+    });
+    await AsyncStorage.setItem(QUEUE_ORPHANED_KEY, JSON.stringify(batches));
+  } catch (error) {
+    parked = false;
+    parkError = error instanceof Error ? error.message : String(error);
+  }
+
+  Sentry.captureException(new Error(`unsent time entries orphaned at ${reason}`), {
+    tags: { area: 'time-entry-queue' },
+    extra: { reason, count, parked, ...(parkError === undefined ? {} : { parkError }) },
+  });
+
+  if (!parked) {
+    throw new QueueParkError();
+  }
+
+  // Only now is the deletion non-destructive.
+  queueGeneration += 1;
+  await AsyncStorage.removeItem(QUEUE_KEY);
+  await AsyncStorage.removeItem(QUEUE_TOMBSTONE_KEY);
+  await AsyncStorage.setItem(QUEUE_NEEDS_ATTENTION_KEY, '[]');
+  return count;
+}
+
+/**
+ * Teardown for a DELIBERATE sign-out only.
+ *
+ * QUEUE_KEY is a single, un-namespaced AsyncStorage key and a queued write
+ * carries no owner, while the replay sends with whatever bearer token the
+ * CURRENT session holds. Left in place across a sign-out on a shared field
+ * phone, technician A's unsent minutes are created under technician B.
+ *
+ * It must NOT run on an involuntary session loss — a 401 token expiry or a
+ * locked keychain also reach `clearAuthData`, and a technician who worked
+ * offline all day would lose the whole backlog on relaunch through no action of
+ * their own. `clearAuthData` therefore takes an explicit `deliberate` flag, and
+ * `reconcileQueueOwner` is what protects the next account on every other path.
+ */
+export async function clearQueueForSignOut(): Promise<{ cleared: number; parked: boolean }> {
+  return withStorageLock(async () => {
+    const owner = await AsyncStorage.getItem(QUEUE_OWNER_KEY).catch(() => null);
+    const cleared = await parkAndEmptyQueue('sign-out', owner);
+    await AsyncStorage.removeItem(QUEUE_OWNER_KEY).catch(() => undefined);
+    return { cleared, parked: true };
+  });
+}
+
+/**
+ * Claims the queue for `userId`, parking it first if it belonged to somebody
+ * else.
+ *
+ * This — not the sign-out hook — is what actually makes a cross-account replay
+ * impossible, because it fires on every path into a session: deliberate
+ * sign-in, a re-login after a token expiry, a reinstall. An UNOWNED queue is
+ * adopted rather than destroyed; a queue this account already owns is left
+ * exactly where it is, which is the whole point of keeping it across an
+ * involuntary session loss.
+ *
+ * Returns null when nothing was parked.
+ */
+export async function reconcileQueueOwner(userId: string): Promise<{ cleared: number } | null> {
+  return withStorageLock(async () => {
+    let owner: string | null = null;
+    try {
+      owner = await AsyncStorage.getItem(QUEUE_OWNER_KEY);
+    } catch {
+      // Unreadable ownership is not evidence of a different owner; adopting is
+      // the non-destructive direction and the next read re-establishes it.
+      return null;
+    }
+    if (owner === userId) return null;
+    if (owner === null) {
+      await AsyncStorage.setItem(QUEUE_OWNER_KEY, userId).catch(() => undefined);
+      return null;
+    }
+
+    const cleared = await parkAndEmptyQueue('account-switch', owner);
+    await AsyncStorage.setItem(QUEUE_OWNER_KEY, userId);
+    return { cleared };
+  });
+}
+
 // --- Needs attention ---------------------------------------------------------
 
 function asNeedsAttentionRow(value: unknown): NeedsAttentionRow | null {
@@ -439,6 +640,10 @@ function isPermanentRejection(error: unknown): boolean {
 }
 
 async function drainQueue(send: (write: QueuedWrite) => Promise<void>): Promise<DrainResult> {
+  // Captured before the first read. Anything that deliberately empties the
+  // queue bumps this, and the reconcile below refuses to write a snapshot taken
+  // under the previous owner back to storage.
+  const generation = queueGeneration;
   const priorTombstone = await readTombstone();
   const queue = await readQueue();
   const snapshotIds = new Set(queue.map((write) => write.id));
@@ -491,6 +696,10 @@ async function drainQueue(send: (write: QueuedWrite) => Promise<void>): Promise<
   let remainingQueue: QueuedWrite[];
   try {
     remainingQueue = await withStorageLock(async () => {
+      // The queue was deliberately emptied while this drain was in flight (a
+      // sign-out, or a different account signing in). Persisting the snapshot
+      // would hand the previous technician's unsent entries to the new session.
+      if (queueGeneration !== generation) return [];
       const currentQueue = await readQueue();
       const appendedWrites = currentQueue.filter((write) => !snapshotIds.has(write.id));
       const kept = [...queue.slice(nextIndex), ...appendedWrites];
@@ -505,8 +714,15 @@ async function drainQueue(send: (write: QueuedWrite) => Promise<void>): Promise<
     remainingQueue = queue.slice(nextIndex);
     // Under the lock: an enqueue that lands between the failure and this write
     // would otherwise clear the tombstone it never saw, and the sent writes
-    // would be replayed after all.
-    await withStorageLock(() => recordTombstone(priorTombstone, sentIds, parkedIds, error));
+    // would be replayed after all. A tombstone is NOT recorded across a
+    // deliberate clear: it names ids from a queue that no longer exists.
+    await withStorageLock(async () => {
+      if (queueGeneration !== generation) {
+        remainingQueue = [];
+        return;
+      }
+      await recordTombstone(priorTombstone, sentIds, parkedIds, error);
+    });
   }
 
   return {

--- a/apps/mobile/src/services/timeEntryReplay.test.ts
+++ b/apps/mobile/src/services/timeEntryReplay.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// `timeEntries` pulls in `../../services/api`, which imports @sentry/react-native
+// — Flow syntax Vitest's node environment cannot parse.
+vi.mock('./api', () => ({ coreRequest: vi.fn() }));
+// `timeEntryQueue` (for QUEUED_KINDS) imports @sentry/react-native, a Flow
+// source this .ts-only suite cannot parse.
+vi.mock('@sentry/react-native', () => ({ captureException: vi.fn(), captureMessage: vi.fn() }));
+
+import { makeReplaySender, UnreplayableWriteError, type ReplaySenders } from './timeEntryReplay';
+import { QUEUED_KINDS, type QueuedWrite } from './timeEntryQueue';
+
+const SERVER_NOW = Date.parse('2026-08-30T18:00:00.000Z');
+
+function write(overrides: Partial<QueuedWrite> & Pick<QueuedWrite, 'kind'>): QueuedWrite {
+  return {
+    id: 'w1',
+    payload: {},
+    queuedAt: '2026-08-30T09:00:00.000Z',
+    attempts: 0,
+    ...overrides,
+  };
+}
+
+function senders() {
+  return {
+    createTimeEntry: vi.fn().mockResolvedValue({ id: 'e1' }),
+    updateTimeEntry: vi.fn().mockResolvedValue({ id: 'e1' }),
+    serverNow: () => SERVER_NOW,
+  };
+}
+
+// A compile-time guard, not a runtime one: reintroducing either verb to
+// `ReplaySenders` makes this line a type error, which is the whole point of
+// removing them from the interface rather than merely not calling them.
+type TimerVerbsOnSenders = Extract<keyof ReplaySenders, 'startTimer' | 'stopTimer'>;
+const NO_TIMER_VERBS: TimerVerbsOnSenders extends never ? true : false = true;
+
+describe('the replay can never call a server-stamped timer verb', () => {
+  it('does not declare startTimer or stopTimer on ReplaySenders', () => {
+    expect(NO_TIMER_VERBS).toBe(true);
+  });
+
+  it('touches no sender other than the two timestamped endpoints, for EVERY queued kind', async () => {
+    // A Proxy records every property the sender reaches for, so this fails if a
+    // future edit calls `senders.startTimer?.()` defensively rather than only
+    // if the interface changes.
+    const touched = new Set<string>();
+    const startTimer = vi.fn();
+    const stopTimer = vi.fn();
+    const backing: Record<string, unknown> = {
+      createTimeEntry: vi.fn().mockResolvedValue({ id: 'e1' }),
+      updateTimeEntry: vi.fn().mockResolvedValue({ id: 'e1' }),
+      serverNow: () => SERVER_NOW,
+      startTimer,
+      stopTimer,
+    };
+    const recorder = new Proxy(backing, {
+      get(target, key) {
+        if (typeof key !== 'string') return undefined;
+        touched.add(key);
+        return target[key];
+      },
+    }) as unknown as ReplaySenders;
+
+    const send = makeReplaySender(recorder);
+    for (const kind of QUEUED_KINDS) {
+      await send(
+        write({
+          kind,
+          payload: {
+            id: 'E',
+            startedAt: '2026-08-30T09:00:00.000Z',
+            endedAt: '2026-08-30T09:40:00.000Z',
+          },
+        })
+      );
+    }
+
+    expect(startTimer).toHaveBeenCalledTimes(0);
+    expect(stopTimer).toHaveBeenCalledTimes(0);
+    expect([...touched].sort()).toEqual(['createTimeEntry', 'serverNow', 'updateTimeEntry']);
+  });
+});
+
+describe('makeReplaySender', () => {
+  it('posts a create with the stored bounds when they are already in the past', async () => {
+    const deps = senders();
+    await makeReplaySender(deps)(
+      write({
+        kind: 'create',
+        payload: {
+          startedAt: '2026-08-30T09:00:00.000Z',
+          endedAt: '2026-08-30T09:40:00.000Z',
+          ticketId: 'k1',
+          description: 'basement switch',
+          isBillable: true,
+        },
+      })
+    );
+    expect(deps.createTimeEntry).toHaveBeenCalledWith({
+      startedAt: '2026-08-30T09:00:00.000Z',
+      endedAt: '2026-08-30T09:40:00.000Z',
+      ticketId: 'k1',
+      description: 'basement switch',
+      isBillable: true,
+    });
+  });
+
+  it('shifts a future-dated span into the past and persists the shift on the write', async () => {
+    // The phone is 3h fast. Unshifted this is a permanent 400 (notFarFuture),
+    // and the drain would park the technician's real work for manual re-entry.
+    const deps = senders();
+    const queued = write({
+      kind: 'create',
+      payload: { startedAt: '2026-08-30T20:20:00.000Z', endedAt: '2026-08-30T21:00:00.000Z' },
+    });
+    await makeReplaySender(deps)(queued);
+
+    const sent = deps.createTimeEntry.mock.calls[0][0] as { startedAt: string; endedAt: string };
+    expect(Date.parse(sent.startedAt)).toBeLessThanOrEqual(SERVER_NOW);
+    expect(Date.parse(sent.endedAt) - Date.parse(sent.startedAt)).toBe(40 * 60_000);
+    // The rewrite has to reach storage, or a retry shifts an already-shifted
+    // span a second time.
+    expect(queued.payload).toMatchObject({ startedAt: sent.startedAt, endedAt: sent.endedAt });
+  });
+
+  it('closes a server-started entry by id at its true tap time', async () => {
+    const deps = senders();
+    await makeReplaySender(deps)(
+      write({
+        kind: 'closeEntry',
+        payload: { id: 'E', endedAt: '2026-08-30T15:00:00.000Z', isBillable: false },
+      })
+    );
+    // NOT the 18:00 replay time: `/time-entries/stop` would have stamped that.
+    expect(deps.updateTimeEntry).toHaveBeenCalledWith('E', {
+      endedAt: '2026-08-30T15:00:00.000Z',
+      isBillable: false,
+    });
+  });
+
+  it('does not shift a closeEntry — the row it closes carries the server\'s own startedAt', async () => {
+    const deps = senders();
+    await makeReplaySender(deps)(
+      write({ kind: 'closeEntry', payload: { id: 'E', endedAt: '2026-08-30T21:00:00.000Z' } })
+    );
+    expect(deps.updateTimeEntry).toHaveBeenCalledWith('E', { endedAt: '2026-08-30T21:00:00.000Z' });
+  });
+
+  it('propagates the server error untouched so drain can read its status', async () => {
+    const deps = senders();
+    const error = Object.assign(new Error('nope'), { status: 409 });
+    deps.createTimeEntry.mockRejectedValue(error);
+    await expect(
+      makeReplaySender(deps)(
+        write({
+          kind: 'create',
+          payload: { startedAt: '2026-08-30T09:00:00.000Z', endedAt: '2026-08-30T09:40:00.000Z' },
+        })
+      )
+    ).rejects.toBe(error);
+  });
+
+  it('rejects an unknown kind as a permanent 400 rather than wedging the queue', async () => {
+    const failure = await makeReplaySender(senders())(
+      write({ kind: 'somethingNew' as QueuedWrite['kind'] })
+    ).catch((error: unknown) => error);
+    expect(failure).toBeInstanceOf(UnreplayableWriteError);
+    expect((failure as UnreplayableWriteError).status).toBe(400);
+  });
+
+  it('rejects a create missing its time bounds as a permanent 400', async () => {
+    await expect(
+      makeReplaySender(senders())(write({ kind: 'create', payload: { ticketId: 'k1' } }))
+    ).rejects.toBeInstanceOf(UnreplayableWriteError);
+  });
+
+  it('rejects a closeEntry missing its entry id as a permanent 400', async () => {
+    await expect(
+      makeReplaySender(senders())(
+        write({ kind: 'closeEntry', payload: { endedAt: '2026-08-30T15:00:00.000Z' } })
+      )
+    ).rejects.toBeInstanceOf(UnreplayableWriteError);
+  });
+});

--- a/apps/mobile/src/services/timeEntryReplay.ts
+++ b/apps/mobile/src/services/timeEntryReplay.ts
@@ -1,0 +1,120 @@
+import type { CreateTimeEntryInput, TimeEntry, UpdateTimeEntryInput } from './timeEntries';
+import type { QueuedWrite } from './timeEntryQueue';
+import { shiftIntoPast } from './timeSpan';
+
+/**
+ * Turns a queued write back into the API call that made it.
+ *
+ * Pure module (no React, no direct transport) so the mapping is unit-testable:
+ * `drain` decides what to keep and what to park purely from the status on the
+ * error this sender throws, which makes the mapping a correctness surface, not
+ * glue.
+ *
+ * `startTimer` and `stopTimer` are deliberately ABSENT from `ReplaySenders`.
+ * Both are server-stamped verbs — the server writes `new Date()` for the bound
+ * they set — so replaying one rewrites when the work happened. Their absence
+ * from this interface is what makes that a compile error rather than a
+ * convention somebody re-reads and re-breaks.
+ */
+
+export interface ReplaySenders {
+  createTimeEntry: (input: CreateTimeEntryInput) => Promise<TimeEntry>;
+  updateTimeEntry: (id: string, input: UpdateTimeEntryInput) => Promise<TimeEntry>;
+  /** The server's clock (services/serverClock.ts), in ms. */
+  serverNow: () => number;
+}
+
+/**
+ * A queued row this build cannot send — an unknown `kind` from a newer app
+ * version, or a `create` with no time bounds.
+ *
+ * It carries status 400 deliberately: `drain` treats 400 as a verdict and
+ * PARKS the row in needs-attention, reporting it to the caller. The
+ * alternative — a bare throw with no status — is read as a transient failure
+ * and retried forever, wedging every entry queued behind it, which loses far
+ * more billable work than the one unsendable row.
+ */
+export class UnreplayableWriteError extends Error {
+  readonly status = 400;
+  readonly statusCode = 400;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'UnreplayableWriteError';
+  }
+}
+
+function optionalString(payload: Record<string, unknown>, key: string): string | undefined {
+  const value = payload[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function optionalBoolean(payload: Record<string, unknown>, key: string): boolean | undefined {
+  const value = payload[key];
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function compact<T extends object>(input: T): T {
+  return Object.fromEntries(Object.entries(input).filter(([, value]) => value !== undefined)) as T;
+}
+
+export function makeReplaySender(senders: ReplaySenders): (write: QueuedWrite) => Promise<void> {
+  return async (write: QueuedWrite): Promise<void> => {
+    switch (write.kind) {
+      case 'create': {
+        const storedStart = optionalString(write.payload, 'startedAt');
+        const storedEnd = optionalString(write.payload, 'endedAt');
+        if (storedStart === undefined || storedEnd === undefined) {
+          throw new UnreplayableWriteError('Queued time entry is missing its start or end time');
+        }
+
+        // A phone whose clock runs fast produces a span the server refuses as
+        // too far in the future, and that 400 is permanent. Shifting BOTH
+        // bounds keeps the duration exact while making the span sendable.
+        const shifted = shiftIntoPast(storedStart, storedEnd, senders.serverNow());
+        // Written back so a retry shifts an already-shifted span by zero rather
+        // than chasing a clock that moved again between attempts.
+        write.payload.startedAt = shifted.startedAt;
+        write.payload.endedAt = shifted.endedAt;
+
+        await senders.createTimeEntry(
+          compact({
+            startedAt: shifted.startedAt,
+            endedAt: shifted.endedAt,
+            ticketId: optionalString(write.payload, 'ticketId'),
+            description: optionalString(write.payload, 'description'),
+            isBillable: optionalBoolean(write.payload, 'isBillable'),
+          }) as CreateTimeEntryInput
+        );
+        return;
+      }
+
+      case 'closeEntry': {
+        const id = optionalString(write.payload, 'id');
+        const endedAt = optionalString(write.payload, 'endedAt');
+        if (id === undefined || endedAt === undefined) {
+          throw new UnreplayableWriteError('Queued timer stop is missing its entry id or end time');
+        }
+        // Deliberately NOT shifted: this closes a row the SERVER started, so
+        // its `startedAt` is already the server's own stamp and `endedAt`
+        // carries no notFarFuture refine. Re-applying the same PATCH is
+        // effect-idempotent, which is why an ambiguous transport failure here
+        // is recoverable where a retried `/stop` would 404.
+        await senders.updateTimeEntry(
+          id,
+          compact({
+            endedAt,
+            description: optionalString(write.payload, 'description'),
+            isBillable: optionalBoolean(write.payload, 'isBillable'),
+          })
+        );
+        return;
+      }
+
+      default:
+        throw new UnreplayableWriteError(
+          `Queued time entry has an unknown kind: ${String(write.kind)}`
+        );
+    }
+  };
+}

--- a/apps/mobile/src/services/timeSpan.test.ts
+++ b/apps/mobile/src/services/timeSpan.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+
+import { closeLocalSpan, shiftIntoPast } from './timeSpan';
+
+const EPOCH = 'launch-1';
+
+describe('closeLocalSpan', () => {
+  it('measures the span from the monotonic anchors when they are comparable', () => {
+    const span = closeLocalSpan(
+      { startedAtWall: '2026-08-30T09:00:00.000Z', startedAtMono: 1_000, monoEpochId: EPOCH },
+      { wallMs: Date.parse('2026-08-30T09:40:00.000Z'), monoMs: 1_000 + 40 * 60_000, monoEpochId: EPOCH }
+    );
+    expect(span).toEqual({
+      startedAt: '2026-08-30T09:00:00.000Z',
+      endedAt: '2026-08-30T09:40:00.000Z',
+      clockUnverified: false,
+    });
+  });
+
+  it('ignores a wall-clock jump mid-span when the monotonic epoch is intact', () => {
+    // The phone picked up a +3h correction while the technician was in a
+    // basement. Wall-to-wall this reads as 3h40m of billable work.
+    const span = closeLocalSpan(
+      { startedAtWall: '2026-08-30T09:00:00.000Z', startedAtMono: 1_000, monoEpochId: EPOCH },
+      {
+        wallMs: Date.parse('2026-08-30T12:40:00.000Z'),
+        monoMs: 1_000 + 40 * 60_000,
+        monoEpochId: EPOCH,
+      }
+    );
+    expect(span).toMatchObject({ endedAt: '2026-08-30T09:40:00.000Z', clockUnverified: false });
+  });
+
+  it('falls back to the wall clock across a relaunch and says the duration is unverified', () => {
+    const span = closeLocalSpan(
+      { startedAtWall: '2026-08-30T09:00:00.000Z', startedAtMono: 1_000, monoEpochId: 'launch-1' },
+      { wallMs: Date.parse('2026-08-30T09:40:00.000Z'), monoMs: 5, monoEpochId: 'launch-2' }
+    );
+    expect(span).toEqual({
+      startedAt: '2026-08-30T09:00:00.000Z',
+      endedAt: '2026-08-30T09:40:00.000Z',
+      clockUnverified: true,
+    });
+  });
+
+  it('refuses to invent a span when the clock ran backwards', () => {
+    expect(
+      closeLocalSpan(
+        { startedAtWall: '2026-08-30T09:00:00.000Z', startedAtMono: null, monoEpochId: null },
+        { wallMs: Date.parse('2026-08-30T08:00:00.000Z'), monoMs: null, monoEpochId: null }
+      )
+    ).toEqual({ unusable: 'clock-went-backwards' });
+  });
+
+  it('floors a mis-tap to one second so endedAt > startedAt still holds', () => {
+    // Not a clock error — a double tap. The server rejects endedAt <= startedAt
+    // outright, and 1s invoices as 0 minutes, which is the honest answer.
+    const span = closeLocalSpan(
+      { startedAtWall: '2026-08-30T09:00:00.000Z', startedAtMono: 10, monoEpochId: EPOCH },
+      { wallMs: Date.parse('2026-08-30T09:00:00.100Z'), monoMs: 110, monoEpochId: EPOCH }
+    );
+    expect(span).toMatchObject({
+      startedAt: '2026-08-30T09:00:00.000Z',
+      endedAt: '2026-08-30T09:00:01.000Z',
+    });
+  });
+});
+
+describe('shiftIntoPast', () => {
+  const serverNow = Date.parse('2026-08-30T09:00:00.000Z');
+
+  it('leaves a span that already ended in the past alone', () => {
+    expect(shiftIntoPast('2026-08-30T08:00:00.000Z', '2026-08-30T08:40:00.000Z', serverNow)).toEqual({
+      startedAt: '2026-08-30T08:00:00.000Z',
+      endedAt: '2026-08-30T08:40:00.000Z',
+    });
+  });
+
+  it('translates BOTH bounds when the device clock is ahead of the server', () => {
+    // A phone three hours fast. `createTimeEntrySchema` refines startedAt with
+    // notFarFuture (5 minutes), so an unshifted span is a permanent 400.
+    const shifted = shiftIntoPast('2026-08-30T11:20:00.000Z', '2026-08-30T12:00:00.000Z', serverNow);
+    expect(shifted).toEqual({
+      startedAt: '2026-08-30T08:20:00.000Z',
+      endedAt: '2026-08-30T09:00:00.000Z',
+    });
+    expect(Date.parse(shifted.startedAt)).toBeLessThanOrEqual(serverNow);
+  });
+
+  it('is duration-invariant for arbitrary inputs', () => {
+    // The whole point: the technician's minutes must survive the correction.
+    const cases: Array<[string, string, number]> = [
+      ['2026-08-30T11:20:00.000Z', '2026-08-30T12:00:00.000Z', serverNow],
+      ['2026-01-01T00:00:00.000Z', '2026-01-01T00:00:01.000Z', Date.parse('2025-12-31T00:00:00Z')],
+      ['2026-08-30T08:00:00.000Z', '2026-08-30T08:40:00.000Z', serverNow],
+      ['2026-08-30T09:00:00.000Z', '2026-08-30T17:30:00.000Z', Date.parse('2026-08-30T09:00:00Z')],
+    ];
+    for (const [start, end, now] of cases) {
+      const shifted = shiftIntoPast(start, end, now);
+      expect(Date.parse(shifted.endedAt) - Date.parse(shifted.startedAt)).toBe(
+        Date.parse(end) - Date.parse(start)
+      );
+    }
+  });
+});

--- a/apps/mobile/src/services/timeSpan.ts
+++ b/apps/mobile/src/services/timeSpan.ts
@@ -1,0 +1,105 @@
+/**
+ * Turns a locally-ticking timer into a closed span with explicit bounds.
+ *
+ * This is where the money logic lives, so it is pure: no storage, no network,
+ * no React. Every offline minute a technician bills passes through
+ * `closeLocalSpan`, and every span that could be rejected for being in the
+ * future passes through `shiftIntoPast`.
+ *
+ * Why a monotonic anchor at all: `Date.now()` on a phone is not monotonic. NTP
+ * corrections, a manual clock change and a timezone-driven jump all move it,
+ * and a shift that moved the wall clock forward three hours mid-job would bill
+ * three extra hours if the duration were measured wall-to-wall.
+ * `performance.now()` is immune to that but resets on every JS launch, so it is
+ * only comparable within one `monoEpochId`.
+ */
+
+export interface SpanTimer {
+  /** Wall-clock ISO of the tap that started the timer. */
+  startedAtWall: string;
+  /** `performance.now()` at that tap, or null if unavailable. */
+  startedAtMono: number | null;
+  /** The JS-launch epoch the mono anchor belongs to. */
+  monoEpochId: string | null;
+}
+
+export interface SpanStop {
+  wallMs: number;
+  monoMs: number | null;
+  monoEpochId: string | null;
+}
+
+export interface ClosedSpan {
+  startedAt: string;
+  endedAt: string;
+  /**
+   * True when the duration had to fall back to the wall clock, because the app
+   * was relaunched mid-timer (or the platform has no `performance.now()`). The
+   * span is still the best available answer; the flag is what lets the UI say
+   * so rather than presenting a possibly-shifted duration as fact.
+   */
+  clockUnverified: boolean;
+}
+
+export type SpanResult = ClosedSpan | { unusable: 'clock-went-backwards' };
+
+/**
+ * A tap-tap on the same second is a mis-tap, not a clock error. The server
+ * requires `endedAt > startedAt`, so the span is floored to one second — which
+ * invoices as 0 minutes, the honest answer.
+ */
+const MIN_SPAN_MS = 1000;
+
+export function closeLocalSpan(timer: SpanTimer, stop: SpanStop): SpanResult {
+  const startWallMs = Date.parse(timer.startedAtWall);
+  if (Number.isNaN(startWallMs)) return { unusable: 'clock-went-backwards' };
+
+  const monoComparable =
+    timer.monoEpochId !== null &&
+    stop.monoEpochId !== null &&
+    timer.monoEpochId === stop.monoEpochId &&
+    timer.startedAtMono !== null &&
+    stop.monoMs !== null;
+
+  const durationMs = monoComparable
+    ? (stop.monoMs as number) - (timer.startedAtMono as number)
+    : stop.wallMs - startWallMs;
+
+  // Only a clock that ran backwards can produce this. Inventing a duration
+  // would be inventing a bill, so the caller parks it for manual entry.
+  if (durationMs <= 0) return { unusable: 'clock-went-backwards' };
+
+  const spanMs = Math.max(durationMs, MIN_SPAN_MS);
+  return {
+    startedAt: new Date(startWallMs).toISOString(),
+    endedAt: new Date(startWallMs + spanMs).toISOString(),
+    clockUnverified: !monoComparable,
+  };
+}
+
+/**
+ * Translates a span that ends after the server's clock back into the past.
+ *
+ * `createTimeEntrySchema.startedAt` is refined `notFarFuture` with 5 minutes of
+ * tolerance, and the drain treats the resulting 400 as permanent — so a phone
+ * running three hours fast would have every offline entry parked for manual
+ * re-entry. BOTH bounds move by the same amount: clamping one alone would
+ * silently rewrite the duration, which is the exact class of bug this whole
+ * design exists to make unrepresentable.
+ */
+export function shiftIntoPast(
+  startedAt: string,
+  endedAt: string,
+  serverNowMs: number
+): { startedAt: string; endedAt: string } {
+  const startMs = Date.parse(startedAt);
+  const endMs = Date.parse(endedAt);
+  if (Number.isNaN(startMs) || Number.isNaN(endMs)) return { startedAt, endedAt };
+  if (!Number.isFinite(serverNowMs) || endMs <= serverNowMs) return { startedAt, endedAt };
+
+  const delta = endMs - serverNowMs;
+  return {
+    startedAt: new Date(startMs - delta).toISOString(),
+    endedAt: new Date(endMs - delta).toISOString(),
+  };
+}

--- a/apps/mobile/src/services/timerReconcile.test.ts
+++ b/apps/mobile/src/services/timerReconcile.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('./api', () => ({ coreRequest: vi.fn() }));
+vi.mock('@sentry/react-native', () => ({ captureException: vi.fn(), captureMessage: vi.fn() }));
+
+import {
+  findDeliveredDuplicate,
+  matchesServerTimer,
+  needsReconciliation,
+  planReconciliation,
+} from './timerReconcile';
+import type { LocalTimer } from './localTimer';
+import type { RunningTimer, TimeEntry } from './timeEntries';
+import type { QueuedWrite } from './timeEntryQueue';
+
+const server: RunningTimer = {
+  id: 'E',
+  localId: null,
+  ticketId: 'k1',
+  startedAt: '2026-08-30T09:00:04.000Z',
+  description: null,
+};
+
+function local(overrides: Partial<LocalTimer> = {}): LocalTimer {
+  return {
+    localId: 'l1',
+    ticketId: 'k1',
+    serverEntryId: null,
+    startedAtWall: '2026-08-30T09:00:00.000Z',
+    startedAtMono: 0,
+    monoEpochId: 'launch-1',
+    startConfirmed: false,
+    description: null,
+    ...overrides,
+  };
+}
+
+function createWrite(overrides: Partial<QueuedWrite> = {}): QueuedWrite {
+  return {
+    id: 'w1',
+    kind: 'create',
+    payload: {
+      ticketId: 'k1',
+      startedAt: '2026-08-30T09:00:00.000Z',
+      endedAt: '2026-08-30T09:40:00.000Z',
+      unconfirmedStart: true,
+    },
+    queuedAt: '2026-08-30T09:40:00.000Z',
+    attempts: 0,
+    ...overrides,
+  };
+}
+
+describe('matchesServerTimer', () => {
+  it('matches on ticket and a start within ten minutes', () => {
+    expect(matchesServerTimer({ ticketId: 'k1', startedAtMs: Date.parse('2026-08-30T09:00:00Z') }, server)).toBe(true);
+  });
+
+  it('rejects a different ticket even at the same instant', () => {
+    expect(matchesServerTimer({ ticketId: 'k2', startedAtMs: Date.parse(server.startedAt) }, server)).toBe(false);
+  });
+
+  it('rejects a start outside the window — that is somebody else\'s timer', () => {
+    expect(matchesServerTimer({ ticketId: 'k1', startedAtMs: Date.parse('2026-08-30T08:30:00Z') }, server)).toBe(false);
+  });
+});
+
+describe('needsReconciliation', () => {
+  it('is true for a local timer whose start was never confirmed', () => {
+    expect(needsReconciliation(local(), [])).toBe(true);
+  });
+
+  it('is false for a confirmed local timer with nothing unconfirmed queued', () => {
+    expect(needsReconciliation(local({ startConfirmed: true }), [createWrite({ payload: {} })])).toBe(false);
+  });
+
+  it('is true for a queued create carrying unconfirmedStart', () => {
+    expect(needsReconciliation(null, [createWrite()])).toBe(true);
+  });
+});
+
+describe('planReconciliation', () => {
+  it('adopts the server identity for a local timer whose start actually landed', () => {
+    expect(planReconciliation({ localTimer: local(), queue: [], server })).toEqual({
+      adopt: { serverEntryId: 'E', startedAt: '2026-08-30T09:00:04.000Z' },
+      substitute: null,
+    });
+  });
+
+  it('closes the phantom instead of creating a second entry', () => {
+    // The start DID land; the create would double-bill the job and leave the
+    // server entry running forever.
+    expect(planReconciliation({ localTimer: null, queue: [createWrite()], server })).toEqual({
+      adopt: null,
+      substitute: {
+        writeId: 'w1',
+        entryId: 'E',
+        endedAt: '2026-08-30T09:40:00.000Z',
+      },
+    });
+  });
+
+  it('carries the queued description and billable flag onto the close', () => {
+    const write = createWrite({
+      payload: {
+        ticketId: 'k1',
+        startedAt: '2026-08-30T09:00:00.000Z',
+        endedAt: '2026-08-30T09:40:00.000Z',
+        unconfirmedStart: true,
+        description: 'basement switch',
+        isBillable: false,
+      },
+    });
+    expect(planReconciliation({ localTimer: null, queue: [write], server }).substitute).toMatchObject({
+      description: 'basement switch',
+      isBillable: false,
+    });
+  });
+
+  it('leaves a non-matching server timer alone and sends the create unchanged', () => {
+    const other: RunningTimer = { ...server, ticketId: 'k9' };
+    expect(planReconciliation({ localTimer: null, queue: [createWrite()], server: other })).toEqual({
+      adopt: null,
+      substitute: null,
+    });
+  });
+
+  it('ignores a queued create that is NOT flagged unconfirmed', () => {
+    const write = createWrite({
+      payload: {
+        ticketId: 'k1',
+        startedAt: '2026-08-30T09:00:00.000Z',
+        endedAt: '2026-08-30T09:40:00.000Z',
+      },
+    });
+    expect(planReconciliation({ localTimer: null, queue: [write], server }).substitute).toBeNull();
+  });
+
+  it('plans nothing when no timer is running on the server', () => {
+    expect(planReconciliation({ localTimer: local(), queue: [createWrite()], server: null })).toEqual({
+      adopt: null,
+      substitute: null,
+    });
+  });
+});
+
+describe('findDeliveredDuplicate', () => {
+  const entry = (overrides: Partial<TimeEntry> = {}): TimeEntry => ({
+    id: 'e1',
+    ticketId: 'k1',
+    startedAt: '2026-08-30T09:00:00.000Z',
+    endedAt: '2026-08-30T09:40:00.000Z',
+    durationMinutes: 40,
+    isBillable: true,
+    billingStatus: 'not_billed',
+    isApproved: false,
+    description: null,
+    ...overrides,
+  });
+
+  const candidate = {
+    ticketId: 'k1',
+    startedAt: '2026-08-30T09:00:30.000Z',
+    endedAt: '2026-08-30T09:40:20.000Z',
+  };
+
+  it('recognises an entry the lost response already created', () => {
+    expect(findDeliveredDuplicate([entry()], candidate)?.id).toBe('e1');
+  });
+
+  it('does not treat a different ticket as the same work', () => {
+    expect(findDeliveredDuplicate([entry({ ticketId: 'k2' })], candidate)).toBeNull();
+  });
+
+  it('does not treat a neighbouring job on the same ticket as a duplicate', () => {
+    expect(
+      findDeliveredDuplicate(
+        [entry({ startedAt: '2026-08-30T11:00:00.000Z', endedAt: '2026-08-30T11:40:00.000Z' })],
+        candidate
+      )
+    ).toBeNull();
+  });
+
+  it('ignores a still-running entry, which has no end to compare', () => {
+    expect(findDeliveredDuplicate([entry({ endedAt: null })], candidate)).toBeNull();
+  });
+});

--- a/apps/mobile/src/services/timerReconcile.ts
+++ b/apps/mobile/src/services/timerReconcile.ts
@@ -1,0 +1,202 @@
+import type { LocalTimer } from './localTimer';
+import type { RunningTimer, TimeEntry, UpdateTimeEntryInput } from './timeEntries';
+import type { QueuedWrite } from './timeEntryQueue';
+
+/**
+ * Resolves what the server actually has against what this device believes.
+ *
+ * Two situations need it, both created by an ambiguous transport failure:
+ *
+ *  - a start request whose response never arrived, so a server entry MAY exist
+ *    for a timer this device is still ticking locally;
+ *  - the queued `create` that such a timer became when it was stopped, which
+ *    would post a SECOND entry for the same work.
+ *
+ * Both are resolved by one `GET /time-entries/running` and matching on
+ * (ticketId, startedAt). Pure module: no storage, no transport.
+ */
+
+/** The server stamps its own startedAt, so the two clocks are never identical. */
+const MATCH_WINDOW_MS = 10 * 60_000;
+/** Bounds within this of an existing entry mean the write already landed. */
+const DUPLICATE_WINDOW_MS = 60_000;
+
+export interface TimerCandidate {
+  ticketId: string | null;
+  startedAtMs: number;
+}
+
+export function matchesServerTimer(candidate: TimerCandidate, server: RunningTimer): boolean {
+  if ((server.ticketId ?? null) !== candidate.ticketId) return false;
+  const serverStartMs = Date.parse(server.startedAt);
+  if (Number.isNaN(serverStartMs) || Number.isNaN(candidate.startedAtMs)) return false;
+  return Math.abs(serverStartMs - candidate.startedAtMs) <= MATCH_WINDOW_MS;
+}
+
+export interface CloseSubstitution {
+  /** The queued `create` this replaces. */
+  writeId: string;
+  entryId: string;
+  endedAt: string;
+  description?: string;
+  isBillable?: boolean;
+}
+
+export interface ReconcilePlan {
+  /** Adopt the local timer under the server's identity, or null. */
+  adopt: { serverEntryId: string; startedAt: string } | null;
+  /** Send this `closeEntry` instead of the named queued `create`, or null. */
+  substitute: CloseSubstitution | null;
+}
+
+const NO_PLAN: ReconcilePlan = { adopt: null, substitute: null };
+
+/** True when something on this device might be shadowing a real server timer. */
+export function needsReconciliation(
+  localTimer: LocalTimer | null,
+  queue: readonly QueuedWrite[]
+): boolean {
+  if (localTimer !== null && localTimer.serverEntryId === null && !localTimer.startConfirmed) {
+    return true;
+  }
+  return queue.some((write) => write.kind === 'create' && write.payload.unconfirmedStart === true);
+}
+
+export function planReconciliation(input: {
+  localTimer: LocalTimer | null;
+  queue: readonly QueuedWrite[];
+  server: RunningTimer | null;
+}): ReconcilePlan {
+  const { localTimer, queue, server } = input;
+  if (server === null || server.id === null) return NO_PLAN;
+
+  if (
+    localTimer !== null &&
+    localTimer.serverEntryId === null &&
+    !localTimer.startConfirmed &&
+    matchesServerTimer(
+      { ticketId: localTimer.ticketId, startedAtMs: Date.parse(localTimer.startedAtWall) },
+      server
+    )
+  ) {
+    // The start DID land. The server's stamp is authoritative from here on.
+    return { adopt: { serverEntryId: server.id, startedAt: server.startedAt }, substitute: null };
+  }
+
+  for (const write of queue) {
+    if (write.kind !== 'create' || write.payload.unconfirmedStart !== true) continue;
+    const startedAt = write.payload.startedAt;
+    const endedAt = write.payload.endedAt;
+    if (typeof startedAt !== 'string' || typeof endedAt !== 'string') continue;
+    const ticketId = typeof write.payload.ticketId === 'string' ? write.payload.ticketId : null;
+    if (!matchesServerTimer({ ticketId, startedAtMs: Date.parse(startedAt) }, server)) continue;
+
+    // The start landed after all, so the server already holds an OPEN row for
+    // this work. Creating a second entry would double-bill it and leave the
+    // first running forever; closing the one that exists records the true end
+    // and clears the phantom in a single call.
+    return {
+      adopt: null,
+      substitute: {
+        writeId: write.id,
+        entryId: server.id,
+        endedAt,
+        ...(typeof write.payload.description === 'string'
+          ? { description: write.payload.description }
+          : {}),
+        ...(typeof write.payload.isBillable === 'boolean'
+          ? { isBillable: write.payload.isBillable }
+          : {}),
+      },
+    };
+  }
+
+  return NO_PLAN;
+}
+
+/**
+ * Whether this week's timesheet already contains the entry a retried `create`
+ * would post.
+ *
+ * A create whose response was lost may already be on the server. Best effort by
+ * design: the caller sends when this cannot be answered, because a duplicate is
+ * correctable from the timesheet while a lost entry is unbilled work.
+ */
+export function findDeliveredDuplicate(
+  entries: readonly TimeEntry[],
+  candidate: { ticketId: string | null; startedAt: string; endedAt: string }
+): TimeEntry | null {
+  const startMs = Date.parse(candidate.startedAt);
+  const endMs = Date.parse(candidate.endedAt);
+  if (Number.isNaN(startMs) || Number.isNaN(endMs)) return null;
+
+  for (const entry of entries) {
+    if ((entry.ticketId ?? null) !== candidate.ticketId) continue;
+    if (entry.endedAt === null) continue;
+    const entryStart = Date.parse(entry.startedAt);
+    const entryEnd = Date.parse(entry.endedAt);
+    if (Number.isNaN(entryStart) || Number.isNaN(entryEnd)) continue;
+    if (
+      Math.abs(entryStart - startMs) <= DUPLICATE_WINDOW_MS &&
+      Math.abs(entryEnd - endMs) <= DUPLICATE_WINDOW_MS
+    ) {
+      return entry;
+    }
+  }
+  return null;
+}
+
+export interface ReconciledSenderDeps {
+  /** The ordinary replay sender (services/timeEntryReplay.ts). */
+  base: (write: QueuedWrite) => Promise<void>;
+  plan: ReconcilePlan;
+  updateTimeEntry: (id: string, input: UpdateTimeEntryInput) => Promise<unknown>;
+  /**
+   * Entries the server already holds for the week containing this write, or
+   * null when that could not be established. Only consulted for a RETRIED
+   * create, so the ordinary drain costs no extra request.
+   */
+  lookupWeekEntries: (write: QueuedWrite) => Promise<readonly TimeEntry[] | null>;
+}
+
+/**
+ * Wraps the replay sender with everything that depends on what the server
+ * already has. Kept here, and pure, because both branches decide whether a
+ * customer gets billed twice — that is not glue.
+ */
+export function makeReconciledSender(
+  deps: ReconciledSenderDeps
+): (write: QueuedWrite) => Promise<void> {
+  return async (write: QueuedWrite): Promise<void> => {
+    const substitute = deps.plan.substitute;
+    if (substitute !== null && substitute.writeId === write.id) {
+      // The start landed after all, so the server already holds an OPEN row for
+      // this work. Closing it records the true end AND clears the phantom;
+      // posting the create would double-bill the job and leave the phantom
+      // running forever.
+      await deps.updateTimeEntry(substitute.entryId, {
+        endedAt: substitute.endedAt,
+        ...(substitute.description === undefined ? {} : { description: substitute.description }),
+        ...(substitute.isBillable === undefined ? {} : { isBillable: substitute.isBillable }),
+      });
+      return;
+    }
+
+    if (write.kind === 'create' && write.attempts > 0) {
+      const startedAt = write.payload.startedAt;
+      const endedAt = write.payload.endedAt;
+      if (typeof startedAt === 'string' && typeof endedAt === 'string') {
+        // Best effort by design: when the week cannot be read we SEND, because
+        // a duplicate is correctable from the timesheet while a lost entry is
+        // simply unbilled work.
+        const entries = await deps.lookupWeekEntries(write).catch(() => null);
+        if (entries !== null) {
+          const ticketId = typeof write.payload.ticketId === 'string' ? write.payload.ticketId : null;
+          if (findDeliveredDuplicate(entries, { ticketId, startedAt, endedAt }) !== null) return;
+        }
+      }
+    }
+
+    await deps.base(write);
+  };
+}

--- a/apps/mobile/src/store/authSlice.test.ts
+++ b/apps/mobile/src/store/authSlice.test.ts
@@ -359,8 +359,8 @@ describe('approver registration status', () => {
   // would also blank the slice, but that safety net lives in another module:
   // asserting it here keeps the guarantee true of authSlice on its own.
   it.each([
-    ['fulfilled', () => logoutAsync.fulfilled(undefined, 'req-id')],
-    ['rejected', () => logoutAsync.rejected(null, 'req-id')],
+    ['fulfilled', () => logoutAsync.fulfilled(undefined, 'req-id', { deliberate: true })],
+    ['rejected', () => logoutAsync.rejected(null, 'req-id', { deliberate: true })],
   ])('clears on logoutAsync.%s — the next user must not inherit the banner or grant', (_name, action) => {
     const store = makeStore();
     store.dispatch(setApproverRegistration({ status: 'failed', reason: 'http_400' }));

--- a/apps/mobile/src/store/authSlice.ts
+++ b/apps/mobile/src/store/authSlice.ts
@@ -114,10 +114,20 @@ export const verifyMfaAsync = createAsyncThunk(
   }
 );
 
+/**
+ * `deliberate: true` ONLY when the technician chose to sign out. An automatic
+ * invalidation (a blocked device, a revoked session) must leave the unsent
+ * time-entry queue in place — see services/auth.ts.
+ */
 export const logoutAsync = createAsyncThunk(
   'auth/logout',
-  async (_, { rejectWithValue, getState }) => {
-    const invalidation = beginSessionInvalidation();
+  async (
+    options: Readonly<{ deliberate?: boolean }> | undefined,
+    { rejectWithValue, getState }
+  ) => {
+    const invalidation = beginSessionInvalidation({
+      deliberate: options?.deliberate === true,
+    });
     const bearerToken = (getState() as { auth: AuthState }).auth.token;
     // Best-effort server logout; we tear down local state regardless of its
     // outcome so the user always leaves the authenticated surface.
@@ -312,6 +322,11 @@ export const logout = Object.assign(
   (): ReturnType<typeof reduceLogout> => {
     // Action creation is synchronous, so request/write fencing happens before
     // Redux publishes the signed-out state to the UI.
+    //
+    // Always INVOLUNTARY: every call site is an automatic invalidation (a
+    // 401/403 on cold-start revalidation, an unreadable keychain, a missing
+    // token). The unsent time-entry queue therefore survives; `logoutAsync({
+    // deliberate: true })` is what the user-facing Sign out buttons dispatch.
     const { cleanup } = beginSessionInvalidation();
     void cleanup.catch(() => undefined); // clearAuthData already reports failures
     return reduceLogout();

--- a/apps/mobile/src/store/index.ts
+++ b/apps/mobile/src/store/index.ts
@@ -6,8 +6,10 @@ import alertsReducer from './alertsSlice';
 import approvalsReducer from './approvalsSlice';
 import aiChatReducer from './aiChatSlice';
 import ticketsReducer from './ticketsSlice';
+import timeReducer from './timeSlice';
 import lifecycleReducer from './lifecycleSlice';
 import { withLogoutReset } from './resettable';
+import { loadServerClock } from '../services/serverClock';
 
 const appReducer = combineReducers({
   auth: authReducer,
@@ -15,6 +17,7 @@ const appReducer = combineReducers({
   approvals: approvalsReducer,
   aiChat: aiChatReducer,
   tickets: ticketsReducer,
+  time: timeReducer,
   lifecycle: lifecycleReducer,
 });
 
@@ -32,6 +35,12 @@ export const store = configureStore({
       },
     }),
 });
+
+// Hydrate the server-clock anchor persisted by a previous launch, so the first
+// offline time entry of a session is already corrected for a device clock that
+// drifted (services/serverClock.ts). Fire-and-forget: it never throws, and an
+// un-hydrated anchor only means the first API response re-establishes it.
+void loadServerClock();
 
 // Infer the `RootState` and `AppDispatch` types from the store itself
 export type RootState = ReturnType<typeof store.getState>;
@@ -84,3 +93,14 @@ export {
   selectTicketAssignee,
   selectTicketTotal,
 } from './ticketsSlice';
+
+export {
+  runningTimerAdopted,
+  startedTimer,
+  stoppedTimer,
+  pendingWritesChanged,
+  needsAttentionChanged,
+  timeErrorRaised,
+  timeAccessDenied,
+  elapsedSeconds,
+} from './timeSlice';

--- a/apps/mobile/src/store/timeSlice.test.ts
+++ b/apps/mobile/src/store/timeSlice.test.ts
@@ -1,8 +1,15 @@
 import { describe, it, expect } from 'vitest';
-import {
+import timeReducer, {
   elapsedSeconds,
   initialTimeState,
+  pendingWritesChanged,
+  needsAttentionChanged,
   queueDepthChanged,
+  runningTimerAdopted,
+  startedTimer,
+  stoppedTimer,
+  timeAccessDenied,
+  timeErrorRaised,
   timerErrored,
   timerStarted,
   timerStopped,
@@ -14,38 +21,52 @@ const ENTRY = {
   durationMinutes: null, isBillable: true, billingStatus: 'not_billed' as const, isApproved: false, description: null,
 };
 
+const RUNNING = {
+  id: 'e9', localId: null, ticketId: 'k9', startedAt: '2026-08-23T09:00:00Z', description: 'onsite',
+};
+
+/** A timer that exists only on this device, started while offline. */
+const LOCAL_RUNNING = {
+  id: null, localId: 'l1', ticketId: 'k9', startedAt: '2026-08-30T09:00:00.000Z', description: null,
+};
+
 describe('elapsedSeconds', () => {
   it('is zero when nothing is running', () => {
     expect(elapsedSeconds(null, new Date('2026-08-23T10:00:00Z'))).toBe(0);
   });
 
   it('counts from startedAt', () => {
-    const running = { id: 't1', ticketId: null, startedAt: '2026-08-23T10:00:00Z', description: null };
+    const running = { id: 't1', localId: null, ticketId: null, startedAt: '2026-08-23T10:00:00Z', description: null };
     expect(elapsedSeconds(running, new Date('2026-08-23T10:02:30Z'))).toBe(150);
   });
 
   it('clamps a future startedAt to zero rather than showing a negative timer', () => {
     // Phone clocks drift; the server accepts up to 5 minutes of skew, so a
     // startedAt slightly ahead of local time is normal, not corrupt.
-    const running = { id: 't1', ticketId: null, startedAt: '2026-08-23T10:05:00Z', description: null };
+    const running = { id: 't1', localId: null, ticketId: null, startedAt: '2026-08-23T10:05:00Z', description: null };
     expect(elapsedSeconds(running, new Date('2026-08-23T10:00:00Z'))).toBe(0);
   });
 
   it('treats an unparseable startedAt as zero instead of NaN', () => {
-    const running = { id: 't1', ticketId: null, startedAt: 'not-a-date', description: null };
+    const running = { id: 't1', localId: null, ticketId: null, startedAt: 'not-a-date', description: null };
     expect(elapsedSeconds(running, new Date('2026-08-23T10:00:00Z'))).toBe(0);
   });
 });
 
 describe('reducers', () => {
   it('starts from an empty state', () => {
-    expect(initialTimeState).toEqual({ running: null, pendingCount: 0, lastError: null });
+    expect(initialTimeState).toEqual({
+      running: null,
+      pendingCount: 0,
+      needsAttentionCount: 0,
+      lastError: null,
+    });
   });
 
   it('records the running timer on start and clears a stale error', () => {
     const errored: TimeState = { ...initialTimeState, lastError: 'boom' };
     const next = timerStarted(errored, ENTRY);
-    expect(next.running).toEqual({ id: 'e1', ticketId: 'k1', startedAt: '2026-08-23T10:00:00Z', description: null });
+    expect(next.running).toEqual({ id: 'e1', localId: null, ticketId: 'k1', startedAt: '2026-08-23T10:00:00Z', description: null });
     expect(next.lastError).toBeNull();
     expect(next).not.toBe(errored);
     expect(errored.running).toBeNull();
@@ -68,5 +89,72 @@ describe('reducers', () => {
     const next = timerErrored(started, 'A timer is already running');
     expect(next.lastError).toBe('A timer is already running');
     expect(next.running).toEqual(started.running);
+  });
+});
+
+describe('time reducer (redux binding)', () => {
+  it('starts from the pure initial state with no recorded denial', () => {
+    const state = timeReducer(undefined, { type: '@@INIT' });
+    expect(state).toEqual({ ...initialTimeState, denial: null });
+  });
+
+  it('adopts a timer the server reports as already running', () => {
+    // Cold start and reinstall both land here: the phone has no local timer but
+    // the user may have started one from the web dashboard.
+    const state = timeReducer(undefined, runningTimerAdopted(RUNNING));
+    expect(state.running).toEqual(RUNNING);
+  });
+
+  it('holds a device-only timer, which is what lets the bar tick offline', () => {
+    const state = timeReducer(undefined, runningTimerAdopted(LOCAL_RUNNING));
+    expect(state.running).toEqual(LOCAL_RUNNING);
+    expect(state.running?.id).toBeNull();
+    expect(elapsedSeconds(state.running, new Date('2026-08-30T09:40:00.000Z'))).toBe(2400);
+  });
+
+  it('clears a stale local timer when the server reports none running', () => {
+    const started = timeReducer(undefined, startedTimer(ENTRY));
+    expect(timeReducer(started, runningTimerAdopted(null)).running).toBeNull();
+  });
+
+  it('records and clears the running timer through the pure reducers', () => {
+    const started = timeReducer(undefined, startedTimer(ENTRY));
+    expect(started.running).toMatchObject({ id: 'e1', ticketId: 'k1' });
+    expect(timeReducer(started, stoppedTimer()).running).toBeNull();
+  });
+
+  it('keeps a denial for the rest of the session so the control is not re-offered', () => {
+    // A 403 is a wall, not a hiccup: re-rendering a Start button that always
+    // fails is how the W02 scope gap reaches a technician as "the app is broken".
+    const denied = timeReducer(undefined, timeAccessDenied({ reason: 'scope', message: 'nope' }));
+    expect(denied.denial).toEqual({ reason: 'scope', message: 'nope' });
+    // A later success does not un-deny; only a fresh sign-in (which resets the
+    // whole store) clears it.
+    expect(timeReducer(denied, pendingWritesChanged(2)).denial).not.toBeNull();
+  });
+
+  it('tracks parked work independently of the queue depth', () => {
+    // The two counts mean different things and are reported separately: a
+    // pending write will still be sent, a parked one never will. Collapsing
+    // them is how "N entries need attention" turns back into a badge that
+    // looks like it is about to clear itself.
+    const state = timeReducer(undefined, needsAttentionChanged(2));
+    expect(state.needsAttentionCount).toBe(2);
+    expect(state.pendingCount).toBe(0);
+    expect(timeReducer(state, pendingWritesChanged(5)).needsAttentionCount).toBe(2);
+    expect(timeReducer(state, needsAttentionChanged(0)).needsAttentionCount).toBe(0);
+  });
+
+  it('tracks queue depth independently of the running timer', () => {
+    const started = timeReducer(undefined, startedTimer(ENTRY));
+    const next = timeReducer(started, pendingWritesChanged(4));
+    expect(next.pendingCount).toBe(4);
+    expect(next.running).toEqual(started.running);
+  });
+
+  it('raises and clears the last error', () => {
+    const raised = timeReducer(undefined, timeErrorRaised('offline'));
+    expect(raised.lastError).toBe('offline');
+    expect(timeReducer(raised, timeErrorRaised(null)).lastError).toBeNull();
   });
 });

--- a/apps/mobile/src/store/timeSlice.ts
+++ b/apps/mobile/src/store/timeSlice.ts
@@ -1,14 +1,26 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
 import type { RunningTimer, TimeEntry } from '../services/timeEntries';
+import type { TimeEntryDenial } from '../services/timeEntryAccess';
 
 export interface TimeState {
   running: RunningTimer | null;
   pendingCount: number;
+  /**
+   * Writes the server refused for good, parked rather than deleted. It lives in
+   * the store, not in the TimerBar, because the bar is not the only surface
+   * that can park one: a stop whose device clock ran backwards is parked from
+   * the ticket screen, and the standing "N need attention" row has to appear
+   * then — not at the next reconnect.
+   */
+  needsAttentionCount: number;
   lastError: string | null;
 }
 
 export const initialTimeState: TimeState = {
   running: null,
   pendingCount: 0,
+  needsAttentionCount: 0,
   lastError: null,
 };
 
@@ -28,6 +40,7 @@ export function timerStarted(state: TimeState, entry: TimeEntry): TimeState {
     ...state,
     running: {
       id: entry.id,
+      localId: null,
       ticketId: entry.ticketId,
       startedAt: entry.startedAt,
       description: entry.description,
@@ -44,6 +57,83 @@ export function queueDepthChanged(state: TimeState, pendingCount: number): TimeS
   return { ...state, pendingCount };
 }
 
+export function needsAttentionChangedState(
+  state: TimeState,
+  needsAttentionCount: number
+): TimeState {
+  return { ...state, needsAttentionCount };
+}
+
 export function timerErrored(state: TimeState, message: string): TimeState {
   return { ...state, lastError: message };
 }
+
+/**
+ * Redux binding over the pure reducers above.
+ *
+ * The running timer lives in the Redux store rather than a module-level
+ * singleton for one reason: `withLogoutReset` (store/resettable.ts) wipes every
+ * registered slice on sign-out. A timer left behind by the previous account
+ * would keep ticking in the bar for the next one — the same cross-session leak
+ * the wrapper exists to prevent.
+ */
+export interface TimeSliceState extends TimeState {
+  /**
+   * Sticky for the session. A 403 from `/time-entries` is a wall, not a
+   * hiccup — an organization-scoped token can never read the table, and a
+   * missing `time_entries:write` grant needs an admin. Re-offering a Start
+   * button that always fails is how that reaches a technician as "the app is
+   * broken", so the denial is remembered and the control is withdrawn until
+   * the next sign-in clears the whole store.
+   */
+  denial: TimeEntryDenial | null;
+}
+
+const initialState: TimeSliceState = { ...initialTimeState, denial: null };
+
+const timeSlice = createSlice({
+  name: 'time',
+  initialState,
+  reducers: {
+    /**
+     * The running timer, from any authority: the server's answer to
+     * GET /time-entries/running, or a timer that exists only on this device
+     * (`id === null`) because it was started offline.
+     */
+    runningTimerAdopted(state, action: PayloadAction<RunningTimer | null>) {
+      state.running = action.payload;
+      state.lastError = null;
+    },
+    startedTimer(state, action: PayloadAction<TimeEntry>) {
+      return { ...state, ...timerStarted(state, action.payload) };
+    },
+    stoppedTimer(state) {
+      return { ...state, ...timerStopped(state) };
+    },
+    pendingWritesChanged(state, action: PayloadAction<number>) {
+      return { ...state, ...queueDepthChanged(state, action.payload) };
+    },
+    needsAttentionChanged(state, action: PayloadAction<number>) {
+      return { ...state, ...needsAttentionChangedState(state, action.payload) };
+    },
+    timeErrorRaised(state, action: PayloadAction<string | null>) {
+      state.lastError = action.payload;
+    },
+    timeAccessDenied(state, action: PayloadAction<TimeEntryDenial>) {
+      state.denial = action.payload;
+      state.lastError = action.payload.message;
+    },
+  },
+});
+
+export const {
+  runningTimerAdopted,
+  startedTimer,
+  stoppedTimer,
+  pendingWritesChanged,
+  needsAttentionChanged,
+  timeErrorRaised,
+  timeAccessDenied,
+} = timeSlice.actions;
+
+export default timeSlice.reducer;

--- a/apps/mobile/src/testing/asyncStorageStub.ts
+++ b/apps/mobile/src/testing/asyncStorageStub.ts
@@ -1,0 +1,39 @@
+/**
+ * In-memory stand-in for `@react-native-async-storage/async-storage`, aliased
+ * in for Vitest only (see apps/mobile/vitest.config.ts).
+ *
+ * The published ESM build imports `./createAsyncStorage` without an extension,
+ * which Node cannot resolve, so ANY suite that transitively reaches the package
+ * dies at import time — including suites that never touch storage themselves.
+ * `services/auth.ts` clears the unsent time-entry queue on sign-out, which puts
+ * the package on the import graph of every auth-adjacent test.
+ *
+ * A suite that cares about storage behaviour still declares its own
+ * `vi.mock('@react-native-async-storage/async-storage', …)`, which takes
+ * precedence over this alias.
+ */
+
+const store = new Map<string, string>();
+
+const asyncStorage = {
+  async getItem(key: string): Promise<string | null> {
+    return store.get(key) ?? null;
+  },
+  async setItem(key: string, value: string): Promise<void> {
+    store.set(key, value);
+  },
+  async removeItem(key: string): Promise<void> {
+    store.delete(key);
+  },
+  async clear(): Promise<void> {
+    store.clear();
+  },
+  async getAllKeys(): Promise<string[]> {
+    return [...store.keys()];
+  },
+  async multiRemove(keys: readonly string[]): Promise<void> {
+    for (const key of keys) store.delete(key);
+  },
+};
+
+export default asyncStorage;

--- a/apps/mobile/vitest.config.ts
+++ b/apps/mobile/vitest.config.ts
@@ -1,3 +1,18 @@
+// The timezone is pinned HERE, in the config, not in the suites that need it.
+//
+// `process.env.TZ = '...'` at the top of a test file works under the default
+// forks pool and silently does NOT under `--pool=threads`: Node does not
+// re-read TZ inside a worker thread, so the assignment applies to nothing and
+// every local/UTC assertion runs in the runner's own zone. That made
+// screens/time/timesheetLocalDays.test.ts pass locally and fail on the
+// documented `--pool=threads --maxWorkers=2` invocation. Setting it before the
+// config is even evaluated puts it in the environment every worker inherits.
+//
+// America/New_York is UTC-4 in August and UTC-5 in January, so it exercises
+// both a non-zero offset and a DST change. Suites that depend on it assert the
+// zone actually applied rather than trusting this line.
+process.env.TZ = 'America/New_York';
+
 import { defineConfig } from 'vitest/config';
 
 // Pure-logic smoke tests only. The mobile app has no React Native test
@@ -9,5 +24,12 @@ export default defineConfig({
     environment: 'node',
     include: ['src/**/*.test.ts'],
     exclude: ['node_modules/**', 'ios/**', 'android/**'],
+    alias: {
+      // The package's ESM build imports './createAsyncStorage' with no
+      // extension, which Node cannot resolve — so any suite that transitively
+      // reaches it fails at import time, storage-related or not. A suite that
+      // asserts on storage still declares its own vi.mock, which wins over this.
+      '@react-native-async-storage/async-storage': '/src/testing/asyncStorageStub.ts',
+    },
   },
 });


### PR DESCRIPTION
## What

Wave W05 of the mobile time-entry feature (#3206): the technician-facing surfaces on top of the client, queue and state slice landed in W03/W04.

- **Ticket detail** gains a TIME section with Start/Stop, driven by a new pure `timerActions.ts` (`startForTicket`, `stopRunningTimer`).
- **TimerBar** rides above the tab bar — `HH:MM:SS` on a 1s interval, the ticket reference, a pending-writes badge, and a Stop action. It is also the app's single queue-replay owner: a false→true `useNetworkConnected` transition drains the offline queue from whatever tab the technician is on.
- **Time tab / weekly timesheet** — `GET /time-entries/timesheet?weekStart=YYYY-MM-DD` grouped by day with daily and weekly totals, inline correction via `PATCH /time-entries/:id`.

## Why these particular shapes

- **`dropped.length > 0` raises a toast naming the count.** A silently discarded time entry is unbillable work; it must never vanish quietly.
- **`weekStart` is date-only, derived from local calendar fields.** Both obvious implementations are wrong: `new Date('2026-08-24')` parses as UTC midnight (the previous day west of Greenwich), and `toISOString()` shifts the day boundary by the phone's offset. Either silently moves entries between weeks. `timesheetWeek.ts` exists to make that testable, and its weekday/month names are fixed strings because Hermes ships a reduced ICU.
- **Approved / billed rows render read-only** with the reason on them, rather than accepting an edit the server answers with `APPROVED_IMMUTABLE` / `ENTRY_BILLED`.
- **403 is never a crash or an empty timesheet.** New `timeEntryAccess.ts` classifies the two different 403s the route emits, because the W02 gate (PR #4234) found both are reachable in production:
  - `requireScope('partner','system')` → `"Insufficient permissions"` → the account is **organization-scoped**; `time_entries` has no org-axis RLS policy, so this can never be retried. Copy says so.
  - `requirePermission` → `"Permission denied"` / `"No permissions found"` → the **role** lacks `time_entries:write`. The default seeded *Partner Technician* role is exactly this case. Copy says an administrator can grant it.
  - Plus `NOT_OWN_ENTRY` (ownership) and `ADMIN_REQUIRED`. An unclassifiable 403 still quotes the server's own message — never a bare "An error occurred".
  A recorded denial is sticky for the session and withdraws the Start/Stop control, so a technician is not offered a button that always fails.
- **`timeSlice.ts` gains a Redux binding** over its existing pure reducers and is registered in the store, so `withLogoutReset` wipes a running timer on sign-out instead of leaking it into the next account's session. The pure functions and their W04 tests are untouched.
- **Transport failures queue; verdicts do not.** NetInfo reports "connected" on a captive portal, so a start/stop that fails with no HTTP status is enqueued rather than lost. A 403/409 is not — a queued 409 would be dropped by the queue's `PERMANENT_STATUSES` rule anyway, and a queued 403 would wedge the head of the queue.
- **`timeEntryReplay.ts`** maps a queued write back to its endpoint. An unknown `kind` or a `create` missing its time bounds throws with status 400 *on purpose*: `drain` treats that as a verdict and drops the row, where a bare throw is retried forever and wedges every entry behind it.

## Tasks covered

- Plan Task 5 — `screens/tickets/timerActions.ts` (+ test) and start/stop wired into `TicketDetailScreen.tsx`.
- Plan Task 6 — `components/TimerBar.tsx` mounted above the tab bar in `navigation/MainNavigator.tsx`, with queue replay on reconnect.
- Plan Task 7 — `screens/time/TimesheetScreen.tsx` and the `TimeTab` route.

Plan: `docs/superpowers/plans/mobile/2026-08-23-mobile-time-entry.md`.

## Tests (verified)

`pnpm --filter breeze-mobile test` — **60 files, 725 passed, 3 skipped**.
`pnpm --filter breeze-mobile typecheck` — **clean**.

New suites, all written red-first and confirmed failing before implementation:

| Suite | Covers |
|---|---|
| `services/timeEntryAccess.test.ts` | 403 classification: scope vs. role vs. ownership vs. unclassifiable; never a generic message; accepts the bare `ApiError` shape |
| `screens/tickets/timerActions.test.ts` | success / offline-queue / `ENTRY_RUNNING` / `NO_RUNNING_TIMER` / denial pass-through; verdicts are not queued; a statusless transport failure is |
| `services/timeEntryReplay.test.ts` | kind→endpoint routing; server error propagated untouched so `drain` can read its status; unknown kind and a bounds-less `create` reject as permanent 400 |
| `lib/timeFormat.test.ts` | `HH:MM:SS` incl. past 24h and negative/NaN clamping; `formatMinutes` renders `null` as an em dash, not `0m` |
| `screens/time/timesheetWeek.test.ts` | Monday-anchored week start; date-only output; local-vs-UTC day boundary; month/year-crossing week steps; deterministic labels |
| `store/timeSlice.test.ts` (extended) | the new Redux binding: adoption of a server-reported timer, sticky denial, queue depth, error raise/clear |

The React Native components (`TimerBar.tsx`, `TimesheetScreen.tsx`, the two modified screens) carry no unit tests, matching this app's convention — `apps/mobile/vitest.config.ts` deliberately includes only `.ts` so component imports never pull the RN/Expo runtime into Vitest. All decision logic was extracted into the pure modules above precisely so it is covered.

## Not checked

- **Plan Task 6 Step 3 — the airplane-mode device walkthrough (airplane mode → start → pending badge → stop → reconnect → both writes land, badge clears) was NOT run.** No device or simulator is available in this environment. The replay path is covered by unit tests on `drain` (W04) and `makeReplaySender` (here), but the end-to-end NetInfo transition on a real handset is unverified.
- Not rendered on a device or simulator at all: layout, the timer bar's fit above the tab bar, and the timesheet's appearance are **not-checked**.
- The 403 states are exercised against synthesised errors, not a live organization-scoped login or a real default *Partner Technician* account — the classification input strings are taken from `apps/api/src/middleware/auth.ts` (verified by reading), not from a live response.

## CI

This PR is based on `feature/3206-mobile-ticketing-time-entry/wave-3898`, not `main`, so `ci.yml` (`pull_request: branches: [main]`) does not fire for it. CI has been dispatched manually against this branch.

Separately: **"Check Migrations" and "Trivy Image Scan" are already red on `origin/main` itself** (355b37465, step "Shipped-migration immutability guard"). Those two failures are pre-existing and are not caused by this work. This PR contains no migration and no Dockerfile change.

Closes #3899

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XVnsGUAURLnTjUMQsguYWv
