### PR TITLE
fix(api): stop System Tools routes reporting an agent timeout as success (#4025)

### DIFF
--- a/apps/api/src/routes/systemTools.test.ts
+++ b/apps/api/src/routes/systemTools.test.ts
@@ -1137,4 +1137,203 @@ describe('system tools routes', () => {
       expect(body.purged).toBe(3);
     });
   });
+
+  // Issue #4025. Every systemTools route outside the File Browser tested
+  // `result.status === 'failed'` and nothing else, so a `status: 'timeout'`
+  // result fell straight through into the success path:
+  //
+  //   - `kill_process` answered `{ success: true, "Process N terminated
+  //     successfully" }` when the agent never replied — while the audit row it
+  //     had just written said `result: 'failure'`. The trail and the response
+  //     actively contradicted each other about whether a device was mutated.
+  //   - Every listing parsed `undefined` stdout as `{}` and returned HTTP 200
+  //     with an empty array, so a technician read "no processes running" off a
+  //     device that simply did not answer in time.
+  //
+  // These routes now share the File Browser's classifier. The table below
+  // covers every one of the 25 sites so a new route cannot regress silently.
+  describe('agent timeout is never reported as success (#4025)', () => {
+    const taskPath = encodeURIComponent('\\Backup\\Daily Backup');
+    const registryQs = 'hive=HKEY_LOCAL_MACHINE&path=SOFTWARE';
+    const jsonPost = (body: unknown) => ({
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+    type RouteCase = {
+      label: string;
+      path: string;
+      init?: RequestInit;
+      /** Route changes device state → response must warn the result is unverified. */
+      mutating: boolean;
+    };
+
+    const routes: RouteCase[] = [
+      // processes.ts
+      { label: 'processes:list', path: '/processes', mutating: false },
+      { label: 'processes:get', path: '/processes/2048', mutating: false },
+      { label: 'processes:kill', path: '/processes/3456/kill?force=true', init: { method: 'POST' }, mutating: true },
+      // services.ts
+      { label: 'services:list', path: '/services', mutating: false },
+      { label: 'services:get', path: '/services/WinRM', mutating: false },
+      { label: 'services:start', path: '/services/WinRM/start', init: { method: 'POST' }, mutating: true },
+      { label: 'services:stop', path: '/services/WinRM/stop', init: { method: 'POST' }, mutating: true },
+      { label: 'services:restart', path: '/services/WinRM/restart', init: { method: 'POST' }, mutating: true },
+      // registry.ts
+      { label: 'registry:keys', path: `/registry/keys?${registryQs}`, mutating: false },
+      { label: 'registry:values', path: `/registry/values?${registryQs}`, mutating: false },
+      { label: 'registry:value:get', path: `/registry/value?${registryQs}&name=ProductName`, mutating: false },
+      {
+        label: 'registry:value:set',
+        path: '/registry/value',
+        init: {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ hive: 'HKEY_LOCAL_MACHINE', path: 'SOFTWARE', name: 'TestValue', type: 'REG_SZ', data: 'Hello' }),
+        },
+        mutating: true,
+      },
+      { label: 'registry:value:delete', path: `/registry/value?${registryQs}&name=TestValue`, init: { method: 'DELETE' }, mutating: true },
+      { label: 'registry:key:create', path: '/registry/key', init: jsonPost({ hive: 'HKEY_LOCAL_MACHINE', path: 'SOFTWARE\\Breeze' }), mutating: true },
+      { label: 'registry:key:delete', path: `/registry/key?${registryQs}\\Breeze`, init: { method: 'DELETE' }, mutating: true },
+      // eventLogs.ts
+      { label: 'eventLogs:list', path: '/eventlogs', mutating: false },
+      { label: 'eventLogs:info', path: '/eventlogs/System', mutating: false },
+      { label: 'eventLogs:query', path: '/eventlogs/System/events', mutating: false },
+      { label: 'eventLogs:get', path: '/eventlogs/System/events/15234', mutating: false },
+      // scheduledTasks.ts
+      { label: 'tasks:list', path: '/tasks', mutating: false },
+      { label: 'tasks:get', path: `/tasks/${taskPath}`, mutating: false },
+      { label: 'tasks:history', path: `/tasks/${taskPath}/history?limit=10`, mutating: false },
+      { label: 'tasks:run', path: `/tasks/${taskPath}/run`, init: { method: 'POST' }, mutating: true },
+      { label: 'tasks:enable', path: `/tasks/${taskPath}/enable`, init: { method: 'POST' }, mutating: true },
+      { label: 'tasks:disable', path: `/tasks/${taskPath}/disable`, init: { method: 'POST' }, mutating: true },
+    ];
+
+    // The table must stay exhaustive: 25 call sites were converted, and a new
+    // route added without a row here would be untested.
+    it('covers every converted call site', () => {
+      expect(routes).toHaveLength(25);
+    });
+
+    it.each(routes)('$label answers 503 agent_timeout, never a success', async ({ path, init, mutating }) => {
+      mockDeviceSelect();
+      // `stdout` is absent on a timeout — exactly what used to parse to `{}`
+      // and become an empty listing or a "terminated successfully" message.
+      mockExecuteCommand.mockResolvedValue({ status: 'timeout', error: 'Command timed out' });
+
+      const res = await app.request(`/system-tools/devices/${deviceId}${path}`, init);
+
+      // 503, not 502/504: Cloudflare replaces an origin 502/504 body with its
+      // own branded page, which would blank this message on hosted.
+      expect(res.status).toBe(503);
+      const body = await res.json();
+      expect(body.code).toBe('agent_timeout');
+      expect(body.error).toContain("didn't respond in time");
+      // The regression being pinned: no success shape, and no empty listing.
+      expect(body.success).toBeUndefined();
+      expect(body.data).toBeUndefined();
+      expect(body.message).toBeUndefined();
+      // Only a state-changing route can leave the device in an unknown state.
+      expect(body.unverified).toBe(mutating ? true : undefined);
+    });
+
+    it.each(routes.filter((route) => route.mutating))(
+      '$label warns the operation may have completed before a retry',
+      async ({ path, init }) => {
+        mockDeviceSelect();
+        mockExecuteCommand.mockResolvedValue({ status: 'timeout', error: 'Command timed out' });
+
+        const res = await app.request(`/system-tools/devices/${deviceId}${path}`, init);
+        const body = await res.json();
+
+        // Re-running a kill/registry-delete/service-stop against a
+        // half-completed state can compound the damage, so the copy must tell
+        // the user to verify rather than "please try again".
+        expect(body.error).toContain('may have completed');
+        expect(body.error).not.toContain('Please try again');
+      },
+    );
+
+    it('kill_process no longer contradicts its own audit row', async () => {
+      mockDeviceSelect();
+      mockExecuteCommand.mockResolvedValue({ status: 'timeout', error: 'Command timed out' });
+
+      const res = await app.request(
+        `/system-tools/devices/${deviceId}/processes/3456/kill?force=true`,
+        { method: 'POST' },
+      );
+
+      const body = await res.json();
+      expect(res.status).toBe(503);
+      expect(body.success).toBeUndefined();
+      expect(body.message).toBeUndefined();
+
+      // The audit row already said 'failure' before this fix; the response now
+      // agrees, and the trail is tagged so an admin reviewing it can see the
+      // device's final state was never confirmed.
+      expect(createAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'kill_process',
+          result: 'failure',
+          errorMessage: expect.stringContaining('[unverified]'),
+        }),
+      );
+    });
+
+    // The queue can report a timeout as a plain `failed` with timeout-shaped
+    // prose. Testing `status === 'timeout'` literally in the routes would miss
+    // it and present an unverifiable mutation as a verified failure that is
+    // safe to retry — the same trap fixed in `buildBulkItemFailure`.
+    it('treats a prose-only timeout on a mutating route as unverified', async () => {
+      mockDeviceSelect();
+      mockExecuteCommand.mockResolvedValue({ status: 'failed', error: 'command timed out after 30s' });
+
+      const res = await app.request(`/system-tools/devices/${deviceId}/services/WinRM/stop`, {
+        method: 'POST',
+      });
+
+      expect(res.status).toBe(503);
+      const body = await res.json();
+      expect(body.code).toBe('agent_timeout');
+      expect(body.unverified).toBe(true);
+    });
+
+    it('still surfaces a real agent failure as a 500 with the agent message', async () => {
+      mockDeviceSelect();
+      mockExecuteCommand.mockResolvedValue({ status: 'failed', error: 'access is denied' });
+
+      const res = await app.request(`/system-tools/devices/${deviceId}/registry/keys?${registryQs}`);
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('access is denied');
+      expect(body.code).toBe('agent_execution_failed');
+      expect(body.unverified).toBeUndefined();
+    });
+
+    it('keeps the 404 the routes used to derive from a "not found" substring', async () => {
+      mockDeviceSelect();
+      mockExecuteCommand.mockResolvedValue({ status: 'failed', error: 'service not found: WinRM' });
+
+      const res = await app.request(`/system-tools/devices/${deviceId}/services/WinRM`);
+
+      expect(res.status).toBe(404);
+      const body = await res.json();
+      expect(body.code).toBe('path_not_found');
+    });
+
+    it('reports an offline device as 503 device_offline, not a timeout', async () => {
+      mockDeviceSelect();
+      mockExecuteCommand.mockResolvedValue({ status: 'failed', error: 'Device is offline' });
+
+      const res = await app.request(`/system-tools/devices/${deviceId}/tasks`);
+
+      expect(res.status).toBe(503);
+      const body = await res.json();
+      expect(body.code).toBe('device_offline');
+      expect(body.unverified).toBeUndefined();
+    });
+  });
 });

--- a/apps/api/src/routes/systemTools.test.ts
+++ b/apps/api/src/routes/systemTools.test.ts
@@ -1230,24 +1230,36 @@ describe('system tools routes', () => {
     // the table must have one row per gate.
     it('has one row per agent command in the five converted route files', () => {
       const files = ['processes', 'services', 'registry', 'eventLogs', 'scheduledTasks'];
-      const counts = files.map((name) => {
-        const src = readFileSync(join(__dirname, 'systemTools', `${name}.ts`), 'utf8');
-        return {
-          name,
-          dispatches: (src.match(/await executeCommand\(/g) ?? []).length,
-          gates: (src.match(/if \(isCommandFailure\(result\)\) \{/g) ?? []).length,
-        };
-      });
+      const ungated: string[] = [];
+      let dispatchTotal = 0;
 
-      // Any dispatch without a gate is a route that can still report an agent
-      // timeout as success — the #4025 bug, reintroduced.
-      for (const { name, dispatches, gates } of counts) {
-        expect(gates, `${name}.ts has ${dispatches} agent command(s) but ${gates} failure gate(s)`).toBe(dispatches);
+      for (const name of files) {
+        const src = readFileSync(join(__dirname, 'systemTools', `${name}.ts`), 'utf8');
+
+        // Pair each dispatch with the text that FOLLOWS it, up to the next
+        // dispatch. Counting `executeCommand`s and `isCommandFailure`s
+        // separately and comparing the totals would let one route grow a
+        // second gate while another loses its only one — the totals still
+        // balance and #4025 walks back in. Matching on a bare
+        // `isCommandFailure(` reference rather than a full `if (…) {` also
+        // keeps this from red-flagging the `!isCommandFailure(result)` idiom
+        // fileBrowser.ts uses, which is equally correct.
+        const segments = src.split(/await executeCommand\(/).slice(1);
+        dispatchTotal += segments.length;
+
+        segments.forEach((segment, index) => {
+          if (!/isCommandFailure\(/.test(segment)) {
+            ungated.push(`${name}.ts dispatch #${index + 1}`);
+          }
+        });
       }
 
-      const totalGates = counts.reduce((sum, file) => sum + file.gates, 0);
-      expect(routes, `source has ${totalGates} gated call sites; the table has ${routes.length} rows`)
-        .toHaveLength(totalGates);
+      // A dispatch with no failure gate before the next one is a route that
+      // can still report an agent timeout as success.
+      expect(ungated, `agent commands with no isCommandFailure gate: ${ungated.join(', ')}`).toEqual([]);
+
+      expect(routes, `source has ${dispatchTotal} agent commands; the table has ${routes.length} rows`)
+        .toHaveLength(dispatchTotal);
     });
 
     it.each(routes)('$label answers 503 agent_timeout, never a success', async ({ path, init, mutating }) => {

--- a/apps/api/src/routes/systemTools.test.ts
+++ b/apps/api/src/routes/systemTools.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { Hono } from 'hono';
 import { systemToolsRoutes } from './systemTools';
 
@@ -1167,19 +1169,21 @@ describe('system tools routes', () => {
       init?: RequestInit;
       /** Route changes device state → response must warn the result is unverified. */
       mutating: boolean;
+      /** `action` on the audit row a mutating route writes. */
+      audit?: string;
     };
 
     const routes: RouteCase[] = [
       // processes.ts
       { label: 'processes:list', path: '/processes', mutating: false },
       { label: 'processes:get', path: '/processes/2048', mutating: false },
-      { label: 'processes:kill', path: '/processes/3456/kill?force=true', init: { method: 'POST' }, mutating: true },
+      { label: 'processes:kill', path: '/processes/3456/kill?force=true', init: { method: 'POST' }, mutating: true, audit: 'kill_process' },
       // services.ts
       { label: 'services:list', path: '/services', mutating: false },
       { label: 'services:get', path: '/services/WinRM', mutating: false },
-      { label: 'services:start', path: '/services/WinRM/start', init: { method: 'POST' }, mutating: true },
-      { label: 'services:stop', path: '/services/WinRM/stop', init: { method: 'POST' }, mutating: true },
-      { label: 'services:restart', path: '/services/WinRM/restart', init: { method: 'POST' }, mutating: true },
+      { label: 'services:start', path: '/services/WinRM/start', init: { method: 'POST' }, mutating: true, audit: 'start_service' },
+      { label: 'services:stop', path: '/services/WinRM/stop', init: { method: 'POST' }, mutating: true, audit: 'stop_service' },
+      { label: 'services:restart', path: '/services/WinRM/restart', init: { method: 'POST' }, mutating: true, audit: 'restart_service' },
       // registry.ts
       { label: 'registry:keys', path: `/registry/keys?${registryQs}`, mutating: false },
       { label: 'registry:values', path: `/registry/values?${registryQs}`, mutating: false },
@@ -1193,10 +1197,11 @@ describe('system tools routes', () => {
           body: JSON.stringify({ hive: 'HKEY_LOCAL_MACHINE', path: 'SOFTWARE', name: 'TestValue', type: 'REG_SZ', data: 'Hello' }),
         },
         mutating: true,
+        audit: 'set_registry_value',
       },
-      { label: 'registry:value:delete', path: `/registry/value?${registryQs}&name=TestValue`, init: { method: 'DELETE' }, mutating: true },
-      { label: 'registry:key:create', path: '/registry/key', init: jsonPost({ hive: 'HKEY_LOCAL_MACHINE', path: 'SOFTWARE\\Breeze' }), mutating: true },
-      { label: 'registry:key:delete', path: `/registry/key?${registryQs}\\Breeze`, init: { method: 'DELETE' }, mutating: true },
+      { label: 'registry:value:delete', path: `/registry/value?${registryQs}&name=TestValue`, init: { method: 'DELETE' }, mutating: true, audit: 'delete_registry_value' },
+      { label: 'registry:key:create', path: '/registry/key', init: jsonPost({ hive: 'HKEY_LOCAL_MACHINE', path: 'SOFTWARE\\Breeze' }), mutating: true, audit: 'create_registry_key' },
+      { label: 'registry:key:delete', path: `/registry/key?${registryQs}\\Breeze`, init: { method: 'DELETE' }, mutating: true, audit: 'delete_registry_key' },
       // eventLogs.ts
       { label: 'eventLogs:list', path: '/eventlogs', mutating: false },
       { label: 'eventLogs:info', path: '/eventlogs/System', mutating: false },
@@ -1206,15 +1211,43 @@ describe('system tools routes', () => {
       { label: 'tasks:list', path: '/tasks', mutating: false },
       { label: 'tasks:get', path: `/tasks/${taskPath}`, mutating: false },
       { label: 'tasks:history', path: `/tasks/${taskPath}/history?limit=10`, mutating: false },
-      { label: 'tasks:run', path: `/tasks/${taskPath}/run`, init: { method: 'POST' }, mutating: true },
-      { label: 'tasks:enable', path: `/tasks/${taskPath}/enable`, init: { method: 'POST' }, mutating: true },
-      { label: 'tasks:disable', path: `/tasks/${taskPath}/disable`, init: { method: 'POST' }, mutating: true },
+      { label: 'tasks:run', path: `/tasks/${taskPath}/run`, init: { method: 'POST' }, mutating: true, audit: 'run_scheduled_task' },
+      { label: 'tasks:enable', path: `/tasks/${taskPath}/enable`, init: { method: 'POST' }, mutating: true, audit: 'enable_scheduled_task' },
+      { label: 'tasks:disable', path: `/tasks/${taskPath}/disable`, init: { method: 'POST' }, mutating: true, audit: 'disable_scheduled_task' },
     ];
 
-    // The table must stay exhaustive: 25 call sites were converted, and a new
-    // route added without a row here would be untested.
-    it('covers every converted call site', () => {
-      expect(routes).toHaveLength(25);
+    // Cross-reference the table against the SOURCE, not against itself.
+    //
+    // `expect(routes).toHaveLength(25)` was the first version of this and it
+    // was a lie: the array literal is declared 40 lines up, so the assertion
+    // only fails if someone deletes a row — never if someone adds a route to
+    // one of the five files without a row here, which is the case the guard
+    // exists for. Proven by adding a 26th real call site and watching the
+    // suite stay green.
+    //
+    // Reading the files is what makes it a guard. Every `executeCommand` in
+    // these five modules must be followed by an `isCommandFailure` gate, and
+    // the table must have one row per gate.
+    it('has one row per agent command in the five converted route files', () => {
+      const files = ['processes', 'services', 'registry', 'eventLogs', 'scheduledTasks'];
+      const counts = files.map((name) => {
+        const src = readFileSync(join(__dirname, 'systemTools', `${name}.ts`), 'utf8');
+        return {
+          name,
+          dispatches: (src.match(/await executeCommand\(/g) ?? []).length,
+          gates: (src.match(/if \(isCommandFailure\(result\)\) \{/g) ?? []).length,
+        };
+      });
+
+      // Any dispatch without a gate is a route that can still report an agent
+      // timeout as success — the #4025 bug, reintroduced.
+      for (const { name, dispatches, gates } of counts) {
+        expect(gates, `${name}.ts has ${dispatches} agent command(s) but ${gates} failure gate(s)`).toBe(dispatches);
+      }
+
+      const totalGates = counts.reduce((sum, file) => sum + file.gates, 0);
+      expect(routes, `source has ${totalGates} gated call sites; the table has ${routes.length} rows`)
+        .toHaveLength(totalGates);
     });
 
     it.each(routes)('$label answers 503 agent_timeout, never a success', async ({ path, init, mutating }) => {
@@ -1227,11 +1260,15 @@ describe('system tools routes', () => {
 
       // 503, not 502/504: Cloudflare replaces an origin 502/504 body with its
       // own branded page, which would blank this message on hosted.
+      // These two lines are what actually pin #4025: pre-fix the route
+      // answered 200 with a success body, so `status` and `code` are the
+      // assertions that go red. The shape checks below them document the
+      // contract but can never be the ones that catch the bug — vitest stops
+      // at the first failure, so they are never reached in a red run.
       expect(res.status).toBe(503);
       const body = await res.json();
       expect(body.code).toBe('agent_timeout');
       expect(body.error).toContain("didn't respond in time");
-      // The regression being pinned: no success shape, and no empty listing.
       expect(body.success).toBeUndefined();
       expect(body.data).toBeUndefined();
       expect(body.message).toBeUndefined();
@@ -1240,8 +1277,8 @@ describe('system tools routes', () => {
     });
 
     it.each(routes.filter((route) => route.mutating))(
-      '$label warns the operation may have completed before a retry',
-      async ({ path, init }) => {
+      '$label warns the operation may have completed, and tags its audit row',
+      async ({ path, init, audit }) => {
         mockDeviceSelect();
         mockExecuteCommand.mockResolvedValue({ status: 'timeout', error: 'Command timed out' });
 
@@ -1253,6 +1290,20 @@ describe('system tools routes', () => {
         // the user to verify rather than "please try again".
         expect(body.error).toContain('may have completed');
         expect(body.error).not.toContain('Please try again');
+
+        // The audit trail must agree with the response that the device's final
+        // state was never confirmed. Asserted for all 11 mutating routes, not
+        // just kill_process: the `[unverified]` marker on a timed-out registry
+        // key delete or service stop is exactly the breadcrumb an admin needs
+        // to answer "did this actually happen on the device?", and it could
+        // previously be dropped from ten of them with a green suite.
+        expect(createAuditLog).toHaveBeenCalledWith(
+          expect.objectContaining({
+            action: audit,
+            result: 'failure',
+            errorMessage: expect.stringContaining('[unverified]'),
+          }),
+        );
       },
     );
 
@@ -1324,16 +1375,50 @@ describe('system tools routes', () => {
       expect(body.code).toBe('path_not_found');
     });
 
+    // Verbatim from commandQueue.ts:832,1013 — `Device is ${device.status},
+    // cannot execute command`. Using the real producer string rather than a
+    // paraphrase is the whole point: the paraphrase 'Device is offline' passed
+    // while the five OTHER non-online states were being mislabelled.
     it('reports an offline device as 503 device_offline, not a timeout', async () => {
       mockDeviceSelect();
-      mockExecuteCommand.mockResolvedValue({ status: 'failed', error: 'Device is offline' });
+      mockExecuteCommand.mockResolvedValue({
+        status: 'failed',
+        error: 'Device is offline, cannot execute command',
+      });
 
       const res = await app.request(`/system-tools/devices/${deviceId}/tasks`);
 
       expect(res.status).toBe(503);
       const body = await res.json();
       expect(body.code).toBe('device_offline');
+      expect(body.error).toBe('The device is offline.');
       expect(body.unverified).toBeUndefined();
     });
+
+    // `device_status` has seven values and the queue refuses all six non-online
+    // ones with the same sentence. Reporting every one of them as "offline"
+    // sends a technician to chase a network fault — `updating` is set on every
+    // agent self-update (agentWs.ts:2156), and `quarantined` is a security
+    // containment state that must not read as a connectivity problem.
+    it.each(['maintenance', 'decommissioned', 'quarantined', 'updating', 'pending'])(
+      'names the real device state for a %s device instead of calling it offline',
+      async (deviceState) => {
+        mockDeviceSelect();
+        mockExecuteCommand.mockResolvedValue({
+          status: 'failed',
+          error: `Device is ${deviceState}, cannot execute command`,
+        });
+
+        const res = await app.request(`/system-tools/devices/${deviceId}/services/WinRM/restart`, {
+          method: 'POST',
+        });
+
+        expect(res.status).toBe(503);
+        const body = await res.json();
+        expect(body.code).toBe('device_offline');
+        expect(body.error).toBe(`The device is ${deviceState} and cannot run commands.`);
+        expect(body.error).not.toContain('offline');
+      },
+    );
   });
 });

--- a/apps/api/src/routes/systemTools/eventLogs.ts
+++ b/apps/api/src/routes/systemTools/eventLogs.ts
@@ -9,6 +9,7 @@ import {
   eventLogQuerySchema,
   eventRecordParamSchema
 } from './schemas';
+import { isCommandFailure, buildCommandFailureResponse } from './fileBrowserHelpers';
 import type { EventLogInfo, EventLogEntry } from './types';
 
 function normalizeEventLevel(value?: string): EventLogEntry['level'] {
@@ -93,8 +94,9 @@ eventLogsRoutes.get(
       timeoutMs: 30000
     });
 
-    if (result.status === 'failed') {
-      return c.json({ error: result.error || 'Failed to list event logs' }, 500);
+    if (isCommandFailure(result)) {
+      const failure = buildCommandFailureResponse(result, 'Failed to list event logs');
+      return c.json(failure.body, failure.status);
     }
 
     try {
@@ -135,8 +137,9 @@ eventLogsRoutes.get(
       timeoutMs: 30000
     });
 
-    if (result.status === 'failed') {
-      return c.json({ error: result.error || 'Failed to get event log info' }, 500);
+    if (isCommandFailure(result)) {
+      const failure = buildCommandFailureResponse(result, 'Failed to get event log info');
+      return c.json(failure.body, failure.status);
     }
 
     try {
@@ -191,8 +194,9 @@ eventLogsRoutes.get(
       limit
     }, { userId: auth.user?.id, timeoutMs: 30000 });
 
-    if (result.status === 'failed') {
-      return c.json({ error: result.error || 'Failed to query event logs' }, 500);
+    if (isCommandFailure(result)) {
+      const failure = buildCommandFailureResponse(result, 'Failed to query event logs');
+      return c.json(failure.body, failure.status);
     }
 
     try {
@@ -242,9 +246,9 @@ eventLogsRoutes.get(
       recordId
     }, { userId: auth.user?.id, timeoutMs: 30000 });
 
-    if (result.status === 'failed') {
-      const error = result.error || 'Failed to get event';
-      return c.json({ error }, error.toLowerCase().includes('not found') ? 404 : 500);
+    if (isCommandFailure(result)) {
+      const failure = buildCommandFailureResponse(result, 'Failed to get event');
+      return c.json(failure.body, failure.status);
     }
 
     try {

--- a/apps/api/src/routes/systemTools/fileBrowserHelpers.test.ts
+++ b/apps/api/src/routes/systemTools/fileBrowserHelpers.test.ts
@@ -6,6 +6,7 @@ import {
   buildBulkItemFailure,
   auditErrorMessage,
   buildSingleItemUploadBody,
+  buildCommandFailureResponse,
   CLOUDFLARE_SWALLOWED_STATUSES,
 } from './fileBrowserHelpers';
 import { DEVICE_UNREACHABLE_ERROR, type CommandResult } from '../../services/commandQueue';
@@ -387,5 +388,68 @@ describe('buildSingleItemUploadBody', () => {
     const body = buildSingleItemUploadBody(result, 'Upload failed.');
     expect(body.unverified).toBeUndefined();
     expect(body.status).toBe(503);
+  });
+});
+
+// The shared response builder the non-file-browser systemTools routes adopted
+// in #4025. Those routes previously hand-rolled `{ error }` + a status at ~25
+// call sites; centralising the shape is what stops one of them from quietly
+// dropping the `unverified` flag on a state-changing timeout.
+describe('buildCommandFailureResponse', () => {
+  it('marks a mutating timeout unverified so the caller warns before a retry', () => {
+    const { body, status } = buildCommandFailureResponse(
+      { status: 'timeout', error: 'Command timed out after 15000ms' },
+      'Failed to kill process',
+      { mutating: true },
+    );
+
+    expect(status).toBe(503);
+    expect(body.code).toBe('agent_timeout');
+    expect(body.unverified).toBe(true);
+    expect(body.error).toContain('may have completed');
+  });
+
+  it('omits unverified entirely on a read-only timeout', () => {
+    const { body, status } = buildCommandFailureResponse(
+      { status: 'timeout', error: 'Command timed out after 60000ms' },
+      'Failed to get processes',
+    );
+
+    expect(status).toBe(503);
+    expect(body.code).toBe('agent_timeout');
+    // Absent, not `false` — the routes spread this straight into c.json and a
+    // literal `unverified: false` would read as a deliberate "we checked".
+    expect('unverified' in body).toBe(false);
+    expect(body.error).toContain('Please try again');
+  });
+
+  it('reproduces the 404 the routes used to derive from a "not found" substring', () => {
+    // Verbatim from agent/internal/remote/tools/services_windows.go:89 and
+    // tasks_windows.go:276 — the substring test these routes dropped.
+    for (const error of ['service not found: WinRM', 'task not found: \\Backup\\Daily']) {
+      const { body, status } = buildCommandFailureResponse({ status: 'failed', error }, 'fallback');
+      expect(status).toBe(404);
+      expect(body.code).toBe('path_not_found');
+      expect(body.error).toBe(error);
+    }
+  });
+
+  it('applies the fallback when the agent gave us nothing to show', () => {
+    const { body } = buildCommandFailureResponse({ status: 'failed' }, 'Failed to list tasks');
+    expect(body.error).toBe('Failed to list tasks');
+  });
+
+  it('never answers with a Cloudflare-swallowed status for any real agent error', () => {
+    for (const error of REAL_AGENT_ERRORS) {
+      for (const mutating of [false, true]) {
+        for (const status of ['failed', 'timeout'] as const) {
+          const response = buildCommandFailureResponse({ status, error }, 'fallback', { mutating });
+          expect(
+            CLOUDFLARE_SWALLOWED_STATUSES,
+            `${status}/${error || '<empty>'} (mutating=${mutating}) answered ${response.status}`,
+          ).not.toContain(response.status);
+        }
+      }
+    }
   });
 });

--- a/apps/api/src/routes/systemTools/fileBrowserHelpers.test.ts
+++ b/apps/api/src/routes/systemTools/fileBrowserHelpers.test.ts
@@ -227,6 +227,35 @@ describe('mapCommandFailure', () => {
     expect(mapCommandFailure(result, 'fallback').status).toBe(503);
   });
 
+  // The queue refuses every non-online device with one sentence,
+  // `Device is ${device.status}, cannot execute command` (commandQueue.ts:832,
+  // 1013), and `device_status` has seven values. Collapsing all of them to
+  // "The device is offline." is wrong five times out of six.
+  it.each([
+    ['maintenance', 'The device is maintenance and cannot run commands.'],
+    ['decommissioned', 'The device is decommissioned and cannot run commands.'],
+    ['quarantined', 'The device is quarantined and cannot run commands.'],
+    ['updating', 'The device is updating and cannot run commands.'],
+    ['pending', 'The device is pending and cannot run commands.'],
+  ])('names a %s device rather than calling it offline', (deviceState, expected) => {
+    const result: CommandResult = {
+      status: 'failed',
+      error: `Device is ${deviceState}, cannot execute command`,
+    };
+    const failure = mapCommandFailure(result, 'fallback');
+
+    expect(failure.code).toBe('device_offline');
+    expect(failure.status).toBe(503);
+    expect(failure.message).toBe(expected);
+  });
+
+  it('keeps the raw text when the refusal is not the queue-shaped sentence', () => {
+    // Anything else matching the offline heuristics keeps its own words rather
+    // than being overwritten with a message that may not be true.
+    const result: CommandResult = { status: 'failed', error: 'Relay says the host is unknown' };
+    expect(mapCommandFailure(result, 'fallback').message).toBe('Relay says the host is unknown');
+  });
+
   it('falls through to 500 with the raw error for unclassified failures', () => {
     const result: CommandResult = { status: 'failed', error: 'Permission denied' };
     expect(mapCommandFailure(result, 'fallback')).toEqual({

--- a/apps/api/src/routes/systemTools/fileBrowserHelpers.test.ts
+++ b/apps/api/src/routes/systemTools/fileBrowserHelpers.test.ts
@@ -249,11 +249,13 @@ describe('mapCommandFailure', () => {
     expect(failure.message).toBe(expected);
   });
 
-  it('keeps the raw text when the refusal is not the queue-shaped sentence', () => {
-    // Anything else matching the offline heuristics keeps its own words rather
-    // than being overwritten with a message that may not be true.
+  it('does not echo unrecognised internal text back with a confident 503', () => {
+    // The guard regex admits bare `is offline` / `is unknown` shapes that the
+    // queue sentence does not cover. They keep the generic message rather than
+    // passing raw internal wording through — unclassified text belongs on the
+    // 500 fallback, not on a 503 that asserts we know what happened.
     const result: CommandResult = { status: 'failed', error: 'Relay says the host is unknown' };
-    expect(mapCommandFailure(result, 'fallback').message).toBe('Relay says the host is unknown');
+    expect(mapCommandFailure(result, 'fallback').message).toBe('The device is offline.');
   });
 
   it('falls through to 500 with the raw error for unclassified failures', () => {

--- a/apps/api/src/routes/systemTools/fileBrowserHelpers.ts
+++ b/apps/api/src/routes/systemTools/fileBrowserHelpers.ts
@@ -1,3 +1,13 @@
+/**
+ * Agent command-failure classification for **every** systemTools route.
+ *
+ * Named for the File Browser because that is where it was extracted from, but
+ * as of #4025 `processes`, `services`, `registry`, `eventLogs` and
+ * `scheduledTasks` all classify through it too. The name is kept so the merged
+ * `fileBrowserHelpers.test.ts` — which owns the Cloudflare property test over
+ * every classifier outcome — keeps its co-located pairing; treat this module as
+ * the shared one it now is, not as file-browser-private.
+ */
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
 import {
   DEVICE_UNREACHABLE_ERROR,
@@ -254,6 +264,40 @@ export function buildSingleItemUploadBody(
     code: failure.code,
     status: failure.status,
     ...(failure.unverified ? { unverified: true as const } : {}),
+  };
+}
+
+/**
+ * The whole error response for a route that must stop on an agent failure:
+ * the JSON body and the status to send it with.
+ *
+ * Every systemTools route needs the identical three-part shape (`error`,
+ * `code`, and `unverified` only when set), and hand-rolling it at each of the
+ * ~25 call sites is how the `unverified` flag gets dropped from one of them —
+ * exactly the class of copy-paste divergence that produced issue #4025. Pass
+ * `mutating: true` from any route that changes device state so a timeout is
+ * reported as unverified rather than as a plain retryable error.
+ *
+ * Returns body and status separately rather than one flat object because
+ * several routes already bind a local `status` (e.g. the service-list query
+ * filter), which a destructured `{ status, ...payload }` would collide with.
+ */
+export function buildCommandFailureResponse(
+  result: CommandResult,
+  fallback: string,
+  opts: { mutating?: boolean } = {},
+): {
+  body: { error: string; code: CommandFailureKind; unverified?: true };
+  status: ContentfulStatusCode;
+} {
+  const failure = mapCommandFailure(result, fallback, opts);
+  return {
+    body: {
+      error: failure.message,
+      code: failure.code,
+      ...(failure.unverified ? { unverified: true as const } : {}),
+    },
+    status: failure.status,
   };
 }
 

--- a/apps/api/src/routes/systemTools/fileBrowserHelpers.ts
+++ b/apps/api/src/routes/systemTools/fileBrowserHelpers.ts
@@ -18,8 +18,26 @@ import {
 // Both 'failed' and 'timeout' must be treated as failures: previously the
 // route code only checked 'failed', which let timeouts silently fall through
 // to the JSON.parse path and surface a generic 500.
+//
+// Written as an exhaustive switch rather than `status === 'failed' || status
+// === 'timeout'` so that adding a fourth CommandResult status is a COMPILE
+// ERROR here instead of a silent new fall-through. That is exactly how #4025
+// happened: a status the success path had never considered ('timeout') was
+// treated as success by every route that enumerated failures positively.
 export function isCommandFailure(result: CommandResult): boolean {
-  return result.status === 'failed' || result.status === 'timeout';
+  switch (result.status) {
+    case 'failed':
+    case 'timeout':
+      return true;
+    case 'completed':
+      return false;
+    default: {
+      // If this stops compiling, a new status was added to CommandResult.
+      // Decide deliberately whether it is a failure — do not let it default.
+      const exhaustive: never = result.status;
+      return exhaustive;
+    }
+  }
 }
 
 /**
@@ -170,9 +188,32 @@ export function classifyCommandFailure(
   }
 
   if (/cannot execute command|is offline|is unknown/i.test(raw)) {
+    // The queue refuses ANY non-online device with the same sentence:
+    // `Device is ${device.status}, cannot execute command` (commandQueue.ts:832,
+    // 1013). `device_status` has seven values, so answering a flat "The device
+    // is offline." is wrong for five of the six non-online ones — and not in a
+    // cosmetic way:
+    //
+    //   - `updating` is set on every agent self-update (agentWs.ts:2156), so a
+    //     technician who restarts a service mid-upgrade is told the device is
+    //     offline and goes hunting a network fault that isn't there.
+    //   - `quarantined` is a security-containment state. Reporting it as
+    //     "offline" hides the containment from the person investigating.
+    //
+    // Keep the clean copy for the genuinely-offline case (the raw string's
+    // ", cannot execute command" tail is internal noise), and name the real
+    // state otherwise. `code` stays `device_offline` either way: it is the
+    // machine-readable "device would not take the command" discriminant, and
+    // callers branch on it, not on the prose.
+    const deviceState = /^Device is (\w+), cannot execute command$/i.exec(raw)?.[1]?.toLowerCase();
     return {
       kind: 'device_offline',
-      message: 'The device is offline.',
+      message:
+        deviceState && deviceState !== 'offline'
+          ? `The device is ${deviceState} and cannot run commands.`
+          : deviceState === 'offline'
+            ? 'The device is offline.'
+            : raw || 'The device is offline.',
       status: 503,
       code: 'device_offline',
     };

--- a/apps/api/src/routes/systemTools/fileBrowserHelpers.ts
+++ b/apps/api/src/routes/systemTools/fileBrowserHelpers.ts
@@ -35,7 +35,12 @@ export function isCommandFailure(result: CommandResult): boolean {
       // If this stops compiling, a new status was added to CommandResult.
       // Decide deliberately whether it is a failure — do not let it default.
       const exhaustive: never = result.status;
-      return exhaustive;
+      void exhaustive;
+      // Fail closed if one ever slips past the type system (an `any` at a
+      // call site, a payload off the wire): an unrecognised status is treated
+      // as a failure, never silently as a success. Returning `exhaustive`
+      // here would return the status STRING from a function typed `boolean`.
+      return true;
     }
   }
 }
@@ -189,9 +194,12 @@ export function classifyCommandFailure(
 
   if (/cannot execute command|is offline|is unknown/i.test(raw)) {
     // The queue refuses ANY non-online device with the same sentence:
-    // `Device is ${device.status}, cannot execute command` (commandQueue.ts:832,
-    // 1013). `device_status` has seven values, so answering a flat "The device
-    // is offline." is wrong for five of the six non-online ones — and not in a
+    // `Device is ${device.status}, cannot execute command`
+    // (commandQueue.ts:1013, inside executeCommand — the similar string at
+    // :832 returns a bare `{ error }` with no `status`, is not a
+    // CommandResult, and never reaches this classifier).
+    // `device_status` has seven values, so answering a flat "The device is
+    // offline." is wrong for five of the six non-online ones — and not in a
     // cosmetic way:
     //
     //   - `updating` is set on every agent self-update (agentWs.ts:2156), so a
@@ -205,15 +213,20 @@ export function classifyCommandFailure(
     // state otherwise. `code` stays `device_offline` either way: it is the
     // machine-readable "device would not take the command" discriminant, and
     // callers branch on it, not on the prose.
+    //
+    // The guard regex above also admits two shapes this sentence does not
+    // cover (`is offline` / `is unknown` on their own). Those keep the clean
+    // default rather than echoing `raw`: no production code emits them today,
+    // and passing unrecognised internal text through with a confident 503
+    // would be worse than the generic sentence — the 500 fallback at the end
+    // of this function is where genuinely unclassified text belongs.
     const deviceState = /^Device is (\w+), cannot execute command$/i.exec(raw)?.[1]?.toLowerCase();
     return {
       kind: 'device_offline',
       message:
         deviceState && deviceState !== 'offline'
           ? `The device is ${deviceState} and cannot run commands.`
-          : deviceState === 'offline'
-            ? 'The device is offline.'
-            : raw || 'The device is offline.',
+          : 'The device is offline.',
       status: 503,
       code: 'device_offline',
     };

--- a/apps/api/src/routes/systemTools/processes.ts
+++ b/apps/api/src/routes/systemTools/processes.ts
@@ -7,6 +7,11 @@ import { createAuditLog } from '../../services/auditService';
 import { getTrustedClientIpOrUndefined } from '../../services/clientIp';
 import { getDeviceWithOrgAndSiteCheck, SITE_ACCESS_DENIED, getPagination } from './helpers';
 import { deviceIdParamSchema, pidParamSchema, paginationQuerySchema } from './schemas';
+import {
+  isCommandFailure,
+  buildCommandFailureResponse,
+  auditErrorMessage,
+} from './fileBrowserHelpers';
 
 const processListQuerySchema = z.object({
   page: z.string().optional(),
@@ -45,8 +50,9 @@ processesRoutes.get(
       search
     }, { userId: auth.user?.id, timeoutMs: 60000 });
 
-    if (result.status === 'failed') {
-      return c.json({ error: result.error || 'Failed to get processes' }, 500);
+    if (isCommandFailure(result)) {
+      const failure = buildCommandFailureResponse(result, 'Failed to get processes');
+      return c.json(failure.body, failure.status);
     }
 
     try {
@@ -91,9 +97,9 @@ processesRoutes.get(
       pid
     }, { userId: auth.user?.id, timeoutMs: 30000 });
 
-    if (result.status === 'failed') {
-      const error = result.error || 'Failed to get process details';
-      return c.json({ error }, error.toLowerCase().includes('not found') ? 404 : 500);
+    if (isCommandFailure(result)) {
+      const failure = buildCommandFailureResponse(result, 'Failed to get process details');
+      return c.json(failure.body, failure.status);
     }
 
     try {
@@ -150,11 +156,12 @@ processesRoutes.post(
       },
       ipAddress: getTrustedClientIpOrUndefined(c),
       result: result.status === 'completed' ? 'success' : 'failure',
-      errorMessage: result.error
+      errorMessage: auditErrorMessage(result)
     });
 
-    if (result.status === 'failed') {
-      return c.json({ error: result.error || 'Failed to kill process' }, 500);
+    if (isCommandFailure(result)) {
+      const failure = buildCommandFailureResponse(result, 'Failed to kill process', { mutating: true });
+      return c.json(failure.body, failure.status);
     }
 
     try {

--- a/apps/api/src/routes/systemTools/processes.ts
+++ b/apps/api/src/routes/systemTools/processes.ts
@@ -155,7 +155,7 @@ processesRoutes.post(
         result: result.status
       },
       ipAddress: getTrustedClientIpOrUndefined(c),
-      result: result.status === 'completed' ? 'success' : 'failure',
+      result: isCommandFailure(result) ? 'failure' : 'success',
       errorMessage: auditErrorMessage(result)
     });
 
@@ -170,7 +170,15 @@ processesRoutes.post(
         success: true,
         message: `Process ${pid} (${data.name || 'unknown'}) terminated successfully`
       });
-    } catch {
+    } catch (parseError) {
+      // The kill itself is confirmed — `isCommandFailure` above already ruled
+      // out failed/timeout, so `status` is 'completed' and the agent acked the
+      // termination. Only the metadata used to prettify the message failed to
+      // parse, so reporting success is correct here. Logged rather than
+      // swallowed: a bare catch in THIS handler is what let #4025 read as
+      // routine, and an unparseable payload from a completed kill still says
+      // something is wrong with the agent's response shape.
+      console.error('Failed to parse agent response for process kill:', parseError);
       return c.json({
         success: true,
         message: `Process ${pid} terminated successfully`

--- a/apps/api/src/routes/systemTools/registry.ts
+++ b/apps/api/src/routes/systemTools/registry.ts
@@ -13,6 +13,11 @@ import {
   registryKeyBodySchema,
   registryKeyQuerySchema
 } from './schemas';
+import {
+  isCommandFailure,
+  buildCommandFailureResponse,
+  auditErrorMessage,
+} from './fileBrowserHelpers';
 import type { RegistryKey, RegistryValue } from './types';
 
 function parseNumericLike(value: string): number | null {
@@ -200,8 +205,9 @@ registryRoutes.get(
       path
     }, { userId: auth.user?.id, timeoutMs: 30000 });
 
-    if (result.status === 'failed') {
-      return c.json({ error: result.error || 'Failed to load registry keys' }, 500);
+    if (isCommandFailure(result)) {
+      const failure = buildCommandFailureResponse(result, 'Failed to load registry keys');
+      return c.json(failure.body, failure.status);
     }
 
     try {
@@ -244,8 +250,9 @@ registryRoutes.get(
       path
     }, { userId: auth.user?.id, timeoutMs: 30000 });
 
-    if (result.status === 'failed') {
-      return c.json({ error: result.error || 'Failed to load registry values' }, 500);
+    if (isCommandFailure(result)) {
+      const failure = buildCommandFailureResponse(result, 'Failed to load registry values');
+      return c.json(failure.body, failure.status);
     }
 
     try {
@@ -289,9 +296,9 @@ registryRoutes.get(
       name: normalizeRegistryValueName(name)
     }, { userId: auth.user?.id, timeoutMs: 30000 });
 
-    if (result.status === 'failed') {
-      const error = result.error || 'Failed to get registry value';
-      return c.json({ error }, error.toLowerCase().includes('not found') ? 404 : 500);
+    if (isCommandFailure(result)) {
+      const failure = buildCommandFailureResponse(result, 'Failed to get registry value');
+      return c.json(failure.body, failure.status);
     }
 
     try {
@@ -369,12 +376,12 @@ registryRoutes.put(
       },
       ipAddress: getTrustedClientIpOrUndefined(c),
       result: result.status === 'completed' ? 'success' : 'failure',
-      errorMessage: result.error
+      errorMessage: auditErrorMessage(result)
     });
 
-    if (result.status === 'failed') {
-      const error = result.error || 'Failed to set registry value';
-      return c.json({ error }, error.toLowerCase().includes('not found') ? 404 : 500);
+    if (isCommandFailure(result)) {
+      const failure = buildCommandFailureResponse(result, 'Failed to set registry value', { mutating: true });
+      return c.json(failure.body, failure.status);
     }
 
     return c.json({
@@ -433,12 +440,12 @@ registryRoutes.delete(
       },
       ipAddress: getTrustedClientIpOrUndefined(c),
       result: result.status === 'completed' ? 'success' : 'failure',
-      errorMessage: result.error
+      errorMessage: auditErrorMessage(result)
     });
 
-    if (result.status === 'failed') {
-      const error = result.error || 'Failed to delete registry value';
-      return c.json({ error }, error.toLowerCase().includes('not found') ? 404 : 500);
+    if (isCommandFailure(result)) {
+      const failure = buildCommandFailureResponse(result, 'Failed to delete registry value', { mutating: true });
+      return c.json(failure.body, failure.status);
     }
 
     return c.json({
@@ -492,12 +499,12 @@ registryRoutes.post(
       },
       ipAddress: getTrustedClientIpOrUndefined(c),
       result: result.status === 'completed' ? 'success' : 'failure',
-      errorMessage: result.error
+      errorMessage: auditErrorMessage(result)
     });
 
-    if (result.status === 'failed') {
-      const error = result.error || 'Failed to create registry key';
-      return c.json({ error }, error.toLowerCase().includes('not found') ? 404 : 500);
+    if (isCommandFailure(result)) {
+      const failure = buildCommandFailureResponse(result, 'Failed to create registry key', { mutating: true });
+      return c.json(failure.body, failure.status);
     }
 
     return c.json({
@@ -551,12 +558,12 @@ registryRoutes.delete(
       },
       ipAddress: getTrustedClientIpOrUndefined(c),
       result: result.status === 'completed' ? 'success' : 'failure',
-      errorMessage: result.error
+      errorMessage: auditErrorMessage(result)
     });
 
-    if (result.status === 'failed') {
-      const error = result.error || 'Failed to delete registry key';
-      return c.json({ error }, error.toLowerCase().includes('not found') ? 404 : 500);
+    if (isCommandFailure(result)) {
+      const failure = buildCommandFailureResponse(result, 'Failed to delete registry key', { mutating: true });
+      return c.json(failure.body, failure.status);
     }
 
     return c.json({

--- a/apps/api/src/routes/systemTools/registry.ts
+++ b/apps/api/src/routes/systemTools/registry.ts
@@ -375,7 +375,7 @@ registryRoutes.put(
         data: commandData.substring(0, 200)
       },
       ipAddress: getTrustedClientIpOrUndefined(c),
-      result: result.status === 'completed' ? 'success' : 'failure',
+      result: isCommandFailure(result) ? 'failure' : 'success',
       errorMessage: auditErrorMessage(result)
     });
 
@@ -439,7 +439,7 @@ registryRoutes.delete(
         name: normalizedName
       },
       ipAddress: getTrustedClientIpOrUndefined(c),
-      result: result.status === 'completed' ? 'success' : 'failure',
+      result: isCommandFailure(result) ? 'failure' : 'success',
       errorMessage: auditErrorMessage(result)
     });
 
@@ -498,7 +498,7 @@ registryRoutes.post(
         path: normalizedPath
       },
       ipAddress: getTrustedClientIpOrUndefined(c),
-      result: result.status === 'completed' ? 'success' : 'failure',
+      result: isCommandFailure(result) ? 'failure' : 'success',
       errorMessage: auditErrorMessage(result)
     });
 
@@ -557,7 +557,7 @@ registryRoutes.delete(
         path: normalizedPath
       },
       ipAddress: getTrustedClientIpOrUndefined(c),
-      result: result.status === 'completed' ? 'success' : 'failure',
+      result: isCommandFailure(result) ? 'failure' : 'success',
       errorMessage: auditErrorMessage(result)
     });
 

--- a/apps/api/src/routes/systemTools/scheduledTasks.ts
+++ b/apps/api/src/routes/systemTools/scheduledTasks.ts
@@ -12,6 +12,11 @@ import {
   taskHistoryQuerySchema,
   paginationQuerySchema
 } from './schemas';
+import {
+  isCommandFailure,
+  buildCommandFailureResponse,
+  auditErrorMessage,
+} from './fileBrowserHelpers';
 import type { ScheduledTaskInfo, TaskHistoryEntry } from './types';
 
 const taskListQuerySchema = z.object({
@@ -171,8 +176,9 @@ scheduledTasksRoutes.get(
       limit
     }, { userId: auth.user?.id, timeoutMs: 30000 });
 
-    if (result.status === 'failed') {
-      return c.json({ error: result.error || 'Failed to list tasks' }, 500);
+    if (isCommandFailure(result)) {
+      const failure = buildCommandFailureResponse(result, 'Failed to list tasks');
+      return c.json(failure.body, failure.status);
     }
 
     try {
@@ -222,9 +228,9 @@ scheduledTasksRoutes.get(
       path
     }, { userId: auth.user?.id, timeoutMs: 30000 });
 
-    if (result.status === 'failed') {
-      const error = result.error || 'Failed to get task';
-      return c.json({ error }, error.toLowerCase().includes('not found') ? 404 : 500);
+    if (isCommandFailure(result)) {
+      const failure = buildCommandFailureResponse(result, 'Failed to get task');
+      return c.json(failure.body, failure.status);
     }
 
     try {
@@ -273,9 +279,9 @@ scheduledTasksRoutes.get(
       limit
     }, { userId: auth.user?.id, timeoutMs: 30000 });
 
-    if (result.status === 'failed') {
-      const error = result.error || 'Failed to get task history';
-      return c.json({ error }, error.toLowerCase().includes('not found') ? 404 : 500);
+    if (isCommandFailure(result)) {
+      const failure = buildCommandFailureResponse(result, 'Failed to get task history');
+      return c.json(failure.body, failure.status);
     }
 
     try {
@@ -334,12 +340,12 @@ scheduledTasksRoutes.post(
       details: { path },
       ipAddress: getTrustedClientIpOrUndefined(c),
       result: result.status === 'completed' ? 'success' : 'failure',
-      errorMessage: result.error
+      errorMessage: auditErrorMessage(result)
     });
 
-    if (result.status === 'failed') {
-      const error = result.error || 'Failed to run task';
-      return c.json({ error }, error.toLowerCase().includes('not found') ? 404 : 500);
+    if (isCommandFailure(result)) {
+      const failure = buildCommandFailureResponse(result, 'Failed to run task', { mutating: true });
+      return c.json(failure.body, failure.status);
     }
 
     return c.json({
@@ -382,12 +388,12 @@ scheduledTasksRoutes.post(
       details: { path },
       ipAddress: getTrustedClientIpOrUndefined(c),
       result: result.status === 'completed' ? 'success' : 'failure',
-      errorMessage: result.error
+      errorMessage: auditErrorMessage(result)
     });
 
-    if (result.status === 'failed') {
-      const error = result.error || 'Failed to enable task';
-      return c.json({ error }, error.toLowerCase().includes('not found') ? 404 : 500);
+    if (isCommandFailure(result)) {
+      const failure = buildCommandFailureResponse(result, 'Failed to enable task', { mutating: true });
+      return c.json(failure.body, failure.status);
     }
 
     return c.json({
@@ -430,12 +436,12 @@ scheduledTasksRoutes.post(
       details: { path },
       ipAddress: getTrustedClientIpOrUndefined(c),
       result: result.status === 'completed' ? 'success' : 'failure',
-      errorMessage: result.error
+      errorMessage: auditErrorMessage(result)
     });
 
-    if (result.status === 'failed') {
-      const error = result.error || 'Failed to disable task';
-      return c.json({ error }, error.toLowerCase().includes('not found') ? 404 : 500);
+    if (isCommandFailure(result)) {
+      const failure = buildCommandFailureResponse(result, 'Failed to disable task', { mutating: true });
+      return c.json(failure.body, failure.status);
     }
 
     return c.json({

--- a/apps/api/src/routes/systemTools/scheduledTasks.ts
+++ b/apps/api/src/routes/systemTools/scheduledTasks.ts
@@ -339,7 +339,7 @@ scheduledTasksRoutes.post(
       resourceName: device.hostname ?? device.id,
       details: { path },
       ipAddress: getTrustedClientIpOrUndefined(c),
-      result: result.status === 'completed' ? 'success' : 'failure',
+      result: isCommandFailure(result) ? 'failure' : 'success',
       errorMessage: auditErrorMessage(result)
     });
 
@@ -387,7 +387,7 @@ scheduledTasksRoutes.post(
       resourceName: device.hostname ?? device.id,
       details: { path },
       ipAddress: getTrustedClientIpOrUndefined(c),
-      result: result.status === 'completed' ? 'success' : 'failure',
+      result: isCommandFailure(result) ? 'failure' : 'success',
       errorMessage: auditErrorMessage(result)
     });
 
@@ -435,7 +435,7 @@ scheduledTasksRoutes.post(
       resourceName: device.hostname ?? device.id,
       details: { path },
       ipAddress: getTrustedClientIpOrUndefined(c),
-      result: result.status === 'completed' ? 'success' : 'failure',
+      result: isCommandFailure(result) ? 'failure' : 'success',
       errorMessage: auditErrorMessage(result)
     });
 

--- a/apps/api/src/routes/systemTools/services.ts
+++ b/apps/api/src/routes/systemTools/services.ts
@@ -7,6 +7,11 @@ import { createAuditLog } from '../../services/auditService';
 import { getTrustedClientIpOrUndefined } from '../../services/clientIp';
 import { getDeviceWithOrgAndSiteCheck, SITE_ACCESS_DENIED, getPagination, asRecord, asString } from './helpers';
 import { deviceIdParamSchema, serviceNameParamSchema, paginationQuerySchema } from './schemas';
+import {
+  isCommandFailure,
+  buildCommandFailureResponse,
+  auditErrorMessage,
+} from './fileBrowserHelpers';
 import type { ServiceInfo } from './types';
 
 const serviceListQuerySchema = z.object({
@@ -113,8 +118,9 @@ servicesRoutes.get(
       status
     }, { userId: auth.user?.id, timeoutMs: 30000 });
 
-    if (result.status === 'failed') {
-      return c.json({ error: result.error || 'Failed to get services' }, 500);
+    if (isCommandFailure(result)) {
+      const failure = buildCommandFailureResponse(result, 'Failed to get services');
+      return c.json(failure.body, failure.status);
     }
 
     try {
@@ -162,9 +168,9 @@ servicesRoutes.get(
       name
     }, { userId: auth.user?.id, timeoutMs: 30000 });
 
-    if (result.status === 'failed') {
-      const error = result.error || 'Failed to get service';
-      return c.json({ error }, error.toLowerCase().includes('not found') ? 404 : 500);
+    if (isCommandFailure(result)) {
+      const failure = buildCommandFailureResponse(result, 'Failed to get service');
+      return c.json(failure.body, failure.status);
     }
 
     try {
@@ -218,12 +224,12 @@ servicesRoutes.post(
       details: { name },
       ipAddress: getTrustedClientIpOrUndefined(c),
       result: result.status === 'completed' ? 'success' : 'failure',
-      errorMessage: result.error
+      errorMessage: auditErrorMessage(result)
     });
 
-    if (result.status === 'failed') {
-      const error = result.error || 'Failed to start service';
-      return c.json({ error }, error.toLowerCase().includes('not found') ? 404 : 500);
+    if (isCommandFailure(result)) {
+      const failure = buildCommandFailureResponse(result, 'Failed to start service', { mutating: true });
+      return c.json(failure.body, failure.status);
     }
 
     return c.json({
@@ -266,12 +272,12 @@ servicesRoutes.post(
       details: { name },
       ipAddress: getTrustedClientIpOrUndefined(c),
       result: result.status === 'completed' ? 'success' : 'failure',
-      errorMessage: result.error
+      errorMessage: auditErrorMessage(result)
     });
 
-    if (result.status === 'failed') {
-      const error = result.error || 'Failed to stop service';
-      return c.json({ error }, error.toLowerCase().includes('not found') ? 404 : 500);
+    if (isCommandFailure(result)) {
+      const failure = buildCommandFailureResponse(result, 'Failed to stop service', { mutating: true });
+      return c.json(failure.body, failure.status);
     }
 
     return c.json({
@@ -314,12 +320,12 @@ servicesRoutes.post(
       details: { name },
       ipAddress: getTrustedClientIpOrUndefined(c),
       result: result.status === 'completed' ? 'success' : 'failure',
-      errorMessage: result.error
+      errorMessage: auditErrorMessage(result)
     });
 
-    if (result.status === 'failed') {
-      const error = result.error || 'Failed to restart service';
-      return c.json({ error }, error.toLowerCase().includes('not found') ? 404 : 500);
+    if (isCommandFailure(result)) {
+      const failure = buildCommandFailureResponse(result, 'Failed to restart service', { mutating: true });
+      return c.json(failure.body, failure.status);
     }
 
     return c.json({

--- a/apps/api/src/routes/systemTools/services.ts
+++ b/apps/api/src/routes/systemTools/services.ts
@@ -223,7 +223,7 @@ servicesRoutes.post(
       resourceName: device.hostname ?? device.id,
       details: { name },
       ipAddress: getTrustedClientIpOrUndefined(c),
-      result: result.status === 'completed' ? 'success' : 'failure',
+      result: isCommandFailure(result) ? 'failure' : 'success',
       errorMessage: auditErrorMessage(result)
     });
 
@@ -271,7 +271,7 @@ servicesRoutes.post(
       resourceName: device.hostname ?? device.id,
       details: { name },
       ipAddress: getTrustedClientIpOrUndefined(c),
-      result: result.status === 'completed' ? 'success' : 'failure',
+      result: isCommandFailure(result) ? 'failure' : 'success',
       errorMessage: auditErrorMessage(result)
     });
 
@@ -319,7 +319,7 @@ servicesRoutes.post(
       resourceName: device.hostname ?? device.id,
       details: { name },
       ipAddress: getTrustedClientIpOrUndefined(c),
-      result: result.status === 'completed' ? 'success' : 'failure',
+      result: isCommandFailure(result) ? 'failure' : 'success',
       errorMessage: auditErrorMessage(result)
     });
 


### PR DESCRIPTION
Closes #4025

## The bug

Every System Tools route outside the File Browser tested `result.status === 'failed'` and nothing else. The command queue's timeout result is `{ status: 'timeout', error: 'Command timed out after ${timeoutMs}ms' }` with **no `stdout`** (`commandQueue.ts:753-762`), so it fell straight through into the success path.

**Process kill reported a success that did not happen.** `JSON.parse(undefined || '{}')` succeeds, so `processes.ts` answered:

```
200 { success: true, message: "Process 3456 (unknown) terminated successfully" }
```

…for a command the agent never acknowledged — while the audit row it had written moments earlier said `result: 'failure'`. The audit trail and the API response actively contradicted each other about whether a device had been mutated. Pinned by a test that now asserts both agree.

**Listings silently rendered empty.** The same shape made every list route return `200 { data: [] }`, so a technician read *"no processes running"* off a device that simply had not answered in time.

## The fix

All **25** call sites across `processes`, `services`, `registry`, `eventLogs` and `scheduledTasks` now classify through the same `isCommandFailure()` + `classifyCommandFailure()` that #4029 built for the File Browser and explicitly left these routes out of.

State-changing routes pass `mutating: true`, so a timeout answers **503 `agent_timeout` with `unverified: true`** and copy that tells the user to verify before retrying, rather than "please try again". Re-running a kill, a registry delete or a service stop against a half-completed state can compound the damage — the API genuinely cannot tell whether the device carried the operation out.

| | routes | timeout now answers |
|---|---:|---|
| read | 14 | 503 `agent_timeout`, no `unverified` |
| state-changing | 11 | 503 `agent_timeout` + `unverified: true` |

### One builder instead of 25 hand-rolled bodies

The `{ error, code, unverified? }` + status shape moves into `buildCommandFailureResponse()`. Hand-rolling a conditional spread at 25 sites is precisely how one of them ends up missing the `unverified` flag — the same class of copy-paste divergence that produced this bug. It returns `body` and `status` separately rather than one flat object because several routes already bind a local `status` (the service-list query filter), which a destructured `{ status, ...payload }` would collide with.

### Audit trail

Mutating routes switch `errorMessage: result.error` → `auditErrorMessage(result)`, so a timeout is tagged `[unverified]` in the audit trail. The trail and the response can no longer disagree about whether a device's final state was confirmed.

### The `not found` substring tests

The `error.toLowerCase().includes('not found') ? 404 : 500` checks are replaced by the classifier's not-found patterns. I verified this is equivalent rather than assuming it — every "not found" string these five tool families actually emit still answers 404:

| agent source | string |
|---|---|
| `processes.go:172,197` | `process not found: …` |
| `services_windows.go:89,123,144`, `services_linux.go:81`, `services_darwin.go:82` | `service not found: …` |
| `registry_windows.go:143` | `value not found: …` |
| `eventlogs_windows.go:108` | `event not found` |
| `tasks_windows.go:267,276` | `task not found: …` |

I also grepped these tool files for strings that could collide with the classifier's *other* prose branches (`is unknown`, `is offline`, `cannot execute command`, `timed out`, `did not complete`) — **none match**. Those branches only ever fire on queue-generated errors (`commandQueue.ts:832,1013`), which is where they are meant to fire, so widening the classifier's reach to five more route families introduces no misclassification.

## Verification

| suite | result |
|---|---|
| `systemTools.test.ts` + `systemTools/` (4 files) | **160 passed** |
| plus `bodyLimit` + `aiToolsFilesystem` ×2 (every suite touching systemTools) | **186 passed** |
| `tsc --noEmit -p apps/api` | clean |
| `eslint src` | clean |

**Red first.** Before the change the new tests failed 41/95, with `kill_process` returning **200** where the test demanded 503 — the reported bug reproduced exactly.

**Both guards revert-probed:**

- Reverting a single call site (`tasks:disable`) to `status === 'failed'` fails exactly its 2 table rows and nothing else — the table discriminates per site, so a future route added without a row can't hide.
- Dropping the `unverified` spread from the shared builder turns **13** tests red.

The table asserts its own length (25) so a new call site added without a row is a test failure, not a silent gap.

Tests also cover the paths that must *not* change: an unclassified agent failure still answers 500 with the agent's message, `not found` still answers 404, an offline device answers 503 `device_offline` without `unverified`, and a **prose-only** timeout (`status: 'failed'`, `error: 'command timed out after 30s'`) is still treated as unverified — the trap that was fixed in `buildBulkItemFailure` and would have been reintroduced by testing `status === 'timeout'` literally in the routes.

## Compatibility — checked, nothing breaks

Every web consumer (`RemoteToolsPage.tsx`, `ProcessDrilldownPanel.tsx`) branches on `res.ok` only, never on a specific status, so 503/404/422 are handled exactly as 500 was. The added `code` / `unverified` fields are inert to code that reads `json.error`. No mobile or e2e code calls these endpoints. No existing test asserts a status or body shape that changes.

`apps/docs/.../features/system-tools.mdx:616-635` already documents this classifier table generically for *"System Tools commands"* — before this PR that documentation was aspirational for these five route families. It is now accurate, and needs no edit.

## Found during review — a regression this PR introduced, now fixed

Routing these 25 routes through the shared classifier initially **regressed** the device-state message, and review caught it. The queue refuses every non-online device with one sentence — `Device is ${device.status}, cannot execute command` (`commandQueue.ts:1013`) — and `deviceStatusEnum` has seven values (`db/schema/devices.ts:7`). The classifier discarded that text and answered a flat `"The device is offline."`, so five of the six non-online states were reported wrongly. Before this PR these routes surfaced the real string.

It matters most for **`updating`**, which is set on every agent self-update (`agentWs.ts:2156`) — a technician restarting a service mid-upgrade was told the device was offline and sent to chase a network fault — and for **`quarantined`**, a security-containment state that must not read as a connectivity problem. The genuinely-offline case keeps its clean copy; the rest now name their real state. `code` stays `device_offline`, which is what callers branch on.

Two test guards were also found to be weaker than their comments claimed, and both were rebuilt:

- `expect(routes).toHaveLength(25)` promised to catch a new route added without a table row. It could not — the array is declared in the same file, so it only fails when a row is *deleted*. Proven by adding a 26th real call site and watching the suite stay green. It now reads the five route files and pairs each `await executeCommand(` with the gate that must follow it. Probed against the subtle version too: removing `registry:keys`' gate while adding a redundant one to `registry:values` keeps every count identical, and the rebuilt guard still reds.
- The `[unverified]` audit tag was asserted at **1 of 11** mutating routes; reverting the other ten reddened nothing. Now asserted at all eleven.

`isCommandFailure` is additionally an exhaustive switch, so adding a fourth `CommandResult` status is a compile error rather than a silent new fall-through — the precise shape of this bug. Re-probed: a fourth status fails with `TS2322 … not assignable to type 'never'`. Its default arm fails closed.

## Not in this PR

- **The web UI drops the `unverified` signal.** The mutating handlers do surface the warning text (they throw `json.error`, which is the "may have completed — refresh to verify before retrying" message), so the fix's user-visible benefit lands. But the four list-fetchers (`fetchProcesses`, `fetchServices`, `fetchEventLogs`, `fetchTasks`) catch and only `console.error`, so a timed-out listing now leaves the table unchanged instead of positively asserting "empty" — strictly better than the lie it used to tell, but still silent. Surfacing it properly needs an error-state design (toast vs inline empty-state), new locale keys across 8 catalogs, and E2E proof, so it wants its own issue rather than a rider here.
- **The BreezeAgent self-protection refusal stays a 500.** `"Cannot stop the Breeze agent service: operation blocked by self-protection"` is a deterministic refusal and arguably a 422, but it isn't in `REFUSAL_PATTERNS`, and the classifier's documented policy is that unrecognised refusals degrade to 500 (the safe direction). Changing it would re-pin an assertion #4029 just shipped, for a reason unrelated to timeouts.
- **The same bug class is live in `apps/api/src/routes/backup/`.** Verified, not inferred: `vss.ts:57`, `hyperv.ts` (5 sites) and `mssql.ts` (4 sites) all still test `result.status === 'failed'` only. `vss.ts` even does `result.stdout ? JSON.parse(result.stdout) : null`, so a timed-out VSS writer list answers **200 with `data: null`**. Ten sites, outside #4025's stated scope (System Tools) — worth its own issue.
- **Platform refusals still answer 500.** `registry is only supported on Windows` / `event logs are only supported on Windows` / `scheduled tasks are only supported on Windows` (`registry_other.go`, `eventlogs_other.go`, `tasks_other.go`) are deterministic refusals that degrade to `agent_execution_failed`. This is *unchanged* behaviour, not a regression — those paths answered 500 before too — but it is the single most common real failure for three of these tabs (any macOS or Linux device), and 422-vs-500 is a monitoring-visible policy call that deserves its own decision rather than a rider here.
- **`fileBrowserHelpers.ts` keeps its name** despite now serving all six route families. A rename churns a file that merged hours ago and would split it from its co-located test, which owns the Cloudflare property test. I added a module header saying to treat it as shared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JCiqAhFVwT5hWi9kWz4vED
