### PR TITLE
fix(api): split remote-access launcher availability from issuance (#3402)

### DIFF
--- a/apps/api/src/routes/devices/core.remoteAccessLaunch.test.ts
+++ b/apps/api/src/routes/devices/core.remoteAccessLaunch.test.ts
@@ -1,33 +1,66 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
+import { getTableName, is, Table } from 'drizzle-orm';
 
 // Hold a configurable partner-settings value the mocked select chain returns.
 // Each test mutates this before calling app.request().
 let mockPartnerSettings: unknown = {};
+
+// A fully chainable, table-aware query-builder stub. Every chain method
+// (from/innerJoin/where/orderBy/limit) returns the same node so any call
+// shape core.ts's GET /devices/:id handler exercises (hardware, network
+// interfaces, metrics, memberships, site, org, partner settings) resolves
+// without throwing, instead of crashing partway through on an unmocked
+// chain shape (which previously meant the GET handler never reached the
+// launcher-availability code at all -- see #3402). The only query that
+// needs a real answer is the partner-settings lookup keyed off `.from(partners)`;
+// everything else safely resolves to an empty array.
+function makeSelectMock() {
+  return vi.fn(() => {
+    let fromTableName: string | null = null;
+    const resolveRows = (): unknown[] =>
+      fromTableName === 'partners' ? [{ settings: mockPartnerSettings }] : [];
+    const node: any = {
+      from: vi.fn((table: unknown) => {
+        try {
+          fromTableName = is(table, Table) ? getTableName(table as Table) : null;
+        } catch {
+          fromTableName = null;
+        }
+        return node;
+      }),
+      innerJoin: vi.fn(() => node),
+      where: vi.fn(() => node),
+      orderBy: vi.fn(() => node),
+      limit: vi.fn(async () => resolveRows()),
+      then: (resolve: (v: unknown[]) => unknown, reject?: (e: unknown) => unknown) =>
+        Promise.resolve(resolveRows()).then(resolve, reject),
+    };
+    return node;
+  });
+}
 
 vi.mock('../../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
   withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
   withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
-    select: vi.fn(() => ({
-      from: vi.fn(() => ({
-        innerJoin: vi.fn(() => ({
-          where: vi.fn(() => ({
-            limit: vi.fn(async () => [{ settings: mockPartnerSettings }])
-          }))
-        })),
-        where: vi.fn(() => ({
-          limit: vi.fn(async () => [])
-        }))
-      }))
-    })),
+    select: makeSelectMock(),
   }
 }));
 
 vi.mock('../../db/schema', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
   return { ...actual };
+});
+
+// Wraps the REAL decryptForColumn so existing behavior (encrypt-at-rest
+// no-op for plaintext) is unchanged, while letting tests assert on whether
+// it was invoked at all -- the whole point of #3402's availability/issuance
+// split.
+vi.mock('../../services/secretCrypto', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, decryptForColumn: vi.fn(actual.decryptForColumn as (...args: unknown[]) => unknown) };
 });
 
 vi.mock('../../middleware/auth', () => ({
@@ -97,6 +130,7 @@ import { getDeviceWithOrgCheck, getDeviceWithOrgAndSiteCheck } from './helpers';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { captureException } from '../../services/sentry';
 import { requirePermission, requireMfa } from '../../middleware/auth';
+import { decryptForColumn } from '../../services/secretCrypto';
 
 // Snapshot mock.calls captured at module-load time (i.e. when core.ts ran its
 // route registrations). beforeEach() clears mock state, so we cannot read these
@@ -318,13 +352,138 @@ describe('POST /devices/:id/remote-access-launch', () => {
       method: 'GET',
       headers: { Authorization: 'Bearer token' }
     });
-    // The GET handler does multiple DB lookups we haven't fully mocked here
-    // (deviceMetrics, sites, organizations), so the status may be 500. What
-    // matters for this test is that even if it somehow returned 200, the
-    // response body MUST NOT contain remoteAccessLaunchUrl.
     if (res.status === 200) {
       const body = await res.json() as Record<string, unknown>;
       expect(body).not.toHaveProperty('remoteAccessLaunchUrl');
     }
+  });
+
+  // -----------------------------------------------------------------------
+  // #3402: GET /devices/:id must resolve `hasRemoteAccessLauncher` via the
+  // availability-only path (no decrypt, no substitution), while POST
+  // /devices/:id/remote-access-launch (issuance) still decrypts to build
+  // the real launch URL. decryptForColumn is wrapped (not stubbed) at the
+  // top of this file so real behavior is unchanged and we can assert on
+  // invocation.
+  // -----------------------------------------------------------------------
+  describe('#3402 — availability (GET) never decrypts; issuance (POST) does', () => {
+    const provider = {
+      id: 'rustdesk',
+      name: 'RustDesk',
+      urlTemplate: 'rustdesk://{id}?password={password}',
+      customFieldKey: 'rustdesk_id',
+      password: 'p#x',
+      enabled: true,
+    };
+
+    it('GET /devices/:id resolves hasRemoteAccessLauncher=true WITHOUT ever calling decryptForColumn', async () => {
+      vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({
+        id: deviceId,
+        orgId: 'org-123',
+        hostname: 'host-1',
+        siteId: 'site-1',
+        customFields: { rustdesk_id: '294064193' }
+      } as never);
+      setPartnerSettings({
+        remoteAccessProviders: { defaultProviderId: 'rustdesk', providers: [provider] }
+      });
+
+      const res = await app.request(`/devices/${deviceId}`, {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' }
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json() as { hasRemoteAccessLauncher?: boolean; remoteAccessLaunchSkipReason?: unknown };
+      expect(body.hasRemoteAccessLauncher).toBe(true);
+      expect(body.remoteAccessLaunchSkipReason).toBeNull();
+
+      // The whole point of the split: the GET path must never touch the
+      // password-bearing decrypt call.
+      expect(decryptForColumn).not.toHaveBeenCalled();
+    });
+
+    it('GET /devices/:id sets skipReason=missing_device_identifier without decrypting, matching what POST would report', async () => {
+      vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({
+        id: deviceId,
+        orgId: 'org-123',
+        hostname: 'host-1',
+        siteId: 'site-1',
+        customFields: {}
+      } as never);
+      setPartnerSettings({
+        remoteAccessProviders: { defaultProviderId: 'rustdesk', providers: [provider] }
+      });
+
+      const res = await app.request(`/devices/${deviceId}`, {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' }
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json() as { hasRemoteAccessLauncher?: boolean; remoteAccessLaunchSkipReason?: unknown };
+      expect(body.hasRemoteAccessLauncher).toBe(false);
+      expect(body.remoteAccessLaunchSkipReason).toBe('missing_device_identifier');
+      expect(decryptForColumn).not.toHaveBeenCalled();
+    });
+
+    it('POST /devices/:id/remote-access-launch (issuance) DOES call decryptForColumn to build the URL', async () => {
+      vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({
+        id: deviceId,
+        orgId: 'org-123',
+        hostname: 'host-1',
+        siteId: 'site-1',
+        customFields: { rustdesk_id: '294064193' }
+      } as never);
+      vi.mocked(getDeviceWithOrgCheck).mockResolvedValue({
+        id: deviceId,
+        orgId: 'org-123',
+        hostname: 'host-1',
+        customFields: { rustdesk_id: '294064193' }
+      } as never);
+      setPartnerSettings({
+        remoteAccessProviders: { defaultProviderId: 'rustdesk', providers: [provider] }
+      });
+
+      const res = await app.request(`/devices/${deviceId}/remote-access-launch`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' }
+      });
+      expect(res.status).toBe(200);
+      expect(decryptForColumn).toHaveBeenCalledWith('partners', 'settings', 'p#x');
+    });
+
+    it('GET availability and POST issuance agree on skip reason for the same missing-provider config', async () => {
+      const missingConfig = { remoteAccessProviders: {} };
+
+      vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({
+        id: deviceId,
+        orgId: 'org-123',
+        hostname: 'host-1',
+        siteId: 'site-1',
+        customFields: { rustdesk_id: '294064193' }
+      } as never);
+      vi.mocked(getDeviceWithOrgCheck).mockResolvedValue({
+        id: deviceId,
+        orgId: 'org-123',
+        hostname: 'host-1',
+        customFields: { rustdesk_id: '294064193' }
+      } as never);
+      setPartnerSettings(missingConfig);
+
+      const getRes = await app.request(`/devices/${deviceId}`, {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' }
+      });
+      expect(getRes.status).toBe(200);
+      const getBody = await getRes.json() as { remoteAccessLaunchSkipReason?: unknown };
+      expect(getBody.remoteAccessLaunchSkipReason).toBe('no_provider_configured');
+
+      const postRes = await app.request(`/devices/${deviceId}/remote-access-launch`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' }
+      });
+      expect(postRes.status).toBe(404);
+      const postBody = await postRes.json() as { code?: string };
+      expect(postBody.code).toBe('no_provider_configured');
+    });
   });
 });

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -55,7 +55,9 @@ import { deleteDeviceCascade } from '../../services/deviceDeletion';
 import { resolveRemoteAccessForDevice } from '../../services/remoteAccessPolicy';
 import {
   resolveRemoteAccessLaunch,
+  checkRemoteAccessLaunchAvailability,
   type RemoteAccessLaunchResult,
+  type RemoteAccessLaunchAvailability,
   type RemoteAccessLaunchSkipReason,
 } from '../../services/remoteAccessLauncher';
 import { captureException } from '../../services/sentry';
@@ -1111,29 +1113,32 @@ coreRoutes.get(
 
     // Resolve whether a third-party remote-tool launcher (RustDesk,
     // ScreenConnect, TeamViewer, etc.) is configured and usable for this
-    // device. We DO NOT return the substituted launch URL here. That is
-    // issued by POST /devices/:id/remote-access-launch on click so the
-    // password-bearing URL is never broadcast in detail-fetch responses.
-    // The flags below only tell the UI whether to render the launcher
-    // button and what to surface if the configuration is wrong.
+    // device. This is an AVAILABILITY check only -- it never decrypts the
+    // provider password or substitutes the template, so it does not build
+    // (or discard) a credential-bearing URL. The actual launch URL is only
+    // ever issued by POST /devices/:id/remote-access-launch on click, so the
+    // password-bearing URL is never broadcast in detail-fetch responses and
+    // never even materialized for a GET. See issue #3402.
     //
     // Skip-reason vocabulary lets the UI distinguish expected-empty
     // ('no_provider_configured'), configuration error ('config_error'),
     // and a potential security event ('scheme_not_allowed': partner
     // template was tampered to resolve to a disallowed scheme only after
-    // substitution).
+    // substitution) -- though `scheme_not_allowed` can only ever be
+    // observed by the issuance path (POST), since detecting it requires the
+    // substitution this availability check deliberately skips.
     let hasRemoteAccessLauncher = false;
     let remoteAccessLaunchSkipReason: RemoteAccessLaunchSkipReason | 'config_error' | null = null;
     try {
-      const launcher = await resolveRemoteAccessLauncherForDevice(
+      const availability = await checkRemoteAccessLauncherAvailabilityForDevice(
         device.orgId,
         device.customFields as Record<string, unknown> | null,
         auth,
       );
-      if (launcher.launchUrl) {
+      if (availability.available) {
         hasRemoteAccessLauncher = true;
       } else {
-        remoteAccessLaunchSkipReason = launcher.skipReason;
+        remoteAccessLaunchSkipReason = availability.skipReason;
       }
     } catch (err) {
       captureException(err, c);
@@ -1157,16 +1162,6 @@ coreRoutes.get(
   }
 );
 
-/**
- * Look up the partner's remote-access launcher config for a device and
- * return the structured result describing whether a launch URL is available.
- *
- * The partners table has partner-axis RLS, and the request scope is the
- * user's (organization or partner), not the partner whose settings we
- * need. We wrap the lookup in a system-scope DB context so the policy
- * engine doesn't filter the row out. This mirrors how remoteAccessPolicy.ts
- * uses systemAuth for the same reason.
- */
 /**
  * Read the acting technician's preferred provider id, if any.
  *
@@ -1196,11 +1191,23 @@ async function readPreferredProviderId(auth: AuthContext): Promise<string | null
   return typeof value === 'string' && value.length > 0 ? value : null;
 }
 
-async function resolveRemoteAccessLauncherForDevice(
+/**
+ * Loads the pieces every launcher call needs -- the tenant's configured
+ * providers and the acting technician's preference -- without touching
+ * credentials. Shared by both the availability check (GET) and the issuance
+ * path (POST) so they evaluate the exact same provider selection; see the
+ * skew case called out in issue #3402.
+ *
+ * The partners table has partner-axis RLS, and the request scope is the
+ * user's (organization or partner), not the partner whose settings we need.
+ * We wrap the lookup in a system-scope DB context so the policy engine
+ * doesn't filter the row out. This mirrors how remoteAccessPolicy.ts uses
+ * systemAuth for the same reason.
+ */
+async function loadRemoteAccessLauncherContext(
   orgId: string,
-  customFields: Record<string, unknown> | null,
   auth?: AuthContext,
-): Promise<RemoteAccessLaunchResult> {
+): Promise<{ providers: InheritableRemoteAccessSettings | undefined; preferredProviderId: string | null }> {
   const partnerSettings = await withSystemDbAccessContext(async () => {
     const [partnerRow] = await db
       .select({ settings: partners.settings })
@@ -1210,9 +1217,34 @@ async function resolveRemoteAccessLauncherForDevice(
       .limit(1);
     return (partnerRow?.settings ?? {}) as PartnerSettings;
   });
-  const providers: InheritableRemoteAccessSettings | undefined =
-    partnerSettings.remoteAccessProviders;
   const preferredProviderId = auth ? await readPreferredProviderId(auth) : null;
+  return { providers: partnerSettings.remoteAccessProviders, preferredProviderId };
+}
+
+/**
+ * Availability-only check: would a launch URL resolve for this device? Never
+ * decrypts the provider password or substitutes the template. This is the
+ * ONLY launcher entry point GET /devices/:id should call.
+ */
+async function checkRemoteAccessLauncherAvailabilityForDevice(
+  orgId: string,
+  customFields: Record<string, unknown> | null,
+  auth?: AuthContext,
+): Promise<RemoteAccessLaunchAvailability> {
+  const { providers, preferredProviderId } = await loadRemoteAccessLauncherContext(orgId, auth);
+  return checkRemoteAccessLaunchAvailability({ customFields }, providers, preferredProviderId);
+}
+
+/**
+ * Issuance: resolves (and returns) the substituted, credential-bearing
+ * launch URL. Only POST /devices/:id/remote-access-launch may call this.
+ */
+async function resolveRemoteAccessLauncherForDevice(
+  orgId: string,
+  customFields: Record<string, unknown> | null,
+  auth?: AuthContext,
+): Promise<RemoteAccessLaunchResult> {
+  const { providers, preferredProviderId } = await loadRemoteAccessLauncherContext(orgId, auth);
   return resolveRemoteAccessLaunch({ customFields }, providers, preferredProviderId);
 }
 

--- a/apps/api/src/services/remoteAccessLauncher.test.ts
+++ b/apps/api/src/services/remoteAccessLauncher.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, beforeAll } from 'vitest';
-import { buildRemoteAccessLaunchUrl, resolveRemoteAccessLaunch } from './remoteAccessLauncher';
+import {
+  buildRemoteAccessLaunchUrl,
+  resolveRemoteAccessLaunch,
+  checkRemoteAccessLaunchAvailability,
+} from './remoteAccessLauncher';
 import { encryptSecret } from './secretCrypto';
 import type { InheritableRemoteAccessSettings, RemoteAccessProvider } from '@breeze/shared';
 
@@ -333,5 +337,126 @@ describe('resolveRemoteAccessLaunch — per-technician provider preference', () 
     const r = resolveRemoteAccessLaunch({ customFields: { k: 'avas' } }, sneaky, 'sneaky');
     expect(r.launchUrl).toBeNull();
     expect(r.skipReason).toBe('scheme_not_allowed');
+  });
+});
+
+// -----------------------------------------------------------------------
+// checkRemoteAccessLaunchAvailability (#3402)
+//
+// The availability check is the ONLY launcher entry point GET
+// /devices/:id may call. It must never decrypt or substitute (covered by
+// a spy in core.remoteAccessLaunch.test.ts), and it must agree with
+// resolveRemoteAccessLaunch (issuance) on every skip reason EXCEPT
+// 'scheme_not_allowed', which by construction only exists once the
+// template has actually been substituted with the real password -- work
+// availability deliberately never does.
+// -----------------------------------------------------------------------
+describe('checkRemoteAccessLaunchAvailability — parity with issuance', () => {
+  const scenarios: Array<{
+    name: string;
+    device: { customFields?: Record<string, unknown> | null };
+    settings: InheritableRemoteAccessSettings | undefined;
+    preferredProviderId?: string | null;
+  }> = [
+    {
+      name: 'no settings at all',
+      device: { customFields: { rustdesk_id: '1' } },
+      settings: undefined,
+    },
+    {
+      name: 'empty settings object',
+      device: { customFields: { rustdesk_id: '1' } },
+      settings: {},
+    },
+    {
+      name: 'unknown defaultProviderId',
+      device: { customFields: { rustdesk_id: '1' } },
+      settings: { ...rustdeskSettings, defaultProviderId: 'nonexistent' },
+    },
+    {
+      name: 'default provider disabled',
+      device: { customFields: { rustdesk_id: '1' } },
+      settings: { ...rustdeskSettings, providers: [{ ...baseProvider, enabled: false }] },
+    },
+    {
+      name: 'device missing the custom field the provider needs',
+      device: { customFields: {} },
+      settings: rustdeskSettings,
+    },
+    {
+      name: 'device custom field is an empty string',
+      device: { customFields: { rustdesk_id: '' } },
+      settings: rustdeskSettings,
+    },
+    {
+      name: 'empty url template',
+      device: { customFields: { rustdesk_id: '1' } },
+      settings: { ...rustdeskSettings, providers: [{ ...baseProvider, urlTemplate: '' }] },
+    },
+    {
+      name: 'happy path — resolves',
+      device: { customFields: { rustdesk_id: '294064193' } },
+      settings: rustdeskSettings,
+    },
+    {
+      name: 'preference falls back to default (unknown preferred id)',
+      device: { customFields: { rustdesk_id: '294064193' } },
+      settings: rustdeskSettings,
+      preferredProviderId: 'not-a-real-provider',
+    },
+    {
+      name: 'preference selects the other enabled provider',
+      device: { customFields: { rustdesk_id: '294064193', mesh_node_id: 'abc123' } },
+      settings: {
+        defaultProviderId: 'rustdesk',
+        providers: [
+          baseProvider,
+          {
+            id: 'mesh',
+            name: 'Mesh',
+            urlTemplate: 'https://mesh.example.test/#device={id}',
+            customFieldKey: 'mesh_node_id',
+            enabled: true,
+          },
+        ],
+      },
+      preferredProviderId: 'mesh',
+    },
+  ];
+
+  it.each(scenarios)('$name: availability and issuance agree', ({ device, settings, preferredProviderId }) => {
+    const availability = checkRemoteAccessLaunchAvailability(device, settings, preferredProviderId);
+    const issuance = resolveRemoteAccessLaunch(device, settings, preferredProviderId);
+
+    expect(availability.skipReason).toBe(issuance.skipReason);
+    expect(availability.providerId).toBe(issuance.providerId);
+    expect(availability.available).toBe(issuance.launchUrl !== null);
+  });
+
+  it('never returns scheme_not_allowed — that is issuance-only, since it requires substitution', () => {
+    const sneaky: InheritableRemoteAccessSettings = {
+      defaultProviderId: 'sneaky',
+      providers: [
+        { id: 'sneaky', name: 'Sneaky', urlTemplate: 'j{id}cript:alert(1)', customFieldKey: 'k', enabled: true },
+      ],
+    };
+    const device = { customFields: { k: 'avas' } };
+
+    const availability = checkRemoteAccessLaunchAvailability(device, sneaky);
+    expect(availability.available).toBe(true);
+    expect(availability.skipReason).toBeNull();
+
+    // Issuance, which DOES substitute, catches the tampered template.
+    const issuance = resolveRemoteAccessLaunch(device, sneaky);
+    expect(issuance.skipReason).toBe('scheme_not_allowed');
+    expect(issuance.launchUrl).toBeNull();
+  });
+
+  it('reports available:true with the resolved providerId on the happy path', () => {
+    const availability = checkRemoteAccessLaunchAvailability(
+      { customFields: { rustdesk_id: '294064193' } },
+      rustdeskSettings,
+    );
+    expect(availability).toEqual({ available: true, providerId: 'rustdesk', skipReason: null });
   });
 });

--- a/apps/api/src/services/remoteAccessLauncher.ts
+++ b/apps/api/src/services/remoteAccessLauncher.ts
@@ -20,10 +20,103 @@ export interface RemoteAccessLaunchResult {
   skipReason: RemoteAccessLaunchSkipReason | null;
 }
 
+// Availability is the subset of RemoteAccessLaunchResult that can be
+// determined WITHOUT decrypting the provider password or substituting the
+// template: provider exists, is enabled, the device carries the identifier
+// the provider needs, and the template is non-empty. There is deliberately
+// no `launchUrl` or `scheme` field here, and `skipReason` can never be
+// `scheme_not_allowed` — that reason only exists once the template has
+// actually been substituted with the real (decrypted) password, which is
+// issuance-only work. See `checkRemoteAccessLaunchAvailability` below.
+export interface RemoteAccessLaunchAvailability {
+  available: boolean;
+  providerId: string | null;
+  skipReason: RemoteAccessLaunchSkipReason | null;
+}
+
 function extractScheme(url: string): string | null {
   const colon = url.indexOf(':');
   if (colon <= 0) return null;
   return url.slice(0, colon).toLowerCase();
+}
+
+// Selects which configured provider a launch would use: the technician's
+// preference if it names a provider this tenant has and is enabled,
+// otherwise the tenant default. Shared by both the availability check and
+// the issuance path so the two can never disagree about *which* provider
+// they're evaluating.
+function selectRemoteAccessProvider(
+  remoteAccess: InheritableRemoteAccessSettings | undefined | null,
+  preferredProviderId?: string | null,
+): { provider: RemoteAccessProvider | null; skipReason: RemoteAccessLaunchSkipReason | null } {
+  if (!remoteAccess?.providers?.length) {
+    return { provider: null, skipReason: 'no_provider_configured' };
+  }
+
+  // A preference only counts when it names a provider this tenant actually has
+  // AND that provider is enabled. Anything else -- unknown id, id belonging to
+  // another tenant, provider since disabled or deleted -- falls through to the
+  // tenant default rather than failing the launch, so a stale preference degrades
+  // quietly instead of stranding the technician.
+  const preferred: RemoteAccessProvider | undefined = preferredProviderId
+    ? remoteAccess.providers.find((p) => p.id === preferredProviderId && p.enabled)
+    : undefined;
+
+  const targetId = preferred?.id ?? remoteAccess.defaultProviderId;
+  if (!targetId) {
+    return { provider: null, skipReason: 'no_provider_configured' };
+  }
+
+  const provider = remoteAccess.providers.find((p) => p.id === targetId);
+  if (!provider) {
+    return { provider: null, skipReason: 'no_provider_configured' };
+  }
+  return { provider, skipReason: null };
+}
+
+// Everything the availability check and the issuance path share, up to (but
+// NOT including) password decryption and template substitution. This is the
+// single source of truth for the pre-decrypt checks so availability and
+// issuance can't drift apart on skip-reason vocabulary.
+function evaluateRemoteAccessLaunchAvailability(
+  device: { customFields?: Record<string, unknown> | null },
+  remoteAccess: InheritableRemoteAccessSettings | undefined | null,
+  preferredProviderId?: string | null,
+): { provider: RemoteAccessProvider | null; idValue: string | null; skipReason: RemoteAccessLaunchSkipReason | null } {
+  const { provider, skipReason } = selectRemoteAccessProvider(remoteAccess, preferredProviderId);
+  if (!provider) {
+    return { provider: null, idValue: null, skipReason };
+  }
+  if (!provider.enabled) {
+    return { provider, idValue: null, skipReason: 'provider_disabled' };
+  }
+
+  const idValue = device.customFields?.[provider.customFieldKey];
+  if (typeof idValue !== 'string' || idValue.length === 0) {
+    return { provider, idValue: null, skipReason: 'missing_device_identifier' };
+  }
+  if (!provider.urlTemplate) {
+    return { provider, idValue, skipReason: 'empty_url_template' };
+  }
+  return { provider, idValue, skipReason: null };
+}
+
+// Checks whether a launch URL WOULD resolve for this device, without
+// decrypting the provider password or substituting the template. This is the
+// only launcher entry point the device-detail GET should call — it answers
+// "should the Connect Desktop button render" without touching credentials.
+// See issue #3402.
+export function checkRemoteAccessLaunchAvailability(
+  device: { customFields?: Record<string, unknown> | null },
+  remoteAccess: InheritableRemoteAccessSettings | undefined | null,
+  preferredProviderId?: string | null,
+): RemoteAccessLaunchAvailability {
+  const result = evaluateRemoteAccessLaunchAvailability(device, remoteAccess, preferredProviderId);
+  return {
+    available: result.skipReason === null,
+    providerId: result.provider?.id ?? null,
+    skipReason: result.skipReason,
+  };
 }
 
 // Build the launch URL the Connect Desktop button should fire for a device,
@@ -63,40 +156,17 @@ export function resolveRemoteAccessLaunch(
   // or a destination -- which is what keeps the javascript: guard below meaningful.
   preferredProviderId?: string | null,
 ): RemoteAccessLaunchResult {
-  if (!remoteAccess?.providers?.length) {
-    return { launchUrl: null, providerId: null, scheme: null, skipReason: 'no_provider_configured' };
-  }
-
-  // A preference only counts when it names a provider this tenant actually has
-  // AND that provider is enabled. Anything else -- unknown id, id belonging to
-  // another tenant, provider since disabled or deleted -- falls through to the
-  // tenant default rather than failing the launch, so a stale preference degrades
-  // quietly instead of stranding the technician.
-  const preferred: RemoteAccessProvider | undefined = preferredProviderId
-    ? remoteAccess.providers.find((p) => p.id === preferredProviderId && p.enabled)
-    : undefined;
-
-  const targetId = preferred?.id ?? remoteAccess.defaultProviderId;
-  if (!targetId) {
-    return { launchUrl: null, providerId: null, scheme: null, skipReason: 'no_provider_configured' };
-  }
-
-  const provider: RemoteAccessProvider | undefined = remoteAccess.providers.find(
-    (p) => p.id === targetId,
+  // Runs the same pre-decrypt checks `checkRemoteAccessLaunchAvailability`
+  // uses (provider selection, enabled, identifier present, template
+  // non-empty) so issuance can never disagree with availability on any of
+  // these skip reasons -- they share one implementation.
+  const { provider, idValue, skipReason } = evaluateRemoteAccessLaunchAvailability(
+    device,
+    remoteAccess,
+    preferredProviderId,
   );
-  if (!provider) {
-    return { launchUrl: null, providerId: null, scheme: null, skipReason: 'no_provider_configured' };
-  }
-  if (!provider.enabled) {
-    return { launchUrl: null, providerId: provider.id, scheme: null, skipReason: 'provider_disabled' };
-  }
-
-  const idValue = device.customFields?.[provider.customFieldKey];
-  if (typeof idValue !== 'string' || idValue.length === 0) {
-    return { launchUrl: null, providerId: provider.id, scheme: null, skipReason: 'missing_device_identifier' };
-  }
-  if (!provider.urlTemplate) {
-    return { launchUrl: null, providerId: provider.id, scheme: null, skipReason: 'empty_url_template' };
+  if (skipReason !== null || !provider || idValue === null) {
+    return { launchUrl: null, providerId: provider?.id ?? null, scheme: null, skipReason };
   }
 
   // Decrypt the provider password before substitution. Provider passwords


### PR DESCRIPTION
## Summary

GET /devices/:id resolved the *full* launcher — decrypting the provider password and building the substituted launch URL via `resolveRemoteAccessLauncherForDevice` — purely to compute the `hasRemoteAccessLauncher` boolean, then discarded the URL (`apps/api/src/routes/devices/core.ts:1125-1136`, pre-fix). That ran a decrypt (`decryptForColumn`) on every device-detail page load for no reason.

This splits `apps/api/src/services/remoteAccessLauncher.ts` into two entry points that share one internal pre-decrypt implementation:

- `checkRemoteAccessLaunchAvailability` — provider selection, enabled check, device-identifier presence, template non-empty. **No decrypt, no substitution.** This is now the *only* launcher call GET `/devices/:id` makes.
- `resolveRemoteAccessLaunch` — unchanged issuance path (decrypts the provider password, substitutes the template, re-checks the substituted scheme). Still the only thing POST `/devices/:id/remote-access-launch` calls.

Both call a shared internal `evaluateRemoteAccessLaunchAvailability` (provider selection + enabled/identifier/template checks) so availability and issuance can never disagree on skip-reason vocabulary or on *which* provider they're evaluating (the skew case called out in the issue: availability must pick the same provider issuance would, including the per-technician preference from #3391).

The one asymmetry, by design: `scheme_not_allowed` can only ever be reported by issuance, since detecting a template that resolves to a disallowed scheme requires substituting the real (decrypted) password — work availability deliberately skips. Availability's `skipReason` type therefore never includes it.

`apps/api/src/routes/devices/core.ts` now has three helpers instead of one: `loadRemoteAccessLauncherContext` (shared partner-settings + preference lookup, still wrapped in `withSystemDbAccessContext` for the partner-axis RLS reason documented inline), `checkRemoteAccessLauncherAvailabilityForDevice` (GET), and `resolveRemoteAccessLauncherForDevice` (POST, unchanged behavior).

## Test plan

- [x] `apps/api/src/services/remoteAccessLauncher.test.ts` — new `checkRemoteAccessLaunchAvailability` parity suite: a table-driven test asserting availability and issuance agree on `skipReason`/`providerId`/available-vs-launchUrl across every skip-reason scenario (no provider, unknown default, disabled provider, missing identifier, empty template, happy path, preference selection/fallback), plus an explicit test that `scheme_not_allowed` is issuance-only.
- [x] `apps/api/src/routes/devices/core.remoteAccessLaunch.test.ts` — new suite asserting GET `/devices/:id` resolves `hasRemoteAccessLauncher`/`remoteAccessLaunchSkipReason` correctly **without ever invoking `decryptForColumn`**, while POST `/devices/:id/remote-access-launch` still does (wrapped, not stubbed, so real crypto behavior is unchanged). Also rebuilt the file's DB mock to be a table-aware chainable stub so the GET handler actually reaches 200 in tests instead of previously crashing partway through on an unmocked query shape (the old test tolerated a 500).
- [x] `pnpm exec vitest run src/services/remoteAccessLauncher.test.ts src/routes/devices/core.remoteAccessLaunch.test.ts --pool=threads --maxWorkers=2` — 46/46 passed.
- [x] `npx tsc --noEmit` (apps/api) — clean.
- [x] `npx eslint` on all four touched files — clean.

Closes #3402

🤖 Generated with [Claude Code](https://claude.com/claude-code)