### PR TITLE
test(api): address review findings on the offboarding lock barrier (#4036)

### DIFF
--- a/apps/api/src/__tests__/integration/offboardingRepairLockBarrier.integration.test.ts
+++ b/apps/api/src/__tests__/integration/offboardingRepairLockBarrier.integration.test.ts
@@ -29,6 +29,17 @@ import { getTestDb } from './setup';
  * mechanism — per-statement context, a connection-scoped GUC, a pool-level
  * `SET` — silently reverts #4022 with a fully green suite.
  *
+ * WHAT THIS FILE DOES AND DOES NOT PIN — read before trusting a green run.
+ * It pins lock ACQUISITION (the repair queues behind the tenant row before it
+ * rechecks) and, via the stamp-time assertion in the benign case, that the
+ * stamp is written by the SAME transaction that was blocked. It does NOT prove
+ * the row is still held throughout drain prep and the queue: a change that took
+ * the lock and dropped it early, keeping the rest in the same transaction,
+ * would still pass everything here. Proving that needs a third client probing
+ * `SELECT ... FOR UPDATE NOWAIT` for 55P03 during the repair's post-barrier
+ * work, which is a harder timing shape and is deliberately not attempted.
+ * Treat the residual gap as known, not as covered.
+ *
  * THE RACE STAGED HERE is the one the committed-abort cases cannot reach:
  *
  *     sweep:    SELECT candidates -> {org, startedAt: null}   (committed read)
@@ -85,9 +96,16 @@ import { getTestDb } from './setup';
  * The layer-1 assertions are `expect.soft` precisely so a future regression
  * reports both halves in one run instead of stopping at the first.
  *
- * FOUR CASES. Two abort barriers (organization and partner — `.for('update')`
- * appears at two separate call sites in `repairIncompleteEntry`, so pinning
- * only one leaves the other uncovered), then:
+ * FIVE CASES. Two abort barriers and two benign barriers, one of each per
+ * scope — `.for('update')` appears at two separate call sites in
+ * `repairIncompleteEntry` and the recheck predicate is written out twice, so
+ * pinning only the organization branch leaves the partner branch uncovered —
+ * then a positive control. Expect three #1105 held-context warnings per run:
+ * every barrier case parks the repair's context for the length of the wait,
+ * well past the 2s `DB_CONTEXT_HELD_WARN_MS` default. They are this file
+ * working, not a leak.
+ *
+ * The roles:
  *
  *  - THE OTHER ALLOWED OUTCOME: the same barrier with a BENIGN uncommitted
  *    write, where the repair waits, re-reads, finds the entry still torn and
@@ -135,6 +153,17 @@ function deferred<T>(): Deferred<T> {
   return { promise, resolve, reject };
 }
 
+/** A rejecting deadline arm for a `Promise.race`; clears its timer when it loses. */
+function lockTimeout(ms: number, message: string): Promise<never> {
+  let timer: NodeJS.Timeout;
+  const promise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), ms);
+  });
+  // Unref'd so a lost race cannot hold the event loop open at teardown.
+  timer!.unref?.();
+  return promise;
+}
+
 async function closeRaceClients(...clients: Sql[]): Promise<void> {
   const results = await Promise.allSettled(clients.map((c) => c.end({ timeout: 1 })));
   const failures = results.flatMap((r) => (r.status === 'rejected' ? [r.reason] : []));
@@ -147,11 +176,14 @@ async function closeRaceClients(...clients: Sql[]): Promise<void> {
  *
  * Scoping to the holder's own pid, rather than counting "any blocked backend"
  * as the currency barrier does: requiring the holder in the blocking set is
- * strictly stronger, and it keeps the assertion unsatisfiable by unrelated lock
- * waits on a shared default `:5433` (a per-worktree `pnpm test-stack` cluster
- * would not show them at all, but this must not depend on which stack it runs
- * against). The holder is idle-in-transaction and never blocked itself, so the
- * only backend that can match is the sweep queued behind the tenant row.
+ * strictly stronger, and it means no lock wait that does not involve the holder
+ * can satisfy it. Not "unsatisfiable by anything else": a sibling run sharing a
+ * default `:5433` could have its `cleanupDatabase()` TRUNCATE blocked by the
+ * holder's ROW EXCLUSIVE and match this filter. That would red the layer-1
+ * assertions loudly rather than pass vacuously, so it is a flake source, not a
+ * false green — and two runs sharing one database collide regardless. The
+ * holder is idle-in-transaction and never blocked itself, so on an uncontended
+ * cluster the only backend that can match is the sweep queued behind the row.
  *
  * Reads `a.query`, which requires the poller to be superuser or the same role
  * — `getTestDb()` is the bootstrap superuser `breeze_test`, and the sweep runs
@@ -159,10 +191,30 @@ async function closeRaceClients(...clients: Sql[]): Promise<void> {
  * come back NULL, the `state = 'active'` filter would drop every row, and this
  * would time out rather than fail loudly, so the privilege is load-bearing.
  */
-async function waitForStatementBlockedBy(holderPid: number, what: string): Promise<string> {
+/**
+ * 10s, not 15s: this shares one budget with vitest's 30s `testTimeout`, and on
+ * the failing path the `finally` still has to release the holder and drain a
+ * sweep that does Redis invalidations, the key expiry and the command inserts.
+ * At 15s a loaded runner could blow the test timeout and replace the message
+ * below with a generic "Test timed out", exactly when it is needed. 10s is
+ * still ~50x the observed time-to-lock.
+ */
+const BLOCK_POLL_TIMEOUT_MS = 10_000;
+
+async function waitForStatementBlockedBy(
+  holderPid: number,
+  what: string,
+  cancelled: () => boolean,
+): Promise<string> {
   const admin = getTestDb();
-  const deadline = Date.now() + 15_000;
+  const deadline = Date.now() + BLOCK_POLL_TIMEOUT_MS;
   for (;;) {
+    // The caller's race may already have settled on the sweep-completion arm —
+    // the EXPECTED failure path under a missing lock. Without this the loop
+    // would keep querying pg_stat_activity every 20ms for the rest of the
+    // deadline, straight through the next test's TRUNCATE: the same orphaned-
+    // work class this harness exists to avoid, just read-only.
+    if (cancelled()) throw new Error(`${what}: block poll cancelled`);
     const rows = await admin.execute<{ query: string }>(sql`
       SELECT a.query AS query
       FROM pg_catalog.pg_stat_activity a
@@ -174,14 +226,15 @@ async function waitForStatementBlockedBy(holderPid: number, what: string): Promi
     const query = rows[0]?.query;
     if (query) return query;
     if (Date.now() > deadline) {
-      // Deliberately does NOT name a cause. A sweep that is still running at
-      // 15s without ever appearing blocked could be a missing lock OR a loaded
+      // Deliberately does NOT name a cause. A sweep that is still running
+      // without ever appearing blocked could be a missing lock OR a loaded
       // box that has not reached the repair yet, and this poll cannot tell them
       // apart. The caller's `Promise.race` against the sweep itself is what
       // diagnoses the missing lock, because a COMPLETED sweep proves it.
       throw new Error(
-        `${what}: no statement was observed queued behind the tenant row within 15s, and the ` +
-        'sweep had not finished either — could not confirm the repair took the row lock (#4036)'
+        `${what}: no statement was observed queued behind the tenant row within ` +
+        `${BLOCK_POLL_TIMEOUT_MS}ms, and the sweep had not finished either — could not confirm ` +
+        'the repair took the row lock (#4036)'
       );
     }
     await new Promise((r) => setTimeout(r, 20));
@@ -214,28 +267,34 @@ async function sweepAgainstUncommittedWrite(
   id: string,
   write: 'abort' | 'benign',
   what: string,
-): Promise<{ result: SweepResult; blockedQuery: string }> {
+): Promise<{ result: SweepResult; blockedQuery: string; releasedAtMs: number }> {
   const lockHeld = deferred<number>();
   const release = deferred<void>();
   const holder = postgres(DATABASE_URL, { max: 1, onnotice: () => {} });
   let holderWork: Promise<void> | undefined;
   let running: Promise<SweepResult> | undefined;
+  let pollCancelled = false;
   try {
     holderWork = holder.begin(async (tx) => {
       const [row] = await tx<{ pid: number }[]>`SELECT pg_backend_pid()::int4 AS pid`;
       // Taken BEFORE the barrier is signalled, so the lock is provably held by
       // the time the sweep starts. The transaction commits when this callback
       // returns, i.e. only after `release`.
+      let updated;
       if (scope === 'organization') {
-        if (write === 'abort') {
-          await tx`UPDATE public.organizations SET status = 'active' WHERE id = ${id}`;
-        } else {
-          await tx`UPDATE public.organizations SET name = ${BENIGN_RENAME} WHERE id = ${id}`;
-        }
-      } else if (write === 'abort') {
-        await tx`UPDATE public.partners SET status = 'active' WHERE id = ${id}`;
+        updated = write === 'abort'
+          ? await tx`UPDATE public.organizations SET status = 'active' WHERE id = ${id}`
+          : await tx`UPDATE public.organizations SET name = ${BENIGN_RENAME} WHERE id = ${id}`;
       } else {
-        await tx`UPDATE public.partners SET name = ${BENIGN_RENAME} WHERE id = ${id}`;
+        updated = write === 'abort'
+          ? await tx`UPDATE public.partners SET status = 'active' WHERE id = ${id}`
+          : await tx`UPDATE public.partners SET name = ${BENIGN_RENAME} WHERE id = ${id}`;
+      }
+      // postgres.js does not error on a 0-row UPDATE, so without this a drifted
+      // fixture id would take NO row lock and the barrier would then accuse the
+      // repair of skipping a lock the harness never staged.
+      if (updated.count !== 1) {
+        throw new Error(`${what}: holder UPDATE matched ${updated.count} rows, expected 1 — fixture id is wrong`);
       }
       lockHeld.resolve(row!.pid);
       await release.promise;
@@ -247,7 +306,15 @@ async function sweepAgainstUncommittedWrite(
     holderWork.catch(() => { /* see above */ });
     const holderPid = await Promise.race([
       lockHeld.promise,
+      // Defensive: the holder resolves `lockHeld` before awaiting `release`, so
+      // this arm cannot win on the success path. It exists for the rejection
+      // path, where the real postgres error forwards through instead.
       holderWork.then(() => { throw new Error(`${what}: holder transaction ended before it took the row lock`); }),
+      // Without a deadline here an unexpectedly blocked holder UPDATE would
+      // hang until vitest's own testTimeout killed the test — and a killed test
+      // never runs this `finally`, leaking a connection sitting
+      // idle-in-transaction on a row lock into every later file.
+      lockTimeout(BLOCK_POLL_TIMEOUT_MS, `${what}: holder never acquired the tenant row lock`),
     ]);
 
     // The sweep's candidate select reads the COMMITTED row, so it still sees
@@ -260,19 +327,41 @@ async function sweepAgainstUncommittedWrite(
     // the poll's timeout, and it fails in milliseconds instead of 15s.
     // `Promise.race` subscribes to both arms, so neither derived rejection can
     // escape as unhandled once the race has settled.
-    const blockedQuery = await Promise.race([
-      waitForStatementBlockedBy(holderPid, what),
-      running.then(() => {
-        throw new Error(
-          `${what}: the sweep ran to completion while another transaction held the tenant row ` +
-          '— the repair never queued behind it, so it read status/stamp WITHOUT the row lock ' +
-          'and a tenant rescued mid-sweep can still be drained (#4036)'
-        );
-      }),
-    ]);
+    let blockedQuery: string;
+    try {
+      blockedQuery = await Promise.race([
+        waitForStatementBlockedBy(holderPid, what, () => pollCancelled),
+        running.then((r) => {
+          throw new Error(
+            `${what}: the sweep ran to completion while another transaction held the tenant row ` +
+            '— the repair never queued behind it, so it read status/stamp WITHOUT the row lock ' +
+            'and a tenant rescued mid-sweep can still be drained (#4036). ' +
+            // The sweep swallows per-tenant throws into `failures` and returns
+            // normally, so a Redis blip or a future lock_timeout ALSO completes
+            // it. A non-zero count means read the sweep's console.error before
+            // blaming `.for('update')` — this message must not assert a lock
+            // fault it has not established.
+            `sweep returned failures=${r.failures} (non-zero => suspect an internal sweep error, not the lock)`
+          );
+        }),
+      ]);
+    } finally {
+      pollCancelled = true;
+    }
+    // DB clock, not JS: the repair stamps with `now()` (= transaction_timestamp
+    // of the transaction that ran it), so the comparison must stay in Postgres'
+    // clock domain. Captured BEFORE the release, while the repair is provably
+    // still blocked.
+    // Epoch millis rather than a timestamptz: `db.execute` hands back the raw
+    // driver row, which does not arrive as a JS Date here.
+    const [clock] = await getTestDb().execute<{ ms: number }>(
+      sql`SELECT (extract(epoch from clock_timestamp()) * 1000)::float8 AS ms`
+    );
+    const releasedAtMs = Number(clock!.ms);
+    expect(Number.isFinite(releasedAtMs), 'clock_timestamp() probe did not return a number').toBe(true);
     release.resolve();
     await holderWork;
-    return { result: await running, blockedQuery };
+    return { result: await running, blockedQuery, releasedAtMs };
   } finally {
     release.resolve();
     if (holderWork) await Promise.allSettled([holderWork]);
@@ -283,6 +372,12 @@ async function sweepAgainstUncommittedWrite(
     // file's `beforeEach` TRUNCATE ... CASCADE. Files run sequentially and the
     // setup retries deadlocks only three times, so an orphan here fails an
     // unrelated suite.
+    //
+    // Not fully closed, and deliberately not claimed to be: the repair's
+    // `writeAuditEvent` is fire-and-forget, so its `audit_logs` INSERT can
+    // still be in flight after this returns and race the next `beforeEach`
+    // TRUNCATE. That one is not drainable from here — the service tracks no
+    // handle for it — and it predates this file.
     if (running) await Promise.allSettled([running]);
     await closeRaceClients(holder);
   }
@@ -376,19 +471,29 @@ async function orgState(
   return row;
 }
 
-async function partnerState(partnerId: string): Promise<{ status: string; startedAt: Date | null } | undefined> {
+async function partnerState(
+  partnerId: string
+): Promise<{ status: string; startedAt: Date | null; name: string } | undefined> {
   const [row] = await getTestDb()
-    .select({ status: partners.status, startedAt: partners.offboardingStartedAt })
+    .select({ status: partners.status, startedAt: partners.offboardingStartedAt, name: partners.name })
     .from(partners)
     .where(eq(partners.id, partnerId));
   return row;
 }
 
-/** The torn state the sweep looks for: offboarding, no drain stamp. */
+/**
+ * The torn state the sweep looks for: offboarding, no drain stamp.
+ *
+ * `offboardingTarget` is set EXPLICITLY rather than left to the schema default.
+ * The enrollment-key probe only discriminates on the churn path — on `archive`
+ * the repair passes `{ preserveEnrollmentKeys: true }` and the key survives
+ * whether or not drain prep ran, so a flipped default would quietly turn
+ * `keyStillUnexpired(...) === true` into a vacuous pass in both abort cases.
+ */
 async function tearOrg(orgId: string): Promise<void> {
   await getTestDb()
     .update(organizations)
-    .set({ status: 'offboarding', offboardingStartedAt: null })
+    .set({ status: 'offboarding', offboardingStartedAt: null, offboardingTarget: 'churn' })
     .where(eq(organizations.id, orgId));
 }
 
@@ -423,7 +528,7 @@ describe.runIf(RUN)('#4036 — the offboarding repair blocks on the tenant row i
     // also takes `devices FOR UPDATE`, and this rules that out — though the holder's
     // non-key UPDATE cannot actually block a child-row write's FOR KEY SHARE.
     expect.soft(q, `blocked on "${blockedQuery}" — expected a lock on organizations`).toContain('organizations');
-    expect.soft(q.startsWith('select'), `blocked on "${blockedQuery}" — a bare UPDATE means the lock is gone`).toBe(true);
+    expect.soft(/^\s*select/.test(q), `blocked on "${blockedQuery}" — a bare UPDATE means the lock is gone`).toBe(true);
 
     // Layer 2: nothing was done to the rescued tenant.
     // `failures` DOES discriminate — a throw out of the repair, or a 40001 from
@@ -432,14 +537,19 @@ describe.runIf(RUN)('#4036 — the offboarding repair blocks on the tenant row i
     expect(result.failures).toBe(0);
     expect(result.orgsFinalized).toBe(0);
     expect(await pendingUninstalls(deviceId)).toBe(0);
-    // Secondary only: `writeAuditEvent` is fire-and-forget, so its ABSENCE can
-    // never false-fail — the enrollment key below is the probe that carries
-    // the weight, because drain prep expires it synchronously.
+    // Secondary only, and weaker than it looks: `writeAuditEvent` is
+    // fire-and-forget, so on a regression where the repair DOES run this can
+    // still read 0 because the insert has not landed yet. It cannot false-fail,
+    // but it also cannot be relied on to red. The enrollment key below is the
+    // probe that carries the weight — drain prep expires it synchronously.
     expect(await repairAudits('organization', org.id)).toBe(0);
     expect(await keyStillUnexpired(keyId), 'drain prep ran against a rescued tenant').toBe(true);
 
     const after = await orgState(org.id);
+    // Shape check: the repair never writes `status`, only the stamp — this just
+    // confirms the holder's abort is what committed.
     expect(after?.status).toBe('active');
+    // The discriminating half: the stamp is what the repair would have written.
     expect(after?.startedAt).toBeNull();
   });
 
@@ -460,7 +570,7 @@ describe.runIf(RUN)('#4036 — the offboarding repair blocks on the tenant row i
     const q = blockedQuery.toLowerCase();
     expect.soft(q, `blocked on "${blockedQuery}" — expected the repair's locking SELECT`).toContain('for update');
     expect.soft(q, `blocked on "${blockedQuery}" — expected a lock on partners`).toContain('partners');
-    expect.soft(q.startsWith('select'), `blocked on "${blockedQuery}" — a bare UPDATE means the lock is gone`).toBe(true);
+    expect.soft(/^\s*select/.test(q), `blocked on "${blockedQuery}" — a bare UPDATE means the lock is gone`).toBe(true);
 
     expect(result.failures).toBe(0);
     // Shape check, not a discriminator — see the organization case above.
@@ -471,6 +581,7 @@ describe.runIf(RUN)('#4036 — the offboarding repair blocks on the tenant row i
     expect(await keyStillUnexpired(keyId), 'drain prep ran against a rescued tenant').toBe(true);
 
     const after = await partnerState(partner.id);
+    // Shape check (see the organization case); the stamp below discriminates.
     expect(after?.status).toBe('active');
     expect(after?.startedAt).toBeNull();
   });
@@ -485,14 +596,14 @@ describe.runIf(RUN)('#4036 — the offboarding repair blocks on the tenant row i
 
     // Same barrier, benign contention: the holder renames the org, so when the
     // repair finally takes the lock the recheck predicate is still satisfied.
-    const { result, blockedQuery } = await sweepAgainstUncommittedWrite(
+    const { result, blockedQuery, releasedAtMs } = await sweepAgainstUncommittedWrite(
       'organization', org.id, 'benign', 'organization repair (benign contention)'
     );
 
     const q = blockedQuery.toLowerCase();
     expect.soft(q, `blocked on "${blockedQuery}" — expected the repair's locking SELECT`).toContain('for update');
     expect.soft(q, `blocked on "${blockedQuery}" — expected a lock on organizations`).toContain('organizations');
-    expect.soft(q.startsWith('select'), `blocked on "${blockedQuery}" — a bare UPDATE means the lock is gone`).toBe(true);
+    expect.soft(/^\s*select/.test(q), `blocked on "${blockedQuery}" — a bare UPDATE means the lock is gone`).toBe(true);
 
     expect(result.failures).toBe(0);
     // The repair WAITED and then did its job — the outcome no other case here
@@ -506,7 +617,63 @@ describe.runIf(RUN)('#4036 — the offboarding repair blocks on the tenant row i
     expect(after?.status).toBe('offboarding');
     expect(after?.startedAt).not.toBeNull();
     // Proves the contention was real and committed mid-repair, not a no-op write.
+    // (Asserts the harness, not the SUT — `await holderWork` would already have
+    // thrown had the holder rolled back. Kept as a cheap staging check.)
     expect(after?.name).toBe(BENIGN_RENAME);
+
+    // SAME-TRANSACTION STAMP. The repair stamps with `DB_NOW` = `now()`, which
+    // in Postgres is transaction_timestamp() — the start of the transaction
+    // that wrote it, not the moment of the write. `releasedAtMs` is a
+    // clock_timestamp() taken while the repair was still provably blocked, so
+    // under the current code the stamp MUST predate it: the transaction was
+    // already open, holding the lock, before the barrier lifted.
+    //
+    // This is the one assertion here that reaches past lock acquisition. If RLS
+    // context ever becomes per-statement — the scenario this file's header
+    // names — the stamp would be written by a transaction that BEGINS after the
+    // release, and its `now()` would land after `releasedAtMs`. It does not cover
+    // a lock dropped early with the rest of the work still in one transaction;
+    // see the header's scope note.
+    expect(after?.startedAt!.getTime(),
+      'the stamp was written by a transaction that began AFTER the barrier lifted — the repair ' +
+      'no longer does its work in the transaction that held the lock (#4036)'
+    ).toBeLessThan(releasedAtMs);
+  });
+
+  // The recheck predicate is written out TWICE in the source, once per scope
+  // branch, so an over-strict recheck introduced only in the partner branch is
+  // invisible to every organization case. This also gives the partner scope a
+  // proof that its candidate actually reaches the repair — without one, a
+  // partner sweep that silently stopped selecting candidates would surface on
+  // the barrier's completion arm as a LOCK accusation.
+  it('partner: a repair that waits on the row and still finds it torn PROCEEDS', async () => {
+    const partner = await createPartner({ status: 'active' });
+    const org = await createOrganization({ partnerId: partner.id, status: 'active' });
+    const site = await createSite({ orgId: org.id });
+    const deviceId = await seedDevice(org.id, site.id, 'partner-benign');
+    const keyId = await seedEnrollmentKey(org.id, 'partner-benign');
+    await tearPartner(partner.id);
+
+    const { result, blockedQuery, releasedAtMs } = await sweepAgainstUncommittedWrite(
+      'partner', partner.id, 'benign', 'partner repair (benign contention)'
+    );
+
+    const q = blockedQuery.toLowerCase();
+    expect.soft(q, `blocked on "${blockedQuery}" — expected the repair's locking SELECT`).toContain('for update');
+    expect.soft(q, `blocked on "${blockedQuery}" — expected a lock on partners`).toContain('partners');
+    expect.soft(/^\s*select/.test(q), `blocked on "${blockedQuery}" — a bare UPDATE means the lock is gone`).toBe(true);
+
+    expect(result.failures).toBe(0);
+    expect(await pendingUninstalls(deviceId), 'the repair abandoned despite the entry still being torn').toBeGreaterThan(0);
+    expect(await keyStillUnexpired(keyId)).toBe(false);
+
+    const after = await partnerState(partner.id);
+    expect(after?.status).toBe('offboarding');
+    expect(after?.startedAt).not.toBeNull();
+    expect(after?.name).toBe(BENIGN_RENAME);
+    expect(after?.startedAt!.getTime(),
+      'the stamp was written by a transaction that began AFTER the barrier lifted (#4036)'
+    ).toBeLessThan(releasedAtMs);
   });
 
   it('positive control: with nothing holding the row, the sweep repairs a genuinely torn organization', async () => {

--- a/apps/api/src/__tests__/integration/offboardingRepairLockBarrier.integration.test.ts
+++ b/apps/api/src/__tests__/integration/offboardingRepairLockBarrier.integration.test.ts
@@ -66,20 +66,52 @@ import { getTestDb } from './setup';
  *     never ran at all — see the recheck suite's note on why the audit row
  *     alone cannot cover that).
  *
- * Verified to discriminate (mutation run against this branch, `.for('update')`
- * deleted from both selects in `repairIncompleteEntry`): both barrier cases go
- * red, reporting the blocked statement as `update "organizations" set ...
- * "offboarding_started_at" = now()` / the `partners` equivalent — the closing
- * stamp, not the locking select — and then failing the committed-outcome
- * assertion with one `self_uninstall` queued against the rescued tenant. The
- * layer-1 assertions are `expect.soft` precisely so a future regression reports
- * both halves in one run instead of stopping at the first.
+ * VERIFIED TO DISCRIMINATE — two mutation runs against `repairIncompleteEntry`,
+ * both restored afterwards:
  *
- * The third case is the positive control. It is what keeps the two barrier
- * cases from passing vacuously: it proves this file's `sweepOffboardingTenants`
- * entry point really does reach the repair for a torn tenant, so a barrier that
- * observed nothing would be a genuine regression rather than a sweep that
- * silently skipped the candidate.
+ *  1. `.for('update')` DELETED from both selects. All three barrier cases red.
+ *     The blocked statement is reported as `update "organizations" set ...
+ *     "offboarding_started_at" = now()` (and the `partners` equivalent) — the
+ *     closing stamp, not the locking select — and the abort cases then fail the
+ *     committed-outcome assertion with one `self_uninstall` queued against the
+ *     rescued tenant. The positive control stays green, as it must: it never
+ *     contends for the row.
+ *  2. `.for('update', { skipLocked: true })` — a plausible "optimization" that
+ *     silently turns contention into a zero-row read. All three barrier cases
+ *     red in ~200ms each, on the sweep-completion arm of the race rather than
+ *     on the poll, because a sweep that FINISHES while the row is held proves
+ *     the repair never queued behind it.
+ *
+ * The layer-1 assertions are `expect.soft` precisely so a future regression
+ * reports both halves in one run instead of stopping at the first.
+ *
+ * FOUR CASES. Two abort barriers (organization and partner — `.for('update')`
+ * appears at two separate call sites in `repairIncompleteEntry`, so pinning
+ * only one leaves the other uncovered), then:
+ *
+ *  - THE OTHER ALLOWED OUTCOME: the same barrier with a BENIGN uncommitted
+ *    write, where the repair waits, re-reads, finds the entry still torn and
+ *    must PROCEED. Blocking is only half the contract — a repair that queued
+ *    correctly and then abandoned anyway would still be a silent no-op of the
+ *    #2774 class, and no other case here asserts that second half: the two
+ *    abort cases expect abandon by construction, and the positive control never
+ *    contends for the row at all.
+ *
+ *    Stated precisely, because it is easy to overclaim: this case is not known
+ *    to be the SOLE catcher of any particular regression. Both mutations tried
+ *    below red it together with the abort cases. It is here to cover the second
+ *    of the two allowed outcomes, which would otherwise be untested.
+ *  - THE POSITIVE CONTROL, with nothing holding the row at all. It is what
+ *    keeps the barrier cases from passing vacuously: it proves this file's
+ *    `sweepOffboardingTenants` entry point really does reach the repair for a
+ *    torn tenant, so a barrier that observed nothing is a genuine regression
+ *    rather than a sweep that silently skipped the candidate.
+ *
+ * The fixtures and probes below are duplicated from
+ * `offboardingRepairRecheck.integration.test.ts` on purpose (CLAUDE.md permits
+ * local helper duplication). One caveat for anyone reading both: `repairAudits`
+ * shares that file's NAME but not its filter — this one keys on
+ * `resourceId` + a scope-derived action so it can serve the partner cases too.
  */
 
 const RUN = !!process.env.DATABASE_URL;
@@ -113,12 +145,19 @@ async function closeRaceClients(...clients: Sql[]): Promise<void> {
  * Wait until some backend is blocked BY `holderPid` specifically, and return
  * the statement it is stuck on.
  *
- * Scoping to the holder's own pid (rather than "any blocked backend", as the
- * currency barrier does) matters here: integration runs share a machine with
- * sibling worktree stacks, and this assertion must not be satisfiable by
- * anyone else's lock wait. The holder is idle-in-transaction and never blocked
- * itself, so the only backend that can match is the sweep queued behind the
- * tenant row.
+ * Scoping to the holder's own pid, rather than counting "any blocked backend"
+ * as the currency barrier does: requiring the holder in the blocking set is
+ * strictly stronger, and it keeps the assertion unsatisfiable by unrelated lock
+ * waits on a shared default `:5433` (a per-worktree `pnpm test-stack` cluster
+ * would not show them at all, but this must not depend on which stack it runs
+ * against). The holder is idle-in-transaction and never blocked itself, so the
+ * only backend that can match is the sweep queued behind the tenant row.
+ *
+ * Reads `a.query`, which requires the poller to be superuser or the same role
+ * — `getTestDb()` is the bootstrap superuser `breeze_test`, and the sweep runs
+ * as `breeze_app`. Under a non-privileged poller `state` and `query` would both
+ * come back NULL, the `state = 'active'` filter would drop every row, and this
+ * would time out rather than fail loudly, so the privilege is load-bearing.
  */
 async function waitForStatementBlockedBy(holderPid: number, what: string): Promise<string> {
   const admin = getTestDb();
@@ -135,9 +174,14 @@ async function waitForStatementBlockedBy(holderPid: number, what: string): Promi
     const query = rows[0]?.query;
     if (query) return query;
     if (Date.now() > deadline) {
+      // Deliberately does NOT name a cause. A sweep that is still running at
+      // 15s without ever appearing blocked could be a missing lock OR a loaded
+      // box that has not reached the repair yet, and this poll cannot tell them
+      // apart. The caller's `Promise.race` against the sweep itself is what
+      // diagnoses the missing lock, because a COMPLETED sweep proves it.
       throw new Error(
-        `${what}: nothing queued behind the tenant row within 15s — the repair read the ` +
-        'tenant WITHOUT taking its row lock, so an aborted tenant can still be drained (#4036)'
+        `${what}: no statement was observed queued behind the tenant row within 15s, and the ` +
+        'sweep had not finished either — could not confirm the repair took the row lock (#4036)'
       );
     }
     await new Promise((r) => setTimeout(r, 20));
@@ -146,21 +190,36 @@ async function waitForStatementBlockedBy(holderPid: number, what: string): Promi
 
 type SweepResult = Awaited<ReturnType<typeof sweepOffboardingTenants>>;
 
+/** The benign holder's write — a rename, which moves nothing the recheck reads. */
+const BENIGN_RENAME = 'renamed-under-the-barrier';
+
 /**
- * Runs the real sweep while a dedicated client holds an UNCOMMITTED
- * `SET status = 'active'` on the tenant row — the operator's abort, staged but
- * not yet visible. Asserts the sweep blocks, then commits the abort and returns
+ * Runs the real sweep while a dedicated client holds an UNCOMMITTED write on
+ * the tenant row. Asserts the sweep blocks, then commits that write and returns
  * the sweep's result together with the statement it was stuck on.
+ *
+ * `write` picks which contention is staged, and both take the same
+ * `FOR NO KEY UPDATE` row lock, so the barrier half is identical:
+ *   - `abort`  — `SET status = 'active'`, the operator rescuing the tenant.
+ *     The repair must re-read under its lock and ABANDON.
+ *   - `benign` — a rename. Nothing the recheck predicate reads has moved, so
+ *     the repair must re-read under its lock and PROCEED. This is the other
+ *     allowed outcome, and the only case that would catch an over-strict
+ *     recheck (or a move to REPEATABLE READ, where the re-read raises 40001
+ *     instead of seeing the new row version) silently turning every contended
+ *     repair into a no-op — with both abort cases still green.
  */
-async function sweepAgainstUncommittedAbort(
+async function sweepAgainstUncommittedWrite(
   scope: 'organization' | 'partner',
   id: string,
+  write: 'abort' | 'benign',
   what: string,
 ): Promise<{ result: SweepResult; blockedQuery: string }> {
   const lockHeld = deferred<number>();
   const release = deferred<void>();
   const holder = postgres(DATABASE_URL, { max: 1, onnotice: () => {} });
   let holderWork: Promise<void> | undefined;
+  let running: Promise<SweepResult> | undefined;
   try {
     holderWork = holder.begin(async (tx) => {
       const [row] = await tx<{ pid: number }[]>`SELECT pg_backend_pid()::int4 AS pid`;
@@ -168,14 +227,24 @@ async function sweepAgainstUncommittedAbort(
       // the time the sweep starts. The transaction commits when this callback
       // returns, i.e. only after `release`.
       if (scope === 'organization') {
-        await tx`UPDATE public.organizations SET status = 'active' WHERE id = ${id}`;
-      } else {
+        if (write === 'abort') {
+          await tx`UPDATE public.organizations SET status = 'active' WHERE id = ${id}`;
+        } else {
+          await tx`UPDATE public.organizations SET name = ${BENIGN_RENAME} WHERE id = ${id}`;
+        }
+      } else if (write === 'abort') {
         await tx`UPDATE public.partners SET status = 'active' WHERE id = ${id}`;
+      } else {
+        await tx`UPDATE public.partners SET name = ${BENIGN_RENAME} WHERE id = ${id}`;
       }
       lockHeld.resolve(row!.pid);
       await release.promise;
     });
-    holderWork.catch(() => { /* surfaced by the awaits below */ });
+    // Pre-attached so a holder failure is never an unhandled rejection. The
+    // race and the `await holderWork` below surface it on the normal paths;
+    // the `finally`'s allSettled deliberately swallows it, because by then the
+    // primary error has already won.
+    holderWork.catch(() => { /* see above */ });
     const holderPid = await Promise.race([
       lockHeld.promise,
       holderWork.then(() => { throw new Error(`${what}: holder transaction ended before it took the row lock`); }),
@@ -184,14 +253,37 @@ async function sweepAgainstUncommittedAbort(
     // The sweep's candidate select reads the COMMITTED row, so it still sees
     // {offboarding, startedAt: null} and hands the repair that stale snapshot —
     // which is the whole point: this is the window #4022 lives in.
-    const running = sweepOffboardingTenants(new Date());
-    const blockedQuery = await waitForStatementBlockedBy(holderPid, what);
+    running = sweepOffboardingTenants(new Date());
+    // Raced against the sweep itself, not just polled: a sweep that RUNS TO
+    // COMPLETION while another transaction holds the tenant row proves the
+    // repair never queued behind it. That is a fact this can establish, unlike
+    // the poll's timeout, and it fails in milliseconds instead of 15s.
+    // `Promise.race` subscribes to both arms, so neither derived rejection can
+    // escape as unhandled once the race has settled.
+    const blockedQuery = await Promise.race([
+      waitForStatementBlockedBy(holderPid, what),
+      running.then(() => {
+        throw new Error(
+          `${what}: the sweep ran to completion while another transaction held the tenant row ` +
+          '— the repair never queued behind it, so it read status/stamp WITHOUT the row lock ' +
+          'and a tenant rescued mid-sweep can still be drained (#4036)'
+        );
+      }),
+    ]);
     release.resolve();
     await holderWork;
     return { result: await running, blockedQuery };
   } finally {
     release.resolve();
     if (holderWork) await Promise.allSettled([holderWork]);
+    // Drain the sweep before returning. On a failure path it is still blocked
+    // on the holder, and the line above has just released it — leaving it in
+    // flight lets a writer that touches enrollment_keys, devices,
+    // device_commands, organizations AND Redis run straight into the NEXT
+    // file's `beforeEach` TRUNCATE ... CASCADE. Files run sequentially and the
+    // setup retries deadlocks only three times, so an orphan here fails an
+    // unrelated suite.
+    if (running) await Promise.allSettled([running]);
     await closeRaceClients(holder);
   }
 }
@@ -270,9 +362,15 @@ async function pendingUninstalls(deviceId: string): Promise<number> {
   return rows.length;
 }
 
-async function orgState(orgId: string): Promise<{ status: string; startedAt: Date | null } | undefined> {
+async function orgState(
+  orgId: string
+): Promise<{ status: string; startedAt: Date | null; name: string } | undefined> {
   const [row] = await getTestDb()
-    .select({ status: organizations.status, startedAt: organizations.offboardingStartedAt })
+    .select({
+      status: organizations.status,
+      startedAt: organizations.offboardingStartedAt,
+      name: organizations.name,
+    })
     .from(organizations)
     .where(eq(organizations.id, orgId));
   return row;
@@ -312,8 +410,8 @@ describe.runIf(RUN)('#4036 — the offboarding repair blocks on the tenant row i
     const keyId = await seedEnrollmentKey(org.id, 'org-lock');
     await tearOrg(org.id);
 
-    const { result, blockedQuery } = await sweepAgainstUncommittedAbort(
-      'organization', org.id, 'organization repair'
+    const { result, blockedQuery } = await sweepAgainstUncommittedWrite(
+      'organization', org.id, 'abort', 'organization repair'
     );
 
     // Layer 1: it is the LOCKING SELECT that waited, not the closing stamp
@@ -321,10 +419,16 @@ describe.runIf(RUN)('#4036 — the offboarding repair blocks on the tenant row i
     // after it has already prepped the drain and queued the uninstalls.
     const q = blockedQuery.toLowerCase();
     expect.soft(q, `blocked on "${blockedQuery}" — expected the repair's locking SELECT`).toContain('for update');
+    // Defense in depth rather than a third discriminating leg: `queueDrainUninstalls`
+    // also takes `devices FOR UPDATE`, and this rules that out — though the holder's
+    // non-key UPDATE cannot actually block a child-row write's FOR KEY SHARE.
     expect.soft(q, `blocked on "${blockedQuery}" — expected a lock on organizations`).toContain('organizations');
     expect.soft(q.startsWith('select'), `blocked on "${blockedQuery}" — a bare UPDATE means the lock is gone`).toBe(true);
 
     // Layer 2: nothing was done to the rescued tenant.
+    // `failures` DOES discriminate — a throw out of the repair, or a 40001 from
+    // the re-read, flips it. `orgsFinalized` does not: the repair branch returns
+    // before finalizing either way, so it is a shape check, not a discriminator.
     expect(result.failures).toBe(0);
     expect(result.orgsFinalized).toBe(0);
     expect(await pendingUninstalls(deviceId)).toBe(0);
@@ -349,8 +453,8 @@ describe.runIf(RUN)('#4036 — the offboarding repair blocks on the tenant row i
     // pass has nothing to do and the partner pass is the only repair in play.
     await tearPartner(partner.id);
 
-    const { result, blockedQuery } = await sweepAgainstUncommittedAbort(
-      'partner', partner.id, 'partner repair'
+    const { result, blockedQuery } = await sweepAgainstUncommittedWrite(
+      'partner', partner.id, 'abort', 'partner repair'
     );
 
     const q = blockedQuery.toLowerCase();
@@ -359,6 +463,7 @@ describe.runIf(RUN)('#4036 — the offboarding repair blocks on the tenant row i
     expect.soft(q.startsWith('select'), `blocked on "${blockedQuery}" — a bare UPDATE means the lock is gone`).toBe(true);
 
     expect(result.failures).toBe(0);
+    // Shape check, not a discriminator — see the organization case above.
     expect(result.partnersFinalized).toBe(0);
     expect(await pendingUninstalls(deviceId)).toBe(0);
     // Secondary only, same reason as the organization case above.
@@ -368,6 +473,40 @@ describe.runIf(RUN)('#4036 — the offboarding repair blocks on the tenant row i
     const after = await partnerState(partner.id);
     expect(after?.status).toBe('active');
     expect(after?.startedAt).toBeNull();
+  });
+
+  it('organization: a repair that waits on the row and still finds it torn PROCEEDS', async () => {
+    const partner = await createPartner({ status: 'active' });
+    const org = await createOrganization({ partnerId: partner.id, status: 'active' });
+    const site = await createSite({ orgId: org.id });
+    const deviceId = await seedDevice(org.id, site.id, 'org-benign');
+    const keyId = await seedEnrollmentKey(org.id, 'org-benign');
+    await tearOrg(org.id);
+
+    // Same barrier, benign contention: the holder renames the org, so when the
+    // repair finally takes the lock the recheck predicate is still satisfied.
+    const { result, blockedQuery } = await sweepAgainstUncommittedWrite(
+      'organization', org.id, 'benign', 'organization repair (benign contention)'
+    );
+
+    const q = blockedQuery.toLowerCase();
+    expect.soft(q, `blocked on "${blockedQuery}" — expected the repair's locking SELECT`).toContain('for update');
+    expect.soft(q, `blocked on "${blockedQuery}" — expected a lock on organizations`).toContain('organizations');
+    expect.soft(q.startsWith('select'), `blocked on "${blockedQuery}" — a bare UPDATE means the lock is gone`).toBe(true);
+
+    expect(result.failures).toBe(0);
+    // The repair WAITED and then did its job — the outcome no other case here
+    // asserts (both abort cases expect abandon; the positive control never
+    // contends). This is the assertion that would notice a repair which queues
+    // on the row correctly and then declines to heal the entry anyway.
+    expect(await pendingUninstalls(deviceId), 'the repair abandoned despite the entry still being torn').toBeGreaterThan(0);
+    expect(await keyStillUnexpired(keyId)).toBe(false);
+
+    const after = await orgState(org.id);
+    expect(after?.status).toBe('offboarding');
+    expect(after?.startedAt).not.toBeNull();
+    // Proves the contention was real and committed mid-repair, not a no-op write.
+    expect(after?.name).toBe(BENIGN_RENAME);
   });
 
   it('positive control: with nothing holding the row, the sweep repairs a genuinely torn organization', async () => {

--- a/apps/api/src/__tests__/integration/offboardingRepairRecheck.integration.test.ts
+++ b/apps/api/src/__tests__/integration/offboardingRepairRecheck.integration.test.ts
@@ -31,11 +31,15 @@ import { getTestDb } from './setup';
  * would not return the tenant once the abort has committed.
  *
  * Scope, deliberately: this pins the RECHECK, not the lock. Every abort here
- * commits before the repair starts, so removing `.for('update')` leaves all of
- * these green. Holding an uncommitted `active` UPDATE open in one transaction
- * while the repair runs in another WOULD pin the lock — see the
- * `pg_stat_activity` barrier in `orgCurrencyCreationBarrier.integration.test.ts`
- * — and would also remove the need to export the function.
+ * commits before the repair starts, so removing `.for('update')` still leaves
+ * all of these green — do not read a green run of THIS file as the lock being
+ * covered.
+ *
+ * The lock is covered, separately: `offboardingRepairLockBarrier.integration.test.ts`
+ * (#4036) holds an uncommitted UPDATE open across the repair and drives the
+ * real `sweepOffboardingTenants`, asserting via `pg_blocking_pids` that the
+ * repair queues behind the tenant row. Deleting `.for('update')` reds THAT
+ * file. The two suites are complementary and both are load-bearing.
  */
 const runDb = it.runIf(!!process.env.DATABASE_URL);
 

--- a/apps/api/src/services/tenantOffboarding.ts
+++ b/apps/api/src/services/tenantOffboarding.ts
@@ -1065,13 +1065,19 @@ export async function finalizePartnerOffboarding(
  * it is safe; the stamp write is the marker that the entry is now complete.
  */
 /**
- * Exported for the integration test that pins #4022: the sweep calls this from a
+ * Exported for the integration test that pins #4022
+ * (`offboardingRepairRecheck.integration.test.ts`): the sweep calls this from a
  * SNAPSHOTTED candidate taken in an earlier, already-committed context, and by
- * the time an abort has committed the sweep own select no longer returns the
- * tenant. A lock-barrier test that holds an uncommitted UPDATE open across the
- * repair could drive it through sweepOffboardingTenants instead, and would pin
- * the FOR UPDATE as well as the recheck; this export is the cost of not doing
- * that here.
+ * the time an abort has committed the sweep's own select no longer returns the
+ * tenant, so that suite cannot stage its six aborts through the sweep.
+ *
+ * The lock-barrier test this comment used to describe as hypothetical now
+ * exists (`offboardingRepairLockBarrier.integration.test.ts`, #4036): it holds
+ * an uncommitted UPDATE open across the repair and DOES drive the real
+ * `sweepOffboardingTenants`, so the FOR UPDATE below is covered. The export
+ * survives only because the recheck suite still imports it directly —
+ * un-exporting means rewriting that suite onto the barrier harness, which is
+ * follow-up work, not a consequence of #4036.
  */
 export async function repairIncompleteEntry(
   scope: 'organization' | 'partner',


### PR DESCRIPTION
Follow-up to #4433 (merged as `0fb5af40d`). That PR landed before this review round finished, so these fixes ship separately. Refs #4036 — leaving the issue open for the maintainer to close.

## Why a second PR

The review on #4433 raised three Major findings. The PR merged while they were still being addressed, so they are applied here against fresh `main` rather than lost.

## Findings addressed

**1. Orphaned sweep promise on every failure path (Major).** The harness never held a reference to the in-flight `sweepOffboardingTenants` promise. If a barrier assertion threw, the `finally` released the holder and returned *while the sweep was still blocked mid-transaction* — a writer touching `enrollment_keys`, `devices`, `device_commands`, `organizations` and Redis, left in flight to run straight into the **next file's** `beforeEach TRUNCATE ... CASCADE`. Integration files run sequentially and the setup retries deadlocks only three times, so an orphan here could red an unrelated suite, in a way that would look like flake in that suite rather than a bug here. The promise is now hoisted and drained with `allSettled` before the client closes.

**2. The barrier could only time out, never diagnose (Major).** The poll is now raced against the sweep itself:

```ts
const blockedQuery = await Promise.race([
  waitForStatementBlockedBy(holderPid, what),
  running.then(() => { throw new Error(`${what}: the sweep ran to completion while another transaction held the tenant row ...`); }),
]);
```

A sweep that runs to **completion** while another transaction holds the tenant row *proves* the repair never queued behind it. That is a fact, established in milliseconds; the old 15s timeout could only guess, and its message named a cause ("the repair read the tenant WITHOUT its row lock") it could not distinguish from a loaded CI box that had not reached the repair yet. The timeout message no longer asserts a cause.

**3. The other allowed outcome was untested (Major).** Blocking is only half the contract. A repair that queued correctly and then abandoned anyway would still be a silent no-op of the #2774 class, and nothing asserted otherwise: the two abort cases expect abandon by construction, and the positive control never contends for the row. Adds a fourth case running the same barrier with a **benign** uncommitted write (a rename — same `FOR NO KEY UPDATE` lock, but nothing the recheck predicate reads has moved), where the repair must wait, re-read, and **proceed**.

**4. Comment accuracy.** #4433 falsified two comments that are still on `main`: the export rationale in `tenantOffboarding.ts` describes the barrier test as hypothetical ("this export is the cost of not doing that here"), and the recheck suite's scope note says pinning the lock "WOULD" require one. Both now point at the suite that exists, and the recheck note keeps its still-true warning — a green run of *that* file is not evidence the lock is covered.

> The `tenantOffboarding.ts` change is **comment-only**. Verified mechanically: every `+`/`-` line in that file's diff is inside a block comment.

Also folded in the smaller review notes: the `orgsFinalized` / `partnersFinalized` assertions are labelled as shape checks rather than discriminators (`failures` is the one that discriminates), the `pg_stat_activity` privilege requirement is documented (a non-superuser poller would see NULL `state`/`query` and time out rather than fail loudly), and the harness's helper duplication + the `repairAudits` name collision with the sibling suite are called out.

## Re-verified by mutation

Both mutations applied to `repairIncompleteEntry` and restored afterwards.

**1. `.for('update')` deleted from both selects — all 3 barrier cases red:**

```
× organization: ... abandons once it commits
× partner: ... abandons once it commits
× organization: a repair that waits on the row and still finds it torn PROCEEDS

AssertionError: blocked on "update "organizations" set "updated_at" = $1,
  "offboarding_started_at" = now() where (...)" — expected the repair's locking SELECT
AssertionError: expected 1 to be +0     <-- one self_uninstall queued against
                                            the rescued tenant. #4022, exactly.
Tests  3 failed | 1 passed (4)
```

The positive control stays green, as it must — it never contends for the row.

**2. `.for('update', { skipLocked: true })`** — a plausible "optimization" that silently turns contention into a zero-row read. All 3 barrier cases red in ~200ms each, on the **new** completion arm:

```
Error: organization repair: the sweep ran to completion while another transaction
held the tenant row — the repair never queued behind it, so it read status/stamp
WITHOUT the row lock and a tenant rescued mid-sweep can still be drained (#4036)
```

**Green with both restored:** `Test Files 2 passed (2) / Tests 10 passed (10)` across this suite and the #4034 recheck suite.

### One claim I walked back

An earlier draft of the header said the benign case would be the *sole* catcher of an over-strict recheck. Both mutations above red it together with the abort cases, so that was not established and the comment now says so explicitly. Its actual justification is narrower and stands on its own: it covers the second of the two allowed outcomes, which nothing else asserts.

## Verification

- `vitest run --config vitest.integration.config.ts` on both offboarding suites — **10 passed**.
- `NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit -p apps/api` — exit 0, no output.
- `npx eslint` on all three touched files — exit 0.
- Real Postgres via a private per-worktree `pnpm test-stack`, not the shared `:5433`, so the `beforeEach` TRUNCATE could not disturb concurrent sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMvN6SU3uwaaC7b2xmUa5m