### PR TITLE
fix(rls): forced parent-join RLS for script_versions / script_to_tags (RMM-QA-220)

### DIFF
--- a/apps/api/migrations/2026-09-30-100000-script-children-rls.sql
+++ b/apps/api/migrations/2026-09-30-100000-script-children-rls.sql
@@ -1,0 +1,187 @@
+-- 2026-09-30-100000: forced parent-join RLS for the two script CHILD tables
+-- that shipped in 0001-baseline.sql with NO row-level security (RMM-QA-220).
+--
+-- Threat: script_versions carries customer script content + history and
+-- script_to_tags pairs a script with a tag; both reach their tenant only
+-- through scripts.script_id / script_tags.tag_id (no org_id), so they were
+-- invisible to the org_id auto-discovery AND absent from every allowlist in
+-- rls-coverage.integration.test.ts while breeze_app held blanket DML
+-- (ensureAppRole.ts). This migration closes the DB invariant; the companion
+-- test changes make the catalog exhaustive so the class cannot recur.
+--
+-- Shape: the canonical FK-child shape of 2026-05-30-fk-child-tables-rls.sql
+-- (DROP IF EXISTS x4, ENABLE + FORCE, four per-command policies named
+-- breeze_org_isolation_*), with predicates that MIRROR the parents' reviewed
+-- policies rather than a plain breeze_has_org_access(parent.org_id):
+--
+--   R(s)  scripts read      = breeze_has_org_access(s.org_id)
+--                             OR breeze_has_partner_access(s.partner_id)
+--                             OR s.is_system
+--                             OR (s.org_id IS NULL AND s.partner_id = breeze_current_partner_id())
+--           (identical to scripts.breeze_dual_axis_select,
+--            2026-06-13-catalog-partner-read-branch.sql)
+--   W(s)  scripts write     = breeze_has_org_access(s.org_id)
+--                             OR breeze_has_partner_access(s.partner_id)
+--           (identical to scripts.breeze_dual_axis_insert/update/delete,
+--            2026-06-13-catalog-partner-axis-rls.sql)
+--   T(t)  script_tags read  = breeze_has_org_access(t.org_id)
+--                             OR breeze_has_partner_access(t.partner_id)
+--                             OR (t.org_id IS NULL AND t.partner_id = breeze_current_partner_id())
+--           (identical to script_tags.breeze_dual_axis_select)
+--
+--   script_versions: SELECT R(s); INSERT W(s); UPDATE W(s)/W(s); DELETE W(s).
+--   script_to_tags:  SELECT R(s) AND T(t); INSERT W(s) AND T(t);
+--                    UPDATE USING W(s) WITH CHECK (W(s) AND T(t)); DELETE W(s).
+--
+-- is_system appears ONLY in SELECT. It must NEVER be in an INSERT/UPDATE/
+-- DELETE predicate (2026-06-13-catalog-partner-axis-rls.sql:62-68, Discussion
+-- #633 — `OR is_system` in a WITH CHECK is cross-tenant script injection).
+-- System seeding runs under system scope, where W(s) is already TRUE.
+--
+-- Tag asymmetry (script_to_tags): INSERT and the UPDATE check gate on the tag
+-- being READABLE, not writable, so an org user may attach its own script to
+-- its MSP's partner-wide tag (the partner-wide-first use case; precedent
+-- 2026-09-25-a-automation-resource-bindings.sql). Unlink authority (UPDATE
+-- USING / DELETE) comes from the SCRIPT write predicate only, so merely
+-- seeing a partner tag never lets a user unlink it from another org's script.
+-- The UPDATE WITH CHECK re-applies the tag leg so a link cannot be re-pointed
+-- at an invisible tag.
+--
+-- Bound parameters: the 2026-05-31 script_execution_batches note concerns an
+-- INSERT WITH CHECK that ORs `s.is_system`; these write predicates carry no
+-- such branch. The only is_system branch here is in SELECT, the same nested-
+-- EXISTS shape role_permissions has run in production since 2026-06-13-b.
+--
+-- The nested EXISTS runs as breeze_app, so the parents' own SELECT policies
+-- filter it too: child visibility can never exceed parent visibility.
+--
+-- Idempotent: DROP POLICY IF EXISTS x4 before each CREATE; ENABLE/FORCE are
+-- no-ops when already set. No data change, so no row-count reporting applies.
+-- autoMigrate wraps each migration file in a transaction — no inner BEGIN/COMMIT.
+
+-- ---------------------------------------------------------------------------
+-- script_versions  ->  scripts(script_id)
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS breeze_org_isolation_select ON public.script_versions;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON public.script_versions;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON public.script_versions;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON public.script_versions;
+ALTER TABLE public.script_versions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.script_versions FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY breeze_org_isolation_select ON public.script_versions FOR SELECT USING (
+  EXISTS (
+    SELECT 1 FROM scripts s
+    WHERE s.id = script_versions.script_id
+      AND (
+        public.breeze_has_org_access(s.org_id)
+        OR public.breeze_has_partner_access(s.partner_id)
+        OR s.is_system
+        OR (s.org_id IS NULL AND s.partner_id = public.breeze_current_partner_id())
+      )
+  )
+);
+CREATE POLICY breeze_org_isolation_insert ON public.script_versions FOR INSERT WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM scripts s
+    WHERE s.id = script_versions.script_id
+      AND (public.breeze_has_org_access(s.org_id) OR public.breeze_has_partner_access(s.partner_id))
+  )
+);
+CREATE POLICY breeze_org_isolation_update ON public.script_versions FOR UPDATE USING (
+  EXISTS (
+    SELECT 1 FROM scripts s
+    WHERE s.id = script_versions.script_id
+      AND (public.breeze_has_org_access(s.org_id) OR public.breeze_has_partner_access(s.partner_id))
+  )
+) WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM scripts s
+    WHERE s.id = script_versions.script_id
+      AND (public.breeze_has_org_access(s.org_id) OR public.breeze_has_partner_access(s.partner_id))
+  )
+);
+CREATE POLICY breeze_org_isolation_delete ON public.script_versions FOR DELETE USING (
+  EXISTS (
+    SELECT 1 FROM scripts s
+    WHERE s.id = script_versions.script_id
+      AND (public.breeze_has_org_access(s.org_id) OR public.breeze_has_partner_access(s.partner_id))
+  )
+);
+
+-- ---------------------------------------------------------------------------
+-- script_to_tags  ->  scripts(script_id)  AND  script_tags(tag_id)
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS breeze_org_isolation_select ON public.script_to_tags;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON public.script_to_tags;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON public.script_to_tags;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON public.script_to_tags;
+ALTER TABLE public.script_to_tags ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.script_to_tags FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY breeze_org_isolation_select ON public.script_to_tags FOR SELECT USING (
+  EXISTS (
+    SELECT 1 FROM scripts s
+    WHERE s.id = script_to_tags.script_id
+      AND (
+        public.breeze_has_org_access(s.org_id)
+        OR public.breeze_has_partner_access(s.partner_id)
+        OR s.is_system
+        OR (s.org_id IS NULL AND s.partner_id = public.breeze_current_partner_id())
+      )
+  )
+  AND EXISTS (
+    SELECT 1 FROM script_tags t
+    WHERE t.id = script_to_tags.tag_id
+      AND (
+        public.breeze_has_org_access(t.org_id)
+        OR public.breeze_has_partner_access(t.partner_id)
+        OR (t.org_id IS NULL AND t.partner_id = public.breeze_current_partner_id())
+      )
+  )
+);
+CREATE POLICY breeze_org_isolation_insert ON public.script_to_tags FOR INSERT WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM scripts s
+    WHERE s.id = script_to_tags.script_id
+      AND (public.breeze_has_org_access(s.org_id) OR public.breeze_has_partner_access(s.partner_id))
+  )
+  AND EXISTS (
+    SELECT 1 FROM script_tags t
+    WHERE t.id = script_to_tags.tag_id
+      AND (
+        public.breeze_has_org_access(t.org_id)
+        OR public.breeze_has_partner_access(t.partner_id)
+        OR (t.org_id IS NULL AND t.partner_id = public.breeze_current_partner_id())
+      )
+  )
+);
+CREATE POLICY breeze_org_isolation_update ON public.script_to_tags FOR UPDATE USING (
+  EXISTS (
+    SELECT 1 FROM scripts s
+    WHERE s.id = script_to_tags.script_id
+      AND (public.breeze_has_org_access(s.org_id) OR public.breeze_has_partner_access(s.partner_id))
+  )
+) WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM scripts s
+    WHERE s.id = script_to_tags.script_id
+      AND (public.breeze_has_org_access(s.org_id) OR public.breeze_has_partner_access(s.partner_id))
+  )
+  AND EXISTS (
+    SELECT 1 FROM script_tags t
+    WHERE t.id = script_to_tags.tag_id
+      AND (
+        public.breeze_has_org_access(t.org_id)
+        OR public.breeze_has_partner_access(t.partner_id)
+        OR (t.org_id IS NULL AND t.partner_id = public.breeze_current_partner_id())
+      )
+  )
+);
+CREATE POLICY breeze_org_isolation_delete ON public.script_to_tags FOR DELETE USING (
+  EXISTS (
+    SELECT 1 FROM scripts s
+    WHERE s.id = script_to_tags.script_id
+      AND (public.breeze_has_org_access(s.org_id) OR public.breeze_has_partner_access(s.partner_id))
+  )
+);

--- a/apps/api/migrations/2026-10-01-100000-script-children-rls.sql
+++ b/apps/api/migrations/2026-10-01-100000-script-children-rls.sql
@@ -1,4 +1,4 @@
--- 2026-09-30-100000: forced parent-join RLS for the two script CHILD tables
+-- 2026-10-01-100000: forced parent-join RLS for the two script CHILD tables
 -- that shipped in 0001-baseline.sql with NO row-level security (RMM-QA-220).
 --
 -- Threat: script_versions carries customer script content + history and

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -758,7 +758,8 @@ const PLATFORM_INFRASTRUCTURE_TABLES: ReadonlySet<string> = new Set<string>([
 // handed to QA. The bucket is shrink-only — an entry may leave ONLY by moving
 // the table into a real bucket (a shape allowlist, INTENTIONAL_UNSCOPED with
 // a plan-doc entry, or PLATFORM_INFRASTRUCTURE_TABLES). A stale name (table
-// dropped) fails the test so the list cannot rot.
+// dropped) fails the test so the list cannot rot. Shrink-only is ENFORCED by
+// the ceiling + frozen name set directly below.
 const UNREVIEWED_RLS_CLASSIFICATION_DEBT: ReadonlyMap<string, string> = new Map<string, string>([
   // Surfaced by RMM-QA-220's exhaustive classification (2026-09). Candidate
   // findings handed to QA — NOT reviewed, NOT blessed. Descriptions are the
@@ -776,6 +777,29 @@ const UNREVIEWED_RLS_CLASSIFICATION_DEBT: ReadonlyMap<string, string> = new Map<
   // appear in no allowlist, so no per-shape assertion in this file checks them.
   ['sessions', 'user_id + token_hash session rows; RLS on/forced, policies user_id = breeze_current_user_id() OR system scope; in no allowlist — candidate USER_ID_SCOPED_TABLES after review.'],
   ['snmp_alert_thresholds', 'device_id -> snmp_devices rows; RLS on/forced, join-through-snmp_devices policies (2026-04-11-bucket-c-dead-cleanup-rls.sql); in no allowlist — candidate PARENT_FK_JOIN_POLICY_TABLES (snmp_devices) after review.'],
+]);
+
+// Enforced shrink-only ratchet for the bucket above (independent-review
+// finding on RMM-QA-220: "documented shrink-only, nothing enforces it"). The
+// ceiling and the frozen name set were fixed at the 2026-09-01 review. LOWER
+// the ceiling when a table leaves the bucket; NEVER raise it, and NEVER add a
+// name to the frozen set — a table that is new to this catalog must be
+// classified into a real bucket (see the D5 failure message), not parked
+// here. Both constants are asserted by 'the unreviewed classification debt
+// bucket only shrinks' below.
+const UNREVIEWED_RLS_CLASSIFICATION_DEBT_CEILING = 11;
+const UNREVIEWED_RLS_CLASSIFICATION_DEBT_FROZEN_NAMES: ReadonlySet<string> = new Set<string>([
+  'device_software',
+  'mobile_sessions',
+  'software_compliance_status',
+  'agent_versions',
+  'cis_check_catalog',
+  'patches',
+  'permissions',
+  'plugin_catalog',
+  'script_templates',
+  'sessions',
+  'snmp_alert_thresholds',
 ]);
 
 // Per-command parent requirements that are STRICTER than PARENT_FK_JOIN_
@@ -1113,12 +1137,37 @@ describe('RLS coverage contract', () => {
       { unclassified, stale, overlapping },
       `Every public base table must be classified. Unclassified tables have neither an org_id column nor an ` +
         `entry in any shape allowlist (ORG_ID_KEYED / PARTNER / DUAL_AXIS / DEVICE_ID_JOIN / PARENT_FK_JOIN / ` +
-        `USER_ID_SCOPED), INTENTIONAL_UNSCOPED, EXEMPT_TABLES, PLATFORM_INFRASTRUCTURE_TABLES or the shrink-only ` +
-        `UNREVIEWED_RLS_CLASSIFICATION_DEBT bucket. Pick a shape (CLAUDE.md "Six tenancy shapes"), add policies in a ` +
-        `migration, and register the table. 'stale' names no longer exist and must be removed; 'overlapping' names ` +
-        `are in a debt/infrastructure bucket AND a real bucket — remove them from the debt bucket.\n` +
+        `USER_ID_SCOPED), INTENTIONAL_UNSCOPED, EXEMPT_TABLES or PLATFORM_INFRASTRUCTURE_TABLES. ` +
+        `Fix: pick a shape (CLAUDE.md "Six tenancy shapes"), add policies in a migration, and register the table. ` +
+        `UNREVIEWED_RLS_CLASSIFICATION_DEBT is frozen (shrink-only, enforced) and is NOT a valid destination for a ` +
+        `new table. 'stale' names no longer exist and must be removed; 'overlapping' names are in a ` +
+        `debt/infrastructure bucket AND a real bucket — remove them from the debt bucket.\n` +
         JSON.stringify({ unclassified, stale, overlapping }, null, 2)
     ).toEqual({ unclassified: [], stale: [], overlapping: [] });
+  });
+
+  // RMM-QA-220 review finding: the debt bucket was documented shrink-only but
+  // nothing enforced it, so a future author facing `unclassified: [x]` could
+  // add one Map entry and go green — the same silent-omission class this
+  // contract exists to close. No database needed: this is a pure ratchet on
+  // the two constants above.
+  it('the unreviewed classification debt bucket only shrinks', () => {
+    const names = [...UNREVIEWED_RLS_CLASSIFICATION_DEBT.keys()];
+    const added = names.filter((name) => !UNREVIEWED_RLS_CLASSIFICATION_DEBT_FROZEN_NAMES.has(name));
+    expect(
+      { added, size: names.length, ceiling: UNREVIEWED_RLS_CLASSIFICATION_DEBT_CEILING },
+      `UNREVIEWED_RLS_CLASSIFICATION_DEBT is shrink-only. Names not in the frozen 2026-09-01 set: ` +
+        `${JSON.stringify(added)}. A table new to this catalog must be classified into a real bucket ` +
+        `(a shape allowlist, INTENTIONAL_UNSCOPED with a plan-doc entry, or PLATFORM_INFRASTRUCTURE_TABLES) — ` +
+        `never parked here. When a table leaves the bucket, remove it from both the Map and the frozen set ` +
+        `and LOWER the ceiling; never raise it.`
+    ).toEqual({ added: [], size: names.length, ceiling: UNREVIEWED_RLS_CLASSIFICATION_DEBT_CEILING });
+    expect(names.length).toBeLessThanOrEqual(UNREVIEWED_RLS_CLASSIFICATION_DEBT_CEILING);
+    // The frozen set must not outgrow the ceiling either (guards against
+    // "add the name to both places" without touching the number).
+    expect(UNREVIEWED_RLS_CLASSIFICATION_DEBT_FROZEN_NAMES.size).toBeLessThanOrEqual(
+      UNREVIEWED_RLS_CLASSIFICATION_DEBT_CEILING
+    );
   });
 
   it('deployment_invites has a database invariant tying org_id to partner_id', async () => {

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -641,6 +641,14 @@ const PARENT_FK_JOIN_POLICY_TABLES: ReadonlyMap<string, readonly string[]> = new
   // breeze_has_org_access(parent.org_id) join would be WRONG because the
   // parent's org_id is NULL for the partner-wide forms this table scopes.
   ['ticket_form_org_links', ['ticket_forms']],
+  // RMM-QA-220: script_versions (script content history) and script_to_tags
+  // (script↔tag join) shipped in the baseline with NO rls and reach their
+  // tenant only through scripts (dual-axis, nullable org_id, is_system) and
+  // script_tags (dual-axis). See 2026-09-30-100000-script-children-rls.sql.
+  // script_to_tags additionally carries a per-command both-parents overlay
+  // (PARENT_FK_REQUIRED_PARENTS_PER_COMMAND below).
+  ['script_versions', ['scripts']],
+  ['script_to_tags', ['scripts', 'script_tags']],
 ]);
 
 // Tables scoped to the calling user via breeze_current_user_id().
@@ -724,6 +732,41 @@ const USER_ID_SCOPED_TABLES: ReadonlySet<string> = new Set<string>([
   // Request paths are limited to the exact user owner; the explicit system
   // branch lets the bounded retry worker drain work for every user.
   'oauth_revocation_retries',
+]);
+
+// Platform bookkeeping tables that hold no tenant data and are not a tenancy
+// shape. Exactly one entry today. Adding here requires the same justification
+// as INTENTIONAL_UNSCOPED (a plan-doc entry per CLAUDE.md "Intentionally
+// system-scoped").
+const PLATFORM_INFRASTRUCTURE_TABLES: ReadonlySet<string> = new Set<string>([
+  'breeze_migrations', // autoMigrate's applied-migration ledger (filename + checksum). No tenant data. See apps/api/src/db/autoMigrate.ts MIGRATION_TABLE.
+]);
+
+// Tables that carry NO tenancy classification in this catalog (most also
+// have no row-level security at all; two carry policies but sit in no
+// allowlist) and were NOT reviewed by RMM-QA-220. Inclusion is a TRACKING FACT, not a
+// security review, and not a blessing: each name is a candidate finding
+// handed to QA. The bucket is shrink-only — an entry may leave ONLY by moving
+// the table into a real bucket (a shape allowlist, INTENTIONAL_UNSCOPED with
+// a plan-doc entry, or PLATFORM_INFRASTRUCTURE_TABLES). A stale name (table
+// dropped) fails the test so the list cannot rot.
+const UNREVIEWED_RLS_CLASSIFICATION_DEBT: ReadonlyMap<string, string> = new Map<string, string>([
+  // Surfaced by RMM-QA-220's exhaustive classification (2026-09). Candidate
+  // findings handed to QA — NOT reviewed, NOT blessed. Descriptions are the
+  // column / catalog facts that a reviewer needs, nothing more.
+  ['device_software', 'device_id-keyed inventory rows, no RLS; candidate shape 5 (device-join) or denormalised org_id.'],
+  ['mobile_sessions', 'user_id / refresh-token session rows, no RLS; candidate shape 6 (breeze_current_user_id). Deferred in 2026-04-11-bucket-c-dead-cleanup-rls.sql.'],
+  ['software_compliance_status', 'device_id + policy_id rows, no RLS; candidate shape 5 (device-join).'],
+  ['agent_versions', 'Global agent release reference data, no RLS; candidate INTENTIONAL_UNSCOPED after review.'],
+  ['cis_check_catalog', 'Global CIS benchmark check catalog; RLS OFF, so its 3 system-only write policies are inert; candidate INTENTIONAL_UNSCOPED after review.'],
+  ['patches', 'Global patch reference data, no RLS; candidate INTENTIONAL_UNSCOPED after review.'],
+  ['permissions', 'Global permission catalog, no RLS; candidate INTENTIONAL_UNSCOPED after review.'],
+  ['plugin_catalog', 'Global plugin catalog, no RLS; candidate INTENTIONAL_UNSCOPED after review.'],
+  ['script_templates', 'Global script template library, no RLS; candidate INTENTIONAL_UNSCOPED after review.'],
+  // The two below DO have RLS enabled + forced with four policies each but
+  // appear in no allowlist, so no per-shape assertion in this file checks them.
+  ['sessions', 'user_id + token_hash session rows; RLS on/forced, policies user_id = breeze_current_user_id() OR system scope; in no allowlist — candidate USER_ID_SCOPED_TABLES after review.'],
+  ['snmp_alert_thresholds', 'device_id -> snmp_devices rows; RLS on/forced, join-through-snmp_devices policies (2026-04-11-bucket-c-dead-cleanup-rls.sql); in no allowlist — candidate PARENT_FK_JOIN_POLICY_TABLES (snmp_devices) after review.'],
 ]);
 
 const REQUIRED_CMDS = ['SELECT', 'INSERT', 'UPDATE', 'DELETE'] as const;
@@ -945,6 +988,71 @@ describe('RLS coverage contract', () => {
       `Tenant-scoped tables missing from the database or missing FORCE ROW LEVEL SECURITY:\n${JSON.stringify([...offenders, ...missingExplicitTables], null, 2)}\n\n` +
         `Fix: add an idempotent migration that runs ALTER TABLE ... FORCE ROW LEVEL SECURITY for each offender.`
     ).toEqual([]);
+  });
+
+  // RMM-QA-220: every assertion above enumerates ONE shape at a time, so a
+  // tenant child that is in no allowlist and has no org_id column (the exact
+  // way script_versions / script_to_tags shipped) is invisible to all of them.
+  // This test enumerates every public base table and demands a classification.
+  it('every public base table is classified by exactly one tenancy bucket', async () => {
+    // relkind 'r' (ordinary) + 'p' (partitioned parent, e.g. metric_rollups);
+    // NOT relispartition — metric_rollups partitions are created at runtime
+    // by breeze_ensure_metric_rollup_partition and would make this
+    // non-deterministic. The partitioned parent is classified once.
+    const rows = (await db.execute(sql`
+      SELECT
+        c.relname AS table_name,
+        EXISTS (
+          SELECT 1 FROM information_schema.columns col
+          WHERE col.table_schema = n.nspname AND col.table_name = c.relname AND col.column_name = 'org_id'
+        ) AS has_org_id
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public'
+        AND c.relkind IN ('r', 'p')
+        AND NOT c.relispartition
+      ORDER BY c.relname;
+    `)) as unknown as Array<{ table_name: string; has_org_id: boolean }>;
+
+    const existing = new Map(rows.map((r) => [r.table_name, r.has_org_id]));
+    const shapeLists: ReadonlyArray<{ has(name: string): boolean }> = [
+      ORG_ID_KEYED_TENANT_TABLES,
+      PARTNER_TENANT_TABLES,
+      DUAL_AXIS_TENANT_TABLES,
+      DEVICE_ID_JOIN_POLICY_TABLES,
+      PARENT_FK_JOIN_POLICY_TABLES,
+      USER_ID_SCOPED_TABLES,
+      INTENTIONAL_UNSCOPED,
+      EXEMPT_TABLES,
+    ];
+    const classifiedByShape = (name: string): boolean =>
+      (existing.get(name) ?? false) || shapeLists.some((list) => list.has(name));
+
+    const unclassified = rows
+      .map((r) => r.table_name)
+      .filter((name) => !classifiedByShape(name))
+      .filter((name) => !PLATFORM_INFRASTRUCTURE_TABLES.has(name))
+      .filter((name) => !UNREVIEWED_RLS_CLASSIFICATION_DEBT.has(name));
+
+    const bucketNames = [...PLATFORM_INFRASTRUCTURE_TABLES, ...UNREVIEWED_RLS_CLASSIFICATION_DEBT.keys()];
+    // Shrink-only ratchet: a name that no longer exists must be removed.
+    const stale = bucketNames.filter((name) => !existing.has(name));
+    // Buckets 3 and 4 are disjoint from every shape list and from each other.
+    const overlapping = [
+      ...bucketNames.filter((name) => existing.has(name) && classifiedByShape(name)),
+      ...[...PLATFORM_INFRASTRUCTURE_TABLES].filter((name) => UNREVIEWED_RLS_CLASSIFICATION_DEBT.has(name)),
+    ];
+
+    expect(
+      { unclassified, stale, overlapping },
+      `Every public base table must be classified. Unclassified tables have neither an org_id column nor an ` +
+        `entry in any shape allowlist (ORG_ID_KEYED / PARTNER / DUAL_AXIS / DEVICE_ID_JOIN / PARENT_FK_JOIN / ` +
+        `USER_ID_SCOPED), INTENTIONAL_UNSCOPED, EXEMPT_TABLES, PLATFORM_INFRASTRUCTURE_TABLES or the shrink-only ` +
+        `UNREVIEWED_RLS_CLASSIFICATION_DEBT bucket. Pick a shape (CLAUDE.md "Six tenancy shapes"), add policies in a ` +
+        `migration, and register the table. 'stale' names no longer exist and must be removed; 'overlapping' names ` +
+        `are in a debt/infrastructure bucket AND a real bucket — remove them from the debt bucket.\n` +
+        JSON.stringify({ unclassified, stale, overlapping }, null, 2)
+    ).toEqual({ unclassified: [], stale: [], overlapping: [] });
   });
 
   it('deployment_invites has a database invariant tying org_id to partner_id', async () => {

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -653,7 +653,7 @@ const PARENT_FK_JOIN_POLICY_TABLES: ReadonlyMap<string, readonly string[]> = new
   // RMM-QA-220: script_versions (script content history) and script_to_tags
   // (script↔tag join) shipped in the baseline with NO rls and reach their
   // tenant only through scripts (dual-axis, nullable org_id, is_system) and
-  // script_tags (dual-axis). See 2026-09-30-100000-script-children-rls.sql.
+  // script_tags (dual-axis). See apps/api/migrations/2026-10-01-100000-script-children-rls.sql.
   // script_to_tags additionally carries a per-command both-parents overlay
   // (PARENT_FK_REQUIRED_PARENTS_PER_COMMAND below).
   ['script_versions', ['scripts']],
@@ -4347,7 +4347,7 @@ describe('m365 communications-delegated RLS — structural enforcement', () => {
 // ---------------------------------------------------------------------------
 // Both tables reach their tenant only through `scripts` (dual-axis, nullable
 // org_id, is_system) and `script_tags` (dual-axis). Migration under test:
-// 2026-09-30-100000-script-children-rls.sql. Runs as `breeze_app` under real
+// apps/api/migrations/2026-10-01-100000-script-children-rls.sql. Runs as `breeze_app` under real
 // contexts, modelled on the scripts partner-wide block above: self-contained
 // fixtures seeded under system scope, cleanup by id in afterAll.
 //

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, it, expect } from 'vitest';
-import { eq, sql } from 'drizzle-orm';
+import { and, eq, inArray, sql } from 'drizzle-orm';
 import { db, withDbAccessContext, withSystemDbAccessContext } from '../../db';
 import { partners, users, organizations, sites, invoices, invoiceLines, invoiceDocuments, contracts, contractLines, contractBillingPeriods, mlFeedbackEvents, unifiCollectors, unifiDeviceTelemetry, unifiClients } from '../../db/schema';
 import { approvalRequests } from '../../db/schema/approvals';
@@ -10,7 +10,7 @@ import {
 import { partnerAbuseSignals, abuseScriptHosts } from '../../db/schema/abuseSignals';
 import { automations, automationRuns } from '../../db/schema/automations';
 import { configurationPolicies } from '../../db/schema/configurationPolicies';
-import { scripts, scriptExecutionBatches } from '../../db/schema/scripts';
+import { scripts, scriptExecutionBatches, scriptTags, scriptToTags, scriptVersions } from '../../db/schema/scripts';
 import { unifiIntegrations, unifiDevices } from '../../db/schema/unifi';
 import { oauthRevocationRetries } from '../../db/schema/oauth';
 import {
@@ -4291,4 +4291,314 @@ describe('m365 communications-delegated RLS — structural enforcement', () => {
       expect(def).not.toMatch(/'active'::text\s*\]?\)?\s*\)?\s*AND vault_ref IS NULL/);
     },
   );
+});
+
+// ---------------------------------------------------------------------------
+// script_versions / script_to_tags — parent-join forge test (RMM-QA-220)
+// ---------------------------------------------------------------------------
+// Both tables reach their tenant only through `scripts` (dual-axis, nullable
+// org_id, is_system) and `script_tags` (dual-axis). Migration under test:
+// 2026-09-30-100000-script-children-rls.sql. Runs as `breeze_app` under real
+// contexts, modelled on the scripts partner-wide block above: self-contained
+// fixtures seeded under system scope, cleanup by id in afterAll.
+//
+// Actors: org A1 (partner A), org B1 (partner B), org A1 with a MIS-SET own
+// partner (B), partner A, partner B. Rows marked "positive" pass on main too —
+// they guard against an over-tight policy; every negative row is RED on main.
+describe('script_versions / script_to_tags RLS — parent-join forge enforcement (Org A/B, Partner A/B)', () => {
+  const runSuffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  let partnerAId: string;
+  let partnerBId: string;
+  let orgA1Id: string;
+  let orgB1Id: string;
+  let sA1Id: string; // org A1 script
+  let sB1Id: string; // org B1 script
+  let sPAId: string; // partner-wide script of partner A (org_id NULL)
+  let sSysId: string; // system script (is_system, org NULL, partner NULL)
+  let tA1Id: string; // org A1 tag
+  let tB1Id: string; // org B1 tag
+  let tPAId: string; // partner-wide tag of partner A
+  let vSysId: string; // seeded version on sSys
+  let vPAId: string; // seeded version on sPA
+  let vA1Id: string | null = null; // version org A1 creates in the positive test
+
+  async function ensureFixtures(): Promise<void> {
+    if (partnerAId) return;
+    await withSystemDbAccessContext(async () => {
+      const seededPartners = await db.insert(partners).values([
+        { name: `RLS ScriptChildren A ${runSuffix}`, slug: `rls-sc-a-${runSuffix}`, type: 'msp', plan: 'pro', status: 'active' },
+        { name: `RLS ScriptChildren B ${runSuffix}`, slug: `rls-sc-b-${runSuffix}`, type: 'msp', plan: 'pro', status: 'active' },
+      ]).returning({ id: partners.id });
+      partnerAId = seededPartners[0]!.id;
+      partnerBId = seededPartners[1]!.id;
+
+      const seededOrgs = await db.insert(organizations).values([
+        { currencyCode: 'USD', partnerId: partnerAId, name: `RLS SC Org A1 ${runSuffix}`, slug: `rls-sc-org-a1-${runSuffix}` },
+        { currencyCode: 'USD', partnerId: partnerBId, name: `RLS SC Org B1 ${runSuffix}`, slug: `rls-sc-org-b1-${runSuffix}` },
+      ]).returning({ id: organizations.id });
+      orgA1Id = seededOrgs[0]!.id;
+      orgB1Id = seededOrgs[1]!.id;
+
+      const base = { osTypes: ['windows'], language: 'powershell' as const, content: 'echo seed' };
+      const seededScripts = await db.insert(scripts).values([
+        { ...base, orgId: orgA1Id, partnerId: partnerAId, name: `sc-sA1-${runSuffix}` },
+        { ...base, orgId: orgB1Id, partnerId: partnerBId, name: `sc-sB1-${runSuffix}` },
+        { ...base, orgId: null, partnerId: partnerAId, name: `sc-sPA-${runSuffix}` },
+        { ...base, orgId: null, partnerId: null, isSystem: true, name: `sc-sSys-${runSuffix}` },
+      ]).returning({ id: scripts.id });
+      sA1Id = seededScripts[0]!.id;
+      sB1Id = seededScripts[1]!.id;
+      sPAId = seededScripts[2]!.id;
+      sSysId = seededScripts[3]!.id;
+
+      const seededTags = await db.insert(scriptTags).values([
+        { orgId: orgA1Id, partnerId: partnerAId, name: `tA1-${runSuffix}` },
+        { orgId: orgB1Id, partnerId: partnerBId, name: `tB1-${runSuffix}` },
+        { orgId: null, partnerId: partnerAId, name: `tPA-${runSuffix}` },
+      ]).returning({ id: scriptTags.id });
+      tA1Id = seededTags[0]!.id;
+      tB1Id = seededTags[1]!.id;
+      tPAId = seededTags[2]!.id;
+
+      // created_by is nullable (0001-baseline.sql:5216) — no users rows needed.
+      const seededVersions = await db.insert(scriptVersions).values([
+        { scriptId: sSysId, version: 1, content: 'echo sys-v1', changelog: 'seed', createdBy: null },
+        { scriptId: sPAId, version: 1, content: 'echo pa-v1', changelog: 'seed', createdBy: null },
+      ]).returning({ id: scriptVersions.id });
+      vSysId = seededVersions[0]!.id;
+      vPAId = seededVersions[1]!.id;
+    });
+  }
+
+  afterAll(async () => {
+    if (!partnerAId) return;
+    await withSystemDbAccessContext(async () => {
+      const scriptIds = [sA1Id, sB1Id, sPAId, sSysId];
+      await db.delete(scriptVersions).where(inArray(scriptVersions.scriptId, scriptIds));
+      await db.delete(scriptToTags).where(inArray(scriptToTags.scriptId, scriptIds));
+      await db.delete(scripts).where(inArray(scripts.id, scriptIds));
+      await db.delete(scriptTags).where(inArray(scriptTags.id, [tA1Id, tB1Id, tPAId]));
+      await db.delete(organizations).where(inArray(organizations.id, [orgA1Id, orgB1Id]));
+      await db.delete(partners).where(inArray(partners.id, [partnerAId, partnerBId]));
+    });
+  });
+
+  function partnerContext(partnerId: string) {
+    return { scope: 'partner' as const, orgId: null, accessibleOrgIds: [], accessiblePartnerIds: [partnerId], userId: null, currentPartnerId: partnerId };
+  }
+
+  // ORGANIZATION scope: no partner-axis write access (accessiblePartnerIds []),
+  // currentPartnerId = the caller's own partner so the read-only own-partner
+  // branch of the parents' SELECT policies applies.
+  function orgContext(orgId: string, ownPartnerId: string | null) {
+    return { scope: 'organization' as const, orgId, accessibleOrgIds: [orgId], accessiblePartnerIds: [], currentPartnerId: ownPartnerId, userId: null };
+  }
+
+  async function expectRlsViolation(table: 'script_versions' | 'script_to_tags', fn: () => Promise<unknown>): Promise<void> {
+    let caught: unknown;
+    try {
+      await fn();
+    } catch (err) {
+      caught = err;
+    }
+    const cause = caught as { cause?: { message?: string }; message?: string } | undefined;
+    const message = cause?.cause?.message ?? cause?.message ?? '';
+    expect(message, `expected an RLS violation on ${table}; got: ${message || '<no error>'}`).toMatch(
+      new RegExp(`new row violates row-level security policy for table "${table}"`),
+    );
+  }
+
+  const versionsOf = (scriptId: string) =>
+    db.select({ id: scriptVersions.id }).from(scriptVersions).where(eq(scriptVersions.scriptId, scriptId));
+  const linksOf = (scriptId: string) =>
+    db.select({ tagId: scriptToTags.tagId }).from(scriptToTags).where(eq(scriptToTags.scriptId, scriptId));
+
+  // 1 (positive)
+  it('org A1 can INSERT and SELECT a version of its own script', async () => {
+    await ensureFixtures();
+    const inserted = await withDbAccessContext(orgContext(orgA1Id, partnerAId), async () =>
+      db.insert(scriptVersions).values({ scriptId: sA1Id, version: 1, content: 'echo a1-v1', changelog: 'org A1', createdBy: null }).returning({ id: scriptVersions.id })
+    );
+    expect(inserted).toHaveLength(1);
+    vA1Id = inserted[0]!.id;
+    const visible = await withDbAccessContext(orgContext(orgA1Id, partnerAId), async () => versionsOf(sA1Id));
+    expect(visible.map((r) => r.id)).toEqual([vA1Id]);
+  });
+
+  // 2 (positive)
+  it('org A1 can INSERT and SELECT a link between its own script and its own tag', async () => {
+    await ensureFixtures();
+    await withDbAccessContext(orgContext(orgA1Id, partnerAId), async () =>
+      db.insert(scriptToTags).values({ scriptId: sA1Id, tagId: tA1Id })
+    );
+    const visible = await withDbAccessContext(orgContext(orgA1Id, partnerAId), async () => linksOf(sA1Id));
+    expect(visible.map((r) => r.tagId)).toEqual([tA1Id]);
+  });
+
+  // 3
+  it("org B1 cannot SELECT org A1's versions or links", async () => {
+    await ensureFixtures();
+    const versions = await withDbAccessContext(orgContext(orgB1Id, partnerBId), async () => versionsOf(sA1Id));
+    const links = await withDbAccessContext(orgContext(orgB1Id, partnerBId), async () => linksOf(sA1Id));
+    expect(versions).toEqual([]);
+    expect(links).toEqual([]);
+  });
+
+  // 4
+  it("org B1 INSERT of a version onto org A1's script is rejected by WITH CHECK", async () => {
+    await ensureFixtures();
+    await expectRlsViolation('script_versions', () =>
+      withDbAccessContext(orgContext(orgB1Id, partnerBId), async () =>
+        db.insert(scriptVersions).values({ scriptId: sA1Id, version: 9, content: 'forged', changelog: null, createdBy: null })
+      )
+    );
+  });
+
+  // 5
+  it('org B1 cannot pair (own script, A tag) nor (A script, own tag)', async () => {
+    await ensureFixtures();
+    await expectRlsViolation('script_to_tags', () =>
+      withDbAccessContext(orgContext(orgB1Id, partnerBId), async () => db.insert(scriptToTags).values({ scriptId: sB1Id, tagId: tA1Id }))
+    );
+    await expectRlsViolation('script_to_tags', () =>
+      withDbAccessContext(orgContext(orgB1Id, partnerBId), async () => db.insert(scriptToTags).values({ scriptId: sA1Id, tagId: tB1Id }))
+    );
+  });
+
+  // 6
+  it("org B1 UPDATE/DELETE on org A1's version and DELETE on its link affect 0 rows and leave the rows intact", async () => {
+    await ensureFixtures();
+    if (!vA1Id) throw new Error('positive test must run first');
+    const updated = await withDbAccessContext(orgContext(orgB1Id, partnerBId), async () =>
+      db.update(scriptVersions).set({ changelog: 'tampered' }).where(eq(scriptVersions.id, vA1Id!)).returning({ id: scriptVersions.id })
+    );
+    const deletedVersions = await withDbAccessContext(orgContext(orgB1Id, partnerBId), async () =>
+      db.delete(scriptVersions).where(eq(scriptVersions.id, vA1Id!)).returning({ id: scriptVersions.id })
+    );
+    const deletedLinks = await withDbAccessContext(orgContext(orgB1Id, partnerBId), async () =>
+      db.delete(scriptToTags).where(and(eq(scriptToTags.scriptId, sA1Id), eq(scriptToTags.tagId, tA1Id))).returning({ tagId: scriptToTags.tagId })
+    );
+    expect(updated).toEqual([]);
+    expect(deletedVersions).toEqual([]);
+    expect(deletedLinks).toEqual([]);
+
+    const intact = await withSystemDbAccessContext(async () =>
+      db.select({ changelog: scriptVersions.changelog }).from(scriptVersions).where(eq(scriptVersions.id, vA1Id!))
+    );
+    expect(intact).toEqual([{ changelog: 'org A1' }]);
+    const linkIntact = await withSystemDbAccessContext(async () => linksOf(sA1Id));
+    expect(linkIntact.map((r) => r.tagId)).toEqual([tA1Id]);
+  });
+
+  // 7
+  it("partner B cannot SELECT org A1's version and cannot INSERT a version onto partner A's partner-wide script", async () => {
+    await ensureFixtures();
+    const visible = await withDbAccessContext(partnerContext(partnerBId), async () => versionsOf(sA1Id));
+    expect(visible).toEqual([]);
+    await expectRlsViolation('script_versions', () =>
+      withDbAccessContext(partnerContext(partnerBId), async () =>
+        db.insert(scriptVersions).values({ scriptId: sPAId, version: 9, content: 'forged', changelog: null, createdBy: null })
+      )
+    );
+  });
+
+  // 8 (positive)
+  it('partner A can INSERT a version and a link on its own partner-wide script', async () => {
+    await ensureFixtures();
+    const inserted = await withDbAccessContext(partnerContext(partnerAId), async () =>
+      db.insert(scriptVersions).values({ scriptId: sPAId, version: 2, content: 'echo pa-v2', changelog: 'partner A', createdBy: null }).returning({ id: scriptVersions.id })
+    );
+    expect(inserted).toHaveLength(1);
+    await withDbAccessContext(partnerContext(partnerAId), async () => db.insert(scriptToTags).values({ scriptId: sPAId, tagId: tPAId }));
+    const links = await withDbAccessContext(partnerContext(partnerAId), async () => linksOf(sPAId));
+    expect(links.map((r) => r.tagId)).toEqual([tPAId]);
+  });
+
+  // 9
+  it("org A1 can SELECT its MSP's partner-wide version (read branch) but cannot INSERT one", async () => {
+    await ensureFixtures();
+    const visible = await withDbAccessContext(orgContext(orgA1Id, partnerAId), async () =>
+      db.select({ id: scriptVersions.id }).from(scriptVersions).where(eq(scriptVersions.id, vPAId))
+    );
+    expect(visible.map((r) => r.id)).toEqual([vPAId]);
+    await expectRlsViolation('script_versions', () =>
+      withDbAccessContext(orgContext(orgA1Id, partnerAId), async () =>
+        db.insert(scriptVersions).values({ scriptId: sPAId, version: 9, content: 'forged', changelog: null, createdBy: null })
+      )
+    );
+  });
+
+  // 10
+  it("org A1 whose own partner is mis-set to B CANNOT SELECT partner A's partner-wide version", async () => {
+    await ensureFixtures();
+    const visible = await withDbAccessContext(orgContext(orgA1Id, partnerBId), async () =>
+      db.select({ id: scriptVersions.id }).from(scriptVersions).where(eq(scriptVersions.id, vPAId))
+    );
+    expect(visible).toEqual([]);
+  });
+
+  // 11 (positive)
+  it("org A1 can link its own script to its MSP's partner-wide tag (tag read branch)", async () => {
+    await ensureFixtures();
+    await withDbAccessContext(orgContext(orgA1Id, partnerAId), async () => db.insert(scriptToTags).values({ scriptId: sA1Id, tagId: tPAId }));
+    const links = await withDbAccessContext(orgContext(orgA1Id, partnerAId), async () => linksOf(sA1Id));
+    expect(links.map((r) => r.tagId).sort()).toEqual([tA1Id, tPAId].sort());
+  });
+
+  // 12
+  it("org B1 cannot link its own script to partner A's partner-wide tag", async () => {
+    await ensureFixtures();
+    await expectRlsViolation('script_to_tags', () =>
+      withDbAccessContext(orgContext(orgB1Id, partnerBId), async () => db.insert(scriptToTags).values({ scriptId: sB1Id, tagId: tPAId }))
+    );
+  });
+
+  // 13 (positive, bound parameter through the extended protocol)
+  it("org A1 can SELECT a system script's version by bound script_id (is_system read branch)", async () => {
+    await ensureFixtures();
+    const visible = await withDbAccessContext(orgContext(orgA1Id, partnerAId), async () => versionsOf(sSysId));
+    expect(visible.map((r) => r.id)).toEqual([vSysId]);
+  });
+
+  // 14
+  it('neither org A1 nor partner A can INSERT a version onto a system script (no is_system in any write predicate)', async () => {
+    await ensureFixtures();
+    await expectRlsViolation('script_versions', () =>
+      withDbAccessContext(orgContext(orgA1Id, partnerAId), async () =>
+        db.insert(scriptVersions).values({ scriptId: sSysId, version: 9, content: 'forged', changelog: null, createdBy: null })
+      )
+    );
+    await expectRlsViolation('script_versions', () =>
+      withDbAccessContext(partnerContext(partnerAId), async () =>
+        db.insert(scriptVersions).values({ scriptId: sSysId, version: 9, content: 'forged', changelog: null, createdBy: null })
+      )
+    );
+  });
+
+  // 16 — runs BEFORE 15 because 15 deletes the (sA1, tA1) link this test re-points.
+  it('org A1 UPDATE re-pointing its own link at org B1\'s tag is rejected by the UPDATE WITH CHECK tag leg', async () => {
+    await ensureFixtures();
+    await expectRlsViolation('script_to_tags', () =>
+      withDbAccessContext(orgContext(orgA1Id, partnerAId), async () =>
+        db.update(scriptToTags).set({ tagId: tB1Id }).where(and(eq(scriptToTags.scriptId, sA1Id), eq(scriptToTags.tagId, tA1Id)))
+      )
+    );
+    const intact = await withSystemDbAccessContext(async () => linksOf(sA1Id));
+    expect(intact.map((r) => r.tagId).sort()).toEqual([tA1Id, tPAId].sort());
+  });
+
+  // 15
+  it("org A1 can DELETE its own link but DELETE on the partner-wide link affects 0 rows (unlink needs script WRITE)", async () => {
+    await ensureFixtures();
+    const own = await withDbAccessContext(orgContext(orgA1Id, partnerAId), async () =>
+      db.delete(scriptToTags).where(and(eq(scriptToTags.scriptId, sA1Id), eq(scriptToTags.tagId, tA1Id))).returning({ tagId: scriptToTags.tagId })
+    );
+    expect(own.map((r) => r.tagId)).toEqual([tA1Id]);
+    const partnerWide = await withDbAccessContext(orgContext(orgA1Id, partnerAId), async () =>
+      db.delete(scriptToTags).where(and(eq(scriptToTags.scriptId, sPAId), eq(scriptToTags.tagId, tPAId))).returning({ tagId: scriptToTags.tagId })
+    );
+    expect(partnerWide).toEqual([]);
+    const intact = await withSystemDbAccessContext(async () => linksOf(sPAId));
+    expect(intact.map((r) => r.tagId)).toEqual([tPAId]);
+  });
 });

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -13,6 +13,15 @@ import { configurationPolicies } from '../../db/schema/configurationPolicies';
 import { scripts, scriptExecutionBatches } from '../../db/schema/scripts';
 import { unifiIntegrations, unifiDevices } from '../../db/schema/unifi';
 import { oauthRevocationRetries } from '../../db/schema/oauth';
+import {
+  coveredCommands,
+  predicateCoversOrgAxis,
+  predicateCoversParents,
+  type Cmd,
+  type ParentRule,
+  type PolicyRow,
+  type PredicateSlot,
+} from '../../db/rlsPolicyShape';
 
 /**
  * Contract test: every tenant-scoped public table must have RLS enabled and
@@ -769,6 +778,63 @@ const UNREVIEWED_RLS_CLASSIFICATION_DEBT: ReadonlyMap<string, string> = new Map<
   ['snmp_alert_thresholds', 'device_id -> snmp_devices rows; RLS on/forced, join-through-snmp_devices policies (2026-04-11-bucket-c-dead-cleanup-rls.sql); in no allowlist — candidate PARENT_FK_JOIN_POLICY_TABLES (snmp_devices) after review.'],
 ]);
 
+// Per-command parent requirements that are STRICTER than PARENT_FK_JOIN_
+// POLICY_TABLES' default "helper on any one declared parent alias". Keyed by
+// table, then command, then predicate slot. A slot that is absent falls back
+// to the default any-of rule over the table's declared parents.
+//
+// script_to_tags (RMM-QA-220, advisor quorum §9 point 6): a link is readable
+// only when BOTH the script and the tag are visible, insertable only when the
+// script is writable AND the tag is visible, re-pointable (UPDATE WITH CHECK)
+// under the same both-parent rule, but unlinkable (UPDATE USING / DELETE) on
+// script write authority alone — tag visibility must not confer unlink rights
+// on another org's script.
+type PerCommandParentRules = Readonly<Partial<Record<Cmd, Readonly<Partial<Record<PredicateSlot, ParentRule>>>>>>;
+// Explicit type arguments on `new Map` keep the 'all-of' / 'any-of' string
+// literals narrow inside the nested object literals (otherwise TS widens them
+// to `string` and the assignment to ParentRule fails).
+const PARENT_FK_REQUIRED_PARENTS_PER_COMMAND: ReadonlyMap<string, PerCommandParentRules> = new Map<string, PerCommandParentRules>([
+  [
+    'script_to_tags',
+    {
+      SELECT: { qual: { kind: 'all-of', parents: ['scripts', 'script_tags'] } },
+      INSERT: { with_check: { kind: 'all-of', parents: ['scripts', 'script_tags'] } },
+      UPDATE: {
+        qual: { kind: 'any-of', parents: ['scripts'] },
+        with_check: { kind: 'all-of', parents: ['scripts', 'script_tags'] },
+      },
+      DELETE: { qual: { kind: 'any-of', parents: ['scripts'] } },
+    },
+  ],
+]);
+
+async function loadPublicPolicies(): Promise<Map<string, PolicyRow[]>> {
+  const rows = (await db.execute(sql`
+    SELECT tablename, policyname, cmd, permissive, qual, with_check
+    FROM pg_policies
+    WHERE schemaname = 'public'
+    ORDER BY tablename, policyname;
+  `)) as unknown as Array<PolicyRow & { tablename: string }>;
+  const byTable = new Map<string, PolicyRow[]>();
+  for (const r of rows) {
+    const list = byTable.get(r.tablename) ?? [];
+    list.push({ policyname: r.policyname, cmd: r.cmd, permissive: r.permissive, qual: r.qual, with_check: r.with_check });
+    byTable.set(r.tablename, list);
+  }
+  return byTable;
+}
+
+/** relname -> relrowsecurity for every public base table (r/p). Absent name = table missing. */
+async function loadRlsState(): Promise<Map<string, boolean>> {
+  const rows = (await db.execute(sql`
+    SELECT c.relname AS table_name, c.relrowsecurity AS rls_on
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public' AND c.relkind IN ('r', 'p');
+  `)) as unknown as Array<{ table_name: string; rls_on: boolean }>;
+  return new Map(rows.map((r) => [r.table_name, r.rls_on]));
+}
+
 const REQUIRED_CMDS = ['SELECT', 'INSERT', 'UPDATE', 'DELETE'] as const;
 
 interface TableRow {
@@ -1233,6 +1299,63 @@ describe('RLS coverage contract', () => {
     ).toEqual([]);
   });
 
+  // RMM-QA-220 (D6b): command-specific version of the org-axis assertion
+  // above, over the SAME table set (org_id tables minus
+  // ORG_AXIS_POLICY_EXCLUDED_TABLES, plus ORG_ID_KEYED_TENANT_TABLES, minus
+  // EXEMPT_TABLES via offendersFrom's filter). Requires
+  // breeze_has_org_access([<table>.]org_id) — or ([<table>.]id) for id-keyed
+  // tables — in USING for SELECT/DELETE, WITH CHECK for INSERT, both for UPDATE.
+  it('every org-tenant public table has command-specific USING/WITH CHECK coverage by breeze_has_org_access on its own org_id', async () => {
+    const idKeyedList = Array.from(ORG_ID_KEYED_TENANT_TABLES);
+    const rows = (await db.execute(sql`
+      WITH org_id_tables AS (
+        SELECT DISTINCT c.relname, c.relrowsecurity, false AS id_keyed
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        JOIN information_schema.columns col
+          ON col.table_schema = n.nspname AND col.table_name = c.relname
+        WHERE n.nspname = 'public'
+          AND c.relkind = 'r'
+          AND col.column_name = 'org_id'
+          AND c.relname <> ALL(${sql.raw(
+            `ARRAY[${Array.from(ORG_AXIS_POLICY_EXCLUDED_TABLES).map((t) => `'${t}'`).join(',')}]::text[]`,
+          )})
+      ),
+      id_keyed_tables AS (
+        SELECT c.relname, c.relrowsecurity, true AS id_keyed
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relkind = 'r'
+          AND c.relname = ANY(${sql.raw(
+            `ARRAY[${idKeyedList.map((t) => `'${t}'`).join(',')}]::text[]`,
+          )})
+      )
+      SELECT relname AS table_name, relrowsecurity AS rls_on, id_keyed FROM org_id_tables
+      UNION ALL
+      SELECT relname AS table_name, relrowsecurity AS rls_on, id_keyed FROM id_keyed_tables
+      ORDER BY 1;
+    `)) as unknown as Array<{ table_name: string; rls_on: boolean; id_keyed: boolean }>;
+
+    const policiesByTable = await loadPublicPolicies();
+    const tableRows: TableRow[] = rows.map((r) => {
+      const covered = coveredCommands(policiesByTable.get(r.table_name) ?? [], (pred) =>
+        predicateCoversOrgAxis(pred, r.table_name, r.id_keyed),
+      );
+      return { table_name: r.table_name, rls_on: r.rls_on, covered_cmds: [...covered] };
+    });
+    const offenders = offendersFrom(tableRows);
+
+    expect(
+      offenders,
+      `Org-tenant tables whose policies do not call breeze_has_org_access on the table's own org_id (or id) in the ` +
+        `slot Postgres evaluates for each command:\n${JSON.stringify(offenders, null, 2)}\n\n` +
+        `Fix: USING for SELECT/DELETE, WITH CHECK for INSERT, both for UPDATE; the argument must be this table's ` +
+        `org_id (id for ORG_ID_KEYED_TENANT_TABLES). A table whose tenancy axis is NOT its org_id column belongs in ` +
+        `ORG_AXIS_POLICY_EXCLUDED_TABLES with a comment (see ticket_form_org_links). Matcher: src/db/rlsPolicyShape.ts.`
+    ).toEqual([]);
+  });
+
   it('every partner-tenant public table has RLS on and all four DML commands covered by breeze_has_partner_access', async () => {
     const partnerTables = Array.from(PARTNER_TENANT_TABLES.keys());
 
@@ -1461,6 +1584,40 @@ describe('RLS coverage contract', () => {
         `breeze_has_org_access(parent.org_id), e.g.: ` +
         `EXISTS (SELECT 1 FROM automations a WHERE a.id = automation_runs.automation_id AND breeze_has_org_access(a.org_id)). ` +
         `See 2026-05-30-fk-child-tables-rls.sql for the canonical shape and the PARENT_FK_JOIN_POLICY_TABLES allowlist.`
+    ).toEqual([]);
+  });
+
+  // RMM-QA-220 (D6a): command-specific version of the assertion above. The
+  // legacy check accepts a helper NAME anywhere in qual OR with_check plus
+  // `LIKE '%FROM parent%'`; this one requires, per command, the helper on the
+  // declared parent's alias in the slot Postgres actually evaluates
+  // (SELECT/DELETE: USING; INSERT: WITH CHECK; UPDATE: both). Either
+  // breeze_has_org_access(<alias>.org_id) or breeze_has_partner_access(
+  // <alias>.partner_id) counts, so dual-axis parents fit. Tables in
+  // PARENT_FK_REQUIRED_PARENTS_PER_COMMAND must satisfy their overlay.
+  it('every parent-FK join-policy table has command-specific USING/WITH CHECK coverage on the declared parent alias', async () => {
+    const policiesByTable = await loadPublicPolicies();
+    const rlsState = await loadRlsState();
+    const offenders: Array<{ table: string; rls_on: boolean; missing_cmds: string[] }> = [];
+
+    for (const [table, parents] of PARENT_FK_JOIN_POLICY_TABLES) {
+      const overlay = PARENT_FK_REQUIRED_PARENTS_PER_COMMAND.get(table);
+      const covered = coveredCommands(policiesByTable.get(table) ?? [], (pred, cmd, slot) => {
+        const rule: ParentRule = overlay?.[cmd]?.[slot] ?? { kind: 'any-of', parents };
+        return predicateCoversParents(pred, rule);
+      });
+      const missing = REQUIRED_CMDS.filter((cmd) => !covered.has(cmd));
+      const rlsOn = rlsState.get(table) ?? false;
+      if (!rlsOn || missing.length > 0) offenders.push({ table, rls_on: rlsOn, missing_cmds: missing });
+    }
+
+    expect(
+      offenders,
+      `Parent-FK join-policy tables whose policies do not guard each command in the slot Postgres evaluates:\n` +
+        `${JSON.stringify(offenders, null, 2)}\n\n` +
+        `Fix: SELECT/DELETE need the parent-alias helper in USING, INSERT in WITH CHECK, UPDATE in BOTH. ` +
+        `Tables listed in PARENT_FK_REQUIRED_PARENTS_PER_COMMAND must satisfy every parent in their all-of rules. ` +
+        `Shape reference: 2026-05-30-fk-child-tables-rls.sql; matcher: src/db/rlsPolicyShape.ts.`
     ).toEqual([]);
   });
 

--- a/apps/api/src/__tests__/integration/scriptBundleRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/scriptBundleRls.integration.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Script bundle import under REAL RLS on script_versions / script_to_tags
+ * (RMM-QA-220, migration 2026-09-30-100000-script-children-rls.sql).
+ *
+ * importBundle authorises the parent script through resolveScriptCreateScope
+ * and then INSERTs script_to_tags (linkTags) and, in `new-version` mode,
+ * script_versions — as `breeze_app` inside the caller's DB access context.
+ * With the child policies forced, those INSERTs must still pass for every
+ * caller scope the route supports:
+ *   (a) organization scope  -> org-owned script (org_id + partner_id set)
+ *   (b) partner scope, availability 'partner' -> partner-wide script (org_id NULL)
+ *   (c) system scope with an explicit orgId -> org-owned script
+ * If any of these regress, the policy is wrong — not the importer (spec §non-goals).
+ */
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { eq, inArray } from 'drizzle-orm';
+import { db, withDbAccessContext, withSystemDbAccessContext } from '../../db';
+import { scripts, scriptTags, scriptToTags, scriptVersions } from '../../db/schema';
+import { buildDbAccessContext } from '../../middleware/auth';
+import { importBundle, type BundleAuth } from '../../services/scriptBundle';
+import { SCRIPT_BUNDLE_VERSION, type ScriptBundleEnvelope } from '../../services/scriptBundle/schema';
+import { createOrganization, createPartner, createUser } from './db-utils';
+
+function bundleAuth(args: {
+  scope: 'organization' | 'partner' | 'system';
+  orgId: string | null;
+  partnerId: string | null;
+  accessibleOrgIds: string[] | null;
+  partnerOrgAccess?: 'all' | 'selected' | 'none' | null;
+  userId: string;
+}): BundleAuth {
+  return {
+    scope: args.scope,
+    orgId: args.orgId,
+    partnerId: args.partnerId,
+    partnerOrgAccess: args.partnerOrgAccess ?? null,
+    accessibleOrgIds: args.accessibleOrgIds,
+    canAccessOrg: (id: string) => args.accessibleOrgIds === null || args.accessibleOrgIds.includes(id),
+    user: { id: args.userId, email: 'bundle-rls@example.com', name: 'Bundle RLS', isPlatformAdmin: false },
+  };
+}
+
+function bundle(content: string, suffix: string): ScriptBundleEnvelope {
+  return {
+    bundleVersion: SCRIPT_BUNDLE_VERSION,
+    scripts: [
+      { name: `Bundle One ${suffix}`, osTypes: ['windows'], language: 'powershell', content, tags: ['alpha', 'beta'], timeoutSeconds: 300, runAs: 'system' },
+      { name: `Bundle Two ${suffix}`, osTypes: ['linux'], language: 'bash', content, tags: ['alpha'], timeoutSeconds: 300, runAs: 'system' },
+    ],
+  };
+}
+
+async function readBack(names: string[]) {
+  return withSystemDbAccessContext(async () => {
+    const rows = await db.select().from(scripts).where(inArray(scripts.name, names));
+    const byName = new Map(rows.map((r) => [r.name, r]));
+    const ids = rows.map((r) => r.id);
+    const versions = ids.length ? await db.select().from(scriptVersions).where(inArray(scriptVersions.scriptId, ids)) : [];
+    const links = ids.length
+      ? await db
+          .select({ scriptId: scriptToTags.scriptId, tagName: scriptTags.name, tagOrgId: scriptTags.orgId, tagPartnerId: scriptTags.partnerId })
+          .from(scriptToTags)
+          .innerJoin(scriptTags, eq(scriptToTags.tagId, scriptTags.id))
+          .where(inArray(scriptToTags.scriptId, ids))
+      : [];
+    return { byName, versions, links };
+  });
+}
+
+async function importTwice(auth: BundleAuth, ctx: ReturnType<typeof buildDbAccessContext>, availability: 'org' | 'partner', orgId: string | null, suffix: string) {
+  const first = await withDbAccessContext(ctx, () => importBundle(auth, bundle('echo v1', suffix), { availability, orgId, mode: 'skip' }));
+  const second = await withDbAccessContext(ctx, () => importBundle(auth, bundle('echo v2', suffix), { availability, orgId, mode: 'new-version' }));
+  return { first, second };
+}
+
+function expectImported(result: Awaited<ReturnType<typeof importBundle>>, expected: { imported?: number; versioned?: number }) {
+  if ('error' in result) throw new Error(`importBundle returned a scope error: ${result.error}`);
+  expect(result.errors).toEqual([]);
+  if (expected.imported !== undefined) expect(result.imported).toBe(expected.imported);
+  if (expected.versioned !== undefined) expect(result.versioned).toBe(expected.versioned);
+}
+
+async function assertChildren(suffix: string, owner: { orgId: string | null; partnerId: string | null }) {
+  const names = [`Bundle One ${suffix}`, `Bundle Two ${suffix}`];
+  const { byName, versions, links } = await readBack(names);
+  const one = byName.get(names[0]!);
+  const two = byName.get(names[1]!);
+  expect(one?.orgId ?? null).toBe(owner.orgId);
+  expect(one?.partnerId ?? null).toBe(owner.partnerId);
+  expect(one?.content).toBe('echo v2');
+  expect(one?.version).toBe(2);
+  // One snapshot per script, holding the v1 content, created by the caller.
+  const oneVersions = versions.filter((v) => v.scriptId === one!.id);
+  const twoVersions = versions.filter((v) => v.scriptId === two!.id);
+  expect(oneVersions.map((v) => [v.version, v.content])).toEqual([[1, 'echo v1']]);
+  expect(twoVersions.map((v) => [v.version, v.content])).toEqual([[1, 'echo v1']]);
+  // Tags: two links on One, one on Two, all owned by the same scope as the script.
+  expect(links.filter((l) => l.scriptId === one!.id).map((l) => l.tagName).sort()).toEqual(['alpha', 'beta']);
+  expect(links.filter((l) => l.scriptId === two!.id).map((l) => l.tagName)).toEqual(['alpha']);
+  for (const l of links) {
+    expect(l.tagOrgId ?? null).toBe(owner.orgId);
+    expect(l.tagPartnerId ?? null).toBe(owner.partnerId);
+  }
+}
+
+describe('script bundle import under forced RLS on script_versions / script_to_tags (RMM-QA-220)', () => {
+  it('(a) organization-scope caller: versions and tag links land on the org-owned script', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const user = await createUser({ partnerId: partner.id, orgId: org.id });
+    const suffix = `org-${Date.now()}`;
+    const auth = bundleAuth({ scope: 'organization', orgId: org.id, partnerId: partner.id, accessibleOrgIds: [org.id], userId: user.id });
+    const ctx = buildDbAccessContext({ scope: 'organization', orgId: org.id, accessibleOrgIds: [org.id], partnerId: partner.id, userId: user.id });
+
+    const { first, second } = await importTwice(auth, ctx, 'org', null, suffix);
+    expectImported(first, { imported: 2 });
+    expectImported(second, { versioned: 2 });
+    await assertChildren(suffix, { orgId: org.id, partnerId: partner.id });
+  });
+
+  it('(b) partner-scope caller with partner-wide capability: versions and tag links land on the partner-wide script', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const user = await createUser({ partnerId: partner.id });
+    const suffix = `pw-${Date.now()}`;
+    const auth = bundleAuth({ scope: 'partner', orgId: null, partnerId: partner.id, accessibleOrgIds: [org.id], partnerOrgAccess: 'all', userId: user.id });
+    const ctx = buildDbAccessContext({ scope: 'partner', orgId: null, accessibleOrgIds: [org.id], partnerId: partner.id, userId: user.id });
+
+    const { first, second } = await importTwice(auth, ctx, 'partner', null, suffix);
+    expectImported(first, { imported: 2 });
+    expectImported(second, { versioned: 2 });
+    await assertChildren(suffix, { orgId: null, partnerId: partner.id });
+  });
+
+  it('(c) system-scope caller with an explicit orgId: versions and tag links land on the org-owned script', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const user = await createUser({ partnerId: partner.id });
+    const suffix = `sys-${Date.now()}`;
+    const auth = bundleAuth({ scope: 'system', orgId: null, partnerId: null, accessibleOrgIds: null, userId: user.id });
+    const ctx = buildDbAccessContext({ scope: 'system', orgId: null, accessibleOrgIds: null, partnerId: null, userId: user.id });
+
+    const { first, second } = await importTwice(auth, ctx, 'org', org.id, suffix);
+    expectImported(first, { imported: 2 });
+    expectImported(second, { versioned: 2 });
+    // resolveScriptCreateScope: system scope -> { orgId: requested, partnerId: null }.
+    await assertChildren(suffix, { orgId: org.id, partnerId: null });
+  });
+
+  it('cross-check: the org-owned links are invisible to a different org under breeze_app', async () => {
+    const partner = await createPartner();
+    const orgA = await createOrganization({ partnerId: partner.id });
+    const orgB = await createOrganization({ partnerId: partner.id });
+    const user = await createUser({ partnerId: partner.id, orgId: orgA.id });
+    const suffix = `xo-${Date.now()}`;
+    const auth = bundleAuth({ scope: 'organization', orgId: orgA.id, partnerId: partner.id, accessibleOrgIds: [orgA.id], userId: user.id });
+    const ctxA = buildDbAccessContext({ scope: 'organization', orgId: orgA.id, accessibleOrgIds: [orgA.id], partnerId: partner.id, userId: user.id });
+    const ctxB = buildDbAccessContext({ scope: 'organization', orgId: orgB.id, accessibleOrgIds: [orgB.id], partnerId: partner.id, userId: null });
+
+    expectImported(await withDbAccessContext(ctxA, () => importBundle(auth, bundle('echo v1', suffix), { availability: 'org', orgId: null, mode: 'skip' })), { imported: 2 });
+    const [row] = await withSystemDbAccessContext(() => db.select({ id: scripts.id }).from(scripts).where(eq(scripts.name, `Bundle One ${suffix}`)));
+    const asB = await withDbAccessContext(ctxB, () =>
+      db.select({ tagId: scriptToTags.tagId }).from(scriptToTags).where(eq(scriptToTags.scriptId, row!.id))
+    );
+    expect(asB).toEqual([]);
+    const asA = await withDbAccessContext(ctxA, () => db.select({ tagId: scriptToTags.tagId }).from(scriptToTags).where(eq(scriptToTags.scriptId, row!.id)));
+    expect(asA).toHaveLength(2);
+  });
+});

--- a/apps/api/src/__tests__/integration/scriptBundleRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/scriptBundleRls.integration.test.ts
@@ -1,6 +1,6 @@
 /**
  * Script bundle import under REAL RLS on script_versions / script_to_tags
- * (RMM-QA-220, migration 2026-09-30-100000-script-children-rls.sql).
+ * (RMM-QA-220, migration apps/api/migrations/2026-10-01-100000-script-children-rls.sql).
  *
  * importBundle authorises the parent script through resolveScriptCreateScope
  * and then INSERTs script_to_tags (linkTags) and, in `new-version` mode,

--- a/apps/api/src/db/rlsPolicyShape.test.ts
+++ b/apps/api/src/db/rlsPolicyShape.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+import {
+  coveredCommands,
+  normalizePredicate,
+  parentAliases,
+  predicateCoversOrgAxis,
+  predicateCoversParent,
+  predicateCoversParents,
+  type PolicyRow,
+} from './rlsPolicyShape';
+
+// Deparsed shapes copied from pg_policies on a migrated test DB (whitespace
+// exactly as Postgres emits it, including the leading "( SELECT").
+const SCRIPTS_JOIN_ORG =
+  '(EXISTS ( SELECT 1 FROM scripts s WHERE ((s.id = script_versions.script_id) AND breeze_has_org_access(s.org_id))))';
+const SCRIPTS_JOIN_PARTNER =
+  '(EXISTS ( SELECT 1 FROM scripts s WHERE ((s.id = script_versions.script_id) AND breeze_has_partner_access(s.partner_id))))';
+const BOTH_PARENTS =
+  '((EXISTS ( SELECT 1 FROM scripts s WHERE ((s.id = script_to_tags.script_id) AND (breeze_has_org_access(s.org_id) OR breeze_has_partner_access(s.partner_id))))) ' +
+  'AND (EXISTS ( SELECT 1 FROM script_tags t WHERE ((t.id = script_to_tags.tag_id) AND (breeze_has_org_access(t.org_id) OR breeze_has_partner_access(t.partner_id))))))';
+const SCRIPTS_ONLY_PLUS_TAG_JOIN_NO_HELPER =
+  '((EXISTS ( SELECT 1 FROM scripts s WHERE ((s.id = script_to_tags.script_id) AND breeze_has_org_access(s.org_id)))) ' +
+  'AND (EXISTS ( SELECT 1 FROM script_tags t WHERE (t.id = script_to_tags.tag_id))))';
+const HELPER_ON_OTHER_ALIAS =
+  '(EXISTS ( SELECT 1 FROM scripts s, organizations o WHERE ((s.id = script_versions.script_id) AND breeze_has_org_access(o.org_id))))';
+const HELPER_ON_CHILD_OWN_COLUMN =
+  '(EXISTS ( SELECT 1 FROM scripts s WHERE (s.id = script_versions.script_id)) AND breeze_has_org_access(org_id))';
+const UNALIASED_PARENT =
+  '(EXISTS ( SELECT 1 FROM scripts WHERE ((scripts.id = script_versions.script_id) AND breeze_has_org_access(scripts.org_id))))';
+const WITH_NEWLINES =
+  '(EXISTS ( SELECT 1\n   FROM scripts s\n  WHERE ((s.id = script_versions.script_id)\n    AND breeze_has_org_access(s.org_id))))';
+
+function policy(p: Partial<PolicyRow> & { cmd: string }): PolicyRow {
+  return { policyname: p.policyname ?? 'p', cmd: p.cmd, permissive: p.permissive ?? 'PERMISSIVE', qual: p.qual ?? null, with_check: p.with_check ?? null };
+}
+
+const scriptsRule = (pred: string | null) => predicateCoversParents(pred, { kind: 'any-of', parents: ['scripts'] });
+
+describe('rlsPolicyShape — parent aliases', () => {
+  it('finds the alias declared after FROM <parent>', () => {
+    expect(parentAliases(SCRIPTS_JOIN_ORG, 'scripts')).toEqual(['s']);
+  });
+  it('falls back to the bare parent name when FROM <parent> has no alias', () => {
+    expect(parentAliases(UNALIASED_PARENT, 'scripts')).toEqual(['scripts']);
+  });
+  it('does not treat FROM script_tags as FROM scripts (word boundary)', () => {
+    expect(parentAliases('(EXISTS ( SELECT 1 FROM script_tags t WHERE (t.id = x.tag_id)))', 'scripts')).toEqual([]);
+  });
+  it('normalises embedded newlines before matching', () => {
+    expect(normalizePredicate(WITH_NEWLINES)).not.toContain('\n');
+    expect(predicateCoversParent(WITH_NEWLINES, 'scripts')).toBe(true);
+  });
+});
+
+describe('rlsPolicyShape — predicateCoversParent(s)', () => {
+  it('accepts breeze_has_org_access on the parent alias', () => {
+    expect(predicateCoversParent(SCRIPTS_JOIN_ORG, 'scripts')).toBe(true);
+  });
+  it('accepts breeze_has_partner_access on the parent alias (dual-axis parents)', () => {
+    expect(predicateCoversParent(SCRIPTS_JOIN_PARTNER, 'scripts')).toBe(true);
+  });
+  it('rejects a helper applied to a non-parent alias even though FROM <parent> is present', () => {
+    expect(predicateCoversParent(HELPER_ON_OTHER_ALIAS, 'scripts')).toBe(false);
+  });
+  it("rejects a helper applied to the child's own column", () => {
+    expect(predicateCoversParent(HELPER_ON_CHILD_OWN_COLUMN, 'scripts')).toBe(false);
+  });
+  it('any-of: one covered parent suffices', () => {
+    expect(predicateCoversParents(SCRIPTS_JOIN_ORG, { kind: 'any-of', parents: ['scripts', 'script_tags'] })).toBe(true);
+  });
+  it('all-of: every listed parent must carry a helper on its alias', () => {
+    expect(predicateCoversParents(BOTH_PARENTS, { kind: 'all-of', parents: ['scripts', 'script_tags'] })).toBe(true);
+    expect(predicateCoversParents(SCRIPTS_ONLY_PLUS_TAG_JOIN_NO_HELPER, { kind: 'all-of', parents: ['scripts', 'script_tags'] })).toBe(false);
+  });
+  it('null / empty predicate never covers', () => {
+    expect(scriptsRule(null)).toBe(false);
+    expect(scriptsRule('')).toBe(false);
+  });
+});
+
+describe('rlsPolicyShape — predicateCoversOrgAxis', () => {
+  it('accepts breeze_has_org_access(org_id) and breeze_has_org_access(<table>.org_id)', () => {
+    expect(predicateCoversOrgAxis('breeze_has_org_access(org_id)', 'devices', false)).toBe(true);
+    expect(predicateCoversOrgAxis('breeze_has_org_access(devices.org_id)', 'devices', false)).toBe(true);
+  });
+  it('rejects a helper on another alias or another column', () => {
+    expect(predicateCoversOrgAxis('breeze_has_org_access(tf.org_id)', 'ticket_form_org_links', false)).toBe(false);
+    expect(predicateCoversOrgAxis('breeze_has_org_access(partner_id)', 'devices', false)).toBe(false);
+    expect(predicateCoversOrgAxis('breeze_has_partner_access(org_id)', 'devices', false)).toBe(false);
+  });
+  it('accepts breeze_has_org_access(id) only for id-keyed tables', () => {
+    expect(predicateCoversOrgAxis('breeze_has_org_access(id)', 'organizations', true)).toBe(true);
+    expect(predicateCoversOrgAxis('breeze_has_org_access(id)', 'devices', false)).toBe(false);
+    expect(predicateCoversOrgAxis('breeze_has_org_access(org_id)', 'organizations', true)).toBe(false);
+  });
+});
+
+describe('rlsPolicyShape — coveredCommands (command → slot)', () => {
+  it('SELECT and DELETE are covered from qual only', () => {
+    const covered = coveredCommands(
+      [policy({ cmd: 'SELECT', qual: SCRIPTS_JOIN_ORG }), policy({ cmd: 'DELETE', qual: SCRIPTS_JOIN_ORG })],
+      (pred) => scriptsRule(pred),
+    );
+    expect([...covered].sort()).toEqual(['DELETE', 'SELECT']);
+  });
+  it('a SELECT policy whose helper sits only in with_check does NOT cover SELECT (the QA-named blind spot)', () => {
+    const covered = coveredCommands([policy({ cmd: 'SELECT', qual: 'true', with_check: SCRIPTS_JOIN_ORG })], (pred) => scriptsRule(pred));
+    expect(covered.size).toBe(0);
+  });
+  it('INSERT is covered from with_check only', () => {
+    expect(coveredCommands([policy({ cmd: 'INSERT', with_check: SCRIPTS_JOIN_ORG })], (pred) => scriptsRule(pred)).has('INSERT')).toBe(true);
+    expect(coveredCommands([policy({ cmd: 'INSERT', qual: SCRIPTS_JOIN_ORG, with_check: 'true' })], (pred) => scriptsRule(pred)).has('INSERT')).toBe(false);
+  });
+  it('UPDATE needs BOTH qual and with_check', () => {
+    expect(coveredCommands([policy({ cmd: 'UPDATE', qual: SCRIPTS_JOIN_ORG, with_check: 'true' })], (pred) => scriptsRule(pred)).has('UPDATE')).toBe(false);
+    expect(coveredCommands([policy({ cmd: 'UPDATE', qual: 'true', with_check: SCRIPTS_JOIN_ORG })], (pred) => scriptsRule(pred)).has('UPDATE')).toBe(false);
+    expect(coveredCommands([policy({ cmd: 'UPDATE', qual: SCRIPTS_JOIN_ORG, with_check: SCRIPTS_JOIN_ORG })], (pred) => scriptsRule(pred)).has('UPDATE')).toBe(true);
+  });
+  it('UPDATE/ALL with a NULL with_check reuses qual as the check (Postgres default); INSERT-only policies do not', () => {
+    expect(coveredCommands([policy({ cmd: 'UPDATE', qual: SCRIPTS_JOIN_ORG, with_check: null })], (pred) => scriptsRule(pred)).has('UPDATE')).toBe(true);
+    const all = coveredCommands([policy({ cmd: 'ALL', qual: SCRIPTS_JOIN_ORG, with_check: null })], (pred) => scriptsRule(pred));
+    expect([...all].sort()).toEqual(['DELETE', 'INSERT', 'SELECT', 'UPDATE']);
+    expect(coveredCommands([policy({ cmd: 'INSERT', qual: SCRIPTS_JOIN_ORG, with_check: null })], (pred) => scriptsRule(pred)).has('INSERT')).toBe(false);
+  });
+  it('cmd=ALL with an explicit with_check expands to all four, checking the right slot for each', () => {
+    const covered = coveredCommands([policy({ cmd: 'ALL', qual: SCRIPTS_JOIN_ORG, with_check: 'true' })], (pred) => scriptsRule(pred));
+    expect([...covered].sort()).toEqual(['DELETE', 'SELECT']);
+  });
+  it('RESTRICTIVE policies never count', () => {
+    expect(coveredCommands([policy({ cmd: 'ALL', permissive: 'RESTRICTIVE', qual: SCRIPTS_JOIN_ORG, with_check: SCRIPTS_JOIN_ORG })], (pred) => scriptsRule(pred)).size).toBe(0);
+  });
+  it('the matcher receives cmd and slot so per-command overlays can differ (script_to_tags shape)', () => {
+    const seen: string[] = [];
+    coveredCommands(
+      [policy({ cmd: 'UPDATE', qual: SCRIPTS_JOIN_ORG, with_check: BOTH_PARENTS })],
+      (pred, cmd, slot) => { seen.push(`${cmd}:${slot}`); return true; },
+    );
+    expect(seen).toEqual(['UPDATE:qual', 'UPDATE:with_check']);
+  });
+});

--- a/apps/api/src/db/rlsPolicyShape.ts
+++ b/apps/api/src/db/rlsPolicyShape.ts
@@ -1,0 +1,144 @@
+/**
+ * Pure predicate-shape matchers for the RLS coverage contract
+ * (src/__tests__/integration/rls-coverage.integration.test.ts).
+ *
+ * Why this exists (RMM-QA-220): the contract used to accept a helper NAME
+ * appearing anywhere in `qual OR with_check` as coverage for every DML
+ * command. Postgres evaluates SELECT/DELETE against USING (`qual`), INSERT
+ * against WITH CHECK (`with_check`), and UPDATE against BOTH — so a helper in
+ * the wrong slot proves nothing for the command the policy governs. These
+ * matchers are command-specific and argument-specific.
+ *
+ * Lives under src/db/ rather than src/__tests__/integration/ on purpose: the
+ * unit runner (vitest.config.ts) excludes that directory wholesale and the
+ * integration runner includes every *.test.ts in it, so a pure function's
+ * unit test has to sit where the Test API job sees it and the real-DB setup
+ * does not.
+ *
+ * Input is the deparsed text of pg_policies.qual / with_check. Postgres drops
+ * the `public.` prefix on helper calls and may emit newlines, so callers get
+ * whitespace-normalised matching for free.
+ */
+export type Cmd = 'SELECT' | 'INSERT' | 'UPDATE' | 'DELETE';
+export const RLS_CMDS: readonly Cmd[] = ['SELECT', 'INSERT', 'UPDATE', 'DELETE'];
+export type PredicateSlot = 'qual' | 'with_check';
+
+export interface PolicyRow {
+  policyname: string;
+  /** 'SELECT' | 'INSERT' | 'UPDATE' | 'DELETE' | 'ALL' (pg_policies.cmd). */
+  cmd: string;
+  /** 'PERMISSIVE' | 'RESTRICTIVE' (pg_policies.permissive). */
+  permissive: string;
+  qual: string | null;
+  with_check: string | null;
+}
+
+export type ParentRule =
+  /** Default parent-FK rule: a covering helper on ANY one declared parent alias. */
+  | { kind: 'any-of'; parents: readonly string[] }
+  /** Overlay: a covering helper on EVERY listed parent alias (script_to_tags). */
+  | { kind: 'all-of'; parents: readonly string[] };
+
+export type PredicateMatcher = (pred: string | null, cmd: Cmd, slot: PredicateSlot) => boolean;
+
+// Tokens that can legally follow `FROM <parent>` and must not be mistaken
+// for an alias when the join is unaliased.
+const NOT_AN_ALIAS = new Set([
+  'where', 'join', 'on', 'left', 'right', 'inner', 'cross', 'full', 'natural',
+  'using', 'and', 'or', 'group', 'order', 'limit', 'union', 'except', 'intersect',
+]);
+
+export function normalizePredicate(pred: string | null): string {
+  return (pred ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Every alias under which `parent` is joined in `pred` via
+ * `FROM [public.]<parent> [AS] <alias>`; the bare parent name when the join
+ * is unaliased. `\b` after the parent name keeps `FROM scripts` from matching
+ * `FROM script_tags`.
+ */
+export function parentAliases(pred: string | null, parent: string): string[] {
+  const text = normalizePredicate(pred);
+  const re = new RegExp(
+    `\\bFROM\\s+(?:public\\.)?${escapeRegExp(parent)}\\b(?:\\s+(?:AS\\s+)?([A-Za-z_][A-Za-z0-9_]*))?`,
+    'gi',
+  );
+  const aliases: string[] = [];
+  for (const m of text.matchAll(re)) {
+    const candidate = m[1];
+    aliases.push(candidate && !NOT_AN_ALIAS.has(candidate.toLowerCase()) ? candidate : parent);
+  }
+  return aliases;
+}
+
+function helperOnAlias(text: string, alias: string): boolean {
+  const re = new RegExp(
+    `\\bbreeze_has_(?:org|partner)_access\\(\\s*${escapeRegExp(alias)}\\.(?:org_id|partner_id)\\s*\\)`,
+    'i',
+  );
+  return re.test(text);
+}
+
+/**
+ * True when `pred` joins `parent` and applies breeze_has_org_access(<alias>.org_id)
+ * or breeze_has_partner_access(<alias>.partner_id) to THAT alias. A helper on
+ * the child's own column or on a non-parent alias does not count.
+ */
+export function predicateCoversParent(pred: string | null, parent: string): boolean {
+  const text = normalizePredicate(pred);
+  if (text === '') return false;
+  return parentAliases(text, parent).some((alias) => helperOnAlias(text, alias));
+}
+
+export function predicateCoversParents(pred: string | null, rule: ParentRule): boolean {
+  if (rule.parents.length === 0) return false;
+  const covered = rule.parents.map((parent) => predicateCoversParent(pred, parent));
+  return rule.kind === 'all-of' ? covered.every(Boolean) : covered.some(Boolean);
+}
+
+/**
+ * Org-axis shape: breeze_has_org_access([<table>.]org_id) — or
+ * breeze_has_org_access([<table>.]id) when `idKeyed` (organizations). Any
+ * other alias or column is NOT this table's tenant expression.
+ */
+export function predicateCoversOrgAxis(pred: string | null, table: string, idKeyed: boolean): boolean {
+  const text = normalizePredicate(pred);
+  if (text === '') return false;
+  const column = idKeyed ? 'id' : 'org_id';
+  const re = new RegExp(
+    `\\bbreeze_has_org_access\\(\\s*(?:(?:public\\.)?${escapeRegExp(table)}\\.)?${column}\\s*\\)`,
+    'i',
+  );
+  return re.test(text);
+}
+
+/**
+ * Commands covered by `policies` under `matches`:
+ *   SELECT / DELETE ← qual; INSERT ← with_check; UPDATE ← qual AND with_check.
+ * cmd='ALL' expands to all four. Only PERMISSIVE rows count. A FOR UPDATE or
+ * FOR ALL policy that omitted WITH CHECK reuses USING as its check (Postgres
+ * semantics; pg_policies then reports with_check = NULL) — a FOR INSERT policy
+ * never gets that fallback, because Postgres requires WITH CHECK for it.
+ */
+export function coveredCommands(policies: readonly PolicyRow[], matches: PredicateMatcher): Set<Cmd> {
+  const covered = new Set<Cmd>();
+  for (const p of policies) {
+    if (p.permissive !== 'PERMISSIVE') continue;
+    const cmds: Cmd[] = p.cmd === 'ALL' ? [...RLS_CMDS] : RLS_CMDS.includes(p.cmd as Cmd) ? [p.cmd as Cmd] : [];
+    const reusesQualAsCheck = p.cmd === 'ALL' || p.cmd === 'UPDATE';
+    const check = p.with_check ?? (reusesQualAsCheck ? p.qual : null);
+    for (const cmd of cmds) {
+      let ok: boolean;
+      if (cmd === 'SELECT' || cmd === 'DELETE') ok = matches(p.qual, cmd, 'qual');
+      else if (cmd === 'INSERT') ok = matches(check, cmd, 'with_check');
+      else ok = matches(p.qual, cmd, 'qual') && matches(check, cmd, 'with_check');
+      if (ok) covered.add(cmd);
+    }
+  }
+  return covered;
+}

--- a/docs/superpowers/plans/2026-09-01-rmm-qa-220-script-children-rls.md
+++ b/docs/superpowers/plans/2026-09-01-rmm-qa-220-script-children-rls.md
@@ -1,0 +1,2019 @@
+# RMM-QA-220 Script Children RLS Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land forced parent-join RLS on `script_versions` and `script_to_tags`, make the RLS coverage catalog exhaustive over every public base table, add command-specific USING/WITH CHECK policy-shape checks, and prove the enforcement behaviourally as `breeze_app` for Org A/B and Partner A/B — every behaviour change RED-first with the failing output retained, every new control proven to discriminate by mutation.
+
+**Architecture:** One new idempotent migration installs four per-command policies per table (canonical `2026-05-30-fk-child-tables-rls.sql` shape) whose nested `EXISTS` mirrors the parents' reviewed predicates: `script_versions` SELECT = the parent's full read predicate (org OR partner OR `is_system` OR own-partner read branch), writes = the parent's write predicate only; `script_to_tags` additionally requires the tag to be readable on SELECT/INSERT/UPDATE-check and derives unlink authority from the script's write predicate only. The contract test `rls-coverage.integration.test.ts` gains the two catalog entries (the retained RED), an exhaustive every-public-base-table classification test with a shrink-only debt bucket, and two command-specific shape tests backed by a pure matcher module `src/db/rlsPolicyShape.ts` (unit-tested in the Test API job). A forge suite as `breeze_app` and a bundle-import regression suite prove behaviour.
+
+**Tech Stack:** PostgreSQL 16 RLS (`pg_policies`, `pg_class`), Drizzle ORM + postgres.js, Vitest (unit runner `vitest.config.ts`; rls-coverage runner `vitest.config.rls-coverage.ts`; integration runner `vitest.integration.config.ts`), per-worktree Docker test stack (`pnpm test-stack`).
+
+**Spec:** `docs/superpowers/specs/2026-09-01-rmm-qa-220-script-children-rls-design.md` (same worktree). Decisions D1–D9, verified facts F1–F22 and the advisor-quorum record live there; this plan cites them by number.
+
+## Global Constraints
+
+- **Worktree (the ONLY tree you touch):** `/private/tmp/claude-501/-Users-toddhebebrand-breeze-rmm-qa/096c7d0d-b990-4dcd-8885-640bde845261/scratchpad/s1wt/rmm-qa-220` — a git worktree of `/Users/toddhebebrand/breeze`, branch `fix/rmm-qa-220-script-children-rls`, based on `origin/main` `1b733cedb`. Never touch any other worktree, never push to `main`, never merge. Every command below runs with the worktree root as `cwd` unless stated; `WT` denotes that absolute path.
+- **Scratch logs (never committed):** `LOGS=/private/tmp/claude-501/-Users-toddhebebrand-breeze-rmm-qa/096c7d0d-b990-4dcd-8885-640bde845261/scratchpad/rmm-qa-220-logs` (`mkdir -p "$LOGS"`). Every RED/GREEN/mutation run is teed there; commit messages quote from these files.
+- **Rigor: HIGH** (auth / tenancy / shipped surfaces). Every behaviour change is RED-first and the failing output is retained verbatim in the commit message. Every new test control is proven to discriminate: mutate, watch it fail, revert, watch it pass — the mutation and its output are recorded in the commit message.
+- **Install once, before anything else:** `pnpm install --frozen-lockfile` (the worktree has no `node_modules` yet).
+- **Typecheck gate:** `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @breeze/api exec tsc --noEmit` (`apps/api/tsconfig.json` includes `src/**/*`, so test files are type-checked too).
+- **Unit tests:** `pnpm --filter @breeze/api exec vitest run <paths>` (unit runner; no DB). Web tests (`pnpm --filter @breeze/web exec vitest run <paths>`) are not needed — this change touches no `apps/web` file.
+- **Real-Postgres suites need the per-worktree stack:** `pnpm test-stack up` (from `WT`; writes `WT/.env.test` with ephemeral ports) and `pnpm test-stack down` when finished. **Never** run `pnpm --filter @breeze/api test:docker:up` — it targets the shared `:5433` containers another session may be using.
+  - Integration runner (migrates the stack DB once via `globalSetup`): `pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts <file>`.
+  - RLS coverage runner (no migrations, no truncation — run it only AFTER an integration run has migrated the DB). Task 0 writes the CI-equivalent variables (`ci.yml:2006-2020`) to `$LOGS/rls-coverage.env`; every invocation is then `set -a && . "$LOGS/rls-coverage.env" && set +a && pnpm --filter @breeze/api test:rls-coverage` (append `-- -t '<test name>'` to run a subset). The shell is zsh, which does not word-split an unquoted `$VAR`, so never try `env $VARS cmd`. `vitest.config.rls-coverage.ts` loads `WT/.env.test` itself.
+  - Postgres container name: `PG="$(grep '^# compose project:' "$WT/.env.test" | awk '{print $4}')-postgres"` (project name derives from the branch: `breeze-test-fix-rmm-qa-220-script-children-rls`). `docker exec -i "$PG" psql -U breeze_test -d breeze_test` is the superuser shell; `breeze_test` may `SET ROLE breeze_app` to act as the unprivileged request role.
+- **Migration hygiene (Task 5 only):** filename `apps/api/migrations/2026-09-30-100000-script-children-rls.sql` (sorts strictly after the current ceiling `2026-09-29-detach-ticket-runs-on-device-org-move.sql`; if `main` has grown past it at commit time pick the next `HHMMSS` that sorts last — never rename after commit). `bash scripts/check-migration-naming.sh --staged` (also runs from the `.githooks/pre-commit` hook) and `pnpm --filter @breeze/api check:migrations` against a fresh database. No inner `BEGIN;`/`COMMIT;` (`autoMigrate` wraps each file — CLAUDE.md, `migrations/README.md:54-56`; the verifier's "some migrations wrap in BEGIN" note is refuted by `grep -l '^BEGIN;' apps/api/migrations/2026-09-*.sql` → nothing). Idempotent: `DROP POLICY IF EXISTS` then `CREATE POLICY`. **Never edit a shipped migration** (`0001-baseline.sql` stays byte-identical).
+- **Files you may touch** (spec §3): `apps/api/migrations/2026-09-30-100000-script-children-rls.sql` (new), `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts`, `apps/api/src/db/rlsPolicyShape.ts` (new), `apps/api/src/db/rlsPolicyShape.test.ts` (new), `apps/api/src/__tests__/integration/scriptBundleRls.integration.test.ts` (new), and this plan/spec pair. **Nothing else** — in particular not `ensureAppRole.ts`, `scriptBundle/index.ts`, `aiToolsScripts.ts`, `routes/scripts.ts`, `tenantCascade.ts`, `orgMergeRegistry.ts`, `db/schema/scripts.ts`, nor anything under `/Users/toddhebebrand/breeze-rmm-qa/docs/qa/probes/` (the QA probe pins the PRE-fix state and is expected to flip; QA owns that).
+- **Policy semantics that must not drift** (D2/D3, verifier concerns 1–3): `is_system` appears ONLY in the `script_versions`/`script_to_tags` SELECT predicates, never in INSERT/UPDATE/DELETE (`2026-06-13-catalog-partner-axis-rls.sql:62-68`, Discussion #633); unlink/UPDATE authority derives from the script WRITE predicate; UPDATE `WITH CHECK` re-applies the tag READ leg; no strict `s.org_id = t.org_id` tightening.
+- **No existing assertion is weakened or removed.** New tests are added beside existing ones.
+- **Commit trailer (every commit):**
+  ```
+  Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+  Claude-Session: https://claude.ai/code/session_01E9p3mtFLSv8SFcZ9fcn8Vu
+  ```
+- **Codex (only if you run it, e.g. the optional pre-PR review in Task 7):** `codex exec "..." -s read-only -m gpt-5.6-sol -C <dir> < /dev/null` — always redirect stdin.
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `apps/api/src/db/rlsPolicyShape.ts` (new, pure) | Predicate-shape matchers: alias discovery for `FROM <parent> [AS] <alias>`, helper-on-parent-alias check (`any-of` / `all-of`), org-axis argument check, command→slot coverage (`coveredCommands`). No DB import. |
+| `apps/api/src/db/rlsPolicyShape.test.ts` (new) | Fixture-driven unit test for the module (Test API job). |
+| `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts` | D4 catalog entries; D5 exhaustive classification + `PLATFORM_INFRASTRUCTURE_TABLES` + `UNREVIEWED_RLS_CLASSIFICATION_DEBT`; D6a/D6b command-specific tests + `PARENT_FK_REQUIRED_PARENTS_PER_COMMAND`; D7 forge describe. |
+| `apps/api/migrations/2026-09-30-100000-script-children-rls.sql` (new) | D1–D3 DDL. |
+| `apps/api/src/__tests__/integration/scriptBundleRls.integration.test.ts` (new) | D8 bundle-import regression under real RLS (org / partner-wide / system callers). |
+
+Commit order (spec §4): (1) plan doc → (2) shape module + unit test → (3) catalog + D5 RED→partial-GREEN → (4) D6a/D6b → (5) D7 forge, committed RED → (6) migration, everything green → (7) D8 regression + mutation proof → (8) push + draft PR. Intermediate commits are allowed to be red in CI; the PR head must be green.
+
+---
+
+### Task 0: Bootstrap the worktree, the test stack, and the pre-fix baseline evidence
+
+**Files:**
+- Create: `docs/superpowers/plans/2026-09-01-rmm-qa-220-script-children-rls.md` (this file — commit it with the spec)
+- No source changes.
+
+**Interfaces:**
+- Produces: a migrated per-worktree test DB (`WT/.env.test`), `$LOGS/baseline-*.log` evidence files, one commit containing spec + plan.
+
+- [ ] **Step 1: Verify the worktree and branch**
+
+```bash
+WT=/private/tmp/claude-501/-Users-toddhebebrand-breeze-rmm-qa/096c7d0d-b990-4dcd-8885-640bde845261/scratchpad/s1wt/rmm-qa-220
+LOGS=/private/tmp/claude-501/-Users-toddhebebrand-breeze-rmm-qa/096c7d0d-b990-4dcd-8885-640bde845261/scratchpad/rmm-qa-220-logs
+mkdir -p "$LOGS"
+cd "$WT" && git status --short && git branch --show-current && git log --oneline -1
+```
+Expected: branch `fix/rmm-qa-220-script-children-rls`; HEAD `1b733cedb` (or a fast-forward of it); untracked `docs/superpowers/specs/2026-09-01-rmm-qa-220-script-children-rls-design.md` and this plan. If the worktree is absent: `git -C /Users/toddhebebrand/breeze fetch origin main && git -C /Users/toddhebebrand/breeze worktree add /private/tmp/claude-501/-Users-toddhebebrand-breeze-rmm-qa/096c7d0d-b990-4dcd-8885-640bde845261/scratchpad/s1wt/rmm-qa-220 fix/rmm-qa-220-script-children-rls` (add `-b fix/rmm-qa-220-script-children-rls … origin/main` only if the branch does not exist).
+
+- [ ] **Step 2: Install dependencies and confirm the typecheck baseline is clean**
+
+```bash
+cd "$WT" && pnpm install --frozen-lockfile 2>&1 | tail -3
+NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @breeze/api exec tsc --noEmit 2>&1 | tee "$LOGS/baseline-tsc.log" | tail -3
+```
+Expected: `tsc` exits 0 with no output. If it does not, stop — the baseline is broken upstream and must be reported, not fixed here.
+
+- [ ] **Step 3: Start the per-worktree stack and migrate it through the current checkout**
+
+```bash
+cd "$WT" && pnpm test-stack up 2>&1 | tee "$LOGS/baseline-stack-up.log" | tail -12
+pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts src/__tests__/integration/scripts-system-rls.integration.test.ts 2>&1 | tee "$LOGS/baseline-migrate.log" | tail -8
+```
+Expected: `[test-stack] project=breeze-test-fix-rmm-qa-220-script-children-rls`, a JSON block with `pgPort`/`redisPort`, `WT/.env.test` written; the integration run prints `[integration global-setup] Running migrations (once per run)...` then `Database ready for testing`, and `scripts-system-rls` passes (3 tests). The DB is now migrated exactly to the checkout (no new migration yet).
+
+- [ ] **Step 4: Record the pre-fix catalog proof (the QA query from `docs/qa/evidence/2026-08-23-core-tenant-isolation.md:31-35`)**
+
+```bash
+PG="$(grep '^# compose project:' "$WT/.env.test" | awk '{print $4}')-postgres"
+docker exec -i "$PG" psql -U breeze_test -d breeze_test -At <<'SQL' | tee "$LOGS/baseline-catalog-prefix.log"
+SELECT json_agg(row_to_json(t)) FROM (
+  SELECT c.relname AS table_name, c.relrowsecurity AS rls_enabled, c.relforcerowsecurity AS force_rls,
+         has_table_privilege('breeze_app', c.oid, 'SELECT') AS app_select,
+         has_table_privilege('breeze_app', c.oid, 'INSERT') AS app_insert,
+         has_table_privilege('breeze_app', c.oid, 'UPDATE') AS app_update,
+         has_table_privilege('breeze_app', c.oid, 'DELETE') AS app_delete
+  FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public' AND c.relname IN ('script_to_tags','script_versions') ORDER BY 1) t;
+SQL
+docker exec -i "$PG" psql -U breeze_test -d breeze_test -At -c "SELECT max(filename) FROM breeze_migrations" | tee "$LOGS/baseline-ledger-max.log"
+```
+Expected: both rows `rls_enabled=false, force_rls=false, app_*=true` (the exact RMM-QA-220 proof, F3); ledger max `2026-09-29-detach-ticket-runs-on-device-org-move.sql`.
+
+- [ ] **Step 5: Confirm the current rls-coverage contract is green on this DB (so every later RED is attributable to this branch)**
+
+```bash
+cat > "$LOGS/rls-coverage.env" <<'ENV'
+JWT_SECRET=ci-smoke-k7x9Qm4pR2vL8nW5jT3yF6hB0cA1dE4gI7
+APP_ENCRYPTION_KEY=ci-smoke-Xz9Lm3Kp7Wn2Qr5Tv8Yb0Hd4Fg6Jc1Ae3
+MFA_ENCRYPTION_KEY=ci-smoke-Nm4Rp8Ws2Kv6Tq0Yh3Bd7Fg1Jc5Le9Ax2
+NODE_ENV=test
+DB_CONTEXTLESS_WRITE_STRICT=true
+ENV
+cd "$WT" && set -a && . "$LOGS/rls-coverage.env" && set +a && pnpm --filter @breeze/api test:rls-coverage 2>&1 | tee "$LOGS/baseline-rls-coverage.log" | tail -6
+```
+Expected: all tests pass (the count is whatever main ships; record it). If anything fails here, stop and report — do not proceed on a red baseline.
+
+- [ ] **Step 6: Commit spec + plan**
+
+```bash
+cd "$WT" && git add docs/superpowers/specs/2026-09-01-rmm-qa-220-script-children-rls-design.md docs/superpowers/plans/2026-09-01-rmm-qa-220-script-children-rls.md
+git commit -m "docs(qa): RMM-QA-220 script children RLS design + plan
+
+Design (D1-D9) and executable plan for forced parent-join RLS on
+script_versions / script_to_tags, exhaustive RLS catalog classification,
+command-specific policy-shape checks and breeze_app forge proofs.
+
+Pre-fix baseline (per-worktree stack, ledger max
+2026-09-29-detach-ticket-runs-on-device-org-move.sql):
+script_to_tags  rls_enabled=false force_rls=false app_select/insert/update/delete=true
+script_versions rls_enabled=false force_rls=false app_select/insert/update/delete=true
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01E9p3mtFLSv8SFcZ9fcn8Vu"
+```
+
+---
+
+### Task 1: `rlsPolicyShape` — pure command-specific predicate matchers (RED → GREEN → mutation proofs)
+
+**Files:**
+- Create: `apps/api/src/db/rlsPolicyShape.ts`
+- Test: `apps/api/src/db/rlsPolicyShape.test.ts`
+
+**Interfaces:**
+- Produces (consumed by Tasks 3):
+  ```ts
+  export type Cmd = 'SELECT' | 'INSERT' | 'UPDATE' | 'DELETE';
+  export const RLS_CMDS: readonly Cmd[];
+  export type PredicateSlot = 'qual' | 'with_check';
+  export interface PolicyRow { policyname: string; cmd: string; permissive: string; qual: string | null; with_check: string | null }
+  export type ParentRule = { kind: 'any-of'; parents: readonly string[] } | { kind: 'all-of'; parents: readonly string[] };
+  export type PredicateMatcher = (pred: string | null, cmd: Cmd, slot: PredicateSlot) => boolean;
+  export function normalizePredicate(pred: string | null): string;
+  export function parentAliases(pred: string | null, parent: string): string[];
+  export function predicateCoversParent(pred: string | null, parent: string): boolean;
+  export function predicateCoversParents(pred: string | null, rule: ParentRule): boolean;
+  export function predicateCoversOrgAxis(pred: string | null, table: string, idKeyed: boolean): boolean;
+  export function coveredCommands(policies: readonly PolicyRow[], matches: PredicateMatcher): Set<Cmd>;
+  ```
+
+Why `src/db/` and not `src/__tests__/integration/`: the unit runner (`vitest.config.ts:15-16`) excludes `src/__tests__/integration/**` wholesale and the integration runner includes every `*.test.ts` there (F20). A pure function's unit test must live where the **Test API** job sees it.
+
+Postgres semantics encoded (verified against the local DB's deparsed `pg_policies` text, e.g. `ticket_form_org_links`: `(EXISTS ( SELECT 1 FROM ticket_forms tf WHERE ((tf.id = ticket_form_org_links.form_id) AND (... breeze_has_org_access(tf.org_id) ... breeze_has_partner_access(tf.partner_id)))))`):
+- SELECT/DELETE are governed by `qual` (USING); INSERT by `with_check`; UPDATE by BOTH.
+- A `FOR UPDATE` / `FOR ALL` policy that omits WITH CHECK reuses USING as its check (`with_check` is NULL in `pg_policies`); the matcher applies that fallback ONLY for those two policy kinds.
+- Deparsed text drops the `public.` prefix on helpers and can contain newlines → normalise whitespace first (F16).
+- Only PERMISSIVE policies count.
+
+- [ ] **Step 1: Write the failing unit test**
+
+Create `apps/api/src/db/rlsPolicyShape.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import {
+  coveredCommands,
+  normalizePredicate,
+  parentAliases,
+  predicateCoversOrgAxis,
+  predicateCoversParent,
+  predicateCoversParents,
+  type PolicyRow,
+} from './rlsPolicyShape';
+
+// Deparsed shapes copied from pg_policies on a migrated test DB (whitespace
+// exactly as Postgres emits it, including the leading "( SELECT").
+const SCRIPTS_JOIN_ORG =
+  '(EXISTS ( SELECT 1 FROM scripts s WHERE ((s.id = script_versions.script_id) AND breeze_has_org_access(s.org_id))))';
+const SCRIPTS_JOIN_PARTNER =
+  '(EXISTS ( SELECT 1 FROM scripts s WHERE ((s.id = script_versions.script_id) AND breeze_has_partner_access(s.partner_id))))';
+const BOTH_PARENTS =
+  '((EXISTS ( SELECT 1 FROM scripts s WHERE ((s.id = script_to_tags.script_id) AND (breeze_has_org_access(s.org_id) OR breeze_has_partner_access(s.partner_id))))) ' +
+  'AND (EXISTS ( SELECT 1 FROM script_tags t WHERE ((t.id = script_to_tags.tag_id) AND (breeze_has_org_access(t.org_id) OR breeze_has_partner_access(t.partner_id))))))';
+const SCRIPTS_ONLY_PLUS_TAG_JOIN_NO_HELPER =
+  '((EXISTS ( SELECT 1 FROM scripts s WHERE ((s.id = script_to_tags.script_id) AND breeze_has_org_access(s.org_id)))) ' +
+  'AND (EXISTS ( SELECT 1 FROM script_tags t WHERE (t.id = script_to_tags.tag_id))))';
+const HELPER_ON_OTHER_ALIAS =
+  '(EXISTS ( SELECT 1 FROM scripts s, organizations o WHERE ((s.id = script_versions.script_id) AND breeze_has_org_access(o.org_id))))';
+const HELPER_ON_CHILD_OWN_COLUMN =
+  '(EXISTS ( SELECT 1 FROM scripts s WHERE (s.id = script_versions.script_id)) AND breeze_has_org_access(org_id))';
+const UNALIASED_PARENT =
+  '(EXISTS ( SELECT 1 FROM scripts WHERE ((scripts.id = script_versions.script_id) AND breeze_has_org_access(scripts.org_id))))';
+const WITH_NEWLINES =
+  '(EXISTS ( SELECT 1\n   FROM scripts s\n  WHERE ((s.id = script_versions.script_id)\n    AND breeze_has_org_access(s.org_id))))';
+
+function policy(p: Partial<PolicyRow> & { cmd: string }): PolicyRow {
+  return { policyname: p.policyname ?? 'p', cmd: p.cmd, permissive: p.permissive ?? 'PERMISSIVE', qual: p.qual ?? null, with_check: p.with_check ?? null };
+}
+
+const scriptsRule = (pred: string | null) => predicateCoversParents(pred, { kind: 'any-of', parents: ['scripts'] });
+
+describe('rlsPolicyShape — parent aliases', () => {
+  it('finds the alias declared after FROM <parent>', () => {
+    expect(parentAliases(SCRIPTS_JOIN_ORG, 'scripts')).toEqual(['s']);
+  });
+  it('falls back to the bare parent name when FROM <parent> has no alias', () => {
+    expect(parentAliases(UNALIASED_PARENT, 'scripts')).toEqual(['scripts']);
+  });
+  it('does not treat FROM script_tags as FROM scripts (word boundary)', () => {
+    expect(parentAliases('(EXISTS ( SELECT 1 FROM script_tags t WHERE (t.id = x.tag_id)))', 'scripts')).toEqual([]);
+  });
+  it('normalises embedded newlines before matching', () => {
+    expect(normalizePredicate(WITH_NEWLINES)).not.toContain('\n');
+    expect(predicateCoversParent(WITH_NEWLINES, 'scripts')).toBe(true);
+  });
+});
+
+describe('rlsPolicyShape — predicateCoversParent(s)', () => {
+  it('accepts breeze_has_org_access on the parent alias', () => {
+    expect(predicateCoversParent(SCRIPTS_JOIN_ORG, 'scripts')).toBe(true);
+  });
+  it('accepts breeze_has_partner_access on the parent alias (dual-axis parents)', () => {
+    expect(predicateCoversParent(SCRIPTS_JOIN_PARTNER, 'scripts')).toBe(true);
+  });
+  it('rejects a helper applied to a non-parent alias even though FROM <parent> is present', () => {
+    expect(predicateCoversParent(HELPER_ON_OTHER_ALIAS, 'scripts')).toBe(false);
+  });
+  it("rejects a helper applied to the child's own column", () => {
+    expect(predicateCoversParent(HELPER_ON_CHILD_OWN_COLUMN, 'scripts')).toBe(false);
+  });
+  it('any-of: one covered parent suffices', () => {
+    expect(predicateCoversParents(SCRIPTS_JOIN_ORG, { kind: 'any-of', parents: ['scripts', 'script_tags'] })).toBe(true);
+  });
+  it('all-of: every listed parent must carry a helper on its alias', () => {
+    expect(predicateCoversParents(BOTH_PARENTS, { kind: 'all-of', parents: ['scripts', 'script_tags'] })).toBe(true);
+    expect(predicateCoversParents(SCRIPTS_ONLY_PLUS_TAG_JOIN_NO_HELPER, { kind: 'all-of', parents: ['scripts', 'script_tags'] })).toBe(false);
+  });
+  it('null / empty predicate never covers', () => {
+    expect(scriptsRule(null)).toBe(false);
+    expect(scriptsRule('')).toBe(false);
+  });
+});
+
+describe('rlsPolicyShape — predicateCoversOrgAxis', () => {
+  it('accepts breeze_has_org_access(org_id) and breeze_has_org_access(<table>.org_id)', () => {
+    expect(predicateCoversOrgAxis('breeze_has_org_access(org_id)', 'devices', false)).toBe(true);
+    expect(predicateCoversOrgAxis('breeze_has_org_access(devices.org_id)', 'devices', false)).toBe(true);
+  });
+  it('rejects a helper on another alias or another column', () => {
+    expect(predicateCoversOrgAxis('breeze_has_org_access(tf.org_id)', 'ticket_form_org_links', false)).toBe(false);
+    expect(predicateCoversOrgAxis('breeze_has_org_access(partner_id)', 'devices', false)).toBe(false);
+    expect(predicateCoversOrgAxis('breeze_has_partner_access(org_id)', 'devices', false)).toBe(false);
+  });
+  it('accepts breeze_has_org_access(id) only for id-keyed tables', () => {
+    expect(predicateCoversOrgAxis('breeze_has_org_access(id)', 'organizations', true)).toBe(true);
+    expect(predicateCoversOrgAxis('breeze_has_org_access(id)', 'devices', false)).toBe(false);
+    expect(predicateCoversOrgAxis('breeze_has_org_access(org_id)', 'organizations', true)).toBe(false);
+  });
+});
+
+describe('rlsPolicyShape — coveredCommands (command → slot)', () => {
+  it('SELECT and DELETE are covered from qual only', () => {
+    const covered = coveredCommands(
+      [policy({ cmd: 'SELECT', qual: SCRIPTS_JOIN_ORG }), policy({ cmd: 'DELETE', qual: SCRIPTS_JOIN_ORG })],
+      (pred) => scriptsRule(pred),
+    );
+    expect([...covered].sort()).toEqual(['DELETE', 'SELECT']);
+  });
+  it('a SELECT policy whose helper sits only in with_check does NOT cover SELECT (the QA-named blind spot)', () => {
+    const covered = coveredCommands([policy({ cmd: 'SELECT', qual: 'true', with_check: SCRIPTS_JOIN_ORG })], (pred) => scriptsRule(pred));
+    expect(covered.size).toBe(0);
+  });
+  it('INSERT is covered from with_check only', () => {
+    expect(coveredCommands([policy({ cmd: 'INSERT', with_check: SCRIPTS_JOIN_ORG })], (pred) => scriptsRule(pred)).has('INSERT')).toBe(true);
+    expect(coveredCommands([policy({ cmd: 'INSERT', qual: SCRIPTS_JOIN_ORG, with_check: 'true' })], (pred) => scriptsRule(pred)).has('INSERT')).toBe(false);
+  });
+  it('UPDATE needs BOTH qual and with_check', () => {
+    expect(coveredCommands([policy({ cmd: 'UPDATE', qual: SCRIPTS_JOIN_ORG, with_check: 'true' })], (pred) => scriptsRule(pred)).has('UPDATE')).toBe(false);
+    expect(coveredCommands([policy({ cmd: 'UPDATE', qual: 'true', with_check: SCRIPTS_JOIN_ORG })], (pred) => scriptsRule(pred)).has('UPDATE')).toBe(false);
+    expect(coveredCommands([policy({ cmd: 'UPDATE', qual: SCRIPTS_JOIN_ORG, with_check: SCRIPTS_JOIN_ORG })], (pred) => scriptsRule(pred)).has('UPDATE')).toBe(true);
+  });
+  it('UPDATE/ALL with a NULL with_check reuses qual as the check (Postgres default); INSERT-only policies do not', () => {
+    expect(coveredCommands([policy({ cmd: 'UPDATE', qual: SCRIPTS_JOIN_ORG, with_check: null })], (pred) => scriptsRule(pred)).has('UPDATE')).toBe(true);
+    const all = coveredCommands([policy({ cmd: 'ALL', qual: SCRIPTS_JOIN_ORG, with_check: null })], (pred) => scriptsRule(pred));
+    expect([...all].sort()).toEqual(['DELETE', 'INSERT', 'SELECT', 'UPDATE']);
+    expect(coveredCommands([policy({ cmd: 'INSERT', qual: SCRIPTS_JOIN_ORG, with_check: null })], (pred) => scriptsRule(pred)).has('INSERT')).toBe(false);
+  });
+  it('cmd=ALL with an explicit with_check expands to all four, checking the right slot for each', () => {
+    const covered = coveredCommands([policy({ cmd: 'ALL', qual: SCRIPTS_JOIN_ORG, with_check: 'true' })], (pred) => scriptsRule(pred));
+    expect([...covered].sort()).toEqual(['DELETE', 'SELECT']);
+  });
+  it('RESTRICTIVE policies never count', () => {
+    expect(coveredCommands([policy({ cmd: 'ALL', permissive: 'RESTRICTIVE', qual: SCRIPTS_JOIN_ORG, with_check: SCRIPTS_JOIN_ORG })], (pred) => scriptsRule(pred)).size).toBe(0);
+  });
+  it('the matcher receives cmd and slot so per-command overlays can differ (script_to_tags shape)', () => {
+    const seen: string[] = [];
+    coveredCommands(
+      [policy({ cmd: 'UPDATE', qual: SCRIPTS_JOIN_ORG, with_check: BOTH_PARENTS })],
+      (pred, cmd, slot) => { seen.push(`${cmd}:${slot}`); return true; },
+    );
+    expect(seen).toEqual(['UPDATE:qual', 'UPDATE:with_check']);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+```bash
+cd "$WT" && pnpm --filter @breeze/api exec vitest run src/db/rlsPolicyShape.test.ts 2>&1 | tee "$LOGS/task1-red.log" | tail -15
+```
+Expected: FAIL — `Failed to resolve import "./rlsPolicyShape"` (module does not exist). Keep the log.
+
+- [ ] **Step 3: Write the module**
+
+Create `apps/api/src/db/rlsPolicyShape.ts`:
+
+```ts
+/**
+ * Pure predicate-shape matchers for the RLS coverage contract
+ * (src/__tests__/integration/rls-coverage.integration.test.ts).
+ *
+ * Why this exists (RMM-QA-220): the contract used to accept a helper NAME
+ * appearing anywhere in `qual OR with_check` as coverage for every DML
+ * command. Postgres evaluates SELECT/DELETE against USING (`qual`), INSERT
+ * against WITH CHECK (`with_check`), and UPDATE against BOTH — so a helper in
+ * the wrong slot proves nothing for the command the policy governs. These
+ * matchers are command-specific and argument-specific.
+ *
+ * Lives under src/db/ rather than src/__tests__/integration/ on purpose: the
+ * unit runner (vitest.config.ts) excludes that directory wholesale and the
+ * integration runner includes every *.test.ts in it, so a pure function's
+ * unit test has to sit where the Test API job sees it and the real-DB setup
+ * does not.
+ *
+ * Input is the deparsed text of pg_policies.qual / with_check. Postgres drops
+ * the `public.` prefix on helper calls and may emit newlines, so callers get
+ * whitespace-normalised matching for free.
+ */
+export type Cmd = 'SELECT' | 'INSERT' | 'UPDATE' | 'DELETE';
+export const RLS_CMDS: readonly Cmd[] = ['SELECT', 'INSERT', 'UPDATE', 'DELETE'];
+export type PredicateSlot = 'qual' | 'with_check';
+
+export interface PolicyRow {
+  policyname: string;
+  /** 'SELECT' | 'INSERT' | 'UPDATE' | 'DELETE' | 'ALL' (pg_policies.cmd). */
+  cmd: string;
+  /** 'PERMISSIVE' | 'RESTRICTIVE' (pg_policies.permissive). */
+  permissive: string;
+  qual: string | null;
+  with_check: string | null;
+}
+
+export type ParentRule =
+  /** Default parent-FK rule: a covering helper on ANY one declared parent alias. */
+  | { kind: 'any-of'; parents: readonly string[] }
+  /** Overlay: a covering helper on EVERY listed parent alias (script_to_tags). */
+  | { kind: 'all-of'; parents: readonly string[] };
+
+export type PredicateMatcher = (pred: string | null, cmd: Cmd, slot: PredicateSlot) => boolean;
+
+// Tokens that can legally follow `FROM <parent>` and must not be mistaken
+// for an alias when the join is unaliased.
+const NOT_AN_ALIAS = new Set([
+  'where', 'join', 'on', 'left', 'right', 'inner', 'cross', 'full', 'natural',
+  'using', 'and', 'or', 'group', 'order', 'limit', 'union', 'except', 'intersect',
+]);
+
+export function normalizePredicate(pred: string | null): string {
+  return (pred ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Every alias under which `parent` is joined in `pred` via
+ * `FROM [public.]<parent> [AS] <alias>`; the bare parent name when the join
+ * is unaliased. `\b` after the parent name keeps `FROM scripts` from matching
+ * `FROM script_tags`.
+ */
+export function parentAliases(pred: string | null, parent: string): string[] {
+  const text = normalizePredicate(pred);
+  const re = new RegExp(
+    `\\bFROM\\s+(?:public\\.)?${escapeRegExp(parent)}\\b(?:\\s+(?:AS\\s+)?([A-Za-z_][A-Za-z0-9_]*))?`,
+    'gi',
+  );
+  const aliases: string[] = [];
+  for (const m of text.matchAll(re)) {
+    const candidate = m[1];
+    aliases.push(candidate && !NOT_AN_ALIAS.has(candidate.toLowerCase()) ? candidate : parent);
+  }
+  return aliases;
+}
+
+function helperOnAlias(text: string, alias: string): boolean {
+  const re = new RegExp(
+    `\\bbreeze_has_(?:org|partner)_access\\(\\s*${escapeRegExp(alias)}\\.(?:org_id|partner_id)\\s*\\)`,
+    'i',
+  );
+  return re.test(text);
+}
+
+/**
+ * True when `pred` joins `parent` and applies breeze_has_org_access(<alias>.org_id)
+ * or breeze_has_partner_access(<alias>.partner_id) to THAT alias. A helper on
+ * the child's own column or on a non-parent alias does not count.
+ */
+export function predicateCoversParent(pred: string | null, parent: string): boolean {
+  const text = normalizePredicate(pred);
+  if (text === '') return false;
+  return parentAliases(text, parent).some((alias) => helperOnAlias(text, alias));
+}
+
+export function predicateCoversParents(pred: string | null, rule: ParentRule): boolean {
+  if (rule.parents.length === 0) return false;
+  const covered = rule.parents.map((parent) => predicateCoversParent(pred, parent));
+  return rule.kind === 'all-of' ? covered.every(Boolean) : covered.some(Boolean);
+}
+
+/**
+ * Org-axis shape: breeze_has_org_access([<table>.]org_id) — or
+ * breeze_has_org_access([<table>.]id) when `idKeyed` (organizations). Any
+ * other alias or column is NOT this table's tenant expression.
+ */
+export function predicateCoversOrgAxis(pred: string | null, table: string, idKeyed: boolean): boolean {
+  const text = normalizePredicate(pred);
+  if (text === '') return false;
+  const column = idKeyed ? 'id' : 'org_id';
+  const re = new RegExp(
+    `\\bbreeze_has_org_access\\(\\s*(?:(?:public\\.)?${escapeRegExp(table)}\\.)?${column}\\s*\\)`,
+    'i',
+  );
+  return re.test(text);
+}
+
+/**
+ * Commands covered by `policies` under `matches`:
+ *   SELECT / DELETE ← qual; INSERT ← with_check; UPDATE ← qual AND with_check.
+ * cmd='ALL' expands to all four. Only PERMISSIVE rows count. A FOR UPDATE or
+ * FOR ALL policy that omitted WITH CHECK reuses USING as its check (Postgres
+ * semantics; pg_policies then reports with_check = NULL) — a FOR INSERT policy
+ * never gets that fallback, because Postgres requires WITH CHECK for it.
+ */
+export function coveredCommands(policies: readonly PolicyRow[], matches: PredicateMatcher): Set<Cmd> {
+  const covered = new Set<Cmd>();
+  for (const p of policies) {
+    if (p.permissive !== 'PERMISSIVE') continue;
+    const cmds: Cmd[] = p.cmd === 'ALL' ? [...RLS_CMDS] : RLS_CMDS.includes(p.cmd as Cmd) ? [p.cmd as Cmd] : [];
+    const reusesQualAsCheck = p.cmd === 'ALL' || p.cmd === 'UPDATE';
+    const check = p.with_check ?? (reusesQualAsCheck ? p.qual : null);
+    for (const cmd of cmds) {
+      let ok: boolean;
+      if (cmd === 'SELECT' || cmd === 'DELETE') ok = matches(p.qual, cmd, 'qual');
+      else if (cmd === 'INSERT') ok = matches(check, cmd, 'with_check');
+      else ok = matches(p.qual, cmd, 'qual') && matches(check, cmd, 'with_check');
+      if (ok) covered.add(cmd);
+    }
+  }
+  return covered;
+}
+```
+
+- [ ] **Step 4: Run the unit test to verify it passes; typecheck**
+
+```bash
+cd "$WT" && pnpm --filter @breeze/api exec vitest run src/db/rlsPolicyShape.test.ts 2>&1 | tee "$LOGS/task1-green.log" | tail -8
+NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @breeze/api exec tsc --noEmit 2>&1 | tail -3
+```
+Expected: all tests in the file pass (22); `tsc` clean.
+
+- [ ] **Step 5: Mutation proofs — each mutation must turn at least one fixture red; revert after each**
+
+Run each mutation with `pnpm --filter @breeze/api exec vitest run src/db/rlsPolicyShape.test.ts 2>&1 | tee "$LOGS/task1-mut-<letter>.log" | grep -E '✓|✗|×|FAIL|Tests'` and note the failing test name, then restore the file (`git checkout -- apps/api/src/db/rlsPolicyShape.ts` is NOT available yet since the file is untracked — instead reverse the edit by hand or keep a copy: `cp apps/api/src/db/rlsPolicyShape.ts "$LOGS/rlsPolicyShape.ts.good"` before mutating, `cp` back after).
+
+  - **Mutation A (whitespace):** in `normalizePredicate` return `(pred ?? '').trim()` (drop the `replace`). Expected red: `normalises embedded newlines before matching`.
+  - **Mutation B (INSERT slot):** in `coveredCommands` change the INSERT branch to `ok = matches(p.qual, cmd, 'qual')`. Expected red: `INSERT is covered from with_check only` (and the `cmd=ALL … expands` fixture).
+  - **Mutation C (all-of → any-of):** in `predicateCoversParents` return `covered.some(Boolean)` unconditionally. Expected red: `all-of: every listed parent must carry a helper on its alias`.
+  - **Mutation D (UPDATE pairing):** in `coveredCommands` change the UPDATE branch to `ok = matches(p.qual, cmd, 'qual')`. Expected red: `UPDATE needs BOTH qual and with_check`.
+  - **Mutation E (alias binding):** in `helperOnAlias` replace `${escapeRegExp(alias)}\\.` with `[A-Za-z_][A-Za-z0-9_]*\\.`. Expected red: `rejects a helper applied to a non-parent alias …`.
+
+After the last revert, re-run: all 22 pass (`tee "$LOGS/task1-green-after-mutations.log"`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd "$WT" && git add apps/api/src/db/rlsPolicyShape.ts apps/api/src/db/rlsPolicyShape.test.ts
+git commit -m "test(rls): command-specific policy-shape matchers for the RLS coverage contract
+
+Pure module (src/db/rlsPolicyShape.ts) + unit fixtures. SELECT/DELETE are
+read from qual, INSERT from with_check, UPDATE from both; helpers must be
+applied to the declared parent alias (any-of / all-of) or to the table's
+own org_id / id. Deparsed newlines are normalised; RESTRICTIVE rows ignored;
+FOR UPDATE / FOR ALL without WITH CHECK reuses USING (Postgres default).
+
+RED (module absent): <paste the 'Failed to resolve import' line from task1-red.log>
+GREEN: 22 passed.
+Mutation controls (each observed red, then reverted):
+  A drop whitespace normalisation -> 'normalises embedded newlines' failed
+  B INSERT read from qual          -> 'INSERT is covered from with_check only' failed
+  C all-of behaves as any-of       -> 'all-of: every listed parent...' failed
+  D UPDATE reads qual only         -> 'UPDATE needs BOTH qual and with_check' failed
+  E helper on any alias accepted   -> 'rejects a helper applied to a non-parent alias' failed
+
+Refs RMM-QA-220.
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01E9p3mtFLSv8SFcZ9fcn8Vu"
+```
+(Replace the `<paste …>` instruction with the actual line from `$LOGS/task1-red.log` before committing.)
+
+---
+
+### Task 2: Exhaustive classification test (D5) and catalog registration (D4) — RED, then partial GREEN with the migration RED retained
+
+**Files:**
+- Modify: `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts` — imports (`:1-15`), `PARENT_FK_JOIN_POLICY_TABLES` (`:584-647`), new constants after `USER_ID_SCOPED_TABLES` (`:649-728`, before `const REQUIRED_CMDS` at `:729`), new test after the force test (`:893-948`).
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `PLATFORM_INFRASTRUCTURE_TABLES: ReadonlySet<string>`, `UNREVIEWED_RLS_CLASSIFICATION_DEBT: ReadonlyMap<string, string>`, and the two `PARENT_FK_JOIN_POLICY_TABLES` entries Tasks 3–5 rely on.
+
+- [ ] **Step 1: Add the D5 test with EMPTY buckets (RED first) — do NOT add the D4 entries yet**
+
+Insert after `const USER_ID_SCOPED_TABLES … ]);` (before `const REQUIRED_CMDS = …`):
+
+```ts
+// Platform bookkeeping tables that hold no tenant data and are not a tenancy
+// shape. Exactly one entry today. Adding here requires the same justification
+// as INTENTIONAL_UNSCOPED (a plan-doc entry per CLAUDE.md "Intentionally
+// system-scoped").
+const PLATFORM_INFRASTRUCTURE_TABLES: ReadonlySet<string> = new Set<string>([
+  // populated in Step 3 from the RED output
+]);
+
+// Tables that carry NEITHER row-level security NOR a tenancy classification
+// and were NOT reviewed by RMM-QA-220. Inclusion is a TRACKING FACT, not a
+// security review, and not a blessing: each name is a candidate finding
+// handed to QA. The bucket is shrink-only — an entry may leave ONLY by moving
+// the table into a real bucket (a shape allowlist, INTENTIONAL_UNSCOPED with
+// a plan-doc entry, or PLATFORM_INFRASTRUCTURE_TABLES). A stale name (table
+// dropped) fails the test so the list cannot rot.
+const UNREVIEWED_RLS_CLASSIFICATION_DEBT: ReadonlyMap<string, string> = new Map<string, string>([
+  // populated in Step 3 from the RED output
+]);
+```
+
+Insert after the force test's closing `});` (the test titled `every tenant-scoped public table has FORCE ROW LEVEL SECURITY enabled`, before `it('deployment_invites has a database invariant …`):
+
+```ts
+  // RMM-QA-220: every assertion above enumerates ONE shape at a time, so a
+  // tenant child that is in no allowlist and has no org_id column (the exact
+  // way script_versions / script_to_tags shipped) is invisible to all of them.
+  // This test enumerates every public base table and demands a classification.
+  it('every public base table is classified by exactly one tenancy bucket', async () => {
+    // relkind 'r' (ordinary) + 'p' (partitioned parent, e.g. metric_rollups);
+    // NOT relispartition — metric_rollups partitions are created at runtime
+    // by breeze_ensure_metric_rollup_partition and would make this
+    // non-deterministic. The partitioned parent is classified once.
+    const rows = (await db.execute(sql`
+      SELECT
+        c.relname AS table_name,
+        EXISTS (
+          SELECT 1 FROM information_schema.columns col
+          WHERE col.table_schema = n.nspname AND col.table_name = c.relname AND col.column_name = 'org_id'
+        ) AS has_org_id
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public'
+        AND c.relkind IN ('r', 'p')
+        AND NOT c.relispartition
+      ORDER BY c.relname;
+    `)) as unknown as Array<{ table_name: string; has_org_id: boolean }>;
+
+    const existing = new Map(rows.map((r) => [r.table_name, r.has_org_id]));
+    const shapeLists: ReadonlyArray<{ has(name: string): boolean }> = [
+      ORG_ID_KEYED_TENANT_TABLES,
+      PARTNER_TENANT_TABLES,
+      DUAL_AXIS_TENANT_TABLES,
+      DEVICE_ID_JOIN_POLICY_TABLES,
+      PARENT_FK_JOIN_POLICY_TABLES,
+      USER_ID_SCOPED_TABLES,
+      INTENTIONAL_UNSCOPED,
+      EXEMPT_TABLES,
+    ];
+    const classifiedByShape = (name: string): boolean =>
+      (existing.get(name) ?? false) || shapeLists.some((list) => list.has(name));
+
+    const unclassified = rows
+      .map((r) => r.table_name)
+      .filter((name) => !classifiedByShape(name))
+      .filter((name) => !PLATFORM_INFRASTRUCTURE_TABLES.has(name))
+      .filter((name) => !UNREVIEWED_RLS_CLASSIFICATION_DEBT.has(name));
+
+    const bucketNames = [...PLATFORM_INFRASTRUCTURE_TABLES, ...UNREVIEWED_RLS_CLASSIFICATION_DEBT.keys()];
+    // Shrink-only ratchet: a name that no longer exists must be removed.
+    const stale = bucketNames.filter((name) => !existing.has(name));
+    // Buckets 3 and 4 are disjoint from every shape list and from each other.
+    const overlapping = [
+      ...bucketNames.filter((name) => existing.has(name) && classifiedByShape(name)),
+      ...[...PLATFORM_INFRASTRUCTURE_TABLES].filter((name) => UNREVIEWED_RLS_CLASSIFICATION_DEBT.has(name)),
+    ];
+
+    expect(
+      { unclassified, stale, overlapping },
+      `Every public base table must be classified. Unclassified tables have neither an org_id column nor an ` +
+        `entry in any shape allowlist (ORG_ID_KEYED / PARTNER / DUAL_AXIS / DEVICE_ID_JOIN / PARENT_FK_JOIN / ` +
+        `USER_ID_SCOPED), INTENTIONAL_UNSCOPED, EXEMPT_TABLES, PLATFORM_INFRASTRUCTURE_TABLES or the shrink-only ` +
+        `UNREVIEWED_RLS_CLASSIFICATION_DEBT bucket. Pick a shape (CLAUDE.md "Six tenancy shapes"), add policies in a ` +
+        `migration, and register the table. 'stale' names no longer exist and must be removed; 'overlapping' names ` +
+        `are in a debt/infrastructure bucket AND a real bucket — remove them from the debt bucket.\n` +
+        JSON.stringify({ unclassified, stale, overlapping }, null, 2)
+    ).toEqual({ unclassified: [], stale: [], overlapping: [] });
+  });
+```
+
+- [ ] **Step 2: Run the new test alone — RED with the unclassified list**
+
+```bash
+cd "$WT" && set -a && . "$LOGS/rls-coverage.env" && set +a && pnpm --filter @breeze/api test:rls-coverage -- -t 'every public base table is classified' 2>&1 | tee "$LOGS/task2-red-d5.log" | tail -40
+```
+Expected: FAIL. `unclassified` is expected to be exactly (F18, 2026-09-20 DB — the fresh-stack output is authoritative and may add post-09-20 tables):
+`agent_versions, breeze_migrations, cis_check_catalog, device_software, mobile_sessions, patches, permissions, plugin_catalog, script_templates, script_to_tags, script_versions, software_compliance_status`. `stale` and `overlapping` are `[]`. If the list differs, the DB is the truth: every extra name goes into the debt bucket in Step 3 with a one-line description derived from its columns (`docker exec -i "$PG" psql -U breeze_test -d breeze_test -At -c "\d <table>"`).
+
+- [ ] **Step 3: Populate the buckets from the RED output and add the D4 catalog entries**
+
+Replace the two empty constants:
+
+```ts
+const PLATFORM_INFRASTRUCTURE_TABLES: ReadonlySet<string> = new Set<string>([
+  'breeze_migrations', // autoMigrate's applied-migration ledger (filename + checksum). No tenant data. See apps/api/src/db/autoMigrate.ts MIGRATION_TABLE.
+]);
+
+const UNREVIEWED_RLS_CLASSIFICATION_DEBT: ReadonlyMap<string, string> = new Map<string, string>([
+  // Surfaced by RMM-QA-220's exhaustive classification (2026-09). Candidate
+  // findings handed to QA — NOT reviewed, NOT blessed. Descriptions are the
+  // column facts that a reviewer needs, nothing more.
+  ['device_software', 'device_id-keyed inventory rows, no RLS; candidate shape 5 (device-join) or denormalised org_id.'],
+  ['mobile_sessions', 'user_id / refresh-token session rows, no RLS; candidate shape 6 (breeze_current_user_id).'],
+  ['software_compliance_status', 'device_id + policy_id rows, no RLS; candidate shape 5 (device-join).'],
+  ['agent_versions', 'Global agent release reference data, no RLS; candidate INTENTIONAL_UNSCOPED after review.'],
+  ['cis_check_catalog', 'Global CIS benchmark check catalog, no RLS; candidate INTENTIONAL_UNSCOPED after review.'],
+  ['patches', 'Global patch reference data, no RLS; candidate INTENTIONAL_UNSCOPED after review.'],
+  ['permissions', 'Global permission catalog, no RLS; candidate INTENTIONAL_UNSCOPED after review.'],
+  ['plugin_catalog', 'Global plugin catalog, no RLS; candidate INTENTIONAL_UNSCOPED after review.'],
+  ['script_templates', 'Global script template library, no RLS; candidate INTENTIONAL_UNSCOPED after review.'],
+]);
+```
+(Append any extra fresh-DB names the RED run reported, each with a column-derived description. Do NOT add `script_versions` / `script_to_tags` here — they are classified by the D4 entries below.)
+
+Add to `PARENT_FK_JOIN_POLICY_TABLES` immediately after the `['ticket_form_org_links', ['ticket_forms']],` entry (still inside the `new Map([...])`):
+
+```ts
+  // RMM-QA-220: script_versions (script content history) and script_to_tags
+  // (script↔tag join) shipped in the baseline with NO rls and reach their
+  // tenant only through scripts (dual-axis, nullable org_id, is_system) and
+  // script_tags (dual-axis). See 2026-09-30-100000-script-children-rls.sql.
+  // script_to_tags additionally carries a per-command both-parents overlay
+  // (PARENT_FK_REQUIRED_PARENTS_PER_COMMAND below).
+  ['script_versions', ['scripts']],
+  ['script_to_tags', ['scripts', 'script_tags']],
+```
+
+- [ ] **Step 4: Run the whole rls-coverage file — D5 GREEN, force test + parent-FK test RED naming the two tables (this is the retained RED for the migration)**
+
+```bash
+cd "$WT" && set -a && . "$LOGS/rls-coverage.env" && set +a && pnpm --filter @breeze/api test:rls-coverage 2>&1 | tee "$LOGS/task2-red-d4.log" | grep -E '✓|✗|×|FAIL|script_versions|script_to_tags|force_rls|rls_on|missing_cmds|Tests ' | head -60
+```
+Expected: `every public base table is classified …` PASSES; `every tenant-scoped public table has FORCE ROW LEVEL SECURITY enabled` FAILS listing `script_to_tags` and `script_versions`; `every parent-FK join-policy table has RLS on …` FAILS with `{"table":"script_versions","rls_on":false,"missing_cmds":["SELECT","INSERT","UPDATE","DELETE"]}` and the same for `script_to_tags`; every other test passes. Copy the two offender JSON blocks verbatim into `$LOGS/task2-red-d4-offenders.txt`.
+
+- [ ] **Step 5: Mutation controls for the D5 ratchet (each red, then reverted)**
+
+  - **Mutation A (stale entry):** add `['no_such_table_rmm_qa_220', 'mutation']` to `UNREVIEWED_RLS_CLASSIFICATION_DEBT`; run `-t 'every public base table is classified'` → expected FAIL with `stale: ["no_such_table_rmm_qa_220"]`. Revert.
+  - **Mutation B (overlap):** add `'scripts'` to `PLATFORM_INFRASTRUCTURE_TABLES`; run → expected FAIL with `overlapping: ["scripts"]`. Revert.
+  - **Mutation C (missing classification):** remove the `'breeze_migrations'` entry; run → expected FAIL with `unclassified: ["breeze_migrations"]`. Revert.
+  Log each to `$LOGS/task2-mut-<letter>.log`; re-run the single test after the final revert → PASS.
+
+- [ ] **Step 6: Typecheck and commit (tests intentionally red on this commit)**
+
+```bash
+cd "$WT" && NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @breeze/api exec tsc --noEmit 2>&1 | tail -3
+git add apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+git commit -m "test(rls): exhaustive public-table classification + register script children (RED)
+
+D5: every public base table (relkind r/p, not relispartition) must be
+classified by a shape allowlist, an org_id column, INTENTIONAL_UNSCOPED,
+EXEMPT_TABLES, PLATFORM_INFRASTRUCTURE_TABLES (breeze_migrations) or the
+shrink-only UNREVIEWED_RLS_CLASSIFICATION_DEBT bucket (stale/overlap fail).
+D4: script_versions -> scripts and script_to_tags -> scripts, script_tags
+registered in PARENT_FK_JOIN_POLICY_TABLES.
+
+RED (D5 with empty buckets, fresh per-worktree DB):
+unclassified = <paste the array from task2-red-d5.log>
+Debt bucket populated from that output and nothing else; the 9 non-script
+names are candidate findings for QA, not reviewed.
+
+RED retained for the migration (this commit is intentionally red in CI):
+<paste the two offender JSON objects from task2-red-d4-offenders.txt>
+force test: script_to_tags, script_versions missing FORCE ROW LEVEL SECURITY.
+
+Mutation controls (each observed red, then reverted):
+  A stale debt entry      -> stale: [no_such_table_rmm_qa_220]
+  B bucket overlap        -> overlapping: [scripts]
+  C drop breeze_migrations-> unclassified: [breeze_migrations]
+
+Refs RMM-QA-220.
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01E9p3mtFLSv8SFcZ9fcn8Vu"
+```
+
+---
+
+### Task 3: Command-specific shape tests D6a (parent-FK, both-parents overlay) and D6b (org-axis)
+
+**Files:**
+- Modify: `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts` — imports; new constant + helpers after `UNREVIEWED_RLS_CLASSIFICATION_DEBT`; D6b test after the org-axis test (`every org-tenant public table has RLS on …`); D6a test after the parent-FK test (`every parent-FK join-policy table has RLS on …`).
+
+**Interfaces:**
+- Consumes (Task 1): `coveredCommands`, `predicateCoversOrgAxis`, `predicateCoversParents`, `Cmd`, `ParentRule`, `PolicyRow`, `PredicateSlot` from `../../db/rlsPolicyShape`.
+- Produces: `PARENT_FK_REQUIRED_PARENTS_PER_COMMAND`, `loadPublicPolicies()`, `loadRlsState()`.
+
+Open decision 3 is resolved all-at-once (D6): the run in Step 3 IS the fresh-DB simulation (F16/F17). If it reds any table other than the two new entries, STOP and triage per D6: fix the policy in a migration if it is genuinely wrong, or add the table to a new `RLS_SHAPE_TRIAGE: ReadonlyMap<string, string>` (name → owning migration + reason) that the test skips — and never loosen the matcher.
+
+- [ ] **Step 1: Add the import, the overlay map and the two loaders**
+
+Add to the imports at the top of the file:
+
+```ts
+import {
+  coveredCommands,
+  predicateCoversOrgAxis,
+  predicateCoversParents,
+  type Cmd,
+  type ParentRule,
+  type PolicyRow,
+  type PredicateSlot,
+} from '../../db/rlsPolicyShape';
+```
+
+Add after `UNREVIEWED_RLS_CLASSIFICATION_DEBT` (before `const REQUIRED_CMDS`):
+
+```ts
+// Per-command parent requirements that are STRICTER than PARENT_FK_JOIN_
+// POLICY_TABLES' default "helper on any one declared parent alias". Keyed by
+// table, then command, then predicate slot. A slot that is absent falls back
+// to the default any-of rule over the table's declared parents.
+//
+// script_to_tags (RMM-QA-220, advisor quorum §9 point 6): a link is readable
+// only when BOTH the script and the tag are visible, insertable only when the
+// script is writable AND the tag is visible, re-pointable (UPDATE WITH CHECK)
+// under the same both-parent rule, but unlinkable (UPDATE USING / DELETE) on
+// script write authority alone — tag visibility must not confer unlink rights
+// on another org's script.
+type PerCommandParentRules = Readonly<Partial<Record<Cmd, Readonly<Partial<Record<PredicateSlot, ParentRule>>>>>>;
+// Explicit type arguments on `new Map` keep the 'all-of' / 'any-of' string
+// literals narrow inside the nested object literals (otherwise TS widens them
+// to `string` and the assignment to ParentRule fails).
+const PARENT_FK_REQUIRED_PARENTS_PER_COMMAND: ReadonlyMap<string, PerCommandParentRules> = new Map<string, PerCommandParentRules>([
+  [
+    'script_to_tags',
+    {
+      SELECT: { qual: { kind: 'all-of', parents: ['scripts', 'script_tags'] } },
+      INSERT: { with_check: { kind: 'all-of', parents: ['scripts', 'script_tags'] } },
+      UPDATE: {
+        qual: { kind: 'any-of', parents: ['scripts'] },
+        with_check: { kind: 'all-of', parents: ['scripts', 'script_tags'] },
+      },
+      DELETE: { qual: { kind: 'any-of', parents: ['scripts'] } },
+    },
+  ],
+]);
+
+async function loadPublicPolicies(): Promise<Map<string, PolicyRow[]>> {
+  const rows = (await db.execute(sql`
+    SELECT tablename, policyname, cmd, permissive, qual, with_check
+    FROM pg_policies
+    WHERE schemaname = 'public'
+    ORDER BY tablename, policyname;
+  `)) as unknown as Array<PolicyRow & { tablename: string }>;
+  const byTable = new Map<string, PolicyRow[]>();
+  for (const r of rows) {
+    const list = byTable.get(r.tablename) ?? [];
+    list.push({ policyname: r.policyname, cmd: r.cmd, permissive: r.permissive, qual: r.qual, with_check: r.with_check });
+    byTable.set(r.tablename, list);
+  }
+  return byTable;
+}
+
+/** relname -> relrowsecurity for every public base table (r/p). Absent name = table missing. */
+async function loadRlsState(): Promise<Map<string, boolean>> {
+  const rows = (await db.execute(sql`
+    SELECT c.relname AS table_name, c.relrowsecurity AS rls_on
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public' AND c.relkind IN ('r', 'p');
+  `)) as unknown as Array<{ table_name: string; rls_on: boolean }>;
+  return new Map(rows.map((r) => [r.table_name, r.rls_on]));
+}
+```
+
+- [ ] **Step 2: Add D6a after the existing parent-FK test and D6b after the existing org-axis test**
+
+D6a — insert immediately after the closing `});` of `it('every parent-FK join-policy table has RLS on and all four DML commands covered by a parent-join org-access policy', …)`:
+
+```ts
+  // RMM-QA-220 (D6a): command-specific version of the assertion above. The
+  // legacy check accepts a helper NAME anywhere in qual OR with_check plus
+  // `LIKE '%FROM parent%'`; this one requires, per command, the helper on the
+  // declared parent's alias in the slot Postgres actually evaluates
+  // (SELECT/DELETE: USING; INSERT: WITH CHECK; UPDATE: both). Either
+  // breeze_has_org_access(<alias>.org_id) or breeze_has_partner_access(
+  // <alias>.partner_id) counts, so dual-axis parents fit. Tables in
+  // PARENT_FK_REQUIRED_PARENTS_PER_COMMAND must satisfy their overlay.
+  it('every parent-FK join-policy table has command-specific USING/WITH CHECK coverage on the declared parent alias', async () => {
+    const policiesByTable = await loadPublicPolicies();
+    const rlsState = await loadRlsState();
+    const offenders: Array<{ table: string; rls_on: boolean; missing_cmds: string[] }> = [];
+
+    for (const [table, parents] of PARENT_FK_JOIN_POLICY_TABLES) {
+      const overlay = PARENT_FK_REQUIRED_PARENTS_PER_COMMAND.get(table);
+      const covered = coveredCommands(policiesByTable.get(table) ?? [], (pred, cmd, slot) => {
+        const rule: ParentRule = overlay?.[cmd]?.[slot] ?? { kind: 'any-of', parents };
+        return predicateCoversParents(pred, rule);
+      });
+      const missing = REQUIRED_CMDS.filter((cmd) => !covered.has(cmd));
+      const rlsOn = rlsState.get(table) ?? false;
+      if (!rlsOn || missing.length > 0) offenders.push({ table, rls_on: rlsOn, missing_cmds: missing });
+    }
+
+    expect(
+      offenders,
+      `Parent-FK join-policy tables whose policies do not guard each command in the slot Postgres evaluates:\n` +
+        `${JSON.stringify(offenders, null, 2)}\n\n` +
+        `Fix: SELECT/DELETE need the parent-alias helper in USING, INSERT in WITH CHECK, UPDATE in BOTH. ` +
+        `Tables listed in PARENT_FK_REQUIRED_PARENTS_PER_COMMAND must satisfy every parent in their all-of rules. ` +
+        `Shape reference: 2026-05-30-fk-child-tables-rls.sql; matcher: src/db/rlsPolicyShape.ts.`
+    ).toEqual([]);
+  });
+```
+
+D6b — insert immediately after the closing `});` of `it('every org-tenant public table has RLS on and all four DML commands covered by breeze_has_org_access', …)`:
+
+```ts
+  // RMM-QA-220 (D6b): command-specific version of the org-axis assertion
+  // above, over the SAME table set (org_id tables minus
+  // ORG_AXIS_POLICY_EXCLUDED_TABLES, plus ORG_ID_KEYED_TENANT_TABLES, minus
+  // EXEMPT_TABLES via offendersFrom's filter). Requires
+  // breeze_has_org_access([<table>.]org_id) — or ([<table>.]id) for id-keyed
+  // tables — in USING for SELECT/DELETE, WITH CHECK for INSERT, both for UPDATE.
+  it('every org-tenant public table has command-specific USING/WITH CHECK coverage by breeze_has_org_access on its own org_id', async () => {
+    const idKeyedList = Array.from(ORG_ID_KEYED_TENANT_TABLES);
+    const rows = (await db.execute(sql`
+      WITH org_id_tables AS (
+        SELECT DISTINCT c.relname, c.relrowsecurity, false AS id_keyed
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        JOIN information_schema.columns col
+          ON col.table_schema = n.nspname AND col.table_name = c.relname
+        WHERE n.nspname = 'public'
+          AND c.relkind = 'r'
+          AND col.column_name = 'org_id'
+          AND c.relname <> ALL(${sql.raw(
+            `ARRAY[${Array.from(ORG_AXIS_POLICY_EXCLUDED_TABLES).map((t) => `'${t}'`).join(',')}]::text[]`,
+          )})
+      ),
+      id_keyed_tables AS (
+        SELECT c.relname, c.relrowsecurity, true AS id_keyed
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relkind = 'r'
+          AND c.relname = ANY(${sql.raw(
+            `ARRAY[${idKeyedList.map((t) => `'${t}'`).join(',')}]::text[]`,
+          )})
+      )
+      SELECT relname AS table_name, relrowsecurity AS rls_on, id_keyed FROM org_id_tables
+      UNION ALL
+      SELECT relname AS table_name, relrowsecurity AS rls_on, id_keyed FROM id_keyed_tables
+      ORDER BY 1;
+    `)) as unknown as Array<{ table_name: string; rls_on: boolean; id_keyed: boolean }>;
+
+    const policiesByTable = await loadPublicPolicies();
+    const tableRows: TableRow[] = rows.map((r) => {
+      const covered = coveredCommands(policiesByTable.get(r.table_name) ?? [], (pred) =>
+        predicateCoversOrgAxis(pred, r.table_name, r.id_keyed),
+      );
+      return { table_name: r.table_name, rls_on: r.rls_on, covered_cmds: [...covered] };
+    });
+    const offenders = offendersFrom(tableRows);
+
+    expect(
+      offenders,
+      `Org-tenant tables whose policies do not call breeze_has_org_access on the table's own org_id (or id) in the ` +
+        `slot Postgres evaluates for each command:\n${JSON.stringify(offenders, null, 2)}\n\n` +
+        `Fix: USING for SELECT/DELETE, WITH CHECK for INSERT, both for UPDATE; the argument must be this table's ` +
+        `org_id (id for ORG_ID_KEYED_TENANT_TABLES). A table whose tenancy axis is NOT its org_id column belongs in ` +
+        `ORG_AXIS_POLICY_EXCLUDED_TABLES with a comment (see ticket_form_org_links). Matcher: src/db/rlsPolicyShape.ts.`
+    ).toEqual([]);
+  });
+```
+
+- [ ] **Step 3: Run the file — D6a red ONLY for the two new entries, D6b green (fresh-DB simulation of F16/F17)**
+
+```bash
+cd "$WT" && NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @breeze/api exec tsc --noEmit 2>&1 | tail -3
+set -a && . "$LOGS/rls-coverage.env" && set +a && pnpm --filter @breeze/api test:rls-coverage 2>&1 | tee "$LOGS/task3-red-d6.log" | grep -E '✓|✗|×|FAIL|"table"|missing_cmds|Tests ' | head -80
+```
+Expected: `… command-specific USING/WITH CHECK coverage on the declared parent alias` FAILS with exactly two offenders (`script_versions` and `script_to_tags`, `rls_on:false`, all four commands missing) — the 30 pre-existing entries pass (F16); `… coverage by breeze_has_org_access on its own org_id` PASSES (F17; verified on the 2026-09-20 DB that the only table where a strict own-column rule differs from the alias-agnostic one is `ticket_form_org_links`, which is already in `ORG_AXIS_POLICY_EXCLUDED_TABLES`). The Task 2 reds persist. Any other D6a/D6b offender → stop and triage (see the note above this task); record the triage in the commit message.
+
+- [ ] **Step 4: Commit (still red for the two script children, by design)**
+
+```bash
+cd "$WT" && git add apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+git commit -m "test(rls): command-specific USING/WITH CHECK shape checks for parent-FK and org-axis tables
+
+D6a: every PARENT_FK_JOIN_POLICY_TABLES entry must carry the helper on the
+declared parent's alias in the slot Postgres evaluates per command; the
+new PARENT_FK_REQUIRED_PARENTS_PER_COMMAND overlay requires BOTH parents
+for script_to_tags SELECT / INSERT / UPDATE-check and scripts alone for
+UPDATE-using / DELETE. D6b: same per-command rule for org-axis tables with
+breeze_has_org_access on the table's own org_id (id when id-keyed).
+Closes the helper-name-anywhere blind spot the QA probe pins.
+
+Fresh per-worktree DB run (open decision 3 -> all tables at once):
+D6a offenders = <paste the two-object JSON from task3-red-d6.log>
+  (30/30 pre-existing parent-FK entries pass)
+D6b offenders = []  (0 asserted org-axis offenders)
+Discriminating proofs for the matcher: src/db/rlsPolicyShape.test.ts
+(mutations A-E in the previous commit).
+
+Refs RMM-QA-220.
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01E9p3mtFLSv8SFcZ9fcn8Vu"
+```
+
+---
+
+### Task 4: Behavioural forge suite as `breeze_app` (D7) — committed RED
+
+**Files:**
+- Modify: `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts` — imports; new `describe` appended at the END of the file.
+
+**Interfaces:**
+- Consumes: `db`, `withDbAccessContext`, `withSystemDbAccessContext` (already imported), Drizzle tables `scripts`, `scriptTags`, `scriptToTags`, `scriptVersions` from `../../db/schema/scripts`, `partners`, `organizations` (already imported), `eq`, `inArray`, `and` from `drizzle-orm`.
+- Produces: nothing consumed later; the failing rows are the retained RED for Task 5.
+
+- [ ] **Step 1: Extend the imports**
+
+Change `import { eq, sql } from 'drizzle-orm';` to `import { and, eq, inArray, sql } from 'drizzle-orm';` and `import { scripts, scriptExecutionBatches } from '../../db/schema/scripts';` to `import { scripts, scriptExecutionBatches, scriptTags, scriptToTags, scriptVersions } from '../../db/schema/scripts';`.
+
+- [ ] **Step 2: Append the forge describe at the end of the file**
+
+```ts
+// ---------------------------------------------------------------------------
+// script_versions / script_to_tags — parent-join forge test (RMM-QA-220)
+// ---------------------------------------------------------------------------
+// Both tables reach their tenant only through `scripts` (dual-axis, nullable
+// org_id, is_system) and `script_tags` (dual-axis). Migration under test:
+// 2026-09-30-100000-script-children-rls.sql. Runs as `breeze_app` under real
+// contexts, modelled on the scripts partner-wide block above: self-contained
+// fixtures seeded under system scope, cleanup by id in afterAll.
+//
+// Actors: org A1 (partner A), org B1 (partner B), org A1 with a MIS-SET own
+// partner (B), partner A, partner B. Rows marked "positive" pass on main too —
+// they guard against an over-tight policy; every negative row is RED on main.
+describe('script_versions / script_to_tags RLS — parent-join forge enforcement (Org A/B, Partner A/B)', () => {
+  const runSuffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  let partnerAId: string;
+  let partnerBId: string;
+  let orgA1Id: string;
+  let orgB1Id: string;
+  let sA1Id: string; // org A1 script
+  let sB1Id: string; // org B1 script
+  let sPAId: string; // partner-wide script of partner A (org_id NULL)
+  let sSysId: string; // system script (is_system, org NULL, partner NULL)
+  let tA1Id: string; // org A1 tag
+  let tB1Id: string; // org B1 tag
+  let tPAId: string; // partner-wide tag of partner A
+  let vSysId: string; // seeded version on sSys
+  let vPAId: string; // seeded version on sPA
+  let vA1Id: string | null = null; // version org A1 creates in the positive test
+
+  async function ensureFixtures(): Promise<void> {
+    if (partnerAId) return;
+    await withSystemDbAccessContext(async () => {
+      const seededPartners = await db.insert(partners).values([
+        { name: `RLS ScriptChildren A ${runSuffix}`, slug: `rls-sc-a-${runSuffix}`, type: 'msp', plan: 'pro', status: 'active' },
+        { name: `RLS ScriptChildren B ${runSuffix}`, slug: `rls-sc-b-${runSuffix}`, type: 'msp', plan: 'pro', status: 'active' },
+      ]).returning({ id: partners.id });
+      partnerAId = seededPartners[0]!.id;
+      partnerBId = seededPartners[1]!.id;
+
+      const seededOrgs = await db.insert(organizations).values([
+        { currencyCode: 'USD', partnerId: partnerAId, name: `RLS SC Org A1 ${runSuffix}`, slug: `rls-sc-org-a1-${runSuffix}` },
+        { currencyCode: 'USD', partnerId: partnerBId, name: `RLS SC Org B1 ${runSuffix}`, slug: `rls-sc-org-b1-${runSuffix}` },
+      ]).returning({ id: organizations.id });
+      orgA1Id = seededOrgs[0]!.id;
+      orgB1Id = seededOrgs[1]!.id;
+
+      const base = { osTypes: ['windows'], language: 'powershell' as const, content: 'echo seed' };
+      const seededScripts = await db.insert(scripts).values([
+        { ...base, orgId: orgA1Id, partnerId: partnerAId, name: `sc-sA1-${runSuffix}` },
+        { ...base, orgId: orgB1Id, partnerId: partnerBId, name: `sc-sB1-${runSuffix}` },
+        { ...base, orgId: null, partnerId: partnerAId, name: `sc-sPA-${runSuffix}` },
+        { ...base, orgId: null, partnerId: null, isSystem: true, name: `sc-sSys-${runSuffix}` },
+      ]).returning({ id: scripts.id });
+      sA1Id = seededScripts[0]!.id;
+      sB1Id = seededScripts[1]!.id;
+      sPAId = seededScripts[2]!.id;
+      sSysId = seededScripts[3]!.id;
+
+      const seededTags = await db.insert(scriptTags).values([
+        { orgId: orgA1Id, partnerId: partnerAId, name: `tA1-${runSuffix}` },
+        { orgId: orgB1Id, partnerId: partnerBId, name: `tB1-${runSuffix}` },
+        { orgId: null, partnerId: partnerAId, name: `tPA-${runSuffix}` },
+      ]).returning({ id: scriptTags.id });
+      tA1Id = seededTags[0]!.id;
+      tB1Id = seededTags[1]!.id;
+      tPAId = seededTags[2]!.id;
+
+      // created_by is nullable (0001-baseline.sql:5216) — no users rows needed.
+      const seededVersions = await db.insert(scriptVersions).values([
+        { scriptId: sSysId, version: 1, content: 'echo sys-v1', changelog: 'seed', createdBy: null },
+        { scriptId: sPAId, version: 1, content: 'echo pa-v1', changelog: 'seed', createdBy: null },
+      ]).returning({ id: scriptVersions.id });
+      vSysId = seededVersions[0]!.id;
+      vPAId = seededVersions[1]!.id;
+    });
+  }
+
+  afterAll(async () => {
+    if (!partnerAId) return;
+    await withSystemDbAccessContext(async () => {
+      const scriptIds = [sA1Id, sB1Id, sPAId, sSysId];
+      await db.delete(scriptVersions).where(inArray(scriptVersions.scriptId, scriptIds));
+      await db.delete(scriptToTags).where(inArray(scriptToTags.scriptId, scriptIds));
+      await db.delete(scripts).where(inArray(scripts.id, scriptIds));
+      await db.delete(scriptTags).where(inArray(scriptTags.id, [tA1Id, tB1Id, tPAId]));
+      await db.delete(organizations).where(inArray(organizations.id, [orgA1Id, orgB1Id]));
+      await db.delete(partners).where(inArray(partners.id, [partnerAId, partnerBId]));
+    });
+  });
+
+  function partnerContext(partnerId: string) {
+    return { scope: 'partner' as const, orgId: null, accessibleOrgIds: [], accessiblePartnerIds: [partnerId], userId: null, currentPartnerId: partnerId };
+  }
+
+  // ORGANIZATION scope: no partner-axis write access (accessiblePartnerIds []),
+  // currentPartnerId = the caller's own partner so the read-only own-partner
+  // branch of the parents' SELECT policies applies.
+  function orgContext(orgId: string, ownPartnerId: string | null) {
+    return { scope: 'organization' as const, orgId, accessibleOrgIds: [orgId], accessiblePartnerIds: [], currentPartnerId: ownPartnerId, userId: null };
+  }
+
+  async function expectRlsViolation(table: 'script_versions' | 'script_to_tags', fn: () => Promise<unknown>): Promise<void> {
+    let caught: unknown;
+    try {
+      await fn();
+    } catch (err) {
+      caught = err;
+    }
+    const cause = caught as { cause?: { message?: string }; message?: string } | undefined;
+    const message = cause?.cause?.message ?? cause?.message ?? '';
+    expect(message, `expected an RLS violation on ${table}; got: ${message || '<no error>'}`).toMatch(
+      new RegExp(`new row violates row-level security policy for table "${table}"`),
+    );
+  }
+
+  const versionsOf = (scriptId: string) =>
+    db.select({ id: scriptVersions.id }).from(scriptVersions).where(eq(scriptVersions.scriptId, scriptId));
+  const linksOf = (scriptId: string) =>
+    db.select({ tagId: scriptToTags.tagId }).from(scriptToTags).where(eq(scriptToTags.scriptId, scriptId));
+
+  // 1 (positive)
+  it('org A1 can INSERT and SELECT a version of its own script', async () => {
+    await ensureFixtures();
+    const inserted = await withDbAccessContext(orgContext(orgA1Id, partnerAId), async () =>
+      db.insert(scriptVersions).values({ scriptId: sA1Id, version: 1, content: 'echo a1-v1', changelog: 'org A1', createdBy: null }).returning({ id: scriptVersions.id })
+    );
+    expect(inserted).toHaveLength(1);
+    vA1Id = inserted[0]!.id;
+    const visible = await withDbAccessContext(orgContext(orgA1Id, partnerAId), async () => versionsOf(sA1Id));
+    expect(visible.map((r) => r.id)).toEqual([vA1Id]);
+  });
+
+  // 2 (positive)
+  it('org A1 can INSERT and SELECT a link between its own script and its own tag', async () => {
+    await ensureFixtures();
+    await withDbAccessContext(orgContext(orgA1Id, partnerAId), async () =>
+      db.insert(scriptToTags).values({ scriptId: sA1Id, tagId: tA1Id })
+    );
+    const visible = await withDbAccessContext(orgContext(orgA1Id, partnerAId), async () => linksOf(sA1Id));
+    expect(visible.map((r) => r.tagId)).toEqual([tA1Id]);
+  });
+
+  // 3
+  it("org B1 cannot SELECT org A1's versions or links", async () => {
+    await ensureFixtures();
+    const versions = await withDbAccessContext(orgContext(orgB1Id, partnerBId), async () => versionsOf(sA1Id));
+    const links = await withDbAccessContext(orgContext(orgB1Id, partnerBId), async () => linksOf(sA1Id));
+    expect(versions).toEqual([]);
+    expect(links).toEqual([]);
+  });
+
+  // 4
+  it("org B1 INSERT of a version onto org A1's script is rejected by WITH CHECK", async () => {
+    await ensureFixtures();
+    await expectRlsViolation('script_versions', () =>
+      withDbAccessContext(orgContext(orgB1Id, partnerBId), async () =>
+        db.insert(scriptVersions).values({ scriptId: sA1Id, version: 9, content: 'forged', changelog: null, createdBy: null })
+      )
+    );
+  });
+
+  // 5
+  it('org B1 cannot pair (own script, A tag) nor (A script, own tag)', async () => {
+    await ensureFixtures();
+    await expectRlsViolation('script_to_tags', () =>
+      withDbAccessContext(orgContext(orgB1Id, partnerBId), async () => db.insert(scriptToTags).values({ scriptId: sB1Id, tagId: tA1Id }))
+    );
+    await expectRlsViolation('script_to_tags', () =>
+      withDbAccessContext(orgContext(orgB1Id, partnerBId), async () => db.insert(scriptToTags).values({ scriptId: sA1Id, tagId: tB1Id }))
+    );
+  });
+
+  // 6
+  it("org B1 UPDATE/DELETE on org A1's version and DELETE on its link affect 0 rows and leave the rows intact", async () => {
+    await ensureFixtures();
+    if (!vA1Id) throw new Error('positive test must run first');
+    const updated = await withDbAccessContext(orgContext(orgB1Id, partnerBId), async () =>
+      db.update(scriptVersions).set({ changelog: 'tampered' }).where(eq(scriptVersions.id, vA1Id!)).returning({ id: scriptVersions.id })
+    );
+    const deletedVersions = await withDbAccessContext(orgContext(orgB1Id, partnerBId), async () =>
+      db.delete(scriptVersions).where(eq(scriptVersions.id, vA1Id!)).returning({ id: scriptVersions.id })
+    );
+    const deletedLinks = await withDbAccessContext(orgContext(orgB1Id, partnerBId), async () =>
+      db.delete(scriptToTags).where(and(eq(scriptToTags.scriptId, sA1Id), eq(scriptToTags.tagId, tA1Id))).returning({ tagId: scriptToTags.tagId })
+    );
+    expect(updated).toEqual([]);
+    expect(deletedVersions).toEqual([]);
+    expect(deletedLinks).toEqual([]);
+
+    const intact = await withSystemDbAccessContext(async () =>
+      db.select({ changelog: scriptVersions.changelog }).from(scriptVersions).where(eq(scriptVersions.id, vA1Id!))
+    );
+    expect(intact).toEqual([{ changelog: 'org A1' }]);
+    const linkIntact = await withSystemDbAccessContext(async () => linksOf(sA1Id));
+    expect(linkIntact.map((r) => r.tagId)).toEqual([tA1Id]);
+  });
+
+  // 7
+  it("partner B cannot SELECT org A1's version and cannot INSERT a version onto partner A's partner-wide script", async () => {
+    await ensureFixtures();
+    const visible = await withDbAccessContext(partnerContext(partnerBId), async () => versionsOf(sA1Id));
+    expect(visible).toEqual([]);
+    await expectRlsViolation('script_versions', () =>
+      withDbAccessContext(partnerContext(partnerBId), async () =>
+        db.insert(scriptVersions).values({ scriptId: sPAId, version: 9, content: 'forged', changelog: null, createdBy: null })
+      )
+    );
+  });
+
+  // 8 (positive)
+  it('partner A can INSERT a version and a link on its own partner-wide script', async () => {
+    await ensureFixtures();
+    const inserted = await withDbAccessContext(partnerContext(partnerAId), async () =>
+      db.insert(scriptVersions).values({ scriptId: sPAId, version: 2, content: 'echo pa-v2', changelog: 'partner A', createdBy: null }).returning({ id: scriptVersions.id })
+    );
+    expect(inserted).toHaveLength(1);
+    await withDbAccessContext(partnerContext(partnerAId), async () => db.insert(scriptToTags).values({ scriptId: sPAId, tagId: tPAId }));
+    const links = await withDbAccessContext(partnerContext(partnerAId), async () => linksOf(sPAId));
+    expect(links.map((r) => r.tagId)).toEqual([tPAId]);
+  });
+
+  // 9
+  it("org A1 can SELECT its MSP's partner-wide version (read branch) but cannot INSERT one", async () => {
+    await ensureFixtures();
+    const visible = await withDbAccessContext(orgContext(orgA1Id, partnerAId), async () =>
+      db.select({ id: scriptVersions.id }).from(scriptVersions).where(eq(scriptVersions.id, vPAId))
+    );
+    expect(visible.map((r) => r.id)).toEqual([vPAId]);
+    await expectRlsViolation('script_versions', () =>
+      withDbAccessContext(orgContext(orgA1Id, partnerAId), async () =>
+        db.insert(scriptVersions).values({ scriptId: sPAId, version: 9, content: 'forged', changelog: null, createdBy: null })
+      )
+    );
+  });
+
+  // 10
+  it("org A1 whose own partner is mis-set to B CANNOT SELECT partner A's partner-wide version", async () => {
+    await ensureFixtures();
+    const visible = await withDbAccessContext(orgContext(orgA1Id, partnerBId), async () =>
+      db.select({ id: scriptVersions.id }).from(scriptVersions).where(eq(scriptVersions.id, vPAId))
+    );
+    expect(visible).toEqual([]);
+  });
+
+  // 11 (positive)
+  it("org A1 can link its own script to its MSP's partner-wide tag (tag read branch)", async () => {
+    await ensureFixtures();
+    await withDbAccessContext(orgContext(orgA1Id, partnerAId), async () => db.insert(scriptToTags).values({ scriptId: sA1Id, tagId: tPAId }));
+    const links = await withDbAccessContext(orgContext(orgA1Id, partnerAId), async () => linksOf(sA1Id));
+    expect(links.map((r) => r.tagId).sort()).toEqual([tA1Id, tPAId].sort());
+  });
+
+  // 12
+  it("org B1 cannot link its own script to partner A's partner-wide tag", async () => {
+    await ensureFixtures();
+    await expectRlsViolation('script_to_tags', () =>
+      withDbAccessContext(orgContext(orgB1Id, partnerBId), async () => db.insert(scriptToTags).values({ scriptId: sB1Id, tagId: tPAId }))
+    );
+  });
+
+  // 13 (positive, bound parameter through the extended protocol)
+  it("org A1 can SELECT a system script's version by bound script_id (is_system read branch)", async () => {
+    await ensureFixtures();
+    const visible = await withDbAccessContext(orgContext(orgA1Id, partnerAId), async () => versionsOf(sSysId));
+    expect(visible.map((r) => r.id)).toEqual([vSysId]);
+  });
+
+  // 14
+  it('neither org A1 nor partner A can INSERT a version onto a system script (no is_system in any write predicate)', async () => {
+    await ensureFixtures();
+    await expectRlsViolation('script_versions', () =>
+      withDbAccessContext(orgContext(orgA1Id, partnerAId), async () =>
+        db.insert(scriptVersions).values({ scriptId: sSysId, version: 9, content: 'forged', changelog: null, createdBy: null })
+      )
+    );
+    await expectRlsViolation('script_versions', () =>
+      withDbAccessContext(partnerContext(partnerAId), async () =>
+        db.insert(scriptVersions).values({ scriptId: sSysId, version: 9, content: 'forged', changelog: null, createdBy: null })
+      )
+    );
+  });
+
+  // 16 — runs BEFORE 15 because 15 deletes the (sA1, tA1) link this test re-points.
+  it('org A1 UPDATE re-pointing its own link at org B1\'s tag is rejected by the UPDATE WITH CHECK tag leg', async () => {
+    await ensureFixtures();
+    await expectRlsViolation('script_to_tags', () =>
+      withDbAccessContext(orgContext(orgA1Id, partnerAId), async () =>
+        db.update(scriptToTags).set({ tagId: tB1Id }).where(and(eq(scriptToTags.scriptId, sA1Id), eq(scriptToTags.tagId, tA1Id)))
+      )
+    );
+    const intact = await withSystemDbAccessContext(async () => linksOf(sA1Id));
+    expect(intact.map((r) => r.tagId).sort()).toEqual([tA1Id, tPAId].sort());
+  });
+
+  // 15
+  it("org A1 can DELETE its own link but DELETE on the partner-wide link affects 0 rows (unlink needs script WRITE)", async () => {
+    await ensureFixtures();
+    const own = await withDbAccessContext(orgContext(orgA1Id, partnerAId), async () =>
+      db.delete(scriptToTags).where(and(eq(scriptToTags.scriptId, sA1Id), eq(scriptToTags.tagId, tA1Id))).returning({ tagId: scriptToTags.tagId })
+    );
+    expect(own.map((r) => r.tagId)).toEqual([tA1Id]);
+    const partnerWide = await withDbAccessContext(orgContext(orgA1Id, partnerAId), async () =>
+      db.delete(scriptToTags).where(and(eq(scriptToTags.scriptId, sPAId), eq(scriptToTags.tagId, tPAId))).returning({ tagId: scriptToTags.tagId })
+    );
+    expect(partnerWide).toEqual([]);
+    const intact = await withSystemDbAccessContext(async () => linksOf(sPAId));
+    expect(intact.map((r) => r.tagId)).toEqual([tPAId]);
+  });
+});
+```
+
+- [ ] **Step 3: Typecheck, then run the forge block — negatives RED on the unmigrated DB**
+
+```bash
+cd "$WT" && NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @breeze/api exec tsc --noEmit 2>&1 | tail -3
+set -a && . "$LOGS/rls-coverage.env" && set +a && pnpm --filter @breeze/api test:rls-coverage -- -t 'parent-join forge enforcement' 2>&1 | tee "$LOGS/task4-red-d7.log" | grep -E '✓|✗|×|FAIL|Tests ' | head -40
+```
+Expected (no policies yet): tests 1, 2, 8, 11, 13 PASS (positive rows); tests 3, 4, 5, 6, 7, 9, 10, 12, 14, 16, 15 FAIL — SELECTs return rows instead of `[]`, forged INSERT/UPDATEs succeed (`expected an RLS violation … got: <no error>`), foreign UPDATE/DELETE return rows instead of `[]`. Record the exact pass/fail list. Note: test 16 fails on main by *succeeding* at the re-point, which changes the (sA1,tA1) link to (sA1,tB1) — so test 15's "own link" delete then also fails; that cascade is expected and disappears once the policy exists.
+
+- [ ] **Step 4: Commit RED**
+
+```bash
+cd "$WT" && git add apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+git commit -m "test(rls): breeze_app forge suite for script_versions / script_to_tags (RED)
+
+Org A/B, Partner A/B and mis-set-own-partner contexts against both script
+children: same-tenant INSERT/SELECT succeed; foreign SELECT hidden; forged
+INSERT (foreign script, foreign/partner tag, system script) rejected by
+WITH CHECK; foreign UPDATE/DELETE affect 0 rows; UPDATE re-point at a
+hidden tag rejected; unlink requires script WRITE; system-script version
+readable by bound script_id; partner-wide version readable via the own-
+partner read branch only.
+
+RED on the unmigrated per-worktree DB (retained for the migration commit):
+<paste the FAIL lines (test names) from task4-red-d7.log>
+Positive rows 1, 2, 8, 11, 13 pass on main by construction (no policy).
+
+Refs RMM-QA-220.
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01E9p3mtFLSv8SFcZ9fcn8Vu"
+```
+
+---
+
+### Task 5: The migration (D1–D3) — everything goes green; idempotency, fresh-DB apply, manual `breeze_app` forge, catalog proof
+
+**Files:**
+- Create: `apps/api/migrations/2026-09-30-100000-script-children-rls.sql`
+
+**Interfaces:**
+- Produces: policies `breeze_org_isolation_{select,insert,update,delete}` on `public.script_versions` and `public.script_to_tags`; RLS ENABLED + FORCED on both. Consumed by every test from Tasks 2–4 and by Task 6.
+
+- [ ] **Step 1: Re-verify the filename ceiling**
+
+```bash
+cd "$WT" && ls apps/api/migrations/*.sql | xargs -n1 basename | node -e 'const n=require("fs").readFileSync(0,"utf8").split("\n").filter(Boolean); console.log(n.sort((a,b)=>a.localeCompare(b)).pop())'
+```
+Expected: `2026-09-29-detach-ticket-runs-on-device-org-move.sql`. If main has moved past `2026-09-30-100000-…`, choose a later `HHMMSS` (or later date) that sorts strictly after the printed name and use that name everywhere below (the D4 comment in the test file, the debt-bucket comment, the migration header).
+
+- [ ] **Step 2: Write the migration**
+
+Create `apps/api/migrations/2026-09-30-100000-script-children-rls.sql`:
+
+```sql
+-- 2026-09-30-100000: forced parent-join RLS for the two script CHILD tables
+-- that shipped in 0001-baseline.sql with NO row-level security (RMM-QA-220).
+--
+-- Threat: script_versions carries customer script content + history and
+-- script_to_tags pairs a script with a tag; both reach their tenant only
+-- through scripts.script_id / script_tags.tag_id (no org_id), so they were
+-- invisible to the org_id auto-discovery AND absent from every allowlist in
+-- rls-coverage.integration.test.ts while breeze_app held blanket DML
+-- (ensureAppRole.ts). This migration closes the DB invariant; the companion
+-- test changes make the catalog exhaustive so the class cannot recur.
+--
+-- Shape: the canonical FK-child shape of 2026-05-30-fk-child-tables-rls.sql
+-- (DROP IF EXISTS x4, ENABLE + FORCE, four per-command policies named
+-- breeze_org_isolation_*), with predicates that MIRROR the parents' reviewed
+-- policies rather than a plain breeze_has_org_access(parent.org_id):
+--
+--   R(s)  scripts read      = breeze_has_org_access(s.org_id)
+--                             OR breeze_has_partner_access(s.partner_id)
+--                             OR s.is_system
+--                             OR (s.org_id IS NULL AND s.partner_id = breeze_current_partner_id())
+--           (identical to scripts.breeze_dual_axis_select,
+--            2026-06-13-catalog-partner-read-branch.sql)
+--   W(s)  scripts write     = breeze_has_org_access(s.org_id)
+--                             OR breeze_has_partner_access(s.partner_id)
+--           (identical to scripts.breeze_dual_axis_insert/update/delete,
+--            2026-06-13-catalog-partner-axis-rls.sql)
+--   T(t)  script_tags read  = breeze_has_org_access(t.org_id)
+--                             OR breeze_has_partner_access(t.partner_id)
+--                             OR (t.org_id IS NULL AND t.partner_id = breeze_current_partner_id())
+--           (identical to script_tags.breeze_dual_axis_select)
+--
+--   script_versions: SELECT R(s); INSERT W(s); UPDATE W(s)/W(s); DELETE W(s).
+--   script_to_tags:  SELECT R(s) AND T(t); INSERT W(s) AND T(t);
+--                    UPDATE USING W(s) WITH CHECK (W(s) AND T(t)); DELETE W(s).
+--
+-- is_system appears ONLY in SELECT. It must NEVER be in an INSERT/UPDATE/
+-- DELETE predicate (2026-06-13-catalog-partner-axis-rls.sql:62-68, Discussion
+-- #633 — `OR is_system` in a WITH CHECK is cross-tenant script injection).
+-- System seeding runs under system scope, where W(s) is already TRUE.
+--
+-- Tag asymmetry (script_to_tags): INSERT and the UPDATE check gate on the tag
+-- being READABLE, not writable, so an org user may attach its own script to
+-- its MSP's partner-wide tag (the partner-wide-first use case; precedent
+-- 2026-09-25-a-automation-resource-bindings.sql). Unlink authority (UPDATE
+-- USING / DELETE) comes from the SCRIPT write predicate only, so merely
+-- seeing a partner tag never lets a user unlink it from another org's script.
+-- The UPDATE WITH CHECK re-applies the tag leg so a link cannot be re-pointed
+-- at an invisible tag.
+--
+-- Bound parameters: the 2026-05-31 script_execution_batches note concerns an
+-- INSERT WITH CHECK that ORs `s.is_system`; these write predicates carry no
+-- such branch. The only is_system branch here is in SELECT, the same nested-
+-- EXISTS shape role_permissions has run in production since 2026-06-13-b.
+--
+-- The nested EXISTS runs as breeze_app, so the parents' own SELECT policies
+-- filter it too: child visibility can never exceed parent visibility.
+--
+-- Idempotent: DROP POLICY IF EXISTS x4 before each CREATE; ENABLE/FORCE are
+-- no-ops when already set. No data change, so no row-count reporting applies.
+-- autoMigrate wraps each migration file in a transaction — no inner BEGIN/COMMIT.
+
+-- ---------------------------------------------------------------------------
+-- script_versions  ->  scripts(script_id)
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS breeze_org_isolation_select ON public.script_versions;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON public.script_versions;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON public.script_versions;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON public.script_versions;
+ALTER TABLE public.script_versions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.script_versions FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY breeze_org_isolation_select ON public.script_versions FOR SELECT USING (
+  EXISTS (
+    SELECT 1 FROM scripts s
+    WHERE s.id = script_versions.script_id
+      AND (
+        public.breeze_has_org_access(s.org_id)
+        OR public.breeze_has_partner_access(s.partner_id)
+        OR s.is_system
+        OR (s.org_id IS NULL AND s.partner_id = public.breeze_current_partner_id())
+      )
+  )
+);
+CREATE POLICY breeze_org_isolation_insert ON public.script_versions FOR INSERT WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM scripts s
+    WHERE s.id = script_versions.script_id
+      AND (public.breeze_has_org_access(s.org_id) OR public.breeze_has_partner_access(s.partner_id))
+  )
+);
+CREATE POLICY breeze_org_isolation_update ON public.script_versions FOR UPDATE USING (
+  EXISTS (
+    SELECT 1 FROM scripts s
+    WHERE s.id = script_versions.script_id
+      AND (public.breeze_has_org_access(s.org_id) OR public.breeze_has_partner_access(s.partner_id))
+  )
+) WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM scripts s
+    WHERE s.id = script_versions.script_id
+      AND (public.breeze_has_org_access(s.org_id) OR public.breeze_has_partner_access(s.partner_id))
+  )
+);
+CREATE POLICY breeze_org_isolation_delete ON public.script_versions FOR DELETE USING (
+  EXISTS (
+    SELECT 1 FROM scripts s
+    WHERE s.id = script_versions.script_id
+      AND (public.breeze_has_org_access(s.org_id) OR public.breeze_has_partner_access(s.partner_id))
+  )
+);
+
+-- ---------------------------------------------------------------------------
+-- script_to_tags  ->  scripts(script_id)  AND  script_tags(tag_id)
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS breeze_org_isolation_select ON public.script_to_tags;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON public.script_to_tags;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON public.script_to_tags;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON public.script_to_tags;
+ALTER TABLE public.script_to_tags ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.script_to_tags FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY breeze_org_isolation_select ON public.script_to_tags FOR SELECT USING (
+  EXISTS (
+    SELECT 1 FROM scripts s
+    WHERE s.id = script_to_tags.script_id
+      AND (
+        public.breeze_has_org_access(s.org_id)
+        OR public.breeze_has_partner_access(s.partner_id)
+        OR s.is_system
+        OR (s.org_id IS NULL AND s.partner_id = public.breeze_current_partner_id())
+      )
+  )
+  AND EXISTS (
+    SELECT 1 FROM script_tags t
+    WHERE t.id = script_to_tags.tag_id
+      AND (
+        public.breeze_has_org_access(t.org_id)
+        OR public.breeze_has_partner_access(t.partner_id)
+        OR (t.org_id IS NULL AND t.partner_id = public.breeze_current_partner_id())
+      )
+  )
+);
+CREATE POLICY breeze_org_isolation_insert ON public.script_to_tags FOR INSERT WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM scripts s
+    WHERE s.id = script_to_tags.script_id
+      AND (public.breeze_has_org_access(s.org_id) OR public.breeze_has_partner_access(s.partner_id))
+  )
+  AND EXISTS (
+    SELECT 1 FROM script_tags t
+    WHERE t.id = script_to_tags.tag_id
+      AND (
+        public.breeze_has_org_access(t.org_id)
+        OR public.breeze_has_partner_access(t.partner_id)
+        OR (t.org_id IS NULL AND t.partner_id = public.breeze_current_partner_id())
+      )
+  )
+);
+CREATE POLICY breeze_org_isolation_update ON public.script_to_tags FOR UPDATE USING (
+  EXISTS (
+    SELECT 1 FROM scripts s
+    WHERE s.id = script_to_tags.script_id
+      AND (public.breeze_has_org_access(s.org_id) OR public.breeze_has_partner_access(s.partner_id))
+  )
+) WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM scripts s
+    WHERE s.id = script_to_tags.script_id
+      AND (public.breeze_has_org_access(s.org_id) OR public.breeze_has_partner_access(s.partner_id))
+  )
+  AND EXISTS (
+    SELECT 1 FROM script_tags t
+    WHERE t.id = script_to_tags.tag_id
+      AND (
+        public.breeze_has_org_access(t.org_id)
+        OR public.breeze_has_partner_access(t.partner_id)
+        OR (t.org_id IS NULL AND t.partner_id = public.breeze_current_partner_id())
+      )
+  )
+);
+CREATE POLICY breeze_org_isolation_delete ON public.script_to_tags FOR DELETE USING (
+  EXISTS (
+    SELECT 1 FROM scripts s
+    WHERE s.id = script_to_tags.script_id
+      AND (public.breeze_has_org_access(s.org_id) OR public.breeze_has_partner_access(s.partner_id))
+  )
+);
+```
+
+- [ ] **Step 3: Naming guard + static migration test**
+
+```bash
+cd "$WT" && git add apps/api/migrations/2026-09-30-100000-script-children-rls.sql
+bash scripts/check-migration-naming.sh --staged 2>&1 | tee "$LOGS/task5-naming.log" | tail -3
+pnpm --filter @breeze/api exec vitest run src/db/autoMigrate.test.ts 2>&1 | tee "$LOGS/task5-automigrate-unit.log" | tail -4
+```
+Expected: naming guard OK (sorts strictly after the committed max); `autoMigrate.test.ts` passes.
+
+- [ ] **Step 4: Apply the migration through the integration runner (globalSetup → autoMigrate), then the full rls-coverage contract — GREEN**
+
+```bash
+cd "$WT" && pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts src/__tests__/integration/scripts-system-rls.integration.test.ts 2>&1 | tee "$LOGS/task5-migrate.log" | tail -6
+PG="$(grep '^# compose project:' "$WT/.env.test" | awk '{print $4}')-postgres"
+docker exec -i "$PG" psql -U breeze_test -d breeze_test -At -c "SELECT filename FROM breeze_migrations WHERE filename LIKE '2026-09-30-100000%'"
+set -a && . "$LOGS/rls-coverage.env" && set +a && pnpm --filter @breeze/api test:rls-coverage 2>&1 | tee "$LOGS/task5-green-rls-coverage.log" | grep -E '✗|×|FAIL|Tests |Test Files' | head
+```
+Expected: the ledger row exists; rls-coverage reports `Test Files 1 passed`, every test passing — including the force test, the legacy parent-FK test, D5, D6a, D6b and all 16 D7 rows. Every RED from Tasks 2–4 is now green with **no test edited**.
+
+- [ ] **Step 5: Idempotency — apply the file twice directly and diff the policy catalog**
+
+```bash
+cd "$WT" && PG="$(grep '^# compose project:' "$WT/.env.test" | awk '{print $4}')-postgres"
+cat > "$LOGS/policy-snapshot.sql" <<'SQL'
+SELECT tablename, policyname, cmd, permissive, md5(coalesce(qual, '') || '|' || coalesce(with_check, ''))
+FROM pg_policies
+WHERE schemaname = 'public' AND tablename IN ('script_versions', 'script_to_tags')
+ORDER BY 1, 2;
+SQL
+docker exec -i "$PG" psql -U breeze_test -d breeze_test -At < "$LOGS/policy-snapshot.sql" > "$LOGS/task5-policies-1.txt"
+docker exec -i "$PG" psql -U breeze_test -d breeze_test -v ON_ERROR_STOP=1 < apps/api/migrations/2026-09-30-100000-script-children-rls.sql > "$LOGS/task5-reapply-1.log" 2>&1
+docker exec -i "$PG" psql -U breeze_test -d breeze_test -v ON_ERROR_STOP=1 < apps/api/migrations/2026-09-30-100000-script-children-rls.sql > "$LOGS/task5-reapply-2.log" 2>&1
+docker exec -i "$PG" psql -U breeze_test -d breeze_test -At < "$LOGS/policy-snapshot.sql" > "$LOGS/task5-policies-2.txt"
+diff "$LOGS/task5-policies-1.txt" "$LOGS/task5-policies-2.txt" && echo IDEMPOTENT && wc -l < "$LOGS/task5-policies-2.txt"
+grep -c 'NOTICE' "$LOGS/task5-reapply-2.log" || true
+```
+Expected: `IDEMPOTENT`, 8 policy rows, no `there is already a transaction in progress` notice (no inner BEGIN).
+
+- [ ] **Step 6: Fresh-database apply (`check:migrations` from empty)**
+
+```bash
+cd "$WT" && PG="$(grep '^# compose project:' "$WT/.env.test" | awk '{print $4}')-postgres"
+PGPORT="$(grep '^DATABASE_URL=' "$WT/.env.test" | sed -E 's#.*localhost:([0-9]+)/.*#\1#')"
+docker exec -i "$PG" psql -U breeze_test -d postgres -c 'DROP DATABASE IF EXISTS breeze_test_fresh' -c 'CREATE DATABASE breeze_test_fresh'
+DATABASE_URL="postgresql://breeze_test:breeze_test@localhost:${PGPORT}/breeze_test_fresh" BREEZE_APP_DB_PASSWORD=breeze_test NODE_ENV=test pnpm --filter @breeze/api check:migrations 2>&1 | tee "$LOGS/task5-check-migrations-fresh.log" | tail -3
+docker exec -i "$PG" psql -U breeze_test -d breeze_test_fresh -At -c "SELECT relname, relrowsecurity, relforcerowsecurity FROM pg_class WHERE relname IN ('script_versions','script_to_tags') ORDER BY 1"
+docker exec -i "$PG" psql -U breeze_test -d postgres -c 'DROP DATABASE breeze_test_fresh'
+```
+Expected: `[check-migrations] OK — all migrations applied`; both rows `t|t`.
+
+- [ ] **Step 7: Manual forge as `breeze_app` via psql (CLAUDE.md workflow step 6)**
+
+```bash
+cd "$WT" && PG="$(grep '^# compose project:' "$WT/.env.test" | awk '{print $4}')-postgres"
+docker exec -i "$PG" psql -U breeze_test -d breeze_test -At <<'SQL' 2>&1 | tee "$LOGS/task5-manual-forge.log"
+BEGIN;
+INSERT INTO partners (id, name, slug) VALUES ('11111111-1111-4111-8111-111111111111','forge A','forge-a'), ('22222222-2222-4222-8222-222222222222','forge B','forge-b');
+INSERT INTO organizations (id, partner_id, name, slug, currency_code) VALUES
+  ('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa','11111111-1111-4111-8111-111111111111','forge org A','forge-org-a','USD'),
+  ('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb','22222222-2222-4222-8222-222222222222','forge org B','forge-org-b','USD');
+INSERT INTO scripts (id, org_id, partner_id, name, os_types, language, content) VALUES
+  ('55555555-5555-4555-8555-555555555555','aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa','11111111-1111-4111-8111-111111111111','forge script A','{windows}','powershell','echo a');
+INSERT INTO script_tags (id, org_id, partner_id, name) VALUES
+  ('77777777-7777-4777-8777-777777777777','aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa','11111111-1111-4111-8111-111111111111','forge tag A');
+-- Now act as the unprivileged request role under an ORGANIZATION-scope context for org B.
+SET ROLE breeze_app;
+SELECT set_config('breeze.scope','organization',true);
+SELECT set_config('breeze.org_id','bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',true);
+SELECT set_config('breeze.accessible_org_ids','bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',true);
+SELECT set_config('breeze.accessible_partner_ids','',true);
+SELECT set_config('breeze.user_id','',true);
+SELECT set_config('breeze.current_partner_id','22222222-2222-4222-8222-222222222222',true);
+SAVEPOINT forge1;
+INSERT INTO script_versions (script_id, version, content) VALUES ('55555555-5555-4555-8555-555555555555', 99, 'forged');
+ROLLBACK TO SAVEPOINT forge1;
+INSERT INTO script_to_tags (script_id, tag_id) VALUES ('55555555-5555-4555-8555-555555555555','77777777-7777-4777-8777-777777777777');
+ROLLBACK;
+SQL
+```
+Expected output contains exactly two errors: `ERROR:  new row violates row-level security policy for table "script_versions"` and `ERROR:  new row violates row-level security policy for table "script_to_tags"`; the final `ROLLBACK` discards every fixture (verify: `docker exec -i "$PG" psql -U breeze_test -d breeze_test -At -c "SELECT count(*) FROM partners WHERE slug IN ('forge-a','forge-b')"` → `0`).
+
+- [ ] **Step 8: Catalog proof re-run (the QA query) and drift check**
+
+```bash
+cd "$WT" && PG="$(grep '^# compose project:' "$WT/.env.test" | awk '{print $4}')-postgres"
+docker exec -i "$PG" psql -U breeze_test -d breeze_test -At <<'SQL' | tee "$LOGS/task5-catalog-postfix.log"
+SELECT json_agg(row_to_json(t)) FROM (
+  SELECT c.relname AS table_name, c.relrowsecurity AS rls_enabled, c.relforcerowsecurity AS force_rls,
+         has_table_privilege('breeze_app', c.oid, 'SELECT') AS app_select,
+         has_table_privilege('breeze_app', c.oid, 'INSERT') AS app_insert,
+         has_table_privilege('breeze_app', c.oid, 'UPDATE') AS app_update,
+         has_table_privilege('breeze_app', c.oid, 'DELETE') AS app_delete
+  FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public' AND c.relname IN ('script_to_tags','script_versions') ORDER BY 1) t;
+SQL
+set -a && . "$WT/.env.test" && set +a && pnpm db:check-drift 2>&1 | tee "$LOGS/task5-check-drift.log" | tail -5
+```
+Expected: both rows `rls_enabled=true, force_rls=true`, privileges unchanged (`app_*=true`, by design — F2); `db:check-drift` clean (policies are not part of the Drizzle schema, F22).
+
+- [ ] **Step 9: Typecheck + commit the migration with every retained RED**
+
+```bash
+cd "$WT" && NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @breeze/api exec tsc --noEmit 2>&1 | tail -3
+git add apps/api/migrations/2026-09-30-100000-script-children-rls.sql
+git commit -m "fix(rls): forced parent-join RLS for script_versions and script_to_tags (RMM-QA-220)
+
+Both tables shipped in 0001-baseline.sql with RLS off while breeze_app
+holds blanket DML. New idempotent migration (canonical 2026-05-30 child
+shape, no inner BEGIN/COMMIT):
+  script_versions: SELECT mirrors scripts' full read predicate (org OR
+    partner OR is_system OR own-partner read branch); INSERT/UPDATE/DELETE
+    mirror scripts' write predicate only (no is_system, Discussion #633).
+  script_to_tags: SELECT = script read AND tag read; INSERT = script WRITE
+    AND tag READ; UPDATE USING script WRITE, WITH CHECK script WRITE AND
+    tag READ; DELETE = script WRITE. Cross-tenant pairing is impossible by
+    construction; unlink never derives from tag visibility.
+
+RED before this commit (per-worktree DB migrated to 1b733cedb):
+  force test: script_to_tags, script_versions missing FORCE RLS
+  parent-FK (legacy + command-specific): <paste offender JSON from task2-red-d4-offenders.txt>
+  forge suite negatives failing: <paste FAIL test names from task4-red-d7.log>
+GREEN after: rls-coverage <N>/<N> (task5-green-rls-coverage.log), no test edited.
+Idempotency: file applied twice via psql, pg_policies snapshot identical, 8 rows.
+Fresh DB: check:migrations OK; both tables relrowsecurity=t relforcerowsecurity=t.
+Manual forge as breeze_app (org B context): INSERT script_versions on org A's
+script -> 'new row violates row-level security policy for table \"script_versions\"';
+INSERT script_to_tags (A script, A tag) -> same for \"script_to_tags\".
+Catalog proof (QA query): rls_enabled=true force_rls=true for both; DML
+privileges unchanged by design (RLS is the defense, ensureAppRole untouched).
+db:check-drift clean.
+
+Refs RMM-QA-220.
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01E9p3mtFLSv8SFcZ9fcn8Vu"
+```
+
+---
+
+### Task 6: Bundle-import regression under real RLS (D8) with a one-time mutation proof
+
+**Files:**
+- Create: `apps/api/src/__tests__/integration/scriptBundleRls.integration.test.ts`
+
+**Interfaces:**
+- Consumes: `importBundle(auth: BundleAuth, bundle: ScriptBundleEnvelope, options: { availability: 'org' | 'partner'; orgId?: string | null; mode: 'skip' | 'rename' | 'new-version' })` and `type BundleAuth = ScriptWriteAuth & Pick<AuthContext, 'user'>` from `../../services/scriptBundle` (`index.ts:327,678`); `SCRIPT_BUNDLE_VERSION`, `type ScriptBundleEnvelope` from `../../services/scriptBundle/schema`; `buildDbAccessContext({ scope, orgId, accessibleOrgIds, partnerId, userId })` from `../../middleware/auth` (`:433`); `createPartner`, `createOrganization`, `createUser` from `./db-utils`.
+- Produces: nothing consumed later.
+
+Why this file and not the rls-coverage suite: `importBundle` writes through the normal `db` under `withDbAccessContext`, and `new-version` mode sets `createdBy: auth.user.id` (`scriptBundle/index.ts:767-775`) so real `users` rows are needed; the integration runner's `setup.ts` TRUNCATE CASCADE (which includes `scripts`, `users`, `partners`) cleans up (F20). This suite passes on main too — it is a regression guard for verifier concern 7 (org-axis parent), the partner-wide parent, and the system short-circuit; its discriminating power is proven once by the mutation in Step 4.
+
+- [ ] **Step 1: Write the test**
+
+```ts
+/**
+ * Script bundle import under REAL RLS on script_versions / script_to_tags
+ * (RMM-QA-220, migration 2026-09-30-100000-script-children-rls.sql).
+ *
+ * importBundle authorises the parent script through resolveScriptCreateScope
+ * and then INSERTs script_to_tags (linkTags) and, in `new-version` mode,
+ * script_versions — as `breeze_app` inside the caller's DB access context.
+ * With the child policies forced, those INSERTs must still pass for every
+ * caller scope the route supports:
+ *   (a) organization scope  -> org-owned script (org_id + partner_id set)
+ *   (b) partner scope, availability 'partner' -> partner-wide script (org_id NULL)
+ *   (c) system scope with an explicit orgId -> org-owned script
+ * If any of these regress, the policy is wrong — not the importer (spec §non-goals).
+ */
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { eq, inArray } from 'drizzle-orm';
+import { db, withDbAccessContext, withSystemDbAccessContext } from '../../db';
+import { scripts, scriptTags, scriptToTags, scriptVersions } from '../../db/schema';
+import { buildDbAccessContext } from '../../middleware/auth';
+import { importBundle, type BundleAuth } from '../../services/scriptBundle';
+import { SCRIPT_BUNDLE_VERSION, type ScriptBundleEnvelope } from '../../services/scriptBundle/schema';
+import { createOrganization, createPartner, createUser } from './db-utils';
+
+function bundleAuth(args: {
+  scope: 'organization' | 'partner' | 'system';
+  orgId: string | null;
+  partnerId: string | null;
+  accessibleOrgIds: string[] | null;
+  partnerOrgAccess?: 'all' | 'selected' | 'none' | null;
+  userId: string;
+}): BundleAuth {
+  return {
+    scope: args.scope,
+    orgId: args.orgId,
+    partnerId: args.partnerId,
+    partnerOrgAccess: args.partnerOrgAccess ?? null,
+    accessibleOrgIds: args.accessibleOrgIds,
+    canAccessOrg: (id: string) => args.accessibleOrgIds === null || args.accessibleOrgIds.includes(id),
+    user: { id: args.userId, email: 'bundle-rls@example.com', name: 'Bundle RLS', isPlatformAdmin: false },
+  };
+}
+
+function bundle(content: string, suffix: string): ScriptBundleEnvelope {
+  return {
+    bundleVersion: SCRIPT_BUNDLE_VERSION,
+    scripts: [
+      { name: `Bundle One ${suffix}`, osTypes: ['windows'], language: 'powershell', content, tags: ['alpha', 'beta'], timeoutSeconds: 300, runAs: 'system' },
+      { name: `Bundle Two ${suffix}`, osTypes: ['linux'], language: 'bash', content, tags: ['alpha'], timeoutSeconds: 300, runAs: 'system' },
+    ],
+  };
+}
+
+async function readBack(names: string[]) {
+  return withSystemDbAccessContext(async () => {
+    const rows = await db.select().from(scripts).where(inArray(scripts.name, names));
+    const byName = new Map(rows.map((r) => [r.name, r]));
+    const ids = rows.map((r) => r.id);
+    const versions = ids.length ? await db.select().from(scriptVersions).where(inArray(scriptVersions.scriptId, ids)) : [];
+    const links = ids.length
+      ? await db
+          .select({ scriptId: scriptToTags.scriptId, tagName: scriptTags.name, tagOrgId: scriptTags.orgId, tagPartnerId: scriptTags.partnerId })
+          .from(scriptToTags)
+          .innerJoin(scriptTags, eq(scriptToTags.tagId, scriptTags.id))
+          .where(inArray(scriptToTags.scriptId, ids))
+      : [];
+    return { byName, versions, links };
+  });
+}
+
+async function importTwice(auth: BundleAuth, ctx: ReturnType<typeof buildDbAccessContext>, availability: 'org' | 'partner', orgId: string | null, suffix: string) {
+  const first = await withDbAccessContext(ctx, () => importBundle(auth, bundle('echo v1', suffix), { availability, orgId, mode: 'skip' }));
+  const second = await withDbAccessContext(ctx, () => importBundle(auth, bundle('echo v2', suffix), { availability, orgId, mode: 'new-version' }));
+  return { first, second };
+}
+
+function expectImported(result: Awaited<ReturnType<typeof importBundle>>, expected: { imported?: number; versioned?: number }) {
+  if ('error' in result) throw new Error(`importBundle returned a scope error: ${result.error}`);
+  expect(result.errors).toEqual([]);
+  if (expected.imported !== undefined) expect(result.imported).toBe(expected.imported);
+  if (expected.versioned !== undefined) expect(result.versioned).toBe(expected.versioned);
+}
+
+async function assertChildren(suffix: string, owner: { orgId: string | null; partnerId: string | null }) {
+  const names = [`Bundle One ${suffix}`, `Bundle Two ${suffix}`];
+  const { byName, versions, links } = await readBack(names);
+  const one = byName.get(names[0]!);
+  const two = byName.get(names[1]!);
+  expect(one?.orgId ?? null).toBe(owner.orgId);
+  expect(one?.partnerId ?? null).toBe(owner.partnerId);
+  expect(one?.content).toBe('echo v2');
+  expect(one?.version).toBe(2);
+  // One snapshot per script, holding the v1 content, created by the caller.
+  const oneVersions = versions.filter((v) => v.scriptId === one!.id);
+  const twoVersions = versions.filter((v) => v.scriptId === two!.id);
+  expect(oneVersions.map((v) => [v.version, v.content])).toEqual([[1, 'echo v1']]);
+  expect(twoVersions.map((v) => [v.version, v.content])).toEqual([[1, 'echo v1']]);
+  // Tags: two links on One, one on Two, all owned by the same scope as the script.
+  expect(links.filter((l) => l.scriptId === one!.id).map((l) => l.tagName).sort()).toEqual(['alpha', 'beta']);
+  expect(links.filter((l) => l.scriptId === two!.id).map((l) => l.tagName)).toEqual(['alpha']);
+  for (const l of links) {
+    expect(l.tagOrgId ?? null).toBe(owner.orgId);
+    expect(l.tagPartnerId ?? null).toBe(owner.partnerId);
+  }
+}
+
+describe('script bundle import under forced RLS on script_versions / script_to_tags (RMM-QA-220)', () => {
+  it('(a) organization-scope caller: versions and tag links land on the org-owned script', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const user = await createUser({ partnerId: partner.id, orgId: org.id });
+    const suffix = `org-${Date.now()}`;
+    const auth = bundleAuth({ scope: 'organization', orgId: org.id, partnerId: partner.id, accessibleOrgIds: [org.id], userId: user.id });
+    const ctx = buildDbAccessContext({ scope: 'organization', orgId: org.id, accessibleOrgIds: [org.id], partnerId: partner.id, userId: user.id });
+
+    const { first, second } = await importTwice(auth, ctx, 'org', null, suffix);
+    expectImported(first, { imported: 2 });
+    expectImported(second, { versioned: 2 });
+    await assertChildren(suffix, { orgId: org.id, partnerId: partner.id });
+  });
+
+  it('(b) partner-scope caller with partner-wide capability: versions and tag links land on the partner-wide script', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const user = await createUser({ partnerId: partner.id });
+    const suffix = `pw-${Date.now()}`;
+    const auth = bundleAuth({ scope: 'partner', orgId: null, partnerId: partner.id, accessibleOrgIds: [org.id], partnerOrgAccess: 'all', userId: user.id });
+    const ctx = buildDbAccessContext({ scope: 'partner', orgId: null, accessibleOrgIds: [org.id], partnerId: partner.id, userId: user.id });
+
+    const { first, second } = await importTwice(auth, ctx, 'partner', null, suffix);
+    expectImported(first, { imported: 2 });
+    expectImported(second, { versioned: 2 });
+    await assertChildren(suffix, { orgId: null, partnerId: partner.id });
+  });
+
+  it('(c) system-scope caller with an explicit orgId: versions and tag links land on the org-owned script', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const user = await createUser({ partnerId: partner.id });
+    const suffix = `sys-${Date.now()}`;
+    const auth = bundleAuth({ scope: 'system', orgId: null, partnerId: null, accessibleOrgIds: null, userId: user.id });
+    const ctx = buildDbAccessContext({ scope: 'system', orgId: null, accessibleOrgIds: null, partnerId: null, userId: user.id });
+
+    const { first, second } = await importTwice(auth, ctx, 'org', org.id, suffix);
+    expectImported(first, { imported: 2 });
+    expectImported(second, { versioned: 2 });
+    // resolveScriptCreateScope: system scope -> { orgId: requested, partnerId: null }.
+    await assertChildren(suffix, { orgId: org.id, partnerId: null });
+  });
+
+  it('cross-check: the org-owned links are invisible to a different org under breeze_app', async () => {
+    const partner = await createPartner();
+    const orgA = await createOrganization({ partnerId: partner.id });
+    const orgB = await createOrganization({ partnerId: partner.id });
+    const user = await createUser({ partnerId: partner.id, orgId: orgA.id });
+    const suffix = `xo-${Date.now()}`;
+    const auth = bundleAuth({ scope: 'organization', orgId: orgA.id, partnerId: partner.id, accessibleOrgIds: [orgA.id], userId: user.id });
+    const ctxA = buildDbAccessContext({ scope: 'organization', orgId: orgA.id, accessibleOrgIds: [orgA.id], partnerId: partner.id, userId: user.id });
+    const ctxB = buildDbAccessContext({ scope: 'organization', orgId: orgB.id, accessibleOrgIds: [orgB.id], partnerId: partner.id, userId: null });
+
+    expectImported(await withDbAccessContext(ctxA, () => importBundle(auth, bundle('echo v1', suffix), { availability: 'org', orgId: null, mode: 'skip' })), { imported: 2 });
+    const [row] = await withSystemDbAccessContext(() => db.select({ id: scripts.id }).from(scripts).where(eq(scripts.name, `Bundle One ${suffix}`)));
+    const asB = await withDbAccessContext(ctxB, () =>
+      db.select({ tagId: scriptToTags.tagId }).from(scriptToTags).where(eq(scriptToTags.scriptId, row!.id))
+    );
+    expect(asB).toEqual([]);
+    const asA = await withDbAccessContext(ctxA, () => db.select({ tagId: scriptToTags.tagId }).from(scriptToTags).where(eq(scriptToTags.scriptId, row!.id)));
+    expect(asA).toHaveLength(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run it — GREEN (migration applied in Task 5)**
+
+```bash
+cd "$WT" && NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @breeze/api exec tsc --noEmit 2>&1 | tail -3
+pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts src/__tests__/integration/scriptBundleRls.integration.test.ts 2>&1 | tee "$LOGS/task6-green.log" | tail -12
+```
+Expected: 4 tests pass. If (a) or (b) fails with an RLS violation, the POLICY is wrong (spec non-goal: never patch the importer) — go back to Task 5.
+
+- [ ] **Step 3: Mutation proof — weaken the INSERT policy on the test DB, watch (b) fail, restore by re-applying the migration file**
+
+```bash
+cd "$WT" && PG="$(grep '^# compose project:' "$WT/.env.test" | awk '{print $4}')-postgres"
+docker exec -i "$PG" psql -U breeze_test -d breeze_test -v ON_ERROR_STOP=1 <<'SQL'
+DROP POLICY breeze_org_isolation_insert ON public.script_versions;
+CREATE POLICY breeze_org_isolation_insert ON public.script_versions FOR INSERT WITH CHECK (
+  EXISTS (SELECT 1 FROM scripts s WHERE s.id = script_versions.script_id AND public.breeze_has_org_access(s.org_id))
+);
+SQL
+pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts src/__tests__/integration/scriptBundleRls.integration.test.ts 2>&1 | tee "$LOGS/task6-mutation.log" | grep -E '✓|✗|×|FAIL|row-level security' | head -12
+docker exec -i "$PG" psql -U breeze_test -d breeze_test -v ON_ERROR_STOP=1 < apps/api/migrations/2026-09-30-100000-script-children-rls.sql > "$LOGS/task6-restore.log" 2>&1
+pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts src/__tests__/integration/scriptBundleRls.integration.test.ts 2>&1 | tee "$LOGS/task6-green-after-restore.log" | tail -6
+```
+Expected: with the partner branch removed, test (b) FAILS (`importBundle` throws `new row violates row-level security policy for table "script_versions"` because the partner-wide script has `org_id NULL`); (a), (c) and the cross-check still pass. After re-applying the migration file: 4 pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd "$WT" && git add apps/api/src/__tests__/integration/scriptBundleRls.integration.test.ts
+git commit -m "test(scripts): bundle import regression under forced script-children RLS
+
+Real-RLS proof that importBundle's script_to_tags / script_versions writes
+still pass for organization-scope (org-axis parent), partner-scope
+partner-wide (partner-axis parent) and system-scope callers, plus a cross-
+org read check as breeze_app. Passes on main (no policy) — regression
+guard, not RED.
+
+Discrimination proof (once, on the per-worktree DB): re-created
+script_versions' INSERT policy WITHOUT the breeze_has_partner_access
+branch -> (b) partner-wide import failed with 'new row violates row-level
+security policy for table \"script_versions\"' (task6-mutation.log); re-
+applied 2026-09-30-100000-script-children-rls.sql -> 4/4 green.
+
+Refs RMM-QA-220.
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01E9p3mtFLSv8SFcZ9fcn8Vu"
+```
+
+---
+
+### Task 7: Full verification battery, push, draft PR with the handback record, teardown
+
+**Files:**
+- No source changes. (Only if the battery finds a problem does anything change — then fix RED-first in the owning task and re-run this task.)
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: pushed branch `fix/rmm-qa-220-script-children-rls` on `origin` (`LanternOps/breeze`), a DRAFT PR against `main`, the handback record in its body.
+
+- [ ] **Step 1: Unit suites (Test API job surface)**
+
+```bash
+cd "$WT" && pnpm --filter @breeze/api exec vitest run src/db/rlsPolicyShape.test.ts src/db/autoMigrate.test.ts src/services/scriptBundle/index.test.ts 2>&1 | tee "$LOGS/task7-unit.log" | tail -6
+NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @breeze/api exec tsc --noEmit 2>&1 | tee "$LOGS/task7-tsc.log" | tail -3
+```
+Expected: all pass; `tsc` clean.
+
+- [ ] **Step 2: Integration suites that touch scripts / registries (expected unchanged-green — no registry touched)**
+
+```bash
+cd "$WT" && pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts \
+  src/__tests__/integration/scriptBundleRls.integration.test.ts \
+  src/__tests__/integration/scripts-system-rls.integration.test.ts \
+  src/__tests__/integration/scripts-soft-delete.integration.test.ts \
+  src/__tests__/integration/tenantCascade.integration.test.ts \
+  src/__tests__/integration/orgMergeRegistry.integration.test.ts \
+  src/__tests__/integration/tenant-export-policy.integration.test.ts \
+  2>&1 | tee "$LOGS/task7-integration.log" | tail -12
+```
+Expected: every file passes. (If a listed file does not exist under that exact name, `ls src/__tests__/integration | grep -i <stem>` and substitute — do not skip it silently; record the substitution.)
+
+- [ ] **Step 3: The full rls-coverage contract one final time, plus migration hygiene on the whole directory**
+
+```bash
+cd "$WT" && set -a && . "$LOGS/rls-coverage.env" && set +a && pnpm --filter @breeze/api test:rls-coverage 2>&1 | tee "$LOGS/task7-rls-coverage.log" | tail -6
+bash scripts/check-migration-naming.sh 2>&1 | tail -2
+git status --short   # must be clean except nothing — no stray files
+```
+Expected: rls-coverage fully green; naming guard OK; working tree clean.
+
+- [ ] **Step 4 (optional, one independent review round — rigor cap): read-only Codex review of the diff**
+
+```bash
+cd "$WT" && git diff origin/main...HEAD > "$LOGS/task7-diff.patch"
+codex exec "Review this diff for tenant-isolation correctness only: (1) does any INSERT/UPDATE/DELETE predicate on script_versions or script_to_tags contain is_system or the own-partner read branch? (2) can an org-scope caller unlink a partner-wide tag from another org's script? (3) does rlsPolicyShape.ts accept a helper on a non-parent alias? Answer each with file:line evidence from the diff at $LOGS/task7-diff.patch; do not propose refactors." -s read-only -m gpt-5.6-sol -C "$WT" < /dev/null > "$LOGS/task7-codex-review.txt" 2>&1 || true
+tail -40 "$LOGS/task7-codex-review.txt"
+```
+Expected answers: (1) no, (2) no, (3) no. Any confirmed, consequential finding goes back to the owning task RED-first; nitpicks are recorded in the PR body, not looped on.
+
+- [ ] **Step 5: Push and open the DRAFT PR**
+
+```bash
+cd "$WT" && git push -u origin fix/rmm-qa-220-script-children-rls 2>&1 | tail -3
+```
+
+Write the PR body to `$LOGS/pr-body.md` with the values filled from the logs (every `<…>` below is replaced by the real number/text from `$LOGS` — none may remain), then create the PR:
+
+````markdown
+## fix(rls): forced parent-join RLS for script_versions / script_to_tags (RMM-QA-220)
+
+`script_versions` (customer script content + history) and `script_to_tags` (script↔tag join) shipped in `0001-baseline.sql` with RLS disabled while `breeze_app` holds blanket DML, and were in no allowlist of the RLS coverage contract. This PR installs forced per-command parent-join policies that mirror the reviewed `scripts` / `script_tags` semantics, makes the coverage catalog exhaustive over every public base table, adds command-specific USING/WITH CHECK shape checks, and proves enforcement behaviourally as `breeze_app`.
+
+Design: `docs/superpowers/specs/2026-09-01-rmm-qa-220-script-children-rls-design.md` (D1–D9, advisor-quorum record). Plan: `docs/superpowers/plans/2026-09-01-rmm-qa-220-script-children-rls.md`.
+
+### Standard implementation handback
+
+```text
+Finding IDs: RMM-QA-220
+Branch / commit / PR: fix/rmm-qa-220-script-children-rls / <head sha> (base origin/main 1b733cedb) / this PR (draft)
+Behavior changed: script_versions and script_to_tags now have RLS ENABLED + FORCED with four per-command policies each (2026-09-30-100000-script-children-rls.sql). script_versions SELECT mirrors scripts' read predicate (org OR partner OR is_system OR own-partner read branch); INSERT/UPDATE/DELETE mirror scripts' write predicate only. script_to_tags SELECT requires script read AND tag read; INSERT requires script WRITE AND tag READ; UPDATE USING script WRITE, WITH CHECK script WRITE AND tag READ; DELETE script WRITE. No app-layer code changed; breeze_app privileges unchanged (RLS is the defense, ensureAppRole untouched).
+Exit-contract clauses proved: (1) idempotent forced parent-join policies preserving reviewed system-script behavior (forge rows 13/14: system version readable, never writable) and preventing cross-tenant pairing (rows 5, 12, 16); (2) exhaustive table classification registers both tables (D5 test + PARENT_FK_JOIN_POLICY_TABLES entries); (3) real breeze_app Org A/B and Partner A/B tests: same-tenant success (rows 1, 2, 8, 11), foreign SELECT hidden (3, 7, 10), forged INSERT rejected (4, 5, 7, 9, 12, 14), foreign UPDATE/DELETE ineffective (6, 15); (4) command-specific policy-shape checks validate USING/WITH CHECK/helper argument for all 32 parent-FK tables (both-parents overlay for script_to_tags) and all asserted org-axis tables.
+Exit-contract clauses still open: none on the two script children at the DB layer; QA-side re-characterisation of the probe blocks core-tenant-isolation-release-contract.test.ts:151-177 (they pin the pre-fix state and now invert) and candidate-bound retest are QA's.
+Tests run and exact results: rlsPolicyShape.test.ts 22/22 PASS (unit; mutations A–E each observed red then reverted); autoMigrate.test.ts PASS; scriptBundle/index.test.ts PASS; test:rls-coverage <N>/<N> PASS on a fresh per-worktree DB (RED before the migration: force test + parent-FK tests naming both tables, forge negatives <list>); scriptBundleRls.integration.test.ts 4/4 PASS (mutation: INSERT policy without partner branch -> partner-wide import fails with the RLS violation; restored -> 4/4); scripts-system-rls, scripts-soft-delete, tenantCascade, orgMergeRegistry, tenant-export-policy integration suites PASS; tsc clean; check:migrations from an empty DB OK; migration applied twice -> identical pg_policies (8 rows).
+Migration / RLS / config / rollout impact: one new idempotent migration, DDL only (ENABLE/FORCE + 8 policies), no data change, no backfill, no config; sorts last (check-migration-naming --staged OK). No cascade/export registry change (neither table has org_id/device_id). db:check-drift clean. Rollback = a follow-up migration dropping the 8 policies and un-forcing RLS.
+Security and tenant/site negative cases: forge suite as breeze_app — org B1 cannot read/insert/update/delete on org A1's versions or links; org B1 cannot pair (own script, A tag), (A script, own tag) or (own script, partner-A tag); partner B cannot read A's version nor write A's partner-wide script; org A1 with a mis-set own partner cannot read A's partner-wide version; org A1 cannot write a system script's version nor unlink a partner-wide link; UPDATE re-point at a hidden tag rejected. Manual psql forge as breeze_app: both INSERTs rejected with "new row violates row-level security policy". Site scope: N/A — neither table carries a site axis.
+Operator/UI states checked: N/A — no UI or route changes; the only readers (aiToolsScripts includeVersionHistory, scriptBundle export/import) authorise the parent first and are covered by scriptBundleRls.integration.test.ts and the unchanged mocked unit suite.
+Candidate-bound evidence still required: QA re-run of the catalog query (docs/qa/evidence/2026-08-23-core-tenant-isolation.md:31-35) and of the release-contract probe against the nominated candidate; review of the new UNREVIEWED_RLS_CLASSIFICATION_DEBT names (device_software, mobile_sessions, software_compliance_status, agent_versions, cis_check_catalog, patches, permissions, plugin_catalog, script_templates<, plus any fresh-DB additions>) as candidate findings; parent-level findings from the quorum (scripts/script_tags composite ownership FK, is_system ⇒ NULL axes, org-erasure 23503 on NO ACTION child FKs) handed back per spec §8.
+```
+
+### Not in scope (handed back as candidate findings — spec §8)
+- Parent-level invariants on `scripts` / `script_tags` (composite ownership FK; `is_system ⇒ NULL axes`).
+- Org/partner erasure `23503` on `script_to_tags` / `script_versions` `NO ACTION` FKs (RLS-independent).
+- The debt-bucket tables and the seven `INTENTIONAL_UNSCOPED` tables whose RLS is off.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+https://claude.ai/code/session_01E9p3mtFLSv8SFcZ9fcn8Vu
+````
+
+```bash
+cd "$WT" && gh pr create --draft --base main --head fix/rmm-qa-220-script-children-rls \
+  --title "fix(rls): forced parent-join RLS for script_versions / script_to_tags (RMM-QA-220)" \
+  --body-file "$LOGS/pr-body.md" 2>&1 | tail -2
+gh pr view --json url,isDraft,baseRefName -q '"\(.url) draft=\(.isDraft) base=\(.baseRefName)"'
+```
+Expected: a draft PR URL, `draft=true base=main`. Confirm CI attaches to the head (`gh pr checks` after a minute; the branch targets `main`, so `ci.yml` triggers — no stacked-PR blind spot). Do NOT merge, do NOT mark ready.
+
+- [ ] **Step 6: Tear down the per-worktree stack**
+
+```bash
+cd "$WT" && pnpm test-stack down 2>&1 | tail -2 && ls "$WT/.env.test" 2>&1 | tail -1
+```
+Expected: containers and volumes removed; `.env.test` gone (`No such file`).
+
+- [ ] **Step 7: Return** the PR URL, head SHA, the list of `$LOGS` files, and the three hand-backs from the PR body's "Not in scope" section.
+
+---
+
+## Spec coverage map (self-review)
+
+| Spec item | Task |
+| --- | --- |
+| D1 migration file, canonical shape, no BEGIN/COMMIT, idempotent, header contents | 5 (Steps 2, 5) |
+| D2 `script_versions` predicates; open decision 1 rejected; bound-parameter refutation | 5 (Step 2), 4 (row 13/14) |
+| D3 `script_to_tags` predicates; open decision 2 = mirror; verifier concern 3 (unlink from script WRITE); UPDATE WITH CHECK tag leg | 5 (Step 2), 4 (rows 5, 11, 12, 15, 16), 3 (overlay) |
+| D4 catalog entries = retained RED | 2 (Steps 3–4) |
+| D5 exhaustive classification, `relkind IN ('r','p') AND NOT relispartition` (verifier concern 4), buckets 3/4, shrink-only, disjointness | 2 |
+| D6 pure module under `src/db/`, unit fixtures + mutations; D6a both-parents overlay; D6b org-axis; open decision 3 all-at-once with triage escape hatch (verifier concern 5) | 1, 3 |
+| D7 forge suite, 16 rows, Org A/B, Partner A/B, mis-set own partner | 4 |
+| D8 bundle regression for org (verifier concern 7), partner-wide and system callers + mutation proof | 6 |
+| D9 quorum already convened (spec §9); optional one review round | 7 (Step 4) |
+| §5 verification battery: fresh DB, twice-apply, manual forge, catalog proof, unit/integration lists, drift, naming, tsc, post-push CI check | 5 (Steps 3–8), 7 |
+| Verifier concern 6 (BEGIN/COMMIT) refuted | Global Constraints |
+| §8 hand-offs surfaced to QA | 7 (PR body) |
+| Exit-evidence contract (row): idempotent forced policies, system-script behaviour preserved, cross-tenant pairing prevented, exhaustive classification, Org A/B + Partner A/B breeze_app proofs, command-specific shape checks | 2, 3, 4, 5, 6 |

--- a/docs/superpowers/plans/2026-09-01-rmm-qa-220-script-children-rls.md
+++ b/docs/superpowers/plans/2026-09-01-rmm-qa-220-script-children-rls.md
@@ -22,8 +22,8 @@
   - Integration runner (migrates the stack DB once via `globalSetup`): `pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts <file>`.
   - RLS coverage runner (no migrations, no truncation — run it only AFTER an integration run has migrated the DB). Task 0 writes the CI-equivalent variables (`ci.yml:2006-2020`) to `$LOGS/rls-coverage.env`; every invocation is then `set -a && . "$LOGS/rls-coverage.env" && set +a && pnpm --filter @breeze/api test:rls-coverage` (append `-- -t '<test name>'` to run a subset). The shell is zsh, which does not word-split an unquoted `$VAR`, so never try `env $VARS cmd`. `vitest.config.rls-coverage.ts` loads `WT/.env.test` itself.
   - Postgres container name: `PG="$(grep '^# compose project:' "$WT/.env.test" | awk '{print $4}')-postgres"` (project name derives from the branch: `breeze-test-fix-rmm-qa-220-script-children-rls`). `docker exec -i "$PG" psql -U breeze_test -d breeze_test` is the superuser shell; `breeze_test` may `SET ROLE breeze_app` to act as the unprivileged request role.
-- **Migration hygiene (Task 5 only):** filename `apps/api/migrations/2026-09-30-100000-script-children-rls.sql` (sorts strictly after the current ceiling `2026-09-29-detach-ticket-runs-on-device-org-move.sql`; if `main` has grown past it at commit time pick the next `HHMMSS` that sorts last — never rename after commit). `bash scripts/check-migration-naming.sh --staged` (also runs from the `.githooks/pre-commit` hook) and `pnpm --filter @breeze/api check:migrations` against a fresh database. No inner `BEGIN;`/`COMMIT;` (`autoMigrate` wraps each file — CLAUDE.md, `migrations/README.md:54-56`; the verifier's "some migrations wrap in BEGIN" note is refuted by `grep -l '^BEGIN;' apps/api/migrations/2026-09-*.sql` → nothing). Idempotent: `DROP POLICY IF EXISTS` then `CREATE POLICY`. **Never edit a shipped migration** (`0001-baseline.sql` stays byte-identical).
-- **Files you may touch** (spec §3): `apps/api/migrations/2026-09-30-100000-script-children-rls.sql` (new), `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts`, `apps/api/src/db/rlsPolicyShape.ts` (new), `apps/api/src/db/rlsPolicyShape.test.ts` (new), `apps/api/src/__tests__/integration/scriptBundleRls.integration.test.ts` (new), and this plan/spec pair. **Nothing else** — in particular not `ensureAppRole.ts`, `scriptBundle/index.ts`, `aiToolsScripts.ts`, `routes/scripts.ts`, `tenantCascade.ts`, `orgMergeRegistry.ts`, `db/schema/scripts.ts`, nor anything under `/Users/toddhebebrand/breeze-rmm-qa/docs/qa/probes/` (the QA probe pins the PRE-fix state and is expected to flip; QA owns that).
+- **Migration hygiene (Task 5 only):** filename `apps/api/migrations/2026-10-01-100000-script-children-rls.sql` (originally `2026-09-30-100000-…`, which sorted after the ceiling at planning time, `2026-09-29-detach-ticket-runs-on-device-org-move.sql`; renamed before merge, while still unshipped, after `main` landed `2026-09-30-ai-agents-impact.sql` and the review found the old name sorting into the middle — never rename after the file ships). `bash scripts/check-migration-naming.sh --staged` (also runs from the `.githooks/pre-commit` hook) and `pnpm --filter @breeze/api check:migrations` against a fresh database. No inner `BEGIN;`/`COMMIT;` (`autoMigrate` wraps each file — CLAUDE.md, `migrations/README.md:54-56`; the verifier's "some migrations wrap in BEGIN" note is refuted by `grep -l '^BEGIN;' apps/api/migrations/2026-09-*.sql` → nothing). Idempotent: `DROP POLICY IF EXISTS` then `CREATE POLICY`. **Never edit a shipped migration** (`0001-baseline.sql` stays byte-identical).
+- **Files you may touch** (spec §3): `apps/api/migrations/2026-10-01-100000-script-children-rls.sql` (new), `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts`, `apps/api/src/db/rlsPolicyShape.ts` (new), `apps/api/src/db/rlsPolicyShape.test.ts` (new), `apps/api/src/__tests__/integration/scriptBundleRls.integration.test.ts` (new), and this plan/spec pair. **Nothing else** — in particular not `ensureAppRole.ts`, `scriptBundle/index.ts`, `aiToolsScripts.ts`, `routes/scripts.ts`, `tenantCascade.ts`, `orgMergeRegistry.ts`, `db/schema/scripts.ts`, nor anything under `/Users/toddhebebrand/breeze-rmm-qa/docs/qa/probes/` (the QA probe pins the PRE-fix state and is expected to flip; QA owns that).
 - **Policy semantics that must not drift** (D2/D3, verifier concerns 1–3): `is_system` appears ONLY in the `script_versions`/`script_to_tags` SELECT predicates, never in INSERT/UPDATE/DELETE (`2026-06-13-catalog-partner-axis-rls.sql:62-68`, Discussion #633); unlink/UPDATE authority derives from the script WRITE predicate; UPDATE `WITH CHECK` re-applies the tag READ leg; no strict `s.org_id = t.org_id` tightening.
 - **No existing assertion is weakened or removed.** New tests are added beside existing ones.
 - **Commit trailer (every commit):**
@@ -40,7 +40,7 @@
 | `apps/api/src/db/rlsPolicyShape.ts` (new, pure) | Predicate-shape matchers: alias discovery for `FROM <parent> [AS] <alias>`, helper-on-parent-alias check (`any-of` / `all-of`), org-axis argument check, command→slot coverage (`coveredCommands`). No DB import. |
 | `apps/api/src/db/rlsPolicyShape.test.ts` (new) | Fixture-driven unit test for the module (Test API job). |
 | `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts` | D4 catalog entries; D5 exhaustive classification + `PLATFORM_INFRASTRUCTURE_TABLES` + `UNREVIEWED_RLS_CLASSIFICATION_DEBT`; D6a/D6b command-specific tests + `PARENT_FK_REQUIRED_PARENTS_PER_COMMAND`; D7 forge describe. |
-| `apps/api/migrations/2026-09-30-100000-script-children-rls.sql` (new) | D1–D3 DDL. |
+| `apps/api/migrations/2026-10-01-100000-script-children-rls.sql` (new) | D1–D3 DDL. |
 | `apps/api/src/__tests__/integration/scriptBundleRls.integration.test.ts` (new) | D8 bundle-import regression under real RLS (org / partner-wide / system callers). |
 
 Commit order (spec §4): (1) plan doc → (2) shape module + unit test → (3) catalog + D5 RED→partial-GREEN → (4) D6a/D6b → (5) D7 forge, committed RED → (6) migration, everything green → (7) D8 regression + mutation proof → (8) push + draft PR. Intermediate commits are allowed to be red in CI; the PR head must be green.
@@ -664,7 +664,7 @@ Add to `PARENT_FK_JOIN_POLICY_TABLES` immediately after the `['ticket_form_org_l
   // RMM-QA-220: script_versions (script content history) and script_to_tags
   // (script↔tag join) shipped in the baseline with NO rls and reach their
   // tenant only through scripts (dual-axis, nullable org_id, is_system) and
-  // script_tags (dual-axis). See 2026-09-30-100000-script-children-rls.sql.
+  // script_tags (dual-axis). See 2026-10-01-100000-script-children-rls.sql.
   // script_to_tags additionally carries a per-command both-parents overlay
   // (PARENT_FK_REQUIRED_PARENTS_PER_COMMAND below).
   ['script_versions', ['scripts']],
@@ -968,7 +968,7 @@ Change `import { eq, sql } from 'drizzle-orm';` to `import { and, eq, inArray, s
 // ---------------------------------------------------------------------------
 // Both tables reach their tenant only through `scripts` (dual-axis, nullable
 // org_id, is_system) and `script_tags` (dual-axis). Migration under test:
-// 2026-09-30-100000-script-children-rls.sql. Runs as `breeze_app` under real
+// 2026-10-01-100000-script-children-rls.sql. Runs as `breeze_app` under real
 // contexts, modelled on the scripts partner-wide block above: self-contained
 // fixtures seeded under system scope, cleanup by id in afterAll.
 //
@@ -1311,7 +1311,7 @@ Claude-Session: https://claude.ai/code/session_01E9p3mtFLSv8SFcZ9fcn8Vu"
 ### Task 5: The migration (D1–D3) — everything goes green; idempotency, fresh-DB apply, manual `breeze_app` forge, catalog proof
 
 **Files:**
-- Create: `apps/api/migrations/2026-09-30-100000-script-children-rls.sql`
+- Create: `apps/api/migrations/2026-10-01-100000-script-children-rls.sql`
 
 **Interfaces:**
 - Produces: policies `breeze_org_isolation_{select,insert,update,delete}` on `public.script_versions` and `public.script_to_tags`; RLS ENABLED + FORCED on both. Consumed by every test from Tasks 2–4 and by Task 6.
@@ -1325,7 +1325,7 @@ Expected: `2026-09-29-detach-ticket-runs-on-device-org-move.sql`. If main has mo
 
 - [ ] **Step 2: Write the migration**
 
-Create `apps/api/migrations/2026-09-30-100000-script-children-rls.sql`:
+Create `apps/api/migrations/2026-10-01-100000-script-children-rls.sql`:
 
 ```sql
 -- 2026-09-30-100000: forced parent-join RLS for the two script CHILD tables
@@ -1520,7 +1520,7 @@ CREATE POLICY breeze_org_isolation_delete ON public.script_to_tags FOR DELETE US
 - [ ] **Step 3: Naming guard + static migration test**
 
 ```bash
-cd "$WT" && git add apps/api/migrations/2026-09-30-100000-script-children-rls.sql
+cd "$WT" && git add apps/api/migrations/2026-10-01-100000-script-children-rls.sql
 bash scripts/check-migration-naming.sh --staged 2>&1 | tee "$LOGS/task5-naming.log" | tail -3
 pnpm --filter @breeze/api exec vitest run src/db/autoMigrate.test.ts 2>&1 | tee "$LOGS/task5-automigrate-unit.log" | tail -4
 ```
@@ -1547,8 +1547,8 @@ WHERE schemaname = 'public' AND tablename IN ('script_versions', 'script_to_tags
 ORDER BY 1, 2;
 SQL
 docker exec -i "$PG" psql -U breeze_test -d breeze_test -At < "$LOGS/policy-snapshot.sql" > "$LOGS/task5-policies-1.txt"
-docker exec -i "$PG" psql -U breeze_test -d breeze_test -v ON_ERROR_STOP=1 < apps/api/migrations/2026-09-30-100000-script-children-rls.sql > "$LOGS/task5-reapply-1.log" 2>&1
-docker exec -i "$PG" psql -U breeze_test -d breeze_test -v ON_ERROR_STOP=1 < apps/api/migrations/2026-09-30-100000-script-children-rls.sql > "$LOGS/task5-reapply-2.log" 2>&1
+docker exec -i "$PG" psql -U breeze_test -d breeze_test -v ON_ERROR_STOP=1 < apps/api/migrations/2026-10-01-100000-script-children-rls.sql > "$LOGS/task5-reapply-1.log" 2>&1
+docker exec -i "$PG" psql -U breeze_test -d breeze_test -v ON_ERROR_STOP=1 < apps/api/migrations/2026-10-01-100000-script-children-rls.sql > "$LOGS/task5-reapply-2.log" 2>&1
 docker exec -i "$PG" psql -U breeze_test -d breeze_test -At < "$LOGS/policy-snapshot.sql" > "$LOGS/task5-policies-2.txt"
 diff "$LOGS/task5-policies-1.txt" "$LOGS/task5-policies-2.txt" && echo IDEMPOTENT && wc -l < "$LOGS/task5-policies-2.txt"
 grep -c 'NOTICE' "$LOGS/task5-reapply-2.log" || true
@@ -1620,7 +1620,7 @@ Expected: both rows `rls_enabled=true, force_rls=true`, privileges unchanged (`a
 
 ```bash
 cd "$WT" && NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @breeze/api exec tsc --noEmit 2>&1 | tail -3
-git add apps/api/migrations/2026-09-30-100000-script-children-rls.sql
+git add apps/api/migrations/2026-10-01-100000-script-children-rls.sql
 git commit -m "fix(rls): forced parent-join RLS for script_versions and script_to_tags (RMM-QA-220)
 
 Both tables shipped in 0001-baseline.sql with RLS off while breeze_app
@@ -1672,7 +1672,7 @@ Why this file and not the rls-coverage suite: `importBundle` writes through the 
 ```ts
 /**
  * Script bundle import under REAL RLS on script_versions / script_to_tags
- * (RMM-QA-220, migration 2026-09-30-100000-script-children-rls.sql).
+ * (RMM-QA-220, migration 2026-10-01-100000-script-children-rls.sql).
  *
  * importBundle authorises the parent script through resolveScriptCreateScope
  * and then INSERTs script_to_tags (linkTags) and, in `new-version` mode,
@@ -1861,7 +1861,7 @@ CREATE POLICY breeze_org_isolation_insert ON public.script_versions FOR INSERT W
 );
 SQL
 pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts src/__tests__/integration/scriptBundleRls.integration.test.ts 2>&1 | tee "$LOGS/task6-mutation.log" | grep -E '✓|✗|×|FAIL|row-level security' | head -12
-docker exec -i "$PG" psql -U breeze_test -d breeze_test -v ON_ERROR_STOP=1 < apps/api/migrations/2026-09-30-100000-script-children-rls.sql > "$LOGS/task6-restore.log" 2>&1
+docker exec -i "$PG" psql -U breeze_test -d breeze_test -v ON_ERROR_STOP=1 < apps/api/migrations/2026-10-01-100000-script-children-rls.sql > "$LOGS/task6-restore.log" 2>&1
 pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts src/__tests__/integration/scriptBundleRls.integration.test.ts 2>&1 | tee "$LOGS/task6-green-after-restore.log" | tail -6
 ```
 Expected: with the partner branch removed, test (b) FAILS (`importBundle` throws `new row violates row-level security policy for table "script_versions"` because the partner-wide script has `org_id NULL`); (a), (c) and the cross-check still pass. After re-applying the migration file: 4 pass.
@@ -1882,7 +1882,7 @@ Discrimination proof (once, on the per-worktree DB): re-created
 script_versions' INSERT policy WITHOUT the breeze_has_partner_access
 branch -> (b) partner-wide import failed with 'new row violates row-level
 security policy for table \"script_versions\"' (task6-mutation.log); re-
-applied 2026-09-30-100000-script-children-rls.sql -> 4/4 green.
+applied 2026-10-01-100000-script-children-rls.sql -> 4/4 green.
 
 Refs RMM-QA-220.
 
@@ -1961,7 +1961,7 @@ Design: `docs/superpowers/specs/2026-09-01-rmm-qa-220-script-children-rls-design
 ```text
 Finding IDs: RMM-QA-220
 Branch / commit / PR: fix/rmm-qa-220-script-children-rls / <head sha> (base origin/main 1b733cedb) / this PR (draft)
-Behavior changed: script_versions and script_to_tags now have RLS ENABLED + FORCED with four per-command policies each (2026-09-30-100000-script-children-rls.sql). script_versions SELECT mirrors scripts' read predicate (org OR partner OR is_system OR own-partner read branch); INSERT/UPDATE/DELETE mirror scripts' write predicate only. script_to_tags SELECT requires script read AND tag read; INSERT requires script WRITE AND tag READ; UPDATE USING script WRITE, WITH CHECK script WRITE AND tag READ; DELETE script WRITE. No app-layer code changed; breeze_app privileges unchanged (RLS is the defense, ensureAppRole untouched).
+Behavior changed: script_versions and script_to_tags now have RLS ENABLED + FORCED with four per-command policies each (2026-10-01-100000-script-children-rls.sql). script_versions SELECT mirrors scripts' read predicate (org OR partner OR is_system OR own-partner read branch); INSERT/UPDATE/DELETE mirror scripts' write predicate only. script_to_tags SELECT requires script read AND tag read; INSERT requires script WRITE AND tag READ; UPDATE USING script WRITE, WITH CHECK script WRITE AND tag READ; DELETE script WRITE. No app-layer code changed; breeze_app privileges unchanged (RLS is the defense, ensureAppRole untouched).
 Exit-contract clauses proved: (1) idempotent forced parent-join policies preserving reviewed system-script behavior (forge rows 13/14: system version readable, never writable) and preventing cross-tenant pairing (rows 5, 12, 16); (2) exhaustive table classification registers both tables (D5 test + PARENT_FK_JOIN_POLICY_TABLES entries); (3) real breeze_app Org A/B and Partner A/B tests: same-tenant success (rows 1, 2, 8, 11), foreign SELECT hidden (3, 7, 10), forged INSERT rejected (4, 5, 7, 9, 12, 14), foreign UPDATE/DELETE ineffective (6, 15); (4) command-specific policy-shape checks validate USING/WITH CHECK/helper argument for all 32 parent-FK tables (both-parents overlay for script_to_tags) and all asserted org-axis tables.
 Exit-contract clauses still open: none on the two script children at the DB layer; QA-side re-characterisation of the probe blocks core-tenant-isolation-release-contract.test.ts:151-177 (they pin the pre-fix state and now invert) and candidate-bound retest are QA's.
 Tests run and exact results: rlsPolicyShape.test.ts 22/22 PASS (unit; mutations A–E each observed red then reverted); autoMigrate.test.ts PASS; scriptBundle/index.test.ts PASS; test:rls-coverage <N>/<N> PASS on a fresh per-worktree DB (RED before the migration: force test + parent-FK tests naming both tables, forge negatives <list>); scriptBundleRls.integration.test.ts 4/4 PASS (mutation: INSERT policy without partner branch -> partner-wide import fails with the RLS violation; restored -> 4/4); scripts-system-rls, scripts-soft-delete, tenantCascade, orgMergeRegistry, tenant-export-policy integration suites PASS; tsc clean; check:migrations from an empty DB OK; migration applied twice -> identical pg_policies (8 rows).

--- a/docs/superpowers/specs/2026-09-01-rmm-qa-220-script-children-rls-design.md
+++ b/docs/superpowers/specs/2026-09-01-rmm-qa-220-script-children-rls-design.md
@@ -53,7 +53,7 @@ The brief's line references were re-read after the fast-forward. The six new com
 
 ### D1 — One new idempotent migration, canonical child shape, no `BEGIN/COMMIT`
 
-File: `apps/api/migrations/2026-09-30-100000-script-children-rls.sql`. Re-verify the ceiling at commit time with `bash scripts/check-migration-naming.sh --staged` (pre-commit hook); if main has grown past `2026-09-30-100000-*`, pick the next `HHMMSS` that sorts strictly after the new max — never rename after commit. Content per table: `DROP POLICY IF EXISTS` ×4, `ALTER TABLE … ENABLE ROW LEVEL SECURITY`, `ALTER TABLE … FORCE ROW LEVEL SECURITY`, four per-command `CREATE POLICY` named `breeze_org_isolation_{select,insert,update,delete}` (F8 convention). `DROP IF EXISTS` + `CREATE` converges, so no `DO $$` guard; no data cleanup, so no row-count `RAISE WARNING` obligation. Header comment states: threat (RMM-QA-220), shape, why `is_system` never appears in a write predicate (pointer to `catalog-partner-axis-rls.sql:62-68`, #633), the D3 tag-visibility asymmetry, the F10/F12 bound-parameter note, and F7 (nested EXISTS is additionally filtered by the parents' own policies).
+File: `apps/api/migrations/2026-10-01-100000-script-children-rls.sql`. Re-verify the ceiling at commit time with `bash scripts/check-migration-naming.sh --staged` (pre-commit hook); if main has grown past `2026-09-30-100000-*`, pick the next `HHMMSS` that sorts strictly after the new max — never rename after commit. Content per table: `DROP POLICY IF EXISTS` ×4, `ALTER TABLE … ENABLE ROW LEVEL SECURITY`, `ALTER TABLE … FORCE ROW LEVEL SECURITY`, four per-command `CREATE POLICY` named `breeze_org_isolation_{select,insert,update,delete}` (F8 convention). `DROP IF EXISTS` + `CREATE` converges, so no `DO $$` guard; no data cleanup, so no row-count `RAISE WARNING` obligation. Header comment states: threat (RMM-QA-220), shape, why `is_system` never appears in a write predicate (pointer to `catalog-partner-axis-rls.sql:62-68`, #633), the D3 tag-visibility asymmetry, the F10/F12 bound-parameter note, and F7 (nested EXISTS is additionally filtered by the parents' own policies).
 
 Cost if wrong: a mis-sorted filename replays before its parents on a fresh DB — caught by the pre-commit hook and `autoMigrate.test.ts`.
 
@@ -107,7 +107,7 @@ Add to `PARENT_FK_JOIN_POLICY_TABLES` (`rls-coverage:584`), replacing nothing:
   // RMM-QA-220: script_versions (script content history) and script_to_tags
   // (script↔tag join) shipped in the baseline with NO rls and reach their
   // tenant only through scripts (dual-axis, nullable org_id, is_system) and
-  // script_tags (dual-axis). See 2026-09-30-100000-script-children-rls.sql.
+  // script_tags (dual-axis). See 2026-10-01-100000-script-children-rls.sql.
   ['script_versions', ['scripts']],
   ['script_to_tags', ['scripts', 'script_tags']],
 ```
@@ -207,7 +207,7 @@ Per CLAUDE.md:149-157 a read-only Codex review (`codex exec … -s read-only -m 
 
 | File | Change | Guard |
 | --- | --- | --- |
-| `apps/api/migrations/2026-09-30-100000-script-children-rls.sql` (new) | D1–D3 DDL; idempotent; no transaction block; header as D1. | `autoMigrate.test.ts`; `check-migration-naming.sh --staged`; re-apply on a migrated DB is a no-op (run twice, `pg_policies` unchanged). |
+| `apps/api/migrations/2026-10-01-100000-script-children-rls.sql` (new) | D1–D3 DDL; idempotent; no transaction block; header as D1. | `autoMigrate.test.ts`; `check-migration-naming.sh --staged`; re-apply on a migrated DB is a no-op (run twice, `pg_policies` unchanged). |
 | `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts` | D4 two catalog entries; D5 new test + `PLATFORM_INFRASTRUCTURE_TABLES` + `UNREVIEWED_RLS_CLASSIFICATION_DEBT`; D6a/D6b new tests + `PARENT_FK_REQUIRED_PARENTS_PER_COMMAND` (+ `RLS_SHAPE_TRIAGE` only if the fresh-DB simulation demands it); D7 forge describe; schema imports (`scripts`, `scriptTags`, `scriptToTags`, `scriptVersions`). No existing assertion is weakened or removed. | `pnpm --filter=@breeze/api test:rls-coverage` on a fresh migrated DB with `DATABASE_URL_APP` and `DB_CONTEXTLESS_WRITE_STRICT=true`. |
 | `apps/api/src/db/rlsPolicyShape.ts` (new) | D6 pure matchers; no DB import; imported by the contract test as `../../db/rlsPolicyShape`. | `rlsPolicyShape.test.ts`. |
 | `apps/api/src/db/rlsPolicyShape.test.ts` (new) | D6 fixture-driven unit test; runs in **Test API** only (F20). | Test API job. |

--- a/docs/superpowers/specs/2026-09-01-rmm-qa-220-script-children-rls-design.md
+++ b/docs/superpowers/specs/2026-09-01-rmm-qa-220-script-children-rls-design.md
@@ -1,0 +1,309 @@
+# RMM-QA-220 Script Children RLS Design
+
+**Finding:** RMM-QA-220 (S1, Core/Scripts/Database tenant isolation). `script_versions` and `script_to_tags` are tenant child tables without `org_id` that ship with RLS disabled and unforced while `breeze_app` holds blanket SELECT/INSERT/UPDATE/DELETE. `script_versions` carries customer script content and history; `script_to_tags` can pair a script with a tag across tenants. Neither table is in any allowlist of `rls-coverage.integration.test.ts`, so the contract suite is green while the CLAUDE.md invariant "every tenant-scoped table MUST have RLS enabled + forced + policies — no app-layer-only fallback" is violated.
+
+**Goal:** Land forced parent-join RLS on both tables that mirrors the reviewed `scripts`/`script_tags` policy semantics exactly (system-script global read, partner-wide own-partner read branch, org-or-partner writes, no `is_system` in any write predicate); make the RLS coverage catalog exhaustive over every public base table so this class cannot recur silently; tighten the policy-shape assertions to command-specific USING/WITH CHECK with the helper applied to the right argument; and prove the enforcement behaviourally as `breeze_app` for Org A/B and Partner A/B. Every behaviour change is RED-first; every new control is proven to discriminate by mutation.
+
+**Branch / worktree:** `fix/rmm-qa-220-script-children-rls` at `/private/tmp/claude-501/-Users-toddhebebrand-breeze-rmm-qa/096c7d0d-b990-4dcd-8885-640bde845261/scratchpad/s1wt/rmm-qa-220`. Originally created from `origin/main` at `0fb5af40d`; **main moved by six commits during design** (`7ca3b8331` … `1b733cedb`) and the branch — which carried no commits of its own — was fast-forwarded to `1b733cedb` on 2026-09-01. Never push to `main`, never merge.
+
+**Method note:** every claim below is labelled *verified* (read in the worktree at `1b733cedb` or executed against the local test database), *inferred*, or *not-checked*. The local database `breeze-postgres-test` (port 5433, `breeze_test/breeze_test`) is migrated through `2026-09-20-sso-verified-domains-dual-axis.sql` (`SELECT max(filename) FROM breeze_migrations`) — ten migrations behind the worktree's ceiling `2026-09-29-detach-ticket-runs-on-device-org-move.sql` — so every database-derived fact carries that caveat and must be re-established on a fresh migrated database during implementation.
+
+## Non-goals and boundaries
+
+- No change to `apps/api/src/db/ensureAppRole.ts`. The blanket grant (`:85,:87`, *verified*) is the platform-wide model for every table; RLS is the defense, not privilege withdrawal. Withdrawing DML from `breeze_app` on two tables would create a third tenancy mechanism no contract test understands.
+- No edit to any shipped migration. `0001-baseline.sql` (tables at `:5200` and `:5210`, FKs at `:14304-14316`, *verified*) stays byte-identical.
+- No app-layer changes in `services/scriptBundle/index.ts`, `services/aiToolsScripts.ts` or `routes/scripts.ts`; the existing callers already authorise the parent and must keep working unchanged under the new policies. If a caller breaks, the policy is wrong, not the caller.
+- No new versions endpoint (web `ScriptVersionHistory.tsx:83-84` notes none exists — per the brief, *not re-checked*); out of scope.
+- No cascade-list registration: neither table has `org_id` or `device_id`, so no `tenantCascade.ts` / `routes/devices/core.ts` / export-policy row applies (CLAUDE.md:74 "A table with no `org_id` needs no entry"; *verified* `tenantCascade.ts` names only `script_categories`, `script_execution_batches`, `script_executions`, `script_tags`, `scripts` at `:350-354`; `orgMergeRegistry.ts:609-613` likewise — children follow their parents by id).
+- No change to the parent tables `scripts` / `script_tags` (no composite ownership FK, no `is_system ⇒ NULL axes` CHECK). The advisor quorum raised both as real parent-level gaps (§9); they are pre-existing, touch shipped parent schema and existing data, and are handed back as candidate findings, not folded under this S1.
+- No change to the `NO ACTION` FKs or to org/partner erasure. The quorum confirmed a latent erasure `23503` (§9, §8.3); it is RLS-independent and unchanged by this work.
+- The other tables the exhaustive classification test surfaces (D5) are NOT fixed here. They go into a shrink-only debt list and back to QA as candidate findings, never blessed as reviewed.
+- The QA probe `docs/qa/probes/core-tenant-isolation-release-contract.test.ts` (breeze-rmm-qa repo) is not edited. Its RMM-QA-220 block at `:151-166` pins the PRE-fix state (`between(rlsCoverage, "const PARENT_FK_JOIN_POLICY_TABLES", "const USER_ID_SCOPED_TABLES")` must NOT contain the two names) and the next block at `:168-177` pins the org-axis test's helper-name-anywhere shape (*verified*). Both are expected to flip once this branch lands; the QA side owns the re-characterisation.
+
+## 1. Verified facts (current main, worktree at 1b733cedb)
+
+The brief's line references were re-read after the fast-forward. The six new commits touch `apps/web`, billing/quote services, `policyEvaluationService`, `automations` schema and one new migration `2026-09-29-100000-automation-policy-compliance-unique.sql` — none touches the two script children, `rls-coverage.integration.test.ts`, `scriptBundle`, or the parent policies (*verified* `git diff --name-only 0fb5af40d 1b733cedb`). The migration ceiling is unchanged: `2026-09-29-100000-…` sorts before `2026-09-29-detach-…` (`'1' < 'd'`).
+
+| # | Fact | Evidence |
+| --- | --- | --- |
+| F1 | Both tables exist only in `0001-baseline.sql`: `script_to_tags(script_id, tag_id)` `:5200-5203`; `script_versions(id, script_id, version, content, changelog, created_by, created_at)` `:5210-5218`; FKs `script_to_tags.script_id → scripts(id)` `:14303-14308` (constraint at `:14305`) and `.tag_id → script_tags(id)` `:14314-14319` (constraint at `:14316`), both default `NO ACTION`. No later migration names either table (`git grep -l -E 'script_versions|script_to_tags' origin/main -- apps/api/migrations` → only `0001-baseline.sql`). No `ENABLE`/`FORCE ROW LEVEL SECURITY`, no `CREATE POLICY`. | *verified*. |
+| F2 | `breeze_app` receives `GRANT SELECT, INSERT, UPDATE, DELETE, REFERENCES ON ALL TABLES IN SCHEMA public` plus matching `ALTER DEFAULT PRIVILEGES` (`ensureAppRole.ts:85,87`). | *verified*. |
+| F3 | On the local DB both tables report `relrowsecurity=false, relforcerowsecurity=false` — the exact QA catalog proof (`docs/qa/evidence/2026-08-23-core-tenant-isolation.md:31-35`). | *verified* (2026-09-20 DB). |
+| F4 | Parent `scripts` policies (`2026-06-13-catalog-partner-axis-rls.sql:55-77`, SELECT re-created by `2026-06-13-catalog-partner-read-branch.sql:69-76`): SELECT `USING (breeze_has_org_access(org_id) OR breeze_has_partner_access(partner_id) OR is_system OR (org_id IS NULL AND partner_id = breeze_current_partner_id()))`; INSERT `WITH CHECK (org OR partner)`; UPDATE `USING (org OR partner) WITH CHECK (org OR partner)`; DELETE `USING (org OR partner)`. The comment at `:62-68` forbids `is_system` in any write predicate (Discussion #633). | *verified*. |
+| F5 | Parent `script_tags`: dual-axis per-command policies with the same write predicate; SELECT gained the read-only own-partner branch at `catalog-partner-read-branch.sql:97-104` (no system flag). Both parents are registered as `PARTNER_TENANT_TABLES` entries (`rls-coverage:210,212`). | *verified*. |
+| F6 | Helper semantics: `breeze_has_org_access(uuid)` (`0008-tenant-rls.sql:42-52`) and `breeze_has_partner_access(uuid)` (`2026-04-11-partners-rls.sql:58-68`) both return TRUE under system scope, FALSE for NULL, else membership in the accessible-ids GUC arrays; `breeze_current_partner_id()` (`catalog-partner-read-branch.sql:36-60`) reads `breeze.current_partner_id`. Under `withSystemDbAccessContext` every write predicate is therefore TRUE. | *verified*. |
+| F7 | A nested `EXISTS (SELECT 1 FROM scripts s …)` inside a child policy runs as `breeze_app`, so the parent's own SELECT policy applies to the subquery. Child visibility can never exceed parent visibility, whatever the child predicate says. | *inferred* from Postgres semantics; the D7 forge tests observe the combined effect. |
+| F8 | Canonical child shape: `2026-05-30-fk-child-tables-rls.sql:1-60` — `DROP POLICY IF EXISTS` ×4, `ENABLE` + `FORCE`, four per-command policies named `breeze_org_isolation_{select,insert,update,delete}`, predicate `EXISTS (SELECT 1 FROM <parent> a WHERE a.id = <child>.<fk> AND breeze_has_org_access(a.org_id))`; file header states "no inner BEGIN/COMMIT". | *verified*. |
+| F9 | Shipped precedent for a nested EXISTS with a system carve-out in SELECT: `role_permissions` (`2026-06-13-b-fk-child-rls-backstop.sql:120-127`) ORs `breeze_has_partner_access(r.partner_id)`, `breeze_has_org_access(r.org_id)` and an `r.is_system` branch; read with a bound `roleId` in `services/permissions.ts` (quorum-cited, *not re-checked*). | *verified* (policy), *inferred* (caller). |
+| F10 | The bound-parameter caveat (`rls-coverage:588-591`; `2026-05-31-script-execution-batches-org-id.sql:4-17`) concerns an **INSERT** `WITH CHECK` containing `s.is_system` for a tenant creating a batch on a system script. | *verified*. |
+| F11 | Every non-test reader/writer of the two tables (`grep -rn -E 'scriptVersions|script_versions|scriptToTags|script_to_tags' src --include='*.ts'` minus `__tests__`, `*.test.ts`, `schema/`): `aiToolsScripts.ts:728-740` SELECT versions by `scriptId` after the parent was authorised; `scriptBundle/index.ts:367-372` SELECT links for readable scripts; `:617-626` SELECT+INSERT links (`linkTags`); `:767-775` INSERT version (`new-version` mode, `createdBy: auth.user.id`) immediately followed by the parent UPDATE at `:776-791`. `routes/scripts.ts` has no version/tag DML. | *verified*. |
+| F12 | The bundle importer can never write a child of a system script: `findConflictByName` (`scriptBundle/index.ts:469-494`) matches only the target scope or the caller's own partner-wide rows (a system script has `org_id IS NULL AND partner_id IS NULL` and matches neither); an org-scope import of a partner-wide conflict in `new-version` mode is refused at `:751-764` ("read-only for an organization import"); new parents are clamped non-system (`scriptWrite.ts`, `isSystem` clamp; `scriptBundle/index.ts:14-16`). So no request path INSERTs a `script_versions` row whose parent is `is_system`. | *verified*. |
+| F13 | Existing catalog: `EXEMPT_TABLES` `:48-62`, `INTENTIONAL_UNSCOPED` `:78-109`, `ORG_AXIS_POLICY_EXCLUDED_TABLES` `:115`, `ORG_ID_KEYED_TENANT_TABLES` `:170`, `PARTNER_TENANT_TABLES` `:177`, `DUAL_AXIS_TENANT_TABLES` `:306`, `DEVICE_ID_JOIN_POLICY_TABLES` `:562`, `PARENT_FK_JOIN_POLICY_TABLES` `:584-647` (30 entries), `USER_ID_SCOPED_TABLES` `:649`. Neither script child appears anywhere. | *verified*. |
+| F14 | Force test `:893-948` unions `org_id`-column tables with the explicit lists; parent-FK assertion `:1295-1358` accepts helper-name anywhere in `qual OR with_check` plus `LIKE '%FROM <parent>%'` with parents OR'd; org-axis assertion `:1057-1121` is the same helper-name-anywhere shape. Every `relkind='r'` query in the file is per-shape (`:911,919,1068,1079,1137,1193,1247,1316,1368,3841,3895`); nothing enumerates all public relations. | *verified*. |
+| F15 | Behavioural forge precedent: `describe('scripts RLS — partner-wide cross-partner forge enforcement (dual-axis)')` `:3005-3168` — self-contained fixtures via `withSystemDbAccessContext`, `partnerContext(partnerId)` and `orgContext(orgId, ownPartnerId)` helpers (`:3044-3059`), `afterAll` cleanup by id, violations matched by `new row violates row-level security policy for table "scripts"`. | *verified*. |
+| F16 | Simulating the D6 command-specific algorithm (`scratchpad/shape_check.py` over `pg_policies` exported to `parentfk-policies.tsv`) against all 30 current `PARENT_FK_JOIN_POLICY_TABLES` entries: 30/30 OK, including dual-axis-parent children (`automation_runs`, `role_permissions`, `config_policy_*`, `psa_ticket_mappings`, `ticket_form_org_links`). Deparsed predicates can contain newlines — normalise whitespace first. | *verified* (2026-09-20 DB); **re-run on a fresh DB** before committing D6. |
+| F17 | Simulating the same per-command rule on org-axis tables (`org_id` column, helper `breeze_has_org_access([alias.]org_id)` in the command-appropriate predicate; SQL in §5): 285 tables, 16 fail on all four commands — 15 of them are `ORG_AXIS_POLICY_EXCLUDED_TABLES` members (partner-axis / user-axis tables that merely carry `org_id`) and the 16th, `m365_consent_sessions`, is `EXEMPT_TABLES`. Zero offenders among the tables the org-axis test actually asserts on. | *verified* (2026-09-20 DB); **re-run on a fresh DB**. |
+| F18 | Public base tables with RLS off or unforced on the local DB (`relkind IN ('r','p') AND NOT relispartition`): `agent_versions, breeze_migrations, cis_check_catalog, device_commands, device_software, intent_outbox, llm_provider_catalog, llm_provider_catalog_revisions, llm_provider_verifications, mobile_sessions, patches, permissions, plugin_catalog, script_templates, script_to_tags, script_versions, software_compliance_status, third_party_package_catalog, third_party_release_tests` (19). Seven are `INTENTIONAL_UNSCOPED`; twelve are in no list. `metric_rollups` is the only `relkind='p'`; its six table partitions are all forced (the 18 other `relispartition` rows are index partitions). | *verified* (2026-09-20 DB); post-09-20 tables are *not-checked*. |
+| F19 | Migration conventions: `localeCompare` order; a new file must sort strictly after the committed max (`scripts/check-migration-naming.sh:29-48`, `--staged`); preferred `YYYY-MM-DD-HHMMSS-<slug>.sql` (`migrations/README.md:140-146`); no inner `BEGIN;`/`COMMIT;` (`README.md:54-56`, CLAUDE.md). The verifier's note that "some recent migrations wrap in BEGIN/COMMIT" is **refuted**: `grep -l '^BEGIN;' apps/api/migrations/2026-09-*.sql` returns nothing. | *verified*. |
+| F20 | Runners: unit `vitest.config.ts:15-16` includes `src/**/*.test.ts` and excludes `src/__tests__/integration/**`; integration `vitest.integration.config.ts:11-12` includes `src/__tests__/integration/**/*.test.ts`; `vitest.config.rls-coverage.ts:18` includes only `rls-coverage.integration.test.ts`; CI runs it on shard 1 with `DATABASE_URL_APP` and `DB_CONTEXTLESS_WRITE_STRICT=true` (`ci.yml:1997-2020`). `setup.ts` TRUNCATE CASCADE list includes `scripts` (`:236`). | *verified*. |
+| F21 | `scripts` are soft-deleted (`schema/scripts.ts:50`); erasure runs under system scope (`tenantCascade.ts`); FK RI checks bypass RLS. FORCE RLS on the children therefore changes nothing about erasure/merge/move. | *verified* (RLS consequence); erasure's pre-existing FK gap is §8.3. |
+| F22 | Drizzle carries no `pgPolicy` for any table (`grep -rl pgPolicy src/db/schema` → none) and `check-drift.ts` does not inspect policies (quorum-cited), so `db:check-drift` is unaffected. | *verified* (grep), *inferred* (check-drift). |
+
+## 2. Decisions
+
+### D1 — One new idempotent migration, canonical child shape, no `BEGIN/COMMIT`
+
+File: `apps/api/migrations/2026-09-30-100000-script-children-rls.sql`. Re-verify the ceiling at commit time with `bash scripts/check-migration-naming.sh --staged` (pre-commit hook); if main has grown past `2026-09-30-100000-*`, pick the next `HHMMSS` that sorts strictly after the new max — never rename after commit. Content per table: `DROP POLICY IF EXISTS` ×4, `ALTER TABLE … ENABLE ROW LEVEL SECURITY`, `ALTER TABLE … FORCE ROW LEVEL SECURITY`, four per-command `CREATE POLICY` named `breeze_org_isolation_{select,insert,update,delete}` (F8 convention). `DROP IF EXISTS` + `CREATE` converges, so no `DO $$` guard; no data cleanup, so no row-count `RAISE WARNING` obligation. Header comment states: threat (RMM-QA-220), shape, why `is_system` never appears in a write predicate (pointer to `catalog-partner-axis-rls.sql:62-68`, #633), the D3 tag-visibility asymmetry, the F10/F12 bound-parameter note, and F7 (nested EXISTS is additionally filtered by the parents' own policies).
+
+Cost if wrong: a mis-sorted filename replays before its parents on a fresh DB — caught by the pre-commit hook and `autoMigrate.test.ts`.
+
+### D2 — `script_versions`: SELECT mirrors the parent's full read predicate; writes mirror the parent's write predicate
+
+```sql
+-- R(s): identical to scripts.breeze_dual_axis_select
+EXISTS (SELECT 1 FROM scripts s
+        WHERE s.id = script_versions.script_id
+          AND (public.breeze_has_org_access(s.org_id)
+               OR public.breeze_has_partner_access(s.partner_id)
+               OR s.is_system
+               OR (s.org_id IS NULL AND s.partner_id = public.breeze_current_partner_id())))
+-- W(s): identical to scripts.breeze_dual_axis_insert/update/delete
+EXISTS (SELECT 1 FROM scripts s
+        WHERE s.id = script_versions.script_id
+          AND (public.breeze_has_org_access(s.org_id)
+               OR public.breeze_has_partner_access(s.partner_id)))
+```
+
+SELECT `USING R(s)`; INSERT `WITH CHECK W(s)`; UPDATE `USING W(s) WITH CHECK W(s)`; DELETE `USING W(s)`.
+
+- **Open decision 1 (an `is_system` branch on INSERT) is rejected outright**, as the verifier requires: `catalog-partner-axis-rls.sql:62-68` forbids `is_system` in any write predicate, and F12 shows no code path writes `script_versions` for a system script, so the batches precedent (F10) has no INSERT to protect. System seeding runs under system scope where `W(s)` is already TRUE (F6).
+- **`OR s.is_system` stays in SELECT** (verifier concern 2, decided): it mirrors the parent's global-read rule and today governs zero rows (F12). Dropping it would make `aiToolsScripts.ts` `includeVersionHistory` silently return `[]` for a system script whose parent is readable — a divergence that fails invisibly. If a future feature versions system scripts, the product rule that makes the current content world-readable governs its history. Cost if wrong: a later system-script revision containing removed material is readable by every tenant — the same exposure class as the parent row, reversible with a one-line policy change.
+- **Bound-parameter concern (F10) refuted for this design**: the write predicates contain no `is_system` branch; the only `is_system` is in a SELECT predicate whose nested-EXISTS shape is in production on `role_permissions` (F9). The D7 suite runs through Drizzle's extended protocol (bound parameters) and test 13 SELECTs a system script's version by bound `script_id`, so the suite is itself the proof. The quorum concurred (§9).
+- The predicates are spelled out rather than reduced to `EXISTS (SELECT 1 FROM scripts s WHERE s.id = script_id)` (which F7 would make equivalent today) so that the structural checks (D6) can read them and so that a future loosening of the parent's SELECT policy does not silently widen the child.
+
+### D3 — `script_to_tags`: read requires both parents visible; INSERT requires script WRITE and tag READ; UPDATE/DELETE require script WRITE only
+
+```sql
+-- T_read(t): identical to script_tags.breeze_dual_axis_select
+EXISTS (SELECT 1 FROM script_tags t
+        WHERE t.id = script_to_tags.tag_id
+          AND (public.breeze_has_org_access(t.org_id)
+               OR public.breeze_has_partner_access(t.partner_id)
+               OR (t.org_id IS NULL AND t.partner_id = public.breeze_current_partner_id())))
+```
+
+SELECT `USING (R(s) AND T_read(t))`; INSERT `WITH CHECK (W(s) AND T_read(t))`; UPDATE `USING W(s) WITH CHECK (W(s) AND T_read(t))`; DELETE `USING W(s)` — with `R(s)`/`W(s)` re-targeted at `script_to_tags.script_id`.
+
+- Cross-tenant pairing is impossible by construction: inserting `(script, tag)` requires writing the script AND seeing the tag. An org user sees only its own org's tags and its partner's partner-wide tags (F5), so `(own script, other org's tag)` and `(other org's script, own tag)` both fail `WITH CHECK`; cross-partner pairing fails on both legs.
+- **Open decision 2 (strict org equality vs. mirroring) resolved as mirror, not tighten**, per the verifier: a partner-scope technician whose `accessibleOrgIds` covers orgs A and B may link A's script to B's tag exactly as the parents permit today; org-scope users cannot. Strict `s.org_id = t.org_id` would break the partner-wide-first model (partner-wide tags exist to be applied across an MSP's orgs) and would forbid `(org script, partner-wide tag)` — the one cross-scope pairing the product advertises. Cost if wrong: same-partner cross-org pairing by partner technicians, which the parents already allow.
+- **Verifier concern 3 satisfied**: unlink authority (DELETE / UPDATE `USING`) derives from the script's write predicate only; a user who can merely read a partner-wide tag cannot unlink it from another org's script because `W(s)` fails there. UPDATE `WITH CHECK` re-applies the INSERT predicate so an UPDATE cannot re-point `tag_id` at an invisible tag (the quorum flagged exactly this hole in a weaker variant and confirmed this form closes it — §9).
+- INSERT gates on tag **READ**, not tag WRITE, deliberately: an org user attaching its own script to its MSP's partner-wide tag is the partner-wide-first use case; requiring tag WRITE would forbid it while the parent SELECT policy advertises the tag as usable. Precedent: `2026-09-25-a-automation-resource-bindings.sql:397-409` lets org-owned bindings reference system or same-partner shared scripts (*verified*). Cost if wrong: an org user can reference (not modify) a partner-wide tag it can already see.
+
+### D4 — Catalog registration is the RED for the existing contract
+
+Add to `PARENT_FK_JOIN_POLICY_TABLES` (`rls-coverage:584`), replacing nothing:
+
+```ts
+  // RMM-QA-220: script_versions (script content history) and script_to_tags
+  // (script↔tag join) shipped in the baseline with NO rls and reach their
+  // tenant only through scripts (dual-axis, nullable org_id, is_system) and
+  // script_tags (dual-axis). See 2026-09-30-100000-script-children-rls.sql.
+  ['script_versions', ['scripts']],
+  ['script_to_tags', ['scripts', 'script_tags']],
+```
+
+On main this alone turns two existing tests red: the force test (`:893`) reports both names with `force_rls_on=false`, and the parent-FK assertion (`:1295`) reports `rls_on=false, missing_cmds=[SELECT,INSERT,UPDATE,DELETE]`. That failure output is the retained RED for the migration. The existing looser assertion is kept as-is; D6 adds the command-specific ones beside it rather than replacing it, so a future loosening of either is a visible diff.
+
+### D5 — Exhaustive classification of every public base table, with an explicit shrink-only debt bucket
+
+New test in the `RLS coverage contract` describe: `every public base table is classified by exactly one tenancy bucket`. Enumerate `pg_class` rows in `public` with `relkind IN ('r','p') AND NOT relispartition` (verifier concern 4: `metric_rollups` partitions are created at runtime by `breeze_ensure_metric_rollup_partition` and would make the test non-deterministic; the partitioned parent is classified once via its `org_id` column — F18). A table is *classified* when it satisfies at least one of:
+
+1. has an `org_id` column (shape 1 auto-discovery — the same predicate the org-axis test uses at `:1060-1068`), or
+2. is a key of `ORG_ID_KEYED_TENANT_TABLES`, `PARTNER_TENANT_TABLES`, `DUAL_AXIS_TENANT_TABLES`, `DEVICE_ID_JOIN_POLICY_TABLES`, `PARENT_FK_JOIN_POLICY_TABLES`, `USER_ID_SCOPED_TABLES`, `INTENTIONAL_UNSCOPED` or `EXEMPT_TABLES`, or
+3. is in the new `PLATFORM_INFRASTRUCTURE_TABLES` — exactly `breeze_migrations` (the runner's bookkeeping; no tenant data; documented in-line), or
+4. is in the new `UNREVIEWED_RLS_CLASSIFICATION_DEBT` — tables that have neither RLS nor a tenancy classification and were NOT reviewed by RMM-QA-220.
+
+"Exactly one" is enforced where it is meaningful: buckets 3 and 4 must be disjoint from every other bucket and from each other, and every name in buckets 3 and 4 must exist in the database (a stale entry fails the test — shrink-only ratchet). Overlaps among the pre-existing shape lists (e.g. `EXEMPT_TABLES ⊂ INTENTIONAL_UNSCOPED`, dual-axis tables that also carry `org_id`) are pre-existing and not re-litigated. The failure message lists unclassified names and points at the shape table in CLAUDE.md.
+
+Expected RED on main (F18): `agent_versions, breeze_migrations, cis_check_catalog, device_software, mobile_sessions, patches, permissions, plugin_catalog, script_templates, script_to_tags, script_versions, software_compliance_status`. The authoritative list is whatever a fresh migrated DB reports at implementation time (captured verbatim in the commit message). After the fix: the two script children leave via D4; `breeze_migrations` goes to bucket 3; the rest go to bucket 4 with a one-line description per name (`device_software` — `device_id`-keyed, no RLS, candidate shape-5; `mobile_sessions` — `user_id`/refresh-token rows, candidate shape-6; `software_compliance_status` — `device_id`+`policy_id`, candidate shape-5; `agent_versions`, `cis_check_catalog`, `patches`, `permissions`, `plugin_catalog`, `script_templates` — global reference data, candidates for `INTENTIONAL_UNSCOPED` after review). The bucket's doc comment states that inclusion is a tracking fact, not a security review, and that entries may only be removed by moving the table into a real bucket.
+
+Why not fix them here: the exit contract is the two script children; each other name is a separate blast-radius decision (three look like genuine tenant tables) and folding them in would either delay this S1 or ship unreviewed policies under its cover. Cost if wrong: the debt list reads as a blessing — mitigated by its name, its comment, and the QA hand-off in §8.
+
+### D6 — Command-specific USING/WITH CHECK shape checks: parent-FK tables (with both-parent overlay) and org-axis tables, rolled out at once
+
+Two new tests beside `:1295` and `:1057`, sharing one pure module `apps/api/src/db/rlsPolicyShape.ts` (under `src/db/`, not `src/__tests__/integration/`, because the unit runner excludes that directory wholesale while the integration runner includes every `*.test.ts` there — F20; a unit test for a pure function must live where the **Test API** job sees it and the real-DB setup does not):
+
+```ts
+export type PolicyRow = { policyname: string; cmd: string; permissive: string; qual: string | null; with_check: string | null };
+export type Cmd = 'SELECT' | 'INSERT' | 'UPDATE' | 'DELETE';
+export type ParentRule =
+  | { kind: 'any-of'; parents: readonly string[] }                       // default: helper on ANY declared parent alias
+  | { kind: 'all-of'; parents: readonly string[] };                      // overlay: helper on EVERY listed parent alias
+/** Parent-FK: true when `pred` satisfies `rule` — for each required parent, a
+ *  `FROM <parent> [AS] [alias]` join plus breeze_has_org_access(<alias>.org_id)
+ *  or breeze_has_partner_access(<alias>.partner_id). */
+export function predicateCoversParents(pred: string | null, rule: ParentRule): boolean;
+/** Org-axis: true when `pred` calls breeze_has_org_access([<table>.]org_id)
+ *  (or breeze_has_org_access(id) when `idKeyed`). */
+export function predicateCoversOrgAxis(pred: string | null, table: string, idKeyed: boolean): boolean;
+/** Commands covered by `policies` under a per-predicate matcher: SELECT/DELETE from
+ *  qual, INSERT from with_check, UPDATE only when BOTH qual and with_check match;
+ *  cmd='ALL' expands; only PERMISSIVE rows count. */
+export function coveredCommands(policies: readonly PolicyRow[], matches: (pred: string | null, cmd: Cmd, slot: 'qual' | 'with_check') => boolean): Set<Cmd>;
+```
+
+Rules: normalise whitespace (`/\s+/g → ' '`) before matching (F16); alias regex `\bFROM\s+<parent>(?:\s+(?:AS\s+)?([a-z_][a-z0-9_]*))?` with the bare parent name as fallback alias; helper regex `breeze_has_(?:org|partner)_access\(<alias>\.(?:org_id|partner_id)\)`; a helper on the child's own column or on a non-parent alias does not count. Accepting either helper on the parent alias is what makes dual-axis parents fit (verifier concern 5, first half).
+
+**D6a — parent-FK test** iterates `PARENT_FK_JOIN_POLICY_TABLES` with the `any-of` rule (automation_runs legitimately ORs two alternative parents), overlaid by a new `PARENT_FK_REQUIRED_PARENTS_PER_COMMAND` map for tables whose semantics need more than one parent — initially exactly `script_to_tags`: `SELECT` and `INSERT` `all-of ['scripts','script_tags']`; `UPDATE` `qual` `any-of ['scripts']`, `with_check` `all-of ['scripts','script_tags']`; `DELETE` `any-of ['scripts']`. This answers the quorum's "the assertion accepts any one listed parent, so `script_to_tags` could pass without validating `script_tags`" (§9).
+
+**D6b — org-axis test** iterates the same `org_id_tables ∪ id_keyed_tables` set as `:1057` (minus `ORG_AXIS_POLICY_EXCLUDED_TABLES`, minus `EXEMPT_TABLES`) and requires `breeze_has_org_access([<table>.]org_id)` — or `(id)` for `ORG_ID_KEYED_TENANT_TABLES` — in the command-appropriate slot. This closes the blind spot the QA probe pins at `:168-177` (helper name in either predicate; no UPDATE `qual`+`with_check` pairing).
+
+**Open decision 3 resolved: all tables at once**, because F16 (30/30) and F17 (0 offenders among asserted org-axis tables) show every existing entry already passes on the 2026-09-20 DB — the verifier's red-main concern is refuted with evidence rather than deferred. Guard: the plan re-runs both simulations on a fresh DB before committing D6; if a post-09-20 migration reshaped a policy so that it fails, implementation stops and triages that table (fix the policy, or record it in a named `RLS_SHAPE_TRIAGE` exception list with the owning migration) — the assertion is never loosened back to helper-name-anywhere. Cost if wrong: one extra triage step; never a weaker check.
+
+RED-first for this control does not come from the DB (on main the two new entries fail only because they have no policies, which D4 already proves). The discriminating proof is a unit test `apps/api/src/db/rlsPolicyShape.test.ts` (unit runner, no DB) written before the module, with fixtures: helper on parent alias in `qual` → SELECT/DELETE covered; helper only in `with_check` → SELECT NOT covered (the exact blind spot QA named); INSERT with helper only in `qual` → NOT covered; UPDATE with `qual` only → NOT covered; `FROM parent p … breeze_has_org_access(other.org_id)` → NOT covered; helper on the child's own `org_id` → NOT covered; `all-of` with one parent missing → NOT covered; `cmd='ALL'` expands to four; predicate with embedded newlines → covered; RESTRICTIVE policy ignored; org-axis `breeze_has_org_access(id)` accepted only when `idKeyed`. Each assertion is mutated once during implementation (e.g. drop the whitespace normalisation; swap `with_check` for `qual` in the INSERT branch; make `all-of` behave as `any-of`) to watch it fail, then reverted.
+
+### D7 — Behavioural forge suite as `breeze_app`: Org A/B and Partner A/B on both tables
+
+New `describe('script_versions / script_to_tags RLS — parent-join forge enforcement (Org A/B, Partner A/B)')` in `rls-coverage.integration.test.ts`, modelled on F15 (self-contained, no `setup.ts`, fixtures under `withSystemDbAccessContext`, `afterAll` deletes children → scripts → tags → orgs → partners by id).
+
+Fixtures: partners A, B; orgs A1 ∈ A, B1 ∈ B; scripts `sA1` (org A1, partner A), `sB1` (org B1, partner B), `sPA` (partner-wide: org NULL, partner A), `sSys` (`is_system`, org NULL, partner NULL); tags `tA1` (org A1, partner A), `tB1` (org B1, partner B), `tPA` (org NULL, partner A); one `script_versions` row on `sSys` and one on `sPA` seeded under system context; `created_by` left NULL (nullable — F1 — so no `users` rows are needed here). Contexts: `orgContext(A1, A)`, `orgContext(B1, B)`, `orgContext(A1, B)` (mis-set own partner), `partnerContext(A)`, `partnerContext(B)`.
+
+| # | Actor | Action | Expected | Red on main? |
+| --- | --- | --- | --- | --- |
+| 1 | org A1 | INSERT version on `sA1`; SELECT it | 1 row / 1 row | no (positive path) |
+| 2 | org A1 | INSERT link `(sA1, tA1)`; SELECT it | ok / 1 row | no |
+| 3 | org B1 | SELECT `sA1` versions and links | `[]` / `[]` | **yes** |
+| 4 | org B1 | INSERT version on `sA1` | RLS violation `"script_versions"` | **yes** |
+| 5 | org B1 | INSERT `(sB1, tA1)` and `(sA1, tB1)` | RLS violation `"script_to_tags"` ×2 | **yes** |
+| 6 | org B1 | UPDATE changelog / DELETE on A's version; DELETE A's link | 0 rows each; rows intact under system read | **yes** |
+| 7 | partner B | SELECT A's version; INSERT version on `sPA` | `[]`; violation | **yes** |
+| 8 | partner A | INSERT version on `sPA`; INSERT link `(sPA, tPA)` | ok; ok | no |
+| 9 | org A1 | SELECT `sPA` version (read branch); INSERT version on `sPA` | 1 row; violation | INSERT half **yes** |
+| 10 | org A1 with own partner = B | SELECT `sPA` version | `[]` | **yes** |
+| 11 | org A1 | INSERT link `(sA1, tPA)` | ok (tag read branch) | no |
+| 12 | org B1 | INSERT link `(sB1, tPA)` | violation (tag belongs to partner A) | **yes** |
+| 13 | org A1 | SELECT `sSys` version by bound `script_id` | 1 row (`is_system` branch, extended protocol) | no |
+| 14 | org A1 / partner A | INSERT version on `sSys` | violation / violation | **yes** |
+| 15 | org A1 | DELETE own link `(sA1, tA1)`; DELETE `(sPA, tPA)` | 1 row; 0 rows (unlink needs script WRITE) | second half **yes** |
+| 16 | org A1 | UPDATE own link `(sA1, tA1)` SET `tag_id = tB1` | violation (UPDATE `WITH CHECK` tag leg) | **yes** |
+
+Rows marked "no" pass on main because there is no policy to reject anything; they are the same-tenant success half of the exit contract and guard against an over-tight policy. The RED evidence retained in the commit message is the failing set (3–7, 9b, 10, 12, 14, 15b, 16). Violation messages are matched exactly as in F15.
+
+### D8 — Bundle-import regression under real RLS, for org, partner-wide and system callers
+
+New `apps/api/src/__tests__/integration/scriptBundleRls.integration.test.ts` (integration runner; `setup.ts` truncation is fine — `scripts` is in its list and TRUNCATE CASCADE takes the children — F20). It calls `importBundle` directly with a real `BundleAuth` (`scope`, `orgId`, `partnerId`, `accessibleOrgIds`, `canAccessOrg`, `user`) inside `withDbAccessContext(buildDbAccessContext(...))`; because `new-version` sets `createdBy: auth.user.id` (F11) the fixture seeds one real `users` row per partner. It imports a two-entry bundle with tags, then the same bundle with changed content in `new-version` mode, and reads back under system context:
+
+- (a) organization-scope caller → org-owned script (`org_id` set, `partner_id` set): one `script_versions` row (version-1 content), two `script_to_tags` rows — verifier concern 7 (org-axis parent).
+- (b) partner-scope caller with `availability: 'partner'` and the partner-wide capability → partner-wide script (`org_id NULL`): same assertions (partner-axis parent).
+- (c) system-scope caller with an explicit `orgId` → org-owned script: same assertions (system short-circuit).
+
+These pass on main (no policy) and are regression guards, not RED. Their discriminating power is proven once by mutation during implementation: re-create `script_versions`' INSERT policy without the `breeze_has_partner_access` branch on the test DB, watch (b) fail with the RLS violation, then re-apply the migration file. Recorded in the commit message.
+
+### D9 — Advisor quorum: convened, returned, and resolved (§9)
+
+Per CLAUDE.md:149-157 a read-only Codex review (`codex exec … -s read-only -m gpt-5.6-sol -C <worktree> < /dev/null`; prompt `scratchpad/codex-prompt.txt`, output `scratchpad/codex-out.txt`) of D2/D3 was run with five pointed questions. It returned no disagreement with SELECT-only `is_system`, tag READ on INSERT, or the canonical parent-join split, and raised four concrete points; each is resolved in §9 and none changes D1–D3.
+
+## 3. Contracts per file
+
+| File | Change | Guard |
+| --- | --- | --- |
+| `apps/api/migrations/2026-09-30-100000-script-children-rls.sql` (new) | D1–D3 DDL; idempotent; no transaction block; header as D1. | `autoMigrate.test.ts`; `check-migration-naming.sh --staged`; re-apply on a migrated DB is a no-op (run twice, `pg_policies` unchanged). |
+| `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts` | D4 two catalog entries; D5 new test + `PLATFORM_INFRASTRUCTURE_TABLES` + `UNREVIEWED_RLS_CLASSIFICATION_DEBT`; D6a/D6b new tests + `PARENT_FK_REQUIRED_PARENTS_PER_COMMAND` (+ `RLS_SHAPE_TRIAGE` only if the fresh-DB simulation demands it); D7 forge describe; schema imports (`scripts`, `scriptTags`, `scriptToTags`, `scriptVersions`). No existing assertion is weakened or removed. | `pnpm --filter=@breeze/api test:rls-coverage` on a fresh migrated DB with `DATABASE_URL_APP` and `DB_CONTEXTLESS_WRITE_STRICT=true`. |
+| `apps/api/src/db/rlsPolicyShape.ts` (new) | D6 pure matchers; no DB import; imported by the contract test as `../../db/rlsPolicyShape`. | `rlsPolicyShape.test.ts`. |
+| `apps/api/src/db/rlsPolicyShape.test.ts` (new) | D6 fixture-driven unit test; runs in **Test API** only (F20). | Test API job. |
+| `apps/api/src/__tests__/integration/scriptBundleRls.integration.test.ts` (new) | D8 regression suite. | Integration Tests job. |
+| `docs/superpowers/specs/2026-09-01-rmm-qa-220-script-children-rls-design.md` (this file) and the plan it precedes | Design + plan. | — |
+
+Files deliberately untouched: `0001-baseline.sql`, `ensureAppRole.ts`, `scriptBundle/index.ts`, `aiToolsScripts.ts`, `routes/scripts.ts`, `routes/scriptBundle.ts`, `tenantCascade.ts`, `orgMergeRegistry.ts`, `routes/devices/core.ts`, `tenantExportPolicyRegistry.ts`, `db/schema/scripts.ts`.
+
+## 4. RED test list (write first, watch fail, keep the output)
+
+1. **D4 registration** → force test (`:893`) and parent-FK assertion (`:1295`) fail on main naming `script_versions` and `script_to_tags` (`rls_on=false`, four commands missing). Output retained in the migration commit.
+2. **D5 exhaustive classification** → fails on main listing the unclassified set (expected ≥ the 12 names in F18; authoritative list from a fresh DB). Output retained in the test commit; the debt bucket is populated from that output and nothing else.
+3. **D6 unit fixtures** (`rlsPolicyShape.test.ts`) → fail before the module exists; each fixture then mutated once against the implementation (list in D6) and the failure observed, then reverted.
+4. **D6a/D6b DB assertions** → on main, D6a fails only for the two new entries (missing policies) and passes for the 30 existing ones; D6b passes (F16/F17 re-confirmed on a fresh DB, or the triage path runs).
+5. **D7 forge block** → the "yes" rows fail on main; the full failing set is retained in the migration commit message.
+6. **D8 bundle regression** → green before and after; discriminated once by the D8 mutation, recorded in the commit message.
+
+Order of commits: (1) spec + plan docs; (2) `rlsPolicyShape` module + unit test (RED→GREEN, mutation proofs); (3) rls-coverage catalog entries + D5 + D6a/D6b + D7 tests — committed RED with the captured failure output (the retained RED for the migration; CI on that intermediate commit is expected red); (4) migration → all green; (5) D8 regression suite + mutation proof. The PR head must be green; intermediate commits need not be.
+
+## 5. Verification battery
+
+- **Fresh DB**: re-create the disposable test stack (`pnpm --filter=@breeze/api test:docker:up` from scratch, or `docker compose -f docker-compose.test.yml down -v` first), run `pnpm --filter=@breeze/api test:integration` (globalSetup migrates), then `pnpm --filter=@breeze/api test:rls-coverage` with the `ci.yml:2006-2020` environment. Apply the migration twice to prove idempotency.
+- **Shape simulations before D6 commit** (both must be clean or triaged): parent-FK — export `pg_policies` for the 32 catalog tables and run `scratchpad/shape_check.py` (or the new module against the same rows); org-axis — the F17 SQL:
+
+  ```sql
+  WITH org_tables AS (
+    SELECT c.relname FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
+    JOIN information_schema.columns col ON col.table_schema=n.nspname AND col.table_name=c.relname
+    WHERE n.nspname='public' AND c.relkind='r' AND col.column_name='org_id'),
+  cmds AS (SELECT unnest(ARRAY['SELECT','INSERT','UPDATE','DELETE']) AS cmd),
+  cov AS (
+    SELECT t.relname, x.cmd, bool_or(CASE x.cmd
+      WHEN 'SELECT' THEN regexp_replace(coalesce(pp.qual,''),'\s+',' ','g') ~ 'breeze_has_org_access\(([a-z_]+\.)?org_id\)'
+      WHEN 'DELETE' THEN regexp_replace(coalesce(pp.qual,''),'\s+',' ','g') ~ 'breeze_has_org_access\(([a-z_]+\.)?org_id\)'
+      WHEN 'INSERT' THEN regexp_replace(coalesce(pp.with_check,''),'\s+',' ','g') ~ 'breeze_has_org_access\(([a-z_]+\.)?org_id\)'
+      WHEN 'UPDATE' THEN regexp_replace(coalesce(pp.qual,''),'\s+',' ','g') ~ 'breeze_has_org_access\(([a-z_]+\.)?org_id\)'
+                     AND regexp_replace(coalesce(pp.with_check,''),'\s+',' ','g') ~ 'breeze_has_org_access\(([a-z_]+\.)?org_id\)' END) AS ok
+    FROM org_tables t CROSS JOIN cmds x
+    LEFT JOIN pg_policies pp ON pp.schemaname='public' AND pp.tablename=t.relname AND pp.permissive='PERMISSIVE' AND (pp.cmd='ALL' OR pp.cmd=x.cmd)
+    GROUP BY t.relname, x.cmd)
+  SELECT relname, cmd FROM cov WHERE NOT ok ORDER BY 1,2;
+  ```
+
+  On the 2026-09-20 DB the only rows are the 15 `ORG_AXIS_POLICY_EXCLUDED_TABLES` members and `m365_consent_sessions` (EXEMPT), i.e. zero asserted offenders.
+- **Manual forge as `breeze_app`** (CLAUDE.md step 6): `psql` as `breeze_app` with `set_config('breeze.scope','organization',true)` and a foreign org id; `INSERT INTO script_versions …` for another org's script → `new row violates row-level security policy for table "script_versions"`; same for `script_to_tags` with a foreign tag.
+- **Catalog proof re-run**: the QA query from `docs/qa/evidence/2026-08-23-core-tenant-isolation.md:31-35` must return `rls_enabled=true, force_rls=true` for both tables (privileges unchanged, by design).
+- **Unit**: `pnpm --filter=@breeze/api test -- rlsPolicyShape autoMigrate scriptBundle` (the mocked `scriptBundle/index.test.ts` stays green — no service code changes).
+- **Integration**: `scriptBundleRls.integration.test.ts`, `scripts-system-rls.integration.test.ts`, `scripts-soft-delete.integration.test.ts`, `tenantCascade.integration.test.ts`, `orgMergeRegistry.integration.test.ts`, `tenant-export-policy.integration.test.ts` (all expected unchanged-green: no registry touched).
+- **Drift**: `pnpm db:check-drift` (policies are not part of the Drizzle schema — F22; expected clean).
+- **Migration hygiene**: `bash scripts/check-migration-naming.sh --staged` on the commit that adds the file; `autoMigrate.test.ts`.
+- **Typecheck** for `apps/api`.
+- **Post-push**: confirm CI runs attached to the head (branch targets `main`, so `ci.yml` triggers; no stacked-PR blind spot), Integration Tests shard 1 shows the rls-coverage step green, then one independent review round before merge (rigor cap).
+
+## 6. Risk register
+
+| Risk | Mitigation |
+| --- | --- |
+| A post-09-20 migration reshaped a parent-FK or org-axis policy so D6 reds an unrelated table | Re-run both simulations on a fresh DB before committing D6; triage per D6; never loosen. |
+| An unseen writer of the children runs under a context that fails `W(s)` | F11 grep found none outside `scriptBundle`; F12 proves no system-script child writes; D8 covers all three caller scopes; `DB_CONTEXTLESS_WRITE_STRICT` in the rls-coverage job catches context-less writes. |
+| The debt bucket is read as a review | Name, doc comment, and the explicit QA hand-off in §8. |
+| `rlsPolicyShape.test.ts` is swallowed by the integration include glob and never runs in the unit job | Placement under `src/db/` (F20, contract table row 4). |
+| Forge fixtures leak between shards | The rls-coverage runner is single-file and shard-1-only (F20); cleanup by id in `afterAll`, as in F15. |
+| D6b broadens the finding's blast radius into a test that guards ~270 tables | Test-only; zero offenders with evidence (F17); a named triage list is the only escape hatch and it names its owner. |
+
+## 7. Non-claims
+
+- This design does not claim a request-path exploit existed; F11/F12 show every caller authorises the parent first. It closes the database invariant and the catalog blind spot.
+- It does not claim `INTENTIONAL_UNSCOPED` tables carry forced RLS. F18 shows seven of them (`device_commands`, `intent_outbox`, `llm_provider_catalog`, `llm_provider_catalog_revisions`, `llm_provider_verifications`, `third_party_package_catalog`, `third_party_release_tests`) have RLS entirely off on the 2026-09-20 DB although the list's comments for some say "Forced RLS". D5 classifies membership only; it does not assert their RLS state. Reported to QA (§8), not fixed here.
+- It does not claim the F18 debt tables are safe. Three (`device_software`, `mobile_sessions`, `software_compliance_status`) carry `device_id`/`user_id` and no RLS and look like tenant tables.
+- It does not claim the parents' own policies are sound: the quorum showed `scripts`/`script_tags` accept `(org_id=A, partner_id=B)` and `(org_id=A, is_system=true)` rows at the RLS layer (route-layer clamps prevent both today). Children can never be tighter than their parents (F7); those are parent findings (§8.1).
+- It does not claim org erasure of an org owning versioned or tagged scripts succeeds today (§8.3); FORCE RLS changes nothing about that path because erasure runs under system scope and FK checks bypass RLS (F21).
+- It does not claim parity between the child policies and the app-layer `canReadScript` (`scriptBundle/index.ts:339-347`); RLS is stricter than the app layer by design and the app layer is not the security boundary.
+- It does not extend the command-specific shape check to partner-axis, dual-axis, device-join or user-id shapes; those assertions keep their current form and are named as follow-up candidates (§8.5).
+- The migration filename `2026-09-30-100000-…` is a proposal pinned to the worktree's current ceiling; the committed name is whatever satisfies `check-migration-naming.sh --staged` at commit time.
+
+## 8. Hand-offs recorded for QA / backlog (not part of this branch)
+
+1. **Parent-level invariants (quorum finding)**: `scripts` and `script_tags` have independent `org_id`/`partner_id` FKs with no `(org_id, partner_id) → organizations(id, partner_id)` composite (precedent `2026-04-11-users-rls.sql:183-201`, quorum-cited), so an org-scope INSERT can set a foreign `partner_id` and expose the row to that partner; and nothing at the DB layer enforces `is_system ⇒ org_id IS NULL AND partner_id IS NULL`, so an org-scope INSERT with `is_system=true` passes the org branch and becomes globally readable. Route-layer clamps (`scriptWrite.ts`) prevent both today. Candidate S1 findings on the parents; requires data audit before adding constraints.
+2. Candidate new findings from the D5 RED list: `device_software`, `mobile_sessions`, `software_compliance_status` (tenant-bearing, no RLS); `agent_versions`, `cis_check_catalog`, `patches`, `permissions`, `plugin_catalog`, `script_templates` (likely global reference data; need an `INTENTIONAL_UNSCOPED` review with a plan-doc entry per CLAUDE.md:47); plus any post-09-20 table the fresh-DB run adds.
+3. **Erasure FK gap (quorum-confirmed)**: `CORE_ORG_CASCADE_DELETE_ORDER` deletes `script_tags` and `scripts` (`tenantCascade.ts:353-354`) but never `script_to_tags`/`script_versions`, whose FKs are `NO ACTION` (F1) — a deterministic `23503` for any org that owns a versioned or tagged script. Fix options: `ON DELETE CASCADE` on the two script/tag FKs plus `SET NULL` on `script_versions.created_by`, or explicit pre-clears in the cascade. Independent of RLS.
+4. Seven `INTENTIONAL_UNSCOPED` tables have RLS off, contradicting their in-list comments (§7).
+5. Command-specific shape checks for the partner-axis, dual-axis, device-join and user-id assertions (same module, same rollout discipline as D6).
+6. The QA probe's RMM-QA-220 blocks (`core-tenant-isolation-release-contract.test.ts:151-177`) will invert once the catalog entries and D6b land; the QA side owns that re-characterisation.
+
+## 9. Advisor quorum record
+
+Codex (`gpt-5.6-sol`, read-only, `scratchpad/codex-out.txt`, exit 0) reviewed the D2/D3 predicates and the F10 concern against the worktree. Verbatim positions and resolutions:
+
+| # | Codex position | Resolution |
+| --- | --- | --- |
+| 1 | Normal org/partner/system scopes behave correctly under the proposed predicates; but the *parents* accept `(org_id=A, partner_id=B)` and `(org_id=A, is_system=true)` rows at the RLS layer, so children inherit that exposure. Recommends composite ownership FK and an `is_system ⇒ NULL axes` invariant on `scripts`/`script_tags`. | **Agreed as a finding, declined as scope.** Parent-schema changes with data-audit blast radius; recorded as §8.1. Child policies cannot be tighter than the parent (F7), so nothing in D2/D3 changes. |
+| 2 | A `script_to_tags` UPDATE `WITH CHECK` that validates only script WRITE lets an owner re-point `tag_id` at a hidden tag. | **Already satisfied**: D3 uses `USING W(s) WITH CHECK (W(s) AND T_read(t))`; Codex noted the workspace design already had this form. D7 row 16 proves it behaviourally. |
+| 3 | Tag READ on INSERT is acceptable; tag WRITE would be a valid stricter product rule but is not required for tenant isolation. Precedent `automation-resource-bindings.sql:397-409`. | **Agreed**; D3 unchanged. |
+| 4 | The 2026-05-31 bound-parameter failure was specifically an INSERT `WITH CHECK` on the `is_system` branch; the proposed child writes carry no such branch; `role_permissions` is valid SELECT counter-evidence; keep the bound-parameter functional test. | **Agreed**; D2 unchanged; D7 row 13 retained. |
+| 5 | FORCE RLS does not break soft delete, org merge, device move or seeds; but org/partner hard erasure is a latent deterministic `23503` because the cascade never deletes these children and their FKs are `NO ACTION`. | **Agreed as a finding, declined as scope** (RLS-independent); recorded as §8.3. |
+| 6 | The existing parent-FK assertion ORs parents, so `script_to_tags` could pass without validating `script_tags`; require both parents for SELECT and INSERT/UPDATE `WITH CHECK`, `scripts` only for UPDATE `USING` and DELETE. | **Adopted**: D6a gains `PARENT_FK_REQUIRED_PARENTS_PER_COMMAND` with exactly that rule for `script_to_tags`. |
+| 7 | `db:check-drift` does not inspect RLS/policies. | **Agreed** (F22); no action. |
+
+No disagreement remains on D1–D3. Points 1 and 5 are surfaced to the orchestrator as new candidate findings rather than silently absorbed.


### PR DESCRIPTION
## fix(rls): forced parent-join RLS for script_versions / script_to_tags (RMM-QA-220)

`script_versions` (customer script content + history) and `script_to_tags` (script↔tag join) shipped in `0001-baseline.sql` with RLS disabled while `breeze_app` holds blanket DML, and were in no allowlist of the RLS coverage contract. This PR installs forced per-command parent-join policies that mirror the reviewed `scripts` / `script_tags` semantics, makes the coverage catalog exhaustive over every public base table, adds command-specific USING/WITH CHECK shape checks, and proves enforcement behaviourally as `breeze_app`.

Design: `docs/superpowers/specs/2026-09-01-rmm-qa-220-script-children-rls-design.md` (D1–D9, advisor-quorum record). Plan: `docs/superpowers/plans/2026-09-01-rmm-qa-220-script-children-rls.md`.

### Standard implementation handback

```text
Finding IDs: RMM-QA-220
Branch / commit / PR: fix/rmm-qa-220-script-children-rls / 071256a3194204166e1581a96aeb89f2f9426b20 (base origin/main 1b733cedb; migration name verified against origin/main 3a3beba54 — see fix round) / this PR (draft)
Behavior changed: script_versions and script_to_tags now have RLS ENABLED + FORCED with four per-command policies each (2026-10-01-100000-script-children-rls.sql). script_versions SELECT mirrors scripts' read predicate (org OR partner OR is_system OR own-partner read branch); INSERT/UPDATE/DELETE mirror scripts' write predicate only. script_to_tags SELECT requires script read AND tag read; INSERT requires script WRITE AND tag READ; UPDATE USING script WRITE, WITH CHECK script WRITE AND tag READ; DELETE script WRITE. No app-layer code changed; breeze_app privileges unchanged (RLS is the defense, ensureAppRole untouched).
Exit-contract clauses proved: (1) idempotent forced parent-join policies preserving reviewed system-script behavior (forge rows 13/14: system version readable, never writable) and preventing cross-tenant pairing (rows 5, 12, 16); (2) exhaustive table classification registers both tables (D5 test + PARENT_FK_JOIN_POLICY_TABLES entries), and the UNREVIEWED_RLS_CLASSIFICATION_DEBT bucket is an enforced shrink-only ratchet (ceiling 11 + frozen 2026-09-01 name set; 'the unreviewed classification debt bucket only shrinks'); (3) real breeze_app Org A/B and Partner A/B tests: same-tenant success (rows 1, 2, 8, 11), foreign SELECT hidden (3, 7, 10), forged INSERT rejected (4, 5, 7, 9, 12, 14), foreign UPDATE/DELETE ineffective (6, 15); (4) command-specific policy-shape checks validate USING/WITH CHECK/helper argument for all 32 parent-FK tables (both-parents overlay for script_to_tags) and all asserted org-axis tables.
Exit-contract clauses still open: none on the two script children at the DB layer; QA-side re-characterisation of the probe blocks core-tenant-isolation-release-contract.test.ts:151-177 (they pin the pre-fix state and now invert) and candidate-bound retest are QA's.
Tests run and exact results: rlsPolicyShape.test.ts 22 passed (22) (unit; mutations A–E each observed red then reverted); autoMigrate.test.ts 63 passed (63) (one load-induced 60s timeout of 'resolves every core migration path referenced from apps/api/src' in the combined run while three other sessions' tsc processes saturated the host; 63/63 in 9.3s on rerun); scriptBundle/index.test.ts PASS (combined unit run 134 passed of 135, the 1 being that timeout); test:rls-coverage 99 passed (99) on a fresh per-worktree DB (baseline before this branch: 80 passed (80); RED before the migration: force test + legacy and command-specific parent-FK tests naming both tables, forge suite 12 failed | 4 passed); scriptBundleRls.integration.test.ts 4 passed (4) (mutation: INSERT policy without the partner branch -> (b) fails 'new row violates row-level security policy for table "script_versions"', 1 failed | 3 passed; restored -> 4/4); integration battery scriptBundleRls + scripts-system-rls + scripts-soft-delete + tenantCascade + orgMergeRegistry + tenant-export-policy: Test Files 6 passed (6), Tests 30 passed (30); tsc --noEmit exit 0; check:migrations from an empty DB '[check-migrations] OK — all migrations applied'; migration applied twice via psql -> identical pg_policies snapshot (8 rows, 0 NOTICEs). Fix round (fresh per-worktree stack, DB migrated from empty through the renamed file): test:rls-coverage 100 passed (100); unit rlsPolicyShape + autoMigrate + scriptBundle/index 135 passed (135); integration battery (scriptBundleRls, scripts-system-rls, scripts-soft-delete, tenantCascade, orgMergeRegistry, tenant-export-policy) Test Files 6 passed (6), Tests 30 passed (30); tsc --noEmit exit 0; check:migrations from an empty DB '[check-migrations] OK — all migrations applied' with both tables relrowsecurity=t relforcerowsecurity=t; twice-apply IDEMPOTENT (8 rows, 0 NOTICE/WARNING/ERROR); manual breeze_app forge (org B context) -> 'new row violates row-level security policy' for "script_versions" and "script_to_tags", fixtures rolled back (0 leftovers); catalog proof rls_enabled=true force_rls=true policies=4 for both; db:check-drift 'No drift detected — all 620 migration files match'; check-migration-naming.sh (whole directory and --staged) OK.
Migration / RLS / config / rollout impact: one new idempotent migration, DDL only (ENABLE/FORCE + 8 policies), no data change, no backfill, no config; renamed in the fix round to 2026-10-01-100000-script-children-rls.sql so it sorts strictly after origin/main's current ceiling 2026-09-30-ai-agents-impact.sql (the original 2026-09-30-100000-… name sorted between main's two newer 2026-09-30 files; the real guard run against a main checkout rejected the old name and accepts the new one; the file was unshipped, so this is not a shipped-migration edit). No cascade/export registry change (neither table has org_id/device_id). db:check-drift 'No drift detected — all 620 migration files match the breeze_migrations ledger.' Rollback = a follow-up migration dropping the 8 policies and un-forcing RLS.
Security and tenant/site negative cases: forge suite as breeze_app — org B1 cannot read/insert/update/delete on org A1's versions or links; org B1 cannot pair (own script, A tag), (A script, own tag) or (own script, partner-A tag); partner B cannot read A's version nor write A's partner-wide script; org A1 with a mis-set own partner cannot read A's partner-wide version; org A1 cannot write a system script's version nor unlink a partner-wide link; UPDATE re-point at a hidden tag rejected. Manual psql forge as breeze_app (org B organization-scope context): INSERT script_versions -> 'ERROR:  new row violates row-level security policy for table "script_versions"'; INSERT script_to_tags -> same for "script_to_tags"; transaction rolled back. Site scope: N/A — neither table carries a site axis.
Operator/UI states checked: N/A — no UI or route changes; the only readers (aiToolsScripts includeVersionHistory, scriptBundle export/import) authorise the parent first and are covered by scriptBundleRls.integration.test.ts and the unchanged mocked unit suite.
Candidate-bound evidence still required: QA re-run of the catalog query (docs/qa/evidence/2026-08-23-core-tenant-isolation.md:31-35) and of the release-contract probe against the nominated candidate; review of the new UNREVIEWED_RLS_CLASSIFICATION_DEBT names (device_software, mobile_sessions, software_compliance_status, agent_versions, cis_check_catalog, patches, permissions, plugin_catalog, script_templates, plus two fresh-DB additions beyond the brief's list — sessions and snmp_alert_thresholds, which DO have RLS on/forced with four policies each but sit in no allowlist) as candidate findings; parent-level findings from the quorum (scripts/script_tags composite ownership FK, is_system ⇒ NULL axes, org-erasure 23503 on NO ACTION child FKs) handed back per spec §8.
```

### Independent review round (Codex, read-only, gpt-5.6-sol)
1. `is_system` appears only in the two SELECT predicates (migration:74, :122); no script-side write predicate carries `is_system` or the own-partner read branch. The own-partner branch Codex cites at :149 / :171 is the intended tag-READ leg of D3 (INSERT / UPDATE-check gate on the tag being readable; unlink authority never derives from it).
2. Confirmed no: UPDATE USING / DELETE authorise solely through script write access (migration:159, :181).
3. Recorded, not looped on (test-side matcher, not an enforcement surface): `rlsPolicyShape.ts` correlates aliases by text, so a predicate that joins the parent as `s` AND a second, non-parent relation under the same alias `s` with the helper on that second `s` would satisfy `predicateCoversParent`. No shipped policy has this shape (D6a runs over all 32 parent-FK tables); the behavioural forge suite — not the matcher — is the enforcement proof for the two tables here. Follow-up: scope the helper search to the parent's own `EXISTS (...)` sub-select.

### Independent review round 2 (fix round on 1dbc42b8c → this head)
Verdict received: FIX-REQUIRED, no CRITICAL. Disposition per finding:
1. **IMPORTANT — migration filename sorts before main's newest (fixed, `071256a31`).** RED: real `check-migration-naming.sh --staged` in a throwaway checkout of origin/main `3a3beba54` → `VIOLATION 2026-09-30-100000-script-children-rls.sql — sorts BEFORE an already-committed migration. Newest committed: 2026-09-30-ai-agents-impact.sql` (exit 1); staged as `2026-10-01-100000-script-children-rls.sql` → `OK` (exit 0). Renamed with `git mv`, header updated, all references swept (grep for the old name → 0 hits). The three in-code mentions now cite the full `apps/api/migrations/<file>` path so `autoMigrate.test.ts` 'resolves every core migration path referenced from apps/api/src' guards them — proven: with one path-form reference reverted to the old name the guard fails naming the file; the bare-filename form it replaced was invisible to that guard.
2. **IMPORTANT — debt bucket had no enforced ceiling (fixed, `4c62807d8`).** RED on the previous head: `CREATE TABLE public.rmm_qa_220_probe` → D5 fails `unclassified: ["rmm_qa_220_probe"]`; add one Map entry to `UNREVIEWED_RLS_CLASSIFICATION_DEBT` → 99 passed (99) — the escape hatch. Fix: `UNREVIEWED_RLS_CLASSIFICATION_DEBT_CEILING = 11` + frozen name set + new test 'the unreviewed classification debt bucket only shrinks' (pure, no DB); D5's Fix text no longer offers the debt bucket. Discrimination: Map entry only → new test fails `Names not in the frozen 2026-09-01 set: ["rmm_qa_220_probe"]` (D5 itself passes, so the new test is the discriminator); entry in Map and frozen set → `expected 12 to be less than or equal to 11`; reverted + table dropped → 100 passed (100).
3. **MINOR — matcher checks presence, not conjunctive load-bearing (skipped).** Already recorded as the alias-scoping follow-up above; the forge suite (row 15 caught M3) is the behavioural backstop. Not changed in this round.
4. **MINOR — forge rows are order-dependent (skipped).** Deterministic under vitest's in-file sequencing and documented inline; no change.
5. **MINOR — script_to_tags SELECT requires tag visibility / `is_system` SELECT branch product confirmation (no code change).** No observable change (the only join reader inner-joins `script_tags`); the `OR s.is_system` SELECT branch stays pinned by forge row 13 and design doc §D2. Product sign-off remains a QA item.

### Not in scope (handed back as candidate findings — spec §8)
- Parent-level invariants on `scripts` / `script_tags` (composite ownership FK; `is_system ⇒ NULL axes`).
- Org/partner erasure `23503` on `script_to_tags` / `script_versions` `NO ACTION` FKs (RLS-independent).
- The debt-bucket tables (11 names above) and the seven `INTENTIONAL_UNSCOPED` tables whose RLS is off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9p3mtFLSv8SFcZ9fcn8Vu

