### PR TITLE
chore(mobile): bump iOS buildNumber to 8

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -9,7 +9,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.breeze.rmm",
-      "buildNumber": "7",
+      "buildNumber": "8",
       "associatedDomains": [
         "webcredentials:us.2breeze.app",
         "webcredentials:eu.2breeze.app"


### PR DESCRIPTION
Build 7 already exists in App Store Connect (uploaded 2026-08-20), and `app.json` still declared `"buildNumber": "7"` with `appVersionSource: "local"`.

Apple rejects a duplicate build number within a version. If Xcode Cloud passes the project's `CFBundleVersion` through rather than assigning its own, the next upload is rejected and the build minutes are wasted — so this is cheap insurance: harmless if Xcode Cloud overrides the value, and the difference between a delivered build and a wasted run if it doesn't.

One-line change, no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eEp7QaCXwJNioNR6vZ6eP