### PR TITLE
fix(api): metric rollups run one short-lived labeled DB context per statement (#4276)

### DIFF
--- a/apps/api/scripts/metric-rollup-backfill.ts
+++ b/apps/api/scripts/metric-rollup-backfill.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env tsx
-import { closeDb, withSystemDbAccessContext } from '../src/db';
+import { closeDb } from '../src/db';
 import { rollupDeviceMetricsRange } from '../src/services/metricRollups';
 import { parseMetricRollupBackfillArgs } from './metric-rollup-backfill.lib';
 
@@ -18,14 +18,18 @@ async function main(): Promise<void> {
     return;
   }
 
-  const result = await withSystemDbAccessContext(() =>
-    rollupDeviceMetricsRange({
-      orgId: options.orgId,
-      from: options.from,
-      to: options.to,
-      expectedSampleSeconds: options.expectedSampleSeconds,
-    })
-  );
+  // No context wrap (#4276): rollupDeviceMetricsRange owns one short-lived
+  // labeled context per statement, and each escapes any ambient context — an
+  // outer wrap here would do no work, just pin an idle-in-transaction
+  // connection for the whole (up to 31-day) pass, and a mid-pass
+  // idle_in_transaction_session_timeout would fail the script on COMMIT after
+  // every inner statement had already committed.
+  const result = await rollupDeviceMetricsRange({
+    orgId: options.orgId,
+    from: options.from,
+    to: options.to,
+    expectedSampleSeconds: options.expectedSampleSeconds,
+  });
 
   if (result.skipped) {
     // Feature flag off for this org — no rollups were written. Warn loudly on stderr

--- a/apps/api/src/__tests__/integration/dbContextTripwire.integration.test.ts
+++ b/apps/api/src/__tests__/integration/dbContextTripwire.integration.test.ts
@@ -204,6 +204,26 @@ describe('#1105 DB-context tripwires', () => {
       expect(capturedMessages[0]!.tags?.dbContextOpener).toEqual(expect.stringContaining('dbContextTripwire'));
     });
 
+    it('withSystemDbAccessContext(fn, label) carries the label through to the tag and message (#4276)', async () => {
+      // The two-argument form is the new surface #4276 adds — the metric
+      // rollup workers pass e.g. 'metricRollups.raw.device_metrics' through it.
+      // The unit tests only assert the label string is handed to a MOCK; this
+      // proves the real plumbing (systemDbAccessContext -> withDbAccessContext
+      // -> formatHeldContextWarning) lands it in the allowlisted tag against a
+      // real held connection.
+      process.env.DB_CONTEXT_HELD_WARN_MS = '50';
+      process.env.DB_CONTEXT_HELD_CAPTURE_THROTTLE_MS = '0';
+      __resetHeldContextCaptureThrottleForTests();
+
+      await withSystemDbAccessContext(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 90));
+      }, 'metricRollups.raw.device_metrics');
+
+      expect(capturedMessages).toHaveLength(1);
+      expect(capturedMessages[0]!.tags?.dbContextLabel).toBe('metricRollups.raw.device_metrics');
+      expect(capturedMessages[0]!.message).toContain('[metricRollups.raw.device_metrics]');
+    });
+
     it('derives a grouping label from the opener when the context is unlabelled (#3218)', async () => {
       // Supersedes the previous contract ("unlabelled callers keep byte-identical
       // message text"). That stability was deliberately traded away in #3218:

--- a/apps/api/src/__tests__/integration/metricRollups.integration.test.ts
+++ b/apps/api/src/__tests__/integration/metricRollups.integration.test.ts
@@ -3,7 +3,7 @@ import './setup';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { and, eq } from 'drizzle-orm';
 
-import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
+import { db, withDbAccessContext, type DbAccessContext } from '../../db';
 import { discoveredAssets, devices, deviceMetrics, deviceProcessSamples, metricRollups, snmpDevices, snmpMetrics } from '../../db/schema';
 import { rollupDeviceMetricsRange } from '../../services/metricRollups';
 import { createOrganization, createPartner, createSite } from './db-utils';
@@ -158,14 +158,18 @@ async function insertSnmpMetric(options: {
 }
 
 async function runRollup(orgId: string, from: Date, to: Date): Promise<void> {
-  await withSystemDbAccessContext(() =>
-    rollupDeviceMetricsRange({
-      orgId,
-      from,
-      to,
-      expectedSampleSeconds: 60,
-    })
-  );
+  // Deliberately NO outer context wrap: this must exercise the same call shape
+  // as jobs/metricRollups.ts — rollupDeviceMetricsRange opens its own labeled
+  // context per statement. If a refactor ever drops that (e.g. removes the
+  // runOutsideDbContext escape or the per-statement contexts), the statements
+  // here would run contextless against forced RLS and fail loudly, instead of
+  // an outer wrap silently absorbing them.
+  await rollupDeviceMetricsRange({
+    orgId,
+    from,
+    to,
+    expectedSampleSeconds: 60,
+  });
 }
 
 async function selectCpuRollups(orgId: string, deviceId: string) {

--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -574,8 +574,41 @@ export async function withDbAccessContext<T>(
   });
 }
 
-export async function withSystemDbAccessContext<T>(fn: () => Promise<T>): Promise<T> {
-  return withDbAccessContext(SYSTEM_DB_ACCESS_CONTEXT, fn);
+/**
+ * The shared system context, optionally carrying a diagnostic `label`.
+ *
+ * Exported as its own function so the blank-label rule has ONE home and a unit
+ * test can pin it: a whitespace-only label must fall through to the shared
+ * constant rather than being stored, because `formatHeldContextWarning` treats
+ * a blank explicit label as "unlabelled" and would then suppress neither the
+ * tag nor the derived fallback consistently. Returns the shared frozen-by-
+ * convention constant when there is no label, so the common case allocates
+ * nothing.
+ */
+export function systemDbAccessContext(label?: string): DbAccessContext {
+  const normalized = label?.trim();
+  return normalized ? { ...SYSTEM_DB_ACCESS_CONTEXT, label: normalized } : SYSTEM_DB_ACCESS_CONTEXT;
+}
+
+/**
+ * Open (or join) a system-scoped RLS context.
+ *
+ * `label` is the optional #3218/#4276 diagnostic name for the code path opening
+ * this context — e.g. `metricRollups.scanOrgs`. It grants nothing and never
+ * reaches Postgres; it only names the context in the #1105 held-connection
+ * warning (message text + `dbContextLabel` tag). Pass one whenever the opener
+ * is an anonymous arrow, which is every BullMQ worker handler: under the tsup
+ * single-file bundle `parseOpenerFrame` collapses all of them to a bare
+ * `index`, so without a label the hold arrives in Sentry unattributed.
+ *
+ * Keep labels low-cardinality — they become part of the grouped Sentry message,
+ * so one per code path, never one per org/device/job id.
+ *
+ * System scope has no other knobs by construction; a caller that needs to vary
+ * anything else about the context should use `withDbAccessContext` directly.
+ */
+export async function withSystemDbAccessContext<T>(fn: () => Promise<T>, label?: string): Promise<T> {
+  return withDbAccessContext(systemDbAccessContext(label), fn);
 }
 
 /**

--- a/apps/api/src/db/systemDbAccessContext.test.ts
+++ b/apps/api/src/db/systemDbAccessContext.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// Importing ./index pulls the DB module; stub the Sentry surface it uses so the
+// unit test never loads the real SDK (mirrors heldContextCaptureThrottle.test.ts).
+vi.mock('../services/sentry', () => ({
+  captureMessage: vi.fn(),
+  captureException: vi.fn(),
+}));
+
+import { SYSTEM_DB_ACCESS_CONTEXT, systemDbAccessContext } from './index';
+
+// Pins the blank-label rule promised in systemDbAccessContext's doc comment
+// (#4276): a missing OR whitespace-only label must fall through to the shared
+// constant. `formatHeldContextWarning` treats a blank explicit label as
+// "unlabelled", so storing one would suppress both the tag and the derived
+// opener fallback; and returning the shared constant keeps the common no-label
+// case allocation-free. A refactor like `label ?? undefined` (dropping the
+// trim) breaks both properties with no other failing test.
+describe('systemDbAccessContext (#4276 label plumbing)', () => {
+  it('returns the shared constant — same reference, no allocation — when no label is given', () => {
+    expect(systemDbAccessContext()).toBe(SYSTEM_DB_ACCESS_CONTEXT);
+    expect(systemDbAccessContext(undefined)).toBe(SYSTEM_DB_ACCESS_CONTEXT);
+  });
+
+  it('treats a whitespace-only label as no label at all', () => {
+    expect(systemDbAccessContext('   ')).toBe(SYSTEM_DB_ACCESS_CONTEXT);
+    expect(systemDbAccessContext('\t\n')).toBe(SYSTEM_DB_ACCESS_CONTEXT);
+    expect(systemDbAccessContext('')).toBe(SYSTEM_DB_ACCESS_CONTEXT);
+  });
+
+  it('stores a real label trimmed, on a copy that leaves the shared constant untouched', () => {
+    const ctx = systemDbAccessContext('  metricRollups.scanOrgs  ');
+    expect(ctx.label).toBe('metricRollups.scanOrgs');
+    expect(ctx).not.toBe(SYSTEM_DB_ACCESS_CONTEXT);
+    expect(SYSTEM_DB_ACCESS_CONTEXT.label).toBeUndefined();
+    // Everything except the label is the system context verbatim.
+    expect({ ...ctx, label: undefined }).toEqual({ ...SYSTEM_DB_ACCESS_CONTEXT, label: undefined });
+  });
+});

--- a/apps/api/src/jobs/metricRollups.test.ts
+++ b/apps/api/src/jobs/metricRollups.test.ts
@@ -15,6 +15,7 @@ const {
   workerProcessorMock,
   runOutsideDbContextMock,
   withSystemDbAccessContextMock,
+  rollupDeviceMetricsRangeMock,
 } = vi.hoisted(() => ({
   getJobMock: vi.fn(),
   addMock: vi.fn(),
@@ -30,6 +31,7 @@ const {
   workerProcessorMock: vi.fn(),
   runOutsideDbContextMock: vi.fn(<T>(fn: () => T) => fn()),
   withSystemDbAccessContextMock: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  rollupDeviceMetricsRangeMock: vi.fn(),
 }));
 
 vi.mock('bullmq', () => ({
@@ -71,7 +73,7 @@ vi.mock('../db/schema', () => ({
 }));
 
 vi.mock('../services/metricRollups', () => ({
-  rollupDeviceMetricsRange: vi.fn(),
+  rollupDeviceMetricsRange: rollupDeviceMetricsRangeMock,
 }));
 
 vi.mock('./workerObservability', () => ({
@@ -101,6 +103,8 @@ describe('metric rollups queue helpers', () => {
     whereMock.mockReset();
     groupByMock.mockReset();
     workerProcessorMock.mockReset();
+    rollupDeviceMetricsRangeMock.mockReset();
+    rollupDeviceMetricsRangeMock.mockResolvedValue({ statements: 24, skipped: false });
     runOutsideDbContextMock.mockClear();
     withSystemDbAccessContextMock.mockClear();
     runOutsideDbContextMock.mockImplementation(<T>(fn: () => T) => fn());
@@ -231,5 +235,51 @@ describe('metric rollups queue helpers', () => {
       'withSystemDbAccessContext:end',
       'addBulk',
     ]);
+  });
+
+  // #4276 — under the tsup single-file bundle every anonymous-arrow opener in
+  // the API collapses to a bare `index` in `parseOpenerFrame`, so an unlabelled
+  // context arrives in Sentry unattributed. The worker tag alone was doing all
+  // the attribution work for this queue's holds.
+  it('labels the scan-orgs system context for Sentry attribution', async () => {
+    await initializeMetricRollupsWorker();
+    withSystemDbAccessContextMock.mockClear();
+
+    await workerProcessorMock({ data: { type: 'scan-orgs', lookbackMinutes: 15 } });
+
+    expect(withSystemDbAccessContextMock).toHaveBeenCalledWith(
+      expect.any(Function),
+      'metricRollups.scanOrgs',
+    );
+  });
+
+  // #4276 — the worker used to wrap ALL of rollupDeviceMetricsRange in one
+  // system context, pinning a pooled connection across 26 sequential statements
+  // for 2s+ every 5 minutes. The service now owns one short-lived context per
+  // statement; a wrap here would make each of those short-circuit back into a
+  // single transaction and silently restore the hold (the alertWorker/#3216
+  // trap).
+  it('does not wrap rollup-org-range in a worker-level system DB context', async () => {
+    await initializeMetricRollupsWorker();
+    withSystemDbAccessContextMock.mockClear();
+    runOutsideDbContextMock.mockClear();
+
+    await workerProcessorMock({
+      data: {
+        type: 'rollup-org-range',
+        orgId: 'org-1',
+        from: '2026-06-18T12:00:00.000Z',
+        to: '2026-06-18T12:15:00.000Z',
+        queuedAt: '2026-06-18T12:15:00.000Z',
+      },
+    });
+
+    expect(withSystemDbAccessContextMock).not.toHaveBeenCalled();
+    expect(runOutsideDbContextMock).toHaveBeenCalledTimes(1);
+    expect(rollupDeviceMetricsRangeMock).toHaveBeenCalledWith({
+      orgId: 'org-1',
+      from: new Date('2026-06-18T12:00:00.000Z'),
+      to: new Date('2026-06-18T12:15:00.000Z'),
+    });
   });
 });

--- a/apps/api/src/jobs/metricRollups.ts
+++ b/apps/api/src/jobs/metricRollups.ts
@@ -71,7 +71,7 @@ async function findRollupOrgRows(): Promise<Array<{ orgId: string }>> {
 
 async function processScanOrgs(data: ScanOrgsJobData): Promise<{ queued: number }> {
   const orgRows = await runOutsideDbContext(() =>
-    withSystemDbAccessContext(() => findRollupOrgRows())
+    withSystemDbAccessContext(() => findRollupOrgRows(), 'metricRollups.scanOrgs')
   );
 
   if (orgRows.length === 0) {
@@ -119,9 +119,14 @@ export function createMetricRollupsWorker(): Worker<MetricRollupJobData> {
         return processScanOrgs(job.data);
       }
       const data = job.data;
-      return runOutsideDbContext(() =>
-        withSystemDbAccessContext(() => processRollupOrgRange(data))
-      );
+      // No worker-level system context here (#4276): rollupDeviceMetricsRange
+      // owns one short-lived labeled context PER statement. Re-wrapping it
+      // would make withDbAccessContext short-circuit into the ambient
+      // transaction and silently restore the single 26-statement hold that
+      // made this worker the top db_context_held_too_long offender. The
+      // runOutsideDbContext escape is kept as belt-and-braces against a future
+      // ambient context on this path.
+      return runOutsideDbContext(() => processRollupOrgRange(data));
     },
     {
       connection: getBullMQConnection(),

--- a/apps/api/src/jobs/metricRollups.ts
+++ b/apps/api/src/jobs/metricRollups.ts
@@ -120,12 +120,12 @@ export function createMetricRollupsWorker(): Worker<MetricRollupJobData> {
       }
       const data = job.data;
       // No worker-level system context here (#4276): rollupDeviceMetricsRange
-      // owns one short-lived labeled context PER statement. Re-wrapping it
-      // would make withDbAccessContext short-circuit into the ambient
-      // transaction and silently restore the single 26-statement hold that
-      // made this worker the top db_context_held_too_long offender. The
-      // runOutsideDbContext escape is kept as belt-and-braces against a future
-      // ambient context on this path.
+      // owns one short-lived labeled context PER statement, each preceded by
+      // its own runOutsideDbContext escape. A wrap here would not be joined —
+      // the escape defeats it — it would just pin an idle-in-transaction
+      // connection for the whole pass (an unlabeled hold, plus a second pool
+      // slot). This outer runOutsideDbContext is belt-and-braces against a
+      // future ambient context on this path.
       return runOutsideDbContext(() => processRollupOrgRange(data));
     },
     {

--- a/apps/api/src/services/metricRollups.test.ts
+++ b/apps/api/src/services/metricRollups.test.ts
@@ -1,14 +1,44 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { executeMock, shouldProduceMlOutputMock } = vi.hoisted(() => ({
-  executeMock: vi.fn(),
-  shouldProduceMlOutputMock: vi.fn(),
-}));
+type ContextTraceEvent =
+  | { type: 'escape' }
+  | { type: 'open'; label: string | undefined }
+  | { type: 'execute' }
+  | { type: 'close'; label: string | undefined };
+
+const {
+  executeMock,
+  shouldProduceMlOutputMock,
+  runOutsideDbContextMock,
+  withSystemDbAccessContextMock,
+  contextTrace,
+} = vi.hoisted(() => {
+  const contextTrace: ContextTraceEvent[] = [];
+  return {
+    contextTrace,
+    executeMock: vi.fn(),
+    shouldProduceMlOutputMock: vi.fn(),
+    runOutsideDbContextMock: vi.fn(<T>(fn: () => T): T => {
+      contextTrace.push({ type: 'escape' });
+      return fn();
+    }),
+    withSystemDbAccessContextMock: vi.fn(async (fn: () => Promise<unknown>, label?: string) => {
+      contextTrace.push({ type: 'open', label });
+      try {
+        return await fn();
+      } finally {
+        contextTrace.push({ type: 'close', label });
+      }
+    }),
+  };
+});
 
 vi.mock('../db', () => ({
   db: {
     execute: executeMock,
   },
+  runOutsideDbContext: runOutsideDbContextMock,
+  withSystemDbAccessContext: withSystemDbAccessContextMock,
 }));
 
 vi.mock('./mlFeatureFlags', () => ({
@@ -17,12 +47,23 @@ vi.mock('./mlFeatureFlags', () => ({
 
 import { rollupDeviceMetricsRange } from './metricRollups';
 
+/** Contexts opened, in order, from the recorded trace. */
+function openedLabels(): Array<string | undefined> {
+  return contextTrace.filter((event) => event.type === 'open').map((event) => event.label);
+}
+
 describe('metric rollups service', () => {
   beforeEach(() => {
+    contextTrace.length = 0;
     executeMock.mockReset();
-    executeMock.mockResolvedValue([]);
+    executeMock.mockImplementation(async () => {
+      contextTrace.push({ type: 'execute' });
+      return [];
+    });
     shouldProduceMlOutputMock.mockReset();
     shouldProduceMlOutputMock.mockResolvedValue(true);
+    runOutsideDbContextMock.mockClear();
+    withSystemDbAccessContextMock.mockClear();
   });
 
   it('gates all writes behind the metric rollups ML feature flag', async () => {
@@ -169,6 +210,104 @@ describe('metric rollups service', () => {
     const snmpHourlyStatementSql = JSON.stringify(executeMock.mock.calls[22]);
     expect(snmpHourlyStatementSql).toContain('snmp_metrics');
     expect(snmpHourlyStatementSql).toContain('sourceBucketSeconds');
+  });
+
+  // #4276 — metricRollupsWorker was the top `db_context_held_too_long` offender
+  // (983 events/7d) because all 26 statements ran inside ONE
+  // withSystemDbAccessContext, pinning a single pooled connection for 2s+ every
+  // 5 minutes. Every statement here is an idempotent upsert, so the atomic
+  // transaction bought nothing: each one now gets its own short-lived context.
+  describe('#4276 per-statement DB contexts', () => {
+    it('opens one short-lived system context per statement, never one spanning all of them', async () => {
+      await rollupDeviceMetricsRange({
+        orgId: '11111111-1111-1111-1111-111111111111',
+        from: new Date('2026-06-18T12:00:00.000Z'),
+        to: new Date('2026-06-18T13:00:00.000Z'),
+      });
+
+      // 24 upserts + the ML feature-flag gate read = 25 contexts, each closing
+      // before the next opens. A trace with two consecutive `open`s means a
+      // context spans more than one statement, which is the bug.
+      expect(openedLabels()).toHaveLength(25);
+      expect(executeMock).toHaveBeenCalledTimes(24);
+
+      let depth = 0;
+      let maxDepth = 0;
+      let executesInsideAContext = 0;
+      for (const event of contextTrace) {
+        if (event.type === 'open') {
+          depth += 1;
+          maxDepth = Math.max(maxDepth, depth);
+        } else if (event.type === 'close') {
+          depth -= 1;
+        } else if (event.type === 'execute' && depth > 0) {
+          executesInsideAContext += 1;
+        }
+      }
+      expect(maxDepth).toBe(1);
+      expect(executesInsideAContext).toBe(24);
+    });
+
+    it('escapes any ambient DB context so a wrapping caller cannot re-create the single long hold', async () => {
+      await rollupDeviceMetricsRange({
+        orgId: '11111111-1111-1111-1111-111111111111',
+        from: new Date('2026-06-18T12:00:00.000Z'),
+        to: new Date('2026-06-18T13:00:00.000Z'),
+      });
+
+      // runOutsideDbContext must precede every context; without it a caller that
+      // already holds a context makes withDbAccessContext short-circuit and all
+      // 24 statements silently rejoin the outer transaction again (the
+      // alertWorker/#3216 trap).
+      expect(runOutsideDbContextMock).toHaveBeenCalledTimes(25);
+      const escapeThenOpen = contextTrace
+        .filter((event) => event.type === 'escape' || event.type === 'open')
+        .map((event) => event.type);
+      expect(escapeThenOpen).toEqual(
+        Array.from({ length: 25 }, () => ['escape', 'open'] as const).flat(),
+      );
+    });
+
+    it('labels every context so Sentry attribution survives the tsup bundle', async () => {
+      await rollupDeviceMetricsRange({
+        orgId: '11111111-1111-1111-1111-111111111111',
+        from: new Date('2026-06-18T12:00:00.000Z'),
+        to: new Date('2026-06-18T13:00:00.000Z'),
+      });
+
+      // `parseOpenerFrame` collapses every anonymous-arrow opener in the bundled
+      // API to a bare `index`, so an unlabelled context is unattributable in
+      // Sentry. Labels stay low-cardinality (one per rollup pass) because they
+      // become the `dbContextLabel` tag AND part of the grouped message.
+      expect(openedLabels().every((label) => typeof label === 'string' && label.length > 0)).toBe(true);
+      expect(new Set(openedLabels())).toEqual(new Set([
+        'metricRollups.mlFeatureGate',
+        'metricRollups.raw.device_metrics',
+        'metricRollups.raw.device_process_samples',
+        'metricRollups.raw.snmp_metrics',
+        'metricRollups.derived.device_metrics.3600',
+        'metricRollups.derived.device_metrics.86400',
+        'metricRollups.derived.device_process_samples.3600',
+        'metricRollups.derived.device_process_samples.86400',
+        'metricRollups.derived.snmp_metrics.3600',
+        'metricRollups.derived.snmp_metrics.86400',
+      ]));
+    });
+
+    it('gates the ML feature-flag read behind its own context so it never runs on the bare pool', async () => {
+      shouldProduceMlOutputMock.mockResolvedValue(false);
+
+      await rollupDeviceMetricsRange({
+        orgId: '11111111-1111-1111-1111-111111111111',
+        from: new Date('2026-06-18T12:00:00.000Z'),
+        to: new Date('2026-06-18T12:15:00.000Z'),
+      });
+
+      // The gate reads `organizations` + `partners`, both RLS-forced: with no
+      // context the read silently returns zero rows and every org looks disabled.
+      expect(openedLabels()).toEqual(['metricRollups.mlFeatureGate']);
+      expect(shouldProduceMlOutputMock).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('rejects invalid ranges before executing writes', async () => {

--- a/apps/api/src/services/metricRollups.test.ts
+++ b/apps/api/src/services/metricRollups.test.ts
@@ -308,6 +308,38 @@ describe('metric rollups service', () => {
       expect(openedLabels()).toEqual(['metricRollups.mlFeatureGate']);
       expect(shouldProduceMlOutputMock).toHaveBeenCalledTimes(1);
     });
+
+    // The split from one atomic transaction to per-statement commits is only
+    // safe because (a) a mid-pass throw PROPAGATES — a partial pass must fail
+    // the BullMQ job / backfill, never be reported as success — and (b) the
+    // already-committed statements stay committed and are re-covered by the
+    // next run's idempotent upserts. This pins (a) and the stop-at-failure
+    // shape; the committed-stays-committed half lives in the integration
+    // suite where real transactions exist.
+    it('propagates a mid-pass statement failure and stops — no later statements, no success result', async () => {
+      const boom = new Error('relation "metric_rollups" deadlocked');
+      executeMock.mockImplementation(async () => {
+        contextTrace.push({ type: 'execute' });
+        if (executeMock.mock.calls.length === 5) throw boom;
+        return [];
+      });
+
+      await expect(
+        rollupDeviceMetricsRange({
+          orgId: '11111111-1111-1111-1111-111111111111',
+          from: new Date('2026-06-18T12:00:00.000Z'),
+          to: new Date('2026-06-18T13:00:00.000Z'),
+        }),
+      ).rejects.toThrow(boom);
+
+      // Statements 1-4 ran (and, in production, committed); statement 5 threw;
+      // 6-24 never ran. Plus the ML gate context, that is exactly 6 opens —
+      // and every context still closed, so the failure cannot leak a held
+      // connection either.
+      expect(executeMock).toHaveBeenCalledTimes(5);
+      expect(openedLabels()).toHaveLength(6);
+      expect(contextTrace.filter((event) => event.type === 'close')).toHaveLength(6);
+    });
   });
 
   it('rejects invalid ranges before executing writes', async () => {

--- a/apps/api/src/services/metricRollups.ts
+++ b/apps/api/src/services/metricRollups.ts
@@ -1,6 +1,6 @@
 import { sql, type SQL } from 'drizzle-orm';
 
-import { db } from '../db';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { shouldProduceMlOutput } from './mlFeatureFlags';
 
 export const METRIC_ROLLUP_VERSION = 'metric-rollups-v1';
@@ -136,6 +136,46 @@ function normalizeRange(from: Date, to: Date): { from: Date; to: Date } {
   return { from, to };
 }
 
+/**
+ * #4276 — run ONE statement inside its OWN short-lived system RLS context.
+ *
+ * This module used to run under a single caller-supplied
+ * `withSystemDbAccessContext`, so all 26 statements shared one transaction and
+ * pinned one pooled connection for the whole pass. At ~2s+ per org every 5
+ * minutes that made `metricRollupsWorker` the top `db_context_held_too_long`
+ * offender (983 events/7d, ~half the system-scope capture budget) and it is
+ * exactly the kind of long single-connection hold that elongates recovery when
+ * the pool degrades (#3225).
+ *
+ * Nothing here needed the atomicity: every statement is an idempotent
+ * `INSERT … SELECT … ON CONFLICT DO UPDATE`, so a pass that dies halfway leaves
+ * a partially-refreshed set of rollups that the next 5-minute run re-upserts.
+ * Splitting also removes a real hazard rather than only trading one: the
+ * derived passes read rows the raw passes just wrote, and across transactions
+ * they read them COMMITTED instead of from the writer's own snapshot.
+ *
+ * `runOutsideDbContext` is not decoration. `withDbAccessContext` short-circuits
+ * to an ambient context when one is open, so without the escape any caller that
+ * wrapped this function (the backfill script and the integration suite both
+ * did) would silently collapse all 24 contexts back into its single transaction
+ * and restore the hold — the same trap documented on `processEvaluateAll`
+ * (jobs/alertWorker.ts, #3216).
+ *
+ * `label` is REQUIRED here, not optional: under the tsup single-file bundle
+ * every opener in this file is an anonymous arrow that `parseOpenerFrame`
+ * collapses to a bare `index`. Keep the label set low-cardinality — one per
+ * rollup pass, never per org or per metric — because it becomes part of the
+ * grouped Sentry message.
+ */
+function inRollupDbContext<T>(label: string, fn: () => Promise<T>): Promise<T> {
+  return runOutsideDbContext(() => withSystemDbAccessContext(fn, label));
+}
+
+/** One rollup statement, in its own context. */
+function execInRollupDbContext(label: string, statement: SQL): Promise<unknown> {
+  return inRollupDbContext(label, () => db.execute(statement));
+}
+
 function expandRangeToBucketBounds(from: Date, to: Date, bucketSeconds: number): { from: Date; to: Date } {
   const bucketMs = bucketSeconds * 1000;
   return {
@@ -151,7 +191,7 @@ async function rollupRawDeviceMetric(options: MetricRollupRange, metric: (typeof
   const expectedSampleSeconds = options.expectedSampleSeconds ?? DEFAULT_EXPECTED_SAMPLE_SECONDS;
   const valueSql = sql.raw(`dm.${metric.column}`);
 
-  await db.execute(sql`
+  await execInRollupDbContext('metricRollups.raw.device_metrics', sql`
     WITH metric_devices AS (
       SELECT DISTINCT dm.org_id, dm.device_id
       FROM device_metrics dm
@@ -236,7 +276,7 @@ async function rollupRawProcessSampleMetric(options: MetricRollupRange, metric: 
   const expectedSampleSeconds = options.expectedSampleSeconds ?? DEFAULT_EXPECTED_SAMPLE_SECONDS;
   const valueSql = sql.raw(metric.valueSql);
 
-  await db.execute(sql`
+  await execInRollupDbContext('metricRollups.raw.device_process_samples', sql`
     WITH process_devices AS (
       SELECT DISTINCT dps.org_id, dps.device_id
       FROM device_process_samples dps
@@ -324,7 +364,7 @@ async function rollupRawSnmpMetrics(options: MetricRollupRange): Promise<void> {
   const toIso = to.toISOString();
   const expectedSampleSeconds = options.expectedSampleSeconds ?? DEFAULT_EXPECTED_SAMPLE_SECONDS;
 
-  await db.execute(sql`
+  await execInRollupDbContext('metricRollups.raw.snmp_metrics', sql`
     WITH snmp_values AS (
       SELECT
         sm.org_id,
@@ -458,7 +498,7 @@ async function rollupDerivedMetricSource(
   const toIso = sourceRange.to.toISOString();
   const targetBucketSql = bucketStartSql(sql`mr.bucket_start`, targetBucketSeconds);
 
-  await db.execute(sql`
+  await execInRollupDbContext(`metricRollups.derived.${sourceTable}.${targetBucketSeconds}`, sql`
     INSERT INTO metric_rollups (
       org_id,
       source_table,
@@ -511,7 +551,12 @@ async function rollupDerivedMetricSource(
 
 export async function rollupDeviceMetricsRange(options: MetricRollupRange): Promise<MetricRollupResult> {
   const { from, to } = normalizeRange(options.from, options.to);
-  if (!(await shouldProduceMlOutput(options.orgId, 'ml.metric_rollups.enabled'))) {
+  // The gate reads `organizations` + `partners`, both RLS-forced — with no
+  // context the read returns zero rows and every org would look disabled.
+  const produceOutput = await inRollupDbContext('metricRollups.mlFeatureGate', () =>
+    shouldProduceMlOutput(options.orgId, 'ml.metric_rollups.enabled')
+  );
+  if (!produceOutput) {
     return {
       orgId: options.orgId,
       from: from.toISOString(),

--- a/apps/api/src/services/metricRollups.ts
+++ b/apps/api/src/services/metricRollups.ts
@@ -154,12 +154,15 @@ function normalizeRange(from: Date, to: Date): { from: Date; to: Date } {
  * derived passes read rows the raw passes just wrote, and across transactions
  * they read them COMMITTED instead of from the writer's own snapshot.
  *
- * `runOutsideDbContext` is not decoration. `withDbAccessContext` short-circuits
- * to an ambient context when one is open, so without the escape any caller that
- * wrapped this function (the backfill script and the integration suite both
- * did) would silently collapse all 24 contexts back into its single transaction
- * and restore the hold — the same trap documented on `processEvaluateAll`
- * (jobs/alertWorker.ts, #3216).
+ * `runOutsideDbContext` is not decoration. Without it, a caller that wrapped
+ * this function in its own context would make `withDbAccessContext`
+ * short-circuit into that ambient transaction, silently collapsing all the
+ * per-statement contexts back into one long hold — the alertWorker/#3216 trap.
+ * WITH the escape, an outer wrap is instead defeated: it does no work and just
+ * pins an idle-in-transaction connection for the whole pass (an unlabeled
+ * #3218-shape hold, plus a second pool slot). So callers must not wrap this
+ * function at all — the worker, backfill script and integration suite all call
+ * it bare.
  *
  * `label` is REQUIRED here, not optional: under the tsup single-file bundle
  * every opener in this file is an anonymous arrow that `parseOpenerFrame`


### PR DESCRIPTION
Part of #4276 (fix directions 2 and 3; direction 1 — bounding the day-level derived ranges — stays open on the issue).

## Problem
`metricRollupsWorker` is the top `db_context_held_too_long` offender (983 events/7d, ~half the system-scope Sentry capture budget): `rollup-org-range` wrapped all of `rollupDeviceMetricsRange` in ONE system context — 24 heavy `INSERT…ON CONFLICT` upserts plus the ML feature-flag gate on one pooled connection, 2s+ per org, every 5 minutes. Long single-connection holds are exactly what elongates recovery when the pool degrades (#3225, recurred in prod 2026-08-30).

## Change
- Each statement now runs in its own `runOutsideDbContext(() => withSystemDbAccessContext(fn, label))` pair. No atomicity was lost that mattered — every statement is an idempotent upsert; a half-finished pass is re-upserted by the next 5-minute run.
- The escape is load-bearing: `withDbAccessContext` short-circuits into an ambient context, so a wrapping caller (the integration suite does this) would otherwise silently rebuild the single long transaction — the alertWorker/#3216 trap.
- The ML gate keeps its own labeled context: it reads RLS-forced `organizations`/`partners` and would see zero rows contextless (= every org silently disabled).
- `withSystemDbAccessContext` gains an optional low-cardinality `label`; under the tsup single-file bundle `parseOpenerFrame` collapses every anonymous-arrow opener to bare `index`, so labels are the only Sentry attribution (#3218).
- Worker level: `scan-orgs` labeled `metricRollups.scanOrgs`; the wrap around `rollup-org-range` removed with a comment explaining why re-adding it restores the bug.

## Tests
Trace-shape pins in `services/metricRollups.test.ts`: exactly 25 labeled contexts, nesting depth never exceeds 1, all 24 executes inside a context, an escape precedes every open, and the exact label set is asserted. Worker tests pin the scan-orgs label and that no worker-level context wraps rollup-org-range. `tsc --noEmit` clean; 19/19 targeted tests green.

## Provenance
Started by an issue-fixer agent that hit the session spend limit mid-service-edit; recovered and completed in the main session — the agent's db/index.ts + test work retained, the service/worker implementation finished to match its test specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bn3WFTjEBmK3nPqmUdQinb