### PR TITLE
fix(web): stop a created quote block from being invisible in the editor (#3519)

### DIFF
--- a/apps/web/src/components/billing/quotes/QuoteEditor.blockcreatestrand.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.blockcreatestrand.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * Regression suite for #3519 — "Quote image upload can create blocks server-side
+ * while the editor shows nothing".
+ *
+ * The stranding mechanism: an image block's ONLY success signal is the block
+ * appearing in the list ("No success toast — the image block visibly appears"),
+ * and that list only moves when the parent's *quiet* refetch lands. A quiet
+ * refetch that fails is swallowed by design, so the user saw: block created
+ * server-side, zero toast, an empty list, and a submit button that had gone
+ * disabled again because the form reset — indistinguishable from "still
+ * uploading". They re-uploaded, four times, into ~10 duplicate blocks.
+ *
+ * These tests pin BOTH directions of the post-create tail:
+ *  - success direction: the create landed but the list never resynced → the
+ *    user must still be told the section exists;
+ *  - failure direction: something after the create failed → the user must NOT
+ *    be told "could not add the section" (the copy that invites a re-submit).
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteEditor from './QuoteEditor';
+import type { QuoteDetail as QuoteDetailData } from './quoteTypes';
+import { addBlock, uploadQuoteImage } from '../../../lib/api/quotes';
+
+vi.mock('../../../stores/auth', () => ({
+  registerOrgIdProvider: vi.fn(),
+  fetchWithAuth: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
+  ),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+const showToast = vi.fn();
+vi.mock('../../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
+
+vi.mock('../../../lib/api/catalog', () => ({
+  listCatalog: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: [] }) } as unknown as Response,
+  ),
+  createCatalogItem: vi.fn(),
+  polishTextRequest: vi.fn(),
+}));
+
+vi.mock('../../../lib/api/quotes', () => ({
+  addBlock: vi.fn(),
+  deleteBlock: vi.fn(),
+  updateBlock: vi.fn(),
+  addManualLine: vi.fn(),
+  addCatalogLine: vi.fn(),
+  updateLine: vi.fn(),
+  removeLine: vi.fn(),
+  moveLine: vi.fn(),
+  reorderBlocks: vi.fn(),
+  uploadQuoteImage: vi.fn(),
+  addQuoteImageFromUrl: vi.fn(),
+  quoteImageUrl: vi.fn().mockReturnValue('/quotes/q-1/images/img-1'),
+}));
+
+const okRes = (data: unknown) =>
+  ({ ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data }) } as unknown as Response);
+const errRes = () =>
+  ({ ok: false, status: 502, statusText: 'Bad Gateway', json: vi.fn().mockResolvedValue({ error: 'upstream exploded' }) } as unknown as Response);
+
+const detail: QuoteDetailData = {
+  quote: {
+    id: 'q-1', quoteNumber: null, partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
+    currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '0.00', taxRate: null,
+    taxTotal: '0.00', total: '0.00', oneTimeTotal: '0.00', monthlyRecurringTotal: '0.00',
+    annualRecurringTotal: '0.00', billToName: null, introNotes: null, terms: null,
+    termsAndConditions: null, sellerSnapshot: null, acceptedAt: null, declinedAt: null,
+    convertedAt: null, convertedInvoiceId: null, sentAt: null, viewedAt: null, createdBy: null,
+    createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+  },
+  blocks: [],
+  lines: [],
+};
+
+const addBlockMock = vi.mocked(addBlock);
+const uploadMock = vi.mocked(uploadQuoteImage);
+
+/** Mount the editor with a parent whose refetch behaviour the test controls,
+ *  pick the image block type, and attach a file — i.e. the exact state the
+ *  reporter was in when they hit "Upload & add image". */
+async function armImageUpload(onChanged: () => unknown) {
+  render(<QuoteEditor detail={detail} onChanged={onChanged as () => void} />);
+  await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+  fireEvent.click(screen.getByTestId('quote-add-block-type-image'));
+  const file = new File(['bytes'], 'diagram.png', { type: 'image/png' });
+  fireEvent.change(screen.getByTestId('quote-block-image-file'), { target: { files: [file] } });
+  return file;
+}
+
+const toastMessages = () =>
+  showToast.mock.calls.map((c) => (c[0] as { message: string }).message);
+
+describe('QuoteEditor — an image block created server-side is never invisible (#3519)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('tells the user the section was added when the list refetch never lands', async () => {
+    // Both mutations succeed — the block EXISTS server-side from here on.
+    uploadMock.mockResolvedValue(okRes({ imageId: 'img-1' }));
+    addBlockMock.mockResolvedValue(okRes({ id: 'blk-new' }));
+    // ...but the parent's quiet refetch fails, so `detail` never changes and the
+    // block list stays empty. This is the reported production state.
+    const onChanged = vi.fn().mockResolvedValue(false);
+
+    await armImageUpload(onChanged);
+    fireEvent.click(screen.getByTestId('quote-add-block-submit'));
+
+    await waitFor(() => expect(addBlockMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(onChanged).toHaveBeenCalled());
+
+    // The editor genuinely shows nothing — that is the bug's premise, not an
+    // artifact: the empty-state placeholder is still the only thing rendered.
+    expect(screen.getByTestId('quote-blocks-empty')).toBeInTheDocument();
+
+    // ...so silence here is what made the reporter re-upload. The user must be
+    // told the section exists and that the view is stale.
+    await waitFor(() => expect(showToast).toHaveBeenCalled());
+    expect(toastMessages().join(' | ')).toMatch(/added/i);
+    // And it must not be the copy that invites a re-submit.
+    expect(toastMessages().join(' | ')).not.toMatch(/could not add/i);
+  });
+
+  it('does not report "could not add the image section" when the create succeeded and only the resync failed', async () => {
+    uploadMock.mockResolvedValue(okRes({ imageId: 'img-1' }));
+    addBlockMock.mockResolvedValue(okRes({ id: 'blk-new' }));
+    // The refetch throws outright (network drop mid-resync) rather than
+    // resolving false — the post-create tail must still land on the honest
+    // outcome instead of the generic add-failed toast or total silence.
+    const onChanged = vi.fn().mockRejectedValue(new Error('network gone'));
+
+    await armImageUpload(onChanged);
+    fireEvent.click(screen.getByTestId('quote-add-block-submit'));
+
+    await waitFor(() => expect(addBlockMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(showToast).toHaveBeenCalled());
+
+    const joined = toastMessages().join(' | ');
+    expect(joined).toMatch(/added/i);
+    expect(joined).not.toMatch(/could not add the image section/i);
+    // The button unlatches so the editor is usable again (a fresh file re-arms it).
+    await waitFor(() => expect(screen.getByTestId('quote-add-block-submit')).toBeDisabled());
+    const retry = new File(['more'], 'again.png', { type: 'image/png' });
+    fireEvent.change(screen.getByTestId('quote-block-image-file'), { target: { files: [retry] } });
+    expect(screen.getByTestId('quote-add-block-submit')).toBeEnabled();
+  });
+
+  it('still reports a genuine pre-create failure as a failure, and adds no block', async () => {
+    // Guard against the fix over-reporting: when the block was NEVER created the
+    // user must get the error, not an "added" notice.
+    uploadMock.mockResolvedValue(okRes({ imageId: 'img-1' }));
+    addBlockMock.mockResolvedValue(errRes());
+    const onChanged = vi.fn().mockResolvedValue(true);
+
+    await armImageUpload(onChanged);
+    fireEvent.click(screen.getByTestId('quote-add-block-submit'));
+
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'upstream exploded', type: 'error' }),
+    ));
+    expect(toastMessages().join(' | ')).not.toMatch(/added/i);
+    // Nothing was created, so the form keeps the file and the button stays live.
+    expect(screen.getByTestId('quote-add-block-submit')).toBeEnabled();
+  });
+
+  it('stays quiet on the happy path — a landed resync is still the success signal', async () => {
+    uploadMock.mockResolvedValue(okRes({ imageId: 'img-1' }));
+    addBlockMock.mockResolvedValue(okRes({ id: 'blk-new' }));
+    const onChanged = vi.fn().mockResolvedValue(true);
+
+    await armImageUpload(onChanged);
+    fireEvent.click(screen.getByTestId('quote-add-block-submit'));
+
+    await waitFor(() => expect(onChanged).toHaveBeenCalled());
+    expect(showToast).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteEditor.blockcreatestrand.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.blockcreatestrand.test.tsx
@@ -146,6 +146,13 @@ describe('QuoteEditor — an image block created server-side is never invisible 
     expect(joined).not.toMatch(/could not add the image section/i);
     // The button unlatches so the editor is usable again (a fresh file re-arms it).
     await waitFor(() => expect(screen.getByTestId('quote-add-block-submit')).toBeDisabled());
+    // NOT asserted here, deliberately: that the uncontrolled file input's own
+    // `.value` was cleared. jsdom never populates `value` from a programmatic
+    // `files` assignment (measured: with the DOM reset deleted, `.value` is
+    // still ''), and a file input's value cannot be set to a non-empty string,
+    // so any assertion on it passes whether or not the reset exists. Shipping
+    // one would claim coverage this layer cannot give. The DOM reset is covered
+    // by inspection; proving it needs a real browser (Playwright).
     const retry = new File(['more'], 'again.png', { type: 'image/png' });
     fireEvent.change(screen.getByTestId('quote-block-image-file'), { target: { files: [retry] } });
     expect(screen.getByTestId('quote-add-block-submit')).toBeEnabled();

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -455,7 +455,13 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
   const resync = useCallback(async (): Promise<boolean> => {
     try {
       return (await onChanged()) !== false;
-    } catch {
+    } catch (err) {
+      // Today's only production parent (QuoteWorkspace.fetchDetail) catches
+      // internally and resolves false, so this branch is unreachable from the
+      // app. Keep the breadcrumb anyway: the moment some future parent throws
+      // instead, a bare `return false` would erase the reason, which is the
+      // failure mode this whole change exists to stop.
+      console.error('[QuoteEditor] refetch threw while resyncing the canvas', err);
       return false;
     }
   }, [onChanged]);
@@ -1217,7 +1223,11 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
   /**
    * The tail every add-block branch runs AFTER the POST has already created the
    * block server-side: reposition it, clear the form, resync the canvas. Two
-   * rules make #3519 structurally impossible from here on.
+   * rules close #3519 for every branch that routes through here — which is the
+   * catch: nothing enforces that routing, so a NEW block type must call this
+   * helper rather than re-inlining `positionNewBlock` + reset + `refresh()`,
+   * or it reopens the bug. (Line creation still has the unfixed twin of this
+   * problem; see the note on `doAddCatalog`.)
    *
    * 1. It never throws. A throw would escape into `runScoped`'s catch and toast
    *    "Could not add the section" over a block that DOES exist — the copy that
@@ -1235,8 +1245,8 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
    * The resync deliberately goes through `resync()` rather than the coalescing
    * `refresh()`: adding a section is a one-shot action, not the tab-through
    * burst the throttle exists to cap, and its outcome report must not sit
-   * behind a cooldown window. Worst case this costs one extra GET when an
-   * unrelated edit already has the window open.
+   * behind a cooldown window. Worst case this costs one extra GET per add,
+   * when an unrelated edit already has the window open.
    */
   const finishBlockCreate = useCallback(async (
     created: { id?: string } | undefined,
@@ -1245,8 +1255,7 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
     let resynced = false;
     try {
       try {
-        // Best-effort and self-toasting: a failed reorder just leaves the new
-        // section at the end, which is visible and non-destructive.
+        // Best-effort and self-toasting — see `positionNewBlock`.
         await positionNewBlock(created);
       } finally {
         resetForm();
@@ -1456,6 +1465,15 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
   [quote.id, refresh, runScoped, t]);
 
   // ---- line mutations (scoped to a line_items block) ----------------------
+  // KNOWN GAP (#3519's unfixed twin, deliberately out of scope here): every line
+  // creation below rests on the same premise the block path just stopped
+  // trusting — "no success toast, the appended row and the moving totals ARE the
+  // feedback" — and ends with the fire-and-forget `refresh()` rather than the
+  // honest `finishBlockCreate` tail. So a line POST that succeeds while its
+  // quiet refetch fails is still completely silent, and a tech on a flaky link
+  // can re-add the same line the way the reporter re-uploaded the same image.
+  // Fixing it needs its own copy, its own 8 locales and its own tests, so it is
+  // filed separately rather than smuggled into this change.
   const doAddCatalog = useCallback(async (blockId: string, item: CatalogItem) => {
     await runAction({
       request: () => addCatalogLine(quote.id, { catalogItemId: item.id, quantity: 1, blockId }),

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -119,7 +119,14 @@ function unresolvedNamesFromMessage(message: string, knownNames: string[]): stri
 
 interface Props {
   detail: QuoteDetailData;
-  onChanged: () => void;
+  /** Ask the parent to refetch the quote. May report whether the refetch
+   *  actually landed: `false` means the canvas is still showing pre-mutation
+   *  data. Mounts that can't tell (standalone renders, tests) return void, and
+   *  the editor treats that as "caught up" so it never cries wolf. The editor
+   *  needs the answer because several mutations have no toast of their own —
+   *  their success signal is the result APPEARING, which a failed refetch turns
+   *  into silence (#3519). */
+  onChanged: () => void | Promise<boolean | void>;
   /** Fires whenever the editor's save state changes: true while any mutation is
    *  in flight or the terms field sits dirty. The workspace uses it to hold
    *  Send until the quote is quiescent, so the irreversible money-moment
@@ -373,6 +380,10 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
   const [richText, setRichText] = useState('');
   const [tableLabel, setTableLabel] = useState('');
   const [imageFile, setImageFile] = useState<File | null>(null);
+  // The file input is uncontrolled (a File can't round-trip through `value`),
+  // so the post-submit reset has to clear the element itself — otherwise the
+  // filename stays on screen after a successful add. See finishBlockCreate.
+  const imageFileInputRef = useRef<HTMLInputElement>(null);
   const [imageCaption, setImageCaption] = useState('');
   const [imageSource, setImageSource] = useState<'file' | 'url'>('file');
   const [imageUrl, setImageUrl] = useState('');
@@ -436,25 +447,37 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
   const refreshTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const refreshTrailing = useRef(false);
   useEffect(() => () => { if (refreshTimer.current) clearTimeout(refreshTimer.current); }, []);
+  // One un-throttled refetch, reporting whether the canvas actually caught up.
+  // A parent that returns void can't tell us, and "can't tell" must read as
+  // caught-up: warning on every legacy mount would train users to ignore the
+  // one warning that matters. Never throws — a rejected refetch is simply a
+  // canvas that did not catch up.
+  const resync = useCallback(async (): Promise<boolean> => {
+    try {
+      return (await onChanged()) !== false;
+    } catch {
+      return false;
+    }
+  }, [onChanged]);
   const refresh = useCallback(() => {
     if (refreshTimer.current) {
       // Inside the cooldown window — remember to fire once more when it closes.
       refreshTrailing.current = true;
       return;
     }
-    onChanged(); // leading edge: refetch now
+    void resync(); // leading edge: refetch now
     const openWindow = () => {
       refreshTimer.current = setTimeout(function close() {
         refreshTimer.current = null;
         if (refreshTrailing.current) {
           refreshTrailing.current = false;
-          onChanged();
+          void resync();
           openWindow(); // reopen so a fresh burst keeps coalescing
         }
       }, 300);
     };
     openWindow();
-  }, [onChanged]);
+  }, [resync]);
 
   const saveTerms = useCallback(async () => {
     if (!termsDirty) return;
@@ -1191,6 +1214,55 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
     } catch { /* toasted; the new section simply lands at the end */ }
   }, [insertAt, sortedBlocks, quote.id, withPendingDeletedBlockIds, t]);
 
+  /**
+   * The tail every add-block branch runs AFTER the POST has already created the
+   * block server-side: reposition it, clear the form, resync the canvas. Two
+   * rules make #3519 structurally impossible from here on.
+   *
+   * 1. It never throws. A throw would escape into `runScoped`'s catch and toast
+   *    "Could not add the section" over a block that DOES exist — the copy that
+   *    invites a re-submit, which is how four uploads became ~10 duplicate
+   *    image blocks in production.
+   * 2. If the canvas does not catch up, it says so. Add-block deliberately has
+   *    no success toast because "the new section visibly appears" IS the
+   *    signal; when the refetch fails that signal degrades to silence, and
+   *    silence is what the user reads as "nothing happened".
+   *
+   * The form reset sits in a `finally` so a failed reposition can't leave the
+   * picked file and the open insert-gap sitting there looking like work still
+   * in flight.
+   *
+   * The resync deliberately goes through `resync()` rather than the coalescing
+   * `refresh()`: adding a section is a one-shot action, not the tab-through
+   * burst the throttle exists to cap, and its outcome report must not sit
+   * behind a cooldown window. Worst case this costs one extra GET when an
+   * unrelated edit already has the window open.
+   */
+  const finishBlockCreate = useCallback(async (
+    created: { id?: string } | undefined,
+    resetForm: () => void,
+  ): Promise<void> => {
+    let resynced = false;
+    try {
+      try {
+        // Best-effort and self-toasting: a failed reorder just leaves the new
+        // section at the end, which is visible and non-destructive.
+        await positionNewBlock(created);
+      } finally {
+        resetForm();
+        setInsertAt(null);
+      }
+      resynced = await resync();
+    } catch (err) {
+      // Rule 1 above. Keep the breadcrumb — the honest toast below is what the
+      // user gets, but a silent catch would hide why the tail broke.
+      console.error('[QuoteEditor] post-create tail failed after the block was created', err);
+    }
+    if (!resynced) {
+      showToast({ message: t('quotes.editor.errors.sectionAddedListStale'), type: 'warning' });
+    }
+  }, [positionNewBlock, resync, t]);
+
   const submitBlock = useCallback(async () => {
     // Image blocks have no block-update endpoint, so the file must exist before
     // the block: upload it (POST /:id/images → { data: { imageId } }), then add
@@ -1233,10 +1305,14 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
           onUnauthorized: UNAUTHORIZED,
           parseSuccess: (d) => { notifyStrippedMarkup(d); return (d as { data: { id?: string } }).data; },
         });
-        await positionNewBlock(createdImg);
-        setImageFile(null); setImageCaption(''); setImageUrl('');
-        setInsertAt(null);
-        refresh();
+        await finishBlockCreate(createdImg, () => {
+          setImageFile(null); setImageCaption(''); setImageUrl('');
+          // The file input is uncontrolled, so clearing React state alone
+          // leaves the chosen filename on screen beside a button that has gone
+          // disabled ("no file picked") — visually identical to a submit still
+          // in flight, which is half of what #3519 felt like from the outside.
+          if (imageFileInputRef.current) imageFileInputRef.current.value = '';
+        });
       }, t('quotes.editor.errors.addImageSection'));
       return;
     }
@@ -1287,10 +1363,7 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
           }
           throw err;
         }
-        await positionNewBlock(createdContract);
-        resetContractForm();
-        setInsertAt(null);
-        refresh();
+        await finishBlockCreate(createdContract, resetContractForm);
       }, t('quotes.editor.errors.addContractSection'));
       return;
     }
@@ -1307,10 +1380,7 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
           onUnauthorized: UNAUTHORIZED,
           parseSuccess: (d) => { notifyStrippedMarkup(d); return (d as { data: { id?: string } }).data; },
         });
-        await positionNewBlock(created);
-        resetTableForm();
-        setInsertAt(null);
-        refresh();
+        await finishBlockCreate(created, resetTableForm);
       }, t('quotes.editor.errors.addSection'));
       return;
     }
@@ -1328,10 +1398,7 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
           onUnauthorized: UNAUTHORIZED,
           parseSuccess: (d) => { notifyStrippedMarkup(d); return (d as { data: { id?: string } }).data; },
         });
-        await positionNewBlock(created);
-        resetCalloutForm();
-        setInsertAt(null);
-        refresh();
+        await finishBlockCreate(created, resetCalloutForm);
       }, t('quotes.editor.errors.addSection'));
       return;
     }
@@ -1357,12 +1424,11 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
         onUnauthorized: UNAUTHORIZED,
         parseSuccess: (d) => { notifyStrippedMarkup(d); return (d as { data: { id?: string } }).data; },
       });
-      await positionNewBlock(created);
-      setHeadingText(''); setRichText(''); setTableLabel('');
-      setInsertAt(null);
-      refresh();
+      await finishBlockCreate(created, () => {
+        setHeadingText(''); setRichText(''); setTableLabel('');
+      });
     }, t('quotes.editor.errors.addSection'));
-  }, [addType, headingText, richText, tableLabel, imageFile, imageCaption, imageSource, imageUrl, contractTemplateId, contractVersion, contractVarValues, contractLabel, resetContractForm, tableFormState, resetTableForm, calloutFormState, resetCalloutForm, positionNewBlock, quote.id, refresh, runScoped, t]);
+  }, [addType, headingText, richText, tableLabel, imageFile, imageCaption, imageSource, imageUrl, contractTemplateId, contractVersion, contractVarValues, contractLabel, resetContractForm, tableFormState, resetTableForm, calloutFormState, resetCalloutForm, finishBlockCreate, quote.id, runScoped, t]);
 
 
   // Removing a line_items block cascades to every line under it (server-side), so
@@ -2132,6 +2198,7 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
                 </div>
                 {imageSource === 'file' ? (
                   <input
+                    ref={imageFileInputRef}
                     type="file"
                     accept="image/png,image/jpeg,image/webp"
                     onChange={(e) => setImageFile(e.target.files?.[0] ?? null)}

--- a/apps/web/src/components/billing/quotes/QuoteWorkspace.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteWorkspace.test.tsx
@@ -1,8 +1,9 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import QuoteWorkspace from './QuoteWorkspace';
 import { fetchWithAuth } from '../../../stores/auth';
+import { showToast } from '../../shared/Toast';
 
 vi.mock('../../../stores/auth', () => ({
   fetchWithAuth: vi.fn(),
@@ -142,5 +143,88 @@ describe('QuoteWorkspace — revision banner', () => {
 
     await waitFor(() => expect(screen.getByTestId('quote-workspace')).toBeInTheDocument());
     expect(screen.queryByTestId('quote-workspace-revision-banner')).not.toBeInTheDocument();
+  });
+});
+
+
+describe('QuoteWorkspace — a mutation whose only signal is "it appears" (#3519)', () => {
+  // End-to-end proof of the chain the issue reported: the POST creates the block
+  // server-side, the workspace's *quiet* reload then fails, and the editor's
+  // canvas therefore never moves. The reload's failure is deliberately silent
+  // at this layer (a mid-edit refetch must not remount the form or flash a page
+  // error), which used to mean the whole interaction was silent — the reporter
+  // re-uploaded four times into ~10 duplicate blocks. `fetchDetail` now answers
+  // whether the view actually caught up so the editor can say so.
+  const draft = { ...sentQuote, quote: { ...sentQuote.quote, status: 'draft', sentAt: null } };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.location.hash = '';
+  });
+
+  it('warns that the section was added when the post-create reload cannot land', async () => {
+    let quoteGets = 0;
+    fetchMock.mockImplementation(async (input: string, init?: { method?: string }) => {
+      if (input === '/quotes/q-1/blocks' && init?.method === 'POST') {
+        return json({ data: { id: 'blk-new' } });
+      }
+      if (input === '/quotes/q-1') {
+        quoteGets += 1;
+        // The initial load succeeds (the editor has to mount at all); every
+        // reload after it fails, which is the production state being pinned.
+        if (quoteGets === 1) return json({ data: draft });
+        return json({ error: 'boom' }, false, 500);
+      }
+      return json({ data: [] });
+    });
+
+    render(<QuoteWorkspace id="q-1" />);
+    await waitFor(() => expect(screen.getByTestId('quote-add-block')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('quote-add-block-type-heading'));
+    fireEvent.change(screen.getByTestId('quote-block-heading-text'), { target: { value: 'Scope of work' } });
+    fireEvent.click(screen.getByTestId('quote-add-block-submit'));
+
+    // The block really was created...
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
+      '/quotes/q-1/blocks',
+      expect.objectContaining({ method: 'POST' }),
+    ));
+    // ...the canvas really is still empty (the reload never landed)...
+    expect(screen.getByTestId('quote-blocks-empty')).toBeInTheDocument();
+    // ...so the user has to be told, in copy that does not invite a re-submit.
+    await waitFor(() => expect(vi.mocked(showToast)).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('Section added') }),
+    ));
+    expect(vi.mocked(showToast).mock.calls.map((c) => (c[0] as { message: string }).message).join(' | '))
+      .not.toMatch(/could not add/i);
+  });
+
+  it('stays quiet when the reload lands — the new section appearing is still the signal', async () => {
+    fetchMock.mockImplementation(async (input: string, init?: { method?: string }) => {
+      if (input === '/quotes/q-1/blocks' && init?.method === 'POST') {
+        return json({ data: { id: 'blk-new' } });
+      }
+      if (input === '/quotes/q-1') return json({ data: draft });
+      return json({ data: [] });
+    });
+
+    render(<QuoteWorkspace id="q-1" />);
+    await waitFor(() => expect(screen.getByTestId('quote-add-block')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('quote-add-block-type-heading'));
+    fireEvent.change(screen.getByTestId('quote-block-heading-text'), { target: { value: 'Scope of work' } });
+    fireEvent.click(screen.getByTestId('quote-add-block-submit'));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
+      '/quotes/q-1/blocks',
+      expect.objectContaining({ method: 'POST' }),
+    ));
+    // Wait for the post-create resync itself (the second GET), so "no toast" is
+    // asserted after the code path that would have toasted, not before it.
+    await waitFor(() => expect(
+      fetchMock.mock.calls.filter(([url]) => url === '/quotes/q-1').length,
+    ).toBeGreaterThanOrEqual(2));
+    expect(vi.mocked(showToast)).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/billing/quotes/QuoteWorkspace.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteWorkspace.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import QuoteWorkspace from './QuoteWorkspace';
@@ -226,5 +226,83 @@ describe('QuoteWorkspace — a mutation whose only signal is "it appears" (#3519
       fetchMock.mock.calls.filter(([url]) => url === '/quotes/q-1').length,
     ).toBeGreaterThanOrEqual(2));
     expect(vi.mocked(showToast)).not.toHaveBeenCalled();
+  });
+});
+
+
+describe('QuoteWorkspace — an older refetch must not clobber a newer one (#3519)', () => {
+  // The second stranding vector in the same function. Quiet reloads DO overlap:
+  // `runScoped` only serialises calls sharing a key, and the add-block key
+  // ('add-block') is not the key a terms blur-save uses ('terms'), so blurring
+  // the terms field and then adding a section fires two independent GETs. The
+  // editor's `refresh()` throttle fires the first on its leading edge and
+  // `resync()` fires the second un-throttled, so both are genuinely in flight.
+  // If the OLDER one resolves last, `setDetail` re-renders the canvas from
+  // pre-mutation data and the just-created block disappears — the same
+  // invisible-block symptom, reached by a different route.
+  const draft = { ...sentQuote, quote: { ...sentQuote.quote, status: 'draft', sentAt: null } };
+  const newBlock = {
+    id: 'blk-new', quoteId: 'q-1', orgId: 'org-1', blockType: 'heading',
+    content: { text: 'Scope of work', level: 2 }, sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.location.hash = '';
+  });
+
+  it('drops a superseded GET that resolves last instead of rolling the canvas back', async () => {
+    // Every GET after the initial load is handed out as a deferred promise so
+    // the test controls the resolution ORDER independently of the issue order.
+    const deferred: { resolve: (r: Response) => void }[] = [];
+    let quoteGets = 0;
+
+    fetchMock.mockImplementation(async (input: string, init?: { method?: string }) => {
+      if (input === '/quotes/q-1/blocks' && init?.method === 'POST') {
+        return json({ data: newBlock });
+      }
+      if (input === '/quotes/q-1') {
+        if (init?.method === 'PATCH') return json({ data: draft }); // terms save
+        quoteGets += 1;
+        if (quoteGets === 1) return json({ data: draft }); // initial mount
+        return new Promise<Response>((resolve) => { deferred.push({ resolve }); });
+      }
+      return json({ data: [] });
+    });
+
+    render(<QuoteWorkspace id="q-1" />);
+    await waitFor(() => expect(screen.getByTestId('quote-add-block')).toBeInTheDocument());
+
+    // GET #2 — the terms blur-save's refresh() leading edge.
+    fireEvent.change(screen.getByTestId('quote-terms'), { target: { value: 'Net 30' } });
+    fireEvent.blur(screen.getByTestId('quote-terms'));
+
+    // GET #3 — the add-block resync, issued while #2 is still open.
+    fireEvent.click(screen.getByTestId('quote-add-block-type-heading'));
+    fireEvent.change(screen.getByTestId('quote-block-heading-text'), { target: { value: 'Scope of work' } });
+    fireEvent.click(screen.getByTestId('quote-add-block-submit'));
+
+    await waitFor(() => expect(deferred.length).toBe(2));
+
+    // The NEWER request answers first, carrying the block that was just created.
+    deferred[1].resolve(json({ data: { ...draft, blocks: [newBlock] } }));
+    await waitFor(() => expect(screen.queryByTestId('quote-blocks-empty')).not.toBeInTheDocument());
+
+    // The OLDER request answers second, carrying the pre-mutation canvas. It is
+    // superseded, so it must be dropped — not applied on top.
+    deferred[0].resolve(json({ data: draft }));
+
+    // Flush the superseded response's continuation before asserting — it has to
+    // get all the way to where setDetail WOULD be called, or "nothing changed"
+    // would just mean "nothing has happened yet". Each turn covers one await in
+    // fetchDetail past the fetch itself (res.json, then the sequence check).
+    await act(async () => { await Promise.resolve(); });
+    await act(async () => { await Promise.resolve(); });
+    await act(async () => { await Promise.resolve(); });
+
+    // The block survives. Without the sequence guard this fails: the stale
+    // payload wins by arriving last and the canvas goes empty again. (Verified
+    // red against the unguarded fetchDetail, so the flush above is sufficient.)
+    expect(screen.queryByTestId('quote-blocks-empty')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/billing/quotes/QuoteWorkspace.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteWorkspace.tsx
@@ -78,7 +78,10 @@ export default function QuoteWorkspace({ id }: Props) {
   // still open — and without this the OLDER response can resolve last and
   // re-render the editor from pre-mutation data, hiding a block that was just
   // created (#3519). Only a response at least as new as the last applied one
-  // may call setDetail.
+  // may call setDetail. Scope note: this guards the SUCCESS path only. The
+  // 404/error paths don't advance the sequence, but they only ever setError on
+  // a non-quiet load, and there is exactly one of those (the initial mount), so
+  // they have no stale response to lose a race to.
   const fetchSeq = useRef(0);
   const appliedSeq = useRef(0);
 
@@ -87,8 +90,10 @@ export default function QuoteWorkspace({ id }: Props) {
   // form and discard the user's in-progress local state and cursor position.
   // Only the initial load shows the skeleton / replaces the view on error.
   //
-  // Returns whether the view now reflects fresh server data. Callers rely on
-  // this: an inline mutation whose only success signal is "the result appears"
+  // Returns whether the view now reflects fresh server data — with one
+  // deliberate exception, the 401 branch, which reports success because the
+  // redirect it fires makes staleness moot (see below). Callers rely on this:
+  // an inline mutation whose only success signal is "the result appears"
   // (an added block, a repriced line) has no signal at all when the reload
   // fails, and MUST say so instead of leaving the user staring at a stale
   // canvas. A quiet failure still stays silent HERE — reporting it is the

--- a/apps/web/src/components/billing/quotes/QuoteWorkspace.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteWorkspace.tsx
@@ -73,25 +73,52 @@ export default function QuoteWorkspace({ id }: Props) {
     pendingDeleteFlushRef.current?.();
   }, []);
 
+  // Monotonic request/apply sequence. Quiet reloads overlap routinely — a slow
+  // multi-megabyte image upload finishes while an earlier edit's refetch is
+  // still open — and without this the OLDER response can resolve last and
+  // re-render the editor from pre-mutation data, hiding a block that was just
+  // created (#3519). Only a response at least as new as the last applied one
+  // may call setDetail.
+  const fetchSeq = useRef(0);
+  const appliedSeq = useRef(0);
+
   // A `quiet` reload (after an inline edit) refetches without flipping `loading`,
   // so the editor stays mounted — a full-page loading state would remount the
   // form and discard the user's in-progress local state and cursor position.
   // Only the initial load shows the skeleton / replaces the view on error.
-  const fetchDetail = useCallback(async (quiet = false) => {
-    if (!id) { setError(t('quotes.workspace.errors.missingId')); setLoading(false); return; }
+  //
+  // Returns whether the view now reflects fresh server data. Callers rely on
+  // this: an inline mutation whose only success signal is "the result appears"
+  // (an added block, a repriced line) has no signal at all when the reload
+  // fails, and MUST say so instead of leaving the user staring at a stale
+  // canvas. A quiet failure still stays silent HERE — reporting it is the
+  // caller's job, since only the caller knows what the user was promised.
+  const fetchDetail = useCallback(async (quiet = false): Promise<boolean> => {
+    if (!id) { setError(t('quotes.workspace.errors.missingId')); setLoading(false); return false; }
+    const seq = ++fetchSeq.current;
     try {
       if (!quiet) setLoading(true);
       setError(undefined);
       const res = await fetchWithAuth(`/quotes/${id}`);
-      if (res.status === 401) return UNAUTHORIZED();
-      if (res.status === 404) { if (!quiet) setError(t('quotes.workspace.errors.notFound')); return; }
+      // The redirect to /login IS the feedback for an expired session (same
+      // contract runAction follows), so this counts as handled, not as a stale
+      // view the caller should warn about on top of a navigation.
+      if (res.status === 401) { UNAUTHORIZED(); return true; }
+      if (res.status === 404) { if (!quiet) setError(t('quotes.workspace.errors.notFound')); return false; }
       if (!res.ok) throw new Error(t('quotes.workspace.errors.loadFailed'));
       const body = (await res.json()) as { data: QuoteDetailData };
+      // Superseded by a newer refetch that already landed: dropping this stale
+      // payload is the correct outcome, and the view IS fresh — the newer
+      // response made it so — so report success rather than a false alarm.
+      if (seq < appliedSeq.current) return true;
+      appliedSeq.current = seq;
       setDetail(body.data);
+      return true;
     } catch (err) {
-      // A failed quiet reload leaves the editor intact; the inline action's own
-      // runAction toast already surfaced the failure.
+      // A failed quiet reload leaves the editor intact and mounted; the caller
+      // decides whether the user needs to hear about the stale view.
       if (!quiet) setError(err instanceof Error ? err.message : t('quotes.workspace.errors.loadFailed'));
+      return false;
     } finally {
       if (!quiet) setLoading(false);
     }
@@ -255,7 +282,9 @@ export default function QuoteWorkspace({ id }: Props) {
           while previewing. */}
       {isDraft && (
         <div className={activeTab === 'editor' ? '' : 'hidden'}>
-          <QuoteEditor detail={detail} onChanged={() => void reload()} onPendingEditsChange={setEditorSavePending} onSaveFailure={reportSaveFailure} onUnsavedEditsChange={setEditorUnsavedField} onRegisterPendingDeleteFlush={registerPendingDeleteFlush} showInternal={showInternal} onToggleInternal={toggleShowInternal} />
+          {/* `reload` is passed unwrapped so the editor can await it and learn
+              whether the canvas actually caught up — see QuoteEditorProps.onChanged. */}
+          <QuoteEditor detail={detail} onChanged={reload} onPendingEditsChange={setEditorSavePending} onSaveFailure={reportSaveFailure} onUnsavedEditsChange={setEditorUnsavedField} onRegisterPendingDeleteFlush={registerPendingDeleteFlush} showInternal={showInternal} onToggleInternal={toggleShowInternal} />
         </div>
       )}
       {activeTab === 'preview' && (

--- a/apps/web/src/locales/de-DE/billing.json
+++ b/apps/web/src/locales/de-DE/billing.json
@@ -694,7 +694,8 @@
         "updateLine": "Die Position konnte nicht aktualisiert werden.",
         "updateSection": "Der Abschnitt konnte nicht aktualisiert werden.",
         "uploadImage": "Das Bild konnte nicht hochgeladen werden.",
-        "noPriceForCurrency": "Kein Preis in {{currency}} für dieses Element. Legen Sie einen im Katalog an oder erfassen Sie eine manuelle Position."
+        "noPriceForCurrency": "Kein Preis in {{currency}} für dieses Element. Legen Sie einen im Katalog an oder erfassen Sie eine manuelle Position.",
+        "sectionAddedListStale": "Abschnitt hinzugefügt, aber die Liste konnte nicht aktualisiert werden. Laden Sie die Seite neu, um ihn zu sehen."
       },
       "image": {
         "alt": "Angebotsbild",

--- a/apps/web/src/locales/en/billing.json
+++ b/apps/web/src/locales/en/billing.json
@@ -694,7 +694,8 @@
         "updateLine": "Could not update the line.",
         "updateSection": "Could not update the section.",
         "uploadImage": "Could not upload the image.",
-        "noPriceForCurrency": "No {{currency}} price for this item. Add one in the catalog or enter a manual line."
+        "noPriceForCurrency": "No {{currency}} price for this item. Add one in the catalog or enter a manual line.",
+        "sectionAddedListStale": "Section added, but the list could not refresh. Reload the page to see it."
       },
       "image": {
         "alt": "Quote image",

--- a/apps/web/src/locales/es-419/billing.json
+++ b/apps/web/src/locales/es-419/billing.json
@@ -694,7 +694,8 @@
         "updateLine": "No se pudo actualizar la línea.",
         "updateSection": "No se pudo actualizar la sección.",
         "uploadImage": "No se pudo cargar la imagen.",
-        "noPriceForCurrency": "Este elemento no tiene precio en {{currency}}. Agregue uno en el catálogo o ingrese una línea manual."
+        "noPriceForCurrency": "Este elemento no tiene precio en {{currency}}. Agregue uno en el catálogo o ingrese una línea manual.",
+        "sectionAddedListStale": "Se agregó la sección, pero no se pudo actualizar la lista. Vuelve a cargar la página para verla."
       },
       "image": {
         "alt": "Imagen de cotización",

--- a/apps/web/src/locales/fr-CA/billing.json
+++ b/apps/web/src/locales/fr-CA/billing.json
@@ -674,7 +674,8 @@
         "updateLine": "Impossible de mettre à jour la ligne.",
         "updateSection": "Impossible de mettre à jour la section.",
         "uploadImage": "Impossible de téléverser l'image.",
-        "noPriceForCurrency": "Aucun prix en {{currency}} pour cet article. Ajoutez-en un au catalogue ou saisissez une ligne manuelle."
+        "noPriceForCurrency": "Aucun prix en {{currency}} pour cet article. Ajoutez-en un au catalogue ou saisissez une ligne manuelle.",
+        "sectionAddedListStale": "Section ajoutée, mais la liste n'a pas pu être actualisée. Rechargez la page pour la voir."
       },
       "image": {
         "alt": "Image du devis",

--- a/apps/web/src/locales/fr-FR/billing.json
+++ b/apps/web/src/locales/fr-FR/billing.json
@@ -694,7 +694,8 @@
         "updateLine": "Impossible de mettre à jour la ligne.",
         "updateSection": "Impossible de mettre à jour la section.",
         "uploadImage": "Impossible de téléverser l'image.",
-        "noPriceForCurrency": "Aucun prix en {{currency}} pour cet article. Ajoutez-en un dans le catalogue ou saisissez une ligne manuelle."
+        "noPriceForCurrency": "Aucun prix en {{currency}} pour cet article. Ajoutez-en un dans le catalogue ou saisissez une ligne manuelle.",
+        "sectionAddedListStale": "Section ajoutée, mais la liste n'a pas pu être actualisée. Rechargez la page pour la voir."
       },
       "image": {
         "alt": "Image du devis",

--- a/apps/web/src/locales/it-IT/billing.json
+++ b/apps/web/src/locales/it-IT/billing.json
@@ -674,7 +674,8 @@
         "updateLine": "Impossibile aggiornare la riga.",
         "updateSection": "Impossibile aggiornare la sezione.",
         "uploadImage": "Impossibile caricare l'immagine.",
-        "noPriceForCurrency": "Nessun prezzo in {{currency}} per questo elemento. Aggiungine uno nel catalogo o inserisci una riga manuale."
+        "noPriceForCurrency": "Nessun prezzo in {{currency}} per questo elemento. Aggiungine uno nel catalogo o inserisci una riga manuale.",
+        "sectionAddedListStale": "Sezione aggiunta, ma non è stato possibile aggiornare l'elenco. Ricarica la pagina per vederla."
       },
       "image": {
         "alt": "Immagine del preventivo",

--- a/apps/web/src/locales/pt-BR/billing.json
+++ b/apps/web/src/locales/pt-BR/billing.json
@@ -694,7 +694,8 @@
         "updateLine": "Não foi possível atualizar a linha.",
         "updateSection": "Não foi possível atualizar a seção.",
         "uploadImage": "Não foi possível enviar a imagem.",
-        "noPriceForCurrency": "Este item não tem preço em {{currency}}. Adicione um no catálogo ou insira uma linha manual."
+        "noPriceForCurrency": "Este item não tem preço em {{currency}}. Adicione um no catálogo ou insira uma linha manual.",
+        "sectionAddedListStale": "Seção adicionada, mas não foi possível atualizar a lista. Recarregue a página para vê-la."
       },
       "image": {
         "alt": "Imagem da cotação",

--- a/apps/web/src/locales/tr-TR/billing.json
+++ b/apps/web/src/locales/tr-TR/billing.json
@@ -702,7 +702,8 @@
         "updateLine": "Hat güncellenemedi.",
         "updateSection": "Bölüm güncellenemedi.",
         "uploadImage": "Resim yüklenemedi.",
-        "noPriceForCurrency": "Bu öğenin {{currency}} fiyatı yok. Katalogda bir fiyat ekleyin veya manuel bir hat girin."
+        "noPriceForCurrency": "Bu öğenin {{currency}} fiyatı yok. Katalogda bir fiyat ekleyin veya manuel bir hat girin.",
+        "sectionAddedListStale": "Bölüm eklendi ancak liste yenilenemedi. Görmek için sayfayı yeniden yükleyin."
       },
       "image": {
         "alt": "Alıntı görseli",


### PR DESCRIPTION
Closes #3519

## The stranding mechanism (established, not assumed)

The issue's first-look note guessed at "a throw between `addBlock` succeeding and `refresh()` leaving the pending flag latched". I traced it and that is **not** what happens on `main`: `runScoped` already clears its pending key in a `finally`, and `positionNewBlock` already swallows its own reorder failure. Neither can latch the button.

The real mechanism is one link further out:

1. Add-block deliberately has **no success toast** — every branch carries the comment *"No success toast — the new section visibly appears"*. The block appearing in the canvas **is** the success signal.
2. That canvas only moves when the workspace's **quiet** refetch lands.
3. `QuoteWorkspace.fetchDetail` swallowed every quiet failure, justified in-code as *"the inline action's own runAction toast already surfaced the failure."* That rationale is sound for a failed mutation — but this is the refresh **after a success**, where `runAction` toasted nothing on purpose.

So a failed quiet refetch turned the whole interaction silent: the block existed server-side, the canvas stayed empty, and the submit button went disabled again — not because it was latched, but because the form reset cleared `imageFile` while the **uncontrolled** `<input type="file">` kept displaying the filename. Disabled button + visible filename + no toast + no block is visually identical to "still uploading". Hence the re-uploads and the ~10 duplicates.

A second, independent vector in the same function: two quiet reloads overlap routinely (a slow multi-megabyte upload finishes while an earlier edit's refetch is still open) and `fetchDetail` had no request sequencing, so the **older** response could resolve last and re-render the editor from pre-mutation data.

## The fix

- **`QuoteWorkspace.fetchDetail`** now returns whether the view actually caught up. A quiet failure still stays silent *at this layer* — a mid-edit refetch must not remount the form or flash a page-level error — because reporting it is the caller's job: only the caller knows what the user was promised. It also carries a monotonic request/apply sequence so a stale overlapping response can never call `setDetail`.
- **`QuoteEditor.finishBlockCreate`** is the tail every add-block branch (image, contract, table, callout, heading/rich-text/line-items) runs *after* the POST has already created the block. Two rules:
  1. **It never throws.** A throw escaped into `runScoped`'s catch and toasted *"Could not add the image section"* over a block that **does** exist — precisely the copy that invites a re-submit.
  2. **If the canvas does not catch up, it says so**, with copy that names the real state and discourages retrying.
  The form reset sits in a `finally` so a failed reposition can't leave the picked file and the open insert-gap looking like work still in flight.
- The **uncontrolled file input** is cleared on reset (React state alone can't clear it), so the filename no longer sits on screen beside a silently-disabled button.

### On the `runAction` convention

`QuoteEditor.tsx` is in the `no-silent-mutations` **targeted set** and is **not** in `runActionAllowlist.ts` — no allowlist entry was added or needed. Every mutation here already goes through `runAction`, and all of them still do; the guard passes unchanged. This bug was never a missing `runAction` wrapper. It was the deliberate *absence of a success toast* (a legitimate choice) resting on a delivery channel — the refetch — that could fail without telling anyone. `runAction` cannot see that: it correctly reported "the POST succeeded". The fix restores the invariant `runAction` exists to protect, one layer out.

## Both directions covered

- **Success direction:** create lands, refetch does not → the user is told the section exists.
- **Failure direction:** anything after the create fails (including a refetch that *throws*) → the user still gets the honest outcome, never *"could not add"*.
- **Pre-create failure** (guard against over-reporting): a non-2xx `addBlock` still toasts the server's error, adds nothing, says nothing about "added", and leaves the button live.
- **Happy path** (guard against toast noise): a landed refetch stays completely quiet.

## Verification

**Red-first, proven.** Both new suites were run against the *unfixed* `QuoteEditor.tsx` / `QuoteWorkspace.tsx` (sources reverted, tests kept). 3 controls failed, all for the same reason — **total silence**:

```
FAIL QuoteEditor.blockcreatestrand.test.tsx > tells the user the section was added when the list refetch never lands
     AssertionError: expected "vi.fn()" to be called at least once
FAIL QuoteEditor.blockcreatestrand.test.tsx > does not report "could not add the image section" when the create succeeded and only the resync failed
     AssertionError: expected "vi.fn()" to be called at least once
FAIL QuoteWorkspace.test.tsx > warns that the section was added when the post-create reload cannot land
     AssertionError: expected "vi.fn()" to be called with arguments: [ ObjectContaining{…} ]
Test Files  2 failed (2) | Tests  3 failed | 9 passed (12)
```

The first control also asserts `quote-blocks-empty` is still rendered *before* it asserts the toast — so "the editor shows no block" is pinned as the premise, not assumed. The 9 that pass in both states are the guards.

With the fix: `2 passed (2) | 13 passed (13)`.

**Review round 2 added a third red-first proof.** The sequence guard now has a dedicated regression test, and it discriminates precisely: deleting *only* the two guard lines (`seq < appliedSeq.current` / `appliedSeq.current = seq`) turns that one test red while the other eight workspace tests stay green.

**One assertion was removed for being vacuous.** Review suggested asserting the uncontrolled file input's `.value` is cleared. Measured: with the DOM reset deleted, `.value` is *still* `''` — jsdom never populates `value` from a programmatic `files` assignment, and a file input's value cannot be set to a non-empty string. The assertion passed either way, so it was removed rather than shipped as fake coverage. **The file-input DOM reset is therefore covered by inspection only; proving it needs a real browser (Playwright).** Labelling that rather than implying coverage.

| Check | Result |
|---|---|
| All 59 `apps/web/src/components/billing/quotes/*.test.tsx` | **59 files, 708 tests passed** (2 foreground batches, re-run after the review fixes) |
| `no-silent-mutations` + i18n guards (`localeParity`, `translationCoverage`, `keyUsage`, `terminologyQuality`, `extractionQuality`) | **passed** |
| `tsc --noEmit` (`@breeze/web`, foreground) | **exit 0, zero output** |
| `eslint` on the 4 changed `.ts(x)` files | **exit 0** |

No `.astro` files changed, so `astro check` adds nothing here.

### i18n

One new key, `quotes.editor.errors.sectionAddedListStale`, added to **all 8 locales** — `en`, `de-DE`, `es-419`, `fr-CA`, `fr-FR`, `it-IT`, `pt-BR`, `tr-TR`. Each was verified present and **genuinely translated** (no locale kept the English string); `fr-CA` and `fr-FR` intentionally share one French sentence, matching how the neighbouring `imageAddedSectionFailed` / `addSection` keys are already written in those two files. `localeParity` and `translationCoverage` pass.

## Known gap this PR does NOT close (found in review, deliberately out of scope)

**Line creation has the exact same defect.** `doAddCatalog`, `addManualLine`, and the Pax8/distributor imports all rest on the same premise the block path just stopped trusting — *"No success toast: the new row visibly appears and the totals move"* — and all still end in the fire-and-forget `refresh()` rather than the honest tail. A line POST that succeeds while its quiet refetch fails is still completely silent, and a tech on a flaky link can re-add the same line the way the reporter re-uploaded the same image.

It is out of scope here because it needs its own copy, its own 8 locales and its own tests, and folding it in would double a diff that is currently provable end to end. It is documented at the call site (`QuoteEditor.tsx`, above `doAddCatalog`) so it cannot be lost, and the `finishBlockCreate` docstring no longer overstates its own reach. **Worth filing as a follow-up.**

Relatedly: the two rules in `finishBlockCreate` only hold for branches that route through it, and nothing enforces that routing — a future sixth block type could re-inline the old tail and reopen the bug. The docstring now says so explicitly rather than claiming the class is structurally impossible.

## CI notes

- `Check Migrations` and `Trivy Image Scan` are red repo-wide right now — they fail on `main` at this PR's exact base (`23001934d`) and on unrelated PRs. #4227 tracks the first; PR #4236 fixes it. **Not attributable to this change**, which touches no migrations and no image contents.
- If `Test Web` reports `InvoiceWorkspace.test.tsx` / `invoice-issue-saving-hint`, that is the known flake #3277 (dupes #4033, #3980, #3219, #2925) — unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
