### PR TITLE
fix(ci): warn on dpkg recovery failure, surface main-red-alert write failures (#3754)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1699,7 +1699,8 @@ jobs:
             # Bounded too: dpkg runs maintainer scripts and can block on its
             # own, and an unbounded recovery would reintroduce the very stall
             # this step exists to prevent.
-            sudo timeout --kill-after=30s 60s dpkg --configure -a || true
+            sudo timeout --kill-after=30s 60s dpkg --configure -a || \
+              echo "::warning::dpkg --configure -a recovery failed after attempt ${attempt}; this can mean a genuinely broken runner (corrupted dpkg state, disk full) rather than a slow mirror — check this run's logs if all ${attempts} attempts fail."
             sleep $((attempt * 15))
           done
           echo "::error::Failed to install Tauri system dependencies after ${attempts} attempts."
@@ -2566,20 +2567,38 @@ jobs:
               if [ -n "$existing" ]; then
                 gh issue close "$existing" --repo "$GITHUB_REPOSITORY" \
                   --comment "Main is green again as of \`$short_sha\`: $RUN_URL" \
-                  || echo "::error::Failed to close ci-red issue #$existing; it will close on the next green main run."
+                  || {
+                    echo "::error::Failed to close ci-red issue #$existing; it will close on the next green main run."
+                    {
+                      echo "### main-red-alert: failed to close ci-red issue #$existing"
+                      echo "Main is green again as of \`$short_sha\`, but closing ci-red issue #$existing failed. It will self-heal on the next green push to main, or can be closed manually. Run: $RUN_URL"
+                    } >> "$GITHUB_STEP_SUMMARY"
+                  }
               fi
               ;;
             failure)
               if [ -n "$existing" ]; then
                 gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" \
                   --body "Still red at \`$short_sha\`: $RUN_URL" \
-                  || echo "::error::Failed to comment on ci-red issue #$existing; the issue is already open, so main-red state is still tracked."
+                  || {
+                    echo "::error::Failed to comment on ci-red issue #$existing; the issue is already open, so main-red state is still tracked."
+                    {
+                      echo "### main-red-alert: failed to comment on ci-red issue #$existing"
+                      echo "Main is still red at \`$short_sha\`, but commenting on ci-red issue #$existing failed. The issue is already open, so main-red state is still tracked, but this run's failure is not recorded on it. Run: $RUN_URL"
+                    } >> "$GITHUB_STEP_SUMMARY"
+                  }
               else
                 body=$(printf "CI failed on a main push at \`%s\`.\n\nRun: %s\n\nThis issue is managed by the main-red-alert job: it stays open while main is red and closes automatically on the next green main run." "$short_sha" "$RUN_URL")
                 gh issue create --repo "$GITHUB_REPOSITORY" --label ci-red \
                   --title "CI is red on main" \
                   --body "$body" \
-                  || echo "::error::Failed to open a ci-red issue for $short_sha — main is RED and untracked. Re-run this job once the API recovers."
+                  || {
+                    echo "::error::Failed to open a ci-red issue for $short_sha — main is RED and untracked. Re-run this job once the API recovers."
+                    {
+                      echo "### :rotating_light: main-red-alert: failed to open ci-red issue"
+                      echo "Main failed at \`$short_sha\`, and opening a ci-red tracking issue also failed. **Main is red and untracked** — this will not self-heal until the next push to main. Re-run this job once the GitHub API recovers, or file the tracking issue by hand. Run: $RUN_URL"
+                    } >> "$GITHUB_STEP_SUMMARY"
+                  }
               fi
               ;;
             *)


### PR DESCRIPTION
## Summary

Follow-up from the silent-failure audit in #3754. **Item 1 (job-level `timeout-minutes: 35` swallowing the step-level apt deadline) was already fixed by #3756** — this PR covers the two remaining items only.

- **Item 2 (MEDIUM):** `.github/workflows/ci.yml` — `dpkg --configure -a || true` between Tauri apt retry attempts swallowed all failures identically, so a genuinely broken runner (corrupted dpkg state, disk full) looked exactly like a slow mirror stall in the logs. Now emits an `::warning::` annotation when the recovery command fails, without changing control flow (the retry loop still proceeds).

- **Item 3 (HIGH):** `main-red-alert` job — all three write paths (`gh issue close`, `gh issue comment`, `gh issue create` against the `ci-red` tracking issue) ended in `|| echo "::error::..."`, so the step always exits 0 regardless of whether the write succeeded. `::error::` annotations don't affect job conclusion and aren't visible in the checks list — only on the run's Annotations tab. Each failure path now also writes to `$GITHUB_STEP_SUMMARY`, so a failed write (especially a failed `gh issue create`, which leaves main red and completely untracked) is visible on the run page itself. Exit code is deliberately left at 0, consistent with #3735's reasoning that this job is a notifier, not a gate, and should not reintroduce the redness that PR removed.

## Test plan

- [x] `actionlint .github/workflows/ci.yml` — no new findings (one pre-existing SC2155 warning at line 1178, confirmed present on `origin/main` before this change, unrelated to the edited sections)
- [x] `apps/api/src/config/ciSuccessGatingContract.test.ts` (parses `ci.yml` job structure) — 7/7 passed, single-fork
- [x] Manual read-through of both diffs for shell correctness (`|| { ... }` blocks under `set -uo pipefail`, no `-e`, so multi-statement failure handlers execute correctly without a stray exit)

No app code touched, so no `tsc`/unit-test surface beyond the config-contract test above.

Closes #3754

🤖 Generated with [Claude Code](https://claude.com/claude-code)