### PR TITLE
fix(api): gate manual/AI agent-update dispatch on the artifact edition (#4093)

### DIFF
--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -50,8 +50,11 @@ import { decryptClaimedCommandsForDelivery } from '../../services/commandDeliver
 import { normalizeReportedScriptSecretEnvVersion } from '../../services/scriptSecretDelivery';
 import { redactSecretsDeep } from '../../services/secretRedaction';
 import { recordAgentHeartbeat, resolveResponseStatus } from '../metrics';
-import { getBinaryEdition } from '../../services/binaryEdition';
 import { ingestRollbackObservation } from '../../services/agentRollbackResult';
+import {
+  editionWithheldDetail,
+  type EditionWithheldContext as SharedEditionWithheldContext,
+} from '../../services/agentEditionCompat';
 
 /**
  * #1121 — pure collapse detector for the watchdogState tolerance gap.
@@ -100,28 +103,11 @@ export function __resetEditionWithheldWarnCacheForTests(): void {
   editionWithheldCaptured = false;
 }
 
-type EditionWithheldContext = {
-  deviceId: string;
-  reportedEdition: string | null | undefined;
-  agentVersion: string | null | undefined;
-};
-
-// The message states the OBSERVED facts and keeps every remediation
-// conditional — agentAcceptsServedEdition returns false for several distinct
-// states (silent post-cutover self-host build, hosted build on a self-host
-// server, unusable version) and asserting one cause for all of them sends an
-// operator down the wrong path.
-function editionWithheldDetail(args: EditionWithheldContext): string {
-  return (
-    `this server serves ${getBinaryEdition()}-edition artifacts and the downloading build ` +
-    `(reported edition=${args.reportedEdition ?? 'none'}, version=${args.agentVersion ?? 'unknown'}) ` +
-    `cannot be confirmed to accept them — the agent-side edition check refuses a mismatched ` +
-    `artifact AFTER download and retries every heartbeat forever, so the server withholds instead. ` +
-    `If the build is a silent ≥0.105.0 self-host agent, recover it with a ` +
-    `${getBinaryEdition()}-edition installer or an agent release that reports its edition; ` +
-    `if it reports the other edition, it is enrolled against a server of the wrong edition.`
-  );
-}
+// The withhold explanation is shared with the DISPATCH gate (#4093) so both
+// doors describe the same condition in the same words. Imported straight from
+// the leaf module rather than through `./helpers` (which suites mock) so the
+// real text is always what an operator reads.
+type EditionWithheldContext = SharedEditionWithheldContext & { deviceId: string };
 
 // Dedupe entries are keyed per (device, reporting role): the main-agent and
 // watchdog branches gate on DIFFERENT binaries' capabilities, and a device

--- a/apps/api/src/routes/agents/helpers.ts
+++ b/apps/api/src/routes/agents/helpers.ts
@@ -291,111 +291,22 @@ export function inferPatchOsType(source: string, deviceOs: unknown): 'windows' |
 }
 
 // ============================================
-// Version Comparison
+// Version Comparison / artifact-edition compatibility
 // ============================================
-
-export function parseComparableVersion(raw: string): { core: number[]; prerelease: string | null } | null {
-  const trimmed = raw.trim().replace(/^v/i, '');
-  if (!trimmed) return null;
-
-  const [rawCorePart, prereleasePart] = trimmed.split('-', 2);
-  const corePart = rawCorePart ?? '';
-  if (!corePart) return null;
-  const coreTokens = corePart.split('.');
-  if (coreTokens.length === 0) return null;
-
-  const core: number[] = [];
-  for (const token of coreTokens) {
-    if (!/^\d+$/.test(token)) return null;
-    core.push(Number.parseInt(token, 10));
-  }
-
-  return {
-    core,
-    prerelease: prereleasePart ?? null,
-  };
-}
-
-export function compareAgentVersions(leftRaw: string, rightRaw: string): number {
-  const left = parseComparableVersion(leftRaw);
-  const right = parseComparableVersion(rightRaw);
-  if (!left || !right) return 0;
-
-  const maxLen = Math.max(left.core.length, right.core.length);
-  for (let i = 0; i < maxLen; i += 1) {
-    const leftPart = left.core[i] ?? 0;
-    const rightPart = right.core[i] ?? 0;
-    if (leftPart !== rightPart) {
-      return leftPart > rightPart ? 1 : -1;
-    }
-  }
-
-  if (left.prerelease === right.prerelease) return 0;
-  if (!left.prerelease) return 1;
-  if (!right.prerelease) return -1;
-  return left.prerelease.localeCompare(right.prerelease);
-}
-
-/**
- * The agent release that introduced the client-side artifact-edition check
- * (updater.editionAllowed, #3349). Builds older than this never consult the
- * manifest's edition field and can apply artifacts of either edition; builds
- * from this version on refuse a mismatched edition AFTER download, so the
- * server must not offer them one (#4072).
- */
-export const AGENT_EDITION_CHECK_INTRODUCED = '0.105.0';
-
-/**
- * Can the binary that would perform a download apply an artifact of THIS
- * server's edition (#4072)?
- *
- * The updater's edition check runs agent-side after the download, so offering
- * a version the build will refuse does not fail once — it wedges the device in
- * a permanent ~60s retry loop (`status='updating'`, never converges, no
- * server-side escape hatch). This predicate is the server-side gate: withhold
- * the offer instead, and the device idles quietly on its current version.
- *
- * Inference, in order:
- *  - A REPORTED agentEdition (either value) means the build both knows its
- *    edition and — because the heartbeat reporting and the one-way
- *    self-host → hosted allowance in updater.editionAllowed shipped in the
- *    same agent release — can apply a hosted artifact. So when serving hosted,
- *    any reporter is accepted; when serving self-host, a 'hosted' reporter is
- *    refused (hosted builds hard-refuse self-host artifacts by design — that
- *    direction would strip the host-policy allowlist and is never relaxed).
- *  - A SILENT agent (no reported edition) is either a pre-0.105.0 build (no
- *    edition check at all → accepts anything) or a self-host build without
- *    the transition allowance (the stranded 0.105.0–0.106.x band, plus any
- *    unfixed self-host build pointed at a hosted control plane → refuses
- *    hosted). Split on the version that introduced the check. A missing or
- *    unparseable version fails closed — the offer resumes on the next beat
- *    once the agent reports something usable.
- *
- * `reportedEdition`/`agentVersion` must describe the binary that DOWNLOADS
- * (this beat's payload values): the main agent for agent/helper/watchdog
- * offers on the main branch, the watchdog itself on the failover branch.
- */
-export function agentAcceptsServedEdition(args: {
-  reportedEdition: string | null | undefined;
-  agentVersion: string | null | undefined;
-}): boolean {
-  const served = getBinaryEdition();
-  if (served === 'self-host') {
-    return args.reportedEdition !== 'hosted';
-  }
-  if (args.reportedEdition === 'hosted' || args.reportedEdition === 'self-host') {
-    return true;
-  }
-  const version = args.agentVersion?.trim();
-  if (!version) return false;
-  // Compare the CORE version only: semver orders `0.105.0-rc.1` BELOW
-  // `0.105.0`, but a prerelease of the introducing version already carries
-  // the check. A prerelease of an older core (0.104.x-rc) predates it.
-  // (`dev-*` builds strip to an unparseable core and fail closed, same as
-  // any other unparseable version — compareAgentVersions returns 0.)
-  const core = version.split('-')[0] ?? version;
-  return compareAgentVersions(core, AGENT_EDITION_CHECK_INTRODUCED) < 0;
-}
+//
+// Moved to services/agentEditionCompat.ts (#4093) so the DISPATCH path
+// (services/commandQueue.ts) can gate on the same predicate the heartbeat
+// offer path uses. This module imports services/commandQueue, so a direct
+// import in the other direction would be a cycle. Re-exported here: every
+// existing import site (and the suites that mock `./helpers`) keeps working.
+export {
+  parseComparableVersion,
+  compareAgentVersions,
+  AGENT_EDITION_CHECK_INTRODUCED,
+  agentAcceptsServedEdition,
+  editionWithheldDetail,
+  type EditionWithheldContext,
+} from '../../services/agentEditionCompat';
 
 // ============================================
 // Policy Probe Processing

--- a/apps/api/src/services/agentEditionCompat.test.ts
+++ b/apps/api/src/services/agentEditionCompat.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { readdirSync, readFileSync, statSync } from 'fs';
+import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
 import { join } from 'path';
 import {
   agentAcceptsServedEdition,
@@ -162,18 +162,32 @@ describe('agentBinaryUpdateDispatchRefusal (#4093)', () => {
 // same class of "new call site forgot the registration" bug has shipped
 // repeatedly in this repo and review has never been what caught it.
 describe('agent-binary update command types are only named at known sites (#4093)', () => {
-  // apps/api — covers both the server (src/) and the operator scripts, which
-  // insert device_commands rows of their own (scripts/recover-stuck-agents.ts).
+  // apps/api — the server (src/) and the operator scripts, which insert
+  // device_commands rows of their own (scripts/recover-stuck-agents.ts) — plus
+  // ee/, whose built-in extensions compile into the same API image and could
+  // grow a dispatch path of their own.
+  //
+  // LIMITATION, so a future reader does not over-trust this: it matches the
+  // literal command-type strings. A dispatcher that reached them indirectly
+  // (e.g. spreading AGENT_BINARY_UPDATE_COMMAND_TYPES) would slip past. The
+  // runtime guards are the real enforcement — executeCommand evaluates the
+  // gate and queueCommand refuses these types; this scan exists to catch the
+  // remaining hole, a hand-rolled db.insert(deviceCommands).
+  const REPO_ROOT = join(__dirname, '..', '..', '..', '..');
   const API_ROOT = join(__dirname, '..', '..');
-  const SCAN_ROOTS = ['src', 'scripts'];
+  const SCAN_ROOTS = [
+    join(API_ROOT, 'src'),
+    join(API_ROOT, 'scripts'),
+    join(REPO_ROOT, 'ee'),
+  ].filter((dir) => existsSync(dir));
 
   // Every file that may mention 'update_agent' / 'update_watchdog'.
   // Adding a file here means: you are dispatching an agent-binary update, so
   // route it through executeCommand(..., { targetRole: 'watchdog' }) — that is
   // the only path that applies agentBinaryUpdateDispatchRefusal.
   const ALLOWED = new Set([
-    'src/services/agentEditionCompat.ts', // the gate itself
-    'src/services/aiToolsAgentMgmt.ts', // trigger_agent_upgrade — the one dispatcher
+    'apps/api/src/services/agentEditionCompat.ts', // the gate itself
+    'apps/api/src/services/aiToolsAgentMgmt.ts', // trigger_agent_upgrade — the one dispatcher
   ]);
 
   function walk(dir: string, out: string[] = []): string[] {
@@ -190,10 +204,10 @@ describe('agent-binary update command types are only named at known sites (#4093
   // couple of thousand synchronous reads and can exceed the 5s default when
   // the suite runs alongside others.
   it('only the gate and the known dispatcher name update_agent / update_watchdog', () => {
-    const files = SCAN_ROOTS.flatMap((root) => walk(join(API_ROOT, root)));
+    const files = SCAN_ROOTS.flatMap((root) => walk(root));
     const offenders = files
       .filter((file) => /\bupdate_(agent|watchdog)\b/.test(readFileSync(file, 'utf8')))
-      .map((file) => file.slice(API_ROOT.length + 1))
+      .map((file) => file.slice(REPO_ROOT.length + 1))
       .filter((rel) => !ALLOWED.has(rel))
       .sort();
 

--- a/apps/api/src/services/agentEditionCompat.test.ts
+++ b/apps/api/src/services/agentEditionCompat.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join } from 'path';
+import {
+  agentAcceptsServedEdition,
+  agentBinaryUpdateDispatchRefusal,
+  AGENT_BINARY_UPDATE_COMMAND_TYPES,
+} from './agentEditionCompat';
+
+const ORIGINAL_EDITION = process.env.BINARY_EDITION;
+
+afterEach(() => {
+  if (ORIGINAL_EDITION === undefined) delete process.env.BINARY_EDITION;
+  else process.env.BINARY_EDITION = ORIGINAL_EDITION;
+});
+
+// #4093 — the dispatch-side counterpart of the heartbeat's offer gate. The
+// predicate itself (agentAcceptsServedEdition) is covered in
+// routes/agents/helpers.agentUpdatePolicy.test.ts; these cover the wrapper
+// that decides whether a COMMAND may be dispatched.
+describe('agentBinaryUpdateDispatchRefusal (#4093)', () => {
+  const strandedDevice = {
+    agentEdition: null,
+    agentVersion: '0.105.1',
+    watchdogVersion: '0.105.1',
+  };
+
+  beforeEach(() => {
+    process.env.BINARY_EDITION = 'hosted';
+  });
+
+  it('is inert for every command type that does not download a binary', () => {
+    for (const type of ['restart_agent', 'run_script', 'reboot', 'dev_update']) {
+      expect(
+        agentBinaryUpdateDispatchRefusal({
+          commandType: type,
+          targetRole: 'watchdog',
+          device: strandedDevice,
+        }),
+      ).toBeNull();
+    }
+  });
+
+  it('covers exactly the two agent-binary update command types', () => {
+    expect([...AGENT_BINARY_UPDATE_COMMAND_TYPES].sort()).toEqual([
+      'update_agent',
+      'update_watchdog',
+    ]);
+  });
+
+  it('refuses a stranded self-host build on a hosted control plane', () => {
+    const reason = agentBinaryUpdateDispatchRefusal({
+      commandType: 'update_agent',
+      targetRole: 'watchdog',
+      device: strandedDevice,
+    });
+    expect(reason).toMatch(/withheld/i);
+    // The reason must name the observed facts the operator needs, not just
+    // "refused" — this string is what lands in the AI tool's per-device error.
+    expect(reason).toContain('version=0.105.1');
+    expect(reason).toContain('edition=none');
+  });
+
+  it('allows a build that reports its edition', () => {
+    expect(
+      agentBinaryUpdateDispatchRefusal({
+        commandType: 'update_agent',
+        targetRole: 'watchdog',
+        device: { agentEdition: 'self-host', agentVersion: '0.108.0', watchdogVersion: '0.108.0' },
+      }),
+    ).toBeNull();
+  });
+
+  it('reads the version band off the WATCHDOG, the binary that downloads', () => {
+    // Main agent inside the check band, watchdog below it → allowed.
+    expect(
+      agentBinaryUpdateDispatchRefusal({
+        commandType: 'update_agent',
+        targetRole: 'watchdog',
+        device: { agentEdition: null, agentVersion: '0.106.0', watchdogVersion: '0.104.0' },
+      }),
+    ).toBeNull();
+    // The reverse → refused.
+    expect(
+      agentBinaryUpdateDispatchRefusal({
+        commandType: 'update_agent',
+        targetRole: 'watchdog',
+        device: { agentEdition: null, agentVersion: '0.104.0', watchdogVersion: '0.106.0' },
+      }),
+    ).toMatch(/withheld/i);
+  });
+
+  it('falls back to the agent version only when no watchdog version was ever reported', () => {
+    expect(
+      agentBinaryUpdateDispatchRefusal({
+        commandType: 'update_agent',
+        targetRole: 'watchdog',
+        device: { agentEdition: null, agentVersion: '0.104.0', watchdogVersion: null },
+      }),
+    ).toBeNull();
+    expect(
+      agentBinaryUpdateDispatchRefusal({
+        commandType: 'update_agent',
+        targetRole: 'watchdog',
+        device: { agentEdition: null, agentVersion: '0.105.1', watchdogVersion: null },
+      }),
+    ).toMatch(/withheld/i);
+  });
+
+  it('refuses a dispatch that does not target the watchdog', () => {
+    expect(
+      agentBinaryUpdateDispatchRefusal({
+        commandType: 'update_agent',
+        targetRole: 'agent',
+        device: { agentEdition: 'hosted', agentVersion: '0.108.0', watchdogVersion: '0.108.0' },
+      }),
+    ).toMatch(/targetRole 'watchdog'/);
+  });
+
+  it('refuses a self-host artifact aimed at a hosted-edition build', () => {
+    process.env.BINARY_EDITION = 'self-host';
+    expect(
+      agentBinaryUpdateDispatchRefusal({
+        commandType: 'update_watchdog',
+        targetRole: 'watchdog',
+        device: { agentEdition: 'hosted', agentVersion: '0.108.0', watchdogVersion: '0.108.0' },
+      }),
+    ).toMatch(/withheld/i);
+    // …and still allows the same server's own edition.
+    expect(
+      agentBinaryUpdateDispatchRefusal({
+        commandType: 'update_watchdog',
+        targetRole: 'watchdog',
+        device: { agentEdition: 'self-host', agentVersion: '0.108.0', watchdogVersion: '0.108.0' },
+      }),
+    ).toBeNull();
+  });
+
+  it('agrees with the raw predicate on the fail-closed unparseable case', () => {
+    expect(agentAcceptsServedEdition({ reportedEdition: null, agentVersion: 'dev-abc' })).toBe(false);
+    expect(
+      agentBinaryUpdateDispatchRefusal({
+        commandType: 'update_agent',
+        targetRole: 'watchdog',
+        device: { agentEdition: null, agentVersion: 'dev-abc', watchdogVersion: 'dev-abc' },
+      }),
+    ).toMatch(/withheld/i);
+  });
+});
+
+// ============================================================
+// Dispatch-site registry (#4093)
+// ============================================================
+//
+// The gate above only helps if every dispatcher goes through it. Two runtime
+// guards already exist — `executeCommand` evaluates the gate and `queueCommand`
+// refuses these types outright — but a hand-rolled `db.insert(deviceCommands)`
+// would evade both. Any such file has to NAME the command type, so this scan
+// pins the set of files allowed to mention one.
+//
+// This is deliberately a static contract, not a code-review convention: the
+// same class of "new call site forgot the registration" bug has shipped
+// repeatedly in this repo and review has never been what caught it.
+describe('agent-binary update command types are only named at known sites (#4093)', () => {
+  // apps/api — covers both the server (src/) and the operator scripts, which
+  // insert device_commands rows of their own (scripts/recover-stuck-agents.ts).
+  const API_ROOT = join(__dirname, '..', '..');
+  const SCAN_ROOTS = ['src', 'scripts'];
+
+  // Every file that may mention 'update_agent' / 'update_watchdog'.
+  // Adding a file here means: you are dispatching an agent-binary update, so
+  // route it through executeCommand(..., { targetRole: 'watchdog' }) — that is
+  // the only path that applies agentBinaryUpdateDispatchRefusal.
+  const ALLOWED = new Set([
+    'src/services/agentEditionCompat.ts', // the gate itself
+    'src/services/aiToolsAgentMgmt.ts', // trigger_agent_upgrade — the one dispatcher
+  ]);
+
+  function walk(dir: string, out: string[] = []): string[] {
+    for (const entry of readdirSync(dir)) {
+      if (entry === 'node_modules' || entry === '__tests__') continue;
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) walk(full, out);
+      else if (entry.endsWith('.ts') && !entry.includes('.test.')) out.push(full);
+    }
+    return out;
+  }
+
+  // Generous timeout: this reads every .ts file under apps/api, which is a
+  // couple of thousand synchronous reads and can exceed the 5s default when
+  // the suite runs alongside others.
+  it('only the gate and the known dispatcher name update_agent / update_watchdog', () => {
+    const files = SCAN_ROOTS.flatMap((root) => walk(join(API_ROOT, root)));
+    const offenders = files
+      .filter((file) => /\bupdate_(agent|watchdog)\b/.test(readFileSync(file, 'utf8')))
+      .map((file) => file.slice(API_ROOT.length + 1))
+      .filter((rel) => !ALLOWED.has(rel))
+      .sort();
+
+    // Guard the guard: an empty scan would make this vacuously green.
+    expect(files.length).toBeGreaterThan(100);
+
+    expect(
+      offenders,
+      'A new file names an agent-binary update command type. Dispatch it through ' +
+        "executeCommand(deviceId, type, payload, { targetRole: 'watchdog' }) so the " +
+        'artifact-edition gate (#4093/#4072) applies, then add the file to ALLOWED here. ' +
+        'A raw db.insert(deviceCommands) bypasses the gate and can strand devices.',
+    ).toEqual([]);
+  }, 60_000);
+});

--- a/apps/api/src/services/agentEditionCompat.ts
+++ b/apps/api/src/services/agentEditionCompat.ts
@@ -1,0 +1,238 @@
+/**
+ * Agent artifact-edition compatibility (#4072, #4093).
+ *
+ * A LEAF module on purpose. The predicate below has to be callable from both
+ * doors that can put a new agent binary on a device:
+ *
+ *   - the heartbeat upgrade OFFER path (routes/agents/heartbeat.ts), and
+ *   - the command DISPATCH path (services/commandQueue.ts -> `update_agent` /
+ *     `update_watchdog`, reached from the manual/AI `trigger_agent_upgrade`
+ *     tool).
+ *
+ * It used to live in routes/agents/helpers.ts, which imports
+ * services/commandQueue — so importing it from commandQueue would have closed
+ * an import cycle. Moving it here (it depends on nothing but the served
+ * edition) removes the cycle rather than papering over it with a lazy import.
+ * helpers.ts re-exports the same symbols, so every existing import site and
+ * the suites that mock `./helpers` are unaffected.
+ */
+
+import { getBinaryEdition } from './binaryEdition';
+
+// ============================================
+// Version Comparison
+// ============================================
+
+export function parseComparableVersion(raw: string): { core: number[]; prerelease: string | null } | null {
+  const trimmed = raw.trim().replace(/^v/i, '');
+  if (!trimmed) return null;
+
+  const [rawCorePart, prereleasePart] = trimmed.split('-', 2);
+  const corePart = rawCorePart ?? '';
+  if (!corePart) return null;
+  const coreTokens = corePart.split('.');
+  if (coreTokens.length === 0) return null;
+
+  const core: number[] = [];
+  for (const token of coreTokens) {
+    if (!/^\d+$/.test(token)) return null;
+    core.push(Number.parseInt(token, 10));
+  }
+
+  return {
+    core,
+    prerelease: prereleasePart ?? null,
+  };
+}
+
+export function compareAgentVersions(leftRaw: string, rightRaw: string): number {
+  const left = parseComparableVersion(leftRaw);
+  const right = parseComparableVersion(rightRaw);
+  if (!left || !right) return 0;
+
+  const maxLen = Math.max(left.core.length, right.core.length);
+  for (let i = 0; i < maxLen; i += 1) {
+    const leftPart = left.core[i] ?? 0;
+    const rightPart = right.core[i] ?? 0;
+    if (leftPart !== rightPart) {
+      return leftPart > rightPart ? 1 : -1;
+    }
+  }
+
+  if (left.prerelease === right.prerelease) return 0;
+  if (!left.prerelease) return 1;
+  if (!right.prerelease) return -1;
+  return left.prerelease.localeCompare(right.prerelease);
+}
+
+/**
+ * The agent release that introduced the client-side artifact-edition check
+ * (updater.editionAllowed, #3349). Builds older than this never consult the
+ * manifest's edition field and can apply artifacts of either edition; builds
+ * from this version on refuse a mismatched edition AFTER download, so the
+ * server must not offer them one (#4072).
+ */
+export const AGENT_EDITION_CHECK_INTRODUCED = '0.105.0';
+
+/**
+ * Can the binary that would perform a download apply an artifact of THIS
+ * server's edition (#4072)?
+ *
+ * The updater's edition check runs agent-side after the download, so offering
+ * a version the build will refuse does not fail once — it wedges the device in
+ * a permanent ~60s retry loop (`status='updating'`, never converges, no
+ * server-side escape hatch). This predicate is the server-side gate: withhold
+ * the offer instead, and the device idles quietly on its current version.
+ *
+ * Inference, in order:
+ *  - A REPORTED agentEdition (either value) means the build both knows its
+ *    edition and — because the heartbeat reporting and the one-way
+ *    self-host → hosted allowance in updater.editionAllowed shipped in the
+ *    same agent release — can apply a hosted artifact. So when serving hosted,
+ *    any reporter is accepted; when serving self-host, a 'hosted' reporter is
+ *    refused (hosted builds hard-refuse self-host artifacts by design — that
+ *    direction would strip the host-policy allowlist and is never relaxed).
+ *  - A SILENT agent (no reported edition) is either a pre-0.105.0 build (no
+ *    edition check at all → accepts anything) or a self-host build without
+ *    the transition allowance (the stranded 0.105.0–0.106.x band, plus any
+ *    unfixed self-host build pointed at a hosted control plane → refuses
+ *    hosted). Split on the version that introduced the check. A missing or
+ *    unparseable version fails closed — the offer resumes on the next beat
+ *    once the agent reports something usable.
+ *
+ * `reportedEdition`/`agentVersion` must describe the binary that DOWNLOADS
+ * (this beat's payload values): the main agent for agent/helper/watchdog
+ * offers on the main branch, the watchdog itself on the failover branch.
+ */
+export function agentAcceptsServedEdition(args: {
+  reportedEdition: string | null | undefined;
+  agentVersion: string | null | undefined;
+}): boolean {
+  const served = getBinaryEdition();
+  if (served === 'self-host') {
+    return args.reportedEdition !== 'hosted';
+  }
+  if (args.reportedEdition === 'hosted' || args.reportedEdition === 'self-host') {
+    return true;
+  }
+  const version = args.agentVersion?.trim();
+  if (!version) return false;
+  // Compare the CORE version only: semver orders `0.105.0-rc.1` BELOW
+  // `0.105.0`, but a prerelease of the introducing version already carries
+  // the check. A prerelease of an older core (0.104.x-rc) predates it.
+  // (`dev-*` builds strip to an unparseable core and fail closed, same as
+  // any other unparseable version — compareAgentVersions returns 0.)
+  const core = version.split('-')[0] ?? version;
+  return compareAgentVersions(core, AGENT_EDITION_CHECK_INTRODUCED) < 0;
+}
+
+// ============================================
+// Dispatch gate (#4093)
+// ============================================
+
+/**
+ * Command types that make a device DOWNLOAD and apply a new agent-family
+ * binary. These are the dispatch-side equivalent of the heartbeat's
+ * `upgradeTo` / `watchdogUpgradeTo` offers, and they are subject to the same
+ * artifact-edition gate.
+ *
+ * Deliberately NOT including `dev_update` (routes/devPush.ts): that command
+ * carries an explicit URL + checksum for a locally built binary and never
+ * touches a signed release manifest, so `updater.editionAllowed` is never
+ * consulted for it. Gating it would block dev-push for no benefit.
+ */
+export const AGENT_BINARY_UPDATE_COMMAND_TYPES: ReadonlySet<string> = new Set([
+  'update_agent',
+  'update_watchdog',
+]);
+
+export type EditionWithheldContext = {
+  deviceId?: string;
+  reportedEdition: string | null | undefined;
+  agentVersion: string | null | undefined;
+};
+
+/**
+ * The shared explanation for a withheld agent-binary update.
+ *
+ * The message states the OBSERVED facts and keeps every remediation
+ * conditional — agentAcceptsServedEdition returns false for several distinct
+ * states (silent post-cutover self-host build, hosted build on a self-host
+ * server, unusable version) and asserting one cause for all of them sends an
+ * operator down the wrong path.
+ */
+export function editionWithheldDetail(args: EditionWithheldContext): string {
+  return (
+    `this server serves ${getBinaryEdition()}-edition artifacts and the downloading build ` +
+    `(reported edition=${args.reportedEdition ?? 'none'}, version=${args.agentVersion ?? 'unknown'}) ` +
+    `cannot be confirmed to accept them — the agent-side edition check refuses a mismatched ` +
+    `artifact AFTER download and retries every heartbeat forever, so the server withholds instead. ` +
+    `If the build is a silent ≥0.105.0 self-host agent, recover it with a ` +
+    `${getBinaryEdition()}-edition installer or an agent release that reports its edition; ` +
+    `if it reports the other edition, it is enrolled against a server of the wrong edition.`
+  );
+}
+
+/**
+ * Should this dispatch of an agent-binary update command be refused (#4093)?
+ *
+ * Returns `null` to allow, or the operator-facing reason to refuse.
+ *
+ * WHY HERE and not at the caller: #4072/#4091 gated the automatic (heartbeat)
+ * door, and the manual/AI door kept dispatching updates the agent refuses
+ * after download — the same failure class as "manual Remediate ignores
+ * enforceMode" (#3381). Gating the one known caller is how the third caller
+ * ships ungated, so this runs at the dispatch chokepoint
+ * (services/commandQueue.ts `executeCommand`) instead.
+ *
+ * DOWNLOADER IDENTITY. Both command types are executed by the breeze-watchdog
+ * (agent/cmd/breeze-watchdog `handleFailoverCommand` -> `doUpdateAgent` /
+ * `doUpdateWatchdog`), whose updater is what consults `editionAllowed`. The
+ * main agent has no handler for either type, so a dispatch that does not
+ * target the watchdog is rejected outright: it would be written with
+ * target_role='agent', sent to the agent WS, and never picked up.
+ *
+ * VERSION. The watchdog is the downloader, so the version band is read from
+ * `watchdogVersion` — written together with `watchdogLastSeen` on every
+ * watchdog beat (routes/agents/heartbeat.ts), so a device fresh enough to
+ * receive a watchdog command always has one. The `agentVersion` fallback
+ * covers the pre-watchdog-telemetry rows only; agent and watchdog install and
+ * upgrade from the same lane, so the main agent's version identifies the
+ * watchdog's build era.
+ *
+ * EDITION. There is no `watchdogEdition` column; `agentEdition` (written from
+ * every MAIN-agent beat) stands in for it, exactly as the heartbeat's failover
+ * branch does. Same known imprecision, documented there: a device whose main
+ * agent already reports an edition but whose watchdog is an older build can
+ * still get a dispatch its watchdog refuses. That is a one-shot command
+ * failure, not the permanent retry loop #4072 describes, and it self-heals
+ * once the watchdog catches up.
+ */
+export function agentBinaryUpdateDispatchRefusal(args: {
+  commandType: string;
+  targetRole: 'agent' | 'watchdog';
+  device: {
+    agentEdition?: string | null;
+    agentVersion?: string | null;
+    watchdogVersion?: string | null;
+  };
+}): string | null {
+  if (!AGENT_BINARY_UPDATE_COMMAND_TYPES.has(args.commandType)) return null;
+
+  if (args.targetRole !== 'watchdog') {
+    return (
+      `${args.commandType} must be dispatched with targetRole 'watchdog' — the breeze-watchdog ` +
+      `is the only consumer that handles it; an agent-targeted row is sent to the agent ` +
+      `WebSocket and never picked up.`
+    );
+  }
+
+  const downloaderVersion = args.device.watchdogVersion ?? args.device.agentVersion ?? null;
+  const context: EditionWithheldContext = {
+    reportedEdition: args.device.agentEdition ?? null,
+    agentVersion: downloaderVersion,
+  };
+  if (agentAcceptsServedEdition(context)) return null;
+
+  return `Agent update withheld (#4072): ${editionWithheldDetail(context)}`;
+}

--- a/apps/api/src/services/aiToolsAgentMgmt.test.ts
+++ b/apps/api/src/services/aiToolsAgentMgmt.test.ts
@@ -346,8 +346,13 @@ describe('trigger_agent_upgrade — pin-aware default target (#2124)', () => {
   });
 
   it('an explicit targetVersion overrides any pin and is used verbatim', async () => {
-    // #1 verifyDeviceAccess, #2 org-wide check, #3 explicit-version existence.
-    mockSelectSequence([[onlineDeviceRow()], [{ id: DEVICE_ID }], [{ version: '0.90.0' }]]);
+    // #1 verifyDeviceAccess, #2 org-wide check, #3 explicit-version existence,
+    // #4 device→org+platform lookup (the explicit version is resolved per
+    // device too, #4093).
+    mockSelectSequence([
+      [onlineDeviceRow()], [{ id: DEVICE_ID }], [{ version: '0.90.0' }],
+      [deviceOrgRow(DEVICE_ID, ORG_ID)],
+    ]);
 
     const result = JSON.parse(
       await tool.handler({ deviceIds: [DEVICE_ID], targetVersion: '0.90.0' }, makeAuth()),
@@ -355,12 +360,69 @@ describe('trigger_agent_upgrade — pin-aware default target (#2124)', () => {
 
     expect(result.queued).toBe(1);
     expect(result.targetVersion).toBe('0.90.0');
-    // The pin resolver is never consulted when a version is explicitly given.
+    // The org's pin config is never consulted when a version is explicitly given.
     expect(getOrgAgentUpdateConfig).not.toHaveBeenCalled();
     expect(executeCommand).toHaveBeenCalledWith(
       DEVICE_ID, 'update_agent', { version: '0.90.0' },
       expect.objectContaining({ targetRole: 'watchdog' }),
     );
+  });
+
+  // #4093 — before this, an explicit targetVersion only had to EXIST in
+  // agent_versions: no component, edition, platform or arch scoping. A version
+  // with no build for the device dispatched an update_agent that could only
+  // fail on the box (download-info 404), reported to the operator as `queued`.
+  it('explicit targetVersion: no build for THIS device is reported, not dispatched', async () => {
+    // The version exists (row #3) but has no build for this platform/arch.
+    vi.mocked(resolvePinnedUpgradeTarget).mockResolvedValue(null);
+    mockSelectSequence([
+      [onlineDeviceRow()], [{ id: DEVICE_ID }], [{ version: '0.90.0' }],
+      [deviceOrgRow(DEVICE_ID, ORG_ID)],
+    ]);
+
+    const result = JSON.parse(
+      await tool.handler({ deviceIds: [DEVICE_ID], targetVersion: '0.90.0' }, makeAuth()),
+    );
+
+    expect(result.errors[DEVICE_ID]).toMatch(/has no build for this device/i);
+    expect(executeCommand).not.toHaveBeenCalled();
+    // The explicit version IS resolved through the same fail-closed resolver
+    // the pinned path uses, with this device's platform/arch.
+    expect(resolvePinnedUpgradeTarget).toHaveBeenCalledWith(
+      expect.objectContaining({
+        component: 'agent', pin: '0.90.0', platform: 'windows', architecture: 'amd64',
+      }),
+    );
+  });
+
+  it('explicit targetVersion: a version with no agent build at all is rejected up front', async () => {
+    // #3 (the version existence probe) returns nothing → reject before any
+    // per-device work.
+    mockSelectSequence([[onlineDeviceRow()], [{ id: DEVICE_ID }], []]);
+
+    const result = JSON.parse(
+      await tool.handler({ deviceIds: [DEVICE_ID], targetVersion: '9.9.9' }, makeAuth()),
+    );
+
+    expect(result.error).toMatch(/not found/i);
+    expect(resolvePinnedUpgradeTarget).not.toHaveBeenCalled();
+    expect(executeCommand).not.toHaveBeenCalled();
+  });
+
+  // The artifact-edition gate itself lives at the dispatch chokepoint
+  // (services/commandQueue.ts executeCommand, #4093). This asserts the tool
+  // surfaces its refusal per device instead of counting it as queued.
+  it('surfaces the dispatch-time edition refusal as a per-device error', async () => {
+    vi.mocked(executeCommand).mockResolvedValue({
+      status: 'failed',
+      error: 'Agent update withheld (#4072): this server serves hosted-edition artifacts …',
+    } as any);
+    mockSelectSequence([[onlineDeviceRow()], [{ id: DEVICE_ID }], [deviceOrgRow(DEVICE_ID, ORG_ID)]]);
+
+    const result = JSON.parse(await tool.handler({ deviceIds: [DEVICE_ID] }, makeAuth()));
+
+    expect(result.queued).toBe(0);
+    expect(result.errors[DEVICE_ID]).toMatch(/withheld/i);
   });
 
   // --- Multi-org batch isolation (the load-bearing new behavior) -------------

--- a/apps/api/src/services/aiToolsAgentMgmt.test.ts
+++ b/apps/api/src/services/aiToolsAgentMgmt.test.ts
@@ -48,10 +48,36 @@ const ORG_ID = '11111111-1111-1111-1111-111111111111';
 const DEVICE_ID = '33333333-3333-3333-3333-333333333333';
 const OTHER_DEVICE_ID = '44444444-4444-4444-4444-444444444444';
 
+// Every `.where()` argument the tool builds, in call order. `and(eq(...))`
+// objects are opaque, so `capturedWhereColumns` below walks them for the
+// columns actually filtered on — without this, a where-clause assertion is
+// vacuous (the chain returns its canned rows whatever it was asked).
+const capturedWheres: unknown[] = [];
+
+function whereColumns(node: any, out: string[] = []): string[] {
+  if (!node) return out;
+  if (Array.isArray(node)) {
+    node.forEach((n) => whereColumns(n, out));
+    return out;
+  }
+  if (typeof node === 'object') {
+    if (typeof node.name === 'string' && node.table) out.push(node.name);
+    if (node.queryChunks) whereColumns(node.queryChunks, out);
+  }
+  return out;
+}
+
+function capturedWhereColumns(index: number): string[] {
+  return whereColumns((capturedWheres[index] as any)?.queryChunks);
+}
+
 function createQueryChain(rows: any[] = []) {
   const chain: any = {};
   chain.from = vi.fn(() => chain);
-  chain.where = vi.fn(() => chain);
+  chain.where = vi.fn((arg: unknown) => {
+    capturedWheres.push(arg);
+    return chain;
+  });
   chain.limit = vi.fn(() => chain);
   chain.groupBy = vi.fn(() => chain);
   chain.orderBy = vi.fn(() => chain);
@@ -61,6 +87,7 @@ function createQueryChain(rows: any[] = []) {
 }
 
 function mockSelectSequence(rowsList: any[][]) {
+  capturedWheres.length = 0;
   let index = 0;
   vi.mocked(db.select).mockImplementation(() => createQueryChain(rowsList[index++] ?? []) as any);
 }
@@ -340,7 +367,7 @@ describe('trigger_agent_upgrade — pin-aware default target (#2124)', () => {
     const result = JSON.parse(await tool.handler({ deviceIds: [DEVICE_ID] }, makeAuth()));
 
     // No doomed dispatch; the operator is told, not silently timed out.
-    expect(result.error).toMatch(/No latest agent version found/i);
+    expect(result.error).toMatch(/No agent build resolved/i);
     expect(result.errors[DEVICE_ID]).toMatch(/has no build for this device/i);
     expect(executeCommand).not.toHaveBeenCalled();
   });
@@ -493,8 +520,43 @@ describe('trigger_agent_upgrade — pin-aware default target (#2124)', () => {
 
     const result = JSON.parse(await tool.handler({ deviceIds: [DEVICE_ID] }, makeAuth()));
 
-    expect(result.error).toMatch(/No latest agent version found/i);
+    expect(result.error).toMatch(/No agent build resolved/i);
     expect(result.errors[DEVICE_ID]).toMatch(/Failed to resolve version pin/i);
+    expect(executeCommand).not.toHaveBeenCalled();
+  });
+
+  // The explicit-version probe is scoped to component='agent' AND this server's
+  // edition (#4093). Asserting the RESULT alone would be vacuous — the mocked
+  // chain returns its canned rows whatever it was asked — so this asserts the
+  // columns the filter actually names. Drop either eq() from the production
+  // query and this fails.
+  it('scopes the explicit-version probe to component and served edition', async () => {
+    mockSelectSequence([
+      [onlineDeviceRow()], [{ id: DEVICE_ID }], [{ version: '0.90.0' }],
+      [deviceOrgRow(DEVICE_ID, ORG_ID)],
+    ]);
+
+    await tool.handler({ deviceIds: [DEVICE_ID], targetVersion: '0.90.0' }, makeAuth());
+
+    // Select #3 is the agent_versions existence probe.
+    expect(capturedWhereColumns(2).sort()).toEqual(['component', 'edition', 'version']);
+  });
+
+  // A device that passed the access check but is absent from the device-row
+  // SELECT was deleted mid-request. It must get a per-device reason; before
+  // this it fell through to a batch-level error naming the wrong cause, with
+  // the `errors` map omitted entirely when the whole batch vanished.
+  it('reports a device that disappeared between the access check and resolution', async () => {
+    mockSelectSequence([
+      [onlineDeviceRow()],
+      [{ id: DEVICE_ID }],
+      [], // device row gone
+    ]);
+
+    const result = JSON.parse(await tool.handler({ deviceIds: [DEVICE_ID] }, makeAuth()));
+
+    expect(result.errors[DEVICE_ID]).toMatch(/no longer exists/i);
+    expect(result.error).toMatch(/No agent build resolved/i);
     expect(executeCommand).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/services/aiToolsAgentMgmt.ts
+++ b/apps/api/src/services/aiToolsAgentMgmt.ts
@@ -304,7 +304,13 @@ export function registerAgentMgmtTools(aiTools: Map<string, AiTool>): void {
             try {
               const cfg = await runOutsideDbContext(() => withSystemDbAccessContext(() => getOrgAgentUpdateConfig(d.orgId)));
               pinByOrg.set(d.orgId, cfg.pins.agent);
-            } catch {
+            } catch (err) {
+              // The operator-facing string is deliberately generic; the cause
+              // has to go somewhere or a batch-wide pin outage is undebuggable.
+              console.error(
+                `[aiToolsAgentMgmt] failed to resolve the agent pin for org ${d.orgId}:`,
+                err,
+              );
               failedOrgs.add(d.orgId);
               errors[d.id] = 'Failed to resolve version pin for this organization';
               continue;
@@ -331,7 +337,11 @@ export function registerAgentMgmtTools(aiTools: Map<string, AiTool>): void {
             pin,
             agentId: d.id,
           });
-        } catch {
+        } catch (err) {
+          console.error(
+            `[aiToolsAgentMgmt] failed to resolve an agent build for device ${d.id}:`,
+            err,
+          );
           errors[d.id] = 'Failed to resolve an agent build for this device';
           continue;
         }
@@ -348,11 +358,22 @@ export function registerAgentMgmtTools(aiTools: Map<string, AiTool>): void {
         }
       }
 
+      // A requested device that produced neither a target nor a reason was not
+      // in `deviceRows` at all — deleted between the access check and this
+      // SELECT. Record it here rather than letting the batch-level error below
+      // name the wrong cause (and, when the WHOLE batch vanished, report no
+      // per-device reason at all).
+      for (const id of deviceIds) {
+        if (!targetByDevice.has(id) && !errors[id]) {
+          errors[id] = 'Device no longer exists — it was removed while this request was running';
+        }
+      }
+
       if (targetByDevice.size === 0) {
         return JSON.stringify({
           error: explicitVersion
             ? `Agent version "${explicitVersion}" has no build for any of the selected devices`
-            : 'No latest agent version found',
+            : 'No agent build resolved for any of the selected devices',
           ...(Object.keys(errors).length > 0 ? { errors } : {}),
         });
       }

--- a/apps/api/src/services/aiToolsAgentMgmt.ts
+++ b/apps/api/src/services/aiToolsAgentMgmt.ts
@@ -13,6 +13,7 @@ import { eq, ne, and, desc, sql, inArray, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { getOrgAgentUpdateConfig, resolvePinnedUpgradeTarget, normalizeAgentArchitecture } from '../routes/agents/helpers';
+import { getBinaryEdition } from './binaryEdition';
 
 type AiToolTier = 1 | 2 | 3 | 4;
 
@@ -227,47 +228,70 @@ export function registerAgentMgmtTools(aiTools: Map<string, AiTool>): void {
         return JSON.stringify({ error: `Access denied for devices: ${deniedIds.join(', ')}` });
       }
 
-      // Resolve the target version PER DEVICE. An explicit targetVersion applies
-      // to all devices; otherwise each device resolves to its org's effective
-      // AGENT pin (issue #2124) — the SAME pin the heartbeat honors — falling
-      // back to the globally promoted latest when the tenant has no pin. This
-      // keeps manual and automatic updates on one resolution path.
+      // Resolve the target version PER DEVICE, through ONE resolver for both
+      // input shapes (#4093). Without an explicit targetVersion each device
+      // resolves its org's effective AGENT pin (issue #2124) — the SAME pin
+      // the heartbeat honors — falling back to the globally promoted latest.
+      // With one, that version is treated as a per-device pin: it still has to
+      // have a build registered for this device's platform/arch under THIS
+      // server's edition. Before #4093 the explicit branch only checked that
+      // the version string existed in agent_versions at all, so a version with
+      // no build for the device dispatched an update_agent that could only
+      // fail on the box.
       const explicitVersion = input.targetVersion as string | undefined;
       const errors: Record<string, string> = {};
       const targetByDevice = new Map<string, string>();
 
       if (explicitVersion) {
+        // Cheap up-front reject for a version this server serves no agent
+        // build of at all (the common case for a typo or a model-invented
+        // string). Scoped to component+edition so it fails here rather than
+        // in the per-device resolver, which treats a registered-but-missing
+        // build as a fleet-freeze-grade misconfiguration and reports it to
+        // Sentry — the wrong signal for a bad tool argument.
         const [versionRow] = await db
           .select({ version: agentVersions.version })
           .from(agentVersions)
-          .where(eq(agentVersions.version, explicitVersion))
+          .where(
+            and(
+              eq(agentVersions.version, explicitVersion),
+              eq(agentVersions.component, 'agent'),
+              eq(agentVersions.edition, getBinaryEdition()),
+            ),
+          )
           .limit(1);
         if (!versionRow) {
           return JSON.stringify({ error: `Agent version "${explicitVersion}" not found` });
         }
-        for (const id of deviceIds) targetByDevice.set(id, explicitVersion);
-      } else {
-        // Need each device's org (to resolve its effective pin) AND its
-        // platform/arch (to fail closed when the pinned/latest version has no
-        // build for that device). Resolving through resolvePinnedUpgradeTarget
-        // per device — the SAME call the heartbeat uses — is what stops this
-        // manual channel from dispatching an update_agent for a binary that
-        // doesn't exist and reporting it as `queued` (a silent, on-device 60s
-        // timeout the operator never sees).
-        const deviceRows = await db
-          .select({
-            id: devices.id,
-            orgId: devices.orgId,
-            osType: devices.osType,
-            architecture: devices.architecture,
-          })
-          .from(devices)
-          .where(inArray(devices.id, deviceIds));
+      }
 
-        const pinByOrg = new Map<string, string | null>();
-        const failedOrgs = new Set<string>();
+      // Need each device's org (to resolve its effective pin) AND its
+      // platform/arch (to fail closed when the pinned/latest/explicit version
+      // has no build for that device). Resolving through
+      // resolvePinnedUpgradeTarget per device — the SAME call the heartbeat
+      // uses — is what stops this manual channel from dispatching an
+      // update_agent for a binary that doesn't exist and reporting it as
+      // `queued` (a silent, on-device 60s timeout the operator never sees).
+      const deviceRows = await db
+        .select({
+          id: devices.id,
+          orgId: devices.orgId,
+          osType: devices.osType,
+          architecture: devices.architecture,
+        })
+        .from(devices)
+        .where(inArray(devices.id, deviceIds));
 
-        for (const d of deviceRows) {
+      const pinByOrg = new Map<string, string | null>();
+      const failedOrgs = new Set<string>();
+
+      for (const d of deviceRows) {
+        let pin: string | null;
+        if (explicitVersion) {
+          // An explicit version overrides any tenant pin — the org's update
+          // config is not consulted at all on this path.
+          pin = explicitVersion;
+        } else {
           if (failedOrgs.has(d.orgId)) {
             errors[d.id] = 'Failed to resolve version pin for this organization';
             continue;
@@ -286,46 +310,51 @@ export function registerAgentMgmtTools(aiTools: Map<string, AiTool>): void {
               continue;
             }
           }
-
-          const normalizedArch = normalizeAgentArchitecture(d.architecture);
-          if (!d.osType || !normalizedArch) {
-            errors[d.id] = 'Device platform/architecture unknown — cannot resolve an agent build';
-            continue;
-          }
-
-          const pin = pinByOrg.get(d.orgId) ?? null;
-          // pin set → that exact build for this platform/arch (null if missing);
-          // pin null → the globally promoted latest for this platform/arch.
-          // Either way, null means "no build" → fail closed, do not dispatch.
-          let target: string | null;
-          try {
-            target = await resolvePinnedUpgradeTarget({
-              component: 'agent',
-              platform: d.osType,
-              architecture: normalizedArch,
-              pin,
-              agentId: d.id,
-            });
-          } catch {
-            errors[d.id] = 'Failed to resolve an agent build for this device';
-            continue;
-          }
-
-          if (target) {
-            targetByDevice.set(d.id, target);
-          } else {
-            errors[d.id] = pin
-              ? `Pinned agent version "${pin}" has no build for this device (${d.osType}/${normalizedArch})`
-              : 'No agent build available for this device platform/architecture';
-          }
+          pin = pinByOrg.get(d.orgId) ?? null;
         }
 
-        if (targetByDevice.size === 0) {
-          return JSON.stringify({
-            error: 'No latest agent version found',
-            ...(Object.keys(errors).length > 0 ? { errors } : {}),
+        const normalizedArch = normalizeAgentArchitecture(d.architecture);
+        if (!d.osType || !normalizedArch) {
+          errors[d.id] = 'Device platform/architecture unknown — cannot resolve an agent build';
+          continue;
+        }
+
+        // pin set → that exact build for this platform/arch (null if missing);
+        // pin null → the globally promoted latest for this platform/arch.
+        // Either way, null means "no build" → fail closed, do not dispatch.
+        let target: string | null;
+        try {
+          target = await resolvePinnedUpgradeTarget({
+            component: 'agent',
+            platform: d.osType,
+            architecture: normalizedArch,
+            pin,
+            agentId: d.id,
           });
+        } catch {
+          errors[d.id] = 'Failed to resolve an agent build for this device';
+          continue;
         }
+
+        if (target) {
+          targetByDevice.set(d.id, target);
+        } else if (explicitVersion) {
+          errors[d.id] =
+            `Agent version "${explicitVersion}" has no build for this device (${d.osType}/${normalizedArch})`;
+        } else {
+          errors[d.id] = pin
+            ? `Pinned agent version "${pin}" has no build for this device (${d.osType}/${normalizedArch})`
+            : 'No agent build available for this device platform/architecture';
+        }
+      }
+
+      if (targetByDevice.size === 0) {
+        return JSON.stringify({
+          error: explicitVersion
+            ? `Agent version "${explicitVersion}" has no build for any of the selected devices`
+            : 'No latest agent version found',
+          ...(Object.keys(errors).length > 0 ? { errors } : {}),
+        });
       }
 
       // Dispatch upgrade commands

--- a/apps/api/src/services/commandQueue.test.ts
+++ b/apps/api/src/services/commandQueue.test.ts
@@ -1079,6 +1079,247 @@ describe('command queue service', () => {
     });
   });
 
+  // ============================================================
+  // #4093 — artifact-edition gate on agent-binary update dispatch
+  // ============================================================
+  //
+  // #4072/#4091 taught the HEARTBEAT offer path to withhold an update from a
+  // build that would refuse the served artifact edition after download. The
+  // manual/AI dispatch door (`trigger_agent_upgrade` -> executeCommand with
+  // type 'update_agent') bypassed it entirely — the same failure class as
+  // "manual Remediate ignores enforceMode" (#3381).
+  //
+  // The gate lives here, at executeCommand, because that is the single point
+  // every agent-binary update dispatch funnels through; gating at the one
+  // known caller is how a third caller silently ships ungated.
+  describe('agent-binary update edition gate (#4093)', () => {
+    const ORIGINAL_EDITION = process.env.BINARY_EDITION;
+
+    function mockDevice(device: Record<string, unknown>) {
+      let pollCall = 0;
+      vi.mocked(db.select).mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockImplementation(() => {
+              pollCall += 1;
+              if (pollCall === 1) return Promise.resolve([device]);
+              return Promise.resolve([
+                { id: 'cmd-e', status: 'completed', result: { status: 'completed' } },
+              ]);
+            }),
+          }),
+        }),
+      }) as any);
+      const insertValues = vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{ id: 'cmd-e', type: 'update_agent' }]),
+        execute: vi.fn().mockResolvedValue(undefined),
+      });
+      vi.mocked(db.insert).mockReturnValue({ values: insertValues } as any);
+      return insertValues;
+    }
+
+    // A device stranded in the 0.105.0-0.106.x band: it carries the client-side
+    // edition check but is a self-host build, and it predates edition
+    // reporting, so agent_edition is NULL.
+    const strandedDevice = {
+      id: 'dev-stranded',
+      status: 'online',
+      agentId: 'agent-stranded',
+      orgId: 'org-1',
+      hostname: 'stranded-pc',
+      watchdogLastSeen: new Date(),
+      agentEdition: null,
+      agentVersion: '0.105.1',
+      watchdogVersion: '0.105.1',
+    };
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      process.env.BINARY_EDITION = 'hosted';
+    });
+
+    afterEach(() => {
+      if (ORIGINAL_EDITION === undefined) delete process.env.BINARY_EDITION;
+      else process.env.BINARY_EDITION = ORIGINAL_EDITION;
+    });
+
+    it('refuses update_agent for a build that would reject the served edition', async () => {
+      const insertValues = mockDevice(strandedDevice);
+
+      const result = await executeCommand(
+        'dev-stranded',
+        'update_agent',
+        { version: '0.108.0' },
+        { userId: 'user-1', targetRole: 'watchdog' },
+      );
+
+      expect(result.status).toBe('failed');
+      expect(result.error).toMatch(/edition/i);
+      // The command row must never be written — a dispatched command whose
+      // artifact the device refuses is a wasted one-shot the operator has to
+      // decode from a raw updater error.
+      expect(insertValues).not.toHaveBeenCalled();
+    });
+
+    it('refuses update_watchdog on the same grounds', async () => {
+      const insertValues = mockDevice(strandedDevice);
+
+      const result = await executeCommand(
+        'dev-stranded',
+        'update_watchdog',
+        { version: '0.108.0' },
+        { userId: 'user-1', targetRole: 'watchdog' },
+      );
+
+      expect(result.status).toBe('failed');
+      expect(result.error).toMatch(/edition/i);
+      expect(insertValues).not.toHaveBeenCalled();
+    });
+
+    it('allows update_agent when the device reports its edition (transition-capable build)', async () => {
+      const insertValues = mockDevice({ ...strandedDevice, agentEdition: 'self-host', agentVersion: '0.108.0', watchdogVersion: '0.108.0' });
+
+      const result = await executeCommand(
+        'dev-stranded',
+        'update_agent',
+        { version: '0.109.0' },
+        { userId: 'user-1', targetRole: 'watchdog' },
+      );
+
+      expect(result.status).toBe('completed');
+      expect(insertValues).toHaveBeenCalled();
+    });
+
+    it('allows update_agent for a pre-check build (< 0.105.0) with no reported edition', async () => {
+      const insertValues = mockDevice({ ...strandedDevice, agentVersion: '0.104.0', watchdogVersion: '0.104.0' });
+
+      const result = await executeCommand(
+        'dev-stranded',
+        'update_agent',
+        { version: '0.108.0' },
+        { userId: 'user-1', targetRole: 'watchdog' },
+      );
+
+      expect(result.status).toBe('completed');
+      expect(insertValues).toHaveBeenCalled();
+    });
+
+    // The WATCHDOG performs the download for a targetRole:'watchdog' command
+    // (agent/cmd/breeze-watchdog handleFailoverCommand -> doUpdateAgent), so
+    // the band inference must key on the watchdog's version, not the main
+    // agent's. Same reasoning as heartbeat.ts's failover branch.
+    it('keys the version band on the WATCHDOG version for watchdog-targeted dispatch', async () => {
+      const insertValues = mockDevice({
+        ...strandedDevice,
+        agentVersion: '0.104.0', // main agent predates the check
+        watchdogVersion: '0.105.1', // but the downloading watchdog does not
+      });
+
+      const result = await executeCommand(
+        'dev-stranded',
+        'update_agent',
+        { version: '0.108.0' },
+        { userId: 'user-1', targetRole: 'watchdog' },
+      );
+
+      expect(result.status).toBe('failed');
+      expect(result.error).toMatch(/edition/i);
+      expect(insertValues).not.toHaveBeenCalled();
+    });
+
+    it('allows a watchdog older than the check band even when the main agent is inside it', async () => {
+      // The watchdog is the downloader; a pre-0.105.0 watchdog has no edition
+      // check and applies the artifact fine, whatever the wedged main agent is.
+      const insertValues = mockDevice({
+        ...strandedDevice,
+        agentVersion: '0.105.1',
+        watchdogVersion: '0.104.0',
+      });
+
+      const result = await executeCommand(
+        'dev-stranded',
+        'update_agent',
+        { version: '0.108.0' },
+        { userId: 'user-1', targetRole: 'watchdog' },
+      );
+
+      expect(result.status).toBe('completed');
+      expect(insertValues).toHaveBeenCalled();
+    });
+
+    // The main agent has no handler for update_agent/update_watchdog: an
+    // agent-targeted row is sent to the agent WebSocket and never picked up,
+    // so it is a dead command, not merely an ungated one.
+    it('refuses an agent-targeted agent-binary update outright', async () => {
+      const insertValues = mockDevice({
+        ...strandedDevice,
+        agentEdition: 'hosted',
+        agentVersion: '0.108.0',
+        watchdogVersion: '0.108.0',
+      });
+
+      const result = await executeCommand(
+        'dev-stranded',
+        'update_agent',
+        { version: '0.109.0' },
+        { userId: 'user-1' }, // default targetRole: 'agent'
+      );
+
+      expect(result.status).toBe('failed');
+      expect(result.error).toMatch(/targetRole 'watchdog'/);
+      expect(insertValues).not.toHaveBeenCalled();
+    });
+
+    // A hosted build hard-refuses a self-host artifact by design (that
+    // direction would strip the host-policy allowlist), so a self-host server
+    // must not push one at a hosted-edition agent either.
+    it('refuses pushing a self-host artifact at a hosted-edition build', async () => {
+      process.env.BINARY_EDITION = 'self-host';
+      const insertValues = mockDevice({ ...strandedDevice, agentEdition: 'hosted', agentVersion: '0.108.0', watchdogVersion: '0.108.0' });
+
+      const result = await executeCommand(
+        'dev-stranded',
+        'update_agent',
+        { version: '0.108.0' },
+        { userId: 'user-1', targetRole: 'watchdog' },
+      );
+
+      expect(result.status).toBe('failed');
+      expect(result.error).toMatch(/edition/i);
+      expect(insertValues).not.toHaveBeenCalled();
+    });
+
+    // The gate is scoped to agent-binary update types only. A watchdog RESTART
+    // downloads nothing, so an edition-incompatible build must still be able
+    // to receive it — that is the recovery path for the very devices the gate
+    // withholds updates from.
+    it('does not gate non-update commands (restart_agent still dispatches)', async () => {
+      const insertValues = mockDevice(strandedDevice);
+
+      const result = await executeCommand(
+        'dev-stranded',
+        'restart_agent',
+        {},
+        { userId: 'user-1', targetRole: 'watchdog' },
+      );
+
+      expect(result.status).toBe('completed');
+      expect(insertValues).toHaveBeenCalled();
+    });
+
+    // queueCommand is the SIBLING device_commands insert site. It has no
+    // device row (BullMQ workers call it with no DB context), so it cannot
+    // evaluate the gate — it must refuse these types outright rather than
+    // become an ungated back door.
+    it('queueCommand refuses agent-binary update types outright', async () => {
+      await expect(queueCommand('dev-stranded', 'update_agent', { version: '0.108.0' }))
+        .rejects.toThrow(/executeCommand/i);
+      await expect(queueCommand('dev-stranded', 'update_watchdog', { version: '0.108.0' }))
+        .rejects.toThrow(/executeCommand/i);
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+  });
+
   describe('queueCommandForExecution expectedOrgId guard', () => {
     function mockDeviceLookup(device: unknown) {
       vi.mocked(db.select).mockReturnValue({

--- a/apps/api/src/services/commandQueue.test.ts
+++ b/apps/api/src/services/commandQueue.test.ts
@@ -1161,6 +1161,50 @@ describe('command queue service', () => {
       expect(insertValues).not.toHaveBeenCalled();
     });
 
+    // The refusal is the operator's only correlation signal when the dispatch
+    // came from an automated caller, so it must reach the logs, not just the
+    // return value.
+    it('logs the refusal with the device id so ops can correlate it', async () => {
+      mockDevice(strandedDevice);
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      await executeCommand(
+        'dev-stranded',
+        'update_agent',
+        { version: '0.108.0' },
+        { userId: 'user-1', targetRole: 'watchdog' },
+      );
+
+      const logged = warn.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(logged).toContain('dev-stranded');
+      expect(logged).toContain('#4093');
+      warn.mockRestore();
+    });
+
+    // Ordering contract: the edition gate must be evaluated BEFORE the
+    // watchdog-liveness gate. An edition mismatch is a permanent property of
+    // the installed build; reporting the transient "watchdog is not reporting"
+    // instead would send the operator back to retry a dispatch that can never
+    // succeed. Swap the two blocks in executeCommand and this fails.
+    it('reports the permanent edition reason ahead of a stale-watchdog reason', async () => {
+      const insertValues = mockDevice({
+        ...strandedDevice,
+        watchdogLastSeen: new Date(Date.now() - 60 * 60 * 1000), // an hour stale
+      });
+
+      const result = await executeCommand(
+        'dev-stranded',
+        'update_agent',
+        { version: '0.108.0' },
+        { userId: 'user-1', targetRole: 'watchdog' },
+      );
+
+      expect(result.status).toBe('failed');
+      expect(result.error).toMatch(/edition/i);
+      expect(result.error).not.toMatch(/not reporting/i);
+      expect(insertValues).not.toHaveBeenCalled();
+    });
+
     it('refuses update_watchdog on the same grounds', async () => {
       const insertValues = mockDevice(strandedDevice);
 

--- a/apps/api/src/services/commandQueue.ts
+++ b/apps/api/src/services/commandQueue.ts
@@ -9,6 +9,10 @@ import {
   releaseClaimedCommandDelivery,
 } from './commandDispatch';
 import { commandAuditDetails } from './commandAudit';
+import {
+  AGENT_BINARY_UPDATE_COMMAND_TYPES,
+  agentBinaryUpdateDispatchRefusal,
+} from './agentEditionCompat';
 import { recordCommandDispatch } from './anomalyMetrics';
 import {
   decryptCommandForDelivery,
@@ -605,6 +609,21 @@ export async function queueCommand(
   // default. Never accept a client-supplied value.
   options: { commandId?: string } = {}
 ): Promise<QueuedCommand> {
+  // #4093 — agent-binary updates must not be created here. This insert site
+  // cannot set target_role (the row would default to 'agent', which has no
+  // handler for these types) and has no device row to evaluate the
+  // artifact-edition gate against. `executeCommand` is the one dispatch path
+  // that does both; refuse loudly rather than let this become the ungated
+  // back door. Checked FIRST: it is a pure Set lookup, so a refused type never
+  // pays for the `resolveCommandCreatedBy` users probe below.
+  if (AGENT_BINARY_UPDATE_COMMAND_TYPES.has(type)) {
+    throw new Error(
+      `${type} cannot be queued through queueCommand — dispatch it via ` +
+        `executeCommand(deviceId, '${type}', payload, { targetRole: 'watchdog' }) ` +
+        `so the artifact-edition gate (#4093) and the watchdog target role are applied.`,
+    );
+  }
+
   // Never stamp `userId` verbatim — it may be a synthetic-auth id with no
   // `users` row, which would fail the created_by FK with 23503 (#3978).
   const safeUserId = await resolveCommandCreatedBy(deviceId, userId);
@@ -930,6 +949,8 @@ export async function executeCommand(
   const dispatchViaWs = targetRole === 'agent' && !preferHeartbeat;
 
   // 1. Verify device inside the auth transaction (RLS-protected).
+  // agentEdition/agentVersion/watchdogVersion feed the artifact-edition gate
+  // below (#4093) — cheap here because this SELECT already runs.
   const [device] = await db
     .select({
       id: devices.id,
@@ -938,6 +959,9 @@ export async function executeCommand(
       orgId: devices.orgId,
       hostname: devices.hostname,
       watchdogLastSeen: devices.watchdogLastSeen,
+      agentEdition: devices.agentEdition,
+      agentVersion: devices.agentVersion,
+      watchdogVersion: devices.watchdogVersion,
     })
     .from(devices)
     .where(eq(devices.id, deviceId))
@@ -945,6 +969,24 @@ export async function executeCommand(
 
   if (!device) {
     return { status: 'failed', error: 'Device not found' };
+  }
+
+  // #4093 — artifact-edition gate for agent-binary updates, at the dispatch
+  // chokepoint. Runs BEFORE the liveness gates below on purpose: an edition
+  // mismatch is a permanent property of the installed build, so reporting the
+  // transient "watchdog is not reporting" first would send the operator back
+  // to retry a dispatch that can never succeed. Inert for every other command
+  // type (see AGENT_BINARY_UPDATE_COMMAND_TYPES).
+  const editionRefusal = agentBinaryUpdateDispatchRefusal({
+    commandType: type,
+    targetRole,
+    device,
+  });
+  if (editionRefusal) {
+    console.warn(
+      `[commandQueue] ${type} dispatch refused for device ${deviceId} (#4093): ${editionRefusal}`,
+    );
+    return { status: 'failed', error: editionRefusal };
   }
 
   if (targetRole === 'watchdog') {


### PR DESCRIPTION
## What

`trigger_agent_upgrade` (AI chat + MCP) resolved a target through the edition-scoped `resolvePinnedUpgradeTarget` and then queued `update_agent` **unconditionally** — never consulting `agentAcceptsServedEdition`, the gate #4072/PR #4091 added to the heartbeat offer path. On a hosted control plane, "update these agents" over a stranded 0.105.0–0.106.x self-host device dispatched a command whose artifact the agent refuses after download. Same failure class as "manual Remediate ignores enforceMode" (#3381): the manual door bypasses the gate the automatic door honors.

## Where the gate went, and why

**`services/commandQueue.ts` `executeCommand`** — the single point every agent-binary update dispatch funnels through — not the one known caller. Gating a call site is how the third call site ships ungated; this repo has that scar five times over. `executeCommand` already loads the device row and already carries command-type (`INTERACTIVE_COMMAND_TYPES`) and target-role (watchdog liveness) policy, so the gate costs three extra selected columns plus a pure predicate. It runs **before** the liveness gates: an edition mismatch is a permanent property of the installed build, so reporting the transient "watchdog is not reporting" first would send the operator back to retry a dispatch that can never succeed.

Two further holes closed at the same layer:

- **`queueCommand` refuses these types outright.** It is the sibling `device_commands` insert site (used by `queueCommandForExecution` and BullMQ workers). It cannot set `target_role` — the row would default to `'agent'`, which has no handler — and has no device row to evaluate the gate against, so it can never be a correct dispatcher for them.
- **`update_agent` / `update_watchdog` must target the watchdog.** `agent/cmd/breeze-watchdog` `handleFailoverCommand` is the only consumer; an agent-targeted row goes to the agent WebSocket and is never picked up.

The AI tool needed no gate of its own — it already maps `executeCommand`'s `{status:'failed', error}` into its per-device `errors` map, so the refusal reaches the operator per device, naming the observed edition and version.

## Dispatch paths audited

| Path | Creates an agent-binary update? | Status |
|---|---|---|
| `routes/agents/heartbeat.ts` main branch (`upgradeTo`, `helperUpgradeTo`, `watchdogUpgradeTo`) | offer, not a command | already gated (#4072) |
| `routes/agents/heartbeat.ts` watchdog-failover branch (`watchdogUpgradeTo`, recovery `upgradeTo`) | offer, not a command | already gated (#4072) |
| `services/aiToolsAgentMgmt.ts` `trigger_agent_upgrade` — AI chat **and** `routes/mcpServer.ts` / `routes/mcpExecutionOrg.ts` (same shared `aiTools` registry, not a separate implementation) | `update_agent`, `targetRole:'watchdog'` | **the bug — now gated** |
| `POST /devices/:id/commands`, `POST /devices/bulk/commands`, `routes/mobile.ts` device action | zod enums that cannot express these types | n/a (the stray `'update'` enum member has no consumer server- or agent-side) |
| `routes/agentVersions.ts` promote ("fleet promote") | flips `isLatest` only; no dispatch | n/a — feeds the gated resolvers |
| `routes/devPush.ts` `dev_update` | explicit URL + checksum, never a signed release manifest, so `updater.editionAllowed` is never consulted | n/a by design — deliberately excluded from the gate |
| `scripts/recover-stuck-agents.ts` | `dev_update` for 0.65.5–0.65.9 only, all below the check band | n/a |
| deployments, workers/jobs, `ee/`, `packages/` | no agent-binary update dispatch exists | n/a |

`update_agent` is named in exactly one non-test API file today, and a static contract test now pins that set — a future hand-rolled `db.insert(deviceCommands)` dispatcher trips a test instead of shipping ungated.

## Module move

`parseComparableVersion` / `compareAgentVersions` / `AGENT_EDITION_CHECK_INTRODUCED` / `agentAcceptsServedEdition` move from `routes/agents/helpers.ts` to a new leaf `services/agentEditionCompat.ts`. `helpers.ts` imports `services/commandQueue`, so importing the predicate back would have closed an import cycle; a lazy import would have hidden the layering problem rather than fixed it. `helpers.ts` re-exports every moved symbol, so all existing import sites — and the suites that `vi.mock('./helpers')` — are untouched. The withhold wording (`editionWithheldDetail`) is now shared, so both doors describe the same condition in the same words.

## Downloader identity

The watchdog performs the download for these commands, so:

- **Version** reads `watchdogVersion`, written alongside `watchdogLastSeen` on every watchdog beat (`heartbeat.ts`), falling back to `agentVersion` only for pre-telemetry rows — agent and watchdog install and upgrade from the same lane.
- **Edition** uses `agentEdition` as the watchdog's proxy. There is no `watchdogEdition` column; this is exactly the stand-in, and the same documented imprecision, that `heartbeat.ts`'s failover branch already accepts. Persisting the watchdog's own reported edition would sharpen it and is a reasonable follow-up — it needs a migration plus the `CORE_TENANT_EXPORT_POLICY` column registration, so it is deliberately out of scope here.

## Second hole named by the issue

An explicit `targetVersion` bypassed edition/platform/arch resolution entirely — it only checked the version string existed in `agent_versions` at all, so a version with no build for a device dispatched an `update_agent` that could only 404 on the box while the tool reported `queued`. It now runs through the same per-device `resolvePinnedUpgradeTarget` call the pin path uses, behind a cheap component+edition-scoped existence probe so a typo'd or model-invented version fails fast instead of tripping the resolver's fleet-freeze Sentry capture.

## Verification

- Red first: 6 new `commandQueue` tests failed with `expected 'completed' to be 'failed'` (the ungated dispatch) before the change; the explicit-version test failed on the old resolution path. The static contract test was proven to discriminate by planting a probe file that names `update_agent`.
- `vitest run` (single fork) green: `agentEditionCompat.test.ts`, `commandQueue.test.ts`, `aiToolsAgentMgmt.test.ts`, `heartbeat.test.ts`, `helpers.agentUpdatePolicy.test.ts` — **268 passed**. Plus `commands.test.ts`, `agentWs.test.ts`, `devices/commands.test.ts`, all `routes/agents/helpers.*.test.ts`, `__tests__/helpers.test.ts` — 321 passed.
- `tsc --noEmit` clean; `eslint src` clean.
- No schema, migration, or tenancy surface touched.

Closes #4093

🤖 Generated with [Claude Code](https://claude.com/claude-code)