### PR TITLE
fix(security): enforce credential-boundary Dockerfile policy on actions executor (#4272)

### DIFF
--- a/apps/api/src/config/dockerfileOpensslUpgrade.test.ts
+++ b/apps/api/src/config/dockerfileOpensslUpgrade.test.ts
@@ -114,8 +114,16 @@ const PINNED_NODE_ALPINE_RE = /^node:[^\s@]*-alpine@sha256:[0-9a-f]{64}$/;
 /** Customer-Graph credential-boundary images with the narrow CVE exception. */
 const CREDENTIAL_BOUNDARY_DOCKERFILES = [
   'apps/m365-graph-read-executor/Dockerfile',
+  'apps/m365-graph-actions-executor/Dockerfile',
   'apps/m365-communications-executor/Dockerfile',
 ] as const;
+
+/** Hardening-script shell variable each credential-boundary Dockerfile is checked through. */
+const CREDENTIAL_BOUNDARY_SCRIPT_VARIABLE: Record<(typeof CREDENTIAL_BOUNDARY_DOCKERFILES)[number], string> = {
+  'apps/m365-graph-read-executor/Dockerfile': 'EXECUTOR_DOCKERFILE',
+  'apps/m365-graph-actions-executor/Dockerfile': 'ACTIONS_EXECUTOR_DOCKERFILE',
+  'apps/m365-communications-executor/Dockerfile': 'COMMS_EXECUTOR_DOCKERFILE',
+};
 
 const HARDENING_SCRIPT = 'scripts/security/check-supply-chain-hardening.sh';
 
@@ -273,10 +281,7 @@ describe('Dockerfile OpenSSL upgrade coverage', () => {
     (dockerfile) => {
       const script = readFileSync(path.join(REPO_ROOT, HARDENING_SCRIPT), 'utf8');
       const source = SOURCES.get(dockerfile)!;
-      const variable =
-        dockerfile === 'apps/m365-graph-read-executor/Dockerfile'
-          ? 'EXECUTOR_DOCKERFILE'
-          : 'COMMS_EXECUTOR_DOCKERFILE';
+      const variable = CREDENTIAL_BOUNDARY_SCRIPT_VARIABLE[dockerfile];
       const apkMutationLines = source
         .split('\n')
         .map((line) => line.trim())

--- a/apps/api/src/config/executorApkPolicy.test.ts
+++ b/apps/api/src/config/executorApkPolicy.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -117,11 +117,15 @@ describe('credential-boundary executor apk policy', () => {
     expect(policyAccepts('RUN $(which apk) add curl')).toBe(false);
   });
 
-  it('applies the policy to both credential-boundary executors', () => {
+  it('applies the policy to all three credential-boundary executors', () => {
     // Guards the wiring rather than the regex: if a future edit drops one of
     // these call sites, the rule silently stops running for that image.
+    // Includes the actions executor (#4272, dup #4264): it holds Graph
+    // *mutation* credentials — the highest blast radius of the three — and
+    // previously had no Dockerfile-content policy applied to it at all.
     const script = execFileSync('cat', [SCRIPT], { encoding: 'utf8' });
     expect(script).toMatch(/require_audited_openssl_upgrade "\$EXECUTOR_DOCKERFILE"/);
+    expect(script).toMatch(/require_audited_openssl_upgrade "\$ACTIONS_EXECUTOR_DOCKERFILE"/);
     expect(script).toMatch(/require_audited_openssl_upgrade "\$COMMS_EXECUTOR_DOCKERFILE"/);
     // ...and that wrapper is what actually runs the rejection rule. If a
     // refactor keeps the call sites but drops this line, the images would still
@@ -130,11 +134,25 @@ describe('credential-boundary executor apk policy', () => {
     // And the images themselves must actually pass it.
     for (const image of [
       'apps/m365-graph-read-executor/Dockerfile',
+      'apps/m365-graph-actions-executor/Dockerfile',
       'apps/m365-communications-executor/Dockerfile',
     ]) {
       expect(() =>
         execFileSync('bash', [SCRIPT, '--check-apk', path.join(REPO_ROOT, image)], { stdio: 'pipe' }),
       ).not.toThrow();
     }
+  });
+
+  it('rejects the exact actions-executor regression reported in #4272', () => {
+    // Issue #4272 verified the gap by appending this line to the real
+    // apps/m365-graph-actions-executor/Dockerfile and observing the full
+    // guard exit 0. Reproduce that mutation against the real file content and
+    // confirm the now-wired policy rejects it.
+    const actionsDockerfile = readFileSync(
+      path.join(REPO_ROOT, 'apps/m365-graph-actions-executor/Dockerfile'),
+      'utf8',
+    );
+    const mutated = `${actionsDockerfile}\nRUN apk add --no-cache sudo openssh netcat-openbsd\n`;
+    expect(policyAccepts(mutated)).toBe(false);
   });
 });

--- a/scripts/security/check-supply-chain-hardening.sh
+++ b/scripts/security/check-supply-chain-hardening.sh
@@ -353,6 +353,30 @@ require_order 'id: push-executor-digest' 'name: Scan exact executor digest' "$ac
 require_order 'name: Scan exact executor digest' 'name: Promote scanned executor digest' "$actions_release_block" \
   "actions-executor release promotion must occur only after its exact digest passes scanning"
 
+# The ACTIONS executor's Dockerfile gets the same shape block as its read
+# sibling. It holds Microsoft Graph *mutation* credentials — the highest
+# blast radius of the three executors — so it must be at least as
+# constrained as the ones with lower privilege, not less (#4272, dup #4264).
+ACTIONS_EXECUTOR_DOCKERFILE=apps/m365-graph-actions-executor/Dockerfile
+[[ -f "$ACTIONS_EXECUTOR_DOCKERFILE" ]] || fail "$ACTIONS_EXECUTOR_DOCKERFILE must package the isolated Graph-actions executor"
+require_grep '^FROM[[:space:]]+node:24-alpine@sha256:[0-9a-f]{64}[[:space:]]+AS[[:space:]]+build' "$ACTIONS_EXECUTOR_DOCKERFILE" \
+  "actions-executor build stage must digest-pin Node while retaining the tag"
+require_grep '^FROM[[:space:]]+node:24-alpine@sha256:[0-9a-f]{64}[[:space:]]+AS[[:space:]]+runner' "$ACTIONS_EXECUTOR_DOCKERFILE" \
+  "actions-executor runtime stage must digest-pin Node while retaining the tag"
+require_grep '^USER[[:space:]]+node$' "$ACTIONS_EXECUTOR_DOCKERFILE" \
+  "actions-executor runtime must run as the non-root node user"
+require_grep '^HEALTHCHECK .*\/healthz' "$ACTIONS_EXECUTOR_DOCKERFILE" \
+  "actions-executor image must declare its bounded health endpoint"
+require_grep '^CMD[[:space:]]+\["node",[[:space:]]*"dist/index\.cjs"\]' "$ACTIONS_EXECUTOR_DOCKERFILE" \
+  "actions-executor image must start only its compiled bounded runtime"
+require_audited_openssl_upgrade "$ACTIONS_EXECUTOR_DOCKERFILE"
+reject_grep '^(COPY|ADD)[[:space:]].*(\.env|\.pem|\.key|secret)' "$ACTIONS_EXECUTOR_DOCKERFILE" \
+  "actions-executor image must not copy env, certificate, key, or secret files"
+reject_grep '^COPY[[:space:]]+\.[[:space:]]+\.' "$ACTIONS_EXECUTOR_DOCKERFILE" \
+  "actions-executor image must use an explicit deterministic build context allowlist"
+require_grep 'directory: "/apps/m365-graph-actions-executor"' .github/dependabot.yml \
+  "Dependabot must maintain the actions-executor Dockerfile's digest-pinned base image"
+
 # The COMMUNICATIONS executor's release image gets the same digest-first shape.
 comms_release_block="$GUARD_TMP_DIR/communications-executor-release.yml"
 extract_yaml_job build-docker-m365-communications-executor .github/workflows/release.yml "$comms_release_block"
@@ -388,8 +412,7 @@ require_grep 'directory: "/apps/m365-communications-executor"' .github/dependabo
   "Dependabot must maintain the communications-executor Dockerfile's digest-pinned base image"
 
 # The communications executor's Dockerfile gets the same shape block as the
-# read executor's. (The actions executor never got one — an acknowledged
-# inconsistency; the comms clone starts consistent.)
+# read and actions executors' (see ACTIONS_EXECUTOR_DOCKERFILE above).
 COMMS_EXECUTOR_DOCKERFILE=apps/m365-communications-executor/Dockerfile
 [[ -f "$COMMS_EXECUTOR_DOCKERFILE" ]] || fail "$COMMS_EXECUTOR_DOCKERFILE must package the isolated communications executor"
 require_grep '^FROM[[:space:]]+node:24-alpine@sha256:[0-9a-f]{64}[[:space:]]+AS[[:space:]]+build' "$COMMS_EXECUTOR_DOCKERFILE" \


### PR DESCRIPTION
## Summary

`scripts/security/check-supply-chain-hardening.sh` enforced a credential-boundary Dockerfile policy for the read and communications M365 executors but not the third — `apps/m365-graph-actions-executor/Dockerfile`, the executor that holds *mutation* credentials, had no Dockerfile-content policy at all. This meant an unaudited `apk add`, a dropped non-root `USER`, an un-pinned base, or a copied secret could land in the highest-privilege of the three executor images and the guard would still exit 0.

Also covers #4264 (duplicate report of the same gap).

## Changes

- `scripts/security/check-supply-chain-hardening.sh`: add `ACTIONS_EXECUTOR_DOCKERFILE` and register it against the same checks the read executor gets — digest-pinned base (build + runner), `USER node`, `HEALTHCHECK .../healthz`, `CMD ["node", "dist/index.cjs"]`, `require_audited_openssl_upgrade`, secret-COPY rejection, and the explicit-build-context-allowlist check — plus a Dependabot-coverage assertion (mirroring the read executor's).
- `apps/api/src/config/dockerfileOpensslUpgrade.test.ts`: add the actions executor to `CREDENTIAL_BOUNDARY_DOCKERFILES` so `it.each` proves it permits only the exact audited OpenSSL upgrade, same as its siblings.
- `apps/api/src/config/executorApkPolicy.test.ts`: extend the wiring test to all three executors, and add a new regression test that reproduces the issue's own verification — append `RUN apk add --no-cache sudo openssh netcat-openbsd` to the real actions Dockerfile content and assert the policy now rejects it (this exact mutation was verified in the issue to pass the guard with exit 0 before this fix).

`apps/m365-graph-actions-executor/Dockerfile` itself is unchanged — it already conforms to the policy (digest-pinned base, `apk upgrade` CVE repair, non-root `USER node`, healthcheck). This PR closes the CI-enforcement gap, not the Dockerfile.

## Verification

- Full guard passes on `main`'s current actions Dockerfile: `bash scripts/security/check-supply-chain-hardening.sh` → `Supply-chain hardening checks passed.`
- Reproduced the issue's exact regression: appending `RUN apk add --no-cache sudo openssh netcat-openbsd` to `apps/m365-graph-actions-executor/Dockerfile` now makes the full guard fail with `ERROR: apps/m365-graph-actions-executor/Dockerfile contains an unaudited apk invocation: ...` (previously exited 0). File was reverted after the manual check; `git diff` on that file is empty.
- `vitest run src/config/dockerfileOpensslUpgrade.test.ts src/config/executorApkPolicy.test.ts --pool=threads --maxWorkers=2` (from `apps/api`): 28/28 passed.
- `tsc --noEmit -p apps/api`: clean.

## Test plan

- [x] Affected vitest files pass
- [x] `tsc --noEmit -p apps/api` clean
- [x] Full `check-supply-chain-hardening.sh` passes on `main`'s actions Dockerfile
- [x] Full guard rejects the issue's reported regression when reproduced

Closes #4272

🤖 Generated with [Claude Code](https://claude.com/claude-code)