### PR TITLE
fix(api): align enrollment-key TTL fallbacks with the 30-day default (#4126 follow-up)

### DIFF
--- a/apps/api/src/routes/enrollmentKeys.ts
+++ b/apps/api/src/routes/enrollmentKeys.ts
@@ -47,6 +47,7 @@ import {
   BootstrapTokenIssuanceError,
 } from "../services/installerBootstrapTokenIssuance";
 import { assertTtlWithinCap, clampTtlToCap } from "../services/enrollmentDefaults";
+import { getDefaultEnrollmentKeyTtlMinutes } from "../services/enrollmentKeyTtlDefault";
 import {
   hasLiveUnexhaustedCapacityToken,
   hasNoLiveUnexhaustedCapacityToken,
@@ -97,10 +98,13 @@ function envInt(name: string, defaultValue: number): number {
 // 30 days by default: techs stage installers through deploy tooling and expect
 // them to keep working well past the download day. Must stay in step with
 // PRODUCT_DEFAULT_ENROLLMENT_TTL_MINUTES (packages/shared enrollmentDefaults).
-const DEFAULT_ENROLLMENT_KEY_TTL_MINUTES = envInt(
-  "ENROLLMENT_KEY_DEFAULT_TTL_MINUTES",
-  60 * 24 * 30,
-);
+//
+// Sourced from the shared enrollmentKeyTtlDefault.ts (#4126 follow-up) so the
+// Partner-API provisioning route (services/enrollmentKeySecurity.ts) and the
+// installer child-key redemption route (routes/installer.ts) can never drift
+// from this route's fallback again — both used to hard-code their own
+// (smaller) numbers.
+const DEFAULT_ENROLLMENT_KEY_TTL_MINUTES = getDefaultEnrollmentKeyTtlMinutes();
 
 // Child enrollment keys (installer downloads, installer-link downloads, and
 // short-link redemptions) get a fresh, independent TTL rather than inheriting

--- a/apps/api/src/routes/installer.test.ts
+++ b/apps/api/src/routes/installer.test.ts
@@ -37,7 +37,7 @@ vi.mock("../services/enrollmentDefaults", () => ({
 // ============================================================
 
 import { Hono } from "hono";
-import { installerRoutes } from "./installer";
+import { installerRoutes, childEnrollmentKeyTtlMinutes } from "./installer";
 import { db } from "../db";
 
 function makeApp() {
@@ -122,6 +122,34 @@ async function redeemBootstrapOk(): Promise<Record<string, unknown>> {
   expect(res.status).toBe(200);
   return await res.json() as Record<string, unknown>;
 }
+
+// #4126 follow-up: the human "Add Device" create route
+// (routes/enrollmentKeys.ts) raised its no-env-set fallback to 43200 minutes
+// (30 days), but this child-key TTL was missed and stayed at `24 * 60` (1
+// day) — a self-hoster who sets neither env var got 30-day keys from Add
+// Device but 1-day installer child keys.
+describe("childEnrollmentKeyTtlMinutes", () => {
+  const orig = process.env.CHILD_ENROLLMENT_KEY_TTL_MINUTES;
+  afterEach(() => {
+    if (orig === undefined) delete process.env.CHILD_ENROLLMENT_KEY_TTL_MINUTES;
+    else process.env.CHILD_ENROLLMENT_KEY_TTL_MINUTES = orig;
+  });
+
+  it("falls back to 43200 minutes (30 days) — matching the human route — when the env var is unset", () => {
+    delete process.env.CHILD_ENROLLMENT_KEY_TTL_MINUTES;
+    expect(childEnrollmentKeyTtlMinutes()).toBe(43200);
+  });
+
+  it("falls back to 43200 when the env var is an empty string (#2776 compose gotcha)", () => {
+    process.env.CHILD_ENROLLMENT_KEY_TTL_MINUTES = "";
+    expect(childEnrollmentKeyTtlMinutes()).toBe(43200);
+  });
+
+  it("still honors an explicit CHILD_ENROLLMENT_KEY_TTL_MINUTES override", () => {
+    process.env.CHILD_ENROLLMENT_KEY_TTL_MINUTES = "90";
+    expect(childEnrollmentKeyTtlMinutes()).toBe(90);
+  });
+});
 
 describe("POST /api/v1/installer/bootstrap", () => {
   it("includes backupServerUrl when AGENT_BACKUP_SERVER_URL is set", async () => {
@@ -382,10 +410,10 @@ describe("POST /api/v1/installer/bootstrap", () => {
     expect(res.status).toBe(200);
     expect(capturedChildKeyValues).not.toBeNull();
     const childExpiresAt = (capturedChildKeyValues as unknown as { expiresAt: Date }).expiresAt;
-    // Clamped to the 60-minute cap, NOT the 1440-minute (24h) default.
+    // Clamped to the 60-minute cap, NOT the 43200-minute (30-day) default.
     expect(childExpiresAt.getTime()).toBeGreaterThanOrEqual(before + 59 * 60 * 1000);
     expect(childExpiresAt.getTime()).toBeLessThanOrEqual(after + 60 * 60 * 1000 + 5_000);
-    expect(clampTtlToCapMock).toHaveBeenCalledWith("o-cap", 1440);
+    expect(clampTtlToCapMock).toHaveBeenCalledWith("o-cap", 43200);
   });
 
   it("does not shorten the child key TTL when the partner cap is above the CHILD_ENROLLMENT_KEY_TTL_MINUTES default (no-op clamp)", async () => {
@@ -431,9 +459,9 @@ describe("POST /api/v1/installer/bootstrap", () => {
     expect(res.status).toBe(200);
     expect(capturedChildKeyValues).not.toBeNull();
     const childExpiresAt = (capturedChildKeyValues as unknown as { expiresAt: Date }).expiresAt;
-    // Unchanged: still the full 1440-minute (24h) default.
-    expect(childExpiresAt.getTime()).toBeGreaterThanOrEqual(before + 1439 * 60 * 1000);
-    expect(childExpiresAt.getTime()).toBeLessThanOrEqual(after + 1441 * 60 * 1000);
+    // Unchanged: still the full 43200-minute (30-day) default.
+    expect(childExpiresAt.getTime()).toBeGreaterThanOrEqual(before + 43199 * 60 * 1000);
+    expect(childExpiresAt.getTime()).toBeLessThanOrEqual(after + 43201 * 60 * 1000);
   });
 
   // #2776 regression. docker-compose threads CHILD_ENROLLMENT_KEY_TTL_MINUTES
@@ -443,7 +471,7 @@ describe("POST /api/v1/installer/bootstrap", () => {
   // `Number(process.env.X ?? 24 * 60)` read yielded 0 there (`??` doesn't fire
   // on '', Number('') === 0), so every redeemed child enrollment key was born
   // already expired and agent enrollment stopped working entirely on upgrade.
-  it("an EMPTY CHILD_ENROLLMENT_KEY_TTL_MINUTES falls back to 24h, not 0 (#2776)", async () => {
+  it("an EMPTY CHILD_ENROLLMENT_KEY_TTL_MINUTES falls back to the shared 30-day default, not 0 (#2776)", async () => {
     vi.stubEnv("CHILD_ENROLLMENT_KEY_TTL_MINUTES", "");
     process.env.PUBLIC_API_URL = "https://us.2breeze.app";
 
@@ -482,12 +510,12 @@ describe("POST /api/v1/installer/bootstrap", () => {
     const after = Date.now();
 
     expect(res.status).toBe(200);
-    // The value handed to the cap clamp is the 24h default, never 0.
-    expect(clampTtlToCapMock).toHaveBeenCalledWith("o-env", 1440);
+    // The value handed to the cap clamp is the shared 30-day default, never 0.
+    expect(clampTtlToCapMock).toHaveBeenCalledWith("o-env", 43200);
     const childExpiresAt = (capturedChildKeyValues as unknown as { expiresAt: Date }).expiresAt;
     expect(childExpiresAt.getTime()).toBeGreaterThan(after);
-    expect(childExpiresAt.getTime()).toBeGreaterThanOrEqual(before + 1439 * 60 * 1000);
-    expect(childExpiresAt.getTime()).toBeLessThanOrEqual(after + 1441 * 60 * 1000);
+    expect(childExpiresAt.getTime()).toBeGreaterThanOrEqual(before + 43199 * 60 * 1000);
+    expect(childExpiresAt.getTime()).toBeLessThanOrEqual(after + 43201 * 60 * 1000);
 
     vi.unstubAllEnvs();
   });

--- a/apps/api/src/routes/installer.ts
+++ b/apps/api/src/routes/installer.ts
@@ -13,6 +13,7 @@ import { BOOTSTRAP_TOKEN_PATTERN } from "../services/installerBootstrapToken";
 import { getTrustedClientIp } from "../services/clientIp";
 import { clampTtlToCap } from "../services/enrollmentDefaults";
 import { envInt } from "../utils/envInt";
+import { getDefaultEnrollmentKeyTtlMinutes } from "../services/enrollmentKeyTtlDefault";
 
 /**
  * Base lifetime for a child enrollment key minted at redemption, in minutes.
@@ -25,12 +26,19 @@ import { envInt } from "../utils/envInt";
  * entirely on any self-host that pulled the release without adding the key to
  * its .env (#2776).
  *
+ * The fallback (when `CHILD_ENROLLMENT_KEY_TTL_MINUTES` itself is unset/empty)
+ * is the shared `ENROLLMENT_KEY_DEFAULT_TTL_MINUTES` default from
+ * enrollmentKeyTtlDefault.ts, not an independent constant — this used to be
+ * its own hard-coded `24 * 60` (1 day), which drifted from the human "Add
+ * Device" route's 30-day default after #4126 raised that one alone (#4126
+ * follow-up).
+ *
  * Resolved per call rather than at module load so the fallback is directly
  * testable; the env is fixed at boot in production, so this is the same value
  * every time.
  */
 export function childEnrollmentKeyTtlMinutes(): number {
-  return envInt("CHILD_ENROLLMENT_KEY_TTL_MINUTES", 24 * 60);
+  return envInt("CHILD_ENROLLMENT_KEY_TTL_MINUTES", getDefaultEnrollmentKeyTtlMinutes());
 }
 
 /**

--- a/apps/api/src/services/enrollmentKeySecurity.test.ts
+++ b/apps/api/src/services/enrollmentKeySecurity.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { createHash } from 'crypto';
-import { hashEnrollmentKey } from './enrollmentKeySecurity';
+import { hashEnrollmentKey, getDefaultEnrollmentKeyTtlMinutes } from './enrollmentKeySecurity';
 
 const originalEnv = {
   NODE_ENV: process.env.NODE_ENV,
@@ -8,6 +8,7 @@ const originalEnv = {
   APP_ENCRYPTION_KEY: process.env.APP_ENCRYPTION_KEY,
   SECRET_ENCRYPTION_KEY: process.env.SECRET_ENCRYPTION_KEY,
   JWT_SECRET: process.env.JWT_SECRET,
+  ENROLLMENT_KEY_DEFAULT_TTL_MINUTES: process.env.ENROLLMENT_KEY_DEFAULT_TTL_MINUTES,
 };
 
 function restoreEnv() {
@@ -42,5 +43,34 @@ describe('enrollment key peppering', () => {
     process.env.JWT_SECRET = 'jwt-key-must-not-be-used';
 
     expect(() => hashEnrollmentKey('raw-key')).toThrow('ENROLLMENT_KEY_PEPPER');
+  });
+});
+
+// #4126 follow-up: the human "Add Device" create route
+// (routes/enrollmentKeys.ts) raised its no-env-set fallback to 43200 minutes
+// (30 days), but this Partner-API provisioning helper was missed and stayed
+// at 60 — a self-hoster who sets neither env var got 30-day keys from Add
+// Device but 1-hour keys from partner-API provisioning.
+describe('getDefaultEnrollmentKeyTtlMinutes', () => {
+  afterEach(restoreEnv);
+
+  it('falls back to 43200 minutes (30 days) — matching the human route — when the env var is unset', () => {
+    delete process.env.ENROLLMENT_KEY_DEFAULT_TTL_MINUTES;
+    expect(getDefaultEnrollmentKeyTtlMinutes()).toBe(43200);
+  });
+
+  it('falls back to 43200 when the env var is set to an empty string (compose renders unset as "")', () => {
+    process.env.ENROLLMENT_KEY_DEFAULT_TTL_MINUTES = '';
+    expect(getDefaultEnrollmentKeyTtlMinutes()).toBe(43200);
+  });
+
+  it('falls back to 43200 when the env var is unparsable', () => {
+    process.env.ENROLLMENT_KEY_DEFAULT_TTL_MINUTES = 'not-a-number';
+    expect(getDefaultEnrollmentKeyTtlMinutes()).toBe(43200);
+  });
+
+  it('still honors an explicit ENROLLMENT_KEY_DEFAULT_TTL_MINUTES override', () => {
+    process.env.ENROLLMENT_KEY_DEFAULT_TTL_MINUTES = '120';
+    expect(getDefaultEnrollmentKeyTtlMinutes()).toBe(120);
   });
 });

--- a/apps/api/src/services/enrollmentKeySecurity.ts
+++ b/apps/api/src/services/enrollmentKeySecurity.ts
@@ -1,4 +1,5 @@
 import { createHash, randomBytes } from 'crypto';
+import { getDefaultEnrollmentKeyTtlMinutes as getSharedDefaultEnrollmentKeyTtlMinutes } from './enrollmentKeyTtlDefault';
 
 /**
  * Mints a raw enrollment key value (64-char hex) for the Partner API
@@ -13,13 +14,14 @@ export function generateEnrollmentKey(): string {
 /**
  * Default lifetime applied when a create request supplies neither
  * `ttlMinutes` nor `expiresAt`. Same env knob the human route has always
- * read; resolved per call so tests can vary the env.
+ * read (`ENROLLMENT_KEY_DEFAULT_TTL_MINUTES`), and the same 43200-minute
+ * (30-day) fallback — see enrollmentKeyTtlDefault.ts for why this delegates
+ * instead of hard-coding its own number (#4126 follow-up: this function used
+ * to fall back to 60 on its own, drifting from the human route's 30 days).
+ * Resolved per call so tests can vary the env.
  */
 export function getDefaultEnrollmentKeyTtlMinutes(): number {
-  const raw = process.env.ENROLLMENT_KEY_DEFAULT_TTL_MINUTES;
-  if (!raw) return 60;
-  const parsed = Number.parseInt(raw, 10);
-  return Number.isFinite(parsed) ? parsed : 60;
+  return getSharedDefaultEnrollmentKeyTtlMinutes();
 }
 
 // Primary pepper used for ALL new enrollment-key hashes. Required in production.

--- a/apps/api/src/services/enrollmentKeyTtlDefault.ts
+++ b/apps/api/src/services/enrollmentKeyTtlDefault.ts
@@ -1,0 +1,35 @@
+import { envInt } from '../utils/envInt';
+
+/**
+ * The single fallback TTL (in minutes) for an enrollment/installer key when
+ * nothing more specific overrides it. 43200 minutes = 30 days.
+ *
+ * #4126 raised the human "Add Device" create route's fallback
+ * (routes/enrollmentKeys.ts, `DEFAULT_ENROLLMENT_KEY_TTL_MINUTES`) from 60
+ * minutes to this 30-day value, on the theory that techs stage installers
+ * through deploy tooling and expect them to keep working well past the
+ * download day. It missed two sibling fallbacks that mint keys the same way:
+ *
+ *   - services/enrollmentKeySecurity.ts's `getDefaultEnrollmentKeyTtlMinutes`
+ *     (used by the Partner-API provisioning route, #3243) stayed at 60.
+ *   - routes/installer.ts's `childEnrollmentKeyTtlMinutes` (installer
+ *     downloads / redemptions) stayed at `24 * 60` (1 day).
+ *
+ * A self-hoster who never set ENROLLMENT_KEY_DEFAULT_TTL_MINUTES or
+ * CHILD_ENROLLMENT_KEY_TTL_MINUTES therefore got 30-day keys from the web UI
+ * but 1-hour partner-API keys and 1-day installer child keys — three
+ * different lifetimes behind what looks like one "default TTL" knob. All
+ * three sites (plus routes/devices/core.ts, which already matched by luck)
+ * now read this single constant so the fallback can't drift apart again.
+ *
+ * Read via envInt (never a hand-rolled `Number(x ?? default)`) so an EMPTY
+ * env value — compose renders an unset var as `VAR: ""`, not absent — also
+ * falls back to the default instead of resolving to 0 (#2776). Resolved per
+ * call rather than cached at module load so the fallback stays directly
+ * testable and reflects `ENROLLMENT_KEY_DEFAULT_TTL_MINUTES` set at any
+ * point before the call; the env is fixed at boot in production, so this is
+ * the same value every time in practice.
+ */
+export function getDefaultEnrollmentKeyTtlMinutes(): number {
+  return envInt('ENROLLMENT_KEY_DEFAULT_TTL_MINUTES', 60 * 24 * 30);
+}


### PR DESCRIPTION
## Summary

PR #4126 raised the human "Add Device" create route's no-env-set enrollment-key TTL fallback (`routes/enrollmentKeys.ts`) to 43200 minutes (30 days), on the theory that techs stage installers through deploy tooling and expect them to keep working well past the download day. Two sibling code paths that mint keys the same way were missed:

- **`apps/api/src/services/enrollmentKeySecurity.ts`** `getDefaultEnrollmentKeyTtlMinutes()` — used by Partner-API provisioning (#3243) — stayed at **60 minutes**, and also returned 60 on unparsable env input.
- **`apps/api/src/routes/installer.ts`** `childEnrollmentKeyTtlMinutes()` — used when redeeming an installer bootstrap token to mint a child enrollment key — stayed at **`24 * 60`** (1 day).

**Operator impact:** a self-hoster who sets neither `ENROLLMENT_KEY_DEFAULT_TTL_MINUTES` nor `CHILD_ENROLLMENT_KEY_TTL_MINUTES` got 30-day keys from the web UI "Add Device" flow, but 1-hour keys from Partner-API provisioning and 1-day child installer keys — three different lifetimes behind what looks like one "default TTL" setting.

## Fix

Introduces `apps/api/src/services/enrollmentKeyTtlDefault.ts` as the single shared default (`envInt('ENROLLMENT_KEY_DEFAULT_TTL_MINUTES', 43200)`, still fully env-overridable) and wires all three sites through it:

- `routes/enrollmentKeys.ts` — its module-level `DEFAULT_ENROLLMENT_KEY_TTL_MINUTES` now calls the shared function instead of duplicating the `envInt` call (same value, same env var — no behavior change here, just removes the third copy of the number).
- `services/enrollmentKeySecurity.ts` — `getDefaultEnrollmentKeyTtlMinutes()` now delegates to the shared default instead of its own hard-coded 60.
- `routes/installer.ts` — `childEnrollmentKeyTtlMinutes()` still reads `CHILD_ENROLLMENT_KEY_TTL_MINUTES` first, but its fallback is now the shared default instead of the independent `24 * 60`.

`routes/devices/core.ts`'s inline enrollment-key TTL default already matched (`envInt('ENROLLMENT_KEY_DEFAULT_TTL_MINUTES', 60 * 24 * 30)`) and was left as-is.

## Test plan

- [x] Red first: added/adjusted unit tests asserting each function's fallback is `43200` with the env unset (and that `ENROLLMENT_KEY_DEFAULT_TTL_MINUTES` / `CHILD_ENROLLMENT_KEY_TTL_MINUTES` overrides still win), confirmed them failing against the pre-fix code (`60` / `1440` respectively).
- [x] Updated three pre-existing `installer.test.ts` tests that had the old `1440`-minute (24h) default baked into their assertions.
- [x] `cd apps/api && npx vitest run src/services/enrollmentKeySecurity.test.ts src/routes/installer.test.ts src/routes/enrollmentKeys --pool=threads --maxWorkers=2` → 8 files, 191 tests, all green.
- [x] `NODE_OPTIONS="--max-old-space-size=8192" npx tsc --noEmit -p apps/api` → clean.
- [x] `npx eslint` on all touched files → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011rcW2EcxjGpJXwAZU8RRci