### PR TITLE
fix(api): apply organizationOrder in SQL so it survives pagination (#4004)

### DIFF
--- a/apps/api/src/__tests__/integration/organizationOrderPagination.integration.test.ts
+++ b/apps/api/src/__tests__/integration/organizationOrderPagination.integration.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Cross-page organization ordering (#4004) — integration.
+ *
+ * `GET /orgs/organizations` used to select each page by `created_at, id` with
+ * LIMIT/OFFSET and only then re-sort THAT PAGE by the partner's stored
+ * `organizationOrder`. Page membership was therefore decided before the
+ * preferred order was consulted, so an org the partner dragged to the top could
+ * never leave page 2. `apps/web/src/lib/fetchAllOrganizations.ts` walks pages of
+ * 100 and concatenates, which makes the assembled list correctly ordered inside
+ * each block and wrong across every block boundary.
+ *
+ * These cases only discriminate because the fixture spans MORE THAN ONE PAGE
+ * and the preferred order disagrees with `created_at` across that boundary. A
+ * single-page assertion passes against the broken code.
+ *
+ * The compiled-SQL companion (`routes/orgs.listQuery.test.ts`) pins the
+ * statement shape without a database; this file proves the shape actually
+ * executes on real Postgres and returns the sequence claimed — including that
+ * the `ARRAY[...]::uuid[]` parameter form is the one Postgres accepts (a
+ * `${jsArray}::uuid[]` spread raises "cannot cast type record to uuid[]" at
+ * runtime and no mock can see that).
+ *
+ * Prerequisites:
+ *   docker compose -f docker-compose.test.yml up -d
+ *
+ * Run:
+ *   pnpm test:integration -- src/__tests__/integration/organizationOrderPagination.integration.test.ts
+ */
+import './setup';
+
+import { Hono } from 'hono';
+import { eq, sql } from 'drizzle-orm';
+import { describe, expect, it } from 'vitest';
+import { organizations, partners } from '../../db/schema';
+import { orgRoutes } from '../../routes/orgs';
+import { createIntegrationTestClient, createOrganization } from './db-utils';
+import { getTestDb } from './setup';
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.route('/api/v1/orgs', orgRoutes);
+  return app;
+}
+
+interface ListResponse {
+  data: Array<{ id: string; name: string }>;
+  pagination: { page: number; limit: number; total: number };
+}
+
+/**
+ * Stamp an explicit `created_at` per org so the "registration order" the
+ * endpoint falls back to is deterministic. `created_at` is `defaultNow()` and
+ * `now()` is the TRANSACTION timestamp, so fixture rows can otherwise tie —
+ * which is exactly why `id` is a mandatory tiebreaker (#3462) and exactly what
+ * would make an ordering assertion flaky rather than wrong.
+ */
+async function stampCreatedAt(orgIds: string[]): Promise<void> {
+  const base = new Date('2026-01-01T00:00:00.000Z').getTime();
+  for (const [index, orgId] of orgIds.entries()) {
+    await getTestDb()
+      .update(organizations)
+      .set({ createdAt: new Date(base + index * 60_000) })
+      .where(eq(organizations.id, orgId));
+  }
+}
+
+async function setPreferredOrder(partnerId: string, orderedIds: string[]): Promise<void> {
+  // `organizationOrder` is plaintext inside the settings blob (the encrypted
+  // column registry only wraps nested remote-access credentials), so seeding it
+  // directly is faithful to what the PATCH /organizations/order route persists.
+  await getTestDb()
+    .update(partners)
+    .set({
+      settings: sql`COALESCE(${partners.settings}, '{}'::jsonb) || ${JSON.stringify({
+        organizationOrder: orderedIds,
+      })}::jsonb`,
+    })
+    .where(eq(partners.id, partnerId));
+}
+
+/** Walk every page the way `fetchAllOrganizations.ts` does and concatenate. */
+async function walkPages(
+  client: { get: (path: string) => Promise<Response> },
+  limit: number,
+): Promise<string[]> {
+  const ids: string[] = [];
+  let page = 1;
+  for (;;) {
+    const res = await client.get(`/api/v1/orgs/organizations?page=${page}&limit=${limit}`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ListResponse;
+    ids.push(...body.data.map((org) => org.id));
+    if (body.data.length < limit || ids.length >= body.pagination.total) break;
+    page += 1;
+    if (page > 20) throw new Error('page walk did not terminate');
+  }
+  return ids;
+}
+
+/**
+ * Five orgs under one partner, `created_at`-ascending, all reachable by the
+ * returned partner-scoped client.
+ */
+async function seedFiveOrgs() {
+  const app = buildApp();
+  const client = await createIntegrationTestClient(app, { scope: 'partner' });
+  const partnerId = client.env.partner.id;
+
+  const extra = [];
+  for (let i = 1; i < 5; i += 1) {
+    extra.push(await createOrganization({ partnerId, name: `Ordering Customer ${i}` }));
+  }
+  const orgIds = [client.env.organization.id, ...extra.map((o) => o.id)];
+  await stampCreatedAt(orgIds);
+  return { client, partnerId, orgIds };
+}
+
+describe('GET /orgs/organizations — organizationOrder across page boundaries (#4004)', () => {
+  it('returns the preferred order across pages, not merely within each page', async () => {
+    const { client, partnerId, orgIds } = await seedFiveOrgs();
+    // Exactly the reverse of created_at: every org has to cross a page
+    // boundary for this to hold, so no page-local sort can satisfy it.
+    const preferred = [...orgIds].reverse();
+    await setPreferredOrder(partnerId, preferred);
+
+    const firstPage = await client.get('/api/v1/orgs/organizations?page=1&limit=2');
+    expect(firstPage.status).toBe(200);
+    const firstBody = (await firstPage.json()) as ListResponse;
+    expect(firstBody.pagination.total).toBe(5);
+    // The pre-fix endpoint returned orgIds[0] and orgIds[1] here — the two
+    // OLDEST orgs — because `created_at, id` chose the page before the stored
+    // order was consulted.
+    expect(firstBody.data.map((o) => o.id)).toEqual([preferred[0], preferred[1]]);
+
+    const secondPage = await client.get('/api/v1/orgs/organizations?page=2&limit=2');
+    const secondBody = (await secondPage.json()) as ListResponse;
+    expect(secondBody.data.map((o) => o.id)).toEqual([preferred[2], preferred[3]]);
+
+    const thirdPage = await client.get('/api/v1/orgs/organizations?page=3&limit=2');
+    const thirdBody = (await thirdPage.json()) as ListResponse;
+    expect(thirdBody.data.map((o) => o.id)).toEqual([preferred[4]]);
+  });
+
+  it('reassembles the exact stored order over a full page walk, with no repeat or drop', async () => {
+    const { client, partnerId, orgIds } = await seedFiveOrgs();
+    const preferred = [orgIds[3]!, orgIds[0]!, orgIds[4]!, orgIds[1]!, orgIds[2]!];
+    await setPreferredOrder(partnerId, preferred);
+
+    expect(await walkPages(client, 2)).toEqual(preferred);
+    // The page size must not change the assembled sequence.
+    expect(await walkPages(client, 50)).toEqual(preferred);
+  });
+
+  it('puts orgs missing from the stored order after the ordered ones, in created_at order', async () => {
+    const { client, partnerId, orgIds } = await seedFiveOrgs();
+    // Only the NEWEST org is pinned; the other four are unlisted. Pre-fix, the
+    // pinned org sat on the last page and page 1 opened with the oldest orgs.
+    await setPreferredOrder(partnerId, [orgIds[4]!]);
+
+    expect(await walkPages(client, 2)).toEqual([
+      orgIds[4],
+      orgIds[0],
+      orgIds[1],
+      orgIds[2],
+      orgIds[3],
+    ]);
+  });
+
+  it('falls back to created_at, id when the partner has stored no order', async () => {
+    const { client, orgIds } = await seedFiveOrgs();
+    expect(await walkPages(client, 2)).toEqual(orgIds);
+  });
+
+  it('ignores a stored id that is not UUID-shaped rather than failing the list', async () => {
+    const { client, partnerId, orgIds } = await seedFiveOrgs();
+    // A uuid[] cast over this array raises 22P02 and would 500 the whole list;
+    // the pre-fix in-JS sort simply never matched such an entry.
+    await setPreferredOrder(partnerId, ['not-a-uuid', orgIds[4]!]);
+
+    const res = await client.get('/api/v1/orgs/organizations?page=1&limit=2');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ListResponse;
+    expect(body.data.map((o) => o.id)).toEqual([orgIds[4], orgIds[0]]);
+  });
+});

--- a/apps/api/src/__tests__/integration/organizationOrderPagination.integration.test.ts
+++ b/apps/api/src/__tests__/integration/organizationOrderPagination.integration.test.ts
@@ -166,6 +166,22 @@ describe('GET /orgs/organizations — organizationOrder across page boundaries (
     ]);
   });
 
+  // NOT COVERED HERE — the system-scope branch (`else if (auth.scope === 'system'
+  // && queryPartnerId)` in orgs.ts) cannot be reached over HTTP from this
+  // harness, and the reason is worth recording rather than papering over. The
+  // route is gated by `requireOrgRead` -> `requirePermission(ORGS_READ)`, and
+  // `getUserPermissions` resolves a user's permissions through their
+  // organization_users / partner_users membership keyed by the request's
+  // partnerId/orgId. A system-scope token carries neither (db-utils mints
+  // `partnerId: null` for system scope, by design), so the lookup returns null
+  // and every system caller gets 403 "No permissions found" — before any
+  // ordering code runs. Promoting the fixture user to `is_platform_admin`
+  // clears the separate SR2-02 live-binding check (middleware/auth.ts:591) but
+  // not this one: there is no platform-admin bypass in `getUserPermissions`.
+  // Covering that branch needs a harness change (a system-reachable role), not
+  // a change to this file, and the ordering it feeds is already proven by the
+  // partner-scope cases above plus the compiled-SQL suite.
+
   it('falls back to created_at, id when the partner has stored no order', async () => {
     const { client, orgIds } = await seedFiveOrgs();
     expect(await walkPages(client, 2)).toEqual(orgIds);

--- a/apps/api/src/db/offsetPaginationOrdering.test.ts
+++ b/apps/api/src/db/offsetPaginationOrdering.test.ts
@@ -75,6 +75,12 @@ const ALLOWED_WITHOUT_LITERAL_ID: ReadonlyArray<{
     reason: 'every branch of the sort switch already ends in asc/desc(tickets.id)',
   },
   {
+    file: 'routes/orgs.listQuery.ts',
+    orderByContains: '...organizationOrderBy',
+    reason:
+      'organizationOrderBy() (same file) ends BOTH of its branches in organizations.createdAt, organizations.id — the empty/junk-order early return IS that pair, and the array_position branch appends it after the preferred-order term (#4004). Unlike the other helper entries here, that is not just prose: routes/orgs.listQuery.test.ts asserts it on the COMPILED SQL for both branches (the tiebreaker follows array_position, and the no-order case emits exactly `order by "organizations"."created_at", "organizations"."id"`), so a regression that dropped the id fails there rather than silently riding this exemption.',
+  },
+  {
     file: 'services/logSearch.ts',
     orderByContains: 'rowsQuery.offset',
     reason:

--- a/apps/api/src/jobs/orgMerge.ts
+++ b/apps/api/src/jobs/orgMerge.ts
@@ -13,8 +13,8 @@
  *      gets the same GDPR-grade cascade delete a manual erasure would run,
  *   3. audits `org.merge.erasure_enqueued`, and
  *   4. best-effort removes the loser from the partner's saved organization
- *      order (cosmetic — a stale id left there is merely ignored by
- *      `applyOrganizationOrder`, never a correctness bug).
+ *      order (cosmetic — a stale id left there is merely ignored by the list
+ *      endpoint's ordering, matching no row, never a correctness bug).
  *
  * Module shape mirrors `jobs/tenantErasure.ts` verbatim: a lazily-created
  * Queue/Worker singleton pair, `jobId = org-merge-<loserOrgId>` so a

--- a/apps/api/src/routes/organizations.test.ts
+++ b/apps/api/src/routes/organizations.test.ts
@@ -315,6 +315,15 @@ describe('organization routes', () => {
             where: vi.fn().mockResolvedValue([{ count: 1 }])
           })
         } as any)
+        // partner-settings read for the preferred org order — runs BEFORE the
+        // page query since #4004, because it supplies the leading ORDER BY term
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([])
+            })
+          })
+        } as any)
         .mockReturnValueOnce({
           from: vi.fn().mockReturnValue({
             where: vi.fn().mockReturnValue({
@@ -323,14 +332,6 @@ describe('organization routes', () => {
                   orderBy: vi.fn().mockResolvedValue(organizations)
                 })
               })
-            })
-          })
-        } as any)
-        // partner-settings read for the preferred org order
-        .mockReturnValueOnce({
-          from: vi.fn().mockReturnValue({
-            where: vi.fn().mockReturnValue({
-              limit: vi.fn().mockResolvedValue([])
             })
           })
         } as any)

--- a/apps/api/src/routes/orgs.listQuery.test.ts
+++ b/apps/api/src/routes/orgs.listQuery.test.ts
@@ -1,0 +1,127 @@
+/**
+ * DB-less compiled-SQL guard for the organization list query (#4004).
+ *
+ * These assertions run against the string `.toSQL()` actually produces, not
+ * against a Drizzle mock's call shape. A `where`/`orderBy` assertion on a mock
+ * proves only that *some* argument was handed to a spy — it stays green when
+ * the argument is wrong, which is precisely the class of bug this file exists
+ * to catch. `.toSQL()` builds the statement synchronously with no connection,
+ * so this lives in the ordinary unit suite.
+ *
+ * The property under test is structural and cross-page: the preferred order
+ * must be part of the ORDER BY of the SAME statement that carries LIMIT/OFFSET.
+ * Sorting the rows a `created_at, id` LIMIT already selected can never move an
+ * organization from page 2 to the top of page 1. The end-to-end proof over real
+ * rows across a real page boundary is
+ * `__tests__/integration/organizationOrderPagination.integration.test.ts`.
+ */
+import { describe, it, expect } from 'vitest';
+import { and, eq, isNull } from 'drizzle-orm';
+import { buildOrganizationListQuery, organizationOrderBy } from './orgs.listQuery';
+import { organizations } from '../db/schema';
+
+const PARTNER_ID = '00000000-0000-4000-8000-000000000001';
+const ORG_A = '11111111-1111-4111-8111-111111111111';
+const ORG_B = '22222222-2222-4222-8222-222222222222';
+const ORG_C = '33333333-3333-4333-8333-333333333333';
+
+const conditions = and(eq(organizations.partnerId, PARTNER_ID), isNull(organizations.deletedAt));
+
+// A NON-ZERO offset on purpose: Drizzle omits `offset 0` from the emitted SQL,
+// so compiling page 1 would leave the OFFSET half of these assertions vacuous.
+// Page 2 is also the page the bug was actually visible on.
+function compile(preferredOrder?: string[] | null) {
+  return buildOrganizationListQuery({ conditions, limit: 2, offset: 2, preferredOrder }).toSQL();
+}
+
+describe('buildOrganizationListQuery — preferred order participates in page selection', () => {
+  it('puts the preferred-order term in the ORDER BY of the same statement as LIMIT/OFFSET', () => {
+    const { sql: text } = compile([ORG_C, ORG_A]);
+
+    const orderByAt = text.indexOf('order by');
+    const arrayPositionAt = text.indexOf('array_position');
+    const limitAt = text.indexOf('limit');
+    const offsetAt = text.indexOf('offset');
+
+    expect(orderByAt).toBeGreaterThan(-1);
+    expect(limitAt).toBeGreaterThan(-1);
+    expect(offsetAt).toBeGreaterThan(-1);
+    // The ordering term exists, sits inside the ORDER BY, and precedes both the
+    // LIMIT and the OFFSET — i.e. Postgres sorts the whole result set on it
+    // before slicing the page, which is what makes a cross-page move
+    // expressible at all.
+    expect(arrayPositionAt).toBeGreaterThan(orderByAt);
+    expect(arrayPositionAt).toBeLessThan(limitAt);
+    expect(arrayPositionAt).toBeLessThan(offsetAt);
+  });
+
+  it('keeps created_at and id as tiebreakers AFTER the preferred-order term (#3462)', () => {
+    const { sql: text } = compile([ORG_C, ORG_A]);
+    const orderBy = text.slice(text.indexOf('order by'));
+
+    const arrayPositionAt = orderBy.indexOf('array_position');
+    const createdAtAt = orderBy.indexOf('"created_at"');
+    const idAt = orderBy.lastIndexOf('"id"');
+
+    expect(createdAtAt).toBeGreaterThan(arrayPositionAt);
+    expect(idAt).toBeGreaterThan(createdAtAt);
+  });
+
+  it('binds each org id as its own parameter rather than interpolating or array-spreading', () => {
+    const { sql: text, params } = compile([ORG_C, ORG_A]);
+
+    // The repo's known Drizzle trap: `${jsArray}::uuid[]` emits N positional
+    // parameters instead of one array value, which fails at runtime with
+    // "cannot cast type record to uuid[]" (routes/devices/core.ts:771). The
+    // ARRAY[...] + sql.join form below is the shape that actually executes.
+    expect(text).toContain('::uuid[]');
+    expect(text).not.toContain(ORG_C);
+    expect(params).toContain(ORG_C);
+    expect(params).toContain(ORG_A);
+    // Preferred-order params keep the caller's sequence: array_position returns
+    // the 1-based index, so the array's own order IS the sort.
+    expect(params.indexOf(ORG_C)).toBeLessThan(params.indexOf(ORG_A));
+  });
+
+  it('falls back to created_at, id alone when no order is stored', () => {
+    for (const empty of [undefined, null, []] as const) {
+      const { sql: text } = compile(empty);
+      expect(text).not.toContain('array_position');
+      const orderBy = text.slice(text.indexOf('order by'));
+      expect(orderBy).toContain('"created_at"');
+    }
+  });
+});
+
+describe('organizationOrderBy — tolerating a stored order that is not clean', () => {
+  function orderTerms(preferredOrder: string[] | null | undefined) {
+    return buildOrganizationListQuery({ conditions, limit: 2, offset: 0, preferredOrder }).toSQL();
+  }
+
+  it('drops entries that are not UUID-shaped instead of letting the uuid[] cast throw', () => {
+    // Pre-fix this list was tolerated by an in-JS sort. A naive SQL port would
+    // send 'not-a-uuid' into ::uuid[] and 500 the whole list with 22P02.
+    const { sql: text, params } = orderTerms(['not-a-uuid', ORG_B, '', ORG_A]);
+    expect(params).not.toContain('not-a-uuid');
+    expect(params).toContain(ORG_B);
+    expect(params).toContain(ORG_A);
+    expect(params.indexOf(ORG_B)).toBeLessThan(params.indexOf(ORG_A));
+    expect(text).toContain('array_position');
+  });
+
+  it('degrades to created_at, id when every stored entry is junk', () => {
+    const { sql: text } = orderTerms(['nope', '']);
+    expect(text).not.toContain('array_position');
+  });
+
+  it('keeps the first occurrence of a duplicated id, matching array_position semantics', () => {
+    const { params } = orderTerms([ORG_B, ORG_A, ORG_B]);
+    const bs = params.filter((p) => p === ORG_B);
+    expect(bs).toHaveLength(1);
+    expect(params.indexOf(ORG_B)).toBeLessThan(params.indexOf(ORG_A));
+  });
+
+  it('returns exactly the tiebreaker columns when there is nothing to prefer', () => {
+    expect(organizationOrderBy(undefined)).toEqual([organizations.createdAt, organizations.id]);
+  });
+});

--- a/apps/api/src/routes/orgs.listQuery.test.ts
+++ b/apps/api/src/routes/orgs.listQuery.test.ts
@@ -63,6 +63,11 @@ describe('buildOrganizationListQuery — preferred order participates in page se
     const createdAtAt = orderBy.indexOf('"created_at"');
     const idAt = orderBy.lastIndexOf('"id"');
 
+    // Assert PRESENCE before relative position. `indexOf` returns -1 when the
+    // term is absent, and `createdAtAt > -1` holds for any ORDER BY at all —
+    // so without this line the whole case passes with the ordering feature
+    // removed, which is exactly the vacuous shape this file exists to avoid.
+    expect(arrayPositionAt).toBeGreaterThan(-1);
     expect(createdAtAt).toBeGreaterThan(arrayPositionAt);
     expect(idAt).toBeGreaterThan(createdAtAt);
   });

--- a/apps/api/src/routes/orgs.listQuery.test.ts
+++ b/apps/api/src/routes/orgs.listQuery.test.ts
@@ -84,11 +84,14 @@ describe('buildOrganizationListQuery — preferred order participates in page se
   });
 
   it('falls back to created_at, id alone when no order is stored', () => {
-    for (const empty of [undefined, null, []] as const) {
+    for (const empty of [undefined, null, [] as string[]]) {
       const { sql: text } = compile(empty);
       expect(text).not.toContain('array_position');
-      const orderBy = text.slice(text.indexOf('order by'));
-      expect(orderBy).toContain('"created_at"');
+      // Pin the whole term, not just the presence of created_at: the #3462
+      // tiebreaker is only load-bearing if `id` is still there behind it.
+      expect(text).toContain(
+        'order by "organizations"."created_at", "organizations"."id" limit',
+      );
     }
   });
 });

--- a/apps/api/src/routes/orgs.listQuery.ts
+++ b/apps/api/src/routes/orgs.listQuery.ts
@@ -1,0 +1,108 @@
+/**
+ * The paginated organization-list query for `GET /orgs/organizations`.
+ *
+ * Extracted from the route handler so the ORDER BY / LIMIT relationship can be
+ * asserted on the COMPILED statement without a database (`.toSQL()`), the way
+ * `routes/incidents.helpers.ts` is. That relationship is the whole point of
+ * this module: the partner's preferred order has to be part of the sort key the
+ * LIMIT/OFFSET walks, not a re-sort of rows a different sort already chose
+ * (#4004).
+ */
+import { sql, type SQL } from 'drizzle-orm';
+import type { PgColumn } from 'drizzle-orm/pg-core';
+import { db } from '../db';
+import { organizations } from '../db/schema';
+import { PG_UUID_REGEX } from '../utils/uuid';
+
+export interface OrganizationListQueryParams {
+  /** Fully-built tenant predicate from the route (already fail-closed). */
+  conditions: SQL | undefined;
+  limit: number;
+  offset: number;
+  /** `partners.settings.organizationOrder`, as stored. May be absent or junk. */
+  preferredOrder?: string[] | null;
+}
+
+/**
+ * The stored order, reduced to what can safely be cast to `uuid[]`.
+ *
+ * `partners.settings` is a jsonb blob: nothing in the database constrains what
+ * `organizationOrder` holds, and the array survives orgs being deleted. The
+ * previous in-JS sort simply never matched a junk entry, but a `::uuid[]` cast
+ * over one raises 22P02 and would take the whole list endpoint down with it, so
+ * the filter is load-bearing rather than defensive tidying.
+ *
+ * Lower-cased and de-duplicated because `array_position` returns the FIRST
+ * match: de-duplicating here keeps the emitted array a faithful picture of the
+ * sort it produces, and Postgres would fold the case on cast anyway.
+ */
+function sanitizePreferredOrderIds(preferredOrder?: string[] | null): string[] {
+  if (!Array.isArray(preferredOrder) || preferredOrder.length === 0) return [];
+
+  const seen = new Set<string>();
+  const ids: string[] = [];
+  for (const raw of preferredOrder) {
+    if (typeof raw !== 'string' || !PG_UUID_REGEX.test(raw)) continue;
+    const id = raw.toLowerCase();
+    if (seen.has(id)) continue;
+    seen.add(id);
+    ids.push(id);
+  }
+  return ids;
+}
+
+/**
+ * ORDER BY terms for the organization list: the partner's preferred order
+ * first, then the stable pagination tiebreaker.
+ *
+ * `array_position` returns the 1-based index of the org in the stored array, or
+ * NULL when it is absent — and an ASC sort puts NULLs last, so orgs the partner
+ * never placed trail the ones it did, in registration order. That reproduces
+ * exactly what the old in-JS `applyOrganizationOrder` computed (ordered ids by
+ * stored index, then the remainder in `created_at, id` order), with the one
+ * difference that matters: Postgres now applies it to the whole result set
+ * rather than to the rows a `created_at, id` LIMIT already picked.
+ *
+ * `created_at, id` stays as the tiebreaker and `id` remains mandatory (#3462):
+ * `created_at` is `defaultNow()` and Postgres `now()` is the TRANSACTION
+ * timestamp, so every org written in one transaction (seed, bulk import,
+ * migration) shares a byte-identical value. Ordering on a tied key alone leaves
+ * row order undefined between two LIMIT/OFFSET queries, and the page walk in
+ * `apps/web/src/lib/fetchAllOrganizations.ts` would silently see some orgs twice
+ * and miss others.
+ *
+ * The ids are bound as N individual parameters inside an `ARRAY[...]::uuid[]`
+ * constructor, NOT as `${ids}::uuid[]`: Drizzle's `sql` template spreads a JS
+ * array into N positional parameters, so the natural-looking form compiles to
+ * `(...)::uuid[]` over a record and fails at runtime with "cannot cast type
+ * record to uuid[]" (the same trap documented at `routes/devices/core.ts:771`).
+ * The array is bounded by the partner's own org count — `PATCH
+ * /organizations/order` sanitizes against it and caps at 10k — so the parameter
+ * count stays far below Postgres's 65535 limit.
+ */
+export function organizationOrderBy(
+  preferredOrder?: string[] | null,
+): (SQL | PgColumn)[] {
+  const ids = sanitizePreferredOrderIds(preferredOrder);
+  if (ids.length === 0) return [organizations.createdAt, organizations.id];
+
+  const idArray = sql.join(
+    ids.map((id) => sql`${id}`),
+    sql`, `,
+  );
+  return [
+    sql`array_position(ARRAY[${idArray}]::uuid[], ${organizations.id}) asc nulls last`,
+    organizations.createdAt,
+    organizations.id,
+  ];
+}
+
+export function buildOrganizationListQuery(params: OrganizationListQueryParams) {
+  return db
+    .select()
+    .from(organizations)
+    .where(params.conditions)
+    .limit(params.limit)
+    .offset(params.offset)
+    .orderBy(...organizationOrderBy(params.preferredOrder));
+}

--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -1631,9 +1631,11 @@ describe('org routes', () => {
         })
       }) as any;
 
-    // Partner scope reads partners.settings for the preferred org order, which
-    // lands BETWEEN the page query and the device counts. It has to be queued
-    // explicitly once anything follows it, or it consumes the next mock.
+    // Partner scope reads partners.settings for the preferred org order. Since
+    // #4004 that order is the leading ORDER BY term of the page query itself,
+    // so the read lands BETWEEN the count and the page query — ahead of the
+    // rows it sorts, not after them. It has to be queued explicitly once
+    // anything follows it, or it consumes the next mock.
     const mockPartnerOrderSettings = () =>
       ({
         from: vi.fn().mockReturnValue({
@@ -1651,6 +1653,7 @@ describe('org routes', () => {
             where: vi.fn().mockResolvedValue([{ count: 1 }])
           })
         } as any)
+        .mockReturnValueOnce(mockPartnerOrderSettings())
         .mockReturnValueOnce({
           from: vi.fn().mockReturnValue({
             where: vi.fn().mockReturnValue({
@@ -1662,7 +1665,6 @@ describe('org routes', () => {
             })
           })
         } as any)
-        .mockReturnValueOnce(mockPartnerOrderSettings())
         .mockReturnValueOnce(mockOrgDeviceCounts([{ orgId: 'org-1', count: 2 }]));
 
       const res = await app.request('/orgs/organizations?page=1&limit=1');
@@ -1685,6 +1687,7 @@ describe('org routes', () => {
             where: vi.fn().mockResolvedValue([{ count: 2 }])
           })
         } as any)
+        .mockReturnValueOnce(mockPartnerOrderSettings())
         .mockReturnValueOnce({
           from: vi.fn().mockReturnValue({
             where: vi.fn().mockReturnValue({
@@ -1696,7 +1699,6 @@ describe('org routes', () => {
             })
           })
         } as any)
-        .mockReturnValueOnce(mockPartnerOrderSettings())
         // org-2 has no devices, so the grouped query simply omits it.
         .mockReturnValueOnce(mockOrgDeviceCounts([{ orgId: 'org-1', count: 12 }]));
 
@@ -1726,6 +1728,7 @@ describe('org routes', () => {
               where: vi.fn().mockResolvedValue([{ count: total }])
             })
           } as any)
+          .mockReturnValueOnce(mockPartnerOrderSettings())
           .mockReturnValueOnce({
             from: vi.fn().mockReturnValue({
               where: vi.fn().mockReturnValue({
@@ -1736,8 +1739,7 @@ describe('org routes', () => {
                 })
               })
             })
-          } as any)
-          .mockReturnValueOnce(mockPartnerOrderSettings());
+          } as any);
         if (orgIds.length > 0) {
           vi.mocked(db.select).mockReturnValueOnce(mockOrgDeviceCounts([]));
         }
@@ -1903,6 +1905,7 @@ describe('org routes', () => {
             where: vi.fn().mockResolvedValue([{ count: 3 }])
           })
         } as any)
+        .mockReturnValueOnce(mockPartnerOrderSettings())
         .mockReturnValueOnce({
           from: vi.fn().mockReturnValue({
             where: vi.fn().mockReturnValue({
@@ -1914,7 +1917,6 @@ describe('org routes', () => {
             })
           })
         } as any)
-        .mockReturnValueOnce(mockPartnerOrderSettings())
         .mockReturnValueOnce({
           from: vi.fn().mockReturnValue({
             where: vi.fn().mockReturnValue({ groupBy: groupBySpy })
@@ -1938,6 +1940,11 @@ describe('org routes', () => {
     // silently see some orgs twice and miss others. This exercises the
     // general paginated branch (partner scope), NOT the own-org early-return
     // branch covered by the projection test below.
+    //
+    // This asserts the ARGUMENTS handed to a mocked `orderBy`, which cannot see
+    // what Postgres would actually run. The compiled-SQL assertions in
+    // `orgs.listQuery.test.ts` are the real guard on the emitted ORDER BY; this
+    // case pins only that the route reaches the builder on the partner branch.
     it('appends a unique id tiebreaker to the sort so paging is stable', async () => {
       setAuthContext({ scope: 'partner', partnerId: 'partner-123' });
       let capturedOrderBy: unknown[] = [];
@@ -1947,6 +1954,8 @@ describe('org routes', () => {
             where: vi.fn().mockResolvedValue([{ count: 0 }])
           })
         } as any)
+        // No stored order, so the sort is the bare tiebreaker.
+        .mockReturnValueOnce(mockPartnerOrderSettings())
         .mockReturnValueOnce({
           from: vi.fn().mockReturnValue({
             where: vi.fn().mockReturnValue({
@@ -1979,6 +1988,7 @@ describe('org routes', () => {
         .mockReturnValueOnce({
           from: vi.fn().mockReturnValue({ where: whereSpy })
         } as any)
+        .mockReturnValueOnce(mockPartnerOrderSettings())
         .mockReturnValueOnce({
           from: vi.fn().mockReturnValue({
             where: vi.fn().mockReturnValue({
@@ -1988,7 +1998,6 @@ describe('org routes', () => {
             })
           })
         } as any)
-        .mockReturnValueOnce(mockPartnerOrderSettings())
         .mockReturnValueOnce(mockOrgDeviceCounts([]));
 
       const res = await app.request('/orgs/organizations?search=contoso');
@@ -5799,7 +5808,17 @@ describe('org routes', () => {
           where: vi.fn().mockResolvedValue([{ count: 1 }])
         })
       } as any);
-      // 2) main list query
+      // 2) partner-settings read — throws. Since #4004 this runs BEFORE the
+      // page query, because its result is the leading ORDER BY term; the
+      // soft-fail therefore has to leave the list query itself still runnable.
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockRejectedValue(new Error('db blew up'))
+          })
+        })
+      } as any);
+      // 3) main list query — still runs, ordered by the created_at, id fallback
       vi.mocked(db.select).mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
@@ -5808,14 +5827,6 @@ describe('org routes', () => {
                 orderBy: vi.fn().mockResolvedValue([{ id: 'org-1', name: 'Org 1' }])
               })
             })
-          })
-        })
-      } as any);
-      // 3) partner-settings read — throws
-      vi.mocked(db.select).mockReturnValueOnce({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockRejectedValue(new Error('db blew up'))
           })
         })
       } as any);

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -23,7 +23,8 @@ import {
   beginOrganizationOffboarding,
   beginPartnerOffboarding,
 } from '../services/tenantOffboarding';
-import { applyOrganizationOrder, sanitizeOrganizationOrder } from '../services/orgOrdering';
+import { sanitizeOrganizationOrder } from '../services/orgOrdering';
+import { buildOrganizationListQuery } from './orgs.listQuery';
 import {
   listArchivedOrgs,
   loadArchivedOrg,
@@ -1351,30 +1352,18 @@ orgRoutes.get('/organizations', requireScope('organization', 'partner', 'system'
         .where(conditions);
   const count = countResult[0]?.count ?? 0;
 
-  const data = noLiveOrgs ? [] : await db
-    .select()
-    .from(organizations)
-    .where(conditions)
-    .limit(limit)
-    .offset(offset)
-    // `id` is a mandatory tiebreaker, not a cosmetic nicety (#3462).
-    // `created_at` is `defaultNow()` and Postgres `now()` is the TRANSACTION
-    // timestamp, so every org written in one transaction (seed, bulk import,
-    // migration) shares a byte-identical value. Ordering on a tied key alone
-    // leaves row order undefined between two LIMIT/OFFSET queries, so the page
-    // walk in `apps/web/src/lib/fetchAllOrganizations.ts` would silently see
-    // some orgs twice and miss others.
-    .orderBy(organizations.createdAt, organizations.id);
-
-  // Apply the partner's preferred organization order, when one is set.
+  // Load the partner's preferred organization order BEFORE the page query.
+  // It has to be part of the ORDER BY that LIMIT/OFFSET walks — applying it to
+  // an already-selected page can only permute that page, so an org the partner
+  // dragged to the top could never leave page 2 (#4004).
   // - partner scope: load own partner settings.
   // - system scope: only when a partnerId filter is in the query.
   // (organization scope already returned above — at most one row anyway.)
-  let ordered = data;
+  let preferredOrder: string[] | undefined;
   let orderPartnerId: string | null = null;
   if (auth.scope === 'partner' && auth.partnerId) orderPartnerId = auth.partnerId;
   else if (auth.scope === 'system' && queryPartnerId) orderPartnerId = queryPartnerId;
-  // Nothing to order when the live query never ran (archived-only partner).
+  // Nothing to order when the live query never runs (archived-only partner).
   if (orderPartnerId && !noLiveOrgs) {
     try {
       const settingsRow = await withSystemDbAccessContext(async () => {
@@ -1385,9 +1374,8 @@ orgRoutes.get('/organizations', requireScope('organization', 'partner', 'system'
           .limit(1);
         return row;
       });
-      const preferredOrder = (settingsRow?.settings as { organizationOrder?: string[] } | undefined)
+      preferredOrder = (settingsRow?.settings as { organizationOrder?: string[] } | undefined)
         ?.organizationOrder;
-      ordered = applyOrganizationOrder(data, preferredOrder);
     } catch (err) {
       // Soft-fail: if we can't load partner settings, fall back to createdAt
       // order so the list still renders. Surface the failure to stderr and
@@ -1400,6 +1388,14 @@ orgRoutes.get('/organizations', requireScope('organization', 'partner', 'system'
       captureException(err, c);
     }
   }
+
+  // One statement: the preferred order is the leading sort key and
+  // `created_at, id` the tiebreaker, so LIMIT/OFFSET slices the intended
+  // sequence. `buildOrganizationListQuery` owns that shape and is pinned on the
+  // compiled SQL in `orgs.listQuery.test.ts`.
+  const ordered = noLiveOrgs
+    ? []
+    : await buildOrganizationListQuery({ conditions, limit, offset, preferredOrder });
 
   // Device count per organization. The list is where an MSP scans "how big is
   // each customer", and the web card renders `{{count}} devices` — with no

--- a/apps/api/src/services/orgOrdering.test.ts
+++ b/apps/api/src/services/orgOrdering.test.ts
@@ -23,62 +23,7 @@ vi.mock('./encryptedColumnRegistry', () => ({
   encryptColumnValueForWrite: vi.fn((_table: string, _column: string, value: unknown) => value),
 }));
 
-import { applyOrganizationOrder, removeOrgFromPartnerOrder, sanitizeOrganizationOrder } from './orgOrdering';
-
-const orgs = [
-  { id: 'a', name: 'Alpha' },
-  { id: 'b', name: 'Bravo' },
-  { id: 'c', name: 'Charlie' },
-  { id: 'd', name: 'Delta' },
-];
-
-describe('applyOrganizationOrder', () => {
-  it('returns input unchanged when preferred order is undefined', () => {
-    expect(applyOrganizationOrder(orgs, undefined).map((o) => o.id)).toEqual(['a', 'b', 'c', 'd']);
-  });
-
-  it('returns input unchanged when preferred order is null', () => {
-    expect(applyOrganizationOrder(orgs, null).map((o) => o.id)).toEqual(['a', 'b', 'c', 'd']);
-  });
-
-  it('returns input unchanged when preferred order is empty', () => {
-    expect(applyOrganizationOrder(orgs, []).map((o) => o.id)).toEqual(['a', 'b', 'c', 'd']);
-  });
-
-  it('reorders matching orgs in the preferred order', () => {
-    expect(applyOrganizationOrder(orgs, ['c', 'a', 'd', 'b']).map((o) => o.id)).toEqual([
-      'c', 'a', 'd', 'b',
-    ]);
-  });
-
-  it('appends orgs missing from preferred order in original order', () => {
-    expect(applyOrganizationOrder(orgs, ['c', 'a']).map((o) => o.id)).toEqual([
-      'c', 'a', 'b', 'd',
-    ]);
-  });
-
-  it('ignores stale ids in preferred order that no longer match an org', () => {
-    expect(applyOrganizationOrder(orgs, ['stale', 'd', 'b']).map((o) => o.id)).toEqual([
-      'd', 'b', 'a', 'c',
-    ]);
-  });
-
-  it('ignores duplicates in preferred order', () => {
-    expect(applyOrganizationOrder(orgs, ['b', 'b', 'a']).map((o) => o.id)).toEqual([
-      'b', 'a', 'c', 'd',
-    ]);
-  });
-
-  it('handles a single-org list', () => {
-    expect(applyOrganizationOrder([{ id: 'x' }], ['x']).map((o) => o.id)).toEqual(['x']);
-  });
-
-  it('does not mutate the input array', () => {
-    const input = [...orgs];
-    applyOrganizationOrder(input, ['d', 'a']);
-    expect(input.map((o) => o.id)).toEqual(['a', 'b', 'c', 'd']);
-  });
-});
+import { removeOrgFromPartnerOrder, sanitizeOrganizationOrder } from './orgOrdering';
 
 describe('sanitizeOrganizationOrder', () => {
   it('keeps only ids that are in the valid set', () => {

--- a/apps/api/src/services/orgOrdering.ts
+++ b/apps/api/src/services/orgOrdering.ts
@@ -1,41 +1,17 @@
-// Server-side sort helper for the organization list. Reads the partner's
-// preferred order (an array of org IDs persisted on partners.settings) and
-// returns the orgs in that order; any orgs missing from the preferred order
-// are appended at the end in their original relative order (which the caller
-// is expected to pre-sort by createdAt).
+// Write-side helpers for the partner's preferred organization order (an array
+// of org IDs persisted on partners.settings).
+//
+// The READ side — turning that array into the list endpoint's sort — is
+// `routes/orgs.listQuery.ts`, and it is SQL, not JavaScript. An in-JS sort
+// applied to an already-selected page could only permute that page, so a
+// cross-page order was inexpressible (#4004); the ordering now has to be part
+// of the ORDER BY that LIMIT/OFFSET walks. Do not reintroduce a post-pagination
+// sort helper here.
 
 import { eq } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { partners } from '../db/schema';
 import { encryptColumnValueForWrite } from './encryptedColumnRegistry';
-
-export interface OrderableOrg {
-  id: string;
-}
-
-export function applyOrganizationOrder<T extends OrderableOrg>(
-  orgs: T[],
-  preferredOrder: string[] | undefined | null,
-): T[] {
-  if (!preferredOrder || preferredOrder.length === 0) return orgs;
-
-  const indexById = new Map<string, number>();
-  for (let i = 0; i < preferredOrder.length; i++) {
-    const id = preferredOrder[i];
-    if (typeof id === 'string' && id.length > 0 && !indexById.has(id)) {
-      indexById.set(id, i);
-    }
-  }
-
-  const ordered: T[] = [];
-  const trailing: T[] = [];
-  for (const org of orgs) {
-    if (indexById.has(org.id)) ordered.push(org);
-    else trailing.push(org);
-  }
-  ordered.sort((a, b) => (indexById.get(a.id) ?? 0) - (indexById.get(b.id) ?? 0));
-  return [...ordered, ...trailing];
-}
 
 // Sanitize a client-supplied order array against the partner's actual
 // non-deleted org IDs. Removes unknown/duplicate entries; preserves the

--- a/apps/web/src/components/settings/OrganizationsPage.tsx
+++ b/apps/web/src/components/settings/OrganizationsPage.tsx
@@ -684,11 +684,14 @@ export default function OrganizationsPage() {
       //     chasing. Two reorders from SEPARATE TABS can still interleave;
       //     that one needs a revision or compare-and-swap on the endpoint,
       //     which has neither.
-      //   - The list endpoint pages by `created_at, id` and applies the
-      //     partner's preferred order only WITHIN each page, so past the first
-      //     page it cannot report a cross-page order at all. Reconciliation is
-      //     therefore authoritative only up to that pre-existing server-side
-      //     limit, which this change does not introduce or fix.
+      //   - Reconciliation used to be authoritative only up to the FIRST page:
+      //     the list endpoint paged by `created_at, id` and applied the
+      //     partner's preferred order only WITHIN each page, so a drag that
+      //     crossed a page boundary could not survive the refetch. Fixed
+      //     server-side in #4004 — the preferred order is now the leading
+      //     ORDER BY term of the paginated query, so the page walk returns the
+      //     stored order end to end and this GET is authoritative for the whole
+      //     list.
       //
       // The refetch was previously unsafe purely because fetchOrganizations
       // answered its own 401 with a bare navigateTo('/login'), which raced the


### PR DESCRIPTION
Closes #4004

## The bug

`GET /orgs/organizations` selected each page with `ORDER BY created_at, id` +
`LIMIT`/`OFFSET`, and only afterwards handed **that page** to
`applyOrganizationOrder`. Page membership was decided before the partner's
stored `organizationOrder` was consulted, so the in-JS sort could only permute
rows a different sort had already chosen — an org the partner dragged to the top
could never leave page 2.

`apps/web/src/lib/fetchAllOrganizations.ts` walks pages of 100 and concatenates,
so the assembled client list was correctly ordered inside each 100-row block and
wrong across every block boundary. Below one page the behaviour was already
correct, which is why it went unnoticed.

Re-verified against `origin/main` (a48b840bb) before starting: still present.

## The fix

The preferred order is now the **leading ORDER BY term of the paginated query
itself**, so Postgres sorts the whole result set before slicing the page:

```sql
order by array_position(ARRAY[$2, $3]::uuid[], "organizations"."id") asc nulls last,
         "organizations"."created_at", "organizations"."id"
limit $4 offset $5
```

`array_position` returns the 1-based index or `NULL`, and an ASC sort puts NULLs
last — so orgs the partner never placed trail the ones it did, in registration
order. That is exactly what `applyOrganizationOrder` computed, now applied to the
whole result set instead of one page. The `created_at, id` tiebreaker stays and
`id` remains mandatory (#3462).

The query moved into `routes/orgs.listQuery.ts` (the `routes/incidents.helpers.ts`
pattern) so the ORDER BY / LIMIT relationship can be asserted on the **compiled**
statement without a database.

### Details worth a reviewer's eye

- **The partner-settings read moved ahead of the page query**, since it now
  supplies the sort key. Its soft-fail is unchanged in kind: a failed settings
  read logs, captures to Sentry, and degrades to `created_at, id` with the list
  still rendering. `orgs.test.ts`'s soft-fail case was updated to queue the
  throwing read in its new position and now additionally proves the list query
  still runs after it.
- **Stored ids are filtered to UUID shape before binding.** `partners.settings`
  is an unconstrained jsonb blob and the old in-JS sort simply never matched a
  junk entry; a `::uuid[]` cast over one raises 22P02 and would take the whole
  endpoint down. Covered by both a compiled-SQL case and an integration case.
- **Ids bind as N parameters inside `ARRAY[...]::uuid[]`**, not as
  `${ids}::uuid[]` — Drizzle's `sql` template spreads a JS array into positional
  parameters, so the natural-looking form fails at runtime with `cannot cast type
  record to uuid[]` (the trap documented at `routes/devices/core.ts:771`). This is
  precisely the class of bug a Drizzle-mock assertion cannot see, hence the
  compiled-SQL suite.
- **`applyOrganizationOrder` is deleted**, not left unused. Keeping a
  post-pagination sort helper around is how this bug comes back; the module
  header now says so.
- **Tenancy unchanged.** Same `conditions` predicate, same request DB access
  context, no bare-pool query, no schema change and no migration — so no
  cascade/export-policy registration applies. Only the ORDER BY moved.
- **Performance.** `organizations` has no `created_at` index, so the pre-fix
  query was already a full sort — the new sort key costs nothing index-wise. The
  array is bounded by the partner's own org count (`PATCH /organizations/order`
  sanitizes against it, cap 10k), and the term only appears when a partner order
  exists, i.e. for a query already scoped to one partner.
- **Stale comment corrected** in `OrganizationsPage.tsx`: #3989 documented this
  limit at the reorder-reconciliation call site ("authoritative only up to the
  first page"). That is no longer true, and a stale caveat is worse than none.

## Tests

- `apps/api/src/routes/orgs.listQuery.test.ts` — **new**, DB-less compiled-SQL
  guard via `.toSQL()`. Asserts the emitted statement, not a Drizzle mock's call
  shape: the ordering term sits inside the ORDER BY and precedes both LIMIT and
  OFFSET; `created_at, id` follow it; ids bind as parameters rather than being
  interpolated; junk/duplicate/empty stored orders degrade correctly. Compiles at
  `offset: 2` on purpose — Drizzle omits `offset 0`, which would make half the
  assertions vacuous.
- `apps/api/src/__tests__/integration/organizationOrderPagination.integration.test.ts`
  — **new**, real Postgres. Five orgs, explicit `created_at` stamps, page size 2,
  preferred order reversed against `created_at` so **every** org has to cross a
  page boundary. Walks every page the way `fetchAllOrganizations` does and
  asserts the reassembled sequence, plus the unlisted-orgs-trail and junk-id
  cases. Single-page assertions pass against the broken code, so the fixture
  spans more than one page deliberately.

Red-first, verified rather than asserted: with `organizationOrderBy` stubbed back to `[created_at, id]`, the compiled-SQL suite failed 4/8 and the integration suite failed **4 of 5** — the one case that stayed green is the "no stored order" fallback, which correctly does not depend on the feature. Both go green with the fix (8/8 and 5/5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
