### PR TITLE
docs: correct self-hosted server sizing table with real baseline (#3959)

### DIFF
--- a/apps/docs/src/content/docs/getting-started/prerequisites.mdx
+++ b/apps/docs/src/content/docs/getting-started/prerequisites.mdx
@@ -18,20 +18,20 @@ This table covers the Breeze **server** (API, web, PostgreSQL, Redis, and the re
 |---|---|---|
 | **CPU** | 2 x86-64 vCPU | 4 vCPU |
 | **RAM** | 4 GiB | 8 GiB |
-| **Disk** | 20 GB SSD | 60 GB SSD, plus snapshot headroom |
+| **Disk** | 20 GiB free in the install directory | 60 GiB SSD-backed, plus snapshot headroom |
 | **OS** | Ubuntu 22.04+ / Debian 12+ | Ubuntu 24.04 LTS |
-| **Network** | Public IP, ports 80/443 open | Static IP with DNS A record |
+| **Network** | Public IP, ports 80/443 open, NTP | Static IP with DNS A record, TLS reverse proxy, NTP |
 
-The **Floor** column is what [`guided-setup.sh`](https://github.com/LanternOps/breeze/blob/main/scripts/guided-setup.sh) checks before install and warns below — it's a warning threshold the script enforces, not a tested capacity limit. Breeze will start below it, but expect resource pressure as your fleet grows.
+The **CPU / RAM / Disk Floor** values are what [`guided-setup.sh`](https://github.com/LanternOps/breeze/blob/main/scripts/guided-setup.sh) checks before install: below them it warns and, without an explicit "continue anyway" (defaulted to no, including in unattended `--yes` runs), the install stops. They're a warning threshold, not a tested capacity limit. The OS and Network rows are general recommendations — the script doesn't check them.
 
-The **Baseline** column is a real-world small-MSP data point, contributed via [#3930](https://github.com/LanternOps/breeze/issues/3930): a two-person MSP running Breeze on TrueNAS SCALE settled on 4 vCPU / 8 GiB RAM / 60 GB SSD, plus extra headroom for snapshots. The jump from the 20 GB disk floor reflects PostgreSQL, Redis's append-only file, container images, logs, upgrade image churn, and (on ZFS) snapshots all competing for the same volume — 20 GB leaves little margin for any of that.
+The **CPU / RAM / Disk Baseline** values are a real-world small-MSP data point, contributed via [#3930](https://github.com/LanternOps/breeze/issues/3930): a two-person MSP settled on 4 vCPU / 8 GiB RAM / 60 GiB SSD, plus extra headroom for snapshots. The jump from the 20 GiB disk floor reflects PostgreSQL, Redis's append-only file, container images, logs, upgrade image churn, and (on ZFS) snapshots all competing for the same volume — 20 GiB leaves little margin for any of that.
 
-Breeze publishes **amd64/x86-64** server images only; there is no arm64 server build.
+Breeze does not publish arm64 server images — GHCR images are amd64 only. On Apple Silicon, use `docker-compose.override.yml.local-build` to build native arm64 images instead (see [Docker Deployment](/deploy/environment/#docker-deployment)).
 
 <Aside type="note" title="No per-agent sizing formula">
-There isn't yet enough controlled data to turn "N agents" into a hardware number, and a made-up formula would be worse than admitting the gap — people size hardware purchases against it. Validate your sizing against actual agent count, event volume, retention window, remote-control usage, and backup policy, and scale up if you see resource pressure.
+There isn't yet enough controlled data to turn "N agents" into a hardware number. Validate your sizing against actual agent count, event volume, retention window, remote-control usage, and backup policy, and scale up if you see resource pressure.
 
-Redis in particular ships with a `256mb` default `maxmemory` and a `noeviction` policy (see [`REDIS_MAXMEMORY`](/deploy/environment/#redis)) — job data queues rather than getting silently dropped, but a fleet outgrowing the default will need it raised, or writes start failing. If you have real-world sizing data for your fleet size, [open an issue](https://github.com/LanternOps/breeze/issues/new) — we'd like to build this table out with more data points.
+Redis in particular ships with a `256mb` default `maxmemory` and a `noeviction` policy (see [`REDIS_MAXMEMORY`](/deploy/environment/#docker-deployment)) — job data queues rather than getting silently dropped, but a fleet outgrowing the default will need it raised, or writes start failing. If you have real-world sizing data for your fleet size, [open an issue](https://github.com/LanternOps/breeze/issues/new) — we'd like to build this table out with more data points.
 </Aside>
 
 ## Required Software

--- a/apps/docs/src/content/docs/getting-started/prerequisites.mdx
+++ b/apps/docs/src/content/docs/getting-started/prerequisites.mdx
@@ -6,17 +6,33 @@ sidebar:
   label: Prerequisites
 ---
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { Tabs, TabItem, Aside } from '@astrojs/starlight/components';
 
 ## Server Requirements
 
-| Resource | Minimum | Recommended (500+ agents) |
+<Aside type="caution" title="Server sizing only">
+This table covers the Breeze **server** (API, web, PostgreSQL, Redis, and the reverse proxy). It says nothing about agent-side footprint on the machines you're monitoring, which is separate and much smaller.
+</Aside>
+
+| Resource | Floor | Baseline (small MSP) |
 |---|---|---|
-| **CPU** | 2 vCPU | 4 vCPU |
-| **RAM** | 4 GB | 8 GB |
-| **Disk** | 40 GB SSD | 100 GB SSD |
+| **CPU** | 2 x86-64 vCPU | 4 vCPU |
+| **RAM** | 4 GiB | 8 GiB |
+| **Disk** | 20 GB SSD | 60 GB SSD, plus snapshot headroom |
 | **OS** | Ubuntu 22.04+ / Debian 12+ | Ubuntu 24.04 LTS |
 | **Network** | Public IP, ports 80/443 open | Static IP with DNS A record |
+
+The **Floor** column is what [`guided-setup.sh`](https://github.com/LanternOps/breeze/blob/main/scripts/guided-setup.sh) checks before install and warns below — it's a warning threshold the script enforces, not a tested capacity limit. Breeze will start below it, but expect resource pressure as your fleet grows.
+
+The **Baseline** column is a real-world small-MSP data point, contributed via [#3930](https://github.com/LanternOps/breeze/issues/3930): a two-person MSP running Breeze on TrueNAS SCALE settled on 4 vCPU / 8 GiB RAM / 60 GB SSD, plus extra headroom for snapshots. The jump from the 20 GB disk floor reflects PostgreSQL, Redis's append-only file, container images, logs, upgrade image churn, and (on ZFS) snapshots all competing for the same volume — 20 GB leaves little margin for any of that.
+
+Breeze publishes **amd64/x86-64** server images only; there is no arm64 server build.
+
+<Aside type="note" title="No per-agent sizing formula">
+There isn't yet enough controlled data to turn "N agents" into a hardware number, and a made-up formula would be worse than admitting the gap — people size hardware purchases against it. Validate your sizing against actual agent count, event volume, retention window, remote-control usage, and backup policy, and scale up if you see resource pressure.
+
+Redis in particular ships with a `256mb` default `maxmemory` and a `noeviction` policy (see [`REDIS_MAXMEMORY`](/deploy/environment/#redis)) — job data queues rather than getting silently dropped, but a fleet outgrowing the default will need it raised, or writes start failing. If you have real-world sizing data for your fleet size, [open an issue](https://github.com/LanternOps/breeze/issues/new) — we'd like to build this table out with more data points.
+</Aside>
 
 ## Required Software
 

--- a/scripts/docs-review/mapping.json
+++ b/scripts/docs-review/mapping.json
@@ -2402,7 +2402,10 @@
     {
       "pattern": "apps/web/src/components/billing/quotes/QuoteContractBlockEditor.tsx",
       "docs": [
-        "features/quotes.mdx"
+        "features/quotes.mdx",
+      "pattern": "scripts/guided-setup.sh",
+      "docs": [
+        "getting-started/prerequisites.mdx"
       ]
     }
   ]

--- a/scripts/docs-review/mapping.json
+++ b/scripts/docs-review/mapping.json
@@ -218,7 +218,8 @@
     {
       "pattern": "docker-compose*.yml",
       "docs": [
-        "deploy/production.mdx"
+        "deploy/production.mdx",
+        "getting-started/prerequisites.mdx"
       ]
     },
     {
@@ -2402,7 +2403,10 @@
     {
       "pattern": "apps/web/src/components/billing/quotes/QuoteContractBlockEditor.tsx",
       "docs": [
-        "features/quotes.mdx",
+        "features/quotes.mdx"
+      ]
+    },
+    {
       "pattern": "scripts/guided-setup.sh",
       "docs": [
         "getting-started/prerequisites.mdx"


### PR DESCRIPTION
## Summary

- The `getting-started/prerequisites.mdx` "Server Requirements" table gave `40 GB` min / `100 GB` recommended disk figures gated on a "500+ agents" tier that was never sourced from `scripts/guided-setup.sh` or any measured deployment — it silently invented a per-agent sizing formula, which is exactly what this issue asks us not to do.
- Replace it with the two sources of truth we actually have:
  - **Floor** — `scripts/guided-setup.sh:22-25`'s warning thresholds (2 vCPU / 4 GiB RAM / 20 GB disk), explicitly labeled as a warning threshold the script enforces, not a tested capacity limit.
  - **Baseline** — the real small-MSP data point from [#3930](https://github.com/LanternOps/breeze/issues/3930) that ToddHebebrand supplied on this issue (4 vCPU / 8 GiB RAM / 60 GB SSD + snapshot headroom).
- Adds an explicit "no per-agent sizing formula" callout (per the issue's instruction not to invent one), including the Redis `256mb maxmemory` / `noeviction` note and a link to `REDIS_MAXMEMORY` in `deploy/environment.mdx`.
- Adds a caveat that the table covers the server only, not agent-side footprint.
- Maps `scripts/guided-setup.sh` → `getting-started/prerequisites.mdx` in `scripts/docs-review/mapping.json` so future threshold changes flag this doc for review.

Docs-only change. No code, no per-agent formula invented — per the issue's explicit instruction.

Closes #3959

## Test plan

- [x] `cd apps/docs && npx astro build` — 167 pages built clean, `getting-started/prerequisites/index.html` generated with no MDX errors.
- [x] Manually reviewed the diff for factual accuracy against `scripts/guided-setup.sh:22-25` and the issue's 2026-08-25 comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)