### PR TITLE
perf(api): index-driven audit retention cutoff + batched deletes (#4239)

### DIFF
--- a/apps/api/src/__tests__/integration/audit-retention.integration.test.ts
+++ b/apps/api/src/__tests__/integration/audit-retention.integration.test.ts
@@ -151,6 +151,136 @@ describe('audit-log retention pruning', () => {
     expect(postBreaks[0]?.n).toBe(0);
   });
 
+  /**
+   * Issue #4239 rewrote the prefix bound from `MIN(chain_seq)` over the full
+   * `audit_log_chain ⋈ audit_logs` join to an ordered early-stop
+   * (`ORDER BY chain_seq LIMIT 1`), and split the DELETE into `LIMIT` batches.
+   * The invariant those must not break is the one the prefix-cut design
+   * (#1002) exists for: chain_seq is COMMIT order, so timestamps can run
+   * old → young → old along the chain, and retention must delete ONLY the
+   * leading old prefix.
+   */
+  describe('chain-prefix invariant under the #4239 rewrite', () => {
+    // Each execute() is its own transaction, so statement order == chain_seq order.
+    const seed = async (rows: Array<{ action: string; ageDays: number }>) => {
+      for (const row of rows) {
+        await getTestDb().execute(sql`
+          INSERT INTO audit_logs (org_id, actor_type, actor_id, action, resource_type, result, timestamp)
+          VALUES (${orgId}, 'system', gen_random_uuid(), ${row.action}, 'test', 'success',
+                  now() - (${row.ageDays}::int * interval '1 day'))
+        `);
+      }
+    };
+
+    const survivors = async () =>
+      (await getTestDb().execute(sql`
+        SELECT a.action, c.chain_seq::text AS chain_seq
+        FROM audit_logs a
+        JOIN audit_log_chain c ON c.audit_id = a.id
+        WHERE a.org_id = ${orgId}
+        ORDER BY c.chain_seq
+      `)) as unknown as Array<{ action: string; chain_seq: string }>;
+
+    const chainBreaks = async () => {
+      const rows = (await getTestDb().execute(
+        sql`SELECT count(*)::int AS n FROM audit_log_verify_chain(${orgId})`,
+      )) as unknown as Array<{ n: number }>;
+      return rows[0]?.n;
+    };
+
+    beforeEach(async () => {
+      await getTestDb().execute(sql`
+        INSERT INTO audit_retention_policies (org_id, retention_days) VALUES (${orgId}, 30)
+      `);
+    });
+
+    it('old → young → old in chain order: deletes only the leading old prefix and leaves the chain verifiable', async () => {
+      await seed([
+        { action: 'old-leading', ageDays: 90 },
+        { action: 'young-blocker', ageDays: 5 },
+        { action: 'old-straggler', ageDays: 60 },
+      ]);
+      expect(await chainBreaks()).toBe(0);
+
+      const stats = await pruneExpiredAuditLogs();
+      expect(stats.errors).toBe(0);
+      // Only the row BELOW the first young entry goes. The 60-day straggler
+      // sits behind it in chain order and must survive this cycle — deleting
+      // it would punch a permanent hole in the linkage.
+      expect(stats.rowsDeleted).toBe(1);
+
+      expect((await survivors()).map((r) => r.action)).toEqual([
+        'young-blocker',
+        'old-straggler',
+      ]);
+      expect(await chainBreaks()).toBe(0);
+    });
+
+    it('drains a multi-batch prefix completely and stays verifiable', async () => {
+      await seed([
+        { action: 'old-1', ageDays: 95 },
+        { action: 'old-2', ageDays: 94 },
+        { action: 'old-3', ageDays: 93 },
+        { action: 'old-4', ageDays: 92 },
+        { action: 'old-5', ageDays: 91 },
+        { action: 'young', ageDays: 1 },
+      ]);
+
+      const stats = await pruneExpiredAuditLogs({ batchSize: 2, maxBatches: 50 });
+
+      expect(stats.rowsDeleted).toBe(5);
+      expect(stats.orgsWithBacklog).toBe(0);
+      expect((await survivors()).map((r) => r.action)).toEqual(['young']);
+      expect(await chainBreaks()).toBe(0);
+    });
+
+    it('stopping at the maxBatches ceiling leaves a contiguous suffix, not holes', async () => {
+      await seed([
+        { action: 'old-1', ageDays: 95 },
+        { action: 'old-2', ageDays: 94 },
+        { action: 'old-3', ageDays: 93 },
+        { action: 'old-4', ageDays: 92 },
+        { action: 'old-5', ageDays: 91 },
+        { action: 'old-6', ageDays: 90 },
+        { action: 'young', ageDays: 1 },
+      ]);
+
+      // 2 batches x 2 rows = 4 of the 6 expired rows; the ceiling stops the loop
+      // while full batches are still coming back.
+      const capped = await pruneExpiredAuditLogs({ batchSize: 2, maxBatches: 2 });
+      expect(capped.rowsDeleted).toBe(4);
+      expect(capped.orgsWithBacklog).toBe(1);
+      expect(capped.errors).toBe(0);
+
+      // The batches must have taken the LOWEST chain_seq values. Anything else
+      // (an unordered LIMIT) would leave a gap mid-chain here.
+      const remaining = await survivors();
+      expect(remaining.map((r) => r.action)).toEqual(['old-5', 'old-6', 'young']);
+      expect(await chainBreaks()).toBe(0);
+
+      // The next run continues the prefix rather than being stuck.
+      const rest = await pruneExpiredAuditLogs({ batchSize: 2, maxBatches: 50 });
+      expect(rest.rowsDeleted).toBe(2);
+      expect(rest.orgsWithBacklog).toBe(0);
+      expect((await survivors()).map((r) => r.action)).toEqual(['young']);
+      expect(await chainBreaks()).toBe(0);
+    });
+
+    it('an org whose rows are all inside the window is untouched and reports no backlog', async () => {
+      await seed([
+        { action: 'young-1', ageDays: 3 },
+        { action: 'young-2', ageDays: 2 },
+      ]);
+
+      const stats = await pruneExpiredAuditLogs({ batchSize: 1, maxBatches: 5 });
+
+      expect(stats.rowsDeleted).toBe(0);
+      expect(stats.orgsWithBacklog).toBe(0);
+      expect((await survivors()).map((r) => r.action)).toEqual(['young-1', 'young-2']);
+      expect(await chainBreaks()).toBe(0);
+    });
+  });
+
   // Regression guard: the bypass GUC must default to off. Without
   // setting it, `breeze_app` (even with the audit_admin role membership)
   // must still see the trigger fire on DELETE.

--- a/apps/api/src/__tests__/integration/audit-retention.integration.test.ts
+++ b/apps/api/src/__tests__/integration/audit-retention.integration.test.ts
@@ -108,11 +108,18 @@ describe('audit-log retention pruning', () => {
     expect(second.errors).toBe(0);
   });
 
-  // Regression guard: pruning must re-anchor the surviving chain so the
-  // verifier still passes. Without the re-anchor, the new oldest row's
-  // prev_checksum still references a deleted row and the verifier flags
-  // it as a tamper.
-  it('re-anchors the hash chain after pruning so audit_log_verify_chain passes', async () => {
+  // Regression guard for the #1002 trusted-anchor rule. NOTE: the name/comment
+  // here used to say retention "re-anchors" the chain — it does not, and cannot:
+  // migration 2026-06-11-g REVOKEs UPDATE from breeze_audit_admin and
+  // audit_log_chain_block_update raises on every UPDATE. Retention deletes a
+  // PREFIX and rewrites nothing; the verifier treats the first surviving entry's
+  // prev_chain_checksum as the trusted anchor.
+  //
+  // The load-bearing assertion is the verify_chain call at the end. The
+  // prev_checksum check below is only a shape check — the seal trigger
+  // (2026-06-11-h) NULLs audit_logs.prev_checksum on EVERY insert, so it would
+  // hold even if the prune did nothing.
+  it('leaves a verifiable chain after pruning, with no re-anchor', async () => {
     await getTestDb().execute(sql`
       INSERT INTO audit_retention_policies (org_id, retention_days)
       VALUES (${orgId}, 30)
@@ -230,6 +237,10 @@ describe('audit-log retention pruning', () => {
 
       expect(stats.rowsDeleted).toBe(5);
       expect(stats.orgsWithBacklog).toBe(0);
+      // Pins that the DELETE's LIMIT really is batchSize: 5 rows at 2 per batch
+      // is 2+2+1 = 3 prefix statements, plus 1 sweep. A statement that bound the
+      // ceiling (50) instead would take all 5 in one batch and report 2.
+      expect(stats.batches).toBe(4);
       expect((await survivors()).map((r) => r.action)).toEqual(['young']);
       expect(await chainBreaks()).toBe(0);
     });
@@ -264,6 +275,53 @@ describe('audit-log retention pruning', () => {
       expect(rest.orgsWithBacklog).toBe(0);
       expect((await survivors()).map((r) => r.action)).toEqual(['young']);
       expect(await chainBreaks()).toBe(0);
+    });
+
+    // The unsealed sweep is the one statement no other test ever makes delete a
+    // row: every seeded row gets a chain entry from the deferred seal trigger, so
+    // the sweep always matches zero and only its syntax was proven. It runs in
+    // SYSTEM scope (accessible_org_ids = '*') against a FORCE-RLS table, so RLS
+    // will not catch a mis-scoped predicate — this is the only thing that would.
+    it('sweeps unsealed expired rows for the policy org only, leaving other tenants alone', async () => {
+      const otherPartner = await createPartner();
+      const otherOrg = await createOrganization({ partnerId: otherPartner.id });
+
+      // session_replication_role=replica suppresses the deferred seal trigger, so
+      // these rows land in audit_logs with no audit_log_chain entry — the shape
+      // the sweep exists for. SET LOCAL keeps it scoped to this transaction.
+      await getTestDb().transaction(async (tx) => {
+        await tx.execute(sql`SET LOCAL session_replication_role = replica`);
+        await tx.execute(sql`
+          INSERT INTO audit_logs (org_id, actor_type, actor_id, action, resource_type, result, timestamp)
+          VALUES
+            (${orgId}, 'system', gen_random_uuid(), 'unsealed-old', 'test', 'success', now() - interval '90 days'),
+            (${orgId}, 'system', gen_random_uuid(), 'unsealed-young', 'test', 'success', now() - interval '2 days'),
+            (${otherOrg.id}, 'system', gen_random_uuid(), 'other-org-old', 'test', 'success', now() - interval '90 days')
+        `);
+      });
+
+      const unsealed = (await getTestDb().execute(sql`
+        SELECT count(*)::int AS n FROM audit_logs a
+        WHERE NOT EXISTS (SELECT 1 FROM audit_log_chain c WHERE c.audit_id = a.id)
+      `)) as unknown as Array<{ n: number }>;
+      expect(unsealed[0]?.n).toBe(3); // the fixture really is unsealed
+
+      // Only orgId has a retention policy (this describe's beforeEach).
+      const stats = await pruneExpiredAuditLogs();
+
+      expect(stats.errors).toBe(0);
+      // Exactly the one expired unsealed row belonging to the policy's org.
+      expect(stats.unsealedRowsDeleted).toBe(1);
+
+      const remaining = (await getTestDb().execute(sql`
+        SELECT a.action, a.org_id::text AS org_id FROM audit_logs a
+        WHERE NOT EXISTS (SELECT 1 FROM audit_log_chain c WHERE c.audit_id = a.id)
+        ORDER BY a.action
+      `)) as unknown as Array<{ action: string; org_id: string }>;
+      // The young row stays (inside the window); the OTHER TENANT's expired row
+      // stays because it has no policy and is not this org.
+      expect(remaining.map((r) => r.action)).toEqual(['other-org-old', 'unsealed-young']);
+      expect(remaining.find((r) => r.action === 'other-org-old')?.org_id).toBe(otherOrg.id);
     });
 
     it('an org whose rows are all inside the window is untouched and reports no backlog', async () => {

--- a/apps/api/src/__tests__/integration/auditRetentionPrivSep.integration.test.ts
+++ b/apps/api/src/__tests__/integration/auditRetentionPrivSep.integration.test.ts
@@ -96,6 +96,57 @@ describe('#915 audit-retention privilege separation', () => {
     expect(after[0]?.n).toBe(0);
   });
 
+  // The dedicated pool is the PRODUCTION path, but every batching/ceiling case
+  // lives in the legacy-path file (the unit tests leave AUDIT_ADMIN_DATABASE_URL
+  // unset, so `pruneOrg` takes the breeze_app branch there). `deleteChainPrefix`
+  // is executor-agnostic, but "agnostic" is a claim until it is exercised: the
+  // dedicated pool sets its own system-scope GUCs, so a batch loop or the
+  // hoisted cutoff SELECT could behave differently here and nothing would know.
+  it('batches the prefix cut and honours the ceiling on the dedicated pool too', async () => {
+    process.env.AUDIT_ADMIN_DATABASE_URL = buildAuditAdminUrl();
+    await closeAuditAdminPool();
+    expect(hasDedicatedAuditAdminPool()).toBe(true);
+
+    await getTestDb().execute(sql`
+      INSERT INTO audit_retention_policies (org_id, retention_days)
+      VALUES (${orgId}, 30)
+    `);
+    // Each execute is its own transaction, so statement order == chain_seq order.
+    for (const days of [95, 94, 93, 92, 91]) {
+      await getTestDb().execute(sql`
+        INSERT INTO audit_logs (org_id, actor_type, actor_id, action, resource_type, result, timestamp)
+        VALUES (${orgId}, 'system', gen_random_uuid(), ${`old-${days}`}, 'test', 'success',
+                now() - (${days}::int * interval '1 day'))
+      `);
+    }
+    await getTestDb().execute(sql`
+      INSERT INTO audit_logs (org_id, actor_type, actor_id, action, resource_type, result, timestamp)
+      VALUES (${orgId}, 'system', gen_random_uuid(), 'young', 'test', 'success', now() - interval '1 day')
+    `);
+
+    // 2 batches x 2 rows = 4 of the 5 expired rows; the ceiling stops the loop.
+    const capped = await pruneExpiredAuditLogs({ batchSize: 2, maxBatches: 2 });
+    expect(capped.errors).toBe(0);
+    expect(capped.rowsDeleted).toBe(4);
+    expect(capped.orgsWithBacklog).toBe(1);
+    expect(capped.backloggedOrgIds).toContain(orgId);
+
+    // Ordered batches leave a contiguous suffix, so the chain still verifies.
+    const breaks = (await getTestDb().execute(
+      sql`SELECT count(*)::int AS n FROM audit_log_verify_chain(${orgId})`,
+    )) as unknown as Array<{ n: number }>;
+    expect(breaks[0]?.n).toBe(0);
+
+    const rest = await pruneExpiredAuditLogs({ batchSize: 2, maxBatches: 50 });
+    expect(rest.rowsDeleted).toBe(1);
+    expect(rest.orgsWithBacklog).toBe(0);
+
+    const survivors = (await getTestDb().execute(
+      sql`SELECT action FROM audit_logs WHERE org_id = ${orgId}`,
+    )) as unknown as Array<{ action: string }>;
+    expect(survivors.map((r) => r.action)).toEqual(['young']);
+  });
+
   it('after REVOKE, breeze_app can no longer SET ROLE breeze_audit_admin', async () => {
     // Open a short-lived breeze_app connection so we can prove the
     // privilege boundary directly, independent of the app pool.

--- a/apps/api/src/jobs/auditRetention.test.ts
+++ b/apps/api/src/jobs/auditRetention.test.ts
@@ -87,8 +87,29 @@ import {
 const ORIGINAL_FLAG = process.env.AUDIT_RETENTION_ENABLED;
 
 /**
- * Flatten a drizzle `sql` template back to its literal SQL text (params drop
- * out, which is all we need to identify and assert on a statement).
+ * Bound parameter VALUES of a drizzle `sql` template, in order.
+ *
+ * This exists because `sqlText` below CANNOT SEE NUMBERS. Measured in this test
+ * environment: `queryChunks` holds `StringChunk` objects (own `value: string[]`)
+ * for literal SQL and raw primitives for bound params. `sqlText` returns a chunk
+ * only when `typeof chunk === 'string'`, so string params are inlined verbatim
+ * while NUMBER params map to ''. A statement binding `LIMIT ${maxBatches}`
+ * instead of `LIMIT ${batchSize}` therefore flattens BYTE-IDENTICALLY, and no
+ * text assertion can tell them apart. Assert through here when the value matters.
+ */
+function sqlParams(query: unknown): unknown[] {
+  const chunks = (query as { queryChunks?: unknown[] } | undefined)?.queryChunks;
+  if (!Array.isArray(chunks)) return [];
+  // Anything that is not a StringChunk (own array-valued `.value`) is a param.
+  return chunks.filter((chunk) => !Array.isArray((chunk as { value?: unknown } | null)?.value));
+}
+
+/**
+ * Flatten a drizzle `sql` template to its literal SQL text.
+ *
+ * Caveat: NUMBER params vanish and STRING params are inlined verbatim (see
+ * `sqlParams`), so `classify` matches against text containing fixture values
+ * like `org-a`. Keep fixture strings free of SQL keywords.
  */
 function sqlText(query: unknown): string {
   const chunks = (query as { queryChunks?: Array<{ value?: unknown } | string> }).queryChunks;
@@ -123,6 +144,12 @@ const executedKinds = (): StatementKind[] => executedSql().map(classify);
  * Route the shared `db.execute` mock by statement kind instead of by call
  * ordinal. Ordinal mocking cannot express the batch loops (their call count is
  * data-dependent), and a miscount would silently shift every later expectation.
+ *
+ * BATCH SCRIPT SEMANTICS: `prefixBatches`/`unsealedBatches` are consumed one per
+ * call, and the LAST element is STICKY — it repeats forever. That is deliberate:
+ * `[10]` with a ceiling models "always a full batch" for the backlog tests. The
+ * corollary is that a script whose last element is >= batchSize never ends the
+ * loop naturally, so end it with a short batch when you mean "then it drained".
  */
 function mockByStatement(handlers: {
   policies?: Array<{ id: string; org_id: string; retention_days: number }>;
@@ -321,8 +348,9 @@ describe('auditRetention worker', () => {
       expect(cutoff).toMatch(/ORDER BY c2\.chain_seq\s+LIMIT 1/);
       // The regression itself: no MIN() aggregate anywhere in the cutoff read.
       expect(cutoff).not.toMatch(/MIN\s*\(/i);
-      // The all-old fallback (MAX+1) stays — it is an index-backed lookup on
-      // (org_id, chain_seq DESC), not a scan.
+      // The all-old fallback (MAX+1) stays. Expected to plan as an index scan on
+      // (org_id, chain_seq DESC), though this test asserts only the SQL shape —
+      // no plan is verified here.
       expect(cutoff).toMatch(/MAX\(c3\.chain_seq\) \+ 1/);
       // Hoisted out of the DELETE so the bound is computed once per policy
       // rather than re-planned inside every batch.
@@ -344,10 +372,38 @@ describe('auditRetention worker', () => {
       const prefixDelete = executedSql().find((t) => classify(t) === 'prefixDelete');
       expect(prefixDelete).toBeDefined();
       expect(prefixDelete).toMatch(/ORDER BY c\.chain_seq\s+LIMIT/);
-      expect(prefixDelete).toMatch(/c\.chain_seq </);
+      // Trailing space matters: `/c\.chain_seq </` also matches `<=`, which
+      // would delete the first YOUNG row and break the prefix invariant.
+      expect(prefixDelete).toMatch(/c\.chain_seq < /);
 
       const sweep = executedSql().find((t) => classify(t) === 'unsealedSweep');
       expect(sweep).toMatch(/LIMIT/);
+    });
+
+    // The LIMIT bound is a NUMBER param, so it is invisible to the flattened
+    // SQL text — a statement binding `LIMIT ${maxBatches}` reads identically.
+    // Without this control, that mutant survives the whole suite and ships a job
+    // that deletes `maxBatches` rows per batch while the short-batch check still
+    // compares against `batchSize`, terminating after ONE batch and reporting
+    // success. Assert the bound VALUE, not the text.
+    it('binds the batch LIMIT to batchSize (not maxBatches) in both DELETEs', async () => {
+      mockByStatement({
+        policies: [{ id: 'p1', org_id: 'org-a', retention_days: 30 }],
+        cutoffSeq: '1000',
+      });
+
+      await pruneExpiredAuditLogs({ batchSize: 37, maxBatches: 9 });
+
+      const call = (kind: StatementKind) =>
+        dbExecuteMock.mock.calls.find((c: unknown[]) => classify(sqlText(c[0])) === kind)?.[0];
+
+      const prefixParams = sqlParams(call('prefixDelete'));
+      expect(prefixParams).toContain(37);
+      expect(prefixParams).not.toContain(9);
+
+      const sweepParams = sqlParams(call('unsealedSweep'));
+      expect(sweepParams).toContain(37);
+      expect(sweepParams).not.toContain(9);
     });
 
     it('keeps issuing prefix batches until one comes back short of the limit', async () => {
@@ -429,6 +485,125 @@ describe('auditRetention worker', () => {
       expect(executedKinds()).not.toContain('unsealedSweep');
     });
 
+    it('raises when the cutoff row is present but the column is missing', async () => {
+      dbExecuteMock.mockImplementation(async (query: unknown) => {
+        switch (classify(sqlText(query))) {
+          case 'policySelect':
+            return [{ id: 'p1', org_id: 'org-a', retention_days: 30 }];
+          case 'cutoff':
+            return [{}]; // column renamed / adapter reshaped the row
+          default:
+            return [];
+        }
+      });
+
+      const stats = await pruneExpiredAuditLogs();
+
+      expect(stats.errors).toBe(1);
+      expect(executedKinds()).not.toContain('prefixDelete');
+    });
+
+    // A DELETE always carries a driver row count. `extractRowCount` returns 0 for
+    // an unrecognised shape, and a 0 ENDS the batch loop — so without this guard
+    // a driver/adapter change silently retains expired rows and reports success.
+    it('raises when a batch DELETE returns no driver row count', async () => {
+      dbExecuteMock.mockImplementation(async (query: unknown) => {
+        switch (classify(sqlText(query))) {
+          case 'policySelect':
+            return [{ id: 'p1', org_id: 'org-a', retention_days: 30 }];
+          case 'cutoff':
+            return [{ cutoff_seq: '1000' }];
+          case 'prefixDelete':
+            return { command: 'DELETE' }; // no rowCount, no count
+          default:
+            return [];
+        }
+      });
+
+      const stats = await pruneExpiredAuditLogs();
+
+      expect(stats.errors).toBe(1);
+      expect(stats.orgsPruned).toBe(0);
+      expect(stats.rowsDeleted).toBe(0);
+    });
+
+    it('flags an org backlogged on the unsealed sweep, not just on the prefix', async () => {
+      mockByStatement({
+        policies: [{ id: 'p1', org_id: 'org-a', retention_days: 30 }],
+        cutoffSeq: '1000',
+        prefixBatches: [0],
+        unsealedBatches: [10],
+      });
+
+      const stats = await pruneExpiredAuditLogs({ batchSize: 10, maxBatches: 2 });
+
+      expect(stats.unsealedRowsDeleted).toBe(20);
+      expect(stats.orgsWithBacklog).toBe(1);
+      expect(stats.backloggedOrgIds).toEqual(['org-a']);
+    });
+
+    it('accumulates stats across several succeeding policies', async () => {
+      const policies = [
+        { id: 'p1', org_id: 'org-a', retention_days: 30 },
+        { id: 'p2', org_id: 'org-b', retention_days: 60 },
+      ];
+      dbExecuteMock.mockImplementation(async (query: unknown) => {
+        switch (classify(sqlText(query))) {
+          case 'policySelect':
+            return policies;
+          case 'cutoff':
+            return [{ cutoff_seq: '1000' }];
+          case 'prefixDelete':
+            return { count: 5 }; // always full at batchSize 5 -> both backlog
+          case 'unsealedSweep':
+            return { count: 1 };
+          default:
+            return [];
+        }
+      });
+
+      const stats = await pruneExpiredAuditLogs({ batchSize: 5, maxBatches: 2 });
+
+      // Sums, not last-write-wins: 2 policies x 2 prefix batches x 5 rows.
+      expect(stats.policies).toBe(2);
+      expect(stats.orgsPruned).toBe(2);
+      expect(stats.rowsDeleted).toBe(20);
+      expect(stats.unsealedRowsDeleted).toBe(2);
+      expect(stats.batches).toBe(6); // (2 prefix + 1 sweep) x 2 policies
+      expect(stats.orgsWithBacklog).toBe(2);
+      expect(stats.backloggedOrgIds).toEqual(['org-a', 'org-b']);
+      expect(stats.errors).toBe(0);
+    });
+
+    it('counts a bookkeeping failure separately and does not call it a prune failure', async () => {
+      dbExecuteMock.mockImplementation(async (query: unknown) => {
+        switch (classify(sqlText(query))) {
+          case 'policySelect':
+            return [{ id: 'p1', org_id: 'org-a', retention_days: 30 }];
+          case 'cutoff':
+            return [{ cutoff_seq: '1000' }];
+          case 'prefixDelete':
+            return { count: 4 };
+          case 'unsealedSweep':
+            return { count: 0 };
+          case 'policyUpdate':
+            throw new Error('bookkeeping write failed');
+          default:
+            return [];
+        }
+      });
+
+      const stats = await pruneExpiredAuditLogs();
+
+      // The rows really were deleted — this must not read as a failed prune.
+      expect(stats.rowsDeleted).toBe(4);
+      expect(stats.orgsPruned).toBe(1);
+      expect(stats.errors).toBe(0);
+      expect(stats.bookkeepingErrors).toBe(1);
+      // Invariant: an org is pruned or errored, never both.
+      expect(stats.orgsPruned + stats.errors).toBe(stats.policies);
+    });
+
     it('treats a NULL cutoff (org has no chain rows) as legitimate, not an error', async () => {
       mockByStatement({
         policies: [{ id: 'p1', org_id: 'org-a', retention_days: 30 }],
@@ -472,6 +647,8 @@ describe('auditRetention worker', () => {
             return [{ cutoff_seq: '1000' }];
           case 'prefixDelete':
             return { count: 3 };
+          case 'unsealedSweep':
+            return { count: 0 };
           default:
             return [];
         }
@@ -503,27 +680,80 @@ describe('auditRetention worker', () => {
   });
 
   describe('batch limits', () => {
-    it('exposes env-configurable defaults', () => {
-      expect(__testOnly.BATCH_SIZE).toBe(5000);
-      expect(__testOnly.MAX_BATCHES).toBe(200);
+    it('defaults to the documented batch size and ceiling', () => {
+      // Compared against the module's own declared defaults rather than bare
+      // literals: BATCH_SIZE/MAX_BATCHES are read from env at import, so an
+      // AUDIT_RETENTION_* var set in a CI or dev environment would otherwise red
+      // this test for a reason unrelated to the code.
+      const envOverridden =
+        process.env.AUDIT_RETENTION_BATCH_SIZE || process.env.AUDIT_RETENTION_MAX_BATCHES;
+      if (!envOverridden) {
+        expect(__testOnly.BATCH_SIZE).toBe(__testOnly.DEFAULT_BATCH_SIZE);
+        expect(__testOnly.MAX_BATCHES).toBe(__testOnly.DEFAULT_MAX_BATCHES);
+      }
+      expect(__testOnly.BATCH_SIZE).toBeGreaterThan(0);
+      expect(__testOnly.MAX_BATCHES).toBeGreaterThan(0);
     });
 
-    it('parsePositiveIntEnv rejects non-positive and unparsable values', () => {
+    it('parsePositiveIntEnv rejects non-positive, unparsable and partially-parsable values', () => {
       const KEY = 'AUDIT_RETENTION_TEST_KNOB';
-      delete process.env[KEY];
-      expect(__testOnly.parsePositiveIntEnv(KEY, 42)).toBe(42);
-      process.env[KEY] = '0';
-      expect(__testOnly.parsePositiveIntEnv(KEY, 42)).toBe(42);
-      process.env[KEY] = '-5';
-      expect(__testOnly.parsePositiveIntEnv(KEY, 42)).toBe(42);
-      process.env[KEY] = 'banana';
-      expect(__testOnly.parsePositiveIntEnv(KEY, 42)).toBe(42);
-      process.env[KEY] = '250';
-      expect(__testOnly.parsePositiveIntEnv(KEY, 42)).toBe(250);
+      const cases: Array<[string | undefined, number]> = [
+        [undefined, 42],
+        ['', 42],
+        ['0', 42],
+        ['-5', 42],
+        ['banana', 42],
+        // Number.parseInt truncates these; without whole-string validation
+        // "1e9" silently becomes 1 — batches of a single row.
+        ['1e9', 42],
+        ['5,000', 42],
+        ['5000x', 42],
+        ['3.7', 42],
+        ['250', 250],
+        ['  250  ', 250],
+      ];
+      for (const [raw, expected] of cases) {
+        if (raw === undefined) delete process.env[KEY];
+        else process.env[KEY] = raw;
+        expect(__testOnly.parsePositiveIntEnv(KEY, 42)).toBe(expected);
+      }
       delete process.env[KEY];
     });
 
-    it('clamps caller-supplied limits to at least 1 so a zero can never disable pruning', async () => {
+    // Job data is untrusted JSON off Redis. `Math.max(1, "abc")` is NaN, and
+    // `batches < NaN` is false, so the old clamp issued ZERO deletes and still
+    // reported orgsPruned:1, errors:0 — a silent no-op wearing a success.
+    it('resolveLimit rejects non-integer job-data values instead of producing NaN', () => {
+      expect(__testOnly.resolveLimit('batchSize', undefined, 5000)).toBe(5000);
+      expect(__testOnly.resolveLimit('batchSize', Number.NaN, 5000)).toBe(5000);
+      expect(__testOnly.resolveLimit('batchSize', 'abc' as unknown as number, 5000)).toBe(5000);
+      expect(__testOnly.resolveLimit('batchSize', null as unknown as number, 5000)).toBe(5000);
+      expect(__testOnly.resolveLimit('batchSize', 0, 5000)).toBe(5000);
+      expect(__testOnly.resolveLimit('batchSize', -10, 5000)).toBe(5000);
+      expect(__testOnly.resolveLimit('batchSize', 2.5, 5000)).toBe(5000);
+      expect(__testOnly.resolveLimit('batchSize', Infinity, 5000)).toBe(5000);
+      expect(__testOnly.resolveLimit('batchSize', 250, 5000)).toBe(250);
+    });
+
+    it('a non-numeric job-data limit still prunes, using the defaults', async () => {
+      mockByStatement({
+        policies: [{ id: 'p1', org_id: 'org-a', retention_days: 30 }],
+        cutoffSeq: '1000',
+        prefixBatches: [0],
+      });
+
+      const stats = await pruneExpiredAuditLogs({
+        batchSize: 'abc' as unknown as number,
+        maxBatches: Number.NaN,
+      });
+
+      // The regression: NaN limits used to issue no DELETE at all.
+      expect(executedKinds().filter((k) => k === 'prefixDelete')).toHaveLength(1);
+      expect(stats.errors).toBe(0);
+      expect(stats.orgsPruned).toBe(1);
+    });
+
+    it('a zero limit falls back to the default rather than disabling pruning', async () => {
       mockByStatement({
         policies: [{ id: 'p1', org_id: 'org-a', retention_days: 30 }],
         cutoffSeq: '1000',
@@ -532,9 +762,29 @@ describe('auditRetention worker', () => {
 
       const stats = await pruneExpiredAuditLogs({ batchSize: 0, maxBatches: 0 });
 
-      // maxBatches 0 would have meant "issue no DELETE at all".
       expect(executedKinds().filter((k) => k === 'prefixDelete')).toHaveLength(1);
       expect(stats.errors).toBe(0);
+    });
+
+    it('worker processor forwards batch overrides from the job payload', async () => {
+      mockByStatement({
+        policies: [{ id: 'p1', org_id: 'org-a', retention_days: 30 }],
+        cutoffSeq: '1000',
+      });
+      createAuditRetentionWorker();
+
+      await capturedWorkerProcessor.current!({
+        name: 'audit-log-retention',
+        id: 'j3',
+        data: { batchSize: 1, maxBatches: 1 },
+      });
+
+      // maxBatches 1 must cap the prefix loop at exactly one statement.
+      expect(executedKinds().filter((k) => k === 'prefixDelete')).toHaveLength(1);
+      const prefixCall = dbExecuteMock.mock.calls.find(
+        (c: unknown[]) => classify(sqlText(c[0])) === 'prefixDelete',
+      )?.[0];
+      expect(sqlParams(prefixCall)).toContain(1);
     });
   });
 

--- a/apps/api/src/jobs/auditRetention.test.ts
+++ b/apps/api/src/jobs/auditRetention.test.ts
@@ -405,6 +405,42 @@ describe('auditRetention worker', () => {
       expect(stats.errors).toBe(0);
     });
 
+    // A broken driver/adapter must not look like "this org has nothing to
+    // prune". Collapsing the two would silently skip the prefix DELETE and
+    // retain expired audit rows past policy while reporting success.
+    it('raises instead of silently skipping the prefix DELETE when the cutoff read comes back empty', async () => {
+      dbExecuteMock.mockImplementation(async (query: unknown) => {
+        switch (classify(sqlText(query))) {
+          case 'policySelect':
+            return [{ id: 'p1', org_id: 'org-a', retention_days: 30 }];
+          case 'cutoff':
+            return []; // impossible for a FROM-less SELECT — driver/mock is broken
+          default:
+            return [];
+        }
+      });
+
+      const stats = await pruneExpiredAuditLogs();
+
+      expect(stats.errors).toBe(1);
+      expect(stats.orgsPruned).toBe(0);
+      // The failure must abort this org's prune, not fall through to the DELETEs.
+      expect(executedKinds()).not.toContain('prefixDelete');
+      expect(executedKinds()).not.toContain('unsealedSweep');
+    });
+
+    it('treats a NULL cutoff (org has no chain rows) as legitimate, not an error', async () => {
+      mockByStatement({
+        policies: [{ id: 'p1', org_id: 'org-a', retention_days: 30 }],
+        cutoffSeq: null,
+      });
+
+      const stats = await pruneExpiredAuditLogs();
+
+      expect(stats.errors).toBe(0);
+      expect(stats.orgsPruned).toBe(1);
+    });
+
     it('reports unsealed-sweep deletions separately instead of dropping them', async () => {
       mockByStatement({
         policies: [{ id: 'p1', org_id: 'org-a', retention_days: 30 }],

--- a/apps/api/src/jobs/auditRetention.test.ts
+++ b/apps/api/src/jobs/auditRetention.test.ts
@@ -86,6 +86,68 @@ import {
 
 const ORIGINAL_FLAG = process.env.AUDIT_RETENTION_ENABLED;
 
+/**
+ * Flatten a drizzle `sql` template back to its literal SQL text (params drop
+ * out, which is all we need to identify and assert on a statement).
+ */
+function sqlText(query: unknown): string {
+  const chunks = (query as { queryChunks?: Array<{ value?: unknown } | string> }).queryChunks;
+  if (!Array.isArray(chunks)) return String(query);
+  return chunks
+    .map((chunk) => {
+      if (typeof chunk === 'string') return chunk;
+      const value = (chunk as { value?: unknown }).value;
+      return Array.isArray(value) ? (value as string[]).join('') : '';
+    })
+    .join(' ');
+}
+
+const executedSql = (): string[] => dbExecuteMock.mock.calls.map((call: unknown[]) => sqlText(call[0]));
+
+type StatementKind = 'policySelect' | 'setRole' | 'setGuc' | 'cutoff' | 'prefixDelete' | 'unsealedSweep' | 'policyUpdate' | 'other';
+
+function classify(text: string): StatementKind {
+  if (/SELECT id, org_id, retention_days/.test(text)) return 'policySelect';
+  if (/SET LOCAL ROLE/.test(text)) return 'setRole';
+  if (/SET LOCAL breeze\.allow_audit_retention/.test(text)) return 'setGuc';
+  if (/AS cutoff_seq/.test(text)) return 'cutoff';
+  if (/UPDATE audit_retention_policies/.test(text)) return 'policyUpdate';
+  if (/NOT EXISTS \(SELECT 1 FROM audit_log_chain/.test(text)) return 'unsealedSweep';
+  if (/DELETE FROM audit_logs/.test(text)) return 'prefixDelete';
+  return 'other';
+}
+
+const executedKinds = (): StatementKind[] => executedSql().map(classify);
+
+/**
+ * Route the shared `db.execute` mock by statement kind instead of by call
+ * ordinal. Ordinal mocking cannot express the batch loops (their call count is
+ * data-dependent), and a miscount would silently shift every later expectation.
+ */
+function mockByStatement(handlers: {
+  policies?: Array<{ id: string; org_id: string; retention_days: number }>;
+  cutoffSeq?: string | null;
+  prefixBatches?: number[];
+  unsealedBatches?: number[];
+}) {
+  const prefix = [...(handlers.prefixBatches ?? [0])];
+  const unsealed = [...(handlers.unsealedBatches ?? [0])];
+  dbExecuteMock.mockImplementation(async (query: unknown) => {
+    switch (classify(sqlText(query))) {
+      case 'policySelect':
+        return handlers.policies ?? [];
+      case 'cutoff':
+        return 'cutoffSeq' in handlers ? [{ cutoff_seq: handlers.cutoffSeq }] : [{ cutoff_seq: '1000' }];
+      case 'prefixDelete':
+        return { count: prefix.length > 1 ? prefix.shift()! : (prefix[0] ?? 0) };
+      case 'unsealedSweep':
+        return { count: unsealed.length > 1 ? unsealed.shift()! : (unsealed[0] ?? 0) };
+      default:
+        return [];
+    }
+  });
+}
+
 describe('auditRetention worker', () => {
   beforeEach(() => {
     vi.resetAllMocks();
@@ -189,16 +251,13 @@ describe('auditRetention worker', () => {
       expect(stats.errors).toBe(0);
     });
 
-    it('issues SET LOCAL ROLE + SET LOCAL GUC before the prefix-cut and unsealed-sweep DELETEs, with no UPDATE', async () => {
-      dbExecuteMock
-        .mockResolvedValueOnce([
-          { id: 'p1', org_id: 'org-a', retention_days: 30 },
-        ]) // policy list
-        .mockResolvedValueOnce(undefined) // SET LOCAL ROLE
-        .mockResolvedValueOnce(undefined) // SET LOCAL GUC
-        .mockResolvedValueOnce({ rowCount: 5 }) // prefix-cut DELETE
-        .mockResolvedValueOnce(undefined) // unsealed-old-rows sweep DELETE
-        .mockResolvedValueOnce(undefined); // UPDATE last_cleanup_at
+    it('issues SET LOCAL ROLE + SET LOCAL GUC before the cutoff read and both DELETEs, with no UPDATE of the audit tables', async () => {
+      mockByStatement({
+        policies: [{ id: 'p1', org_id: 'org-a', retention_days: 30 }],
+        cutoffSeq: '1000',
+        prefixBatches: [5],
+        unsealedBatches: [0],
+      });
 
       const stats = await pruneExpiredAuditLogs();
       expect(stats.policies).toBe(1);
@@ -206,83 +265,181 @@ describe('auditRetention worker', () => {
       expect(stats.rowsDeleted).toBe(5);
       expect(stats.errors).toBe(0);
 
-      // 1 select + 4 (role/guc/prefix-cut delete/unsealed sweep) + 1 last_cleanup_at update = 6 calls.
-      expect(dbExecuteMock).toHaveBeenCalledTimes(6);
+      // Both bypass layers must be armed BEFORE anything touches audit_logs.
+      expect(executedKinds()).toEqual([
+        'policySelect',
+        'setRole',
+        'setGuc',
+        'cutoff',
+        'prefixDelete',
+        'unsealedSweep',
+        'policyUpdate',
+      ]);
 
-      const callTexts = dbExecuteMock.mock.calls.map((call: unknown[]) => {
-        const q = call[0];
-        const sqlObj = q as { queryChunks?: Array<{ value?: string[] } | string> };
-        if (Array.isArray(sqlObj.queryChunks)) {
-          return sqlObj.queryChunks
-            .map((c) => (typeof c === 'string' ? c : Array.isArray((c as { value?: unknown }).value) ? ((c as { value: string[] }).value).join('') : ''))
-            .join(' ');
-        }
-        return String(q);
-      });
-      expect(callTexts[1]).toMatch(/SET LOCAL ROLE breeze_audit_admin/);
-      expect(callTexts[2]).toMatch(/SET LOCAL breeze\.allow_audit_retention/);
-      // (a) prefix-cut DELETE: removes the maximal all-old chain prefix.
-      expect(callTexts[3]).toMatch(/DELETE FROM audit_logs/);
-      expect(callTexts[3]).toMatch(/SELECT c\.audit_id/);
-      expect(callTexts[3]).toMatch(/FROM audit_log_chain c/);
-      // (b) unsealed-old-rows sweep: old rows with no chain entry.
-      expect(callTexts[4]).toMatch(/DELETE FROM audit_logs a/);
-      expect(callTexts[4]).toMatch(/NOT EXISTS \(SELECT 1 FROM audit_log_chain c WHERE c\.audit_id = a\.id\)/);
+      const texts = executedSql();
+      expect(texts[4]).toMatch(/SELECT c\.audit_id/);
+      expect(texts[4]).toMatch(/FROM audit_log_chain c/);
       // The deferred-sealing design (issue #1002) never re-anchors: retention
       // must issue NO UPDATE of audit_logs or audit_log_chain — the only
       // UPDATE in the whole pass is the last_cleanup_at bookkeeping.
-      const updates = callTexts.filter((t) => /UPDATE/i.test(t));
+      const updates = texts.filter((t) => /UPDATE/i.test(t));
       expect(updates).toHaveLength(1);
       expect(updates[0]).toMatch(/UPDATE audit_retention_policies/);
     });
 
     it('never issues an UPDATE even when no rows were deleted (no re-anchor exists)', async () => {
-      dbExecuteMock
-        .mockResolvedValueOnce([
-          { id: 'p1', org_id: 'org-a', retention_days: 30 },
-        ])
-        .mockResolvedValueOnce(undefined) // SET LOCAL ROLE
-        .mockResolvedValueOnce(undefined) // SET LOCAL GUC
-        .mockResolvedValueOnce({ rowCount: 0 }) // prefix-cut DELETE — no rows
-        .mockResolvedValueOnce(undefined) // unsealed-old-rows sweep DELETE
-        .mockResolvedValueOnce(undefined); // UPDATE last_cleanup_at
+      mockByStatement({
+        policies: [{ id: 'p1', org_id: 'org-a', retention_days: 30 }],
+        cutoffSeq: '1000',
+        prefixBatches: [0],
+      });
 
       const stats = await pruneExpiredAuditLogs();
       expect(stats.rowsDeleted).toBe(0);
-      // 1 select + 4 (role/guc/prefix-cut delete/unsealed sweep) + 1 last_cleanup_at = 6 calls.
-      expect(dbExecuteMock).toHaveBeenCalledTimes(6);
       // Design guarantee (issue #1002): retention never UPDATEs audit_logs or
       // audit_log_chain — verify treats the first surviving entry's prev as
       // the trusted anchor, so no re-anchor rewrite is ever issued.
-      const callTexts = dbExecuteMock.mock.calls.map((call: unknown[]) => {
-        const q = call[0];
-        const sqlObj = q as { queryChunks?: Array<{ value?: string[] } | string> };
-        if (Array.isArray(sqlObj.queryChunks)) {
-          return sqlObj.queryChunks
-            .map((c) => (typeof c === 'string' ? c : Array.isArray((c as { value?: unknown }).value) ? ((c as { value: string[] }).value).join('') : ''))
-            .join(' ');
-        }
-        return String(q);
+      expect(
+        executedSql().some((t) => /UPDATE audit_logs|UPDATE audit_log_chain|prev_checksum/.test(t)),
+      ).toBe(false);
+    });
+
+    // Issue #4239: the cutoff arm must never be a MIN() over the full
+    // audit_log_chain ⋈ audit_logs join. MIN has to consume the whole join
+    // before it can answer and the arm cannot constrain a2.org_id, which is
+    // what made the planner pick a Seq Scan of audit_logs per policy.
+    it('computes the prefix bound with an ordered early-stop, not MIN() over the full join', async () => {
+      mockByStatement({
+        policies: [{ id: 'p1', org_id: 'org-a', retention_days: 30 }],
+        cutoffSeq: '1000',
       });
-      expect(callTexts.some((t) => /UPDATE audit_logs|UPDATE audit_log_chain|prev_checksum/.test(t))).toBe(false);
+
+      await pruneExpiredAuditLogs();
+
+      const cutoff = executedSql().find((t) => /AS cutoff_seq/.test(t));
+      expect(cutoff).toBeDefined();
+      expect(cutoff).toMatch(/ORDER BY c2\.chain_seq\s+LIMIT 1/);
+      // The regression itself: no MIN() aggregate anywhere in the cutoff read.
+      expect(cutoff).not.toMatch(/MIN\s*\(/i);
+      // The all-old fallback (MAX+1) stays — it is an index-backed lookup on
+      // (org_id, chain_seq DESC), not a scan.
+      expect(cutoff).toMatch(/MAX\(c3\.chain_seq\) \+ 1/);
+      // Hoisted out of the DELETE so the bound is computed once per policy
+      // rather than re-planned inside every batch.
+      const prefixDelete = executedSql().find((t) => classify(t) === 'prefixDelete');
+      expect(prefixDelete).not.toMatch(/AS cutoff_seq|MAX\(c3/);
+    });
+
+    // Issue #4239 + #1002 together: batching is only safe because each batch
+    // takes the LOWEST remaining chain_seq values. Drop the ORDER BY and a
+    // maxBatches stop would leave holes mid-chain — a permanent linkage break.
+    it('deletes the prefix in ordered, LIMIT-bounded batches', async () => {
+      mockByStatement({
+        policies: [{ id: 'p1', org_id: 'org-a', retention_days: 30 }],
+        cutoffSeq: '1000',
+      });
+
+      await pruneExpiredAuditLogs();
+
+      const prefixDelete = executedSql().find((t) => classify(t) === 'prefixDelete');
+      expect(prefixDelete).toBeDefined();
+      expect(prefixDelete).toMatch(/ORDER BY c\.chain_seq\s+LIMIT/);
+      expect(prefixDelete).toMatch(/c\.chain_seq </);
+
+      const sweep = executedSql().find((t) => classify(t) === 'unsealedSweep');
+      expect(sweep).toMatch(/LIMIT/);
+    });
+
+    it('keeps issuing prefix batches until one comes back short of the limit', async () => {
+      mockByStatement({
+        policies: [{ id: 'p1', org_id: 'org-a', retention_days: 30 }],
+        cutoffSeq: '1000',
+        prefixBatches: [10, 10, 3],
+      });
+
+      const stats = await pruneExpiredAuditLogs({ batchSize: 10, maxBatches: 50 });
+
+      expect(stats.rowsDeleted).toBe(23);
+      expect(executedKinds().filter((k) => k === 'prefixDelete')).toHaveLength(3);
+      // A short batch ends the loop — no wasted round-trip after it.
+      expect(stats.orgsWithBacklog).toBe(0);
+      expect(stats.batches).toBe(4); // 3 prefix + 1 sweep
+    });
+
+    it('stops at the maxBatches ceiling and reports the org as still backlogged', async () => {
+      mockByStatement({
+        policies: [{ id: 'p1', org_id: 'org-a', retention_days: 30 }],
+        cutoffSeq: '1000',
+        prefixBatches: [10],
+      });
+
+      const stats = await pruneExpiredAuditLogs({ batchSize: 10, maxBatches: 2 });
+
+      // Ceiling honoured — not a runaway loop.
+      expect(executedKinds().filter((k) => k === 'prefixDelete')).toHaveLength(2);
+      expect(stats.rowsDeleted).toBe(20);
+      // Full batches were still coming back when the ceiling hit, so rows remain.
+      expect(stats.orgsWithBacklog).toBe(1);
+      // Still counted as pruned — the pass succeeded, it just did not finish.
+      expect(stats.orgsPruned).toBe(1);
+      expect(stats.errors).toBe(0);
+    });
+
+    it('skips the prefix DELETE entirely when the org has no chain rows, but still sweeps', async () => {
+      mockByStatement({
+        policies: [{ id: 'p1', org_id: 'org-a', retention_days: 30 }],
+        cutoffSeq: null,
+      });
+
+      const stats = await pruneExpiredAuditLogs();
+
+      expect(executedKinds()).toEqual([
+        'policySelect',
+        'setRole',
+        'setGuc',
+        'cutoff',
+        'unsealedSweep',
+        'policyUpdate',
+      ]);
+      expect(stats.rowsDeleted).toBe(0);
+      expect(stats.errors).toBe(0);
+    });
+
+    it('reports unsealed-sweep deletions separately instead of dropping them', async () => {
+      mockByStatement({
+        policies: [{ id: 'p1', org_id: 'org-a', retention_days: 30 }],
+        cutoffSeq: '1000',
+        prefixBatches: [2],
+        unsealedBatches: [7],
+      });
+
+      const stats = await pruneExpiredAuditLogs({ batchSize: 100, maxBatches: 5 });
+
+      expect(stats.rowsDeleted).toBe(2);
+      expect(stats.unsealedRowsDeleted).toBe(7);
     });
 
     it('continues to the next policy when one fails', async () => {
-      dbExecuteMock
-        .mockResolvedValueOnce([
-          { id: 'p1', org_id: 'org-a', retention_days: 30 },
-          { id: 'p2', org_id: 'org-b', retention_days: 365 },
-        ]) // policy list
-        // org-a: role, guc, DELETE fails
-        .mockResolvedValueOnce(undefined)
-        .mockResolvedValueOnce(undefined)
-        .mockRejectedValueOnce(new Error('connection lost'))
-        // org-b: role, guc, prefix-cut DELETE ok, sweep DELETE ok, last_cleanup_at UPDATE ok
-        .mockResolvedValueOnce(undefined)
-        .mockResolvedValueOnce(undefined)
-        .mockResolvedValueOnce({ rowCount: 3 })
-        .mockResolvedValueOnce(undefined)
-        .mockResolvedValueOnce(undefined);
+      const policies = [
+        { id: 'p1', org_id: 'org-a', retention_days: 30 },
+        { id: 'p2', org_id: 'org-b', retention_days: 365 },
+      ];
+      let cutoffReads = 0;
+      dbExecuteMock.mockImplementation(async (query: unknown) => {
+        switch (classify(sqlText(query))) {
+          case 'policySelect':
+            return policies;
+          case 'cutoff':
+            // org-a's cutoff read blows up; org-b's succeeds.
+            cutoffReads += 1;
+            if (cutoffReads === 1) throw new Error('connection lost');
+            return [{ cutoff_seq: '1000' }];
+          case 'prefixDelete':
+            return { count: 3 };
+          default:
+            return [];
+        }
+      });
 
       const stats = await pruneExpiredAuditLogs();
       expect(stats.policies).toBe(2);
@@ -292,14 +449,11 @@ describe('auditRetention worker', () => {
     });
 
     it('records last_cleanup_at outside the role-switched transaction', async () => {
-      dbExecuteMock
-        .mockResolvedValueOnce([
-          { id: 'p1', org_id: 'org-a', retention_days: 30 },
-        ])
-        .mockResolvedValueOnce(undefined) // SET LOCAL ROLE
-        .mockResolvedValueOnce(undefined) // SET LOCAL GUC
-        .mockResolvedValueOnce({ rowCount: 0 }) // DELETE (no rows)
-        .mockResolvedValueOnce(undefined); // UPDATE
+      mockByStatement({
+        policies: [{ id: 'p1', org_id: 'org-a', retention_days: 30 }],
+        cutoffSeq: '1000',
+        prefixBatches: [0],
+      });
 
       await pruneExpiredAuditLogs();
 
@@ -308,16 +462,43 @@ describe('auditRetention worker', () => {
       // independently. Mock invocations: 1 for policy SELECT, 1 for
       // role-switch+DELETE tx, 1 for UPDATE tx = 3 total.
       expect(withSystemDbAccessContextMock).toHaveBeenCalledTimes(3);
+      expect(executedSql().at(-1)).toMatch(/UPDATE audit_retention_policies/);
+    });
+  });
 
-      const updateCall = dbExecuteMock.mock.calls.at(-1)?.[0] as {
-        queryChunks?: Array<{ value?: string[] } | string>;
-      };
-      const updateText = Array.isArray(updateCall?.queryChunks)
-        ? updateCall.queryChunks
-            .map((c) => (typeof c === 'string' ? c : Array.isArray((c as { value?: unknown }).value) ? ((c as { value: string[] }).value).join('') : ''))
-            .join(' ')
-        : String(updateCall);
-      expect(updateText).toMatch(/UPDATE audit_retention_policies/);
+  describe('batch limits', () => {
+    it('exposes env-configurable defaults', () => {
+      expect(__testOnly.BATCH_SIZE).toBe(5000);
+      expect(__testOnly.MAX_BATCHES).toBe(200);
+    });
+
+    it('parsePositiveIntEnv rejects non-positive and unparsable values', () => {
+      const KEY = 'AUDIT_RETENTION_TEST_KNOB';
+      delete process.env[KEY];
+      expect(__testOnly.parsePositiveIntEnv(KEY, 42)).toBe(42);
+      process.env[KEY] = '0';
+      expect(__testOnly.parsePositiveIntEnv(KEY, 42)).toBe(42);
+      process.env[KEY] = '-5';
+      expect(__testOnly.parsePositiveIntEnv(KEY, 42)).toBe(42);
+      process.env[KEY] = 'banana';
+      expect(__testOnly.parsePositiveIntEnv(KEY, 42)).toBe(42);
+      process.env[KEY] = '250';
+      expect(__testOnly.parsePositiveIntEnv(KEY, 42)).toBe(250);
+      delete process.env[KEY];
+    });
+
+    it('clamps caller-supplied limits to at least 1 so a zero can never disable pruning', async () => {
+      mockByStatement({
+        policies: [{ id: 'p1', org_id: 'org-a', retention_days: 30 }],
+        cutoffSeq: '1000',
+        prefixBatches: [0],
+      });
+
+      const stats = await pruneExpiredAuditLogs({ batchSize: 0, maxBatches: 0 });
+
+      // maxBatches 0 would have meant "issue no DELETE at all".
+      expect(executedKinds().filter((k) => k === 'prefixDelete')).toHaveLength(1);
+      expect(stats.errors).toBe(0);
     });
   });
 

--- a/apps/api/src/jobs/auditRetention.ts
+++ b/apps/api/src/jobs/auditRetention.ts
@@ -38,15 +38,19 @@
  * end of transaction block"), so a single outer transaction would
  * cascade-fail the entire pass.
  *
- * Idempotent: re-running the same day matches zero rows because the
- * previous run already deleted everything older than the cutoff.
+ * Idempotent for orgs that finished: re-running the same day matches zero
+ * rows once an org's whole expired prefix is gone. An org that stopped at the
+ * AUDIT_RETENTION_MAX_BATCHES ceiling is deliberately NOT idempotent — the
+ * next run (same day or not) continues its prefix. See `orgsWithBacklog`.
  *
  * Scale (issue #4239): the prefix bound is an ordered early-stop
  * (`ORDER BY chain_seq LIMIT 1`) rather than a `MIN()` over a full join,
  * and the deletes run in bounded `LIMIT` batches (AUDIT_RETENTION_BATCH_SIZE
- * / AUDIT_RETENTION_MAX_BATCHES), matching the sibling retention jobs. At
- * 22M rows the previous shape planned as a per-policy Seq Scan of
- * `audit_logs`, so each policy cost the same regardless of org size.
+ * / AUDIT_RETENTION_MAX_BATCHES), matching the sibling retention jobs. The
+ * reporter of #4239 observed the previous shape planning as a per-policy Seq
+ * Scan of `audit_logs` on their ~17.8M-row tables, so each policy cost the
+ * same regardless of org size. Those numbers are REPORTED, not reproduced
+ * here — see the detail in `deleteChainPrefix`.
  *
  * Schedule: daily at 03:30 UTC, half-hour offset from oauthCleanup
  * (03:00 UTC) so the two crons don't pile onto the same minute.
@@ -77,22 +81,62 @@ const DAILY_CRON = jobSchedule('audit-retention');
 
 function parsePositiveIntEnv(name: string, defaultValue: number): number {
   const raw = process.env[name];
-  if (!raw) return defaultValue;
-  const parsed = Number.parseInt(raw, 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
+  if (raw === undefined || raw.trim() === '') return defaultValue;
+  // Validate the WHOLE string. `Number.parseInt` truncates at the first invalid
+  // character and the remainder still passes a `> 0` check, so "1e9" would
+  // silently become 1 — batches of a single row, with no warning, on the exact
+  // knob an operator reaches for when draining a backlog.
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    console.warn(`[AuditRetention] Invalid ${name}="${raw}" (not a plain integer), using default ${defaultValue}`);
+    return defaultValue;
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
     console.warn(`[AuditRetention] Invalid ${name}="${raw}", using default ${defaultValue}`);
     return defaultValue;
   }
   return parsed;
 }
 
+/**
+ * Resolve a per-run batch limit from untrusted job payload data.
+ *
+ * BullMQ job data is JSON off Redis — an operator hand-enqueuing a drain can put
+ * anything in it, and `RetentionJobData` constrains nothing at runtime. The
+ * previous `Math.max(1, value ?? DEFAULT)` turned a non-numeric value into `NaN`,
+ * and `batches < NaN` is false on the first check, so the loop issued ZERO
+ * DELETEs and the pass reported `orgsPruned: 1, errors: 0` — a silent
+ * no-op wearing a success. Validate and fall back loudly instead of clamping.
+ */
+function resolveLimit(name: string, value: number | undefined, defaultValue: number): number {
+  if (value === undefined || value === null) return defaultValue;
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    console.warn(
+      `[AuditRetention] Ignoring invalid job-data ${name}=${JSON.stringify(value)}; using ${defaultValue}`,
+    );
+    return defaultValue;
+  }
+  return value;
+}
+
 // Batched deletes (issue #4239). Same LIMIT-loop shape as the sibling retention
 // jobs (mlOutputRetention, deviceMetricsRetention, eventDispatchWorker): delete a
 // bounded slice, stop as soon as a batch comes back short of the limit.
+//
+// SCOPE OF THE WIN, precisely: this bounds each STATEMENT, not the transaction.
+// Every batch for one org still commits as a single transaction (SET LOCAL only
+// has meaning inside one), so this buys no lock-duration or xmin-horizon relief
+// over the previous single unbounded DELETE — it trades one huge statement for
+// many small ones and adds a per-run ceiling. The actual #4239 fix is the cutoff
+// hoist in deleteChainPrefix; the batching is what keeps any one statement's
+// plan index-driven and caps per-run work.
 const BATCH_SIZE = parsePositiveIntEnv('AUDIT_RETENTION_BATCH_SIZE', 5000);
 // Per-org ceiling so one org with a large backlog cannot monopolise the nightly
-// pass. Stopping early is safe: the cap leaves a shorter chain PREFIX deleted
-// (see the ORDER BY note in deleteChainPrefix), and the next run advances it.
+// pass. Applied INDEPENDENTLY to the prefix loop and the unsealed sweep, so one
+// org can issue up to 2 * MAX_BATCHES statements. Stopping early is safe: the cap
+// leaves a shorter chain PREFIX deleted (see the ORDER BY note in
+// deleteChainPrefix), and the next run advances it.
 const MAX_BATCHES = parsePositiveIntEnv('AUDIT_RETENTION_MAX_BATCHES', 200);
 
 function isRetentionEnabled(): boolean {
@@ -124,13 +168,29 @@ export interface RetentionStats {
   unsealedRowsDeleted: number;
   /** DELETE statements issued across all policies (prefix cut + sweep). */
   batches: number;
-  /** Orgs that hit the per-org batch ceiling and still have expired rows. */
+  /**
+   * Orgs whose final batch came back FULL at the ceiling — i.e. almost certainly
+   * still have expired rows below the cutoff. A heuristic, not a guarantee: a
+   * remainder that is an exact multiple of `batchSize` is counted too. And it
+   * says nothing about expired stragglers sitting ABOVE the first young row,
+   * which are never in scope for the prefix cut — so `0` is not an all-clear.
+   */
   orgsWithBacklog: number;
+  /** The org ids behind `orgsWithBacklog`, so a non-draining org is identifiable. */
+  backloggedOrgIds: string[];
+  /** Policies whose prune failed; their expired rows are still on disk. */
   errors: number;
+  /** Policies that pruned successfully but whose last_cleanup_at UPDATE failed. */
+  bookkeepingErrors: number;
   durationMs: number;
 }
 
-/** Per-run batch tuning; falsy/absent fields fall back to the env-configured defaults. */
+/**
+ * Per-run batch tuning. ABSENT (null/undefined) fields fall back to the
+ * env-configured defaults; a supplied value must be a positive safe integer or
+ * it is rejected with a warning and the default is used (see `resolveLimit`).
+ * Note this is a compile-time shape only — BullMQ delivers it as untrusted JSON.
+ */
 export interface RetentionJobData {
   batchSize?: number;
   maxBatches?: number;
@@ -173,12 +233,14 @@ interface SqlExecutor {
  * `maxBatches` ceiling is reached. Mirrors the sibling retention jobs' loop
  * (`mlOutputRetention.pruneMetricAnomalies`, `deviceMetricsRetention`).
  *
- * `buildStatement` is a thunk because each iteration needs a fresh `sql`
- * fragment — drizzle's tagged template objects are not safely re-executable.
+ * `buildStatement` is a thunk so each call site can close over its own
+ * parameters. A drizzle `sql` object is in fact re-executable — `execute` only
+ * reads `queryChunks` — so this is a convenience, not a correctness requirement.
  */
 async function runBatchedDelete(
   exec: SqlExecutor,
   limits: BatchLimits,
+  label: string,
   buildStatement: () => ReturnType<typeof sql>,
 ): Promise<BatchedDeleteResult> {
   let rowsDeleted = 0;
@@ -187,6 +249,22 @@ async function runBatchedDelete(
 
   while (batches < limits.maxBatches) {
     const result = await exec.execute(buildStatement());
+    // `extractRowCount` is loud only for null/undefined: for any OTHER
+    // unrecognised shape it returns 0 (pinned by db/rowCount.test.ts, and
+    // relied on there for SELECTs). A 0 here does not merely under-report — it
+    // ENDS the loop and the org is recorded as fully pruned, so a driver,
+    // pooler or adapter change that alters the result shape would silently
+    // retain expired audit rows while reporting success. A DELETE always
+    // carries a driver row count, so demand one rather than inferring "nothing
+    // left to delete" from an unreadable result. Same principle as the cutoff
+    // guard below and as db/rowCount.ts's deliberate non-null-safety.
+    const raw = result as { rowCount?: unknown; count?: unknown };
+    if (typeof raw.rowCount !== 'number' && typeof raw.count !== 'number') {
+      throw new Error(
+        `[AuditRetention] ${label} DELETE returned no driver row count (batch ${batches + 1}) — ` +
+          'refusing to read an unreadable count as "nothing left to delete"',
+      );
+    }
     lastBatchDeleted = extractRowCount(result);
     rowsDeleted += lastBatchDeleted;
     batches += 1;
@@ -214,10 +292,16 @@ async function deleteChainPrefix(
   // Prefix-cut delete (issue #1002 redesign): chain_seq order is COMMIT order,
   // which can disagree with timestamp order around long transactions, so a raw
   // `timestamp < cutoff` delete could remove a mid-chain entry and leave a
-  // permanent linkage hole. Instead delete the maximal chain PREFIX that is
-  // entirely older than the cutoff — everything below the first "young" row in
-  // chain order. Old stragglers sitting behind a young row survive one extra
-  // nightly cycle and are caught as the prefix advances.
+  // permanent linkage hole. Instead delete a chain PREFIX that is entirely
+  // older than the cutoff — everything below the first "young" row in chain
+  // order — either the maximal such prefix or as much of it as the per-run
+  // batch ceiling allows (see MAX_BATCHES).
+  //
+  // Old stragglers sitting behind a young row survive until that BLOCKER itself
+  // ages past the cutoff, which can be up to a full `retention_days` later —
+  // not "one extra cycle", and on a busy org the blocker is continuously
+  // replaced. Worth stating plainly: this job is compliance-facing and those
+  // rows are expired-but-retained the whole time.
   //
   // No re-anchor follows: audit_log_verify_chain treats the first surviving
   // entry's prev_chain_checksum as the trusted anchor (it references the
@@ -227,24 +311,54 @@ async function deleteChainPrefix(
   // set breeze.allow_audit_retention='1' SET LOCAL before calling this.
 
   // Step 1 — the prefix bound, hoisted out of the DELETE and rewritten as an
-  // ordered early-stop (issue #4239). The old form was
-  // `MIN(c2.chain_seq)` over the same filtered join. MIN has to consume the
-  // WHOLE join before it can answer, and because the arm never constrains
-  // `a2.org_id`, `audit_logs_org_timestamp_idx (org_id, timestamp DESC)` is
-  // unusable — at 22M rows the planner chose a Seq Scan of audit_logs hash
-  // joined to a Seq Scan of audit_log_chain, ~3.3 min and ~14.8 GiB of block
-  // reads for ONE org, repeated per policy.
+  // ordered early-stop (issue #4239). The old form was `MIN(c2.chain_seq)` over
+  // the same filtered join. MIN has to consume the WHOLE join before it can
+  // answer, and because the arm never constrains `a2.org_id`,
+  // `audit_logs_org_timestamp_idx (org_id, timestamp DESC)` cannot apply.
+  //
+  // REPORTED (issue #4239, external operator on a self-hosted single-node PG16
+  // with ~14 policies — NOT reproduced on our infrastructure, we have no
+  // dataset at that scale): at ~17.8M rows the planner chose a Seq Scan of
+  // audit_logs hash joined to a Seq Scan of audit_log_chain — ~200s and
+  // ~1.94M shared-buffer block reads (~14.8 GiB, some possibly OS-cache hits)
+  // for ONE org's cutoff, repeated per policy.
   //
   // `ORDER BY c2.chain_seq LIMIT 1` returns the identical value (the smallest
-  // chain_seq in the same filtered set, or NULL) — it is a pure plan change,
-  // not a semantic one, and it does not depend on timestamps being monotonic in
-  // chain order. But it lets the planner walk audit_log_chain in ascending
-  // chain_seq order and PK-probe audit_logs per candidate, stopping at the FIRST
-  // young row: ~(deletable prefix + 1) rows instead of the whole table. Which
-  // index carries that walk is the planner's choice — measured at 270k rows it
-  // took audit_log_chain_pkey with an org_id filter; with many orgs a backward
-  // scan of audit_log_chain_org_seq_idx (org_id, chain_seq DESC) is the more
-  // selective option. Either way the shape is an ordered early stop, not a scan.
+  // chain_seq in the same filtered set, or NULL) — a pure plan change, not a
+  // semantic one, and it does not depend on timestamps being monotonic in chain
+  // order. The LIMIT is what makes an ordered index path cheap to the planner,
+  // so it can walk audit_log_chain in ascending chain_seq order, PK-probe
+  // audit_logs per candidate, and stop at the FIRST young row.
+  //
+  // CAVEAT — not verified at production scale. Locally at 270k rows the planner
+  // took audit_log_chain_pkey with an org_id filter (an early stop, but in
+  // GLOBAL chain order, so the walk covers other orgs' interleaved rows too).
+  // #4239 reports that at ~17.8M rows the planner rejects
+  // audit_log_chain_org_seq_idx for this join because it is not covering
+  // (audit_id is absent) — that was measured on the MIN/hash-join shape, which
+  // has no LIMIT to make an index path attractive, so it does not transfer
+  // directly. Still, an early stop is not guaranteed: a Sort over a Seq Scan
+  // would satisfy the ORDER BY while consuming everything. If #4239 recurs, the
+  // reporter's direction 2 (denormalised `logged_at` plus
+  // `(org_id, chain_seq) INCLUDE (logged_at, audit_id)`) is the follow-up. The
+  // batching in step 2 bounds the DELETE either way.
+  //
+  // WHY HOISTING THE CUTOFF IS SAFE (load-bearing dependency — read before
+  // changing either side). The bound is computed once, then reused by DELETEs in
+  // LATER statements, each of which takes a fresh READ COMMITTED snapshot. That
+  // is only sound because `audit_log_seal_one`
+  // (migrations/2026-06-11-h-audit-chain-seal-and-verify.sql:45) takes
+  // `pg_advisory_xact_lock(1000200, hashtext(org_id))` BEFORE allocating
+  // chain_seq, from a DEFERRED constraint trigger, so the lock is held from
+  // allocation through commit. Per org that makes chain_seq allocation order
+  // identical to commit-visibility order: a row committing between our cutoff
+  // read and a later batch necessarily has chain_seq above everything we could
+  // see, so it can never fall inside `chain_seq < cutoffSeq` and be swept into
+  // the prefix. If that advisory lock is ever relaxed, this hoist becomes unsafe
+  // and the bound must move back inside each DELETE.
+  //
+  // (`now()` is transaction_timestamp(), and every batch runs in the one per-org
+  // transaction, so the time reference is stable across batches too.)
   //
   // chain_seq is bigserial (int8); round-trip it as text so neither the driver's
   // int8 handling nor JS number precision can round a large sequence value.
@@ -293,7 +407,7 @@ async function deleteChainPrefix(
   // break the prefix-cut design exists to prevent.
   const prefix = cutoffSeq === null
     ? { rowsDeleted: 0, batches: 0, hasMore: false }
-    : await runBatchedDelete(exec, limits, () => sql`
+    : await runBatchedDelete(exec, limits, 'prefix-cut', () => sql`
         DELETE FROM audit_logs
         WHERE id IN (
           SELECT c.audit_id
@@ -308,17 +422,24 @@ async function deleteChainPrefix(
   // Step 3 — sweep any UNSEALED old rows too (shouldn't exist post-backfill;
   // keeps retention complete if one ever appears). The chain has no entry for
   // them, so deleting them can't affect linkage and needs no ordering. Batched
-  // for the same reason as the prefix cut: this is the same 22M-row table.
-  const sweep = await runBatchedDelete(exec, limits, () => sql`
+  // for the same reason as the prefix cut: same table, and an org that somehow
+  // accumulated a large unsealed backlog must not monopolise the pass.
+  // The outer DELETE repeats `org_id` rather than leaning on ctid alone. ctid is
+  // unique per TABLE today, but only per PARTITION — if audit_logs is ever
+  // range-partitioned (a live option at this size) a bare ctid predicate becomes
+  // a cross-tenant delete, and this statement runs in system scope
+  // (accessible_org_ids = '*') where RLS would not catch it. Costs nothing.
+  const sweep = await runBatchedDelete(exec, limits, 'unsealed-sweep', () => sql`
     DELETE FROM audit_logs
-    WHERE ctid IN (
-      SELECT a.ctid
-      FROM audit_logs a
-      WHERE a.org_id = ${policy.org_id}
-        AND a.timestamp < (now() - (${policy.retention_days}::int * interval '1 day'))
-        AND NOT EXISTS (SELECT 1 FROM audit_log_chain c WHERE c.audit_id = a.id)
-      LIMIT ${limits.batchSize}
-    )
+    WHERE org_id = ${policy.org_id}
+      AND ctid IN (
+        SELECT a.ctid
+        FROM audit_logs a
+        WHERE a.org_id = ${policy.org_id}
+          AND a.timestamp < (now() - (${policy.retention_days}::int * interval '1 day'))
+          AND NOT EXISTS (SELECT 1 FROM audit_log_chain c WHERE c.audit_id = a.id)
+        LIMIT ${limits.batchSize}
+      )
   `);
 
   return {
@@ -385,8 +506,8 @@ export async function pruneExpiredAuditLogs(
 ): Promise<RetentionStats> {
   const startedAt = Date.now();
   const limits: BatchLimits = {
-    batchSize: Math.max(1, options.batchSize ?? BATCH_SIZE),
-    maxBatches: Math.max(1, options.maxBatches ?? MAX_BATCHES),
+    batchSize: resolveLimit('batchSize', options.batchSize, BATCH_SIZE),
+    maxBatches: resolveLimit('maxBatches', options.maxBatches, MAX_BATCHES),
   };
   const stats: RetentionStats = {
     policies: 0,
@@ -395,7 +516,9 @@ export async function pruneExpiredAuditLogs(
     unsealedRowsDeleted: 0,
     batches: 0,
     orgsWithBacklog: 0,
+    backloggedOrgIds: [],
     errors: 0,
+    bookkeepingErrors: 0,
     durationMs: 0,
   };
 
@@ -412,19 +535,44 @@ export async function pruneExpiredAuditLogs(
   stats.policies = policies.length;
 
   for (const policy of policies) {
+    let pruned: PrunePolicyResult;
     try {
-      const pruned = await pruneOrg(policy, limits);
+      pruned = await pruneOrg(policy, limits);
+    } catch (err) {
+      // The prune itself failed. Both paths are transactional, so nothing was
+      // deleted — this org contributes no rows and is NOT counted as pruned.
+      stats.errors += 1;
+      captureException(err, undefined, {
+        job: 'audit-retention',
+        stage: 'prune',
+        orgId: policy.org_id,
+        policyId: policy.id,
+      });
+      console.error(
+        `[AuditRetention] prune failed for org=${policy.org_id} policy=${policy.id} — expired rows retained:`,
+        err instanceof Error ? err.message : err,
+      );
+      continue;
+    }
 
-      stats.rowsDeleted += pruned.rowsDeleted;
-      stats.unsealedRowsDeleted += pruned.unsealedRowsDeleted;
-      stats.batches += pruned.batches;
-      if (pruned.hasMore) stats.orgsWithBacklog += 1;
-      stats.orgsPruned += 1;
+    stats.rowsDeleted += pruned.rowsDeleted;
+    stats.unsealedRowsDeleted += pruned.unsealedRowsDeleted;
+    stats.batches += pruned.batches;
+    if (pruned.hasMore) {
+      stats.orgsWithBacklog += 1;
+      stats.backloggedOrgIds.push(policy.org_id);
+    }
+    stats.orgsPruned += 1;
 
-      // Record last_cleanup_at in its own transaction (the DELETE tx
-      // already committed). breeze_app retains UPDATE on
-      // audit_retention_policies via the blanket grant — no role
-      // switch needed here.
+    // Bookkeeping runs in its OWN try: the prune already committed, so a failure
+    // here must not be reported as "cleanup failed" (it isn't — rows really were
+    // deleted) nor counted against `errors`, which would make this org both
+    // pruned and errored and break `orgsPruned + errors === policies`.
+    //
+    // Its own transaction too (the DELETE tx already committed). breeze_app
+    // retains UPDATE on audit_retention_policies via the blanket grant — no role
+    // switch needed here.
+    try {
       await runWithSystemDbAccess(async () => {
         await dbModule.db.execute(sql`
           UPDATE audit_retention_policies
@@ -433,10 +581,15 @@ export async function pruneExpiredAuditLogs(
         `);
       });
     } catch (err) {
-      stats.errors += 1;
-      captureException(err);
+      stats.bookkeepingErrors += 1;
+      captureException(err, undefined, {
+        job: 'audit-retention',
+        stage: 'bookkeeping',
+        orgId: policy.org_id,
+        policyId: policy.id,
+      });
       console.error(
-        `[AuditRetention] cleanup failed for org=${policy.org_id} policy=${policy.id}:`,
+        `[AuditRetention] prune SUCCEEDED for org=${policy.org_id} policy=${policy.id} but the last_cleanup_at bookkeeping UPDATE failed (rows WERE deleted):`,
         err instanceof Error ? err.message : err,
       );
     }
@@ -444,15 +597,43 @@ export async function pruneExpiredAuditLogs(
 
   stats.durationMs = Date.now() - startedAt;
   console.log(
-    `[AuditRetention] Pruned ${stats.rowsDeleted} row(s) (+${stats.unsealedRowsDeleted} unsealed) across ${stats.orgsPruned}/${stats.policies} polic(ies) in ${stats.batches} batch(es) of ${limits.batchSize} in ${stats.durationMs}ms (errors=${stats.errors}, backlogged=${stats.orgsWithBacklog})`,
+    `[AuditRetention] Pruned ${stats.rowsDeleted} row(s) (+${stats.unsealedRowsDeleted} unsealed) across ${stats.orgsPruned}/${stats.policies} polic(ies) in ${stats.batches} batch(es) of ${limits.batchSize} in ${stats.durationMs}ms (errors=${stats.errors}, bookkeepingErrors=${stats.bookkeepingErrors}, backlogged=${stats.orgsWithBacklog})`,
   );
-  if (stats.orgsWithBacklog > 0) {
-    // Not an error: the ceiling did its job. Say so loudly anyway, because the
-    // only other signal that a backlog is draining across nights is watching
-    // rowsDeleted stay pinned at maxBatches * batchSize.
+
+  if (stats.unsealedRowsDeleted > 0) {
+    // Unsealed rows should not exist post-backfill: the seal trigger writes a
+    // chain entry for every insert. A non-zero count here means rows are landing
+    // in audit_logs without being sealed, which is an audit-integrity defect in
+    // its own right — louder than a number buried in the log line above.
     console.warn(
-      `[AuditRetention] ${stats.orgsWithBacklog} org(s) hit the ${limits.maxBatches}-batch ceiling and still have expired rows; the next run continues the prefix.`,
+      `[AuditRetention] swept ${stats.unsealedRowsDeleted} UNSEALED audit row(s) — these should not exist post-backfill; the chain seal trigger may be dropping rows`,
     );
+  }
+
+  if (stats.errors > 0) {
+    // A failed policy means that org's expired rows are still on disk. The job
+    // itself still resolves (one bad tenant must not abort the pass), so this
+    // line plus the tagged Sentry events above are the signal.
+    console.error(
+      `[AuditRetention] ${stats.errors}/${stats.policies} polic(ies) FAILED — expired audit rows retained for those orgs`,
+    );
+  }
+
+  if (stats.orgsWithBacklog > 0) {
+    // Not an error: the ceiling did its job. Named, and routed to Sentry, so a
+    // backlog that never drains across nights is visible as a recurring signal
+    // rather than one line of stdout. Note this counts only rows BELOW the
+    // cutoff — expired stragglers sitting above the first young row are not
+    // included, so this is a floor on what remains, never an all-clear.
+    const message =
+      `[AuditRetention] ${stats.orgsWithBacklog} org(s) stopped at the ${limits.maxBatches}-batch ceiling ` +
+      `with more rows below the cutoff; the next run continues where this one stopped: ` +
+      stats.backloggedOrgIds.join(', ');
+    console.warn(message);
+    captureException(new Error(message), undefined, {
+      job: 'audit-retention',
+      reason: 'backlog_ceiling',
+    });
   }
   return stats;
 }
@@ -576,6 +757,9 @@ export const __testOnly = {
   DAILY_CRON,
   BATCH_SIZE,
   MAX_BATCHES,
+  DEFAULT_BATCH_SIZE: 5000,
+  DEFAULT_MAX_BATCHES: 200,
   isRetentionEnabled,
   parsePositiveIntEnv,
+  resolveLimit,
 };

--- a/apps/api/src/jobs/auditRetention.ts
+++ b/apps/api/src/jobs/auditRetention.ts
@@ -265,9 +265,24 @@ async function deleteChainPrefix(
         WHERE c3.org_id = ${policy.org_id}
       )
     )::text AS cutoff_seq
-  `)) as unknown as Array<{ cutoff_seq: string | null }>;
-  // NULL only when the org has no chain entries at all — nothing to prefix-cut.
-  const cutoffSeq = cutoffRows[0]?.cutoff_seq ?? null;
+  `)) as unknown as Array<{ cutoff_seq?: string | null }> | undefined;
+  const cutoffRow = cutoffRows?.[0];
+  if (!cutoffRow || cutoffRow.cutoff_seq === undefined) {
+    // `SELECT COALESCE(...)` has no FROM, so Postgres ALWAYS returns exactly one
+    // row carrying this column. Getting nothing back means the driver, the
+    // executor adapter or a test double is broken — it does NOT mean the org has
+    // nothing to prune. Collapsing the two (`rows[0]?.x ?? null`) would silently
+    // skip the prefix DELETE and retain expired audit rows past policy, which in
+    // this job is a compliance failure that reports itself as success. Fail loudly
+    // instead; the per-policy catch records it and the pass continues. Same
+    // principle as the deliberate non-null-safety in db/rowCount.ts.
+    throw new Error(
+      `[AuditRetention] cutoff query returned no row for org=${policy.org_id} — expected exactly one`,
+    );
+  }
+  // NULL (not absent) only when the org has no chain entries at all — nothing to
+  // prefix-cut, but the unsealed sweep below still runs.
+  const cutoffSeq = cutoffRow.cutoff_seq;
 
   // Step 2 — delete that prefix in bounded batches instead of one unbounded
   // statement (issue #4239). `ORDER BY c.chain_seq` is load-bearing, not

--- a/apps/api/src/jobs/auditRetention.ts
+++ b/apps/api/src/jobs/auditRetention.ts
@@ -41,6 +41,13 @@
  * Idempotent: re-running the same day matches zero rows because the
  * previous run already deleted everything older than the cutoff.
  *
+ * Scale (issue #4239): the prefix bound is an ordered early-stop
+ * (`ORDER BY chain_seq LIMIT 1`) rather than a `MIN()` over a full join,
+ * and the deletes run in bounded `LIMIT` batches (AUDIT_RETENTION_BATCH_SIZE
+ * / AUDIT_RETENTION_MAX_BATCHES), matching the sibling retention jobs. At
+ * 22M rows the previous shape planned as a per-policy Seq Scan of
+ * `audit_logs`, so each policy cost the same regardless of org size.
+ *
  * Schedule: daily at 03:30 UTC, half-hour offset from oauthCleanup
  * (03:00 UTC) so the two crons don't pile onto the same minute.
  *
@@ -68,6 +75,26 @@ const REPEAT_JOB_ID = 'audit-log-retention';
 // Daily at 03:30 UTC — off-peak and offset from oauthCleanup's 03:00.
 const DAILY_CRON = jobSchedule('audit-retention');
 
+function parsePositiveIntEnv(name: string, defaultValue: number): number {
+  const raw = process.env[name];
+  if (!raw) return defaultValue;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    console.warn(`[AuditRetention] Invalid ${name}="${raw}", using default ${defaultValue}`);
+    return defaultValue;
+  }
+  return parsed;
+}
+
+// Batched deletes (issue #4239). Same LIMIT-loop shape as the sibling retention
+// jobs (mlOutputRetention, deviceMetricsRetention, eventDispatchWorker): delete a
+// bounded slice, stop as soon as a batch comes back short of the limit.
+const BATCH_SIZE = parsePositiveIntEnv('AUDIT_RETENTION_BATCH_SIZE', 5000);
+// Per-org ceiling so one org with a large backlog cannot monopolise the nightly
+// pass. Stopping early is safe: the cap leaves a shorter chain PREFIX deleted
+// (see the ORDER BY note in deleteChainPrefix), and the next run advances it.
+const MAX_BATCHES = parsePositiveIntEnv('AUDIT_RETENTION_MAX_BATCHES', 200);
+
 function isRetentionEnabled(): boolean {
   const raw = process.env.AUDIT_RETENTION_ENABLED;
   if (raw === undefined || raw === '') return true; // default ON
@@ -87,15 +114,51 @@ const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
 export interface RetentionStats {
   policies: number;
   orgsPruned: number;
+  /** Rows removed by the chain-prefix cut. */
   rowsDeleted: number;
+  /**
+   * Rows removed by the unsealed-row sweep. Reported separately rather than
+   * folded into `rowsDeleted` so the prefix-cut number keeps its existing
+   * meaning, while sweep deletions stop being invisible in the job result.
+   */
+  unsealedRowsDeleted: number;
+  /** DELETE statements issued across all policies (prefix cut + sweep). */
+  batches: number;
+  /** Orgs that hit the per-org batch ceiling and still have expired rows. */
+  orgsWithBacklog: number;
   errors: number;
   durationMs: number;
+}
+
+/** Per-run batch tuning; falsy/absent fields fall back to the env-configured defaults. */
+export interface RetentionJobData {
+  batchSize?: number;
+  maxBatches?: number;
 }
 
 interface PolicyRow {
   id: string;
   org_id: string;
   retention_days: number;
+}
+
+interface BatchLimits {
+  batchSize: number;
+  maxBatches: number;
+}
+
+interface BatchedDeleteResult {
+  rowsDeleted: number;
+  batches: number;
+  /** True when the ceiling stopped a loop that was still deleting full batches. */
+  hasMore: boolean;
+}
+
+interface PrunePolicyResult {
+  rowsDeleted: number;
+  unsealedRowsDeleted: number;
+  batches: number;
+  hasMore: boolean;
 }
 
 // Minimal shape of the postgres-js / drizzle handle we need. Both the
@@ -106,12 +169,48 @@ interface SqlExecutor {
 }
 
 /**
+ * Run one DELETE repeatedly until a batch comes back short of `batchSize` or the
+ * `maxBatches` ceiling is reached. Mirrors the sibling retention jobs' loop
+ * (`mlOutputRetention.pruneMetricAnomalies`, `deviceMetricsRetention`).
+ *
+ * `buildStatement` is a thunk because each iteration needs a fresh `sql`
+ * fragment — drizzle's tagged template objects are not safely re-executable.
+ */
+async function runBatchedDelete(
+  exec: SqlExecutor,
+  limits: BatchLimits,
+  buildStatement: () => ReturnType<typeof sql>,
+): Promise<BatchedDeleteResult> {
+  let rowsDeleted = 0;
+  let batches = 0;
+  let lastBatchDeleted = 0;
+
+  while (batches < limits.maxBatches) {
+    const result = await exec.execute(buildStatement());
+    lastBatchDeleted = extractRowCount(result);
+    rowsDeleted += lastBatchDeleted;
+    batches += 1;
+    if (lastBatchDeleted < limits.batchSize) break;
+  }
+
+  return {
+    rowsDeleted,
+    batches,
+    hasMore: batches >= limits.maxBatches && lastBatchDeleted >= limits.batchSize,
+  };
+}
+
+/**
  * The retention DELETE for a single org, parameterized over the executor so
  * it can run on either pool. Assumes the caller has already armed the
  * trigger-bypass GUC (`breeze.allow_audit_retention = '1'`) on the same
  * transaction/connection.
  */
-async function deleteChainPrefix(exec: SqlExecutor, policy: PolicyRow): Promise<number> {
+async function deleteChainPrefix(
+  exec: SqlExecutor,
+  policy: PolicyRow,
+  limits: BatchLimits,
+): Promise<PrunePolicyResult> {
   // Prefix-cut delete (issue #1002 redesign): chain_seq order is COMMIT order,
   // which can disagree with timestamp order around long transactions, so a raw
   // `timestamp < cutoff` delete could remove a mid-chain entry and leave a
@@ -126,41 +225,93 @@ async function deleteChainPrefix(exec: SqlExecutor, policy: PolicyRow): Promise<
   // audit_logs — at all. The FK ON DELETE CASCADE removes the pruned rows'
   // chain entries; their BEFORE DELETE trigger passes because both call paths
   // set breeze.allow_audit_retention='1' SET LOCAL before calling this.
-  const result = await exec.execute(sql`
-    DELETE FROM audit_logs
-    WHERE id IN (
-      SELECT c.audit_id
-      FROM audit_log_chain c
-      WHERE c.org_id = ${policy.org_id}
-        AND c.chain_seq < COALESCE(
-          (
-            SELECT MIN(c2.chain_seq)
-            FROM audit_log_chain c2
-            JOIN audit_logs a2 ON a2.id = c2.audit_id
-            WHERE c2.org_id = ${policy.org_id}
-              AND a2.timestamp >= (now() - (${policy.retention_days}::int * interval '1 day'))
-          ),
-          (
-            SELECT MAX(c3.chain_seq) + 1
-            FROM audit_log_chain c3
-            WHERE c3.org_id = ${policy.org_id}
-          )
+
+  // Step 1 — the prefix bound, hoisted out of the DELETE and rewritten as an
+  // ordered early-stop (issue #4239). The old form was
+  // `MIN(c2.chain_seq)` over the same filtered join. MIN has to consume the
+  // WHOLE join before it can answer, and because the arm never constrains
+  // `a2.org_id`, `audit_logs_org_timestamp_idx (org_id, timestamp DESC)` is
+  // unusable — at 22M rows the planner chose a Seq Scan of audit_logs hash
+  // joined to a Seq Scan of audit_log_chain, ~3.3 min and ~14.8 GiB of block
+  // reads for ONE org, repeated per policy.
+  //
+  // `ORDER BY c2.chain_seq LIMIT 1` returns the identical value (the smallest
+  // chain_seq in the same filtered set, or NULL) — it is a pure plan change,
+  // not a semantic one, and it does not depend on timestamps being monotonic in
+  // chain order. But it lets the planner walk audit_log_chain in ascending
+  // chain_seq order and PK-probe audit_logs per candidate, stopping at the FIRST
+  // young row: ~(deletable prefix + 1) rows instead of the whole table. Which
+  // index carries that walk is the planner's choice — measured at 270k rows it
+  // took audit_log_chain_pkey with an org_id filter; with many orgs a backward
+  // scan of audit_log_chain_org_seq_idx (org_id, chain_seq DESC) is the more
+  // selective option. Either way the shape is an ordered early stop, not a scan.
+  //
+  // chain_seq is bigserial (int8); round-trip it as text so neither the driver's
+  // int8 handling nor JS number precision can round a large sequence value.
+  const cutoffRows = (await exec.execute(sql`
+    SELECT COALESCE(
+      (
+        SELECT c2.chain_seq
+        FROM audit_log_chain c2
+        JOIN audit_logs a2 ON a2.id = c2.audit_id
+        WHERE c2.org_id = ${policy.org_id}
+          AND a2.timestamp >= (now() - (${policy.retention_days}::int * interval '1 day'))
+        ORDER BY c2.chain_seq
+        LIMIT 1
+      ),
+      (
+        SELECT MAX(c3.chain_seq) + 1
+        FROM audit_log_chain c3
+        WHERE c3.org_id = ${policy.org_id}
+      )
+    )::text AS cutoff_seq
+  `)) as unknown as Array<{ cutoff_seq: string | null }>;
+  // NULL only when the org has no chain entries at all — nothing to prefix-cut.
+  const cutoffSeq = cutoffRows[0]?.cutoff_seq ?? null;
+
+  // Step 2 — delete that prefix in bounded batches instead of one unbounded
+  // statement (issue #4239). `ORDER BY c.chain_seq` is load-bearing, not
+  // cosmetic: each batch must take the LOWEST remaining chain_seq values so
+  // that whatever has been deleted is always a contiguous prefix. Without it
+  // `LIMIT` would pick an arbitrary subset, and stopping at `maxBatches` would
+  // leave holes in the middle of the chain — exactly the permanent linkage
+  // break the prefix-cut design exists to prevent.
+  const prefix = cutoffSeq === null
+    ? { rowsDeleted: 0, batches: 0, hasMore: false }
+    : await runBatchedDelete(exec, limits, () => sql`
+        DELETE FROM audit_logs
+        WHERE id IN (
+          SELECT c.audit_id
+          FROM audit_log_chain c
+          WHERE c.org_id = ${policy.org_id}
+            AND c.chain_seq < ${cutoffSeq}::bigint
+          ORDER BY c.chain_seq
+          LIMIT ${limits.batchSize}
         )
+      `);
+
+  // Step 3 — sweep any UNSEALED old rows too (shouldn't exist post-backfill;
+  // keeps retention complete if one ever appears). The chain has no entry for
+  // them, so deleting them can't affect linkage and needs no ordering. Batched
+  // for the same reason as the prefix cut: this is the same 22M-row table.
+  const sweep = await runBatchedDelete(exec, limits, () => sql`
+    DELETE FROM audit_logs
+    WHERE ctid IN (
+      SELECT a.ctid
+      FROM audit_logs a
+      WHERE a.org_id = ${policy.org_id}
+        AND a.timestamp < (now() - (${policy.retention_days}::int * interval '1 day'))
+        AND NOT EXISTS (SELECT 1 FROM audit_log_chain c WHERE c.audit_id = a.id)
+      LIMIT ${limits.batchSize}
     )
   `);
-  const count = extractRowCount(result);
 
-  // Sweep any UNSEALED old rows too (shouldn't exist post-backfill; keeps
-  // retention complete if one ever appears). The chain has no entry for them,
-  // so deleting them can't affect linkage.
-  await exec.execute(sql`
-    DELETE FROM audit_logs a
-    WHERE a.org_id = ${policy.org_id}
-      AND a.timestamp < (now() - (${policy.retention_days}::int * interval '1 day'))
-      AND NOT EXISTS (SELECT 1 FROM audit_log_chain c WHERE c.audit_id = a.id)
-  `);
-
-  return count;
+  return {
+    rowsDeleted: prefix.rowsDeleted,
+    unsealedRowsDeleted: sweep.rowsDeleted,
+    batches: prefix.batches + sweep.batches,
+    hasMore: prefix.hasMore || sweep.hasMore,
+  };
 }
 
 /**
@@ -172,7 +323,7 @@ async function deleteChainPrefix(exec: SqlExecutor, policy: PolicyRow): Promise<
  *  - LEGACY path: run on the breeze_app pool via withSystemDbAccessContext,
  *    arming BOTH the SET LOCAL ROLE and the bypass GUC (pre-#915 behavior).
  */
-async function pruneOrg(policy: PolicyRow): Promise<number> {
+async function pruneOrg(policy: PolicyRow, limits: BatchLimits): Promise<PrunePolicyResult> {
   if (hasDedicatedAuditAdminPool()) {
     const adminDb = getAuditAdminDb();
     // Run inside a transaction so SET LOCAL is scoped to this prune. The
@@ -193,7 +344,7 @@ async function pruneOrg(policy: PolicyRow): Promise<number> {
       // Trigger bypass; the connection logs in AS breeze_audit_admin, which
       // already holds the DELETE privilege (no SET ROLE needed).
       await tx.execute(sql`SET LOCAL breeze.allow_audit_retention = '1'`);
-      return deleteChainPrefix(tx as unknown as SqlExecutor, policy);
+      return deleteChainPrefix(tx as unknown as SqlExecutor, policy, limits);
     });
   }
 
@@ -203,7 +354,7 @@ async function pruneOrg(policy: PolicyRow): Promise<number> {
     // transaction and revert on commit/rollback automatically.
     await dbModule.db.execute(sql`SET LOCAL ROLE breeze_audit_admin`);
     await dbModule.db.execute(sql`SET LOCAL breeze.allow_audit_retention = '1'`);
-    return deleteChainPrefix(dbModule.db as unknown as SqlExecutor, policy);
+    return deleteChainPrefix(dbModule.db as unknown as SqlExecutor, policy, limits);
   });
 }
 
@@ -214,12 +365,21 @@ async function pruneOrg(policy: PolicyRow): Promise<number> {
  * The worker processor below calls this and surfaces the stats in the
  * job return value.
  */
-export async function pruneExpiredAuditLogs(): Promise<RetentionStats> {
+export async function pruneExpiredAuditLogs(
+  options: RetentionJobData = {},
+): Promise<RetentionStats> {
   const startedAt = Date.now();
+  const limits: BatchLimits = {
+    batchSize: Math.max(1, options.batchSize ?? BATCH_SIZE),
+    maxBatches: Math.max(1, options.maxBatches ?? MAX_BATCHES),
+  };
   const stats: RetentionStats = {
     policies: 0,
     orgsPruned: 0,
     rowsDeleted: 0,
+    unsealedRowsDeleted: 0,
+    batches: 0,
+    orgsWithBacklog: 0,
     errors: 0,
     durationMs: 0,
   };
@@ -238,9 +398,12 @@ export async function pruneExpiredAuditLogs(): Promise<RetentionStats> {
 
   for (const policy of policies) {
     try {
-      const rowsDeleted = await pruneOrg(policy);
+      const pruned = await pruneOrg(policy, limits);
 
-      stats.rowsDeleted += rowsDeleted;
+      stats.rowsDeleted += pruned.rowsDeleted;
+      stats.unsealedRowsDeleted += pruned.unsealedRowsDeleted;
+      stats.batches += pruned.batches;
+      if (pruned.hasMore) stats.orgsWithBacklog += 1;
       stats.orgsPruned += 1;
 
       // Record last_cleanup_at in its own transaction (the DELETE tx
@@ -266,8 +429,16 @@ export async function pruneExpiredAuditLogs(): Promise<RetentionStats> {
 
   stats.durationMs = Date.now() - startedAt;
   console.log(
-    `[AuditRetention] Pruned ${stats.rowsDeleted} row(s) across ${stats.orgsPruned}/${stats.policies} polic(ies) in ${stats.durationMs}ms (errors=${stats.errors})`,
+    `[AuditRetention] Pruned ${stats.rowsDeleted} row(s) (+${stats.unsealedRowsDeleted} unsealed) across ${stats.orgsPruned}/${stats.policies} polic(ies) in ${stats.batches} batch(es) of ${limits.batchSize} in ${stats.durationMs}ms (errors=${stats.errors}, backlogged=${stats.orgsWithBacklog})`,
   );
+  if (stats.orgsWithBacklog > 0) {
+    // Not an error: the ceiling did its job. Say so loudly anyway, because the
+    // only other signal that a backlog is draining across nights is watching
+    // rowsDeleted stay pinned at maxBatches * batchSize.
+    console.warn(
+      `[AuditRetention] ${stats.orgsWithBacklog} org(s) hit the ${limits.maxBatches}-batch ceiling and still have expired rows; the next run continues the prefix.`,
+    );
+  }
   return stats;
 }
 
@@ -283,15 +454,20 @@ export function getAuditRetentionQueue(): Queue {
   return retentionQueue;
 }
 
-export function createAuditRetentionWorker(): Worker {
-  return new Worker(
+export function createAuditRetentionWorker(): Worker<RetentionJobData> {
+  return new Worker<RetentionJobData>(
     QUEUE_NAME,
-    async (job: Job) => {
+    async (job: Job<RetentionJobData>) => {
       if (job.name !== JOB_NAME) {
         console.warn(`[AuditRetention] Ignoring unknown job name: ${job.name}`);
         return { skipped: true, rowsDeleted: 0 };
       }
-      return pruneExpiredAuditLogs();
+      // Batch overrides come off the job payload so an operator draining a
+      // backlog by hand can widen the ceiling for one run without a redeploy.
+      return pruneExpiredAuditLogs({
+        batchSize: job.data?.batchSize,
+        maxBatches: job.data?.maxBatches,
+      });
     },
     {
       connection: getBullMQConnection(),
@@ -383,5 +559,8 @@ export const __testOnly = {
   JOB_NAME,
   REPEAT_JOB_ID,
   DAILY_CRON,
+  BATCH_SIZE,
+  MAX_BATCHES,
   isRetentionEnabled,
+  parsePositiveIntEnv,
 };


### PR DESCRIPTION
Closes #4239

## What was wrong

`pruneExpiredAuditLogs()` computed each policy's chain-prefix bound with `MIN(chain_seq)` over a full `audit_log_chain ⋈ audit_logs` join. `MIN` has to consume the whole join before it can answer, and the arm never constrains `a2.org_id`, so `audit_logs_org_timestamp_idx (org_id, timestamp DESC)` was unusable. At the reporter's ~22M rows the planner picked a Seq Scan of `audit_logs` hash joined to a Seq Scan of `audit_log_chain` — a cost that tracks **total table size, not the org** — repeated once per policy. The outer DELETE Seq-Scanned `audit_logs` a second time, unbounded.

## What changed

Both moves were pre-approved in the issue thread.

**1. Ordered early-stop cutoff (direction 1).** `ORDER BY chain_seq LIMIT 1` in place of `MIN(chain_seq)`. Identical value over an identical filtered set — a pure plan change, and it does not depend on timestamps being monotonic in chain order. The bound is also **hoisted out of the DELETE** so it is computed once per policy instead of re-planned inside every batch. The `COALESCE(..., MAX+1)` all-old fallback stays (it is an index lookup, not a scan).

**2. Batched deletes (direction 3).** The prefix cut and the unsealed-row sweep now run in `LIMIT`-bounded batches with a per-org ceiling, matching the sibling retention jobs (`mlOutputRetention`, `deviceMetricsRetention`, `eventDispatchWorker`): delete a bounded slice, stop when a batch comes back short. Tunable via `AUDIT_RETENTION_BATCH_SIZE` (default 5000) / `AUDIT_RETENTION_MAX_BATCHES` (default 200), and overridable per run from the job payload so an operator draining a backlog can widen the ceiling without a redeploy.

No migration, no new index, no schema change. Privilege separation, both bypass layers, per-policy transaction isolation and the "retention never UPDATEs the audit tables" guarantee are all untouched.

### The invariant, and why `ORDER BY` is load-bearing

`ORDER BY c.chain_seq` inside the batch subquery is **not cosmetic**. Each batch must take the LOWEST remaining `chain_seq` so that what has been deleted is always a contiguous prefix. Without it, `LIMIT` picks an arbitrary subset and stopping at `maxBatches` leaves holes mid-chain — exactly the permanent linkage break the #1002 prefix-cut design exists to prevent.

This is not theoretical. Deleting the `ORDER BY` and re-running the integration suite: with 6 expired rows, `batchSize: 2, maxBatches: 2`, Postgres deleted `old-3..old-6` and left `old-1, old-2` — a real mid-chain hole.

## Evidence

**Plan shape, measured on 270k seeded rows across 6 orgs (pg16, `EXPLAIN (ANALYZE, BUFFERS)`).** This reproduces the reported shape at a scale I can reach; it is not 22M-row evidence.

Cutoff SELECT, one org:

| | old (`MIN`) | new (ordered early-stop) |
|---|---|---|
| plan | Parallel Hash Join over **Seq Scan `audit_logs`** + **Seq Scan `audit_log_chain`** | `Limit` → Nested Loop → Index Scan + PK probes |
| rows discarded | 76,500 + 74,999 | 6,668 |
| buffers | **15,717** | **263** |
| exec time | 30.7 ms | 1.3 ms |

Equivalence checked on that data: both forms return `chain_seq = 6720`.

The DELETE plan changes from `Seq Scan on audit_logs` **twice** (once for the cutoff InitPlan, once for the outer hash join) to fully index-driven — `Limit` → Index Scan on `audit_log_chain` → Index Scan on `audit_logs_pkey`, with no Seq Scan of `audit_logs` at all.

**What I could not verify:** `EXPLAIN` from the reporter's real 22M-row tables. The issue asked for before/after at that scale and it is still the useful confirmation — the steady-state claim (walk ≈ prefix length) is a plan-shape argument, not a measurement at production size.

## Tests

- `apps/api/src/jobs/auditRetention.test.ts` — 22 passed. New coverage: cutoff uses an ordered early-stop and contains no `MIN(`; the bound is hoisted out of the DELETE; the prefix DELETE carries `ORDER BY c.chain_seq` + `LIMIT`; the loop continues until a short batch; the `maxBatches` ceiling stops it and reports the org as backlogged; a null cutoff skips the prefix DELETE but still sweeps; limits clamp to ≥1 so a `0` can never disable pruning. Ordinal mocking was replaced with statement-kind dispatch — batch loops have a data-dependent call count that ordinals cannot express.
- `apps/api/src/__tests__/integration/audit-retention.integration.test.ts` — 10 passed on real Postgres. New: the `old → young → old` chain-order invariant (deletes only the leading old prefix, keeps the trailing old row, `audit_log_verify_chain()` returns 0 breaks); a multi-batch prefix drains completely; **stopping at the ceiling leaves a contiguous suffix, not holes**; an all-young org is untouched.

Both of the load-bearing controls were **mutation-verified** — I broke the implementation each way and confirmed the specific test went red, then restored:
- remove `ORDER BY` from the batch DELETE → `deletes the prefix in ordered, LIMIT-bounded batches` fails, and the integration `contiguous suffix` test fails on real data.
- revert the cutoff to `MIN()` → `computes the prefix bound with an ordered early-stop` fails.

**Status:** `tsc --noEmit` clean; `eslint` clean on all three files; 202 unit tests green across the 8 affected files; 12 integration tests green across both audit-retention suites.

## Note for the reviewer

`RetentionStats` gains `unsealedRowsDeleted`, `batches` and `orgsWithBacklog`. The unsealed sweep previously deleted rows that were never counted anywhere, so a manual prune could report `0 rows deleted` while rows vanished; it is now reported separately rather than folded into `rowsDeleted`, which keeps that field's existing meaning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JCiqAhFVwT5hWi9kWz4vED