### PR TITLE
fix(viewer): fall back gracefully when the WebView has no WebRTC (#3410)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -547,6 +547,40 @@ jobs:
       - name: Run Portal tests
         run: pnpm test --filter=@breeze/portal
 
+  # The Viewer's TypeScript tests (transports, keymap, protocol, paste, …) ran
+  # in no CI job at all until issue #3410 added a regression test here and found
+  # the gap — only the Rust half (apps/viewer/src-tauri) was covered, by
+  # rust-check. Uses test:run because the package's `test` script is watch mode.
+  test-viewer:
+    name: Test Viewer
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version-file: .node-version
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Viewer tests
+        run: pnpm --filter=@breeze/viewer test:run
+
+      - name: Run Viewer type check
+        working-directory: apps/viewer
+        run: pnpm exec tsc --noEmit
+
   test-office-addin-core:
     name: Test Office Add-in Core
     runs-on: ubuntu-latest
@@ -2360,7 +2394,7 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, test-api, test-m365-graph-read-executor, test-m365-graph-actions-executor, test-m365-communications-executor, test-web, test-mobile, test-portal, test-office-addin-core, test-excel-addin, test-word-addin, test-powerpoint-addin, test-outlook-addin, security-audit, build-api, build-m365-graph-read-executor, build-m365-graph-actions-executor, build-m365-communications-executor, build-web, build-portal, build-agent, test-agent, test-agent-windows, windows-runtime-smoke, integration-test, check-migrations-nonsuperuser, rust-check, smoke-test, auth-browser-transition-browser-contract]
+    needs: [lint, typecheck, test-api, test-m365-graph-read-executor, test-m365-graph-actions-executor, test-m365-communications-executor, test-web, test-mobile, test-portal, test-viewer, test-office-addin-core, test-excel-addin, test-word-addin, test-powerpoint-addin, test-outlook-addin, security-audit, build-api, build-m365-graph-read-executor, build-m365-graph-actions-executor, build-m365-communications-executor, build-web, build-portal, build-agent, test-agent, test-agent-windows, windows-runtime-smoke, integration-test, check-migrations-nonsuperuser, rust-check, smoke-test, auth-browser-transition-browser-contract]
     if: ${{ !cancelled() }}
     steps:
       - name: Check all jobs passed
@@ -2374,6 +2408,7 @@ jobs:
           TEST_WEB_RESULT: ${{ needs.test-web.result }}
           TEST_MOBILE_RESULT: ${{ needs.test-mobile.result }}
           TEST_PORTAL_RESULT: ${{ needs.test-portal.result }}
+          TEST_VIEWER_RESULT: ${{ needs.test-viewer.result }}
           TEST_OFFICE_ADDIN_CORE_RESULT: ${{ needs.test-office-addin-core.result }}
           TEST_EXCEL_ADDIN_RESULT: ${{ needs.test-excel-addin.result }}
           TEST_WORD_ADDIN_RESULT: ${{ needs.test-word-addin.result }}
@@ -2406,6 +2441,7 @@ jobs:
              [[ "${TEST_WEB_RESULT}" != "success" ]] || \
              [[ "${TEST_MOBILE_RESULT}" != "success" ]] || \
              [[ "${TEST_PORTAL_RESULT}" != "success" ]] || \
+             [[ "${TEST_VIEWER_RESULT}" != "success" ]] || \
              [[ "${TEST_OFFICE_ADDIN_CORE_RESULT}" != "success" ]] || \
              [[ "${TEST_EXCEL_ADDIN_RESULT}" != "success" ]] || \
              [[ "${TEST_WORD_ADDIN_RESULT}" != "success" ]] || \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -551,6 +551,8 @@ jobs:
   # in no CI job at all until issue #3410 added a regression test here and found
   # the gap — only the Rust half (apps/viewer/src-tauri) was covered, by
   # rust-check. Uses test:run because the package's `test` script is watch mode.
+  # Covers tests + types only: @breeze/viewer still defines no `lint` script, so
+  # `turbo run lint` skips it and the repo-wide Lint job does not reach it.
   test-viewer:
     name: Test Viewer
     runs-on: ubuntu-latest

--- a/apps/docs/src/content/docs/features/remote-access.mdx
+++ b/apps/docs/src/content/docs/features/remote-access.mdx
@@ -522,6 +522,38 @@ export APPIMAGE_EXTRACT_AND_RUN=1
 
 Extract-and-run unpacks the whole bundle on every launch, so sessions start noticeably slower and each launch writes to `$TMPDIR`. Installing FUSE 2 is the better outcome where it is allowed.
 
+### WebRTC needs webkit2gtk built with the GStreamer plugins
+
+The Linux viewer renders in webkit2gtk, the system WebView, rather than bundling its own browser engine. Whether WebRTC is available therefore depends on how your distribution compiled webkit2gtk and which GStreamer plugins are installed — on a number of builds `RTCPeerConnection` is not exposed at all.
+
+When that is the case the viewer detects it before connecting, skips WebRTC, and runs the session on the WebSocket (JPEG) transport instead. A notice in the session window explains the switch, and the toolbar badge reads **WS** rather than **WebRTC**. The session still works; you lose the WebRTC-only features:
+
+| Available on WebSocket | WebRTC only |
+|---|---|
+| Screen view, keyboard, mouse, clipboard | Remote audio |
+| Reconnect, session end | Multi-monitor switching |
+| | Bitrate and quality controls |
+| | Secure attention sequence (Ctrl+Alt+Del) |
+
+To get WebRTC, install the GStreamer plugin sets webkit2gtk uses for it, then relaunch the viewer:
+
+```bash
+# Debian / Ubuntu
+sudo apt install gstreamer1.0-plugins-base gstreamer1.0-plugins-good \
+  gstreamer1.0-plugins-bad gstreamer1.0-libav
+
+# Fedora / RHEL
+sudo dnf install gstreamer1-plugins-base gstreamer1-plugins-good \
+  gstreamer1-plugins-bad-free gstreamer1-libav
+
+# Arch
+sudo pacman -S gst-plugins-base gst-plugins-good gst-plugins-bad gst-libav
+```
+
+<Aside type="note">
+  Some distributions ship a webkit2gtk built without WebRTC support regardless of which GStreamer plugins are present. If the viewer still reports no WebRTC after installing them, the WebSocket transport is the expected behavior on that host — remote desktop keeps working, at lower video quality.
+</Aside>
+
 ### Viewer launches but no window appears
 
 If the process shows up in `ps` but nothing is drawn, FUSE is working and the problem is the desktop stack, not packaging — typically a host GTK module or `gvfs` build that is incompatible with the bundled runtime. Run the AppImage from a terminal and read the messages: `Failed to load module` and `undefined symbol` lines name the offending host library. Starting with a clean environment (`env -i DISPLAY=$DISPLAY HOME=$HOME ~/Downloads/breeze-viewer-linux.AppImage`) confirms whether a host module is being injected.
@@ -532,6 +564,9 @@ If the process shows up in `ps` but nothing is drawn, FUSE is working and the pr
 
 **Linux viewer does nothing when run.**
 The AppImage needs FUSE 2 to mount itself. On Debian 13 / Ubuntu 24.04+ the package is `libfuse2t64`, not `libfuse2`. See [Linux viewer (AppImage)](#linux-viewer-appimage) for the per-distribution package names and the `--appimage-extract-and-run` fallback.
+
+**Linux viewer always connects on the WebSocket transport, never WebRTC.**
+The host's webkit2gtk build does not expose `RTCPeerConnection`, so the viewer skips WebRTC and uses the WebSocket (JPEG) transport. The session window shows a notice saying so, and the browser console logs `WebRTC is unavailable in this WebView (no RTCPeerConnection global)`. Installing the GStreamer plugin sets usually restores it — see [WebRTC needs webkit2gtk built with the GStreamer plugins](#webrtc-needs-webkit2gtk-built-with-the-gstreamer-plugins). This is a property of the host, not of the device you are connecting to.
 
 **Session stuck in `connecting`.**
 WebRTC negotiation failed and the viewer has not yet fallen back to WebSocket. Confirm the device is online and the agent WebSocket connection is active (check the device detail page). Common causes:

--- a/apps/docs/src/content/docs/features/remote-access.mdx
+++ b/apps/docs/src/content/docs/features/remote-access.mdx
@@ -530,10 +530,13 @@ When that is the case the viewer detects it before connecting, skips WebRTC, and
 
 | Available on WebSocket | WebRTC only |
 |---|---|
-| Screen view, keyboard, mouse, clipboard | Remote audio |
+| Screen view, keyboard, mouse | Remote audio |
+| Paste as keystrokes | Clipboard sync |
 | Reconnect, session end | Multi-monitor switching |
 | | Bitrate and quality controls |
 | | Secure attention sequence (Ctrl+Alt+Del) |
+| | Switching between user sessions |
+| | Low-latency cursor streaming |
 
 To get WebRTC, install the GStreamer plugin sets webkit2gtk uses for it, then relaunch the viewer:
 

--- a/apps/docs/src/content/docs/features/remote-access.mdx
+++ b/apps/docs/src/content/docs/features/remote-access.mdx
@@ -528,12 +528,12 @@ The Linux viewer renders in webkit2gtk, the system WebView, rather than bundling
 
 When that is the case the viewer detects it before connecting, skips WebRTC, and runs the session on the WebSocket (JPEG) transport instead. A notice in the session window explains the switch, and the toolbar badge reads **WS** rather than **WebRTC**. The session still works; you lose the WebRTC-only features:
 
-| Available on WebSocket | WebRTC only |
+| Available on WebSocket | Not available on WebSocket |
 |---|---|
 | Screen view, keyboard, mouse | Remote audio |
 | Paste as keystrokes | Clipboard sync |
-| Reconnect, session end | Multi-monitor switching |
-| | Bitrate and quality controls |
+| Quality, scale and FPS limit | Multi-monitor switching |
+| Reconnect, session end | Bitrate control |
 | | Secure attention sequence (Ctrl+Alt+Del) |
 | | Switching between user sessions |
 | | Low-latency cursor streaming |

--- a/apps/docs/src/content/docs/features/remote-access.mdx
+++ b/apps/docs/src/content/docs/features/remote-access.mdx
@@ -524,9 +524,9 @@ Extract-and-run unpacks the whole bundle on every launch, so sessions start noti
 
 ### WebRTC needs webkit2gtk built with the GStreamer plugins
 
-The Linux viewer renders in webkit2gtk, the system WebView, rather than bundling its own browser engine. Whether WebRTC is available therefore depends on how your distribution compiled webkit2gtk and which GStreamer plugins are installed — on a number of builds `RTCPeerConnection` is not exposed at all.
+The Linux viewer renders in webkit2gtk, the system WebView, rather than bundling its own browser engine. Whether WebRTC is available therefore depends on how your distribution compiled webkit2gtk and which GStreamer plugins are installed. This shows up two ways: on some builds `RTCPeerConnection` is not exposed at all, and on others it exists but fails the moment a connection is actually created.
 
-When that is the case the viewer detects it before connecting, skips WebRTC, and runs the session on the WebSocket (JPEG) transport instead. A notice in the session window explains the switch, and the toolbar badge reads **WS** rather than **WebRTC**. The session still works; you lose the WebRTC-only features:
+The viewer handles both. The first is detected before connecting, so WebRTC is skipped outright; the second is discovered on the first attempt, after which the viewer stops retrying WebRTC for the rest of the session. Either way it falls back to the WebSocket (JPEG) transport, a notice in the session window explains the switch, and the toolbar badge reads **WS** rather than **WebRTC**. The session still works; you lose the WebRTC-only features:
 
 | Available on WebSocket | Not available on WebSocket |
 |---|---|

--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -8,6 +8,7 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "test": "vitest",
+    "test:run": "vitest run",
     "tauri": "tauri"
   },
   "dependencies": {

--- a/apps/viewer/src/components/DesktopViewer.tsx
+++ b/apps/viewer/src/components/DesktopViewer.tsx
@@ -193,12 +193,26 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
   const [capabilities, setCapabilities] = useState<TransportCapabilities | null>(null);
   const [desktopState, setDesktopState] = useState<{ state: 'loginwindow' | 'user_session' | null; username: string | null }>({ state: null, username: null });
   const [webRTCAvailable, setWebRTCAvailable] = useState(false);
-  // Whether THIS WebView can construct an RTCPeerConnection at all (issue
-  // #3410). Deliberately distinct from `webRTCAvailable` above, which tracks
-  // whether the REMOTE macOS device is in a state where WebRTC capture works.
-  // A WebView either has WebRTC or it does not, and that never changes while
-  // the app is running, so it is read once via a lazy initializer.
+  // Whether THIS WebView can do WebRTC at all (issue #3410). Deliberately
+  // distinct from `webRTCAvailable` above, which tracks whether the REMOTE
+  // macOS device is in a state where WebRTC capture works.
+  //
+  // Two parts, because the capability is discovered in two stages. The cheap
+  // `typeof` probe runs once up front; but a webkit2gtk build missing its
+  // GStreamer plugins exposes the constructor and only throws on use, so the
+  // rest is learned from the first real attempt.
   const [webrtcSupported] = useState(isWebRTCSupported);
+  const [webrtcRuntimeUnusable, setWebrtcRuntimeUnusable] = useState(false);
+  const webrtcUsable = webrtcSupported && !webrtcRuntimeUnusable;
+  // The ref is what the connect/reconnect/switch paths read. They must NOT take
+  // `webrtcUsable` as a dependency: it is in the connect effect's closure, and
+  // flipping it would re-run that effect — a full teardown plus a second
+  // connect-code exchange — at the exact moment WebRTC just failed.
+  const webrtcUsableRef = useRef(webrtcSupported);
+  const markWebRTCUnusable = useCallback(() => {
+    webrtcUsableRef.current = false;
+    setWebrtcRuntimeUnusable(true);
+  }, []);
   const [webrtcNoticeDismissed, setWebrtcNoticeDismissed] = useState(false);
   const [remoteUserName, setRemoteUserName] = useState<string | null>(null);
   const [credentialsPrompt, setCredentialsPrompt] = useState<{ requiresUsername: boolean; submit: (creds: { username?: string; password: string }) => void } | null>(null);
@@ -370,7 +384,7 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
     // macOS auto-handoff is gated the same way, so reaching this means one of
     // those gates has drifted — hence error, not warn. A silent return here
     // would be a dead click with no feedback at all.
-    if (target === 'webrtc' && !webrtcSupported) {
+    if (target === 'webrtc' && !webrtcUsableRef.current) {
       console.error('Ignoring switch to WebRTC: this WebView has no RTCPeerConnection. A UI gate should have prevented this.');
       return;
     }
@@ -492,7 +506,7 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
       switchingToRef.current = null;
       setSwitchingTo(null);
     }
-  }, [connectVncTransport, setTransportState, webrtcSupported]);
+  }, [connectVncTransport, setTransportState]);
 
   // ── WebRTC connection ──────────────────────────────────────────────
 
@@ -579,6 +593,7 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
       },
       onCursorChannelOpen: () => setCursorStreamActive(true),
       onCursorChannelClose: () => setCursorStreamActive(false),
+      onWebRTCUnsupported: markWebRTCUnusable,
     });
 
     if (!sessionWrapper) return false;
@@ -601,7 +616,7 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
     // Hostname is already set from the exchange response before connectWebRTC is called.
     // Connection state will flip to 'connected' via onConnected callback.
     return true;
-  }, [defaultTargetSessionId]);
+  }, [defaultTargetSessionId, markWebRTCUnusable]);
 
   // Keep the forward ref in sync so switchTransport can call the latest version.
   connectWebRTCRef.current = connectWebRTC;
@@ -755,7 +770,7 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
     // to WebRTC, except on a WebView that has none: there WebSocket is the only
     // transport that can ever come back, and retrying WebRTC would burn the
     // entire 30s reconnect window on attempts that cannot succeed (issue #3410).
-    const originalTransport: Transport = recordedTransport ?? (webrtcSupported ? 'webrtc' : 'websocket');
+    const originalTransport: Transport = recordedTransport ?? (webrtcUsableRef.current ? 'webrtc' : 'websocket');
     if (!recordedTransport) {
       console.warn(`Reconnect: transport ref was null, defaulting to ${originalTransport}`);
     }
@@ -838,7 +853,7 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
     } finally {
       reconnectInFlightRef.current = false;
     }
-  }, [connectWebRTC, connectWebSocket, connectVncTransport, stopReconnect, remoteOs, webrtcSupported]);
+  }, [connectWebRTC, connectWebSocket, connectVncTransport, stopReconnect, remoteOs]);
 
   const startReconnect = useCallback(() => {
     if (!authRef.current || userDisconnectRef.current) return;
@@ -978,7 +993,7 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
         // Try WebRTC first — unless this WebView has no WebRTC at all, in which
         // case skip straight to WebSocket rather than paying a doomed signalling
         // round trip on every connect and reconnect (issue #3410).
-        const webrtcOk = webrtcSupported ? await connectWebRTC(authParams) : false;
+        const webrtcOk = webrtcUsableRef.current ? await connectWebRTC(authParams) : false;
         if (cancelled) {
           webrtcRef.current?.close();
           webrtcRef.current = null;
@@ -1076,7 +1091,7 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
 	        });
 	      }
 	    };
-	  }, [connectWebRTC, connectWebSocket, connectVncTransport, onError, params, stopReconnect, webrtcSupported]);
+	  }, [connectWebRTC, connectWebSocket, connectVncTransport, onError, params, stopReconnect]);
 
   // Mark a window as "session active" only when fully connected.
   // Pass session_id so Rust can detect duplicate deep links for the same session.
@@ -1342,10 +1357,12 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
       setWebRTCAvailable(mode === 'user_session');
       setRemoteUserName(result.poll.username);
 
-      // `webrtcSupported` first: this poll runs every 2s, so without it a
-      // WebRTC-less WebView would re-attempt the handoff (and trip the
-      // switchTransport backstop) on every tick (issue #3410).
-      if (webrtcSupported && shouldAutoHandoffToWebRTC({
+      // Capability first, so a WebRTC-less WebView never proposes the handoff
+      // at all. `shouldAutoHandoffToWebRTC` already latches on previousMode, so
+      // this saves a stray backstop log per login transition rather than one
+      // per 2s tick — but it keeps the decision where the other gates live
+      // instead of relying on the backstop to clean up (issue #3410).
+      if (webrtcUsableRef.current && shouldAutoHandoffToWebRTC({
         remoteOs,
         deviceId,
         currentTransport: transportRef.current,
@@ -1364,7 +1381,7 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
       cancelled = true;
       clearInterval(interval);
     };
-  }, [transport, remoteOs, status, webrtcSupported]);
+  }, [transport, remoteOs, status]);
 
   // ── Frame rendering (WebSocket JPEG path) ──────────────────────────
 
@@ -1998,7 +2015,7 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
         onCancelPaste={handleCancelPaste}
         reconnectSecondsLeft={reconnectSecondsLeft}
         webRTCAvailable={webRTCAvailable}
-        webrtcSupported={webrtcSupported}
+        webrtcSupported={webrtcUsable}
         remoteUserName={remoteUserName}
         desktopState={desktopState}
         onSwitchTransport={(target) => switchTransport(target, 'user')}
@@ -2076,7 +2093,7 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
             VNC deep links, which never attempt WebRTC at all) and made it vanish
             mid-session on the macOS websocket→VNC auto-handoff. Suppressed only
             while the fatal error overlay owns the screen. */}
-        {!webrtcSupported && status !== 'error' && !webrtcNoticeDismissed && (
+        {!webrtcUsable && status !== 'error' && status !== 'disconnected' && !webrtcNoticeDismissed && (
           <div
             role="status"
             aria-live="polite"

--- a/apps/viewer/src/components/DesktopViewer.tsx
+++ b/apps/viewer/src/components/DesktopViewer.tsx
@@ -59,15 +59,25 @@ const HANDSHAKE_REJECTED_MESSAGE =
   'The connection was refused before it opened. Retry to reconnect.';
 
 // Shown when this WebView has no WebRTC implementation at all, so the session
-// runs on the WebSocket/JPEG transport instead (issue #3410). This is normal on
-// Linux, where the Viewer renders in webkit2gtk and WebRTC is only present if
-// the distro built it with the GStreamer WebRTC plugins. Not an error — the
-// session works, just without the WebRTC-only extras (audio, multi-monitor,
-// bitrate control), so it is a notice rather than a failure state.
+// runs on a fallback transport instead (issue #3410). This is normal on Linux,
+// where the Viewer renders in webkit2gtk and WebRTC is only present if the
+// distro built it with the GStreamer WebRTC plugins. Not an error — the session
+// works, just without the WebRTC-only extras (audio, multi-monitor, bitrate
+// control), so it is a notice rather than a failure state.
+//
+// Deliberately does NOT name the fallback transport: the session can start on
+// WebSocket and later auto-hand-off to VNC, and naming one would either go
+// stale mid-session or force the notice to be gated on the current transport —
+// which is what previously hid it from every VNC session entirely.
+//
+// The feature list is the intersection of what the two fallbacks lose, per
+// `capabilitiesFor` in lib/transports/types.ts — VNC keeps clipboard sync while
+// WebSocket does not, so clipboard is deliberately not named here.
 const WEBRTC_UNSUPPORTED_MESSAGE =
-  'This system’s WebView has no WebRTC support, so the session is using the ' +
-  'compatibility (WebSocket) transport. Video will be lower quality, and audio, ' +
-  'multi-monitor and bitrate controls are unavailable.';
+  'This system’s WebView has no WebRTC support, so the session is using a ' +
+  'compatibility transport. Video quality is lower, and remote audio, ' +
+  'multi-monitor switching, bitrate controls, Ctrl+Alt+Del and session ' +
+  'switching are unavailable.';
 
 // Module-level dedupe for the one-time connect-code exchange.
 // React strict-mode in dev mounts → unmounts → remounts the component
@@ -355,11 +365,13 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
     }
     if (transportRef.current === target) return;
     // Never tear down a working session to switch to a transport this WebView
-    // cannot run. Guarding here covers both the toolbar's manual switch and the
-    // macOS auto-handoff, which are the only ways to reach WebRTC after the
-    // initial connect (issue #3410).
+    // cannot run (issue #3410). Backstop only: the toolbar already hides or
+    // disables both WebRTC affordances via `transportAvailability`, and the
+    // macOS auto-handoff is gated the same way, so reaching this means one of
+    // those gates has drifted — hence error, not warn. A silent return here
+    // would be a dead click with no feedback at all.
     if (target === 'webrtc' && !webrtcSupported) {
-      console.warn('Ignoring switch to WebRTC: this WebView has no RTCPeerConnection.');
+      console.error('Ignoring switch to WebRTC: this WebView has no RTCPeerConnection. A UI gate should have prevented this.');
       return;
     }
     const auth = authRef.current;
@@ -1330,7 +1342,10 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
       setWebRTCAvailable(mode === 'user_session');
       setRemoteUserName(result.poll.username);
 
-      if (shouldAutoHandoffToWebRTC({
+      // `webrtcSupported` first: this poll runs every 2s, so without it a
+      // WebRTC-less WebView would re-attempt the handoff (and trip the
+      // switchTransport backstop) on every tick (issue #3410).
+      if (webrtcSupported && shouldAutoHandoffToWebRTC({
         remoteOs,
         deviceId,
         currentTransport: transportRef.current,
@@ -1349,7 +1364,7 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
       cancelled = true;
       clearInterval(interval);
     };
-  }, [transport, remoteOs, status]);
+  }, [transport, remoteOs, status, webrtcSupported]);
 
   // ── Frame rendering (WebSocket JPEG path) ──────────────────────────
 
@@ -1784,6 +1799,11 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
     }
   }, []);
 
+  // Reconnects over WebRTC unconditionally, and deliberately carries no
+  // `webrtcSupported` guard: it is unreachable on a WebView without WebRTC.
+  // `sessions` is only ever populated from the WebRTC control channel, and the
+  // toolbar hides the session switcher behind `capabilities.sessionSwitch`,
+  // which is false for both fallback transports (issue #3410).
   const handleSwitchSession = useCallback(async (sessionId: number) => {
     if (switchingSessionRef.current) return;
     const auth = authRef.current;
@@ -1978,6 +1998,7 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
         onCancelPaste={handleCancelPaste}
         reconnectSecondsLeft={reconnectSecondsLeft}
         webRTCAvailable={webRTCAvailable}
+        webrtcSupported={webrtcSupported}
         remoteUserName={remoteUserName}
         desktopState={desktopState}
         onSwitchTransport={(target) => switchTransport(target, 'user')}
@@ -2048,9 +2069,14 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
 
         {/* WebRTC-unsupported notice (issue #3410).
             Non-modal and dismissible: the session works, so this explains the
-            degraded quality rather than blocking on it. Gated on the WebSocket
-            transport so it never contradicts what the toolbar badge shows. */}
-        {!webrtcSupported && transport === 'websocket' && !webrtcNoticeDismissed && (
+            degraded quality rather than blocking on it.
+
+            Gated on the capability, NOT on the resulting transport. Keying it to
+            `transport === 'websocket'` hid it from every VNC session (including
+            VNC deep links, which never attempt WebRTC at all) and made it vanish
+            mid-session on the macOS websocket→VNC auto-handoff. Suppressed only
+            while the fatal error overlay owns the screen. */}
+        {!webrtcSupported && status !== 'error' && !webrtcNoticeDismissed && (
           <div
             role="status"
             aria-live="polite"

--- a/apps/viewer/src/components/DesktopViewer.tsx
+++ b/apps/viewer/src/components/DesktopViewer.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useCallback, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { type ConnectionParams } from '../lib/protocol';
 import { exchangeDesktopConnectCode, exchangeVncConnectCode } from '../lib/api';
-import { scaleVideoCoords, AgentSessionError, SessionEndedError, type AuthenticatedConnectionParams } from '../lib/webrtc';
+import { scaleVideoCoords, isWebRTCSupported, AgentSessionError, SessionEndedError, type AuthenticatedConnectionParams } from '../lib/webrtc';
 import { connectWebRTC as connectWebRTCTransport, type WebRTCSessionWrapper } from '../lib/transports/webrtc';
 import { connectWebSocket as connectWebSocketTransport, type WebSocketSessionWrapper } from '../lib/transports/websocket';
 import { capabilitiesFor, type TransportCapabilities } from '../lib/transports/types';
@@ -57,6 +57,17 @@ const SESSION_ENDED_MESSAGE =
 // Retrying is safe and always mints a brand new one-time ticket.
 const HANDSHAKE_REJECTED_MESSAGE =
   'The connection was refused before it opened. Retry to reconnect.';
+
+// Shown when this WebView has no WebRTC implementation at all, so the session
+// runs on the WebSocket/JPEG transport instead (issue #3410). This is normal on
+// Linux, where the Viewer renders in webkit2gtk and WebRTC is only present if
+// the distro built it with the GStreamer WebRTC plugins. Not an error — the
+// session works, just without the WebRTC-only extras (audio, multi-monitor,
+// bitrate control), so it is a notice rather than a failure state.
+const WEBRTC_UNSUPPORTED_MESSAGE =
+  'This system’s WebView has no WebRTC support, so the session is using the ' +
+  'compatibility (WebSocket) transport. Video will be lower quality, and audio, ' +
+  'multi-monitor and bitrate controls are unavailable.';
 
 // Module-level dedupe for the one-time connect-code exchange.
 // React strict-mode in dev mounts → unmounts → remounts the component
@@ -172,6 +183,13 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
   const [capabilities, setCapabilities] = useState<TransportCapabilities | null>(null);
   const [desktopState, setDesktopState] = useState<{ state: 'loginwindow' | 'user_session' | null; username: string | null }>({ state: null, username: null });
   const [webRTCAvailable, setWebRTCAvailable] = useState(false);
+  // Whether THIS WebView can construct an RTCPeerConnection at all (issue
+  // #3410). Deliberately distinct from `webRTCAvailable` above, which tracks
+  // whether the REMOTE macOS device is in a state where WebRTC capture works.
+  // A WebView either has WebRTC or it does not, and that never changes while
+  // the app is running, so it is read once via a lazy initializer.
+  const [webrtcSupported] = useState(isWebRTCSupported);
+  const [webrtcNoticeDismissed, setWebrtcNoticeDismissed] = useState(false);
   const [remoteUserName, setRemoteUserName] = useState<string | null>(null);
   const [credentialsPrompt, setCredentialsPrompt] = useState<{ requiresUsername: boolean; submit: (creds: { username?: string; password: string }) => void } | null>(null);
   // Bumped every time a new WebRTC connection is established (initial connect
@@ -336,6 +354,14 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
       return;
     }
     if (transportRef.current === target) return;
+    // Never tear down a working session to switch to a transport this WebView
+    // cannot run. Guarding here covers both the toolbar's manual switch and the
+    // macOS auto-handoff, which are the only ways to reach WebRTC after the
+    // initial connect (issue #3410).
+    if (target === 'webrtc' && !webrtcSupported) {
+      console.warn('Ignoring switch to WebRTC: this WebView has no RTCPeerConnection.');
+      return;
+    }
     const auth = authRef.current;
     if (!auth) return;
 
@@ -454,7 +480,7 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
       switchingToRef.current = null;
       setSwitchingTo(null);
     }
-  }, [connectVncTransport, setTransportState]);
+  }, [connectVncTransport, setTransportState, webrtcSupported]);
 
   // ── WebRTC connection ──────────────────────────────────────────────
 
@@ -712,9 +738,14 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
     oldRtc?.close();
 
     reconnectInFlightRef.current = true;
-    const originalTransport = transportRef.current;
-    if (!originalTransport) {
-      console.warn('Reconnect: transport ref was null, defaulting to WebRTC');
+    const recordedTransport = transportRef.current;
+    // No transport recorded — the drop beat the first successful connect. Default
+    // to WebRTC, except on a WebView that has none: there WebSocket is the only
+    // transport that can ever come back, and retrying WebRTC would burn the
+    // entire 30s reconnect window on attempts that cannot succeed (issue #3410).
+    const originalTransport: Transport = recordedTransport ?? (webrtcSupported ? 'webrtc' : 'websocket');
+    if (!recordedTransport) {
+      console.warn(`Reconnect: transport ref was null, defaulting to ${originalTransport}`);
     }
     try {
       if (originalTransport === 'websocket') {
@@ -795,7 +826,7 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
     } finally {
       reconnectInFlightRef.current = false;
     }
-  }, [connectWebRTC, connectWebSocket, connectVncTransport, stopReconnect, remoteOs]);
+  }, [connectWebRTC, connectWebSocket, connectVncTransport, stopReconnect, remoteOs, webrtcSupported]);
 
   const startReconnect = useCallback(() => {
     if (!authRef.current || userDisconnectRef.current) return;
@@ -932,8 +963,10 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
           setRemoteOs(exchange.osType);
         }
 
-        // Try WebRTC first
-        const webrtcOk = await connectWebRTC(authParams);
+        // Try WebRTC first — unless this WebView has no WebRTC at all, in which
+        // case skip straight to WebSocket rather than paying a doomed signalling
+        // round trip on every connect and reconnect (issue #3410).
+        const webrtcOk = webrtcSupported ? await connectWebRTC(authParams) : false;
         if (cancelled) {
           webrtcRef.current?.close();
           webrtcRef.current = null;
@@ -1031,7 +1064,7 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
 	        });
 	      }
 	    };
-	  }, [connectWebRTC, connectWebSocket, connectVncTransport, onError, params, stopReconnect]);
+	  }, [connectWebRTC, connectWebSocket, connectVncTransport, onError, params, stopReconnect, webrtcSupported]);
 
   // Mark a window as "session active" only when fully connected.
   // Pass session_id so Rust can detect duplicate deep links for the same session.
@@ -2011,6 +2044,29 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
               handleDisconnect();
             }}
           />
+        )}
+
+        {/* WebRTC-unsupported notice (issue #3410).
+            Non-modal and dismissible: the session works, so this explains the
+            degraded quality rather than blocking on it. Gated on the WebSocket
+            transport so it never contradicts what the toolbar badge shows. */}
+        {!webrtcSupported && transport === 'websocket' && !webrtcNoticeDismissed && (
+          <div
+            role="status"
+            aria-live="polite"
+            className="absolute top-3 left-1/2 -translate-x-1/2 z-30 max-w-xl flex items-start gap-2 px-3 py-2 rounded bg-amber-900/90 border border-amber-700 text-amber-100 text-xs shadow-lg"
+          >
+            <span className="flex-1">{WEBRTC_UNSUPPORTED_MESSAGE}</span>
+            <button
+              type="button"
+              onClick={() => setWebrtcNoticeDismissed(true)}
+              className="shrink-0 text-amber-400 hover:text-amber-100"
+              title="Dismiss"
+              aria-label="Dismiss WebRTC compatibility notice"
+            >
+              ✕
+            </button>
+          </div>
         )}
 
         {/* Transport-switching overlay */}

--- a/apps/viewer/src/components/DesktopViewer.tsx
+++ b/apps/viewer/src/components/DesktopViewer.tsx
@@ -2091,8 +2091,9 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
             Gated on the capability, NOT on the resulting transport. Keying it to
             `transport === 'websocket'` hid it from every VNC session (including
             VNC deep links, which never attempt WebRTC at all) and made it vanish
-            mid-session on the macOS websocket→VNC auto-handoff. Suppressed only
-            while the fatal error overlay owns the screen. */}
+            mid-session on the macOS websocket→VNC auto-handoff. Suppressed while
+            a full-screen overlay owns the view — the fatal error card and the
+            "Session Ended" card. */}
         {!webrtcUsable && status !== 'error' && status !== 'disconnected' && !webrtcNoticeDismissed && (
           <div
             role="status"

--- a/apps/viewer/src/components/ViewerToolbar.tsx
+++ b/apps/viewer/src/components/ViewerToolbar.tsx
@@ -3,6 +3,7 @@ import type { ComponentType } from 'react';
 import { Monitor, Wifi, WifiOff, Maximize, Minimize, Keyboard, ClipboardPaste, ChevronDown, X, ArrowLeftRight, Volume2, VolumeX, MousePointer2, Check, Zap, MoreVertical, SlidersHorizontal } from 'lucide-react';
 import type { TransportCapabilities } from '../lib/transports/types';
 import { transportHasQualityControls } from '../lib/transportTuning';
+import { webrtcSwitchUnavailableReason, shouldShowWebRTCSwitchPill } from '../lib/transportAvailability';
 
 interface MonitorInfo {
   index: number;
@@ -53,6 +54,14 @@ interface Props {
   onCancelPaste: () => void;
   /** True when a user session is active on the remote device and WebRTC is available (for Switch pill). */
   webRTCAvailable?: boolean;
+  /**
+   * Whether THIS WebView can construct an RTCPeerConnection at all — distinct
+   * from `webRTCAvailable`, which is about the remote device. False on Linux
+   * webkit2gtk builds without WebRTC, where offering the switch would produce a
+   * dead control (issue #3410). Defaults to true so existing callers are
+   * unaffected.
+   */
+  webrtcSupported?: boolean;
   /** The logged-in username on the remote end (for Switch pill label). */
   remoteUserName?: string | null;
   /** Current desktop state from agent control-channel events. */
@@ -165,6 +174,7 @@ export default function ViewerToolbar({
   onCancelPaste,
   reconnectSecondsLeft,
   webRTCAvailable = false,
+  webrtcSupported = true,
   remoteUserName = null,
   desktopState,
   onSwitchTransport,
@@ -298,11 +308,13 @@ export default function ViewerToolbar({
   }, [webRTCAvailable]);
 
   // Auto-dismiss the "Switch to WebRTC" pill after 30 seconds
-  const showSwitchPill =
-    transport === 'vnc' &&
-    remoteOs === 'macos' &&
-    webRTCAvailable &&
-    !pillDismissed;
+  const showSwitchPill = shouldShowWebRTCSwitchPill({
+    transport,
+    remoteOs,
+    webRTCAvailable,
+    webrtcSupported,
+    pillDismissed,
+  });
 
   useEffect(() => {
     if (!showSwitchPill) return;
@@ -374,22 +386,33 @@ export default function ViewerToolbar({
                 <div className="absolute left-0 top-full mt-1 w-40 bg-gray-800 border border-gray-600 rounded-lg shadow-xl z-50 py-1">
                   {(['webrtc', 'vnc'] as const).map((opt) => {
                     const isActive = transport === opt;
-                    const isLoginWindow = opt === 'webrtc' && desktopState?.state === 'loginwindow';
+                    // Non-null only for 'webrtc', and only when something makes
+                    // the switch impossible — a WebView with no WebRTC, or a
+                    // remote sitting at the login window. Doubles as the tooltip
+                    // so a greyed-out row always says why (issue #3410).
+                    const unavailableReason =
+                      opt === 'webrtc'
+                        ? webrtcSwitchUnavailableReason({
+                            webrtcSupported,
+                            desktopState: desktopState?.state,
+                          })
+                        : null;
+                    const isUnavailable = unavailableReason !== null;
                     return (
                       <button
                         key={opt}
-                        disabled={isActive || isLoginWindow}
+                        disabled={isActive || isUnavailable}
                         onClick={() => {
-                          if (!isActive && !isLoginWindow) {
+                          if (!isActive && !isUnavailable) {
                             onSwitchTransport?.(opt);
                           }
                           setTransportDropdownOpen(false);
                         }}
-                        title={isLoginWindow ? 'WebRTC unavailable: device is at login window' : undefined}
+                        title={unavailableReason ?? undefined}
                         className={`w-full flex items-center justify-between px-3 py-1.5 text-xs text-left ${
                           isActive
                             ? 'text-gray-200 cursor-default'
-                            : isLoginWindow
+                            : isUnavailable
                             ? 'text-gray-500 cursor-not-allowed'
                             : 'text-gray-300 hover:bg-gray-700'
                         }`}

--- a/apps/viewer/src/components/ViewerToolbar.tsx
+++ b/apps/viewer/src/components/ViewerToolbar.tsx
@@ -401,7 +401,14 @@ export default function ViewerToolbar({
                     return (
                       <button
                         key={opt}
-                        disabled={isActive || isUnavailable}
+                        // Deliberately NOT `disabled` when unavailable: browsers
+                        // suppress pointer events on disabled controls, so the
+                        // `title` explaining WHY would never appear and the row
+                        // would be an unfocusable grey blank. aria-disabled +
+                        // the no-op click below gives the same semantics while
+                        // keeping the tooltip and screen-reader text.
+                        disabled={isActive}
+                        aria-disabled={isUnavailable || undefined}
                         onClick={() => {
                           if (!isActive && !isUnavailable) {
                             onSwitchTransport?.(opt);

--- a/apps/viewer/src/lib/transportAvailability.test.ts
+++ b/apps/viewer/src/lib/transportAvailability.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import {
+  WEBRTC_UNSUPPORTED_HINT,
+  webrtcSwitchUnavailableReason,
+  shouldShowWebRTCSwitchPill,
+} from './transportAvailability';
+
+// Issue #3410. Skipping WebRTC on a WebView that has none is only half a fix:
+// the toolbar still offered the switch, and clicking it did nothing at all —
+// quieter than the crash it replaced. These predicates gate those controls.
+
+describe('webrtcSwitchUnavailableReason', () => {
+  it('blocks the switch when the WebView has no WebRTC', () => {
+    expect(
+      webrtcSwitchUnavailableReason({ webrtcSupported: false, desktopState: 'user_session' }),
+    ).toBe(WEBRTC_UNSUPPORTED_HINT);
+  });
+
+  it('still blocks at the login window when WebRTC is supported', () => {
+    expect(
+      webrtcSwitchUnavailableReason({ webrtcSupported: true, desktopState: 'loginwindow' }),
+    ).toMatch(/login window/);
+  });
+
+  it('reports the WebView gap ahead of the login window — the WebView one is permanent', () => {
+    expect(
+      webrtcSwitchUnavailableReason({ webrtcSupported: false, desktopState: 'loginwindow' }),
+    ).toBe(WEBRTC_UNSUPPORTED_HINT);
+  });
+
+  it('allows the switch when WebRTC works and a user is logged in', () => {
+    expect(
+      webrtcSwitchUnavailableReason({ webrtcSupported: true, desktopState: 'user_session' }),
+    ).toBeNull();
+  });
+
+  it('allows the switch when desktop state is unknown', () => {
+    expect(
+      webrtcSwitchUnavailableReason({ webrtcSupported: true, desktopState: null }),
+    ).toBeNull();
+  });
+});
+
+describe('shouldShowWebRTCSwitchPill', () => {
+  const offerable = {
+    transport: 'vnc',
+    remoteOs: 'macos',
+    webRTCAvailable: true,
+    webrtcSupported: true,
+    pillDismissed: false,
+  };
+
+  it('offers the switch when the remote is ready and this WebView can do WebRTC', () => {
+    expect(shouldShowWebRTCSwitchPill(offerable)).toBe(true);
+  });
+
+  it('never invites a click this WebView cannot honour', () => {
+    // webRTCAvailable describes the REMOTE macOS device, so on its own it
+    // actively invites a click that the switchTransport guard would swallow.
+    expect(shouldShowWebRTCSwitchPill({ ...offerable, webrtcSupported: false })).toBe(false);
+  });
+
+  it.each([
+    ['not on VNC', { transport: 'websocket' }],
+    ['remote is not macOS', { remoteOs: 'windows' }],
+    ['remote WebRTC not available', { webRTCAvailable: false }],
+    ['already dismissed', { pillDismissed: true }],
+  ])('stays hidden when %s', (_label, override) => {
+    expect(shouldShowWebRTCSwitchPill({ ...offerable, ...override })).toBe(false);
+  });
+});

--- a/apps/viewer/src/lib/transportAvailability.ts
+++ b/apps/viewer/src/lib/transportAvailability.ts
@@ -25,7 +25,11 @@ export const WEBRTC_LOGIN_WINDOW_HINT = 'WebRTC unavailable: device is at login 
  * always carries its reason rather than being inertly greyed out.
  */
 export function webrtcSwitchUnavailableReason(params: {
-  /** Whether THIS WebView can construct an RTCPeerConnection. */
+  /**
+   * Whether THIS WebView can actually do WebRTC — the up-front `typeof` probe
+   * AND the runtime discovery, since a build can expose RTCPeerConnection and
+   * still throw on use. Callers pass the combined value.
+   */
   webrtcSupported: boolean;
   /** Remote macOS session state, when known. */
   desktopState: string | null | undefined;
@@ -48,7 +52,7 @@ export function shouldShowWebRTCSwitchPill(params: {
   remoteOs: string | null;
   /** Remote device is in a state where WebRTC capture works. */
   webRTCAvailable: boolean;
-  /** This WebView can construct an RTCPeerConnection. */
+  /** This WebView can actually do WebRTC (probe AND runtime discovery). */
   webrtcSupported: boolean;
   pillDismissed: boolean;
 }): boolean {

--- a/apps/viewer/src/lib/transportAvailability.ts
+++ b/apps/viewer/src/lib/transportAvailability.ts
@@ -1,0 +1,62 @@
+/**
+ * Whether the WebRTC transport can be *offered* to the operator right now.
+ *
+ * Kept out of the components on purpose: the same two facts gate a dropdown
+ * option, a call-to-action pill and the `switchTransport` guard, and when those
+ * drifted apart the toolbar happily invited a click that silently did nothing
+ * (issue #3410). Pure predicates keep the three in step and testable without a
+ * DOM — same shape as `autoHandoff.ts`.
+ */
+
+/**
+ * Shown when this WebView cannot do WebRTC at all. Unlike the login-window
+ * case, this never resolves while the app is running — no amount of waiting or
+ * logging in on the remote machine changes it.
+ */
+export const WEBRTC_UNSUPPORTED_HINT =
+  "WebRTC unavailable: this system's WebView has no WebRTC support";
+
+export const WEBRTC_LOGIN_WINDOW_HINT = 'WebRTC unavailable: device is at login window';
+
+/**
+ * Why a switch to WebRTC is unavailable, or `null` when it can be offered.
+ *
+ * The returned string doubles as the control's tooltip, so a disabled option
+ * always carries its reason rather than being inertly greyed out.
+ */
+export function webrtcSwitchUnavailableReason(params: {
+  /** Whether THIS WebView can construct an RTCPeerConnection. */
+  webrtcSupported: boolean;
+  /** Remote macOS session state, when known. */
+  desktopState: string | null | undefined;
+}): string | null {
+  // Ordered deliberately: the WebView gap is permanent, so it is the more
+  // useful thing to report when both apply.
+  if (!params.webrtcSupported) return WEBRTC_UNSUPPORTED_HINT;
+  if (params.desktopState === 'loginwindow') return WEBRTC_LOGIN_WINDOW_HINT;
+  return null;
+}
+
+/**
+ * Whether to show the "user logged in — switch to WebRTC" pill.
+ *
+ * `webRTCAvailable` describes the *remote* macOS device, so on its own it will
+ * happily advertise a switch that this WebView could never perform.
+ */
+export function shouldShowWebRTCSwitchPill(params: {
+  transport: string | null;
+  remoteOs: string | null;
+  /** Remote device is in a state where WebRTC capture works. */
+  webRTCAvailable: boolean;
+  /** This WebView can construct an RTCPeerConnection. */
+  webrtcSupported: boolean;
+  pillDismissed: boolean;
+}): boolean {
+  return (
+    params.transport === 'vnc' &&
+    params.remoteOs === 'macos' &&
+    params.webRTCAvailable &&
+    params.webrtcSupported &&
+    !params.pillDismissed
+  );
+}

--- a/apps/viewer/src/lib/transports/webrtc.test.ts
+++ b/apps/viewer/src/lib/transports/webrtc.test.ts
@@ -40,6 +40,7 @@ function makeDeps(): WebRTCDeps {
     onClipboardChannel: vi.fn(),
     onCursorChannelOpen: vi.fn(),
     onCursorChannelClose: vi.fn(),
+    onWebRTCUnsupported: vi.fn(),
   };
 }
 
@@ -71,6 +72,47 @@ describe('connectWebRTC — WebView without WebRTC (issue #3410)', () => {
     // capability gap in this WebView.
     expect(logged).not.toMatch(/WebRTC connection failed/);
     expect(logged).toMatch(/websocket/i);
+  });
+
+  it('tells the caller WebRTC is unusable, so the UI can latch it', async () => {
+    removeRTCPeerConnection();
+    vi.stubGlobal('fetch', vi.fn());
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const deps = makeDeps();
+
+    await connectWebRTC(auth, deps);
+
+    // Without this the discovery dies here: connectWebRTC returns null for both
+    // "unsupported" and "attempt failed", so the component could never gate its
+    // notice or its toolbar affordances on it.
+    expect(deps.onWebRTCUnsupported).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT report unusable when WebRTC merely fails to connect', async () => {
+    // A reachable WebRTC stack whose signalling fails must stay retryable —
+    // latching it as unsupported would wrongly disable WebRTC for the session.
+    vi.stubGlobal(
+      'RTCPeerConnection',
+      class {
+        iceGatheringState = 'complete';
+        localDescription = { sdp: 'v=0', type: 'offer' };
+        addTransceiver() {}
+        createDataChannel() {
+          return { close() {}, bufferedAmountLowThreshold: 0 };
+        }
+        async createOffer() {
+          return { sdp: 'v=0', type: 'offer' };
+        }
+        async setLocalDescription() {}
+        close() {}
+      },
+    );
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 500, headers: new Headers(), text: async () => 'boom', json: async () => ({}) })));
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const deps = makeDeps();
+
+    await expect(connectWebRTC(auth, deps)).resolves.toBeNull();
+    expect(deps.onWebRTCUnsupported).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/viewer/src/lib/transports/webrtc.test.ts
+++ b/apps/viewer/src/lib/transports/webrtc.test.ts
@@ -44,13 +44,16 @@ function makeDeps(): WebRTCDeps {
 }
 
 describe('connectWebRTC — WebView without WebRTC (issue #3410)', () => {
-  it('resolves to null so the caller falls back, instead of rejecting', async () => {
+  it('short-circuits before any signalling traffic, and resolves null to fall back', async () => {
     removeRTCPeerConnection();
     const fetchSpy = vi.fn();
     vi.stubGlobal('fetch', fetchSpy);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     await expect(connectWebRTC(auth, makeDeps())).resolves.toBeNull();
-    // The guard must short-circuit before any signalling traffic.
+    // The `toBeNull` half is NOT discriminating on its own — the generic catch
+    // also returns null. This assertion is the one that fails if the guard in
+    // createWebRTCSession is removed.
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
@@ -69,17 +72,16 @@ describe('connectWebRTC — WebView without WebRTC (issue #3410)', () => {
     expect(logged).not.toMatch(/WebRTC connection failed/);
     expect(logged).toMatch(/websocket/i);
   });
-
-  it('does not fire the failure lifecycle callbacks that drive reconnect', async () => {
-    removeRTCPeerConnection();
-    vi.stubGlobal('fetch', vi.fn());
-    vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const deps = makeDeps();
-
-    await connectWebRTC(auth, deps);
-
-    // An unsupported WebView is permanent — retrying WebRTC is pure waste.
-    expect(deps.onFailed).not.toHaveBeenCalled();
-    expect(deps.onConnected).not.toHaveBeenCalled();
-  });
 });
+
+// NOTE ON LOG-COUPLING: the assertions above match on warning prose, which is
+// normally brittle. It is unavoidable here — the unsupported branch and the
+// generic catch both `return null`, so the log is the ONLY observable
+// difference between them. If you are rewording that warning, update these
+// assertions; do not delete them, because they are the only guard on the
+// branch existing at all.
+//
+// Deliberately NOT tested: that onFailed/onConnected stay unfired. Those are
+// only ever invoked from a live `pc.onconnectionstatechange` handler, so any
+// throw from createWebRTCSession skips them regardless of this PR's changes —
+// such a test passes under every mutation and guards nothing.

--- a/apps/viewer/src/lib/transports/webrtc.test.ts
+++ b/apps/viewer/src/lib/transports/webrtc.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { connectWebRTC, type WebRTCDeps } from './webrtc';
+import type { AuthenticatedConnectionParams } from '../webrtc';
+
+const globalScope = globalThis as Record<string, unknown>;
+
+/**
+ * Remove the global outright rather than stubbing it to `undefined` — only a
+ * genuinely absent identifier reproduces the webkit2gtk ReferenceError that
+ * issue #3410 is about.
+ */
+function removeRTCPeerConnection(): void {
+  delete globalScope.RTCPeerConnection;
+}
+
+afterEach(() => {
+  delete globalScope.RTCPeerConnection;
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const auth: AuthenticatedConnectionParams = {
+  sessionId: 'sess-3410',
+  apiUrl: 'https://api.example.com',
+  accessToken: 'viewer-token',
+  deviceId: 'dev-1',
+};
+
+function makeDeps(): WebRTCDeps {
+  return {
+    videoElement: document.createElement('video'),
+    cursorOverlayRef: { current: null },
+    showRemoteCursorRef: { current: false },
+    remoteCursorShapeRef: { current: 'default' },
+    onConnected: vi.fn(),
+    onDisconnected: vi.fn(),
+    onFailed: vi.fn(),
+    onClosed: vi.fn(),
+    onAudioTrack: vi.fn(),
+    onClipboardChannel: vi.fn(),
+    onCursorChannelOpen: vi.fn(),
+    onCursorChannelClose: vi.fn(),
+  };
+}
+
+describe('connectWebRTC — WebView without WebRTC (issue #3410)', () => {
+  it('resolves to null so the caller falls back, instead of rejecting', async () => {
+    removeRTCPeerConnection();
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    await expect(connectWebRTC(auth, makeDeps())).resolves.toBeNull();
+    // The guard must short-circuit before any signalling traffic.
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('logs a cause the operator can act on, not a raw ReferenceError dump', async () => {
+    removeRTCPeerConnection();
+    vi.stubGlobal('fetch', vi.fn());
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await connectWebRTC(auth, makeDeps());
+
+    const logged = warn.mock.calls.map((args) => args.map(String).join(' ')).join('\n');
+    expect(logged).toMatch(/webrtc/i);
+    // The old log was the generic 'WebRTC connection failed:' + the caught
+    // ReferenceError, which reads as a transient fault rather than a permanent
+    // capability gap in this WebView.
+    expect(logged).not.toMatch(/WebRTC connection failed/);
+    expect(logged).toMatch(/websocket/i);
+  });
+
+  it('does not fire the failure lifecycle callbacks that drive reconnect', async () => {
+    removeRTCPeerConnection();
+    vi.stubGlobal('fetch', vi.fn());
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const deps = makeDeps();
+
+    await connectWebRTC(auth, deps);
+
+    // An unsupported WebView is permanent — retrying WebRTC is pure waste.
+    expect(deps.onFailed).not.toHaveBeenCalled();
+    expect(deps.onConnected).not.toHaveBeenCalled();
+  });
+});

--- a/apps/viewer/src/lib/transports/webrtc.ts
+++ b/apps/viewer/src/lib/transports/webrtc.ts
@@ -4,7 +4,7 @@
  * React refs/state are threaded in via WebRTCDeps callbacks.
  */
 
-import { createWebRTCSession, AgentSessionError, SessionEndedError, type AuthenticatedConnectionParams } from '../webrtc';
+import { createWebRTCSession, AgentSessionError, SessionEndedError, WebRTCUnsupportedError, type AuthenticatedConnectionParams } from '../webrtc';
 import type { TransportSession } from './types';
 import { capabilitiesFor } from './types';
 
@@ -195,6 +195,19 @@ export async function connectWebRTC(
     // dead sessionId and the viewer shows a terminal "session ended" state.
     if (err instanceof SessionEndedError) {
       throw err;
+    }
+    // This WebView has no WebRTC implementation at all (commonly a Linux
+    // webkit2gtk build without the GStreamer WebRTC plugins — issue #3410).
+    // That is a permanent capability gap, not a failed attempt, so say so
+    // plainly instead of logging it as a connection failure that a retry might
+    // clear. Returning null routes the caller to the WebSocket transport.
+    if (err instanceof WebRTCUnsupportedError) {
+      console.warn(
+        'WebRTC is unavailable in this WebView (no RTCPeerConnection global) — ' +
+          'using the WebSocket transport instead. On Linux this usually means the ' +
+          'webkit2gtk build is missing its GStreamer WebRTC plugins.',
+      );
+      return null;
     }
     console.warn('WebRTC connection failed:', err);
     return null;

--- a/apps/viewer/src/lib/transports/webrtc.ts
+++ b/apps/viewer/src/lib/transports/webrtc.ts
@@ -26,6 +26,15 @@ export interface WebRTCDeps {
   onClipboardChannel: (channel: RTCDataChannel) => void;
   onCursorChannelOpen: () => void;
   onCursorChannelClose: () => void;
+  /**
+   * This WebView cannot do WebRTC at all, so every future attempt is wasted.
+   *
+   * Needed because `connectWebRTC` returns `null` for BOTH "unsupported" and
+   * "attempt failed" — without this signal the discovery dies here and the
+   * component can never gate its notice or its toolbar affordances on it
+   * (issue #3410). Fires only for a permanent gap, never for a failed attempt.
+   */
+  onWebRTCUnsupported?: () => void;
 }
 
 export interface WebRTCSessionWrapper extends TransportSession {
@@ -202,11 +211,11 @@ export async function connectWebRTC(
     // plainly instead of logging it as a connection failure that a retry might
     // clear. Returning null routes the caller to the WebSocket transport.
     if (err instanceof WebRTCUnsupportedError) {
-      console.warn(
-        'WebRTC is unavailable in this WebView (no RTCPeerConnection global) — ' +
-          'using the WebSocket transport instead. On Linux this usually means the ' +
-          'webkit2gtk build is missing its GStreamer WebRTC plugins.',
-      );
+      // Carry the error's own message rather than restating a cause: it may be
+      // a missing RTCPeerConnection global OR a constructor that exists and
+      // throws, and those point at different things to go fix.
+      console.warn(`WebRTC is unavailable in this WebView — using the WebSocket transport instead. ${err.message}`);
+      deps.onWebRTCUnsupported?.();
       return null;
     }
     console.warn('WebRTC connection failed:', err);

--- a/apps/viewer/src/lib/webrtc.test.ts
+++ b/apps/viewer/src/lib/webrtc.test.ts
@@ -174,6 +174,52 @@ describe('createWebRTCSession — RTCPeerConnection present but unusable', () =>
     expect(String(err.message)).toContain('WebRTC is not supported in this build');
   });
 
+  it('retries STUN-only before blaming the WebView, so a bad TURN config is not misdiagnosed', async () => {
+    // iceServers come from the API unvalidated. A malformed `urls` or a TURN
+    // entry missing credentials makes the constructor throw — which must not be
+    // reported as "this WebView has no WebRTC", or one bad server row would
+    // permanently disable WebRTC for every viewer.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        json: async () => ({ iceServers: [{ urls: 'not-a-valid-url' }] }),
+        text: async () => '{}',
+      })),
+    );
+    const configs: RTCConfiguration[] = [];
+    vi.stubGlobal(
+      'RTCPeerConnection',
+      class {
+        iceGatheringState = 'complete';
+        localDescription = null;
+        constructor(config: RTCConfiguration) {
+          configs.push(config);
+          if (configs.length === 1) throw new SyntaxError('Invalid ICE server URL');
+        }
+        addTransceiver() {}
+        createDataChannel() {
+          return { close() {}, bufferedAmountLowThreshold: 0 };
+        }
+        async createOffer() {
+          return { sdp: 'v=0', type: 'offer' };
+        }
+        async setLocalDescription() {}
+        close() {}
+      },
+    );
+
+    const err = await createWebRTCSession(params, document.createElement('video')).catch((e) => e);
+
+    expect(configs).toHaveLength(2);
+    // Second attempt drops the server-supplied list for the built-in STUN default.
+    expect(configs[1].iceServers).toEqual([{ urls: 'stun:stun.l.google.com:19302' }]);
+    // It got past construction, so it must NOT be classed as an unusable WebView.
+    expect(err).not.toBeInstanceOf(WebRTCUnsupportedError);
+  });
+
   it('maps a throwing createDataChannel to WebRTCUnsupportedError and closes the connection', async () => {
     stubIceFetch();
     const close = vi.fn();

--- a/apps/viewer/src/lib/webrtc.test.ts
+++ b/apps/viewer/src/lib/webrtc.test.ts
@@ -131,3 +131,69 @@ describe('createWebRTCSession — missing RTCPeerConnection', () => {
   });
 });
 
+// A webkit2gtk build missing its GStreamer WebRTC plugins is the case the issue
+// actually describes, and there the global usually EXISTS while construction
+// fails. A `typeof` probe alone would call that supported and let the failure
+// resurface as a generic "connection failed", so construction is guarded too.
+describe('createWebRTCSession — RTCPeerConnection present but unusable', () => {
+  const params: AuthenticatedConnectionParams = {
+    sessionId: 'sess-3410',
+    apiUrl: 'https://api.example.com',
+    accessToken: 'viewer-token',
+  };
+
+  function stubIceFetch(): void {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        json: async () => ({ iceServers: [] }),
+        text: async () => '{}',
+      })),
+    );
+  }
+
+  it('maps a throwing constructor to WebRTCUnsupportedError', async () => {
+    stubIceFetch();
+    vi.stubGlobal(
+      'RTCPeerConnection',
+      class {
+        constructor() {
+          throw new TypeError('WebRTC is not supported in this build');
+        }
+      },
+    );
+
+    const err = await createWebRTCSession(params, document.createElement('video')).catch((e) => e);
+
+    expect(err).toBeInstanceOf(WebRTCUnsupportedError);
+    // The underlying cause must survive — it is the only clue about which
+    // part of the WebView stack is missing.
+    expect(String(err.message)).toContain('WebRTC is not supported in this build');
+  });
+
+  it('maps a throwing createDataChannel to WebRTCUnsupportedError and closes the connection', async () => {
+    stubIceFetch();
+    const close = vi.fn();
+    vi.stubGlobal(
+      'RTCPeerConnection',
+      class {
+        close = close;
+        addTransceiver() {}
+        createDataChannel(): never {
+          throw new DOMException('Not implemented', 'NotSupportedError');
+        }
+      },
+    );
+
+    const err = await createWebRTCSession(params, document.createElement('video')).catch((e) => e);
+
+    expect(err).toBeInstanceOf(WebRTCUnsupportedError);
+    // Without this the half-built peer connection leaks — `close` is only
+    // defined further down, after the channels are created.
+    expect(close).toHaveBeenCalled();
+  });
+});
+

--- a/apps/viewer/src/lib/webrtc.test.ts
+++ b/apps/viewer/src/lib/webrtc.test.ts
@@ -211,6 +211,8 @@ describe('createWebRTCSession — RTCPeerConnection present but unusable', () =>
       },
     );
 
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
     const err = await createWebRTCSession(params, document.createElement('video')).catch((e) => e);
 
     expect(configs).toHaveLength(2);
@@ -218,6 +220,13 @@ describe('createWebRTCSession — RTCPeerConnection present but unusable', () =>
     expect(configs[1].iceServers).toEqual([{ urls: 'stun:stun.l.google.com:19302' }]);
     // It got past construction, so it must NOT be classed as an unusable WebView.
     expect(err).not.toBeInstanceOf(WebRTCUnsupportedError);
+    // The retry must not be silent: it drops the configured TURN relay, so a
+    // session that later fails at ICE would otherwise surface as a generic
+    // "WebRTC connection failed" with the real cause never named.
+    const logged = warn.mock.calls.map((a) => a.map(String).join(' ')).join('\n');
+    expect(logged).toMatch(/ice/i);
+    expect(logged).toMatch(/turn/i);
+    expect(logged).toContain('Invalid ICE server URL');
   });
 
   it('maps a throwing createDataChannel to WebRTCUnsupportedError and closes the connection', async () => {

--- a/apps/viewer/src/lib/webrtc.test.ts
+++ b/apps/viewer/src/lib/webrtc.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect } from 'vitest';
-import { scaleVideoCoords } from './webrtc';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  scaleVideoCoords,
+  isWebRTCSupported,
+  createWebRTCSession,
+  WebRTCUnsupportedError,
+  type AuthenticatedConnectionParams,
+} from './webrtc';
 
 function setVideoSize(video: HTMLVideoElement, w: number, h: number) {
   Object.defineProperty(video, 'videoWidth', { value: w, configurable: true });
@@ -43,6 +49,85 @@ describe('scaleVideoCoords', () => {
 
     expect(scaleVideoCoords(1000, 250, video)).toEqual({ x: 960, y: 540 });
     expect(scaleVideoCoords(0, 250, video).x).toBe(0);
+  });
+});
+
+// ── WebRTC feature detection (issue #3410) ────────────────────────────────
+//
+// The Linux Viewer is a Tauri app rendering in webkit2gtk. Depending on how the
+// distro built webkit2gtk/GStreamer, `RTCPeerConnection` can be absent as a
+// global entirely, so `new RTCPeerConnection(...)` threw a bare ReferenceError
+// ("Can't find variable: RTCPeerConnection" — JavaScriptCore's phrasing) from
+// deep inside createWebRTCSession.
+
+/** Minimal stand-in so the "supported" branch can be exercised under jsdom. */
+class FakeRTCPeerConnection {
+  close() {}
+}
+
+const globalScope = globalThis as Record<string, unknown>;
+
+/**
+ * Remove the global outright rather than stubbing it to `undefined`.
+ *
+ * The distinction matters: an assigned-but-undefined global makes
+ * `new RTCPeerConnection()` a TypeError, whereas the identifier being genuinely
+ * absent — the real webkit2gtk case — makes it a ReferenceError. Only the
+ * latter reproduces issue #3410, so the guard has to be proven against it.
+ */
+function removeRTCPeerConnection(): void {
+  delete globalScope.RTCPeerConnection;
+}
+
+afterEach(() => {
+  delete globalScope.RTCPeerConnection;
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('isWebRTCSupported', () => {
+  it('is false when the RTCPeerConnection global is missing (webkit2gtk)', () => {
+    removeRTCPeerConnection();
+    expect(isWebRTCSupported()).toBe(false);
+  });
+
+  it('is true when the RTCPeerConnection global is present', () => {
+    vi.stubGlobal('RTCPeerConnection', FakeRTCPeerConnection);
+    expect(isWebRTCSupported()).toBe(true);
+  });
+});
+
+describe('createWebRTCSession — missing RTCPeerConnection', () => {
+  const params: AuthenticatedConnectionParams = {
+    sessionId: 'sess-3410',
+    apiUrl: 'https://api.example.com',
+    accessToken: 'viewer-token',
+    deviceId: 'dev-1',
+  };
+
+  it('rejects with WebRTCUnsupportedError instead of a bare ReferenceError', async () => {
+    removeRTCPeerConnection();
+    const videoEl = document.createElement('video');
+
+    const err = await createWebRTCSession(params, videoEl).catch((e) => e);
+
+    expect(err).toBeInstanceOf(WebRTCUnsupportedError);
+    // Before the guard this was `ReferenceError: RTCPeerConnection is not
+    // defined` (JavaScriptCore words it "Can't find variable: …"), thrown from
+    // the unguarded constructor. A ReferenceError here means the guard is gone.
+    expect(err).not.toBeInstanceOf(ReferenceError);
+    expect(String(err.message)).toMatch(/webrtc/i);
+  });
+
+  it('bails out before spending a request on the ICE-servers endpoint', async () => {
+    removeRTCPeerConnection();
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+    const videoEl = document.createElement('video');
+
+    await createWebRTCSession(params, videoEl).catch(() => {});
+
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/viewer/src/lib/webrtc.ts
+++ b/apps/viewer/src/lib/webrtc.ts
@@ -78,6 +78,36 @@ export function parseRetryAfterMs(headerValue: string | null): number | null {
   return seconds * 1000;
 }
 
+/**
+ * Error thrown when this WebView has no WebRTC implementation at all, so no
+ * amount of retrying or re-signalling can ever produce a peer connection.
+ * Distinguished from a *failed* connection attempt: callers should fall
+ * straight through to the WebSocket transport and tell the user why, rather
+ * than treating it as a transient error worth another attempt.
+ */
+export class WebRTCUnsupportedError extends Error {
+  constructor(
+    message = 'WebRTC is not available in this WebView, so remote desktop cannot use the WebRTC transport.',
+  ) {
+    super(message);
+    this.name = 'WebRTCUnsupportedError';
+  }
+}
+
+/**
+ * Whether this WebView can construct an RTCPeerConnection at all.
+ *
+ * The Linux Viewer is a Tauri app rendered by webkit2gtk. Whether that build
+ * exposes WebRTC depends entirely on how the distro compiled webkit2gtk and
+ * whether the matching GStreamer plugins are installed — on a fair number of
+ * builds `RTCPeerConnection` is simply not a global. Reading it as a bare
+ * identifier would itself throw a ReferenceError there, so this MUST stay a
+ * `typeof` check against the global object (issue #3410).
+ */
+export function isWebRTCSupported(): boolean {
+  return typeof (globalThis as { RTCPeerConnection?: unknown }).RTCPeerConnection === 'function';
+}
+
 export interface AuthenticatedConnectionParams {
   sessionId: string;
   apiUrl: string;
@@ -132,6 +162,14 @@ export async function createWebRTCSession(
   displayIndex?: number,
   targetSessionId?: number,
 ): Promise<WebRTCSession> {
+  // Bail out before any network work when the WebView has no WebRTC at all.
+  // This must come first: the ICE-servers request below would otherwise burn a
+  // round trip (and a rate-limit slot) fetching TURN credentials for a peer
+  // connection that can never be constructed (issue #3410).
+  if (!isWebRTCSupported()) {
+    throw new WebRTCUnsupportedError();
+  }
+
   // Fetch ICE servers (includes TURN credentials if configured)
   let iceServers: RTCIceServer[] = [{ urls: 'stun:stun.l.google.com:19302' }];
   try {

--- a/apps/viewer/src/lib/webrtc.ts
+++ b/apps/viewer/src/lib/webrtc.ts
@@ -146,6 +146,49 @@ export function nextAnswerPollInterval(currentMs: number): number {
 }
 
 /**
+ * Build the peer connection and its two data channels, treating any failure as
+ * a permanent capability gap rather than a failed attempt.
+ *
+ * `isWebRTCSupported()` catches the WebViews where `RTCPeerConnection` is not a
+ * global at all, but that is only the blunter half of the problem: a webkit2gtk
+ * build missing its GStreamer WebRTC plugins commonly *exposes* the constructor
+ * and then throws when you actually use it. Left unguarded, that resurfaced as
+ * a generic "WebRTC connection failed" — retryable-looking, and it suppressed
+ * the notice that tells the operator why quality dropped (issue #3410).
+ *
+ * Also closes a leak: `close()` is not defined until after the channels exist,
+ * so a throw from `createDataChannel` used to strand an open peer connection.
+ */
+function createPeerConnection(iceServers: RTCIceServer[]): {
+  pc: RTCPeerConnection;
+  inputChannel: RTCDataChannel;
+  controlChannel: RTCDataChannel;
+} {
+  let pc: RTCPeerConnection | undefined;
+  try {
+    pc = new RTCPeerConnection({ iceServers });
+
+    // Receive-only video transceiver (agent sends H264 video track)
+    pc.addTransceiver('video', { direction: 'recvonly' });
+
+    // DataChannels for input events and control messages.
+    // Input uses ordered + unreliable delivery: ordered ensures mouse_down →
+    // mouse_move → mouse_up arrive in sequence (required for drag operations),
+    // maxRetransmits: 0 keeps latency low by skipping retransmission of lost packets.
+    const inputChannel = pc.createDataChannel('input', { ordered: true, maxRetransmits: 0 });
+    const controlChannel = pc.createDataChannel('control', { ordered: true });
+    return { pc, inputChannel, controlChannel };
+  } catch (err) {
+    try { pc?.close(); } catch { /* already failing — nothing to salvage */ }
+    const cause = err instanceof Error ? err.message : String(err);
+    throw new WebRTCUnsupportedError(
+      `This WebView could not create a WebRTC peer connection: ${cause}. On Linux ` +
+        'this usually means the webkit2gtk build is missing its GStreamer WebRTC plugins.',
+    );
+  }
+}
+
+/**
  * Create a WebRTC session with the remote agent.
  *
  * Flow:
@@ -188,17 +231,7 @@ export async function createWebRTCSession(
     console.warn('Failed to fetch ICE servers, falling back to STUN-only:', error);
   }
 
-  const pc = new RTCPeerConnection({ iceServers });
-
-  // Receive-only video transceiver (agent sends H264 video track)
-  pc.addTransceiver('video', { direction: 'recvonly' });
-
-  // DataChannels for input events and control messages.
-  // Input uses ordered + unreliable delivery: ordered ensures mouse_down →
-  // mouse_move → mouse_up arrive in sequence (required for drag operations),
-  // maxRetransmits: 0 keeps latency low by skipping retransmission of lost packets.
-  const inputChannel = pc.createDataChannel('input', { ordered: true, maxRetransmits: 0 });
-  const controlChannel = pc.createDataChannel('control', { ordered: true });
+  const { pc, inputChannel, controlChannel } = createPeerConnection(iceServers);
 
   let closed = false;
   const close = () => {

--- a/apps/viewer/src/lib/webrtc.ts
+++ b/apps/viewer/src/lib/webrtc.ts
@@ -126,6 +126,13 @@ export interface WebRTCSession {
 const ICE_GATHER_TIMEOUT_MS = 3000;
 
 /**
+ * Fallback ICE configuration. Used both when the ICE-servers endpoint is
+ * unreachable and as the known-good config `createPeerConnection` retries with
+ * before concluding a WebView cannot do WebRTC at all.
+ */
+const DEFAULT_ICE_SERVERS: readonly RTCIceServer[] = [{ urls: 'stun:stun.l.google.com:19302' }];
+
+/**
  * Answer-poll pacing. The poll starts tight so a healthy agent (which answers
  * within a few hundred ms) is still picked up almost immediately, then backs
  * off geometrically so a slow or dead session doesn't turn the 15s window into
@@ -146,20 +153,10 @@ export function nextAnswerPollInterval(currentMs: number): number {
 }
 
 /**
- * Build the peer connection and its two data channels, treating any failure as
- * a permanent capability gap rather than a failed attempt.
- *
- * `isWebRTCSupported()` catches the WebViews where `RTCPeerConnection` is not a
- * global at all, but that is only the blunter half of the problem: a webkit2gtk
- * build missing its GStreamer WebRTC plugins commonly *exposes* the constructor
- * and then throws when you actually use it. Left unguarded, that resurfaced as
- * a generic "WebRTC connection failed" — retryable-looking, and it suppressed
- * the notice that tells the operator why quality dropped (issue #3410).
- *
- * Also closes a leak: `close()` is not defined until after the channels exist,
- * so a throw from `createDataChannel` used to strand an open peer connection.
+ * One attempt at a peer connection plus its two data channels, propagating any
+ * failure as-is. Callers classify; this only guarantees it leaves nothing open.
  */
-function createPeerConnection(iceServers: RTCIceServer[]): {
+function buildPeerConnection(iceServers: RTCIceServer[]): {
   pc: RTCPeerConnection;
   inputChannel: RTCDataChannel;
   controlChannel: RTCDataChannel;
@@ -179,12 +176,51 @@ function createPeerConnection(iceServers: RTCIceServer[]): {
     const controlChannel = pc.createDataChannel('control', { ordered: true });
     return { pc, inputChannel, controlChannel };
   } catch (err) {
+    // Don't strand a half-built connection: `close()` below is not defined until
+    // after the channels exist, so an throw from addTransceiver/createDataChannel
+    // used to leak an open pc.
     try { pc?.close(); } catch { /* already failing — nothing to salvage */ }
-    const cause = err instanceof Error ? err.message : String(err);
-    throw new WebRTCUnsupportedError(
-      `This WebView could not create a WebRTC peer connection: ${cause}. On Linux ` +
-        'this usually means the webkit2gtk build is missing its GStreamer WebRTC plugins.',
-    );
+    throw err;
+  }
+}
+
+/**
+ * Build the peer connection, classifying a failure this WebView can never
+ * recover from as {@link WebRTCUnsupportedError}.
+ *
+ * `isWebRTCSupported()` catches the WebViews where `RTCPeerConnection` is not a
+ * global at all, but that is only the blunter half of the problem: a webkit2gtk
+ * build missing its GStreamer WebRTC plugins commonly *exposes* the constructor
+ * and then throws when you actually use it. Left unclassified, that resurfaced
+ * as a generic "WebRTC connection failed" — retryable-looking, and it suppressed
+ * the notice that tells the operator why quality dropped (issue #3410).
+ */
+function createPeerConnection(iceServers: RTCIceServer[]): {
+  pc: RTCPeerConnection;
+  inputChannel: RTCDataChannel;
+  controlChannel: RTCDataChannel;
+} {
+  try {
+    return buildPeerConnection(iceServers);
+  } catch (firstErr) {
+    // The ICE list comes from the API and is only checked for being a non-empty
+    // array — a malformed `urls` or a TURN entry without credentials makes the
+    // constructor throw per spec. That is a server-config fault, not a missing
+    // WebRTC implementation, and calling it the latter would send an admin
+    // chasing GStreamer over a TURN typo (and, once the UI latches the
+    // capability, permanently disable WebRTC over one bad row).
+    //
+    // So prove it against a config we know is well-formed before blaming the
+    // WebView. If STUN-only also fails, the implementation really is absent.
+    try {
+      return buildPeerConnection([...DEFAULT_ICE_SERVERS]);
+    } catch (retryErr) {
+      const cause = retryErr instanceof Error ? retryErr.message : String(retryErr);
+      throw new WebRTCUnsupportedError(
+        `This WebView could not create a WebRTC peer connection: ${cause}. On Linux ` +
+          'this usually means the webkit2gtk build is missing its GStreamer WebRTC plugins.',
+      );
+    }
   }
 }
 
@@ -214,7 +250,7 @@ export async function createWebRTCSession(
   }
 
   // Fetch ICE servers (includes TURN credentials if configured)
-  let iceServers: RTCIceServer[] = [{ urls: 'stun:stun.l.google.com:19302' }];
+  let iceServers: RTCIceServer[] = [...DEFAULT_ICE_SERVERS];
   try {
     const iceResp = await apiFetch(
       params.apiUrl,

--- a/apps/viewer/src/lib/webrtc.ts
+++ b/apps/viewer/src/lib/webrtc.ts
@@ -176,9 +176,9 @@ function buildPeerConnection(iceServers: RTCIceServer[]): {
     const controlChannel = pc.createDataChannel('control', { ordered: true });
     return { pc, inputChannel, controlChannel };
   } catch (err) {
-    // Don't strand a half-built connection: `close()` below is not defined until
-    // after the channels exist, so an throw from addTransceiver/createDataChannel
-    // used to leak an open pc.
+    // Don't strand a half-built connection. createWebRTCSession's `close()` is
+    // not defined until after the channels exist, so a throw from
+    // addTransceiver/createDataChannel used to leak an open pc.
     try { pc?.close(); } catch { /* already failing — nothing to salvage */ }
     throw err;
   }
@@ -212,6 +212,17 @@ function createPeerConnection(iceServers: RTCIceServer[]): {
     //
     // So prove it against a config we know is well-formed before blaming the
     // WebView. If STUN-only also fails, the implementation really is absent.
+    //
+    // Log first, and unconditionally: when the retry SUCCEEDS this is the only
+    // trace that the operator's ICE config was rejected. The session then runs
+    // without the configured TURN relay, so on a symmetric-NAT or restrictive
+    // network it will still fail at ICE — and without this line that surfaces
+    // as a generic "WebRTC connection failed" with the real cause never named.
+    console.warn(
+      'ICE servers from the API were rejected by RTCPeerConnection; retrying STUN-only. ' +
+        'TURN relay is disabled for this session — check the ice-servers response:',
+      firstErr,
+    );
     try {
       return buildPeerConnection([...DEFAULT_ICE_SERVERS]);
     } catch (retryErr) {


### PR DESCRIPTION
Closes #3410

## The bug

The Linux Viewer is a Tauri app rendered by **webkit2gtk**, whose WebRTC support depends on how the distribution compiled it and whether the matching GStreamer plugins are installed. Where `RTCPeerConnection` is not a global, `apps/viewer/src/lib/webrtc.ts` constructed it unguarded:

```ts
const pc = new RTCPeerConnection({ iceServers });
```

That threw a bare `ReferenceError` from deep inside the signalling path. JavaScriptCore words it `Can't find variable: RTCPeerConnection` — the exact string the reporter pasted, and why the console line looked like a browser error rather than ours.

**Reproduced before fixing** (jsdom, where the identifier is genuinely absent, as on the affected webkit2gtk builds):

```
typeof RTCPeerConnection = undefined
THROWN: ReferenceError | RTCPeerConnection is not defined
```

The session was not dead — the transport caught the throw and returned `null`, so the viewer fell through to WebSocket/JPEG. But the fallback was accidental rather than designed: a full ICE-servers round trip was spent on every connect and reconnect for a peer connection that could never exist; the log said the generic `WebRTC connection failed:`, which reads as transient; nothing told the operator why quality had dropped; and reconnect could burn its whole 30s window retrying the impossible.

## The fix

- **`isWebRTCSupported()` + `WebRTCUnsupportedError`** (`lib/webrtc.ts`), with the probe at the very top of `createWebRTCSession` — before the ICE-servers request, so an unsupported WebView costs no network at all. It is a `typeof` check against the global object; reading the bare identifier would itself throw.
- **`createPeerConnection()` helper** wrapping construction, `addTransceiver` and both `createDataChannel` calls. A webkit2gtk build missing its GStreamer plugins commonly *exposes* `RTCPeerConnection` and then throws on use — the `typeof` probe alone would call that supported and let the failure resurface as a generic "connection failed". Any failure now maps to `WebRTCUnsupportedError` with the underlying cause preserved. This also closes a **pre-existing leak**: `close()` was not defined until after the channels were built, so a throw from `createDataChannel` stranded an open peer connection.
- **`transports/webrtc.ts`** distinguishes "this WebView has none" from "this attempt failed", logging an actionable cause while still returning `null` so the caller falls through.
- **`lib/transportAvailability.ts`** (new) — pure predicates gating every WebRTC affordance, so the dropdown option, the switch pill and the `switchTransport` backstop cannot drift apart. Same shape as the existing `autoHandoff.ts`.
- **A dismissible `role="status"` notice** explaining the compatibility transport and what it costs.
- **Docs** — a webkit2gtk/GStreamer section with per-distro install commands plus a troubleshooting entry on `features/remote-access`.

## Review rounds 2 and 3 — four real defects in my own earlier commits

The first commit stopped the crash but was not a complete fix. These were caught in review, not shipped:

1. **Silent dead controls.** The toolbar transport dropdown and the "user logged in — switch to WebRTC" pill stayed enabled. Clicking either hit the guard and silently returned; the pill even *self-dismissed*, signalling success. That traded a bad error message for **no feedback at all** — strictly worse than the crash on the feedback axis. Both are now gated, the macOS auto-handoff is gated at its call site (it polls every 2s), and the `switchTransport` check is an explicit backstop logging at `error` level, since reaching it means a UI gate has drifted.
2. **The probe missed the issue's own stated root cause** — see `createPeerConnection()` above. Worse, `webrtcSupported` would have been `true` in that case, actively *suppressing* the new notice.
3. **The notice was gated on `transport === 'websocket'`**, hiding it from every VNC session — including VNC deep links, which never attempt WebRTC at all — and making it vanish mid-session on the macOS websocket→VNC handoff. Now gated on the capability itself.
4. **The classification never reached the UI** (round 2). `webrtcSupported` came only from the up-front `typeof` probe and was never written again, so on a WebView that *exposes* `RTCPeerConnection` and throws on use — the case the issue actually describes — every gate stayed off and the notice never appeared. The net effect of `createPeerConnection` was a different console string. The transport now reports it via `onWebRTCUnsupported` and the component latches it, split across a ref (effects) and state (render) so the latch cannot re-run the connect effect and re-exchange the connect code.
5. **The STUN-only retry degraded silently** (round 3). It bound the original error and never logged it, so a malformed ICE/TURN config produced zero diagnostics while the session quietly ran without its TURN relay — the exact failure class the retry was added to avoid.

Also corrected: the docs table and notice **overstated what survives the fallback**. Ground truth is `capabilitiesFor()` in `lib/transports/types.ts` — websocket has `clipboardChannel: false`, so listing clipboard as available contradicted both the code and this page's own existing text. Clipboard sync, session switching and cursor streaming moved out of the WebSocket column, and quality/scale/FPS moved into it (only *bitrate* is WebRTC-only). The column is now titled "Not available on WebSocket" rather than "WebRTC only", because VNC keeps clipboard sync — and for the same reason the in-app notice lists only the intersection of what both fallbacks lose.

## Two adjacent problems this surfaced

**1. The Viewer's TypeScript tests ran in zero CI jobs.** Only the Rust half (`apps/viewer/src-tauri`) was covered. The 20 test files here — including this PR's regression tests — would never have guarded anything. Adds a `test-viewer` job (tests + `tsc --noEmit`) wired into `ci-success` on all four legs, so it fails closed. Confirmed the pre-existing suite was already green before wiring it. (Covers tests and types only: `@breeze/viewer` still has no `lint` script.)

**2. `DesktopViewer.tsx` was a "binary" file to git.** It held a raw NUL byte — a cache-key delimiter written as a literal instead of an escape — so git rendered *no diff* for this 2000-line component, in any PR. Replaced with the equivalent Unicode escape, verified byte-identical at runtime (`charCodeAt(4) === 0`, strings compare equal).

> ⚠️ Because the *base* blob still has the NUL, GitHub shows `DesktopViewer.tsx` as binary **in this PR only**. From the next PR on it diffs normally. To review it here:
> `git diff --text origin/main...fix/3410-viewer-webrtc-unsupported -- apps/viewer/src/components/DesktopViewer.tsx`

## Verification

| Check | Result |
|---|---|
| `vitest run` (whole viewer suite) | **20 files, 211 tests passed** (was 18/189 on main) |
| `tsc --noEmit` (apps/viewer) | clean |
| `pnpm test:workflow-security` | 113/113 pass |
| `pnpm --filter=@breeze/docs build` | 167 pages, clean; anchor verified in built HTML |
| `pnpm install --frozen-lockfile` | clean |

Tests were written **red first**, and the guards are **mutation-verified** rather than assumed:

| Mutation | Result |
|---|---|
| Remove the `createWebRTCSession` guard | 4 tests red |
| Remove the transport-layer `WebRTCUnsupportedError` branch | 1 test red |
| `isWebRTCSupported()` → `return true` | 5 tests red |
| Drop `webrtcSupported` from the pill predicate | 1 test red |
| Drop `webrtcSupported` from the dropdown predicate | 2 tests red |
| Drop the `onWebRTCUnsupported` call | 1 test red |
| Drop the ICE-rejection warning | 1 test red |

Both test files remove the global outright rather than stubbing it `undefined` — an assigned-but-undefined global yields a `TypeError`, and only a genuinely absent identifier reproduces the `ReferenceError` this issue is about.

One assertion was **deleted** during review: "does not fire the failure lifecycle callbacks" passed under every mutation (those callbacks only fire from a live connection-state handler), so it guarded nothing and inflated the apparent guard count.

## Known gaps

- **`apps/viewer` has no component-test infrastructure** (no `@testing-library/react`, no `.test.tsx`), so the `ViewerToolbar` wiring rests on `tsc` plus the tested predicates rather than a render test. Adding that infra is a follow-up, not something I wanted to smuggle into this PR as a lockfile change.
- **No telemetry.** `console.warn` is invisible in a shipped Tauri build (no devtools, no Sentry in the viewer), so nobody can answer "how many Linux viewers are silently on the JPEG transport?" — the question that would have surfaced this years earlier. Worth its own issue.
- No agent-side or API changes; this is entirely viewer-local capability detection. Not exercised on a real webkit2gtk host without WebRTC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
