### PR TITLE
feat(mobile): ticket push routing, notification prefs and Settings controls (#4336)

### DIFF
--- a/apps/docs/src/content/docs/features/mobile.mdx
+++ b/apps/docs/src/content/docs/features/mobile.mdx
@@ -143,6 +143,27 @@ The notification service exposes listeners for:
 - `addNotificationResponseReceivedListener` -- fires when the user taps a notification.
 - `getLastNotificationResponse` -- retrieves the notification that launched the app from a terminated state.
 
+### Ticket Notifications
+
+Technicians receive two categories of ticket push on iOS:
+
+| Category | Sent when | Governed by |
+|----------|-----------|-------------|
+| **Assigned to me** | A ticket is assigned to you by someone else (self-assignment never pushes) | `assignedEnabled` |
+| **SLA breach** | A ticket misses its response or resolution SLA | `slaScope` |
+
+Tapping either notification opens that ticket's detail screen, from a cold start as well as from the background.
+
+Notification bodies are lock-screen safe: they carry the ticket number and the customer organization only, never the ticket subject. The subject loads after you unlock and the app authenticates.
+
+**What the preferences do and do not suppress.** These settings govern **push delivery only**. Your in-app notification inbox and any configured email still record every assignment and breach, so turning pushes off never hides work from you -- it only stops your phone buzzing.
+
+Additional delivery rules:
+
+- **Quiet hours** configured on the device suppress ticket pushes outright; they are dropped, not deferred.
+- A **per-user burst cap** (20 pushes per 5 minutes) protects against bulk reassignment. Capped pushes are dropped; the in-app rows are still written.
+- `All tickets` fans out to at most 500 opted-in technicians per breach event.
+
 ### Notification Settings
 
 Users can configure notification preferences per mobile device through `PATCH /devices/:id/settings`:
@@ -153,7 +174,21 @@ Users can configure notification preferences per mobile device through `PATCH /d
 | `severities` | `string[]` | Filter notifications by severity: `critical`, `high`, `medium`, `low`, `info` |
 | `quietHours` | `object \| null` | Suppress notifications during specified hours with `start`, `end`, and optional `timezone` |
 
-The Settings screen in the app also provides local toggles for "Push Notifications" and "Critical Alerts Only" that are persisted via AsyncStorage.
+The Settings screen in the app shows a **Notifications** row that reports the real push-registration state for this phone, and links out to system Settings when the OS permission is the actual control. It is a status readout, not a toggle -- the app has no code path that could honour an in-app on/off for OS-presented pushes, and the earlier "Push Notifications" / "Critical Alerts Only" switches only wrote AsyncStorage keys that nothing consumed.
+
+Ticket push categories are a **per-user** preference (they follow you across every phone you sign in on), configured from **Settings** in the app or through the API:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/users/me/ticket-push-preferences` | Read the caller's ticket push preferences. Returns defaults when nothing has been saved |
+| PATCH | `/users/me/ticket-push-preferences` | Update one or both settings |
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `assignedEnabled` | `boolean` | `true` | Push when a ticket is assigned to you |
+| `slaScope` | `"off" \| "owned" \| "any"` | `"owned"` | `off` = no SLA pushes; `owned` = tickets assigned to you; `any` = every ticket in your MSP you have access to |
+
+Both endpoints act on the authenticated caller only -- there is no way to read or write another user's preferences, and a `userId` in the request body is rejected.
 
 ---
 

--- a/apps/docs/src/content/docs/features/notifications.mdx
+++ b/apps/docs/src/content/docs/features/notifications.mdx
@@ -341,7 +341,10 @@ Breeze also supports push notifications to registered mobile devices via Firebas
 Push notifications subscribe to the same `alert.triggered` event bus and run in parallel with the notification dispatcher. Delivery status is tracked in the `push_notifications` table with states: `pending`, `sent`, `stubbed`, `failed`.
 
 <Aside type="note">
-  APNS (iOS) push delivery is currently stubbed and not yet fully implemented. Android push via FCM is functional when `FIREBASE_SERVICE_ACCOUNT` is configured.
+  APNs (iOS) delivery is live: it powers approval requests and ticket push
+  categories. Android push via FCM is functional when `FIREBASE_SERVICE_ACCOUNT`
+  is configured; ticket push categories are iOS-only today — the server logs and
+  skips FCM tokens for them.
 </Aside>
 
 ---

--- a/apps/mobile/src/navigation/MainNavigator.tsx
+++ b/apps/mobile/src/navigation/MainNavigator.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { View } from 'react-native';
 import type { NavigatorScreenParams } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
@@ -16,6 +17,7 @@ import { TicketsScreen } from '../screens/tickets/TicketsScreen';
 import { TicketDetailScreen } from '../screens/tickets/TicketDetailScreen';
 import { TimesheetScreen } from '../screens/time/TimesheetScreen';
 import { TimeSuggestionsScreen } from '../screens/time/TimeSuggestionsScreen';
+import { flushPendingNavigation } from './navigationRef';
 import { HomeIcon, SystemsIcon, TicketsIcon, TimeIcon } from '../components/TabIcons';
 import { TimerBar } from '../components/TimerBar';
 import { palette, fontFamily } from '../theme';
@@ -166,6 +168,28 @@ function TabBarWithTimer(props: BottomTabBarProps) {
 }
 
 export function MainNavigator() {
+  // Second flush source for buffered ticket taps (#4336), and the one that
+  // matters most.
+  //
+  // NavigationContainer's `onReady` fires at most ONCE per container instance —
+  // react-navigation guards it with an `onReadyCalledRef` it never resets
+  // (@react-navigation/core BaseNavigationContainer) — while the container's
+  // readiness is defined as "a root navigator has registered a focus listener",
+  // i.e. THIS component being mounted. ApprovalGate renders ApprovalScreen
+  // instead of its children for the duration of an approval takeover, so
+  // readiness genuinely cycles true -> false -> true inside one session.
+  //
+  // A ticket tap taken while an approval is on screen therefore buffers, and
+  // `onReady` never fires again to release it. Flushing on mount here delivers
+  // it the moment the tab tree comes back, which is exactly the behaviour the
+  // spec asks for: the tap navigates underneath and is revealed when the
+  // decision clears. This runs after the navigator's own effects (React flushes
+  // child effects before parent effects), so the container is ready by now;
+  // flushPendingNavigation re-buffers rather than dropping if it somehow is not.
+  useEffect(() => {
+    flushPendingNavigation();
+  }, []);
+
   return (
     <Tab.Navigator
       tabBar={(props: BottomTabBarProps) => <TabBarWithTimer {...props} />}

--- a/apps/mobile/src/navigation/MainNavigator.tsx
+++ b/apps/mobile/src/navigation/MainNavigator.tsx
@@ -1,4 +1,5 @@
 import { View } from 'react-native';
+import type { NavigatorScreenParams } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import {
   BottomTabBar,
@@ -43,10 +44,16 @@ export type TimeStackParamList = {
   TimeSuggestions: { date?: string } | undefined;
 };
 
+/**
+ * `TicketsTab` carries nested params so push taps can address a screen inside
+ * the tickets stack directly (`navigateToTicket`, #4336). Declared rather than
+ * cast: a cast here would let a rename inside TicketsStackParamList compile
+ * fine and fail only on a real device.
+ */
 export type MainTabParamList = {
   HomeTab: undefined;
   SystemsTab: undefined;
-  TicketsTab: undefined;
+  TicketsTab: NavigatorScreenParams<TicketsStackParamList> | undefined;
   TimeTab: undefined;
 };
 

--- a/apps/mobile/src/navigation/PushTapRouter.tsx
+++ b/apps/mobile/src/navigation/PushTapRouter.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as Sentry from '@sentry/react-native';
 
 import { store, useAppDispatch } from '../store';
 import { fetchTickets } from '../store/ticketsSlice';
@@ -11,7 +12,7 @@ import {
   removeNotificationSubscription,
 } from '../services/notifications';
 import { navigateToTicket } from './navigationRef';
-import { LAST_HANDLED_RESPONSE_KEY, shouldReplayResponse } from './pushRouting';
+import { LAST_HANDLED_RESPONSE_KEY, shouldHandleTap, shouldReplayResponse } from './pushRouting';
 
 /**
  * W10 (#4336). Ticket-only push listeners.
@@ -45,6 +46,9 @@ export function PushTapRouter() {
       } catch (err) {
         console.warn('[PushTapRouter] could not persist last handled response', err);
       }
+      // Re-checked after the await: a sign-out (or any teardown) mid-write must
+      // not navigate a tree that has already been swapped out.
+      if (cancelled) return;
       navigateToTicket(ticketId);
     };
 
@@ -69,7 +73,11 @@ export function PushTapRouter() {
         if (!shouldReplayResponse(identifier, lastHandled.current)) return;
         await handleTap(identifier, parsed.ticketId);
       } catch (err) {
+        // Reported, not just logged: a failure here means the push that
+        // launched the app silently opened nothing, which is invisible to us
+        // and looks to the technician like the notification did not work.
         console.warn('[PushTapRouter] cold-start replay failed', err);
+        Sentry.captureException(err, { tags: { area: 'push-tap-cold-start' } });
       }
     })();
 
@@ -86,7 +94,11 @@ export function PushTapRouter() {
     const tapped = addNotificationResponseReceivedListener((response) => {
       const parsed = parseTicketNotification(response.notification);
       if (!parsed) return;
-      void handleTap(response.notification.request.identifier, parsed.ticketId);
+      const identifier = response.notification.request.identifier;
+      // expo also delivers the app-LAUNCHING response here, so without this the
+      // cold-start branch above and this listener both act on the same tap.
+      if (!shouldHandleTap(identifier, lastHandled.current)) return;
+      void handleTap(identifier, parsed.ticketId);
     });
 
     return () => {

--- a/apps/mobile/src/navigation/PushTapRouter.tsx
+++ b/apps/mobile/src/navigation/PushTapRouter.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useRef } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import { store, useAppDispatch } from '../store';
+import { fetchTickets } from '../store/ticketsSlice';
+import {
+  addNotificationReceivedListener,
+  addNotificationResponseReceivedListener,
+  getLastNotificationResponse,
+  parseTicketNotification,
+  removeNotificationSubscription,
+} from '../services/notifications';
+import { navigateToTicket } from './navigationRef';
+import { LAST_HANDLED_RESPONSE_KEY, shouldReplayResponse } from './pushRouting';
+
+/**
+ * W10 (#4336). Ticket-only push listeners.
+ *
+ * Sibling of {@link ApprovalGate}, never a child: `ApprovalGate` returns
+ * `<ApprovalScreen />` instead of its children while an approval is focused, so
+ * a nested router would unmount and tear down these subscriptions exactly when
+ * an approval is on screen — the one case the spec requires taps to survive (a
+ * ticket tap during an approval navigates underneath and is revealed when the
+ * decision clears). Expo subscriptions are independently removable, so a second
+ * type-filtered listener coexists with ApprovalGate's own.
+ *
+ * Renders nothing. All decisions live in `pushRouting.ts` /
+ * `services/notifications.ts` so they are unit-tested; this file is wiring.
+ */
+export function PushTapRouter() {
+  const dispatch = useAppDispatch();
+  /** Response identifier we have already navigated for, in this process. */
+  const lastHandled = useRef<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const handleTap = async (identifier: string, ticketId: string) => {
+      lastHandled.current = identifier;
+      try {
+        // Persisted so a relaunch does not replay the same launching tap. A
+        // storage failure only costs one redundant navigation, so it must not
+        // block the navigation itself.
+        await AsyncStorage.setItem(LAST_HANDLED_RESPONSE_KEY, identifier);
+      } catch (err) {
+        console.warn('[PushTapRouter] could not persist last handled response', err);
+      }
+      navigateToTicket(ticketId);
+    };
+
+    // Cold start: the response that launched the app is only available here,
+    // never through the tap listener. Identifier-guarded so a remount does not
+    // re-navigate (getLastNotificationResponseAsync returns the same response
+    // for the life of the process).
+    void (async () => {
+      try {
+        const stored = await AsyncStorage.getItem(LAST_HANDLED_RESPONSE_KEY);
+        if (cancelled) return;
+        // Do not clobber a live tap that landed while storage was being read.
+        if (lastHandled.current === null) lastHandled.current = stored;
+
+        const last = await getLastNotificationResponse();
+        if (cancelled || !last) return;
+
+        const parsed = parseTicketNotification(last.notification);
+        if (!parsed) return;
+
+        const identifier = last.notification.request.identifier;
+        if (!shouldReplayResponse(identifier, lastHandled.current)) return;
+        await handleTap(identifier, parsed.ticketId);
+      } catch (err) {
+        console.warn('[PushTapRouter] cold-start replay failed', err);
+      }
+    })();
+
+    const received = addNotificationReceivedListener((notification) => {
+      if (!parseTicketNotification(notification)) return;
+      // Foreground: the OS still presents the banner, so all this owes the
+      // technician is a list that already reflects the change when they look.
+      // Read the live filters rather than closing over them — the effect must
+      // not re-run (and tear down its subscriptions) on every filter change.
+      const { queue, assignee } = store.getState().tickets;
+      void dispatch(fetchTickets({ statusGroup: queue, assignee }));
+    });
+
+    const tapped = addNotificationResponseReceivedListener((response) => {
+      const parsed = parseTicketNotification(response.notification);
+      if (!parsed) return;
+      void handleTap(response.notification.request.identifier, parsed.ticketId);
+    });
+
+    return () => {
+      cancelled = true;
+      removeNotificationSubscription(received);
+      removeNotificationSubscription(tapped);
+    };
+  }, [dispatch]);
+
+  return null;
+}

--- a/apps/mobile/src/navigation/RootNavigator.tsx
+++ b/apps/mobile/src/navigation/RootNavigator.tsx
@@ -25,6 +25,8 @@ import { ensureApproverDevice } from '../services/approverDevice';
 import { AuthNavigator } from './AuthNavigator';
 import { MainNavigator } from './MainNavigator';
 import { ApprovalGate } from './ApprovalGate';
+import { PushTapRouter } from './PushTapRouter';
+import { flushPendingNavigation, navigationRef } from './navigationRef';
 import { OnboardingScreen } from '../screens/onboarding/OnboardingScreen';
 import { Spinner } from '../components/Spinner';
 import { palette } from '../theme';
@@ -300,14 +302,27 @@ export function RootNavigator() {
   }
 
   return (
-    <NavigationContainer theme={navigationTheme}>
+    <NavigationContainer theme={navigationTheme} ref={navigationRef} onReady={flushPendingNavigation}>
+      {/* Mandatory MFA enrollment outranks everything, ticket taps included:
+          PushTapRouter is not mounted in that branch, so a buffered tap waits
+          rather than navigating past the gate. */}
       {mfaEnrollmentRequired ? (
         <MfaEnrollmentRequiredScreen />
       ) : token ? (
         hasOnboarded ? (
-          <ApprovalGate>
-            <MainNavigator />
-          </ApprovalGate>
+          // PushTapRouter is a SIBLING of ApprovalGate, never a child (#4336).
+          // ApprovalGate renders <ApprovalScreen /> INSTEAD of its children
+          // while an approval is focused, so nesting the router would tear its
+          // notification subscriptions down for the whole approval lifecycle
+          // and silently stop routing ticket taps. It stays inside the
+          // authenticated + onboarded branch so a tap never navigates a
+          // signed-out container.
+          <>
+            <PushTapRouter />
+            <ApprovalGate>
+              <MainNavigator />
+            </ApprovalGate>
+          </>
         ) : (
           <OnboardingScreen onComplete={handleOnboardingComplete} />
         )

--- a/apps/mobile/src/navigation/navigationRef.test.ts
+++ b/apps/mobile/src/navigation/navigationRef.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// vi.hoisted: the mock factory below is hoisted above normal consts.
+const ref = vi.hoisted(() => ({ ready: false, navigate: vi.fn() }));
+vi.mock('@react-navigation/native', () => ({
+  createNavigationContainerRef: () => ({
+    isReady: () => ref.ready,
+    navigate: ref.navigate,
+  }),
+}));
+
+import { __resetPendingForTests, flushPendingNavigation, navigateToTicket } from './navigationRef';
+
+describe('navigateToTicket (#4336)', () => {
+  beforeEach(() => {
+    ref.ready = false;
+    ref.navigate.mockClear();
+    __resetPendingForTests();
+  });
+
+  it('navigates immediately when the container is ready', () => {
+    ref.ready = true;
+
+    navigateToTicket('t-1');
+
+    expect(ref.navigate).toHaveBeenCalledWith('TicketsTab', {
+      screen: 'TicketDetail',
+      params: { ticketId: 't-1' },
+    });
+  });
+
+  it('buffers before ready and flushes exactly once on onReady', () => {
+    // A cold-start tap resolves before NavigationContainer mounts. Navigating
+    // then is a silent no-op — react-navigation drops the call — so the tap
+    // that launched the app would open nothing.
+    navigateToTicket('t-1');
+    navigateToTicket('t-2'); // latest tap wins
+
+    expect(ref.navigate).not.toHaveBeenCalled();
+
+    ref.ready = true;
+    flushPendingNavigation();
+    flushPendingNavigation(); // onReady can fire again on a container remount
+
+    expect(ref.navigate).toHaveBeenCalledTimes(1);
+    expect(ref.navigate).toHaveBeenCalledWith('TicketsTab', {
+      screen: 'TicketDetail',
+      params: { ticketId: 't-2' },
+    });
+  });
+
+  it('flushing with nothing buffered is a no-op', () => {
+    ref.ready = true;
+
+    flushPendingNavigation();
+
+    expect(ref.navigate).not.toHaveBeenCalled();
+  });
+
+  it('re-buffers rather than dropping when the container is still not ready at flush time', () => {
+    // onReady is the only caller today, but a flush from anywhere else must not
+    // silently discard the pending tap.
+    navigateToTicket('t-3');
+
+    flushPendingNavigation(); // still not ready
+
+    expect(ref.navigate).not.toHaveBeenCalled();
+
+    ref.ready = true;
+    flushPendingNavigation();
+
+    expect(ref.navigate).toHaveBeenCalledTimes(1);
+    expect(ref.navigate).toHaveBeenCalledWith('TicketsTab', {
+      screen: 'TicketDetail',
+      params: { ticketId: 't-3' },
+    });
+  });
+});

--- a/apps/mobile/src/navigation/navigationRef.test.ts
+++ b/apps/mobile/src/navigation/navigationRef.test.ts
@@ -40,12 +40,38 @@ describe('navigateToTicket (#4336)', () => {
 
     ref.ready = true;
     flushPendingNavigation();
-    flushPendingNavigation(); // onReady can fire again on a container remount
+    flushPendingNavigation(); // more than one flush source; must not double-navigate
 
     expect(ref.navigate).toHaveBeenCalledTimes(1);
     expect(ref.navigate).toHaveBeenCalledWith('TicketsTab', {
       screen: 'TicketDetail',
       params: { ticketId: 't-2' },
+    });
+  });
+
+  it('delivers a tap buffered while the navigator was torn down and remounted', () => {
+    // The real scenario this exists for: ApprovalGate renders ApprovalScreen
+    // INSTEAD of MainNavigator, so the root navigator unmounts and isReady()
+    // goes true -> false -> true within one container lifetime. NavigationContainer's
+    // onReady fires at most ONCE per container (react-navigation guards it with
+    // an onReadyCalledRef it never resets), so the remount is flushed by
+    // MainNavigator's own mount effect instead. Without that second flush
+    // source, a ticket tap taken during an approval is stranded forever.
+    ref.ready = true;
+    flushPendingNavigation(); // container's one-and-only onReady, nothing buffered
+    expect(ref.navigate).not.toHaveBeenCalled();
+
+    ref.ready = false; // approval takeover unmounts MainNavigator
+    navigateToTicket('t-4'); // technician taps a ticket push underneath it
+    expect(ref.navigate).not.toHaveBeenCalled();
+
+    ref.ready = true; // approval decided, MainNavigator remounts
+    flushPendingNavigation(); // from MainNavigator's mount effect
+
+    expect(ref.navigate).toHaveBeenCalledTimes(1);
+    expect(ref.navigate).toHaveBeenCalledWith('TicketsTab', {
+      screen: 'TicketDetail',
+      params: { ticketId: 't-4' },
     });
   });
 

--- a/apps/mobile/src/navigation/navigationRef.ts
+++ b/apps/mobile/src/navigation/navigationRef.ts
@@ -1,0 +1,48 @@
+import { createNavigationContainerRef } from '@react-navigation/native';
+
+import type { MainTabParamList } from './MainNavigator';
+
+/**
+ * W10 (#4336). Module-level navigation ref so non-screen code (PushTapRouter)
+ * can navigate.
+ *
+ * No `linking` config is wired: nothing produces Breeze URLs, and a deep-link
+ * config would be a second, untested route table to keep in step with this one.
+ */
+export const navigationRef = createNavigationContainerRef<MainTabParamList>();
+
+/**
+ * The latest ticket a tap asked for while the container was not yet mounted.
+ *
+ * Exactly one slot, not a queue: a technician who taps two pushes during a cold
+ * start wants the last one they touched, and replaying both would flash a
+ * ticket they already moved past.
+ */
+let pendingTicketId: string | null = null;
+
+export function navigateToTicket(ticketId: string): void {
+  // react-navigation silently DROPS navigate() calls before the container is
+  // ready, so a cold-start tap would open nothing at all. Buffer instead.
+  if (!navigationRef.isReady()) {
+    pendingTicketId = ticketId;
+    return;
+  }
+  navigationRef.navigate('TicketsTab', {
+    screen: 'TicketDetail',
+    params: { ticketId },
+  });
+}
+
+/** Call from `NavigationContainer`'s `onReady`. Safe to call repeatedly. */
+export function flushPendingNavigation(): void {
+  if (!pendingTicketId) return;
+  const ticketId = pendingTicketId;
+  pendingTicketId = null;
+  // Re-buffers itself if the container somehow still is not ready, so an early
+  // flush cannot swallow the tap.
+  navigateToTicket(ticketId);
+}
+
+export function __resetPendingForTests(): void {
+  pendingTicketId = null;
+}

--- a/apps/mobile/src/navigation/pushRouting.test.ts
+++ b/apps/mobile/src/navigation/pushRouting.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// pushRouting imports the parser out of services/notifications, which pulls
+// expo-notifications (and friends) in at module top. Same factory block as
+// services/notifications.test.ts so nothing drags the React Native runtime into
+// the node-only vitest environment.
+vi.mock('react-native', () => ({ Platform: { OS: 'ios' } }));
+vi.mock('expo-device', () => ({ isDevice: true }));
+vi.mock('expo-constants', () => ({ default: { expoConfig: { extra: {} } } }));
+vi.mock('expo-notifications', () => ({
+  setNotificationHandler: vi.fn(),
+  getPermissionsAsync: vi.fn(),
+  requestPermissionsAsync: vi.fn(),
+  getDevicePushTokenAsync: vi.fn(),
+  getExpoPushTokenAsync: vi.fn(),
+  setNotificationChannelAsync: vi.fn(),
+  getPresentedNotificationsAsync: vi.fn(),
+  dismissNotificationAsync: vi.fn(),
+  setBadgeCountAsync: vi.fn(),
+  AndroidImportance: { MAX: 5, HIGH: 4 },
+}));
+vi.mock('../services/api', () => ({ registerPushToken: vi.fn() }));
+
+import { resolvePushRoute, shouldReplayResponse } from './pushRouting';
+
+describe('resolvePushRoute (#4336)', () => {
+  it('routes ticket data to TicketDetail', () => {
+    expect(resolvePushRoute({ type: 'ticket', ticketId: 't-1', reason: 'assigned' })).toEqual({
+      kind: 'ticket',
+      ticketId: 't-1',
+    });
+    expect(
+      resolvePushRoute({ type: 'ticket', ticketId: 't-2', reason: 'sla_breached', target: 'resolution' })
+    ).toEqual({ kind: 'ticket', ticketId: 't-2' });
+  });
+
+  it('ignores approvals, alerts, time suggestions and garbage', () => {
+    // ApprovalGate owns approval pushes; routing them here would navigate
+    // underneath the approval takeover for no reason.
+    expect(resolvePushRoute({ type: 'approval', approvalId: 'a' })).toBeNull();
+    expect(resolvePushRoute({ alertId: 'x', eventType: 'alert.triggered' })).toBeNull();
+    expect(resolvePushRoute({ type: 'time_suggestions', date: '2026-08-29' })).toBeNull();
+    expect(resolvePushRoute({ type: 'ticket', ticketId: '', reason: 'assigned' })).toBeNull();
+    expect(resolvePushRoute(null)).toBeNull();
+    expect(resolvePushRoute(undefined)).toBeNull();
+  });
+});
+
+describe('shouldReplayResponse (#4336)', () => {
+  it('replays a never-seen identifier once', () => {
+    expect(shouldReplayResponse('r-1', null)).toBe(true);
+    expect(shouldReplayResponse('r-1', 'r-1')).toBe(false);
+    expect(shouldReplayResponse('r-2', 'r-1')).toBe(true);
+  });
+
+  it('never replays without an identifier', () => {
+    // getLastNotificationResponseAsync keeps returning the SAME response on
+    // every mount, so a missing identifier means we cannot tell a fresh cold
+    // start from a remount — navigating on every remount is the worse failure.
+    expect(shouldReplayResponse(undefined, null)).toBe(false);
+    expect(shouldReplayResponse(null, null)).toBe(false);
+    expect(shouldReplayResponse('', 'r-1')).toBe(false);
+  });
+});

--- a/apps/mobile/src/navigation/pushRouting.test.ts
+++ b/apps/mobile/src/navigation/pushRouting.test.ts
@@ -21,7 +21,7 @@ vi.mock('expo-notifications', () => ({
 }));
 vi.mock('../services/api', () => ({ registerPushToken: vi.fn() }));
 
-import { resolvePushRoute, shouldReplayResponse } from './pushRouting';
+import { resolvePushRoute, shouldHandleTap, shouldReplayResponse } from './pushRouting';
 
 describe('resolvePushRoute (#4336)', () => {
   it('routes ticket data to TicketDetail', () => {
@@ -60,5 +60,27 @@ describe('shouldReplayResponse (#4336)', () => {
     expect(shouldReplayResponse(undefined, null)).toBe(false);
     expect(shouldReplayResponse(null, null)).toBe(false);
     expect(shouldReplayResponse('', 'r-1')).toBe(false);
+  });
+});
+
+describe('shouldHandleTap (#4336)', () => {
+  it('skips a tap for the identifier we already acted on', () => {
+    // expo delivers the app-LAUNCHING response to the response listener as well
+    // as through getLastNotificationResponseAsync, so without this the cold
+    // start handles the same tap twice.
+    expect(shouldHandleTap('r-1', 'r-1')).toBe(false);
+  });
+
+  it('handles a genuinely new tap', () => {
+    expect(shouldHandleTap('r-2', 'r-1')).toBe(true);
+    expect(shouldHandleTap('r-1', null)).toBe(true);
+  });
+
+  it('handles an identifier-less tap rather than dropping it', () => {
+    // Opposite default to shouldReplayResponse, deliberately: a live tap is a
+    // real user action, so failing to dedupe it must not mean discarding it.
+    // The worst case is one redundant navigation to a screen they asked for.
+    expect(shouldHandleTap(undefined, 'r-1')).toBe(true);
+    expect(shouldHandleTap('', 'r-1')).toBe(true);
   });
 });

--- a/apps/mobile/src/navigation/pushRouting.ts
+++ b/apps/mobile/src/navigation/pushRouting.ts
@@ -1,0 +1,37 @@
+import { parseTicketData } from '../services/notifications';
+
+/**
+ * W10 (#4336). Where a push tap should land, decided without touching
+ * navigation state — so the decision is unit-testable and the component that
+ * performs it stays a thin listener.
+ *
+ * Only ticket pushes route here. Approval pushes are owned by `ApprovalGate`
+ * (it focuses the approval and takes the screen over) and alert pushes have no
+ * tap handler yet; both must resolve to `null` rather than being routed twice.
+ */
+export type PushRoute = { kind: 'ticket'; ticketId: string } | null;
+
+/** AsyncStorage key holding the last notification response we already acted on. */
+export const LAST_HANDLED_RESPONSE_KEY = 'notif:lastHandledResponseId';
+
+export function resolvePushRoute(data: Record<string, unknown> | null | undefined): PushRoute {
+  const ticket = parseTicketData(data);
+  return ticket ? { kind: 'ticket', ticketId: ticket.ticketId } : null;
+}
+
+/**
+ * Cold-start replay guard.
+ *
+ * `getLastNotificationResponseAsync()` returns the SAME response on every
+ * mount for the whole process lifetime — it is "what launched the app", not "a
+ * new tap". Replaying it unguarded yanks the technician back to a ticket every
+ * time the navigator remounts. The response identifier is the only stable
+ * discriminator, so no identifier means no replay.
+ */
+export function shouldReplayResponse(
+  identifier: string | null | undefined,
+  lastHandled: string | null
+): boolean {
+  if (!identifier) return false;
+  return identifier !== lastHandled;
+}

--- a/apps/mobile/src/navigation/pushRouting.ts
+++ b/apps/mobile/src/navigation/pushRouting.ts
@@ -35,3 +35,23 @@ export function shouldReplayResponse(
   if (!identifier) return false;
   return identifier !== lastHandled;
 }
+
+/**
+ * Live-tap guard.
+ *
+ * expo delivers the response that LAUNCHED the app to the response listener as
+ * well as through `getLastNotificationResponseAsync()`, so a cold-start tap
+ * arrives down both paths and would otherwise be handled twice.
+ *
+ * The default is the opposite of {@link shouldReplayResponse} on purpose: a
+ * live tap is a real user action, so being unable to dedupe it (no identifier)
+ * must not mean discarding it. The worst case is one redundant navigation to a
+ * screen the technician just asked for.
+ */
+export function shouldHandleTap(
+  identifier: string | null | undefined,
+  lastHandled: string | null
+): boolean {
+  if (!identifier) return true;
+  return identifier !== lastHandled;
+}

--- a/apps/mobile/src/screens/chat/components/SettingsSheet.tsx
+++ b/apps/mobile/src/screens/chat/components/SettingsSheet.tsx
@@ -25,6 +25,7 @@ import {
   saveTicketPushPrefs,
   selectTicketPushPrefs,
   selectTicketPushPrefsError,
+  selectTicketPushPrefsErrorKind,
   selectTicketPushPrefsSaving,
   useAppDispatch,
   useAppSelector,
@@ -98,6 +99,7 @@ export function SettingsSheet({ visible, onCancel }: Props) {
   const pushRegistration = useAppSelector((s) => s.auth.pushRegistration);
   const pushRegistrationReason = useAppSelector((s) => s.auth.pushRegistrationReason);
   const prefsError = useAppSelector(selectTicketPushPrefsError);
+  const prefsErrorKind = useAppSelector(selectTicketPushPrefsErrorKind);
 
   const screenWidth = Dimensions.get('window').width;
   const sheetWidth = Math.min(screenWidth * 0.84, 420);
@@ -138,11 +140,19 @@ export function SettingsSheet({ visible, onCancel }: Props) {
 
   // A failed preference save has already been rolled back in the slice; without
   // this the value would just silently snap back and look like a missed tap.
+  // The two failures are worded apart on purpose — a load failure happens on
+  // sheet open, when the technician has not saved anything.
   useEffect(() => {
     if (!prefsError) return;
-    setToast({ kind: 'error', text: 'Could not save notification settings.' });
+    setToast({
+      kind: 'error',
+      text:
+        prefsErrorKind === 'load'
+          ? 'Could not load notification settings.'
+          : 'Could not save notification settings.',
+    });
     dispatch(clearNotificationPrefsError());
-  }, [prefsError, dispatch]);
+  }, [prefsError, prefsErrorKind, dispatch]);
 
   function onRevokeDevice(device: PairedMobileDevice) {
     if (device.isCurrent) {

--- a/apps/mobile/src/screens/chat/components/SettingsSheet.tsx
+++ b/apps/mobile/src/screens/chat/components/SettingsSheet.tsx
@@ -19,7 +19,16 @@ import Animated, {
 import Constants from 'expo-constants';
 
 import { useApprovalTheme, palette, radii, spacing, type } from '../../../theme';
-import { useAppDispatch, useAppSelector } from '../../../store';
+import {
+  clearNotificationPrefsError,
+  loadTicketPushPrefs,
+  saveTicketPushPrefs,
+  selectTicketPushPrefs,
+  selectTicketPushPrefsError,
+  selectTicketPushPrefsSaving,
+  useAppDispatch,
+  useAppSelector,
+} from '../../../store';
 import { logoutAsync } from '../../../store/authSlice';
 import {
   blockPairedDevice,
@@ -31,14 +40,6 @@ import {
   selectConnectedApps,
   selectPairedDevices,
 } from '../../../store/lifecycleSlice';
-import {
-  clearError as clearNotificationPrefsError,
-  loadTicketPushPrefs,
-  saveTicketPushPrefs,
-  selectTicketPushPrefs,
-  selectTicketPushPrefsError,
-  selectTicketPushPrefsSaving,
-} from '../../../store/notificationPrefsSlice';
 import {
   checkBiometricAvailability,
   isBiometricEnabled,

--- a/apps/mobile/src/screens/chat/components/SettingsSheet.tsx
+++ b/apps/mobile/src/screens/chat/components/SettingsSheet.tsx
@@ -32,6 +32,14 @@ import {
   selectPairedDevices,
 } from '../../../store/lifecycleSlice';
 import {
+  clearError as clearNotificationPrefsError,
+  loadTicketPushPrefs,
+  saveTicketPushPrefs,
+  selectTicketPushPrefs,
+  selectTicketPushPrefsError,
+  selectTicketPushPrefsSaving,
+} from '../../../store/notificationPrefsSlice';
+import {
   checkBiometricAvailability,
   isBiometricEnabled,
   setBiometricEnabled,
@@ -41,6 +49,7 @@ import { getAccountDeletionUrl } from '../../../services/serverConfig';
 import { ease, duration } from '../../../lib/motion';
 import { track } from '../../../lib/analytics';
 import { relativeTime } from '../../../lib/relativeTime';
+import { useNetworkConnected } from '../../../lib/useNetworkConnected';
 import { Toast } from '../../../components/Toast';
 import { notificationsRowCopy, type NotificationsRowCopy } from './pushUnavailableCopy';
 import { Avatar } from './Avatar';
@@ -87,6 +96,7 @@ export function SettingsSheet({ visible, onCancel }: Props) {
   // to system Settings when that's the real control.
   const pushRegistration = useAppSelector((s) => s.auth.pushRegistration);
   const pushRegistrationReason = useAppSelector((s) => s.auth.pushRegistrationReason);
+  const prefsError = useAppSelector(selectTicketPushPrefsError);
 
   const screenWidth = Dimensions.get('window').width;
   const sheetWidth = Math.min(screenWidth * 0.84, 420);
@@ -118,7 +128,20 @@ export function SettingsSheet({ visible, onCancel }: Props) {
     // semantics — the sheet is the entry point).
     void dispatch(fetchPairedDevices());
     void dispatch(fetchConnectedApps());
-  }, [visible, sheetWidth, dispatch]);
+
+    // Ticket push preferences are per USER, so another phone (or the API) can
+    // have changed them since this sheet last opened. Only worth loading when
+    // push actually registered — the controls are hidden otherwise (#4336).
+    if (pushRegistration === 'ok') void dispatch(loadTicketPushPrefs());
+  }, [visible, sheetWidth, dispatch, pushRegistration]);
+
+  // A failed preference save has already been rolled back in the slice; without
+  // this the value would just silently snap back and look like a missed tap.
+  useEffect(() => {
+    if (!prefsError) return;
+    setToast({ kind: 'error', text: 'Could not save notification settings.' });
+    dispatch(clearNotificationPrefsError());
+  }, [prefsError, dispatch]);
 
   function onRevokeDevice(device: PairedMobileDevice) {
     if (device.isCurrent) {
@@ -284,6 +307,7 @@ export function SettingsSheet({ visible, onCancel }: Props) {
             biometricAvailable={biometricAvailable}
             biometricOn={biometricOn}
             pushCopy={notificationsRowCopy(pushRegistration, pushRegistrationReason)}
+            pushRegistered={pushRegistration === 'ok'}
             buildVersion={buildVersion}
             pairedDevices={pairedDevices}
             connectedApps={connectedApps}
@@ -328,6 +352,7 @@ function SheetBody({
   biometricAvailable,
   biometricOn,
   pushCopy,
+  pushRegistered,
   buildVersion,
   pairedDevices,
   connectedApps,
@@ -350,6 +375,7 @@ function SheetBody({
   biometricAvailable: boolean;
   biometricOn: boolean;
   pushCopy: NotificationsRowCopy;
+  pushRegistered: boolean;
   buildVersion: string;
   pairedDevices: PairedMobileDevice[];
   connectedApps: ConnectedApp[];
@@ -415,6 +441,10 @@ function SheetBody({
           onPress={onPressNotificationSettings}
           theme={theme}
         />
+
+        {/* Only meaningful once a push token exists — otherwise the server has
+            nowhere to send what these settings govern (#4336). */}
+        {pushRegistered ? <TicketPushPreferenceRows theme={theme} /> : null}
 
         <SectionDivider color={theme.border} />
 
@@ -694,12 +724,14 @@ function ToggleRow({
   description,
   value,
   onChange,
+  disabled,
   theme,
 }: {
   label: string;
   description?: string;
   value: boolean;
   onChange: (v: boolean) => void;
+  disabled?: boolean;
   theme: ReturnType<typeof useApprovalTheme>;
 }) {
   return (
@@ -709,6 +741,7 @@ function ToggleRow({
         paddingVertical: spacing[3],
         flexDirection: 'row',
         alignItems: 'center',
+        opacity: disabled ? 0.5 : 1,
       }}
     >
       <View style={{ flex: 1, marginRight: spacing[3] }}>
@@ -722,9 +755,141 @@ function ToggleRow({
       <Switch
         value={value}
         onValueChange={onChange}
+        disabled={disabled}
         trackColor={{ false: theme.bg3, true: palette.brand.deep }}
         thumbColor={value ? palette.brand.base : theme.textMd}
       />
+    </View>
+  );
+}
+
+/**
+ * W10 (#4336). The two ticket push categories.
+ *
+ * Reads the slice itself rather than taking six more props through SheetBody —
+ * it is already at twenty, and none of these values are of any use to the rest
+ * of the sheet.
+ */
+function TicketPushPreferenceRows({ theme }: { theme: ReturnType<typeof useApprovalTheme> }) {
+  const dispatch = useAppDispatch();
+  const connected = useNetworkConnected();
+  const prefs = useAppSelector(selectTicketPushPrefs);
+  const saving = useAppSelector(selectTicketPushPrefsSaving);
+
+  // No offline write queue for preferences: a setting saved into a queue would
+  // sit there silently disagreeing with what the server is using to decide what
+  // to push. Disabled-with-a-reason is the honest state.
+  const disabled = !connected || saving;
+
+  return (
+    <>
+      <ToggleRow
+        label="Assigned to me"
+        description={
+          connected
+            ? 'Push when a ticket is assigned to you'
+            : 'Offline — reconnect to change'
+        }
+        value={prefs.assignedEnabled}
+        onChange={(next) => {
+          void dispatch(saveTicketPushPrefs({ assignedEnabled: next }));
+        }}
+        disabled={disabled}
+        theme={theme}
+      />
+      <SegmentedRow
+        label="SLA breaches"
+        // These controls govern PUSH ONLY. "Off" must not read as "hide it
+        // entirely" — the in-app inbox row and the email are still written on
+        // every breach, and the worker implements exactly that. A toggle that
+        // quietly means more than it says is how support tickets get filed
+        // against the notification system.
+        description={
+          connected
+            ? 'Push when a ticket misses its response or resolution SLA. Your in-app inbox still records every breach.'
+            : 'Offline — reconnect to change'
+        }
+        value={prefs.slaScope}
+        options={[
+          { value: 'off', label: 'Off' },
+          { value: 'owned', label: 'My tickets' },
+          { value: 'any', label: 'All tickets' },
+        ]}
+        onChange={(scope) => {
+          if (scope === prefs.slaScope) return;
+          void dispatch(saveTicketPushPrefs({ slaScope: scope }));
+        }}
+        disabled={disabled}
+        theme={theme}
+      />
+    </>
+  );
+}
+
+function SegmentedRow<T extends string>({
+  label,
+  description,
+  value,
+  options,
+  onChange,
+  disabled,
+  theme,
+}: {
+  label: string;
+  description?: string;
+  value: T;
+  options: { value: T; label: string }[];
+  onChange: (v: T) => void;
+  disabled?: boolean;
+  theme: ReturnType<typeof useApprovalTheme>;
+}) {
+  return (
+    <View
+      style={{
+        paddingHorizontal: spacing[6],
+        paddingVertical: spacing[3],
+        opacity: disabled ? 0.5 : 1,
+      }}
+    >
+      <Text style={[type.bodyMd, { color: theme.textHi }]}>{label}</Text>
+      {description ? (
+        <Text style={[type.meta, { color: theme.textMd, marginTop: spacing[1] }]}>
+          {description}
+        </Text>
+      ) : null}
+      <View
+        style={{
+          flexDirection: 'row',
+          marginTop: spacing[2],
+          borderRadius: radii.md,
+          backgroundColor: theme.bg3,
+          padding: 2,
+        }}
+      >
+        {options.map((option) => {
+          const selected = option.value === value;
+          return (
+            <Pressable
+              key={option.value}
+              accessibilityRole="button"
+              accessibilityState={{ selected, disabled: !!disabled }}
+              disabled={disabled}
+              onPress={() => onChange(option.value)}
+              style={{
+                flex: 1,
+                paddingVertical: spacing[2],
+                alignItems: 'center',
+                borderRadius: radii.sm,
+                backgroundColor: selected ? palette.brand.deep : 'transparent',
+              }}
+            >
+              <Text style={[type.meta, { color: selected ? palette.brand.base : theme.textMd }]}>
+                {option.label}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
     </View>
   );
 }

--- a/apps/mobile/src/services/notifications.test.ts
+++ b/apps/mobile/src/services/notifications.test.ts
@@ -41,7 +41,10 @@ import {
   reconcilePushRegistration,
   staleApprovalNotificationIds,
   parseApprovalNotification,
+  parseTicketData,
+  parseTicketNotification,
   parseTimeSuggestionsNotification,
+  shouldSetBadgeFor,
 } from './notifications';
 import {
   notificationsRowCopy,
@@ -329,5 +332,108 @@ describe('parseTimeSuggestionsNotification (#3900)', () => {
   it('parseApprovalNotification still works on the approval payload (no regression)', () => {
     expect(parseApprovalNotification(pushWith({ type: 'approval', approvalId: 'a1' }))).toEqual({ approvalId: 'a1' });
     expect(parseApprovalNotification(pushWith({ type: 'time_suggestions', date: '2026-08-29' }))).toBeNull();
+  });
+});
+
+// ── W10 (#4336): the ticket push parser ────────────────────────────────────
+// Wire contract is `buildTicketPush` in apps/api/src/services/expoPush.ts,
+// shipped in the API half (PR #4281): `{ type: 'ticket', ticketId, reason,
+// target?, internalNumber? }`.
+describe('parseTicketData (#4336)', () => {
+  it('parses assigned and sla_breached payloads', () => {
+    expect(parseTicketData({ type: 'ticket', ticketId: 't-1', reason: 'assigned' })).toEqual({
+      ticketId: 't-1',
+      reason: 'assigned',
+    });
+    expect(
+      parseTicketData({ type: 'ticket', ticketId: 't-1', reason: 'sla_breached', target: 'response' })
+    ).toEqual({ ticketId: 't-1', reason: 'sla_breached', target: 'response' });
+    expect(
+      parseTicketData({ type: 'ticket', ticketId: 't-1', reason: 'sla_breached', target: 'resolution' })
+    ).toEqual({ ticketId: 't-1', reason: 'sla_breached', target: 'resolution' });
+  });
+
+  it('ignores the server-side presentation extras it does not route on', () => {
+    // buildTicketPush also ships `internalNumber` for the lock-screen body.
+    // Routing must not depend on it, and its presence must not defeat the parse.
+    expect(
+      parseTicketData({ type: 'ticket', ticketId: 't-1', reason: 'assigned', internalNumber: 'T-42' })
+    ).toEqual({ ticketId: 't-1', reason: 'assigned' });
+  });
+
+  it('returns null for malformed or non-ticket data', () => {
+    expect(parseTicketData(null)).toBeNull();
+    expect(parseTicketData(undefined)).toBeNull();
+    expect(parseTicketData({ type: 'approval', approvalId: 'a' })).toBeNull();
+    expect(parseTicketData({ alertId: 'x', eventType: 'alert.triggered' })).toBeNull();
+    expect(parseTicketData({ type: 'ticket' })).toBeNull();
+    expect(parseTicketData({ type: 'ticket', ticketId: '', reason: 'assigned' })).toBeNull();
+    expect(parseTicketData({ type: 'ticket', ticketId: 42, reason: 'assigned' })).toBeNull();
+    expect(parseTicketData({ type: 'ticket', ticketId: 't-1', reason: 'bogus' })).toBeNull();
+  });
+
+  it('drops an unknown target but keeps the notification', () => {
+    // A target the phone does not understand is cosmetic; dropping the whole
+    // push would strand the technician on a breach they were told about.
+    expect(
+      parseTicketData({ type: 'ticket', ticketId: 't-1', reason: 'sla_breached', target: 'x' })
+    ).toEqual({ ticketId: 't-1', reason: 'sla_breached' });
+  });
+
+  it('parseTicketNotification reads the data bag off a notification', () => {
+    expect(parseTicketNotification(pushWith({ type: 'ticket', ticketId: 't-9', reason: 'assigned' }))).toEqual(
+      { ticketId: 't-9', reason: 'assigned' }
+    );
+    expect(parseTicketNotification({ request: { identifier: 'n1', content: {} } } as never)).toBeNull();
+  });
+
+  it('the other parsers still reject ticket payloads (no cross-talk)', () => {
+    expect(parseApprovalNotification(pushWith({ type: 'ticket', ticketId: 't-1', reason: 'assigned' }))).toBeNull();
+    expect(
+      parseTimeSuggestionsNotification(pushWith({ type: 'ticket', ticketId: 't-1', reason: 'assigned' }))
+    ).toBeNull();
+  });
+});
+
+describe('shouldSetBadgeFor (#4336)', () => {
+  it('is false for ticket pushes and true otherwise (badge stays owned by approvals)', () => {
+    // reconcileApprovalNotifications SETS the badge to the pending-approval
+    // count. A ticket push that incremented it would be overwritten on the next
+    // reconcile anyway — but until then it reads as a phantom approval.
+    expect(shouldSetBadgeFor({ type: 'ticket', ticketId: 't-1', reason: 'assigned' })).toBe(false);
+    expect(shouldSetBadgeFor({ type: 'approval', approvalId: 'a' })).toBe(true);
+    expect(shouldSetBadgeFor({ alertId: 'x', eventType: 'alert.triggered' })).toBe(true);
+    expect(shouldSetBadgeFor(undefined)).toBe(true);
+    expect(shouldSetBadgeFor(null)).toBe(true);
+  });
+
+  it('the registered foreground handler actually consults it', async () => {
+    // Asserting the pure function alone would stay green if the handler kept
+    // its hard-coded `shouldSetBadge: true`.
+    const config = notif.setNotificationHandler.mock.calls[0]?.[0] as {
+      handleNotification: (n: unknown) => Promise<{ shouldSetBadge: boolean }>;
+    };
+    expect(config).toBeDefined();
+
+    await expect(
+      config.handleNotification(pushWith({ type: 'ticket', ticketId: 't-1', reason: 'assigned' }))
+    ).resolves.toMatchObject({ shouldSetBadge: false, shouldShowBanner: true });
+    await expect(
+      config.handleNotification(pushWith({ type: 'approval', approvalId: 'a' }))
+    ).resolves.toMatchObject({ shouldSetBadge: true });
+  });
+});
+
+describe('the tickets Android channel (#4336)', () => {
+  it('is registered alongside alerts and approvals', async () => {
+    platform.OS = 'android';
+    constants.expoConfig = { extra: { eas: { projectId: 'proj-1' } } };
+
+    await registerForPushNotifications();
+
+    expect(notif.setNotificationChannelAsync).toHaveBeenCalledWith(
+      'tickets',
+      expect.objectContaining({ name: 'Tickets' })
+    );
   });
 });

--- a/apps/mobile/src/services/notifications.ts
+++ b/apps/mobile/src/services/notifications.ts
@@ -9,11 +9,13 @@ import { registerPushToken as apiRegisterPushToken } from './api';
 // Configure how notifications are handled when the app is in the foreground.
 // SDK 55: shouldShowAlert is deprecated; use shouldShowBanner + shouldShowList.
 Notifications.setNotificationHandler({
-  handleNotification: async () => ({
+  handleNotification: async (notification) => ({
     shouldShowBanner: true,
     shouldShowList: true,
     shouldPlaySound: true,
-    shouldSetBadge: true,
+    shouldSetBadge: shouldSetBadgeFor(
+      notification.request.content.data as Record<string, unknown> | undefined
+    ),
   }),
 });
 
@@ -102,6 +104,18 @@ export async function registerForPushNotifications(): Promise<PushRegistrationOu
         name: 'Approvals',
         importance: Notifications.AndroidImportance.MAX,
         vibrationPattern: [0, 200, 100, 200],
+        lightColor: '#1c8a9e',
+        sound: 'default',
+      });
+
+      // W10 (#4336). Inert on today's builds — Android push is not wired at all
+      // (see the projectId branch above) and the server skips FCM tokens for
+      // ticket pushes. Registered now so the channel exists the moment either
+      // side lands, rather than ticket pushes arriving on 'default'.
+      await Notifications.setNotificationChannelAsync('tickets', {
+        name: 'Tickets',
+        importance: Notifications.AndroidImportance.HIGH,
+        vibrationPattern: [0, 200],
         lightColor: '#1c8a9e',
         sound: 'default',
       });
@@ -285,6 +299,61 @@ export function parseApprovalNotification(
     return { approvalId: data.approvalId };
   }
   return null;
+}
+
+/**
+ * W10 (#4336). What a ticket push carries once it has been validated.
+ *
+ * Deliberately narrower than the wire payload: the server also sends
+ * `internalNumber` for the lock-screen body, which nothing on this side routes
+ * on. Keeping the parsed shape to the routing-relevant fields means a change to
+ * the presentation extras cannot break tap handling.
+ */
+export interface TicketPushData {
+  ticketId: string;
+  reason: 'assigned' | 'sla_breached';
+  target?: 'response' | 'resolution';
+}
+
+/**
+ * Pure parser over the notification `data` map.
+ *
+ * Wire contract: `buildTicketPush` in `apps/api/src/services/expoPush.ts`
+ * (shipped in the API half of W07, PR #4281) emits
+ * `{ type: 'ticket', ticketId, reason, target?, internalNumber? }`.
+ *
+ * An unrecognised `target` is dropped rather than rejecting the push: the
+ * target is a label, and refusing the whole notification would strand the
+ * technician on a breach the server already decided to tell them about. A bad
+ * `ticketId` or `reason` IS fatal — both feed navigation.
+ */
+export function parseTicketData(
+  data: Record<string, unknown> | null | undefined
+): TicketPushData | null {
+  if (!data || data.type !== 'ticket') return null;
+  if (typeof data.ticketId !== 'string' || data.ticketId.length === 0) return null;
+  if (data.reason !== 'assigned' && data.reason !== 'sla_breached') return null;
+  const parsed: TicketPushData = { ticketId: data.ticketId, reason: data.reason };
+  if (data.target === 'response' || data.target === 'resolution') parsed.target = data.target;
+  return parsed;
+}
+
+export function parseTicketNotification(
+  notification: Notifications.Notification | Notifications.NotificationResponse['notification']
+): TicketPushData | null {
+  return parseTicketData(notification.request.content.data as Record<string, unknown> | undefined);
+}
+
+/**
+ * Ticket pushes never touch the app badge.
+ *
+ * `reconcileApprovalNotifications` SETS the badge to the pending-approval
+ * count, so the badge means "approvals waiting on you" and nothing else. A
+ * ticket push that bumped it would read as a phantom approval until the next
+ * reconcile silently corrected it.
+ */
+export function shouldSetBadgeFor(data: Record<string, unknown> | null | undefined): boolean {
+  return !(data && data.type === 'ticket');
 }
 
 /** The server sends a date-only `YYYY-MM-DD`; the screen puts it straight into `?date=`. */

--- a/apps/mobile/src/services/ticketPushPrefs.test.ts
+++ b/apps/mobile/src/services/ticketPushPrefs.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const coreRequest = vi.fn();
+vi.mock('./api', () => ({ coreRequest: (...args: unknown[]) => coreRequest(...args) }));
+
+import {
+  getTicketPushPrefs,
+  TICKET_PUSH_PREFERENCE_DEFAULTS,
+  updateTicketPushPrefs,
+} from './ticketPushPrefs';
+
+beforeEach(() => {
+  coreRequest.mockReset();
+});
+
+describe('getTicketPushPrefs (#4336)', () => {
+  it('reads the CORE endpoint and unwraps `settings`', async () => {
+    // Path matters twice over: `coreRequest` prefixes /api/v1, while the
+    // default `request` helper prefixes /api/v1/mobile — and there is no
+    // ticket-push route under the mobile namespace, so the wrong helper is a
+    // silent 404 that looks exactly like "no preferences saved".
+    coreRequest.mockResolvedValue({ settings: { assignedEnabled: false, slaScope: 'any' } });
+
+    await expect(getTicketPushPrefs()).resolves.toEqual({
+      assignedEnabled: false,
+      slaScope: 'any',
+    });
+    expect(coreRequest).toHaveBeenCalledWith('/users/me/ticket-push-preferences');
+  });
+
+  it('falls back to the shipped defaults when the server sends nothing usable', async () => {
+    // Defaults live on the server too (resolveTicketPushPrefs); this guard is
+    // for a truncated/odd body, so the Settings sheet never renders `undefined`
+    // as an unchecked switch and writes a change the user did not make.
+    coreRequest.mockResolvedValue({});
+
+    await expect(getTicketPushPrefs()).resolves.toEqual(TICKET_PUSH_PREFERENCE_DEFAULTS);
+  });
+
+  it('coerces an unknown slaScope back to the default rather than trusting it', async () => {
+    coreRequest.mockResolvedValue({ settings: { assignedEnabled: true, slaScope: 'everything' } });
+
+    await expect(getTicketPushPrefs()).resolves.toEqual({
+      assignedEnabled: true,
+      slaScope: 'owned',
+    });
+  });
+});
+
+describe('updateTicketPushPrefs (#4336)', () => {
+  it('PATCHes only the changed keys and returns the server echo', async () => {
+    // The API schema is `.strict()`: sending a key it does not know (a stale
+    // field, a userId) is a 400, so the patch must stay minimal.
+    coreRequest.mockResolvedValue({ settings: { assignedEnabled: true, slaScope: 'any' } });
+
+    await expect(updateTicketPushPrefs({ slaScope: 'any' })).resolves.toEqual({
+      assignedEnabled: true,
+      slaScope: 'any',
+    });
+
+    expect(coreRequest).toHaveBeenCalledWith('/users/me/ticket-push-preferences', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ slaScope: 'any' }),
+    });
+  });
+
+  it('propagates a failure instead of resolving to defaults', async () => {
+    // The slice rolls the optimistic value back on a rejection. Swallowing the
+    // error here would leave the UI showing a setting the server never stored.
+    coreRequest.mockRejectedValue({ message: 'Network down', statusCode: 0 });
+
+    await expect(updateTicketPushPrefs({ assignedEnabled: false })).rejects.toMatchObject({
+      message: 'Network down',
+    });
+  });
+});

--- a/apps/mobile/src/services/ticketPushPrefs.ts
+++ b/apps/mobile/src/services/ticketPushPrefs.ts
@@ -20,7 +20,14 @@ export interface TicketPushPreferences {
   slaScope: TicketSlaPushScope;
 }
 
-export type UpdateTicketPushPreferences = Partial<TicketPushPreferences>;
+/**
+ * At least one key, mirroring the server's `.refine()` on
+ * `updateTicketPushPreferencesSchema`. A plain `Partial<>` would let
+ * `updateTicketPushPrefs({})` typecheck and then 400 at runtime.
+ */
+export type UpdateTicketPushPreferences =
+  | { assignedEnabled: boolean; slaScope?: TicketSlaPushScope }
+  | { assignedEnabled?: boolean; slaScope: TicketSlaPushScope };
 
 /** Mirrors TICKET_PUSH_PREFERENCE_DEFAULTS in packages/shared. */
 export const TICKET_PUSH_PREFERENCE_DEFAULTS: TicketPushPreferences = {

--- a/apps/mobile/src/services/ticketPushPrefs.ts
+++ b/apps/mobile/src/services/ticketPushPrefs.ts
@@ -1,0 +1,84 @@
+import { coreRequest } from './api';
+
+/**
+ * W10 (#4336). Per-USER ticket push preferences.
+ *
+ * These follow the technician across every phone they sign in on, unlike the
+ * per-device alert settings behind `PATCH /devices/:id/settings`.
+ *
+ * The types are declared locally rather than imported from
+ * `@breeze/shared/validators/ticketPushPreferences`: the mobile app has no
+ * dependency on the shared package (Expo bundles from source, and pulling the
+ * whole validator package in for two types would drag zod into the app
+ * bundle). The wire contract is the `settings` object, and the API route tests
+ * own it on the server side.
+ */
+export type TicketSlaPushScope = 'off' | 'owned' | 'any';
+
+export interface TicketPushPreferences {
+  assignedEnabled: boolean;
+  slaScope: TicketSlaPushScope;
+}
+
+export type UpdateTicketPushPreferences = Partial<TicketPushPreferences>;
+
+/** Mirrors TICKET_PUSH_PREFERENCE_DEFAULTS in packages/shared. */
+export const TICKET_PUSH_PREFERENCE_DEFAULTS: TicketPushPreferences = {
+  assignedEnabled: true,
+  slaScope: 'owned',
+};
+
+const SLA_SCOPES: readonly TicketSlaPushScope[] = ['off', 'owned', 'any'];
+
+/**
+ * Normalise whatever came back onto the two settings the UI renders.
+ *
+ * The server normalises too (`resolveTicketPushPrefs`), so this is defence
+ * against a truncated or older-shaped body — without it a missing field
+ * renders as an unchecked switch, and the next tap PATCHes a change the
+ * technician never intended to make.
+ */
+function normalize(raw: unknown): TicketPushPreferences {
+  const settings = (raw ?? {}) as Partial<TicketPushPreferences>;
+  return {
+    assignedEnabled:
+      typeof settings.assignedEnabled === 'boolean'
+        ? settings.assignedEnabled
+        : TICKET_PUSH_PREFERENCE_DEFAULTS.assignedEnabled,
+    slaScope:
+      typeof settings.slaScope === 'string' && SLA_SCOPES.includes(settings.slaScope)
+        ? settings.slaScope
+        : TICKET_PUSH_PREFERENCE_DEFAULTS.slaScope,
+  };
+}
+
+/**
+ * `coreRequest`, not `request`: this route lives on the core `/api/v1` surface
+ * (`apps/api/src/routes/users.ts`). The default helper prefixes
+ * `/api/v1/mobile`, where no such route exists — a 404 that would be
+ * indistinguishable from "nothing saved yet".
+ */
+export async function getTicketPushPrefs(): Promise<TicketPushPreferences> {
+  const res = await coreRequest<{ settings?: TicketPushPreferences }>(
+    '/users/me/ticket-push-preferences'
+  );
+  return normalize(res?.settings);
+}
+
+/**
+ * Send only the keys that changed. The API schema is `.strict()`, so an unknown
+ * key (or a `userId` — the route is self-only by construction) is a 400.
+ */
+export async function updateTicketPushPrefs(
+  patch: UpdateTicketPushPreferences
+): Promise<TicketPushPreferences> {
+  const res = await coreRequest<{ settings?: TicketPushPreferences }>(
+    '/users/me/ticket-push-preferences',
+    {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(patch),
+    }
+  );
+  return normalize(res?.settings);
+}

--- a/apps/mobile/src/store/index.ts
+++ b/apps/mobile/src/store/index.ts
@@ -8,6 +8,7 @@ import aiChatReducer from './aiChatSlice';
 import ticketsReducer from './ticketsSlice';
 import timeReducer from './timeSlice';
 import timeSuggestionsReducer from './timeSuggestionsSlice';
+import notificationPrefsReducer from './notificationPrefsSlice';
 import lifecycleReducer from './lifecycleSlice';
 import { withLogoutReset } from './resettable';
 import { loadServerClock } from '../services/serverClock';
@@ -20,6 +21,7 @@ const appReducer = combineReducers({
   tickets: ticketsReducer,
   time: timeReducer,
   timeSuggestions: timeSuggestionsReducer,
+  notificationPrefs: notificationPrefsReducer,
   lifecycle: lifecycleReducer,
 });
 
@@ -95,6 +97,15 @@ export {
   selectTicketAssignee,
   selectTicketTotal,
 } from './ticketsSlice';
+
+export {
+  loadTicketPushPrefs,
+  saveTicketPushPrefs,
+  clearError as clearNotificationPrefsError,
+  selectTicketPushPrefs,
+  selectTicketPushPrefsSaving,
+  selectTicketPushPrefsError,
+} from './notificationPrefsSlice';
 
 export {
   runningTimerAdopted,

--- a/apps/mobile/src/store/index.ts
+++ b/apps/mobile/src/store/index.ts
@@ -105,6 +105,7 @@ export {
   selectTicketPushPrefs,
   selectTicketPushPrefsSaving,
   selectTicketPushPrefsError,
+  selectTicketPushPrefsErrorKind,
 } from './notificationPrefsSlice';
 
 export {

--- a/apps/mobile/src/store/logoutResetContract.test.ts
+++ b/apps/mobile/src/store/logoutResetContract.test.ts
@@ -72,4 +72,30 @@ describe('every slice is wiped on sign-out', () => {
     const after = root({ timeSuggestions: populated }, { type: logout.type });
     expect(after.timeSuggestions).toEqual(initialTimeSuggestionsState);
   });
+
+  // ── W10 (#4336) ──────────────────────────────────────────────────────────
+  it('notificationPrefs is registered in combineReducers, so withLogoutReset clears it', async () => {
+    // Push preferences are per USER, not per device: leaving the previous
+    // account's slaScope in place would show the next technician on this phone
+    // a setting that is not theirs, and the Settings sheet would happily PATCH
+    // it back to the server under the new account.
+    const { store } = await import('./index');
+    expect(store.getState()).toHaveProperty('notificationPrefs');
+  });
+
+  it('a populated notificationPrefs slice returns to its initial state on LOGOUT', async () => {
+    const { default: reducer, loadTicketPushPrefs } = await import('./notificationPrefsSlice');
+    const initial = reducer(undefined, { type: '@@init' });
+    const populated = reducer(
+      initial,
+      loadTicketPushPrefs.fulfilled({ assignedEnabled: false, slaScope: 'any' }, 'r', undefined)
+    );
+    expect(populated.prefs.slaScope).toBe('any');
+
+    const { withLogoutReset } = await import('./resettable');
+    const { combineReducers } = await import('@reduxjs/toolkit');
+    const root = withLogoutReset(combineReducers({ notificationPrefs: reducer }));
+    const after = root({ notificationPrefs: populated }, { type: logout.type });
+    expect(after.notificationPrefs).toEqual(initial);
+  });
 });

--- a/apps/mobile/src/store/notificationPrefsSlice.test.ts
+++ b/apps/mobile/src/store/notificationPrefsSlice.test.ts
@@ -1,10 +1,16 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('../services/ticketPushPrefs', () => ({
+const client = vi.hoisted(() => ({
   getTicketPushPrefs: vi.fn(),
   updateTicketPushPrefs: vi.fn(),
+}));
+vi.mock('../services/ticketPushPrefs', () => ({
+  getTicketPushPrefs: client.getTicketPushPrefs,
+  updateTicketPushPrefs: client.updateTicketPushPrefs,
   TICKET_PUSH_PREFERENCE_DEFAULTS: { assignedEnabled: true, slaScope: 'owned' },
 }));
+
+import { configureStore } from '@reduxjs/toolkit';
 
 import reducer, {
   clearError,
@@ -12,6 +18,7 @@ import reducer, {
   saveTicketPushPrefs,
   selectTicketPushPrefs,
   selectTicketPushPrefsError,
+  selectTicketPushPrefsErrorKind,
   selectTicketPushPrefsSaving,
 } from './notificationPrefsSlice';
 
@@ -105,10 +112,93 @@ describe('notificationPrefsSlice (#4336)', () => {
   });
 
   it('exposes selectors over the mounted slice key', () => {
-    const state = { notificationPrefs: { ...initial, saving: true, error: 'boom' } };
+    const state = {
+      notificationPrefs: { ...initial, saving: true, error: 'boom', errorKind: 'save' as const },
+    };
 
     expect(selectTicketPushPrefs(state)).toEqual({ assignedEnabled: true, slaScope: 'owned' });
     expect(selectTicketPushPrefsSaving(state)).toBe(true);
     expect(selectTicketPushPrefsError(state)).toBe('boom');
+    expect(selectTicketPushPrefsErrorKind(state)).toBe('save');
+  });
+
+  it('distinguishes a failed LOAD from a failed SAVE', () => {
+    // Both land in the same `error` field, and the Settings sheet toasts off
+    // it. Without the kind, a failed sheet-open load tells the technician
+    // "could not save" for a save they never made.
+    const loadFailed = reducer(
+      initial,
+      loadTicketPushPrefs.rejected(null, 'r', undefined, 'Network down')
+    );
+    expect(loadFailed.errorKind).toBe('load');
+
+    const saveFailed = reducer(
+      reducer(initial, saveTicketPushPrefs.pending('r', { slaScope: 'off' })),
+      saveTicketPushPrefs.rejected(null, 'r', { slaScope: 'off' }, 'Network down')
+    );
+    expect(saveFailed.errorKind).toBe('save');
+
+    expect(reducer(saveFailed, clearError()).errorKind).toBeNull();
+  });
+});
+
+describe('notificationPrefsSlice save serialisation (#4336)', () => {
+  beforeEach(() => {
+    client.getTicketPushPrefs.mockReset();
+    client.updateTicketPushPrefs.mockReset();
+  });
+
+  function makeStore() {
+    return configureStore({ reducer: { notificationPrefs: reducer } });
+  }
+
+  it('refuses a second save while one is in flight, so the rollback snapshot stays truthful', async () => {
+    // The single rollback slot is only correct if at most one save is ever
+    // outstanding. Overlapping saves would let the second snapshot the FIRST
+    // one's unconfirmed optimistic value as "last known good", and a double
+    // rejection would then leave a never-persisted setting on screen forever.
+    // The Settings controls disable themselves while saving, but a tap landing
+    // inside that render tick would otherwise still get through — so the
+    // invariant is enforced here, not in the component.
+    let resolveFirst: (v: unknown) => void = () => {};
+    client.updateTicketPushPrefs.mockImplementationOnce(
+      () => new Promise((resolve) => { resolveFirst = resolve; })
+    );
+
+    const store = makeStore();
+    const first = store.dispatch(saveTicketPushPrefs({ assignedEnabled: false }));
+    expect(store.getState().notificationPrefs.saving).toBe(true);
+
+    await store.dispatch(saveTicketPushPrefs({ slaScope: 'any' }));
+
+    expect(client.updateTicketPushPrefs).toHaveBeenCalledTimes(1);
+    // The dropped save left no trace: the second control did NOT move
+    // optimistically for a request that was never sent.
+    expect(store.getState().notificationPrefs.prefs.slaScope).toBe('owned');
+
+    resolveFirst({ assignedEnabled: false, slaScope: 'owned' });
+    await first;
+
+    expect(store.getState().notificationPrefs.saving).toBe(false);
+    expect(store.getState().notificationPrefs.prefs).toEqual({
+      assignedEnabled: false,
+      slaScope: 'owned',
+    });
+  });
+
+  it('accepts the next save once the first has settled', async () => {
+    client.updateTicketPushPrefs
+      .mockResolvedValueOnce({ assignedEnabled: false, slaScope: 'owned' })
+      .mockResolvedValueOnce({ assignedEnabled: false, slaScope: 'any' });
+
+    const store = makeStore();
+    await store.dispatch(saveTicketPushPrefs({ assignedEnabled: false }));
+    await store.dispatch(saveTicketPushPrefs({ slaScope: 'any' }));
+
+    expect(client.updateTicketPushPrefs).toHaveBeenCalledTimes(2);
+    expect(store.getState().notificationPrefs.prefs).toEqual({
+      assignedEnabled: false,
+      slaScope: 'any',
+    });
   });
 });

--- a/apps/mobile/src/store/notificationPrefsSlice.test.ts
+++ b/apps/mobile/src/store/notificationPrefsSlice.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../services/ticketPushPrefs', () => ({
+  getTicketPushPrefs: vi.fn(),
+  updateTicketPushPrefs: vi.fn(),
+  TICKET_PUSH_PREFERENCE_DEFAULTS: { assignedEnabled: true, slaScope: 'owned' },
+}));
+
+import reducer, {
+  clearError,
+  loadTicketPushPrefs,
+  saveTicketPushPrefs,
+  selectTicketPushPrefs,
+  selectTicketPushPrefsError,
+  selectTicketPushPrefsSaving,
+} from './notificationPrefsSlice';
+
+const initial = reducer(undefined, { type: '@@init' });
+
+describe('notificationPrefsSlice (#4336)', () => {
+  it('starts at the server-side defaults, so the sheet renders correctly before the first load', () => {
+    expect(initial.prefs).toEqual({ assignedEnabled: true, slaScope: 'owned' });
+    expect(initial.status).toBe('idle');
+    expect(initial.saving).toBe(false);
+    expect(initial.error).toBeNull();
+  });
+
+  it('load.fulfilled replaces prefs and marks the slice ready', () => {
+    const next = reducer(
+      initial,
+      loadTicketPushPrefs.fulfilled({ assignedEnabled: false, slaScope: 'any' }, 'r', undefined)
+    );
+
+    expect(next.prefs).toEqual({ assignedEnabled: false, slaScope: 'any' });
+    expect(next.status).toBe('ready');
+  });
+
+  it('load.rejected records the error without clobbering the current prefs', () => {
+    const ready = reducer(
+      initial,
+      loadTicketPushPrefs.fulfilled({ assignedEnabled: false, slaScope: 'any' }, 'r', undefined)
+    );
+
+    const next = reducer(
+      ready,
+      loadTicketPushPrefs.rejected(null, 'r2', undefined, 'Network down')
+    );
+
+    expect(next.status).toBe('error');
+    expect(next.error).toBe('Network down');
+    expect(next.prefs).toEqual({ assignedEnabled: false, slaScope: 'any' });
+  });
+
+  it('save.pending applies the patch optimistically; save.rejected rolls back and records the error', () => {
+    const pending = reducer(initial, saveTicketPushPrefs.pending('r', { slaScope: 'any' }));
+    expect(pending.prefs.slaScope).toBe('any');
+    expect(pending.prefs.assignedEnabled).toBe(true); // untouched key survives
+    expect(pending.saving).toBe(true);
+
+    const rejected = reducer(
+      pending,
+      saveTicketPushPrefs.rejected(null, 'r', { slaScope: 'any' }, 'Network down')
+    );
+
+    // Leaving the optimistic value on screen would tell the technician they had
+    // turned SLA pushes on for every ticket when the server still has 'owned'.
+    expect(rejected.prefs.slaScope).toBe('owned');
+    expect(rejected.saving).toBe(false);
+    expect(rejected.error).toBe('Network down');
+  });
+
+  it('rolls back to the value that was live when the save started, not to the defaults', () => {
+    const ready = reducer(
+      initial,
+      loadTicketPushPrefs.fulfilled({ assignedEnabled: false, slaScope: 'any' }, 'r', undefined)
+    );
+    const pending = reducer(ready, saveTicketPushPrefs.pending('r2', { slaScope: 'off' }));
+
+    const rejected = reducer(
+      pending,
+      saveTicketPushPrefs.rejected(null, 'r2', { slaScope: 'off' }, 'Nope')
+    );
+
+    expect(rejected.prefs).toEqual({ assignedEnabled: false, slaScope: 'any' });
+  });
+
+  it('save.fulfilled adopts the server echo, even when it disagrees with the optimistic patch', () => {
+    const pending = reducer(initial, saveTicketPushPrefs.pending('r', { assignedEnabled: false }));
+
+    const done = reducer(
+      pending,
+      saveTicketPushPrefs.fulfilled(
+        { assignedEnabled: false, slaScope: 'owned' },
+        'r',
+        { assignedEnabled: false }
+      )
+    );
+
+    expect(done.prefs).toEqual({ assignedEnabled: false, slaScope: 'owned' });
+    expect(done.saving).toBe(false);
+  });
+
+  it('clearError clears, so the Settings sheet does not re-toast the same failure', () => {
+    expect(reducer({ ...initial, error: 'x' }, clearError()).error).toBeNull();
+  });
+
+  it('exposes selectors over the mounted slice key', () => {
+    const state = { notificationPrefs: { ...initial, saving: true, error: 'boom' } };
+
+    expect(selectTicketPushPrefs(state)).toEqual({ assignedEnabled: true, slaScope: 'owned' });
+    expect(selectTicketPushPrefsSaving(state)).toBe(true);
+    expect(selectTicketPushPrefsError(state)).toBe('boom');
+  });
+});

--- a/apps/mobile/src/store/notificationPrefsSlice.ts
+++ b/apps/mobile/src/store/notificationPrefsSlice.ts
@@ -1,0 +1,118 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+
+import {
+  getTicketPushPrefs,
+  TICKET_PUSH_PREFERENCE_DEFAULTS,
+  updateTicketPushPrefs,
+  type TicketPushPreferences,
+  type UpdateTicketPushPreferences,
+} from '../services/ticketPushPrefs';
+
+/**
+ * W10 (#4336). The technician's ticket push preferences.
+ *
+ * Saves are optimistic with a rollback: these controls are switches, and a
+ * switch that waits on a round-trip before moving reads as broken on a slow
+ * link. The cost is that a failed save must put the old value back — leaving
+ * the optimistic one on screen would tell the technician they had turned SLA
+ * pushes on for every ticket when the server still has `owned`.
+ */
+export interface NotificationPrefsState {
+  prefs: TicketPushPreferences;
+  status: 'idle' | 'loading' | 'ready' | 'error';
+  saving: boolean;
+  /** Snapshot taken on save.pending so save.rejected can restore it. */
+  rollback: TicketPushPreferences | null;
+  error: string | null;
+}
+
+const initialState: NotificationPrefsState = {
+  prefs: { ...TICKET_PUSH_PREFERENCE_DEFAULTS },
+  status: 'idle',
+  saving: false,
+  rollback: null,
+  error: null,
+};
+
+function messageOf(err: unknown, fallback: string): string {
+  return (err as { message?: string } | null)?.message ?? fallback;
+}
+
+export const loadTicketPushPrefs = createAsyncThunk(
+  'notificationPrefs/load',
+  async (_: void, { rejectWithValue }) => {
+    try {
+      return await getTicketPushPrefs();
+    } catch (err: unknown) {
+      return rejectWithValue(messageOf(err, 'Failed to load notification settings'));
+    }
+  }
+);
+
+export const saveTicketPushPrefs = createAsyncThunk(
+  'notificationPrefs/save',
+  async (patch: UpdateTicketPushPreferences, { rejectWithValue }) => {
+    try {
+      return await updateTicketPushPrefs(patch);
+    } catch (err: unknown) {
+      return rejectWithValue(messageOf(err, 'Failed to save notification settings'));
+    }
+  }
+);
+
+const notificationPrefsSlice = createSlice({
+  name: 'notificationPrefs',
+  initialState,
+  reducers: {
+    clearError: (state) => {
+      state.error = null;
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(loadTicketPushPrefs.pending, (state) => {
+        state.status = 'loading';
+      })
+      .addCase(loadTicketPushPrefs.fulfilled, (state, action) => {
+        state.prefs = action.payload;
+        state.status = 'ready';
+        state.error = null;
+      })
+      .addCase(loadTicketPushPrefs.rejected, (state, action) => {
+        // Deliberately leaves `prefs` alone: a failed refresh must not silently
+        // reset the values the technician is currently looking at.
+        state.status = 'error';
+        state.error = (action.payload as string) ?? action.error.message ?? 'Failed to load';
+      })
+      .addCase(saveTicketPushPrefs.pending, (state, action) => {
+        state.rollback = { ...state.prefs };
+        state.prefs = { ...state.prefs, ...action.meta.arg };
+        state.saving = true;
+        state.error = null;
+      })
+      .addCase(saveTicketPushPrefs.fulfilled, (state, action) => {
+        // Adopt the echo rather than keeping the optimistic value: the server
+        // is the authority on what was actually stored.
+        state.prefs = action.payload;
+        state.saving = false;
+        state.rollback = null;
+        state.status = 'ready';
+      })
+      .addCase(saveTicketPushPrefs.rejected, (state, action) => {
+        if (state.rollback) state.prefs = state.rollback;
+        state.rollback = null;
+        state.saving = false;
+        state.error = (action.payload as string) ?? action.error.message ?? 'Failed to save';
+      });
+  },
+});
+
+export const { clearError } = notificationPrefsSlice.actions;
+export default notificationPrefsSlice.reducer;
+
+export const selectTicketPushPrefs = (state: { notificationPrefs: NotificationPrefsState }) =>
+  state.notificationPrefs.prefs;
+export const selectTicketPushPrefsSaving = (state: { notificationPrefs: NotificationPrefsState }) =>
+  state.notificationPrefs.saving;
+export const selectTicketPushPrefsError = (state: { notificationPrefs: NotificationPrefsState }) =>
+  state.notificationPrefs.error;

--- a/apps/mobile/src/store/notificationPrefsSlice.ts
+++ b/apps/mobile/src/store/notificationPrefsSlice.ts
@@ -21,9 +21,22 @@ export interface NotificationPrefsState {
   prefs: TicketPushPreferences;
   status: 'idle' | 'loading' | 'ready' | 'error';
   saving: boolean;
-  /** Snapshot taken on save.pending so save.rejected can restore it. */
+  /**
+   * Snapshot taken on save.pending so save.rejected can restore it.
+   *
+   * A single slot is only sound because at most one save is ever outstanding —
+   * see the `condition` on `saveTicketPushPrefs`. Overlapping saves would let
+   * the second snapshot the first one's *unconfirmed* optimistic value as
+   * "last known good".
+   */
   rollback: TicketPushPreferences | null;
   error: string | null;
+  /**
+   * Which operation produced `error`. Both thunks write the same field, and the
+   * Settings sheet toasts off it — without this a failed sheet-open load tells
+   * the technician a save failed when they never made one.
+   */
+  errorKind: 'load' | 'save' | null;
 }
 
 const initialState: NotificationPrefsState = {
@@ -32,6 +45,7 @@ const initialState: NotificationPrefsState = {
   saving: false,
   rollback: null,
   error: null,
+  errorKind: null,
 };
 
 function messageOf(err: unknown, fallback: string): string {
@@ -57,6 +71,20 @@ export const saveTicketPushPrefs = createAsyncThunk(
     } catch (err: unknown) {
       return rejectWithValue(messageOf(err, 'Failed to save notification settings'));
     }
+  },
+  {
+    /**
+     * One save at a time. The single `rollback` slot is only truthful while no
+     * other save is outstanding, and the Settings controls already disable
+     * themselves during a save — but a tap landing inside that render tick
+     * would still get through, so the invariant is enforced here rather than
+     * trusted to the component.
+     *
+     * `dispatchConditionRejection` stays at its default (false), so a refused
+     * save dispatches nothing at all: no optimistic move, no error, no toast.
+     */
+    condition: (_patch, { getState }) =>
+      !(getState() as { notificationPrefs: NotificationPrefsState }).notificationPrefs.saving,
   }
 );
 
@@ -66,6 +94,7 @@ const notificationPrefsSlice = createSlice({
   reducers: {
     clearError: (state) => {
       state.error = null;
+      state.errorKind = null;
     },
   },
   extraReducers: (builder) => {
@@ -77,18 +106,21 @@ const notificationPrefsSlice = createSlice({
         state.prefs = action.payload;
         state.status = 'ready';
         state.error = null;
+        state.errorKind = null;
       })
       .addCase(loadTicketPushPrefs.rejected, (state, action) => {
         // Deliberately leaves `prefs` alone: a failed refresh must not silently
         // reset the values the technician is currently looking at.
         state.status = 'error';
         state.error = (action.payload as string) ?? action.error.message ?? 'Failed to load';
+        state.errorKind = 'load';
       })
       .addCase(saveTicketPushPrefs.pending, (state, action) => {
         state.rollback = { ...state.prefs };
         state.prefs = { ...state.prefs, ...action.meta.arg };
         state.saving = true;
         state.error = null;
+        state.errorKind = null;
       })
       .addCase(saveTicketPushPrefs.fulfilled, (state, action) => {
         // Adopt the echo rather than keeping the optimistic value: the server
@@ -103,6 +135,7 @@ const notificationPrefsSlice = createSlice({
         state.rollback = null;
         state.saving = false;
         state.error = (action.payload as string) ?? action.error.message ?? 'Failed to save';
+        state.errorKind = 'save';
       });
   },
 });
@@ -116,3 +149,6 @@ export const selectTicketPushPrefsSaving = (state: { notificationPrefs: Notifica
   state.notificationPrefs.saving;
 export const selectTicketPushPrefsError = (state: { notificationPrefs: NotificationPrefsState }) =>
   state.notificationPrefs.error;
+export const selectTicketPushPrefsErrorKind = (state: {
+  notificationPrefs: NotificationPrefsState;
+}) => state.notificationPrefs.errorKind;


### PR DESCRIPTION
Closes #4336

W10 of the mobile ticketing feature (#3206): the **mobile half** of W07 (#3901). The backend half shipped in #4281, so this PR consumes a contract that is already on `main` — it does not add or change any server code.

Plan: `docs/superpowers/plans/mobile/2026-08-29-ticket-push-categories.md`, **Tasks 13–18**. Tasks 1–12 (API) were done in #4281 and are untouched here.

## What ships

| Task | Change |
|---|---|
| 13 | `parseTicketData` / `parseTicketNotification` / `shouldSetBadgeFor`, the `tickets` Android channel, and a badge-aware foreground handler |
| 14 | `navigation/pushRouting.ts` (pure route resolver + cold-start replay guard) and `navigation/navigationRef.ts` (module-level ref with a one-slot buffer) |
| 15 | `PushTapRouter` + `RootNavigator` wiring (`ref`, `onReady`) |
| 16 | `services/ticketPushPrefs.ts` client + `store/notificationPrefsSlice.ts` with optimistic save and rollback |
| 17 | Two preference controls in the Settings sheet |
| 18 | Docs: ticket push categories, the preference endpoints, and two stale claims retired |

A technician now gets a push when a ticket is assigned to them or breaches its response/resolution SLA, tapping it opens `TicketDetail` (background **and** cold start), and the two categories are controllable from Settings.

## Contract verified against the shipped API, not the plan

The plan predates #4281, so the wire shape was re-read from `main` before writing the parser. `buildTicketPush` (`apps/api/src/services/expoPush.ts`) emits:

```ts
{ type: 'ticket', ticketId, reason: 'assigned' | 'sla_breached', target?: 'response' | 'resolution', internalNumber? }
```

`internalNumber` is a presentation extra the plan did not mention. The parser deliberately ignores it and returns only the routing-relevant fields, with a test pinning that a change to the presentation extras cannot break tap handling.

## Decisions worth a reviewer's attention

**`PushTapRouter` is a SIBLING of `ApprovalGate`, never a child.** `ApprovalGate` returns `<ApprovalScreen />` *instead of* its children while an approval is focused, so nesting the router would tear down its notification subscriptions for exactly the lifetime the spec requires taps to survive. If a later refactor moves it inside, the symptom is silent: pushes still arrive, taps just stop routing while an approval is on screen.

**Ticket pushes never touch the badge.** `reconcileApprovalNotifications` *sets* the badge to the pending-approval count, so the badge means "approvals waiting on you". A ticket push that bumped it would read as a phantom approval until the next reconcile silently corrected it. The test asserts the registered handler actually consults `shouldSetBadgeFor` — asserting the pure function alone would have stayed green against the old hard-coded `shouldSetBadge: true`.

**The SLA control suppresses PUSH only.** The in-app inbox row and the email are written on every breach regardless of the preference (spec D6, implemented server-side in #4281). The row copy says so explicitly: *"Your in-app inbox still records every breach."* A control that quietly means more than it says is how support tickets get filed against the notification system.

**`navigateToTicket` buffers one pending id.** react-navigation silently drops `navigate()` before the container is ready, which is precisely the cold-start tap. One slot, not a queue: a technician who taps two pushes during a cold start wants the last one they touched.

**Cold-start replay is identifier-guarded and persisted.** `getLastNotificationResponseAsync()` returns the same response for the life of the process, so replaying it unguarded yanks the technician back to a ticket on every navigator remount. The handled identifier is written to AsyncStorage so a relaunch does not replay the launching tap either.

## Deviations from the plan

1. **Branched from `main`, not stacked on the API branch.** The plan's Task 1 Step 3 predates #4281 merging. A stacked PR whose base is not `main` runs **zero** CI here (`ci.yml` triggers on `pull_request: branches: [main]`), and the API half is already on `main` anyway.
2. **`Closes #4336`, not `Closes #3901`.** #3901 auto-closed on the #4281 merge even though the mobile half was never built; #4336 is the tracker sub-issue that actually represents this work.
3. **The API client lives in a new `services/ticketPushPrefs.ts`, not appended to `services/api.ts`.** This follows the `services/tickets.ts` precedent (feature service over `coreRequest`), keeps `api.ts` from growing past 1000 lines, and — the reason that matters — makes the endpoint path unit-testable. `coreRequest` prefixes `/api/v1` while the default `request` helper prefixes `/api/v1/mobile`, where no such route exists; the wrong helper is a silent 404 indistinguishable from "nothing saved yet". There is now a test pinning it.
4. **`MainTabParamList.TicketsTab` widened to `NavigatorScreenParams<TicketsStackParamList> | undefined`** rather than casting the `navigate` call, as the plan's `[not-checked]` note allowed. A cast would let a rename inside `TicketsStackParamList` compile fine and fail only on a device.
5. **The preference rows read the slice directly** instead of taking six more props through `SheetBody`, which is already at twenty props and none of which the rest of the sheet uses.
6. **One extra doc fix, in scope.** `mobile.mdx` still claimed the Settings screen has "Push Notifications" / "Critical Alerts Only" toggles persisted via AsyncStorage. #3118 replaced those with a status readout. Corrected in the same section this PR was already editing.

## Verification

| Check | Result |
|---|---|
| `npx vitest run` (apps/mobile, full suite) | **81 files, 1040 passed, 3 skipped** |
| `npx tsc --noEmit` (apps/mobile) | **clean** |
| `pnpm --filter @breeze/docs build` | **167 pages, Complete** (Starlight fails on malformed MDX / broken links) |
| Migrations touched | **none** — no tenancy, cascade, export-policy or RLS surface in this diff |

Every new module was written red-first: the parser tests, the routing/nav-ref tests, the client tests and the slice tests were each run and observed failing before the implementation existed.

`test-mobile` in CI runs exactly these two commands, so a green job here is the same evidence.

## Not verified — needs a device pass before merge

There is **no iOS device build in this loop**, so the plan's Task 19 Step 2 checklist is outstanding. Everything below is covered by unit tests at the logic level but unproven end-to-end on hardware:

- assign from web → push arrives → tap from terminated / background / foreground
- force-quit then tap → opens `TicketDetail` after boot; relaunch normally → no navigation (replay guard)
- approval overlay focused, then a ticket tap → ticket revealed after the decision clears (this is the one that catches a regression moving `PushTapRouter` under `ApprovalGate`)
- badge unchanged after ticket pushes
- Settings: rows appear only when push is registered; airplane mode disables them; API down → toast + value rolls back

## Open question for the maintainer

`buildTicketPush` sets APNs `category: 'BREEZE_TICKET'`, and `apns.ts` notes "No client category is registered in W07". This PR does not call `setNotificationCategoryAsync` — an unregistered category identifier is inert on iOS (default presentation, no custom actions), and W07 ships no notification actions for it to expose. Registering it is only worth doing when someone wants Acknowledge / Assign-to-me buttons on the lock screen. Flagging rather than deciding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
