### PR TITLE
fix(web): return an IdP re-verification to the card it started from (#4055)

### DIFF
--- a/apps/web/src/components/settings/ProfilePage.passkeys.test.tsx
+++ b/apps/web/src/components/settings/ProfilePage.passkeys.test.tsx
@@ -35,8 +35,9 @@ vi.mock('./ConnectSsoCard', () => ({
 }));
 
 import ProfilePage from './ProfilePage';
+import { SSO_REAUTH_INTENT_KEY, stashSsoReauthIntent } from '@/lib/ssoReauthIntent';
 
-const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+const makeJsonResponse =(payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
   ({
     ok,
     status,
@@ -47,6 +48,9 @@ const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500):
 describe('ProfilePage passkey management', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // #4055 records the originating card here; a value bleeding between tests
+    // would silently reroute the one after it.
+    sessionStorage.clear();
     globalThis.URL.createObjectURL = vi.fn(() => 'blob:fake');
     globalThis.URL.revokeObjectURL = vi.fn();
   });
@@ -188,6 +192,9 @@ describe('ProfilePage passkey management', () => {
     it('sends the SAME grant to BOTH register/options and register/verify', async () => {
       // Arriving back from the IdP: the callback hands the grant over in the
       // fragment, and ProfilePage holds it for whichever road spends it first.
+      // #4055: the trip started from the passkey card, so that is what is
+      // recorded — the return must come back here, not to the TOTP QR screen.
+      stashSsoReauthIntent('passkey');
       window.history.replaceState(null, '', `/settings/profile#ssoReauthGrant=${GRANT}`);
 
       fetchWithAuthMock.mockImplementation(async (url: string) => {
@@ -307,6 +314,167 @@ describe('ProfilePage passkey management', () => {
       await screen.findByText(/No passkeys are registered/i);
       expect(document.querySelector('#passkey-password')).toBeTruthy();
       expect(screen.queryByTestId('passkey-sso-reauth')).toBeNull();
+    });
+
+    // ── #4055 ────────────────────────────────────────────────────────────────
+    // Both cards start the SAME `POST /sso/reauth/start` trip and the callback
+    // returns everyone to the same `#ssoReauthGrant=` fragment. Nothing used to
+    // record WHICH card the user left from, so the return path unconditionally
+    // ran /auth/mfa/setup and force-opened the TOTP QR screen — a user who
+    // clicked "Verify with your identity provider" on the PASSKEY card landed
+    // on a different card, a different factor, and a TOTP secret they never
+    // asked for (left stranded in Redis under `mfa:setup:<userId>`).
+    describe('returning to the card the trip started from (#4055)', () => {
+      it('records the passkey card as the origin BEFORE navigating to the IdP', async () => {
+        window.history.replaceState(null, '', '/settings/profile');
+        // Captured at assign() time, not after: the recorded intent has to be
+        // durable at the instant the page leaves, or the return has nothing.
+        let intentAtNavigation: string | null = 'not-called';
+        const assignMock = vi.fn(() => {
+          intentAtNavigation = sessionStorage.getItem(SSO_REAUTH_INTENT_KEY);
+        });
+        const realLocation = window.location;
+        Object.defineProperty(window, 'location', {
+          configurable: true,
+          value: { assign: assignMock, hash: '', search: '', pathname: '/settings/profile' },
+        });
+
+        fetchWithAuthMock.mockImplementation(async (url: string) => {
+          const u = String(url);
+          if (u === '/auth/passkeys') return makeJsonResponse({ passkeys: [] });
+          if (u === '/sso/reauth/start') {
+            return makeJsonResponse({ authUrl: 'https://idp.example.com/authorize?prompt=login' });
+          }
+          return makeJsonResponse({});
+        });
+
+        try {
+          render(<ProfilePage initialUser={passwordlessUser} />);
+          await screen.findByText(/No passkeys are registered/i);
+          fireEvent.click(screen.getByTestId('passkey-sso-reauth'));
+
+          await waitFor(() => expect(assignMock).toHaveBeenCalled());
+          expect(intentAtNavigation).toBe('passkey');
+        } finally {
+          // In a `finally` on purpose: a bare restore after the assertions is
+          // skipped when one fails, and the stubbed location then leaks into
+          // every later test in this file as an empty hash.
+          Object.defineProperty(window, 'location', { configurable: true, value: realLocation });
+        }
+      });
+
+      it('returns to the passkey card and never fires the TOTP /auth/mfa/setup call', async () => {
+        stashSsoReauthIntent('passkey');
+        window.history.replaceState(null, '', `/settings/profile#ssoReauthGrant=${GRANT}`);
+
+        fetchWithAuthMock.mockImplementation(async (url: string) => {
+          const u = String(url);
+          if (u === '/auth/passkeys') return makeJsonResponse({ passkeys: [] });
+          if (u === '/auth/mfa/setup') {
+            return makeJsonResponse({ qrCodeDataUrl: 'data:image/png;base64,abc' });
+          }
+          return makeJsonResponse({});
+        });
+
+        render(<ProfilePage initialUser={passwordlessUser} />);
+        await screen.findByText(/No passkeys are registered/i);
+
+        // The grant landed and the card is armed: the submit replaces the CTA.
+        expect(screen.getByTestId('passkey-add')).toBeTruthy();
+        expect(screen.queryByTestId('passkey-sso-reauth')).toBeNull();
+
+        // And the user is NOT dropped on the TOTP enrollment screen.
+        expect(screen.queryByText(/Set up authenticator/i)).toBeNull();
+
+        // The load-bearing assertion: no TOTP secret is minted for a user who
+        // asked for a passkey. `mfa:setup:<userId>` is only cleared by the TOTP
+        // confirm step, so an unwanted one sits in Redis until its TTL expires.
+        expect(callTo('/auth/mfa/setup')).toHaveLength(0);
+      });
+
+      it('brings the passkey card to the user rather than leaving it below the fold', async () => {
+        const scrollSpy = vi.fn();
+        const realScroll = Element.prototype.scrollIntoView;
+        // jsdom has no layout and so no scrollIntoView implementation.
+        Element.prototype.scrollIntoView = scrollSpy;
+
+        stashSsoReauthIntent('passkey');
+        window.history.replaceState(null, '', `/settings/profile#ssoReauthGrant=${GRANT}`);
+        fetchWithAuthMock.mockImplementation(async (url: string) => {
+          if (String(url) === '/auth/passkeys') return makeJsonResponse({ passkeys: [] });
+          return makeJsonResponse({});
+        });
+
+        try {
+          render(<ProfilePage initialUser={passwordlessUser} />);
+          await screen.findByText(/No passkeys are registered/i);
+
+          const card = await screen.findByTestId('passkey-card');
+          await waitFor(() => {
+            expect(scrollSpy.mock.contexts).toContain(card);
+          });
+
+          // Scrolling helps a sighted user; focus is what routes a keyboard or
+          // screen-reader user, and it names the next thing to do.
+          await waitFor(() => {
+            expect(document.activeElement).toBe(document.querySelector('#passkey-name'));
+          });
+        } finally {
+          Element.prototype.scrollIntoView = realScroll;
+        }
+      });
+
+      it('replaces the now-stale "verify first" instruction once the grant is in hand', async () => {
+        stashSsoReauthIntent('passkey');
+        window.history.replaceState(null, '', `/settings/profile#ssoReauthGrant=${GRANT}`);
+        fetchWithAuthMock.mockImplementation(async (url: string) => {
+          if (String(url) === '/auth/passkeys') return makeJsonResponse({ passkeys: [] });
+          return makeJsonResponse({});
+        });
+
+        render(<ProfilePage initialUser={passwordlessUser} />);
+        await screen.findByText(/No passkeys are registered/i);
+
+        // Telling someone to "re-verify before adding a passkey" seconds after
+        // they did exactly that reads as a failed round-trip.
+        expect(screen.queryByText(/Re-verify with your provider before adding a passkey/i))
+          .toBeNull();
+        expect(screen.getByText(/Your identity is verified/i)).toBeTruthy();
+      });
+
+      it('consumes the recorded intent so a later return cannot replay it', async () => {
+        stashSsoReauthIntent('passkey');
+        window.history.replaceState(null, '', `/settings/profile#ssoReauthGrant=${GRANT}`);
+        fetchWithAuthMock.mockImplementation(async (url: string) => {
+          if (String(url) === '/auth/passkeys') return makeJsonResponse({ passkeys: [] });
+          return makeJsonResponse({});
+        });
+
+        render(<ProfilePage initialUser={passwordlessUser} />);
+        await screen.findByText(/No passkeys are registered/i);
+
+        expect(sessionStorage.getItem(SSO_REAUTH_INTENT_KEY)).toBeNull();
+      });
+
+      // Storage blocked (private mode, hardened browser) leaves nothing to
+      // read. That must land on the pre-#4055 behaviour rather than on a
+      // half-state where neither card does anything.
+      it('falls back to the TOTP road when no intent was recorded', async () => {
+        window.history.replaceState(null, '', `/settings/profile#ssoReauthGrant=${GRANT}`);
+        fetchWithAuthMock.mockImplementation(async (url: string) => {
+          const u = String(url);
+          if (u === '/auth/passkeys') return makeJsonResponse({ passkeys: [] });
+          if (u === '/auth/mfa/setup') {
+            return makeJsonResponse({ qrCodeDataUrl: 'data:image/png;base64,abc' });
+          }
+          return makeJsonResponse({});
+        });
+
+        render(<ProfilePage initialUser={passwordlessUser} />);
+
+        await waitFor(() => expect(callTo('/auth/mfa/setup')).toHaveLength(1));
+        await screen.findByText(/Set up authenticator/i);
+      });
     });
   });
 });

--- a/apps/web/src/components/settings/ProfilePage.passkeys.test.tsx
+++ b/apps/web/src/components/settings/ProfilePage.passkeys.test.tsx
@@ -37,7 +37,7 @@ vi.mock('./ConnectSsoCard', () => ({
 import ProfilePage from './ProfilePage';
 import { SSO_REAUTH_INTENT_KEY, stashSsoReauthIntent } from '@/lib/ssoReauthIntent';
 
-const makeJsonResponse =(payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
   ({
     ok,
     status,
@@ -45,9 +45,17 @@ const makeJsonResponse =(payload: unknown, ok = true, status = ok ? 200 : 500): 
     json: vi.fn().mockResolvedValue(payload),
   }) as unknown as Response;
 
+// Captured before any test can stub it. Several tests here replace
+// `window.location` with a plain object to intercept `assign()`; restoring it
+// unconditionally up front — rather than trusting each test's own cleanup —
+// means one failed assertion cannot leak an empty hash into every test after
+// it. Same guard `ProfilePage.test.tsx` already carries.
+const REAL_LOCATION = window.location;
+
 describe('ProfilePage passkey management', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    Object.defineProperty(window, 'location', { configurable: true, value: REAL_LOCATION });
     // #4055 records the originating card here; a value bleeding between tests
     // would silently reroute the one after it.
     sessionStorage.clear();
@@ -260,6 +268,13 @@ describe('ProfilePage passkey management', () => {
       expect(screen.queryByTestId('passkey-add')).toBeNull();
       expect(document.querySelector('#passkey-password')).toBeNull();
 
+      // #4055: the OTHER half of the instruction ternary. Asserting only the
+      // testids would let the two branches be swapped — telling a user with no
+      // grant that their identity is already verified — without a red test.
+      expect(screen.getByText(/Re-verify with your provider before adding a passkey/i))
+        .toBeTruthy();
+      expect(screen.queryByText(/Your identity is verified/i)).toBeNull();
+
       // And nothing proofless is ever sent.
       expect(callTo('/auth/passkeys/register/options')).toHaveLength(0);
       expect(callTo('/auth/passkeys/register/verify')).toHaveLength(0);
@@ -416,6 +431,43 @@ describe('ProfilePage passkey management', () => {
 
           // Scrolling helps a sighted user; focus is what routes a keyboard or
           // screen-reader user, and it names the next thing to do.
+          await waitFor(() => {
+            expect(document.activeElement).toBe(document.querySelector('#passkey-name'));
+          });
+        } finally {
+          Element.prototype.scrollIntoView = realScroll;
+        }
+      });
+
+      // The PRODUCTION mount. `profile.astro` renders `<ProfilePage client:load />`
+      // with no `initialUser`, so the component spends its first renders behind
+      // a "Loading profile…" early return while GET /users/me is in flight —
+      // the passkey card does not exist in the DOM at the moment the mount
+      // effect flips the return flag. Every other test here passes
+      // `initialUser` and therefore skips that branch entirely, which is
+      // exactly how a landing that never fires in production stays green.
+      it('lands on the passkey card even though it mounts after the profile finishes loading', async () => {
+        const scrollSpy = vi.fn();
+        const realScroll = Element.prototype.scrollIntoView;
+        Element.prototype.scrollIntoView = scrollSpy;
+
+        stashSsoReauthIntent('passkey');
+        window.history.replaceState(null, '', `/settings/profile#ssoReauthGrant=${GRANT}`);
+        fetchWithAuthMock.mockImplementation(async (url: string) => {
+          const u = String(url);
+          if (u === '/users/me') return makeJsonResponse(passwordlessUser);
+          if (u === '/auth/passkeys') return makeJsonResponse({ passkeys: [] });
+          return makeJsonResponse({});
+        });
+
+        try {
+          // No initialUser — the real page never has one.
+          render(<ProfilePage />);
+
+          const card = await screen.findByTestId('passkey-card');
+          await waitFor(() => {
+            expect(scrollSpy.mock.contexts).toContain(card);
+          });
           await waitFor(() => {
             expect(document.activeElement).toBe(document.querySelector('#passkey-name'));
           });

--- a/apps/web/src/components/settings/ProfilePage.test.tsx
+++ b/apps/web/src/components/settings/ProfilePage.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import ProfilePage from './ProfilePage';
 import { fetchWithAuth } from '../../stores/auth';
+import { SSO_REAUTH_INTENT_KEY, stashSsoReauthIntent } from '@/lib/ssoReauthIntent';
 import { writeDensity, writeFontPreference, writeThemePreference, writeTimeFormatPreference } from '@/lib/appearance';
 
 vi.mock('../../stores/auth', () => ({
@@ -478,6 +479,9 @@ describe('ProfilePage — SSO re-authentication enrollment (#4018)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     restoreLocation();
+    // #4055 records the originating card in sessionStorage; a value bleeding
+    // between tests would silently reroute the one after it.
+    sessionStorage.clear();
     // Real jsdom location + history so the hash-consumption assertions below
     // exercise the actual replaceState behaviour rather than a stub's.
     window.history.replaceState(null, '', '/settings/profile');
@@ -748,4 +752,86 @@ describe('ProfilePage — SSO re-authentication enrollment (#4018)', () => {
   // them together, and the passwordless confirm view's only action is a
   // full-page navigation to the IdP — so a reload drops the user on the status
   // card rather than on a QR screen with a dead Verify button. See the report.
+
+  // ── #4055: the TOTP half of "return to the card you left from" ─────────────
+  // The passkey half lives in ProfilePage.passkeys.test.tsx. These pin the side
+  // that must NOT change: the authenticator card's own round-trip still lands
+  // on the QR screen, and it now says so out loud instead of relying on it
+  // being the only thing the return path could possibly do.
+  describe('returning to the card the trip started from (#4055)', () => {
+    it('records the authenticator card as the origin BEFORE navigating to the IdP', async () => {
+      // Captured at assign() time: the recorded intent has to be durable at the
+      // instant the page leaves, or the return has nothing to read.
+      let intentAtNavigation: string | null = 'not-called';
+      const assignMock = vi.fn(() => {
+        intentAtNavigation = sessionStorage.getItem(SSO_REAUTH_INTENT_KEY);
+      });
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: {
+          assign: assignMock,
+          hash: '',
+          search: '',
+          pathname: '/settings/profile',
+          href: 'http://localhost/settings/profile',
+        },
+      });
+
+      fetchWithAuthMock.mockImplementation(async (url) => {
+        if (String(url) === '/auth/passkeys') return makeJsonResponse({ passkeys: [] });
+        if (String(url) === '/sso/reauth/start') {
+          return makeJsonResponse({ authUrl: 'https://idp.example.com/authorize?prompt=login' });
+        }
+        return undefined as unknown as Response;
+      });
+
+      try {
+        render(<ProfilePage initialUser={{ ...BASE_USER, hasPassword: false }} />);
+        fireEvent.click(screen.getByTestId('mfa-setup-start'));
+        fireEvent.click(await screen.findByTestId('mfa-sso-reauth'));
+
+        await waitFor(() => expect(assignMock).toHaveBeenCalled());
+        expect(intentAtNavigation).toBe('totp');
+      } finally {
+        // In a `finally` on purpose: a bare restore after the assertions is
+        // skipped when one fails, and the stubbed location then leaks into
+        // every later test as an empty hash.
+        restoreLocation();
+      }
+    });
+
+    it('still opens the QR screen when the trip started from the authenticator card', async () => {
+      stashSsoReauthIntent('totp');
+      window.history.replaceState(null, '', '/settings/profile#ssoReauthGrant=grant-abc');
+
+      render(<ProfilePage initialUser={{ ...BASE_USER, hasPassword: false }} />);
+
+      await waitFor(() => {
+        const setupCall = fetchWithAuthMock.mock.calls.find(
+          ([url]) => String(url) === '/auth/mfa/setup'
+        );
+        expect(setupCall).toBeDefined();
+        expect(JSON.parse(String(setupCall![1]?.body))).toEqual({ ssoReauthGrantId: 'grant-abc' });
+      });
+      await screen.findByText(/Set up authenticator/i);
+      expect(sessionStorage.getItem(SSO_REAUTH_INTENT_KEY)).toBeNull();
+    });
+
+    // An intent recorded for a trip that never completed must not survive to
+    // reroute the next one. The mount effect consumes it whether or not a grant
+    // came back — an error return (`?ssoReauthError=`) leaves nothing to route.
+    it('clears a stale intent even when the return carried no grant', async () => {
+      stashSsoReauthIntent('passkey');
+      window.history.replaceState(null, '', '/settings/profile?ssoReauthError=reauth_not_fresh');
+
+      render(<ProfilePage initialUser={{ ...BASE_USER, hasPassword: false }} />);
+      await screen.findByTestId('mfa-setup-start');
+
+      expect(sessionStorage.getItem(SSO_REAUTH_INTENT_KEY)).toBeNull();
+      // No grant, so nothing to enroll with — and certainly no /mfa/setup.
+      expect(
+        fetchWithAuthMock.mock.calls.filter(([url]) => String(url) === '/auth/mfa/setup')
+      ).toHaveLength(0);
+    });
+  });
 });

--- a/apps/web/src/components/settings/ProfilePage.tsx
+++ b/apps/web/src/components/settings/ProfilePage.tsx
@@ -18,6 +18,11 @@ import { useAvatarBlobUrl } from '@/lib/avatarBlobCache';
 import { formatNumber } from '@/lib/i18n/format';
 import { runAction } from '@/lib/runAction';
 import { showToast } from '../shared/Toast';
+import {
+  stashSsoReauthIntent,
+  takeSsoReauthIntent,
+  type SsoReauthIntent,
+} from '@/lib/ssoReauthIntent';
 
 const createProfileSchema = (t: TFunction) => z.object({
   name: z.string().min(2, t('profilePage.nameMustBeAtLeast2Characters')),
@@ -162,6 +167,14 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
   const [ssoReauthGrantId, setSsoReauthGrantId] = useState<string | null>(null);
   const [ssoSetupReady, setSsoSetupReady] = useState(false);
   const [isStartingSsoReauth, setIsStartingSsoReauth] = useState(false);
+  // #4055: this page load IS the return leg of a round-trip the PASSKEY card
+  // started, so the passkey card — not the TOTP one — is where the user must be
+  // put down. Distinct from `hasSsoReauthGrant`, which only says a grant is in
+  // hand and stays true for the rest of the flow: this fires the one-shot
+  // "bring the card to the user" landing and then stops mattering.
+  const [passkeyReauthReturn, setPasskeyReauthReturn] = useState(false);
+  const passkeyCardRef = useRef<HTMLDivElement | null>(null);
+  const passkeyNameRef = useRef<HTMLInputElement | null>(null);
 
   // Avatar upload state
   const [avatarFile, setAvatarFile] = useState<File | null>(null);
@@ -490,13 +503,34 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
   const hasSsoReauthGrant = ssoReauthGrantId !== null;
 
   // Consume an `#ssoReauthGrant=<id>` handed back by the SSO callback: the user
-  // has just re-proved their identity at the IdP, so run /mfa/setup with the
-  // grant and drop them straight on the QR screen. Mount-only by design — the
+  // has just re-proved their identity at the IdP. Mount-only by design — the
   // fragment is stripped as it is read, so this can never fire twice.
+  //
+  // #4055: BOTH the TOTP card and the passkey card start the same round-trip
+  // and the callback returns everyone to the same fragment, so the return leg
+  // has to be told which card to go back to. It used to run /mfa/setup
+  // unconditionally, which dropped a user who wanted a PASSKEY onto the TOTP QR
+  // screen and minted a TOTP secret nobody asked for — one that then sits in
+  // Redis under `mfa:setup:<userId>` until its TTL expires, because only the
+  // TOTP confirm step clears it.
   useEffect(() => {
     const grantId = takeSsoReauthGrantFromHash();
+    // Consumed unconditionally, grant or not: an error return
+    // (`?ssoReauthError=`) has nothing to route, and an intent left behind
+    // would misroute the NEXT round-trip instead.
+    const intent = takeSsoReauthIntent();
     if (!grantId) return;
     setSsoReauthGrantId(grantId);
+    if (intent === 'passkey') {
+      // Deliberately NO /mfa/setup here. The passkey road spends the same grant
+      // on register/options + register/verify, which the card below already
+      // knows how to do once `hasSsoReauthGrant` is true.
+      setPasskeyReauthReturn(true);
+      return;
+    }
+    // `null` (nothing recorded — storage blocked, or a link from before #4055)
+    // keeps the historical TOTP road rather than stranding the user on a page
+    // where neither card does anything.
     void requestMfaSetup({ ssoReauthGrantId: grantId }).then((ok) => {
       // Only open the QR view when the server actually issued a secret. On
       // failure the error banner is already set and the user stays on the
@@ -508,6 +542,18 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
     // way — the fragment is stripped as it is read — but re-running would burn
     // a second /mfa/setup call for nothing.
   }, []);
+
+  // #4055: the IdP trip is a full-page navigation, so the browser puts the user
+  // back at the TOP of a long settings page while the passkey card they left
+  // from sits below the fold. Routing them back to it means actually taking
+  // them there. Focus does the same job for keyboard and screen-reader users,
+  // and lands on the one field they still have to fill in.
+  useEffect(() => {
+    if (!passkeyReauthReturn) return;
+    // jsdom has no layout and so no `scrollIntoView`; optional-call it.
+    passkeyCardRef.current?.scrollIntoView?.({ behavior: 'smooth', block: 'start' });
+    passkeyNameRef.current?.focus?.();
+  }, [passkeyReauthReturn]);
 
   // Surface the callback's failure codes
   // (`/settings/profile?ssoReauthError=<code>`), exactly once.
@@ -534,7 +580,11 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
     // ... was not found") and fails the Lint job.
   }, []);
 
-  const handleSsoReauthStart = async () => {
+  // #4055: `intent` is the CARD this trip started from. Every scrap of React
+  // state dies at the navigation below and the callback's return URL is minted
+  // server-side, so the only way the return leg can know where to put the user
+  // down is to write it somewhere that survives the trip.
+  const handleSsoReauthStart = async (intent: SsoReauthIntent) => {
     setMfaError(undefined);
     setMfaSuccess(undefined);
     setIsStartingSsoReauth(true);
@@ -544,6 +594,10 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
         errorFallback: t('profilePage.couldNotStartIdentityProviderVerification'),
       });
       if (body?.authUrl) {
+        // Recorded only once there is somewhere to go: a failed start never
+        // leaves the page, so writing it earlier would just leave a stale value
+        // for a trip that did not happen.
+        stashSsoReauthIntent(intent);
         // External IdP URL — a full-page navigation, not the SPA router (which
         // rejects an off-origin path as an open redirect).
         window.location.assign(body.authUrl);
@@ -975,7 +1029,7 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
       <MFASettings
         enabled={user?.mfaEnabled ?? false}
         hasPassword={user?.hasPassword}
-        onSsoReauth={handleSsoReauthStart}
+        onSsoReauth={() => handleSsoReauthStart('totp')}
         ssoSetupReady={ssoSetupReady}
         ssoReauthGrantAvailable={hasSsoReauthGrant}
         qrCodeDataUrl={qrCodeDataUrl}
@@ -993,7 +1047,11 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
       <ConnectSsoCard />
 
       {/* Passkeys */}
-      <div className="space-y-6 rounded-lg border bg-card p-6 shadow-xs">
+      <div
+        ref={passkeyCardRef}
+        data-testid="passkey-card"
+        className="space-y-6 rounded-lg border bg-card p-6 shadow-xs"
+      >
         <div className="space-y-1">
           <h2 className="text-lg font-semibold">{t('profilePage.passkeys')}</h2>
           <p className="text-sm text-muted-foreground">
@@ -1085,8 +1143,13 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
           <div className="space-y-1">
             <h3 className="text-sm font-medium">{t('profilePage.addPasskey')}</h3>
             <p className="text-xs text-muted-foreground">
+              {/* #4055: "re-verify BEFORE adding a passkey" is stale the moment
+                  the grant lands — saying it to someone who just completed the
+                  round-trip reads as a failed trip. */}
               {isPasswordless
-                ? t('profilePage.thisAccountSignsInThroughAnIdentityProviderVerifyBeforeAddingAPasskey')
+                ? hasSsoReauthGrant
+                  ? t('profilePage.yourIdentityIsVerifiedNameThisPasskeyAndContinue')
+                  : t('profilePage.thisAccountSignsInThroughAnIdentityProviderVerifyBeforeAddingAPasskey')
                 : t('profilePage.reEnterYourAccountPasswordBeforeAddingOrDeletingAPasskey')}</p>
           </div>
           <div className="space-y-2">
@@ -1094,6 +1157,7 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
               {t('profilePage.passkeyName')}</label>
             <input
               id="passkey-name"
+              ref={passkeyNameRef}
               type="text"
               value={passkeyName}
               onChange={event => setPasskeyName(event.target.value)}
@@ -1123,7 +1187,7 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
             <button
               type="button"
               data-testid="passkey-sso-reauth"
-              onClick={() => { void handleSsoReauthStart(); }}
+              onClick={() => { void handleSsoReauthStart('passkey'); }}
               disabled={isAddingPasskey || isStartingSsoReauth}
               className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
             >

--- a/apps/web/src/components/settings/ProfilePage.tsx
+++ b/apps/web/src/components/settings/ProfilePage.tsx
@@ -173,8 +173,8 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
   // hand and stays true for the rest of the flow: this fires the one-shot
   // "bring the card to the user" landing and then stops mattering.
   const [passkeyReauthReturn, setPasskeyReauthReturn] = useState(false);
-  const passkeyCardRef = useRef<HTMLDivElement | null>(null);
   const passkeyNameRef = useRef<HTMLInputElement | null>(null);
+  const passkeyLandingDone = useRef(false);
 
   // Avatar upload state
   const [avatarFile, setAvatarFile] = useState<File | null>(null);
@@ -548,10 +548,22 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
   // from sits below the fold. Routing them back to it means actually taking
   // them there. Focus does the same job for keyboard and screen-reader users,
   // and lands on the one field they still have to fill in.
-  useEffect(() => {
-    if (!passkeyReauthReturn) return;
+  //
+  // A CALLBACK ref, keyed on the flag, rather than an effect over an object
+  // ref. The real page is `<ProfilePage client:load />` with no `initialUser`,
+  // so the component sits behind the `isLoadingUser` early return below while
+  // GET /users/me is in flight — the card does not exist in the DOM at the
+  // moment the mount effect sets the flag, and an effect keyed only on the flag
+  // would find a null ref and never run again. React re-invokes a callback ref
+  // whose identity changed, so this fires whichever way the race lands: card
+  // already mounted (identity change re-invokes it) or card mounted later (the
+  // attach invokes it). Child refs attach before parents, so the name input is
+  // already populated by the time this runs. The latch keeps it one-shot.
+  const passkeyCardRef = useCallback((node: HTMLDivElement | null) => {
+    if (!node || !passkeyReauthReturn || passkeyLandingDone.current) return;
+    passkeyLandingDone.current = true;
     // jsdom has no layout and so no `scrollIntoView`; optional-call it.
-    passkeyCardRef.current?.scrollIntoView?.({ behavior: 'smooth', block: 'start' });
+    node.scrollIntoView?.({ behavior: 'smooth', block: 'start' });
     passkeyNameRef.current?.focus?.();
   }, [passkeyReauthReturn]);
 

--- a/apps/web/src/lib/ssoReauthIntent.test.ts
+++ b/apps/web/src/lib/ssoReauthIntent.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  SSO_REAUTH_INTENT_KEY,
+  stashSsoReauthIntent,
+  takeSsoReauthIntent,
+} from './ssoReauthIntent';
+
+describe('ssoReauthIntent (#4055)', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('round-trips the intent across a full-page navigation', () => {
+    stashSsoReauthIntent('passkey');
+
+    expect(sessionStorage.getItem(SSO_REAUTH_INTENT_KEY)).toBe('passkey');
+    expect(takeSsoReauthIntent()).toBe('passkey');
+  });
+
+  // The IdP round-trip is one-shot. A value left behind would misroute the
+  // NEXT return — the exact class of bug #4055 is about.
+  it('consumes the intent so a second read cannot replay it', () => {
+    stashSsoReauthIntent('totp');
+
+    expect(takeSsoReauthIntent()).toBe('totp');
+    expect(takeSsoReauthIntent()).toBeNull();
+    expect(sessionStorage.getItem(SSO_REAUTH_INTENT_KEY)).toBeNull();
+  });
+
+  it('returns null when nothing was stashed', () => {
+    expect(takeSsoReauthIntent()).toBeNull();
+  });
+
+  // Anything outside the union is a stale or foreign value. It must not be
+  // handed back as an intent, AND it must still be cleared — otherwise it sits
+  // there poisoning every later read.
+  it('rejects and clears an unrecognized stored value', () => {
+    sessionStorage.setItem(SSO_REAUTH_INTENT_KEY, 'sms');
+
+    expect(takeSsoReauthIntent()).toBeNull();
+    expect(sessionStorage.getItem(SSO_REAUTH_INTENT_KEY)).toBeNull();
+  });
+
+  // Private-mode / quota / blocked-storage browsers throw on access. The intent
+  // is a routing nicety; it must never take the enrollment flow down with it.
+  it('never throws when sessionStorage is unavailable', () => {
+    const real = Object.getOwnPropertyDescriptor(window, 'sessionStorage');
+    Object.defineProperty(window, 'sessionStorage', {
+      configurable: true,
+      get() {
+        throw new Error('storage disabled');
+      },
+    });
+
+    try {
+      expect(() => stashSsoReauthIntent('passkey')).not.toThrow();
+      expect(takeSsoReauthIntent()).toBeNull();
+    } finally {
+      if (real) Object.defineProperty(window, 'sessionStorage', real);
+    }
+  });
+});

--- a/apps/web/src/lib/ssoReauthIntent.ts
+++ b/apps/web/src/lib/ssoReauthIntent.ts
@@ -1,0 +1,62 @@
+/**
+ * #4055 — which card started the IdP re-verification round-trip.
+ *
+ * A passwordless (SSO-provisioned) account can start the same
+ * `POST /sso/reauth/start` trip from two places on the profile page: the TOTP
+ * setup card and the "Add a passkey" card. Both leave the origin entirely
+ * (`window.location.assign(<IdP url>)`), so every scrap of React state is gone
+ * by the time the SSO callback redirects back to
+ * `/settings/profile#ssoReauthGrant=<id>` — and that return URL is minted
+ * server-side, so the client cannot hang anything off it.
+ *
+ * Hence sessionStorage rather than this repo's usual `window.location.hash`
+ * convention for UI state: the hash convention covers in-page state on a URL we
+ * control, and neither half of that holds here. Same shape, and the same
+ * private-mode caveat, as `orgSwitch.ts`'s switch-toast stash — carry one small
+ * fact across a full-page navigation, then consume it.
+ *
+ * Deliberately NOT round-tripped through the API: the re-auth state row is
+ * security-relevant (epochs, sid, single-use grant), and a purely presentational
+ * "which card do I go back to" preference has no business on it.
+ */
+
+export type SsoReauthIntent = 'totp' | 'passkey';
+
+export const SSO_REAUTH_INTENT_KEY = 'breeze.ssoReauth.intent';
+
+function isIntent(value: string | null): value is SsoReauthIntent {
+  return value === 'totp' || value === 'passkey';
+}
+
+/** Record the originating card immediately before navigating to the IdP. */
+export function stashSsoReauthIntent(intent: SsoReauthIntent): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.setItem(SSO_REAUTH_INTENT_KEY, intent);
+  } catch {
+    // Private mode / blocked storage / quota. The intent only decides which
+    // card the user lands on; never fail the enrollment trip over it. The
+    // reader's `null` fallback keeps the historical TOTP road.
+  }
+}
+
+/**
+ * Read and CONSUME the recorded intent.
+ *
+ * Consuming matters as much as reading: the grant is single-use, so a value
+ * left behind would misroute the NEXT round-trip. An unrecognized value is
+ * cleared too — otherwise a stale or foreign write sits there poisoning every
+ * later read. `null` means "not recorded", and callers must treat that as the
+ * pre-#4055 default (TOTP) so a storage-blocked browser behaves as it always
+ * did rather than losing the QR screen.
+ */
+export function takeSsoReauthIntent(): SsoReauthIntent | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const stored = window.sessionStorage.getItem(SSO_REAUTH_INTENT_KEY);
+    if (stored !== null) window.sessionStorage.removeItem(SSO_REAUTH_INTENT_KEY);
+    return isIntent(stored) ? stored : null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -2243,6 +2243,7 @@
     "ssoReauthEmailUnverified": "Ihr Identitätsanbieter meldet, dass Ihre E-Mail-Adresse nicht bestätigt ist. Bestätigen Sie sie dort und versuchen Sie es erneut.",
     "ssoReauthProofExpired": "Ihre Überprüfung durch den Identitätsanbieter ist abgelaufen. Führen Sie sie erneut durch, um die Einrichtung der Multi-Faktor-Authentifizierung abzuschließen.",
     "thisAccountSignsInThroughAnIdentityProviderVerifyBeforeAddingAPasskey": "Dieses Konto meldet sich über einen Identitätsanbieter an und hat kein Passwort. Bestätigen Sie sich erneut bei Ihrem Anbieter, bevor Sie einen Passkey hinzufügen.",
+    "yourIdentityIsVerifiedNameThisPasskeyAndContinue": "Ihre Identität wurde bestätigt. Benennen Sie diesen Passkey und fahren Sie fort.",
     "verifyWithYourIdentityProvider": "Mit Ihrem Identitätsanbieter bestätigen",
     "passkeyIdpVerificationRequired": "Bestätigen Sie sich bei Ihrem Identitätsanbieter, bevor Sie einen Passkey hinzufügen.",
     "ssoReauthFailed": "Die Bestätigung bei Ihrem Identitätsanbieter ist fehlgeschlagen. Bitte versuchen Sie es erneut.",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -2243,6 +2243,7 @@
     "ssoReauthEmailUnverified": "Your identity provider reports that your email address is not verified. Verify it there, then try again.",
     "ssoReauthProofExpired": "Your identity provider verification has expired. Verify again to finish setting up multi-factor authentication.",
     "thisAccountSignsInThroughAnIdentityProviderVerifyBeforeAddingAPasskey": "This account signs in through an identity provider and has no password. Re-verify with your provider before adding a passkey.",
+    "yourIdentityIsVerifiedNameThisPasskeyAndContinue": "Your identity is verified. Name this passkey and continue.",
     "verifyWithYourIdentityProvider": "Verify with your identity provider",
     "passkeyIdpVerificationRequired": "Verify with your identity provider before adding a passkey.",
     "ssoReauthFailed": "Could not verify with your identity provider. Please try again.",

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -2243,6 +2243,7 @@
     "ssoReauthEmailUnverified": "Tu proveedor de identidad indica que tu dirección de correo no está verificada. Verifícala allí y vuelve a intentarlo.",
     "ssoReauthProofExpired": "Tu verificación con el proveedor de identidad venció. Verifícate de nuevo para terminar de configurar la autenticación multifactor.",
     "thisAccountSignsInThroughAnIdentityProviderVerifyBeforeAddingAPasskey": "Esta cuenta inicia sesión mediante un proveedor de identidad y no tiene contraseña. Vuelve a verificarte con tu proveedor antes de agregar una clave de acceso.",
+    "yourIdentityIsVerifiedNameThisPasskeyAndContinue": "Tu identidad está verificada. Asigna un nombre a esta clave de acceso y continúa.",
     "verifyWithYourIdentityProvider": "Verificar con tu proveedor de identidad",
     "passkeyIdpVerificationRequired": "Verifícate con tu proveedor de identidad antes de agregar una clave de acceso.",
     "ssoReauthFailed": "No se pudo verificar con tu proveedor de identidad. Inténtalo de nuevo.",

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -2238,6 +2238,7 @@
     "ssoReauthEmailUnverified": "Votre fournisseur d'identité indique que votre adresse courriel n'est pas vérifiée. Vérifiez-la auprès de lui, puis réessayez.",
     "ssoReauthProofExpired": "Votre vérification auprès du fournisseur d'identité est expirée. Vérifiez de nouveau pour terminer la configuration de l'authentification multifacteur.",
     "thisAccountSignsInThroughAnIdentityProviderVerifyBeforeAddingAPasskey": "Ce compte ouvre une session par un fournisseur d'identité et n'a pas de mot de passe. Vérifiez de nouveau auprès de votre fournisseur avant d'ajouter une clé d'accès.",
+    "yourIdentityIsVerifiedNameThisPasskeyAndContinue": "Votre identité est vérifiée. Nommez cette clé d’accès et continuez.",
     "verifyWithYourIdentityProvider": "Vérifier auprès de votre fournisseur d'identité",
     "passkeyIdpVerificationRequired": "Vérifiez auprès de votre fournisseur d'identité avant d'ajouter une clé d'accès.",
     "ssoReauthFailed": "Impossible de vérifier avec votre fournisseur d'identité. Veuillez réessayer.",

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -2243,6 +2243,7 @@
     "ssoReauthEmailUnverified": "Votre fournisseur d'identité indique que votre adresse e-mail n'est pas vérifiée. Vérifiez-la chez lui, puis réessayez.",
     "ssoReauthProofExpired": "Votre vérification auprès du fournisseur d'identité a expiré. Vérifiez de nouveau pour terminer la configuration de l'authentification multifacteur.",
     "thisAccountSignsInThroughAnIdentityProviderVerifyBeforeAddingAPasskey": "Ce compte se connecte via un fournisseur d'identité et n'a pas de mot de passe. Vérifiez de nouveau auprès de votre fournisseur avant d'ajouter une clé d'accès.",
+    "yourIdentityIsVerifiedNameThisPasskeyAndContinue": "Votre identité est vérifiée. Nommez cette clé d’accès et continuez.",
     "verifyWithYourIdentityProvider": "Vérifier auprès de votre fournisseur d'identité",
     "passkeyIdpVerificationRequired": "Vérifiez auprès de votre fournisseur d'identité avant d'ajouter une clé d'accès.",
     "ssoReauthFailed": "Impossible de vérifier avec votre fournisseur d'identité. Veuillez réessayer.",

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -2238,6 +2238,7 @@
     "ssoReauthEmailUnverified": "Il tuo provider di identità segnala che il tuo indirizzo e-mail non è verificato. Verificalo lì, quindi riprova.",
     "ssoReauthProofExpired": "La verifica tramite il provider di identità è scaduta. Eseguila di nuovo per completare la configurazione dell'autenticazione a più fattori.",
     "thisAccountSignsInThroughAnIdentityProviderVerifyBeforeAddingAPasskey": "Questo account accede tramite un provider di identità e non ha una password. Esegui di nuovo la verifica presso il provider prima di aggiungere una passkey.",
+    "yourIdentityIsVerifiedNameThisPasskeyAndContinue": "La tua identità è stata verificata. Assegna un nome a questa passkey e continua.",
     "verifyWithYourIdentityProvider": "Verifica con il tuo provider di identità",
     "passkeyIdpVerificationRequired": "Verifica con il tuo provider di identità prima di aggiungere una passkey.",
     "ssoReauthFailed": "Non è stato possibile verificare con il tuo provider di identità. Riprova.",

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -2243,6 +2243,7 @@
     "ssoReauthEmailUnverified": "Seu provedor de identidade informa que seu endereço de e-mail não foi verificado. Verifique-o lá e tente de novo.",
     "ssoReauthProofExpired": "Sua verificação com o provedor de identidade expirou. Verifique novamente para concluir a configuração da autenticação multifator.",
     "thisAccountSignsInThroughAnIdentityProviderVerifyBeforeAddingAPasskey": "Esta conta faz login por um provedor de identidade e não tem senha. Verifique novamente com o provedor antes de adicionar uma chave de acesso.",
+    "yourIdentityIsVerifiedNameThisPasskeyAndContinue": "Sua identidade foi verificada. Dê um nome a esta chave de acesso e continue.",
     "verifyWithYourIdentityProvider": "Verificar com seu provedor de identidade",
     "passkeyIdpVerificationRequired": "Verifique com seu provedor de identidade antes de adicionar uma chave de acesso.",
     "ssoReauthFailed": "Não foi possível verificar com seu provedor de identidade. Tente novamente.",

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -2243,6 +2243,7 @@
     "ssoReauthEmailUnverified": "Kimlik sağlayıcınız e-posta adresinizin doğrulanmadığını bildiriyor. Adresi orada doğrulayıp tekrar deneyin.",
     "ssoReauthProofExpired": "Kimlik sağlayıcısı doğrulamanızın süresi doldu. Çok faktörlü kimlik doğrulama kurulumunu tamamlamak için yeniden doğrulayın.",
     "thisAccountSignsInThroughAnIdentityProviderVerifyBeforeAddingAPasskey": "Bu hesap bir kimlik sağlayıcı üzerinden oturum açıyor ve parolası yok. Geçiş anahtarı eklemeden önce sağlayıcınızda yeniden doğrulayın.",
+    "yourIdentityIsVerifiedNameThisPasskeyAndContinue": "Kimliğiniz doğrulandı. Bu geçiş anahtarına bir ad verin ve devam edin.",
     "verifyWithYourIdentityProvider": "Kimlik sağlayıcınızla doğrulayın",
     "passkeyIdpVerificationRequired": "Geçiş anahtarı eklemeden önce kimlik sağlayıcınızla doğrulayın.",
     "ssoReauthFailed": "Kimlik sağlayıcınızla doğrulanamadı. Lütfen tekrar deneyin.",


### PR DESCRIPTION
Closes #4055

## Root cause

A passwordless (SSO-provisioned) account can start the **same** `POST /sso/reauth/start` round-trip from two cards on the profile page: the TOTP setup card (`MFASettings`) and "Add a passkey" (`ProfilePage`, `data-testid="passkey-sso-reauth"`). Both leave the origin entirely — `window.location.assign(<IdP url>)` — and the SSO callback returns everyone to the same server-minted `/settings/profile#ssoReauthGrant=<id>`.

Nothing recorded **which** card the user left from, so `ProfilePage`'s mount effect ran `requestMfaSetup` unconditionally and set `ssoSetupReady`, which `MFASettings`' own effect turns into `setView('setup')` — and never resets. A user who clicked "Verify with your identity provider" on the **passkey** card came back to the **TOTP QR screen**: a different card, a different factor, and a `/auth/mfa/setup` call they never asked for. That call's candidate secret is stashed in Redis under `mfa:setup:<userId>` and is only deleted by the TOTP *confirm* step, so an abandoned detour leaves it sitting there until its TTL expires.

## The fix

Carry the originating card across the round-trip and route the return leg on it.

- **New `apps/web/src/lib/ssoReauthIntent.ts`** — stashes `'totp' | 'passkey'` and consumes it on return.
- **`handleSsoReauthStart(intent)`** — both call sites pass their own card's intent. The stash happens only once `runAction` has produced an `authUrl`, so a failed start (which never leaves the page) can't leave a stale value behind.
- **The mount effect** consumes the intent **unconditionally** — an error return (`?ssoReauthError=`) has nothing to route, and a value left behind would misroute the *next* trip — then skips `/auth/mfa/setup` entirely when the intent is `'passkey'`. The passkey card already knows how to spend the same grant on `register/options` + `register/verify` once `hasSsoReauthGrant` is true.
- **A passkey return scrolls the passkey card into view and focuses the name field.** The trip is a full-page navigation, so the browser drops the user at the *top* of a long settings page with the card they left from below the fold; "return the user to the card" has to mean actually taking them there. Focus does the same job for keyboard and screen-reader users.
- **The card's instruction line changes once the grant is in hand** ("Your identity is verified. Name this passkey and continue.") — telling someone to "re-verify before adding a passkey" seconds after they did exactly that reads as a failed round-trip.

## Why `sessionStorage` and not the repo's `window.location.hash` convention

The hash convention (`DeviceDetails.tsx`, `OrganizationsPage.tsx`) covers **in-page UI state on a URL we control**. Neither half holds here:

1. The trip leaves the origin for the IdP, so all React state — and any hash we set — is gone by the time we come back.
2. The return URL is minted **server-side** by the SSO callback. The client cannot hang anything off it.

The alternative was round-tripping the intent through the API's re-auth state row. Rejected deliberately: that row is security-relevant (epochs, `sid`, the single-use grant), and a purely presentational "which card do I go back to" preference has no business on it — it would also mean a server contract change and a migration for a UI routing fix.

`sessionStorage` is the shape this repo already uses for exactly this problem — `apps/web/src/lib/orgSwitch.ts` stashes a confirmation toast across a full-page reload — including the same private-mode caveat: every access is wrapped in try/catch, and a `null` read falls back to the **historical TOTP road** so a storage-blocked browser behaves as it did before this PR rather than landing on a page where neither card does anything.

No API, schema, migration, or tenancy surface is touched; the stale-Redis-key symptom in the issue is fixed by no longer making the call, not by changing `mfa.ts`.

## Verification

- `apps/web` affected suites, single-fork on a base rebased onto current `main`:
  `ssoReauthIntent.test.ts` (5), `ProfilePage.test.tsx` (32),
  `ProfilePage.passkeys.test.tsx` (13) — **50 passed**.
- Regression batch: `src/lib/i18n` (locale parity + translation coverage) and
  `src/lib/__tests__/no-silent-mutations.test.ts` — **252 passed (8 files)**;
  plus `MFASettings.test.tsx`, `ConnectSsoCard`, `ApproverDevicesSection`,
  `ChangePasswordForm` green on the pre-rebase run.
- `tsc --noEmit -p apps/web/tsconfig.json` — clean. `pnpm --filter @breeze/web lint`
  — clean. No `.astro`, API, schema, or migration files changed.

**Red-first.** The 6 passkey-road and 3 TOTP-road assertions were written against
unmodified `ProfilePage` and watched fail (8 red; the 9th — "falls back to the TOTP
road when no intent was recorded" — passes before and after by design, it pins the
fallback). One of those initial reds was a *test* defect, not a product one: a
`window.location` stub restored after the assertions instead of in a `finally`
leaked an empty hash into every later test in the file. Fixed before implementing,
so the remaining reds are honest.

**Second red, found in review — the landing never fired in production.** The first
commit hung the scroll+focus off an object ref plus an effect keyed on the return
flag. But `profile.astro` renders `<ProfilePage client:load />` with **no**
`initialUser`, so `isLoadingUser` starts true and the component's first commits
return the "Loading profile…" early return — the passkey card is not in the DOM at
the moment the mount effect sets the flag. The effect found a null ref, no-opped
through the optional chain, and never ran again once the card mounted. Every
existing test passes `initialUser` and so skips that branch entirely, which is
exactly how a landing that never happens stays green. The second commit replaces it
with a **callback ref** latched by `passkeyLandingDone`, which fires on whichever
render actually attaches the node, and adds a regression test that renders
`<ProfilePage />` with no `initialUser` — watched failing on the old effect first.

`runAction`: `handleSsoReauthStart` already routes `POST /sso/reauth/start` through
`runAction`; this PR changes its signature, not its error path.

## i18n

One new key, `profilePage.yourIdentityIsVerifiedNameThisPasskeyAndContinue`, added to all 8 locales.

pt-BR strings are machine-drafted pending native review

es-419, fr-FR, fr-CA, de-DE, and it-IT strings are machine-drafted pending native review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
