### PR TITLE
fix(ops): make docker-compose.monitoring.yml composable with prod stack (#4362)

### DIFF
--- a/apps/api/src/config/envComposeParity.test.ts
+++ b/apps/api/src/config/envComposeParity.test.ts
@@ -91,9 +91,15 @@ const ROOT_ALLOWLIST: Record<string, string> = {
     'no consumer — the shipped business-email gate reads SIGNUP_REQUIRE_BUSINESS_EMAIL / SIGNUP_BUSINESS_EMAIL_CONTACT_URL instead',
 };
 
-// The digest-pinned droplet stack. Its api block is well-maintained; after
-// wiring the parity gaps, nothing here needs an intentional exception.
-const PROD_ALLOWLIST: Record<string, string> = {};
+// The digest-pinned droplet stack. Its api block is well-maintained; the two
+// entries below are the prod-side counterpart of GRAFANA_ADMIN_USER/PASSWORD
+// in ROOT_ALLOWLIST above — consumed by the optional docker-compose.monitoring.yml
+// overlay (see scripts/prod/deploy.sh's ENABLE_MONITORING), never by
+// deploy/docker-compose.prod.yml itself (#4362).
+const PROD_ALLOWLIST: Record<string, string> = {
+  GRAFANA_ADMIN_PASSWORD: 'consumed by docker-compose.monitoring.yml, not deploy/docker-compose.prod.yml',
+  POSTGRES_EXPORTER_DSN: 'consumed by docker-compose.monitoring.yml, not deploy/docker-compose.prod.yml',
+};
 
 interface Pair {
   name: string;

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -231,6 +231,21 @@ LOG_LEVEL=info
 METRICS_SCRAPE_TOKEN=
 SENTRY_DSN=
 
+# ── Monitoring overlay (optional, ON by default via scripts/prod/deploy.sh's
+#    ENABLE_MONITORING) ─────────────────────────────────────────────
+# docker compose -f deploy/docker-compose.prod.yml -f docker-compose.monitoring.yml ...
+# Set ENABLE_MONITORING=false before running scripts/prod/deploy.sh to skip
+# the overlay entirely and leave the vars below unset.
+GRAFANA_ADMIN_PASSWORD=
+# This stack has no local `postgres` service (managed database — see
+# DATABASE_URL above), so postgres-exporter cannot default to a local
+# `postgres` hostname the way the self-host docker-compose.yml does. Point
+# this at the SAME managed database as DATABASE_URL, in postgres_exporter's
+# DSN form (a role with pg_monitor/read access is sufficient; it does not need
+# write access):
+#   postgresql://user:password@host:port/dbname?sslmode=require
+POSTGRES_EXPORTER_DSN=
+
 # Public self-service registration is opt-in for production/self-hosted deploys.
 # Single runtime flag gates both the API endpoints and the dashboard UI (the UI
 # reads it from /api/v1/config at runtime — no web rebuild needed). Issue #1308.

--- a/deploy/compose-config-test.env
+++ b/deploy/compose-config-test.env
@@ -34,6 +34,11 @@ REMOTE_WS_LEGACY_TICKET_WRITER_DRAINED_AT=2026-01-01T00:00:00.000Z
 REMOTE_WS_LEGACY_VIEWER_ISSUER_DRAINED_AT=2026-01-01T00:00:00.000Z
 BILLING_SERVICE_API_KEY=compose-config-placeholder
 TURN_SECRET=compose-config-placeholder
+# docker-compose.monitoring.yml overlay (#4362) — has no local `postgres`
+# service, so postgres-exporter's DSN must be supplied explicitly.
+METRICS_SCRAPE_TOKEN=compose-config-placeholder
+GRAFANA_ADMIN_PASSWORD=compose-config-placeholder
+POSTGRES_EXPORTER_DSN=postgresql://user:password@db.example.invalid:5432/breeze?sslmode=require
 M365_CUSTOMER_GRAPH_READ_ONBOARDING_ENABLED=false
 # Wave 3 live-authorization epoch rollout mode (compat until the fleet drains v1 writers).
 EVENT_PERMISSION_EPOCH_MODE=compat

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -139,11 +139,20 @@ services:
     image: prometheuscommunity/postgres-exporter:v0.15.0
     container_name: breeze-postgres-exporter
     restart: unless-stopped
+    # No hard `depends_on: postgres` here on purpose: this overlay must compose
+    # cleanly on top of BOTH the root docker-compose.yml (dev, which runs a
+    # local `postgres` service) and deploy/docker-compose.prod.yml (prod, which
+    # has no local Postgres — it uses a managed database). A `depends_on` on a
+    # service name that only exists in one of the two base files makes the
+    # combined project invalid ("depends on undefined service") for the other
+    # (#4362). `restart: unless-stopped` covers the ordering gap: the exporter
+    # simply retries until the DSN below becomes reachable.
+    #
+    # POSTGRES_EXPORTER_DSN lets prod point this at the managed database
+    # instead of the local `postgres` hostname, which does not resolve there.
+    # Left unset, it falls back to the local dev DSN (unchanged behavior).
     environment:
-      DATA_SOURCE_NAME: postgresql://${POSTGRES_USER:-breeze}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD required}@postgres:5432/${POSTGRES_DB:-breeze}?sslmode=disable
-    depends_on:
-      postgres:
-        condition: service_healthy
+      DATA_SOURCE_NAME: ${POSTGRES_EXPORTER_DSN:-postgresql://${POSTGRES_USER:-breeze}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD (local dev postgres) or POSTGRES_EXPORTER_DSN (e.g. prod, no local postgres service) in .env}@postgres:5432/${POSTGRES_DB:-breeze}?sslmode=disable}
     networks:
       - breeze
 

--- a/docs/operations/DEPLOY_PRODUCTION.md
+++ b/docs/operations/DEPLOY_PRODUCTION.md
@@ -56,6 +56,7 @@ Set at least these values in `.env.prod`:
 - `METRICS_SCRAPE_TOKEN`
 - `PUBLIC_API_URL` (example: `https://app.example.com/api/v1`)
 - `GRAFANA_ADMIN_PASSWORD`
+- `POSTGRES_EXPORTER_DSN` (required when the monitoring overlay is enabled — `ENABLE_MONITORING=true`, the default for `scripts/prod/deploy.sh`; this stack has no local `postgres` service, so point it at the same managed database as `DATABASE_URL`, in `postgres_exporter`'s DSN form: `postgresql://user:password@host:port/dbname?sslmode=require`)
 
 ### Obtaining image digests
 

--- a/scripts/ops/verify-monitoring.sh
+++ b/scripts/ops/verify-monitoring.sh
@@ -6,12 +6,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 ENV_FILE="${BREEZE_ENV_FILE:-${REPO_ROOT}/.env.prod}"
 # Grafana is defined in the monitoring overlay (docker-compose.monitoring.yml),
-# which pins container_name: breeze-grafana. We exec into it by container
-# name rather than via `docker compose -f deploy/docker-compose.prod.yml -f
-# docker-compose.monitoring.yml`: that combination is not a valid compose
-# project — the monitoring overlay's postgres-exporter service depends on a
-# `postgres` service that only exists in the root docker-compose.yml (dev),
-# not in the managed-Postgres prod stack. See #4278.
+# which pins container_name: breeze-grafana. We exec into it by container name
+# rather than reconstructing the full `docker compose -f
+# deploy/docker-compose.prod.yml -f docker-compose.monitoring.yml` invocation
+# (env file, project name, etc.) just to run one `exec` — simpler, and this
+# script only needs to reach an already-running container. The two-file combo
+# itself is a valid compose project as of #4362 (previously it was not: the
+# overlay's postgres-exporter service hard-depended on a `postgres` service
+# that only exists in the root docker-compose.yml (dev), not in the
+# managed-Postgres prod stack — see #4278).
 GRAFANA_CONTAINER="${GRAFANA_CONTAINER:-breeze-grafana}"
 
 if [[ $# -ge 1 ]]; then

--- a/scripts/prod/deploy.sh
+++ b/scripts/prod/deploy.sh
@@ -133,7 +133,12 @@ required_vars=(
 )
 
 if [[ "${ENABLE_MONITORING}" == "true" ]]; then
-  required_vars+=(METRICS_SCRAPE_TOKEN GRAFANA_ADMIN_PASSWORD)
+  # POSTGRES_EXPORTER_DSN: the prod stack has no local `postgres` service (it
+  # uses a managed database), so postgres-exporter cannot fall back to the
+  # dev-only local DSN docker-compose.monitoring.yml defaults to. Required
+  # here so a missing value fails fast with a clear message instead of a
+  # buried Compose interpolation error (#4362).
+  required_vars+=(METRICS_SCRAPE_TOKEN GRAFANA_ADMIN_PASSWORD POSTGRES_EXPORTER_DSN)
 fi
 
 for name in "${required_vars[@]}"; do

--- a/scripts/security/check-supply-chain-hardening.sh
+++ b/scripts/security/check-supply-chain-hardening.sh
@@ -679,6 +679,28 @@ require_grep 'metrics_scrape_token:' docker-compose.monitoring.yml \
 require_grep 'environment: METRICS_SCRAPE_TOKEN' docker-compose.monitoring.yml \
   "monitoring compose must source metrics scrape token from the environment"
 
+# docker-compose.monitoring.yml must compose cleanly on top of BOTH base
+# stacks: the self-host root docker-compose.yml (which runs a local `postgres`
+# service) and deploy/docker-compose.prod.yml (which has no local Postgres —
+# managed database only). A `depends_on` on a service name that exists in only
+# one of the two makes the combined project invalid for the other (#4362).
+# Behavioral proof, requires Docker — advisory when unavailable, matching
+# check-relay-edge-hardening.sh's coturn probe.
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+  monitoring_err="$(mktemp)"
+  if ! docker compose --env-file .env.example -f docker-compose.yml -f docker-compose.monitoring.yml config >/dev/null 2>"$monitoring_err"; then
+    cat "$monitoring_err" >&2
+    rm -f "$monitoring_err"
+    fail "docker-compose.monitoring.yml does not compose cleanly with the root docker-compose.yml (dev)"
+  fi
+  if ! docker compose --env-file deploy/compose-config-test.env -f deploy/docker-compose.prod.yml -f docker-compose.monitoring.yml config >/dev/null 2>"$monitoring_err"; then
+    cat "$monitoring_err" >&2
+    rm -f "$monitoring_err"
+    fail "docker-compose.monitoring.yml does not compose cleanly with deploy/docker-compose.prod.yml (#4362)"
+  fi
+  rm -f "$monitoring_err"
+fi
+
 require_grep 'envFlag..ENABLE_REGISTRATION., false' apps/api/src/routes/system.ts \
   "system config status must default registration to disabled"
 require_grep "envFlag\\('ENABLE_REGISTRATION', false\\)" apps/api/src/routes/auth/schemas.ts \


### PR DESCRIPTION
## Summary

`docker-compose.monitoring.yml`'s `postgres-exporter` service hard-depended
on a `postgres` service (`depends_on: postgres: condition: service_healthy`)
that only exists in the root `docker-compose.yml` (dev stack). It does not
exist in `deploy/docker-compose.prod.yml`, which intentionally has no local
Postgres — production uses a managed database.

`docker compose -f deploy/docker-compose.prod.yml -f docker-compose.monitoring.yml config`
therefore failed immediately with `service "postgres-exporter" depends on
undefined service "postgres": invalid compose project`. This is exactly the
overlay `scripts/prod/deploy.sh` applies when `ENABLE_MONITORING=true` (its
default), so any strict-prod deploy with monitoring enabled broke at the
`compose config` validation step (`scripts/prod/deploy.sh:285`), and the
monitoring stack never actually started via that path.

## Changes

- `docker-compose.monitoring.yml`: drop the hard `depends_on: postgres`
  (the exporter now retries via `restart: unless-stopped` until its DSN is
  reachable — no ordering dependency needed). `DATA_SOURCE_NAME` now reads
  from a new `POSTGRES_EXPORTER_DSN` override, falling back to the existing
  local dev DSN unchanged, since prod has no `postgres` hostname to resolve
  against.
- `scripts/prod/deploy.sh`: require `POSTGRES_EXPORTER_DSN` alongside the
  existing `METRICS_SCRAPE_TOKEN`/`GRAFANA_ADMIN_PASSWORD` checks when
  `ENABLE_MONITORING=true`, so a missing value fails fast with a clear
  message instead of surfacing as a buried Compose interpolation error.
- `deploy/.env.example` + `docs/operations/DEPLOY_PRODUCTION.md`: document
  the new var (and the previously-undocumented `GRAFANA_ADMIN_PASSWORD`
  requirement, which `deploy.sh` already enforced but `.env.example` never
  mentioned).
- `scripts/security/check-supply-chain-hardening.sh`: extend the existing
  monitoring-compose assertions with a behavioral proof — `docker compose
  config` must resolve for **both** base-file combinations (root
  `docker-compose.yml` + overlay, and `deploy/docker-compose.prod.yml` +
  overlay), gated on Docker availability like the existing coturn probe in
  `check-relay-edge-hardening.sh`. Backed by two new placeholders in
  `deploy/compose-config-test.env`.
- `apps/api/src/config/envComposeParity.test.ts`: allow-list
  `GRAFANA_ADMIN_PASSWORD` / `POSTGRES_EXPORTER_DSN` in `PROD_ALLOWLIST` —
  they're consumed by the monitoring overlay, not
  `deploy/docker-compose.prod.yml` itself, mirroring the existing
  `GRAFANA_ADMIN_USER`/`PASSWORD` entries in `ROOT_ALLOWLIST`.
- `scripts/ops/verify-monitoring.sh`: updated a comment that had gone stale
  (it documented the now-fixed compose incompatibility as a design
  rationale for execing into the container by name; kept that design, fixed
  the claim).

## Verification

Reproduced the original failure against `origin/main` and confirmed the fix
resolves it:

```
$ docker compose --env-file deploy/compose-config-test.env \
    -f deploy/docker-compose.prod.yml -f docker-compose.monitoring.yml config
# before: service "postgres-exporter" depends on undefined service "postgres": invalid compose project
# after:  exit 0
```

Also confirmed the dev combination (`docker-compose.yml` +
`docker-compose.monitoring.yml`) still resolves cleanly and that
`postgres-exporter`'s `DATA_SOURCE_NAME` still defaults correctly to the
local dev DSN when `POSTGRES_EXPORTER_DSN` is unset.

- `pnpm exec vitest run apps/api/src/config/envComposeParity.test.ts` — 14/14 passed
- `npx tsc --noEmit` (apps/api) — clean
- `bash scripts/security/check-supply-chain-hardening.sh` — passed (includes the new compose-config behavioral check for both base-file combinations)
- `bash scripts/security/check-relay-edge-hardening.sh` — passed (sanity check, unrelated files)
- `bash -n scripts/prod/deploy.sh` — syntax OK

Closes #4362

🤖 Generated with [Claude Code](https://claude.com/claude-code)