### PR TITLE
fix(api): unique index + atomic upserts for automation_policy_compliance (#4122)

### DIFF
--- a/apps/api/migrations/2026-09-29-100000-automation-policy-compliance-unique.sql
+++ b/apps/api/migrations/2026-09-29-100000-automation-policy-compliance-unique.sql
@@ -1,0 +1,101 @@
+-- automation_policy_compliance: dedupe + unique indexes (#4122)
+--
+-- The table has always been an "upsert" target but never had a uniqueness
+-- constraint to upsert against, and `policyEvaluationService.ts` wrote it with a
+-- non-atomic select-then-insert. Two concurrent evaluations of the same policy
+-- (scheduled sweep + manual "Evaluate now", or two workers on the same policy)
+-- both saw "no row" and both inserted, so duplicates accumulate for a single
+-- (policy, device) pair. Readers then pick an arbitrary one:
+--   * `policyAlertBridge.handlePolicyViolation`'s reconcile guard reads this
+--     table to decide whether a violation is still current (mitigated in #4117
+--     with `ORDER BY updated_at DESC`, which is a tiebreak, not a guarantee).
+--   * The evaluation upsert itself kept writing to whichever duplicate its
+--     unordered SELECT happened to return, so status could ping-pong.
+--
+-- Two shapes live in this table and exactly one axis is populated per row:
+--   1. automation policy   -> (policy_id, device_id)
+--   2. config policy item  -> (config_policy_id, config_item_name, device_id)
+-- Both key columns are nullable, so uniqueness is expressed as two PARTIAL
+-- unique indexes rather than table constraints.
+--
+-- Index creation is deliberately NOT `CONCURRENTLY`: autoMigrate wraps each file
+-- in a transaction, and splitting the dedupe from the index build would leave a
+-- window in which a racing writer re-creates a duplicate and the concurrent
+-- build finishes INVALID. Doing both in one transaction is the atomic option.
+
+-- ---------------------------------------------------------------------------
+-- 1. Dedupe the automation-policy shape, keeping the freshest row per pair.
+--    "Freshest" = highest updated_at, id DESC as a deterministic tiebreak.
+--    The surviving row carries its own remediation_attempts; counters on the
+--    discarded duplicates are intentionally not merged — the freshest row is
+--    the one every reader was already trying to read.
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE
+  removed_policy_dupes INTEGER;
+BEGIN
+  WITH ranked AS (
+    SELECT
+      id,
+      ROW_NUMBER() OVER (
+        PARTITION BY policy_id, device_id
+        ORDER BY updated_at DESC, id DESC
+      ) AS ordinal
+    FROM automation_policy_compliance
+    WHERE policy_id IS NOT NULL
+  )
+  DELETE FROM automation_policy_compliance
+   WHERE id IN (SELECT id FROM ranked WHERE ordinal > 1);
+  GET DIAGNOSTICS removed_policy_dupes = ROW_COUNT;
+
+  -- Deliberately always-report (no `IF n > 0` guard): a zero is evidence too.
+  -- These rows drive compliance state and alert reconciliation, so the count of
+  -- what this cleanup discarded belongs in the Postgres log unconditionally.
+  RAISE WARNING 'automation_policy_compliance dedupe: removed % duplicate (policy_id, device_id) row(s)',
+    removed_policy_dupes;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- 2. Dedupe the config-policy-item shape.
+--    Scoped to rows where BOTH key columns are populated: NULLs never collide
+--    in a btree unique index, so a row missing config_item_name cannot be keyed
+--    and must not be deleted on a key we cannot actually form.
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE
+  removed_config_dupes INTEGER;
+BEGIN
+  WITH ranked AS (
+    SELECT
+      id,
+      ROW_NUMBER() OVER (
+        PARTITION BY config_policy_id, config_item_name, device_id
+        ORDER BY updated_at DESC, id DESC
+      ) AS ordinal
+    FROM automation_policy_compliance
+    WHERE config_policy_id IS NOT NULL
+      AND config_item_name IS NOT NULL
+  )
+  DELETE FROM automation_policy_compliance
+   WHERE id IN (SELECT id FROM ranked WHERE ordinal > 1);
+  GET DIAGNOSTICS removed_config_dupes = ROW_COUNT;
+
+  RAISE WARNING 'automation_policy_compliance dedupe: removed % duplicate (config_policy_id, config_item_name, device_id) row(s)',
+    removed_config_dupes;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- 3. The uniqueness the writers upsert against.
+--    The predicates below are reproduced verbatim as `targetWhere` in
+--    `policyEvaluationService.ts` — Postgres only infers a partial index as an
+--    ON CONFLICT arbiter when the statement's inference predicate implies the
+--    index predicate, so the two must be kept in lockstep.
+-- ---------------------------------------------------------------------------
+CREATE UNIQUE INDEX IF NOT EXISTS apc_policy_device_uq
+  ON automation_policy_compliance (policy_id, device_id)
+  WHERE policy_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS apc_config_policy_item_device_uq
+  ON automation_policy_compliance (config_policy_id, config_item_name, device_id)
+  WHERE config_policy_id IS NOT NULL
+    AND config_item_name IS NOT NULL;

--- a/apps/api/migrations/2026-09-29-100000-automation-policy-compliance-unique.sql
+++ b/apps/api/migrations/2026-09-29-100000-automation-policy-compliance-unique.sql
@@ -23,6 +23,21 @@
 -- window in which a racing writer re-creates a duplicate and the concurrent
 -- build finishes INVALID. Doing both in one transaction is the atomic option.
 
+-- `automation_policy_compliance` is ENABLE + FORCE ROW LEVEL SECURITY
+-- (2026-04-11-bucket-c-phase-5-admin-cold-rls.sql), so the policies apply to the
+-- table OWNER too — and `breeze_current_scope()` defaults to 'none', not
+-- 'system' (0012-tenant-rls-deny-default.sql supersedes 0008: missing scope
+-- DENIES). autoMigrate sets no scope. On the containerised deployment
+-- DATABASE_URL is a superuser and bypasses RLS anyway, but on managed Postgres
+-- (DigitalOcean/RDS) the admin role is NOT a superuser — there the DELETEs
+-- below would match zero rows, the RAISE WARNING would report a truthful-looking
+-- "removed 0" that is actually an RLS artifact, and CREATE UNIQUE INDEX would
+-- then abort on the surviving duplicates and refuse the API's boot.
+--
+-- `is_local = true` scopes this to autoMigrate's per-file transaction. Same
+-- one-liner as 2026-04-13-fix-uuid-hostnames.sql and ~10 later migrations.
+SELECT set_config('breeze.scope', 'system', true);
+
 -- ---------------------------------------------------------------------------
 -- 1. Dedupe the automation-policy shape, keeping the freshest row per pair.
 --    "Freshest" = highest updated_at, id DESC as a deterministic tiebreak.

--- a/apps/api/src/__tests__/integration/automationPoliciesPartnerRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/automationPoliciesPartnerRls.integration.test.ts
@@ -19,7 +19,7 @@
  */
 import './setup';
 import { afterEach, describe, expect, it } from 'vitest';
-import { eq, inArray } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm';
 import { db, withDbAccessContext, type DbAccessContext } from '../../db';
 import { automationPolicies, automationPolicyCompliance, devices, sites } from '../../db/schema';
 import { evaluatePolicy } from '../../services/policyEvaluationService';
@@ -324,5 +324,101 @@ describe('evaluatePolicy — partner-wide evaluation fan-out (#2129)', () => {
     const evaluatedIds = result.results.map((r) => r.deviceId);
     expect(evaluatedIds).toContain(device1);
     expect(evaluatedIds).not.toContain(device2);
+  });
+
+  /**
+   * #4122. `automation_policy_compliance` had no uniqueness and the writer was a
+   * select-then-insert, so two evaluations racing between the SELECT and the
+   * INSERT each created a row for the same (policy, device).
+   *
+   * Neither property below is reachable from the unit suite: the compiled-SQL
+   * test (`policyEvaluationService.upsertSql.test.ts`) proves the statement
+   * NAMES the right arbiter, but only a real Postgres decides whether it can
+   * INFER the partial index. If `targetWhere` ever stops implying the index
+   * predicate the statement dies at runtime with
+   * `42P10 there is no unique or exclusion constraint matching the ON CONFLICT
+   * specification` — and this is the only place that surfaces.
+   */
+  async function seedPolicyForDevice(hostname: string) {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const deviceId = await seedDevice(org.id, hostname);
+    const policyId = await seedPartnerPolicy(partner.id);
+    const [policy] = await withDbAccessContext(SYSTEM_CTX, () =>
+      db.select().from(automationPolicies).where(eq(automationPolicies.id, policyId)),
+    );
+    return { policy: policy!, policyId, deviceId };
+  }
+
+  function complianceRowsFor(policyId: string, deviceId: string) {
+    return withDbAccessContext(SYSTEM_CTX, () =>
+      db
+        .select({ id: automationPolicyCompliance.id })
+        .from(automationPolicyCompliance)
+        .where(
+          and(
+            eq(automationPolicyCompliance.policyId, policyId),
+            eq(automationPolicyCompliance.deviceId, deviceId),
+          ),
+        ),
+    );
+  }
+
+  it('re-evaluating UPDATES the compliance row through the real ON CONFLICT arbiter', async () => {
+    const { policy, policyId, deviceId } = await seedPolicyForDevice('upsert-serial');
+    const opts = { source: 'integration-test', requestRemediation: false };
+
+    await withDbAccessContext(SYSTEM_CTX, () => evaluatePolicy(policy, opts));
+    // The second pass is the one that takes the DO UPDATE branch against a live
+    // partial index. A 42P10 or a bare unique violation fails the test here.
+    await withDbAccessContext(SYSTEM_CTX, () => evaluatePolicy(policy, opts));
+
+    expect(await complianceRowsFor(policyId, deviceId)).toHaveLength(1);
+  });
+
+  /**
+   * The durable half of the fix. Racing two `evaluatePolicy` calls and hoping
+   * they interleave is NOT a test — I tried it, and reverting the writer to the
+   * old select-then-insert left it green, because nothing forces the two SELECTs
+   * to both land before either INSERT.
+   *
+   * What actually makes the duplicate unreachable is the index, so assert that
+   * directly: emit the exact write the old code produced when it lost the race
+   * (a blind INSERT for an already-present key) and require Postgres to reject
+   * it. This holds no matter what the application layer does, which is the
+   * guarantee #4122 asked for.
+   */
+  it('a blind duplicate INSERT for an existing (policy, device) is rejected by the index (#4122)', async () => {
+    const { policy, policyId, deviceId } = await seedPolicyForDevice('upsert-blind-dup');
+
+    await withDbAccessContext(SYSTEM_CTX, () =>
+      evaluatePolicy(policy, { source: 'integration-test', requestRemediation: false }),
+    );
+    expect(await complianceRowsFor(policyId, deviceId)).toHaveLength(1);
+
+    const failure = await withDbAccessContext(SYSTEM_CTX, () =>
+      db.insert(automationPolicyCompliance).values({ policyId, deviceId, status: 'pending' }),
+    ).then(
+      () => null,
+      (error: unknown) => error,
+    );
+    expect(failure, 'the blind duplicate INSERT must be rejected').not.toBeNull();
+
+    // Assert the SQLSTATE and the constraint NAME, not the message: Drizzle
+    // wraps the driver error, so `.message` is its own "Failed query: …" text
+    // and a message regex would pass for any failure at all — including an RLS
+    // denial, which would let this test go green with no index present.
+    const codes: string[] = [];
+    const constraints: string[] = [];
+    for (let error = failure as { code?: string; constraint_name?: string; cause?: unknown } | null;
+         error;
+         error = (error.cause ?? null) as typeof error) {
+      if (error.code) codes.push(error.code);
+      if (error.constraint_name) constraints.push(error.constraint_name);
+    }
+    expect(codes, `expected unique_violation, got codes ${JSON.stringify(codes)}`).toContain('23505');
+    expect(constraints).toContain('apc_policy_device_uq');
+
+    expect(await complianceRowsFor(policyId, deviceId)).toHaveLength(1);
   });
 });

--- a/apps/api/src/db/schema/automations.ts
+++ b/apps/api/src/db/schema/automations.ts
@@ -235,4 +235,19 @@ export const automationPolicyCompliance = pgTable('automation_policy_compliance'
 }, (table) => ({
   configPolicyIdIdx: index('apc_config_policy_id_idx').on(table.configPolicyId),
   deviceIdIdx: index('apc_device_id_idx').on(table.deviceId),
+  // Two shapes share this table and exactly one axis is populated per row, so
+  // uniqueness is two PARTIAL indexes rather than table constraints (#4122).
+  // `policyEvaluationService.ts` names these predicates verbatim as the
+  // `targetWhere` of its ON CONFLICT arbiter — Postgres only infers a partial
+  // index when the statement's predicate implies the index's, so the three
+  // copies (here, migration 2026-09-29-100000, and the service) move together.
+  policyDeviceUq: uniqueIndex('apc_policy_device_uq')
+    .on(table.policyId, table.deviceId)
+    .where(sql`${table.policyId} IS NOT NULL`),
+  // config_item_name is nullable and NULLs never collide in a btree unique
+  // index, so a row without one cannot be keyed — it stays outside the index
+  // rather than being silently treated as a distinct key.
+  configPolicyItemDeviceUq: uniqueIndex('apc_config_policy_item_device_uq')
+    .on(table.configPolicyId, table.configItemName, table.deviceId)
+    .where(sql`${table.configPolicyId} IS NOT NULL AND ${table.configItemName} IS NOT NULL`),
 }));

--- a/apps/api/src/services/policyAlertBridge.ts
+++ b/apps/api/src/services/policyAlertBridge.ts
@@ -211,9 +211,11 @@ export async function handlePolicyViolation(orgId: string, payload: PolicyEventP
       eq(automationPolicyCompliance.policyId, payload.policyId),
       eq(automationPolicyCompliance.deviceId, payload.deviceId),
     ))
-    // Duplicate (policy, device) compliance rows exist in the wild — without
-    // an explicit order, an arbitrary stale 'compliant' row can suppress a
-    // real violation. Most-recently-updated row wins.
+    // Duplicate (policy, device) rows are no longer reachable: #4122 deduped
+    // the table and added the partial unique index `apc_policy_device_uq`, and
+    // the evaluation writes are now ON CONFLICT upserts. The ordering stays as
+    // defence-in-depth — it costs nothing on a single row, and it keeps this
+    // read deterministic rather than depending on the index for correctness.
     .orderBy(desc(automationPolicyCompliance.updatedAt))
     .limit(1);
   if (compliance && compliance.status !== 'non_compliant') {

--- a/apps/api/src/services/policyEvaluationService.ts
+++ b/apps/api/src/services/policyEvaluationService.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, isNull, ne, or, sql, type SQL } from 'drizzle-orm';
+import { and, eq, inArray, isNotNull, isNull, ne, or, sql, type SQL } from 'drizzle-orm';
 import { db } from '../db';
 import {
   automationPolicies,
@@ -128,6 +128,99 @@ type DeviceRuleEvaluation = {
 };
 
 type VersionOperator = 'any' | 'exact' | 'minimum' | 'maximum';
+
+// ─── Compliance-row upserts (#4122) ─────────────────────────────────────────
+//
+// Both compliance shapes used to be written with a non-atomic select-then-
+// insert against a table that had no uniqueness at all, so two concurrent
+// evaluations of the same policy each saw "no row" and each inserted. The
+// duplicates then fed `policyAlertBridge`'s reconcile guard and the next
+// evaluation's own read, which picked an arbitrary one of them.
+//
+// Migration 2026-09-29-100000 adds the two PARTIAL unique indexes these
+// builders arbitrate on. Postgres only infers a partial index as an ON CONFLICT
+// arbiter when the statement's inference predicate implies the index predicate,
+// so each `targetWhere` below must stay byte-for-byte equivalent to its index's
+// `WHERE`. Getting it wrong is loud, not silent: `42P10 there is no unique or
+// exclusion constraint matching the ON CONFLICT specification`.
+//
+// `remediationAttempts` is deliberately absent from every SET list — it is a
+// counter owned by the remediation path and a re-evaluation must not reset it.
+// This matches the UPDATE these upserts replace.
+//
+// Both builders are exported so `policyEvaluationService.upsertSql.test.ts` can
+// assert the COMPILED SQL. A call-shape assertion against a mocked `db` would
+// stay green with the wrong conflict target, which is the whole bug class here.
+
+type ComplianceUpsertDetails = Record<string, unknown>;
+
+export function buildPolicyComplianceUpsert(input: {
+  policyId: string;
+  deviceId: string;
+  status: EvaluationStatus;
+  details: ComplianceUpsertDetails;
+  checkedAt: Date;
+}) {
+  const mutable = {
+    status: input.status,
+    details: input.details,
+    lastCheckedAt: input.checkedAt,
+    updatedAt: input.checkedAt,
+  };
+  return db
+    .insert(automationPolicyCompliance)
+    .values({
+      policyId: input.policyId,
+      deviceId: input.deviceId,
+      ...mutable,
+    })
+    .onConflictDoUpdate({
+      // Mirrors `apc_policy_device_uq`.
+      target: [automationPolicyCompliance.policyId, automationPolicyCompliance.deviceId],
+      targetWhere: isNotNull(automationPolicyCompliance.policyId),
+      set: mutable,
+    });
+}
+
+export function buildConfigPolicyComplianceUpsert(input: {
+  configPolicyId: string;
+  configItemName: string;
+  deviceId: string;
+  status: 'compliant' | 'non_compliant' | 'error';
+  details: ComplianceUpsertDetails;
+  checkedAt: Date;
+}) {
+  const mutable = {
+    status: input.status,
+    details: input.details,
+    lastCheckedAt: input.checkedAt,
+    updatedAt: input.checkedAt,
+  };
+  return db
+    .insert(automationPolicyCompliance)
+    .values({
+      // Explicitly NULL: this row lives on the config-policy axis, and a
+      // non-null policy_id here would also land it in `apc_policy_device_uq`.
+      policyId: null,
+      configPolicyId: input.configPolicyId,
+      configItemName: input.configItemName,
+      deviceId: input.deviceId,
+      ...mutable,
+    })
+    .onConflictDoUpdate({
+      // Mirrors `apc_config_policy_item_device_uq`.
+      target: [
+        automationPolicyCompliance.configPolicyId,
+        automationPolicyCompliance.configItemName,
+        automationPolicyCompliance.deviceId,
+      ],
+      targetWhere: and(
+        isNotNull(automationPolicyCompliance.configPolicyId),
+        isNotNull(automationPolicyCompliance.configItemName),
+      ),
+      set: mutable,
+    });
+}
 
 export type RuleEvaluationDebugInput = {
   device: {
@@ -1379,36 +1472,27 @@ export async function evaluatePolicy(
       registryState: registryStateByDevice.get(device.id) ?? [],
       configState: configStateByDevice.get(device.id) ?? [],
     });
+    const checkedAt = new Date();
     const status: EvaluationStatus = evaluation.passed ? 'compliant' : 'non_compliant';
     const details = {
-      evaluatedAt: new Date().toISOString(),
+      evaluatedAt: checkedAt.toISOString(),
       rules: ruleKeys,
       passed: evaluation.passed,
       ruleResults: evaluation.details,
       source,
     };
 
-    if (existing) {
-      await db
-        .update(automationPolicyCompliance)
-        .set({
-          status,
-          details,
-          lastCheckedAt: new Date(),
-          updatedAt: new Date(),
-        })
-        .where(eq(automationPolicyCompliance.id, existing.id));
-    } else {
-      await db
-        .insert(automationPolicyCompliance)
-        .values({
-          policyId: policy.id,
-          deviceId: device.id,
-          status,
-          details,
-          lastCheckedAt: new Date(),
-        });
-    }
+    // The `existing` read above still supplies `previousStatus` for the event
+    // payloads below, but it no longer decides insert-vs-update: a concurrent
+    // evaluation may have inserted the row between that SELECT and here, and
+    // only the ON CONFLICT arbiter closes that window (#4122).
+    await buildPolicyComplianceUpsert({
+      policyId: policy.id,
+      deviceId: device.id,
+      status,
+      details,
+      checkedAt,
+    });
 
     const remediationRunId = requestRemediation
       ? await triggerRemediationAutomation(policy, device, status, await remediationAutomationIdForOrg(device.orgId))
@@ -1652,8 +1736,9 @@ export async function evaluateDeviceComplianceFromConfigPolicy(
 
     const ruleKeys = parsePolicyRules(complianceRule.rules).rules.map((rule) => rule.type);
 
+    const checkedAt = new Date();
     const evaluationDetails = {
-      evaluatedAt: new Date().toISOString(),
+      evaluatedAt: checkedAt.toISOString(),
       rules: ruleKeys,
       passed: status === 'compliant',
       ruleResults: ruleDetails,
@@ -1661,42 +1746,17 @@ export async function evaluateDeviceComplianceFromConfigPolicy(
       enforcementLevel: complianceRule.enforcementLevel,
     };
 
-    // Upsert compliance row keyed by (configPolicyId=featureLinkId, configItemName, deviceId)
-    const [existing] = await db
-      .select()
-      .from(automationPolicyCompliance)
-      .where(
-        and(
-          eq(automationPolicyCompliance.configPolicyId, complianceRule.featureLinkId),
-          eq(automationPolicyCompliance.configItemName, complianceRule.name),
-          eq(automationPolicyCompliance.deviceId, deviceId)
-        )
-      )
-      .limit(1);
-
-    if (existing) {
-      await db
-        .update(automationPolicyCompliance)
-        .set({
-          status,
-          details: evaluationDetails,
-          lastCheckedAt: new Date(),
-          updatedAt: new Date(),
-        })
-        .where(eq(automationPolicyCompliance.id, existing.id));
-    } else {
-      await db
-        .insert(automationPolicyCompliance)
-        .values({
-          policyId: null,
-          configPolicyId: complianceRule.featureLinkId,
-          configItemName: complianceRule.name,
-          deviceId,
-          status,
-          details: evaluationDetails,
-          lastCheckedAt: new Date(),
-        });
-    }
+    // Atomic upsert keyed by (configPolicyId=featureLinkId, configItemName,
+    // deviceId). This replaced a select-then-insert whose read/write gap let
+    // two concurrent evaluations both insert for the same key (#4122).
+    await buildConfigPolicyComplianceUpsert({
+      configPolicyId: complianceRule.featureLinkId,
+      configItemName: complianceRule.name,
+      deviceId,
+      status,
+      details: evaluationDetails,
+      checkedAt,
+    });
 
     // Trigger remediation if enforcement is 'enforce'
     let remediationTriggered = false;

--- a/apps/api/src/services/policyEvaluationService.upsertSql.test.ts
+++ b/apps/api/src/services/policyEvaluationService.upsertSql.test.ts
@@ -18,7 +18,7 @@
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { getTableConfig } from 'drizzle-orm/pg-core';
+import { PgDialect, getTableConfig } from 'drizzle-orm/pg-core';
 import {
   buildConfigPolicyComplianceUpsert,
   buildPolicyComplianceUpsert,
@@ -40,7 +40,11 @@ function normalizePredicate(raw: string): string {
     .replace(/"automation_policy_compliance"\./g, '')
     .replace(/"/g, '')
     .replace(/\s+/g, ' ')
-    .replace(/^\(|\)$/g, '')
+    // `.trim()` BEFORE stripping the wrapping parens: the migration's predicate
+    // ends with a newline that collapses to a space, which would otherwise
+    // orphan the trailing `)` and turn a reformat into a confusing false FAIL.
+    .trim()
+    .replace(/^\((.*)\)$/, '$1')
     .trim()
     .toLowerCase();
 }
@@ -127,7 +131,12 @@ describe('buildPolicyComplianceUpsert — compiled SQL', () => {
     // brand-new row gets 0) — what matters is that it is absent from the SET
     // list, which is the only branch that touches an existing row.
     expect(setList).not.toMatch(/remediation_attempts/i);
-    expect(params).toEqual(expect.arrayContaining(['pol-1', 'dev-1', 'non_compliant']));
+    // POSITIONAL, not `arrayContaining`: the compiled VALUES list is
+    // `(default, $1, default, default, $2, $3, ...)` = policy_id, device_id,
+    // status. `arrayContaining` is order-insensitive, so it cannot tell that
+    // apart from `values({ policyId: deviceId, deviceId: policyId })` — a
+    // guaranteed cross-column corruption it would wave through.
+    expect(params.slice(0, 3)).toEqual(['pol-1', 'dev-1', 'non_compliant']);
   });
 });
 
@@ -141,9 +150,14 @@ describe('buildConfigPolicyComplianceUpsert — compiled SQL', () => {
   });
 
   it('writes policy_id NULL so the row cannot also land in the policy-axis index', () => {
-    const { sql, params } = configSql();
-    expect(sql).toMatch(/"policy_id"/);
-    expect(params).toEqual(expect.arrayContaining([null, 'fl-1', 'Disk space', 'dev-1', 'compliant']));
+    // Positional for the same reason as above — and here it is the ONLY way to
+    // prove the null lands in `policy_id` specifically. `toMatch(/"policy_id"/)`
+    // would be trivially true: Drizzle names every column in the INSERT list
+    // regardless of what was passed. Compiled order is
+    // `(default, $1..$4, ...)` = policy_id, config_policy_id, config_item_name,
+    // device_id, status.
+    const { params } = configSql();
+    expect(params.slice(0, 5)).toEqual([null, 'fl-1', 'Disk space', 'dev-1', 'compliant']);
   });
 
   it('preserves remediation_attempts on the conflict branch', () => {
@@ -182,6 +196,19 @@ describe('unique-index lockstep: migration ↔ schema ↔ upsert', () => {
       expect(declared?.where, `${indexName} must stay a PARTIAL index`).toBeDefined();
 
       const migrationIndex = readMigrationIndex(indexName);
+
+      // Compile the schema's own predicate and diff it against the migration's.
+      // `toBeDefined()` alone was not enough: it passes for ANY predicate, so
+      // the schema could declare `device_id IS NOT NULL` — a different index
+      // entirely — and this block would still be green. Comparing the compiled
+      // text is what makes the third copy actually participate in the lockstep.
+      const declaredWhere = declared?.where;
+      expect(declaredWhere).toBeDefined();
+      expect(
+        normalizePredicate(new PgDialect().sqlToQuery(declaredWhere!).sql),
+        `${indexName} schema predicate drifted from the migration`,
+      ).toBe(migrationIndex.predicate);
+
       const declaredColumns = (declared?.columns ?? []).map(
         (column) => (column as { name?: string }).name,
       );

--- a/apps/api/src/services/policyEvaluationService.upsertSql.test.ts
+++ b/apps/api/src/services/policyEvaluationService.upsertSql.test.ts
@@ -1,0 +1,191 @@
+/**
+ * #4122 — `automation_policy_compliance` upserts must be atomic.
+ *
+ * The bug this guards was NOT "the wrong function was called". It was a
+ * select-then-insert whose read/write gap let two concurrent policy
+ * evaluations both insert for the same key, against a table with no uniqueness
+ * at all. A call-shape assertion (`expect(db.insert).toHaveBeenCalled()`, or
+ * `expect.objectContaining({ target: expect.any(Array) })` against a mocked
+ * `../db`) reproduces that bug class exactly: it stays green when the conflict
+ * target names the wrong columns, when `targetWhere` is dropped so Postgres
+ * cannot infer the partial index (42P10), and when the arbiter drifts away
+ * from the index the migration actually created.
+ *
+ * So this file deliberately does NOT mock `../db` — the real Drizzle builder
+ * compiles real SQL — and it cross-checks that SQL against the migration file
+ * and the Drizzle schema, the two other places the same predicate is written.
+ */
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { getTableConfig } from 'drizzle-orm/pg-core';
+import {
+  buildConfigPolicyComplianceUpsert,
+  buildPolicyComplianceUpsert,
+} from './policyEvaluationService';
+import { automationPolicyCompliance } from '../db/schema';
+
+const MIGRATION_PATH = path.resolve(
+  __dirname,
+  '../../migrations/2026-09-29-100000-automation-policy-compliance-unique.sql',
+);
+
+const POLICY_INDEX = 'apc_policy_device_uq';
+const CONFIG_INDEX = 'apc_config_policy_item_device_uq';
+
+/** Collapse whitespace and drop `"automation_policy_compliance".` / quoting so
+ *  a migration predicate and a compiled Drizzle predicate become comparable. */
+function normalizePredicate(raw: string): string {
+  return raw
+    .replace(/"automation_policy_compliance"\./g, '')
+    .replace(/"/g, '')
+    .replace(/\s+/g, ' ')
+    .replace(/^\(|\)$/g, '')
+    .trim()
+    .toLowerCase();
+}
+
+/** Parse `CREATE UNIQUE INDEX ... <name> ON <table> (cols) WHERE <pred>;` out of
+ *  the migration, so the test fails if the migration is edited out of step. */
+function readMigrationIndex(indexName: string): { columns: string[]; predicate: string } {
+  const migrationSql = readFileSync(MIGRATION_PATH, 'utf8');
+  const match = new RegExp(
+    String.raw`CREATE UNIQUE INDEX IF NOT EXISTS ${indexName}\s+ON automation_policy_compliance\s*\(([^)]*)\)\s*WHERE ([^;]+);`,
+    'i',
+  ).exec(migrationSql);
+  const [, columnList, predicate] = match ?? [];
+  if (columnList === undefined || predicate === undefined) {
+    throw new Error(`migration ${path.basename(MIGRATION_PATH)} has no unique index ${indexName}`);
+  }
+  return {
+    columns: columnList.split(',').map((column) => column.trim()),
+    predicate: normalizePredicate(predicate),
+  };
+}
+
+/** Pull the `on conflict (...) where ... do update set ...` clause apart. */
+function parseOnConflict(sql: string): { columns: string[]; predicate: string; setList: string } {
+  const match = /on conflict \(([^)]*)\)\s*where (.+?) do update set (.*)$/is.exec(sql);
+  const [, columnList, predicate, setList] = match ?? [];
+  if (columnList === undefined || predicate === undefined || setList === undefined) {
+    throw new Error(`compiled SQL has no partial-index ON CONFLICT arbiter:\n${sql}`);
+  }
+  return {
+    columns: columnList.split(',').map((column) => column.trim().replace(/"/g, '')),
+    predicate: normalizePredicate(predicate),
+    setList,
+  };
+}
+
+const CHECKED_AT = new Date('2026-09-29T10:00:00.000Z');
+
+function policySql() {
+  return buildPolicyComplianceUpsert({
+    policyId: 'pol-1',
+    deviceId: 'dev-1',
+    status: 'non_compliant',
+    details: { passed: false },
+    checkedAt: CHECKED_AT,
+  }).toSQL();
+}
+
+function configSql() {
+  return buildConfigPolicyComplianceUpsert({
+    configPolicyId: 'fl-1',
+    configItemName: 'Disk space',
+    deviceId: 'dev-1',
+    status: 'compliant',
+    details: { passed: true },
+    checkedAt: CHECKED_AT,
+  }).toSQL();
+}
+
+describe('buildPolicyComplianceUpsert — compiled SQL', () => {
+  it('is a single INSERT ... ON CONFLICT, not a select-then-insert', () => {
+    const { sql } = policySql();
+    expect(sql).toMatch(/^insert into "automation_policy_compliance"/i);
+    expect(sql).toMatch(/ do update set /i);
+  });
+
+  it('arbitrates on (policy_id, device_id) with the partial-index predicate', () => {
+    const { columns, predicate } = parseOnConflict(policySql().sql);
+    expect(columns).toEqual(['policy_id', 'device_id']);
+    // Without this predicate Postgres cannot infer the PARTIAL index and the
+    // statement fails 42P10 at runtime — a green call-shape test would not see it.
+    expect(predicate).toBe('policy_id is not null');
+  });
+
+  it('updates status/details/last_checked_at/updated_at and preserves remediation_attempts', () => {
+    const { sql, params } = policySql();
+    const { setList } = parseOnConflict(sql);
+    expect(setList).toMatch(/"status" = /i);
+    expect(setList).toMatch(/"details" = /i);
+    expect(setList).toMatch(/"last_checked_at" = /i);
+    expect(setList).toMatch(/"updated_at" = /i);
+    // The counter belongs to the remediation path; re-evaluating must not reset
+    // it. Drizzle still names it in the INSERT column list (as `default`, so a
+    // brand-new row gets 0) — what matters is that it is absent from the SET
+    // list, which is the only branch that touches an existing row.
+    expect(setList).not.toMatch(/remediation_attempts/i);
+    expect(params).toEqual(expect.arrayContaining(['pol-1', 'dev-1', 'non_compliant']));
+  });
+});
+
+describe('buildConfigPolicyComplianceUpsert — compiled SQL', () => {
+  it('arbitrates on (config_policy_id, config_item_name, device_id) with both NOT NULL legs', () => {
+    const { columns, predicate } = parseOnConflict(configSql().sql);
+    expect(columns).toEqual(['config_policy_id', 'config_item_name', 'device_id']);
+    // Both legs are required: config_item_name is nullable, and an index
+    // predicate the statement does not imply is not inferable.
+    expect(predicate).toBe('config_policy_id is not null and config_item_name is not null');
+  });
+
+  it('writes policy_id NULL so the row cannot also land in the policy-axis index', () => {
+    const { sql, params } = configSql();
+    expect(sql).toMatch(/"policy_id"/);
+    expect(params).toEqual(expect.arrayContaining([null, 'fl-1', 'Disk space', 'dev-1', 'compliant']));
+  });
+
+  it('preserves remediation_attempts on the conflict branch', () => {
+    expect(parseOnConflict(configSql().sql).setList).not.toMatch(/remediation_attempts/i);
+  });
+});
+
+/**
+ * The same two predicates are written in three places (migration, Drizzle
+ * schema, service). Postgres infers a partial index as an ON CONFLICT arbiter
+ * only when the statement's predicate implies the index's, so drift between
+ * any two of them is a runtime 42P10 or — worse — a silently unenforced
+ * uniqueness. These assert the three copies still agree.
+ */
+describe('unique-index lockstep: migration ↔ schema ↔ upsert', () => {
+  it.each([
+    [POLICY_INDEX, policySql],
+    [CONFIG_INDEX, configSql],
+  ])('%s matches the compiled ON CONFLICT arbiter', (indexName, build) => {
+    const migrationIndex = readMigrationIndex(indexName as string);
+    const arbiter = parseOnConflict((build as () => { sql: string })().sql);
+    expect(arbiter.columns).toEqual(migrationIndex.columns);
+    expect(arbiter.predicate).toBe(migrationIndex.predicate);
+  });
+
+  it('the Drizzle schema declares both partial unique indexes', () => {
+    const { indexes } = getTableConfig(automationPolicyCompliance);
+    const byName = new Map(indexes.map((entry) => [entry.config.name, entry.config]));
+
+    for (const indexName of [POLICY_INDEX, CONFIG_INDEX]) {
+      const declared = byName.get(indexName);
+      // Drift here is what `pnpm db:check-drift` reports; asserting it in the
+      // unit suite means CI catches a schema/migration split without a live DB.
+      expect(declared, `${indexName} missing from the Drizzle schema`).toBeDefined();
+      expect(declared?.unique).toBe(true);
+      expect(declared?.where, `${indexName} must stay a PARTIAL index`).toBeDefined();
+
+      const migrationIndex = readMigrationIndex(indexName);
+      const declaredColumns = (declared?.columns ?? []).map(
+        (column) => (column as { name?: string }).name,
+      );
+      expect(declaredColumns).toEqual(migrationIndex.columns);
+    }
+  });
+});


### PR DESCRIPTION
## The bug

`automation_policy_compliance` had **no uniqueness on either of the two shapes it stores**, and `policyEvaluationService` wrote it with a non-atomic select-then-insert. Two concurrent evaluations of the same policy — scheduled sweep + manual "Evaluate now", or two workers on one policy — both saw "no row" and both inserted, so duplicates accumulated per key.

Readers then picked an arbitrary one:
- `policyAlertBridge.handlePolicyViolation`'s reconcile guard could read a stale row. #4117 mitigated this with `ORDER BY updated_at DESC`, which is a tiebreak, not a guarantee.
- The evaluation upsert itself kept writing to whichever duplicate its unordered `SELECT` returned, so status could ping-pong between rows.

## The fix

**Migration `2026-09-29-100000-automation-policy-compliance-unique.sql`** — dedupes both shapes keeping the freshest row per key (`updated_at DESC, id DESC`), then adds two **partial** unique indexes:

| Index | Key | Predicate |
|---|---|---|
| `apc_policy_device_uq` | `(policy_id, device_id)` | `policy_id IS NOT NULL` |
| `apc_config_policy_item_device_uq` | `(config_policy_id, config_item_name, device_id)` | both `IS NOT NULL` |

Partial because the key columns are nullable and exactly one axis is populated per row.

Notes on the migration:
- **Sets `breeze.scope` to `system` first.** The table is FORCE RLS and `breeze_current_scope()` defaults to `'none'` (0012 superseded 0008's `'system'` default), while autoMigrate sets no scope. On the containerised deployment `DATABASE_URL` is a superuser so RLS is bypassed — but on managed Postgres (DigitalOcean/RDS) the admin role is not, and there the DELETEs would match zero rows and `CREATE UNIQUE INDEX` would then abort on the survivors, refusing the API's boot. Same one-liner `2026-04-13-fix-uuid-hostnames.sql` and ~10 later migrations use. (Caught in review; see the verification section.)
- Each dedupe reports its count via `GET DIAGNOSTICS` + `RAISE WARNING` **unconditionally** (no `IF n > 0` guard) — these rows drive compliance state and alert reconciliation, so a zero is evidence too.
- The config-shape dedupe is scoped to rows where **both** key columns are populated. NULLs never collide in a btree unique index, so a row without a `config_item_name` cannot be keyed and must not be deleted on a key that cannot be formed.
- Dedupe and index build share one transaction, so no racing writer can slip a duplicate in between. That also rules out `CONCURRENTLY`, which cannot run inside `autoMigrate`'s wrapper and would finish `INVALID` if a duplicate landed mid-build.
- New file only; no shipped migration edited.

**Service** — both write sites become `ON CONFLICT DO UPDATE` upserts, extracted into `buildPolicyComplianceUpsert` / `buildConfigPolicyComplianceUpsert`.
- `remediation_attempts` stays out of every `SET` list, matching the `UPDATE` these replace.
- The automation-policy site **keeps** its existing `SELECT` — it still supplies `previousStatus` for the emitted events; it just no longer decides insert-vs-update.
- Each `targetWhere` reproduces its index predicate verbatim. Postgres only infers a partial index as an `ON CONFLICT` arbiter when the statement's predicate implies the index's, so the three copies (migration, Drizzle schema, service) must move together.

## Verification

**Unit:** 181 tests green; `tsc --noEmit -p apps/api` clean; eslint clean.

Because the failure mode is "wrong arbiter" rather than "wrong function called", the unit test asserts the **compiled SQL** (`.toSQL()`, real Drizzle builder, `../db` deliberately not mocked) and diffs the arbiter against both the migration DDL and the Drizzle schema predicate. Every assertion is mutation-checked: dropping `targetWhere`, dropping a conflict-target column, swapping the `policy_id`/`device_id` bindings, and drifting the schema predicate each turn it red.

**Real Postgres:** brought up an isolated per-worktree stack, applied all 618 migrations, and confirmed both indexes exist with exactly the intended predicates. `pnpm db:check-drift` clean.

Two cases added to the existing `evaluatePolicy` integration harness (10 tests green, run 3x, no flake): a re-evaluation that takes the `DO UPDATE` branch against the **live** index, and a blind duplicate INSERT that must be rejected — asserted on SQLSTATE `23505` plus the constraint name, since Drizzle wraps the driver error and a message regex would also pass for an RLS denial. Dropping the live index reds these with the real `42P10 infer_arbiter_indexes`, which is the failure the unit test can only assert by proxy.

The RLS-scope bug above was reproduced both ways against a non-superuser table owner under FORCE RLS: without the fix, `removed 0` (an RLS artifact that reads as "there were none") followed by `ERROR: could not create unique index`; with it, `removed 1` and a clean build.

> One thing I got wrong and want visible: I first wrote the concurrency case as two racing `evaluatePolicy` calls. Reverting the writer to the old select-then-insert left it **green** — nothing forces both SELECTs to land before either INSERT — so it was not a test, and I replaced it with the deterministic index-level assertion above.

## Follow-up (not in this PR)

Migrations doing DML on FORCE-RLS tables without setting `breeze.scope` is a repo-wide pattern, not unique to this file (`2026-09-22-ai-alert-verdicts-live-unique.sql` has the same gap). Worth a separate issue.

Closes #4122

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMvN6SU3uwaaC7b2xmUa5m