### PR TITLE
fix(api): let the seeded Partner Technician work tickets and log time (#4251)

### DIFF
--- a/apps/api/migrations/2026-09-27-technician-ticket-write-permissions.sql
+++ b/apps/api/migrations/2026-09-27-technician-ticket-write-permissions.sql
@@ -1,0 +1,52 @@
+-- #4251: the seeded 'Partner Technician' role can read tickets but never write
+-- them, and therefore never holds time_entries:write.
+--
+-- The only grant path for time_entries is 2026-06-12-a-ticketing-time-parts.sql,
+-- which propagates each time_entries perm off the MATCHING tickets perm:
+-- time_entries:read to every role holding tickets:read, time_entries:write to
+-- every role holding tickets:write. Partner Technician holds tickets:read only
+-- (apps/api/src/db/seed.ts), so it received time_entries:read and nothing else.
+-- The #3206 W05 mobile timer renders that technician's timesheet and then 403s
+-- on start/stop.
+--
+-- seed.ts is fixed in the same commit, which repairs FRESH installs. This
+-- migration repairs EXISTING ones. Scope is deliberately narrow:
+--   * only is_system roles literally named 'Partner Technician' — a
+--     partner-authored custom role is theirs to define, never ours to widen;
+--   * tickets:manage is NOT granted (reassigning ticket organization and
+--     editing another author's comment stay admin actions);
+--   * Partner Viewer / Org Viewer are untouched.
+--
+-- Idempotent: every INSERT is guarded by NOT EXISTS, so re-applying is a no-op.
+
+DO $$
+DECLARE
+  granted integer;
+  total   integer := 0;
+  perm    text;
+BEGIN
+  FOREACH perm IN ARRAY ARRAY['tickets:write', 'time_entries:read', 'time_entries:write']
+  LOOP
+    INSERT INTO role_permissions (role_id, permission_id)
+    SELECT r.id, p.id
+    FROM roles r
+    JOIN permissions p
+      ON p.resource = split_part(perm, ':', 1)
+     AND p.action   = split_part(perm, ':', 2)
+    WHERE r.is_system = true
+      AND r.name = 'Partner Technician'
+      AND NOT EXISTS (
+        SELECT 1 FROM role_permissions x
+        WHERE x.role_id = r.id AND x.permission_id = p.id
+      );
+
+    GET DIAGNOSTICS granted = ROW_COUNT;
+    total := total + granted;
+
+    -- Report even a zero: this migration widens an authorization boundary, so
+    -- the count belongs in the Postgres log whether or not it changed anything.
+    RAISE WARNING 'granted % to % Partner Technician role(s)', perm, granted;
+  END LOOP;
+
+  RAISE WARNING 'technician ticket-write backfill: % role_permission row(s) inserted', total;
+END $$;

--- a/apps/api/src/db/seed.test.ts
+++ b/apps/api/src/db/seed.test.ts
@@ -93,9 +93,10 @@ describe('SYSTEM_ROLES ⊆ DEFAULT_PERMISSIONS', () => {
   // permission a system role grants must be seeded. The reverse is NOT asserted:
   // DEFAULT_PERMISSIONS (and the shared PERMISSION_GRANTS registry) may legitimately
   // be a superset, defining permissions no system role grants yet (e.g.
-  // time_entries:*, automations:* live in the registry but aren't seeded because
-  // no system role references them). A registry/seed superset is fine; an
-  // unseeded role grant is the bug.
+  // automations:* lives in the registry but isn't seeded because no system role
+  // references it). A registry/seed superset is fine; an unseeded role grant is
+  // the bug. time_entries:* used to be the example here; #4251 moved it into
+  // DEFAULT_PERMISSIONS when Partner Technician started granting it.
   const seededKeys = new Set(
     DEFAULT_PERMISSIONS.map((p) => `${p.resource}:${p.action}`),
   );
@@ -296,5 +297,40 @@ describe('topology:write permission (issue #1728)', () => {
   it('Partner Admin covers topology via the wildcard grant', () => {
     const role = SYSTEM_ROLES.find((r) => r.name === 'Partner Admin');
     expect(role?.permissions).toContain('*:*');
+  });
+});
+
+describe('technician ticket + time-entry RBAC (#4251)', () => {
+  // #3206 shipped a mobile start/stop timer whose routes require
+  // time_entries:write. The seeded technician roles held tickets:read only, so
+  // the only grant path (2026-06-12-a-ticketing-time-parts.sql, which
+  // propagates time_entries:* off the matching tickets:* perm) gave them
+  // time_entries:read and nothing else: the timesheet renders, start/stop 403s.
+  // These assertions pin the fix so a later trim of the role can't silently
+  // re-break the timer.
+  const byName = (name: string) => SYSTEM_ROLES.find((r) => r.name === name);
+
+  it('Partner Technician can update a ticket and log time against it', () => {
+    expect(byName('Partner Technician')?.permissions).toEqual(
+      expect.arrayContaining(['tickets:read', 'tickets:write', 'time_entries:read', 'time_entries:write']),
+    );
+  });
+
+  it('Partner Technician does NOT gain tickets:manage', () => {
+    // tickets:manage reassigns ticket organization and edits any author's
+    // comment — an admin action, deliberately still withheld.
+    expect(byName('Partner Technician')?.permissions).not.toContain('tickets:manage');
+  });
+
+  it('Partner Viewer stays read-only on tickets and time entries', () => {
+    const perms = byName('Partner Viewer')?.permissions ?? [];
+    expect(perms).not.toContain('tickets:write');
+    expect(perms).not.toContain('time_entries:write');
+  });
+
+  it('time_entries:read/write are seeded, or seedRoles silently drops the grant', () => {
+    const seeded = new Set(DEFAULT_PERMISSIONS.map((p) => `${p.resource}:${p.action}`));
+    expect(seeded.has('time_entries:read')).toBe(true);
+    expect(seeded.has('time_entries:write')).toBe(true);
   });
 });

--- a/apps/api/src/db/seed.ts
+++ b/apps/api/src/db/seed.ts
@@ -101,9 +101,10 @@ export function resolveBootstrapAdminConfig(
 // asserts every resource:action referenced by SYSTEM_ROLES below exists here.
 // This is intentionally a subset of PERMISSION_GRANTS (the shared registry):
 // the registry may define permissions no system role grants yet (e.g.
-// time_entries:*, automations:*) without those needing a seeded row — only
-// permissions a system role actually references must be seeded, or seedRoles
-// silently drops the grant.
+// automations:*) without those needing a seeded row — only permissions a
+// system role actually references must be seeded, or seedRoles silently drops
+// the grant. time_entries:* moved INTO this list with #4251, when the
+// technician roles started granting them.
 export const DEFAULT_PERMISSIONS = [
   // Backup / recovery
   { resource: 'backup', action: 'read', description: 'View backup and recovery resources' },
@@ -141,6 +142,12 @@ export const DEFAULT_PERMISSIONS = [
   { resource: 'tickets', action: 'read', description: 'View tickets, comments, and categories' },
   { resource: 'tickets', action: 'write', description: 'Create and update tickets, comments, and categories' },
   { resource: 'tickets', action: 'manage', description: 'Edit or delete any comment and reassign ticket organization' },
+
+  // Time entries (#4251). Seeded because Partner Technician grants them: the
+  // mobile start/stop timer (#3206 W05) calls routes gated on
+  // time_entries:write, and an unseeded grant is dropped silently by seedRoles.
+  { resource: 'time_entries', action: 'read', description: 'View time entries and timesheets' },
+  { resource: 'time_entries', action: 'write', description: 'Log and edit time entries' },
 
   // Microsoft 365 partner-global ticket mailbox administration
   { resource: 'ticket_mailbox', action: 'read', description: 'View Microsoft 365 ticket mailbox connection status' },
@@ -239,7 +246,11 @@ export const SYSTEM_ROLES = [
       'devices:read', 'devices:execute',
       'scripts:read', 'scripts:execute',
       'alerts:read', 'alerts:acknowledge',
-      'tickets:read',
+      // #4251: a technician works tickets — comments, status, assignment — and
+      // logs time against them from the mobile timer (#3206 W05). tickets:manage
+      // (reassign org, edit any author's comment) stays an admin action.
+      'tickets:read', 'tickets:write',
+      'time_entries:read', 'time_entries:write',
       'ticket_mailbox:read',
       'reports:read', 'reports:write',
       'sites:read',


### PR DESCRIPTION
## Problem

#3206 W05 put a start/stop timer on the mobile ticket detail screen. It 403s for the default **Partner Technician**.

**Verified** — the role holds `tickets:read` and no ticket write perm (`apps/api/src/db/seed.ts`, `SYSTEM_ROLES`).

**Verified** — the only grant path for time entries is `apps/api/migrations/2026-06-12-a-ticketing-time-parts.sql:114-134`, which propagates each `time_entries` perm off the **matching** `tickets` perm: `time_entries:read` to every role holding `tickets:read`, `time_entries:write` to every role holding `tickets:write`. A technician with `tickets:read` only therefore received `time_entries:read` and never `time_entries:write` — the timesheet renders, start/stop fails.

## Fix

Grant `tickets:write` + `time_entries:read` + `time_entries:write` to Partner Technician:

- **`seed.ts`** — fixes fresh installs.
- **`2026-09-27-technician-ticket-write-permissions.sql`** — fixes existing ones.

`time_entries:read/write` also move into `DEFAULT_PERMISSIONS`. `seedRoles` resolves each role permission against a map built from that list and drops a miss with a `console.warn`, so a `SYSTEM_ROLES` grant without a seeded permission row is a silent no-op. The `SYSTEM_ROLES ⊆ DEFAULT_PERMISSIONS` contract test is what surfaced this — it went red first, then green.

## Scope — what is deliberately NOT granted

- **`tickets:manage`** stays admin-only (reassigns ticket organization; edits any author's comment).
- The migration touches only `is_system` roles literally named `'Partner Technician'`. A partner-authored custom role with the same name is theirs to define.
- Every Viewer role is untouched.

## Worth knowing before merging

`tickets:write` also gates ticket **configuration** surfaces — categories, forms, response templates, `ticketConfig`. Those routes carry an additional `canManagePartnerWidePolicies` guard (partner scope + `org_access='all'`), so a technician with restricted org access still cannot reach them; a technician with full org access now can. That is a real widening beyond the timer, and it is the price of the existing permission granularity — there is no separate `tickets:configure`.

`tickets/moveOrg.ts` additionally requires `organizations:write` + MFA, which Partner Technician does not hold. Still blocked.

## Verification

**Verified** — migration replayed against Postgres 16 on a fixture holding two seeded Partner Technician rows, one custom (`is_system=false`) role of the same name, and a Partner Viewer:

```
FIRST APPLY   granted tickets:write to 2 role(s)
              granted time_entries:read to 0 role(s)   (already held)
              granted time_entries:write to 2 role(s)
              backfill: 4 role_permission row(s) inserted
SECOND APPLY  backfill: 0 role_permission row(s) inserted
```

Post-state: both seeded technicians hold `tickets:read, tickets:write, time_entries:read, time_entries:write`; the custom role and the viewer are unchanged.

**Verified** — `seed.test.ts` (148 tests), `mcpServer.test.ts`, `autoMigrate.test.ts` (63 tests), `check-migration-naming.sh` all pass.

**Not-checked** — the actual `role_permissions` state on the EU/US production databases. The migration is a `NOT EXISTS`-guarded insert, so it is safe whatever it finds, but the real row counts are unknown until it runs.

## Out of scope

Blocker 2 in #4251 — `manage_tickets` has no `TOOL_TIERS` entry, so the AI "log 45 minutes to ticket X" path is dead on web and mobile alike — is untouched here. It is one instance of #3300 (86 of 217 registered AI tools are untiered) and needs that fix, not this one.

**Org Technician has the identical gap** (`tickets:read` only) and is deliberately left out: the decision that authorised this change named Partner Technician. Say the word and it is a two-line follow-up.

Closes #4251

🤖 Generated with [Claude Code](https://claude.com/claude-code)