### PR TITLE
fix(api): desktopWs input schema omits key_press, drops paste-as-keystrokes on WS fallback (#4370)

### DIFF
--- a/apps/api/src/routes/desktopWs.ts
+++ b/apps/api/src/routes/desktopWs.ts
@@ -62,9 +62,12 @@ import {
 // Zod validation for desktop user messages.
 // Exported for desktopWs_inputSchema.test.ts, which asserts this enum covers
 // every input kind the Viewer's sendInputFn (apps/viewer/src/components/
-// DesktopViewer.tsx) can emit on the WebSocket fallback transport — the same
-// events the agent's WebRTC-side desktopInputTypes allowlist
-// (agent/internal/heartbeat/handlers_desktop.go) accepts.
+// DesktopViewer.tsx) can emit. Note WebRTC sessions inject input via the
+// user helper's data channel and never reach this schema at all (this route
+// only carries the WebSocket *fallback* transport) — but the agent's own
+// command-relay handler for that fallback path, handleDesktopInput /
+// desktopInputTypes in agent/internal/heartbeat/handlers_desktop.go, accepts
+// the same event kinds, so this enum should stay a superset of that map.
 export const desktopInputEvent = z.object({
   type: z.enum(['mousemove', 'mousedown', 'mouseup', 'keydown', 'keyup', 'wheel', 'click', 'dblclick', 'mouse_move', 'mouse_down', 'mouse_up', 'mouse_scroll', 'key_down', 'key_up', 'key_press']),
   x: z.number().min(-10000).max(100000).optional(),

--- a/apps/api/src/routes/desktopWs.ts
+++ b/apps/api/src/routes/desktopWs.ts
@@ -59,9 +59,14 @@ import {
   type RemoteWsUpgradeContext,
 } from '../services/remoteWsUpgrade';
 
-// Zod validation for desktop user messages
-const desktopInputEvent = z.object({
-  type: z.enum(['mousemove', 'mousedown', 'mouseup', 'keydown', 'keyup', 'wheel', 'click', 'dblclick', 'mouse_move', 'mouse_down', 'mouse_up', 'key_down', 'key_up']),
+// Zod validation for desktop user messages.
+// Exported for desktopWs_inputSchema.test.ts, which asserts this enum covers
+// every input kind the Viewer's sendInputFn (apps/viewer/src/components/
+// DesktopViewer.tsx) can emit on the WebSocket fallback transport — the same
+// events the agent's WebRTC-side desktopInputTypes allowlist
+// (agent/internal/heartbeat/handlers_desktop.go) accepts.
+export const desktopInputEvent = z.object({
+  type: z.enum(['mousemove', 'mousedown', 'mouseup', 'keydown', 'keyup', 'wheel', 'click', 'dblclick', 'mouse_move', 'mouse_down', 'mouse_up', 'mouse_scroll', 'key_down', 'key_up', 'key_press']),
   x: z.number().min(-10000).max(100000).optional(),
   y: z.number().min(-10000).max(100000).optional(),
   button: z.union([z.string().max(20), z.number().int().min(0).max(4)]).optional(),

--- a/apps/api/src/routes/desktopWs_inputSchema.test.ts
+++ b/apps/api/src/routes/desktopWs_inputSchema.test.ts
@@ -110,24 +110,55 @@ import { desktopInputEvent } from './desktopWs';
 // -------------------------------------------------------------------
 // Derive the real set of input kinds the Viewer emits, straight from its
 // source, rather than hardcoding a list here that could silently drift out
-// of sync with apps/viewer. Every `sendInputFn({ type: '<kind>', ... })`
-// call site in DesktopViewer.tsx feeds the WS fallback transport
-// (`wsSession.inputChannel.send`) exactly like it feeds WebRTC — see
-// `sendInputFn` in that file, which branches on transport but sends the
-// same event shape either way.
-function readViewerEmittedInputKinds(): string[] {
-  const here = path.dirname(fileURLToPath(import.meta.url));
-  // apps/api/src/routes -> apps/viewer/src/components/DesktopViewer.tsx
-  const viewerPath = path.resolve(here, '../../../viewer/src/components/DesktopViewer.tsx');
-  const source = readFileSync(viewerPath, 'utf8');
+// of sync with apps/viewer.
+//
+// Two sources feed the WS input channel (`wsSession.inputChannel.send`,
+// inside `sendInputFn` in DesktopViewer.tsx — it branches on transport but
+// sends the same event shape to WS and WebRTC either way):
+//
+//  1. Direct literal calls: `sendInputFn({ type: '<kind>', ... })` in
+//     DesktopViewer.tsx (mouse/keyboard live input).
+//  2. The indirect Paste Text path: DesktopViewer.tsx wires
+//     `sendInput: event => sendInputFn({ ...event })` into `sendPasteText`
+//     (pasteText.ts), which forwards `PasteKeyEvent` objects built by
+//     `textToKeyEvents` in paste.ts. Those events never appear as a literal
+//     `sendInputFn({ type: ... })` call site — an earlier version of this
+//     scraper only caught `key_press` here by coincidence, via unrelated
+//     live-keystroke call sites — so paste.ts is scanned directly for the
+//     `type:` literals it constructs.
+//
+// Deliberately NOT scanned: the many other `{ type: '...' }` messages
+// DesktopViewer.tsx sends over the WebRTC *control* channel via raw
+// `ch.send(...)` (e.g. `list_monitors`, `set_cursor_stream`, `toggle_audio`).
+// Those are WebRTC-exclusive control messages with no WS-fallback
+// counterpart in `desktopMessageSchema` at all, so they're out of scope for
+// this input-event coverage check.
+function readTypeLiterals(source: string, re: RegExp): Set<string> {
   const kinds = new Set<string>();
-  const re = /sendInputFn\(\{\s*type:\s*'([a-z_]+)'/g;
   let match: RegExpExecArray | null;
   while ((match = re.exec(source)) !== null) {
     const kind = match[1];
     if (kind) kinds.add(kind);
   }
-  return Array.from(kinds);
+  return kinds;
+}
+
+function readViewerEmittedInputKinds(): string[] {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  // apps/api/src/routes -> apps/viewer/src/...
+  const viewerRoot = path.resolve(here, '../../../viewer/src');
+
+  const desktopViewerSource = readFileSync(path.join(viewerRoot, 'components/DesktopViewer.tsx'), 'utf8');
+  // Quote- and property-order-agnostic within each sendInputFn({...}) call.
+  const directKinds = readTypeLiterals(
+    desktopViewerSource,
+    /sendInputFn\(\{[^}]*?\btype:\s*['"]([a-zA-Z_]+)['"]/g
+  );
+
+  const pasteSource = readFileSync(path.join(viewerRoot, 'lib/paste.ts'), 'utf8');
+  const pasteKinds = readTypeLiterals(pasteSource, /type:\s*['"]([a-zA-Z_]+)['"]/g);
+
+  return Array.from(new Set([...directKinds, ...pasteKinds]));
 }
 
 describe('desktopWs input schema — Viewer coverage', () => {

--- a/apps/api/src/routes/desktopWs_inputSchema.test.ts
+++ b/apps/api/src/routes/desktopWs_inputSchema.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+// -------------------------------------------------------------------
+// Mocks — must be declared before any import that triggers the modules.
+// Shapes mirror desktopWs.test.ts so module resolution matches; this file
+// only needs desktopInputEvent, but importing desktopWs.ts pulls in its
+// full module graph.
+// -------------------------------------------------------------------
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    select: vi.fn(),
+    update: vi.fn(),
+    insert: vi.fn(),
+  },
+}));
+
+vi.mock('../db/schema', () => ({
+  remoteSessions: { id: 'remoteSessions.id', deviceId: 'remoteSessions.deviceId', status: 'remoteSessions.status', userId: 'remoteSessions.userId' },
+  devices: { id: 'devices.id' },
+  users: { id: 'users.id', status: 'users.status' },
+  patchPolicies: {},
+  alertRules: {},
+  backupConfigs: {},
+  securityPolicies: {},
+  automationPolicies: {},
+  maintenanceWindows: {},
+  softwarePolicies: {},
+  sensitiveDataPolicies: {},
+  peripheralPolicies: {},
+}));
+
+vi.mock('../services/remoteSessionAuth', () => ({
+  consumeWsTicket: vi.fn(),
+  consumeDesktopConnectCode: vi.fn(),
+  createWsTicket: vi.fn(async () => ({ ticket: 'tkt' })),
+  createLegacyViewerCompatibilityWsTicket: vi.fn(),
+  getViewerAccessTokenExpirySeconds: vi.fn(() => 900),
+}));
+
+vi.mock('../services/jwt', () => ({
+  createAccessToken: vi.fn(async () => 'mock-access-token-xyz'),
+  createViewerAccessToken: vi.fn(async () => 'mock-viewer-token'),
+  verifyViewerAccessToken: vi.fn(),
+}));
+
+vi.mock('../services/viewerTokenRevocation', () => ({
+  isViewerJtiRevoked: vi.fn(async () => false),
+  isViewerSessionRevoked: vi.fn(async () => false),
+  revokeViewerSession: vi.fn(async () => undefined),
+}));
+
+vi.mock('./agentWs', () => ({
+  sendCommandToAgent: vi.fn(() => true),
+  isAgentConnected: vi.fn(() => true),
+}));
+
+vi.mock('../services/remoteAccessPolicy', () => ({
+  checkRemoteAccess: vi.fn().mockResolvedValue({ allowed: true }),
+  resolveDesktopSessionPolicy: vi.fn().mockResolvedValue({
+    clipboard: 'both',
+    idleTimeoutMinutes: 5,
+    maxSessionDurationHours: 8,
+  }),
+}));
+
+vi.mock('../services/redis', () => ({
+  getRedis: vi.fn(() => ({})),
+}));
+
+vi.mock('../services/rate-limit', () => ({
+  rateLimiter: vi.fn(async () => ({
+    allowed: true,
+    remaining: 9,
+    resetAt: new Date(Date.now() + 60_000),
+  })),
+}));
+
+vi.mock('./remote/helpers', () => ({
+  logSessionAudit: vi.fn(async () => undefined),
+  getIceServers: vi.fn(() => []),
+  buildRemoteSessionPromptPayload: vi.fn(async () => undefined),
+}));
+
+vi.mock('./remote/schemas', () => ({
+  webrtcOfferSchema: {
+    safeParse: vi.fn(),
+  },
+}));
+
+vi.mock('../services/clientIp', () => ({
+  getTrustedClientIp: vi.fn(() => '127.0.0.1'),
+}));
+
+vi.mock('../services/auditService', () => ({
+  createAuditLogAsync: vi.fn(),
+}));
+
+// -------------------------------------------------------------------
+// Imports (after mocks)
+// -------------------------------------------------------------------
+import { desktopInputEvent } from './desktopWs';
+
+// -------------------------------------------------------------------
+// Derive the real set of input kinds the Viewer emits, straight from its
+// source, rather than hardcoding a list here that could silently drift out
+// of sync with apps/viewer. Every `sendInputFn({ type: '<kind>', ... })`
+// call site in DesktopViewer.tsx feeds the WS fallback transport
+// (`wsSession.inputChannel.send`) exactly like it feeds WebRTC — see
+// `sendInputFn` in that file, which branches on transport but sends the
+// same event shape either way.
+function readViewerEmittedInputKinds(): string[] {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  // apps/api/src/routes -> apps/viewer/src/components/DesktopViewer.tsx
+  const viewerPath = path.resolve(here, '../../../viewer/src/components/DesktopViewer.tsx');
+  const source = readFileSync(viewerPath, 'utf8');
+  const kinds = new Set<string>();
+  const re = /sendInputFn\(\{\s*type:\s*'([a-z_]+)'/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(source)) !== null) {
+    const kind = match[1];
+    if (kind) kinds.add(kind);
+  }
+  return Array.from(kinds);
+}
+
+describe('desktopWs input schema — Viewer coverage', () => {
+  const viewerKinds = readViewerEmittedInputKinds();
+
+  it('source-derived extraction actually found kinds (guards against a silently-vacuous regex)', () => {
+    // Sanity floor: if this regexes to zero, the parametrized assertions
+    // below would vacuously pass on nothing. Fail loudly instead.
+    expect(viewerKinds.length).toBeGreaterThanOrEqual(5);
+    expect(viewerKinds).toEqual(
+      expect.arrayContaining(['key_down', 'key_up', 'key_press', 'mouse_move', 'mouse_down', 'mouse_up', 'mouse_scroll'])
+    );
+  });
+
+  it.each(readViewerEmittedInputKinds())(
+    'WS schema accepts Viewer-emitted input kind %s',
+    (kind) => {
+      const result = desktopInputEvent.safeParse({ type: kind });
+      expect(result.success).toBe(true);
+    }
+  );
+
+  it('rejects an unknown/garbage input kind (schema is not just permissive)', () => {
+    const result = desktopInputEvent.safeParse({ type: 'definitely_not_a_real_kind' });
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #4370

## The bug

`apps/api/src/routes/desktopWs.ts`'s `desktopInputEvent` zod enum omitted `key_press`, which the Viewer's Paste Text path (`apps/viewer/src/lib/paste.ts` `textToKeyEvents`) emits for every pasted character. On the WebSocket fallback transport (used whenever WebRTC isn't available), any input event that fails schema validation is silently dropped — so pasting into a remote session over the WS fallback did nothing at all, independent of the layout-mangling bug that #4352 already fixed for the WebRTC path.

## The fix

Added `key_press` to the enum. While building the schema-coverage regression test the issue asked for, I found `mouse_scroll` was *also* missing — same root cause, silently dropping every scroll-wheel event on the WS fallback (`DesktopViewer.tsx`'s wheel handler calls `sendInputFn({ type: 'mouse_scroll', ... })` regardless of transport). Both `key_press` and `mouse_scroll` are already in the agent's own accepted-input allowlist (`agent/internal/heartbeat/handlers_desktop.go` `desktopInputTypes`), so this brings the API's WS validation back in line with what the Viewer actually sends and the agent actually accepts.

`desktopInputEvent` is now exported so the new test can import it directly.

## Test

`apps/api/src/routes/desktopWs_inputSchema.test.ts` reads `DesktopViewer.tsx`'s source directly and regex-extracts every `sendInputFn({ type: '<kind>', ... })` call site, then asserts the WS schema's `safeParse` accepts each one — a real coverage test (not hardcoded against the fix) that fails loudly if the Viewer ever emits an event kind this schema doesn't know about. A sanity-floor assertion guards against the extraction itself silently returning zero and making the parametrized checks vacuous, plus one negative test confirming the schema still rejects garbage.

## Verification

- Red-first: reverted the schema change, ran the new test → 8/9 failed. Restored the fix → 9/9 passed.
- `apps/api/src/routes/desktopWs*.test.ts` (8 files, 88 tests): all pass — `pnpm exec vitest run src/routes/desktopWs_inputSchema.test.ts src/routes/desktopWs.test.ts src/routes/desktopWs_onmessage.test.ts src/routes/desktopWs_lifecycle.test.ts src/routes/desktopWs_multitenant.test.ts src/routes/desktopWs_onopen.test.ts src/routes/desktopWs_rate_limit_cleanup.test.ts src/routes/desktopWs_utils_http.test.ts --pool=threads --maxWorkers=2`
- `tsc --noEmit -p apps/api` (matches CI's `typecheck` job step): clean.
- `eslint` on both touched files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)