### PR TITLE
fix(web): resolve typed lib/api mutation wrappers in no-silent-mutations guard (#3503)

### DIFF
--- a/apps/web/src/lib/__tests__/fixtures/no-silent-mutations/src/components/QuoteActions.tsx
+++ b/apps/web/src/lib/__tests__/fixtures/no-silent-mutations/src/components/QuoteActions.tsx
@@ -1,0 +1,5 @@
+import { sendQuote as issueQuote } from '../lib/api';
+
+export async function issue(id: string): Promise<void> {
+  await issueQuote(id);
+}

--- a/apps/web/src/lib/__tests__/fixtures/no-silent-mutations/src/lib/api/index.ts
+++ b/apps/web/src/lib/__tests__/fixtures/no-silent-mutations/src/lib/api/index.ts
@@ -1,0 +1,1 @@
+export { getQuote, sendQuote } from './quotes';

--- a/apps/web/src/lib/__tests__/fixtures/no-silent-mutations/src/lib/api/quotes.ts
+++ b/apps/web/src/lib/__tests__/fixtures/no-silent-mutations/src/lib/api/quotes.ts
@@ -1,0 +1,9 @@
+import { fetchWithAuth } from '../../stores/auth';
+
+export function getQuote(id: string): Promise<Response> {
+  return fetchWithAuth(`/quotes/${id}`);
+}
+
+export function sendQuote(id: string): Promise<Response> {
+  return fetchWithAuth(`/quotes/${id}/send`, { method: 'POST' });
+}

--- a/apps/web/src/lib/__tests__/fixtures/no-silent-mutations/src/stores/auth.ts
+++ b/apps/web/src/lib/__tests__/fixtures/no-silent-mutations/src/stores/auth.ts
@@ -1,0 +1,3 @@
+export function fetchWithAuth(_url: string, _options?: RequestInit): Promise<Response> {
+  throw new Error('fixture transport is never executed');
+}

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -1,6 +1,7 @@
 /**
- * Guard: in the targeted set, every *mutating* fetchWithAuth call site must be
- * lexically wrapped by `runAction(...)` OR carry an explicit, reasoned
+ * Guard: in the targeted set, every *mutating* fetchWithAuth call site — direct
+ * or reached through an imported `src/lib/api/*` wrapper — must be lexically
+ * wrapped by `runAction(...)` OR carry an explicit, reasoned
  * `// runaction-exempt:` marker (for the legitimate aggregate / inline-feedback
  * handlers). Whole-file allowlist entries (typed service layers, transport
  * stores) are still skipped via RUN_ACTION_ALLOWLIST.
@@ -11,11 +12,13 @@
  * runAction usage passed unconditionally, and `{ method: opts.method }` /
  * `{ method }` / parenthesised URL args were never matched at all. It had no
  * teeth for the realistic regression. This one is call-local and conservative:
- * a non-literal `method` is treated as potentially-mutating.
+ * a non-literal `method` is treated as potentially-mutating. Imported API
+ * wrappers are resolved through TypeScript symbols, including aliases and
+ * re-exports, instead of relying on a hand-maintained wrapper-name list.
  */
 import { describe, it, expect } from 'vitest';
-import { readFileSync, statSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
+import { statSync } from 'node:fs';
+import { resolve, dirname, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import ts from 'typescript';
 import { RUN_ACTION_ALLOWLIST, RUN_ACTION_MIGRATION_BACKLOG } from '../runActionAllowlist';
@@ -24,6 +27,8 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const SRC_ROOT = resolve(__dirname, '../..'); // apps/web/src
 const WEB_ROOT = SRC_ROOT;
 const REPO_ROOT = resolve(WEB_ROOT, '../../..');
+const API_ROOT = resolve(SRC_ROOT, 'lib/api');
+const FIXTURE_ROOT = resolve(__dirname, 'fixtures/no-silent-mutations/src');
 
 // WS-A "targeted set": files that have ADOPTED runAction and must not regress
 // to silent mutations. Grows as more handlers migrate (see the backlog).
@@ -208,6 +213,11 @@ const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
 const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
 
 type Violation = { line: number; snippet: string };
+type TypeAwareContext = {
+  sourceFile: ts.SourceFile;
+  checker: ts.TypeChecker;
+  apiRoot: string;
+};
 
 function calleeName(expr: ts.Expression): string | null {
   if (ts.isIdentifier(expr)) return expr.text;
@@ -268,6 +278,52 @@ function isWrappedByRunAction(node: ts.Node): boolean {
   return false;
 }
 
+function resolvedSymbolAt(node: ts.Node, checker: ts.TypeChecker): ts.Symbol | undefined {
+  let symbol = checker.getSymbolAtLocation(node);
+  const seen = new Set<ts.Symbol>();
+  while (symbol && symbol.flags & ts.SymbolFlags.Alias && !seen.has(symbol)) {
+    seen.add(symbol);
+    const target = checker.getAliasedSymbol(symbol);
+    if (target === symbol) break;
+    symbol = target;
+  }
+  return symbol;
+}
+
+function isInside(root: string, file: string): boolean {
+  const normalizedRoot = resolve(root);
+  const normalizedFile = resolve(file);
+  return normalizedFile === normalizedRoot || normalizedFile.startsWith(`${normalizedRoot}${sep}`);
+}
+
+/** Whether an imported lib/api export's implementation issues a mutation. */
+function isMutatingApiWrapper(call: ts.CallExpression, context: TypeAwareContext): boolean {
+  const symbol = resolvedSymbolAt(call.expression, context.checker);
+  if (!symbol) return false;
+
+  return (symbol.declarations ?? []).some((declaration) => {
+    if (!isInside(context.apiRoot, declaration.getSourceFile().fileName)) return false;
+
+    let mutates = false;
+    const visit = (node: ts.Node): void => {
+      if (mutates) return;
+      if (
+        ts.isCallExpression(node) &&
+        calleeName(node.expression) === 'fetchWithAuth' &&
+        isMutatingCall(node) &&
+        !isWrappedByRunAction(node) &&
+        !isExempt(declaration.getSourceFile().text, node)
+      ) {
+        mutates = true;
+        return;
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(declaration);
+    return mutates;
+  });
+}
+
 function enclosingStatementStart(node: ts.Node): number {
   let cur: ts.Node = node;
   while (
@@ -292,13 +348,25 @@ function isExempt(src: string, node: ts.Node): boolean {
   return /runaction-exempt/i.test(window);
 }
 
-function findViolations(src: string, label = 'sample.tsx'): Violation[] {
-  const sf = ts.createSourceFile(label, src, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+function findViolations(
+  src: string,
+  label = 'sample.tsx',
+  context?: TypeAwareContext,
+): Violation[] {
+  const sf = context?.sourceFile ??
+    ts.createSourceFile(label, src, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
   const violations: Violation[] = [];
 
   const visit = (node: ts.Node): void => {
-    if (ts.isCallExpression(node) && calleeName(node.expression) === 'fetchWithAuth') {
-      if (isMutatingCall(node) && !isWrappedByRunAction(node) && !isExempt(src, node)) {
+    if (ts.isCallExpression(node)) {
+      const directMutation =
+        calleeName(node.expression) === 'fetchWithAuth' && isMutatingCall(node);
+      const wrapperMutation = Boolean(context && isMutatingApiWrapper(node, context));
+      if (
+        (directMutation || wrapperMutation) &&
+        !isWrappedByRunAction(node) &&
+        !isExempt(src, node)
+      ) {
         const { line } = sf.getLineAndCharacterOfPosition(node.getStart());
         violations.push({
           line: line + 1,
@@ -371,6 +439,29 @@ describe('guard self-checks (AST analyzer)', () => {
     expect(entry).toBeDefined();
     expect(allowAbsolute.has(resolve(REPO_ROOT, entry.file))).toBe(true);
   });
+
+  it('flags an imported typed mutation wrapper through aliases and API re-exports', () => {
+    const componentPath = resolve(FIXTURE_ROOT, 'components/QuoteActions.tsx');
+    const apiRoot = resolve(FIXTURE_ROOT, 'lib/api');
+    const program = ts.createProgram({
+      rootNames: [componentPath],
+      options: {
+        module: ts.ModuleKind.ESNext,
+        moduleResolution: ts.ModuleResolutionKind.Bundler,
+        target: ts.ScriptTarget.ES2022,
+        jsx: ts.JsxEmit.ReactJSX,
+      },
+    });
+    const sourceFile = program.getSourceFile(componentPath);
+    expect(sourceFile).toBeDefined();
+    expect(
+      findViolations(sourceFile!.text, componentPath, {
+        sourceFile: sourceFile!,
+        checker: program.getTypeChecker(),
+        apiRoot,
+      }),
+    ).toHaveLength(1);
+  });
 });
 
 // ─── Backlog integrity check ─────────────────────────────────────────────────
@@ -389,6 +480,15 @@ describe('migration backlog integrity', () => {
 
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
+  const configPath = resolve(WEB_ROOT, '..', 'tsconfig.json');
+  const config = ts.readConfigFile(configPath, ts.sys.readFile);
+  if (config.error) {
+    throw new Error(ts.flattenDiagnosticMessageText(config.error.messageText, '\n'));
+  }
+  const parsedConfig = ts.parseJsonConfigFileContent(config.config, ts.sys, dirname(configPath));
+  const program = ts.createProgram({ rootNames: absoluteFiles, options: parsedConfig.options });
+  const checker = program.getTypeChecker();
+
   it('finds files to scan', () => {
     // 104: 99 since #3989 added OrganizationsPage.tsx, plus MergeOrgModal.tsx
     // (org-lifecycle Wave 3), plus ArchiveOrgModal.tsx (org-lifecycle Wave 5),
@@ -407,8 +507,14 @@ describe('no silent mutations in targeted set', () => {
     if (allowAbsolute.has(absPath)) continue; // whole-file allowlisted — skip
 
     it(`${webRelLabel}: every mutating fetchWithAuth is wrapped by runAction or explicitly exempt`, () => {
-      const src = readFileSync(absPath, 'utf8');
-      const violations = findViolations(src, webRelLabel);
+      const sourceFile = program.getSourceFile(absPath);
+      expect(sourceFile).toBeDefined();
+      const src = sourceFile!.text;
+      const violations = findViolations(src, webRelLabel, {
+        sourceFile: sourceFile!,
+        checker,
+        apiRoot: API_ROOT,
+      });
       expect(
         violations,
         violations.length

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -17,8 +17,8 @@
  * re-exports, instead of relying on a hand-maintained wrapper-name list.
  */
 import { describe, it, expect } from 'vitest';
-import { statSync } from 'node:fs';
-import { resolve, dirname, sep } from 'node:path';
+import { readFileSync, statSync } from 'node:fs';
+import { resolve, dirname, sep, extname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import ts from 'typescript';
 import { RUN_ACTION_ALLOWLIST, RUN_ACTION_MIGRATION_BACKLOG } from '../runActionAllowlist';
@@ -486,7 +486,13 @@ describe('no silent mutations in targeted set', () => {
     throw new Error(ts.flattenDiagnosticMessageText(config.error.messageText, '\n'));
   }
   const parsedConfig = ts.parseJsonConfigFileContent(config.config, ts.sys, dirname(configPath));
-  const program = ts.createProgram({ rootNames: absoluteFiles, options: parsedConfig.options });
+  // .astro files aren't a script kind the TS compiler recognizes, so it never
+  // includes them in the program — only feed it files TS can natively parse
+  // (.ts/.tsx). Anything else (e.g. .astro) falls back to the legacy
+  // no-program, no-wrapper-resolution scan below.
+  const TS_NATIVE_EXTENSIONS = new Set(['.ts', '.tsx']);
+  const programFiles = absoluteFiles.filter((f) => TS_NATIVE_EXTENSIONS.has(extname(f)));
+  const program = ts.createProgram({ rootNames: programFiles, options: parsedConfig.options });
   const checker = program.getTypeChecker();
 
   it('finds files to scan', () => {
@@ -508,13 +514,12 @@ describe('no silent mutations in targeted set', () => {
 
     it(`${webRelLabel}: every mutating fetchWithAuth is wrapped by runAction or explicitly exempt`, () => {
       const sourceFile = program.getSourceFile(absPath);
-      expect(sourceFile).toBeDefined();
-      const src = sourceFile!.text;
-      const violations = findViolations(src, webRelLabel, {
-        sourceFile: sourceFile!,
-        checker,
-        apiRoot: API_ROOT,
-      });
+      // Files the TS compiler doesn't natively parse (e.g. .astro) are never
+      // in the program — fall back to the legacy standalone-parse scan
+      // (direct fetchWithAuth calls only, no lib/api wrapper resolution).
+      const violations = sourceFile
+        ? findViolations(sourceFile.text, webRelLabel, { sourceFile, checker, apiRoot: API_ROOT })
+        : findViolations(readFileSync(absPath, 'utf8'), webRelLabel);
       expect(
         violations,
         violations.length


### PR DESCRIPTION
## What

`no-silent-mutations` (`apps/web/src/lib/__tests__/no-silent-mutations.test.ts`) only recognized *lexical* `fetchWithAuth(...)` calls with a mutating method. Mutations routed through typed `lib/api/*` wrappers (the established convention for quotes/invoices/contracts/catalog) were invisible to the guard — demonstrated in #3501's review, where replacing both `runAction(...)` blocks in `QuoteActions.tsx` with bare `await`s left the whole web suite, including this guard, green.

## Fix

The guard now builds a real `ts.Program` over the targeted set, resolves each `fetchWithAuth` call site's callee through the TypeScript checker (following aliased imports and re-exports), and — for any call that resolves to a declaration under `src/lib/api/` — inspects that wrapper's body for an unwrapped mutating `fetchWithAuth`. If found, the *call site* is flagged exactly as a direct mutation would be, subject to the same `runAction`/`runaction-exempt`/allowlist rules as before.

A new fixture-based self-check (`fixtures/no-silent-mutations/src/...`) proves the resolution path: a component importing a renamed re-export of a mutating wrapper is correctly flagged.

**Extra fix beyond the original patch:** the type-aware `ts.Program` only understands `.ts`/`.tsx`, but `TARGET_GLOBS` grew to include `src/pages/approvals.astro` after this fix was first drafted (#4380 review, Sept 1). Feeding an `.astro` path into `ts.createProgram` silently drops it, so `program.getSourceFile()` returned `undefined` and the guard threw. Fixed by filtering the program's `rootNames` to native TS extensions and falling back to the legacy standalone-parse scan (direct `fetchWithAuth` only, no wrapper resolution) for anything the program doesn't cover.

## Verification

- `apps/web`: `pnpm exec vitest run src/lib/__tests__/no-silent-mutations.test.ts --pool=threads --maxWorkers=2` — 119/119 passed.
- Manually reproduced the exact regression from #3501's review: replaced the `runAction(...)` wrapper around `sendQuote(...)` in the real `QuoteActions.tsx` with a bare `await` — guard went **red**, flagging the call site. Reverted — guard is **green** again.
- `npx tsc --noEmit -p apps/web` — clean.
- `npx astro check` (apps/web) — 0 errors (pre-existing unrelated warnings only).
- `runActionAllowlist.ts` untouched — allowlist semantics preserved.

Closes #3503

🤖 Generated with [Claude Code](https://claude.com/claude-code)