### PR TITLE
docs(ai-agents): document the ticket-helpdesk and anomaly trigger lanes (#4213)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -552,8 +552,8 @@ GRAFANA_ADMIN_PASSWORD=changeme
 # ABUSE_SCRIPT_INDICATORS={"tlds": [], "hosts": []}
 # Durable event dispatch (wave 3.5c, #4085).
 #
-# Governs how events (automation triggers, DNS threat alerts, notifications,
-# policy alerts, webhook deliveries) are handed to their subscribers:
+# Governs how events (AI agent and automation triggers, DNS threat alerts,
+# notifications, policy alerts, webhook deliveries) reach their subscribers:
 #   off     - today's behavior: in-process delivery only (default).
 #   shadow  - mirror routing plans into event_delivery_receipts for
 #             observability, but still execute nothing via the queue.
@@ -568,9 +568,11 @@ GRAFANA_ADMIN_PASSWORD=changeme
 #
 # Comma-separated subscriber ids to route via the queue when
 # EVENT_DISPATCH_MODE=enforce (ignored otherwise). Known ids are declared in
-# services/eventSubscriberIds.ts: automation-worker, dns-threat-alerts,
+# services/eventSubscriberIds.ts: ai-agent-alert-verdict, ai-agent-anomaly,
+# ai-agent-ticket-helpdesk, automation-worker, dns-threat-alerts,
 # notification-dispatcher, policy-alert-bridge, webhook-delivery. Unknown ids
-# are rejected at boot.
+# are rejected at boot. Naming a subscriber selects durable queue delivery;
+# it does not enable or disable the feature behind that subscriber.
 # EVENT_DISPATCH_QUEUE_SUBSCRIBERS=webhook-delivery,notification-dispatcher
 
 # Process role for the 3.5d socket/worker split (wave 3.5b, #4084; compose

--- a/apps/docs/src/content/docs/deploy/environment.mdx
+++ b/apps/docs/src/content/docs/deploy/environment.mdx
@@ -413,6 +413,17 @@ with its own rollout gate. See [Rollout Modes](/deploy/rollout-modes/).
   If you do not want Workspace, leave `BREEZE_WORKSPACE_ENABLED` unset — no extension is needed and nothing else changes.
 </Aside>
 
+## Durable event dispatch
+
+Event dispatch settings select how a subscriber receives events. They do not enable or disable the feature behind that subscriber. For example, the ticket-helpdesk and anomaly agent lanes still run in-process with the default `off` mode. See [AI Agents](/features/ai-agents/) for lane requirements and durable trigger guidance.
+
+| Variable | Default | Description |
+|---|---|---|
+| `EVENT_DISPATCH_MODE` | `off` | Accepts `off`, `shadow`, or `enforce`. `off` uses in-process delivery only. `shadow` also mirrors routing plans into delivery receipts for observability but executes nothing through the queue. `enforce` sends each named subscriber through the BullMQ queue only, skips its in-process delivery, and leaves unnamed subscribers in-process. |
+| `EVENT_DISPATCH_QUEUE_SUBSCRIBERS` | Empty | Comma-separated subscriber IDs used only when the mode is `enforce`: `ai-agent-alert-verdict`, `ai-agent-anomaly`, `ai-agent-ticket-helpdesk`, `automation-worker`, `dns-threat-alerts`, `notification-dispatcher`, `policy-alert-bridge`, `webhook-delivery`. An empty list is accepted but leaves everything in-process and produces a boot warning. The variable is ignored in other modes. |
+
+Both variables are validated when the API starts. An invalid mode or an unknown subscriber ID stops the API from starting and identifies the invalid value. As with other API settings, map each variable in the `api` service's `environment:` block of your compose file as well as setting it in `.env`.
+
 ## MCP Server
 
 | Variable | Default | Description |

--- a/apps/docs/src/content/docs/deploy/environment.mdx
+++ b/apps/docs/src/content/docs/deploy/environment.mdx
@@ -420,7 +420,7 @@ Event dispatch settings select how a subscriber receives events. They do not ena
 | Variable | Default | Description |
 |---|---|---|
 | `EVENT_DISPATCH_MODE` | `off` | Accepts `off`, `shadow`, or `enforce`. `off` uses in-process delivery only. `shadow` also mirrors routing plans into delivery receipts for observability but executes nothing through the queue. `enforce` sends each named subscriber through the BullMQ queue only, skips its in-process delivery, and leaves unnamed subscribers in-process. |
-| `EVENT_DISPATCH_QUEUE_SUBSCRIBERS` | Empty | Comma-separated subscriber IDs used only when the mode is `enforce`: `ai-agent-alert-verdict`, `ai-agent-anomaly`, `ai-agent-ticket-helpdesk`, `automation-worker`, `dns-threat-alerts`, `notification-dispatcher`, `policy-alert-bridge`, `webhook-delivery`. An empty list is accepted but leaves everything in-process and produces a boot warning. The variable is ignored in other modes. |
+| `EVENT_DISPATCH_QUEUE_SUBSCRIBERS` | — | Comma-separated subscriber IDs used only when the mode is `enforce`: `ai-agent-alert-verdict`, `ai-agent-anomaly`, `ai-agent-ticket-helpdesk`, `automation-worker`, `dns-threat-alerts`, `notification-dispatcher`, `policy-alert-bridge`, `webhook-delivery`. An empty list is accepted but leaves everything in-process and produces a boot warning. The variable is ignored in other modes. |
 
 Both variables are validated when the API starts. An invalid mode or an unknown subscriber ID stops the API from starting and identifies the invalid value. As with other API settings, map each variable in the `api` service's `environment:` block of your compose file as well as setting it in `.env`.
 

--- a/apps/docs/src/content/docs/features/ai-agents.mdx
+++ b/apps/docs/src/content/docs/features/ai-agents.mdx
@@ -40,7 +40,7 @@ Runs are triggered by an **alert**, an **anomaly**, a **schedule**, a **ticket**
 | `failed` | Stopped on an error. |
 | `cancelled` | Stopped by a person. |
 | `expired` | Exceeded its wall-clock budget. |
-| `skipped` | A run record was created but did not execute. |
+| `skipped` | A run record was created but stopped before executing, for example when the agent's policy was revoked between admission and start. |
 
 Admission checks happen before Breeze creates a run. If an agent policy filters out a trigger, no `skipped` run appears in the runs list. See [Why nothing happened](#why-nothing-happened) for the skip signals that are recorded instead.
 
@@ -118,13 +118,13 @@ If the underlying anomaly has already been promoted to an alert, the anomaly run
 
 The **Settings → AI Agents** form exposes alert severities and the maintenance-window toggle, but it does not show an anomaly control. First list agents and identify the organization-scoped triage agent for the customer:
 
-```http
+```bash
 GET /api/v1/ai/agents
 ```
 
 Then patch only the anomaly opt-in:
 
-```http
+```bash
 PATCH /api/v1/ai/agents/{agentId}
 Content-Type: application/json
 
@@ -137,7 +137,7 @@ The server merges the `triggers` object one level onto the stored policy. Fields
 
 Verify the effective policy for the organization:
 
-```http
+```bash
 GET /api/v1/ai/agents/effective?orgId={orgId}&kind=triage
 ```
 
@@ -145,13 +145,17 @@ Confirm that `triggers.anomalyEnabled` is `true` in the response.
 
 ## Why nothing happened
 
-When admission is refused, Breeze does not create a run row, so nothing new appears in the runs list. The API writes a `run skipped` log line with the reason, organization, agent, trigger kind, and device. It also publishes an `ai.agent.run.skipped` event.
+When admission is refused, Breeze does not create a run row, so nothing new appears in the runs list. The API always writes a `run skipped` log line carrying the reason, organization, agent, trigger kind, and device.
 
-| Skip reason | Meaning |
-|---|---|
-| `trigger_filter_mismatch` | The anomaly opt-in gate or a narrowing trigger filter did not match. |
-| `no_effective_agent` | The required partner baseline does not exist. |
-| `kill_switch_off` | `BREEZE_AI_AGENTS_ENABLED` is off. |
+| Skip reason | Meaning | Also published as an event |
+|---|---|---|
+| `trigger_filter_mismatch` | The anomaly opt-in gate or a narrowing trigger filter did not match. | Yes |
+| `no_effective_agent` | No enabled partner baseline agent of that kind exists. | No, log only |
+| `kill_switch_off` | `BREEZE_AI_AGENTS_ENABLED` is off. | No, log only |
+
+Only a skip that happens *after* the agent has been resolved publishes an `ai.agent.run.skipped` event. `kill_switch_off` and `no_effective_agent` are deliberately log-only: they fire on every trigger in every organization for as long as the condition holds, so publishing them would put a write on the hot alert path for a non-event. If you want to catch those two, alert on the log line rather than the event.
+
+A run that was already admitted can also stop before it starts. If the agent is disabled or its policy is revoked between admission and delivery, the run transitions to `skipped` with the reason `policy_revoked_before_start` and publishes `ai.agent.run.skipped`. Unlike the admission-time skips above, that case does leave a run record in the runs list.
 
 ## Durable delivery for agent triggers
 

--- a/apps/docs/src/content/docs/features/ai-agents.mdx
+++ b/apps/docs/src/content/docs/features/ai-agents.mdx
@@ -1,11 +1,11 @@
 ---
 title: AI Agents
-description: Configure an AI agent that triages alerts, records what it did, and proposes actions for a human to approve.
+description: Configure permission-scoped AI agents and review their recorded runs and proposed actions.
 ---
 
 import { Steps, Aside } from '@astrojs/starlight/components';
 
-An AI agent is a named, permission-scoped worker you configure once. It wakes on a trigger, gathers context from the devices it is allowed to see, and writes up what it found. Every run is recorded, and anything the agent wants to *do* is proposed for a person to approve.
+An AI agent is a named, permission-scoped worker you configure once. It wakes on a trigger, gathers the context available for that trigger, and writes up what it found. Every run is recorded, and anything the agent wants to *do* is proposed for a person to approve.
 
 Agents are off by default and must be enabled by your operator before they appear. See [Enabling agents](#enabling-agents).
 
@@ -17,7 +17,7 @@ Agents are off by default and must be enabled by your operator before they appea
 
 Manage agents under **Settings → AI Agents**.
 
-An agent has a **kind**, which decides what it is for and what triggers it. Triage agents run against alerts: when an alert fires, the agent reads the device, its recent history, and related signals, then records its assessment on the run.
+An agent has a **kind**: `triage`, `patch`, or `helpdesk`. The kind decides what the agent is for and what triggers it. Triage agents accept alerts and opted-in anomaly incidents. Helpdesk agents accept newly created tickets.
 
 Each agent carries its own limits — devices per run, concurrent runs, runs per hour, turns per run, spend per run and per day, wall-clock time, and a ceiling on the percentage of your fleet it may touch in a day. These are enforced per run, not advisory.
 
@@ -27,9 +27,9 @@ Each agent carries its own limits — devices per run, concurrent runs, runs per
 
 ## Runs
 
-Every time an agent wakes, it opens a **run**. The run is the audit surface: open it to see what triggered the agent, which devices it looked at, and what it concluded.
+When a trigger passes admission, the agent opens a **run**. The run is the audit surface: open it to see what triggered the agent, which devices it looked at, and what it concluded.
 
-Runs are triggered by an **alert**, by a **schedule**, by a **ticket**, or **manually** from the agent itself. A run moves through these states:
+Runs are triggered by an **alert**, an **anomaly**, a **schedule**, a **ticket**, or **manually** from the agent itself. A run moves through these states:
 
 | Status | Meaning |
 |---|---|
@@ -40,9 +40,9 @@ Runs are triggered by an **alert**, by a **schedule**, by a **ticket**, or **man
 | `failed` | Stopped on an error. |
 | `cancelled` | Stopped by a person. |
 | `expired` | Exceeded its wall-clock budget. |
-| `skipped` | Did not run — for example, the agent's own policy filtered the trigger out. |
+| `skipped` | A run record was created but did not execute. |
 
-A run that ends in `skipped` tells you the agent was reached but declined the work, which is different from never having been triggered at all.
+Admission checks happen before Breeze creates a run. If an agent policy filters out a trigger, no `skipped` run appears in the runs list. See [Why nothing happened](#why-nothing-happened) for the skip signals that are recorded instead.
 
 ## Approving what an agent proposes
 
@@ -76,6 +76,98 @@ Creating a triage agent automatically creates a matching **system-managed automa
 </Aside>
 
 Disabling the agent disables its wiring too, so an agent that is switched off never gets live alerts routed in front of it.
+
+## Ticket helpdesk lane
+
+A newly created ticket can wake a helpdesk agent when all of these conditions are met:
+
+- `BREEZE_AI_AGENTS_ENABLED=true`.
+- An enabled partner-level baseline agent of kind `helpdesk` exists. An organization-level agent cannot enable itself without this baseline.
+- The effective policy is enabled for both the partner and the organization, and its mode is not Off.
+- The ticket matches the optional `triggers.ticketCategories` and `triggers.ticketPriorities` filters. An absent filter is unrestricted.
+
+Every ticket creation is written to a transactional outbox. A background publisher drains the outbox onto the event bus approximately every five seconds, so you do not need a separate ticket trigger flag.
+
+Ticket-triggered runs are always forced into Shadow mode, regardless of the agent's configured mode. They have no device context, so device-changing tools are denied outright.
+
+Only ticket creation admits a helpdesk run in this release. Ticket comments and status changes are published on the event bus, but this lane does not read them yet. A ticket that already has agent-originated comment activity is also rejected to prevent a loop.
+
+## Anomaly lane
+
+A newly opened anomaly incident can wake a triage agent when all of these conditions are met:
+
+- `BREEZE_AI_AGENTS_ENABLED=true`.
+- Anomaly Detection is enabled for the organization through `ml.anomalies.enabled`. It is off by default, and the global ML kill switches can still suppress it. See [Availability and enabling](/features/ml-insights/#availability-and-enabling).
+- An enabled partner-level baseline agent of kind `triage` exists. Triage is the only agent kind that accepts anomaly triggers.
+- The organization-level triage agent sets `triggers.anomalyEnabled` to `true`. Its default is `false`.
+- The optional narrowing filters match the incident.
+
+The detector collapses raw anomalies into a canonical incident. A background publisher sends each newly opened incident to the event bus, so you do not need another anomaly event flag.
+
+<Aside type="caution" title="Opt in each organization, not the partner baseline">
+  Set `triggers.anomalyEnabled` on the **organization-level** triage agent. Breeze never reads this value from the partner baseline. Setting it on the partner baseline does nothing and produces no error or warning, while an organization with no override row always resolves to off. This prevents a partner from opting every downstream organization into an unproven detector with one setting.
+</Aside>
+
+Anomaly-triggered runs are always forced into Shadow mode. They are bound to a device, so device pinning, site scope, and maintenance-window rules still apply normally.
+
+You can narrow admission with `triggers.anomalyTypes`, `triggers.metricNames`, `triggers.minAnomalyScore`, and the usual site and device-tag filters. An absent filter is unrestricted. These filters cannot opt the lane in; `triggers.anomalyEnabled` is still required.
+
+If the underlying anomaly has already been promoted to an alert, the anomaly run reuses the alert's deduplication key. One incident therefore does not produce both an anomaly run and a separate alert-triage run.
+
+### Opt in through the API
+
+The **Settings → AI Agents** form exposes alert severities and the maintenance-window toggle, but it does not show an anomaly control. First list agents and identify the organization-scoped triage agent for the customer:
+
+```http
+GET /api/v1/ai/agents
+```
+
+Then patch only the anomaly opt-in:
+
+```http
+PATCH /api/v1/ai/agents/{agentId}
+Content-Type: application/json
+
+{"triggers": {"anomalyEnabled": true}}
+```
+
+`{agentId}` must identify the organization-scoped agent, not the partner baseline. The request requires the `ai_agents:write` permission and a completed MFA step, as do other agent mutations.
+
+The server merges the `triggers` object one level onto the stored policy. Fields you omit keep their values, and later edits in the UI do not clear `anomalyEnabled` because the form submits only its own trigger fields.
+
+Verify the effective policy for the organization:
+
+```http
+GET /api/v1/ai/agents/effective?orgId={orgId}&kind=triage
+```
+
+Confirm that `triggers.anomalyEnabled` is `true` in the response.
+
+## Why nothing happened
+
+When admission is refused, Breeze does not create a run row, so nothing new appears in the runs list. The API writes a `run skipped` log line with the reason, organization, agent, trigger kind, and device. It also publishes an `ai.agent.run.skipped` event.
+
+| Skip reason | Meaning |
+|---|---|
+| `trigger_filter_mismatch` | The anomaly opt-in gate or a narrowing trigger filter did not match. |
+| `no_effective_agent` | The required partner baseline does not exist. |
+| `kill_switch_off` | `BREEZE_AI_AGENTS_ENABLED` is off. |
+
+## Durable delivery for agent triggers
+
+**The event dispatch settings do not enable or disable the ticket-helpdesk or anomaly lanes.** Both subscribers are registered when the API starts, and both lanes still run in-process when `EVENT_DISPATCH_MODE` is unset or `off`. Naming a subscriber changes the durability of its delivery hop, not whether the feature runs.
+
+In-process delivery is best-effort. If a handler throws, Breeze writes the failure only to the API log, swallows it, and loses the trigger. Queue delivery leaves a delivery receipt and retries a failed hop. The `ai-agent-ticket-helpdesk` and `ai-agent-anomaly` subscribers each retry up to five times with a 10-second backoff. `ai-agent-alert-verdict` retries up to three times with a 30-second backoff.
+
+| `EVENT_DISPATCH_MODE` | Delivery behavior |
+|---|---|
+| `off` | In-process delivery only. This is the default when the variable is unset. |
+| `shadow` | Also mirrors the routing plan into delivery receipts for observability, but executes nothing through the queue. |
+| `enforce` | Routes named subscribers only through the BullMQ queue and skips their in-process delivery. Subscribers that are not named continue in-process. |
+
+`EVENT_DISPATCH_QUEUE_SUBSCRIBERS` is ignored unless the mode is `enforce`. To make these trigger hops durable, set the mode to `enforce` and name `ai-agent-ticket-helpdesk` and/or `ai-agent-anomaly`. An empty subscriber list is accepted, but everything remains in-process and the API logs a warning at boot.
+
+See [Environment Variables](/deploy/environment/) for validation rules and the complete subscriber ID list.
 
 ## Enabling agents
 

--- a/apps/docs/src/content/docs/features/ml-insights.mdx
+++ b/apps/docs/src/content/docs/features/ml-insights.mdx
@@ -122,6 +122,8 @@ If Remediation Suggestions is enabled, each open anomaly also shows a **Suggeste
   When the **Anomalies** tab shows "Anomaly detection is disabled for this organization," the `ml.anomalies.enabled` flag is off for that organization. Enable it as described in [Availability and enabling](#availability-and-enabling).
 </Aside>
 
+A newly opened anomaly incident can also wake an AI triage agent. This is off unless that organization's triage agent is explicitly opted in. Anomaly-triggered runs are forced into Shadow mode, so they only observe and report. See [AI Agents](/features/ai-agents/#anomaly-lane) for the opt-in procedure and agent requirements.
+
 ---
 
 ## Alert Correlation and Root Cause Analysis


### PR DESCRIPTION
Closes #4213

## What was missing

Neither the ticket-helpdesk nor the anomaly agent lane was documented anywhere. Worse, the one enumeration an operator would actually find — `.env.example`'s "Known ids are declared in `services/eventSubscriberIds.ts`" comment — was **stale**: it listed five subscriber ids and omitted all three `ai-agent-*` ids, so anyone reading it would conclude `ai-agent-ticket-helpdesk` and `ai-agent-anomaly` did not exist.

## The issue's premise needed correcting, not transcribing

The issue says the two ids "must be added to `EVENT_DISPATCH_QUEUE_SUBSCRIBERS` to enable each lane." Verified against the code, that is not what the flag does:

- `registerAllEventSubscribers()` registers **both subscribers unconditionally** at boot.
- `partitionSubscribersForEvent()` only splits matched subscribers into local vs. queue, and only when `EVENT_DISPATCH_MODE=enforce`.
- With the default `EVENT_DISPATCH_MODE=off`, **both lanes still run**, in-process.

So the flag is a **transport/durability selector, not an enablement gate**. What naming an id buys is BullMQ retry (`ai-agent-ticket-helpdesk` and `ai-agent-anomaly`: 5 attempts / 10s backoff; `ai-agent-alert-verdict`: 3 / 30s) plus an `event_delivery_receipts` row, in place of in-process delivery where `invokeLocalHandlers` swallows handler failures and only logs them. The docs lead with that correction so a reader coming from the issue title cannot come away with the wrong model.

The **actual** anomaly gate is per-agent `triggers.anomalyEnabled`, and its merge rule is deliberately unlike every other policy field: `mergeAgentPolicies` reads **only the organization row's own value** and never consults the partner baseline in either direction. Setting it on a partner-wide baseline therefore does nothing — no error, no warning, no runs. That is the single most likely misconfiguration and it gets a caution callout.

## Verified value lists

`EVENT_SUBSCRIBER_IDS` — exactly eight, unknown ids are a hard boot refusal:

`ai-agent-alert-verdict`, `ai-agent-anomaly`, `ai-agent-ticket-helpdesk`, `automation-worker`, `dns-threat-alerts`, `notification-dispatcher`, `policy-alert-bridge`, `webhook-delivery`

`EVENT_DISPATCH_MODE` — `off` (default) | `shadow` | `enforce`; anything else is a hard boot refusal.

## Changes

| File | Change |
|---|---|
| `features/ai-agents.mdx` | Ticket-helpdesk lane, anomaly lane, partner-baseline caution, the `PATCH /api/v1/ai/agents/{id}` opt-in recipe + `GET /ai/agents/effective` verification, a "why nothing happened" skip-reason table, and durable delivery. Also fixes two pre-existing stale statements: the trigger list omitted **anomaly**, and the agent kinds were never named (`triage`, `patch`, `helpdesk`). |
| `deploy/environment.mdx` | New **Durable event dispatch** section with both variables and all eight ids. |
| `features/ml-insights.mdx` | Cross-link from Anomaly Detection to the lane and its opt-in. |
| `.env.example` | Full eight-id list; adds a line stating that naming a subscriber selects durable delivery rather than enabling the feature behind it. |

Docs only — no source file is touched. In particular this deliberately does **not** edit `services/eventDispatchQueue.ts` (#4238) or `jobs/eventDispatchWorker.ts` (#4244); both are read and cited, not modified.

## Verification

- `pnpm --filter @breeze/docs check` — 0 errors, 0 warnings, 0 hints
- `pnpm --filter @breeze/docs build` — 167 pages built, clean
- `pnpm test:docs-automation` — 5/5 pass
- `vitest run src/config/envComposeParity.test.ts src/db/bootstrapDocs.test.ts` — 16/16 pass (these parse `.env.example`; the edit is comment-only so documented-variable parity is unchanged)
- `vitest run src/config/validate.test.ts src/config/env.eventDispatch.test.ts` — 365/365 pass
- Every cited `docs.breezermm.com` URL curled for a 200 before use

`.env.example` is not in `ci.yml`'s `paths-ignore`, so this PR runs full CI rather than **Docs CI** alone. That is intended — the stale id list is the thing an operator would actually have read.

## Follow-up found while working, deliberately NOT fixed here

`features/ai-agents.mdx` still carries a caution reading *"The only modes accepted today are Off and Shadow ... Autonomous execution is a later release."* That is now **stale**: `SUPPORTED_AGENT_MODES` is `['off', 'shadow', 'act']` and the web form renders a selectable `act` option gated on `assertActPrerequisites`. Correcting it means documenting act mode properly (prerequisites, exposure caps, the approval path), which is its own docs task and well outside #4213. Nothing added here contradicts the aside — both new lanes force `shadow` regardless of configured mode — but it should be filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)