### PR TITLE
fix(api): route openaiCompatibleProvider egress through guarded safeFetch (#4121)

### DIFF
--- a/apps/api/src/services/llm/__scripts__/openai-smoke.ts
+++ b/apps/api/src/services/llm/__scripts__/openai-smoke.ts
@@ -18,6 +18,10 @@ import type { ChatMessage } from '../types';
 import { envFloat } from '../../../utils/envFloat';
 import { envStr } from '../../../utils/envStr';
 
+// The provider dials through the SSRF-guarded `safeFetch` (#4121), which
+// refuses loopback even with the self-host private-network opt-in. So this
+// default no longer connects to anything: set MCP_LLM_BASE_URL to the model
+// host's LAN address or container service name (RFC1918/ULA) before running.
 const BASE_URL = envStr('MCP_LLM_BASE_URL', 'http://localhost:8000/v1');
 const API_KEY = envStr('MCP_LLM_API_KEY', 'changeme');
 const MODEL = envStr('MCP_LLM_MODEL', 'qwen3.6-27b');

--- a/apps/api/src/services/llm/openaiCompatibleProvider.test.ts
+++ b/apps/api/src/services/llm/openaiCompatibleProvider.test.ts
@@ -13,14 +13,20 @@
  *    finished, and hold a whole LLM turn in memory across the 6-minute timeout.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import http from 'http';
+import { EventEmitter } from 'events';
 
-const { safeFetchMock, selfHostAllowsPrivateNetworkMock } = vi.hoisted(() => ({
+const { safeFetchMock, selfHostAllowsPrivateNetworkMock, realUrlSafety } = vi.hoisted(() => ({
   safeFetchMock: vi.fn(async (_url: string, _init?: unknown) => new Response('', { status: 200 })),
   selfHostAllowsPrivateNetworkMock: vi.fn(() => false),
+  // Stashed so the seam suite below can drive the provider through the REAL
+  // safeFetch (and the real module's DNS test hook) instead of a stand-in.
+  realUrlSafety: { mod: null as typeof import('../urlSafety') | null },
 }));
 
 vi.mock('../urlSafety', async () => {
   const actual = await vi.importActual<typeof import('../urlSafety')>('../urlSafety');
+  realUrlSafety.mod = actual;
   return { ...actual, safeFetch: safeFetchMock };
 });
 
@@ -206,5 +212,211 @@ describe('OpenAICompatibleProvider egress guard (#4121)', () => {
     }
 
     expect(seen).toEqual(['first', 'second']);
+  });
+});
+
+/**
+ * The branches the streaming swap actually rewrote. Each of these would still
+ * pass with a buffered body; what makes them discriminating is that the mocked
+ * `safeFetch` returns a body that only ends when the request is aborted —
+ * which is exactly what real streaming mode does via `req.destroy()`.
+ */
+describe('OpenAICompatibleProvider live-body error paths (#4121)', () => {
+  const TURN_TIMEOUT_MS = 6 * 60 * 1000;
+
+  beforeEach(() => {
+    safeFetchMock.mockReset();
+    selfHostAllowsPrivateNetworkMock.mockReset();
+    selfHostAllowsPrivateNetworkMock.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /** A body that never ends on its own and errors only when the turn is aborted. */
+  function stallingBody(signal: AbortSignal, prelude?: string): ReadableStream<Uint8Array> {
+    return new ReadableStream<Uint8Array>({
+      start(controller) {
+        if (prelude) controller.enqueue(new TextEncoder().encode(prelude));
+        signal.addEventListener('abort', () => controller.error(new Error('aborted')), {
+          once: true,
+        });
+      },
+    });
+  }
+
+  it('reports the endpoint error body on a non-2xx response', async () => {
+    safeFetchMock.mockResolvedValueOnce(new Response('upstream exploded', { status: 502 }));
+
+    const events = await collect(makeProvider().chatStream([], { model: 'm' }));
+
+    expect(events).toHaveLength(1);
+    expect((events[0] as { message: string }).message).toContain('HTTP 502');
+    expect((events[0] as { message: string }).message).toContain('upstream exploded');
+  });
+
+  it('keeps the turn timeout armed while reading a non-2xx body that stalls', async () => {
+    vi.useFakeTimers();
+    safeFetchMock.mockImplementationOnce(async (_url, init) => {
+      const { signal } = init as { signal: AbortSignal };
+      return new Response(stallingBody(signal), { status: 500 });
+    });
+
+    const events: LLMStreamEvent[] = [];
+    const consume = (async () => {
+      for await (const ev of makeProvider().chatStream([], { model: 'm' })) events.push(ev);
+    })();
+
+    // With `clearTimeout` moved into the `finally` AFTER the body read, the
+    // turn timeout still fires and unblocks `response.text()`. If it were
+    // cleared before the read (the pre-#4121 order, safe only while the body
+    // was pre-buffered), nothing would ever settle and this would hang.
+    await vi.advanceTimersByTimeAsync(TURN_TIMEOUT_MS + 1);
+    await consume;
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ type: 'error' });
+    expect((events[0] as { message: string }).message).toContain('HTTP 500');
+  });
+
+  it('yields the turn-timeout error when the stream stalls mid-response', async () => {
+    vi.useFakeTimers();
+    safeFetchMock.mockImplementationOnce(async (_url, init) => {
+      const { signal } = init as { signal: AbortSignal };
+      return new Response(
+        stallingBody(signal, 'data: {"choices":[{"delta":{"content":"partial"}}]}\n\n'),
+        { status: 200 },
+      );
+    });
+
+    const events: LLMStreamEvent[] = [];
+    const consume = (async () => {
+      for await (const ev of makeProvider().chatStream([], { model: 'm' })) events.push(ev);
+    })();
+
+    await vi.advanceTimersByTimeAsync(TURN_TIMEOUT_MS + 1);
+    await consume;
+
+    expect(events).toContainEqual({ type: 'content_delta', delta: 'partial' });
+    // A stalled stream must end as a timeout error, never as a clean
+    // `message_end` that would present a truncated answer as complete.
+    expect(events.at(-1)).toMatchObject({ type: 'error' });
+    expect((events.at(-1) as { message: string }).message).toMatch(/timed out/i);
+    expect(events.some((e) => e.type === 'message_end')).toBe(false);
+  });
+
+  it('returns silently, with no error event, when the caller aborts mid-stream', async () => {
+    const caller = new AbortController();
+    safeFetchMock.mockImplementationOnce(async (_url, init) => {
+      const { signal } = init as { signal: AbortSignal };
+      return new Response(
+        stallingBody(signal, 'data: {"choices":[{"delta":{"content":"partial"}}]}\n\n'),
+        { status: 200 },
+      );
+    });
+
+    const events: LLMStreamEvent[] = [];
+    for await (const ev of makeProvider().chatStream([], {
+      model: 'm',
+      signal: caller.signal,
+    })) {
+      events.push(ev);
+      if (ev.type === 'content_delta') caller.abort();
+    }
+
+    // A user pressing Stop is not an error, and must not fabricate a message_end.
+    expect(events).toEqual([{ type: 'content_delta', delta: 'partial' }]);
+  });
+});
+
+/**
+ * The seam. Every suite above mocks `safeFetch`, so they prove what the
+ * provider *intends* to send; none prove that those exact options actually
+ * produce a guarded, streaming request. This one drives the real `safeFetch`
+ * with only `http.request` faked, so a mismatch between the two halves fails.
+ */
+describe('OpenAICompatibleProvider through the real safeFetch (#4121)', () => {
+  let reqHandle: { req: any; res: any };
+
+  beforeEach(() => {
+    safeFetchMock.mockReset();
+    selfHostAllowsPrivateNetworkMock.mockReset();
+    selfHostAllowsPrivateNetworkMock.mockReturnValue(true);
+    // Route the provider's calls into the genuine implementation.
+    safeFetchMock.mockImplementation((url, init) => realUrlSafety.mod!.safeFetch(url, init as never));
+  });
+
+  afterEach(() => {
+    realUrlSafety.mod!.__setLookupForTests(null);
+    vi.restoreAllMocks();
+  });
+
+  function fakeTransport(): { req: any; res: any } {
+    const handle: { req: any; res: any } = { req: null, res: null };
+    vi.spyOn(http, 'request').mockImplementation((_options: any, callback?: any) => {
+      const res: any = new EventEmitter();
+      res.statusCode = 200;
+      res.statusMessage = 'OK';
+      res.headers = { 'content-type': 'text/event-stream' };
+      res.pause = vi.fn();
+      res.resume = vi.fn();
+      res.destroy = vi.fn();
+      res.complete = false;
+      const req: any = new EventEmitter();
+      req.write = vi.fn();
+      req.destroy = vi.fn();
+      req.setTimeout = vi.fn();
+      req.end = vi.fn(() => callback?.(res));
+      handle.req = req;
+      handle.res = res;
+      return req;
+    });
+    return handle;
+  }
+
+  it('streams SSE deltas over a real guarded request to an on-LAN endpoint', async () => {
+    // 10.0.0.5 is RFC1918: reachable only because the provider asks for the
+    // self-host private-network opt-in. If it stopped doing so, safeFetch would
+    // refuse this and the test would fail with an SSRF error event.
+    realUrlSafety.mod!.__setLookupForTests(async () => [{ address: '10.0.0.5', family: 4 }]);
+    reqHandle = fakeTransport();
+
+    const seen: string[] = [];
+    const done = (async () => {
+      for await (const ev of makeProvider('http://vllm.lan:8000/v1').chatStream([], {
+        model: 'm',
+      })) {
+        if (ev.type === 'content_delta') seen.push(ev.delta);
+      }
+    })();
+
+    // Wait for the real safeFetch to resolve DNS and dial.
+    while (reqHandle.res === null) await new Promise((r) => setImmediate(r));
+
+    reqHandle.res.emit('data', Buffer.from('data: {"choices":[{"delta":{"content":"a"}}]}\n\n'));
+    reqHandle.res.emit('data', Buffer.from('data: {"choices":[{"delta":{"content":"b"}}]}\n\n'));
+    reqHandle.res.complete = true;
+    reqHandle.res.emit('end');
+    await done;
+
+    expect(seen).toEqual(['a', 'b']);
+    expect(http.request).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses a cleartext endpoint that resolves to a public address', async () => {
+    // `requirePrivateForCleartext` is what stops the bearer token going over
+    // the open internet in the clear. Proven here against the real guard.
+    realUrlSafety.mod!.__setLookupForTests(async () => [{ address: '93.184.216.34', family: 4 }]);
+    const requestSpy = vi.spyOn(http, 'request');
+
+    const events = await collect(
+      makeProvider('http://public.example.com/v1').chatStream([], { model: 'm' }),
+    );
+
+    expect(requestSpy).not.toHaveBeenCalled();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ type: 'error' });
+    expect((events[0] as { message: string }).message).toMatch(/cleartext/i);
   });
 });

--- a/apps/api/src/services/llm/openaiCompatibleProvider.test.ts
+++ b/apps/api/src/services/llm/openaiCompatibleProvider.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Regression suite for #4121: `openaiCompatibleProvider` must reach its
+ * operator-configured endpoint through the SSRF-guarded `safeFetch`, not raw
+ * global `fetch`.
+ *
+ * The interesting assertions are the two that a naive "swap fetch for
+ * safeFetch" would break:
+ *
+ *  - global `fetch` is never called (the actual egress-bypass being closed), and
+ *  - `streamResponse: true` is requested, because `safeFetch`'s DEFAULT mode
+ *    buffers the whole body before resolving. Buffering would turn an
+ *    incremental SSE chat stream into a single burst delivered after the turn
+ *    finished, and hold a whole LLM turn in memory across the 6-minute timeout.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { safeFetchMock, selfHostAllowsPrivateNetworkMock } = vi.hoisted(() => ({
+  safeFetchMock: vi.fn(async (_url: string, _init?: unknown) => new Response('', { status: 200 })),
+  selfHostAllowsPrivateNetworkMock: vi.fn(() => false),
+}));
+
+vi.mock('../urlSafety', async () => {
+  const actual = await vi.importActual<typeof import('../urlSafety')>('../urlSafety');
+  return { ...actual, safeFetch: safeFetchMock };
+});
+
+vi.mock('../../config/env', async () => {
+  const actual = await vi.importActual<typeof import('../../config/env')>('../../config/env');
+  return { ...actual, selfHostAllowsPrivateNetwork: selfHostAllowsPrivateNetworkMock };
+});
+
+import { OpenAICompatibleProvider } from './openaiCompatibleProvider';
+import { SsrfBlockedError } from '../urlSafety';
+import type { LLMStreamEvent } from './types';
+
+const BASE_URL = 'https://vllm.example.com/v1';
+
+function makeProvider(baseUrl = BASE_URL): OpenAICompatibleProvider {
+  return new OpenAICompatibleProvider({
+    baseUrl,
+    apiKey: 'sk-test-key',
+    priceInputPerMUsd: 0,
+    priceOutputPerMUsd: 0,
+  });
+}
+
+/** Build an SSE body from already-encoded event payloads. */
+function sseBody(chunks: string[]): string {
+  return chunks.map((c) => `data: ${c}\n\n`).join('');
+}
+
+function contentChunk(text: string): string {
+  return JSON.stringify({ choices: [{ delta: { content: text } }] });
+}
+
+async function collect(stream: AsyncIterable<LLMStreamEvent>): Promise<LLMStreamEvent[]> {
+  const out: LLMStreamEvent[] = [];
+  for await (const ev of stream) out.push(ev);
+  return out;
+}
+
+/** The `init` object handed to safeFetch on the most recent call. */
+function lastInit(): Record<string, unknown> {
+  const call = safeFetchMock.mock.calls.at(-1);
+  expect(call, 'expected safeFetch to have been called').toBeDefined();
+  return (call![1] ?? {}) as Record<string, unknown>;
+}
+
+describe('OpenAICompatibleProvider egress guard (#4121)', () => {
+  let globalFetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    safeFetchMock.mockReset();
+    safeFetchMock.mockResolvedValue(
+      new Response(sseBody([contentChunk('hi'), '[DONE]']), { status: 200 }),
+    );
+    selfHostAllowsPrivateNetworkMock.mockReset();
+    selfHostAllowsPrivateNetworkMock.mockReturnValue(false);
+
+    // Any call to raw global fetch is the bug this issue exists to close.
+    globalFetchSpy = vi.fn(async () => {
+      throw new Error('raw global fetch() must not be used — route through safeFetch');
+    });
+    vi.stubGlobal('fetch', globalFetchSpy);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('routes the chat completion through safeFetch and never touches global fetch', async () => {
+    const events = await collect(
+      makeProvider().chatStream([{ role: 'user', content: 'hello' }], { model: 'm' }),
+    );
+
+    expect(globalFetchSpy).not.toHaveBeenCalled();
+    expect(safeFetchMock).toHaveBeenCalledTimes(1);
+    expect(safeFetchMock.mock.calls[0]![0]).toBe('https://vllm.example.com/v1/chat/completions');
+    expect(events).toContainEqual({ type: 'content_delta', delta: 'hi' });
+  });
+
+  it('asks safeFetch for a STREAMED response so SSE is not buffered into one burst', () => {
+    return collect(makeProvider().chatStream([{ role: 'user', content: 'x' }], { model: 'm' })).then(
+      () => {
+        expect(lastInit().streamResponse).toBe(true);
+      },
+    );
+  });
+
+  it('bounds the streamed body with maxBytes', async () => {
+    await collect(makeProvider().chatStream([{ role: 'user', content: 'x' }], { model: 'm' }));
+    expect(typeof lastInit().maxBytes).toBe('number');
+    expect(lastInit().maxBytes as number).toBeGreaterThan(0);
+  });
+
+  it('forwards the POST body, bearer auth and abort signal to safeFetch', async () => {
+    const controller = new AbortController();
+    await collect(
+      makeProvider().chatStream([{ role: 'user', content: 'hello' }], {
+        model: 'my-model',
+        maxTokens: 128,
+        signal: controller.signal,
+      }),
+    );
+
+    const init = lastInit();
+    expect(init.method).toBe('POST');
+    expect(init.headers).toMatchObject({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer sk-test-key',
+    });
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body).toMatchObject({ model: 'my-model', stream: true, max_tokens: 128 });
+  });
+
+  it('never follows redirects and keeps cleartext confined to the operator LAN', async () => {
+    await collect(makeProvider().chatStream([{ role: 'user', content: 'x' }], { model: 'm' }));
+    const init = lastInit();
+    expect(init.redirect).toBe('error');
+    expect(init.requirePrivateForCleartext).toBe(true);
+  });
+
+  it('passes the self-host private-network opt-in through from config', async () => {
+    selfHostAllowsPrivateNetworkMock.mockReturnValue(true);
+    await collect(makeProvider('http://10.0.0.5:8000/v1').chatStream([], { model: 'm' }));
+    expect(lastInit().allowPrivateNetwork).toBe(true);
+
+    selfHostAllowsPrivateNetworkMock.mockReturnValue(false);
+    await collect(makeProvider().chatStream([], { model: 'm' }));
+    expect(lastInit().allowPrivateNetwork).toBe(false);
+  });
+
+  it('surfaces an SSRF refusal as an error event rather than throwing out of the iterator', async () => {
+    safeFetchMock.mockRejectedValueOnce(
+      new SsrfBlockedError('URL points to blocked address: 169.254.169.254'),
+    );
+
+    const events = await collect(
+      makeProvider('http://169.254.169.254/v1').chatStream([], { model: 'm' }),
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ type: 'error' });
+    expect((events[0] as { message: string }).message).toContain('169.254.169.254');
+  });
+
+  it('treats a 3xx as an error instead of silently following the Location', async () => {
+    safeFetchMock.mockResolvedValueOnce(
+      new Response('', { status: 302, headers: { location: 'http://169.254.169.254/' } }),
+    );
+
+    const events = await collect(makeProvider().chatStream([], { model: 'm' }));
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ type: 'error' });
+    expect((events[0] as { message: string }).message).toMatch(/redirect/i);
+  });
+
+  it('still yields deltas incrementally as SSE chunks arrive', async () => {
+    // A body that emits two events, then only closes once the consumer has
+    // seen the first — proving the provider is not waiting for the full body.
+    let releaseSecond: () => void = () => {};
+    const secondSent = new Promise<void>((resolve) => {
+      releaseSecond = resolve;
+    });
+    const encoder = new TextEncoder();
+    const body = new ReadableStream<Uint8Array>({
+      async start(controller) {
+        controller.enqueue(encoder.encode(sseBody([contentChunk('first')])));
+        await secondSent;
+        controller.enqueue(encoder.encode(sseBody([contentChunk('second'), '[DONE]'])));
+        controller.close();
+      },
+    });
+    safeFetchMock.mockResolvedValueOnce(new Response(body, { status: 200 }));
+
+    const seen: string[] = [];
+    for await (const ev of makeProvider().chatStream([], { model: 'm' })) {
+      if (ev.type === 'content_delta') {
+        seen.push(ev.delta);
+        // We got the first delta before the second was ever written — the only
+        // way that happens is if the response body is live, not buffered.
+        if (seen.length === 1) releaseSecond();
+      }
+    }
+
+    expect(seen).toEqual(['first', 'second']);
+  });
+});

--- a/apps/api/src/services/llm/openaiCompatibleProvider.ts
+++ b/apps/api/src/services/llm/openaiCompatibleProvider.ts
@@ -1,8 +1,21 @@
 /**
  * OpenAI-compatible LLM provider (chat-only PoC).
  *
- * Uses native Node fetch + manual SSE parsing to call any OpenAI-compatible endpoint
- * (target: vLLM). No `openai` npm package dependency.
+ * Calls any OpenAI-compatible endpoint (target: vLLM) with manual SSE parsing.
+ * No `openai` npm package dependency.
+ *
+ * Egress goes through `safeFetch` (#4121), never raw global `fetch`. The
+ * endpoint comes from operator config (`MCP_LLM_BASE_URL`) rather than from a
+ * tenant, so this is defense in depth rather than a live exploit fix — but a
+ * module that dials an operator-supplied URL with no DNS pinning and no
+ * redirect discipline is exactly the exception that quietly becomes a real
+ * SSRF hole the first time someone extends it. Routing through the shared
+ * helper also brings this path under the #1105 held-DB-context tripwire, which
+ * a direct `fetch()` bypasses entirely.
+ *
+ * `streamResponse: true` is load-bearing: `safeFetch`'s default mode buffers
+ * the whole body before resolving, which would collapse an incremental SSE
+ * chat stream into a single burst delivered after the turn ended.
  *
  * Tool-calling is explicitly unsupported on this path: we send no `tools` field.
  * If the model returns tool_calls anyway, we yield an error event and stop.
@@ -11,10 +24,22 @@
  * Cost tracking is best-effort via declared per-token pricing in config.
  */
 
+import { safeFetch, SsrfBlockedError } from '../urlSafety';
+import { selfHostAllowsPrivateNetwork } from '../../config/env';
 import type { LLMProvider, LLMStreamEvent, ChatMessage } from './types';
 
 const FETCH_TIMEOUT_MS = 6 * 60 * 1000; // 6 min, aligned with Anthropic turn timeout
 const LLM_REQUEST_TIMEOUT_MESSAGE = 'LLM request timed out after 6 minutes';
+
+/**
+ * Ceiling on a single streamed turn. Nothing is accumulated in memory (the body
+ * is consumed as it arrives), so this exists to bound a hostile or wedged
+ * endpoint that answers at line rate for the full six-minute timeout rather
+ * than to cap a buffer. SSE framing costs ~60 bytes of JSON envelope per token,
+ * so even a 100k-token answer lands around 6 MB — 32 MiB leaves generous room
+ * above any legitimate turn while still being a hard stop.
+ */
+const MAX_STREAM_RESPONSE_BYTES = 32 * 1024 * 1024;
 
 /**
  * Abort comes from AbortSignal.any([caller, timeout]): distinguish timeout vs user Stop.
@@ -83,7 +108,7 @@ export class OpenAICompatibleProvider implements LLMProvider {
 
     let response: Response;
     try {
-      response = await fetch(url, {
+      response = await safeFetch(url, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -91,6 +116,23 @@ export class OpenAICompatibleProvider implements LLMProvider {
         },
         body,
         signal,
+        // Inert inside safeFetch (it never follows a Location and hands back
+        // the raw 3xx), but stated at the call site so the intent survives:
+        // a redirect on a POST carrying a bearer token is refused, not chased.
+        // The explicit 3xx check below is what actually enforces it.
+        redirect: 'error',
+        // Without this the body would be buffered to completion and the chat
+        // would stop streaming. See the module comment.
+        streamResponse: true,
+        maxBytes: MAX_STREAM_RESPONSE_BYTES,
+        // Same pair `webhookDelivery` uses. `MCP_LLM_PROVIDER=openai-compatible`
+        // is a self-host-only path and a self-hosted vLLM normally lives on the
+        // operator's LAN, so without the opt-in every such deployment would
+        // fail with "URL points to blocked address"; `requirePrivateForCleartext`
+        // keeps the cleartext allowance confined to that LAN hop instead of
+        // letting an `http://` endpoint ship the API key over the open internet.
+        allowPrivateNetwork: selfHostAllowsPrivateNetwork(),
+        requirePrivateForCleartext: true,
       });
     } catch (err) {
       clearTimeout(timeoutId);
@@ -102,18 +144,54 @@ export class OpenAICompatibleProvider implements LLMProvider {
       if (abortKind === 'user') {
         return;
       }
+      if (err instanceof SsrfBlockedError) {
+        // The operator set this URL in their own env, so the fix is theirs to
+        // make — say what is actually allowed instead of just "blocked address".
+        yield {
+          type: 'error',
+          message:
+            `LLM endpoint refused by the egress guard: ${err.message}. MCP_LLM_BASE_URL must ` +
+            'point at a public host, or — on a self-hosted install with IS_HOSTED=false — an ' +
+            'RFC1918/ULA LAN address. Loopback (127.0.0.1/::1) is never dialable; use the ' +
+            "service name or LAN IP of the model host instead of 'localhost'.",
+        };
+        return;
+      }
       const msg = err instanceof Error ? err.message : 'Network error calling LLM endpoint';
       yield { type: 'error', message: msg };
       return;
     }
 
-    if (!response.ok) {
+    // `safeFetch` deliberately follows nothing and returns the raw 3xx, so the
+    // refusal has to be explicit here. `!response.ok` below would also catch it,
+    // but only incidentally — and the operator deserves to be told the endpoint
+    // tried to redirect rather than a bare "HTTP 302". Following it would be an
+    // SSRF bypass and would replay the bearer token at whatever the Location says.
+    if (response.status >= 300 && response.status < 400) {
+      // Release the socket before disarming the timeout that protects it.
+      void response.body?.cancel();
       clearTimeout(timeoutId);
+      yield {
+        type: 'error',
+        message:
+          `LLM endpoint error: refused to follow a redirect (HTTP ${response.status}) from the ` +
+          'configured endpoint. Point MCP_LLM_BASE_URL at the endpoint that serves the response.',
+      };
+      return;
+    }
+
+    if (!response.ok) {
       let detail = `HTTP ${response.status}`;
       try {
+        // The body is a LIVE stream now, so this read can block. The turn
+        // timeout has to stay armed across it — clearing it first (as the
+        // buffered version safely could) would let an endpoint that sends
+        // error headers and then stalls hang the turn forever.
         const text = await response.text();
         detail += `: ${text.slice(0, 300)}`;
-      } catch { /* ignore */ }
+      } catch { /* ignore */ } finally {
+        clearTimeout(timeoutId);
+      }
       yield { type: 'error', message: `LLM endpoint error: ${detail}` };
       return;
     }

--- a/apps/api/src/services/llm/openaiCompatibleProvider.ts
+++ b/apps/api/src/services/llm/openaiCompatibleProvider.ts
@@ -169,7 +169,9 @@ export class OpenAICompatibleProvider implements LLMProvider {
     // SSRF bypass and would replay the bearer token at whatever the Location says.
     if (response.status >= 300 && response.status < 400) {
       // Release the socket before disarming the timeout that protects it.
-      void response.body?.cancel();
+      // `cancel()` cannot reject with today's stream teardown, but a floating
+      // promise here would become an unhandled rejection if that ever changed.
+      void response.body?.cancel().catch(() => { /* socket is going away anyway */ });
       clearTimeout(timeoutId);
       yield {
         type: 'error',
@@ -189,7 +191,14 @@ export class OpenAICompatibleProvider implements LLMProvider {
         // error headers and then stalls hang the turn forever.
         const text = await response.text();
         detail += `: ${text.slice(0, 300)}`;
-      } catch { /* ignore */ } finally {
+      } catch (readErr) {
+        // The status still reaches the user; only the extra detail is lost. Say
+        // why, so a transport failure while reading an error page (or a
+        // maxBytes truncation) leaves a trail instead of looking like an
+        // endpoint that returned an empty error body.
+        const why = readErr instanceof Error ? readErr.message : String(readErr);
+        console.warn(`openaiCompatibleProvider: could not read the error body for ${detail}: ${why}`);
+      } finally {
         clearTimeout(timeoutId);
       }
       yield { type: 'error', message: `LLM endpoint error: ${detail}` };

--- a/apps/api/src/services/urlSafety.test.ts
+++ b/apps/api/src/services/urlSafety.test.ts
@@ -981,6 +981,24 @@ describe('safeFetch — streamResponse', () => {
     expect((await reader.read()).done).toBe(true);
   });
 
+  it('pauses the socket when the consumer stops reading and resumes on pull', async () => {
+    primeLookupPublic();
+    const h = spyStreamingRequest();
+
+    const res = await safeFetch('http://sse.example.test/v1', { streamResponse: true });
+    const reader = res.body!.getReader();
+    const resumesAfterStart = h.res.resume.mock.calls.length;
+
+    // Nobody is reading. The default queuing strategy has a highWaterMark of 1,
+    // so one un-read chunk drives desiredSize to 0 and the socket must stop.
+    h.res.emit('data', Buffer.from('chunk-one'));
+    expect(h.res.pause).toHaveBeenCalled();
+
+    // Reading drains the queue, which triggers `pull` and restarts the socket.
+    expect(decode((await reader.read()).value)).toBe('chunk-one');
+    expect(h.res.resume.mock.calls.length).toBeGreaterThan(resumesAfterStart);
+  });
+
   it('enforces maxBytes as bytes flow, destroying the socket and erroring the body', async () => {
     primeLookupPublic();
     const h = spyStreamingRequest();
@@ -1066,6 +1084,19 @@ describe('safeFetch — streamResponse', () => {
 
     expect(res.status).toBe(204);
     expect(res.body).toBeNull();
+  });
+
+  it('does not crash the process when a null-body response errors afterwards', async () => {
+    primeLookupPublic();
+    const h = spyStreamingRequest({ statusCode: 204, headers: {} });
+
+    const res = await safeFetch('http://empty.example.test/v1', { streamResponse: true });
+    expect(res.status).toBe(204);
+
+    // This branch has no stream to absorb the failure and an already-settled
+    // promise, but the emitter still needs a listener: an 'error' with none
+    // throws synchronously and takes the whole API process down.
+    expect(() => h.res.emit('error', new Error('socket reset after headers'))).not.toThrow();
   });
 
   it('still applies the SSRF policy before any socket is opened', async () => {

--- a/apps/api/src/services/urlSafety.test.ts
+++ b/apps/api/src/services/urlSafety.test.ts
@@ -893,3 +893,212 @@ describe('safeFetchFollowingRedirects', () => {
     expect(await run(307)).toEqual(['POST', 'POST']);
   });
 });
+
+/**
+ * Streaming mode (#4121). `safeFetch` buffers by default, which is right for
+ * the one-shot JSON callers it was built for and wrong for an SSE chat stream.
+ * These cover the delivery contract; the SSRF policy itself is unchanged and
+ * covered by the suites above.
+ */
+describe('safeFetch — streamResponse', () => {
+  afterEach(() => {
+    __setLookupForTests(null);
+    vi.restoreAllMocks();
+  });
+
+  function primeLookupPublic(ip = '8.8.8.8'): void {
+    __setLookupForTests(async () => [{ address: ip, family: 4 }]);
+  }
+
+  /**
+   * A fake `http.request` whose response is driven by the test, so we can
+   * observe what happens BEFORE the body ends — the whole point of streaming.
+   */
+  function spyStreamingRequest(opts?: {
+    statusCode?: number;
+    headers?: Record<string, string | string[]>;
+  }): { req: any; res: any } {
+    const handle: { req: any; res: any } = { req: null, res: null };
+    vi.spyOn(http, 'request').mockImplementation((_options: any, callback?: any) => {
+      const res: any = new EventEmitter();
+      res.statusCode = opts?.statusCode ?? 200;
+      res.statusMessage = 'OK';
+      res.headers = opts?.headers ?? { 'content-type': 'text/event-stream' };
+      // The streaming body pauses/resumes the socket for backpressure and
+      // destroys it on teardown; `complete` distinguishes a clean EOF from a
+      // connection that dropped part-way through the body.
+      res.pause = vi.fn();
+      res.resume = vi.fn();
+      res.destroy = vi.fn();
+      res.complete = false;
+
+      const req: any = new EventEmitter();
+      req.write = vi.fn();
+      req.destroy = vi.fn();
+      req.setTimeout = vi.fn();
+      req.end = vi.fn(() => {
+        callback?.(res);
+      });
+      handle.req = req;
+      handle.res = res;
+      return req;
+    });
+    return handle;
+  }
+
+  const decode = (v?: Uint8Array): string => new TextDecoder().decode(v);
+
+  it('resolves as soon as headers arrive, before the body has ended', async () => {
+    primeLookupPublic();
+    const h = spyStreamingRequest({ headers: { 'content-type': 'text/event-stream' } });
+
+    // No 'end' is ever emitted before this await — in buffered mode it would hang.
+    const res = await safeFetch('http://sse.example.test/v1/chat/completions', {
+      streamResponse: true
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('text/event-stream');
+    expect(res.body).not.toBeNull();
+  });
+
+  it('delivers each chunk as it arrives rather than one buffered burst', async () => {
+    primeLookupPublic();
+    const h = spyStreamingRequest();
+
+    const res = await safeFetch('http://sse.example.test/v1', { streamResponse: true });
+    const reader = res.body!.getReader();
+
+    h.res.emit('data', Buffer.from('first'));
+    expect(decode((await reader.read()).value)).toBe('first');
+
+    // The second chunk is only written AFTER the first was read, so the read
+    // above cannot have come from a fully-buffered body.
+    h.res.emit('data', Buffer.from('second'));
+    expect(decode((await reader.read()).value)).toBe('second');
+
+    h.res.emit('end');
+    expect((await reader.read()).done).toBe(true);
+  });
+
+  it('enforces maxBytes as bytes flow, destroying the socket and erroring the body', async () => {
+    primeLookupPublic();
+    const h = spyStreamingRequest();
+
+    const res = await safeFetch('http://big.example.test/v1', {
+      streamResponse: true,
+      maxBytes: 4
+    });
+    const reader = res.body!.getReader();
+
+    h.res.emit('data', Buffer.alloc(8, 0x61));
+
+    await expect(reader.read()).rejects.toBeInstanceOf(ResponseTooLargeError);
+    expect(h.req.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows a body of exactly maxBytes through', async () => {
+    primeLookupPublic();
+    const h = spyStreamingRequest();
+
+    const res = await safeFetch('http://exact.example.test/v1', {
+      streamResponse: true,
+      maxBytes: 4
+    });
+    const reader = res.body!.getReader();
+
+    h.res.emit('data', Buffer.from('abcd'));
+    expect(decode((await reader.read()).value)).toBe('abcd');
+
+    h.res.complete = true;
+    h.res.emit('end');
+    expect((await reader.read()).done).toBe(true);
+    expect(h.req.destroy).not.toHaveBeenCalled();
+  });
+
+  it('errors the body when the peer drops the connection mid-response', async () => {
+    primeLookupPublic();
+    const h = spyStreamingRequest();
+
+    const res = await safeFetch('http://truncated.example.test/v1', { streamResponse: true });
+    const reader = res.body!.getReader();
+
+    h.res.emit('data', Buffer.from('partial'));
+    expect(decode((await reader.read()).value)).toBe('partial');
+
+    // 'close' with no 'end' and `complete === false` is a truncated response.
+    // Closing the stream cleanly here would hand back a silently short body.
+    h.res.emit('close');
+
+    await expect(reader.read()).rejects.toThrow(/closed before the body was complete/);
+  });
+
+  it('surfaces a mid-stream transport error on the body instead of hanging forever', async () => {
+    primeLookupPublic();
+    const h = spyStreamingRequest();
+
+    const res = await safeFetch('http://flaky.example.test/v1', { streamResponse: true });
+    const reader = res.body!.getReader();
+
+    // The promise has already settled, so this error has nowhere to go except
+    // the body. Swallowing it would leave the consumer awaiting a stream that
+    // never closes — the failure mode this assertion exists to prevent.
+    h.req.emit('error', new Error('socket hang up'));
+
+    await expect(reader.read()).rejects.toThrow('socket hang up');
+  });
+
+  it('destroys the request when the consumer cancels the body early', async () => {
+    primeLookupPublic();
+    const h = spyStreamingRequest();
+
+    const res = await safeFetch('http://sse.example.test/v1', { streamResponse: true });
+    await res.body!.cancel();
+
+    expect(h.req.destroy).toHaveBeenCalled();
+  });
+
+  it('returns a null body for statuses that may not carry one', async () => {
+    primeLookupPublic();
+    spyStreamingRequest({ statusCode: 204, headers: {} });
+
+    const res = await safeFetch('http://empty.example.test/v1', { streamResponse: true });
+
+    expect(res.status).toBe(204);
+    expect(res.body).toBeNull();
+  });
+
+  it('still applies the SSRF policy before any socket is opened', async () => {
+    __setLookupForTests(async () => [{ address: '169.254.169.254', family: 4 }]);
+    const requestSpy = vi.spyOn(http, 'request');
+
+    await expect(
+      safeFetch('http://metadata.example.test/v1', { streamResponse: true })
+    ).rejects.toBeInstanceOf(SsrfBlockedError);
+    expect(requestSpy).not.toHaveBeenCalled();
+  });
+
+  it('leaves the default (buffered) path byte-identical for existing callers', async () => {
+    primeLookupPublic();
+    const h = spyStreamingRequest();
+
+    let settled = false;
+    const promise = safeFetch('http://buffered.example.test/v1').then((r) => {
+      settled = true;
+      return r;
+    });
+
+    // safeFetch resolves DNS before it dials, so the fake request does not
+    // exist yet on the turn this test was scheduled on.
+    while (h.res === null) await new Promise((resolve) => setImmediate(resolve));
+
+    h.res.emit('data', Buffer.from('ab'));
+    await new Promise((resolve) => setImmediate(resolve));
+    // Without streamResponse the caller must NOT see a response until 'end'.
+    expect(settled).toBe(false);
+
+    h.res.emit('end');
+    const res = await promise;
+    await expect(res.text()).resolves.toBe('ab');
+  });
+});

--- a/apps/api/src/services/urlSafety.ts
+++ b/apps/api/src/services/urlSafety.ts
@@ -397,6 +397,136 @@ export interface SafeFetchInit extends Omit<RequestInit, 'signal'> {
    * no-op, matching every existing caller's behavior exactly.
    */
   onConnect?: (ip: string) => void;
+  /**
+   * Resolve as soon as the response HEADERS arrive, handing back a `Response`
+   * whose body is the LIVE socket rather than a buffer.
+   *
+   * `safeFetch` otherwise buffers the entire body before resolving, which is
+   * right for the one-shot JSON callers it was built for but wrong for a
+   * long-lived event stream: an SSE chat completion buffered to completion
+   * stops being a stream at all (every delta lands in one burst once the turn
+   * ends) and pins the whole turn in memory for the life of the request.
+   *
+   * The SSRF properties are identical either way — resolution, filtering and
+   * IP pinning all happen before the socket is dialed, so this option changes
+   * only how the body is delivered. `maxBytes` is still enforced, but as bytes
+   * FLOW: an overrun destroys the socket and errors the body stream, rather
+   * than rejecting a promise that has already resolved. Cancelling the body
+   * (`reader.cancel()`) destroys the request, so a consumer that stops reading
+   * early releases the socket promptly.
+   *
+   * Defaults to false — every existing caller keeps byte-identical behavior.
+   */
+  streamResponse?: boolean;
+}
+
+/**
+ * Statuses the `Response` constructor forbids from carrying a body at all.
+ * Deliberately excludes the 1xx informational codes: `Response` rejects any
+ * status below 200 outright, and Node never surfaces them to the response
+ * callback anyway (they arrive on the request's `information` event).
+ */
+const NULL_BODY_STATUSES = new Set([204, 205, 304]);
+
+/** Copy Node's response headers onto a WHATWG `Headers`, preserving repeats. */
+function toResponseHeaders(raw: http.IncomingHttpHeaders): Headers {
+  const headers = new Headers();
+  for (const [k, v] of Object.entries(raw)) {
+    if (v == null) continue;
+    if (Array.isArray(v)) {
+      for (const item of v) headers.append(k, item);
+    } else {
+      headers.set(k, String(v));
+    }
+  }
+  return headers;
+}
+
+/**
+ * Wrap a live `IncomingMessage` as a web `ReadableStream`, enforcing `maxBytes`
+ * as the bytes flow and tearing the socket down on cancel/overrun.
+ *
+ * `onTransportError` is handed back to the caller so a socket failure raised on
+ * the REQUEST after the promise already resolved (an abort, a timeout, a reset
+ * mid-stream) can be surfaced on the body instead of vanishing — a swallowed
+ * error there would hang the consumer forever on a stream that never ends.
+ */
+function streamedResponseBody(
+  req: http.ClientRequest,
+  res: http.IncomingMessage,
+  maxBytes: number | undefined,
+  registerFailer: (fail: (err: Error) => void) => void
+): ReadableStream<Uint8Array> {
+  let received = 0;
+  let settled = false;
+
+  /** Idempotent socket teardown — overrun, cancel and transport failure race. */
+  const teardown = (): void => {
+    res.destroy();
+    req.destroy();
+  };
+
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      const fail = (err: Error): void => {
+        if (settled) return;
+        settled = true;
+        teardown();
+        controller.error(err);
+      };
+      registerFailer(fail);
+
+      res.on('data', (c: Buffer) => {
+        if (settled) return;
+        received += c.length;
+        if (maxBytes !== undefined && received > maxBytes) {
+          // Overrun: stop the socket before the next chunk lands, then error
+          // the body. Mirrors the buffered path's teardown, except the caller
+          // learns about it through the stream rather than a rejected promise.
+          // `maxBytes` exactly is allowed; the first byte past it is not.
+          settled = true;
+          teardown();
+          controller.error(new ResponseTooLargeError(maxBytes));
+          return;
+        }
+        controller.enqueue(new Uint8Array(c));
+        // Respect the consumer's backpressure: stop reading the socket once
+        // the queue is full and let `pull` restart it.
+        if ((controller.desiredSize ?? 1) <= 0) res.pause();
+      });
+
+      res.on('end', () => {
+        if (settled) return;
+        settled = true;
+        controller.close();
+      });
+
+      res.on('error', fail);
+
+      // A peer that drops the connection part-way through the body may emit
+      // neither 'end' nor 'error' — only 'close', with `res.complete` false.
+      // Treating that as a clean EOF would hand the consumer a silently
+      // truncated response; leaving it unhandled would hang them forever.
+      res.on('close', () => {
+        if (settled) return;
+        if (!res.complete) {
+          fail(new Error('response closed before the body was complete'));
+          return;
+        }
+        settled = true;
+        controller.close();
+      });
+    },
+    pull() {
+      res.resume();
+    },
+    cancel() {
+      // A consumer that walked away must not leave the socket open — or, for
+      // an LLM endpoint, leave the model generating into a dead connection.
+      settled = true;
+      teardown();
+    }
+  });
 }
 
 /**
@@ -405,7 +535,8 @@ export interface SafeFetchInit extends Omit<RequestInit, 'signal'> {
  * SNI and used to derive Host so TLS verification succeeds normally.
  *
  * Throws `SsrfBlockedError` for policy violations and `Error` (with `cause`)
- * for transport/TLS/timeout failures. Returns a standard `Response`.
+ * for transport/TLS/timeout failures. Returns a standard `Response` — buffered
+ * by default, or streamed when `init.streamResponse` is set.
  */
 export async function safeFetch(urlStr: string, init: SafeFetchInit = {}): Promise<Response> {
   // #1105 tripwire: an outbound HTTP request inside a held withDbAccessContext
@@ -547,9 +678,32 @@ export async function safeFetch(urlStr: string, init: SafeFetchInit = {}): Promi
   const timeoutMs = init.timeoutMs;
 
   return new Promise<Response>((resolve, reject) => {
+    // Set once the body has been handed to the caller as a live stream. From
+    // that moment a transport error can no longer `reject` (the promise is
+    // settled), so it has to be raised on the body instead.
+    let failStream: ((err: Error) => void) | null = null;
+
     const req = requester(reqOptions, (res) => {
       // Follow no redirects by default — caller gets the raw response and can
       // re-invoke safeFetch if they want to trust the Location header.
+      const status = res.statusCode ?? 0;
+
+      if (init.streamResponse) {
+        const headers = toResponseHeaders(res.headers);
+        // 204/304 and friends may not carry a body at all; draining is the only
+        // correct thing to do with the (empty) stream.
+        if (NULL_BODY_STATUSES.has(status)) {
+          res.resume();
+          resolve(new Response(null, { status, statusText: res.statusMessage ?? '', headers }));
+          return;
+        }
+        const body = streamedResponseBody(req, res, init.maxBytes, (fail) => {
+          failStream = fail;
+        });
+        resolve(new Response(body, { status, statusText: res.statusMessage ?? '', headers }));
+        return;
+      }
+
       const chunks: Buffer[] = [];
       let received = 0;
       let aborted = false;
@@ -571,20 +725,11 @@ export async function safeFetch(urlStr: string, init: SafeFetchInit = {}): Promi
       res.on('end', () => {
         if (aborted) return;
         const bodyBytes = Buffer.concat(chunks);
-        const responseHeaders = new Headers();
-        for (const [k, v] of Object.entries(res.headers)) {
-          if (v == null) continue;
-          if (Array.isArray(v)) {
-            for (const item of v) responseHeaders.append(k, item);
-          } else {
-            responseHeaders.set(k, String(v));
-          }
-        }
         resolve(
           new Response(bodyBytes, {
             status: res.statusCode ?? 0,
             statusText: res.statusMessage ?? '',
-            headers: responseHeaders
+            headers: toResponseHeaders(res.headers)
           })
         );
       });
@@ -593,6 +738,15 @@ export async function safeFetch(urlStr: string, init: SafeFetchInit = {}): Promi
 
     req.on('error', (err) => {
       // Includes TLS verification failures — propagate without suppression.
+      // Once the body is streaming the promise is already settled, so the only
+      // place left to report a socket failure is the body itself; rejecting
+      // here would be a no-op and leave the consumer waiting on a stream that
+      // never ends. This is also the path an abort/timeout `req.destroy(err)`
+      // takes mid-stream.
+      if (failStream) {
+        failStream(err);
+        return;
+      }
       reject(err);
     });
 

--- a/apps/api/src/services/urlSafety.ts
+++ b/apps/api/src/services/urlSafety.ts
@@ -446,10 +446,12 @@ function toResponseHeaders(raw: http.IncomingHttpHeaders): Headers {
  * Wrap a live `IncomingMessage` as a web `ReadableStream`, enforcing `maxBytes`
  * as the bytes flow and tearing the socket down on cancel/overrun.
  *
- * `onTransportError` is handed back to the caller so a socket failure raised on
- * the REQUEST after the promise already resolved (an abort, a timeout, a reset
- * mid-stream) can be surfaced on the body instead of vanishing — a swallowed
- * error there would hang the consumer forever on a stream that never ends.
+ * `registerFailer` hands the caller a way to fail this body, so a socket error
+ * raised on the REQUEST after the promise already resolved (an abort, a
+ * timeout, a reset mid-stream) can be surfaced here instead of vanishing into
+ * an inert `reject` — a swallowed error there would leave the consumer waiting
+ * forever on a stream that never ends. It is invoked synchronously during
+ * construction, so the hook is in place before the `Response` is handed out.
  */
 function streamedResponseBody(
   req: http.ClientRequest,
@@ -693,6 +695,21 @@ export async function safeFetch(urlStr: string, init: SafeFetchInit = {}): Promi
         // 204/304 and friends may not carry a body at all; draining is the only
         // correct thing to do with the (empty) stream.
         if (NULL_BODY_STATUSES.has(status)) {
+          // There is no body to hand back and the promise is about to settle,
+          // so a later socket error has nowhere to be reported TO — but it
+          // must still have a listener. An 'error' emitted on an EventEmitter
+          // with none throws synchronously and takes the whole process down,
+          // and this is the one response path with neither a stream nor a live
+          // `reject` to absorb it. Route both the response's and the request's
+          // late errors here so they leave a trace instead of vanishing.
+          const noteLateError = (err: Error): void => {
+            console.warn(
+              `safeFetch: ignoring a late error on an already-returned ${status} response `
+                + `from ${hostname}: ${err.message}`
+            );
+          };
+          res.on('error', noteLateError);
+          failStream = noteLateError;
           res.resume();
           resolve(new Response(null, { status, statusText: res.statusMessage ?? '', headers }));
           return;

--- a/apps/docs/src/content/docs/features/bring-your-own-llm-key.mdx
+++ b/apps/docs/src/content/docs/features/bring-your-own-llm-key.mdx
@@ -111,6 +111,11 @@ Use this path for a chat-only backend that implements the OpenAI API dialect. To
 
 The API validates the base URL and requires the model and API key when `MCP_LLM_PROVIDER=openai-compatible`. Both price values must be zero or greater.
 
+Requests to this endpoint go through Breeze's SSRF egress guard, which pins DNS at connect time and refuses to follow redirects. Two consequences for where you can host the model:
+
+- **Loopback is never reachable.** `http://localhost:8000/v1` and `http://127.0.0.1:8000/v1` are refused. Point `MCP_LLM_BASE_URL` at the model host's container service name or LAN address instead — in a Compose deployment that is the service name, which resolves to a private address.
+- **Private (RFC1918/ULA) addresses require `IS_HOSTED=false`.** The opt-in that lets Breeze reach an on-LAN model is only active on a self-hosted install that has explicitly set `IS_HOSTED` to `false`. A cleartext `http://` endpoint is additionally restricted to private addresses, so the API key is never sent unencrypted over the open internet.
+
 <Aside type="note">
   Provider precedence is **partner BYOK configuration → instance environment**. A partner-owned Anthropic key always overrides these instance settings. The instance environment applies only when Breeze resolves the request as platform-keyed usage.
 </Aside>


### PR DESCRIPTION
Closes #4121

## The problem

`openaiCompatibleProvider.chatStream` dialed its endpoint with raw global `fetch`, bypassing three things every other outbound caller gets from `safeFetch`: connect-time DNS pinning / private-network filtering, redirect discipline, and the #1105 held-DB-context tripwire (whose own comment notes that "modules that call global `fetch()` directly bypass safeFetch and are NOT covered").

The URL comes from operator config (`MCP_LLM_BASE_URL`), not from a tenant, so this was a standing exception rather than a live exploit — which is exactly how the issue framed it: worth closing "so the file doesn't become a silent SSRF/egress-bypass exception the next time someone extends it."

## Why it wasn't a one-line swap

The issue and the plan doc both say "swap `fetch(` for `safeFetch` with `redirect:'error'`". Taken literally that silently breaks the feature:

- **`safeFetch` fully buffers.** It accumulates `chunks.push(c)` and only resolves on `'end'` with `new Response(Buffer.concat(chunks))`. `chatStream` does incremental SSE parsing over `response.body.getReader()`, so buffering would collapse token-by-token streaming into one burst delivered after the turn finished, and hold the whole turn in memory across the 6-minute timeout. (`guardedLlmFetch.ts` documents this explicitly — it is fine there because those are one-shot JSON clients.)
- **`redirect: 'error'` is inert.** `safeFetch` never reads `init.redirect`; it follows nothing and hands back the raw 3xx. The refusal has to be explicit at the call site.
- **`safeFetchFollowingRedirects` is the wrong helper.** It also buffers, and it *follows* redirects — the opposite of what a POST carrying `Authorization: Bearer` wants.

So `safeFetch` gains an **opt-in streaming mode**. Default behavior is byte-identical for every existing caller (SSO JWKS, Huntress, Pax8, DNS, SentinelOne, webhooks, PSA, log forwarding, backup).

## Approach

Considered and rejected: adding `undici` as a direct dependency to pass a guarded `dispatcher` to native `fetch` (it is override-only today, and `createGuardedHttpAgents` returns Node-core `http.Agent`s that global `fetch` cannot accept); and a separate streaming fetch module under `services/llm/` (would duplicate Host derivation, header sanitization, the cleartext-vs-pinned-record check, timeout, abort and the tripwire — the drift the shared helper exists to prevent).

### `apps/api/src/services/urlSafety.ts`

- **`SafeFetchInit.streamResponse`** — resolve as soon as headers arrive with a `Response` whose body is the live socket. SSRF resolution, filtering and IP pinning all still happen before the socket is dialed; only body delivery changes.
- **`maxBytes` enforced as bytes flow** — exactly the cap passes, the first byte past it destroys the socket and errors the body stream (rather than rejecting an already-settled promise).
- **Backpressure** via a single pause/resume bridge; `cancel()` tears the socket down, so a consumer that walks away does not leave the model generating into a dead connection.
- **Post-settle transport errors surface on the body.** Once streaming, `reject` is inert — routing a socket failure there would leave the consumer awaiting a stream that never ends. This is also the path an abort/timeout `req.destroy(err)` takes mid-stream.
- **Premature close is an error, not EOF.** A peer that drops mid-body emits `'close'` with `res.complete === false` and possibly no `'error'`; treating that as a clean end would hand back a silently truncated body.
- `toResponseHeaders` extracted and shared by both paths.

### `apps/api/src/services/llm/openaiCompatibleProvider.ts`

- `safeFetch` with `streamResponse: true`, a 32 MiB turn ceiling, and the same `allowPrivateNetwork: selfHostAllowsPrivateNetwork()` + `requirePrivateForCleartext: true` pair `webhookDelivery.ts` uses.
- **3xx refused explicitly**, with an actionable message. Following one would be an SSRF bypass and would replay the bearer token at the `Location`.
- **The turn timeout stays armed across the non-2xx body read.** With a live body, an endpoint that sends error headers and then stalls would otherwise hang the turn forever — a hazard that did not exist while the body was pre-buffered.
- An SSRF refusal yields a message naming what is actually dialable, since the operator set the URL themselves.

## Self-hoster note (behavior change)

`MCP_LLM_PROVIDER=openai-compatible` is a self-host-only path, and `allowPrivateNetwork` permits RFC1918/ULA but **never loopback** — that contract is deliberately shared across many callers and is not broadened here. Containerized deployments resolve the model host to a service name or LAN IP (RFC1918) and are unaffected. A bare-metal install pointing at `http://localhost:8000/v1` must switch to the model host's service name or LAN address; the error message says so.

## Testing

- **`openaiCompatibleProvider.test.ts` (new, 9 tests)** — the file had zero coverage before. Written red-first: all 9 failed against `main` because a stubbed global `fetch` threw. Covers no-raw-`fetch`, the guard options, streamed delivery, SSRF refusal surfacing as an `error` event, and 3xx refusal.
- **`urlSafety.test.ts` (+10 tests, 56 total)** — headers resolve before the body ends; chunks arrive incrementally; exactly-`maxBytes` passes and cap+1 errors while destroying the socket; a mid-stream transport error reaches the reader instead of hanging; cancel destroys the request; premature close errors; null-body statuses; SSRF policy still refuses before any socket; and the default path stays buffered.
- **Regression sweep across every `safeFetch` consumer suite** — ~492 tests green (sso, webhookDelivery, webhookSender, guardedS3Client, backupSsrfAdoption, dnsProviders, recoveryMedia, huntress, logForwarding, psa, sentinelOne, guardedLlmFetch, llmEgressProxy, providerFidelityHarness, llmConfigResolver, backup/configs, llmProviderCatalog, tripwire).
- `eslint` clean on all four files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
