### PR TITLE
docs(release-notes): next-release draft — #4324 loopback refusal + #4323 maintenance-window start times

### DIFF
--- a/docs/release-notes/next-release-draft.md
+++ b/docs/release-notes/next-release-draft.md
@@ -8,7 +8,7 @@ Add an entry the moment you introduce something an operator or self-hoster would
 notice — a new env var, a new log line, a new metric, a changed default, a
 behaviour change. A commit subject weeks later will not carry it.
 
-Last release: **v0.106.0** (2026-08-17).
+Last release: **v0.108.0** (2026-08-26). `v0.109.0-rc.*` tags exist as drafts.
 
 ---
 
@@ -50,3 +50,45 @@ Last release: **v0.106.0** (2026-08-17).
   `source` has it stripped by validation and the server's own stamp always wins.
 - No new environment variables. No action required for existing deployments beyond the
   migration note above.
+
+## Breaking — self-hosters running a local LLM over loopback (#4324, merged)
+
+Merged 2026-09-01 (PR #4324, closes #4121).
+
+`MCP_LLM_PROVIDER=openai-compatible` now routes its egress through the guarded
+`safeFetch` path (connect-time DNS pinning, private-network filtering, explicit
+redirect refusal) instead of raw global `fetch`. The shared guard contract
+permits RFC1918/ULA when the self-host private-network opt-in is set but
+**never permits loopback**, and that contract is deliberately not broadened.
+
+Consequence: a **bare-metal** install with
+`MCP_LLM_BASE_URL=http://localhost:8000/v1` (or `http://127.0.0.1:8000/v1`) will
+stop working. The refusal is explicit, not silent — the error names the fix.
+Point `MCP_LLM_BASE_URL` at the model host's **container service name or LAN
+(RFC1918/ULA) address** instead of `localhost`.
+
+Containerized deployments are unaffected: a Compose service name resolves to a
+private address and already passes. Note the default value of
+`MCP_LLM_BASE_URL` is still `http://localhost:8000/v1`, so anyone relying on the
+default on bare metal is affected.
+
+## Fixed — recurring maintenance windows fire at the configured time (#4323, merged)
+
+Merged 2026-08-31 (PR #4323, closes #4224).
+
+Configuration-policy maintenance windows with `daily` / `weekly` / `monthly`
+recurrence had **no start-time control in the UI**, and the evaluator hardcoded
+every recurring window to **local midnight**. A policy configured as "daily, 2h,
+Europe/Warsaw" was silently enforcing 00:00–02:00 Warsaw — a window the admin
+never chose and the UI never displayed.
+
+`config_policy_maintenance_settings.window_start` is now recurrence-discriminated
+(`once` = ISO-8601 local datetime as before; `daily`/`weekly`/`monthly` = `HH:MM`,
+anchored to every day / Sunday / the 1st respectively), and the evaluator resolves
+the most recent occurrence at or before now.
+
+**Operator-visible behaviour change.** There is **no migration** — the column is
+already `varchar(30)` and **NULL keeps meaning midnight**, so every existing
+policy keeps the schedule it has today. But any policy an admin now edits to set a
+real start time will begin firing at that time rather than at midnight, which is
+the point. Worth calling out so nobody reads a shifted window as a regression.


### PR DESCRIPTION
Adds two entries to `docs/release-notes/next-release-draft.md` for the next `/release` pass:

- **Breaking — #4324** (merged 2026-09-01): `openai-compatible` LLM egress now goes through guarded `safeFetch`; loopback is never dialable, so bare-metal self-hosters with `MCP_LLM_BASE_URL=http://localhost:8000/v1` (including the untouched default) must switch to the model host's service name or LAN address. Compose deployments unaffected.
- **Fixed — #4323** (merged 2026-08-31): recurring maintenance windows get a real start time; the evaluator previously pinned every recurring window to local midnight. No migration; NULL keeps meaning midnight.

Also updates the stale "Last release" header line (v0.106.0 → v0.108.0) and preserves the existing #3900 section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTQvd5qr2a9CNSjzshsUzS