### PR TITLE
ci: give apt a transport deadline in the Tauri dependency install (#3730)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1677,8 +1677,10 @@ jobs:
             /etc/apt/sources.list.d/*.list \
             /etc/apt/sources.list.d/*.sources 2>/dev/null || true
           install_deps() {
-            sudo timeout --kill-after=30s 2m apt-get update && \
+            sudo timeout --kill-after=30s 2m apt-get update \
+              -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o Acquire::Retries=3 && \
             sudo timeout --kill-after=30s 5m apt-get install -y --no-install-recommends \
+              -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o Acquire::Retries=3 \
               libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
           }
           attempts=3


### PR DESCRIPTION
**Problem:** #3730 established (bdunncompany's log analysis) that the Rust Check stall is a wedged package download inside `apt-get install` — apt sets no per-connection deadline by default, so a stalled `libwebkit2gtk` fetch blocks silently until the outer `timeout 5m` kills the whole attempt. #3731 bounded the damage; this applies the targeted fix that issue identified as still missing.

**Change:** `-o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o Acquire::Retries=3` on both apt invocations in `install_deps()`. A wedged connection now errors in 30s and apt retries at the transport layer; the existing attempt loop and outer timeouts stay as backstops.

Refs #3730

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZFVYRgU9MVdTA7m5gMMcU