### PR TITLE
fix(api): un-export resolveUserDisplayNames RLS-bypassing name oracle (#3983)

### DIFF
--- a/apps/api/src/routes/alerts/actorNames.test.ts
+++ b/apps/api/src/routes/alerts/actorNames.test.ts
@@ -87,7 +87,10 @@ describe('resolveUserDisplayNames (via withAlertActorNames)', () => {
       { id: 'alert-2', acknowledgedBy: ADMIN_ID, resolvedBy: ADMIN_ID },
     ]);
 
-    expect(enriched.every((row) => row.acknowledgedByName === 'Breeze Admin')).toBe(true);
+    expect(enriched.map((row) => row.acknowledgedByName)).toEqual([
+      'Breeze Admin',
+      'Breeze Admin',
+    ]);
 
     // Assert the compiled SQL, not just that `where` was called: a mock-only
     // assertion would pass on an empty or wrong-column predicate.

--- a/apps/api/src/routes/alerts/actorNames.test.ts
+++ b/apps/api/src/routes/alerts/actorNames.test.ts
@@ -22,7 +22,7 @@ vi.mock('../../db', () => ({
 
 vi.mock('../../services/sentry', () => ({ captureException: captureExceptionMock }));
 
-import { resolveUserDisplayNames, withAlertActorNames } from './actorNames';
+import { withAlertActorNames } from './actorNames';
 
 const ADMIN_ID = '9cea2f85-2da1-445d-88cc-7c404d7504c4';
 const TECH_ID = '1f0e3f2c-9a2b-4c7d-9f10-8f6a2b3c4d5e';
@@ -54,13 +54,25 @@ beforeEach(() => {
   withSystemDbAccessContextMock.mockImplementation(async (fn: () => unknown) => fn());
 });
 
-describe('resolveUserDisplayNames', () => {
-  it('does not touch the database when there is no actor id to resolve', async () => {
+// resolveUserDisplayNames is intentionally module-private (#3983): it's an
+// RLS-bypassing name oracle and withAlertActorNames is its only legitimate
+// caller. Exercise its behavior only through that public entry point so a
+// future contributor can't reach for it directly off a passing test.
+describe('resolveUserDisplayNames (via withAlertActorNames)', () => {
+  it('does not touch the database when no row carries a resolvable actor id', async () => {
     mockUsersQuery([]);
 
-    const names = await resolveUserDisplayNames([null, undefined, '']);
+    const [alert] = await withAlertActorNames([
+      { id: 'alert-1', acknowledgedBy: null, resolvedBy: undefined, dismissedBy: '' },
+    ]);
 
-    expect(names.size).toBe(0);
+    expect(alert).toEqual(
+      expect.objectContaining({
+        acknowledgedByName: null,
+        resolvedByName: null,
+        dismissedByName: null,
+      })
+    );
     expect(selectMock).not.toHaveBeenCalled();
     expect(withSystemDbAccessContextMock).not.toHaveBeenCalled();
   });
@@ -68,10 +80,14 @@ describe('resolveUserDisplayNames', () => {
   it('selects only id + name and filters on the distinct actor ids', async () => {
     mockUsersQuery([{ id: ADMIN_ID, name: 'Breeze Admin' }]);
 
-    // ADMIN_ID appears three times — the query must ask for it once.
-    const names = await resolveUserDisplayNames([ADMIN_ID, ADMIN_ID, null, ADMIN_ID]);
+    // ADMIN_ID appears three times across these rows — the query must ask for
+    // it once.
+    const enriched = await withAlertActorNames([
+      { id: 'alert-1', acknowledgedBy: ADMIN_ID, resolvedBy: null },
+      { id: 'alert-2', acknowledgedBy: ADMIN_ID, resolvedBy: ADMIN_ID },
+    ]);
 
-    expect(names.get(ADMIN_ID)).toBe('Breeze Admin');
+    expect(enriched.every((row) => row.acknowledgedByName === 'Breeze Admin')).toBe(true);
 
     // Assert the compiled SQL, not just that `where` was called: a mock-only
     // assertion would pass on an empty or wrong-column predicate.
@@ -87,7 +103,7 @@ describe('resolveUserDisplayNames', () => {
   it('reads users in a system DB context, outside any request context', async () => {
     mockUsersQuery([{ id: ADMIN_ID, name: 'Breeze Admin' }]);
 
-    await resolveUserDisplayNames([ADMIN_ID]);
+    await withAlertActorNames([{ id: 'alert-1', acknowledgedBy: ADMIN_ID }]);
 
     // `users` RLS hides partner-level staff (org_id NULL) from org-scoped
     // callers, so the lookup must escape the request context or the name comes

--- a/apps/api/src/routes/alerts/actorNames.ts
+++ b/apps/api/src/routes/alerts/actorNames.ts
@@ -39,8 +39,18 @@ export type AlertActorNames = Partial<
  * already access-checked for, and only the display name is returned — no email,
  * no tenancy columns. The Audit Trail already shows those same callers the
  * acting user's name/email for the same actions.
+ *
+ * Deliberately NOT exported (#3983). This is an RLS-bypassing name oracle: it
+ * accepts an arbitrary list of user ids and resolves them outside any request
+ * tenancy scope. That's only safe because `withAlertActorNames` below is the
+ * sole caller and every id it passes in already came off an access-checked
+ * alert row. A general-purpose exported "give me names for these ids" helper
+ * invites a future caller (an endpoint that echoes ids from a request body, a
+ * batch/list route resolving ids it never itself authorized) to turn this into
+ * cross-tenant user enumeration. Keep it module-private; route all name
+ * resolution through `withAlertActorNames`.
  */
-export async function resolveUserDisplayNames(
+async function resolveUserDisplayNames(
   userIds: readonly (string | null | undefined)[]
 ): Promise<Map<string, string>> {
   const ids = [


### PR DESCRIPTION
## Summary

`resolveUserDisplayNames` in `apps/api/src/routes/alerts/actorNames.ts` deliberately runs outside request DB context (`runOutsideDbContext` → `withSystemDbAccessContext`) so it can resolve technician names regardless of the caller's tenancy scope. That's correct for its one real use — every id it receives already came off an access-checked alert row — but as an **exported** helper it reads like a general-purpose "resolve any user ids" utility. A future careless caller (an endpoint echoing ids from a request body, a batch route resolving un-authorized ids) could turn it into cross-tenant user enumeration with nothing at the call site looking wrong.

This PR:
- Un-exports `resolveUserDisplayNames`, making it module-private to `actorNames.ts`. `withAlertActorNames` (the sole legitimate caller) stays exported and unchanged in behavior.
- Adds a doc comment on the function stating the tenancy precondition and why it's kept private.
- Re-routes the three `resolveUserDisplayNames`-specific unit tests (dedup + selected columns, compiled SQL predicate, system-DB-context escape) through the public `withAlertActorNames` entry point instead of importing the internal function directly.

`git grep -n "resolveUserDisplayNames" apps/api/src` confirms the only references left are the function definition, its internal call site, and the test file's `describe` label/comments — no import of it remains anywhere.

Closes #3983

## Test plan
- [x] `pnpm exec vitest run src/routes/alerts/actorNames.test.ts --pool=threads --maxWorkers=2` — 10/10 passed
- [x] `npx tsc --noEmit` (apps/api) — clean
- [x] `git grep -n "resolveUserDisplayNames" apps/api/src` — no remaining import outside the module itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)