### PR TITLE
fix(deps): dedupe hono@4.13.5 lockfile keys — unbreaks all CI on main

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8398,10 +8398,6 @@ packages:
     resolution: {integrity: sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==}
     engines: {node: '>=16.9.0'}
 
-  hono@4.13.5:
-    resolution: {integrity: sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==}
-    engines: {node: '>=16.9.0'}
-
   hosted-git-info@7.0.2:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -20504,8 +20500,6 @@ snapshots:
   hoist-non-react-statics@3.3.2:
     dependencies:
       react-is: 16.13.1
-
-  hono@4.13.5: {}
 
   hono@4.13.5: {}
 


### PR DESCRIPTION
## Description
main's `pnpm-lock.yaml` carries duplicated `hono@4.13.5` mapping keys (one in `packages:`, one inline-form in `snapshots:`) — a textual-merge artifact of the dependabot sweep around #4310. `pnpm install --frozen-lockfile` fails with `ERR_PNPM_BROKEN_LOCKFILE`, which reds every CI job on every PR (currently blocking #4348 among others). Same failure mode as the 2026-08-24 sweep.

## Fix
Surgical dedupe: removed the two duplicate blocks after asserting each is byte-identical to its kept sibling. No regeneration (avoids transitive drift while main is down). Verified: whole-file per-section duplicate-key scan clean; `pnpm install --frozen-lockfile` resolves and installs; `--frozen-lockfile --lockfile-only` exits 0 across all 21 workspace projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T62pzFYZhVXCEuo5gYEoUu