### PR TITLE
fix(deps): dedupe pnpm-lock after dependabot sweep

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8398,10 +8398,6 @@ packages:
     resolution: {integrity: sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==}
     engines: {node: '>=16.9.0'}
 
-  hono@4.13.5:
-    resolution: {integrity: sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==}
-    engines: {node: '>=16.9.0'}
-
   hosted-git-info@7.0.2:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -20504,8 +20500,6 @@ snapshots:
   hoist-non-react-statics@3.3.2:
     dependencies:
       react-is: 16.13.1
-
-  hono@4.13.5: {}
 
   hono@4.13.5: {}
 


### PR DESCRIPTION
## Problem

The 17-PR dependabot sweep (#4302–#4318) left `pnpm-lock.yaml` on `main` with a **byte-identical duplicate `hono@4.13.5` block** in both the `packages:` and `snapshots:` sections. Git's textual merge appended the duplicate rather than conflicting, so GitHub reported every PR as mergeable and each PR was green in isolation.

Result: `pnpm install --frozen-lockfile` fails with `ERR_PNPM_BROKEN_LOCKFILE: duplicated mapping key` — which is step 1 of every CI job.

This is a recurrence of the 2026-08-24 sweep incident.

## Fix

Surgical, not regenerated:
- Both duplicate blocks were asserted **byte-identical** before touching anything.
- The second copy of each was deleted (6 lines total). No other lockfile content changed.
- `pnpm install --frozen-lockfile` verified green on a clean worktree of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTQvd5qr2a9CNSjzshsUzS