### PR TITLE
fix(abuse): close #4356 review findings — scan gate, axis map, IP normalization

### DIFF
--- a/apps/api/src/services/abuseSignals/corroboration.test.ts
+++ b/apps/api/src/services/abuseSignals/corroboration.test.ts
@@ -345,6 +345,7 @@ describe('SIGNAL_AXIS coverage', () => {
     'billing.card_testing',
     'fraud.suspended_console_ip',
     'fraud.dead_account_probe_origin',
+    'rmm.recidivist_endpoint',
     'fraud.failed_login_cluster',
     'resource.enrollment_denied',
     'resource.volume_outlier',

--- a/apps/api/src/services/abuseSignals/corroboration.ts
+++ b/apps/api/src/services/abuseSignals/corroboration.ts
@@ -41,7 +41,9 @@ import type { ComputedSignal } from './types';
  * safe default for a NEW detector (it can corroborate immediately), but it
  * means adding a detector that restates an existing observation REQUIRES adding
  * it here — otherwise it double-counts. `corroboration.test.ts` asserts every
- * key this sweep can emit is mapped.
+ * key in its hand-maintained EMITTED_KEYS list is mapped or explicitly
+ * ineligible — when you add a detector, add its key THERE as well as here, or
+ * the assertion cannot see it.
  */
 export const SIGNAL_AXIS: Record<string, string> = {
   // `session_intensity` is "fast enroll-to-remote" and `enrollment_velocity` is
@@ -63,6 +65,13 @@ export const SIGNAL_AXIS: Record<string, string> = {
   // manufacture an alert, the same trap the ip_scatter pair is grouped for.
   'fraud.suspended_console_ip': 'origin_ip',
   'fraud.dead_account_probe_origin': 'origin_ip',
+  // Deliberately its OWN axis, distinct from origin_ip: the recidivist
+  // detector reads endpoint identity (ScreenConnect client GUID, hostname,
+  // device egress IP), the origin-IP detector reads console/network origin.
+  // A ring re-establishing trips both from independent evidence sources, and
+  // that pair corroborating (hostname-only watch at 60 + probe watch at 55)
+  // is the desired outcome, not double-counting.
+  'rmm.recidivist_endpoint': 'endpoint_identity',
   'billing.cardholder_name_mismatch': 'billing_identity',
   'billing.card_testing': 'billing_identity',
   'billing.shared_card_fingerprint': 'billing_identity',

--- a/apps/api/src/services/abuseSignals/originIp.test.ts
+++ b/apps/api/src/services/abuseSignals/originIp.test.ts
@@ -195,6 +195,48 @@ describe('fraud.suspended_console_ip', () => {
     );
     expect(keys(out)).toEqual([SUSPENDED_CONSOLE_IP_KEY]);
   });
+
+  it('matches a compressed IPv6 literal against its expanded form exactly', () => {
+    // The exact-match path is the alert-tier signal, so compression must not
+    // defeat it any more than it defeats the /64 grouping.
+    const out = computeOriginIpSignals(
+      [agg({ originIps: ['2001:db8:145:2002::1'] })],
+      corpus({ suspendedIps: new Map([['2001:0db8:0145:2002:0000:0000:0000:0001', ['Dead Co']]]) }),
+      cfg,
+      NOW,
+    );
+    expect(keys(out)).toEqual([SUSPENDED_CONSOLE_IP_KEY]);
+    expect(out[0]!.evidence.matchedIps).toEqual(['2001:db8:145:2002::1']);
+  });
+
+  it('matches an IPv4-mapped IPv6 address against itself and counts it once', () => {
+    // ::ffff:203.0.113.7 exercises the embedded-v4-tail branch of expandIPv6.
+    const mapped = '::ffff:203.0.113.7';
+    const out = computeOriginIpSignals(
+      [agg({ originIps: [mapped, '::ffff:cb00:7107'] })],
+      corpus({ suspendedIps: new Map([[mapped, ['Dead Co']]]) }),
+      cfg,
+      NOW,
+    );
+    expect(keys(out)).toEqual([SUSPENDED_CONSOLE_IP_KEY]);
+    // The dotted-quad and hex spellings canonicalize to one address: one
+    // match, base score only, no per_extra_ip inflation.
+    expect(out[0]!.score).toBe(cfg['fraud.suspended_console_ip.base_score']);
+    expect(out[0]!.evidence.matchedIps).toHaveLength(1);
+  });
+
+  it('counts two XFF spellings of one client address as ONE matched IP', () => {
+    // Same real client behind two different legacy proxy second hops must not
+    // earn the per_extra_ip bonus, and the evidence must cite the clean IP.
+    const out = computeOriginIpSignals(
+      [agg({ originIps: ['203.0.113.7, 172.19.0.8', '203.0.113.7, 172.19.0.5'] })],
+      corpus({ suspendedIps: new Map([['203.0.113.7', ['Dead Co']]]) }),
+      cfg,
+      NOW,
+    );
+    expect(out[0]!.score).toBe(cfg['fraud.suspended_console_ip.base_score']);
+    expect(out[0]!.evidence.matchedIps).toEqual(['203.0.113.7']);
+  });
 });
 
 describe('fraud.dead_account_probe_origin', () => {
@@ -232,6 +274,29 @@ describe('fraud.dead_account_probe_origin', () => {
     const out = computeOriginIpSignals(
       [agg({ originIps: ['192.0.2.61'] })],
       corpus({ probes: [probe('192.0.2.72', hours * 60 + 1)] }),
+      cfg,
+      NOW,
+    );
+    expect(out).toEqual([]);
+  });
+
+  it('still fires for a probe exactly window_hours old (inclusive boundary)', () => {
+    // Pins the comparator to strict `>` — an accidental `>=` would silently
+    // shave the boundary and no other test would notice.
+    const hours = cfg['fraud.dead_account_probe_origin.window_hours'];
+    const out = computeOriginIpSignals(
+      [agg({ originIps: ['192.0.2.61'] })],
+      corpus({ probes: [probe('192.0.2.72', hours * 60)] }),
+      cfg,
+      NOW,
+    );
+    expect(keys(out)).toEqual([DEAD_ACCOUNT_PROBE_KEY]);
+  });
+
+  it('ignores a probe timestamped in the future (clock skew, not evidence)', () => {
+    const out = computeOriginIpSignals(
+      [agg({ originIps: ['192.0.2.61'] })],
+      corpus({ probes: [probe('192.0.2.72', -5)] }),
       cfg,
       NOW,
     );

--- a/apps/api/src/services/abuseSignals/originIp.ts
+++ b/apps/api/src/services/abuseSignals/originIp.ts
@@ -215,15 +215,21 @@ export function computeOriginIpSignals(
   const out: ComputedSignal[] = [];
   for (const partner of aggregates) {
     const matchedIps: string[] = [];
+    const seenMatchKeys = new Set<string>();
     const suspendedPartners: string[] = [];
     const seenSuspended = new Set<string>();
 
     for (const ip of partner.originIps) {
       const key = canonical(ip);
-      if (!key) continue;
+      if (!key || seenMatchKeys.has(key)) continue;
       const names = suspendedByCanonical.get(key);
       if (!names) continue;
-      matchedIps.push(ip.trim());
+      // Dedup on the canonical key and cite the bare client address: two
+      // surface forms of one address (compressed vs expanded IPv6, or two XFF
+      // chains) are one match, and the evidence line must be a clean IP an
+      // on-call analyst can grep infra records for.
+      seenMatchKeys.add(key);
+      matchedIps.push(clientIp(ip));
       for (const name of names) {
         if (seenSuspended.has(name)) continue;
         seenSuspended.add(name);
@@ -321,15 +327,21 @@ export async function loadOriginIpAggregates(): Promise<OriginIpResult> {
       -- 'pending' is in scope for the same reason billingIdentity includes it:
       -- a pre-positioned account never activates, so an active-only detector
       -- is blind to the entire shape this one exists to catch.
+      --
+      -- Deliberately NO age gate on this population, unlike heuristics.ts's
+      -- scoped CTE. There the 90-day cutoff mirrors the scorer's own age decay
+      -- (youngWeight() reaches zero at young_zero_weight_days), so excluding
+      -- old partners from the query matches what the scorer would do anyway.
+      -- THIS scorer has no age decay at all — a 120-day-old account that
+      -- starts working the console from a newly-suspended operator's address
+      -- must be scannable the first time that correlation exists, and an age
+      -- gate here would exclude exactly that partner (it cannot yet have an
+      -- open row from this detector to re-admit it). The cost of the wider
+      -- population is bounded elsewhere: the audit arm of scoped_ips is
+      -- timestamp-bounded to 90 days, so a dormant partner contributes only
+      -- its signup_ip row. Per the header rule, re-time against the larger
+      -- region before narrowing this again.
       WHERE p.deleted_at IS NULL AND p.status IN ('active', 'pending')
-        AND (
-          p.created_at > now() - interval '90 days'
-          OR EXISTS (
-            SELECT 1 FROM partner_abuse_signals pas
-            WHERE pas.partner_id = p.id AND pas.resolved_at IS NULL
-              AND pas.signal_key IN (${SUSPENDED_CONSOLE_IP_KEY}, ${DEAD_ACCOUNT_PROBE_KEY})
-          )
-        )
     ),
     -- No bound on how long ago the partner was SUSPENDED, on purpose: an
     -- operator who returns four months later is exactly who this is for. The
@@ -409,7 +421,12 @@ export async function loadOriginIpAggregates(): Promise<OriginIpResult> {
         };
         byPartner.set(row.partner_id, agg);
       }
-      if (!agg.originIps.includes(row.ip)) agg.originIps.push(row.ip);
+      // Normalize before dedup: the same client logged through two different
+      // legacy XFF second hops ("1.2.3.4, 10.0.0.1" vs "1.2.3.4, 10.0.0.5")
+      // must collapse to one origin, or the per_extra_ip bonus counts one real
+      // address twice and the evidence body shows garbled chain strings.
+      const ip = clientIp(row.ip);
+      if (ip && !agg.originIps.includes(ip)) agg.originIps.push(ip);
     } else if (row.kind === 'suspended') {
       const names = suspendedIps.get(row.ip);
       if (names) {


### PR DESCRIPTION
Follow-up to #4356 (merged before its post-review fixes landed). Four-agent review findings, all verified:

**Critical — origin-IP detector's 90-day scan gate contradicted its own design.** `loadOriginIpAggregates`'s `scoped` CTE only admitted partners younger than 90 days or already carrying an open row *from this same detector*. A 120-day-old dormant account that starts working the console from a newly-suspended operator's address — the exact pre-positioned shape the detector's header says it exists for — could never be scanned the first time the correlation appeared. The gate is dropped: unlike `heuristics.ts` (whose identical-looking gate mirrors its scorer's age decay to zero at 90 days), this scorer has no age decay, so the gate was a silent detection hole, not an optimization. Cost stays bounded by the 90-day timestamp bound on the audit arm; the CTE comment says to re-time against the larger region before narrowing again.

**Important — `rmm.recidivist_endpoint` missing from the corroboration axis map post-rebase.** It can emit at watch tier (hostname-only, 60 < 70) and was silently falling through to the own-axis default the module docs say must never happen undecided. Now explicitly mapped to its own `endpoint_identity` axis (endpoint-fingerprint evidence is independent of console-origin evidence — that pair corroborating is desired), added to the test's `EMITTED_KEYS` list, and the header comment no longer overclaims that the test discovers emitted keys on its own.

**Minor — matched-IP dedup/evidence used raw strings.** Two XFF spellings or compressed/expanded IPv6 forms of one client address counted twice toward `per_extra_ip` and surfaced garbled chain strings in alert evidence. Matching now dedupes on the canonical key and cites the bare client IP.

**Tests added** for the previously untested branches: inclusive `window_hours` boundary, future-probe clock-skew guard, IPv4-mapped IPv6 (`::ffff:`) expansion, compressed-vs-expanded exact IPv6 match, XFF-variant dedup. Suite: 11 files / 279 tests green.

One reviewer finding was rejected as a false positive: the `stage1.suspended_ip_match` comments reference the live signup gate, which is real but lives outside this repo's API code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012p7gDFgGMniE4CkVJV3ESj