### PR TITLE
fix(docker): route portal dev island module URLs to portal in Caddy (#3906)

### DIFF
--- a/docker-compose.override.yml.dev
+++ b/docker-compose.override.yml.dev
@@ -14,6 +14,13 @@ services:
   caddy:
     # Uses canonical docker/Caddyfile.prod mounted by the base compose.
     # No command override needed — Caddy reads the volume-mounted config.
+    environment:
+      # Enables the @portalDevAssets matcher (#3906) so unprefixed Astro/Vite
+      # dev module URLs for portal islands (/src/*, /@fs/*, /@vite/*,
+      # /node_modules/.vite/*) route to the dev portal service instead of
+      # 404ing against web:4321. Unset in production — see the matcher's
+      # comment in docker/Caddyfile.prod.
+      CADDY_PORTAL_DEV_ASSETS: "1"
 
   binaries-init:
     image: alpine:3.19

--- a/docker/Caddyfile.prod
+++ b/docker/Caddyfile.prod
@@ -312,6 +312,43 @@
     reverse_proxy portal:4322
   }
 
+  # --- Dev-only: portal client-island module URLs (#3906) ---
+  # apps/portal/astro.config.mjs sets `base: /portal`, but that only prefixes
+  # *page* routes. Astro's dev server (Vite) does NOT honor `base` for the
+  # raw module-graph URLs the `astro-island` runtime fetches to hydrate a
+  # `client:load` island — e.g. `/src/components/portal/PublicQuoteView.tsx`,
+  # `/@fs/*`, `/@vite/*`, `/node_modules/.vite/*`. In dev those unprefixed
+  # requests fell through to the web catch-all below (web:4321), which has no
+  # such file: a silent 404, so the island never hydrated even though the
+  # SSR'd markup still looked correct (portal e2e specs were asserting
+  # against dead markup — see project memory
+  # portal_dev_island_hydration_404.md). A production build serves portal's
+  # own bundled assets already prefixed under /portal/*, so this has never
+  # been a prod issue.
+  #
+  # The web app is ALSO Astro + React islands and serves the SAME class of
+  # raw dev paths for its OWN islands, so this can't be routed by path alone
+  # — that would steal web's dev assets. Gate on the Referer (the browser
+  # sends it on these module-graph fetches, pointing at the page that
+  # requested them) so only requests that came from a /portal page reach the
+  # portal dev server.
+  #
+  # CADDY_PORTAL_DEV_ASSETS is unset in production — docker-compose.yml sets
+  # no such var for the caddy service, so `{env.CADDY_PORTAL_DEV_ASSETS}` is
+  # "" there and this matcher can never fire (same env-gate pattern as
+  # @remoteAccessClosed above). Only docker-compose.override.yml.dev sets it
+  # to "1", for the code-mounted dev portal (Dockerfile.portal.dev) used by
+  # both plain dev-mode and wt-stack/worktree stacks (which layer on top of
+  # .dev — see scripts/dev/wt-stack/compose.ts).
+  @portalDevAssets {
+    expression {env.CADDY_PORTAL_DEV_ASSETS} == "1"
+    header_regexp Referer ^https?://[^/]+(?::\d+)?/portal(?:/|$)
+    path /src/* /@fs/* /@vite/* /node_modules/.vite/*
+  }
+  handle @portalDevAssets {
+    reverse_proxy portal:4322
+  }
+
   # --- Web frontend (catch-all, with compression) ---
   handle {
     encode zstd gzip

--- a/e2e-tests/tests/multi-currency.spec.ts
+++ b/e2e-tests/tests/multi-currency.spec.ts
@@ -1,7 +1,7 @@
 import type { APIRequestContext, Page, Request } from '@playwright/test';
 import { test, expect } from '../fixtures';
 import { clearRefreshState } from '../test-helpers';
-import { waitForAppReady } from '../pages/hydration';
+import { waitForAppReady, waitForHydration } from '../pages/hydration';
 import { OrgBillingSettingsPage } from '../pages/OrgBillingSettingsPage';
 import { InvoicesPage } from '../pages/InvoicesPage';
 import { QuotesPage } from '../pages/QuotesPage';
@@ -227,12 +227,18 @@ test.describe('multi-currency — non-USD org browser slices', () => {
         await expect(doc).not.toContainText('$');
         await expect(publicPage.getByTestId('public-quote-accept')).toBeVisible();
 
+        // Hydration guard (#3906) — see the same note in
+        // quote-contract-proposal.spec.ts: Caddy previously dropped this
+        // `client:load` island's unprefixed dev module URL into the web
+        // catch-all instead of the portal, so it never hydrated even though
+        // the SSR'd markup above looked correct. Fail loud here if that
+        // routing (docker/Caddyfile.prod's @portalDevAssets matcher)
+        // regresses.
+        await waitForHydration(publicPage, 'public-quote-accept');
+
         // Accept through the same public endpoint the "Accept & sign" button
-        // calls. PublicQuoteView is a `client:load` island served under the
-        // portal's `/portal` base path, and Astro dev-mode fails to fetch its
-        // hydration module there (project memory portal_dev_island_hydration_404),
-        // so every button on this page is inert in a dev stack regardless of
-        // selector or timing — see the same note in quote-contract-proposal.spec.ts.
+        // calls, rather than by clicking it, so this stays deterministic
+        // regardless of the signer-name input's exact UI validation.
         const acceptResponse = await publicPage.request.post(
           `${origin}/api/v1/quotes/public/${acceptToken}/accept`,
           { data: { signerName: 'Jordan Rivers' } },

--- a/e2e-tests/tests/quote-contract-proposal.spec.ts
+++ b/e2e-tests/tests/quote-contract-proposal.spec.ts
@@ -244,23 +244,25 @@ test.describe('quote + contract proposal lifecycle', () => {
       await expect(publicPage.getByTestId('public-quote-signer')).toBeVisible();
       await expect(publicPage.getByTestId('public-quote-accept')).toBeVisible();
 
+      // Hydration guard (#3906): a worktree-stack Caddy config used to route
+      // the unprefixed Astro/Vite dev module URLs these `client:load`
+      // islands fetch (e.g. `/src/components/portal/PublicQuoteView.tsx`)
+      // into the web catch-all instead of the portal, so the hydration
+      // module always 404'd here and PublicQuoteView never mounted — the
+      // SSR'd markup above looked correct while every button on the page was
+      // inert. Caddy now routes those dev module URLs to the portal service
+      // (docker/Caddyfile.prod's @portalDevAssets matcher), so this island
+      // MUST hydrate; if the routing (or the island) regresses, fail loud
+      // here instead of only being caught by the console 404 nobody reads.
+      await waitForHydration(publicPage, 'public-quote-accept');
+
       // Accept via the same public endpoint the "Accept & sign" button calls
-      // (POST /quotes/public/:token/accept, { signerName }), NOT by clicking
-      // it: PublicQuoteView is a `client:load` island served under the
-      // portal's `/portal` base path, and Astro dev-mode has a documented
-      // base-path-in-dev gotcha where the island's hydration module 404s
-      // (browser requests `/src/components/portal/PublicQuoteView.tsx`,
-      // missing the `/portal` prefix — confirmed via console/network capture:
-      // "[astro-island] Error hydrating ... Failed to fetch dynamically
-      // imported module"). See project memory
-      // portal_dev_island_hydration_404.md: dev-only, already known, and
-      // CI's smoke-test job builds the portal from a production bundle
-      // (serves islands under /portal/_astro/*) where hydration is expected
-      // to work. Every button on this page is therefore inert in THIS stack
-      // regardless of selector/timing — calling the endpoint directly
-      // exercises the real accept path (quoteAcceptService: converts the
-      // quote, auto-creates the recurring billing Contract, snapshots the
-      // executed contract_documents row) without depending on hydration.
+      // (POST /quotes/public/:token/accept, { signerName }) rather than by
+      // clicking it, so this assertion stays deterministic regardless of the
+      // signer-name input's exact UI validation: exercises the real accept
+      // path (quoteAcceptService: converts the quote, auto-creates the
+      // recurring billing Contract, snapshots the executed
+      // contract_documents row) independent of form-fill timing.
       const acceptResponse = await publicPage.request.post(
         `${origin}/api/v1/quotes/public/${token}/accept`,
         { data: { signerName: 'Jordan Rivers' } },


### PR DESCRIPTION
## Summary

In a `pnpm wt-stack` (or plain `docker-compose.override.yml.dev`) stack, no portal React island ever hydrated. Pages rendered their server HTML and then failed silently — the markup looked right, so a browser-level check could pass while nothing on the page was actually interactive.

**Root cause:** `apps/portal/astro.config.mjs` sets `base: /portal`, but Astro's dev server (Vite) does not honor that `base` for the raw module-graph URLs the `astro-island` runtime fetches to hydrate a `client:load` island — e.g. `/src/components/portal/PublicQuoteView.tsx`, `/@fs/*`, `/@vite/*`, `/node_modules/.vite/*`. `docker/Caddyfile.prod` only matched `/portal` and `/portal/*`, so those unprefixed dev requests fell through to the web catch-all (`web:4321`), which has no matching file — a silent 404. A production build serves portal's own bundled, base-prefixed assets, so this has never shown up in prod.

**Fix (Option A from the issue):** a dev-only `@portalDevAssets` Caddy matcher, gated on a new `CADDY_PORTAL_DEV_ASSETS` env var set only by `docker-compose.override.yml.dev` (which `docker-compose.override.yml.worktree` layers on top of for `wt-stack`). It's unset in production, so `{env.CADDY_PORTAL_DEV_ASSETS}` is empty there and the matcher can never fire — production routing is untouched. Since `apps/web` is *also* Astro + React islands and serves the same class of raw dev paths for its own islands, the matcher additionally gates on the `Referer` header so only requests that came from a `/portal` page get routed to the portal dev server, rather than stealing web's own dev assets.

- `docker/Caddyfile.prod` — new `@portalDevAssets` matcher block (env + Referer + path gated), placed before the web catch-all.
- `docker-compose.override.yml.dev` — sets `CADDY_PORTAL_DEV_ASSETS: "1"` on the `caddy` service.
- `e2e-tests/tests/quote-contract-proposal.spec.ts` / `multi-currency.spec.ts` — add a `waitForHydration` guard on the public portal accept island (previously these specs worked around the dead-hydration bug by calling the accept API directly instead of clicking) so a routing regression fails loud instead of only showing up as a console 404 nobody reads.

## Test plan

- [x] `caddy validate --config docker/Caddyfile.prod --adapter caddyfile` (via pinned `caddy:2-alpine` docker image) — valid, no new warnings vs. the pre-change file.
- [x] `docker compose config` rendered for both the prod-only file set and the `.dev` + `.worktree` layered set (with a dummy env file covering the compose file's required vars) — confirmed `CADDY_PORTAL_DEV_ASSETS=1` merges through for the caddy service in dev/worktree, and is absent entirely in the prod-only render.
- [x] Existing Caddyfile contract test: `apps/api/src/config/proxyTrustCompose.test.ts` + `composeBindMounts.test.ts` — 9/9 passed.
- [x] `e2e-tests` typecheck (`npx tsc --noEmit -p tsconfig.json`) — clean.
- [x] `scripts/security/check-supply-chain-hardening.sh` — passed (no Watchtower/compose hardening regressions).
- [ ] Not run: the new `waitForHydration` e2e assertions against a live `wt-stack` (guardrail for this session — the shared stack ports were in use by sibling in-flight work). These should be exercised the next time this branch runs through `pnpm wt-stack up && pnpm wt-stack test -- tests/quote-contract-proposal.spec.ts tests/multi-currency.spec.ts` before merge.

Closes #3906

🤖 Generated with [Claude Code](https://claude.com/claude-code)