### PR TITLE
test(api): stop asserting ephemeral-port inequality in llmEgressProxy restart test

### DIFF
--- a/apps/api/src/services/llm/llmEgressProxy.test.ts
+++ b/apps/api/src/services/llm/llmEgressProxy.test.ts
@@ -656,12 +656,18 @@ describe('getLlmEgressProxy', () => {
     const first = await getLlmEgressProxy();
     const second = await getLlmEgressProxy();
     expect(second).toBe(first);
-    const firstPort = first.port();
     await first.close();
 
     const third = await getLlmEgressProxy();
     expect(third).not.toBe(first);
-    expect(third.port()).not.toBe(firstPort);
+    // Deliberately not asserting the new port differs from the old one: the
+    // kernel may legally hand back the just-freed ephemeral port (flaked in CI
+    // when both listeners bound the same port). Prove the new listener is live
+    // instead — any CONNECT outcome means it accepted the connection.
+    expect(third.port()).toBeGreaterThan(0);
+    const out = await proxyConnect({ port: third.port(), token: null, target: `${PROVIDER_HOST}:443` });
+    if (out.kind === 'tunnel') out.socket.destroy();
+    expect(['tunnel', 'status']).toContain(out.kind);
     await third.close();
   });
 });


### PR DESCRIPTION
**Flake:** `getLlmEgressProxy > returns the same lazily-started instance and re-starts after close` asserted `third.port() !== firstPort`. The proxy binds `listen(0)`, and after `close()` the kernel may legally hand the just-freed ephemeral port back to the next listener — observed on Linux CI (both bound 34877), reddening the unrelated PR #4359. Local macOS allocates incrementally, so it never reproduces there.

**Fix:** drop the port-inequality assertion (it tests an OS property, not the module contract — instance identity is already proven by `expect(third).not.toBe(first)`) and replace it with a liveness probe: a CONNECT round-trip against the new listener via the file's existing `proxyConnect` helper.

Verified: 20/20 tests in the file pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZFVYRgU9MVdTA7m5gMMcU