### PR TITLE
fix(agent): stop re-prompting Screen Recording on every helper start (#4327)

### DIFF
--- a/agent/internal/userhelper/tcc_darwin.go
+++ b/agent/internal/userhelper/tcc_darwin.go
@@ -154,12 +154,26 @@ func checkTCCPermissions(desktopContext string, allowPrompt bool, allowCapturePr
 	}
 }
 
-// RequestScreenRecording triggers the macOS system prompt for Screen Recording
-// permission. Only triggers the prompt once per process — subsequent calls just
-// check the current state. Should be called on first startup to ensure the user
-// sees the consent dialog.
+// RequestScreenRecording asks macOS for Screen Recording permission via
+// CGRequestScreenCaptureAccess(). This is a *prompting* API: whenever macOS
+// does not already attribute a grant to this binary it shows the system consent
+// dialog. Callers must gate it — see maybeRequestScreenRecording.
 func RequestScreenRecording() bool {
 	return bool(C.requestScreenRecording())
+}
+
+// Indirection seams for the two CoreGraphics entry points the consent policy
+// depends on, so the policy can be exercised in tests without real TCC state.
+var (
+	screenRecordingGrantedFn = func() bool { return bool(C.checkScreenRecording()) }
+	requestScreenRecordingFn = RequestScreenRecording
+)
+
+// maybeRequestScreenRecording decides whether to raise the macOS Screen
+// Recording consent dialog.
+func maybeRequestScreenRecording(markerPath string, now time.Time) {
+	granted := requestScreenRecordingFn()
+	log.Info("Screen Recording permission request", "alreadyGranted", granted)
 }
 
 // probeFullDiskAccess checks Full Disk Access by attempting to open the system
@@ -229,12 +243,7 @@ func RunTCCCheckLoop(conn *ipc.Conn, stopChan chan struct{}, desktopContext stri
 		firstCheck = false
 	}
 
-	// On first run, trigger the Screen Recording system prompt via
-	// CGRequestScreenCaptureAccess(). This is idempotent — macOS only shows the
-	// dialog once per app. If the user has already granted the permission, this
-	// returns immediately with true.
-	granted := RequestScreenRecording()
-	log.Info("Screen Recording permission request", "alreadyGranted", granted)
+	maybeRequestScreenRecording(screenRecordingMarkerPath(), time.Now())
 
 	// Immediate first check (sends full TCC status to the service)
 	check()
@@ -375,19 +384,32 @@ func cloneBoolPtr(v *bool) *bool {
 // we've already shown the first-run TCC dialog to this user. Uses the user's
 // Application Support directory to prevent other processes from tampering.
 func tccPromptFilePath() string {
+	return tccMarkerFilePath("tcc-prompted")
+}
+
+// screenRecordingMarkerPath returns the path to the marker file recording when
+// we last raised the Screen Recording consent dialog for this user.
+func screenRecordingMarkerPath() string {
+	return tccMarkerFilePath("screen-recording-requested")
+}
+
+// tccMarkerFilePath returns the path to a per-user TCC marker file. Uses the
+// user's Application Support directory to prevent other processes from
+// tampering, falling back to the temp dir when that is unavailable.
+func tccMarkerFilePath(name string) string {
 	cu, err := user.Current()
 	if err != nil {
-		log.Warn("could not determine current user for TCC prompt marker, using shared path",
-			"error", err.Error())
-		return filepath.Join(os.TempDir(), "breeze-tcc-prompted")
+		log.Warn("could not determine current user for TCC marker, using shared path",
+			"marker", name, "error", err.Error())
+		return filepath.Join(os.TempDir(), "breeze-"+name)
 	}
 	dir := filepath.Join(cu.HomeDir, "Library", "Application Support", "Breeze")
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		log.Warn("could not create Breeze app support dir, falling back to tmp",
 			"dir", dir, "error", err.Error())
-		return filepath.Join(os.TempDir(), fmt.Sprintf("breeze-tcc-prompted-%s", cu.Uid))
+		return filepath.Join(os.TempDir(), fmt.Sprintf("breeze-%s-%s", name, cu.Uid))
 	}
-	return filepath.Join(dir, "tcc-prompted")
+	return filepath.Join(dir, name)
 }
 
 // showTCCDialog shows an osascript dialog listing missing permissions with an

--- a/agent/internal/userhelper/tcc_darwin.go
+++ b/agent/internal/userhelper/tcc_darwin.go
@@ -116,6 +116,11 @@ const tccFastCheckDuration = 30 * time.Minute
 
 const tccHelperCommandTimeout = 15 * time.Second
 
+// screenRecordingRequestInterval is the minimum gap between two macOS Screen
+// Recording consent dialogs raised by this helper for the same user, applied
+// only while the permission is actually missing.
+const screenRecordingRequestInterval = 24 * time.Hour
+
 // CheckTCCPermissions probes macOS TCC permissions. On the first call,
 // triggers the accessibility system prompt; subsequent calls check silently.
 func CheckTCCPermissions(desktopContext string) *ipc.TCCStatus {
@@ -169,11 +174,59 @@ var (
 	requestScreenRecordingFn = RequestScreenRecording
 )
 
-// maybeRequestScreenRecording decides whether to raise the macOS Screen
-// Recording consent dialog.
+// maybeRequestScreenRecording raises the macOS Screen Recording consent dialog
+// only when it can actually help. CGRequestScreenCaptureAccess() shows the
+// system dialog on *every* call whose grant macOS does not attribute to this
+// binary, so calling it once per helper process meant one dialog per launchd
+// (re)start — every kickstart, and once per respawn in the exit-1 loop from
+// #4194 (#4327). Two gates:
+//
+//  1. If the non-prompting probe (CGPreflightScreenCaptureAccess, with the
+//     macOS 26 capture fallback) already reports access, never ask.
+//  2. Otherwise ask at most once per screenRecordingRequestInterval per user,
+//     recorded in a marker file, so a fresh install still gets its consent
+//     dialog but a respawning helper cannot storm the user with them.
+//
+// A marker we cannot read or write fails open (we prompt), matching the FDA
+// guidance marker: gate 1 already stops the reported re-prompt on its own.
 func maybeRequestScreenRecording(markerPath string, now time.Time) {
+	if screenRecordingGrantedFn() {
+		log.Debug("Screen Recording already granted — not raising the consent dialog")
+		return
+	}
+	if !screenRecordingRequestDue(markerPath, now) {
+		log.Debug("Screen Recording consent requested recently — not raising the dialog again",
+			"path", markerPath)
+		return
+	}
+
 	granted := requestScreenRecordingFn()
 	log.Info("Screen Recording permission request", "alreadyGranted", granted)
+
+	if err := os.WriteFile(markerPath, []byte(now.UTC().Format(time.RFC3339)), 0600); err != nil {
+		log.Warn("failed to write Screen Recording request marker — user may see repeated prompts",
+			"path", markerPath, "error", err.Error())
+	}
+}
+
+// screenRecordingRequestDue reports whether enough time has passed since the
+// last consent dialog. An absent, unreadable, or unparseable marker means yes.
+func screenRecordingRequestDue(markerPath string, now time.Time) bool {
+	data, err := os.ReadFile(markerPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Warn("could not read Screen Recording request marker — requesting anyway",
+				"path", markerPath, "error", err.Error())
+		}
+		return true
+	}
+	last, err := time.Parse(time.RFC3339, strings.TrimSpace(string(data)))
+	if err != nil {
+		log.Warn("Screen Recording request marker is unparseable — requesting anyway",
+			"path", markerPath, "error", err.Error())
+		return true
+	}
+	return now.Sub(last) >= screenRecordingRequestInterval
 }
 
 // probeFullDiskAccess checks Full Disk Access by attempting to open the system
@@ -194,9 +247,10 @@ func probeFullDiskAccess() bool {
 }
 
 // RunTCCCheckLoop periodically checks TCC permissions and sends status via IPC.
-// It runs an immediate check on start (triggering the Screen Recording prompt
-// if not yet granted), then re-checks at a fast interval while permissions are
-// missing, switching to the slower interval once all are granted.
+// It runs an immediate check on start (raising the Screen Recording consent
+// dialog only when the permission is missing and we have not asked recently),
+// then re-checks at a fast interval while permissions are missing, switching to
+// the slower interval once all are granted.
 func RunTCCCheckLoop(conn *ipc.Conn, stopChan chan struct{}, desktopContext string, canProbe func() bool) {
 	startedAt := time.Now()
 	var seq uint64

--- a/agent/internal/userhelper/tcc_darwin_test.go
+++ b/agent/internal/userhelper/tcc_darwin_test.go
@@ -1,0 +1,132 @@
+//go:build darwin && cgo
+
+package userhelper
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// maybeRequestScreenRecording must never raise the macOS consent dialog when we
+// already have Screen Recording access, and must not raise it more than once
+// per screenRecordingRequestInterval when we don't. Calling the prompting API
+// (CGRequestScreenCaptureAccess) unconditionally at the top of the check loop is
+// what produced one system dialog per helper start in #4327, multiplied by the
+// launchd respawn loop in #4194.
+func TestMaybeRequestScreenRecording(t *testing.T) {
+	now := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name string
+		// granted is what the non-prompting probe reports.
+		granted bool
+		// marker is the timestamp already recorded, or nil for no marker file.
+		marker *time.Time
+		// markerBody overrides marker with raw file content.
+		markerBody      string
+		wantRequest     bool
+		wantMarkerStamp string
+	}{
+		{
+			name:            "already granted, no marker — never prompts",
+			granted:         true,
+			wantRequest:     false,
+			wantMarkerStamp: "",
+		},
+		{
+			name:            "already granted, stale marker — still never prompts",
+			granted:         true,
+			marker:          timePtr(now.Add(-72 * time.Hour)),
+			wantRequest:     false,
+			wantMarkerStamp: now.Add(-72 * time.Hour).Format(time.RFC3339),
+		},
+		{
+			name:            "not granted, no marker — prompts and records it",
+			granted:         false,
+			wantRequest:     true,
+			wantMarkerStamp: now.Format(time.RFC3339),
+		},
+		{
+			name:            "not granted, recent marker — stays quiet",
+			granted:         false,
+			marker:          timePtr(now.Add(-1 * time.Hour)),
+			wantRequest:     false,
+			wantMarkerStamp: now.Add(-1 * time.Hour).Format(time.RFC3339),
+		},
+		{
+			name:            "not granted, stale marker — prompts again and refreshes",
+			granted:         false,
+			marker:          timePtr(now.Add(-25 * time.Hour)),
+			wantRequest:     true,
+			wantMarkerStamp: now.Format(time.RFC3339),
+		},
+		{
+			name:            "not granted, unparseable marker — prompts and repairs marker",
+			granted:         false,
+			markerBody:      "not-a-timestamp",
+			wantRequest:     true,
+			wantMarkerStamp: now.Format(time.RFC3339),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			markerPath := filepath.Join(t.TempDir(), "screen-recording-requested")
+			switch {
+			case tt.markerBody != "":
+				writeMarker(t, markerPath, tt.markerBody)
+			case tt.marker != nil:
+				writeMarker(t, markerPath, tt.marker.Format(time.RFC3339))
+			}
+
+			requested := false
+			restore := stubScreenRecordingFns(t, tt.granted, func() bool {
+				requested = true
+				return tt.granted
+			})
+			defer restore()
+
+			maybeRequestScreenRecording(markerPath, now)
+
+			if requested != tt.wantRequest {
+				t.Errorf("prompting API called = %v, want %v", requested, tt.wantRequest)
+			}
+
+			data, err := os.ReadFile(markerPath)
+			if tt.wantMarkerStamp == "" {
+				if !os.IsNotExist(err) {
+					t.Errorf("expected no marker file, got content %q err %v", data, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("reading marker: %v", err)
+			}
+			if string(data) != tt.wantMarkerStamp {
+				t.Errorf("marker = %q, want %q", data, tt.wantMarkerStamp)
+			}
+		})
+	}
+}
+
+func stubScreenRecordingFns(t *testing.T, granted bool, request func() bool) func() {
+	t.Helper()
+	origGranted, origRequest := screenRecordingGrantedFn, requestScreenRecordingFn
+	screenRecordingGrantedFn = func() bool { return granted }
+	requestScreenRecordingFn = request
+	return func() {
+		screenRecordingGrantedFn = origGranted
+		requestScreenRecordingFn = origRequest
+	}
+}
+
+func writeMarker(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0600); err != nil {
+		t.Fatalf("seeding marker: %v", err)
+	}
+}
+
+func timePtr(v time.Time) *time.Time { return &v }


### PR DESCRIPTION
## Root cause

`RunTCCCheckLoop` called `RequestScreenRecording()` unconditionally at the top of every invocation (`agent/internal/userhelper/tcc_darwin.go:236` on main), and that function is a straight call to `CGRequestScreenCaptureAccess()` (`tcc_darwin.go:162`, C shim `tcc_darwin.go:45-49`) — a **prompting** API. The loop is started once per helper process, from `Client.Run` after IPC auth (`agent/internal/userhelper/client.go:150`), so the prompting API fired once per helper **process start**, not once per install.

The inline comment justifying that call — "This is idempotent — macOS only shows the dialog once per app" — is wrong for a launchd-managed, non-bundled Mach-O: whenever macOS does not attribute an existing grant to this binary, the call raises the system dialog *every* time. So every `launchctl kickstart` produced a dialog, and #4194's exit-1 respawn loop (reporter saw `runs = 5 / last exit code = 1`) multiplied that by the respawn count. The reporter on 0.108 sees the dialog on every helper start with the System Settings toggle already ON.

A non-prompting probe was already compiled in and used elsewhere in the same file: `checkScreenRecording()` (`tcc_darwin.go:19-40`) → `CGPreflightScreenCaptureAccess()` plus a `CGWindowListCreateImage` capture fallback for macOS 26. Line 236 simply never consulted it.

Note the reporter's own probe output on the affected host shows `screenRecording=true` / `captureGranted=true`, i.e. `checkScreenRecording()` returns **true** there — so gate 1 below alone silences the reported re-prompt on that host, independent of *why* macOS answers the request API with a dialog.

## Fix

`maybeRequestScreenRecording(markerPath, now)` replaces the unconditional call, with two gates:

1. **If the non-prompting probe already reports access, never call the prompting API.** This is the actual defect and the whole fix for the reported host.
2. **If access really is missing, ask at most once per 24h per user**, recorded as an RFC3339 timestamp in `~/Library/Application Support/Breeze/screen-recording-requested`. A fresh install still gets its consent dialog; a respawning or repeatedly kickstarted helper cannot storm the user with them.

Marker path reuses the helper's existing per-user marker helper (the FDA `tcc-prompted` marker already lives in that dir, with the same `os.TempDir()` fallbacks) — generalized to `tccMarkerFilePath(name)`, no new state location. An unreadable/unwritable/unparseable marker **fails open** (we prompt), matching `handleFullDiskAccessGuidance`; gate 1 stands on its own regardless.

The two CoreGraphics entry points are now behind package-level function vars (`screenRecordingGrantedFn`, `requestScreenRecordingFn`) purely as test seams.

## Why not X

- **Why not prompt only on first-ever run (permanent marker)?** A permanent marker means a user who denies once, or whose grant is later revoked, never sees the dialog again — the helper would go silent on a genuinely missing permission with no on-machine signal (there is no FDA-style guidance path for Screen Recording; that path deliberately covers FDA only). A 24h floor kills the storm without making the prompt unrecoverable.
- **Why not drop the prompting call entirely and rely on the web UI banner?** Fresh installs would then require a manual System Settings visit with no on-machine cue. The macOS consent dialog is the correct UX for a permission that *has* a request API — the bug was calling it when it cannot help, not calling it at all.
- **Why not re-derive grant state from TCC.db?** That is the retired self-heal pattern from #3380 (sqlite3 subprocess, denied by macOS, writes with no code-identity binding). This change reads permission state only through the public CoreGraphics APIs already in use, and writes nothing outside the user's own Application Support directory. No TCC.db writes, no `sqlite3` subprocess, nothing resurrected.
- **Why not also fix the `remoteDesktop=false` / `captureGranted=true` reporting confusion from the same issue?** Separate defect (inconclusive capture probe rendered as "Missing"), separate change — kept out to keep this diff reviewable.
- **Why gate on `checkScreenRecording()` rather than raw preflight?** It is the same function the loop already reports status with, so gate 1 cannot disagree with what we tell the server, and it keeps the macOS 26 fallback. It is non-prompting and already runs every check cycle, so this adds no new prompt surface.

## Testing

Red-first. `TestMaybeRequestScreenRecording` (table-driven, 6 cases) was written against the extracted-but-unchanged behavior and all 6 subtests failed, including the discriminating one:

```
--- FAIL: TestMaybeRequestScreenRecording/already_granted,_no_marker_—_never_prompts
    tcc_darwin_test.go:94: prompting API called = true, want false
```

After the fix all 6 pass. Cases: granted/no marker, granted/stale marker, not-granted/no marker, not-granted/recent marker, not-granted/stale marker, not-granted/unparseable marker.

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test -race ./internal/userhelper/...` — ok
- `go test -race ./...` — one pre-existing environment failure unrelated to this change (`internal/heartbeat` `TestHandleHttpRequest`: `httptest` binds a link-local `169.254.x` address on this host and trips the SSRF guard). Verified it fails identically with this change reverted to `origin/main`.
- Non-darwin behavior unchanged: `tcc_other.go` untouched; `GOOS=linux`, `GOOS=windows`, and `CGO_ENABLED=0` darwin builds all green.

Refs #4327

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTQvd5qr2a9CNSjzshsUzS