### PR TITLE
docs(integrations): replace the Intuit sandbox sample email — unreds the customer-PII guard on main

### DIFF
--- a/docs/integrations/quickbooks-sandbox-verification.md
+++ b/docs/integrations/quickbooks-sandbox-verification.md
@@ -253,7 +253,7 @@ assigns the sandbox company, e.g. "Breeze QBO Sandbox 1"), never the realm ID.
 
 3. **Reconcile one existing customer by email and confirm it; verify QBO is
    unchanged.**
-   Result: PASS. Visible status: org with billing email `Surf@Intuit.com` was proposed to QBO customer 2 with confidence `exact_email`; confirm + sync → `confirmed / synced`, `remote_entity_id=2`, `remote_sync_token=1`, `remote_currency_code=USD`. QBO customer 2 was sparse-updated (DisplayName now follows the Breeze org name).
+   Result: PASS. Visible status: org with billing email `surf@example.com` was proposed to QBO customer 2 with confidence `exact_email`; confirm + sync → `confirmed / synced`, `remote_entity_id=2`, `remote_sync_token=1`, `remote_currency_code=USD`. QBO customer 2 was sparse-updated (DisplayName now follows the Breeze org name).
 
 4. **Choose create-new for a second organization; sync twice; verify one QBO
    Customer exists and the second sync updates it without duplication.**


### PR DESCRIPTION
Main has been red on **Security Audit → customer-PII guard** since #4492 (`418f7a407`): `docs/integrations/quickbooks-sandbox-verification.md:256` contains `Surf@Intuit.com`. That is Intuit's own QuickBooks sandbox sample contact, not customer data, but the guard is allowlist-based and `intuit.com` isn't a blessed domain — so every PR now fails Security Audit. Replaced with `surf@example.com` (the doc's meaning is unchanged; it's illustrating sandbox seed data).

Verified: `bash scripts/security/check-customer-pii.sh` passes locally on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011rcW2EcxjGpJXwAZU8RRci