### PR TITLE
fix(api): escape the request context in the scriptDispatch actor probe (#4299)

### DIFF
--- a/apps/api/src/services/scriptDispatch.test.ts
+++ b/apps/api/src/services/scriptDispatch.test.ts
@@ -3,6 +3,7 @@ import { SQL, Param } from 'drizzle-orm';
 
 vi.mock('../db', () => ({
   db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn() },
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 vi.mock('./commandQueue', () => ({ queueCommand: vi.fn() }));
@@ -484,6 +485,72 @@ describe('dispatchScriptToDevice — users-FK probe-and-degrade (#3826)', () => 
     expect(db.insert).not.toHaveBeenCalled();
     const [, , , userId] = vi.mocked(queueCommand).mock.calls[0]!;
     expect(userId).toBeUndefined();
+  });
+
+  // #4299: the load-bearing half of the probe. `users` is an RLS-forced
+  // dual-axis table and `withSystemDbAccessContext` short-circuits to the
+  // caller's store when one is already open (`withDbAccessContext` returns
+  // early on an existing store), so a probe that does not FIRST escape the
+  // request context runs org-scoped. A partner-level human (`users.org_id IS
+  // NULL`) matches no branch of the users SELECT policy from an org-scoped,
+  // user-less context, so the probe reads zero rows and degrades a REAL human
+  // to NULL on both `triggered_by` and `created_by` — silently, since this
+  // path is FK-safe. Nesting order is the observable proof this suite can
+  // make: `db` is mocked here, so no RLS policy is actually evaluated. The
+  // real-Postgres proof of the identical escape (a partner-level human kept
+  // through an org-scoped, user-less caller context) is the load-bearing test
+  // in __tests__/integration/commandQueueCreatedBy.integration.test.ts, which
+  // covers the sibling probe in commandQueue.ts. This assertion fails against
+  // the pre-#4299 code — verified, not assumed.
+  it('runs the actor probe OUTSIDE the caller DB context, in a system context', async () => {
+    const dbModule = await import('../db');
+    const order: string[] = [];
+    vi.mocked(dbModule.runOutsideDbContext).mockImplementationOnce(async (fn: () => unknown) => {
+      order.push('enter-outside');
+      const result = await fn();
+      order.push('exit-outside');
+      return result;
+    });
+    vi.mocked(dbModule.withSystemDbAccessContext).mockImplementationOnce(async (fn: () => unknown) => {
+      order.push('enter-system');
+      const result = await fn();
+      order.push('exit-system');
+      return result;
+    });
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockImplementation(() => {
+            order.push('users-probe');
+            return Promise.resolve([{ id: 'probed' }]);
+          }),
+        }),
+      }),
+    } as any);
+
+    const r = await dispatchScriptToDevice({
+      device: device(),
+      source: { kind: 'saved', script: savedScript() },
+      triggeredBy: 'user-1',
+      createdBy: 'user-1',
+    });
+
+    expect(r.ok).toBe(true);
+    // Nesting matters: outside must open before system, and the read must land
+    // between them. `withSystemDbAccessContext` alone (no escape) yields
+    // ['enter-system', 'users-probe', 'exit-system'] and is the regression.
+    expect(order).toEqual([
+      'enter-outside',
+      'enter-system',
+      'users-probe',
+      'exit-system',
+      'exit-outside',
+    ]);
+    // And the real user still survives the guard on BOTH columns.
+    const execValues = vi.mocked(db.insert).mock.results[0]!.value.values.mock.calls[0]![0];
+    expect(execValues.triggeredBy).toBe('user-1');
+    const [, , , userId] = vi.mocked(queueCommand).mock.calls[0]!;
+    expect(userId).toBe('user-1');
   });
 
   it('does not add an $actor key when the script has no bound parameters and the actor IS real', async () => {

--- a/apps/api/src/services/scriptDispatch.ts
+++ b/apps/api/src/services/scriptDispatch.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { and, eq } from 'drizzle-orm';
 import { canonicalizeScriptParameters, hasVariableTokens } from '@breeze/shared';
 
-import { db, withSystemDbAccessContext } from '../db';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { devices, organizations, scriptExecutions, scripts, sites, users } from '../db/schema';
 import {
   claimPendingCommandForDelivery,
@@ -353,16 +353,36 @@ export async function dispatchScriptToDevice(input: DispatchScriptInput): Promis
   // one lookup on whichever is present settles both writes. `createdBy` is
   // preferred as the probe candidate since it is the one that always reaches
   // queueCommand.
+  //
+  // #4299: the probe must ESCAPE the caller's context before opening the
+  // system one. `withDbAccessContext` short-circuits when a store already
+  // exists, so `withSystemDbAccessContext` on its own is a no-op inside a
+  // request — the "system" probe silently inherits the caller's scope. Under
+  // the org-scoped, user-less context `dbAccessContextFromAuth` builds for an
+  // `ai_agent` principal, a partner-level human (`users.org_id IS NULL`)
+  // matches NO branch of the RLS SELECT policy on `users` (partner access is
+  // not granted to an org-scoped caller, the org branch is skipped on a NULL
+  // `org_id`, and `breeze_current_user_id()` is null), so the probe reads zero
+  // rows and degrades a REAL human to NULL on both columns. This path is
+  // FK-safe, so that damage is silent — no 23503, just attribution quietly
+  // lost. `runOutsideDbContext` clears both stores, which is what lets the
+  // nested `withSystemDbAccessContext` open a genuinely fresh system-scoped
+  // transaction. Mirrors the fix shipped for `resolveCommandCreatedBy` in
+  // commandQueue.ts (#4292); note the directly-imported `runOutsideDbContext`
+  // is used, never `db.runOutsideDbContext` (the `db` proxy delegates to the
+  // active transaction, which has no such method).
   const actorCandidateId = input.createdBy ?? input.triggeredBy ?? null;
   const actorIsRealUser = actorCandidateId
-    ? await withSystemDbAccessContext(async () => {
-        const [userRow] = await db
-          .select({ id: users.id })
-          .from(users)
-          .where(eq(users.id, actorCandidateId))
-          .limit(1);
-        return Boolean(userRow);
-      })
+    ? await runOutsideDbContext(() =>
+        withSystemDbAccessContext(async () => {
+          const [userRow] = await db
+            .select({ id: users.id })
+            .from(users)
+            .where(eq(users.id, actorCandidateId))
+            .limit(1);
+          return Boolean(userRow);
+        }),
+      )
     : true;
   const safeTriggeredBy = actorIsRealUser ? input.triggeredBy ?? null : null;
   const safeCreatedBy = actorIsRealUser ? input.createdBy ?? null : null;


### PR DESCRIPTION
Closes #4299

## What was wrong

`apps/api/src/services/scriptDispatch.ts` held a third, independently-written copy of the "is this actor a real `users` row?" probe, and it called `withSystemDbAccessContext` **without first escaping the caller's context**. `runOutsideDbContext` appeared zero times in the file.

`withDbAccessContext` short-circuits when a store already exists, so inside a request-scoped, org-scoped context the "system" probe was not system-scoped at all — it inherited the caller's scope. From the org-scoped, user-less context `dbAccessContextFromAuth` builds for an `ai_agent` principal, a partner-level human (`users.org_id IS NULL`) matches **no** branch of the RLS SELECT policy on `users`:

- `breeze_has_partner_access(partner_id)` — partner access is not granted to an org-scoped caller
- `org_id IS NOT NULL AND breeze_has_org_access(org_id)` — skipped on a NULL `org_id`
- `id = breeze_current_user_id()` — null, the context forces `userId: null`

The probe read zero rows, `actorIsRealUser` came back `false`, and a **real human's attribution was silently degraded to NULL** on both `script_executions.triggered_by` and `device_commands.created_by`, with the id parked in the `$actor` sidecar.

Unlike #3978, this path is FK-safe — there is no 23503 crash. The damage is quieter: script/automation executions attributed to nobody, on an audit-adjacent record, with no error anywhere.

## The fix

One function. Wrap the probe in `runOutsideDbContext` before `withSystemDbAccessContext`, per the documented rule in CLAUDE.md ("call `runOutsideDbContext` first if inside a request"). This mirrors the fix shipped for `resolveCommandCreatedBy` in `commandQueue.ts` (PR #4292).

The directly-imported `runOutsideDbContext` is used, never `db.runOutsideDbContext` — the `db` proxy delegates property lookups to the active transaction, which has no such method (the trap `commandQueue.ts` documents at its `runOutsideDbContextSafe` alias).

Everything else is unchanged: same single probe settling both columns, same degrade semantics, same `degradedActorId` / `$actor` sidecar. No behaviour beyond the context escape moved.

## Test

Added `runs the actor probe OUTSIDE the caller DB context, in a system context` to `scriptDispatch.test.ts` — a nesting-order assertion that the probe opens `runOutsideDbContext`, then `withSystemDbAccessContext`, and lands the `users` read between them, plus an assertion that a real user still survives on both columns.

**Verified red before the fix**, with exactly the regression shape:

```
- "enter-outside",
    "enter-system",
    "users-probe",
    "exit-system",
- "exit-outside",
```

## Scope note (issue item 3, deliberately not done here)

The issue suggested considering whether the three probe copies should converge on one helper. Not done — `commandQueue.ts`'s `resolveCommandCreatedBy` returns a single resolved id, while this site probes one id to settle **two** columns and carries a `degradedActorId` sidecar the command site has no equivalent for. Reusing that helper verbatim would change behaviour beyond the context fix, which is exactly what a tenancy-sensitive change should not do. Convergence is worth its own PR.

## Coverage honesty

`db` is mocked in `scriptDispatch.test.ts`, so this suite proves the **escape happens**, not that Postgres RLS then behaves as described — no policy is evaluated. The real-Postgres proof of the identical escape (a partner-level human kept through an org-scoped, user-less caller context) is the load-bearing test in `__tests__/integration/commandQueueCreatedBy.integration.test.ts`, covering the sibling probe. An equivalent integration suite for the dispatch path was **not** added here: it needs the truncating shared test DB, and this machine currently has many agents running against it.

## Verification

- `pnpm exec vitest run` over 14 affected files (`scriptDispatch`, `scriptExecution`, `sourcedParameters`, all `automationRuntime.*`, `aiToolsScripts.runScript.orgEquality`, `fleetFindings/dispatch`, `commandQueue`, `agentEditionAutoMigrate`) — **432 passed**. The wider sweep matters because adding the `runOutsideDbContext` import breaks any sibling suite whose `../db` mock omits it; none did.
- `tsc --noEmit` on `apps/api` — clean.
- `eslint` on both touched files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMvN6SU3uwaaC7b2xmUa5m