### PR TITLE
test(security): exercise the 'upgrade present' half of the apk hardening guard (#4271)

### DIFF
--- a/apps/api/src/config/dockerfileOpensslUpgrade.test.ts
+++ b/apps/api/src/config/dockerfileOpensslUpgrade.test.ts
@@ -134,6 +134,27 @@ function checkApkPolicy(source: string) {
   }
 }
 
+/**
+ * Unlike checkApkPolicy (--check-apk, which only calls reject_unaudited_apk
+ * and therefore never reaches the require_grep "upgrade must be present" half
+ * of require_audited_openssl_upgrade), this invokes --require-openssl-upgrade
+ * so both halves of the credential-boundary rule run. See issue #4271.
+ */
+function checkOpensslUpgradePolicy(source: string) {
+  const directory = mkdtempSync(path.join(tmpdir(), 'breeze-openssl-upgrade-policy-'));
+  const dockerfile = path.join(directory, 'Dockerfile');
+  writeFileSync(dockerfile, source);
+  try {
+    return spawnSync(
+      'bash',
+      [path.join(REPO_ROOT, HARDENING_SCRIPT), '--require-openssl-upgrade', dockerfile],
+      { encoding: 'utf8' },
+    );
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
 interface Stage {
   /** Lowercased `AS` alias, or undefined for an unnamed stage. */
   alias?: string;
@@ -317,8 +338,63 @@ describe('Dockerfile OpenSSL upgrade coverage', () => {
     }
     for (const source of rejected) {
       const result = checkApkPolicy(source);
-      expect(result.status, `unexpectedly accepted: ${source}`).not.toBe(0);
+      // A bare `.not.toBe(0)` is satisfied by any non-zero exit — including
+      // status null (spawnSync failure) or 127 (missing script) — which would
+      // stay green even if the script started failing rejected inputs for an
+      // unrelated reason (a `set -u` trip, an arg-handling regression, a
+      // bash-version difference in CI). Pin the exact exit code and the
+      // specific rejection reason so only the intended policy failure passes.
+      expect(result.error, `harness failed to run the policy: ${source}`).toBeUndefined();
+      expect(result.status, `unexpectedly accepted: ${source}`).toBe(1);
+      expect(result.stderr, `wrong rejection reason: ${source}`).toMatch(
+        /contains an unaudited apk invocation/,
+      );
     }
+  });
+
+  it('exercises the "upgrade must be present" half via --require-openssl-upgrade', () => {
+    // --check-apk (used by checkApkPolicy above) calls reject_unaudited_apk
+    // directly and never reaches the require_grep call inside
+    // require_audited_openssl_upgrade. Deleting that require_grep call left
+    // the whole suite green until this test was added (issue #4271) — a
+    // read-executor Dockerfile that silently lost its OpenSSL upgrade would
+    // pass the full hardening script undetected.
+    const good = [
+      'FROM node:24-alpine@sha256:' + 'a'.repeat(64) + ' AS runner',
+      'RUN apk upgrade --no-cache libcrypto3 libssl3 && \\',
+      '    rm -rf /tmp',
+    ].join('\n');
+    const result = checkOpensslUpgradePolicy(good);
+    expect(result.error, 'harness failed to run the policy').toBeUndefined();
+    expect(result.status, result.stderr).toBe(0);
+
+    const missing = [
+      'FROM node:24-alpine@sha256:' + 'a'.repeat(64) + ' AS runner',
+      'CMD ["node", "index.js"]',
+    ].join('\n');
+    const missingResult = checkOpensslUpgradePolicy(missing);
+    expect(missingResult.error, 'harness failed to run the policy').toBeUndefined();
+    expect(missingResult.status, 'no upgrade line: unexpectedly accepted').toBe(1);
+    expect(missingResult.stderr).toMatch(/must contain exactly: apk upgrade --no-cache libcrypto3 libssl3/);
+
+    const commentedOut = [
+      'FROM node:24-alpine@sha256:' + 'a'.repeat(64) + ' AS runner',
+      '# RUN apk upgrade --no-cache libcrypto3 libssl3',
+      'CMD ["node", "index.js"]',
+    ].join('\n');
+    const commentedResult = checkOpensslUpgradePolicy(commentedOut);
+    expect(commentedResult.error, 'harness failed to run the policy').toBeUndefined();
+    expect(commentedResult.status, 'commented-out upgrade: unexpectedly accepted').toBe(1);
+    expect(commentedResult.stderr).toMatch(/must contain exactly: apk upgrade --no-cache libcrypto3 libssl3/);
+
+    const halfPresent = [
+      'FROM node:24-alpine@sha256:' + 'a'.repeat(64) + ' AS runner',
+      'RUN apk upgrade --no-cache libcrypto3',
+    ].join('\n');
+    const halfResult = checkOpensslUpgradePolicy(halfPresent);
+    expect(halfResult.error, 'harness failed to run the policy').toBeUndefined();
+    expect(halfResult.status, 'half-present upgrade: unexpectedly accepted').toBe(1);
+    expect(halfResult.stderr).toMatch(/contains an unaudited apk invocation/);
   });
 
   it('accepts the two packages in either order, and rejects a non-upgrade mention', () => {

--- a/scripts/security/check-supply-chain-hardening.sh
+++ b/scripts/security/check-supply-chain-hardening.sh
@@ -76,6 +76,16 @@ if [[ "${1:-}" == "--check-apk" ]]; then
   exit 0
 fi
 
+# Unlike --check-apk (which only exercises the "no unaudited apk invocation"
+# half via reject_unaudited_apk), this exercises the full credential-boundary
+# rule including the "the audited upgrade line is actually present" half
+# (require_grep inside require_audited_openssl_upgrade) — see issue #4271.
+if [[ "${1:-}" == "--require-openssl-upgrade" ]]; then
+  [[ -n "${2:-}" && -f "${2:-}" && -r "${2:-}" ]] || fail "--require-openssl-upgrade needs a readable Dockerfile"
+  require_audited_openssl_upgrade "$2"
+  exit 0
+fi
+
 extract_yaml_job() {
   local job="$1"
   local workflow="$2"


### PR DESCRIPTION
## Summary

The apk credential-boundary guard (`scripts/security/check-supply-chain-hardening.sh`) has two test-side gaps flagged in #4271:

1. **`--check-apk` mode never exercises the "upgrade present" half.** It calls `reject_unaudited_apk` directly, never `require_audited_openssl_upgrade`'s `require_grep` call. Deleting that `require_grep` call left the whole vitest suite green (verified by mutation before/after this fix — see test plan).
2. **Rejection assertions carried no discriminating power.** `dockerfileOpensslUpgrade.test.ts` asserted only `.not.toBe(0)`, which is satisfied by a `spawnSync` harness failure (`status: null`) or a missing-script exit (`127`) just as much as by the intended policy rejection.

## Changes

- `scripts/security/check-supply-chain-hardening.sh`: add a `--require-openssl-upgrade` mode that runs the full `require_audited_openssl_upgrade` rule (both `reject_unaudited_apk` and the `require_grep` presence check), parallel to the existing `--check-apk` mode.
- `apps/api/src/config/dockerfileOpensslUpgrade.test.ts`:
  - New `checkOpensslUpgradePolicy` helper invoking `--require-openssl-upgrade`.
  - New test exercising missing / commented-out / half-present / correct upgrade fixtures against the full rule, asserting both exit code and the specific stderr reason.
  - Tightened `'rejects every apk mutation except the exact two-package repair'` to assert `result.error` is undefined, `result.status === 1`, and `result.stderr` matches `/contains an unaudited apk invocation/`, instead of the previous bare `.not.toBe(0)`.

Test-only change; the shipped control itself is unmodified in behavior (the new script mode is additive — `--check-apk` and `require_audited_openssl_upgrade` are untouched).

## Coordination with in-flight PRs

Two other open PRs touch the same two files:
- #4422 (#4272): adds the actions executor to `CREDENTIAL_BOUNDARY_DOCKERFILES` + a `require_audited_openssl_upgrade "$ACTIONS_EXECUTOR_DOCKERFILE"` script block, around `check-supply-chain-hardening.sh:353+` (M365 actions-executor section).
- #4409 (#4362): adds a compose-config behavioral check around `check-supply-chain-hardening.sh:679+` (monitoring overlay section).

This PR's script edit is scoped to the top of the file (the `--check-apk`/`--require-openssl-upgrade` mode dispatch, right after `require_audited_openssl_upgrade`'s definition, before `extract_yaml_job`), and its test edit only adds a new helper/test and tightens one existing assertion — no shared lines with either PR's diff. Should merge cleanly after either lands.

## Test plan

- `pnpm exec vitest run src/config/dockerfileOpensslUpgrade.test.ts --pool=threads --maxWorkers=2` — 17/17 passing.
- Mutation check: manually deleted the `require_grep` call from `require_audited_openssl_upgrade` in the script, re-ran the suite — the new test went red (`expected +0 to be 1`) exactly as the issue predicted, confirming it closes the gap. Restored the script and re-ran — 17/17 green again.
- `shellcheck scripts/security/check-supply-chain-hardening.sh` — clean.
- `npx eslint apps/api/src/config/dockerfileOpensslUpgrade.test.ts` — clean.
- `node --max-old-space-size=8192 ./node_modules/typescript/bin/tsc --noEmit -p .` (apps/api) — clean (plain `tsc --noEmit` OOMs on this monorepo's default heap regardless of this change; increasing heap resolves it).

Closes #4271

🤖 Generated with [Claude Code](https://claude.com/claude-code)