### PR TITLE
fix(api/ai): report LLM stream 'error' events to Sentry (#4329)

### DIFF
--- a/apps/api/src/services/llm/openaiSessionManager.test.ts
+++ b/apps/api/src/services/llm/openaiSessionManager.test.ts
@@ -1,8 +1,36 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+// #4329: the runTurn() background turn touches withDbAccessContext (turnCount
+// increment in its `finally`) even on the stream-error path under test here.
+// Same db-mock shape as aiKillState.test.ts: pass calls straight through so
+// runTurn's DB write is a no-op instead of hitting a real pool.
+vi.mock('../../db', () => ({
+  db: {
+    update: () => ({ set: () => ({ where: () => Promise.resolve() }) }),
+  },
+  runOutsideDbContext: vi.fn(<T,>(fn: () => T): T => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown> | unknown) => fn()),
+}));
+
+vi.mock('../sentry', () => ({
+  captureException: vi.fn(),
+}));
+
+vi.mock('./historyBuilder', () => ({
+  buildMessagesFromHistory: vi.fn(async () => []),
+  ToolUseInHistoryError: class ToolUseInHistoryError extends Error {},
+}));
+
+vi.mock('../../config/validate', () => ({
+  getConfig: vi.fn(() => ({ MCP_LLM_MODEL: 'test-model' })),
+}));
+
 import { OpenAISessionManager } from './openaiSessionManager';
+import { captureException } from '../sentry';
 import type { RequestLike } from '../auditEvents';
 import type { OpenAICompatibleProvider } from './openaiCompatibleProvider';
 import type { AuthContext } from '../../middleware/auth';
+import type { LLMStreamEvent } from './types';
 
 // Mirrors the canonical shim in services/clientIp.test.ts.
 function makeContext(headers: Record<string, string | undefined>, remoteAddress?: string): RequestLike {
@@ -65,5 +93,57 @@ describe('OpenAISessionManager.getOrCreate — auditSnapshot.ip via trusted reso
     manager = new OpenAISessionManager({} as OpenAICompatibleProvider);
     const session = manager.getOrCreate('sess-no-ctx', 'org-1', {} as AuthContext, undefined);
     expect(session.auditSnapshot.ip).toBeUndefined();
+  });
+});
+
+describe('OpenAISessionManager.startTurn — stream error events reach Sentry (#4329)', () => {
+  let manager: OpenAISessionManager | undefined;
+
+  afterEach(() => {
+    manager?.shutdown();
+    manager = undefined;
+    vi.clearAllMocks();
+  });
+
+  it('calls captureException when the provider yields an error stream event, not just on a thrown exception', async () => {
+    // Regression guard: before #4329's fix, only the surrounding try/catch's
+    // `catch (err)` called captureException — a provider-*yielded* `error`
+    // event (the guarded-fetch refusal path added by #4324, e.g. an SSRF
+    // block or a non-2xx endpoint response) published to the client but never
+    // reached Sentry.
+    const fakeProvider = {
+      chatStream: async function* (): AsyncGenerator<LLMStreamEvent> {
+        yield { type: 'error', message: 'LLM endpoint error: HTTP 500: backend unavailable' };
+      },
+    } as unknown as OpenAICompatibleProvider;
+
+    manager = new OpenAISessionManager(fakeProvider);
+    const session = manager.getOrCreate('sess-stream-err', 'org-1', {} as AuthContext, undefined);
+    manager.tryTransitionToProcessing(session);
+
+    const events: Array<{ type: string }> = [];
+    const sub = session.eventBus.subscribe('test-sub');
+    const consumer = (async () => {
+      for await (const e of sub) {
+        events.push(e);
+        if (e.type === 'done') break;
+      }
+    })();
+
+    manager.startTurn(session, 'test-model', 'system prompt', 'hello');
+    await consumer;
+
+    // The client-facing behavior is unchanged — the error still publishes.
+    expect(events).toContainEqual({
+      type: 'error',
+      message: 'LLM endpoint error: HTTP 500: backend unavailable',
+    });
+
+    // The fix: the yielded error is ALSO reported to Sentry, same as the
+    // catch-block path for thrown exceptions.
+    expect(captureException).toHaveBeenCalledTimes(1);
+    const [reportedErr] = vi.mocked(captureException).mock.calls.at(0)!;
+    expect(reportedErr).toBeInstanceOf(Error);
+    expect((reportedErr as Error).message).toContain('LLM endpoint error: HTTP 500: backend unavailable');
   });
 });

--- a/apps/api/src/services/llm/openaiSessionManager.ts
+++ b/apps/api/src/services/llm/openaiSessionManager.ts
@@ -219,6 +219,14 @@ export class OpenAISessionManager {
               break;
             case 'error':
               hadError = true;
+              // Mirror the catch block below: this is the same failure surface
+              // (a stream error), just reported by the provider as a yielded
+              // event instead of a thrown exception. `event.message` is already
+              // the client-facing text (see openaiCompatibleProvider.ts — it is
+              // never raw provider/response text beyond what already reaches
+              // the client via the publish() below), so no separate
+              // sanitization step is needed before sending it to Sentry.
+              captureException(new Error(`LLM stream error: ${event.message}`));
               session.eventBus.publish({ type: 'error', message: event.message });
               break;
             case 'message_start':


### PR DESCRIPTION
## Summary

`apps/api/src/services/llm/openaiSessionManager.ts`'s stream loop had two
paths for the same failure surface reported two different ways: the `catch`
block (errors *thrown* out of the provider iterator) called `captureException`,
but the `case 'error':` branch (errors the provider *yields* as a stream
event) only published to the client's eventBus — never reaching Sentry.

`#4324` (merged) routed `openaiCompatibleProvider` through the guarded
`safeFetch`, which turns transport-layer conditions that previously surfaced
as thrown exceptions (DNS pinning refusals, private-network/loopback blocks,
redirect refusals, timeouts) into provider-yielded `error` events instead.
That materially increases what flows through the unreported branch — exactly
the failures an operator most needs to see after a BYO-LLM misconfiguration
(e.g. a bare-metal install pointing `MCP_LLM_BASE_URL` at
`http://localhost:8000/v1`, now refused by the egress guard) produced no
Sentry signal at all, only a message in the user's chat window.

## Fix

```ts
case 'error':
  hadError = true;
  captureException(new Error(`LLM stream error: ${event.message}`));
  session.eventBus.publish({ type: 'error', message: event.message });
  break;
```

Mirrors the sibling `catch` block's convention: that block calls
`captureException(err)` with no extra tags, so there's nothing to mirror onto
the Sentry scrubber's tag allowlist here either — kept intentionally plain
rather than inventing new tags that would silently get voided.

`event.message` is already the exact string the very same line publishes to
the client, so capturing it in Sentry doesn't expose anything beyond what the
client already sees — no separate sanitization step (like the `catch`
block's `sanitizeErrorForClient`) is needed.

Diff is surgical to the `case 'error':` branch — #4384 (session eviction) is
being fixed in the same file in parallel.

## Test plan

- Added a regression test asserting `captureException` is called when the
  provider yields a stream `error` event (previously would fail with
  "called 0 times" — verified red against the pre-fix code before applying
  the fix).
- `apps/api/src/services/llm/openaiSessionManager.test.ts` — 4/4 passed
  (`pnpm exec vitest run src/services/llm/openaiSessionManager.test.ts --pool=threads --maxWorkers=2`)
- `pnpm exec tsc --noEmit --project apps/api/tsconfig.json` — clean
- `eslint` on both touched files — clean

Closes #4329

🤖 Generated with [Claude Code](https://claude.com/claude-code)