### PR TITLE
feat(abuse): corroborated-watch promotion + origin-IP recidivism detector

### DIFF
--- a/apps/api/src/services/abuseSignals/config.ts
+++ b/apps/api/src/services/abuseSignals/config.ts
@@ -163,9 +163,13 @@ export const SIGNAL_DEFAULTS = {
   //
   // per_extra_axis is deliberately large enough that two watch-tier axes clear
   // severity.alert_score at defaults (55 + 15 = 70), because the whole point is
-  // to make a corroborated pair reach an operator in real time. Raising
-  // severity.alert_score or lowering this demotes the result to watch rather
-  // than producing an alert its score contradicts.
+  // to make a corroborated pair reach an operator in real time.
+  //
+  // Reaching min_axes is necessary but NOT sufficient: the aggregate must also
+  // cross severity.alert_score or nothing is emitted at all. Two weak axes can
+  // sum below it (45 + 15 = 60), and a synthetic *watch* row would notify
+  // nobody while crowding out the weekly digest's 20-row watch list. Lowering
+  // this value therefore silences the signal rather than demoting it.
   'fraud.corroborated_watch.min_axes': 2,
   'fraud.corroborated_watch.per_extra_axis': 15,
 } as const satisfies Record<string, number>;

--- a/apps/api/src/services/abuseSignals/config.ts
+++ b/apps/api/src/services/abuseSignals/config.ts
@@ -150,6 +150,28 @@ export const SIGNAL_DEFAULTS = {
   'rmm.recidivist_endpoint.hostname_ip_score': 90,
   'rmm.recidivist_endpoint.hostname_score': 60,
   'rmm.recidivist_endpoint.ip_score': 40,
+  // Origin-IP recidivism (originIp.ts). NOT age-decayed — an address shared
+  // with a suspended operator is evidence about infrastructure, and
+  // pre-positioned accounts sit dormant for weeks precisely to age out of
+  // young-account weighting.
+  //
+  // base_score is set to meet severity.alert_score exactly, so ONE exact
+  // address shared with a suspended partner pages. That equality is an intent,
+  // not an invariant — both numbers are independently overridable — and it
+  // mirrors the confidence the signup gate already assigns to an exact
+  // signup-IP match, whose every production hold has been a true positive.
+  // There is deliberately no cap on how many suspended partners may share an
+  // address; see the note in originIp.ts on why that guard was removed.
+  'fraud.suspended_console_ip.base_score': 70,
+  'fraud.suspended_console_ip.per_extra_ip': 10,
+  // The /24 (IPv6 /64) sibling. A network is a weaker tie than an address, so
+  // this caps BELOW severity.alert_score and corroborates instead — same rule
+  // as session_intensity and cardholder_name_mismatch. Its looseness is
+  // bounded on two sides: the counterparty must be a failed login against an
+  // ALREADY-SUSPENDED account, and it must fall inside window_hours. Do not
+  // raise it past the alert threshold; widen the evidence instead.
+  'fraud.dead_account_probe_origin.window_hours': 24,
+  'fraud.dead_account_probe_origin.score': 55,
   // Cross-signal corroboration (corroboration.ts). This is the "second signal"
   // that the capped scores above (session_intensity, cardholder_name_mismatch,
   // provider_default_hostname generic) have always referred to — it did not

--- a/apps/api/src/services/abuseSignals/config.ts
+++ b/apps/api/src/services/abuseSignals/config.ts
@@ -150,6 +150,24 @@ export const SIGNAL_DEFAULTS = {
   'rmm.recidivist_endpoint.hostname_ip_score': 90,
   'rmm.recidivist_endpoint.hostname_score': 60,
   'rmm.recidivist_endpoint.ip_score': 40,
+  // Cross-signal corroboration (corroboration.ts). This is the "second signal"
+  // that the capped scores above (session_intensity, cardholder_name_mismatch,
+  // provider_default_hostname generic) have always referred to — it did not
+  // exist until 2026-08-16, which is why a partner could fire several capped
+  // watch signals and never notify anyone.
+  //
+  // min_axes counts DISTINCT EVIDENCE AXES, not signals: two detectors that
+  // restate one observation (the two IP-scatter signals) share an axis and
+  // cannot corroborate each other. 2 is the meaningful floor — one axis is a
+  // single detector, which is what the caps already decided is not enough.
+  //
+  // per_extra_axis is deliberately large enough that two watch-tier axes clear
+  // severity.alert_score at defaults (55 + 15 = 70), because the whole point is
+  // to make a corroborated pair reach an operator in real time. Raising
+  // severity.alert_score or lowering this demotes the result to watch rather
+  // than producing an alert its score contradicts.
+  'fraud.corroborated_watch.min_axes': 2,
+  'fraud.corroborated_watch.per_extra_axis': 15,
 } as const satisfies Record<string, number>;
 
 export type SignalConfigKey = keyof typeof SIGNAL_DEFAULTS;

--- a/apps/api/src/services/abuseSignals/corroboration.test.ts
+++ b/apps/api/src/services/abuseSignals/corroboration.test.ts
@@ -22,6 +22,37 @@ function watch(partnerId: string, signalKey: string, score: number): ComputedSig
 }
 
 describe('computeCorroborationSignals', () => {
+  it('counts the two origin-IP signals as ONE axis', () => {
+    // They restate one observation — this partner works from infrastructure a
+    // suspended operator used — measured at two strengths. The scorer today
+    // suppresses the weaker row when the exact match fires, so this pair
+    // cannot co-occur in practice; the mapping exists so that relaxing that
+    // suppression can never silently manufacture an alert from a single fact.
+    const out = computeCorroborationSignals(
+      [
+        watch('p1', 'fraud.suspended_console_ip', 65),
+        watch('p1', 'fraud.dead_account_probe_origin', 55),
+      ],
+      cfg,
+    );
+    expect(out).toEqual([]);
+  });
+
+  it('lets an origin-IP signal corroborate a billing signal', () => {
+    // The pair that would have caught the 08-31 re-establishment: an
+    // infrastructure axis and an identity axis are genuinely independent.
+    const out = computeCorroborationSignals(
+      [
+        watch('p1', 'fraud.dead_account_probe_origin', 55),
+        watch('p1', 'billing.cardholder_name_mismatch', 55),
+      ],
+      cfg,
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]!.severity).toBe('alert');
+    expect(out[0]!.evidence.axisCount).toBe(2);
+  });
+
   it('promotes two capped watch signals on independent axes to an alert', () => {
     // The onlineAccount-Statement shape: session_intensity 65 was the only
     // signal anyone looked at, and cardholder_name_mismatch 55 sat beside it.
@@ -312,6 +343,8 @@ describe('SIGNAL_AXIS coverage', () => {
     'billing.cardholder_name_mismatch',
     'billing.shared_card_fingerprint',
     'billing.card_testing',
+    'fraud.suspended_console_ip',
+    'fraud.dead_account_probe_origin',
     'fraud.failed_login_cluster',
     'resource.enrollment_denied',
     'resource.volume_outlier',

--- a/apps/api/src/services/abuseSignals/corroboration.test.ts
+++ b/apps/api/src/services/abuseSignals/corroboration.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect } from 'vitest';
+import { loadSignalConfig, scoreToSeverity } from './config';
+import {
+  computeCorroborationSignals,
+  axisFor,
+  SIGNAL_AXIS,
+  CORROBORATED_SIGNAL_KEY,
+} from './corroboration';
+import type { ComputedSignal } from './types';
+
+const cfg = loadSignalConfig();
+
+function watch(partnerId: string, signalKey: string, score: number): ComputedSignal {
+  return {
+    partnerId,
+    signalKey,
+    score,
+    severity: scoreToSeverity(score, cfg),
+    evidence: { partnerName: 'Acme' },
+  };
+}
+
+describe('computeCorroborationSignals', () => {
+  it('promotes two capped watch signals on independent axes to an alert', () => {
+    // The onlineAccount-Statement shape: session_intensity 65 was the only
+    // signal anyone looked at, and cardholder_name_mismatch 55 sat beside it.
+    // Both are watch, so neither notified; together they are two axes.
+    const out = computeCorroborationSignals(
+      [
+        watch('p1', 'rmm.session_intensity', 65),
+        watch('p1', 'billing.cardholder_name_mismatch', 55),
+      ],
+      cfg,
+    );
+
+    expect(out).toHaveLength(1);
+    expect(out[0]!.signalKey).toBe(CORROBORATED_SIGNAL_KEY);
+    expect(out[0]!.partnerId).toBe('p1');
+    // 65 anchor + 15 for the second independent axis.
+    expect(out[0]!.score).toBe(80);
+    expect(out[0]!.severity).toBe('alert');
+    expect(out[0]!.evidence.axisCount).toBe(2);
+    expect(out[0]!.evidence.partnerName).toBe('Acme');
+  });
+
+  it('does NOT corroborate two signals that restate one observation', () => {
+    // enrollment_ip_spread and device_ip_scatter share the ip_scatter axis:
+    // they are the same fact about a residential-serving MSP.
+    const out = computeCorroborationSignals(
+      [
+        watch('p1', 'rmm.enrollment_ip_spread', 60),
+        watch('p1', 'rmm.device_ip_scatter', 55),
+      ],
+      cfg,
+    );
+    expect(out).toHaveLength(0);
+  });
+
+  it('takes the stronger score when one axis fires twice, and still needs a second axis', () => {
+    const out = computeCorroborationSignals(
+      [
+        watch('p1', 'rmm.enrollment_ip_spread', 50),
+        watch('p1', 'rmm.device_ip_scatter', 60),
+        watch('p1', 'rmm.session_intensity', 45),
+      ],
+      cfg,
+    );
+    expect(out).toHaveLength(1);
+    // anchor is the strongest single axis (ip_scatter 60), not the sum of the
+    // two ip_scatter signals.
+    expect(out[0]!.score).toBe(75);
+    expect(out[0]!.evidence.axisCount).toBe(2);
+  });
+
+  it('never fires on a single axis', () => {
+    expect(
+      computeCorroborationSignals([watch('p1', 'billing.cardholder_name_mismatch', 60)], cfg),
+    ).toHaveLength(0);
+  });
+
+  it('ignores alert-severity signals — they already notify on their own', () => {
+    const alert: ComputedSignal = {
+      partnerId: 'p1',
+      signalKey: 'rmm.remote_access_installer',
+      score: 100,
+      severity: 'alert',
+      evidence: { partnerName: 'Acme' },
+    };
+    const out = computeCorroborationSignals(
+      [alert, watch('p1', 'rmm.session_intensity', 65)],
+      cfg,
+    );
+    expect(out).toHaveLength(0);
+  });
+
+  it('ignores info-tier signals', () => {
+    const out = computeCorroborationSignals(
+      [watch('p1', 'rmm.session_intensity', 65), watch('p1', 'billing.card_testing', 10)],
+      cfg,
+    );
+    expect(out).toHaveLength(0);
+  });
+
+  it('excludes invariant.* signals as corroborators', () => {
+    const invariant: ComputedSignal = {
+      partnerId: 'p1',
+      signalKey: 'invariant.active_unverified_email',
+      score: 50,
+      severity: 'watch',
+      evidence: { partnerName: 'Acme' },
+    };
+    const out = computeCorroborationSignals(
+      [invariant, watch('p1', 'rmm.session_intensity', 65)],
+      cfg,
+    );
+    expect(out).toHaveLength(0);
+  });
+
+  it('scores independently per partner and does not leak across partners', () => {
+    const out = computeCorroborationSignals(
+      [
+        watch('p1', 'rmm.session_intensity', 65),
+        watch('p2', 'billing.cardholder_name_mismatch', 55),
+      ],
+      cfg,
+    );
+    expect(out).toHaveLength(0);
+  });
+
+  it('clamps at 100 with many axes', () => {
+    const out = computeCorroborationSignals(
+      [
+        watch('p1', 'rmm.session_intensity', 65),
+        watch('p1', 'billing.cardholder_name_mismatch', 55),
+        watch('p1', 'rmm.consumer_devices', 60),
+        watch('p1', 'rmm.device_ip_scatter', 55),
+        watch('p1', 'fraud.failed_login_cluster', 50),
+        watch('p1', 'resource.volume_outlier', 45),
+      ],
+      cfg,
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]!.score).toBe(100);
+    expect(out[0]!.severity).toBe('alert');
+  });
+
+  it('is idempotent — re-running over its own output adds nothing', () => {
+    const first = computeCorroborationSignals(
+      [
+        watch('p1', 'rmm.session_intensity', 65),
+        watch('p1', 'billing.cardholder_name_mismatch', 55),
+      ],
+      cfg,
+    );
+    const second = computeCorroborationSignals(
+      [
+        watch('p1', 'rmm.session_intensity', 65),
+        watch('p1', 'billing.cardholder_name_mismatch', 55),
+        ...first,
+      ],
+      cfg,
+    );
+    expect(second).toHaveLength(1);
+    expect(second[0]!.score).toBe(first[0]!.score);
+  });
+
+  it('respects a raised min_axes override', () => {
+    const strict = { ...cfg, 'fraud.corroborated_watch.min_axes': 3 };
+    const out = computeCorroborationSignals(
+      [
+        watch('p1', 'rmm.session_intensity', 65),
+        watch('p1', 'billing.cardholder_name_mismatch', 55),
+      ],
+      strict,
+    );
+    expect(out).toHaveLength(0);
+  });
+
+  it('stays watch rather than claiming an alert its score contradicts', () => {
+    // Lowering per_extra_axis must demote the result, not produce a severity
+    // that disagrees with the score.
+    const timid = { ...cfg, 'fraud.corroborated_watch.per_extra_axis': 1 };
+    const out = computeCorroborationSignals(
+      [
+        watch('p1', 'billing.cardholder_name_mismatch', 55),
+        watch('p1', 'rmm.consumer_devices', 50),
+      ],
+      timid,
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]!.score).toBe(56);
+    expect(out[0]!.severity).toBe('watch');
+  });
+});
+
+describe('SIGNAL_AXIS coverage', () => {
+  // Every key the sweep can emit must be mapped, or it silently becomes its
+  // own axis and can double-count against a sibling that restates it.
+  const EMITTED_KEYS = [
+    'rmm.consumer_devices',
+    'rmm.enrollment_velocity',
+    'rmm.session_intensity',
+    'rmm.enrollment_ip_spread',
+    'rmm.provider_default_hostname',
+    'rmm.device_ip_scatter',
+    'rmm.remote_access_installer',
+    'rmm.unbranded_installer',
+    'rmm.shared_installer_host',
+    'billing.cardholder_name_mismatch',
+    'billing.shared_card_fingerprint',
+    'billing.card_testing',
+    'fraud.failed_login_cluster',
+    'resource.enrollment_denied',
+    'resource.volume_outlier',
+  ];
+
+  it.each(EMITTED_KEYS)('%s has an explicit axis', (key) => {
+    expect(SIGNAL_AXIS[key]).toBeDefined();
+  });
+
+  it('groups the two IP-scatter signals onto one axis', () => {
+    expect(axisFor('rmm.enrollment_ip_spread')).toBe(axisFor('rmm.device_ip_scatter'));
+  });
+
+  it('keeps session and billing identity on separate axes', () => {
+    expect(axisFor('rmm.session_intensity')).not.toBe(axisFor('billing.cardholder_name_mismatch'));
+  });
+
+  it('falls back to the signal key itself for an unmapped detector', () => {
+    expect(axisFor('rmm.brand_new_detector')).toBe('rmm.brand_new_detector');
+  });
+});

--- a/apps/api/src/services/abuseSignals/corroboration.test.ts
+++ b/apps/api/src/services/abuseSignals/corroboration.test.ts
@@ -4,6 +4,7 @@ import {
   computeCorroborationSignals,
   axisFor,
   SIGNAL_AXIS,
+  CORROBORATION_INELIGIBLE,
   CORROBORATED_SIGNAL_KEY,
 } from './corroboration';
 import type { ComputedSignal } from './types';
@@ -144,7 +145,10 @@ describe('computeCorroborationSignals', () => {
     expect(out[0]!.severity).toBe('alert');
   });
 
-  it('is idempotent — re-running over its own output adds nothing', () => {
+  it('does not stack when re-run over its own output', () => {
+    // Feeding the synthetic signal back in must not produce a second one.
+    // (Its own alert severity trips the already-alerting suppression, which
+    // is the desired outcome either way.)
     const first = computeCorroborationSignals(
       [
         watch('p1', 'rmm.session_intensity', 65),
@@ -152,6 +156,8 @@ describe('computeCorroborationSignals', () => {
       ],
       cfg,
     );
+    expect(first).toHaveLength(1);
+
     const second = computeCorroborationSignals(
       [
         watch('p1', 'rmm.session_intensity', 65),
@@ -160,8 +166,7 @@ describe('computeCorroborationSignals', () => {
       ],
       cfg,
     );
-    expect(second).toHaveLength(1);
-    expect(second[0]!.score).toBe(first[0]!.score);
+    expect(second).toHaveLength(0);
   });
 
   it('respects a raised min_axes override', () => {
@@ -176,9 +181,20 @@ describe('computeCorroborationSignals', () => {
     expect(out).toHaveLength(0);
   });
 
-  it('stays watch rather than claiming an alert its score contradicts', () => {
-    // Lowering per_extra_axis must demote the result, not produce a severity
-    // that disagrees with the score.
+  it('emits nothing rather than a synthetic watch when the aggregate misses alert', () => {
+    // Two weak axes: 45 + 15 = 60, below the 70 alert threshold. A synthetic
+    // watch row would notify nobody and crowd the digest's 20-row watch list.
+    const out = computeCorroborationSignals(
+      [
+        watch('p1', 'rmm.provider_default_hostname', 45),
+        watch('p1', 'rmm.device_ip_scatter', 45),
+      ],
+      cfg,
+    );
+    expect(out).toHaveLength(0);
+  });
+
+  it('emits nothing when per_extra_axis is lowered below the alert threshold', () => {
     const timid = { ...cfg, 'fraud.corroborated_watch.per_extra_axis': 1 };
     const out = computeCorroborationSignals(
       [
@@ -187,9 +203,96 @@ describe('computeCorroborationSignals', () => {
       ],
       timid,
     );
-    expect(out).toHaveLength(1);
-    expect(out[0]!.score).toBe(56);
-    expect(out[0]!.severity).toBe('watch');
+    expect(out).toHaveLength(0);
+  });
+
+  it('never emits a non-alert signal for any input', () => {
+    const out = computeCorroborationSignals(
+      [
+        watch('p1', 'rmm.provider_default_hostname', 41),
+        watch('p1', 'rmm.device_ip_scatter', 42),
+        watch('p2', 'billing.card_testing', 40),
+        watch('p2', 'rmm.consumer_devices', 44),
+        watch('p3', 'rmm.session_intensity', 65),
+        watch('p3', 'billing.cardholder_name_mismatch', 55),
+      ],
+      cfg,
+    );
+    expect(out.every((s) => s.severity === 'alert')).toBe(true);
+  });
+
+  it('leads the evidence with a compact axis summary for the 800-char alert body', () => {
+    const out = computeCorroborationSignals(
+      [
+        watch('p1', 'rmm.session_intensity', 65),
+        watch('p1', 'billing.cardholder_name_mismatch', 55),
+      ],
+      cfg,
+    );
+    expect(out[0]!.evidence.summary).toBe(
+      'enrollment_burst:rmm.session_intensity=65 + billing_identity:billing.cardholder_name_mismatch=55',
+    );
+    // partnerName and summary must survive truncation of the serialised body.
+    const keys = Object.keys(out[0]!.evidence);
+    expect(keys.indexOf('partnerName')).toBeLessThan(keys.indexOf('contributors'));
+    expect(keys.indexOf('summary')).toBeLessThan(keys.indexOf('contributors'));
+  });
+});
+
+describe('corroboration eligibility', () => {
+  it('does not let a failed-login burst corroborate — the partner may be the victim', () => {
+    const out = computeCorroborationSignals(
+      [
+        watch('p1', 'fraud.failed_login_cluster', 65),
+        watch('p1', 'rmm.consumer_devices', 60),
+      ],
+      cfg,
+    );
+    expect(out).toHaveLength(0);
+  });
+
+  it('does not let resource-volume signals corroborate — heavy automation is normal', () => {
+    const out = computeCorroborationSignals(
+      [
+        watch('p1', 'resource.volume_outlier', 65),
+        watch('p1', 'resource.enrollment_denied', 60),
+      ],
+      cfg,
+    );
+    expect(out).toHaveLength(0);
+  });
+
+  it('suppresses the synthetic page when the partner already has a direct alert', () => {
+    const direct: ComputedSignal = {
+      partnerId: 'p1',
+      signalKey: 'rmm.remote_access_installer',
+      score: 100,
+      severity: 'alert',
+      evidence: { partnerName: 'Acme' },
+    };
+    const out = computeCorroborationSignals(
+      [
+        direct,
+        watch('p1', 'rmm.session_intensity', 65),
+        watch('p1', 'billing.cardholder_name_mismatch', 55),
+      ],
+      cfg,
+    );
+    expect(out).toHaveLength(0);
+  });
+
+  it('treats the enrollment burst and fast enroll-to-remote as ONE axis', () => {
+    // A legitimate onboarding bulk-enrolls and immediately connects to each
+    // box, firing both. They must not corroborate each other.
+    expect(axisFor('rmm.session_intensity')).toBe(axisFor('rmm.enrollment_velocity'));
+    const out = computeCorroborationSignals(
+      [
+        watch('p1', 'rmm.session_intensity', 65),
+        watch('p1', 'rmm.enrollment_velocity', 60),
+      ],
+      cfg,
+    );
+    expect(out).toHaveLength(0);
   });
 });
 
@@ -214,8 +317,18 @@ describe('SIGNAL_AXIS coverage', () => {
     'resource.volume_outlier',
   ];
 
-  it.each(EMITTED_KEYS)('%s has an explicit axis', (key) => {
-    expect(SIGNAL_AXIS[key]).toBeDefined();
+  it.each(EMITTED_KEYS)('%s is either mapped to an axis or explicitly ineligible', (key) => {
+    // The invariant that matters: no emitted key may fall through to the
+    // "own axis" default, which would silently make it paging-grade
+    // corroboration without anyone deciding that.
+    const decided = SIGNAL_AXIS[key] !== undefined || CORROBORATION_INELIGIBLE.has(key);
+    expect(decided).toBe(true);
+  });
+
+  it('keeps the two sets disjoint', () => {
+    for (const key of CORROBORATION_INELIGIBLE) {
+      expect(SIGNAL_AXIS[key]).toBeUndefined();
+    }
   });
 
   it('groups the two IP-scatter signals onto one axis', () => {

--- a/apps/api/src/services/abuseSignals/corroboration.ts
+++ b/apps/api/src/services/abuseSignals/corroboration.ts
@@ -57,6 +57,12 @@ export const SIGNAL_AXIS: Record<string, string> = {
   'rmm.remote_access_installer': 'script',
   'rmm.unbranded_installer': 'script',
   'rmm.shared_installer_host': 'script',
+  // Both origin-IP signals restate one observation — this partner works from
+  // infrastructure a suspended operator used — measured at two strengths
+  // (exact address vs /24). Counting them as two axes would let a single fact
+  // manufacture an alert, the same trap the ip_scatter pair is grouped for.
+  'fraud.suspended_console_ip': 'origin_ip',
+  'fraud.dead_account_probe_origin': 'origin_ip',
   'billing.cardholder_name_mismatch': 'billing_identity',
   'billing.card_testing': 'billing_identity',
   'billing.shared_card_fingerprint': 'billing_identity',

--- a/apps/api/src/services/abuseSignals/corroboration.ts
+++ b/apps/api/src/services/abuseSignals/corroboration.ts
@@ -1,0 +1,133 @@
+import { scoreToSeverity, type SignalConfig } from './config';
+import type { ComputedSignal } from './types';
+
+/**
+ * Cross-signal corroboration.
+ *
+ * Several detectors deliberately cap their score below `severity.alert_score`
+ * because, on their own, they describe behaviour a legitimate operator also
+ * exhibits — trialling remote sessions on a new device, paying with a spouse's
+ * card, running unrenamed provider VMs. The config comments on those caps
+ * (`rmm.session_intensity.max_score`, `billing.cardholder_name_mismatch.score`,
+ * `rmm.provider_default_hostname.generic_max_score`) all say the signal "needs
+ * a second signal to reach alert".
+ *
+ * That second half was never built. Severity is a pure function of one signal's
+ * own score, so a partner firing four capped `watch` signals produced four
+ * `watch` rows and — because only `alert` is ever delivered
+ * (persistence.ts) — zero notifications. In production that gap cost real
+ * victims: on several confirmed-fraud accounts a capped `watch` signal was the
+ * ONLY signal that fired and nobody was notified.
+ *
+ * This closes it by emitting a synthetic `fraud.corroborated_watch` signal
+ * rather than by mutating another detector's severity in place. Keeping it a
+ * separate row means each detector keeps its own honest score, the existing
+ * dedup/stale-resolution key `(partner_id, signal_key)` still works, and an
+ * operator can acknowledge "yes, this combination is fine for this partner"
+ * without suppressing the underlying detectors.
+ */
+
+/**
+ * Which independent line of evidence a signal represents.
+ *
+ * Corroboration counts DISTINCT AXES, never raw signal count, and that
+ * distinction is the whole false-positive control. `rmm.enrollment_ip_spread`
+ * and `rmm.device_ip_scatter` are both restatements of one observation — this
+ * fleet's addresses are scattered — and they co-fire on legitimate MSPs that
+ * serve residential customers. Counting them as two would manufacture an alert
+ * out of a single fact. They share an axis on purpose.
+ *
+ * A signal key absent from this map is treated as its own axis. That is the
+ * safe default for a NEW detector (it can corroborate immediately), but it
+ * means adding a detector that restates an existing observation REQUIRES adding
+ * it here — otherwise it double-counts. `corroboration.test.ts` asserts every
+ * key this sweep can emit is mapped.
+ */
+export const SIGNAL_AXIS: Record<string, string> = {
+  'rmm.session_intensity': 'session',
+  'rmm.consumer_devices': 'fleet_shape',
+  'rmm.provider_default_hostname': 'fleet_shape',
+  'rmm.enrollment_ip_spread': 'ip_scatter',
+  'rmm.device_ip_scatter': 'ip_scatter',
+  'rmm.enrollment_velocity': 'enrollment_velocity',
+  'rmm.remote_access_installer': 'script',
+  'rmm.unbranded_installer': 'script',
+  'rmm.shared_installer_host': 'script',
+  'billing.cardholder_name_mismatch': 'billing_identity',
+  'billing.card_testing': 'billing_identity',
+  'billing.shared_card_fingerprint': 'billing_identity',
+  'fraud.failed_login_cluster': 'auth',
+  'resource.enrollment_denied': 'resource',
+  'resource.volume_outlier': 'resource',
+};
+
+export const CORROBORATED_SIGNAL_KEY = 'fraud.corroborated_watch';
+
+export function axisFor(signalKey: string): string {
+  return SIGNAL_AXIS[signalKey] ?? signalKey;
+}
+
+/**
+ * Pure — no I/O. Runs on the signals the other detectors already computed, so
+ * it adds no queries to the sweep.
+ *
+ * `invariant.*` signals are excluded as corroborators: they are hardcoded to
+ * `alert` and already notify on their own, so folding them in would only
+ * restate an alert that has already been delivered.
+ */
+export function computeCorroborationSignals(
+  computed: ComputedSignal[],
+  cfg: SignalConfig,
+): ComputedSignal[] {
+  const minAxes = cfg['fraud.corroborated_watch.min_axes'];
+  const perExtraAxis = cfg['fraud.corroborated_watch.per_extra_axis'];
+
+  const byPartner = new Map<string, ComputedSignal[]>();
+  for (const s of computed) {
+    if (s.severity !== 'watch') continue;
+    if (s.signalKey.startsWith('invariant.')) continue;
+    if (s.signalKey === CORROBORATED_SIGNAL_KEY) continue;
+    const list = byPartner.get(s.partnerId);
+    if (list) list.push(s);
+    else byPartner.set(s.partnerId, [s]);
+  }
+
+  const out: ComputedSignal[] = [];
+  for (const [partnerId, signals] of byPartner) {
+    // Highest-scoring signal per axis: two watch signals on one axis
+    // contribute one axis and the stronger of the two scores.
+    const bestByAxis = new Map<string, ComputedSignal>();
+    for (const s of signals) {
+      const axis = axisFor(s.signalKey);
+      const current = bestByAxis.get(axis);
+      if (!current || s.score > current.score) bestByAxis.set(axis, s);
+    }
+    if (bestByAxis.size < minAxes) continue;
+
+    const contributors = [...bestByAxis.entries()]
+      .map(([axis, s]) => ({ axis, signalKey: s.signalKey, score: s.score }))
+      .sort((a, b) => b.score - a.score || a.axis.localeCompare(b.axis));
+
+    // Anchor on the strongest single axis, then add for each INDEPENDENT
+    // corroborating axis. Deriving severity through the normal
+    // scoreToSeverity keeps score and severity consistent, so lowering
+    // per_extra_axis (or raising severity.alert_score) demotes this to watch
+    // rather than producing an 'alert' that its own score contradicts.
+    const base = contributors[0]?.score ?? 0;
+    const score = Math.min(100, Math.round(base + perExtraAxis * (bestByAxis.size - 1)));
+
+    out.push({
+      partnerId,
+      signalKey: CORROBORATED_SIGNAL_KEY,
+      score,
+      severity: scoreToSeverity(score, cfg),
+      // partnerName must lead: index.ts formatSignalAlert reads it.
+      evidence: {
+        partnerName: signals.find((s) => s.evidence.partnerName)?.evidence.partnerName ?? 'unknown',
+        axisCount: bestByAxis.size,
+        contributors,
+      },
+    });
+  }
+  return out;
+}

--- a/apps/api/src/services/abuseSignals/corroboration.ts
+++ b/apps/api/src/services/abuseSignals/corroboration.ts
@@ -44,22 +44,44 @@ import type { ComputedSignal } from './types';
  * key this sweep can emit is mapped.
  */
 export const SIGNAL_AXIS: Record<string, string> = {
-  'rmm.session_intensity': 'session',
+  // `session_intensity` is "fast enroll-to-remote" and `enrollment_velocity` is
+  // the enrollment burst itself — the same episode measured twice. An MSP
+  // onboarding a customer bulk-enrolls and immediately connects to each box,
+  // firing both. One axis.
+  'rmm.session_intensity': 'enrollment_burst',
+  'rmm.enrollment_velocity': 'enrollment_burst',
   'rmm.consumer_devices': 'fleet_shape',
   'rmm.provider_default_hostname': 'fleet_shape',
   'rmm.enrollment_ip_spread': 'ip_scatter',
   'rmm.device_ip_scatter': 'ip_scatter',
-  'rmm.enrollment_velocity': 'enrollment_velocity',
   'rmm.remote_access_installer': 'script',
   'rmm.unbranded_installer': 'script',
   'rmm.shared_installer_host': 'script',
   'billing.cardholder_name_mismatch': 'billing_identity',
   'billing.card_testing': 'billing_identity',
   'billing.shared_card_fingerprint': 'billing_identity',
-  'fraud.failed_login_cluster': 'auth',
-  'resource.enrollment_denied': 'resource',
-  'resource.volume_outlier': 'resource',
 };
+
+/**
+ * Signals that may NOT corroborate, no matter how strongly they fire.
+ *
+ * `fraud.failed_login_cluster` is not directional: a burst of failed logins
+ * usually means the partner is being ATTACKED, not that it is the attacker.
+ * Treating it as evidence against the partner would page us about victims.
+ *
+ * `resource.*` measures volume, and heavy automation is a normal reason to be
+ * loud. It is a capacity/abuse-of-plan concern, not evidence of fraud, and
+ * folding it in would let two non-fraud observations manufacture a page.
+ *
+ * These are listed explicitly rather than matched by prefix so a NEW detector
+ * in either namespace has to make a deliberate choice rather than silently
+ * inheriting paging-grade weight.
+ */
+export const CORROBORATION_INELIGIBLE = new Set([
+  'fraud.failed_login_cluster',
+  'resource.enrollment_denied',
+  'resource.volume_outlier',
+]);
 
 export const CORROBORATED_SIGNAL_KEY = 'fraud.corroborated_watch';
 
@@ -82,11 +104,19 @@ export function computeCorroborationSignals(
   const minAxes = cfg['fraud.corroborated_watch.min_axes'];
   const perExtraAxis = cfg['fraud.corroborated_watch.per_extra_axis'];
 
+  // A partner that already has a real alert this sweep is being paged about
+  // anyway; a second synthetic page for the same account is noise.
+  const alreadyAlerting = new Set(
+    computed.filter((s) => s.severity === 'alert').map((s) => s.partnerId),
+  );
+
   const byPartner = new Map<string, ComputedSignal[]>();
   for (const s of computed) {
     if (s.severity !== 'watch') continue;
     if (s.signalKey.startsWith('invariant.')) continue;
     if (s.signalKey === CORROBORATED_SIGNAL_KEY) continue;
+    if (CORROBORATION_INELIGIBLE.has(s.signalKey)) continue;
+    if (alreadyAlerting.has(s.partnerId)) continue;
     const list = byPartner.get(s.partnerId);
     if (list) list.push(s);
     else byPartner.set(s.partnerId, [s]);
@@ -109,21 +139,30 @@ export function computeCorroborationSignals(
       .sort((a, b) => b.score - a.score || a.axis.localeCompare(b.axis));
 
     // Anchor on the strongest single axis, then add for each INDEPENDENT
-    // corroborating axis. Deriving severity through the normal
-    // scoreToSeverity keeps score and severity consistent, so lowering
-    // per_extra_axis (or raising severity.alert_score) demotes this to watch
-    // rather than producing an 'alert' that its own score contradicts.
+    // corroborating axis. Severity is derived through the normal
+    // scoreToSeverity so score and severity never contradict each other.
     const base = contributors[0]?.score ?? 0;
     const score = Math.min(100, Math.round(base + perExtraAxis * (bestByAxis.size - 1)));
+    const severity = scoreToSeverity(score, cfg);
+
+    // Emit ONLY when the aggregate actually reaches alert. Two weak axes can
+    // sum below the threshold (45 + 15 = 60), and a synthetic *watch* row
+    // would be pure cost: it notifies nobody, duplicates evidence already
+    // visible on the constituent rows, and crowds out the weekly digest's
+    // 20-row watch list. The whole purpose of this signal is to page.
+    if (severity !== 'alert') continue;
 
     out.push({
       partnerId,
       signalKey: CORROBORATED_SIGNAL_KEY,
       score,
-      severity: scoreToSeverity(score, cfg),
-      // partnerName must lead: index.ts formatSignalAlert reads it.
+      severity,
+      // Key order matters: index.ts formatSignalAlert reads partnerName, and
+      // truncates the serialised evidence at 800 chars — so the human-readable
+      // axis summary goes near the front, before the detailed contributors.
       evidence: {
         partnerName: signals.find((s) => s.evidence.partnerName)?.evidence.partnerName ?? 'unknown',
+        summary: contributors.map((c) => `${c.axis}:${c.signalKey}=${c.score}`).join(' + '),
         axisCount: bestByAxis.size,
         contributors,
       },

--- a/apps/api/src/services/abuseSignals/index.ts
+++ b/apps/api/src/services/abuseSignals/index.ts
@@ -8,6 +8,7 @@ import { loadPartnerAggregates, computeHeuristicSignals, loadHostnameIndicators 
 import { loadScriptFindings, computeScriptSignals, loadScriptIndicators } from './scriptContent';
 import { loadBillingIdentityAggregates, computeBillingIdentitySignals } from './billingIdentity';
 import { syncEndpointFingerprints, loadRecidivistMatches, computeRecidivistSignals } from './recidivistEndpoint';
+import { computeCorroborationSignals } from './corroboration';
 import { persistSignals, markDelivered } from './persistence';
 import type { ComputedSignal } from './types';
 
@@ -81,6 +82,14 @@ export async function runAbuseSweep(): Promise<{ fired: number; notified: number
     // is more suspicious, not less (see the scorer's own header comment).
     ...computeRecidivistSignals(recidivist.matches, cfg),
   ];
+  // Corroboration runs LAST and reads only what the detectors above produced —
+  // no extra queries. It promotes a partner whose evidence spans two or more
+  // independent axes, which is the mechanism the capped watch scores in
+  // config.ts have always assumed. Deliberately not added to
+  // evaluatedPartnerIds below: every partner it can fire on already got there
+  // via the detector that produced the underlying watch signal, and widening
+  // that set would change stale-resolution for OTHER signals on that partner.
+  computed.push(...computeCorroborationSignals(computed, cfg));
   // Script-scanned and billing-scanned partners join the evaluated set so open
   // rows for those detectors stale-resolve when the evidence disappears
   // (script edited/deleted, cardholder name corrected). persistSignals only

--- a/apps/api/src/services/abuseSignals/index.ts
+++ b/apps/api/src/services/abuseSignals/index.ts
@@ -8,6 +8,7 @@ import { loadPartnerAggregates, computeHeuristicSignals, loadHostnameIndicators 
 import { loadScriptFindings, computeScriptSignals, loadScriptIndicators } from './scriptContent';
 import { loadBillingIdentityAggregates, computeBillingIdentitySignals } from './billingIdentity';
 import { syncEndpointFingerprints, loadRecidivistMatches, computeRecidivistSignals } from './recidivistEndpoint';
+import { loadOriginIpAggregates, computeOriginIpSignals } from './originIp';
 import { computeCorroborationSignals } from './corroboration';
 import { persistSignals, markDelivered } from './persistence';
 import type { ComputedSignal } from './types';
@@ -49,7 +50,7 @@ export async function runAbuseSweep(): Promise<{ fired: number; notified: number
   const cfg = loadSignalConfig();
   const now = new Date();
 
-  const { invariants, aggregates, scriptFindings, billingIdentity, recidivist } = await runSystemDbCompute(
+  const { invariants, aggregates, scriptFindings, billingIdentity, recidivist, originIp } = await runSystemDbCompute(
     async () => {
       // syncEndpointFingerprints refreshes the corpus before the correlation
       // read below runs, same ordering scriptContent uses for its own scan.
@@ -60,6 +61,7 @@ export async function runAbuseSweep(): Promise<{ fired: number; notified: number
         scriptFindings: await loadScriptFindings(now),
         billingIdentity: await loadBillingIdentityAggregates(),
         recidivist: await loadRecidivistMatches(),
+        originIp: await loadOriginIpAggregates(),
       };
     },
   );
@@ -81,6 +83,10 @@ export async function runAbuseSweep(): Promise<{ fired: number; notified: number
     // re-established aged account matching a suspended partner's fingerprint
     // is more suspicious, not less (see the scorer's own header comment).
     ...computeRecidivistSignals(recidivist.matches, cfg),
+    // Origin-IP recidivism is likewise never age-decayed — a pre-positioned
+    // account sits dormant for weeks by design, so weighting it by account age
+    // would silence it exactly when it matures into a live operator.
+    ...computeOriginIpSignals(originIp.aggregates, originIp.corpus, cfg, now),
   ];
   // Corroboration runs LAST and reads only what the detectors above produced —
   // no extra queries. It promotes a partner whose evidence spans two or more
@@ -99,6 +105,7 @@ export async function runAbuseSweep(): Promise<{ fired: number; notified: number
     ...scriptFindings.scannedPartnerIds,
     ...billingIdentity.scannedPartnerIds,
     ...recidivist.scannedPartnerIds,
+    ...originIp.scannedPartnerIds,
   ]);
   const { toNotify } = await runSystemDbCompute(() => persistSignals(computed, now, evaluatedPartnerIds));
 

--- a/apps/api/src/services/abuseSignals/originIp.test.ts
+++ b/apps/api/src/services/abuseSignals/originIp.test.ts
@@ -1,0 +1,343 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeOriginIpSignals,
+  networkPrefix,
+  SUSPENDED_CONSOLE_IP_KEY,
+  DEAD_ACCOUNT_PROBE_KEY,
+  type OriginIpCorpus,
+  type PartnerOriginAggregate,
+} from './originIp';
+import { SIGNAL_DEFAULTS, scoreToSeverity } from './config';
+
+// Every address, name and mailbox below is invented for this file. IPv4
+// fixtures use RFC 5737 documentation ranges (192.0.2.0/24, 198.51.100.0/24,
+// 203.0.113.0/24) and IPv6 fixtures use the RFC 3849 documentation prefix
+// (2001:db8::/32) so no real operator address is ever committed to a public
+// repo — the same rule billingIdentity.test.ts applies to mailbox domains.
+
+const cfg = SIGNAL_DEFAULTS;
+const NOW = new Date('2026-08-31T15:30:00Z');
+
+function agg(overrides: Partial<PartnerOriginAggregate> = {}): PartnerOriginAggregate {
+  return {
+    partnerId: 'p1',
+    partnerName: 'Nordvane',
+    partnerStatus: 'pending',
+    originIps: [],
+    ...overrides,
+  };
+}
+
+function corpus(overrides: Partial<OriginIpCorpus> = {}): OriginIpCorpus {
+  return {
+    suspendedIps: new Map(),
+    probes: [],
+    ...overrides,
+  };
+}
+
+const keys = (signals: ReturnType<typeof computeOriginIpSignals>) => signals.map((s) => s.signalKey);
+
+describe('networkPrefix', () => {
+  it('groups IPv4 by /24', () => {
+    expect(networkPrefix('192.0.2.61')).toBe(networkPrefix('192.0.2.72'));
+    expect(networkPrefix('192.0.2.61')).not.toBe(networkPrefix('192.0.3.61'));
+  });
+
+  it('groups IPv6 by /64 regardless of compression', () => {
+    // The same /64 written compressed and expanded must collapse to one
+    // prefix, or an operator hopping addresses inside a single assignment
+    // reads as two unrelated networks.
+    expect(networkPrefix('2001:db8:145:2002::1')).toBe(
+      networkPrefix('2001:db8:0145:2002:64d5:59e4:bb86:ce4d'),
+    );
+    expect(networkPrefix('2001:db8:145:2002::1')).not.toBe(networkPrefix('2001:db8:145:2003::1'));
+  });
+
+  it('takes the client hop out of a legacy X-Forwarded-For chain', () => {
+    // Production audit rows predating proxy reduction store the whole chain,
+    // e.g. "198.51.100.9, 172.19.0.8" where the second hop is the
+    // container-internal proxy. Parsing the raw string yields nothing, which
+    // would drop that request's origin silently — the leftmost entry is the
+    // client and the one that identifies the operator.
+    expect(networkPrefix('198.51.100.9, 172.19.0.8')).toBe(networkPrefix('198.51.100.9'));
+    expect(networkPrefix('198.51.100.9,172.19.0.8')).toBe(networkPrefix('198.51.100.9'));
+  });
+
+  it('returns null for junk the audit log actually stores', () => {
+    // ip_address is a varchar and production contains the literal string
+    // 'unknown' on rows written before the field was populated.
+    for (const junk of ['unknown', '', '   ', 'not-an-ip', '999.1.1.1']) {
+      expect(networkPrefix(junk)).toBeNull();
+    }
+  });
+});
+
+describe('computeOriginIpSignals — quiet cases', () => {
+  it('emits nothing with no partners and no corpus', () => {
+    expect(computeOriginIpSignals([], corpus(), cfg, NOW)).toEqual([]);
+  });
+
+  it('emits nothing for a partner whose origins match nothing', () => {
+    const out = computeOriginIpSignals(
+      [agg({ originIps: ['192.0.2.10'] })],
+      corpus({ suspendedIps: new Map([['198.51.100.5', ['Dead Co']]]) }),
+      cfg,
+      NOW,
+    );
+    expect(out).toEqual([]);
+  });
+
+  it('ignores junk origin IPs instead of matching them against each other', () => {
+    // Two partners both carrying 'unknown' must not correlate.
+    const out = computeOriginIpSignals(
+      [agg({ originIps: ['unknown', ''] })],
+      corpus({ suspendedIps: new Map([['unknown', ['Dead Co']]]) }),
+      cfg,
+      NOW,
+    );
+    expect(out).toEqual([]);
+  });
+});
+
+describe('fraud.suspended_console_ip', () => {
+  it('fires at alert on a single exact IP shared with a suspended partner', () => {
+    // The Lagus / Fetching Post shape: the operator failed a login on the dead
+    // account and signed up again from the same console IP four minutes later.
+    // signup_ip alone caught this only because they happened to reuse it; the
+    // console IP is what actually ties the accounts.
+    const out = computeOriginIpSignals(
+      [agg({ originIps: ['203.0.113.7'] })],
+      corpus({ suspendedIps: new Map([['203.0.113.7', ['Fetching Post']]]) }),
+      cfg,
+      NOW,
+    );
+
+    expect(keys(out)).toEqual([SUSPENDED_CONSOLE_IP_KEY]);
+    expect(out[0]!.score).toBe(cfg['fraud.suspended_console_ip.base_score']);
+    expect(out[0]!.severity).toBe('alert');
+    expect(out[0]!.partnerId).toBe('p1');
+    expect(out[0]!.evidence).toMatchObject({
+      partnerName: 'Nordvane',
+      matchedIps: ['203.0.113.7'],
+      suspendedPartners: ['Fetching Post'],
+    });
+  });
+
+  it('scores higher for each additional shared IP', () => {
+    const out = computeOriginIpSignals(
+      [agg({ originIps: ['203.0.113.7', '203.0.113.8', '192.0.2.1'] })],
+      corpus({
+        suspendedIps: new Map([
+          ['203.0.113.7', ['Fetching Post']],
+          ['203.0.113.8', ['Lagus']],
+        ]),
+      }),
+      cfg,
+      NOW,
+    );
+
+    expect(out[0]!.score).toBe(
+      cfg['fraud.suspended_console_ip.base_score'] + cfg['fraud.suspended_console_ip.per_extra_ip'],
+    );
+    // Only the matching addresses are cited — the partner's clean IPs are not
+    // evidence and must not pad the report.
+    expect(out[0]!.evidence.matchedIps).toEqual(['203.0.113.7', '203.0.113.8']);
+  });
+
+  it('clamps at 100 rather than overflowing on a long shared list', () => {
+    const ips = Array.from({ length: 20 }, (_, i) => `203.0.113.${i + 1}`);
+    const out = computeOriginIpSignals(
+      [agg({ originIps: ips })],
+      corpus({ suspendedIps: new Map(ips.map((ip) => [ip, ['Dead Co']])) }),
+      cfg,
+      NOW,
+    );
+    expect(out[0]!.score).toBe(100);
+  });
+
+  it('applies NO cardinality cap when many suspended partners share one IP', () => {
+    // The 08-23 lesson: the signup gate silenced its equivalent check once an
+    // IP reached three suspended accounts, on the theory that a busy IP is
+    // shared egress. Every capped IP in production turned out to be an abuse
+    // IP and the guard never once prevented a false positive. More suspended
+    // neighbours must make this signal STRONGER, never silent.
+    const many = ['Dead A', 'Dead B', 'Dead C', 'Dead D', 'Dead E'];
+    const out = computeOriginIpSignals(
+      [agg({ originIps: ['203.0.113.7'] })],
+      corpus({ suspendedIps: new Map([['203.0.113.7', many]]) }),
+      cfg,
+      NOW,
+    );
+
+    expect(keys(out)).toEqual([SUSPENDED_CONSOLE_IP_KEY]);
+    expect(out[0]!.severity).toBe('alert');
+    expect(out[0]!.evidence.suspendedPartners).toEqual(many);
+  });
+
+  it('matches an exact address recorded as a forwarded-for chain', () => {
+    const out = computeOriginIpSignals(
+      [agg({ originIps: ['203.0.113.7, 172.19.0.8'] })],
+      corpus({ suspendedIps: new Map([['203.0.113.7', ['Dead Co']]]) }),
+      cfg,
+      NOW,
+    );
+    expect(keys(out)).toEqual([SUSPENDED_CONSOLE_IP_KEY]);
+  });
+
+  it('matches an IPv6 console address exactly', () => {
+    const ip = '2001:db8:145:2002:64d5:59e4:bb86:ce4d';
+    const out = computeOriginIpSignals(
+      [agg({ originIps: [ip] })],
+      corpus({ suspendedIps: new Map([[ip, ['Dead Co']]]) }),
+      cfg,
+      NOW,
+    );
+    expect(keys(out)).toEqual([SUSPENDED_CONSOLE_IP_KEY]);
+  });
+});
+
+describe('fraud.dead_account_probe_origin', () => {
+  const probe = (ip: string, minutesAgo: number) => ({
+    ip,
+    partnerName: 'Techlace',
+    at: new Date(NOW.getTime() - minutesAgo * 60_000),
+  });
+
+  it('fires when the new account works from the same /24 the operator probed a dead account from', () => {
+    // The 08-31 shape, and the reason this signal is a /24 rather than an
+    // exact match: the operator probed the suspended account from .72 at 14:06
+    // and ran the new one from .61 at 15:08. An exact-IP rule sees nothing.
+    const out = computeOriginIpSignals(
+      [agg({ originIps: ['192.0.2.61'] })],
+      corpus({ probes: [probe('192.0.2.72', 84)] }),
+      cfg,
+      NOW,
+    );
+
+    expect(keys(out)).toEqual([DEAD_ACCOUNT_PROBE_KEY]);
+    expect(out[0]!.score).toBe(cfg['fraud.dead_account_probe_origin.score']);
+    // Deliberately BELOW alert: a /24 is a weaker tie than an exact address,
+    // so this corroborates rather than pages on its own.
+    expect(out[0]!.severity).toBe('watch');
+    expect(scoreToSeverity(out[0]!.score, cfg)).toBe('watch');
+    expect(out[0]!.evidence).toMatchObject({
+      partnerName: 'Nordvane',
+      probedPartners: ['Techlace'],
+    });
+  });
+
+  it('does not fire for a probe outside the window', () => {
+    const hours = cfg['fraud.dead_account_probe_origin.window_hours'];
+    const out = computeOriginIpSignals(
+      [agg({ originIps: ['192.0.2.61'] })],
+      corpus({ probes: [probe('192.0.2.72', hours * 60 + 1)] }),
+      cfg,
+      NOW,
+    );
+    expect(out).toEqual([]);
+  });
+
+  it('does not fire for a probe from a different /24', () => {
+    const out = computeOriginIpSignals(
+      [agg({ originIps: ['192.0.2.61'] })],
+      corpus({ probes: [probe('198.51.100.72', 10)] }),
+      cfg,
+      NOW,
+    );
+    expect(out).toEqual([]);
+  });
+
+  it('matches an IPv6 probe on the /64', () => {
+    const out = computeOriginIpSignals(
+      [agg({ originIps: ['2001:db8:145:2002:aaaa::9'] })],
+      corpus({ probes: [probe('2001:db8:145:2002:64d5:59e4:bb86:ce4d', 10)] }),
+      cfg,
+      NOW,
+    );
+    expect(keys(out)).toEqual([DEAD_ACCOUNT_PROBE_KEY]);
+  });
+
+  it('does not fire for a different IPv6 /64', () => {
+    const out = computeOriginIpSignals(
+      [agg({ originIps: ['2001:db8:145:2003:aaaa::9'] })],
+      corpus({ probes: [probe('2001:db8:145:2002:64d5:59e4:bb86:ce4d', 10)] }),
+      cfg,
+      NOW,
+    );
+    expect(out).toEqual([]);
+  });
+
+  it('is suppressed when the exact-IP signal already fired for that partner', () => {
+    // The exact match strictly dominates the /24 match and they share an axis,
+    // so emitting both would add a row that can never change an outcome.
+    const out = computeOriginIpSignals(
+      [agg({ originIps: ['192.0.2.61'] })],
+      corpus({
+        suspendedIps: new Map([['192.0.2.61', ['Dead Co']]]),
+        probes: [probe('192.0.2.72', 10)],
+      }),
+      cfg,
+      NOW,
+    );
+    expect(keys(out)).toEqual([SUSPENDED_CONSOLE_IP_KEY]);
+  });
+
+  it('deduplicates the probed-partner list', () => {
+    const out = computeOriginIpSignals(
+      [agg({ originIps: ['192.0.2.61'] })],
+      corpus({ probes: [probe('192.0.2.72', 10), probe('192.0.2.90', 20)] }),
+      cfg,
+      NOW,
+    );
+    expect(out[0]!.evidence.probedPartners).toEqual(['Techlace']);
+  });
+});
+
+describe('scoring is independent of account age', () => {
+  it('does not decay — the aggregate carries no created-at for the scorer to weight', () => {
+    // Sibling rule to the billing-identity and script-content detectors: an IP
+    // shared with a suspended operator is evidence about infrastructure, not
+    // about how recently the account was created. A six-week-old pre-position
+    // account (firstsocialcircle sat dormant for six) must score the same as
+    // one signed up minutes ago.
+    const out = computeOriginIpSignals(
+      [agg({ originIps: ['203.0.113.7'] })],
+      corpus({ suspendedIps: new Map([['203.0.113.7', ['Dead Co']]]) }),
+      cfg,
+      NOW,
+    );
+    const later = computeOriginIpSignals(
+      [agg({ originIps: ['203.0.113.7'] })],
+      corpus({ suspendedIps: new Map([['203.0.113.7', ['Dead Co']]]) }),
+      cfg,
+      new Date(NOW.getTime() + 365 * 86_400_000),
+    );
+    expect(later[0]!.score).toBe(out[0]!.score);
+  });
+});
+
+describe('multiple partners', () => {
+  it('scores each partner independently', () => {
+    const out = computeOriginIpSignals(
+      [
+        agg({ partnerId: 'p1', originIps: ['203.0.113.7'] }),
+        // Deliberately in a DIFFERENT /24 from the probe below — 192.0.2.x
+        // would have made this partner a match, not a control.
+        agg({ partnerId: 'p2', partnerName: 'Bellmoor', originIps: ['198.51.100.10'] }),
+        agg({ partnerId: 'p3', partnerName: 'Quillon', originIps: ['192.0.2.61'] }),
+      ],
+      corpus({
+        suspendedIps: new Map([['203.0.113.7', ['Dead Co']]]),
+        probes: [{ ip: '192.0.2.72', partnerName: 'Techlace', at: NOW }],
+      }),
+      cfg,
+      NOW,
+    );
+
+    expect(out.map((s) => [s.partnerId, s.signalKey])).toEqual([
+      ['p1', SUSPENDED_CONSOLE_IP_KEY],
+      ['p3', DEAD_ACCOUNT_PROBE_KEY],
+    ]);
+  });
+});

--- a/apps/api/src/services/abuseSignals/originIp.ts
+++ b/apps/api/src/services/abuseSignals/originIp.ts
@@ -1,0 +1,427 @@
+import { isIP } from 'node:net';
+import { sql } from 'drizzle-orm';
+import { db } from '../../db';
+import { scoreToSeverity, type SignalConfig } from './config';
+import type { ComputedSignal } from './types';
+
+/**
+ * Origin-IP recidivism.
+ *
+ * The signup gate's `stage1.suspended_ip_match` reads ONE address: the IP the
+ * registration request arrived from. That was enough while operators signed up
+ * straight from their own infrastructure. It no longer is — the observed shape
+ * is now:
+ *
+ *   1. probe the suspended account (a failed login) from ring infrastructure,
+ *   2. sign up the replacement from a clean residential address,
+ *   3. only then work the new account from the ring address again.
+ *
+ * Step 2 is what the signup gate sees, and it is clean by construction. The
+ * evidence lives in steps 1 and 3, both of which are console activity that
+ * nothing scored until this detector.
+ *
+ * Two signals, deliberately of different strengths:
+ *
+ *  - `fraud.suspended_console_ip` — an EXACT address shared with a suspended
+ *    partner. Scored to reach alert on a single match, matching the confidence
+ *    the signup gate already assigns to an exact signup-IP match (which has a
+ *    perfect record: every hold it ever placed was a true positive).
+ *
+ *  - `fraud.dead_account_probe_origin` — the partner works from the same /24
+ *    (or IPv6 /64) that someone recently probed a SUSPENDED partner's login
+ *    from. A network is a weaker tie than an address, so this caps below alert
+ *    and corroborates instead. Its looseness is bounded on two sides: the
+ *    counterparty must be a failed login against an already-suspended account,
+ *    and it must be recent.
+ *
+ * Neither is age-decayed. Sibling rule to the billing-identity and
+ * script-content detectors: an address shared with a suspended operator is
+ * evidence about infrastructure, not about how old the account is — and
+ * pre-positioned accounts sit dormant for weeks precisely to age out of
+ * young-account weighting.
+ */
+
+export const SUSPENDED_CONSOLE_IP_KEY = 'fraud.suspended_console_ip';
+export const DEAD_ACCOUNT_PROBE_KEY = 'fraud.dead_account_probe_origin';
+
+export interface PartnerOriginAggregate {
+  partnerId: string;
+  partnerName: string;
+  partnerStatus: 'active' | 'pending';
+  /** Distinct addresses this partner has been seen at: signup_ip plus every audit `ip_address` for its users. */
+  originIps: string[];
+}
+
+export interface DeadAccountProbe {
+  ip: string;
+  /** The suspended partner whose login was probed. */
+  partnerName: string;
+  at: Date;
+}
+
+export interface OriginIpCorpus {
+  /** Exact address -> names of the suspended partners seen at it. */
+  suspendedIps: Map<string, string[]>;
+  probes: DeadAccountProbe[];
+}
+
+export interface OriginIpResult {
+  aggregates: PartnerOriginAggregate[];
+  corpus: OriginIpCorpus;
+  /** Partners this detector actually evaluated, for stale-resolution in persistSignals. */
+  scannedPartnerIds: string[];
+}
+
+/**
+ * Pull the client address out of whatever `audit_logs.ip_address` holds.
+ *
+ * That column is a varchar and production holds three shapes: a bare address,
+ * the literal string `unknown` (rows written before the field was populated),
+ * and — on older rows — an unreduced `X-Forwarded-For` chain such as
+ * `"198.51.100.9, 172.19.0.8"`, where the second hop is the container-internal
+ * proxy address. The leftmost entry is the client, which is the one that
+ * identifies the operator; taking the whole string instead would parse as
+ * nothing and silently drop the row's origin entirely.
+ */
+function clientIp(raw: string): string {
+  const first = raw.split(',')[0] ?? '';
+  return first.trim();
+}
+
+/**
+ * Collapse an address to the network we treat as "the same place": /24 for
+ * IPv4, /64 for IPv6 (the smallest unit routinely assigned to one customer).
+ *
+ * Returns null for anything that is not an address — `unknown` and other junk
+ * must never match each other, or every legacy row would correlate with every
+ * other one.
+ */
+export function networkPrefix(raw: string): string | null {
+  const ip = clientIp(raw);
+  const version = isIP(ip);
+  if (version === 4) {
+    const octets = ip.split('.');
+    return `v4:${octets[0]}.${octets[1]}.${octets[2]}`;
+  }
+  if (version === 6) {
+    const groups = expandIPv6(ip);
+    if (!groups) return null;
+    return `v6:${groups.slice(0, 4).join(':')}`;
+  }
+  return null;
+}
+
+/**
+ * Expand an IPv6 literal to its eight zero-padded groups.
+ *
+ * Written out rather than compared as strings because the same /64 arrives in
+ * both forms — `2001:db8:145:2002::1` from one request and
+ * `2001:db8:0145:2002:64d5:59e4:bb86:ce4d` from the next — and a textual
+ * prefix comparison would read those as two unrelated networks, which is
+ * exactly the hop this detector exists to catch.
+ */
+function expandIPv6(ip: string): string[] | null {
+  // An embedded IPv4 tail (::ffff:203.0.113.7) contributes two groups.
+  const v4Tail = ip.match(/(\d{1,3}(?:\.\d{1,3}){3})$/);
+  let work = ip;
+  if (v4Tail) {
+    const octets = v4Tail[1]!.split('.').map(Number);
+    if (octets.some((o) => !Number.isInteger(o) || o > 255)) return null;
+    const hi = ((octets[0]! << 8) | octets[1]!).toString(16);
+    const lo = ((octets[2]! << 8) | octets[3]!).toString(16);
+    work = `${ip.slice(0, ip.length - v4Tail[1]!.length)}${hi}:${lo}`;
+  }
+
+  const halves = work.split('::');
+  if (halves.length > 2) return null;
+  const parse = (segment: string): string[] | null => {
+    if (segment === '') return [];
+    const out: string[] = [];
+    for (const group of segment.split(':')) {
+      if (!/^[0-9a-fA-F]{1,4}$/.test(group)) return null;
+      out.push(group.toLowerCase().padStart(4, '0'));
+    }
+    return out;
+  };
+
+  const head = parse(halves[0]!);
+  if (head === null) return null;
+  if (halves.length === 1) return head.length === 8 ? head : null;
+  const tail = parse(halves[1]!);
+  if (tail === null) return null;
+  const fill = 8 - head.length - tail.length;
+  if (fill < 0) return null;
+  return [...head, ...Array<string>(fill).fill('0000'), ...tail];
+}
+
+/** Normalize for exact comparison: IPv6 compression must not defeat an exact match. */
+function canonical(raw: string): string | null {
+  const ip = clientIp(raw);
+  const version = isIP(ip);
+  if (version === 4) return `v4:${ip}`;
+  if (version === 6) {
+    const groups = expandIPv6(ip);
+    return groups ? `v6:${groups.join(':')}` : null;
+  }
+  return null;
+}
+
+/**
+ * Pure — no I/O.
+ *
+ * Note what is deliberately absent: any cap on how many suspended partners may
+ * share an address. The signup gate shipped exactly that guard and it silenced
+ * the check the moment an IP reached its third suspended account — on the
+ * theory that a busy address must be shared egress. In production every capped
+ * address turned out to be ring infrastructure and the guard never once
+ * prevented a false positive; it only ever hid the third, fourth and fifth
+ * account of a ring that had already been proven. More suspended neighbours
+ * make this signal stronger, never quieter.
+ */
+export function computeOriginIpSignals(
+  aggregates: PartnerOriginAggregate[],
+  corpus: OriginIpCorpus,
+  cfg: SignalConfig,
+  now: Date,
+): ComputedSignal[] {
+  const base = cfg['fraud.suspended_console_ip.base_score'];
+  const perExtra = cfg['fraud.suspended_console_ip.per_extra_ip'];
+  const probeScore = cfg['fraud.dead_account_probe_origin.score'];
+  const windowMs = cfg['fraud.dead_account_probe_origin.window_hours'] * 3_600_000;
+
+  // Exact-match index, keyed canonically so a compressed IPv6 literal on one
+  // side and an expanded one on the other still meet.
+  const suspendedByCanonical = new Map<string, string[]>();
+  for (const [ip, names] of corpus.suspendedIps) {
+    const key = canonical(ip);
+    if (!key) continue;
+    const existing = suspendedByCanonical.get(key);
+    if (existing) existing.push(...names);
+    else suspendedByCanonical.set(key, [...names]);
+  }
+
+  const probesByPrefix = new Map<string, DeadAccountProbe[]>();
+  for (const probe of corpus.probes) {
+    if (now.getTime() - probe.at.getTime() > windowMs) continue;
+    // A probe timestamped in the future is clock skew, not evidence.
+    if (probe.at.getTime() > now.getTime()) continue;
+    const prefix = networkPrefix(probe.ip);
+    if (!prefix) continue;
+    const existing = probesByPrefix.get(prefix);
+    if (existing) existing.push(probe);
+    else probesByPrefix.set(prefix, [probe]);
+  }
+
+  const out: ComputedSignal[] = [];
+  for (const partner of aggregates) {
+    const matchedIps: string[] = [];
+    const suspendedPartners: string[] = [];
+    const seenSuspended = new Set<string>();
+
+    for (const ip of partner.originIps) {
+      const key = canonical(ip);
+      if (!key) continue;
+      const names = suspendedByCanonical.get(key);
+      if (!names) continue;
+      matchedIps.push(ip.trim());
+      for (const name of names) {
+        if (seenSuspended.has(name)) continue;
+        seenSuspended.add(name);
+        suspendedPartners.push(name);
+      }
+    }
+
+    if (matchedIps.length > 0) {
+      const score = Math.min(100, Math.round(base + perExtra * (matchedIps.length - 1)));
+      out.push({
+        partnerId: partner.partnerId,
+        signalKey: SUSPENDED_CONSOLE_IP_KEY,
+        score,
+        severity: scoreToSeverity(score, cfg),
+        // Key order matters: index.ts truncates serialised evidence at 800
+        // chars, so the human-readable identifiers lead.
+        evidence: {
+          partnerName: partner.partnerName,
+          partnerStatus: partner.partnerStatus,
+          matchedIps,
+          suspendedPartners,
+        },
+      });
+      // The exact match strictly dominates a /24 match and the two share a
+      // corroboration axis, so a second row could never change an outcome.
+      continue;
+    }
+
+    const probedPartners: string[] = [];
+    const matchedPrefixes: string[] = [];
+    const seenProbed = new Set<string>();
+    for (const ip of partner.originIps) {
+      const prefix = networkPrefix(ip);
+      if (!prefix) continue;
+      const probes = probesByPrefix.get(prefix);
+      if (!probes) continue;
+      if (!matchedPrefixes.includes(prefix)) matchedPrefixes.push(prefix);
+      for (const probe of probes) {
+        if (seenProbed.has(probe.partnerName)) continue;
+        seenProbed.add(probe.partnerName);
+        probedPartners.push(probe.partnerName);
+      }
+    }
+
+    if (probedPartners.length === 0) continue;
+    out.push({
+      partnerId: partner.partnerId,
+      signalKey: DEAD_ACCOUNT_PROBE_KEY,
+      score: probeScore,
+      severity: scoreToSeverity(probeScore, cfg),
+      evidence: {
+        partnerName: partner.partnerName,
+        partnerStatus: partner.partnerStatus,
+        probedPartners,
+        matchedNetworks: matchedPrefixes,
+      },
+    });
+  }
+  return out;
+}
+
+/**
+ * Every audit lookup below reaches `audit_logs` through
+ * `audit_logs_actor_email_timestamp_idx` — the ONLY selective index that table
+ * has. It carries ~5M rows / 4GB in production with no index on `action`,
+ * `actor_id`, `ip_address` or `timestamp` alone, so any predicate that starts
+ * from one of those is a full sequential scan.
+ *
+ * Three shape rules, each measured against the production US database
+ * (the larger of the two regions) because each earlier draft was too slow:
+ *
+ *  1. **Bound every audit read by `timestamp`.** Leaving the suspended-partner
+ *     corpus unbounded cost 15s and returned byte-identical rows to a 365-day
+ *     bound at 0.4s: suspended accounts stop generating audit rows when they
+ *     are suspended, so the unbounded tail is empty by construction.
+ *
+ *  2. **Never put `action` in a predicate that has to stand on its own.**
+ *     Filtering `action = 'user.login.failed'` as a separate CTE made the
+ *     planner abandon the email index and the query timed out at 180s. It is
+ *     applied here as a FILTER clause on an aggregate that is already reading
+ *     the rows for another reason.
+ *
+ *  3. **Aggregate INSIDE the single read.** Materialising raw audit rows and
+ *     grouping them afterwards cost 45s; grouping to `(name, ip)` inside the
+ *     CTE — ~220 rows out of it — costs 2.1s cold and 144ms warm.
+ *
+ * If you extend this query, keep `actor_email` as the entry point and re-time
+ * it against the larger region rather than trusting a local dataset.
+ */
+export async function loadOriginIpAggregates(): Promise<OriginIpResult> {
+  const rows = (await db.execute(sql`
+    WITH scoped AS (
+      SELECT p.id, p.name, p.status, p.signup_ip
+      FROM partners p
+      -- 'pending' is in scope for the same reason billingIdentity includes it:
+      -- a pre-positioned account never activates, so an active-only detector
+      -- is blind to the entire shape this one exists to catch.
+      WHERE p.deleted_at IS NULL AND p.status IN ('active', 'pending')
+        AND (
+          p.created_at > now() - interval '90 days'
+          OR EXISTS (
+            SELECT 1 FROM partner_abuse_signals pas
+            WHERE pas.partner_id = p.id AND pas.resolved_at IS NULL
+              AND pas.signal_key IN (${SUSPENDED_CONSOLE_IP_KEY}, ${DEAD_ACCOUNT_PROBE_KEY})
+          )
+        )
+    ),
+    -- No bound on how long ago the partner was SUSPENDED, on purpose: an
+    -- operator who returns four months later is exactly who this is for. The
+    -- 365-day bound below is on how far back we read their audit history,
+    -- which is a different thing — a suspended account stops producing rows.
+    suspended AS MATERIALIZED (
+      SELECT p.id, p.name, p.signup_ip
+      FROM partners p
+      WHERE p.deleted_at IS NULL AND p.status = 'suspended'
+    ),
+    -- ONE pass over the suspended operators' audit history, aggregated in
+    -- place to ~200 rows. last_failed_at doubles as the probe detector: a
+    -- failed login against a user who belongs to an ALREADY-SUSPENDED partner
+    -- is the operator rattling the handle on the dead account, and on every
+    -- case on record it precedes the replacement signup. See rules 2 and 3 in
+    -- the header before touching the FILTER.
+    susp_audit AS MATERIALIZED (
+      SELECT sp.name, al.ip_address AS ip,
+        max(al."timestamp") FILTER (
+          WHERE al.action = 'user.login.failed' AND al."timestamp" > now() - interval '30 days'
+        ) AS last_failed_at
+      FROM suspended sp
+      JOIN users u ON u.partner_id = sp.id
+      JOIN audit_logs al ON al.actor_email = u.email
+      WHERE al."timestamp" > now() - interval '365 days'
+        AND al.ip_address IS NOT NULL AND al.ip_address <> 'unknown'
+      GROUP BY sp.name, al.ip_address
+    ),
+    scoped_ips AS (
+      SELECT s.id AS partner_id, s.name, s.status::text AS status, host(s.signup_ip::inet) AS ip
+      FROM scoped s WHERE s.signup_ip IS NOT NULL
+      UNION
+      SELECT s.id, s.name, s.status::text, al.ip_address
+      FROM scoped s
+      JOIN users u ON u.partner_id = s.id
+      JOIN audit_logs al ON al.actor_email = u.email
+      WHERE al."timestamp" > now() - interval '90 days'
+        AND al.ip_address IS NOT NULL AND al.ip_address <> 'unknown'
+    ),
+    suspended_ip_list AS (
+      SELECT sp.name, host(sp.signup_ip::inet) AS ip
+      FROM suspended sp WHERE sp.signup_ip IS NOT NULL
+      UNION
+      SELECT name, ip FROM susp_audit
+    ),
+    probe_list AS (
+      SELECT name, ip, last_failed_at AS at FROM susp_audit WHERE last_failed_at IS NOT NULL
+    )
+    SELECT 'scoped' AS kind, partner_id::text AS partner_id, name, status, ip, NULL::timestamptz AS at FROM scoped_ips
+    UNION ALL
+    SELECT 'suspended', NULL, name, NULL, ip, NULL FROM suspended_ip_list
+    UNION ALL
+    SELECT 'probe', NULL, name, NULL, ip, at FROM probe_list
+  `)) as unknown as Array<{
+    kind: 'scoped' | 'suspended' | 'probe';
+    partner_id: string | null;
+    name: string;
+    status: string | null;
+    ip: string;
+    at: Date | string | null;
+  }>;
+
+  const byPartner = new Map<string, PartnerOriginAggregate>();
+  const suspendedIps = new Map<string, string[]>();
+  const probes: DeadAccountProbe[] = [];
+
+  for (const row of rows) {
+    if (row.kind === 'scoped') {
+      if (!row.partner_id) continue;
+      let agg = byPartner.get(row.partner_id);
+      if (!agg) {
+        agg = {
+          partnerId: row.partner_id,
+          partnerName: row.name,
+          partnerStatus: row.status === 'pending' ? 'pending' : 'active',
+          originIps: [],
+        };
+        byPartner.set(row.partner_id, agg);
+      }
+      if (!agg.originIps.includes(row.ip)) agg.originIps.push(row.ip);
+    } else if (row.kind === 'suspended') {
+      const names = suspendedIps.get(row.ip);
+      if (names) {
+        if (!names.includes(row.name)) names.push(row.name);
+      } else {
+        suspendedIps.set(row.ip, [row.name]);
+      }
+    } else if (row.at) {
+      probes.push({ ip: row.ip, partnerName: row.name, at: new Date(row.at) });
+    }
+  }
+
+  const aggregates = [...byPartner.values()];
+  return { aggregates, corpus: { suspendedIps, probes }, scannedPartnerIds: aggregates.map((a) => a.partnerId) };
+}

--- a/apps/api/src/services/abuseSignals/sweep.test.ts
+++ b/apps/api/src/services/abuseSignals/sweep.test.ts
@@ -15,6 +15,7 @@ const {
   syncEndpointFingerprints,
   loadRecidivistMatches,
   computeRecidivistSignals,
+  loadOriginIpAggregates,
   persistSignals,
   markDelivered,
   sendOpsAlert,
@@ -32,6 +33,7 @@ const {
   syncEndpointFingerprints: vi.fn(),
   loadRecidivistMatches: vi.fn(),
   computeRecidivistSignals: vi.fn(),
+  loadOriginIpAggregates: vi.fn(),
   persistSignals: vi.fn(),
   markDelivered: vi.fn(),
   sendOpsAlert: vi.fn(),
@@ -57,6 +59,13 @@ vi.mock('./recidivistEndpoint', () => ({
   syncEndpointFingerprints,
   loadRecidivistMatches,
   computeRecidivistSignals,
+}));
+// computeOriginIpSignals is deliberately NOT mocked — the wiring test below
+// proves the real scorer runs inside the sweep and its output reaches
+// persistSignals and the corroborator.
+vi.mock('./originIp', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./originIp')>()),
+  loadOriginIpAggregates,
 }));
 vi.mock('./persistence', () => ({ persistSignals, markDelivered }));
 vi.mock('../opsAlerts', () => ({ sendOpsAlert, isOpsAlertingConfigured: vi.fn(() => true) }));
@@ -115,6 +124,11 @@ beforeEach(() => {
   syncEndpointFingerprints.mockResolvedValue(undefined);
   loadRecidivistMatches.mockResolvedValue({ matches: [], scannedPartnerIds: [] });
   computeRecidivistSignals.mockReturnValue([]);
+  loadOriginIpAggregates.mockResolvedValue({
+    aggregates: [],
+    corpus: { suspendedIps: new Map(), probes: [] },
+    scannedPartnerIds: [],
+  });
   persistSignals.mockResolvedValue({ toNotify: [] });
   markDelivered.mockResolvedValue(undefined);
 });
@@ -318,5 +332,87 @@ describe('runAbuseSweep — corroboration wiring', () => {
 
     expect(result.fired).toBe(3);
     expect(recordAbuseSignalFired).toHaveBeenCalledWith('alert');
+  });
+});
+
+describe('runAbuseSweep — origin-IP detector wiring', () => {
+  it('reproduces the 08-31 re-establishment: a /24 probe match plus a billing mismatch pages', async () => {
+    // The account that got away. The operator probed a SUSPENDED partner's
+    // login from 192.0.2.72, signed up minutes later from a clean residential
+    // address (so the signup gate saw nothing), then worked the new account
+    // from 192.0.2.61. Its only signal was a capped billing watch, which
+    // notified nobody, and $99 was captured before anyone looked.
+    //
+    // Origin-IP contributes a second INDEPENDENT axis, and the pair clears
+    // severity.alert_score through the existing corroborator.
+    loadOriginIpAggregates.mockResolvedValue({
+      aggregates: [
+        {
+          partnerId: 'p1',
+          partnerName: 'Nordvane',
+          partnerStatus: 'active' as const,
+          originIps: ['192.0.2.61'],
+        },
+      ],
+      corpus: {
+        suspendedIps: new Map(),
+        probes: [{ ip: '192.0.2.72', partnerName: 'Techlace', at: new Date() }],
+      },
+      scannedPartnerIds: ['p1'],
+    });
+    computeBillingIdentitySignals.mockReturnValue([
+      {
+        partnerId: 'p1',
+        signalKey: 'billing.cardholder_name_mismatch',
+        score: 55,
+        severity: 'watch',
+        evidence: { partnerName: 'Nordvane' },
+      },
+    ]);
+
+    await runAbuseSweep();
+
+    const persisted = persistSignals.mock.calls[0]![0] as ComputedSignal[];
+    const byKey = new Map(persisted.map((s) => [s.signalKey, s]));
+
+    // The detector itself stays honest at watch — a /24 is a weaker tie than
+    // an exact address.
+    expect(byKey.get('fraud.dead_account_probe_origin')?.severity).toBe('watch');
+    // ...and the two axes together reach alert, which is what pages.
+    const corroborated = byKey.get('fraud.corroborated_watch');
+    expect(corroborated?.severity).toBe('alert');
+    expect(corroborated?.evidence.axisCount).toBe(2);
+
+    // Origin-IP-scanned partners must join the evaluated set, or their rows can
+    // never stale-resolve once the operator's infrastructure goes quiet.
+    const evaluated = persistSignals.mock.calls[0]![2] as Set<string>;
+    expect(evaluated.has('p1')).toBe(true);
+  });
+
+  it('does not double-count the two origin-IP signals as independent axes', async () => {
+    // Both signals restate one observation. An exact match already suppresses
+    // the /24 row, but even if both were present they share an axis and must
+    // not manufacture an alert between themselves.
+    loadOriginIpAggregates.mockResolvedValue({
+      aggregates: [
+        {
+          partnerId: 'p1',
+          partnerName: 'Nordvane',
+          partnerStatus: 'pending' as const,
+          originIps: ['192.0.2.61'],
+        },
+      ],
+      corpus: {
+        suspendedIps: new Map(),
+        probes: [{ ip: '192.0.2.72', partnerName: 'Techlace', at: new Date() }],
+      },
+      scannedPartnerIds: ['p1'],
+    });
+
+    await runAbuseSweep();
+
+    const persisted = persistSignals.mock.calls[0]![0] as ComputedSignal[];
+    expect(persisted.map((s) => s.signalKey)).toEqual(['fraud.dead_account_probe_origin']);
+    expect(persisted.some((s) => s.signalKey === 'fraud.corroborated_watch')).toBe(false);
   });
 });

--- a/apps/api/src/services/abuseSignals/sweep.test.ts
+++ b/apps/api/src/services/abuseSignals/sweep.test.ts
@@ -275,3 +275,48 @@ describe('runAbuseSweep', () => {
     expect([...evaluatedPartnerIds].sort()).toEqual(['pA', 'pRecidivist']);
   });
 });
+
+describe('runAbuseSweep — corroboration wiring', () => {
+  // The pure scorer is covered in corroboration.test.ts; these prove the sweep
+  // actually feeds it every detector's output and persists what it returns.
+  // './corroboration' is deliberately NOT mocked here.
+  function watch(signalKey: string, score: number, partnerId = 'p1'): ComputedSignal {
+    return { partnerId, signalKey, score, severity: 'watch', evidence: { partnerName: 'Acme' } };
+  }
+
+  it('emits a corroborated alert from watch signals produced by DIFFERENT detectors', async () => {
+    // session_intensity comes from heuristics, cardholder_name_mismatch from
+    // billingIdentity — the cross-detector case that motivated this.
+    computeHeuristicSignals.mockReturnValue([watch('rmm.session_intensity', 65)]);
+    computeBillingIdentitySignals.mockReturnValue([watch('billing.cardholder_name_mismatch', 55)]);
+
+    await runAbuseSweep();
+
+    const persisted = persistSignals.mock.calls[0]![0] as ComputedSignal[];
+    const corroborated = persisted.filter((s) => s.signalKey === 'fraud.corroborated_watch');
+    expect(corroborated).toHaveLength(1);
+    expect(corroborated[0]!.severity).toBe('alert');
+    expect(corroborated[0]!.partnerId).toBe('p1');
+    // The underlying signals are still persisted at their own honest severity.
+    expect(persisted.filter((s) => s.severity === 'watch')).toHaveLength(2);
+  });
+
+  it('does not corroborate when only one axis fires', async () => {
+    computeHeuristicSignals.mockReturnValue([watch('rmm.session_intensity', 65)]);
+
+    await runAbuseSweep();
+
+    const persisted = persistSignals.mock.calls[0]![0] as ComputedSignal[];
+    expect(persisted.some((s) => s.signalKey === 'fraud.corroborated_watch')).toBe(false);
+  });
+
+  it('counts the corroborated signal in the fired total and the severity metric', async () => {
+    computeHeuristicSignals.mockReturnValue([watch('rmm.session_intensity', 65)]);
+    computeBillingIdentitySignals.mockReturnValue([watch('billing.cardholder_name_mismatch', 55)]);
+
+    const result = await runAbuseSweep();
+
+    expect(result.fired).toBe(3);
+    expect(recordAbuseSignalFired).toHaveBeenCalledWith('alert');
+  });
+});


### PR DESCRIPTION
## Summary

Two additions to the abuse-signal sweep, closing gaps observed in the 08-23 → 08-31 incident run:

**1. Cross-signal corroboration (`fraud.corroborated_watch`)** — the "second signal" that the capped watch-tier scores (`session_intensity`, `cardholder_name_mismatch`, generic `provider_default_hostname`) have always referred to but which never existed: a partner could fire several capped watch signals and never notify anyone. Runs last in the sweep, reads only what the detectors already produced (no extra queries), counts **distinct evidence axes** (detectors restating one observation share an axis), and promotes 2+ corroborated axes to alert (55 + 15 = 70 at defaults). Tightened after design review: axis dedup, promotion policy, and sweep wiring proven by test.

**2. Origin-IP recidivism (`originIp.ts`)** — the signup gate's `stage1.suspended_ip_match` reads only the registration request IP, and the observed ring shape now signs up from a clean residential address while probing/working the account from ring infrastructure (08-31: techlace/airbagluxhub shared a console-login IP the scoring never saw). Two signals of deliberately different strengths:
- `fraud.suspended_console_ip` — exact address shared with a suspended partner; alerts on a single match (mirrors the signup gate's perfect-record exact-IP confidence).
- `fraud.dead_account_probe_origin` — same /24 (IPv6 /64) as a recent failed login against an already-suspended account; caps below alert and corroborates instead.

Neither is age-decayed — pre-positioned accounts sit dormant precisely to age out of young-account weighting.

Rebased onto main; merged additively with the recidivist-endpoint detector that landed there (both detectors + both config blocks wired into the sweep and the evaluated set).

## Testing
- `apps/api` abuseSignals suite: 11 files, 273 tests pass post-rebase (includes sweep wiring tests proving corroboration reads real detector output and originIp's real scorer runs in the sweep).
- ESLint clean on `src/services/abuseSignals/`; `tsc --noEmit` shows only a pre-existing unrelated `cron-parser` resolution error in `scheduleRegistry.contract.test.ts`.
- No migrations, no schema/tenancy changes — RLS/cascade contracts untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012p7gDFgGMniE4CkVJV3ESj