### PR TITLE
fix(api): register the event-dispatch maintenance repeatables unconditionally (#4124)

### DIFF
--- a/apps/api/src/jobs/eventDispatchWorker.test.ts
+++ b/apps/api/src/jobs/eventDispatchWorker.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * Behaviour of the event-dispatch worker (route-event + deliver-event
@@ -530,23 +530,73 @@ describe('eventDispatchProcessor', () => {
 });
 
 describe('initializeEventDispatchWorker / shutdownEventDispatchWorker', () => {
-  it('mode off, empty queue: no-op, worker not created', async () => {
+  // The module holds `worker` / `maintenanceWorker` / `maintenanceQueue` in
+  // module-level state. Since maintenance now registers on EVERY path
+  // (including the ones that never start a main worker), a test that leaves
+  // it running would leak that state into the next test's close()/construct()
+  // counts. Shutting down after every case keeps each `it` independent.
+  afterEach(async () => {
+    await shutdownEventDispatchWorker();
+  });
+
+  /** Worker names passed to attachWorkerObservability, in call order. */
+  function observedWorkerNames(): string[] {
+    return attachWorkerObservabilityMock.mock.calls.map((call) => (call as [unknown, string])[1]);
+  }
+
+  /** BullMQ queue names the Worker constructor was invoked with, in order. */
+  function constructedWorkerQueues(): string[] {
+    return workerConstructorMock.mock.calls.map((call) => (call as [string, ...unknown[]])[0]);
+  }
+
+  it('mode off, empty queue: main worker NOT started, but the maintenance repeatables STILL register (#4124)', async () => {
     eventDispatchModeMock.mockReturnValue('off');
     getJobCountsMock.mockResolvedValue({ waiting: 0, delayed: 0, active: 0, paused: 0 });
 
     await initializeEventDispatchWorker();
 
-    expect(attachWorkerObservabilityMock).not.toHaveBeenCalled();
+    // Registration is unconditional so residual `event_delivery_receipts`
+    // from a completed rollout keep aging out after EVENT_DISPATCH_MODE goes
+    // back to 'off' and the queue drains — previously they only aged out the
+    // next time the main worker happened to start.
+    expect(observedWorkerNames()).toEqual(['eventDispatchMaintenance']);
+    expect(constructedWorkerQueues()).toEqual(['event-dispatch-maintenance']);
+    expect(queueAddMock.mock.calls.map((call) => call[0])).toEqual([
+      'receipt-retention',
+      'shadow-compare'
+    ]);
   });
 
-  it('mode off, backlog probe throws: does NOT propagate (would permanently pin /ready) — treated as no backlog, no worker started', async () => {
+  it('mode off, backlog probe throws: does NOT propagate (would permanently pin /ready) — treated as no backlog, main worker not started, maintenance still registers', async () => {
     eventDispatchModeMock.mockReturnValue('off');
     getJobCountsMock.mockRejectedValue(new Error('redis unreachable'));
 
     await expect(initializeEventDispatchWorker()).resolves.toBeUndefined();
 
+    // Only the probe failure is reported — maintenance registration succeeded.
     expect(captureExceptionMock).toHaveBeenCalledTimes(1);
-    expect(attachWorkerObservabilityMock).not.toHaveBeenCalled();
+    expect(observedWorkerNames()).toEqual(['eventDispatchMaintenance']);
+    expect(constructedWorkerQueues()).toEqual(['event-dispatch-maintenance']);
+    expect(queueAddMock.mock.calls.map((call) => call[0])).toEqual([
+      'receipt-retention',
+      'shadow-compare'
+    ]);
+  });
+
+  it('mode off, empty queue, maintenance registration fails: still resolves (a housekeeping job must never pin /ready) and closes what it opened', async () => {
+    eventDispatchModeMock.mockReturnValue('off');
+    getJobCountsMock.mockResolvedValue({ waiting: 0, delayed: 0, active: 0, paused: 0 });
+    const boom = new Error('redis unreachable during repeatable registration');
+    queueGetRepeatableJobsMock.mockRejectedValue(boom);
+
+    await expect(initializeEventDispatchWorker()).resolves.toBeUndefined();
+
+    expect(captureExceptionMock).toHaveBeenCalledWith(boom);
+    // The maintenance worker + queue this path opened are both closed. No main
+    // worker exists on this path, so the subsequent shutdown (afterEach) has
+    // nothing further to close.
+    expect(workerCloseMock).toHaveBeenCalledTimes(1);
+    expect(queueCloseMock).toHaveBeenCalledTimes(1);
   });
 
   it('mode off, queue has a backlog: starts the worker anyway to drain it, AND registers the maintenance repeatables', async () => {

--- a/apps/api/src/jobs/eventDispatchWorker.test.ts
+++ b/apps/api/src/jobs/eventDispatchWorker.test.ts
@@ -589,9 +589,33 @@ describe('initializeEventDispatchWorker / shutdownEventDispatchWorker', () => {
     const boom = new Error('redis unreachable during repeatable registration');
     queueGetRepeatableJobsMock.mockRejectedValue(boom);
 
-    await expect(initializeEventDispatchWorker()).resolves.toBeUndefined();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      await expect(initializeEventDispatchWorker()).resolves.toBeUndefined();
 
-    expect(captureExceptionMock).toHaveBeenCalledWith(boom);
+      // This suppression is swallowed BY DESIGN (a housekeeping job must never
+      // pin /ready), and since #4124 it runs on the default mode='off' boot —
+      // i.e. on every instance in the fleet, not just the opt-in rollout
+      // population. The Sentry report is therefore the ONLY operator-visible
+      // trace that retention never got scheduled, so it has to carry the
+      // `worker` tag (the triage axis attachWorkerObservability gives every
+      // other failure on this worker) and a greppable errorId in the log line.
+      expect(captureExceptionMock).toHaveBeenCalledWith(boom, undefined, {
+        worker: 'eventDispatchMaintenance'
+      });
+      expect(
+        consoleError.mock.calls.some((call) =>
+          call.some(
+            (arg) =>
+              typeof arg === 'string' &&
+              arg.includes('EVENT_DISPATCH_MAINTENANCE_REGISTRATION_FAILED')
+          )
+        )
+      ).toBe(true);
+    } finally {
+      consoleError.mockRestore();
+    }
+
     // The maintenance worker + queue this path opened are both closed. No main
     // worker exists on this path, so the subsequent shutdown (afterEach) has
     // nothing further to close.
@@ -657,7 +681,12 @@ describe('initializeEventDispatchWorker / shutdownEventDispatchWorker', () => {
     await expect(initializeEventDispatchWorker()).resolves.toBeUndefined();
 
     expect(captureExceptionMock).toHaveBeenCalledTimes(1);
-    expect(captureExceptionMock).toHaveBeenCalledWith(boom);
+    // Tagged `worker` so the report is attributable in Sentry — see the
+    // mode='off' sibling case above for why this tag carries the whole triage
+    // burden for a failure that is otherwise swallowed.
+    expect(captureExceptionMock).toHaveBeenCalledWith(boom, undefined, {
+      worker: 'eventDispatchMaintenance'
+    });
 
     // Cleanup closed the maintenance worker (Worker#close, shared mock with
     // the main worker's — see below) and the maintenance queue: one call

--- a/apps/api/src/jobs/eventDispatchWorker.ts
+++ b/apps/api/src/jobs/eventDispatchWorker.ts
@@ -925,8 +925,7 @@ export async function initializeEventDispatchWorker(): Promise<void> {
       await maintenanceQueue.close().catch(() => {});
       maintenanceQueue = null;
     }
-    //
-    // Because it IS swallowed, this report is the only operator-visible trace
+    // Because the error IS swallowed, this report is the only visible trace
     // that retention never got scheduled — `workerStatus` deliberately gets no
     // `eventDispatchMaintenance` key, since `readiness.ts` fails readiness on
     // `outcomes.every(Boolean)` and a `false` there would pin `/ready` exactly

--- a/apps/api/src/jobs/eventDispatchWorker.ts
+++ b/apps/api/src/jobs/eventDispatchWorker.ts
@@ -45,14 +45,11 @@ const { db } = dbModule;
  * comment for why not this queue): `receipt-retention` (daily batched-delete
  * pruning of `event_delivery_receipts`) and `shadow-compare` (5-minute parity
  * check between shadow-mode routing and local delivery, the evidence gate for
- * flipping to enforce). Both are registered whenever the MAIN worker above
- * actually starts (mode != 'off', or draining a backlog) — including in
- * `mode='off'` if a backlog forces a start. KNOWN GAP: if mode goes back to
- * 'off' and the queue fully drains, the worker (and therefore both
- * maintenance repeatables) stops, so residual receipts from a completed
- * rollout only age out the next time the worker is started again (mode
- * re-enabled, or a fresh backlog appears) — see
- * `registerEventDispatchMaintenanceRepeatables`'s docstring for the tradeoff.
+ * flipping to enforce). Both are registered on EVERY boot (#4124),
+ * independently of whether the MAIN worker above starts — retention is
+ * exactly the job that must keep running once a rollout ends and the queue
+ * drains, and shadow-compare re-checks the mode at run time. See
+ * `registerEventDispatchMaintenanceRepeatables`'s docstring.
  */
 
 const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
@@ -769,19 +766,23 @@ export function createEventDispatchMaintenanceWorker(): Worker {
 
 /**
  * Registers both maintenance repeatables. Called from
- * `initializeEventDispatchWorker` whenever the MAIN worker actually starts
- * (mode != 'off', or draining a backlog), unconditionally regardless of the
- * current mode:
+ * `initializeEventDispatchWorker` on EVERY boot (#4124) — including
+ * `mode='off'` with an empty queue, when the main worker deliberately does
+ * not start. Both job bodies are cheap and self-gating, so there is nothing
+ * to gate the registration on:
  *
- *  - retention: ideally would also run while mode='off' if receipts remain
- *    from a completed rollout, but that requires a DB probe at boot just to
- *    decide "should retention run" for a purely housekeeping job. Accepted
- *    gap (see `initializeEventDispatchWorker`'s docstring): once mode returns
- *    to 'off' and the queue drains, residual receipts age out only the next
- *    time the worker starts (mode re-enabled, or a backlog reappears).
- *  - shadow-compare: cheap to register unconditionally; it re-checks
- *    `eventDispatchMode() === 'shadow'` on every RUN, not just here at
- *    registration (see `runShadowComparisonSweep`) — mode can flip between
+ *  - retention: MUST run while mode='off' — that is exactly when residual
+ *    `event_delivery_receipts` from a completed rollout need to age out. The
+ *    original wave-3.5c shape tied registration to the main worker starting,
+ *    which meant those rows only aged out the next time the worker happened
+ *    to start (mode re-enabled, or a backlog reappeared). Running it always
+ *    costs three index-driven DELETE passes plus one COUNT per day; on an
+ *    empty table that is nothing, and it needs no boot-time DB probe to
+ *    decide whether it is worth scheduling.
+ *  - shadow-compare: it re-checks `eventDispatchMode() === 'shadow'` on every
+ *    RUN, not just here at registration (see `runShadowComparisonSweep`), and
+ *    returns `{ skipped: true }` outside shadow mode — so a tick under
+ *    mode='off' is a single function call, and mode can flip between
  *    5-minute ticks without a worker restart.
  *
  * Registration idiom (remove existing repeatables then add) mirrors
@@ -832,10 +833,15 @@ export function createEventDispatchWorker(): Worker {
 }
 
 /**
- * Starts the worker whenever `eventDispatchMode() !== 'off'`, OR the queue
- * already holds jobs — so flipping the mode back to `off` still drains
- * whatever is in flight rather than abandoning it. No-op (one log line) only
- * when both are false.
+ * Starts the MAIN worker whenever `eventDispatchMode() !== 'off'`, OR the
+ * queue already holds jobs — so flipping the mode back to `off` still drains
+ * whatever is in flight rather than abandoning it.
+ *
+ * The MAINTENANCE worker and its two repeatables, by contrast, are registered
+ * on every boot regardless of mode or backlog (#4124) — see
+ * `registerEventDispatchMaintenanceRepeatables`. Retention is precisely the
+ * job that has to keep running once a rollout ends, and shadow-compare
+ * self-gates at run time.
  *
  * Called from index.ts's `initializeWorkers()` AFTER its `Promise.allSettled`
  * block completes — by then `registerAllEventSubscribers()` (synchronous, run
@@ -845,8 +851,9 @@ export function createEventDispatchWorker(): Worker {
  */
 export async function initializeEventDispatchWorker(): Promise<void> {
   const mode = eventDispatchMode();
+  let startMainWorker = mode !== 'off';
 
-  if (mode === 'off') {
+  if (!startMainWorker) {
     // A throw here (e.g. Redis unreachable while constructing the queue) must
     // NEVER propagate: `EVENT_DISPATCH_MODE=off` is the default, so an
     // unguarded probe failure would set `workerStatus['eventDispatch'] =
@@ -865,24 +872,29 @@ export async function initializeEventDispatchWorker(): Promise<void> {
       backlog = 0;
     }
     if (backlog === 0) {
-      console.log('[EventDispatchWorker] mode=off and queue empty — worker not started');
-      return;
+      console.log(
+        '[EventDispatchWorker] mode=off and queue empty — main worker not started (maintenance repeatables still register)'
+      );
+    } else {
+      console.warn(
+        `[EventDispatchWorker] mode=off but ${backlog} job(s) remain queued — starting worker to drain them`
+      );
+      startMainWorker = true;
     }
-    console.warn(
-      `[EventDispatchWorker] mode=off but ${backlog} job(s) remain queued — starting worker to drain them`
-    );
   }
 
-  try {
-    worker = createEventDispatchWorker();
-    attachWorkerObservability(worker, 'eventDispatch');
-    console.log(`[EventDispatchWorker] Initialized (mode=${mode})`);
-  } catch (error) {
-    if (worker) {
-      await worker.close().catch(() => {});
-      worker = null;
+  if (startMainWorker) {
+    try {
+      worker = createEventDispatchWorker();
+      attachWorkerObservability(worker, 'eventDispatch');
+      console.log(`[EventDispatchWorker] Initialized (mode=${mode})`);
+    } catch (error) {
+      if (worker) {
+        await worker.close().catch(() => {});
+        worker = null;
+      }
+      throw error;
     }
-    throw error;
   }
 
   try {
@@ -891,12 +903,14 @@ export async function initializeEventDispatchWorker(): Promise<void> {
     await registerEventDispatchMaintenanceRepeatables();
     console.log('[EventDispatchWorker] Maintenance repeatables registered (receipt-retention, shadow-compare)');
   } catch (error) {
-    // ISOLATED failure domain, deliberately NOT rethrown: the main worker
-    // constructed just above is already healthy and serving real event
-    // traffic, and this function's caller (index.ts's initializeWorkers)
-    // sets `workerStatus['eventDispatch'] = true` only if this promise
-    // resolves — the exact off-mode-backlog-probe lesson a few lines up
-    // applies here too. Maintenance registration does 3+ fresh Redis
+    // ISOLATED failure domain, deliberately NOT rethrown: whatever the main
+    // worker is doing (running and serving real event traffic, or
+    // deliberately not started because mode='off') is unaffected, and this
+    // function's caller (index.ts's initializeWorkers) sets
+    // `workerStatus['eventDispatch'] = true` only if this promise resolves —
+    // the exact off-mode-backlog-probe lesson a few lines up applies here
+    // too, and applies HARDER now that this block runs on the default
+    // mode='off' boot as well. Maintenance registration does 3+ fresh Redis
     // round-trips (getRepeatableJobs, 2x removeRepeatableByKey/add), so a
     // transient Redis blip during boot must degrade to "retention/
     // shadow-compare didn't get scheduled this boot" rather than pinning

--- a/apps/api/src/jobs/eventDispatchWorker.ts
+++ b/apps/api/src/jobs/eventDispatchWorker.ts
@@ -925,8 +925,28 @@ export async function initializeEventDispatchWorker(): Promise<void> {
       await maintenanceQueue.close().catch(() => {});
       maintenanceQueue = null;
     }
-    console.error('[EventDispatchWorker] Failed to register maintenance repeatables (main worker unaffected):', error);
-    captureException(error instanceof Error ? error : new Error(String(error)));
+    //
+    // Because it IS swallowed, this report is the only operator-visible trace
+    // that retention never got scheduled — `workerStatus` deliberately gets no
+    // `eventDispatchMaintenance` key, since `readiness.ts` fails readiness on
+    // `outcomes.every(Boolean)` and a `false` there would pin `/ready` exactly
+    // as this block exists to prevent. So it has to be findable on its own:
+    // a greppable `errorId` in the log line (the convention this file already
+    // uses for EVENT_DISPATCH_RECEIPTS_ABANDONED / _SHADOW_MISMATCH) and the
+    // `worker` Sentry tag — the same triage axis `attachWorkerObservability`
+    // puts on every job-level failure from this worker, and one of the few
+    // tag names that survives the sentry.ts scrubber allowlist.
+    console.error(
+      `[EventDispatchWorker] maintenance-registration-failed ${JSON.stringify({
+        errorId: 'EVENT_DISPATCH_MAINTENANCE_REGISTRATION_FAILED',
+        mainWorkerStarted: startMainWorker,
+        mode
+      })}`,
+      error
+    );
+    captureException(error instanceof Error ? error : new Error(String(error)), undefined, {
+      worker: 'eventDispatchMaintenance'
+    });
   }
 }
 


### PR DESCRIPTION
Closes #4124

## Root cause

`initializeEventDispatchWorker` (`apps/api/src/jobs/eventDispatchWorker.ts`) returned early when `EVENT_DISPATCH_MODE=off` **and** the queue was empty:

```ts
if (backlog === 0) {
  console.log('[EventDispatchWorker] mode=off and queue empty — worker not started');
  return;   // <- skipped the maintenance block below
}
```

That `return` sat *above* the block that constructs the maintenance worker and registers the two repeatables, so registration was coupled to the **main** worker starting.

For `shadow-compare` that coupling is harmless. For `receipt-retention` it is backwards: the moment retention matters most is exactly the mode=`off`, queue-drained state **after** a rollout ends, when residual `event_delivery_receipts` rows have nothing left to prune them. As shipped in wave 3.5c they only aged out the next time the worker happened to start again (mode re-enabled, or a fresh backlog appeared) — the "Accepted gap" the original docstring recorded.

## Change

**Commit 1 — split the two concerns** inside `initializeEventDispatchWorker`:

- The **main** worker keeps its existing gate unchanged (`mode !== 'off'`, or a backlog to drain). The mode=`off` branch now sets a `startMainWorker` flag instead of returning.
- The **maintenance** worker + both repeatables register on **every** boot.

Neither job body needs a registration-time gate — they are both self-gating, which is what the issue's proposed shape rests on:

- `runShadowComparisonSweep` re-checks `eventDispatchMode() === 'shadow'` at **run** time and returns `{ skipped: true }` otherwise. A 5-minute tick under mode=`off` is one function call.
- `runReceiptRetentionSweep` on an empty table is three index-driven `DELETE` passes plus one `COUNT`, once a day (`3 15 * * *` via the scheduleRegistry cron lane).

The maintenance registration **failure domain is unchanged and still isolated** — swallowed, closes only what it opened, never rethrown. `index.ts` sets `workerStatus['eventDispatch'] = true` only if this promise resolves, so a transient Redis blip during boot must degrade to "repeatables didn't get scheduled this boot" rather than pinning `/ready` to not-ready for the process lifetime over a housekeeping job.

Docstrings that recorded the now-closed gap (module header + `registerEventDispatchMaintenanceRepeatables` + `initializeEventDispatchWorker`) are rewritten to state the new contract.

**No new registration site.** Process-role gating is untouched: `index.ts` calls this only when `breezeRole() !== 'api'`, and `src/worker.ts` has its own call — so exactly one process still registers the repeatables.

**Commit 2 — observability proportional to the widened reach** (from review, see below). That deliberate suppression now runs on the *default* mode=`off` boot, i.e. on every instance in the fleet rather than only the opt-in rollout population — so the Sentry report became the only operator-visible trace that retention never got scheduled, and it was a bare untagged `captureException`. It now carries:

- a structured log line with `errorId: 'EVENT_DISPATCH_MAINTENANCE_REGISTRATION_FAILED'` plus the mode and whether the main worker started — the same shape as this file's existing `EVENT_DISPATCH_RECEIPTS_ABANDONED` / `EVENT_DISPATCH_SHADOW_MISMATCH` lines;
- a `worker: 'eventDispatchMaintenance'` Sentry tag, the triage axis `attachWorkerObservability` puts on every job-level failure from this worker. `worker` is on `sentry.ts`'s `ALLOWED_TAG_NAMES`, so it survives the scrubber (BREEZE-18).

## Deliberate non-fix (reviewer suggestion, declined with reason)

The review also suggested an informational `workerStatus['eventDispatchMaintenance']` key. **Not doing that**, and it is not merely a scope call: `apps/api/src/services/readiness.ts:106-107` computes

```ts
const outcomes = Object.values(workerStatus);
return outcomes.length > 0 && outcomes.every(Boolean);
```

so there is no such thing as an "informational" entry in that map — any `false` pins `/ready` to not-ready, which is precisely what this catch block exists to prevent. A non-readiness-gating health signal for maintenance repeatables is a genuine gap, but it needs its own mechanism and is a separate change from this issue.

## Scope note (#3946)

Issue #3946 — `metricRollupMaintenance` registering `attachWorkerObservability` twice — is adjacent but **not** fixed here and does not collide: it is a different worker in `metricRollupMaintenance.ts`. This PR adds **no** new `attachWorkerObservability` call site; the existing `eventDispatchMaintenance` registration simply now also runs on the mode=`off` path. Worker-name cardinality is unchanged.

## Tests

Red-first, both commits. In `apps/api/src/jobs/eventDispatchWorker.test.ts`:

1. `mode off, empty queue` — main worker NOT started, but exactly one observability registration (`eventDispatchMaintenance`), the Worker constructed against `event-dispatch-maintenance`, and both repeatables added in order. This is the assertion the issue is about.
2. `mode off, backlog probe throws` — same, and still exactly one `captureException` (the probe failure), proving maintenance registration succeeded on that path too.
3. `mode off, empty queue, maintenance registration fails` — resolves rather than rejecting, closes only the maintenance worker + queue, and (commit 2) emits the `errorId` log line and the `worker`-tagged capture. Covers the isolated failure domain on the newly-reachable mode=`off` path.

Cases 1-3 were confirmed failing against the pre-fix implementation before the change landed (`3 failed | 34 passed`); the commit-2 assertion was likewise watched fail first.

Also added an `afterEach` shutdown to that describe block: the module holds `worker` / `maintenanceWorker` / `maintenanceQueue` in module-level state, and now that maintenance registers on paths that previously created nothing, a test that left it running would leak close()/construct() counts into the next case.

**Local evidence** (foreground, single-fork `--pool=threads --maxWorkers=2`):

| Check | Result |
|---|---|
| `vitest run src/jobs/eventDispatchWorker.test.ts src/jobs/eventDispatchWorker.sql.test.ts src/worker.boot.test.ts src/jobs/workerObservability.test.ts src/services/sentry.test.ts` | **98 passed (5 files)** |
| `tsc --noEmit --project apps/api/tsconfig.json` (the CI `typecheck` job's exact command) | exit 0 |
| `eslint src/jobs/eventDispatchWorker.ts src/jobs/eventDispatchWorker.test.ts` | exit 0 |

No schema, migration, tenancy, cascade, or export-policy surface is touched — no new table and no new column, so none of the registration lists apply.

## Operational note for the reviewer

The one real cost of this change: a worker-role process now constructs a BullMQ `Worker` + `Queue` for `event-dispatch-maintenance` even when the feature is entirely disabled (a couple of extra Redis connections), and runs a daily no-op retention sweep. That is the tradeoff the issue explicitly proposes, and it is what makes retention actually reach the rows it exists to prune.

🤖 Generated with [Claude Code](https://claude.com/claude-code)