### PR TITLE
fix(quotes): reject WebP quote images at upload (#3483)

### DIFF
--- a/apps/api/src/middleware/bodyLimit.test.ts
+++ b/apps/api/src/middleware/bodyLimit.test.ts
@@ -148,9 +148,10 @@ describe('bodyLimitForPath', () => {
   });
 
   // Regression for #3482: quote block/cover image uploads. The UI advertises
-  // "PNG, JPEG, or WebP, up to 5 MB" and the route registers its own 5MB+64KB
-  // bodyLimit, but the global gate ran first and 413'd anything over 1MB with
-  // the generic "Request body too large".
+  // "PNG or JPEG, up to 5 MB" (WebP dropped in #3483 — pdfkit can't embed it)
+  // and the route registers its own 5MB+64KB bodyLimit, but the global gate
+  // ran first and 413'd anything over 1MB with the generic "Request body too
+  // large".
   it('carves out quote image uploads at the route 5MB cap (#3482)', () => {
     expect(bodyLimitForPath('/api/v1/quotes/11111111-1111-4111-8111-111111111111/images')).toEqual({
       rule: 'image-upload',

--- a/apps/api/src/routes/quotes/lifecycle.test.ts
+++ b/apps/api/src/routes/quotes/lifecycle.test.ts
@@ -38,14 +38,21 @@ vi.mock('../../jobs/quoteSendQueue', () => ({
   scheduleQuoteSend: vi.fn(),
   cancelQuoteSend: vi.fn(),
 }));
-vi.mock('../../services/quoteImageStorage', () => ({
-  writeQuoteImage: vi.fn(), readQuoteImage: vi.fn(), sniffImageMime: vi.fn(), MAX_QUOTE_IMAGE_SIZE_BYTES: 5 * 1024 * 1024,
-  fetchRemoteImage: vi.fn(),
-  QUOTE_IMAGE_WEBP_REJECTED_MESSAGE: "WebP images can't be used in quote PDFs — please upload a PNG or JPEG image instead.",
-  RemoteImageError: class RemoteImageError extends Error {
-    constructor(public reason: string, msg: string) { super(msg); this.name = 'RemoteImageError'; }
-  },
-}));
+// QUOTE_IMAGE_WEBP_REJECTED_MESSAGE comes from the REAL module (importActual)
+// rather than a hardcoded copy here — a hardcoded duplicate would let the
+// mock and the real constant drift apart silently, since every assertion
+// below compares the route's response against this same import.
+vi.mock('../../services/quoteImageStorage', async (importActual) => {
+  const actual = await importActual<typeof import('../../services/quoteImageStorage')>();
+  return {
+    writeQuoteImage: vi.fn(), readQuoteImage: vi.fn(), sniffImageMime: vi.fn(), MAX_QUOTE_IMAGE_SIZE_BYTES: 5 * 1024 * 1024,
+    fetchRemoteImage: vi.fn(),
+    QUOTE_IMAGE_WEBP_REJECTED_MESSAGE: actual.QUOTE_IMAGE_WEBP_REJECTED_MESSAGE,
+    RemoteImageError: class RemoteImageError extends Error {
+      constructor(public reason: string, msg: string) { super(msg); this.name = 'RemoteImageError'; }
+    },
+  };
+});
 vi.mock('./quotes', () => ({
   quoteActorFrom: () => ({ userId: 'u1', partnerId: 'p1', accessibleOrgIds: null }),
   handleServiceError: (_c: unknown, err: unknown) => { throw err; },

--- a/apps/api/src/routes/quotes/lifecycle.test.ts
+++ b/apps/api/src/routes/quotes/lifecycle.test.ts
@@ -41,6 +41,7 @@ vi.mock('../../jobs/quoteSendQueue', () => ({
 vi.mock('../../services/quoteImageStorage', () => ({
   writeQuoteImage: vi.fn(), readQuoteImage: vi.fn(), sniffImageMime: vi.fn(), MAX_QUOTE_IMAGE_SIZE_BYTES: 5 * 1024 * 1024,
   fetchRemoteImage: vi.fn(),
+  QUOTE_IMAGE_WEBP_REJECTED_MESSAGE: "WebP images can't be used in quote PDFs — please upload a PNG or JPEG image instead.",
   RemoteImageError: class RemoteImageError extends Error {
     constructor(public reason: string, msg: string) { super(msg); this.name = 'RemoteImageError'; }
   },
@@ -54,7 +55,7 @@ vi.mock('../../services/contractTemplateRender', () => ({ loadContractBlockRende
 import { quoteLifecycleRoutes } from './lifecycle';
 import { getQuote } from '../../services/quoteService';
 import { scheduleQuoteSend, cancelQuoteSend } from '../../jobs/quoteSendQueue';
-import { fetchRemoteImage, writeQuoteImage, RemoteImageError } from '../../services/quoteImageStorage';
+import { fetchRemoteImage, writeQuoteImage, sniffImageMime, RemoteImageError, QUOTE_IMAGE_WEBP_REJECTED_MESSAGE } from '../../services/quoteImageStorage';
 import { loadContractBlockRenderData } from '../../services/contractTemplateRender';
 
 const QUOTE_ID = '11111111-1111-4111-8111-111111111111';
@@ -268,9 +269,23 @@ describe('POST /:id/images — from URL (JSON body)', () => {
   });
 
   it('415s a URL whose bytes are not a supported image', async () => {
-    vi.mocked(fetchRemoteImage).mockRejectedValue(new RemoteImageError('not_image', "That URL isn't a PNG, JPEG, or WebP image"));
+    vi.mocked(fetchRemoteImage).mockRejectedValue(new RemoteImageError('not_image', "That URL isn't a PNG or JPEG image"));
     const res = await appWith('partner', PERMS).request(`/${QUOTE_ID}/images`, jsonReq('https://cdn/page.png'));
     expect(res.status).toBe(415);
+  });
+
+  // #3483: pdfkit (the quote PDF renderer) can't embed WebP — doc.image() threw
+  // and the render loop's catch-and-continue silently dropped the image from
+  // the exported PDF. fetchRemoteImage now rejects WebP explicitly (as
+  // RemoteImageError('not_image', ...)); this proves the route surfaces that
+  // as a visible 415 rather than accepting the image only to have it vanish
+  // from the PDF later.
+  it('415s a remote WebP image with a message telling the author to use PNG/JPEG', async () => {
+    vi.mocked(fetchRemoteImage).mockRejectedValue(new RemoteImageError('not_image', QUOTE_IMAGE_WEBP_REJECTED_MESSAGE));
+    const res = await appWith('partner', PERMS).request(`/${QUOTE_ID}/images`, jsonReq('https://cdn/photo.webp'));
+    expect(res.status).toBe(415);
+    expect(await res.json()).toEqual({ error: QUOTE_IMAGE_WEBP_REJECTED_MESSAGE });
+    expect(writeQuoteImage).not.toHaveBeenCalled();
   });
 
   it('502s an unreachable / blocked URL', async () => {
@@ -300,6 +315,54 @@ describe('POST /:id/images — from URL (JSON body)', () => {
     vi.mocked(fetchRemoteImage).mockRejectedValue(new Error('boom'));
     const res = await appWith('partner', PERMS).request(`/${QUOTE_ID}/images`, jsonReq('https://cdn/a.png'));
     expect(res.status).toBe(500);
+    expect(writeQuoteImage).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /:id/images — multipart file upload', () => {
+  const PERMS = ['quotes:read', 'quotes:write'];
+
+  function makeMultipart(bytes: Buffer, mime: string, filename: string): { body: BodyInit; headers: HeadersInit } {
+    const formData = new FormData();
+    const view = new Uint8Array(bytes.byteLength);
+    view.set(bytes);
+    formData.append('file', new Blob([view], { type: mime }), filename);
+    // Undici sets Content-Type (with boundary) automatically for a FormData body.
+    return { body: formData, headers: {} };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getQuote).mockResolvedValue({ quote: { orgId: 'org-1' } } as never);
+    vi.mocked(writeQuoteImage).mockResolvedValue({ id: 'img-9', byteSize: 4, sha256: 'x' } as never);
+  });
+
+  it('accepts a sniffed PNG and writes it', async () => {
+    vi.mocked(sniffImageMime).mockReturnValue('image/png');
+    const { body, headers } = makeMultipart(Buffer.from([1, 2, 3, 4]), 'image/png', 'a.png');
+    const res = await appWith('partner', PERMS).request(`/${QUOTE_ID}/images`, { method: 'POST', body, headers });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ data: { imageId: 'img-9', mime: 'image/png', byteSize: 4 } });
+    expect(writeQuoteImage).toHaveBeenCalledWith(QUOTE_ID, 'org-1', 'image/png', expect.any(Buffer));
+  });
+
+  // #3483: the upload surface previously advertised (and accepted) WebP, but
+  // pdfkit can't embed it — the image silently vanished from the exported PDF.
+  // The route must now reject it visibly at upload time instead.
+  it('415s a WebP file with a message telling the author to use PNG/JPEG, and never persists it', async () => {
+    vi.mocked(sniffImageMime).mockReturnValue('image/webp');
+    const { body, headers } = makeMultipart(Buffer.from([1, 2, 3, 4]), 'image/webp', 'photo.webp');
+    const res = await appWith('partner', PERMS).request(`/${QUOTE_ID}/images`, { method: 'POST', body, headers });
+    expect(res.status).toBe(415);
+    expect(await res.json()).toEqual({ error: QUOTE_IMAGE_WEBP_REJECTED_MESSAGE });
+    expect(writeQuoteImage).not.toHaveBeenCalled();
+  });
+
+  it('415s bytes that sniff to no recognized image format', async () => {
+    vi.mocked(sniffImageMime).mockReturnValue(null);
+    const { body, headers } = makeMultipart(Buffer.from('not an image'), 'image/png', 'fake.png');
+    const res = await appWith('partner', PERMS).request(`/${QUOTE_ID}/images`, { method: 'POST', body, headers });
+    expect(res.status).toBe(415);
     expect(writeQuoteImage).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/quotes/lifecycle.ts
+++ b/apps/api/src/routes/quotes/lifecycle.ts
@@ -10,7 +10,7 @@ import { writeRouteAudit } from '../../services/auditEvents';
 import { supersededAuditEvent } from '../../services/quoteSupersedeAudit';
 import { scheduleQuoteSend, cancelQuoteSend } from '../../jobs/quoteSendQueue';
 import { getQuote } from '../../services/quoteService';
-import { writeQuoteImage, readQuoteImage, sniffImageMime, MAX_QUOTE_IMAGE_SIZE_BYTES, fetchRemoteImage, RemoteImageError, type RemoteImageFailureReason } from '../../services/quoteImageStorage';
+import { writeQuoteImage, readQuoteImage, sniffImageMime, MAX_QUOTE_IMAGE_SIZE_BYTES, fetchRemoteImage, RemoteImageError, QUOTE_IMAGE_WEBP_REJECTED_MESSAGE, type RemoteImageFailureReason } from '../../services/quoteImageStorage';
 import { loadContractBlockRenderData } from '../../services/contractTemplateRender';
 import { quoteActorFrom, handleServiceError } from './quotes';
 
@@ -201,7 +201,8 @@ quoteLifecycleRoutes.post('/:id/images',
       if (file.size > MAX_QUOTE_IMAGE_SIZE_BYTES) return c.json({ error: 'Image too large (max 5 MB)' }, 413);
       const buffer = Buffer.from(await file.arrayBuffer());
       const mime = sniffImageMime(buffer);
-      if (!mime) return c.json({ error: 'Unsupported image format. Allowed: PNG, JPEG, WebP.' }, 415);
+      if (!mime) return c.json({ error: 'Unsupported image format. Allowed: PNG, JPEG.' }, 415);
+      if (mime === 'image/webp') return c.json({ error: QUOTE_IMAGE_WEBP_REJECTED_MESSAGE }, 415);
       const written = await writeQuoteImage(id, quote.orgId, mime, buffer);
       return c.json({ data: { imageId: written.id, mime, byteSize: written.byteSize } });
     } catch (err) { return handleServiceError(c, err); }

--- a/apps/api/src/services/quoteImageStorage.test.ts
+++ b/apps/api/src/services/quoteImageStorage.test.ts
@@ -12,7 +12,7 @@ vi.mock('./urlSafety', async (importActual) => {
   return { ...actual, safeFetch: vi.fn() };
 });
 
-import { fetchRemoteImage, RemoteImageError, MAX_QUOTE_IMAGE_SIZE_BYTES } from './quoteImageStorage';
+import { fetchRemoteImage, RemoteImageError, MAX_QUOTE_IMAGE_SIZE_BYTES, QUOTE_IMAGE_WEBP_REJECTED_MESSAGE } from './quoteImageStorage';
 import { safeFetch, SsrfBlockedError } from './urlSafety';
 
 const safeFetchMock = vi.mocked(safeFetch);
@@ -20,6 +20,10 @@ const safeFetchMock = vi.mocked(safeFetch);
 // A minimal but valid PNG magic-byte header (>= 12 bytes) so the real
 // sniffImageMime recognizes it.
 const PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d]);
+
+// A minimal but valid WebP "RIFF....WEBP" header (>= 12 bytes) so the real
+// sniffImageMime recognizes it as image/webp.
+const WEBP = Buffer.from([0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50]);
 
 // Minimal stub of just the Response surface fetchRemoteImage uses (`ok`,
 // `headers.get`, `arrayBuffer`). Avoids undici recomputing a real Response's
@@ -64,6 +68,20 @@ describe('fetchRemoteImage', () => {
   it('rejects bytes that are not a supported image even if the URL claims one', async () => {
     safeFetchMock.mockResolvedValue(res(Buffer.from('<!doctype html><html></html>')));
     await expect(fetchRemoteImage('https://cdn/looks-like.png')).rejects.toMatchObject({ reason: 'not_image' });
+  });
+
+  // #3483: pdfkit (the quote PDF renderer) can only embed PNG/JPEG — doc.image()
+  // throws on WebP, and the render loop's catch-and-continue silently dropped
+  // the image from the exported PDF with no error surfaced anywhere. Reject it
+  // here, at the URL-import boundary, with a message that tells the author why
+  // and what to do instead — rather than accepting bytes sniffImageMime happily
+  // recognizes as a real image, only to have them vanish downstream.
+  it('rejects a real WebP image with a clear message, distinct from "not an image"', async () => {
+    safeFetchMock.mockResolvedValue(res(WEBP));
+    await expect(fetchRemoteImage('https://cdn/photo.webp')).rejects.toMatchObject({
+      reason: 'not_image',
+      message: QUOTE_IMAGE_WEBP_REJECTED_MESSAGE,
+    });
   });
 
   it('rejects a buffer over the 5 MB cap', async () => {

--- a/apps/api/src/services/quoteImageStorage.ts
+++ b/apps/api/src/services/quoteImageStorage.ts
@@ -10,6 +10,19 @@ export { sniffImageMime };
 export const MAX_QUOTE_IMAGE_SIZE_BYTES = 5 * 1024 * 1024; // reuse the avatar cap
 
 /**
+ * Quote PDFs are rendered with pdfkit, which can only embed PNG and JPEG —
+ * calling `doc.image()` on WebP bytes throws, and the renderer's per-image
+ * catch-and-continue silently dropped the image from the exported PDF with
+ * no error surfaced anywhere (#3483). Avatars go through a different (non-PDF)
+ * path and keep accepting WebP via `sniffImageMime`/`asAvatarMime`; quote
+ * images reject it explicitly here, at the upload boundary, for both the
+ * multipart route and the URL-import path below — so the failure is visible
+ * to the quote author immediately instead of to the customer, later, as a
+ * blank gap in a PDF that already sent.
+ */
+export const QUOTE_IMAGE_WEBP_REJECTED_MESSAGE = "WebP images can't be used in quote PDFs — please upload a PNG or JPEG image instead.";
+
+/**
  * Persist a proposal image as a bytea blob on `quote_images`, scoped to its
  * quote + org. The org-axis RLS on `quote_images` is the access boundary; the
  * caller must be inside a request/system DB access context. Magic-byte sniffing
@@ -114,7 +127,8 @@ export async function fetchRemoteImage(url: string): Promise<{ mime: string; buf
   }
 
   const mime = sniffImageMime(buffer);
-  if (!mime) throw new RemoteImageError('not_image', "That URL isn't a PNG, JPEG, or WebP image");
+  if (!mime) throw new RemoteImageError('not_image', "That URL isn't a PNG or JPEG image");
+  if (mime === 'image/webp') throw new RemoteImageError('not_image', QUOTE_IMAGE_WEBP_REJECTED_MESSAGE);
 
   return { mime, buffer };
 }

--- a/apps/api/src/services/quotePdf.test.ts
+++ b/apps/api/src/services/quotePdf.test.ts
@@ -1,8 +1,19 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import zlib from 'node:zlib';
 import PDFKitDocument from 'pdfkit';
 import { PDFDocument, PDFDict, PDFName } from 'pdf-lib';
 import { formatMoney } from '@breeze/shared';
+
+// Spy on captureException (kept otherwise-real) so the #3483 doc.image()
+// failure tests can assert the render loop actually REPORTS a draw failure,
+// not just that it degrades to "no image" — the two behaviors are distinct
+// and the previous version of this file only proved the latter.
+vi.mock('./sentry', async (importActual) => {
+  const actual = await importActual<typeof import('./sentry')>();
+  return { ...actual, captureException: vi.fn() };
+});
+
+import { captureException } from './sentry';
 import { renderQuotePdf, contractUploadedMarker, columnsFor, imageIntrinsicSize } from './quotePdf';
 
 // Encode a real, pdfkit-decodable grayscale PNG of the given dimensions. The
@@ -346,6 +357,7 @@ describe('renderQuotePdf', () => {
   // imageIntrinsicSize-only assertion that WebP merely fails to *parse*
   // (which never proved the render path degrades instead of vanishing silently).
   it('degrades gracefully — surrounding content still renders — when an image block holds WebP bytes pdfkit cannot embed', async () => {
+    vi.mocked(captureException).mockClear();
     const webpBytes = Buffer.from([0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x45, 0x42, 0x50]); // RIFF....WEBP
     const buf = await renderQuotePdf(
       { id: 'q1', quoteNumber: 'Q-WEBP', oneTimeTotal: '0.00', monthlyRecurringTotal: '0.00', annualRecurringTotal: '0.00', total: '0.00', currencyCode: 'USD' },
@@ -363,6 +375,34 @@ describe('renderQuotePdf', () => {
     // render — a decode failure degrades to "no image", never aborts the doc.
     expect(text).toContain('Skipped image');
     expect(text).toContain('AFTERWEBP');
+    // The draw failure must be REPORTED, not just swallowed — this is the
+    // actual behavior change this PR makes at this call site (previously
+    // console.error-only). A previous version of this test only proved the
+    // "no throw" half; this proves the "not silent" half too.
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it('cover image: reports a WebP draw failure via captureException and leaves the page usable (no leaked clip/save state)', async () => {
+    vi.mocked(captureException).mockClear();
+    const webpBytes = Buffer.from([0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x45, 0x42, 0x50]); // RIFF....WEBP
+    const buf = await renderQuotePdf(
+      {
+        id: 'q1', quoteNumber: 'Q-WEBP-COVER', oneTimeTotal: '0.00', monthlyRecurringTotal: '0.00', annualRecurringTotal: '0.00', total: '0.00', currencyCode: 'USD',
+        coverPage: { enabled: true, title: 'COVERTITLE', coverImageId: 'cover-webp' },
+      } as never,
+      [{ id: 'b1', blockType: 'rich_text', sortOrder: 0, content: { html: '<p>BODYAFTERCOVER</p>' } }],
+      [],
+      async () => ({ data: webpBytes }),
+      {},
+    );
+    expect(buf.subarray(0, 4).toString()).toBe('%PDF');
+    expect(captureException).toHaveBeenCalledTimes(1);
+    const text = extractPdfText(buf);
+    // A failed cover-image draw must not corrupt the content stream (the
+    // unmatched doc.save()/doc.restore() bug this PR also fixes) — the cover
+    // title and the body content that follows must both still be legible.
+    expect(text).toContain('COVERTITLE');
+    expect(text).toContain('BODYAFTERCOVER');
   });
 
   it('embeds a product thumbnail for a catalog-sourced line via loadCatalogImage', async () => {

--- a/apps/api/src/services/quotePdf.test.ts
+++ b/apps/api/src/services/quotePdf.test.ts
@@ -338,6 +338,33 @@ describe('renderQuotePdf', () => {
     expect(text).toContain('world');
   });
 
+  // #3483: quote image uploads now reject WebP at the API boundary (route-level
+  // fix), but bytes already stored before that shipped must still not corrupt
+  // or abort the whole document. pdfkit's doc.image() throws synchronously on
+  // WebP; this proves the render loop's catch actually swallows that specific
+  // draw failure and keeps rendering everything around it — replacing the old
+  // imageIntrinsicSize-only assertion that WebP merely fails to *parse*
+  // (which never proved the render path degrades instead of vanishing silently).
+  it('degrades gracefully — surrounding content still renders — when an image block holds WebP bytes pdfkit cannot embed', async () => {
+    const webpBytes = Buffer.from([0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x45, 0x42, 0x50]); // RIFF....WEBP
+    const buf = await renderQuotePdf(
+      { id: 'q1', quoteNumber: 'Q-WEBP', oneTimeTotal: '0.00', monthlyRecurringTotal: '0.00', annualRecurringTotal: '0.00', total: '0.00', currencyCode: 'USD' },
+      [
+        { id: 'b1', blockType: 'image', sortOrder: 0, content: { imageId: 'img-webp', caption: 'Skipped image', width: 200 } },
+        { id: 'b2', blockType: 'rich_text', sortOrder: 1, content: { html: '<p>AFTERWEBP</p>' } },
+      ],
+      [],
+      async () => ({ data: webpBytes }),
+      {},
+    );
+    expect(buf.subarray(0, 4).toString()).toBe('%PDF');
+    const text = extractPdfText(buf);
+    // The caption and the block after the failed image draw must still
+    // render — a decode failure degrades to "no image", never aborts the doc.
+    expect(text).toContain('Skipped image');
+    expect(text).toContain('AFTERWEBP');
+  });
+
   it('embeds a product thumbnail for a catalog-sourced line via loadCatalogImage', async () => {
     const requested: string[] = [];
     const buf = await renderQuotePdf(
@@ -1049,7 +1076,11 @@ describe('imageIntrinsicSize', () => {
   it('returns null for unparseable buffers', () => {
     expect(imageIntrinsicSize(Buffer.from('not an image at all'))).toBeNull();
     expect(imageIntrinsicSize(Buffer.alloc(0))).toBeNull();
-    // WebP (RIFF) — pdfkit can't embed it and the probe doesn't parse it.
+    // WebP (RIFF) — the probe doesn't parse it either, so the render loop
+    // falls back to a fixed fitHeight rather than a measured aspect ratio.
+    // (The renderQuotePdf-level "degrades gracefully ... WebP" test above
+    // proves the actual doc.image() failure this feeds into is caught and
+    // reported, not silently swallowed — #3483.)
     expect(imageIntrinsicSize(Buffer.from('RIFF0000WEBPVP8 '))).toBeNull();
   });
 });

--- a/apps/api/src/services/quotePdf.ts
+++ b/apps/api/src/services/quotePdf.ts
@@ -699,18 +699,23 @@ async function renderCoverPage(
       captureException(e instanceof Error ? e : new Error(String(e)));
     }
     if (img?.data) {
+      // doc.save() must be paired with doc.restore() even when doc.image()
+      // throws (e.g. a WebP blob stored before upload-time rejection shipped,
+      // #3483) — otherwise the unmatched `q` graphics-state push corrupts the
+      // page's content stream for every draw call after this one. restore()
+      // now runs in `finally` so a failed draw still unwinds cleanly.
+      doc.save();
       try {
-        doc.save();
         doc.rect(0, 0, doc.page.width, doc.page.height).clip();
         doc.image(img.data, 0, 0, { cover: [doc.page.width, doc.page.height] });
-        doc.restore();
         hasBackground = true;
       } catch (e) {
-        // A decode-at-draw failure (e.g. a WebP blob stored before upload-time
-        // rejection shipped, #3483) must not be the one silent gap — report it
+        // A decode-at-draw failure must not be the one silent gap — report it
         // the same way the sibling doc.image() catches in this file do.
         console.error('[quotePdf] cover doc.image failed', cp.coverImageId, e instanceof Error ? e.message : e);
         captureException(e instanceof Error ? e : new Error(String(e)));
+      } finally {
+        doc.restore();
       }
     }
   }

--- a/apps/api/src/services/quotePdf.ts
+++ b/apps/api/src/services/quotePdf.ts
@@ -706,7 +706,11 @@ async function renderCoverPage(
         doc.restore();
         hasBackground = true;
       } catch (e) {
+        // A decode-at-draw failure (e.g. a WebP blob stored before upload-time
+        // rejection shipped, #3483) must not be the one silent gap — report it
+        // the same way the sibling doc.image() catches in this file do.
         console.error('[quotePdf] cover doc.image failed', cp.coverImageId, e instanceof Error ? e.message : e);
+        captureException(e instanceof Error ? e : new Error(String(e)));
       }
     }
   }
@@ -949,8 +953,11 @@ export async function renderQuotePdf(
           doc.image(img.data, c.left, y, { fit: [fitWidth, fitHeight] });
           y += drawnHeight + 6;
         } catch (e) {
-          // A corrupt/unsupported image must not abort the whole document.
+          // A corrupt/unsupported image (e.g. a WebP blob stored before
+          // upload-time rejection shipped, #3483) must not abort the whole
+          // document — but it must not be silent either, so report it.
           console.error('[quotePdf] doc.image failed', imageId, e instanceof Error ? e.message : e);
+          captureException(e instanceof Error ? e : new Error(String(e)));
           y += 6;
         }
         const caption = (b.content as { caption?: string }).caption;

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -2218,7 +2218,7 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
                   <input
                     ref={imageFileInputRef}
                     type="file"
-                    accept="image/png,image/jpeg,image/webp"
+                    accept="image/png,image/jpeg"
                     onChange={(e) => setImageFile(e.target.files?.[0] ?? null)}
                     data-testid="quote-block-image-file"
                     className="block w-full text-sm text-muted-foreground file:mr-3 file:rounded-md file:border file:bg-muted file:px-3 file:py-1.5 file:text-xs file:font-medium"
@@ -2515,7 +2515,7 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
                   <>
                     <input
                       type="file"
-                      accept="image/png,image/jpeg,image/webp"
+                      accept="image/png,image/jpeg"
                       onChange={(e) => { const f = e.target.files?.[0]; if (f) uploadCoverImage(f); }}
                       disabled={isPending('cover-image')}
                       data-testid="quote-cover-page-image-file"

--- a/apps/web/src/components/billing/quotes/QuoteLineRows.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteLineRows.tsx
@@ -1409,7 +1409,7 @@ export function EditableLineRow({
           <input
             ref={imageInputRef}
             type="file"
-            accept="image/png,image/jpeg,image/webp"
+            accept="image/png,image/jpeg"
             className="hidden"
             data-testid={`quote-line-image-input-${line.id}`}
             onChange={(e) => {

--- a/apps/web/src/locales/de-DE/billing.json
+++ b/apps/web/src/locales/de-DE/billing.json
@@ -557,7 +557,7 @@
       "addSection": {
         "captionPlaceholder": "Bildunterschrift (optional)",
         "headingPlaceholder": "Überschriftentext",
-        "imageHelp": "PNG, JPEG oder WebP, bis zu 5 MB.",
+        "imageHelp": "PNG oder JPEG, bis zu 5 MB.",
         "imageUrlPlaceholder": "https://example.com/photo.png",
         "insertHere": "Abschnitt hinzufügen",
         "richTextPlaceholder": "Vorschlagstext…",
@@ -875,7 +875,7 @@
         "preparedForPlaceholder": "Kundennamen überschreiben",
         "showPreparedBy": "„Erstellt von“ anzeigen (Ihr Unternehmen)",
         "imageLabel": "Deckblattbild",
-        "imageHelp": "PNG, JPEG oder WebP, bis zu 5 MB.",
+        "imageHelp": "PNG oder JPEG, bis zu 5 MB.",
         "removeImage": "Bild entfernen"
       },
       "ghost": {

--- a/apps/web/src/locales/en/billing.json
+++ b/apps/web/src/locales/en/billing.json
@@ -557,7 +557,7 @@
       "addSection": {
         "captionPlaceholder": "Caption (optional)",
         "headingPlaceholder": "Heading text",
-        "imageHelp": "PNG, JPEG, or WebP, up to 5 MB.",
+        "imageHelp": "PNG or JPEG, up to 5 MB.",
         "imageUrlPlaceholder": "https://example.com/photo.png",
         "insertHere": "Add section",
         "richTextPlaceholder": "Proposal text…",
@@ -875,7 +875,7 @@
         "preparedForPlaceholder": "Override the customer name",
         "showPreparedBy": "Show “prepared by” (your company)",
         "imageLabel": "Cover image",
-        "imageHelp": "PNG, JPEG, or WebP, up to 5 MB.",
+        "imageHelp": "PNG or JPEG, up to 5 MB.",
         "removeImage": "Remove image"
       },
       "ghost": {

--- a/apps/web/src/locales/es-419/billing.json
+++ b/apps/web/src/locales/es-419/billing.json
@@ -557,7 +557,7 @@
       "addSection": {
         "captionPlaceholder": "Título (opcional)",
         "headingPlaceholder": "Texto del encabezado",
-        "imageHelp": "PNG, JPEG o WebP, hasta 5 MB.",
+        "imageHelp": "PNG o JPEG, hasta 5 MB.",
         "imageUrlPlaceholder": "https://example.com/photo.png",
         "insertHere": "Agregar sección",
         "richTextPlaceholder": "Texto de la propuesta…",
@@ -875,7 +875,7 @@
         "preparedForPlaceholder": "Reemplazar el nombre del cliente",
         "showPreparedBy": "Mostrar “preparado por” (tu empresa)",
         "imageLabel": "Imagen de portada",
-        "imageHelp": "PNG, JPEG o WebP, hasta 5 MB.",
+        "imageHelp": "PNG o JPEG, hasta 5 MB.",
         "removeImage": "Quitar imagen"
       },
       "ghost": {

--- a/apps/web/src/locales/fr-CA/billing.json
+++ b/apps/web/src/locales/fr-CA/billing.json
@@ -557,7 +557,7 @@
       "addSection": {
         "captionPlaceholder": "Légende (facultatif)",
         "headingPlaceholder": "Texte du titre",
-        "imageHelp": "PNG, JPEG ou WebP, jusqu'à 5 MB.",
+        "imageHelp": "PNG ou JPEG, jusqu'à 5 MB.",
         "imageUrlPlaceholder": "https://example.com/photo.png",
         "insertHere": "Ajouter une section",
         "richTextPlaceholder": "Texte de proposition…",
@@ -838,7 +838,7 @@
         "preparedForPlaceholder": "Remplacer le nom du client",
         "showPreparedBy": "Afficher « préparé par » (votre entreprise)",
         "imageLabel": "Image de couverture",
-        "imageHelp": "PNG, JPEG ou WebP, jusqu'à 5 MB.",
+        "imageHelp": "PNG ou JPEG, jusqu'à 5 MB.",
         "removeImage": "Supprimer l'image"
       },
       "ghost": {

--- a/apps/web/src/locales/fr-FR/billing.json
+++ b/apps/web/src/locales/fr-FR/billing.json
@@ -557,7 +557,7 @@
       "addSection": {
         "captionPlaceholder": "Légende (facultatif)",
         "headingPlaceholder": "Texte du titre",
-        "imageHelp": "PNG, JPEG ou WebP, jusqu'à 5 MB.",
+        "imageHelp": "PNG ou JPEG, jusqu'à 5 MB.",
         "imageUrlPlaceholder": "https://example.com/photo.png",
         "insertHere": "Ajouter une section",
         "richTextPlaceholder": "Texte de proposition…",
@@ -875,7 +875,7 @@
         "preparedForPlaceholder": "Remplacer le nom du client",
         "showPreparedBy": "Afficher « préparé par » (votre entreprise)",
         "imageLabel": "Image de couverture",
-        "imageHelp": "PNG, JPEG ou WebP, jusqu'à 5 MB.",
+        "imageHelp": "PNG ou JPEG, jusqu'à 5 MB.",
         "removeImage": "Supprimer l'image"
       },
       "ghost": {

--- a/apps/web/src/locales/it-IT/billing.json
+++ b/apps/web/src/locales/it-IT/billing.json
@@ -557,7 +557,7 @@
       "addSection": {
         "captionPlaceholder": "Didascalia (facoltativa)",
         "headingPlaceholder": "Testo intestazione",
-        "imageHelp": "PNG, JPEG o WebP, fino a 5 MB.",
+        "imageHelp": "PNG o JPEG, fino a 5 MB.",
         "imageUrlPlaceholder": "https://example.com/photo.png",
         "insertHere": "Aggiungi sezione",
         "richTextPlaceholder": "Testo della proposta…",
@@ -838,7 +838,7 @@
         "preparedForPlaceholder": "Sostituisci il nome del cliente",
         "showPreparedBy": "Mostra “preparata da” (la tua azienda)",
         "imageLabel": "Immagine copertina",
-        "imageHelp": "PNG, JPEG o WebP, fino a 5 MB.",
+        "imageHelp": "PNG o JPEG, fino a 5 MB.",
         "removeImage": "Rimuovi immagine"
       },
       "ghost": {

--- a/apps/web/src/locales/pt-BR/billing.json
+++ b/apps/web/src/locales/pt-BR/billing.json
@@ -557,7 +557,7 @@
       "addSection": {
         "captionPlaceholder": "Legenda (opcional)",
         "headingPlaceholder": "Texto do título",
-        "imageHelp": "PNG, JPEG ou WebP, até 5 MB.",
+        "imageHelp": "PNG ou JPEG, até 5 MB.",
         "imageUrlPlaceholder": "https://example.com/photo.png",
         "insertHere": "Adicionar seção",
         "richTextPlaceholder": "Texto da proposta…",
@@ -875,7 +875,7 @@
         "preparedForPlaceholder": "Substituir o nome do cliente",
         "showPreparedBy": "Mostrar “preparado por” (sua empresa)",
         "imageLabel": "Imagem de capa",
-        "imageHelp": "PNG, JPEG ou WebP, até 5 MB.",
+        "imageHelp": "PNG ou JPEG, até 5 MB.",
         "removeImage": "Remover imagem"
       },
       "ghost": {

--- a/apps/web/src/locales/tr-TR/billing.json
+++ b/apps/web/src/locales/tr-TR/billing.json
@@ -557,7 +557,7 @@
       "addSection": {
         "captionPlaceholder": "Altyazı (isteğe bağlı)",
         "headingPlaceholder": "Başlık metni",
-        "imageHelp": "PNG, JPEG veya WebP, 5 MB'a kadar.",
+        "imageHelp": "PNG veya JPEG, 5 MB'a kadar.",
         "imageUrlPlaceholder": "https://example.com/photo.png",
         "insertHere": "Bölüm ekle",
         "richTextPlaceholder": "Teklif metni…",
@@ -883,7 +883,7 @@
         "preparedForPlaceholder": "Müşteri adını geçersiz kılın",
         "showPreparedBy": "“Şirketiniz tarafından hazırlanan”ı göster",
         "imageLabel": "Kapak resmi",
-        "imageHelp": "PNG, JPEG veya WebP, 5 MB'a kadar.",
+        "imageHelp": "PNG veya JPEG, 5 MB'a kadar.",
         "removeImage": "Resmi kaldır"
       },
       "ghost": {


### PR DESCRIPTION
## Summary

Quote PDFs are rendered with pdfkit, which can only embed PNG/JPEG. Calling `doc.image()` on WebP bytes throws, and the render loop's catch-and-continue was silently dropping the image from the exported PDF — with no error surfaced anywhere — even though the upload surface advertised (and accepted) WebP. A customer could open a sent quote PDF with a blank gap where an image should be.

`apps/api` has no image-transcoding library in its dependencies (`sharp` is only a `devDependency` of `apps/docs`, not used by the API), so per the issue's own fallback guidance this implements **option 2: reject WebP at the upload boundary**, rather than adding a new dependency to transcode it.

## Changes

- `apps/api/src/services/quoteImageStorage.ts` — `fetchRemoteImage` (URL-import path) now rejects a sniffed `image/webp` mime with a clear `QUOTE_IMAGE_WEBP_REJECTED_MESSAGE`, distinct from the generic "not an image" case.
- `apps/api/src/routes/quotes/lifecycle.ts` — the multipart `POST /:id/images` route applies the same WebP rejection (415) for direct file uploads.
- `apps/web/src/components/billing/quotes/QuoteEditor.tsx` and `QuoteLineRows.tsx` — the file-picker `accept` attributes drop `image/webp` to match what the API now actually accepts.
- `apps/api/src/services/quotePdf.ts` — defense-in-depth: the two render-time `doc.image()` catch blocks that only did `console.error` (cover image, inline image block) now also call `captureException`, matching the third call site (line thumbnails) that already reported to Sentry. This covers any WebP bytes stored before this fix shipped — they still degrade gracefully instead of aborting the PDF, but the failure is no longer invisible.

## Tests

- `apps/api/src/services/quoteImageStorage.test.ts` — new test proving `fetchRemoteImage` rejects a real WebP buffer with the clear message (not just "not an image").
- `apps/api/src/routes/quotes/lifecycle.test.ts` — new `POST /:id/images — multipart file upload` describe block proving PNG is accepted, WebP is rejected with 415 + the clear message (and never persisted), and unrecognized bytes are rejected too. Also added the URL-import-path equivalent 415 test and fixed the now-stale "PNG, JPEG, or WebP" message in an existing test.
- `apps/api/src/services/quotePdf.test.ts` — replaced the old assertion that only proved `imageIntrinsicSize` can't *parse* WebP with a real `renderQuotePdf` test proving the render path actually degrades gracefully (no throw, surrounding content still renders) when WebP bytes reach `doc.image()` — the scenario that previously shipped as a silent gap.

## Test plan

- [x] `pnpm exec vitest run apps/api/src/services/quotePdf.test.ts apps/api/src/services/quotePdf.classicRegression.test.ts apps/api/src/services/quoteImageStorage.test.ts apps/api/src/routes/quotes/lifecycle.test.ts --pool=threads --maxWorkers=2` — 103/103 passed
- [x] `tsc --noEmit` clean in `apps/api` and `apps/web`
- [x] `eslint` clean on all touched files

Closes #3483

🤖 Generated with [Claude Code](https://claude.com/claude-code)