### PR TITLE
fix(auth): accept same-origin cookie requests outside CORS_ALLOWED_ORIGINS (self-host SSH-tunnel / LAN login loop)

### DIFF
--- a/apps/api/src/routes/auth/binding.test.ts
+++ b/apps/api/src/routes/auth/binding.test.ts
@@ -235,10 +235,26 @@ describe('POST /browser-binding/bootstrap', () => {
   it('rejects a present Origin outside the configured allowlist', async () => {
     const response = await app.request('/browser-binding/bootstrap', {
       method: 'POST',
-      headers: { origin: 'https://evil.example', 'sec-fetch-site': 'same-origin' },
+      headers: { origin: 'https://evil.example', 'sec-fetch-site': 'same-site' },
     });
     expect(response.status).toBe(403);
     expect(transition.resolve).not.toHaveBeenCalled();
+  });
+
+  it('accepts an Origin outside the allowlist when the browser asserts it is same-origin (SSH-tunnel self-host)', async () => {
+    transition.resolve.mockImplementationOnce(() => {
+      throw new AuthBindingRotationRequiredError({ kind: 'browser', value: C2 }, 'missing');
+    });
+    const response = await app.request('/browser-binding/bootstrap', {
+      method: 'POST',
+      headers: {
+        origin: 'https://localhost:8443',
+        'sec-fetch-site': 'same-origin',
+        'x-forwarded-proto': 'https',
+      },
+    });
+    expect(response.status).toBe(204);
+    expect(transition.resolve).toHaveBeenCalled();
   });
 
   it('rejects Sec-Fetch-Site cross-site even when Origin is otherwise allowed', async () => {

--- a/apps/api/src/routes/auth/binding.ts
+++ b/apps/api/src/routes/auth/binding.ts
@@ -8,6 +8,7 @@ import {
   type AuthBindingSource,
 } from '../../services/authBrowserTransition';
 import { readMobileDeviceId } from '../../services/mobileDeviceBinding';
+import { isSameOriginRequest } from '../../services/requestTransport';
 import {
   AUTH_BINDING_COOKIE_NAME,
   buildAuthBindingCookie,
@@ -56,8 +57,8 @@ export const authBindingRoutes = new Hono();
 
 authBindingRoutes.post('/browser-binding/bootstrap', async (c) => {
   const origin = c.req.header('origin');
-  if (origin && !isAllowedOrigin(origin)) {
-    return c.json({ error: 'Invalid request origin' }, 403);
+  if (origin && !isAllowedOrigin(origin) && !isSameOriginRequest(c, origin)) {
+    return c.json({ error: 'Invalid request origin', code: 'invalid_request_origin' }, 403);
   }
 
   if (c.req.header('sec-fetch-site')?.trim().toLowerCase() === 'cross-site') {

--- a/apps/api/src/routes/auth/helpers.test.ts
+++ b/apps/api/src/routes/auth/helpers.test.ts
@@ -44,12 +44,19 @@ function makeContext(headers: Record<string, string | undefined>, remoteAddress?
   } as RequestLike;
 }
 
-function makeCsrfContext(headers: Record<string, string>): Context {
+function makeCsrfContext(
+  headers: Record<string, string>,
+  opts: { url?: string } = {},
+): Context {
   const normalized = Object.fromEntries(
     Object.entries(headers).map(([name, value]) => [name.toLowerCase(), value]),
   );
   return {
-    req: { header: (name: string) => normalized[name.toLowerCase()] },
+    req: {
+      header: (name: string) => normalized[name.toLowerCase()],
+      // Default to an internal hop URL so nothing matches a browser origin by accident.
+      url: opts.url ?? 'http://api:3001/api/v1/auth/refresh',
+    },
   } as unknown as Context;
 }
 
@@ -88,7 +95,7 @@ describe('terminal strict cookie CSRF boundary', () => {
   it.each([
     [{ cookie: 'breeze_csrf_token=csrf', 'x-breeze-csrf': 'different', origin: 'https://breeze.example.com', 'sec-fetch-site': 'same-origin' }, 'Invalid CSRF token'],
     [{ cookie: 'breeze_csrf_token=csrf', 'x-breeze-csrf': 'csrf', 'sec-fetch-site': 'same-origin' }, 'Missing request origin'],
-    [{ cookie: 'breeze_csrf_token=csrf', 'x-breeze-csrf': 'csrf', origin: 'https://evil.example', 'sec-fetch-site': 'same-origin' }, 'Invalid request origin'],
+    [{ cookie: 'breeze_csrf_token=csrf', 'x-breeze-csrf': 'csrf', origin: 'https://evil.example', 'sec-fetch-site': 'same-site' }, 'Invalid request origin'],
     [{ cookie: 'breeze_csrf_token=csrf', 'x-breeze-csrf': 'csrf', origin: 'https://breeze.example.com', 'sec-fetch-site': 'cross-site' }, 'Cross-site request blocked'],
   ])('rejects malformed strict terminal request %#', (headers, expected) => {
     expect(validateStrictCookieCsrfRequest(makeCsrfContext(headers))).toBe(expected);
@@ -102,6 +109,46 @@ describe('terminal strict cookie CSRF boundary', () => {
       'sec-fetch-site': 'same-site',
     });
     expect(validateStrictCookieCsrfRequest(c)).toBeNull();
+  });
+
+  // Self-hosters reach the bundled Caddy through an SSH tunnel / LAN name that
+  // is not the configured origin (quickstart: https://localhost:8443 while
+  // CORS_ALLOWED_ORIGINS=https://localhost). Every such request is same-origin —
+  // browser and API share one origin behind Caddy — so it must not be treated
+  // as CSRF. Proof is either the browser's own Sec-Fetch-Site: same-origin or
+  // Origin equalling the request's effective scheme + Host.
+  describe('same-origin requests outside CORS_ALLOWED_ORIGINS', () => {
+    const tokens = { cookie: 'breeze_csrf_token=csrf', 'x-breeze-csrf': 'csrf' };
+
+    it('accepts the tunnel origin when the browser asserts Sec-Fetch-Site: same-origin (strict + non-strict)', () => {
+      const c = makeCsrfContext({ ...tokens, origin: 'https://localhost:8443', 'sec-fetch-site': 'same-origin' });
+      expect(validateStrictCookieCsrfRequest(c)).toBeNull();
+      expect(validateCookieCsrfRequest(c)).toBeNull();
+    });
+
+    it('accepts the tunnel origin when it equals the request scheme + Host and no fetch metadata is present', () => {
+      const c = makeCsrfContext(
+        { ...tokens, origin: 'https://localhost:8443', host: 'localhost:8443' },
+        { url: 'https://localhost:8443/api/v1/auth/refresh' },
+      );
+      expect(validateStrictCookieCsrfRequest(c)).toBeNull();
+      expect(validateCookieCsrfRequest(c)).toBeNull();
+    });
+
+    it('still rejects a foreign origin that matches neither the allowlist nor the request host', () => {
+      const c = makeCsrfContext(
+        { ...tokens, origin: 'https://evil.example', 'sec-fetch-site': 'same-site', host: 'localhost:8443' },
+        { url: 'https://localhost:8443/api/v1/auth/refresh' },
+      );
+      expect(validateStrictCookieCsrfRequest(c)).toBe('Invalid request origin');
+      expect(validateCookieCsrfRequest(c)).toBe('Invalid request origin');
+    });
+
+    it('rejects Origin: null even with Sec-Fetch-Site: same-origin', () => {
+      const c = makeCsrfContext({ ...tokens, origin: 'null', 'sec-fetch-site': 'same-origin', host: 'localhost:8443' });
+      expect(validateStrictCookieCsrfRequest(c)).toBe('Invalid request origin');
+      expect(validateCookieCsrfRequest(c)).toBe('Invalid request origin');
+    });
   });
 });
 

--- a/apps/api/src/routes/auth/helpers.ts
+++ b/apps/api/src/routes/auth/helpers.ts
@@ -15,7 +15,7 @@ import {
 } from '../../services';
 import { envStr } from '../../utils/envStr';
 import { getImmediatePeerIpOrUndefined, rateLimitIpKey, trustsForwardedHeadersFrom } from '../../services/clientIp';
-import { effectiveRequestScheme } from '../../services/requestTransport';
+import { effectiveRequestScheme, isSameOriginRequest } from '../../services/requestTransport';
 import { createAuditLogAsync } from '../../services/auditService';
 import { recordFailedLogin } from '../../services/anomalyMetrics';
 import { consumeMFAToken } from '../../services/mfa';
@@ -1011,8 +1011,11 @@ export function validateCookieCsrfRequest(c: Context): string | null {
     return 'Invalid CSRF token';
   }
 
+  // A same-origin request (SSH tunnel / LAN name that is not the configured
+  // public URL) is not CSRF even when its Origin is outside the allowlist —
+  // see isSameOriginRequest.
   const origin = c.req.header('origin');
-  if (origin && !isAllowedOrigin(origin)) {
+  if (origin && !isAllowedOrigin(origin) && !isSameOriginRequest(c, origin)) {
     return 'Invalid request origin';
   }
 
@@ -1041,7 +1044,7 @@ export function validateStrictCookieCsrfRequest(c: Context): string | null {
 
   const origin = c.req.header('origin');
   if (!origin) return 'Missing request origin';
-  if (!isAllowedOrigin(origin)) return 'Invalid request origin';
+  if (!isAllowedOrigin(origin) && !isSameOriginRequest(c, origin)) return 'Invalid request origin';
 
   const fetchSite = c.req.header('sec-fetch-site');
   if (fetchSite) {

--- a/apps/api/src/routes/auth/login.ts
+++ b/apps/api/src/routes/auth/login.ts
@@ -866,7 +866,15 @@ loginRoutes.post('/refresh', async (c) => {
   const csrfError = validateCookieCsrfRequest(c);
   if (csrfError) {
     clearRefreshTokenCookie(c);
-    return c.json({ error: csrfError }, 403);
+    // `code` lets the web client tell an origin misconfiguration (operator
+    // opened Breeze at an address outside CORS_ALLOWED_ORIGINS) apart from a
+    // dead session, instead of showing "session expired" for both.
+    return c.json(
+      csrfError === 'Invalid request origin'
+        ? { error: csrfError, code: 'invalid_request_origin' }
+        : { error: csrfError },
+      403,
+    );
   }
 
   const payload = await verifyToken(refreshToken);

--- a/apps/api/src/routes/portal/helpers.test.ts
+++ b/apps/api/src/routes/portal/helpers.test.ts
@@ -7,6 +7,7 @@ import {
   setPortalSessionCookies,
   clearPortalSessionCookies,
   _resetPortalCookieWarnStateForTests,
+  validatePortalCookieCsrfRequest,
 } from './helpers';
 import type { Context } from 'hono';
 
@@ -289,5 +290,56 @@ describe('portal cookie transport warnings (#2611 diagnostics)', () => {
     setPortalSessionCookies(makeCookieContext({ forwardedProto: 'http' }).c, 't');
     expect(allWarnings()).toContain('PORTAL_COOKIE_SAME_SITE=None');
     expect(allWarnings()).toContain('WILL silently discard');
+  });
+});
+
+describe('validatePortalCookieCsrfRequest — same-origin requests outside CORS_ALLOWED_ORIGINS', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalOrigins = process.env.CORS_ALLOWED_ORIGINS;
+  const originalTrust = process.env.TRUST_PROXY_HEADERS;
+
+  beforeEach(() => {
+    process.env.NODE_ENV = 'production';
+    process.env.CORS_ALLOWED_ORIGINS = 'https://portal.example.com';
+    process.env.TRUST_PROXY_HEADERS = 'false';
+  });
+
+  afterEach(() => {
+    if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = originalNodeEnv;
+    if (originalOrigins === undefined) delete process.env.CORS_ALLOWED_ORIGINS;
+    else process.env.CORS_ALLOWED_ORIGINS = originalOrigins;
+    if (originalTrust === undefined) delete process.env.TRUST_PROXY_HEADERS;
+    else process.env.TRUST_PROXY_HEADERS = originalTrust;
+  });
+
+  function csrfContext(headers: Record<string, string>, url = 'http://api:3001/api/v1/portal/logout'): Context {
+    const normalized = Object.fromEntries(
+      Object.entries(headers).map(([name, value]) => [name.toLowerCase(), value]),
+    );
+    return {
+      get: (key: string) => (key === 'portalAuth' ? { authMethod: 'cookie' } : undefined),
+      req: { header: (name: string) => normalized[name.toLowerCase()], url },
+    } as unknown as Context;
+  }
+
+  const tokens = { cookie: 'breeze_portal_csrf_token=csrf', 'x-breeze-csrf': 'csrf' };
+
+  it('accepts a tunnel origin the browser asserts is same-origin', () => {
+    const c = csrfContext({ ...tokens, origin: 'https://localhost:8443', 'sec-fetch-site': 'same-origin' });
+    expect(validatePortalCookieCsrfRequest(c)).toBeNull();
+  });
+
+  it('accepts a tunnel origin equal to the request scheme + Host', () => {
+    const c = csrfContext(
+      { ...tokens, origin: 'https://localhost:8443', host: 'localhost:8443' },
+      'https://localhost:8443/api/v1/portal/logout',
+    );
+    expect(validatePortalCookieCsrfRequest(c)).toBeNull();
+  });
+
+  it('still rejects a foreign origin', () => {
+    const c = csrfContext({ ...tokens, origin: 'https://evil.example', 'sec-fetch-site': 'same-site', host: 'localhost:8443' });
+    expect(validatePortalCookieCsrfRequest(c)).toBe('Invalid request origin');
   });
 });

--- a/apps/api/src/routes/portal/helpers.ts
+++ b/apps/api/src/routes/portal/helpers.ts
@@ -9,6 +9,7 @@ import { DEFAULT_ALLOWED_ORIGINS } from '../../services/corsOrigins';
 import { getRedis } from '../../services/redis';
 import { portalBase } from '../../services/portalUrl';
 import type { PortalSession } from './schemas';
+import { isSameOriginRequest } from '../../services/requestTransport';
 import {
   PORTAL_SESSION_COOKIE_NAME,
   PORTAL_SESSION_COOKIE_PATH,
@@ -542,8 +543,10 @@ export function validatePortalCookieCsrfRequest(c: Context): string | null {
     return 'Invalid CSRF token';
   }
 
+  // Same-origin requests (tunnel / LAN name outside the allowlist) are not
+  // CSRF — see services/requestTransport.ts isSameOriginRequest.
   const origin = c.req.header('origin');
-  if (origin && !isAllowedOrigin(origin)) {
+  if (origin && !isAllowedOrigin(origin) && !isSameOriginRequest(c, origin)) {
     return 'Invalid request origin';
   }
 

--- a/apps/api/src/services/clientIp.ts
+++ b/apps/api/src/services/clientIp.ts
@@ -229,7 +229,7 @@ function shouldEmitProxyTrustWarnNow(key: string): boolean {
   return true;
 }
 
-const TRUST_GATED_HEADER_LIST = 'CF-Connecting-IP/X-Forwarded-For/X-Real-IP/X-Forwarded-Proto';
+const TRUST_GATED_HEADER_LIST = 'CF-Connecting-IP/X-Forwarded-For/X-Real-IP/X-Forwarded-Proto/X-Forwarded-Host';
 
 function warnForwardedHeadersFromUntrustedPeer(peerIp: string | undefined): void {
   // Count every occurrence — Prometheus rates are only useful unsampled.

--- a/apps/api/src/services/clientIp.ts
+++ b/apps/api/src/services/clientIp.ts
@@ -200,6 +200,10 @@ export function hasTrustGatedForwardedHeaders(c: RequestLike): boolean {
   return (
     hasForwardedIpHeaders(c)
     || Boolean(c.req.header('x-forwarded-proto') ?? c.req.header('X-Forwarded-Proto'))
+    // Consumed by effectiveRequestOrigin (same-origin CSRF proof) only from a
+    // trusted peer, so an untrusted peer sending it is the same
+    // misconfiguration signal as the headers above.
+    || Boolean(c.req.header('x-forwarded-host') ?? c.req.header('X-Forwarded-Host'))
   );
 }
 

--- a/apps/api/src/services/requestTransport.test.ts
+++ b/apps/api/src/services/requestTransport.test.ts
@@ -242,6 +242,14 @@ describe('isSameOriginRequest', () => {
     ['non-http scheme', 'ftp://localhost:8443'],
     ['origin with a path', 'https://localhost:8443/login'],
     ['empty origin', ''],
+    // Spellings the WHATWG parser would normalise into a match; the Origin
+    // grammar rejects them before parsing.
+    ['backslash origin', 'https:\\\\localhost:8443'],
+    ['origin with userinfo', 'https://user@localhost:8443'],
+    ['percent-encoded host', 'https://local%68ost:8443'],
+    ['origin with an empty query', 'https://localhost:8443?'],
+    ['origin with an empty fragment', 'https://localhost:8443#'],
+    ['origin with a trailing slash', 'https://localhost:8443/'],
   ])('rejects a %s even with Sec-Fetch-Site: same-origin', (_label, origin) => {
     process.env.TRUST_PROXY_HEADERS = 'false';
     const c = ctx({ headers: { origin, 'sec-fetch-site': 'same-origin', host: 'localhost:8443' }, url: 'https://localhost:8443/x' });
@@ -260,6 +268,11 @@ describe('isSameOriginRequest', () => {
     it('accepts Origin equal to the request scheme + Host', () => {
       const c = ctx({ headers: { host: 'localhost:8443' }, url: 'https://localhost:8443/api/v1/auth/refresh' });
       expect(isSameOriginRequest(c, 'https://localhost:8443')).toBe(true);
+    });
+
+    it('accepts IPv4 and bracketed IPv6 hosts', () => {
+      expect(isSameOriginRequest(ctx({ headers: { host: '192.168.1.50' }, url: 'https://192.168.1.50/x' }), 'https://192.168.1.50')).toBe(true);
+      expect(isSameOriginRequest(ctx({ headers: { host: '[::1]:8443' }, url: 'https://[::1]:8443/x' }), 'https://[::1]:8443')).toBe(true);
     });
 
     it('normalises host case and default ports', () => {

--- a/apps/api/src/services/requestTransport.test.ts
+++ b/apps/api/src/services/requestTransport.test.ts
@@ -1,10 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import type { Context } from 'hono';
-import {
-  effectiveRequestScheme,
-  isCanonicalRequestHost,
-  canonicalHttpsRedirect,
-} from './requestTransport';
+import { effectiveRequestScheme, isCanonicalRequestHost, canonicalHttpsRedirect, isSameOriginRequest } from './requestTransport';
 
 // Mirrors the canonical shim pattern used across services/clientIp.test.ts and
 // routes/auth/helpers.test.ts.
@@ -203,6 +199,139 @@ describe('requestTransport', () => {
     it('does not redirect a request already using canonical https (no-op pass-through)', () => {
       const c = makeContext({ url: 'https://api.example.com/foo', host: 'api.example.com', remoteAddress: null });
       expect(canonicalHttpsRedirect(c, publicApiUrl)).toBeNull();
+    });
+  });
+});
+
+describe('isSameOriginRequest', () => {
+  const originalTrust = process.env.TRUST_PROXY_HEADERS;
+  const originalCidrs = process.env.TRUSTED_PROXY_CIDRS;
+
+  afterEach(() => {
+    if (originalTrust === undefined) delete process.env.TRUST_PROXY_HEADERS;
+    else process.env.TRUST_PROXY_HEADERS = originalTrust;
+    if (originalCidrs === undefined) delete process.env.TRUSTED_PROXY_CIDRS;
+    else process.env.TRUSTED_PROXY_CIDRS = originalCidrs;
+  });
+
+  function ctx(opts: {
+    headers?: Record<string, string>;
+    url?: string;
+    remoteAddress?: string;
+  }): Context {
+    const headers: Record<string, string> = {};
+    for (const [k, v] of Object.entries(opts.headers ?? {})) headers[k.toLowerCase()] = v;
+    return {
+      req: {
+        header: (name: string) => headers[name.toLowerCase()],
+        url: opts.url ?? 'http://api:3001/api/v1/auth/refresh',
+      },
+      ...(opts.remoteAddress ? { env: { incoming: { socket: { remoteAddress: opts.remoteAddress } } } } : {}),
+    } as unknown as Context;
+  }
+
+  it('accepts an origin outside the allowlist when the browser asserts Sec-Fetch-Site: same-origin', () => {
+    process.env.TRUST_PROXY_HEADERS = 'false';
+    const c = ctx({ headers: { origin: 'https://localhost:8443', 'sec-fetch-site': 'same-origin', host: 'api:3001' } });
+    expect(isSameOriginRequest(c, 'https://localhost:8443')).toBe(true);
+  });
+
+  it.each([
+    ['null origin', 'null'],
+    ['malformed origin', 'not an origin'],
+    ['non-http scheme', 'ftp://localhost:8443'],
+    ['origin with a path', 'https://localhost:8443/login'],
+    ['empty origin', ''],
+  ])('rejects a %s even with Sec-Fetch-Site: same-origin', (_label, origin) => {
+    process.env.TRUST_PROXY_HEADERS = 'false';
+    const c = ctx({ headers: { origin, 'sec-fetch-site': 'same-origin', host: 'localhost:8443' }, url: 'https://localhost:8443/x' });
+    expect(isSameOriginRequest(c, origin)).toBe(false);
+  });
+
+  it('does not treat Sec-Fetch-Site: same-site as proof (sibling subdomains are same-site)', () => {
+    process.env.TRUST_PROXY_HEADERS = 'false';
+    const c = ctx({ headers: { origin: 'https://evil.example.com', 'sec-fetch-site': 'same-site', host: 'app.example.com' }, url: 'https://app.example.com/x' });
+    expect(isSameOriginRequest(c, 'https://evil.example.com')).toBe(false);
+  });
+
+  describe('direct requests (no proxy trust)', () => {
+    beforeEach(() => { process.env.TRUST_PROXY_HEADERS = 'false'; });
+
+    it('accepts Origin equal to the request scheme + Host', () => {
+      const c = ctx({ headers: { host: 'localhost:8443' }, url: 'https://localhost:8443/api/v1/auth/refresh' });
+      expect(isSameOriginRequest(c, 'https://localhost:8443')).toBe(true);
+    });
+
+    it('normalises host case and default ports', () => {
+      const upper = ctx({ headers: { host: 'LOCALHOST:8443' }, url: 'https://localhost:8443/x' });
+      expect(isSameOriginRequest(upper, 'https://localhost:8443')).toBe(true);
+      const defaultPort = ctx({ headers: { host: 'app.example.com:443' }, url: 'https://app.example.com/x' });
+      expect(isSameOriginRequest(defaultPort, 'https://app.example.com')).toBe(true);
+    });
+
+    it('rejects a scheme mismatch, a host mismatch, and a missing Host', () => {
+      expect(isSameOriginRequest(ctx({ headers: { host: 'localhost:8443' }, url: 'https://localhost:8443/x' }), 'http://localhost:8443')).toBe(false);
+      expect(isSameOriginRequest(ctx({ headers: { host: 'localhost:8443' }, url: 'https://localhost:8443/x' }), 'https://localhost:9443')).toBe(false);
+      expect(isSameOriginRequest(ctx({ headers: {}, url: 'https://localhost:8443/x' }), 'https://localhost:8443')).toBe(false);
+    });
+
+    it('ignores X-Forwarded-Proto/X-Forwarded-Host from an untrusted peer', () => {
+      const c = ctx({
+        headers: { host: 'api:3001', 'x-forwarded-proto': 'https', 'x-forwarded-host': 'localhost:8443' },
+        url: 'http://api:3001/x',
+        remoteAddress: '203.0.113.9',
+      });
+      expect(isSameOriginRequest(c, 'https://localhost:8443')).toBe(false);
+    });
+  });
+
+  describe('behind a trusted reverse proxy', () => {
+    const PROXY = '172.31.0.10';
+    beforeEach(() => {
+      process.env.TRUST_PROXY_HEADERS = 'true';
+      process.env.TRUSTED_PROXY_CIDRS = `${PROXY}/32`;
+    });
+
+    it('uses the forwarded scheme and X-Forwarded-Host (the Caddy-fronted self-host topology)', () => {
+      const c = ctx({
+        headers: { host: 'api:3001', 'x-forwarded-proto': 'https', 'x-forwarded-host': 'localhost:8443' },
+        url: 'http://api:3001/x',
+        remoteAddress: PROXY,
+      });
+      expect(isSameOriginRequest(c, 'https://localhost:8443')).toBe(true);
+    });
+
+    it('falls back to Host when the trusted proxy passes it through unchanged', () => {
+      const c = ctx({
+        headers: { host: 'localhost:8443', 'x-forwarded-proto': 'https' },
+        url: 'http://localhost:8443/x',
+        remoteAddress: PROXY,
+      });
+      expect(isSameOriginRequest(c, 'https://localhost:8443')).toBe(true);
+    });
+
+    it('fails closed on a multi-valued or empty X-Forwarded-Host', () => {
+      const multi = ctx({
+        headers: { host: 'localhost:8443', 'x-forwarded-proto': 'https', 'x-forwarded-host': 'localhost:8443, evil.example' },
+        url: 'http://localhost:8443/x',
+        remoteAddress: PROXY,
+      });
+      expect(isSameOriginRequest(multi, 'https://localhost:8443')).toBe(false);
+      const empty = ctx({
+        headers: { host: 'localhost:8443', 'x-forwarded-proto': 'https', 'x-forwarded-host': '' },
+        url: 'http://localhost:8443/x',
+        remoteAddress: PROXY,
+      });
+      expect(isSameOriginRequest(empty, 'https://localhost:8443')).toBe(false);
+    });
+
+    it('still rejects a cross-site origin that merely matches nothing', () => {
+      const c = ctx({
+        headers: { host: 'api:3001', 'x-forwarded-proto': 'https', 'x-forwarded-host': 'app.example.com' },
+        url: 'http://api:3001/x',
+        remoteAddress: PROXY,
+      });
+      expect(isSameOriginRequest(c, 'https://evil.example')).toBe(false);
     });
   });
 });

--- a/apps/api/src/services/requestTransport.ts
+++ b/apps/api/src/services/requestTransport.ts
@@ -135,3 +135,95 @@ export function canonicalHttpsRedirect(c: Context, publicApiUrl: URL): URL | nul
   location.search = requestUrl.search;
   return location;
 }
+
+/**
+ * Parse a browser `Origin` header value into its normalized origin
+ * (`scheme://host[:port]`, lowercase host, default port dropped). Returns null
+ * for anything that is not a plain HTTP(S) origin: the literal `null` origin
+ * (sandboxed iframes, redirects across origins), malformed values, other
+ * schemes, or a value smuggling a path/query/credentials.
+ */
+export function parseHttpOrigin(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed || trimmed.toLowerCase() === 'null') return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+  if (parsed.username || parsed.password || parsed.pathname !== '/' || parsed.search || parsed.hash) {
+    return null;
+  }
+  return parsed.origin;
+}
+
+/**
+ * The origin this request was addressed to, as the browser saw it: the
+ * effective scheme (`effectiveRequestScheme`, i.e. a trusted
+ * `X-Forwarded-Proto` or the direct socket scheme) plus the host the browser
+ * put in the URL. Behind a trusted proxy that host is `X-Forwarded-Host`; a
+ * proxy that passes `Host` through unchanged (Caddy's default) needs no
+ * forwarded-host header at all. Untrusted peers cannot influence either
+ * component — `trustsForwardedHeadersFrom` gates both.
+ *
+ * Fails closed (null) on a missing/unparsable host, or on a trusted
+ * `X-Forwarded-Host` that is empty or multi-valued (several proxy hops with
+ * no way to tell which one the browser addressed).
+ */
+export function effectiveRequestOrigin(c: Context): string | null {
+  const scheme = effectiveRequestScheme(c);
+
+  let host: string | undefined;
+  if (trustsForwardedHeadersFrom(c)) {
+    const forwardedHost = c.req.header('x-forwarded-host');
+    if (forwardedHost !== undefined) {
+      const trimmed = forwardedHost.trim();
+      if (!trimmed || trimmed.includes(',')) return null;
+      host = trimmed;
+    }
+  }
+  if (host === undefined) host = c.req.header('host')?.trim();
+  if (!host) return null;
+
+  return parseHttpOrigin(`${scheme}://${host}`);
+}
+
+/**
+ * Whether a cookie-authenticated request provably comes from the page's OWN
+ * origin, independent of the CORS_ALLOWED_ORIGINS allowlist.
+ *
+ * Why this exists: self-hosters reach the bundled Caddy through an SSH tunnel
+ * or a LAN name that differs from the configured public URL (the quickstart's
+ * own recipe is `ssh -L 8443:127.0.0.1:443` → https://localhost:8443 while
+ * the generated allowlist is https://localhost). Every request in that
+ * topology is same-origin — browser and API share one origin behind Caddy —
+ * yet the allowlist rejected it on /auth/refresh, cleared the refresh cookie,
+ * and produced an endless "session expired" loop that looked like a wrong
+ * password. A same-origin request is by definition not cross-site request
+ * forgery, so it is safe to admit regardless of the allowlist.
+ *
+ * Proof is one of:
+ *  1. `Sec-Fetch-Site: same-origin` — set by the browser, never by script, and
+ *     only when the initiator's origin equals the request URL's origin.
+ *  2. The `Origin` header equals `effectiveRequestOrigin(c)`. A cross-site
+ *     page's browser sends ITS origin, which can never equal our own host;
+ *     DNS rebinding cannot carry our host-only cookies to another host.
+ *
+ * Always fails closed on a `null`/malformed `Origin`. `same-site` is NOT
+ * accepted (sibling subdomains and subdomain takeovers are same-site). Callers
+ * must keep their double-submit token check in front of this, and their
+ * `Sec-Fetch-Site: cross-site` veto after it.
+ */
+export function isSameOriginRequest(c: Context, origin: string | undefined): boolean {
+  const requestOrigin = parseHttpOrigin(origin);
+  if (!requestOrigin) return false;
+
+  if (c.req.header('sec-fetch-site')?.trim().toLowerCase() === 'same-origin') {
+    return true;
+  }
+
+  const effective = effectiveRequestOrigin(c);
+  return effective !== null && effective === requestOrigin;
+}

--- a/apps/api/src/services/requestTransport.ts
+++ b/apps/api/src/services/requestTransport.ts
@@ -143,9 +143,17 @@ export function canonicalHttpsRedirect(c: Context, publicApiUrl: URL): URL | nul
  * (sandboxed iframes, redirects across origins), malformed values, other
  * schemes, or a value smuggling a path/query/credentials.
  */
+// The ASCII serialization of an HTTP(S) origin, as a browser emits it:
+// scheme, host (DNS name in punycode, IPv4, or bracketed IPv6), optional port.
+// Checked BEFORE the WHATWG parser so lenient spellings the parser would
+// normalise (backslashes, percent-encoding, userinfo, an empty `?`/`#`) are
+// rejected rather than canonicalised into a match.
+const HTTP_ORIGIN_RE = /^https?:\/\/(?:[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)*\.?|\[[0-9A-Fa-f:.]+\])(?::[0-9]{1,5})?$/;
+
 export function parseHttpOrigin(value: string | undefined): string | null {
   const trimmed = value?.trim();
   if (!trimmed || trimmed.toLowerCase() === 'null') return null;
+  if (!HTTP_ORIGIN_RE.test(trimmed)) return null;
   let parsed: URL;
   try {
     parsed = new URL(trimmed);


### PR DESCRIPTION
## Why

Reported on Discord / #4201 thread: after `guided-setup.sh`, a self-hoster "cannot log in with the bootstrap admin, with the original or the new password". Reproduced against a 0.108.0 stack. The password was fine. The quickstart's own recipe (`BREEZE_DOMAIN=localhost`, `ssh -L 8443:127.0.0.1:443`, browse `https://localhost:8443`) produces a browser origin with a port, while the generated allowlist is `CORS_ALLOWED_ORIGINS=https://localhost`. `POST /auth/refresh` runs `validateCookieCsrfRequest`, rejects the origin with 403 `Invalid request origin`, and clears the refresh cookie; the web client keeps access tokens in memory only, so the first hard navigation (the setup wizard's "Continue to Dashboard") evicts the session, and every later login mints a fresh cookie that hits the same static mismatch. Result: an endless `/login?reason=session-expired` loop that looks like a bad password. Any LAN name or alternate hostname that differs from `PUBLIC_APP_URL` fails the same way.

## What changed

- `services/requestTransport.ts`: `isSameOriginRequest(c, origin)` plus `parseHttpOrigin` / `effectiveRequestOrigin`. A request is admitted when the browser asserts `Sec-Fetch-Site: same-origin`, or when `Origin` equals the request's effective origin (`effectiveRequestScheme` + `X-Forwarded-Host` from a trusted proxy, else `Host`). Fails closed on `null`/malformed origins, never accepts `same-site`, only consumes `X-Forwarded-Host` through the existing `trustsForwardedHeadersFrom` gate, and rejects a multi-valued/empty trusted value instead of guessing.
- Wired as a fallback **after** the allowlist in: auth `validateCookieCsrfRequest` (`/refresh`) and `validateStrictCookieCsrfRequest` (`/logout`, CF Access logout prep), `/browser-binding/bootstrap`, and the portal CSRF validator. The double-submit token remains the first gate and the `cross-site` veto remains last.
- `/auth/refresh` 403 for this case now carries `code: "invalid_request_origin"` (a companion web PR shows an operator-facing notice instead of "session expired").
- `X-Forwarded-Host` added to `hasTrustGatedForwardedHeaders` so an untrusted peer sending it raises the existing proxy-misconfiguration warning.
- Two existing tests paired a foreign `Origin` with `Sec-Fetch-Site: same-origin` (impossible from a browser); they now use `same-site`.

## Why this is safe

A cross-site page's browser sends *its* origin, which can never equal our host; `Sec-Fetch-Site` cannot be set by script; DNS rebinding cannot carry our host-only cookies to another host (no `Domain` attribute on the auth cookies). Same-origin fetches neither preflight nor need CORS, so the CORS middleware is untouched. Design confirmed by an independent Codex `xhigh` review before implementation.

## Verification

- Red-first tests: 15 new cases across `requestTransport.test.ts`, `auth/helpers.test.ts`, `auth/binding.test.ts`, `portal/helpers.test.ts` (same-origin via fetch metadata, via Origin==Host direct, via trusted `X-Forwarded-Host`, untrusted spoof ignored, multi-valued XFH fails closed, `null`/malformed/`same-site`/foreign origins rejected).
- `vitest run` on the 7 affected files: 337 passed. `eslint` and `tsc --noEmit` clean.
- Manual: 0.108.0 stack behind Caddy, `POST /auth/refresh` with `Origin: https://localhost:8443` and a valid CSRF pair → 403 before this change, 200 with `Origin: https://localhost` (allowlisted); with this change the tunnel origin is accepted.
- A follow-up PR adds a CI job that runs `guided-setup.sh` end to end on a runner and exercises exactly this refresh through a local tunnel, so it cannot regress silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PiZHjEw4swqE7HvYP5cEpo