### PR TITLE
feat(ai): pre-cap AI budget alerts W02 — recipients, email, delivery worker, partner fan-out (#4388)

### DIFF
--- a/apps/api/src/__tests__/integration/aiBudgetAlertDelivery.integration.test.ts
+++ b/apps/api/src/__tests__/integration/aiBudgetAlertDelivery.integration.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Real-Postgres integration proof for the AI budget alert DELIVERY worker
+ * (#4388 W02). `jobs/aiBudgetAlertDelivery.test.ts` covers the branch logic
+ * against a mocked `db.execute`; this suite covers the parts a mock is
+ * structurally blind to, because they are properties of the TRANSACTION rather
+ * than of the statements:
+ *
+ *  - Failure bookkeeping. The unit suite sees the `delivery_attempts + 1,
+ *    last_delivery_error = …` UPDATE being *issued* and passes either way. Only
+ *    a real transaction shows that issuing it inside the context the rethrow
+ *    then aborts leaves ZERO durable trace — the row still reads
+ *    `delivery_attempts = 0, last_delivery_error = NULL` after a hard failure,
+ *    so the reconcile sweep's `delivery_attempts < MAX_ATTEMPTS` guard can
+ *    never retire a permanently-failing row and operators see no error at all.
+ *  - The success marker committing together with the delivery it marks.
+ *  - The not-visible error class on a genuinely absent row.
+ *  - Idempotency across two calls on the same (delivered) row.
+ *
+ * Only the OUTBOUND edges are mocked — email, the event bus, and the recipient
+ * resolver (whose own query is unit-tested in
+ * `services/usersWithPermission.test.ts`). The database and the DB-context
+ * helpers are deliberately real: they are the thing under test.
+ *
+ * Fixtures are seeded per test, not in `beforeAll`: the integration setup's
+ * global `beforeEach` truncates the tenant tables (organizations cascades into
+ * `ai_budget_alert_events`), so a `beforeAll` fixture would already be gone.
+ */
+import './setup';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { sql } from 'drizzle-orm';
+
+const mocks = vi.hoisted(() => ({
+  sendEmail: vi.fn(),
+  publishEvent: vi.fn(),
+  publishUserEvent: vi.fn(),
+  /** Rewritten by `seedOrgWithRecipient` once the seeded user id exists. */
+  recipients: [] as string[],
+}));
+
+vi.mock('../../services/email', () => ({
+  getEmailService: () => ({ sendEmail: mocks.sendEmail }),
+}));
+vi.mock('../../services/eventBus', () => ({
+  publishEvent: mocks.publishEvent,
+  // `createNotification` fires a best-effort live nudge through the bus.
+  getEventBus: () => ({ publishUserEvent: mocks.publishUserEvent }),
+  EVENT_TYPES: { AI_BUDGET_THRESHOLD_CROSSED: 'ai.budget.threshold_crossed' },
+}));
+vi.mock('../../services/usersWithPermission', () => ({
+  resolveUsersWithPermissionForOrg: vi.fn(async () => mocks.recipients),
+}));
+
+import { db, withSystemDbAccessContext } from '../../db';
+import { AiBudgetAlertEventNotVisibleError, deliverAiBudgetAlert } from '../../jobs/aiBudgetAlertDelivery';
+import { createOrganization, createPartner, createUser } from './db-utils';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+type EventRow = {
+  delivered_at: string | null;
+  recipient_count: number | null;
+  delivery_attempts: number;
+  last_delivery_error: string | null;
+};
+
+async function seedOrgWithRecipient(): Promise<{ orgId: string; userId: string }> {
+  const partner = await createPartner();
+  const org = await createOrganization({ partnerId: partner.id });
+  const user = await createUser({ partnerId: partner.id, orgId: org.id });
+  mocks.recipients = [user.id];
+  return { orgId: org.id, userId: user.id };
+}
+
+/** Monthly + rung 95, so `shouldEmail` is true and the email edge is exercised. */
+async function insertEvent(orgId: string): Promise<string> {
+  const rows = await withSystemDbAccessContext(() => db.execute<{ id: string }>(sql`
+    INSERT INTO ai_budget_alert_events (org_id, period, period_key, threshold_pct, cap_cents, used_cents, billing_source)
+    VALUES (${orgId}::uuid, 'monthly', '2026-09', 95, 10000, 9600, 'platform')
+    RETURNING id
+  `));
+  return rows[0]!.id;
+}
+
+async function readEvent(eventId: string): Promise<EventRow> {
+  const rows = await withSystemDbAccessContext(() => db.execute<EventRow>(sql`
+    SELECT delivered_at, recipient_count, delivery_attempts, last_delivery_error
+    FROM ai_budget_alert_events WHERE id = ${eventId}::uuid
+  `));
+  return rows[0]!;
+}
+
+async function notificationsFor(userId: string) {
+  return withSystemDbAccessContext(() => db.execute<{ link: string | null; dedupe_key: string | null; priority: string }>(sql`
+    SELECT link, dedupe_key, priority FROM user_notifications WHERE user_id = ${userId}::uuid
+  `));
+}
+
+describe('deliverAiBudgetAlert against real Postgres (#4388 W02)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.sendEmail.mockResolvedValue(undefined);
+    mocks.publishEvent.mockResolvedValue(undefined);
+    mocks.publishUserEvent.mockResolvedValue(undefined);
+  });
+
+  runDb('commits the notification, the email and the delivered marker together', async () => {
+    const { orgId, userId } = await seedOrgWithRecipient();
+    const eventId = await insertEvent(orgId);
+
+    await expect(deliverAiBudgetAlert(eventId)).resolves.toEqual({ recipients: 1, emailed: true });
+
+    const row = await readEvent(eventId);
+    expect(row.delivered_at).not.toBeNull();
+    expect(Number(row.recipient_count)).toBe(1);
+    expect(Number(row.delivery_attempts)).toBe(1);
+    expect(row.last_delivery_error).toBeNull();
+
+    const notifications = await notificationsFor(userId);
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]).toMatchObject({
+      link: '/settings/ai-usage',
+      dedupe_key: `ai-budget-alert:${eventId}`,
+      priority: 'high',
+    });
+  });
+
+  runDb('DURABLY records a delivery failure (attempts + error) even though it rethrows', async () => {
+    const { orgId, userId } = await seedOrgWithRecipient();
+    const eventId = await insertEvent(orgId);
+    mocks.sendEmail.mockRejectedValue(new Error('smtp exploded'));
+
+    await expect(deliverAiBudgetAlert(eventId)).rejects.toThrow('smtp exploded');
+
+    const row = await readEvent(eventId);
+    expect(row.delivered_at).toBeNull();
+    expect(Number(row.delivery_attempts)).toBe(1);
+    expect(row.last_delivery_error).toContain('smtp exploded');
+
+    // The in-app notifications written before the send DID roll back with the
+    // failing transaction, which is what makes the retry safe: the whole
+    // customer-facing delivery is re-attempted, not half of it.
+    expect(await notificationsFor(userId)).toHaveLength(0);
+  });
+
+  runDb('throws the retryable not-visible error for a row that does not exist', async () => {
+    await expect(deliverAiBudgetAlert(randomUUID())).rejects.toBeInstanceOf(AiBudgetAlertEventNotVisibleError);
+  });
+
+  runDb('is idempotent: a second call on a delivered row sends nothing', async () => {
+    const { orgId, userId } = await seedOrgWithRecipient();
+    const eventId = await insertEvent(orgId);
+
+    await expect(deliverAiBudgetAlert(eventId)).resolves.toEqual({ recipients: 1, emailed: true });
+    await expect(deliverAiBudgetAlert(eventId)).resolves.toEqual({ recipients: 0, emailed: false });
+
+    expect(mocks.sendEmail).toHaveBeenCalledTimes(1);
+    expect(await notificationsFor(userId)).toHaveLength(1);
+    expect(Number((await readEvent(eventId)).delivery_attempts)).toBe(1);
+  });
+});

--- a/apps/api/src/jobs/aiBudgetAlertDelivery.test.ts
+++ b/apps/api/src/jobs/aiBudgetAlertDelivery.test.ts
@@ -12,6 +12,8 @@ const mocks = vi.hoisted(() => ({
   evaluateAiBudgetThresholds: vi.fn(),
   withSystemContext: vi.fn(),
   runOutside: vi.fn(),
+  attachObservability: vi.fn(),
+  captureMessage: vi.fn(),
 }));
 
 vi.mock('bullmq', () => ({ Queue: class { add = vi.fn(); }, Worker: class {}, Job: class {} }));
@@ -25,20 +27,23 @@ vi.mock('../db', () => ({
   runOutsideDbContext: mocks.runOutside,
 }));
 vi.mock('../services/redis', () => ({ getBullMQConnection: () => ({}) }));
-vi.mock('../services/sentry', () => ({ captureException: vi.fn(), captureMessage: vi.fn() }));
+vi.mock('../services/sentry', () => ({ captureException: vi.fn(), captureMessage: mocks.captureMessage }));
 vi.mock('../services/userNotifications', () => ({ createNotification: mocks.createNotification }));
 vi.mock('../services/usersWithPermission', () => ({ resolveUsersWithPermissionForOrg: mocks.resolveUsers }));
 vi.mock('../services/email', () => ({ getEmailService: mocks.getEmailService }));
 vi.mock('../services/eventBus', () => ({ publishEvent: mocks.publishEvent, EVENT_TYPES: { AI_BUDGET_THRESHOLD_CROSSED: 'ai.budget.threshold_crossed' } }));
 vi.mock('../services/aiBudgetAlerts', () => ({ evaluateAiBudgetThresholds: mocks.evaluateAiBudgetThresholds }));
-vi.mock('./workerObservability', () => ({ attachWorkerObservability: vi.fn() }));
+vi.mock('./workerObservability', () => ({ attachWorkerObservability: mocks.attachObservability }));
 vi.mock('../services/c2cM365', () => ({ getFrontendBaseUrl: () => 'https://app.example.com' }));
 
 import {
+  AI_BUDGET_ALERT_QUEUE,
   AiBudgetAlertEventNotVisibleError,
+  classifyAiBudgetAlertFailure,
   deliverAiBudgetAlert,
   evaluatePartnerOrgs,
   getAiBudgetAlertQueue,
+  initializeAiBudgetAlertWorker,
   processJob,
   reconcileUndeliveredAiBudgetAlerts,
 } from './aiBudgetAlertDelivery';
@@ -327,5 +332,52 @@ describe('processJob (payload validation + terminal not-visible handling)', () =
       .resolves.toBeDefined();
     expect(warn).toHaveBeenCalledWith(expect.stringContaining(EVENT_UUID));
     warn.mockRestore();
+
+    // Fix round 2: completing the job here means the `failed` listener never
+    // fires on the exhausting attempt, so the classifier's held
+    // `reportOnlyWhenExhausted` report can never be released. Without a signal
+    // emitted from HERE, a permanently invisible event would leave no trace in
+    // Sentry at all — a warning-level message keeps the terminal case
+    // observable without reintroducing the error-level page.
+    expect(mocks.captureMessage).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ eventCode: 'ai_budget_alert_event_not_visible', level: 'warning' }),
+    );
+  });
+});
+
+describe('classifyAiBudgetAlertFailure (worker observability, fix round 2)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    armContextMocks();
+  });
+
+  // Without a classifier, workerObservability's `failed` listener
+  // captureExceptions EVERY attempt at error level. The not-visible retry is an
+  // EXPECTED, self-healing race (the inserting transaction has not committed on
+  // the ambient-system path), so attempts 1..N-1 would each page for something
+  // that resolves itself on the next attempt.
+  it('classifies a not-visible event as expected: warning level, held until attempts are exhausted', () => {
+    expect(classifyAiBudgetAlertFailure(undefined, new AiBudgetAlertEventNotVisibleError(EVENT_UUID))).toEqual({
+      reason: 'ai_budget_alert_event_not_visible',
+      level: 'warning',
+      reportOnlyWhenExhausted: true,
+    });
+  });
+
+  it('leaves every other failure at the default error-level report on every attempt', () => {
+    expect(classifyAiBudgetAlertFailure(undefined, new Error('smtp down'))).toBeNull();
+    expect(classifyAiBudgetAlertFailure(undefined, new TypeError('boom'))).toBeNull();
+  });
+
+  // A classifier nothing attaches is dead code that reads as a fix.
+  it('is wired into the worker via attachWorkerObservability', async () => {
+    await initializeAiBudgetAlertWorker();
+
+    expect(mocks.attachObservability).toHaveBeenCalledWith(
+      expect.anything(),
+      AI_BUDGET_ALERT_QUEUE,
+      { classifyFailure: classifyAiBudgetAlertFailure },
+    );
   });
 });

--- a/apps/api/src/jobs/aiBudgetAlertDelivery.test.ts
+++ b/apps/api/src/jobs/aiBudgetAlertDelivery.test.ts
@@ -1,0 +1,109 @@
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  execute: vi.fn(),
+  createNotification: vi.fn(),
+  resolveUsers: vi.fn(),
+  sendEmail: vi.fn(),
+  getEmailService: vi.fn(),
+  publishEvent: vi.fn(),
+}));
+
+vi.mock('bullmq', () => ({ Queue: class { add = vi.fn(); }, Worker: class {}, Job: class {} }));
+vi.mock('../db', () => ({
+  db: { execute: mocks.execute },
+  withSystemDbAccessContext: (fn: () => Promise<unknown>) => fn(),
+  runOutsideDbContext: (fn: () => Promise<unknown>) => fn(),
+}));
+vi.mock('../services/redis', () => ({ getBullMQConnection: () => ({}) }));
+vi.mock('../services/sentry', () => ({ captureException: vi.fn(), captureMessage: vi.fn() }));
+vi.mock('../services/userNotifications', () => ({ createNotification: mocks.createNotification }));
+vi.mock('../services/usersWithPermission', () => ({ resolveUsersWithPermissionForOrg: mocks.resolveUsers }));
+vi.mock('../services/email', () => ({ getEmailService: mocks.getEmailService }));
+vi.mock('../services/eventBus', () => ({ publishEvent: mocks.publishEvent, EVENT_TYPES: { AI_BUDGET_THRESHOLD_CROSSED: 'ai.budget.threshold_crossed' } }));
+vi.mock('./workerObservability', () => ({ attachWorkerObservability: vi.fn() }));
+vi.mock('../services/c2cM365', () => ({ getFrontendBaseUrl: () => 'https://app.example.com' }));
+
+import { deliverAiBudgetAlert } from './aiBudgetAlertDelivery';
+
+const dialect = new PgDialect();
+
+const baseEvent = {
+  id: 'evt-1', org_id: 'org1', org_name: 'Acme', period: 'monthly', period_key: '2026-09',
+  threshold_pct: 80, cap_cents: 10000, used_cents: 8100, billing_source: 'platform', delivered_at: null,
+};
+
+function renderSql(q: unknown): string {
+  return dialect.sqlToQuery(q as SQL).sql;
+}
+
+/**
+ * Dispatches `db.execute` by the rendered SQL text rather than by call order.
+ * The brief's original mock queued `mockResolvedValueOnce` twice (once in
+ * `beforeEach`, once per test), which makes the SECOND `execute` call resolve
+ * to the event row — but the second call in the real implementation is the
+ * users/email lookup, not a second event load. Rendering the query text and
+ * matching on table name is order-independent and survives that mismatch.
+ */
+function mockExecute(event: Record<string, unknown> | null, userRows: Array<{ email: string }> = [{ email: 'a@x.io' }, { email: 'b@x.io' }]) {
+  mocks.execute.mockImplementation(async (q: unknown) => {
+    const text = renderSql(q);
+    if (text.includes('FROM ai_budget_alert_events')) return event ? [event] : [];
+    if (text.includes('FROM users')) return userRows;
+    return [];
+  });
+}
+
+describe('deliverAiBudgetAlert', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.resolveUsers.mockResolvedValue(['u1', 'u2']);
+    mocks.getEmailService.mockReturnValue({ sendEmail: mocks.sendEmail });
+    mocks.createNotification.mockResolvedValue('n1');
+    mockExecute(baseEvent);
+  });
+
+  it('notifies every recipient with the event id as dedupe key, sends one email, publishes, marks delivered', async () => {
+    const result = await deliverAiBudgetAlert('evt-1');
+    expect(result).toEqual({ recipients: 2, emailed: true });
+    expect(mocks.createNotification).toHaveBeenCalledTimes(2);
+    expect(mocks.createNotification).toHaveBeenCalledWith(expect.objectContaining({
+      userId: 'u1', orgId: 'org1', type: 'ai', dedupeKey: 'ai-budget-alert:evt-1', link: '/settings/ai-usage', priority: 'normal',
+    }));
+    expect(mocks.sendEmail).toHaveBeenCalledTimes(1);
+    expect(mocks.sendEmail.mock.calls[0]?.[0].to).toEqual(['a@x.io', 'b@x.io']);
+    expect(mocks.publishEvent).toHaveBeenCalledWith('ai.budget.threshold_crossed', 'org1', expect.objectContaining({ thresholdPct: 80 }), 'ai-budget-alerts');
+    expect(JSON.stringify(mocks.execute.mock.calls.at(-1))).toContain('delivered_at');
+  });
+
+  it('skips email for daily pre-cap rungs and when no email service is configured', async () => {
+    mockExecute({ ...baseEvent, period: 'daily', period_key: '2026-09-30' });
+    await expect(deliverAiBudgetAlert('evt-1')).resolves.toEqual({ recipients: 2, emailed: false });
+    expect(mocks.sendEmail).not.toHaveBeenCalled();
+
+    mocks.resolveUsers.mockResolvedValue(['u1']);
+    mocks.getEmailService.mockReturnValue(null);
+    mockExecute(baseEvent);
+    await expect(deliverAiBudgetAlert('evt-1')).resolves.toEqual({ recipients: 1, emailed: false });
+  });
+
+  it('marks priority high at 95 and above', async () => {
+    mockExecute({ ...baseEvent, threshold_pct: 95 });
+    await deliverAiBudgetAlert('evt-1');
+    expect(mocks.createNotification).toHaveBeenCalledWith(expect.objectContaining({ priority: 'high' }));
+  });
+
+  it('is a no-op for an already delivered event', async () => {
+    mockExecute({ ...baseEvent, delivered_at: new Date().toISOString() });
+    await expect(deliverAiBudgetAlert('evt-1')).resolves.toEqual({ recipients: 0, emailed: false });
+    expect(mocks.createNotification).not.toHaveBeenCalled();
+  });
+
+  it('records the failure and rethrows so BullMQ retries', async () => {
+    mocks.sendEmail.mockRejectedValue(new Error('smtp down'));
+    await expect(deliverAiBudgetAlert('evt-1')).rejects.toThrow('smtp down');
+    expect(JSON.stringify(mocks.execute.mock.calls.at(-1))).toContain('delivery_attempts');
+  });
+});

--- a/apps/api/src/jobs/aiBudgetAlertDelivery.test.ts
+++ b/apps/api/src/jobs/aiBudgetAlertDelivery.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   sendEmail: vi.fn(),
   getEmailService: vi.fn(),
   publishEvent: vi.fn(),
+  evaluateAiBudgetThresholds: vi.fn(),
 }));
 
 vi.mock('bullmq', () => ({ Queue: class { add = vi.fn(); }, Worker: class {}, Job: class {} }));
@@ -23,10 +24,11 @@ vi.mock('../services/userNotifications', () => ({ createNotification: mocks.crea
 vi.mock('../services/usersWithPermission', () => ({ resolveUsersWithPermissionForOrg: mocks.resolveUsers }));
 vi.mock('../services/email', () => ({ getEmailService: mocks.getEmailService }));
 vi.mock('../services/eventBus', () => ({ publishEvent: mocks.publishEvent, EVENT_TYPES: { AI_BUDGET_THRESHOLD_CROSSED: 'ai.budget.threshold_crossed' } }));
+vi.mock('../services/aiBudgetAlerts', () => ({ evaluateAiBudgetThresholds: mocks.evaluateAiBudgetThresholds }));
 vi.mock('./workerObservability', () => ({ attachWorkerObservability: vi.fn() }));
 vi.mock('../services/c2cM365', () => ({ getFrontendBaseUrl: () => 'https://app.example.com' }));
 
-import { deliverAiBudgetAlert } from './aiBudgetAlertDelivery';
+import { deliverAiBudgetAlert, evaluatePartnerOrgs, getAiBudgetAlertQueue, reconcileUndeliveredAiBudgetAlerts } from './aiBudgetAlertDelivery';
 
 const dialect = new PgDialect();
 
@@ -105,5 +107,94 @@ describe('deliverAiBudgetAlert', () => {
     mocks.sendEmail.mockRejectedValue(new Error('smtp down'));
     await expect(deliverAiBudgetAlert('evt-1')).rejects.toThrow('smtp down');
     expect(JSON.stringify(mocks.execute.mock.calls.at(-1))).toContain('delivery_attempts');
+  });
+
+  it('marks delivered before the event-bus publish, so a publish failure does not fail delivery and a retry does not resend', async () => {
+    // Finding 1: notifications + email are the customer-facing delivery: they
+    // must be durably marked BEFORE the (best-effort) bus publish, so that a
+    // publish failure never causes BullMQ to retry a job that already sent.
+    mocks.publishEvent.mockRejectedValueOnce(new Error('redis unavailable'));
+
+    const first = await deliverAiBudgetAlert('evt-1');
+    expect(first).toEqual({ recipients: 2, emailed: true });
+    expect(mocks.sendEmail).toHaveBeenCalledTimes(1);
+    // The delivered_at UPDATE already ran, even though publish rejected.
+    expect(JSON.stringify(mocks.execute.mock.calls.at(-1))).toContain('delivered_at');
+
+    // Simulate BullMQ retrying the same job id: the row this call loads back
+    // out is now delivered (the mark-delivered write ran before the publish
+    // that failed), so the retry must be a no-op, not a second send.
+    mockExecute({ ...baseEvent, delivered_at: new Date().toISOString() });
+    const second = await deliverAiBudgetAlert('evt-1');
+    expect(second).toEqual({ recipients: 0, emailed: false });
+    expect(mocks.sendEmail).toHaveBeenCalledTimes(1);
+    expect(mocks.createNotification).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('reconcileUndeliveredAiBudgetAlerts', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('re-enqueues each undelivered row and returns the row count', async () => {
+    mocks.execute.mockImplementation(async (q: unknown) => {
+      const text = renderSql(q);
+      if (text.includes('FROM ai_budget_alert_events')) return [{ id: 'evt-a' }, { id: 'evt-b' }];
+      return [];
+    });
+    const queue = getAiBudgetAlertQueue();
+
+    const count = await reconcileUndeliveredAiBudgetAlerts();
+
+    expect(count).toBe(2);
+    const addMock = queue.add as unknown as ReturnType<typeof vi.fn>;
+    const jobIds = addMock.mock.calls.map((call: unknown[]) => (call[2] as { jobId: string }).jobId);
+    expect(jobIds).toEqual(['deliver-evt-a', 'deliver-evt-b']);
+    const selectText = mocks.execute.mock.calls.map((call: unknown[]) => renderSql(call[0])).find((t: string) => t.includes('FROM ai_budget_alert_events'));
+    expect(selectText).toContain('delivered_at IS NULL');
+    expect(selectText).toContain('delivery_attempts <');
+  });
+
+  it('enqueues nothing and returns 0 when there are no undelivered rows', async () => {
+    mocks.execute.mockResolvedValue([]);
+    const queue = getAiBudgetAlertQueue();
+
+    const count = await reconcileUndeliveredAiBudgetAlerts();
+
+    expect(count).toBe(0);
+    expect(queue.add).not.toHaveBeenCalled();
+  });
+});
+
+describe('evaluatePartnerOrgs (partner-wide evaluation fan-out)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.evaluateAiBudgetThresholds.mockResolvedValue([]);
+  });
+
+  it('evaluates every active org of the partner, in order, and returns the count', async () => {
+    mocks.execute.mockImplementation(async (q: unknown) => {
+      const text = renderSql(q);
+      if (text.includes('FROM organizations')) return [{ id: 'org-a' }, { id: 'org-b' }];
+      return [];
+    });
+
+    const count = await evaluatePartnerOrgs('partner-1');
+
+    expect(count).toBe(2);
+    expect(mocks.evaluateAiBudgetThresholds.mock.calls.map((call: unknown[]) => call[0])).toEqual(['org-a', 'org-b']);
+    const selectText = mocks.execute.mock.calls.map((call: unknown[]) => renderSql(call[0])).find((t: string) => t.includes('FROM organizations'));
+    expect(selectText).toContain('partner_id');
+    expect(selectText).toContain('deleted_at IS NULL');
+  });
+
+  it('evaluates nothing when the partner has no active orgs', async () => {
+    mocks.execute.mockResolvedValue([]);
+
+    const count = await evaluatePartnerOrgs('partner-1');
+
+    expect(count).toBe(0);
+    expect(mocks.evaluateAiBudgetThresholds).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/jobs/aiBudgetAlertDelivery.test.ts
+++ b/apps/api/src/jobs/aiBudgetAlertDelivery.test.ts
@@ -10,13 +10,19 @@ const mocks = vi.hoisted(() => ({
   getEmailService: vi.fn(),
   publishEvent: vi.fn(),
   evaluateAiBudgetThresholds: vi.fn(),
+  withSystemContext: vi.fn(),
+  runOutside: vi.fn(),
 }));
 
 vi.mock('bullmq', () => ({ Queue: class { add = vi.fn(); }, Worker: class {}, Job: class {} }));
+// Real `vi.fn`s (not inline arrows) so the #4276 diagnostic `label` argument
+// every BullMQ handler must pass to `withSystemDbAccessContext` is assertable,
+// and so the failure-bookkeeping write can be proven to open its OWN context
+// rather than reusing the one its rethrow aborts.
 vi.mock('../db', () => ({
   db: { execute: mocks.execute },
-  withSystemDbAccessContext: (fn: () => Promise<unknown>) => fn(),
-  runOutsideDbContext: (fn: () => Promise<unknown>) => fn(),
+  withSystemDbAccessContext: mocks.withSystemContext,
+  runOutsideDbContext: mocks.runOutside,
 }));
 vi.mock('../services/redis', () => ({ getBullMQConnection: () => ({}) }));
 vi.mock('../services/sentry', () => ({ captureException: vi.fn(), captureMessage: vi.fn() }));
@@ -28,9 +34,40 @@ vi.mock('../services/aiBudgetAlerts', () => ({ evaluateAiBudgetThresholds: mocks
 vi.mock('./workerObservability', () => ({ attachWorkerObservability: vi.fn() }));
 vi.mock('../services/c2cM365', () => ({ getFrontendBaseUrl: () => 'https://app.example.com' }));
 
-import { deliverAiBudgetAlert, evaluatePartnerOrgs, getAiBudgetAlertQueue, reconcileUndeliveredAiBudgetAlerts } from './aiBudgetAlertDelivery';
+import {
+  AiBudgetAlertEventNotVisibleError,
+  deliverAiBudgetAlert,
+  evaluatePartnerOrgs,
+  getAiBudgetAlertQueue,
+  processJob,
+  reconcileUndeliveredAiBudgetAlerts,
+} from './aiBudgetAlertDelivery';
 
 const dialect = new PgDialect();
+
+/** `vi.resetAllMocks()` wipes implementations, so the context wrappers have to be re-armed per test. */
+function armContextMocks() {
+  mocks.withSystemContext.mockImplementation(async (fn: () => Promise<unknown>) => fn());
+  mocks.runOutside.mockImplementation(async (fn: () => Promise<unknown>) => fn());
+}
+
+/** The rendered SQL text + bound params of an `sql` template, for order-independent assertions. */
+function renderQuery(q: unknown): { sql: string; params: unknown[] } {
+  const { sql, params } = dialect.sqlToQuery(q as SQL);
+  return { sql, params: params as unknown[] };
+}
+
+function fakeJob(data: unknown, opts: { attemptsMade?: number; attempts?: number } = {}) {
+  return {
+    id: 'job-1',
+    data,
+    attemptsMade: opts.attemptsMade ?? 0,
+    opts: { attempts: opts.attempts ?? 5 },
+  } as unknown as Parameters<typeof processJob>[0];
+}
+
+const EVENT_UUID = '11111111-1111-4111-8111-111111111111';
+const PARTNER_UUID = '22222222-2222-4222-8222-222222222222';
 
 const baseEvent = {
   id: 'evt-1', org_id: 'org1', org_name: 'Acme', period: 'monthly', period_key: '2026-09',
@@ -61,6 +98,7 @@ function mockExecute(event: Record<string, unknown> | null, userRows: Array<{ em
 describe('deliverAiBudgetAlert', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    armContextMocks();
     mocks.resolveUsers.mockResolvedValue(['u1', 'u2']);
     mocks.getEmailService.mockReturnValue({ sendEmail: mocks.sendEmail });
     mocks.createNotification.mockResolvedValue('n1');
@@ -78,6 +116,26 @@ describe('deliverAiBudgetAlert', () => {
     expect(mocks.sendEmail.mock.calls[0]?.[0].to).toEqual(['a@x.io', 'b@x.io']);
     expect(mocks.publishEvent).toHaveBeenCalledWith('ai.budget.threshold_crossed', 'org1', expect.objectContaining({ thresholdPct: 80 }), 'ai-budget-alerts');
     expect(JSON.stringify(mocks.execute.mock.calls.at(-1))).toContain('delivered_at');
+    // #4276: every BullMQ handler must name the context it opens.
+    expect(mocks.withSystemContext).toHaveBeenCalledWith(expect.any(Function), 'aiBudgetAlertDelivery.deliver');
+  });
+
+  it('loads the event row FOR UPDATE so a duplicate job serialises behind the first (W02 critical #1 iv)', async () => {
+    await deliverAiBudgetAlert('evt-1');
+    const loadSql = mocks.execute.mock.calls
+      .map((call: unknown[]) => renderQuery(call[0]).sql)
+      .find((text: string) => text.includes('FROM ai_budget_alert_events'));
+    expect(loadSql).toContain('FOR UPDATE OF e');
+  });
+
+  it('throws a retryable not-visible error when the row is missing (W02 critical #1 ii)', async () => {
+    // A missing row is overwhelmingly "inserted but not committed yet", not
+    // "gone". Returning success there completes the job, and BullMQ's retained
+    // completed hash then makes reconcile's same-jobId re-add a silent no-op —
+    // the alert is lost. Throw so the existing backoff retries.
+    mockExecute(null);
+    await expect(deliverAiBudgetAlert('evt-1')).rejects.toBeInstanceOf(AiBudgetAlertEventNotVisibleError);
+    expect(mocks.createNotification).not.toHaveBeenCalled();
   });
 
   it('skips email for daily pre-cap rungs and when no email service is configured', async () => {
@@ -103,10 +161,24 @@ describe('deliverAiBudgetAlert', () => {
     expect(mocks.createNotification).not.toHaveBeenCalled();
   });
 
-  it('records the failure and rethrows so BullMQ retries', async () => {
+  it('records the failure in its OWN context and rethrows so BullMQ retries', async () => {
     mocks.sendEmail.mockRejectedValue(new Error('smtp down'));
     await expect(deliverAiBudgetAlert('evt-1')).rejects.toThrow('smtp down');
-    expect(JSON.stringify(mocks.execute.mock.calls.at(-1))).toContain('delivery_attempts');
+
+    // Minor 5: `toContain('delivery_attempts')` also matches the SUCCESS
+    // marker UPDATE, so it passed even when no failure row was written at all.
+    // Pin the failure write specifically: a non-null last_delivery_error and
+    // NO delivered_at stamp.
+    const last = renderQuery(mocks.execute.mock.calls.at(-1)?.[0]);
+    expect(last.sql).toContain('last_delivery_error =');
+    expect(last.sql).not.toContain('delivered_at = now()');
+    expect(last.params).toContain('smtp down');
+
+    // W02 important #2: the bookkeeping UPDATE must run in a FRESH context —
+    // written inside the delivery context it would be rolled back by the very
+    // rethrow that follows it (or fail 25P02 after a DB-level error).
+    expect(mocks.runOutside).toHaveBeenCalledTimes(2);
+    expect(mocks.withSystemContext).toHaveBeenCalledTimes(2);
   });
 
   it('marks delivered before the event-bus publish, so a publish failure does not fail delivery and a retry does not resend', async () => {
@@ -135,6 +207,7 @@ describe('deliverAiBudgetAlert', () => {
 describe('reconcileUndeliveredAiBudgetAlerts', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    armContextMocks();
   });
 
   it('re-enqueues each undelivered row and returns the row count', async () => {
@@ -150,10 +223,17 @@ describe('reconcileUndeliveredAiBudgetAlerts', () => {
     expect(count).toBe(2);
     const addMock = queue.add as unknown as ReturnType<typeof vi.fn>;
     const jobIds = addMock.mock.calls.map((call: unknown[]) => (call[2] as { jobId: string }).jobId);
-    expect(jobIds).toEqual(['deliver-evt-a', 'deliver-evt-b']);
+    // W02 critical #1 (iii): a per-sweep suffix. BullMQ's addStandardJob Lua
+    // short-circuits on `EXISTS <prefix><jobId>` and returns the EXISTING id,
+    // and `removeOnComplete: {count: 200}` keeps the completed hash around —
+    // so a bare `deliver-<id>` re-add after a completed no-op run enqueues
+    // NOTHING and the alert stays undelivered forever.
+    expect(jobIds[0]).toMatch(/^deliver-evt-a-r\d+$/);
+    expect(jobIds[1]).toMatch(/^deliver-evt-b-r\d+$/);
     const selectText = mocks.execute.mock.calls.map((call: unknown[]) => renderSql(call[0])).find((t: string) => t.includes('FROM ai_budget_alert_events'));
     expect(selectText).toContain('delivered_at IS NULL');
     expect(selectText).toContain('delivery_attempts <');
+    expect(mocks.withSystemContext).toHaveBeenCalledWith(expect.any(Function), 'aiBudgetAlertDelivery.reconcile');
   });
 
   it('enqueues nothing and returns 0 when there are no undelivered rows', async () => {
@@ -170,6 +250,7 @@ describe('reconcileUndeliveredAiBudgetAlerts', () => {
 describe('evaluatePartnerOrgs (partner-wide evaluation fan-out)', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    armContextMocks();
     mocks.evaluateAiBudgetThresholds.mockResolvedValue([]);
   });
 
@@ -187,6 +268,13 @@ describe('evaluatePartnerOrgs (partner-wide evaluation fan-out)', () => {
     const selectText = mocks.execute.mock.calls.map((call: unknown[]) => renderSql(call[0])).find((t: string) => t.includes('FROM organizations'));
     expect(selectText).toContain('partner_id');
     expect(selectText).toContain('deleted_at IS NULL');
+    // Minor 6: a dead-lifecycle org has no live AI spend and must not be
+    // re-evaluated (purging in particular is mid-erasure).
+    expect(selectText).toContain('status NOT IN');
+    for (const dead of ['purging', 'archived', 'churned', 'merging', 'offboarding']) {
+      expect(selectText).toContain(`'${dead}'`);
+    }
+    expect(mocks.withSystemContext).toHaveBeenCalledWith(expect.any(Function), 'aiBudgetAlertDelivery.evaluatePartner');
   });
 
   it('evaluates nothing when the partner has no active orgs', async () => {
@@ -196,5 +284,48 @@ describe('evaluatePartnerOrgs (partner-wide evaluation fan-out)', () => {
 
     expect(count).toBe(0);
     expect(mocks.evaluateAiBudgetThresholds).not.toHaveBeenCalled();
+  });
+});
+
+describe('processJob (payload validation + terminal not-visible handling)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    armContextMocks();
+    mocks.evaluateAiBudgetThresholds.mockResolvedValue([]);
+  });
+
+  it('drops a deliver job whose eventId is not a uuid instead of retrying it (minor 10)', async () => {
+    await expect(processJob(fakeJob({ type: 'deliver', eventId: 'not-a-uuid' }))).resolves.toMatchObject({ skipped: expect.any(String) });
+    expect(mocks.execute).not.toHaveBeenCalled();
+  });
+
+  it('drops an evaluate-partner job whose partnerId is not a uuid (minor 10)', async () => {
+    await expect(processJob(fakeJob({ type: 'evaluate-partner', partnerId: 42 }))).resolves.toMatchObject({ skipped: expect.any(String) });
+    expect(mocks.evaluateAiBudgetThresholds).not.toHaveBeenCalled();
+  });
+
+  it('drops a job with an unknown type', async () => {
+    await expect(processJob(fakeJob({ type: 'nonsense' }))).resolves.toMatchObject({ skipped: expect.any(String) });
+  });
+
+  it('runs a well-formed evaluate-partner job', async () => {
+    mocks.execute.mockImplementation(async (q: unknown) => (renderSql(q).includes('FROM organizations') ? [{ id: 'org-a' }] : []));
+    await expect(processJob(fakeJob({ type: 'evaluate-partner', partnerId: PARTNER_UUID }))).resolves.toBe(1);
+  });
+
+  it('retries a not-visible event on a non-final attempt, and gives up quietly on the final one (W02 critical #1 ii)', async () => {
+    mockExecute(null);
+
+    // attempt 1 of 5 -> the error propagates so BullMQ backs off and retries.
+    await expect(processJob(fakeJob({ type: 'deliver', eventId: EVENT_UUID }, { attemptsMade: 0, attempts: 5 })))
+      .rejects.toBeInstanceOf(AiBudgetAlertEventNotVisibleError);
+
+    // attempt 5 of 5 -> a genuinely deleted org must not land in Sentry as a
+    // failed job; log and complete instead.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    await expect(processJob(fakeJob({ type: 'deliver', eventId: EVENT_UUID }, { attemptsMade: 4, attempts: 5 })))
+      .resolves.toBeDefined();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining(EVENT_UUID));
+    warn.mockRestore();
   });
 });

--- a/apps/api/src/jobs/aiBudgetAlertDelivery.ts
+++ b/apps/api/src/jobs/aiBudgetAlertDelivery.ts
@@ -20,7 +20,7 @@ import { buildAiBudgetAlertEmail, describeAiBudgetAlert, shouldEmail } from '../
 import { evaluateAiBudgetThresholds } from '../services/aiBudgetAlerts';
 import { getFrontendBaseUrl } from '../services/c2cM365';
 import { PG_UUID_REGEX } from '../utils/uuid';
-import { attachWorkerObservability } from './workerObservability';
+import { attachWorkerObservability, type WorkerFailureClassification } from './workerObservability';
 
 export const AI_BUDGET_ALERT_QUEUE = 'ai-budget-alert-delivery';
 const USAGE_PATH = '/settings/ai-usage';
@@ -47,6 +47,34 @@ export class AiBudgetAlertEventNotVisibleError extends Error {
     super(`ai budget alert event ${eventId} is not visible (uncommitted or deleted)`);
     this.name = 'AiBudgetAlertEventNotVisibleError';
   }
+}
+
+/**
+ * Severity for this worker's own failure modes (BREEZE-1J mechanism).
+ *
+ * `AiBudgetAlertEventNotVisibleError` is thrown to ASK BullMQ for a retry on an
+ * expected, self-healing condition — the inserting transaction has not
+ * committed yet — not to report a fault. Without a classifier,
+ * `attachWorkerObservability`'s `failed` listener captureExceptions every
+ * attempt at error level, so the ordinary uncommitted-row race would page once
+ * per attempt for something the next attempt fixes by itself. Warning level,
+ * held until the attempts are exhausted, collapses that burst.
+ *
+ * Every other error keeps the default: error level, reported on each attempt.
+ * Reasons are hardcoded labels — no event, org or job id ever goes into a tag.
+ */
+export function classifyAiBudgetAlertFailure(
+  _job: Job | undefined,
+  err: Error,
+): WorkerFailureClassification | null {
+  if (err instanceof AiBudgetAlertEventNotVisibleError) {
+    return {
+      reason: 'ai_budget_alert_event_not_visible',
+      level: 'warning',
+      reportOnlyWhenExhausted: true,
+    };
+  }
+  return null;
 }
 
 export type AiBudgetAlertJobData =
@@ -315,6 +343,18 @@ export async function processJob(job: Job<AiBudgetAlertJobData>): Promise<unknow
         // failing it, so an ordinary tenant deletion doesn't page anyone.
         if (err instanceof AiBudgetAlertEventNotVisibleError && job.attemptsMade + 1 >= (job.opts.attempts ?? 1)) {
           console.warn(`[AI] budget alert event ${eventId} never became visible: rolled back or org deleted; giving up after ${job.attemptsMade + 1} attempt(s)`);
+          // Completing the job means BullMQ's `failed` event never fires on
+          // this, the exhausting attempt — so the classifier's
+          // `reportOnlyWhenExhausted` report for the earlier attempts is never
+          // released, and without the message below the mode would vanish from
+          // Sentry entirely. This is the classifier's terminal half: the same
+          // `warning` severity, emitted from the one place that knows the job
+          // is giving up. Deliberately NOT captureException: a deleted org is
+          // not a fault and must not page.
+          captureMessage('AI budget alert event never became visible', {
+            eventCode: 'ai_budget_alert_event_not_visible',
+            level: 'warning',
+          });
           return { skipped: 'event-not-visible' };
         }
         throw err;
@@ -339,7 +379,7 @@ export async function processJob(job: Job<AiBudgetAlertJobData>): Promise<unknow
 export async function initializeAiBudgetAlertWorker(): Promise<void> {
   if (worker) return;
   worker = new Worker<AiBudgetAlertJobData>(AI_BUDGET_ALERT_QUEUE, processJob, { connection: getBullMQConnection(), concurrency: 2 });
-  attachWorkerObservability(worker, AI_BUDGET_ALERT_QUEUE);
+  attachWorkerObservability(worker, AI_BUDGET_ALERT_QUEUE, { classifyFailure: classifyAiBudgetAlertFailure });
   // Sub-hourly (every 15 minutes), so it is exempt from scheduleRegistry.ts
   // (which only allocates coarse, >= hourly schedules) — confirmed against
   // scheduleRegistry.contract.test.ts's minimumGapMs threshold. The four

--- a/apps/api/src/jobs/aiBudgetAlertDelivery.ts
+++ b/apps/api/src/jobs/aiBudgetAlertDelivery.ts
@@ -129,21 +129,40 @@ export async function deliverAiBudgetAlert(eventId: string): Promise<{ recipient
         }
       }
 
-      await publishEvent(EVENT_TYPES.AI_BUDGET_THRESHOLD_CROSSED, event.org_id, {
-        eventId: event.id,
-        period: event.period,
-        periodKey: event.period_key,
-        thresholdPct: ctx.thresholdPct,
-        capCents: ctx.capCents,
-        usedCents: ctx.usedCents,
-        billingSource: event.billing_source,
-      }, 'ai-budget-alerts');
-
+      // Mark delivered BEFORE the event-bus publish. Notifications + email
+      // above are the actual customer-facing delivery; the publish below is
+      // observability only. If it were ordered first and then failed (a real
+      // Redis call), the outer catch would record a failed attempt and
+      // BullMQ would retry a job whose customer-facing work already
+      // succeeded — resending the email, which (unlike the in-app
+      // notification's dedupe-key unique index) has no idempotency guard.
+      // Marking delivered here means a retry hits the `event.delivered_at`
+      // short-circuit above and returns early instead of resending anything.
       await db.execute(sql`
         UPDATE ai_budget_alert_events
         SET delivered_at = now(), recipient_count = ${userIds.length}, delivery_attempts = delivery_attempts + 1, last_delivery_error = NULL
         WHERE id = ${eventId}::uuid
       `);
+
+      // Best-effort only, deliberately outside the outer try/catch's failure
+      // path: a publish failure must never undo the delivery just marked
+      // above or trigger a retry of it.
+      try {
+        await publishEvent(EVENT_TYPES.AI_BUDGET_THRESHOLD_CROSSED, event.org_id, {
+          eventId: event.id,
+          period: event.period,
+          periodKey: event.period_key,
+          thresholdPct: ctx.thresholdPct,
+          capCents: ctx.capCents,
+          usedCents: ctx.usedCents,
+          billingSource: event.billing_source,
+        }, 'ai-budget-alerts');
+      } catch (publishErr) {
+        const publishMsg = publishErr instanceof Error ? publishErr.message : String(publishErr);
+        console.error(`[AI] budget alert event-bus publish failed for event ${eventId} (delivery already marked complete):`, publishMsg);
+        captureException(publishErr instanceof Error ? publishErr : new Error(publishMsg), undefined, { service: 'aiBudgetAlertDelivery' });
+      }
+
       return { recipients: userIds.length, emailed };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -170,7 +189,8 @@ export async function reconcileUndeliveredAiBudgetAlerts(): Promise<number> {
   return rows.length;
 }
 
-async function evaluatePartnerOrgs(partnerId: string): Promise<number> {
+/** Exported for tests (finding 2, fix round 1). Internal to the job's switch otherwise — no other caller. */
+export async function evaluatePartnerOrgs(partnerId: string): Promise<number> {
   const rows = await runOutsideDbContext(() => withSystemDbAccessContext(() => db.execute<{ id: string }>(sql`
     SELECT id FROM organizations WHERE partner_id = ${partnerId}::uuid AND deleted_at IS NULL
   `)));

--- a/apps/api/src/jobs/aiBudgetAlertDelivery.ts
+++ b/apps/api/src/jobs/aiBudgetAlertDelivery.ts
@@ -1,0 +1,214 @@
+/**
+ * #4388 — delivery worker for pre-cap AI budget alert events recorded by
+ * `services/aiBudgetAlerts.ts`. One in-app notification per recipient, one
+ * combined email when the policy calls for it, an event-bus publish, plus a
+ * reconcile sweep for rows a crash left undelivered and a partner-wide
+ * evaluation fan-out for the org-scoped evaluator.
+ */
+
+import { Job, Queue, Worker } from 'bullmq';
+import { sql } from 'drizzle-orm';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { getBullMQConnection } from '../services/redis';
+import { captureException, captureMessage } from '../services/sentry';
+import { createNotification } from '../services/userNotifications';
+import { resolveUsersWithPermissionForOrg } from '../services/usersWithPermission';
+import { PERMISSIONS } from '../services/permissions';
+import { getEmailService } from '../services/email';
+import { EVENT_TYPES, publishEvent } from '../services/eventBus';
+import { buildAiBudgetAlertEmail, describeAiBudgetAlert, shouldEmail } from '../services/aiBudgetAlertEmail';
+import { evaluateAiBudgetThresholds } from '../services/aiBudgetAlerts';
+import { getFrontendBaseUrl } from '../services/c2cM365';
+import { attachWorkerObservability } from './workerObservability';
+
+export const AI_BUDGET_ALERT_QUEUE = 'ai-budget-alert-delivery';
+const USAGE_PATH = '/settings/ai-usage';
+const MAX_ATTEMPTS = 5;
+
+export type AiBudgetAlertJobData =
+  | { type: 'deliver'; eventId: string }
+  | { type: 'reconcile' }
+  | { type: 'evaluate-partner'; partnerId: string };
+
+let queue: Queue<AiBudgetAlertJobData> | null = null;
+let worker: Worker<AiBudgetAlertJobData> | null = null;
+
+export function getAiBudgetAlertQueue(): Queue<AiBudgetAlertJobData> {
+  if (!queue) queue = new Queue<AiBudgetAlertJobData>(AI_BUDGET_ALERT_QUEUE, { connection: getBullMQConnection() });
+  return queue;
+}
+
+export async function enqueueAiBudgetAlertDelivery(eventId: string): Promise<void> {
+  await getAiBudgetAlertQueue().add('deliver', { type: 'deliver', eventId }, {
+    jobId: `deliver-${eventId}`,
+    attempts: MAX_ATTEMPTS,
+    backoff: { type: 'exponential', delay: 30_000 },
+    removeOnComplete: { count: 200 },
+    removeOnFail: { count: 200 },
+  });
+}
+
+export async function enqueueAiBudgetEvaluationForPartner(partnerId: string): Promise<void> {
+  await getAiBudgetAlertQueue().add('evaluate-partner', { type: 'evaluate-partner', partnerId }, {
+    jobId: `evaluate-partner-${partnerId}-${Date.now()}`,
+    attempts: 3,
+    removeOnComplete: { count: 50 },
+    removeOnFail: { count: 50 },
+  });
+}
+
+type EventRow = {
+  id: string; org_id: string; org_name: string; period: 'daily' | 'monthly'; period_key: string;
+  threshold_pct: number; cap_cents: number; used_cents: number; billing_source: 'platform' | 'partner_key'; delivered_at: string | null;
+};
+
+/** Exported for tests. Idempotent: in-app writes dedupe on the event id, and a delivered row short-circuits. */
+export async function deliverAiBudgetAlert(eventId: string): Promise<{ recipients: number; emailed: boolean }> {
+  return runOutsideDbContext(() => withSystemDbAccessContext(async () => {
+    const loaded = await db.execute<EventRow>(sql`
+      SELECT e.id, e.org_id, o.name AS org_name, e.period, e.period_key, e.threshold_pct, e.cap_cents, e.used_cents, e.billing_source, e.delivered_at
+      FROM ai_budget_alert_events e
+      JOIN organizations o ON o.id = e.org_id
+      WHERE e.id = ${eventId}::uuid
+    `);
+    const event = loaded[0];
+    if (!event) {
+      // Org deleted (FK cascade) or never existed. Nothing to deliver.
+      return { recipients: 0, emailed: false };
+    }
+    if (event.delivered_at) return { recipients: 0, emailed: false };
+
+    try {
+      const ctx = {
+        orgName: event.org_name,
+        period: event.period,
+        periodKey: event.period_key,
+        thresholdPct: Number(event.threshold_pct),
+        capCents: Number(event.cap_cents),
+        usedCents: Number(event.used_cents),
+        billingSource: event.billing_source,
+        usagePath: USAGE_PATH,
+        appBaseUrl: getFrontendBaseUrl(),
+      };
+      const { title, message } = describeAiBudgetAlert(ctx);
+      const userIds = await resolveUsersWithPermissionForOrg(event.org_id, PERMISSIONS.BILLING_MANAGE);
+
+      if (userIds.length === 0) {
+        captureMessage('AI budget alert has no recipients', {
+          eventCode: 'ai_budget_alert_no_recipients',
+          tags: { org_id: event.org_id },
+        });
+      }
+
+      for (const userId of userIds) {
+        await createNotification({
+          userId,
+          orgId: event.org_id,
+          type: 'ai',
+          title,
+          message,
+          link: USAGE_PATH,
+          priority: ctx.thresholdPct >= 95 ? 'high' : 'normal',
+          metadata: { eventId: event.id, period: event.period, periodKey: event.period_key, thresholdPct: ctx.thresholdPct },
+          dedupeKey: `ai-budget-alert:${event.id}`,
+        });
+      }
+
+      let emailed = false;
+      const emailService = getEmailService();
+      if (emailService && userIds.length > 0 && shouldEmail(event.period, ctx.thresholdPct)) {
+        const rows = await db.execute<{ email: string }>(sql`
+          SELECT email FROM users
+          WHERE id IN (${sql.join(userIds.map((id) => sql`${id}::uuid`), sql`, `)}) AND email IS NOT NULL
+        `);
+        const to = rows.map((r) => r.email);
+        if (to.length > 0) {
+          const email = buildAiBudgetAlertEmail(ctx);
+          await emailService.sendEmail({ to, subject: email.subject, html: email.html, text: email.text });
+          emailed = true;
+        }
+      }
+
+      await publishEvent(EVENT_TYPES.AI_BUDGET_THRESHOLD_CROSSED, event.org_id, {
+        eventId: event.id,
+        period: event.period,
+        periodKey: event.period_key,
+        thresholdPct: ctx.thresholdPct,
+        capCents: ctx.capCents,
+        usedCents: ctx.usedCents,
+        billingSource: event.billing_source,
+      }, 'ai-budget-alerts');
+
+      await db.execute(sql`
+        UPDATE ai_budget_alert_events
+        SET delivered_at = now(), recipient_count = ${userIds.length}, delivery_attempts = delivery_attempts + 1, last_delivery_error = NULL
+        WHERE id = ${eventId}::uuid
+      `);
+      return { recipients: userIds.length, emailed };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await db.execute(sql`
+        UPDATE ai_budget_alert_events
+        SET delivery_attempts = delivery_attempts + 1, last_delivery_error = ${msg.slice(0, 500)}
+        WHERE id = ${eventId}::uuid
+      `).catch(() => undefined);
+      captureException(err instanceof Error ? err : new Error(msg), undefined, { service: 'aiBudgetAlertDelivery' });
+      throw err;
+    }
+  }));
+}
+
+/** Re-enqueues events inserted but never delivered (crash between insert and enqueue, or an enqueue call that itself failed). Excludes rows that already exhausted retries — those need operator attention, not another silent re-attempt. */
+export async function reconcileUndeliveredAiBudgetAlerts(): Promise<number> {
+  const rows = await runOutsideDbContext(() => withSystemDbAccessContext(() => db.execute<{ id: string }>(sql`
+    SELECT id FROM ai_budget_alert_events
+    WHERE delivered_at IS NULL AND delivery_attempts < ${MAX_ATTEMPTS} AND created_at < now() - interval '2 minutes'
+    ORDER BY created_at
+    LIMIT 500
+  `)));
+  for (const row of rows) await enqueueAiBudgetAlertDelivery(row.id);
+  return rows.length;
+}
+
+async function evaluatePartnerOrgs(partnerId: string): Promise<number> {
+  const rows = await runOutsideDbContext(() => withSystemDbAccessContext(() => db.execute<{ id: string }>(sql`
+    SELECT id FROM organizations WHERE partner_id = ${partnerId}::uuid AND deleted_at IS NULL
+  `)));
+  // Sequential, not Promise.all: bounded concurrency against a per-org
+  // evaluator that itself opens a system DB context and a transaction per
+  // period, so a large partner does not open dozens of connections at once.
+  for (const row of rows) await evaluateAiBudgetThresholds(row.id);
+  return rows.length;
+}
+
+async function processJob(job: Job<AiBudgetAlertJobData>): Promise<unknown> {
+  switch (job.data.type) {
+    case 'deliver': return deliverAiBudgetAlert(job.data.eventId);
+    case 'reconcile': return reconcileUndeliveredAiBudgetAlerts();
+    case 'evaluate-partner': return evaluatePartnerOrgs(job.data.partnerId);
+  }
+}
+
+export async function initializeAiBudgetAlertWorker(): Promise<void> {
+  if (worker) return;
+  worker = new Worker<AiBudgetAlertJobData>(AI_BUDGET_ALERT_QUEUE, processJob, { connection: getBullMQConnection(), concurrency: 2 });
+  attachWorkerObservability(worker, AI_BUDGET_ALERT_QUEUE);
+  // Sub-hourly (every 15 minutes), so it is exempt from scheduleRegistry.ts
+  // (which only allocates coarse, >= hourly schedules) — confirmed against
+  // scheduleRegistry.contract.test.ts's minimumGapMs threshold. The four
+  // offset minutes keep it off the :00/:15/:30/:45 pile-up other fine-grained
+  // ticks converge on.
+  await getAiBudgetAlertQueue().add('reconcile', { type: 'reconcile' }, {
+    jobId: 'ai-budget-alert-reconcile',
+    repeat: { pattern: '7,22,37,52 * * * *' },
+    removeOnComplete: { count: 5 },
+    removeOnFail: { count: 10 },
+  });
+}
+
+export async function shutdownAiBudgetAlertWorker(): Promise<void> {
+  await worker?.close();
+  worker = null;
+  await queue?.close();
+  queue = null;
+}

--- a/apps/api/src/jobs/aiBudgetAlertDelivery.ts
+++ b/apps/api/src/jobs/aiBudgetAlertDelivery.ts
@@ -19,11 +19,35 @@ import { EVENT_TYPES, publishEvent } from '../services/eventBus';
 import { buildAiBudgetAlertEmail, describeAiBudgetAlert, shouldEmail } from '../services/aiBudgetAlertEmail';
 import { evaluateAiBudgetThresholds } from '../services/aiBudgetAlerts';
 import { getFrontendBaseUrl } from '../services/c2cM365';
+import { PG_UUID_REGEX } from '../utils/uuid';
 import { attachWorkerObservability } from './workerObservability';
 
 export const AI_BUDGET_ALERT_QUEUE = 'ai-budget-alert-delivery';
 const USAGE_PATH = '/settings/ai-usage';
 const MAX_ATTEMPTS = 5;
+
+/**
+ * The event row is not readable yet — almost always because the inserting
+ * transaction has not committed (`evaluateAiBudgetThresholds` running inside a
+ * caller-owned system transaction still enqueues before that transaction
+ * commits), occasionally because the org was deleted and the FK cascade took
+ * the row with it.
+ *
+ * This MUST be an error, not a `{recipients: 0}` success. A completed job's
+ * hash is retained by `removeOnComplete`, and BullMQ's addStandardJob Lua
+ * returns the EXISTING id when `EXISTS <prefix><jobId>` — so a job that
+ * completed against an invisible row makes every later add under the same job
+ * id (including the reconcile sweep's) a silent no-op, and the alert is lost
+ * for good. Throwing lets the configured exponential backoff re-read the row
+ * once it is visible; `processJob` converts the FINAL attempt into a logged
+ * completion so a genuinely deleted org does not page anyone.
+ */
+export class AiBudgetAlertEventNotVisibleError extends Error {
+  constructor(public readonly eventId: string) {
+    super(`ai budget alert event ${eventId} is not visible (uncommitted or deleted)`);
+    this.name = 'AiBudgetAlertEventNotVisibleError';
+  }
+}
 
 export type AiBudgetAlertJobData =
   | { type: 'deliver'; eventId: string }
@@ -38,9 +62,17 @@ export function getAiBudgetAlertQueue(): Queue<AiBudgetAlertJobData> {
   return queue;
 }
 
-export async function enqueueAiBudgetAlertDelivery(eventId: string): Promise<void> {
+/**
+ * `jobId` defaults to the stable `deliver-<eventId>`, which is what makes the
+ * ordinary post-insert enqueue idempotent. The reconcile sweep passes its OWN
+ * per-sweep id instead: a retained completed/failed job hash under the stable
+ * id would otherwise make the sweep's re-add a no-op (BullMQ returns the
+ * existing job id when the key exists), i.e. the exact rows reconcile exists
+ * to rescue would be the rows it can never re-enqueue.
+ */
+export async function enqueueAiBudgetAlertDelivery(eventId: string, jobId = `deliver-${eventId}`): Promise<void> {
   await getAiBudgetAlertQueue().add('deliver', { type: 'deliver', eventId }, {
-    jobId: `deliver-${eventId}`,
+    jobId,
     attempts: MAX_ATTEMPTS,
     backoff: { type: 'exponential', delay: 30_000 },
     removeOnComplete: { count: 200 },
@@ -62,23 +94,54 @@ type EventRow = {
   threshold_pct: number; cap_cents: number; used_cents: number; billing_source: 'platform' | 'partner_key'; delivered_at: string | null;
 };
 
+/**
+ * Record a failed attempt on the event row.
+ *
+ * Deliberately its OWN `runOutsideDbContext` + system context, run only AFTER
+ * the delivery context has unwound. Written inside the delivery context — as
+ * it was before W02 — the UPDATE is part of the very transaction the rethrow
+ * then aborts, so it leaves NO durable trace: `delivery_attempts` stays 0 and
+ * `last_delivery_error` stays NULL forever. That is not cosmetic. The
+ * reconcile sweep's `delivery_attempts < MAX_ATTEMPTS` guard exists to stop
+ * re-attempting a permanently broken row, and with a counter frozen at 0 it
+ * can never fire; operators, meanwhile, see a row that looks untouched rather
+ * than one that has failed five times. Worse, when the original error came
+ * from a DB statement the transaction is already aborted, so the bookkeeping
+ * write itself fails with 25P02 instead of recording anything.
+ *
+ * Best-effort by construction: a failure here must not mask the real error.
+ */
+async function recordDeliveryFailure(eventId: string, message: string): Promise<void> {
+  await runOutsideDbContext(() => withSystemDbAccessContext(() => db.execute(sql`
+    UPDATE ai_budget_alert_events
+    SET delivery_attempts = delivery_attempts + 1, last_delivery_error = ${message.slice(0, 500)}
+    WHERE id = ${eventId}::uuid
+  `), 'aiBudgetAlertDelivery.recordFailure')).catch((bookkeepingErr: unknown) => {
+    console.error(`[AI] budget alert failure bookkeeping failed for event ${eventId}:`, bookkeepingErr instanceof Error ? bookkeepingErr.message : bookkeepingErr);
+  });
+}
+
 /** Exported for tests. Idempotent: in-app writes dedupe on the event id, and a delivered row short-circuits. */
 export async function deliverAiBudgetAlert(eventId: string): Promise<{ recipients: number; emailed: boolean }> {
-  return runOutsideDbContext(() => withSystemDbAccessContext(async () => {
-    const loaded = await db.execute<EventRow>(sql`
-      SELECT e.id, e.org_id, o.name AS org_name, e.period, e.period_key, e.threshold_pct, e.cap_cents, e.used_cents, e.billing_source, e.delivered_at
-      FROM ai_budget_alert_events e
-      JOIN organizations o ON o.id = e.org_id
-      WHERE e.id = ${eventId}::uuid
-    `);
-    const event = loaded[0];
-    if (!event) {
-      // Org deleted (FK cascade) or never existed. Nothing to deliver.
-      return { recipients: 0, emailed: false };
-    }
-    if (event.delivered_at) return { recipients: 0, emailed: false };
+  try {
+    return await runOutsideDbContext(() => withSystemDbAccessContext(async () => {
+      // FOR UPDATE OF e (the event row only — never the joined organizations
+      // row) serialises two jobs racing the same event: the loser blocks here
+      // until the winner's transaction commits and then reads the freshly
+      // stamped `delivered_at`, taking the no-op branch below instead of
+      // sending a second email. Without the lock both jobs read
+      // `delivered_at IS NULL` concurrently and both send.
+      const loaded = await db.execute<EventRow>(sql`
+        SELECT e.id, e.org_id, o.name AS org_name, e.period, e.period_key, e.threshold_pct, e.cap_cents, e.used_cents, e.billing_source, e.delivered_at
+        FROM ai_budget_alert_events e
+        JOIN organizations o ON o.id = e.org_id
+        WHERE e.id = ${eventId}::uuid
+        FOR UPDATE OF e
+      `);
+      const event = loaded[0];
+      if (!event) throw new AiBudgetAlertEventNotVisibleError(eventId);
+      if (event.delivered_at) return { recipients: 0, emailed: false };
 
-    try {
       const ctx = {
         orgName: event.org_name,
         period: event.period,
@@ -129,7 +192,9 @@ export async function deliverAiBudgetAlert(eventId: string): Promise<{ recipient
         }
       }
 
-      // Mark delivered BEFORE the event-bus publish. Notifications + email
+      // Mark delivered BEFORE the event-bus publish, and inside the SAME
+      // transaction as the notification writes above, so the marker and the
+      // delivery it marks commit or roll back together. Notifications + email
       // above are the actual customer-facing delivery; the publish below is
       // observability only. If it were ordered first and then failed (a real
       // Redis call), the outer catch would record a failed attempt and
@@ -144,9 +209,9 @@ export async function deliverAiBudgetAlert(eventId: string): Promise<{ recipient
         WHERE id = ${eventId}::uuid
       `);
 
-      // Best-effort only, deliberately outside the outer try/catch's failure
-      // path: a publish failure must never undo the delivery just marked
-      // above or trigger a retry of it.
+      // Best-effort only, swallowed here so it never reaches the function-level
+      // failure path: a publish failure must never undo the delivery just
+      // marked above or trigger a retry of it.
       try {
         await publishEvent(EVENT_TYPES.AI_BUDGET_THRESHOLD_CROSSED, event.org_id, {
           eventId: event.id,
@@ -163,18 +228,22 @@ export async function deliverAiBudgetAlert(eventId: string): Promise<{ recipient
         captureException(publishErr instanceof Error ? publishErr : new Error(publishMsg), undefined, { service: 'aiBudgetAlertDelivery' });
       }
 
+      console.log(`[AI] budget alert delivered event=${eventId} org=${event.org_id} recipients=${userIds.length} emailed=${emailed}`);
       return { recipients: userIds.length, emailed };
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      await db.execute(sql`
-        UPDATE ai_budget_alert_events
-        SET delivery_attempts = delivery_attempts + 1, last_delivery_error = ${msg.slice(0, 500)}
-        WHERE id = ${eventId}::uuid
-      `).catch(() => undefined);
-      captureException(err instanceof Error ? err : new Error(msg), undefined, { service: 'aiBudgetAlertDelivery' });
+    }, 'aiBudgetAlertDelivery.deliver'));
+  } catch (err) {
+    // OUTSIDE the context above on purpose — see `recordDeliveryFailure`.
+    if (err instanceof AiBudgetAlertEventNotVisibleError) {
+      // No row to book anything against, and no bug to report: the insert has
+      // not committed yet (retry) or the org is gone (processJob retires it on
+      // the final attempt). Deliberately not sent to Sentry.
       throw err;
     }
-  }));
+    const msg = err instanceof Error ? err.message : String(err);
+    await recordDeliveryFailure(eventId, msg);
+    captureException(err instanceof Error ? err : new Error(msg), undefined, { service: 'aiBudgetAlertDelivery' });
+    throw err;
+  }
 }
 
 /** Re-enqueues events inserted but never delivered (crash between insert and enqueue, or an enqueue call that itself failed). Excludes rows that already exhausted retries — those need operator attention, not another silent re-attempt. */
@@ -184,28 +253,86 @@ export async function reconcileUndeliveredAiBudgetAlerts(): Promise<number> {
     WHERE delivered_at IS NULL AND delivery_attempts < ${MAX_ATTEMPTS} AND created_at < now() - interval '2 minutes'
     ORDER BY created_at
     LIMIT 500
-  `)));
-  for (const row of rows) await enqueueAiBudgetAlertDelivery(row.id);
+  `), 'aiBudgetAlertDelivery.reconcile'));
+  // One id per sweep, shared by every row in it: unique enough to defeat a
+  // retained job hash, stable enough that two overlapping sweeps (the repeat
+  // job is every 15 minutes; a sweep is bounded at 500 rows) still collapse
+  // into one job per row rather than queueing the same delivery twice.
+  const sweep = Date.now();
+  for (const row of rows) await enqueueAiBudgetAlertDelivery(row.id, `deliver-${row.id}-r${sweep}`);
+  if (rows.length > 0) console.log(`[AI] budget alert reconcile re-enqueued ${rows.length} undelivered event(s)`);
   return rows.length;
 }
 
 /** Exported for tests (finding 2, fix round 1). Internal to the job's switch otherwise — no other caller. */
 export async function evaluatePartnerOrgs(partnerId: string): Promise<number> {
+  // Dead-lifecycle orgs are skipped: they accrue no AI spend, so evaluating
+  // them is pure load, and `purging` is mid-erasure — inserting a fresh
+  // ai_budget_alert_events row under it would race the cascade. Written as an
+  // EXCLUSION list rather than `status = 'active'` on purpose: `trial` orgs
+  // are live paying-adjacent tenants whose budgets very much do apply, and a
+  // future live status must default to being evaluated, not to silently
+  // dropping out of alerting.
   const rows = await runOutsideDbContext(() => withSystemDbAccessContext(() => db.execute<{ id: string }>(sql`
-    SELECT id FROM organizations WHERE partner_id = ${partnerId}::uuid AND deleted_at IS NULL
-  `)));
+    SELECT id FROM organizations
+    WHERE partner_id = ${partnerId}::uuid
+      AND deleted_at IS NULL
+      AND status NOT IN ('purging', 'archived', 'churned', 'merging', 'offboarding')
+  `), 'aiBudgetAlertDelivery.evaluatePartner'));
   // Sequential, not Promise.all: bounded concurrency against a per-org
   // evaluator that itself opens a system DB context and a transaction per
   // period, so a large partner does not open dozens of connections at once.
   for (const row of rows) await evaluateAiBudgetThresholds(row.id);
+  console.log(`[AI] budget alert partner fan-out partner=${partnerId} orgs=${rows.length}`);
   return rows.length;
 }
 
-async function processJob(job: Job<AiBudgetAlertJobData>): Promise<unknown> {
-  switch (job.data.type) {
-    case 'deliver': return deliverAiBudgetAlert(job.data.eventId);
-    case 'reconcile': return reconcileUndeliveredAiBudgetAlerts();
-    case 'evaluate-partner': return evaluatePartnerOrgs(job.data.partnerId);
+/**
+ * Exported for tests.
+ *
+ * `job.data` is deserialised Redis payload, not a typed value: a job left over
+ * from an older deploy, a hand-injected one, or a truncated write all arrive
+ * here shaped however Redis had them. An unvalidated id goes straight into a
+ * `::uuid` cast and raises 22P02 on every one of the five attempts before
+ * failing loudly for something no retry can fix — so validate the shape first
+ * and drop what cannot be run.
+ */
+export async function processJob(job: Job<AiBudgetAlertJobData>): Promise<unknown> {
+  const data = job.data as Partial<{ type: unknown; eventId: unknown; partnerId: unknown }> | undefined;
+
+  switch (data?.type) {
+    case 'deliver': {
+      const eventId = data.eventId;
+      if (typeof eventId !== 'string' || !PG_UUID_REGEX.test(eventId)) {
+        console.error(`[AI] budget alert job ${job.id} carries a non-uuid eventId (${String(eventId)}); dropping`);
+        return { skipped: 'invalid-event-id' };
+      }
+      try {
+        return await deliverAiBudgetAlert(eventId);
+      } catch (err) {
+        // Final attempt on a row that never appeared: the insert was rolled
+        // back or the org was erased. Complete the job with a log instead of
+        // failing it, so an ordinary tenant deletion doesn't page anyone.
+        if (err instanceof AiBudgetAlertEventNotVisibleError && job.attemptsMade + 1 >= (job.opts.attempts ?? 1)) {
+          console.warn(`[AI] budget alert event ${eventId} never became visible: rolled back or org deleted; giving up after ${job.attemptsMade + 1} attempt(s)`);
+          return { skipped: 'event-not-visible' };
+        }
+        throw err;
+      }
+    }
+    case 'reconcile':
+      return reconcileUndeliveredAiBudgetAlerts();
+    case 'evaluate-partner': {
+      const partnerId = data.partnerId;
+      if (typeof partnerId !== 'string' || !PG_UUID_REGEX.test(partnerId)) {
+        console.error(`[AI] budget alert job ${job.id} carries a non-uuid partnerId (${String(partnerId)}); dropping`);
+        return { skipped: 'invalid-partner-id' };
+      }
+      return evaluatePartnerOrgs(partnerId);
+    }
+    default:
+      console.error(`[AI] budget alert job ${job.id} has an unrecognised type (${String(data?.type)}); dropping`);
+      return { skipped: 'unknown-job-type' };
   }
 }
 

--- a/apps/api/src/jobs/workerObservability.ts
+++ b/apps/api/src/jobs/workerObservability.ts
@@ -88,6 +88,8 @@ export const WORKER_FAILURE_REASONS = [
   'desktop_stop_pending',
   /** desktopSessionFinalizationWorker: another finalizer already released the intent. */
   'desktop_intent_already_released',
+  /** aiBudgetAlertDelivery: the event row is not committed/visible yet (#4388). */
+  'ai_budget_alert_event_not_visible',
 ] as const;
 
 export type WorkerFailureReason = (typeof WORKER_FAILURE_REASONS)[number];

--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -5074,6 +5074,43 @@ describe('org routes', () => {
       expect(enqueueAiBudgetEvaluationForPartner).toHaveBeenCalledWith('partner-123');
     });
 
+    // W02 minor 8: `!== undefined` fires the fleet-wide fan-out on every save
+    // of the AI settings card, including the many that re-post an unchanged
+    // aiBudgets block alongside an edit to some other field. The fan-out walks
+    // EVERY org of the partner and evaluates each one, so a no-op resubmit is
+    // real, avoidable load. Compare the value actually being persisted against
+    // the previous one.
+    it('does NOT enqueue when the submitted aiBudgets is deep-equal to the stored one (#4388 W02)', async () => {
+      setAuthContext({ scope: 'partner', partnerId: 'partner-123' });
+      const storedAiBudgets = { monthlyBudgetCents: 5000, alertThresholdPercents: [50, 95] };
+      const currentPartner = { id: 'partner-123', name: 'Acme MSP', settings: { aiBudgets: storedAiBudgets } };
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([currentPartner]),
+          }),
+        }),
+      } as any);
+      vi.mocked(db.update).mockReturnValueOnce({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([currentPartner]),
+          }),
+        }),
+      } as any);
+
+      const res = await app.request('/orgs/partners/me', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        // Rungs resubmitted in a different order: normalisation makes this
+        // byte-identical to what is already stored, so it is a true no-op.
+        body: JSON.stringify({ settings: { aiBudgets: { monthlyBudgetCents: 5000, alertThresholdPercents: [95, 50] } } }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(enqueueAiBudgetEvaluationForPartner).not.toHaveBeenCalled();
+    });
+
     // NOTE: `updatePartnerSettingsSchema`'s `aiBudgets` field is
     // `z.object({...}).optional()`, not `.nullable()` — an explicit
     // `{ aiBudgets: null }` is rejected by zValidator before the handler ever

--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -13,6 +13,13 @@ vi.mock('../services/clientIp', () => ({
   getTrustedClientIpOrUndefined: vi.fn()
 }));
 
+// PATCH /partners/me fans a partner-wide aiBudgets change out to every org's
+// budget evaluation (#4388 W02) — mocked so these route tests pin the CALL,
+// not the queue/worker machinery (covered by jobs/aiBudgetAlertDelivery.test.ts).
+vi.mock('../jobs/aiBudgetAlertDelivery', () => ({
+  enqueueAiBudgetEvaluationForPartner: vi.fn().mockResolvedValue(undefined),
+}));
+
 // GET /orgs/sites rides the org's resolved enrollment defaults along for the
 // Add Device modal (#2776). Mocked so these route tests don't depend on the
 // org⋈partner settings join.
@@ -294,6 +301,7 @@ import {
 } from '../services/tenantOffboarding';
 import { captureException } from '../services/sentry';
 import { seedSystemTicketStatuses } from '../services/ticketConfigService';
+import { enqueueAiBudgetEvaluationForPartner } from '../jobs/aiBudgetAlertDelivery';
 
 describe('org routes', () => {
   let app: Hono;
@@ -5033,6 +5041,74 @@ describe('org routes', () => {
 
       expect(res.status).toBe(200);
       expect(persistedSettings?.aiBudgets).toMatchObject({ alertThresholdPercents: [50, 95] });
+    });
+
+    // spec §4.2 #3: a partner-wide cap/rung change must be re-evaluated for
+    // every org off-request, since the effective budget for orgs with no
+    // org-level override changes the instant the partner-wide default does.
+    it('enqueues a partner-wide budget re-evaluation when aiBudgets change (#4388)', async () => {
+      setAuthContext({ scope: 'partner', partnerId: 'partner-123' });
+      const currentPartner = { id: 'partner-123', name: 'Acme MSP', settings: {} };
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([currentPartner]),
+          }),
+        }),
+      } as any);
+      vi.mocked(db.update).mockReturnValueOnce({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ ...currentPartner, settings: { aiBudgets: { monthlyBudgetCents: 5000 } } }]),
+          }),
+        }),
+      } as any);
+
+      const res = await app.request('/orgs/partners/me', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ settings: { aiBudgets: { monthlyBudgetCents: 5000 } } }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(enqueueAiBudgetEvaluationForPartner).toHaveBeenCalledWith('partner-123');
+    });
+
+    // NOTE: `updatePartnerSettingsSchema`'s `aiBudgets` field is
+    // `z.object({...}).optional()`, not `.nullable()` — an explicit
+    // `{ aiBudgets: null }` is rejected by zValidator before the handler ever
+    // runs (confirmed: zod's `invalid_type` on `null` for an optional object).
+    // So the `!== undefined` check in the handler (rather than a truthy check)
+    // is written to also cover a future null-clearing payload once the schema
+    // allows one, but that scenario isn't reachable through this route today
+    // and isn't exercised here — only the two reachable cases are.
+
+    it('does NOT enqueue a partner-wide budget re-evaluation on a PATCH that does not touch aiBudgets', async () => {
+      setAuthContext({ scope: 'partner', partnerId: 'partner-123' });
+      const currentPartner = { id: 'partner-123', name: 'Acme MSP', settings: {} };
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([currentPartner]),
+          }),
+        }),
+      } as any);
+      vi.mocked(db.update).mockReturnValueOnce({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ ...currentPartner, name: 'Acme Managed Services' }]),
+          }),
+        }),
+      } as any);
+
+      const res = await app.request('/orgs/partners/me', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Acme Managed Services' }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(enqueueAiBudgetEvaluationForPartner).not.toHaveBeenCalled();
     });
 
     // issue #2124: a partner-locked pin can freeze every child org's fleet, so an

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -1,3 +1,4 @@
+import { isDeepStrictEqual } from 'node:util';
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import type { Context, Next } from 'hono';
@@ -1033,8 +1034,16 @@ orgRoutes.patch(
   clearPartnerScopePolicyCache(partner.id);
   clearPartnerAllowlistCache(partner.id);
 
-  if (body.settings?.aiBudgets !== undefined) {
-    // Caps or rungs changed fleet-wide: re-evaluate every org off-request (spec §4.2 #3).
+  // Caps or rungs changed fleet-wide: re-evaluate every org off-request (spec
+  // §4.2 #3). Compare the value actually PERSISTED (post-normalisation) against
+  // what was stored, not merely `!== undefined`: the settings card re-posts the
+  // whole aiBudgets block on every save, so a presence check fans a full
+  // partner-wide evaluation — one per org, each opening its own DB context —
+  // out of an edit to some unrelated field. `isDeepStrictEqual` matches the
+  // comparison `assertNotLocked` (services/effectiveSettings.ts) already uses
+  // on this same JSONB, and normalisation above makes a reordered rung array a
+  // true no-op rather than a spurious change.
+  if (body.settings?.aiBudgets !== undefined && !isDeepStrictEqual(newSettings.aiBudgets, currentSettings.aiBudgets)) {
     void enqueueAiBudgetEvaluationForPartner(auth.partnerId as string).catch((err: unknown) => {
       console.error('[orgs] aiBudgets fan-out enqueue failed:', err instanceof Error ? err.message : err);
     });

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -15,6 +15,7 @@ import { authMiddleware, requireMfa, requirePermission, requireScope, requirePar
 import { writeAuditEvent, writeRouteAudit } from '../services/auditEvents';
 import { getEffectiveOrgSettings, assertNotLocked } from '../services/effectiveSettings';
 import { normalizeAlertThresholds } from '../services/aiBudgetAlerts';
+import { enqueueAiBudgetEvaluationForPartner } from '../jobs/aiBudgetAlertDelivery';
 import { clearPartnerScopePolicyCache } from '../oauth/partnerScopePolicy';
 import { PERMISSIONS, canAccessSite, type UserPermissions } from '../services/permissions';
 import {
@@ -1031,6 +1032,13 @@ orgRoutes.patch(
   // next token mint without waiting for the 60s TTL.
   clearPartnerScopePolicyCache(partner.id);
   clearPartnerAllowlistCache(partner.id);
+
+  if (body.settings?.aiBudgets !== undefined) {
+    // Caps or rungs changed fleet-wide: re-evaluate every org off-request (spec §4.2 #3).
+    void enqueueAiBudgetEvaluationForPartner(auth.partnerId as string).catch((err: unknown) => {
+      console.error('[orgs] aiBudgets fan-out enqueue failed:', err instanceof Error ? err.message : err);
+    });
+  }
 
   const auditOrgId = await resolveAuditOrgIdForPartner(auth.partnerId);
   writeRouteAudit(c, {

--- a/apps/api/src/services/actionIntents/intentApprovers.ts
+++ b/apps/api/src/services/actionIntents/intentApprovers.ts
@@ -41,8 +41,6 @@ import {
   organizations,
   organizationUsers,
   partnerUsers,
-  rolePermissions,
-  permissions,
   users,
   type ActionIntent,
 } from '../../db/schema';
@@ -55,6 +53,7 @@ import {
   getUserPermissions,
   hasPermission,
 } from '../permissions';
+import { resolveUsersWithPermissionForOrg } from '../usersWithPermission';
 
 /**
  * Resolve the distinct user ids eligible to decide an action intent for
@@ -62,86 +61,7 @@ import {
  * context, so it may be called from any ambient context (or none).
  */
 export async function resolveIntentApprovers(orgId: string): Promise<string[]> {
-  return withSystemDbAccessContext(async () => {
-    // Role ids that grant approvals:decide. One join from role_permissions →
-    // permissions; matches the resource/action pair AND the wildcard grants
-    // (resource='*' / action='*') so this resolver mirrors hasPermission()
-    // (permissions.ts), which treats resource==='*' / action==='*' as
-    // covering any concrete pair. Without this a role granting approvals:* or
-    // *:* (superadmin) would never resolve as an eligible approver.
-    const grantingRoles = await db
-      .select({ roleId: rolePermissions.roleId })
-      .from(rolePermissions)
-      .innerJoin(permissions, eq(rolePermissions.permissionId, permissions.id))
-      .where(
-        and(
-          inArray(permissions.resource, [PERMISSIONS.APPROVALS_DECIDE.resource, '*']),
-          inArray(permissions.action, [PERMISSIONS.APPROVALS_DECIDE.action, '*']),
-        ),
-      );
-
-    const grantingRoleIds = [...new Set(grantingRoles.map((r) => r.roleId))];
-    if (grantingRoleIds.length === 0) return [];
-
-    // The org's owning partner — needed to resolve partner-scope membership.
-    const [org] = await db
-      .select({ partnerId: organizations.partnerId })
-      .from(organizations)
-      .where(eq(organizations.id, orgId))
-      .limit(1);
-
-    const candidateUserIds = new Set<string>();
-
-    // 1. Direct org members holding an approvals:decide role. Joined against
-    // `users` and gated on status='active' so a disabled or still-invited
-    // account is never counted as an eligible approver — it both inflates
-    // the four-eyes fan-out with someone who can't actually decide, and can
-    // wrongly suppress the sole-operator fallback (intentService.ts) by
-    // making it look like a second approver exists when none does.
-    const orgMembers = await db
-      .select({ userId: organizationUsers.userId })
-      .from(organizationUsers)
-      .innerJoin(users, eq(users.id, organizationUsers.userId))
-      .where(
-        and(
-          eq(organizationUsers.orgId, orgId),
-          inArray(organizationUsers.roleId, grantingRoleIds),
-          eq(users.status, 'active'),
-        ),
-      );
-    for (const m of orgMembers) candidateUserIds.add(m.userId);
-
-    // 2. Partner members of the org's partner whose org_access covers this
-    // org — the population plain organization_users membership can never see
-    // (CRITICAL-2: partner techs/admins have no organization_users row).
-    // Same `users` join + status='active' gate as above.
-    if (org?.partnerId) {
-      const partnerMembers = await db
-        .select({
-          userId: partnerUsers.userId,
-          orgAccess: partnerUsers.orgAccess,
-          orgIds: partnerUsers.orgIds,
-        })
-        .from(partnerUsers)
-        .innerJoin(users, eq(users.id, partnerUsers.userId))
-        .where(
-          and(
-            eq(partnerUsers.partnerId, org.partnerId),
-            inArray(partnerUsers.roleId, grantingRoleIds),
-            eq(users.status, 'active'),
-          ),
-        );
-      for (const m of partnerMembers) {
-        if (m.orgAccess === 'all') {
-          candidateUserIds.add(m.userId);
-        } else if (m.orgAccess === 'selected' && m.orgIds?.includes(orgId)) {
-          candidateUserIds.add(m.userId);
-        }
-      }
-    }
-
-    return [...candidateUserIds];
-  });
+  return resolveUsersWithPermissionForOrg(orgId, PERMISSIONS.APPROVALS_DECIDE);
 }
 
 // ============================================================

--- a/apps/api/src/services/aiBudgetAlertEmail.test.ts
+++ b/apps/api/src/services/aiBudgetAlertEmail.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { buildAiBudgetAlertEmail, describeAiBudgetAlert, periodResetLabel, shouldEmail } from './aiBudgetAlertEmail';
+
+const base = { orgName: 'Acme <Corp>', period: 'monthly' as const, periodKey: '2026-09', thresholdPct: 80, capCents: 10000, usedCents: 8123, billingSource: 'platform' as const, usagePath: '/settings/ai-usage', appBaseUrl: 'https://app.example.com' };
+
+describe('describeAiBudgetAlert', () => {
+  it('names the rung, org and period', () => {
+    expect(describeAiBudgetAlert(base).title).toBe('AI budget at 80% for Acme <Corp> (monthly)');
+    expect(describeAiBudgetAlert(base).message).toContain('$81.23 of $100.00');
+  });
+  it('uses cap-reached wording at 100', () => {
+    const d = describeAiBudgetAlert({ ...base, thresholdPct: 100, usedCents: 10000 });
+    expect(d.title).toBe('AI budget reached for Acme <Corp> (monthly)');
+    expect(d.message).toContain('paused');
+  });
+});
+
+describe('buildAiBudgetAlertEmail', () => {
+  it('escapes the org name and links to the usage page', () => {
+    const e = buildAiBudgetAlertEmail(base);
+    expect(e.html).toContain('Acme &lt;Corp&gt;');
+    expect(e.html).not.toContain('Acme <Corp>');
+    expect(e.html).toContain('https://app.example.com/settings/ai-usage');
+    expect(e.text).toContain('$81.23 of $100.00');
+  });
+  it('states the billing destination', () => {
+    expect(buildAiBudgetAlertEmail(base).text).toContain('Breeze AI credits');
+    expect(buildAiBudgetAlertEmail({ ...base, billingSource: 'partner_key' }).text).toContain('your Anthropic API key');
+  });
+});
+
+describe('periodResetLabel', () => {
+  it('monthly resets on the first of next month UTC', () => expect(periodResetLabel('monthly', '2026-09')).toBe('1 Oct 2026 00:00 UTC'));
+  it('daily resets next UTC midnight', () => expect(periodResetLabel('daily', '2026-09-30')).toBe('1 Oct 2026 00:00 UTC'));
+});
+
+describe('shouldEmail', () => {
+  it.each([['monthly', 50, true], ['monthly', 100, true], ['daily', 80, false], ['daily', 100, true]] as const)('%s %s → %s', (p, r, want) => {
+    expect(shouldEmail(p, r)).toBe(want);
+  });
+});

--- a/apps/api/src/services/aiBudgetAlertEmail.test.ts
+++ b/apps/api/src/services/aiBudgetAlertEmail.test.ts
@@ -16,10 +16,12 @@ describe('describeAiBudgetAlert', () => {
 });
 
 describe('buildAiBudgetAlertEmail', () => {
-  it('escapes the org name and links to the usage page', () => {
+  it('escapes the org name exactly once in the heading', () => {
     const e = buildAiBudgetAlertEmail(base);
-    expect(e.html).toContain('Acme &lt;Corp&gt;');
-    expect(e.html).not.toContain('Acme <Corp>');
+    const heading = e.html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/)?.[1] ?? '';
+    expect(heading).toContain('Acme &lt;Corp&gt;');
+    expect(heading).not.toContain('&amp;lt;');
+    expect(heading).not.toContain('<Corp>');
     expect(e.html).toContain('https://app.example.com/settings/ai-usage');
     expect(e.text).toContain('$81.23 of $100.00');
   });
@@ -35,7 +37,7 @@ describe('periodResetLabel', () => {
 });
 
 describe('shouldEmail', () => {
-  it.each([['monthly', 50, true], ['monthly', 100, true], ['daily', 80, false], ['daily', 100, true]] as const)('%s %s → %s', (p, r, want) => {
+  it.each([['monthly', 50, true], ['monthly', 100, true], ['daily', 80, false], ['daily', 99, false], ['daily', 100, true]] as const)('%s %s → %s', (p, r, want) => {
     expect(shouldEmail(p, r)).toBe(want);
   });
 });

--- a/apps/api/src/services/aiBudgetAlertEmail.ts
+++ b/apps/api/src/services/aiBudgetAlertEmail.ts
@@ -52,6 +52,6 @@ export function buildAiBudgetAlertEmail(ctx: AiBudgetAlertContext): { subject: s
     renderButton('Review AI usage', url),
     renderParagraph('You receive this because you can manage billing for this organization in Breeze.', { muted: true, marginTop: 16 }),
   ].join('\n');
-  const html = renderLayout({ title, preheader: message.slice(0, 120), heading: escapeHtml(title), body });
+  const html = renderLayout({ title, preheader: message.slice(0, 120), heading: title, body });
   return { subject: title, html, text };
 }

--- a/apps/api/src/services/aiBudgetAlertEmail.ts
+++ b/apps/api/src/services/aiBudgetAlertEmail.ts
@@ -1,0 +1,57 @@
+import { escapeHtml, renderButton, renderLayout, renderParagraph } from './emailLayout';
+
+export interface AiBudgetAlertContext {
+  orgName: string;
+  period: 'daily' | 'monthly';
+  periodKey: string;
+  thresholdPct: number;
+  capCents: number;
+  usedCents: number;
+  billingSource: 'platform' | 'partner_key';
+  usagePath: string;
+  appBaseUrl: string;
+}
+
+const usd = (cents: number) => `$${(cents / 100).toFixed(2)}`;
+
+export function periodResetLabel(period: 'daily' | 'monthly', periodKey: string): string {
+  const [y, m, d] = periodKey.split('-').map(Number) as [number, number, number];
+  const next = period === 'monthly' ? new Date(Date.UTC(y, m, 1)) : new Date(Date.UTC(y, m - 1, d + 1));
+  const day = next.getUTCDate();
+  const mon = next.toLocaleString('en-GB', { month: 'short', timeZone: 'UTC' });
+  return `${day} ${mon} ${next.getUTCFullYear()} 00:00 UTC`;
+}
+
+/** Spec section 4.5: daily pre-cap rungs are in-app only. */
+export function shouldEmail(period: 'daily' | 'monthly', thresholdPct: number): boolean {
+  return period === 'monthly' || thresholdPct >= 100;
+}
+
+function billedTo(source: AiBudgetAlertContext['billingSource']): string {
+  return source === 'partner_key' ? 'Billed to your Anthropic API key.' : 'Billed to Breeze AI credits.';
+}
+
+export function describeAiBudgetAlert(ctx: AiBudgetAlertContext): { title: string; message: string } {
+  const reached = ctx.thresholdPct >= 100;
+  const title = reached
+    ? `AI budget reached for ${ctx.orgName} (${ctx.period})`
+    : `AI budget at ${ctx.thresholdPct}% for ${ctx.orgName} (${ctx.period})`;
+  const spend = `${usd(ctx.usedCents)} of ${usd(ctx.capCents)} used this ${ctx.period === 'daily' ? 'day' : 'month'}; resets ${periodResetLabel(ctx.period, ctx.periodKey)}.`;
+  const message = reached
+    ? `${spend} AI features are paused for this organization until the period resets or the cap is raised. ${billedTo(ctx.billingSource)}`
+    : `${spend} ${billedTo(ctx.billingSource)}`;
+  return { title, message };
+}
+
+export function buildAiBudgetAlertEmail(ctx: AiBudgetAlertContext): { subject: string; html: string; text: string } {
+  const { title, message } = describeAiBudgetAlert(ctx);
+  const url = `${ctx.appBaseUrl}${ctx.usagePath}`;
+  const text = [title, '', message, '', `Review usage and budget: ${url}`].join('\n');
+  const body = [
+    renderParagraph(escapeHtml(message)),
+    renderButton('Review AI usage', url),
+    renderParagraph('You receive this because you can manage billing for this organization in Breeze.', { muted: true, marginTop: 16 }),
+  ].join('\n');
+  const html = renderLayout({ title, preheader: message.slice(0, 120), heading: escapeHtml(title), body });
+  return { subject: title, html, text };
+}

--- a/apps/api/src/services/aiBudgetAlerts.test.ts
+++ b/apps/api/src/services/aiBudgetAlerts.test.ts
@@ -75,6 +75,7 @@ describe('evaluateAiBudgetThresholds', () => {
     vi.mocked(runOutsideDbContext).mockClear();
     vi.mocked(withSystemDbAccessContext).mockClear();
     vi.mocked(getCurrentDbAccessContext).mockReset().mockReturnValue(undefined);
+    vi.mocked(enqueueAiBudgetAlertDelivery).mockClear();
   });
 
   it('does nothing when AI is disabled', async () => {
@@ -99,6 +100,7 @@ describe('evaluateAiBudgetThresholds', () => {
     // usage read, then advisory lock (unused), then insert suppressed by the monotonic guard
     responses = [[{ total_cost_cents: 8100 }], [], []];
     await expect(evaluateAiBudgetThresholds('org1')).resolves.toEqual([]);
+    expect(enqueueAiBudgetAlertDelivery).not.toHaveBeenCalled();
   });
 
   it('does not escape to a system context when already system-scoped (finding #1)', async () => {

--- a/apps/api/src/services/aiBudgetAlerts.test.ts
+++ b/apps/api/src/services/aiBudgetAlerts.test.ts
@@ -11,8 +11,10 @@ vi.mock('../db', () => ({
 vi.mock('./effectiveSettings', () => ({ getEffectiveAiBudget: vi.fn(), DEFAULT_AI_ALERT_THRESHOLD_PERCENTS: [50, 80, 95] }));
 vi.mock('./llm/llmConfigResolver', () => ({ getLlmBillingSourceForOrg: vi.fn() }));
 vi.mock('./sentry', () => ({ captureException: vi.fn() }));
+vi.mock('../jobs/aiBudgetAlertDelivery', () => ({ enqueueAiBudgetAlertDelivery: vi.fn().mockResolvedValue(undefined) }));
 
 import { computeBudgetPct, evaluateAiBudgetThresholds, normalizeAlertThresholds, periodKeysFor, pickRung } from './aiBudgetAlerts';
+import { enqueueAiBudgetAlertDelivery } from '../jobs/aiBudgetAlertDelivery';
 import { db, getCurrentDbAccessContext, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { getEffectiveAiBudget } from './effectiveSettings';
 import { getLlmBillingSourceForOrg } from './llm/llmConfigResolver';
@@ -89,6 +91,7 @@ describe('evaluateAiBudgetThresholds', () => {
     expect(created).toEqual([{ id: 'evt-1', period: 'monthly', thresholdPct: 95 }]);
     expect(executed.join('\n')).toContain('threshold_pct >=');
     expect(executed.join('\n')).toContain('ON CONFLICT');
+    expect(enqueueAiBudgetAlertDelivery).toHaveBeenCalledWith('evt-1');
   });
 
   it('returns nothing when the insert is suppressed (rung already fired)', async () => {

--- a/apps/api/src/services/aiBudgetAlerts.test.ts
+++ b/apps/api/src/services/aiBudgetAlerts.test.ts
@@ -131,6 +131,43 @@ describe('evaluateAiBudgetThresholds', () => {
     expect(withSystemDbAccessContext).toHaveBeenCalledTimes(1);
   });
 
+  it('enqueues delivery only AFTER the system context (and its transaction) has resolved (W02 critical #1)', async () => {
+    // The event row is inserted inside the transaction `withSystemDbAccessContext`
+    // opens. Enqueuing from inside that callback races the COMMIT: BullMQ can
+    // hand `deliver-<id>` to a worker that sees no row, and a completed job's
+    // retained hash then makes reconcile's re-add a silent no-op. The enqueue
+    // must therefore run at context depth 0 — i.e. after the wrapper resolved.
+    vi.mocked(getCurrentDbAccessContext).mockReturnValue({ scope: 'organization' } as never);
+    vi.mocked(getEffectiveAiBudget).mockResolvedValue({ enabled: true, monthlyBudgetCents: 10000, dailyBudgetCents: null, alertThresholdPercents: [50, 80, 95] } as never);
+    responses = [[{ total_cost_cents: 9600 }], [], [{ id: 'evt-1' }]];
+
+    let contextDepth = 0;
+    const depthsAtEnqueue: number[] = [];
+    vi.mocked(withSystemDbAccessContext).mockImplementationOnce(async (fn: () => unknown) => {
+      contextDepth++;
+      try {
+        return await fn();
+      } finally {
+        contextDepth--;
+      }
+    });
+    vi.mocked(enqueueAiBudgetAlertDelivery).mockImplementationOnce(async () => {
+      depthsAtEnqueue.push(contextDepth);
+    });
+
+    await expect(evaluateAiBudgetThresholds('org1')).resolves.toEqual([{ id: 'evt-1', period: 'monthly', thresholdPct: 95 }]);
+
+    expect(depthsAtEnqueue).toEqual([0]);
+  });
+
+  it('still returns the created rows when the enqueue itself fails (never-throws contract)', async () => {
+    vi.mocked(getEffectiveAiBudget).mockResolvedValue({ enabled: true, monthlyBudgetCents: 10000, dailyBudgetCents: null, alertThresholdPercents: [50, 80, 95] } as never);
+    responses = [[{ total_cost_cents: 9600 }], [], [{ id: 'evt-1' }]];
+    vi.mocked(enqueueAiBudgetAlertDelivery).mockRejectedValueOnce(new Error('redis down'));
+
+    await expect(evaluateAiBudgetThresholds('org1')).resolves.toEqual([{ id: 'evt-1', period: 'monthly', thresholdPct: 95 }]);
+  });
+
   it('returns early without checking the billing source when the org has no caps (finding #3)', async () => {
     vi.mocked(getEffectiveAiBudget).mockResolvedValue({ enabled: true, monthlyBudgetCents: null, dailyBudgetCents: 0, alertThresholdPercents: [50, 80, 95] } as never);
 

--- a/apps/api/src/services/aiBudgetAlerts.ts
+++ b/apps/api/src/services/aiBudgetAlerts.ts
@@ -55,14 +55,20 @@ export function periodKeysFor(now: Date): { daily: string; monthly: string } {
  * rung (highest only; monotonic per period — see spec §4.2). Never throws
  * into the caller: the recorder path is fire-and-forget and must not fail a turn.
  *
- * Delivery is enqueued once, after BOTH periods' `db.transaction` calls have
- * resolved (i.e. every row this call is going to insert is already committed),
- * never from inside a transaction callback. Enqueuing per-row before the next
- * period's read/insert has run would let a later period's failure strand an
- * already-queued job pointed at a row that in fact committed fine — moving the
- * enqueue loop after the whole evaluation removes that ordering dependency
- * entirely: every enqueue in the loop refers to an already-durable row
- * regardless of what any other period did.
+ * DELIVERY IS ENQUEUED OUTSIDE THE DB CONTEXT, after `run()` has fully
+ * resolved. `withSystemDbAccessContext` opens a real `baseDb.transaction`, and
+ * the per-period `db.transaction` calls are savepoints inside it — so an
+ * enqueue written inside `run()` publishes `deliver-<id>` while the INSERT is
+ * still uncommitted. A worker picking that job up first sees no row; before
+ * W02 it treated that as success and COMPLETED, and BullMQ's addStandardJob
+ * Lua short-circuits on `EXISTS <prefix><jobId>` (returning the existing id)
+ * while `removeOnComplete: {count: 200}` keeps the completed hash around — so
+ * the reconcile sweep's re-add under the same job id did nothing and the alert
+ * was silently lost. Hoisting the loop out closes the window on the escape
+ * path entirely; on the ambient-system path (`checkCostAnomalies`, whose
+ * transaction is still open when we return) the residual race is covered by
+ * the worker treating a missing row as RETRYABLE, plus reconcile's per-sweep
+ * job id.
  */
 export async function evaluateAiBudgetThresholds(orgId: string, now = new Date()): Promise<CreatedAlertEvent[]> {
   const run = async (): Promise<CreatedAlertEvent[]> => {
@@ -121,19 +127,6 @@ export async function evaluateAiBudgetThresholds(orgId: string, now = new Date()
       if (id) created.push({ id, period, thresholdPct: rung });
     }
 
-    if (created.length > 0) {
-      // Lazy import breaks the jobs → services → jobs cycle: this module
-      // enqueues into the delivery worker, and the delivery worker's
-      // partner-fan-out job calls back into this module's evaluator.
-      const { enqueueAiBudgetAlertDelivery } = await import('../jobs/aiBudgetAlertDelivery');
-      for (const event of created) {
-        await enqueueAiBudgetAlertDelivery(event.id).catch((err: unknown) => {
-          // The reconcile job picks up any row left undelivered.
-          console.error(`[AI] budget alert enqueue failed for event ${event.id}:`, err instanceof Error ? err.message : err);
-        });
-      }
-    }
-
     return created;
   };
 
@@ -148,11 +141,32 @@ export async function evaluateAiBudgetThresholds(orgId: string, now = new Date()
   // 25-connection production ceiling for ~7 queries. Same skip-branch contract
   // as `readWithPartnerAxisVisibility` (db/partnerAxisRead.ts).
   const ambientScope = getCurrentDbAccessContext()?.scope;
-  const evaluate = ambientScope === 'system' ? run() : runOutsideDbContext(() => withSystemDbAccessContext(run));
+  const evaluate = ambientScope === 'system' ? run() : runOutsideDbContext(() => withSystemDbAccessContext(run, 'aiBudgetAlerts.evaluate'));
 
-  return evaluate.catch((err: unknown) => {
+  const created = await evaluate.catch((err: unknown) => {
     captureException(err instanceof Error ? err : new Error(String(err)), undefined, { orgId, service: 'aiBudgetAlerts' });
     console.error(`[AI] budget threshold evaluation failed for org=${orgId}:`, err instanceof Error ? err.message : err);
-    return [];
+    return [] as CreatedAlertEvent[];
   });
+
+  if (created.length > 0) {
+    try {
+      // Lazy import breaks the jobs → services → jobs cycle: this module
+      // enqueues into the delivery worker, and the delivery worker's
+      // partner-fan-out job calls back into this module's evaluator.
+      const { enqueueAiBudgetAlertDelivery } = await import('../jobs/aiBudgetAlertDelivery');
+      for (const event of created) {
+        await enqueueAiBudgetAlertDelivery(event.id).catch((err: unknown) => {
+          // The reconcile job picks up any row left undelivered.
+          console.error(`[AI] budget alert enqueue failed for event ${event.id}:`, err instanceof Error ? err.message : err);
+        });
+      }
+    } catch (err: unknown) {
+      // A failed dynamic import must not break the never-throws contract; the
+      // rows are committed and the reconcile sweep will pick them up.
+      console.error('[AI] budget alert delivery enqueue unavailable:', err instanceof Error ? err.message : err);
+    }
+  }
+
+  return created;
 }

--- a/apps/api/src/services/aiBudgetAlerts.ts
+++ b/apps/api/src/services/aiBudgetAlerts.ts
@@ -55,8 +55,14 @@ export function periodKeysFor(now: Date): { daily: string; monthly: string } {
  * rung (highest only; monotonic per period — see spec §4.2). Never throws
  * into the caller: the recorder path is fire-and-forget and must not fail a turn.
  *
- * Task 8 (later wave) enqueues delivery after each inserted row — that call
- * belongs right after `created.push(...)` below.
+ * Delivery is enqueued once, after BOTH periods' `db.transaction` calls have
+ * resolved (i.e. every row this call is going to insert is already committed),
+ * never from inside a transaction callback. Enqueuing per-row before the next
+ * period's read/insert has run would let a later period's failure strand an
+ * already-queued job pointed at a row that in fact committed fine — moving the
+ * enqueue loop after the whole evaluation removes that ordering dependency
+ * entirely: every enqueue in the loop refers to an already-durable row
+ * regardless of what any other period did.
  */
 export async function evaluateAiBudgetThresholds(orgId: string, now = new Date()): Promise<CreatedAlertEvent[]> {
   const run = async (): Promise<CreatedAlertEvent[]> => {
@@ -114,6 +120,20 @@ export async function evaluateAiBudgetThresholds(orgId: string, now = new Date()
       const id = inserted[0]?.id;
       if (id) created.push({ id, period, thresholdPct: rung });
     }
+
+    if (created.length > 0) {
+      // Lazy import breaks the jobs → services → jobs cycle: this module
+      // enqueues into the delivery worker, and the delivery worker's
+      // partner-fan-out job calls back into this module's evaluator.
+      const { enqueueAiBudgetAlertDelivery } = await import('../jobs/aiBudgetAlertDelivery');
+      for (const event of created) {
+        await enqueueAiBudgetAlertDelivery(event.id).catch((err: unknown) => {
+          // The reconcile job picks up any row left undelivered.
+          console.error(`[AI] budget alert enqueue failed for event ${event.id}:`, err instanceof Error ? err.message : err);
+        });
+      }
+    }
+
     return created;
   };
 

--- a/apps/api/src/services/eventBus.ts
+++ b/apps/api/src/services/eventBus.ts
@@ -174,6 +174,8 @@ export type EventType =
   | 'ai.agent.run.completed'
   | 'ai.agent.run.failed'
   | 'ai.agent.run.skipped'
+  // #4388 — an org crossed an AI budget rung; org-level, no device/site.
+  | 'ai.budget.threshold_crossed'
   // Wave 2 (#3823). Addressed to ONE user, never broadcast — see
   // publishUserEvent, which deliberately does not use the ordinary publish
   // path. Two segments so it stays subscribable under EVENT_TYPE_RE.
@@ -654,6 +656,8 @@ export const EVENT_TYPES = {
   AI_AGENT_RUN_COMPLETED: 'ai.agent.run.completed' as const,
   AI_AGENT_RUN_FAILED: 'ai.agent.run.failed' as const,
   AI_AGENT_RUN_SKIPPED: 'ai.agent.run.skipped' as const,
+  // #4388
+  AI_BUDGET_THRESHOLD_CROSSED: 'ai.budget.threshold_crossed' as const,
   // Wave 2 (#3823). Addressed to one user via publishUserEvent — never
   // broadcast, never written to the stream or the global channel.
   NOTIFICATION_CREATED: 'notification.created' as const,

--- a/apps/api/src/services/sentryEventCodes.ts
+++ b/apps/api/src/services/sentryEventCodes.ts
@@ -106,6 +106,8 @@ export const SENTRY_EVENT_CODES = [
    * the caller; a sustained stream means real capacity exhaustion.
    */
   'ai_session_cap_all_in_flight',
+  /** A crossed AI budget rung (#4388) resolved to zero notifiable recipients. */
+  'ai_budget_alert_no_recipients',
 
   // --- backup -----------------------------------------------------------
   /** A backup result matched no job row (deleted, or invisible under RLS). */

--- a/apps/api/src/services/sentryEventCodes.ts
+++ b/apps/api/src/services/sentryEventCodes.ts
@@ -108,6 +108,8 @@ export const SENTRY_EVENT_CODES = [
   'ai_session_cap_all_in_flight',
   /** A crossed AI budget rung (#4388) resolved to zero notifiable recipients. */
   'ai_budget_alert_no_recipients',
+  /** An AI budget alert event never became visible before its retries ran out. */
+  'ai_budget_alert_event_not_visible',
 
   // --- backup -----------------------------------------------------------
   /** A backup result matched no job row (deleted, or invisible under RLS). */

--- a/apps/api/src/services/usersWithPermission.test.ts
+++ b/apps/api/src/services/usersWithPermission.test.ts
@@ -4,6 +4,8 @@ import { PERMISSION_GRANTS as PERMISSIONS } from '@breeze/shared';
 
 vi.mock('../db', () => ({
   withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  getCurrentDbAccessContext: vi.fn(() => undefined),
   db: {
     select: vi.fn(),
   },
@@ -18,7 +20,7 @@ vi.mock('../db/schema', () => ({
   users: { id: 'id', status: 'status' },
 }));
 
-import { db } from '../db';
+import { db, getCurrentDbAccessContext, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { resolveUsersWithPermissionForOrg } from './usersWithPermission';
 
 const dialect = new PgDialect();
@@ -76,6 +78,9 @@ describe('resolveUsersWithPermissionForOrg', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(db.select).mockReset();
+    // `clearAllMocks` clears calls but KEEPS implementations, so a scope pinned
+    // by one test would leak into the next. Reset the ambient scope explicitly.
+    vi.mocked(getCurrentDbAccessContext).mockReturnValue(undefined);
     roleWhereArgs = [];
   });
 
@@ -105,5 +110,30 @@ describe('resolveUsersWithPermissionForOrg', () => {
     await resolveUsersWithPermissionForOrg('org1', PERMISSIONS.BILLING_MANAGE);
     expect(renderedWhere(0)).toContain('billing');
     expect(renderedWhere(0)).toContain('manage');
+  });
+
+  // W02 finding #3: `withSystemDbAccessContext` is a PASSTHROUGH when a context
+  // already exists (db/index.ts) — under an org-scoped request context the
+  // partner_users read (Shape 3, partner-axis RLS) silently returns ZERO rows
+  // and every partner admin drops out of the result. The escape must be taken
+  // explicitly, exactly like `readWithPartnerAxisVisibility`.
+  it('escapes an org-scoped ambient context before reading partner_users (finding #3)', async () => {
+    vi.mocked(getCurrentDbAccessContext).mockReturnValue({ scope: 'organization' } as never);
+    mockGrantingRoles([]);
+
+    await resolveUsersWithPermissionForOrg('org1', PERMISSIONS.BILLING_MANAGE);
+
+    expect(runOutsideDbContext).toHaveBeenCalledTimes(1);
+    expect(withSystemDbAccessContext).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT escape when the ambient context is already system-scoped (finding #3)', async () => {
+    vi.mocked(getCurrentDbAccessContext).mockReturnValue({ scope: 'system' } as never);
+    mockGrantingRoles([]);
+
+    await resolveUsersWithPermissionForOrg('org1', PERMISSIONS.BILLING_MANAGE);
+
+    expect(runOutsideDbContext).not.toHaveBeenCalled();
+    expect(withSystemDbAccessContext).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/services/usersWithPermission.test.ts
+++ b/apps/api/src/services/usersWithPermission.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { PERMISSION_GRANTS as PERMISSIONS } from '@breeze/shared';
+
+vi.mock('../db', () => ({
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    select: vi.fn(),
+  },
+}));
+
+vi.mock('../db/schema', () => ({
+  organizations: { id: 'id', partnerId: 'partner_id' },
+  organizationUsers: { userId: 'user_id', orgId: 'org_id', roleId: 'role_id' },
+  partnerUsers: { userId: 'user_id', partnerId: 'partner_id', roleId: 'role_id', orgAccess: 'org_access', orgIds: 'org_ids' },
+  rolePermissions: { roleId: 'role_id', permissionId: 'permission_id' },
+  permissions: { id: 'id', resource: 'resource', action: 'action' },
+  users: { id: 'id', status: 'status' },
+}));
+
+import { db } from '../db';
+import { resolveUsersWithPermissionForOrg } from './usersWithPermission';
+
+const dialect = new PgDialect();
+
+// Captures the `where(...)` argument passed to the granting-roles query (the
+// first select issued), keyed by call order, so `renderedWhere` can compile it
+// to real parameterized SQL — asserting the compiled query, not object
+// identity (see intentApprovers.test.ts, which this file's mock scaffolding
+// mirrors).
+let roleWhereArgs: unknown[] = [];
+
+function mockGrantingRoles(rows: Array<{ roleId: string }>) {
+  const where = vi.fn().mockImplementation((arg: unknown) => {
+    roleWhereArgs.push(arg);
+    return Promise.resolve(rows);
+  });
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      innerJoin: vi.fn().mockReturnValue({ where }),
+    }),
+  } as any);
+}
+
+function mockOrg(row: { partnerId: string | null }) {
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([row]) }),
+    }),
+  } as any);
+}
+
+function mockOrgMembers(rows: Array<{ userId: string }>) {
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      innerJoin: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(rows) }),
+    }),
+  } as any);
+}
+
+function mockPartnerMembers(rows: Array<{ userId: string; orgAccess: string; orgIds: string[] | null }>) {
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      innerJoin: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(rows) }),
+    }),
+  } as any);
+}
+
+function renderedWhere(index: number): string {
+  const arg = roleWhereArgs[index];
+  const { sql, params } = dialect.sqlToQuery(arg as never);
+  return `${sql} ${JSON.stringify(params)}`;
+}
+
+describe('resolveUsersWithPermissionForOrg', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(db.select).mockReset();
+    roleWhereArgs = [];
+  });
+
+  it('matches wildcard grants (*:*) for billing:manage', async () => {
+    mockGrantingRoles([{ roleId: 'r-super' }]);
+    mockOrg({ partnerId: 'p1' });
+    mockOrgMembers([]);
+    mockPartnerMembers([{ userId: 'u-admin', orgAccess: 'all', orgIds: null }]);
+    await expect(resolveUsersWithPermissionForOrg('org1', PERMISSIONS.BILLING_MANAGE)).resolves.toEqual(['u-admin']);
+  });
+
+  it('excludes partner users whose selected org list does not cover the org', async () => {
+    mockGrantingRoles([{ roleId: 'r1' }]);
+    mockOrg({ partnerId: 'p1' });
+    mockOrgMembers([]);
+    mockPartnerMembers([{ userId: 'u-other', orgAccess: 'selected', orgIds: ['org2'] }]);
+    await expect(resolveUsersWithPermissionForOrg('org1', PERMISSIONS.BILLING_MANAGE)).resolves.toEqual([]);
+  });
+
+  it('returns [] when no role grants the permission', async () => {
+    mockGrantingRoles([]);
+    await expect(resolveUsersWithPermissionForOrg('org1', PERMISSIONS.BILLING_MANAGE)).resolves.toEqual([]);
+  });
+
+  it('renders the permission pair into the role query', async () => {
+    mockGrantingRoles([]);
+    await resolveUsersWithPermissionForOrg('org1', PERMISSIONS.BILLING_MANAGE);
+    expect(renderedWhere(0)).toContain('billing');
+    expect(renderedWhere(0)).toContain('manage');
+  });
+});

--- a/apps/api/src/services/usersWithPermission.ts
+++ b/apps/api/src/services/usersWithPermission.ts
@@ -1,0 +1,89 @@
+/**
+ * Generalised permission-holder resolver, extracted from
+ * `resolveIntentApprovers` (actionIntents/intentApprovers.ts) so any caller —
+ * not just the action-intents approval layer — can ask "which users hold
+ * permission X for org Y". `resolveIntentApprovers` is now a one-line wrapper
+ * around this with `PERMISSIONS.APPROVALS_DECIDE`; see that file's header
+ * comment for the full rationale behind the query shape (mirrors
+ * `resolveElevationApprovers`, requires `users.status = 'active'`, etc).
+ */
+
+import { and, eq, inArray } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../db';
+import { organizations, organizationUsers, partnerUsers, permissions, rolePermissions, users } from '../db/schema';
+
+export interface PermissionPair {
+  resource: string;
+  action: string;
+}
+
+/**
+ * Distinct active user ids that hold `permission` for `orgId`: org members
+ * whose role grants it, plus partner users of the owning partner whose org
+ * access covers the org. Wildcard-aware ('*' resource/action), mirrors
+ * hasPermission(). Opens its own system DB context — callable from any
+ * ambient context (or none).
+ */
+export async function resolveUsersWithPermissionForOrg(orgId: string, permission: PermissionPair): Promise<string[]> {
+  return withSystemDbAccessContext(async () => {
+    const grantingRoles = await db
+      .select({ roleId: rolePermissions.roleId })
+      .from(rolePermissions)
+      .innerJoin(permissions, eq(rolePermissions.permissionId, permissions.id))
+      .where(
+        and(
+          inArray(permissions.resource, [permission.resource, '*']),
+          inArray(permissions.action, [permission.action, '*']),
+        ),
+      );
+
+    const grantingRoleIds = [...new Set(grantingRoles.map((r) => r.roleId))];
+    if (grantingRoleIds.length === 0) return [];
+
+    const [org] = await db
+      .select({ partnerId: organizations.partnerId })
+      .from(organizations)
+      .where(eq(organizations.id, orgId))
+      .limit(1);
+
+    const out = new Set<string>();
+
+    const orgMembers = await db
+      .select({ userId: organizationUsers.userId })
+      .from(organizationUsers)
+      .innerJoin(users, eq(users.id, organizationUsers.userId))
+      .where(
+        and(
+          eq(organizationUsers.orgId, orgId),
+          inArray(organizationUsers.roleId, grantingRoleIds),
+          eq(users.status, 'active'),
+        ),
+      );
+    for (const m of orgMembers) out.add(m.userId);
+
+    if (org?.partnerId) {
+      const partnerMembers = await db
+        .select({
+          userId: partnerUsers.userId,
+          orgAccess: partnerUsers.orgAccess,
+          orgIds: partnerUsers.orgIds,
+        })
+        .from(partnerUsers)
+        .innerJoin(users, eq(users.id, partnerUsers.userId))
+        .where(
+          and(
+            eq(partnerUsers.partnerId, org.partnerId),
+            inArray(partnerUsers.roleId, grantingRoleIds),
+            eq(users.status, 'active'),
+          ),
+        );
+      for (const m of partnerMembers) {
+        if (m.orgAccess === 'all' || (m.orgAccess === 'selected' && m.orgIds?.includes(orgId))) {
+          out.add(m.userId);
+        }
+      }
+    }
+
+    return [...out];
+  });
+}

--- a/apps/api/src/services/usersWithPermission.ts
+++ b/apps/api/src/services/usersWithPermission.ts
@@ -3,13 +3,31 @@
  * `resolveIntentApprovers` (actionIntents/intentApprovers.ts) so any caller —
  * not just the action-intents approval layer — can ask "which users hold
  * permission X for org Y". `resolveIntentApprovers` is now a one-line wrapper
- * around this with `PERMISSIONS.APPROVALS_DECIDE`; see that file's header
- * comment for the full rationale behind the query shape (mirrors
- * `resolveElevationApprovers`, requires `users.status = 'active'`, etc).
+ * around this with `PERMISSIONS.APPROVALS_DECIDE`.
+ *
+ * Query shape (rationale carried over from `intentApprovers.ts`, which is
+ * where it was written and where the extraction dropped it):
+ *
+ *  - Mirrors `resolveElevationApprovers` (services/pamApprovers.ts) for the
+ *    role/membership resolution: role ids granting the permission — INCLUDING
+ *    wildcard `'*'` grants, which is why both `resource` and `action` are
+ *    matched with `inArray([wanted, '*'])` rather than plain equality — via
+ *    role_permissions ⋈ permissions, then organization_users direct members
+ *    plus partner_users of the org's owning partner whose org_access is 'all'
+ *    or 'selected' ∋ orgId.
+ *  - Both candidate queries additionally join `users` and require
+ *    `status = 'active'` (`resolveElevationApprovers` does not): a disabled or
+ *    still-invited account can hold a granting role but must never be counted
+ *    — it inflates fan-outs and, in the approvals case, wrongly suppresses the
+ *    sole-operator fallback.
+ *  - The PARTNER population is the whole point of the second query. Partner-
+ *    scope MSP staff have no `organization_users` row at all, so an
+ *    org-members-only resolver silently returns nobody for the population most
+ *    likely to hold `billing:manage` or `approvals:decide`.
  */
 
 import { and, eq, inArray } from 'drizzle-orm';
-import { db, withSystemDbAccessContext } from '../db';
+import { db, getCurrentDbAccessContext, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { organizations, organizationUsers, partnerUsers, permissions, rolePermissions, users } from '../db/schema';
 
 export interface PermissionPair {
@@ -21,11 +39,29 @@ export interface PermissionPair {
  * Distinct active user ids that hold `permission` for `orgId`: org members
  * whose role grants it, plus partner users of the owning partner whose org
  * access covers the org. Wildcard-aware ('*' resource/action), mirrors
- * hasPermission(). Opens its own system DB context — callable from any
- * ambient context (or none).
+ * hasPermission().
+ *
+ * CONTEXT GUARANTEE: the read always runs in SYSTEM scope, whatever the
+ * ambient context — the escape below is what makes that true. It is not
+ * enough to wrap the body in `withSystemDbAccessContext`: that helper is a
+ * PASSTHROUGH when a context already exists (db/index.ts — nested
+ * `withDbAccessContext` keeps the outer store), so under an org-scoped request
+ * context the query would run with the REQUESTER's GUCs. It would not raise;
+ * `partner_users` is partner-axis (Shape 3) and `breeze_has_partner_access`
+ * evaluates against `breeze.accessible_partner_ids`, which is `[]` for every
+ * org-scoped caller — so the partner branch silently returns ZERO rows and
+ * every partner admin drops out of the result. Same guarded-escape contract as
+ * `readWithPartnerAxisVisibility` (db/partnerAxisRead.ts): take the escape
+ * only when it is needed, because `runOutsideDbContext` + a nested system
+ * context opens a SECOND transaction on a SECOND pooled connection while the
+ * first is still held.
+ *
+ * The escaped read is pinned to the caller's `orgId` and widens only which
+ * COLUMNS/ROWS of the permission graph are legible for THAT org — it never
+ * lets a caller name an org it could not otherwise reach.
  */
 export async function resolveUsersWithPermissionForOrg(orgId: string, permission: PermissionPair): Promise<string[]> {
-  return withSystemDbAccessContext(async () => {
+  const read = async (): Promise<string[]> => {
     const grantingRoles = await db
       .select({ roleId: rolePermissions.roleId })
       .from(rolePermissions)
@@ -85,5 +121,12 @@ export async function resolveUsersWithPermissionForOrg(orgId: string, permission
     }
 
     return [...out];
-  });
+  };
+
+  // Named imports on purpose: a unit suite whose `vi.mock('../db')` factory
+  // omits one of these fails loudly ("No <name> export is defined on the
+  // mock") instead of silently skipping the escape.
+  const ambientScope = getCurrentDbAccessContext()?.scope;
+  if (ambientScope === 'system') return read();
+  return runOutsideDbContext(() => withSystemDbAccessContext(read, 'usersWithPermission.resolveForOrg'));
 }

--- a/apps/api/src/services/workerEntrypointClosure.contract.test.ts
+++ b/apps/api/src/services/workerEntrypointClosure.contract.test.ts
@@ -271,7 +271,7 @@ function parseRegistrySource(): RegistryEntrySource[] {
 // entry can't slip past both suites at once).
 const EXPECTED_NAMES = [
   'alertWorkers', 'alertCorrelationWorker', 'metricRollupsWorker', 'metricRollupMaintenance',
-  'metricAnomaliesWorker', 'fleetFindingsWorker', 'fleetRemediationDispatchWorker', 'mlOutputRetention',
+  'metricAnomaliesWorker', 'aiBudgetAlertDeliveryWorker', 'fleetFindingsWorker', 'fleetRemediationDispatchWorker', 'mlOutputRetention',
   'offlineDetector', 'notificationDispatcher', 'webhookDelivery', 'webhookDeliveryRecovery',
   'policyEvaluationWorker', 'softwareComplianceWorker', 'softwareRemediationWorker', 'aiAgentRunner',
   'agentNotifyRetry', 'fixWatchWorker',
@@ -453,7 +453,7 @@ describe('workerEntrypointClosure contract (#4086 Task 5)', () => {
 
   describe('global-placement entries never reach socket-local dispatch', () => {
     const entries = parseRegistrySource();
-    expect(entries.length).toBe(122); // sanity: the source-parsing regex itself must find all 122
+    expect(entries.length).toBe(123); // sanity: the source-parsing regex itself must find all 123
 
     const globalEntries = entries.filter((e) => e.placement === 'global');
     expect(globalEntries.length).toBeGreaterThan(0);

--- a/apps/api/src/services/workerRegistry.test.ts
+++ b/apps/api/src/services/workerRegistry.test.ts
@@ -24,9 +24,9 @@ import {
 // This list is duplicated here deliberately — the whole point of the test is
 // to catch drift between the plan's documented contract and the actual
 // registry, so it must not import the list from the module under test.
-const EXPECTED_122_NAMES = [
+const EXPECTED_123_NAMES = [
   'alertWorkers', 'alertCorrelationWorker', 'metricRollupsWorker', 'metricRollupMaintenance',
-  'metricAnomaliesWorker', 'fleetFindingsWorker', 'fleetRemediationDispatchWorker', 'mlOutputRetention',
+  'metricAnomaliesWorker', 'aiBudgetAlertDeliveryWorker', 'fleetFindingsWorker', 'fleetRemediationDispatchWorker', 'mlOutputRetention',
   'offlineDetector', 'notificationDispatcher', 'webhookDelivery', 'webhookDeliveryRecovery',
   'policyEvaluationWorker', 'softwareComplianceWorker', 'softwareRemediationWorker', 'aiAgentRunner',
   'agentNotifyRetry', 'fixWatchWorker',
@@ -60,12 +60,12 @@ const EXPECTED_122_NAMES = [
 ];
 
 describe('workerRegistry: losslessness', () => {
-  it('contains exactly the 122 known names, in order', () => {
-    expect(WORKER_REGISTRY.map((e) => e.name)).toEqual(EXPECTED_122_NAMES);
+  it('contains exactly the 123 known names, in order', () => {
+    expect(WORKER_REGISTRY.map((e) => e.name)).toEqual(EXPECTED_123_NAMES);
   });
 
-  it('has exactly 122 entries', () => {
-    expect(WORKER_REGISTRY.length).toBe(122);
+  it('has exactly 123 entries', () => {
+    expect(WORKER_REGISTRY.length).toBe(123);
   });
 
   it('every entry has a well-formed shape', () => {
@@ -85,14 +85,14 @@ describe('workerRegistry: losslessness', () => {
 
 describe('workerRegistry: selectWorkers', () => {
   it("'all' selects every entry", () => {
-    expect(selectWorkers('all').length).toBe(122);
+    expect(selectWorkers('all').length).toBe(123);
     expect(selectWorkers('all')).toEqual(WORKER_REGISTRY);
   });
 
   it("'api' and 'worker' partition the set with no overlap and no loss", () => {
     const api = selectWorkers('api');
     const worker = selectWorkers('worker');
-    expect(api.length + worker.length).toBe(122);
+    expect(api.length + worker.length).toBe(123);
 
     const apiNames = new Set(api.map((e) => e.name));
     const workerNames = new Set(worker.map((e) => e.name));
@@ -100,7 +100,7 @@ describe('workerRegistry: selectWorkers', () => {
       expect(workerNames.has(name)).toBe(false);
     }
     const union = new Set([...apiNames, ...workerNames]);
-    expect(union.size).toBe(122);
+    expect(union.size).toBe(123);
   });
 
   it("'api' selects only socket-owner placements", () => {

--- a/apps/api/src/services/workerRegistry.ts
+++ b/apps/api/src/services/workerRegistry.ts
@@ -115,6 +115,14 @@ export const WORKER_REGISTRY: readonly WorkerRegistration[] = [
     },
   },
   {
+    name: 'aiBudgetAlertDeliveryWorker',
+    placement: 'global',
+    load: async () => {
+      const m = await import('../jobs/aiBudgetAlertDelivery');
+      return { init: m.initializeAiBudgetAlertWorker, shutdown: m.shutdownAiBudgetAlertWorker };
+    },
+  },
+  {
     name: 'fleetFindingsWorker',
     placement: 'global',
     load: async () => {


### PR DESCRIPTION
## Summary

Wave 2 of **pre-cap AI budget alerts** (#4388): delivery. Wave 1 (#4487) records one durable `ai_budget_alert_events` row per crossed rung; this wave turns each row into an in-app notification for every `billing:manage` holder covering the org, one email when the policy says so, and an event-bus publish, with a reconcile job for rows that were inserted but never delivered and a partner-wide re-evaluation when a partner changes its fleet-wide AI budget.

Stacked on #4487 (base branch `feature/4388-ai-budget-alerts/wave-4389`). Spec: `docs/superpowers/specs/ai-mcp/2026-09-01-ai-budget-threshold-alerts-design.md` §4.4–4.6. Plan tasks 6–9.

### What changed

- **Shared permission resolver** — `services/usersWithPermission.ts`: `resolveUsersWithPermissionForOrg(orgId, permission)` extracted from `resolveIntentApprovers` (which is now a one-line wrapper). Wildcard-aware; org members whose role grants it plus partner users whose org access covers the org; active users only.
- **Copy + email** — `services/aiBudgetAlertEmail.ts`: `describeAiBudgetAlert` (in-app title/message), `buildAiBudgetAlertEmail` (subject/html/text via `emailLayout`), `periodResetLabel`, `shouldEmail` (monthly rungs and any 100% rung email; daily 50/80/95 are in-app only). Titles read `AI budget at 80% for <org> (monthly)`.
- **Delivery worker** — `jobs/aiBudgetAlertDelivery.ts`: BullMQ queue with `deliver-<eventId>` jobs (idempotent per event), `reconcile` repeat job for undelivered rows, and `evaluate-partner` fan-out that re-runs the wave-1 evaluator for every active org of a partner. In-app link `/settings/ai-usage`; email links use `getFrontendBaseUrl()`. New event type `ai.budget.threshold_crossed`. Registered in `workerRegistry`.
- **Evaluator hook** — the wave-1 evaluator enqueues delivery for each created row **after** its transaction commits (never inside it), lazily importing the job module; an enqueue failure is logged and the reconcile job picks the row up.
- **Partner fan-out hook** — `PATCH /partners/me` enqueues `evaluate-partner` when `settings.aiBudgets` changes, so a lowered fleet-wide cap fires now rather than on each org's next AI turn.

### Verification

- Unit: `usersWithPermission`, `actionIntents/intentApprovers` (unchanged assertions), `aiBudgetAlertEmail`, `jobs/aiBudgetAlertDelivery`, `aiBudgetAlerts`, `eventBus`, `workerRegistry`, `routes/orgs`.
- tsc + eslint clean on every changed file.
- Stack smoke (`pnpm wt-stack`, SMTP pointed at a local mailpit sink): seeded 96¢ of monthly usage on the seeded org, then `PUT /ai/budget` with a $1 monthly cap. Result: one `ai_budget_alert_events` row (monthly / 95) with `delivered_at` set, `delivery_attempts = 1`, `recipient_count = 1`; one in-app notification for the partner admin titled `AI budget at 95% for Default Organization (monthly)` linking to `/settings/ai-usage` (unread count 1); one email in mailpit with the spend line, reset date, billing source and the absolute usage link; `ai.budget.threshold_crossed` published on the event bus. A second `PUT /ai/budget` added no row and no email (monotonic guard + idempotent delivery).
- Fan-out smoke: `PATCH /partners/me` with a partner-wide 96¢ monthly cap ran the `evaluate-partner` job, which fired rung 100 for the seeded org (second event row, second email `AI budget reached for Default Organization (monthly)`, second bus publish).

### Whole-branch review fixes (`ea6f7287d`)

- **Delivery is correct regardless of the producer's transaction.** The evaluator enqueues only after its own context returns; the worker treats a not-yet-visible row as retryable (BullMQ backoff) and only warns on the final attempt; reconcile enqueues under a per-sweep jobId so a retained completed job can never block it (BullMQ's `addStandardJob` Lua returns the existing job on `EXISTS`, confirmed in the installed 5.81.2); the worker loads the event `FOR UPDATE` so duplicate jobs serialise on `delivered_at` (no double email).
- **Failure bookkeeping is durable.** `delivery_attempts` / `last_delivery_error` are written in a fresh context after the delivery transaction aborts, so the reconcile guard actually excludes exhausted rows. Proven by a real-Postgres integration test (`aiBudgetAlertDelivery.integration.test.ts`: success, failure bookkeeping, invisible row, idempotent second call).
- **`resolveUsersWithPermissionForOrg` takes the guarded context escape** (runs directly under a system ambient, escapes an org/partner/absent ambient), with the original rationale comments restored.
- Worker contexts carry labels; job data is validated; fan-out skips purging/archived/churned/merging/offboarding orgs; the partner hook fires only when `aiBudgets` actually changed; success paths log.

### Notes for reviewers

- This PR is stacked; `ci.yml` does not run on PRs whose base is not `main`, so CI was dispatched manually with `gh workflow run CI --ref feature/4388-ai-budget-alerts/wave-4390`. Retarget to `main` after #4487 merges.

Closes #4390

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E52B3JTqJ2wFJyZN8dRARZ
