### PR TITLE
perf(api): roll up each metric source in one pass instead of once per metric (#4341)

### DIFF
--- a/apps/api/src/__tests__/integration/metricRollups.integration.test.ts
+++ b/apps/api/src/__tests__/integration/metricRollups.integration.test.ts
@@ -50,7 +50,18 @@ async function insertMetric(options: {
   deviceId: string;
   timestamp: Date;
   cpuPercent: number;
+  /** #4341: leave every nullable column NULL, as an agent that reports no disk/network/process counters does. */
+  nullableColumnsNull?: boolean;
 }): Promise<void> {
+  const nullable = options.nullableColumnsNull
+    ? {
+      diskReadBps: null, diskWriteBps: null,
+      bandwidthInBps: null, bandwidthOutBps: null, processCount: null,
+    }
+    : {
+      diskReadBps: 100, diskWriteBps: 200,
+      bandwidthInBps: 300, bandwidthOutBps: 400, processCount: 50,
+    };
   await (getTestDb() as any).insert(deviceMetrics).values({
     orgId: options.orgId,
     deviceId: options.deviceId,
@@ -60,11 +71,7 @@ async function insertMetric(options: {
     ramUsedMb: 2048,
     diskPercent: 40,
     diskUsedGb: 120,
-    diskReadBps: 100,
-    diskWriteBps: 200,
-    bandwidthInBps: 300,
-    bandwidthOutBps: 400,
-    processCount: 50,
+    ...nullable,
   });
 }
 
@@ -371,6 +378,87 @@ describe('metric rollups integration', () => {
       gapSeconds: 240,
     }));
     expect((updatedGapBucket.metadata as Record<string, unknown>).isGap).toBe(false);
+  });
+
+  // #4341 — the raw passes went from one statement per metric (10 over
+  // device_metrics, 7 over device_process_samples) to one statement per source
+  // table. These two pin the properties that a single shared bucket grid could
+  // most plausibly break: that every series is still emitted, and that a series
+  // whose column is NULL for the whole window is still emitted for NO buckets
+  // rather than a window's worth of `isGap` rows.
+  describe('#4341 single-pass raw rollups', () => {
+    it('emits every device_metrics and process-sample series from one pass per source table', async () => {
+      const device = await insertDevice({ orgId: orgA, siteId: siteA, hostname: 'all-series-device' });
+      await insertMetric({ orgId: orgA, deviceId: device, timestamp: new Date('2026-06-18T12:00:00.000Z'), cpuPercent: 10 });
+      await insertMetric({ orgId: orgA, deviceId: device, timestamp: new Date('2026-06-18T12:01:00.000Z'), cpuPercent: 30 });
+      await insertProcessSample({
+        orgId: orgA, deviceId: device, timestamp: new Date('2026-06-18T12:00:00.000Z'),
+        cpu: 12, ramMb: 512, diskBps: 1000, netBps: 2000,
+      });
+
+      await runRollup(orgA, new Date('2026-06-18T12:00:00.000Z'), new Date('2026-06-18T12:05:00.000Z'));
+
+      const rows = await getTestDb()
+        .select()
+        .from(metricRollups)
+        .where(and(
+          eq(metricRollups.orgId, orgA),
+          eq(metricRollups.deviceId, device),
+          eq(metricRollups.bucketSeconds, 300)
+        ));
+
+      const byName = new Map(rows.map((row) => [row.metricName, row]));
+      expect([...byName.keys()].sort()).toEqual([
+        'bandwidth_in_bps', 'bandwidth_out_bps', 'cpu_percent', 'disk_percent',
+        'disk_read_bps', 'disk_used_gb', 'disk_write_bps', 'process_count',
+        'ram_percent', 'ram_used_mb',
+        'top_process_count', 'top_process_cpu_percent_max', 'top_process_cpu_percent_sum',
+        'top_process_disk_bps_sum', 'top_process_net_bps_sum',
+        'top_process_ram_mb_max', 'top_process_ram_mb_sum',
+      ]);
+
+      // metric_type still travels with its own series, not the first one's.
+      expect(byName.get('cpu_percent')?.metricType).toBe('cpu');
+      expect(byName.get('ram_used_mb')?.metricType).toBe('memory');
+      expect(byName.get('bandwidth_in_bps')?.metricType).toBe('network');
+      expect(byName.get('process_count')?.metricType).toBe('process');
+      expect(byName.get('top_process_ram_mb_sum')?.sourceTable).toBe('device_process_samples');
+
+      // Each series aggregates its OWN column, so the values must differ.
+      expect(byName.get('cpu_percent')?.avgValue).toBe(20);
+      expect(byName.get('ram_used_mb')?.avgValue).toBe(2048);
+      expect(byName.get('cpu_percent')?.sampleCount).toBe(2);
+      expect(byName.get('top_process_ram_mb_sum')?.avgValue).toBe(512);
+      expect(byName.get('top_process_net_bps_sum')?.avgValue).toBe(2000);
+    });
+
+    it('emits no rollups for a device_metrics column that is NULL across the whole window', async () => {
+      const device = await insertDevice({ orgId: orgA, siteId: siteA, hostname: 'null-columns-device' });
+      await insertMetric({
+        orgId: orgA, deviceId: device, timestamp: new Date('2026-06-18T12:00:00.000Z'),
+        cpuPercent: 10, nullableColumnsNull: true,
+      });
+
+      await runRollup(orgA, new Date('2026-06-18T12:00:00.000Z'), new Date('2026-06-18T12:10:00.000Z'));
+
+      const names = (await getTestDb()
+        .select()
+        .from(metricRollups)
+        .where(and(
+          eq(metricRollups.orgId, orgA),
+          eq(metricRollups.deviceId, device),
+          eq(metricRollups.sourceTable, 'device_metrics'),
+          eq(metricRollups.bucketSeconds, 300)
+        )))
+        .map((row) => row.metricName);
+
+      // The NOT NULL columns still roll up (two 300s buckets each, one of them a gap).
+      expect(names.filter((name) => name === 'cpu_percent')).toHaveLength(2);
+      // The nullable ones must produce nothing at all — not gap rows.
+      for (const name of ['disk_read_bps', 'disk_write_bps', 'bandwidth_in_bps', 'bandwidth_out_bps', 'process_count']) {
+        expect(names).not.toContain(name);
+      }
+    });
   });
 
   it('materializes linked SNMP metric buckets and ignores unlinked or non-numeric SNMP series', async () => {

--- a/apps/api/src/__tests__/integration/metricRollups.integration.test.ts
+++ b/apps/api/src/__tests__/integration/metricRollups.integration.test.ts
@@ -424,12 +424,44 @@ describe('metric rollups integration', () => {
       expect(byName.get('process_count')?.metricType).toBe('process');
       expect(byName.get('top_process_ram_mb_sum')?.sourceTable).toBe('device_process_samples');
 
-      // Each series aggregates its OWN column, so the values must differ.
-      expect(byName.get('cpu_percent')?.avgValue).toBe(20);
-      expect(byName.get('ram_used_mb')?.avgValue).toBe(2048);
-      expect(byName.get('cpu_percent')?.sampleCount).toBe(2);
-      expect(byName.get('top_process_ram_mb_sum')?.avgValue).toBe(512);
+      // Each series aggregates its OWN column, so every aggregate must carry
+      // that column's numbers — not the first series', and not a mix.
+      expect(byName.get('cpu_percent')).toEqual(expect.objectContaining({
+        avgValue: 20,      // (10 + 30) / 2
+        minValue: 10,
+        maxValue: 30,
+        p95Value: 29,      // percentile_cont(0.95) over [10, 30]
+        sumValue: 40,
+        sampleCount: 2,
+        gapSeconds: 180,   // 300 - 2 * expectedSampleSeconds(60)
+      }));
+      expect(byName.get('cpu_percent')?.metadata).toEqual({
+        rollupVersion: 'metric-rollups-v1',
+        source: 'raw',
+        expectedSampleSeconds: 60,
+        isGap: false,
+      });
+
+      expect(byName.get('ram_used_mb')).toEqual(expect.objectContaining({
+        avgValue: 2048, minValue: 2048, maxValue: 2048, sumValue: 4096, sampleCount: 2,
+      }));
+
+      expect(byName.get('top_process_ram_mb_sum')).toEqual(expect.objectContaining({
+        avgValue: 512, minValue: 512, maxValue: 512, p95Value: 512, sumValue: 512,
+        sampleCount: 1,
+        gapSeconds: 240,   // 300 - 1 * 60
+      }));
       expect(byName.get('top_process_net_bps_sum')?.avgValue).toBe(2000);
+      expect(byName.get('top_process_disk_bps_sum')?.avgValue).toBe(1000);
+      expect(byName.get('top_process_cpu_percent_max')?.avgValue).toBe(12);
+      expect(byName.get('top_process_count')?.avgValue).toBe(1);
+      expect(byName.get('top_process_count')?.metadata).toEqual({
+        rollupVersion: 'metric-rollups-v1',
+        source: 'raw',
+        sourceTable: 'device_process_samples',
+        expectedSampleSeconds: 60,
+        isGap: false,
+      });
     });
 
     it('emits no rollups for a device_metrics column that is NULL across the whole window', async () => {

--- a/apps/api/src/jobs/metricRollups.test.ts
+++ b/apps/api/src/jobs/metricRollups.test.ts
@@ -104,7 +104,7 @@ describe('metric rollups queue helpers', () => {
     groupByMock.mockReset();
     workerProcessorMock.mockReset();
     rollupDeviceMetricsRangeMock.mockReset();
-    rollupDeviceMetricsRangeMock.mockResolvedValue({ statements: 24, skipped: false });
+    rollupDeviceMetricsRangeMock.mockResolvedValue({ statements: 9, skipped: false });
     runOutsideDbContextMock.mockClear();
     withSystemDbAccessContextMock.mockClear();
     runOutsideDbContextMock.mockImplementation(<T>(fn: () => T) => fn());
@@ -254,8 +254,8 @@ describe('metric rollups queue helpers', () => {
   });
 
   // #4276 — the worker used to wrap ALL of rollupDeviceMetricsRange in one
-  // system context, pinning a pooled connection across 26 sequential statements
-  // for 2s+ every 5 minutes. The service now owns one short-lived context per
+  // system context, pinning a pooled connection across every sequential
+  // statement of the pass for 2s+ every 5 minutes. The service now owns one short-lived context per
   // statement; a wrap here would make each of those short-circuit back into a
   // single transaction and silently restore the hold (the alertWorker/#3216
   // trap).

--- a/apps/api/src/services/metricRollups.test.ts
+++ b/apps/api/src/services/metricRollups.test.ts
@@ -12,10 +12,13 @@ const {
   runOutsideDbContextMock,
   withSystemDbAccessContextMock,
   contextTrace,
+  openContext,
 } = vi.hoisted(() => {
   const contextTrace: ContextTraceEvent[] = [];
+  const openContext: { label: string | undefined } = { label: undefined };
   return {
     contextTrace,
+    openContext,
     executeMock: vi.fn(),
     shouldProduceMlOutputMock: vi.fn(),
     runOutsideDbContextMock: vi.fn(<T>(fn: () => T): T => {
@@ -24,9 +27,12 @@ const {
     }),
     withSystemDbAccessContextMock: vi.fn(async (fn: () => Promise<unknown>, label?: string) => {
       contextTrace.push({ type: 'open', label });
+      const previous = openContext.label;
+      openContext.label = label;
       try {
         return await fn();
       } finally {
+        openContext.label = previous;
         contextTrace.push({ type: 'close', label });
       }
     }),
@@ -52,12 +58,36 @@ function openedLabels(): Array<string | undefined> {
   return contextTrace.filter((event) => event.type === 'open').map((event) => event.label);
 }
 
+/** Every statement issued under `label`, serialized the way the SQL assertions read it. */
+const executedSqlByLabel = new Map<string, string[]>();
+
+/**
+ * The one statement issued under `label`. Fails loudly when a label ran more
+ * (or fewer) than once, which is exactly the #4341 regression: one statement
+ * per raw source table, not one per metric.
+ */
+function onlyStatementFor(label: string): string {
+  const statements = executedSqlByLabel.get(label) ?? [];
+  expect(statements).toHaveLength(1);
+  return statements[0] as string;
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
 describe('metric rollups service', () => {
   beforeEach(() => {
     contextTrace.length = 0;
+    executedSqlByLabel.clear();
+    openContext.label = undefined;
     executeMock.mockReset();
-    executeMock.mockImplementation(async () => {
+    executeMock.mockImplementation(async (statement: unknown) => {
       contextTrace.push({ type: 'execute' });
+      const label = openContext.label ?? '<no-context>';
+      const existing = executedSqlByLabel.get(label) ?? [];
+      existing.push(JSON.stringify(statement));
+      executedSqlByLabel.set(label, existing);
       return [];
     });
     shouldProduceMlOutputMock.mockReset();
@@ -96,8 +126,8 @@ describe('metric rollups service', () => {
       to: new Date('2026-06-18T13:00:00.000Z'),
     });
 
-    expect(result).toMatchObject({ statements: 24, skipped: false });
-    expect(executeMock).toHaveBeenCalledTimes(24);
+    expect(result).toMatchObject({ statements: 9, skipped: false });
+    expect(executeMock).toHaveBeenCalledTimes(9);
     const executedSql = JSON.stringify(executeMock.mock.calls);
     expect(executedSql).toContain('ON CONFLICT');
     expect(executedSql).toContain('percentile_cont(0.95)');
@@ -115,7 +145,7 @@ describe('metric rollups service', () => {
       expectedSampleSeconds: 60,
     });
 
-    const rawStatementSql = JSON.stringify(executeMock.mock.calls[0]);
+    const rawStatementSql = onlyStatementFor('metricRollups.raw.device_metrics');
     expect(rawStatementSql).toContain('generate_series');
     expect(rawStatementSql).toContain('bucket_grid');
     expect(rawStatementSql).toContain('LEFT JOIN device_metrics');
@@ -132,11 +162,11 @@ describe('metric rollups service', () => {
       to: new Date('2026-06-18T12:15:00.000Z'),
     });
 
-    // The raw device statement is the first execute() call. Its LEFT JOIN must
-    // carry an explicit [from,to) bound in addition to the per-bucket bound;
-    // without it the generate_series-derived bucket_start predicate is
-    // non-sargable and Postgres bitmap-scans each device's entire history.
-    const rawDeviceSql = JSON.stringify(executeMock.mock.calls[0]);
+    // The raw device statement's LEFT JOIN must carry an explicit [from,to)
+    // bound in addition to the per-bucket bound; without it the
+    // generate_series-derived bucket_start predicate is non-sargable and
+    // Postgres bitmap-scans each device's entire history.
+    const rawDeviceSql = onlyStatementFor('metricRollups.raw.device_metrics');
     expect(rawDeviceSql).toContain('LEFT JOIN device_metrics');
     expect(rawDeviceSql).toContain('join window bound');
   });
@@ -148,7 +178,7 @@ describe('metric rollups service', () => {
       to: new Date('2026-06-18T13:00:00.000Z'),
     });
 
-    const hourlyStatementSql = JSON.stringify(executeMock.mock.calls[18]);
+    const hourlyStatementSql = onlyStatementFor('metricRollups.derived.device_metrics.3600');
     expect(hourlyStatementSql).toContain('sum(mr.avg_value * mr.sample_count)');
     expect(hourlyStatementSql).toContain('sum(mr.gap_seconds)');
     expect(hourlyStatementSql).not.toContain('AND mr.sample_count > 0');
@@ -162,7 +192,9 @@ describe('metric rollups service', () => {
       to: new Date('2026-06-18T12:15:00.000Z'),
     });
 
-    const processStatementSql = JSON.stringify(executeMock.mock.calls[10]);
+    // All seven series now come out of ONE statement (#4341); each assertion
+    // below still pins the SQL that produces its series.
+    const processStatementSql = onlyStatementFor('metricRollups.raw.device_process_samples');
     expect(processStatementSql).toContain('device_process_samples');
     expect(processStatementSql).toContain('process_devices');
     expect(processStatementSql).toContain('sample_values');
@@ -170,20 +202,17 @@ describe('metric rollups service', () => {
     expect(processStatementSql).toContain('jsonb_array_length(dps.top_processes)');
     expect(processStatementSql).toContain("'process'");
 
-    const processCpuStatementSql = JSON.stringify(executeMock.mock.calls[11]);
-    expect(processCpuStatementSql).toContain('top_process_cpu_percent_sum');
-    expect(processCpuStatementSql).toContain('jsonb_array_elements(dps.top_processes)');
-    expect(processCpuStatementSql).toContain("proc.value -> 'cpu'");
+    expect(processStatementSql).toContain('top_process_cpu_percent_sum');
+    expect(processStatementSql).toContain('jsonb_array_elements(dps.top_processes)');
+    expect(processStatementSql).toContain("proc.value -> 'cpu'");
 
-    const processCpuMaxStatementSql = JSON.stringify(executeMock.mock.calls[12]);
-    expect(processCpuMaxStatementSql).toContain('top_process_cpu_percent_max');
-    expect(processCpuMaxStatementSql).toContain('max(');
+    expect(processStatementSql).toContain('top_process_cpu_percent_max');
+    expect(processStatementSql).toContain('max(');
 
-    const processRamMaxStatementSql = JSON.stringify(executeMock.mock.calls[14]);
-    expect(processRamMaxStatementSql).toContain('top_process_ram_mb_max');
-    expect(processRamMaxStatementSql).toContain("proc.value -> 'ramMb'");
+    expect(processStatementSql).toContain('top_process_ram_mb_max');
+    expect(processStatementSql).toContain("proc.value -> 'ramMb'");
 
-    const processHourlyStatementSql = JSON.stringify(executeMock.mock.calls[20]);
+    const processHourlyStatementSql = onlyStatementFor('metricRollups.derived.device_process_samples.3600');
     expect(processHourlyStatementSql).toContain('device_process_samples');
     expect(processHourlyStatementSql).toContain('sourceBucketSeconds');
   });
@@ -195,7 +224,7 @@ describe('metric rollups service', () => {
       to: new Date('2026-06-18T12:15:00.000Z'),
     });
 
-    const snmpStatementSql = JSON.stringify(executeMock.mock.calls[17]);
+    const snmpStatementSql = onlyStatementFor('metricRollups.raw.snmp_metrics');
     expect(snmpStatementSql).toContain('snmp_metrics');
     expect(snmpStatementSql).toContain('snmp_devices');
     expect(snmpStatementSql).toContain('discovered_assets');
@@ -207,13 +236,110 @@ describe('metric rollups service', () => {
     expect(snmpStatementSql).toContain('snmpDeviceId');
     expect(snmpStatementSql).toContain('displayName');
 
-    const snmpHourlyStatementSql = JSON.stringify(executeMock.mock.calls[22]);
+    const snmpHourlyStatementSql = onlyStatementFor('metricRollups.derived.snmp_metrics.3600');
     expect(snmpHourlyStatementSql).toContain('snmp_metrics');
     expect(snmpHourlyStatementSql).toContain('sourceBucketSeconds');
   });
 
+  // #4341 — the raw passes used to issue ONE full CTE per metric: 10 scans of
+  // the `device_metrics` window plus 7 scans of the `device_process_samples`
+  // window, per org, every 5 minutes. On US prod the process-sample CTE alone
+  // ran ~107k times over 31.5h at 1.5-2.0s mean (~168,600s total, ~150% of the
+  // managed DB's single vCPU, 900+GB of shared buffer reads) and was the top DB
+  // load by a wide margin. Each source window is now scanned once and every
+  // series is derived from that single pass.
+  describe('#4341 single-pass raw rollups', () => {
+    const DEVICE_METRIC_SERIES: ReadonlyArray<readonly [string, string]> = [
+      ['cpu', 'cpu_percent'],
+      ['memory', 'ram_percent'],
+      ['memory', 'ram_used_mb'],
+      ['disk', 'disk_percent'],
+      ['disk', 'disk_used_gb'],
+      ['disk', 'disk_read_bps'],
+      ['disk', 'disk_write_bps'],
+      ['network', 'bandwidth_in_bps'],
+      ['network', 'bandwidth_out_bps'],
+      ['process', 'process_count'],
+    ];
+    const PROCESS_METRIC_SERIES: readonly string[] = [
+      'top_process_count',
+      'top_process_cpu_percent_sum',
+      'top_process_cpu_percent_max',
+      'top_process_ram_mb_sum',
+      'top_process_ram_mb_max',
+      'top_process_disk_bps_sum',
+      'top_process_net_bps_sum',
+    ];
+
+    const RANGE = {
+      orgId: '11111111-1111-1111-1111-111111111111',
+      from: new Date('2026-06-18T12:00:00.000Z'),
+      to: new Date('2026-06-18T13:00:00.000Z'),
+    } as const;
+
+    it('scans each raw source window once per pass, not once per metric', async () => {
+      const result = await rollupDeviceMetricsRange({ ...RANGE });
+
+      // 1 device_metrics + 1 device_process_samples + 1 snmp_metrics + 6 derived.
+      expect(result).toMatchObject({ statements: 9, skipped: false });
+      expect(executeMock).toHaveBeenCalledTimes(9);
+      expect(executedSqlByLabel.get('metricRollups.raw.device_metrics')).toHaveLength(1);
+      expect(executedSqlByLabel.get('metricRollups.raw.device_process_samples')).toHaveLength(1);
+    });
+
+    it('derives all ten device_metrics series from that one scan, each keeping its own metric_type', async () => {
+      await rollupDeviceMetricsRange({ ...RANGE });
+
+      const deviceSql = onlyStatementFor('metricRollups.raw.device_metrics');
+      for (const [metricType, metricName] of DEVICE_METRIC_SERIES) {
+        expect(deviceSql).toContain(metricName);
+        expect(deviceSql).toContain(metricType);
+      }
+      // The window itself is read at most twice (device discovery + the bucket
+      // join). Ten reads is the bug.
+      expect(countOccurrences(deviceSql, 'FROM device_metrics')).toBeLessThanOrEqual(2);
+    });
+
+    it('keeps the per-metric non-null device filter so nullable columns gain no phantom gap rows', async () => {
+      await rollupDeviceMetricsRange({ ...RANGE });
+
+      // Half the device_metrics columns are nullable (disk_*_bps, bandwidth_*_bps,
+      // process_count). Per-metric statements each built their own device list
+      // with `WHERE <col> IS NOT NULL`, so a device that never reported
+      // process_count produced NO process_count rollups. A shared bucket grid
+      // must not silently start emitting `isGap` rows for those series.
+      const deviceSql = onlyStatementFor('metricRollups.raw.device_metrics');
+      expect(deviceSql).toContain('metric_devices');
+      expect(deviceSql).toContain('IS NOT NULL');
+      for (const [, metricName] of DEVICE_METRIC_SERIES) {
+        expect(deviceSql).toContain(`dm.${metricName} IS NOT NULL`);
+      }
+    });
+
+    it('derives all seven process-sample series from that one scan', async () => {
+      await rollupDeviceMetricsRange({ ...RANGE });
+
+      const processSql = onlyStatementFor('metricRollups.raw.device_process_samples');
+      for (const metricName of PROCESS_METRIC_SERIES) {
+        expect(processSql).toContain(metricName);
+      }
+      expect(countOccurrences(processSql, 'FROM device_process_samples')).toBe(2);
+    });
+
+    it('expands each top_processes array once per sample row, not once per metric', async () => {
+      await rollupDeviceMetricsRange({ ...RANGE });
+
+      // Six of the seven process series aggregate the SAME jsonb array. Running
+      // `jsonb_array_elements` once per series re-parses every sample six times;
+      // that jsonb work, not just the table scan, is what made this CTE the top
+      // DB consumer.
+      const processSql = onlyStatementFor('metricRollups.raw.device_process_samples');
+      expect(countOccurrences(processSql, 'jsonb_array_elements(dps.top_processes)')).toBe(1);
+    });
+  });
+
   // #4276 — metricRollupsWorker was the top `db_context_held_too_long` offender
-  // (983 events/7d) because all 26 statements ran inside ONE
+  // (983 events/7d) because all of the pass's statements ran inside ONE
   // withSystemDbAccessContext, pinning a single pooled connection for 2s+ every
   // 5 minutes. Every statement here is an idempotent upsert, so the atomic
   // transaction bought nothing: each one now gets its own short-lived context.
@@ -225,11 +351,11 @@ describe('metric rollups service', () => {
         to: new Date('2026-06-18T13:00:00.000Z'),
       });
 
-      // 24 upserts + the ML feature-flag gate read = 25 contexts, each closing
+      // 9 upserts + the ML feature-flag gate read = 10 contexts, each closing
       // before the next opens. A trace with two consecutive `open`s means a
       // context spans more than one statement, which is the bug.
-      expect(openedLabels()).toHaveLength(25);
-      expect(executeMock).toHaveBeenCalledTimes(24);
+      expect(openedLabels()).toHaveLength(10);
+      expect(executeMock).toHaveBeenCalledTimes(9);
 
       let depth = 0;
       let maxDepth = 0;
@@ -245,7 +371,7 @@ describe('metric rollups service', () => {
         }
       }
       expect(maxDepth).toBe(1);
-      expect(executesInsideAContext).toBe(24);
+      expect(executesInsideAContext).toBe(9);
     });
 
     it('escapes any ambient DB context so a wrapping caller cannot re-create the single long hold', async () => {
@@ -257,14 +383,14 @@ describe('metric rollups service', () => {
 
       // runOutsideDbContext must precede every context; without it a caller that
       // already holds a context makes withDbAccessContext short-circuit and all
-      // 24 statements silently rejoin the outer transaction again (the
+      // 9 statements silently rejoin the outer transaction again (the
       // alertWorker/#3216 trap).
-      expect(runOutsideDbContextMock).toHaveBeenCalledTimes(25);
+      expect(runOutsideDbContextMock).toHaveBeenCalledTimes(10);
       const escapeThenOpen = contextTrace
         .filter((event) => event.type === 'escape' || event.type === 'open')
         .map((event) => event.type);
       expect(escapeThenOpen).toEqual(
-        Array.from({ length: 25 }, () => ['escape', 'open'] as const).flat(),
+        Array.from({ length: 10 }, () => ['escape', 'open'] as const).flat(),
       );
     });
 
@@ -333,7 +459,7 @@ describe('metric rollups service', () => {
       ).rejects.toThrow(boom);
 
       // Statements 1-4 ran (and, in production, committed); statement 5 threw;
-      // 6-24 never ran. Plus the ML gate context, that is exactly 6 opens —
+      // 6-9 never ran. Plus the ML gate context, that is exactly 6 opens —
       // and every context still closed, so the failure cannot leak a held
       // connection either.
       expect(executeMock).toHaveBeenCalledTimes(5);

--- a/apps/api/src/services/metricRollups.test.ts
+++ b/apps/api/src/services/metricRollups.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { SQL } from 'drizzle-orm';
 
 type ContextTraceEvent =
   | { type: 'escape' }
@@ -58,8 +60,8 @@ function openedLabels(): Array<string | undefined> {
   return contextTrace.filter((event) => event.type === 'open').map((event) => event.label);
 }
 
-/** Every statement issued under `label`, serialized the way the SQL assertions read it. */
-const executedSqlByLabel = new Map<string, string[]>();
+/** Every statement issued under `label`: its serialization and the SQL object itself. */
+const executedByLabel = new Map<string, Array<{ json: string; statement: SQL }>>();
 
 /**
  * The one statement issued under `label`. Fails loudly when a label ran more
@@ -67,9 +69,21 @@ const executedSqlByLabel = new Map<string, string[]>();
  * per raw source table, not one per metric.
  */
 function onlyStatementFor(label: string): string {
-  const statements = executedSqlByLabel.get(label) ?? [];
+  const statements = executedByLabel.get(label) ?? [];
   expect(statements).toHaveLength(1);
-  return statements[0] as string;
+  return (statements[0] as { json: string }).json;
+}
+
+/**
+ * The bound parameters of the one statement issued under `label`, in order.
+ * Substring assertions on the serialized SQL cannot tell `'cpu'` the metric_type
+ * from `'cpu_percent'` the metric_name, so anything about which value is bound
+ * WHERE has to read the compiled parameter list instead.
+ */
+function onlyStatementParamsFor(label: string): unknown[] {
+  const statements = executedByLabel.get(label) ?? [];
+  expect(statements).toHaveLength(1);
+  return new PgDialect().sqlToQuery((statements[0] as { statement: SQL }).statement).params;
 }
 
 function countOccurrences(haystack: string, needle: string): number {
@@ -79,15 +93,15 @@ function countOccurrences(haystack: string, needle: string): number {
 describe('metric rollups service', () => {
   beforeEach(() => {
     contextTrace.length = 0;
-    executedSqlByLabel.clear();
+    executedByLabel.clear();
     openContext.label = undefined;
     executeMock.mockReset();
     executeMock.mockImplementation(async (statement: unknown) => {
       contextTrace.push({ type: 'execute' });
       const label = openContext.label ?? '<no-context>';
-      const existing = executedSqlByLabel.get(label) ?? [];
-      existing.push(JSON.stringify(statement));
-      executedSqlByLabel.set(label, existing);
+      const existing = executedByLabel.get(label) ?? [];
+      existing.push({ json: JSON.stringify(statement), statement: statement as SQL });
+      executedByLabel.set(label, existing);
       return [];
     });
     shouldProduceMlOutputMock.mockReset();
@@ -283,17 +297,30 @@ describe('metric rollups service', () => {
       // 1 device_metrics + 1 device_process_samples + 1 snmp_metrics + 6 derived.
       expect(result).toMatchObject({ statements: 9, skipped: false });
       expect(executeMock).toHaveBeenCalledTimes(9);
-      expect(executedSqlByLabel.get('metricRollups.raw.device_metrics')).toHaveLength(1);
-      expect(executedSqlByLabel.get('metricRollups.raw.device_process_samples')).toHaveLength(1);
+      expect(executedByLabel.get('metricRollups.raw.device_metrics')).toHaveLength(1);
+      expect(executedByLabel.get('metricRollups.raw.device_process_samples')).toHaveLength(1);
     });
 
     it('derives all ten device_metrics series from that one scan, each keeping its own metric_type', async () => {
       await rollupDeviceMetricsRange({ ...RANGE });
 
       const deviceSql = onlyStatementFor('metricRollups.raw.device_metrics');
-      for (const [metricType, metricName] of DEVICE_METRIC_SERIES) {
+      for (const [, metricName] of DEVICE_METRIC_SERIES) {
         expect(deviceSql).toContain(metricName);
-        expect(deviceSql).toContain(metricType);
+      }
+
+      // `toContain(metricType)` would be vacuous here — 'cpu' is a substring of
+      // 'cpu_percent', 'disk' of 'disk_percent', 'process' of 'process_count' —
+      // so it would still pass with metric_type dropped from the unpivot
+      // entirely. The unpivot binds each row as (metric_type, metric_name), so
+      // assert on that adjacency in the compiled parameter list instead. Each
+      // name is bound twice (the non-null probe, then the unpivot); the unpivot
+      // is the later one.
+      const params = onlyStatementParamsFor('metricRollups.raw.device_metrics');
+      for (const [metricType, metricName] of DEVICE_METRIC_SERIES) {
+        const unpivotIndex = params.lastIndexOf(metricName);
+        expect(unpivotIndex).toBeGreaterThan(0);
+        expect(params[unpivotIndex - 1]).toBe(metricType);
       }
       // The window itself is read at most twice (device discovery + the bucket
       // join). Ten reads is the bug.

--- a/apps/api/src/services/metricRollups.ts
+++ b/apps/api/src/services/metricRollups.ts
@@ -27,65 +27,69 @@ const DEVICE_METRIC_ROLLUP_SOURCES = [
   { metricType: 'process', metricName: 'process_count', column: 'process_count' },
 ] as const;
 
+/**
+ * One expansion of a sample row's `top_processes` array, feeding every
+ * array-derived series below (#4341).
+ *
+ * Each of the six array series used to be its own scalar subquery in its own
+ * statement, so every sample row was re-parsed six times per pass. They now
+ * read out of this single `jsonb_array_elements` expansion.
+ *
+ * Value-identical to the old per-series subqueries:
+ *  - `sum`: the old form summed `CASE … ELSE 0`, this one skips NULLs. float8
+ *    addition of 0 is exact, so the totals match; an all-non-numeric array gave
+ *    `0+0+…=0` before and `NULL → coalesce → 0` now.
+ *  - `max`: the old CASE already produced NULL for non-numbers, so `max` saw
+ *    the same input set.
+ *  - empty / NULL array: `jsonb_array_elements` yields zero rows either way, an
+ *    aggregate over zero rows is NULL, and `coalesce(…, 0)` lands on 0 in both.
+ *
+ * `dps` is the outer `device_process_samples` row this is LATERAL-joined to.
+ */
+const PROCESS_SAMPLE_PROCESS_AGGREGATE_SQL = `
+      SELECT
+        coalesce(sum(proc_values.cpu), 0)::double precision AS cpu_percent_sum,
+        coalesce(max(proc_values.cpu), 0)::double precision AS cpu_percent_max,
+        coalesce(sum(proc_values.ram_mb), 0)::double precision AS ram_mb_sum,
+        coalesce(max(proc_values.ram_mb), 0)::double precision AS ram_mb_max,
+        coalesce(sum(proc_values.disk_bps), 0)::double precision AS disk_bps_sum,
+        coalesce(sum(proc_values.net_bps), 0)::double precision AS net_bps_sum
+      FROM (
+        SELECT
+          CASE WHEN jsonb_typeof(proc.value -> 'cpu') = 'number'
+            THEN (proc.value ->> 'cpu')::double precision
+          END AS cpu,
+          CASE WHEN jsonb_typeof(proc.value -> 'ramMb') = 'number'
+            THEN (proc.value ->> 'ramMb')::double precision
+          END AS ram_mb,
+          CASE WHEN jsonb_typeof(proc.value -> 'diskBps') = 'number'
+            THEN (proc.value ->> 'diskBps')::double precision
+          END AS disk_bps,
+          CASE WHEN jsonb_typeof(proc.value -> 'netBps') = 'number'
+            THEN (proc.value ->> 'netBps')::double precision
+          END AS net_bps
+        FROM jsonb_array_elements(dps.top_processes) AS proc(value)
+      ) proc_values`;
+
+/**
+ * `valueSql` is evaluated once per `device_process_samples` row and becomes one
+ * `sample_values` column named after the series. `top_process_count` reads the
+ * array length directly (NULL for a NULL array, which is what makes its
+ * `sample_count` legitimately differ from the coalesced series); the rest read
+ * the shared per-row aggregate above. `metricName` doubles as the column name,
+ * so it must stay a bare SQL identifier.
+ */
 const PROCESS_SAMPLE_ROLLUP_SOURCES = [
   {
     metricName: 'top_process_count',
     valueSql: 'jsonb_array_length(dps.top_processes)::double precision',
   },
-  {
-    metricName: 'top_process_cpu_percent_sum',
-    valueSql: `(SELECT coalesce(sum(
-      CASE WHEN jsonb_typeof(proc.value -> 'cpu') = 'number'
-        THEN (proc.value ->> 'cpu')::double precision
-        ELSE 0
-      END
-    ), 0)::double precision FROM jsonb_array_elements(dps.top_processes) AS proc(value))`,
-  },
-  {
-    metricName: 'top_process_cpu_percent_max',
-    valueSql: `(SELECT coalesce(max(
-      CASE WHEN jsonb_typeof(proc.value -> 'cpu') = 'number'
-        THEN (proc.value ->> 'cpu')::double precision
-        ELSE NULL
-      END
-    ), 0)::double precision FROM jsonb_array_elements(dps.top_processes) AS proc(value))`,
-  },
-  {
-    metricName: 'top_process_ram_mb_sum',
-    valueSql: `(SELECT coalesce(sum(
-      CASE WHEN jsonb_typeof(proc.value -> 'ramMb') = 'number'
-        THEN (proc.value ->> 'ramMb')::double precision
-        ELSE 0
-      END
-    ), 0)::double precision FROM jsonb_array_elements(dps.top_processes) AS proc(value))`,
-  },
-  {
-    metricName: 'top_process_ram_mb_max',
-    valueSql: `(SELECT coalesce(max(
-      CASE WHEN jsonb_typeof(proc.value -> 'ramMb') = 'number'
-        THEN (proc.value ->> 'ramMb')::double precision
-        ELSE NULL
-      END
-    ), 0)::double precision FROM jsonb_array_elements(dps.top_processes) AS proc(value))`,
-  },
-  {
-    metricName: 'top_process_disk_bps_sum',
-    valueSql: `(SELECT coalesce(sum(
-      CASE WHEN jsonb_typeof(proc.value -> 'diskBps') = 'number'
-        THEN (proc.value ->> 'diskBps')::double precision
-        ELSE 0
-      END
-    ), 0)::double precision FROM jsonb_array_elements(dps.top_processes) AS proc(value))`,
-  },
-  {
-    metricName: 'top_process_net_bps_sum',
-    valueSql: `(SELECT coalesce(sum(
-      CASE WHEN jsonb_typeof(proc.value -> 'netBps') = 'number'
-        THEN (proc.value ->> 'netBps')::double precision
-        ELSE 0
-      END
-    ), 0)::double precision FROM jsonb_array_elements(dps.top_processes) AS proc(value))`,
-  },
+  { metricName: 'top_process_cpu_percent_sum', valueSql: 'proc_agg.cpu_percent_sum' },
+  { metricName: 'top_process_cpu_percent_max', valueSql: 'proc_agg.cpu_percent_max' },
+  { metricName: 'top_process_ram_mb_sum', valueSql: 'proc_agg.ram_mb_sum' },
+  { metricName: 'top_process_ram_mb_max', valueSql: 'proc_agg.ram_mb_max' },
+  { metricName: 'top_process_disk_bps_sum', valueSql: 'proc_agg.disk_bps_sum' },
+  { metricName: 'top_process_net_bps_sum', valueSql: 'proc_agg.net_bps_sum' },
 ] as const;
 
 export interface MetricRollupRange {
@@ -141,8 +145,9 @@ function normalizeRange(from: Date, to: Date): { from: Date; to: Date } {
  * #4276 — run ONE statement inside its OWN short-lived system RLS context.
  *
  * This module used to run under a single caller-supplied
- * `withSystemDbAccessContext`, so all 26 statements shared one transaction and
- * pinned one pooled connection for the whole pass. At ~2s+ per org every 5
+ * `withSystemDbAccessContext`, so every statement of the pass (26 of them at
+ * the time; 9 since #4341) shared one transaction and pinned one pooled
+ * connection for the whole pass. At ~2s+ per org every 5
  * minutes that made `metricRollupsWorker` the top `db_context_held_too_long`
  * offender (983 events/7d, ~half the system-scope capture budget) and it is
  * exactly the kind of long single-connection hold that elongates recovery when
@@ -188,21 +193,102 @@ function expandRangeToBucketBounds(from: Date, to: Date, bucketSeconds: number):
   };
 }
 
-async function rollupRawDeviceMetric(options: MetricRollupRange, metric: (typeof DEVICE_METRIC_ROLLUP_SOURCES)[number]): Promise<void> {
+/** `VALUES (…), (…), …` rows, one per source, for an unpivot join. */
+function valuesRows(rows: SQL[]): SQL {
+  return sql.join(rows, sql.raw(',\n        '));
+}
+
+const SERIES_AGGREGATE_SUFFIXES = ['avg', 'min', 'max', 'p95', 'sum', 'count'] as const;
+
+/**
+ * The six aggregates one rollup series needs, aliased `<key>_avg`, `<key>_min`, …
+ *
+ * #4341 computes every series of a source table in ONE grouped pass and unpivots
+ * afterwards, so each aggregate still sees its own input expression at its own
+ * type. Unpivoting the *inputs* instead would force a single common value column,
+ * which for `device_metrics` would silently turn `sum(real)` — Postgres
+ * accumulates that in `real` — into a float8 sum, and for both tables would
+ * multiply the bucket grid by the series count (inflating the planner's row
+ * estimate enough to trip `jit_above_cost` on a query that does not need JIT).
+ */
+function seriesAggregates(sources: ReadonlyArray<{ key: string; valueSql: string }>): SQL {
+  return sql.join(
+    sources.map(({ key, valueSql }) => {
+      const value = sql.raw(valueSql);
+      const alias = (suffix: string) => sql.raw(`${key}_${suffix}`);
+      return sql`
+        avg(${value})::double precision AS ${alias('avg')},
+        min(${value})::double precision AS ${alias('min')},
+        max(${value})::double precision AS ${alias('max')},
+        percentile_cont(0.95) within group (order by ${value})::double precision AS ${alias('p95')},
+        sum(${value})::double precision AS ${alias('sum')},
+        count(${value})::integer AS ${alias('count')}`;
+    }),
+    sql.raw(','),
+  );
+}
+
+/** `ba.<key>_avg, ba.<key>_min, …` — one series' aggregates, read back for the unpivot. */
+function seriesAggregateColumns(key: string): SQL {
+  return sql.raw(SERIES_AGGREGATE_SUFFIXES.map((suffix) => `ba.${key}_${suffix}`).join(', '));
+}
+
+/** Column list the unpivot `VALUES` join binds its aggregate columns to. */
+const SERIES_VALUE_COLUMNS = sql.raw('avg_value, min_value, max_value, p95_value, sum_value, sample_count');
+
+/**
+ * #4341 — ONE statement for all ten `device_metrics` series.
+ *
+ * This used to be ten statements, each re-running the identical
+ * `metric_devices` DISTINCT scan and the identical bucket-grid LEFT JOIN over
+ * the same window, differing only in which column they aggregated. Together
+ * with the seven-statement process-sample loop that made the rollup pass the
+ * single largest consumer of the production DB's CPU.
+ *
+ * The rewrite aggregates every column in ONE grouped pass and unpivots the
+ * result afterwards, so each aggregate still sees its column at its native type
+ * (`real` / `integer` / `bigint`). Unpivoting the *inputs* instead would have
+ * forced a common `double precision` value column and quietly changed
+ * `sum(real)`, which Postgres accumulates in `real`, into a float8 sum.
+ *
+ * `metric_devices` keeps its per-metric `IS NOT NULL` device filter — half
+ * these columns are nullable, and a device that never reports (say)
+ * `process_count` must still produce NO `process_count` rollups rather than a
+ * window's worth of `isGap` rows. The shared bucket grid is built from the
+ * union of those device sets and re-narrowed per series by the closing join.
+ */
+async function rollupRawDeviceMetrics(options: MetricRollupRange): Promise<void> {
   const { from, to } = normalizeRange(options.from, options.to);
   const fromIso = from.toISOString();
   const toIso = to.toISOString();
   const expectedSampleSeconds = options.expectedSampleSeconds ?? DEFAULT_EXPECTED_SAMPLE_SECONDS;
-  const valueSql = sql.raw(`dm.${metric.column}`);
+
+  const notNullProbes = valuesRows(DEVICE_METRIC_ROLLUP_SOURCES.map((metric) =>
+    sql`(${metric.metricName}::text, ${sql.raw(`dm.${metric.column} IS NOT NULL`)})`
+  ));
+
+  const bucketAggregates = seriesAggregates(
+    DEVICE_METRIC_ROLLUP_SOURCES.map((metric) => ({ key: metric.column, valueSql: `dm.${metric.column}` }))
+  );
+
+  const seriesRows = valuesRows(DEVICE_METRIC_ROLLUP_SOURCES.map((metric) =>
+    sql`(${metric.metricType}::text, ${metric.metricName}::text, ${seriesAggregateColumns(metric.column)})`
+  ));
 
   await execInRollupDbContext('metricRollups.raw.device_metrics', sql`
     WITH metric_devices AS (
-      SELECT DISTINCT dm.org_id, dm.device_id
+      SELECT DISTINCT dm.org_id, dm.device_id, probe.metric_name
       FROM device_metrics dm
+      CROSS JOIN LATERAL (VALUES
+        ${notNullProbes}
+      ) AS probe(metric_name, has_value)
       WHERE dm.org_id = ${options.orgId}
         AND dm.timestamp >= ${fromIso}::timestamp
         AND dm.timestamp < ${toIso}::timestamp
-        AND ${valueSql} IS NOT NULL
+        AND probe.has_value
+    ),
+    grid_devices AS (
+      SELECT DISTINCT org_id, device_id FROM metric_devices
     ),
     buckets AS (
       SELECT generate_series(
@@ -212,9 +298,31 @@ async function rollupRawDeviceMetric(options: MetricRollupRange, metric: (typeof
       )::timestamp AS bucket_start
     ),
     bucket_grid AS (
-      SELECT md.org_id, md.device_id, buckets.bucket_start
-      FROM metric_devices md
+      SELECT gd.org_id, gd.device_id, buckets.bucket_start
+      FROM grid_devices gd
       CROSS JOIN buckets
+    ),
+    bucket_aggregates AS (
+      SELECT
+        bg.org_id,
+        bg.device_id,
+        bg.bucket_start,${bucketAggregates}
+      FROM bucket_grid bg
+      LEFT JOIN device_metrics dm
+        ON dm.org_id = bg.org_id
+        AND dm.device_id = bg.device_id
+        -- join window bound: constrain the scan to [from,to). bucket_start comes
+        -- from generate_series, so the per-bucket predicates below are NOT sargable
+        -- and Postgres would bitmap-scan each device's ENTIRE metric history per
+        -- bucket. These two constant bounds let it index-range only the window.
+        AND dm.timestamp >= ${fromIso}::timestamp
+        AND dm.timestamp < ${toIso}::timestamp
+        AND dm.timestamp >= bg.bucket_start
+        AND dm.timestamp < bg.bucket_start + (interval '1 second' * ${RAW_BUCKET_SECONDS})
+      -- No per-column IS NOT NULL filter here: every aggregate above already
+      -- skips NULL inputs, so dropping it leaves each series' numbers untouched
+      -- while letting all ten share one join.
+      GROUP BY bg.org_id, bg.device_id, bg.bucket_start
     )
     INSERT INTO metric_rollups (
       org_id,
@@ -234,51 +342,77 @@ async function rollupRawDeviceMetric(options: MetricRollupRange, metric: (typeof
       metadata
     )
     SELECT
-      bg.org_id,
+      ba.org_id,
       'device_metrics',
-      bg.device_id,
-      ${metric.metricType},
-      ${metric.metricName},
-      bg.bucket_start,
+      ba.device_id,
+      series.metric_type,
+      series.metric_name,
+      ba.bucket_start,
       ${RAW_BUCKET_SECONDS},
-      avg(${valueSql})::double precision,
-      min(${valueSql})::double precision,
-      max(${valueSql})::double precision,
-      percentile_cont(0.95) within group (order by ${valueSql})::double precision,
-      sum(${valueSql})::double precision,
-      count(${valueSql})::integer,
-      greatest(${RAW_BUCKET_SECONDS} - (count(${valueSql})::integer * ${expectedSampleSeconds}), 0)::integer,
+      series.avg_value,
+      series.min_value,
+      series.max_value,
+      series.p95_value,
+      series.sum_value,
+      series.sample_count,
+      greatest(${RAW_BUCKET_SECONDS} - (series.sample_count * ${expectedSampleSeconds}), 0)::integer,
       jsonb_build_object(
         'rollupVersion', ${METRIC_ROLLUP_VERSION}::text,
         'source', 'raw',
         'expectedSampleSeconds', ${expectedSampleSeconds}::integer,
-        'isGap', count(${valueSql}) = 0
+        'isGap', series.sample_count = 0
       )
-    FROM bucket_grid bg
-    LEFT JOIN device_metrics dm
-      ON dm.org_id = bg.org_id
-      AND dm.device_id = bg.device_id
-      -- join window bound: constrain the scan to [from,to). bucket_start comes
-      -- from generate_series, so the per-bucket predicates below are NOT sargable
-      -- and Postgres would bitmap-scan each device's ENTIRE metric history per
-      -- bucket. These two constant bounds let it index-range only the window.
-      AND dm.timestamp >= ${fromIso}::timestamp
-      AND dm.timestamp < ${toIso}::timestamp
-      AND dm.timestamp >= bg.bucket_start
-      AND dm.timestamp < bg.bucket_start + (interval '1 second' * ${RAW_BUCKET_SECONDS})
-      AND ${valueSql} IS NOT NULL
-    GROUP BY bg.org_id, bg.device_id, bg.bucket_start
+    FROM bucket_aggregates ba
+    CROSS JOIN LATERAL (VALUES
+        ${seriesRows}
+    ) AS series(metric_type, metric_name, ${SERIES_VALUE_COLUMNS})
+    JOIN metric_devices md
+      ON md.org_id = ba.org_id
+      AND md.device_id = ba.device_id
+      AND md.metric_name = series.metric_name
     ON CONFLICT (org_id, source_table, device_id, metric_type, metric_name, bucket_seconds, bucket_start)
     DO UPDATE SET ${upsertAssignments()}
   `);
 }
 
-async function rollupRawProcessSampleMetric(options: MetricRollupRange, metric: (typeof PROCESS_SAMPLE_ROLLUP_SOURCES)[number]): Promise<void> {
+/**
+ * #4341 — ONE statement for all seven `device_process_samples` series.
+ *
+ * This was the top statement on the production DB by a wide margin: seven
+ * copies of the same CTE, each rescanning the same window (`process_devices`
+ * DISTINCT + `sample_values`) and re-expanding every sample's `top_processes`
+ * array. `pg_stat_statements` over 31.5h on US prod: ~107k calls at 1.5-2.0s
+ * mean, ~168,600s total — ~1.5 query-seconds per wall-second on a single-vCPU
+ * managed DB, with 900+GB of shared buffer reads starving interactive queries.
+ *
+ * `sample_values` now projects one column per series instead of one row per
+ * series, so the bucket grid and the LEFT JOIN keep exactly the cardinality
+ * they had; only the aggregate list widens, and every series still aggregates
+ * its own `double precision` expression. (A row-wise unpivot was measurably
+ * worse: it multiplies the grid by seven, and because `generate_series` is
+ * costed at its 1000-row default the inflated estimate tripped
+ * `jit_above_cost`, adding ~1.1s of JIT compilation to a sub-100ms query.)
+ */
+async function rollupRawProcessSampleMetrics(options: MetricRollupRange): Promise<void> {
   const { from, to } = normalizeRange(options.from, options.to);
   const fromIso = from.toISOString();
   const toIso = to.toISOString();
   const expectedSampleSeconds = options.expectedSampleSeconds ?? DEFAULT_EXPECTED_SAMPLE_SECONDS;
-  const valueSql = sql.raw(metric.valueSql);
+
+  const sampleColumns = sql.join(
+    PROCESS_SAMPLE_ROLLUP_SOURCES.map((metric) =>
+      sql`${sql.raw(metric.valueSql)} AS ${sql.raw(metric.metricName)}`
+    ),
+    sql.raw(',\n        '),
+  );
+
+  const bucketAggregates = seriesAggregates(
+    PROCESS_SAMPLE_ROLLUP_SOURCES.map((metric) => ({ key: metric.metricName, valueSql: `sv.${metric.metricName}` }))
+  );
+
+  const seriesRows = valuesRows(PROCESS_SAMPLE_ROLLUP_SOURCES.map((metric) =>
+    sql`(${metric.metricName}::text, ${seriesAggregateColumns(metric.metricName)})`
+  ));
 
   await execInRollupDbContext('metricRollups.raw.device_process_samples', sql`
     WITH process_devices AS (
@@ -305,11 +439,26 @@ async function rollupRawProcessSampleMetric(options: MetricRollupRange, metric: 
         dps.org_id,
         dps.device_id,
         dps.timestamp,
-        ${valueSql} AS metric_value
+        ${sampleColumns}
       FROM device_process_samples dps
+      CROSS JOIN LATERAL (${sql.raw(PROCESS_SAMPLE_PROCESS_AGGREGATE_SQL)}
+      ) AS proc_agg
       WHERE dps.org_id = ${options.orgId}
         AND dps.timestamp >= ${fromIso}::timestamp
         AND dps.timestamp < ${toIso}::timestamp
+    ),
+    bucket_aggregates AS (
+      SELECT
+        bg.org_id,
+        bg.device_id,
+        bg.bucket_start,${bucketAggregates}
+      FROM bucket_grid bg
+      LEFT JOIN sample_values sv
+        ON sv.org_id = bg.org_id
+        AND sv.device_id = bg.device_id
+        AND sv.timestamp >= bg.bucket_start
+        AND sv.timestamp < bg.bucket_start + (interval '1 second' * ${RAW_BUCKET_SECONDS})
+      GROUP BY bg.org_id, bg.device_id, bg.bucket_start
     )
     INSERT INTO metric_rollups (
       org_id,
@@ -329,34 +478,31 @@ async function rollupRawProcessSampleMetric(options: MetricRollupRange, metric: 
       metadata
     )
     SELECT
-      bg.org_id,
+      ba.org_id,
       'device_process_samples',
-      bg.device_id,
+      ba.device_id,
       'process',
-      ${metric.metricName},
-      bg.bucket_start,
+      series.metric_name,
+      ba.bucket_start,
       ${RAW_BUCKET_SECONDS},
-      avg(sv.metric_value)::double precision,
-      min(sv.metric_value)::double precision,
-      max(sv.metric_value)::double precision,
-      percentile_cont(0.95) within group (order by sv.metric_value)::double precision,
-      sum(sv.metric_value)::double precision,
-      count(sv.metric_value)::integer,
-      greatest(${RAW_BUCKET_SECONDS} - (count(sv.metric_value)::integer * ${expectedSampleSeconds}), 0)::integer,
+      series.avg_value,
+      series.min_value,
+      series.max_value,
+      series.p95_value,
+      series.sum_value,
+      series.sample_count,
+      greatest(${RAW_BUCKET_SECONDS} - (series.sample_count * ${expectedSampleSeconds}), 0)::integer,
       jsonb_build_object(
         'rollupVersion', ${METRIC_ROLLUP_VERSION}::text,
         'source', 'raw',
         'sourceTable', 'device_process_samples',
         'expectedSampleSeconds', ${expectedSampleSeconds}::integer,
-        'isGap', count(sv.metric_value) = 0
+        'isGap', series.sample_count = 0
       )
-    FROM bucket_grid bg
-    LEFT JOIN sample_values sv
-      ON sv.org_id = bg.org_id
-      AND sv.device_id = bg.device_id
-      AND sv.timestamp >= bg.bucket_start
-      AND sv.timestamp < bg.bucket_start + (interval '1 second' * ${RAW_BUCKET_SECONDS})
-    GROUP BY bg.org_id, bg.device_id, bg.bucket_start
+    FROM bucket_aggregates ba
+    CROSS JOIN LATERAL (VALUES
+        ${seriesRows}
+    ) AS series(metric_name, ${SERIES_VALUE_COLUMNS})
     ON CONFLICT (org_id, source_table, device_id, metric_type, metric_name, bucket_seconds, bucket_start)
     DO UPDATE SET ${upsertAssignments()}
   `);
@@ -589,16 +735,14 @@ async function runRollupDeviceMetricsRange(options: MetricRollupRange): Promise<
     };
   }
 
+  // #4341 — one statement per raw source table, not one per metric. Each of
+  // these derives every series for its table from a single scan of the window.
   let statements = 0;
-  for (const metric of DEVICE_METRIC_ROLLUP_SOURCES) {
-    await rollupRawDeviceMetric(options, metric);
-    statements += 1;
-  }
+  await rollupRawDeviceMetrics(options);
+  statements += 1;
 
-  for (const metric of PROCESS_SAMPLE_ROLLUP_SOURCES) {
-    await rollupRawProcessSampleMetric(options, metric);
-    statements += 1;
-  }
+  await rollupRawProcessSampleMetrics(options);
+  statements += 1;
 
   await rollupRawSnmpMetrics(options);
   statements += 1;


### PR DESCRIPTION
## Problem

`rollupMetricsForOrg` looped its source lists and issued **one full CTE per metric** — 10 statements rescanning the `device_metrics` window and 7 rescanning the `device_process_samples` window, per org, every 5 minutes.

On US production, `pg_stat_statements` over a 31.5h window (2026-09-01) showed the process-sample CTE alone at ~107k calls at 1.5–2.0s mean, ~168,600s total execution — roughly **1.5 query-seconds per wall-second**, continuously occupying ~150% of the managed DB's single vCPU, with 900+GB of shared buffer reads. It was the top DB load by a wide margin and the main reason interactive dashboard queries contend for buffers (`BufferMapping` waits; cache hit ratio 79.7%).

`device_process_samples` has no `(org_id, timestamp)` index, so each of those 7 statements re-reads the same window from a table holding weeks of retention.

## Change

Each source table is now read **once per pass**. Both raw passes aggregate every series in ONE grouped pass over the bucket grid and unpivot the aggregates afterwards via `CROSS JOIN LATERAL (VALUES …)`. The process pass additionally expands each sample's `top_processes` array once, through a shared LATERAL aggregate, instead of once per array-derived series.

**24 statements per pass → 9.** (10 + 7 + 1 raw + 6 derived → 1 + 1 + 1 + 6.) The SNMP and derived passes are untouched.

Distinct from #4276 — that PR (#4285) split the pass into per-statement DB contexts. This one reduces how many statements there are. The per-statement context/escape/label contract is preserved unchanged.

## Why output is identical

- **Aggregates are unpivoted, not inputs.** A row-wise unpivot needs one common `double precision` value column, which would turn `sum(real)` — Postgres accumulates that in `real` — into a float8 sum. It also multiplies the bucket grid by the series count; the inflated `generate_series` row estimate then trips `jit_above_cost` and adds ~1.1s of JIT compilation to a sub-100ms query (measured, which is why the shape you see here is the one that shipped).
- **`metric_devices` keeps its per-metric `IS NOT NULL` device filter.** Half the `device_metrics` columns are nullable, and a device that never reports (say) `process_count` must still produce **no** `process_count` rollups, not a window's worth of `isGap` rows. The shared grid is built from the union of those device sets and re-narrowed per series by the closing join.
- **The per-column `IS NOT NULL` predicate is dropped from the bucket join**, because every aggregate (including `percentile_cont`) already skips NULL inputs — so each series' numbers are untouched while all ten share one join.
- The shared `top_processes` aggregate is value-identical to the old per-series subqueries: float8 addition of `0` is exact, so `sum(CASE … ELSE 0)` and `coalesce(sum(x), 0)` agree; the old `max` CASE already produced NULL for non-numbers; and an empty array aggregates over zero rows to NULL → `0` in both forms.

## Verification

**Equivalence (real Postgres 16).** Replayed the old 24-statement pass and the new 9-statement pass over identical randomized fixtures in a throwaway database and diffed every `metric_rollups` row (row set via `EXCEPT ALL` both ways, plus a keyed `FULL OUTER JOIN` comparing all value columns with `IS NOT DISTINCT FROM`). Fixtures covered empty and non-numeric `top_processes` payloads, optional `diskBps`/`netBps` absent, all-NULL nullable columns, mixed-NULL devices, sparse gap buckets, out-of-window rows on both sides, foreign-org rows, and a second pass to exercise the `ON CONFLICT DO UPDATE` replay path. **Identical row sets and bit-identical values across 5 seeds × 2 session timezones (10 runs).**

**Performance (same harness, with production's index set and a table far larger than the window).** Buffer blocks reading the source window, per pass:

| source | old | new | |
|---|---|---|---|
| `device_metrics` | 19730 blocks (154MB), 10 statements | 2057 blocks (16MB), 1 statement | **9.6× fewer** |
| `device_process_samples` | 16380 blocks (128MB), 7 statements | 2340 blocks (18MB), 1 statement | **7.0× fewer** |

Wall time on that local fixture is 2.5×/2.2× because the `metric_rollups` upsert side is unchanged (same rows written) and dominates locally; on prod the read side is what is saturating the vCPU.

**Tests.**
- `apps/api/src/services/metricRollups.test.ts` — new `#4341 single-pass raw rollups` block (5 tests) written red-first against the old code: exactly one statement per raw source table, all 10 device series with their own `metric_type` from that one scan, the per-metric non-null device filter still present, all 7 process series from one scan, and `jsonb_array_elements(dps.top_processes)` appearing exactly once. Existing SQL assertions were re-anchored from fragile positional `mock.calls[n]` indices to context labels.
- `apps/api/src/__tests__/integration/metricRollups.integration.test.ts` — 2 new tests against a real DB: every device-metric and process-sample series is emitted from one pass with its own `metric_type` and its own values, and a column that is NULL across the whole window produces no rows at all (not gap rows). Mutation-checked: deleting the per-series narrowing from the closing join turns both red.
- 25 unit tests and 8 integration tests green; `tsc --noEmit` and `eslint` clean.

Closes #4341

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMvN6SU3uwaaC7b2xmUa5m
