### PR TITLE
feat(worker): /metrics endpoint, event-loop + DB-pool monitors, breeze_role Sentry tag (#4143)

### DIFF
--- a/apps/api/src/routes/metrics.ts
+++ b/apps/api/src/routes/metrics.ts
@@ -7,25 +7,23 @@
 import { Hono } from 'hono';
 import { routePath as honoRoutePath } from 'hono/route';
 import { avg, and, eq, gte, inArray, sql } from 'drizzle-orm';
-import { Counter, Gauge, Histogram, Registry } from 'prom-client';
-import { createHash, timingSafeEqual } from 'crypto';
+import { Counter, Gauge, Histogram } from 'prom-client';
 
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { deviceMetrics, devices, metricRollups, recoveryReadiness as recoveryReadinessTable, remoteSessions } from '../db/schema';
 import { authMiddleware, requirePermission, requireScope } from '../middleware/auth';
 import { getTrustedClientIpOrUndefined } from '../services/clientIp';
-import { getEventLoopLagStats, readLatestEventLoopLag } from '../services/eventLoopMonitor';
+import { metricsRegistry } from '../services/metricsRegistry';
 import {
-  getDbConnectTimeoutStats,
-  setDbConnectTimeoutMetricsRecorder,
-} from '../services/dbConnectTimeoutStats';
+  bindRuntimeMetricsRecorders,
+  initializeRuntimeMetricDefaults,
+  updateRuntimeMetrics,
+} from '../services/metricsRuntime';
 import {
-  DB_POOL_HEALTH_VERDICTS,
-  getDbPoolHealthCheckFailures,
-  getDbPoolHealthProbeCloseFailures,
-  getDbPoolHealthWindowMs,
-  getLastDbPoolHealthAssessment,
-} from '../db/dbPoolHealthMonitor';
+  evaluateMetricsScrapeAuth,
+  parseMetricsScrapeIpAllowlist,
+  resolveMetricsScrapeToken,
+} from '../services/metricsScrapeAuth';
 import { PERMISSIONS, type UserPermissions } from '../services/permissions';
 import { BACKUP_LOW_READINESS_THRESHOLD } from './backup/constants';
 import {
@@ -71,14 +69,6 @@ export {
 export const metricsRoutes = new Hono();
 const requireMetricsRead = requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action);
 
-function resolveMetricsScrapeToken(): string | undefined {
-  const rawToken = process.env.METRICS_SCRAPE_TOKEN?.trim();
-  // Production hardening: refuse to run with obvious placeholder tokens.
-  return (process.env.NODE_ENV ?? 'development') === 'production' && (!rawToken || rawToken === 'REDACTED_DEV_TOKEN')
-    ? undefined
-    : rawToken;
-}
-
 let METRICS_SCRAPE_TOKEN = resolveMetricsScrapeToken();
 
 function envFlag(name: string, fallback: boolean): boolean {
@@ -86,17 +76,6 @@ function envFlag(name: string, fallback: boolean): boolean {
   if (!raw) return fallback;
   const normalized = raw.trim().toLowerCase();
   return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
-}
-
-function parseCsvSet(raw: string | undefined): Set<string> {
-  if (!raw) return new Set();
-  return new Set(raw.split(',').map((s) => s.trim()).filter((s) => s.length > 0));
-}
-
-function safeEqual(a: string, b: string): boolean {
-  const ha = createHash('sha256').update(a).digest();
-  const hb = createHash('sha256').update(b).digest();
-  return timingSafeEqual(ha, hb);
 }
 
 // Default: hide org IDs in Prometheus labels in production (they can leak tenant identifiers).
@@ -109,9 +88,14 @@ function resolveMetricsIncludeOrgId(): boolean {
 
 let METRICS_INCLUDE_ORG_ID = resolveMetricsIncludeOrgId();
 
-let METRICS_SCRAPE_IP_ALLOWLIST = parseCsvSet(process.env.METRICS_SCRAPE_IP_ALLOWLIST);
+let METRICS_SCRAPE_IP_ALLOWLIST = parseMetricsScrapeIpAllowlist();
 
-const register = new Registry();
+// The Registry itself now lives in the leaf `services/metricsRegistry` (#4143)
+// so `worker.ts` can render a scrape without importing this route file — see
+// that module's header for why the extraction was load-bearing rather than
+// cosmetic. Aliased to `register` so every series declaration below reads
+// unchanged.
+const register = metricsRegistry;
 registerM365CustomerGraphReadPrometheusCounter(register);
 registerM365CustomerGraphActionsPrometheusCounter(register);
 registerM365GraphReadActionPrometheusCounter(register);
@@ -496,148 +480,6 @@ const extensionJobOutcomeTotal = new Counter({
   registers: [register],
 });
 
-const processStartTimeGauge = new Gauge({
-  name: 'process_start_time_seconds',
-  help: 'Start time of the process since unix epoch in seconds',
-  registers: [register]
-});
-
-const nodejsVersionInfoGauge = new Gauge({
-  name: 'nodejs_version_info',
-  help: 'Node.js version info',
-  labelNames: ['version'] as const,
-  registers: [register]
-});
-
-// #3022 — event-loop lag as a scrapable series. This is the metric whose
-// absence made the original incident a manual investigation: three unrelated
-// Sentry signatures, all downstream of a stalled main thread, and nothing in
-// the dashboards that showed the stall itself.
-//
-// Seconds, per Prometheus base-unit convention. The `breeze_` prefix is
-// deliberate — prom-client's `collectDefaultMetrics()` is not called anywhere in
-// this API, so there is no upstream `nodejs_eventloop_lag_*` series to collide
-// with or to inherit alert rules from. These are ours and are named as such.
-//
-// `_lag_max_seconds` is INSTANTANEOUS (last completed sampling interval plus any
-// in-flight stall), matching upstream's reset-per-collection semantics. Feeding
-// it from the retained high-water mark instead would keep a 1.2s blip elevated
-// for the full retention window, so `starved == 1 for 1m` would fire on a
-// momentary spike and `max_over_time` would count one stall many times. The
-// high-water mark is still published, under a name that says so.
-const eventLoopLagMaxGauge = new Gauge({
-  name: 'breeze_nodejs_eventloop_lag_max_seconds',
-  help: 'Event-loop delay over the last completed sampling interval, including any in-flight stall',
-  registers: [register]
-});
-
-const eventLoopLagWindowMaxGauge = new Gauge({
-  name: 'breeze_nodejs_eventloop_lag_window_max_seconds',
-  help: 'Worst event-loop delay retained across the whole sampling window (high-water mark)',
-  registers: [register]
-});
-
-// Named `_window_` to match its time base. It summarises the retained window,
-// while `_lag_max_seconds` is instantaneous — leaving it as a bare `_lag_mean_`
-// made the two read as a matched max/mean pair that they are not, and a
-// recovered loop could publish a max BELOW its mean (0.005 vs 0.011), which on
-// a dashboard reads as an instrumentation bug.
-const eventLoopLagWindowMeanGauge = new Gauge({
-  name: 'breeze_nodejs_eventloop_lag_window_mean_seconds',
-  help: 'Mean event-loop delay across the retained sampling window',
-  registers: [register]
-});
-
-// Derived from the INSTANTANEOUS lag so it clears as soon as the loop recovers.
-// Exposed as its own series rather than left to a `> threshold` alert
-// expression so the API's own starvation threshold — configurable via
-// EVENT_LOOP_STARVATION_WARN_MS — stays the single definition of "starved",
-// instead of being restated (and drifting) in the alerting rules.
-const eventLoopStarvedGauge = new Gauge({
-  name: 'breeze_nodejs_eventloop_starved',
-  help: '1 when the current event-loop lag is at or above the configured starvation threshold, else 0',
-  registers: [register]
-});
-
-// 0 whenever the monitor is disabled or not yet started. Without this, the
-// gauges above sit at 0 in exactly that case and read as a perfectly healthy
-// loop — alert on `monitored == 0` to catch a blind instance.
-const eventLoopMonitoredGauge = new Gauge({
-  name: 'breeze_nodejs_eventloop_monitored',
-  help: '1 when event-loop lag instrumentation is running, else 0',
-  registers: [register]
-});
-
-// #3214 — Postgres CONNECT_TIMEOUT as a first-class series. During the incident
-// this signal existed only as individual Sentry events and console lines, so the
-// thing that actually mattered — the RATE, sustained at ~144/min for hours while
-// the pool decayed from 35 live connections to 9 — was invisible. `cause` comes
-// from services/postgresConnectTimeout.ts, so a starved event loop (#3022) can
-// be told apart from a genuine connect failure on the same chart.
-const dbConnectTimeoutsTotal = new Counter({
-  name: 'breeze_db_connect_timeouts_total',
-  help: 'Total Postgres CONNECT_TIMEOUT errors observed, by diagnosed cause',
-  labelNames: ['cause'] as const,
-  registers: [register]
-});
-
-// The same rate the watchdog evaluates, republished so an alert rule and the
-// warning in the logs derive from one number instead of two definitions that can
-// drift apart.
-const dbConnectTimeoutRateGauge = new Gauge({
-  name: 'breeze_db_connect_timeout_rate_per_min',
-  help: 'Postgres CONNECT_TIMEOUT errors per minute over the pool-health window',
-  registers: [register]
-});
-
-// Enum-style gauge: exactly one verdict carries 1, the rest carry 0. Modelled as
-// a label rather than a numeric code because the operational response differs per
-// verdict and an alert must be able to name which — `pool-degraded` means restart
-// the API (the pool cannot self-heal, #3214), `database-unreachable` means do NOT
-// restart, the fault is downstream. Before the first evaluation, whenever the
-// watchdog is disabled, and after a failed evaluation, ALL series stay 0.
-//
-// Note there is no `healthy` verdict to publish — the quiet one is
-// `below-threshold`, because the underlying count is a floor and pool occupancy
-// is never observed. Alert on `verdict="pool-degraded" == 1`, never on the
-// negation of a healthy series.
-const dbPoolHealthGauge = new Gauge({
-  name: 'breeze_db_pool_health',
-  help: '1 for the pool-health watchdog current verdict, 0 for the others (all 0 before the first evaluation)',
-  labelNames: ['verdict'] as const,
-  registers: [register]
-});
-
-// Freshness, without which the gauge above cannot be trusted. A watchdog that
-// starts throwing every tick would otherwise leave its last verdict asserted
-// indefinitely; `lastAssessment` is cleared on failure so the verdict series go
-// to 0, and this timestamp is what lets an alert require recency rather than
-// merely a value. 0 = never evaluated.
-const dbPoolHealthLastCheckGauge = new Gauge({
-  name: 'breeze_db_pool_health_last_check_timestamp_seconds',
-  help: 'Unix time of the last completed pool-health evaluation (0 = never)',
-  registers: [register]
-});
-
-// Gauges, not Counters, and therefore deliberately WITHOUT the `_total` suffix
-// (which OpenMetrics reserves for counters). The underlying values are
-// process-lifetime totals owned by dbPoolHealthMonitor and read absolutely on
-// each scrape, so there is no per-event increment to drive a Counter with.
-const dbPoolHealthCheckFailuresGauge = new Gauge({
-  name: 'breeze_db_pool_health_check_failures',
-  help: 'Pool-health evaluations that threw before producing a verdict, since process start',
-  registers: [register]
-});
-
-// Each failed close is a probe socket that may have been leaked — against the
-// database the watchdog is diagnosing. Surfaced so the watchdog cannot quietly
-// become a contributor to connection exhaustion.
-const dbPoolHealthProbeCloseFailuresGauge = new Gauge({
-  name: 'breeze_db_pool_health_probe_close_failures',
-  help: 'Pool-health probe clients whose end() failed since process start, each a possible leaked connection',
-  registers: [register]
-});
-
 function initializeMetricDefaults(): void {
   httpRequestsInFlight.set(0);
   // Seeded so `sum(rate(http_requests_total{...}))` has a denominator from the
@@ -681,26 +523,10 @@ function initializeMetricDefaults(): void {
   extensionRequestErrorsTotal.labels('unknown', 'unknown').inc(0);
   extensionJobsTotal.labels('unknown', 'unknown').inc(0);
   extensionJobOutcomeTotal.labels('unknown', 'unknown', 'success').inc(0);
-  nodejsVersionInfoGauge.labels(process.version).set(1);
-  // Publish the event-loop series from process start so a dashboard or alert
-  // rule referencing them is never querying a metric that does not exist yet.
-  eventLoopMonitoredGauge.set(0);
-  eventLoopLagMaxGauge.set(0);
-  eventLoopLagWindowMaxGauge.set(0);
-  eventLoopLagWindowMeanGauge.set(0);
-  eventLoopStarvedGauge.set(0);
-  // #3214. Seeded at 0 for the same reason: an alert on the connect-timeout rate
-  // must not silently match nothing on an instance that has not yet timed out.
-  dbConnectTimeoutsTotal.labels('event-loop-starvation').inc(0);
-  dbConnectTimeoutsTotal.labels('connectivity').inc(0);
-  dbConnectTimeoutsTotal.labels('unknown').inc(0);
-  dbConnectTimeoutRateGauge.set(0);
-  for (const verdict of DB_POOL_HEALTH_VERDICTS) {
-    dbPoolHealthGauge.labels(verdict).set(0);
-  }
-  dbPoolHealthLastCheckGauge.set(0);
-  dbPoolHealthCheckFailuresGauge.set(0);
-  dbPoolHealthProbeCloseFailuresGauge.set(0);
+  // Process identity, event-loop (#3022) and pool-health (#3214) series moved
+  // to the leaf `services/metricsRuntime` for #4143 so the worker role can
+  // publish them too; their seeds move with them.
+  initializeRuntimeMetricDefaults();
 }
 
 initializeMetricDefaults();
@@ -812,55 +638,6 @@ function normalizeMetricLabel(value: string, fallback: string): string {
     .replace(/[^a-z0-9]+/g, '_')
     .replace(/^_+|_+$/g, '');
   return normalized.length > 0 ? normalized : fallback;
-}
-
-function updateProcessMetrics(): void {
-  processStartTimeGauge.set(Math.floor(Date.now() / 1000 - process.uptime()));
-  updateEventLoopMetrics();
-  updateDbPoolHealthMetrics();
-}
-
-/**
- * Republishes the watchdog's latest verdict (#3214). Read on scrape rather than
- * pushed on evaluation so a scrape always reflects the most recent check even if
- * the watchdog interval and the scrape interval differ.
- *
- * The rate is recomputed here over the SAME window the watchdog uses, so the
- * gauge and the log warning cannot disagree. When no verdict exists yet, every
- * verdict series is left at 0 — see the gauge's declaration for why "not
- * observed" must not collapse into "healthy".
- */
-function updateDbPoolHealthMetrics(): void {
-  dbConnectTimeoutRateGauge.set(getDbConnectTimeoutStats(getDbPoolHealthWindowMs()).ratePerMin);
-  const assessment = getLastDbPoolHealthAssessment();
-  for (const verdict of DB_POOL_HEALTH_VERDICTS) {
-    dbPoolHealthGauge.labels(verdict).set(assessment?.verdict === verdict ? 1 : 0);
-  }
-  dbPoolHealthLastCheckGauge.set(assessment ? Math.floor(assessment.at / 1000) : 0);
-  dbPoolHealthCheckFailuresGauge.set(getDbPoolHealthCheckFailures());
-  dbPoolHealthProbeCloseFailuresGauge.set(getDbPoolHealthProbeCloseFailures());
-}
-
-function updateEventLoopMetrics(): void {
-  const stats = getEventLoopLagStats();
-  const latest = readLatestEventLoopLag();
-  eventLoopMonitoredGauge.set(stats.monitored ? 1 : 0);
-  // `worstLagMs` on both, rather than the sampled max: it folds in a stall that
-  // is still in flight and has therefore not been recorded as a sample yet. A
-  // scrape landing mid-stall must not report the loop as healthy.
-  eventLoopLagMaxGauge.set(latest.worstLagMs / 1000);
-  eventLoopLagWindowMaxGauge.set(stats.worstLagMs / 1000);
-  eventLoopLagWindowMeanGauge.set(stats.meanLagMs / 1000);
-  // Uses the RAW EVENT_LOOP_STARVATION_WARN_MS, not the connect-window cap that
-  // services/postgresConnectTimeout.ts applies. Deliberate: this gauge tracks
-  // "is the loop unhealthy by the operator's own definition", whereas the cap
-  // exists solely so a raised warn threshold cannot mis-attribute a specific
-  // Postgres timeout. With EVENT_LOOP_STARVATION_WARN_MS above 10s the two can
-  // disagree for the same stall — the gauge reads 0 while Sentry says
-  // event-loop-starvation — and that is the intended reading of each.
-  eventLoopStarvedGauge.set(
-    latest.monitored && latest.worstLagMs >= stats.starvationThresholdMs ? 1 : 0,
-  );
 }
 
 function upsertCounterState(state: Map<string, CounterValue>, labels: Record<string, string>, amount = 1): void {
@@ -1138,14 +915,14 @@ function recordExtensionJobMetric(
 }
 
 function bindMetricsRecorders(): void {
-  // #3214. The stats module is a zero-import leaf (it sits in the graph of
-  // services/sentry.ts), so the Prometheus counter is pushed IN from here rather
-  // than pulled by it — same inversion as setConnectTimeoutClassifier.
-  setDbConnectTimeoutMetricsRecorder({
-    onConnectTimeout: (cause) => {
-      dbConnectTimeoutsTotal.labels(cause).inc();
-    },
-  });
+  // #3214's `setDbConnectTimeoutMetricsRecorder` binding moved to the leaf
+  // `services/metricsRuntime` (#4143): the recorder is a single global slot,
+  // and binding it here left a worker-role process — which never loads this
+  // file — counting no CONNECT_TIMEOUTs while its own pool-health watchdog
+  // alerted on the rate derived from them. Still re-called from here so
+  // `resetMetricsForTesting()` keeps restoring the slot that
+  // `__resetDbConnectTimeoutStatsForTests()` nulls.
+  bindRuntimeMetricsRecorders();
 
   setS1MetricsRecorder({
     onSyncRun: (job, outcome, durationMs) => {
@@ -1210,7 +987,7 @@ bindMetricsRecorders();
 export function resetMetricsForTesting(): void {
   METRICS_SCRAPE_TOKEN = resolveMetricsScrapeToken();
   METRICS_INCLUDE_ORG_ID = resolveMetricsIncludeOrgId();
-  METRICS_SCRAPE_IP_ALLOWLIST = parseCsvSet(process.env.METRICS_SCRAPE_IP_ALLOWLIST);
+  METRICS_SCRAPE_IP_ALLOWLIST = parseMetricsScrapeIpAllowlist();
 
   resetS1MetricsForTesting();
   register.resetMetrics();
@@ -1426,7 +1203,7 @@ async function metricsResponse(c: any): Promise<Response> {
   // `up` flips to 0 so it reads as a dead API rather than a sick database.
   // `refreshFleetGauges` is internally timeout-bounded and never rejects.
   await refreshFleetGauges();
-  updateProcessMetrics();
+  updateRuntimeMetrics();
   const metrics = await register.metrics();
 
   return c.text(metrics, 200, {
@@ -1655,21 +1432,23 @@ metricsRoutes.get('/trends', authMiddleware, requireScope('organization', 'partn
 });
 
 metricsRoutes.get('/scrape', async (c) => {
-  if (!METRICS_SCRAPE_TOKEN) {
-    return c.json({ error: 'Metrics scrape token is not configured' }, 503);
-  }
-
-  if (METRICS_SCRAPE_IP_ALLOWLIST.size > 0) {
-    const ip = getTrustedClientIpOrUndefined(c);
-    if (!ip || !METRICS_SCRAPE_IP_ALLOWLIST.has(ip)) {
-      return c.json({ error: 'Forbidden' }, 403);
-    }
-  }
-
-  const authHeader = c.req.header('Authorization');
-  const expectedHeader = `Bearer ${METRICS_SCRAPE_TOKEN}`;
-  if (!safeEqual(authHeader ?? '', expectedHeader)) {
-    return c.json({ error: 'Unauthorized' }, 401);
+  // The three rules (configured token -> source-IP allowlist -> constant-time
+  // bearer compare) live in the leaf `services/metricsScrapeAuth` so the
+  // worker role's raw-node:http `/metrics` enforces the SAME gate rather than
+  // a second, independently drifting copy of it (#4143).
+  //
+  // `getTrustedClientIpOrUndefined` is still resolved here and only when the
+  // allowlist is non-empty: it is the api-role-specific half (it consults
+  // forwarded headers against this process's trusted-proxy configuration,
+  // which the worker's port does not have).
+  const denial = evaluateMetricsScrapeAuth({
+    token: METRICS_SCRAPE_TOKEN,
+    ipAllowlist: METRICS_SCRAPE_IP_ALLOWLIST,
+    authHeader: c.req.header('Authorization'),
+    clientIp: METRICS_SCRAPE_IP_ALLOWLIST.size > 0 ? getTrustedClientIpOrUndefined(c) : undefined,
+  });
+  if (denial) {
+    return c.json({ error: denial.error }, denial.status);
   }
 
   return metricsResponse(c);

--- a/apps/api/src/services/metricsRegistry.ts
+++ b/apps/api/src/services/metricsRegistry.ts
@@ -1,0 +1,37 @@
+/**
+ * The process-wide Prometheus registry (#4143).
+ *
+ * This module exists ONLY to hold the `Registry` singleton, and it must stay a
+ * LEAF — `prom-client` is its one and only import, and nothing may be added
+ * here that reaches `routes/`, `db/`, or any service. That constraint is
+ * load-bearing, not stylistic:
+ *
+ *   `worker.ts` (BREEZE_ROLE=worker) statically imports this file so its slim
+ *   raw-node:http server can serve `/metrics`, and
+ *   `services/workerEntrypointClosure.contract.test.ts` walks worker.ts's
+ *   import closure asserting it never reaches `routes/`. The registry used to
+ *   be a module-private `const register = new Registry()` inside
+ *   `routes/metrics.ts`, which meant the ONLY way to render a scrape was to
+ *   load the entire route graph. In split-role mode (#4086) that made the
+ *   worker container — the process actually running the 76 relocated BullMQ
+ *   workers, the retention sweeps and the heavy jobs — completely unscrapable:
+ *   `up` for it did not exist, and every series it could have published simply
+ *   was not there. Not stale, not zero: absent, which no alert rule can see.
+ *
+ * Both roles share this one registry instance rather than each minting their
+ * own, so a series' name, help text and label set have exactly one definition
+ * regardless of which container publishes it. Which series are actually
+ * REGISTERED still differs by role, and that is expected — an api-role process
+ * registers the HTTP/business/fleet series from `routes/metrics.ts`, while a
+ * worker-role process registers the role-agnostic runtime series from
+ * `services/metricsRuntime.ts`. A scrape of either renders whatever that
+ * process has registered; neither invents series for work it does not do.
+ */
+import { Registry } from 'prom-client';
+
+/**
+ * The shared registry. `routes/metrics.ts` registers the API's series onto it
+ * and renders it for `/api/metrics/scrape`; `worker.ts` renders it for its own
+ * `/metrics`.
+ */
+export const metricsRegistry = new Registry();

--- a/apps/api/src/services/metricsRuntime.ts
+++ b/apps/api/src/services/metricsRuntime.ts
@@ -1,0 +1,288 @@
+/**
+ * Role-agnostic RUNTIME metrics: process identity, event-loop lag (#3022) and
+ * Postgres pool health (#3214).
+ *
+ * Extracted from `routes/metrics.ts` for #4143. Every series here describes the
+ * PROCESS, not the HTTP surface, so all of it is equally meaningful in a
+ * worker-role container — and, per the incidents that produced #3022 and
+ * #3214, it matters MOST there: the pool-exhaustion and event-loop-starvation
+ * signatures were loudest on the patch scheduler and the heavy jobs, which is
+ * precisely the work that moved off the api process in split-role mode
+ * (#4086). Left inside the route file, none of it could be published by the
+ * container running that work.
+ *
+ * Import closure: `prom-client`, `./metricsRegistry`, `./eventLoopMonitor`,
+ * `./dbConnectTimeoutStats` and `../db/dbPoolHealthMonitor` — none of which
+ * reach `routes/`, which is what lets `worker.ts` load this module at boot
+ * without violating `services/workerEntrypointClosure.contract.test.ts`.
+ *
+ * Importing this module REGISTERS the series (module-scope `new Gauge({
+ * registers: [metricsRegistry] })`). Registration is therefore per-process and
+ * happens exactly once — a second import is a no-op, and a process that never
+ * imports it publishes none of these series rather than publishing zeros.
+ */
+import { Counter, Gauge } from 'prom-client';
+
+import { metricsRegistry } from './metricsRegistry';
+import { getEventLoopLagStats, readLatestEventLoopLag } from './eventLoopMonitor';
+import { getDbConnectTimeoutStats, setDbConnectTimeoutMetricsRecorder } from './dbConnectTimeoutStats';
+import {
+  DB_POOL_HEALTH_VERDICTS,
+  getDbPoolHealthCheckFailures,
+  getDbPoolHealthProbeCloseFailures,
+  getDbPoolHealthWindowMs,
+  getLastDbPoolHealthAssessment,
+} from '../db/dbPoolHealthMonitor';
+
+const register = metricsRegistry;
+
+const processStartTimeGauge = new Gauge({
+  name: 'process_start_time_seconds',
+  help: 'Start time of the process since unix epoch in seconds',
+  registers: [register]
+});
+
+const nodejsVersionInfoGauge = new Gauge({
+  name: 'nodejs_version_info',
+  help: 'Node.js version info',
+  labelNames: ['version'] as const,
+  registers: [register]
+});
+
+// #3022 — event-loop lag as a scrapable series. This is the metric whose
+// absence made the original incident a manual investigation: three unrelated
+// Sentry signatures, all downstream of a stalled main thread, and nothing in
+// the dashboards that showed the stall itself.
+//
+// Seconds, per Prometheus base-unit convention. The `breeze_` prefix is
+// deliberate — prom-client's `collectDefaultMetrics()` is not called anywhere in
+// this API, so there is no upstream `nodejs_eventloop_lag_*` series to collide
+// with or to inherit alert rules from. These are ours and are named as such.
+//
+// `_lag_max_seconds` is INSTANTANEOUS (last completed sampling interval plus any
+// in-flight stall), matching upstream's reset-per-collection semantics. Feeding
+// it from the retained high-water mark instead would keep a 1.2s blip elevated
+// for the full retention window, so `starved == 1 for 1m` would fire on a
+// momentary spike and `max_over_time` would count one stall many times. The
+// high-water mark is still published, under a name that says so.
+const eventLoopLagMaxGauge = new Gauge({
+  name: 'breeze_nodejs_eventloop_lag_max_seconds',
+  help: 'Event-loop delay over the last completed sampling interval, including any in-flight stall',
+  registers: [register]
+});
+
+const eventLoopLagWindowMaxGauge = new Gauge({
+  name: 'breeze_nodejs_eventloop_lag_window_max_seconds',
+  help: 'Worst event-loop delay retained across the whole sampling window (high-water mark)',
+  registers: [register]
+});
+
+// Named `_window_` to match its time base. It summarises the retained window,
+// while `_lag_max_seconds` is instantaneous — leaving it as a bare `_lag_mean_`
+// made the two read as a matched max/mean pair that they are not, and a
+// recovered loop could publish a max BELOW its mean (0.005 vs 0.011), which on
+// a dashboard reads as an instrumentation bug.
+const eventLoopLagWindowMeanGauge = new Gauge({
+  name: 'breeze_nodejs_eventloop_lag_window_mean_seconds',
+  help: 'Mean event-loop delay across the retained sampling window',
+  registers: [register]
+});
+
+// Derived from the INSTANTANEOUS lag so it clears as soon as the loop recovers.
+// Exposed as its own series rather than left to a `> threshold` alert
+// expression so the API's own starvation threshold — configurable via
+// EVENT_LOOP_STARVATION_WARN_MS — stays the single definition of "starved",
+// instead of being restated (and drifting) in the alerting rules.
+const eventLoopStarvedGauge = new Gauge({
+  name: 'breeze_nodejs_eventloop_starved',
+  help: '1 when the current event-loop lag is at or above the configured starvation threshold, else 0',
+  registers: [register]
+});
+
+// 0 whenever the monitor is disabled or not yet started. Without this, the
+// gauges above sit at 0 in exactly that case and read as a perfectly healthy
+// loop — alert on `monitored == 0` to catch a blind instance.
+const eventLoopMonitoredGauge = new Gauge({
+  name: 'breeze_nodejs_eventloop_monitored',
+  help: '1 when event-loop lag instrumentation is running, else 0',
+  registers: [register]
+});
+
+// #3214 — Postgres CONNECT_TIMEOUT as a first-class series. During the incident
+// this signal existed only as individual Sentry events and console lines, so the
+// thing that actually mattered — the RATE, sustained at ~144/min for hours while
+// the pool decayed from 35 live connections to 9 — was invisible. `cause` comes
+// from services/postgresConnectTimeout.ts, so a starved event loop (#3022) can
+// be told apart from a genuine connect failure on the same chart.
+const dbConnectTimeoutsTotal = new Counter({
+  name: 'breeze_db_connect_timeouts_total',
+  help: 'Total Postgres CONNECT_TIMEOUT errors observed, by diagnosed cause',
+  labelNames: ['cause'] as const,
+  registers: [register]
+});
+
+// The same rate the watchdog evaluates, republished so an alert rule and the
+// warning in the logs derive from one number instead of two definitions that can
+// drift apart.
+const dbConnectTimeoutRateGauge = new Gauge({
+  name: 'breeze_db_connect_timeout_rate_per_min',
+  help: 'Postgres CONNECT_TIMEOUT errors per minute over the pool-health window',
+  registers: [register]
+});
+
+// Enum-style gauge: exactly one verdict carries 1, the rest carry 0. Modelled as
+// a label rather than a numeric code because the operational response differs per
+// verdict and an alert must be able to name which — `pool-degraded` means restart
+// the API (the pool cannot self-heal, #3214), `database-unreachable` means do NOT
+// restart, the fault is downstream. Before the first evaluation, whenever the
+// watchdog is disabled, and after a failed evaluation, ALL series stay 0.
+//
+// Note there is no `healthy` verdict to publish — the quiet one is
+// `below-threshold`, because the underlying count is a floor and pool occupancy
+// is never observed. Alert on `verdict="pool-degraded" == 1`, never on the
+// negation of a healthy series.
+const dbPoolHealthGauge = new Gauge({
+  name: 'breeze_db_pool_health',
+  help: '1 for the pool-health watchdog current verdict, 0 for the others (all 0 before the first evaluation)',
+  labelNames: ['verdict'] as const,
+  registers: [register]
+});
+
+// Freshness, without which the gauge above cannot be trusted. A watchdog that
+// starts throwing every tick would otherwise leave its last verdict asserted
+// indefinitely; `lastAssessment` is cleared on failure so the verdict series go
+// to 0, and this timestamp is what lets an alert require recency rather than
+// merely a value. 0 = never evaluated.
+const dbPoolHealthLastCheckGauge = new Gauge({
+  name: 'breeze_db_pool_health_last_check_timestamp_seconds',
+  help: 'Unix time of the last completed pool-health evaluation (0 = never)',
+  registers: [register]
+});
+
+// Gauges, not Counters, and therefore deliberately WITHOUT the `_total` suffix
+// (which OpenMetrics reserves for counters). The underlying values are
+// process-lifetime totals owned by dbPoolHealthMonitor and read absolutely on
+// each scrape, so there is no per-event increment to drive a Counter with.
+const dbPoolHealthCheckFailuresGauge = new Gauge({
+  name: 'breeze_db_pool_health_check_failures',
+  help: 'Pool-health evaluations that threw before producing a verdict, since process start',
+  registers: [register]
+});
+
+// Each failed close is a probe socket that may have been leaked — against the
+// database the watchdog is diagnosing. Surfaced so the watchdog cannot quietly
+// become a contributor to connection exhaustion.
+const dbPoolHealthProbeCloseFailuresGauge = new Gauge({
+  name: 'breeze_db_pool_health_probe_close_failures',
+  help: 'Pool-health probe clients whose end() failed since process start, each a possible leaked connection',
+  registers: [register]
+});
+
+/**
+ * Seeds every series above so a dashboard or alert rule referencing them is
+ * never querying a metric that does not exist yet. Idempotent — safe to call
+ * again after `metricsRegistry.resetMetrics()`.
+ */
+export function initializeRuntimeMetricDefaults(): void {
+  nodejsVersionInfoGauge.labels(process.version).set(1);
+  processStartTimeGauge.set(Math.floor(Date.now() / 1000 - process.uptime()));
+  // Publish the event-loop series from process start so a dashboard or alert
+  // rule referencing them is never querying a metric that does not exist yet.
+  eventLoopMonitoredGauge.set(0);
+  eventLoopLagMaxGauge.set(0);
+  eventLoopLagWindowMaxGauge.set(0);
+  eventLoopLagWindowMeanGauge.set(0);
+  eventLoopStarvedGauge.set(0);
+  // #3214. Seeded at 0 for the same reason: an alert on the connect-timeout rate
+  // must not silently match nothing on an instance that has not yet timed out.
+  dbConnectTimeoutsTotal.labels('event-loop-starvation').inc(0);
+  dbConnectTimeoutsTotal.labels('connectivity').inc(0);
+  dbConnectTimeoutsTotal.labels('unknown').inc(0);
+  dbConnectTimeoutRateGauge.set(0);
+  for (const verdict of DB_POOL_HEALTH_VERDICTS) {
+    dbPoolHealthGauge.labels(verdict).set(0);
+  }
+  dbPoolHealthLastCheckGauge.set(0);
+  dbPoolHealthCheckFailuresGauge.set(0);
+  dbPoolHealthProbeCloseFailuresGauge.set(0);
+}
+
+/**
+ * #3214. The stats module is a zero-import leaf (it sits in the graph of
+ * services/sentry.ts), so the Prometheus counter is pushed IN from here rather
+ * than pulled by it — same inversion as setConnectTimeoutClassifier.
+ *
+ * Bound at module load rather than by a caller, because the recorder is a
+ * single global slot: leaving it to each entrypoint meant the worker role
+ * (which never loads `routes/metrics.ts`) counted no CONNECT_TIMEOUTs at all,
+ * while `db/dbPoolHealthMonitor.ts` — running in that same process — was
+ * alerting on the rate derived from them.
+ *
+ * Also EXPORTED and re-called from `routes/metrics.ts`'s `bindMetricsRecorders`
+ * because `__resetDbConnectTimeoutStatsForTests()` nulls the recorder slot, and
+ * `resetMetricsForTesting()` is what tests rely on to put it back. Idempotent:
+ * the slot is overwritten, never appended to.
+ */
+export function bindRuntimeMetricsRecorders(): void {
+  setDbConnectTimeoutMetricsRecorder({
+    onConnectTimeout: (cause) => {
+      dbConnectTimeoutsTotal.labels(cause).inc();
+    },
+  });
+}
+
+/**
+ * Republishes the watchdog's latest verdict (#3214). Read on scrape rather than
+ * pushed on evaluation so a scrape always reflects the most recent check even if
+ * the watchdog interval and the scrape interval differ.
+ *
+ * The rate is recomputed here over the SAME window the watchdog uses, so the
+ * gauge and the log warning cannot disagree. When no verdict exists yet, every
+ * verdict series is left at 0 — see the gauge's declaration for why "not
+ * observed" must not collapse into "healthy".
+ */
+function updateDbPoolHealthMetrics(): void {
+  dbConnectTimeoutRateGauge.set(getDbConnectTimeoutStats(getDbPoolHealthWindowMs()).ratePerMin);
+  const assessment = getLastDbPoolHealthAssessment();
+  for (const verdict of DB_POOL_HEALTH_VERDICTS) {
+    dbPoolHealthGauge.labels(verdict).set(assessment?.verdict === verdict ? 1 : 0);
+  }
+  dbPoolHealthLastCheckGauge.set(assessment ? Math.floor(assessment.at / 1000) : 0);
+  dbPoolHealthCheckFailuresGauge.set(getDbPoolHealthCheckFailures());
+  dbPoolHealthProbeCloseFailuresGauge.set(getDbPoolHealthProbeCloseFailures());
+}
+
+function updateEventLoopMetrics(): void {
+  const stats = getEventLoopLagStats();
+  const latest = readLatestEventLoopLag();
+  eventLoopMonitoredGauge.set(stats.monitored ? 1 : 0);
+  // `worstLagMs` on both, rather than the sampled max: it folds in a stall that
+  // is still in flight and has therefore not been recorded as a sample yet. A
+  // scrape landing mid-stall must not report the loop as healthy.
+  eventLoopLagMaxGauge.set(latest.worstLagMs / 1000);
+  eventLoopLagWindowMaxGauge.set(stats.worstLagMs / 1000);
+  eventLoopLagWindowMeanGauge.set(stats.meanLagMs / 1000);
+  // Uses the RAW EVENT_LOOP_STARVATION_WARN_MS, not the connect-window cap that
+  // services/postgresConnectTimeout.ts applies. Deliberate: this gauge tracks
+  // "is the loop unhealthy by the operator's own definition", whereas the cap
+  // exists solely so a raised warn threshold cannot mis-attribute a specific
+  // Postgres timeout. With EVENT_LOOP_STARVATION_WARN_MS above 10s the two can
+  // disagree for the same stall — the gauge reads 0 while Sentry says
+  // event-loop-starvation — and that is the intended reading of each.
+  eventLoopStarvedGauge.set(
+    latest.monitored && latest.worstLagMs >= stats.starvationThresholdMs ? 1 : 0,
+  );
+}
+
+/**
+ * Refreshes every read-on-scrape series here. Both entrypoints call this
+ * immediately before rendering the registry.
+ */
+export function updateRuntimeMetrics(): void {
+  processStartTimeGauge.set(Math.floor(Date.now() / 1000 - process.uptime()));
+  updateEventLoopMetrics();
+  updateDbPoolHealthMetrics();
+}
+
+initializeRuntimeMetricDefaults();
+bindRuntimeMetricsRecorders();

--- a/apps/api/src/services/metricsScrapeAuth.test.ts
+++ b/apps/api/src/services/metricsScrapeAuth.test.ts
@@ -1,0 +1,177 @@
+/**
+ * The shared `/metrics` scrape gate (#4143).
+ *
+ * This is the module both roles now enforce with — `routes/metrics.ts`'s
+ * `/api/metrics/scrape` and `worker.ts`'s `/metrics` — so a hole here is a hole
+ * in BOTH containers at once. The rules being asserted are the ones that were
+ * previously written out longhand inside the route handler; the point of
+ * pinning them here is that the extraction preserved every one of them,
+ * including the two that are easy to lose in a refactor: the production
+ * placeholder-token refusal, and the fact that the IP check runs BEFORE the
+ * token compare.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  directPeerAddress,
+  evaluateMetricsScrapeAuth,
+  parseMetricsScrapeIpAllowlist,
+  resolveMetricsScrapeToken,
+  safeEqual,
+} from './metricsScrapeAuth';
+
+const TOKEN = 'super-secret-scrape-token';
+
+function evaluate(overrides: Partial<Parameters<typeof evaluateMetricsScrapeAuth>[0]> = {}) {
+  return evaluateMetricsScrapeAuth({
+    token: TOKEN,
+    ipAllowlist: new Set<string>(),
+    authHeader: `Bearer ${TOKEN}`,
+    clientIp: undefined,
+    ...overrides,
+  });
+}
+
+describe('resolveMetricsScrapeToken', () => {
+  it('honours a configured token outside production', () => {
+    expect(resolveMetricsScrapeToken({ NODE_ENV: 'development', METRICS_SCRAPE_TOKEN: '  tok  ' }))
+      .toBe('tok');
+  });
+
+  it('honours the dev placeholder outside production so a local stack can scrape itself', () => {
+    expect(
+      resolveMetricsScrapeToken({ NODE_ENV: 'test', METRICS_SCRAPE_TOKEN: 'REDACTED_DEV_TOKEN' }),
+    ).toBe('REDACTED_DEV_TOKEN');
+  });
+
+  it('refuses the dev placeholder in production', () => {
+    // Production hardening: shipping the placeholder must DISABLE the endpoint,
+    // not authenticate every caller who read it out of the repo.
+    expect(
+      resolveMetricsScrapeToken({ NODE_ENV: 'production', METRICS_SCRAPE_TOKEN: 'REDACTED_DEV_TOKEN' }),
+    ).toBeUndefined();
+  });
+
+  it('refuses an unset or blank token in production', () => {
+    expect(resolveMetricsScrapeToken({ NODE_ENV: 'production' })).toBeUndefined();
+    expect(resolveMetricsScrapeToken({ NODE_ENV: 'production', METRICS_SCRAPE_TOKEN: '   ' }))
+      .toBeUndefined();
+  });
+
+  it('defaults an unset NODE_ENV to development rather than production', () => {
+    expect(resolveMetricsScrapeToken({ METRICS_SCRAPE_TOKEN: 'REDACTED_DEV_TOKEN' }))
+      .toBe('REDACTED_DEV_TOKEN');
+  });
+});
+
+describe('parseMetricsScrapeIpAllowlist', () => {
+  it('is empty (unrestricted) when unset or blank', () => {
+    expect(parseMetricsScrapeIpAllowlist(undefined).size).toBe(0);
+    expect(parseMetricsScrapeIpAllowlist('').size).toBe(0);
+  });
+
+  it('trims entries and drops empties from a CSV', () => {
+    expect([...parseMetricsScrapeIpAllowlist(' 10.0.0.1 , ,10.0.0.2,')])
+      .toEqual(['10.0.0.1', '10.0.0.2']);
+  });
+});
+
+describe('safeEqual', () => {
+  it('compares equal and unequal strings without throwing on a length mismatch', () => {
+    // The hash-then-compare shape exists precisely so `timingSafeEqual` never
+    // sees buffers of different lengths — it THROWS on that, which would turn a
+    // wrong-token 401 into a 500 and leak the token length.
+    expect(safeEqual('abc', 'abc')).toBe(true);
+    expect(() => safeEqual('a', 'a-much-longer-value')).not.toThrow();
+    expect(safeEqual('a', 'a-much-longer-value')).toBe(false);
+  });
+});
+
+describe('evaluateMetricsScrapeAuth', () => {
+  it('allows a correct bearer token with no allowlist configured', () => {
+    expect(evaluate()).toBeNull();
+  });
+
+  it('503s when no token is configured, regardless of what the caller sends', () => {
+    // Not 401: the operator has not enabled scraping, which is not the caller's
+    // fault and is a different fix from "your credential is wrong".
+    expect(evaluate({ token: undefined })).toEqual({
+      status: 503,
+      error: 'Metrics scrape token is not configured',
+    });
+    expect(evaluate({ token: undefined, authHeader: undefined })).toEqual({
+      status: 503,
+      error: 'Metrics scrape token is not configured',
+    });
+  });
+
+  it('401s on a missing, malformed, or wrong bearer token', () => {
+    for (const authHeader of [undefined, '', TOKEN, `Bearer ${TOKEN}x`, 'Basic abc']) {
+      expect(evaluate({ authHeader }), `authHeader=${String(authHeader)}`).toEqual({
+        status: 401,
+        error: 'Unauthorized',
+      });
+    }
+  });
+
+  it('403s an off-allowlist peer, and does so BEFORE looking at the token', () => {
+    // Order matters: an off-allowlist prober must not be able to use the
+    // response to learn anything about the token compare. Asserting it with a
+    // CORRECT token is what makes this a real ordering test — if the token
+    // check ran first, this would return null instead of a 403.
+    expect(evaluate({ ipAllowlist: new Set(['10.0.0.1']), clientIp: '10.9.9.9' })).toEqual({
+      status: 403,
+      error: 'Forbidden',
+    });
+    expect(evaluate({ ipAllowlist: new Set(['10.0.0.1']), clientIp: undefined })).toEqual({
+      status: 403,
+      error: 'Forbidden',
+    });
+  });
+
+  it('403 beats 401: an off-allowlist peer with a WRONG token still gets 403', () => {
+    expect(
+      evaluate({ ipAllowlist: new Set(['10.0.0.1']), clientIp: '10.9.9.9', authHeader: 'Bearer nope' }),
+    ).toEqual({ status: 403, error: 'Forbidden' });
+  });
+
+  it('503 beats everything: an unconfigured token refuses even an allowlisted peer', () => {
+    expect(
+      evaluate({ token: undefined, ipAllowlist: new Set(['10.0.0.1']), clientIp: '10.0.0.1' }),
+    ).toEqual({ status: 503, error: 'Metrics scrape token is not configured' });
+  });
+
+  it('allows an allowlisted peer with the correct token', () => {
+    expect(evaluate({ ipAllowlist: new Set(['10.0.0.1']), clientIp: '10.0.0.1' })).toBeNull();
+  });
+
+  it('still checks the token for an allowlisted peer', () => {
+    // Being on the allowlist is not authentication. Without this, adding an
+    // allowlist would silently downgrade the endpoint to IP-only auth.
+    expect(
+      evaluate({ ipAllowlist: new Set(['10.0.0.1']), clientIp: '10.0.0.1', authHeader: 'Bearer nope' }),
+    ).toEqual({ status: 401, error: 'Unauthorized' });
+  });
+});
+
+describe('directPeerAddress', () => {
+  it('returns the raw peer address', () => {
+    expect(directPeerAddress({ remoteAddress: '10.0.0.5' })).toBe('10.0.0.5');
+  });
+
+  it('normalises an IPv4-mapped IPv6 peer so a plain-IPv4 allowlist matches', () => {
+    // Dual-stack listeners report `::ffff:a.b.c.d`. Without normalisation an
+    // operator's `METRICS_SCRAPE_IP_ALLOWLIST=10.0.0.5` would never match and
+    // the endpoint would 403 every legitimate scrape.
+    expect(directPeerAddress({ remoteAddress: '::ffff:10.0.0.5' })).toBe('10.0.0.5');
+  });
+
+  it('leaves a genuine IPv6 address alone', () => {
+    expect(directPeerAddress({ remoteAddress: '2001:db8::1' })).toBe('2001:db8::1');
+  });
+
+  it('is undefined for an absent or blank peer address', () => {
+    expect(directPeerAddress({ remoteAddress: undefined })).toBeUndefined();
+    expect(directPeerAddress({ remoteAddress: '  ' })).toBeUndefined();
+  });
+});

--- a/apps/api/src/services/metricsScrapeAuth.ts
+++ b/apps/api/src/services/metricsScrapeAuth.ts
@@ -1,0 +1,132 @@
+/**
+ * The `/metrics` scrape gate, shared by both roles (#4143).
+ *
+ * A LEAF module (`node:crypto` only) for the same reason as
+ * `services/metricsRegistry.ts`: `worker.ts` statically imports it, and
+ * `services/workerEntrypointClosure.contract.test.ts` forbids that file's
+ * closure from reaching `routes/`.
+ *
+ * Why share it at all rather than let the worker grow its own check: the
+ * api-role `/api/metrics/scrape` gate is three rules — a configured token, an
+ * optional source-IP allowlist, and a constant-time bearer comparison — and a
+ * second, independently written copy of those three rules is exactly how one
+ * container ends up quietly weaker than the other. The decision lives here
+ * once; each role supplies its own inputs, because they read the peer address
+ * differently (see `clientIp` below).
+ */
+import { createHash, timingSafeEqual } from 'node:crypto';
+
+/** HTTP status + body for a REFUSED scrape. `null` from the evaluator = allow. */
+export interface MetricsScrapeDenial {
+  status: 401 | 403 | 503;
+  error: string;
+}
+
+export interface MetricsScrapeAuthInput {
+  /** Resolved scrape token; `undefined`/empty means the endpoint is disabled. */
+  token: string | undefined;
+  /** Empty set = no source-IP restriction. */
+  ipAllowlist: Set<string>;
+  /** Raw `Authorization` header value, if any. */
+  authHeader: string | undefined;
+  /**
+   * Peer address, already resolved by the caller. Only consulted when
+   * `ipAllowlist` is non-empty, so a caller may skip the (potentially costly)
+   * resolution entirely when the allowlist is unset.
+   */
+  clientIp: string | undefined;
+}
+
+/**
+ * Production hardening: an unset token, or the shipped dev placeholder, means
+ * "not configured" in production and the endpoint refuses rather than serving
+ * unauthenticated. Outside production the raw value is honoured as-is so a
+ * local stack can scrape itself.
+ */
+export function resolveMetricsScrapeToken(
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  const rawToken = env.METRICS_SCRAPE_TOKEN?.trim();
+  return (env.NODE_ENV ?? 'development') === 'production' &&
+    (!rawToken || rawToken === 'REDACTED_DEV_TOKEN')
+    ? undefined
+    : rawToken;
+}
+
+/** `METRICS_SCRAPE_IP_ALLOWLIST` as a set; empty set = unrestricted. */
+export function parseMetricsScrapeIpAllowlist(
+  raw: string | undefined = process.env.METRICS_SCRAPE_IP_ALLOWLIST,
+): Set<string> {
+  if (!raw) return new Set();
+  return new Set(
+    raw
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0),
+  );
+}
+
+/**
+ * Constant-time string comparison.
+ *
+ * Hashed first so `timingSafeEqual` always receives equal-length buffers — it
+ * THROWS on a length mismatch, and a thrown comparison would both leak the
+ * token length and turn a wrong-token 401 into a 500.
+ */
+export function safeEqual(a: string, b: string): boolean {
+  const ha = createHash('sha256').update(a).digest();
+  const hb = createHash('sha256').update(b).digest();
+  return timingSafeEqual(ha, hb);
+}
+
+/**
+ * The gate. Returns `null` to ALLOW, or the denial to render.
+ *
+ * Order matters and matches the api-role handler exactly: configuration first
+ * (503 — the operator has not enabled scraping, which is not the caller's
+ * fault), then the source-IP allowlist (403), then the bearer token (401). The
+ * IP check runs BEFORE the token comparison so an off-allowlist prober cannot
+ * use response timing on the token compare at all.
+ */
+export function evaluateMetricsScrapeAuth(
+  input: MetricsScrapeAuthInput,
+): MetricsScrapeDenial | null {
+  if (!input.token) {
+    return { status: 503, error: 'Metrics scrape token is not configured' };
+  }
+
+  if (input.ipAllowlist.size > 0) {
+    if (!input.clientIp || !input.ipAllowlist.has(input.clientIp)) {
+      return { status: 403, error: 'Forbidden' };
+    }
+  }
+
+  if (!safeEqual(input.authHeader ?? '', `Bearer ${input.token}`)) {
+    return { status: 401, error: 'Unauthorized' };
+  }
+
+  return null;
+}
+
+/**
+ * Peer address for a raw `node:http` request, for the worker's slim server.
+ *
+ * DIRECT PEER ONLY — `X-Forwarded-For` and friends are deliberately ignored.
+ * The api-role handler runs `getTrustedClientIpOrUndefined`, which consults
+ * forwarded headers because the API genuinely sits behind a configured trusted
+ * proxy; the worker's health/metrics port has no trusted-proxy configuration
+ * at all, so honouring a forwarded header there would let any caller name its
+ * own source IP and walk straight through the allowlist. Refusing to read them
+ * is the strictly safer default, and the cost is explicit: if a proxy is ever
+ * put in front of this port, `METRICS_SCRAPE_IP_ALLOWLIST` must list the
+ * PROXY's address, not the scraper's.
+ *
+ * IPv4-mapped IPv6 peers (`::ffff:10.0.0.5`) are normalised to their dotted
+ * form so an allowlist written as plain IPv4 matches on a dual-stack listener.
+ */
+export function directPeerAddress(socket: { remoteAddress?: string | undefined }): string | undefined {
+  const raw = socket.remoteAddress?.trim();
+  if (!raw) return undefined;
+  const mapped = /^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/i.exec(raw);
+  return mapped ? mapped[1] : raw;
+}

--- a/apps/api/src/services/sentry.breezeRole.test.ts
+++ b/apps/api/src/services/sentry.breezeRole.test.ts
@@ -1,0 +1,141 @@
+/**
+ * The `breeze_role` Sentry tag (#4143).
+ *
+ * Since the api/worker role split (#4086) a droplet in split mode runs two
+ * containers off the same image, with the same DSN, release and environment.
+ * Without this tag an event from the worker is indistinguishable from one
+ * served on the request path — so "is this the scheduler or the API?", the
+ * first question asked in both #3022 and #3214, could not be answered from
+ * Sentry at all.
+ *
+ * Two halves, and BOTH are needed for the tag to actually arrive:
+ *   1. `initSentry` sets it on the global scope.
+ *   2. `ALLOWED_TAG_NAMES` lists it, so `scrubEvent` — which rebuilds `tags`
+ *      from that allowlist on the way out — does not delete it.
+ * Half 2 is the one this repo has silently lost before: the `worker` tag was
+ * set correctly for two days and then voided by the allowlist landing without
+ * it (see that entry's chronology in services/sentry.ts). Asserting the tag is
+ * set is therefore NOT sufficient evidence that it ships; the scrubber
+ * assertion below is what closes that gap.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const initMock = vi.fn();
+const moduleSetTagMock = vi.fn();
+
+vi.mock('@sentry/node', () => ({
+  init: (...args: unknown[]) => initMock(...args),
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+  flush: vi.fn().mockResolvedValue(true),
+  withScope: (cb: (scope: unknown) => void) => cb({ setTag: vi.fn(), setContext: vi.fn(), setLevel: vi.fn(), setExtras: vi.fn() }),
+  setUser: vi.fn(),
+  setTag: (...args: unknown[]) => moduleSetTagMock(...args),
+}));
+
+const ORIGINAL_ENV = { ...process.env };
+const DSN = 'https://abc@o1.ingest.us.sentry.io/2';
+
+beforeEach(() => {
+  vi.resetModules();
+  initMock.mockClear();
+  moduleSetTagMock.mockClear();
+  process.env = { ...ORIGINAL_ENV };
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe('breeze_role Sentry tag (#4143)', () => {
+  it.each([
+    ['worker', 'worker'],
+    ['api', 'api'],
+    ['all', 'all'],
+  ])('initSentry tags the scope with BREEZE_ROLE=%s -> %s', async (role, expected) => {
+    process.env.SENTRY_DSN = DSN;
+    process.env.BREEZE_ROLE = role;
+
+    const { initSentry } = await import('./sentry');
+    initSentry();
+
+    expect(moduleSetTagMock).toHaveBeenCalledWith('breeze_role', expected);
+  });
+
+  it('defaults to `all` when BREEZE_ROLE is unset', async () => {
+    process.env.SENTRY_DSN = DSN;
+    delete process.env.BREEZE_ROLE;
+
+    const { initSentry } = await import('./sentry');
+    initSentry();
+
+    expect(moduleSetTagMock).toHaveBeenCalledWith('breeze_role', 'all');
+  });
+
+  it('does not set the tag when Sentry is disabled (no DSN)', async () => {
+    // `initSentry` returns early without a DSN; setting a tag on an
+    // uninitialised client is pointless and would misreport isSentryEnabled().
+    delete process.env.SENTRY_DSN;
+    process.env.BREEZE_ROLE = 'worker';
+
+    const { initSentry, isSentryEnabled } = await import('./sentry');
+    initSentry();
+
+    expect(isSentryEnabled()).toBe(false);
+    expect(moduleSetTagMock).not.toHaveBeenCalledWith('breeze_role', expect.anything());
+  });
+
+  it('SURVIVES the scrubber — the tag is allowlisted, not silently voided', async () => {
+    // The load-bearing half. `scrubEvent` rebuilds `event.tags` from
+    // ALLOWED_TAG_NAMES, so a tag that is set but not listed arrives as
+    // nothing at all — exactly how the `worker` tag regressed for two days.
+    const { scrubEvent } = await import('./sentry');
+
+    const scrubbed = scrubEvent({
+      tags: { breeze_role: 'worker', some_unlisted_tag: 'dropped' },
+    } as Record<string, unknown>);
+
+    expect(scrubbed.tags).toEqual({ breeze_role: 'worker' });
+  });
+
+  it.each(['all', 'api', 'worker'])('survives the scrubber for role %s', async (role) => {
+    const { scrubEvent } = await import('./sentry');
+    const scrubbed = scrubEvent({ tags: { breeze_role: role } } as Record<string, unknown>);
+    expect(scrubbed.tags).toEqual({ breeze_role: role });
+  });
+});
+
+describe('sentryBreezeRoleTag agrees with config/env breezeRole (anti-drift)', () => {
+  // services/sentry.ts deliberately does NOT import config/env — it is imported
+  // by ~120 modules including db/index.ts, and config/env reads ~40 env values
+  // into module-scope consts. The duplication that buys is only safe while the
+  // two normalisations agree, which is what this pins.
+  it.each([
+    ['worker', 'worker'],
+    ['api', 'api'],
+    ['all', 'all'],
+    ['', 'all'],
+    ['  WORKER  ', 'worker'],
+    ['API', 'api'],
+    ['nonsense', 'all'],
+    ['workerish', 'all'],
+  ])('BREEZE_ROLE=%o -> %s in both implementations', async (raw, expected) => {
+    process.env.BREEZE_ROLE = raw;
+
+    const { sentryBreezeRoleTag } = await import('./sentry');
+    const { breezeRole } = await import('../config/env');
+
+    expect(sentryBreezeRoleTag()).toBe(expected);
+    expect(breezeRole()).toBe(expected);
+  });
+
+  it('agrees when BREEZE_ROLE is unset entirely', async () => {
+    delete process.env.BREEZE_ROLE;
+
+    const { sentryBreezeRoleTag } = await import('./sentry');
+    const { breezeRole } = await import('../config/env');
+
+    expect(sentryBreezeRoleTag()).toBe('all');
+    expect(breezeRole()).toBe('all');
+  });
+});

--- a/apps/api/src/services/sentry.ts
+++ b/apps/api/src/services/sentry.ts
@@ -261,6 +261,16 @@ const ALLOWED_TAG_NAMES = new Set([
   // thousand. Cardinality is bounded in practice by the throttle: at most one
   // event per outage.
   'llm_egress_dropped',
+  // #4143: which CONTAINER produced the event. Since the api/worker role split
+  // (#4086) a droplet in split mode runs two processes off the same image,
+  // same DSN, same release — so an event from the worker was indistinguishable
+  // from one served on the request path, and "is this the scheduler or the
+  // API?" (the first question asked in both #3022 and #3214) could not be
+  // answered from Sentry at all. Set once at init from `breezeRole()`, whose
+  // return type is the closed union `'all' | 'api' | 'worker'`; anything else
+  // in BREEZE_ROLE is folded to `all` by that function, so this tag is a
+  // 3-value set by construction and carries no tenant, device or host.
+  'breeze_role',
 ]);
 const UNSAFE_TAG_CHARACTERS = /[/?#\r\n]/;
 const SAFE_STRUCTURAL_NAME = /^[A-Za-z_$<][A-Za-z0-9_.$<>:[\] ]{0,127}$/;
@@ -437,6 +447,30 @@ export function scrubTransactionEvent<T extends Record<string, any>>(event: T): 
   return event;
 }
 
+/**
+ * The `breeze_role` tag value (#4143).
+ *
+ * Deliberately re-derived from `process.env.BREEZE_ROLE` here instead of
+ * importing `breezeRole()` from `config/env`. This module is imported by ~120
+ * others including `db/index.ts` (see setConnectTimeoutClassifier above for the
+ * incident that established the rule), and `config/env` is not a leaf: it reads
+ * ~40 `process.env` values into module-scope `export const`s, so importing it
+ * from here would both grow this module's graph and pull that env SNAPSHOT
+ * forward to whenever anything first reports an error.
+ *
+ * The duplication is intentional and pinned: `sentry.breezeRole.test.ts`
+ * asserts this function agrees with `breezeRole()` over every input class,
+ * including the unrecognised-value fallback, so the two cannot drift apart
+ * silently. Unlike `breezeRole()` this one does NOT warn on an unrecognised
+ * value — that warning is the config layer's job and is already emitted once
+ * at boot; repeating it from the Sentry layer would add nothing.
+ */
+export function sentryBreezeRoleTag(): 'all' | 'api' | 'worker' {
+  const raw = (process.env.BREEZE_ROLE ?? '').trim().toLowerCase();
+  if (raw === 'api' || raw === 'worker') return raw;
+  return 'all';
+}
+
 function parseSampleRate(raw: string | undefined): number {
   if (!raw) return 0;
   const parsed = Number(raw);
@@ -469,6 +503,18 @@ export function initSentry(): void {
     beforeSend: (event) => scrubEvent(event),
     beforeSendTransaction: (event) => scrubTransactionEvent(event)
   });
+
+  // #4143. Set on the global scope so EVERY event inherits it — including the
+  // per-job isolation scopes `attachWorkerObservability` forks, and the
+  // process-level unhandledRejection/uncaughtException reports that belong to
+  // no request. Without it the two containers a split-mode droplet runs are
+  // indistinguishable in Sentry: same DSN, same release, same environment.
+  //
+  // Allowlisted in ALLOWED_TAG_NAMES above — `scrubEvent` rebuilds `tags` from
+  // that list on the way out, so an unallowlisted tag set here would be
+  // silently dropped rather than merely unused (the exact `worker`-tag
+  // regression documented there).
+  Sentry.setTag('breeze_role', sentryBreezeRoleTag());
 
   initialized = true;
 }

--- a/apps/api/src/worker.boot.test.ts
+++ b/apps/api/src/worker.boot.test.ts
@@ -19,6 +19,9 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import http from 'node:http';
+import { Gauge } from 'prom-client';
+
+const SCRAPE_TOKEN = 'worker-scrape-token';
 
 const mocks = vi.hoisted(() => {
   return {
@@ -26,7 +29,15 @@ const mocks = vi.hoisted(() => {
     validateConfig: vi.fn<() => { NODE_ENV: string }>(),
     initSentry: vi.fn(),
     captureException: vi.fn(),
+    captureMessage: vi.fn(),
     flushSentry: vi.fn(async () => {}),
+    setConnectTimeoutClassifier: vi.fn(),
+    safeDiagnoseConnectTimeout: vi.fn(() => null),
+    startEventLoopMonitor: vi.fn<() => { intervalMs: number } | null>(() => ({ intervalMs: 500 })),
+    stopEventLoopMonitor: vi.fn(),
+    startDbPoolHealthMonitor: vi.fn<() => number | null>(() => 30_000),
+    stopDbPoolHealthMonitor: vi.fn(),
+    updateRuntimeMetrics: vi.fn(),
     dbExecute: vi.fn(async () => [] as unknown[]),
     withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
     closeDb: vi.fn(async () => {}),
@@ -67,7 +78,36 @@ vi.mock('./config/validate', () => ({ validateConfig: mocks.validateConfig }));
 vi.mock('./services/sentry', () => ({
   initSentry: mocks.initSentry,
   captureException: mocks.captureException,
+  captureMessage: mocks.captureMessage,
   flushSentry: mocks.flushSentry,
+  setConnectTimeoutClassifier: mocks.setConnectTimeoutClassifier,
+}));
+// #4143 observability wiring. The monitors themselves are covered by their own
+// suites (eventLoopMonitor.test.ts / dbPoolHealthMonitor.test.ts); what this
+// file owns is that worker.ts STARTS and STOPS them at the right points, which
+// is exactly the wiring that was missing and is silent when absent — an
+// unstarted monitor reports `monitored: false`, which every consumer correctly
+// reads as "unknown". Nothing breaks; the container just goes blind.
+vi.mock('./services/eventLoopMonitor', () => ({
+  startEventLoopMonitor: mocks.startEventLoopMonitor,
+  stopEventLoopMonitor: mocks.stopEventLoopMonitor,
+  getEventLoopStarvationThresholdMs: () => 1_000,
+}));
+vi.mock('./services/eventLoopStarvationReporter', () => ({
+  createStarvationReporter: () => () => {},
+}));
+vi.mock('./services/postgresConnectTimeout', () => ({
+  safeDiagnoseConnectTimeout: mocks.safeDiagnoseConnectTimeout,
+  getConnectTimeoutStarvationThresholdMs: () => 1_000,
+}));
+vi.mock('./db/dbPoolHealthMonitor', () => ({
+  startDbPoolHealthMonitor: mocks.startDbPoolHealthMonitor,
+  stopDbPoolHealthMonitor: mocks.stopDbPoolHealthMonitor,
+  getDbPoolHealthWindowMs: () => 60_000,
+  getDbPoolHealthMinTimeouts: () => 3,
+}));
+vi.mock('./services/metricsRuntime', () => ({
+  updateRuntimeMetrics: mocks.updateRuntimeMetrics,
 }));
 vi.mock('./db', () => ({
   db: { execute: mocks.dbExecute },
@@ -150,6 +190,31 @@ function getJson(port: number, path: string): Promise<{ status: number; body: un
   });
 }
 
+/**
+ * Raw GET returning the body as TEXT plus headers — `/metrics` renders
+ * Prometheus exposition format, not JSON, so `getJson` cannot read it.
+ */
+function rawGet(
+  port: number,
+  path: string,
+  headers: Record<string, string> = {},
+): Promise<{ status: number; body: string; contentType: string | undefined }> {
+  return new Promise((resolve, reject) => {
+    const req = http.get({ host: '127.0.0.1', port, path, headers }, (res) => {
+      let data = '';
+      res.on('data', (chunk) => { data += chunk; });
+      res.on('end', () =>
+        resolve({
+          status: res.statusCode ?? 0,
+          body: data,
+          contentType: res.headers['content-type'],
+        }),
+      );
+    });
+    req.on('error', reject);
+  });
+}
+
 beforeEach(() => {
   exitCalls = [];
   vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
@@ -158,6 +223,8 @@ beforeEach(() => {
   }) as never);
 
   process.env.API_PORT = '0';
+  process.env.METRICS_SCRAPE_TOKEN = SCRAPE_TOKEN;
+  delete process.env.METRICS_SCRAPE_IP_ALLOWLIST;
 
   vi.clearAllMocks();
   mocks.shutdownPhaseCalls.length = 0;
@@ -384,5 +451,226 @@ describe('worker.ts boot (#4086 Task 6)', () => {
 
     // Let the gated shutdown settle so it doesn't leak into the next test.
     resolveShutdown({ failures: [], timedOutPhases: [] });
+  });
+});
+
+/**
+ * #4143 — the worker container's own observability surface.
+ *
+ * Before this, a droplet in split mode published NOTHING from the container
+ * running the relocated BullMQ workers: the Prometheus registry was private to
+ * `routes/metrics.ts`, which a worker-role process must never import (see
+ * services/workerEntrypointClosure.contract.test.ts), so every series that
+ * process could have produced was ABSENT — not stale, not zero. No `up`, no
+ * event-loop lag, no pool-health verdict, on the exact process where #3022 and
+ * #3214 were loudest.
+ */
+describe('worker.ts /metrics (#4143)', () => {
+  /**
+   * Registers a uniquely-named gauge on the registry singleton **that the
+   * freshly-imported worker sees**.
+   *
+   * It MUST run after `importFreshWorker()`: that calls `vi.resetModules()`,
+   * so a registry imported before the reset is a different instance from the
+   * one worker.ts binds to, and a canary on it would never appear no matter
+   * how correct the endpoint is. Dynamically importing here resolves within
+   * the same post-reset module registry the worker got.
+   *
+   * Finding this canary in the response is what distinguishes "serves the
+   * SHARED registry" — the entire point of extracting it out of
+   * routes/metrics.ts — from "serves some empty registry of its own", which
+   * would satisfy every auth-gate assertion below while publishing nothing.
+   */
+  async function registerCanary(): Promise<string> {
+    const { metricsRegistry } = await import('./services/metricsRegistry');
+    const name = `worker_metrics_canary_${Math.random().toString(36).slice(2)}`;
+    const gauge = new Gauge({
+      name,
+      help: 'canary proving /metrics renders the shared registry',
+      registers: [metricsRegistry],
+    });
+    gauge.set(42);
+    return name;
+  }
+
+  it('serves the SHARED registry with the correct token', async () => {
+    const worker = await importFreshWorker();
+    const canary = await registerCanary();
+    const port = await waitForListening(worker);
+
+    const res = await rawGet(port, '/metrics', { Authorization: `Bearer ${SCRAPE_TOKEN}` });
+
+    expect(res.status).toBe(200);
+    expect(res.contentType).toContain('text/plain');
+    expect(res.body).toContain(`${canary} 42`);
+  });
+
+  it('refreshes the read-on-scrape runtime series before rendering', async () => {
+    // Without this the event-loop lag and pool-health verdict would render
+    // whatever they held at boot: a flat, entirely plausible healthy line that
+    // cannot be told apart from a genuinely quiet process.
+    const worker = await importFreshWorker();
+    await waitFor(() => worker._getWorkerInitPhaseForTest() === 'started');
+    const port = await waitForListening(worker);
+    mocks.updateRuntimeMetrics.mockClear();
+
+    await rawGet(port, '/metrics', { Authorization: `Bearer ${SCRAPE_TOKEN}` });
+
+    expect(mocks.updateRuntimeMetrics).toHaveBeenCalled();
+  });
+
+  it('401s a missing, malformed or wrong bearer token', async () => {
+    const worker = await importFreshWorker();
+    const canary = await registerCanary();
+    const port = await waitForListening(worker);
+
+    for (const headers of [
+      {},
+      { Authorization: SCRAPE_TOKEN },
+      { Authorization: `Bearer ${SCRAPE_TOKEN}x` },
+    ]) {
+      const res = await rawGet(port, '/metrics', headers as Record<string, string>);
+      expect(res.status, JSON.stringify(headers)).toBe(401);
+      expect(JSON.parse(res.body)).toEqual({ error: 'Unauthorized' });
+      // A refusal must never leak the series it is refusing to serve.
+      expect(res.body).not.toContain(canary);
+    }
+  });
+
+  it('503s when METRICS_SCRAPE_TOKEN is not configured', async () => {
+    delete process.env.METRICS_SCRAPE_TOKEN;
+    const worker = await importFreshWorker();
+    const canary = await registerCanary();
+    const port = await waitForListening(worker);
+
+    const res = await rawGet(port, '/metrics', { Authorization: 'Bearer anything' });
+
+    expect(res.status).toBe(503);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Metrics scrape token is not configured' });
+    expect(res.body).not.toContain(canary);
+  });
+
+  it('403s an off-allowlist peer even with the correct token', async () => {
+    process.env.METRICS_SCRAPE_IP_ALLOWLIST = '203.0.113.7';
+    const worker = await importFreshWorker();
+    const canary = await registerCanary();
+    const port = await waitForListening(worker);
+
+    // The test client connects from loopback, which is not on the allowlist.
+    const res = await rawGet(port, '/metrics', { Authorization: `Bearer ${SCRAPE_TOKEN}` });
+
+    expect(res.status).toBe(403);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Forbidden' });
+    expect(res.body).not.toContain(canary);
+  });
+
+  it('allows a loopback peer when loopback is on the allowlist', async () => {
+    // Pins the direct-peer resolution end to end, including the IPv4-mapped
+    // IPv6 normalisation a dual-stack listener produces.
+    process.env.METRICS_SCRAPE_IP_ALLOWLIST = '127.0.0.1,::1';
+    const worker = await importFreshWorker();
+    const canary = await registerCanary();
+    const port = await waitForListening(worker);
+
+    const res = await rawGet(port, '/metrics', { Authorization: `Bearer ${SCRAPE_TOKEN}` });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toContain(`${canary} 42`);
+  });
+
+  it('ignores X-Forwarded-For — the allowlist matches the DIRECT peer only', async () => {
+    // This port has no trusted-proxy configuration, so honouring a forwarded
+    // header would let any caller name its own source IP and walk straight
+    // through the allowlist.
+    process.env.METRICS_SCRAPE_IP_ALLOWLIST = '203.0.113.7';
+    const worker = await importFreshWorker();
+    const port = await waitForListening(worker);
+
+    const res = await rawGet(port, '/metrics', {
+      Authorization: `Bearer ${SCRAPE_TOKEN}`,
+      'X-Forwarded-For': '203.0.113.7',
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('answers before boot completes rather than 404ing', async () => {
+    // The health server starts at step 3, long before the dynamic imports and
+    // the worker registry. A scrape landing in that window must get the
+    // endpoint (rendering whatever is registered so far), not a 404 that reads
+    // as "this build has no /metrics".
+    let releaseParity!: () => void;
+    mocks.waitForMigrationParity.mockImplementation(
+      () => new Promise<void>((resolve) => { releaseParity = () => resolve(); }),
+    );
+
+    const worker = await importFreshWorker();
+    const port = await waitForListening(worker);
+
+    const res = await rawGet(port, '/metrics', { Authorization: `Bearer ${SCRAPE_TOKEN}` });
+    expect(res.status).toBe(200);
+
+    releaseParity();
+    await waitFor(() => worker._getWorkerInitPhaseForTest() === 'started');
+  });
+
+  it('still 404s an unknown path', async () => {
+    const worker = await importFreshWorker();
+    const port = await waitForListening(worker);
+
+    const res = await rawGet(port, '/metrics/scrape', { Authorization: `Bearer ${SCRAPE_TOKEN}` });
+    expect(res.status).toBe(404);
+  });
+});
+
+/**
+ * #3022/#3214 monitors on the worker role (#4143). These are the two
+ * instrumentations that "matter MOST where the heavy jobs run" — and an
+ * unstarted monitor is completely silent: it reports `monitored: false`, which
+ * every consumer correctly reads as "unknown". Nothing breaks and no other
+ * test fails; the container simply goes blind. That is exactly why the wiring
+ * needs its own assertions.
+ */
+describe('worker.ts observability monitors (#4143)', () => {
+  it('starts the event-loop monitor and injects the SAFE CONNECT_TIMEOUT classifier', async () => {
+    const worker = await importFreshWorker();
+    await waitFor(() => worker._getWorkerInitPhaseForTest() === 'started');
+
+    expect(mocks.startEventLoopMonitor).toHaveBeenCalledTimes(1);
+    // The never-throwing variant specifically: this runs on error paths, where
+    // a throw would cost the original report.
+    expect(mocks.setConnectTimeoutClassifier).toHaveBeenCalledWith(mocks.safeDiagnoseConnectTimeout);
+  });
+
+  it('starts the DB pool-health watchdog', async () => {
+    const worker = await importFreshWorker();
+    await waitFor(() => worker._getWorkerInitPhaseForTest() === 'started');
+
+    expect(mocks.startDbPoolHealthMonitor).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops both monitors in the shutdown preamble, before the phases run', async () => {
+    // Ordering is the assertion, not merely that they are stopped: the
+    // watchdog must not open a fresh probe connection while the `db` phase
+    // drains the pool, which would report `database-unreachable` about a
+    // process that is simply shutting down.
+    const order: string[] = [];
+    mocks.stopEventLoopMonitor.mockImplementation(() => { order.push('stopEventLoop'); });
+    mocks.stopDbPoolHealthMonitor.mockImplementation(() => { order.push('stopDbPoolHealth'); });
+    mocks.runShutdownPhases.mockImplementation(
+      async (phases: Array<{ name: string }>) => {
+        order.push('phases');
+        mocks.shutdownPhaseCalls.push(phases.map((p) => p.name));
+        return { failures: [], timedOutPhases: [] };
+      },
+    );
+
+    const worker = await importFreshWorker();
+    await waitFor(() => worker._getWorkerInitPhaseForTest() === 'started');
+
+    process.emit('SIGTERM');
+    await waitFor(() => exitCalls.length > 0);
+
+    expect(order).toEqual(['stopEventLoop', 'stopDbPoolHealth', 'phases']);
   });
 });

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -285,10 +285,22 @@ async function handleMetricsRequest(req: IncomingMessage, res: ServerResponse): 
   } catch (error) {
     // A render fault must not take the process down, and must not be silent:
     // Prometheus sees a 500 (so `up` stays 1 while the scrape fails, which is
-    // the distinguishable state) and the fault is reported.
+    // the distinguishable state) and the fault is reported. The detail stays in
+    // the log and Sentry — the response body is a fixed string, because this
+    // endpoint answers before authentication has told us anything about who is
+    // asking on the 503 path and there is no reason to narrate internals to a
+    // scraper on any path.
     console.error('[worker][metrics] Failed to render metrics:', error);
     captureException(error instanceof Error ? error : new Error(String(error)));
-    writeJson(res, 500, { error: 'Failed to render metrics' });
+    // Guarded: if the throw came from `res.end()` the 200 header is already on
+    // the wire, and calling writeHead again raises ERR_HTTP_HEADERS_SENT from
+    // inside this catch — which would reject the promise and report a
+    // secondary, misleading error INSTEAD of the real one above.
+    if (!res.headersSent) {
+      writeJson(res, 500, { error: 'Failed to render metrics' });
+    } else {
+      res.end();
+    }
   }
 }
 

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -44,10 +44,25 @@
  * `services/rejectionSuppressions` (zero imports of its own) — each
  * independently verified importable without pulling in the route graph.
  *
+ * #4143 added four more, all held to the same bar: `services/eventLoopMonitor`
+ * (`node:perf_hooks` only), `services/eventLoopStarvationReporter` (the
+ * monitor only), `services/postgresConnectTimeout` (leaves only), and the two
+ * metrics leaves `services/metricsRegistry` (`prom-client` only) and
+ * `services/metricsScrapeAuth` (`node:crypto` only). `services/metricsRuntime`
+ * and `db/dbPoolHealthMonitor` are deliberately NOT static — their graphs
+ * reach `postgres`, and the health server must be listening before that loads.
+ *
  * Boot order (the contract, see the plan doc's Task 6):
  *   1. dotenv + role guard (fail closed — this binary runs ONLY as worker).
  *   2. validateConfig(); initSentry().
- *   3. Slim raw-node:http health server, started FIRST (before DB/Redis).
+ *   2b. #3022/#3214/#4143 observability: event-loop lag monitor +
+ *      CONNECT_TIMEOUT classifier immediately after initSentry (so a stall is
+ *      observable for the whole life of the process), and a `breeze_role`
+ *      Sentry tag set inside initSentry so this container's events are
+ *      distinguishable from the api container's.
+ *   3. Slim raw-node:http health server, started FIRST (before DB/Redis). It
+ *      serves `/health`, `/health/ready` and — auth-gated by the same rules as
+ *      the api role's `/api/metrics/scrape` — `/metrics`.
  *   4. DB reachability probe, then `waitForMigrationParity()` — NEVER
  *      `autoMigrate()`. A worker-role process never applies migrations. Then
  *      `initializeDatabaseForStartup({ autoMigrateEnabled: false, production })`
@@ -63,16 +78,42 @@
  *   8. Start the registry's `global`-placement workers, then the
  *      event-dispatch consumer (its own phase-2 special, same as index.ts) —
  *      no relay consumer (socket-owner, stays on api/all).
- *   9. Signal handlers → phased shutdown (drain → workers → queues →
- *      eventbus → redis → db → sentry), mirroring index.ts's Part A
- *      semantics.
+ *   8b. Pool-health watchdog (after validateConfig and after the classifier —
+ *      see the call site for both ordering constraints), plus the runtime
+ *      metric series that publish its verdict and the event-loop lag.
+ *   9. Signal handlers → phased shutdown. The preamble stops both monitors,
+ *      then the phases run (drain → workers → queues → eventbus → redis → db →
+ *      sentry), mirroring index.ts's Part A semantics.
  */
 import 'dotenv/config';
 import { createServer, type IncomingMessage, type ServerResponse, type Server } from 'node:http';
 import { sql } from 'drizzle-orm';
 import { breezeRole } from './config/env';
 import { validateConfig } from './config/validate';
-import { captureException, flushSentry, initSentry } from './services/sentry';
+import {
+  captureException,
+  captureMessage,
+  flushSentry,
+  initSentry,
+  setConnectTimeoutClassifier,
+} from './services/sentry';
+import {
+  getEventLoopStarvationThresholdMs,
+  startEventLoopMonitor,
+  stopEventLoopMonitor,
+} from './services/eventLoopMonitor';
+import { createStarvationReporter } from './services/eventLoopStarvationReporter';
+import {
+  getConnectTimeoutStarvationThresholdMs,
+  safeDiagnoseConnectTimeout,
+} from './services/postgresConnectTimeout';
+import { metricsRegistry } from './services/metricsRegistry';
+import {
+  directPeerAddress,
+  evaluateMetricsScrapeAuth,
+  parseMetricsScrapeIpAllowlist,
+  resolveMetricsScrapeToken,
+} from './services/metricsScrapeAuth';
 import {
   computeWorkersHealthy,
   createReadinessEvaluator,
@@ -104,6 +145,18 @@ let shuttingDown = false;
 let migrationParityAchieved = false;
 let healthServer: Server | null = null;
 let auditRetryInterval: NodeJS.Timeout | null = null;
+
+/**
+ * Set once `services/metricsRuntime` has been dynamically imported (#4143).
+ *
+ * That module is NOT a static import: its own graph reaches
+ * `db/dbPoolHealthMonitor` and therefore `postgres`, and the health server has
+ * to be listening before any of that loads (boot step 3). Until it is wired,
+ * `/metrics` still answers — it renders whatever the registry holds and simply
+ * omits the runtime series, which is the honest reading of "this process has
+ * not registered them yet". It never 500s and never fabricates a zero.
+ */
+let refreshRuntimeMetrics: (() => void) | null = null;
 
 // Assigned once the dynamically-imported db/redis modules are available
 // (start of main(), before any readiness probe can actually be reached).
@@ -184,6 +237,61 @@ async function handleReadyRequest(res: ServerResponse): Promise<void> {
   }
 }
 
+/**
+ * `/metrics` (#4143) — the worker role's Prometheus scrape endpoint.
+ *
+ * Before this existed, a droplet in split mode published NOTHING from the
+ * container running the relocated BullMQ workers: the registry was private to
+ * `routes/metrics.ts`, which a worker-role process must never import, so every
+ * series that process could have produced was absent rather than stale. No
+ * `up`, no event-loop lag, no pool-health verdict — on the exact process where
+ * #3022 and #3214 were loudest.
+ *
+ * The gate is the SAME three rules the api role applies on
+ * `/api/metrics/scrape`, shared via `services/metricsScrapeAuth` rather than
+ * reimplemented: configured token (else 503), optional source-IP allowlist
+ * (else 403), constant-time bearer compare (else 401). One difference is
+ * deliberate and documented on `directPeerAddress`: the allowlist here matches
+ * the DIRECT PEER and ignores forwarded headers, because this port has no
+ * trusted-proxy configuration to validate them against.
+ *
+ * Env is read per-request, not cached at module load, so an operator can fix a
+ * missing `METRICS_SCRAPE_TOKEN` without the token resolution having been
+ * frozen at boot. At Prometheus scrape intervals the cost is irrelevant.
+ */
+async function handleMetricsRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const ipAllowlist = parseMetricsScrapeIpAllowlist();
+  const denial = evaluateMetricsScrapeAuth({
+    token: resolveMetricsScrapeToken(),
+    ipAllowlist,
+    authHeader: req.headers.authorization,
+    clientIp: ipAllowlist.size > 0 ? directPeerAddress(req.socket) : undefined,
+  });
+  if (denial) {
+    writeJson(res, denial.status, { error: denial.error });
+    return;
+  }
+
+  try {
+    // Refresh the read-on-scrape series (event-loop lag, pool-health verdict)
+    // before rendering, exactly as the api role's `metricsResponse` does.
+    refreshRuntimeMetrics?.();
+    const body = await metricsRegistry.metrics();
+    res.writeHead(200, {
+      'Content-Type': metricsRegistry.contentType,
+      'Cache-Control': 'no-cache, no-store, must-revalidate',
+    });
+    res.end(body);
+  } catch (error) {
+    // A render fault must not take the process down, and must not be silent:
+    // Prometheus sees a 500 (so `up` stays 1 while the scrape fails, which is
+    // the distinguishable state) and the fault is reported.
+    console.error('[worker][metrics] Failed to render metrics:', error);
+    captureException(error instanceof Error ? error : new Error(String(error)));
+    writeJson(res, 500, { error: 'Failed to render metrics' });
+  }
+}
+
 function startHealthServer(port: number): Server {
   const server = createServer((req: IncomingMessage, res: ServerResponse) => {
     const pathName = (req.url ?? '/').split('?')[0];
@@ -195,6 +303,10 @@ function startHealthServer(port: number): Server {
     }
     if (pathName === '/health/ready') {
       void handleReadyRequest(res);
+      return;
+    }
+    if (pathName === '/metrics') {
+      void handleMetricsRequest(req, res);
       return;
     }
     writeJson(res, 404, { error: 'not found' });
@@ -229,6 +341,48 @@ export async function bootWorker(): Promise<void> {
 
   // Step 2.
   initSentry();
+
+  // #3022/#4143 — start measuring event-loop lag immediately after Sentry and
+  // before any DB/Redis work, mirroring index.ts, so a stall is observable for
+  // the whole life of the process. This matters MORE here than on the api
+  // role: the loudest signature in the original incident was the patch
+  // scheduler, and in split mode that runs in THIS container. The monitor is a
+  // native histogram plus one unref'd interval — it holds nothing open.
+  const eventLoopMonitor = startEventLoopMonitor({
+    onSample: createStarvationReporter({
+      thresholdMs: getEventLoopStarvationThresholdMs,
+      capture: (message, tags) =>
+        captureMessage(message, { eventCode: 'event_loop_starvation', tags }),
+    }),
+  });
+  if (eventLoopMonitor) {
+    console.log(
+      `[worker][event-loop] Lag monitor started (interval ${eventLoopMonitor.intervalMs}ms, `
+      + `warn threshold ${getEventLoopStarvationThresholdMs()}ms, `
+      + `CONNECT_TIMEOUT attribution threshold ${getConnectTimeoutStarvationThresholdMs()}ms)`,
+    );
+    if (eventLoopMonitor.intervalMs > getEventLoopStarvationThresholdMs()) {
+      console.warn(
+        `[worker][event-loop] EVENT_LOOP_MONITOR_INTERVAL_MS (${eventLoopMonitor.intervalMs}ms) exceeds the `
+        + `starvation threshold (${getEventLoopStarvationThresholdMs()}ms). Stalls shorter than one `
+        + `sampling interval cannot be observed, so CONNECT_TIMEOUT causes will report "unknown" (#3022).`,
+      );
+    }
+  } else {
+    console.warn(
+      '[worker][event-loop] Lag monitor DISABLED via EVENT_LOOP_MONITOR_DISABLED — Postgres '
+      + 'CONNECT_TIMEOUT errors will report cause "unknown" because starvation can be '
+      + 'neither ruled in nor out (#3022).',
+    );
+  }
+
+  // Injected rather than imported by services/sentry.ts, which must stay a leaf
+  // — same inversion index.ts performs. Must follow startEventLoopMonitor:
+  // before the monitor runs every diagnosis correctly reports 'unknown' rather
+  // than guessing. The SAFE variant specifically — this runs on error paths and
+  // a throw here would cost the original report.
+  setConnectTimeoutClassifier(safeDiagnoseConnectTimeout);
+
   const config = validateConfig();
   console.log(`[worker] Validated config: NODE_ENV=${config.NODE_ENV}`);
 
@@ -253,6 +407,38 @@ export async function bootWorker(): Promise<void> {
   const { shutdownEventDispatchQueue } = await import('./services/eventDispatchQueue');
   const { getEventBus } = await import('./services/eventBus');
   const { drainAuditRetryQueue } = await import('./services/auditService');
+  const {
+    getDbPoolHealthMinTimeouts,
+    getDbPoolHealthWindowMs,
+    startDbPoolHealthMonitor,
+    stopDbPoolHealthMonitor,
+  } = await import('./db/dbPoolHealthMonitor');
+  // Registers the role-agnostic runtime series onto the shared registry and
+  // binds the CONNECT_TIMEOUT counter recorder. Dynamic because its graph
+  // reaches `db/dbPoolHealthMonitor` -> `postgres`; the health server above is
+  // already listening, so this cannot delay liveness.
+  const { updateRuntimeMetrics } = await import('./services/metricsRuntime');
+  refreshRuntimeMetrics = updateRuntimeMetrics;
+
+  // #3214/#4143 — pool-health watchdog. Ordering matches index.ts's two
+  // constraints: after setConnectTimeoutClassifier (nothing is counted until
+  // that is wired, so an earlier start only gives it an empty window) and
+  // after validateConfig (its probe builds a connection URL straight from the
+  // environment, so starting first lets a short interval fire a probe against
+  // unvalidated config and report the misconfiguration as a database fault).
+  const dbPoolHealthIntervalMs = startDbPoolHealthMonitor();
+  if (dbPoolHealthIntervalMs === null) {
+    console.warn(
+      '[worker][db-pool-health] Watchdog DISABLED via DB_POOL_HEALTH_DISABLED — a poisoned '
+      + 'postgres.js pool will decay silently until someone notices the jobs stop (#3214).',
+    );
+  } else {
+    console.log(
+      `[worker][db-pool-health] Watchdog started (interval ${dbPoolHealthIntervalMs}ms, `
+      + `window ${getDbPoolHealthWindowMs()}ms, probe threshold `
+      + `${getDbPoolHealthMinTimeouts()} CONNECT_TIMEOUT(s) per window)`,
+    );
+  }
 
   const { db, withSystemDbAccessContext } = dbModule;
   const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
@@ -389,6 +575,14 @@ export async function bootWorker(): Promise<void> {
     shutdownStarted = true;
     shuttingDown = true;
     console.log(`[worker][shutdown] Received ${signal}, shutting down gracefully...`);
+
+    // Both samplers are already unref'd, so stopping them is tidiness rather
+    // than a requirement — but it keeps a winding-down process from emitting
+    // starvation warnings about itself, and stops the watchdog opening a fresh
+    // probe connection while the pool drains (which would report
+    // `database-unreachable` about a process that is simply shutting down).
+    stopEventLoopMonitor();
+    stopDbPoolHealthMonitor();
 
     if (auditRetryInterval) {
       clearInterval(auditRetryInterval);

--- a/docs/deploy/worker-split.md
+++ b/docs/deploy/worker-split.md
@@ -17,9 +17,9 @@ Design docs:
 - `worker` (new, opt-in) runs `node dist/worker.cjs`: the same image, hardcoded
   `BREEZE_ROLE=worker`, no HTTP route graph, no agent sockets. It owns the
   global-placement background workers (retention jobs, sync workers, most
-  scheduled jobs) and exposes a slim health surface (`/health`,
-  `/health/ready`) on the same `API_PORT` (default 3001) inside its own
-  container.
+  scheduled jobs) and exposes a slim health + metrics surface (`/health`,
+  `/health/ready`, `/metrics`) on the same `API_PORT` (default 3001) inside
+  its own container.
 - Socket-owner workers (anything whose import closure or runtime reaches
   agent-socket dispatch — see the plan's Task 5 classification) **stay on the
   `api` container** this wave. `BREEZE_ROLE=all` (the default, both
@@ -30,6 +30,34 @@ Design docs:
   `worker` service always sees the same env the `api` container does (Redis,
   DB, encryption keys, feature flags, …), with only `BREEZE_ROLE` hardcoded
   differently per service.
+
+## Observability (#4143)
+
+The `worker` container publishes its own Prometheus series on
+`http://<worker>:3001/metrics` — **a separate scrape target from the api
+container's `/api/metrics/scrape`**. Add it to your Prometheus config when you
+adopt the split, or the process that runs the heavy jobs is invisible: before
+#4143 its series were not stale or zero, they were ABSENT, and `up` for it did
+not exist at all.
+
+- **Auth is the same gate as the api role's `/api/metrics/scrape`**:
+  `METRICS_SCRAPE_TOKEN` as a bearer token (503 when unset), the optional
+  `METRICS_SCRAPE_IP_ALLOWLIST` (403), then the token compare (401). Both come
+  from the shared `x-api-env` anchor, so the worker already has them.
+- **One deliberate difference:** the worker's IP allowlist matches the
+  **direct peer** and ignores `X-Forwarded-For`, because this port has no
+  trusted-proxy configuration to validate forwarded headers against. If you put
+  a proxy in front of it, allowlist the *proxy's* address, not the scraper's.
+- **What it publishes** is the role-agnostic runtime set — event-loop lag
+  (#3022) and Postgres pool health (#3214) — which is precisely the
+  instrumentation that matters most on the container running the heavy jobs.
+  It does NOT publish the api's HTTP/business/fleet series, because a
+  worker-role process does not serve requests; expect those only from the api
+  target, and do not alert on their absence here.
+- **Sentry events from this container carry `breeze_role: worker`** (the api
+  container's carry `api`, an unsplit one `all`). Before that tag, both
+  containers reported under the same DSN, release and environment with nothing
+  to tell them apart.
 
 ## Prerequisites
 


### PR DESCRIPTION
## The problem

In split-role mode (#4086), the `worker` container is the process running the 76 relocated BullMQ workers, the retention sweeps, and the heavy scheduled jobs. It was also completely unobservable — three separate gaps:

1. **No `/metrics`.** The Prometheus `Registry` was a module-private `const register = new Registry()` inside `routes/metrics.ts` — the one file a worker-role process must never import (`services/workerEntrypointClosure.contract.test.ts` enforces this). The only way to render a scrape was to load the entire route graph. So the worker published *nothing*: not stale series, not zeros — **absent**, with no `up` target either, which no alert rule can see.
2. **No `startEventLoopMonitor` (#3022) / `startDbPoolHealthMonitor` (#3214).** Both were wired only in `index.ts`. The loudest signature in #3022's original incident was the patch scheduler — which in split mode runs in *this* container.
3. **No `breeze_role` Sentry tag.** Both containers run the same image, same DSN, same release, same environment. Their events were indistinguishable.

## The fix

Three new **leaf** modules, each held to the worker's import-closure contract:

| Module | Closure | Role |
|---|---|---|
| `services/metricsRegistry.ts` | `prom-client` only | the shared `Registry` singleton |
| `services/metricsRuntime.ts` | `prom-client` + 3 leaves + `db/dbPoolHealthMonitor` | role-agnostic runtime series |
| `services/metricsScrapeAuth.ts` | `node:crypto` only | the scrape gate both roles enforce |

**`routes/metrics.ts`** now aliases the shared registry as `register` — every existing series declaration is unchanged. The runtime gauges (process identity, event-loop lag ×5, connect-timeout ×2, pool-health ×4) moved to `metricsRuntime` verbatim, along with their seeds and scrape-time refresh.

`metricsRuntime` also owns the `setDbConnectTimeoutMetricsRecorder` binding. That recorder is a **single global slot**: bound from the route file, a worker-role process counted no CONNECT_TIMEOUTs at all while `db/dbPoolHealthMonitor` — running in that same process — alerted on the rate derived from them. It is still re-called from `bindMetricsRecorders()`, because `__resetDbConnectTimeoutStatsForTests()` nulls the slot and `resetMetricsForTesting()` is what tests rely on to restore it.

**`worker.ts`** serves `/metrics` from its slim raw-node:http server behind the shared gate, starts the event-loop monitor + SAFE CONNECT_TIMEOUT classifier right after `initSentry()`, starts the pool-health watchdog after `validateConfig()` (both of index.ts's documented ordering constraints preserved), and **stops both in the shutdown preamble ahead of the phases** — so the watchdog cannot open a probe connection while the `db` phase drains the pool and report `database-unreachable` about a process that is simply shutting down.

**`services/sentry.ts`** sets `breeze_role` (`api`|`worker`|`all`) on the global scope in `initSentry()`, **and** adds it to `ALLOWED_TAG_NAMES`. Both halves are required: `scrubEvent` rebuilds `tags` from that allowlist, so a set-but-unlisted tag arrives as nothing — exactly how the `worker` tag regressed for two days (documented in that file). The value is re-derived locally rather than imported from `config/env`, which is *not* a leaf (~40 module-scope `process.env` reads) and would have grown the graph of a module ~120 others import, including `db/index.ts`. An anti-drift test pins the two normalisations together across every input class.

### One deliberate behavioural difference

The api role's `/api/metrics/scrape` resolves the client IP via `getTrustedClientIpOrUndefined`, which consults forwarded headers against that process's trusted-proxy config. The worker's port has **no** trusted-proxy configuration, so its allowlist matches the **direct peer** and ignores `X-Forwarded-For` — otherwise any caller could name its own source IP and walk through the allowlist. Documented at the call site, in `docs/deploy/worker-split.md`, and covered by a test.

## Verification

- **Contract test (the hard constraint):** `workerEntrypointClosure.contract.test.ts` — **97 passed**. Mutation-proved live: adding `import { metricsRoutes } from '../routes/metrics'` to the new leaf produced **2 failures**, then restored.
- **Affected suites, single-fork** (`--pool=threads --maxWorkers=2`): 18 files, **621 passed / 0 failed** — worker boot, routes/metrics, sentry ×2, event-loop monitor + wiring, dbPoolHealth monitor + wiring, connect-timeout stats, metricsMiddleware, heartbeat, softwareRemediationWorker, retention/actionIntents/m365/agentCertificateBinding metrics.
- **Typecheck:** `tsc --noEmit --project apps/api/tsconfig.json` clean.
- **Lint:** `eslint` clean on all 9 changed/added files.
- **New tests mutation-checked** (not vacuous) — each mutation below produced real failures, then was reverted:

  | Mutation | Result |
  |---|---|
  | drop the `/metrics` route from worker.ts | 8 failed |
  | drop `stopEventLoopMonitor()` from the shutdown preamble | 1 failed |
  | drop `Sentry.setTag('breeze_role', …)` | 4 failed |
  | drop `breeze_role` from `ALLOWED_TAG_NAMES` | 4 failed |

The `/metrics` tests run against the **real** slim HTTP server and register a canary gauge on the registry singleton the freshly-imported worker binds to — so they distinguish "serves the SHARED registry" from "serves some empty registry of its own", which would otherwise satisfy every auth assertion while publishing nothing.

## Operator note

`docs/deploy/worker-split.md` gains an Observability section: the worker is a **separate Prometheus scrape target** (`http://<worker>:3001/metrics`) that must be added when adopting the split. It publishes the runtime set only — expect the HTTP/business/fleet series from the api target and do not alert on their absence here.

Closes #4143

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMvN6SU3uwaaC7b2xmUa5m