### PR TITLE
fix(clientAi): use isPgUniqueViolation helper for tenant-mapping conflict (#4325)

### DIFF
--- a/apps/api/src/routes/clientAi/admin.test.ts
+++ b/apps/api/src/routes/clientAi/admin.test.ts
@@ -165,13 +165,21 @@ describe('client-ai admin — tenant mapping', () => {
     );
   });
 
-  it('PUT maps a tenant-uniqueness violation to 409 tenant_already_mapped', async () => {
+  it('PUT maps a DrizzleQueryError-wrapped tenant-uniqueness violation to 409 tenant_already_mapped', async () => {
+    // DrizzleQueryError shape: generic outer error, real PostgresError (with
+    // code + constraint_name) on .cause — mirrors what postgres.js + Drizzle
+    // actually produce, not a flattened one-level stub.
+    const pgErr = Object.assign(new Error('duplicate key value violates unique constraint'), {
+      code: '23505',
+      constraint_name: 'client_ai_tenant_mappings_tenant_uniq',
+    });
+    const drizzleErr = Object.assign(new Error('Failed query: insert into "client_ai_tenant_mappings" ...'), {
+      cause: pgErr,
+    });
     dbInsertMock.mockImplementation(() => ({
       values: vi.fn(() => ({
         onConflictDoUpdate: vi.fn(() => ({
-          returning: vi.fn(() =>
-            Promise.reject(Object.assign(new Error('duplicate'), { cause: { code: '23505' } }))
-          ),
+          returning: vi.fn(() => Promise.reject(drizzleErr)),
         })),
       })),
     }));
@@ -182,6 +190,30 @@ describe('client-ai admin — tenant mapping', () => {
     });
     expect(res.status).toBe(409);
     expect(await res.json()).toEqual({ error: 'tenant_already_mapped' });
+  });
+
+  it('PUT does NOT map a 23505 on a different constraint to 409 — it propagates', async () => {
+    const pgErr = Object.assign(new Error('duplicate key value violates unique constraint'), {
+      code: '23505',
+      constraint_name: 'client_ai_tenant_mappings_pkey',
+    });
+    const drizzleErr = Object.assign(new Error('Failed query: insert into "client_ai_tenant_mappings" ...'), {
+      cause: pgErr,
+    });
+    dbInsertMock.mockImplementation(() => ({
+      values: vi.fn(() => ({
+        onConflictDoUpdate: vi.fn(() => ({
+          returning: vi.fn(() => Promise.reject(drizzleErr)),
+        })),
+      })),
+    }));
+    const res = await buildApp().request(`/client-ai/admin/orgs/${ORG_ID}/tenant-mapping`, {
+      method: 'PUT',
+      headers: AUTHED,
+      body: JSON.stringify({ entraTenantId: TID }),
+    });
+    // Not the deliberately-opaque 409 mapping; the raw error surfaces instead.
+    expect(res.status).toBe(500);
   });
 
   it('DELETE removes the mapping and audits', async () => {

--- a/apps/api/src/routes/clientAi/admin.test.ts
+++ b/apps/api/src/routes/clientAi/admin.test.ts
@@ -168,7 +168,9 @@ describe('client-ai admin — tenant mapping', () => {
   it('PUT maps a DrizzleQueryError-wrapped tenant-uniqueness violation to 409 tenant_already_mapped', async () => {
     // DrizzleQueryError shape: generic outer error, real PostgresError (with
     // code + constraint_name) on .cause — mirrors what postgres.js + Drizzle
-    // actually produce, not a flattened one-level stub.
+    // actually produce. Note this fixture is the same one-level depth the old
+    // hand-rolled `.cause?.code` check also handled; the constraint-name
+    // discrimination this PR adds is what the NEXT test actually guards.
     const pgErr = Object.assign(new Error('duplicate key value violates unique constraint'), {
       code: '23505',
       constraint_name: 'client_ai_tenant_mappings_tenant_uniq',

--- a/apps/api/src/routes/clientAi/admin.ts
+++ b/apps/api/src/routes/clientAi/admin.ts
@@ -11,6 +11,7 @@ import { PERMISSIONS } from '../../services/permissions';
 import { CLIENT_AI_ENTRA_CLIENT_ID } from '../../config/env';
 import { resolveScopedOrgId } from '../c2c/helpers';
 import { getOrgPolicy } from '../../services/clientAiPolicy';
+import { isPgUniqueViolation } from '../../utils/pgErrors';
 import { putPolicySchema, putTenantMappingSchema } from './schemas';
 import { clientAiAdminOrgRoutes } from './adminOrgs';
 import { clientAiAdminSessionRoutes } from './adminSessions';
@@ -133,7 +134,7 @@ clientAiAdminRoutes.put(
     } catch (err) {
       // client_ai_tenant_mappings_tenant_uniq: the tenant is already mapped to
       // a DIFFERENT org. Deliberately opaque — do not reveal which org.
-      if ((err as { cause?: { code?: string } }).cause?.code === '23505') {
+      if (isPgUniqueViolation(err, 'client_ai_tenant_mappings_tenant_uniq')) {
         return c.json({ error: 'tenant_already_mapped' }, 409);
       }
       throw err;


### PR DESCRIPTION
## Summary

`apps/api/src/routes/clientAi/admin.ts` hand-rolled a single-level `.cause?.code === '23505'` unwrap to detect the tenant-mapping unique-conflict case, instead of using the canonical `isPgUniqueViolation` helper in `apps/api/src/utils/pgErrors.ts`. Two defects:

1. **Single-level unwrap.** The helper walks the `.cause` chain up to 5 deep because a `DrizzleQueryError` wraps a `PostgresError`, and other wrapper shapes exist too. The hand-rolled check only handled the one-wrap shape.
2. **No constraint-name check.** The comment names `client_ai_tenant_mappings_tenant_uniq` as the intended trigger, but the code matched *any* 23505 on the insert statement and reported it as `tenant_already_mapped`, which would misreport an unrelated unique violation on the same table.

## Fix

Swap to `isPgUniqueViolation(err, 'client_ai_tenant_mappings_tenant_uniq')`, which fixes both defects in one call and preserves the deliberately-opaque 409 response.

## Tests

`apps/api/src/routes/clientAi/admin.test.ts`:
- Replaced the old single-level-unwrap test with one asserting a `DrizzleQueryError`-wrapped 23505 (outer generic error, `PostgresError` with `code` + `constraint_name` on `.cause`) on the correct constraint still maps to 409 `tenant_already_mapped`.
- Added a test asserting a 23505 naming a *different* constraint on the same table does NOT get mapped to 409 — it propagates (500).

Closes #4325

## Test plan

- [x] `pnpm exec vitest run src/routes/clientAi/admin.test.ts --pool=threads --maxWorkers=2` — 16/16 passed
- [x] `pnpm exec vitest run src/utils/pgErrors.test.ts --pool=threads --maxWorkers=2` — 20/20 passed (helper unchanged, sanity check)
- [x] `NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit -p apps/api` — clean
- [x] `npx eslint` on both changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)