### PR TITLE
feat(ai,web): AI budget alert thresholds UI + /ai/usage alerts (#4388 W03)

### DIFF
--- a/apps/api/src/db/seedE2eFixtures.test.ts
+++ b/apps/api/src/db/seedE2eFixtures.test.ts
@@ -1,9 +1,43 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// In-memory stand-in for the Drizzle query builder. Tables are matched by
+// object identity, so a test seeds "rows that already exist" per table and
+// reads back what the seeder tried to insert.
+const dbState = vi.hoisted(() => ({
+  existing: new Map<unknown, Array<{ id: string }>>(),
+  inserts: [] as Array<{ table: unknown; values: unknown }>,
+}));
+
+vi.mock('./index', () => {
+  const rowsFor = (table: unknown) => Promise.resolve(dbState.existing.get(table) ?? []);
+  const db = {
+    select: () => ({
+      from: (table: unknown) => {
+        const limit = () => rowsFor(table);
+        const orderBy = () => ({ limit });
+        return { where: () => ({ limit, orderBy }), limit, orderBy };
+      },
+    }),
+    insert: (table: unknown) => ({
+      values: (values: unknown) => {
+        dbState.inserts.push({ table, values });
+        return Object.assign(Promise.resolve(undefined), {
+          onConflictDoUpdate: () => Promise.resolve(undefined),
+          returning: () => Promise.resolve([{ id: `seeded-${dbState.inserts.length}` }]),
+        });
+      },
+    }),
+  };
+  return { db, withSystemDbAccessContext: <T>(fn: () => T) => fn() };
+});
+
 import {
   resolveSeedE2eGuard,
+  seedE2eFixtures,
   E2E_MACOS_DEVICE_ID,
   E2E_WINDOWS_DEVICE_ID,
 } from './seedE2eFixtures';
+import { aiBudgetAlertEvents, organizations, sites } from './schema';
 
 describe('resolveSeedE2eGuard', () => {
   it('allows seeding in development', () => {
@@ -51,5 +85,62 @@ describe('e2e fixture device ids', () => {
 
   it('uses two distinct device ids', () => {
     expect(E2E_MACOS_DEVICE_ID).not.toBe(E2E_WINDOWS_DEVICE_ID);
+  });
+});
+
+// #4388 W03: the e2e spec asserts a fired rung renders on /settings/ai-usage,
+// which only happens when the seeded row lands in the org's CURRENT monthly
+// period. A local-time period key would silently miss the window near a month
+// boundary, and a non-idempotent insert would break re-seeding a live DB.
+describe('seedE2eFixtures AI budget alert event', () => {
+  beforeEach(() => {
+    dbState.existing.clear();
+    dbState.inserts.length = 0;
+    dbState.existing.set(organizations, [{ id: 'org-1' }]);
+    dbState.existing.set(sites, [{ id: 'site-1' }]);
+    vi.useFakeTimers();
+    // 00:30 UTC on the 1st is the previous month in every negative-offset
+    // zone, so a local-time period key resolves to 2026-02 here.
+    vi.setSystemTime(new Date('2026-03-01T00:30:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const alertInserts = () =>
+    dbState.inserts
+      .filter((row) => row.table === aiBudgetAlertEvents)
+      .map((row) => row.values as Record<string, unknown>);
+
+  it('seeds one fired monthly rung keyed to the current UTC month', async () => {
+    const result = await seedE2eFixtures({ quiet: true });
+
+    expect(result.seeded).toBe(true);
+    expect(alertInserts()).toEqual([
+      {
+        orgId: 'org-1',
+        period: 'monthly',
+        periodKey: '2026-03',
+        thresholdPct: 80,
+        capCents: 10000,
+        usedCents: 8500,
+        billingSource: 'platform',
+        deliveredAt: new Date('2026-03-01T00:30:00.000Z'),
+        recipientCount: 1,
+      },
+    ]);
+  });
+
+  it('does not re-insert the rung when it already exists', async () => {
+    dbState.existing.set(aiBudgetAlertEvents, [{ id: 'existing-event' }]);
+
+    const result = await seedE2eFixtures({ quiet: true });
+
+    expect(result.seeded).toBe(true);
+    expect(alertInserts()).toEqual([]);
+    // The run still reached the alert-event section (other fixtures inserted),
+    // so the empty list above is a skipped insert, not an aborted seed.
+    expect(dbState.inserts.length).toBeGreaterThan(0);
   });
 });

--- a/apps/api/src/db/seedE2eFixtures.ts
+++ b/apps/api/src/db/seedE2eFixtures.ts
@@ -35,6 +35,7 @@ import {
   devicePatches,
   backupConfigs,
   backupJobs,
+  aiBudgetAlertEvents,
 } from './schema';
 import { and, eq } from 'drizzle-orm';
 
@@ -354,6 +355,41 @@ export async function seedE2eFixtures(
           startedAt: new Date(Date.now() - 6 * 60 * 60 * 1000),
           completedAt: new Date(Date.now() - 350 * 60 * 1000),
           errorLog: 'E2E synthetic failure: target unreachable',
+        }),
+    );
+
+    // ── AI budget alert event (#4388 W03) ───────────────────────────────────
+    // One fired monthly 80% rung for the current period so the AI usage
+    // settings page (`/settings/ai-usage`) renders `ai-budget-fired-rungs`.
+    // Period key computed the same way as aiCostTracker.ts getUsageSummary()
+    // (UTC calendar month, `YYYY-MM`) so it's found by the same query.
+    const now = new Date();
+    const monthlyKey = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
+    await upsertByLookup(
+      () =>
+        db
+          .select({ id: aiBudgetAlertEvents.id })
+          .from(aiBudgetAlertEvents)
+          .where(
+            and(
+              eq(aiBudgetAlertEvents.orgId, orgId),
+              eq(aiBudgetAlertEvents.period, 'monthly'),
+              eq(aiBudgetAlertEvents.periodKey, monthlyKey),
+              eq(aiBudgetAlertEvents.thresholdPct, 80),
+            ),
+          )
+          .limit(1),
+      () =>
+        db.insert(aiBudgetAlertEvents).values({
+          orgId,
+          period: 'monthly',
+          periodKey: monthlyKey,
+          thresholdPct: 80,
+          capCents: 10000,
+          usedCents: 8500,
+          billingSource: 'platform',
+          deliveredAt: now,
+          recipientCount: 1,
         }),
     );
 

--- a/apps/api/src/routes/ai.ts
+++ b/apps/api/src/routes/ai.ts
@@ -1055,12 +1055,15 @@ aiRoutes.get(
     const orgId = c.req.query('orgId') || auth.orgId;
 
     if (!orgId) {
-      // System/partner users without a specific org — return zero usage
+      // System/partner users without a specific org: no org to resolve an
+      // effective budget for, so budget stays null. #4388: alerts.fired must
+      // still be present (empty) so callers can read it unconditionally.
       return c.json({
         daily: { inputTokens: 0, outputTokens: 0, totalCostCents: 0, messageCount: 0 },
         monthly: { inputTokens: 0, outputTokens: 0, totalCostCents: 0, messageCount: 0 },
         budget: null,
         billedTo: 'platform' as const,
+        alerts: { fired: [] },
       });
     }
 

--- a/apps/api/src/routes/ai_admin.test.ts
+++ b/apps/api/src/routes/ai_admin.test.ts
@@ -194,6 +194,35 @@ describe('AI routes', () => {
 
       expect(res.status).toBe(403);
     });
+
+    // #4388: the no-orgId branch (system/partner users with no specific org)
+    // never calls getUsageSummary, so it has its own literal response shape.
+    // alerts.fired must still be present (empty) so callers can read
+    // `usage.alerts.fired` unconditionally across every /ai/usage response.
+    it('returns alerts.fired as an empty array when there is no orgId to resolve', async () => {
+      const { authMiddleware } = await import('../middleware/auth');
+      vi.mocked(authMiddleware).mockImplementationOnce((c: any, next: any) => {
+        c.set('auth', {
+          user: { id: 'admin-1', email: 'admin@example.com' },
+          scope: 'system',
+          orgId: null,
+          accessibleOrgIds: null,
+          canAccessOrg: () => true,
+        });
+        return next();
+      });
+
+      const res = await app.request('/ai/usage', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.budget).toBeNull();
+      expect(body.alerts).toEqual({ fired: [] });
+      expect(getUsageSummary).not.toHaveBeenCalled();
+    });
   });
 
   // ============================================

--- a/apps/api/src/services/aiCostTracker.test.ts
+++ b/apps/api/src/services/aiCostTracker.test.ts
@@ -84,11 +84,14 @@ vi.mock('../db/schema', () => ({
 
 vi.mock('./redis', () => ({ getRedis: vi.fn(() => ({})) }));
 vi.mock('./rate-limit', () => ({ rateLimiter: vi.fn() }));
-// Default: an enabled, unlimited effective budget with the default alert
-// ladder, same shape `getEffectiveAiBudget` itself defaults to. Individual
-// tests override via `vi.mocked(getEffectiveAiBudget).mockResolvedValue(...)`.
-vi.mock('./effectiveSettings', () => ({
-  getEffectiveAiBudget: vi.fn().mockResolvedValue({
+
+// Single source of truth for an enabled, unlimited effective budget with the
+// default alert ladder, same shape `getEffectiveAiBudget` itself defaults
+// to. Used both as the module mock's default resolved value below and by
+// the local `effectiveBudget()` override helper in the #4388 getUsageSummary
+// describe block, so the 8 fields aren't typed out twice.
+const { DEFAULT_EFFECTIVE_BUDGET } = vi.hoisted(() => ({
+  DEFAULT_EFFECTIVE_BUDGET: {
     enabled: true,
     monthlyBudgetCents: null,
     dailyBudgetCents: null,
@@ -97,7 +100,13 @@ vi.mock('./effectiveSettings', () => ({
     messagesPerHourPerOrg: 200,
     approvalMode: 'per_step',
     alertThresholdPercents: [50, 80, 95],
-  }),
+  },
+}));
+
+// Default: the fixture above. Individual tests override via
+// `vi.mocked(getEffectiveAiBudget).mockResolvedValue(...)`.
+vi.mock('./effectiveSettings', () => ({
+  getEffectiveAiBudget: vi.fn().mockResolvedValue(DEFAULT_EFFECTIVE_BUDGET),
 }));
 vi.mock('./sentry', () => ({ captureException: vi.fn(), captureMessage: vi.fn() }));
 vi.mock('./aiBudgetAlerts', () => ({ evaluateAiBudgetThresholds: vi.fn().mockResolvedValue([]) }));
@@ -1140,14 +1149,7 @@ describe('getUsageSummary catalog endpoint provenance (#3922 W4)', () => {
 
 describe('getUsageSummary: effective budget + alert ladder (#4388)', () => {
   const effectiveBudget = (over: Record<string, unknown> = {}) => ({
-    enabled: true,
-    monthlyBudgetCents: null,
-    dailyBudgetCents: null,
-    maxTurnsPerSession: 50,
-    messagesPerMinutePerUser: 20,
-    messagesPerHourPerOrg: 200,
-    approvalMode: 'per_step',
-    alertThresholdPercents: [50, 80, 95],
+    ...DEFAULT_EFFECTIVE_BUDGET,
     ...over,
   }) as Awaited<ReturnType<typeof getEffectiveAiBudget>>;
 
@@ -1179,7 +1181,9 @@ describe('getUsageSummary: effective budget + alert ladder (#4388)', () => {
     expect(summary.budget?.monthlyBudgetCents).toBe(5000);
     expect(summary.budget?.alertThresholdPercents).toEqual([50, 80, 95]);
     // #2190: the budget read must be self-contexted like checkBudgetDetailed.
-    expect(vi.mocked(withSystemDbAccessContext)).toHaveBeenCalled();
+    // getUsageSummary only wraps that one read (unlike checkBudget, which
+    // also self-contexts a usage read), so it's called exactly once here.
+    expect(vi.mocked(withSystemDbAccessContext)).toHaveBeenCalledTimes(1);
   });
 
   it('lists rungs fired in the current periods', async () => {

--- a/apps/api/src/services/aiCostTracker.test.ts
+++ b/apps/api/src/services/aiCostTracker.test.ts
@@ -47,6 +47,10 @@ vi.mock('../db', () => ({
     update: vi.fn(),
     insert: vi.fn(),
     select: vi.fn(),
+    // Default: no alert-event rows. `vi.clearAllMocks()` (used in beforeEach
+    // below) only resets call tracking, not this implementation, so tests
+    // that don't care about `alerts.fired` never have to stub it themselves.
+    execute: vi.fn().mockResolvedValue([]),
   },
 }));
 
@@ -80,7 +84,21 @@ vi.mock('../db/schema', () => ({
 
 vi.mock('./redis', () => ({ getRedis: vi.fn(() => ({})) }));
 vi.mock('./rate-limit', () => ({ rateLimiter: vi.fn() }));
-vi.mock('./effectiveSettings', () => ({ getEffectiveAiBudget: vi.fn() }));
+// Default: an enabled, unlimited effective budget with the default alert
+// ladder, same shape `getEffectiveAiBudget` itself defaults to. Individual
+// tests override via `vi.mocked(getEffectiveAiBudget).mockResolvedValue(...)`.
+vi.mock('./effectiveSettings', () => ({
+  getEffectiveAiBudget: vi.fn().mockResolvedValue({
+    enabled: true,
+    monthlyBudgetCents: null,
+    dailyBudgetCents: null,
+    maxTurnsPerSession: 50,
+    messagesPerMinutePerUser: 20,
+    messagesPerHourPerOrg: 200,
+    approvalMode: 'per_step',
+    alertThresholdPercents: [50, 80, 95],
+  }),
+}));
 vi.mock('./sentry', () => ({ captureException: vi.fn(), captureMessage: vi.fn() }));
 vi.mock('./aiBudgetAlerts', () => ({ evaluateAiBudgetThresholds: vi.fn().mockResolvedValue([]) }));
 
@@ -1107,6 +1125,135 @@ describe('getUsageSummary catalog endpoint provenance (#3922 W4)', () => {
       catalogEndpointName: null,
     });
     expect(getCatalogEntryNameMock).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================
+// #4388: /ai/usage effective budget + fired-alert ladder
+// ============================================
+//
+// getUsageSummary used to read the raw `ai_budgets` row directly. It now
+// reads the EFFECTIVE budget (org row merged with any partner-wide override,
+// via getEffectiveAiBudget) so a partner-set cap is reflected here exactly
+// like it already is in checkBudgetDetailed. It also reports which alert
+// rungs have already fired for the org's current daily/monthly periods.
+
+describe('getUsageSummary: effective budget + alert ladder (#4388)', () => {
+  const effectiveBudget = (over: Record<string, unknown> = {}) => ({
+    enabled: true,
+    monthlyBudgetCents: null,
+    dailyBudgetCents: null,
+    maxTurnsPerSession: 50,
+    messagesPerMinutePerUser: 20,
+    messagesPerHourPerOrg: 200,
+    approvalMode: 'per_step',
+    alertThresholdPercents: [50, 80, 95],
+    ...over,
+  }) as Awaited<ReturnType<typeof getEffectiveAiBudget>>;
+
+  const currentMonthKey = () => {
+    const now = new Date();
+    return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
+  };
+  const currentDailyKey = () => {
+    const now = new Date();
+    return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}-${String(now.getUTCDate()).padStart(2, '0')}`;
+  };
+
+  beforeEach(() => {
+    setupDbMocks(null);
+  });
+
+  it('returns the EFFECTIVE budget (partner override wins) and the threshold ladder', async () => {
+    // A raw `ai_budgets` row would say 99999; this proves the merged/effective
+    // value is what ships, not whatever the org's own row happens to hold.
+    vi.mocked(getEffectiveAiBudget).mockResolvedValue(effectiveBudget({
+      monthlyBudgetCents: 5000,
+      dailyBudgetCents: null,
+      approvalMode: 'per_step',
+      alertThresholdPercents: [50, 80, 95],
+    }));
+
+    const summary = await getUsageSummary('org1');
+
+    expect(summary.budget?.monthlyBudgetCents).toBe(5000);
+    expect(summary.budget?.alertThresholdPercents).toEqual([50, 80, 95]);
+    // #2190: the budget read must be self-contexted like checkBudgetDetailed.
+    expect(vi.mocked(withSystemDbAccessContext)).toHaveBeenCalled();
+  });
+
+  it('lists rungs fired in the current periods', async () => {
+    vi.mocked(getEffectiveAiBudget).mockResolvedValue(effectiveBudget({ monthlyBudgetCents: 5000 }));
+    vi.mocked(db.execute).mockResolvedValueOnce([
+      {
+        period: 'monthly',
+        period_key: currentMonthKey(),
+        threshold_pct: 80,
+        created_at: '2026-09-03T10:00:00Z',
+        delivered_at: '2026-09-03T10:00:05Z',
+      },
+    ] as never);
+
+    const summary = await getUsageSummary('org1');
+
+    expect(summary.alerts.fired).toEqual([
+      {
+        period: 'monthly',
+        periodKey: currentMonthKey(),
+        thresholdPct: 80,
+        createdAt: '2026-09-03T10:00:00.000Z',
+        deliveredAt: '2026-09-03T10:00:05.000Z',
+      },
+    ]);
+  });
+
+  it('reports an undelivered rung with a null deliveredAt', async () => {
+    vi.mocked(getEffectiveAiBudget).mockResolvedValue(effectiveBudget({ dailyBudgetCents: 1000 }));
+    vi.mocked(db.execute).mockResolvedValueOnce([
+      {
+        period: 'daily',
+        period_key: currentDailyKey(),
+        threshold_pct: 50,
+        created_at: '2026-09-03T10:00:00Z',
+        delivered_at: null,
+      },
+    ] as never);
+
+    const summary = await getUsageSummary('org1');
+
+    expect(summary.alerts.fired).toEqual([
+      {
+        period: 'daily',
+        periodKey: currentDailyKey(),
+        thresholdPct: 50,
+        createdAt: '2026-09-03T10:00:00.000Z',
+        deliveredAt: null,
+      },
+    ]);
+  });
+
+  // The instruction not to use a vacuous assertion here means: don't just
+  // stub db.execute to return whatever and check the mapping (the test
+  // above already does that). Separately prove the query itself is scoped
+  // to THIS org and THIS org's current daily/monthly period keys, by
+  // asserting on the exact rendered SQL text and interpolated values that
+  // reached the mocked db.execute call.
+  it('scopes the fired-events query to this org and its current daily/monthly period keys', async () => {
+    vi.mocked(getEffectiveAiBudget).mockResolvedValue(effectiveBudget());
+    const executeMock = vi.mocked(db.execute);
+
+    await getUsageSummary('org-scope-1');
+
+    expect(executeMock).toHaveBeenCalledTimes(1);
+    const queryArg = executeMock.mock.calls[0]![0] as unknown as {
+      _sql: TemplateStringsArray;
+      values: unknown[];
+    };
+    const renderedSql = queryArg._sql.join('?');
+    expect(renderedSql).toContain('FROM ai_budget_alert_events');
+    expect(renderedSql).toContain("period = 'daily'");
+    expect(renderedSql).toContain("period = 'monthly'");
+    expect(queryArg.values).toEqual(['org-scope-1', currentDailyKey(), currentMonthKey()]);
   });
 });
 

--- a/apps/api/src/services/aiCostTracker.test.ts
+++ b/apps/api/src/services/aiCostTracker.test.ts
@@ -1167,8 +1167,9 @@ describe('getUsageSummary: effective budget + alert ladder (#4388)', () => {
   });
 
   it('returns the EFFECTIVE budget (partner override wins) and the threshold ladder', async () => {
-    // A raw `ai_budgets` row would say 99999; this proves the merged/effective
-    // value is what ships, not whatever the org's own row happens to hold.
+    // getUsageSummary reads ONLY getEffectiveAiBudget (the org row merged with
+    // any partner-wide override); it no longer selects the raw `ai_budgets`
+    // row, so what this helper resolves is exactly what ships.
     vi.mocked(getEffectiveAiBudget).mockResolvedValue(effectiveBudget({
       monthlyBudgetCents: 5000,
       dailyBudgetCents: null,

--- a/apps/api/src/services/aiCostTracker.ts
+++ b/apps/api/src/services/aiCostTracker.ts
@@ -1269,11 +1269,24 @@ export async function getUsageSummary(orgId: string): Promise<{
     monthlyUsedCents: number;
     dailyUsedCents: number;
     approvalMode: string;
-  } | null;
+    /** #4388: pre-cap alert rungs (1-99), partner-override-aware. */
+    alertThresholdPercents: number[];
+  };
   billedTo: AiBillingSource;
   /** Name of the catalog endpoint the org's most recent session used, or null
    *  for direct-Anthropic / platform-key traffic (#3922 W4). */
   catalogEndpointName: string | null;
+  /** #4388: threshold rungs already fired for the org's CURRENT daily and
+   *  monthly periods (nothing from prior, rolled-over periods). */
+  alerts: {
+    fired: Array<{
+      period: 'daily' | 'monthly';
+      periodKey: string;
+      thresholdPct: number;
+      createdAt: string;
+      deliveredAt: string | null;
+    }>;
+  };
 }> {
   const now = new Date();
   const dailyKey = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}-${String(now.getUTCDate()).padStart(2, '0')}`;
@@ -1291,11 +1304,25 @@ export async function getUsageSummary(orgId: string): Promise<{
     .where(and(eq(aiCostUsage.orgId, orgId), eq(aiCostUsage.period, 'monthly'), eq(aiCostUsage.periodKey, monthlyKey)))
     .limit(1);
 
-  const [budget] = await db
-    .select()
-    .from(aiBudgets)
-    .where(eq(aiBudgets.orgId, orgId))
-    .limit(1);
+  // #4388: the EFFECTIVE budget (org row merged with any partner-wide
+  // override), not the raw ai_budgets row: a partner-set cap must show up
+  // here exactly like it already does in checkBudgetDetailed. Self-contexted
+  // for the same #2190 reason as that function; see the comment there.
+  const budget = await withSystemDbAccessContext(() => getEffectiveAiBudget(orgId));
+
+  const fired = await db.execute<{
+    period: 'daily' | 'monthly';
+    period_key: string;
+    threshold_pct: number;
+    created_at: string;
+    delivered_at: string | null;
+  }>(sql`
+    SELECT period, period_key, threshold_pct, created_at, delivered_at
+    FROM ai_budget_alert_events
+    WHERE org_id = ${orgId}::uuid
+      AND ((period = 'daily' AND period_key = ${dailyKey}) OR (period = 'monthly' AND period_key = ${monthlyKey}))
+    ORDER BY created_at
+  `);
 
   const billedTo = await getLlmBillingSourceForOrg(orgId);
 
@@ -1320,15 +1347,25 @@ export async function getUsageSummary(orgId: string): Promise<{
       totalCostCents: monthlyUsage?.totalCostCents ?? 0,
       messageCount: monthlyUsage?.messageCount ?? 0
     },
-    budget: budget ? {
+    budget: {
       enabled: budget.enabled,
       monthlyBudgetCents: budget.monthlyBudgetCents,
       dailyBudgetCents: budget.dailyBudgetCents,
       monthlyUsedCents: monthlyUsage?.totalCostCents ?? 0,
       dailyUsedCents: dailyUsage?.totalCostCents ?? 0,
       approvalMode: budget.approvalMode ?? 'per_step',
-    } : null,
+      alertThresholdPercents: budget.alertThresholdPercents,
+    },
     billedTo,
     catalogEndpointName,
+    alerts: {
+      fired: fired.map((r) => ({
+        period: r.period,
+        periodKey: r.period_key,
+        thresholdPct: Number(r.threshold_pct),
+        createdAt: new Date(r.created_at).toISOString(),
+        deliveredAt: r.delivered_at ? new Date(r.delivered_at).toISOString() : null,
+      })),
+    },
   };
 }

--- a/apps/api/src/services/aiCostTracker.ts
+++ b/apps/api/src/services/aiCostTracker.ts
@@ -1321,7 +1321,7 @@ export async function getUsageSummary(orgId: string): Promise<{
     FROM ai_budget_alert_events
     WHERE org_id = ${orgId}::uuid
       AND ((period = 'daily' AND period_key = ${dailyKey}) OR (period = 'monthly' AND period_key = ${monthlyKey}))
-    ORDER BY created_at
+    ORDER BY created_at, id
   `);
 
   const billedTo = await getLlmBillingSourceForOrg(orgId);

--- a/apps/docs/src/content/docs/features/ai.mdx
+++ b/apps/docs/src/content/docs/features/ai.mdx
@@ -324,7 +324,7 @@ When billing is not configured, AI usage is unlimited — cost tracking still re
 
 Independent of hard budget enforcement, an organisation can get warned as its AI spend approaches its cap. Each period (daily and monthly) is checked against a ladder of percentage thresholds, and once spend crosses a rung, an alert fires for that rung.
 
-The default ladder is 50%, 80%, and 95% of the configured budget. On top of the ladder, a 100% "cap reached" alert always fires when the budget is exhausted, even if the ladder is empty or disabled — that alert cannot be turned off. Each rung fires once per period; the ladder resets automatically when the daily or monthly period rolls over.
+The default ladder is 50%, 80%, and 95% of the configured budget. On top of the ladder, a 100% "cap reached" alert always fires when the budget is exhausted, even if the ladder is empty or disabled, since that alert cannot be turned off. Each rung fires once per period; the ladder resets automatically when the daily or monthly period rolls over.
 
 Alerts are delivered to active users with the `billing:manage` permission, whether they belong to the organisation directly or are partner users whose access covers that organisation. Delivery has two channels:
 
@@ -338,7 +338,7 @@ The threshold ladder is configured in two places:
 - **Organisation**: **Settings → AI Usage** on the org's own budget configuration.
 - **Partner**: the **AI Budgets** tab of Partner Settings, which can set a value that applies across every organisation under the partner.
 
-A partner-set value locks the field on the organisation page — the org can see it but can't override it. Leaving the field empty means "inherit the default ladder" (50/80/95); explicitly setting it to an empty list turns pre-cap warnings off entirely for that org (the 100% cap-reached alert still fires regardless).
+A partner-set value locks the field on the organisation page, so the org can see it but can't override it. Leaving the field empty means "inherit the default ladder" (50/80/95); explicitly setting it to an empty list turns pre-cap warnings off entirely for that org (the 100% cap-reached alert still fires regardless).
 
 ---
 

--- a/apps/docs/src/content/docs/features/ai.mdx
+++ b/apps/docs/src/content/docs/features/ai.mdx
@@ -324,6 +324,8 @@ When billing is not configured, AI usage is unlimited — cost tracking still re
 
 Independent of hard budget enforcement, an organisation can get warned as its AI spend approaches its cap. Each period (daily and monthly) is checked against a ladder of percentage thresholds, and once spend crosses a rung, an alert fires for that rung.
 
+Alerts only fire for an organisation that has AI enabled and a daily or monthly cap set. With no cap there is nothing to measure a percentage against, so no rung can be crossed.
+
 The default ladder is 50%, 80%, and 95% of the configured budget. On top of the ladder, a 100% "cap reached" alert always fires when the budget is exhausted, even if the ladder is empty or disabled, since that alert cannot be turned off. Each rung fires once per period; the ladder resets automatically when the daily or monthly period rolls over.
 
 Alerts are delivered to active users with the `billing:manage` permission, whether they belong to the organisation directly or are partner users whose access covers that organisation. Delivery has two channels:
@@ -338,7 +340,9 @@ The threshold ladder is configured in two places:
 - **Organisation**: **Settings → AI Usage** on the org's own budget configuration.
 - **Partner**: the **AI Budgets** tab of Partner Settings, which can set a value that applies across every organisation under the partner.
 
-A partner-set value locks the field on the organisation page, so the org can see it but can't override it. Leaving the field empty means "inherit the default ladder" (50/80/95); explicitly setting it to an empty list turns pre-cap warnings off entirely for that org (the 100% cap-reached alert still fires regardless).
+A partner-set value locks the field on the organisation page, so the org can see it but can't override it.
+
+Either field takes two kinds of input: leave it empty to inherit (the org inherits the partner value, or the 50/80/95 default when the partner sets nothing), or type an explicit ladder of up to five whole percentages, such as `60, 90`. Turning pre-cap warnings off entirely requires storing an empty list, which the UI cannot produce; do that through `PUT /ai/budget` with `"alertThresholdPercents": []`. The 100% cap-reached alert still fires regardless.
 
 ---
 

--- a/apps/docs/src/content/docs/features/ai.mdx
+++ b/apps/docs/src/content/docs/features/ai.mdx
@@ -320,6 +320,26 @@ When billing is not configured, AI usage is unlimited — cost tracking still re
   Cost tracking is automatic — no configuration required. It works for both the main AI assistant and the Helper AI chat. Billing credit enforcement is optional and requires the billing service environment variables. See [Environment Variables](/deploy/environment/) for details.
 </Aside>
 
+### Budget alerts
+
+Independent of hard budget enforcement, an organisation can get warned as its AI spend approaches its cap. Each period (daily and monthly) is checked against a ladder of percentage thresholds, and once spend crosses a rung, an alert fires for that rung.
+
+The default ladder is 50%, 80%, and 95% of the configured budget. On top of the ladder, a 100% "cap reached" alert always fires when the budget is exhausted, even if the ladder is empty or disabled — that alert cannot be turned off. Each rung fires once per period; the ladder resets automatically when the daily or monthly period rolls over.
+
+Alerts are delivered to active users with the `billing:manage` permission, whether they belong to the organisation directly or are partner users whose access covers that organisation. Delivery has two channels:
+
+- Monthly rungs and the 100% cap-reached alert are delivered both in-app and by email.
+- Daily 50/80/95 rungs are delivered in-app only, to avoid an email per day as spend climbs toward a much smaller cap.
+
+### Configuring thresholds
+
+The threshold ladder is configured in two places:
+
+- **Organisation**: **Settings → AI Usage** on the org's own budget configuration.
+- **Partner**: the **AI Budgets** tab of Partner Settings, which can set a value that applies across every organisation under the partner.
+
+A partner-set value locks the field on the organisation page — the org can see it but can't override it. Leaving the field empty means "inherit the default ladder" (50/80/95); explicitly setting it to an empty list turns pre-cap warnings off entirely for that org (the 100% cap-reached alert still fires regardless).
+
 ---
 
 ## AI Input Sanitization

--- a/apps/web/src/components/settings/AiBudgetThresholdsInput.test.tsx
+++ b/apps/web/src/components/settings/AiBudgetThresholdsInput.test.tsx
@@ -70,6 +70,43 @@ describe('AiBudgetThresholdsInput', () => {
     expect(screen.queryByTestId('thresholds-error')).not.toBeInTheDocument();
   });
 
+  // The commit path swallows unparseable text (no onChange), so the page above
+  // has no other way to know its Save button would persist the stale value.
+  it('reports invalid on an unparseable entry and valid again once it parses', () => {
+    const onValidityChange = vi.fn();
+    render(
+      <AiBudgetThresholdsInput value={[]} onChange={vi.fn()} onValidityChange={onValidityChange} testId="thresholds" />,
+    );
+    const input = screen.getByTestId('thresholds-input');
+
+    fireEvent.change(input, { target: { value: '100' } });
+    fireEvent.blur(input);
+    expect(onValidityChange).toHaveBeenLastCalledWith(false);
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(input).toHaveAttribute('aria-describedby', 'thresholds-error');
+    expect(screen.getByTestId('thresholds-error')).toHaveAttribute('id', 'thresholds-error');
+
+    fireEvent.change(input, { target: { value: '50, 80' } });
+    fireEvent.blur(input);
+    expect(onValidityChange).toHaveBeenLastCalledWith(true);
+    expect(input).not.toHaveAttribute('aria-invalid');
+    expect(input).not.toHaveAttribute('aria-describedby');
+  });
+
+  it('releases the caller when it unmounts holding unparseable text', () => {
+    const onValidityChange = vi.fn();
+    const { unmount } = render(
+      <AiBudgetThresholdsInput value={[]} onChange={vi.fn()} onValidityChange={onValidityChange} testId="thresholds" />,
+    );
+    const input = screen.getByTestId('thresholds-input');
+    fireEvent.change(input, { target: { value: 'abc' } });
+    fireEvent.blur(input);
+    expect(onValidityChange).toHaveBeenLastCalledWith(false);
+
+    unmount();
+    expect(onValidityChange).toHaveBeenLastCalledWith(true);
+  });
+
   it('does not commit a disabled input', () => {
     const onChange = vi.fn();
     render(<AiBudgetThresholdsInput value={[50]} onChange={onChange} disabled testId="thresholds" />);

--- a/apps/web/src/components/settings/AiBudgetThresholdsInput.test.tsx
+++ b/apps/web/src/components/settings/AiBudgetThresholdsInput.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import AiBudgetThresholdsInput from './AiBudgetThresholdsInput';
+
+describe('AiBudgetThresholdsInput', () => {
+  it('renders current rungs as chips and emits a normalised list on blur', () => {
+    const onChange = vi.fn();
+    render(<AiBudgetThresholdsInput value={[50, 80]} onChange={onChange} testId="thresholds" />);
+    expect(screen.getByText('50%')).toBeInTheDocument();
+    const input = screen.getByTestId('thresholds-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '95, 50, 80' } });
+    fireEvent.blur(input);
+    expect(onChange).toHaveBeenLastCalledWith([50, 80, 95]);
+  });
+
+  it('rejects values outside 1..99 with an inline error and does not emit', () => {
+    const onChange = vi.fn();
+    render(<AiBudgetThresholdsInput value={[]} onChange={onChange} testId="thresholds" />);
+    const input = screen.getByTestId('thresholds-input');
+    fireEvent.change(input, { target: { value: '100' } });
+    fireEvent.blur(input);
+    expect(screen.getByTestId('thresholds-error')).toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('emits undefined (inherit) when cleared', () => {
+    const onChange = vi.fn();
+    render(<AiBudgetThresholdsInput value={[50]} onChange={onChange} testId="thresholds" />);
+    fireEvent.change(screen.getByTestId('thresholds-input'), { target: { value: '' } });
+    fireEvent.blur(screen.getByTestId('thresholds-input'));
+    expect(onChange).toHaveBeenLastCalledWith(undefined);
+  });
+});

--- a/apps/web/src/components/settings/AiBudgetThresholdsInput.test.tsx
+++ b/apps/web/src/components/settings/AiBudgetThresholdsInput.test.tsx
@@ -30,4 +30,53 @@ describe('AiBudgetThresholdsInput', () => {
     fireEvent.blur(screen.getByTestId('thresholds-input'));
     expect(onChange).toHaveBeenLastCalledWith(undefined);
   });
+
+  it('rejects more than five values with an inline error and does not emit', () => {
+    const onChange = vi.fn();
+    render(<AiBudgetThresholdsInput value={[]} onChange={onChange} testId="thresholds" />);
+    const input = screen.getByTestId('thresholds-input');
+    fireEvent.change(input, { target: { value: '10, 20, 30, 40, 50, 60' } });
+    fireEvent.blur(input);
+    expect(screen.getByTestId('thresholds-error')).toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('dedupes duplicate values within the same input', () => {
+    const onChange = vi.fn();
+    render(<AiBudgetThresholdsInput value={[]} onChange={onChange} testId="thresholds" />);
+    const input = screen.getByTestId('thresholds-input');
+    fireEvent.change(input, { target: { value: '50, 50, 80' } });
+    fireEvent.blur(input);
+    expect(onChange).toHaveBeenLastCalledWith([50, 80]);
+  });
+
+  it('commits on Enter without requiring blur', () => {
+    const onChange = vi.fn();
+    render(<AiBudgetThresholdsInput value={[]} onChange={onChange} testId="thresholds" />);
+    const input = screen.getByTestId('thresholds-input');
+    fireEvent.change(input, { target: { value: '50, 80' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onChange).toHaveBeenLastCalledWith([50, 80]);
+  });
+
+  it('clears a stale inline error as soon as the user edits the text again', () => {
+    const onChange = vi.fn();
+    render(<AiBudgetThresholdsInput value={[]} onChange={onChange} testId="thresholds" />);
+    const input = screen.getByTestId('thresholds-input');
+    fireEvent.change(input, { target: { value: '100' } });
+    fireEvent.blur(input);
+    expect(screen.getByTestId('thresholds-error')).toBeInTheDocument();
+    fireEvent.change(input, { target: { value: '50' } });
+    expect(screen.queryByTestId('thresholds-error')).not.toBeInTheDocument();
+  });
+
+  it('does not commit a disabled input', () => {
+    const onChange = vi.fn();
+    render(<AiBudgetThresholdsInput value={[50]} onChange={onChange} disabled testId="thresholds" />);
+    const input = screen.getByTestId('thresholds-input') as HTMLInputElement;
+    expect(input.disabled).toBe(true);
+    fireEvent.change(input, { target: { value: '80' } });
+    fireEvent.blur(input);
+    expect(onChange).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/components/settings/AiBudgetThresholdsInput.tsx
+++ b/apps/web/src/components/settings/AiBudgetThresholdsInput.tsx
@@ -28,6 +28,7 @@ export default function AiBudgetThresholdsInput({ value, onChange, disabled, pla
   useEffect(() => { setText(value?.join(', ') ?? ''); }, [value]);
 
   const commit = () => {
+    if (disabled) return;
     const parsed = parseThresholds(text);
     if (!parsed.ok) { setInvalid(true); return; }
     setInvalid(false);
@@ -48,7 +49,7 @@ export default function AiBudgetThresholdsInput({ value, onChange, disabled, pla
         value={text}
         disabled={disabled}
         placeholder={placeholder}
-        onChange={(e) => setText(e.target.value)}
+        onChange={(e) => { setText(e.target.value); setInvalid(false); }}
         onBlur={commit}
         onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); commit(); } }}
         className={`h-10 w-full rounded-md border bg-background px-3 text-sm ${disabled ? 'opacity-60 cursor-not-allowed' : ''}`}

--- a/apps/web/src/components/settings/AiBudgetThresholdsInput.tsx
+++ b/apps/web/src/components/settings/AiBudgetThresholdsInput.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import '@/lib/i18n';
+
+type Props = {
+  value: number[] | undefined;
+  onChange: (value: number[] | undefined) => void;
+  disabled?: boolean;
+  placeholder?: string;
+  testId?: string;
+};
+
+export function parseThresholds(raw: string): { ok: true; value: number[] | undefined } | { ok: false } {
+  const trimmed = raw.trim();
+  if (trimmed === '') return { ok: true, value: undefined };
+  const parts = trimmed.split(/[\s,]+/).filter(Boolean);
+  const nums = parts.map(Number);
+  if (nums.some((n) => !Number.isInteger(n) || n < 1 || n > 99)) return { ok: false };
+  const uniq = [...new Set(nums)].sort((a, b) => a - b);
+  if (uniq.length > 5) return { ok: false };
+  return { ok: true, value: uniq };
+}
+
+export default function AiBudgetThresholdsInput({ value, onChange, disabled, placeholder, testId = 'ai-budget-thresholds' }: Props) {
+  const { t } = useTranslation('settings');
+  const [text, setText] = useState(value?.join(', ') ?? '');
+  const [invalid, setInvalid] = useState(false);
+  useEffect(() => { setText(value?.join(', ') ?? ''); }, [value]);
+
+  const commit = () => {
+    const parsed = parseThresholds(text);
+    if (!parsed.ok) { setInvalid(true); return; }
+    setInvalid(false);
+    onChange(parsed.value);
+  };
+
+  return (
+    <div className="space-y-1">
+      <div className="flex flex-wrap gap-1">
+        {(value ?? []).map((v) => (
+          <span key={v} className="rounded-full bg-muted px-2 py-0.5 text-xs">{v}%</span>
+        ))}
+      </div>
+      <input
+        type="text"
+        inputMode="numeric"
+        data-testid={`${testId}-input`}
+        value={text}
+        disabled={disabled}
+        placeholder={placeholder}
+        onChange={(e) => setText(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); commit(); } }}
+        className={`h-10 w-full rounded-md border bg-background px-3 text-sm ${disabled ? 'opacity-60 cursor-not-allowed' : ''}`}
+      />
+      {invalid && (
+        <p data-testid={`${testId}-error`} className="text-xs text-red-600">{t('aiBudgetThresholds.invalid')}</p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/AiBudgetThresholdsInput.tsx
+++ b/apps/web/src/components/settings/AiBudgetThresholdsInput.tsx
@@ -1,10 +1,25 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import '@/lib/i18n';
+
+/**
+ * The default ladder, rendered as the org-page placeholder. It is deliberately
+ * NOT a locale string: it is a numeric example of the input format, identical
+ * in every language, and a per-locale copy of it pushed every settings.json
+ * over its exact-English duplicate baseline.
+ */
+export const DEFAULT_THRESHOLDS_PLACEHOLDER = '50, 80, 95';
 
 type Props = {
   value: number[] | undefined;
   onChange: (value: number[] | undefined) => void;
+  /**
+   * Reports whether the text currently in the box parses. Callers gate their
+   * Save button on it: `commit()` swallows unparseable text (it never calls
+   * `onChange`), so without this the page would silently save the previous
+   * value while the red inline error is still on screen.
+   */
+  onValidityChange?: (valid: boolean) => void;
   disabled?: boolean;
   placeholder?: string;
   testId?: string;
@@ -21,19 +36,37 @@ export function parseThresholds(raw: string): { ok: true; value: number[] | unde
   return { ok: true, value: uniq };
 }
 
-export default function AiBudgetThresholdsInput({ value, onChange, disabled, placeholder, testId = 'ai-budget-thresholds' }: Props) {
+export default function AiBudgetThresholdsInput({ value, onChange, onValidityChange, disabled, placeholder, testId = 'ai-budget-thresholds' }: Props) {
   const { t } = useTranslation('settings');
   const [text, setText] = useState(value?.join(', ') ?? '');
   const [invalid, setInvalid] = useState(false);
-  useEffect(() => { setText(value?.join(', ') ?? ''); }, [value]);
+  // Mirrors `invalid` so the setter below can compare against the live value
+  // from any closure (effects included) without taking it as a dependency.
+  const invalidRef = useRef(false);
+  const onValidityChangeRef = useRef(onValidityChange);
+  useEffect(() => { onValidityChangeRef.current = onValidityChange; }, [onValidityChange]);
+  // Unparseable text lives only in this component, so a caller that gated its
+  // Save button on our validity must be released when we go away.
+  useEffect(() => () => { if (invalidRef.current) onValidityChangeRef.current?.(true); }, []);
+
+  const markInvalid = useCallback((next: boolean) => {
+    if (invalidRef.current === next) return;
+    invalidRef.current = next;
+    setInvalid(next);
+    onValidityChangeRef.current?.(!next);
+  }, []);
+
+  useEffect(() => { setText(value?.join(', ') ?? ''); markInvalid(false); }, [value, markInvalid]);
 
   const commit = () => {
     if (disabled) return;
     const parsed = parseThresholds(text);
-    if (!parsed.ok) { setInvalid(true); return; }
-    setInvalid(false);
+    if (!parsed.ok) { markInvalid(true); return; }
+    markInvalid(false);
     onChange(parsed.value);
   };
+
+  const errorId = `${testId}-error`;
 
   return (
     <div className="space-y-1">
@@ -49,13 +82,15 @@ export default function AiBudgetThresholdsInput({ value, onChange, disabled, pla
         value={text}
         disabled={disabled}
         placeholder={placeholder}
-        onChange={(e) => { setText(e.target.value); setInvalid(false); }}
+        aria-invalid={invalid || undefined}
+        aria-describedby={invalid ? errorId : undefined}
+        onChange={(e) => { setText(e.target.value); markInvalid(false); }}
         onBlur={commit}
         onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); commit(); } }}
         className={`h-10 w-full rounded-md border bg-background px-3 text-sm ${disabled ? 'opacity-60 cursor-not-allowed' : ''}`}
       />
       {invalid && (
-        <p data-testid={`${testId}-error`} className="text-xs text-red-600">{t('aiBudgetThresholds.invalid')}</p>
+        <p id={errorId} data-testid={errorId} className="text-xs text-red-600">{t('aiBudgetThresholds.invalid')}</p>
       )}
     </div>
   );

--- a/apps/web/src/components/settings/AiUsagePage.test.tsx
+++ b/apps/web/src/components/settings/AiUsagePage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, act } from '@testing-library/react';
 
 const fetchWithAuth = vi.fn();
 vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
@@ -121,5 +121,95 @@ describe('AiUsagePage effective-settings parallel fetch', () => {
     resolveSessions(jsonRes({ data: [] }));
     resolveEff(jsonRes({ locked: [] }));
     await act(async () => { await Promise.resolve(); });
+  });
+});
+
+// #4388 W03: the ladder is the one budget field the org row cannot distinguish
+// from "inherit", and the one whose input can hold text that never reaches the
+// form state. Both contracts are load-bearing and only observable in the PUT.
+describe('AiUsagePage alert threshold ladder', () => {
+  function mockUsageWithBudget(alertThresholdPercents: number[] | undefined) {
+    fetchWithAuth.mockImplementation((url: string, init?: RequestInit) => {
+      if (url === '/ai/usage' && !init) {
+        return Promise.resolve(jsonRes({
+          ...usageBody(),
+          budget: {
+            enabled: true,
+            monthlyBudgetCents: 5000,
+            dailyBudgetCents: null,
+            monthlyUsedCents: 0,
+            dailyUsedCents: 0,
+            approvalMode: 'per_step',
+            alertThresholdPercents,
+          },
+        }));
+      }
+      if (url.startsWith('/ai/admin/sessions')) return Promise.resolve(jsonRes({ data: [] }));
+      return Promise.resolve(jsonRes({ success: true }));
+    });
+  }
+
+  const budgetPutBody = () => {
+    const call = fetchWithAuth.mock.calls.find(
+      ([url, init]) => url === '/ai/budget' && (init as RequestInit | undefined)?.method === 'PUT',
+    );
+    expect(call).toBeDefined();
+    return JSON.parse((call![1] as RequestInit).body as string) as Record<string, unknown>;
+  };
+
+  it('sends alertThresholdPercents: null when the ladder is cleared', async () => {
+    mockUsageWithBudget([50, 80, 95]);
+    render(<AiUsagePage />);
+
+    const input = await screen.findByTestId('ai-budget-thresholds-input');
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.blur(input);
+    fireEvent.click(screen.getByTestId('ai-budget-save'));
+
+    await waitFor(() => expect(budgetPutBody()).toHaveProperty('alertThresholdPercents', null));
+  });
+
+  it('sends the edited ladder', async () => {
+    mockUsageWithBudget(undefined);
+    render(<AiUsagePage />);
+
+    const input = await screen.findByTestId('ai-budget-thresholds-input');
+    fireEvent.change(input, { target: { value: '60, 90' } });
+    fireEvent.blur(input);
+    fireEvent.click(screen.getByTestId('ai-budget-save'));
+
+    await waitFor(() => expect(budgetPutBody()).toHaveProperty('alertThresholdPercents', [60, 90]));
+  });
+
+  // The form seeds from the EFFECTIVE budget, so an untouched field is showing
+  // whatever the org inherits. Sending it back would pin that inherited ladder
+  // onto the org row as an explicit choice.
+  it('omits alertThresholdPercents entirely when the field was never edited', async () => {
+    mockUsageWithBudget([50, 80, 95]);
+    render(<AiUsagePage />);
+
+    await screen.findByTestId('ai-budget-thresholds-input');
+    fireEvent.click(screen.getByTestId('ai-budget-save'));
+
+    await waitFor(() => expect(budgetPutBody()).toHaveProperty('monthlyBudgetCents', 5000));
+    expect(budgetPutBody()).not.toHaveProperty('alertThresholdPercents');
+  });
+
+  it('disables Save while the ladder text does not parse', async () => {
+    mockUsageWithBudget([50, 80, 95]);
+    render(<AiUsagePage />);
+
+    const input = await screen.findByTestId('ai-budget-thresholds-input');
+    const save = screen.getByTestId('ai-budget-save') as HTMLButtonElement;
+    expect(save.disabled).toBe(false);
+
+    fireEvent.change(input, { target: { value: '100' } });
+    fireEvent.blur(input);
+    expect(screen.getByTestId('ai-budget-thresholds-error')).toBeInTheDocument();
+    expect(save.disabled).toBe(true);
+
+    fireEvent.change(input, { target: { value: '95' } });
+    fireEvent.blur(input);
+    expect(save.disabled).toBe(false);
   });
 });

--- a/apps/web/src/components/settings/AiUsagePage.tsx
+++ b/apps/web/src/components/settings/AiUsagePage.tsx
@@ -4,9 +4,18 @@ import { useState, useEffect, useCallback } from 'react';
 import { Bot, DollarSign, Flag, MessageSquare, Zap, Save, Loader2, Lock } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
 import { useOrgStore } from '../../stores/orgStore';
-import { formatDateTime } from '@/lib/dateTimeFormat';
+import { formatDate, formatDateTime } from '@/lib/dateTimeFormat';
 import { formatCurrency, formatNumber } from '@/lib/i18n/format';
-import AiBudgetThresholdsInput from './AiBudgetThresholdsInput';
+import AiBudgetThresholdsInput, { DEFAULT_THRESHOLDS_PLACEHOLDER } from './AiBudgetThresholdsInput';
+
+/**
+ * Literal keys per alert period, so the i18n key scanner can see them (a
+ * `t(\`...${f.period}\`)` template is a dynamic key it cannot check).
+ */
+const PERIOD_LABEL_KEYS = {
+  daily: 'aiUsagePage.periodLabel.daily',
+  monthly: 'aiUsagePage.periodLabel.monthly',
+} as const;
 
 interface UsageData {
   daily: { inputTokens: number; outputTokens: number; totalCostCents: number; messageCount: number };
@@ -68,6 +77,12 @@ export default function AiUsagePage() {
   const [saveSuccess, setSaveSuccess] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showFlaggedOnly, setShowFlaggedOnly] = useState(false);
+  // The org row cannot distinguish "inherit" from an explicit ladder, and the
+  // form seeds itself from the EFFECTIVE budget, so sending the field on every
+  // save would pin the inherited default (50/80/95) onto the org. Only a field
+  // the user actually edited in this session is sent (#4388 W03).
+  const [thresholdsDirty, setThresholdsDirty] = useState(false);
+  const [thresholdsValid, setThresholdsValid] = useState(true);
   const { currentOrgId } = useOrgStore();
   const [budget, setBudget] = useState<BudgetForm>({
     enabled: true,
@@ -101,6 +116,7 @@ export default function AiUsagePage() {
         const data = await usageRes.json();
         setUsage(data);
         if (data.budget) {
+          setThresholdsDirty(false);
           setBudget({
             enabled: data.budget.enabled,
             monthlyBudgetDollars: data.budget.monthlyBudgetCents ? (data.budget.monthlyBudgetCents / 100).toFixed(2) : '',
@@ -155,7 +171,12 @@ export default function AiUsagePage() {
       if (!isLocked('messagesPerMinutePerUser')) payload.messagesPerMinutePerUser = parseInt(budget.messagesPerMinutePerUser) || 20;
       if (!isLocked('messagesPerHourPerOrg')) payload.messagesPerHourPerOrg = parseInt(budget.messagesPerHourPerOrg) || 200;
       if (!isLocked('approvalMode')) payload.approvalMode = budget.approvalMode;
-      if (!isLocked('alertThresholdPercents')) payload.alertThresholdPercents = budget.alertThresholdPercents ?? null;
+      // Only when the user edited the ladder in this session: an untouched
+      // field is showing the effective (possibly inherited) value, and sending
+      // it back would write that value onto the org row as an explicit choice.
+      if (!isLocked('alertThresholdPercents') && thresholdsDirty) {
+        payload.alertThresholdPercents = budget.alertThresholdPercents ?? null;
+      }
 
       const res = await fetchWithAuth('/ai/budget', {
         method: 'PUT',
@@ -238,11 +259,14 @@ export default function AiUsagePage() {
 
       {usage?.alerts?.fired?.length ? (
         <p data-testid="ai-budget-fired-rungs" className="text-xs text-muted-foreground">
-          {usage.alerts.fired.map((f) => t('aiUsagePage.firedRung', {
-            pct: f.thresholdPct,
-            period: t(`aiUsagePage.periodLabel.${f.period}`, { defaultValue: f.period }),
-            date: new Date(f.createdAt).toLocaleDateString(),
-          })).join(' · ')}
+          {usage.alerts.fired.map((f) => {
+            const periodKey = PERIOD_LABEL_KEYS[f.period as keyof typeof PERIOD_LABEL_KEYS];
+            return t('aiUsagePage.firedRung', {
+              pct: f.thresholdPct,
+              period: periodKey ? t(/* i18n-dynamic */ periodKey) : f.period,
+              date: formatDate(f.createdAt),
+            });
+          }).join(' · ')}
         </p>
       ) : null}
 
@@ -326,9 +350,10 @@ export default function AiUsagePage() {
             <span className="text-sm text-muted-foreground">{t('aiUsagePage.alertThresholds')}</span>
             <AiBudgetThresholdsInput
               value={budget.alertThresholdPercents}
-              onChange={(v) => setBudget({ ...budget, alertThresholdPercents: v })}
+              onChange={(v) => { setThresholdsDirty(true); setBudget({ ...budget, alertThresholdPercents: v }); }}
+              onValidityChange={setThresholdsValid}
               disabled={isLocked('alertThresholdPercents')}
-              placeholder={t('aiUsagePage.alertThresholdsPlaceholder')}
+              placeholder={DEFAULT_THRESHOLDS_PLACEHOLDER}
               testId="ai-budget-thresholds"
             />
             {isLocked('alertThresholdPercents') && (
@@ -384,7 +409,7 @@ export default function AiUsagePage() {
           <button
             data-testid="ai-budget-save"
             onClick={handleSaveBudget}
-            disabled={saving || allFieldsLocked}
+            disabled={saving || allFieldsLocked || !thresholdsValid}
             className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
           >
             {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}

--- a/apps/web/src/components/settings/AiUsagePage.tsx
+++ b/apps/web/src/components/settings/AiUsagePage.tsx
@@ -238,7 +238,11 @@ export default function AiUsagePage() {
 
       {usage?.alerts?.fired?.length ? (
         <p data-testid="ai-budget-fired-rungs" className="text-xs text-muted-foreground">
-          {usage.alerts.fired.map((f) => t('aiUsagePage.firedRung', { pct: f.thresholdPct, period: f.period, date: new Date(f.createdAt).toLocaleDateString() })).join(' · ')}
+          {usage.alerts.fired.map((f) => t('aiUsagePage.firedRung', {
+            pct: f.thresholdPct,
+            period: t(`aiUsagePage.periodLabel.${f.period}`, { defaultValue: f.period }),
+            date: new Date(f.createdAt).toLocaleDateString(),
+          })).join(' · ')}
         </p>
       ) : null}
 
@@ -324,7 +328,7 @@ export default function AiUsagePage() {
               value={budget.alertThresholdPercents}
               onChange={(v) => setBudget({ ...budget, alertThresholdPercents: v })}
               disabled={isLocked('alertThresholdPercents')}
-              placeholder="50, 80, 95"
+              placeholder={t('aiUsagePage.alertThresholdsPlaceholder')}
               testId="ai-budget-thresholds"
             />
             {isLocked('alertThresholdPercents') && (

--- a/apps/web/src/components/settings/AiUsagePage.tsx
+++ b/apps/web/src/components/settings/AiUsagePage.tsx
@@ -6,6 +6,7 @@ import { fetchWithAuth } from '../../stores/auth';
 import { useOrgStore } from '../../stores/orgStore';
 import { formatDateTime } from '@/lib/dateTimeFormat';
 import { formatCurrency, formatNumber } from '@/lib/i18n/format';
+import AiBudgetThresholdsInput from './AiBudgetThresholdsInput';
 
 interface UsageData {
   daily: { inputTokens: number; outputTokens: number; totalCostCents: number; messageCount: number };
@@ -23,7 +24,11 @@ interface UsageData {
     monthlyUsedCents: number;
     dailyUsedCents: number;
     approvalMode: string;
+    alertThresholdPercents?: number[];
   } | null;
+  alerts?: {
+    fired: Array<{ period: string; periodKey: string; thresholdPct: number; createdAt: string; deliveredAt: string | null }>;
+  };
 }
 
 interface SessionRow {
@@ -50,6 +55,7 @@ interface BudgetForm {
   messagesPerMinutePerUser: string;
   messagesPerHourPerOrg: string;
   approvalMode: ApprovalMode;
+  alertThresholdPercents: number[] | undefined;
 }
 
 export default function AiUsagePage() {
@@ -71,6 +77,7 @@ export default function AiUsagePage() {
     messagesPerMinutePerUser: '20',
     messagesPerHourPerOrg: '200',
     approvalMode: 'per_step',
+    alertThresholdPercents: undefined,
   });
 
   const fetchData = useCallback(async () => {
@@ -102,6 +109,7 @@ export default function AiUsagePage() {
             messagesPerMinutePerUser: '20',
             messagesPerHourPerOrg: '200',
             approvalMode: data.budget.approvalMode || 'per_step',
+            alertThresholdPercents: data.budget.alertThresholdPercents,
           });
         }
       }
@@ -130,7 +138,7 @@ export default function AiUsagePage() {
   const budgetFields = [
     'enabled', 'monthlyBudgetCents', 'dailyBudgetCents',
     'maxTurnsPerSession', 'messagesPerMinutePerUser', 'messagesPerHourPerOrg',
-    'approvalMode',
+    'approvalMode', 'alertThresholdPercents',
   ];
   const allFieldsLocked = budgetFields.every((f) => isLocked(f));
 
@@ -147,6 +155,7 @@ export default function AiUsagePage() {
       if (!isLocked('messagesPerMinutePerUser')) payload.messagesPerMinutePerUser = parseInt(budget.messagesPerMinutePerUser) || 20;
       if (!isLocked('messagesPerHourPerOrg')) payload.messagesPerHourPerOrg = parseInt(budget.messagesPerHourPerOrg) || 200;
       if (!isLocked('approvalMode')) payload.approvalMode = budget.approvalMode;
+      if (!isLocked('alertThresholdPercents')) payload.alertThresholdPercents = budget.alertThresholdPercents ?? null;
 
       const res = await fetchWithAuth('/ai/budget', {
         method: 'PUT',
@@ -227,6 +236,12 @@ export default function AiUsagePage() {
         />
       </div>
 
+      {usage?.alerts?.fired?.length ? (
+        <p data-testid="ai-budget-fired-rungs" className="text-xs text-muted-foreground">
+          {usage.alerts.fired.map((f) => t('aiUsagePage.firedRung', { pct: f.thresholdPct, period: f.period, date: new Date(f.createdAt).toLocaleDateString() })).join(' · ')}
+        </p>
+      ) : null}
+
       {/* Budget configuration */}
       <div className="rounded-lg border bg-card p-6">
         <h2 className="text-lg font-semibold mb-4">{t('aiUsagePage.budgetConfiguration')}</h2>
@@ -304,6 +319,21 @@ export default function AiUsagePage() {
             )}
           </label>
           <label className="block">
+            <span className="text-sm text-muted-foreground">{t('aiUsagePage.alertThresholds')}</span>
+            <AiBudgetThresholdsInput
+              value={budget.alertThresholdPercents}
+              onChange={(v) => setBudget({ ...budget, alertThresholdPercents: v })}
+              disabled={isLocked('alertThresholdPercents')}
+              placeholder="50, 80, 95"
+              testId="ai-budget-thresholds"
+            />
+            {isLocked('alertThresholdPercents') && (
+              <span className="mt-1 flex items-center gap-1 text-xs text-amber-600 dark:text-amber-400 italic">
+                <Lock className="h-3 w-3" /> {t('aiUsagePage.managedByPartner')}</span>
+            )}
+            <span className="mt-1 block text-xs text-muted-foreground">{t('aiUsagePage.alertThresholdsHelp')}</span>
+          </label>
+          <label className="block">
             <span className="text-sm text-muted-foreground">{t('aiUsagePage.maxTurnsPerSession')}</span>
             <input
               type="number"
@@ -348,6 +378,7 @@ export default function AiUsagePage() {
         </div>
         <div className="mt-4 flex items-center gap-3">
           <button
+            data-testid="ai-budget-save"
             onClick={handleSaveBudget}
             disabled={saving || allFieldsLocked}
             className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"

--- a/apps/web/src/components/settings/PartnerAiBudgetsTab.tsx
+++ b/apps/web/src/components/settings/PartnerAiBudgetsTab.tsx
@@ -7,9 +7,15 @@ type Props = {
   /** Internal representation uses cents for budgets; this component displays dollars */
   data: InheritableAiBudgetSettings;
   onChange: (data: InheritableAiBudgetSettings) => void;
+  /**
+   * Raised when the alert-threshold box holds text that does not parse. The
+   * hub gates its Save button on it, so an unparseable ladder cannot be
+   * silently dropped while the save reports success (#4388 W03).
+   */
+  onValidityChange?: (valid: boolean) => void;
 };
 
-export default function PartnerAiBudgetsTab({ data, onChange }: Props) {
+export default function PartnerAiBudgetsTab({ data, onChange, onValidityChange }: Props) {
   const { t } = useTranslation('settings');
   const set = (patch: Partial<InheritableAiBudgetSettings>) =>
     onChange({ ...data, ...patch });
@@ -122,6 +128,7 @@ export default function PartnerAiBudgetsTab({ data, onChange }: Props) {
               <AiBudgetThresholdsInput
                 value={data.alertThresholdPercents}
                 onChange={(v) => set({ alertThresholdPercents: v })}
+                onValidityChange={onValidityChange}
                 placeholder={t('partnerAiBudgets.notSet')}
                 testId="partner-ai-budget-thresholds"
               />

--- a/apps/web/src/components/settings/PartnerAiBudgetsTab.tsx
+++ b/apps/web/src/components/settings/PartnerAiBudgetsTab.tsx
@@ -1,6 +1,7 @@
 import type { InheritableAiBudgetSettings } from '@breeze/shared';
 import { useTranslation } from 'react-i18next';
 import '@/lib/i18n';
+import AiBudgetThresholdsInput from './AiBudgetThresholdsInput';
 
 type Props = {
   /** Internal representation uses cents for budgets; this component displays dollars */
@@ -114,6 +115,17 @@ export default function PartnerAiBudgetsTab({ data, onChange }: Props) {
                 min={1}
                 max={10000}
               />
+            </div>
+
+            <div className="space-y-2 sm:col-span-2">
+              <label className="text-sm font-medium">{t('partnerAiBudgets.alertThresholds')}</label>
+              <AiBudgetThresholdsInput
+                value={data.alertThresholdPercents}
+                onChange={(v) => set({ alertThresholdPercents: v })}
+                placeholder={t('partnerAiBudgets.notSet')}
+                testId="partner-ai-budget-thresholds"
+              />
+              <p className="text-xs text-muted-foreground">{t('partnerAiBudgets.alertThresholdsHelp')}</p>
             </div>
           </div>
 

--- a/apps/web/src/components/settings/PartnerSettingsPage.test.tsx
+++ b/apps/web/src/components/settings/PartnerSettingsPage.test.tsx
@@ -737,3 +737,89 @@ describe('PartnerSettingsPage access gate (no flash-of-access-denied)', () => {
     expect(screen.queryByText('Loading partner settings...')).toBeNull();
   });
 });
+
+// #4388 W03: the partner ladder is inheritable. Omitting the key means "orgs
+// decide", which is a different instruction to the API than any array value.
+// The distinction only exists in the serialised PATCH body.
+describe('PartnerSettingsPage AI Budgets tab', () => {
+  const partnerWithLadder = {
+    id: 'partner-1',
+    name: 'Acme MSP',
+    slug: 'acme',
+    type: 'partner',
+    plan: 'pro',
+    createdAt: '2026-02-09T00:00:00.000Z',
+    settings: {
+      timezone: 'UTC',
+      dateFormat: 'MM/DD/YYYY',
+      timeFormat: '12h',
+      language: 'en',
+      businessHours: { preset: 'business' },
+      contact: {},
+      address: {},
+      aiBudgets: { enabled: true, monthlyBudgetCents: 5000, alertThresholdPercents: [50, 80] },
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.location.hash = '';
+    useOrgStoreMock.mockReturnValue({ currentPartnerId: 'partner-1', isLoading: false } as never);
+    fetchWithAuthMock.mockResolvedValue(makeJsonResponse({ data: [] }));
+    fetchWithAuthMock.mockResolvedValueOnce(makeJsonResponse(partnerWithLadder));
+  });
+
+  const patchedSettings = () => {
+    const patchCall = fetchWithAuthMock.mock.calls.find(
+      ([, init]) => (init as RequestInit | undefined)?.method === 'PATCH'
+    );
+    expect(patchCall).toBeDefined();
+    const body = JSON.parse((patchCall![1] as RequestInit).body as string);
+    return body.settings as Record<string, Record<string, unknown>>;
+  };
+
+  it('drops alertThresholdPercents from the payload when the ladder is cleared', async () => {
+    render(<PartnerSettingsPage />);
+    await screen.findByText('Partner Settings');
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('link', { name: /^ai budgets$/i }));
+
+    const input = await screen.findByTestId('partner-ai-budget-thresholds-input');
+    expect((input as HTMLInputElement).value).toBe('50, 80');
+    await user.clear(input);
+    await user.tab();
+
+    await user.click(screen.getByRole('button', { name: /save settings/i }));
+
+    const settings = patchedSettings();
+    expect(settings.aiBudgets).toBeDefined();
+    // Enabled still round-trips, so this is an omitted key, not an omitted tab.
+    expect(settings.aiBudgets.enabled).toBe(true);
+    expect(settings.aiBudgets).not.toHaveProperty('alertThresholdPercents');
+  });
+
+  it('blocks Save while the ladder text does not parse', async () => {
+    render(<PartnerSettingsPage />);
+    await screen.findByText('Partner Settings');
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('link', { name: /^ai budgets$/i }));
+
+    // Commit a real edit first, so the tab is dirty and the Save button is
+    // enabled for a reason other than the one under test.
+    const input = await screen.findByTestId('partner-ai-budget-thresholds-input');
+    await user.clear(input);
+    await user.type(input, '60, 90');
+    await user.tab();
+    const saveBtn = screen.getByRole('button', { name: /save settings/i }) as HTMLButtonElement;
+    expect(saveBtn.disabled).toBe(false);
+
+    await user.clear(input);
+    await user.type(input, '100');
+    await user.tab();
+
+    expect(screen.getByTestId('partner-ai-budget-thresholds-error')).not.toBeNull();
+    expect(saveBtn.disabled).toBe(true);
+  });
+});

--- a/apps/web/src/components/settings/PartnerSettingsPage.tsx
+++ b/apps/web/src/components/settings/PartnerSettingsPage.tsx
@@ -207,6 +207,11 @@ export default function PartnerSettingsPage() {
   const [defaultsData, setDefaultsData] = useState<InheritableDefaultSettings>({});
   const [brandingData, setBrandingData] = useState<InheritableBrandingSettings>({});
   const [aiBudgetsData, setAiBudgetsData] = useState<InheritableAiBudgetSettings>({});
+  // The AI Budgets tab's alert-threshold box can hold text that does not parse;
+  // it never reaches `aiBudgetsData`, so saving while it is red would persist
+  // the previous ladder and report success (#4388 W03). The input reports true
+  // again when it unmounts, so leaving the tab never strands the Save button.
+  const [aiBudgetsValid, setAiBudgetsValid] = useState(true);
   const [remoteAccessData, setRemoteAccessData] = useState<InheritableRemoteAccessSettings>({});
   // Registered agent/watchdog versions for the pin selectors (#2124).
   const [pinnableVersions, setPinnableVersions] = useState<PinnableVersions | null>(null);
@@ -544,7 +549,7 @@ export default function PartnerSettingsPage() {
             {t('partnerSettingsPage.selfSaving')}
           </p>
         ) : (
-          <button type="button" onClick={handleSave} disabled={saving || !isDirty}
+          <button type="button" onClick={handleSave} disabled={saving || !isDirty || !aiBudgetsValid}
             className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:opacity-50">
             {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
             {saving ? t('common:states.saving') : t('partnerSettingsPage.saveSettings')}
@@ -655,7 +660,7 @@ export default function PartnerSettingsPage() {
 
           {activeTab === 'aiBudgets' && (
             <section className="rounded-lg border bg-card p-6 shadow-xs">
-              <PartnerAiBudgetsTab data={aiBudgetsData} onChange={setAiBudgetsData} />
+              <PartnerAiBudgetsTab data={aiBudgetsData} onChange={setAiBudgetsData} onValidityChange={setAiBudgetsValid} />
             </section>
           )}
 

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -1302,6 +1302,11 @@
     "alertThresholds": "Warnen bei (% des Budgets)",
     "alertThresholdsHelp": "Benachrichtigungen gehen an Partner-Admins mit Abrechnungszugriff. 100% (Obergrenze erreicht) wird immer gesendet.",
     "firedRung": "{{pct}}% {{period}}-Warnung gesendet am {{date}}",
+    "alertThresholdsPlaceholder": "50, 80, 95",
+    "periodLabel": {
+      "daily": "täglich",
+      "monthly": "monatlich"
+    },
     "maxTurnsPerSession": "Maximale Umdrehungen pro Sitzung",
     "msgsMinPerUser": "Nachrichten/Minute pro Benutzer",
     "msgsHrPerOrg": "Nachrichten/Std. pro Organisation",

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -119,6 +119,8 @@
     "maxTurns": "Max. Umdrehungen pro Sitzung",
     "messagesPerMinute": "Nachrichten pro Minute und Benutzer",
     "messagesPerHour": "Nachrichten pro Stunde und Organisation",
+    "alertThresholds": "Warnen bei (% des Budgets)",
+    "alertThresholdsHelp": "Partner-Admins mit Abrechnungszugriff erhalten bei jeder Stufe eine In-App-Benachrichtigung und eine E-Mail für monatliche und Obergrenzen-Warnungen. Leer lassen, um 50, 80, 95 zu übernehmen.",
     "notSet": "Nicht festgelegt – Organisationen werden individuell konfiguriert",
     "description": "Budgetwerte werden in allen untergeordneten Organisationen durchgesetzt. Dollarbeträge werden intern in Cent gespeichert.",
     "modes": {
@@ -127,6 +129,9 @@
       "autoApprove": "Automatisch genehmigen",
       "hybridPlan": "Hybridplan"
     }
+  },
+  "aiBudgetThresholds": {
+    "invalid": "Geben Sie bis zu fünf ganze Zahlen zwischen 1 und 99 ein, durch Kommas getrennt."
   },
   "partnerAiProvider": {
     "title": "KI-Anbieter",
@@ -1294,6 +1299,9 @@
     "monthlyBudget": "Monatsbudget ($)",
     "noLimit": "Keine Begrenzung",
     "dailyBudget": "Tagesbudget ($)",
+    "alertThresholds": "Warnen bei (% des Budgets)",
+    "alertThresholdsHelp": "Benachrichtigungen gehen an Partner-Admins mit Abrechnungszugriff. 100% (Obergrenze erreicht) wird immer gesendet.",
+    "firedRung": "{{pct}}% {{period}}-Warnung gesendet am {{date}}",
     "maxTurnsPerSession": "Maximale Umdrehungen pro Sitzung",
     "msgsMinPerUser": "Nachrichten/Minute pro Benutzer",
     "msgsHrPerOrg": "Nachrichten/Std. pro Organisation",

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -121,7 +121,7 @@
     "messagesPerHour": "Nachrichten pro Stunde und Organisation",
     "alertThresholds": "Warnen bei (% des Budgets)",
     "alertThresholdsHelp": "Partner-Admins mit Abrechnungszugriff erhalten bei jeder Stufe eine In-App-Benachrichtigung und eine E-Mail für monatliche und Obergrenzen-Warnungen. Leer lassen, um 50, 80, 95 zu übernehmen.",
-    "notSet": "Nicht festgelegt – Organisationen werden individuell konfiguriert",
+    "notSet": "Nicht festgelegt, Organisationen werden individuell konfiguriert",
     "description": "Budgetwerte werden in allen untergeordneten Organisationen durchgesetzt. Dollarbeträge werden intern in Cent gespeichert.",
     "modes": {
       "perStep": "Pro Schritt",
@@ -1302,7 +1302,6 @@
     "alertThresholds": "Warnen bei (% des Budgets)",
     "alertThresholdsHelp": "Benachrichtigungen gehen an Partner-Admins mit Abrechnungszugriff. 100% (Obergrenze erreicht) wird immer gesendet.",
     "firedRung": "{{pct}}% {{period}}-Warnung gesendet am {{date}}",
-    "alertThresholdsPlaceholder": "50, 80, 95",
     "periodLabel": {
       "daily": "täglich",
       "monthly": "monatlich"

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -121,7 +121,7 @@
     "messagesPerHour": "Messages per Hour per Org",
     "alertThresholds": "Warn at (% of budget)",
     "alertThresholdsHelp": "Partner admins with billing access get an in-app alert at each rung and an email for monthly and cap-reached alerts. Leave empty to inherit 50, 80, 95.",
-    "notSet": "Not set — orgs configure individually",
+    "notSet": "Not set, orgs configure individually",
     "description": "Budget values are enforced across all child organizations. Dollar amounts are stored in cents internally.",
     "modes": {
       "perStep": "Per Step",
@@ -1302,7 +1302,6 @@
     "alertThresholds": "Warn at (% of budget)",
     "alertThresholdsHelp": "Alerts go to partner admins with billing access. 100% (cap reached) is always sent.",
     "firedRung": "{{pct}}% {{period}} alert sent {{date}}",
-    "alertThresholdsPlaceholder": "50, 80, 95",
     "periodLabel": {
       "daily": "daily",
       "monthly": "monthly"

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -119,6 +119,8 @@
     "maxTurns": "Max Turns per Session",
     "messagesPerMinute": "Messages per Minute per User",
     "messagesPerHour": "Messages per Hour per Org",
+    "alertThresholds": "Warn at (% of budget)",
+    "alertThresholdsHelp": "Partner admins with billing access get an in-app alert at each rung and an email for monthly and cap-reached alerts. Leave empty to inherit 50, 80, 95.",
     "notSet": "Not set — orgs configure individually",
     "description": "Budget values are enforced across all child organizations. Dollar amounts are stored in cents internally.",
     "modes": {
@@ -127,6 +129,9 @@
       "autoApprove": "Auto Approve",
       "hybridPlan": "Hybrid Plan"
     }
+  },
+  "aiBudgetThresholds": {
+    "invalid": "Enter up to five whole numbers between 1 and 99, separated by commas."
   },
   "partnerAiProvider": {
     "title": "AI Provider",
@@ -1294,6 +1299,9 @@
     "monthlyBudget": "Monthly Budget ($)",
     "noLimit": "No limit",
     "dailyBudget": "Daily Budget ($)",
+    "alertThresholds": "Warn at (% of budget)",
+    "alertThresholdsHelp": "Alerts go to partner admins with billing access. 100% (cap reached) is always sent.",
+    "firedRung": "{{pct}}% {{period}} alert sent {{date}}",
     "maxTurnsPerSession": "Max Turns Per Session",
     "msgsMinPerUser": "Msgs/Min Per User",
     "msgsHrPerOrg": "Msgs/Hr Per Org",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -1302,6 +1302,11 @@
     "alertThresholds": "Warn at (% of budget)",
     "alertThresholdsHelp": "Alerts go to partner admins with billing access. 100% (cap reached) is always sent.",
     "firedRung": "{{pct}}% {{period}} alert sent {{date}}",
+    "alertThresholdsPlaceholder": "50, 80, 95",
+    "periodLabel": {
+      "daily": "daily",
+      "monthly": "monthly"
+    },
     "maxTurnsPerSession": "Max Turns Per Session",
     "msgsMinPerUser": "Msgs/Min Per User",
     "msgsHrPerOrg": "Msgs/Hr Per Org",

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -119,6 +119,8 @@
     "maxTurns": "Giros máximos por sesión",
     "messagesPerMinute": "Mensajes por minuto por usuario",
     "messagesPerHour": "Mensajes por hora por organización",
+    "alertThresholds": "Avisar al (% del presupuesto)",
+    "alertThresholdsHelp": "Los administradores del partner con acceso a facturación reciben una alerta en la aplicación en cada nivel y un correo para las alertas mensuales y de límite alcanzado. Deja vacío para heredar 50, 80, 95.",
     "notSet": "No configurado: las organizaciones se configuran individualmente",
     "description": "Los valores presupuestarios se aplican en todas las organizaciones secundarias. Los montos en dólares se almacenan internamente en centavos.",
     "modes": {
@@ -127,6 +129,9 @@
       "autoApprove": "Aprobación automática",
       "hybridPlan": "Plan híbrido"
     }
+  },
+  "aiBudgetThresholds": {
+    "invalid": "Ingresa hasta cinco números enteros entre 1 y 99, separados por comas."
   },
   "partnerAiProvider": {
     "title": "Proveedor de IA",
@@ -1294,6 +1299,9 @@
     "monthlyBudget": "Presupuesto mensual ($)",
     "noLimit": "Sin límite",
     "dailyBudget": "Presupuesto diario ($)",
+    "alertThresholds": "Avisar al (% del presupuesto)",
+    "alertThresholdsHelp": "Las alertas se envían a los administradores del partner con acceso a facturación. El 100% (límite alcanzado) siempre se envía.",
+    "firedRung": "Alerta del {{pct}}% {{period}} enviada el {{date}}",
     "maxTurnsPerSession": "Giros máximos por sesión",
     "msgsMinPerUser": "Mensajes/min por usuario",
     "msgsHrPerOrg": "Mensajes/hora por organización",

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -1302,7 +1302,6 @@
     "alertThresholds": "Avisar al (% del presupuesto)",
     "alertThresholdsHelp": "Las alertas se envían a los administradores del partner con acceso a facturación. El 100% (límite alcanzado) siempre se envía.",
     "firedRung": "Alerta del {{pct}}% {{period}} enviada el {{date}}",
-    "alertThresholdsPlaceholder": "50, 80, 95",
     "periodLabel": {
       "daily": "diaria",
       "monthly": "mensual"

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -1302,6 +1302,11 @@
     "alertThresholds": "Avisar al (% del presupuesto)",
     "alertThresholdsHelp": "Las alertas se envían a los administradores del partner con acceso a facturación. El 100% (límite alcanzado) siempre se envía.",
     "firedRung": "Alerta del {{pct}}% {{period}} enviada el {{date}}",
+    "alertThresholdsPlaceholder": "50, 80, 95",
+    "periodLabel": {
+      "daily": "diaria",
+      "monthly": "mensual"
+    },
     "maxTurnsPerSession": "Giros máximos por sesión",
     "msgsMinPerUser": "Mensajes/min por usuario",
     "msgsHrPerOrg": "Mensajes/hora por organización",

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -1302,6 +1302,11 @@
     "alertThresholds": "Avertir à (% du budget)",
     "alertThresholdsHelp": "Les alertes sont envoyées aux administrateurs partenaires ayant accès à la facturation. 100% (plafond atteint) est toujours envoyé.",
     "firedRung": "Alerte {{pct}}% {{period}} envoyée le {{date}}",
+    "alertThresholdsPlaceholder": "50, 80, 95",
+    "periodLabel": {
+      "daily": "quotidienne",
+      "monthly": "mensuelle"
+    },
     "maxTurnsPerSession": "Nombre maximal de tours par session",
     "msgsMinPerUser": "Messages par Min par utilisateur",
     "msgsHrPerOrg": "Messages et RH par organisation",

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -119,6 +119,8 @@
     "maxTurns": "Nombre maximal de tours par session",
     "messagesPerMinute": "Messages par minute et utilisateur",
     "messagesPerHour": "Messages par heure et par organisation",
+    "alertThresholds": "Avertir à (% du budget)",
+    "alertThresholdsHelp": "Les administrateurs partenaires ayant accès à la facturation reçoivent une alerte dans l'application à chaque palier et un courriel pour les alertes mensuelles et de plafond atteint. Laissez vide pour hériter de 50, 80, 95.",
     "notSet": "Non défini — les organisations se configurent individuellement",
     "description": "Les valeurs budgétaires sont appliquées dans toutes les organisations d’enfants. Les montants en dollars sont stockés en centimes en interne.",
     "modes": {
@@ -127,6 +129,9 @@
       "autoApprove": "Approbation automatique",
       "hybridPlan": "Plan hybride"
     }
+  },
+  "aiBudgetThresholds": {
+    "invalid": "Saisissez jusqu'à cinq nombres entiers entre 1 et 99, séparés par des virgules."
   },
   "partnerAiProvider": {
     "title": "Fournisseur d'IA",
@@ -1294,6 +1299,9 @@
     "monthlyBudget": "Budget mensuel ($)",
     "noLimit": "Aucune limite",
     "dailyBudget": "Budget quotidien ($)",
+    "alertThresholds": "Avertir à (% du budget)",
+    "alertThresholdsHelp": "Les alertes sont envoyées aux administrateurs partenaires ayant accès à la facturation. 100% (plafond atteint) est toujours envoyé.",
+    "firedRung": "Alerte {{pct}}% {{period}} envoyée le {{date}}",
     "maxTurnsPerSession": "Nombre maximal de tours par session",
     "msgsMinPerUser": "Messages par Min par utilisateur",
     "msgsHrPerOrg": "Messages et RH par organisation",

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -121,7 +121,7 @@
     "messagesPerHour": "Messages par heure et par organisation",
     "alertThresholds": "Avertir à (% du budget)",
     "alertThresholdsHelp": "Les administrateurs partenaires ayant accès à la facturation reçoivent une alerte dans l'application à chaque palier et un courriel pour les alertes mensuelles et de plafond atteint. Laissez vide pour hériter de 50, 80, 95.",
-    "notSet": "Non défini — les organisations se configurent individuellement",
+    "notSet": "Non défini, les organisations se configurent individuellement",
     "description": "Les valeurs budgétaires sont appliquées dans toutes les organisations d’enfants. Les montants en dollars sont stockés en centimes en interne.",
     "modes": {
       "perStep": "Par étape",
@@ -1302,7 +1302,6 @@
     "alertThresholds": "Avertir à (% du budget)",
     "alertThresholdsHelp": "Les alertes sont envoyées aux administrateurs partenaires ayant accès à la facturation. 100% (plafond atteint) est toujours envoyé.",
     "firedRung": "Alerte {{pct}}% {{period}} envoyée le {{date}}",
-    "alertThresholdsPlaceholder": "50, 80, 95",
     "periodLabel": {
       "daily": "quotidienne",
       "monthly": "mensuelle"

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -1302,6 +1302,11 @@
     "alertThresholds": "Avertir à (% du budget)",
     "alertThresholdsHelp": "Les alertes sont envoyées aux administrateurs partenaires ayant accès à la facturation. 100% (plafond atteint) est toujours envoyé.",
     "firedRung": "Alerte {{pct}}% {{period}} envoyée le {{date}}",
+    "alertThresholdsPlaceholder": "50, 80, 95",
+    "periodLabel": {
+      "daily": "quotidienne",
+      "monthly": "mensuelle"
+    },
     "maxTurnsPerSession": "Nombre maximal de tours par session",
     "msgsMinPerUser": "Messages par Min par utilisateur",
     "msgsHrPerOrg": "Messages et RH par organisation",

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -121,7 +121,7 @@
     "messagesPerHour": "Messages par heure et par organisation",
     "alertThresholds": "Avertir à (% du budget)",
     "alertThresholdsHelp": "Les administrateurs partenaires ayant accès à la facturation reçoivent une alerte dans l'application à chaque palier et un e-mail pour les alertes mensuelles et de plafond atteint. Laissez vide pour hériter de 50, 80, 95.",
-    "notSet": "Non défini — les organisations se configurent individuellement",
+    "notSet": "Non défini, les organisations se configurent individuellement",
     "description": "Les valeurs budgétaires sont appliquées dans toutes les organisations d’enfants. Les montants en dollars sont stockés en centimes en interne.",
     "modes": {
       "perStep": "Par étape",
@@ -1302,7 +1302,6 @@
     "alertThresholds": "Avertir à (% du budget)",
     "alertThresholdsHelp": "Les alertes sont envoyées aux administrateurs partenaires ayant accès à la facturation. 100% (plafond atteint) est toujours envoyé.",
     "firedRung": "Alerte {{pct}}% {{period}} envoyée le {{date}}",
-    "alertThresholdsPlaceholder": "50, 80, 95",
     "periodLabel": {
       "daily": "quotidienne",
       "monthly": "mensuelle"

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -119,6 +119,8 @@
     "maxTurns": "Nombre maximal de tours par session",
     "messagesPerMinute": "Messages par minute et utilisateur",
     "messagesPerHour": "Messages par heure et par organisation",
+    "alertThresholds": "Avertir à (% du budget)",
+    "alertThresholdsHelp": "Les administrateurs partenaires ayant accès à la facturation reçoivent une alerte dans l'application à chaque palier et un e-mail pour les alertes mensuelles et de plafond atteint. Laissez vide pour hériter de 50, 80, 95.",
     "notSet": "Non défini — les organisations se configurent individuellement",
     "description": "Les valeurs budgétaires sont appliquées dans toutes les organisations d’enfants. Les montants en dollars sont stockés en centimes en interne.",
     "modes": {
@@ -127,6 +129,9 @@
       "autoApprove": "Approbation automatique",
       "hybridPlan": "Plan hybride"
     }
+  },
+  "aiBudgetThresholds": {
+    "invalid": "Saisissez jusqu'à cinq nombres entiers entre 1 et 99, séparés par des virgules."
   },
   "partnerAiProvider": {
     "title": "Fournisseur d'IA",
@@ -1294,6 +1299,9 @@
     "monthlyBudget": "Budget mensuel ($)",
     "noLimit": "Aucune limite",
     "dailyBudget": "Budget quotidien ($)",
+    "alertThresholds": "Avertir à (% du budget)",
+    "alertThresholdsHelp": "Les alertes sont envoyées aux administrateurs partenaires ayant accès à la facturation. 100% (plafond atteint) est toujours envoyé.",
+    "firedRung": "Alerte {{pct}}% {{period}} envoyée le {{date}}",
     "maxTurnsPerSession": "Nombre maximal de tours par session",
     "msgsMinPerUser": "Messages par Min par utilisateur",
     "msgsHrPerOrg": "Messages et RH par organisation",

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -1302,6 +1302,11 @@
     "alertThresholds": "Avvisa al (% del budget)",
     "alertThresholdsHelp": "Gli avvisi vengono inviati agli admin partner con accesso alla fatturazione. Il 100% (limite raggiunto) viene sempre inviato.",
     "firedRung": "Avviso {{pct}}% {{period}} inviato il {{date}}",
+    "alertThresholdsPlaceholder": "50, 80, 95",
+    "periodLabel": {
+      "daily": "giornaliero",
+      "monthly": "mensile"
+    },
     "maxTurnsPerSession": "Turni massimi per sessione",
     "msgsMinPerUser": "Messaggi/min per utente",
     "msgsHrPerOrg": "Messaggi/ora per organizzazione",

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -119,6 +119,8 @@
     "maxTurns": "Turni massimi per sessione",
     "messagesPerMinute": "Messaggi al minuto per utente",
     "messagesPerHour": "Messaggi all'ora per org",
+    "alertThresholds": "Avvisa al (% del budget)",
+    "alertThresholdsHelp": "Gli admin partner con accesso alla fatturazione ricevono un avviso in-app a ogni soglia e un'email per gli avvisi mensili e di limite raggiunto. Lascia vuoto per ereditare 50, 80, 95.",
     "notSet": "Non impostato — le org si configurano singolarmente",
     "description": "I valori di budget vengono applicati a tutte le organizzazioni figlie. Gli importi in dollari sono archiviati internamente in centesimi.",
     "modes": {
@@ -127,6 +129,9 @@
       "autoApprove": "Approvazione automatica",
       "hybridPlan": "Piano ibrido"
     }
+  },
+  "aiBudgetThresholds": {
+    "invalid": "Inserisci fino a cinque numeri interi tra 1 e 99, separati da virgole."
   },
   "partnerAiProvider": {
     "title": "Provider IA",
@@ -1294,6 +1299,9 @@
     "monthlyBudget": "Budget mensile ($)",
     "noLimit": "Nessun limite",
     "dailyBudget": "Budget giornaliero ($)",
+    "alertThresholds": "Avvisa al (% del budget)",
+    "alertThresholdsHelp": "Gli avvisi vengono inviati agli admin partner con accesso alla fatturazione. Il 100% (limite raggiunto) viene sempre inviato.",
+    "firedRung": "Avviso {{pct}}% {{period}} inviato il {{date}}",
     "maxTurnsPerSession": "Turni massimi per sessione",
     "msgsMinPerUser": "Messaggi/min per utente",
     "msgsHrPerOrg": "Messaggi/ora per organizzazione",

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -121,7 +121,7 @@
     "messagesPerHour": "Messaggi all'ora per org",
     "alertThresholds": "Avvisa al (% del budget)",
     "alertThresholdsHelp": "Gli admin partner con accesso alla fatturazione ricevono un avviso in-app a ogni soglia e un'email per gli avvisi mensili e di limite raggiunto. Lascia vuoto per ereditare 50, 80, 95.",
-    "notSet": "Non impostato — le org si configurano singolarmente",
+    "notSet": "Non impostato, le org si configurano singolarmente",
     "description": "I valori di budget vengono applicati a tutte le organizzazioni figlie. Gli importi in dollari sono archiviati internamente in centesimi.",
     "modes": {
       "perStep": "Per passaggio",
@@ -1302,7 +1302,6 @@
     "alertThresholds": "Avvisa al (% del budget)",
     "alertThresholdsHelp": "Gli avvisi vengono inviati agli admin partner con accesso alla fatturazione. Il 100% (limite raggiunto) viene sempre inviato.",
     "firedRung": "Avviso {{pct}}% {{period}} inviato il {{date}}",
-    "alertThresholdsPlaceholder": "50, 80, 95",
     "periodLabel": {
       "daily": "giornaliero",
       "monthly": "mensile"

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -119,6 +119,8 @@
     "maxTurns": "Máximo de turnos por sessão",
     "messagesPerMinute": "Mensagens por minuto por usuário",
     "messagesPerHour": "Mensagens por hora por organização",
+    "alertThresholds": "Avisar em (% do orçamento)",
+    "alertThresholdsHelp": "Administradores parceiros com acesso a cobrança recebem um alerta no aplicativo em cada nível e um e-mail para alertas mensais e de limite atingido. Deixe em branco para herdar 50, 80, 95.",
     "notSet": "Não definido — as organizações configuram individualmente",
     "description": "Os valores de orçamento são aplicados a todas as organizações filhas. Os valores em dólares são armazenados internamente em centavos.",
     "modes": {
@@ -127,6 +129,9 @@
       "autoApprove": "Aprovar automaticamente",
       "hybridPlan": "Plano híbrido"
     }
+  },
+  "aiBudgetThresholds": {
+    "invalid": "Insira até cinco números inteiros entre 1 e 99, separados por vírgulas."
   },
   "partnerAiProvider": {
     "title": "Provedor de IA",
@@ -1294,6 +1299,9 @@
     "monthlyBudget": "Orçamento mensal (US$)",
     "noLimit": "Sem limite",
     "dailyBudget": "Orçamento diário (US$)",
+    "alertThresholds": "Avisar em (% do orçamento)",
+    "alertThresholdsHelp": "Os alertas vão para administradores parceiros com acesso a cobrança. 100% (limite atingido) é sempre enviado.",
+    "firedRung": "Alerta de {{pct}}% {{period}} enviado em {{date}}",
     "maxTurnsPerSession": "Máximo de turnos por sessão",
     "msgsMinPerUser": "Mensagens/minuto por usuário",
     "msgsHrPerOrg": "Mensagens/hora por organização",

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -121,7 +121,7 @@
     "messagesPerHour": "Mensagens por hora por organização",
     "alertThresholds": "Avisar em (% do orçamento)",
     "alertThresholdsHelp": "Administradores parceiros com acesso a cobrança recebem um alerta no aplicativo em cada nível e um e-mail para alertas mensais e de limite atingido. Deixe em branco para herdar 50, 80, 95.",
-    "notSet": "Não definido — as organizações configuram individualmente",
+    "notSet": "Não definido, as organizações configuram individualmente",
     "description": "Os valores de orçamento são aplicados a todas as organizações filhas. Os valores em dólares são armazenados internamente em centavos.",
     "modes": {
       "perStep": "Por etapa",
@@ -1302,7 +1302,6 @@
     "alertThresholds": "Avisar em (% do orçamento)",
     "alertThresholdsHelp": "Os alertas vão para administradores parceiros com acesso a cobrança. 100% (limite atingido) é sempre enviado.",
     "firedRung": "Alerta de {{pct}}% {{period}} enviado em {{date}}",
-    "alertThresholdsPlaceholder": "50, 80, 95",
     "periodLabel": {
       "daily": "diário",
       "monthly": "mensal"

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -1302,6 +1302,11 @@
     "alertThresholds": "Avisar em (% do orçamento)",
     "alertThresholdsHelp": "Os alertas vão para administradores parceiros com acesso a cobrança. 100% (limite atingido) é sempre enviado.",
     "firedRung": "Alerta de {{pct}}% {{period}} enviado em {{date}}",
+    "alertThresholdsPlaceholder": "50, 80, 95",
+    "periodLabel": {
+      "daily": "diário",
+      "monthly": "mensal"
+    },
     "maxTurnsPerSession": "Máximo de turnos por sessão",
     "msgsMinPerUser": "Mensagens/minuto por usuário",
     "msgsHrPerOrg": "Mensagens/hora por organização",

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -121,7 +121,7 @@
     "messagesPerHour": "Kuruluş Başına Saat Başına Mesaj Sayısı",
     "alertThresholds": "Uyar (bütçenin %'si)",
     "alertThresholdsHelp": "Faturalama erişimine sahip partner yöneticileri her eşikte uygulama içi bir uyarı ve aylık ile limit aşımı uyarıları için e-posta alır. 50, 80, 95 değerlerini devralmak için boş bırakın.",
-    "notSet": "Ayarlanmadı — kuruluşlar ayrı ayrı yapılandırılır",
+    "notSet": "Ayarlanmadı, kuruluşlar ayrı ayrı yapılandırılır",
     "description": "Bütçe değerleri tüm alt kuruluşlarda uygulanır. Dolar tutarları dahili olarak sent cinsinden saklanır.",
     "modes": {
       "perStep": "Adım Başına",
@@ -1302,7 +1302,6 @@
     "alertThresholds": "Uyar (bütçenin %'si)",
     "alertThresholdsHelp": "Uyarılar, faturalama erişimine sahip partner yöneticilerine gönderilir. %100 (limite ulaşıldı) her zaman gönderilir.",
     "firedRung": "%{{pct}} {{period}} uyarısı {{date}} tarihinde gönderildi",
-    "alertThresholdsPlaceholder": "50, 80, 95",
     "periodLabel": {
       "daily": "günlük",
       "monthly": "aylık"

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -1302,6 +1302,11 @@
     "alertThresholds": "Uyar (bütçenin %'si)",
     "alertThresholdsHelp": "Uyarılar, faturalama erişimine sahip partner yöneticilerine gönderilir. %100 (limite ulaşıldı) her zaman gönderilir.",
     "firedRung": "%{{pct}} {{period}} uyarısı {{date}} tarihinde gönderildi",
+    "alertThresholdsPlaceholder": "50, 80, 95",
+    "periodLabel": {
+      "daily": "günlük",
+      "monthly": "aylık"
+    },
     "maxTurnsPerSession": "Oturum Başına Maksimum Dönüş Sayısı",
     "msgsMinPerUser": "Mesaj/Kullanıcı Başına Min",
     "msgsHrPerOrg": "Kuruluş Başına Mesaj/Saat",

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -119,6 +119,8 @@
     "maxTurns": "Oturum Başına Maksimum Dönüş Sayısı",
     "messagesPerMinute": "Kullanıcı Başına Dakikada Mesaj Sayısı",
     "messagesPerHour": "Kuruluş Başına Saat Başına Mesaj Sayısı",
+    "alertThresholds": "Uyar (bütçenin %'si)",
+    "alertThresholdsHelp": "Faturalama erişimine sahip partner yöneticileri her eşikte uygulama içi bir uyarı ve aylık ile limit aşımı uyarıları için e-posta alır. 50, 80, 95 değerlerini devralmak için boş bırakın.",
     "notSet": "Ayarlanmadı — kuruluşlar ayrı ayrı yapılandırılır",
     "description": "Bütçe değerleri tüm alt kuruluşlarda uygulanır. Dolar tutarları dahili olarak sent cinsinden saklanır.",
     "modes": {
@@ -127,6 +129,9 @@
       "autoApprove": "Otomatik Onayla",
       "hybridPlan": "Hibrit Plan"
     }
+  },
+  "aiBudgetThresholds": {
+    "invalid": "1 ile 99 arasında, virgülle ayrılmış en fazla beş tam sayı girin."
   },
   "partnerAiProvider": {
     "title": "Yapay Zeka Sağlayıcısı",
@@ -1294,6 +1299,9 @@
     "monthlyBudget": "Aylık Bütçe ($)",
     "noLimit": "Sınır yok",
     "dailyBudget": "Günlük Bütçe ($)",
+    "alertThresholds": "Uyar (bütçenin %'si)",
+    "alertThresholdsHelp": "Uyarılar, faturalama erişimine sahip partner yöneticilerine gönderilir. %100 (limite ulaşıldı) her zaman gönderilir.",
+    "firedRung": "%{{pct}} {{period}} uyarısı {{date}} tarihinde gönderildi",
     "maxTurnsPerSession": "Oturum Başına Maksimum Dönüş Sayısı",
     "msgsMinPerUser": "Mesaj/Kullanıcı Başına Min",
     "msgsHrPerOrg": "Kuruluş Başına Mesaj/Saat",

--- a/e2e-tests/pages/AiUsagePage.ts
+++ b/e2e-tests/pages/AiUsagePage.ts
@@ -19,6 +19,15 @@ export class AiUsagePage extends BasePage {
 
   async goto() {
     await this.page.goto(this.url);
+    await this.waitUntilReady();
+  }
+
+  /**
+   * Wait for the island to hydrate after any navigation this Page Object did
+   * not perform itself (a `page.reload()`, say). A bare `waitFor()` on the
+   * input passes on the SSR'd markup, before React has attached its handlers.
+   */
+  async waitUntilReady() {
     await waitForAppReady(this.page, 'ai-budget-thresholds-input');
   }
 }

--- a/e2e-tests/pages/AiUsagePage.ts
+++ b/e2e-tests/pages/AiUsagePage.ts
@@ -1,4 +1,5 @@
 import { BasePage } from './BasePage';
+import { waitForAppReady } from './hydration';
 
 /**
  * `/settings/ai-usage` — org AI usage + budget configuration.
@@ -18,6 +19,6 @@ export class AiUsagePage extends BasePage {
 
   async goto() {
     await this.page.goto(this.url);
-    await this.thresholdsInput().waitFor();
+    await waitForAppReady(this.page, 'ai-budget-thresholds-input');
   }
 }

--- a/e2e-tests/pages/AiUsagePage.ts
+++ b/e2e-tests/pages/AiUsagePage.ts
@@ -1,0 +1,23 @@
+import { BasePage } from './BasePage';
+
+/**
+ * `/settings/ai-usage` — org AI usage + budget configuration.
+ *
+ * #4388 W03: budget alert thresholds round-trip through
+ * `AiBudgetThresholdsInput` (`ai-budget-thresholds-input`) and the save
+ * button (`ai-budget-save`), and any already-fired rungs for the current
+ * period render in `ai-budget-fired-rungs` (only present when
+ * `usage.alerts.fired` is non-empty — see `AiUsagePage.tsx`).
+ */
+export class AiUsagePage extends BasePage {
+  url = '/settings/ai-usage';
+
+  thresholdsInput = () => this.page.getByTestId('ai-budget-thresholds-input');
+  saveButton = () => this.page.getByTestId('ai-budget-save');
+  firedRungs = () => this.page.getByTestId('ai-budget-fired-rungs');
+
+  async goto() {
+    await this.page.goto(this.url);
+    await this.thresholdsInput().waitFor();
+  }
+}

--- a/e2e-tests/seed-fixtures.sql
+++ b/e2e-tests/seed-fixtures.sql
@@ -223,5 +223,23 @@ BEGIN
     SET status = 'open', accepted_by = NULL, accepted_until = NULL, resolved_at = NULL, mitigation_note = NULL
     WHERE device_id = v_windows_device_id AND vulnerability_id = v_vuln_critical;
 
+  -- ───────────────────────────────────────────────────────────────────
+  -- AI budget alert event (#4388 W03): one fired monthly 80% rung for the
+  -- current UTC calendar month so the AI usage settings page
+  -- (/settings/ai-usage) renders `ai-budget-fired-rungs`. period_key
+  -- computed the same way as aiCostTracker.ts getUsageSummary() (UTC
+  -- `YYYY-MM`) so it's found by the same query. Mirrored in
+  -- apps/api/src/db/seedE2eFixtures.ts.
+  -- ───────────────────────────────────────────────────────────────────
+  INSERT INTO ai_budget_alert_events (org_id, period, period_key, threshold_pct, cap_cents, used_cents, billing_source, delivered_at, recipient_count)
+  SELECT v_org_id, 'monthly', to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM'), 80, 10000, 8500, 'platform', NOW(), 1
+  WHERE NOT EXISTS (
+    SELECT 1 FROM ai_budget_alert_events
+    WHERE org_id = v_org_id
+      AND period = 'monthly'
+      AND period_key = to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM')
+      AND threshold_pct = 80
+  );
+
   RAISE NOTICE 'E2E fixtures seeded for org %', v_org_id;
 END $$;

--- a/e2e-tests/tests/ai-budget-alerts.spec.ts
+++ b/e2e-tests/tests/ai-budget-alerts.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '../fixtures';
+import { AiUsagePage } from '../pages/AiUsagePage';
+
+/**
+ * #4388 W03 — org AI budget threshold alerts, browser slice.
+ *
+ * Two things a browser can prove that the API/integration suites (Wave 2)
+ * cannot:
+ *   1. the alert-threshold input on `/settings/ai-usage` actually round-trips
+ *      through the real save button and a page reload (not just the PUT
+ *      /ai/budget contract);
+ *   2. a fired rung for the org's current monthly period renders in
+ *      `ai-budget-fired-rungs` — seeded via `e2e-tests/seed-fixtures.sql` /
+ *      `apps/api/src/db/seedE2eFixtures.ts` (one 80% monthly
+ *      `ai_budget_alert_events` row for the seeded org, current UTC
+ *      `YYYY-MM` period key).
+ *
+ * Restoring the thresholds afterwards is not required — this is the only
+ * spec that touches this org's `ai_budgets.alert_threshold_pcts`.
+ */
+test.describe('AI budget alert thresholds', () => {
+  test('thresholds input round-trips and a fired rung renders', async ({ authedPage }) => {
+    const aiUsage = new AiUsagePage(authedPage);
+    await aiUsage.goto();
+
+    await expect(aiUsage.firedRungs()).toBeVisible();
+    await expect(aiUsage.firedRungs()).toContainText('80%');
+
+    await aiUsage.thresholdsInput().fill('60, 90');
+    await aiUsage.thresholdsInput().blur();
+
+    const [putResponse] = await Promise.all([
+      authedPage.waitForResponse(
+        (r) => r.request().method() === 'PUT' && /\/ai\/budget$/.test(new URL(r.url()).pathname),
+      ),
+      aiUsage.saveButton().click(),
+    ]);
+    expect(putResponse.ok()).toBe(true);
+
+    await authedPage.reload();
+    await aiUsage.thresholdsInput().waitFor();
+    await expect(aiUsage.thresholdsInput()).toHaveValue('60, 90');
+  });
+});

--- a/e2e-tests/tests/ai-budget-alerts.spec.ts
+++ b/e2e-tests/tests/ai-budget-alerts.spec.ts
@@ -38,7 +38,7 @@ test.describe('AI budget alert thresholds', () => {
     expect(putResponse.ok()).toBe(true);
 
     await authedPage.reload();
-    await aiUsage.thresholdsInput().waitFor();
+    await aiUsage.waitUntilReady();
     await expect(aiUsage.thresholdsInput()).toHaveValue('60, 90');
   });
 });


### PR DESCRIPTION
Wave 3 of #4388 (pre-cap AI budget alerts): the `/ai/usage` alerts surface, the threshold settings UI on both the org and partner pages, an e2e spec, and docs. Spec sections 4.8 and 4.9 of `docs/superpowers/specs/ai-mcp/2026-09-01-ai-budget-threshold-alerts-design.md`.

Stacked on #4496 (W02), which is stacked on #4487 (W01). Base is `feature/4388-ai-budget-alerts/wave-4390`; retarget to `main` once the parents merge. Because the base is not `main`, CI is dispatched manually for this branch.

Closes #4391

## What changed

**API**
- `GET /ai/usage` now returns the effective budget (partner override wins) via `getEffectiveAiBudget`, includes `budget.alertThresholdPercents`, and adds a top-level `alerts.fired[]` listing the rungs already fired for the current daily and monthly periods. The no-org branch returns `alerts: { fired: [] }` so the key is always present.

**Web**
- New `AiBudgetThresholdsInput` (comma or space separated integers 1 to 99, max five, sorted and deduplicated, chips, inline error with `aria-invalid` and `aria-describedby`, `onValidityChange`).
- Org page `/settings/ai-usage`: threshold field with partner lock, fired-rung markers, Save disabled while the field is invalid, and the field is only sent when the user edited it (so a save no longer pins the inherited default ladder onto the org row).
- Partner settings, AI Budgets tab: partner-wide threshold field; clearing sends `undefined` (the partner schema is optional, not nullable).
- Locale keys in all eight `settings.json` files; the untranslated period word in the fired-rung sentence is now a translated label; the `partnerAiBudgets.notSet` em dash removed.

**Tests and docs**
- Unit: `aiCostTracker.test.ts`, `ai_admin.test.ts`, component tests for the input, org and partner clearing-contract tests, a seed test for the fired-rung fixture row.
- E2E: `e2e-tests/tests/ai-budget-alerts.spec.ts` + `pages/AiUsagePage.ts`; seeded `ai_budget_alert_events` row in both `seed-fixtures.sql` and `seedE2eFixtures.ts`.
- Docs: "Budget alerts" section in `apps/docs/src/content/docs/features/ai.mdx`.
- Also carries the W02 contract-test fix (`workerEntrypointClosure.contract.test.ts` registers `aiBudgetAlertDeliveryWorker`), merged forward from wave-4390.

## Verification
- Web: 97 files / 1094 tests including the full `src/lib/i18n` guard directory; `astro check` 0 errors; eslint clean.
- API: `aiCostTracker`, `ai_admin`, `ai.ticket`, `seedE2eFixtures`, alert suites, worker contract tests green; `tsc --noEmit` clean.
- Playwright `ai-budget-alerts` green against the worktree stack.
- Browser smoke on the stack: partner-wide `90, 70` saves as `[70, 90]` and locks the org field with "Managed by partner"; seeded rung renders as "80% monthly alert sent <date>"; an invalid entry shows the error and disables Save.
- Reviews: per-task reviews plus an opus whole-branch review with one fix wave and a scoped re-review.

## Follow-ups (not in this PR)
- Greyed "inheriting default" display (spec 4.9) needs an API raw-vs-effective signal.
- Five other partner-tab `notSet` strings still contain an em dash (pre-existing).
- `handleSaveBudget` still uses the pre-existing inline error UI rather than `runAction`.
- e2e global-setup swallows a Redis NOAUTH on the rate-limit flush when `REDIS_PASSWORD` is unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyYQpa3oMfjMRSjET5WnEr
