### PR TITLE
fix(web,docs): surface origin-rejected refresh as its own login notice; fix SSH-tunnel recipe

### DIFF
--- a/apps/docs/src/content/docs/getting-started/quickstart.mdx
+++ b/apps/docs/src/content/docs/getting-started/quickstart.mdx
@@ -164,6 +164,26 @@ Pick whichever fits:
   # then browse to https://localhost:8443
   ```
 
+  A browser origin includes the **port**, so `https://localhost:8443` is a
+  different origin from the `https://localhost` that the generated `.env`
+  allows, and the API rejects sign-in requests coming from it. Pick one of:
+
+  ```bash
+  # Forward the SAME port — 443 is privileged, so run this as root
+  sudo ssh -L 443:127.0.0.1:443 user@your-server
+  # then browse to https://localhost
+  ```
+
+  ```bash
+  # …or keep the high port and add the tunnel origin to .env on the server
+  # (comma-separated, no spaces, no trailing paths)
+  CORS_ALLOWED_ORIGINS=https://localhost,https://localhost:8443
+  docker compose up -d api
+  ```
+
+  From the next release the API accepts same-origin requests on its own, so the
+  extra entry is no longer required — but it stays correct either way.
+
 - **LAN address** — serve the machine's IP or hostname directly:
 
   ```bash
@@ -180,6 +200,23 @@ Pick whichever fits:
 
 Whichever you choose, `PUBLIC_APP_URL` must be the URL users actually visit:
 it is what agent installers and portal links are built from.
+
+## Troubleshooting
+
+**You are sent back to the login page with "session expired" right after signing in**
+- Cause: the address in your browser's address bar is not an origin this server
+  accepts. `CORS_ALLOWED_ORIGINS` doesn't list it, or `PUBLIC_APP_URL` is set to
+  a different address than the one you are visiting. Reaching a
+  `BREEZE_DOMAIN=localhost` install through an SSH tunnel on a different port is
+  the usual way to land here — the password was fine, the sign-in worked, and
+  the token refresh that follows it is what got rejected.
+- Confirm: open your browser devtools, go to the **Network** tab, and sign in
+  again. `POST /api/v1/auth/refresh` returns **403** with the body
+  `{"error":"Invalid request origin"}`. Newer Breeze builds also say so on the
+  login page itself, naming the exact origin that was refused.
+- Fix: browse to the address in `PUBLIC_APP_URL`, or add the address you are
+  actually using to `CORS_ALLOWED_ORIGINS` in `.env` (comma-separated, no spaces,
+  no trailing paths) and restart the API with `docker compose up -d api`.
 
 ## What's Running
 

--- a/apps/web/src/components/auth/AdminSessionManager.test.tsx
+++ b/apps/web/src/components/auth/AdminSessionManager.test.tsx
@@ -520,6 +520,23 @@ describe('AdminSessionManager heartbeat refresh outcomes (Task 3)', () => {
     expect(apiLogoutMock).not.toHaveBeenCalled();
   });
 
+  // Same eviction as 'auth-failed', different reason code: the keepalive is
+  // the second way a self-hoster on a rejected origin reaches /login, and it
+  // must carry the code that explains the bounce.
+  it("'origin-rejected' evicts with the origin-rejected reason", async () => {
+    restoreAccessTokenFromCookieDetailedMock.mockResolvedValue('origin-rejected');
+
+    render(<AdminSessionManager />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(handleSessionExpiredMock).toHaveBeenCalledTimes(1);
+    expect(handleSessionExpiredMock).toHaveBeenCalledWith('origin-rejected');
+    expect(apiLogoutMock).not.toHaveBeenCalled();
+  });
+
   it("'transient' does nothing — no eviction, no stamp, the next heartbeat retries", async () => {
     restoreAccessTokenFromCookieDetailedMock.mockResolvedValue('transient');
 

--- a/apps/web/src/components/auth/AdminSessionManager.tsx
+++ b/apps/web/src/components/auth/AdminSessionManager.tsx
@@ -73,12 +73,17 @@ export default function AdminSessionManager() {
       const outcome = await restoreAccessTokenFromCookieDetailed();
       if (outcome === 'restored') {
         lastRefreshAtRef.current = Date.now();
-      } else if (outcome === 'auth-failed') {
+      } else if (outcome === 'auth-failed' || outcome === 'origin-rejected') {
         // The refresh endpoint reached a verdict: the session is
         // unrecoverable. Stand the heartbeat down before evicting so no
         // later tick fires a redundant refresh against a dead cookie.
+        //
+        // 'origin-rejected' evicts identically but carries its own reason to
+        // /login: the API refused this browser's Origin, so the sign-in page
+        // must explain the CORS/PUBLIC_APP_URL mismatch instead of claiming the
+        // session expired.
         idleLogoutInFlightRef.current = true;
-        handleSessionExpired('session-expired');
+        handleSessionExpired(outcome === 'origin-rejected' ? 'origin-rejected' : 'session-expired');
       }
       // 'transient': no verdict on the cookie (network/5xx blip) — do
       // nothing. lastRefreshAtRef stays stale so the next 30s heartbeat

--- a/apps/web/src/components/auth/LoginPage.test.tsx
+++ b/apps/web/src/components/auth/LoginPage.test.tsx
@@ -416,11 +416,11 @@ describe('LoginPage navigation after MFA verify', () => {
 // /login?next=…&reason=<code>. Without a notice the user lands on a bare sign-in
 // form with no explanation of why they were kicked out.
 describe('LoginPage session-expiry notice', () => {
-  function withSearch(search: string, run: () => Promise<void>): Promise<void> {
+  function withSearch(search: string, run: () => Promise<void>, origin?: string): Promise<void> {
     const realLocation = window.location;
     Object.defineProperty(window, 'location', {
       configurable: true,
-      value: { ...realLocation, search },
+      value: { ...realLocation, search, ...(origin ? { origin } : {}) },
     });
     return run().finally(() => {
       Object.defineProperty(window, 'location', { configurable: true, value: realLocation });
@@ -437,6 +437,25 @@ describe('LoginPage session-expiry notice', () => {
       const notice = await screen.findByTestId('login-session-expired-notice');
       expect(notice).toHaveTextContent(copy);
     }));
+
+  // A self-hoster on an SSH tunnel is bounced here after EVERY successful
+  // login because the API rejects https://localhost:8443 as an origin. The
+  // generic expiry copy sends them hunting for a password problem, so this
+  // notice has to name the origin the browser is actually using and both
+  // settings that accept it.
+  it('renders the origin-rejected notice with the browser origin interpolated', async () =>
+    withSearch(
+      '?next=%2Fdevices&reason=origin-rejected',
+      async () => {
+        render(<LoginPage />);
+
+        const notice = await screen.findByTestId('login-session-expired-notice');
+        expect(notice).toHaveTextContent('https://localhost:8443');
+        expect(notice).toHaveTextContent(/PUBLIC_APP_URL/);
+        expect(notice).toHaveTextContent(/CORS_ALLOWED_ORIGINS/);
+      },
+      'https://localhost:8443',
+    ));
 
   it('renders nothing for an unrecognized reason', async () =>
     withSearch('?reason=made-up-code', async () => {

--- a/apps/web/src/components/auth/LoginPage.tsx
+++ b/apps/web/src/components/auth/LoginPage.tsx
@@ -45,6 +45,17 @@ function getSessionExpiredNotice(t: ReturnType<typeof useTranslation<'auth'>>['t
     idle: t('login.notices.idle', {
       defaultValue: 'You were signed out due to inactivity.',
     }),
+    // Not an expiry: POST /auth/refresh answered 403 "Invalid request origin",
+    // i.e. the API was never told about the address this browser is using
+    // (classically a self-hoster on an SSH tunnel — https://localhost:8443
+    // against a CORS_ALLOWED_ORIGINS of https://localhost). Without naming the
+    // origin, the bounce is indistinguishable from a bad password and it
+    // repeats after every successful sign-in.
+    'origin-rejected': t('login.notices.originRejected', {
+      origin: window.location.origin,
+      defaultValue:
+        'This Breeze server is not configured to accept sign-ins from {{origin}}. Open Breeze at the public URL set during setup (PUBLIC_APP_URL), or add {{origin}} to CORS_ALLOWED_ORIGINS in .env and restart the API.',
+    }),
   };
   return reason ? sessionExpiredCopy[reason] : undefined;
 }

--- a/apps/web/src/locales/de-DE/auth.json
+++ b/apps/web/src/locales/de-DE/auth.json
@@ -160,6 +160,7 @@
     "newHere": "Neu hier?",
     "notices": {
       "idle": "Sie wurden wegen Inaktivität abgemeldet.",
+      "originRejected": "Dieser Breeze-Server ist nicht dafür konfiguriert, Anmeldungen von {{origin}} zu akzeptieren. Öffnen Sie Breeze unter der bei der Einrichtung festgelegten öffentlichen Adresse (PUBLIC_APP_URL) oder fügen Sie {{origin}} zu CORS_ALLOWED_ORIGINS in .env hinzu und starten Sie die API neu.",
       "registrationDisabled": "Neue Registrierungen sind derzeit deaktiviert. Wenden Sie sich an Ihre Administration.",
       "sessionExpired": "Ihre Sitzung ist abgelaufen. Bitte melden Sie sich erneut an, um fortzufahren."
     },

--- a/apps/web/src/locales/en/auth.json
+++ b/apps/web/src/locales/en/auth.json
@@ -160,6 +160,7 @@
     "newHere": "New here?",
     "notices": {
       "idle": "You were signed out due to inactivity.",
+      "originRejected": "This Breeze server is not configured to accept sign-ins from {{origin}}. Open Breeze at the public URL set during setup (PUBLIC_APP_URL), or add {{origin}} to CORS_ALLOWED_ORIGINS in .env and restart the API.",
       "registrationDisabled": "New registrations are currently disabled. Please contact your administrator.",
       "sessionExpired": "Your session expired. Please sign in again to continue."
     },

--- a/apps/web/src/locales/es-419/auth.json
+++ b/apps/web/src/locales/es-419/auth.json
@@ -160,6 +160,7 @@
     "newHere": "¿Nuevo aquí?",
     "notices": {
       "idle": "Se cerró su sesión por inactividad.",
+      "originRejected": "Este servidor de Breeze no está configurado para aceptar inicios de sesión desde {{origin}}. Abra Breeze en la dirección pública definida durante la configuración (PUBLIC_APP_URL) o agregue {{origin}} a CORS_ALLOWED_ORIGINS en .env y reinicie la API.",
       "registrationDisabled": "Los nuevos registros están actualmente deshabilitados. Por favor contacte a su administrador.",
       "sessionExpired": "Su sesión expiró. Inicie sesión nuevamente para continuar."
     },

--- a/apps/web/src/locales/fr-CA/auth.json
+++ b/apps/web/src/locales/fr-CA/auth.json
@@ -160,6 +160,7 @@
     "newHere": "Nouveau ici ?",
     "notices": {
       "idle": "Votre session a été fermée en raison d’une période d’inactivité.",
+      "originRejected": "Ce serveur Breeze n’est pas configuré pour accepter les connexions provenant de {{origin}}. Ouvrez Breeze à l’adresse publique définie lors de l’installation (PUBLIC_APP_URL), ou ajoutez {{origin}} à CORS_ALLOWED_ORIGINS dans .env puis redémarrez l’API.",
       "registrationDisabled": "Les nouvelles immatriculations sont actuellement désactivées. Veuillez contacter votre administrateur.",
       "sessionExpired": "Votre session est expirée. Ouvrez une session de nouveau pour continuer."
     },

--- a/apps/web/src/locales/fr-FR/auth.json
+++ b/apps/web/src/locales/fr-FR/auth.json
@@ -160,6 +160,7 @@
     "newHere": "Nouveau ici ?",
     "notices": {
       "idle": "Vous avez été déconnecté pour cause d’inactivité.",
+      "originRejected": "Ce serveur Breeze n’est pas configuré pour accepter les connexions depuis {{origin}}. Ouvrez Breeze à l’adresse publique définie lors de l’installation (PUBLIC_APP_URL), ou ajoutez {{origin}} à CORS_ALLOWED_ORIGINS dans .env puis redémarrez l’API.",
       "registrationDisabled": "Les nouvelles immatriculations sont actuellement désactivées. Veuillez contacter votre administrateur.",
       "sessionExpired": "Votre session a expiré. Veuillez vous reconnecter pour continuer."
     },

--- a/apps/web/src/locales/it-IT/auth.json
+++ b/apps/web/src/locales/it-IT/auth.json
@@ -160,6 +160,7 @@
     "newHere": "È la tua prima volta qui?",
     "notices": {
       "idle": "Sei stato disconnesso per inattività.",
+      "originRejected": "Questo server Breeze non è configurato per accettare accessi da {{origin}}. Apri Breeze all’indirizzo pubblico impostato durante la configurazione (PUBLIC_APP_URL) oppure aggiungi {{origin}} a CORS_ALLOWED_ORIGINS in .env e riavvia l’API.",
       "registrationDisabled": "Le nuove registrazioni sono attualmente disabilitate. Contatta il tuo amministratore.",
       "sessionExpired": "La tua sessione è scaduta. Accedi di nuovo per continuare."
     },

--- a/apps/web/src/locales/pt-BR/auth.json
+++ b/apps/web/src/locales/pt-BR/auth.json
@@ -160,6 +160,7 @@
     "newHere": "Novo por aqui?",
     "notices": {
       "idle": "Você foi desconectado por inatividade.",
+      "originRejected": "Este servidor Breeze não está configurado para aceitar entradas a partir de {{origin}}. Abra o Breeze no endereço público definido durante a configuração (PUBLIC_APP_URL) ou adicione {{origin}} a CORS_ALLOWED_ORIGINS no .env e reinicie a API.",
       "registrationDisabled": "Novos cadastros estão desativados no momento. Entre em contato com o administrador.",
       "sessionExpired": "Sua sessão expirou. Entre novamente para continuar."
     },

--- a/apps/web/src/locales/tr-TR/auth.json
+++ b/apps/web/src/locales/tr-TR/auth.json
@@ -160,6 +160,7 @@
     "newHere": "Burada yeni misiniz?",
     "notices": {
       "idle": "Etkinlik olmadığı için oturumunuz kapatıldı.",
+      "originRejected": "Bu Breeze sunucusu {{origin}} adresinden gelen oturum açma isteklerini kabul edecek şekilde yapılandırılmamış. Breeze’i kurulum sırasında belirlenen genel adresten (PUBLIC_APP_URL) açın veya {{origin}} adresini .env dosyasındaki CORS_ALLOWED_ORIGINS değerine ekleyip API’yi yeniden başlatın.",
       "registrationDisabled": "Yeni kayıtlar şu anda devre dışıdır. Lütfen yöneticinizle iletişime geçin.",
       "sessionExpired": "Oturumunuzun süresi doldu. Devam etmek için lütfen tekrar oturum açın."
     },

--- a/apps/web/src/stores/auth.test.ts
+++ b/apps/web/src/stores/auth.test.ts
@@ -364,6 +364,59 @@ describe('auth store fetchWithAuth', () => {
     expect(replace).toHaveBeenCalledWith(`/login?next=${encodeURIComponent('/devices')}&reason=session-expired`);
   });
 
+  // Self-hosted origin rejection, NOT a dead session. A self-hoster who reaches
+  // the dashboard over an SSH tunnel (`ssh -L 8443:127.0.0.1:443`) browses
+  // https://localhost:8443 while the generated .env allows only
+  // https://localhost, so validateCookieCsrfRequest answers POST /auth/refresh
+  // with 403 {"error":"Invalid request origin"}. Evicting is still correct —
+  // no access token can be minted from that origin — but reporting it as
+  // "session expired" made a pure config problem read as a wrong password,
+  // after EVERY successful login. The reason code is what lets the login page
+  // name the origin and the two settings that fix it.
+  it('reports a 403 "Invalid request origin" refresh as origin-rejected, not session-expired', async () => {
+    useAuthStore.getState().login(baseUser, baseTokens);
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(makeResponse({ error: 'unauthorized' }, false, 401))
+      .mockResolvedValueOnce(makeResponse({ error: 'Invalid request origin' }, false, 403));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { replace, restore } = mockLocation('/devices');
+    try {
+      await fetchWithAuth('/devices');
+    } finally {
+      restore();
+    }
+
+    expect(useAuthStore.getState().isAuthenticated).toBe(false);
+    expect(useAuthStore.getState().sessionExpiredReason).toBe('origin-rejected');
+    expect(replace).toHaveBeenCalledWith(`/login?next=${encodeURIComponent('/devices')}&reason=origin-rejected`);
+  });
+
+  // The discriminator is the body, not the status: every OTHER 403 on refresh
+  // stays a generic expiry, or the notice would blame CORS for unrelated
+  // rejections.
+  it('leaves an unrelated 403 on refresh as a generic session expiry', async () => {
+    useAuthStore.getState().login(baseUser, baseTokens);
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(makeResponse({ error: 'unauthorized' }, false, 401))
+      .mockResolvedValueOnce(makeResponse({ error: 'Forbidden' }, false, 403));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { replace, restore } = mockLocation('/devices');
+    try {
+      await fetchWithAuth('/devices');
+    } finally {
+      restore();
+    }
+
+    expect(useAuthStore.getState().sessionExpiredReason).toBe('session-expired');
+    expect(replace).toHaveBeenCalledWith(`/login?next=${encodeURIComponent('/devices')}&reason=session-expired`);
+  });
+
   // QA 2026-07-08: a single transient 502 on /auth/refresh must NOT boot the
   // user — a gateway blip reaches no verdict on the refresh cookie, so we retry
   // with backoff and recover the session instead of hard-logging-out.
@@ -1515,6 +1568,21 @@ describe('restoreAccessTokenFromCookieDetailed (Task 3 — proactive keepalive)'
     const outcome = await restoreAccessTokenFromCookieDetailed();
 
     expect(outcome).toBe('auth-failed');
+  });
+
+  // Split out from 'auth-failed' so the heartbeat's eviction can carry the
+  // reason code the login notice keys off. Still an eviction — the origin can
+  // never mint a token — just an honestly-labelled one.
+  it("returns 'origin-rejected' on a 403 \"Invalid request origin\"", async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(makeResponse({ error: 'Invalid request origin' }, false, 403))
+    );
+
+    const outcome = await restoreAccessTokenFromCookieDetailed();
+
+    expect(outcome).toBe('origin-rejected');
+    expect(useAuthStore.getState().tokens).toBeNull();
   });
 
   it("returns 'transient' once a 5xx exhausts the retry budget — no verdict on the cookie", async () => {

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -92,6 +92,12 @@ export interface Tokens {
   expiresInSeconds: number;
 }
 
+/**
+ * Why the app bounced the user to /login. Rendered as `?reason=<code>` by
+ * handleSessionExpired() and turned into copy by LoginPage.
+ */
+export type SessionExpiredReason = 'session-expired' | 'idle' | 'origin-rejected';
+
 interface AuthState {
   user: User | null;
   tokens: Tokens | null;
@@ -103,7 +109,12 @@ interface AuthState {
   // overlay, login-page notice) can render a reason in the same tick the nav
   // collapses. NOT persisted — see partialize below — a stale reason must
   // never survive a reload.
-  sessionExpiredReason: 'session-expired' | 'idle' | null;
+  //
+  // 'origin-rejected' is NOT an expiry at all: the API refused the request's
+  // Origin (403 "Invalid request origin"), so no session could be minted from
+  // this address in the first place. It shares this field because the eviction
+  // and redirect are identical — only the copy the user needs differs.
+  sessionExpiredReason: SessionExpiredReason | null;
   // Epoch ms until which POST /auth/refresh is rate-limited for this user
   // (issue #3696). Non-null means "the session is FINE, the server is just
   // throttling us" — the opposite of sessionExpiredReason. AuthOverlay renders
@@ -382,7 +393,10 @@ export function resolveApiOrigin(): string {
 // that only care about restored-or-not.
 type RefreshOutcome =
   | { kind: 'restored'; tokens: Tokens }
-  | { kind: 'auth-failed' }
+  // `originRejected` marks the sub-case where the refresh was refused because
+  // of WHERE the browser is, not because of the cookie it sent — see the 403
+  // branch in refreshFetchOnce. Still an eviction; only the reason differs.
+  | { kind: 'auth-failed'; originRejected?: boolean }
   | { kind: 'transient' }
   // The server rate-limited POST /auth/refresh (429). Like 'transient' this is
   // NOT a verdict on the refresh cookie — but unlike a gateway blip it comes
@@ -420,6 +434,9 @@ async function fetchAuthIssuerWithBindingRetry(
 //                of ms to wait. Split out from `transient` in #3696 because the
 //                two need OPPOSITE handling: a blip should be retried right
 //                away, a throttle must NOT be (see requestTokenRefresh).
+//   - originRejected: a hard failure too, but caused by the browser's Origin
+//                not being allowed (403 "Invalid request origin"), not by the
+//                refresh cookie. Same eviction, different explanation.
 //   - neither:   a hard failure (expired/reused refresh cookie, real 401/403) —
 //                the session is unrecoverable and the caller must evict.
 type RefreshFetchResult = {
@@ -427,7 +444,15 @@ type RefreshFetchResult = {
   raced: boolean;
   transient: boolean;
   throttledForMs?: number;
+  originRejected?: boolean;
 };
+
+// The exact body the API's cookie-CSRF guard answers with when the request's
+// Origin isn't in CORS_ALLOWED_ORIGINS (apps/api/src/routes/auth/helpers.ts,
+// validateCookieCsrfRequest). Matched on the BODY, not the bare 403: other
+// 403s on this endpoint are genuine auth failures and must keep the generic
+// expiry copy.
+const ORIGIN_REJECTED_ERROR = 'Invalid request origin';
 
 // Fallback wait when a 429 arrives without a usable Retry-After/retryAfter —
 // matches the server's default 60s window (apps/api/src/services/rate-limit.ts,
@@ -542,6 +567,22 @@ async function refreshFetchOnce(): Promise<RefreshFetchResult> {
     };
   }
 
+  // A 403 "Invalid request origin" is a CONFIGURATION verdict, not a session
+  // verdict: the request was rejected on its Origin header before the refresh
+  // cookie was evaluated, so retrying (from this address) can only fail again.
+  // It still evicts — no access token can be minted here — but the user needs
+  // to be told about CORS_ALLOWED_ORIGINS / PUBLIC_APP_URL, not about their
+  // password. Self-hosters hit this on every login when they reach the
+  // dashboard at an address the API was never told about (an SSH tunnel's
+  // https://localhost:8443 against a CORS_ALLOWED_ORIGINS of https://localhost).
+  if (refreshResponse.status === 403) {
+    const body = await refreshResponse.json().catch(() => null) as { error?: string } | null;
+    if (body?.error === ORIGIN_REJECTED_ERROR) {
+      return { tokens: null, raced: false, transient: false, originRejected: true };
+    }
+    return { tokens: null, raced: false, transient: false };
+  }
+
   // 5xx (typically a 502/503/504 from the gateway) means the request never
   // reached a verdict on the refresh cookie — retryable, not an auth failure.
   if (refreshResponse.status >= 500) {
@@ -609,11 +650,13 @@ async function requestTokenRefresh(): Promise<RefreshOutcome> {
         // was the same org-switch logout, just rarer. Deliberately reuses the
         // existing bounded ladder rather than adding a second counter — the
         // whole loop stays capped at MAX_TRANSIENT_REFRESH_RETRIES passes.
-        if (!retry.transient && !retry.raced) return { kind: 'auth-failed' };
+        if (!retry.transient && !retry.raced) {
+          return { kind: 'auth-failed', originRejected: retry.originRejected };
+        }
       } else if (!result.transient) {
         // Hard failure (expired/reused refresh cookie, real 401/403): the
         // session is unrecoverable — evict.
-        return { kind: 'auth-failed' };
+        return { kind: 'auth-failed', originRejected: result.originRejected };
       }
 
       // Transient gateway/network failure. Retry with bounded exponential
@@ -777,12 +820,16 @@ export async function waitForPendingRefresh(): Promise<void> {
  * this; callers that only care about restored-or-not keep using the boolean
  * wrapper below.
  */
-export async function restoreAccessTokenFromCookieDetailed(): Promise<'restored' | 'auth-failed' | 'transient' | 'throttled'> {
+export async function restoreAccessTokenFromCookieDetailed(): Promise<'restored' | 'auth-failed' | 'origin-rejected' | 'transient' | 'throttled'> {
   try {
     const outcome = await requestTokenRefreshShared();
     if (outcome.kind === 'restored') {
       useAuthStore.getState().setTokens(outcome.tokens);
     }
+    // Reported separately from 'auth-failed' so callers that evict can pass the
+    // reason on to handleSessionExpired. Callers that only branch on 'restored'
+    // or 'throttled' are unaffected: this is still a dead end.
+    if (outcome.kind === 'auth-failed' && outcome.originRejected) return 'origin-rejected';
     return outcome.kind;
   } catch (err) {
     // Unexpected throw, not a verdict from the server — treat as transient so
@@ -977,6 +1024,17 @@ export class AuthThrottledError extends Error {
 }
 
 /**
+ * Reason code for an eviction caused by a failed refresh. Everything except an
+ * origin rejection is reported as a plain expiry — including 'transient', where
+ * the bounded retries were exhausted without a verdict.
+ */
+function expiryReasonFor(outcome: RefreshOutcome): SessionExpiredReason {
+  return outcome.kind === 'auth-failed' && outcome.originRejected
+    ? 'origin-rejected'
+    : 'session-expired';
+}
+
+/**
  * Single entry point for "the session is unrecoverable, evict and redirect."
  * Both fetchWithAuth expiry paths (dead refresh cookie on bootstrap, and a
  * 401 that survives a refresh-and-retry) funnel through here so idle-timeout
@@ -986,7 +1044,7 @@ export class AuthThrottledError extends Error {
  * The in-flight flag resets on login() so a later re-login (or the next test)
  * can trigger it again.
  */
-export function handleSessionExpired(reason: 'session-expired' | 'idle' = 'session-expired'): void {
+export function handleSessionExpired(reason: SessionExpiredReason = 'session-expired'): void {
   if (sessionExpiryInFlight) return;
   sessionExpiryInFlight = true;
 
@@ -1079,7 +1137,7 @@ export async function fetchWithAuth(rawUrl: string, options: FetchWithAuthOption
       // This evicts on 'transient' too (bounded retries exhausted), unlike the
       // background heartbeat which can wait forever: a foreground fetch needs a
       // verdict now — bounded retries, then evict.
-      handleSessionExpired('session-expired');
+      handleSessionExpired(expiryReasonFor(outcome));
       throw new AuthSessionExpiredError();
     }
   }
@@ -1164,7 +1222,7 @@ export async function fetchWithAuth(rawUrl: string, options: FetchWithAuthOption
             useAuthStore.getState().authThrottledUntil ?? Date.now() + outcome.retryAfterMs
           );
         }
-        handleSessionExpired('session-expired');
+        handleSessionExpired(expiryReasonFor(outcome));
       }
     }
   }


### PR DESCRIPTION
## The chain this fixes

A self-hoster follows the quickstart's **"Reaching the dashboard from another machine"** section, keeps `BREEZE_DOMAIN=localhost`, runs `ssh -L 8443:127.0.0.1:443 user@your-server`, and browses `https://localhost:8443`. The generated `.env` has `CORS_ALLOWED_ORIGINS=https://localhost` — no port, so a different origin.

1. Sign-in succeeds.
2. `POST /api/v1/auth/refresh` runs `validateCookieCsrfRequest` (`apps/api/src/routes/auth/helpers.ts`), which rejects `Origin: https://localhost:8443` with **403 `{"error":"Invalid request origin"}`** and clears the refresh cookie.
3. `refreshFetchOnce` in `apps/web/src/stores/auth.ts` classified that 403 as a hard auth failure, `handleSessionExpired('session-expired')` fired, and the user landed on `/login?reason=session-expired`.

Net effect: **after every successful login the user is bounced back to the sign-in page with "your session expired"** — indistinguishable from a wrong password, for what is purely a config mismatch. The recipe in our own docs is what puts them there.

A separate PR fixes the API to accept same-origin requests. This one makes the failure diagnosable and fixes the documented recipe.

## What changed

**Web — a distinct reason code (`fix(web)`)**

- `refreshFetchOnce` recognises the exact 403 body (`ORIGIN_REJECTED_ERROR = 'Invalid request origin'`) and reports `originRejected: true`. Every **other** 403 falls through unchanged — the discriminator is the body, not the status.
- The flag rides through `RefreshOutcome` as `{ kind: 'auth-failed'; originRejected?: boolean }`. Eviction behaviour is untouched: no access token can be minted from that origin, so evicting is still correct — only the explanation was wrong.
- `sessionExpiredReason` and `handleSessionExpired(reason)` gain `'origin-rejected'` (new exported `SessionExpiredReason` type).
- Callers traced end to end:
  - `fetchWithAuth` — both eviction sites now pass `expiryReasonFor(outcome)` → `?reason=origin-rejected`.
  - `AdminSessionManager` keepalive — `restoreAccessTokenFromCookieDetailed()` gained an `'origin-rejected'` outcome; the heartbeat evicts identically but with the new reason.
  - `AuthGuard`, `AuthOverlay`, `layout/DashboardWrapper` — these never used a reason code (bare soft `navigateTo('/login')`); left alone deliberately, since threading one through would mean restructuring the refresh state machine for a path that loses the race to `handleSessionExpired`'s hard `location.replace` anyway.
- `LoginPage` renders copy for `reason=origin-rejected`, interpolating `window.location.origin`:
  > This Breeze server is not configured to accept sign-ins from `https://localhost:8443`. Open Breeze at the public URL set during setup (PUBLIC_APP_URL), or add `https://localhost:8443` to CORS_ALLOWED_ORIGINS in .env and restart the API.
- `login.notices.originRejected` added to `en` **and all seven** other catalogs (de-DE, es-419, fr-CA, fr-FR, it-IT, pt-BR, tr-TR), env-var names left untranslated so the protected-literal contract holds.

**Docs — fix the recipe (`docs(selfhost)`)**

- The SSH-tunnel bullet now says the browser origin includes the **port**, and gives both working options: forward 443 itself (as root), or add `CORS_ALLOWED_ORIGINS=https://localhost,https://localhost:8443` and `docker compose up -d api`. Notes that the same-origin fix makes the extra entry unnecessary from the next release, but that it stays correct.
- New `## Troubleshooting` entry — *"You are sent back to the login page with 'session expired' right after signing in"* — with cause, the devtools confirmation (403 `Invalid request origin` on the refresh call), and the fix. Follows the existing bold-symptom / bullet-cause-and-fix shape used in `deploy/cloudflare-tunnel.mdx`.

## Testing

Red-first: the four new assertions were written and watched fail (`4 failed | 139 passed`) before any implementation existed.

| Command | Result |
|---|---|
| `npx vitest run src/stores/auth.test.ts src/components/auth/LoginPage.test.tsx src/components/auth/AdminSessionManager.test.tsx` | **143 passed** (3 files) |
| `npx vitest run src/lib/i18n` (locale parity, coverage, terminology) | **135 passed** (7 files) |
| `npx vitest run` (full apps/web suite) | **7088 passed** (686 files) |
| `pnpm exec astro check` (apps/web) | 0 errors, 0 warnings |
| `pnpm lint` (apps/web) | clean |
| `pnpm --filter @breeze/docs check` / `build` | 0 errors / 167 pages built |

New cases:

- `auth.test.ts` — a 403 `Invalid request origin` on refresh sets `sessionExpiredReason: 'origin-rejected'` and redirects to `…&reason=origin-rejected`; a **control** case proves an unrelated 403 still reports `session-expired`; `restoreAccessTokenFromCookieDetailed` returns `'origin-rejected'`.
- `AdminSessionManager.test.tsx` — the keepalive evicts with `handleSessionExpired('origin-rejected')`.
- `LoginPage.test.tsx` — the notice renders with the browser origin interpolated and names both settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PiZHjEw4swqE7HvYP5cEpo
