### PR TITLE
fix(api): stop stamping agent.command.* audit rows as success at dispatch (#4225)

### DIFF
--- a/apps/api/migrations/2026-09-29-audit-result-dispatched.sql
+++ b/apps/api/migrations/2026-09-29-audit-result-dispatched.sql
@@ -1,0 +1,13 @@
+-- #4225: agent.command.* audit rows are written at dispatch time
+-- (services/commandQueue.ts) and previously hardcoded result='success', so a
+-- command that later fails still reads as a successful completion in the
+-- audit trail. Add a neutral 'dispatched' outcome to the audit_result enum
+-- so the dispatch-time row can stop asserting an outcome it doesn't know yet.
+--
+-- This file contains ONLY the ALTER TYPE. Postgres forbids USING a value
+-- added by ALTER TYPE ... ADD VALUE inside the same transaction, and
+-- autoMigrate wraps each file in one — so any statement referencing
+-- 'dispatched' must live in a later file, not here (mirrors
+-- 2026-09-05-b-audit-actor-type-ai-agent.sql).
+
+ALTER TYPE public.audit_result ADD VALUE IF NOT EXISTS 'dispatched';

--- a/apps/api/src/db/schema/audit.enums.test.ts
+++ b/apps/api/src/db/schema/audit.enums.test.ts
@@ -114,7 +114,7 @@ describe('actor_type enum parity (shared ↔ DB schema ↔ validators ↔ OpenAP
   });
 
   it('audit_result parity stays intact alongside', () => {
-    expect([...auditResultEnum.enumValues].sort()).toEqual(['denied', 'failure', 'success']);
+    expect([...auditResultEnum.enumValues].sort()).toEqual(['denied', 'dispatched', 'failure', 'success']);
     expect([...AUDIT_RESULTS].sort()).toEqual([...auditResultEnum.enumValues].sort());
     const zodOptions = auditQuerySchema.shape.result.unwrap().options;
     expect([...zodOptions].sort()).toEqual([...auditResultEnum.enumValues].sort());

--- a/apps/api/src/routes/devices/events.test.ts
+++ b/apps/api/src/routes/devices/events.test.ts
@@ -109,14 +109,9 @@ describe('formatActionMessage (automated command labels)', () => {
   // #4225: these rows are written at DISPATCH time (commandQueue.ts), before
   // the agent has reported back, so the label must not claim completion and
   // the audit row's `result` must not claim 'success'.
-  it('labels automated patch installs in dispatch tense, not completed tense', () => {
+  it('labels automated patch installs in dispatch tense, not completed tense, with no suffix for the neutral result', () => {
     expect(formatActionMessage('agent.command.install_patches', 'host-1', 'dispatched'))
       .toBe('Patch install command sent — host-1');
-  });
-
-  it('does not append a suffix for the neutral dispatched result', () => {
-    expect(formatActionMessage('agent.command.install_patches', 'host-1', 'dispatched'))
-      .not.toContain('(failed)');
   });
 
   it('labels automated script runs', () => {

--- a/apps/api/src/routes/devices/events.test.ts
+++ b/apps/api/src/routes/devices/events.test.ts
@@ -106,25 +106,33 @@ describe('likePrefixPattern (action-prefix LIKE escaping)', () => {
 });
 
 describe('formatActionMessage (automated command labels)', () => {
-  it('labels automated patch installs', () => {
-    expect(formatActionMessage('agent.command.install_patches', 'host-1', 'success'))
-      .toBe('Patches installed — host-1');
+  // #4225: these rows are written at DISPATCH time (commandQueue.ts), before
+  // the agent has reported back, so the label must not claim completion and
+  // the audit row's `result` must not claim 'success'.
+  it('labels automated patch installs in dispatch tense, not completed tense', () => {
+    expect(formatActionMessage('agent.command.install_patches', 'host-1', 'dispatched'))
+      .toBe('Patch install command sent — host-1');
+  });
+
+  it('does not append a suffix for the neutral dispatched result', () => {
+    expect(formatActionMessage('agent.command.install_patches', 'host-1', 'dispatched'))
+      .not.toContain('(failed)');
   });
 
   it('labels automated script runs', () => {
-    expect(formatActionMessage('agent.command.script', null, 'success'))
-      .toBe('Script ran');
+    expect(formatActionMessage('agent.command.script', null, 'dispatched'))
+      .toBe('Script run command sent');
   });
 
-  it('marks a failed automated patch install', () => {
+  it('still marks a failed automated command explicitly', () => {
     expect(formatActionMessage('agent.command.install_patches', 'host-1', 'failure'))
-      .toBe('Patches installed — host-1 (failed)');
+      .toBe('Patch install command sent — host-1 (failed)');
   });
 
   it('labels rollback, uninstall, and update', () => {
-    expect(formatActionMessage('agent.command.rollback_patches', null, 'success')).toBe('Patches rolled back');
-    expect(formatActionMessage('agent.command.software_uninstall', null, 'success')).toBe('Software uninstalled');
-    expect(formatActionMessage('agent.command.software_update', null, 'success')).toBe('Software updated');
+    expect(formatActionMessage('agent.command.rollback_patches', null, 'dispatched')).toBe('Patch rollback command sent');
+    expect(formatActionMessage('agent.command.software_uninstall', null, 'dispatched')).toBe('Software uninstall command sent');
+    expect(formatActionMessage('agent.command.software_update', null, 'dispatched')).toBe('Software update command sent');
   });
 });
 

--- a/apps/api/src/routes/devices/events.ts
+++ b/apps/api/src/routes/devices/events.ts
@@ -350,11 +350,15 @@ const actionLabels: Record<string, string> = {
   'agent.recovery_keys.submit': 'Recovery keys escrowed',
   'script.execute': 'Script executed',
   'script.execution.cancel': 'Script execution cancelled',
-  'agent.command.install_patches': 'Patches installed',
-  'agent.command.rollback_patches': 'Patches rolled back',
-  'agent.command.script': 'Script ran',
-  'agent.command.software_uninstall': 'Software uninstalled',
-  'agent.command.software_update': 'Software updated',
+  // These fire when the command is DISPATCHED to the agent, not when it
+  // completes — the audit row's `result` is 'dispatched', not 'success' (see
+  // commandQueue.ts, #4225). Keep the copy in the command-sent tense so it
+  // doesn't assert an outcome the row can't know yet.
+  'agent.command.install_patches': 'Patch install command sent',
+  'agent.command.rollback_patches': 'Patch rollback command sent',
+  'agent.command.script': 'Script run command sent',
+  'agent.command.software_uninstall': 'Software uninstall command sent',
+  'agent.command.software_update': 'Software update command sent',
   'alert.acknowledge': 'Alert acknowledged',
   'alert.resolve': 'Alert resolved',
   'alert.suppress': 'Alert suppressed',

--- a/apps/api/src/services/commandQueue.test.ts
+++ b/apps/api/src/services/commandQueue.test.ts
@@ -287,6 +287,11 @@ describe('command queue service', () => {
       'exit-system',
       'exit-outside',
     ]);
+    // #4225: this row is written at DISPATCH time, before the agent has
+    // reported back, so it must NOT claim 'success' — that would assert an
+    // outcome the command hasn't reached yet. Assert the neutral value
+    // explicitly (not just objectContaining) so a regression back to
+    // 'success' fails here rather than only in a UI test.
     expect(auditInsertValues).toHaveBeenCalledWith(
       expect.objectContaining({
         orgId: 'org-42',
@@ -296,7 +301,7 @@ describe('command queue service', () => {
         resourceType: 'device',
         resourceId: 'dev-1',
         resourceName: 'host-1',
-        result: 'success',
+        result: 'dispatched',
       })
     );
   });
@@ -656,12 +661,18 @@ describe('command queue service', () => {
     const result = await executeCommand('dev-2', CommandTypes.CAPTURE_PPROF, { profile: 'all' }, { userId: 'user-1' });
 
     expect(result.status).toBe('completed');
+    // #4225: the audit row is written when the command is DISPATCHED, not
+    // when it completes — `result.status` above being 'completed' is the
+    // polled command outcome, unrelated to the audit row's `result` field.
+    // The audit insert must not claim 'success' regardless of how the
+    // command ultimately resolves.
     expect(auditValues).toHaveBeenCalledWith(expect.objectContaining({
       action: 'agent.command.capture_pprof',
       actorId: 'user-1',
       resourceType: 'device',
       resourceId: 'dev-2',
       orgId: 'org-1',
+      result: 'dispatched',
     }));
   });
 

--- a/apps/api/src/services/commandQueue.ts
+++ b/apps/api/src/services/commandQueue.ts
@@ -696,7 +696,11 @@ export async function queueCommand(
           resourceId: deviceId,
           resourceName: device.hostname,
           details: commandAuditDetails(commandId, type, payload),
-          result: 'success',
+          // Dispatch-time row: the agent hasn't reported back yet, so this
+          // cannot claim 'success' (#4225). No completion-time audit event is
+          // written anywhere — the command's terminal status lives only on
+          // `device_commands` / `patch_job_results`, not the audit log.
+          result: 'dispatched',
         });
       })
     ).catch((err) => {
@@ -1108,7 +1112,9 @@ export async function executeCommand(
               resourceId: deviceId,
               resourceName: device.hostname,
               details: commandAuditDetails(command.id, type, payload),
-              result: 'success',
+              // Dispatch-time row: the agent hasn't reported back yet, so
+              // this cannot claim 'success' (#4225).
+              result: 'dispatched',
             })
             .execute()
       )

--- a/apps/api/src/services/commandQueue.ts
+++ b/apps/api/src/services/commandQueue.ts
@@ -697,9 +697,15 @@ export async function queueCommand(
           resourceName: device.hostname,
           details: commandAuditDetails(commandId, type, payload),
           // Dispatch-time row: the agent hasn't reported back yet, so this
-          // cannot claim 'success' (#4225). No completion-time audit event is
-          // written anywhere — the command's terminal status lives only on
-          // `device_commands` / `patch_job_results`, not the audit log.
+          // cannot claim 'success' (#4225). A completion-time audit event
+          // DOES exist (action: 'agent.command.result.submit', written in
+          // agentWs.ts and routes/agents/commands.ts with a real success/
+          // failure result) — but it can't join THIS device's feed: it's
+          // keyed on resourceId = commandId with no deviceId in `details`,
+          // while the device feed matches on resourceId = deviceId OR
+          // details->>'deviceId' (events.ts). Adding a deviceId to that
+          // existing event's details would close the loop; this PR does not
+          // do that — out of scope per the issue.
           result: 'dispatched',
         });
       })

--- a/apps/web/src/components/devices/DeviceActivityFeed.test.tsx
+++ b/apps/web/src/components/devices/DeviceActivityFeed.test.tsx
@@ -44,15 +44,16 @@ describe('DeviceActivityFeed', () => {
       {
         id: 'e1',
         action: 'agent.command.install_patches',
-        message: 'Patches installed — host-1',
-        result: 'success',
+        // #4225: dispatch-time row — dispatch-tense copy, neutral result.
+        message: 'Patch install command sent — host-1',
+        result: 'dispatched',
         initiatedBy: null,
         timestamp: new Date().toISOString(),
         actor: { type: 'system', name: 'System' },
       },
     ]);
     render(<DeviceActivityFeed deviceId="dev-1" />);
-    expect(await screen.findByText('Patches installed — host-1')).toBeInTheDocument();
+    expect(await screen.findByText('Patch install command sent — host-1')).toBeInTheDocument();
     expect(screen.getByText('Automated')).toBeInTheDocument();
     // The "Automated" chip conveys the actor; the generic "System" must not also show.
     expect(screen.queryByText('System')).toBeNull();
@@ -89,8 +90,9 @@ describe('DeviceActivityFeed', () => {
       {
         id: 'e1',
         action: 'agent.command.script',
-        message: 'Script ran',
-        result: 'success',
+        // #4225: dispatch-time row — dispatch-tense copy, neutral result.
+        message: 'Script run command sent',
+        result: 'dispatched',
         initiatedBy: null,
         timestamp: new Date().toISOString(),
         actor: { type: 'system', name: 'System' },

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -55,8 +55,11 @@ export const NOTIFICATION_CHANNEL_TYPES = ['email', 'slack', 'teams', 'webhook',
 export const ACTOR_TYPES = ['user', 'api_key', 'agent', 'system', 'ai_agent'] as const;
 
 // Audit Results — same contract as ACTOR_TYPES above, for the `audit_result`
-// Postgres enum.
-export const AUDIT_RESULTS = ['success', 'failure', 'denied'] as const;
+// Postgres enum. 'dispatched' is the neutral outcome for commands audited at
+// enqueue time, before the agent has reported back — see commandQueue.ts and
+// issue #4225. It must never be conflated with 'success': the dispatch-time
+// audit row cannot yet know whether the command actually succeeded.
+export const AUDIT_RESULTS = ['success', 'failure', 'denied', 'dispatched'] as const;
 
 // Remote Session Types
 export const REMOTE_SESSION_TYPES = ['terminal', 'desktop', 'file_transfer'] as const;


### PR DESCRIPTION
## Summary

`services/commandQueue.ts` writes the `agent.command.*` audit row at
**dispatch time** (fire-and-forget, by design) but hardcoded
`result: 'success'` at both write sites (`queueCommand` and `executeCommand`).
Nothing ever updates that row after the command completes, so a command that
later fails still reads as a successful completion in the audit trail — e.g.
a patch job that failed its preflight showed as **"Patches installed"**,
`result: success`, listing all patches (#4223).

## Fix (minimal, per issue scope)

- Added a neutral `'dispatched'` value to the `audit_result` enum:
  `packages/shared/src/constants/index.ts` (the single source of truth,
  widens the Drizzle enum / Zod validators / OpenAPI spec for free) +
  `apps/api/migrations/2026-09-29-audit-result-dispatched.sql`
  (`ALTER TYPE ... ADD VALUE IF NOT EXISTS`, isolated in its own file per the
  existing `2026-09-05-b-audit-actor-type-ai-agent.sql` pattern — Postgres
  forbids using a value added by `ALTER TYPE` in the same transaction).
- Both `result: 'success'` audit-insert sites in `commandQueue.ts` now write
  `result: 'dispatched'`.
- Updated the `agent.command.*` labels in `routes/devices/events.ts` from
  completed-tense ("Patches installed") to dispatch-tense ("Patch install
  command sent") so the rendered message doesn't assert an outcome that
  hasn't happened. `formatActionMessage`'s failure/denied suffix logic is
  unaffected — 'dispatched' is neutral and gets no suffix, same as before.
- Updated `audit.enums.test.ts`'s pinned enum-parity assertion to include the
  new value.

## Out of scope (explicitly, per issue)

A second completion-time audit event (dispatched → completed/failed) is
**not** built here — that's the "better" fix the issue calls out as a
separate, larger change. This PR only stops the dispatch-time row from
falsely claiming success.

## Tests

- `apps/api/src/services/commandQueue.test.ts`: both audit-insert call sites
  (`queueCommand`'s fire-and-forget block, and `executeCommand`'s org-scoped
  insert) now assert `result: 'dispatched'` instead of `'success'`.
- `apps/api/src/routes/devices/events.test.ts`: `formatActionMessage` tests
  updated to dispatch-tense copy, plus a new assertion that the neutral
  `'dispatched'` result gets no `(failed)`-style suffix.
- `apps/api/src/db/schema/audit.enums.test.ts`: enum parity assertion
  updated to include `'dispatched'`.

Affected suites run single-fork, all green:
```
apps/api: commandQueue.test.ts, devices/events.test.ts, audit.enums.test.ts
  Test Files  3 passed (3)
       Tests  76 passed (76)
```
`tsc --noEmit` clean on `apps/api` (pre-existing unrelated errors in
`packages/shared/src/validators/quotes.test.ts` confirmed present on
`origin/main` before this change, untouched here).

Closes #4225

🤖 Generated with [Claude Code](https://claude.com/claude-code)