### PR TITLE
fix(web): stop a deferred prop-sync effect from discarding an invoice notes edit (#3277)

### DIFF
--- a/apps/web/src/components/billing/InvoiceEditor.test.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.test.tsx
@@ -472,12 +472,14 @@ describe('InvoiceEditor', () => {
   // never saw and overwrite it with the pre-edit value, silently clearing the
   // dirty flag; `saveNotes`/`saveTerms` then short-circuit on `!dirty` and no
   // PATCH is sent at all. That is what made the InvoiceWorkspace queued-Issue
-  // tests flaky for six weeks across #2925/#3219/#3277/#3980/#4033.
+  // tests flaky, filed five times from 2026-07-29 on, across
+  // #2925/#3219/#3277/#3980/#4033.
   //
   // The ordering hazard itself is only reachable by out-racing React's
   // scheduler, so these cases pin the observable contract instead: a re-render
   // whose server value is UNCHANGED after normalisation must never touch the
-  // draft, and one whose server value genuinely changed must replace it. The
+  // draft — and must leave it SAVEABLE, which is the part that actually broke —
+  // while one whose server value genuinely changed must replace it. The
   // null → '' case is the deterministic discriminator — the old
   // `useEffect(..., [invoice.notes])` compared the RAW prop, so that round-trip
   // re-ran the effect and discarded the draft.
@@ -493,6 +495,18 @@ describe('InvoiceEditor', () => {
       // Nothing the user cares about changed, so the draft must survive.
       rerender(<InvoiceEditor detail={draft([manualLine], { notes: '' })} onChanged={vi.fn()} />);
       expect(screen.getByTestId('invoice-notes')).toHaveValue('Half-typed note');
+
+      // …and it must still be SAVEABLE. The visible text is only a proxy: the
+      // damage in #3277 was the silently-cleared `notesDirty`, which makes
+      // `saveNotes()` short-circuit so the blur sends nothing at all. Asserting
+      // the text alone would pass for a regression that clears the flag without
+      // touching the value, which is the same silent data loss wearing a
+      // different hat — so assert the PATCH actually goes out.
+      fireEvent.blur(screen.getByTestId('invoice-notes'));
+      await waitFor(() => expect(fetchMock.mock.calls.some(
+        (c) => (c[1] as RequestInit)?.method === 'PATCH'
+          && String((c[1] as RequestInit)?.body).includes('Half-typed note'),
+      )).toBe(true));
     });
 
     it('keeps a dirty terms draft across the same null → "" round-trip', async () => {
@@ -504,6 +518,14 @@ describe('InvoiceEditor', () => {
 
       rerender(<InvoiceEditor detail={draft([manualLine], { termsAndConditions: '' })} onChanged={vi.fn()} />);
       expect(screen.getByTestId('invoice-terms')).toHaveValue('Net 15');
+
+      // Same reason as the notes case: prove the edit is still saveable, not
+      // merely still visible.
+      fireEvent.blur(screen.getByTestId('invoice-terms'));
+      await waitFor(() => expect(fetchMock.mock.calls.some(
+        (c) => (c[1] as RequestInit)?.method === 'PATCH'
+          && String((c[1] as RequestInit)?.body).includes('Net 15'),
+      )).toBe(true));
     });
 
     it('DOES replace the draft when the server value genuinely changes', async () => {

--- a/apps/web/src/components/billing/InvoiceEditor.test.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.test.tsx
@@ -466,4 +466,58 @@ describe('InvoiceEditor', () => {
     expect(price).toHaveTextContent('420.00');
     expect(price).not.toHaveTextContent('500');
   });
+
+  // #3277 — the free-text fields re-sync from the server value DURING RENDER,
+  // not from a `useEffect`. A deferred effect can flush AFTER a keystroke it
+  // never saw and overwrite it with the pre-edit value, silently clearing the
+  // dirty flag; `saveNotes`/`saveTerms` then short-circuit on `!dirty` and no
+  // PATCH is sent at all. That is what made the InvoiceWorkspace queued-Issue
+  // tests flaky for six weeks across #2925/#3219/#3277/#3980/#4033.
+  //
+  // The ordering hazard itself is only reachable by out-racing React's
+  // scheduler, so these cases pin the observable contract instead: a re-render
+  // whose server value is UNCHANGED after normalisation must never touch the
+  // draft, and one whose server value genuinely changed must replace it. The
+  // null → '' case is the deterministic discriminator — the old
+  // `useEffect(..., [invoice.notes])` compared the RAW prop, so that round-trip
+  // re-ran the effect and discarded the draft.
+  describe('server value re-sync', () => {
+    it('keeps a dirty notes draft when a refetch reports the same value under a different raw form (null → "")', async () => {
+      const { rerender } = render(<InvoiceEditor detail={draft([manualLine], { notes: null })} onChanged={vi.fn()} />);
+      await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
+
+      fireEvent.change(screen.getByTestId('invoice-notes'), { target: { value: 'Half-typed note' } });
+      expect(screen.getByTestId('invoice-notes')).toHaveValue('Half-typed note');
+
+      // A quiet refetch lands carrying '' where the previous payload had null.
+      // Nothing the user cares about changed, so the draft must survive.
+      rerender(<InvoiceEditor detail={draft([manualLine], { notes: '' })} onChanged={vi.fn()} />);
+      expect(screen.getByTestId('invoice-notes')).toHaveValue('Half-typed note');
+    });
+
+    it('keeps a dirty terms draft across the same null → "" round-trip', async () => {
+      const { rerender } = render(<InvoiceEditor detail={draft([manualLine], { termsAndConditions: null })} onChanged={vi.fn()} />);
+      await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
+
+      fireEvent.change(screen.getByTestId('invoice-terms'), { target: { value: 'Net 15' } });
+      expect(screen.getByTestId('invoice-terms')).toHaveValue('Net 15');
+
+      rerender(<InvoiceEditor detail={draft([manualLine], { termsAndConditions: '' })} onChanged={vi.fn()} />);
+      expect(screen.getByTestId('invoice-terms')).toHaveValue('Net 15');
+    });
+
+    it('DOES replace the draft when the server value genuinely changes', async () => {
+      const { rerender } = render(<InvoiceEditor detail={draft([manualLine], { notes: 'Original' })} onChanged={vi.fn()} />);
+      await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
+      expect(screen.getByTestId('invoice-notes')).toHaveValue('Original');
+
+      fireEvent.change(screen.getByTestId('invoice-notes'), { target: { value: 'Local draft' } });
+      expect(screen.getByTestId('invoice-notes')).toHaveValue('Local draft');
+
+      // Someone else's edit arrived. The local draft is stale — replacing it is
+      // the deliberate behaviour this fix preserves, not a regression.
+      rerender(<InvoiceEditor detail={draft([manualLine], { notes: 'Updated on the server' })} onChanged={vi.fn()} />);
+      expect(screen.getByTestId('invoice-notes')).toHaveValue('Updated on the server');
+    });
+  });
 });

--- a/apps/web/src/components/billing/InvoiceEditor.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.tsx
@@ -220,12 +220,13 @@ export default function InvoiceEditor({ detail, onChanged, onPendingEditsChange,
   // short-circuits on `!notesDirty`, the following blur then dispatches NO PATCH
   // at all: the edit is discarded with no request, no error and no "unsaved" cue.
   //
-  // That is what made the InvoiceWorkspace queued-Issue tests flaky for six weeks
-  // (#2925 → #3219 → #3277 → #3980 → #4033). Under load the passive-effect flush
-  // slipped past the commit that Testing Library was waiting on, the PATCH was
-  // never sent, so `savePending` never went true and `invoice-issue-saving-hint`
-  // never rendered — a condition that could never become true, which is why three
-  // successive rounds of raising the `waitFor` budget could not fix it.
+  // That is what made the InvoiceWorkspace queued-Issue tests flaky, filed five
+  // times from 2026-07-29 on (#2925 → #3219 → #3277 → #3980 → #4033). Under load
+  // the passive-effect flush slipped past the commit that Testing Library was
+  // waiting on, the PATCH was never sent, so `savePending` never went true and
+  // `invoice-issue-saving-hint` never rendered — a condition that could never
+  // become true, which is why both attempts to fix it by enlarging the timeout
+  // budget (#3284, #3956) could not hold.
   //
   // Evaluating the same condition during render removes the window entirely:
   // there is no deferred write that can land after a local edit, and the mount

--- a/apps/web/src/components/billing/InvoiceEditor.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.tsx
@@ -193,12 +193,58 @@ export default function InvoiceEditor({ detail, onChanged, onPendingEditsChange,
     [onSaveFailure],
   );
 
-  const [notes, setNotes] = useState(invoice.notes ?? '');
+  const serverNotes = invoice.notes ?? '';
+  const serverTerms = invoice.termsAndConditions ?? '';
+  const [notes, setNotes] = useState(serverNotes);
   const [notesDirty, setNotesDirty] = useState(false);
   const [notesSaved, flashNotesSaved] = useSavedFlash();
-  const [terms, setTerms] = useState(invoice.termsAndConditions ?? '');
+  const [terms, setTerms] = useState(serverTerms);
   const [termsDirty, setTermsDirty] = useState(false);
   const [termsSaved, flashTermsSaved] = useSavedFlash();
+
+  // Re-sync the free-text fields when the SERVER value changes — a refetch
+  // brought different notes/terms, so the local draft is stale and must be
+  // replaced. Derived DURING RENDER (React's documented "adjusting state when a
+  // prop changes" pattern) rather than from a `useEffect`, and that distinction
+  // is the entire fix for #3277.
+  //
+  // The previous shape was:
+  //   useEffect(() => { setNotes(invoice.notes ?? ''); setNotesDirty(false); }, [invoice.notes]);
+  // which ALSO ran once on mount, where it is normally a redundant no-op — the
+  // useState initialisers already hold the server value. But a passive effect is
+  // deferred: React commits the editor, and only schedules the effect flush for a
+  // later task. Anything that lands in between — a keystroke in the real app, a
+  // `fireEvent.change` in a test that awaited the commit — is applied FIRST, and
+  // then the stale mount effect flushes and overwrites it with the pre-edit
+  // server value, silently clearing `notesDirty` with it. Because `saveNotes()`
+  // short-circuits on `!notesDirty`, the following blur then dispatches NO PATCH
+  // at all: the edit is discarded with no request, no error and no "unsaved" cue.
+  //
+  // That is what made the InvoiceWorkspace queued-Issue tests flaky for six weeks
+  // (#2925 → #3219 → #3277 → #3980 → #4033). Under load the passive-effect flush
+  // slipped past the commit that Testing Library was waiting on, the PATCH was
+  // never sent, so `savePending` never went true and `invoice-issue-saving-hint`
+  // never rendered — a condition that could never become true, which is why three
+  // successive rounds of raising the `waitFor` budget could not fix it.
+  //
+  // Evaluating the same condition during render removes the window entirely:
+  // there is no deferred write that can land after a local edit, and the mount
+  // pass is a genuine no-op because the synced value starts equal to the server
+  // value. Comparing the NORMALISED strings additionally stops a null → ''
+  // round-trip from spuriously clobbering a draft, which the raw-prop dependency
+  // did not.
+  const [syncedServerNotes, setSyncedServerNotes] = useState(serverNotes);
+  if (syncedServerNotes !== serverNotes) {
+    setSyncedServerNotes(serverNotes);
+    setNotes(serverNotes);
+    setNotesDirty(false);
+  }
+  const [syncedServerTerms, setSyncedServerTerms] = useState(serverTerms);
+  if (syncedServerTerms !== serverTerms) {
+    setSyncedServerTerms(serverTerms);
+    setTerms(serverTerms);
+    setTermsDirty(false);
+  }
 
   // Per-line dirty fields, reported up from each LineRow. This MUST be lifted:
   // a line field whose save failed keeps its local value (nothing reverts it)
@@ -263,8 +309,8 @@ export default function InvoiceEditor({ detail, onChanged, onPendingEditsChange,
   const [picked, setPicked] = useState<CatalogItem | null>(null);
   const [pickQty, setPickQty] = useState('1');
 
-  useEffect(() => { setNotes(invoice.notes ?? ''); setNotesDirty(false); }, [invoice.notes]);
-  useEffect(() => { setTerms(invoice.termsAndConditions ?? ''); setTermsDirty(false); }, [invoice.termsAndConditions]);
+  // (notes/terms re-sync is derived during render — see the block by their
+  // useState declarations above. It must NOT move back into a useEffect: #3277.)
 
   // An empty catalog and a BROKEN catalog need different copy: rendering "No
   // catalog items — add in catalog" because the response failed to parse sends

--- a/apps/web/src/components/billing/InvoiceWorkspace.test.tsx
+++ b/apps/web/src/components/billing/InvoiceWorkspace.test.tsx
@@ -48,9 +48,9 @@ function invoice(over: Record<string, unknown>) {
   };
 }
 
-// #3277 — this file ran on a raised Testing Library `asyncUtilTimeout` (5000ms)
-// inside a raised per-test ceiling (15000ms) for six weeks. Both are gone, and
-// deliberately so: the diagnosis they were built on was wrong.
+// #3277 — this file ran on a raised Testing Library `asyncUtilTimeout` (5000ms,
+// added by #3284) inside a raised per-test ceiling (15000ms, added by #3956).
+// Both are gone, and deliberately so: the diagnosis they were built on was wrong.
 //
 // The theory was that the queued-Issue tests assert the end of a multi-hop
 // propagation chain (PATCH settles → editor reports → workspace clears
@@ -61,13 +61,19 @@ function invoice(over: Record<string, unknown>) {
 // `notesDirty`, so the following blur short-circuited and dispatched no PATCH at
 // all. `savePending` never went true, so `invoice-issue-saving-hint` could never
 // render — no timeout is large enough for a condition that never becomes true,
-// which is why raising it three times (#3284, #3956) never held and the flake
-// came back as #3980 and #4033.
+// which is why enlarging the budget twice — #3284 raised the `waitFor` timeout,
+// #3956 added the per-test ceiling above it — never held, and the flake came
+// back as #3980 and #4033.
 //
 // With the race removed at source the hint is present SYNCHRONOUSLY inside the
-// blur's own act() flush — measured present-before-any-poll on 200/200 runs
-// under load — so the default budget is not merely sufficient, it is unused.
-// Keeping the inflation would only buy a slower, less legible failure for every
+// blur's own act() flush, for a reason you can check by reading the code rather
+// than trusting this comment: `runScoped` marks the key pending BEFORE it awaits
+// the request, and `fetchWithAuth` is a bare `vi.fn()` here, so nothing suspends
+// before the commit. (That is also what a 200-iteration loaded-CPU harness
+// measured while the fix was being developed; the counts are recorded in PR
+// #4294 rather than asserted here, since the harness was not committed.)
+// The default budget is therefore not merely sufficient, it is unused, and
+// keeping the inflation would only buy a slower, less legible failure for every
 // genuine future breakage in this file.
 describe('InvoiceWorkspace', () => {
   beforeEach(() => {

--- a/apps/web/src/components/billing/InvoiceWorkspace.test.tsx
+++ b/apps/web/src/components/billing/InvoiceWorkspace.test.tsx
@@ -1,5 +1,5 @@
-import { configure, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import InvoiceWorkspace from './InvoiceWorkspace';
 import { _resetShowMarginMemoryForTests } from './billingUi';
@@ -48,48 +48,28 @@ function invoice(over: Record<string, unknown>) {
   };
 }
 
-// Testing Library's async budget, and the per-test ceiling it must fit inside.
-// The two expiring together is what made #3277's recurrence unreadable — see
-// the note inside the describe.
-const DEFAULT_ASYNC_UTIL_TIMEOUT_MS = 1000;
-const ASYNC_UTIL_TIMEOUT_MS = 5000;
-const TEST_TIMEOUT_MS = 15000;
-
-describe('InvoiceWorkspace', { timeout: TEST_TIMEOUT_MS }, () => {
-  // #3219 — the queued-Issue tests assert the END of a multi-hop propagation
-  // chain: the PATCH promise settles → the editor reports saved/failed → the
-  // workspace clears `savePending` → the header un-gates → the queued Issue
-  // fires a fetch. Every hop is promise/render scheduling, so under CI load the
-  // whole chain can outrun Testing Library's 1000ms default `waitFor` timeout.
-  //
-  // That is exactly what the three recorded sightings look like: #2925, this
-  // issue, and #3277 all failed at ~1038ms, i.e. a fraction over the default,
-  // and all passed on a same-commit rerun and locally.
-  //
-  // Fake timers are the wrong instrument here despite being the usual reflex —
-  // nothing in this chain is timer-driven. The delay is promise microtasks plus
-  // React render scheduling, which fake timers do not advance, so they would add
-  // machinery without touching the cause.
-  //
-  // Raised file-wide rather than per-assertion so a future test in this file
-  // inherits the headroom instead of re-discovering the flake. Restored
-  // afterwards because Testing Library's `configure` is process-global.
-  //
-  // ASYNC_UTIL_TIMEOUT_MS MUST stay strictly below TEST_TIMEOUT_MS. The first
-  // pass at this set it to 5000ms while vitest's `testTimeout` default is also
-  // 5000ms, so the two expired together: the test died with a bare
-  // "Test timed out in 5000ms" before any `waitFor` could report WHICH element
-  // never arrived. That is how #3277 recurred on main (fe6407861) reading as an
-  // opaque timeout rather than the diagnosable ~1038ms waitFor failure the
-  // earlier sightings gave us. Keep the gap — it is what makes the next flake
-  // legible.
-  beforeAll(() => {
-    configure({ asyncUtilTimeout: ASYNC_UTIL_TIMEOUT_MS });
-  });
-  afterAll(() => {
-    configure({ asyncUtilTimeout: DEFAULT_ASYNC_UTIL_TIMEOUT_MS });
-  });
-
+// #3277 — this file ran on a raised Testing Library `asyncUtilTimeout` (5000ms)
+// inside a raised per-test ceiling (15000ms) for six weeks. Both are gone, and
+// deliberately so: the diagnosis they were built on was wrong.
+//
+// The theory was that the queued-Issue tests assert the end of a multi-hop
+// propagation chain (PATCH settles → editor reports → workspace clears
+// `savePending` → header un-gates → queued Issue fires) and that under CI load
+// the chain simply outran the 1000ms default. It does not. The chain never
+// STARTED: a deferred prop-sync `useEffect` in InvoiceEditor flushed after the
+// `fireEvent.change` it never saw, restored the pre-edit notes value and cleared
+// `notesDirty`, so the following blur short-circuited and dispatched no PATCH at
+// all. `savePending` never went true, so `invoice-issue-saving-hint` could never
+// render — no timeout is large enough for a condition that never becomes true,
+// which is why raising it three times (#3284, #3956) never held and the flake
+// came back as #3980 and #4033.
+//
+// With the race removed at source the hint is present SYNCHRONOUSLY inside the
+// blur's own act() flush — measured present-before-any-poll on 200/200 runs
+// under load — so the default budget is not merely sufficient, it is unused.
+// Keeping the inflation would only buy a slower, less legible failure for every
+// genuine future breakage in this file.
+describe('InvoiceWorkspace', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // The margin preference persists to localStorage plus an in-memory mirror
@@ -213,6 +193,13 @@ describe('InvoiceWorkspace', { timeout: TEST_TIMEOUT_MS }, () => {
     // saving hint. (Typing alone is not "saving": nothing has been sent yet.)
     fireEvent.change(screen.getByTestId('invoice-notes'), { target: { value: 'Edited' } });
     fireEvent.blur(screen.getByTestId('invoice-notes'));
+    // Assert the two PRECONDITIONS the rest of this test rests on, before the
+    // wait that depends on them (#3277). Both are synchronous, so a regression
+    // reports "the edit was discarded" or "no PATCH was sent" by name and
+    // instantly, instead of exhausting a `waitFor` on a hint that could never
+    // have rendered — which is the failure mode that took five issues to read.
+    expect(screen.getByTestId('invoice-notes')).toHaveValue('Edited');
+    expect(fetchMock.mock.calls.some((c) => (c[1] as RequestInit)?.method === 'PATCH')).toBe(true);
     await waitFor(() => expect(screen.getByTestId('invoice-issue-saving-hint')).toBeInTheDocument());
 
     // Clicking Issue queues (nothing fires while the save is pending)…
@@ -246,6 +233,9 @@ describe('InvoiceWorkspace', { timeout: TEST_TIMEOUT_MS }, () => {
 
     fireEvent.change(screen.getByTestId('invoice-notes'), { target: { value: 'Edited' } });
     fireEvent.blur(screen.getByTestId('invoice-notes'));
+    // Same two preconditions as the sibling case above — see #3277.
+    expect(screen.getByTestId('invoice-notes')).toHaveValue('Edited');
+    expect(fetchMock.mock.calls.some((c) => (c[1] as RequestInit)?.method === 'PATCH')).toBe(true);
     await waitFor(() => expect(screen.getByTestId('invoice-issue-saving-hint')).toBeInTheDocument());
 
     fireEvent.click(screen.getByTestId('invoice-issue'));


### PR DESCRIPTION
Closes #3277.

## The flake, and why four previous attempts didn't hold

`InvoiceWorkspace.test.tsx`'s two queued-Issue tests have reddened at least six PRs and been filed five times since 2026-07-29 — #2925, #3219, #3277, #3980, #4033 — always on PRs touching no billing code, always green on a same-commit rerun. Two fixes shipped and neither held:

| | what it did | why it didn't hold |
|---|---|---|
| #3284 | raised `asyncUtilTimeout` 1000 → 5000ms | diagnosed "the propagation chain outruns the budget under load". It doesn't. |
| #3956 | pinned a 15000ms per-test ceiling above it | correctly restored a *legible* failure, and said so — it explicitly did not claim to fix the race. |

Both were built on the theory that these tests await the end of a multi-hop chain (PATCH settles → editor reports → workspace clears `savePending` → header un-gates → queued Issue fires) and that a loaded runner outran the budget. The ~1038ms failures looked like it.

That theory is wrong, and #3956's own evidence is what disproves it: the recurrence exhausted the **full 5000ms**. A chain that is merely slow finishes in five seconds. This one never started.

## Deterministic repro

A throwaway harness ran the failing scenario 200× in one file (startup dominates cost) under ambient load ~22–46 on a 14-core box, with the component instrumented. On a failing iteration:

```
--- editor visible; about to fireEvent.change ---
NOTES-ONCHANGE v="Edited"        <- change handler set notes='Edited', notesDirty=true
SYNC-EFFECT-RUN notes=""         <- the MOUNT-time prop-sync effect flushed AFTER, wiping both
--- change dispatched; about to fireEvent.blur ---
SAVE-NOTES-CALLED dirty=false notes=""   <- short-circuits; NO PATCH is ever dispatched
```

`afterChange=""` — the textarea is already empty *immediately after* `fireEvent.change({value:'Edited'})`, and `patchCalls=0`.

## Root cause

`InvoiceEditor.tsx` re-synced its free-text drafts from the server value in an effect:

```ts
useEffect(() => { setNotes(invoice.notes ?? ''); setNotesDirty(false); }, [invoice.notes]);
```

That effect also runs **on mount**, where it is normally a redundant no-op — the `useState` initialisers already hold the server value. But a passive effect is **deferred**: React commits the editor and only schedules the flush for a later task. Testing Library's `waitFor` resolves on the commit (MutationObserver), so it can return while the mount effect is still pending. The next `act()` — inside `fireEvent.change` — applies the keystroke *first* and then flushes the stale mount effect, which overwrites it with the pre-edit value and clears `notesDirty` with it.

`saveNotes()` short-circuits on `!notesDirty`, so the blur dispatches **no PATCH at all**. `savePending` never goes true, so `invoice-issue-saving-hint` never renders.

**No timeout is large enough for a condition that can never become true.** That is the whole reason both attempts at enlarging the budget failed.

This is not purely a test artifact: the same deferred write can land after a real keystroke and discard an edit with no request, no error and no "unsaved" cue. The window is one scheduler task, so a human rarely hits it — but it is the same defect.

## The fix

Evaluate the same condition **during render** (React's documented "adjusting state when a prop changes" pattern) instead of from an effect. There is then no deferred write that can land after a local edit, and the mount pass is a genuine no-op because the synced value starts equal to the server value. Behaviour is otherwise preserved: a server value that genuinely changes still replaces the local draft.

One deliberate improvement: the comparison is on the **normalised** strings, so a `null → ''` round-trip no longer re-runs the sync and clobbers a draft. The old raw-prop dependency did.

### Timeouts reverted, deliberately

Both inflations are removed and the file is back on Testing Library's defaults. With the race gone, the saving hint is present **synchronously inside the blur's own `act()` flush** — measured present-before-any-poll on 200/200 runs — so the default budget is not merely sufficient, it is unused. Keeping 5000ms/15000ms would only buy a slower, less legible failure for every genuine future breakage here. This is the opposite of widening a timeout, and it is backed by measurement rather than assumption.

The two queued-Issue tests now assert their preconditions directly (the edit stuck; a PATCH was dispatched) before the wait that depends on them, so a regression reports *"the edit was discarded"* by name and instantly, rather than exhausting a wait on a hint that could never have rendered.

## Evidence

**A/B under identical ambient load (~22–46), Testing Library default 1000ms budget, 200 iterations each:**

| arm | result |
|---|---|
| pre-fix `InvoiceEditor.tsx` | **2 failed / 200** |
| fixed `InvoiceEditor.tsx` | **0 failed / 200** |

Arm B's file was confirmed by md5 against the saved fixed copy, not assumed.

**Stability after the fix — 50 consecutive process runs, all green:**

```
# 25 runs, 7/7 each
pnpm exec vitest run --pool=threads --maxWorkers=2 src/components/billing/InvoiceWorkspace.test.tsx
#   -> pass=25 fail=0 stall=0

# 25 runs, 32/32 each
pnpm exec vitest run --pool=threads --maxWorkers=2 \
  src/components/billing/InvoiceWorkspace.test.tsx src/components/billing/InvoiceEditor.test.tsx
#   -> pass=25 fail=0 stall=0
```

(`--pool=threads` because the default forks pool cannot start workers at all on this loaded host — it reports `no tests`, which is a stall, not a pass. CI is unaffected.)

**Regression tests — red-first, verified against the pre-fix implementation:**

Three cases added to `InvoiceEditor.test.tsx`. The `null → ''` pair is the deterministic discriminator; both fail on the old code and pass on the new:

```
x keeps a dirty notes draft when a refetch reports the same value under a different raw form (null -> "")
x keeps a dirty terms draft across the same null -> "" round-trip
```

Each of those two blurs the field after the re-sync and asserts the **PATCH actually goes out carrying the drafted text** — not merely that the text is still on screen. That distinction came out of review: the visible value is only a proxy, and the damage in #3277 was the silently-cleared dirty flag, so a regression that cleared the flag without touching the value would have passed a text-only assertion.

The third (`DOES replace the draft when the server value genuinely changes`) passes on both — it pins the behaviour that is deliberately retained.

**On reverting the timeouts specifically:** the 50 consecutive runs above execute *all seven* tests in `InvoiceWorkspace.test.tsx` at the default budget, not just the two queued-Issue cases — including `updates the header from "Draft invoice"…`, which has its own multi-hop async chain. That test also ran on the 1000ms default from its creation until #3284 (2026-08-10) and was never implicated in any of the five filings.

**Gate:** `src/components/billing` — 88 files / 773 tests, 0 failures · `tsc --noEmit` exit 0 · `eslint` exit 0 on all three changed files. No `.astro` touched.

## Not fixed here

- **The same anti-pattern exists in two quote-side files** — `billing/quotes/QuoteEditor.tsx:408` and `billing/quotes/QuoteHeaderMeta.tsx:54` carry the identical deferred prop-sync shape and are presumably vulnerable to the same silent edit-discard. Left alone **on purpose: open PR #4284 is editing `billing/quotes/*`**, so touching them here would collide. Worth a follow-up issue once #4284 lands.
- **A separate, orthogonal hazard I did not change → filed as #4296.** After a successful notes save the quiet refetch returns the new value, which re-syncs and discards anything typed while the PATCH was in flight — silently. Two independent review agents confirmed the trace and both agreed it is out of scope here, since closing it needs a product decision about when the server may overwrite what someone is typing. The quote-side occurrences above are recorded there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
