### PR TITLE
fix(security): Trivy-scan the api/web images we actually ship (#4273)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -157,77 +157,61 @@ jobs:
           format: 'table'
           exit-code: '1'
 
+  # Builds and scans every container image this repo publishes, using the SAME
+  # Dockerfile the release lanes ship.
+  #
+  # This list used to be hand-maintained beside the publish lists in release.yml
+  # and hosted-images.yml, and the two drifted: the job built the
+  # `docker/Dockerfile.api|web` compose variants while release/hosted shipped
+  # `apps/api|web/Dockerfile`, so the two most widely deployed images in the
+  # product were gated by nothing and shipped a known HIGH CVE
+  # (issues #4273 / #4260). `apps/api/src/config/dockerfileImageScanCoverage.test.ts`
+  # now derives the published set from those workflows and fails if anything
+  # published is missing from the matrix below.
   trivy-image-scan:
-    name: Trivy Image Scan
+    name: Trivy Image Scan (${{ matrix.image }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # --- Published to GHCR by release.yml and hosted-images.yml ---
+          - image: api
+            dockerfile: apps/api/Dockerfile
+          - image: web
+            dockerfile: apps/web/Dockerfile
+          - image: portal
+            dockerfile: apps/portal/Dockerfile
+          - image: m365-graph-read-executor
+            dockerfile: apps/m365-graph-read-executor/Dockerfile
+          - image: m365-graph-actions-executor
+            dockerfile: apps/m365-graph-actions-executor/Dockerfile
+          - image: m365-communications-executor
+            dockerfile: apps/m365-communications-executor/Dockerfile
+          # --- Never published, but built from source by CI and by users ---
+          # ci.yml's smoke test builds these via docker-compose.override.yml.ci,
+          # and self-hosters build them via docker-compose.override.yml.local-build,
+          # so they stay gated too.
+          - image: api-compose
+            dockerfile: docker/Dockerfile.api
+          - image: web-compose
+            dockerfile: docker/Dockerfile.web
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
-      - name: Build API image
-        run: docker build -f docker/Dockerfile.api -t breeze-api:security-scan .
+      - name: Build image
+        env:
+          DOCKERFILE: ${{ matrix.dockerfile }}
+          IMAGE: ${{ matrix.image }}
+        run: docker build -f "$DOCKERFILE" -t "breeze-${IMAGE}:security-scan" .
 
-      - name: Build Web image
-        run: docker build -f docker/Dockerfile.web -t breeze-web:security-scan .
-
-      - name: Build Portal image
-        run: docker build -f apps/portal/Dockerfile -t breeze-portal:security-scan .
-
-      - name: Build M365 Graph Read Executor image
-        run: docker build -f apps/m365-graph-read-executor/Dockerfile -t breeze-m365-graph-read-executor:security-scan .
-
-      - name: Build M365 Graph Actions Executor image
-        run: docker build -f apps/m365-graph-actions-executor/Dockerfile -t breeze-m365-graph-actions-executor:security-scan .
-
-      - name: Build M365 Communications Executor image
-        run: docker build -f apps/m365-communications-executor/Dockerfile -t breeze-m365-communications-executor:security-scan .
-
-      - name: Scan API image
+      - name: Scan image
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          image-ref: 'breeze-api:security-scan'
-          severity: 'HIGH,CRITICAL'
-          format: 'table'
-          exit-code: '1'
-
-      - name: Scan Web image
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        with:
-          image-ref: 'breeze-web:security-scan'
-          severity: 'HIGH,CRITICAL'
-          format: 'table'
-          exit-code: '1'
-
-      - name: Scan Portal image
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        with:
-          image-ref: 'breeze-portal:security-scan'
-          severity: 'HIGH,CRITICAL'
-          format: 'table'
-          exit-code: '1'
-
-      - name: Scan M365 Graph Read Executor image
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        with:
-          image-ref: 'breeze-m365-graph-read-executor:security-scan'
-          severity: 'HIGH,CRITICAL'
-          format: 'table'
-          exit-code: '1'
-
-      - name: Scan M365 Graph Actions Executor image
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        with:
-          image-ref: 'breeze-m365-graph-actions-executor:security-scan'
-          severity: 'HIGH,CRITICAL'
-          format: 'table'
-          exit-code: '1'
-
-      - name: Scan M365 Communications Executor image
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        with:
-          image-ref: 'breeze-m365-communications-executor:security-scan'
+          image-ref: 'breeze-${{ matrix.image }}:security-scan'
           severity: 'HIGH,CRITICAL'
           format: 'table'
           exit-code: '1'

--- a/apps/api/src/config/dockerfileImageScanCoverage.test.ts
+++ b/apps/api/src/config/dockerfileImageScanCoverage.test.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import path from 'node:path';
+import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { load } from 'js-yaml';
 import { describe, expect, it } from 'vitest';
@@ -19,12 +20,12 @@ import { describe, expect, it } from 'vitest';
  *
  * The durable defect was the hand-maintained parallel list: a scan roster kept
  * by hand next to a publish roster kept by hand, with nothing tying the two
- * together. So this guard does not hand-list anything. It derives:
+ * together. So this guard hand-lists neither. It derives:
  *
  *  - **published** — every `file:` input of every `docker/build-push-action`
- *    step in `release.yml` and `hosted-images.yml` whose step actually pushes
- *    (`push: true`, or `outputs: ...push=true` for the push-by-digest lanes),
- *    with `${{ matrix.* }}` expanded against that job's own matrix.
+ *    step, in every workflow, whose step actually pushes (`push: true`, or
+ *    `outputs: ...push=true` for the push-by-digest lanes), with
+ *    `${{ matrix.* }}` expanded against that job's own matrix.
  *  - **scanned** — the `dockerfile:` values of `security.yml`'s
  *    `trivy-image-scan` matrix.
  *
@@ -32,32 +33,53 @@ import { describe, expect, it } from 'vitest';
  * Add a new published image and this test fails until it is scanned; retarget a
  * publish step at a different Dockerfile and it fails until the scan follows.
  *
+ * Anything the derivation cannot resolve **throws** rather than resolving to
+ * nothing. That asymmetry is deliberate: every assertion here is a set
+ * comparison, so a derivation that silently shrinks turns the whole suite
+ * vacuously green — the same "green means nothing" failure this file exists to
+ * prevent, one level up.
+ *
  * This is a static read of the workflow YAML; it never invokes Docker or the
  * GitHub API.
  *
- * Scope note: this covers the **CI** gate (`security.yml` runs on every PR,
- * every push to `main`, and weekly). Release-*time* digest scanning
- * (build → scan the exact manifest → promote the tag) exists today only for the
- * three M365 executors; extending it to api/web/portal/binaries means
- * hand-rolling the multi-tag promotion that `docker/metadata-action` currently
- * does for those jobs, and is deliberately left to a follow-up.
+ * ## What this guard does NOT prove
+ *
+ * Recorded so they are not mistaken for coverage:
+ *
+ *  1. **That the images are clean.** It proves the scan job *looks at* every
+ *     published Dockerfile. Whether Trivy then finds something is CI's job.
+ *  2. **That the scan job's result blocks a merge.** It does not, today:
+ *     `main`'s ruleset requires exactly one status check, `CI Success`, whose
+ *     `needs:` list contains no job from this workflow. So a red
+ *     `Trivy Image Scan` is *visible* — on the PR, and on `main` — but not
+ *     merge-blocking, before or after this change. (That visibility is what
+ *     eventually surfaced CVE-2026-14456; see dockerfileOpensslUpgrade.test.ts.)
+ *     `runs on pull requests and blocks on failure` below checks what is
+ *     checkable from inside the repo — the trigger, the absence of a job-level
+ *     `if:`, the absence of `continue-on-error` — but branch protection lives
+ *     in repo settings, which no test here can read. Related: the matrix
+ *     conversion renamed the check from `Trivy Image Scan` to
+ *     `Trivy Image Scan (<image>)`. That is safe only because nothing requires
+ *     the old context; if these are ever made required, they must be added as
+ *     the eight new per-image contexts.
+ *  3. **That the scanned build and the published build are the same bytes.**
+ *     CI builds the Dockerfile at PR time; `release.yml` builds it again at tag
+ *     time. Only the three M365 executors scan the exact published manifest
+ *     before promoting its tag. `release-time digest scanning` below snapshots
+ *     which published images have that and which do not, so the gap stays
+ *     visible rather than silent.
  */
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
 
-const SECURITY_WORKFLOW = '.github/workflows/security.yml';
+const WORKFLOW_DIR = '.github/workflows';
+const SECURITY_WORKFLOW = `${WORKFLOW_DIR}/security.yml`;
 const SCAN_JOB_ID = 'trivy-image-scan';
 
-/** Workflows that push images to the registry. */
-const PUBLISHING_WORKFLOWS = [
-  '.github/workflows/release.yml',
-  '.github/workflows/hosted-images.yml',
-];
-
 /**
- * Published images that the CI scan job deliberately does not build, with the
- * reason recorded. Keep this list at zero entries wherever possible — every
- * entry is a shipped image with no image-level vulnerability gate.
+ * Published images the CI scan job deliberately does not build, with the reason
+ * recorded. Keep this at zero entries wherever possible — every entry is a
+ * shipped image with no image-level vulnerability gate.
  */
 const SCAN_EXEMPT: Record<string, string> = {
   'docker/Dockerfile.binaries':
@@ -70,13 +92,40 @@ const SCAN_EXEMPT: Record<string, string> = {
     'already covers.',
 };
 
-type Step = { uses?: string; run?: string; with?: Record<string, unknown>; env?: Record<string, unknown> };
+type Step = {
+  uses?: string;
+  run?: string;
+  with?: Record<string, unknown>;
+  env?: Record<string, unknown>;
+  'continue-on-error'?: unknown;
+};
 type Matrix = { include?: Record<string, unknown>[] } & Record<string, unknown>;
-type Job = { steps?: Step[]; strategy?: { matrix?: Matrix } };
-type Workflow = { jobs?: Record<string, Job> };
+type Job = {
+  if?: unknown;
+  'continue-on-error'?: unknown;
+  steps?: Step[];
+  // `matrix` is a string when the workflow computes it at run time
+  // (`matrix: ${{ fromJSON(...) }}`).
+  strategy?: { matrix?: Matrix | string };
+};
+type Workflow = { on?: Record<string, unknown>; jobs?: Record<string, Job> };
+
+const BUILD_PUSH_ACTION = 'docker/build-push-action';
+const TRIVY_ACTION = 'aquasecurity/trivy-action';
 
 function readWorkflow(relPath: string): Workflow {
   return load(readFileSync(path.join(REPO_ROOT, relPath), 'utf8')) as Workflow;
+}
+
+/** Every workflow in the repo, parsed. Derived — nothing here is hand-listed. */
+function allWorkflows(): [string, Workflow][] {
+  return readdirSync(path.join(REPO_ROOT, WORKFLOW_DIR))
+    .filter((name) => name.endsWith('.yml') || name.endsWith('.yaml'))
+    .sort((a, b) => a.localeCompare(b))
+    .map((name) => {
+      const rel = `${WORKFLOW_DIR}/${name}`;
+      return [rel, readWorkflow(rel)] as [string, Workflow];
+    });
 }
 
 /**
@@ -84,11 +133,20 @@ function readWorkflow(relPath: string): Workflow {
  *
  * Only the two shapes these workflows use are supported — a bare `include:`
  * list, and plain list-valued keys. Anything else throws rather than silently
- * expanding to nothing, because a silent empty expansion would drop a published
- * image out of the derived set and make this whole guard pass vacuously.
+ * expanding to nothing.
  */
-function matrixCombinations(matrix: Matrix | undefined): Record<string, unknown>[] {
+function matrixCombinations(matrix: Matrix | string | undefined): Record<string, unknown>[] {
   if (!matrix) return [{}];
+
+  // A whole-matrix expression (`matrix: ${{ fromJSON(...) }}`, as
+  // dev-build-agent.yml uses) is only knowable at run time. Spreading the
+  // string would yield one bogus axis per character, so refuse it outright —
+  // callers only reach here for jobs that actually build images.
+  if (typeof matrix === 'string') {
+    throw new Error(
+      `Dynamic matrix expression cannot be resolved statically: ${matrix.trim().slice(0, 80)}`,
+    );
+  }
 
   const { include, ...axes } = matrix;
   const axisNames = Object.keys(axes);
@@ -116,51 +174,94 @@ function matrixCombinations(matrix: Matrix | undefined): Record<string, unknown>
 /** Substitute `${{ matrix.key }}` in a workflow expression against one binding. */
 function expandMatrixRefs(template: string, binding: Record<string, unknown>): string | null {
   let unresolved = false;
-  const expanded = template.replace(/\$\{\{\s*matrix\.([A-Za-z0-9_-]+)\s*\}\}/g, (_full, key: string) => {
-    const value = binding[key];
-    if (typeof value !== 'string') {
-      unresolved = true;
-      return '';
-    }
-    return value;
-  });
+  const expanded = template.replace(
+    /\$\{\{\s*matrix\.([A-Za-z0-9_-]+)\s*\}\}/g,
+    (_full, key: string) => {
+      const value = binding[key];
+      if (typeof value !== 'string') {
+        unresolved = true;
+        return '';
+      }
+      return value;
+    },
+  );
   // Any other `${{ ... }}` (env, needs, inputs) means we cannot resolve a
   // concrete path; report it rather than guessing.
   if (unresolved || /\$\{\{/.test(expanded)) return null;
   return expanded;
 }
 
-/** True when a build-push-action step publishes the image it builds. */
-function stepPushes(inputs: Record<string, unknown>): boolean {
-  if (inputs.push === true || inputs.push === 'true') return true;
+/**
+ * Whether a build-push-action step publishes the image it builds.
+ *
+ * Throws on a `push:` this cannot decide — notably the common
+ * `push: ${{ github.event_name != 'pull_request' }}` idiom, which would
+ * otherwise make a genuinely published image invisible to the whole guard.
+ */
+function stepPushes(inputs: Record<string, unknown>, where: string): boolean {
+  const push = inputs.push;
+  if (push !== undefined) {
+    if (push === true || push === 'true') return true;
+    if (push === false || push === 'false') return false;
+    throw new Error(
+      `${where}: cannot decide whether \`push: ${String(push)}\` publishes. Teach ` +
+        'stepPushes about it — treating it as "does not push" would drop a shipped ' +
+        'image out of the coverage check.',
+    );
+  }
   const outputs = inputs.outputs;
-  return typeof outputs === 'string' && /(^|,)push=true(,|$)/.test(outputs);
+  if (outputs !== undefined) {
+    if (typeof outputs !== 'string') {
+      throw new Error(`${where}: unsupported \`outputs:\` of type ${typeof outputs}`);
+    }
+    // Split into fields and read only `push=`. Other fields routinely
+    // interpolate (`name=${{ env.IMAGE_BASE }}/...`) without affecting whether
+    // the step publishes. Splitting also survives a YAML block scalar's
+    // trailing newline, which an anchored regex over the raw string would miss
+    // — silently reclassifying a push-by-digest step as "does not push".
+    const fields = outputs.split(',').map((field) => field.trim());
+    const pushField = fields.find((field) => field.startsWith('push='));
+    if (pushField === undefined) return false;
+    const value = pushField.slice('push='.length);
+    if (value === 'true') return true;
+    if (value === 'false') return false;
+    throw new Error(
+      `${where}: cannot decide whether \`${pushField}\` publishes. Teach stepPushes ` +
+        'about it — treating it as "does not push" would drop a shipped image out ' +
+        'of the coverage check.',
+    );
+  }
+  // No `push:` and no `push=` field: build-push-action defaults to not pushing.
+  return false;
 }
 
-/** Dockerfiles published to the registry, derived from the release workflows. */
-function publishedDockerfiles(): { dockerfile: string; source: string }[] {
-  const published: { dockerfile: string; source: string }[] = [];
+/** Dockerfiles published to a registry, derived from every workflow. */
+function publishedDockerfiles(): { dockerfile: string; workflow: string; job: string }[] {
+  const published: { dockerfile: string; workflow: string; job: string }[] = [];
 
-  for (const workflow of PUBLISHING_WORKFLOWS) {
-    const jobs = readWorkflow(workflow).jobs ?? {};
-    for (const [jobId, job] of Object.entries(jobs)) {
+  for (const [workflow, doc] of allWorkflows()) {
+    for (const [jobId, job] of Object.entries(doc.jobs ?? {})) {
+      const buildSteps = (job.steps ?? []).filter((step) =>
+        step.uses?.startsWith(BUILD_PUSH_ACTION),
+      );
+      if (buildSteps.length === 0) continue;
+      // Expanded only for image-building jobs: a job with a matrix this cannot
+      // resolve is a hard error, but only when it might publish an image.
       const bindings = matrixCombinations(job.strategy?.matrix);
-      for (const step of job.steps ?? []) {
-        if (!step.uses?.startsWith('docker/build-push-action')) continue;
+      for (const step of buildSteps) {
+        const where = `${workflow} job '${jobId}'`;
         const inputs = step.with ?? {};
-        if (!stepPushes(inputs)) continue;
+        if (!stepPushes(inputs, where)) continue;
         const file = inputs.file;
         if (typeof file !== 'string') {
-          throw new Error(`${workflow} job '${jobId}' pushes without a \`file:\` input`);
+          throw new Error(`${where} pushes without a \`file:\` input`);
         }
         for (const binding of bindings) {
           const resolved = expandMatrixRefs(file, binding);
           if (resolved === null) {
-            throw new Error(
-              `${workflow} job '${jobId}' has a \`file:\` this guard cannot resolve: ${file}`,
-            );
+            throw new Error(`${where} has a \`file:\` this guard cannot resolve: ${file}`);
           }
-          published.push({ dockerfile: resolved, source: `${workflow}:${jobId}` });
+          published.push({ dockerfile: resolved, workflow, job: jobId });
         }
       }
     }
@@ -183,17 +284,29 @@ function scannedDockerfiles(): string[] {
   });
 }
 
+/**
+ * THE predicate this whole file exists to enforce: published images with no
+ * scan and no recorded reason. Kept as a pure function so it can be exercised
+ * against synthetic rosters below, rather than only against the live one.
+ */
+function uncoveredPublished(
+  published: readonly string[],
+  scanned: readonly string[],
+  exempt: Readonly<Record<string, string>>,
+): string[] {
+  return published.filter((file) => !scanned.includes(file) && !(file in exempt));
+}
+
+/** Every Dockerfile tracked in the repo, wherever it lives. */
 function findDockerfiles(): string[] {
-  const found: string[] = [];
-  for (const entry of readdirSync(path.join(REPO_ROOT, 'apps'), { withFileTypes: true })) {
-    if (!entry.isDirectory()) continue;
-    const rel = `apps/${entry.name}/Dockerfile`;
-    if (existsSync(path.join(REPO_ROOT, rel))) found.push(rel);
+  const result = spawnSync('git', ['ls-files', '-z'], { cwd: REPO_ROOT, encoding: 'utf8' });
+  if (result.status !== 0) {
+    throw new Error(`git ls-files failed: ${result.stderr}`);
   }
-  for (const entry of readdirSync(path.join(REPO_ROOT, 'docker'), { withFileTypes: true })) {
-    if (entry.isFile() && entry.name.startsWith('Dockerfile')) found.push(`docker/${entry.name}`);
-  }
-  return found.sort((a, b) => a.localeCompare(b));
+  return result.stdout
+    .split('\0')
+    .filter((file) => file && path.basename(file).startsWith('Dockerfile'))
+    .sort((a, b) => a.localeCompare(b));
 }
 
 const PUBLISHED = publishedDockerfiles();
@@ -201,7 +314,6 @@ const PUBLISHED_FILES = [...new Set(PUBLISHED.map((entry) => entry.dockerfile))]
   a.localeCompare(b),
 );
 const SCANNED_FILES = scannedDockerfiles();
-const SECURITY_SOURCE = readFileSync(path.join(REPO_ROOT, SECURITY_WORKFLOW), 'utf8');
 
 describe('Trivy image scan covers the images we publish', () => {
   it('derives a non-empty published and scanned set', () => {
@@ -211,26 +323,30 @@ describe('Trivy image scan covers the images we publish', () => {
     expect(PUBLISHED_FILES).toContain('apps/web/Dockerfile');
     expect(PUBLISHED_FILES.length).toBeGreaterThanOrEqual(6);
     expect(SCANNED_FILES.length).toBeGreaterThanOrEqual(6);
+    // The disk walk backstops the derivation, so it must see more than the
+    // published set — otherwise a Dockerfile could go missing from both.
+    expect(findDockerfiles().length).toBeGreaterThan(PUBLISHED_FILES.length);
   });
 
-  it.each(PUBLISHED_FILES)('%s is built and scanned by the CI Trivy job', (dockerfile) => {
-    if (dockerfile in SCAN_EXEMPT) {
-      expect(SCANNED_FILES).not.toContain(dockerfile);
-      return;
-    }
-
-    const publishers = PUBLISHED.filter((entry) => entry.dockerfile === dockerfile)
-      .map((entry) => entry.source)
-      .join(', ');
+  it('leaves no published image unscanned', () => {
+    const uncovered = uncoveredPublished(PUBLISHED_FILES, SCANNED_FILES, SCAN_EXEMPT);
+    const detail = uncovered
+      .map((file) => {
+        const publishers = PUBLISHED.filter((entry) => entry.dockerfile === file)
+          .map((entry) => `${entry.workflow}:${entry.job}`)
+          .join(', ');
+        return `  ${file} — pushed by ${publishers}`;
+      })
+      .join('\n');
 
     expect(
-      SCANNED_FILES,
-      `${dockerfile} is pushed to the registry by ${publishers}, but ` +
-        `${SECURITY_WORKFLOW}'s ${SCAN_JOB_ID} matrix never builds it — so no ` +
-        'image-level vulnerability gate ever looks at the image customers run ' +
-        '(issues #4273 / #4260). Add a matrix entry for it, or record a reason ' +
-        'in SCAN_EXEMPT.',
-    ).toContain(dockerfile);
+      uncovered,
+      'These Dockerfiles are pushed to a registry but never built by ' +
+        `${SECURITY_WORKFLOW}'s ${SCAN_JOB_ID} matrix, so no image-level ` +
+        'vulnerability gate ever looks at the image customers run ' +
+        `(issues #4273 / #4260):\n${detail}\n` +
+        'Add a matrix entry for each, or record a reason in SCAN_EXEMPT.',
+    ).toEqual([]);
   });
 
   it('every scanned Dockerfile exists on disk', () => {
@@ -245,19 +361,40 @@ describe('Trivy image scan covers the images we publish', () => {
 
   it('the scan matrix actually drives the build and scan steps', () => {
     // Without this, the matrix could list every published image while the steps
-    // kept building a hardcoded one — a roster that looks like coverage and is
-    // not. The build step must reference `matrix.dockerfile`, and the scan must
-    // still be blocking on HIGH/CRITICAL.
+    // kept building a hardcoded one — eight legs all building the API image and
+    // reporting a green `Trivy Image Scan (web)`. A roster that looks like
+    // coverage and is not, which is this file's whole subject.
     const job = readWorkflow(SECURITY_WORKFLOW).jobs?.[SCAN_JOB_ID];
     const steps = job?.steps ?? [];
 
-    const buildStep = steps.find((step) => typeof step.run === 'string' && step.run.includes('docker build'));
+    const buildStep = steps.find(
+      (step) => typeof step.run === 'string' && step.run.includes('docker build'),
+    );
     expect(buildStep, `${SCAN_JOB_ID} has no \`docker build\` step`).toBeDefined();
-    const buildRefs = JSON.stringify([buildStep?.run, buildStep?.env]);
-    expect(buildRefs).toMatch(/matrix\.dockerfile/);
-    expect(buildRefs).toMatch(/matrix\.image/);
 
-    const scanStep = steps.find((step) => step.uses?.startsWith('aquasecurity/trivy-action'));
+    // The matrix values reach the shell through `env:` (the injection-safe
+    // idiom). Find the variable names by what they carry, so renaming them is
+    // fine but dropping the wiring is not.
+    const stepEnv = Object.entries(buildStep?.env ?? {});
+    const dockerfileVar = stepEnv.find(([, v]) => /matrix\.dockerfile/.test(String(v)))?.[0];
+    const imageVar = stepEnv.find(([, v]) => /matrix\.image/.test(String(v)))?.[0];
+    expect(dockerfileVar, 'build step does not receive `matrix.dockerfile`').toBeDefined();
+    expect(imageVar, 'build step does not receive `matrix.image`').toBeDefined();
+
+    // …and the command must actually consume them. Carrying the values in
+    // `env:` while the command hardcodes a path satisfies "references the
+    // matrix" without scanning anything the matrix names.
+    const runLine = buildStep?.run ?? '';
+    expect(runLine).toMatch(new RegExp(`\\$\\{?${dockerfileVar}\\b`));
+    expect(runLine).toMatch(new RegExp(`\\$\\{?${imageVar}\\b`));
+    expect(
+      runLine,
+      'the build command names a Dockerfile path literally instead of using the ' +
+        'matrix value, so every matrix leg would build the same image while ' +
+        'reporting per-image check names.',
+    ).not.toMatch(/-f\s+["']?(apps|docker)\//);
+
+    const scanStep = steps.find((step) => step.uses?.startsWith(TRIVY_ACTION));
     expect(scanStep, `${SCAN_JOB_ID} has no trivy-action step`).toBeDefined();
     expect(String(scanStep?.with?.['image-ref'])).toMatch(/matrix\.image/);
     expect(scanStep?.with?.severity).toBe('HIGH,CRITICAL');
@@ -265,19 +402,65 @@ describe('Trivy image scan covers the images we publish', () => {
 
     // The action must stay SHA-pinned like every other third-party action here.
     // (The trailing `# vX.Y.Z` is a YAML comment, so it is not part of `uses`.)
-    expect(scanStep?.uses).toMatch(/^aquasecurity\/trivy-action@[0-9a-f]{40}$/);
+    expect(scanStep?.uses).toMatch(new RegExp(`^${TRIVY_ACTION}@[0-9a-f]{40}$`));
+  });
+
+  it('the scan job runs on pull requests and blocks on failure', () => {
+    // A correct roster on a job that never runs — or that swallows its own
+    // failure — is the same false green in a different place.
+    const workflow = readWorkflow(SECURITY_WORKFLOW);
+    expect(Object.keys(workflow.on ?? {}), `${SECURITY_WORKFLOW} must run on PRs`).toContain(
+      'pull_request',
+    );
+
+    const job = workflow.jobs?.[SCAN_JOB_ID];
+    expect(
+      job?.if,
+      `${SCAN_JOB_ID} has a job-level \`if:\`, so it may not run on the PRs it is ` +
+        'supposed to gate. If the condition is intentional, assert the intent here.',
+    ).toBeUndefined();
+    expect(job?.['continue-on-error'], `${SCAN_JOB_ID} must fail the run, not warn`).toBeFalsy();
+    for (const step of job?.steps ?? []) {
+      expect(
+        step['continue-on-error'],
+        `a step in ${SCAN_JOB_ID} sets continue-on-error, so a HIGH/CRITICAL finding ` +
+          'would report green.',
+      ).toBeFalsy();
+    }
+  });
+
+  it('no workflow publishes an image outside docker/build-push-action', () => {
+    // The derivation only understands build-push-action steps. A raw
+    // `docker push` or `docker buildx build --push` would publish an image the
+    // whole guard is blind to.
+    for (const [workflow, doc] of allWorkflows()) {
+      for (const [jobId, job] of Object.entries(doc.jobs ?? {})) {
+        for (const step of job.steps ?? []) {
+          const run = typeof step.run === 'string' ? step.run : '';
+          expect(
+            /docker\s+push\s|docker\s+buildx\s+build\b[^\n]*--push/.test(run),
+            `${workflow} job '${jobId}' publishes an image with a raw docker command. ` +
+              'publishedDockerfiles() cannot see it, so its Dockerfile would silently ' +
+              'drop out of the scan-coverage check.',
+          ).toBe(false);
+        }
+      }
+    }
   });
 
   it('leaves no Dockerfile silently unclassified', () => {
-    // Anti-rot snapshot: a new Dockerfile, or a publish step retargeted at a
-    // different file, changes this map and forces a human to decide which side
-    // of the line it belongs on instead of quietly losing coverage.
+    // Anti-rot snapshot over every tracked Dockerfile, not just the published
+    // ones — it is the backstop for a derivation that shrinks. A new image, or
+    // a publish step retargeted at a different file, changes this map and
+    // forces a human to decide which side of the line it belongs on.
     const classification = Object.fromEntries(
       findDockerfiles().map((dockerfile) => {
         const published = PUBLISHED_FILES.includes(dockerfile);
         const scanned = SCANNED_FILES.includes(dockerfile);
         if (published && scanned) return [dockerfile, 'published + scanned'];
-        if (published) return [dockerfile, 'published, scan-exempt'];
+        if (published && dockerfile in SCAN_EXEMPT) return [dockerfile, 'published, scan-exempt'];
+        // Never a resting state: a shipped image with no gate and no reason.
+        if (published) return [dockerfile, 'PUBLISHED BUT UNSCANNED'];
         if (scanned) return [dockerfile, 'not published, scanned anyway'];
         return [dockerfile, 'not published, not scanned'];
       }),
@@ -290,9 +473,9 @@ describe('Trivy image scan covers the images we publish', () => {
       'apps/m365-graph-read-executor/Dockerfile': 'published + scanned',
       'apps/portal/Dockerfile': 'published + scanned',
       'apps/web/Dockerfile': 'published + scanned',
-      // Built by ci.yml's smoke test (docker-compose.override.yml.ci) and by the
-      // local-build compose mode, so they stay gated even though release never
-      // pushes them.
+      // Built from source by ci.yml's smoke test and the local-build compose
+      // mode; see `the compose variants are still built from source` below,
+      // which derives that rather than trusting this comment.
       'docker/Dockerfile.api': 'not published, scanned anyway',
       'docker/Dockerfile.web': 'not published, scanned anyway',
       // See SCAN_EXEMPT: staging/ build context cannot be reproduced in CI.
@@ -304,13 +487,77 @@ describe('Trivy image scan covers the images we publish', () => {
     });
   });
 
+  it('the compose variants are still built from source somewhere', () => {
+    // The snapshot keeps docker/Dockerfile.api|web scanned even though release
+    // never pushes them, on the grounds that CI's smoke test and the
+    // local-build compose mode build them. Derive that instead of asserting it
+    // in prose, so the rationale cannot rot while the entries stay.
+    const compose = ['docker-compose.override.yml.ci', 'docker-compose.override.yml.local-build']
+      .map((file) => readFileSync(path.join(REPO_ROOT, file), 'utf8'))
+      .join('\n');
+
+    for (const dockerfile of ['docker/Dockerfile.api', 'docker/Dockerfile.web']) {
+      if (!SCANNED_FILES.includes(dockerfile)) continue;
+      expect(
+        compose,
+        `${dockerfile} is scanned but nothing publishes it and no compose override ` +
+          'builds it — either it is dead and both should go, or the reason it is ' +
+          'still scanned has changed and belongs in the snapshot above.',
+      ).toContain(dockerfile);
+    }
+  });
+
   it('records a reason for every scan exemption', () => {
     for (const [dockerfile, reason] of Object.entries(SCAN_EXEMPT)) {
       expect(PUBLISHED_FILES, `${dockerfile} is exempted but nothing publishes it`).toContain(
         dockerfile,
       );
+      expect(
+        SCANNED_FILES,
+        `${dockerfile} is now scanned, so its SCAN_EXEMPT entry is stale — delete it ` +
+          'so the exemption list stays an accurate inventory of unguarded images.',
+      ).not.toContain(dockerfile);
       expect(reason.length).toBeGreaterThan(80);
     }
+  });
+
+  it('marks which published images lack release-time digest scanning', () => {
+    // Blind-spot marker, not a gate. CI scans the Dockerfile at PR time;
+    // `release.yml` builds it again at tag time. Only jobs that scan the exact
+    // pushed manifest before promoting its tag close that window. Snapshotting
+    // the split keeps the remaining gap visible and makes closing it a
+    // deliberate, reviewed change rather than an invisible non-event.
+    const coverage: Record<string, string> = {};
+    for (const [workflow, doc] of allWorkflows()) {
+      for (const [jobId, job] of Object.entries(doc.jobs ?? {})) {
+        const steps = job.steps ?? [];
+        if (!steps.some((step) => step.uses?.startsWith(BUILD_PUSH_ACTION))) continue;
+        const pushes = steps.some(
+          (step) =>
+            step.uses?.startsWith(BUILD_PUSH_ACTION) &&
+            stepPushes(step.with ?? {}, `${workflow} job '${jobId}'`),
+        );
+        if (!pushes) continue;
+        coverage[`${workflow}:${jobId}`] = steps.some((step) => step.uses?.startsWith(TRIVY_ACTION))
+          ? 'scans the pushed digest'
+          : 'NO release-time scan';
+      }
+    }
+
+    expect(coverage).toEqual({
+      '.github/workflows/hosted-images.yml:build-m365-executor-image': 'scans the pushed digest',
+      '.github/workflows/hosted-images.yml:build-server-image': 'NO release-time scan',
+      '.github/workflows/release.yml:build-binaries-image': 'NO release-time scan',
+      '.github/workflows/release.yml:build-docker-api': 'NO release-time scan',
+      '.github/workflows/release.yml:build-docker-m365-communications-executor':
+        'scans the pushed digest',
+      '.github/workflows/release.yml:build-docker-m365-graph-actions-executor':
+        'scans the pushed digest',
+      '.github/workflows/release.yml:build-docker-m365-graph-read-executor':
+        'scans the pushed digest',
+      '.github/workflows/release.yml:build-docker-portal': 'NO release-time scan',
+      '.github/workflows/release.yml:build-docker-web': 'NO release-time scan',
+    });
   });
 
   it('local preflight builds the published api/web images, not the compose proxies', () => {
@@ -324,22 +571,66 @@ describe('Trivy image scan covers the images we publish', () => {
 });
 
 describe('the coverage derivation is discriminating', () => {
-  // These exercise the helpers against synthetic workflows: without them the
+  // These run the real predicates against synthetic input. Without them the
   // suite would pass just as happily on a derivation that returned nothing.
 
-  it('counts only steps that actually push', () => {
-    const inputs = { file: 'apps/api/Dockerfile' };
-    expect(stepPushes({ ...inputs, push: true })).toBe(true);
-    expect(stepPushes({ ...inputs, push: false })).toBe(false);
-    expect(stepPushes(inputs)).toBe(false);
+  it('flags a published image dropped from the scan roster', () => {
+    // The exact regression this file exists for, run through the real
+    // predicate rather than re-asserting the live rosters.
+    const published = ['apps/api/Dockerfile', 'apps/web/Dockerfile'];
+    expect(uncoveredPublished(published, published, {})).toEqual([]);
+    expect(uncoveredPublished(published, ['apps/web/Dockerfile'], {})).toEqual([
+      'apps/api/Dockerfile',
+    ]);
+    // …and the pre-fix roster: scanning proxies nobody ships covers nothing.
     expect(
-      stepPushes({
-        ...inputs,
-        outputs: 'type=image,name=ghcr.io/x/api,push-by-digest=true,name-canonical=true,push=true',
-      }),
+      uncoveredPublished(published, ['docker/Dockerfile.api', 'docker/Dockerfile.web'], {}),
+    ).toEqual(published);
+    // An exemption suppresses the finding — and only for the file it names.
+    expect(uncoveredPublished(published, [], { 'apps/api/Dockerfile': 'reason' })).toEqual([
+      'apps/web/Dockerfile',
+    ]);
+  });
+
+  it('counts only steps that actually push, and refuses the ones it cannot decide', () => {
+    const inputs = { file: 'apps/api/Dockerfile' };
+    const where = 'test';
+    expect(stepPushes({ ...inputs, push: true }, where)).toBe(true);
+    expect(stepPushes({ ...inputs, push: false }, where)).toBe(false);
+    expect(stepPushes(inputs, where)).toBe(false);
+    expect(
+      stepPushes(
+        {
+          ...inputs,
+          outputs: 'type=image,name=ghcr.io/x/api,push-by-digest=true,name-canonical=true,push=true',
+        },
+        where,
+      ),
     ).toBe(true);
     // `push-by-digest=true` alone is not a push.
-    expect(stepPushes({ ...inputs, outputs: 'type=image,push-by-digest=true' })).toBe(false);
+    expect(stepPushes({ ...inputs, outputs: 'type=image,push-by-digest=true' }, where)).toBe(false);
+    // A YAML block scalar keeps a trailing newline; an anchored regex would
+    // read this as "does not push" and drop a shipped image from the guard.
+    expect(stepPushes({ ...inputs, outputs: 'type=image,name=x,push=true\n' }, where)).toBe(true);
+    // The idiom that would otherwise make a published image invisible.
+    expect(() =>
+      stepPushes({ ...inputs, push: "${{ github.event_name != 'pull_request' }}" }, where),
+    ).toThrow(/cannot decide/);
+    expect(() =>
+      stepPushes({ ...inputs, outputs: 'type=image,push=${{ inputs.publish }}' }, where),
+    ).toThrow(/cannot decide/);
+    // An expression in a field that is NOT `push=` says nothing about whether
+    // the step publishes — this is the live push-by-digest form.
+    expect(
+      stepPushes(
+        {
+          ...inputs,
+          outputs:
+            'type=image,name=${{ env.IMAGE_BASE }}/api,push-by-digest=true,name-canonical=true,push=true',
+        },
+        where,
+      ),
+    ).toBe(true);
   });
 
   it('expands matrix references and refuses the ones it cannot resolve', () => {
@@ -367,16 +658,14 @@ describe('the coverage derivation is discriminating', () => {
     ]);
   });
 
-  it('would fail if a published Dockerfile were dropped from the scan matrix', () => {
-    // The real check is `expect(SCANNED_FILES).toContain(dockerfile)`. Prove it
-    // discriminates by running the same comparison against a scan roster with
-    // the shipped API image removed.
-    const withApiDropped = SCANNED_FILES.filter((f) => f !== 'apps/api/Dockerfile');
-    expect(withApiDropped).not.toContain('apps/api/Dockerfile');
-    expect(PUBLISHED_FILES).toContain('apps/api/Dockerfile');
-  });
-
-  it('reads the security workflow it claims to check', () => {
-    expect(SECURITY_SOURCE).toContain('trivy-image-scan:');
+  it('walks the whole repo for Dockerfiles, not just two directories', () => {
+    // The snapshot is the backstop for a shrinking derivation, so its input has
+    // to see a Dockerfile wherever someone puts one.
+    const found = findDockerfiles();
+    expect(found).toContain('apps/api/Dockerfile');
+    expect(found).toContain('docker/Dockerfile.binaries');
+    // Basename match, not a substring sweep: the test files next to this one
+    // have "dockerfile" in their names and are not Dockerfiles.
+    expect(found.every((file) => path.basename(file).startsWith('Dockerfile'))).toBe(true);
   });
 });

--- a/apps/api/src/config/dockerfileImageScanCoverage.test.ts
+++ b/apps/api/src/config/dockerfileImageScanCoverage.test.ts
@@ -65,9 +65,16 @@ import { describe, expect, it } from 'vitest';
  *  3. **That the scanned build and the published build are the same bytes.**
  *     CI builds the Dockerfile at PR time; `release.yml` builds it again at tag
  *     time. Only the three M365 executors scan the exact published manifest
- *     before promoting its tag. `release-time digest scanning` below snapshots
- *     which published images have that and which do not, so the gap stays
- *     visible rather than silent.
+ *     before promoting its tag. The snapshot below records, per publishing job,
+ *     whether it has a trivy-action step at all — a weaker fact than
+ *     "scans the pushed digest", and labelled as the weaker fact deliberately
+ *     (see the comment there). It keeps the gap visible; it does not measure it.
+ *
+ * Sources for the claims above that live outside this repo, so a later reader
+ * knows they were checked rather than assumed: the ruleset in (2) was read with
+ * `gh api repos/LanternOps/breeze/rulesets` on 2026-09-01 — one rule of type
+ * `required_status_checks`, one context, `CI Success`. Re-check it before
+ * relying on it; nothing here can.
  */
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
@@ -241,17 +248,19 @@ function publishedDockerfiles(): { dockerfile: string; workflow: string; job: st
 
   for (const [workflow, doc] of allWorkflows()) {
     for (const [jobId, job] of Object.entries(doc.jobs ?? {})) {
-      const buildSteps = (job.steps ?? []).filter((step) =>
-        step.uses?.startsWith(BUILD_PUSH_ACTION),
+      const where = `${workflow} job '${jobId}'`;
+      // Whether a step pushes needs no matrix, so decide that FIRST. Expanding
+      // up front would make a job that merely builds (`push: false`) inside a
+      // dynamic matrix throw over a matrix irrelevant to publishing.
+      const pushingSteps = (job.steps ?? []).filter(
+        (step) => step.uses?.startsWith(BUILD_PUSH_ACTION) && stepPushes(step.with ?? {}, where),
       );
-      if (buildSteps.length === 0) continue;
-      // Expanded only for image-building jobs: a job with a matrix this cannot
-      // resolve is a hard error, but only when it might publish an image.
+      if (pushingSteps.length === 0) continue;
+      // Now the matrix must resolve: this job publishes, so an unresolvable
+      // matrix means we cannot know which Dockerfiles it ships.
       const bindings = matrixCombinations(job.strategy?.matrix);
-      for (const step of buildSteps) {
-        const where = `${workflow} job '${jobId}'`;
+      for (const step of pushingSteps) {
         const inputs = step.with ?? {};
-        if (!stepPushes(inputs, where)) continue;
         const file = inputs.file;
         if (typeof file !== 'string') {
           throw new Error(`${where} pushes without a \`file:\` input`);
@@ -297,7 +306,17 @@ function uncoveredPublished(
   return published.filter((file) => !scanned.includes(file) && !(file in exempt));
 }
 
-/** Every Dockerfile tracked in the repo, wherever it lives. */
+/**
+ * Every Dockerfile tracked in the repo, wherever it lives.
+ *
+ * Tracked, note: this reads the git index, so an *untracked* Dockerfile is
+ * invisible to the snapshot below. That is the right trade — CI and release
+ * only ever build tracked files, and a path-glob walk would instead miss any
+ * Dockerfile outside the two directories it knew about — but the snapshot is
+ * the sole backstop for several drift shapes, so the dependency is worth
+ * knowing. It fails loud (non-zero `git ls-files`) outside a git checkout
+ * rather than returning an empty list.
+ */
 function findDockerfiles(): string[] {
   const result = spawnSync('git', ['ls-files', '-z'], { cwd: REPO_ROOT, encoding: 'utf8' });
   if (result.status !== 0) {
@@ -381,18 +400,24 @@ describe('Trivy image scan covers the images we publish', () => {
     expect(dockerfileVar, 'build step does not receive `matrix.dockerfile`').toBeDefined();
     expect(imageVar, 'build step does not receive `matrix.image`').toBeDefined();
 
-    // …and the command must actually consume them. Carrying the values in
-    // `env:` while the command hardcodes a path satisfies "references the
-    // matrix" without scanning anything the matrix names.
+    // …and the command must actually consume them, as the `-f` argument
+    // itself. One claim about one token: "does the run line mention
+    // $DOCKERFILE somewhere" is satisfied by an unrelated `echo`, and a
+    // negative "no literal path" check is evaded by writing `./apps/...`.
+    // Asserting the argument position can be neither drifted past nor dodged.
     const runLine = buildStep?.run ?? '';
-    expect(runLine).toMatch(new RegExp(`\\$\\{?${dockerfileVar}\\b`));
-    expect(runLine).toMatch(new RegExp(`\\$\\{?${imageVar}\\b`));
     expect(
       runLine,
-      'the build command names a Dockerfile path literally instead of using the ' +
-        'matrix value, so every matrix leg would build the same image while ' +
-        'reporting per-image check names.',
-    ).not.toMatch(/-f\s+["']?(apps|docker)\//);
+      'the build command must pass the matrix Dockerfile as its `-f` argument. ' +
+        'Carrying the value in `env:` while `-f` names a path literally satisfies ' +
+        '"references the matrix" while every matrix leg builds the same image and ' +
+        'still reports per-image check names.',
+    ).toMatch(new RegExp(`-f\\s+["']?\\$\\{?${dockerfileVar}\\b`));
+    expect(
+      runLine,
+      'the built tag must carry the matrix image name, or the scan step below ' +
+        'would look up an image this step never produced.',
+    ).toMatch(new RegExp(`-t\\s+["'][^"']*\\$\\{?${imageVar}\\b`));
 
     const scanStep = steps.find((step) => step.uses?.startsWith(TRIVY_ACTION));
     expect(scanStep, `${SCAN_JOB_ID} has no trivy-action step`).toBeDefined();
@@ -492,12 +517,12 @@ describe('Trivy image scan covers the images we publish', () => {
     // never pushes them, on the grounds that CI's smoke test and the
     // local-build compose mode build them. Derive that instead of asserting it
     // in prose, so the rationale cannot rot while the entries stay.
-    const compose = ['docker-compose.override.yml.ci', 'docker-compose.override.yml.local-build']
+    const CI_OVERRIDE = 'docker-compose.override.yml.ci';
+    const compose = [CI_OVERRIDE, 'docker-compose.override.yml.local-build']
       .map((file) => readFileSync(path.join(REPO_ROOT, file), 'utf8'))
       .join('\n');
 
     for (const dockerfile of ['docker/Dockerfile.api', 'docker/Dockerfile.web']) {
-      if (!SCANNED_FILES.includes(dockerfile)) continue;
       expect(
         compose,
         `${dockerfile} is scanned but nothing publishes it and no compose override ` +
@@ -505,6 +530,16 @@ describe('Trivy image scan covers the images we publish', () => {
           'still scanned has changed and belongs in the snapshot above.',
       ).toContain(dockerfile);
     }
+
+    // The override file naming those Dockerfiles is only half the claim; the
+    // other half is that CI still runs it. Without this, every `.ci` reference
+    // in ci.yml could be repointed elsewhere and the rationale would read as
+    // derived while being false.
+    expect(
+      readFileSync(path.join(REPO_ROOT, '.github/workflows/ci.yml'), 'utf8'),
+      `ci.yml no longer uses ${CI_OVERRIDE}, so "CI's smoke test builds them" is ` +
+        'no longer a reason to keep the compose variants in the scan matrix.',
+    ).toContain(CI_OVERRIDE);
   });
 
   it('records a reason for every scan exemption', () => {
@@ -538,25 +573,35 @@ describe('Trivy image scan covers the images we publish', () => {
             stepPushes(step.with ?? {}, `${workflow} job '${jobId}'`),
         );
         if (!pushes) continue;
+        // Label exactly what is checked — the presence of a trivy-action step
+        // in the job — and nothing more. The stronger claim ("scans the exact
+        // pushed digest before promoting its tag") additionally requires an
+        // `image-ref` naming the digest and the build→scan→promote ordering,
+        // which check-supply-chain-hardening.sh:321-330 enforces for the
+        // executors. Writing that stronger label here from this weaker
+        // predicate would put a false coverage claim in the file, which the
+        // docblock above then cites: an unrelated `scan-type: fs` step would
+        // earn a job the "scans the pushed digest" label, and the natural
+        // review action on a snapshot diff is to accept the new label.
         coverage[`${workflow}:${jobId}`] = steps.some((step) => step.uses?.startsWith(TRIVY_ACTION))
-          ? 'scans the pushed digest'
-          : 'NO release-time scan';
+          ? 'has a trivy-action step'
+          : 'NO trivy-action step';
       }
     }
 
     expect(coverage).toEqual({
-      '.github/workflows/hosted-images.yml:build-m365-executor-image': 'scans the pushed digest',
-      '.github/workflows/hosted-images.yml:build-server-image': 'NO release-time scan',
-      '.github/workflows/release.yml:build-binaries-image': 'NO release-time scan',
-      '.github/workflows/release.yml:build-docker-api': 'NO release-time scan',
+      '.github/workflows/hosted-images.yml:build-m365-executor-image': 'has a trivy-action step',
+      '.github/workflows/hosted-images.yml:build-server-image': 'NO trivy-action step',
+      '.github/workflows/release.yml:build-binaries-image': 'NO trivy-action step',
+      '.github/workflows/release.yml:build-docker-api': 'NO trivy-action step',
       '.github/workflows/release.yml:build-docker-m365-communications-executor':
-        'scans the pushed digest',
+        'has a trivy-action step',
       '.github/workflows/release.yml:build-docker-m365-graph-actions-executor':
-        'scans the pushed digest',
+        'has a trivy-action step',
       '.github/workflows/release.yml:build-docker-m365-graph-read-executor':
-        'scans the pushed digest',
-      '.github/workflows/release.yml:build-docker-portal': 'NO release-time scan',
-      '.github/workflows/release.yml:build-docker-web': 'NO release-time scan',
+        'has a trivy-action step',
+      '.github/workflows/release.yml:build-docker-portal': 'NO trivy-action step',
+      '.github/workflows/release.yml:build-docker-web': 'NO trivy-action step',
     });
   });
 

--- a/apps/api/src/config/dockerfileImageScanCoverage.test.ts
+++ b/apps/api/src/config/dockerfileImageScanCoverage.test.ts
@@ -1,0 +1,382 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { load } from 'js-yaml';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Guard against the "the image we scan is not the image we ship" class
+ * (issues #4273 / #4260).
+ *
+ * `security.yml`'s `Trivy Image Scan` job used to build and scan
+ * `docker/Dockerfile.api` and `docker/Dockerfile.web` — two files that neither
+ * `release.yml` nor `hosted-images.yml` ever publishes. The images customers
+ * actually run are built from `apps/api/Dockerfile` and `apps/web/Dockerfile`,
+ * and those were scanned nowhere. A green `Trivy Image Scan` therefore said
+ * nothing about the two most widely deployed images in the product, which is
+ * how they came to ship a known HIGH CVE (CVE-2026-14456, libcrypto3/libssl3)
+ * that the *scanned* proxies had already been patched for (#4246 / #4257).
+ *
+ * The durable defect was the hand-maintained parallel list: a scan roster kept
+ * by hand next to a publish roster kept by hand, with nothing tying the two
+ * together. So this guard does not hand-list anything. It derives:
+ *
+ *  - **published** — every `file:` input of every `docker/build-push-action`
+ *    step in `release.yml` and `hosted-images.yml` whose step actually pushes
+ *    (`push: true`, or `outputs: ...push=true` for the push-by-digest lanes),
+ *    with `${{ matrix.* }}` expanded against that job's own matrix.
+ *  - **scanned** — the `dockerfile:` values of `security.yml`'s
+ *    `trivy-image-scan` matrix.
+ *
+ * …and asserts published ⊆ scanned, modulo the one recorded exemption below.
+ * Add a new published image and this test fails until it is scanned; retarget a
+ * publish step at a different Dockerfile and it fails until the scan follows.
+ *
+ * This is a static read of the workflow YAML; it never invokes Docker or the
+ * GitHub API.
+ *
+ * Scope note: this covers the **CI** gate (`security.yml` runs on every PR,
+ * every push to `main`, and weekly). Release-*time* digest scanning
+ * (build → scan the exact manifest → promote the tag) exists today only for the
+ * three M365 executors; extending it to api/web/portal/binaries means
+ * hand-rolling the multi-tag promotion that `docker/metadata-action` currently
+ * does for those jobs, and is deliberately left to a follow-up.
+ */
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
+
+const SECURITY_WORKFLOW = '.github/workflows/security.yml';
+const SCAN_JOB_ID = 'trivy-image-scan';
+
+/** Workflows that push images to the registry. */
+const PUBLISHING_WORKFLOWS = [
+  '.github/workflows/release.yml',
+  '.github/workflows/hosted-images.yml',
+];
+
+/**
+ * Published images that the CI scan job deliberately does not build, with the
+ * reason recorded. Keep this list at zero entries wherever possible — every
+ * entry is a shipped image with no image-level vulnerability gate.
+ */
+const SCAN_EXEMPT: Record<string, string> = {
+  'docker/Dockerfile.binaries':
+    'release.yml builds it from `context: staging/` — a release-time artifact ' +
+    'directory assembled by earlier jobs that does not exist in a plain repo ' +
+    'checkout, so the CI job cannot reproduce the image. Its base is the ' +
+    'floating `alpine:3.24` tag (re-pulls upstream fixes on every rebuild ' +
+    'rather than freezing a package set behind a digest pin) and its payload is ' +
+    'this repo’s own release binaries, which the Trivy filesystem scan ' +
+    'already covers.',
+};
+
+type Step = { uses?: string; run?: string; with?: Record<string, unknown>; env?: Record<string, unknown> };
+type Matrix = { include?: Record<string, unknown>[] } & Record<string, unknown>;
+type Job = { steps?: Step[]; strategy?: { matrix?: Matrix } };
+type Workflow = { jobs?: Record<string, Job> };
+
+function readWorkflow(relPath: string): Workflow {
+  return load(readFileSync(path.join(REPO_ROOT, relPath), 'utf8')) as Workflow;
+}
+
+/**
+ * Every concrete variable binding a job's matrix produces.
+ *
+ * Only the two shapes these workflows use are supported — a bare `include:`
+ * list, and plain list-valued keys. Anything else throws rather than silently
+ * expanding to nothing, because a silent empty expansion would drop a published
+ * image out of the derived set and make this whole guard pass vacuously.
+ */
+function matrixCombinations(matrix: Matrix | undefined): Record<string, unknown>[] {
+  if (!matrix) return [{}];
+
+  const { include, ...axes } = matrix;
+  const axisNames = Object.keys(axes);
+
+  if (include && axisNames.length === 0) return include;
+
+  if (!include && axisNames.length > 0) {
+    let combos: Record<string, unknown>[] = [{}];
+    for (const name of axisNames) {
+      const values = axes[name];
+      if (!Array.isArray(values)) {
+        throw new Error(`Unsupported matrix axis '${name}': expected a list, got ${typeof values}`);
+      }
+      combos = combos.flatMap((combo) => values.map((value) => ({ ...combo, [name]: value })));
+    }
+    return combos;
+  }
+
+  throw new Error(
+    'Unsupported matrix shape (mixed `include` + axes). Teach matrixCombinations ' +
+      'about it rather than letting the derived image set silently shrink.',
+  );
+}
+
+/** Substitute `${{ matrix.key }}` in a workflow expression against one binding. */
+function expandMatrixRefs(template: string, binding: Record<string, unknown>): string | null {
+  let unresolved = false;
+  const expanded = template.replace(/\$\{\{\s*matrix\.([A-Za-z0-9_-]+)\s*\}\}/g, (_full, key: string) => {
+    const value = binding[key];
+    if (typeof value !== 'string') {
+      unresolved = true;
+      return '';
+    }
+    return value;
+  });
+  // Any other `${{ ... }}` (env, needs, inputs) means we cannot resolve a
+  // concrete path; report it rather than guessing.
+  if (unresolved || /\$\{\{/.test(expanded)) return null;
+  return expanded;
+}
+
+/** True when a build-push-action step publishes the image it builds. */
+function stepPushes(inputs: Record<string, unknown>): boolean {
+  if (inputs.push === true || inputs.push === 'true') return true;
+  const outputs = inputs.outputs;
+  return typeof outputs === 'string' && /(^|,)push=true(,|$)/.test(outputs);
+}
+
+/** Dockerfiles published to the registry, derived from the release workflows. */
+function publishedDockerfiles(): { dockerfile: string; source: string }[] {
+  const published: { dockerfile: string; source: string }[] = [];
+
+  for (const workflow of PUBLISHING_WORKFLOWS) {
+    const jobs = readWorkflow(workflow).jobs ?? {};
+    for (const [jobId, job] of Object.entries(jobs)) {
+      const bindings = matrixCombinations(job.strategy?.matrix);
+      for (const step of job.steps ?? []) {
+        if (!step.uses?.startsWith('docker/build-push-action')) continue;
+        const inputs = step.with ?? {};
+        if (!stepPushes(inputs)) continue;
+        const file = inputs.file;
+        if (typeof file !== 'string') {
+          throw new Error(`${workflow} job '${jobId}' pushes without a \`file:\` input`);
+        }
+        for (const binding of bindings) {
+          const resolved = expandMatrixRefs(file, binding);
+          if (resolved === null) {
+            throw new Error(
+              `${workflow} job '${jobId}' has a \`file:\` this guard cannot resolve: ${file}`,
+            );
+          }
+          published.push({ dockerfile: resolved, source: `${workflow}:${jobId}` });
+        }
+      }
+    }
+  }
+
+  return published;
+}
+
+/** Dockerfiles the CI Trivy image job builds and scans. */
+function scannedDockerfiles(): string[] {
+  const job = readWorkflow(SECURITY_WORKFLOW).jobs?.[SCAN_JOB_ID];
+  if (!job) throw new Error(`${SECURITY_WORKFLOW} has no '${SCAN_JOB_ID}' job`);
+
+  return matrixCombinations(job.strategy?.matrix).map((binding, index) => {
+    const dockerfile = binding.dockerfile;
+    if (typeof dockerfile !== 'string') {
+      throw new Error(`${SCAN_JOB_ID} matrix entry ${index} has no \`dockerfile:\` value`);
+    }
+    return dockerfile;
+  });
+}
+
+function findDockerfiles(): string[] {
+  const found: string[] = [];
+  for (const entry of readdirSync(path.join(REPO_ROOT, 'apps'), { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const rel = `apps/${entry.name}/Dockerfile`;
+    if (existsSync(path.join(REPO_ROOT, rel))) found.push(rel);
+  }
+  for (const entry of readdirSync(path.join(REPO_ROOT, 'docker'), { withFileTypes: true })) {
+    if (entry.isFile() && entry.name.startsWith('Dockerfile')) found.push(`docker/${entry.name}`);
+  }
+  return found.sort((a, b) => a.localeCompare(b));
+}
+
+const PUBLISHED = publishedDockerfiles();
+const PUBLISHED_FILES = [...new Set(PUBLISHED.map((entry) => entry.dockerfile))].sort((a, b) =>
+  a.localeCompare(b),
+);
+const SCANNED_FILES = scannedDockerfiles();
+const SECURITY_SOURCE = readFileSync(path.join(REPO_ROOT, SECURITY_WORKFLOW), 'utf8');
+
+describe('Trivy image scan covers the images we publish', () => {
+  it('derives a non-empty published and scanned set', () => {
+    // Sanity: every assertion below is a set comparison, so an empty derivation
+    // on either side would pass vacuously while covering nothing.
+    expect(PUBLISHED_FILES).toContain('apps/api/Dockerfile');
+    expect(PUBLISHED_FILES).toContain('apps/web/Dockerfile');
+    expect(PUBLISHED_FILES.length).toBeGreaterThanOrEqual(6);
+    expect(SCANNED_FILES.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it.each(PUBLISHED_FILES)('%s is built and scanned by the CI Trivy job', (dockerfile) => {
+    if (dockerfile in SCAN_EXEMPT) {
+      expect(SCANNED_FILES).not.toContain(dockerfile);
+      return;
+    }
+
+    const publishers = PUBLISHED.filter((entry) => entry.dockerfile === dockerfile)
+      .map((entry) => entry.source)
+      .join(', ');
+
+    expect(
+      SCANNED_FILES,
+      `${dockerfile} is pushed to the registry by ${publishers}, but ` +
+        `${SECURITY_WORKFLOW}'s ${SCAN_JOB_ID} matrix never builds it — so no ` +
+        'image-level vulnerability gate ever looks at the image customers run ' +
+        '(issues #4273 / #4260). Add a matrix entry for it, or record a reason ' +
+        'in SCAN_EXEMPT.',
+    ).toContain(dockerfile);
+  });
+
+  it('every scanned Dockerfile exists on disk', () => {
+    for (const dockerfile of SCANNED_FILES) {
+      expect(
+        existsSync(path.join(REPO_ROOT, dockerfile)),
+        `${SCAN_JOB_ID} scans ${dockerfile}, which does not exist — the job would ` +
+          'fail at build time, or worse, the entry is a typo silently covering nothing.',
+      ).toBe(true);
+    }
+  });
+
+  it('the scan matrix actually drives the build and scan steps', () => {
+    // Without this, the matrix could list every published image while the steps
+    // kept building a hardcoded one — a roster that looks like coverage and is
+    // not. The build step must reference `matrix.dockerfile`, and the scan must
+    // still be blocking on HIGH/CRITICAL.
+    const job = readWorkflow(SECURITY_WORKFLOW).jobs?.[SCAN_JOB_ID];
+    const steps = job?.steps ?? [];
+
+    const buildStep = steps.find((step) => typeof step.run === 'string' && step.run.includes('docker build'));
+    expect(buildStep, `${SCAN_JOB_ID} has no \`docker build\` step`).toBeDefined();
+    const buildRefs = JSON.stringify([buildStep?.run, buildStep?.env]);
+    expect(buildRefs).toMatch(/matrix\.dockerfile/);
+    expect(buildRefs).toMatch(/matrix\.image/);
+
+    const scanStep = steps.find((step) => step.uses?.startsWith('aquasecurity/trivy-action'));
+    expect(scanStep, `${SCAN_JOB_ID} has no trivy-action step`).toBeDefined();
+    expect(String(scanStep?.with?.['image-ref'])).toMatch(/matrix\.image/);
+    expect(scanStep?.with?.severity).toBe('HIGH,CRITICAL');
+    expect(String(scanStep?.with?.['exit-code'])).toBe('1');
+
+    // The action must stay SHA-pinned like every other third-party action here.
+    // (The trailing `# vX.Y.Z` is a YAML comment, so it is not part of `uses`.)
+    expect(scanStep?.uses).toMatch(/^aquasecurity\/trivy-action@[0-9a-f]{40}$/);
+  });
+
+  it('leaves no Dockerfile silently unclassified', () => {
+    // Anti-rot snapshot: a new Dockerfile, or a publish step retargeted at a
+    // different file, changes this map and forces a human to decide which side
+    // of the line it belongs on instead of quietly losing coverage.
+    const classification = Object.fromEntries(
+      findDockerfiles().map((dockerfile) => {
+        const published = PUBLISHED_FILES.includes(dockerfile);
+        const scanned = SCANNED_FILES.includes(dockerfile);
+        if (published && scanned) return [dockerfile, 'published + scanned'];
+        if (published) return [dockerfile, 'published, scan-exempt'];
+        if (scanned) return [dockerfile, 'not published, scanned anyway'];
+        return [dockerfile, 'not published, not scanned'];
+      }),
+    );
+
+    expect(classification).toEqual({
+      'apps/api/Dockerfile': 'published + scanned',
+      'apps/m365-communications-executor/Dockerfile': 'published + scanned',
+      'apps/m365-graph-actions-executor/Dockerfile': 'published + scanned',
+      'apps/m365-graph-read-executor/Dockerfile': 'published + scanned',
+      'apps/portal/Dockerfile': 'published + scanned',
+      'apps/web/Dockerfile': 'published + scanned',
+      // Built by ci.yml's smoke test (docker-compose.override.yml.ci) and by the
+      // local-build compose mode, so they stay gated even though release never
+      // pushes them.
+      'docker/Dockerfile.api': 'not published, scanned anyway',
+      'docker/Dockerfile.web': 'not published, scanned anyway',
+      // See SCAN_EXEMPT: staging/ build context cannot be reproduced in CI.
+      'docker/Dockerfile.binaries': 'published, scan-exempt',
+      // Hot-reload dev images: floating base tag, never published.
+      'docker/Dockerfile.api.dev': 'not published, not scanned',
+      'docker/Dockerfile.portal.dev': 'not published, not scanned',
+      'docker/Dockerfile.web.dev': 'not published, not scanned',
+    });
+  });
+
+  it('records a reason for every scan exemption', () => {
+    for (const [dockerfile, reason] of Object.entries(SCAN_EXEMPT)) {
+      expect(PUBLISHED_FILES, `${dockerfile} is exempted but nothing publishes it`).toContain(
+        dockerfile,
+      );
+      expect(reason.length).toBeGreaterThan(80);
+    }
+  });
+
+  it('local preflight builds the published api/web images, not the compose proxies', () => {
+    // scripts/security/preflight.sh is the "run CI's gates locally" script. It
+    // built the same docker/Dockerfile.* proxies, so a developer running it saw
+    // the same false green CI did.
+    const preflight = readFileSync(path.join(REPO_ROOT, 'scripts/security/preflight.sh'), 'utf8');
+    expect(preflight).toContain('-f apps/api/Dockerfile');
+    expect(preflight).toContain('-f apps/web/Dockerfile');
+  });
+});
+
+describe('the coverage derivation is discriminating', () => {
+  // These exercise the helpers against synthetic workflows: without them the
+  // suite would pass just as happily on a derivation that returned nothing.
+
+  it('counts only steps that actually push', () => {
+    const inputs = { file: 'apps/api/Dockerfile' };
+    expect(stepPushes({ ...inputs, push: true })).toBe(true);
+    expect(stepPushes({ ...inputs, push: false })).toBe(false);
+    expect(stepPushes(inputs)).toBe(false);
+    expect(
+      stepPushes({
+        ...inputs,
+        outputs: 'type=image,name=ghcr.io/x/api,push-by-digest=true,name-canonical=true,push=true',
+      }),
+    ).toBe(true);
+    // `push-by-digest=true` alone is not a push.
+    expect(stepPushes({ ...inputs, outputs: 'type=image,push-by-digest=true' })).toBe(false);
+  });
+
+  it('expands matrix references and refuses the ones it cannot resolve', () => {
+    expect(expandMatrixRefs('apps/${{ matrix.image }}/Dockerfile', { image: 'web' })).toBe(
+      'apps/web/Dockerfile',
+    );
+    expect(expandMatrixRefs('${{ matrix.dockerfile }}', { dockerfile: 'apps/api/Dockerfile' })).toBe(
+      'apps/api/Dockerfile',
+    );
+    // Unknown axis, and non-matrix expressions, must return null rather than a
+    // half-substituted path that silently matches nothing.
+    expect(expandMatrixRefs('apps/${{ matrix.image }}/Dockerfile', {})).toBeNull();
+    expect(expandMatrixRefs('${{ env.DOCKERFILE }}', {})).toBeNull();
+  });
+
+  it('throws on a matrix shape it does not understand', () => {
+    expect(() => matrixCombinations({ include: [{ image: 'api' }], image: ['api'] })).toThrow(
+      /Unsupported matrix shape/,
+    );
+    expect(() => matrixCombinations({ image: 'api' })).toThrow(/Unsupported matrix axis/);
+    expect(matrixCombinations(undefined)).toEqual([{}]);
+    expect(matrixCombinations({ image: ['api', 'web'] })).toEqual([
+      { image: 'api' },
+      { image: 'web' },
+    ]);
+  });
+
+  it('would fail if a published Dockerfile were dropped from the scan matrix', () => {
+    // The real check is `expect(SCANNED_FILES).toContain(dockerfile)`. Prove it
+    // discriminates by running the same comparison against a scan roster with
+    // the shipped API image removed.
+    const withApiDropped = SCANNED_FILES.filter((f) => f !== 'apps/api/Dockerfile');
+    expect(withApiDropped).not.toContain('apps/api/Dockerfile');
+    expect(PUBLISHED_FILES).toContain('apps/api/Dockerfile');
+  });
+
+  it('reads the security workflow it claims to check', () => {
+    expect(SECURITY_SOURCE).toContain('trivy-image-scan:');
+  });
+});

--- a/scripts/security/check-supply-chain-hardening.sh
+++ b/scripts/security/check-supply-chain-hardening.sh
@@ -321,12 +321,12 @@ require_order 'name: Scan exact executor digest' 'name: Promote scanned executor
   "executor release promotion must occur only after its exact digest passes scanning"
 require_order 'name: Promote scanned executor digest' 'name: Upload executor digest' "$executor_release_block" \
   "executor digest artifact must describe the promoted image"
-require_grep 'breeze-m365-graph-read-executor:security-scan' .github/workflows/security.yml \
-  "security workflow must build and scan the executor image"
+require_grep 'dockerfile: apps/m365-graph-read-executor/Dockerfile' .github/workflows/security.yml \
+  "security workflow's trivy-image-scan matrix must build and scan the executor image"
 [[ -x scripts/security/check-m365-graph-read-runtime.sh ]] || \
   fail "scripts/security/check-m365-graph-read-runtime.sh must be executable"
-require_grep 'breeze-m365-graph-actions-executor:security-scan' .github/workflows/security.yml \
-  "security workflow must build and scan the actions-executor image"
+require_grep 'dockerfile: apps/m365-graph-actions-executor/Dockerfile' .github/workflows/security.yml \
+  "security workflow's trivy-image-scan matrix must build and scan the actions-executor image"
 [[ -x scripts/security/check-m365-graph-actions-runtime.sh ]] || \
   fail "scripts/security/check-m365-graph-actions-runtime.sh must be executable"
 
@@ -382,8 +382,8 @@ require_order 'name: Scan exact executor digest' 'name: Promote scanned executor
   "communications-executor release promotion must occur only after its exact digest passes scanning"
 require_order 'name: Promote scanned executor digest' 'name: Upload executor digest' "$comms_release_block" \
   "communications-executor digest artifact must describe the promoted image"
-require_grep 'breeze-m365-communications-executor:security-scan' .github/workflows/security.yml \
-  "security workflow must build and scan the communications-executor image"
+require_grep 'dockerfile: apps/m365-communications-executor/Dockerfile' .github/workflows/security.yml \
+  "security workflow's trivy-image-scan matrix must build and scan the communications-executor image"
 require_grep 'directory: "/apps/m365-communications-executor"' .github/dependabot.yml \
   "Dependabot must maintain the communications-executor Dockerfile's digest-pinned base image"
 
@@ -525,6 +525,17 @@ require_grep "severity: 'HIGH,CRITICAL'" .github/workflows/security.yml \
   "Trivy must fail on HIGH and CRITICAL vulnerabilities"
 require_grep '^  trivy-image-scan:' .github/workflows/security.yml \
   "security workflow must scan built Docker images"
+# The scan must target the Dockerfiles release.yml and hosted-images.yml
+# actually publish. It previously built the docker/Dockerfile.api|web compose
+# variants, which ship to nobody, leaving the two most widely deployed images
+# with no image-level gate at all (issues #4273 / #4260). Full published-vs-
+# scanned reconciliation lives in
+# apps/api/src/config/dockerfileImageScanCoverage.test.ts; these two keep the
+# regression visible to the shell gate as well.
+require_grep 'dockerfile: apps/api/Dockerfile' .github/workflows/security.yml \
+  "security workflow's trivy-image-scan matrix must build and scan the shipped API image"
+require_grep 'dockerfile: apps/web/Dockerfile' .github/workflows/security.yml \
+  "security workflow's trivy-image-scan matrix must build and scan the shipped Web image"
 require_grep "format: 'sarif'" .github/workflows/security.yml \
   "Trivy filesystem scan must emit SARIF"
 require_grep "format: 'cyclonedx'" .github/workflows/security.yml \

--- a/scripts/security/check-supply-chain-hardening.sh
+++ b/scripts/security/check-supply-chain-hardening.sh
@@ -527,11 +527,13 @@ require_grep '^  trivy-image-scan:' .github/workflows/security.yml \
   "security workflow must scan built Docker images"
 # The scan must target the Dockerfiles release.yml and hosted-images.yml
 # actually publish. It previously built the docker/Dockerfile.api|web compose
-# variants, which ship to nobody, leaving the two most widely deployed images
-# with no image-level gate at all (issues #4273 / #4260). Full published-vs-
-# scanned reconciliation lives in
+# variants, which ship to nobody, so the two most widely deployed images in the
+# product were never scanned at all (issues #4273 / #4260). Note this makes the
+# images visible, not merge-blocking: main's ruleset requires only `CI Success`,
+# which does not depend on any security.yml job. Full published-vs-scanned
+# reconciliation lives in
 # apps/api/src/config/dockerfileImageScanCoverage.test.ts; these two keep the
-# regression visible to the shell gate as well.
+# regression visible to the shell check as well.
 require_grep 'dockerfile: apps/api/Dockerfile' .github/workflows/security.yml \
   "security workflow's trivy-image-scan matrix must build and scan the shipped API image"
 require_grep 'dockerfile: apps/web/Dockerfile' .github/workflows/security.yml \

--- a/scripts/security/preflight.sh
+++ b/scripts/security/preflight.sh
@@ -148,18 +148,25 @@ else
 fi
 
 # 6) Trivy image scan — CI: security.yml job trivy-image-scan
-# Builds API + Web images then scans them. Slow (~5-10 min on a cold cache),
-# skipped under --fast.
+# Builds the shipped API + Web images then scans them. Slow (~5-10 min on a cold
+# cache), skipped under --fast.
+#
+# These are the Dockerfiles release.yml and hosted-images.yml actually publish.
+# This step used to build docker/Dockerfile.api|web instead — files nothing
+# ships — so a local green here said nothing about the images customers run
+# (issues #4273 / #4260). CI's matrix covers the compose variants, portal and
+# the three M365 executors as well; this local mirror stays at the two heaviest
+# shipped images to keep the run bounded.
 if [ "$FAST_MODE" = "1" ]; then
   skip "trivy image scan (api+web)" "--fast skipped; run without --fast to include"
 elif ! command -v docker >/dev/null 2>&1; then
   skip "trivy image scan (api+web)" "docker not on PATH"
 else
   step "build breeze-api image (security-scan tag)" bash -c '
-    docker build -f docker/Dockerfile.api -t breeze-api:security-scan .
+    docker build -f apps/api/Dockerfile -t breeze-api:security-scan .
   '
   step "build breeze-web image (security-scan tag)" bash -c '
-    docker build -f docker/Dockerfile.web -t breeze-web:security-scan .
+    docker build -f apps/web/Dockerfile -t breeze-web:security-scan .
   '
   TRIVY_IMG_CMD=(trivy image --severity HIGH,CRITICAL --exit-code 1)
   if command -v trivy >/dev/null 2>&1; then


### PR DESCRIPTION
Closes #4273

Also addresses #4260 (same defect, filed independently from the #4246 fix — leaving it open for the reporter to confirm).

## The defect

`security.yml`'s `Trivy Image Scan` job built and scanned `docker/Dockerfile.api` and `docker/Dockerfile.web`. Neither file is ever published. The images customers actually run are built from `apps/api/Dockerfile` and `apps/web/Dockerfile` — and those were scanned **nowhere**: not in CI, not at release time, not in the hosted lane.

So a green `Trivy Image Scan` said nothing about the two most widely deployed images in the product. That is very likely how both came to ship a known HIGH CVE (CVE-2026-14456, libcrypto3/libssl3) that the *scanned* proxies had already been patched for (#4246 / #4257).

Verified coverage before this PR:

| Dockerfile | Published by | CI scan | Release-time scan |
|---|---|---|---|
| `apps/api/Dockerfile` | release.yml, hosted-images.yml | **no** | no |
| `apps/web/Dockerfile` | release.yml, hosted-images.yml | **no** | no |
| `apps/portal/Dockerfile` | release.yml, hosted-images.yml | yes | no |
| `apps/m365-*-executor/Dockerfile` (x3) | release.yml, hosted-images.yml | yes | yes (digest→scan→promote) |
| `docker/Dockerfile.binaries` | release.yml | no | no |
| `docker/Dockerfile.api` / `.web` | **nothing** | yes | n/a |

## The fix

The durable defect was the hand-maintained parallel list: a scan roster kept by hand beside a publish roster kept by hand, with nothing tying them together. Retargeting the two paths alone would just reset the clock, so:

**`.github/workflows/security.yml`** — `trivy-image-scan` becomes a matrix over `{image, dockerfile}` covering all six published Dockerfiles plus the two `docker/Dockerfile.*` compose variants (still built from source by `ci.yml`'s smoke test via `docker-compose.override.yml.ci`, and by self-hosters via `docker-compose.override.yml.local-build`, so they stay gated). Running as a matrix also parallelises what were six sequential image builds in one job.

**`apps/api/src/config/dockerfileImageScanCoverage.test.ts`** (new) — the anti-drift contract. It hand-lists nothing; it walks every workflow in `.github/workflows` and derives:

- **published** = the `file:` input of every `docker/build-push-action` step that actually pushes (`push: true`, or the `push=` field of `outputs:` for the push-by-digest lanes), with `${{ matrix.* }}` expanded against that job's own matrix;
- **scanned** = the `dockerfile:` values of the security workflow's scan matrix;

…and asserts published ⊆ scanned. Add a published image without scanning it, or retarget a publish step at a different Dockerfile, and this fails. Anything the derivation cannot resolve **throws** rather than resolving to nothing — a silently shrinking derivation would make every set comparison vacuously green, which is the same failure this file exists to prevent one level up.

`docker/Dockerfile.binaries` is the single recorded exemption, with its reason stored next to it: release builds it from `context: staging/`, a release-time artifact directory that does not exist in a repo checkout, so CI cannot reproduce the image (its base is the floating `alpine:3.24` tag and its payload is our own release binaries, already covered by the Trivy filesystem scan).

**`scripts/security/preflight.sh`** — built the same unshipped proxies, so a developer running the local mirror saw the same false green CI did. Now builds the shipped api/web Dockerfiles.

**`scripts/security/check-supply-chain-hardening.sh`** — its three executor scan assertions keyed off image tag strings (`breeze-m365-…:security-scan`) that the matrix no longer spells out literally; they now assert the matrix entry. Added the same assertion for the shipped api/web images so the regression is visible to the shell check too.

## Verification

**Live CI is the headline:** all 8 `Trivy Image Scan (…)` legs went green on the first push, including the two that never existed before — `Trivy Image Scan (api)` and `Trivy Image Scan (web)`. The shipped images are now scanned, and they are clean, so this does not arrive red on `main`.

- Real `docker build` of both `apps/api/Dockerfile` and `apps/web/Dockerfile` from a plain repo-root context succeeds locally — the new matrix entries are buildable, not just well-formed YAML.
- `dockerfileImageScanCoverage.test.ts` 16 passed; 555 passed across `apps/api/src/config/` (the two sibling Dockerfile guards included).
- **Mutation-checked, twice.** The first review ran a 12-mutation battery and found three mutations that broke the control while leaving the suite green. All three now fail (see the second commit): a build step carrying the matrix values in `env:` while hardcoding `-f apps/api/Dockerfile`; a job-level `if: github.event_name == 'schedule'`; `continue-on-error: true` on the Trivy step. Deleting the `apps/api/Dockerfile` matrix entry also still fails, naming the exact publishers.
- `tsc --noEmit` (apps/api) clean; `eslint` clean on the new file.
- `bash scripts/security/check-supply-chain-hardening.sh` passes.
- `actionlint 1.7.12 -shellcheck=` (the pinned CI version) clean over all workflows; `check-workflow-security.mjs` policy + its 113 self-tests pass.

## Two things worth a maintainer decision

**1. This makes the images visible, not merge-blocking.** `main`'s ruleset requires exactly one status check, `CI Success`, whose `needs:` list contains no job from `security.yml`. So a red `Trivy Image Scan` shows on the PR and on `main` but does not block a merge — that was true before this PR too. (Visibility is still what surfaced CVE-2026-14456.) If enforcement is wanted, the eight new per-image contexts would need adding to the ruleset, or folding into a `CI Success`-style aggregator. Related: the matrix renamed the check from `Trivy Image Scan` to `Trivy Image Scan (<image>)`, which is safe *only* because nothing requires the old context. Both facts are recorded in the new test's docblock so a future ruleset edit does not silently re-break it.

**2. Release-time digest scanning is still missing for api/web/portal/binaries.** `release.yml` and `hosted-images.yml` push those tags with no scan; only the three M365 executors do build → scan the exact manifest → promote. Extending that pattern means hand-rolling the multi-tag promotion (`{{version}}` / `{{major}}.{{minor}}` / `{{major}}` / `latest`) that `docker/metadata-action` does for those jobs today — `latest` gates every CLI install — so it belongs in its own change. The new test snapshots which publishing jobs have release-time scanning and which do not, so the gap now carries a marker instead of being invisible.

## CI cost

Eight concurrent runners per PR instead of one runner doing six sequential builds. Wall-clock should improve; total runner-minutes go up. The two new legs use plain `docker build` with no `cache-from: type=gha` (matching the existing legs); adding GHA cache is an easy follow-up if the minutes matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
