### PR TITLE
chore(ci): repin Swatinem/rust-cache to the v2.9.2 release commit (#3748)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1656,7 +1656,7 @@ jobs:
           toolchain: stable
 
       - name: Rust cache
-        uses: swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: |
             apps/helper/src-tauri -> target
@@ -1719,7 +1719,7 @@ jobs:
 
       - name: Rust cache
         if: steps.changes.outputs.cargo == 'true'
-        uses: swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: |
             apps/helper/src-tauri -> target

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1054,7 +1054,7 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Rust cache
-        uses: swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: apps/viewer/src-tauri -> target
 
@@ -1212,7 +1212,7 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Rust cache
-        uses: swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: apps/helper/src-tauri -> target
 
@@ -1297,7 +1297,7 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Rust cache
-        uses: swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: apps/viewer/src-tauri -> target
 
@@ -1434,7 +1434,7 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Rust cache
-        uses: swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: apps/helper/src-tauri -> target
 

--- a/scripts/security/check-supply-chain-hardening.sh
+++ b/scripts/security/check-supply-chain-hardening.sh
@@ -198,9 +198,19 @@ for workflow in .github/workflows/ci.yml .github/workflows/release.yml; do
     "$workflow must pin Swatinem/rust-cache to the v2.9.2 release commit"
 done
 # require_grep only proves one good line exists; this proves no site deviates.
-rust_cache_offenders="$(
-  grep -rn -i -- 'rust-cache@' .github/workflows/ | grep -vF -- "$RUST_CACHE_PIN" || true
-)"
+# Capture the scan's own status rather than letting a trailing `|| true` absorb
+# it: grep exits 1 for "no matches" but 2 for "could not read", and a security
+# predicate must never answer "clean" about input it could not read (the rule
+# reject_unaudited_apk above is written to). Piping straight into the filter
+# would hide that, because pipefail reports the rightmost status and the filter
+# legitimately exits 1 once it removes every compliant line.
+rust_cache_status=0
+rust_cache_lines="$(grep -rn -i -- 'rust-cache@' .github/workflows/)" || rust_cache_status=$?
+((rust_cache_status <= 1)) || fail \
+  "rust-cache scan of .github/workflows/ failed (grep status $rust_cache_status)"
+# The filter is deliberately case-sensitive: the owner is `Swatinem` upstream,
+# so a lowercase re-drift is reported instead of silently accepted.
+rust_cache_offenders="$(printf '%s\n' "$rust_cache_lines" | grep -vF -- "$RUST_CACHE_PIN" || true)"
 [[ -z "$rust_cache_offenders" ]] || fail \
   "every rust-cache pin must be ${RUST_CACHE_PIN}, found:"$'\n'"$rust_cache_offenders"
 

--- a/scripts/security/check-supply-chain-hardening.sh
+++ b/scripts/security/check-supply-chain-hardening.sh
@@ -184,6 +184,26 @@ for dockerfile in apps/api/Dockerfile apps/web/Dockerfile docker/Dockerfile.api 
     "$dockerfile must pin pnpm to 10.34.5"
 done
 
+# Swatinem/rust-cache sat on an untagged master HEAD for months while a trailing
+# `# v2` comment made it look pinned to a release (#3748). A bare major-version
+# comment gives Dependabot no tag to resolve against, so it tracks the default
+# branch and each weekly group PR carries the next branch head forward. Four of
+# the six call sites are release.yml jobs that build signed customer binaries,
+# so the restored cache feeds compiled output. Pin every site to the 2.9.2
+# release commit and require the precise `# vX.Y.Z` comment, so a re-drift fails
+# here rather than inside a signed release build.
+RUST_CACHE_PIN='Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2'
+for workflow in .github/workflows/ci.yml .github/workflows/release.yml; do
+  require_grep "uses: ${RUST_CACHE_PIN//./\\.}\$" "$workflow" \
+    "$workflow must pin Swatinem/rust-cache to the v2.9.2 release commit"
+done
+# require_grep only proves one good line exists; this proves no site deviates.
+rust_cache_offenders="$(
+  grep -rn -i -- 'rust-cache@' .github/workflows/ | grep -vF -- "$RUST_CACHE_PIN" || true
+)"
+[[ -z "$rust_cache_offenders" ]] || fail \
+  "every rust-cache pin must be ${RUST_CACHE_PIN}, found:"$'\n'"$rust_cache_offenders"
+
 # The customer-Graph-read credential boundary ships as a separately built
 # executor. Keep its image, CI/release coverage, and deployment boundary from
 # silently disappearing while the feature remains dark by default.


### PR DESCRIPTION
## What

Repins all **6** `swatinem/rust-cache` call sites from an untagged `master` HEAD to the **v2.9.2 release commit**, and adds a guard so the drift cannot silently return.

## Why

`f0d9c3887740aee45f6153b24b3a6b815192ec16` is `Swatinem/rust-cache` **`master` HEAD** — a Dependabot merge commit dated 2026-08-17 — not a release. The trailing `# v2` comment claimed otherwise, so the pin carried eleven days of untagged branch drift while still *looking* pinned. It was the only action in the repo whose comment didn't resolve to its SHA.

The drift is self-perpetuating: a bare major-version comment gives Dependabot no tag to resolve against, so it tracks the default branch and each weekly group PR carries the next branch head forward. The previous pin (`a45951ff…`) was also an untagged `master` merge commit past 2.9.2.

Four of the six sites are `release.yml` jobs building **signed customer binaries** (`apps/viewer/src-tauri`, `apps/helper/src-tauri`), where a restored cache can influence compiled output. SHA-pinning is supposed to buy "this is a specific reviewed release"; pinning to a moving branch head gives that up while still looking pinned. Nothing indicates the current commit is malicious.

## Tag → SHA mapping (resolved from upstream, not copied)

Both annotated tags were dereferenced to their target commit:

| Ref | Tag object | Target commit | Notes |
|---|---|---|---|
| `tags/v2` | `49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c` | **`6323deb102c322ba6fcbdcafc7e3dddab59af2b6`** | commit message `2.9.2`, 2026-08-06 |
| `tags/v2.9.2` | `63fed3e2fecf6f7b51dc6f043341b79ef82a9ae7` | **`6323deb102c322ba6fcbdcafc7e3dddab59af2b6`** | same commit — agrees |
| `heads/master` | — | `f0d9c3887740aee45f6153b24b3a6b815192ec16` | what we pinned *before*; 2026-08-17 Dependabot merge |

`v2.9.2` is the newest release (2026-08-06). Every site is now:

```yaml
uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
```

## Call sites — 6 confirmed by grep

Verified against `origin/main` (`a48b840bb`); line numbers shifted from those in the issue.

- `.github/workflows/ci.yml:1659`, `:1722`
- `.github/workflows/release.yml:1057`, `:1215`, `:1300`, `:1437`

The only other repo-wide `rust-cache` hit is a prose comment in `.github/zizmor.yml` — no pin, unchanged.

## Also folded in

**Owner casing** — normalized `swatinem` → `Swatinem` (upstream casing). GitHub resolves case-insensitively so this was never a bug, but it makes the pin greppable against upstream. Same lines already changing, so zero extra diff surface.

**Regression guard** (`scripts/security/check-supply-chain-hardening.sh`) — this is the one piece of scope beyond the pins; **say the word and I'll drop it.** It lives in a different file from the workflows, so it can't collide with #4254 or #3471. Rationale: without it, next week's Dependabot group PR re-drifts the pin and we are back here — that is exactly how this state arose. `zizmor`'s `unpinned-uses: hash-pin` policy only proves *a* SHA is present, not that it is a **released** one, which is why the drift survived every prior check.

The guard is deliberately the local, network-free version of follow-on #2 from the issue (the full "every action's comment resolves upstream" check needs network and fits better as a scheduled workflow — not attempted here). It follows the file's existing hardcoded-pin convention (`pnpm@10.34.5`) and asserts two things:

1. Each workflow contains the exact expected pin line (catches deletion/rename).
2. **No** `rust-cache@` line anywhere in `.github/workflows/` deviates from it — because `require_grep` alone only proves one good line exists, which would miss a single drifted site.

## Verification

Red-first, and both directions of the control were proven:

- **RED** (guard added, pins still drifted) → `ERROR: .github/workflows/ci.yml must pin Swatinem/rust-cache to the v2.9.2 release commit`
- **GREEN** (after repin) → `Supply-chain hardening checks passed.`
- **Mutation test** — reverted *one* of six sites to the old SHA while leaving the `# v2.9.2` comment intact (the exact Dependabot failure shape, which assertion #1 alone would miss). Guard failed and named the site: `.github/workflows/ci.yml:1722`. Restored → passes.
- **YAML validity** — both workflows parse: `ci.yml` 37 jobs, `release.yml` 26 jobs.
- `git grep f0d9c388…` → 0 hits repo-wide.

No application code touched, so no test/typecheck surface beyond the above; the changed script is itself the test and it runs in CI at `ci.yml:745` and in `scripts/security/preflight.sh`.

Closes #3748

🤖 Generated with [Claude Code](https://claude.com/claude-code)
