### PR TITLE
chore: gitignore local AI-assistant state and sandbox env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,12 @@ dist/
 .env.prod
 .env.finder-dev
 
-# IDE
+# IDE / AI-assistant local state
+.specstory/
+.cursorindexingignore
+.env.cloud
+docker-compose.finder-dev.override.yml
+*.bak-*
 .idea/
 .vscode/
 *.swp


### PR DESCRIPTION
Ignores local-only files that show up untracked on dev machines: `.specstory/` (SpecStory session transcripts), `.cursorindexingignore`, `.env.cloud` (Claude cloud sandbox env), `docker-compose.finder-dev.override.yml`, and `*.bak-*` backups. None were ever tracked; this keeps them out of accidental `git add -A` commits — `.env.cloud` and the transcripts are the private ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)