### PR TITLE
fix(db): patch postgres.js 3.4.9 — null nextWriteTimer/chunk on teardown so a dead socket can't poison a pool slot (#3225)

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -14,6 +14,7 @@ WORKDIR /app
 
 # Copy workspace configuration
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY patches ./patches
 COPY apps/api/package.json ./apps/api/
 COPY packages/shared/package.json ./packages/shared/
 # apps/api and the built-in @breeze/ext-workspace extension depend on these

--- a/apps/api/src/config/dockerfileWorkspaceManifests.test.ts
+++ b/apps/api/src/config/dockerfileWorkspaceManifests.test.ts
@@ -421,10 +421,11 @@ describe('Dockerfile workspace-manifest copy scope', () => {
 
   it.each(COVERED)('%s copies patches/ before its pnpm install when patchedDependencies exist', (dockerfile) => {
     // pnpm.patchedDependencies (root package.json) makes `patches/<pkg>.patch`
-    // part of dependency resolution itself: an install stage that has the
-    // lockfile but not the patch file hard-fails under `--frozen-lockfile`
-    // (ERR_PNPM_PATCH_NOT_APPLIED-class) and silently skips the patch on an
-    // unpinned install. Neither failure surfaces in a required PR job — image
+    // part of dependency resolution itself: an install stage whose build
+    // context lacks the patch file crashes with an uncaught
+    // `ENOENT ... open '.../patches/<pkg>.patch'` (from pnpm hashing the patch
+    // file) — frozen or unpinned lockfile alike, verified against the pinned
+    // pnpm@10.34.5. Loud, but it never surfaces in a required PR job — image
     // builds live in the non-blocking smoke-test job and the release
     // workflows — which is the same late-discovery profile as the manifest
     // drift above (#2661). First patched dep: postgres@3.4.9 (#3225).

--- a/apps/api/src/config/dockerfileWorkspaceManifests.test.ts
+++ b/apps/api/src/config/dockerfileWorkspaceManifests.test.ts
@@ -419,6 +419,28 @@ describe('Dockerfile workspace-manifest copy scope', () => {
     ]);
   });
 
+  it.each(COVERED)('%s copies patches/ before its pnpm install when patchedDependencies exist', (dockerfile) => {
+    // pnpm.patchedDependencies (root package.json) makes `patches/<pkg>.patch`
+    // part of dependency resolution itself: an install stage that has the
+    // lockfile but not the patch file hard-fails under `--frozen-lockfile`
+    // (ERR_PNPM_PATCH_NOT_APPLIED-class) and silently skips the patch on an
+    // unpinned install. Neither failure surfaces in a required PR job — image
+    // builds live in the non-blocking smoke-test job and the release
+    // workflows — which is the same late-discovery profile as the manifest
+    // drift above (#2661). First patched dep: postgres@3.4.9 (#3225).
+    const rootManifest = readJson(path.join(REPO_ROOT, 'package.json'));
+    const patched = ((rootManifest.pnpm ?? {}) as Record<string, unknown>).patchedDependencies;
+    const hasPatches = patched !== undefined && Object.keys(patched as object).length > 0;
+    if (!hasPatches) return;
+
+    const analysis = ANALYSES.get(dockerfile)!;
+    expect(
+      analysis.installSources.some((src) => src === '.' || src === 'patches' || src.startsWith('patches/')),
+      `${dockerfile} runs its pnpm install without copying patches/, but root package.json declares ` +
+        'pnpm.patchedDependencies. Add `COPY patches ./patches` before the `RUN pnpm install`.',
+    ).toBe(true);
+  });
+
   it.each(COVERED)('%s copies the source of every workspace package it installs', (dockerfile) => {
     const analysis = ANALYSES.get(dockerfile)!;
     const missing = [...analysis.required]

--- a/apps/api/src/db/dbPoolHealthMonitor.ts
+++ b/apps/api/src/db/dbPoolHealthMonitor.ts
@@ -1,18 +1,23 @@
 /**
  * Pool-health watchdog for the postgres.js connection-poisoning failure (#3214).
  *
- * THE FAILURE IT WATCHES FOR. postgres.js 3.4.9 leaves a pooled connection
- * permanently unable to flush a deferred write once its socket dies with one
- * buffered — see `db/postgresJsPoolPoisoning.test.ts`, which reproduces the
- * defect deterministically and cites the exact upstream lines. A poisoned slot
- * then reconnects forever, timing out at `connect_timeout` every time. Slots are
- * lost one at a time (in the production incident: 35 configured, 9 live after a
- * few hours) and only an API restart recovers them.
+ * THE FAILURE IT WATCHES FOR. Unpatched postgres.js 3.4.9 leaves a pooled
+ * connection permanently unable to flush a deferred write once its socket dies
+ * with one buffered. A poisoned slot then reconnects forever, timing out at
+ * `connect_timeout` every time. Slots are lost one at a time (in the production
+ * incident: 35 configured, 9 live after a few hours) and only an API restart
+ * recovers them.
  *
- * WHY A WATCHDOG AND NOT A FIX. The broken state lives inside a closure in the
- * driver; nothing outside the driver can reach it. This module cannot repair the
- * pool. What it CAN do is collapse the diagnosis — which took hours of manual
- * work during the incident — into a single automatic verdict.
+ * THAT DEFECT IS NOW REPAIRED by `patches/postgres@3.4.9.patch` (#3225), and
+ * `db/postgresJsPoolPoisoning.test.ts` asserts the repair holds. This watchdog
+ * predates the patch and stays as defense-in-depth: it detects pool
+ * degradation from ANY cause — including the patch silently ceasing to apply
+ * (e.g. a postgres version bump that drops `patchedDependencies`), which is
+ * exactly the failure the test's message warns about. If its `pool-degraded`
+ * verdict ever fires again, check the patch is still applying before assuming
+ * a new driver bug. This module cannot repair the pool; what it does is
+ * collapse the diagnosis — which took hours of manual work during the
+ * 2026-08-07 incident — into a single automatic verdict.
  *
  * THE DIAGNOSTIC TRICK. A sustained CONNECT_TIMEOUT rate on its own is
  * ambiguous: it looks identical whether the database is unreachable or the pool

--- a/apps/api/src/db/postgresJsPoolPoisoning.test.ts
+++ b/apps/api/src/db/postgresJsPoolPoisoning.test.ts
@@ -3,7 +3,8 @@ import postgres from 'postgres';
 import { describe, expect, it } from 'vitest';
 
 /**
- * KNOWN-DEFECT PIN for the postgres.js pool-poisoning bug behind #3214.
+ * Regression guard for the postgres.js pool-poisoning bug behind #3214,
+ * repaired by the vendored patch tracked in #3225.
  *
  * ---------------------------------------------------------------------------
  * THE DEFECT (postgres.js 3.4.9, `src/connection.js`)
@@ -50,21 +51,26 @@ import { describe, expect, it } from 'vitest';
  * process restart (fresh closures).
  *
  * ---------------------------------------------------------------------------
- * WHY THIS TEST ASSERTS THE BUG RATHER THAN THE FIX
+ * THE REPAIR THIS TEST NOW GUARDS (#3225)
  * ---------------------------------------------------------------------------
- * postgres.js 3.4.9 is the LATEST published release — there is no version to
- * upgrade to, and the broken state lives inside a closure that nothing outside
- * the driver can reach. The repo therefore ships a WATCHDOG
- * (`db/dbPoolHealthMonitor.ts`), not a repair.
+ * `patches/postgres@3.4.9.patch` (pnpm patchedDependencies) adds
+ * `chunk = nextWriteTimer = null` after the `clearImmediate` in BOTH teardown
+ * paths — `terminate()` and `closed()` — in all three shipped builds
+ * (src/, cjs/src/, cf/src/). With the patch applied, a reconnect after a
+ * mid-write socket death schedules its flush normally and the handshake bytes
+ * reach the wire.
  *
- * This test pins the defect so that:
- *   1. the mechanism is documented executably rather than in prose that rots;
- *   2. there is a dependency-free reproduction to attach to an upstream report;
- *   3. the day the driver is fixed (or patched locally), this test FAILS and
- *      says so — which is the signal to drop the watchdog and its metrics.
+ * This file originally pinned the DEFECT (so the mechanism was documented
+ * executably and reproducible for an upstream report). Now that the patch is
+ * vendored, the poisoning test asserts the FIX instead: if it goes red, the
+ * patch has stopped applying — most likely a `postgres` version bump that
+ * dropped `patchedDependencies` without the new release containing the
+ * upstream repair. Re-verify src/connection.js teardown before removing the
+ * patch or weakening this test.
  *
- * A test that goes red on an upstream *improvement* is deliberate. Read the
- * failure message before "fixing" it.
+ * The `db/dbPoolHealthMonitor.ts` watchdog predates the patch and stays as
+ * defense-in-depth: it detects pool degradation from ANY cause, not just this
+ * one.
  */
 
 interface FakeSocket extends EventEmitter {
@@ -195,11 +201,13 @@ describe('postgres.js deferred-write pool poisoning (#3214)', () => {
     ).toBeGreaterThan(0);
   }, 15_000);
 
-  it('a socket that dies with a buffered write leaves the connection permanently unable to flush', async () => {
+  it('a socket that dies with a buffered write can still flush after reconnect (patched)', async () => {
     // Attempt 1's socket is closed while the StartupMessage flush is still
-    // queued. `closed()` cancels the immediate but leaves `nextWriteTimer`
-    // non-null, so attempt 2 — a full reconnect with a brand-new socket —
-    // schedules no flush at all and writes zero bytes.
+    // queued. Unpatched 3.4.9 leaves `nextWriteTimer` non-null in `closed()`,
+    // so attempt 2 — a full reconnect with a brand-new socket — schedules no
+    // flush and writes zero bytes (the #3214 pool poisoning). With
+    // patches/postgres@3.4.9.patch applied, both teardown paths null the timer
+    // and drop the stale chunk, so the reconnect handshake reaches the wire.
     const written = await runHandshakeAttempts({
       killAttempts: new Set([1]),
       settleMs: 1_500,
@@ -208,17 +216,17 @@ describe('postgres.js deferred-write pool poisoning (#3214)', () => {
     expect(
       written.length,
       'expected the driver to reconnect after the socket closed. If it no longer '
-        + 'reconnects at all, that is also an upstream behaviour change — re-read this '
-        + 'pin against src/connection.js rather than adjusting the harness.',
+        + 'reconnects at all, that is an upstream behaviour change — re-read this '
+        + 'test against src/connection.js rather than adjusting the harness.',
     ).toBeGreaterThanOrEqual(2);
 
     expect(
       written[1],
-      'postgres.js appears to FLUSH after a socket death with a buffered write — the '
-        + 'deferred-write defect behind #3214 looks fixed. Confirm against '
-        + 'src/connection.js (does closed()/terminate() now reset nextWriteTimer and '
-        + 'chunk to null?), then delete this pin AND the db/dbPoolHealthMonitor.ts '
-        + 'watchdog it exists to justify.',
-    ).toBe(0);
+      'the reconnect after a mid-write socket death wrote ZERO bytes — the #3214 '
+        + 'pool poisoning is back, meaning patches/postgres@3.4.9.patch is no longer '
+        + 'applying (a postgres version bump that dropped pnpm patchedDependencies?). '
+        + 'Re-apply the patch against the new version, or verify upstream now nulls '
+        + 'nextWriteTimer and chunk in terminate()/closed() before removing it.',
+    ).toBeGreaterThan(0);
   }, 15_000);
 });

--- a/apps/api/src/db/postgresJsPoolPoisoning.test.ts
+++ b/apps/api/src/db/postgresJsPoolPoisoning.test.ts
@@ -1,6 +1,22 @@
 import { EventEmitter } from 'node:events';
-import postgres from 'postgres';
+import { createRequire } from 'node:module';
+import postgresEsm from 'postgres';
 import { describe, expect, it } from 'vitest';
+
+// The patch lands in THREE independent hunks (src/, cjs/src/, cf/src/), and the
+// two that matter here resolve to different files: this test file's ESM import
+// follows the package's `import` condition to `src/index.js`, while production
+// (`dist/index.cjs`, tsup externalizes postgres) `require()`s the `default`
+// condition — `cjs/src/index.js`. Exercising only one build would stay green
+// while the other's hunk silently stopped applying (empirically confirmed:
+// reverting only the cjs hunk left the ESM-only suite passing). So every test
+// below runs against BOTH entries.
+const postgresCjs = createRequire(import.meta.url)('postgres') as typeof postgresEsm;
+
+const DRIVER_BUILDS = [
+  ['esm (src/ — what this test file imports)', postgresEsm],
+  ['cjs (cjs/src/ — what production dist/index.cjs loads)', postgresCjs],
+] as const;
 
 /**
  * Regression guard for the postgres.js pool-poisoning bug behind #3214,
@@ -113,6 +129,7 @@ function createFakeSocket(): FakeSocket {
  * the race — no timing luck involved.
  */
 async function runHandshakeAttempts(options: {
+  postgres: typeof postgresEsm;
   killAttempts: ReadonlySet<number>;
   settleMs: number;
   /**
@@ -123,6 +140,7 @@ async function runHandshakeAttempts(options: {
    */
   killDelayMs?: number;
 }): Promise<number[]> {
+  const postgres = options.postgres;
   const sockets: FakeSocket[] = [];
 
   // `socket` is a genuine postgres.js option — `parseOptions` copies it
@@ -166,11 +184,12 @@ async function runHandshakeAttempts(options: {
   return sockets.map((s) => s.bytesWritten);
 }
 
-describe('postgres.js deferred-write pool poisoning (#3214)', () => {
+describe.each(DRIVER_BUILDS)('postgres.js deferred-write pool poisoning (#3214) — %s', (_buildName, postgres) => {
   it('control: an undisturbed connection flushes its StartupMessage', async () => {
     // Proves the harness itself works — without this, the poisoning assertion
     // below could pass simply because the fake socket never receives anything.
     const written = await runHandshakeAttempts({
+      postgres,
       killAttempts: new Set(),
       settleMs: 250,
     });
@@ -187,6 +206,7 @@ describe('postgres.js deferred-write pool poisoning (#3214)', () => {
     // completes its handshake write normally. That isolates the buffered write
     // as the actual cause, which is the claim an upstream report has to make.
     const written = await runHandshakeAttempts({
+      postgres,
       killAttempts: new Set([1]),
       killDelayMs: 60,
       settleMs: 1_500,
@@ -209,6 +229,7 @@ describe('postgres.js deferred-write pool poisoning (#3214)', () => {
     // patches/postgres@3.4.9.patch applied, both teardown paths null the timer
     // and drop the stale chunk, so the reconnect handshake reaches the wire.
     const written = await runHandshakeAttempts({
+      postgres,
       killAttempts: new Set([1]),
       settleMs: 1_500,
     });

--- a/apps/m365-communications-executor/Dockerfile
+++ b/apps/m365-communications-executor/Dockerfile
@@ -6,6 +6,7 @@ RUN npm install -g pnpm@10.34.5
 WORKDIR /app
 
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml tsconfig.json ./
+COPY patches ./patches
 COPY apps/m365-communications-executor/package.json ./apps/m365-communications-executor/
 COPY packages/shared/package.json ./packages/shared/
 RUN pnpm install --frozen-lockfile --filter=@breeze/m365-communications-executor...

--- a/apps/m365-graph-actions-executor/Dockerfile
+++ b/apps/m365-graph-actions-executor/Dockerfile
@@ -6,6 +6,7 @@ RUN npm install -g pnpm@10.34.5
 WORKDIR /app
 
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml tsconfig.json ./
+COPY patches ./patches
 COPY apps/m365-graph-actions-executor/package.json ./apps/m365-graph-actions-executor/
 COPY packages/shared/package.json ./packages/shared/
 RUN pnpm install --frozen-lockfile --filter=@breeze/m365-graph-actions-executor...

--- a/apps/m365-graph-read-executor/Dockerfile
+++ b/apps/m365-graph-read-executor/Dockerfile
@@ -6,6 +6,7 @@ RUN npm install -g pnpm@10.34.5
 WORKDIR /app
 
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml tsconfig.json ./
+COPY patches ./patches
 COPY apps/m365-graph-read-executor/package.json ./apps/m365-graph-read-executor/
 COPY packages/shared/package.json ./packages/shared/
 RUN pnpm install --frozen-lockfile --filter=@breeze/m365-graph-read-executor...

--- a/apps/portal/Dockerfile
+++ b/apps/portal/Dockerfile
@@ -20,6 +20,7 @@ WORKDIR /app
 # shared manifest must be present for lockfile workspace resolution here and the
 # shared source must be copied into the builder stage below — mirrors apps/web/Dockerfile.
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY patches ./patches
 COPY apps/portal/package.json ./apps/portal/
 COPY packages/shared/package.json ./packages/shared/
 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -23,6 +23,7 @@ WORKDIR /app
 # (v0.98.0 shipped without a web image this way: @breeze/extension-web-sdk was
 # absent here, so its `zod` never installed and Rolldown failed to resolve it.)
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY patches ./patches
 COPY apps/web/package.json ./apps/web/
 COPY packages/shared/package.json ./packages/shared/
 COPY packages/extension-web-sdk/package.json ./packages/extension-web-sdk/

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -4,6 +4,7 @@ RUN npm install -g pnpm@10.34.5
 FROM base AS deps
 WORKDIR /app
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml* ./
+COPY patches ./patches
 COPY apps/api/package.json ./apps/api/
 COPY packages/shared/package.json ./packages/shared/
 COPY packages/extension-sdk/package.json ./packages/extension-sdk/

--- a/docker/Dockerfile.api.dev
+++ b/docker/Dockerfile.api.dev
@@ -9,6 +9,7 @@ WORKDIR /app
 
 # Copy workspace configuration
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml* ./
+COPY patches ./patches
 COPY turbo.json tsconfig.json ./
 
 # Copy package.json files for dependency installation

--- a/docker/Dockerfile.portal.dev
+++ b/docker/Dockerfile.portal.dev
@@ -6,6 +6,7 @@ RUN npm install -g pnpm@10.34.5
 WORKDIR /app
 
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml* ./
+COPY patches ./patches
 COPY turbo.json tsconfig.json ./
 
 COPY apps/portal/package.json ./apps/portal/

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -4,6 +4,7 @@ RUN npm install -g pnpm@10.34.5
 FROM base AS deps
 WORKDIR /app
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml* ./
+COPY patches ./patches
 COPY apps/web/package.json ./apps/web/
 COPY packages/shared/package.json ./packages/shared/
 COPY packages/extension-web-sdk/package.json ./packages/extension-web-sdk/

--- a/docker/Dockerfile.web.dev
+++ b/docker/Dockerfile.web.dev
@@ -9,6 +9,7 @@ WORKDIR /app
 
 # Copy workspace configuration
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml* ./
+COPY patches ./patches
 COPY turbo.json tsconfig.json ./
 
 # Copy package.json files for dependency installation

--- a/package.json
+++ b/package.json
@@ -102,7 +102,10 @@
       "@grpc/grpc-js@<1.14.4": ">=1.14.4",
       "js-yaml@>=4.0.0 <4.3.1": ">=4.3.1 <5.0.0",
       "nanoid@<3.3.18": ">=3.3.18 <4.0.0",
-    "deepmerge-ts@<8.0.0": ">=8.0.1 <9.0.0"
+      "deepmerge-ts@<8.0.0": ">=8.0.1 <9.0.0"
+    },
+    "patchedDependencies": {
+      "postgres@3.4.9": "patches/postgres@3.4.9.patch"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     },
     "patchedDependencies": {
       "postgres@3.4.9": "patches/postgres@3.4.9.patch"
-    }
+    },
+    "allowUnusedPatches": true
   }
 }

--- a/patches/postgres@3.4.9.patch
+++ b/patches/postgres@3.4.9.patch
@@ -1,0 +1,60 @@
+diff --git a/cf/src/connection.js b/cf/src/connection.js
+index 8e79170aeb13efe8c3c77ccede0cd3a115b5e1b5..e8ac8871964302ecf70c4127baf074f67f490a30 100644
+--- a/cf/src/connection.js
++++ b/cf/src/connection.js
+@@ -427,6 +427,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
+       error(Errors.connection('CONNECTION_DESTROYED', options))
+ 
+     clearImmediate(nextWriteTimer)
++    chunk = nextWriteTimer = null
+     if (socket) {
+       socket.removeListener('data', data)
+       socket.removeListener('connect', connected)
+@@ -440,6 +441,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
+     remaining = 0
+     incomings = null
+     clearImmediate(nextWriteTimer)
++    chunk = nextWriteTimer = null
+     socket.removeListener('data', data)
+     socket.removeListener('connect', connected)
+     idleTimer.cancel()
+diff --git a/cjs/src/connection.js b/cjs/src/connection.js
+index 07f6716702ac888215c86ad6e0071aaf55ae519c..16536624d7075b7707f2c72c321f37a29af18e4d 100644
+--- a/cjs/src/connection.js
++++ b/cjs/src/connection.js
+@@ -425,6 +425,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
+       error(Errors.connection('CONNECTION_DESTROYED', options))
+ 
+     clearImmediate(nextWriteTimer)
++    chunk = nextWriteTimer = null
+     if (socket) {
+       socket.removeListener('data', data)
+       socket.removeListener('connect', connected)
+@@ -438,6 +439,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
+     remaining = 0
+     incomings = null
+     clearImmediate(nextWriteTimer)
++    chunk = nextWriteTimer = null
+     socket.removeListener('data', data)
+     socket.removeListener('connect', connected)
+     idleTimer.cancel()
+diff --git a/src/connection.js b/src/connection.js
+index 1b1cccde43b4570d5d071d6ffaab2669b3c2065a..54469592072a071572641d64ddb17779988f697f 100644
+--- a/src/connection.js
++++ b/src/connection.js
+@@ -425,6 +425,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
+       error(Errors.connection('CONNECTION_DESTROYED', options))
+ 
+     clearImmediate(nextWriteTimer)
++    chunk = nextWriteTimer = null
+     if (socket) {
+       socket.removeListener('data', data)
+       socket.removeListener('connect', connected)
+@@ -438,6 +439,7 @@ function Connection(options, queues = {}, { onopen = noop, onend = noop, onclose
+     remaining = 0
+     incomings = null
+     clearImmediate(nextWriteTimer)
++    chunk = nextWriteTimer = null
+     socket.removeListener('data', data)
+     socket.removeListener('connect', connected)
+     idleTimer.cancel()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17647,7 +17647,7 @@ snapshots:
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
   anynum@1.0.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,11 @@ overrides:
   nanoid@<3.3.18: '>=3.3.18 <4.0.0'
   deepmerge-ts@<8.0.0: '>=8.0.1 <9.0.0'
 
+patchedDependencies:
+  postgres@3.4.9:
+    hash: d73fec0fc4be4034390ba6d0f8ee47d8b0a2e1b83c199be823c4a8bbd0ab0e1d
+    path: patches/postgres@3.4.9.patch
+
 importers:
 
   .:
@@ -162,7 +167,7 @@ importers:
         version: 5.81.2
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(gel@2.2.0)(pg@8.22.0)(postgres@3.4.9)
+        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(gel@2.2.0)(pg@8.22.0)(postgres@3.4.9(patch_hash=d73fec0fc4be4034390ba6d0f8ee47d8b0a2e1b83c199be823c4a8bbd0ab0e1d))
       fast-xml-parser:
         specifier: '>=5.10.1'
         version: 5.10.1
@@ -216,7 +221,7 @@ importers:
         version: 8.22.0
       postgres:
         specifier: ^3.4.9
-        version: 3.4.9
+        version: 3.4.9(patch_hash=d73fec0fc4be4034390ba6d0f8ee47d8b0a2e1b83c199be823c4a8bbd0ab0e1d)
       prom-client:
         specifier: ^15.1.3
         version: 15.1.3
@@ -475,7 +480,7 @@ importers:
         version: 6.2.4
       postgres:
         specifier: ^3.4.9
-        version: 3.4.9
+        version: 3.4.9(patch_hash=d73fec0fc4be4034390ba6d0f8ee47d8b0a2e1b83c199be823c4a8bbd0ab0e1d)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -1196,7 +1201,7 @@ importers:
         version: link:../../packages/extension-web-sdk
       drizzle-orm:
         specifier: 0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(gel@2.2.0)(pg@8.22.0)(postgres@3.4.9)
+        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(gel@2.2.0)(pg@8.22.0)(postgres@3.4.9(patch_hash=d73fec0fc4be4034390ba6d0f8ee47d8b0a2e1b83c199be823c4a8bbd0ab0e1d))
       hono:
         specifier: 4.13.3
         version: 4.13.3
@@ -1227,7 +1232,7 @@ importers:
         version: 20.11.1
       postgres:
         specifier: 3.4.9
-        version: 3.4.9
+        version: 3.4.9(patch_hash=d73fec0fc4be4034390ba6d0f8ee47d8b0a2e1b83c199be823c4a8bbd0ab0e1d)
       tsup:
         specifier: 8.5.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.12)(typescript@5.9.3)(yaml@2.9.0)
@@ -18923,13 +18928,13 @@ snapshots:
       esbuild: 0.28.1
       tsx: 4.23.12
 
-  drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(gel@2.2.0)(pg@8.22.0)(postgres@3.4.9):
+  drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(gel@2.2.0)(pg@8.22.0)(postgres@3.4.9(patch_hash=d73fec0fc4be4034390ba6d0f8ee47d8b0a2e1b83c199be823c4a8bbd0ab0e1d)):
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/pg': 8.21.0
       gel: 2.2.0
       pg: 8.22.0
-      postgres: 3.4.9
+      postgres: 3.4.9(patch_hash=d73fec0fc4be4034390ba6d0f8ee47d8b0a2e1b83c199be823c4a8bbd0ab0e1d)
 
   dset@3.1.4: {}
 
@@ -22584,7 +22589,7 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
-  postgres@3.4.9: {}
+  postgres@3.4.9(patch_hash=d73fec0fc4be4034390ba6d0f8ee47d8b0a2e1b83c199be823c4a8bbd0ab0e1d): {}
 
   posthog-react-native@4.61.2(bb55ae04d66ffa4cad0f4c81ef35aa5c):
     dependencies:

--- a/scripts/security/check-customer-pii.sh
+++ b/scripts/security/check-customer-pii.sh
@@ -28,7 +28,7 @@ cd "$(dirname "$0")/../.."
 # reserved/placeholder TLDs + infra families, then exact known-safe domains).
 # "domains" that are really file extensions (e.g. an icon path "128x128@2x.png"
 # parses as foo@2x.png) — never customer data.
-ALLOW_RE='\.(png|ico|svg|jpe?g|webp|gif|html?|css|js|jsx|ts|tsx|json|md|sh|ya?ml|txt|woff2?)$'
+ALLOW_RE='\.(png|ico|svg|jpe?g|webp|gif|html?|css|js|jsx|ts|tsx|json|md|sh|ya?ml|txt|woff2?|patch)$'
 ALLOW_RE="$ALLOW_RE"'|\.(test|example|local|internal|invalid|localhost)$'
 ALLOW_RE="$ALLOW_RE"'|(^|\.)example\.(com|net|org)$'
 ALLOW_RE="$ALLOW_RE"'|(^|\.)sentry\.io$'


### PR DESCRIPTION
Fixes #3225. Closes the loop on #3214.

## Why now
The CONNECT_TIMEOUT storm recurred in prod (US) tonight, 2026-08-30 20:20-21:47Z on 0.108.0 — ~66/min against a demonstrably healthy DB, contained only by an api restart ([#3225 comment](https://github.com/LanternOps/breeze/issues/3225#issuecomment-5471464540)). Detection (#3224) works; this ships the repair.

## What
**First patched dependency in the repo**: `patches/postgres@3.4.9.patch` via pnpm `patchedDependencies`. Two lines per teardown path — `terminate()` and `closed()` get `chunk = nextWriteTimer = null` after their `clearImmediate`, in all three shipped builds (`src/`, `cjs/src/`, `cf/src/`; prod runs cjs, vitest runs src). This is exactly the fix shape #3225 specifies: `nextWrite()` was the only reset point, so a socket death with a buffered write left the slot unable to ever schedule a flush again.

## Verification (red-first)
- Baseline: the known-defect pin `postgresJsPoolPoisoning.test.ts` passed (3/3) = bug present.
- Patch applied → pin went red exactly as its failure message predicts: the poisoned reconnect wrote **87 bytes instead of 0**.
- Pin rewritten to assert the fix; it now fails loudly if a future `postgres` bump drops `patchedDependencies` without upstream containing the repair. Controls (positive + negative) unchanged.
- `vitest run src/db`: 1637 passed; only failure is `offsetPaginationOrdering.test.ts` timing out its 5s budget on a loaded machine (repo-scan test, unrelated — verified in isolation, no source it scans is touched here).
- Dockerfile-manifest + compose-bind-mount guards green (69/69).

## Dockerfile sweep (the non-obvious part)
Every workspace image build runs `pnpm install --frozen-lockfile` from a stage that only COPYs manifests — the lockfile now references `patches/`, so **install fails without it**. Added `COPY patches ./patches` to all 11 workspace Dockerfiles (api/web/portal prod, 3 m365 executors, docker/ prod+dev variants).

## Deliberately kept
`db/dbPoolHealthMonitor.ts` watchdog stays as defense-in-depth — it detects pool degradation from any cause, not just this one. The pin's original instruction to delete it on fix was written when the only possible fix was upstream.

## Risk
DB driver layer, so blast radius is high; mitigations: the change is 6 identical lines confined to teardown paths, the deterministic repro proves the exact mechanism, and the pin guards regression both ways. Suggest letting this ride a normal release (no hotfix) and watching BREEZE-1C/1W stay quiet post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bn3WFTjEBmK3nPqmUdQinb