### PR TITLE
fix(mobile): getServerUrl throws on a failed read instead of returning null (#4002)

### DIFF
--- a/apps/mobile/src/screens/chat/components/SettingsSheet.tsx
+++ b/apps/mobile/src/screens/chat/components/SettingsSheet.tsx
@@ -262,11 +262,23 @@ export function SettingsSheet({ visible, onCancel }: Props) {
             // We track the user-intent click, not the actual server-side
             // deletion request (that happens on the web flow).
             track('account_deletion_requested');
-            // The deletion page is served on the server the user selected at
-            // sign-in (e.g. https://us.2breeze.app/account/delete), not a
-            // hardcoded marketing domain. Resolve it at tap time.
-            const url = await getAccountDeletionUrl(FALLBACK_API_BASE_URL);
-            await safeOpen(url);
+            try {
+              // The deletion page is served on the server the user selected
+              // at sign-in (e.g. https://us.2breeze.app/account/delete), not
+              // a hardcoded marketing domain. Resolve it at tap time.
+              //
+              // getAccountDeletionUrl throws ServerUrlReadError when the
+              // stored server can't be read (rather than opening the wrong
+              // tenant's deletion page) — surface that instead of letting the
+              // promise reject silently.
+              const url = await getAccountDeletionUrl(FALLBACK_API_BASE_URL);
+              await safeOpen(url);
+            } catch {
+              setToast({
+                kind: 'error',
+                text: 'Could not open the deletion page. Please try again.',
+              });
+            }
           },
         },
       ],

--- a/apps/mobile/src/services/api.serverUrlFailure.test.ts
+++ b/apps/mobile/src/services/api.serverUrlFailure.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Caller-level regression test for #4002: a SecureStore read failure for the
+// configured server URL must fail the request, not silently reroute it to
+// FALLBACK_API_BASE_URL (the hosted US host). This exercises the real
+// `requestWithPrefix` code path (via the exported `login`), not just the
+// `serverConfig` unit in isolation, since the bug was in how a caller
+// combined `getServerUrl()` with `|| FALLBACK_API_BASE_URL`.
+
+const secureValues = new Map<string, string>();
+const fetchWithTimeout = vi.fn();
+const serverConfig = vi.hoisted(() => ({
+  getServerUrl: vi.fn(async (): Promise<string | null> => 'https://api.example.test'),
+}));
+const secureStore = vi.hoisted(() => ({
+  getItemAsync: vi.fn(async (key: string) => secureValues.get(key) ?? null),
+  setItemAsync: vi.fn(async (key: string, value: string) => { secureValues.set(key, value); }),
+  deleteItemAsync: vi.fn(async (key: string) => { secureValues.delete(key); }),
+}));
+
+vi.mock('expo-secure-store', () => ({
+  WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'device-only',
+  getItemAsync: (...args: Parameters<typeof secureStore.getItemAsync>) => secureStore.getItemAsync(...args),
+  setItemAsync: (...args: Parameters<typeof secureStore.setItemAsync>) => secureStore.setItemAsync(...args),
+  deleteItemAsync: (...args: Parameters<typeof secureStore.deleteItemAsync>) => secureStore.deleteItemAsync(...args),
+}));
+vi.mock('@sentry/react-native', () => ({ captureMessage: vi.fn(), captureException: vi.fn() }));
+// Real ServerUrlReadError so `.name`/`instanceof` assertions below match
+// production behavior, not a mock shape.
+vi.mock('./serverConfig', async () => {
+  const actual = await vi.importActual<typeof import('./serverConfig')>('./serverConfig');
+  return {
+    ...actual,
+    getServerUrl: () => serverConfig.getServerUrl(),
+  };
+});
+vi.mock('./installationId', () => ({
+  getOrCreateInstallationId: vi.fn(async () => 'install-1'),
+}));
+vi.mock('./fetchWithTimeout', () => ({
+  fetchWithTimeout: (...args: unknown[]) => fetchWithTimeout(...args),
+}));
+vi.mock('./csrfToken', () => ({
+  applyCsrfSignal: vi.fn(async () => undefined),
+  forgetCsrfToken: vi.fn(async () => undefined),
+  getCsrfHeaderValue: vi.fn(async () => 'csrf'),
+  readCsrfCookie: vi.fn(() => ({ kind: 'absent' })),
+}));
+
+import { login, FALLBACK_API_BASE_URL } from './api';
+import { ServerUrlReadError } from './serverConfig';
+
+beforeEach(() => {
+  secureValues.clear();
+  serverConfig.getServerUrl.mockReset().mockResolvedValue('https://api.example.test');
+  secureStore.getItemAsync.mockClear();
+  fetchWithTimeout.mockReset();
+});
+
+describe('auth path fails closed on a server-URL read failure (#4002)', () => {
+  it('rejects login() with ServerUrlReadError instead of falling back to FALLBACK_API_BASE_URL', async () => {
+    serverConfig.getServerUrl.mockReset().mockRejectedValue(new ServerUrlReadError(new Error('keychain locked')));
+
+    await expect(login('tech@example.test', 'password')).rejects.toBeInstanceOf(ServerUrlReadError);
+
+    // The request must never go out at all — least of all to the hosted
+    // fallback host — once the configured server can't be determined.
+    expect(fetchWithTimeout).not.toHaveBeenCalled();
+  });
+
+  it('sanity check: a genuinely unconfigured server (null) still reaches FALLBACK_API_BASE_URL', async () => {
+    serverConfig.getServerUrl.mockReset().mockResolvedValue(null);
+    fetchWithTimeout.mockResolvedValue(
+      new Response(JSON.stringify({ error: 'no server configured' }), {
+        status: 500,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    await expect(login('tech@example.test', 'password')).rejects.toBeTruthy();
+
+    expect(fetchWithTimeout).toHaveBeenCalledTimes(1);
+    const [url] = fetchWithTimeout.mock.calls[0] as [string, unknown];
+    expect(url.startsWith(FALLBACK_API_BASE_URL)).toBe(true);
+  });
+});

--- a/apps/mobile/src/services/serverConfig.test.ts
+++ b/apps/mobile/src/services/serverConfig.test.ts
@@ -9,7 +9,12 @@ vi.mock('expo-secure-store', () => ({
 
 import * as SecureStore from 'expo-secure-store';
 
-import { buildAccountDeletionUrl, getAccountDeletionUrl } from './serverConfig';
+import {
+  buildAccountDeletionUrl,
+  getAccountDeletionUrl,
+  getServerUrl,
+  ServerUrlReadError,
+} from './serverConfig';
 
 const FALLBACK = 'https://api.fallback.example';
 
@@ -57,5 +62,52 @@ describe('getAccountDeletionUrl', () => {
     await expect(getAccountDeletionUrl(FALLBACK)).resolves.toBe(
       'https://api.fallback.example/account/delete',
     );
+  });
+
+  it('propagates ServerUrlReadError instead of falling back on a failed read', async () => {
+    // A locked keychain must not silently resolve to the fallback base — that
+    // would send the deletion request to the wrong tenant's server (#4002).
+    vi.mocked(SecureStore.getItemAsync).mockRejectedValueOnce(new Error('keychain locked'));
+    await expect(getAccountDeletionUrl(FALLBACK)).rejects.toThrow(ServerUrlReadError);
+  });
+});
+
+describe('getServerUrl', () => {
+  it('resolves null when nothing is configured (genuine absence)', async () => {
+    vi.mocked(SecureStore.getItemAsync).mockResolvedValueOnce(null);
+    await expect(getServerUrl()).resolves.toBeNull();
+  });
+
+  it('resolves the stored url on a successful read', async () => {
+    vi.mocked(SecureStore.getItemAsync).mockResolvedValueOnce('https://eu.2breeze.app');
+    await expect(getServerUrl()).resolves.toBe('https://eu.2breeze.app');
+  });
+
+  it('throws ServerUrlReadError — not null — when the read itself fails', async () => {
+    const original = new Error('keychain locked');
+    vi.mocked(SecureStore.getItemAsync).mockRejectedValueOnce(original);
+    await expect(getServerUrl()).rejects.toThrow(ServerUrlReadError);
+  });
+
+  it('sets .name explicitly so call sites can branch without instanceof', async () => {
+    vi.mocked(SecureStore.getItemAsync).mockRejectedValueOnce(new Error('keychain locked'));
+    try {
+      await getServerUrl();
+      expect.unreachable('getServerUrl should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ServerUrlReadError);
+      expect((err as Error).name).toBe('ServerUrlReadError');
+    }
+  });
+
+  it('preserves the original error as .cause for diagnostics', async () => {
+    const original = new Error('keychain locked');
+    vi.mocked(SecureStore.getItemAsync).mockRejectedValueOnce(original);
+    try {
+      await getServerUrl();
+      expect.unreachable('getServerUrl should have thrown');
+    } catch (err) {
+      expect((err as Error).cause).toBe(original);
+    }
   });
 });

--- a/apps/mobile/src/services/serverConfig.ts
+++ b/apps/mobile/src/services/serverConfig.ts
@@ -47,19 +47,52 @@ export function buildAccountDeletionUrl(
 /**
  * Resolve the account-deletion URL from the server chosen at sign-in
  * (SecureStore key `breeze_server_url`). Falls back to `fallbackBaseUrl` when
- * no server is stored.
+ * no server is stored. Propagates `ServerUrlReadError` when the read itself
+ * fails — see `getServerUrl`.
  */
 export async function getAccountDeletionUrl(fallbackBaseUrl: string): Promise<string> {
   const stored = await getServerUrl();
   return buildAccountDeletionUrl(stored, fallbackBaseUrl);
 }
 
+/**
+ * Thrown by `getServerUrl` when SecureStore itself fails to read the key —
+ * e.g. a transiently locked keychain — as distinct from a successful read
+ * that simply found nothing stored. Branch on `.name` rather than
+ * `instanceof` at call sites: subclass `instanceof` is unreliable across
+ * RN/Hermes bundles (see `SecureWipeError` in `services/auth.ts`), and
+ * `.name` is set explicitly here to keep that contract sound.
+ */
+export class ServerUrlReadError extends Error {
+  constructor(cause: unknown) {
+    super('Failed to read the configured server URL from secure storage', { cause });
+    this.name = 'ServerUrlReadError';
+  }
+}
+
+/**
+ * Resolve the server URL the user configured at sign-in.
+ *
+ * Returns `null` ONLY when SecureStore genuinely has nothing stored under
+ * this key — that legitimately means "not configured", and callers are free
+ * to fall back to `FALLBACK_API_BASE_URL`. A FAILED read (locked keychain,
+ * SecureStore unavailable, etc.) throws `ServerUrlReadError` instead of
+ * collapsing into that same `null`.
+ *
+ * Folding the two together let every `(await getServerUrl()) || FALLBACK`
+ * call site silently reroute a self-hosted (or non-US) tenant to the hosted
+ * default host on a transient keychain error, including on the auth path —
+ * login and MFA request bodies went to a server the tenant never configured
+ * (#4002). Throwing makes the failure propagate through that same `await`
+ * expression (it never reaches the `||`), so every existing call site fails
+ * closed without needing its own change.
+ */
 export async function getServerUrl(): Promise<string | null> {
   try {
     return await SecureStore.getItemAsync(SERVER_URL_KEY);
   } catch (error) {
     console.error('Error retrieving server URL:', error);
-    return null;
+    throw new ServerUrlReadError(error);
   }
 }
 


### PR DESCRIPTION
## Summary

`getServerUrl()` folded a SecureStore read **failure** (locked keychain, SecureStore unavailable) into the same `null` return as a genuine "nothing configured" absence. Every one of its ~11 call sites does:

```ts
const baseUrl = (await getServerUrl()) || FALLBACK_API_BASE_URL;
```

`FALLBACK_API_BASE_URL` is the hosted US host in all build profiles, so a transient keychain read failure silently rerouted a self-hosted or non-US tenant to the hosted default — including on the **auth path** (login/MFA request bodies going to a server the tenant never configured).

## Fix

`getServerUrl()` now:
- Returns `null` **only** when SecureStore genuinely has nothing stored (a successful read of an absent key) — callers are free to fall back in that case.
- **Throws `ServerUrlReadError`** when the read itself fails, instead of catching it into `null`.

Because the throw happens inside the same `await getServerUrl()` expression every caller already uses, the failure now propagates through that `await` and never reaches the `|| FALLBACK_API_BASE_URL` — **every existing call site fails closed with no per-caller change needed.** Verified by reading each of the ~11 call sites: none wraps the `getServerUrl()` call in a try/catch that would re-swallow it (the one call site inside a try/catch, `aiChat.ts`'s streaming path, already routes the caught error to `opts.onError(...)`, which is the correct surfaced-failure behavior).

`getAccountDeletionUrl` (which calls `getServerUrl` directly) now propagates the same error. Its one caller that awaited it outside a try/catch (`SettingsSheet.tsx`'s delete-account flow) is updated to catch it and show an error toast instead of leaving an unhandled promise rejection.

`ServerUrlReadError` follows the existing `SecureWipeError` convention in `services/auth.ts`: sets `.name` explicitly (RN/Hermes `instanceof` across bundles is unreliable) and preserves the original error as `.cause`.

## Testing

- `apps/mobile/src/services/serverConfig.test.ts` — new coverage for both states: a successful read of an absent key resolves `null`; a failed read throws `ServerUrlReadError` (with `.name` and `.cause` assertions); `getAccountDeletionUrl` propagates rather than silently falling back.
- `apps/mobile/src/services/api.serverUrlFailure.test.ts` (new) — caller-level regression test through the real `requestWithPrefix`/`login` path: a server-URL read failure rejects `login()` with `ServerUrlReadError` and **the request is never sent** (`fetchWithTimeout` not called), vs. a genuine `null` (unconfigured) still reaching `FALLBACK_API_BASE_URL` as before.
- All 12 other test files touching `getServerUrl` (aiChat, search, approverDevice, ticketAttachments, api.mfa, api.logout, api.formdata, etc.) re-run clean — no regressions from the changed contract.

```
pnpm exec vitest run src/services/serverConfig.test.ts src/services/api.serverUrlFailure.test.ts --pool=threads --maxWorkers=2
# 2 files, 15 tests passed

pnpm exec vitest run <12 other affected files> --pool=threads --maxWorkers=2
# 12 files, 132 tests passed

pnpm exec tsc --noEmit
# clean
```

Closes #4002

🤖 Generated with [Claude Code](https://claude.com/claude-code)