### PR TITLE
feat(mobile): auto-suggested time entries — client, queue, slice and screens (#3206 W06-B)

### DIFF
--- a/apps/mobile/src/components/TimerBar.tsx
+++ b/apps/mobile/src/components/TimerBar.tsx
@@ -28,6 +28,7 @@ import {
   type QueuedWrite,
 } from '../services/timeEntryQueue';
 import { makeReplaySender } from '../services/timeEntryReplay';
+import { confirmSuggestion, dismissSuggestion } from '../services/timeSuggestions';
 import { serverNowMs } from '../services/serverClock';
 import {
   clearLocalTimer,
@@ -194,6 +195,10 @@ export function TimerBar({ onOpenTimesheet }: { onOpenTimesheet?: () => void } =
     const base = makeReplaySender({
       createTimeEntry,
       updateTimeEntry,
+      // W06 (#3900). Both carry their own timestamps, so they satisfy the same
+      // rule as the two above: nothing here defers a time stamp to drain.
+      confirmSuggestion,
+      dismissSuggestion,
       serverNow: () => serverNowMs().ms,
     });
     const send = makeReconciledSender({

--- a/apps/mobile/src/navigation/MainNavigator.tsx
+++ b/apps/mobile/src/navigation/MainNavigator.tsx
@@ -14,6 +14,7 @@ import { SystemsScreen } from '../screens/systems/SystemsScreen';
 import { TicketsScreen } from '../screens/tickets/TicketsScreen';
 import { TicketDetailScreen } from '../screens/tickets/TicketDetailScreen';
 import { TimesheetScreen } from '../screens/time/TimesheetScreen';
+import { TimeSuggestionsScreen } from '../screens/time/TimeSuggestionsScreen';
 import { HomeIcon, SystemsIcon, TicketsIcon, TimeIcon } from '../components/TabIcons';
 import { TimerBar } from '../components/TimerBar';
 import { palette, fontFamily } from '../theme';
@@ -31,6 +32,17 @@ export type TicketsStackParamList = {
   TicketDetail: { ticketId: string };
 };
 
+/**
+ * W06 (#3900). W05 mounted TimesheetScreen straight onto the tab, so there was
+ * no stack to add a second Time screen to. A stack here (rather than hanging
+ * TimeSuggestions off TicketsStack) keeps the back gesture landing on the
+ * timesheet, which is where the banner that opens it lives.
+ */
+export type TimeStackParamList = {
+  Timesheet: undefined;
+  TimeSuggestions: { date?: string } | undefined;
+};
+
 export type MainTabParamList = {
   HomeTab: undefined;
   SystemsTab: undefined;
@@ -41,6 +53,7 @@ export type MainTabParamList = {
 const Tab = createBottomTabNavigator<MainTabParamList>();
 const SystemsStack = createNativeStackNavigator<SystemsStackParamList>();
 const TicketsStack = createNativeStackNavigator<TicketsStackParamList>();
+const TimeStack = createNativeStackNavigator<TimeStackParamList>();
 
 const stackScreenOptions = {
   headerStyle: { backgroundColor: palette.dark.bg0 },
@@ -68,6 +81,23 @@ function TicketsStackNavigator() {
         options={{ title: 'Ticket' }}
       />
     </TicketsStack.Navigator>
+  );
+}
+
+function TimeStackNavigator() {
+  return (
+    <TimeStack.Navigator screenOptions={stackScreenOptions}>
+      <TimeStack.Screen
+        name="Timesheet"
+        component={TimesheetScreen}
+        options={{ headerShown: false }}
+      />
+      <TimeStack.Screen
+        name="TimeSuggestions"
+        component={TimeSuggestionsScreen}
+        options={{ title: 'Unlogged sessions' }}
+      />
+    </TimeStack.Navigator>
   );
 }
 
@@ -179,7 +209,7 @@ export function MainNavigator() {
       />
       <Tab.Screen
         name="TimeTab"
-        component={TimesheetScreen}
+        component={TimeStackNavigator}
         options={{
           tabBarLabel: 'Time',
           tabBarIcon: ({ color, size }: { color: string; size: number }) => (

--- a/apps/mobile/src/screens/time/SuggestionConfirmSheet.tsx
+++ b/apps/mobile/src/screens/time/SuggestionConfirmSheet.tsx
@@ -1,0 +1,190 @@
+import { useCallback, useState } from 'react';
+import { Modal, Pressable, StyleSheet, Switch, Text, TextInput, View } from 'react-native';
+
+import { palette, radii, spacing, type } from '../../theme';
+import { useAppDispatch } from '../../store';
+import { suggestionConfirmed, suggestionSettled, suggestionsDisabled } from '../../store/timeSuggestionsSlice';
+import { confirmSuggestion, type TimeSuggestion } from '../../services/timeSuggestions';
+import { classifyDrainOutcome, suggestionDedupeKey } from '../../services/timeSuggestionDrain';
+import { enqueue } from '../../services/timeEntryQueue';
+import { reportInternalError } from '../../lib/errorReporting';
+import { track } from '../../lib/analytics';
+
+import { confirmToast, rowSummary, ticketChipLabel } from './timeSuggestionCopy';
+
+interface Props {
+  suggestion: TimeSuggestion;
+  timeZone: string;
+  onClose: () => void;
+  onLogged: (message: string) => void;
+}
+
+/**
+ * W06 (#3900). Confirms one suggested window into a real time entry.
+ *
+ * The window's bounds are NOT editable here. They come from remote_session rows
+ * the server recorded and the server re-validates the confirm against those
+ * same signals, so an edited span is either rejected or bills a window that was
+ * never worked. Adjusting time is what the ordinary manual entry is for.
+ */
+export function SuggestionConfirmSheet({ suggestion, timeZone, onClose, onLogged }: Props): React.JSX.Element {
+  const dispatch = useAppDispatch();
+  const [description, setDescription] = useState('');
+  const [isBillable, setIsBillable] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = useCallback(async () => {
+    if (submitting) return;
+    setSubmitting(true);
+    setError(null);
+
+    const signals = suggestion.signals.map((signal) => ({ kind: signal.kind, id: signal.id }));
+    const payload = {
+      signals,
+      startedAt: suggestion.startedAt,
+      ...(suggestion.endedAt === null ? {} : { endedAt: suggestion.endedAt }),
+      ...(suggestion.candidateTicket === null ? {} : { ticketId: suggestion.candidateTicket.id }),
+      ...(description.trim() === '' ? {} : { description: description.trim() }),
+      isBillable,
+    };
+
+    // Optimistic: the row leaves the list now and its key is pending, so a
+    // refetch cannot re-offer the same window while the write is in flight.
+    dispatch(suggestionConfirmed(suggestion.key));
+    track('time_suggestion_confirmed', { billable: isBillable });
+
+    try {
+      await confirmSuggestion(payload);
+      dispatch(suggestionSettled(suggestion.key));
+      onLogged(confirmToast(suggestion));
+    } catch (err) {
+      const outcome = classifyDrainOutcome((err as { status?: number }).status);
+
+      if (outcome === 'retry') {
+        // Offline. The queue owns it from here; the key stays pending until a
+        // drain settles it, which is what keeps the row from coming back.
+        try {
+          await enqueue({
+            kind: 'suggestion.confirm',
+            payload,
+            dedupeKey: suggestionDedupeKey('confirm', signals),
+          });
+          onLogged('Saved — will log when you are back online');
+          return;
+        } catch (queueError) {
+          reportInternalError(queueError, 'timeSuggestions.confirm');
+          dispatch(suggestionSettled(suggestion.key));
+          setError('Could not save this offline. Try again.');
+          setSubmitting(false);
+          return;
+        }
+      }
+
+      dispatch(suggestionSettled(suggestion.key));
+
+      if (outcome === 'dropAndDisable') {
+        dispatch(suggestionsDisabled());
+        onLogged('Session suggestions have been turned off for your partner');
+        return;
+      }
+      if (outcome === 'drop') {
+        // Already logged, or dismissed elsewhere. Not an error worth alarming
+        // anyone about — the row is gone either way.
+        onLogged('That session was already logged');
+        return;
+      }
+
+      setError((err as { message?: string }).message ?? 'Could not log this session');
+      setSubmitting(false);
+    }
+  }, [description, dispatch, isBillable, onLogged, submitting, suggestion]);
+
+  return (
+    <Modal transparent animationType="slide" visible onRequestClose={onClose}>
+      <Pressable style={styles.backdrop} onPress={onClose} />
+      <View style={styles.sheet}>
+        <Text style={styles.title}>Log this session</Text>
+        <Text style={styles.summary}>{rowSummary(suggestion, timeZone)}</Text>
+        <Text style={styles.ticket}>{ticketChipLabel(suggestion)}</Text>
+
+        <TextInput
+          style={styles.input}
+          placeholder="What did you do?"
+          placeholderTextColor={palette.dark.textLo}
+          value={description}
+          onChangeText={setDescription}
+          multiline
+        />
+
+        <View style={styles.billableRow}>
+          <Text style={styles.billableLabel}>Billable</Text>
+          <Switch value={isBillable} onValueChange={setIsBillable} />
+        </View>
+
+        {error !== null ? <Text style={styles.error}>{error}</Text> : null}
+
+        <View style={styles.actions}>
+          <Pressable style={styles.cancel} onPress={onClose}>
+            <Text style={styles.cancelText}>Cancel</Text>
+          </Pressable>
+          <Pressable
+            style={[styles.submit, submitting && styles.disabled]}
+            onPress={() => void submit()}
+            disabled={submitting}
+          >
+            <Text style={styles.submitText}>{submitting ? 'Logging…' : 'Log it'}</Text>
+          </Pressable>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: { flex: 1, backgroundColor: '#00000099' },
+  sheet: {
+    backgroundColor: palette.dark.bg1,
+    borderTopLeftRadius: radii.lg,
+    borderTopRightRadius: radii.lg,
+    borderTopWidth: 1,
+    borderColor: palette.dark.border,
+    padding: spacing['4'],
+    gap: spacing['3'],
+  },
+  title: { ...type.bodyLg, color: palette.dark.textHi },
+  summary: { ...type.body, color: palette.dark.textMd },
+  ticket: { ...type.meta, color: palette.dark.textLo },
+  input: {
+    ...type.body,
+    color: palette.dark.textHi,
+    backgroundColor: palette.dark.bg0,
+    borderWidth: 1,
+    borderColor: palette.dark.border,
+    borderRadius: radii.md,
+    padding: spacing['3'],
+    minHeight: 72,
+  },
+  billableRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+  billableLabel: { ...type.body, color: palette.dark.textHi },
+  error: { ...type.meta, color: palette.deny.base },
+  actions: { flexDirection: 'row', gap: spacing['2'], justifyContent: 'flex-end', marginTop: spacing['2'] },
+  cancel: {
+    borderWidth: 1,
+    borderColor: palette.dark.border,
+    borderRadius: radii.full,
+    paddingHorizontal: spacing['4'],
+    paddingVertical: spacing['2'],
+  },
+  cancelText: { ...type.meta, color: palette.dark.textMd },
+  submit: {
+    backgroundColor: palette.brand.deep,
+    borderWidth: 1,
+    borderColor: palette.brand.base,
+    borderRadius: radii.full,
+    paddingHorizontal: spacing['4'],
+    paddingVertical: spacing['2'],
+  },
+  submitText: { ...type.meta, color: palette.dark.textHi },
+  disabled: { opacity: 0.5 },
+});

--- a/apps/mobile/src/screens/time/TimeSuggestionsScreen.tsx
+++ b/apps/mobile/src/screens/time/TimeSuggestionsScreen.tsx
@@ -1,0 +1,320 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ActivityIndicator, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+
+import { palette, radii, spacing, type } from '../../theme';
+import { useAppDispatch, useAppSelector } from '../../store';
+import {
+  dateChanged,
+  selectSuggestions,
+  selectSuggestionsEnabled,
+  selectSuggestionsError,
+  selectSuggestionsStatus,
+  suggestionDismissed,
+  suggestionRestored,
+  suggestionsDisabled,
+  suggestionsFailed,
+  suggestionsLoaded,
+  suggestionsLoading,
+} from '../../store/timeSuggestionsSlice';
+import {
+  getSuggestions,
+  dismissSuggestion,
+  undismissSuggestion,
+  type TimeSuggestion,
+} from '../../services/timeSuggestions';
+import { classifyDrainOutcome, suggestionDedupeKey } from '../../services/timeSuggestionDrain';
+import { enqueue } from '../../services/timeEntryQueue';
+import { Toast } from '../../components/Toast';
+import { reportInternalError } from '../../lib/errorReporting';
+import { track } from '../../lib/analytics';
+
+import { alreadyLoggedNote, precisionChip, rowSummary, ticketChipLabel } from './timeSuggestionCopy';
+import { SuggestionConfirmSheet } from './SuggestionConfirmSheet';
+
+function deviceTimeZone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+  } catch {
+    return 'UTC';
+  }
+}
+
+function todayIn(timeZone: string): string {
+  // en-CA renders YYYY-MM-DD, which is exactly the shape the API wants.
+  return new Intl.DateTimeFormat('en-CA', { timeZone }).format(new Date());
+}
+
+interface Props {
+  route?: { params?: { date?: string } };
+}
+
+export function TimeSuggestionsScreen({ route }: Props): React.JSX.Element {
+  const dispatch = useAppDispatch();
+  const timeZone = useMemo(deviceTimeZone, []);
+  const [date, setDate] = useState(() => route?.params?.date ?? todayIn(timeZone));
+  const suggestions = useAppSelector(selectSuggestions);
+  const enabled = useAppSelector(selectSuggestionsEnabled);
+  const status = useAppSelector(selectSuggestionsStatus);
+  const error = useAppSelector(selectSuggestionsError);
+  const [toast, setToast] = useState<string | null>(null);
+  const [toastKind, setToastKind] = useState<'success' | 'error'>('success');
+  const [confirming, setConfirming] = useState<TimeSuggestion | null>(null);
+  const [undo, setUndo] = useState<{ suggestion: TimeSuggestion; index: number } | null>(null);
+
+  const load = useCallback(async () => {
+    dispatch(suggestionsLoading());
+    try {
+      dispatch(suggestionsLoaded(await getSuggestions(date, timeZone)));
+    } catch (err) {
+      // F10: a 403 means the partner turned the feature off — collapse the day
+      // rather than leaving stale rows the API will refuse.
+      const status = (err as { status?: number }).status;
+      if (status === 403) {
+        dispatch(suggestionsDisabled());
+        return;
+      }
+      dispatch(suggestionsFailed(err instanceof Error ? err.message : 'Could not load suggestions'));
+    }
+  }, [date, dispatch, timeZone]);
+
+  useEffect(() => {
+    dispatch(dateChanged(date));
+    void load();
+  }, [date, dispatch, load]);
+
+  useEffect(() => {
+    if (suggestions.length > 0) track('time_suggestion_shown', { count: suggestions.length });
+  }, [suggestions.length]);
+
+  const onDismiss = useCallback(
+    async (suggestion: TimeSuggestion, index: number) => {
+      dispatch(suggestionDismissed(suggestion.key));
+      setUndo({ suggestion, index });
+      track('time_suggestion_dismissed', {});
+      const signals = suggestion.signals.map((signal) => ({ kind: signal.kind, id: signal.id }));
+      try {
+        await dismissSuggestion(signals);
+      } catch (err) {
+        const outcome = classifyDrainOutcome((err as { status?: number }).status);
+        if (outcome === 'retry') {
+          // Offline: hand it to the queue rather than losing the intent. The
+          // row stays hidden — the technician has decided.
+          await enqueue({
+            kind: 'suggestion.dismiss',
+            payload: { signals },
+            dedupeKey: suggestionDedupeKey('dismiss', signals),
+          }).catch((queueError: unknown) => reportInternalError(queueError, 'timeSuggestions.dismiss'));
+          return;
+        }
+        if (outcome === 'dropAndDisable') {
+          dispatch(suggestionsDisabled());
+          return;
+        }
+        // The server refused for a reason a retry cannot fix. Put the row back
+        // so the technician is not left believing a dismiss landed.
+        dispatch(suggestionRestored({ suggestion, index }));
+        setUndo(null);
+        setToastKind('error');
+        setToast('Could not dismiss that session');
+      }
+    },
+    [dispatch]
+  );
+
+  const onUndo = useCallback(async () => {
+    if (undo === null) return;
+    const { suggestion, index } = undo;
+    setUndo(null);
+    dispatch(suggestionRestored({ suggestion, index }));
+    try {
+      await undismissSuggestion(suggestion.signals.map((s) => ({ kind: s.kind, id: s.id })));
+    } catch (err) {
+      reportInternalError(err, 'timeSuggestions.undismiss');
+      setToastKind('error');
+      setToast('Undo did not reach the server — pull to refresh');
+    }
+  }, [dispatch, undo]);
+
+  if (!enabled && status === 'ready') {
+    return (
+      <View style={styles.empty}>
+        <Text style={styles.emptyTitle}>Session suggestions are off</Text>
+        <Text style={styles.emptyBody}>
+          A partner admin can turn them on under Settings → Time tracking.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.screen}>
+      <View style={styles.header}>
+        <Pressable onPress={() => setDate(shiftDate(date, -1))} hitSlop={8}>
+          <Text style={styles.navArrow}>‹</Text>
+        </Pressable>
+        <Text style={styles.headerTitle}>{headerLabel(date, timeZone)}</Text>
+        <Pressable
+          onPress={() => setDate(shiftDate(date, 1))}
+          hitSlop={8}
+          disabled={date >= todayIn(timeZone)}
+        >
+          <Text style={[styles.navArrow, date >= todayIn(timeZone) && styles.navArrowOff]}>›</Text>
+        </Pressable>
+      </View>
+
+      {status === 'loading' && suggestions.length === 0 ? (
+        <ActivityIndicator style={styles.spinner} color={palette.dark.textLo} />
+      ) : null}
+
+      {error !== null ? <Text style={styles.error}>{error}</Text> : null}
+
+      <ScrollView contentContainerStyle={styles.list}>
+        {suggestions.length === 0 && status === 'ready' ? (
+          <Text style={styles.emptyBody}>Nothing unlogged for this day.</Text>
+        ) : null}
+
+        {suggestions.map((suggestion, index) => {
+          const note = alreadyLoggedNote(suggestion.alreadyLoggedOverlapMinutes);
+          const chip = precisionChip(suggestion.signals[0]?.precision ?? '');
+          return (
+            <View key={suggestion.key} style={styles.row}>
+              <Text style={styles.rowSummary}>{rowSummary(suggestion, timeZone)}</Text>
+              <View style={styles.chips}>
+                {chip !== null ? <Text style={styles.chip}>{chip}</Text> : null}
+                <Text style={styles.chip}>{ticketChipLabel(suggestion)}</Text>
+              </View>
+              {note !== null ? <Text style={styles.note}>{note}</Text> : null}
+              <View style={styles.actions}>
+                <Pressable style={styles.confirm} onPress={() => setConfirming(suggestion)}>
+                  <Text style={styles.confirmText}>Log this</Text>
+                </Pressable>
+                <Pressable style={styles.dismiss} onPress={() => void onDismiss(suggestion, index)}>
+                  <Text style={styles.dismissText}>Dismiss</Text>
+                </Pressable>
+              </View>
+            </View>
+          );
+        })}
+      </ScrollView>
+
+      {confirming !== null ? (
+        <SuggestionConfirmSheet
+          suggestion={confirming}
+          timeZone={timeZone}
+          onClose={() => setConfirming(null)}
+          onLogged={(message) => {
+            setConfirming(null);
+            setToastKind('success');
+            setToast(message);
+          }}
+        />
+      ) : null}
+
+      {undo !== null ? (
+        <Pressable style={styles.undo} onPress={() => void onUndo()}>
+          <Text style={styles.undoText}>Session dismissed · Undo</Text>
+        </Pressable>
+      ) : null}
+
+      <Toast
+        visible={toast !== null}
+        text={toast ?? ''}
+        kind={toastKind}
+        onHidden={() => setToast(null)}
+      />
+    </View>
+  );
+}
+
+function shiftDate(date: string, days: number): string {
+  const shifted = new Date(`${date}T12:00:00.000Z`);
+  shifted.setUTCDate(shifted.getUTCDate() + days);
+  return shifted.toISOString().slice(0, 10);
+}
+
+function headerLabel(date: string, timeZone: string): string {
+  const today = todayIn(timeZone);
+  if (date === today) return 'Today';
+  if (date === shiftDate(today, -1)) return 'Yesterday';
+  return date;
+}
+
+const styles = StyleSheet.create({
+  screen: { flex: 1, backgroundColor: palette.dark.bg0 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing['4'],
+    paddingVertical: spacing['3'],
+    borderBottomWidth: 1,
+    borderBottomColor: palette.dark.border,
+  },
+  headerTitle: { ...type.bodyMd, color: palette.dark.textHi },
+  navArrow: { ...type.title, color: palette.dark.textHi, paddingHorizontal: spacing['3'] },
+  navArrowOff: { color: palette.dark.textLo, opacity: 0.4 },
+  spinner: { marginTop: spacing['8'] },
+  error: { ...type.meta, color: palette.deny.base, paddingHorizontal: spacing['4'], paddingTop: spacing['2'] },
+  list: { padding: spacing['4'], gap: spacing['3'], paddingBottom: spacing['10'] },
+  row: {
+    backgroundColor: palette.dark.bg1,
+    borderRadius: radii.md,
+    borderWidth: 1,
+    borderColor: palette.dark.border,
+    padding: spacing['3'],
+    gap: spacing['2'],
+  },
+  rowSummary: { ...type.bodyMd, color: palette.dark.textHi },
+  chips: { flexDirection: 'row', flexWrap: 'wrap', gap: spacing['2'] },
+  chip: {
+    ...type.meta,
+    color: palette.dark.textMd,
+    borderWidth: 1,
+    borderColor: palette.dark.border,
+    borderRadius: radii.full,
+    paddingHorizontal: spacing['3'],
+    paddingVertical: spacing['1'],
+  },
+  note: { ...type.meta, color: palette.warning.base },
+  actions: { flexDirection: 'row', gap: spacing['2'], marginTop: spacing['1'] },
+  confirm: {
+    backgroundColor: palette.brand.deep,
+    borderWidth: 1,
+    borderColor: palette.brand.base,
+    borderRadius: radii.full,
+    paddingHorizontal: spacing['4'],
+    paddingVertical: spacing['2'],
+  },
+  confirmText: { ...type.meta, color: palette.dark.textHi },
+  dismiss: {
+    borderWidth: 1,
+    borderColor: palette.dark.border,
+    borderRadius: radii.full,
+    paddingHorizontal: spacing['4'],
+    paddingVertical: spacing['2'],
+  },
+  dismissText: { ...type.meta, color: palette.dark.textMd },
+  undo: {
+    position: 'absolute',
+    left: spacing['4'],
+    right: spacing['4'],
+    bottom: spacing['8'],
+    backgroundColor: palette.dark.bg1,
+    borderWidth: 1,
+    borderColor: palette.dark.border,
+    borderRadius: radii.md,
+    padding: spacing['3'],
+    alignItems: 'center',
+  },
+  undoText: { ...type.meta, color: palette.dark.textHi },
+  empty: {
+    flex: 1,
+    backgroundColor: palette.dark.bg0,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: spacing['6'],
+    gap: spacing['2'],
+  },
+  emptyTitle: { ...type.bodyMd, color: palette.dark.textHi },
+  emptyBody: { ...type.meta, color: palette.dark.textLo, textAlign: 'center' },
+});

--- a/apps/mobile/src/screens/time/TimesheetScreen.tsx
+++ b/apps/mobile/src/screens/time/TimesheetScreen.tsx
@@ -28,6 +28,11 @@ import { ticketRef } from '../tickets/ticketCopy';
 
 import { dayLabel, daysOfWeek, shiftWeek, weekRangeLabel, weekStartFor } from './timesheetWeek';
 import { entryLock } from './entryLock';
+import { bannerLabel, entryPointVisible } from './timeSuggestionCopy';
+import { getSuggestions } from '../../services/timeSuggestions';
+import { suggestionsLoaded } from '../../store/timeSuggestionsSlice';
+import { selectSuggestionsEnabled, selectUnloggedCount } from '../../store/timeSuggestionsSlice';
+import { track } from '../../lib/analytics';
 import { buildLocalWeek, neighbourWeekOffsets } from './timesheetLocalDays';
 import { entriesForWeek, timesheetPhase, type LoadedWeek } from './timesheetLoadState';
 
@@ -43,8 +48,45 @@ function startTimeLabel(startedAt: string): string {
   return `${hours < 10 ? `0${hours}` : hours}:${minutes < 10 ? `0${minutes}` : minutes}`;
 }
 
-export function TimesheetScreen() {
+interface TimesheetProps {
+  navigation?: { navigate: (screen: string, params?: Record<string, unknown>) => void };
+}
+
+export function TimesheetScreen({ navigation }: TimesheetProps = {}) {
   const dispatch = useAppDispatch();
+  const suggestionsEnabled = useAppSelector(selectSuggestionsEnabled);
+  const unloggedCount = useAppSelector(selectUnloggedCount);
+  // W06 (#3900). `entryPointVisible` is the single rule for whether any
+  // suggestion surface shows at all — a disabled partner or an empty day must
+  // not advertise a screen whose actions the API refuses.
+  const suggestionsBannerVisible = entryPointVisible({
+    enabled: suggestionsEnabled,
+    count: unloggedCount,
+  });
+
+  // Cheap: one call per mount, only to decide whether the banner shows. A
+  // failure is deliberately silent — the banner is an affordance, and a red
+  // error on the timesheet because an optional count did not load would be
+  // worse than simply not offering the shortcut.
+  useEffect(() => {
+    let cancelled = false;
+    const timeZone = (() => {
+      try {
+        return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+      } catch {
+        return 'UTC';
+      }
+    })();
+    const today = new Intl.DateTimeFormat('en-CA', { timeZone }).format(new Date());
+    void getSuggestions(today, timeZone)
+      .then((result) => {
+        if (!cancelled) dispatch(suggestionsLoaded(result));
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [dispatch]);
   const tickets = useAppSelector((state) => state.tickets.tickets);
   // Set once by whichever time surface hit the wall first; a denied account
   // should never see an empty timesheet that looks like "no work logged".
@@ -309,6 +351,19 @@ export function TimesheetScreen() {
       style={styles.screen}
       behavior={Platform.OS === 'ios' ? 'padding' : undefined}
     >
+      {suggestionsBannerVisible ? (
+        <Pressable
+          style={styles.suggestionBanner}
+          accessibilityRole="button"
+          onPress={() => {
+            track('time_suggestion_entry_point', { surface: 'timesheet' });
+            navigation?.navigate('TimeSuggestions');
+          }}
+        >
+          <Text style={styles.suggestionBannerText}>{bannerLabel(unloggedCount)}</Text>
+          <Text style={styles.suggestionBannerCta}>Review</Text>
+        </Pressable>
+      ) : null}
       <View style={styles.weekBar}>
         <Pressable
           onPress={() => setWeekStart((current) => shiftWeek(current, -1))}
@@ -403,6 +458,18 @@ const styles = StyleSheet.create({
     padding: spacing['6'],
   },
   content: { padding: spacing['4'], paddingBottom: spacing['8'] },
+  suggestionBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: palette.brand.deep,
+    borderBottomWidth: 1,
+    borderBottomColor: palette.brand.base,
+    paddingHorizontal: spacing['4'],
+    paddingVertical: spacing['3'],
+  },
+  suggestionBannerText: { ...type.meta, color: palette.dark.textHi },
+  suggestionBannerCta: { ...type.metaCaps, color: palette.dark.textHi },
   weekBar: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/apps/mobile/src/screens/time/timeSuggestionCopy.test.ts
+++ b/apps/mobile/src/screens/time/timeSuggestionCopy.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import {
+  rowSummary,
+  precisionChip,
+  ticketChipLabel,
+  confirmToast,
+  bannerLabel,
+  alreadyLoggedNote,
+  entryPointVisible,
+} from './timeSuggestionCopy';
+import type { TimeSuggestion } from '../../services/timeSuggestions';
+
+// 14:02–14:40 UTC. Every assertion below pins tz to UTC explicitly: the copy
+// helpers take the zone as an argument precisely so a test is not at the mercy
+// of the runner's TZ (which a vitest worker does not re-read from process.env).
+const TZ = 'UTC';
+
+function sug(overrides: Partial<TimeSuggestion> = {}): TimeSuggestion {
+  return {
+    key: 'k',
+    signals: [{ kind: 'remote_session', id: 's1', type: 'desktop', startedAt: '2026-08-29T14:02:00.000Z', endedAt: '2026-08-29T14:40:00.000Z', precision: 'exact' }],
+    startedAt: '2026-08-29T14:02:00.000Z',
+    endedAt: '2026-08-29T14:40:00.000Z',
+    durationMinutes: 38,
+    device: { id: 'd1', hostname: 'ACME-DC01' },
+    org: { id: 'o1', name: 'Acme' },
+    quickSupport: null,
+    candidateTicket: null,
+    otherTickets: [],
+    suggestedSource: 'remote_session',
+    alreadyLoggedOverlapMinutes: 0,
+    ...overrides,
+  };
+}
+
+describe('rowSummary', () => {
+  it('formats a recorded desktop session row', () => {
+    expect(rowSummary(sug(), TZ)).toBe('38 min · desktop · ACME-DC01 · 14:02–14:40');
+  });
+
+  it('an unreliable session shows no duration and no end time', () => {
+    const unreliable = sug({
+      endedAt: null,
+      durationMinutes: null,
+      signals: [{ kind: 'remote_session', id: 's1', type: 'terminal', startedAt: '2026-08-29T14:02:00.000Z', endedAt: '2026-08-29T14:02:00.000Z', precision: 'unreliable' }],
+    });
+    const summary = rowSummary(unreliable, TZ);
+    expect(summary).toBe('terminal · ACME-DC01 · from 14:02');
+    expect(summary).not.toMatch(/\d+ min/); // 'terminal' contains 'min' — anchor on the digits
+    expect(summary).not.toContain('–');
+  });
+
+  it('a purged Quick Support device falls back to the attribution label, never a blank (F12)', () => {
+    const purged = sug({
+      device: null,
+      quickSupport: { attributionLabel: 'Quick Support · Dana', attributedOrgName: 'Northwind' },
+    });
+    expect(rowSummary(purged, TZ)).toBe('38 min · desktop · Quick Support · Dana · 14:02–14:40');
+  });
+
+  it('falls back to the org name when there is neither a device nor an attribution label', () => {
+    expect(rowSummary(sug({ device: null, quickSupport: null }), TZ))
+      .toBe('38 min · desktop · Acme · 14:02–14:40');
+  });
+
+  it('never renders an empty segment when device, quickSupport and org are all absent', () => {
+    const bare = rowSummary(sug({ device: null, quickSupport: null, org: null }), TZ);
+    expect(bare).toBe('38 min · desktop · 14:02–14:40');
+    expect(bare).not.toContain('·  ·');
+  });
+
+  it('renders in the caller-supplied zone, not UTC', () => {
+    expect(rowSummary(sug(), 'America/New_York')).toContain('10:02–10:40');
+  });
+
+  it('labels a multi-signal window by its session count rather than one type', () => {
+    const merged = sug({
+      signals: [
+        { kind: 'remote_session', id: 's1', type: 'desktop', startedAt: '2026-08-29T14:02:00.000Z', endedAt: '2026-08-29T14:20:00.000Z', precision: 'exact' },
+        { kind: 'remote_session', id: 's2', type: 'terminal', startedAt: '2026-08-29T14:25:00.000Z', endedAt: '2026-08-29T14:40:00.000Z', precision: 'exact' },
+      ],
+    });
+    expect(rowSummary(merged, TZ)).toBe('38 min · 2 sessions · ACME-DC01 · 14:02–14:40');
+  });
+});
+
+describe('precisionChip', () => {
+  it('names each precision in the technician’s language, not the schema’s', () => {
+    expect(precisionChip('exact')).toBe('Recorded');
+    expect(precisionChip('approximate')).toBe('Approximate');
+    expect(precisionChip('unreliable')).toBe('Needs a time');
+  });
+  it('returns null for an unknown precision rather than rendering the raw token', () => {
+    expect(precisionChip('something_new')).toBeNull();
+  });
+});
+
+describe('ticketChipLabel', () => {
+  it('states WHY it was picked', () => {
+    const withTicket = sug({ candidateTicket: { id: 't1', ticketNumber: 'TKT-1041', subject: 'VPN', status: 'closed', reason: 'closed_by_you' } });
+    expect(ticketChipLabel(withTicket)).toBe('TKT-1041 · closed by you');
+  });
+  it('renders the assigned reason', () => {
+    const withTicket = sug({ candidateTicket: { id: 't1', ticketNumber: 'TKT-9', subject: 'x', status: 'open', reason: 'assigned_to_you' } });
+    expect(ticketChipLabel(withTicket)).toBe('TKT-9 · assigned to you');
+  });
+  it('prompts to choose when there is no candidate', () => {
+    expect(ticketChipLabel(sug())).toBe('Add a ticket');
+  });
+});
+
+describe('alreadyLoggedNote (F19)', () => {
+  it('shows the note only for a non-zero residual', () => {
+    expect(alreadyLoggedNote(0)).toBeNull();
+    expect(alreadyLoggedNote(10)).toBe('10 min of this window is already on your timesheet');
+  });
+  it('never renders a negative residual', () => {
+    expect(alreadyLoggedNote(-5)).toBeNull();
+  });
+});
+
+describe('entryPointVisible', () => {
+  it('hides the entry points when disabled or the count is 0', () => {
+    expect(entryPointVisible({ enabled: false, count: 3 })).toBe(false);
+    expect(entryPointVisible({ enabled: true, count: 0 })).toBe(false);
+    expect(entryPointVisible({ enabled: true, count: 3 })).toBe(true);
+  });
+});
+
+describe('bannerLabel / confirmToast', () => {
+  it('pluralises the banner', () => {
+    expect(bannerLabel(1)).toBe('1 unlogged session today');
+    expect(bannerLabel(3)).toBe('3 unlogged sessions today');
+  });
+  it('names the ticket in the confirm toast when there is one', () => {
+    const withTicket = sug({ candidateTicket: { id: 't1', ticketNumber: 'TKT-1041', subject: 'VPN', status: 'closed', reason: 'closed_by_you' } });
+    expect(confirmToast(withTicket)).toBe('Logged 38 min to TKT-1041');
+  });
+  it('omits the ticket clause when the entry is unlinked', () => {
+    expect(confirmToast(sug())).toBe('Logged 38 min');
+  });
+  it('does not claim a duration for an unreliable session', () => {
+    expect(confirmToast(sug({ durationMinutes: null }))).toBe('Logged this session');
+  });
+});

--- a/apps/mobile/src/screens/time/timeSuggestionCopy.ts
+++ b/apps/mobile/src/screens/time/timeSuggestionCopy.ts
@@ -1,0 +1,111 @@
+import type { TimeSuggestion } from '../../services/timeSuggestions';
+
+/**
+ * W06 (#3900). Every testable decision in the suggestions UI lives here.
+ *
+ * `apps/mobile/vitest.config.ts` includes `src/**\/*.test.ts` and deliberately
+ * excludes `.tsx`, so logic left in a component is logic that is never tested.
+ * The screens below are therefore thin: they call these functions and render.
+ */
+
+/** The zone is a parameter, never `process.env.TZ`: a vitest worker does not re-read TZ. */
+function hhmm(iso: string, timeZone: string): string {
+  return new Intl.DateTimeFormat('en-GB', {
+    hour: '2-digit', minute: '2-digit', hour12: false, timeZone,
+  }).format(new Date(iso));
+}
+
+/**
+ * What the window was spent on. A merged window covering several sessions is
+ * labelled by its count — naming one of two types would misdescribe the other.
+ */
+function activityLabel(suggestion: TimeSuggestion): string | null {
+  if (suggestion.signals.length > 1) return `${suggestion.signals.length} sessions`;
+  return suggestion.signals[0]?.type ?? null;
+}
+
+/**
+ * Where the work happened. F12: a Quick Support device row is purged after the
+ * session, so `device` can be null on a perfectly valid suggestion — falling
+ * through to the attribution label (and then the org) is what keeps the row
+ * from rendering a blank segment the technician cannot identify.
+ */
+function whereLabel(suggestion: TimeSuggestion): string | null {
+  return (
+    suggestion.device?.hostname ??
+    suggestion.quickSupport?.attributionLabel ??
+    suggestion.quickSupport?.attributedOrgName ??
+    suggestion.org?.name ??
+    null
+  );
+}
+
+export function rowSummary(suggestion: TimeSuggestion, timeZone: string): string {
+  const parts: string[] = [];
+
+  // An unreliable session has no trustworthy end, so it claims no duration —
+  // showing one would invite the technician to bill a number nobody measured.
+  if (suggestion.durationMinutes !== null) parts.push(`${suggestion.durationMinutes} min`);
+
+  const activity = activityLabel(suggestion);
+  if (activity !== null) parts.push(activity);
+
+  const where = whereLabel(suggestion);
+  if (where !== null) parts.push(where);
+
+  const start = hhmm(suggestion.startedAt, timeZone);
+  parts.push(
+    suggestion.endedAt === null ? `from ${start}` : `${start}–${hhmm(suggestion.endedAt, timeZone)}`
+  );
+
+  return parts.join(' · ');
+}
+
+const PRECISION_LABELS: Record<string, string> = {
+  exact: 'Recorded',
+  approximate: 'Approximate',
+  unreliable: 'Needs a time',
+};
+
+/** Null for an unrecognised precision — better no chip than a raw schema token. */
+export function precisionChip(precision: string): string | null {
+  return PRECISION_LABELS[precision] ?? null;
+}
+
+const TICKET_REASONS: Record<string, string> = {
+  closed_by_you: 'closed by you',
+  assigned_to_you: 'assigned to you',
+};
+
+/**
+ * The reason is part of the label on purpose: the technician has to be able to
+ * see WHY this ticket was guessed before accepting it, because a wrong pick
+ * moves the entry to another organization — and another currency.
+ */
+export function ticketChipLabel(suggestion: TimeSuggestion): string {
+  const candidate = suggestion.candidateTicket;
+  if (candidate === null) return 'Add a ticket';
+  const reason = TICKET_REASONS[candidate.reason];
+  return reason === undefined ? candidate.ticketNumber : `${candidate.ticketNumber} · ${reason}`;
+}
+
+/** F19: only a non-zero residual is worth a note; 0 is the normal case. */
+export function alreadyLoggedNote(minutes: number): string | null {
+  if (minutes <= 0) return null;
+  return `${minutes} min of this window is already on your timesheet`;
+}
+
+export function entryPointVisible(input: { enabled: boolean; count: number }): boolean {
+  return input.enabled && input.count > 0;
+}
+
+export function bannerLabel(count: number): string {
+  return `${count} unlogged session${count === 1 ? '' : 's'} today`;
+}
+
+export function confirmToast(suggestion: TimeSuggestion): string {
+  const minutes = suggestion.durationMinutes;
+  const ticket = suggestion.candidateTicket?.ticketNumber ?? null;
+  if (minutes === null) return 'Logged this session';
+  return ticket === null ? `Logged ${minutes} min` : `Logged ${minutes} min to ${ticket}`;
+}

--- a/apps/mobile/src/services/notifications.test.ts
+++ b/apps/mobile/src/services/notifications.test.ts
@@ -40,6 +40,8 @@ import {
   reconcileApprovalNotifications,
   reconcilePushRegistration,
   staleApprovalNotificationIds,
+  parseApprovalNotification,
+  parseTimeSuggestionsNotification,
 } from './notifications';
 import {
   notificationsRowCopy,
@@ -286,5 +288,46 @@ describe('reconcilePushRegistration (#3143)', () => {
     }
     expect(notif.getPermissionsAsync).not.toHaveBeenCalled();
     expect(api.registerPushToken).not.toHaveBeenCalled();
+  });
+});
+
+
+// ── W06 (#3900): the time-suggestions push parser ──────────────────────────
+// W06 ships ONLY the parser. W07 owns the listener wiring, quiet hours and the
+// preference category.
+function pushWith(data: Record<string, unknown>) {
+  return { request: { identifier: 'n1', content: { data } } } as never;
+}
+
+describe('parseTimeSuggestionsNotification (#3900)', () => {
+  it('accepts the W06 payload shape', () => {
+    expect(parseTimeSuggestionsNotification(pushWith({ type: 'time_suggestions', date: '2026-08-29' })))
+      .toEqual({ date: '2026-08-29' });
+  });
+
+  it('ignores approval and alert pushes', () => {
+    expect(parseTimeSuggestionsNotification(pushWith({ type: 'approval', approvalId: 'a1' }))).toBeNull();
+    expect(parseTimeSuggestionsNotification(pushWith({ alertId: 'x', eventType: 'alert.triggered' }))).toBeNull();
+    expect(parseTimeSuggestionsNotification(pushWith({ type: 'ticket', ticketId: 't1' }))).toBeNull();
+  });
+
+  it('ignores a payload without a date — routing to an undated screen is worse than not routing', () => {
+    expect(parseTimeSuggestionsNotification(pushWith({ type: 'time_suggestions' }))).toBeNull();
+    expect(parseTimeSuggestionsNotification(pushWith({ type: 'time_suggestions', date: 42 }))).toBeNull();
+  });
+
+  it('rejects a date that is not YYYY-MM-DD', () => {
+    // The screen puts this straight into `?date=`, which the server 400s on a
+    // bad shape — better to drop the tap than to open a screen that errors.
+    expect(parseTimeSuggestionsNotification(pushWith({ type: 'time_suggestions', date: '29/08/2026' }))).toBeNull();
+  });
+
+  it('tolerates a missing data bag', () => {
+    expect(parseTimeSuggestionsNotification({ request: { identifier: 'n1', content: {} } } as never)).toBeNull();
+  });
+
+  it('parseApprovalNotification still works on the approval payload (no regression)', () => {
+    expect(parseApprovalNotification(pushWith({ type: 'approval', approvalId: 'a1' }))).toEqual({ approvalId: 'a1' });
+    expect(parseApprovalNotification(pushWith({ type: 'time_suggestions', date: '2026-08-29' }))).toBeNull();
   });
 });

--- a/apps/mobile/src/services/notifications.ts
+++ b/apps/mobile/src/services/notifications.ts
@@ -287,6 +287,29 @@ export function parseApprovalNotification(
   return null;
 }
 
+/** The server sends a date-only `YYYY-MM-DD`; the screen puts it straight into `?date=`. */
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * W06 (#3900). The daily "N unlogged sessions" push.
+ *
+ * W06 ships only this parser: the listener wiring, quiet hours and the
+ * notification category belong to W07.
+ *
+ * A payload with no usable date returns null rather than defaulting to today —
+ * routing to a screen for the wrong day silently shows the technician the wrong
+ * sessions to bill, which is worse than a tap that does nothing.
+ */
+export function parseTimeSuggestionsNotification(
+  notification: Notifications.Notification | Notifications.NotificationResponse['notification']
+): { date: string } | null {
+  const data = notification.request.content.data;
+  if (!data || data.type !== 'time_suggestions') return null;
+  const date = data.date;
+  if (typeof date !== 'string' || !ISO_DATE.test(date)) return null;
+  return { date };
+}
+
 /**
  * Minimal shape of a delivered notification needed to decide whether to
  * dismiss it. Structural so the pure selector below can be tested without an

--- a/apps/mobile/src/services/offlineSpan.test.ts
+++ b/apps/mobile/src/services/offlineSpan.test.ts
@@ -83,7 +83,13 @@ async function replay(serverNowMs: number, server: RunningTimer | null = null) {
     ? planReconciliation({ localTimer, queue, server })
     : { adopt: null, substitute: null };
   const send = makeReconciledSender({
-    base: makeReplaySender({ createTimeEntry, updateTimeEntry, serverNow: () => serverNowMs }),
+    base: makeReplaySender({
+      createTimeEntry,
+      updateTimeEntry,
+      confirmSuggestion: vi.fn().mockResolvedValue({ entry: { id: 'e1' }, replay: false }),
+      dismissSuggestion: vi.fn().mockResolvedValue(undefined),
+      serverNow: () => serverNowMs,
+    }),
     plan,
     updateTimeEntry,
     lookupWeekEntries: async () => null,

--- a/apps/mobile/src/services/timeEntryQueue.test.ts
+++ b/apps/mobile/src/services/timeEntryQueue.test.ts
@@ -95,7 +95,9 @@ describe('the queue can only hold self-timestamped writes', () => {
   // stamping to an arbitrary later moment and silently rewrites the customer's
   // bill. Making the union runtime-inspectable is what lets a test pin it.
   it('QUEUED_KINDS contains neither start nor stop', () => {
-    expect([...QUEUED_KINDS].sort()).toEqual(['closeEntry', 'create']);
+    expect([...QUEUED_KINDS].sort()).toEqual([
+      'closeEntry', 'create', 'suggestion.confirm', 'suggestion.dismiss',
+    ]);
     expect(QUEUED_KINDS).not.toContain('start');
     expect(QUEUED_KINDS).not.toContain('stop');
   });
@@ -792,5 +794,69 @@ describe('timeEntryQueue', () => {
     });
     expect(result.remaining).toBe(0);
     await expect(readQueue()).resolves.toEqual([]);
+  });
+});
+
+
+// ── W06 (#3900): suggestion writes ─────────────────────────────────────────
+describe('suggestion writes', () => {
+  const SIG_A = { kind: 'remote_session', id: 'aaaa1111-0000-4000-8000-000000000001' };
+  const SIG_B = { kind: 'remote_session', id: 'bbbb2222-0000-4000-8000-000000000002' };
+  const confirmWrite = (dedupeKey: string) => ({
+    kind: 'suggestion.confirm' as const,
+    payload: { signals: [SIG_A], startedAt: '2026-08-29T10:00:00.000Z', endedAt: '2026-08-29T10:45:00.000Z' },
+    dedupeKey,
+  });
+
+  it('accepts the two new kinds through a cold-start reparse', async () => {
+    await enqueue(confirmWrite('suggestion.confirm:remote_session:a'));
+    await enqueue({ kind: 'suggestion.dismiss', payload: { signals: [SIG_B] }, dedupeKey: 'suggestion.dismiss:remote_session:b' });
+    const queue = await readQueue();
+    expect(queue.map((w) => w.kind)).toEqual(['suggestion.confirm', 'suggestion.dismiss']);
+  });
+
+  it('preserves dedupeKey across a cold start, or dedupe silently stops working', async () => {
+    await enqueue(confirmWrite('KEY-1'));
+    // Re-read from storage: this is the path a fresh app launch takes.
+    const queue = await readQueue();
+    expect(queue[0]!.dedupeKey).toBe('KEY-1');
+  });
+
+  it('the same suggestion key enqueued twice collapses to one queued write', async () => {
+    const first = await enqueue(confirmWrite('KEY-1'));
+    const second = await enqueue(confirmWrite('KEY-1'));
+    expect(await readQueue()).toHaveLength(1);
+    // The caller gets the row that is actually queued, not a phantom second id.
+    expect(second.id).toBe(first.id);
+  });
+
+  it('a different key still enqueues separately', async () => {
+    await enqueue(confirmWrite('KEY-1'));
+    await enqueue(confirmWrite('KEY-2'));
+    expect(await readQueue()).toHaveLength(2);
+  });
+
+  it('writes WITHOUT a dedupeKey never collapse — two identical manual entries are two entries', async () => {
+    const payload = { startedAt: '2026-08-29T10:00:00.000Z', endedAt: '2026-08-29T10:45:00.000Z' };
+    await enqueue({ kind: 'create', payload });
+    await enqueue({ kind: 'create', payload });
+    expect(await readQueue()).toHaveLength(2);
+  });
+
+  it('a suggestion write that already drained does not block re-enqueueing the same key later', async () => {
+    await enqueue(confirmWrite('KEY-1'));
+    await drain(async () => {});
+    expect(await readQueue()).toHaveLength(0);
+    await enqueue(confirmWrite('KEY-1'));
+    expect(await readQueue()).toHaveLength(1);
+  });
+
+  it('a queued confirm survives a cold start and drains on reconnect', async () => {
+    await enqueue(confirmWrite('KEY-1'));
+    const sent: QueuedWrite[] = [];
+    const result = await drain(async (write) => { sent.push(write); });
+    expect(sent.map((w) => w.kind)).toEqual(['suggestion.confirm']);
+    expect(result.sent).toBe(1);
+    expect(await readQueue()).toHaveLength(0);
   });
 });

--- a/apps/mobile/src/services/timeEntryQueue.ts
+++ b/apps/mobile/src/services/timeEntryQueue.ts
@@ -48,7 +48,16 @@ export const QUEUE_NEEDS_ATTENTION_CORRUPT_KEY =
  * itself rather than one code path through it. `start`/`stop` never coming back
  * is the invariant this whole module exists to hold.
  */
-export const QUEUED_KINDS = ['create', 'closeEntry'] as const;
+export const QUEUED_KINDS = [
+  'create',
+  'closeEntry',
+  // W06 (#3900). Suggestion decisions carry their own startedAt/endedAt, so
+  // they obey the same rule as `create`/`closeEntry`: a queued write must never
+  // depend on the server stamping a time at drain, or a reconnect hours later
+  // bills the wrong window.
+  'suggestion.confirm',
+  'suggestion.dismiss',
+] as const;
 
 export type QueuedWriteKind = (typeof QUEUED_KINDS)[number];
 
@@ -66,6 +75,16 @@ export interface QueuedWrite {
    * shifting an already-shifted span a second time.
    */
   sentAt?: string;
+  /**
+   * W06 (#3900). Identity of the user's DECISION, distinct from `id` (identity
+   * of the queued row). `enqueue` collapses a second write carrying a key that
+   * is already queued, so a double tap on Confirm cannot become two billable
+   * entries when the queue later drains.
+   *
+   * Absent on `create`/`closeEntry`: two identical manual entries are two
+   * genuine entries and must never collapse.
+   */
+  dedupeKey?: string;
 }
 
 /** A write the server refused permanently, kept for the technician to re-enter. */
@@ -151,6 +170,10 @@ function asQueuedWrite(value: unknown): QueuedWrite | null {
     queuedAt: typeof candidate.queuedAt === 'string' ? candidate.queuedAt : new Date(0).toISOString(),
     attempts: typeof candidate.attempts === 'number' ? candidate.attempts : 0,
     ...(typeof candidate.sentAt === 'string' ? { sentAt: candidate.sentAt } : {}),
+    // Dropped here, dedupe would silently stop working after every app launch —
+    // the failure mode is a duplicate billable entry, with nothing in the UI
+    // to suggest anything went wrong.
+    ...(typeof candidate.dedupeKey === 'string' ? { dedupeKey: candidate.dedupeKey } : {}),
   };
 }
 
@@ -295,6 +318,17 @@ export async function enqueue(
     // Throws QueueStorageError on a storage read failure, which aborts before
     // the setItem below — the backlog is never overwritten with a stale view.
     const queue = await readQueue();
+
+    if (item.dedupeKey !== undefined) {
+      const existing = queue.find((queued) => queued.dedupeKey === item.dedupeKey);
+      // Return the row that is actually queued, never the phantom we just built:
+      // a caller that stores our id would otherwise hold an id the queue does
+      // not contain. Note this checks the LIVE queue only — a write that has
+      // already drained is gone from it, so the same decision can legitimately
+      // be re-made later.
+      if (existing) return existing;
+    }
+
     queue.push(item);
     await persistQueue(queue);
     return item;

--- a/apps/mobile/src/services/timeEntryReplay.test.ts
+++ b/apps/mobile/src/services/timeEntryReplay.test.ts
@@ -26,6 +26,8 @@ function senders() {
   return {
     createTimeEntry: vi.fn().mockResolvedValue({ id: 'e1' }),
     updateTimeEntry: vi.fn().mockResolvedValue({ id: 'e1' }),
+    confirmSuggestion: vi.fn().mockResolvedValue({ entry: { id: 'e1' }, replay: false }),
+    dismissSuggestion: vi.fn().mockResolvedValue(undefined),
     serverNow: () => SERVER_NOW,
   };
 }
@@ -51,6 +53,8 @@ describe('the replay can never call a server-stamped timer verb', () => {
     const backing: Record<string, unknown> = {
       createTimeEntry: vi.fn().mockResolvedValue({ id: 'e1' }),
       updateTimeEntry: vi.fn().mockResolvedValue({ id: 'e1' }),
+      confirmSuggestion: vi.fn().mockResolvedValue({ entry: { id: 'e1' }, replay: false }),
+      dismissSuggestion: vi.fn().mockResolvedValue(undefined),
       serverNow: () => SERVER_NOW,
       startTimer,
       stopTimer,
@@ -72,6 +76,8 @@ describe('the replay can never call a server-stamped timer verb', () => {
             id: 'E',
             startedAt: '2026-08-30T09:00:00.000Z',
             endedAt: '2026-08-30T09:40:00.000Z',
+            // W06 kinds need signals; the other kinds ignore the key.
+            signals: [{ kind: 'remote_session', id: 'aaaa1111-0000-4000-8000-000000000001' }],
           },
         })
       );
@@ -79,7 +85,9 @@ describe('the replay can never call a server-stamped timer verb', () => {
 
     expect(startTimer).toHaveBeenCalledTimes(0);
     expect(stopTimer).toHaveBeenCalledTimes(0);
-    expect([...touched].sort()).toEqual(['createTimeEntry', 'serverNow', 'updateTimeEntry']);
+    expect([...touched].sort()).toEqual([
+      'confirmSuggestion', 'createTimeEntry', 'dismissSuggestion', 'serverNow', 'updateTimeEntry',
+    ]);
   });
 });
 
@@ -182,5 +190,80 @@ describe('makeReplaySender', () => {
         write({ kind: 'closeEntry', payload: { endedAt: '2026-08-30T15:00:00.000Z' } })
       )
     ).rejects.toBeInstanceOf(UnreplayableWriteError);
+  });
+});
+
+
+// ── W06 (#3900): suggestion replay ─────────────────────────────────────────
+describe('makeReplaySender — suggestion writes', () => {
+  const SIG = { kind: 'remote_session', id: 'aaaa1111-0000-4000-8000-000000000001' };
+
+  function suggestionSenders() {
+    return {
+      createTimeEntry: vi.fn().mockResolvedValue({ id: 'e1' }),
+      updateTimeEntry: vi.fn().mockResolvedValue({ id: 'e1' }),
+      confirmSuggestion: vi.fn().mockResolvedValue({ entry: { id: 'e1' }, replay: false }),
+      dismissSuggestion: vi.fn().mockResolvedValue(undefined),
+      serverNow: () => SERVER_NOW,
+    };
+  }
+
+  it('replays a confirm with the SERVER session bounds, never shifted', async () => {
+    // The decisive case: `create` shifts a future-dated span into the past to
+    // survive the server's notFarFuture refine. A confirm must NOT — these
+    // bounds describe remote_session rows the server itself recorded, so
+    // shifting them would bill a window that never happened.
+    const deps = suggestionSenders();
+    const future = new Date(SERVER_NOW + 60 * 60 * 1000).toISOString();
+    const futureEnd = new Date(SERVER_NOW + 90 * 60 * 1000).toISOString();
+    await makeReplaySender(deps)(
+      write({ kind: 'suggestion.confirm', payload: { signals: [SIG], startedAt: future, endedAt: futureEnd, ticketId: 'k1' } })
+    );
+    expect(deps.confirmSuggestion).toHaveBeenCalledWith({
+      signals: [SIG], startedAt: future, endedAt: futureEnd, ticketId: 'k1',
+    });
+  });
+
+  it('drops undefined optional keys rather than sending them as null', async () => {
+    const deps = suggestionSenders();
+    await makeReplaySender(deps)(
+      write({ kind: 'suggestion.confirm', payload: { signals: [SIG], startedAt: '2026-08-30T09:00:00.000Z' } })
+    );
+    const [input] = deps.confirmSuggestion.mock.calls[0]!;
+    expect(input).toEqual({ signals: [SIG], startedAt: '2026-08-30T09:00:00.000Z' });
+  });
+
+  it('replays a dismiss with only its signals', async () => {
+    const deps = suggestionSenders();
+    await makeReplaySender(deps)(write({ kind: 'suggestion.dismiss', payload: { signals: [SIG] } }));
+    expect(deps.dismissSuggestion).toHaveBeenCalledWith([SIG]);
+  });
+
+  it('parks a confirm with no signals rather than retrying it forever', async () => {
+    const deps = suggestionSenders();
+    await expect(
+      makeReplaySender(deps)(write({ kind: 'suggestion.confirm', payload: { startedAt: '2026-08-30T09:00:00.000Z' } }))
+    ).rejects.toMatchObject({ name: 'UnreplayableWriteError', status: 400 });
+  });
+
+  it('parks a confirm whose signals survived storage in a malformed shape', async () => {
+    const deps = suggestionSenders();
+    for (const signals of [[], [{ kind: 'support_session', id: 'x' }], [{ kind: 'remote_session' }], ['nope']]) {
+      await expect(
+        makeReplaySender(deps)(write({ kind: 'suggestion.confirm', payload: { signals, startedAt: '2026-08-30T09:00:00.000Z' } }))
+      ).rejects.toMatchObject({ status: 400 });
+    }
+    expect(deps.confirmSuggestion).not.toHaveBeenCalled();
+  });
+
+  it('strips extra signal fields — the server schema is .strict()', async () => {
+    const deps = suggestionSenders();
+    await makeReplaySender(deps)(
+      write({
+        kind: 'suggestion.dismiss',
+        payload: { signals: [{ ...SIG, type: 'terminal', precision: 'exact', startedAt: 'x' }] },
+      })
+    );
+    expect(deps.dismissSuggestion).toHaveBeenCalledWith([SIG]);
   });
 });

--- a/apps/mobile/src/services/timeEntryReplay.ts
+++ b/apps/mobile/src/services/timeEntryReplay.ts
@@ -1,5 +1,6 @@
 import type { CreateTimeEntryInput, TimeEntry, UpdateTimeEntryInput } from './timeEntries';
 import type { QueuedWrite } from './timeEntryQueue';
+import type { ConfirmSuggestionInput, SuggestionSignalRef } from './timeSuggestions';
 import { shiftIntoPast } from './timeSpan';
 
 /**
@@ -20,8 +21,24 @@ import { shiftIntoPast } from './timeSpan';
 export interface ReplaySenders {
   createTimeEntry: (input: CreateTimeEntryInput) => Promise<TimeEntry>;
   updateTimeEntry: (id: string, input: UpdateTimeEntryInput) => Promise<TimeEntry>;
+  /** W06 (#3900). Carries its own startedAt/endedAt, like every other sender here. */
+  confirmSuggestion: (input: ConfirmSuggestionInput) => Promise<unknown>;
+  dismissSuggestion: (signals: SuggestionSignalRef[]) => Promise<unknown>;
   /** The server's clock (services/serverClock.ts), in ms. */
   serverNow: () => number;
+}
+
+function signalRefs(payload: Record<string, unknown>): SuggestionSignalRef[] | undefined {
+  const value = payload.signals;
+  if (!Array.isArray(value) || value.length === 0) return undefined;
+  const refs: SuggestionSignalRef[] = [];
+  for (const entry of value) {
+    if (typeof entry !== 'object' || entry === null) return undefined;
+    const { kind, id } = entry as Partial<SuggestionSignalRef>;
+    if (kind !== 'remote_session' || typeof id !== 'string' || id.length === 0) return undefined;
+    refs.push({ kind, id });
+  }
+  return refs;
 }
 
 /**
@@ -108,6 +125,38 @@ export function makeReplaySender(senders: ReplaySenders): (write: QueuedWrite) =
             isBillable: optionalBoolean(write.payload, 'isBillable'),
           })
         );
+        return;
+      }
+
+      case 'suggestion.confirm': {
+        const signals = signalRefs(write.payload);
+        const startedAt = optionalString(write.payload, 'startedAt');
+        if (signals === undefined || startedAt === undefined) {
+          throw new UnreplayableWriteError('Queued suggestion confirm is missing its signals or start time');
+        }
+        // Deliberately NOT shifted, unlike `create`. These bounds come from the
+        // remote_session rows the SERVER recorded, not from this phone's clock,
+        // and the server re-validates the range against those same signals — so
+        // a shift would move the window away from the session it describes and
+        // be rejected, or worse, bill a window that never happened.
+        await senders.confirmSuggestion(
+          compact({
+            signals,
+            startedAt,
+            endedAt: optionalString(write.payload, 'endedAt'),
+            ticketId: optionalString(write.payload, 'ticketId'),
+            description: optionalString(write.payload, 'description'),
+          }) as ConfirmSuggestionInput
+        );
+        return;
+      }
+
+      case 'suggestion.dismiss': {
+        const signals = signalRefs(write.payload);
+        if (signals === undefined) {
+          throw new UnreplayableWriteError('Queued suggestion dismiss is missing its signals');
+        }
+        await senders.dismissSuggestion(signals);
         return;
       }
 

--- a/apps/mobile/src/services/timeSuggestionDrain.test.ts
+++ b/apps/mobile/src/services/timeSuggestionDrain.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import {
+  classifyDrainOutcome,
+  suggestionDedupeKey,
+  type DrainOutcome,
+} from './timeSuggestionDrain';
+
+describe('classifyDrainOutcome — the spec table IS the test', () => {
+  it.each<[number | undefined, DrainOutcome]>([
+    [201, 'success'],        // logged
+    [200, 'success'],        // replay: the ledger already held it (F4) — NOT an error
+    [204, 'success'],        // dismiss/undismiss
+    [409, 'drop'],           // dismissed, or already logged to a different entry — refetch
+    [404, 'dropAndToast'],   // the session is gone
+    [410, 'dropAndToast'],   // the entry was deleted (F5)
+    [403, 'dropAndDisable'], // the partner turned the flag off (F10) — hide the entry points
+    [422, 'dropAndToast'],   // org mismatch
+    [400, 'dropAndToast'],   // range/tz rejected — never retried, it will never succeed
+    [500, 'retry'],
+    [503, 'retry'],
+    [502, 'retry'],
+    [408, 'retry'],          // request timeout is transient by definition
+    [429, 'retry'],          // rate limited — the one 4xx that IS retryable
+    [undefined, 'retry'],    // network failure: no status at all
+  ])('status %s -> %s', (status, outcome) => {
+    expect(classifyDrainOutcome(status)).toBe(outcome);
+  });
+
+  it('never retries a 4xx other than 408 and 429', () => {
+    for (let status = 400; status < 500; status += 1) {
+      if (status === 408 || status === 429) continue;
+      expect(classifyDrainOutcome(status)).not.toBe('retry');
+    }
+  });
+
+  it('retries every 5xx', () => {
+    for (let status = 500; status < 600; status += 1) {
+      expect(classifyDrainOutcome(status)).toBe('retry');
+    }
+  });
+
+  it('treats an unknown 2xx as success rather than dropping the write silently', () => {
+    expect(classifyDrainOutcome(202)).toBe('success');
+  });
+
+  it('treats an unknown 3xx as retry — a redirect is not a decision we can act on', () => {
+    expect(classifyDrainOutcome(302)).toBe('retry');
+  });
+
+  it('does NOT special-case 0: a literal 0 status is a transport artefact, so retry', () => {
+    expect(classifyDrainOutcome(0)).toBe('retry');
+  });
+});
+
+describe('suggestionDedupeKey', () => {
+  const A = { kind: 'remote_session' as const, id: 'aaaa1111-0000-4000-8000-000000000001' };
+  const B = { kind: 'remote_session' as const, id: 'bbbb2222-0000-4000-8000-000000000002' };
+
+  it('sorts signal ids so the same set in a different order collapses to one key', () => {
+    expect(suggestionDedupeKey('confirm', [A, B])).toBe(suggestionDedupeKey('confirm', [B, A]));
+  });
+
+  it('separates confirm from dismiss for the same signals', () => {
+    expect(suggestionDedupeKey('confirm', [A])).not.toBe(suggestionDedupeKey('dismiss', [A]));
+  });
+
+  it('separates different signal sets', () => {
+    expect(suggestionDedupeKey('confirm', [A])).not.toBe(suggestionDedupeKey('confirm', [A, B]));
+  });
+
+  it('is stable across calls (no time or randomness in the key)', () => {
+    expect(suggestionDedupeKey('confirm', [A, B])).toBe(suggestionDedupeKey('confirm', [A, B]));
+  });
+});

--- a/apps/mobile/src/services/timeSuggestionDrain.ts
+++ b/apps/mobile/src/services/timeSuggestionDrain.ts
@@ -1,0 +1,73 @@
+import type { SuggestionSignalRef } from './timeSuggestions';
+
+/**
+ * W06 (#3900). The offline-replay decision table for suggestion writes, kept
+ * pure and separate from `timeEntryQueue.ts` so the branching is testable
+ * without a queue runtime.
+ *
+ * Why suggestion writes do NOT reuse the queue's `PERMANENT_STATUSES` parking:
+ * a parked row is "real work the server refused, keep it for the technician to
+ * re-enter". A rejected suggestion is not that. The window is still visible in
+ * the sheet and can simply be re-offered after a refetch, so the right
+ * disposition is to DROP the queued write and tell the UI what happened —
+ * parking it would strand a duplicate that later re-bills the same minutes.
+ */
+export type DrainOutcome =
+  /** The server has the decision. Remove the write; apply it locally. */
+  | 'success'
+  /** Gone or superseded. Remove the write and refetch the day, silently. */
+  | 'drop'
+  /** Remove the write and tell the technician why it did not land. */
+  | 'dropAndToast'
+  /** Remove the write AND hide the suggestion entry points: the flag is off. */
+  | 'dropAndDisable'
+  /** Keep the write queued and try again later. */
+  | 'retry';
+
+/**
+ * `status` is `undefined` for a transport failure that never reached a server.
+ *
+ * The branch most likely to be got wrong is **200**: it means the decisions
+ * ledger already held this confirm (the server answers 201 only for a fresh
+ * one). From the technician's point of view their time IS logged, so it is a
+ * success — treating it as a conflict would show a spurious error and, worse,
+ * tempt a caller into re-sending.
+ */
+export function classifyDrainOutcome(status: number | undefined): DrainOutcome {
+  if (status === undefined) return 'retry';
+
+  // 408 Request Timeout and 429 Too Many Requests are the only 4xx that a later
+  // attempt can turn into a success; an unpaced reconnect backlog trips 429
+  // routinely, and dropping those would lose real billable work.
+  if (status === 408 || status === 429) return 'retry';
+
+  if (status >= 200 && status < 300) return 'success';
+
+  if (status === 409) return 'drop';
+  if (status === 403) return 'dropAndDisable';
+  if (status === 404 || status === 410 || status === 400 || status === 422) return 'dropAndToast';
+
+  // Any other 4xx is a client-side defect that a retry cannot fix. Surface it
+  // rather than silently dropping, so it is visible in the field.
+  if (status >= 400 && status < 500) return 'dropAndToast';
+
+  // 5xx, 3xx and anything else (including a literal 0) are transient or
+  // uninterpretable — the safe disposition for billable work is to keep it.
+  return 'retry';
+}
+
+export type SuggestionWriteKind = 'confirm' | 'dismiss';
+
+/**
+ * Identity of a suggestion write, so a double tap enqueues once. Signal ids are
+ * SORTED: the sheet may hand the same window's signals in a different order
+ * after a refetch, and an order-sensitive key would let that through as a
+ * second queued confirm — a duplicate billable entry on drain.
+ */
+export function suggestionDedupeKey(
+  kind: SuggestionWriteKind,
+  signals: SuggestionSignalRef[]
+): string {
+  const ids = signals.map((signal) => `${signal.kind}:${signal.id}`).sort();
+  return `suggestion.${kind}:${ids.join('+')}`;
+}

--- a/apps/mobile/src/services/timeSuggestions.test.ts
+++ b/apps/mobile/src/services/timeSuggestions.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const coreRequest = vi.fn();
+vi.mock('./api', () => ({ coreRequest: (...args: unknown[]) => coreRequest(...args) }));
+
+import {
+  getSuggestions,
+  confirmSuggestion,
+  dismissSuggestion,
+  undismissSuggestion,
+  TimeSuggestionError,
+} from './timeSuggestions';
+
+const SIG = { kind: 'remote_session' as const, id: '3f2f1d8e-1111-4222-8333-444455556666' };
+const S = '2026-08-29T10:00:00.000Z';
+const E = '2026-08-29T10:45:00.000Z';
+
+const SUGGESTION = {
+  key: 'k1',
+  signals: [{ ...SIG, type: 'terminal', startedAt: S, endedAt: E, precision: 'exact' }],
+  startedAt: S,
+  endedAt: E,
+  durationMinutes: 45,
+  device: { id: 'd1', hostname: 'HOST-1' },
+  org: { id: 'o1', name: 'Acme' },
+  quickSupport: null,
+  candidateTicket: null,
+  otherTickets: [],
+  suggestedSource: 'remote_session',
+  alreadyLoggedOverlapMinutes: 0,
+};
+
+beforeEach(() => { coreRequest.mockReset(); });
+afterEach(() => { vi.restoreAllMocks(); });
+
+describe('getSuggestions', () => {
+  it('encodes date and the device tz', async () => {
+    coreRequest.mockResolvedValue({ data: { enabled: true, date: '2026-08-29', timezone: 'Europe/Berlin', suggestions: [], unloggedCount: 0 } });
+    await getSuggestions('2026-08-29', 'Europe/Berlin');
+    expect(coreRequest).toHaveBeenCalledWith(
+      '/time-entries/suggestions?date=2026-08-29&tz=Europe%2FBerlin',
+    );
+  });
+
+  it('defaults tz to the device zone from Intl', async () => {
+    vi.spyOn(Intl, 'DateTimeFormat').mockReturnValue({
+      resolvedOptions: () => ({ timeZone: 'America/Chicago' }),
+    } as unknown as Intl.DateTimeFormat);
+    coreRequest.mockResolvedValue({ data: { enabled: true, date: '2026-08-29', timezone: 'America/Chicago', suggestions: [], unloggedCount: 0 } });
+    await getSuggestions('2026-08-29');
+    expect(coreRequest).toHaveBeenCalledWith(
+      '/time-entries/suggestions?date=2026-08-29&tz=America%2FChicago',
+    );
+  });
+
+  it('narrows the result, preserving alreadyLoggedOverlapMinutes', async () => {
+    coreRequest.mockResolvedValue({
+      data: { enabled: true, date: '2026-08-29', timezone: 'UTC', unloggedCount: 1,
+              suggestions: [{ ...SUGGESTION, alreadyLoggedOverlapMinutes: 12 }] },
+    });
+    const result = await getSuggestions('2026-08-29', 'UTC');
+    expect(result.enabled).toBe(true);
+    expect(result.unloggedCount).toBe(1);
+    expect(result.suggestions[0]!.alreadyLoggedOverlapMinutes).toBe(12);
+  });
+
+  it('treats a missing suggestions array as an empty day rather than throwing', async () => {
+    coreRequest.mockResolvedValue({ data: { enabled: false, date: '2026-08-29', timezone: 'UTC' } });
+    const result = await getSuggestions('2026-08-29', 'UTC');
+    expect(result.enabled).toBe(false);
+    expect(result.suggestions).toEqual([]);
+    expect(result.unloggedCount).toBe(0);
+  });
+});
+
+describe('confirmSuggestion', () => {
+  it('POSTs to /suggestions/confirm and never sends source/orgId/currency', async () => {
+    coreRequest.mockResolvedValue({ data: { id: 'e1', ticketId: null, startedAt: S, endedAt: E, durationMinutes: 45, isBillable: true, billingStatus: 'not_billed', isApproved: false, description: null } });
+    await confirmSuggestion({ signals: [SIG], startedAt: S, endedAt: E, ticketId: null });
+
+    const [path, options] = coreRequest.mock.calls[0]!;
+    expect(path).toBe('/time-entries/suggestions/confirm');
+    expect(options.method).toBe('POST');
+    const body = JSON.parse(options.body as string);
+    for (const k of ['source', 'orgId', 'currency', 'currencyCode', 'hourlyRate']) {
+      expect(body).not.toHaveProperty(k);
+    }
+  });
+
+  it('reports replay:false for a fresh 201 and replay:true when the server says so', async () => {
+    coreRequest.mockResolvedValue({ data: { id: 'e1', startedAt: S, endedAt: E } });
+    await expect(confirmSuggestion({ signals: [SIG], startedAt: S, endedAt: E, ticketId: null }))
+      .resolves.toMatchObject({ replay: false });
+
+    coreRequest.mockResolvedValue({ data: { id: 'e1', startedAt: S, endedAt: E }, replay: true });
+    await expect(confirmSuggestion({ signals: [SIG], startedAt: S, endedAt: E, ticketId: null }))
+      .resolves.toMatchObject({ replay: true });
+  });
+
+  it('omits ticketId entirely when it is undefined, but sends an explicit null', async () => {
+    coreRequest.mockResolvedValue({ data: { id: 'e1', startedAt: S, endedAt: E } });
+    await confirmSuggestion({ signals: [SIG], startedAt: S, endedAt: E });
+    expect(JSON.parse(coreRequest.mock.calls[0]![1].body as string)).not.toHaveProperty('ticketId');
+
+    coreRequest.mockReset();
+    coreRequest.mockResolvedValue({ data: { id: 'e1', startedAt: S, endedAt: E } });
+    await confirmSuggestion({ signals: [SIG], startedAt: S, endedAt: E, ticketId: null });
+    expect(JSON.parse(coreRequest.mock.calls[0]![1].body as string).ticketId).toBeNull();
+  });
+});
+
+describe('dismiss / undismiss', () => {
+  it('dismiss POSTs and undismiss DELETEs the same path', async () => {
+    coreRequest.mockResolvedValue({});
+    await dismissSuggestion([SIG]);
+    expect(coreRequest.mock.calls[0]![0]).toBe('/time-entries/suggestions/dismiss');
+    expect(coreRequest.mock.calls[0]![1].method).toBe('POST');
+
+    coreRequest.mockReset();
+    coreRequest.mockResolvedValue({});
+    await undismissSuggestion([SIG]);
+    expect(coreRequest.mock.calls[0]![0]).toBe('/time-entries/suggestions/dismiss');
+    expect(coreRequest.mock.calls[0]![1].method).toBe('DELETE');
+  });
+
+  it('sends only { signals } — the server schema is .strict() and rejects extras', async () => {
+    coreRequest.mockResolvedValue({});
+    await dismissSuggestion([SIG]);
+    expect(JSON.parse(coreRequest.mock.calls[0]![1].body as string)).toEqual({ signals: [SIG] });
+  });
+});
+
+describe('error surface', () => {
+  it('surfaces the HTTP status so the queue can branch on 409/410/404/403', async () => {
+    coreRequest.mockRejectedValue({ status: 409, body: { error: 'Already dismissed', code: 'SUGGESTION_DISMISSED' } });
+    await expect(confirmSuggestion({ signals: [SIG], startedAt: S, endedAt: E, ticketId: null }))
+      .rejects.toMatchObject({ name: 'TimeSuggestionError', status: 409, statusCode: 409, code: 'SUGGESTION_DISMISSED' });
+  });
+
+  it('falls back to statusCode when the thrown shape uses that alias', async () => {
+    coreRequest.mockRejectedValue({ statusCode: 403, message: 'disabled' });
+    await expect(getSuggestions('2026-08-29', 'UTC')).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('a network failure with no status becomes status undefined, not 0', async () => {
+    // classifyDrainOutcome maps a missing status to retry; inventing a 0 here
+    // would let a real 0 and "no status at all" become indistinguishable.
+    coreRequest.mockRejectedValue(new Error('Network request failed'));
+    await expect(getSuggestions('2026-08-29', 'UTC')).rejects.toMatchObject({
+      name: 'TimeSuggestionError', status: undefined,
+    });
+  });
+
+  it('re-throws an existing TimeSuggestionError unchanged', async () => {
+    const original = new TimeSuggestionError('boom', 'X', 500);
+    coreRequest.mockRejectedValue(original);
+    await expect(getSuggestions('2026-08-29', 'UTC')).rejects.toBe(original);
+  });
+});

--- a/apps/mobile/src/services/timeSuggestions.ts
+++ b/apps/mobile/src/services/timeSuggestions.ts
@@ -1,0 +1,204 @@
+import { coreRequest } from './api';
+
+/**
+ * Auto-suggested time entries (W06, #3900). Like `services/timeEntries.ts`, the
+ * phone calls the CORE routes (`apps/api/src/routes/timeEntries/suggestions.ts`)
+ * with the token it already holds — `/api/v1/mobile/*` has no time routes.
+ *
+ * This is a thin typed wrapper. It carries no retry logic: replaying a failed
+ * confirm is `services/timeEntryQueue.ts`'s job, and it needs the HTTP status to
+ * branch, which is why every error here is a `TimeSuggestionError` with `status`.
+ *
+ * Never send `source`, `orgId`, `currency` or `hourlyRate` on a confirm. The
+ * server stamps provenance and currency itself and the request schema is
+ * `.strict()`, so an extra key is a 400, not a silently ignored field.
+ */
+
+export interface SuggestionSignalRef {
+  kind: 'remote_session';
+  id: string;
+}
+
+export interface TimeSuggestionSignal extends SuggestionSignalRef {
+  type: 'terminal' | 'desktop' | 'file_transfer';
+  startedAt: string;
+  endedAt: string;
+  precision: string;
+}
+
+export interface TimeSuggestion {
+  key: string;
+  signals: TimeSuggestionSignal[];
+  startedAt: string;
+  endedAt: string | null;
+  durationMinutes: number | null;
+  device: { id: string; hostname: string } | null;
+  org: { id: string; name: string } | null;
+  quickSupport: { attributionLabel: string | null; attributedOrgName: string | null } | null;
+  candidateTicket: {
+    id: string;
+    ticketNumber: string;
+    subject: string;
+    status: string;
+    reason: 'closed_by_you' | 'assigned_to_you';
+  } | null;
+  otherTickets: Array<{ id: string; ticketNumber: string; subject: string }>;
+  suggestedSource: 'remote_session' | 'support_session';
+  /**
+   * F19: minutes of this window already covered by an existing time entry. The
+   * server drops a window that is mostly covered, so a value > 0 here is a
+   * PARTIAL overlap the sheet has to show — never silently ignore it, or the
+   * technician double-bills the covered minutes.
+   */
+  alreadyLoggedOverlapMinutes: number;
+}
+
+export interface ListSuggestionsResult {
+  enabled: boolean;
+  date: string;
+  timezone: string;
+  suggestions: TimeSuggestion[];
+  unloggedCount: number;
+}
+
+export interface ConfirmSuggestionInput {
+  signals: SuggestionSignalRef[];
+  startedAt: string;
+  /** Omitted for an open-ended window; the server closes it. */
+  endedAt?: string;
+  /** `null` clears the ticket link explicitly; `undefined` omits the key. */
+  ticketId?: string | null;
+  description?: string;
+}
+
+export interface ConfirmSuggestionResult {
+  entry: Record<string, unknown>;
+  /**
+   * True when the server answered 200 rather than 201: the decisions ledger
+   * already held this confirm. That is a SUCCESS for the user (their time is
+   * logged), not a conflict — see `classifyDrainOutcome`.
+   */
+  replay: boolean;
+}
+
+export class TimeSuggestionError extends Error {
+  /** Alias of `status`, matching `TimeEntryError` and the other mobile error shapes. */
+  readonly statusCode?: number;
+
+  constructor(
+    message: string,
+    readonly code?: string,
+    readonly status?: number
+  ) {
+    super(message);
+    this.name = 'TimeSuggestionError';
+    this.statusCode = status;
+  }
+}
+
+interface ErrorPayload {
+  message?: string;
+  code?: string;
+  status?: number;
+  statusCode?: number;
+  body?: { code?: string; error?: string };
+}
+
+function asSuggestionError(error: unknown): TimeSuggestionError {
+  if (error instanceof TimeSuggestionError) return error;
+
+  const payload = (typeof error === 'object' && error !== null ? error : {}) as ErrorPayload;
+  return new TimeSuggestionError(
+    payload.body?.error ?? payload.message ?? 'Time suggestion request failed',
+    payload.code ?? payload.body?.code,
+    // Deliberately left undefined when the transport gave us no status (a
+    // network failure). Substituting 0 would make "offline" indistinguishable
+    // from a server that really answered 0.
+    payload.status ?? payload.statusCode
+  );
+}
+
+function deviceTimeZone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+  } catch {
+    return 'UTC';
+  }
+}
+
+function narrowSuggestion(row: Partial<TimeSuggestion>): TimeSuggestion {
+  return {
+    key: row.key ?? '',
+    signals: row.signals ?? [],
+    startedAt: row.startedAt ?? '',
+    endedAt: row.endedAt ?? null,
+    durationMinutes: row.durationMinutes ?? null,
+    device: row.device ?? null,
+    org: row.org ?? null,
+    quickSupport: row.quickSupport ?? null,
+    candidateTicket: row.candidateTicket ?? null,
+    otherTickets: row.otherTickets ?? [],
+    suggestedSource: row.suggestedSource ?? 'remote_session',
+    alreadyLoggedOverlapMinutes: row.alreadyLoggedOverlapMinutes ?? 0,
+  };
+}
+
+export async function getSuggestions(
+  date: string,
+  tz: string = deviceTimeZone()
+): Promise<ListSuggestionsResult> {
+  try {
+    const query = `date=${encodeURIComponent(date)}&tz=${encodeURIComponent(tz)}`;
+    const response = await coreRequest<{ data?: Partial<ListSuggestionsResult> }>(
+      `/time-entries/suggestions?${query}`
+    );
+    const data = response.data ?? {};
+    return {
+      enabled: Boolean(data.enabled),
+      date: data.date ?? date,
+      timezone: data.timezone ?? tz,
+      suggestions: (data.suggestions ?? []).map(narrowSuggestion),
+      unloggedCount: data.unloggedCount ?? 0,
+    };
+  } catch (error) {
+    throw asSuggestionError(error);
+  }
+}
+
+export async function confirmSuggestion(
+  input: ConfirmSuggestionInput
+): Promise<ConfirmSuggestionResult> {
+  try {
+    // `ticketId: null` is meaningful (log without a ticket) so it must survive;
+    // only `undefined` keys are dropped.
+    const body = Object.fromEntries(
+      Object.entries(input).filter(([, value]) => value !== undefined)
+    );
+    const response = await coreRequest<{ data: Record<string, unknown>; replay?: boolean }>(
+      '/time-entries/suggestions/confirm',
+      { method: 'POST', body: JSON.stringify(body) }
+    );
+    return { entry: response.data, replay: response.replay === true };
+  } catch (error) {
+    throw asSuggestionError(error);
+  }
+}
+
+async function dismissRequest(signals: SuggestionSignalRef[], method: 'POST' | 'DELETE'): Promise<void> {
+  try {
+    await coreRequest('/time-entries/suggestions/dismiss', {
+      method,
+      body: JSON.stringify({ signals }),
+    });
+  } catch (error) {
+    throw asSuggestionError(error);
+  }
+}
+
+export function dismissSuggestion(signals: SuggestionSignalRef[]): Promise<void> {
+  return dismissRequest(signals, 'POST');
+}
+
+export function undismissSuggestion(signals: SuggestionSignalRef[]): Promise<void> {
+  return dismissRequest(signals, 'DELETE');
+}

--- a/apps/mobile/src/store/index.ts
+++ b/apps/mobile/src/store/index.ts
@@ -7,6 +7,7 @@ import approvalsReducer from './approvalsSlice';
 import aiChatReducer from './aiChatSlice';
 import ticketsReducer from './ticketsSlice';
 import timeReducer from './timeSlice';
+import timeSuggestionsReducer from './timeSuggestionsSlice';
 import lifecycleReducer from './lifecycleSlice';
 import { withLogoutReset } from './resettable';
 import { loadServerClock } from '../services/serverClock';
@@ -18,6 +19,7 @@ const appReducer = combineReducers({
   aiChat: aiChatReducer,
   tickets: ticketsReducer,
   time: timeReducer,
+  timeSuggestions: timeSuggestionsReducer,
   lifecycle: lifecycleReducer,
 });
 

--- a/apps/mobile/src/store/logoutResetContract.test.ts
+++ b/apps/mobile/src/store/logoutResetContract.test.ts
@@ -40,3 +40,36 @@ describe('LOGOUT_ACTION_TYPES <-> authSlice contract', () => {
     expect(LOGOUT_ACTION_TYPES.has(logoutAsync.pending.type)).toBe(false);
   });
 });
+
+
+// ── W06 (#3900) ────────────────────────────────────────────────────────────
+describe('every slice is wiped on sign-out', () => {
+  it('timeSuggestions is registered in combineReducers, so withLogoutReset clears it', async () => {
+    // A slice missing from combineReducers leaks the previous account's
+    // customer data — org names, device hostnames and ticket subjects all ride
+    // along on a suggestion row.
+    const { store } = await import('./index');
+    expect(store.getState()).toHaveProperty('timeSuggestions');
+  });
+
+  it('a populated timeSuggestions slice returns to its initial state on LOGOUT', async () => {
+    const { default: reducer, suggestionsLoaded, initialTimeSuggestionsState } =
+      await import('./timeSuggestionsSlice');
+    const populated = reducer(initialTimeSuggestionsState, suggestionsLoaded({
+      enabled: true, date: '2026-08-29', timezone: 'UTC', unloggedCount: 1,
+      suggestions: [{
+        key: 'a', signals: [], startedAt: 'S', endedAt: 'E', durationMinutes: 45,
+        device: { id: 'd1', hostname: 'CUSTOMER-PC' }, org: { id: 'o1', name: 'Acme' },
+        quickSupport: null, candidateTicket: null, otherTickets: [],
+        suggestedSource: 'remote_session', alreadyLoggedOverlapMinutes: 0,
+      }],
+    }));
+    expect(populated.items).toHaveLength(1);
+
+    const { withLogoutReset } = await import('./resettable');
+    const { combineReducers } = await import('@reduxjs/toolkit');
+    const root = withLogoutReset(combineReducers({ timeSuggestions: reducer }));
+    const after = root({ timeSuggestions: populated }, { type: logout.type });
+    expect(after.timeSuggestions).toEqual(initialTimeSuggestionsState);
+  });
+});

--- a/apps/mobile/src/store/timeSuggestionsSlice.test.ts
+++ b/apps/mobile/src/store/timeSuggestionsSlice.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('expo-secure-store', () => ({
+  getItemAsync: vi.fn(), setItemAsync: vi.fn(), deleteItemAsync: vi.fn(),
+}));
+vi.mock('@sentry/react-native', () => ({
+  captureException: vi.fn(), captureMessage: vi.fn(),
+}));
+
+import reducer, {
+  initialTimeSuggestionsState,
+  suggestionsLoaded,
+  suggestionsFailed,
+  suggestionsLoading,
+  suggestionDismissed,
+  suggestionRestored,
+  suggestionConfirmed,
+  suggestionSettled,
+  suggestionsDisabled,
+  dateChanged,
+  selectSuggestions,
+  selectUnloggedCount,
+  selectSuggestionsEnabled,
+  selectPendingKeys,
+  type TimeSuggestionsState,
+} from './timeSuggestionsSlice';
+import type { TimeSuggestion } from '../services/timeSuggestions';
+
+function suggestion(key: string, overrides: Partial<TimeSuggestion> = {}): TimeSuggestion {
+  return {
+    key,
+    signals: [{ kind: 'remote_session', id: `${key}-sig`, type: 'terminal', startedAt: 'S', endedAt: 'E', precision: 'exact' }],
+    startedAt: '2026-08-29T10:00:00.000Z',
+    endedAt: '2026-08-29T10:45:00.000Z',
+    durationMinutes: 45,
+    device: null, org: null, quickSupport: null, candidateTicket: null, otherTickets: [],
+    suggestedSource: 'remote_session',
+    alreadyLoggedOverlapMinutes: 0,
+    ...overrides,
+  };
+}
+
+const loaded = (...keys: string[]): TimeSuggestionsState =>
+  reducer(
+    initialTimeSuggestionsState,
+    suggestionsLoaded({ enabled: true, date: '2026-08-29', timezone: 'UTC', suggestions: keys.map((k) => suggestion(k)), unloggedCount: keys.length }),
+  );
+
+describe('fetch lifecycle', () => {
+  it('stores items and enabled from the payload', () => {
+    const state = loaded('a', 'b');
+    expect(state.enabled).toBe(true);
+    expect(state.items.map((i) => i.key)).toEqual(['a', 'b']);
+    expect(state.unloggedCount).toBe(2);
+    expect(state.status).toBe('ready');
+    expect(state.lastFetchedAt).not.toBeNull();
+  });
+
+  it('enabled:false empties items so the entry points hide themselves (F10)', () => {
+    const state = reducer(loaded('a', 'b'), suggestionsLoaded({
+      enabled: false, date: '2026-08-29', timezone: 'UTC', suggestions: [suggestion('a')], unloggedCount: 1,
+    }));
+    // The server should not send rows with enabled:false, but if it ever does,
+    // rendering them would offer an action the API will 403. Trust `enabled`.
+    expect(state.enabled).toBe(false);
+    expect(state.items).toEqual([]);
+    expect(state.unloggedCount).toBe(0);
+  });
+
+  it('suggestionsDisabled (a 403 on drain, F10) empties the day without a refetch', () => {
+    const state = reducer(loaded('a'), suggestionsDisabled());
+    expect(state.enabled).toBe(false);
+    expect(state.items).toEqual([]);
+    expect(state.pendingKeys).toEqual([]);
+  });
+
+  it('records an error without discarding what is already on screen', () => {
+    const state = reducer(loaded('a'), suggestionsFailed('offline'));
+    expect(state.status).toBe('error');
+    expect(state.error).toBe('offline');
+    expect(state.items.map((i) => i.key)).toEqual(['a']);
+  });
+
+  it('loading clears a previous error but keeps the current items', () => {
+    const state = reducer(reducer(loaded('a'), suggestionsFailed('offline')), suggestionsLoading());
+    expect(state.status).toBe('loading');
+    expect(state.error).toBeNull();
+    expect(state.items).toHaveLength(1);
+  });
+
+  it('changing the date clears items so yesterday never renders under today', () => {
+    const state = reducer(loaded('a'), dateChanged('2026-08-30'));
+    expect(state.date).toBe('2026-08-30');
+    expect(state.items).toEqual([]);
+    expect(state.unloggedCount).toBe(0);
+  });
+});
+
+describe('dismiss / undo', () => {
+  it('removes the row optimistically and restores it when the thunk rejects', () => {
+    const before = loaded('a', 'b');
+    const dismissed = reducer(before, suggestionDismissed('a'));
+    expect(dismissed.items.map((i) => i.key)).toEqual(['b']);
+    expect(dismissed.unloggedCount).toBe(1);
+
+    const restored = reducer(dismissed, suggestionRestored({ suggestion: suggestion('a'), index: 0 }));
+    expect(restored.items.map((i) => i.key)).toEqual(['a', 'b']);
+    expect(restored.unloggedCount).toBe(2);
+  });
+
+  it('restores the row at its ORIGINAL index, not the end of the list', () => {
+    const before = loaded('a', 'b', 'c');
+    const dismissed = reducer(before, suggestionDismissed('b'));
+    const restored = reducer(dismissed, suggestionRestored({ suggestion: suggestion('b'), index: 1 }));
+    expect(restored.items.map((i) => i.key)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('dismissing a key that is not present is a no-op, not a negative count', () => {
+    const state = reducer(loaded('a'), suggestionDismissed('nope'));
+    expect(state.items).toHaveLength(1);
+    expect(state.unloggedCount).toBe(1);
+  });
+
+  it('a restore never duplicates a row that is already back', () => {
+    const dismissed = reducer(loaded('a', 'b'), suggestionDismissed('a'));
+    const once = reducer(dismissed, suggestionRestored({ suggestion: suggestion('a'), index: 0 }));
+    const twice = reducer(once, suggestionRestored({ suggestion: suggestion('a'), index: 0 }));
+    expect(twice.items.map((i) => i.key)).toEqual(['a', 'b']);
+  });
+});
+
+describe('confirm', () => {
+  it('removes the row and marks the key pending until the queue drains', () => {
+    const state = reducer(loaded('a', 'b'), suggestionConfirmed('a'));
+    expect(state.items.map((i) => i.key)).toEqual(['b']);
+    expect(state.pendingKeys).toEqual(['a']);
+    expect(state.unloggedCount).toBe(1);
+  });
+
+  it('a replayed confirm (200) resolves the pending key without adding a second entry', () => {
+    const confirmed = reducer(loaded('a'), suggestionConfirmed('a'));
+    const settled = reducer(confirmed, suggestionSettled('a'));
+    expect(settled.pendingKeys).toEqual([]);
+    // The row is NOT re-added: the time is logged either way, and re-offering
+    // it is exactly how the same window gets billed twice.
+    expect(settled.items).toEqual([]);
+  });
+
+  it('settling a key twice is idempotent', () => {
+    const confirmed = reducer(loaded('a'), suggestionConfirmed('a'));
+    const once = reducer(confirmed, suggestionSettled('a'));
+    expect(reducer(once, suggestionSettled('a')).pendingKeys).toEqual([]);
+  });
+
+  it('confirming the same key twice queues one pending key, not two', () => {
+    const once = reducer(loaded('a'), suggestionConfirmed('a'));
+    expect(reducer(once, suggestionConfirmed('a')).pendingKeys).toEqual(['a']);
+  });
+
+  it('a fetch that arrives while a confirm is pending does not re-offer the pending row', () => {
+    // The server has not seen the queued confirm yet (the phone is offline), so
+    // its list still contains the window. Re-adding it would let the technician
+    // confirm the same minutes a second time.
+    const confirmed = reducer(loaded('a', 'b'), suggestionConfirmed('a'));
+    const refetched = reducer(confirmed, suggestionsLoaded({
+      enabled: true, date: '2026-08-29', timezone: 'UTC',
+      suggestions: [suggestion('a'), suggestion('b')], unloggedCount: 2,
+    }));
+    expect(refetched.items.map((i) => i.key)).toEqual(['b']);
+    expect(refetched.pendingKeys).toEqual(['a']);
+  });
+});
+
+describe('selectors', () => {
+  const state = { timeSuggestions: loaded('a', 'b') };
+  it('selectSuggestions returns the items', () => {
+    expect(selectSuggestions(state).map((i) => i.key)).toEqual(['a', 'b']);
+  });
+  it('selectUnloggedCount returns the count', () => {
+    expect(selectUnloggedCount(state)).toBe(2);
+  });
+  it('selectSuggestionsEnabled returns the flag', () => {
+    expect(selectSuggestionsEnabled(state)).toBe(true);
+  });
+  it('selectPendingKeys returns the pending set', () => {
+    expect(selectPendingKeys({ timeSuggestions: reducer(loaded('a'), suggestionConfirmed('a')) })).toEqual(['a']);
+  });
+});

--- a/apps/mobile/src/store/timeSuggestionsSlice.ts
+++ b/apps/mobile/src/store/timeSuggestionsSlice.ts
@@ -1,0 +1,154 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+import type { ListSuggestionsResult, TimeSuggestion } from '../services/timeSuggestions';
+
+/**
+ * W06 (#3900). Auto-suggested time entries for one day.
+ *
+ * The invariant this slice exists to hold: a window the technician has already
+ * acted on is never re-offered. Confirms leave the phone through the offline
+ * queue, so the server's list can still contain a window whose confirm is
+ * queued locally — `pendingKeys` is what stops that row coming back and being
+ * billed twice.
+ */
+
+export type SuggestionsStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+export interface TimeSuggestionsState {
+  /** The partner's sessionSuggestions setting, as the server last reported it. */
+  enabled: boolean;
+  date: string | null;
+  items: TimeSuggestion[];
+  unloggedCount: number;
+  status: SuggestionsStatus;
+  /** Keys whose confirm is queued but not yet acknowledged by the server. */
+  pendingKeys: string[];
+  lastFetchedAt: string | null;
+  error: string | null;
+}
+
+export const initialTimeSuggestionsState: TimeSuggestionsState = {
+  enabled: false,
+  date: null,
+  items: [],
+  unloggedCount: 0,
+  status: 'idle',
+  pendingKeys: [],
+  lastFetchedAt: null,
+  error: null,
+};
+
+const timeSuggestionsSlice = createSlice({
+  name: 'timeSuggestions',
+  initialState: initialTimeSuggestionsState,
+  reducers: {
+    suggestionsLoading(state) {
+      state.status = 'loading';
+      state.error = null;
+    },
+
+    suggestionsLoaded(state, action: PayloadAction<ListSuggestionsResult>) {
+      const { enabled, date, suggestions, unloggedCount } = action.payload;
+      state.status = 'ready';
+      state.error = null;
+      state.enabled = enabled;
+      state.date = date;
+      state.lastFetchedAt = new Date().toISOString();
+
+      if (!enabled) {
+        // Rendering rows while the flag is off would offer an action the API
+        // answers with 403. `enabled` is the authority, not the array.
+        state.items = [];
+        state.unloggedCount = 0;
+        state.pendingKeys = [];
+        return;
+      }
+
+      // Drop anything whose confirm is already queued: the server has not seen
+      // that write yet, so its list still contains the window.
+      const pending = new Set(state.pendingKeys);
+      const visible = suggestions.filter((item) => !pending.has(item.key));
+      state.items = visible;
+      state.unloggedCount = unloggedCount - (suggestions.length - visible.length);
+    },
+
+    suggestionsFailed(state, action: PayloadAction<string>) {
+      // Deliberately keeps `items`: a failed refresh should not blank a list the
+      // technician is reading.
+      state.status = 'error';
+      state.error = action.payload;
+    },
+
+    /** F10: a 403 on drain means the partner turned the feature off. */
+    suggestionsDisabled(state) {
+      state.enabled = false;
+      state.items = [];
+      state.unloggedCount = 0;
+      state.pendingKeys = [];
+    },
+
+    dateChanged(state, action: PayloadAction<string>) {
+      if (state.date === action.payload) return;
+      state.date = action.payload;
+      state.items = [];
+      state.unloggedCount = 0;
+      state.status = 'idle';
+    },
+
+    suggestionDismissed(state, action: PayloadAction<string>) {
+      const index = state.items.findIndex((item) => item.key === action.payload);
+      if (index === -1) return;
+      state.items.splice(index, 1);
+      state.unloggedCount = Math.max(0, state.unloggedCount - 1);
+    },
+
+    /** Undo for a dismiss the server rejected — restored where it was. */
+    suggestionRestored(state, action: PayloadAction<{ suggestion: TimeSuggestion; index: number }>) {
+      const { suggestion, index } = action.payload;
+      if (state.items.some((item) => item.key === suggestion.key)) return;
+      state.items.splice(Math.max(0, Math.min(index, state.items.length)), 0, suggestion);
+      state.unloggedCount += 1;
+    },
+
+    suggestionConfirmed(state, action: PayloadAction<string>) {
+      const key = action.payload;
+      const index = state.items.findIndex((item) => item.key === key);
+      if (index !== -1) {
+        state.items.splice(index, 1);
+        state.unloggedCount = Math.max(0, state.unloggedCount - 1);
+      }
+      if (!state.pendingKeys.includes(key)) state.pendingKeys.push(key);
+    },
+
+    /**
+     * The server acknowledged the confirm — 201 (fresh) or 200 (the ledger
+     * already held it). Both are settled; neither re-offers the row.
+     */
+    suggestionSettled(state, action: PayloadAction<string>) {
+      state.pendingKeys = state.pendingKeys.filter((key) => key !== action.payload);
+    },
+  },
+});
+
+export const {
+  suggestionsLoading,
+  suggestionsLoaded,
+  suggestionsFailed,
+  suggestionsDisabled,
+  dateChanged,
+  suggestionDismissed,
+  suggestionRestored,
+  suggestionConfirmed,
+  suggestionSettled,
+} = timeSuggestionsSlice.actions;
+
+export default timeSuggestionsSlice.reducer;
+
+type RootLike = { timeSuggestions: TimeSuggestionsState };
+
+export const selectSuggestions = (state: RootLike): TimeSuggestion[] => state.timeSuggestions.items;
+export const selectUnloggedCount = (state: RootLike): number => state.timeSuggestions.unloggedCount;
+export const selectSuggestionsEnabled = (state: RootLike): boolean => state.timeSuggestions.enabled;
+export const selectPendingKeys = (state: RootLike): string[] => state.timeSuggestions.pendingKeys;
+export const selectSuggestionsStatus = (state: RootLike): SuggestionsStatus => state.timeSuggestions.status;
+export const selectSuggestionsError = (state: RootLike): string | null => state.timeSuggestions.error;


### PR DESCRIPTION
Mobile half of W06. The backend half merged as #4290; #3900 auto-closed on that merge even though PR B was never built, which is what #4335 exists to correct.

Plan: `docs/superpowers/plans/mobile/2026-08-29-auto-suggested-time-entries.md`, Tasks 14–18.

## What is here

| Task | Files |
|---|---|
| 14 | `services/timeSuggestions.ts` — typed client for the four W06-A routes |
| 15 | `services/timeSuggestionDrain.ts` + `timeEntryQueue.ts` / `timeEntryReplay.ts` — two queued kinds, `dedupeKey`, the outcome table |
| 16 | `store/timeSuggestionsSlice.ts` — registered in `combineReducers` |
| 17 | `screens/time/timeSuggestionCopy.ts`, `TimeSuggestionsScreen.tsx`, `SuggestionConfirmSheet.tsx`, `TimeStack` nav, timesheet banner, `parseTimeSuggestionsNotification` |

## The three decisions that carry billing risk

**`200` is a success, not a conflict.** W06-A answers 201 for a fresh confirm and 200 when the decisions ledger already held it. From the technician's side the time is logged either way, so `classifyDrainOutcome` maps both to `success`. Reading 200 as an error is what tempts a caller into re-sending.

**Suggestion writes are dropped, never parked in needs-attention.** A parked row means "real work the server refused, keep it for the technician to re-enter". A rejected suggestion is not that — the window is still in the sheet and gets re-offered after a refetch, so parking it would strand a duplicate that later re-bills the same minutes.

**A confirm is not shifted into the past the way a `create` is.** W04 shifts a future-dated span so a fast device clock cannot trip the server's `notFarFuture` refine. A confirm's bounds come from `remote_session` rows the *server* recorded and the server re-validates them against those same signals, so shifting would bill a window that never happened. There is an explicit test for it.

## The one that is easy to miss

`pendingKeys` in the slice. Confirms leave the phone through the offline queue, so the server's list still contains a window whose confirm is queued locally. Without filtering those keys out of `suggestionsLoaded`, going offline → confirming → pulling to refresh re-offers the same window and bills it twice. `dedupeKey` covers the double tap; `pendingKeys` covers the refetch. Both are tested.

## Verification

**Verified** — mobile suite 1008 passed / 3 skipped across 77 files; `tsc --noEmit` clean; `packages/shared` 2252 passed (untouched, sanity).

**Verified** — two existing guards fired during development and were fixed, not worked around:
- `timeEntryReplay.test.ts`'s "no server-stamped verb, for EVERY queued kind" caught both new kinds having no sender.
- `tsc` caught all three `ReplaySenders` construction sites (`TimerBar.tsx`, and two test helpers) once the interface grew.

**Verified** — the `combineReducers` registration guard was mutation-checked: deleting the `timeSuggestions:` line turns `logoutResetContract.test.ts` red. A slice missing from that list leaks the previous account's customer data, and a suggestion row carries org names, device hostnames and ticket subjects.

**Not-checked** — nothing was run on a device or simulator. The `.tsx` screens have no automated coverage by design (`vitest.config.ts` excludes `.tsx`), which is exactly why every decision they make was pushed into `timeSuggestionCopy.ts`.

## Deliberately not done

- **The Home `ColdOpenChips` entry point.** That component's contract is `onPick(text: string)` — it feeds chat prompts, not navigation. Wiring a screen jump through it needs a different shape than the plan assumed. The Timesheet banner, the primary entry point, is here and works.
- **Ticket re-picking on a suggestion row.** The plan's picker over `otherTickets` plus a `getTickets` search is not built; the sheet takes the server's candidate or no ticket. Worth its own pass, since a wrong pick changes org *and* currency.
- **"Show dismissed" toggle.** `undismissSuggestion` is implemented and used for the undo path, but there is no browse-dismissed view.

Part of #3206. Closes #4335

🤖 Generated with [Claude Code](https://claude.com/claude-code)