### PR TITLE
feat(web,api): P2-4b — ticket triage web: AI-draft send-as-me/discard/resolve prefill, autonomy toggle, triage run surfaces (8 locales)

### DIFF
--- a/apps/api/src/routes/tickets/aiDrafts.ts
+++ b/apps/api/src/routes/tickets/aiDrafts.ts
@@ -7,9 +7,10 @@ import { listActiveTicketDrafts, sendTicketDraft, discardTicketDraft } from '../
 import { getScopedTicketOr404, actorFrom, handleServiceError } from './tickets';
 
 // P2-4 (#4191), Task A10 — human draft routes: list a ticket's active AI
-// drafts, "send as me" a reply draft, or discard one. A `resolution_note`
-// draft is NEVER sendable/discardable here — it is consumed only via the
-// resolve flow (`POST /:id/status` with `aiDraftId`, tickets.ts). Same
+// drafts, "send as me" a reply draft, or discard one (either kind — discard
+// has no kind restriction). A `resolution_note` draft is NEVER SENDABLE
+// here (sendTicketDraft 409s on kind !== 'reply') — it is consumed only via
+// the resolve flow (`POST /:id/status` with `aiDraftId`, tickets.ts). Same
 // RBAC/org-scoping idiom as the sibling `/:id/triage-suggestion` routes in
 // ./tickets.ts: tickets:read for the list, tickets:write for the mutations,
 // `getScopedTicketOr404` for tenant + site-axis scoping.

--- a/apps/api/src/services/ticketService.test.ts
+++ b/apps/api/src/services/ticketService.test.ts
@@ -932,6 +932,45 @@ describe('changeTicketStatus — aiDraftId (P2-4, #4191, Task A10)', () => {
     expect(draftUpdatePayload.consumedAt).toBeInstanceOf(Date);
   });
 
+  // C1 (final review #4191): a technician-edited resolutionNote supplied
+  // alongside aiDraftId must win over the draft's content — the draft is
+  // still locked/validated/consumed either way. Non-uniform fixture: the
+  // supplied text is deliberately different from the draft content so a
+  // regression that silently prefers the draft would fail loudly.
+  it('C1: supplied resolutionNote wins over draft content on the full-transition path; draft still consumed', async () => {
+    dbMocks.selectResult
+      .mockResolvedValueOnce([{ id: 't-1', orgId: 'o-1', partnerId: 'p-1', status: 'open', resolvedAt: null }])
+      .mockResolvedValueOnce([{ id: 'draft-1', ticketId: 't-1', kind: 'resolution_note', state: 'active', content: 'AI-drafted note' }]);
+    dbMocks.updateReturning
+      .mockResolvedValueOnce([{ id: 't-1', status: 'resolved' }])
+      .mockResolvedValueOnce([{ id: 'draft-1' }]);
+    dbMocks.insertReturning.mockResolvedValue([{ id: 'c-1' }]);
+
+    await changeTicketStatus('t-1', { status: 'resolved' }, { resolutionNote: 'Technician-edited note', aiDraftId: 'draft-1' }, actor);
+
+    const ticketUpdatePayload = setMock.mock.calls[0]![0];
+    expect(ticketUpdatePayload).toMatchObject({ status: 'resolved', resolutionNote: 'Technician-edited note' });
+
+    // Draft was still locked/validated/consumed even though its content lost.
+    const draftUpdatePayload = setMock.mock.calls[1]![0];
+    expect(draftUpdatePayload).toMatchObject({ state: 'consumed', consumedBy: 'u-1' });
+  });
+
+  it('C1: empty/whitespace resolutionNote + aiDraftId falls back to draft content on the full-transition path', async () => {
+    dbMocks.selectResult
+      .mockResolvedValueOnce([{ id: 't-1', orgId: 'o-1', partnerId: 'p-1', status: 'open', resolvedAt: null }])
+      .mockResolvedValueOnce([{ id: 'draft-1', ticketId: 't-1', kind: 'resolution_note', state: 'active', content: 'AI-drafted note' }]);
+    dbMocks.updateReturning
+      .mockResolvedValueOnce([{ id: 't-1', status: 'resolved' }])
+      .mockResolvedValueOnce([{ id: 'draft-1' }]);
+    dbMocks.insertReturning.mockResolvedValue([{ id: 'c-1' }]);
+
+    await changeTicketStatus('t-1', { status: 'resolved' }, { resolutionNote: '   ', aiDraftId: 'draft-1' }, actor);
+
+    const ticketUpdatePayload = setMock.mock.calls[0]![0];
+    expect(ticketUpdatePayload).toMatchObject({ status: 'resolved', resolutionNote: 'AI-drafted note' });
+  });
+
   it('404s when the draft does not exist', async () => {
     dbMocks.selectResult
       .mockResolvedValueOnce([{ id: 't-1', orgId: 'o-1', partnerId: 'p-1', status: 'open', resolvedAt: null }])
@@ -1011,6 +1050,36 @@ describe('changeTicketStatus — aiDraftId (P2-4, #4191, Task A10)', () => {
     const draftUpdatePayload = setMock.mock.calls[1]![0];
     expect(draftUpdatePayload).toMatchObject({ state: 'consumed', consumedBy: 'u-1' });
     expect(draftUpdatePayload.consumedAt).toBeInstanceOf(Date);
+  });
+
+  // C1 (final review #4191): same as the full-transition case above but for
+  // the same-status/statusId-relabel fast path — supplied resolutionNote
+  // still wins over the draft's content.
+  it('C1: supplied resolutionNote wins over draft content on the same-status fast path; draft still consumed', async () => {
+    const ticket = { id: 't-1', orgId: 'o-1', partnerId: 'p-1', status: 'resolved', statusId: 'old-status-id', resolvedAt: new Date('2026-08-01') };
+    dbMocks.selectResult
+      .mockResolvedValueOnce([ticket])
+      .mockResolvedValueOnce([{ id: 'draft-1', ticketId: 't-1', kind: 'resolution_note', state: 'active', content: 'AI relabel note' }]);
+    configMocks.getTicketStatusById.mockResolvedValueOnce({
+      id: 'new-status-id', partnerId: 'p-1', coreStatus: 'resolved', name: 'Resolved - Verified', isActive: true
+    });
+    dbMocks.updateReturning
+      .mockResolvedValueOnce([{ ...ticket, statusId: 'new-status-id', resolutionNote: 'Technician-edited relabel note' }])
+      .mockResolvedValueOnce([{ id: 'draft-1' }]);
+    dbMocks.insertReturning.mockResolvedValue([{ id: 'c-1' }]);
+
+    await changeTicketStatus(
+      't-1',
+      { statusId: 'new-status-id' },
+      { resolutionNote: 'Technician-edited relabel note', aiDraftId: 'draft-1' },
+      actor
+    );
+
+    const ticketUpdatePayload = setMock.mock.calls[0]![0];
+    expect(ticketUpdatePayload).toMatchObject({ statusId: 'new-status-id', resolutionNote: 'Technician-edited relabel note' });
+
+    const draftUpdatePayload = setMock.mock.calls[1]![0];
+    expect(draftUpdatePayload).toMatchObject({ state: 'consumed', consumedBy: 'u-1' });
   });
 
   it('rejects aiDraftId on a non-resolve same-status fast-path transition (different statusId, same core status) with 400', async () => {

--- a/apps/api/src/services/ticketService.ts
+++ b/apps/api/src/services/ticketService.ts
@@ -554,6 +554,12 @@ export interface ChangeStatusOptions {
    * UPDATE` (mirrors `sendTicketDraft`'s locking contract) — a draft that is
    * missing, the wrong kind, or no longer `active` fails the whole resolve
    * with a 404/409 rather than silently resolving without it.
+   *
+   * Review fix (#4191 final review, C1) — this draft is ALWAYS consumed when
+   * supplied, but it does not always win: a non-empty `resolutionNote` on the
+   * same call is the technician's (possibly edited) text and takes priority
+   * over the draft's content. The draft is treated as a fallback/default,
+   * never a silent override of caller-supplied text.
    */
   aiDraftId?: string;
 }
@@ -675,7 +681,15 @@ export async function changeTicketStatus(
   if (toStatus === fromStatus) {
     const now = new Date();
     const patch: Partial<typeof tickets.$inferInsert> = { statusId: resolvedStatusId ?? null, updatedAt: now };
-    if (sameStatusDraft) patch.resolutionNote = sameStatusDraft.content;
+    // C1 (#4191 final review): a non-empty caller-supplied resolutionNote
+    // (e.g. the technician edited the prefilled AI draft before submitting)
+    // wins over the draft's content — the draft is still consumed below.
+    const appliedResolutionNote = sameStatusDraft
+      ? (opts.resolutionNote?.trim() ? opts.resolutionNote : sameStatusDraft.content)
+      : undefined;
+    if (sameStatusDraft) {
+      patch.resolutionNote = appliedResolutionNote;
+    }
     const updated = await db
       .update(tickets)
       .set(patch)
@@ -701,7 +715,7 @@ export async function changeTicketStatus(
     // same core value but swaps the statusId back to the system row (and
     // carries no draft) produces an empty content and identical
     // oldValue/newValue, which would be a no-op noise row in the feed.
-    const feedContent = sameStatusDraft ? sameStatusDraft.content : customStatusName;
+    const feedContent = sameStatusDraft ? appliedResolutionNote : customStatusName;
     if (feedContent) {
       await db.insert(ticketComments).values({
         ticketId,
@@ -745,7 +759,10 @@ export async function changeTicketStatus(
   let draftToConsume: { id: string } | null = null;
   if (toStatus === 'resolved' && opts.aiDraftId) {
     const draft = await lockAndValidateResolutionDraft(ticketId, opts.aiDraftId);
-    resolutionNote = draft.content;
+    // C1 (#4191 final review): a non-empty caller-supplied resolutionNote
+    // (e.g. the technician edited the prefilled AI draft before submitting)
+    // wins over the draft's content — the draft is still consumed below.
+    resolutionNote = opts.resolutionNote?.trim() ? opts.resolutionNote : draft.content;
     draftToConsume = { id: draft.id };
   }
 

--- a/apps/web/src/components/aiAgents/RunDetailPage.test.tsx
+++ b/apps/web/src/components/aiAgents/RunDetailPage.test.tsx
@@ -222,6 +222,33 @@ const NARRATIVE = {
   contextTruncated: false,
 };
 
+// P2-4 (#4191, Task 12) — a `triage`-profile run's ticket proposal
+// (`AiAgentRunTicketProposalDto`). Every field carries a DISTINCT value (not
+// a uniform fixture) so a wrong-field bug — e.g. rendering `priority.value`
+// under the `categoryId` label — cannot hide behind matching text.
+const TICKET_PROPOSAL = {
+  version: 1 as const,
+  summary: 'Printer offline; the user needs the driver reinstalled.',
+  fields: {
+    categoryId: { value: 'cat-hardware-printer', confidence: 0.82 },
+    priority: { value: 'high' as const, confidence: 0.65 },
+  },
+  device: { hostname: 'WKS-07', serial: 'SN-778812' },
+  draftReply: 'Hi Jordan, we are dispatching a fix for the printer driver now.',
+  draftResolutionNote: 'Reinstalled the HP LaserJet driver remotely; test page printed cleanly.',
+  notes: ['User reported the issue at 08:12.', 'No other devices affected on this site.'],
+  intentIds: ['intent-42'],
+  draftsWritten: [{ kind: 'reply' as const, draftId: 'draft-91' }],
+};
+
+const TICKET_INTENT = {
+  id: 'intent-42',
+  status: 'approved',
+  actionName: 'manage_tickets:update_fields',
+  approvalScope: 'supervised' as const,
+  decidedVia: 'policy',
+};
+
 function mockEndpoints(opts: {
   detail?: unknown;
   detailOk?: boolean;
@@ -606,5 +633,80 @@ describe('RunDetailPage narrative', () => {
     // Formatted through the locale date formatter, never the raw ISO string.
     expect(period.textContent).not.toContain('2026-08-17T00:00:00.000Z');
     expect(period.textContent).toContain('2026');
+  });
+});
+
+// P2-4 (#4191, Task 12) — the ticket-triage proposal section: a
+// `triage`-profile run's outcome (`AiAgentRunTicketProposalDto`). Same
+// "renders nothing when absent" contract as the sweep/narrative sections
+// above — `ticketProposal` is null for every other profile.
+describe('RunDetailPage ticket triage proposal', () => {
+  it('renders nothing when the run carries no ticket proposal', async () => {
+    mockEndpoints({ detail: { ...RUN_DETAIL, ticketProposal: null } });
+    render(<RunDetailPage runId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('run-detail-page')).toBeInTheDocument());
+    expect(screen.queryByTestId('ai-agent-run-triage')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('run-detail-profile-triage')).not.toBeInTheDocument();
+  });
+
+  it('badges the run as triage in the header and renders the proposal summary', async () => {
+    mockEndpoints({ detail: { ...RUN_DETAIL, ticketProposal: TICKET_PROPOSAL, intents: [TICKET_INTENT] } });
+    render(<RunDetailPage runId="run-1" />);
+
+    expect(await screen.findByTestId('run-detail-profile-triage')).toBeInTheDocument();
+    expect(screen.getByTestId('ai-agent-run-triage-summary')).toHaveTextContent(TICKET_PROPOSAL.summary);
+  });
+
+  it('renders each proposed field with its OWN confidence — not the sibling field\'s', async () => {
+    mockEndpoints({ detail: { ...RUN_DETAIL, ticketProposal: TICKET_PROPOSAL, intents: [TICKET_INTENT] } });
+    render(<RunDetailPage runId="run-1" />);
+
+    const categoryRow = await screen.findByTestId('ai-agent-run-triage-field-categoryId');
+    expect(categoryRow).toHaveTextContent('cat-hardware-printer');
+    expect(categoryRow).toHaveTextContent('82');
+
+    const priorityRow = screen.getByTestId('ai-agent-run-triage-field-priority');
+    expect(priorityRow).toHaveTextContent('high');
+    expect(priorityRow).toHaveTextContent('65');
+    // Cross-contamination guard: the category row must not carry priority's
+    // confidence value, and vice versa.
+    expect(categoryRow).not.toHaveTextContent('65');
+    expect(priorityRow).not.toHaveTextContent('82');
+  });
+
+  it('renders the proposed device identifiers, notes, and both drafts', async () => {
+    mockEndpoints({ detail: { ...RUN_DETAIL, ticketProposal: TICKET_PROPOSAL, intents: [TICKET_INTENT] } });
+    render(<RunDetailPage runId="run-1" />);
+
+    await waitFor(() => screen.getByTestId('ai-agent-run-triage'));
+    expect(screen.getByTestId('ai-agent-run-triage-device')).toHaveTextContent('WKS-07');
+    expect(screen.getByTestId('ai-agent-run-triage-device')).toHaveTextContent('SN-778812');
+    expect(screen.getByTestId('ai-agent-run-triage-notes')).toHaveTextContent('User reported the issue at 08:12.');
+    expect(screen.getByTestId('ai-agent-run-triage-notes')).toHaveTextContent('No other devices affected on this site.');
+    expect(screen.getByTestId('ai-agent-run-triage-draft-reply')).toHaveTextContent(TICKET_PROPOSAL.draftReply);
+    expect(screen.getByTestId('ai-agent-run-triage-draft-resolution')).toHaveTextContent(TICKET_PROPOSAL.draftResolutionNote);
+  });
+
+  it('links a proposal intent to its live status from the run\'s intents array, and lists the draft written', async () => {
+    mockEndpoints({ detail: { ...RUN_DETAIL, ticketProposal: TICKET_PROPOSAL, intents: [TICKET_INTENT] } });
+    render(<RunDetailPage runId="run-1" />);
+
+    const intentRow = await screen.findByTestId('ai-agent-run-triage-intent-intent-42');
+    expect(intentRow).toHaveTextContent('manage_tickets:update_fields');
+    expect(intentRow).toHaveTextContent('approved');
+
+    expect(screen.getByTestId('ai-agent-run-triage-draft-draft-91')).toBeInTheDocument();
+  });
+
+  it('never renders raw tool args/input/output anywhere in the triage section', async () => {
+    mockEndpoints({ detail: { ...RUN_DETAIL, ticketProposal: TICKET_PROPOSAL, intents: [TICKET_INTENT] } });
+    const { container } = render(<RunDetailPage runId="run-1" />);
+
+    await waitFor(() => screen.getByTestId('ai-agent-run-triage'));
+    const html = container.innerHTML;
+    for (const forbidden of ['toolInput', 'toolOutput', 'args', 'arguments']) {
+      expect(html).not.toContain(forbidden);
+    }
   });
 });

--- a/apps/web/src/components/aiAgents/RunDetailPage.tsx
+++ b/apps/web/src/components/aiAgents/RunDetailPage.tsx
@@ -9,6 +9,7 @@ import { formatCurrency, formatNumber } from '@/lib/i18n/format';
 import type {
   AiAgentRunDetailDto,
   AiAgentRunSweepFindingDto,
+  AiAgentRunTicketProposalDto,
   AiAgentRunTraceEntryDto,
   AiSweepKind,
   AiSweepSeverity,
@@ -397,6 +398,166 @@ function NarrativeSectionBlock({
   );
 }
 
+function draftKindLabel(t: (key: string) => string, kind: 'reply' | 'resolution_note'): string {
+  return kind === 'reply'
+    ? t('aiAgentsPage.runs.triage.draftKinds.reply')
+    : t('aiAgentsPage.runs.triage.draftKinds.resolutionNote');
+}
+
+/**
+ * P2-4 (#4191, Task 12) — a `triage`-profile run's ticket proposal
+ * (`AiAgentRunTicketProposalDto`). Same safe-projection posture as the sweep
+ * and narrative sections above: every field on this DTO is already
+ * display-safe by construction (`mapTicketProposal`, runTrace.ts — named-field
+ * projection, no raw tool payload).
+ *
+ * `intentIds` only names ids; the STATUS shown for each comes from the run's
+ * own `intents` array (already fetched for the "Linked approvals" section
+ * below) rather than being duplicated onto the proposal DTO — a live
+ * cross-reference by id, falling back to the bare id if the run's intents
+ * projection ever disagrees with it (defensive only; in practice
+ * `intentIds` is populated FROM the same `action_intents` rows).
+ */
+function TicketProposalSection({
+  proposal,
+  intents,
+  t,
+}: {
+  proposal: AiAgentRunTicketProposalDto;
+  intents: AiAgentRunDetailDto['intents'];
+  t: (key: string, opts?: Record<string, unknown>) => string;
+}) {
+  const intentsById = new Map(intents.map((intent) => [intent.id, intent]));
+  const hasFields = proposal.fields && (proposal.fields.categoryId || proposal.fields.priority);
+  const hasDevice = proposal.device && (proposal.device.hostname || proposal.device.serial);
+
+  return (
+    <section data-testid="ai-agent-run-triage" className="rounded-lg border bg-card p-4">
+      <h2 className="text-sm font-semibold">{t('aiAgentsPage.runs.triage.title')}</h2>
+
+      <p className="mt-2 text-sm" data-testid="ai-agent-run-triage-summary">
+        {proposal.summary}
+      </p>
+
+      {hasFields && (
+        <div className="mt-3 space-y-1" data-testid="ai-agent-run-triage-fields">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            {t('aiAgentsPage.runs.triage.fieldsTitle')}
+          </h3>
+          <ul className="space-y-1 text-sm">
+            {proposal.fields?.categoryId && (
+              <li data-testid="ai-agent-run-triage-field-categoryId">
+                <span className="font-medium">{t('aiAgentsPage.runs.triage.fields.categoryId')}</span>
+                {': '}
+                <span>{proposal.fields.categoryId.value}</span>{' '}
+                <span className="text-xs text-muted-foreground">
+                  {t('aiAgentsPage.runs.triage.confidence', {
+                    value: Math.round(proposal.fields.categoryId.confidence * 100),
+                  })}
+                </span>
+              </li>
+            )}
+            {proposal.fields?.priority && (
+              <li data-testid="ai-agent-run-triage-field-priority">
+                <span className="font-medium">{t('aiAgentsPage.runs.triage.fields.priority')}</span>
+                {': '}
+                <span>{proposal.fields.priority.value}</span>{' '}
+                <span className="text-xs text-muted-foreground">
+                  {t('aiAgentsPage.runs.triage.confidence', {
+                    value: Math.round(proposal.fields.priority.confidence * 100),
+                  })}
+                </span>
+              </li>
+            )}
+          </ul>
+        </div>
+      )}
+
+      {hasDevice && (
+        <p className="mt-2 text-sm text-muted-foreground" data-testid="ai-agent-run-triage-device">
+          {t('aiAgentsPage.runs.triage.device', {
+            value: [proposal.device?.hostname, proposal.device?.serial].filter(Boolean).join(' / '),
+          })}
+        </p>
+      )}
+
+      {proposal.draftReply && (
+        <div className="mt-3" data-testid="ai-agent-run-triage-draft-reply">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            {t('aiAgentsPage.runs.triage.draftReplyTitle')}
+          </h3>
+          <p className="mt-1 whitespace-pre-wrap text-sm">{proposal.draftReply}</p>
+        </div>
+      )}
+
+      {proposal.draftResolutionNote && (
+        <div className="mt-3" data-testid="ai-agent-run-triage-draft-resolution">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            {t('aiAgentsPage.runs.triage.draftResolutionTitle')}
+          </h3>
+          <p className="mt-1 whitespace-pre-wrap text-sm">{proposal.draftResolutionNote}</p>
+        </div>
+      )}
+
+      {proposal.notes && proposal.notes.length > 0 && (
+        <div className="mt-3" data-testid="ai-agent-run-triage-notes">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            {t('aiAgentsPage.runs.triage.notesTitle')}
+          </h3>
+          <ul className="mt-1 list-disc space-y-0.5 pl-5 text-sm text-muted-foreground">
+            {proposal.notes.map((note, index) => (
+              <li key={index}>{note}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {proposal.intentIds && proposal.intentIds.length > 0 && (
+        <div className="mt-3" data-testid="ai-agent-run-triage-intents">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            {t('aiAgentsPage.runs.triage.intentsTitle')}
+          </h3>
+          <ul className="mt-1 space-y-1 text-sm">
+            {proposal.intentIds.map((intentId) => {
+              const intent = intentsById.get(intentId);
+              return (
+                <li
+                  key={intentId}
+                  className="flex flex-wrap items-center gap-2"
+                  data-testid={`ai-agent-run-triage-intent-${intentId}`}
+                >
+                  <span className="font-medium">{intent?.actionName ?? intentId}</span>
+                  <span className="text-xs text-muted-foreground">
+                    {intent?.status ?? t('aiAgentsPage.runs.triage.intentUnknown')}
+                  </span>
+                  <a href="/approvals" className="text-primary hover:underline">
+                    {t('aiAgentsPage.runs.detail.intents.viewAll')}
+                  </a>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+
+      {proposal.draftsWritten && proposal.draftsWritten.length > 0 && (
+        <div className="mt-3" data-testid="ai-agent-run-triage-drafts-written">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            {t('aiAgentsPage.runs.triage.draftsWrittenTitle')}
+          </h3>
+          <ul className="mt-1 space-y-0.5 text-sm text-muted-foreground">
+            {proposal.draftsWritten.map((draft) => (
+              <li key={draft.draftId} data-testid={`ai-agent-run-triage-draft-${draft.draftId}`}>
+                {draftKindLabel(t, draft.kind)}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
+  );
+}
+
 function ExposureBudgetCard({ orgId, kind, t }: { orgId: string; kind: string; t: (key: string, opts?: Record<string, unknown>) => string }) {
   const [budget, setBudget] = useState<ExposureBudgetDto | null>(null);
   const [loading, setLoading] = useState(true);
@@ -613,6 +774,18 @@ export default function RunDetailPage({ runId }: RunDetailPageProps) {
           <span className={`inline-flex rounded px-1.5 py-0.5 text-xs font-medium ${verdictBadgeClass(run.runVerdict)}`}>
             {verdictLabel(t, run.runVerdict)}
           </span>
+          {/* P2-4 (#4191, Task 12) — the detail DTO carries no `profile`
+              field (unlike the list item), so `ticketProposal !== null` is
+              the discriminator, same as the sweep/narrative sections below
+              gating on their own null-checked field. */}
+          {run.ticketProposal && (
+            <span
+              data-testid="run-detail-profile-triage"
+              className="inline-flex rounded bg-teal-500/10 px-1.5 py-0.5 text-xs font-medium text-teal-700"
+            >
+              {t('aiAgentsPage.runs.profile.triage')}
+            </span>
+          )}
         </div>
 
         <dl className="mt-3 grid grid-cols-2 gap-x-6 gap-y-2 text-sm sm:grid-cols-4">
@@ -694,6 +867,14 @@ export default function RunDetailPage({ runId }: RunDetailPageProps) {
 
       {run.orgId && run.agentKind && (
         <ExposureBudgetCard orgId={run.orgId} kind={run.agentKind} t={t} />
+      )}
+
+      {/* Phase 2 wave P2-4 (#4191, Task 12) — a `triage`-profile run's
+          ticket proposal. Null for every other profile, so the whole
+          section is absent rather than empty for them (same contract as
+          the sweep/narrative sections below). */}
+      {run.ticketProposal && (
+        <TicketProposalSection proposal={run.ticketProposal} intents={run.intents} t={t} />
       )}
 
       {/* Phase 2 wave P2-2 (#4189) — a `sweep`-profile run's findings. Null

--- a/apps/web/src/components/aiAgents/RunDetailPage.tsx
+++ b/apps/web/src/components/aiAgents/RunDetailPage.tsx
@@ -447,9 +447,13 @@ function TicketProposalSection({
           <ul className="space-y-1 text-sm">
             {proposal.fields?.categoryId && (
               <li data-testid="ai-agent-run-triage-field-categoryId">
-                <span className="font-medium">{t('aiAgentsPage.runs.triage.fields.categoryId')}</span>
+                {/* I3 (#4191 final review): this value is a raw category UUID
+                    (no catalog fetch here to resolve it to a name) — the
+                    "ID" label plus monospace styling makes that legible
+                    instead of reading as a broken/garbled category name. */}
+                <span className="font-medium">{t('aiAgentsPage.runs.triage.fields.categoryIdLabel')}</span>
                 {': '}
-                <span>{proposal.fields.categoryId.value}</span>{' '}
+                <span className="font-mono text-xs">{proposal.fields.categoryId.value}</span>{' '}
                 <span className="text-xs text-muted-foreground">
                   {t('aiAgentsPage.runs.triage.confidence', {
                     value: Math.round(proposal.fields.categoryId.confidence * 100),

--- a/apps/web/src/components/aiAgents/RunsListPage.test.tsx
+++ b/apps/web/src/components/aiAgents/RunsListPage.test.tsx
@@ -225,6 +225,29 @@ describe('RunsListPage', () => {
     expect(screen.queryByTestId('ai-agent-run-profile-narrative-run-2')).not.toBeInTheDocument();
   });
 
+  // P2-4 (#4191, Task 12) — a triage-profile run is a ticket outcome, not a
+  // device incident; the badge is what tells the two apart in a mixed list,
+  // same as the sweep/narrative badges above.
+  it('badges a triage-profile run beside its verdict', async () => {
+    mockEndpoints({ runs: [{ ...RUN_1, id: 'run-5', profile: 'triage' as const }] });
+    render(<RunsListPage />);
+
+    await waitFor(() => expect(screen.getByTestId('runs-list-table')).toBeInTheDocument());
+    expect(screen.getByTestId('ai-agent-run-profile-triage-run-5')).toBeInTheDocument();
+    // The three profile badges are mutually exclusive.
+    expect(screen.queryByTestId('ai-agent-run-profile-sweep-run-5')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('ai-agent-run-profile-narrative-run-5')).not.toBeInTheDocument();
+  });
+
+  it('omits the triage badge for every other run profile', async () => {
+    mockEndpoints({ runs: [{ ...RUN_1, id: 'run-4', profile: 'sweep' as const }, RUN_2] });
+    render(<RunsListPage />);
+
+    await waitFor(() => expect(screen.getByTestId('runs-list-table')).toBeInTheDocument());
+    expect(screen.queryByTestId('ai-agent-run-profile-triage-run-4')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('ai-agent-run-profile-triage-run-2')).not.toBeInTheDocument();
+  });
+
   it('hides the Organization column when a single org is selected', async () => {
     mockEndpoints();
     render(<RunsListPage />);

--- a/apps/web/src/components/aiAgents/RunsListPage.tsx
+++ b/apps/web/src/components/aiAgents/RunsListPage.tsx
@@ -366,6 +366,18 @@ export default function RunsListPage() {
                           {t('aiAgentsPage.runs.profile.narrative')}
                         </span>
                       )}
+                      {/* Phase 2 wave P2-4 (#4191, Task 12) — a triage-profile
+                          run is a ticket outcome, not a device incident; same
+                          "tell the two apart in a mixed list" rationale as
+                          the sweep/narrative badges above. */}
+                      {run.profile === 'triage' && (
+                        <span
+                          data-testid={`ai-agent-run-profile-triage-${run.id}`}
+                          className="ml-1.5 inline-flex rounded bg-teal-500/10 px-1.5 py-0.5 text-xs font-medium text-teal-700"
+                        >
+                          {t('aiAgentsPage.runs.profile.triage')}
+                        </span>
+                      )}
                     </td>
                     <td className="px-4 py-3 whitespace-nowrap text-muted-foreground">
                       {formatDateTime(run.queuedAt)}

--- a/apps/web/src/components/settings/AiAgentForm.tsx
+++ b/apps/web/src/components/settings/AiAgentForm.tsx
@@ -743,14 +743,21 @@ export default function AiAgentForm({
             {t('aiAgentsPage.fields.respectMaintenanceWindows')}
           </label>
 
-          {/* P2-4 (#4191). Only a `triage` agent's runs ever consult
-              `triggers.ticketAutonomousWrites` (ticket-triggered admission,
-              runService.ts). Disabled — never hidden — on a partner-wide row:
-              the merge reads ONLY the org's own override
-              (effectivePolicy.ts), so a partner baseline value can never take
-              effect; hiding it outright would look like the field vanished
-              rather than explain why it cannot be set here. */}
-          {draft.kind === 'triage' && (
+          {/* P2-4 (#4191) review fix — ticket-triggered runs are admitted
+              with `kind: 'helpdesk'` (ticketHelpdeskSubscriber.ts's
+              `admitTriageRun`: `createAndEnqueueAgentRun({ kind: 'helpdesk',
+              triggerKind: 'ticket', profile: 'triage', ... })`), and
+              runService.ts's `resolveEffectiveAgentSystem(orgId, kind)`
+              resolves the effective policy off THAT `kind` field — never
+              `triage`, which is a different agent kind entirely (the
+              scheduled-sweeps gate a few lines below IS genuinely
+              triage-only; do not copy this gate from that one again).
+              Disabled — never hidden — on a partner-wide row: the merge
+              reads ONLY the org's own override (effectivePolicy.ts), so a
+              partner baseline value can never take effect; hiding it
+              outright would look like the field vanished rather than
+              explain why it cannot be set here. */}
+          {draft.kind === 'helpdesk' && (
             <div className="space-y-1">
               <label className="flex items-center gap-2 text-sm">
                 <input

--- a/apps/web/src/components/settings/AiAgentForm.tsx
+++ b/apps/web/src/components/settings/AiAgentForm.tsx
@@ -164,6 +164,11 @@ interface Draft {
   /** Wave 5 Part B (#3827). Operator's per-agent opt-in to unattended
    *  policy-decided authorization — see actAssets in save() below. */
   supervisedActionKeys: string[];
+  /** P2-4 (#4191). Org-row-only opt-in that lifts the forced-shadow behavior
+   *  for ticket-triggered runs — same "reads ONLY the org's own override"
+   *  merge semantics as `anomalyEnabled` (never itself surfaced on this
+   *  form). See `AiAgentTriggers.ticketAutonomousWrites`'s docstring. */
+  ticketAutonomousWrites: boolean;
 }
 
 function draftFrom(
@@ -190,6 +195,7 @@ function draftFrom(
     roleIds: agent?.recipients?.roleIds ?? [],
     instructions: agent?.instructions ?? '',
     supervisedActionKeys: agent?.actAssets?.supervisedActionKeys ?? [],
+    ticketAutonomousWrites: agent?.triggers?.ticketAutonomousWrites ?? false,
   };
 }
 
@@ -337,6 +343,7 @@ export default function AiAgentForm({
       triggers: {
         alertSeverities: draft.severities,
         respectMaintenanceWindows: draft.respectMaintenanceWindows,
+        ticketAutonomousWrites: draft.ticketAutonomousWrites,
       },
       toolAllowlist: lines(draft.toolAllowlist),
       protectedResources: {
@@ -735,6 +742,31 @@ export default function AiAgentForm({
             />
             {t('aiAgentsPage.fields.respectMaintenanceWindows')}
           </label>
+
+          {/* P2-4 (#4191). Only a `triage` agent's runs ever consult
+              `triggers.ticketAutonomousWrites` (ticket-triggered admission,
+              runService.ts). Disabled — never hidden — on a partner-wide row:
+              the merge reads ONLY the org's own override
+              (effectivePolicy.ts), so a partner baseline value can never take
+              effect; hiding it outright would look like the field vanished
+              rather than explain why it cannot be set here. */}
+          {draft.kind === 'triage' && (
+            <div className="space-y-1">
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={draft.ticketAutonomousWrites}
+                  disabled={draft.ownerScope !== 'organization'}
+                  onChange={(e) => patch({ ticketAutonomousWrites: e.target.checked })}
+                  data-testid="ai-agent-ticket-autonomous-writes"
+                />
+                {t('aiAgentsPage.fields.ticketAutonomousWrites')}
+              </label>
+              <p className="pl-6 text-xs text-muted-foreground">
+                {t('aiAgentsPage.fields.ticketAutonomousWritesHint')}
+              </p>
+            </div>
+          )}
         </fieldset>
 
         <fieldset className="space-y-2 rounded-md border p-3 md:col-span-2">

--- a/apps/web/src/components/settings/AiAgentsPage.test.tsx
+++ b/apps/web/src/components/settings/AiAgentsPage.test.tsx
@@ -62,18 +62,28 @@ const ORG_AGENT = {
   allOrgs: false,
 };
 
-// P2-4 (#4191) — an ORG-owned triage agent, the only ownership axis the
-// `ticketAutonomousWrites` toggle can ever take effect on (org-row-only
-// opt-in; see AiAgentTriggers.ticketAutonomousWrites's docstring).
-const ORG_TRIAGE_AGENT = {
+// P2-4 (#4191) review fix — ticket-triggered runs are admitted with
+// `kind: 'helpdesk'` (ticketHelpdeskSubscriber.ts's `admitTriageRun`,
+// `createAndEnqueueAgentRun({ kind: 'helpdesk', ... })`), and runService.ts
+// resolves the effective policy off THAT kind — never `triage` (the
+// scheduled-sweeps kind, a different gate entirely). `ticketAutonomousWrites`
+// can therefore only ever take effect on a `helpdesk`-kind, ORG-owned row.
+const ORG_HELPDESK_AGENT = {
   ...PARTNER_AGENT,
   id: 'a3',
-  kind: 'triage' as const,
-  name: 'Org triage',
+  kind: 'helpdesk' as const,
+  name: 'Org helpdesk',
   orgId: 'org-1',
   partnerId: null,
   ownerScope: 'organization' as const,
   allOrgs: false,
+};
+
+const PARTNER_HELPDESK_AGENT = {
+  ...PARTNER_AGENT,
+  id: 'a4',
+  kind: 'helpdesk' as const,
+  name: 'Partner helpdesk',
 };
 
 function mockEndpoints(agents: unknown[] = [PARTNER_AGENT]) {
@@ -546,32 +556,40 @@ describe('AiAgentsPage', () => {
 // never consulted in either direction (effectivePolicy.ts's merge), so a
 // partner-wide row must never let an operator believe toggling it does
 // anything.
+//
+// Review fix (#4191): ticket-triggered runs are admitted with
+// `kind: 'helpdesk'` (ticketHelpdeskSubscriber.ts's `admitTriageRun`), and
+// runService.ts resolves the effective policy off THAT kind — never
+// `triage` (a different, scheduled-sweeps-only gate). Every fixture below
+// is `helpdesk`-kind for that reason, EXCEPT the first test, which proves
+// a `triage`-kind agent — the exact kind this toggle was originally
+// (wrongly) gated on — never renders it at all.
 describe('AiAgentsPage ticketAutonomousWrites toggle (P2-4, #4191)', () => {
-  it('hides the toggle entirely for a non-triage agent kind', async () => {
-    mockEndpoints([ORG_AGENT]);
-    render(<AiAgentsPage />);
-
-    await waitFor(() => screen.getByTestId('ai-agent-edit-a2'));
-    fireEvent.click(screen.getByTestId('ai-agent-edit-a2'));
-
-    await screen.findByTestId('ai-agent-editor');
-    expect(screen.queryByTestId('ai-agent-ticket-autonomous-writes')).toBeNull();
-  });
-
-  it('renders the toggle DISABLED for a partner-wide triage agent — it can never take effect there', async () => {
+  it('hides the toggle entirely for a triage-kind agent — ticket runs are admitted as helpdesk, never triage', async () => {
     mockEndpoints([PARTNER_AGENT]);
     render(<AiAgentsPage />);
 
     await waitFor(() => screen.getByTestId('ai-agent-edit-a1'));
     fireEvent.click(screen.getByTestId('ai-agent-edit-a1'));
 
+    await screen.findByTestId('ai-agent-editor');
+    expect(screen.queryByTestId('ai-agent-ticket-autonomous-writes')).toBeNull();
+  });
+
+  it('renders the toggle DISABLED for a partner-wide helpdesk agent — it can never take effect there', async () => {
+    mockEndpoints([PARTNER_HELPDESK_AGENT]);
+    render(<AiAgentsPage />);
+
+    await waitFor(() => screen.getByTestId('ai-agent-edit-a4'));
+    fireEvent.click(screen.getByTestId('ai-agent-edit-a4'));
+
     const checkbox = await screen.findByTestId('ai-agent-ticket-autonomous-writes');
     expect(checkbox).toBeDisabled();
   });
 
-  it('renders the toggle CHECKED when the stored org-owned agent already opted in', async () => {
+  it('renders the toggle CHECKED when the stored org-owned helpdesk agent already opted in', async () => {
     const preset = {
-      ...ORG_TRIAGE_AGENT,
+      ...ORG_HELPDESK_AGENT,
       triggers: { alertSeverities: ['critical'], respectMaintenanceWindows: true, ticketAutonomousWrites: true },
     };
     mockEndpoints([preset]);
@@ -585,8 +603,8 @@ describe('AiAgentsPage ticketAutonomousWrites toggle (P2-4, #4191)', () => {
     expect(checkbox).toBeChecked();
   });
 
-  it('round-trips a toggle flip through to the PATCH body for an org-owned triage agent', async () => {
-    const orgAgent = { ...ORG_TRIAGE_AGENT, supportedModes: ['off', 'shadow', 'act'] as const };
+  it('round-trips a toggle flip through to the PATCH body for an org-owned helpdesk agent', async () => {
+    const orgAgent = { ...ORG_HELPDESK_AGENT, supportedModes: ['off', 'shadow', 'act'] as const };
     fetchMock.mockImplementation((url: string, init?: RequestInit) => {
       if (url === '/ai/agents/policy-decidable-keys') return Promise.resolve(json({ data: [] }));
       if (url === '/ai/agents/a3' && init?.method === 'PATCH') return Promise.resolve(json({ data: orgAgent }));

--- a/apps/web/src/components/settings/AiAgentsPage.test.tsx
+++ b/apps/web/src/components/settings/AiAgentsPage.test.tsx
@@ -62,6 +62,20 @@ const ORG_AGENT = {
   allOrgs: false,
 };
 
+// P2-4 (#4191) — an ORG-owned triage agent, the only ownership axis the
+// `ticketAutonomousWrites` toggle can ever take effect on (org-row-only
+// opt-in; see AiAgentTriggers.ticketAutonomousWrites's docstring).
+const ORG_TRIAGE_AGENT = {
+  ...PARTNER_AGENT,
+  id: 'a3',
+  kind: 'triage' as const,
+  name: 'Org triage',
+  orgId: 'org-1',
+  partnerId: null,
+  ownerScope: 'organization' as const,
+  allOrgs: false,
+};
+
 function mockEndpoints(agents: unknown[] = [PARTNER_AGENT]) {
   fetchMock.mockImplementation((url: string) => {
     // Registered BEFORE the generic '/ai/agents' prefix check below — that
@@ -523,5 +537,79 @@ describe('AiAgentsPage', () => {
         fetchMock.mock.calls.some(([, init]) => (init as RequestInit | undefined)?.method === 'DELETE'),
       ).toBe(true),
     );
+  });
+});
+
+// P2-4 (#4191, Task 12) — the `ticketAutonomousWrites` org-row-only opt-in
+// toggle. Same "org override only" posture as `anomalyEnabled` (never
+// surfaced on the web form at all): the partner baseline's own value is
+// never consulted in either direction (effectivePolicy.ts's merge), so a
+// partner-wide row must never let an operator believe toggling it does
+// anything.
+describe('AiAgentsPage ticketAutonomousWrites toggle (P2-4, #4191)', () => {
+  it('hides the toggle entirely for a non-triage agent kind', async () => {
+    mockEndpoints([ORG_AGENT]);
+    render(<AiAgentsPage />);
+
+    await waitFor(() => screen.getByTestId('ai-agent-edit-a2'));
+    fireEvent.click(screen.getByTestId('ai-agent-edit-a2'));
+
+    await screen.findByTestId('ai-agent-editor');
+    expect(screen.queryByTestId('ai-agent-ticket-autonomous-writes')).toBeNull();
+  });
+
+  it('renders the toggle DISABLED for a partner-wide triage agent — it can never take effect there', async () => {
+    mockEndpoints([PARTNER_AGENT]);
+    render(<AiAgentsPage />);
+
+    await waitFor(() => screen.getByTestId('ai-agent-edit-a1'));
+    fireEvent.click(screen.getByTestId('ai-agent-edit-a1'));
+
+    const checkbox = await screen.findByTestId('ai-agent-ticket-autonomous-writes');
+    expect(checkbox).toBeDisabled();
+  });
+
+  it('renders the toggle CHECKED when the stored org-owned agent already opted in', async () => {
+    const preset = {
+      ...ORG_TRIAGE_AGENT,
+      triggers: { alertSeverities: ['critical'], respectMaintenanceWindows: true, ticketAutonomousWrites: true },
+    };
+    mockEndpoints([preset]);
+    render(<AiAgentsPage />);
+
+    await waitFor(() => screen.getByTestId('ai-agent-edit-a3'));
+    fireEvent.click(screen.getByTestId('ai-agent-edit-a3'));
+
+    const checkbox = await screen.findByTestId('ai-agent-ticket-autonomous-writes');
+    expect(checkbox).not.toBeDisabled();
+    expect(checkbox).toBeChecked();
+  });
+
+  it('round-trips a toggle flip through to the PATCH body for an org-owned triage agent', async () => {
+    const orgAgent = { ...ORG_TRIAGE_AGENT, supportedModes: ['off', 'shadow', 'act'] as const };
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url === '/ai/agents/policy-decidable-keys') return Promise.resolve(json({ data: [] }));
+      if (url === '/ai/agents/a3' && init?.method === 'PATCH') return Promise.resolve(json({ data: orgAgent }));
+      if (url.startsWith('/ai/agents/schedules')) return Promise.resolve(json({ data: [] }));
+      if (url.startsWith('/ai/agents')) return Promise.resolve(json({ data: [orgAgent] }));
+      if (url === '/roles') return Promise.resolve(json({ data: [] }));
+      return Promise.resolve(json({ data: [] }));
+    });
+    render(<AiAgentsPage />);
+
+    await waitFor(() => screen.getByTestId('ai-agent-edit-a3'));
+    fireEvent.click(screen.getByTestId('ai-agent-edit-a3'));
+
+    const checkbox = await screen.findByTestId('ai-agent-ticket-autonomous-writes');
+    expect(checkbox).not.toBeChecked();
+    fireEvent.click(checkbox);
+    fireEvent.click(screen.getByTestId('ai-agent-save'));
+
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.some(([, init]) => (init as RequestInit | undefined)?.method === 'PATCH')).toBe(true),
+    );
+    const patch = fetchMock.mock.calls.find(([, init]) => (init as RequestInit | undefined)?.method === 'PATCH');
+    const body = JSON.parse((patch?.[1] as RequestInit).body as string);
+    expect(body.triggers.ticketAutonomousWrites).toBe(true);
   });
 });

--- a/apps/web/src/components/tickets/TicketWorkbench.test.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.test.tsx
@@ -522,6 +522,142 @@ describe('TicketWorkbench ML triage suggestions', () => {
   });
 });
 
+describe('TicketWorkbench AI drafts (#4191, Task 11)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  /** Sets up fetchWithAuth: ticket GET, triage-suggestion GET (disabled), and
+   *  a stubbed ai-drafts GET returning `drafts`. Mutations return {success:true}
+   *  unless overridden by `extra`. */
+  function mockDraftsApi(drafts: unknown[], extra?: (url: string, init?: RequestInit) => Response | null) {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (extra) {
+        const res = extra(url, init);
+        if (res) return res;
+      }
+      if (url === '/tickets/tk-1' && (!init?.method || init.method === 'GET')) {
+        return makeJsonResponse({ data: makeTicket({ id: 'tk-1' }) });
+      }
+      if (url === '/tickets/tk-1/triage-suggestion' && (!init?.method || init.method === 'GET')) {
+        return makeJsonResponse({ enabled: false, flagSource: 'default', suggestion: null });
+      }
+      if (url === '/tickets/tk-1/ai-drafts' && (!init?.method || init.method === 'GET')) {
+        return makeJsonResponse({ data: drafts });
+      }
+      return makeJsonResponse({ success: true });
+    });
+  }
+
+  const replyDraft = {
+    id: 'draft-reply-1',
+    kind: 'reply',
+    content: 'Thanks for reaching out — please try rebooting the printer.',
+    createdAt: '2026-08-01T12:00:00.000Z',
+    runId: 'run-1',
+  };
+
+  const resolutionDraft = {
+    id: 'draft-note-1',
+    kind: 'resolution_note',
+    content: 'Replaced the fuser assembly; printer now prints cleanly.',
+    createdAt: '2026-08-01T12:00:00.000Z',
+    runId: 'run-2',
+  };
+
+  it('renders an AI draft card with the kind label and editable content', async () => {
+    mockDraftsApi([replyDraft]);
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    const card = await screen.findByTestId('ticket-ai-draft');
+    expect(card).toBeInTheDocument();
+    const textarea = screen.getByTestId('ticket-ai-draft-content') as HTMLTextAreaElement;
+    expect(textarea.value).toBe(replyDraft.content);
+    expect(screen.getByTestId('ticket-ai-draft-send')).toBeInTheDocument();
+    expect(screen.getByTestId('ticket-ai-draft-discard')).toBeInTheDocument();
+  });
+
+  it('sends the (edited) draft content via runAction and removes the card', async () => {
+    mockDraftsApi([replyDraft]);
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    const textarea = await screen.findByTestId('ticket-ai-draft-content');
+    fireEvent.change(textarea, { target: { value: 'Edited: please reboot the printer twice.' } });
+    fireEvent.click(screen.getByTestId('ticket-ai-draft-send'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/tickets/tk-1/ai-drafts/draft-reply-1/send',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ content: 'Edited: please reboot the printer twice.' }),
+        }),
+      );
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId('ticket-ai-draft')).toBeNull();
+    });
+  });
+
+  it('discards a draft via runAction without sending, and removes the card', async () => {
+    mockDraftsApi([replyDraft]);
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-ai-draft');
+    fireEvent.click(screen.getByTestId('ticket-ai-draft-discard'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/tickets/tk-1/ai-drafts/draft-reply-1/discard',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      '/tickets/tk-1/ai-drafts/draft-reply-1/send',
+      expect.anything(),
+    );
+    await waitFor(() => {
+      expect(screen.queryByTestId('ticket-ai-draft')).toBeNull();
+    });
+  });
+
+  it('prefills the resolve note from an active resolution_note draft and sends aiDraftId on resolve', async () => {
+    mockDraftsApi([resolutionDraft]);
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-workbench');
+    // Give the ai-drafts fetch a tick to land before opening the resolve form.
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/tickets/tk-1/ai-drafts'));
+
+    fireEvent.change(screen.getByTestId('ticket-workbench-status'), { target: { value: 'resolved' } });
+
+    const note = screen.getByTestId('ticket-workbench-resolve-note') as HTMLTextAreaElement;
+    expect(note.value).toBe(resolutionDraft.content);
+
+    fireEvent.click(screen.getByTestId('ticket-workbench-resolve-submit'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/tickets/tk-1/status',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ status: 'resolved', resolutionNote: resolutionDraft.content, aiDraftId: 'draft-note-1' }),
+        }),
+      );
+    });
+  });
+
+  it('never renders a card for a draft the ai-drafts endpoint does not return (consumed/discarded)', async () => {
+    mockDraftsApi([]);
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-workbench');
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/tickets/tk-1/ai-drafts'));
+    expect(screen.queryByTestId('ticket-ai-draft')).toBeNull();
+  });
+});
+
 describe('TicketWorkbench pending/on_hold prompt', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/web/src/components/tickets/TicketWorkbench.test.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.test.tsx
@@ -712,6 +712,105 @@ describe('TicketWorkbench AI drafts (#4191, Task 11)', () => {
     });
   });
 
+  // C1 (#4191 final review): the technician editing the prefilled note before
+  // submitting must NOT be silently replaced by the draft's original content.
+  // Non-uniform fixture — the edited text is deliberately different from
+  // resolutionDraft.content — so a regression that resends the draft's
+  // content instead of the edited value fails loudly.
+  it('C1: submits the technician-edited note (not the draft content) alongside aiDraftId', async () => {
+    mockDraftsApi([resolutionDraft]);
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-workbench');
+    await screen.findByTestId('ticket-ai-draft-resolution_note');
+
+    fireEvent.change(screen.getByTestId('ticket-workbench-status'), { target: { value: 'resolved' } });
+
+    const note = screen.getByTestId('ticket-workbench-resolve-note') as HTMLTextAreaElement;
+    expect(note.value).toBe(resolutionDraft.content);
+    fireEvent.change(note, { target: { value: 'Technician-edited resolution note' } });
+
+    fireEvent.click(screen.getByTestId('ticket-workbench-resolve-submit'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/tickets/tk-1/status',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ status: 'resolved', resolutionNote: 'Technician-edited resolution note', aiDraftId: 'draft-note-1' }),
+        }),
+      );
+    });
+  });
+
+  // I1 (#4191 final review): a 404 (stale draft id after a ticket switch,
+  // e.g. resolveDraftId survived from a prior ticket's aiDrafts state) used
+  // to fall through the `err.status === 409` check and loop forever. The
+  // recovery must match the sibling send/discard handlers (any non-401).
+  it('I1: on a 404 resolve conflict from a stale aiDraftId, drops it and retries without it (not just 409)', async () => {
+    let resolveAttempts = 0;
+    let consumed = false;
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url === '/tickets/tk-1' && (!init?.method || init.method === 'GET')) {
+        return makeJsonResponse({ data: makeTicket({ id: 'tk-1' }) });
+      }
+      if (url === '/tickets/tk-1/triage-suggestion' && (!init?.method || init.method === 'GET')) {
+        return makeJsonResponse({ enabled: false, flagSource: 'default', suggestion: null });
+      }
+      if (url === '/tickets/tk-1/ai-drafts' && (!init?.method || init.method === 'GET')) {
+        return makeJsonResponse({ data: consumed ? [] : [resolutionDraft] });
+      }
+      if (url === '/tickets/tk-1/status' && init?.method === 'POST') {
+        resolveAttempts += 1;
+        if (resolveAttempts === 1) {
+          consumed = true;
+          return makeJsonResponse({ error: 'Draft not found' }, false, 404);
+        }
+        return makeJsonResponse({ data: makeTicket({ id: 'tk-1', status: 'resolved' }) });
+      }
+      return makeJsonResponse({ success: true });
+    });
+
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-workbench');
+    await screen.findByTestId('ticket-ai-draft-resolution_note');
+
+    fireEvent.change(screen.getByTestId('ticket-workbench-status'), { target: { value: 'resolved' } });
+    const note = screen.getByTestId('ticket-workbench-resolve-note') as HTMLTextAreaElement;
+    expect(note.value).toBe(resolutionDraft.content);
+
+    fireEvent.click(screen.getByTestId('ticket-workbench-resolve-submit'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/tickets/tk-1/status',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ status: 'resolved', resolutionNote: resolutionDraft.content, aiDraftId: 'draft-note-1' }),
+        }),
+      );
+    });
+
+    expect(screen.getByTestId('ticket-workbench-resolve-form')).toBeInTheDocument();
+    expect(note.value).toBe(resolutionDraft.content);
+
+    fireEvent.click(screen.getByTestId('ticket-workbench-resolve-submit'));
+
+    // The second submit must NOT loop the same 404 forever — it posts without
+    // the now-dropped aiDraftId.
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/tickets/tk-1/status',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ status: 'resolved', resolutionNote: resolutionDraft.content }),
+        }),
+      );
+    });
+  });
+
   it('on a 409 resolve conflict from a stale aiDraftId, keeps the typed note and retries without it', async () => {
     let resolveAttempts = 0;
     // Same rationale as the send-409 test above: an explicit "consumed" flag
@@ -790,6 +889,51 @@ describe('TicketWorkbench AI drafts (#4191, Task 11)', () => {
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/tickets/tk-1/ai-drafts'));
     expect(screen.queryByTestId('ticket-ai-draft-reply')).toBeNull();
     expect(screen.queryByTestId('ticket-ai-draft-resolution_note')).toBeNull();
+  });
+
+  // I2 (#4191 final review): ticket A's AI-draft card must clear as soon as
+  // ticketId switches — not linger until ticket B's ai-drafts fetch resolves.
+  // The new ticket's GET is held open (never resolved during the assertion)
+  // so a regression that only clears on refetch-complete would still show
+  // ticket A's stale card at the point we check.
+  it('I2: clears stale AI-draft cards immediately on ticket switch, before the new fetch resolves', async () => {
+    let resolveTk2Drafts!: (value: Response) => void;
+    const tk2DraftsPromise = new Promise<Response>((resolve) => { resolveTk2Drafts = resolve; });
+
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url === '/tickets/tk-1' && (!init?.method || init.method === 'GET')) {
+        return makeJsonResponse({ data: makeTicket({ id: 'tk-1', internalNumber: 'T-2026-0001' }) });
+      }
+      if (url === '/tickets/tk-2' && (!init?.method || init.method === 'GET')) {
+        return makeJsonResponse({ data: makeTicket({ id: 'tk-2', internalNumber: 'T-2026-0002' }) });
+      }
+      if (url === '/tickets/tk-1/triage-suggestion' || url === '/tickets/tk-2/triage-suggestion') {
+        return makeJsonResponse({ enabled: false, flagSource: 'default', suggestion: null });
+      }
+      if (url === '/tickets/tk-1/ai-drafts' && (!init?.method || init.method === 'GET')) {
+        return makeJsonResponse({ data: [replyDraft] });
+      }
+      if (url === '/tickets/tk-2/ai-drafts' && (!init?.method || init.method === 'GET')) {
+        return tk2DraftsPromise; // held open deliberately
+      }
+      return makeJsonResponse({ success: true });
+    });
+
+    const { rerender } = render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+    await screen.findByTestId('ticket-ai-draft-reply');
+
+    rerender(<TicketWorkbench ticketId="tk-2" assignees={[]} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ticket-workbench-number')).toHaveTextContent('T-2026-0002');
+    });
+    // Ticket A's card is gone even though ticket B's ai-drafts fetch is still
+    // unresolved at this point.
+    expect(screen.queryByTestId('ticket-ai-draft-reply')).toBeNull();
+
+    resolveTk2Drafts(makeJsonResponse({ data: [resolutionDraft] }));
+    await screen.findByTestId('ticket-ai-draft-resolution_note');
   });
 });
 

--- a/apps/web/src/components/tickets/TicketWorkbench.test.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.test.tsx
@@ -570,21 +570,37 @@ describe('TicketWorkbench AI drafts (#4191, Task 11)', () => {
     mockDraftsApi([replyDraft]);
     render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
 
-    const card = await screen.findByTestId('ticket-ai-draft');
+    const card = await screen.findByTestId('ticket-ai-draft-reply');
     expect(card).toBeInTheDocument();
-    const textarea = screen.getByTestId('ticket-ai-draft-content') as HTMLTextAreaElement;
+    const textarea = screen.getByTestId('ticket-ai-draft-reply-content') as HTMLTextAreaElement;
     expect(textarea.value).toBe(replyDraft.content);
-    expect(screen.getByTestId('ticket-ai-draft-send')).toBeInTheDocument();
-    expect(screen.getByTestId('ticket-ai-draft-discard')).toBeInTheDocument();
+    expect(screen.getByTestId('ticket-ai-draft-reply-send')).toBeInTheDocument();
+    expect(screen.getByTestId('ticket-ai-draft-reply-discard')).toBeInTheDocument();
+  });
+
+  it('renders a reply and a resolution_note draft simultaneously with per-kind testids', async () => {
+    mockDraftsApi([replyDraft, resolutionDraft]);
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-ai-draft-reply');
+    await screen.findByTestId('ticket-ai-draft-resolution_note');
+
+    expect(screen.getByTestId('ticket-ai-draft-reply-content')).toHaveValue(replyDraft.content);
+    expect(screen.getByTestId('ticket-ai-draft-resolution_note-content')).toHaveValue(resolutionDraft.content);
+    expect(screen.getByTestId('ticket-ai-draft-reply-send')).toBeInTheDocument();
+    // Send is reply-only — the API 409s a send on a resolution_note draft.
+    expect(screen.queryByTestId('ticket-ai-draft-resolution_note-send')).toBeNull();
+    expect(screen.getByTestId('ticket-ai-draft-reply-discard')).toBeInTheDocument();
+    expect(screen.getByTestId('ticket-ai-draft-resolution_note-discard')).toBeInTheDocument();
   });
 
   it('sends the (edited) draft content via runAction and removes the card', async () => {
     mockDraftsApi([replyDraft]);
     render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
 
-    const textarea = await screen.findByTestId('ticket-ai-draft-content');
+    const textarea = await screen.findByTestId('ticket-ai-draft-reply-content');
     fireEvent.change(textarea, { target: { value: 'Edited: please reboot the printer twice.' } });
-    fireEvent.click(screen.getByTestId('ticket-ai-draft-send'));
+    fireEvent.click(screen.getByTestId('ticket-ai-draft-reply-send'));
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
@@ -596,7 +612,7 @@ describe('TicketWorkbench AI drafts (#4191, Task 11)', () => {
       );
     });
     await waitFor(() => {
-      expect(screen.queryByTestId('ticket-ai-draft')).toBeNull();
+      expect(screen.queryByTestId('ticket-ai-draft-reply')).toBeNull();
     });
   });
 
@@ -604,8 +620,8 @@ describe('TicketWorkbench AI drafts (#4191, Task 11)', () => {
     mockDraftsApi([replyDraft]);
     render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
 
-    await screen.findByTestId('ticket-ai-draft');
-    fireEvent.click(screen.getByTestId('ticket-ai-draft-discard'));
+    await screen.findByTestId('ticket-ai-draft-reply');
+    fireEvent.click(screen.getByTestId('ticket-ai-draft-reply-discard'));
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
@@ -618,7 +634,51 @@ describe('TicketWorkbench AI drafts (#4191, Task 11)', () => {
       expect.anything(),
     );
     await waitFor(() => {
-      expect(screen.queryByTestId('ticket-ai-draft')).toBeNull();
+      expect(screen.queryByTestId('ticket-ai-draft-reply')).toBeNull();
+    });
+  });
+
+  it('on a 409 send conflict (already sent/discarded elsewhere), refetches and drops the stale card', async () => {
+    // Keyed on an explicit "consumed" flag (flipped only by the conflicting
+    // POST) rather than a raw GET call counter — the initial mount can
+    // legitimately re-fetch ai-drafts more than once before the user ever
+    // clicks Send, and a call-count-based fixture would flake on that.
+    let consumed = false;
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url === '/tickets/tk-1' && (!init?.method || init.method === 'GET')) {
+        return makeJsonResponse({ data: makeTicket({ id: 'tk-1' }) });
+      }
+      if (url === '/tickets/tk-1/triage-suggestion' && (!init?.method || init.method === 'GET')) {
+        return makeJsonResponse({ enabled: false, flagSource: 'default', suggestion: null });
+      }
+      if (url === '/tickets/tk-1/ai-drafts' && (!init?.method || init.method === 'GET')) {
+        return makeJsonResponse({ data: consumed ? [] : [replyDraft] });
+      }
+      if (url === '/tickets/tk-1/ai-drafts/draft-reply-1/send' && init?.method === 'POST') {
+        consumed = true;
+        return makeJsonResponse({ error: 'Draft is no longer active' }, false, 409);
+      }
+      return makeJsonResponse({ success: true });
+    });
+
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-ai-draft-reply');
+    fireEvent.click(screen.getByTestId('ticket-ai-draft-reply-send'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/tickets/tk-1/ai-drafts/draft-reply-1/send',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+
+    // The card can only disappear here via a refetch landing after `consumed`
+    // flipped true (there is no successful-send optimistic-removal path on
+    // this failing request) — so this proves the post-conflict refetch fired.
+    await waitFor(() => {
+      expect(screen.queryByTestId('ticket-ai-draft-reply')).toBeNull();
     });
   });
 
@@ -627,8 +687,12 @@ describe('TicketWorkbench AI drafts (#4191, Task 11)', () => {
     render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
 
     await screen.findByTestId('ticket-workbench');
-    // Give the ai-drafts fetch a tick to land before opening the resolve form.
-    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/tickets/tk-1/ai-drafts'));
+    // Wait for the resolution_note draft CARD to render — proof that aiDrafts
+    // (and the aiDraftsRef it syncs to) has actually committed, not just that
+    // the ai-drafts fetch was called. openResolveForm() reads the ref
+    // synchronously inside the status-change handler below, so this is load-
+    // bearing, not decorative.
+    await screen.findByTestId('ticket-ai-draft-resolution_note');
 
     fireEvent.change(screen.getByTestId('ticket-workbench-status'), { target: { value: 'resolved' } });
 
@@ -648,13 +712,84 @@ describe('TicketWorkbench AI drafts (#4191, Task 11)', () => {
     });
   });
 
+  it('on a 409 resolve conflict from a stale aiDraftId, keeps the typed note and retries without it', async () => {
+    let resolveAttempts = 0;
+    // Same rationale as the send-409 test above: an explicit "consumed" flag
+    // (flipped by the first failing /status POST), not a raw GET call count.
+    let consumed = false;
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url === '/tickets/tk-1' && (!init?.method || init.method === 'GET')) {
+        return makeJsonResponse({ data: makeTicket({ id: 'tk-1' }) });
+      }
+      if (url === '/tickets/tk-1/triage-suggestion' && (!init?.method || init.method === 'GET')) {
+        return makeJsonResponse({ enabled: false, flagSource: 'default', suggestion: null });
+      }
+      if (url === '/tickets/tk-1/ai-drafts' && (!init?.method || init.method === 'GET')) {
+        return makeJsonResponse({ data: consumed ? [] : [resolutionDraft] });
+      }
+      if (url === '/tickets/tk-1/status' && init?.method === 'POST') {
+        resolveAttempts += 1;
+        if (resolveAttempts === 1) {
+          // Someone else already consumed/discarded the draft between the
+          // form opening and this submit.
+          consumed = true;
+          return makeJsonResponse({ error: 'Draft is no longer active' }, false, 409);
+        }
+        return makeJsonResponse({ data: makeTicket({ id: 'tk-1', status: 'resolved' }) });
+      }
+      return makeJsonResponse({ success: true });
+    });
+
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+
+    await screen.findByTestId('ticket-workbench');
+    // Same rationale as the prefill test above: wait for the card, not just
+    // the fetch call.
+    await screen.findByTestId('ticket-ai-draft-resolution_note');
+
+    fireEvent.change(screen.getByTestId('ticket-workbench-status'), { target: { value: 'resolved' } });
+    const note = screen.getByTestId('ticket-workbench-resolve-note') as HTMLTextAreaElement;
+    expect(note.value).toBe(resolutionDraft.content);
+
+    fireEvent.click(screen.getByTestId('ticket-workbench-resolve-submit'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/tickets/tk-1/status',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ status: 'resolved', resolutionNote: resolutionDraft.content, aiDraftId: 'draft-note-1' }),
+        }),
+      );
+    });
+
+    // The 409 keeps the form open with the typed note untouched, and drops
+    // the now-dead aiDraftId.
+    expect(screen.getByTestId('ticket-workbench-resolve-form')).toBeInTheDocument();
+    expect(note.value).toBe(resolutionDraft.content);
+
+    fireEvent.click(screen.getByTestId('ticket-workbench-resolve-submit'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/tickets/tk-1/status',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ status: 'resolved', resolutionNote: resolutionDraft.content }),
+        }),
+      );
+    });
+  });
+
   it('never renders a card for a draft the ai-drafts endpoint does not return (consumed/discarded)', async () => {
     mockDraftsApi([]);
     render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
 
     await screen.findByTestId('ticket-workbench');
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/tickets/tk-1/ai-drafts'));
-    expect(screen.queryByTestId('ticket-ai-draft')).toBeNull();
+    expect(screen.queryByTestId('ticket-ai-draft-reply')).toBeNull();
+    expect(screen.queryByTestId('ticket-ai-draft-resolution_note')).toBeNull();
   });
 });
 

--- a/apps/web/src/components/tickets/TicketWorkbench.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.tsx
@@ -141,6 +141,15 @@ type TicketTriageSuggestion = {
   reasons: string[];
 };
 
+// P2-4 (#4191), Task 11 — mirrors ActiveTicketDraftRow (ticketService.ts).
+type TicketAiDraft = {
+  id: string;
+  kind: 'reply' | 'resolution_note';
+  content: string;
+  createdAt: string;
+  runId: string | null;
+};
+
 export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, expanded, resolveRequestToken, refreshToken, assignees: assigneesProp, categories = [] }: Props) {
   const { t } = useTranslation('tickets');
   const [ticket, setTicket] = useState<TicketDetail | null>(null);
@@ -195,6 +204,24 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
   const [triageLoading, setTriageLoading] = useState(false);
   const [applyingTriage, setApplyingTriage] = useState(false);
   const [rejectingTriage, setRejectingTriage] = useState(false);
+
+  // P2-4 (#4191), Task 11 — active AI drafts (at most one `reply` + one
+  // `resolution_note`, per ticket_drafts_active_uq). `draftContent` holds the
+  // per-draft editable textarea value, seeded from the fetched content and
+  // diverging only when the technician edits before sending.
+  const [aiDrafts, setAiDrafts] = useState<TicketAiDraft[]>([]);
+  const [draftContent, setDraftContent] = useState<Record<string, string>>({});
+  const [sendingDraftId, setSendingDraftId] = useState<string | null>(null);
+  const [discardingDraftId, setDiscardingDraftId] = useState<string | null>(null);
+  // Read by openResolveForm via a ref (not a direct closure/dependency) so
+  // that helper's identity stays stable across ai-drafts refetches — see the
+  // comment above openResolveForm for why that stability matters.
+  const aiDraftsRef = useRef<TicketAiDraft[]>([]);
+  useEffect(() => { aiDraftsRef.current = aiDrafts; }, [aiDrafts]);
+  // The resolution_note draft (if any) prefilled into the currently-open
+  // resolve form; sent back as `aiDraftId` so the server consumes it in the
+  // same transaction as the resolve CAS.
+  const [resolveDraftId, setResolveDraftId] = useState<string | null>(null);
 
   // Partner canned responses for the reply composer. Best-effort: an empty list
   // (or a failed/forbidden load) simply hides the picker.
@@ -294,6 +321,38 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
     return () => { cancelled = true; };
   }, [ticket, ticketId]);
 
+  // P2-4 (#4191), Task 11 — active AI drafts, fetched alongside the triage
+  // suggestion above. Seeds `draftContent` for any newly-seen draft id
+  // without clobbering an in-progress edit; a draft the API stops returning
+  // (sent/discarded/consumed elsewhere) simply drops out of `aiDrafts`, which
+  // is the only thing the card list renders from.
+  useEffect(() => {
+    if (!ticket) {
+      setAiDrafts([]);
+      setDraftContent({});
+      return;
+    }
+    let cancelled = false;
+    void fetchWithAuth(`/tickets/${ticketId}/ai-drafts`)
+      .then(async (res) => (res.ok ? res.json() : null))
+      .then((body) => {
+        if (cancelled) return;
+        const drafts: TicketAiDraft[] = Array.isArray(body?.data) ? body.data : [];
+        setAiDrafts(drafts);
+        setDraftContent((prev) => {
+          const next = { ...prev };
+          for (const draft of drafts) {
+            if (!(draft.id in next)) next[draft.id] = draft.content;
+          }
+          return next;
+        });
+      })
+      .catch(() => {
+        if (!cancelled) setAiDrafts([]);
+      });
+    return () => { cancelled = true; };
+  }, [ticket, ticketId]);
+
   // Bulk actions in the queue mutate tickets behind the pane's back; the parent
   // bumps refreshToken after a bulk apply so the detail can't go stale. The ref
   // guard makes the effect fire only on an actual token bump — without it, a
@@ -319,13 +378,30 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
     setPendingOpen(null);
     setPendingReason('');
     setPendingStatusId(null);
+    setResolveDraftId(null);
     setDeleteOpen(false);
   }, [ticketId]);
 
+  // Opens the resolve form and, when an active `resolution_note` AI draft
+  // exists, prefills the note field from it and remembers its id so
+  // submitResolve can pass `aiDraftId`. Reads aiDraftsRef rather than
+  // depending on `aiDrafts` directly so this callback's identity stays
+  // stable across ai-drafts refetches (background reconciles re-fetch
+  // drafts on every ticket change) — otherwise the resolveRequestToken
+  // effect below would re-fire and reopen the form on every refetch.
+  const openResolveForm = useCallback(() => {
+    setResolveOpen(true);
+    const draft = aiDraftsRef.current.find((d) => d.kind === 'resolution_note');
+    setResolveDraftId(draft ? draft.id : null);
+    if (draft) {
+      setResolutionNote((prev) => (prev.trim() ? prev : draft.content));
+    }
+  }, []);
+
   // Page-level `e` shortcut: open the inline resolve form (UI brief: `e` opens the resolution-note form)
   useEffect(() => {
-    if (resolveRequestToken) setResolveOpen(true);
-  }, [resolveRequestToken]);
+    if (resolveRequestToken) openResolveForm();
+  }, [resolveRequestToken, openResolveForm]);
 
   // Fetch assignees once; degrade gracefully if the endpoint is unavailable.
   // Skipped entirely when the host already supplies the list via the prop.
@@ -587,14 +663,63 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
     }
   }, [rejectingTriage, ticketId, triageSuggestion, t]);
 
+  // "Send as me" — posts the (possibly technician-edited) draft content as a
+  // PUBLIC comment under the calling technician's own identity. Reply drafts
+  // only; the API 409s a resolution_note draft here (it's consumed only via
+  // the resolve flow's aiDraftId, below).
+  const sendAiDraft = useCallback(async (draft: TicketAiDraft) => {
+    if (sendingDraftId || discardingDraftId) return;
+    const content = (draftContent[draft.id] ?? draft.content).trim();
+    if (!content) return;
+    setSendingDraftId(draft.id);
+    try {
+      await runAction({
+        request: () => fetchWithAuth(`/tickets/${ticketId}/ai-drafts/${draft.id}/send`, {
+          method: 'POST',
+          body: JSON.stringify({ content }),
+        }),
+        errorFallback: t('ticketWorkbench.aiDraft.sendFailed'),
+        successMessage: t('ticketWorkbench.aiDraft.sent'),
+        onUnauthorized: () => void navigateTo(loginPathWithNext(), { replace: true })
+      });
+      setAiDrafts((prev) => prev.filter((d) => d.id !== draft.id));
+      // The send created a new public comment — refresh the feed.
+      afterMutation();
+    } catch (err) {
+      if (!(err instanceof ActionError)) throw err;
+    } finally {
+      setSendingDraftId(null);
+    }
+  }, [afterMutation, discardingDraftId, draftContent, sendingDraftId, ticketId, t]);
+
+  // Discards a draft (either kind) without acting on it.
+  const discardAiDraft = useCallback(async (draft: TicketAiDraft) => {
+    if (sendingDraftId || discardingDraftId) return;
+    setDiscardingDraftId(draft.id);
+    try {
+      await runAction({
+        request: () => fetchWithAuth(`/tickets/${ticketId}/ai-drafts/${draft.id}/discard`, { method: 'POST' }),
+        errorFallback: t('ticketWorkbench.aiDraft.discardFailed'),
+        successMessage: t('ticketWorkbench.aiDraft.discarded'),
+        onUnauthorized: () => void navigateTo(loginPathWithNext(), { replace: true })
+      });
+      setAiDrafts((prev) => prev.filter((d) => d.id !== draft.id));
+      if (resolveDraftId === draft.id) setResolveDraftId(null);
+    } catch (err) {
+      if (!(err instanceof ActionError)) throw err;
+    } finally {
+      setDiscardingDraftId(null);
+    }
+  }, [discardingDraftId, resolveDraftId, sendingDraftId, ticketId, t]);
+
   // Fallback path: option values are the six core enums; POST {status}.
   const onStatusChange = useCallback(async (status: TicketStatus) => {
     setPendingStatusId(null);
-    if (status === 'resolved') { setResolveOpen(true); return; }
+    if (status === 'resolved') { openResolveForm(); return; }
     if (status === 'pending' || status === 'on_hold') { setPendingOpen(status); return; }
     // Core path clears any custom-status decoration the row may have carried.
     await mutate('/status', { status }, t('ticketWorkbench.toast.statusUpdated'), t('ticketWorkbench.toast.statusUpdateFailed'), { status, statusName: null, statusColor: null });
-  }, [mutate, t]);
+  }, [mutate, openResolveForm, t]);
 
   // Config path: option values are custom-status row ids; the chosen row's
   // coreStatus drives the same resolve/pending forms, and the POST sends
@@ -602,7 +727,7 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
   const onCustomStatusChange = useCallback(async (statusId: string) => {
     const row = config?.statuses.find((s) => s.id === statusId);
     if (!row) return;
-    if (row.coreStatus === 'resolved') { setPendingStatusId(statusId); setResolveOpen(true); return; }
+    if (row.coreStatus === 'resolved') { setPendingStatusId(statusId); openResolveForm(); return; }
     if (row.coreStatus === 'pending' || row.coreStatus === 'on_hold') {
       setPendingStatusId(statusId);
       setPendingOpen(row.coreStatus);
@@ -610,18 +735,21 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
     }
     setPendingStatusId(null);
     await mutate('/status', { statusId }, t('ticketWorkbench.toast.statusUpdated'), t('ticketWorkbench.toast.statusUpdateFailed'), { status: row.coreStatus, statusName: row.name, statusColor: row.color ?? null });
-  }, [config, mutate, t]);
+  }, [config, mutate, openResolveForm, t]);
 
   const submitResolve = useCallback(async () => {
     if (!resolutionNote.trim()) return;
     const target = pendingStatusId ? { statusId: pendingStatusId } : { status: 'resolved' as const };
     const note = resolutionNote.trim();
-    const ok = await mutate('/status', { ...target, resolutionNote: note }, t('ticketWorkbench.toast.ticketResolved'), t('ticketWorkbench.toast.resolveFailed'), { status: 'resolved', resolutionNote: note });
+    const body = { ...target, resolutionNote: note, ...(resolveDraftId ? { aiDraftId: resolveDraftId } : {}) };
+    const ok = await mutate('/status', body, t('ticketWorkbench.toast.ticketResolved'), t('ticketWorkbench.toast.resolveFailed'), { status: 'resolved', resolutionNote: note });
     if (!ok) return; // keep the form open and the typed note intact on failure
+    if (resolveDraftId) setAiDrafts((prev) => prev.filter((d) => d.id !== resolveDraftId));
     setResolveOpen(false);
     setResolutionNote('');
     setPendingStatusId(null);
-  }, [mutate, resolutionNote, pendingStatusId, t]);
+    setResolveDraftId(null);
+  }, [mutate, resolutionNote, pendingStatusId, resolveDraftId, t]);
 
   const submitPending = useCallback(async () => {
     if (!pendingOpen) return;
@@ -1119,6 +1247,43 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
             </div>
           </div>
         )}
+        {aiDrafts.map((draft) => (
+          <div key={draft.id} className="mt-2 rounded-md border bg-muted/30 p-2" data-testid="ticket-ai-draft">
+            <div className="flex items-center gap-1.5 text-xs font-medium">
+              <Sparkles className="h-3.5 w-3.5 text-primary" />
+              {draft.kind === 'reply' ? t('ticketWorkbench.aiDraft.kindReply') : t('ticketWorkbench.aiDraft.kindResolutionNote')}
+            </div>
+            <textarea
+              value={draftContent[draft.id] ?? draft.content}
+              onChange={(e) => setDraftContent((prev) => ({ ...prev, [draft.id]: e.target.value }))}
+              rows={3}
+              className="mt-1 w-full rounded-md border bg-background px-2 py-1.5 text-sm"
+              data-testid="ticket-ai-draft-content"
+            />
+            <div className="mt-1.5 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => void discardAiDraft(draft)}
+                disabled={sendingDraftId === draft.id || discardingDraftId === draft.id}
+                className="rounded-md border px-2 py-1 text-xs hover:bg-muted disabled:opacity-50"
+                data-testid="ticket-ai-draft-discard"
+              >
+                {discardingDraftId === draft.id ? t('common:states.saving') : t('ticketWorkbench.aiDraft.discard')}
+              </button>
+              {draft.kind === 'reply' && (
+                <button
+                  type="button"
+                  onClick={() => void sendAiDraft(draft)}
+                  disabled={sendingDraftId === draft.id || discardingDraftId === draft.id || !(draftContent[draft.id] ?? draft.content).trim()}
+                  className="rounded-md bg-primary px-2 py-1 text-xs font-medium text-white disabled:opacity-50"
+                  data-testid="ticket-ai-draft-send"
+                >
+                  {sendingDraftId === draft.id ? t('ticketWorkbench.aiDraft.sending') : t('ticketWorkbench.aiDraft.sendAsMe')}
+                </button>
+              )}
+            </div>
+          </div>
+        ))}
         {resolveOpen && (
           <div className="mt-2 rounded-md border bg-muted/30 p-2" data-testid="ticket-workbench-resolve-form">
             <label className="text-xs font-medium" htmlFor="resolve-note">{t('ticketWorkbench.resolve.noteLabel')}</label>

--- a/apps/web/src/components/tickets/TicketWorkbench.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.tsx
@@ -391,6 +391,13 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
     setPendingStatusId(null);
     setResolveDraftId(null);
     setDeleteOpen(false);
+    // I2 (#4191 final review): without this, ticket A's AI-draft cards (and
+    // any in-progress per-draft edits) stayed visible until the new
+    // ticket's `refetchAiDrafts` call resolved — a stale card could even be
+    // sent/discarded against the wrong ticket. Clear both eagerly here
+    // rather than waiting on the `[ticket, ticketId]` refetch effect.
+    setAiDrafts([]);
+    setDraftContent({});
   }, [ticketId]);
 
   // Opens the resolve form and, when an active `resolution_note` AI draft
@@ -778,12 +785,15 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
       });
     } catch (err) {
       if (!(err instanceof ActionError)) throw err;
-      // A 409 while an aiDraftId was attached means the resolution-note
-      // draft was consumed/discarded elsewhere since the form opened. Drop
-      // the now-dead id (and refetch the draft list, so its card
-      // disappears too) so the technician's next submit — the typed note
-      // stays put — POSTs without it, instead of looping the same 409.
-      if (err.status === 409 && resolveDraftId) {
+      // A non-401 failure while an aiDraftId was attached means the
+      // resolution-note draft is no longer valid — consumed/discarded
+      // elsewhere (409), OR its id is stale after a ticket switch reset it
+      // out from under this submit (404, I1 #4191 final review: matches the
+      // sibling send/discard recovery condition below, not just 409, so a
+      // 404 doesn't loop forever). Drop the now-dead id (and refetch the
+      // draft list, so its card disappears too) so the technician's next
+      // submit — the typed note stays put — POSTs without it.
+      if (err.status !== 401 && resolveDraftId) {
         setResolveDraftId(null);
         void refetchAiDrafts(ticketId);
       }

--- a/apps/web/src/components/tickets/TicketWorkbench.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.tsx
@@ -321,37 +321,48 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
     return () => { cancelled = true; };
   }, [ticket, ticketId]);
 
+  // Loads the (fresh) active-draft list for `forTicketId` from the server —
+  // the shared loader behind both the mount/ticket-change effect below AND
+  // the post-conflict recovery calls in sendAiDraft/discardAiDraft/
+  // submitResolve. Guarded against a ticket switch racing an in-flight fetch
+  // via `ticketIdRef` rather than an effect-local `cancelled` flag, since
+  // this is also called imperatively outside any effect.
+  const ticketIdRef = useRef(ticketId);
+  useEffect(() => { ticketIdRef.current = ticketId; }, [ticketId]);
+
+  const refetchAiDrafts = useCallback(async (forTicketId: string) => {
+    try {
+      const res = await fetchWithAuth(`/tickets/${forTicketId}/ai-drafts`);
+      if (!res.ok) return;
+      const body = await res.json();
+      if (ticketIdRef.current !== forTicketId) return; // ticket switched mid-flight
+      const drafts: TicketAiDraft[] = Array.isArray(body?.data) ? body.data : [];
+      setAiDrafts(drafts);
+      setDraftContent((prev) => {
+        const next = { ...prev };
+        for (const draft of drafts) {
+          if (!(draft.id in next)) next[draft.id] = draft.content;
+        }
+        return next;
+      });
+    } catch {
+      // Best-effort — leave the existing (possibly stale) list rather than
+      // clearing it out from under an in-progress edit on a network blip.
+    }
+  }, []);
+
   // P2-4 (#4191), Task 11 — active AI drafts, fetched alongside the triage
-  // suggestion above. Seeds `draftContent` for any newly-seen draft id
-  // without clobbering an in-progress edit; a draft the API stops returning
-  // (sent/discarded/consumed elsewhere) simply drops out of `aiDrafts`, which
-  // is the only thing the card list renders from.
+  // suggestion above. A draft the API stops returning (sent/discarded/
+  // consumed elsewhere) simply drops out of `aiDrafts` on the next fetch,
+  // which is the only thing the card list renders from.
   useEffect(() => {
     if (!ticket) {
       setAiDrafts([]);
       setDraftContent({});
       return;
     }
-    let cancelled = false;
-    void fetchWithAuth(`/tickets/${ticketId}/ai-drafts`)
-      .then(async (res) => (res.ok ? res.json() : null))
-      .then((body) => {
-        if (cancelled) return;
-        const drafts: TicketAiDraft[] = Array.isArray(body?.data) ? body.data : [];
-        setAiDrafts(drafts);
-        setDraftContent((prev) => {
-          const next = { ...prev };
-          for (const draft of drafts) {
-            if (!(draft.id in next)) next[draft.id] = draft.content;
-          }
-          return next;
-        });
-      })
-      .catch(() => {
-        if (!cancelled) setAiDrafts([]);
-      });
-    return () => { cancelled = true; };
-  }, [ticket, ticketId]);
+    void refetchAiDrafts(ticketId);
+  }, [ticket, ticketId, refetchAiDrafts]);
 
   // Bulk actions in the queue mutate tickets behind the pane's back; the parent
   // bumps refreshToken after a bulk apply so the detail can't go stale. The ref
@@ -687,10 +698,16 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
       afterMutation();
     } catch (err) {
       if (!(err instanceof ActionError)) throw err;
+      // A non-401 failure (typically a 409 — someone else already sent or
+      // discarded this exact draft) would otherwise leave the card mounted
+      // and interactive on stale local state, looping the same 409 on every
+      // retry. Refetch the real active-draft list so a now-gone draft's
+      // card actually disappears.
+      if (err.status !== 401) void refetchAiDrafts(ticketId);
     } finally {
       setSendingDraftId(null);
     }
-  }, [afterMutation, discardingDraftId, draftContent, sendingDraftId, ticketId, t]);
+  }, [afterMutation, discardingDraftId, draftContent, refetchAiDrafts, sendingDraftId, ticketId, t]);
 
   // Discards a draft (either kind) without acting on it.
   const discardAiDraft = useCallback(async (draft: TicketAiDraft) => {
@@ -707,10 +724,16 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
       if (resolveDraftId === draft.id) setResolveDraftId(null);
     } catch (err) {
       if (!(err instanceof ActionError)) throw err;
+      // Same stale-card recovery as sendAiDraft — a non-401 failure here is
+      // typically a 409 (already sent/discarded/consumed elsewhere).
+      if (err.status !== 401) {
+        void refetchAiDrafts(ticketId);
+        if (resolveDraftId === draft.id) setResolveDraftId(null);
+      }
     } finally {
       setDiscardingDraftId(null);
     }
-  }, [discardingDraftId, resolveDraftId, sendingDraftId, ticketId, t]);
+  }, [discardingDraftId, refetchAiDrafts, resolveDraftId, sendingDraftId, ticketId, t]);
 
   // Fallback path: option values are the six core enums; POST {status}.
   const onStatusChange = useCallback(async (status: TicketStatus) => {
@@ -737,19 +760,42 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
     await mutate('/status', { statusId }, t('ticketWorkbench.toast.statusUpdated'), t('ticketWorkbench.toast.statusUpdateFailed'), { status: row.coreStatus, statusName: row.name, statusColor: row.color ?? null });
   }, [config, mutate, openResolveForm, t]);
 
+  // Not routed through the shared `mutate` helper (unlike onStatusChange/
+  // onCustomStatusChange/submitPending) because it needs the thrown
+  // ActionError's status to tell a draft-related 409 apart from any other
+  // resolve failure — `mutate` swallows that down to a bare boolean.
   const submitResolve = useCallback(async () => {
     if (!resolutionNote.trim()) return;
     const target = pendingStatusId ? { statusId: pendingStatusId } : { status: 'resolved' as const };
     const note = resolutionNote.trim();
     const body = { ...target, resolutionNote: note, ...(resolveDraftId ? { aiDraftId: resolveDraftId } : {}) };
-    const ok = await mutate('/status', body, t('ticketWorkbench.toast.ticketResolved'), t('ticketWorkbench.toast.resolveFailed'), { status: 'resolved', resolutionNote: note });
-    if (!ok) return; // keep the form open and the typed note intact on failure
+    try {
+      await runAction({
+        request: () => fetchWithAuth(`/tickets/${ticketId}/status`, { method: 'POST', body: JSON.stringify(body) }),
+        errorFallback: t('ticketWorkbench.toast.resolveFailed'),
+        successMessage: t('ticketWorkbench.toast.ticketResolved'),
+        onUnauthorized: () => void navigateTo(loginPathWithNext(), { replace: true })
+      });
+    } catch (err) {
+      if (!(err instanceof ActionError)) throw err;
+      // A 409 while an aiDraftId was attached means the resolution-note
+      // draft was consumed/discarded elsewhere since the form opened. Drop
+      // the now-dead id (and refetch the draft list, so its card
+      // disappears too) so the technician's next submit — the typed note
+      // stays put — POSTs without it, instead of looping the same 409.
+      if (err.status === 409 && resolveDraftId) {
+        setResolveDraftId(null);
+        void refetchAiDrafts(ticketId);
+      }
+      return; // keep the form open and the typed note intact on failure
+    }
+    afterMutation({ status: 'resolved', resolutionNote: note });
     if (resolveDraftId) setAiDrafts((prev) => prev.filter((d) => d.id !== resolveDraftId));
     setResolveOpen(false);
     setResolutionNote('');
     setPendingStatusId(null);
     setResolveDraftId(null);
-  }, [mutate, resolutionNote, pendingStatusId, resolveDraftId, t]);
+  }, [afterMutation, pendingStatusId, refetchAiDrafts, resolutionNote, resolveDraftId, t, ticketId]);
 
   const submitPending = useCallback(async () => {
     if (!pendingOpen) return;
@@ -1248,7 +1294,10 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
           </div>
         )}
         {aiDrafts.map((draft) => (
-          <div key={draft.id} className="mt-2 rounded-md border bg-muted/30 p-2" data-testid="ticket-ai-draft">
+          // At most one `reply` + one `resolution_note` draft can be active
+          // at once (ticket_drafts_active_uq) — testids are keyed per kind
+          // (not per draft id) so both cards are independently addressable.
+          <div key={draft.id} className="mt-2 rounded-md border bg-muted/30 p-2" data-testid={`ticket-ai-draft-${draft.kind}`}>
             <div className="flex items-center gap-1.5 text-xs font-medium">
               <Sparkles className="h-3.5 w-3.5 text-primary" />
               {draft.kind === 'reply' ? t('ticketWorkbench.aiDraft.kindReply') : t('ticketWorkbench.aiDraft.kindResolutionNote')}
@@ -1258,7 +1307,7 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
               onChange={(e) => setDraftContent((prev) => ({ ...prev, [draft.id]: e.target.value }))}
               rows={3}
               className="mt-1 w-full rounded-md border bg-background px-2 py-1.5 text-sm"
-              data-testid="ticket-ai-draft-content"
+              data-testid={`ticket-ai-draft-${draft.kind}-content`}
             />
             <div className="mt-1.5 flex justify-end gap-2">
               <button
@@ -1266,7 +1315,7 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
                 onClick={() => void discardAiDraft(draft)}
                 disabled={sendingDraftId === draft.id || discardingDraftId === draft.id}
                 className="rounded-md border px-2 py-1 text-xs hover:bg-muted disabled:opacity-50"
-                data-testid="ticket-ai-draft-discard"
+                data-testid={`ticket-ai-draft-${draft.kind}-discard`}
               >
                 {discardingDraftId === draft.id ? t('common:states.saving') : t('ticketWorkbench.aiDraft.discard')}
               </button>
@@ -1276,7 +1325,7 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
                   onClick={() => void sendAiDraft(draft)}
                   disabled={sendingDraftId === draft.id || discardingDraftId === draft.id || !(draftContent[draft.id] ?? draft.content).trim()}
                   className="rounded-md bg-primary px-2 py-1 text-xs font-medium text-white disabled:opacity-50"
-                  data-testid="ticket-ai-draft-send"
+                  data-testid={`ticket-ai-draft-${draft.kind}-send`}
                 >
                   {sendingDraftId === draft.id ? t('ticketWorkbench.aiDraft.sending') : t('ticketWorkbench.aiDraft.sendAsMe')}
                 </button>

--- a/apps/web/src/lib/i18n/translationCoverage.test.ts
+++ b/apps/web/src/lib/i18n/translationCoverage.test.ts
@@ -241,7 +241,9 @@ const namespaceDuplicateBaselines = {
     // rather than root-caused here).
     // +5: aiAgentsPage.runs (#3828 Task 4) — "Agent" and "Ticket" are the
     // same word in French, and "OK" is locale-invariant.
-    'settings.json': 159,
+    // +1: aiAgentsPage.runs.triage.notesTitle (P2-4, #4191) — "Notes" is the
+    // same word in French.
+    'settings.json': 160,
     // +1: ticketTimeBilling.noAmount — the em-dash placeholder for a row with
     // no amount is locale-invariant punctuation, identical in every catalog.
     // +1: ticketWorkbench.invoice.missingRateEntry "{{description}} — {{hours}} h" is two
@@ -319,7 +321,9 @@ const namespaceDuplicateBaselines = {
     // rather than root-caused here).
     // +5: aiAgentsPage.runs (#3828 Task 4) — "Agent" and "Ticket" are the
     // same word in French, and "OK" is locale-invariant.
-    'settings.json': 164,
+    // +1: aiAgentsPage.runs.triage.notesTitle (P2-4, #4191) — "Notes" is the
+    // same word in French.
+    'settings.json': 165,
     // +1: ticketTimeBilling.noAmount — the em-dash placeholder for a row with
     // no amount is locale-invariant punctuation, identical in every catalog.
     // +1: ticketWorkbench.invoice.missingRateEntry "{{description}} — {{hours}} h" is two

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -1687,7 +1687,7 @@
         "title": "Ticket-Triage",
         "fieldsTitle": "Vorgeschlagene Felder",
         "fields": {
-          "categoryId": "Kategorie",
+          "categoryIdLabel": "Kategorie-ID",
           "priority": "Priorität"
         },
         "confidence": "{{value}} % Konfidenz",

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -1493,7 +1493,9 @@
       "recipientRolesFailed": "Rollen konnten nicht geladen werden; Benachrichtigungsempfänger lassen sich derzeit nicht ändern.",
       "supervisedActionKeysHint": "Vorgänge, die dieser Agent OHNE einen menschlichen Klick auf Genehmigen ausführen darf, wenn eine passende Richtlinie existiert und im Expositionslimit der Organisation noch Spielraum ist. Jeder Vorgang durchläuft zur Ausführungszeit weiterhin die Live-Schutzmechanismen, den Kill-Switch und die Organisationslimits.",
       "supervisedActionKeysEmpty": "Es sind keine per Richtlinie entscheidbaren Aktionen registriert.",
-      "supervisedActionKeysFailed": "Die Liste der per Richtlinie entscheidbaren Aktionen konnte nicht geladen werden, daher kann die unbeaufsichtigte Autorisierung derzeit nicht geändert werden."
+      "supervisedActionKeysFailed": "Die Liste der per Richtlinie entscheidbaren Aktionen konnte nicht geladen werden, daher kann die unbeaufsichtigte Autorisierung derzeit nicht geändert werden.",
+      "ticketAutonomousWrites": "Autonome Ticket-Schreibvorgänge",
+      "ticketAutonomousWritesHint": "Nur Organisationsüberschreibung — autonome Ticket-Schreibvorgänge erfordern den Aktionsmodus und diese Opt-in-Einstellung auf Organisationsebene"
     },
     "loading": "Agenten werden geladen …",
     "runs": {
@@ -1540,7 +1542,8 @@
       },
       "profile": {
         "sweep": "Prüflauf",
-        "narrative": "Wochenbericht"
+        "narrative": "Wochenbericht",
+        "triage": "Ticket-Triage"
       },
       "sweep": {
         "title": "Ergebnisse des Prüflaufs",
@@ -1678,6 +1681,26 @@
           "partialNote": "Teilweise Erfassung, solange die unbeaufsichtigte Richtlinienautorisierung deaktiviert ist — die tatsächliche Nutzung kann höher sein.",
           "unavailable": "Keine aktive Agentenrichtlinie für die Organisation dieses Laufs.",
           "loading": "Budget wird geladen…"
+        }
+      },
+      "triage": {
+        "title": "Ticket-Triage",
+        "fieldsTitle": "Vorgeschlagene Felder",
+        "fields": {
+          "categoryId": "Kategorie",
+          "priority": "Priorität"
+        },
+        "confidence": "{{value}} % Konfidenz",
+        "device": "Gerätezuordnung: {{value}}",
+        "draftReplyTitle": "Antwortentwurf",
+        "draftResolutionTitle": "Entwurf der Lösungsnotiz",
+        "notesTitle": "Notizen",
+        "intentsTitle": "Vorgeschlagene Ticketänderungen",
+        "intentUnknown": "Status nicht verfügbar",
+        "draftsWrittenTitle": "Erstellte Entwürfe",
+        "draftKinds": {
+          "reply": "Antwortentwurf",
+          "resolutionNote": "Entwurf der Lösungsnotiz"
         }
       }
     }

--- a/apps/web/src/locales/de-DE/tickets.json
+++ b/apps/web/src/locales/de-DE/tickets.json
@@ -445,6 +445,17 @@
       "feedbackFailed": "Ticket-Triage-Feedback konnte nicht gespeichert werden.",
       "feedbackSaved": "Ticket-Triage-Feedback gespeichert"
     },
+    "aiDraft": {
+      "kindReply": "KI-Antwortentwurf",
+      "kindResolutionNote": "KI-Entwurf des Lösungsvermerks",
+      "sendAsMe": "Als ich senden",
+      "sending": "Wird gesendet…",
+      "discard": "Verwerfen",
+      "sendFailed": "KI-Entwurf konnte nicht gesendet werden.",
+      "sent": "Entwurf gesendet",
+      "discardFailed": "KI-Entwurf konnte nicht verworfen werden.",
+      "discarded": "Entwurf verworfen"
+    },
     "resolve": {
       "noteLabel": "Lösungsvermerk (sichtbar für den Antragsteller)",
       "submit": "Ticket lösen"

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -1493,7 +1493,9 @@
       "recipientRolesFailed": "Couldn't load roles, so notification recipients can't be changed right now.",
       "supervisedActionKeysHint": "Operations this agent may execute WITHOUT a human clicking approve, when a matching policy exists and the org's exposure cap has room. Each one still passes live guardrails, the kill switch, and per-org caps at execution time.",
       "supervisedActionKeysEmpty": "No policy-decidable actions are registered.",
-      "supervisedActionKeysFailed": "Couldn't load the policy-decidable action list, so unattended authorization can't be changed right now."
+      "supervisedActionKeysFailed": "Couldn't load the policy-decidable action list, so unattended authorization can't be changed right now.",
+      "ticketAutonomousWrites": "Autonomous ticket writes",
+      "ticketAutonomousWritesHint": "Org override only — autonomous ticket writes require act mode and this org-level opt-in"
     },
     "loading": "Loading agents…",
     "runs": {
@@ -1540,7 +1542,8 @@
       },
       "profile": {
         "sweep": "Sweep",
-        "narrative": "Weekly report"
+        "narrative": "Weekly report",
+        "triage": "Ticket triage"
       },
       "sweep": {
         "title": "Sweep findings",
@@ -1678,6 +1681,26 @@
           "partialNote": "Partial accounting while unattended policy authorization is disabled — this may understate actual exposure.",
           "unavailable": "No active agent policy for this run's organization.",
           "loading": "Loading budget…"
+        }
+      },
+      "triage": {
+        "title": "Ticket triage",
+        "fieldsTitle": "Proposed fields",
+        "fields": {
+          "categoryId": "Category",
+          "priority": "Priority"
+        },
+        "confidence": "{{value}}% confidence",
+        "device": "Device match: {{value}}",
+        "draftReplyTitle": "Draft reply",
+        "draftResolutionTitle": "Draft resolution note",
+        "notesTitle": "Notes",
+        "intentsTitle": "Proposed ticket changes",
+        "intentUnknown": "Status unavailable",
+        "draftsWrittenTitle": "Drafts written",
+        "draftKinds": {
+          "reply": "Reply draft",
+          "resolutionNote": "Resolution-note draft"
         }
       }
     }

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -1687,7 +1687,7 @@
         "title": "Ticket triage",
         "fieldsTitle": "Proposed fields",
         "fields": {
-          "categoryId": "Category",
+          "categoryIdLabel": "Category ID",
           "priority": "Priority"
         },
         "confidence": "{{value}}% confidence",

--- a/apps/web/src/locales/en/tickets.json
+++ b/apps/web/src/locales/en/tickets.json
@@ -445,6 +445,17 @@
       "feedbackFailed": "Could not save ticket triage feedback.",
       "feedbackSaved": "Ticket triage feedback saved"
     },
+    "aiDraft": {
+      "kindReply": "AI-drafted reply",
+      "kindResolutionNote": "AI-drafted resolution note",
+      "sendAsMe": "Send as me",
+      "sending": "Sending…",
+      "discard": "Discard",
+      "sendFailed": "Could not send the AI draft.",
+      "sent": "Draft sent",
+      "discardFailed": "Could not discard the AI draft.",
+      "discarded": "Draft discarded"
+    },
     "resolve": {
       "noteLabel": "Resolution note (visible to requester)",
       "submit": "Resolve ticket"

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -1493,7 +1493,9 @@
       "recipientRolesFailed": "No se pudieron cargar los roles, así que por ahora no se pueden cambiar los destinatarios de las notificaciones.",
       "supervisedActionKeysHint": "Operaciones que este agente puede ejecutar SIN que una persona haga clic en aprobar, cuando existe una política coincidente y el límite de exposición de la organización tiene margen. Cada una igual pasa por las protecciones en vivo, el interruptor de apagado y los límites por organización en el momento de la ejecución.",
       "supervisedActionKeysEmpty": "No hay acciones decidibles por política registradas.",
-      "supervisedActionKeysFailed": "No se pudo cargar la lista de acciones decidibles por política, así que la autorización no supervisada no se puede cambiar en este momento."
+      "supervisedActionKeysFailed": "No se pudo cargar la lista de acciones decidibles por política, así que la autorización no supervisada no se puede cambiar en este momento.",
+      "ticketAutonomousWrites": "Escrituras autónomas de tickets",
+      "ticketAutonomousWritesHint": "Solo anulación de la organización — las escrituras autónomas de tickets requieren el modo de actuación y esta activación a nivel de organización"
     },
     "loading": "Cargando agentes…",
     "runs": {
@@ -1540,7 +1542,8 @@
       },
       "profile": {
         "sweep": "Barrido",
-        "narrative": "Informe semanal"
+        "narrative": "Informe semanal",
+        "triage": "Triaje de tickets"
       },
       "sweep": {
         "title": "Hallazgos del barrido",
@@ -1678,6 +1681,26 @@
           "partialNote": "Contabilización parcial mientras la autorización de política desatendida está deshabilitada — esto puede subestimar la exposición real.",
           "unavailable": "No hay una política de agente activa para la organización de esta ejecución.",
           "loading": "Cargando presupuesto…"
+        }
+      },
+      "triage": {
+        "title": "Triaje de tickets",
+        "fieldsTitle": "Campos propuestos",
+        "fields": {
+          "categoryId": "Categoría",
+          "priority": "Prioridad"
+        },
+        "confidence": "{{value}}% confianza",
+        "device": "Dispositivo coincidente: {{value}}",
+        "draftReplyTitle": "Borrador de respuesta",
+        "draftResolutionTitle": "Borrador de nota de resolución",
+        "notesTitle": "Notas",
+        "intentsTitle": "Cambios de ticket propuestos",
+        "intentUnknown": "Estado no disponible",
+        "draftsWrittenTitle": "Borradores creados",
+        "draftKinds": {
+          "reply": "Borrador de respuesta",
+          "resolutionNote": "Borrador de nota de resolución"
         }
       }
     }

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -1687,7 +1687,7 @@
         "title": "Triaje de tickets",
         "fieldsTitle": "Campos propuestos",
         "fields": {
-          "categoryId": "Categoría",
+          "categoryIdLabel": "ID de categoría",
           "priority": "Prioridad"
         },
         "confidence": "{{value}}% confianza",

--- a/apps/web/src/locales/es-419/tickets.json
+++ b/apps/web/src/locales/es-419/tickets.json
@@ -445,6 +445,17 @@
       "feedbackFailed": "No se pudieron guardar los comentarios sobre la clasificación de tickets.",
       "feedbackSaved": "Comentarios sobre la clasificación de tickets guardados"
     },
+    "aiDraft": {
+      "kindReply": "Respuesta generada por IA",
+      "kindResolutionNote": "Nota de resolución generada por IA",
+      "sendAsMe": "Enviar como yo",
+      "sending": "Enviando…",
+      "discard": "Descartar",
+      "sendFailed": "No se pudo enviar el borrador de la IA.",
+      "sent": "Borrador enviado",
+      "discardFailed": "No se pudo descartar el borrador de la IA.",
+      "discarded": "Borrador descartado"
+    },
     "resolve": {
       "noteLabel": "Nota de resolución (visible para el solicitante)",
       "submit": "Resolver ticket"

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -1687,7 +1687,7 @@
         "title": "Triage des tickets",
         "fieldsTitle": "Champs proposés",
         "fields": {
-          "categoryId": "Catégorie",
+          "categoryIdLabel": "ID de catégorie",
           "priority": "Priorité"
         },
         "confidence": "{{value}} % confiance",

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -1493,7 +1493,9 @@
       "recipientRolesFailed": "Impossible de charger les rôles ; les destinataires des notifications ne peuvent pas être modifiés pour le moment.",
       "supervisedActionKeysHint": "Opérations que cet agent peut exécuter SANS qu’un humain clique sur approuver, lorsqu’une politique correspondante existe et que le plafond d’exposition de l’organisation le permet. Chacune passe tout de même par les garde-fous en direct, l’interrupteur d’arrêt et les plafonds par organisation au moment de l’exécution.",
       "supervisedActionKeysEmpty": "Aucune action décidable par politique n’est enregistrée.",
-      "supervisedActionKeysFailed": "Impossible de charger la liste des actions décidables par politique ; l’autorisation sans surveillance ne peut pas être modifiée pour le moment."
+      "supervisedActionKeysFailed": "Impossible de charger la liste des actions décidables par politique ; l’autorisation sans surveillance ne peut pas être modifiée pour le moment.",
+      "ticketAutonomousWrites": "Écritures autonomes de tickets",
+      "ticketAutonomousWritesHint": "Dérogation d'organisation seulement — les écritures autonomes de tickets nécessitent le mode action et cette activation au niveau de l'organisation"
     },
     "loading": "Chargement des agents en cours…",
     "runs": {
@@ -1540,7 +1542,8 @@
       },
       "profile": {
         "sweep": "Balayage",
-        "narrative": "Rapport hebdomadaire"
+        "narrative": "Rapport hebdomadaire",
+        "triage": "Triage des tickets"
       },
       "sweep": {
         "title": "Constats du balayage",
@@ -1678,6 +1681,26 @@
           "partialNote": "Comptabilisation partielle tant que l'autorisation de politique sans surveillance est désactivée — l'exposition réelle peut être sous-estimée.",
           "unavailable": "Aucune politique d'agent active pour l'organisation de cette exécution.",
           "loading": "Chargement du budget…"
+        }
+      },
+      "triage": {
+        "title": "Triage des tickets",
+        "fieldsTitle": "Champs proposés",
+        "fields": {
+          "categoryId": "Catégorie",
+          "priority": "Priorité"
+        },
+        "confidence": "{{value}} % confiance",
+        "device": "Appareil correspondant : {{value}}",
+        "draftReplyTitle": "Brouillon de réponse",
+        "draftResolutionTitle": "Brouillon de note de résolution",
+        "notesTitle": "Notes",
+        "intentsTitle": "Modifications de ticket proposées",
+        "intentUnknown": "Statut indisponible",
+        "draftsWrittenTitle": "Brouillons créés",
+        "draftKinds": {
+          "reply": "Brouillon de réponse",
+          "resolutionNote": "Brouillon de note de résolution"
         }
       }
     }

--- a/apps/web/src/locales/fr-CA/tickets.json
+++ b/apps/web/src/locales/fr-CA/tickets.json
@@ -445,6 +445,17 @@
       "feedbackFailed": "Impossible d’enregistrer les retours de triage des billets.",
       "feedbackSaved": "Retour d’information sur le triage des billets enregistré"
     },
+    "aiDraft": {
+      "kindReply": "Réponse rédigée par l’IA",
+      "kindResolutionNote": "Note de résolution rédigée par l’IA",
+      "sendAsMe": "Envoyer en mon nom",
+      "sending": "Envoi en cours…",
+      "discard": "Rejeter",
+      "sendFailed": "Impossible d’envoyer le brouillon de l’IA.",
+      "sent": "Brouillon envoyé",
+      "discardFailed": "Impossible de rejeter le brouillon de l’IA.",
+      "discarded": "Brouillon rejeté"
+    },
     "resolve": {
       "noteLabel": "Note de résolution (visible pour le demandeur)",
       "submit": "Résoudre le billet"

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -1687,7 +1687,7 @@
         "title": "Triage des tickets",
         "fieldsTitle": "Champs proposés",
         "fields": {
-          "categoryId": "Catégorie",
+          "categoryIdLabel": "ID de catégorie",
           "priority": "Priorité"
         },
         "confidence": "{{value}} % confiance",

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -1493,7 +1493,9 @@
       "recipientRolesFailed": "Impossible de charger les rôles ; les destinataires des notifications ne peuvent pas être modifiés pour le moment.",
       "supervisedActionKeysHint": "Opérations que cet agent peut exécuter SANS qu’un humain clique sur approuver, lorsqu’une politique correspondante existe et que le plafond d’exposition de l’organisation le permet. Chacune passe tout de même par les garde-fous en direct, l’interrupteur d’arrêt et les plafonds par organisation au moment de l’exécution.",
       "supervisedActionKeysEmpty": "Aucune action décidable par politique n’est enregistrée.",
-      "supervisedActionKeysFailed": "Impossible de charger la liste des actions décidables par politique ; l’autorisation sans surveillance ne peut pas être modifiée pour le moment."
+      "supervisedActionKeysFailed": "Impossible de charger la liste des actions décidables par politique ; l’autorisation sans surveillance ne peut pas être modifiée pour le moment.",
+      "ticketAutonomousWrites": "Écritures autonomes de tickets",
+      "ticketAutonomousWritesHint": "Dérogation d'organisation uniquement — les écritures autonomes de tickets nécessitent le mode action et cette activation au niveau de l'organisation"
     },
     "loading": "Chargement des agents…",
     "runs": {
@@ -1540,7 +1542,8 @@
       },
       "profile": {
         "sweep": "Balayage",
-        "narrative": "Rapport hebdomadaire"
+        "narrative": "Rapport hebdomadaire",
+        "triage": "Triage des tickets"
       },
       "sweep": {
         "title": "Constats du balayage",
@@ -1678,6 +1681,26 @@
           "partialNote": "Comptabilisation partielle tant que l'autorisation de politique sans surveillance est désactivée — l'exposition réelle peut être sous-estimée.",
           "unavailable": "Aucune politique d'agent active pour l'organisation de cette exécution.",
           "loading": "Chargement du budget…"
+        }
+      },
+      "triage": {
+        "title": "Triage des tickets",
+        "fieldsTitle": "Champs proposés",
+        "fields": {
+          "categoryId": "Catégorie",
+          "priority": "Priorité"
+        },
+        "confidence": "{{value}} % confiance",
+        "device": "Appareil correspondant : {{value}}",
+        "draftReplyTitle": "Brouillon de réponse",
+        "draftResolutionTitle": "Brouillon de note de résolution",
+        "notesTitle": "Notes",
+        "intentsTitle": "Modifications de ticket proposées",
+        "intentUnknown": "Statut indisponible",
+        "draftsWrittenTitle": "Brouillons créés",
+        "draftKinds": {
+          "reply": "Brouillon de réponse",
+          "resolutionNote": "Brouillon de note de résolution"
         }
       }
     }

--- a/apps/web/src/locales/fr-FR/tickets.json
+++ b/apps/web/src/locales/fr-FR/tickets.json
@@ -445,6 +445,17 @@
       "feedbackFailed": "Impossible d’enregistrer les retours de triage des tickets.",
       "feedbackSaved": "Retour d’information sur le triage des tickets enregistré"
     },
+    "aiDraft": {
+      "kindReply": "Réponse rédigée par l’IA",
+      "kindResolutionNote": "Note de résolution rédigée par l’IA",
+      "sendAsMe": "Envoyer en mon nom",
+      "sending": "Envoi en cours…",
+      "discard": "Rejeter",
+      "sendFailed": "Impossible d’envoyer le brouillon de l’IA.",
+      "sent": "Brouillon envoyé",
+      "discardFailed": "Impossible de rejeter le brouillon de l’IA.",
+      "discarded": "Brouillon rejeté"
+    },
     "resolve": {
       "noteLabel": "Note de résolution (visible pour le demandeur)",
       "submit": "Résoudre le ticket"

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -1493,7 +1493,9 @@
       "recipientRolesFailed": "Impossibile caricare i ruoli: al momento i destinatari delle notifiche non possono essere modificati.",
       "supervisedActionKeysHint": "Operazioni che questo agente può eseguire SENZA che un essere umano clicchi su approva, quando esiste una policy corrispondente e il limite di esposizione dell'organizzazione ha margine. Ognuna passa comunque attraverso le protezioni live, l'interruttore di emergenza e i limiti per organizzazione al momento dell'esecuzione.",
       "supervisedActionKeysEmpty": "Nessuna azione decidibile tramite policy è registrata.",
-      "supervisedActionKeysFailed": "Impossibile caricare l'elenco delle azioni decidibili tramite policy, quindi l'autorizzazione non presidiata non può essere modificata al momento."
+      "supervisedActionKeysFailed": "Impossibile caricare l'elenco delle azioni decidibili tramite policy, quindi l'autorizzazione non presidiata non può essere modificata al momento.",
+      "ticketAutonomousWrites": "Scritture autonome dei ticket",
+      "ticketAutonomousWritesHint": "Solo override a livello di organizzazione — le scritture autonome dei ticket richiedono la modalità azione e questa attivazione a livello di organizzazione"
     },
     "loading": "Caricamento degli agenti…",
     "runs": {
@@ -1540,7 +1542,8 @@
       },
       "profile": {
         "sweep": "Scansione",
-        "narrative": "Report settimanale"
+        "narrative": "Report settimanale",
+        "triage": "Triage dei ticket"
       },
       "sweep": {
         "title": "Rilevazioni della scansione",
@@ -1678,6 +1681,26 @@
           "partialNote": "Contabilizzazione parziale finché l'autorizzazione delle policy non presidiate è disattivata — l'esposizione reale potrebbe essere sottostimata.",
           "unavailable": "Nessuna policy agente attiva per l'organizzazione di questa esecuzione.",
           "loading": "Caricamento del budget…"
+        }
+      },
+      "triage": {
+        "title": "Triage dei ticket",
+        "fieldsTitle": "Campi proposti",
+        "fields": {
+          "categoryId": "Categoria",
+          "priority": "Priorità"
+        },
+        "confidence": "{{value}}% di confidenza",
+        "device": "Dispositivo corrispondente: {{value}}",
+        "draftReplyTitle": "Bozza di risposta",
+        "draftResolutionTitle": "Bozza della nota di risoluzione",
+        "notesTitle": "Note",
+        "intentsTitle": "Modifiche al ticket proposte",
+        "intentUnknown": "Stato non disponibile",
+        "draftsWrittenTitle": "Bozze create",
+        "draftKinds": {
+          "reply": "Bozza di risposta",
+          "resolutionNote": "Bozza della nota di risoluzione"
         }
       }
     }

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -1687,7 +1687,7 @@
         "title": "Triage dei ticket",
         "fieldsTitle": "Campi proposti",
         "fields": {
-          "categoryId": "Categoria",
+          "categoryIdLabel": "ID categoria",
           "priority": "Priorità"
         },
         "confidence": "{{value}}% di confidenza",

--- a/apps/web/src/locales/it-IT/tickets.json
+++ b/apps/web/src/locales/it-IT/tickets.json
@@ -445,6 +445,17 @@
       "feedbackFailed": "Impossibile salvare il feedback sul triage del ticket.",
       "feedbackSaved": "Feedback sul triage del ticket salvato"
     },
+    "aiDraft": {
+      "kindReply": "Risposta redatta dall’IA",
+      "kindResolutionNote": "Nota di risoluzione redatta dall’IA",
+      "sendAsMe": "Invia come me",
+      "sending": "Invio in corso…",
+      "discard": "Scarta",
+      "sendFailed": "Impossibile inviare la bozza dell’IA.",
+      "sent": "Bozza inviata",
+      "discardFailed": "Impossibile scartare la bozza dell’IA.",
+      "discarded": "Bozza scartata"
+    },
     "resolve": {
       "noteLabel": "Nota di risoluzione (visibile al richiedente)",
       "submit": "Risolvi ticket"

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -1493,7 +1493,9 @@
       "recipientRolesFailed": "Não foi possível carregar as funções, então os destinatários das notificações não podem ser alterados agora.",
       "supervisedActionKeysHint": "Operações que este agente pode executar SEM um humano clicar em aprovar, quando existe uma política correspondente e o limite de exposição da organização tem espaço. Cada uma ainda passa pelas proteções em tempo real, pelo interruptor de interrupção e pelos limites por organização no momento da execução.",
       "supervisedActionKeysEmpty": "Nenhuma ação decidível por política está registrada.",
-      "supervisedActionKeysFailed": "Não foi possível carregar a lista de ações decidíveis por política, então a autorização não supervisionada não pode ser alterada agora."
+      "supervisedActionKeysFailed": "Não foi possível carregar a lista de ações decidíveis por política, então a autorização não supervisionada não pode ser alterada agora.",
+      "ticketAutonomousWrites": "Gravações autônomas de chamados",
+      "ticketAutonomousWritesHint": "Somente substituição da organização — gravações autônomas de chamados exigem o modo de ação e esta ativação em nível de organização"
     },
     "loading": "Carregando agentes…",
     "runs": {
@@ -1540,7 +1542,8 @@
       },
       "profile": {
         "sweep": "Varredura",
-        "narrative": "Relatório semanal"
+        "narrative": "Relatório semanal",
+        "triage": "Triagem de chamados"
       },
       "sweep": {
         "title": "Constatações da varredura",
@@ -1678,6 +1681,26 @@
           "partialNote": "Contabilização parcial enquanto a autorização de política não supervisionada está desativada — isso pode subestimar a exposição real.",
           "unavailable": "Nenhuma política de agente ativa para a organização desta execução.",
           "loading": "Carregando orçamento…"
+        }
+      },
+      "triage": {
+        "title": "Triagem de chamados",
+        "fieldsTitle": "Campos propostos",
+        "fields": {
+          "categoryId": "Categoria",
+          "priority": "Prioridade"
+        },
+        "confidence": "{{value}}% de confiança",
+        "device": "Dispositivo correspondente: {{value}}",
+        "draftReplyTitle": "Rascunho de resposta",
+        "draftResolutionTitle": "Rascunho da nota de resolução",
+        "notesTitle": "Notas",
+        "intentsTitle": "Alterações de chamado propostas",
+        "intentUnknown": "Status indisponível",
+        "draftsWrittenTitle": "Rascunhos criados",
+        "draftKinds": {
+          "reply": "Rascunho de resposta",
+          "resolutionNote": "Rascunho da nota de resolução"
         }
       }
     }

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -1687,7 +1687,7 @@
         "title": "Triagem de chamados",
         "fieldsTitle": "Campos propostos",
         "fields": {
-          "categoryId": "Categoria",
+          "categoryIdLabel": "ID da categoria",
           "priority": "Prioridade"
         },
         "confidence": "{{value}}% de confiança",

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -1495,7 +1495,7 @@
       "supervisedActionKeysEmpty": "Nenhuma ação decidível por política está registrada.",
       "supervisedActionKeysFailed": "Não foi possível carregar a lista de ações decidíveis por política, então a autorização não supervisionada não pode ser alterada agora.",
       "ticketAutonomousWrites": "Gravações autônomas de chamados",
-      "ticketAutonomousWritesHint": "Somente substituição da organização — gravações autônomas de chamados exigem o modo de ação e esta ativação em nível de organização"
+      "ticketAutonomousWritesHint": "Somente substituição da organização — gravações autônomas de chamados exigem o modo de ação e a ativação neste nível de organização"
     },
     "loading": "Carregando agentes…",
     "runs": {

--- a/apps/web/src/locales/pt-BR/tickets.json
+++ b/apps/web/src/locales/pt-BR/tickets.json
@@ -445,6 +445,17 @@
       "feedbackFailed": "Não foi possível salvar o feedback da triagem do chamado.",
       "feedbackSaved": "Feedback da triagem salvo"
     },
+    "aiDraft": {
+      "kindReply": "Resposta gerada por IA",
+      "kindResolutionNote": "Nota de resolução gerada por IA",
+      "sendAsMe": "Enviar como eu",
+      "sending": "Enviando…",
+      "discard": "Descartar",
+      "sendFailed": "Não foi possível enviar o rascunho da IA.",
+      "sent": "Rascunho enviado",
+      "discardFailed": "Não foi possível descartar o rascunho da IA.",
+      "discarded": "Rascunho descartado"
+    },
     "resolve": {
       "noteLabel": "Nota de resolução (visível para o solicitante)",
       "submit": "Resolver chamado"

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -1687,7 +1687,7 @@
         "title": "Talep önceliklendirme",
         "fieldsTitle": "Önerilen alanlar",
         "fields": {
-          "categoryId": "Kategori",
+          "categoryIdLabel": "Kategori Kimliği",
           "priority": "Öncelik"
         },
         "confidence": "{{value}}% güven",

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -1493,7 +1493,9 @@
       "recipientRolesFailed": "Roller yüklenemedi, bu nedenle bildirim alıcıları şu anda değiştirilemiyor.",
       "supervisedActionKeysHint": "Eşleşen bir politika varsa ve kuruluşun maruziyet sınırında yer varsa, bu aracının bir insan onaylamadan gerçekleştirebileceği işlemler. Her biri yürütme anında yine de canlı korumalardan, kapatma anahtarından ve kuruluş başına sınırlardan geçer.",
       "supervisedActionKeysEmpty": "Politikayla karar verilebilecek işlem kayıtlı değil.",
-      "supervisedActionKeysFailed": "Politikayla karar verilebilecek işlem listesi yüklenemedi, bu nedenle gözetimsiz yetkilendirme şu anda değiştirilemiyor."
+      "supervisedActionKeysFailed": "Politikayla karar verilebilecek işlem listesi yüklenemedi, bu nedenle gözetimsiz yetkilendirme şu anda değiştirilemiyor.",
+      "ticketAutonomousWrites": "Otonom talep yazmaları",
+      "ticketAutonomousWritesHint": "Yalnızca organizasyon geçersiz kılması — otonom talep yazmaları eylem modunu ve bu organizasyon düzeyindeki katılımı gerektirir"
     },
     "loading": "Aracılar yükleniyor…",
     "runs": {
@@ -1540,7 +1542,8 @@
       },
       "profile": {
         "sweep": "Tarama",
-        "narrative": "Haftalık rapor"
+        "narrative": "Haftalık rapor",
+        "triage": "Talep önceliklendirme"
       },
       "sweep": {
         "title": "Tarama bulguları",
@@ -1678,6 +1681,26 @@
           "partialNote": "Gözetimsiz politika yetkilendirmesi devre dışıyken kısmi muhasebeleştirme yapılır — bu, gerçek maruziyeti olduğundan az gösterebilir.",
           "unavailable": "Bu çalıştırmanın organizasyonu için etkin bir aracı politikası yok.",
           "loading": "Bütçe yükleniyor…"
+        }
+      },
+      "triage": {
+        "title": "Talep önceliklendirme",
+        "fieldsTitle": "Önerilen alanlar",
+        "fields": {
+          "categoryId": "Kategori",
+          "priority": "Öncelik"
+        },
+        "confidence": "{{value}}% güven",
+        "device": "Eşleşen cihaz: {{value}}",
+        "draftReplyTitle": "Yanıt taslağı",
+        "draftResolutionTitle": "Çözüm notu taslağı",
+        "notesTitle": "Notlar",
+        "intentsTitle": "Önerilen talep değişiklikleri",
+        "intentUnknown": "Durum kullanılamıyor",
+        "draftsWrittenTitle": "Oluşturulan taslaklar",
+        "draftKinds": {
+          "reply": "Yanıt taslağı",
+          "resolutionNote": "Çözüm notu taslağı"
         }
       }
     }

--- a/apps/web/src/locales/tr-TR/tickets.json
+++ b/apps/web/src/locales/tr-TR/tickets.json
@@ -445,6 +445,17 @@
       "feedbackFailed": "Bilet önceliklendirme geri bildirimi kaydedilemedi.",
       "feedbackSaved": "Bilet önceliklendirme geri bildirimi kaydedildi"
     },
+    "aiDraft": {
+      "kindReply": "Yapay zeka tarafından hazırlanan yanıt",
+      "kindResolutionNote": "Yapay zeka tarafından hazırlanan çözüm notu",
+      "sendAsMe": "Benim adıma gönder",
+      "sending": "Gönderiliyor…",
+      "discard": "Vazgeç",
+      "sendFailed": "Yapay zeka taslağı gönderilemedi.",
+      "sent": "Taslak gönderildi",
+      "discardFailed": "Yapay zeka taslağı silinemedi.",
+      "discarded": "Taslak silindi"
+    },
     "resolve": {
       "noteLabel": "Çözüm notu (talep sahibi tarafından görülebilir)",
       "submit": "Bileti çözümle"


### PR DESCRIPTION
Closes #4191 (AI agents phase 2 — W04 P2-4 ticket triage). Stacked on #4300 (P2-4a). Plan: `docs/superpowers/plans/ai-mcp/2026-08-30-ai-agents-p2-4-ticket-triage.md`.

## What this does
- **Ticket workbench AI drafts**: card per active draft (`reply` editable + Send as me; both kinds discardable), edited content wins, concurrent-conflict recovery (any non-401 failure refetches and drops stale cards), drafts cleared on ticket switch; resolution-note draft prefills the resolve form and is consumed via `aiDraftId` — **a technician's edited note always wins over the draft text** (API precedence fixed in-wave on both resolve paths).
- **Settings**: `ticketAutonomousWrites` checkbox on **helpdesk-kind** agents (the kind that receives ticket runs — a review caught the toggle initially gated on the wrong kind), org-override-only (disabled with hint on partner-wide rows), mirroring the org-row-only merge.
- **Run surfaces**: triage proposal section on run detail (summary, per-field confidence, category id, device identifiers, intents with live state, drafts written), triage profile badges on list + detail.
- 8 locales, genuinely translated; per-kind data-testids; runAction + no-silent-mutations conventions.

## Verification
- Web: components suites green (tickets 244+, aiAgents, settings), i18n trio 211/211, astro check clean, lint clean. API (in-wave fix): ticketService 190/190, tsc clean.
- Whole-branch final review (opus) on both PRs; PR B's found+fixed: edited-note override (Critical), 404 recovery loop, stale cards across ticket switch, raw category UUID.
- Stacked branch = no automatic CI; dispatched via `gh workflow run CI --ref feature/4187-ai-agents-p2/wave-4191-b`.

## Follow-ups (non-blocking)
- Per-field skip reasons don't reach the run DTO (console-only today; plan asked for surfacing — small API follow-up).
- Per-intent `/approvals` links repeat; could collapse to one.
- Draft cards share one in-flight lock (acting on one disables the other briefly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)