### PR TITLE
fix(billing): reword the reprice CURRENCY_LOCKED error for operators (#4417)

### DIFF
--- a/apps/api/src/services/contractService.test.ts
+++ b/apps/api/src/services/contractService.test.ts
@@ -165,7 +165,7 @@ describe('changeContractCurrency reprice (price-book reprice of catalog lines, #
     queueResult([{ id: 'l1', catalogItemId: 'cat1' }, { id: 'l2', catalogItemId: null }]);
     await expect(
       svc.changeContractCurrency('c1', { currencyCode: 'EUR', reprice: true }, actor)
-    ).rejects.toMatchObject({ code: 'CURRENCY_LOCKED', status: 409, message: expect.stringContaining('1 non-catalog line(s) cannot be repriced — pass clearLines instead') });
+    ).rejects.toMatchObject({ code: 'CURRENCY_LOCKED', status: 409, message: expect.stringContaining('1 non-catalog line(s) have no price in the new currency — remove all lines first, or keep the current currency') });
     expect(resolvePriceMock).not.toHaveBeenCalled();
     expect((db as unknown as Chain).set.mock.calls.length).toBe(0);
     expect((db as unknown as Chain).delete.mock.calls.length).toBe(0);

--- a/apps/api/src/services/contractService.ts
+++ b/apps/api/src/services/contractService.ts
@@ -743,7 +743,7 @@ export async function changeContractCurrency(
         const repriceable = lineRows.filter((l) => l.catalogItemId !== null);
         const rest = lineRows.length - repriceable.length;
         if (rest > 0) {
-          throw new ContractServiceError(`${rest} non-catalog line(s) cannot be repriced — pass clearLines instead`, 409, 'CURRENCY_LOCKED');
+          throw new ContractServiceError(`${rest} non-catalog line(s) have no price in the new currency — remove all lines first, or keep the current currency`, 409, 'CURRENCY_LOCKED');
         }
         const catalogActor = { userId: actor.userId, partnerId: c.partnerId, accessibleOrgIds: actor.accessibleOrgIds };
         for (const line of repriceable) {

--- a/apps/api/src/services/quoteService.test.ts
+++ b/apps/api/src/services/quoteService.test.ts
@@ -1087,7 +1087,7 @@ describe('changeQuoteCurrency reprice (price-book reprice of catalog lines, #377
     ]);
     await expect(
       svc.changeQuoteCurrency('q1', { currencyCode: 'EUR', reprice: true }, actor)
-    ).rejects.toMatchObject({ code: 'CURRENCY_LOCKED', status: 409, message: expect.stringContaining('1 non-catalog line(s) cannot be repriced — pass clearLines instead') });
+    ).rejects.toMatchObject({ code: 'CURRENCY_LOCKED', status: 409, message: expect.stringContaining('1 non-catalog line(s) have no price in the new currency — remove all lines first, or keep the current currency') });
     expect(resolvePriceMock).not.toHaveBeenCalled();
     expect((db as unknown as Chain).set.mock.calls.length).toBe(0);
     expect((db as unknown as { delete: { mock: { calls: unknown[][] } } }).delete.mock.calls.length).toBe(0);

--- a/apps/api/src/services/quoteService.ts
+++ b/apps/api/src/services/quoteService.ts
@@ -1248,7 +1248,7 @@ async function repriceQuoteCatalogLines(
   const repriceable = lines.filter((l) => l.sourceType === 'catalog' && l.catalogItemId !== null && l.parentLineId === null);
   const rest = lines.length - repriceable.length;
   if (rest > 0) {
-    throw new QuoteServiceError(`${rest} non-catalog line(s) cannot be repriced — pass clearLines instead`, 409, 'CURRENCY_LOCKED');
+    throw new QuoteServiceError(`${rest} non-catalog line(s) have no price in the new currency — remove all lines first, or keep the current currency`, 409, 'CURRENCY_LOCKED');
   }
   const catalogActor = { userId: actor.userId, partnerId: q.partnerId, accessibleOrgIds: actor.accessibleOrgIds };
   for (const line of repriceable) {


### PR DESCRIPTION
**Problem (#4417, from the 2026-09-01 UI QA sweep):** the contract/quote reprice failure toast read `1 non-catalog line(s) cannot be repriced — pass clearLines instead`. `clearLines` is an API request field; the user's word for that action in the same dialog is "Remove all contract lines".

**Change:** both services (`contractService.ts`, `quoteService.ts`) now say what the operator can do: `N non-catalog line(s) have no price in the new currency — remove all lines first, or keep the current currency`. Error code (`CURRENCY_LOCKED`, 409) unchanged; the two service tests updated to match.

Verified: 129/129 tests in the two touched service suites.

Fixes #4417

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011rcW2EcxjGpJXwAZU8RRci