### PR TITLE
fix(devices): detach ai_agent_runs.ticket_id on device org-move (#4215)

### DIFF
--- a/apps/api/migrations/2026-09-29-detach-ticket-runs-on-device-org-move.sql
+++ b/apps/api/migrations/2026-09-29-detach-ticket-runs-on-device-org-move.sql
@@ -1,0 +1,80 @@
+-- #4215 — detach ai_agent_runs.ticket_id on a device org-move.
+--
+-- breeze_cascade_device_org_id() (last replaced in
+-- 2026-09-20-ai-agents-anomaly-pilot.sql) severs the moved device's
+-- ai_agent_runs lineage pointers with a single `WHERE device_id = NEW.id`
+-- statement. That WHERE can never reach `ticket_id`: ticket-triggered runs are
+-- device-less (trigger_kind 'ticket' stamps ticket_id and leaves device_id
+-- NULL), yet `tickets` IS returned by breeze_device_child_orgid_tables(), so a
+-- ticket bound to the moved device is re-stamped to the destination org by the
+-- generic loop below while the run — whose org_id deliberately stays with the
+-- SOURCE org (owner decision 2026-08-23) — keeps pointing at a now-foreign
+-- ticket. Same cross-tenant-pointer class that #3828 fixed for
+-- anomaly_incident_id, recorded since then as a known gap in
+-- moveOrg.coverage.test.ts.
+--
+-- Fix: a second, ticket-keyed detach using the same
+-- `ticket_id IN (SELECT id FROM tickets WHERE device_id = ...)` join the
+-- route's ticket_attachments / time_entries / ticket_parts org rewrites
+-- already use. It reaches both the device-less ticket runs and device runs on
+-- the same ticket, and touches nothing whose ticket stays behind in the source
+-- org. Placed BEFORE the generic loop so both sides of the statement are still
+-- read pre-restamp, matching the metric_anomaly_incidents reverse pointer.
+--
+-- Mirrors the identical pair of statements in
+-- apps/api/src/routes/devices/moveOrg.ts (the route path); this function is
+-- the DB-side path for direct-SQL/non-route callers such as orgMerge. The two
+-- sites are held in sync by moveOrg.coverage.test.ts's "ai_agent_runs
+-- run-lineage detach coverage" block, which derives the expected column set
+-- from the ai_agent_runs schema's own FK columns and resolves the newest
+-- migration defining this function dynamically.
+--
+-- Full function body copied verbatim from 2026-09-20-ai-agents-anomaly-pilot
+-- (the newest definition; no later migration replaces this function) with only
+-- the ticket-keyed UPDATE added. CREATE OR REPLACE is idempotent by
+-- construction — re-applying this file re-installs the same body.
+CREATE OR REPLACE FUNCTION public.breeze_cascade_device_org_id()
+  RETURNS trigger
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = public, pg_catalog
+  AS $$
+DECLARE
+  child_table text;
+BEGIN
+  -- Agent-run history stays with the SOURCE org (owner decision 2026-08-23):
+  -- sever the moved device's lineage links instead of re-stamping org_id.
+  UPDATE public.ai_agent_runs
+    SET device_id = NULL, alert_id = NULL, session_id = NULL, anomaly_incident_id = NULL
+    WHERE device_id = NEW.id;
+  -- ticket_id is device-lineage too, but unreachable from `WHERE device_id`:
+  -- ticket-triggered runs carry a ticket_id with a NULL device_id. Key off the
+  -- ticket's device_id instead (#4215).
+  UPDATE public.ai_agent_runs
+    SET ticket_id = NULL
+    WHERE ticket_id IN (SELECT id FROM public.tickets WHERE device_id = NEW.id);
+  -- Reverse pointer: the incident's back-link to the (now-detached) run must
+  -- not keep naming a source-org run once the incident itself is re-stamped
+  -- to the destination org by the generic loop below.
+  UPDATE public.metric_anomaly_incidents
+    SET agent_run_id = NULL
+    WHERE device_id = NEW.id;
+  FOR child_table IN SELECT public.breeze_device_child_orgid_tables() LOOP
+    EXECUTE format(
+      'UPDATE public.%I SET org_id = $1 WHERE device_id = $2 AND org_id IS DISTINCT FROM $1',
+      child_table
+    ) USING NEW.org_id, NEW.id;
+  END LOOP;
+  RETURN NULL; -- AFTER trigger; return value ignored
+END;
+$$;
+
+-- Deliberately NO historical backfill of already-stale ticket_id values.
+-- ai_agent_runs is FORCE ROW LEVEL SECURITY, so a bare `UPDATE ... WHERE
+-- r.org_id IS DISTINCT FROM t.org_id` here would be subject to policy even for
+-- the table owner and, run without a breeze_* access context, would match zero
+-- rows — a cleanup that silently reports "0 cleaned" while leaving the rows in
+-- place is worse than none (it destroys the forensic signal a real count would
+-- carry). Any pre-fix rows are a read-only lineage pointer on run history the
+-- source org already owned; if a sweep is wanted it belongs in a scripted
+-- backfill run under a known access context, not in this migration.

--- a/apps/api/src/__tests__/integration/agentRunMoveSemantics.integration.test.ts
+++ b/apps/api/src/__tests__/integration/agentRunMoveSemantics.integration.test.ts
@@ -36,6 +36,7 @@ import {
   alerts,
   devices,
   metricAnomalyIncidents,
+  tickets,
 } from '../../db/schema';
 import type { NewActionIntent } from '../../db/schema/actionIntents';
 import { createAccessToken } from '../../services/jwt';
@@ -418,5 +419,130 @@ describe('agent-run move semantics (owner decision 2026-08-23)', () => {
     expect(movedRun.orgId).toBe(orgA.id);
     expect(movedRun.anomalyIncidentId).toBeNull();
     expect(movedRun.deviceId).toBeNull();
+  });
+
+  it('#4215: the REAL move route detaches ticket_id on device-less ticket runs, and only those', async () => {
+    // The fifth device-lineage FK. Unlike the four above it is unreachable
+    // from `WHERE device_id = <moved>`: a triage run on a ticket carries
+    // ticket_id with a NULL device_id (trigger_kind 'ticket'), so the
+    // device-keyed detach never sees it while `tickets` IS in
+    // getDeviceOrgDenormalizedTables() — the ticket follows the device to the
+    // target org and the retained source-org run is left naming a foreign
+    // ticket. Both the route and breeze_cascade_device_org_id() now run a
+    // second, ticket-keyed statement; this drives the route end to end.
+    //
+    // The second run/ticket pair is the discriminator: a ticket NOT bound to
+    // the moved device stays in the source org, so its run must keep its
+    // ticket_id. Without it a detach that simply nulled every ticket_id would
+    // pass this test.
+    const adminDb = getTestDb() as any;
+    const env = await setupTestEnvironment({ scope: 'partner' });
+    const { partner, organization: orgA, site: siteA, user, role } = env;
+    const orgB = await createOrganization({ partnerId: partner.id });
+    const siteB = await createSite({ orgId: orgB.id });
+
+    const device = await insertDevice(orgA.id, siteA.id);
+    const [agent] = await withSystemDbAccessContext(() =>
+      db
+        .insert(aiAgents)
+        .values({ orgId: orgA.id, partnerId: null, kind: 'triage', name: 'Triage', createdBy: user.id })
+        .returning(),
+    );
+
+    const unique = randomUUID().slice(0, 8);
+    const [ticketOnDevice] = await adminDb
+      .insert(tickets)
+      .values({
+        orgId: orgA.id,
+        partnerId: partner.id,
+        deviceId: device.id,
+        ticketNumber: `RUNMOVE-DEV-${unique}`,
+        subject: 'ticket bound to the moving device',
+        source: 'manual',
+      })
+      .returning();
+    const [ticketElsewhere] = await adminDb
+      .insert(tickets)
+      .values({
+        orgId: orgA.id,
+        partnerId: partner.id,
+        deviceId: null,
+        ticketNumber: `RUNMOVE-OTHER-${unique}`,
+        subject: 'ticket that stays in the source org',
+        source: 'manual',
+      })
+      .returning();
+
+    const [movingTicketRun, stayingTicketRun] = await withSystemDbAccessContext(() =>
+      db
+        .insert(aiAgentRuns)
+        .values([
+          {
+            ...runValues(agent!.id, orgA.id, `run-move-ticket-${randomUUID()}`),
+            triggerKind: 'ticket',
+            deviceId: null,
+            ticketId: ticketOnDevice.id,
+          },
+          {
+            ...runValues(agent!.id, orgA.id, `run-stay-ticket-${randomUUID()}`),
+            triggerKind: 'ticket',
+            deviceId: null,
+            ticketId: ticketElsewhere.id,
+          },
+        ])
+        .returning(),
+    );
+    // Guard the fixture itself: a device-less ticket run is the whole point.
+    expect(movingTicketRun!.deviceId).toBeNull();
+
+    const token = await createAccessToken({
+      sub: user.id,
+      email: user.email,
+      roleId: role.id,
+      orgId: null,
+      partnerId: partner.id,
+      scope: 'partner',
+      mfa: true,
+      aep: 1,
+      mep: 1,
+      sid: randomUUID(),
+    });
+
+    const app = new Hono();
+    app.route('/devices', moveOrgRoutes);
+    const res = await app.request(`/devices/${device.id}/move-org`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ orgId: orgB.id, siteId: siteB.id }),
+    });
+    expect(res.status, JSON.stringify(await res.clone().json())).toBe(200);
+
+    // The device's ticket followed it; the unrelated one did not.
+    const [movedTicket] = await adminDb
+      .select()
+      .from(tickets)
+      .where(eq(tickets.id, ticketOnDevice.id));
+    expect(movedTicket.orgId).toBe(orgB.id);
+    const [stayedTicket] = await adminDb
+      .select()
+      .from(tickets)
+      .where(eq(tickets.id, ticketElsewhere.id));
+    expect(stayedTicket.orgId).toBe(orgA.id);
+
+    // The run stayed home with ticket_id severed — no cross-tenant pointer.
+    const [detached] = await adminDb
+      .select()
+      .from(aiAgentRuns)
+      .where(eq(aiAgentRuns.id, movingTicketRun!.id));
+    expect(detached.orgId).toBe(orgA.id);
+    expect(detached.ticketId).toBeNull();
+
+    // ...and the run whose ticket never left is untouched.
+    const [untouched] = await adminDb
+      .select()
+      .from(aiAgentRuns)
+      .where(eq(aiAgentRuns.id, stayingTicketRun!.id));
+    expect(untouched.orgId).toBe(orgA.id);
+    expect(untouched.ticketId).toBe(ticketElsewhere.id);
   });
 });

--- a/apps/api/src/routes/devices/moveOrg.coverage.test.ts
+++ b/apps/api/src/routes/devices/moveOrg.coverage.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { getTableName } from 'drizzle-orm';
@@ -345,28 +345,26 @@ describe('DEVICE_SITE_DENORMALIZED_TABLES coverage', () => {
  * destination org — exactly the bug this blocker fixes for
  * `anomaly_incident_id`.
  *
- * The detach statement is duplicated in two places that must stay in sync:
- * moveOrg.ts's UPDATE and breeze_cascade_device_org_id()'s identical UPDATE
- * (the DB-side trigger, for direct-SQL/non-route callers). This block derives
- * the expected column set from the ai_agent_runs schema's own FK columns —
- * not a hand-maintained list — so the next FK added to this table cannot
- * silently skip both detach sites the way anomaly_incident_id did.
+ * The detach is duplicated in two places that must stay in sync: moveOrg.ts's
+ * UPDATEs and breeze_cascade_device_org_id()'s identical UPDATEs (the DB-side
+ * trigger, for direct-SQL/non-route callers). Each site needs TWO statements,
+ * not one: `WHERE device_id = <moved>` cannot reach `ticket_id`, because
+ * ticket-triggered runs are device-less (trigger_kind 'ticket' stamps
+ * ticket_id and leaves device_id NULL), so ticket_id is severed by its own
+ * `WHERE ticket_id IN (SELECT id FROM tickets WHERE device_id = <moved>)`
+ * statement — the same join shape the ticket_attachments / time_entries /
+ * ticket_parts org rewrites already use (#4215).
+ *
+ * This block derives the expected column set from the ai_agent_runs schema's
+ * own FK columns — not a hand-maintained list — and unions the SET clauses of
+ * EVERY ai_agent_runs UPDATE at each site, so the next FK added to this table
+ * cannot silently skip both detach sites the way anomaly_incident_id (#3828)
+ * and ticket_id (#4215) did.
  */
 describe('ai_agent_runs run-lineage detach coverage', () => {
   const runsCfg = getTableConfig(aiAgentRuns);
   const denormTableSet = new Set<string>(getDeviceOrgDenormalizedTables());
-
-  // KNOWN, pre-existing, NOT fixed by this change: `ticket_id` references
-  // `tickets`, which IS in getDeviceOrgDenormalizedTables() (tickets bound to
-  // the moved device are re-stamped to the destination org by the generic
-  // loop) — so by the same reasoning as anomaly_incident_id, a source-org run
-  // keeping its ticket_id would end up pointing at a now-foreign ticket too.
-  // That gap predates this PR (wave 6 PR 3, #3828) and is NOT one of the
-  // three review blockers this change fixes — flagged here instead of
-  // silently "fixed" as a scope change. Tracked for a follow-up; remove this
-  // entry (and stop excluding it below) once ticket_id is detached alongside
-  // device_id/alert_id/session_id/anomaly_incident_id in both sites.
-  const KNOWN_UNDETACHED_RUN_LINEAGE_COLUMNS: ReadonlySet<string> = new Set(['ticket_id']);
+  const MIGRATIONS_DIR = fileURLToPath(new URL('../../../migrations/', import.meta.url));
 
   // Columns that reference the run's OWN identity, not a row that moves WITH
   // the device — must stay untouched by device-lineage detach.
@@ -382,58 +380,106 @@ describe('ai_agent_runs run-lineage detach coverage', () => {
       const foreignTableName = getTableName(ref.foreignTable);
       const isDeviceLineage = foreignTableName === 'devices' || denormTableSet.has(foreignTableName);
       if (!isDeviceLineage) continue;
-      if (KNOWN_UNDETACHED_RUN_LINEAGE_COLUMNS.has(column.name)) continue;
       expected.push(column.name);
     }
     return expected.sort();
   }
 
-  function extractDetachColumns(sqlText: string): string[] {
-    // Matches `<col> = NULL` occurrences inside an UPDATE ai_agent_runs SET
-    // ... WHERE device_id = ... statement targeting a single row's lineage
-    // columns (not bulk org_id rewrites, which use `= <param>` not `= NULL`).
-    return [...sqlText.matchAll(/\b([a-z_]+)\s*=\s*NULL\b/g)].map((m) => m[1]!).sort();
+  /**
+   * SET clause of every `UPDATE <tableRef> ... WHERE ...` statement in `src`.
+   * Unioned rather than matched once because ticket_id is detached by its own
+   * statement (device-less ticket runs are unreachable from `WHERE device_id`).
+   */
+  function runUpdateSetClauses(src: string, tableRef: string): string[] {
+    return [...src.matchAll(new RegExp(`UPDATE ${tableRef}\\s+SET ([\\s\\S]*?)\\s*WHERE `, 'g'))].map(
+      (m) => m[1]!,
+    );
   }
 
-  it('sanity: the derived expected set is non-empty and contains the known lineage columns', () => {
+  function extractDetachColumns(setClauses: string[]): string[] {
+    // Matches `<col> = NULL` occurrences inside the SET clause of an
+    // `UPDATE ai_agent_runs` statement (not bulk org_id rewrites, which use
+    // `= <param>` not `= NULL`).
+    const columns = new Set<string>();
+    for (const clause of setClauses) {
+      for (const m of clause.matchAll(/\b([a-z_]+)\s*=\s*NULL\b/g)) columns.add(m[1]!);
+    }
+    return [...columns].sort();
+  }
+
+  /**
+   * Newest migration that (re)defines breeze_cascade_device_org_id(), resolved
+   * the same way autoMigrate applies files — filename `localeCompare` order,
+   * last definition wins. Resolved dynamically (not a hardcoded filename) so a
+   * later migration replacing the function again cannot leave this contract
+   * silently asserting a superseded definition.
+   */
+  function newestCascadeFunctionMigration(): { name: string; src: string } {
+    const definitions = readdirSync(MIGRATIONS_DIR)
+      .filter((name) => /^\d{4}-.*\.sql$/.test(name))
+      .sort((a, b) => a.localeCompare(b))
+      .map((name) => ({ name, src: readFileSync(`${MIGRATIONS_DIR}${name}`, 'utf8') }))
+      .filter(({ src }) => /CREATE OR REPLACE FUNCTION (public\.)?breeze_cascade_device_org_id/.test(src));
+    const newest = definitions.at(-1);
+    expect(newest, 'no migration defines breeze_cascade_device_org_id()').toBeTruthy();
+    return newest!;
+  }
+
+  const moveOrgSource = () =>
+    readFileSync(fileURLToPath(new URL('./moveOrg.ts', import.meta.url)), 'utf8');
+
+  it('sanity: the derived expected set is non-empty and contains every device-lineage column', () => {
     const expected = deriveExpectedDetachColumns();
     expect(expected.length).toBeGreaterThan(0);
     expect(expected).toEqual(
-      expect.arrayContaining(['device_id', 'alert_id', 'session_id', 'anomaly_incident_id']),
+      expect.arrayContaining([
+        'device_id',
+        'alert_id',
+        'session_id',
+        'anomaly_incident_id',
+        'ticket_id',
+      ]),
     );
   });
 
   it('moveOrg.ts detaches exactly the derived run-lineage columns', () => {
-    const moveOrgPath = fileURLToPath(new URL('./moveOrg.ts', import.meta.url));
-    const src = readFileSync(moveOrgPath, 'utf8');
-
-    const match = src.match(/UPDATE ai_agent_runs SET ([\s\S]*?)\s*WHERE device_id/);
+    const setClauses = runUpdateSetClauses(moveOrgSource(), 'ai_agent_runs');
     expect(
-      match,
-      'moveOrg.ts no longer has the expected "UPDATE ai_agent_runs SET ... WHERE device_id" statement — update this test if the statement shape changed intentionally',
-    ).toBeTruthy();
+      setClauses.length,
+      'moveOrg.ts no longer has any "UPDATE ai_agent_runs SET ... WHERE ..." statement — update this test if the statement shape changed intentionally',
+    ).toBeGreaterThan(0);
 
-    const actual = extractDetachColumns(match![1]!);
-    expect(actual).toEqual(deriveExpectedDetachColumns());
+    expect(extractDetachColumns(setClauses)).toEqual(deriveExpectedDetachColumns());
+  });
+
+  it('moveOrg.ts severs ticket_id through the tickets join, not WHERE device_id (#4215)', () => {
+    // Ticket-triggered runs carry ticket_id with a NULL device_id, so the
+    // device-keyed detach above cannot reach them. Keying off the ticket's
+    // device_id catches BOTH those and device-triggered runs on the same
+    // ticket, and touches nothing whose ticket stays in the source org.
+    expect(moveOrgSource()).toMatch(
+      /UPDATE ai_agent_runs SET ticket_id = NULL\s+WHERE ticket_id IN \(SELECT id FROM tickets WHERE device_id = \$\{deviceId\}::uuid\)/,
+    );
   });
 
   it('breeze_cascade_device_org_id() detaches exactly the derived run-lineage columns', () => {
-    // Newest definition of the function as of this PR — grep migrations/ for
-    // `CREATE OR REPLACE FUNCTION public.breeze_cascade_device_org_id` if this
-    // ever fails after a later migration replaces the function again.
-    const migrationPath = fileURLToPath(
-      new URL('../../../migrations/2026-09-20-ai-agents-anomaly-pilot.sql', import.meta.url),
-    );
-    const src = readFileSync(migrationPath, 'utf8');
-
-    const match = src.match(/UPDATE public\.ai_agent_runs\s+SET ([\s\S]*?)\s*WHERE device_id = NEW\.id/);
+    const { name, src } = newestCascadeFunctionMigration();
+    const setClauses = runUpdateSetClauses(src, 'public\\.ai_agent_runs');
     expect(
-      match,
-      'breeze_cascade_device_org_id() no longer has the expected ai_agent_runs detach statement',
-    ).toBeTruthy();
+      setClauses.length,
+      `${name} redefines breeze_cascade_device_org_id() but has no ai_agent_runs detach statement`,
+    ).toBeGreaterThan(0);
 
-    const actual = extractDetachColumns(match![1]!);
-    expect(actual).toEqual(deriveExpectedDetachColumns());
+    expect(
+      extractDetachColumns(setClauses),
+      `${name} is the newest definition of breeze_cascade_device_org_id() and its ai_agent_runs detach has drifted from moveOrg.ts / the schema's FK columns`,
+    ).toEqual(deriveExpectedDetachColumns());
+  });
+
+  it('breeze_cascade_device_org_id() severs ticket_id through the tickets join (#4215)', () => {
+    expect(newestCascadeFunctionMigration().src).toMatch(
+      /UPDATE public\.ai_agent_runs\s+SET ticket_id = NULL\s+WHERE ticket_id IN \(SELECT id FROM public\.tickets WHERE device_id = NEW\.id\)/,
+    );
   });
 });
 
@@ -454,9 +500,9 @@ describe('ai_agent_runs run-lineage detach coverage', () => {
  * trigger for direct-SQL/non-route callers) in this round — the controller
  * ruling scoped this fix to the moveOrg route only. A direct
  * `UPDATE devices SET org_id = ...` that bypasses the route would still leave
- * a stale scope_device_id; tracked as a known gap for a follow-up, same
- * pattern as this file's own `KNOWN_UNDETACHED_RUN_LINEAGE_COLUMNS` note for
- * ticket_id above.
+ * a stale scope_device_id; tracked as a known gap for a follow-up, the same
+ * way the ai_agent_runs `ticket_id` gap above was carried as a documented
+ * hole until #4215 closed it in both sites.
  */
 describe('action_intents.scope_device_id detach coverage', () => {
   it('moveOrg.ts tombstones scope_device_id for the moved device, scoped to live statuses', () => {

--- a/apps/api/src/routes/devices/moveOrg.test.ts
+++ b/apps/api/src/routes/devices/moveOrg.test.ts
@@ -499,6 +499,54 @@ describe('POST /devices/:id/move-org', () => {
       expect(idx('ticket_parts')).toBeLessThan(idx('ticket_attachments'));
     });
 
+    it('detaches ai_agent_runs.ticket_id via the tickets join, before tickets are re-stamped (#4215)', async () => {
+      vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue(SAMPLE_DEVICE as never);
+      rigOrgAndSiteSelects({
+        orgRows: [
+          { id: SOURCE_ORG, partnerId: 'partner-1' },
+          { id: TARGET_ORG, partnerId: 'partner-1' },
+        ],
+        siteRow: { id: TARGET_SITE },
+      });
+      const { statements } = rigTransactionSuccess();
+
+      const res = await app.request(`/devices/${DEVICE_ID}/move-org`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ orgId: TARGET_ORG, siteId: TARGET_SITE }),
+      });
+      expect(res.status).toBe(200);
+
+      // Agent-run history stays with the SOURCE org, so every FK pointing at a
+      // row that moves WITH the device must be severed. `ticket_id` is
+      // unreachable from the device-keyed detach: ticket-triggered runs carry
+      // a ticket_id with a NULL device_id, so they need their own statement
+      // keyed off the ticket's device_id.
+      const collapse = (s: string) => s.replace(/\s+/g, ' ').trim();
+      const runDetaches = statements
+        .filter((s) => s.startsWith('UPDATE ai_agent_runs '))
+        .map(collapse);
+      expect(
+        runDetaches,
+        `Expected the device-keyed run detach plus the ticket-keyed one.\nStatements:\n${statements.join('\n')}`,
+      ).toEqual([
+        'UPDATE ai_agent_runs SET device_id = NULL, alert_id = NULL, session_id = NULL, ' +
+          `anomaly_incident_id = NULL WHERE device_id = ${DEVICE_ID}::uuid`,
+        'UPDATE ai_agent_runs SET ticket_id = NULL ' +
+          `WHERE ticket_id IN (SELECT id FROM tickets WHERE device_id = ${DEVICE_ID}::uuid)`,
+      ]);
+
+      // The subselect resolves tickets by device_id, which the move never
+      // rewrites — but run it BEFORE the generic loop re-stamps tickets.org_id
+      // so both sides of the statement are still read under the SOURCE org,
+      // matching the metric_anomaly_incidents reverse-pointer ordering.
+      const detachIdx = statements.findIndex((s) => s.startsWith('UPDATE ai_agent_runs SET ticket_id'));
+      const ticketsIdx = statements.findIndex((s) => s.startsWith('UPDATE tickets '));
+      expect(detachIdx).toBeGreaterThanOrEqual(0);
+      expect(ticketsIdx).toBeGreaterThanOrEqual(0);
+      expect(detachIdx).toBeLessThan(ticketsIdx);
+    });
+
     it('rewrites time_entries org_id via the ticket join inside the transaction', async () => {
       vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue(SAMPLE_DEVICE as never);
       rigOrgAndSiteSelects({

--- a/apps/api/src/routes/devices/moveOrg.ts
+++ b/apps/api/src/routes/devices/moveOrg.ts
@@ -245,11 +245,30 @@ moveOrgRoutes.post(
         // re-stamped to the target org by the loop below, so a retained
         // source-org run keeping alert_id/session_id/anomaly_incident_id would
         // point across tenants (and /ai-agents/:id/runs would serve those
-        // foreign ids to the source org). All four FKs are ON DELETE SET NULL —
-        // nullable by design.
+        // foreign ids to the source org). ticket_id is the fifth such FK but
+        // needs a different WHERE — see the statement below. All five FKs are
+        // ON DELETE SET NULL — nullable by design.
         await tx.execute(
           sql`UPDATE ai_agent_runs SET device_id = NULL, alert_id = NULL, session_id = NULL, anomaly_incident_id = NULL
               WHERE device_id = ${deviceId}::uuid`,
+        );
+
+        // ticket_id is the fifth device-lineage FK and needs its OWN statement
+        // (#4215): `tickets` is in getDeviceOrgDenormalizedTables(), so a
+        // ticket bound to this device is re-stamped to the target org by the
+        // loop below — but ticket-triggered runs are device-less
+        // (trigger_kind 'ticket' stamps ticket_id and leaves device_id NULL),
+        // so the device-keyed detach above cannot reach them and the retained
+        // source-org run would keep pointing at a now-foreign ticket. Keying
+        // off the ticket's own device_id catches BOTH the device-less ticket
+        // runs and device runs on the same ticket, and touches nothing whose
+        // ticket stays behind in the source org. Same tickets-join shape as
+        // the ticket_attachments/time_entries/ticket_parts rewrites further
+        // down; runs BEFORE the loop for the same reason the reverse pointer
+        // below does, so both sides are still read under the SOURCE org.
+        await tx.execute(
+          sql`UPDATE ai_agent_runs SET ticket_id = NULL
+              WHERE ticket_id IN (SELECT id FROM tickets WHERE device_id = ${deviceId}::uuid)`,
         );
 
         // Reverse pointer: metric_anomaly_incidents.agent_run_id (no FK) must


### PR DESCRIPTION
Closes #4215.

## The gap

On a cross-org device move, `ai_agent_runs` history deliberately stays with the **source** org (owner decision 2026-08-23), so every FK pointing at a row that moves *with* the device has to be severed instead. Four were: `device_id`, `alert_id`, `session_id`, `anomaly_incident_id`.

`ticket_id` is the fifth, and it is **unreachable from `WHERE device_id = <moved>`** — a ticket-triggered run carries `ticket_id` with a **NULL `device_id`** (`trigger_kind = 'ticket'`). Meanwhile `tickets` *is* in `getDeviceOrgDenormalizedTables()`, so a ticket bound to the moved device is re-stamped to the destination org by the generic loop, and the retained source-org run is left naming a now-foreign ticket.

Exactly the cross-tenant-pointer class #3828 fixed for `anomaly_incident_id`; it has been carried since then as `KNOWN_UNDETACHED_RUN_LINEAGE_COLUMNS` in `moveOrg.coverage.test.ts`. That allowlist is now gone.

## The fix

A second, **ticket-keyed** statement at both detach sites, using the same `ticket_id IN (SELECT id FROM tickets WHERE device_id = ...)` join the `ticket_attachments` / `time_entries` / `ticket_parts` org rewrites already use. Keying off the *ticket's* `device_id` reaches both the device-less ticket runs and device runs on the same ticket, and touches nothing whose ticket stays behind in the source org.

| Site | Change |
|---|---|
| `apps/api/src/routes/devices/moveOrg.ts` | New UPDATE, placed **before** the denormalized-table loop so both sides are still read under the source org (same ordering rationale as the `metric_anomaly_incidents` reverse pointer). |
| `apps/api/migrations/2026-09-29-detach-ticket-runs-on-device-org-move.sql` | `CREATE OR REPLACE FUNCTION public.breeze_cascade_device_org_id()` — the DB-side path for direct-SQL/non-route callers such as `orgMerge`. Body copied verbatim from `2026-09-20-ai-agents-anomaly-pilot.sql` (the newest definition) with only the new statement added. Fix-forward; no shipped migration edited. |

**No historical backfill, deliberately.** `ai_agent_runs` is `FORCE ROW LEVEL SECURITY`, and the repo has a *Check Migrations (non-superuser)* CI job — a bare in-migration `UPDATE ... WHERE r.org_id IS DISTINCT FROM t.org_id` would be subject to policy with no `breeze_*` access context set, match zero rows, and report a misleading "0 cleaned". If a sweep is wanted it belongs in a scripted backfill under a known access context. Rationale is recorded in the migration itself.

## Test contract

The `ai_agent_runs run-lineage detach coverage` block keeps the two sites in sync by deriving the expected column set from the schema's **own FK columns** (not a hand list). Two changes were needed because the columns no longer live in a single statement:

- It now **unions the SET clauses of every `UPDATE ai_agent_runs`** at each site, rather than matching one statement.
- It **resolves the newest migration defining `breeze_cascade_device_org_id()` dynamically** (filename `localeCompare` order, the same way `autoMigrate` applies files) instead of by hardcoded filename — so a later redefinition can't leave the contract silently asserting a superseded body. That was a live footgun: the old test pointed at `2026-09-20-...` by name.

Plus targeted assertions at both sites that `ticket_id` is severed *through the tickets join*, not by a blanket `WHERE device_id`.

## Verification

Every claim below was run, not inferred.

**Red first.** With the tests written and no implementation, `moveOrg.coverage.test.ts` + `moveOrg.test.ts` were **5 failed / 42 passed**; after the fix, **47 passed**.

**Real Postgres, DB-side function** (throwaway container, minimal fixture, trigger fired via `UPDATE devices SET org_id`):

| Run | device-less ticket run | device run on same ticket | run whose ticket stays |
|---|---|---|---|
| pre-fix function | `ticket_id` **kept** | `ticket_id` **kept** | kept (correct) |
| this PR's function | `ticket_id` **NULL** | `ticket_id` **NULL** | **kept** (correct) |

Assertion `count(*) FROM ai_agent_runs r JOIN tickets t ON t.id = r.ticket_id WHERE r.org_id IS DISTINCT FROM t.org_id` → **2 pre-fix, 0 post-fix**.

**Integration test** (`agentRunMoveSemantics.integration.test.ts`, real DB, `breeze_app` NOSUPERUSER/NOBYPASSRLS so RLS is genuinely exercised) — drives `POST /devices/:id/move-org` end to end:

- New case green (5/5 in the file).
- Control: pre-fix trigger **and** route statement removed → the new case fails on exactly the `ticket_id` assertion, other 4 pass. The test discriminates.
- Second control: route statement restored, trigger still pre-fix → green, confirming the route-side statement is load-bearing on its own for the route path (the migration covers the non-route path).

**Migration applied in-set:** `pnpm db:migrate` against a fresh DB applied it **last** (`[auto-migrate] Applying: 2026-09-29-detach-ticket-runs-on-device-org-move.sql`), and re-applying the file is a no-op (`CREATE OR REPLACE`). `pnpm db:check-drift` → *"No drift detected — all 618 migration files match the breeze_migrations ledger."*

**Other:** `tsc --noEmit -p apps/api` clean; `eslint` on all four TS files clean; `autoMigrate.test.ts` 63 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMvN6SU3uwaaC7b2xmUa5m
