### PR TITLE
fix(api): serve component binaries from the promoted agent_versions row (#3499)

### DIFF
--- a/apps/api/src/routes/agentVersions.test.ts
+++ b/apps/api/src/routes/agentVersions.test.ts
@@ -229,6 +229,11 @@ describe("agentVersions routes", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // clearAllMocks clears calls but KEEPS implementations, so a
+    // mockResolvedValue set by one backup-guard test would leak into every
+    // later one and silently stop it exercising the branch its name claims.
+    vi.mocked(getPromotedComponentVersion).mockReset();
+    vi.mocked(getPromotedComponentVersion).mockResolvedValue(null);
     platformAdminState.allow = true;
     delete process.env.AGENT_UPDATE_MANIFEST_PUBLIC_KEYS;
     delete process.env.BREEZE_UPDATE_MANIFEST_PUBLIC_KEYS;
@@ -1558,6 +1563,72 @@ describe("agentVersions routes", () => {
         expect(body.url).toBe(canonical);
         expect(body.checksum).toBe(checksum);
       } finally {
+        delete process.env.PUBLIC_API_URL;
+        delete process.env.BINARY_VERSION;
+      }
+    });
+
+    // The guard must mirror the download route's BINARY_SOURCE branch, not
+    // just its github half. In local mode that route streams ONE unversioned
+    // file from disk/S3 whose version is the binaries-volume build — the env
+    // version — and never consults the promoted row. Deriving the promoted row
+    // here would withhold the rewrite (and cost a pointless query) whenever the
+    // promoted row differs from the disk build, e.g. AGENT_AUTO_PROMOTE=false
+    // or after a rollback via POST /agent-versions/promote, silently ending
+    // backup self-heal for those deployments.
+    it("compares against the env version in local mode, without consulting the promoted row", async () => {
+      const canonical =
+        "https://github.com/LanternOps/breeze/releases/download/v1.0.0/breeze-backup-linux-amd64";
+      const checksum = "c".repeat(64);
+      const signed = makeSignedReleaseManifest({
+        component: "backup",
+        platform: "linux",
+        arch: "amd64",
+        url: canonical,
+        checksum,
+        size: 2048,
+      });
+
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([
+              {
+                version: "1.0.0",
+                platform: "linux",
+                architecture: "amd64",
+                component: "backup",
+                downloadUrl: canonical,
+                checksum,
+                fileSize: BigInt(2048),
+                releaseManifest: signed.manifest,
+                manifestSignature: signed.signature,
+                signingKeyId: "test-key",
+                // Not promoted — 1.1.0 is. In github mode that would withhold
+                // the rewrite; in local mode the disk build is what matters.
+                isLatest: false,
+              },
+            ]),
+          }),
+        }),
+      } as any);
+      vi.mocked(getPromotedComponentVersion).mockResolvedValue("1.1.0");
+
+      process.env.BINARY_SOURCE = "local";
+      process.env.PUBLIC_API_URL = "https://us.example.com";
+      process.env.BINARY_VERSION = "1.0.0";
+      try {
+        const res = await app.request(
+          "/agent-versions/1.0.0/download?platform=linux&arch=amd64&component=backup",
+        );
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.url).toBe(
+          "https://us.example.com/api/v1/agents/download/backup/linux/amd64",
+        );
+        expect(getPromotedComponentVersion).not.toHaveBeenCalled();
+      } finally {
+        delete process.env.BINARY_SOURCE;
         delete process.env.PUBLIC_API_URL;
         delete process.env.BINARY_VERSION;
       }

--- a/apps/api/src/routes/agentVersions.test.ts
+++ b/apps/api/src/routes/agentVersions.test.ts
@@ -30,6 +30,14 @@ vi.mock("../db", () => ({
   },
 }));
 
+// #3499: the component=backup rewrite guard asks this resolver what the
+// versionless download route will actually serve. Default to "no promoted
+// row", which makes the guard fall back to comparing against the env version —
+// the behavior every pre-existing test in this file was written against.
+vi.mock("../services/promotedAgentVersion", () => ({
+  getPromotedComponentVersion: vi.fn(async () => null),
+}));
+
 vi.mock("../services/manifestSigning", () => ({
   // Simulate no DB-provisioned deployment keys by default so tests that
   // don't set env vars still get a soft-pass (no env + no DB = empty keyset).
@@ -88,6 +96,7 @@ import { writeRouteAudit } from "../services/auditEvents";
 import { syncFromGitHub } from "../services/binarySync";
 import { captureException } from "../services/sentry";
 import { ResponseTooLargeError, SsrfBlockedError } from "../services/urlSafety";
+import { getPromotedComponentVersion } from "../services/promotedAgentVersion";
 import { requiredPlatformTrustFor } from "../services/releaseAssetTrust";
 
 // Recursively searches an and()/eq() spy tree (see drizzleSpies above) for an
@@ -739,21 +748,26 @@ describe("agentVersions routes", () => {
 
   describe("GET /agent-versions/latest", () => {
     it("should return latest version for platform/arch", async () => {
+      const rows = [
+        {
+          version: "1.2.0",
+          downloadUrl: "https://s3.example.com/agent-1.2.0-linux-amd64",
+          checksum: "a".repeat(64),
+          releaseManifest: null,
+          manifestSignature: null,
+          signingKeyId: null,
+          fileSize: BigInt(45000000),
+          releaseNotes: "Bug fixes",
+        },
+      ];
       vi.mocked(db.select).mockReturnValue({
         from: vi.fn().mockReturnValue({
+          // .orderBy() is the created_at tiebreak that keeps this endpoint in
+          // lockstep with services/promotedAgentVersion.ts (#3499).
           where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue([
-              {
-                version: "1.2.0",
-                downloadUrl: "https://s3.example.com/agent-1.2.0-linux-amd64",
-                checksum: "a".repeat(64),
-                releaseManifest: null,
-                manifestSignature: null,
-                signingKeyId: null,
-                fileSize: BigInt(45000000),
-                releaseNotes: "Bug fixes",
-              },
-            ]),
+            orderBy: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue(rows),
+            }),
           }),
         }),
       } as any);
@@ -771,11 +785,35 @@ describe("agentVersions routes", () => {
       expect(body.releaseNotes).toBe("Bug fixes");
     });
 
+    it("orders by created_at DESC, matching the resolver that serves the bytes (#3499)", async () => {
+      // This endpoint hands out the checksum; services/promotedAgentVersion.ts
+      // resolves the bytes it is verified against. Nothing in the schema
+      // enforces one isLatest row per (component, platform, arch, edition) —
+      // the invariant is demote-then-insert, not a unique constraint. If only
+      // one of the two ordered, a duplicate promoted row would make them
+      // select DIFFERENT rows: a checksum for a release the download route
+      // does not serve, silently. That is #3499 again.
+      const orderByMock = vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue([]),
+      });
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ orderBy: orderByMock }),
+        }),
+      } as any);
+
+      await app.request("/agent-versions/latest?platform=linux&arch=amd64");
+
+      expect(orderByMock).toHaveBeenCalledTimes(1);
+    });
+
     it("should return 404 when no version exists", async () => {
       vi.mocked(db.select).mockReturnValue({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue([]),
+            orderBy: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([]),
+            }),
           }),
         }),
       } as any);
@@ -789,7 +827,9 @@ describe("agentVersions routes", () => {
 
     it("scopes the lookup to this server's own edition (default self-host)", async () => {
       const whereMock = vi.fn().mockReturnValue({
-        limit: vi.fn().mockResolvedValue([]),
+        orderBy: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([]),
+        }),
       });
       vi.mocked(db.select).mockReturnValue({
         from: vi.fn().mockReturnValue({ where: whereMock }),
@@ -804,7 +844,9 @@ describe("agentVersions routes", () => {
 
     it("scopes the lookup to BINARY_EDITION=hosted when configured", async () => {
       const whereMock = vi.fn().mockReturnValue({
-        limit: vi.fn().mockResolvedValue([]),
+        orderBy: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([]),
+        }),
       });
       vi.mocked(db.select).mockReturnValue({
         from: vi.fn().mockReturnValue({ where: whereMock }),
@@ -1314,21 +1356,16 @@ describe("agentVersions routes", () => {
       }
     });
 
-    // AGENT_AUTO_PROMOTE=false means isLatest can point at a fleet version
-    // that is NOT what the server currently serves at the versionless route
-    // (deploy-to-promote window). isLatest must never be treated as
-    // sufficient on its own — only an exact match against the server's
-    // pinned current version (getGithubReleaseVersion) may trigger the
-    // rewrite. See the invariant comment on
-    // backupVersionIsServableByVersionlessRoute in agentVersions.ts.
     // #3499 inverted this case. The versionless /download/backup/:os/:arch
     // route used to serve the server's env version (BINARY_VERSION), so a
     // promoted row that the env had moved past was NOT servable by it and the
-    // rewrite had to be withheld. The route now serves the promoted (isLatest)
-    // row itself, so this row IS exactly what it serves and the rewrite is
-    // correct — this is the deploy-to-promote window (AGENT_AUTO_PROMOTE=false,
+    // rewrite had to be withheld — the guard tested the env version and
+    // isLatest was explicitly not sufficient. The route now serves the
+    // promoted row, so this row IS exactly what it serves and the rewrite is
+    // correct. This is the deploy-to-promote window (AGENT_AUTO_PROMOTE=false,
     // server on 1.1.0, fleet still promoted to 1.0.0) that used to hand out
-    // mismatched bytes.
+    // mismatched bytes. The guard no longer restates either rule: it asks the
+    // route's own resolver what will be served and compares.
     it("rewrites component=backup when the row IS the promoted isLatest row, even though the server's env version has moved ahead (#3499)", async () => {
       const canonical =
         "https://github.com/LanternOps/breeze/releases/download/v1.0.0/breeze-backup-linux-amd64";
@@ -1368,6 +1405,10 @@ describe("agentVersions routes", () => {
           }),
         }),
       } as any);
+
+      // The versionless route resolves the promoted row — this one — even
+      // though the server's own env version has moved ahead to 1.1.0.
+      vi.mocked(getPromotedComponentVersion).mockResolvedValue("1.0.0");
 
       process.env.PUBLIC_API_URL = "https://us.example.com";
       process.env.BINARY_VERSION = "1.1.0";
@@ -1454,14 +1495,14 @@ describe("agentVersions routes", () => {
       }
     });
 
-    // The other half of the #3499 inversion. Matching the server's env version
-    // (BINARY_VERSION) no longer makes a row servable by the versionless
-    // route, because that route resolves the promoted row instead. A
-    // non-promoted row must therefore keep the stored immutable URL — the
-    // conservative direction: the agent's host-equality check refuses the
-    // canonical github URL and simply does not heal, rather than downloading
-    // the promoted version's bytes against this row's checksum.
-    it("does NOT rewrite component=backup when the row merely matches the server's env version but is not promoted (#3499)", async () => {
+    // The other half of the #3499 change. Once a row IS promoted, matching the
+    // server's env version no longer makes a different row servable by the
+    // versionless route — that route serves the promoted one. So a
+    // non-promoted row keeps the stored immutable URL: the agent's
+    // host-equality check refuses the canonical github URL and simply does not
+    // heal, rather than downloading the promoted version's bytes against this
+    // row's checksum.
+    it("does NOT rewrite component=backup when the row merely matches the server's env version but another row is promoted (#3499)", async () => {
       const canonical =
         "https://github.com/LanternOps/breeze/releases/download/v1.0.0/breeze-backup-linux-amd64";
       const checksum = "e".repeat(64);
@@ -1493,11 +1534,16 @@ describe("agentVersions routes", () => {
                 // #3499 the versionless route serves whatever is promoted, not
                 // this. Must NOT rewrite.
                 isLatest: false,
+
               },
             ]),
           }),
         }),
       } as any);
+
+      // 1.1.0 is promoted, so that — not this row — is what the versionless
+      // route serves, even though this row matches BINARY_VERSION.
+      vi.mocked(getPromotedComponentVersion).mockResolvedValue("1.1.0");
 
       process.env.PUBLIC_API_URL = "https://us.example.com";
       process.env.BINARY_VERSION = "1.0.0";

--- a/apps/api/src/routes/agentVersions.test.ts
+++ b/apps/api/src/routes/agentVersions.test.ts
@@ -1321,7 +1321,15 @@ describe("agentVersions routes", () => {
     // pinned current version (getGithubReleaseVersion) may trigger the
     // rewrite. See the invariant comment on
     // backupVersionIsServableByVersionlessRoute in agentVersions.ts.
-    it("does NOT rewrite component=backup when the row is isLatest but not the server's current version — returns the stored immutable URL untouched", async () => {
+    // #3499 inverted this case. The versionless /download/backup/:os/:arch
+    // route used to serve the server's env version (BINARY_VERSION), so a
+    // promoted row that the env had moved past was NOT servable by it and the
+    // rewrite had to be withheld. The route now serves the promoted (isLatest)
+    // row itself, so this row IS exactly what it serves and the rewrite is
+    // correct — this is the deploy-to-promote window (AGENT_AUTO_PROMOTE=false,
+    // server on 1.1.0, fleet still promoted to 1.0.0) that used to hand out
+    // mismatched bytes.
+    it("rewrites component=backup when the row IS the promoted isLatest row, even though the server's env version has moved ahead (#3499)", async () => {
       const canonical =
         "https://github.com/LanternOps/breeze/releases/download/v1.0.0/breeze-backup-linux-amd64";
       const checksum = "f".repeat(64);
@@ -1349,11 +1357,11 @@ describe("agentVersions routes", () => {
                 releaseManifest: signed.manifest,
                 manifestSignature: signed.signature,
                 signingKeyId: "test-key",
-                // isLatest in the DB, but the server has already deployed a
-                // newer version and is pinned to it (AGENT_AUTO_PROMOTE=false
-                // means the fleet-wide promotion of 1.0.0 hasn't happened
-                // yet). The versionless route would serve 1.1.0's bytes, not
-                // this row's — must NOT rewrite.
+                // Promoted in the DB even though the server has already
+                // deployed a newer version (AGENT_AUTO_PROMOTE=false, so
+                // 1.1.0 is not the fleet target yet). Since #3499 the
+                // versionless route resolves this promoted row, so it serves
+                // exactly these bytes — rewrite is correct.
                 isLatest: true,
               },
             ]),
@@ -1369,9 +1377,11 @@ describe("agentVersions routes", () => {
         );
         expect(res.status).toBe(200);
         const body = await res.json();
-        // Stored canonical (immutable GitHub asset) URL, NOT the
-        // server-relative versionless route.
-        expect(body.url).toBe(canonical);
+        // Server-relative versionless route: it now resolves this same
+        // promoted row, so the bytes it serves match this row's checksum.
+        expect(body.url).toBe(
+          "https://us.example.com/api/v1/agents/download/backup/linux/amd64",
+        );
         expect(body.checksum).toBe(checksum);
       } finally {
         delete process.env.PUBLIC_API_URL;
@@ -1381,14 +1391,14 @@ describe("agentVersions routes", () => {
 
     // Design: breeze-backup's version is slaved to the agent's, and agents
     // request it by EXACT version. buildServerRelativeAgentDownloadUrl points
-    // at the versionless /download/backup/:os/:arch route, which can only
-    // ever serve whatever the server currently considers latest. Rewriting a
-    // non-latest, non-current backup version to that route would silently
-    // hand the agent NEWER bytes than the version it pinned — the updater's
+    // at the versionless /download/backup/:os/:arch route, which can only ever
+    // serve ONE release — since #3499, the promoted (isLatest) row. Rewriting
+    // a non-promoted backup version to that route would silently hand the
+    // agent DIFFERENT bytes than the version it pinned — the updater's
     // checksum/manifest check then (correctly) rejects them, and the agent
     // can never heal. So the rewrite must be gated to rows the versionless
     // route would actually serve.
-    it("does NOT rewrite component=backup when the row is neither latest nor the server's current version — returns the stored immutable URL untouched", async () => {
+    it("does NOT rewrite component=backup when the row is neither promoted nor the server's current version — returns the stored immutable URL untouched", async () => {
       const canonical =
         "https://github.com/LanternOps/breeze/releases/download/v0.90.0/breeze-backup-linux-amd64";
       const checksum = "d".repeat(64);
@@ -1444,7 +1454,14 @@ describe("agentVersions routes", () => {
       }
     });
 
-    it("rewrites component=backup when the requested version matches the server's pinned current version, even though isLatest is false", async () => {
+    // The other half of the #3499 inversion. Matching the server's env version
+    // (BINARY_VERSION) no longer makes a row servable by the versionless
+    // route, because that route resolves the promoted row instead. A
+    // non-promoted row must therefore keep the stored immutable URL — the
+    // conservative direction: the agent's host-equality check refuses the
+    // canonical github URL and simply does not heal, rather than downloading
+    // the promoted version's bytes against this row's checksum.
+    it("does NOT rewrite component=backup when the row merely matches the server's env version but is not promoted (#3499)", async () => {
       const canonical =
         "https://github.com/LanternOps/breeze/releases/download/v1.0.0/breeze-backup-linux-amd64";
       const checksum = "e".repeat(64);
@@ -1472,9 +1489,9 @@ describe("agentVersions routes", () => {
                 releaseManifest: signed.manifest,
                 manifestSignature: signed.signature,
                 signingKeyId: "test-key",
-                // Not (yet) flagged isLatest in the DB, but it's the version
-                // BINARY_VERSION pins the server to — the versionless route
-                // would serve exactly this.
+                // Matches BINARY_VERSION, but is NOT the promoted row — since
+                // #3499 the versionless route serves whatever is promoted, not
+                // this. Must NOT rewrite.
                 isLatest: false,
               },
             ]),
@@ -1490,9 +1507,9 @@ describe("agentVersions routes", () => {
         );
         expect(res.status).toBe(200);
         const body = await res.json();
-        expect(body.url).toBe(
-          "https://us.example.com/api/v1/agents/download/backup/linux/amd64",
-        );
+        // Stored canonical (immutable GitHub asset) URL, NOT the
+        // server-relative versionless route.
+        expect(body.url).toBe(canonical);
         expect(body.checksum).toBe(checksum);
       } finally {
         delete process.env.PUBLIC_API_URL;

--- a/apps/api/src/routes/agentVersions.ts
+++ b/apps/api/src/routes/agentVersions.ts
@@ -17,7 +17,6 @@ import { syncFromGitHub } from "../services/binarySync";
 import { captureException } from "../services/sentry";
 import { ResponseTooLargeError, SsrfBlockedError } from "../services/urlSafety";
 import { getBinaryEdition } from "../services/binaryEdition";
-import { getGithubReleaseVersion } from "../services/binarySource";
 import { PERMISSIONS } from "../services/permissions";
 import {
   verifyReleaseArtifactManifestAsset,
@@ -791,25 +790,29 @@ agentVersionRoutes.get(
 
     // breeze-backup is version-slaved to the agent but requested by EXACT
     // version (unlike agent/helper/watchdog, which always want "latest").
-    // The versionless /download/backup/:os/:arch route can only ever serve
-    // whatever the server currently considers latest (BINARY_VERSION /
-    // BREEZE_VERSION — see binarySource.getGithubReleaseVersion). Rewriting
-    // to that route for a NON-current backup version would hand an agent
-    // healing to an older pinned version newer bytes than it asked for; the
-    // updater verifies checksum+manifest against the pinned version and
-    // fails safe, but can never actually heal. So for component=backup only,
-    // rewrite exclusively when this row IS the exact version the versionless
-    // route would serve — it matches the server's own pinned version
-    // (getGithubReleaseVersion). isLatest is NOT sufficient: production runs
+    // The versionless /download/backup/:os/:arch route can only ever serve ONE
+    // release, so rewriting a NON-servable backup version to it would hand an
+    // agent healing to an older pinned version different bytes than it asked
+    // for; the updater verifies checksum+manifest against the pinned version
+    // and fails safe, but can never actually heal. So for component=backup
+    // only, rewrite exclusively when this row IS the one that route serves.
+    //
+    // Which row that is changed in #3499. It used to be the server's own
+    // per-process env version (BINARY_VERSION/BREEZE_VERSION, via
+    // binarySource.getGithubReleaseVersion), so this guard compared against
+    // that and isLatest was explicitly NOT sufficient: production runs
     // AGENT_AUTO_PROMOTE=false, so after deploying server version Y the DB's
     // isLatest rows can still point at the still-rolling-out fleet version X.
-    // An agent pinned to X would then get rewritten to the versionless route,
-    // which serves Y's bytes — checksum verification fails fleet-wide for the
-    // entire deploy-to-promote window. Every other component keeps the
+    // #3499 inverted exactly that: the download route now resolves the
+    // promoted (isLatest) agent_versions row — the same row this endpoint
+    // reads the checksum from — so isLatest is now the correct predicate and
+    // the env version is the wrong one. During that same deploy-to-promote
+    // window the route now serves X, matching a pin of X instead of breaking
+    // it. These two must stay in lockstep: this guard has to test for whatever
+    // the versionless route actually serves. Every other component keeps the
     // unconditional rewrite.
     const backupVersionIsServableByVersionlessRoute =
-      versionInfo.component !== "backup" ||
-      versionInfo.version === getGithubReleaseVersion();
+      versionInfo.component !== "backup" || versionInfo.isLatest;
 
     const serverRelativeUrl = backupVersionIsServableByVersionlessRoute
       ? buildServerRelativeAgentDownloadUrl(

--- a/apps/api/src/routes/agentVersions.ts
+++ b/apps/api/src/routes/agentVersions.ts
@@ -17,7 +17,7 @@ import { syncFromGitHub } from "../services/binarySync";
 import { captureException } from "../services/sentry";
 import { ResponseTooLargeError, SsrfBlockedError } from "../services/urlSafety";
 import { getBinaryEdition } from "../services/binaryEdition";
-import { getGithubReleaseVersion } from "../services/binarySource";
+import { getBinarySource, getGithubReleaseVersion } from "../services/binarySource";
 import { getPromotedComponentVersion } from "../services/promotedAgentVersion";
 import { PERMISSIONS } from "../services/permissions";
 import {
@@ -823,12 +823,22 @@ agentVersionRoutes.get(
     // the unconditional rewrite.
     let backupVersionIsServableByVersionlessRoute = true;
     if (versionInfo.component === "backup") {
+      // Mirror the route's own BINARY_SOURCE branch. Only the github branch
+      // resolves the promoted row; in local mode the route streams ONE
+      // unversioned file from disk/S3 whose version is the binaries-volume
+      // build — i.e. the env version, which is what this guard has always
+      // compared against there. Deriving the promoted row in local mode would
+      // withhold the rewrite (and cost a query) whenever the promoted row and
+      // the disk build differ, e.g. AGENT_AUTO_PROMOTE=false or after a
+      // rollback via POST /agent-versions/promote.
       const versionlessRouteServes =
-        (await getPromotedComponentVersion(
-          "backup",
-          dbPlatformToRouteOs(versionInfo.platform),
-          versionInfo.architecture,
-        )) ?? getGithubReleaseVersion();
+        getBinarySource() === "github"
+          ? ((await getPromotedComponentVersion(
+              "backup",
+              dbPlatformToRouteOs(versionInfo.platform),
+              versionInfo.architecture,
+            )) ?? getGithubReleaseVersion())
+          : getGithubReleaseVersion();
       backupVersionIsServableByVersionlessRoute =
         versionInfo.version === versionlessRouteServes;
     }

--- a/apps/api/src/routes/agentVersions.ts
+++ b/apps/api/src/routes/agentVersions.ts
@@ -17,6 +17,8 @@ import { syncFromGitHub } from "../services/binarySync";
 import { captureException } from "../services/sentry";
 import { ResponseTooLargeError, SsrfBlockedError } from "../services/urlSafety";
 import { getBinaryEdition } from "../services/binaryEdition";
+import { getGithubReleaseVersion } from "../services/binarySource";
+import { getPromotedComponentVersion } from "../services/promotedAgentVersion";
 import { PERMISSIONS } from "../services/permissions";
 import {
   verifyReleaseArtifactManifestAsset,
@@ -684,6 +686,15 @@ agentVersionRoutes.get(
           eq(agentVersions.edition, getBinaryEdition()),
         ),
       )
+      // MUST match the tiebreak in services/promotedAgentVersion.ts, which
+      // resolves the bytes these checksums are verified against (#3499).
+      // Nothing enforces one promoted row per (component, platform, arch,
+      // edition) — the invariant is maintained by demote-then-insert, not a
+      // unique constraint — so if only one of the two ordered, a duplicate
+      // isLatest row would make them select DIFFERENT rows and hand out a
+      // checksum for a release the download route does not serve. That is
+      // #3499 all over again, and silent.
+      .orderBy(desc(agentVersions.createdAt))
       .limit(1);
 
     if (!latestVersion) {
@@ -797,22 +808,30 @@ agentVersionRoutes.get(
     // and fails safe, but can never actually heal. So for component=backup
     // only, rewrite exclusively when this row IS the one that route serves.
     //
-    // Which row that is changed in #3499. It used to be the server's own
-    // per-process env version (BINARY_VERSION/BREEZE_VERSION, via
-    // binarySource.getGithubReleaseVersion), so this guard compared against
-    // that and isLatest was explicitly NOT sufficient: production runs
-    // AGENT_AUTO_PROMOTE=false, so after deploying server version Y the DB's
-    // isLatest rows can still point at the still-rolling-out fleet version X.
-    // #3499 inverted exactly that: the download route now resolves the
-    // promoted (isLatest) agent_versions row — the same row this endpoint
-    // reads the checksum from — so isLatest is now the correct predicate and
-    // the env version is the wrong one. During that same deploy-to-promote
-    // window the route now serves X, matching a pin of X instead of breaking
-    // it. These two must stay in lockstep: this guard has to test for whatever
-    // the versionless route actually serves. Every other component keeps the
-    // unconditional rewrite.
-    const backupVersionIsServableByVersionlessRoute =
-      versionInfo.component !== "backup" || versionInfo.isLatest;
+    // WHICH row that is changed in #3499, so rather than restate the route's
+    // rule here and let the two drift, ask the route's OWN resolver what it
+    // will serve and compare. Restating it is what made this guard subtly
+    // wrong twice: it used to hardcode "the env version", correct only while
+    // the route resolved BINARY_VERSION/BREEZE_VERSION; a plain `isLatest`
+    // test would be equally wrong for a never-synced deployment, where no row
+    // is promoted and the route legitimately falls back to the env version.
+    // Deriving it keeps both cases right by construction.
+    //
+    // A resolver fault throws rather than guessing, and this endpoint is
+    // already DB-dependent (it just read versionInfo), so it surfaces as a 5xx
+    // instead of a rewrite that might not match. Every other component keeps
+    // the unconditional rewrite.
+    let backupVersionIsServableByVersionlessRoute = true;
+    if (versionInfo.component === "backup") {
+      const versionlessRouteServes =
+        (await getPromotedComponentVersion(
+          "backup",
+          dbPlatformToRouteOs(versionInfo.platform),
+          versionInfo.architecture,
+        )) ?? getGithubReleaseVersion();
+      backupVersionIsServableByVersionlessRoute =
+        versionInfo.version === versionlessRouteServes;
+    }
 
     const serverRelativeUrl = backupVersionIsServableByVersionlessRoute
       ? buildServerRelativeAgentDownloadUrl(

--- a/apps/api/src/routes/agents/download.test.ts
+++ b/apps/api/src/routes/agents/download.test.ts
@@ -24,6 +24,12 @@ vi.mock('../../services/binarySource', () => ({
   },
 }));
 
+vi.mock('../../services/promotedAgentVersion', () => ({
+  // Default: no promoted row, so every pre-existing test keeps exercising the
+  // historical env-resolved redirect path unchanged.
+  getPromotedComponentVersion: vi.fn(async () => null),
+}));
+
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
 import { execFile, execFileSync } from 'node:child_process';
 import { createServer } from 'node:http';
@@ -31,8 +37,9 @@ import type { AddressInfo } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { downloadRoutes } from './download';
-import { getBinarySource, getGithubAgentPkgUrl, getGithubUserHelperUrl, getGithubWatchdogUrl, getGithubBackupUrl } from '../../services/binarySource';
+import { getBinarySource, getGithubAgentUrl, getGithubAgentPkgUrl, getGithubHelperUrl, getGithubUserHelperUrl, getGithubWatchdogUrl, getGithubBackupUrl } from '../../services/binarySource';
 import { isS3Configured, getPresignedUrl } from '../../services/s3Storage';
+import { getPromotedComponentVersion } from '../../services/promotedAgentVersion';
 
 describe('public agent binary downloads', () => {
   const originalAgentDir = process.env.AGENT_BINARY_DIR;
@@ -103,11 +110,14 @@ describe('public agent binary downloads', () => {
       const lin = await downloadRoutes.request('/download/watchdog/linux/amd64');
       expect(lin.status).toBe(302);
       expect(lin.headers.get('location')).toBe('https://github.test/linux-amd64/breeze-watchdog');
-      expect(getGithubWatchdogUrl).toHaveBeenCalledWith('linux', 'amd64');
+      // Third arg is the promoted-row version (#3499); undefined here because
+      // the default resolver mock reports no promoted row, so the builder
+      // falls back to the env-resolved release tag.
+      expect(getGithubWatchdogUrl).toHaveBeenCalledWith('linux', 'amd64', undefined);
 
       const win = await downloadRoutes.request('/download/watchdog/windows/amd64');
       expect(win.status).toBe(302);
-      expect(getGithubWatchdogUrl).toHaveBeenCalledWith('windows', 'amd64');
+      expect(getGithubWatchdogUrl).toHaveBeenCalledWith('windows', 'amd64', undefined);
     } finally {
       // Restore the module-mock default so later tests still see 'local'
       // (vi.restoreAllMocks does not reset vi.mock factory fns).
@@ -148,11 +158,11 @@ describe('public agent binary downloads', () => {
       const lin = await downloadRoutes.request('/download/backup/linux/amd64');
       expect(lin.status).toBe(302);
       expect(lin.headers.get('location')).toBe('https://github.test/linux-amd64/breeze-backup');
-      expect(getGithubBackupUrl).toHaveBeenCalledWith('linux', 'amd64');
+      expect(getGithubBackupUrl).toHaveBeenCalledWith('linux', 'amd64', undefined);
 
       const win = await downloadRoutes.request('/download/backup/windows/amd64');
       expect(win.status).toBe(302);
-      expect(getGithubBackupUrl).toHaveBeenCalledWith('windows', 'amd64');
+      expect(getGithubBackupUrl).toHaveBeenCalledWith('windows', 'amd64', undefined);
     } finally {
       // Restore the module-mock default so later tests still see 'local'
       // (vi.restoreAllMocks does not reset vi.mock factory fns).
@@ -193,7 +203,7 @@ describe('public agent binary downloads', () => {
       const win = await downloadRoutes.request('/download/user-helper/windows/amd64');
       expect(win.status).toBe(302);
       expect(win.headers.get('location')).toBe('https://github.test/windows-amd64/breeze-user-helper');
-      expect(getGithubUserHelperUrl).toHaveBeenCalledWith('windows', 'amd64');
+      expect(getGithubUserHelperUrl).toHaveBeenCalledWith('windows', 'amd64', undefined);
     } finally {
       vi.mocked(getBinarySource).mockReturnValue('local');
     }
@@ -223,6 +233,130 @@ describe('public agent binary downloads', () => {
   it('rejects non-darwin pkg requests', async () => {
     const res = await downloadRoutes.request('/download/linux/amd64/pkg');
     expect(res.status).toBe(400);
+  });
+});
+
+// Issue #3499. install.sh fetches the expected SHA-256 from
+// GET /agent-versions/latest (the agent_versions isLatest row) and then
+// downloads the bytes from GET /agents/download/:os/:arch. The download route
+// used to build its GitHub redirect from BINARY_VERSION||BREEZE_VERSION
+// resolved from per-process env, a completely independent source of truth. When
+// the two disagreed — observed one full release apart, 0.104.0 metadata vs
+// 0.105.1 bytes, after the GitHub sync stalled — the install aborted with
+// "Checksum verification failed for downloaded agent binary".
+//
+// These tests pin the bytes to the SAME promoted row the checksum comes from.
+// In each divergence case the env-resolved version (0.105.1) is what the route
+// served BEFORE the fix, so asserting the promoted version (0.104.0) appears
+// instead is what discriminates fixed from broken.
+describe('component downloads serve the DB-promoted version (issue #3499)', () => {
+  const ENV_VERSION = '0.105.1'; // BINARY_VERSION/BREEZE_VERSION in this process
+  const PROMOTED_VERSION = '0.104.0'; // the agent_versions isLatest row
+
+  // Stand-ins for the real builders: render whichever version the route passes,
+  // falling back to the env-resolved version when it passes none.
+  const urlFor =
+    (component: string) =>
+    (os: string, arch: string, version?: string) =>
+      `https://github.test/releases/download/v${version ?? ENV_VERSION}/breeze-${component}-${os}-${arch}`;
+
+  beforeEach(() => {
+    vi.mocked(getBinarySource).mockReturnValue('github');
+    vi.mocked(getGithubAgentUrl).mockImplementation(urlFor('agent'));
+    vi.mocked(getGithubBackupUrl).mockImplementation(urlFor('backup'));
+    vi.mocked(getGithubWatchdogUrl).mockImplementation(urlFor('watchdog'));
+    vi.mocked(getGithubUserHelperUrl).mockImplementation(urlFor('user-helper'));
+    vi.mocked(getGithubHelperUrl).mockImplementation(
+      (os: string, version?: string) =>
+        `https://github.test/releases/download/v${version ?? ENV_VERSION}/breeze-helper-${os}`,
+    );
+    vi.mocked(getPromotedComponentVersion).mockResolvedValue(PROMOTED_VERSION);
+  });
+
+  afterEach(() => {
+    // Restore the module-mock defaults for later describes (vi.restoreAllMocks
+    // does not reset vi.mock factory fns).
+    vi.mocked(getBinarySource).mockReturnValue('local');
+    vi.mocked(getPromotedComponentVersion).mockReset();
+    vi.mocked(getPromotedComponentVersion).mockResolvedValue(null);
+  });
+
+  it('serves the agent binary from the promoted row, not the env-resolved version', async () => {
+    const res = await downloadRoutes.request('/download/linux/amd64');
+
+    expect(res.status).toBe(302);
+    expect(getPromotedComponentVersion).toHaveBeenCalledWith('agent', 'linux', 'amd64');
+    expect(res.headers.get('location')).toBe(
+      `https://github.test/releases/download/v${PROMOTED_VERSION}/breeze-agent-linux-amd64`,
+    );
+    // The exact failure from the issue: env-resolved bytes against a
+    // promoted-row checksum.
+    expect(res.headers.get('location')).not.toContain(ENV_VERSION);
+  });
+
+  it('serves the backup binary from the promoted row (install.sh checksums this too)', async () => {
+    const res = await downloadRoutes.request('/download/backup/darwin/arm64');
+
+    expect(res.status).toBe(302);
+    expect(getPromotedComponentVersion).toHaveBeenCalledWith('backup', 'darwin', 'arm64');
+    expect(res.headers.get('location')).toBe(
+      `https://github.test/releases/download/v${PROMOTED_VERSION}/breeze-backup-darwin-arm64`,
+    );
+  });
+
+  it('serves watchdog, user-helper and helper from their own promoted rows', async () => {
+    const watchdog = await downloadRoutes.request('/download/watchdog/windows/amd64');
+    expect(watchdog.headers.get('location')).toBe(
+      `https://github.test/releases/download/v${PROMOTED_VERSION}/breeze-watchdog-windows-amd64`,
+    );
+    expect(getPromotedComponentVersion).toHaveBeenCalledWith('watchdog', 'windows', 'amd64');
+
+    const userHelper = await downloadRoutes.request('/download/user-helper/windows/amd64');
+    expect(userHelper.headers.get('location')).toBe(
+      `https://github.test/releases/download/v${PROMOTED_VERSION}/breeze-user-helper-windows-amd64`,
+    );
+    expect(getPromotedComponentVersion).toHaveBeenCalledWith('user-helper', 'windows', 'amd64');
+
+    // The helper builder is per-OS, but its promoted row is still looked up
+    // per (os, arch) — HELPER_TARGETS registers darwin/amd64 and darwin/arm64
+    // as separate rows pointing at the same .dmg.
+    const helper = await downloadRoutes.request('/download/helper/darwin/arm64');
+    expect(helper.headers.get('location')).toBe(
+      `https://github.test/releases/download/v${PROMOTED_VERSION}/breeze-helper-darwin`,
+    );
+    expect(getPromotedComponentVersion).toHaveBeenCalledWith('helper', 'darwin', 'arm64');
+  });
+
+  it('falls back to the env-resolved version when no promoted row exists', async () => {
+    // A deployment that has never completed a binary sync has no isLatest row.
+    // Behavior must stay exactly as it was rather than 404/500 the download.
+    vi.mocked(getPromotedComponentVersion).mockResolvedValue(null);
+
+    const res = await downloadRoutes.request('/download/linux/amd64');
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe(
+      `https://github.test/releases/download/v${ENV_VERSION}/breeze-agent-linux-amd64`,
+    );
+  });
+
+  it('does not consult the promoted row in local (non-github) mode', async () => {
+    // Local mode streams from disk / S3; there is no release tag to reconcile,
+    // so the extra query would be pure overhead on every download.
+    vi.mocked(getBinarySource).mockReturnValue('local');
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await downloadRoutes.request('/download/linux/amd64');
+
+    expect(getPromotedComponentVersion).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid os/arch before querying for a promoted row', async () => {
+    const badOs = await downloadRoutes.request('/download/solaris/amd64');
+    expect(badOs.status).toBe(400);
+    const badArch = await downloadRoutes.request('/download/linux/sparc');
+    expect(badArch.status).toBe(400);
+    expect(getPromotedComponentVersion).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/routes/agents/download.test.ts
+++ b/apps/api/src/routes/agents/download.test.ts
@@ -340,6 +340,26 @@ describe('component downloads serve the DB-promoted version (issue #3499)', () =
     );
   });
 
+  it('503s instead of serving the env version when the promoted lookup faults', async () => {
+    // The fallback-to-env path is reserved for "no promoted row at all". A
+    // lookup FAULT must not silently serve a release that may not match the
+    // checksum the client already holds — that is #3499, and it would report a
+    // server-side DB fault to the end user as a checksum failure.
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.mocked(getPromotedComponentVersion).mockRejectedValue(
+      new Error('connection terminated'),
+    );
+
+    const res = await downloadRoutes.request('/download/linux/amd64');
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get('retry-after')).toBe('30');
+    const body = await res.text();
+    // Must not leak the fault detail to an unauthenticated caller.
+    expect(body).not.toContain('connection terminated');
+    expect(console.error).toHaveBeenCalled();
+  });
+
   it('does not consult the promoted row in local (non-github) mode', async () => {
     // Local mode streams from disk / S3; there is no release tag to reconcile,
     // so the extra query would be pure overhead on every download.
@@ -348,6 +368,21 @@ describe('component downloads serve the DB-promoted version (issue #3499)', () =
 
     await downloadRoutes.request('/download/linux/amd64');
 
+    expect(getPromotedComponentVersion).not.toHaveBeenCalled();
+  });
+
+  it('leaves the macOS .pkg route on env resolution, deliberately', async () => {
+    // install.sh's darwin branch verifies the .pkg with xar magic bytes and
+    // `spctl` Gatekeeper notarization, never a SHA-256 against
+    // /agent-versions/latest — so there is no checksum/bytes pair to keep
+    // consistent here and nothing for #3499 to fix. Pinned as a test so the
+    // one builder without a version parameter reads as intentional rather
+    // than an omission.
+    vi.mocked(getGithubAgentPkgUrl).mockReturnValue('https://github.test/pkg');
+
+    const res = await downloadRoutes.request('/download/darwin/arm64/pkg');
+
+    expect(res.status).toBe(302);
     expect(getPromotedComponentVersion).not.toHaveBeenCalled();
   });
 

--- a/apps/api/src/routes/agents/download.test.ts
+++ b/apps/api/src/routes/agents/download.test.ts
@@ -371,6 +371,22 @@ describe('component downloads serve the DB-promoted version (issue #3499)', () =
     expect(getPromotedComponentVersion).not.toHaveBeenCalled();
   });
 
+  it('503s when the promoted row carries a malformed release tag', async () => {
+    // agent_versions.version has no format constraint, so a promoted row can
+    // carry a tag the URL builder refuses. That is the same "cannot determine
+    // a release" condition as a lookup fault and must not escape as a bare 500.
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.mocked(getPromotedComponentVersion).mockResolvedValue('../../evil');
+    vi.mocked(getGithubAgentUrl).mockImplementation(() => {
+      throw new Error('Refusing to build a download URL for malformed release tag');
+    });
+
+    const res = await downloadRoutes.request('/download/linux/amd64');
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get('retry-after')).toBe('30');
+  });
+
   it('leaves the macOS .pkg route on env resolution, deliberately', async () => {
     // install.sh's darwin branch verifies the .pkg with xar magic bytes and
     // `spctl` Gatekeeper notarization, never a SHA-256 against

--- a/apps/api/src/routes/agents/download.ts
+++ b/apps/api/src/routes/agents/download.ts
@@ -97,15 +97,37 @@ function registerComponentDownloadRoute(config: ComponentDownloadConfig): void {
     // GET /agent-versions/latest serves the checksum from. Resolving it from
     // per-process env here instead let the bytes and the checksum drift a full
     // release apart whenever the binary sync stalled, which install.sh reports
-    // as "Checksum verification failed for downloaded agent binary". A null
-    // result (no promoted row, or a DB fault — both logged by the resolver)
-    // falls back to the historical env-resolved URL.
+    // as "Checksum verification failed for downloaded agent binary".
+    //
+    // null means "no promoted row at all" — the cold-start state of a
+    // deployment that has never synced — so fall back to the env-resolved URL
+    // and keep those deployments working exactly as they did. A lookup FAULT
+    // is different and throws: serving the env version then would reintroduce
+    // the very mismatch this fixes and report a server-side DB fault to the
+    // end user as a checksum failure.
     if (getBinarySource() === 'github') {
-      const promotedVersion = await getPromotedComponentVersion(
-        config.component,
-        os,
-        arch,
-      );
+      let promotedVersion: string | null;
+      try {
+        promotedVersion = await getPromotedComponentVersion(
+          config.component,
+          os,
+          arch,
+        );
+      } catch (err) {
+        console.error(
+          `[${config.logTag}] refusing to serve ${filename}: could not resolve the promoted release`,
+          err,
+        );
+        return c.json(
+          {
+            error: 'Service unavailable',
+            message:
+              'Could not determine the current release. Retry shortly; if this persists, check the API logs.',
+          },
+          503,
+          { 'Retry-After': '30' },
+        );
+      }
       return c.redirect(
         config.githubUrlFor(os, arch, promotedVersion ?? undefined),
         302,
@@ -203,7 +225,15 @@ registerComponentDownloadRoute({
 // ============================================
 // Agent .pkg Installer Download (macOS, public, no auth)
 // ============================================
-
+// Deliberately NOT version-pinned to the promoted agent_versions row the way
+// the five component routes above are (#3499). install.sh's macOS branch never
+// sha256-checks the .pkg against /agent-versions/latest — it verifies xar magic
+// bytes and Apple notarization via `spctl --assess` instead — so there is no
+// checksum/bytes pair here to keep consistent, and no install-time failure to
+// prevent. The tradeoff is that a macOS install lands on the env-resolved
+// release while Linux lands on the promoted one; the agent reconciles on its
+// first heartbeat, which offers the promoted version through the normal
+// verified updater path.
 downloadRoutes.get('/download/:os/:arch/pkg', async (c) => {
   const os = c.req.param('os');
   const arch = c.req.param('arch');

--- a/apps/api/src/routes/agents/download.ts
+++ b/apps/api/src/routes/agents/download.ts
@@ -106,16 +106,22 @@ function registerComponentDownloadRoute(config: ComponentDownloadConfig): void {
     // the very mismatch this fixes and report a server-side DB fault to the
     // end user as a checksum failure.
     if (getBinarySource() === 'github') {
-      let promotedVersion: string | null;
+      let redirectUrl: string;
       try {
-        promotedVersion = await getPromotedComponentVersion(
+        const promotedVersion = await getPromotedComponentVersion(
           config.component,
           os,
           arch,
         );
+        // Inside the try on purpose: the URL builder ALSO throws — on a
+        // malformed release tag, which a promoted row can carry because
+        // agent_versions.version has no format constraint. That is the same
+        // "we cannot determine a release to serve" condition, so it belongs on
+        // the same 503 rather than falling through to a bare 500.
+        redirectUrl = config.githubUrlFor(os, arch, promotedVersion ?? undefined);
       } catch (err) {
         console.error(
-          `[${config.logTag}] refusing to serve ${filename}: could not resolve the promoted release`,
+          `[${config.logTag}] refusing to serve ${filename}: could not resolve a release to redirect to`,
           err,
         );
         return c.json(
@@ -128,10 +134,7 @@ function registerComponentDownloadRoute(config: ComponentDownloadConfig): void {
           { 'Retry-After': '30' },
         );
       }
-      return c.redirect(
-        config.githubUrlFor(os, arch, promotedVersion ?? undefined),
-        302,
-      );
+      return c.redirect(redirectUrl, 302);
     }
 
     // Local mode: try S3 presigned redirect first (bandwidth offload)

--- a/apps/api/src/routes/agents/download.ts
+++ b/apps/api/src/routes/agents/download.ts
@@ -4,6 +4,7 @@ import { join, resolve } from 'node:path';
 import { VALID_OS, VALID_ARCH } from './schemas';
 import { isS3Configured, getPresignedUrl, isS3NotFound } from '../../services/s3Storage';
 import { getBinarySource, getGithubAgentUrl, getGithubAgentPkgUrl, getGithubHelperUrl, getGithubUserHelperUrl, getGithubWatchdogUrl, getGithubBackupUrl, HELPER_FILENAMES } from '../../services/binarySource';
+import { getPromotedComponentVersion, type PromotedComponent } from '../../services/promotedAgentVersion';
 
 export const downloadRoutes = new Hono();
 
@@ -31,8 +32,17 @@ interface ComponentDownloadConfig {
   filenameFor: (os: string, arch: string) => string | undefined;
   /** 400 message when filenameFor returns undefined (helper's per-OS lookup table). */
   invalidOsMessage?: (os: string) => string;
-  /** Canonical GitHub release asset URL for BINARY_SOURCE=github. */
-  githubUrlFor: (os: string, arch: string) => string;
+  /**
+   * agent_versions.component value for this route, used to resolve the
+   * promoted (isLatest) release the bytes must come from (#3499).
+   */
+  component: PromotedComponent;
+  /**
+   * Canonical GitHub release asset URL for BINARY_SOURCE=github. `version`
+   * pins the release tag to the promoted agent_versions row; when omitted the
+   * builder falls back to the env-resolved BINARY_VERSION/BREEZE_VERSION.
+   */
+  githubUrlFor: (os: string, arch: string, version?: string) => string;
   /** Local binary directory to serve from in non-github mode. */
   binaryDir: () => string;
 }
@@ -81,9 +91,25 @@ function registerComponentDownloadRoute(config: ComponentDownloadConfig): void {
       );
     }
 
-    // GitHub redirect mode — no local binaries needed
+    // GitHub redirect mode — no local binaries needed.
+    //
+    // #3499: pin the release tag to the same agent_versions isLatest row that
+    // GET /agent-versions/latest serves the checksum from. Resolving it from
+    // per-process env here instead let the bytes and the checksum drift a full
+    // release apart whenever the binary sync stalled, which install.sh reports
+    // as "Checksum verification failed for downloaded agent binary". A null
+    // result (no promoted row, or a DB fault — both logged by the resolver)
+    // falls back to the historical env-resolved URL.
     if (getBinarySource() === 'github') {
-      return c.redirect(config.githubUrlFor(os, arch), 302);
+      const promotedVersion = await getPromotedComponentVersion(
+        config.component,
+        os,
+        arch,
+      );
+      return c.redirect(
+        config.githubUrlFor(os, arch, promotedVersion ?? undefined),
+        302,
+      );
     }
 
     // Local mode: try S3 presigned redirect first (bandwidth offload)
@@ -168,6 +194,7 @@ registerComponentDownloadRoute({
   logTag: 'agent-download',
   s3Prefix: 'agent',
   entityLabel: 'Agent binary',
+  component: 'agent',
   filenameFor: perArchFilename('agent'),
   githubUrlFor: getGithubAgentUrl,
   binaryDir: () => resolve(process.env.AGENT_BINARY_DIR || './agent/bin'),
@@ -270,9 +297,10 @@ registerComponentDownloadRoute({
   logTag: 'helper-download',
   s3Prefix: 'helper',
   entityLabel: 'Helper binary',
+  component: 'helper',
   filenameFor: (os) => HELPER_FILENAMES[os],
   invalidOsMessage: (os) => `No helper binary available for OS: ${os}`,
-  githubUrlFor: (os) => getGithubHelperUrl(os),
+  githubUrlFor: (os, _arch, version) => getGithubHelperUrl(os, version),
   binaryDir: () => resolve(process.env.HELPER_BINARY_DIR || './agent/bin'),
 });
 
@@ -289,6 +317,7 @@ registerComponentDownloadRoute({
   logTag: 'watchdog-download',
   s3Prefix: 'watchdog',
   entityLabel: 'Watchdog binary',
+  component: 'watchdog',
   filenameFor: perArchFilename('watchdog'),
   githubUrlFor: getGithubWatchdogUrl,
   binaryDir: () => resolve(process.env.AGENT_BINARY_DIR || './agent/bin'),
@@ -307,6 +336,7 @@ registerComponentDownloadRoute({
   logTag: 'backup-download',
   s3Prefix: 'backup',
   entityLabel: 'Backup binary',
+  component: 'backup',
   filenameFor: perArchFilename('backup'),
   githubUrlFor: getGithubBackupUrl,
   binaryDir: () => resolve(process.env.AGENT_BINARY_DIR || './agent/bin'),
@@ -325,6 +355,7 @@ registerComponentDownloadRoute({
   logTag: 'user-helper-download',
   s3Prefix: 'user-helper',
   entityLabel: 'User-helper binary',
+  component: 'user-helper',
   filenameFor: perArchFilename('user-helper'),
   githubUrlFor: getGithubUserHelperUrl,
   binaryDir: () => resolve(process.env.AGENT_BINARY_DIR || './agent/bin'),

--- a/apps/api/src/routes/agents/helpers.ts
+++ b/apps/api/src/routes/agents/helpers.ts
@@ -2311,6 +2311,13 @@ export async function resolvePinnedUpgradeTarget(args: {
   const { component, platform, architecture, pin, agentId } = args;
 
   if (pin === null) {
+    // LOCKSTEP (#3499): this promoted-row query is duplicated by
+    // services/promotedAgentVersion.ts (which resolves the BYTES the download
+    // route serves) and by GET /agent-versions/latest (which serves the
+    // CHECKSUM). All three must use the same predicates and the same
+    // created_at tiebreak — if the version offered here is not the version
+    // whose bytes get served, agents are told to upgrade to something that
+    // fails checksum verification on arrival.
     const [latest] = await db
       .select({ version: agentVersions.version })
       .from(agentVersions)

--- a/apps/api/src/services/binarySource.test.ts
+++ b/apps/api/src/services/binarySource.test.ts
@@ -1,12 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   getGithubAgentUrl,
+  getGithubBackupUrl,
   getGithubHelperUrl,
   getGithubInstallerAppUrl,
   getGithubRegularMsiUrl,
   getGithubReleasePageUrl,
   getGithubReleaseRepository,
+  getGithubUserHelperUrl,
   getGithubViewerUrl,
+  getGithubWatchdogUrl,
 } from './binarySource';
 
 describe('binarySource release-source unification', () => {
@@ -68,5 +71,77 @@ describe('binarySource release-source unification', () => {
     expect(() => getGithubAgentUrl('windows', 'amd64')).toThrow(
       /Invalid release source repository/,
     );
+  });
+
+  // Issue #3499. The component-download routes resolve the promoted
+  // agent_versions row and pass its version here, so the bytes come from the
+  // same release as the checksum GET /agent-versions/latest handed the client.
+  // Without these assertions the builders could accept the argument and ignore
+  // it — the routes would still "pass a version", every route test would still
+  // pass, and the bug would be back.
+  describe('explicit version overrides the env-resolved release (#3499)', () => {
+    it('pins the release tag to the version passed, not BINARY_VERSION', () => {
+      // The exact production divergence: env says 0.105.1, the promoted row
+      // says 0.104.0. The bytes must come from 0.104.0.
+      process.env.BINARY_VERSION = '0.105.1';
+
+      const url = getGithubAgentUrl('linux', 'amd64', '0.104.0');
+
+      expect(url).toBe(
+        'https://github.com/lanternops/breeze/releases/download/v0.104.0/breeze-agent-linux-amd64',
+      );
+      expect(url).not.toContain('0.105.1');
+    });
+
+    it('pins every component builder, not just the agent', () => {
+      process.env.BINARY_VERSION = '0.105.1';
+      const base = 'https://github.com/lanternops/breeze/releases/download/v0.104.0';
+
+      expect(getGithubBackupUrl('linux', 'amd64', '0.104.0')).toBe(
+        `${base}/breeze-backup-linux-amd64`,
+      );
+      expect(getGithubWatchdogUrl('windows', 'amd64', '0.104.0')).toBe(
+        `${base}/breeze-watchdog-windows-amd64.exe`,
+      );
+      expect(getGithubUserHelperUrl('windows', 'amd64', '0.104.0')).toBe(
+        `${base}/breeze-user-helper-windows-amd64.exe`,
+      );
+      expect(getGithubHelperUrl('darwin', '0.104.0')).toBe(
+        `${base}/breeze-helper-macos.dmg`,
+      );
+    });
+
+    it('overrides even the floating "latest" default when no version is pinned', () => {
+      // With BINARY_VERSION unset the env resolution is the literal "latest",
+      // i.e. whatever GitHub published most recently — an unbounded external
+      // value. A promoted row must still win.
+      expect(getGithubAgentUrl('linux', 'amd64', '0.104.0')).toBe(
+        'https://github.com/lanternops/breeze/releases/download/v0.104.0/breeze-agent-linux-amd64',
+      );
+    });
+
+    it('accepts an already-v-prefixed version without doubling the prefix', () => {
+      expect(getGithubAgentUrl('linux', 'amd64', 'v0.104.0')).toBe(
+        'https://github.com/lanternops/breeze/releases/download/v0.104.0/breeze-agent-linux-amd64',
+      );
+    });
+
+    it('omitting the version preserves the historical env-resolved behavior', () => {
+      process.env.BINARY_VERSION = '0.105.1';
+      expect(getGithubAgentUrl('linux', 'amd64')).toBe(
+        'https://github.com/lanternops/breeze/releases/download/v0.105.1/breeze-agent-linux-amd64',
+      );
+    });
+
+    it('refuses a malformed version rather than 404ing mysteriously', () => {
+      // agent_versions.version has no format constraint and rows are creatable
+      // via POST /agent-versions, so this string is no longer env-only.
+      expect(() => getGithubAgentUrl('linux', 'amd64', '../../evil')).toThrow(
+        /malformed release tag/,
+      );
+      expect(() => getGithubAgentUrl('linux', 'amd64', 'unknown/../x')).toThrow(
+        /malformed release tag/,
+      );
+    });
   });
 });

--- a/apps/api/src/services/binarySource.ts
+++ b/apps/api/src/services/binarySource.ts
@@ -56,6 +56,14 @@ function githubDownloadBase(version?: string): string {
   // agent_versions rows store a bare semver ("0.105.1"); the env var is also
   // bare by convention. Normalize either form to the "v"-prefixed release tag.
   const tag = resolved.startsWith('v') ? resolved : `v${resolved}`;
+  // The tag is now interpolated into a URL path from a DB row (creatable via
+  // POST /agent-versions) rather than only from env, and agent_versions.version
+  // has no format constraint. Refuse anything that could escape the release
+  // path instead of 404ing mysteriously — the same standard releaseSource.ts
+  // applies to the repository segment.
+  if (!/^v[0-9A-Za-z._-]+$/.test(tag)) {
+    throw new Error(`Refusing to build a download URL for malformed release tag "${tag}"`);
+  }
   return `${getReleaseSourceReleaseBase()}/download/${tag}`;
 }
 

--- a/apps/api/src/services/binarySource.ts
+++ b/apps/api/src/services/binarySource.ts
@@ -42,12 +42,21 @@ export function getGithubReleasePageUrl(): string {
   return `${getReleaseSourceReleaseBase()}/tag/v${version}`;
 }
 
-function githubDownloadBase(): string {
-  const version = getGithubReleaseVersion();
-  if (version === 'latest') {
+// `version` overrides the per-process env resolution (BINARY_VERSION /
+// BREEZE_VERSION). Callers that must agree with a checksum served from the
+// agent_versions row — the public component-download routes, see
+// services/promotedAgentVersion.ts and issue #3499 — pass the promoted row's
+// version explicitly so the bytes and the checksum come from one source.
+// Omitting it preserves the historical env-resolved behavior.
+function githubDownloadBase(version?: string): string {
+  const resolved = version ?? getGithubReleaseVersion();
+  if (resolved === 'latest') {
     return `${getReleaseSourceReleaseBase()}/latest/download`;
   }
-  return `${getReleaseSourceReleaseBase()}/download/v${version}`;
+  // agent_versions rows store a bare semver ("0.105.1"); the env var is also
+  // bare by convention. Normalize either form to the "v"-prefixed release tag.
+  const tag = resolved.startsWith('v') ? resolved : `v${resolved}`;
+  return `${getReleaseSourceReleaseBase()}/download/${tag}`;
 }
 
 // Spec 3c serving-surface guard: routes/agents/download.ts redirects and
@@ -55,13 +64,13 @@ function githubDownloadBase(): string {
 // ever seeing a manifest. All canonical asset filenames are static strings
 // today, so this is a tripwire against a future builder (or refactor) leaking
 // a signing-input asset onto a public surface.
-function githubAssetDownloadUrl(filename: string): string {
+function githubAssetDownloadUrl(filename: string, version?: string): string {
   if (isSigningInputAssetName(filename)) {
     throw new Error(
       `Refusing to build a download URL for signing-input asset "${filename}"`,
     );
   }
-  return `${githubDownloadBase()}/${filename}`;
+  return `${githubDownloadBase(version)}/${filename}`;
 }
 
 export function getGithubReleaseRepository(): string {
@@ -82,16 +91,16 @@ export function getGithubReleaseArtifactManifestSignatureUrl(): string {
   return `${githubDownloadBase()}/release-artifact-manifest.json.ed25519`;
 }
 
-export function getGithubAgentUrl(os: string, arch: string): string {
+export function getGithubAgentUrl(os: string, arch: string, version?: string): string {
   const extension = os === 'windows' ? '.exe' : '';
   const filename = `breeze-agent-${os}-${arch}${extension}`;
-  return githubAssetDownloadUrl(filename);
+  return githubAssetDownloadUrl(filename, version);
 }
 
-export function getGithubBackupUrl(os: string, arch: string): string {
+export function getGithubBackupUrl(os: string, arch: string, version?: string): string {
   const extension = os === 'windows' ? '.exe' : '';
   const filename = `breeze-backup-${os}-${arch}${extension}`;
-  return githubAssetDownloadUrl(filename);
+  return githubAssetDownloadUrl(filename, version);
 }
 
 export function getGithubAgentPkgUrl(os: string, arch: string): string {
@@ -99,10 +108,10 @@ export function getGithubAgentPkgUrl(os: string, arch: string): string {
   return githubAssetDownloadUrl(filename);
 }
 
-export function getGithubWatchdogUrl(os: string, arch: string): string {
+export function getGithubWatchdogUrl(os: string, arch: string, version?: string): string {
   const extension = os === 'windows' ? '.exe' : '';
   const filename = `breeze-watchdog-${os}-${arch}${extension}`;
-  return githubAssetDownloadUrl(filename);
+  return githubAssetDownloadUrl(filename, version);
 }
 
 // breeze-user-helper is the GUI-subsystem sibling of breeze-agent. The agent
@@ -110,10 +119,10 @@ export function getGithubWatchdogUrl(os: string, arch: string): string {
 // asset URL helpers and stays OS-general. It is a distinct release asset from
 // the Tauri "helper" app served by HELPER_FILENAMES — don't conflate the two
 // (#1878).
-export function getGithubUserHelperUrl(os: string, arch: string): string {
+export function getGithubUserHelperUrl(os: string, arch: string, version?: string): string {
   const extension = os === 'windows' ? '.exe' : '';
   const filename = `breeze-user-helper-${os}-${arch}${extension}`;
-  return githubAssetDownloadUrl(filename);
+  return githubAssetDownloadUrl(filename, version);
 }
 
 export function getGithubRegularMsiUrl(): string {
@@ -138,10 +147,10 @@ export const HELPER_FILENAMES: Record<string, string> = {
   linux: 'breeze-helper-linux.AppImage',
 };
 
-export function getGithubHelperUrl(os: string): string {
+export function getGithubHelperUrl(os: string, version?: string): string {
   const filename = HELPER_FILENAMES[os];
   if (!filename) throw new Error(`Unknown helper OS: ${os}`);
-  return githubAssetDownloadUrl(filename);
+  return githubAssetDownloadUrl(filename, version);
 }
 
 /**

--- a/apps/api/src/services/binarySync.test.ts
+++ b/apps/api/src/services/binarySync.test.ts
@@ -2604,8 +2604,14 @@ describe("unpublished pinned release is loud, not a /releases/latest fallback (#
 
     await expect(syncBinaries()).rejects.toThrow(/GitHub API error: 404/);
 
+    // The remedy wording changed with #3499: a failed sync no longer leaves the
+    // download redirect disagreeing with agent_versions (the redirect follows
+    // the promoted row now), so the hint says the fleet simply will not advance
+    // rather than promising that setting BINARY_VERSION realigns the redirect.
+    // It must still name BINARY_VERSION as the lever and still refuse the
+    // /releases/latest fallback.
     expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringMatching(/pinned release v0\.106\.0 FAILED.*set BINARY_VERSION to the last PUBLISHED release/s),
+      expect.stringMatching(/pinned release v0\.106\.0 FAILED.*set BINARY_VERSION to a PUBLISHED release/s),
     );
     expect(fetchSpy).not.toHaveBeenCalledWith(
       `${apiBase}/releases/latest`,

--- a/apps/api/src/services/binarySync.ts
+++ b/apps/api/src/services/binarySync.ts
@@ -869,15 +869,20 @@ async function registerFromOfficialManifest(args: {
 /**
  * The GitHub release tag boot-time sync is pinned to (#3742).
  *
- * Every `/api/v1/agents/download/*` redirect is built from
- * getGithubReleaseVersion() (BINARY_VERSION || BREEZE_VERSION), so that is the
- * only release whose bytes this server can actually serve. Boot sync used to
- * fetch `/releases/latest` unconditionally, which — with AGENT_AUTO_PROMOTE
- * defaulting to true — promoted isLatest past the deployed images on a mere
- * API restart: the heartbeat then told agents to upgrade to a version whose
- * assets the redirect couldn't serve, and every attempt died on checksum
- * mismatch. Pinning sync to the same version as the redirect makes "a
- * self-hoster's fleet moves when THEY upgrade their server" the default.
+ * Boot sync used to fetch `/releases/latest` unconditionally, which — with
+ * AGENT_AUTO_PROMOTE defaulting to true — promoted isLatest past the deployed
+ * images on a mere API restart: the heartbeat then told agents to upgrade to a
+ * version whose assets the redirect couldn't serve, and every attempt died on
+ * checksum mismatch. Pinning sync to this version makes "a self-hoster's fleet
+ * moves when THEY upgrade their server" the default.
+ *
+ * NOTE (#3499): this used to also be the only release whose bytes the server
+ * could serve, because every `/api/v1/agents/download/*` redirect was built
+ * from getGithubReleaseVersion(). That is no longer true — the redirect now
+ * follows the promoted `agent_versions` row, so the bytes and the checksum
+ * agree by construction and a stale sync can no longer produce the mismatch
+ * described above. This pin still governs which release boot sync REGISTERS
+ * (and, under AGENT_AUTO_PROMOTE=true, promotes).
  *
  * Returns undefined when no version is pinned (BREEZE_VERSION unset or
  * literally "latest"), preserving the previous /releases/latest behaviour for
@@ -893,10 +898,13 @@ function unpublishedPinnedReleaseHint(pinnedTag: string, err: unknown): string {
   const reason = err instanceof Error ? err.message : String(err);
   return (
     `[binarySync] GitHub sync of pinned release ${pinnedTag} FAILED (${reason}). ` +
-    `No agent binaries were registered for this version. If ${pinnedTag} is not ` +
-    `published yet (server images rolled ahead of the GitHub release), set ` +
-    `BINARY_VERSION to the last PUBLISHED release so boot sync and the download ` +
-    `redirect agree — do not expect a fallback to /releases/latest (#3742).`
+    `No agent binaries were registered for this version, so the fleet stays on ` +
+    `the last successfully synced release: agent_versions is unchanged, and ` +
+    `since #3499 the download routes serve that same promoted release, so ` +
+    `installs and upgrades keep working — they just will not advance to ` +
+    `${pinnedTag}. To move the fleet, publish ${pinnedTag}, or set ` +
+    `BINARY_VERSION to a PUBLISHED release so boot sync can register it. There ` +
+    `is deliberately no fallback to /releases/latest (#3742).`
   );
 }
 
@@ -909,9 +917,13 @@ export async function syncBinaries(): Promise<void> {
     try {
       await syncFromGitHub(pinnedTag);
     } catch (err) {
-      // Deliberately NOT falling back to /releases/latest: that would register
-      // an older release as isLatest while the download redirect stays pinned
-      // to this version, which is the inverse of the #3742 checksum loop.
+      // Deliberately NOT falling back to /releases/latest: that would silently
+      // move the fleet's promoted release to something the operator never
+      // asked for. (Pre-#3499 it was worse still — the download redirect
+      // stayed pinned to this version while isLatest moved, which is the
+      // inverse of the #3742 checksum loop. The redirect now follows the
+      // promoted row, so that particular mismatch is gone; the reason to
+      // refuse the fallback is now intent, not divergence.)
       // Tell the operator what to do instead.
       if (pinnedTag) console.error(unpublishedPinnedReleaseHint(pinnedTag, err));
       throw err;

--- a/apps/api/src/services/promotedAgentVersion.test.ts
+++ b/apps/api/src/services/promotedAgentVersion.test.ts
@@ -229,6 +229,19 @@ describe('getPromotedComponentVersion', () => {
     expect(captureException).toHaveBeenCalledTimes(1);
   });
 
+  it('treats the "unknown" local-registration sentinel as no promoted row', async () => {
+    // binarySync stores the literal "unknown" when BINARY_VERSION_FILE is
+    // unset and promotes it under the default AGENT_AUTO_PROMOTE. Returning it
+    // would build ".../releases/download/vunknown/..." and 404 every download
+    // on a deployment that later switches to BINARY_SOURCE=github.
+    dbMock._setResult([{ version: 'unknown' }]);
+
+    await expect(
+      getPromotedComponentVersion('agent', 'linux', 'amd64'),
+    ).resolves.toBeNull();
+    expect(console.warn).toHaveBeenCalledTimes(1);
+  });
+
   it('THROWS on an unmapped route OS rather than reporting a missing row', async () => {
     // VALID_OS gates this upstream, but that invariant lives in another file.
     // An unmapped OS must not match zero rows and masquerade as a

--- a/apps/api/src/services/promotedAgentVersion.test.ts
+++ b/apps/api/src/services/promotedAgentVersion.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Tests for getPromotedComponentVersion — the single query that makes the
+ * public component-download routes serve bytes from the SAME agent_versions
+ * row that GET /agent-versions/latest serves the checksum from (issue #3499).
+ *
+ * The route-level behavior (redirect target actually uses this version) is
+ * pinned in routes/agents/download.test.ts. This file pins the resolver's own
+ * contract: the WHERE structure it queries with — including the route-os →
+ * DB-platform mapping that a checksum/bytes mismatch would otherwise hide —
+ * and its two fall-back-to-env paths.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks — vi.hoisted() must run before any import.
+// ---------------------------------------------------------------------------
+const { dbMock } = vi.hoisted(() => {
+  let nextResult: unknown[] = [];
+  let nextError: Error | null = null;
+  const chains: any[] = [];
+
+  const makeSelectChain = () => {
+    const settle = () =>
+      nextError ? Promise.reject(nextError) : Promise.resolve(nextResult);
+    const chain: any = {
+      from: vi.fn(() => chain),
+      where: vi.fn(() => chain),
+      orderBy: vi.fn(() => chain),
+      limit: vi.fn(() => settle()),
+    };
+    chains.push(chain);
+    return chain;
+  };
+
+  const dbMock = {
+    select: vi.fn(() => makeSelectChain()),
+    _setResult(rows: unknown[]) {
+      nextResult = rows;
+      nextError = null;
+    },
+    _setError(err: Error) {
+      nextError = err;
+    },
+    /** The `.where()` argument of the most recent select chain. */
+    _lastWhereArg(): unknown {
+      const chain = chains[chains.length - 1];
+      return chain?.where.mock.calls[0]?.[0];
+    },
+    _reset() {
+      chains.length = 0;
+      nextResult = [];
+      nextError = null;
+    },
+  };
+
+  return { dbMock };
+});
+
+vi.mock('../db', () => ({ db: dbMock }));
+
+// Mock columns are plain strings so PgDialect compiles them into bound params,
+// letting the assertions pin the real WHERE structure rather than a substring.
+vi.mock('../db/schema', () => ({
+  agentVersions: {
+    version: 'av.version',
+    platform: 'av.platform',
+    architecture: 'av.architecture',
+    component: 'av.component',
+    isLatest: 'av.is_latest',
+    edition: 'av.edition',
+    createdAt: 'av.created_at',
+  },
+}));
+
+// Import under test — AFTER all mocks are installed.
+import {
+  getPromotedComponentVersion,
+  resetPromotedVersionWarningCache,
+} from './promotedAgentVersion';
+import { PgDialect } from 'drizzle-orm/pg-core';
+
+function compiledWhere() {
+  return new PgDialect().sqlToQuery(dbMock._lastWhereArg() as never);
+}
+
+/** Value bound immediately after `column` in the compiled WHERE params. */
+function boundValueFor(column: string): unknown {
+  const { params } = compiledWhere();
+  const idx = params.indexOf(column);
+  expect(idx).toBeGreaterThanOrEqual(0);
+  return params[idx + 1];
+}
+
+describe('getPromotedComponentVersion', () => {
+  const OLD_EDITION = process.env.BINARY_EDITION;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbMock._reset();
+    resetPromotedVersionWarningCache();
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    if (OLD_EDITION === undefined) delete process.env.BINARY_EDITION;
+    else process.env.BINARY_EDITION = OLD_EDITION;
+    vi.restoreAllMocks();
+  });
+
+  it('returns the promoted version for the requested component/os/arch', async () => {
+    dbMock._setResult([{ version: '0.104.0' }]);
+
+    await expect(
+      getPromotedComponentVersion('agent', 'linux', 'amd64'),
+    ).resolves.toBe('0.104.0');
+  });
+
+  it('maps the route OS "darwin" to the DB platform "macos"', async () => {
+    // agent_versions stores macOS rows as "macos"; the download route paths use
+    // Go GOOS ("darwin"). Querying the unmapped value would match no row, and
+    // the route would silently fall back to the env version — reintroducing
+    // exactly the checksum/bytes divergence this resolver exists to close.
+    dbMock._setResult([{ version: '0.104.0' }]);
+
+    await getPromotedComponentVersion('agent', 'darwin', 'arm64');
+
+    expect(boundValueFor('av.platform')).toBe('macos');
+    expect(boundValueFor('av.architecture')).toBe('arm64');
+  });
+
+  it('passes linux and windows through unmapped', async () => {
+    dbMock._setResult([{ version: '0.104.0' }]);
+    await getPromotedComponentVersion('watchdog', 'windows', 'amd64');
+    expect(boundValueFor('av.platform')).toBe('windows');
+    expect(boundValueFor('av.component')).toBe('watchdog');
+  });
+
+  it('filters on the promoted row and this server edition', async () => {
+    process.env.BINARY_EDITION = 'hosted';
+    dbMock._setResult([{ version: '0.104.0' }]);
+
+    await getPromotedComponentVersion('backup', 'linux', 'amd64');
+
+    expect(boundValueFor('av.is_latest')).toBe(true);
+    // Same edition scoping as /agent-versions/latest (#4072), so the checksum
+    // route and this one can never resolve different editions of a version.
+    expect(boundValueFor('av.edition')).toBe('hosted');
+  });
+
+  it('defaults the edition filter to self-host', async () => {
+    delete process.env.BINARY_EDITION;
+    dbMock._setResult([{ version: '0.104.0' }]);
+
+    await getPromotedComponentVersion('agent', 'linux', 'amd64');
+
+    expect(boundValueFor('av.edition')).toBe('self-host');
+  });
+
+  it('returns null and warns when no promoted row exists', async () => {
+    // A deployment that has never completed a binary sync. The caller must
+    // fall back to the env-resolved version rather than fail the download.
+    dbMock._setResult([]);
+
+    await expect(
+      getPromotedComponentVersion('agent', 'linux', 'amd64'),
+    ).resolves.toBeNull();
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(console.warn).mock.calls[0]?.[0]).toContain('#3499');
+  });
+
+  it('warns only once per component/os/arch for a persistent gap', async () => {
+    // Otherwise a self-hoster with no synced rows logs on every download.
+    dbMock._setResult([]);
+    await getPromotedComponentVersion('agent', 'linux', 'amd64');
+    await getPromotedComponentVersion('agent', 'linux', 'amd64');
+    expect(console.warn).toHaveBeenCalledTimes(1);
+
+    // A different tuple is still reported.
+    await getPromotedComponentVersion('agent', 'windows', 'amd64');
+    expect(console.warn).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns null and logs the fault when the lookup throws', async () => {
+    // Degrades to the pre-#3499 env-resolved behavior instead of turning a
+    // transient DB fault into a failed install. Must never be swallowed.
+    dbMock._setError(new Error('connection terminated'));
+
+    await expect(
+      getPromotedComponentVersion('agent', 'linux', 'amd64'),
+    ).resolves.toBeNull();
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(console.error).mock.calls[0]?.[0]).toContain('#3499');
+  });
+});

--- a/apps/api/src/services/promotedAgentVersion.test.ts
+++ b/apps/api/src/services/promotedAgentVersion.test.ts
@@ -58,6 +58,11 @@ const { dbMock } = vi.hoisted(() => {
 
 vi.mock('../db', () => ({ db: dbMock }));
 
+vi.mock('./sentry', () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
 // Mock columns are plain strings so PgDialect compiles them into bound params,
 // letting the assertions pin the real WHERE structure rather than a substring.
 vi.mock('../db/schema', () => ({
@@ -75,8 +80,10 @@ vi.mock('../db/schema', () => ({
 // Import under test — AFTER all mocks are installed.
 import {
   getPromotedComponentVersion,
-  resetPromotedVersionWarningCache,
+  PromotedVersionUnavailableError,
+  __resetPromotedVersionCaptureCacheForTests,
 } from './promotedAgentVersion';
+import { captureException, captureMessage } from './sentry';
 import { PgDialect } from 'drizzle-orm/pg-core';
 
 function compiledWhere() {
@@ -97,7 +104,7 @@ describe('getPromotedComponentVersion', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     dbMock._reset();
-    resetPromotedVersionWarningCache();
+    __resetPromotedVersionCaptureCacheForTests();
     vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     vi.spyOn(console, 'error').mockImplementation(() => undefined);
   });
@@ -148,6 +155,25 @@ describe('getPromotedComponentVersion', () => {
     expect(boundValueFor('av.edition')).toBe('hosted');
   });
 
+  it('ANDs its predicates with equality — not OR, and not negated', async () => {
+    // The bound-parameter assertions above are blind to SQL structure: they
+    // pass identically whether the predicates are ANDed or ORed, and whether
+    // isLatest is compared with = or <>. Both mutations are catastrophic — OR
+    // returns a row matching ANY clause (bytes for a different
+    // platform/arch/component than the checksum), and <> selects precisely the
+    // NON-promoted rows. Pin the operators themselves.
+    dbMock._setResult([{ version: '0.104.0' }]);
+
+    await getPromotedComponentVersion('agent', 'linux', 'amd64');
+    const { sql } = compiledWhere();
+
+    expect(sql).not.toMatch(/\bor\b/i);
+    expect(sql).toMatch(/\band\b/i);
+    // Five equality predicates, no negation.
+    expect(sql).not.toContain('<>');
+    expect(sql.match(/=/g)).toHaveLength(5);
+  });
+
   it('defaults the edition filter to self-host', async () => {
     delete process.env.BINARY_EDITION;
     dbMock._setResult([{ version: '0.104.0' }]);
@@ -169,27 +195,49 @@ describe('getPromotedComponentVersion', () => {
     expect(vi.mocked(console.warn).mock.calls[0]?.[0]).toContain('#3499');
   });
 
-  it('warns only once per component/os/arch for a persistent gap', async () => {
-    // Otherwise a self-hoster with no synced rows logs on every download.
+  it('logs the missing row EVERY time but captures to Sentry only once per tuple', async () => {
+    // The console line is what an operator greps to confirm the gap is still
+    // happening, so it must not be deduped to one line from whenever the first
+    // download landed. The Sentry capture is the expensive one — dedupe that.
     dbMock._setResult([]);
     await getPromotedComponentVersion('agent', 'linux', 'amd64');
     await getPromotedComponentVersion('agent', 'linux', 'amd64');
-    expect(console.warn).toHaveBeenCalledTimes(1);
 
-    // A different tuple is still reported.
-    await getPromotedComponentVersion('agent', 'windows', 'amd64');
     expect(console.warn).toHaveBeenCalledTimes(2);
+    expect(captureMessage).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(captureMessage).mock.calls[0]?.[1]).toMatchObject({
+      eventCode: 'agent_promoted_version_missing',
+    });
+
+    // A different tuple is a distinct gap and captures again.
+    await getPromotedComponentVersion('agent', 'windows', 'amd64');
+    expect(captureMessage).toHaveBeenCalledTimes(2);
   });
 
-  it('returns null and logs the fault when the lookup throws', async () => {
-    // Degrades to the pre-#3499 env-resolved behavior instead of turning a
-    // transient DB fault into a failed install. Must never be swallowed.
+  it('THROWS when the lookup faults — never silently serves the env version', async () => {
+    // Falling back here would reintroduce #3499 (bytes that do not match the
+    // checksum the client already holds) and would surface a server-side DB
+    // fault to an end user as "Checksum verification failed", the exact string
+    // this fix exists to eliminate. The caller turns this into a 503.
     dbMock._setError(new Error('connection terminated'));
 
     await expect(
       getPromotedComponentVersion('agent', 'linux', 'amd64'),
-    ).resolves.toBeNull();
+    ).rejects.toBeInstanceOf(PromotedVersionUnavailableError);
+
     expect(console.error).toHaveBeenCalledTimes(1);
-    expect(vi.mocked(console.error).mock.calls[0]?.[0]).toContain('#3499');
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it('THROWS on an unmapped route OS rather than reporting a missing row', async () => {
+    // VALID_OS gates this upstream, but that invariant lives in another file.
+    // An unmapped OS must not match zero rows and masquerade as a
+    // never-synced deployment, which would silently fall back to env.
+    dbMock._setResult([{ version: '0.104.0' }]);
+
+    await expect(
+      getPromotedComponentVersion('agent', 'solaris', 'amd64'),
+    ).rejects.toBeInstanceOf(PromotedVersionUnavailableError);
+    expect(dbMock.select).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/services/promotedAgentVersion.ts
+++ b/apps/api/src/services/promotedAgentVersion.ts
@@ -2,6 +2,7 @@ import { and, desc, eq } from 'drizzle-orm';
 import { db } from '../db';
 import { agentVersions } from '../db/schema';
 import { getBinaryEdition } from './binaryEdition';
+import { captureException, captureMessage } from './sentry';
 
 /**
  * Which release the public component-download routes should actually serve.
@@ -21,6 +22,17 @@ import { getBinaryEdition } from './binaryEdition';
  * halves could disagree at all. This resolver is the single query both halves
  * now go through, so a stale sync yields a *consistent old version* instead of
  * an inconsistent pair.
+ *
+ * MUST STAY IN LOCKSTEP with two other readers of the promoted row:
+ *   - `GET /agent-versions/latest` (routes/agentVersions.ts) — serves the
+ *     checksum these bytes are verified against. Same five predicates and the
+ *     same `ORDER BY created_at DESC` tiebreak: if one orders and the other
+ *     does not, a duplicate `isLatest` row makes them select DIFFERENT rows
+ *     and reintroduces #3499 with no signal at all.
+ *   - `resolvePinnedUpgradeTarget({ pin: null })` (routes/agents/helpers.ts)
+ *     — picks the version the heartbeat OFFERS the fleet. If it and this
+ *     resolver disagree, agents are told to upgrade to a version whose bytes
+ *     this server will not serve.
  *
  * `agent_versions` is a global (non-tenant) table with no RLS, so this is safe
  * to call from the public, unauthenticated download routes in any DB context —
@@ -44,45 +56,81 @@ export type PromotedComponent =
   | 'watchdog'
   | 'backup';
 
-// A deployment that has never completed a binary sync has no isLatest row at
-// all, and a self-hoster in that state would otherwise log once per download.
-// Dedupe per (component, os, arch) so a persistent gap reports once per
-// process rather than per request — same shape as warnedMissingPinBuilds in
-// routes/agents/helpers.ts.
-const warnedMissingPromotedRows = new Set<string>();
-
-function warnOnce(key: string, message: string): void {
-  if (warnedMissingPromotedRows.has(key)) return;
-  warnedMissingPromotedRows.add(key);
-  console.warn(message);
+/**
+ * The promoted row could not be read, so we do NOT know which bytes match the
+ * checksum `/agent-versions/latest` is handing out.
+ *
+ * Deliberately NOT degraded into "serve the env-resolved version": that is the
+ * pre-#3499 behavior, i.e. the bug. It would hand the client bytes that fail
+ * the checksum it already holds, surfacing a server-side DB fault to an end
+ * user as "Checksum verification failed for downloaded agent binary" — the
+ * single most misleading message available, and the exact string this fix
+ * exists to eliminate. It would also silently break the lockstep the
+ * component=backup rewrite guard in routes/agentVersions.ts depends on.
+ * Callers should fail the request (503) so the fault is reported where it is.
+ */
+export class PromotedVersionUnavailableError extends Error {
+  constructor(component: string, platform: string, arch: string, cause: unknown) {
+    super(
+      `Could not resolve the promoted agent_versions row for ${component} ` +
+        `${platform}/${arch}; refusing to serve a release that may not match ` +
+        `the checksum clients were given (#3499)`,
+    );
+    this.name = 'PromotedVersionUnavailableError';
+    this.cause = cause;
+  }
 }
 
-/** Test-only: clears the once-per-process warning dedupe. */
-export function resetPromotedVersionWarningCache(): void {
-  warnedMissingPromotedRows.clear();
+// A deployment that has never completed a binary sync has no isLatest row at
+// all. Log EVERY occurrence (an operator grepping needs to see it is ongoing,
+// not one line from whenever the first download happened) but capture to
+// Sentry only once per (component, os, arch) so a persistent gap does not
+// burn the quota — the shape resolvePinnedUpgradeTarget uses in
+// routes/agents/helpers.ts for the analogous fleet-wide freeze.
+const capturedMissingPromotedRows = new Set<string>();
+
+/** Test-only: clears the once-per-process Sentry capture dedupe. */
+export function __resetPromotedVersionCaptureCacheForTests(): void {
+  capturedMissingPromotedRows.clear();
 }
 
 /**
  * Resolve the promoted (`isLatest`) version for a component/os/arch, using the
  * exact row that `GET /agent-versions/latest` would serve a checksum from.
  *
- * Returns `null` when there is no such row, which tells the caller to fall
- * back to the historical env-resolved version. Returning `null` (rather than
- * throwing) on a DB fault is deliberate: it degrades to exactly the behavior
- * this route had before #3499 instead of turning a transient DB blip into a
- * failed install, and the client-side checksum verification remains the
- * backstop either way. The fault is logged, never swallowed silently.
+ * Returns `null` only when there is genuinely no such row — the expected
+ * cold-start state of a deployment that has never synced — which tells the
+ * caller to fall back to the historical env-resolved version so those
+ * deployments keep working exactly as before.
+ *
+ * @throws {PromotedVersionUnavailableError} if the lookup itself fails.
  */
 export async function getPromotedComponentVersion(
   component: PromotedComponent,
   routeOs: string,
   arch: string,
 ): Promise<string | null> {
-  const platform = ROUTE_OS_TO_DB_PLATFORM[routeOs] ?? routeOs;
-  const key = `${component}:${routeOs}:${arch}`;
+  const platform = ROUTE_OS_TO_DB_PLATFORM[routeOs];
+  if (!platform) {
+    // Unreachable while VALID_OS gates the routes, but that invariant lives in
+    // another file. Report it distinctly instead of letting an unmapped OS
+    // match no row and masquerade as a never-synced deployment.
+    throw new PromotedVersionUnavailableError(
+      component,
+      routeOs,
+      arch,
+      new Error(`Unmapped route OS "${routeOs}"`),
+    );
+  }
 
+  // Outside the try: a fail-closed edition misconfiguration is a defect to
+  // surface, not a transient fault to fall back from.
+  const edition = getBinaryEdition();
+  const key = `${component}:${platform}:${arch}`;
+
+  let row: { version: string } | undefined;
   try {
-    const [row] = await db
+    [row] = await db
       .select({ version: agentVersions.version })
       .from(agentVersions)
       .where(
@@ -94,32 +142,44 @@ export async function getPromotedComponentVersion(
           // Each server only serves its own build edition (#4072) — same
           // scoping as /agent-versions/latest, so the checksum route and this
           // one can never land on different editions of the same version.
-          eq(agentVersions.edition, getBinaryEdition()),
+          eq(agentVersions.edition, edition),
         ),
       )
       // Newest first if the single-isLatest invariant is ever violated (it is
       // maintained by demote-then-insert, not by a unique constraint).
+      // /agent-versions/latest applies the SAME tiebreak — see the lockstep
+      // note above; ordering only here would itself cause a divergence.
       .orderBy(desc(agentVersions.createdAt))
       .limit(1);
-
-    if (!row) {
-      warnOnce(
-        key,
-        `[promotedAgentVersion] no promoted ${getBinaryEdition()}-edition ` +
-          `agent_versions row for ${component} ${platform}/${arch}; serving the ` +
-          `env-resolved release version instead. The checksum from ` +
-          `/agent-versions/latest cannot be guaranteed to match these bytes (#3499).`,
-      );
-      return null;
-    }
-
-    return row.version;
   } catch (err) {
     console.error(
-      `[promotedAgentVersion] lookup failed for ${component} ${platform}/${arch}; ` +
-        `falling back to the env-resolved release version (#3499)`,
+      `[promotedAgentVersion] lookup failed for ${component} ${platform}/${arch} ` +
+        `(edition ${edition})`,
       err,
     );
+    captureException(new PromotedVersionUnavailableError(component, platform, arch, err));
+    throw new PromotedVersionUnavailableError(component, platform, arch, err);
+  }
+
+  if (!row) {
+    console.warn(
+      `[promotedAgentVersion] no promoted ${edition}-edition agent_versions row ` +
+        `for ${component} ${platform}/${arch}; serving the env-resolved release ` +
+        `version instead. The checksum from /agent-versions/latest cannot be ` +
+        `guaranteed to match these bytes (#3499).`,
+    );
+    if (!capturedMissingPromotedRows.has(key)) {
+      capturedMissingPromotedRows.add(key);
+      captureMessage(
+        `No promoted agent_versions row for ${component} ${platform}/${arch} ` +
+          `(edition ${edition}); every download of this component falls back to ` +
+          `the env-resolved release and may fail client-side checksum ` +
+          `verification (#3499).`,
+        { eventCode: 'agent_promoted_version_missing', level: 'warning' },
+      );
+    }
     return null;
   }
+
+  return row.version;
 }

--- a/apps/api/src/services/promotedAgentVersion.ts
+++ b/apps/api/src/services/promotedAgentVersion.ts
@@ -157,8 +157,25 @@ export async function getPromotedComponentVersion(
         `(edition ${edition})`,
       err,
     );
-    captureException(new PromotedVersionUnavailableError(component, platform, arch, err));
-    throw new PromotedVersionUnavailableError(component, platform, arch, err);
+    const unavailable = new PromotedVersionUnavailableError(
+      component,
+      platform,
+      arch,
+      err,
+    );
+    captureException(unavailable);
+    throw unavailable;
+  }
+
+  // binarySync's local-registration path stores the literal "unknown" when
+  // BINARY_VERSION_FILE is unset (services/binarySync.ts, registerLocalBinaries),
+  // and registers it with isLatest=true under the default AGENT_AUTO_PROMOTE.
+  // A deployment that later switches to BINARY_SOURCE=github would otherwise
+  // build ".../releases/download/vunknown/..." and 404 every download, where
+  // before #3499 it served the env version. Treat the sentinel as "no usable
+  // promoted row" so that fallback still applies.
+  if (row?.version === 'unknown') {
+    row = undefined;
   }
 
   if (!row) {

--- a/apps/api/src/services/promotedAgentVersion.ts
+++ b/apps/api/src/services/promotedAgentVersion.ts
@@ -1,0 +1,125 @@
+import { and, desc, eq } from 'drizzle-orm';
+import { db } from '../db';
+import { agentVersions } from '../db/schema';
+import { getBinaryEdition } from './binaryEdition';
+
+/**
+ * Which release the public component-download routes should actually serve.
+ *
+ * Issue #3499: the bytes and the checksum used to come from two independent
+ * sources of truth. `GET /agent-versions/latest` reads the checksum from the
+ * `agent_versions` row with `isLatest=true`; `GET /agents/download/:os/:arch`
+ * built its GitHub redirect from `BINARY_VERSION || BREEZE_VERSION` resolved
+ * from per-process env at request time. Those two can disagree — and did, one
+ * full release apart, when the GitHub sync stalled and left `agent_versions`
+ * frozen at 0.104.0 while the download route happily served 0.105.1. install.sh
+ * then fetched a 0.104.0 checksum, downloaded 0.105.1 bytes, and aborted with
+ * "Checksum verification failed for downloaded agent binary".
+ *
+ * The checksum check was not malfunctioning — it correctly refused a binary
+ * that did not match the metadata it was handed. The defect is that the two
+ * halves could disagree at all. This resolver is the single query both halves
+ * now go through, so a stale sync yields a *consistent old version* instead of
+ * an inconsistent pair.
+ *
+ * `agent_versions` is a global (non-tenant) table with no RLS, so this is safe
+ * to call from the public, unauthenticated download routes in any DB context —
+ * the same reason `GET /agent-versions/latest` queries it with the bare `db`
+ * handle.
+ */
+
+// Route paths use Go GOOS names ("darwin"); agent_versions stores "macos".
+// Mirrors PLATFORM_MAP in routes/agentVersions.ts.
+const ROUTE_OS_TO_DB_PLATFORM: Record<string, string> = {
+  linux: 'linux',
+  darwin: 'macos',
+  windows: 'windows',
+};
+
+/** The components registered in agent_versions that have a download route. */
+export type PromotedComponent =
+  | 'agent'
+  | 'helper'
+  | 'user-helper'
+  | 'watchdog'
+  | 'backup';
+
+// A deployment that has never completed a binary sync has no isLatest row at
+// all, and a self-hoster in that state would otherwise log once per download.
+// Dedupe per (component, os, arch) so a persistent gap reports once per
+// process rather than per request — same shape as warnedMissingPinBuilds in
+// routes/agents/helpers.ts.
+const warnedMissingPromotedRows = new Set<string>();
+
+function warnOnce(key: string, message: string): void {
+  if (warnedMissingPromotedRows.has(key)) return;
+  warnedMissingPromotedRows.add(key);
+  console.warn(message);
+}
+
+/** Test-only: clears the once-per-process warning dedupe. */
+export function resetPromotedVersionWarningCache(): void {
+  warnedMissingPromotedRows.clear();
+}
+
+/**
+ * Resolve the promoted (`isLatest`) version for a component/os/arch, using the
+ * exact row that `GET /agent-versions/latest` would serve a checksum from.
+ *
+ * Returns `null` when there is no such row, which tells the caller to fall
+ * back to the historical env-resolved version. Returning `null` (rather than
+ * throwing) on a DB fault is deliberate: it degrades to exactly the behavior
+ * this route had before #3499 instead of turning a transient DB blip into a
+ * failed install, and the client-side checksum verification remains the
+ * backstop either way. The fault is logged, never swallowed silently.
+ */
+export async function getPromotedComponentVersion(
+  component: PromotedComponent,
+  routeOs: string,
+  arch: string,
+): Promise<string | null> {
+  const platform = ROUTE_OS_TO_DB_PLATFORM[routeOs] ?? routeOs;
+  const key = `${component}:${routeOs}:${arch}`;
+
+  try {
+    const [row] = await db
+      .select({ version: agentVersions.version })
+      .from(agentVersions)
+      .where(
+        and(
+          eq(agentVersions.platform, platform),
+          eq(agentVersions.architecture, arch),
+          eq(agentVersions.component, component),
+          eq(agentVersions.isLatest, true),
+          // Each server only serves its own build edition (#4072) — same
+          // scoping as /agent-versions/latest, so the checksum route and this
+          // one can never land on different editions of the same version.
+          eq(agentVersions.edition, getBinaryEdition()),
+        ),
+      )
+      // Newest first if the single-isLatest invariant is ever violated (it is
+      // maintained by demote-then-insert, not by a unique constraint).
+      .orderBy(desc(agentVersions.createdAt))
+      .limit(1);
+
+    if (!row) {
+      warnOnce(
+        key,
+        `[promotedAgentVersion] no promoted ${getBinaryEdition()}-edition ` +
+          `agent_versions row for ${component} ${platform}/${arch}; serving the ` +
+          `env-resolved release version instead. The checksum from ` +
+          `/agent-versions/latest cannot be guaranteed to match these bytes (#3499).`,
+      );
+      return null;
+    }
+
+    return row.version;
+  } catch (err) {
+    console.error(
+      `[promotedAgentVersion] lookup failed for ${component} ${platform}/${arch}; ` +
+        `falling back to the env-resolved release version (#3499)`,
+      err,
+    );
+    return null;
+  }
+}

--- a/apps/api/src/services/sentryEventCodes.ts
+++ b/apps/api/src/services/sentryEventCodes.ts
@@ -107,6 +107,11 @@ export const SENTRY_EVENT_CODES = [
   /** Snapshots are unattributable because two orgs share a destination. */
   'backup_snapshot_ambiguous_destination',
 
+  // --- agent binary serving ---------------------------------------------
+  /** No promoted `agent_versions` row, so downloads fall back to the
+   *  env-resolved release and may fail client-side checksums (#3499). */
+  'agent_promoted_version_missing',
+
   // --- device lifecycle -------------------------------------------------
   /** The device cascade could not read the caller's prior `lock_timeout`. */
   'device_deletion_lock_timeout_unreadable',


### PR DESCRIPTION
Closes #3499

## The defect

`install.sh` fetches the expected SHA-256 from `GET /agent-versions/latest` (the `agent_versions` row with `isLatest=true`) and then downloads the bytes from `GET /agents/download/:os/:arch`. Those two endpoints resolved "which release is current" through **two independent mechanisms**:

- **checksum** — the promoted `agent_versions` row, written by `binarySync`.
- **bytes** — `getGithubReleaseVersion()` (`services/binarySource.ts:33`), reading `BINARY_VERSION || BREEZE_VERSION` from **per-process env at request time**.

So the download path was structurally incapable of agreeing with the checksum path except by coincidence. When the GitHub sync stalled, `agent_versions` stayed frozen at 0.104.0 while the route happily served 0.105.1 — one full release apart — and the install aborted with `Checksum verification failed for downloaded agent binary`.

To be explicit about what was *not* wrong: the checksum check behaved correctly. It refused a binary that genuinely did not match the metadata it was handed, and this has nothing to do with code signing. The defect is that the two halves could disagree at all.

## The fix

Both halves now go through one query. `services/promotedAgentVersion.ts` resolves the promoted (`isLatest`) row — same platform/arch/component/**edition** scoping *and the same `created_at DESC` tiebreak* as `/agent-versions/latest` — and the download routes pin the GitHub release tag to it. A stale sync now yields a *consistent old version* instead of an inconsistent pair.

Applied to all five components pulled with a checksum comparison, not just the agent: `install.sh` checksum-verifies **backup** the same way it does the agent, and watchdog / user-helper / helper are fetched by the agent's verified updater against the same metadata.

**Two distinct failure modes, deliberately handled differently:**

| condition | behavior | why |
|---|---|---|
| No promoted row at all | Fall back to the env-resolved URL, log every time, capture to Sentry once per tuple | The cold-start state of a deployment that has never synced. Must keep working exactly as before. |
| Lookup **faults** | Throw → route returns **503 + Retry-After** | Falling back here *is* the pre-#3499 bug: it hands the client bytes that fail the checksum it already holds, reporting a server-side DB fault to an end user as "Checksum verification failed" — the exact string this fix eliminates. |

## Coupled change worth reviewing closely

`/agent-versions/:version/download` gates its `component=backup` URL rewrite on "is this row what the versionless route will serve". It used to hardcode *the env version*, correct only while the route resolved env.

Rather than restate the route's new rule here (a plain `isLatest` test would have been wrong too — for a never-synced deployment nothing is promoted and the route legitimately falls back to env, which would have silently removed backup self-heal for exactly the deployments the fallback protects), **the guard now asks the route's own resolver what will be served and compares.** The two cannot drift.

## Verification

- **Mutation-tested**, because a reviewer found the original tests could not detect a revert. Each of these previously survived and now fails:
  - builders accepting the promoted version and **ignoring** it — a complete revert of the fix — passed all ~30k API tests before; now fails 5.
  - `and(...)` → `or(...)` and `eq(isLatest,true)` → `ne(...)` in the resolver — both passed before; now fail.
  - the `darwin`→`macos` platform mapping.
- The regression test was red before the fix with exactly the reported symptom (`Expected v0.104.0, Received v0.105.1`).
- Affected suites green single-run: 12 files / ~540 tests across `promotedAgentVersion`, `binarySource`, `binarySync`, `agents/download`, `agentVersions`, `agentVersionsLocalModeRoundtrip`, `supportPublic`, `viewers/download`, `helpers.agentUpdatePolicy`, `heartbeat`, `sentry*`.
- `tsc --noEmit` clean; `eslint` clean on all touched files.
- CI's `BINARY_SOURCE=github download path` smoke job (real API + real DB) passed on the first commit — end-to-end evidence the DB lookup works outside the mocks.

## Notes for the reviewer

- **`/agent-versions/latest` had no `ORDER BY`.** Nothing enforces one promoted row per `(component, platform, arch, edition)` — the invariant is demote-then-insert, not a unique constraint — so adding the tiebreak to only the new resolver would have made the two halves select *different* rows on a duplicate. Both now share it, and a test pins it. **A partial unique index on `isLatest` is the real fix and is worth a follow-up.**
- **`#3742`'s operator guidance was made false by this change** and is updated: it told operators to set `BINARY_VERSION` "so boot sync and the download redirect agree", but the redirect follows the promoted row now.
- **macOS `.pkg` is deliberately not pinned.** Its install path verifies xar magic bytes and Gatekeeper notarization, never a SHA-256 against `/agent-versions/latest`, so there is no checksum/bytes pair to keep consistent. Pinned as a test so it reads as intentional. Consequence: a macOS install lands on the env release while Linux lands on the promoted one, reconciling on first heartbeat.
- **Not fixed here:** for non-backup components the rewrite stays unconditional, so an agent pinned to a *non-promoted* version still gets the promoted bytes and fails safe without healing. Pre-existing and unchanged (it previously got the env version, equally mismatched); gating every component looked like a deliberate design decision to leave alone.
- **`BINARY_SOURCE=local` is still unpinned** — this fix reconciles the github branch only.
- Adds one indexed read to a public route that already 302-redirects. A short TTL cache would make it free if that ever matters.

No schema or migration changes — `agent_versions` is a global, non-RLS catalog table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JCiqAhFVwT5hWi9kWz4vED
