### PR TITLE
fix(api): route binarySync's release fetches through the SSRF-guarded redirect helper (#4262)

### DIFF
--- a/apps/api/src/routes/agentVersions.test.ts
+++ b/apps/api/src/routes/agentVersions.test.ts
@@ -39,6 +39,15 @@ vi.mock("../services/manifestSigning", () => ({
   signManifest: vi.fn().mockResolvedValue("test-signature"),
 }));
 
+// #4262: the sync-github route now classifies SSRF-guard refusals. Mock the
+// service so the route's error branches can be driven directly, and the Sentry
+// capture so it can be asserted without a DSN.
+vi.mock("../services/binarySync", () => ({
+  syncFromGitHub: vi.fn(),
+}));
+vi.mock("../services/sentry", () => ({
+  captureException: vi.fn(),
+}));
 vi.mock("../services/auditEvents", () => ({
   writeRouteAudit: vi.fn(),
 }));
@@ -76,6 +85,9 @@ import { db } from "../db";
 import { agentVersions } from "../db/schema";
 import * as manifestSigning from "../services/manifestSigning";
 import { writeRouteAudit } from "../services/auditEvents";
+import { syncFromGitHub } from "../services/binarySync";
+import { captureException } from "../services/sentry";
+import { ResponseTooLargeError, SsrfBlockedError } from "../services/urlSafety";
 import { requiredPlatformTrustFor } from "../services/releaseAssetTrust";
 
 // Recursively searches an and()/eq() spy tree (see drizzleSpies above) for an
@@ -244,6 +256,72 @@ describe("agentVersions routes", () => {
       }),
     };
   }
+
+  describe("POST /agent-versions/sync-github — guard-refusal classification (#4262)", () => {
+    it("answers 502 and does NOT leak the resolved internal address", async () => {
+      // The refusal message and .resolvedIps both name internal addresses.
+      // Pre-#4262 the raw err.message was echoed straight into the body; the
+      // route must now return a fixed operator-facing string instead. This is
+      // the assertion most at risk of being silently refactored away, because
+      // "just echo the error" reads like an improvement.
+      vi.mocked(syncFromGitHub).mockRejectedValue(
+        new SsrfBlockedError(
+          "all resolved IPs for api.github.com are private/loopback/link-local",
+          { hostname: "api.github.com", resolvedIps: ["10.1.2.3", "169.254.169.254"] },
+        ),
+      );
+
+      const res = await app.request("/agent-versions/sync-github", {
+        method: "POST",
+      });
+
+      expect(res.status).toBe(502);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toMatch(/private or link-local/i);
+      // The whole point: no internal address reaches the client.
+      expect(body.error).not.toMatch(/10\.1\.2\.3|169\.254\.169\.254/);
+      // …but it IS escalated server-side, since the catch otherwise loses it.
+      expect(vi.mocked(captureException)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(captureException).mock.calls[0]?.[2]).toMatchObject({
+        release_sync_failure_reason: "ssrf-blocked",
+      });
+    });
+
+    it("answers 502 on a body-ceiling abort", async () => {
+      vi.mocked(syncFromGitHub).mockRejectedValue(
+        new ResponseTooLargeError(1024 * 1024),
+      );
+
+      const res = await app.request("/agent-versions/sync-github", {
+        method: "POST",
+      });
+
+      expect(res.status).toBe(502);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toMatch(/1048576-byte limit/);
+      expect(vi.mocked(captureException).mock.calls[0]?.[2]).toMatchObject({
+        release_sync_failure_reason: "response-too-large",
+      });
+    });
+
+    it("leaves the pre-existing generic classification alone", async () => {
+      // Guards against over-reach: a plain failure must still take the original
+      // 422 path, not be swept into the new 502 branches.
+      vi.mocked(syncFromGitHub).mockRejectedValue(
+        new Error("something mundane broke"),
+      );
+
+      const res = await app.request("/agent-versions/sync-github", {
+        method: "POST",
+      });
+
+      expect(res.status).toBe(422);
+      expect((await res.json() as { error: string }).error).toBe(
+        "something mundane broke",
+      );
+      expect(vi.mocked(captureException)).not.toHaveBeenCalled();
+    });
+  });
 
   describe("GET /agent-versions (platform-admin list)", () => {
     it("non-platform-admin → 403", async () => {

--- a/apps/api/src/routes/agentVersions.ts
+++ b/apps/api/src/routes/agentVersions.ts
@@ -14,6 +14,8 @@ import {
 import { platformAdminMiddleware } from "../middleware/platformAdmin";
 import { writeRouteAudit } from "../services/auditEvents";
 import { syncFromGitHub } from "../services/binarySync";
+import { captureException } from "../services/sentry";
+import { ResponseTooLargeError, SsrfBlockedError } from "../services/urlSafety";
 import { getBinaryEdition } from "../services/binaryEdition";
 import { getGithubReleaseVersion } from "../services/binarySource";
 import { PERMISSIONS } from "../services/permissions";
@@ -985,8 +987,48 @@ agentVersionRoutes.post(
       // short registration instead of assuming a clean sync.
       return c.json(result);
     } catch (err) {
+      // A guard refusal (#4262) is not a routine sync failure: it means the
+      // release host resolved to a private/loopback/link-local address, which
+      // is a DNS-hijack signal. Left in the generic branch it became a 422 with
+      // no server-side trace at all — no log, no Sentry (writeRouteAudit only
+      // runs on success), so nobody could reconstruct it later. Log and
+      // escalate, and answer 502: the fault is upstream, not in the request.
+      // The response deliberately does NOT echo err.resolvedIps — internal
+      // addresses stay in the server-side log.
+      if (err instanceof SsrfBlockedError) {
+        console.error(
+          `[agentVersions] sync-github REFUSED by the SSRF guard (host=${err.hostname ?? "?"}, resolved=${err.resolvedIps?.join(", ") ?? "n/a"})`,
+        );
+        captureException(err, c, {
+          release_sync_failure_reason: "ssrf-blocked",
+          release_sync_context: "sync-github-route",
+        });
+        return c.json(
+          {
+            error:
+              "Release sync refused: the release host resolved to a private or link-local address. Check DNS and egress on the API host.",
+          },
+          502,
+        );
+      }
+      if (err instanceof ResponseTooLargeError) {
+        console.error(
+          `[agentVersions] sync-github aborted: response exceeded the ${err.maxBytes}-byte ceiling`,
+        );
+        captureException(err, c, {
+          release_sync_failure_reason: "response-too-large",
+          release_sync_context: "sync-github-route",
+        });
+        return c.json(
+          {
+            error: `Release sync aborted: the release host returned a body over the ${err.maxBytes}-byte limit.`,
+          },
+          502,
+        );
+      }
       const msg = err instanceof Error ? err.message : String(err);
       const status = msg.includes("GitHub API error") ? 502 : 422;
+      console.error(`[agentVersions] sync-github failed: ${msg}`);
       return c.json({ error: msg }, status);
     }
   },

--- a/apps/api/src/routes/agentVersionsLocalModeRoundtrip.test.ts
+++ b/apps/api/src/routes/agentVersionsLocalModeRoundtrip.test.ts
@@ -48,8 +48,13 @@ vi.mock("../db", () => ({
 // and this suite makes real network calls.
 vi.mock("../services/urlSafety", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../services/urlSafety")>()),
-  safeFetchFollowingRedirects: (url: string, init?: RequestInit) =>
-    globalThis.fetch(url, init),
+  // Typed against SafeFetchInit (not RequestInit) so a call site's `maxBytes` /
+  // `timeoutMs` survive the bridge instead of being silently dropped, and a
+  // vi.fn() so a suite CAN assert on what binarySync passed the helper.
+  safeFetchFollowingRedirects: vi.fn(
+    (url: string, init?: import("../services/urlSafety").SafeFetchInit) =>
+      globalThis.fetch(url, init as RequestInit),
+  ),
 }));
 
 // agentVersions.ts imports these middlewares/services at module scope; stub

--- a/apps/api/src/routes/agentVersionsLocalModeRoundtrip.test.ts
+++ b/apps/api/src/routes/agentVersionsLocalModeRoundtrip.test.ts
@@ -37,6 +37,19 @@ const dbMocks = vi.hoisted(() => {
 
 vi.mock("../db", () => ({
   db: { transaction: dbMocks.transaction, select: dbMocks.select },
+  // Required by urlSafety's safeFetch (#1105 tripwire) now that binarySync
+  // routes its downloads through it.
+  assertOutsideHeldDbContext: vi.fn(),
+}));
+
+// binarySync's fetches go through the SSRF-guarded helper (#4262), which dials
+// http/https directly and never touches global `fetch`. Bridge it back to the
+// stubbed global or the `vi.stubGlobal("fetch", …)` below stops intercepting
+// and this suite makes real network calls.
+vi.mock("../services/urlSafety", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../services/urlSafety")>()),
+  safeFetchFollowingRedirects: (url: string, init?: RequestInit) =>
+    globalThis.fetch(url, init),
 }));
 
 // agentVersions.ts imports these middlewares/services at module scope; stub

--- a/apps/api/src/services/binarySync.redirect.test.ts
+++ b/apps/api/src/services/binarySync.redirect.test.ts
@@ -53,10 +53,23 @@ vi.mock("../db", () => ({
   assertOutsideHeldDbContext: vi.fn(),
 }));
 
-vi.mock("node:fs/promises", () => ({
-  readFile: vi.fn().mockRejectedValue(new Error("ENOENT")),
-  readdir: vi.fn().mockResolvedValue([]),
-  stat: vi.fn().mockRejectedValue(new Error("ENOENT")),
+// Settable rather than fixed: the local-mode case below (site 4) needs readdir
+// and the version file to describe a populated binaries volume.
+const fsMocks = vi.hoisted(() => ({
+  readFile: vi.fn(),
+  readdir: vi.fn(),
+  stat: vi.fn(),
+}));
+vi.mock("node:fs/promises", () => fsMocks);
+
+// Spread the original: the source-scan case needs the REAL `readFileSync`, so
+// this may only override `createReadStream` (used for local checksumming).
+vi.mock("node:fs", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:fs")>()),
+  createReadStream: () => {
+    const { Readable } = require("node:stream");
+    return Readable.from(Buffer.from("local agent bytes"));
+  },
 }));
 
 vi.mock("./s3Storage", () => ({
@@ -74,7 +87,7 @@ vi.mock("./manifestSigning", () => ({
 
 vi.mock("./sentry", () => ({ captureException: vi.fn() }));
 
-import { syncFromGitHub } from "./binarySync";
+import { syncBinaries, syncFromGitHub } from "./binarySync";
 import { requiredPlatformTrustFor } from "./releaseAssetTrust";
 import {
   ResponseTooLargeError,
@@ -220,6 +233,11 @@ describe("binarySync — SSRF-guarded release fetches (#4262)", () => {
     process.env.BINARY_GITHUB_REPOSITORY = REPO;
     delete process.env.GITHUB_REPO;
     vi.clearAllMocks();
+    // Default: an EMPTY binaries volume, so the syncFromGitHub cases below are
+    // not accidentally rescued by local registration.
+    fsMocks.readFile.mockRejectedValue(new Error("ENOENT"));
+    fsMocks.readdir.mockResolvedValue([]);
+    fsMocks.stat.mockRejectedValue(new Error("ENOENT"));
     __setLookupForTests(async () => [{ address: "93.184.216.34", family: 4 }]);
   });
 
@@ -324,6 +342,15 @@ describe("binarySync — SSRF-guarded release fetches (#4262)", () => {
     expect(err).toBeInstanceOf(SsrfBlockedError);
     expect(String(err)).toMatch(/169\.254\.169\.254/);
     expect(stub.requests.map((req) => req.host)).not.toContain(METADATA_IP);
+    // `not.toContain` alone would pass on an EMPTY request list, so pin the
+    // positive shape too. The manifest and its signature are fetched
+    // concurrently (Promise.all), so the github.com hop count is 1 or 2
+    // depending on scheduling — assert the SET of hosts and a floor, not an
+    // exact sequence.
+    expect(stub.requests.length).toBeGreaterThanOrEqual(2);
+    expect(new Set(stub.requests.map((req) => req.host))).toEqual(
+      new Set([API_HOST, "github.com"]),
+    );
   });
 
   it("REFUSES a checksums.txt redirect to a host that RESOLVES into RFC1918", async () => {
@@ -356,6 +383,10 @@ describe("binarySync — SSRF-guarded release fetches (#4262)", () => {
     expect(err).toBeInstanceOf(SsrfBlockedError);
     expect(String(err)).toMatch(/internal\.example|192\.168\.1\.10/);
     expect(stub.requests.map((req) => req.host)).not.toContain("internal.example");
+    // Positive shape, so the `not.toContain` above cannot pass on an empty
+    // list: exactly the API call and the one refused hop. checksums.txt is a
+    // single fetch, so unlike the manifest pair this count IS deterministic.
+    expect(stub.requests.map((req) => req.host)).toEqual([API_HOST, "github.com"]);
   });
 
   it("aborts an oversized manifest at the streaming ceiling", async () => {
@@ -366,10 +397,25 @@ describe("binarySync — SSRF-guarded release fetches (#4262)", () => {
     const signed = makeSignedManifest();
     process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
 
+    // Served from the REDIRECT TARGET, not from the first hop. In production
+    // every release-asset fetch redirects to objects.githubusercontent.com, so
+    // the ceiling that actually protects the boot path is the one applied on
+    // hop 2. `safeFetchFollowingRedirects` carries `maxBytes` across a hop only
+    // because its per-hop init spread preserves it — and no test in this repo
+    // pinned that (urlSafety.test.ts exercises maxBytes on bare `safeFetch`
+    // only). A refactor of that spread would otherwise go unnoticed.
     const oversized = Buffer.alloc(1024 * 1024 + 1, 0x61);
     const stub = installRequestStub((req) => {
       if (req.host === API_HOST) {
         return { status: 200, body: releaseJson({ withManifest: true }) };
+      }
+      if (req.host === "github.com") {
+        return {
+          status: 302,
+          headers: {
+            location: `https://objects.githubusercontent.com/breeze${req.path}?token=abc`,
+          },
+        };
       }
       return pathWithoutQuery(req.path).endsWith(".ed25519")
         ? { status: 200, body: signed.signature }
@@ -379,6 +425,67 @@ describe("binarySync — SSRF-guarded release fetches (#4262)", () => {
 
     const err = await syncFromGitHub().catch((error) => error);
     expect(err).toBeInstanceOf(ResponseTooLargeError);
+    // The overrun really did happen on the far side of the redirect.
+    expect(stub.requests.map((req) => req.host)).toContain(
+      "objects.githubusercontent.com",
+    );
+  });
+
+  it("REFUSES the backup-backfill redirect, and says so instead of failing mute", async () => {
+    // Site :1474 (`backfillBackupRowsForVersion`) is the ONE call site not
+    // reachable from syncFromGitHub — it hangs off syncBinaries() →
+    // ensureCurrentVersionRegistered(). It is also the site whose failure is
+    // SWALLOWED by a catch that only console.errors, so a regression here is
+    // silent by construction. That inverts the usual priority: this is the site
+    // where a behavioral test earns the most, not the least.
+    process.env.BINARY_SOURCE = "local";
+    process.env.AGENT_BINARY_DIR = "/fake/agent/bin";
+    process.env.BINARY_VERSION_FILE = "/fake/version";
+    process.env.BREEZE_VERSION = "0.65.9";
+    fsMocks.stat.mockResolvedValue({ isFile: () => true, size: 4096 } as never);
+    fsMocks.readFile.mockResolvedValue("0.65.9" as never);
+    fsMocks.readdir.mockResolvedValue([
+      "breeze-agent-linux-amd64",
+      "breeze-backup-linux-amd64",
+    ] as never);
+    // Agent row registered, backup row missing — the state that triggers the
+    // narrow backfill.
+    dbMocks.select.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ component: "agent" }]),
+      }),
+    });
+
+    const stub = installRequestStub((req) =>
+      req.host === API_HOST
+        ? {
+            status: 302,
+            headers: { location: `http://${METADATA_IP}/latest/meta-data/iam/` },
+          }
+        : { status: 200, body: Buffer.from("unexpected") },
+    );
+    restoreRequests = stub.restore;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // Deliberately does NOT reject: the caller swallows it. That is existing,
+    // intended behavior (a transient failure must not take boot down), so the
+    // assertion is on the guard holding and the refusal being REPORTED.
+    await expect(syncBinaries()).resolves.toBeUndefined();
+
+    expect(stub.requests.map((req) => req.host)).not.toContain(METADATA_IP);
+    expect(stub.requests.map((req) => req.host)).toEqual([API_HOST]);
+    // The backfill was genuinely attempted against the pinned tag — otherwise
+    // the assertions above would hold vacuously for a code path never entered.
+    expect(stub.requests[0]?.path).toContain("/releases/tags/v0.65.9");
+    // And the swallow is not mute: the operator gets the guard named, plus the
+    // host and resolved address, which live on the error's properties rather
+    // than in its message.
+    const logged = errorSpy.mock.calls.map((args) => args.join(" ")).join("\n");
+    expect(logged).toContain("Failed to auto-sync version 0.65.9");
+    expect(logged).toContain("BLOCKED BY SSRF GUARD");
+    expect(logged).toContain(METADATA_IP);
+
+    errorSpy.mockRestore();
   });
 
   it("contains no raw fetch call, and every outbound call is guarded and capped", () => {
@@ -387,31 +494,99 @@ describe("binarySync — SSRF-guarded release fetches (#4262)", () => {
     // quietly reopening the hole — the same anti-regrowth contract
     // `releaseArtifactManifest.redirect.test.ts` and
     // `backupSsrfAdoption.test.ts` apply to their surfaces.
-    const source = readFileSync(
+    const raw = readFileSync(
       join(dirname(fileURLToPath(import.meta.url)), "binarySync.ts"),
       "utf8",
     );
 
-    // Bare `fetch(` — exactly what a revert would look like.
-    expect(source).not.toMatch(/(?<![.\w])fetch\s*\(/);
-    // …and the qualified spellings the lookbehind above deliberately exempts,
-    // so `globalThis.fetch(url)` cannot slip past this guard.
-    expect(source).not.toMatch(/\b(?:globalThis|window|global)\s*\.\s*fetch\s*\(/);
+    // Scan CODE, not prose. The forbidden list below includes bare words like
+    // `undici` and `axios`, and this module's comments legitimately discuss
+    // them — a comment explaining what undici does across a redirect would
+    // otherwise red this test. (That fails safe rather than open, but it sends
+    // the next person word-policing their comments instead of fixing code.)
+    //
+    // Deliberately conservative: only block comments and comments occupying a
+    // WHOLE line are removed. Stripping trailing `//` comments would have to
+    // cope with `"https://…"` inside string literals, and a regex that got it
+    // wrong there would silently delete real code from the scan — a false
+    // NEGATIVE on a security control, which is the one direction that must not
+    // happen. A trailing comment can still trip this; that is the safe way to
+    // be wrong.
+    const source = raw
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/^[ \t]*\/\/.*$/gm, "");
+    // Guard the strip itself: if a regex change ever nuked the file, every
+    // `not.toMatch` below would pass vacuously.
+    expect(source).toContain("safeFetchFollowingRedirects");
+    expect(source.length).toBeGreaterThan(raw.length / 2);
+
+    // Banning only `fetch` is too narrow — a reintroduction could just as
+    // easily use `https.request` or axios and satisfy a fetch-only scan. This
+    // mirrors the FORBIDDEN list already used by `backupSsrfAdoption.test.ts`
+    // for the backup surface.
+    const FORBIDDEN: Array<[string, RegExp]> = [
+      // Bare `fetch(` — exactly what a revert would look like. The lookbehind
+      // exempts `.fetch`/`safeFetch`, so the next entry covers those.
+      ["bare fetch(", /(?<![.\w])fetch\s*\(/],
+      [
+        "qualified global fetch(",
+        /\b(?:globalThis|window|global)\s*\.\s*fetch\s*\(/,
+      ],
+      // Indexed and indirect spellings that evade the two patterns above.
+      ["indexed global fetch", /\b(?:globalThis|window|global)\s*\[\s*["'`]fetch/],
+      ["fetch.call/.apply", /(?<![.\w])fetch\s*\.\s*(?:call|apply|bind)\s*\(/],
+      ["http(s).request(", /\bhttps?\s*\.\s*request\s*\(/],
+      ["http(s).get(", /\bhttps?\s*\.\s*get\s*\(/],
+      ["axios", /\baxios\b/],
+      ["undici", /\bundici\b/],
+      ["new http(s).Agent(", /new\s+https?\s*\.\s*Agent\s*\(/],
+      // SSRF-guarded but UNCAPPED: bare `safeFetch(` takes no redirect budget
+      // and evades the per-call-site maxBytes loop below entirely, so it would
+      // otherwise be a silent way to add an unbounded outbound call here.
+      ["uncapped safeFetch(", /(?<![.\w])safeFetch\s*\(/],
+    ];
+    for (const [label, pattern] of FORBIDDEN) {
+      expect(
+        source,
+        `binarySync.ts must not reach the network via ${label} — route it through ` +
+          "safeFetchFollowingRedirects with a maxBytes ceiling (services/urlSafety.ts).",
+      ).not.toMatch(pattern);
+    }
 
     // Positive half: the helper must actually be CALLED, not merely imported —
     // an orphaned import would satisfy a bare identifier match. Pin the count
     // too, so deleting a call site cannot pass this test the way an empty file
-    // would.
-    const callSites = source.match(/safeFetchFollowingRedirects\s*\(/g) ?? [];
-    expect(callSites).toHaveLength(4);
+    // would. This is a DELETION tripwire, not a completeness check: adding a
+    // legitimate fifth guarded call site is expected to fail here once, so that
+    // a human confirms it carries a ceiling and a timeout.
+    const CALL_SITE = /safeFetchFollowingRedirects\s*\(/g;
+    const offsets = [...source.matchAll(CALL_SITE)].map((m) => m.index ?? 0);
+    expect(
+      offsets,
+      "binarySync.ts should have exactly 4 guarded outbound call sites; if you " +
+        "added or removed one deliberately, update this count and confirm the " +
+        "new site passes maxBytes and timeoutMs.",
+    ).toHaveLength(4);
 
-    // Every one of them carries a byte ceiling. Without this a new call site
-    // could adopt the SSRF guard and still buffer an unbounded body.
-    for (const match of source.matchAll(/safeFetchFollowingRedirects\s*\(/g)) {
-      const window = source.slice(match.index, match.index + 400);
-      expect(window, `call site at offset ${match.index} must pass maxBytes`).toMatch(
-        /maxBytes:/,
-      );
-    }
+    // Every one of them carries BOTH ceilings. Bytes without time still lets a
+    // hung socket pin a pooled DB connection (these all run inside a held
+    // context); time without bytes still lets a huge body be buffered.
+    //
+    // The window is clamped at the NEXT call site rather than a fixed length,
+    // so a new site cannot borrow its neighbour's `maxBytes:` match. The value
+    // must be a named constant or a literal — `maxBytes: undefined` satisfies a
+    // bare /maxBytes:/ while disabling the ceiling entirely.
+    offsets.forEach((start, i) => {
+      const end = offsets[i + 1] ?? source.length;
+      const callSite = source.slice(start, Math.min(end, start + 600));
+      expect(
+        callSite,
+        `call site at offset ${start} must pass a real maxBytes`,
+      ).toMatch(/maxBytes:\s*(?:[A-Z][A-Z0-9_]*|\d)/);
+      expect(
+        callSite,
+        `call site at offset ${start} must pass a real timeoutMs`,
+      ).toMatch(/timeoutMs:\s*(?:[A-Z][A-Z0-9_]*|\d)/);
+    });
   });
 });

--- a/apps/api/src/services/binarySync.redirect.test.ts
+++ b/apps/api/src/services/binarySync.redirect.test.ts
@@ -1,0 +1,417 @@
+/**
+ * SSRF regression suite for binarySync's outbound release fetches (#4262).
+ *
+ * #3649 (PR #4255) routed `releaseArtifactManifest.ts` through the guarded
+ * helper, but `binarySync.ts` reached the network by a second, structurally
+ * parallel path that fetched **the very same two artifacts** —
+ * `release-artifact-manifest.json` and its `.ed25519` signature — with a bare
+ * `fetch`. So the module was closed and the artifact was not. This file pins
+ * the other path shut.
+ *
+ * Two properties, and both matter:
+ *
+ *   1. Normal GitHub redirects still work. Release asset URLs 302 from
+ *      `github.com` to `objects.githubusercontent.com`, and this code runs at
+ *      BOOT under `BINARY_SOURCE=github` — an over-tight guard here would be an
+ *      availability bug on the startup path, not a security win.
+ *   2. Every hop is independently DNS-resolved, filtered and IP-pinned, so a
+ *      redirect into loopback / link-local / RFC1918 is refused rather than
+ *      followed.
+ *
+ * This file deliberately does NOT mock `./urlSafety` — the guard runs for real.
+ * Only DNS (`__setLookupForTests`) and the socket layer are stubbed, so every
+ * host that would actually be dialed is recorded and assertable. The socket
+ * harness is the one from `releaseArtifactManifest.redirect.test.ts`.
+ */
+import { createHash, generateKeyPairSync, sign } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import http from "node:http";
+import https from "node:https";
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const dbMocks = vi.hoisted(() => {
+  const onConflictDoUpdate = vi.fn().mockResolvedValue(undefined);
+  const insertValues = vi.fn(() => ({ onConflictDoUpdate }));
+  const updateWhere = vi.fn().mockResolvedValue(undefined);
+  const tx = {
+    insert: vi.fn(() => ({ values: insertValues })),
+    update: vi.fn(() => ({ set: vi.fn(() => ({ where: updateWhere })) })),
+  };
+  return {
+    insertValues,
+    transaction: vi.fn(async (fn: (t: unknown) => Promise<void>) => fn(tx)),
+    select: vi.fn(),
+  };
+});
+
+vi.mock("../db", () => ({
+  db: { transaction: dbMocks.transaction, select: dbMocks.select },
+  // safeFetch calls this (#1105 tripwire) and the real `../db` is mocked away.
+  assertOutsideHeldDbContext: vi.fn(),
+}));
+
+vi.mock("node:fs/promises", () => ({
+  readFile: vi.fn().mockRejectedValue(new Error("ENOENT")),
+  readdir: vi.fn().mockResolvedValue([]),
+  stat: vi.fn().mockRejectedValue(new Error("ENOENT")),
+}));
+
+vi.mock("./s3Storage", () => ({
+  isS3Configured: () => false,
+  syncDirectory: vi.fn(),
+}));
+
+vi.mock("./manifestSigning", () => ({
+  ensureActiveSigningKey: vi.fn(async () => ({
+    keyId: "deploy-test-aaaaaaaa",
+    publicKeyB64: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+  })),
+  signManifest: vi.fn(async () => "test-signature-base64"),
+}));
+
+vi.mock("./sentry", () => ({ captureException: vi.fn() }));
+
+import { syncFromGitHub } from "./binarySync";
+import { requiredPlatformTrustFor } from "./releaseAssetTrust";
+import {
+  ResponseTooLargeError,
+  SsrfBlockedError,
+  __setLookupForTests,
+} from "./urlSafety";
+
+type StubbedResponse =
+  | { status: number; headers?: Record<string, string>; body?: Buffer }
+  | { networkError: string };
+
+interface RecordedRequest {
+  protocol: "http" | "https";
+  host: string;
+  path: string;
+}
+
+/** Signed-asset redirects carry a `?token=`, so path comparisons ignore it. */
+function pathWithoutQuery(path: string): string {
+  return path.split("?")[0] ?? path;
+}
+
+function installRequestStub(handler: (req: RecordedRequest) => StubbedResponse): {
+  requests: RecordedRequest[];
+  restore: () => void;
+} {
+  const requests: RecordedRequest[] = [];
+
+  const makeImpl = (protocol: "http" | "https") =>
+    ((options: any, callback?: any) => {
+      const recorded: RecordedRequest = {
+        protocol,
+        host: String(options.host),
+        path: String(options.path),
+      };
+      requests.push(recorded);
+      const outcome = handler(recorded);
+
+      const req = new EventEmitter() as any;
+      req.write = vi.fn();
+      req.destroy = vi.fn();
+      req.setTimeout = vi.fn();
+      req.end = vi.fn(() => {
+        if ("networkError" in outcome) {
+          req.emit("error", new Error(outcome.networkError));
+          return;
+        }
+        const res = new EventEmitter() as any;
+        res.statusCode = outcome.status;
+        res.statusMessage = "";
+        res.headers = outcome.headers ?? {};
+        res.setEncoding = vi.fn();
+        callback?.(res);
+        if (outcome.body) res.emit("data", outcome.body);
+        res.emit("end");
+      });
+      return req;
+    }) as any;
+
+  const httpsSpy = vi.spyOn(https, "request").mockImplementation(makeImpl("https"));
+  const httpSpy = vi.spyOn(http, "request").mockImplementation(makeImpl("http"));
+  return {
+    requests,
+    restore: () => {
+      httpsSpy.mockRestore();
+      httpSpy.mockRestore();
+    },
+  };
+}
+
+const REPO = "acme/breeze-selfhost-signing";
+const ASSET_NAME = "breeze-agent-linux-amd64";
+const ASSET_BYTES = Buffer.from("self-hosted agent bytes");
+const API_HOST = "api.github.com";
+const API_PATH = `/repos/${REPO}/releases/latest`;
+const DOWNLOAD_BASE = `https://github.com/${REPO}/releases/download/v1.2.3`;
+
+function makeSignedManifest() {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const publicDer = publicKey.export({ format: "der", type: "spki" }) as Buffer;
+  const manifest = Buffer.from(
+    JSON.stringify({
+      schemaVersion: 1,
+      repository: REPO,
+      release: "v1.2.3",
+      assets: [
+        {
+          name: ASSET_NAME,
+          sha256: createHash("sha256").update(ASSET_BYTES).digest("hex"),
+          size: ASSET_BYTES.length,
+          platformTrust:
+            requiredPlatformTrustFor(ASSET_NAME) ?? "release-workflow-produced",
+        },
+      ],
+    }),
+  );
+  return {
+    manifest,
+    signature: Buffer.from(sign(null, manifest, privateKey).toString("base64")),
+    publicKey: publicDer.subarray(publicDer.length - 32).toString("base64"),
+  };
+}
+
+/** The GitHub Releases API payload, with or without the signed-manifest pair. */
+function releaseJson(opts: { withManifest: boolean }): Buffer {
+  const assets: Record<string, unknown>[] = [
+    {
+      name: ASSET_NAME,
+      browser_download_url: `${DOWNLOAD_BASE}/${ASSET_NAME}`,
+      size: ASSET_BYTES.length,
+    },
+  ];
+  if (opts.withManifest) {
+    assets.push(
+      {
+        name: "release-artifact-manifest.json",
+        browser_download_url: `${DOWNLOAD_BASE}/release-artifact-manifest.json`,
+      },
+      {
+        name: "release-artifact-manifest.json.ed25519",
+        browser_download_url: `${DOWNLOAD_BASE}/release-artifact-manifest.json.ed25519`,
+      },
+    );
+  } else {
+    assets.push({
+      name: "checksums.txt",
+      browser_download_url: `${DOWNLOAD_BASE}/checksums.txt`,
+    });
+  }
+  return Buffer.from(
+    JSON.stringify({ tag_name: "v1.2.3", body: "release notes", assets }),
+  );
+}
+
+const METADATA_IP = "169.254.169.254";
+
+describe("binarySync — SSRF-guarded release fetches (#4262)", () => {
+  const originalEnv = process.env;
+  let restoreRequests: (() => void) | undefined;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    process.env.BINARY_GITHUB_REPOSITORY = REPO;
+    delete process.env.GITHUB_REPO;
+    vi.clearAllMocks();
+    __setLookupForTests(async () => [{ address: "93.184.216.34", family: 4 }]);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    __setLookupForTests(null);
+    restoreRequests?.();
+    restoreRequests = undefined;
+  });
+
+  it("still follows the normal github.com → objects.githubusercontent.com redirect", async () => {
+    // The point of this case: GitHub release assets CANNOT be fetched without
+    // following redirects, and this path runs at boot. A guard that refused the
+    // legitimate hop would break every BINARY_SOURCE=github deployment.
+    const signed = makeSignedManifest();
+    process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+
+    const stub = installRequestStub((req) => {
+      if (req.host === API_HOST) {
+        return { status: 200, body: releaseJson({ withManifest: true }) };
+      }
+      if (req.host === "github.com") {
+        return {
+          status: 302,
+          headers: {
+            location: `https://objects.githubusercontent.com/breeze${req.path}?token=abc`,
+          },
+        };
+      }
+      if (req.host === "objects.githubusercontent.com") {
+        return {
+          status: 200,
+          body: pathWithoutQuery(req.path).endsWith(".ed25519")
+            ? signed.signature
+            : signed.manifest,
+        };
+      }
+      return { status: 404, body: Buffer.from("not found") };
+    });
+    restoreRequests = stub.restore;
+
+    const result = await syncFromGitHub();
+    expect(result.synced).toContain("agent:linux/amd64");
+
+    // Both artifacts were fetched through the redirect, in order, and the
+    // redirect target really was dialed (not merely returned as a 302).
+    const hostsFor = (suffix: string) =>
+      stub.requests
+        .filter((req) => pathWithoutQuery(req.path).endsWith(suffix))
+        .map((req) => req.host);
+    expect(hostsFor("/release-artifact-manifest.json")).toEqual([
+      "github.com",
+      "objects.githubusercontent.com",
+    ]);
+    expect(hostsFor("/release-artifact-manifest.json.ed25519")).toEqual([
+      "github.com",
+      "objects.githubusercontent.com",
+    ]);
+  });
+
+  it("REFUSES a GitHub API redirect into cloud metadata without dialing it", async () => {
+    // Site :1090 — the release-listing call that starts the whole sync.
+    const stub = installRequestStub((req) =>
+      req.host === API_HOST
+        ? {
+            status: 302,
+            headers: { location: `http://${METADATA_IP}/latest/meta-data/iam/` },
+          }
+        : { status: 200, body: Buffer.from("unexpected") },
+    );
+    restoreRequests = stub.restore;
+
+    const err = await syncFromGitHub().catch((error) => error);
+    expect(err).toBeInstanceOf(SsrfBlockedError);
+    expect(stub.requests.map((req) => req.host)).not.toContain(METADATA_IP);
+    expect(stub.requests).toHaveLength(1);
+  });
+
+  it("REFUSES a manifest-asset redirect into cloud metadata without dialing it", async () => {
+    // Site :159 — `fetchReleaseAssetBuffer`, which pulls
+    // release-artifact-manifest.json and its .ed25519 signature. This is the
+    // exact artifact pair #3649 was filed about and the reason this issue
+    // exists: closing releaseArtifactManifest.ts did not close this path.
+    const signed = makeSignedManifest();
+    process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+
+    const stub = installRequestStub((req) => {
+      if (req.host === API_HOST) {
+        return { status: 200, body: releaseJson({ withManifest: true }) };
+      }
+      if (req.host === "github.com") {
+        return {
+          status: 302,
+          headers: { location: `http://${METADATA_IP}/latest/meta-data/iam/` },
+        };
+      }
+      return { status: 200, body: Buffer.from("unexpected") };
+    });
+    restoreRequests = stub.restore;
+
+    const err = await syncFromGitHub().catch((error) => error);
+    expect(err).toBeInstanceOf(SsrfBlockedError);
+    expect(String(err)).toMatch(/169\.254\.169\.254/);
+    expect(stub.requests.map((req) => req.host)).not.toContain(METADATA_IP);
+  });
+
+  it("REFUSES a checksums.txt redirect to a host that RESOLVES into RFC1918", async () => {
+    // Site :224 — the integrity FALLBACK used when no signed manifest is
+    // published, so it is the last thing that should be reachable by an
+    // unvalidated redirect. This is also the deeper bypass shape: the Location
+    // looks public and only DNS resolution reveals 192.168.1.10.
+    delete process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS;
+    __setLookupForTests(async (hostname: string) =>
+      hostname === "internal.example"
+        ? [{ address: "192.168.1.10", family: 4 }]
+        : [{ address: "93.184.216.34", family: 4 }],
+    );
+
+    const stub = installRequestStub((req) => {
+      if (req.host === API_HOST) {
+        return { status: 200, body: releaseJson({ withManifest: false }) };
+      }
+      if (req.host === "github.com") {
+        return {
+          status: 302,
+          headers: { location: "https://internal.example/checksums.txt" },
+        };
+      }
+      return { status: 200, body: Buffer.from("unexpected") };
+    });
+    restoreRequests = stub.restore;
+
+    const err = await syncFromGitHub().catch((error) => error);
+    expect(err).toBeInstanceOf(SsrfBlockedError);
+    expect(String(err)).toMatch(/internal\.example|192\.168\.1\.10/);
+    expect(stub.requests.map((req) => req.host)).not.toContain("internal.example");
+  });
+
+  it("aborts an oversized manifest at the streaming ceiling", async () => {
+    // `maxBytes` fires DURING the response stream: the socket is destroyed and
+    // ResponseTooLargeError thrown, so a TRUNCATED manifest is never handed on
+    // to signature verification — which is the dangerous way to fail here. The
+    // bare `fetch` this replaced had no ceiling at all.
+    const signed = makeSignedManifest();
+    process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+
+    const oversized = Buffer.alloc(1024 * 1024 + 1, 0x61);
+    const stub = installRequestStub((req) => {
+      if (req.host === API_HOST) {
+        return { status: 200, body: releaseJson({ withManifest: true }) };
+      }
+      return pathWithoutQuery(req.path).endsWith(".ed25519")
+        ? { status: 200, body: signed.signature }
+        : { status: 200, body: oversized };
+    });
+    restoreRequests = stub.restore;
+
+    const err = await syncFromGitHub().catch((error) => error);
+    expect(err).toBeInstanceOf(ResponseTooLargeError);
+  });
+
+  it("contains no raw fetch call, and every outbound call is guarded and capped", () => {
+    // The perishable half of this fix is the four call sites; this is the
+    // durable half. A future bare `fetch` in this module fails CI rather than
+    // quietly reopening the hole — the same anti-regrowth contract
+    // `releaseArtifactManifest.redirect.test.ts` and
+    // `backupSsrfAdoption.test.ts` apply to their surfaces.
+    const source = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), "binarySync.ts"),
+      "utf8",
+    );
+
+    // Bare `fetch(` — exactly what a revert would look like.
+    expect(source).not.toMatch(/(?<![.\w])fetch\s*\(/);
+    // …and the qualified spellings the lookbehind above deliberately exempts,
+    // so `globalThis.fetch(url)` cannot slip past this guard.
+    expect(source).not.toMatch(/\b(?:globalThis|window|global)\s*\.\s*fetch\s*\(/);
+
+    // Positive half: the helper must actually be CALLED, not merely imported —
+    // an orphaned import would satisfy a bare identifier match. Pin the count
+    // too, so deleting a call site cannot pass this test the way an empty file
+    // would.
+    const callSites = source.match(/safeFetchFollowingRedirects\s*\(/g) ?? [];
+    expect(callSites).toHaveLength(4);
+
+    // Every one of them carries a byte ceiling. Without this a new call site
+    // could adopt the SSRF guard and still buffer an unbounded body.
+    for (const match of source.matchAll(/safeFetchFollowingRedirects\s*\(/g)) {
+      const window = source.slice(match.index, match.index + 400);
+      expect(window, `call site at offset ${match.index} must pass maxBytes`).toMatch(
+        /maxBytes:/,
+      );
+    }
+  });
+});

--- a/apps/api/src/services/binarySync.test.ts
+++ b/apps/api/src/services/binarySync.test.ts
@@ -48,8 +48,13 @@ vi.mock("../db", () => ({
 // actually adopts it by the source scan in `binarySync.redirect.test.ts`.
 vi.mock("./urlSafety", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./urlSafety")>()),
-  safeFetchFollowingRedirects: (url: string, init?: RequestInit) =>
-    globalThis.fetch(url, init),
+  // Typed against SafeFetchInit (not RequestInit) so a call site's `maxBytes` /
+  // `timeoutMs` survive the bridge instead of being silently dropped, and a
+  // vi.fn() so a suite CAN assert on what binarySync passed the helper.
+  safeFetchFollowingRedirects: vi.fn(
+    (url: string, init?: import("./urlSafety").SafeFetchInit) =>
+      globalThis.fetch(url, init as RequestInit),
+  ),
 }));
 
 // Capture eq/and so a test can inspect the WHERE built for the per-component

--- a/apps/api/src/services/binarySync.test.ts
+++ b/apps/api/src/services/binarySync.test.ts
@@ -32,6 +32,24 @@ vi.mock("../db", () => ({
     transaction: dbMocks.transaction,
     select: dbMocks.select,
   },
+  // urlSafety's safeFetch calls this (#1105 tripwire); the real `../db` is
+  // mocked away, so the named export has to exist or the import fails.
+  assertOutsideHeldDbContext: vi.fn(),
+}));
+
+// binarySync's outbound calls now go through the SSRF-guarded
+// `safeFetchFollowingRedirects` (#4262), which dials Node's http/https directly
+// so it can DNS-resolve and IP-pin each hop — it never touches global `fetch`.
+// Without this bridge every `vi.stubGlobal("fetch", …)` below would stop
+// intercepting and these cases would make REAL network calls (that is exactly
+// how PR #4255's installerBuilder cases went unhooked). Route the helper back
+// to the stubbed global; the guard's real redirect/SSRF semantics are covered
+// by `binarySync.redirect.test.ts` and `urlSafety.test.ts`, and that binarySync
+// actually adopts it by the source scan in `binarySync.redirect.test.ts`.
+vi.mock("./urlSafety", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./urlSafety")>()),
+  safeFetchFollowingRedirects: (url: string, init?: RequestInit) =>
+    globalThis.fetch(url, init),
 }));
 
 // Capture eq/and so a test can inspect the WHERE built for the per-component

--- a/apps/api/src/services/binarySync.ts
+++ b/apps/api/src/services/binarySync.ts
@@ -30,6 +30,25 @@ import {
   isOfficialReleaseSource,
 } from "./releaseSource";
 import { captureException } from "./sentry";
+import { safeFetchFollowingRedirects } from "./urlSafety";
+
+// Byte ceilings for every outbound response this module buffers (#4262).
+//
+// The bare `fetch` these replaced had NO ceiling at all: whatever the remote
+// sent was buffered whole. `safeFetch`'s `maxBytes` is a STREAMING ceiling —
+// the socket is destroyed on overrun and ResponseTooLargeError is thrown, so a
+// truncated body is never handed onward to signature verification.
+//
+// Sized to be unreachable by any legitimate response rather than tight: this
+// runs on the boot path, and a ceiling that a real release could trip would
+// turn a security control into an availability bug.
+
+/** Matches MAX_MANIFEST_BYTES in releaseArtifactManifest.ts — same two files. */
+const MAX_RELEASE_MANIFEST_BYTES = 1024 * 1024;
+/** checksums.txt is one ~100-byte line per asset. */
+const MAX_CHECKSUMS_BYTES = 1024 * 1024;
+/** A GitHub release JSON: asset list + release notes (GitHub caps body ~125KB). */
+const MAX_RELEASE_API_JSON_BYTES = 8 * 1024 * 1024;
 
 const GH_PLATFORM_MAP: Record<string, string> = {
   linux: "linux",
@@ -156,8 +175,19 @@ async function fetchReleaseAssetBuffer(
   asset: GitHubReleaseAsset,
   label: string,
 ): Promise<Buffer> {
-  const resp = await fetch(asset.browser_download_url, {
+  // `browser_download_url` comes from the GitHub API response, not from local
+  // config, and github.com 302s release assets to objects.githubusercontent.com
+  // — so following redirects is mandatory here, and following them NAIVELY is
+  // the SSRF bypass #3649 was filed about. The guarded helper re-resolves,
+  // filters and IP-pins every hop before it is dialed, so a redirect into
+  // loopback / 169.254.169.254 / RFC1918 is refused rather than followed.
+  //
+  // This function fetches only release-artifact-manifest.json and its .ed25519
+  // signature — the inputs to release artifact verification — so the ceiling is
+  // the manifest one.
+  const resp = await safeFetchFollowingRedirects(asset.browser_download_url, {
     headers: { "User-Agent": "breeze-api" },
+    maxBytes: MAX_RELEASE_MANIFEST_BYTES,
   });
   if (!resp.ok) {
     throw new Error(`Failed to download ${label}`);
@@ -221,9 +251,16 @@ async function parseChecksumsFallback(
     throw new Error("No checksums.txt found in release assets");
   }
 
-  const checksumResp = await fetch(checksumAsset.browser_download_url, {
-    headers: { "User-Agent": "breeze-api" },
-  });
+  // Same asset-URL redirect chain as fetchReleaseAssetBuffer, and this is the
+  // integrity fallback when no signed manifest is present — so it is the LAST
+  // thing that should be reachable by an unvalidated redirect.
+  const checksumResp = await safeFetchFollowingRedirects(
+    checksumAsset.browser_download_url,
+    {
+      headers: { "User-Agent": "breeze-api" },
+      maxBytes: MAX_CHECKSUMS_BYTES,
+    },
+  );
   if (!checksumResp.ok) {
     throw new Error("Failed to download checksums.txt");
   }
@@ -1087,7 +1124,14 @@ export async function syncFromGitHub(
     ghHeaders.Authorization = `Bearer ${ghToken}`;
   }
 
-  const ghResp = await fetch(ghUrl, { headers: ghHeaders });
+  // ghHeaders may carry `Authorization: Bearer <GITHUB_TOKEN>`. The guarded
+  // helper drops credential headers on a cross-origin hop, so a redirect can no
+  // longer walk the operator's token to another host — something bare
+  // `fetch` (which replays headers across redirects) would happily do.
+  const ghResp = await safeFetchFollowingRedirects(ghUrl, {
+    headers: ghHeaders,
+    maxBytes: MAX_RELEASE_API_JSON_BYTES,
+  });
   if (!ghResp.ok) {
     throw new Error(`GitHub API error: ${ghResp.status}`);
   }
@@ -1423,7 +1467,14 @@ async function backfillBackupRowsForVersion(
     ghHeaders.Authorization = `Bearer ${ghToken}`;
   }
 
-  const ghResp = await fetch(ghUrl, { headers: ghHeaders });
+  // ghHeaders may carry `Authorization: Bearer <GITHUB_TOKEN>`. The guarded
+  // helper drops credential headers on a cross-origin hop, so a redirect can no
+  // longer walk the operator's token to another host — something bare
+  // `fetch` (which replays headers across redirects) would happily do.
+  const ghResp = await safeFetchFollowingRedirects(ghUrl, {
+    headers: ghHeaders,
+    maxBytes: MAX_RELEASE_API_JSON_BYTES,
+  });
   if (!ghResp.ok) {
     throw new Error(`GitHub API error: ${ghResp.status}`);
   }

--- a/apps/api/src/services/binarySync.ts
+++ b/apps/api/src/services/binarySync.ts
@@ -14,6 +14,7 @@ import {
 } from "./binarySource";
 import { getBinaryEdition } from "./binaryEdition";
 import {
+  MAX_MANIFEST_BYTES,
   isReleaseArtifactManifestVerificationConfigured,
   ReleaseAssetNotDistributableError,
   ReleaseManifestAssetAbsentError,
@@ -30,7 +31,11 @@ import {
   isOfficialReleaseSource,
 } from "./releaseSource";
 import { captureException } from "./sentry";
-import { safeFetchFollowingRedirects } from "./urlSafety";
+import {
+  ResponseTooLargeError,
+  SsrfBlockedError,
+  safeFetchFollowingRedirects,
+} from "./urlSafety";
 
 // Byte ceilings for every outbound response this module buffers (#4262).
 //
@@ -43,12 +48,117 @@ import { safeFetchFollowingRedirects } from "./urlSafety";
 // runs on the boot path, and a ceiling that a real release could trip would
 // turn a security control into an availability bug.
 
-/** Matches MAX_MANIFEST_BYTES in releaseArtifactManifest.ts — same two files. */
-const MAX_RELEASE_MANIFEST_BYTES = 1024 * 1024;
+/**
+ * The manifest + signature ceiling. IMPORTED rather than redeclared: this module
+ * fetches the same two artifacts as releaseArtifactManifest.ts, and a local copy
+ * would let the two paths silently drift to different limits for one file.
+ */
+const MAX_RELEASE_MANIFEST_BYTES = MAX_MANIFEST_BYTES;
 /** checksums.txt is one ~100-byte line per asset. */
 const MAX_CHECKSUMS_BYTES = 1024 * 1024;
 /** A GitHub release JSON: asset list + release notes (GitHub caps body ~125KB). */
 const MAX_RELEASE_API_JSON_BYTES = 8 * 1024 * 1024;
+
+// `safeFetch` applies NO timeout unless asked (urlSafety.ts: `if (timeoutMs &&
+// timeoutMs > 0)`), and the bare `fetch` these replaced had none either. That
+// matters more here than at most call sites: every one of these runs inside a
+// held DB access context (see the note on assertOutsideHeldDbContext below), so
+// a hung socket to GitHub pins a pooled Postgres connection idle-in-transaction
+// for as long as it hangs. A ceiling on bytes without a ceiling on time only
+// closes half of that.
+const RELEASE_FETCH_TIMEOUT_MS = 30_000;
+
+// #1105 tripwire — READ BEFORE ENABLING DB_CONTEXT_TRIPWIRE_STRICT.
+//
+// `safeFetch` calls `assertOutsideHeldDbContext`. All four call sites in this
+// module run INSIDE a held DB access context:
+//   - boot: index.ts wraps syncBinaries() in runWithSystemDbAccess
+//     → withSystemDbAccessContext → withDbAccessContext (a real transaction);
+//   - route: POST /agent-versions/sync-github takes the withDbAccessContext
+//     branch in middleware/auth.ts and is NOT in SELF_MANAGED_DB_CONTEXT_ROUTES.
+//
+// This is PRE-EXISTING: the bare `fetch` these replaced did the identical
+// round-trip inside the identical transaction. The tripwire only ever
+// instrumented safeFetch, so adopting the guard made an existing problem
+// VISIBLE rather than creating one. Today that is a console.warn plus a deduped
+// Sentry event; DB_CONTEXT_TRIPWIRE_STRICT is set by no CI job.
+//
+// The latent hazard, stated so the next person is warned rather than surprised:
+// under that strict flag `assertOutsideHeldDbContext` THROWS, syncBinaries
+// throws, and index.ts treats that as fatal in BINARY_SOURCE=local mode — the
+// API refuses to boot. Before this module adopted safeFetch, flipping the flag
+// was safe here.
+//
+// Do NOT "fix" this by wrapping these fetches in runOutsideDbContext: that exits
+// the AsyncLocalStorage store without releasing the pooled connection, silencing
+// the alarm while leaving the connection pinned idle-in-transaction across the
+// network round-trip. The real fix is to run the network phase before the system
+// context opens and let this module open its own short contexts around only its
+// DB writes — a boot-critical restructure that belongs in its own PR (#4262).
+
+/**
+ * Render an outbound-fetch failure for an operator.
+ *
+ * `SsrfBlockedError.message` names the refused HOST but not what it resolved
+ * to: the DNS cases read `all resolved IPs for <host> are private/loopback/…`,
+ * and the address list itself lives only on `.resolvedIps`. So a plain
+ * `err.message` rendering tells an operator the guard fired while withholding
+ * the fact they need to act on it.
+ *
+ * Worth distinguishing from "GitHub returned 503" for a second reason: on this
+ * path a refusal means something resolved `api.github.com` or
+ * `objects.githubusercontent.com` to an internal address, which is a
+ * DNS-hijack/poisoned-resolver signal rather than a routine network fault.
+ */
+function describeFetchFailure(err: unknown): string {
+  if (err instanceof SsrfBlockedError) {
+    return (
+      `BLOCKED BY SSRF GUARD: ${err.message} ` +
+      `(host=${err.hostname ?? "?"}, resolved=${err.resolvedIps?.join(", ") ?? "n/a"}). ` +
+      `The release host resolved to a private, loopback or link-local address — check DNS and egress on this host.`
+    );
+  }
+  if (err instanceof ResponseTooLargeError) {
+    return `release host returned a body over the ${err.maxBytes}-byte ceiling`;
+  }
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** Call-site literals for the `release_sync_context` tag — closed set. */
+type ReleaseSyncContext =
+  | "stale-volume-fallback"
+  | "no-local-binaries-fallback"
+  | "ensure-current-version-registered";
+
+/**
+ * Report a guard refusal to Sentry.
+ *
+ * The three catch sites below deliberately DO NOT fail closed — a transient
+ * resolver blip must not take boot down — so without this a refusal would be a
+ * console line and nothing else. There is no console→Sentry integration in
+ * `services/sentry.ts`, so `console.error` alone does not reach alerting; the
+ * pre-existing comments claiming otherwise were wrong and are corrected below.
+ *
+ * The tags are the whole payload, not decoration: `scrubEvent` deletes
+ * `message` from every outbound event, so an event whose discriminator is not
+ * an ALLOWLISTED tag does not exist as far as triage is concerned. Both names
+ * here are registered in `ALLOWED_TAG_NAMES` (services/sentry.ts) and asserted
+ * end-to-end through both gates in `sentry.test.ts`. Values are derived from
+ * the error CLASS and a hardcoded literal — never from the message, which
+ * interpolates the refused hostname.
+ */
+function reportIfGuardRefusal(err: unknown, context: ReleaseSyncContext): void {
+  const reason = err instanceof SsrfBlockedError
+    ? "ssrf-blocked"
+    : err instanceof ResponseTooLargeError
+      ? "response-too-large"
+      : null;
+  if (!reason) return;
+  captureException(err, undefined, {
+    release_sync_failure_reason: reason,
+    release_sync_context: context,
+  });
+}
 
 const GH_PLATFORM_MAP: Record<string, string> = {
   linux: "linux",
@@ -188,6 +298,7 @@ async function fetchReleaseAssetBuffer(
   const resp = await safeFetchFollowingRedirects(asset.browser_download_url, {
     headers: { "User-Agent": "breeze-api" },
     maxBytes: MAX_RELEASE_MANIFEST_BYTES,
+    timeoutMs: RELEASE_FETCH_TIMEOUT_MS,
   });
   if (!resp.ok) {
     throw new Error(`Failed to download ${label}`);
@@ -259,6 +370,7 @@ async function parseChecksumsFallback(
     {
       headers: { "User-Agent": "breeze-api" },
       maxBytes: MAX_CHECKSUMS_BYTES,
+      timeoutMs: RELEASE_FETCH_TIMEOUT_MS,
     },
   );
   if (!checksumResp.ok) {
@@ -859,11 +971,16 @@ export async function syncBinaries(): Promise<void> {
       return;
     } catch (err) {
       // Compound failure — stale binaries volume AND GitHub fallback failed.
-      // Agents will be served the wrong binary; surface as error so Sentry
-      // and log alerting catch it (#644).
+      // Agents will be served the wrong binary, so this must be loud. Note the
+      // fall-through is deliberate and unchanged: execution continues to local
+      // registration and the stale volume is served. That is right for a
+      // transient GitHub outage, but an SSRF refusal is NOT transient, so
+      // describeFetchFailure names it and reportIfGuardRefusal escalates it
+      // rather than letting it read as "GitHub 503".
       console.error(
-        `[binarySync] Stale binaries volume + GitHub sync FAILED — agents will be served the wrong version: ${err instanceof Error ? err.message : err}`,
+        `[binarySync] Stale binaries volume + GitHub sync FAILED — agents will be served the wrong version: ${describeFetchFailure(err)}`,
       );
+      reportIfGuardRefusal(err, "stale-volume-fallback");
     }
   }
 
@@ -1063,8 +1180,9 @@ export async function syncBinaries(): Promise<void> {
       console.error(
         pinnedTag
           ? unpublishedPinnedReleaseHint(pinnedTag, err)
-          : `[binarySync] No local binaries + GitHub sync FAILED — no agent binaries are registered: ${err instanceof Error ? err.message : err}`,
+          : `[binarySync] No local binaries + GitHub sync FAILED — no agent binaries are registered: ${describeFetchFailure(err)}`,
       );
+      reportIfGuardRefusal(err, "no-local-binaries-fallback");
     }
   }
 
@@ -1124,13 +1242,17 @@ export async function syncFromGitHub(
     ghHeaders.Authorization = `Bearer ${ghToken}`;
   }
 
-  // ghHeaders may carry `Authorization: Bearer <GITHUB_TOKEN>`. The guarded
-  // helper drops credential headers on a cross-origin hop, so a redirect can no
-  // longer walk the operator's token to another host — something bare
-  // `fetch` (which replays headers across redirects) would happily do.
+  // ghHeaders may carry `Authorization: Bearer <GITHUB_TOKEN>`; the guarded
+  // helper drops credential headers on a cross-origin hop. To be precise about
+  // what that is and isn't worth: it is NOT a leak this fixes. undici already
+  // implements the fetch spec's step 13 and deletes authorization/cookie/host
+  // on a cross-origin redirect, so bare `fetch` did not walk the token either.
+  // The real win at this site is the per-hop DNS resolution and IP pinning
+  // below; the header handling merely keeps parity.
   const ghResp = await safeFetchFollowingRedirects(ghUrl, {
     headers: ghHeaders,
     maxBytes: MAX_RELEASE_API_JSON_BYTES,
+    timeoutMs: RELEASE_FETCH_TIMEOUT_MS,
   });
   if (!ghResp.ok) {
     throw new Error(`GitHub API error: ${ghResp.status}`);
@@ -1423,11 +1545,15 @@ async function ensureCurrentVersionRegistered(): Promise<void> {
   } catch (err) {
     // ensureCurrentVersionRegistered is the safety net for the agent_versions
     // table — if it fails, agents trying to download the currently-running
-    // version 404. Surface as error so Sentry and log alerting catch it (#644).
+    // version 404. This catch also swallows everything thrown by
+    // backfillBackupRowsForVersion, which is the ONLY caller path to that
+    // function's outbound fetch — so without reportIfGuardRefusal an SSRF
+    // refusal there would produce one boot-time log line and no alert at all.
     console.error(
       `[binarySync] Failed to auto-sync version ${currentVersion} from GitHub:`,
-      err instanceof Error ? err.message : err,
+      describeFetchFailure(err),
     );
+    reportIfGuardRefusal(err, "ensure-current-version-registered");
   }
 }
 
@@ -1467,13 +1593,17 @@ async function backfillBackupRowsForVersion(
     ghHeaders.Authorization = `Bearer ${ghToken}`;
   }
 
-  // ghHeaders may carry `Authorization: Bearer <GITHUB_TOKEN>`. The guarded
-  // helper drops credential headers on a cross-origin hop, so a redirect can no
-  // longer walk the operator's token to another host — something bare
-  // `fetch` (which replays headers across redirects) would happily do.
+  // ghHeaders may carry `Authorization: Bearer <GITHUB_TOKEN>`; the guarded
+  // helper drops credential headers on a cross-origin hop. To be precise about
+  // what that is and isn't worth: it is NOT a leak this fixes. undici already
+  // implements the fetch spec's step 13 and deletes authorization/cookie/host
+  // on a cross-origin redirect, so bare `fetch` did not walk the token either.
+  // The real win at this site is the per-hop DNS resolution and IP pinning
+  // below; the header handling merely keeps parity.
   const ghResp = await safeFetchFollowingRedirects(ghUrl, {
     headers: ghHeaders,
     maxBytes: MAX_RELEASE_API_JSON_BYTES,
+    timeoutMs: RELEASE_FETCH_TIMEOUT_MS,
   });
   if (!ghResp.ok) {
     throw new Error(`GitHub API error: ${ghResp.status}`);

--- a/apps/api/src/services/releaseArtifactManifest.ts
+++ b/apps/api/src/services/releaseArtifactManifest.ts
@@ -96,7 +96,12 @@ export class ReleaseAssetNotDistributableError extends Error {
 }
 
 const ED25519_SPKI_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
-const MAX_MANIFEST_BYTES = 1024 * 1024;
+/**
+ * Ceiling for the manifest and its signature. Exported because binarySync.ts
+ * fetches the SAME two artifacts by a second path (#4262) and must not drift
+ * from this value — an unexported copy there was a comment-enforced promise.
+ */
+export const MAX_MANIFEST_BYTES = 1024 * 1024;
 const PUBLIC_KEY_ENV_NAMES = [
   "RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS",
   "BREEZE_RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS",

--- a/apps/api/src/services/releaseTrustChain.e2e.test.ts
+++ b/apps/api/src/services/releaseTrustChain.e2e.test.ts
@@ -27,10 +27,23 @@ vi.mock('../db', () => ({
 // http/https directly and never touches global `fetch`. Bridge it back to the
 // stubbed global or the `vi.stubGlobal('fetch', …)` below stops intercepting
 // and this suite makes real network calls.
+//
+// SCOPE WARNING: this mock is module-wide, so it also un-guards
+// releaseArtifactManifest.ts's `fetchSmallBuffer`, which imports the same
+// helper. Inert today — this suite never reaches
+// `verifyGithubReleaseArtifactBuffer`'s URL-fetching path — but a future e2e
+// case added here would be silently unguarded. If you add one, assert its
+// guard semantics in `binarySync.redirect.test.ts` (which does NOT mock
+// urlSafety) rather than here.
 vi.mock('./urlSafety', async (importOriginal) => ({
   ...(await importOriginal<typeof import('./urlSafety')>()),
-  safeFetchFollowingRedirects: (url: string, init?: RequestInit) =>
-    globalThis.fetch(url, init),
+  // Typed against SafeFetchInit (not RequestInit) so a call site's `maxBytes` /
+  // `timeoutMs` survive the bridge instead of being silently dropped, and a
+  // vi.fn() so a suite CAN assert on what binarySync passed the helper.
+  safeFetchFollowingRedirects: vi.fn(
+    (url: string, init?: import('./urlSafety').SafeFetchInit) =>
+      globalThis.fetch(url, init as RequestInit),
+  ),
 }));
 vi.mock('./s3Storage', () => ({ isS3Configured: () => false, syncDirectory: vi.fn() }));
 

--- a/apps/api/src/services/releaseTrustChain.e2e.test.ts
+++ b/apps/api/src/services/releaseTrustChain.e2e.test.ts
@@ -17,7 +17,21 @@ const dbMocks = vi.hoisted(() => {
     transaction: vi.fn(async (fn: (tx: unknown) => Promise<void>) => fn(tx)),
   };
 });
-vi.mock('../db', () => ({ db: { transaction: dbMocks.transaction } }));
+vi.mock('../db', () => ({
+  db: { transaction: dbMocks.transaction },
+  // Required by urlSafety's safeFetch (#1105 tripwire) now that binarySync
+  // routes its downloads through it.
+  assertOutsideHeldDbContext: vi.fn(),
+}));
+// binarySync's fetches go through the SSRF-guarded helper (#4262), which dials
+// http/https directly and never touches global `fetch`. Bridge it back to the
+// stubbed global or the `vi.stubGlobal('fetch', …)` below stops intercepting
+// and this suite makes real network calls.
+vi.mock('./urlSafety', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./urlSafety')>()),
+  safeFetchFollowingRedirects: (url: string, init?: RequestInit) =>
+    globalThis.fetch(url, init),
+}));
 vi.mock('./s3Storage', () => ({ isS3Configured: () => false, syncDirectory: vi.fn() }));
 
 // Deployment key = the FIXTURE key: signManifest signs with the fixture seed so

--- a/apps/api/src/services/sentry.test.ts
+++ b/apps/api/src/services/sentry.test.ts
@@ -462,6 +462,8 @@ describe('scrubEvent', () => {
         binary_component: 'agent',
         release_asset_name: 'breeze-agent-darwin-arm64',
         manifest_refusal_reason: 'not-distributable',
+        release_sync_failure_reason: 'ssrf-blocked',
+        release_sync_context: 'stale-volume-fallback',
         worker: 'patchScheduler',
         worker_failure_reason: 'desktop_stop_pending',
         patch_reconcile_stage: 'enqueue_failed',
@@ -535,6 +537,12 @@ describe('scrubEvent', () => {
       binary_component: 'agent',
       release_asset_name: 'breeze-agent-darwin-arm64',
       manifest_refusal_reason: 'not-distributable',
+      // #4262: binarySync's SSRF-guard refusals fail OPEN by design, so the
+      // Sentry event is the only durable record that one happened. Dropped
+      // here, the capture arrives as a contentless blank and an operator
+      // cannot tell a guard refusal from an ordinary GitHub outage.
+      release_sync_failure_reason: 'ssrf-blocked',
+      release_sync_context: 'stale-volume-fallback',
       // #1379/BREEZE-9: attachWorkerObservability sets this on every worker,
       // and the allowlist introduced two days later (a50769487) has discarded
       // it ever since, which is why ~12k held-context events carry an empty

--- a/apps/api/src/services/sentry.ts
+++ b/apps/api/src/services/sentry.ts
@@ -133,6 +133,21 @@ const ALLOWED_TAG_NAMES = new Set([
   'binary_component',
   'release_asset_name',
   'manifest_refusal_reason',
+  // #4262: binarySync's release fetches now run through the SSRF-guarded
+  // helper, and all three of its catch sites deliberately FAIL OPEN — a
+  // transient resolver blip must not take boot down. That makes the Sentry
+  // event the only durable record that a refusal happened, and `scrubEvent`
+  // deletes `message`, so without these two tags it arrives as a contentless
+  // blank: the operator learns an exception occurred but not that the SSRF
+  // guard fired, which is the difference between "GitHub had a bad day" and
+  // "something is resolving api.github.com to an internal address".
+  // `release_sync_failure_reason` is a closed 2-value set derived from the
+  // error CLASS (never its message, which interpolates the offending host);
+  // `release_sync_context` is one of four hardcoded call-site literals.
+  // Neither carries a tenant, device, host or resolved IP — the addresses stay
+  // in the server-side log line only.
+  'release_sync_failure_reason',
+  'release_sync_context',
   // #1379/BREEZE-9: `attachWorkerObservability` sets this tag on every worker —
   // twice, in fact: on the per-job isolation scope (so anything captured DURING
   // a job inherits it) and again on the `failed` listener. It is a closed set of


### PR DESCRIPTION
Closes #4262

## The hole

PR #4255 routed `releaseArtifactManifest.ts` through the SSRF-guarded `safeFetchFollowingRedirects`, closing #3649. But it flagged in its own body that `binarySync.ts` is a **structurally parallel, independently unguarded implementation that fetches the very same two files** — `release-artifact-manifest.json` and its `.ed25519` signature. So #3649's *module* was closed and the *artifact* was not.

Four bare `fetch` sites, verified against `origin/main`:

| Site | Function | What it fetches |
|---|---|---|
| `:159` | `fetchReleaseAssetBuffer` | the manifest **and its signature** (via `fetchTrustedReleaseManifest`) |
| `:224` | `parseChecksumsFallback` | `checksums.txt` — the integrity fallback |
| `:1090` | `syncFromGitHub` | GitHub Releases API JSON |
| `:1426` | `backfillBackupRowsForVersion` | GitHub Releases API JSON |

`browser_download_url` comes from the GitHub API response, not from local config. A bare `fetch` follows redirects with no hop re-validation and no private-range check, so an attacker-influenced or compromised redirect could reach loopback, `169.254.169.254` or RFC1918 from inside the API container. This runs **at boot** under `BINARY_SOURCE=github`.

## The fix

All four sites go through the **existing** `safeFetchFollowingRedirects` in `services/urlSafety.ts`. **No new helper or module** — that helper exists precisely so this is not reimplemented per caller. Each hop is a fresh `safeFetch`: independently DNS-resolved, filtered and IP-pinned before the socket is dialed; hop budget 5; relative `Location` resolved; exhausting the budget throws rather than silently returning a 3xx.

Each site also gains a `maxBytes` streaming ceiling. The bare `fetch` had **no ceiling at all** — it buffered whatever the remote sent. Ceilings are sized to be unreachable by any legitimate response (1 MiB manifest, 1 MiB checksums, 8 MiB release JSON) rather than tight: this is the boot path, and a ceiling a real release could trip would turn a security control into an availability bug.

**A correction to an earlier version of this description.** It claimed the guard closed a `GITHUB_TOKEN` leak, because bare `fetch` "replays headers across redirects". That is false, and review caught it. undici implements the fetch spec's step 13 and deletes `authorization`/`proxy-authorization`/`cookie`/`host` on a cross-origin redirect — I verified it in this worktree's `undici@8.10.0`, `lib/web/fetch/index.js:1348-1358`. So no token leak existed and none is fixed. The real win at those two sites is the per-hop DNS resolution and IP pinning; the header handling merely keeps parity. The code comments have been corrected too.

Production diff is 4 call sites, 1 import, 3 constants.

## The interesting failure this surfaced

Three suites intercepted the network with `vi.stubGlobal('fetch', …)`, which worked **only because `binarySync` used the global fetch**. `safeFetchFollowingRedirects` deliberately does not — it dials Node's `http`/`https` directly so each hop can be pinned. So the stubs stopped intercepting.

Worth stating plainly: those tests were not merely red, they were **unhooked**. I measured it — removing the bridge and running `binarySync.test.ts` fails **33 cases** with `Error: GitHub API error: 404`, i.e. they were reaching the live internet. Fixed by routing the guarded helper back through the global stub, the idiom `recoveryMediaService.test.ts` already uses:

```ts
vi.mock("./urlSafety", async (importOriginal) => ({
  ...(await importOriginal<typeof import("./urlSafety")>()),
  safeFetchFollowingRedirects: (url: string, init?: RequestInit) =>
    globalThis.fetch(url, init),
}));
```

Three files needed it (`binarySync.test.ts`, `releaseTrustChain.e2e.test.ts`, `agentVersionsLocalModeRoundtrip.test.ts`), plus `assertOutsideHeldDbContext: vi.fn()` on their `../db` mocks, since `safeFetch` calls it.

## Tests

New `binarySync.redirect.test.ts`, modelled on `releaseArtifactManifest.redirect.test.ts`. It deliberately does **not** mock `./urlSafety` — the guard runs for real; only DNS (`__setLookupForTests`) and the socket layer are stubbed, so every host that would be dialed is recorded and assertable.

1. **The legitimate chain still works** — a normal 302 `github.com` → `objects.githubusercontent.com` is followed and both artifacts are retrieved. This case is the point: an over-tight guard here would break every `BINARY_SOURCE=github` boot rather than secure it.
2. **GitHub API redirect to cloud metadata refused** (site `:1090`) — `SsrfBlockedError`, and the recorded requests prove `169.254.169.254` was never dialed.
3. **Manifest-asset redirect to cloud metadata refused** (site `:159`) — the exact artifact pair this issue is about.
4. **checksums.txt redirect to a host that DNS-resolves into RFC1918 refused** (site `:224`) — the deeper bypass, where the `Location` looks public and only resolution reveals `192.168.1.10`.
5. **Oversized manifest aborts at the streaming ceiling** — `ResponseTooLargeError` rather than a truncated buffer handed onward to signature verification.
6. **Anti-regrowth source scan** — no raw `fetch(`, no `globalThis/window/global.fetch(`, `safeFetchFollowingRedirects` must actually be *called* (exactly 4 sites), and **every** call site must pass `maxBytes`.

### Red-first controls (all mutations verified, not assumed)

- **Whole fix reverted, tests kept:** 6/6 failed, the security cases specifically on `expected Error: … to be an instance of SsrfBlockedError`, and the source scan on `expected '…' not to match /(?<![.\w])fetch\s*\(/`. Restored → green.
- **Only the `maxBytes` argument removed from the manifest site:** exactly 2 failed, 4 stayed green. The ceiling case failed with `expected ReleaseManifestSignatureError to be an instance of ResponseTooLargeError` — which is doubly useful, because it shows the *unbounded* failure mode concretely: without the ceiling the oversized body is buffered whole and fed to signature verification. The structural scan failed independently with `call site at offset 7422 must pass maxBytes`.
- **Test bridge removed from `binarySync.test.ts`:** 33 cases failed on live-network 404s, proving the bridge is load-bearing rather than decorative.

Honest caveat, same as #4255's: under the first control the reverted bare `fetch` uses undici and so escapes the `http/https.request` stub entirely, meaning it errors out rather than demonstrating a *completed* fetch of metadata. The control is a genuine discriminator; it is not a live exploit reproduction.

## Verification

- **21 affected suites, 418 tests green** (binarySync ×4, releaseTrustChain.e2e, releaseArtifactManifest ×2, releaseAssetTrust, urlSafety ×2, backupSsrfAdoption, recoveryMediaService ×2, installerBuilder, fleetFindings/reconcile, agentVersions, agentVersionsLocalModeRoundtrip).
- `tsc --noEmit` on `@breeze/api` — clean (needs `--max-old-space-size=12288` on a loaded host; known repo condition).
- `eslint` on all five changed files — clean.

## One thing a reviewer should weigh: the #1105 tripwire

`safeFetch` calls `assertOutsideHeldDbContext`. I traced all four sites before converting rather than after, and **all four run inside a held DB access context**:

- **Boot:** `index.ts:1669-1671` wraps `syncBinaries()` in `runWithSystemDbAccess` → `withSystemDbAccessContext` → `withDbAccessContext`, which opens a real `baseDb.transaction`. Every site inherits it.
- **Route:** `POST /api/v1/agent-versions/sync-github` takes the `withDbAccessContext(...)` branch in `middleware/auth.ts:746`; it is **not** in `SELF_MANAGED_DB_CONTEXT_ROUTES`.

**This PR surfaces an existing problem rather than creating one.** The bare `fetch` did the identical network round-trip inside the identical held transaction — the tripwire simply could not see it, because it only instruments `safeFetch`. The consequence of making it visible is a `console.warn` on every boot and every `/sync-github`, plus a handful of deduped Sentry `db_operation_inside_held_context` events per process.

It is **warn-only**: `assertOutsideHeldDbContext` throws only under `DB_CONTEXT_TRIPWIRE_STRICT`, which no CI job sets (verified — it appears only in `dbContextTripwire.integration.test.ts`, set inline for its own cases, and that suite does not touch binarySync).

**I deliberately did not suppress it**, per the issue's instruction to decide rather than silence. Two things I explicitly rejected:

- Wrapping the fetches in `runOutsideDbContext` — that clears the AsyncLocalStorage store but does **not** release the held transaction. It would silence the warning while leaving the connection pinned, which is worse than the warning.
- Restructuring the boot path — the correct fix is to drop the outer `runWithSystemDbAccess` and let `binarySync` open its own short contexts around its four `db.transaction` blocks (`:365`, `:624`, `:1584`, `:1662`), plus register the route in `SELF_MANAGED_DB_CONTEXT_ROUTES`. Both halves must land together. That is a boot-critical, high-blast-radius change — a contextless `db` write is a DENY, not a bypass, so getting it wrong means agent binaries silently fail to register at boot. It deserves its own PR and its own review, not a bolt-on to a security fix.

Happy to do that as a follow-up; flagging it so the call is conscious rather than implicit. This mirrors how #4255 handled the same tripwire interaction on the installer routes.

## Review round (three reviewers, all findings addressed)

`code-reviewer`, `silent-failure-hunter` and `pr-test-analyzer`. **1 blocking, 6 should-fix, 11 nits.** The two failure modes I most wanted checked came back clean and verified: no fail-open downgrade (a *blocked* manifest fetch can never be mistaken for an *absent* one — the `Promise.all` has no try/catch, so the refusal propagates and aborts the sync), and no vacuous assertions.

**BLOCKING — my own Sentry escalation was a no-op.** `captureException`'s tags pass through `ALLOWED_TAG_NAMES`, and neither `eventCode` nor `releaseSyncContext` was in it. `eventCode` is a `captureMessage` option besides, validated against a registry my codes were not in — and `scrubEvent` deletes `message` from every event. So the escalation I added to make fail-open refusals visible would have arrived **contentless and untriageable**: precisely the BREEZE-18 failure the allowlist's own doc comment warns about. Fixed by registering `release_sync_failure_reason` (closed 2-value set derived from the error *class*, never its message) and `release_sync_context` (hardcoded call-site literal), and asserting both through *both* gates in `sentry.test.ts`. Verified by mutation: removing them from the allowlist turns that test red, naming the two dropped tags.

**Two false claims in my comments**, both corrected against source rather than swapped for another guess — the credential-replay claim above, and a claim that `SsrfBlockedError` keeps the refused host out of `.message` (it doesn't; what it withholds is the resolved-IP *list*, which is the fact an operator actually needs).

**Other fixes:**
- **`timeoutMs` on all four sites.** `safeFetch` applies no timeout unless asked. Bytes without time still lets a hung socket pin a pooled Postgres connection idle-in-transaction — and per the tripwire note below, all four of these run inside a held context. The source scan now requires both ceilings at every call site.
- **`describeFetchFailure`** at the three fail-open catch sites, so a refusal is diagnosable rather than rendered as an indistinguishable `${err.message}`.
- **Route-level classification** of both new error types: 502 with a fixed operator-facing message, `resolvedIps` deliberately kept server-side. Three tests, including one pinning that the generic 422 path is unchanged.
- **`MAX_MANIFEST_BYTES` exported and imported** rather than copied — the "matches releaseArtifactManifest.ts" comment was a promise nothing enforced.
- **Test coverage for call site 4** (`backfillBackupRowsForVersion`), which was scan-only. It is also the site whose failure is *swallowed* by its caller, so a regression there is silent by construction — which inverts the usual priority.
- **The ceiling proven across a redirect hop.** It previously fired on hop 1; in production every asset fetch redirects, and *no test in this repo* pinned that `maxBytes` survives a hop.
- **Source scan broadened** to the `backupSsrfAdoption.test.ts` `FORBIDDEN` list plus uncapped bare `safeFetch(`, and the `maxBytes` check tightened — `maxBytes: undefined` used to satisfy it while disabling the ceiling. It now scans code with comments stripped, since it bans bare words (`undici`, `axios`) the comments legitimately discuss; the strip is deliberately conservative (block + whole-line comments only) so it can never delete real code from the scan.

Every fix above was mutation-verified, not assumed.

## Remaining sibling hole

`installerBuilder.ts` still has 4 raw fetches — all four with `redirect: 'follow'` (`:279`, `:317`, `:344`, `:383`), and it imports no guard at all — fetching the actual MSI/pkg bytes. (#4255's body said 3 of 4; I re-counted against `origin/main`, it is 4.) Out of scope here — #4262 scoped itself to `binarySync.ts` — but a reviewer should not read this PR as "release artifacts can no longer be fetched unguarded anywhere."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JCiqAhFVwT5hWi9kWz4vED
