### PR TITLE
fix(web): Windows install one-liner downloads via the server, not GitHub

### DIFF
--- a/apps/web/src/components/devices/AddDeviceModal.tsx
+++ b/apps/web/src/components/devices/AddDeviceModal.tsx
@@ -1211,9 +1211,6 @@ export default function AddDeviceModal({
               const commands = buildInstallCommands({
                 apiUrl:
                   import.meta.env.PUBLIC_API_URL || window.location.origin,
-                ghBase:
-                  import.meta.env.PUBLIC_AGENT_DOWNLOAD_URL ||
-                  "https://github.com/lanternops/breeze/releases/latest/download",
                 token: onboardingToken || "<TOKEN>",
                 enrollmentSecret: enrollmentSecret || undefined,
               });

--- a/apps/web/src/components/setup/EnrollDeviceStep.tsx
+++ b/apps/web/src/components/setup/EnrollDeviceStep.tsx
@@ -475,9 +475,6 @@ export default function EnrollDeviceStep({ orgId, siteId, onBack, onFinish: _onF
           {(() => {
             const commands: Record<Platform, string> = buildInstallCommands({
               apiUrl: import.meta.env.PUBLIC_API_URL || window.location.origin,
-              ghBase:
-                import.meta.env.PUBLIC_AGENT_DOWNLOAD_URL ||
-                'https://github.com/lanternops/breeze/releases/latest/download',
               token: onboardingToken || '<TOKEN>',
               enrollmentSecret: enrollmentSecret || undefined,
             });

--- a/apps/web/src/lib/installCommands.test.ts
+++ b/apps/web/src/lib/installCommands.test.ts
@@ -3,7 +3,6 @@ import { buildInstallCommands } from './installCommands';
 
 const base = {
   apiUrl: 'https://rmm.example.com',
-  ghBase: 'https://github.com/lanternops/breeze/releases/latest/download',
   token: 'enroll_abc123',
 };
 
@@ -63,7 +62,19 @@ describe('buildInstallCommands', () => {
       const { windows } = buildInstallCommands(base);
       expect(windows.startsWith("$ErrorActionPreference='Stop';")).toBe(true);
       expect(windows).toContain('Invoke-WebRequest');
-      expect(windows).toContain('breeze-agent-windows-amd64.exe');
+    });
+
+    it('downloads the agent from the server, not GitHub (#4441)', () => {
+      // The server's download route is what serves BYO / self-hosted signed
+      // binaries (BINARY_SOURCE=local, or a custom BINARY_GITHUB_REPOSITORY).
+      // A hard-coded github.com URL bypasses that and hands a self-hoster the
+      // upstream binary — the unix path already goes through install.sh on the
+      // server, so Windows must match.
+      const { windows } = buildInstallCommands(base);
+      expect(windows).toContain(
+        'Invoke-WebRequest -Uri "https://rmm.example.com/api/v1/agents/download/windows/amd64" -OutFile breeze-agent.exe'
+      );
+      expect(windows).not.toContain('github.com');
     });
 
     it('checks $LASTEXITCODE after every agent invocation', () => {
@@ -93,14 +104,14 @@ describe('buildInstallCommands', () => {
     });
   });
 
-  it('strips trailing slashes from apiUrl and ghBase', () => {
+  it('strips trailing slashes from apiUrl', () => {
     const cmds = buildInstallCommands({
       ...base,
       apiUrl: 'https://rmm.example.com/',
-      ghBase: 'https://gh.example.com/dl/',
     });
     expect(cmds.macos).toContain('https://rmm.example.com/api/v1/agents/install.sh');
     expect(cmds.macos).not.toContain('com//');
-    expect(cmds.windows).toContain('https://gh.example.com/dl/breeze-agent-windows-amd64.exe');
+    expect(cmds.windows).toContain('https://rmm.example.com/api/v1/agents/download/windows/amd64');
+    expect(cmds.windows).not.toContain('com//');
   });
 });

--- a/apps/web/src/lib/installCommands.ts
+++ b/apps/web/src/lib/installCommands.ts
@@ -1,8 +1,6 @@
 export interface InstallCommandOptions {
   /** Breeze API origin, e.g. https://eu.2breeze.app */
   apiUrl: string;
-  /** Base URL for direct Windows binary downloads (GitHub releases) */
-  ghBase: string;
   /** Enrollment token from the Add Device / setup flow */
   token: string;
   /** Optional org enrollment secret */
@@ -29,7 +27,6 @@ export interface InstallCommands {
  */
 export function buildInstallCommands(opts: InstallCommandOptions): InstallCommands {
   const apiUrl = opts.apiUrl.replace(/\/+$/, '');
-  const ghBase = opts.ghBase.replace(/\/+$/, '');
   const { token, enrollmentSecret } = opts;
 
   // The connectivity message is scoped to the fetch + shebang check only —
@@ -42,6 +39,13 @@ export function buildInstallCommands(opts: InstallCommandOptions): InstallComman
     `{ echo "[ERROR] Could not fetch the Breeze installer from ${apiUrl} — verify this machine has network access to your Breeze server." >&2; false; }; } && ` +
     `sudo bash "$f" --server "${apiUrl}" --token "${token}"${unixSecretFlag}`;
 
+  // Windows downloads through the server's own route, never a hard-coded
+  // GitHub URL: that route is what serves BYO / self-hosted signed binaries
+  // (BINARY_SOURCE=local, or a custom BINARY_GITHUB_REPOSITORY) and what
+  // install.sh already uses for macOS/Linux. In github mode the server 302s
+  // to the release asset it is pinned to, which Invoke-WebRequest follows
+  // exactly as it did for GitHub's own latest/download redirect (#4441).
+  //
   // The MZ-magic check is the Windows analog of the unix shebang check: a
   // captive portal's 200 HTML saved as breeze-agent.exe would otherwise stop
   // the chain with PowerShell's raw "not a valid application" exception
@@ -56,7 +60,7 @@ export function buildInstallCommands(opts: InstallCommandOptions): InstallComman
     `{throw "Breeze: downloaded file is not a Windows executable - a captive portal or web filter may be intercepting this network"}`;
   const windows =
     `$ErrorActionPreference='Stop'; ` +
-    `Invoke-WebRequest -Uri "${ghBase}/breeze-agent-windows-amd64.exe" -OutFile breeze-agent.exe; ` +
+    `Invoke-WebRequest -Uri "${apiUrl}/api/v1/agents/download/windows/amd64" -OutFile breeze-agent.exe; ` +
     `${winMzCheck}; ` +
     `.\\breeze-agent.exe service install; ${winThrow('service install')}; ` +
     `.\\breeze-agent.exe enroll "${token}" --server "${apiUrl}"${winSecretFlag}; ${winThrow('enrollment')}; ` +


### PR DESCRIPTION
Closes #4441

## Problem

With BYO / self-hosted binaries configured, the server correctly serves the custom-signed Windows agent from `GET /api/v1/agents/download/windows/amd64` (the Download Agent section and the macOS/Linux one-liners all use it), but the **Windows PowerShell command** generated by Add Device and the setup wizard downloaded from a hard-coded `https://github.com/lanternops/breeze/releases/latest/download/...` URL. A self-hoster who signed their own build got the upstream EXE anyway. Reported on Discord by MisterMind, who validated this exact change on their 0.108.0 instance.

## Change

- `installCommands.ts`: build the Windows `Invoke-WebRequest` URI from `apiUrl` (`${apiUrl}/api/v1/agents/download/windows/amd64`), matching `install.sh` and the published docs.
- Remove `ghBase` from `InstallCommandOptions` and both callers (`AddDeviceModal.tsx`, `EnrollDeviceStep.tsx`). Its only source was `PUBLIC_AGENT_DOWNLOAD_URL`, an undocumented Astro build-time env var with no Dockerfile build arg and no other references in the repo, so prebuilt-image self-hosters could never have set it.
- Tests: new assertion that the Windows command targets the server route and contains no `github.com`; trailing-slash test now covers the Windows URL.

## Behavior on hosted

Verified (HEAD request, both regions): the route 302s to the object-storage presigned URL for the same binary the Download Agent page serves. PowerShell already followed GitHub's own `latest/download` redirect, so nothing new is exercised. Side effect, desirable: hosted Windows installs now fetch the server-promoted version rather than whatever GitHub `latest` is at that moment, matching macOS/Linux.

## Verification

- `installCommands.test.ts`: red first (fixture drops `ghBase`; new URL assertion), then 11/11 green.
- `AddDeviceModal.test.tsx` + `EnrollDeviceStep.test.tsx`: 33/33.
- `tsc --noEmit` and `eslint` on the four changed files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R6rFWM8Pi5neCyzH3YjFWC