### PR TITLE
fix(api): default new partners' inbound email-to-ticket to off (#3608)

### DIFF
--- a/apps/api/src/services/partnerCreate.test.ts
+++ b/apps/api/src/services/partnerCreate.test.ts
@@ -177,6 +177,25 @@ describe('createPartner', () => {
     expect(userCall.values.passwordHash).toBe('hashed');
   });
 
+  // Issue #3608: new partners must opt IN to inbound email-to-ticket rather
+  // than inheriting the readers' absent-flag-means-true fallback (which
+  // exists solely as the pre-#3606 upgrade path for existing partners).
+  it('writes an explicit settings.ticketing.inbound.enabled=false for new partners', async () => {
+    await createPartner({
+      orgName: 'Acme',
+      adminEmail: 'alex@acme.com',
+      adminName: 'Alex',
+      passwordHash: 'hashed',
+      origin: { mcp: false },
+      status: 'active',
+    });
+
+    const partnerCall = insertCalls.find((c) => (c.table as any).__t === 'partners')!;
+    expect(partnerCall.values.settings).toMatchObject({
+      ticketing: { inbound: { enabled: false } },
+    });
+  });
+
   it('inserts six system ticket_statuses rows inside the transaction', async () => {
     await createPartner({
       orgName: 'Acme',

--- a/apps/api/src/services/partnerCreate.ts
+++ b/apps/api/src/services/partnerCreate.ts
@@ -83,6 +83,16 @@ export async function createPartner(
         mcpOriginUserAgent: mcpOrigin ? (input.origin as { userAgent?: string }).userAgent ?? null : null,
         signupIp: !mcpOrigin ? (input.origin as { ip?: string }).ip ?? null : null,
         signupUserAgent: !mcpOrigin ? (input.origin as { userAgent?: string }).userAgent ?? null : null,
+        // Issue #3608 (decision: Option B, 2026-08-16): new partners opt IN to
+        // inbound email-to-ticket rather than inheriting the readers'
+        // "absent flag reads as true" fallback. That fallback
+        // (`loadPartnerInboundPolicy` in inboundEmail/resolveOrg.ts and
+        // `getTicketConfig` in ticketConfigService.ts, both `enabled !== false`)
+        // stays as-is — it exists solely as the pre-#3606 upgrade path for
+        // partners created before this default existed. Do NOT "fix" the
+        // readers to match this new-partner default; the two are deliberately
+        // different concerns. Do NOT backfill existing partners' settings.
+        settings: { ticketing: { inbound: { enabled: false } } },
       })
       .returning();
 


### PR DESCRIPTION
## Summary

- Implements the Option B decision recorded on #3608 (2026-08-16): `createPartner` now writes an explicit `settings.ticketing.inbound.enabled: false` at partner-creation time, so new partners must opt in to inbound email-to-ticket instead of silently inheriting the readers' absent-flag-means-true default.
- The readers (`loadPartnerInboundPolicy` in `apps/api/src/services/inboundEmail/resolveOrg.ts` and `getTicketConfig` in `apps/api/src/services/ticketConfigService.ts`, both `enabled !== false`) are left unchanged and now serve solely as the upgrade path for partners created before this default existed — commented in `partnerCreate.ts` so a future reader doesn't "fix" it back into agreement, per the issue's explicit warning.
- No backfill of existing partners' `settings` — scope is new-partner creation only, as specified in the issue.
- The prerequisite card-visibility work (#3598, closed) and copy fix (#3599 / PR #3627, merged) that make the off-state visible to operators are already shipped, satisfying the issue's "only bundled with the card work" condition.

## Test plan

- [x] New unit test in `apps/api/src/services/partnerCreate.test.ts`: asserts the partner insert's `settings` matches `{ ticketing: { inbound: { enabled: false } } }`. Confirmed red before the fix, green after.
- [x] `pnpm --filter @breeze/api exec vitest run src/services/partnerCreate.test.ts --pool=threads --maxWorkers=2` — 6/6 passed.
- [x] `pnpm --filter @breeze/api exec vitest run src/services/ticketConfigService.test.ts src/services/inboundEmail/resolvePartner.test.ts --pool=threads --maxWorkers=2` — 66/66 passed (no regression in the readers this decision deliberately leaves unchanged).
- [x] `NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit -p apps/api` — clean.

Closes #3608

🤖 Generated with [Claude Code](https://claude.com/claude-code)