### PR TITLE
fix(api): webhook_deliveries blocks GDPR org erasure — add ON DELETE CASCADE (#4100)

### DIFF
--- a/apps/api/migrations/2026-09-29-webhook-deliveries-cascade.sql
+++ b/apps/api/migrations/2026-09-29-webhook-deliveries-cascade.sql
@@ -1,0 +1,24 @@
+-- #4100: webhook_deliveries.webhook_id -> webhooks.id has no ON DELETE action
+-- (defaults to NO ACTION), while `webhooks` IS registered in
+-- CORE_ORG_CASCADE_DELETE_ORDER (tenantCascade.ts). The moment an org's
+-- webhook has ever recorded a delivery, org erasure's DELETE FROM webhooks
+-- raises a 23503 FK violation and the whole erasure aborts.
+--
+-- Fix: ON DELETE CASCADE. Delivery rows are worthless without their webhook
+-- (they exist purely to record/replay a POST for a webhook that itself just
+-- got deleted), so cascading them is correct, not just convenient. This is
+-- the same shape as software_install_methods.catalog_id (see
+-- tenantCascade.ts's ASSOCIATED_SYSTEM_SCOPED_TABLES comment) — a DB-level
+-- ON DELETE CASCADE needs no entry in the erasure pre-clear list, the
+-- org-merge registry, or the export-policy registry, because the cascade
+-- deletes the child automatically when the parent goes, and merge only
+-- repoints `webhooks.org_id` (webhook_deliveries has no org_id column of its
+-- own; it travels with its parent's id, which merge never changes).
+--
+-- webhook_deliveries already carries RLS (PARENT_FK_JOIN_POLICY_TABLES,
+-- PR #1290) — untouched here.
+ALTER TABLE webhook_deliveries
+  DROP CONSTRAINT IF EXISTS webhook_deliveries_webhook_id_webhooks_id_fk;
+ALTER TABLE webhook_deliveries
+  ADD CONSTRAINT webhook_deliveries_webhook_id_webhooks_id_fk
+  FOREIGN KEY (webhook_id) REFERENCES webhooks(id) ON DELETE CASCADE;

--- a/apps/api/src/__tests__/integration/tenantCascadeExecution.integration.test.ts
+++ b/apps/api/src/__tests__/integration/tenantCascadeExecution.integration.test.ts
@@ -31,6 +31,9 @@ interface SeedHandles {
   siteIdControl: string;
   accountingConnectionId: string;
   catalogItemId: string;
+  webhookIdErased: string;
+  webhookIdControl: string;
+  webhookDeliveryIdErased: string;
 }
 
 async function seed(): Promise<SeedHandles> {
@@ -139,6 +142,37 @@ async function seed(): Promise<SeedHandles> {
       (${accountingConnectionId}, ${partnerId}, 'catalog_item', ${catalogItemId}, 'Item', 'qbo-item-1', 'confirmed', 'synced')
   `);
 
+  // Regression fixture for #4100: webhooks IS in CORE_ORG_CASCADE_DELETE_ORDER,
+  // but webhook_deliveries has no org_id column (invisible to the cascade
+  // contract test's org_id auto-discovery) and formerly had no ON DELETE
+  // action on its webhook_id FK — so a populated delivery row made the plain
+  // `DELETE FROM webhooks WHERE org_id = ...` below raise 23503 and abort the
+  // whole erasure. One webhook + delivery per org, mirroring the
+  // erased/control shape used throughout this fixture.
+  const [webhookErased] = (await testDb.execute(sql`
+    INSERT INTO webhooks (org_id, name, url, events)
+    VALUES (${orgIdToErase}, 'Erase Webhook', 'https://example.com/erase', ARRAY['ticket.created'])
+    RETURNING id
+  `)) as unknown as Array<{ id: string }>;
+  const [webhookControl] = (await testDb.execute(sql`
+    INSERT INTO webhooks (org_id, name, url, events)
+    VALUES (${orgIdControl}, 'Control Webhook', 'https://example.com/control', ARRAY['ticket.created'])
+    RETURNING id
+  `)) as unknown as Array<{ id: string }>;
+  const webhookIdErased = webhookErased!.id;
+  const webhookIdControl = webhookControl!.id;
+
+  const [deliveryErased] = (await testDb.execute(sql`
+    INSERT INTO webhook_deliveries (webhook_id, event_type, event_id, payload)
+    VALUES (${webhookIdErased}, 'ticket.created', 'evt-erased-1', '{}'::jsonb)
+    RETURNING id
+  `)) as unknown as Array<{ id: string }>;
+  await testDb.execute(sql`
+    INSERT INTO webhook_deliveries (webhook_id, event_type, event_id, payload)
+    VALUES (${webhookIdControl}, 'ticket.created', 'evt-control-1', '{}'::jsonb)
+  `);
+  const webhookDeliveryIdErased = deliveryErased!.id;
+
   return {
     partnerId,
     orgIdToErase,
@@ -148,6 +182,9 @@ async function seed(): Promise<SeedHandles> {
     siteIdControl,
     accountingConnectionId,
     catalogItemId,
+    webhookIdErased,
+    webhookIdControl,
+    webhookDeliveryIdErased,
   };
 }
 
@@ -276,5 +313,41 @@ describe('cascadeDeleteOrg — end-to-end', () => {
     const stats = await cascadeDeleteOrg(handles.orgIdToErase, handles.userId);
     // Org was already erased; every cascade-list table matches zero rows.
     expect(stats.totalRowsDeleted).toBe(0);
+  });
+
+  // Regression test for #4100.
+  it('erases an org with a populated webhook_deliveries row instead of aborting on FK violation', async () => {
+    const testDb = getTestDb();
+
+    // Before the fix, this threw a 23503 FK violation (webhook_deliveries.
+    // webhook_id had no ON DELETE action) and the erasure aborted entirely —
+    // the assertion that matters here is that this does NOT throw.
+    const stats = await cascadeDeleteOrg(handles.orgIdToErase, handles.userId);
+
+    expect(stats.tablesDeleted.webhooks).toBe(1);
+
+    const erasedWebhookRows = (await testDb.execute(
+      sql`SELECT id FROM webhooks WHERE id = ${handles.webhookIdErased}`,
+    )) as unknown as unknown[];
+    expect(erasedWebhookRows.length).toBe(0);
+
+    // The delivery row has no org_id of its own — it is gone because
+    // ON DELETE CASCADE removed it when its parent webhook was deleted, not
+    // because the cascade loop targeted webhook_deliveries directly.
+    const erasedDeliveryRows = (await testDb.execute(
+      sql`SELECT id FROM webhook_deliveries WHERE id = ${handles.webhookDeliveryIdErased}`,
+    )) as unknown as unknown[];
+    expect(erasedDeliveryRows.length).toBe(0);
+
+    // Control org's webhook + delivery are untouched.
+    const controlWebhookRows = (await testDb.execute(
+      sql`SELECT id FROM webhooks WHERE id = ${handles.webhookIdControl}`,
+    )) as unknown as unknown[];
+    expect(controlWebhookRows.length).toBe(1);
+
+    const controlDeliveryRows = (await testDb.execute(
+      sql`SELECT id FROM webhook_deliveries WHERE webhook_id = ${handles.webhookIdControl}`,
+    )) as unknown as unknown[];
+    expect(controlDeliveryRows.length).toBe(1);
   });
 });

--- a/apps/api/src/db/schema/integrations.ts
+++ b/apps/api/src/db/schema/integrations.ts
@@ -80,7 +80,7 @@ export const webhooks = pgTable('webhooks', {
 
 export const webhookDeliveries = pgTable('webhook_deliveries', {
   id: uuid('id').primaryKey().defaultRandom(),
-  webhookId: uuid('webhook_id').notNull().references(() => webhooks.id),
+  webhookId: uuid('webhook_id').notNull().references(() => webhooks.id, { onDelete: 'cascade' }),
   eventType: varchar('event_type', { length: 100 }).notNull(),
   eventId: varchar('event_id', { length: 100 }).notNull(),
   payload: jsonb('payload').notNull(),

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -559,10 +559,9 @@ webhookRoutes.delete(
       return c.json({ error: 'Webhook not found' }, 404);
     }
 
-    await db
-      .delete(webhookDeliveries)
-      .where(eq(webhookDeliveries.webhookId, webhook.id));
-
+    // webhook_deliveries.webhook_id is ON DELETE CASCADE (#4100,
+    // 2026-09-29-webhook-deliveries-cascade.sql) — deliveries are removed by
+    // Postgres when the webhook row goes, so no explicit pre-delete here.
     await db
       .delete(webhooksTable)
       .where(eq(webhooksTable.id, webhook.id));


### PR DESCRIPTION
Closes #4100

## Problem

`webhook_deliveries.webhook_id -> webhooks.id` had no `ON DELETE` action (defaulting to `NO ACTION`), while `webhooks` IS registered in `CORE_ORG_CASCADE_DELETE_ORDER` (`tenantCascade.ts`). The moment an org's webhook had ever recorded a delivery, GDPR org erasure's `DELETE FROM webhooks` raised a `23503` FK violation and aborted the whole erasure — the same failure shape CLAUDE.md documents as shipped/blocked five times before (#1359, #1351, #1365, #2179, #2514).

`webhook_deliveries` has no `org_id` column, so the org-cascade contract test's `org_id`-based auto-discovery could never require it in a cascade list.

## Fix

New idempotent migration (`2026-09-29-webhook-deliveries-cascade.sql`): `DROP CONSTRAINT IF EXISTS` + re-add `webhook_deliveries_webhook_id_webhooks_id_fk` with `ON DELETE CASCADE`, mirrored in the Drizzle schema (`onDelete: 'cascade'`). Delivery rows are worthless without their webhook, so cascading is correct, not just convenient — the preferred fix option called out in the issue.

## Why no other registration list needs a change

This repo has multiple tenant-table registration lists, so I checked each one against precedent already in the codebase rather than assuming:

- **`tenantCascade.ts` `ASSOCIATED_SYSTEM_SCOPED_TABLES`** (the FK pre-clear list): not needed — a DB-level `ON DELETE CASCADE` makes the pre-clear unnecessary. Matches the existing `software_install_methods.catalog_id` precedent in the same file ("needs no entry: its catalog_id FK is ON DELETE CASCADE").
- **`orgMergeRegistry.ts` / its `EXTRA_REQUIRED` contract list**: not needed — `webhook_deliveries` has no `org_id` column and is not in `getOrgCascadeDeleteOrder()`, and (unlike `report_runs`, which *did* need an entry when it joined `ASSOCIATED_SYSTEM_SCOPED_TABLES`) this fix never adds `webhook_deliveries` to that list, so it stays out of merge's scope — merge only repoints `webhooks.org_id`, and the child rows travel with their parent's unchanged `id` for free.
- **`tenantExportPolicyRegistry.ts`**: not needed — the registry is `org_id`-keyed and explicitly exempts no-`org_id` tables (see the existing `report_runs` comment: "has no org_id, so its matching principal_kind column needs no policy entry").
- **RLS coverage (`PARENT_FK_JOIN_POLICY_TABLES`)**: already registered by PR #1290 — untouched here, confirmed still passing.
- **moveOrg coverage**: not applicable — that axis is device-org moves; webhooks/deliveries aren't device-scoped.

## Verification

Ran against a fully isolated per-worktree Postgres (`pnpm test-stack up`, not the shared test container, to avoid cross-contamination from other in-flight work):

- Applied the new migration to a fresh DB, then re-ran `db:migrate` a second time — no-op, confirming idempotency.
- `pnpm db:check-drift` — clean, all 618 migration files match the ledger.
- Manual forge: inserted a webhook + a `webhook_deliveries` row referencing it, deleted the webhook, confirmed the delivery row cascade-deleted (`confdeltype = 'c'` on the constraint; 1 row before, 0 after).
- `vitest run src/services/tenantCascade.test.ts src/services/tenantCascade.partner.test.ts` — 25/25 passed.
- `vitest run --config vitest.integration.config.ts src/__tests__/integration/tenantCascade.integration.test.ts src/__tests__/integration/orgMergeRegistry.integration.test.ts` — 19/19 passed (real Postgres; confirms orgMergeRegistry needs no changes).
- `vitest run --config vitest.config.rls-coverage.ts` — 80/80 passed (confirms the existing RLS registration for `webhook_deliveries` is intact).
- `vitest run --config vitest.integration.config.ts src/__tests__/integration/tenantExportErasureRoundtrip.integration.test.ts` — 2/2 passed (confirms export policy needs no changes).
- `vitest run src/routes/webhooks.test.ts src/services/webhookDeliveryRecord.sql.test.ts src/jobs/webhookDeliveryRecovery.sql.test.ts` — 21/21 passed (no regression in the webhook delivery/recovery code paths).
- `tsc --noEmit` (apps/api) — clean.

## Out of scope

- The issue's suggested regression guard ("every FK into a `CORE_ORG_CASCADE_DELETE_ORDER` table from a non-cascade table carries `ON DELETE CASCADE`/`SET NULL`") — worth doing but is a separate, broader contract-test addition; not bundled here to keep this fix minimal and reviewable.
- The retention-job gap noted in the issue (no horizon on `webhook_deliveries` growth) — explicitly flagged in the issue as "worth bundling ... or filing separately"; left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)