### PR TITLE
test(web): deterministic ordering for the QuoteWorkspace superseded-GET flake

### DIFF
--- a/apps/web/src/components/billing/quotes/QuoteWorkspace.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteWorkspace.test.tsx
@@ -273,16 +273,34 @@ describe('QuoteWorkspace — an older refetch must not clobber a newer one (#351
     render(<QuoteWorkspace id="q-1" />);
     await waitFor(() => expect(screen.getByTestId('quote-add-block')).toBeInTheDocument());
 
-    // GET #2 — the terms blur-save's refresh() leading edge.
+    // GET #2 — the terms blur-save's refresh() leading edge. Awaited to its own
+    // deferred slot BEFORE the add-block interaction starts. Neither GET is
+    // issued by the fireEvent that provokes it: #2 comes from an async
+    // continuation of the terms PATCH (QuoteEditor.tsx:499, via refresh() ->
+    // resync()) and #3 from a continuation of the block POST
+    // (QuoteEditor.tsx:1436 -> finishBlockCreate -> resync()). Firing both
+    // interactions back-to-back leaves those two continuations unsynchronised,
+    // so nothing pins WHICH one lands in deferred[0] — yet every assertion
+    // below depends on deferred[0] being the older request and deferred[1] the
+    // newer one. Sequencing the provocations pins that order instead of
+    // inheriting it from whichever continuation drained first, and gives each
+    // chain its own waitFor budget rather than making them share one window.
     fireEvent.change(screen.getByTestId('quote-terms'), { target: { value: 'Net 30' } });
     fireEvent.blur(screen.getByTestId('quote-terms'));
+    await waitFor(() => expect(deferred).toHaveLength(1));
 
-    // GET #3 — the add-block resync, issued while #2 is still open.
+    // GET #3 — the add-block resync. #2 is still an unresolved promise here, so
+    // the two requests genuinely overlap, exactly as before: this only removes
+    // the ambiguity about their order, not the concurrency being tested.
     fireEvent.click(screen.getByTestId('quote-add-block-type-heading'));
     fireEvent.change(screen.getByTestId('quote-block-heading-text'), { target: { value: 'Scope of work' } });
     fireEvent.click(screen.getByTestId('quote-add-block-submit'));
+    await waitFor(() => expect(deferred).toHaveLength(2));
 
-    await waitFor(() => expect(deferred.length).toBe(2));
+    // Neither refetch has answered yet, so the canvas is still pre-mutation.
+    // Pinning that here is what stops the "block survives" assertion at the end
+    // from passing for the trivial reason that the canvas never moved at all.
+    expect(screen.getByTestId('quote-blocks-empty')).toBeInTheDocument();
 
     // The NEWER request answers first, carrying the block that was just created.
     deferred[1].resolve(json({ data: { ...draft, blocks: [newBlock] } }));


### PR DESCRIPTION
## Why

`QuoteWorkspace.test.tsx > QuoteWorkspace — an older refetch must not clobber a newer one (#3519) > drops a superseded GET that resolves last instead of rolling the canvas back` reddened **main** at `016310dc` (CI run 33464798919) with `expected 1 to be 2` at `apps/web/src/components/billing/quotes/QuoteWorkspace.test.tsx:285` — the second deferred GET never arrived inside the `waitFor` window.

It is a flake, not a regression: the test was added by #4284 (merged 2026-08-31), passed on main at `16e3ba7f`, and the diff at `016310dc` (#4334) is API-only ticket permissions and cannot touch this component. Tracked by #4339.

## Root cause (verified, not inferred)

Neither GET the test collects is issued by the `fireEvent` that provokes it. Confirmed by capturing the call stack at the mocked `fetchWithAuth`:

| GET | Issued at | Reached via |
|---|---|---|
| #2 | `apps/web/src/components/billing/quotes/QuoteEditor.tsx:499` | terms blur-save, **after** `await runAction(PATCH /quotes/:id)` resolves → `refresh()` (`QuoteEditor.tsx:474`, leading edge) → `resync()` |
| #3 | `apps/web/src/components/billing/quotes/QuoteEditor.tsx:1436` | block POST → `finishBlockCreate` (`QuoteEditor.tsx:1264`) → `resync()` |

The old test fired both interactions back-to-back with nothing between them (`QuoteWorkspace.test.tsx:277-283`), so those two promise continuations ran **unsynchronised**:

1. Nothing pinned which one landed in `deferred[0]`. Every assertion after line 285 depends on `deferred[0]` being the **older** request and `deferred[1]` the **newer** one — the whole premise of the test — but that ordering was inherited from whichever continuation happened to drain first, not enforced.
2. Both chains had to reach their GET inside a **single shared 1000 ms** `waitFor` budget.

## What changed

Test-only. The component's sequence guard (`apps/web/src/components/billing/quotes/QuoteWorkspace.tsx:118`) is **untouched**.

- Each provocation is now awaited to its own `deferred` slot: blur terms → `await waitFor(deferred).toHaveLength(1)`, then add the block → `await waitFor(deferred).toHaveLength(2)`. That pins `deferred[0]` = older / `deferred[1]` = newer, and gives each chain its own budget.
- The concurrency under test is unchanged: GET #2 is still an unresolved deferred promise at the moment GET #3 is issued, so the two genuinely overlap exactly as before.
- Added a precondition assertion that the canvas is still pre-mutation (`quote-blocks-empty` present) once both GETs are in flight — so the closing "the block survives" assertion cannot pass for the trivial reason that the canvas never moved at all.

## Verification

- **Non-vacuity:** with `if (seq < appliedSeq.current) return true;` removed from `QuoteWorkspace.tsx:118`, the rewritten test **fails**. Restored, it passes. The test still proves a superseded stale GET is dropped.
- **Stability:** 20/20 consecutive passes of the file (`npx vitest run src/components/billing/quotes/QuoteWorkspace.test.tsx --pool=threads --maxWorkers=2`).
- Full `apps/web` suite green (672 files) on this base.
- eslint clean.

Refs #4339, #4284

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTQvd5qr2a9CNSjzshsUzS