### PR TITLE
fix(security): recognise intuit.com in the customer-PII guard (QuickBooks sandbox sample)

### DIFF
--- a/scripts/security/check-customer-pii.sh
+++ b/scripts/security/check-customer-pii.sh
@@ -38,6 +38,9 @@ ALLOW_RE="$ALLOW_RE"'|(^|\.)breeze\.(io|dev)$'
 ALLOW_RE="$ALLOW_RE"'|(^|\.)acme[a-z0-9-]*\.(co|com)$'
 ALLOW_RE="$ALLOW_RE"'|(^|\.)theirmsp\.com$'
 ALLOW_RE="$ALLOW_RE"'|(^|\.)gserviceaccount\.com$'
+# Intuit's public QuickBooks sandbox sample company ships fixture contacts like
+# Surf@Intuit.com — vendor sample identities, not Breeze customer data.
+ALLOW_RE="$ALLOW_RE"'|(^|\.)intuit\.com$'
 # Exact known-safe domains: public/example, infra, generic placeholders, and
 # owner-blessed real domains (olivetech.co — see PR #1968 discussion).
 ALLOW_RE="$ALLOW_RE"'|^(anthropic\.com|nist\.gov|google\.com|gmail\.com|mailinator\.com|contoso\.com|lanternops\.io|lantern\.it|olivetech\.co|a\.com|b\.co|b\.com|x\.com|mail\.x\.com|x\.io|y\.com|foo\.com|bar\.com|test\.com|corp\.com|company\.com|org\.com|msp\.com|yourmsp\.com|customer\.com|cust\.com|partner\.com|evil\.com|notours\.com|nowhere\.com|yourcompany\.com|yourdomain\.com|theirdomain\.com)$'


### PR DESCRIPTION
## Inherited red on main

`Security Audit` → "Run customer-PII guard" has failed on main since 418f7a407 (#4492, QuickBooks invoice push Phase C) and is still red on ede3d6eb1:

```
customer-pii guard: found email address(es) with an unrecognised domain.
  docs/integrations/quickbooks-sandbox-verification.md:256:Surf@Intuit.com
customer-pii guard: 1 disallowed email domain reference(s).
```

## Why allowlist rather than delete the doc line

`Surf@Intuit.com` is a stock contact from Intuit's public QuickBooks Online sandbox sample company — the fixture data every QBO developer sandbox ships with. It is a vendor sample identity, not Breeze customer PII, and the verification doc legitimately records the exact-email reconcile against it. So the correct fix is to recognise `intuit.com` in the guard's allowlist (with a comment explaining why), keeping the evidence intact.

## Change

One `ALLOW_RE` entry in `scripts/security/check-customer-pii.sh` (`(^|\.)intuit\.com$`) plus a two-line comment. No other files touched.

## Local verification (same command CI runs: `bash scripts/security/check-customer-pii.sh`)

Before the change (verified — reproduces the CI red exactly):
```
  docs/integrations/quickbooks-sandbox-verification.md:256:Surf@Intuit.com
customer-pii guard: 1 disallowed email domain reference(s).
exit=1
```

After the change (verified):
```
customer-pii guard: OK (no unrecognised email domains in tracked files).
exit=0
```

Negative control (verified, transient staged file, not committed): a doc containing `bob@realcustomer-dental.com` still fails the guard with exit 1, so the allowlist widening is scoped to `intuit.com` only.

The guard has no test file of its own, so no test was added; the RED/GREEN/negative-control runs above are the discrimination evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9p3mtFLSv8SFcZ9fcn8Vu
