### PR TITLE
fix(api): close the check-then-act race in every single-alert acknowledge and suppress path (#4101)

### DIFF
--- a/apps/api/src/routes/alerts/alerts.ackSuppressCas.test.ts
+++ b/apps/api/src/routes/alerts/alerts.ackSuppressCas.test.ts
@@ -1,0 +1,286 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { SQL } from 'drizzle-orm';
+
+/**
+ * POST /alerts/:id/acknowledge and POST /alerts/:id/suppress are compare-and-swaps
+ * (#4101), for the same reason POST /alerts/:id/resolve became one in #4094/#4099.
+ *
+ * Both used to read the alert's status and then UPDATE by id unconditionally —
+ * textbook check-then-act. The damage is not merely a double-acknowledge: tech A
+ * resolves (the resolve CAS wins, `alert.resolved` publishes, the escalation is
+ * cancelled), tech B's stale list still shows the alert active and B clicks
+ * Acknowledge. B's id-only UPDATE stamps `status='acknowledged'` over the
+ * resolution, leaving a reopened alert that carries `resolvedAt`/`resolvedBy` and
+ * whose escalation is already gone. Suppress has the identical shape.
+ *
+ * Two kinds of assertion here, deliberately (see alerts.resolveCas.test.ts):
+ *
+ *  - BEHAVIOUR — an empty `RETURNING` (exactly what Postgres gives a caller whose
+ *    CAS matched nothing) must produce a 409 and NO fan-out.
+ *  - COMPILED SQL — the predicate the handler actually passed to `.where()`,
+ *    compiled through `PgDialect`. drizzle-orm and ../../db/schema are REAL in this
+ *    file for that reason: a mocked-drizzle `where` assertion can only substring-
+ *    match column NAMES, which cannot tell `and` from `or` and cannot see the
+ *    status list gaining a status that makes the CAS a no-op.
+ */
+const { dbMock, updateWheres, updateReturns, selectRows, alertRow } = vi.hoisted(() => {
+  const updateWheres: unknown[] = [];
+  const updateReturns: unknown[][] = [];
+  const selectRows: unknown[][] = [];
+  const alertRow = {
+    id: '33333333-3333-4333-8333-333333333333',
+    orgId: 'org-1',
+    deviceId: 'device-1',
+    ruleId: null as string | null,
+    configPolicyId: null as string | null,
+    context: null as unknown,
+    status: 'active',
+    title: 'Disk almost full',
+    triggeredAt: new Date('2026-01-01T00:00:00.000Z'),
+  };
+  const dbMock = {
+    select: () => ({
+      from: () => ({ where: () => ({ limit: () => Promise.resolve(selectRows.shift() ?? []) }) }),
+    }),
+    update: () => ({
+      set: () => ({
+        where: (predicate: unknown) => {
+          updateWheres.push(predicate);
+          return { returning: () => Promise.resolve(updateReturns.shift() ?? []) };
+        },
+      }),
+    }),
+  };
+  return { dbMock, updateWheres, updateReturns, selectRows, alertRow };
+});
+
+const publishEvent = vi.fn((..._args: unknown[]) => Promise.resolve('evt'));
+const emitAlertStateFeedback = vi.fn((..._args: unknown[]) => Promise.resolve());
+const writeRouteAudit = vi.fn();
+const getAlertWithOrgCheck = vi.fn();
+
+vi.mock('../../db', () => ({
+  db: dbMock,
+  runOutsideDbContext: (fn: () => unknown) => fn(),
+  withSystemDbAccessContext: (fn: () => unknown) => fn(),
+}));
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: async (_c: unknown, next: () => Promise<void>) => next(),
+  requireScope: () => async (c: { set: (k: string, v: unknown) => void }, next: () => Promise<void>) => {
+    c.set('auth', {
+      scope: 'organization',
+      user: { id: 'user-1', name: 'Tech One', email: 'tech@org.example' },
+      partnerId: null,
+      orgId: 'org-1',
+      accessibleOrgIds: null,
+      canAccessOrg: () => true,
+    });
+    await next();
+  },
+  requirePermission: () => async (c: { set: (k: string, v: unknown) => void }, next: () => Promise<void>) => {
+    c.set('permissions', { granted: new Set<string>() });
+    await next();
+  },
+  requireMfa: () => async (_c: unknown, next: () => Promise<void>) => next(),
+  siteAccessCheck: () => () => true,
+}));
+vi.mock('../../services/alertCooldown', () => ({
+  setCooldown: vi.fn(),
+  markConfigPolicyRuleCooldown: vi.fn(),
+}));
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: (...a: unknown[]) => writeRouteAudit(...a) }));
+vi.mock('../../services/eventBus', () => ({ publishEvent: (...a: unknown[]) => publishEvent(...a) }));
+vi.mock('../../services/mlFeedbackEmitters', () => ({
+  emitAlertStateFeedback: (...a: unknown[]) => emitAlertStateFeedback(...a),
+  emitCorrelationFeedback: vi.fn(),
+}));
+vi.mock('../../services/ticketService', () => ({
+  createTicketFromAlert: vi.fn(),
+  TicketServiceError: class TicketServiceError extends Error { status = 400; },
+}));
+vi.mock('./helpers', () => ({
+  getPagination: () => ({ page: 1, limit: 50, offset: 0 }),
+  ensureOrgAccess: () => true,
+  getAlertWithOrgCheck: (...args: unknown[]) => getAlertWithOrgCheck(...args),
+  validateNotificationChannelConfig: vi.fn(),
+}));
+// Severs the aiVerdict transitive import chain — same reason as
+// alerts.resolveCas.test.ts; this suite does not exercise verdicts.
+vi.mock('../../services/aiAgents/alertVerdicts', () => ({
+  latestVerdictsForAlerts: vi.fn(async () => new Map()),
+  projectAlertAiVerdictSummary: vi.fn(),
+}));
+
+import { alertsRoutes } from './alerts';
+
+const app = new Hono().route('/alerts', alertsRoutes);
+const dialect = new PgDialect();
+
+const ACK_CAS_LOST =
+  'Alert is no longer acknowledgeable — its status is no longer active.';
+const SUPPRESS_CAS_LOST =
+  'Alert is no longer suppressible — it already reached a terminal status (resolved or dismissed).';
+
+const acknowledgeRequest = () =>
+  app.request(`/alerts/${alertRow.id}/acknowledge`, { method: 'POST' });
+
+const suppressUntil = new Date('2099-01-01T00:00:00.000Z').toISOString();
+const suppressRequest = (body: Record<string, unknown> = { until: suppressUntil }) =>
+  app.request(`/alerts/${alertRow.id}/suppress`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+beforeEach(() => {
+  updateWheres.length = 0;
+  updateReturns.length = 0;
+  selectRows.length = 0;
+  vi.clearAllMocks();
+  publishEvent.mockResolvedValue('evt');
+  emitAlertStateFeedback.mockResolvedValue(undefined);
+  // The pre-read always sees an actionable alert; the race happens after it.
+  getAlertWithOrgCheck.mockResolvedValue({ ...alertRow, status: 'active' });
+});
+
+describe('POST /alerts/:id/acknowledge — the losing caller', () => {
+  it('answers 409 and does not report an acknowledgement it did not perform', async () => {
+    updateReturns.push([]); // CAS matched nothing: another transition got there first
+
+    const res = await acknowledgeRequest();
+
+    expect(res.status).toBe(409);
+    await expect(res.json()).resolves.toEqual({ error: ACK_CAS_LOST });
+  });
+
+  it('publishes no alert.acknowledged event, emits no ML feedback and writes no audit', async () => {
+    updateReturns.push([]);
+
+    await acknowledgeRequest();
+
+    // The whole point of the CAS. Before it, a stale client acking an alert that
+    // was resolved a moment ago both clobbered the resolution AND published
+    // `alert.acknowledged` for a transition that never legitimately happened,
+    // feeding the ML feedback loop a phantom acknowledgement.
+    expect(publishEvent).not.toHaveBeenCalled();
+    expect(emitAlertStateFeedback).not.toHaveBeenCalled();
+    expect(writeRouteAudit).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /alerts/:id/acknowledge — the winning caller', () => {
+  it('answers 200 and publishes exactly once', async () => {
+    updateReturns.push([{ ...alertRow, status: 'acknowledged' }]);
+
+    const res = await acknowledgeRequest();
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ id: alertRow.id, status: 'acknowledged' });
+    expect(publishEvent).toHaveBeenCalledTimes(1);
+    expect(publishEvent.mock.calls[0]?.[0]).toBe('alert.acknowledged');
+    expect(emitAlertStateFeedback).toHaveBeenCalledTimes(1);
+    expect(writeRouteAudit).toHaveBeenCalledTimes(1);
+  });
+
+  it('gives an already-acknowledged alert the SAME 409 the CAS loser gets', async () => {
+    getAlertWithOrgCheck.mockResolvedValue({ ...alertRow, status: 'acknowledged' });
+
+    const res = await acknowledgeRequest();
+
+    // Losing at the pre-read and losing at the CAS are the same real-world event —
+    // somebody else acknowledged first — so they must not return two different
+    // codes purely on timing. #4099 made exactly this change for resolve.
+    expect(res.status).toBe(409);
+    expect(updateWheres).toHaveLength(0);
+  });
+
+  it('keeps a resolved alert a 400 illegal transition, not a race', async () => {
+    getAlertWithOrgCheck.mockResolvedValue({ ...alertRow, status: 'resolved' });
+
+    const res = await acknowledgeRequest();
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: 'Cannot acknowledge alert with status: resolved',
+    });
+  });
+});
+
+describe('POST /alerts/:id/acknowledge — the shipped predicate (compiled SQL)', () => {
+  it('scopes the UPDATE by id AND acknowledgeable status', async () => {
+    updateReturns.push([{ ...alertRow, status: 'acknowledged' }]);
+
+    await acknowledgeRequest();
+
+    expect(updateWheres).toHaveLength(1);
+    const { sql, params } = dialect.sqlToQuery(updateWheres[0] as SQL);
+
+    // `or` instead of `and` would stamp every active alert in EVERY tenant
+    // acknowledged from one request; dropping the status list makes the write
+    // unconditional again (the #4101 bug); admitting any non-active status lets an
+    // acknowledge overwrite a resolution. Each changes this string or its params.
+    expect(sql).toBe('("alerts"."id" = $1 and "alerts"."status" in ($2))');
+    expect(params).toEqual([alertRow.id, 'active']);
+  });
+});
+
+describe('POST /alerts/:id/suppress — the losing caller', () => {
+  it('answers 409 and fans nothing out', async () => {
+    updateReturns.push([]); // CAS matched nothing
+
+    const res = await suppressRequest();
+
+    expect(res.status).toBe(409);
+    await expect(res.json()).resolves.toEqual({ error: SUPPRESS_CAS_LOST });
+    expect(emitAlertStateFeedback).not.toHaveBeenCalled();
+    expect(writeRouteAudit).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /alerts/:id/suppress — the winning caller', () => {
+  it('answers 200 and records the suppression once', async () => {
+    updateReturns.push([{ ...alertRow, status: 'suppressed' }]);
+
+    const res = await suppressRequest();
+
+    expect(res.status).toBe(200);
+    expect(emitAlertStateFeedback).toHaveBeenCalledTimes(1);
+    expect(writeRouteAudit).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a dismissed alert a 400', async () => {
+    getAlertWithOrgCheck.mockResolvedValue({ ...alertRow, status: 'dismissed' });
+
+    const res = await suppressRequest();
+
+    expect(res.status).toBe(400);
+    expect(updateWheres).toHaveLength(0);
+  });
+});
+
+describe('POST /alerts/:id/suppress — the shipped predicate (compiled SQL)', () => {
+  it('scopes the UPDATE by id AND suppressible status', async () => {
+    updateReturns.push([{ ...alertRow, status: 'suppressed' }]);
+
+    await suppressRequest();
+
+    expect(updateWheres).toHaveLength(1);
+    const { sql, params } = dialect.sqlToQuery(updateWheres[0] as SQL);
+
+    expect(sql).toBe('("alerts"."id" = $1 and "alerts"."status" in ($2, $3, $4))');
+    expect(params).toEqual([alertRow.id, 'active', 'acknowledged', 'suppressed']);
+  });
+
+  it('re-suppressing an already-suppressed alert is still allowed', async () => {
+    // `suppressed` is deliberately IN the CAS set: extending or shortening an
+    // existing mute is a legitimate operation, unlike re-acknowledging.
+    getAlertWithOrgCheck.mockResolvedValue({ ...alertRow, status: 'suppressed' });
+    updateReturns.push([{ ...alertRow, status: 'suppressed' }]);
+
+    const res = await suppressRequest();
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/api/src/routes/alerts/alerts.ts
+++ b/apps/api/src/routes/alerts/alerts.ts
@@ -20,7 +20,14 @@ import {
 } from '../../db/schema';
 import { requireScope, requirePermission } from '../../middleware/auth';
 import { setCooldown, markConfigPolicyRuleCooldown } from '../../services/alertCooldown';
-import { ALERT_CAS_LOST_MESSAGE, buildResolveAlertCas } from '../../services/alertService';
+import {
+  ALERT_ACKNOWLEDGE_CAS_LOST_MESSAGE,
+  ALERT_CAS_LOST_MESSAGE,
+  ALERT_SUPPRESS_CAS_LOST_MESSAGE,
+  buildAcknowledgeAlertCas,
+  buildResolveAlertCas,
+  buildSuppressAlertCas,
+} from '../../services/alertService';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { publishEvent } from '../../services/eventBus';
 import { emitAlertStateFeedback } from '../../services/mlFeedbackEmitters';
@@ -842,11 +849,25 @@ alertsRoutes.post(
       return c.json({ error: 'Alert not found' }, 404);
     }
 
+    // Fast path with a specific message. It is NOT the concurrency control — the
+    // compare-and-swap below is. Two techs on the same alert both clear this check.
+    // `acknowledged` gets the same 409 the CAS loser gets: losing at the pre-read
+    // and losing at the write are the same real-world event (somebody acknowledged
+    // first), so they must not return two codes purely on timing (#4099 made
+    // exactly this change for resolve).
+    if (alert.status === 'acknowledged') {
+      return c.json({ error: 'Alert is already acknowledged' }, 409);
+    }
     if (alert.status !== 'active') {
       return c.json({ error: `Cannot acknowledge alert with status: ${alert.status}` }, 400);
     }
 
     const acknowledgedAt = new Date();
+    // Winner-takes-all (#4101). Updating by id alone let a stale client acknowledge
+    // an alert another tech had just resolved — stamping `status='acknowledged'`
+    // over the resolution, leaving `resolvedAt`/`resolvedBy` populated on a
+    // "reopened" alert whose escalation was already cancelled — and still publish
+    // `alert.acknowledged` for a transition that never legitimately happened.
     const [updated] = await db
       .update(alerts)
       .set({
@@ -854,10 +875,13 @@ alertsRoutes.post(
         acknowledgedAt,
         acknowledgedBy: auth.user.id
       })
-      .where(eq(alerts.id, alertId))
+      .where(buildAcknowledgeAlertCas(alertId))
       .returning();
     if (!updated) {
-      return c.json({ error: 'Failed to acknowledge alert' }, 500);
+      // The CAS matched nothing between the read above and this write: the alert
+      // left `active` first. Everything below (event, ML feedback, audit) belongs
+      // to whoever performed that transition, not to this caller.
+      return c.json({ error: ALERT_ACKNOWLEDGE_CAS_LOST_MESSAGE }, 409);
     }
 
     try {
@@ -1066,16 +1090,18 @@ alertsRoutes.post(
       }
     }
 
+    // Winner-takes-all (#4101) — same shape as the acknowledge handler above. A
+    // stale suppress landing on a just-resolved alert would un-resolve it.
     const [updated] = await db
       .update(alerts)
       .set({
         status: 'suppressed',
         suppressedUntil
       })
-      .where(eq(alerts.id, alertId))
+      .where(buildSuppressAlertCas(alertId))
       .returning();
     if (!updated) {
-      return c.json({ error: 'Failed to suppress alert' }, 500);
+      return c.json({ error: ALERT_SUPPRESS_CAS_LOST_MESSAGE }, 409);
     }
 
     await emitAlertStateFeedback({

--- a/apps/api/src/routes/mobile.ackCas.test.ts
+++ b/apps/api/src/routes/mobile.ackCas.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { SQL } from 'drizzle-orm';
+
+/**
+ * POST /mobile/alerts/:id/acknowledge is a compare-and-swap (#4101).
+ *
+ * The twin of routes/alerts/alerts.ts's acknowledge handler, and it carried the
+ * same check-then-act defect plus one of its own: it never looked at the UPDATE's
+ * `RETURNING` at all (`updated?.id ?? alertId`), so a write that matched zero rows
+ * still published `alert.acknowledged`, still emitted ML feedback, still wrote an
+ * audit entry and still answered 200 — with a `null` body. Under `breeze_app` RLS a
+ * zero-row write raises no error, so that fallback turned both a lost race and a
+ * tenancy mismatch into a silent success.
+ *
+ * See alerts.ackSuppressCas.test.ts for why the predicate is asserted as COMPILED
+ * SQL rather than by column name.
+ */
+const { dbMock, updateWheres, updateReturns, selectReturns, alertRow } = vi.hoisted(() => {
+  const updateWheres: unknown[] = [];
+  const updateReturns: unknown[][] = [];
+  const selectReturns: unknown[][] = [];
+  const alertRow = {
+    id: '44444444-4444-4444-8444-444444444444',
+    orgId: 'org-1',
+    deviceId: 'device-1',
+    ruleId: null as string | null,
+    configPolicyId: null as string | null,
+    context: null as unknown,
+    status: 'active',
+    title: 'Agent offline',
+    triggeredAt: new Date('2026-08-29T10:00:00.000Z'),
+  };
+  const dbMock = {
+    // mobile.ts keeps its OWN `getAlertWithOrgCheck`, so the pre-read is driven
+    // through this queue rather than by mocking a helper module.
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: () => Promise.resolve(selectReturns.shift() ?? []) }),
+      }),
+    }),
+    update: () => ({
+      set: () => ({
+        where: (predicate: unknown) => {
+          updateWheres.push(predicate);
+          return { returning: () => Promise.resolve(updateReturns.shift() ?? []) };
+        },
+      }),
+    }),
+  };
+  return { dbMock, updateWheres, updateReturns, selectReturns, alertRow };
+});
+
+const publishEvent = vi.fn((..._args: unknown[]) => Promise.resolve('evt'));
+const emitAlertStateFeedback = vi.fn((..._args: unknown[]) => Promise.resolve());
+const writeRouteAudit = vi.fn();
+
+vi.mock('../db', () => ({
+  db: dbMock,
+  runOutsideDbContext: (fn: () => unknown) => fn(),
+  withSystemDbAccessContext: (fn: () => unknown) => fn(),
+}));
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: async (_c: unknown, next: () => Promise<void>) => next(),
+  requireScope: () => async (c: { set: (k: string, v: unknown) => void }, next: () => Promise<void>) => {
+    c.set('auth', {
+      scope: 'organization',
+      user: { id: 'user-1', name: 'Tech One', email: 'tech@org.example' },
+      partnerId: null,
+      orgId: 'org-1',
+      accessibleOrgIds: null,
+      canAccessOrg: () => true,
+    });
+    await next();
+  },
+  requirePermission: () => async (c: { set: (k: string, v: unknown) => void }, next: () => Promise<void>) => {
+    c.set('permissions', { granted: new Set<string>() });
+    await next();
+  },
+  requireMfa: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+vi.mock('../middleware/userRateLimit', () => ({ userRateLimit: () => async (_c: unknown, next: () => Promise<void>) => next() }));
+vi.mock('../services/alertCooldown', () => ({
+  setCooldown: vi.fn(),
+  markConfigPolicyRuleCooldown: vi.fn(),
+}));
+vi.mock('../services/auditEvents', () => ({ writeRouteAudit: (...a: unknown[]) => writeRouteAudit(...a) }));
+vi.mock('../services/eventBus', () => ({ publishEvent: (...a: unknown[]) => publishEvent(...a) }));
+vi.mock('../services/mlFeedbackEmitters', () => ({
+  emitAlertStateFeedback: (...a: unknown[]) => emitAlertStateFeedback(...a),
+}));
+vi.mock('../services/wakeOnLan', () => ({ dispatchWake: vi.fn() }));
+vi.mock('../services/scriptExecution', () => ({ executeScriptOnDevices: vi.fn() }));
+
+import { mobileRoutes } from './mobile';
+
+const app = new Hono().route('/mobile', mobileRoutes);
+const dialect = new PgDialect();
+
+const ACK_CAS_LOST =
+  'Alert is no longer acknowledgeable — its status is no longer active.';
+
+const acknowledgeRequest = () =>
+  app.request(`/mobile/alerts/${alertRow.id}/acknowledge`, { method: 'POST' });
+
+beforeEach(() => {
+  updateWheres.length = 0;
+  updateReturns.length = 0;
+  selectReturns.length = 0;
+  vi.clearAllMocks();
+  publishEvent.mockResolvedValue('evt');
+  emitAlertStateFeedback.mockResolvedValue(undefined);
+  // The pre-read always sees an active alert; the race happens after it.
+  selectReturns.push([{ ...alertRow, status: 'active' }]);
+});
+
+describe('POST /mobile/alerts/:id/acknowledge — the losing caller', () => {
+  it('answers 409 and fans nothing out', async () => {
+    updateReturns.push([]); // CAS matched nothing
+
+    const res = await acknowledgeRequest();
+
+    expect(res.status).toBe(409);
+    await expect(res.json()).resolves.toEqual({ error: ACK_CAS_LOST });
+    expect(publishEvent).not.toHaveBeenCalled();
+    expect(emitAlertStateFeedback).not.toHaveBeenCalled();
+    expect(writeRouteAudit).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /mobile/alerts/:id/acknowledge — the winning caller', () => {
+  it('answers 200 with the updated row and publishes exactly once', async () => {
+    updateReturns.push([{ ...alertRow, status: 'acknowledged' }]);
+
+    const res = await acknowledgeRequest();
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ id: alertRow.id, status: 'acknowledged' });
+    expect(publishEvent).toHaveBeenCalledTimes(1);
+    expect(publishEvent.mock.calls[0]?.[0]).toBe('alert.acknowledged');
+    expect(writeRouteAudit).toHaveBeenCalledTimes(1);
+  });
+
+  it('gives an already-acknowledged alert the SAME 409 the CAS loser gets', async () => {
+    selectReturns[0] = [{ ...alertRow, status: 'acknowledged' }];
+
+    const res = await acknowledgeRequest();
+
+    expect(res.status).toBe(409);
+    expect(updateWheres).toHaveLength(0);
+  });
+
+  it('keeps a resolved alert a 400', async () => {
+    selectReturns[0] = [{ ...alertRow, status: 'resolved' }];
+
+    const res = await acknowledgeRequest();
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /mobile/alerts/:id/acknowledge — the shipped predicate (compiled SQL)', () => {
+  it('scopes the UPDATE by id AND acknowledgeable status', async () => {
+    updateReturns.push([{ ...alertRow, status: 'acknowledged' }]);
+
+    await acknowledgeRequest();
+
+    expect(updateWheres).toHaveLength(1);
+    const { sql, params } = dialect.sqlToQuery(updateWheres[0] as SQL);
+
+    expect(sql).toBe('("alerts"."id" = $1 and "alerts"."status" in ($2))');
+    expect(params).toEqual([alertRow.id, 'active']);
+  });
+});

--- a/apps/api/src/routes/mobile.ts
+++ b/apps/api/src/routes/mobile.ts
@@ -18,7 +18,12 @@ import {
 import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
 import { userRateLimit } from '../middleware/userRateLimit';
 import { setCooldown, markConfigPolicyRuleCooldown } from '../services/alertCooldown';
-import { ALERT_CAS_LOST_MESSAGE, buildResolveAlertCas } from '../services/alertService';
+import {
+  ALERT_ACKNOWLEDGE_CAS_LOST_MESSAGE,
+  ALERT_CAS_LOST_MESSAGE,
+  buildAcknowledgeAlertCas,
+  buildResolveAlertCas,
+} from '../services/alertService';
 import { writeRouteAudit } from '../services/auditEvents';
 import { publishEvent } from '../services/eventBus';
 import { escapeLike } from '../utils/sql';
@@ -904,11 +909,23 @@ mobileRoutes.post(
       return c.json({ error: 'Alert not found' }, 404);
     }
 
+    // Fast path with a specific message. It is NOT the concurrency control — the
+    // compare-and-swap below is. See the twin handler in routes/alerts/alerts.ts
+    // for why `acknowledged` carries the CAS loser's 409 rather than a 400.
+    if (alert.status === 'acknowledged') {
+      return c.json({ error: 'Alert is already acknowledged' }, 409);
+    }
     if (alert.status !== 'active') {
       return c.json({ error: `Cannot acknowledge alert with status: ${alert.status}` }, 400);
     }
 
     const acknowledgedAt = new Date();
+    // Winner-takes-all (#4101) — same predicate as the twin handler in
+    // routes/alerts/alerts.ts. This path additionally never looked at the
+    // `RETURNING` at all (`updated?.id ?? alertId`), so a write that matched zero
+    // rows — a lost race, or a row this tenant context cannot see, which raises no
+    // error under breeze_app RLS — still published `alert.acknowledged`, still fed
+    // the ML loop and still answered 200 with a null body.
     const [updated] = await db
       .update(alerts)
       .set({
@@ -916,15 +933,18 @@ mobileRoutes.post(
         acknowledgedAt,
         acknowledgedBy: auth.user.id
       })
-      .where(eq(alerts.id, alertId))
+      .where(buildAcknowledgeAlertCas(alertId))
       .returning();
+    if (!updated) {
+      return c.json({ error: ALERT_ACKNOWLEDGE_CAS_LOST_MESSAGE }, 409);
+    }
 
     try {
       await publishEvent(
         'alert.acknowledged',
         alert.orgId,
         {
-          alertId: updated?.id ?? alertId,
+          alertId: updated.id,
           ruleId: alert.ruleId,
           deviceId: alert.deviceId,
           acknowledgedBy: auth.user.id
@@ -938,7 +958,7 @@ mobileRoutes.post(
 
     await emitAlertStateFeedback({
       orgId: alert.orgId,
-      alertId: updated?.id ?? alertId,
+      alertId: updated.id,
       eventType: 'alert.acknowledged',
       outcome: 'acknowledged',
       actorUserId: auth.user.id,
@@ -953,8 +973,8 @@ mobileRoutes.post(
       orgId: alert.orgId,
       action: 'mobile.alert.acknowledge',
       resourceType: 'alert',
-      resourceId: updated?.id ?? alertId,
-      resourceName: updated?.title ?? alert.title
+      resourceId: updated.id,
+      resourceName: updated.title
     });
 
     return c.json(updated);

--- a/apps/api/src/services/aiToolsAlerts.ackSuppressCas.test.ts
+++ b/apps/api/src/services/aiToolsAlerts.ackSuppressCas.test.ts
@@ -1,0 +1,200 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { SQL } from 'drizzle-orm';
+
+/**
+ * `manage_alerts { action: 'acknowledge' | 'suppress' }` are compare-and-swaps
+ * (#4101), the same shape as the `resolve` action (`aiToolsAlerts.resolveCas.test.ts`).
+ *
+ * Before this change both did read-status-then-UPDATE-by-id and never asked for a
+ * `RETURNING` at all, so the tool reported `success: true` and published
+ * `alert.acknowledged` / `alert.suppressed` for a write that may have matched zero
+ * rows — or, worse, that overwrote a resolution a technician had just performed.
+ * An agent step racing a technician is not hypothetical: a retried or duplicated
+ * tool call races itself.
+ *
+ * Two kinds of assertion here, deliberately:
+ *
+ *  - BEHAVIOUR — an empty `RETURNING` (the CAS matched nothing) must produce the
+ *    CAS-lost error and NO fan-out.
+ *  - COMPILED SQL — the predicate the handler actually passes to `.where()`,
+ *    compiled through `PgDialect`. drizzle-orm and ../db/schema are REAL in this
+ *    file for that reason: a mocked-drizzle `where` assertion can only substring-
+ *    match column NAMES, which cannot tell `and` from `or` and cannot see the
+ *    status list gaining a value that makes the CAS a no-op.
+ */
+const { dbMock, updateWheres, updateReturns, alertRow } = vi.hoisted(() => {
+  const updateWheres: unknown[] = [];
+  const updateReturns: unknown[][] = [];
+  const alertRow = {
+    id: '66666666-6666-4666-8666-666666666666',
+    orgId: 'org-1',
+    deviceId: 'device-1',
+    ruleId: null as string | null,
+    configPolicyId: null as string | null,
+    status: 'active',
+    title: 'Disk almost full',
+    triggeredAt: new Date('2026-01-01T00:00:00.000Z'),
+  };
+  const dbMock = {
+    select: () => ({
+      from: () => ({ where: () => ({ limit: () => Promise.resolve([alertRow]) }) }),
+    }),
+    update: () => ({
+      set: () => ({
+        where: (predicate: unknown) => {
+          updateWheres.push(predicate);
+          return { returning: () => Promise.resolve(updateReturns.shift() ?? []) };
+        },
+      }),
+    }),
+  };
+  return { dbMock, updateWheres, updateReturns, alertRow };
+});
+
+const publishEvent = vi.fn((..._args: unknown[]) => Promise.resolve('evt'));
+const emitAlertStateFeedback = vi.fn((..._args: unknown[]) => Promise.resolve());
+
+vi.mock('../db', () => ({ db: dbMock }));
+vi.mock('./eventBus', () => ({ publishEvent: (...a: unknown[]) => publishEvent(...a) }));
+vi.mock('./mlFeedbackEmitters', () => ({ emitAlertStateFeedback: (...a: unknown[]) => emitAlertStateFeedback(...a) }));
+
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+import { registerAlertTools } from './aiToolsAlerts';
+
+const ACK_CAS_LOST =
+  'Alert is no longer acknowledgeable — its status is no longer active.';
+const SUPPRESS_CAS_LOST =
+  'Alert is no longer suppressible — it already reached a terminal status (resolved or dismissed).';
+
+function manageAlerts(): AiTool['handler'] {
+  const registry = new Map<string, AiTool>();
+  registerAlertTools(registry);
+  return registry.get('manage_alerts')!.handler;
+}
+
+// Unrestricted org caller — see aiToolsAlerts.resolveCas.test.ts. This file is
+// about the CAS, not the site axis.
+function makeAuth(): AuthContext {
+  return {
+    principal: { kind: 'user_session' },
+    user: { id: '11111111-1111-4111-8111-111111111111', email: 'user@example.com', name: 'User', isPlatformAdmin: false },
+    token: {} as never,
+    partnerId: null,
+    orgId: 'org-1',
+    scope: 'organization',
+    accessibleOrgIds: ['org-1'],
+    orgCondition: () => undefined,
+    canAccessOrg: (orgId) => orgId === 'org-1',
+  } as AuthContext;
+}
+
+const acknowledge = () => manageAlerts()({ action: 'acknowledge', alertId: alertRow.id }, makeAuth());
+const suppress = (overrides: Record<string, unknown> = {}) =>
+  manageAlerts()({ action: 'suppress', alertId: alertRow.id, suppressDuration: 24, ...overrides }, makeAuth());
+
+beforeEach(() => {
+  updateWheres.length = 0;
+  updateReturns.length = 0;
+  vi.clearAllMocks();
+  publishEvent.mockResolvedValue('evt');
+  emitAlertStateFeedback.mockResolvedValue(undefined);
+  // The pre-read always sees an actionable alert; the race happens after it.
+  alertRow.status = 'active';
+});
+
+describe('manage_alerts acknowledge — the losing caller', () => {
+  it('answers the CAS-lost error instead of claiming success', async () => {
+    updateReturns.push([]); // CAS matched nothing
+
+    const result = JSON.parse(await acknowledge());
+
+    expect(result).toEqual({ error: ACK_CAS_LOST });
+    expect(result.success).toBeUndefined();
+  });
+
+  it('publishes no alert.acknowledged event and emits no ML feedback', async () => {
+    updateReturns.push([]);
+
+    await acknowledge();
+
+    expect(publishEvent).not.toHaveBeenCalled();
+    expect(emitAlertStateFeedback).not.toHaveBeenCalled();
+  });
+});
+
+describe('manage_alerts acknowledge — the winning caller', () => {
+  it('answers success and publishes alert.acknowledged exactly once', async () => {
+    updateReturns.push([{ id: alertRow.id }]);
+
+    const result = JSON.parse(await acknowledge());
+
+    expect(result.success).toBe(true);
+    expect(publishEvent).toHaveBeenCalledTimes(1);
+    expect(publishEvent.mock.calls[0]?.[0]).toBe('alert.acknowledged');
+    expect(emitAlertStateFeedback).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('manage_alerts acknowledge — the shipped predicate (compiled SQL)', () => {
+  it('scopes the UPDATE by id AND acknowledgeable status', async () => {
+    updateReturns.push([{ id: alertRow.id }]);
+
+    await acknowledge();
+
+    expect(updateWheres).toHaveLength(1);
+    const { sql, params } = new PgDialect().sqlToQuery(updateWheres[0] as SQL);
+
+    expect(sql).toBe('("alerts"."id" = $1 and "alerts"."status" in ($2))');
+    expect(params).toEqual([alertRow.id, 'active']);
+  });
+});
+
+describe('manage_alerts suppress — the losing caller', () => {
+  it('answers the CAS-lost error and fans nothing out', async () => {
+    updateReturns.push([]); // CAS matched nothing
+
+    const result = JSON.parse(await suppress());
+
+    expect(result).toEqual({ error: SUPPRESS_CAS_LOST });
+    expect(publishEvent).not.toHaveBeenCalled();
+    expect(emitAlertStateFeedback).not.toHaveBeenCalled();
+  });
+});
+
+describe('manage_alerts suppress — the winning caller', () => {
+  it('answers success and publishes alert.suppressed exactly once', async () => {
+    updateReturns.push([{ id: alertRow.id }]);
+
+    const result = JSON.parse(await suppress());
+
+    expect(result.success).toBe(true);
+    expect(publishEvent).toHaveBeenCalledTimes(1);
+    expect(publishEvent.mock.calls[0]?.[0]).toBe('alert.suppressed');
+    expect(emitAlertStateFeedback).toHaveBeenCalledTimes(1);
+  });
+
+  it('still refuses a resolved alert at the pre-read', async () => {
+    alertRow.status = 'resolved';
+
+    const result = JSON.parse(await suppress());
+
+    expect(result).toEqual({ error: 'Cannot suppress a resolved alert' });
+    expect(updateWheres).toHaveLength(0);
+  });
+});
+
+describe('manage_alerts suppress — the shipped predicate (compiled SQL)', () => {
+  it('scopes the UPDATE by id AND suppressible status', async () => {
+    updateReturns.push([{ id: alertRow.id }]);
+
+    await suppress();
+
+    expect(updateWheres).toHaveLength(1);
+    const { sql, params } = new PgDialect().sqlToQuery(updateWheres[0] as SQL);
+
+    expect(sql).toBe('("alerts"."id" = $1 and "alerts"."status" in ($2, $3, $4))');
+    expect(params).toEqual([alertRow.id, 'active', 'acknowledged', 'suppressed']);
+  });
+});

--- a/apps/api/src/services/aiToolsAlerts.ts
+++ b/apps/api/src/services/aiToolsAlerts.ts
@@ -13,7 +13,14 @@ import { eq, and, desc, sql, inArray, ne, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { publishEvent } from './eventBus';
-import { ALERT_CAS_LOST_MESSAGE, buildResolveAlertCas } from './alertService';
+import {
+  ALERT_ACKNOWLEDGE_CAS_LOST_MESSAGE,
+  ALERT_CAS_LOST_MESSAGE,
+  ALERT_SUPPRESS_CAS_LOST_MESSAGE,
+  buildAcknowledgeAlertCas,
+  buildResolveAlertCas,
+  buildSuppressAlertCas,
+} from './alertService';
 import { deviceIdSiteDenied, resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
 import { emitAlertStateFeedback } from './mlFeedbackEmitters';
 import {
@@ -159,14 +166,27 @@ export function registerAlertTools(aiTools: Map<string, AiTool>): void {
         }
 
         const acknowledgedAt = new Date();
-        await db
+        // Winner-takes-all (#4101), same shape as the `resolve` branch below and as
+        // both HTTP acknowledge routes. Without the status predicate an agent step
+        // racing a technician's resolve — or racing a retried/duplicated copy of
+        // its own tool call — stamped `acknowledged` over the resolution and
+        // reported `success: true`. There was no `RETURNING` at all, so a write
+        // that matched zero rows (a lost race, or a row invisible to this tenant
+        // context, which raises no error under breeze_app RLS) was indistinguishable
+        // from a real acknowledgement.
+        const acknowledgeWrite = await db
           .update(alerts)
           .set({
             status: 'acknowledged',
             acknowledgedAt,
             acknowledgedBy: auth.user.id
           })
-          .where(eq(alerts.id, input.alertId as string));
+          .where(buildAcknowledgeAlertCas(input.alertId as string))
+          .returning({ id: alerts.id });
+
+        if (acknowledgeWrite.length === 0) {
+          return JSON.stringify({ error: ALERT_ACKNOWLEDGE_CAS_LOST_MESSAGE });
+        }
 
         let eventWarning: string | undefined;
         try {
@@ -309,14 +329,21 @@ export function registerAlertTools(aiTools: Map<string, AiTool>): void {
         const resolutionNote = (input.resolutionNote as string)
           ?? (forever ? 'Suppressed indefinitely via AI assistant' : `Suppressed for ${durationHours}h via AI assistant`);
 
-        await db
+        // Winner-takes-all (#4101) — same shape as the acknowledge branch above. A
+        // stale suppress landing on a just-resolved alert would un-resolve it.
+        const suppressWrite = await db
           .update(alerts)
           .set({
             status: 'suppressed',
             suppressedUntil,
             resolutionNote
           })
-          .where(eq(alerts.id, input.alertId as string));
+          .where(buildSuppressAlertCas(input.alertId as string))
+          .returning({ id: alerts.id });
+
+        if (suppressWrite.length === 0) {
+          return JSON.stringify({ error: ALERT_SUPPRESS_CAS_LOST_MESSAGE });
+        }
 
         let suppressEventWarning: string | undefined;
         try {

--- a/apps/api/src/services/alertService.ackCasSql.test.ts
+++ b/apps/api/src/services/alertService.ackCasSql.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest';
+import { PgDialect } from 'drizzle-orm/pg-core';
+
+// Only the CONNECTION is mocked. drizzle-orm and ../db/schema stay REAL so the
+// predicates can be compiled — the whole point of this file.
+vi.mock('../db', () => ({ db: {} }));
+
+import { alertStatusEnum } from '../db/schema/alerts';
+import {
+  ACKNOWLEDGEABLE_ALERT_STATUSES,
+  RESOLVABLE_ALERT_STATUSES,
+  SUPPRESSIBLE_ALERT_STATUSES,
+  buildAcknowledgeAlertCas,
+  buildSuppressAlertCas,
+} from './alertService';
+
+/**
+ * COMPILED-SQL assertions for the acknowledge/suppress compare-and-swap predicates
+ * (#4101), the acknowledge-side twin of `alertService.resolveCasSql.test.ts`.
+ *
+ * Compiling is not ceremony. A mocked-drizzle assertion that only checks column
+ * names appear cannot tell `and` from `or` — which would stamp every matching
+ * alert in EVERY tenant from one request — and cannot see the status list gaining
+ * a value that makes the CAS a no-op. Both mutations change the string or the
+ * params below.
+ */
+describe('acknowledge compare-and-swap predicate (compiled SQL)', () => {
+  const dialect = new PgDialect();
+
+  it('emits an AND of the id equality and the acknowledgeable-status set', () => {
+    const { sql, params } = dialect.sqlToQuery(buildAcknowledgeAlertCas('alert-1')!);
+
+    expect(sql).toBe('("alerts"."id" = $1 and "alerts"."status" in ($2))');
+    expect(params).toEqual(['alert-1', 'active']);
+  });
+
+  it('admits ONLY active', () => {
+    // Every acknowledge call site refuses a non-active alert at its pre-read; the
+    // CAS is that same rule expressed where it is actually enforceable. Admitting
+    // `resolved` here is the #4101 bug in its purest form: an acknowledge that
+    // overwrites somebody else's resolution.
+    expect([...ACKNOWLEDGEABLE_ALERT_STATUSES]).toEqual(['active']);
+  });
+});
+
+describe('suppress compare-and-swap predicate (compiled SQL)', () => {
+  const dialect = new PgDialect();
+
+  it('emits an AND of the id equality and the suppressible-status set', () => {
+    const { sql, params } = dialect.sqlToQuery(buildSuppressAlertCas('alert-2')!);
+
+    expect(sql).toBe('("alerts"."id" = $1 and "alerts"."status" in ($2, $3, $4))');
+    expect(params).toEqual(['alert-2', 'active', 'acknowledged', 'suppressed']);
+  });
+
+  it('keeps `suppressed` itself in the set so a mute can be re-timed', () => {
+    // Unlike acknowledge, re-suppressing is legitimate (extend/shorten the mute),
+    // so dropping `suppressed` here would break a real workflow rather than close
+    // a race.
+    expect([...SUPPRESSIBLE_ALERT_STATUSES]).toContain('suppressed');
+  });
+});
+
+/**
+ * Drift guard. The three status lists are separate on purpose — they express three
+ * different invariants and must be free to diverge — but every one of them is
+ * derived from the same enum, so a new `alert_status` value must be classified
+ * deliberately rather than silently inheriting whatever the list happens to hold.
+ */
+describe('CAS status lists stay anchored to the alert_status enum', () => {
+  const TERMINAL = ['resolved', 'dismissed'] as const;
+
+  it('lists only real enum values', () => {
+    for (const status of [
+      ...ACKNOWLEDGEABLE_ALERT_STATUSES,
+      ...SUPPRESSIBLE_ALERT_STATUSES,
+      ...RESOLVABLE_ALERT_STATUSES,
+    ]) {
+      expect(alertStatusEnum.enumValues).toContain(status);
+    }
+  });
+
+  it('never admits a terminal status into any CAS', () => {
+    for (const terminal of TERMINAL) {
+      expect(ACKNOWLEDGEABLE_ALERT_STATUSES).not.toContain(terminal);
+      expect(SUPPRESSIBLE_ALERT_STATUSES).not.toContain(terminal);
+      expect(RESOLVABLE_ALERT_STATUSES).not.toContain(terminal);
+    }
+  });
+
+  it('suppressible == every non-terminal status, derived from the enum', () => {
+    // A new non-terminal status (say `snoozed`) that nobody adds here would make
+    // suppress silently un-suppressible for those rows. Deriving the expectation
+    // from the enum turns that into a failing test instead of a field report.
+    const nonTerminal = alertStatusEnum.enumValues.filter(
+      (status) => !(TERMINAL as readonly string[]).includes(status)
+    );
+    expect([...SUPPRESSIBLE_ALERT_STATUSES].sort()).toEqual([...nonTerminal].sort());
+  });
+});

--- a/apps/api/src/services/alertService.ts
+++ b/apps/api/src/services/alertService.ts
@@ -265,6 +265,9 @@ export async function checkAutoResolve(alertId: string): Promise<boolean> {
  */
 export const RESOLVABLE_ALERT_STATUSES = ['active', 'acknowledged', 'suppressed'] as const;
 
+/** The `alert_status` enum, as the column itself types it. */
+type AlertStatus = (typeof alerts.$inferSelect)['status'];
+
 /**
  * What a resolve path reports when it LOSES the compare-and-swap.
  *
@@ -294,9 +297,93 @@ export const ALERT_CAS_LOST_MESSAGE =
  *     it pins each row to the exact status its snapshot saw.
  */
 export function buildResolveAlertCas(alertId: string) {
+  return buildAlertStatusCas(alertId, RESOLVABLE_ALERT_STATUSES);
+}
+
+/**
+ * The one status an alert can be acknowledged FROM.
+ *
+ * Deliberately narrower than the resolvable set and not derivable from it: every
+ * acknowledge call site already refuses a non-active alert at its pre-read, and
+ * re-acknowledging an acknowledged alert is not a workflow anybody asked for. What
+ * the pre-read could never do is stop the write, which is the #4101 bug — see
+ * `buildAcknowledgeAlertCas`.
+ */
+export const ACKNOWLEDGEABLE_ALERT_STATUSES = ['active'] as const;
+
+/**
+ * The statuses an alert can be suppressed FROM: everything except the two terminal
+ * ones. `suppressed` is in the set on purpose — re-timing an existing mute
+ * (extending or shortening it) is a legitimate operation, unlike re-acknowledging.
+ *
+ * Textually identical to `RESOLVABLE_ALERT_STATUSES` today, and kept a separate
+ * constant anyway: the two express different invariants ("still silenceable" vs
+ * "still resolvable") and must be free to diverge when a status is added. Aliasing
+ * them would make a future non-terminal status silently inherit both answers.
+ * `alertService.ackCasSql.test.ts` derives both from the `alert_status` enum so a
+ * new value forces the classification instead of defaulting to one.
+ */
+export const SUPPRESSIBLE_ALERT_STATUSES = ['active', 'acknowledged', 'suppressed'] as const;
+
+/**
+ * What an acknowledge path reports when it LOSES the compare-and-swap.
+ *
+ * Same discipline as `ALERT_CAS_LOST_MESSAGE`: state only what the code can verify
+ * (the row is no longer active), never "another request acknowledged it" — an empty
+ * `RETURNING` is also what an RLS-invisible write produces, and naming the benign
+ * cause in user-visible text forecloses the hypothesis worth chasing when the cause
+ * is not benign.
+ */
+export const ALERT_ACKNOWLEDGE_CAS_LOST_MESSAGE =
+  'Alert is no longer acknowledgeable — its status is no longer active.';
+
+/** What a suppress path reports when it LOSES the compare-and-swap. */
+export const ALERT_SUPPRESS_CAS_LOST_MESSAGE =
+  'Alert is no longer suppressible — it already reached a terminal status (resolved or dismissed).';
+
+/**
+ * The compare-and-swap predicate for acknowledging ONE alert by id (#4101).
+ *
+ * The acknowledge handlers had the identical check-then-act shape the resolve paths
+ * carried before #4094/#4099: read the status, then UPDATE by id unconditionally.
+ * The damage is worse than a double-acknowledge. Tech A resolves — the resolve CAS
+ * wins, `alert.resolved` publishes, the escalation is cancelled. Tech B's stale list
+ * still shows the alert active and B clicks Acknowledge; B's id-only UPDATE stamps
+ * `status='acknowledged'` over the resolution, leaving a reopened alert that still
+ * carries `resolvedAt`/`resolvedBy` and whose escalation is already gone.
+ *
+ * Single definition for every single-alert acknowledge path: both HTTP routes
+ * (`routes/alerts/alerts.ts`, `routes/mobile.ts`) and the `manage_alerts` AI tool.
+ * The two multi-row acknowledge paths compose the status predicate directly because
+ * they need `inArray(alerts.id, ...)` rather than an id equality:
+ *   - the correlation-group acknowledge (`routes/alerts/correlations.ts`);
+ *   - the bulk alert action (`routes/alerts/alerts.ts`), stricter still — it pins
+ *     each row to the exact status its snapshot saw.
+ */
+export function buildAcknowledgeAlertCas(alertId: string) {
+  return buildAlertStatusCas(alertId, ACKNOWLEDGEABLE_ALERT_STATUSES);
+}
+
+/**
+ * The compare-and-swap predicate for suppressing ONE alert by id (#4101). Same
+ * check-then-act defect and the same fix shape as `buildAcknowledgeAlertCas`; a
+ * stale suppress landing on a just-resolved alert un-resolves it.
+ */
+export function buildSuppressAlertCas(alertId: string) {
+  return buildAlertStatusCas(alertId, SUPPRESSIBLE_ALERT_STATUSES);
+}
+
+/**
+ * The one place the CAS SHAPE lives. The three builders above differ only in which
+ * statuses they admit; funnelling them through here means a change to the shape
+ * (`and` → `or`, dropping the id equality) cannot land on one transition and miss
+ * the other two — which is exactly how a predicate and its compiled-SQL test have
+ * drifted apart in this file before.
+ */
+function buildAlertStatusCas(alertId: string, statuses: readonly AlertStatus[]) {
   return and(
     eq(alerts.id, alertId),
-    inArray(alerts.status, [...RESOLVABLE_ALERT_STATUSES]),
+    inArray(alerts.status, [...statuses]),
   );
 }
 

--- a/apps/docs/src/content/docs/reference/api.mdx
+++ b/apps/docs/src/content/docs/reference/api.mdx
@@ -229,9 +229,9 @@ audit log.
 | `GET` | `/alerts` | List alerts |
 | `GET` | `/alerts/summary` | Alert summary counts |
 | `GET` | `/alerts/:id` | Get alert details |
-| `POST` | `/alerts/:id/acknowledge` | Acknowledge alert |
-| `POST` | `/alerts/:id/resolve` | Resolve alert |
-| `POST` | `/alerts/:id/suppress` | Suppress alert |
+| `POST` | `/alerts/:id/acknowledge` | Acknowledge alert. Valid only from `active`; returns `409` if the alert left that status first (another user, or the auto-resolve sweep, got there first) |
+| `POST` | `/alerts/:id/resolve` | Resolve alert. Returns `409` if the alert already reached a terminal status |
+| `POST` | `/alerts/:id/suppress` | Suppress alert. Returns `409` if the alert already reached a terminal status |
 | `POST` | `/alerts/:id/dismiss` | Permanently dismiss an alert. Terminal and valid from any status (including `resolved`); dismissed alerts are hidden from `GET /alerts` unless you filter to `status=dismissed` |
 | `POST` | `/alerts/bulk` | Bulk state change for up to 100 alerts — `action` is one of `acknowledge`, `resolve`, `suppress`, or `dismiss` |
 
@@ -1159,8 +1159,8 @@ Over the transport, the server speaks JSON-RPC 2.0. Alongside `tools/*` and `res
 | `GET` | `/mobile/devices/:id/settings` | Device settings |
 | `GET` | `/mobile/devices/:id` | Device details |
 | `GET` | `/mobile/alerts/inbox` | Alert inbox |
-| `POST` | `/mobile/alerts/:id/acknowledge` | Acknowledge alert |
-| `POST` | `/mobile/alerts/:id/resolve` | Resolve alert |
+| `POST` | `/mobile/alerts/:id/acknowledge` | Acknowledge alert. Same `409`-on-conflict contract as `POST /alerts/:id/acknowledge` |
+| `POST` | `/mobile/alerts/:id/resolve` | Resolve alert. Same `409`-on-conflict contract as `POST /alerts/:id/resolve` |
 | `POST` | `/mobile/devices/:id/actions` | Send device action |
 | `GET` | `/mobile/summary` | Dashboard summary |
 


### PR DESCRIPTION
Closes #4101

## The bug

The single-alert **acknowledge** and **suppress** handlers carried the identical read-check-write shape the resolve paths had before #4083/#4099 introduced `buildResolveAlertCas`: read the alert's status, then `UPDATE ... WHERE id = $1` unconditionally. Two concurrent callers both clear the check and both write.

Per the issue's own review comment, the damage is worse than a double-acknowledge:

> Tech A resolves (CAS wins, `alert.resolved` published, escalation cancelled); tech B's stale list still shows it active and B clicks Acknowledge — B's id-only UPDATE stamps `status='acknowledged'` over the resolution, producing a reopened alert with `resolvedAt`/`resolvedBy` populated and its escalation already cancelled.

Suppress has the same shape: a stale suppress landing on a just-resolved alert un-resolves it.

## The fix — reusing the resolve-side pattern, not inventing a second one

Two new status lists and two new predicate builders sit beside `buildResolveAlertCas` in `apps/api/src/services/alertService.ts`. All three now funnel through one private `buildAlertStatusCas`, so the CAS **shape** has a single definition and cannot change on one transition while missing the other two — the exact drift the existing `buildResolveAlertCas` docblock warns about.

| Constant | Value | Why |
|---|---|---|
| `ACKNOWLEDGEABLE_ALERT_STATUSES` | `['active']` | Every ack call site already refuses a non-active alert at its pre-read; the CAS is that same rule expressed where it is enforceable |
| `SUPPRESSIBLE_ALERT_STATUSES` | `['active','acknowledged','suppressed']` | Everything except the two terminal statuses. `suppressed` stays in the set on purpose — re-timing an existing mute is legitimate, unlike re-acknowledging |

`SUPPRESSIBLE_*` is textually identical to `RESOLVABLE_*` today and is kept a **separate** constant anyway: the two express different invariants and must be free to diverge when a status is added. Aliasing them would make a future non-terminal status silently inherit both answers.

## Call sites — enumerated and verified, not trusted

The issue said five. I enumerated `status: 'acknowledged'` / `status: 'suppressed'` writes across `apps/api/src` and `ee/` and confirmed it: **five single-alert sites were racy, two multi-row sites were already correct.**

**Fixed (5):**

| # | File | Handler | Was |
|---|---|---|---|
| 1 | `apps/api/src/routes/alerts/alerts.ts` | `POST /alerts/:id/acknowledge` | `.where(eq(alerts.id, alertId))` |
| 2 | `apps/api/src/routes/alerts/alerts.ts` | `POST /alerts/:id/suppress` | `.where(eq(alerts.id, alertId))` |
| 3 | `apps/api/src/routes/mobile.ts` | `POST /mobile/alerts/:id/acknowledge` | `.where(eq(alerts.id, alertId))`, **and never read `RETURNING`** |
| 4 | `apps/api/src/services/aiToolsAlerts.ts` | `manage_alerts { action: 'acknowledge' }` | `.where(eq(alerts.id, ...))`, **no `RETURNING` at all** |
| 5 | `apps/api/src/services/aiToolsAlerts.ts` | `manage_alerts { action: 'suppress' }` | `.where(eq(alerts.id, ...))`, **no `RETURNING` at all** |

**Already correct — verified, left unchanged (2):** both write many rows and need `inArray(alerts.id, ...)` rather than an id equality, so they compose the status predicate directly:

- `routes/alerts/alerts.ts` bulk action — stricter still, pins each row to `eq(alerts.status, alert.status)` from its snapshot.
- `routes/alerts/correlations.ts` `mutateAlerts` — `eq(alerts.status, 'active')` for acknowledge.

## Silent failures fixed along the way

- **`routes/mobile.ts`** never looked at the UPDATE's `RETURNING` (`updated?.id ?? alertId`). A write matching zero rows — a lost race, *or a row invisible to this tenant context, which raises no error under `breeze_app` RLS* — still published `alert.acknowledged`, still fed the ML feedback loop, still wrote an audit entry, and still answered **200 with a `null` body**.
- **Both AI-tool branches** requested no `RETURNING` and returned `success: true` unconditionally.

## Response codes

- CAS loser → **409** with a message that states only what the code can verify (never "another request acknowledged it" — an empty `RETURNING` is also what an RLS-invisible write produces).
- `acknowledged` at the pre-read → **409** (was 400). Losing at the read and losing at the write are the same real-world event, so they must not return two codes purely on timing. **#4099 made exactly this change for resolve** (`git log -S` confirms the 400 → 409 flip landed in `1c59bb687`).
- `resolved` / `dismissed` at the pre-read → stays **400** (illegal transition, not a race), matching resolve's treatment of `dismissed`.
- No client depends on the old codes: `AlertsPage.tsx` / `AlertDetailPage.tsx` apply their optimistic update *after* `runAction` resolves, so a 409 skips it and toasts. The removed `'Failed to acknowledge alert'` / `'Failed to suppress alert'` 500 strings had zero references repo-wide.

## Tests — written red first

**20 of 31 new assertions failed against the unpatched source**, including the ones that matter most: the mobile route publishing `alert.acknowledged` on a zero-row write, both AI-tool branches reporting `success: true`, and every compiled-SQL assertion (main's predicate has no status term at all).

Four suites, mirroring the four established `*.resolveCas.test.ts` files. Each asserts **both**:

- **Behaviour** — an empty `RETURNING` (exactly what Postgres gives a caller whose CAS matched nothing) must produce the conflict and **no** fan-out: no event, no ML feedback, no audit.
- **Compiled SQL** — the predicate the handler *actually passed* to `.where()`, compiled through `PgDialect`. A mocked-drizzle assertion that substring-matches column names cannot tell `and` from `or` (which would stamp every matching alert in **every** tenant from one request) and cannot see the status list gaining a value that makes the CAS a no-op.

> **Concurrency disclosure:** these are compiled-SQL + lost-race-behaviour assertions, **not** two genuinely concurrent transactions against real Postgres. The unit job has no database. The predicate is what makes the write atomic in Postgres, and these tests pin both the predicate and the handler's response to losing.

`alertService.ackCasSql.test.ts` additionally derives its expectations from the `alert_status` **enum**, so adding a status forces a deliberate classification instead of silently inheriting one list's answer.

New files:
- `apps/api/src/services/alertService.ackCasSql.test.ts`
- `apps/api/src/routes/alerts/alerts.ackSuppressCas.test.ts`
- `apps/api/src/routes/mobile.ackCas.test.ts`
- `apps/api/src/services/aiToolsAlerts.ackSuppressCas.test.ts`

## Verification

- New suites: **31 passed** (4 files).
- Regression, single-fork: `alerts.test.ts`, `alerts.resolveCas.test.ts`, `alerts.authz.test.ts`, `correlations.test.ts`, `correlations.resolveCas.test.ts` → **98 passed**; `mobile.test.ts`, `mobile.resolveCas.test.ts`, `mobile.cursor.test.ts` → **80 passed / 3 skipped**; nine `alertService.*` / `aiToolsAlerts.*` / `warrantyAlertEvaluator.resolveCas` suites → **55 passed**.
- `eslint` on all eight touched files: clean.
- No schema, migration, or tenancy-table change — no RLS or cascade-registration surface touched.

## Docs

`apps/docs/src/content/docs/reference/api.mdx` now records the 409-on-conflict contract for acknowledge/resolve/suppress (web + mobile), which #4099 introduced for resolve but never documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)