### PR TITLE
fix(quotes): theme PDF header fonts, tighten docTheme type, fix vacuous test (#3546)

### DIFF
--- a/apps/api/src/services/quotePdf.ts
+++ b/apps/api/src/services/quotePdf.ts
@@ -751,13 +751,13 @@ async function renderCoverPage(
 
   const preparedForName = cp.preparedForName ?? quote.billToName ?? null;
   if (preparedForName) {
-    doc.fillColor('#9ca3af').fontSize(9).font('Helvetica-Bold').text('PREPARED FOR', c.left, rowY);
-    doc.fillColor('#111827').fontSize(12).font('Helvetica-Bold').text(preparedForName, c.left, rowY + 14, { width: colW });
+    doc.fillColor('#9ca3af').fontSize(9).font(fonts.heading.bold).text('PREPARED FOR', c.left, rowY);
+    doc.fillColor('#111827').fontSize(12).font(fonts.heading.bold).text(preparedForName, c.left, rowY + 14, { width: colW });
     // Start the address at the name's real bottom edge (doc.y) — a name long
     // enough to wrap painted the address on top of its second line when this
     // assumed a fixed one-line name height.
     let addrY = Math.max(rowY + 30, doc.y + 4);
-    doc.fillColor('#4b5563').fontSize(9).font('Helvetica');
+    doc.fillColor('#4b5563').fontSize(9).font(fonts.body.regular);
     for (const line of addressLines(quote.billToAddress as BillToAddress | null)) {
       doc.text(line, c.left, addrY, { width: colW });
       addrY += 12;
@@ -768,10 +768,10 @@ async function renderCoverPage(
   // explicit `false` as "show" so a legacy/loosely-typed value degrades safely.
   if (cp.showPreparedBy !== false) {
     const seller = (quote.sellerSnapshot as SellerSnapshot | null) ?? null;
-    doc.fillColor('#9ca3af').fontSize(9).font('Helvetica-Bold').text('PREPARED BY', rightX, rowY);
-    doc.fillColor('#111827').fontSize(12).font('Helvetica-Bold').text(seller?.name ?? partnerName, rightX, rowY + 14, { width: colW });
+    doc.fillColor('#9ca3af').fontSize(9).font(fonts.heading.bold).text('PREPARED BY', rightX, rowY);
+    doc.fillColor('#111827').fontSize(12).font(fonts.heading.bold).text(seller?.name ?? partnerName, rightX, rowY + 14, { width: colW });
     let addrY = Math.max(rowY + 30, doc.y + 4); // same wrap-safe start as PREPARED FOR
-    doc.fillColor('#4b5563').fontSize(9).font('Helvetica');
+    doc.fillColor('#4b5563').fontSize(9).font(fonts.body.regular);
     for (const line of sellerAddressLines(seller)) {
       doc.text(line, rightX, addrY, { width: colW });
       addrY += 12;
@@ -848,10 +848,10 @@ export async function renderQuotePdf(
   const rightX = c.left + c.contentWidth * 0.55;
   const rightW = c.contentWidth * 0.45;
 
-  doc.fillColor('#9ca3af').fontSize(9).font('Helvetica-Bold').text('FROM', c.left, y);
-  doc.fillColor('#111827').fontSize(12).font('Helvetica-Bold').text(seller?.name ?? partnerName, c.left, y + 12, { width: c.contentWidth * 0.5 });
+  doc.fillColor('#9ca3af').fontSize(9).font(fonts.heading.bold).text('FROM', c.left, y);
+  doc.fillColor('#111827').fontSize(12).font(fonts.heading.bold).text(seller?.name ?? partnerName, c.left, y + 12, { width: c.contentWidth * 0.5 });
   let fromY = doc.y + 2;
-  doc.fillColor('#4b5563').fontSize(10).font('Helvetica');
+  doc.fillColor('#4b5563').fontSize(10).font(fonts.body.regular);
   for (const aline of sellerAddressLines(seller)) {
     doc.text(aline, c.left, fromY, { width: c.contentWidth * 0.5 });
     fromY = doc.y + 1.5;
@@ -863,17 +863,17 @@ export async function renderQuotePdf(
 
   let billY = y;
   if (quote.billToName) {
-    doc.fillColor('#9ca3af').fontSize(9).font('Helvetica-Bold').text('PREPARED FOR', rightX, billY, { width: rightW });
-    doc.fillColor('#111827').fontSize(12).font('Helvetica-Bold').text(quote.billToName, rightX, billY + 12, { width: rightW });
+    doc.fillColor('#9ca3af').fontSize(9).font(fonts.heading.bold).text('PREPARED FOR', rightX, billY, { width: rightW });
+    doc.fillColor('#111827').fontSize(12).font(fonts.heading.bold).text(quote.billToName, rightX, billY + 12, { width: rightW });
     billY = doc.y + 2;
   }
-  doc.fillColor('#4b5563').fontSize(10).font('Helvetica');
+  doc.fillColor('#4b5563').fontSize(10).font(fonts.body.regular);
   for (const aline of addressLines(quote.billToAddress as BillToAddress | null)) {
     doc.text(aline, rightX, billY, { width: rightW });
     billY = doc.y + 1.5;
   }
   if (quote.billToTaxId) { doc.fillColor('#6b7280').fontSize(9).text(`Tax ID: ${quote.billToTaxId}`, rightX, billY, { width: rightW }); billY = doc.y + 1.5; }
-  doc.fillColor('#4b5563').fontSize(10).font('Helvetica');
+  doc.fillColor('#4b5563').fontSize(10).font(fonts.body.regular);
   if (quote.issueDate) { doc.text(`Issued: ${formatDate(quote.issueDate)}`, rightX, billY, { width: rightW }); billY = doc.y + 2; }
   if (quote.expiryDate) { doc.text(`Valid until: ${formatDate(quote.expiryDate)}`, rightX, billY, { width: rightW }); billY = doc.y + 2; }
 

--- a/apps/api/src/services/quotePdf.ts
+++ b/apps/api/src/services/quotePdf.ts
@@ -882,7 +882,7 @@ export async function renderQuotePdf(
 
   // Intro notes, if any (above the blocks).
   if (quote.introNotes) {
-    doc.fillColor('#4b5563').fontSize(10).font('Helvetica').text(quote.introNotes, c.left, y, { width: c.contentWidth });
+    doc.fillColor('#4b5563').fontSize(10).font(fonts.body.regular).text(quote.introNotes, c.left, y, { width: c.contentWidth });
     y = doc.y + 14;
   }
 
@@ -955,7 +955,7 @@ export async function renderQuotePdf(
         }
         const caption = (b.content as { caption?: string }).caption;
         if (caption) {
-          doc.fillColor('#6b7280').fontSize(9).font('Helvetica').text(caption, c.left, y, { width: c.contentWidth });
+          doc.fillColor('#6b7280').fontSize(9).font(fonts.body.regular).text(caption, c.left, y, { width: c.contentWidth });
           y = doc.y;
         }
         doc.fillColor('#111827');
@@ -1028,8 +1028,8 @@ export async function renderQuotePdf(
   // ---- Terms & Conditions --------------------------------------------------
   if (quote.termsAndConditions) {
     y = ensureSpace(doc, y + 14, 60);
-    doc.fillColor('#9ca3af').fontSize(9).font('Helvetica-Bold').text('TERMS & CONDITIONS', c.left, y); y = doc.y + 4;
-    doc.fillColor('#6b7280').fontSize(9).font('Helvetica').text(quote.termsAndConditions, c.left, y, { width: c.contentWidth });
+    doc.fillColor('#9ca3af').fontSize(9).font(fonts.heading.bold).text('TERMS & CONDITIONS', c.left, y); y = doc.y + 4;
+    doc.fillColor('#6b7280').fontSize(9).font(fonts.body.regular).text(quote.termsAndConditions, c.left, y, { width: c.contentWidth });
     y = doc.y;
   }
 
@@ -1038,7 +1038,7 @@ export async function renderQuotePdf(
   // footer band below, on EVERY page.
   if (quote.terms) {
     y = ensureSpace(doc, y + 14, 60);
-    doc.fillColor('#9ca3af').fontSize(9).font('Helvetica').text(quote.terms, c.left, y, { width: c.contentWidth });
+    doc.fillColor('#9ca3af').fontSize(9).font(fonts.body.regular).text(quote.terms, c.left, y, { width: c.contentWidth });
   }
 
   // ---- Per-page footer band: branding footer + quote number + page X of Y ---

--- a/apps/portal/src/components/portal/documentShell.tsx
+++ b/apps/portal/src/components/portal/documentShell.tsx
@@ -7,6 +7,7 @@
 import { markChipClass, type MarkTone } from './ui';
 import type { ReactNode } from 'react';
 import { sellerLines } from '@/lib/sellerLines';
+import type { DocumentThemeId } from '@breeze/shared';
 
 export interface DocSeller {
   name: string | null;
@@ -25,7 +26,7 @@ export interface DocSeller {
  *  call site. */
 export function DocumentPaper({
   children, testId, docTheme,
-}: { primaryColor?: string | null; children: ReactNode; testId?: string; docTheme?: string | null }) {
+}: { primaryColor?: string | null; children: ReactNode; testId?: string; docTheme?: DocumentThemeId | null }) {
   return (
     <div
       data-testid={testId}

--- a/apps/portal/src/lib/api.ts
+++ b/apps/portal/src/lib/api.ts
@@ -7,7 +7,7 @@ import { navigateTo } from './navigation';
 // Invoice-domain enum SSOT lives in @breeze/shared (billing-enums.ts). Imported
 // into local scope for the InvoiceSummary/InvoiceDetail types below and re-exported
 // (type-only, erased at build) so '@/lib/api' consumers are unaffected.
-import type { DocumentThemeId, InvoiceStatus, PublicQuoteHeader, QuotePresentation, TicketFormField } from '@breeze/shared';
+import type { DocumentPageSize, DocumentThemeId, InvoiceStatus, PublicQuoteHeader, QuotePresentation, TicketFormField } from '@breeze/shared';
 
 // Client API base. Empty (the default) → same-origin **relative** requests
 // (`/api/v1/...`), which the reverse proxy routes to the API under `/api/*`. This
@@ -658,7 +658,7 @@ export interface PublicInvoiceDetail {
     logoUrl: string | null;
     primaryColor: string | null;
     theme: DocumentThemeId;
-    pageSize: string;
+    pageSize: DocumentPageSize;
   };
 }
 

--- a/apps/portal/src/lib/api.ts
+++ b/apps/portal/src/lib/api.ts
@@ -7,7 +7,7 @@ import { navigateTo } from './navigation';
 // Invoice-domain enum SSOT lives in @breeze/shared (billing-enums.ts). Imported
 // into local scope for the InvoiceSummary/InvoiceDetail types below and re-exported
 // (type-only, erased at build) so '@/lib/api' consumers are unaffected.
-import type { InvoiceStatus, PublicQuoteHeader, QuotePresentation, TicketFormField } from '@breeze/shared';
+import type { DocumentThemeId, InvoiceStatus, PublicQuoteHeader, QuotePresentation, TicketFormField } from '@breeze/shared';
 
 // Client API base. Empty (the default) → same-origin **relative** requests
 // (`/api/v1/...`), which the reverse proxy routes to the API under `/api/*`. This
@@ -657,7 +657,7 @@ export interface PublicInvoiceDetail {
     contactEmail: string | null;
     logoUrl: string | null;
     primaryColor: string | null;
-    theme: string;
+    theme: DocumentThemeId;
     pageSize: string;
   };
 }

--- a/packages/shared/src/validators/quotes.test.ts
+++ b/packages/shared/src/validators/quotes.test.ts
@@ -285,7 +285,19 @@ describe('table block content', () => {
     expect(quoteBlockInputSchema.safeParse(bad).success).toBe(false);
   });
   it('rejects >8 columns, >100 rows, oversized cells, bad weight', () => {
-    const cols9 = { ...valid, content: { ...valid.content, columns: Array.from({ length: 9 }, () => ({ label: 'c' })), rows: [] } };
+    // A real row with 9 cells matching the 9 columns — cells.length ===
+    // columns.length, and rows.min(1) is satisfied — so the only remaining
+    // violation is columns.max(8). An empty `rows: []` here would fail
+    // rows.min(1) first, passing this assertion even if columns.max(8) were
+    // deleted from the schema.
+    const cols9 = {
+      ...valid,
+      content: {
+        ...valid.content,
+        columns: Array.from({ length: 9 }, () => ({ label: 'c' })),
+        rows: [{ cells: Array.from({ length: 9 }, () => 'x') }],
+      },
+    };
     expect(quoteBlockInputSchema.safeParse(cols9).success).toBe(false);
     const bigCell = structuredClone(valid); bigCell.content.rows[0].cells[0] = 'x'.repeat(2001);
     expect(quoteBlockInputSchema.safeParse(bigCell).success).toBe(false);

--- a/packages/shared/src/validators/quotes.test.ts
+++ b/packages/shared/src/validators/quotes.test.ts
@@ -299,6 +299,10 @@ describe('table block content', () => {
       },
     };
     expect(quoteBlockInputSchema.safeParse(cols9).success).toBe(false);
+    // Same discipline for the row cap: 101 rows of 2 cells each (matching
+    // `valid`'s 2 columns), so the only violation is rows.max(100).
+    const rows101 = { ...valid, content: { ...valid.content, rows: Array.from({ length: 101 }, () => ({ cells: ['a', 'b'] })) } };
+    expect(quoteBlockInputSchema.safeParse(rows101).success).toBe(false);
     const bigCell = structuredClone(valid); bigCell.content.rows[0].cells[0] = 'x'.repeat(2001);
     expect(quoteBlockInputSchema.safeParse(bigCell).success).toBe(false);
     for (const weight of [0, -1, 1.5, Infinity, 11]) {


### PR DESCRIPTION
## Summary

Three small follow-ups from the proposal presentation system final review (#3526 / #3535 / #3539 / #3545):

- **Condensed theme: PDF header/terms labels still Helvetica.** `apps/api/src/services/quotePdf.ts` — the FROM / PREPARED FOR / PREPARED BY header block (cover-page renderer + main render's first-page header), plus the intro notes, image caption, and TERMS & CONDITIONS block, hard-coded `Helvetica`/`Helvetica-Bold` instead of the resolved theme fonts, so a condensed document rendered these next to Barlow Condensed headings (mixed-font blocks). Swapped to `fonts.heading.bold` / `fonts.body.regular`, matching the convention already used for the title and PROPOSAL eyebrow elsewhere in the same function. `classic` resolves to the same Helvetica strings, so the classic regression harness (`quotePdf.classicRegression.test.ts`) is byte-for-byte unchanged. `renderLineTable`/`renderRecurringSummary`'s own hard-coded fonts (line-item table rendering) are a separate, larger change — `renderLineTable` doesn't currently take a `fonts` param — tracked in #4438.
- **`documentShell.tsx` `docTheme` typed as bare `string`.** Tightened `DocumentPaper`'s `docTheme` prop to `DocumentThemeId | null` (from `@breeze/shared`, mirroring `apps/api/src/services/documentThemes.ts`'s server-side source of truth) so a typo'd theme id fails the build instead of silently falling through to `classic`. This surfaced that `PublicInvoiceDetail.branding.theme` (and, for consistency, its sibling `pageSize`) in `apps/portal/src/lib/api.ts` were also bare `string` — tightened both to `DocumentThemeId`/`DocumentPageSize`.
- **Vacuous 9-column validator test.** `packages/shared/src/validators/quotes.test.ts` — the `cols9` case (rejects >8 columns) used `rows: []`, which fails the schema's `rows.min(1)` before `columns.max(8)` is ever evaluated, so the assertion passed even with the column cap deleted. Replaced with a real row of 9 cells matching the 9 columns so the only remaining violation is the column cap. Also added the same-technique `rows.max(100)` case the test's own name promised but never covered.

Scoped tightly to avoid conflicting with open PR #4408 (also touching `quotePdf.ts`, in the `doc.image()` catch blocks / cover-image save-restore `finally` — a disjoint region from this diff; verified with a three-way `git merge-file` — zero conflicts).

Not included (filed as follow-up #4438): the `renderLineTable`/`renderRecurringSummary` typography and the multi-run non-left-aligned-cell PDF table test gap — both larger changes than the items above.

Closes #3546
Refs #4438

## Test plan

- [x] `packages/shared`: `vitest run src/validators/quotes.test.ts` — 56 passed. Verified non-vacuous by temporarily removing `columns.max(8)` from the schema and confirming the `cols9` assertion goes red, then restoring it.
- [x] `apps/api`: `vitest run src/services/quotePdf.test.ts src/services/quotePdf.classicRegression.test.ts` — 51 passed (classic regression green).
- [x] `apps/portal`: `vitest run src/components/portal/PublicQuoteView.test.tsx src/components/portal/PublicQuoteView.superseded.test.tsx` — 11 passed.
- [x] `tsc --noEmit -p apps/api` — clean.
- [x] `tsc --noEmit -p apps/portal` — clean.
- [x] `eslint` on all four changed files — clean.
- [x] `tsc --noEmit -p packages/shared` reports 3 pre-existing errors in `quotes.test.ts` unrelated to this change (verified identical on unmodified `origin/main` via `git stash`).

## Review

Reviewed via `pr-review-toolkit:code-reviewer`. Two "Important" findings, both addressed in the second commit (extended the font swap to the terms/intro/caption block; filed #4438 for the genuinely out-of-scope remainder rather than leaving it unlinked under `Closes #3546`). Two "Minor" findings, both addressed (rows>100 test case; `pageSize` type tightening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)