### PR TITLE
fix(api): honor the reboot policy when a patch job partially fails (#4228)

### DIFF
--- a/apps/api/src/jobs/patchJobExecutor.test.ts
+++ b/apps/api/src/jobs/patchJobExecutor.test.ts
@@ -1546,4 +1546,96 @@ describe('post-patch reboot policy is independent of overall job success (#4228)
     expect(evaluateRebootPolicy).toHaveBeenCalledWith('device-1', 'if_required', true);
     expect(executeReboot).toHaveBeenCalled();
   });
+
+  it('honors a reported rebootRequired: false over the static patch flags', async () => {
+    // The approved set statically claims patch-1 requires a reboot, but the agent
+    // installed it and reported `rebootRequired: false` — Windows does not always
+    // need the restart the catalog advertises. The agent observed the real
+    // machine, so its `false` wins. Drop the `??` and read the static flags
+    // directly and this device gets an unnecessary reboot.
+    vi.mocked(evaluateRebootPolicy).mockResolvedValue({
+      shouldReboot: false,
+      reason: 'No installed patch requires reboot',
+      deferred: false,
+    });
+
+    await runDeviceExecution({
+      approvedPatches: TWO_PATCHES, // patch-1 has requiresReboot: true
+      rebootPolicy: 'if_required',
+      command: agentCommandRow({
+        success: true,
+        installedCount: 2,
+        failedCount: 0,
+        rebootRequired: false,
+        results: [
+          { id: 'patch-1', externalId: 'KB5000001', status: 'installed', rebootRequired: false },
+          { id: 'patch-2', externalId: 'KB5000002', status: 'installed', rebootRequired: false },
+        ],
+      }),
+    });
+
+    expect(evaluateRebootPolicy).toHaveBeenCalledWith('device-1', 'if_required', false);
+    expect(executeReboot).not.toHaveBeenCalled();
+  });
+
+  it('treats a per-patch installed entry as an install even when installedCount is 0', async () => {
+    // The two signals disagree: the summary counter says nothing installed, the
+    // per-patch array says patch-1 did. `anyPatchInstalled` ORs them, so the
+    // reboot still gets evaluated. Reading only `installedCount` would silently
+    // reinstate #4228 for any agent whose counter is absent, stale, or wrong.
+    vi.mocked(evaluateRebootPolicy).mockResolvedValue({
+      shouldReboot: true,
+      reason: 'Installed patch requires reboot',
+      deferred: false,
+    });
+
+    await runDeviceExecution({
+      approvedPatches: TWO_PATCHES,
+      rebootPolicy: 'if_required',
+      command: agentCommandRow({
+        success: false,
+        installedCount: 0,
+        failedCount: 1,
+        rebootRequired: true,
+        results: [
+          { id: 'patch-1', externalId: 'KB5000001', status: 'installed', rebootRequired: true },
+          { id: 'patch-2', externalId: 'KB5000002', status: 'failed', error: '0x80070005' },
+        ],
+      }),
+    });
+
+    expect(evaluateRebootPolicy).toHaveBeenCalledWith('device-1', 'if_required', true);
+    expect(executeReboot).toHaveBeenCalled();
+  });
+
+  it('evaluates the reboot policy for a rollback-only run with no net installs', async () => {
+    // Deliberate: `rolled_back` counts as "the device changed". Uninstalling a
+    // patch can require a restart just as installing one can, so a rollback that
+    // reports rebootRequired must reach the policy even though nothing was
+    // installed. Pinned because it is the least obvious arm of anyPatchInstalled
+    // and reads like a copy-paste at a glance.
+    vi.mocked(evaluateRebootPolicy).mockResolvedValue({
+      shouldReboot: true,
+      reason: 'Installed patch requires reboot',
+      deferred: false,
+    });
+
+    await runDeviceExecution({
+      approvedPatches: TWO_PATCHES,
+      rebootPolicy: 'if_required',
+      command: agentCommandRow({
+        success: false,
+        installedCount: 0,
+        failedCount: 1,
+        rebootRequired: true,
+        results: [
+          { id: 'patch-1', externalId: 'KB5000001', status: 'rolled_back', rebootRequired: true },
+          { id: 'patch-2', externalId: 'KB5000002', status: 'failed', error: '0x80070005' },
+        ],
+      }),
+    });
+
+    expect(evaluateRebootPolicy).toHaveBeenCalledWith('device-1', 'if_required', true);
+    expect(executeReboot).toHaveBeenCalled();
+  });
 });

--- a/apps/api/src/jobs/patchJobExecutor.test.ts
+++ b/apps/api/src/jobs/patchJobExecutor.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const shared = vi.hoisted(() => ({
   getJobMock: vi.fn(),
@@ -105,6 +105,7 @@ import {
 } from './patchJobExecutor';
 import { resolveApprovedPatchesForDevice } from '../services/patchApprovalEvaluator';
 import { queueCommandForExecution } from '../services/commandQueue';
+import { evaluateRebootPolicy, executeReboot } from '../services/patchRebootHandler';
 
 function createSelectChain(rows: any[] = []) {
   const chain: any = {};
@@ -1217,5 +1218,294 @@ describe('parseJobCategoryList (#2117 category filter fail-closed parse)', () =>
   it('returns null when an array carries a non-string entry', () => {
     expect(parseJobCategoryList(['driver', 42])).toBeNull();
     expect(parseJobCategoryList([{ category: 'driver' }])).toBeNull();
+  });
+});
+
+// ============================================================================
+// #4228 — post-patch reboot policy on a partially failed job
+// ============================================================================
+
+type AgentPatchEntry = {
+  id: string;
+  externalId: string;
+  status: 'installed' | 'failed' | 'rolled_back';
+  rebootRequired?: boolean;
+  error?: string;
+};
+
+/**
+ * Builds the command row exactly as a Windows agent produces it.
+ *
+ * The shape is load-bearing for #4228: `executePatchInstallCommand`
+ * (agent/internal/heartbeat/heartbeat.go) returns `Status: "failed"` /
+ * `ExitCode: 1` the moment ONE patch fails, while still emitting the full
+ * install summary on stdout — so `rebootRequired: true` and
+ * `installedCount > 0` arrive on a command the server reads as failed. Anything
+ * keyed off overall success therefore misses the reboot the successful installs
+ * need.
+ */
+function agentCommandRow(summary: {
+  success: boolean;
+  installedCount: number;
+  failedCount: number;
+  rebootRequired: boolean;
+  results: AgentPatchEntry[];
+}) {
+  return {
+    status: summary.failedCount > 0 ? 'failed' : 'completed',
+    result: {
+      stdout: JSON.stringify(summary),
+      exitCode: summary.failedCount > 0 ? 1 : 0,
+      error: summary.failedCount > 0 ? `${summary.failedCount} patch operations failed` : undefined,
+    },
+  };
+}
+
+/**
+ * Drives the real per-device worker processor end to end (prepare → poll →
+ * record) so the reboot decision is exercised through the shipped code path
+ * rather than a hand-called internal.
+ */
+async function runDeviceExecution(opts: {
+  approvedPatches: Array<{ patchId: string; externalId: string; requiresReboot: boolean }>;
+  rebootPolicy?: string;
+  command: { status: string; result: unknown } | null;
+}) {
+  const { approvedPatches, rebootPolicy = 'if_required', command } = opts;
+
+  vi.mocked(db.select)
+    // 1. patch job row
+    .mockImplementationOnce(() => createSelectChain([{
+      id: 'job-1',
+      orgId: 'org-1',
+      status: 'running',
+      patches: { ringId: null, autoApprove: {} },
+      targets: { deviceIds: ['device-1'], deployment: { rebootPolicy } },
+    }]) as any)
+    // 2. device-in-org check
+    .mockImplementationOnce(() => createSelectChain([{ id: 'device-1' }]) as any)
+    // 3. patch records for the install command (terminal .where(), no .limit())
+    .mockImplementationOnce(() => createWhereSelectChain(
+      approvedPatches.map((p) => ({
+        id: p.patchId,
+        source: 'windows_update',
+        externalId: p.externalId,
+        title: p.externalId,
+      })),
+    ) as any)
+    // 4. completion poll on device_commands
+    .mockImplementationOnce(() => createSelectChain(command ? [command] : []) as any)
+    // 5. checkAndFinalizeJob — no row, so it returns early
+    .mockImplementationOnce(() => createSelectChain([]) as any);
+
+  vi.mocked(db.insert).mockImplementation(() => ({
+    values: vi.fn(() => Promise.resolve()),
+  }) as any);
+  vi.mocked(db.update).mockImplementation(() => ({
+    set: vi.fn(() => ({ where: vi.fn(() => Promise.resolve()) })),
+  }) as any);
+
+  vi.mocked(resolveApprovedPatchesForDevice).mockResolvedValueOnce(approvedPatches as any);
+  vi.mocked(queueCommandForExecution).mockResolvedValueOnce({ command: { id: 'cmd-1' } } as any);
+
+  createPatchJobDeviceWorker();
+  const running = shared.processorRefs['patch-job-devices']({
+    data: {
+      type: 'execute-patch-job-device',
+      patchJobId: 'job-1',
+      deviceId: 'device-1',
+      orgId: 'org-1',
+    },
+  });
+  // pollForPatchCommandResult sleeps 5s before its first read of device_commands.
+  await vi.advanceTimersByTimeAsync(5_000);
+  return running;
+}
+
+const TWO_PATCHES = [
+  { patchId: 'patch-1', externalId: 'KB5000001', requiresReboot: true },
+  { patchId: 'patch-2', externalId: 'KB5000002', requiresReboot: false },
+];
+
+describe('post-patch reboot policy is independent of overall job success (#4228)', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.useFakeTimers();
+    shared.processorRef = undefined;
+    shared.processorRefs = {};
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.mocked(executeReboot).mockResolvedValue({ success: true, delayMinutes: 15 });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('dispatches the reboot when one patch fails but an installed patch requires one', async () => {
+    vi.mocked(evaluateRebootPolicy).mockResolvedValue({
+      shouldReboot: true,
+      reason: 'Installed patch requires reboot',
+      deferred: false,
+    });
+
+    await runDeviceExecution({
+      approvedPatches: TWO_PATCHES,
+      rebootPolicy: 'if_required',
+      command: agentCommandRow({
+        success: false,
+        installedCount: 1,
+        failedCount: 1,
+        rebootRequired: true,
+        results: [
+          { id: 'patch-1', externalId: 'KB5000001', status: 'installed', rebootRequired: true },
+          { id: 'patch-2', externalId: 'KB5000002', status: 'failed', error: '0x80070005' },
+        ],
+      }),
+    });
+
+    // The reboot requirement the agent reported must reach the policy even
+    // though the job's aggregate status is "failed".
+    expect(evaluateRebootPolicy).toHaveBeenCalledWith('device-1', 'if_required', true);
+    expect(executeReboot).toHaveBeenCalledWith(
+      'device-1',
+      'Installed patch requires reboot',
+      { expectedOrgId: 'org-1' },
+    );
+  });
+
+  it('records that the dispatched reboot followed a partially failed job', async () => {
+    vi.mocked(evaluateRebootPolicy).mockResolvedValue({
+      shouldReboot: true,
+      reason: 'Installed patch requires reboot',
+      deferred: false,
+    });
+
+    await runDeviceExecution({
+      approvedPatches: TWO_PATCHES,
+      command: agentCommandRow({
+        success: false,
+        installedCount: 1,
+        failedCount: 1,
+        rebootRequired: true,
+        results: [
+          { id: 'patch-1', externalId: 'KB5000001', status: 'installed', rebootRequired: true },
+          { id: 'patch-2', externalId: 'KB5000002', status: 'failed', error: '0x80070005' },
+        ],
+      }),
+    });
+
+    const logged = logSpy.mock.calls.map((args: unknown[]) => args.join(' ')).join('\n');
+    expect(logged).toContain('device-1');
+    expect(logged).toContain('scheduled reboot');
+    expect(logged).toMatch(/partial/i);
+  });
+
+  it('records why the reboot was skipped when the policy declines it', async () => {
+    vi.mocked(evaluateRebootPolicy).mockResolvedValue({
+      shouldReboot: false,
+      reason: 'Reboot policy is never',
+      deferred: false,
+    });
+
+    await runDeviceExecution({
+      approvedPatches: TWO_PATCHES,
+      rebootPolicy: 'never',
+      command: agentCommandRow({
+        success: false,
+        installedCount: 1,
+        failedCount: 1,
+        rebootRequired: true,
+        results: [
+          { id: 'patch-1', externalId: 'KB5000001', status: 'installed', rebootRequired: true },
+          { id: 'patch-2', externalId: 'KB5000002', status: 'failed', error: '0x80070005' },
+        ],
+      }),
+    });
+
+    expect(evaluateRebootPolicy).toHaveBeenCalledWith('device-1', 'never', true);
+    expect(executeReboot).not.toHaveBeenCalled();
+    const logged = logSpy.mock.calls.map((args: unknown[]) => args.join(' ')).join('\n');
+    expect(logged).toContain('Reboot policy is never');
+  });
+
+  it('does not reboot when every patch failed and nothing was installed', async () => {
+    await runDeviceExecution({
+      // Both patches statically claim to require a reboot — neither installed.
+      approvedPatches: [
+        { patchId: 'patch-1', externalId: 'KB5000001', requiresReboot: true },
+        { patchId: 'patch-2', externalId: 'KB5000002', requiresReboot: true },
+      ],
+      command: agentCommandRow({
+        success: false,
+        installedCount: 0,
+        failedCount: 2,
+        rebootRequired: false,
+        results: [
+          { id: 'patch-1', externalId: 'KB5000001', status: 'failed', error: '0x80070005' },
+          { id: 'patch-2', externalId: 'KB5000002', status: 'failed', error: '0x80070005' },
+        ],
+      }),
+    });
+
+    expect(evaluateRebootPolicy).not.toHaveBeenCalled();
+    expect(executeReboot).not.toHaveBeenCalled();
+    const logged = logSpy.mock.calls.map((args: unknown[]) => args.join(' ')).join('\n');
+    expect(logged).toMatch(/no patch installed/i);
+  });
+
+  it('does not manufacture a reboot from static flags when a failed run is unparsable', async () => {
+    // Agent returned a failed command with non-JSON stdout: we know nothing about
+    // what installed, so the `approvedPatches.some(p => p.requiresReboot)`
+    // fallback — which assumes a success-shaped run — must not fire.
+    await runDeviceExecution({
+      approvedPatches: [
+        { patchId: 'patch-1', externalId: 'KB5000001', requiresReboot: true },
+      ],
+      command: {
+        status: 'failed',
+        result: { stdout: 'Access is denied.', exitCode: 1, error: 'install failed' },
+      },
+    });
+
+    expect(evaluateRebootPolicy).not.toHaveBeenCalled();
+    expect(executeReboot).not.toHaveBeenCalled();
+  });
+
+  it('does not reboot when the install command never came back', async () => {
+    await runDeviceExecution({
+      approvedPatches: [
+        { patchId: 'patch-1', externalId: 'KB5000001', requiresReboot: true },
+      ],
+      command: null,
+    });
+
+    expect(evaluateRebootPolicy).not.toHaveBeenCalled();
+    expect(executeReboot).not.toHaveBeenCalled();
+  });
+
+  it('still falls back to static requiresReboot flags on a fully successful unparsable run', async () => {
+    // Behaviour preserved from before #4228: a completed, exit-0 command whose
+    // stdout we cannot parse means every approved patch installed, so the static
+    // flags are a sound description of what landed.
+    vi.mocked(evaluateRebootPolicy).mockResolvedValue({
+      shouldReboot: true,
+      reason: 'Installed patch requires reboot',
+      deferred: false,
+    });
+
+    await runDeviceExecution({
+      approvedPatches: TWO_PATCHES,
+      command: {
+        status: 'completed',
+        result: { stdout: 'Installation successful.', exitCode: 0 },
+      },
+    });
+
+    expect(evaluateRebootPolicy).toHaveBeenCalledWith('device-1', 'if_required', true);
+    expect(executeReboot).toHaveBeenCalled();
   });
 });

--- a/apps/api/src/jobs/patchJobExecutor.test.ts
+++ b/apps/api/src/jobs/patchJobExecutor.test.ts
@@ -1473,6 +1473,44 @@ describe('post-patch reboot policy is independent of overall job success (#4228)
 
     expect(evaluateRebootPolicy).not.toHaveBeenCalled();
     expect(executeReboot).not.toHaveBeenCalled();
+    // ...but an unparsable result is an anomaly, not a shrug: it is the one way a
+    // real partial success can still read as "nothing installed", so it has to
+    // leave a trail rather than silently taking the conservative branch.
+    expect(captureException).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('unparsable patch install result') }),
+    );
+    const logged = logSpy.mock.calls.map((args: unknown[]) => args.join(' ')).join('\n');
+    expect(logged).toMatch(/unparsable/i);
+    // Must NOT claim the stronger "no patch installed successfully" — we do not know that.
+    expect(logged).not.toContain('no patch installed successfully');
+  });
+
+  it('records that a declined reboot was deferred by the maintenance window', async () => {
+    vi.mocked(evaluateRebootPolicy).mockResolvedValue({
+      shouldReboot: false,
+      reason: 'Outside maintenance window — reboot deferred',
+      deferred: true,
+    });
+
+    await runDeviceExecution({
+      approvedPatches: TWO_PATCHES,
+      rebootPolicy: 'maintenance_window',
+      command: agentCommandRow({
+        success: false,
+        installedCount: 1,
+        failedCount: 1,
+        rebootRequired: true,
+        results: [
+          { id: 'patch-1', externalId: 'KB5000001', status: 'installed', rebootRequired: true },
+          { id: 'patch-2', externalId: 'KB5000002', status: 'failed', error: '0x80070005' },
+        ],
+      }),
+    });
+
+    expect(executeReboot).not.toHaveBeenCalled();
+    const logged = logSpy.mock.calls.map((args: unknown[]) => args.join(' ')).join('\n');
+    expect(logged).toContain('Outside maintenance window');
+    expect(logged).toContain('(deferred)');
   });
 
   it('does not reboot when the install command never came back', async () => {

--- a/apps/api/src/jobs/patchJobExecutor.ts
+++ b/apps/api/src/jobs/patchJobExecutor.ts
@@ -1120,6 +1120,8 @@ async function recordDeviceExecution(
       patchId?: string;
       externalId?: string;
       success?: boolean;
+      /** Agent's per-patch outcome: 'installed' | 'failed' | 'rolled_back'. */
+      status?: string;
       error?: string;
       rebootRequired?: boolean;
     }>;
@@ -1140,8 +1142,31 @@ async function recordDeviceExecution(
     (parsedResult?.success ?? true) &&
     (typeof commandResult?.exitCode !== 'number' || commandResult.exitCode === 0);
 
+  // Did the run actually change anything on the device? Deliberately NOT
+  // `overallSuccess`: the agent returns Status "failed" / exit 1 the moment ONE
+  // patch in the batch fails, while the other twelve are installed and pending a
+  // reboot (#4228). `installedCount` is the agent's own count of successful
+  // installs/rollbacks; the per-patch array is the fallback for a payload that
+  // omits it. A total failure, or a command that never came back, leaves both
+  // empty.
+  const installedCount = parsedResult?.installedCount;
+  const anyPatchInstalled =
+    (typeof installedCount === 'number' && installedCount > 0) ||
+    (parsedResult?.results?.some(
+      (r) => r.success === true || r.status === 'installed' || r.status === 'rolled_back',
+    ) ?? false);
+
+  // The agent ORs `rebootRequired` across every SUCCESSFUL install, so a partial
+  // failure still carries an accurate value — use it verbatim, including a
+  // reported `false`.
+  //
+  // The fallback only covers a result we could not parse at all (non-JSON
+  // stdout, or no stdout). Reading the static `requiresReboot` flags off the
+  // approved set assumes every one of them installed, which is only sound for a
+  // success-shaped run: on a failed or timed-out command we have no idea which
+  // patches landed, so those flags must not manufacture a reboot.
   const anyRebootRequired = parsedResult?.rebootRequired ??
-    approvedPatches.some((p) => p.requiresReboot);
+    (overallSuccess ? approvedPatches.some((p) => p.requiresReboot) : false);
 
   // 6. Insert patchJobResults per patch
   for (const patch of approvedPatches) {
@@ -1170,16 +1195,46 @@ async function recordDeviceExecution(
   }
 
   // 7. Evaluate reboot policy
+  //
+  // This used to sit inside `if (overallSuccess)`. A 13-patch job with a single
+  // failed patch reports `success: false` / exit 1 from the agent, so the policy
+  // was never consulted at all and the reboot the other twelve installs needed
+  // was dropped — silently, with not one log line to explain the
+  // `Reboot Required: Yes` the UI kept showing (#4228). Whether a reboot is
+  // needed is a property of what actually installed, not of the job's aggregate
+  // status, so the policy is now evaluated whenever at least one patch landed.
+  //
+  // A run that installed NOTHING still skips: there is nothing to finalize, and
+  // an `always` policy would otherwise reboot a device the job never changed.
+  //
+  // Every branch below logs. The pre-#4228 silence is what made this bug
+  // invisible in production, so "no reboot" must be as traceable as a dispatch.
   const rebootPolicy = targets?.deployment?.rebootPolicy ?? 'if_required';
-  if (overallSuccess) {
+  const rebootLog = `[PatchJobExecutor] job ${patchJobId} device ${deviceId} reboot policy "${rebootPolicy}"`;
+
+  if (!overallSuccess && !anyPatchInstalled) {
+    console.log(
+      `${rebootLog}: not evaluated — no patch installed successfully (rebootRequired=${anyRebootRequired})`
+    );
+  } else {
     const rebootEval = await evaluateRebootPolicy(deviceId, rebootPolicy, anyRebootRequired);
-    if (rebootEval.shouldReboot) {
+    if (!rebootEval.shouldReboot) {
+      console.log(
+        `${rebootLog}: no reboot — ${rebootEval.reason}${rebootEval.deferred ? ' (deferred)' : ''}`
+      );
+    } else {
       // No delay passed: executeReboot resolves it from the device's effective
       // patch policy (#3197). It used to default to 5 minutes, which reached
       // none of the agent's warning thresholds, so the user got no notice.
       const rebootResult = await executeReboot(deviceId, rebootEval.reason, {
         expectedOrgId: orgId,
       });
+      // A partially failed job that still reboots is the #4228 path — name it in
+      // the log so an operator reading "the job failed but the box rebooted" can
+      // tell intent from accident.
+      const partialSuffix = overallSuccess
+        ? ''
+        : ' (job partially failed; successfully installed patches still require a reboot)';
       if (!rebootResult.success) {
         // captureException, not just a console line: this is the post-patch
         // reboot — the path #3197 is about — and a failure here leaves the device
@@ -1196,7 +1251,7 @@ async function recordDeviceExecution(
         );
       } else {
         console.log(
-          `[PatchJobExecutor] scheduled reboot for device ${deviceId} in ${rebootResult.delayMinutes}m`
+          `${rebootLog}: scheduled reboot in ${rebootResult.delayMinutes}m — ${rebootEval.reason}${partialSuffix}`
         );
       }
     }

--- a/apps/api/src/jobs/patchJobExecutor.ts
+++ b/apps/api/src/jobs/patchJobExecutor.ts
@@ -1130,11 +1130,26 @@ async function recordDeviceExecution(
     failedCount?: number;
   } | null = null;
 
+  // A well-formed agent ALWAYS emits the install summary as JSON
+  // (`executePatchInstallCommand` marshals it on both the success and the
+  // failure return), so unparsable stdout is an anomaly, not a shrug. It also
+  // became load-bearing with #4228: the reboot decision is now read out of this
+  // payload, so a parse failure is the one way a genuine partial success can
+  // still look like "nothing installed". It must leave a trail.
+  let resultUnparsable = false;
   if (commandResult?.stdout) {
     try {
       parsedResult = JSON.parse(commandResult.stdout);
-    } catch {
-      // Non-JSON stdout
+    } catch (err) {
+      resultUnparsable = true;
+      console.warn(
+        `[PatchJobExecutor] unparsable patch result stdout for job ${patchJobId} device ${deviceId}: ${String(err)}`
+      );
+      captureException(
+        new Error(
+          `[PatchJobExecutor] unparsable patch install result for job ${patchJobId} device ${deviceId}`
+        )
+      );
     }
   }
 
@@ -1213,8 +1228,13 @@ async function recordDeviceExecution(
   const rebootLog = `[PatchJobExecutor] job ${patchJobId} device ${deviceId} reboot policy "${rebootPolicy}"`;
 
   if (!overallSuccess && !anyPatchInstalled) {
+    // Say which of the two it is. "No patch installed" is a fact when the agent
+    // told us so; when its output was unparsable it is an assumption, and an
+    // operator chasing a device that did not reboot needs to tell them apart.
     console.log(
-      `${rebootLog}: not evaluated — no patch installed successfully (rebootRequired=${anyRebootRequired})`
+      `${rebootLog}: not evaluated — ${resultUnparsable
+        ? 'result unparsable, cannot confirm any install (see prior warning)'
+        : 'no patch installed successfully'} (rebootRequired=${anyRebootRequired})`
     );
   } else {
     const rebootEval = await evaluateRebootPolicy(deviceId, rebootPolicy, anyRebootRequired);


### PR DESCRIPTION
## The bug

A scheduled patch job installs 12 of 13 patches, one fails, the operation reports `Reboot Required: Yes` — and the device never reboots, even with the reboot policy set to `If required`. Nothing in the logs explains it.

## Root cause

The Windows agent is correct and is **not** changed here. `executePatchInstallCommand` (`agent/internal/heartbeat/heartbeat.go`) walks the whole batch, ORs `rebootRequired` across every *successful* install, and emits the full summary — `{ success: false, installedCount: 12, failedCount: 1, rebootRequired: true, results: [...] }` — on stdout. But because `failedCount > 0` it returns `Status: "failed"` / `ExitCode: 1`.

Server-side, `recordDeviceExecution` (`apps/api/src/jobs/patchJobExecutor.ts`) computes `anyRebootRequired` correctly from that payload — and then gated the **entire** reboot-policy evaluation behind `if (overallSuccess)`:

```ts
const overallSuccess = finalCommand?.status === 'completed' && ...   // false: agent said "failed"

if (overallSuccess) {
  const rebootEval = await evaluateRebootPolicy(deviceId, rebootPolicy, anyRebootRequired);
  ...
}
```

One failed patch out of thirteen makes `overallSuccess` false, so `evaluateRebootPolicy` was never called at all. The `If required` policy was never consulted, the reboot the other twelve installs needed was dropped, and — because the guard simply skipped the block — **not one log line** recorded that a reboot had been suppressed. That silence is why the UI kept showing `Reboot Required: Yes` next to a device that never restarted.

## The fix

Whether a reboot is needed is a property of **what actually installed**, not of the job's aggregate status.

- **Evaluate on what landed, not on overall success.** A new `anyPatchInstalled` — the agent's own `installedCount`, falling back to a per-patch entry with `status: 'installed' | 'rolled_back'` — gates the policy call. A partially failed job whose successful patches require a reboot now honors `if_required` (and every other policy).
- **A run that installed NOTHING still skips.** There is nothing to finalize, and evaluating unconditionally would let an `always` policy reboot a device the job never touched. This is logged, not silent.
- **Guard the static-flag fallback.** `anyRebootRequired` fell back to `approvedPatches.some(p => p.requiresReboot)` when the result was unparsable. Those flags describe what *would* be needed had every approved patch installed — an assumption that only holds for a success-shaped run. On a failed or timed-out command we have no idea which patches landed, so they must not manufacture a reboot. The fallback is now conditioned on `overallSuccess`, which leaves fully successful runs behaving exactly as before.
- **Log the decision every way it can go** — dispatched (explicitly naming the partial failure, so an operator reading "the job failed but the box rebooted" can tell intent from accident), declined by the policy (carrying the policy's own reason, including the deferred maintenance-window case), and not evaluated because nothing installed.

### On surfacing the skip reason

Reboot *dispatches* are already durably audited: `schedule_reboot` is in `commandQueue`'s `AUDITED_COMMANDS`, so `executeReboot` writes an `agent.command.schedule_reboot` audit row with the reason and delay. There is no equivalent persisted per-device surface for a *skip* — `patch_job_results` rows are per-patch, and `patch_job_results.rebooted_at` has no writer anywhere in the API today — so the skip reason lands in the structured log rather than inventing a schema surface for it. Worth noting separately: the UI's `Reboot Required: Yes` is read from the agent payload on `device_commands`, not from `patch_job_results`, so it was reporting the truth all along; only the dispatch was missing.

## Tests

New suite in `apps/api/src/jobs/patchJobExecutor.test.ts`, driving the real per-device worker processor end to end (prepare → poll → record) against the exact command shape the agent produces:

| Test | Guards |
|---|---|
| dispatches the reboot when one patch fails but an installed patch requires one | the reported bug — **red before the fix** (`evaluateRebootPolicy`: 0 calls) |
| records that the dispatched reboot followed a partially failed job | the dispatch log — **red before** |
| records why the reboot was skipped when the policy declines it | the declined-by-policy log — **red before** |
| does not reboot when every patch failed and nothing was installed | no reboot on a total failure, and it says so — **red before** (log assertion) |
| does not manufacture a reboot from static flags when a failed run is unparsable | the fallback guard |
| does not reboot when the install command never came back | timeout path |
| still falls back to static requiresReboot flags on a fully successful unparsable run | **behavior preserved** — green before *and* after |

Red-then-green confirmed: 4 failing → `43 passed (43)`.

## Verification

- `npx vitest run src/jobs/patchJobExecutor.test.ts` — 43 passed
- `npx vitest run src/services/patchRebootHandler.test.ts src/jobs/patchSchedulerWorker.test.ts src/jobs/patchSchedulerWorker.dbcontext.test.ts` — 55 passed
- `npx tsc --noEmit` (apps/api) — clean
- `npx eslint` on both changed files — clean

Server-side only; no schema, migration, or agent changes.

Closes #4228

🤖 Generated with [Claude Code](https://claude.com/claude-code)
