### PR TITLE
feat: Ticket push categories — API (#3206 W07-A)

### DIFF
--- a/apps/api/migrations/2026-09-25-ticket-push-preferences.sql
+++ b/apps/api/migrations/2026-09-25-ticket-push-preferences.sql
@@ -1,0 +1,40 @@
+-- apps/api/migrations/2026-09-25-ticket-push-preferences.sql
+-- W07 (#3901): per-user mobile push preferences for ticket events.
+-- Shape 6 (user-scoped). No org_id/partner_id by design: a personal preference,
+-- same category as mobile_devices — NOT a Partner-Wide-First config table.
+-- Consequently it appears in NO cascade list (no org_id, no device_id) and in
+-- no export-policy entry; USER_ID_SCOPED_TABLES is the only registration.
+-- Idempotent; no inner BEGIN/COMMIT (autoMigrate wraps each file).
+
+DO $$ BEGIN
+  CREATE TYPE ticket_sla_push_scope AS ENUM ('off', 'owned', 'any');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE TABLE IF NOT EXISTS ticket_push_preferences (
+  user_id          uuid PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+  assigned_enabled boolean NOT NULL DEFAULT true,
+  sla_scope        ticket_sla_push_scope NOT NULL DEFAULT 'owned',
+  created_at       timestamptz NOT NULL DEFAULT now(),
+  updated_at       timestamptz NOT NULL DEFAULT now()
+);
+
+-- The 'any' fan-out query (services/ticketPush.ts) filters on sla_scope = 'any'
+-- then joins users on partner_id; keep the opted-in set cheap to enumerate.
+CREATE INDEX IF NOT EXISTS ticket_push_preferences_sla_any_idx
+  ON ticket_push_preferences (user_id) WHERE sla_scope = 'any';
+
+ALTER TABLE ticket_push_preferences ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ticket_push_preferences FORCE ROW LEVEL SECURITY;
+
+-- Policy spelling mirrors user_notifications_user_isolation
+-- (2026-09-04-ai-agent-notifications.sql). The `system` branch is required:
+-- the ticket notify worker reads this table inside withSystemDbAccessContext.
+-- No partner/org admin branch is ORed in — nobody but the user and system
+-- jobs needs a push preference.
+DROP POLICY IF EXISTS ticket_push_preferences_user_isolation ON ticket_push_preferences;
+CREATE POLICY ticket_push_preferences_user_isolation ON ticket_push_preferences
+  FOR ALL
+  USING      (public.breeze_current_scope() = 'system' OR user_id = public.breeze_current_user_id())
+  WITH CHECK (public.breeze_current_scope() = 'system' OR user_id = public.breeze_current_user_id());
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON ticket_push_preferences TO breeze_app;

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -660,6 +660,11 @@ const USER_ID_SCOPED_TABLES: ReadonlySet<string> = new Set<string>([
   'user_sso_identities',
   'push_notifications',
   'mobile_devices',
+  // ticket_push_preferences: W07 (#3901) per-user ticket push preferences.
+  // Pure Shape 6 — user_id PK, no org/partner axis. Behavioural proof is
+  // ticketPushPreferencesRls.integration.test.ts; this entry only pins that
+  // the policy references breeze_current_user_id.
+  'ticket_push_preferences',
   // ticket_comments: Shape 6 on the author axis, PLUS an extra permissive
   // SELECT policy (breeze_ticket_parent_select, 2026-06-10-a migration)
   // that ORs in visibility when the parent ticket is org-accessible —

--- a/apps/api/src/__tests__/integration/ticketPushFanout.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ticketPushFanout.integration.test.ts
@@ -276,6 +276,52 @@ describe('ticket push fan-out — tenant boundary', () => {
     expect(allTruncated).toBe(false);
   });
 
+  /**
+   * REGRESSION (#4281 review): `getUserPushTargets`' device filter
+   * (notifications_enabled = true AND status = 'active') was pinned by NOTHING
+   * — the unit suite's chainable db mock ignores the WHERE and every fixture
+   * here took the column defaults. Tokens are deliberately left populated on
+   * the blocked/opted-out rows so this pins the QUERY, not the revoke route's
+   * token clearing.
+   */
+  runDb('a blocked device and a notifications-off device never receive a ticket push', async () => {
+    const fx = await seed();
+    await withSystemDbAccessContext(async () => {
+      await db.insert(mobileDevices).values({
+        userId: fx.owner.id,
+        deviceId: uniq('dev-blocked'),
+        platform: 'ios',
+        apnsToken: `tok-blocked-${fx.owner.id}`,
+        status: 'blocked',
+      });
+      await db.insert(mobileDevices).values({
+        userId: fx.owner.id,
+        deviceId: uniq('dev-muted'),
+        platform: 'ios',
+        apnsToken: `tok-muted-${fx.owner.id}`,
+        notificationsEnabled: false,
+      });
+    });
+
+    await handleTicketEvent({
+      type: 'ticket.assigned',
+      ticketId: fx.ticket.id,
+      orgId: fx.orgA.id,
+      partnerId: fx.p1.id,
+      actorUserId: fx.anyB.id,
+      eventId: 'e-devfilter',
+      payload: { assigneeId: fx.owner.id },
+    });
+
+    const calls = dispatch.mock.calls as unknown as Array<[{ token: string }[]]>;
+    const sent = calls.flatMap((c) => c[0].map((t) => t.token));
+    // Positive control: the active, notifications-enabled handset DID receive it,
+    // so an empty `sent` can never read as "the filter works".
+    expect(sent).toContain(`tok-${fx.owner.id}`);
+    expect(sent).not.toContain(`tok-blocked-${fx.owner.id}`);
+    expect(sent).not.toContain(`tok-muted-${fx.owner.id}`);
+  });
+
   runDb('the owner is notified from the assignee branch, never via the capped list', async () => {
     const fx = await seed();
     await handleTicketEvent({

--- a/apps/api/src/__tests__/integration/ticketPushFanout.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ticketPushFanout.integration.test.ts
@@ -1,0 +1,275 @@
+/**
+ * W07 (#3901): the push fan-out's tenant boundary, proven against real Postgres.
+ *
+ * The worker runs inside withSystemDbAccessContext (RLS bypassed), so isolation
+ * here is entirely app-layer: the partner filter compiled into
+ * anySlaSubscribersQuery plus the per-user permission re-check in
+ * isAuthorisedForTicket. Push transport is mocked (no APNs in CI); the durable
+ * observable is user_notifications.
+ *
+ * Prerequisites: a live test database (`pnpm test-stack up`, or
+ * docker compose -f docker-compose.test.yml up -d).
+ */
+import './setup';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { eq } from 'drizzle-orm';
+
+vi.mock('../../services/apns', async (orig) => ({
+  ...(await orig<typeof import('../../services/apns')>()),
+  isApnsConfigured: () => true,
+}));
+// vi.hoisted, not a plain const: vi.mock factories are hoisted above every
+// top-level binding, so a bare `const dispatch` here dies with
+// "Cannot access 'dispatch' before initialization" the moment the worker
+// imports expoPush.
+const dispatch = vi.hoisted(() => vi.fn(async () => ({ tokensFound: 1, dispatched: 1, errors: 0 })));
+vi.mock('../../services/expoPush', async (orig) => ({
+  ...(await orig<typeof import('../../services/expoPush')>()),
+  dispatchPushToTokens: dispatch,
+}));
+vi.mock('../../services/email', () => ({ getEmailService: () => null }));
+
+import { db, withSystemDbAccessContext } from '../../db';
+import { mobileDevices, ticketPushPreferences, tickets, userNotifications } from '../../db/schema';
+import { handleTicketEvent } from '../../jobs/ticketNotifyWorker';
+import { ANY_SUBSCRIBER_CAP, listAnySlaSubscribers } from '../../services/ticketPush';
+import {
+  assignUserToOrganization,
+  assignUserToPartner,
+  createOrganization,
+  createPartner,
+  createRole,
+  createUser,
+  grantRolePermissions,
+} from './db-utils';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+let seq = 0;
+const uniq = (p: string) => `${p}-${Date.now()}-${seq++}`;
+
+/**
+ * A user who actually passes the fan-out gate: a membership AND a role that
+ * really holds `tickets:read` through the permissions catalog that
+ * getUserPermissions resolves at runtime.
+ *
+ * `createUser({ withMembership: true })` is NOT enough — the role it builds has
+ * zero permissions (db-utils createRole only inserts a `roles` row); grants live
+ * in the separate grantRolePermissions. A withMembership user is therefore
+ * filtered out of every fan-out, and the "obvious fix" (relaxing the expectation
+ * to `[]`) would be a vacuously green test. Pass `perms: []` to build the
+ * negative control: identical shape, no tickets:read.
+ */
+async function makeUser(opts: {
+  partnerId: string;
+  orgId?: string | null;
+  perms?: Array<{ resource: string; action: string }>;
+  orgAccess?: 'all' | 'selected' | 'none';
+}) {
+  const perms = opts.perms ?? [{ resource: 'tickets', action: 'read' }];
+  const user = await createUser({
+    partnerId: opts.partnerId,
+    orgId: opts.orgId ?? null,
+    email: `${uniq('fanout')}@example.com`,
+  });
+  if (opts.orgId) {
+    const role = await createRole({ scope: 'organization', orgId: opts.orgId, partnerId: opts.partnerId });
+    if (perms.length) await grantRolePermissions(role.id, perms);
+    await assignUserToOrganization(user.id, opts.orgId, role.id);
+  } else {
+    const role = await createRole({ scope: 'partner', partnerId: opts.partnerId });
+    if (perms.length) await grantRolePermissions(role.id, perms);
+    await assignUserToPartner(user.id, opts.partnerId, role.id, opts.orgAccess ?? 'all');
+  }
+  return user;
+}
+
+async function seed() {
+  const p1 = await createPartner();
+  const p2 = await createPartner();
+  const orgA = await createOrganization({ partnerId: p1.id });
+  const orgB = await createOrganization({ partnerId: p1.id });
+
+  // Partner-wide, tickets:read, orgAccess 'all' — the ticket's assignee.
+  const owner = await makeUser({ partnerId: p1.id });
+  // Org-scoped to orgA (the ticket's org) — must receive.
+  const anyA = await makeUser({ partnerId: p1.id, orgId: orgA.id });
+  // Org-scoped to orgB — must NOT receive (canAccessOrg false).
+  const anyB = await makeUser({ partnerId: p1.id, orgId: orgB.id });
+  // Another partner entirely — must NOT receive (SQL partner filter).
+  const foreign = await makeUser({ partnerId: p2.id });
+  // NEGATIVE CONTROL: right partner, opted into 'any', but NO tickets:read.
+  // Without this user, a run where the permission grant silently failed would
+  // still look "correct" — everyone excluded, for the wrong reason.
+  const noPerm = await makeUser({ partnerId: p1.id, perms: [] });
+
+  await withSystemDbAccessContext(async () => {
+    for (const u of [anyA, anyB, foreign, noPerm]) {
+      await db.insert(ticketPushPreferences).values({ userId: u.id, slaScope: 'any' });
+      await db.insert(mobileDevices).values({
+        userId: u.id,
+        deviceId: uniq('dev'),
+        platform: 'ios',
+        apnsToken: `tok-${u.id}`,
+      });
+    }
+    await db.insert(mobileDevices).values({
+      userId: owner.id,
+      deviceId: uniq('dev'),
+      platform: 'ios',
+      apnsToken: `tok-${owner.id}`,
+    });
+  });
+
+  // ticket_number is NOT NULL with no default; status is the ticket_status enum.
+  // No `as never` cast — that cast is exactly what would hide a missing column.
+  const [ticket] = await withSystemDbAccessContext(() =>
+    db
+      .insert(tickets)
+      .values({
+        orgId: orgA.id,
+        partnerId: p1.id,
+        ticketNumber: uniq('TKT'),
+        internalNumber: 'T-2026-0042',
+        subject: 'Printer',
+        status: 'open',
+        assignedTo: owner.id,
+      })
+      .returning());
+
+  return { p1, p2, orgA, orgB, owner, anyA, anyB, foreign, noPerm, ticket: ticket! };
+}
+
+const rowsFor = (ticketId: string) =>
+  withSystemDbAccessContext(() =>
+    db
+      .select({ userId: userNotifications.userId, dedupeKey: userNotifications.dedupeKey })
+      .from(userNotifications)
+      .where(eq(userNotifications.link, `/tickets#${ticketId}`)));
+
+describe('ticket push fan-out — tenant boundary', () => {
+  beforeEach(() => dispatch.mockClear());
+
+  /**
+   * The SQL partner filter, isolated.
+   *
+   * Mutation-tested: deleting `eq(users.partnerId, partnerId)` from
+   * anySlaSubscribersQuery leaves the end-to-end fan-out tests below GREEN,
+   * because two later layers (assertSamePartner, then isAuthorisedForTicket —
+   * which cannot resolve permissions for a user with no membership in this
+   * partner) independently exclude the foreign subscriber. Defence in depth is
+   * the right design, but it means no end-to-end assertion pins the SQL clause.
+   * This test does: it calls the discovery query directly, so dropping the
+   * filter turns it red on its own.
+   */
+  runDb('listAnySlaSubscribers never returns a subscriber from another partner', async () => {
+    const fx = await seed();
+    const { users: subs } = await withSystemDbAccessContext(() => listAnySlaSubscribers(fx.p1.id));
+    const ids = subs.map((s) => s.userId);
+    // Positive control: the query really does find this partner's opted-in users,
+    // so an empty result can never read as "isolation works".
+    expect(ids).toContain(fx.anyA.id);
+    expect(ids).toContain(fx.anyB.id);
+    expect(ids).not.toContain(fx.foreign.id);
+  });
+
+  runDb(
+    "cross-partner 'any' opt-in receives nothing; org-scoped user receives only own-org breaches",
+    async () => {
+      const fx = await seed();
+      await handleTicketEvent({
+        type: 'ticket.sla_breached',
+        ticketId: fx.ticket.id,
+        orgId: fx.orgA.id,
+        partnerId: fx.p1.id,
+        actorUserId: null,
+        eventId: 'e1',
+        payload: { target: 'response', internalNumber: null, subject: 'Printer', assigneeId: fx.owner.id },
+      });
+      const ids = (await rowsFor(fx.ticket.id)).map((r) => r.userId).sort();
+
+      // BOTH halves must fire. The positive half proves the permission grant
+      // actually resolved (an empty `ids` is a broken fixture, not a pass); the
+      // negative half proves the boundary discriminates.
+      expect(ids).toContain(fx.owner.id);
+      expect(ids).toContain(fx.anyA.id);
+      expect(ids).not.toContain(fx.anyB.id); // orgB — canAccessOrg false
+      expect(ids).not.toContain(fx.foreign.id); // partner 2 — SQL partner filter
+      expect(ids).not.toContain(fx.noPerm.id); // no tickets:read
+      expect(ids).toEqual([fx.owner.id, fx.anyA.id].sort());
+      expect(dispatch).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  runDb('replaying the same breach yields no second row and no second push', async () => {
+    const fx = await seed();
+    const ev = {
+      type: 'ticket.sla_breached' as const,
+      ticketId: fx.ticket.id,
+      orgId: fx.orgA.id,
+      partnerId: fx.p1.id,
+      actorUserId: null,
+      eventId: 'e1',
+      payload: {
+        target: 'resolution' as const,
+        internalNumber: null,
+        subject: 'Printer',
+        assigneeId: fx.owner.id,
+      },
+    };
+    await handleTicketEvent(ev);
+    dispatch.mockClear();
+    await handleTicketEvent(ev);
+    expect(dispatch).not.toHaveBeenCalled();
+    const rows = await rowsFor(fx.ticket.id);
+    expect(rows.filter((r) => r.userId === fx.owner.id)).toHaveLength(1);
+  });
+
+  runDb('A→B→A reassignment pushes twice; a retry of one event does not', async () => {
+    const fx = await seed();
+    const assign = (eventId: string) =>
+      handleTicketEvent({
+        type: 'ticket.assigned',
+        ticketId: fx.ticket.id,
+        orgId: fx.orgA.id,
+        partnerId: fx.p1.id,
+        actorUserId: fx.anyB.id,
+        eventId,
+        payload: { assigneeId: fx.owner.id },
+      });
+    await assign('e-a1');
+    await assign('e-a1');
+    await assign('e-a2');
+    expect(dispatch).toHaveBeenCalledTimes(2);
+  });
+
+  runDb(`'any' fan-out is capped at ${ANY_SUBSCRIBER_CAP} and always includes the owner`, async () => {
+    const fx = await seed();
+    // makeUser goes through db-utils' own privileged handle; keep it OUTSIDE
+    // withSystemDbAccessContext so the two connection paths never nest.
+    const extras: string[] = [];
+    for (let i = 0; i < ANY_SUBSCRIBER_CAP + 5; i++) {
+      const u = await makeUser({ partnerId: fx.p1.id }); // real tickets:read grant
+      extras.push(u.id);
+    }
+    await withSystemDbAccessContext(async () => {
+      for (const id of extras) {
+        await db.insert(ticketPushPreferences).values({ userId: id, slaScope: 'any' });
+      }
+    });
+    await handleTicketEvent({
+      type: 'ticket.sla_breached',
+      ticketId: fx.ticket.id,
+      orgId: fx.orgA.id,
+      partnerId: fx.p1.id,
+      actorUserId: null,
+      eventId: 'e-cap',
+      payload: { target: 'response', internalNumber: null, subject: 'Printer', assigneeId: fx.owner.id },
+    });
+    const rows = await rowsFor(fx.ticket.id);
+    expect(rows.length).toBeLessThanOrEqual(ANY_SUBSCRIBER_CAP + 1);
+    // Positive control: the cap truncates, it does not empty the fan-out.
+    expect(rows.length).toBeGreaterThan(1);
+    expect(rows.some((r) => r.userId === fx.owner.id)).toBe(true);
+  });
+});

--- a/apps/api/src/__tests__/integration/ticketPushFanout.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ticketPushFanout.integration.test.ts
@@ -243,20 +243,41 @@ describe('ticket push fan-out — tenant boundary', () => {
     expect(dispatch).toHaveBeenCalledTimes(2);
   });
 
-  runDb(`'any' fan-out is capped at ${ANY_SUBSCRIBER_CAP} and always includes the owner`, async () => {
+  /**
+   * The cap, proven with a small injected value instead of 505 real users.
+   *
+   * The plan's original shape seeded ANY_SUBSCRIBER_CAP + 5 users, each with a
+   * role and a permission grant; that is ~2000 serial statements and blows the
+   * 30s integration timeout (it did, twice). The plan's own fallback applies:
+   * make the cap injectable rather than delete the test — it is a
+   * tenant-blast-radius control. listAnySlaSubscribers takes `cap` for exactly
+   * this; the worker never passes it, so production stays at
+   * ANY_SUBSCRIBER_CAP, which ticketPush.sql.test.ts pins into the compiled
+   * LIMIT.
+   */
+  runDb('the any-SLA subscriber list truncates at the cap, lowest user id first', async () => {
     const fx = await seed();
-    // makeUser goes through db-utils' own privileged handle; keep it OUTSIDE
-    // withSystemDbAccessContext so the two connection paths never nest.
-    const extras: string[] = [];
-    for (let i = 0; i < ANY_SUBSCRIBER_CAP + 5; i++) {
-      const u = await makeUser({ partnerId: fx.p1.id }); // real tickets:read grant
-      extras.push(u.id);
-    }
-    await withSystemDbAccessContext(async () => {
-      for (const id of extras) {
-        await db.insert(ticketPushPreferences).values({ userId: id, slaScope: 'any' });
-      }
-    });
+    const CAP = 2;
+    // seed() already opted 4 users in (anyA, anyB, foreign, noPerm); three of
+    // them are in p1, which is > CAP.
+    const { users: subs, truncated } = await withSystemDbAccessContext(() =>
+      listAnySlaSubscribers(fx.p1.id, CAP));
+
+    expect(truncated).toBe(true);
+    expect(subs).toHaveLength(CAP);
+    // Deterministic truncation: ordered by user id, so the same partner always
+    // loses the same tail rather than a random subset per run.
+    const ids = subs.map((s) => s.userId);
+    expect(ids).toEqual([...ids].sort());
+    // Positive control: an uncapped call returns strictly more than the capped one.
+    const { users: all, truncated: allTruncated } = await withSystemDbAccessContext(() =>
+      listAnySlaSubscribers(fx.p1.id));
+    expect(all.length).toBeGreaterThan(CAP);
+    expect(allTruncated).toBe(false);
+  });
+
+  runDb('the owner is notified from the assignee branch, never via the capped list', async () => {
+    const fx = await seed();
     await handleTicketEvent({
       type: 'ticket.sla_breached',
       ticketId: fx.ticket.id,
@@ -267,9 +288,9 @@ describe('ticket push fan-out — tenant boundary', () => {
       payload: { target: 'response', internalNumber: null, subject: 'Printer', assigneeId: fx.owner.id },
     });
     const rows = await rowsFor(fx.ticket.id);
-    expect(rows.length).toBeLessThanOrEqual(ANY_SUBSCRIBER_CAP + 1);
-    // Positive control: the cap truncates, it does not empty the fan-out.
-    expect(rows.length).toBeGreaterThan(1);
+    // The owner has no ticket_push_preferences row at all, so they can never
+    // appear in listAnySlaSubscribers — they are reached only because they are
+    // the assignee. That is what keeps the cap from ever dropping the owner.
     expect(rows.some((r) => r.userId === fx.owner.id)).toBe(true);
   });
 });

--- a/apps/api/src/__tests__/integration/ticketPushPreferencesRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ticketPushPreferencesRls.integration.test.ts
@@ -1,0 +1,103 @@
+/**
+ * ticket_push_preferences RLS — user axis, behaviourally (W07, #3901).
+ * The coverage contract only proves the policy MENTIONS breeze_current_user_id;
+ * this file proves one user cannot read/insert/update another's row as
+ * breeze_app, that the system context sees everything (the notify worker reads
+ * this table inside withSystemDbAccessContext), and that deleting a user
+ * cascades the row.
+ *
+ * Prerequisites: docker compose -f docker-compose.test.yml up -d
+ */
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
+import { ticketPushPreferences, users } from '../../db/schema';
+import { createOrganization, createPartner, createUser } from './db-utils';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+async function expectSqlState(fn: () => Promise<unknown>, code: string): Promise<void> {
+  let raised: unknown;
+  try { await fn(); } catch (err) { raised = err; }
+  expect(raised, `expected SQLSTATE ${code}, but the statement succeeded`).toBeDefined();
+  const cause = (raised as { cause?: { code?: string } })?.cause;
+  expect(cause?.code ?? (raised as { code?: string })?.code).toBe(code);
+}
+
+async function seed() {
+  const partner = await createPartner();
+  const org = await createOrganization({ partnerId: partner.id });
+  const userA = await createUser({ partnerId: partner.id, orgId: org.id });
+  const userB = await createUser({ partnerId: partner.id, orgId: org.id });
+  const ctx = (userId: string): DbAccessContext => ({
+    scope: 'partner',
+    orgId: null,
+    accessibleOrgIds: [org.id],
+    accessiblePartnerIds: [partner.id],
+    userId,
+  });
+  return { partner, org, userA, userB, ctxA: ctx(userA.id), ctxB: ctx(userB.id) };
+}
+
+describe('ticket_push_preferences RLS — user axis', () => {
+  runDb('a user can upsert and read their own row', async () => {
+    const fx = await seed();
+    await withDbAccessContext(fx.ctxA, () =>
+      db.insert(ticketPushPreferences).values({ userId: fx.userA.id, slaScope: 'any' }));
+    const rows = await withDbAccessContext(fx.ctxA, () =>
+      db.select().from(ticketPushPreferences).where(eq(ticketPushPreferences.userId, fx.userA.id)));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.slaScope).toBe('any');
+  });
+
+  runDb('THE GUARD: a same-partner peer cannot read, update or forge the row', async () => {
+    const fx = await seed();
+    await withSystemDbAccessContext(() =>
+      db.insert(ticketPushPreferences).values({ userId: fx.userA.id, assignedEnabled: false }));
+
+    const read = await withDbAccessContext(fx.ctxB, () =>
+      db.select().from(ticketPushPreferences).where(eq(ticketPushPreferences.userId, fx.userA.id)));
+    expect(read).toHaveLength(0);
+
+    const updated = await withDbAccessContext(fx.ctxB, () =>
+      db.update(ticketPushPreferences).set({ slaScope: 'off' })
+        .where(eq(ticketPushPreferences.userId, fx.userA.id)).returning({ userId: ticketPushPreferences.userId }));
+    expect(updated).toHaveLength(0);
+
+    // Forging a row for someone else fails WITH CHECK → 42501.
+    await expectSqlState(
+      () => withDbAccessContext(fx.ctxB, () =>
+        db.insert(ticketPushPreferences).values({ userId: fx.userA.id, slaScope: 'any' })
+          .onConflictDoUpdate({ target: ticketPushPreferences.userId, set: { slaScope: 'any' } })),
+      '42501'
+    );
+
+    const still = await withSystemDbAccessContext(() =>
+      db.select().from(ticketPushPreferences).where(eq(ticketPushPreferences.userId, fx.userA.id)));
+    expect(still[0]!.assignedEnabled).toBe(false);
+  });
+
+  runDb('system context sees every row (worker discovery path)', async () => {
+    const fx = await seed();
+    await withDbAccessContext(fx.ctxA, () =>
+      db.insert(ticketPushPreferences).values({ userId: fx.userA.id, slaScope: 'any' }));
+    await withDbAccessContext(fx.ctxB, () =>
+      db.insert(ticketPushPreferences).values({ userId: fx.userB.id, slaScope: 'any' }));
+    const rows = await withSystemDbAccessContext(() =>
+      db.select({ userId: ticketPushPreferences.userId }).from(ticketPushPreferences)
+        .where(eq(ticketPushPreferences.slaScope, 'any')));
+    const ids = rows.map((r) => r.userId);
+    expect(ids).toEqual(expect.arrayContaining([fx.userA.id, fx.userB.id]));
+  });
+
+  runDb('deleting the user cascades the preference row', async () => {
+    const fx = await seed();
+    await withSystemDbAccessContext(() =>
+      db.insert(ticketPushPreferences).values({ userId: fx.userB.id }));
+    await withSystemDbAccessContext(() => db.delete(users).where(eq(users.id, fx.userB.id)));
+    const rows = await withSystemDbAccessContext(() =>
+      db.select().from(ticketPushPreferences).where(eq(ticketPushPreferences.userId, fx.userB.id)));
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -42,6 +42,7 @@ export * from './storageEncryption';
 export * from './backupVerification';
 export * from './snmp';
 export * from './notifications';
+export * from './ticketPushPreferences';
 export * from './configurationPolicies';
 export * from './automations';
 export * from './filters';

--- a/apps/api/src/db/schema/ticketPushPreferences.ts
+++ b/apps/api/src/db/schema/ticketPushPreferences.ts
@@ -1,0 +1,20 @@
+import { pgTable, pgEnum, uuid, boolean, timestamp, index } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
+import { users } from './users';
+
+export const ticketSlaPushScopeEnum = pgEnum('ticket_sla_push_scope', ['off', 'owned', 'any']);
+
+/**
+ * Per-user mobile push preferences for ticket events (W07, #3901).
+ * Shape 6 (user-scoped RLS, breeze_current_user_id). Missing row = defaults;
+ * see resolveTicketPushPrefs in @breeze/shared.
+ */
+export const ticketPushPreferences = pgTable('ticket_push_preferences', {
+  userId: uuid('user_id').primaryKey().references(() => users.id, { onDelete: 'cascade' }),
+  assignedEnabled: boolean('assigned_enabled').notNull().default(true),
+  slaScope: ticketSlaPushScopeEnum('sla_scope').notNull().default('owned'),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+}, (t) => ({
+  slaAnyIdx: index('ticket_push_preferences_sla_any_idx').on(t.userId).where(sql`${t.slaScope} = 'any'`),
+}));

--- a/apps/api/src/jobs/ticketNotifyWorker.graphFork.test.ts
+++ b/apps/api/src/jobs/ticketNotifyWorker.graphFork.test.ts
@@ -50,7 +50,8 @@ const gfPush = vi.hoisted(() => ({
   loadTicketPushPrefs: vi.fn(async () => ({ assignedEnabled: false, slaScope: 'off' as const })),
   listAnySlaSubscribers: vi.fn(async () => ({ users: [] as unknown[], truncated: false })),
   isAuthorisedForTicket: vi.fn(async () => false),
-  collectTicketPush: vi.fn(async () => null),
+  admitPush: vi.fn(async () => []),
+  resolvePushJobs: vi.fn(async () => []),
 }));
 vi.mock('../services/userNotifications', () => ({ createNotification: gfPush.createNotification }));
 vi.mock('../services/ticketPush', async (orig) => ({
@@ -59,7 +60,8 @@ vi.mock('../services/ticketPush', async (orig) => ({
   loadTicketPushPrefs: gfPush.loadTicketPushPrefs,
   listAnySlaSubscribers: gfPush.listAnySlaSubscribers,
   isAuthorisedForTicket: gfPush.isAuthorisedForTicket,
-  collectTicketPush: gfPush.collectTicketPush,
+  admitPush: gfPush.admitPush,
+  resolvePushJobs: gfPush.resolvePushJobs,
 }));
 vi.mock('../db/schema/mobile', () => ({
   mobileDevices: { userId: 'user_id', fcmToken: 'fcm_token', apnsToken: 'apns_token', platform: 'platform', status: 'status', notificationsEnabled: 'notifications_enabled', quietHours: 'quiet_hours' },

--- a/apps/api/src/jobs/ticketNotifyWorker.graphFork.test.ts
+++ b/apps/api/src/jobs/ticketNotifyWorker.graphFork.test.ts
@@ -63,7 +63,7 @@ describe('ticketNotifyWorker M365 Graph fork', () => {
 
     await handleTicketEvent({
       type: 'ticket.commented', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
-      actorUserId: 'u-1', payload: { commentId: 'c-1', isPublic: true },
+      actorUserId: 'u-1', eventId: 'evt-1', payload: { commentId: 'c-1', isPublic: true },
     });
 
     expect(sendThreadedMock).toHaveBeenCalledTimes(1);
@@ -80,7 +80,7 @@ describe('ticketNotifyWorker M365 Graph fork', () => {
 
     await handleTicketEvent({
       type: 'ticket.commented', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
-      actorUserId: 'u-1', payload: { commentId: 'c-1', isPublic: true },
+      actorUserId: 'u-1', eventId: 'evt-2', payload: { commentId: 'c-1', isPublic: true },
     });
 
     expect(sendNewMock).toHaveBeenCalledTimes(1);
@@ -97,7 +97,7 @@ describe('ticketNotifyWorker M365 Graph fork', () => {
 
     await handleTicketEvent({
       type: 'ticket.commented', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
-      actorUserId: 'u-1', payload: { commentId: 'c-1', isPublic: true },
+      actorUserId: 'u-1', eventId: 'evt-3', payload: { commentId: 'c-1', isPublic: true },
     });
 
     expect(sendEmailMock).toHaveBeenCalledTimes(1);
@@ -115,7 +115,7 @@ describe('ticketNotifyWorker M365 Graph fork', () => {
 
     await handleTicketEvent({
       type: 'ticket.assigned', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
-      actorUserId: 'u-1', payload: { assigneeId: 'u-2' },
+      actorUserId: 'u-1', eventId: 'evt-4', payload: { assigneeId: 'u-2' },
     });
 
     expect(sendThreadedMock).not.toHaveBeenCalled();

--- a/apps/api/src/jobs/ticketNotifyWorker.graphFork.test.ts
+++ b/apps/api/src/jobs/ticketNotifyWorker.graphFork.test.ts
@@ -35,9 +35,34 @@ vi.mock('../db/schema', () => ({
   partners: { id: 'id', slug: 'slug', name: 'name', settings: 'settings' },
   organizations: { id: 'id', name: 'name' },
   userNotifications: {},
-  users: { id: 'id' },
+  users: { id: 'id', partnerId: 'partner_id', status: 'status', email: 'email' },
+  mobileDevices: { userId: 'user_id', fcmToken: 'fcm_token', apnsToken: 'apns_token', platform: 'platform', status: 'status', notificationsEnabled: 'notifications_enabled', quietHours: 'quiet_hours' },
+  ticketPushPreferences: { userId: 'user_id', assignedEnabled: 'assigned_enabled', slaScope: 'sla_scope' },
   ticketStatusEnum: { enumValues: ['new', 'open', 'pending', 'on_hold', 'resolved', 'closed'] },
   ticketSourceEnum: { enumValues: ['portal', 'email', 'alert', 'manual', 'api', 'ai'] },
+}));
+// W07 (#3901): the assignee branch now writes through createNotification and
+// consults the ticketPush helpers. Stub them so this file keeps testing exactly
+// what it is about — the Graph-vs-EmailService fork — and nothing else.
+const gfPush = vi.hoisted(() => ({
+  createNotification: vi.fn(async () => 'n-1' as string | null),
+  loadUserCandidate: vi.fn(async (id: string) => ({ userId: id, partnerId: 'p-1', status: 'active', email: 'tech@msp.example' })),
+  loadTicketPushPrefs: vi.fn(async () => ({ assignedEnabled: false, slaScope: 'off' as const })),
+  listAnySlaSubscribers: vi.fn(async () => ({ users: [] as unknown[], truncated: false })),
+  isAuthorisedForTicket: vi.fn(async () => false),
+  collectTicketPush: vi.fn(async () => null),
+}));
+vi.mock('../services/userNotifications', () => ({ createNotification: gfPush.createNotification }));
+vi.mock('../services/ticketPush', async (orig) => ({
+  ...(await orig<typeof import('../services/ticketPush')>()),
+  loadUserCandidate: gfPush.loadUserCandidate,
+  loadTicketPushPrefs: gfPush.loadTicketPushPrefs,
+  listAnySlaSubscribers: gfPush.listAnySlaSubscribers,
+  isAuthorisedForTicket: gfPush.isAuthorisedForTicket,
+  collectTicketPush: gfPush.collectTicketPush,
+}));
+vi.mock('../db/schema/mobile', () => ({
+  mobileDevices: { userId: 'user_id', fcmToken: 'fcm_token', apnsToken: 'apns_token', platform: 'platform', status: 'status', notificationsEnabled: 'notifications_enabled', quietHours: 'quiet_hours' },
 }));
 vi.mock('../services/ticketMailbox/resolveOutboundMailbox', () => ({ resolveOutboundMailbox: resolveMailboxMock }));
 vi.mock('../services/ticketMailbox/graphReplySender', () => ({ sendThreadedReply: sendThreadedMock, sendNewMail: sendNewMock }));
@@ -109,7 +134,7 @@ describe('ticketNotifyWorker M365 Graph fork', () => {
   it('NEVER routes assignee/tech notifications through Graph (ticket.assigned uses EmailService)', async () => {
     selectMock
       .mockResolvedValueOnce([{ id: 't-1', orgId: 'o-1', partnerId: 'p-1', internalNumber: 'T-1', subject: 'Printer', submitterEmail: 'cust@x.com' }]) // getTicket
-      .mockResolvedValueOnce([{ id: 'u-2', email: 'tech@msp.example' }]); // assignee user
+      .mockResolvedValueOnce([{ name: 'Acme' }]); // org name (assignee now via loadUserCandidate)
     // Even if a mailbox WERE connected, the assignee path must never consult it.
     resolveMailboxMock.mockResolvedValue({ ...MAILBOX, originalMessageId: 'orig-1' });
 

--- a/apps/api/src/jobs/ticketNotifyWorker.test.ts
+++ b/apps/api/src/jobs/ticketNotifyWorker.test.ts
@@ -23,7 +23,8 @@ const { insertValuesMock, selectMock, updateSetMock, sendEmailMock, getEmailServ
 vi.mock('bullmq', () => ({ Queue: vi.fn(() => ({ add: vi.fn() })), Worker: vi.fn() }));
 vi.mock('../services/redis', () => ({ getBullMQConnection: vi.fn(() => ({})) }));
 vi.mock('../services/email', () => ({ getEmailService: getEmailServiceMock }));
-vi.mock('../services/sentry', () => ({ captureException: vi.fn() }));
+const sentry = vi.hoisted(() => ({ captureException: vi.fn() }));
+vi.mock('../services/sentry', () => ({ captureException: sentry.captureException }));
 // outboundThreading.ts reads TICKETS_INBOUND_DOMAIN via getConfig(). The specifier
 // from this file (in jobs/) is '../config/validate', which resolves to the same
 // apps/api/src/config/validate.ts that outboundThreading imports as '../../config/validate'.
@@ -70,7 +71,9 @@ const push = vi.hoisted(() => ({
   loadTicketPushPrefs: vi.fn(async () => ({ assignedEnabled: true, slaScope: 'owned' as 'off' | 'owned' | 'any' })),
   listAnySlaSubscribers: vi.fn(async () => ({ users: [] as unknown[], truncated: false })),
   isAuthorisedForTicket: vi.fn(async () => true),
-  collectTicketPush: vi.fn(async (_u: string, spec: unknown): Promise<{ tokens: { token: string; platform: string; provider: string }[]; spec: unknown } | null> => ({ tokens: [{ token: 'tok', platform: 'ios', provider: 'apns' }], spec })),
+  admitPush: vi.fn(async (pending: { userId: string; spec: unknown }[]) => pending),
+  resolvePushJobs: vi.fn(async (pending: { userId: string; spec: unknown }[]) =>
+    pending.map((p) => ({ tokens: [{ token: 'tok', platform: 'ios', provider: 'apns' }], spec: p.spec }))),
   dispatchPushToTokens: vi.fn(async () => ({ tokensFound: 1, dispatched: 1, errors: 0 })),
   order: [] as string[],
 }));
@@ -83,7 +86,8 @@ vi.mock('../services/ticketPush', async (orig) => {
     loadTicketPushPrefs: push.loadTicketPushPrefs,
     listAnySlaSubscribers: push.listAnySlaSubscribers,
     isAuthorisedForTicket: push.isAuthorisedForTicket,
-    collectTicketPush: (...a: [string, never]) => { push.order.push('collect'); return push.collectTicketPush(...a); },
+    admitPush: (...a: [never]) => { push.order.push('admit'); return push.admitPush(...a); },
+    resolvePushJobs: (...a: [never]) => { push.order.push('tokens'); return push.resolvePushJobs(...a); },
   };
 });
 vi.mock('../services/expoPush', async (orig) => {
@@ -600,7 +604,9 @@ function resetPushMocks(): void {
   push.loadTicketPushPrefs.mockResolvedValue({ assignedEnabled: true, slaScope: 'owned' });
   push.listAnySlaSubscribers.mockResolvedValue({ users: [], truncated: false });
   push.isAuthorisedForTicket.mockResolvedValue(true);
-  push.collectTicketPush.mockImplementation(async (_u: string, spec: unknown) => ({ tokens: [{ token: 'tok', platform: 'ios', provider: 'apns' }], spec }));
+  push.admitPush.mockImplementation(async (pending: { userId: string; spec: unknown }[]) => pending);
+  push.resolvePushJobs.mockImplementation(async (pending: { userId: string; spec: unknown }[]) =>
+    pending.map((p) => ({ tokens: [{ token: 'tok', platform: 'ios', provider: 'apns' }], spec: p.spec })));
   push.dispatchPushToTokens.mockResolvedValue({ tokensFound: 1, dispatched: 1, errors: 0 });
   withSystemDbAccessContextMock.mockImplementation(async (fn: () => unknown) => {
     push.order.push('ctx:enter');
@@ -628,7 +634,9 @@ describe('ticket push fan-out (W07)', () => {
       expect.objectContaining({ title: 'Ticket assigned to you', body: 'T-2026-0042 \u00b7 Acme' }),
       'ticket',
     );
-    expect(push.order).toEqual(['ctx:enter', 'collect', 'ctx:exit', 'dispatch']);
+    // #1105: the notification context closes BEFORE the Redis throttle
+    // admission; the device read runs in its own short second context.
+    expect(push.order).toEqual(['ctx:enter', 'ctx:exit', 'admit', 'ctx:enter', 'tokens', 'ctx:exit', 'dispatch']);
     expect(sendEmailMock).toHaveBeenCalled();
   });
 
@@ -659,18 +667,68 @@ describe('ticket push fan-out (W07)', () => {
     await handleTicketEvent(assigned() as never);
     expect(push.createNotification).toHaveBeenCalled();
     expect(sendEmailMock).toHaveBeenCalled();
-    expect(push.collectTicketPush).not.toHaveBeenCalled();
+    expect(push.admitPush).toHaveBeenCalledWith([]);
   });
 
   it('assignee lacking org access is not pushed (row still written)', async () => {
     push.isAuthorisedForTicket.mockResolvedValueOnce(false);
     await handleTicketEvent(assigned() as never);
     expect(push.createNotification).toHaveBeenCalled();
-    expect(push.collectTicketPush).not.toHaveBeenCalled();
+    expect(push.admitPush).toHaveBeenCalledWith([]);
   });
 
-  it('collectTicketPush null (throttled/quiet/apns-off): row + email, no dispatch', async () => {
-    push.collectTicketPush.mockResolvedValueOnce(null);
+  /**
+   * REGRESSION (#4281 review): `status !== 'active'` was a TERMINAL gate on the
+   * whole collector, so an invited (not-yet-onboarded) technician assigned a
+   * ticket silently lost the in-app row AND the assignment email that main sent
+   * unconditionally. Account status is a PUSH precondition (a device cannot be
+   * registered without a login), never a reason to withhold the inbox row.
+   */
+  it('invited assignee still gets the in-app row and the email — only the push is gated', async () => {
+    push.loadUserCandidate.mockResolvedValueOnce({ userId: 'u-2', partnerId: 'p-1', status: 'invited', email: 'invited@msp.example' });
+    await handleTicketEvent(assigned() as never);
+    expect(push.createNotification).toHaveBeenCalledWith(expect.objectContaining({ userId: 'u-2' }));
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+    expect(push.dispatchPushToTokens).not.toHaveBeenCalled();
+  });
+
+  /**
+   * REGRESSION (#4281 review): `tickets.partner_id` is deliberately NULLABLE
+   * (see 2026-06-09-a-native-ticketing-core.sql — "old API code may still
+   * insert tickets without it during a rolling deploy"), and both emitters
+   * propagate the null verbatim. `assertSamePartner(candidate, null)` returns
+   * false, which made the whole recipient terminal AND raised a Sentry error
+   * framed as a forgery signal. A missing event partner gates the PUSH (already
+   * conditional on event.partnerId) — never the row or the email.
+   */
+  it('legacy ticket with a null event partner: row + email still written, push withheld, nothing reported', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await handleTicketEvent({ ...assigned(), partnerId: null } as never);
+    expect(push.createNotification).toHaveBeenCalledWith(expect.objectContaining({ userId: 'u-2' }));
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+    expect(push.dispatchPushToTokens).not.toHaveBeenCalled();
+    expect(sentry.captureException).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  /**
+   * REGRESSION (#4281 review): the up-to-500-recipient fan-out held one pooled
+   * Postgres connection in an OPEN transaction across a Redis `multi()` and an
+   * N-query device read per recipient (the #1105 class the worker's own comment
+   * claims to avoid). The throttle admission is Redis-only and must run with no
+   * DB context open; the device read gets its own short, batched context.
+   */
+  it('the Redis throttle admission runs AFTER the notification context closes (#1105)', async () => {
+    await handleTicketEvent(assigned() as never);
+    const firstExit = push.order.indexOf('ctx:exit');
+    expect(firstExit).toBeGreaterThanOrEqual(0);
+    expect(push.order.slice(0, firstExit)).not.toContain('admit');
+    expect(push.order.slice(0, firstExit)).not.toContain('tokens');
+    expect(push.order.indexOf('admit')).toBeGreaterThan(firstExit);
+  });
+
+  it('throttled / quiet-hours / apns-off: row + email, no dispatch', async () => {
+    push.admitPush.mockResolvedValueOnce([]);
     await handleTicketEvent(assigned() as never);
     expect(push.dispatchPushToTokens).not.toHaveBeenCalled();
     expect(sendEmailMock).toHaveBeenCalled();
@@ -699,7 +757,7 @@ describe('sla_breached fan-out (W07)', () => {
     await handleTicketEvent(breach('u-2') as never);
     expect(push.createNotification).toHaveBeenCalledWith(expect.objectContaining({ userId: 'u-2', dedupeKey: 'ticket:t-1:sla:response:u-2' }));
     expect(sendEmailMock).toHaveBeenCalledTimes(1);
-    expect(push.collectTicketPush).not.toHaveBeenCalled();
+    expect(push.admitPush).toHaveBeenCalledWith([]);
     expect(push.dispatchPushToTokens).not.toHaveBeenCalled();
     // Short-circuit: 'off' must not cost a permission round-trip.
     expect(push.isAuthorisedForTicket).not.toHaveBeenCalled();
@@ -709,7 +767,7 @@ describe('sla_breached fan-out (W07)', () => {
     push.isAuthorisedForTicket.mockResolvedValueOnce(false);
     await handleTicketEvent(breach('u-2') as never);
     expect(push.createNotification).toHaveBeenCalledTimes(1);
-    expect(push.collectTicketPush).not.toHaveBeenCalled();
+    expect(push.admitPush).toHaveBeenCalledWith([]);
   });
 
   it("an unauthorised 'any' subscriber gets NO row at all (asymmetry with the owner is deliberate)", async () => {
@@ -746,10 +804,42 @@ describe('sla_breached fan-out (W07)', () => {
     expect(push.createNotification).not.toHaveBeenCalled();
   });
 
+  /**
+   * REGRESSION (#4281 review): the owner's SLA email was pushed onto `emails`
+   * BEFORE `notify()` ran the dedupe check, so a redelivered BullMQ job
+   * suppressed the duplicate row and the duplicate push but re-emailed the
+   * owner — contradicting the wave's stated invariant ("a retry re-pushes
+   * nothing and re-emails nobody"). The assigned branch already got this right.
+   */
+  it('replay (createNotification -> null) re-emails nobody and re-pushes nothing', async () => {
+    push.createNotification.mockResolvedValueOnce(null);
+    await handleTicketEvent(breach('u-2') as never);
+    expect(sendEmailMock).not.toHaveBeenCalled();
+    expect(push.dispatchPushToTokens).not.toHaveBeenCalled();
+  });
+
+  it('invited owner keeps the in-app row and the SLA email; only the push is gated', async () => {
+    push.loadUserCandidate.mockResolvedValueOnce({ userId: 'u-2', partnerId: 'p-1', status: 'invited', email: 'tech@msp.example' });
+    await handleTicketEvent(breach('u-2') as never);
+    expect(push.createNotification).toHaveBeenCalledWith(expect.objectContaining({ userId: 'u-2' }));
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+    expect(push.dispatchPushToTokens).not.toHaveBeenCalled();
+  });
+
+  it('null event partner: the owner still gets the SLA row and email, push withheld, nothing reported', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await handleTicketEvent({ ...breach('u-2'), partnerId: null } as never);
+    expect(push.createNotification).toHaveBeenCalledWith(expect.objectContaining({ userId: 'u-2' }));
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+    expect(push.dispatchPushToTokens).not.toHaveBeenCalled();
+    expect(sentry.captureException).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
   it('every dispatch happens after the system context exits', async () => {
     push.listAnySlaSubscribers.mockResolvedValueOnce({ users: [{ userId: 'u-5', partnerId: 'p-1', status: 'active', email: null }], truncated: false });
     await handleTicketEvent(breach('u-2') as never);
-    const exitAt = push.order.indexOf('ctx:exit');
+    const exitAt = push.order.lastIndexOf('ctx:exit');
     expect(push.order.filter((x) => x === 'dispatch').length).toBe(2);
     expect(push.order.slice(0, exitAt)).not.toContain('dispatch');
   });

--- a/apps/api/src/jobs/ticketNotifyWorker.test.ts
+++ b/apps/api/src/jobs/ticketNotifyWorker.test.ts
@@ -72,7 +72,7 @@ describe('handleTicketEvent', () => {
 
     await handleTicketEvent({
       type: 'ticket.assigned', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
-      actorUserId: 'u-1', payload: { assigneeId: 'u-2' }
+      actorUserId: 'u-1', eventId: 'evt-1', payload: { assigneeId: 'u-2' }
     });
 
     expect(withSystemDbAccessContextMock).toHaveBeenCalled();
@@ -85,7 +85,7 @@ describe('handleTicketEvent', () => {
 
     await handleTicketEvent({
       type: 'ticket.assigned', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
-      actorUserId: 'u-1', payload: { assigneeId: 'u-2' }
+      actorUserId: 'u-1', eventId: 'evt-2', payload: { assigneeId: 'u-2' }
     });
 
     expect(insertValuesMock).toHaveBeenCalledWith(expect.objectContaining({
@@ -97,7 +97,7 @@ describe('handleTicketEvent', () => {
   it('skips self-assignment notifications', async () => {
     await handleTicketEvent({
       type: 'ticket.assigned', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
-      actorUserId: 'u-2', payload: { assigneeId: 'u-2' }
+      actorUserId: 'u-2', eventId: 'evt-3', payload: { assigneeId: 'u-2' }
     });
     expect(insertValuesMock).not.toHaveBeenCalled();
   });
@@ -106,7 +106,7 @@ describe('handleTicketEvent', () => {
     selectMock.mockResolvedValueOnce([{ id: 't-1', orgId: 'o-1', internalNumber: 'T-2026-0042', subject: 'Printer', submitterEmail: 'enduser@acme.example' }]);
     await handleTicketEvent({
       type: 'ticket.commented', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
-      actorUserId: 'u-1', payload: { commentId: 'c-1', isPublic: true }
+      actorUserId: 'u-1', eventId: 'evt-4', payload: { commentId: 'c-1', isPublic: true }
     });
     expect(sendEmailMock).toHaveBeenCalledWith(expect.objectContaining({
       to: 'enduser@acme.example',
@@ -118,7 +118,7 @@ describe('handleTicketEvent', () => {
     selectMock.mockResolvedValueOnce([{ id: 't-1', orgId: 'o-1', internalNumber: 'T-2026-0042', subject: 'Printer', submitterEmail: 'enduser@acme.example' }]);
     await handleTicketEvent({
       type: 'ticket.commented', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
-      actorUserId: 'u-1', payload: { commentId: 'c-1', isPublic: false }
+      actorUserId: 'u-1', eventId: 'evt-5', payload: { commentId: 'c-1', isPublic: false }
     });
     expect(sendEmailMock).not.toHaveBeenCalled();
   });
@@ -129,7 +129,7 @@ describe('handleTicketEvent', () => {
     selectMock.mockResolvedValueOnce([{ id: 't-1', orgId: 'o-1', internalNumber: 'T-2026-0042', subject: 'Printer', submitterEmail: 'enduser@acme.example' }]);
     await handleTicketEvent({
       type: 'ticket.commented', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
-      actorUserId: 'u-1', payload: { commentId: 'c-1', isPublic: true, inbound: true }
+      actorUserId: 'u-1', eventId: 'evt-6', payload: { commentId: 'c-1', isPublic: true, inbound: true }
     });
     expect(sendEmailMock).not.toHaveBeenCalled();
   });
@@ -139,7 +139,7 @@ describe('handleTicketEvent', () => {
     selectMock.mockResolvedValueOnce([{ id: 't-1', orgId: 'o-1', internalNumber: 'T-2026-0042', subject: 'Printer', submitterEmail: 'enduser@acme.example' }]);
     await handleTicketEvent({
       type: 'ticket.commented', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
-      actorUserId: 'u-1', payload: { commentId: 'c-2', isPublic: true, inbound: false }
+      actorUserId: 'u-1', eventId: 'evt-7', payload: { commentId: 'c-2', isPublic: true, inbound: false }
     });
     expect(sendEmailMock).toHaveBeenCalledWith(expect.objectContaining({
       to: 'enduser@acme.example'
@@ -155,7 +155,7 @@ describe('handleTicketEvent', () => {
     await handleTicketEvent({
       type: 'ticket.commented',
       ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
-      actorUserId: 'u-1',
+      actorUserId: 'u-1', eventId: 'evt-8',
       payload: { commentId: 'c-9', isPublic: true /* inbound omitted = false */ }
     } as never);
 
@@ -182,7 +182,7 @@ describe('handleTicketEvent', () => {
     await handleTicketEvent({
       type: 'ticket.commented',
       ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
-      actorUserId: 'u-1',
+      actorUserId: 'u-1', eventId: 'evt-9',
       payload: { commentId: 'c-9', isPublic: true }
     } as never);
 
@@ -198,7 +198,7 @@ describe('handleTicketEvent', () => {
     await handleTicketEvent({
       type: 'ticket.commented',
       ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
-      actorUserId: 'u-1',
+      actorUserId: 'u-1', eventId: 'evt-10',
       payload: { commentId: 'c-9', isPublic: true }
     } as never);
 
@@ -215,7 +215,7 @@ describe('handleTicketEvent', () => {
     await handleTicketEvent({
       type: 'ticket.status_changed',
       ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
-      actorUserId: 'u-1',
+      actorUserId: 'u-1', eventId: 'evt-11',
       payload: { from: 'open', to: 'resolved', resolutionNote: null }
     } as never);
 
@@ -238,7 +238,7 @@ describe('handleTicketEvent', () => {
     await handleTicketEvent({
       type: 'ticket.autoresponse',
       ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
-      actorUserId: null,
+      actorUserId: null, eventId: 'evt-12',
       payload: { to: 'jane@x.com', internalNumber: 'T-2026-0001', subject: 'printer down' }
     } as never);
 
@@ -264,7 +264,7 @@ describe('handleTicketEvent', () => {
     await handleTicketEvent({
       type: 'ticket.autoresponse',
       ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
-      actorUserId: null,
+      actorUserId: null, eventId: 'evt-13',
       payload: { to: 'jane@x.com', internalNumber: 'T-2026-0001', subject: 'printer down' }
     } as never);
 
@@ -283,7 +283,7 @@ describe('handleTicketEvent', () => {
     await handleTicketEvent({
       type: 'ticket.autoresponse',
       ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
-      actorUserId: null,
+      actorUserId: null, eventId: 'evt-14',
       payload: { to: 'jane@x.com', internalNumber: 'T-2026-0001', subject: 'printer down' }
     } as never);
 
@@ -298,7 +298,7 @@ describe('handleTicketEvent', () => {
       .mockResolvedValueOnce([{ id: 'u-2', email: 'tech@msp.example' }]);
     await expect(handleTicketEvent({
       type: 'ticket.assigned', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
-      actorUserId: 'u-1', payload: { assigneeId: 'u-2' }
+      actorUserId: 'u-1', eventId: 'evt-15', payload: { assigneeId: 'u-2' }
     })).resolves.toBeUndefined();
     expect(insertValuesMock).toHaveBeenCalled();
   });
@@ -309,7 +309,7 @@ describe('handleTicketEvent', () => {
 
     await expect(handleTicketEvent({
       type: 'ticket.assigned', ticketId: 'missing', orgId: 'o-1', partnerId: 'p-1',
-      actorUserId: 'u-1', payload: { assigneeId: 'u-2' }
+      actorUserId: 'u-1', eventId: 'evt-16', payload: { assigneeId: 'u-2' }
     })).rejects.toThrow(/not found/i);
   });
 
@@ -321,7 +321,7 @@ describe('handleTicketEvent', () => {
 
     await expect(handleTicketEvent({
       type: 'ticket.assigned', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
-      actorUserId: 'u-1', payload: { assigneeId: 'u-2' }
+      actorUserId: 'u-1', eventId: 'evt-17', payload: { assigneeId: 'u-2' }
     })).resolves.toBeUndefined();
 
     expect(insertValuesMock).toHaveBeenCalledTimes(1);
@@ -339,7 +339,7 @@ describe('handleTicketEvent', () => {
 
     await expect(handleTicketEvent({
       type: 'ticket.assigned', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
-      actorUserId: 'u-1', payload: { assigneeId: 'u-deleted' }
+      actorUserId: 'u-1', eventId: 'evt-18', payload: { assigneeId: 'u-deleted' }
     })).resolves.toBeUndefined();
 
     expect(insertValuesMock).not.toHaveBeenCalled();
@@ -355,7 +355,7 @@ describe('handleTicketEvent', () => {
 
     await handleTicketEvent({
       type: 'ticket.sla_breached', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
-      actorUserId: null, payload: { target: 'response', internalNumber: 'T-2026-0001', subject: 'Printer', assigneeId: 'u-2' }
+      actorUserId: null, eventId: 'evt-19', payload: { target: 'response', internalNumber: 'T-2026-0001', subject: 'Printer', assigneeId: 'u-2' }
     });
 
     expect(insertValuesMock).toHaveBeenCalledWith(expect.objectContaining({
@@ -382,7 +382,7 @@ describe('handleTicketEvent', () => {
 
     await expect(handleTicketEvent({
       type: 'ticket.sla_breached', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
-      actorUserId: null, payload: { target: 'resolution', internalNumber: 'T-2026-0001', subject: 'Printer', assigneeId: 'u-deleted' }
+      actorUserId: null, eventId: 'evt-20', payload: { target: 'resolution', internalNumber: 'T-2026-0001', subject: 'Printer', assigneeId: 'u-deleted' }
     })).resolves.toBeUndefined();
 
     expect(selectMock).toHaveBeenCalledTimes(2);
@@ -394,7 +394,7 @@ describe('handleTicketEvent', () => {
 
     await expect(handleTicketEvent({
       type: 'ticket.sla_breached', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
-      actorUserId: null, payload: { target: 'response', internalNumber: 'T-2026-0001', subject: 'Printer', assigneeId: null }
+      actorUserId: null, eventId: 'evt-21', payload: { target: 'response', internalNumber: 'T-2026-0001', subject: 'Printer', assigneeId: null }
     })).resolves.toBeUndefined();
 
     expect(selectMock).not.toHaveBeenCalled();
@@ -407,7 +407,7 @@ describe('handleTicketEvent', () => {
 
     await expect(handleTicketEvent({
       type: 'ticket.sla_breached', ticketId: 'missing', orgId: 'o-1', partnerId: 'p-1',
-      actorUserId: null, payload: { target: 'response', internalNumber: 'T-2026-0001', subject: 'Printer', assigneeId: 'u-2' }
+      actorUserId: null, eventId: 'evt-22', payload: { target: 'response', internalNumber: 'T-2026-0001', subject: 'Printer', assigneeId: 'u-2' }
     })).rejects.toThrow(/not found/i);
   });
 
@@ -424,7 +424,7 @@ describe('handleTicketEvent', () => {
 
     await handleTicketEvent({
       type: 'ticket.status_changed', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
-      actorUserId: 'u-1', payload: { from: 'open', to: 'resolved' }
+      actorUserId: 'u-1', eventId: 'evt-23', payload: { from: 'open', to: 'resolved' }
     });
 
     expect(sendEmailMock).toHaveBeenCalledTimes(1);
@@ -439,7 +439,7 @@ describe('handleTicketEvent', () => {
   it('ticket.updated is an explicit no-op — no ticket lookup, no insert, no email', async () => {
     await handleTicketEvent({
       type: 'ticket.updated', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
-      actorUserId: 'u-1', payload: { changed: ['subject', 'priority'] }
+      actorUserId: 'u-1', eventId: 'evt-24', payload: { changed: ['subject', 'priority'] }
     });
     expect(selectMock).not.toHaveBeenCalled();
     expect(insertValuesMock).not.toHaveBeenCalled();
@@ -454,7 +454,7 @@ describe('handleTicketEvent', () => {
 
     await handleTicketEvent({
       type: 'ticket.status_changed', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
-      actorUserId: 'u-1', payload: { from: 'open', to: 'pending' }
+      actorUserId: 'u-1', eventId: 'evt-25', payload: { from: 'open', to: 'pending' }
     });
 
     expect(sendEmailMock).not.toHaveBeenCalled();
@@ -468,7 +468,7 @@ describe('handleTicketEvent', () => {
 
     await expect(handleTicketEvent({
       type: 'ticket.status_changed', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
-      actorUserId: 'u-1', payload: { from: 'open', to: 'resolved' }
+      actorUserId: 'u-1', eventId: 'evt-26', payload: { from: 'open', to: 'resolved' }
     })).resolves.toBeUndefined();
 
     expect(sendEmailMock).not.toHaveBeenCalled();
@@ -487,7 +487,7 @@ describe('handleTicketEvent', () => {
 
     await expect(handleTicketEvent({
       type: 'ticket.status_changed', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
-      actorUserId: 'u-1', payload: { from: 'open', to: 'resolved' }
+      actorUserId: 'u-1', eventId: 'evt-27', payload: { from: 'open', to: 'resolved' }
     })).rejects.toThrow(/not yet visible/i);
 
     expect(sendEmailMock).not.toHaveBeenCalled();
@@ -507,7 +507,7 @@ describe('handleTicketEvent', () => {
 
     await expect(handleTicketEvent({
       type: 'ticket.status_changed', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
-      actorUserId: 'u-1', payload: { from: 'open', to: 'resolved' }
+      actorUserId: 'u-1', eventId: 'evt-28', payload: { from: 'open', to: 'resolved' }
     })).resolves.toBeUndefined();
 
     expect(sendEmailMock).toHaveBeenCalledTimes(1);
@@ -522,7 +522,7 @@ describe('handleTicketEvent', () => {
 
     await handleTicketEvent({
       type: 'ticket.created', ticketId: 't-2', orgId: 'o-1', partnerId: 'p-1',
-      actorUserId: 'u-1', payload: { internalNumber: 'T-2026-0100', assigneeId: 'u-3', source: 'manual' }
+      actorUserId: 'u-1', eventId: 'evt-29', payload: { internalNumber: 'T-2026-0100', assigneeId: 'u-3', source: 'manual' }
     });
 
     expect(insertValuesMock).toHaveBeenCalledWith(expect.objectContaining({

--- a/apps/api/src/jobs/ticketNotifyWorker.test.ts
+++ b/apps/api/src/jobs/ticketNotifyWorker.test.ts
@@ -2,7 +2,14 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const { insertValuesMock, selectMock, updateSetMock, sendEmailMock, getEmailServiceMock, withSystemDbAccessContextMock } = vi.hoisted(() => {
   const insertValuesMock = vi.fn().mockResolvedValue([]);
-  const withSystemDbAccessContextMock = vi.fn((fn: () => unknown) => fn());
+  // Records context enter/exit so tests can prove every push dispatch happens
+  // AFTER the system DB context closes (#1105).
+  const withSystemDbAccessContextMock = vi.fn(async (fn: () => unknown) => {
+    push.order.push('ctx:enter');
+    const r = await fn();
+    push.order.push('ctx:exit');
+    return r;
+  });
   return {
     insertValuesMock,
     selectMock: vi.fn(),
@@ -40,7 +47,9 @@ vi.mock('../db/schema', () => ({
   partners: { id: 'id', slug: 'slug', name: 'name', settings: 'settings' },
   organizations: { id: 'id', name: 'name' },
   userNotifications: {},
-  users: { id: 'id' },
+  users: { id: 'id', partnerId: 'partner_id', status: 'status', email: 'email' },
+  mobileDevices: { userId: 'user_id', fcmToken: 'fcm_token', apnsToken: 'apns_token', platform: 'platform', status: 'status', notificationsEnabled: 'notifications_enabled', quietHours: 'quiet_hours' },
+  ticketPushPreferences: { userId: 'user_id', assignedEnabled: 'assigned_enabled', slaScope: 'sla_scope' },
   ticketStatusEnum: { enumValues: ['new', 'open', 'pending', 'on_hold', 'resolved', 'closed'] },
   ticketSourceEnum: { enumValues: ['portal', 'email', 'alert', 'manual', 'api', 'ai'] }
 }));
@@ -54,6 +63,37 @@ vi.mock('../services/ticketMailbox/graphReplySender', () => ({
   sendNewMail: vi.fn(async () => {})
 }));
 
+// ── W07 (#3901): push fan-out collaborators ────────────────────────────────
+const push = vi.hoisted(() => ({
+  createNotification: vi.fn(async (_input: { userId: string; dedupeKey?: string }) => 'n-1' as string | null),
+  loadUserCandidate: vi.fn(async (id: string) => ({ userId: id, partnerId: 'p-1', status: 'active', email: 'tech@msp.example' })),
+  loadTicketPushPrefs: vi.fn(async () => ({ assignedEnabled: true, slaScope: 'owned' as 'off' | 'owned' | 'any' })),
+  listAnySlaSubscribers: vi.fn(async () => ({ users: [] as unknown[], truncated: false })),
+  isAuthorisedForTicket: vi.fn(async () => true),
+  collectTicketPush: vi.fn(async (_u: string, spec: unknown): Promise<{ tokens: { token: string; platform: string; provider: string }[]; spec: unknown } | null> => ({ tokens: [{ token: 'tok', platform: 'ios', provider: 'apns' }], spec })),
+  dispatchPushToTokens: vi.fn(async () => ({ tokensFound: 1, dispatched: 1, errors: 0 })),
+  order: [] as string[],
+}));
+vi.mock('../services/userNotifications', () => ({ createNotification: push.createNotification }));
+vi.mock('../services/ticketPush', async (orig) => {
+  const actual = await orig<typeof import('../services/ticketPush')>();
+  return {
+    ...actual,
+    loadUserCandidate: push.loadUserCandidate,
+    loadTicketPushPrefs: push.loadTicketPushPrefs,
+    listAnySlaSubscribers: push.listAnySlaSubscribers,
+    isAuthorisedForTicket: push.isAuthorisedForTicket,
+    collectTicketPush: (...a: [string, never]) => { push.order.push('collect'); return push.collectTicketPush(...a); },
+  };
+});
+vi.mock('../services/expoPush', async (orig) => {
+  const actual = await orig<typeof import('../services/expoPush')>();
+  return {
+    ...actual,
+    dispatchPushToTokens: (...a: unknown[]) => { push.order.push('dispatch'); return push.dispatchPushToTokens(...(a as [])); },
+  };
+});
+
 import { handleTicketEvent } from './ticketNotifyWorker';
 
 describe('handleTicketEvent', () => {
@@ -61,7 +101,7 @@ describe('handleTicketEvent', () => {
     vi.clearAllMocks();
     selectMock.mockReset();
     updateSetMock.mockReset();
-    withSystemDbAccessContextMock.mockImplementation((fn: () => unknown) => fn());
+    withSystemDbAccessContextMock.mockImplementation(async (fn: () => unknown) => fn());
     getEmailServiceMock.mockReturnValue({ sendEmail: sendEmailMock });
   });
 
@@ -88,7 +128,7 @@ describe('handleTicketEvent', () => {
       actorUserId: 'u-1', eventId: 'evt-2', payload: { assigneeId: 'u-2' }
     });
 
-    expect(insertValuesMock).toHaveBeenCalledWith(expect.objectContaining({
+    expect(push.createNotification).toHaveBeenCalledWith(expect.objectContaining({
       userId: 'u-2', type: 'ticket', link: '/tickets#T-2026-0042'
     }));
     expect(sendEmailMock).toHaveBeenCalled();
@@ -99,7 +139,7 @@ describe('handleTicketEvent', () => {
       type: 'ticket.assigned', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
       actorUserId: 'u-2', eventId: 'evt-3', payload: { assigneeId: 'u-2' }
     });
-    expect(insertValuesMock).not.toHaveBeenCalled();
+    expect(push.createNotification).not.toHaveBeenCalled();
   });
 
   it('public comment emails the requester', async () => {
@@ -300,7 +340,7 @@ describe('handleTicketEvent', () => {
       type: 'ticket.assigned', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
       actorUserId: 'u-1', eventId: 'evt-15', payload: { assigneeId: 'u-2' }
     })).resolves.toBeUndefined();
-    expect(insertValuesMock).toHaveBeenCalled();
+    expect(push.createNotification).toHaveBeenCalled();
   });
 
   it('throws (for BullMQ retry) when the ticket row is not found', async () => {
@@ -324,8 +364,8 @@ describe('handleTicketEvent', () => {
       actorUserId: 'u-1', eventId: 'evt-17', payload: { assigneeId: 'u-2' }
     })).resolves.toBeUndefined();
 
-    expect(insertValuesMock).toHaveBeenCalledTimes(1);
-    expect(insertValuesMock).toHaveBeenCalledWith(expect.objectContaining({
+    expect(push.createNotification).toHaveBeenCalledTimes(1);
+    expect(push.createNotification).toHaveBeenCalledWith(expect.objectContaining({
       userId: 'u-2', type: 'ticket'
     }));
   });
@@ -334,15 +374,15 @@ describe('handleTicketEvent', () => {
 
   it('resolves silently when assignee user row is missing — no insert, no email, no throw', async () => {
     selectMock
-      .mockResolvedValueOnce([{ id: 't-1', orgId: 'o-1', internalNumber: 'T-2026-0042', subject: 'Printer', submitterEmail: null }])
-      .mockResolvedValueOnce([]); // assignee user row absent (deleted user)
+      .mockResolvedValueOnce([{ id: 't-1', orgId: 'o-1', internalNumber: 'T-2026-0042', subject: 'Printer', submitterEmail: null }]);
+    push.loadUserCandidate.mockResolvedValueOnce(null as never); // deleted user
 
     await expect(handleTicketEvent({
       type: 'ticket.assigned', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
       actorUserId: 'u-1', eventId: 'evt-18', payload: { assigneeId: 'u-deleted' }
     })).resolves.toBeUndefined();
 
-    expect(insertValuesMock).not.toHaveBeenCalled();
+    expect(push.createNotification).not.toHaveBeenCalled();
     expect(sendEmailMock).not.toHaveBeenCalled();
   });
 
@@ -358,7 +398,7 @@ describe('handleTicketEvent', () => {
       actorUserId: null, eventId: 'evt-19', payload: { target: 'response', internalNumber: 'T-2026-0001', subject: 'Printer', assigneeId: 'u-2' }
     });
 
-    expect(insertValuesMock).toHaveBeenCalledWith(expect.objectContaining({
+    expect(push.createNotification).toHaveBeenCalledWith(expect.objectContaining({
       userId: 'u-2',
       orgId: 'o-1',
       type: 'ticket',
@@ -375,30 +415,32 @@ describe('handleTicketEvent', () => {
     }));
   });
 
-  it('ticket.sla_breached with no assignee creates no notification and no email', async () => {
+  it('ticket.sla_breached with a deleted assignee and no subscribers creates no notification and no email', async () => {
     selectMock
-      .mockResolvedValueOnce([{ id: 't-1', orgId: 'o-1', internalNumber: 'T-2026-0001', subject: 'Printer', submitterEmail: null }])
-      .mockResolvedValueOnce([]); // assignee user row absent (deleted user)
+      .mockResolvedValueOnce([{ id: 't-1', orgId: 'o-1', internalNumber: 'T-2026-0001', subject: 'Printer', submitterEmail: null }]);
+    push.loadUserCandidate.mockResolvedValueOnce(null as never); // deleted user
 
     await expect(handleTicketEvent({
       type: 'ticket.sla_breached', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
       actorUserId: null, eventId: 'evt-20', payload: { target: 'resolution', internalNumber: 'T-2026-0001', subject: 'Printer', assigneeId: 'u-deleted' }
     })).resolves.toBeUndefined();
 
-    expect(selectMock).toHaveBeenCalledTimes(2);
-    expect(insertValuesMock).not.toHaveBeenCalled();
+    expect(push.createNotification).not.toHaveBeenCalled();
     expect(sendEmailMock).not.toHaveBeenCalled();
 
     vi.clearAllMocks();
     selectMock.mockReset();
+    // W07: an UNASSIGNED breach is no longer an early return — the 'any'
+    // subscriber fan-out still runs, so the ticket row IS read. With no
+    // subscribers, nobody is notified.
+    selectMock.mockResolvedValueOnce([{ id: 't-1', orgId: 'o-1', internalNumber: 'T-2026-0001', subject: 'Printer', submitterEmail: null }]);
 
     await expect(handleTicketEvent({
       type: 'ticket.sla_breached', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
       actorUserId: null, eventId: 'evt-21', payload: { target: 'response', internalNumber: 'T-2026-0001', subject: 'Printer', assigneeId: null }
     })).resolves.toBeUndefined();
 
-    expect(selectMock).not.toHaveBeenCalled();
-    expect(insertValuesMock).not.toHaveBeenCalled();
+    expect(push.createNotification).not.toHaveBeenCalled();
     expect(sendEmailMock).not.toHaveBeenCalled();
   });
 
@@ -442,7 +484,7 @@ describe('handleTicketEvent', () => {
       actorUserId: 'u-1', eventId: 'evt-24', payload: { changed: ['subject', 'priority'] }
     });
     expect(selectMock).not.toHaveBeenCalled();
-    expect(insertValuesMock).not.toHaveBeenCalled();
+    expect(push.createNotification).not.toHaveBeenCalled();
     expect(sendEmailMock).not.toHaveBeenCalled();
   });
 
@@ -518,19 +560,197 @@ describe('handleTicketEvent', () => {
   it('ticket.created with assigneeId fans out in-app row and email (same as ticket.assigned)', async () => {
     selectMock
       .mockResolvedValueOnce([{ id: 't-2', orgId: 'o-1', internalNumber: 'T-2026-0100', subject: 'New ticket', submitterEmail: null }])
-      .mockResolvedValueOnce([{ id: 'u-3', email: 'assignee@msp.example' }]);
+      .mockResolvedValueOnce([{ name: 'Acme' }]); // getOrgName for the push spec
+    // W07: the assignee row now comes from ticketPush.loadUserCandidate, not a
+    // raw select, so its email is supplied here.
+    push.loadUserCandidate.mockResolvedValueOnce({ userId: 'u-3', partnerId: 'p-1', status: 'active', email: 'assignee@msp.example' });
 
     await handleTicketEvent({
       type: 'ticket.created', ticketId: 't-2', orgId: 'o-1', partnerId: 'p-1',
       actorUserId: 'u-1', eventId: 'evt-29', payload: { internalNumber: 'T-2026-0100', assigneeId: 'u-3', source: 'manual' }
     });
 
-    expect(insertValuesMock).toHaveBeenCalledWith(expect.objectContaining({
+    expect(push.createNotification).toHaveBeenCalledWith(expect.objectContaining({
       userId: 'u-3', type: 'ticket', link: '/tickets#T-2026-0100'
     }));
     expect(sendEmailMock).toHaveBeenCalledWith(expect.objectContaining({
       to: 'assignee@msp.example',
       subject: expect.stringContaining('T-2026-0100')
     }));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// W07 (#3901): ticket push fan-out
+// ---------------------------------------------------------------------------
+
+const TICKET = { id: 't-1', orgId: 'o-1', internalNumber: 'T-2026-0042', subject: 'Printer', submitterEmail: null };
+
+const assigned = (over: Record<string, unknown> = {}) => ({
+  type: 'ticket.assigned' as const, ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1', actorUserId: 'u-1',
+  eventId: 'evt-1', payload: { assigneeId: 'u-2' }, ...over,
+});
+
+function resetPushMocks(): void {
+  vi.clearAllMocks();
+  selectMock.mockReset();
+  push.order.length = 0;
+  push.createNotification.mockResolvedValue('n-1');
+  push.loadUserCandidate.mockImplementation(async (id: string) => ({ userId: id, partnerId: 'p-1', status: 'active', email: 'tech@msp.example' }));
+  push.loadTicketPushPrefs.mockResolvedValue({ assignedEnabled: true, slaScope: 'owned' });
+  push.listAnySlaSubscribers.mockResolvedValue({ users: [], truncated: false });
+  push.isAuthorisedForTicket.mockResolvedValue(true);
+  push.collectTicketPush.mockImplementation(async (_u: string, spec: unknown) => ({ tokens: [{ token: 'tok', platform: 'ios', provider: 'apns' }], spec }));
+  push.dispatchPushToTokens.mockResolvedValue({ tokensFound: 1, dispatched: 1, errors: 0 });
+  withSystemDbAccessContextMock.mockImplementation(async (fn: () => unknown) => {
+    push.order.push('ctx:enter');
+    const r = await fn();
+    push.order.push('ctx:exit');
+    return r;
+  });
+  getEmailServiceMock.mockReturnValue({ sendEmail: sendEmailMock });
+}
+
+describe('ticket push fan-out (W07)', () => {
+  beforeEach(() => {
+    resetPushMocks();
+    // getTicket, then getOrgName.
+    selectMock.mockResolvedValueOnce([TICKET]).mockResolvedValueOnce([{ name: 'Acme' }]);
+  });
+
+  it('assigned: writes the in-app row with the dedupe key, then pushes after the context exits', async () => {
+    await handleTicketEvent(assigned() as never);
+    expect(push.createNotification).toHaveBeenCalledWith(expect.objectContaining({
+      userId: 'u-2', orgId: 'o-1', type: 'ticket', dedupeKey: 'ticket:t-1:assigned:u-2:evt-1',
+    }));
+    expect(push.dispatchPushToTokens).toHaveBeenCalledWith(
+      [{ token: 'tok', platform: 'ios', provider: 'apns' }],
+      expect.objectContaining({ title: 'Ticket assigned to you', body: 'T-2026-0042 \u00b7 Acme' }),
+      'ticket',
+    );
+    expect(push.order).toEqual(['ctx:enter', 'collect', 'ctx:exit', 'dispatch']);
+    expect(sendEmailMock).toHaveBeenCalled();
+  });
+
+  it('dedupe replay (createNotification -> null): no push, no email', async () => {
+    push.createNotification.mockResolvedValueOnce(null);
+    await handleTicketEvent(assigned() as never);
+    expect(push.dispatchPushToTokens).not.toHaveBeenCalled();
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to job.id when the event has no eventId (pre-deploy jobs)', async () => {
+    await handleTicketEvent({ ...assigned(), eventId: undefined } as never, 'job-77');
+    expect(push.createNotification).toHaveBeenCalledWith(expect.objectContaining({ dedupeKey: 'ticket:t-1:assigned:u-2:job-77' }));
+  });
+
+  it('foreign-partner assignee: no row, no push, no email, reported', async () => {
+    push.loadUserCandidate.mockResolvedValueOnce({ userId: 'u-2', partnerId: 'p-OTHER', status: 'active', email: 'x@y' });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await handleTicketEvent(assigned() as never);
+    expect(push.createNotification).not.toHaveBeenCalled();
+    expect(push.dispatchPushToTokens).not.toHaveBeenCalled();
+    expect(sendEmailMock).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('assignedEnabled=false: in-app + email, no push', async () => {
+    push.loadTicketPushPrefs.mockResolvedValueOnce({ assignedEnabled: false, slaScope: 'owned' });
+    await handleTicketEvent(assigned() as never);
+    expect(push.createNotification).toHaveBeenCalled();
+    expect(sendEmailMock).toHaveBeenCalled();
+    expect(push.collectTicketPush).not.toHaveBeenCalled();
+  });
+
+  it('assignee lacking org access is not pushed (row still written)', async () => {
+    push.isAuthorisedForTicket.mockResolvedValueOnce(false);
+    await handleTicketEvent(assigned() as never);
+    expect(push.createNotification).toHaveBeenCalled();
+    expect(push.collectTicketPush).not.toHaveBeenCalled();
+  });
+
+  it('collectTicketPush null (throttled/quiet/apns-off): row + email, no dispatch', async () => {
+    push.collectTicketPush.mockResolvedValueOnce(null);
+    await handleTicketEvent(assigned() as never);
+    expect(push.dispatchPushToTokens).not.toHaveBeenCalled();
+    expect(sendEmailMock).toHaveBeenCalled();
+  });
+});
+
+describe('sla_breached fan-out (W07)', () => {
+  const breach = (assigneeId: string | null) => ({
+    type: 'ticket.sla_breached' as const, ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1', actorUserId: null, eventId: 'evt-2',
+    payload: { target: 'response' as const, internalNumber: 'T-2026-0042', subject: 'Printer', assigneeId },
+  });
+  beforeEach(() => {
+    resetPushMocks();
+    selectMock.mockResolvedValueOnce([TICKET]).mockResolvedValueOnce([{ name: 'Acme' }]);
+  });
+
+  it("owner with slaScope 'owned' gets row + push + email; key has no eventId", async () => {
+    await handleTicketEvent(breach('u-2') as never);
+    expect(push.createNotification).toHaveBeenCalledWith(expect.objectContaining({ userId: 'u-2', dedupeKey: 'ticket:t-1:sla:response:u-2' }));
+    expect(push.dispatchPushToTokens).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ title: 'SLA breached (response)' }), 'ticket');
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("owner with slaScope 'off' still gets the in-app row and the email — only the push stops (D6)", async () => {
+    push.loadTicketPushPrefs.mockResolvedValueOnce({ assignedEnabled: true, slaScope: 'off' });
+    await handleTicketEvent(breach('u-2') as never);
+    expect(push.createNotification).toHaveBeenCalledWith(expect.objectContaining({ userId: 'u-2', dedupeKey: 'ticket:t-1:sla:response:u-2' }));
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+    expect(push.collectTicketPush).not.toHaveBeenCalled();
+    expect(push.dispatchPushToTokens).not.toHaveBeenCalled();
+    // Short-circuit: 'off' must not cost a permission round-trip.
+    expect(push.isAuthorisedForTicket).not.toHaveBeenCalled();
+  });
+
+  it('owner who cannot access the org keeps the row but is not pushed', async () => {
+    push.isAuthorisedForTicket.mockResolvedValueOnce(false);
+    await handleTicketEvent(breach('u-2') as never);
+    expect(push.createNotification).toHaveBeenCalledTimes(1);
+    expect(push.collectTicketPush).not.toHaveBeenCalled();
+  });
+
+  it("an unauthorised 'any' subscriber gets NO row at all (asymmetry with the owner is deliberate)", async () => {
+    push.listAnySlaSubscribers.mockResolvedValueOnce({ users: [{ userId: 'u-5', partnerId: 'p-1', status: 'active', email: null }], truncated: false });
+    push.isAuthorisedForTicket.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    await handleTicketEvent(breach('u-2') as never);
+    const recipients = push.createNotification.mock.calls.map((c) => c[0].userId);
+    expect(recipients).toEqual(['u-2']);
+  });
+
+  it("unassigned breach reaches only 'any' subscribers; no email", async () => {
+    push.listAnySlaSubscribers.mockResolvedValueOnce({ users: [
+      { userId: 'u-5', partnerId: 'p-1', status: 'active', email: null },
+      { userId: 'u-6', partnerId: 'p-1', status: 'active', email: null },
+    ], truncated: false });
+    await handleTicketEvent(breach(null) as never);
+    expect(push.createNotification).toHaveBeenCalledTimes(2);
+    expect(push.createNotification).toHaveBeenCalledWith(expect.objectContaining({ userId: 'u-5', dedupeKey: 'ticket:t-1:sla:response:u-5' }));
+    expect(push.dispatchPushToTokens).toHaveBeenCalledTimes(2);
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+
+  it("'any' subscriber who is also the owner is notified once", async () => {
+    push.loadTicketPushPrefs.mockResolvedValueOnce({ assignedEnabled: true, slaScope: 'any' });
+    push.listAnySlaSubscribers.mockResolvedValueOnce({ users: [{ userId: 'u-2', partnerId: 'p-1', status: 'active', email: 'a@b' }], truncated: false });
+    await handleTicketEvent(breach('u-2') as never);
+    expect(push.createNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it("'any' subscriber without org access is filtered", async () => {
+    push.listAnySlaSubscribers.mockResolvedValueOnce({ users: [{ userId: 'u-5', partnerId: 'p-1', status: 'active', email: null }], truncated: false });
+    push.isAuthorisedForTicket.mockResolvedValueOnce(false);
+    await handleTicketEvent(breach(null) as never);
+    expect(push.createNotification).not.toHaveBeenCalled();
+  });
+
+  it('every dispatch happens after the system context exits', async () => {
+    push.listAnySlaSubscribers.mockResolvedValueOnce({ users: [{ userId: 'u-5', partnerId: 'p-1', status: 'active', email: null }], truncated: false });
+    await handleTicketEvent(breach('u-2') as never);
+    const exitAt = push.order.indexOf('ctx:exit');
+    expect(push.order.filter((x) => x === 'dispatch').length).toBe(2);
+    expect(push.order.slice(0, exitAt)).not.toContain('dispatch');
   });
 });

--- a/apps/api/src/jobs/ticketNotifyWorker.ts
+++ b/apps/api/src/jobs/ticketNotifyWorker.ts
@@ -28,7 +28,7 @@
 import { Worker, type Job } from 'bullmq';
 import { eq } from 'drizzle-orm';
 import * as dbModule from '../db';
-import { organizations, partners, tickets, userNotifications, users } from '../db/schema';
+import { organizations, partners, tickets } from '../db/schema';
 import { getEmailService } from '../services/email';
 import { escapeHtml } from '../services/emailLayout';
 import { buildThreadingHeaders, partnerInboundAddress, ticketThreadAnchor } from '../services/inboundEmail/outboundThreading';
@@ -39,6 +39,17 @@ import type { TicketTemplateVars } from '@breeze/shared';
 import { getBullMQConnection } from '../services/redis';
 import { captureException } from '../services/sentry';
 import { TICKET_EVENTS_QUEUE, type TicketEvent } from '../services/ticketEvents';
+import { createNotification } from '../services/userNotifications';
+import { buildTicketPush, dispatchPushToTokens } from '../services/expoPush';
+import {
+  assertSamePartner,
+  collectTicketPush,
+  isAuthorisedForTicket,
+  listAnySlaSubscribers,
+  loadTicketPushPrefs,
+  loadUserCandidate,
+  type PushJob,
+} from '../services/ticketPush';
 
 const { db } = dbModule;
 
@@ -70,17 +81,34 @@ async function getTicket(ticketId: string) {
   return rows[0] ?? null;
 }
 
+async function getOrgName(orgId: string): Promise<string> {
+  const rows = await db.select({ name: organizations.name }).from(organizations).where(eq(organizations.id, orgId)).limit(1);
+  return rows[0]?.name ?? '';
+}
+
+/** Resolved once per event; collected results are sent after the context exits. */
+interface Collected {
+  emails: EmailPayload[];
+  pushes: PushJob[];
+}
+
 /**
- * Returns collected email payloads (does not send). The assignee lookup is
- * done BEFORE the userNotifications insert so an FK-violation can never occur
+ * Returns collected email payloads AND push jobs (sends neither). The assignee
+ * lookup is done BEFORE the notification row so an FK violation can never occur
  * for a deleted user.
+ *
+ * W07 (#3901): the row is written through createNotification with a dedupeKey —
+ * that is the idempotency anchor. A null return means "already written by a
+ * previous attempt", so a BullMQ retry re-pushes nothing and re-emails nobody.
  */
 async function collectAssigneeNotification(
   event: TicketEvent,
-  assigneeId: string
-): Promise<EmailPayload[]> {
+  assigneeId: string,
+  eventId: string
+): Promise<Collected> {
+  const none: Collected = { emails: [], pushes: [] };
   // Self-assign: skip notification entirely.
-  if (!assigneeId || assigneeId === event.actorUserId) return [];
+  if (!assigneeId || assigneeId === event.actorUserId) return none;
 
   // Pre-commit emission contract: ticket may not be visible yet — throw to trigger retry.
   const ticket = await getTicket(event.ticketId);
@@ -91,35 +119,48 @@ async function collectAssigneeNotification(
   const label = ticket.internalNumber ?? ticket.ticketNumber ?? ticket.id;
 
   // Assignee lookup FIRST — if no user row, terminal condition (deleted user).
-  const assigneeRows = await db.select({ id: users.id, email: users.email })
-    .from(users)
-    .where(eq(users.id, assigneeId))
-    .limit(1);
-  const assignee = assigneeRows[0];
-  if (!assignee) {
-    // User was deleted — silently skip, no insert, no email (terminal).
-    return [];
-  }
+  // Then the D5 partner assertion: this worker runs with RLS bypassed, so the
+  // tenant boundary is entirely app-layer from here on.
+  const assignee = await loadUserCandidate(assigneeId);
+  if (!assignee) return none;
+  if (!assertSamePartner(assignee, event.partnerId, { ticketId: ticket.id })) return none;
+  if (assignee.status !== 'active') return none;
 
-  // Assignee exists — safe to insert FK-constrained notification row.
-  await db.insert(userNotifications).values({
+  // Idempotency anchor (D2): null = replay -> nothing else happens.
+  const id = await createNotification({
     userId: assigneeId,
     orgId: event.orgId,
     type: 'ticket',
     priority: 'normal',
     title: `Ticket assigned: ${label}`,
     message: ticket.subject,
-    link: `/tickets#${ticket.internalNumber ?? ticket.id}`
-  }).returning();
+    link: `/tickets#${ticket.internalNumber ?? ticket.id}`,
+    dedupeKey: `ticket:${ticket.id}:assigned:${assigneeId}:${eventId}`,
+  });
+  if (id === null) return none;
 
-  if (!assignee.email) return [];
+  const emails: EmailPayload[] = assignee.email
+    ? [{
+        to: assignee.email,
+        subject: `[${label}] Assigned to you: ${ticket.subject}`,
+        html: `<p>You have been assigned ticket <strong>${escapeHtml(label)}</strong>: ${escapeHtml(ticket.subject)}</p>`,
+        bestEffort: true,
+      }]
+    : [];
 
-  return [{
-    to: assignee.email,
-    subject: `[${label}] Assigned to you: ${ticket.subject}`,
-    html: `<p>You have been assigned ticket <strong>${escapeHtml(label)}</strong>: ${escapeHtml(ticket.subject)}</p>`,
-    bestEffort: true
-  }];
+  const pushes: PushJob[] = [];
+  const prefs = await loadTicketPushPrefs(assigneeId);
+  if (prefs.assignedEnabled && event.partnerId && (await isAuthorisedForTicket(assigneeId, event.partnerId, event.orgId))) {
+    const spec = buildTicketPush({
+      ticketId: ticket.id,
+      reason: 'assigned',
+      internalNumber: ticket.internalNumber ?? null,
+      orgName: await getOrgName(event.orgId),
+    });
+    const job = await collectTicketPush(assigneeId, spec);
+    if (job) pushes.push(job);
+  }
+  return { emails, pushes };
 }
 
 /**
@@ -281,52 +322,111 @@ async function collectAutoresponse(
 }
 
 async function collectSlaBreachNotification(
-  event: Extract<TicketEvent, { type: 'ticket.sla_breached' }>,
-  assigneeId: string
-): Promise<EmailPayload[]> {
+  event: Extract<TicketEvent, { type: 'ticket.sla_breached' }>
+): Promise<Collected> {
   const ticket = await getTicket(event.ticketId);
   if (!ticket) {
     throw new Error(`Ticket not found (likely uncommitted): ${event.ticketId}`);
   }
 
-  const assigneeRows = await db.select({ id: users.id, email: users.email })
-    .from(users)
-    .where(eq(users.id, assigneeId))
-    .limit(1);
-  const assignee = assigneeRows[0];
-  if (!assignee) {
-    return [];
-  }
-
   const label = event.payload.internalNumber ?? event.ticketId;
   const target = event.payload.target;
+  const emails: EmailPayload[] = [];
+  const pushes: PushJob[] = [];
+  const notified = new Set<string>();
+  let orgName: string | null = null;
+  const spec = async () =>
+    buildTicketPush({
+      ticketId: ticket.id,
+      reason: 'sla_breached',
+      target,
+      internalNumber: event.payload.internalNumber,
+      orgName: orgName ?? (orgName = await getOrgName(event.orgId)),
+    });
 
-  await db.insert(userNotifications).values({
-    userId: assigneeId,
-    orgId: event.orgId,
-    type: 'ticket',
-    priority: 'normal',
-    title: `SLA breached: ${label}`,
-    message: `${target} SLA breached for ${event.payload.subject}`,
-    link: `/tickets#${event.payload.internalNumber ?? event.ticketId}`
-  }).returning();
+  /**
+   * The in-app row is ALWAYS written for a candidate that reaches here; `push`
+   * governs the phone only (spec D6: the throttle applies to every push, never
+   * to in-app rows, and every push-drop row in the spec's failure-modes table
+   * keeps "in-app row + email written"). Suppressing the inbox row would also
+   * be a silent behaviour regression: the owner's SLA row is unconditional on
+   * main today.
+   */
+  const notify = async (userId: string, opts: { push: boolean }): Promise<void> => {
+    if (notified.has(userId)) return;
+    notified.add(userId);
+    const id = await createNotification({
+      userId,
+      orgId: event.orgId,
+      type: 'ticket',
+      priority: 'normal',
+      title: `SLA breached: ${label}`,
+      message: `${target} SLA breached for ${event.payload.subject}`,
+      link: `/tickets#${event.payload.internalNumber ?? event.ticketId}`,
+      dedupeKey: `ticket:${ticket.id}:sla:${target}:${userId}`,
+    });
+    if (id === null) return; // replay — nothing further
+    if (!opts.push) return;  // preference says no phone; row already written
+    const job = await collectTicketPush(userId, await spec());
+    if (job) pushes.push(job);
+  };
 
-  if (!assignee.email) return [];
+  // Owner: email and in-app row as before (unconditional). slaScope governs the
+  // PUSH only — 'off' means "stop buzzing my phone", not "hide it from my inbox".
+  const assigneeId = event.payload.assigneeId;
+  if (assigneeId) {
+    const assignee = await loadUserCandidate(assigneeId);
+    if (assignee && assertSamePartner(assignee, event.partnerId, { ticketId: ticket.id }) && assignee.status === 'active') {
+      if (assignee.email) {
+        emails.push({
+          to: assignee.email,
+          subject: `SLA breached: ${label} — ${event.payload.subject}`,
+          html: `<p>The ${escapeHtml(target)} SLA breached for ticket <strong>${escapeHtml(label)}</strong>: ${escapeHtml(event.payload.subject)}</p>`,
+          bestEffort: true,
+        });
+      }
+      const prefs = await loadTicketPushPrefs(assigneeId);
+      // Short-circuit deliberately: skip the permission round-trip when the
+      // preference already rules the push out.
+      const pushOwner =
+        prefs.slaScope !== 'off' &&
+        !!event.partnerId &&
+        (await isAuthorisedForTicket(assigneeId, event.partnerId, event.orgId));
+      await notify(assigneeId, { push: pushOwner });
+    }
+  }
 
-  return [{
-    to: assignee.email,
-    subject: `SLA breached: ${label} — ${event.payload.subject}`,
-    html: `<p>The ${escapeHtml(target)} SLA breached for ticket <strong>${escapeHtml(label)}</strong>: ${escapeHtml(event.payload.subject)}</p>`,
-    bestEffort: true
-  }];
+  // 'any' subscribers (D5): partner-filtered in SQL, re-authorised per user.
+  // Push only — no email.
+  //
+  // NOTE the asymmetry with the owner branch above, and it is intentional: an
+  // 'any' subscriber gets NO row at all when unauthorised, because they would
+  // not otherwise be a recipient of this ticket — writing an inbox row for
+  // someone who cannot access the org would leak the ticket's existence. The
+  // owner is already a legitimate recipient, so only their push is gated.
+  if (event.partnerId) {
+    const { users: subs } = await listAnySlaSubscribers(event.partnerId);
+    for (const sub of subs) {
+      if (notified.has(sub.userId)) continue;
+      if (!assertSamePartner(sub, event.partnerId, { ticketId: ticket.id })) continue;
+      if (!(await isAuthorisedForTicket(sub.userId, event.partnerId, event.orgId))) continue;
+      await notify(sub.userId, { push: true });
+    }
+  }
+
+  return { emails, pushes };
 }
 
 /**
  * Core handler: runs DB work inside the system context, collects email payloads,
  * then sends emails after the context exits.
  */
-export async function handleTicketEvent(event: TicketEvent): Promise<void> {
+export async function handleTicketEvent(event: TicketEvent, jobId?: string): Promise<void> {
+  // W07 (#3901): the dedupe anchor. Jobs queued before eventId shipped lack it,
+  // so fall back to the BullMQ job id (stable across that job's retries).
+  const eventId = event.eventId ?? jobId ?? `legacy:${event.ticketId}:${event.type}`;
   let emailPayloads: EmailPayload[] = [];
+  let pushJobs: PushJob[] = [];
 
   await runWithSystemDbAccess(async () => {
     switch (event.type) {
@@ -334,15 +434,18 @@ export async function handleTicketEvent(event: TicketEvent): Promise<void> {
       case 'ticket.assigned': {
         const assigneeId = event.payload.assigneeId;
         if (assigneeId) {
-          emailPayloads = await collectAssigneeNotification(event, assigneeId);
+          const collected = await collectAssigneeNotification(event, assigneeId, eventId);
+          emailPayloads = collected.emails;
+          pushJobs = collected.pushes;
         }
         return;
       }
       case 'ticket.sla_breached': {
-        const assigneeId = event.payload.assigneeId;
-        if (assigneeId) {
-          emailPayloads = await collectSlaBreachNotification(event, assigneeId);
-        }
+        // NOT gated on assigneeId any more: an UNASSIGNED breach still fans out
+        // to partner-wide ('any') SLA subscribers.
+        const collected = await collectSlaBreachNotification(event);
+        emailPayloads = collected.emails;
+        pushJobs = collected.pushes;
         return;
       }
       case 'ticket.commented': {
@@ -419,6 +522,16 @@ export async function handleTicketEvent(event: TicketEvent): Promise<void> {
     }
   });
 
+  // Pushes — OUTSIDE the DB context (#1105). Best-effort; dispatchPushToTokens
+  // never throws. Deliberately BEFORE the email early-return below: a push-only
+  // recipient ('any' SLA subscriber) produces zero email payloads.
+  for (const job of pushJobs) {
+    const r = await dispatchPushToTokens(job.tokens, job.spec, 'ticket');
+    if (r.errors > 0) {
+      console.warn(`[TicketNotify] ticket push partial failure ticket=${event.ticketId} dispatched=${r.dispatched} errors=${r.errors}`);
+    }
+  }
+
   // Send emails OUTSIDE the DB context to avoid idle-in-transaction pool poison (#1105).
   if (emailPayloads.length === 0) return;
   // getEmailService() may be null (no platform transport configured). Graph payloads
@@ -470,7 +583,7 @@ export function initializeTicketNotifyWorker(): Promise<void> {
 
   worker = new Worker<TicketEvent>(
     TICKET_EVENTS_QUEUE,
-    async (job: Job<TicketEvent>) => handleTicketEvent(job.data),
+    async (job: Job<TicketEvent>) => handleTicketEvent(job.data, job.id),
     { connection: getBullMQConnection(), concurrency: 5 }
   );
 

--- a/apps/api/src/jobs/ticketNotifyWorker.ts
+++ b/apps/api/src/jobs/ticketNotifyWorker.ts
@@ -42,13 +42,14 @@ import { TICKET_EVENTS_QUEUE, type TicketEvent } from '../services/ticketEvents'
 import { createNotification } from '../services/userNotifications';
 import { buildTicketPush, dispatchPushToTokens } from '../services/expoPush';
 import {
+  admitPush,
   assertSamePartner,
-  collectTicketPush,
   isAuthorisedForTicket,
   listAnySlaSubscribers,
   loadTicketPushPrefs,
   loadUserCandidate,
-  type PushJob,
+  resolvePushJobs,
+  type PendingPush,
 } from '../services/ticketPush';
 
 const { db } = dbModule;
@@ -89,7 +90,12 @@ async function getOrgName(orgId: string): Promise<string> {
 /** Resolved once per event; collected results are sent after the context exits. */
 interface Collected {
   emails: EmailPayload[];
-  pushes: PushJob[];
+  /**
+   * Recipients that SHOULD be pushed. Deliberately not resolved jobs: the
+   * transport gates (Redis throttle) and the device read happen after the
+   * collection context closes — see handleTicketEvent (#1105).
+   */
+  pushes: PendingPush[];
 }
 
 /**
@@ -123,8 +129,15 @@ async function collectAssigneeNotification(
   // tenant boundary is entirely app-layer from here on.
   const assignee = await loadUserCandidate(assigneeId);
   if (!assignee) return none;
-  if (!assertSamePartner(assignee, event.partnerId, { ticketId: ticket.id })) return none;
-  if (assignee.status !== 'active') return none;
+  // A NULL event.partnerId is NOT a mismatch. `tickets.partner_id` is
+  // deliberately nullable (2026-06-09-a-native-ticketing-core.sql: "old API
+  // code may still insert tickets without it during a rolling deploy") and both
+  // emitters propagate the null verbatim, so treating it as a forged recipient
+  // would drop the row AND the email main writes unconditionally — and raise a
+  // Sentry error for a legacy row. When the event carries no partner the PUSH
+  // is withheld (it is gated on event.partnerId below); the inbox row and email
+  // are not.
+  if (event.partnerId && !assertSamePartner(assignee, event.partnerId, { ticketId: ticket.id })) return none;
 
   // Idempotency anchor (D2): null = replay -> nothing else happens.
   const id = await createNotification({
@@ -148,17 +161,27 @@ async function collectAssigneeNotification(
       }]
     : [];
 
-  const pushes: PushJob[] = [];
+  // Account status (D5) gates the PHONE only — a device cannot be registered
+  // without a login, so a non-active user has nothing to push to. It must never
+  // suppress the inbox row or the email: an invited technician assigned a
+  // ticket before accepting their invite still has to be told.
+  const pushes: PendingPush[] = [];
   const prefs = await loadTicketPushPrefs(assigneeId);
-  if (prefs.assignedEnabled && event.partnerId && (await isAuthorisedForTicket(assigneeId, event.partnerId, event.orgId))) {
-    const spec = buildTicketPush({
-      ticketId: ticket.id,
-      reason: 'assigned',
-      internalNumber: ticket.internalNumber ?? null,
-      orgName: await getOrgName(event.orgId),
+  if (
+    prefs.assignedEnabled &&
+    assignee.status === 'active' &&
+    event.partnerId &&
+    (await isAuthorisedForTicket(assigneeId, event.partnerId, event.orgId))
+  ) {
+    pushes.push({
+      userId: assigneeId,
+      spec: buildTicketPush({
+        ticketId: ticket.id,
+        reason: 'assigned',
+        internalNumber: ticket.internalNumber ?? null,
+        orgName: await getOrgName(event.orgId),
+      }),
     });
-    const job = await collectTicketPush(assigneeId, spec);
-    if (job) pushes.push(job);
   }
   return { emails, pushes };
 }
@@ -332,7 +355,7 @@ async function collectSlaBreachNotification(
   const label = event.payload.internalNumber ?? event.ticketId;
   const target = event.payload.target;
   const emails: EmailPayload[] = [];
-  const pushes: PushJob[] = [];
+  const pushes: PendingPush[] = [];
   const notified = new Set<string>();
   let orgName: string | null = null;
   const spec = async () =>
@@ -352,8 +375,8 @@ async function collectSlaBreachNotification(
    * be a silent behaviour regression: the owner's SLA row is unconditional on
    * main today.
    */
-  const notify = async (userId: string, opts: { push: boolean }): Promise<void> => {
-    if (notified.has(userId)) return;
+  const notify = async (userId: string, opts: { push: boolean }): Promise<boolean> => {
+    if (notified.has(userId)) return false;
     notified.add(userId);
     const id = await createNotification({
       userId,
@@ -365,10 +388,9 @@ async function collectSlaBreachNotification(
       link: `/tickets#${event.payload.internalNumber ?? event.ticketId}`,
       dedupeKey: `ticket:${ticket.id}:sla:${target}:${userId}`,
     });
-    if (id === null) return; // replay — nothing further
-    if (!opts.push) return;  // preference says no phone; row already written
-    const job = await collectTicketPush(userId, await spec());
-    if (job) pushes.push(job);
+    if (id === null) return false; // replay — nothing further, INCLUDING the email
+    if (opts.push) pushes.push({ userId, spec: await spec() });
+    return true;
   };
 
   // Owner: email and in-app row as before (unconditional). slaScope governs the
@@ -376,8 +398,25 @@ async function collectSlaBreachNotification(
   const assigneeId = event.payload.assigneeId;
   if (assigneeId) {
     const assignee = await loadUserCandidate(assigneeId);
-    if (assignee && assertSamePartner(assignee, event.partnerId, { ticketId: ticket.id }) && assignee.status === 'active') {
-      if (assignee.email) {
+    // Same null-partner rule as the assigned branch: a legacy ticket with no
+    // partner_id is not a forged recipient, it just cannot be pushed.
+    const partnerOk = assignee && (!event.partnerId || assertSamePartner(assignee, event.partnerId, { ticketId: ticket.id }));
+    if (assignee && partnerOk) {
+      const prefs = await loadTicketPushPrefs(assigneeId);
+      // Short-circuit deliberately: skip the permission round-trip when the
+      // preference (or a non-active account) already rules the push out.
+      const pushOwner =
+        prefs.slaScope !== 'off' &&
+        assignee.status === 'active' &&
+        !!event.partnerId &&
+        (await isAuthorisedForTicket(assigneeId, event.partnerId, event.orgId));
+      // The email is queued only AFTER the dedupe anchor confirms this is not a
+      // replay. Queuing it first (as this branch originally did) meant a
+      // redelivered BullMQ job re-emailed the owner while the row and the push
+      // both deduped — breaking the wave's "a retry re-emails nobody" contract
+      // that the assigned branch already honours.
+      const wrote = await notify(assigneeId, { push: pushOwner });
+      if (wrote && assignee.email) {
         emails.push({
           to: assignee.email,
           subject: `SLA breached: ${label} — ${event.payload.subject}`,
@@ -385,14 +424,6 @@ async function collectSlaBreachNotification(
           bestEffort: true,
         });
       }
-      const prefs = await loadTicketPushPrefs(assigneeId);
-      // Short-circuit deliberately: skip the permission round-trip when the
-      // preference already rules the push out.
-      const pushOwner =
-        prefs.slaScope !== 'off' &&
-        !!event.partnerId &&
-        (await isAuthorisedForTicket(assigneeId, event.partnerId, event.orgId));
-      await notify(assigneeId, { push: pushOwner });
     }
   }
 
@@ -426,7 +457,7 @@ export async function handleTicketEvent(event: TicketEvent, jobId?: string): Pro
   // so fall back to the BullMQ job id (stable across that job's retries).
   const eventId = event.eventId ?? jobId ?? `legacy:${event.ticketId}:${event.type}`;
   let emailPayloads: EmailPayload[] = [];
-  let pushJobs: PushJob[] = [];
+  let pending: PendingPush[] = [];
 
   await runWithSystemDbAccess(async () => {
     switch (event.type) {
@@ -436,7 +467,7 @@ export async function handleTicketEvent(event: TicketEvent, jobId?: string): Pro
         if (assigneeId) {
           const collected = await collectAssigneeNotification(event, assigneeId, eventId);
           emailPayloads = collected.emails;
-          pushJobs = collected.pushes;
+          pending = collected.pushes;
         }
         return;
       }
@@ -445,7 +476,7 @@ export async function handleTicketEvent(event: TicketEvent, jobId?: string): Pro
         // to partner-wide ('any') SLA subscribers.
         const collected = await collectSlaBreachNotification(event);
         emailPayloads = collected.emails;
-        pushJobs = collected.pushes;
+        pending = collected.pushes;
         return;
       }
       case 'ticket.commented': {
@@ -522,9 +553,18 @@ export async function handleTicketEvent(event: TicketEvent, jobId?: string): Pro
     }
   });
 
-  // Pushes — OUTSIDE the DB context (#1105). Best-effort; dispatchPushToTokens
-  // never throws. Deliberately BEFORE the email early-return below: a push-only
-  // recipient ('any' SLA subscriber) produces zero email payloads.
+  // Push materialisation and delivery — all OUTSIDE the collection context
+  // (#1105). The collection transaction above is now bounded to permission
+  // reads and notification inserts; the Redis throttle runs with no DB context
+  // open at all, and the device read gets its own SHORT, batched system context
+  // (the alertWorker pattern: one short context per DB read, never a blanket
+  // wrap around a fan-out loop). Deliberately BEFORE the email early-return
+  // below: a push-only recipient ('any' SLA subscriber) produces zero emails.
+  const admitted = await admitPush(pending);
+  const pushJobs = admitted.length > 0
+    ? await runWithSystemDbAccess(() => resolvePushJobs(admitted))
+    : [];
+
   for (const job of pushJobs) {
     const r = await dispatchPushToTokens(job.tokens, job.spec, 'ticket');
     if (r.errors > 0) {

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -2735,6 +2735,59 @@ describe('user routes', () => {
       expect(res.status).toBe(200);
     });
 
+    // W07 (#3901): the ticket push preference routes are self-service — the
+    // subject is always auth.user.id and the body schema is .strict(), so a
+    // smuggled userId is a 400, never an escalation. They must therefore be
+    // exempt from the partner-wide MANAGEMENT gate, exactly as /me is. The
+    // technician this feature targets is a 'selected'-access partner user; if
+    // the gate applies, the whole wave is unreachable for them.
+    it('exempts GET /me/ticket-push-preferences for a non-all partner admin', async () => {
+      seedMembership('selected');
+      authAsPartner();
+      // Only select is the preference lookup (no row) — the gate must NOT run
+      // its partnerUsers membership query on a self-service path.
+      vi.mocked(db.select).mockReset().mockReturnValue({
+        from: vi.fn(() => ({ where: vi.fn(() => ({ limit: vi.fn(() => Promise.resolve([])) })) })),
+      } as any);
+
+      const res = await app.request('/users/me/ticket-push-preferences', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ settings: { assignedEnabled: true, slaScope: 'owned' } });
+    });
+
+    it('exempts PATCH /me/ticket-push-preferences for a non-all partner admin', async () => {
+      seedMembership('none');
+      authAsPartner();
+      vi.mocked(db.insert).mockReturnValueOnce({
+        values: vi.fn(() => ({
+          onConflictDoUpdate: vi.fn(() => ({
+            returning: vi.fn(() => Promise.resolve([{ assignedEnabled: true, slaScope: 'any' }])),
+          })),
+        })),
+      } as never);
+
+      const res = await app.request('/users/me/ticket-push-preferences', {
+        method: 'PATCH',
+        headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ slaScope: 'any' }),
+      });
+
+      expect(res.status).toBe(200);
+    });
+
+    // Control: the gate itself must still bite on partner-wide MANAGEMENT.
+    // Without this, widening the regex to something too broad passes silently.
+    it("still denies a 'selected' partner-admin on partner-wide user management", async () => {
+      seedMembership('selected');
+      authAsPartner();
+      const res = await app.request('/users', { method: 'GET', headers: { Authorization: 'Bearer token' } });
+      expect(res.status).toBe(403);
+    });
+
     it('exempts self-service GET /me from the management gate for non-all admins', async () => {
       // A 'selected'/'none' partner admin (accessibleOrgIds IS an array, so the
       // shape early-return does NOT fire) must still reach their own profile —

--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -167,6 +167,12 @@ vi.mock('../db/schema', () => ({
   sensitiveDataPolicies: {},
   peripheralPolicies: {},
   discoveredAssetTypeEnum: { enumValues: ['workstation', 'server', 'printer', 'unknown'] },
+  ticketPushPreferences: {
+    userId: { __column: 'ticket_push_preferences.user_id' },
+    assignedEnabled: { __column: 'ticket_push_preferences.assigned_enabled' },
+    slaScope: { __column: 'ticket_push_preferences.sla_scope' },
+    updatedAt: { __column: 'ticket_push_preferences.updated_at' },
+  },
 }));
 
 vi.mock('drizzle-orm', async (importOriginal) => {
@@ -207,6 +213,13 @@ vi.mock('../services/sentry', () => ({
 
 vi.mock('../services/auditService', () => ({
   createAuditLogAsync: createAuditLogAsyncMock
+}));
+
+// W07 (#3901): the ticket push preference PATCH audits through writeRouteAudit.
+const { writeRouteAuditMock } = vi.hoisted(() => ({ writeRouteAuditMock: vi.fn() }));
+vi.mock('../services/auditEvents', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../services/auditEvents')>()),
+  writeRouteAudit: writeRouteAuditMock,
 }));
 
 vi.mock('../services/clientIp', () => ({
@@ -2747,5 +2760,88 @@ describe('user routes', () => {
 
       expect(res.status).toBe(200);
     });
+  });
+});
+
+
+// ---------------------------------------------------------------------------
+// W07 (#3901): /me/ticket-push-preferences
+// ---------------------------------------------------------------------------
+
+/**
+ * Earlier describes in this file leave `authMiddleware` mocked as a partner
+ * user WITH accessibleOrgIds (the gate suite). Reset it to the file's default
+ * so these route tests are order-independent; the gate-exemption behaviour is
+ * asserted separately inside `full partner access gate (orgAccess===all)`.
+ */
+function authAsDefaultPartner(): void {
+  vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+    c.set('auth', {
+      scope: 'partner',
+      partnerId: 'partner-123',
+      orgId: null,
+      user: { id: 'user-123', email: 'test@example.com' }
+    });
+    return next();
+  });
+}
+
+describe('GET /me/ticket-push-preferences', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authAsDefaultPartner();
+    vi.mocked(db.select).mockReset().mockReturnValue({
+      from: vi.fn(() => ({ where: vi.fn(() => ({ limit: vi.fn(() => Promise.resolve([])) })) })),
+    } as never);
+  });
+
+  it('returns defaults when no row exists and does not insert', async () => {
+    const app = new Hono().route('/users', userRoutes);
+    const res = await app.request('/users/me/ticket-push-preferences');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ settings: { assignedEnabled: true, slaScope: 'owned' } });
+    expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
+  });
+
+  it('returns the stored row', async () => {
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: () => ({ where: () => ({ limit: () => Promise.resolve([{ assignedEnabled: false, slaScope: 'any' }]) }) }),
+    } as never);
+    const app = new Hono().route('/users', userRoutes);
+    const res = await app.request('/users/me/ticket-push-preferences');
+    expect(await res.json()).toEqual({ settings: { assignedEnabled: false, slaScope: 'any' } });
+  });
+});
+
+describe('PATCH /me/ticket-push-preferences', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authAsDefaultPartner();
+  });
+
+  const patch = (body: unknown) =>
+    new Hono().route('/users', userRoutes).request('/users/me/ticket-push-preferences', {
+      method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body),
+    });
+
+  it('400 on empty body', async () => { expect((await patch({})).status).toBe(400); });
+  it('400 on unknown key (strict) — userId can never come from the body', async () => {
+    expect((await patch({ userId: 'someone-else', slaScope: 'off' })).status).toBe(400);
+  });
+  it('400 on invalid scope', async () => { expect((await patch({ slaScope: 'all' })).status).toBe(400); });
+
+  it('upserts only the provided fields for auth.user.id and audits', async () => {
+    const valuesMock = vi.fn((_v: Record<string, unknown>) => ({
+      onConflictDoUpdate: vi.fn(() => ({ returning: vi.fn(() => Promise.resolve([{ assignedEnabled: true, slaScope: 'any' }])) })),
+    }));
+    vi.mocked(db.insert).mockReturnValueOnce({ values: valuesMock } as never);
+    const res = await patch({ slaScope: 'any' });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ settings: { assignedEnabled: true, slaScope: 'any' } });
+    expect(valuesMock).toHaveBeenCalledWith(expect.objectContaining({ userId: 'user-123', slaScope: 'any' }));
+    expect(valuesMock.mock.calls[0]![0]).not.toHaveProperty('assignedEnabled');
+    expect(writeRouteAuditMock).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      action: 'user.ticket_push_preferences.update', resourceId: 'user-123',
+    }));
   });
 });

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { SUPPORTED_LOCALES } from '@breeze/shared';
+import { SUPPORTED_LOCALES, resolveTicketPushPrefs, updateTicketPushPreferencesSchema } from '@breeze/shared';
 import type { SupportedLocale } from '@breeze/shared';
 import { zValidator } from '../lib/validation';
 import { bodyLimit } from 'hono/body-limit';
@@ -8,7 +8,7 @@ import { and, eq, or } from 'drizzle-orm';
 import { HTTPException } from 'hono/http-exception';
 import { nanoid } from 'nanoid';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
-import { users, partnerUsers, organizationUsers, roles, organizations, partners } from '../db/schema';
+import { users, partnerUsers, organizationUsers, roles, organizations, partners, ticketPushPreferences } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission } from '../middleware/auth';
 import {
   MAX_AVATAR_SIZE_BYTES,
@@ -32,6 +32,7 @@ import {
   type ScopeContext,
 } from '../services/roleAssignment';
 import { createAuditLogAsync } from '../services/auditService';
+import { writeRouteAudit } from '../services/auditEvents';
 import { getTrustedClientIpOrUndefined } from '../services/clientIp';
 import { getEmailService } from '../services/email';
 import { captureException } from '../services/sentry';
@@ -460,6 +461,62 @@ function validatePreferenceEnum(
   }
   return null;
 }
+
+// W07 (#3901): per-user ticket push preferences. Self-only by construction —
+// the user id is auth.user.id, never a param or body field (the schema is
+// .strict(), so a smuggled userId is a 400). Lives on the core user route, not
+// /mobile, so a web Settings toggle can reuse it later (spec D10).
+//
+// NOTE: these paths are exempted from the partner-wide MANAGEMENT gate at the
+// top of this file — see the isSelfServiceRoute predicate.
+userRoutes.get('/me/ticket-push-preferences', async (c) => {
+  const auth = c.get('auth');
+  const rows = await db
+    .select({
+      assignedEnabled: ticketPushPreferences.assignedEnabled,
+      slaScope: ticketPushPreferences.slaScope,
+    })
+    .from(ticketPushPreferences)
+    .where(eq(ticketPushPreferences.userId, auth.user.id))
+    .limit(1);
+  // Missing row = defaults; no insert on read.
+  return c.json({ settings: resolveTicketPushPrefs(rows[0] ?? null) });
+});
+
+userRoutes.patch(
+  '/me/ticket-push-preferences',
+  zValidator('json', updateTicketPushPreferencesSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const body = c.req.valid('json');
+    const set: { assignedEnabled?: boolean; slaScope?: 'off' | 'owned' | 'any'; updatedAt: Date } = {
+      updatedAt: new Date(),
+    };
+    if (body.assignedEnabled !== undefined) set.assignedEnabled = body.assignedEnabled;
+    if (body.slaScope !== undefined) set.slaScope = body.slaScope;
+
+    const [row] = await db
+      .insert(ticketPushPreferences)
+      .values({ userId: auth.user.id, ...set })
+      .onConflictDoUpdate({ target: ticketPushPreferences.userId, set })
+      .returning({
+        assignedEnabled: ticketPushPreferences.assignedEnabled,
+        slaScope: ticketPushPreferences.slaScope,
+      });
+
+    writeRouteAudit(c, {
+      // orgId is a REQUIRED property on RouteAuditInput (services/auditEvents.ts),
+      // so it cannot be omitted. A partner-scoped mobile token has no org.
+      orgId: auth.orgId ?? null,
+      action: 'user.ticket_push_preferences.update',
+      resourceType: 'user',
+      resourceId: auth.user.id,
+      details: { ...body },
+    });
+
+    return c.json({ settings: resolveTicketPushPrefs(row ?? set) });
+  }
+);
 
 userRoutes.patch('/me', zValidator('json', updateMeSchema), async (c) => {
   const auth = c.get('auth');

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -57,14 +57,23 @@ userRoutes.use('*', async (c, next) => {
     return;
   }
 
-  // Self-service routes (own profile + own/displayed avatar) must stay accessible
-  // to EVERY partner user regardless of org-access level. This gate governs
-  // partner-wide user MANAGEMENT only — without this exemption a 'selected'/'none'
-  // partner admin would be 403'd on GET/PATCH /me and the top-bar avatar
-  // (GET /:id/avatar runs its own scope check in the handler).
+  // Self-service routes (own profile + own/displayed avatar + own notification
+  // preferences) must stay accessible to EVERY partner user regardless of
+  // org-access level. This gate governs partner-wide user MANAGEMENT only —
+  // without this exemption a 'selected'/'none' partner admin would be 403'd on
+  // GET/PATCH /me, the top-bar avatar (GET /:id/avatar runs its own scope check
+  // in the handler), and (W07, #3901) their own ticket push preferences, which
+  // is the field technician this feature exists for.
+  //
+  // A route may be added here ONLY if its subject is derived from auth.user.id
+  // and never from a path param or request body. Both /me/ticket-push-preferences
+  // handlers satisfy that: the id is auth.user.id and the PATCH schema is
+  // .strict(), so a smuggled `userId` is a 400. Do NOT widen this to
+  // /\/me(\/.*)?$/ — that would auto-exempt every future /me/* route,
+  // including ones whose subject is not auth.user.id. The allowlist is the point.
   const path = c.req.path;
   const isSelfServiceRoute =
-    /\/me(\/avatar)?$/.test(path) ||
+    /\/me(\/avatar|\/ticket-push-preferences)?$/.test(path) ||
     (c.req.method === 'GET' && /\/avatar$/.test(path));
   if (isSelfServiceRoute) {
     await next();

--- a/apps/api/src/services/apns.test.ts
+++ b/apps/api/src/services/apns.test.ts
@@ -185,6 +185,32 @@ describe('apns — buildApnsRequest', () => {
     });
   });
 
+  /**
+   * REGRESSION (#4281 review, critical): APNs rejects an `apns-collapse-id`
+   * longer than 64 BYTES with 400 `BadCollapseId`, and nothing on the path
+   * bounded it. The wire layer is the last place that can guarantee the
+   * contract regardless of what a caller builds.
+   */
+  it('clamps an over-long collapse id to 64 bytes, deterministically and injectively', async () => {
+    mockConfig(CONFIGURED);
+    const { buildApnsRequest } = await import('./apns');
+
+    const long = `ticket:${'a'.repeat(80)}:sla_breached:resolution`;
+    const got = buildApnsRequest('tok', { title: 'T', body: 'B', collapseId: long }, 'JWT')
+      .headers['apns-collapse-id']!;
+
+    expect(Buffer.byteLength(got, 'utf8')).toBeLessThanOrEqual(64);
+    // Same input -> same header (coalescing still works across sends).
+    expect(buildApnsRequest('tok', { title: 'T', body: 'B', collapseId: long }, 'JWT')
+      .headers['apns-collapse-id']).toBe(got);
+    // Different input -> different header (distinct notifications never merge).
+    expect(buildApnsRequest('tok', { title: 'T', body: 'B', collapseId: `${long}x` }, 'JWT')
+      .headers['apns-collapse-id']).not.toBe(got);
+    // A value already inside the limit is passed through untouched.
+    expect(buildApnsRequest('tok', { title: 'T', body: 'B', collapseId: 'grp-1' }, 'JWT')
+      .headers['apns-collapse-id']).toBe('grp-1');
+  });
+
   it('never lets a caller-supplied aps key in data clobber the notification payload', async () => {
     mockConfig(CONFIGURED);
     const { buildApnsRequest } = await import('./apns');

--- a/apps/api/src/services/apns.test.ts
+++ b/apps/api/src/services/apns.test.ts
@@ -112,6 +112,22 @@ describe('apns — provider JWT', () => {
 });
 
 describe('apns — buildApnsRequest', () => {
+  it('emits aps.thread-id and aps.category only when set', async () => {
+    mockConfig(CONFIGURED);
+    const { buildApnsRequest } = await import('./apns');
+    const req = buildApnsRequest('tok', { title: 'T', body: 'B', threadId: 'ticket:t-1', category: 'BREEZE_TICKET' }, 'jwt');
+    const body = JSON.parse(req.body);
+    expect(body.aps['thread-id']).toBe('ticket:t-1');
+    expect(body.aps.category).toBe('BREEZE_TICKET');
+  });
+
+  it('keeps the approval request byte-identical when threadId/category are absent', async () => {
+    mockConfig(CONFIGURED);
+    const { buildApnsRequest } = await import('./apns');
+    const before = JSON.parse(buildApnsRequest('tok', { title: 'T', body: 'B', data: { type: 'approval' } }, 'jwt').body);
+    expect(Object.keys(before.aps).sort()).toEqual(['alert', 'sound']);
+  });
+
   beforeEach(() => vi.resetModules());
   afterEach(() => {
     vi.resetModules();

--- a/apps/api/src/services/apns.ts
+++ b/apps/api/src/services/apns.ts
@@ -83,6 +83,10 @@ export interface ApnsPayload {
   collapseId?: string;
   /** Store-and-forward window in seconds. 0 = deliver immediately or discard. */
   ttl?: number;
+  /** Groups notifications in Notification Center (aps.thread-id). */
+  threadId?: string;
+  /** UNNotificationCategory identifier (aps.category). No client category is registered in W07. */
+  category?: string;
 }
 
 export interface ApnsRequest {
@@ -170,14 +174,21 @@ export function buildApnsRequest(deviceToken: string, payload: ApnsPayload, jwt:
     headers['apns-collapse-id'] = payload.collapseId;
   }
 
+  // Optional keys are assigned conditionally so a payload without them stays
+  // byte-identical to what shipped before W07 (the approval path asserts on
+  // exact key sets).
+  const aps: Record<string, unknown> = {
+    alert: { title: payload.title, body: payload.body },
+    sound: 'default',
+  };
+  if (payload.threadId) aps['thread-id'] = payload.threadId;
+  if (payload.category) aps.category = payload.category;
+
   // Spread custom data first so a caller-supplied `aps` key can never clobber
   // the notification payload (aps is a reserved APNs key).
   const body = JSON.stringify({
     ...(payload.data ?? {}),
-    aps: {
-      alert: { title: payload.title, body: payload.body },
-      sound: 'default',
-    },
+    aps,
   });
 
   return { path, headers, body };

--- a/apps/api/src/services/apns.ts
+++ b/apps/api/src/services/apns.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import http2 from 'node:http2';
 import { importPKCS8, SignJWT } from 'jose';
 import { getConfig } from '../config/validate';
@@ -30,6 +31,9 @@ const DEFAULT_TTL_SECONDS = 60 * 60;
 // should be purged from our DB rather than retried. Mirrors the DeviceNotRegistered
 // handling in expoPush.ts.
 const UNREGISTERED_REASONS = new Set(['BadDeviceToken', 'Unregistered', 'DeviceTokenNotForTopic']);
+
+// APNs rejects an apns-collapse-id longer than 64 bytes with 400 BadCollapseId.
+const MAX_COLLAPSE_ID_BYTES = 64;
 
 const PROD_HOST = 'https://api.push.apple.com';
 const SANDBOX_HOST = 'https://api.sandbox.push.apple.com';
@@ -147,6 +151,19 @@ export function __resetApnsProviderTokenCacheForTests(): void {
 }
 
 /**
+ * Enforces Apple's 64-byte `apns-collapse-id` ceiling at the wire layer, so a
+ * caller can never silently lose every push of a category to 400
+ * BadCollapseId (#4281: `ticket:<uuid>:sla_breached:resolution` was 67 bytes).
+ * Over-long values collapse to a sha256 prefix: deterministic (coalescing still
+ * works across sends) and injective in practice (distinct notifications never
+ * merge). Values already inside the limit pass through byte-identical.
+ */
+export function clampCollapseId(value: string): string {
+  if (Buffer.byteLength(value, 'utf8') <= MAX_COLLAPSE_ID_BYTES) return value;
+  return createHash('sha256').update(value).digest('hex').slice(0, 32);
+}
+
+/**
  * Builds the HTTP/2 request (pseudo-headers + JSON body) for a single push.
  * PURE: no network, no config beyond the bundle id, deterministic given inputs
  * (except apns-expiration, which is now()+ttl). The signed provider JWT is
@@ -171,7 +188,7 @@ export function buildApnsRequest(deviceToken: string, payload: ApnsPayload, jwt:
     'apns-expiration': String(expiration),
   };
   if (payload.collapseId) {
-    headers['apns-collapse-id'] = payload.collapseId;
+    headers['apns-collapse-id'] = clampCollapseId(payload.collapseId);
   }
 
   // Optional keys are assigned conditionally so a payload without them stays

--- a/apps/api/src/services/expoPush.test.ts
+++ b/apps/api/src/services/expoPush.test.ts
@@ -42,6 +42,9 @@ import {
   buildApprovalPush,
   getUserPushTokens,
   dispatchApprovalPush,
+  buildTicketPush,
+  dispatchPushToTokens,
+  dispatchApprovalPushToTokens,
 } from './expoPush';
 import { db } from '../db';
 
@@ -392,5 +395,66 @@ describe('dispatchApprovalPush routing', () => {
     expect(sendApnsNotificationMock).not.toHaveBeenCalled();
     expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining('not wired to FCM'));
     infoSpy.mockRestore();
+  });
+});
+
+
+// ---------------------------------------------------------------------------
+// W07 (#3901): generalised push spec + ticket pushes
+// ---------------------------------------------------------------------------
+
+describe('buildTicketPush', () => {
+  it('assigned: lock-screen-safe body, 24h ttl, collapse/thread ids, no subject', () => {
+    const spec = buildTicketPush({ ticketId: 't-1', reason: 'assigned', internalNumber: 'T-2026-0042', orgName: 'Acme' });
+    expect(spec.title).toBe('Ticket assigned to you');
+    expect(spec.body).toBe('T-2026-0042 \u00b7 Acme');
+    expect(spec.data).toEqual({ type: 'ticket', ticketId: 't-1', reason: 'assigned', internalNumber: 'T-2026-0042' });
+    expect(spec.ttl).toBe(86400);
+    expect(spec.collapseId).toBe('ticket:t-1:assigned');
+    expect(spec.threadId).toBe('ticket:t-1');
+    expect(spec.category).toBe('BREEZE_TICKET');
+    expect(spec.channelId).toBe('tickets');
+    expect(JSON.stringify(spec)).not.toContain('subject');
+  });
+  it('sla_breached: target in title/collapse, 4h ttl, "Ticket" fallback label', () => {
+    const spec = buildTicketPush({ ticketId: 't-1', reason: 'sla_breached', target: 'response', internalNumber: null, orgName: 'Acme' });
+    expect(spec.title).toBe('SLA breached (response)');
+    expect(spec.body).toBe('Ticket \u00b7 Acme');
+    expect(spec.ttl).toBe(14400);
+    expect(spec.collapseId).toBe('ticket:t-1:sla_breached:response');
+    expect(spec.data).toEqual({ type: 'ticket', ticketId: 't-1', reason: 'sla_breached', target: 'response' });
+  });
+  it('truncates a long org name', () => {
+    const spec = buildTicketPush({ ticketId: 't-1', reason: 'assigned', internalNumber: 'T-1', orgName: 'x'.repeat(200) });
+    expect(spec.body.length).toBeLessThanOrEqual('T-1 \u00b7 '.length + 60);
+  });
+});
+
+describe('dispatchPushToTokens', () => {
+  beforeEach(() => { sendApnsNotificationMock.mockReset(); updateSetCalls.length = 0; });
+
+  it('forwards ttl, collapseId, threadId and category to APNs', async () => {
+    sendApnsNotificationMock.mockResolvedValue({ ok: true, status: 200 });
+    const spec = buildTicketPush({ ticketId: 't-1', reason: 'assigned', internalNumber: 'T-1', orgName: 'Acme' });
+    const res = await dispatchPushToTokens([{ token: 'apns-1', platform: 'ios', provider: 'apns' }], spec);
+    expect(res).toEqual({ tokensFound: 1, dispatched: 1, errors: 0 });
+    expect(sendApnsNotificationMock).toHaveBeenCalledWith('apns-1', expect.objectContaining({
+      ttl: 86400, collapseId: 'ticket:t-1:assigned', threadId: 'ticket:t-1', category: 'BREEZE_TICKET',
+    }));
+  });
+
+  it('purges an unregistered APNs token', async () => {
+    sendApnsNotificationMock.mockResolvedValue({ ok: false, status: 410, unregistered: true });
+    await dispatchPushToTokens([{ token: 'dead', platform: 'ios', provider: 'apns' }],
+      buildTicketPush({ ticketId: 't-1', reason: 'assigned', internalNumber: 'T-1', orgName: 'Acme' }));
+    expect(updateSetCalls).toContainEqual({ apnsToken: null });
+  });
+
+  it('approval wrapper output is unchanged', async () => {
+    sendApnsNotificationMock.mockResolvedValue({ ok: true, status: 200 });
+    await dispatchApprovalPushToTokens([{ token: 'apns-1', platform: 'ios', provider: 'apns' }],
+      { approvalId: 'a1', actionLabel: 'Reboot', requestingClientLabel: 'Claude' });
+    const [, payload] = sendApnsNotificationMock.mock.calls[0]!;
+    expect(payload).toEqual({ title: 'Approval requested', body: 'Claude: Reboot', data: { type: 'approval', approvalId: 'a1' }, ttl: 60 });
   });
 });

--- a/apps/api/src/services/expoPush.test.ts
+++ b/apps/api/src/services/expoPush.test.ts
@@ -421,8 +421,30 @@ describe('buildTicketPush', () => {
     expect(spec.title).toBe('SLA breached (response)');
     expect(spec.body).toBe('Ticket \u00b7 Acme');
     expect(spec.ttl).toBe(14400);
-    expect(spec.collapseId).toBe('ticket:t-1:sla_breached:response');
+    expect(spec.collapseId).toBe('ticket:t-1:sla:response');
     expect(spec.data).toEqual({ type: 'ticket', ticketId: 't-1', reason: 'sla_breached', target: 'response' });
+  });
+  /**
+   * REGRESSION (#4281 review, critical): APNs caps `apns-collapse-id` at 64
+   * BYTES and answers an over-long value with 400 `BadCollapseId`. Every
+   * fixture above uses the 3-character id `t-1`; the real `tickets.id` is a
+   * 36-char uuid, which made `ticket:<uuid>:sla_breached:resolution` 67 bytes
+   * — so every native-APNs SLA push was rejected while the in-app row and the
+   * email still landed. Pin the length with a REAL uuid, not a short fixture.
+   */
+  it('collapse ids stay inside the 64-byte apns-collapse-id limit for a real uuid ticket id', () => {
+    const uuid = '0f5a1c2e-3b4d-4e5f-8a9b-0c1d2e3f4a5b';
+    const specs = [
+      buildTicketPush({ ticketId: uuid, reason: 'assigned', internalNumber: 'T-2026-0042', orgName: 'Acme' }),
+      buildTicketPush({ ticketId: uuid, reason: 'sla_breached', target: 'response', internalNumber: null, orgName: 'Acme' }),
+      buildTicketPush({ ticketId: uuid, reason: 'sla_breached', target: 'resolution', internalNumber: null, orgName: 'Acme' }),
+    ];
+    for (const spec of specs) {
+      expect(Buffer.byteLength(spec.collapseId!, 'utf8')).toBeLessThanOrEqual(64);
+    }
+    // Shortening must not collapse the two SLA targets onto one another.
+    expect(specs[1]!.collapseId).not.toBe(specs[2]!.collapseId);
+    expect(specs[0]!.collapseId).not.toBe(specs[1]!.collapseId);
   });
   it('truncates a long org name', () => {
     const spec = buildTicketPush({ ticketId: 't-1', reason: 'assigned', internalNumber: 'T-1', orgName: 'x'.repeat(200) });

--- a/apps/api/src/services/expoPush.ts
+++ b/apps/api/src/services/expoPush.ts
@@ -237,8 +237,14 @@ export function buildTicketPush(args: {
     data,
     ttl: isSla ? TICKET_SLA_TTL_SECONDS : TICKET_ASSIGNED_TTL_SECONDS,
     channelId: 'tickets',
+    // KEEP THESE SHORT. APNs rejects an `apns-collapse-id` over 64 BYTES with
+    // 400 BadCollapseId, and `ticketId` is a 36-char uuid in production — the
+    // original `:sla_breached:` spelling produced 65/67 bytes, so every native
+    // SLA push was rejected while the in-app row and email still landed.
+    // Longest form today: `ticket:` + 36 + `:sla:resolution` = 58 bytes.
+    // buildApnsRequest clamps as a backstop; do not rely on it.
     collapseId: isSla
-      ? `ticket:${args.ticketId}:sla_breached:${args.target ?? 'response'}`
+      ? `ticket:${args.ticketId}:sla:${args.target ?? 'response'}`
       : `ticket:${args.ticketId}:assigned`,
     threadId: `ticket:${args.ticketId}`,
     category: 'BREEZE_TICKET',

--- a/apps/api/src/services/expoPush.ts
+++ b/apps/api/src/services/expoPush.ts
@@ -9,6 +9,10 @@ const MAX_LABEL_LEN = 60;
 // requester has moved on, so we cap the store-and-forward window at 60s across
 // every provider (Expo ttl + APNs apns-expiration).
 const APPROVAL_PUSH_TTL_SECONDS = 60;
+// W07 (#3901). An assignment stays useful for a working day; an SLA breach
+// stops being actionable much sooner.
+const TICKET_ASSIGNED_TTL_SECONDS = 86_400;
+const TICKET_SLA_TTL_SECONDS = 14_400;
 
 /**
  * Expo push tokens are bearer-like device addresses: anyone holding one can
@@ -180,13 +184,67 @@ export interface DispatchApprovalPushArgs {
   requestingClientLabel: string;
 }
 
-export interface DispatchApprovalPushResult {
+/**
+ * A fully-built, provider-agnostic push (W07, #3901). `buildApprovalPush` and
+ * `buildTicketPush` produce these; `dispatchPushToTokens` consumes them.
+ */
+export interface PushSpec {
+  title: string;
+  body: string;
+  data: Record<string, unknown>;
+  ttl: number;
+  channelId: string;
+  collapseId?: string;
+  threadId?: string;
+  category?: string;
+  /** Expo relay only; APNs always sounds. */
+  sound?: 'default' | null;
+  priority?: 'default' | 'normal' | 'high';
+}
+
+export interface DispatchPushResult {
   /** Total tokens the user has registered (all providers). */
   tokensFound: number;
   /** Tokens the provider accepted for delivery. */
   dispatched: number;
   /** Tokens that failed (rejected ticket, dead token, or transport error). */
   errors: number;
+}
+
+export type DispatchApprovalPushResult = DispatchPushResult;
+
+/**
+ * Lock-screen-safe ticket push (spec D11): internal number + org name only.
+ * The subject NEVER appears — it loads after authenticated navigation.
+ * No badge: the badge count is owned by the approval path.
+ */
+export function buildTicketPush(args: {
+  ticketId: string;
+  reason: 'assigned' | 'sla_breached';
+  target?: 'response' | 'resolution';
+  internalNumber: string | null;
+  orgName: string;
+}): PushSpec {
+  const label = (args.internalNumber ?? 'Ticket').slice(0, MAX_LABEL_LEN);
+  const org = args.orgName.slice(0, MAX_LABEL_LEN);
+  const isSla = args.reason === 'sla_breached';
+  const data: Record<string, unknown> = { type: 'ticket', ticketId: args.ticketId, reason: args.reason };
+  if (isSla && args.target) data.target = args.target;
+  if (args.internalNumber) data.internalNumber = args.internalNumber;
+  return {
+    title: isSla ? `SLA breached (${args.target ?? 'response'})` : 'Ticket assigned to you',
+    body: `${label} \u00b7 ${org}`,
+    data,
+    ttl: isSla ? TICKET_SLA_TTL_SECONDS : TICKET_ASSIGNED_TTL_SECONDS,
+    channelId: 'tickets',
+    collapseId: isSla
+      ? `ticket:${args.ticketId}:sla_breached:${args.target ?? 'response'}`
+      : `ticket:${args.ticketId}:assigned`,
+    threadId: `ticket:${args.ticketId}`,
+    category: 'BREEZE_TICKET',
+    sound: 'default',
+    priority: 'high',
+  };
 }
 
 /**
@@ -213,30 +271,49 @@ async function purgeApnsToken(token: string): Promise<void> {
  *
  * Best-effort: never throws; returns per-provider dispatch/error counts.
  */
-export async function dispatchApprovalPushToTokens(
+/**
+ * Fans a single push spec out across pre-resolved, provider-tagged tokens.
+ * Split from the approval-specific wrapper so callers that must resolve tokens
+ * inside a specific DB access context (agent/AI/ticket paths) can do the read
+ * there and perform the network sends here, AFTER the context closes — never
+ * holding a DB transaction open across the push round-trip (#1105).
+ *
+ * Best-effort: never throws; returns per-provider dispatch/error counts.
+ */
+export async function dispatchPushToTokens(
   tokens: TaggedPushToken[],
-  args: DispatchApprovalPushArgs
-): Promise<DispatchApprovalPushResult> {
-  const result: DispatchApprovalPushResult = {
+  spec: PushSpec,
+  logLabel = 'push'
+): Promise<DispatchPushResult> {
+  const result: DispatchPushResult = {
     tokensFound: tokens.length,
     dispatched: 0,
     errors: 0,
   };
   if (tokens.length === 0) return result;
 
-  const payload = buildApprovalPush(args);
-
   // Expo relay tokens — one batched POST, existing dead-token handling.
   const expoTokens = tokens.filter((t) => t.provider === 'expo');
   if (expoTokens.length > 0) {
     try {
-      const tickets = await sendExpoPush(expoTokens.map((t) => ({ to: t.token, ...payload })));
+      const tickets = await sendExpoPush(
+        expoTokens.map((t) => ({
+          to: t.token,
+          title: spec.title,
+          body: spec.body,
+          data: spec.data,
+          sound: spec.sound ?? 'default',
+          priority: spec.priority ?? 'high',
+          channelId: spec.channelId,
+          ttl: spec.ttl,
+        }))
+      );
       for (const ticket of tickets) {
         if (ticket.status === 'ok') result.dispatched++;
         else result.errors++;
       }
     } catch (err) {
-      console.error('[push] expo approval dispatch failed', err);
+      console.error(`[push] expo ${logLabel} dispatch failed`, err);
       result.errors += expoTokens.length;
     }
   }
@@ -247,12 +324,18 @@ export async function dispatchApprovalPushToTokens(
     // sendApnsNotification never throws, but stay defensive so one bad token
     // can't abort the rest of the fan-out.
     try {
-      const res = await sendApnsNotification(t.token, {
-        title: payload.title,
-        body: payload.body,
-        data: payload.data,
-        ttl: APPROVAL_PUSH_TTL_SECONDS,
-      });
+      // Optional keys are assigned conditionally so the approval payload stays
+      // byte-identical to what shipped before W07.
+      const payload: Parameters<typeof sendApnsNotification>[1] = {
+        title: spec.title,
+        body: spec.body,
+        data: spec.data,
+        ttl: spec.ttl,
+      };
+      if (spec.collapseId) payload.collapseId = spec.collapseId;
+      if (spec.threadId) payload.threadId = spec.threadId;
+      if (spec.category) payload.category = spec.category;
+      const res = await sendApnsNotification(t.token, payload);
       if (res.ok) {
         result.dispatched++;
       } else {
@@ -260,7 +343,7 @@ export async function dispatchApprovalPushToTokens(
         if (res.unregistered) await purgeApnsToken(t.token);
       }
     } catch (err) {
-      console.error('[push] apns approval dispatch failed', {
+      console.error(`[push] apns ${logLabel} dispatch failed`, {
         token: redactPushToken(t.token),
         error: err instanceof Error ? err.message : String(err),
       });
@@ -268,7 +351,7 @@ export async function dispatchApprovalPushToTokens(
     }
   }
 
-  // Native FCM (Android) approval delivery is out of scope for the current iOS
+  // Native FCM (Android) delivery is out of scope for the current iOS
   // submission. The existing firebase path (notifications.sendFCM) speaks a
   // different PushPayload shape and requires FIREBASE_SERVICE_ACCOUNT init, so
   // wiring it here is non-trivial — we deliberately skip rather than
@@ -276,11 +359,32 @@ export async function dispatchApprovalPushToTokens(
   const fcmTokens = tokens.filter((t) => t.provider === 'fcm');
   if (fcmTokens.length > 0) {
     console.info(
-      `[push] android approval push not wired to FCM yet — ${fcmTokens.length} token(s) skipped`
+      `[push] android ${logLabel} push not wired to FCM yet — ${fcmTokens.length} token(s) skipped`
     );
   }
 
   return result;
+}
+
+/** Approval-shaped wrapper; unchanged public name, result type and payload. */
+export async function dispatchApprovalPushToTokens(
+  tokens: TaggedPushToken[],
+  args: DispatchApprovalPushArgs
+): Promise<DispatchApprovalPushResult> {
+  const p = buildApprovalPush(args);
+  return dispatchPushToTokens(
+    tokens,
+    {
+      title: p.title!,
+      body: p.body!,
+      data: (p.data ?? {}) as Record<string, unknown>,
+      ttl: p.ttl ?? APPROVAL_PUSH_TTL_SECONDS,
+      channelId: p.channelId ?? 'approvals',
+      sound: p.sound,
+      priority: p.priority,
+    },
+    'approval'
+  );
 }
 
 /**

--- a/apps/api/src/services/notifications.ts
+++ b/apps/api/src/services/notifications.ts
@@ -5,6 +5,11 @@ import { alerts, mobileDevices, organizationUsers, pushNotifications, users } fr
 import { and, eq } from 'drizzle-orm';
 import { getEventBus } from './eventBus';
 import { isApnsConfigured, sendApnsNotification } from './apns';
+// Moved to its own module in W07 (#3901) so non-Firebase callers can use it.
+// Re-exported here so every existing importer keeps working.
+import { isInQuietHours, type QuietHoursConfig } from './quietHours';
+
+export { isInQuietHours, type QuietHoursConfig };
 
 export interface PushPayload {
   title: string;
@@ -12,13 +17,6 @@ export interface PushPayload {
   data: Record<string, string>;
   alertId: string | null;
   eventType: string;
-}
-
-export interface QuietHoursConfig {
-  start: string;
-  end: string;
-  timezone?: string;
-  enabled?: boolean;
 }
 
 type AlertSeverity = 'critical' | 'high' | 'medium' | 'low' | 'info';
@@ -217,30 +215,6 @@ export async function sendAPNS(token: string, payload: PushPayload): Promise<Pus
   throw new Error(`APNS delivery failed (status ${res.status}${res.reason ? `, ${res.reason}` : ''})`);
 }
 
-export function isInQuietHours(quietHours?: QuietHoursConfig | null): boolean {
-  if (!quietHours || quietHours.enabled === false) {
-    return false;
-  }
-
-  const startMinutes = parseMinutes(quietHours.start);
-  const endMinutes = parseMinutes(quietHours.end);
-
-  if (startMinutes === null || endMinutes === null) {
-    return false;
-  }
-
-  const nowMinutes = getMinutesInTimezone(new Date(), quietHours.timezone);
-
-  if (startMinutes === endMinutes) {
-    return true;
-  }
-
-  if (startMinutes < endMinutes) {
-    return nowMinutes >= startMinutes && nowMinutes < endMinutes;
-  }
-
-  return nowMinutes >= startMinutes || nowMinutes < endMinutes;
-}
 
 export function subscribeToAlertEvents(): () => void {
   const bus = getEventBus();
@@ -305,44 +279,4 @@ export async function getUsersForAlert(orgId: string, severity?: AlertSeverity):
   return rows.map(row => row.userId);
 }
 
-function parseMinutes(value: string): number | null {
-  const match = /^(\d{1,2}):(\d{2})$/.exec(value);
-  if (!match) {
-    return null;
-  }
 
-  const hours = Number(match[1]);
-  const minutes = Number(match[2]);
-
-  if (Number.isNaN(hours) || Number.isNaN(minutes)) {
-    return null;
-  }
-
-  if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) {
-    return null;
-  }
-
-  return hours * 60 + minutes;
-}
-
-function getMinutesInTimezone(date: Date, timezone?: string): number {
-  if (!timezone) {
-    return date.getHours() * 60 + date.getMinutes();
-  }
-
-  try {
-    const parts = new Intl.DateTimeFormat('en-US', {
-      timeZone: timezone,
-      hourCycle: 'h23',
-      hour: '2-digit',
-      minute: '2-digit'
-    }).formatToParts(date);
-
-    const hour = Number(parts.find(part => part.type === 'hour')?.value ?? '0');
-    const minute = Number(parts.find(part => part.type === 'minute')?.value ?? '0');
-
-    return hour * 60 + minute;
-  } catch (err) {
-    return date.getHours() * 60 + date.getMinutes();
-  }
-}

--- a/apps/api/src/services/quietHours.test.ts
+++ b/apps/api/src/services/quietHours.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { isInQuietHours } from './quietHours';
+
+const at = (iso: string) => new Date(iso);
+
+describe('isInQuietHours', () => {
+  it('is false when unset or disabled', () => {
+    expect(isInQuietHours(null)).toBe(false);
+    expect(isInQuietHours({ start: '22:00', end: '07:00', enabled: false, timezone: 'UTC' })).toBe(false);
+  });
+  it('handles an overnight window in UTC', () => {
+    const cfg = { start: '22:00', end: '07:00', timezone: 'UTC' };
+    expect(isInQuietHours(cfg, at('2026-01-01T23:30:00Z'))).toBe(true);
+    expect(isInQuietHours(cfg, at('2026-01-01T06:59:00Z'))).toBe(true);
+    expect(isInQuietHours(cfg, at('2026-01-01T12:00:00Z'))).toBe(false);
+  });
+  it('handles a same-day window and treats start==end as always quiet', () => {
+    expect(isInQuietHours({ start: '09:00', end: '17:00', timezone: 'UTC' }, at('2026-01-01T10:00:00Z'))).toBe(true);
+    expect(isInQuietHours({ start: '09:00', end: '09:00', timezone: 'UTC' }, at('2026-01-01T03:00:00Z'))).toBe(true);
+  });
+  it('is false on a malformed time', () => {
+    expect(isInQuietHours({ start: '25:00', end: '07:00', timezone: 'UTC' }, at('2026-01-01T03:00:00Z'))).toBe(false);
+  });
+});

--- a/apps/api/src/services/quietHours.ts
+++ b/apps/api/src/services/quietHours.ts
@@ -1,0 +1,81 @@
+/**
+ * Quiet-hours evaluation, extracted from services/notifications.ts (W07, #3901).
+ *
+ * Lives on its own so callers that must not pull in firebase-admin (the ticket
+ * push fan-out) can use it. `notifications.ts` re-exports both symbols so every
+ * existing importer keeps working.
+ */
+export interface QuietHoursConfig {
+  start: string;
+  end: string;
+  timezone?: string;
+  enabled?: boolean;
+}
+
+/** Pure: no DB, no Firebase. `now` is injectable for tests. */
+export function isInQuietHours(quietHours?: QuietHoursConfig | null, now: Date = new Date()): boolean {
+  if (!quietHours || quietHours.enabled === false) {
+    return false;
+  }
+
+  const startMinutes = parseMinutes(quietHours.start);
+  const endMinutes = parseMinutes(quietHours.end);
+
+  if (startMinutes === null || endMinutes === null) {
+    return false;
+  }
+
+  const nowMinutes = getMinutesInTimezone(now, quietHours.timezone);
+
+  if (startMinutes === endMinutes) {
+    return true;
+  }
+
+  if (startMinutes < endMinutes) {
+    return nowMinutes >= startMinutes && nowMinutes < endMinutes;
+  }
+
+  return nowMinutes >= startMinutes || nowMinutes < endMinutes;
+}
+
+function parseMinutes(value: string): number | null {
+  const match = /^(\d{1,2}):(\d{2})$/.exec(value);
+  if (!match) {
+    return null;
+  }
+
+  const hours = Number(match[1]);
+  const minutes = Number(match[2]);
+
+  if (Number.isNaN(hours) || Number.isNaN(minutes)) {
+    return null;
+  }
+
+  if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) {
+    return null;
+  }
+
+  return hours * 60 + minutes;
+}
+
+function getMinutesInTimezone(date: Date, timezone?: string): number {
+  if (!timezone) {
+    return date.getHours() * 60 + date.getMinutes();
+  }
+
+  try {
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      hourCycle: 'h23',
+      hour: '2-digit',
+      minute: '2-digit'
+    }).formatToParts(date);
+
+    const hour = Number(parts.find(part => part.type === 'hour')?.value ?? '0');
+    const minute = Number(parts.find(part => part.type === 'minute')?.value ?? '0');
+
+    return hour * 60 + minute;
+  } catch {
+    return date.getHours() * 60 + date.getMinutes();
+  }
+}

--- a/apps/api/src/services/ticketEvents.test.ts
+++ b/apps/api/src/services/ticketEvents.test.ts
@@ -79,4 +79,30 @@ describe('emitTicketEvent', () => {
     expect(captureExceptionMock).toHaveBeenCalledTimes(1);
     expect(captureExceptionMock).toHaveBeenCalledWith(err);
   });
+  it('stamps a uuid eventId when the emitter did not provide one', async () => {
+    await emitTicketEvent({
+      type: 'ticket.assigned', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
+      actorUserId: 'u-1', payload: { assigneeId: 'u-2' }
+    });
+    const [, data] = addMock.mock.calls[0]!;
+    expect((data as { eventId: string }).eventId).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('preserves a caller-provided eventId', async () => {
+    await emitTicketEvent({
+      type: 'ticket.assigned', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
+      actorUserId: 'u-1', eventId: 'fixed-id', payload: { assigneeId: 'u-2' }
+    });
+    const [, data] = addMock.mock.calls[0]!;
+    expect((data as { eventId: string }).eventId).toBe('fixed-id');
+  });
+
+  it('does NOT use eventId as the BullMQ jobId (queue dedupe semantics unchanged)', async () => {
+    await emitTicketEvent({
+      type: 'ticket.assigned', ticketId: 't-1', orgId: 'o-1', partnerId: 'p-1',
+      actorUserId: 'u-1', eventId: 'fixed-id', payload: { assigneeId: 'u-2' }
+    });
+    const [, , opts] = addMock.mock.calls[0]!;
+    expect((opts as { jobId?: string }).jobId).toBeUndefined();
+  });
 });

--- a/apps/api/src/services/ticketEvents.ts
+++ b/apps/api/src/services/ticketEvents.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import { Queue } from 'bullmq';
 import { getBullMQConnection } from './redis';
 import { captureException } from './sentry';
@@ -14,6 +15,14 @@ interface TicketEventEnvelope {
   orgId: string;
   partnerId: string | null;
   actorUserId?: string | null;
+  /**
+   * W07 (#3901): unique per emitted event; the notify worker uses it in the
+   * user_notifications dedupe key so a BullMQ retry never re-pushes while a
+   * genuine A->B->A reassignment does. Stamped by emitTicketEvent — emitters
+   * never set it. Jobs queued before this shipped lack it; the worker falls
+   * back to job.id.
+   */
+  eventId: string;
 }
 
 export type TicketEvent = TicketEventEnvelope & (
@@ -42,6 +51,11 @@ export type TicketEvent = TicketEventEnvelope & (
 
 export type TicketEventType = TicketEvent['type'];
 
+type DistributiveOmit<T, K extends PropertyKey> = T extends unknown ? Omit<T, K> : never;
+
+/** What emitters pass: eventId is optional and normally omitted. */
+export type TicketEventInput = DistributiveOmit<TicketEvent, 'eventId'> & { eventId?: string };
+
 let queue: Queue | null = null;
 
 export function getTicketEventsQueue(): Queue {
@@ -53,7 +67,8 @@ export function getTicketEventsQueue(): Queue {
 
 // Fire-and-forget by design: a Redis outage must never fail the user-facing
 // mutation that emitted the event. Consumers (notifications) are best-effort.
-export async function emitTicketEvent(event: TicketEvent): Promise<void> {
+export async function emitTicketEvent(input: TicketEventInput): Promise<void> {
+  const event = { ...input, eventId: input.eventId ?? randomUUID() } as TicketEvent;
   try {
     await getTicketEventsQueue().add(event.type, event, {
       removeOnComplete: { count: 100 },

--- a/apps/api/src/services/ticketEventsContract.test.ts
+++ b/apps/api/src/services/ticketEventsContract.test.ts
@@ -40,7 +40,8 @@ const hoisted = vi.hoisted(() => {
   const loadTicketPushPrefsMock = vi.fn(async () => ({ assignedEnabled: true, slaScope: 'owned' as const }));
   const listAnySlaSubscribersMock = vi.fn(async () => ({ users: [] as unknown[], truncated: false }));
   const isAuthorisedForTicketMock = vi.fn(async () => true);
-  const collectTicketPushMock = vi.fn(async () => null);
+  const admitPushMock = vi.fn(async () => []);
+  const resolvePushJobsMock = vi.fn(async () => []);
   const dispatchPushToTokensMock = vi.fn(async () => ({ tokensFound: 0, dispatched: 0, errors: 0 }));
   return {
     selectQueue,
@@ -56,7 +57,8 @@ const hoisted = vi.hoisted(() => {
     loadTicketPushPrefsMock,
     listAnySlaSubscribersMock,
     isAuthorisedForTicketMock,
-    collectTicketPushMock,
+    admitPushMock,
+    resolvePushJobsMock,
     dispatchPushToTokensMock
   };
 });
@@ -148,7 +150,8 @@ vi.mock('./ticketPush', () => ({
   loadTicketPushPrefs: hoisted.loadTicketPushPrefsMock,
   listAnySlaSubscribers: hoisted.listAnySlaSubscribersMock,
   isAuthorisedForTicket: hoisted.isAuthorisedForTicketMock,
-  collectTicketPush: hoisted.collectTicketPushMock,
+  admitPush: hoisted.admitPushMock,
+  resolvePushJobs: hoisted.resolvePushJobsMock,
   assertSamePartner: (c: { partnerId: string }, eventPartnerId: string | null) =>
     !!eventPartnerId && c.partnerId === eventPartnerId,
   ANY_SUBSCRIBER_CAP: 500,
@@ -192,7 +195,8 @@ describe('ticket-events producer→consumer contract', () => {
     hoisted.loadTicketPushPrefsMock.mockResolvedValue({ assignedEnabled: true, slaScope: 'owned' });
     hoisted.listAnySlaSubscribersMock.mockResolvedValue({ users: [], truncated: false });
     hoisted.isAuthorisedForTicketMock.mockResolvedValue(true);
-    hoisted.collectTicketPushMock.mockResolvedValue(null);
+    hoisted.admitPushMock.mockResolvedValue([]);
+    hoisted.resolvePushJobsMock.mockResolvedValue([]);
   });
 
   // ── createTicket with assignee → ticket.created ──────────────────────────

--- a/apps/api/src/services/ticketEventsContract.test.ts
+++ b/apps/api/src/services/ticketEventsContract.test.ts
@@ -27,6 +27,21 @@ const hoisted = vi.hoisted(() => {
   const getEmailServiceMock = vi.fn();
   const withSystemDbAccessContextMock = vi.fn((fn: () => unknown) => fn());
   const emitCaptured: unknown[] = [];
+  // W07 (#3901): the assignee branch no longer inserts into user_notifications
+  // directly — it goes through createNotification (the dedupe anchor) and then
+  // through the ticketPush helpers. Those are collaborators of the CONSUMER,
+  // not part of the producer→consumer payload seam this file exists to pin, so
+  // they are mocked; the seam assertion moves from insertValuesMock to
+  // createNotificationMock, which still sees the event's field names.
+  const createNotificationMock = vi.fn(async () => 'n-1' as string | null);
+  const loadUserCandidateMock = vi.fn(async (id: string) => ({
+    userId: id, partnerId: 'p-1', status: 'active', email: 'tech@msp.example',
+  }));
+  const loadTicketPushPrefsMock = vi.fn(async () => ({ assignedEnabled: true, slaScope: 'owned' as const }));
+  const listAnySlaSubscribersMock = vi.fn(async () => ({ users: [] as unknown[], truncated: false }));
+  const isAuthorisedForTicketMock = vi.fn(async () => true);
+  const collectTicketPushMock = vi.fn(async () => null);
+  const dispatchPushToTokensMock = vi.fn(async () => ({ tokensFound: 0, dispatched: 0, errors: 0 }));
   return {
     selectQueue,
     insertReturningQueue,
@@ -35,7 +50,14 @@ const hoisted = vi.hoisted(() => {
     sendEmailMock,
     getEmailServiceMock,
     withSystemDbAccessContextMock,
-    emitCaptured
+    emitCaptured,
+    createNotificationMock,
+    loadUserCandidateMock,
+    loadTicketPushPrefsMock,
+    listAnySlaSubscribersMock,
+    isAuthorisedForTicketMock,
+    collectTicketPushMock,
+    dispatchPushToTokensMock
   };
 });
 
@@ -120,6 +142,22 @@ vi.mock('../db/schema', () => ({
   ticketSourceEnum: { enumValues: ['portal', 'email', 'alert', 'manual', 'api', 'ai'] }
 }));
 
+vi.mock('./userNotifications', () => ({ createNotification: hoisted.createNotificationMock }));
+vi.mock('./ticketPush', () => ({
+  loadUserCandidate: hoisted.loadUserCandidateMock,
+  loadTicketPushPrefs: hoisted.loadTicketPushPrefsMock,
+  listAnySlaSubscribers: hoisted.listAnySlaSubscribersMock,
+  isAuthorisedForTicket: hoisted.isAuthorisedForTicketMock,
+  collectTicketPush: hoisted.collectTicketPushMock,
+  assertSamePartner: (c: { partnerId: string }, eventPartnerId: string | null) =>
+    !!eventPartnerId && c.partnerId === eventPartnerId,
+  ANY_SUBSCRIBER_CAP: 500,
+}));
+vi.mock('./expoPush', () => ({
+  dispatchPushToTokens: hoisted.dispatchPushToTokensMock,
+  buildTicketPush: vi.fn(() => ({ title: 't', body: 'b', data: {} })),
+}));
+
 vi.mock('bullmq', () => ({ Queue: vi.fn(() => ({ add: vi.fn() })), Worker: vi.fn() }));
 vi.mock('../services/redis', () => ({ getBullMQConnection: vi.fn(() => ({})) }));
 vi.mock('../services/email', () => ({ getEmailService: hoisted.getEmailServiceMock }));
@@ -147,6 +185,14 @@ describe('ticket-events producer→consumer contract', () => {
     hoisted.withSystemDbAccessContextMock.mockImplementation((fn: () => unknown) => fn());
     hoisted.getEmailServiceMock.mockReturnValue({ sendEmail: hoisted.sendEmailMock });
     hoisted.sendEmailMock.mockResolvedValue(undefined);
+    hoisted.createNotificationMock.mockResolvedValue('n-1');
+    hoisted.loadUserCandidateMock.mockImplementation(async (id: string) => ({
+      userId: id, partnerId: 'p-1', status: 'active', email: 'tech@msp.example',
+    }));
+    hoisted.loadTicketPushPrefsMock.mockResolvedValue({ assignedEnabled: true, slaScope: 'owned' });
+    hoisted.listAnySlaSubscribersMock.mockResolvedValue({ users: [], truncated: false });
+    hoisted.isAuthorisedForTicketMock.mockResolvedValue(true);
+    hoisted.collectTicketPushMock.mockResolvedValue(null);
   });
 
   // ── createTicket with assignee → ticket.created ──────────────────────────
@@ -165,21 +211,25 @@ describe('ticket-events producer→consumer contract', () => {
     const event = hoisted.emitCaptured[0] as TicketEvent;
     expect(event.type).toBe('ticket.created');
 
-    // Worker selects: ticket lookup, then assignee user lookup
+    // Worker selects: ticket lookup, then the org-name lookup for the push body.
+    // The assignee row now comes from the mocked loadUserCandidate, not the queue.
     hoisted.selectQueue.push(
       [{ id: 't-c1', orgId: 'o-1', internalNumber: 'T-2026-C001', subject: 'Contract test', submitterEmail: null }],
-      [{ id: 'u-assignee', email: 'tech@msp.example' }]
+      [{ name: 'Acme' }]
     );
-    // Worker insert: userNotifications insert
-    hoisted.insertReturningQueue.push([]);
 
-    hoisted.insertValuesMock.mockClear();
+    hoisted.createNotificationMock.mockClear();
 
     await handleTicketEvent(event);
 
-    expect(hoisted.insertValuesMock).toHaveBeenCalledWith(expect.objectContaining({
+    // The seam assertion: the emitted event's assigneeId/orgId reach the
+    // consumer's notification write, and the dedupe key is anchored on the
+    // event's own eventId (W07 D2).
+    expect(hoisted.createNotificationMock).toHaveBeenCalledWith(expect.objectContaining({
       userId: 'u-assignee',
-      type: 'ticket'
+      orgId: 'o-1',
+      type: 'ticket',
+      dedupeKey: expect.stringContaining('ticket:t-c1:assigned:u-assignee:')
     }));
     expect(hoisted.sendEmailMock).toHaveBeenCalledWith(expect.objectContaining({
       to: 'tech@msp.example',

--- a/apps/api/src/services/ticketPush.sql.test.ts
+++ b/apps/api/src/services/ticketPush.sql.test.ts
@@ -10,7 +10,7 @@
  * subscriber from being enumerated.
  */
 import { describe, it, expect } from 'vitest';
-import { anySlaSubscribersQuery, ANY_SUBSCRIBER_CAP } from './ticketPush';
+import { anySlaSubscribersQuery, ANY_SUBSCRIBER_CAP, userPushTargetsQuery } from './ticketPush';
 
 describe("anySlaSubscribersQuery — compiled SQL (vacuous-Drizzle trap)", () => {
   it('filters on sla_scope = any, users.partner_id = $partner, status = active, ordered, capped', () => {
@@ -21,5 +21,25 @@ describe("anySlaSubscribersQuery — compiled SQL (vacuous-Drizzle trap)", () =>
     expect(sql).toMatch(/order by "users"\."id"/i);
     expect(sql).toMatch(/limit \$\d/i);
     expect(params).toEqual(expect.arrayContaining(['any', 'p-1', 'active', ANY_SUBSCRIBER_CAP + 1]));
+  });
+});
+
+/**
+ * REGRESSION (#4281 review): the device filter had NO guard of any kind — the
+ * unit suite's chainable `../db` mock ignores the WHERE, and every fixture in
+ * the fan-out integration test took the column defaults
+ * (notifications_enabled = true, status = 'active'), so deleting either clause
+ * left the whole wave green. `mobile_devices.status` is the lost-phone /
+ * admin-revocation lifecycle column and `notifications_enabled` is the ONLY
+ * guard for a technician who turned notifications off in the app (the opt-out
+ * route does not clear tokens), so both are security-relevant.
+ */
+describe('userPushTargetsQuery — compiled SQL (vacuous-Drizzle trap)', () => {
+  it('filters on user_id IN, notifications_enabled = true and status = active', () => {
+    const { sql, params } = userPushTargetsQuery(['u-1', 'u-2']).toSQL();
+    expect(sql).toMatch(/"mobile_devices"\."user_id" in \(/i);
+    expect(sql).toMatch(/"mobile_devices"\."notifications_enabled" = \$\d/);
+    expect(sql).toMatch(/"mobile_devices"\."status" = \$\d/);
+    expect(params).toEqual(expect.arrayContaining(['u-1', 'u-2', true, 'active']));
   });
 });

--- a/apps/api/src/services/ticketPush.sql.test.ts
+++ b/apps/api/src/services/ticketPush.sql.test.ts
@@ -1,0 +1,25 @@
+/**
+ * W07 (#3901): the ONE assertion that must not be vacuous — the compiled SQL of
+ * the 'any'-SLA subscriber query. This file deliberately does NOT mock ../db, so
+ * the real Drizzle builder produces real SQL; a `where` built against a mocked
+ * table object would compile to something that asserts nothing (memory: vacuous
+ * Drizzle where-clause assertions).
+ *
+ * The partner filter here IS the tenant boundary: the worker runs under a
+ * system DB context with RLS bypassed, so nothing else stops a cross-partner
+ * subscriber from being enumerated.
+ */
+import { describe, it, expect } from 'vitest';
+import { anySlaSubscribersQuery, ANY_SUBSCRIBER_CAP } from './ticketPush';
+
+describe("anySlaSubscribersQuery — compiled SQL (vacuous-Drizzle trap)", () => {
+  it('filters on sla_scope = any, users.partner_id = $partner, status = active, ordered, capped', () => {
+    const { sql, params } = anySlaSubscribersQuery('p-1').toSQL();
+    expect(sql).toMatch(/"ticket_push_preferences"\."sla_scope" = \$\d/);
+    expect(sql).toMatch(/"users"\."partner_id" = \$\d/);
+    expect(sql).toMatch(/"users"\."status" = \$\d/);
+    expect(sql).toMatch(/order by "users"\."id"/i);
+    expect(sql).toMatch(/limit \$\d/i);
+    expect(params).toEqual(expect.arrayContaining(['any', 'p-1', 'active', ANY_SUBSCRIBER_CAP + 1]));
+  });
+});

--- a/apps/api/src/services/ticketPush.test.ts
+++ b/apps/api/src/services/ticketPush.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const m = vi.hoisted(() => ({
+  isApnsConfigured: vi.fn(() => true),
+  checkNotificationThrottle: vi.fn(async () => ({ allowed: true, currentCount: 1, windowExpiresAt: 0 })),
+  getUserPermissions: vi.fn(),
+  captureException: vi.fn(),
+  selectRows: vi.fn(async () => [] as unknown[]),
+}));
+vi.mock('./apns', () => ({ isApnsConfigured: m.isApnsConfigured }));
+vi.mock('./notificationThrottle', () => ({ checkNotificationThrottle: m.checkNotificationThrottle }));
+vi.mock('./sentry', () => ({ captureException: m.captureException }));
+vi.mock('./permissions', async (orig) => {
+  const actual = await orig<typeof import('./permissions')>();
+  return { ...actual, getUserPermissions: m.getUserPermissions };
+});
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(() => {
+      const chain: Record<string, unknown> = {};
+      for (const k of ['from', 'innerJoin', 'where', 'orderBy']) chain[k] = vi.fn(() => chain);
+      chain.limit = vi.fn(() => m.selectRows());
+      // Awaited without a trailing .limit() (getUserPushTargets).
+      chain.then = (res: (v: unknown) => void) => m.selectRows().then(res);
+      return chain;
+    }),
+  },
+}));
+
+import { db } from '../db';
+import {
+  assertSamePartner, isAuthorisedForTicket, collectTicketPush, __resetApnsWarnForTests,
+} from './ticketPush';
+import { buildTicketPush } from './expoPush';
+
+const spec = buildTicketPush({ ticketId: 't-1', reason: 'assigned', internalNumber: 'T-1', orgName: 'Acme' });
+
+describe('assertSamePartner', () => {
+  beforeEach(() => { m.captureException.mockClear(); });
+
+  it('returns false, warns and reports when the candidate is in another partner', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const ok = assertSamePartner({ userId: 'u-9', partnerId: 'p-OTHER', status: 'active', email: null }, 'p-1', { ticketId: 't-1' });
+    expect(ok).toBe(false);
+    expect(warn).toHaveBeenCalled();
+    expect(m.captureException).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+  it('returns true for the same partner', () => {
+    expect(assertSamePartner({ userId: 'u-2', partnerId: 'p-1', status: 'active', email: null }, 'p-1', { ticketId: 't-1' })).toBe(true);
+  });
+  it('returns false when the event has no partner', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(assertSamePartner({ userId: 'u-2', partnerId: 'p-1', status: 'active', email: null }, null, { ticketId: 't-1' })).toBe(false);
+    warn.mockRestore();
+  });
+});
+
+describe('isAuthorisedForTicket', () => {
+  it('requires tickets:read AND org access', async () => {
+    m.getUserPermissions.mockResolvedValueOnce({ scope: 'partner', orgAccess: 'selected', allowedOrgIds: ['o-2'], permissions: [{ resource: 'tickets', action: 'read' }] });
+    expect(await isAuthorisedForTicket('u-2', 'p-1', 'o-1')).toBe(false);
+    m.getUserPermissions.mockResolvedValueOnce({ scope: 'partner', orgAccess: 'all', permissions: [{ resource: 'devices', action: 'read' }] });
+    expect(await isAuthorisedForTicket('u-2', 'p-1', 'o-1')).toBe(false);
+    m.getUserPermissions.mockResolvedValueOnce({ scope: 'partner', orgAccess: 'all', permissions: [{ resource: 'tickets', action: 'read' }] });
+    expect(await isAuthorisedForTicket('u-2', 'p-1', 'o-1')).toBe(true);
+  });
+  it('is false when permissions resolve to null', async () => {
+    m.getUserPermissions.mockResolvedValueOnce(null);
+    expect(await isAuthorisedForTicket('u-2', 'p-1', 'o-1')).toBe(false);
+  });
+});
+
+describe('collectTicketPush', () => {
+  beforeEach(() => { vi.clearAllMocks(); __resetApnsWarnForTests(); m.isApnsConfigured.mockReturnValue(true); m.checkNotificationThrottle.mockResolvedValue({ allowed: true, currentCount: 1, windowExpiresAt: 0 }); });
+
+  it('returns null without reading tokens when APNs is not configured (D8)', async () => {
+    m.isApnsConfigured.mockReturnValue(false);
+    expect(await collectTicketPush('u-2', spec)).toBeNull();
+    expect(vi.mocked(db.select)).not.toHaveBeenCalled();
+  });
+  it('returns null when throttled (D6) and still does not read tokens', async () => {
+    m.checkNotificationThrottle.mockResolvedValueOnce({ allowed: false, currentCount: 21, windowExpiresAt: 0 });
+    expect(await collectTicketPush('u-2', spec)).toBeNull();
+    expect(m.checkNotificationThrottle).toHaveBeenCalledWith('mobile-ticket', 'user:u-2', 20, 300);
+    expect(vi.mocked(db.select)).not.toHaveBeenCalled();
+  });
+  it('drops devices in quiet hours and returns null when none remain (D12)', async () => {
+    m.selectRows.mockResolvedValueOnce([{ apns: 'tok-1', fcm: null, platform: 'ios', quietHours: { start: '00:00', end: '00:00', timezone: 'UTC' } }]);
+    expect(await collectTicketPush('u-2', spec)).toBeNull();
+  });
+  it('returns a PushJob with the tagged tokens otherwise', async () => {
+    m.selectRows.mockResolvedValueOnce([{ apns: 'tok-1', fcm: null, platform: 'ios', quietHours: null }]);
+    const job = await collectTicketPush('u-2', spec);
+    expect(job).toEqual({ tokens: [{ token: 'tok-1', platform: 'ios', provider: 'apns' }], spec });
+  });
+});

--- a/apps/api/src/services/ticketPush.test.ts
+++ b/apps/api/src/services/ticketPush.test.ts
@@ -29,7 +29,7 @@ vi.mock('../db', () => ({
 
 import { db } from '../db';
 import {
-  assertSamePartner, isAuthorisedForTicket, collectTicketPush, __resetApnsWarnForTests,
+  admitPush, assertSamePartner, isAuthorisedForTicket, resolvePushJobs, __resetApnsWarnForTests,
 } from './ticketPush';
 import { buildTicketPush } from './expoPush';
 
@@ -71,27 +71,56 @@ describe('isAuthorisedForTicket', () => {
   });
 });
 
-describe('collectTicketPush', () => {
+/**
+ * Two-phase by design (#4281 review): `admitPush` is Redis-only so the worker
+ * can run it with NO DB context open, and `resolvePushJobs` does ONE batched
+ * device read inside a short system context. Previously both ran per-recipient
+ * inside the single open fan-out transaction (#1105 class).
+ */
+describe('admitPush', () => {
   beforeEach(() => { vi.clearAllMocks(); __resetApnsWarnForTests(); m.isApnsConfigured.mockReturnValue(true); m.checkNotificationThrottle.mockResolvedValue({ allowed: true, currentCount: 1, windowExpiresAt: 0 }); });
 
-  it('returns null without reading tokens when APNs is not configured (D8)', async () => {
+  it('admits nobody and reads no tokens when APNs is not configured (D8)', async () => {
     m.isApnsConfigured.mockReturnValue(false);
-    expect(await collectTicketPush('u-2', spec)).toBeNull();
+    expect(await admitPush([{ userId: 'u-2', spec }])).toEqual([]);
+    expect(m.checkNotificationThrottle).not.toHaveBeenCalled();
     expect(vi.mocked(db.select)).not.toHaveBeenCalled();
   });
-  it('returns null when throttled (D6) and still does not read tokens', async () => {
-    m.checkNotificationThrottle.mockResolvedValueOnce({ allowed: false, currentCount: 21, windowExpiresAt: 0 });
-    expect(await collectTicketPush('u-2', spec)).toBeNull();
+
+  it('drops a throttled recipient (D6), keeps the rest, and touches no DB at all', async () => {
+    m.checkNotificationThrottle
+      .mockResolvedValueOnce({ allowed: false, currentCount: 21, windowExpiresAt: 0 })
+      .mockResolvedValueOnce({ allowed: true, currentCount: 1, windowExpiresAt: 0 });
+    const out = await admitPush([{ userId: 'u-2', spec }, { userId: 'u-3', spec }]);
+    expect(out.map((p) => p.userId)).toEqual(['u-3']);
     expect(m.checkNotificationThrottle).toHaveBeenCalledWith('mobile-ticket', 'user:u-2', 20, 300);
     expect(vi.mocked(db.select)).not.toHaveBeenCalled();
   });
-  it('drops devices in quiet hours and returns null when none remain (D12)', async () => {
-    m.selectRows.mockResolvedValueOnce([{ apns: 'tok-1', fcm: null, platform: 'ios', quietHours: { start: '00:00', end: '00:00', timezone: 'UTC' } }]);
-    expect(await collectTicketPush('u-2', spec)).toBeNull();
+});
+
+describe('resolvePushJobs', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('returns no job for a recipient whose devices are all in quiet hours (D12)', async () => {
+    m.selectRows.mockResolvedValueOnce([{ userId: 'u-2', apns: 'tok-1', fcm: null, platform: 'ios', quietHours: { start: '00:00', end: '00:00', timezone: 'UTC' } }]);
+    expect(await resolvePushJobs([{ userId: 'u-2', spec }])).toEqual([]);
   });
-  it('returns a PushJob with the tagged tokens otherwise', async () => {
-    m.selectRows.mockResolvedValueOnce([{ apns: 'tok-1', fcm: null, platform: 'ios', quietHours: null }]);
-    const job = await collectTicketPush('u-2', spec);
-    expect(job).toEqual({ tokens: [{ token: 'tok-1', platform: 'ios', provider: 'apns' }], spec });
+
+  it('reads every recipient in ONE batched query and tags each job with its own tokens', async () => {
+    m.selectRows.mockResolvedValueOnce([
+      { userId: 'u-2', apns: 'tok-1', fcm: null, platform: 'ios', quietHours: null },
+      { userId: 'u-3', apns: null, fcm: 'tok-2', platform: 'android', quietHours: null },
+    ]);
+    const jobs = await resolvePushJobs([{ userId: 'u-2', spec }, { userId: 'u-3', spec }]);
+    expect(jobs).toEqual([
+      { tokens: [{ token: 'tok-1', platform: 'ios', provider: 'apns' }], spec },
+      { tokens: [{ token: 'tok-2', platform: 'android', provider: 'fcm' }], spec },
+    ]);
+    expect(vi.mocked(db.select)).toHaveBeenCalledTimes(1);
+  });
+
+  it('is a no-op with no pending pushes', async () => {
+    expect(await resolvePushJobs([])).toEqual([]);
+    expect(vi.mocked(db.select)).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/services/ticketPush.ts
+++ b/apps/api/src/services/ticketPush.ts
@@ -1,0 +1,213 @@
+/**
+ * W07 (#3901): push fan-out helpers for ticket events.
+ *
+ * Everything here is called by ticketNotifyWorker INSIDE
+ * withSystemDbAccessContext, which bypasses RLS. That context is DISCOVERY
+ * ONLY. Every recipient is re-authorised (spec D5): same partner as the event,
+ * active, holds tickets:read, and can access the ticket's org. Network I/O
+ * (dispatchPushToTokens) is NOT done here — the worker sends after the context
+ * exits (#1105).
+ */
+import { and, asc, eq } from 'drizzle-orm';
+import { resolveTicketPushPrefs, type TicketPushPreferences } from '@breeze/shared';
+import { db } from '../db';
+import { mobileDevices, ticketPushPreferences, users } from '../db/schema';
+import { isApnsConfigured } from './apns';
+import { checkNotificationThrottle } from './notificationThrottle';
+import { canAccessOrg, getUserPermissions, hasPermission, PERMISSIONS } from './permissions';
+import { isInQuietHours, type QuietHoursConfig } from './quietHours';
+import { captureException } from './sentry';
+import type { PushSpec, TaggedPushToken } from './expoPush';
+
+export interface PushJob {
+  tokens: TaggedPushToken[];
+  spec: PushSpec;
+}
+
+export interface RecipientCandidate {
+  userId: string;
+  partnerId: string;
+  status: string;
+  email: string | null;
+}
+
+/**
+ * Hard blast-radius cap on the partner-wide ('any') SLA fan-out. A partner with
+ * thousands of opted-in techs must not turn one breach into thousands of pushes
+ * inside a single job.
+ */
+export const ANY_SUBSCRIBER_CAP = 500;
+const THROTTLE_CHANNEL = 'mobile-ticket';
+const THROTTLE_MAX = 20;
+const THROTTLE_WINDOW_S = 300;
+
+let warnedApnsUnconfigured = false;
+export function __resetApnsWarnForTests(): void {
+  warnedApnsUnconfigured = false;
+}
+
+/**
+ * Unexecuted builder so the compiled SQL can be asserted (ticketPush.sql.test.ts).
+ * `eq(users.partnerId, partnerId)` IS the tenant boundary — the worker runs with
+ * RLS bypassed, so nothing below this line stops a cross-partner subscriber.
+ */
+export function anySlaSubscribersQuery(partnerId: string) {
+  return db
+    .select({
+      userId: users.id,
+      partnerId: users.partnerId,
+      status: users.status,
+      email: users.email,
+    })
+    .from(ticketPushPreferences)
+    .innerJoin(users, eq(users.id, ticketPushPreferences.userId))
+    .where(
+      and(
+        eq(ticketPushPreferences.slaScope, 'any'),
+        eq(users.partnerId, partnerId),
+        eq(users.status, 'active')
+      )
+    )
+    .orderBy(asc(users.id))
+    .limit(ANY_SUBSCRIBER_CAP + 1); // +1 so truncation is observable
+}
+
+export async function listAnySlaSubscribers(
+  partnerId: string
+): Promise<{ users: RecipientCandidate[]; truncated: boolean }> {
+  const rows = (await anySlaSubscribersQuery(partnerId)) as RecipientCandidate[];
+  const truncated = rows.length > ANY_SUBSCRIBER_CAP;
+  if (truncated) {
+    console.warn(
+      `[TicketPush] 'any' SLA subscribers exceed cap partner=${partnerId} cap=${ANY_SUBSCRIBER_CAP}; first ${ANY_SUBSCRIBER_CAP} by user id`
+    );
+  }
+  return { users: rows.slice(0, ANY_SUBSCRIBER_CAP), truncated };
+}
+
+export async function loadUserCandidate(userId: string): Promise<RecipientCandidate | null> {
+  const rows = await db
+    .select({
+      userId: users.id,
+      partnerId: users.partnerId,
+      status: users.status,
+      email: users.email,
+    })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+  return (rows[0] as RecipientCandidate | undefined) ?? null;
+}
+
+export async function loadTicketPushPrefs(userId: string): Promise<TicketPushPreferences> {
+  const rows = await db
+    .select({
+      assignedEnabled: ticketPushPreferences.assignedEnabled,
+      slaScope: ticketPushPreferences.slaScope,
+    })
+    .from(ticketPushPreferences)
+    .where(eq(ticketPushPreferences.userId, userId))
+    .limit(1);
+  return resolveTicketPushPrefs(rows[0] ?? null);
+}
+
+/** D5 step 1: cheap partner assertion. A mismatch is a forged/moved user — terminal + reported. */
+export function assertSamePartner(
+  c: RecipientCandidate,
+  eventPartnerId: string | null,
+  ctx: { ticketId: string }
+): boolean {
+  if (eventPartnerId && c.partnerId === eventPartnerId) return true;
+  const msg = `[TicketPush] recipient partner mismatch user=${c.userId} userPartner=${c.partnerId} eventPartner=${eventPartnerId} ticket=${ctx.ticketId}`;
+  console.warn(msg);
+  captureException(new Error(msg));
+  return false;
+}
+
+/** D5 step 3: permission + org access, resolved through the normal permission service. */
+export async function isAuthorisedForTicket(
+  userId: string,
+  partnerId: string,
+  orgId: string
+): Promise<boolean> {
+  const perms = await getUserPermissions(userId, { partnerId, orgId });
+  if (!perms) return false;
+  return (
+    hasPermission(perms, PERMISSIONS.TICKETS_READ.resource, PERMISSIONS.TICKETS_READ.action) &&
+    canAccessOrg(perms, orgId)
+  );
+}
+
+/**
+ * Active, notifications-enabled devices, minus those inside quiet hours (D12).
+ *
+ * Re-selects rather than wrapping getUserPushTokens because that helper does
+ * not return quiet_hours; the three-line provider inference is duplicated
+ * deliberately rather than exporting a shared helper.
+ */
+export async function getUserPushTargets(
+  userId: string,
+  now: Date = new Date()
+): Promise<TaggedPushToken[]> {
+  const rows = await db
+    .select({
+      fcm: mobileDevices.fcmToken,
+      apns: mobileDevices.apnsToken,
+      platform: mobileDevices.platform,
+      quietHours: mobileDevices.quietHours,
+    })
+    .from(mobileDevices)
+    .where(
+      and(
+        eq(mobileDevices.userId, userId),
+        eq(mobileDevices.notificationsEnabled, true),
+        eq(mobileDevices.status, 'active')
+      )
+    );
+
+  const out: TaggedPushToken[] = [];
+  for (const row of rows) {
+    if (isInQuietHours(row.quietHours as QuietHoursConfig | null, now)) continue;
+    for (const token of [row.fcm, row.apns]) {
+      if (!token) continue;
+      out.push({
+        token,
+        platform: row.platform,
+        provider: token.startsWith('ExponentPushToken')
+          ? 'expo'
+          : row.platform === 'ios'
+            ? 'apns'
+            : 'fcm',
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * D8 (APNs configured?) -> D6 (throttle) -> tokens -> D12 (quiet hours).
+ * Never throws; null means "nothing to send" and the caller writes the in-app
+ * row and email regardless.
+ */
+export async function collectTicketPush(userId: string, spec: PushSpec): Promise<PushJob | null> {
+  if (!isApnsConfigured()) {
+    if (!warnedApnsUnconfigured) {
+      warnedApnsUnconfigured = true;
+      console.info('[TicketPush] APNs not configured — ticket pushes skipped (in-app + email unaffected)');
+    }
+    return null;
+  }
+  const throttle = await checkNotificationThrottle(
+    THROTTLE_CHANNEL,
+    `user:${userId}`,
+    THROTTLE_MAX,
+    THROTTLE_WINDOW_S
+  );
+  if (!throttle.allowed) {
+    console.warn(`[TicketPush] throttled user=${userId} count=${throttle.currentCount}`);
+    return null;
+  }
+  const tokens = await getUserPushTargets(userId);
+  if (tokens.length === 0) return null;
+  return { tokens, spec };
+}

--- a/apps/api/src/services/ticketPush.ts
+++ b/apps/api/src/services/ticketPush.ts
@@ -1,14 +1,24 @@
 /**
  * W07 (#3901): push fan-out helpers for ticket events.
  *
- * Everything here is called by ticketNotifyWorker INSIDE
+ * Recipient DISCOVERY (loadUserCandidate / listAnySlaSubscribers / prefs /
+ * isAuthorisedForTicket) is called by ticketNotifyWorker INSIDE
  * withSystemDbAccessContext, which bypasses RLS. That context is DISCOVERY
  * ONLY. Every recipient is re-authorised (spec D5): same partner as the event,
- * active, holds tickets:read, and can access the ticket's org. Network I/O
- * (dispatchPushToTokens) is NOT done here — the worker sends after the context
- * exits (#1105).
+ * holds tickets:read, and can access the ticket's org; account status gates the
+ * PUSH (see the worker) — never the in-app row or the email.
+ *
+ * Push materialisation is deliberately TWO-PHASE so no network round-trip ever
+ * happens inside the open fan-out transaction (#1105 class — the shape
+ * alertWorker was refactored away from):
+ *   1. `admitPush`      — Redis only (D8 APNs-configured + D6 throttle). The
+ *                         worker runs it with NO DB context open.
+ *   2. `resolvePushJobs` — ONE batched device read (D12 quiet hours), run by
+ *                         the worker in its own short system context.
+ * The APNs/Expo send itself (dispatchPushToTokens) happens after that context
+ * closes too.
  */
-import { and, asc, eq } from 'drizzle-orm';
+import { and, asc, eq, inArray } from 'drizzle-orm';
 import { resolveTicketPushPrefs, type TicketPushPreferences } from '@breeze/shared';
 import { db } from '../db';
 import { mobileDevices, ticketPushPreferences, users } from '../db/schema';
@@ -21,6 +31,12 @@ import type { PushSpec, TaggedPushToken } from './expoPush';
 
 export interface PushJob {
   tokens: TaggedPushToken[];
+  spec: PushSpec;
+}
+
+/** A recipient the collectors decided SHOULD be pushed, before any transport gate. */
+export interface PendingPush {
+  userId: string;
   spec: PushSpec;
 }
 
@@ -146,18 +162,17 @@ export async function isAuthorisedForTicket(
 }
 
 /**
- * Active, notifications-enabled devices, minus those inside quiet hours (D12).
- *
- * Re-selects rather than wrapping getUserPushTokens because that helper does
- * not return quiet_hours; the three-line provider inference is duplicated
- * deliberately rather than exporting a shared helper.
+ * Unexecuted builder so the compiled SQL can be asserted
+ * (ticketPush.sql.test.ts). `notifications_enabled` is the ONLY guard for a
+ * technician who muted pushes in the app (the opt-out route does not clear
+ * tokens), and `status = 'active'` excludes a soft-blocked handset (lost-phone
+ * revocation / admin takeover — see db/schema/mobile.ts). Both are
+ * security-relevant, so neither may be asserted through a chainable db mock.
  */
-export async function getUserPushTargets(
-  userId: string,
-  now: Date = new Date()
-): Promise<TaggedPushToken[]> {
-  const rows = await db
+export function userPushTargetsQuery(userIds: string[]) {
+  return db
     .select({
+      userId: mobileDevices.userId,
       fcm: mobileDevices.fcmToken,
       apns: mobileDevices.apnsToken,
       platform: mobileDevices.platform,
@@ -166,55 +181,98 @@ export async function getUserPushTargets(
     .from(mobileDevices)
     .where(
       and(
-        eq(mobileDevices.userId, userId),
+        inArray(mobileDevices.userId, userIds),
         eq(mobileDevices.notificationsEnabled, true),
         eq(mobileDevices.status, 'active')
       )
     );
+}
 
+interface DeviceRow {
+  userId: string;
+  fcm: string | null;
+  apns: string | null;
+  /** `device_platform` pg enum — must stay narrowed, TaggedPushToken.platform is not `string`. */
+  platform: 'ios' | 'android';
+  quietHours: unknown;
+}
+
+function tagTokens(row: DeviceRow): TaggedPushToken[] {
   const out: TaggedPushToken[] = [];
-  for (const row of rows) {
-    if (isInQuietHours(row.quietHours as QuietHoursConfig | null, now)) continue;
-    for (const token of [row.fcm, row.apns]) {
-      if (!token) continue;
-      out.push({
-        token,
-        platform: row.platform,
-        provider: token.startsWith('ExponentPushToken')
-          ? 'expo'
-          : row.platform === 'ios'
-            ? 'apns'
-            : 'fcm',
-      });
-    }
+  for (const token of [row.fcm, row.apns]) {
+    if (!token) continue;
+    out.push({
+      token,
+      platform: row.platform,
+      provider: token.startsWith('ExponentPushToken')
+        ? 'expo'
+        : row.platform === 'ios'
+          ? 'apns'
+          : 'fcm',
+    });
   }
   return out;
 }
 
 /**
- * D8 (APNs configured?) -> D6 (throttle) -> tokens -> D12 (quiet hours).
- * Never throws; null means "nothing to send" and the caller writes the in-app
- * row and email regardless.
+ * Phase 1 — D8 (APNs configured?) then D6 (throttle). Redis ONLY: this must be
+ * safe to call with no DB access context open, which is exactly how the worker
+ * calls it. Never throws.
  */
-export async function collectTicketPush(userId: string, spec: PushSpec): Promise<PushJob | null> {
+export async function admitPush(pending: PendingPush[]): Promise<PendingPush[]> {
+  if (pending.length === 0) return [];
   if (!isApnsConfigured()) {
     if (!warnedApnsUnconfigured) {
       warnedApnsUnconfigured = true;
       console.info('[TicketPush] APNs not configured — ticket pushes skipped (in-app + email unaffected)');
     }
-    return null;
+    return [];
   }
-  const throttle = await checkNotificationThrottle(
-    THROTTLE_CHANNEL,
-    `user:${userId}`,
-    THROTTLE_MAX,
-    THROTTLE_WINDOW_S
-  );
-  if (!throttle.allowed) {
-    console.warn(`[TicketPush] throttled user=${userId} count=${throttle.currentCount}`);
-    return null;
+  const admitted: PendingPush[] = [];
+  for (const p of pending) {
+    const throttle = await checkNotificationThrottle(
+      THROTTLE_CHANNEL,
+      `user:${p.userId}`,
+      THROTTLE_MAX,
+      THROTTLE_WINDOW_S
+    );
+    if (!throttle.allowed) {
+      console.warn(`[TicketPush] throttled user=${p.userId} count=${throttle.currentCount}`);
+      continue;
+    }
+    admitted.push(p);
   }
-  const tokens = await getUserPushTargets(userId);
-  if (tokens.length === 0) return null;
-  return { tokens, spec };
+  return admitted;
+}
+
+/**
+ * Phase 2 — token resolution + D12 (quiet hours), in ONE batched query for the
+ * whole fan-out. Needs a DB access context (the worker opens a short system one
+ * for just this call). A recipient with no deliverable token yields no job.
+ */
+export async function resolvePushJobs(
+  pending: PendingPush[],
+  now: Date = new Date()
+): Promise<PushJob[]> {
+  if (pending.length === 0) return [];
+  const userIds = [...new Set(pending.map((p) => p.userId))];
+  const rows = (await userPushTargetsQuery(userIds)) as DeviceRow[];
+
+  const byUser = new Map<string, TaggedPushToken[]>();
+  for (const row of rows) {
+    if (isInQuietHours(row.quietHours as QuietHoursConfig | null, now)) continue;
+    const tokens = tagTokens(row);
+    if (tokens.length === 0) continue;
+    const existing = byUser.get(row.userId);
+    if (existing) existing.push(...tokens);
+    else byUser.set(row.userId, tokens);
+  }
+
+  const jobs: PushJob[] = [];
+  for (const p of pending) {
+    const tokens = byUser.get(p.userId);
+    if (!tokens || tokens.length === 0) continue;
+    jobs.push({ tokens, spec: p.spec });
+  }
+  return jobs;
 }

--- a/apps/api/src/services/ticketPush.ts
+++ b/apps/api/src/services/ticketPush.ts
@@ -51,7 +51,7 @@ export function __resetApnsWarnForTests(): void {
  * `eq(users.partnerId, partnerId)` IS the tenant boundary — the worker runs with
  * RLS bypassed, so nothing below this line stops a cross-partner subscriber.
  */
-export function anySlaSubscribersQuery(partnerId: string) {
+export function anySlaSubscribersQuery(partnerId: string, cap: number = ANY_SUBSCRIBER_CAP) {
   return db
     .select({
       userId: users.id,
@@ -69,20 +69,27 @@ export function anySlaSubscribersQuery(partnerId: string) {
       )
     )
     .orderBy(asc(users.id))
-    .limit(ANY_SUBSCRIBER_CAP + 1); // +1 so truncation is observable
+    .limit(cap + 1); // +1 so truncation is observable
 }
 
+/**
+ * `cap` is a parameter, not a constant read, ONLY so the real-DB truncation test
+ * can prove the behaviour with a handful of users instead of 505 (seeding 505
+ * users with roles and permission grants blows a 30s integration timeout). The
+ * worker never passes it — production is always ANY_SUBSCRIBER_CAP.
+ */
 export async function listAnySlaSubscribers(
-  partnerId: string
+  partnerId: string,
+  cap: number = ANY_SUBSCRIBER_CAP
 ): Promise<{ users: RecipientCandidate[]; truncated: boolean }> {
-  const rows = (await anySlaSubscribersQuery(partnerId)) as RecipientCandidate[];
-  const truncated = rows.length > ANY_SUBSCRIBER_CAP;
+  const rows = (await anySlaSubscribersQuery(partnerId, cap)) as RecipientCandidate[];
+  const truncated = rows.length > cap;
   if (truncated) {
     console.warn(
-      `[TicketPush] 'any' SLA subscribers exceed cap partner=${partnerId} cap=${ANY_SUBSCRIBER_CAP}; first ${ANY_SUBSCRIBER_CAP} by user id`
+      `[TicketPush] 'any' SLA subscribers exceed cap partner=${partnerId} cap=${cap}; first ${cap} by user id`
     );
   }
-  return { users: rows.slice(0, ANY_SUBSCRIBER_CAP), truncated };
+  return { users: rows.slice(0, cap), truncated };
 }
 
 export async function loadUserCandidate(userId: string): Promise<RecipientCandidate | null> {

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -1074,6 +1074,7 @@ export * from './queryParams';
 export * from './timeEntries';
 export * from './portal';
 export * from './ticketConfig';
+export * from './ticketPushPreferences';
 export * from './clientAiDlp';
 export * from './quickSupport';
 

--- a/packages/shared/src/validators/ticketPushPreferences.test.ts
+++ b/packages/shared/src/validators/ticketPushPreferences.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveTicketPushPrefs,
+  updateTicketPushPreferencesSchema,
+  ticketPushPreferencesSchema,
+  TICKET_PUSH_PREFERENCE_DEFAULTS,
+} from './ticketPushPreferences';
+
+describe('resolveTicketPushPrefs', () => {
+  it('returns defaults for null and undefined', () => {
+    expect(resolveTicketPushPrefs(null)).toEqual({ assignedEnabled: true, slaScope: 'owned' });
+    expect(resolveTicketPushPrefs(undefined)).toEqual(TICKET_PUSH_PREFERENCE_DEFAULTS);
+  });
+  it('fills missing fields from defaults and keeps provided ones', () => {
+    expect(resolveTicketPushPrefs({ slaScope: 'any' })).toEqual({ assignedEnabled: true, slaScope: 'any' });
+    expect(resolveTicketPushPrefs({ assignedEnabled: false })).toEqual({ assignedEnabled: false, slaScope: 'owned' });
+  });
+  it('never returns an unknown scope', () => {
+    expect(resolveTicketPushPrefs({ slaScope: 'bogus' as never }).slaScope).toBe('owned');
+  });
+});
+
+describe('updateTicketPushPreferencesSchema', () => {
+  it('rejects an empty patch', () => {
+    expect(updateTicketPushPreferencesSchema.safeParse({}).success).toBe(false);
+  });
+  it('rejects unknown keys (strict)', () => {
+    expect(updateTicketPushPreferencesSchema.safeParse({ userId: 'x', slaScope: 'off' }).success).toBe(false);
+  });
+  it('accepts a partial patch', () => {
+    expect(updateTicketPushPreferencesSchema.safeParse({ slaScope: 'any' }).success).toBe(true);
+    expect(updateTicketPushPreferencesSchema.safeParse({ assignedEnabled: false }).success).toBe(true);
+  });
+  it('rejects an invalid scope', () => {
+    expect(updateTicketPushPreferencesSchema.safeParse({ slaScope: 'all' }).success).toBe(false);
+  });
+});
+
+describe('ticketPushPreferencesSchema', () => {
+  it('requires both fields', () => {
+    expect(ticketPushPreferencesSchema.safeParse({ assignedEnabled: true }).success).toBe(false);
+  });
+});

--- a/packages/shared/src/validators/ticketPushPreferences.ts
+++ b/packages/shared/src/validators/ticketPushPreferences.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+
+/**
+ * Per-user mobile push preferences for ticket events (W07, #3901).
+ * Stored in `ticket_push_preferences` (Shape 6, user-scoped). A missing row
+ * means "defaults" — resolveTicketPushPrefs is the single place that says so,
+ * for API and app alike (spec D13).
+ */
+export const ticketSlaPushScopeSchema = z.enum(['off', 'owned', 'any']);
+export type TicketSlaPushScope = z.infer<typeof ticketSlaPushScopeSchema>;
+
+export const ticketPushPreferencesSchema = z.object({
+  assignedEnabled: z.boolean(),
+  slaScope: ticketSlaPushScopeSchema,
+});
+export type TicketPushPreferences = z.infer<typeof ticketPushPreferencesSchema>;
+
+export const updateTicketPushPreferencesSchema = ticketPushPreferencesSchema
+  .partial()
+  .strict()
+  .refine((v) => v.assignedEnabled !== undefined || v.slaScope !== undefined, {
+    message: 'No settings provided',
+  });
+export type UpdateTicketPushPreferences = z.infer<typeof updateTicketPushPreferencesSchema>;
+
+export const TICKET_PUSH_PREFERENCE_DEFAULTS: TicketPushPreferences = Object.freeze({
+  assignedEnabled: true,
+  slaScope: 'owned',
+}) as TicketPushPreferences;
+
+/** Total: any input (including garbage scopes) resolves to a valid preference set. */
+export function resolveTicketPushPrefs(
+  row: Partial<TicketPushPreferences> | null | undefined
+): TicketPushPreferences {
+  const scopeParsed = ticketSlaPushScopeSchema.safeParse(row?.slaScope);
+  return {
+    assignedEnabled:
+      typeof row?.assignedEnabled === 'boolean'
+        ? row.assignedEnabled
+        : TICKET_PUSH_PREFERENCE_DEFAULTS.assignedEnabled,
+    slaScope: scopeParsed.success ? scopeParsed.data : TICKET_PUSH_PREFERENCE_DEFAULTS.slaScope,
+  };
+}


### PR DESCRIPTION
`Refs #3901` — this PR ships the **backend half** of W07 only: the `ticket_push_preferences` table and its RLS, the preference endpoints, the push-sender generalisation, and the worker fan-out with dedupe.

**The mobile half has not shipped.** Tap routing (`PushTapRouter`, `navigationRef`), the Settings-sheet controls, the mobile API client/slice, and the docs updates (plan Tasks 13–18) are all still to come in a stacked PR, and **that** PR closes #3901. Nothing user-visible on the phone changes from this PR alone: with no mobile build that registers for the `tickets` category, the fan-out simply pushes to whatever APNs tokens already exist.

Plan: `docs/superpowers/plans/mobile/2026-08-29-ticket-push-categories.md` (on `docs/3206-w06-w08-specs-plans`, PR #4258). Tasks 2–12.

## What a technician gets

An iOS push when a ticket is assigned to them, and when a ticket they own — or, by opt-in, any ticket in their partner — breaches its response or resolution SLA. Preferences are per-user: `assignedEnabled` (default true) and `slaScope` of `off` / `owned` (default) / `any`.

## Tasks completed

An earlier session had already landed Tasks 2–10 as nine commits and left Task 11 uncommitted mid-flight. This run audited all of it (including mutation-testing the controls) rather than trusting it, then finished the wave.

**Already built by the earlier run (audited, kept):**

| Task | What |
|---|---|
| 2 | `packages/shared/.../ticketPushPreferences.ts` — Zod schemas, defaults, total `resolveTicketPushPrefs` |
| 3 | Migration `2026-09-25-ticket-push-preferences.sql`, Drizzle schema, RLS registration + behavioural RLS suite |
| 4 | `eventId` stamped on the ticket-event envelope |
| 5 | `isInQuietHours` extracted to `services/quietHours.ts` |
| 6 | APNs `thread-id` / `category`, emitted only when set |
| 7 | `PushSpec`, `dispatchPushToTokens`, `buildTicketPush`; approval dispatch became a wrapper |
| 8 | `GET`/`PATCH /api/v1/users/me/ticket-push-preferences` |
| 9 | Widened the `/users` router's self-service exemption so the route is reachable |
| 10 | `services/ticketPush.ts` — recipient discovery, authorisation, per-user push collection |

**Completed in this run:**

| Task | What |
|---|---|
| 11 | Worker fan-out: `createNotification({ dedupeKey })` as the idempotency anchor, per-recipient re-authorisation, push collection inside the system context, `dispatchPushToTokens` **after** it exits (#1105). Committed the previous run's work after fixing three type errors and two dead schema imports it had left. |
| 12 | `ticketPushFanout.integration.test.ts` — six real-Postgres tests: cross-partner and cross-org isolation with a no-permission negative control, an isolated `listAnySlaSubscribers` partner-filter assertion, dedupe replay, A→B→A reassignment, and cap truncation. |
| — | `ticketEventsContract.test.ts` updated: the producer→consumer seam test asserted the old direct `db.insert` into `user_notifications`. Not named by the plan (it lives under `services/`), and it is a **required Test API** job, so it would have reddened CI. |

Tasks 13–18 (mobile) and Task 19 Step 2 (manual device checklist) are **out of scope** for this PR. The device checklist has **not been run** — there is no mobile build for this wave yet.

## Tenancy

`ticket_push_preferences` is **Shape 6** (user-id scoped): `user_id` PK, no `org_id`, no `partner_id`, no `device_id`, not append-only. It is a personal preference in the same category as `mobile_devices` — this sentence is the CLAUDE.md-required justification for it not being a Partner-Wide-First config table.

RLS is `ENABLE` + `FORCE` + one policy in the creating migration: `breeze_current_scope() = 'system' OR user_id = breeze_current_user_id()`, on both `USING` and `WITH CHECK`. The `system` branch is required — the notify worker reads this table inside `withSystemDbAccessContext`.

### Registration lists

| List | File | Edited? |
|---|---|---|
| `USER_ID_SCOPED_TABLES` | `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts` | **YES** — the only entry this table needs |
| `CORE_ORG_CASCADE_DELETE_ORDER` | `services/tenantCascade.ts` | no — no `org_id` column |
| `CORE_TENANT_EXPORT_POLICY` | `services/tenantExportPolicyRegistry.ts` | no — not an org-cascade table, and **no existing org-cascade table gains a column in this wave** |
| `CORE_DEVICE_CASCADE_DELETE_TABLES` / `CORE_DEVICE_ORG_DENORMALIZED_TABLES` | `routes/devices/core.ts` | no — no `device_id` column |
| `AUDIT_ADMIN_REQUIRED_TABLES` | `services/tenantCascade.ts` | no — not append-only |
| `orgMergeRegistry` | `services/orgMergeRegistry.ts` | no — verified: the registry's required set is `getOrgCascadeDeleteOrder()` + a hardcoded `EXTRA_REQUIRED`; adding this table would fail its "no policy names an unrequired table" assertion |

Proved by grep, not judgement: `grep -rn 'ticket_push_preferences' apps/api/src/services/tenantCascade.ts` is empty, and `mobile_devices` — the closest existing analogue, also user-PK — appears in none of these lists either. All six suites were run (below).

## The two risky surfaces, and how they are held

**Task 9 widened an authorisation predicate on `userRoutes.use('*')`, so its blast radius is every route on the `/users` router.** The exemption went from `/\/me(\/avatar)?$/` to `/\/me(\/avatar|\/ticket-push-preferences)?$/` — an allowlist, deliberately not `/\/me(\/.*)?$/`, which would auto-exempt every future `/me/*` route. It newly exempts exactly one path. `users.test.ts` covers both new exemptions plus a **control** that a `'selected'` partner-admin is still 403'd on partner-wide user management, so widening the regex too far cannot pass silently. Both handlers derive the subject from `auth.user.id`; the PATCH schema is `.strict()`, so a smuggled `userId` is a 400.

**`services/ticketPush.ts` runs under `withSystemDbAccessContext` with RLS bypassed — it is the only tenant boundary for pushes.** Three independent layers: the partner filter compiled into `anySlaSubscribersQuery`, `assertSamePartner` (warn + `captureException` on mismatch), and `isAuthorisedForTicket` (`getUserPermissions` → `tickets:read` + `canAccessOrg`). Active status is checked too.

Every control was **mutation-tested**, and this found something worth reporting. The plan's mutation table expected "`assertSamePartner` returns true" and "drop the SQL partner filter" each to redden the end-to-end fan-out test. **Neither does on its own** — the three layers are individually redundant, so removing any one leaves the fan-out correct. Rather than accept an unpinned clause, the test file gained a direct `listAnySlaSubscribers` assertion that reddens on the dropped filter (verified), and `assertSamePartner` is pinned by its own unit tests plus the worker's foreign-partner case (verified: mutating it reddens three tests). Confirmed-discriminating mutations:

| Mutation | Test that went RED |
|---|---|
| `isAuthorisedForTicket` returns `true` unconditionally | fan-out isolation test — `anyB` and `noPerm` appear |
| drop `eq(users.partnerId, partnerId)` from `anySlaSubscribersQuery` | `listAnySlaSubscribers never returns a subscriber from another partner` |
| `createNotification` called without `dedupeKey` | integration replay test (two owner rows) + two worker unit tests |
| `assertSamePartner` returns `true` unconditionally | 3 unit tests across `ticketPush.test.ts` and `ticketNotifyWorker.test.ts` |
| push dispatch moved inside the system context | 4 worker unit tests, incl. the explicit ordering assertion |
| `truncated` forced to `false` | cap-truncation integration test |

**#1105:** all network I/O happens after the DB context exits. The push loop sits deliberately **before** the email early-return, because an `any` SLA subscriber produces zero email payloads.

## Contract suites — real outcomes

Run against a live per-worktree Postgres (`pnpm test-stack up`).

| Suite | Outcome | Note |
|---|---|---|
| `@breeze/shared` unit | **passed** | 84 files, 2208 tests |
| `@breeze/api` unit (full) | **passed** | after fixing `ticketEventsContract`; see "pre-existing" below |
| `pnpm lint` | **passed** | 6/6 tasks |
| `tsc --noEmit` (api) | **passed** | needs `NODE_OPTIONS=--max-old-space-size=8192` locally — OOMs at the default heap |
| `pnpm db:check-drift` | **passed** | 595 migration files match the ledger |
| `test:rls` (`vitest.config.rls.ts`) | **passed** | 26 passed, 5 skipped |
| `rls-coverage.integration.test.ts` | **passed** | 75 tests — has its own runner (`vitest.config.rls-coverage.ts`); it is *excluded* from the integration config, so passing it as a path there silently runs nothing |
| `ticketPushPreferencesRls.integration.test.ts` | **passed** | 4 tests |
| `ticketPushFanout.integration.test.ts` | **passed** | 6 tests, none skipped |
| `userNotificationsRls.integration.test.ts` | **passed** | 12 tests |
| `tenantCascade.integration.test.ts` + `tenant-export-policy.integration.test.ts` | **passed** | 7 tests — no diff expected, none needed |
| `tenantExportErasureRoundtrip.integration.test.ts` + `orgMergeRegistry.integration.test.ts` | **passed** | 13 tests |

**Pre-existing local failure, not from this PR:** `src/db/offsetPaginationOrdering.test.ts` times out (5s `testTimeout`, ~80s of repo-wide AST scanning on this machine). Verified by running the same file on a checkout that does not contain these changes — it fails identically there. `tenantVariables.test.ts` and `workerEntrypointClosure.contract.test.ts` each failed once under `--maxWorkers=2` contention and pass in isolation.

## Deviations from the plan

1. **`getUserPushTargets` re-selects devices** instead of reusing `getUserPushTokens`, because the latter drops `quiet_hours`. (Anticipated by the plan.)
2. **Task 12's cap test was rewritten.** The plan seeded `ANY_SUBSCRIBER_CAP + 5` users, each with a role and a permission grant — ~2000 serial statements, which blew the 30s integration timeout twice. The plan's own fallback applies: `listAnySlaSubscribers`/`anySlaSubscribersQuery` now take an optional `cap` defaulting to `ANY_SUBSCRIBER_CAP`. The worker never passes it, production is unchanged, and `ticketPush.sql.test.ts` still pins `ANY_SUBSCRIBER_CAP + 1` into the compiled `LIMIT`. The rewritten tests prove truncation, the lowest-user-id ordering that makes truncation deterministic, and that the owner is reached through the assignee branch rather than the capped list.
3. **Task 12's mutation table was wrong about two of its four rows** (see above). Fixed by adding a control, not by relaxing an expectation.
4. **`const dispatch = vi.fn(...)` in the plan's Task 12 snippet cannot work** — `vi.mock` factories hoist above top-level bindings, so it dies at import with `Cannot access 'dispatch' before initialization`. Uses `vi.hoisted`.
5. **`ticketEventsContract.test.ts` needed updating** and the plan does not mention it. It is in the required **Test API** job.
6. **Branch prefix.** `feature/…` per CLAUDE.md's Feature Lifecycle rule, not `feat/` per `AGENTS.md:309` — the same prefix waves W01–W03 of this feature already shipped under. Flagging, not "fixing".
7. **Migration date.** `2026-09-25`, not the plan's `2026-09-23`: `2026-09-23` and `2026-09-24-a/-b` shipped since the plan was written. Re-verified at push time that it still sorts after every migration on `origin/main` (`23001934`).
8. `slaScope='off'` suppresses the owner's **push** only; their in-app row and email are still written (spec D6). Resolved in the plan, restated here because it is the kind of thing a reviewer will read as a bug.

## CI

Two checks are **already red on `origin/main` itself** (`355b37465`) and are unrelated to this PR — do not chase them:
- **Check Migrations** — step "Shipped-migration immutability guard"
- **Trivy Image Scan**

This PR targets `main`, so CI runs normally, including the blocking integration shards. No hand-dispatch needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XVnsGUAURLnTjUMQsguYWv
