### PR TITLE
docs(billing): document contract templates and quote contract blocks (#3487)

### DIFF
--- a/apps/docs/src/content/docs/features/contracts.mdx
+++ b/apps/docs/src/content/docs/features/contracts.mdx
@@ -109,12 +109,43 @@ Select contracts using the checkboxes in the contract list to reveal a bulk acti
 
 Actions run per-item in isolation, so partial success is possible.
 
+## Contract Templates
+
+Separate from the recurring-billing contracts above, Breeze keeps a library of **contract templates** -- the legal-document text (or an uploaded PDF) you attach to a quote for the customer to review and effectively sign as part of accepting a proposal. Open **Contracts → Templates** to manage the library.
+
+A template is owned either by your whole partner (usable on any customer's quotes) or by a single organization, chosen when you create it.
+
+### Creating a Template
+
+<Steps>
+1. Go to **Contracts → Templates** and click **New template**.
+2. Name it and choose its owner: your **partner** (available to every organization) or one **organization** (available only there).
+3. Add a version -- either **author** the document as rich text directly in Breeze, or **upload a PDF** (up to 10MB). An uploaded file must be a readable, unencrypted PDF.
+4. **Publish** the version once it's ready to use on quotes.
+</Steps>
+
+### Versions
+
+Each template can have multiple versions. A new version starts as a **draft** you can keep editing; **publishing** it locks the content and assigns it a version number -- published versions are immutable, so a template already attached to a quote never changes underneath the customer. To revise a published template, add another version and publish that one; existing quotes stay pinned to whichever version they were attached with (see [Contract blocks](/features/quotes/#contract-blocks) in the quote editor).
+
+**Archive** a template to stop it from being used on new quotes. Archiving doesn't touch versions already attached to existing quotes or the executed documents generated from them.
+
+### Variables
+
+An authored template can include `{{variable}}` placeholders that Breeze fills in per quote when the block is rendered or sent. Each placeholder is either:
+
+- **Auto** -- filled automatically from the quote, with no data entry required. The built-in auto variables are the customer's name and address, your organization's (seller) name, the quote number and title, the one-time/monthly/annual/total amounts, and the effective and expiry dates.
+- **Manual** -- anything else. The technician attaching the template to a quote fills these in by hand (for example, a scope note or a specific term).
+
+Publishing a version scans its body for `{{variable}}` tokens and classifies each one automatically -- a name that matches a built-in auto variable is treated as auto, everything else as manual.
+
 ## Permissions
 
-Contract access is governed by role permissions: viewing requires contract read access, creating and editing requires contract write access, and lifecycle actions (activate, pause, resume, cancel) require contract management access. Assign these through **Settings → Users & Roles**.
+Contract access is governed by role permissions: viewing requires contract read access, creating and editing requires contract write access, and lifecycle actions (activate, pause, resume, cancel) require contract management access. The same permissions gate the contract template library. Assign these through **Settings → Users & Roles**.
 
 ## Related
 
 - [Invoices](/features/invoices/) -- where generated invoices land
 - [Product Catalog](/features/product-catalog/) -- link contract lines to catalog items
 - [Online Payments](/features/online-payments/) -- let customers pay generated invoices online
+- [Quotes → Contract blocks](/features/quotes/#contract-blocks) -- attach a contract template to a quote

--- a/apps/docs/src/content/docs/features/quotes.mdx
+++ b/apps/docs/src/content/docs/features/quotes.mdx
@@ -170,12 +170,33 @@ Beyond priced line items, a quote body can contain content blocks that turn it i
 | **Rich text** | Scope, assumptions, terms — formatted paragraphs, lists, and headings |
 | **Table** | Comparison grids, schedules, responsibility matrices |
 | **Callout** | Pulling out a caveat, an inclusion, or a deadline |
+| **Contract** | Attaching a template from your [contract template library](/features/contracts/#contract-templates) for the customer to review as part of the proposal |
 
 Tables and callouts are edited **in place** on the quote itself, so what you see while editing is what the customer receives — no round trip through a PDF to check the result.
 
 <Aside>
   Rich text is sanitized before it is stored. If you paste markup Breeze does not allow, it tells you what was stripped rather than silently discarding it.
 </Aside>
+
+### Contract blocks
+
+A **Contract** block attaches a document from your [contract template library](/features/contracts/#contract-templates) to a quote, so the customer reviews (and, by accepting the quote, effectively agrees to) that document alongside the priced lines.
+
+<Steps>
+1. Add a **Contract** block and choose a **template** and, if the template has more than one, a **published version**.
+2. Optionally give the block a **label** (shown instead of the template's name).
+3. If the template declares any **manual variables**, fill them in -- Breeze won't let you add the block with one left blank.
+</Steps>
+
+The block pins to the **specific published version** you picked at attach time -- it doesn't automatically follow later edits to the template. If a newer version of the same template is published afterward, the block shows an **Update to vN** button so you can re-pin it deliberately; nothing changes until you click it.
+
+**Variables** are resolved when the block renders: auto variables (customer name/address, your organization's name, quote number/title, totals, dates) come from the quote automatically; manual variables use whatever you entered when you attached (or last edited) the block. An uploaded-PDF template has no variables -- it's attached as-is.
+
+<Aside type="caution">
+  **Send is blocked while any contract block has an unresolved variable.** If a manual variable is left blank -- for example, after switching a block to a newer template version that added one -- Breeze refuses to send the quote until every declared variable on every contract block has a value. The block editor lists which ones are still missing.
+</Aside>
+
+When the customer **accepts** a quote with contract blocks, Breeze freezes each block's rendered content (an authored template's substituted text, or an uploaded PDF as-is) into a permanent, standalone **contract document** -- the record of exactly what the customer saw and agreed to at that moment, unaffected by any later edits to the template. Executed contract documents can be downloaded as PDF from the **Contracts → Documents** tab, or from the related recurring contract's own detail page if one was linked.
 
 ## Cloning a Quote
 
@@ -205,4 +226,5 @@ Quote access is governed by role permissions: viewing requires quote read access
 - [Product Catalog](/features/product-catalog/) -- the price list quotes pull from
 - [Invoices](/features/invoices/) -- where an accepted quote's one-time charges land, deposit first
 - [Recurring Contracts](/features/contracts/) -- where an accepted quote's recurring lines become agreements
+- [Recurring Contracts → Contract Templates](/features/contracts/#contract-templates) -- manage the document library contract blocks attach
 - [Online Payments](/features/online-payments/) -- let customers pay the deposit and balance by card

--- a/apps/docs/src/content/docs/features/quotes.mdx
+++ b/apps/docs/src/content/docs/features/quotes.mdx
@@ -183,12 +183,12 @@ Tables and callouts are edited **in place** on the quote itself, so what you see
 A **Contract** block attaches a document from your [contract template library](/features/contracts/#contract-templates) to a quote, so the customer reviews (and, by accepting the quote, effectively agrees to) that document alongside the priced lines.
 
 <Steps>
-1. Add a **Contract** block and choose a **template** and, if the template has more than one, a **published version**.
+1. Add a **Contract** block and choose a **template**. Breeze attaches its **latest published version** -- there's no separate version picker, and a template with no published version yet can't be attached.
 2. Optionally give the block a **label** (shown instead of the template's name).
 3. If the template declares any **manual variables**, fill them in -- Breeze won't let you add the block with one left blank.
 </Steps>
 
-The block pins to the **specific published version** you picked at attach time -- it doesn't automatically follow later edits to the template. If a newer version of the same template is published afterward, the block shows an **Update to vN** button so you can re-pin it deliberately; nothing changes until you click it.
+The block pins to **whichever published version was latest at attach time** -- it doesn't automatically follow later edits to the template. If a newer version of the same template is published afterward, the block shows an **Update to vN** button so you can re-pin it to that newer version deliberately; nothing changes until you click it.
 
 **Variables** are resolved when the block renders: auto variables (customer name/address, your organization's name, quote number/title, totals, dates) come from the quote automatically; manual variables use whatever you entered when you attached (or last edited) the block. An uploaded-PDF template has no variables -- it's attached as-is.
 

--- a/scripts/docs-review/mapping.json
+++ b/scripts/docs-review/mapping.json
@@ -2353,6 +2353,57 @@
       "docs": [
         "features/ai-agents.mdx"
       ]
+    },
+    {
+      "pattern": "apps/api/src/services/contractTemplateService.ts",
+      "docs": [
+        "features/contracts.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/services/contractTemplateRender.ts",
+      "docs": [
+        "features/contracts.mdx",
+        "features/quotes.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/services/contractDocumentService.ts",
+      "docs": [
+        "features/contracts.mdx",
+        "features/quotes.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/db/schema/contractDocuments.ts",
+      "docs": [
+        "features/contracts.mdx",
+        "reference/schema.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/api/src/routes/contracts/templates.ts",
+      "docs": [
+        "features/contracts.mdx"
+      ]
+    },
+    {
+      "pattern": "packages/shared/src/validators/contractTemplates.ts",
+      "docs": [
+        "features/contracts.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/web/src/components/contracts/TemplatesTab.tsx",
+      "docs": [
+        "features/contracts.mdx"
+      ]
+    },
+    {
+      "pattern": "apps/web/src/components/billing/quotes/QuoteContractBlockEditor.tsx",
+      "docs": [
+        "features/quotes.mdx"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

`apps/docs` had zero coverage of the contract-document feature set that quotes rely on for signature/acceptance flows:

- The contract template library and its draft → publish (immutable) versioning lifecycle
- `{{variable}}` substitution in authored templates (auto-populated vs. manually filled variables)
- Attaching a contract block to a quote and pinning it to a specific published version
- The send-time gate that blocks sending a quote while any declared contract variable is unresolved
- Executed contract documents generated (and frozen) on quote acceptance

`features/contracts.mdx` only documented the recurring-lines → draft-contracts billing path; `features/quotes.mdx` didn't mention contract blocks at all.

## Changes

- **`apps/docs/src/content/docs/features/contracts.mdx`** — new "Contract Templates" section: creating a template (partner-wide or org-owned), authoring vs. PDF-upload versions, the draft/publish immutability model, and the auto/manual variable split (with the built-in auto variables).
- **`apps/docs/src/content/docs/features/quotes.mdx`** — added "Contract" to the content-block table, and a new "Contract blocks" section: attaching a template to a quote, version pinning + the "Update to vN" nudge, variable resolution, the unresolved-variable send gate, and executed contract documents on acceptance.
- **`scripts/docs-review/mapping.json`** — registered the contract-template service/route/schema/web source files against the two docs pages so future sweeps pick them up.

Content was written directly from the current implementation (`apps/api/src/services/contractTemplateService.ts`, `contractTemplateRender.ts`, `contractDocumentService.ts`, `apps/api/src/routes/contracts/templates.ts`, `apps/api/src/db/schema/contractDocuments.ts`, `packages/shared/src/validators/contractTemplates.ts`, and the web UI in `apps/web/src/components/contracts/` and `apps/web/src/components/billing/quotes/QuoteContractBlockEditor.tsx`) — not invented.

## Verification

- `pnpm --filter docs build` — 167 pages built, no MDX errors; confirmed the two new sections render in the built HTML output.
- `pnpm --filter docs check` (astro check) — 0 errors, 0 warnings, 0 hints.
- `scripts/docs-review/mapping.json` validated as JSON; diff is additive only (no reformatting of existing entries).

Closes #3487

🤖 Generated with [Claude Code](https://claude.com/claude-code)