### PR TITLE
fix(extensions): record activeVersion only after built-in activation succeeds (#3468)

### DIFF
--- a/apps/api/src/extensions/builtinExtensions.test.ts
+++ b/apps/api/src/extensions/builtinExtensions.test.ts
@@ -350,6 +350,64 @@ describe('loadBuiltinExtensions', () => {
     expect((await stateStore.get(NAME))?.enabled).toBe(false);
   });
 
+  // Regression for #3468: `activeVersion` must be written to
+  // `installed_extensions` only AFTER `registry.activate()` succeeds, not
+  // observed alongside `configuredVersion` before it runs. Two real built-ins
+  // registered, the second sharing the first's `routeNamespace` so
+  // `ExtensionContributionRegistry.activate` genuinely throws (a real
+  // namespace-collision failure, not a mocked one) partway through the second
+  // builtin's staged pipeline.
+  it('a mid-pipeline activation failure on the second built-in leaves the first correctly active and records no phantom activeVersion for the second', async () => {
+    const NAME_2 = 'demo-builtin-2';
+    const VERSION_2 = '2.0.0';
+    const ENABLE_ENV_VAR_2 = 'BREEZE_DEMO_BUILTIN_2_ENABLED';
+    const builtin2 = fixtureBuiltin({
+      name: NAME_2,
+      enableEnvVar: ENABLE_ENV_VAR_2,
+      // Same NAMESPACE as the first builtin (fixtureManifest's default) —
+      // ExtensionContributionRegistry.activate() throws a real "route
+      // namespace already owned" error for this, once the first builtin is
+      // already active.
+      manifest: fixtureManifest({ name: NAME_2, version: VERSION_2 }),
+    });
+
+    process.env[ENABLE_ENV_VAR_2] = 'true';
+    try {
+      const h = createHarness({ builtins: [fixtureBuiltin(), builtin2] });
+
+      await expect(h.load()).rejects.toThrow(/route namespace .* is already owned by extension "demo-builtin"/i);
+
+      // Full pipeline ran for builtin 1, and got as far as 'activate' (where
+      // it throws) for builtin 2 — nothing downstream of that ran for it.
+      expect(h.calls).toEqual([
+        'migration', 'tenancy', 'stage', 'validate', 'activate', 'web',
+        'migration', 'tenancy', 'stage', 'validate', 'activate',
+      ]);
+
+      // Built-in 1: unaffected by built-in 2's later failure — still
+      // correctly activated with its real active version recorded.
+      const snapshot1 = h.registry.get(NAME);
+      expect(snapshot1?.enabled).toBe(true);
+      expect(snapshot1?.version).toBe(VERSION);
+      const row1 = await h.stateStore.get(NAME);
+      expect(row1?.activeVersion).toBe(VERSION);
+      expect(row1?.lifecycleState).toBe('active');
+
+      // Built-in 2: activate() threw, so it never reached the registry, and
+      // — this is the bug this test guards against — `installed_extensions`
+      // must NOT claim an active version that was never actually activated.
+      // upsertObserved ran (before activate) and seeded configuredVersion,
+      // but recordActive (after activate) never ran.
+      expect(h.registry.get(NAME_2)).toBeUndefined();
+      const row2 = await h.stateStore.get(NAME_2);
+      expect(row2?.configuredVersion).toBe(VERSION_2);
+      expect(row2?.activeVersion).toBeNull();
+      expect(row2?.lifecycleState).toBe('discovered');
+    } finally {
+      delete process.env[ENABLE_ENV_VAR_2];
+    }
+  });
+
   it('registers agent rate-limit skip prefixes when agentRoutes is true', async () => {
     const h = createHarness();
     await h.load();

--- a/apps/api/src/extensions/builtinExtensions.ts
+++ b/apps/api/src/extensions/builtinExtensions.ts
@@ -772,28 +772,35 @@ export async function loadBuiltinExtensions(args: LoadBuiltinExtensionsArgs): Pr
 
       // Seed the persisted row from the manifest's facts. A built-in has no
       // artifact digest or publisher: it is delivered by the core image itself.
-      const existing = await stateStore.get(name);
+      // `activeVersion` is deliberately NOT included here: this observation
+      // runs before registry.activate() below, and writing it here would let a
+      // mid-pipeline activation failure leave the row claiming an active
+      // version that never actually activated. `recordActive`, called only
+      // after activate() succeeds, is the sole writer of `active_version`.
       await stateStore.upsertObserved({
         name,
         configuredVersion: manifest.version,
-        activeVersion: manifest.version,
         manifestApiVersion: manifest.apiVersion,
         serverSdkVersion: manifest.requires.serverSdk,
         webSdkVersion: manifest.requires.webSdk ?? null,
       });
-      // FIRST boot only: default the runtime flag to enabled. On every later
-      // boot the persisted flag is authoritative, so an operator's disable
-      // survives restarts and deploys.
-      if (existing === null) await stateStore.setEnabled(name, true);
 
       // Activation reads the durable flag, so the enabled gate and the
       // platform-admin enable/disable surface behave identically for a
-      // built-in.
+      // built-in. No explicit first-boot `setEnabled(true)` is needed: on
+      // INSERT, `upsertObserved` relies on the `enabled` column's
+      // `default(true)` (db/schema/extensions.ts), and on UPDATE it never
+      // touches `enabled` — so a fresh row is already enabled, and an
+      // existing row's persisted flag (including an operator's disable)
+      // survives restarts and deploys untouched.
       registry.activate({ ...staged, enabled: await stateStore.isEnabled(name) });
       if (staged.routeApp && manifest.agentRoutes === true) {
         ports.registerRateLimitSkip(`/api/v1/ext/${name}/agent/`);
         ports.registerRateLimitSkip(`/api/v1/${manifest.routeNamespace}/agent/`);
       }
+      // activeVersion is recorded here — only after activate() succeeds — so a
+      // mid-pipeline failure never leaves installed_extensions claiming an
+      // active version that was never actually activated.
       await stateStore.recordActive(name, manifest.version);
 
       // NOTE: deliberately no registerExtensionRoot. Fault attribution keys on


### PR DESCRIPTION
## Summary

Follow-up from #3455 (workspace ee-merge), flagged in the final whole-branch review and post-review hardening pass. No behavior bug in practice today — this is lifecycle-state hardening for the staged built-in extension pipeline.

- `installed_extensions.activeVersion` is now written **only after** `registry.activate()` succeeds. Previously it was set in the same `upsertObserved()` call that seeds `configuredVersion`, before `activate()` ran — so a mid-pipeline activation failure could leave a row claiming an active version that was never actually activated. `recordActive()` (already called only after a successful `activate()`) is now the sole writer of `activeVersion`.
- Dropped the redundant first-boot `setEnabled(name, true)` call in `loadBuiltinExtensions`. The `installed_extensions.enabled` column already defaults to `true` on `INSERT` (`db/schema/extensions.ts`), and `upsertObserved`'s `UPDATE` path never touches `enabled` — so the explicit call was a no-op duplicating the DB default (and the `stateStore.get(name)` lookup that gated it is no longer needed either).

## Test plan

- [x] Added a two-builtin mid-pipeline-failure regression test in `apps/api/src/extensions/builtinExtensions.test.ts`: two real built-ins are registered where the second shares the first's `routeNamespace`, so `ExtensionContributionRegistry.activate()` genuinely throws (a real route-namespace-collision error, not a mock) partway through the second builtin's staged pipeline. Asserts the first builtin stays correctly activated (`activeVersion` = its version, `lifecycleState` = `'active'`), and the second's row shows `activeVersion: null` / `lifecycleState: 'discovered'` — i.e. `upsertObserved` seeded it but `recordActive` never ran.
- [x] `pnpm exec vitest run src/extensions/builtinExtensions.test.ts --pool=threads --maxWorkers=2` — 45 passed (all existing tests + the new one).
- [x] `npx tsc --noEmit` in `apps/api` — clean.
- [x] `npx eslint src/extensions/builtinExtensions.ts src/extensions/builtinExtensions.test.ts` — clean.

Closes #3468

🤖 Generated with [Claude Code](https://claude.com/claude-code)