### PR TITLE
fix(api): exclude ws-ticket polling from fallback audit logging (#3991)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -543,6 +543,10 @@ const FALLBACK_AUDIT_EXCLUDE_PREFIXES = [
 ];
 
 const FALLBACK_AUDIT_EXCLUDE_PATHS: RegExp[] = [
+  // Transport-layer ticket mint for the event-stream WebSocket, polled routinely
+  // by the web app. Not a user action — nobody is accountable for it, and it
+  // does not belong in a compliance trail. See issue #3991.
+  /^\/api\/v1\/events\/ws-ticket$/,
   // Agent telemetry endpoints are high-volume and many already emit explicit audit events.
   /^\/api\/v1\/agents\/[^/]+\/heartbeat$/,
   /^\/api\/v1\/agents\/[^/]+\/security\/status$/,

--- a/apps/api/src/index.ws-ticket-audit.test.ts
+++ b/apps/api/src/index.ws-ticket-audit.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const indexSource = readFileSync(new URL('./index.ts', import.meta.url), 'utf8');
+
+function fallbackExcludePathsSource(): string {
+  const match = indexSource.match(
+    /const FALLBACK_AUDIT_EXCLUDE_PATHS: RegExp\[\] = \[(?<entries>[\s\S]*?)\n\];/,
+  );
+  if (!match?.groups?.entries) {
+    throw new Error('Could not locate FALLBACK_AUDIT_EXCLUDE_PATHS');
+  }
+  return match.groups.entries;
+}
+
+// Mirrors the pattern added to FALLBACK_AUDIT_EXCLUDE_PATHS in index.ts. Kept
+// as a literal (not eval'd from source) so this test exercises real regex
+// behaviour without importing index.ts, which has module-load side effects
+// (DB pool creation, server startup).
+const WS_TICKET_EXCLUDE_PATTERN = /^\/api\/v1\/events\/ws-ticket$/;
+
+describe('ws-ticket fallback audit exclusion', () => {
+  it('is present in FALLBACK_AUDIT_EXCLUDE_PATHS (drift guard)', () => {
+    const entries = fallbackExcludePathsSource();
+    expect(entries).toContain(WS_TICKET_EXCLUDE_PATTERN.source);
+  });
+
+  it('matches the ws-ticket route and only that route', () => {
+    expect(WS_TICKET_EXCLUDE_PATTERN.test('/api/v1/events/ws-ticket')).toBe(true);
+    expect(WS_TICKET_EXCLUDE_PATTERN.test('/api/v1/events/subscribe')).toBe(false);
+    expect(WS_TICKET_EXCLUDE_PATTERN.test('/api/v1/events')).toBe(false);
+    expect(WS_TICKET_EXCLUDE_PATTERN.test('/api/v1/events/ws-ticket/extra')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`POST /api/v1/events/ws-ticket` mints a transport-layer WebSocket ticket that the web app requests routinely. The fallback audit middleware was recording it as a user action (`api.post.events.ws-ticket`), but a machine-driven ticket mint isn't a user action — nobody is accountable for it, and it doesn't belong in a compliance trail regardless of row volume.

This adds `ws-ticket` to `FALLBACK_AUDIT_EXCLUDE_PATHS` in `apps/api/src/index.ts`, mirroring how other machine-polling routes (agent heartbeat, telemetry submits, security-status, etc.) are already excluded from the fallback audit middleware.

## Scope

This PR addresses **item 1 only** from #3991: excluding ws-ticket from user audit logging.

**Item 2 remains open and is intentionally NOT done here:** rendering human-readable labels for fallback audit rows instead of raw route templates (e.g. `Api patch orgs :id billing-settings` for a billing-currency change). That's a separate, heavier sweep across the fallback middleware's action-naming and the web Audit Trail rendering — it needs its own PR. The issue should stay open until that's addressed.

## Changes

- `apps/api/src/index.ts`: added `/^\/api\/v1\/events\/ws-ticket$/` to `FALLBACK_AUDIT_EXCLUDE_PATHS`.
- `apps/api/src/index.ws-ticket-audit.test.ts`: new unit test — asserts the exclusion pattern is present in the source (drift guard) and exercises real regex behavior (matches the ws-ticket route only, not sibling `/events/*` routes).

## Test plan

- [x] `pnpm exec vitest run src/index.ws-ticket-audit.test.ts src/index.time-entry-audit.test.ts --pool=threads --maxWorkers=2` — 3 passed
- [x] `npx tsc --noEmit` (apps/api) — clean, exit 0
- [x] `npx eslint src/index.ts src/index.ws-ticket-audit.test.ts` — clean

Closes item 1 of #3991 (item 2 stays open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)