### PR TITLE
fix(web): make the FX approximate line report failure instead of vanishing (#4415)

### DIFF
--- a/apps/web/src/components/billing/shared/ApproximateMoneyLine.test.tsx
+++ b/apps/web/src/components/billing/shared/ApproximateMoneyLine.test.tsx
@@ -167,6 +167,27 @@ describe('ApproximateMoneyLine', () => {
     expect(fetchWithAuth).not.toHaveBeenCalled();
   });
 
+  // Both of these bodies PASS `useApproximateTotal.validate` — an empty array is
+  // still an array, a whitespace code is still a non-empty string — so they
+  // reach the component for real. The line must fall back to what it can prove
+  // rather than rendering "no  exchange rate for " (or nothing at all).
+  it('falls back to the generic failure when the server names NO codes', async () => {
+    fetchWithAuth.mockResolvedValue(jsonRes(unavailableBody([], [])));
+    render(<ApproximateMoneyLine byCurrency={BOOK} date="2026-08-21" />);
+    const line = await screen.findByTestId('approximate-money-line');
+    expect(line.textContent).toBe('≈ total unavailable — could not load exchange rates');
+    expect(line.dataset.approxState).toBe('unavailable');
+  });
+
+  it('falls back to the generic failure when the target currency is unusable', async () => {
+    const body = unavailableBody([{ currencyCode: 'NGN', reason: 'missing' }], ['NGN']);
+    fetchWithAuth.mockResolvedValue(jsonRes({ data: { ...body.data, targetCurrencyCode: '   ' } }));
+    render(<ApproximateMoneyLine byCurrency={BOOK} date="2026-08-21" />);
+    const line = await screen.findByTestId('approximate-money-line');
+    // Never "no  exchange rate for NGN": half a pair is not a fact.
+    expect(line.textContent).toBe('≈ total unavailable — could not load exchange rates');
+  });
+
   it('still shows NO figure in the unavailable state — no partial total, no 1:1', async () => {
     fetchWithAuth.mockResolvedValue(jsonRes(unavailableBody([{ currencyCode: 'EUR', reason: 'missing' }], ['EUR'])));
     const { container } = render(<ApproximateMoneyLine byCurrency={BOOK} date="2026-08-21" />);

--- a/apps/web/src/components/billing/shared/ApproximateMoneyLine.test.tsx
+++ b/apps/web/src/components/billing/shared/ApproximateMoneyLine.test.tsx
@@ -5,11 +5,17 @@ const fetchWithAuth = vi.fn();
 vi.mock('@/stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
 vi.mock('../../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
 
-// The en catalog entry lands with the rest of the locales in the wiring task;
-// pinning the template HERE proves the component passes exactly the
-// interpolations that entry consumes ({{amount}} and {{rateDate}}).
+// Pinning the templates HERE proves the component passes exactly the
+// interpolations each catalog entry consumes. The catalogs themselves are
+// exercised for real by `moneyRollupApproximate.test.tsx`, which renders the
+// seven surfaces against the shipped `en` file, and by the locale parity suite.
 const TEMPLATES: Record<string, string> = {
   'money.approximateTotal': '≈ {{amount}} approximate · rates as of {{rateDate}}',
+  'money.approximateUnavailableMissing': '≈ total unavailable — no {{target}} exchange rate for {{codes}}',
+  'money.approximateUnavailableStale': '≈ total unavailable — {{target}} exchange rate too old for {{codes}}',
+  'money.approximateUnavailableMixed': '≈ total unavailable — {{codes}} could not be converted to {{target}}',
+  'money.approximateUnavailableCodesOverflow': '{{codes}} and {{more}} more',
+  'money.approximateFailed': '≈ total unavailable — could not load exchange rates',
 };
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -53,6 +59,7 @@ describe('ApproximateMoneyLine', () => {
     await waitFor(() => expect(screen.getByTestId('approximate-money-line')).toBeInTheDocument());
     expect(screen.getByTestId('approximate-money-line').textContent)
       .toBe('≈ CA$22,940.00 approximate · rates as of 2026-08-21');
+    expect(screen.getByTestId('approximate-money-line').dataset.approxState).toBe('available');
   });
 
   it('renders NOTHING while the request is in flight', async () => {
@@ -63,18 +70,22 @@ describe('ApproximateMoneyLine', () => {
     expect(screen.queryByTestId('approximate-money-line')).toBeNull();
   });
 
-  it('renders NOTHING when the request fails — the segmentation above it is the answer', async () => {
+  // #4415: a failed request used to render nothing, so a self-hoster with no
+  // exchange-rate feed saw an approximate line that simply never appeared and
+  // had no way to learn why. The line must SAY it could not be produced.
+  it('renders a VISIBLE failure state when the request fails — never silence', async () => {
     fetchWithAuth.mockResolvedValue(jsonRes({ error: { code: 'BOOM' } }, 500));
-    const { container } = render(<ApproximateMoneyLine byCurrency={BOOK} date="2026-08-21" />);
-    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(container.innerHTML).toBe(''));
+    render(<ApproximateMoneyLine byCurrency={BOOK} date="2026-08-21" />);
+    const line = await screen.findByTestId('approximate-money-line');
+    expect(line.textContent).toBe('≈ total unavailable — could not load exchange rates');
+    expect(line.dataset.approxState).toBe('failed');
   });
 
-  it('renders NOTHING for a 409 NO_REPORTING_CURRENCY partner', async () => {
-    fetchWithAuth.mockResolvedValue(jsonRes({ error: { code: 'NO_REPORTING_CURRENCY' } }, 409));
+  it('never presents a figure in the failure state — no total, no naive 1:1 sum', async () => {
+    fetchWithAuth.mockResolvedValue(jsonRes({ error: { code: 'BOOM' } }, 500));
     const { container } = render(<ApproximateMoneyLine byCurrency={BOOK} date="2026-08-21" />);
-    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(container.innerHTML).toBe(''));
+    await screen.findByTestId('approximate-money-line');
+    expect(container.textContent).not.toMatch(/\d/);
   });
 
   it('renders NOTHING for a `not-needed` single-currency book — no shipped summary strip moves', async () => {
@@ -88,21 +99,89 @@ describe('ApproximateMoneyLine', () => {
     await waitFor(() => expect(container.innerHTML).toBe(''));
   });
 
-  it('renders NOTHING when the server reports `unavailable` — no placeholder, no partial total, no 1:1', async () => {
-    fetchWithAuth.mockResolvedValue(jsonRes({
-      data: {
-        ...AVAILABLE,
-        status: 'unavailable',
-        total: null,
-        rateDate: null,
-        unavailableCurrencyCodes: ['EUR'],
-      },
-    }));
+  const unavailableBody = (
+    groups: { currencyCode: string; reason?: 'missing' | 'stale' }[],
+    unavailableCurrencyCodes: string[],
+  ) => ({
+    data: {
+      ...AVAILABLE,
+      status: 'unavailable',
+      total: null,
+      rateDate: null,
+      groups: groups.map((g) => ({
+        currencyCode: g.currencyCode, amount: '1.00', convertedAmount: null,
+        rate: null, rateDate: null, source: null, ...(g.reason ? { reason: g.reason } : {}),
+      })),
+      unavailableCurrencyCodes,
+    },
+  });
+
+  it('NAMES the currency the server could not convert when it reports `unavailable`', async () => {
+    fetchWithAuth.mockResolvedValue(jsonRes(unavailableBody(
+      [{ currencyCode: 'USD' }, { currencyCode: 'NGN', reason: 'missing' }],
+      ['NGN'],
+    )));
+    render(<ApproximateMoneyLine byCurrency={BOOK} date="2026-08-21" />);
+    const line = await screen.findByTestId('approximate-money-line');
+    expect(line.textContent).toBe('≈ total unavailable — no CAD exchange rate for NGN');
+    expect(line.dataset.approxState).toBe('unavailable');
+  });
+
+  it('says the rate is STALE rather than missing when that is what the server reported', async () => {
+    fetchWithAuth.mockResolvedValue(jsonRes(unavailableBody([{ currencyCode: 'EUR', reason: 'stale' }], ['EUR'])));
+    render(<ApproximateMoneyLine byCurrency={BOOK} date="2026-08-21" />);
+    const line = await screen.findByTestId('approximate-money-line');
+    expect(line.textContent).toBe('≈ total unavailable — CAD exchange rate too old for EUR');
+  });
+
+  it('lists every uncoverable currency, not just the first', async () => {
+    fetchWithAuth.mockResolvedValue(jsonRes(unavailableBody(
+      [{ currencyCode: 'EUR', reason: 'stale' }, { currencyCode: 'NGN', reason: 'missing' }],
+      ['EUR', 'NGN'],
+    )));
+    render(<ApproximateMoneyLine byCurrency={BOOK} date="2026-08-21" />);
+    const line = await screen.findByTestId('approximate-money-line');
+    expect(line.textContent).toBe('≈ total unavailable — EUR, NGN could not be converted to CAD');
+  });
+
+  it('caps a long list and COUNTS the remainder — never elides it into an ellipsis', async () => {
+    const codes = ['AED', 'BRL', 'CHF', 'EUR', 'NGN', 'ZAR'];
+    fetchWithAuth.mockResolvedValue(jsonRes(unavailableBody(
+      codes.map((currencyCode) => ({ currencyCode, reason: 'missing' as const })),
+      codes,
+    )));
+    render(<ApproximateMoneyLine byCurrency={BOOK} date="2026-08-21" />);
+    const line = await screen.findByTestId('approximate-money-line');
+    expect(line.textContent)
+      .toBe('≈ total unavailable — no CAD exchange rate for AED, BRL, CHF, EUR and 2 more');
+  });
+
+  // The other half of the same defect class: a book this client cannot even
+  // encode (a credit note pushing one currency negative) used to make the line
+  // vanish with no request and no trace.
+  it('reports a book it could not encode instead of vanishing — and asks the server nothing', async () => {
+    render(<ApproximateMoneyLine byCurrency={[{ code: 'USD', amount: '100.00' }, { code: 'EUR', amount: -5 }]} />);
+    const line = await screen.findByTestId('approximate-money-line');
+    expect(line.textContent).toBe('≈ total unavailable — could not load exchange rates');
+    expect(line.dataset.approxState).toBe('failed');
+    expect(fetchWithAuth).not.toHaveBeenCalled();
+  });
+
+  it('still shows NO figure in the unavailable state — no partial total, no 1:1', async () => {
+    fetchWithAuth.mockResolvedValue(jsonRes(unavailableBody([{ currencyCode: 'EUR', reason: 'missing' }], ['EUR'])));
     const { container } = render(<ApproximateMoneyLine byCurrency={BOOK} date="2026-08-21" />);
-    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(container.innerHTML).toBe(''));
+    await screen.findByTestId('approximate-money-line');
     expect(container.textContent).not.toContain('22940');
-    expect(container.textContent).not.toContain('≈');
+    expect(container.textContent).not.toContain('CA$');
+    expect(container.textContent).not.toMatch(/\d/);
+  });
+
+  it('keeps the failure state as quiet visually as the total it replaces', async () => {
+    fetchWithAuth.mockResolvedValue(jsonRes(unavailableBody([{ currencyCode: 'EUR', reason: 'missing' }], ['EUR'])));
+    render(<ApproximateMoneyLine byCurrency={BOOK} date="2026-08-21" />);
+    const line = await screen.findByTestId('approximate-money-line');
+    expect(line.className).toContain('text-xs');
+    expect(line.className).toContain('text-muted-foreground');
   });
 
   it('renders nothing and asks the server nothing for an empty book', async () => {
@@ -116,5 +195,15 @@ describe('ApproximateMoneyLine', () => {
     render(<ApproximateMoneyLine byCurrency={BOOK} date="2026-08-21" testId="invoices-approx" />);
     await waitFor(() => expect(screen.getByTestId('invoices-approx')).toBeInTheDocument());
     expect(screen.queryByTestId('approximate-money-line')).toBeNull();
+  });
+
+  // A page suite asserting the line exists must not be able to pass on a
+  // failure state and vice versa: same testId, different `data-approx-state`.
+  it('keeps the overridden testId in the failure states, distinguished by data-approx-state', async () => {
+    fetchWithAuth.mockResolvedValue(jsonRes(unavailableBody([{ currencyCode: 'NGN', reason: 'missing' }], ['NGN'])));
+    render(<ApproximateMoneyLine byCurrency={BOOK} date="2026-08-21" testId="invoices-approx" />);
+    const line = await screen.findByTestId('invoices-approx');
+    expect(line.dataset.approxState).toBe('unavailable');
+    expect(line.textContent).toContain('NGN');
   });
 });

--- a/apps/web/src/components/billing/shared/ApproximateMoneyLine.tsx
+++ b/apps/web/src/components/billing/shared/ApproximateMoneyLine.tsx
@@ -4,12 +4,28 @@ import { selectApproxTotal } from '@/lib/reporting/approximateTotal';
 import { useApproximateTotal } from '@/lib/useApproximateTotal';
 import { formatMoney } from './format';
 
+/** A partner whose book spans a dozen currencies must not push a one-line
+ *  companion into a paragraph on seven surfaces. The overflow is COUNTED, never
+ *  elided into an ellipsis: "and 4 more" still tells the reader how much they
+ *  are not seeing, which a CSS truncation would not. */
+const MAX_LISTED_CODES = 4;
+
 /**
  * The optional "≈ X <partner currency>" companion line (multi-currency spec §8).
+ *
  * It NEVER replaces the authoritative per-currency segmentation above it, and it
- * renders nothing at all when a single leg is missing or stale — an approximate
- * total that silently drops a currency is worse than no total. All conversion
- * and summation happened on the server; this component only formats.
+ * never shows a figure it cannot stand behind — a partial approximate total is
+ * worse than none. All conversion and summation happened on the server; this
+ * component only formats.
+ *
+ * What it does NOT do any more (#4415, the fourth hide-on-failure bug on this
+ * surface): silently render nothing when the total could not be produced. A
+ * suppressed FIGURE is not a suppressed LINE. `unavailable` and a failed request
+ * both render an explicit, equally muted sentence naming what went wrong, so a
+ * self-hoster with no exchange-rate feed learns why the total is absent instead
+ * of seeing a line that never appears. Only two states render nothing, and both
+ * are genuinely empty of information: the request is still in flight, and the
+ * server answered `not-needed` because the book needs no conversion at all.
  */
 export function ApproximateMoneyLine({ byCurrency, date, testId }: {
   byCurrency: readonly { code: string; amount: string | number }[];
@@ -18,17 +34,55 @@ export function ApproximateMoneyLine({ byCurrency, date, testId }: {
 }) {
   const { t } = useTranslation('common');
   const { response, loading, failed } = useApproximateTotal(byCurrency, date);
-  if (loading || failed) return null;
-  const view = selectApproxTotal(response);
-  if (view.status !== 'available') return null;
-  return (
-    <div className="text-xs text-muted-foreground" data-testid={testId ?? 'approximate-money-line'}>
-      {t('money.approximateTotal', {
-        amount: formatMoney(view.amount, view.currencyCode),
-        rateDate: view.rateDate,
-      })}
+
+  // Loading is the ONLY state that renders nothing on its own: a flash of
+  // "unavailable" before the answer arrives would be its own kind of lie.
+  if (loading) return null;
+
+  const view = failed ? null : selectApproxTotal(response);
+  if (view?.status === 'hidden') return null;
+
+  const line = (state: string, text: string) => (
+    <div
+      className="text-xs text-muted-foreground"
+      data-testid={testId ?? 'approximate-money-line'}
+      data-approx-state={state}
+    >
+      {text}
     </div>
   );
+
+  // A request that produced no answer at all: the server, the session or the
+  // network is the problem, and there are no currency codes to name.
+  if (!view) return line('failed', t('money.approximateFailed'));
+
+  if (view.status === 'unavailable') {
+    // Without codes or a target currency there is no pair to name, and the body
+    // itself was unusable — say only what we actually know.
+    if (view.currencyCodes.length === 0 || !view.targetCurrencyCode) {
+      return line('unavailable', t('money.approximateFailed'));
+    }
+    const listed = view.currencyCodes.slice(0, MAX_LISTED_CODES).join(', ');
+    const overflow = view.currencyCodes.length - MAX_LISTED_CODES;
+    // `more`, not i18next's reserved `count`: this fragment has no plural forms
+    // in any catalog, and passing `count` would send i18next hunting for
+    // `_one`/`_other` keys that do not exist.
+    const codes = overflow > 0
+      ? t('money.approximateUnavailableCodesOverflow', { codes: listed, more: overflow })
+      : listed;
+    // Literal keys, deliberately — a lookup table would read as a dynamic key
+    // and the `keyUsage` guard could no longer prove these three entries are
+    // still in the catalogs.
+    const vars = { codes, target: view.targetCurrencyCode };
+    if (view.reason === 'missing') return line('unavailable', t('money.approximateUnavailableMissing', vars));
+    if (view.reason === 'stale') return line('unavailable', t('money.approximateUnavailableStale', vars));
+    return line('unavailable', t('money.approximateUnavailableMixed', vars));
+  }
+
+  return line('available', t('money.approximateTotal', {
+    amount: formatMoney(view.amount, view.currencyCode),
+    rateDate: view.rateDate,
+  }));
 }
 
 export default ApproximateMoneyLine;

--- a/apps/web/src/components/moneyRollupApproximate.test.tsx
+++ b/apps/web/src/components/moneyRollupApproximate.test.tsx
@@ -12,10 +12,18 @@
  * Every surface is asserted in all five states:
  *   1. mixed book + rates available → segmentation UNCHANGED + the line renders
  *   2. single-currency book         → no line, shipped summary byte-identical
- *   3. a stale leg                  → segmentation only
- *   4. an uncovered pair            → segmentation only, and NO 1:1 figure and
- *                                     NO target-currency symbol anywhere
- *   5. endpoint 500                 → segmentation only, no toast
+ *   3. a stale leg                  → segmentation + the line SAYS the rate is
+ *                                     too old and names the currency
+ *   4. an uncovered pair            → segmentation + the line names the
+ *                                     currency, and NO 1:1 figure and NO
+ *                                     target-currency symbol anywhere
+ *   5. endpoint 500                 → segmentation + the line says it could not
+ *                                     load rates, and still no toast
+ *
+ * States 3-5 asserted the OPPOSITE until #4415: the line rendered nothing, so
+ * a self-hoster with no exchange-rate feed could not tell a broken conversion
+ * from a working one. Suppressing the FIGURE is the contract; suppressing the
+ * LINE was the bug — the fourth of its kind on this surface.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor, within } from '@testing-library/react';
@@ -288,39 +296,49 @@ describe.each(SURFACES)('$name — reporting-only approximate line', (surface) =
     expect(total.textContent).not.toContain('≈');
   });
 
-  it('3. a stale leg: segmentation only, no approximate line', async () => {
+  it('3. a stale leg: segmentation kept AND the line says the rate is too old', async () => {
     rates = () => json({ data: unavailable('stale') });
     surface.render();
     await assertSegmentation(surface);
 
     await waitFor(() => expect(fetchWithAuth)
       .toHaveBeenCalledWith(expect.stringContaining('/billing/reporting-totals'), { skipOrgIdInjection: true }));
-    await waitFor(() => expect(screen.queryByTestId(surface.testId)).toBeNull());
+    const line = await screen.findByTestId(surface.testId);
+    // Resolved through the SHIPPED en catalog, not a mocked template.
+    expect(line.textContent).toBe('≈ total unavailable — CAD exchange rate too old for EUR');
+    expect(line.dataset.approxState).toBe('unavailable');
   });
 
-  it('4. an uncovered pair: no 1:1 figure and no target-currency symbol anywhere', async () => {
+  it('4. an uncovered pair: the line names the currency, and still no 1:1 figure anywhere', async () => {
     rates = () => json({ data: unavailable('missing') });
     surface.render();
     await assertSegmentation(surface);
 
     await waitFor(() => expect(fetchWithAuth)
       .toHaveBeenCalledWith(expect.stringContaining('/billing/reporting-totals'), { skipOrgIdInjection: true }));
-    await waitFor(() => expect(screen.queryByTestId(surface.testId)).toBeNull());
-    // The no-silent-1:1 guard: the foreign group is neither converted at 1.0
-    // nor relabelled with the reporting currency.
+    const line = await screen.findByTestId(surface.testId);
+    expect(line.textContent).toBe('≈ total unavailable — no CAD exchange rate for EUR');
+    // The no-silent-1:1 guard, unchanged in substance: the foreign group is
+    // neither converted at 1.0 nor relabelled with the reporting currency. The
+    // explanation carries no figure at all, so it cannot be mistaken for one.
     expect(document.body.textContent).not.toContain(TARGET_SYMBOL);
     expect(document.body.textContent).not.toContain(NAIVE_SUM);
-    expect(document.body.textContent).not.toContain('≈');
+    expect(line.textContent).not.toMatch(/\d/);
   });
 
-  it('5. endpoint failure: segmentation unchanged, no line, no toast', async () => {
+  it('5. endpoint failure: segmentation unchanged, the line says so, still no toast', async () => {
     rates = () => json({ error: { code: 'BOOM' } }, false, 500);
     surface.render();
     await assertSegmentation(surface);
 
     await waitFor(() => expect(fetchWithAuth)
       .toHaveBeenCalledWith(expect.stringContaining('/billing/reporting-totals'), { skipOrgIdInjection: true }));
-    await waitFor(() => expect(screen.queryByTestId(surface.testId)).toBeNull());
+    const line = await screen.findByTestId(surface.testId);
+    expect(line.textContent).toBe('≈ total unavailable — could not load exchange rates');
+    expect(line.dataset.approxState).toBe('failed');
+    // Still inline and muted: an optional companion line never escalates to a
+    // toast, on seven surfaces that may each render several of them.
+    expect(line.className).toContain('text-muted-foreground');
     expect(showToast).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/partner/PartnerDashboard.test.tsx
+++ b/apps/web/src/components/partner/PartnerDashboard.test.tsx
@@ -132,7 +132,7 @@ describe('PartnerDashboard MRR (multi-currency, wave 7)', () => {
     expect(total.compareDocumentPosition(approx) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
-  it('keeps the segmented total and renders no approximate line when the rates endpoint fails', async () => {
+  it('keeps the segmented total and SAYS the approximate line is unavailable when the rates endpoint fails', async () => {
     wire([
       org('o1', 'Acme', [{ currencyCode: 'USD', amount: '12300.00' }]),
       org('o2', 'Globex', [{ currencyCode: 'EUR', amount: '4100.00' }]),
@@ -142,7 +142,12 @@ describe('PartnerDashboard MRR (multi-currency, wave 7)', () => {
     const total = await screen.findByTestId('partner-dashboard-total-mrr');
     await waitFor(() => expect(fetchWithAuth)
       .toHaveBeenCalledWith(expect.stringContaining('/billing/reporting-totals'), { skipOrgIdInjection: true }));
+    // The authoritative segmentation is untouched by the FX failure...
     expect(total.textContent).toBe('$12,300.00 + €4,100.00');
-    await waitFor(() => expect(screen.queryByTestId('partner-dashboard-mrr-approx')).toBeNull());
+    // ...and the companion line reports the failure instead of vanishing (#4415).
+    const approx = await screen.findByTestId('partner-dashboard-mrr-approx');
+    expect(approx.textContent).toBe('≈ total unavailable — could not load exchange rates');
+    expect(approx.dataset.approxState).toBe('failed');
+    expect(approx.textContent).not.toContain('CA$');
   });
 });

--- a/apps/web/src/lib/__tests__/useApproximateTotal.test.tsx
+++ b/apps/web/src/lib/__tests__/useApproximateTotal.test.tsx
@@ -86,10 +86,34 @@ describe('useApproximateTotal — request shape', () => {
     expect(screen.getByTestId('state').dataset.failed).toBe('false');
   });
 
-  it('does not fetch when every entry is malformed (nothing to ask about)', async () => {
+  // An empty book and an UNUSABLE one both skip the request, but they are not
+  // the same answer: one has nothing to say, the other has something it failed
+  // to say. Collapsing them is what let a credit note pushing a currency
+  // negative silently erase the line (#4415), so the split is asserted here at
+  // the hook layer, not just at the component that renders it.
+  it('reports FAILED — not idle — when the book cannot be encoded at all', async () => {
     render(<Probe book={[{ code: 'USD', amount: 'not-a-number' }, { code: '', amount: '1.00' }]} />);
     await waitFor(() => expect(screen.getByTestId('state').dataset.loading).toBe('false'));
     expect(fetchWithAuth).not.toHaveBeenCalled();
+    expect(screen.getByTestId('state').dataset.failed).toBe('true');
+    expect(screen.getByTestId('state').textContent).toBe('null');
+  });
+
+  it('reports FAILED for a single negative leg — a credit note must not erase the line', async () => {
+    render(<Probe book={[{ code: 'USD', amount: '100.00' }, { code: 'EUR', amount: -5 }]} />);
+    await waitFor(() => expect(screen.getByTestId('state').dataset.loading).toBe('false'));
+    expect(fetchWithAuth).not.toHaveBeenCalled();
+    expect(screen.getByTestId('state').dataset.failed).toBe('true');
+  });
+
+  it('goes back to a real request once an unusable book becomes usable again', async () => {
+    fetchWithAuth.mockResolvedValue(jsonRes({ data: AVAILABLE }));
+    const { rerender } = render(<Probe book={[{ code: 'USD', amount: -1 }]} />);
+    await waitFor(() => expect(screen.getByTestId('state').dataset.failed).toBe('true'));
+
+    rerender(<Probe book={BOOK} date="2026-08-21" />);
+    await waitFor(() => expect(screen.getByTestId('state').dataset.failed).toBe('false'));
+    expect(fetchWithAuth).toHaveBeenCalledTimes(1);
   });
 
   it('never sends a currency the caller did not provide, and never substitutes USD', async () => {

--- a/apps/web/src/lib/reporting/approximateTotal.test.ts
+++ b/apps/web/src/lib/reporting/approximateTotal.test.ts
@@ -16,25 +16,26 @@ const base = {
 describe('buildGroupsParam', () => {
   it('sorts, deduplicates by summing nothing and quantizes amounts to the minor unit', () => {
     expect(buildGroupsParam([{ code: 'usd', amount: 12300 }, { code: 'EUR', amount: '4100.00' }]))
-      .toBe('EUR:4100.00,USD:12300.00');
+      .toEqual({ kind: 'query', value: 'EUR:4100.00,USD:12300.00' });
   });
-  it('is empty for an empty book', () => {
-    expect(buildGroupsParam([])).toBe('');
+  it('is `empty` — not `invalid` — for an empty book: nothing to ask, nothing to say', () => {
+    expect(buildGroupsParam([])).toEqual({ kind: 'empty' });
   });
   it('drops groups with a blank code rather than sending a malformed pair', () => {
-    expect(buildGroupsParam([{ code: '', amount: 1 }, { code: 'USD', amount: 2 }])).toBe('USD:2.00');
+    expect(buildGroupsParam([{ code: '', amount: 1 }, { code: 'USD', amount: 2 }]))
+      .toEqual({ kind: 'query', value: 'USD:2.00' });
   });
   it('keeps the first group for an uppercased, trimmed currency code', () => {
     expect(buildGroupsParam([
       { code: ' usd ', amount: '1.25' },
       { code: 'USD', amount: '99.00' },
-    ])).toBe('USD:1.25');
+    ])).toEqual({ kind: 'query', value: 'USD:1.25' });
   });
   it('does not replace an invalid first occurrence with a later duplicate', () => {
     expect(buildGroupsParam([
       { code: 'USD', amount: '-1' },
       { code: 'usd', amount: '2.00' },
-    ])).toBe('');
+    ])).toEqual({ kind: 'invalid' });
   });
 
   it('quantizes the float residue a per-currency rollup accumulates', () => {
@@ -44,30 +45,33 @@ describe('buildGroupsParam', () => {
     const parts = [1234.56, 89.99, 4321.01, 77.77, 1000.10, 250.25, 19.99, 8888.88, 6.66, 4444.44, 33.33, 12.17];
     const sum = parts.reduce((acc, n) => acc + n, 0);
     expect(String(sum)).not.toMatch(/^\d+(\.\d{1,2})?$/); // residue really is there
-    expect(buildGroupsParam([{ code: 'USD', amount: sum }])).toBe(`USD:${sum.toFixed(2)}`);
+    expect(buildGroupsParam([{ code: 'USD', amount: sum }]))
+      .toEqual({ kind: 'query', value: `USD:${sum.toFixed(2)}` });
   });
 
   it('quantizes at the ZERO-decimal minor unit for JPY', () => {
-    expect(buildGroupsParam([{ code: 'JPY', amount: '1000.4' }])).toBe('JPY:1000.00');
-    expect(buildGroupsParam([{ code: 'JPY', amount: '1000.5' }])).toBe('JPY:1001.00');
+    expect(buildGroupsParam([{ code: 'JPY', amount: '1000.4' }])).toEqual({ kind: 'query', value: 'JPY:1000.00' });
+    expect(buildGroupsParam([{ code: 'JPY', amount: '1000.5' }])).toEqual({ kind: 'query', value: 'JPY:1001.00' });
   });
 
   it('suppresses the WHOLE line when any leg is negative — never a partial basis', () => {
     // A credit note / refund adjustment can push one currency negative. Sending
     // only the positive legs would get an `available` total whose basis omits a
     // currency, which is exactly the partial approximation the spec forbids.
-    expect(buildGroupsParam([{ code: 'USD', amount: 100 }, { code: 'EUR', amount: -5 }])).toBe('');
+    expect(buildGroupsParam([{ code: 'USD', amount: 100 }, { code: 'EUR', amount: -5 }]))
+      .toEqual({ kind: 'invalid' });
   });
 
   it('suppresses the WHOLE line when any leg is non-finite', () => {
-    expect(buildGroupsParam([{ code: 'USD', amount: 100 }, { code: 'EUR', amount: Number.NaN }])).toBe('');
-    expect(buildGroupsParam([{ code: 'USD', amount: 100 }, { code: 'EUR', amount: Number.POSITIVE_INFINITY }])).toBe('');
-    expect(buildGroupsParam([{ code: 'USD', amount: 100 }, { code: 'EUR', amount: 'not-a-number' }])).toBe('');
+    for (const bad of [Number.NaN, Number.POSITIVE_INFINITY, 'not-a-number'] as const) {
+      expect(buildGroupsParam([{ code: 'USD', amount: 100 }, { code: 'EUR', amount: bad }]))
+        .toEqual({ kind: 'invalid' });
+    }
   });
 
   it('accepts whitespace and exponent-notation amounts a rollup can hand it', () => {
     expect(buildGroupsParam([{ code: 'GBP', amount: ' 2.00 ' }, { code: 'EUR', amount: '1e3' }]))
-      .toBe('EUR:1000.00,GBP:2.00');
+      .toEqual({ kind: 'query', value: 'EUR:1000.00,GBP:2.00' });
   });
 });
 
@@ -82,12 +86,118 @@ describe('selectApproxTotal', () => {
   });
 
   it.each([
-    ['a null response (not loaded / failed)', null],
+    ['a null response (nothing was asked)', null],
     ['not-needed (single-currency book)', { ...base, status: 'not-needed', rateDate: null, total: '540.00' }],
-    ['unavailable (any missing or stale leg)', { ...base, status: 'unavailable', rateDate: null, total: null, unavailableCurrencyCodes: ['EUR'] }],
+  ])('hides the line for %s — these are the ONLY two states with nothing to say', (_label, res) => {
+    expect(selectApproxTotal(res as ReportingTotalResponse | null)).toEqual({ status: 'hidden' });
+  });
+
+  // #4415: `unavailable` is a rich answer, not an absence. Collapsing it into
+  // `hidden` is what made four consecutive releases ship a line that silently
+  // never rendered for partners with no exchange-rate coverage.
+  it('surfaces `unavailable` with the codes the server could not convert', () => {
+    const res: ReportingTotalResponse = {
+      ...base,
+      status: 'unavailable',
+      rateDate: null,
+      total: null,
+      groups: [
+        { currencyCode: 'USD', amount: '1.00', convertedAmount: null, rate: null, rateDate: null, source: null },
+        { currencyCode: 'NGN', amount: '2.00', convertedAmount: null, rate: null, rateDate: null, source: null, reason: 'missing' },
+      ],
+      unavailableCurrencyCodes: ['NGN'],
+    };
+    expect(selectApproxTotal(res)).toEqual({
+      status: 'unavailable', currencyCodes: ['NGN'], targetCurrencyCode: 'CAD', reason: 'missing',
+    });
+  });
+
+  it('carries the `stale` reason through rather than flattening every failure to one word', () => {
+    const res: ReportingTotalResponse = {
+      ...base,
+      status: 'unavailable',
+      rateDate: null,
+      total: null,
+      groups: [{ currencyCode: 'EUR', amount: '2.00', convertedAmount: null, rate: null, rateDate: null, source: null, reason: 'stale' }],
+      unavailableCurrencyCodes: ['EUR'],
+    };
+    expect(selectApproxTotal(res)).toEqual({
+      status: 'unavailable', currencyCodes: ['EUR'], targetCurrencyCode: 'CAD', reason: 'stale',
+    });
+  });
+
+  it('reports `mixed` when the failing legs disagree — never picks one and hides the other', () => {
+    const res: ReportingTotalResponse = {
+      ...base,
+      status: 'unavailable',
+      rateDate: null,
+      total: null,
+      groups: [
+        { currencyCode: 'EUR', amount: '2.00', convertedAmount: null, rate: null, rateDate: null, source: null, reason: 'stale' },
+        { currencyCode: 'NGN', amount: '3.00', convertedAmount: null, rate: null, rateDate: null, source: null, reason: 'missing' },
+      ],
+      unavailableCurrencyCodes: ['EUR', 'NGN'],
+    };
+    expect(selectApproxTotal(res)).toEqual({
+      status: 'unavailable', currencyCodes: ['EUR', 'NGN'], targetCurrencyCode: 'CAD', reason: 'mixed',
+    });
+  });
+
+  it('reports `mixed` when the server names codes but no reason at all', () => {
+    const res: ReportingTotalResponse = {
+      ...base, status: 'unavailable', rateDate: null, total: null, unavailableCurrencyCodes: ['ZAR'],
+    };
+    expect(selectApproxTotal(res)).toEqual({
+      status: 'unavailable', currencyCodes: ['ZAR'], targetCurrencyCode: 'CAD', reason: 'mixed',
+    });
+  });
+
+  it.each([
     ['available but with no total', { ...base, status: 'available', rateDate: '2026-09-01', total: null }],
     ['available but with no rate date', { ...base, status: 'available', rateDate: null, total: '1.00' }],
-  ])('hides the line for %s', (_label, res) => {
-    expect(selectApproxTotal(res as ReportingTotalResponse | null)).toEqual({ status: 'hidden' });
+  ])('treats an unusable `available` body as unavailable, not as silence: %s', (_label, res) => {
+    expect(selectApproxTotal(res as ReportingTotalResponse | null)).toEqual({
+      status: 'unavailable', currencyCodes: [], targetCurrencyCode: 'CAD', reason: 'mixed',
+    });
+  });
+
+  it('ignores a reason outside the contract rather than reporting it as `missing`', () => {
+    // The body is unvalidated JSON at this point: a drifted server must not be
+    // able to make the copy assert a cause the contract has no word for.
+    const res = {
+      ...base, status: 'unavailable', rateDate: null, total: null,
+      groups: [{ currencyCode: 'EUR', amount: '2.00', convertedAmount: null, rate: null, rateDate: null, source: null, reason: 'gremlins' }],
+      unavailableCurrencyCodes: ['EUR'],
+    } as unknown as ReportingTotalResponse;
+    expect(selectApproxTotal(res)).toEqual({
+      status: 'unavailable', currencyCodes: ['EUR'], targetCurrencyCode: 'CAD', reason: 'mixed',
+    });
+  });
+
+  it('ignores the reason of a group the server did NOT flag as unavailable', () => {
+    const res: ReportingTotalResponse = {
+      ...base,
+      status: 'unavailable',
+      rateDate: null,
+      total: null,
+      groups: [
+        { currencyCode: 'EUR', amount: '2.00', convertedAmount: null, rate: null, rateDate: null, source: null, reason: 'stale' },
+        { currencyCode: 'NGN', amount: '3.00', convertedAmount: null, rate: null, rateDate: null, source: null, reason: 'missing' },
+      ],
+      unavailableCurrencyCodes: ['NGN'],
+    };
+    expect(selectApproxTotal(res)).toEqual({
+      status: 'unavailable', currencyCodes: ['NGN'], targetCurrencyCode: 'CAD', reason: 'missing',
+    });
+  });
+
+  it('deduplicates and uppercases the codes it reports', () => {
+    const res = {
+      ...base, status: 'unavailable', rateDate: null, total: null,
+      unavailableCurrencyCodes: ['ngn', 'NGN', 'eur'],
+    } as unknown as ReportingTotalResponse;
+    expect(selectApproxTotal(res)).toEqual({
+      status: 'unavailable', currencyCodes: ['NGN', 'EUR'], targetCurrencyCode: 'CAD', reason: 'mixed',
+    });
   });
 });

--- a/apps/web/src/lib/reporting/approximateTotal.ts
+++ b/apps/web/src/lib/reporting/approximateTotal.ts
@@ -9,9 +9,13 @@
  *
  * Display rules that are not negotiable:
  * - a book already entirely in the target currency shows no approximate line;
- * - ANY missing, stale or incomplete leg hides the WHOLE line (the server
- *   returns status 'unavailable' and total null — a partial approximation is a
- *   dishonest number);
+ * - ANY missing, stale or incomplete leg suppresses the whole FIGURE (the
+ *   server returns status 'unavailable' and total null — a partial
+ *   approximation is a dishonest number), but the line then SAYS SO and names
+ *   the currencies it could not convert. Suppressing the figure is not the same
+ *   as rendering nothing: rendering nothing is how #4415 (and the three
+ *   hide-on-failure bugs before it) left self-hosters with no rate feed staring
+ *   at a line that never appeared and no way to find out why;
  * - the disclosed rate date is whatever the server reports as the OLDEST
  *   contributing leg;
  * - the authoritative per-currency segmentation above this line always stays
@@ -44,19 +48,59 @@ export interface ReportingTotalResponse {
   unavailableCurrencyCodes: readonly string[];
 }
 
+/** Why the server could not produce a total. `mixed` covers both "the failing
+ *  legs disagree" and "the server named codes but no reason" — either way the
+ *  copy has to stay non-committal rather than assert a cause we do not have. */
+export type ApproxUnavailableReason = 'missing' | 'stale' | 'mixed';
+
+/**
+ * The view the line renders. Deliberately EXHAUSTIVE over everything the
+ * endpoint can answer, with exactly one silent member (`hidden`) reserved for
+ * the two states that genuinely have nothing to say: no request was made, and
+ * `not-needed` (the book is already entirely in the reporting currency).
+ *
+ * Every failure is a NAMED member carrying its detail. That is the whole point
+ * of #4415: `unavailable` used to fall into `hidden`, so four releases shipped
+ * a line that silently never rendered for partners with no rate coverage. A
+ * future contributor cannot re-hide a failure without deleting a union member
+ * and reddening the switch in `ApproximateMoneyLine`.
+ */
 export type ApproxTotalView =
   | { status: 'hidden' }
+  | {
+    status: 'unavailable';
+    currencyCodes: readonly string[];
+    /** The currency the conversion was TO. Named in the copy on purpose: the
+     *  server flags the source group that could not convert, which is not
+     *  necessarily the leg whose rate is missing — when the target leg fails,
+     *  every group inherits that reason (`reportingTotals.ts`). "no CAD rate
+     *  for NGN" describes the PAIR and is true either way; "NGN's rate is
+     *  missing" would assert a cause we have not established. */
+    targetCurrencyCode: string;
+    reason: ApproxUnavailableReason;
+  }
   | { status: 'available'; amount: string; currencyCode: string; rateDate: string };
 
 const PLAIN_NON_NEGATIVE_DECIMAL = /^(\d+)(?:\.(\d*))?$/;
 
+/** What a book is worth asking about. `empty` and `invalid` were ONE return
+ *  value ('') until #4415, which is why an unusable leg — a negative balance, a
+ *  currency the client cannot round — made the whole line vanish with no
+ *  request and no trace, indistinguishable from having nothing to ask. They are
+ *  separate members now so the caller can stay silent for one and speak for the
+ *  other. */
+export type ApproxGroupsQuery =
+  | { kind: 'empty' }
+  | { kind: 'invalid' }
+  | { kind: 'query'; value: string };
+
 /** `USD:12300.00,EUR:4100.00` — sorted, deduplicated, every amount quantized to
- *  the currency's minor unit. Returns '' when there is nothing to ask about,
- *  and ALSO when any single leg is unusable (negative, non-finite): the caller
- *  then makes no request and renders no line at all. Skipping the bad leg
- *  instead would ask the server to approximate a book it was not given, and the
- *  answer would come back `available` — a partial approximate total, which the
- *  spec forbids (§8: one unavailable leg suppresses the WHOLE line).
+ *  the currency's minor unit. `invalid` when any single leg is unusable
+ *  (negative, non-finite, unroundable): the caller then makes no request and
+ *  reports that it could not build one. Skipping the bad leg instead would ask
+ *  the server to approximate a book it was not given, and the answer would come
+ *  back `available` — a partial approximate total, which the spec forbids
+ *  (§8: one unavailable leg suppresses the WHOLE figure).
  *
  *  Quantization is mandatory, not cosmetic: the callers' per-currency sums come
  *  from `sumByCurrency`, which accumulates in JS `number`, so a rollup of a
@@ -68,7 +112,7 @@ const PLAIN_NON_NEGATIVE_DECIMAL = /^(\d+)(?:\.(\d*))?$/;
  *  converted figure. */
 export function buildGroupsParam(
   byCurrency: readonly { code: string; amount: string | number }[],
-): string {
+): ApproxGroupsQuery {
   const groups = new Map<string, string>();
   const seenCodes = new Set<string>();
 
@@ -81,33 +125,81 @@ export function buildGroupsParam(
     try {
       amount = roundToCurrency(group.amount, code);
     } catch {
-      return '';
+      return { kind: 'invalid' };
     }
-    if (!PLAIN_NON_NEGATIVE_DECIMAL.test(amount)) return '';
+    if (!PLAIN_NON_NEGATIVE_DECIMAL.test(amount)) return { kind: 'invalid' };
 
     groups.set(code, amount);
   }
 
-  return [...groups]
-    .sort(([left], [right]) => left.localeCompare(right))
-    .map(([code, amount]) => `${code}:${amount}`)
-    .join(',');
-}
-
-/** The ONLY display decision: show the server's total, or show nothing. */
-export function selectApproxTotal(response: ReportingTotalResponse | null): ApproxTotalView {
-  if (
-    response?.status !== 'available'
-    || response.total === null
-    || response.rateDate === null
-  ) {
-    return { status: 'hidden' };
-  }
+  if (groups.size === 0) return { kind: 'empty' };
 
   return {
-    status: 'available',
-    amount: response.total,
-    currencyCode: response.targetCurrencyCode,
-    rateDate: response.rateDate,
+    kind: 'query',
+    value: [...groups]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([code, amount]) => `${code}:${amount}`)
+      .join(','),
+  };
+}
+
+/** Codes the server could not convert, uppercased and deduplicated in the order
+ *  the server reported them — the copy names them verbatim, so a duplicate or a
+ *  lowercase code would read as two different currencies. */
+function unavailableCodes(response: ReportingTotalResponse): string[] {
+  const seen = new Set<string>();
+  for (const raw of response.unavailableCurrencyCodes ?? []) {
+    const code = String(raw).trim().toUpperCase();
+    if (code) seen.add(code);
+  }
+  return [...seen];
+}
+
+/** The reason the FAILING legs agree on, or `mixed`. Never guesses: a leg with
+ *  no reason (or a reason outside the contract — the body is unvalidated JSON)
+ *  contributes nothing, and disagreement stays `mixed` rather than picking the
+ *  first and presenting it as THE cause. */
+function unavailableReason(
+  response: ReportingTotalResponse,
+  codes: readonly string[],
+): ApproxUnavailableReason {
+  const wanted = new Set(codes);
+  const reasons = new Set<'missing' | 'stale'>();
+  for (const group of response.groups ?? []) {
+    if (group?.reason !== 'missing' && group?.reason !== 'stale') continue;
+    if (!wanted.has(String(group.currencyCode).trim().toUpperCase())) continue;
+    reasons.add(group.reason);
+  }
+  if (reasons.size !== 1) return 'mixed';
+  return reasons.has('stale') ? 'stale' : 'missing';
+}
+
+/**
+ * The ONLY display decision. Three outcomes, no fourth: the server's total, an
+ * explicit account of why there isn't one, or silence — and silence is reserved
+ * for the two states that carry no information (nothing was asked; the book
+ * needs no conversion). A body that claims `available` without a usable total or
+ * rate date is a contract violation, and it reports as unavailable rather than
+ * disappearing: `useApproximateTotal.validate` already rejects that shape, so
+ * this branch exists to make the drift visible if it ever stops doing so.
+ */
+export function selectApproxTotal(response: ReportingTotalResponse | null): ApproxTotalView {
+  if (!response || response.status === 'not-needed') return { status: 'hidden' };
+
+  if (response.status === 'available' && response.total !== null && response.rateDate !== null) {
+    return {
+      status: 'available',
+      amount: response.total,
+      currencyCode: response.targetCurrencyCode,
+      rateDate: response.rateDate,
+    };
+  }
+
+  const currencyCodes = unavailableCodes(response);
+  return {
+    status: 'unavailable',
+    currencyCodes,
+    targetCurrencyCode: String(response.targetCurrencyCode ?? '').trim().toUpperCase(),
+    reason: unavailableReason(response, currencyCodes),
   };
 }

--- a/apps/web/src/lib/useApproximateTotal.ts
+++ b/apps/web/src/lib/useApproximateTotal.ts
@@ -13,9 +13,13 @@
 // currency from the actor's partner and returns it as `targetCurrencyCode`.
 // There is no client-side default and no 'USD' fallback anywhere here.
 //
-// Failure is always quiet: `failed` means "render segmentation only". A
-// partner with no reporting currency answers 409 NO_REPORTING_CURRENCY, which
-// is a configuration state, not an error to surface.
+// Failure is quiet in PRESENTATION, never in existence (#4415): `failed` means
+// "the segmentation above is the only figure", and the caller still renders a
+// muted sentence saying the approximate total could not be produced. It used to
+// mean "render nothing", which is how a self-hoster with no exchange-rate feed
+// got a line that simply never appeared. Every non-2xx — including the 409
+// NO_REPORTING_CURRENCY a partner can effectively never hit — lands here and
+// reads the same to the user.
 import { useEffect, useState } from 'react';
 
 import { fetchWithAuth } from '../stores/auth';
@@ -26,17 +30,27 @@ export { resetApproximateTotalCache };
 
 export interface ApproximateTotalState {
   /** The server's validated answer, or null while loading / after a failure.
-   *  `status: 'unavailable'` is an ANSWER (a leg was missing or stale), not a
-   *  failure — the caller renders nothing either way. */
+   *  `status: 'unavailable'` is an ANSWER (a leg was missing or stale) carrying
+   *  the codes it could not convert — the caller RENDERS that, it is not a
+   *  synonym for "show nothing" (#4415). */
   response: ReportingTotalResponse | null;
-  /** True while a request for this key is in flight. Callers render nothing. */
+  /** True while a request for this key is in flight. Callers render nothing —
+   *  this is the only state with nothing honest to say yet. */
   loading: boolean;
-  /** True when the request could not produce an answer (non-2xx, rejected, or
-   *  malformed). Callers render the per-currency segmentation only. */
+  /** True when no answer could be produced: non-2xx (including the near-dead
+   *  409 NO_REPORTING_CURRENCY), a rejected fetch, a malformed body, or a book
+   *  this client could not even turn into a request. Deliberately ONE flag and
+   *  not a discriminated error code: every one of those resolves to the same
+   *  user-facing sentence, and a partner always has a reporting currency
+   *  (`partners.currency_code` is NOT NULL DEFAULT 'USD'), so splitting the 409
+   *  out would buy a message nobody sees at the cost of threading a code
+   *  through the loader and its cache. Callers render an explicit muted
+   *  "could not load exchange rates", never silence. */
   failed: boolean;
 }
 
 const IDLE: ApproximateTotalState = { response: null, loading: false, failed: false };
+const FAILED: ApproximateTotalState = { response: null, loading: false, failed: true };
 
 const STATUSES = new Set(['available', 'unavailable', 'not-needed']);
 
@@ -133,18 +147,27 @@ export function useApproximateTotal(
   byCurrency: readonly { code: string; amount: string | number }[],
   date?: string,
 ): ApproximateTotalState {
-  const groupsParam = buildGroupsParam(byCurrency);
+  const query = buildGroupsParam(byCurrency);
+  const groupsParam = query.kind === 'query' ? query.value : '';
+  // An empty book has nothing to say; a book we could not encode is a failure
+  // the caller must SHOW, not a second flavour of "nothing to ask" (#4415).
+  const unbuildable = query.kind === 'invalid';
   const requestDate = date ?? todayUtc();
   const key = groupsParam ? approximateTotalCacheKey(requestDate, groupsParam) : '';
 
   const [state, setState] = useState<ApproximateTotalState>(() => {
+    if (unbuildable) return FAILED;
     const cached = key ? approximateTotalCache.values.get(key) : undefined;
     return cached ? { response: cached, loading: false, failed: false } : IDLE;
   });
 
   useEffect(() => {
-    // Nothing to ask about (empty book, or every entry malformed): no request,
-    // no loading state, no line.
+    if (unbuildable) {
+      setState(FAILED);
+      return;
+    }
+
+    // Nothing to ask about (empty book): no request, no loading state, no line.
     if (!groupsParam) {
       setState(IDLE);
       return;
@@ -165,7 +188,7 @@ export function useApproximateTotal(
         : { response: null, loading: false, failed: true });
     });
     return () => { cancelled = true; };
-  }, [key, groupsParam, requestDate]);
+  }, [key, groupsParam, requestDate, unbuildable]);
 
   return state;
 }

--- a/apps/web/src/locales/de-DE/common.json
+++ b/apps/web/src/locales/de-DE/common.json
@@ -2412,6 +2412,11 @@
     "link": "Neuigkeiten"
   },
   "money": {
-    "approximateTotal": "≈ {{amount}} ungefähr · Kurse vom {{rateDate}}"
+    "approximateTotal": "≈ {{amount}} ungefähr · Kurse vom {{rateDate}}",
+    "approximateFailed": "≈ Summe nicht verfügbar — Wechselkurse konnten nicht geladen werden",
+    "approximateUnavailableMissing": "≈ Summe nicht verfügbar — kein {{target}}-Wechselkurs für {{codes}}",
+    "approximateUnavailableStale": "≈ Summe nicht verfügbar — {{target}}-Wechselkurs für {{codes}} ist zu alt",
+    "approximateUnavailableMixed": "≈ Summe nicht verfügbar — {{codes}} konnte nicht in {{target}} umgerechnet werden",
+    "approximateUnavailableCodesOverflow": "{{codes}} und {{more}} weitere"
   }
 }

--- a/apps/web/src/locales/en/common.json
+++ b/apps/web/src/locales/en/common.json
@@ -2412,6 +2412,11 @@
     "link": "What's new"
   },
   "money": {
-    "approximateTotal": "≈ {{amount}} approximate · rates as of {{rateDate}}"
+    "approximateTotal": "≈ {{amount}} approximate · rates as of {{rateDate}}",
+    "approximateFailed": "≈ total unavailable — could not load exchange rates",
+    "approximateUnavailableMissing": "≈ total unavailable — no {{target}} exchange rate for {{codes}}",
+    "approximateUnavailableStale": "≈ total unavailable — {{target}} exchange rate too old for {{codes}}",
+    "approximateUnavailableMixed": "≈ total unavailable — {{codes}} could not be converted to {{target}}",
+    "approximateUnavailableCodesOverflow": "{{codes}} and {{more}} more"
   }
 }

--- a/apps/web/src/locales/es-419/common.json
+++ b/apps/web/src/locales/es-419/common.json
@@ -2412,6 +2412,11 @@
     "link": "Novedades"
   },
   "money": {
-    "approximateTotal": "≈ {{amount}} aproximado · tipos de cambio del {{rateDate}}"
+    "approximateTotal": "≈ {{amount}} aproximado · tipos de cambio del {{rateDate}}",
+    "approximateFailed": "≈ total no disponible — no se pudieron cargar los tipos de cambio",
+    "approximateUnavailableMissing": "≈ total no disponible — no hay tipo de cambio a {{target}} para {{codes}}",
+    "approximateUnavailableStale": "≈ total no disponible — el tipo de cambio a {{target}} para {{codes}} es demasiado antiguo",
+    "approximateUnavailableMixed": "≈ total no disponible — {{codes}} no se pudo convertir a {{target}}",
+    "approximateUnavailableCodesOverflow": "{{codes}} y {{more}} más"
   }
 }

--- a/apps/web/src/locales/fr-CA/common.json
+++ b/apps/web/src/locales/fr-CA/common.json
@@ -2412,6 +2412,11 @@
     "link": "Nouveautés"
   },
   "money": {
-    "approximateTotal": "≈ {{amount}} approximatif · taux au {{rateDate}}"
+    "approximateTotal": "≈ {{amount}} approximatif · taux au {{rateDate}}",
+    "approximateFailed": "≈ total non disponible — impossible de charger les taux de change",
+    "approximateUnavailableMissing": "≈ total non disponible — aucun taux de change vers {{target}} pour {{codes}}",
+    "approximateUnavailableStale": "≈ total non disponible — le taux de change vers {{target}} pour {{codes}} est trop ancien",
+    "approximateUnavailableMixed": "≈ total non disponible — impossible de convertir {{codes}} en {{target}}",
+    "approximateUnavailableCodesOverflow": "{{codes}} et {{more}} de plus"
   }
 }

--- a/apps/web/src/locales/fr-FR/common.json
+++ b/apps/web/src/locales/fr-FR/common.json
@@ -2412,6 +2412,11 @@
     "link": "Nouveautés"
   },
   "money": {
-    "approximateTotal": "≈ {{amount}} approximatif · taux du {{rateDate}}"
+    "approximateTotal": "≈ {{amount}} approximatif · taux du {{rateDate}}",
+    "approximateFailed": "≈ total non disponible — impossible de charger les taux de change",
+    "approximateUnavailableMissing": "≈ total non disponible — aucun taux de change vers {{target}} pour {{codes}}",
+    "approximateUnavailableStale": "≈ total non disponible — le taux de change vers {{target}} pour {{codes}} est trop ancien",
+    "approximateUnavailableMixed": "≈ total non disponible — impossible de convertir {{codes}} en {{target}}",
+    "approximateUnavailableCodesOverflow": "{{codes}} et {{more}} autres"
   }
 }

--- a/apps/web/src/locales/it-IT/common.json
+++ b/apps/web/src/locales/it-IT/common.json
@@ -2412,6 +2412,11 @@
     "link": "Novità"
   },
   "money": {
-    "approximateTotal": "≈ {{amount}} approssimativo · cambi al {{rateDate}}"
+    "approximateTotal": "≈ {{amount}} approssimativo · cambi al {{rateDate}}",
+    "approximateFailed": "≈ totale non disponibile — impossibile caricare i tassi di cambio",
+    "approximateUnavailableMissing": "≈ totale non disponibile — nessun tasso di cambio verso {{target}} per {{codes}}",
+    "approximateUnavailableStale": "≈ totale non disponibile — il tasso di cambio verso {{target}} per {{codes}} è troppo vecchio",
+    "approximateUnavailableMixed": "≈ totale non disponibile — impossibile convertire {{codes}} in {{target}}",
+    "approximateUnavailableCodesOverflow": "{{codes}} e altri {{more}}"
   }
 }

--- a/apps/web/src/locales/pt-BR/common.json
+++ b/apps/web/src/locales/pt-BR/common.json
@@ -2412,6 +2412,11 @@
     "link": "Novidades"
   },
   "money": {
-    "approximateTotal": "≈ {{amount}} aproximado · taxas de {{rateDate}}"
+    "approximateTotal": "≈ {{amount}} aproximado · taxas de {{rateDate}}",
+    "approximateFailed": "≈ total indisponível — não foi possível carregar as taxas de câmbio",
+    "approximateUnavailableMissing": "≈ total indisponível — sem taxa de câmbio para {{target}} em {{codes}}",
+    "approximateUnavailableStale": "≈ total indisponível — a taxa de câmbio para {{target}} em {{codes}} está desatualizada",
+    "approximateUnavailableMixed": "≈ total indisponível — não foi possível converter {{codes}} em {{target}}",
+    "approximateUnavailableCodesOverflow": "{{codes}} e mais {{more}}"
   }
 }

--- a/apps/web/src/locales/tr-TR/common.json
+++ b/apps/web/src/locales/tr-TR/common.json
@@ -2412,6 +2412,11 @@
     "link": "Yenilikler"
   },
   "money": {
-    "approximateTotal": "≈ {{amount}} yaklaşık · {{rateDate}} tarihli kurlarla"
+    "approximateTotal": "≈ {{amount}} yaklaşık · {{rateDate}} tarihli kurlarla",
+    "approximateFailed": "≈ toplam kullanılamıyor — döviz kurları yüklenemedi",
+    "approximateUnavailableMissing": "≈ toplam kullanılamıyor — {{codes}} için {{target}} döviz kuru yok",
+    "approximateUnavailableStale": "≈ toplam kullanılamıyor — {{codes}} için {{target}} döviz kuru çok eski",
+    "approximateUnavailableMixed": "≈ toplam kullanılamıyor — {{codes}} birimi {{target}} para birimine çevrilemedi",
+    "approximateUnavailableCodesOverflow": "{{codes}} ve {{more}} tane daha"
   }
 }


### PR DESCRIPTION
Fixes #4415. Follow-up of #3772 (multi-currency W07).

## The bug

`ApproximateMoneyLine` returned `null` for loading, a failed request **and** the server's `status: "unavailable"` alike:

```tsx
if (loading || failed) return null;
const view = selectApproxTotal(response);
if (view.status !== 'available') return null;
```

The endpoint answers with real detail (`status:"unavailable"`, `unavailableCurrencyCodes:["NGN"]`, per-group `reason:"missing"|"stale"`) and all of it was discarded. Seven surfaces share the component — invoices, quotes, contracts, timesheets, partner dashboard, ticket labor, ticket parts — so a self-hoster with no exchange-rate coverage saw a line that simply never rendered and had no way to learn why.

This is the **fourth** hide-on-failure defect on this exact surface during the multi-currency program, so the fix removes the mechanism, not the instance.

## The fix

`ApproxTotalView` is now **exhaustive** over everything the endpoint can answer, with exactly ONE silent member (`hidden`) reserved for the two states that carry no information: no request was made, and `not-needed` (the book is already entirely in the reporting currency). `unavailable` is its own member carrying the codes and the reason — re-hiding a failure now requires deleting a union member and reddening the component.

| State | Renders |
|---|---|
| loading | nothing — a flash of "unavailable" would be its own lie |
| `not-needed` / empty book | nothing |
| `unavailable` | `≈ total unavailable — no CAD exchange rate for NGN` |
| request failed | `≈ total unavailable — could not load exchange rates` |

Same `text-xs text-muted-foreground` styling as the total it replaces and the same `data-testid`, plus a `data-approx-state` attribute so a page suite cannot pass on the wrong state. **No figure of any kind appears in a failure state**, so the existing no-silent-1:1 guard is preserved (the suite now asserts `not.toMatch(/\d/)` on the line, which is stricter than the old blanket "no ≈ anywhere").

## Three accuracy points

These came out of an independent read of the design (Codex, read-only) and are worth calling out because two of them are things the naive fix gets wrong:

- **The copy names the PAIR, not the leg.** `unavailableCurrencyCodes` flags the *source* group that could not convert. When the **target** leg fails, `reportingTotals.ts` makes every group inherit that reason — so "NGN's rate is missing" would assert a cause we have not established. "no CAD exchange rate for NGN" is true either way.
- **The code list is capped at four and the remainder is COUNTED** (`… and 2 more`). A many-currency partner must not turn a one-line companion into a paragraph on seven surfaces, and a CSS truncation would hide the overflow silently — the same defect class again.
- **`unavailableReason` accepts only `missing`/`stale`.** The body is unvalidated JSON at that point; a drifted server cannot make the copy assert a cause the contract has no word for. Disagreement stays `mixed` rather than promoting the first leg's reason.

## One adjacent hole closed

`buildGroupsParam` returned `''` for both an empty book **and** an unusable one (a credit note pushing a currency negative, an unroundable currency code) — the identical defect one layer down: the line vanished with no request and no trace. It returns `{ kind: 'empty' | 'invalid' | 'query' }` now, and `invalid` surfaces as the visible failure state.

## Deliberately NOT done

409 `NO_REPORTING_CURRENCY` reads as the generic failure rather than getting its own message. `partners.currency_code` is `NOT NULL DEFAULT 'USD'`, so the branch is effectively unreachable for a real partner- or org-scoped viewer; threading an error code through `loadApproximateTotal` and its cache would buy a sentence nobody sees. Noted in the hook's contract comment so the next reader does not re-litigate it.

## Strings

Five new keys in `money.*`, landed in **all 8 locale catalogs** (en, de-DE, es-419, fr-CA, fr-FR, it-IT, pt-BR, tr-TR). The keys are referenced as **literals**, not through a lookup table, so `keyUsage.test.ts` can still prove they exist in the catalogs. The seven-surface contract suite resolves them through the *shipped* `en` file rather than a mocked template, so the wiring is proven end to end.

## Verification

- `apps/web` full suite: **686 files / 7096 tests passed** (`vitest run --pool=threads --maxWorkers=2`)
- `tsc --noEmit` on `apps/web`: clean
- `eslint` on all touched files: clean
- `apps/api/src/services/exchangeRateBoundary.test.ts` (FX reporting-only architectural guard): 7 passed — no new file references an FX module
- Locale parity suite: 79 passed

Red-first: the new assertions were written and watched fail (16 failures, all "element not found") before the implementation landed.

Three existing suites asserted the *old* hide-on-failure contract and were inverted: `ApproximateMoneyLine.test.tsx`, the seven-surface `moneyRollupApproximate.test.tsx` (states 3/4/5), and a sibling copy in `PartnerDashboard.test.tsx` that a `src/components/billing/` path glob would have missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)