### PR TITLE
feat(ai,web): surface partner AI credit balance on /ai/usage and the usage page (#4388 W04)

### DIFF
--- a/apps/api/src/routes/ai.ts
+++ b/apps/api/src/routes/ai.ts
@@ -1064,7 +1064,7 @@ aiRoutes.get(
         budget: null,
         billedTo: 'platform' as const,
         // #4388 W04: present (null) on every /ai/usage response, same
-        // rationale as `alerts.fired` above — callers read `usage.credits`
+        // rationale as `alerts.fired` above: callers read `usage.credits`
         // unconditionally.
         credits: null,
         alerts: { fired: [] },
@@ -1075,7 +1075,13 @@ aiRoutes.get(
       return c.json({ error: 'Access denied to this organization' }, 403);
     }
 
-    const usage = await getUsageSummary(orgId);
+    // #4388 W04: the credit pool is PARTNER-wide, shared across every one of
+    // the MSP's customer orgs. An organization-scoped token belongs to one of
+    // those customers, so handing it that balance would leak a partner-level
+    // figure across the tenancy boundary (and let one customer watch another's
+    // spend drain it). Only partner- and system-scoped callers get it.
+    const includeCredits = auth.scope === 'partner' || auth.scope === 'system';
+    const usage = await getUsageSummary(orgId, { includeCredits });
     return c.json(usage);
   }
 );

--- a/apps/api/src/routes/ai.ts
+++ b/apps/api/src/routes/ai.ts
@@ -1063,6 +1063,10 @@ aiRoutes.get(
         monthly: { inputTokens: 0, outputTokens: 0, totalCostCents: 0, messageCount: 0 },
         budget: null,
         billedTo: 'platform' as const,
+        // #4388 W04: present (null) on every /ai/usage response, same
+        // rationale as `alerts.fired` above — callers read `usage.credits`
+        // unconditionally.
+        credits: null,
         alerts: { fired: [] },
       });
     }

--- a/apps/api/src/routes/ai_admin.test.ts
+++ b/apps/api/src/routes/ai_admin.test.ts
@@ -186,6 +186,91 @@ describe('AI routes', () => {
       expect(body.billedTo).toBe('partner_key');
     });
 
+    // ============================================
+    // #4388 W04: the partner-wide credit pool
+    // ============================================
+    //
+    // `credits` is the MSP's balance, shared across every one of its customer
+    // orgs, so an organization-scoped token must never receive it. The mock
+    // below stands in for a WARM cache: getUsageSummary hands back a balance
+    // whenever the caller asked for one, so a `credits: null` in the response
+    // is the ROUTE withholding it, not an empty cache.
+    const CACHED_CREDITS = {
+      remaining: 1240, includedBalance: 0, purchasedBalance: 1240, fetchedAt: '2026-09-01T00:00:00.000Z',
+    };
+
+    function mockWarmCreditCache() {
+      vi.mocked(getUsageSummary).mockImplementation(
+        (async (_orgId: string, options?: { includeCredits?: boolean }) => ({
+          daily: { inputTokens: 0, outputTokens: 0, totalCostCents: 0, messageCount: 0 },
+          monthly: { inputTokens: 0, outputTokens: 0, totalCostCents: 0, messageCount: 0 },
+          budget: null,
+          billedTo: 'platform',
+          catalogEndpointName: null,
+          credits: options?.includeCredits ? CACHED_CREDITS : null,
+          alerts: { fired: [] },
+        })) as unknown as typeof getUsageSummary,
+      );
+    }
+
+    async function authAs(scope: 'organization' | 'partner' | 'system') {
+      const { authMiddleware } = await import('../middleware/auth');
+      vi.mocked(authMiddleware).mockImplementationOnce((c: any, next: any) => {
+        c.set('auth', {
+          user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+          scope,
+          partnerId: scope === 'organization' ? null : 'partner-1',
+          orgId: ORG_ID,
+          accessibleOrgIds: [ORG_ID],
+          orgCondition: () => undefined,
+          canAccessOrg: () => true,
+        });
+        return next();
+      });
+    }
+
+    it('withholds the partner-wide credit pool from an organization-scoped token', async () => {
+      mockWarmCreditCache();
+      await authAs('organization');
+
+      const res = await app.request('/ai/usage', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(200);
+      expect((await res.json()).credits).toBeNull();
+      expect(getUsageSummary).toHaveBeenCalledWith(ORG_ID, { includeCredits: false });
+    });
+
+    it('returns the credit balance to a partner-scoped token', async () => {
+      mockWarmCreditCache();
+      await authAs('partner');
+
+      const res = await app.request('/ai/usage', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(200);
+      expect((await res.json()).credits).toEqual(CACHED_CREDITS);
+      expect(getUsageSummary).toHaveBeenCalledWith(ORG_ID, { includeCredits: true });
+    });
+
+    it('returns the credit balance to a system-scoped token', async () => {
+      mockWarmCreditCache();
+      await authAs('system');
+
+      const res = await app.request('/ai/usage', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(200);
+      expect((await res.json()).credits).toEqual(CACHED_CREDITS);
+      expect(getUsageSummary).toHaveBeenCalledWith(ORG_ID, { includeCredits: true });
+    });
+
     it('returns 403 when accessing other org', async () => {
       const res = await app.request('/ai/usage?orgId=other-org', {
         method: 'GET',

--- a/apps/api/src/services/aiCostTracker.test.ts
+++ b/apps/api/src/services/aiCostTracker.test.ts
@@ -82,7 +82,17 @@ vi.mock('../db/schema', () => ({
   organizations: { id: 'id', partnerId: 'partnerId' },
 }));
 
-vi.mock('./redis', () => ({ getRedis: vi.fn(() => ({})) }));
+// #4388 W04: `set`/`get` back the per-partner credit-balance cache
+// (checkBillingCreditsDetailed writes it, getUsageSummary reads it).
+// `mockResolvedValue` at creation survives `vi.clearAllMocks()` in the outer
+// beforeEach (it only clears call tracking, not the implementation), so each
+// test only needs to override what it cares about via `mockResolvedValueOnce`
+// / `mockRejectedValueOnce`.
+const { redisSet, redisGet } = vi.hoisted(() => ({
+  redisSet: vi.fn().mockResolvedValue('OK'),
+  redisGet: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('./redis', () => ({ getRedis: vi.fn(() => ({ set: redisSet, get: redisGet })) }));
 vi.mock('./rate-limit', () => ({ rateLimiter: vi.fn() }));
 
 // Single source of truth for an enabled, unlimited effective budget with the
@@ -246,6 +256,8 @@ function billingCreditsResponse(input: {
   allowed: boolean;
   remainingCredits: number;
   plan: string;
+  includedBalance?: number;
+  purchasedBalance?: number;
 }): Response {
   return new Response(JSON.stringify(input), {
     status: 200,
@@ -1478,6 +1490,136 @@ describe('checkBillingCreditsDetailed', () => {
     await expect(checkBillingCredits('org-cd-3', 'platform')).resolves.toBe(
       'AI assistant requires the Community plan.',
     );
+  });
+});
+
+// ============================================
+// #4388 W04: partner credit-balance cache
+// ============================================
+//
+// checkBillingCreditsDetailed writes the last-seen balance to Redis
+// (`ai:credits:<partnerId>`, 60s TTL) so getUsageSummary can surface it on
+// /ai/usage without an extra billing-service round trip per page load. The
+// write must never fail the credit check itself — a Redis outage degrades to
+// "no cached balance to show", not a broken AI gate.
+
+describe('checkBillingCreditsDetailed: partner credit cache (#4388 W04)', () => {
+  it('caches the last credit balance per partner for /ai/usage (#4388)', async () => {
+    const fetchMock = enableBillingService();
+    fetchMock.mockResolvedValueOnce(billingCreditsResponse({
+      allowed: true, remainingCredits: 1240, includedBalance: 0, purchasedBalance: 1240, plan: 'pro',
+    }));
+    setupDbMocks(null); // organizations partnerId lookup resolves 'partner-1'
+
+    await checkBillingCreditsDetailed('org-cache-1', 'platform');
+
+    expect(redisSet).toHaveBeenCalledWith(
+      'ai:credits:partner-1',
+      expect.stringContaining('"remaining":1240'),
+      'EX',
+      60,
+    );
+    const written = JSON.parse(redisSet.mock.calls[0]![1] as string);
+    expect(written).toMatchObject({ remaining: 1240, includedBalance: 0, purchasedBalance: 1240 });
+    expect(typeof written.fetchedAt).toBe('string');
+  });
+
+  it('defaults includedBalance/purchasedBalance to 0 when the billing response omits them (pre-deploy compat)', async () => {
+    const fetchMock = enableBillingService();
+    fetchMock.mockResolvedValueOnce(billingCreditsResponse({
+      allowed: true, remainingCredits: 500, plan: 'pro',
+    }));
+    setupDbMocks(null);
+
+    await checkBillingCreditsDetailed('org-cache-2', 'platform');
+
+    const written = JSON.parse(redisSet.mock.calls[0]![1] as string);
+    expect(written).toMatchObject({ remaining: 500, includedBalance: 0, purchasedBalance: 0 });
+  });
+
+  it('does not throw and still returns the access decision when the cache write fails', async () => {
+    const fetchMock = enableBillingService();
+    fetchMock.mockResolvedValueOnce(billingCreditsResponse({
+      allowed: true, remainingCredits: 10, plan: 'pro',
+    }));
+    setupDbMocks(null);
+    redisSet.mockRejectedValueOnce(new Error('redis down'));
+
+    await expect(checkBillingCreditsDetailed('org-cache-3', 'platform')).resolves.toBeNull();
+  });
+});
+
+// getUsageSummary's `credits` field: cached per-partner balance, surfaced only
+// for platform-billed orgs. Must never throw — a Redis outage or a missing
+// partner/cache entry all degrade to `credits: null`, never a 500.
+describe('getUsageSummary: credits (#4388 W04)', () => {
+  beforeEach(() => {
+    setupDbMocks(null); // organizations partnerId lookup resolves 'partner-1'
+  });
+
+  it('returns the cached credit balance when billed to the platform and a cache entry exists', async () => {
+    getLlmBillingSourceForOrgMock.mockResolvedValueOnce('platform');
+    redisGet.mockResolvedValueOnce(JSON.stringify({
+      remaining: 1240, includedBalance: 0, purchasedBalance: 1240, fetchedAt: '2026-09-01T00:00:00.000Z',
+    }));
+
+    const summary = await getUsageSummary('org1');
+
+    expect(summary.credits).toEqual({
+      remaining: 1240, includedBalance: 0, purchasedBalance: 1240, fetchedAt: '2026-09-01T00:00:00.000Z',
+    });
+    expect(redisGet).toHaveBeenCalledWith('ai:credits:partner-1');
+  });
+
+  it('is null for BYOK orgs (billedTo partner_key) — never even reads the cache', async () => {
+    getLlmBillingSourceForOrgMock.mockResolvedValueOnce('partner_key');
+
+    const summary = await getUsageSummary('org1');
+
+    expect(summary.credits).toBeNull();
+    expect(redisGet).not.toHaveBeenCalled();
+  });
+
+  it('is null when the org has no partner id', async () => {
+    getLlmBillingSourceForOrgMock.mockResolvedValueOnce('platform');
+    mockDb.select.mockImplementation((cols?: Record<string, unknown>) => {
+      const isPartnerLookup = !!cols && 'partnerId' in cols;
+      return {
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({
+            limit: vi.fn().mockResolvedValue(isPartnerLookup ? [{ partnerId: null }] : []),
+          })),
+        })),
+      };
+    });
+
+    const summary = await getUsageSummary('org1');
+
+    expect(summary.credits).toBeNull();
+    expect(redisGet).not.toHaveBeenCalled();
+  });
+
+  it('is null when uncached', async () => {
+    getLlmBillingSourceForOrgMock.mockResolvedValueOnce('platform');
+    redisGet.mockResolvedValueOnce(null);
+
+    const summary = await getUsageSummary('org1');
+
+    expect(summary.credits).toBeNull();
+  });
+
+  it('never throws when the Redis read fails; degrades to null', async () => {
+    getLlmBillingSourceForOrgMock.mockResolvedValueOnce('platform');
+    redisGet.mockRejectedValueOnce(new Error('redis down'));
+
+    await expect(getUsageSummary('org1')).resolves.toMatchObject({ credits: null });
+  });
+
+  it('is null (not a throw) when the cached value is corrupt/not valid JSON', async () => {
+    getLlmBillingSourceForOrgMock.mockResolvedValueOnce('platform');
+    redisGet.mockResolvedValueOnce('not-json');
+
+    await expect(getUsageSummary('org1')).resolves.toMatchObject({ credits: null });
   });
 });
 

--- a/apps/api/src/services/aiCostTracker.test.ts
+++ b/apps/api/src/services/aiCostTracker.test.ts
@@ -1497,11 +1497,11 @@ describe('checkBillingCreditsDetailed', () => {
 // #4388 W04: partner credit-balance cache
 // ============================================
 //
-// checkBillingCreditsDetailed writes the last-seen balance to Redis
-// (`ai:credits:<partnerId>`, 60s TTL) so getUsageSummary can surface it on
-// /ai/usage without an extra billing-service round trip per page load. The
-// write must never fail the credit check itself — a Redis outage degrades to
-// "no cached balance to show", not a broken AI gate.
+// checkBillingCreditsDetailed and getUsageSummary share one fetch-and-cache
+// path, writing the last-seen balance to Redis (`ai:credits:<partnerId>`,
+// 900s TTL) so /ai/usage can surface it without a billing-service round trip
+// per page load. The write must never fail the credit check itself: a Redis
+// outage degrades to "no cached balance to show", not a broken AI gate.
 
 describe('checkBillingCreditsDetailed: partner credit cache (#4388 W04)', () => {
   it('caches the last credit balance per partner for /ai/usage (#4388)', async () => {
@@ -1513,11 +1513,14 @@ describe('checkBillingCreditsDetailed: partner credit cache (#4388 W04)', () => 
 
     await checkBillingCreditsDetailed('org-cache-1', 'platform');
 
+    // 900s, not 60s: the cache is now read-through from the usage page, and a
+    // one-minute TTL meant the credits card had nothing to render on almost
+    // every page load.
     expect(redisSet).toHaveBeenCalledWith(
       'ai:credits:partner-1',
       expect.stringContaining('"remaining":1240'),
       'EX',
-      60,
+      900,
     );
     const written = JSON.parse(redisSet.mock.calls[0]![1] as string);
     expect(written).toMatchObject({ remaining: 1240, includedBalance: 0, purchasedBalance: 1240 });
@@ -1549,32 +1552,54 @@ describe('checkBillingCreditsDetailed: partner credit cache (#4388 W04)', () => 
   });
 });
 
-// getUsageSummary's `credits` field: cached per-partner balance, surfaced only
-// for platform-billed orgs. Must never throw — a Redis outage or a missing
-// partner/cache entry all degrade to `credits: null`, never a 500.
+// getUsageSummary's `credits` field: the partner-wide balance, surfaced only
+// when the CALLER opted in (`includeCredits`) and only for platform-billed
+// orgs. Read-through: a cache miss fills the cache from the billing service
+// rather than rendering nothing. Must never throw: a Redis outage, a missing
+// partner, a corrupt entry, or a billing outage all degrade to
+// `credits: null`, never a 500.
+const CACHED = { remaining: 1240, includedBalance: 0, purchasedBalance: 1240, fetchedAt: '2026-09-01T00:00:00.000Z' };
+
 describe('getUsageSummary: credits (#4388 W04)', () => {
   beforeEach(() => {
     setupDbMocks(null); // organizations partnerId lookup resolves 'partner-1'
+    // vi.clearAllMocks() clears recorded calls but NOT queued
+    // mockResolvedValueOnce values, and several tests here deliberately leave
+    // one unconsumed (they assert the cache is never read). Reset explicitly
+    // so that queued value cannot surface in the next test.
+    redisGet.mockReset();
+    redisGet.mockResolvedValue(null);
+    redisSet.mockReset();
+    redisSet.mockResolvedValue('OK');
   });
 
   it('returns the cached credit balance when billed to the platform and a cache entry exists', async () => {
     getLlmBillingSourceForOrgMock.mockResolvedValueOnce('platform');
-    redisGet.mockResolvedValueOnce(JSON.stringify({
-      remaining: 1240, includedBalance: 0, purchasedBalance: 1240, fetchedAt: '2026-09-01T00:00:00.000Z',
-    }));
+    redisGet.mockResolvedValueOnce(JSON.stringify(CACHED));
 
-    const summary = await getUsageSummary('org1');
+    const summary = await getUsageSummary('org1', { includeCredits: true });
 
-    expect(summary.credits).toEqual({
-      remaining: 1240, includedBalance: 0, purchasedBalance: 1240, fetchedAt: '2026-09-01T00:00:00.000Z',
-    });
+    expect(summary.credits).toEqual(CACHED);
     expect(redisGet).toHaveBeenCalledWith('ai:credits:partner-1');
   });
 
-  it('is null for BYOK orgs (billedTo partner_key) — never even reads the cache', async () => {
-    getLlmBillingSourceForOrgMock.mockResolvedValueOnce('partner_key');
+  // The partner-wide pool must not reach an org-scoped caller. Proven against
+  // a WARM cache, so a null here is the flag withholding it, not an empty
+  // cache: without the gate this same fixture returns the balance above.
+  it('is null when the caller did not ask for credits, even with a warm cache', async () => {
+    getLlmBillingSourceForOrgMock.mockResolvedValueOnce('platform');
+    redisGet.mockResolvedValueOnce(JSON.stringify(CACHED));
 
     const summary = await getUsageSummary('org1');
+
+    expect(summary.credits).toBeNull();
+    expect(redisGet).not.toHaveBeenCalled();
+  });
+
+  it('is null for BYOK orgs (billedTo partner_key): never even reads the cache', async () => {
+    getLlmBillingSourceForOrgMock.mockResolvedValueOnce('partner_key');
+
+    const summary = await getUsageSummary('org1', { includeCredits: true });
 
     expect(summary.credits).toBeNull();
     expect(redisGet).not.toHaveBeenCalled();
@@ -1593,17 +1618,17 @@ describe('getUsageSummary: credits (#4388 W04)', () => {
       };
     });
 
-    const summary = await getUsageSummary('org1');
+    const summary = await getUsageSummary('org1', { includeCredits: true });
 
     expect(summary.credits).toBeNull();
     expect(redisGet).not.toHaveBeenCalled();
   });
 
-  it('is null when uncached', async () => {
+  it('is null when uncached and no billing service is configured (self-hosted)', async () => {
     getLlmBillingSourceForOrgMock.mockResolvedValueOnce('platform');
     redisGet.mockResolvedValueOnce(null);
 
-    const summary = await getUsageSummary('org1');
+    const summary = await getUsageSummary('org1', { includeCredits: true });
 
     expect(summary.credits).toBeNull();
   });
@@ -1612,14 +1637,87 @@ describe('getUsageSummary: credits (#4388 W04)', () => {
     getLlmBillingSourceForOrgMock.mockResolvedValueOnce('platform');
     redisGet.mockRejectedValueOnce(new Error('redis down'));
 
-    await expect(getUsageSummary('org1')).resolves.toMatchObject({ credits: null });
+    await expect(getUsageSummary('org1', { includeCredits: true })).resolves.toMatchObject({ credits: null });
   });
 
   it('is null (not a throw) when the cached value is corrupt/not valid JSON', async () => {
     getLlmBillingSourceForOrgMock.mockResolvedValueOnce('platform');
     redisGet.mockResolvedValueOnce('not-json');
 
-    await expect(getUsageSummary('org1')).resolves.toMatchObject({ credits: null });
+    await expect(getUsageSummary('org1', { includeCredits: true })).resolves.toMatchObject({ credits: null });
+  });
+});
+
+// Read-through fill. The cache used to be written ONLY by an AI turn, so on a
+// fleet that is not mid-conversation the credits card essentially never
+// rendered and the header cost indicator flickered. getUsageSummary now fills
+// the cache itself on a miss.
+describe('getUsageSummary: credit cache read-through (#4388 W04)', () => {
+  beforeEach(() => {
+    setupDbMocks(null); // organizations partnerId lookup resolves 'partner-1'
+    // vi.clearAllMocks() clears recorded calls but NOT queued
+    // mockResolvedValueOnce values, and several tests here deliberately leave
+    // one unconsumed (they assert the cache is never read). Reset explicitly
+    // so that queued value cannot surface in the next test.
+    redisGet.mockReset();
+    redisGet.mockResolvedValue(null);
+    redisSet.mockReset();
+    redisSet.mockResolvedValue('OK');
+  });
+
+  it('a cache HIT does not call the billing service at all', async () => {
+    const fetchMock = enableBillingService();
+    getLlmBillingSourceForOrgMock.mockResolvedValueOnce('platform');
+    redisGet.mockResolvedValueOnce(JSON.stringify(CACHED));
+
+    const summary = await getUsageSummary('org1', { includeCredits: true });
+
+    expect(summary.credits).toEqual(CACHED);
+    // /ai/usage is polled by the header indicator on every page; a hit that
+    // still round-trips to billing would defeat the cache entirely.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('a cache MISS fetches from billing once and writes the cache with a 900s TTL', async () => {
+    const fetchMock = enableBillingService();
+    fetchMock.mockResolvedValueOnce(billingCreditsResponse({
+      allowed: true, remainingCredits: 777, includedBalance: 200, purchasedBalance: 577, plan: 'pro',
+    }));
+    getLlmBillingSourceForOrgMock.mockResolvedValueOnce('platform');
+    redisGet.mockResolvedValueOnce(null);
+
+    const summary = await getUsageSummary('org1', { includeCredits: true });
+
+    expect(summary.credits).toMatchObject({ remaining: 777, includedBalance: 200, purchasedBalance: 577 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://billing.internal/api/internal/partners/partner-1/ai-credits',
+      expect.objectContaining({ headers: { Authorization: 'Bearer billing-key' } }),
+    );
+    expect(redisSet).toHaveBeenCalledWith(
+      'ai:credits:partner-1',
+      expect.stringContaining('"remaining":777'),
+      'EX',
+      900,
+    );
+  });
+
+  it('a billing HTTP failure on the miss path yields credits: null without throwing', async () => {
+    const fetchMock = enableBillingService();
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 503 }));
+    getLlmBillingSourceForOrgMock.mockResolvedValueOnce('platform');
+    redisGet.mockResolvedValueOnce(null);
+
+    await expect(getUsageSummary('org1', { includeCredits: true })).resolves.toMatchObject({ credits: null });
+  });
+
+  it('a billing transport failure on the miss path yields credits: null without throwing', async () => {
+    const fetchMock = enableBillingService();
+    fetchMock.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+    getLlmBillingSourceForOrgMock.mockResolvedValueOnce('platform');
+    redisGet.mockResolvedValueOnce(null);
+
+    await expect(getUsageSummary('org1', { includeCredits: true })).resolves.toMatchObject({ credits: null });
   });
 });
 

--- a/apps/api/src/services/aiCostTracker.ts
+++ b/apps/api/src/services/aiCostTracker.ts
@@ -206,7 +206,36 @@ export async function checkBillingCreditsDetailed(
       return null;
     }
 
-    const data = await res.json() as { allowed: boolean; remainingCredits: number; plan: string };
+    const data = await res.json() as {
+      allowed: boolean;
+      remainingCredits: number;
+      plan: string;
+      /** breeze-billing added these alongside `remainingCredits` (in flight,
+       *  #4388 W04) — optional here so this deploys safely ahead of that
+       *  billing-service rollout; both default to 0 in the cached record
+       *  until the field actually starts arriving. */
+      includedBalance?: number;
+      purchasedBalance?: number;
+    };
+
+    // #4388 W04: cache the latest balance per PARTNER (not per org — the
+    // balance is partner-wide) so getUsageSummary can surface it on
+    // /ai/usage without its own billing-service round trip. Best-effort: a
+    // Redis outage must not affect the credit gate this function exists for.
+    const redis = getRedis();
+    if (redis) {
+      void redis.set(
+        `ai:credits:${org.partnerId}`,
+        JSON.stringify({
+          remaining: data.remainingCredits,
+          includedBalance: data.includedBalance ?? 0,
+          purchasedBalance: data.purchasedBalance ?? 0,
+          fetchedAt: new Date().toISOString(),
+        }),
+        'EX',
+        60,
+      ).catch(() => undefined);
+    }
 
     if (!data.allowed) {
       if (['free', 'starter'].includes(data.plan)) {
@@ -1276,6 +1305,12 @@ export async function getUsageSummary(orgId: string): Promise<{
   /** Name of the catalog endpoint the org's most recent session used, or null
    *  for direct-Anthropic / platform-key traffic (#3922 W4). */
   catalogEndpointName: string | null;
+  /** #4388 W04: the partner's platform-credit balance, as last cached by
+   *  checkBillingCreditsDetailed. `null` when billed to the partner's own
+   *  key (BYOK — no platform credits apply), when the org has no partner id,
+   *  or when nothing has been cached yet (no billing service, or the cache
+   *  entry expired/was never written). Never throws. */
+  credits: { remaining: number; includedBalance: number; purchasedBalance: number; fetchedAt: string } | null;
   /** #4388: threshold rungs already fired for the org's CURRENT daily and
    *  monthly periods (nothing from prior, rolled-over periods). */
   alerts: {
@@ -1334,6 +1369,27 @@ export async function getUsageSummary(orgId: string): Promise<{
     if (entryId) catalogEndpointName = await getCatalogEntryName(entryId);
   }
 
+  // #4388 W04: the cached partner credit balance. Only meaningful for
+  // platform-billed orgs (a partner_key/BYOK org spends against its own
+  // Anthropic account, not platform credits). Wrapped so a Redis outage, a
+  // missing/deleted org row, or a corrupt cache entry all degrade to `null`
+  // rather than a 500 on /ai/usage.
+  let credits: { remaining: number; includedBalance: number; purchasedBalance: number; fetchedAt: string } | null = null;
+  if (billedTo === 'platform') {
+    try {
+      const [org] = await db
+        .select({ partnerId: organizations.partnerId })
+        .from(organizations)
+        .where(eq(organizations.id, orgId))
+        .limit(1);
+      const redis = org?.partnerId ? getRedis() : null;
+      const raw = redis ? await redis.get(`ai:credits:${org?.partnerId}`) : null;
+      if (raw) credits = JSON.parse(raw);
+    } catch {
+      credits = null;
+    }
+  }
+
   return {
     daily: {
       inputTokens: dailyUsage?.inputTokens ?? 0,
@@ -1358,6 +1414,7 @@ export async function getUsageSummary(orgId: string): Promise<{
     },
     billedTo,
     catalogEndpointName,
+    credits,
     alerts: {
       fired: fired.map((r) => ({
         period: r.period,

--- a/apps/api/src/services/aiCostTracker.ts
+++ b/apps/api/src/services/aiCostTracker.ts
@@ -132,6 +132,99 @@ const DEFAULT_PRICING = { inputPerMillion: 500, outputPerMillion: 2500 };
 const CACHE_READ_INPUT_MULTIPLIER = 0.1;
 const CACHE_WRITE_INPUT_MULTIPLIER = 1.25;
 
+/** The record cached at `ai:credits:<partnerId>` and surfaced on /ai/usage. */
+export interface CachedPartnerCredits {
+  remaining: number;
+  includedBalance: number;
+  purchasedBalance: number;
+  fetchedAt: string;
+}
+
+/**
+ * How long a fetched partner credit balance stays cached.
+ *
+ * 15 minutes, up from the 60s this shipped with. The cache used to be written
+ * only by {@link checkBillingCreditsDetailed}, which runs only on an actual AI
+ * turn: for any org that was not mid-conversation the entry had long expired
+ * by the time the usage page or the header cost indicator asked for it, so the
+ * credits card rendered on almost no page load and the header flickered
+ * between "has credits" and nothing. {@link getUsageSummary} now fills the
+ * cache on a miss, and a 15-minute TTL keeps a page refresh from turning into
+ * a billing-service round trip every time. A balance this stale is fine for a
+ * display surface; the credit GATE always reads live.
+ */
+const PARTNER_CREDITS_CACHE_TTL_SECONDS = 900;
+
+/** The `/ai-credits` response from breeze-billing. */
+interface BillingCreditsPayload {
+  allowed: boolean;
+  remainingCredits: number;
+  plan: string;
+  /** Present since breeze-billing's #4388 W04 rollout; optional so this
+   *  deploys safely ahead of it, defaulting to 0 in the cached record. */
+  includedBalance?: number;
+  purchasedBalance?: number;
+}
+
+/**
+ * Discriminated so each caller can react to a failure the way it needs to:
+ * the credit gate reports HTTP and transport failures to Sentry and falls
+ * open, while the usage page just shows no credits card.
+ */
+type PartnerCreditsFetch =
+  | { ok: true; payload: BillingCreditsPayload; credits: CachedPartnerCredits }
+  | { ok: false; reason: 'unconfigured' }
+  | { ok: false; reason: 'http'; status: number }
+  | { ok: false; reason: 'transport'; error: unknown };
+
+/**
+ * Fetch a partner's platform credit balance from breeze-billing and cache it
+ * at `ai:credits:<partnerId>`, the single place that HTTP call is made.
+ *
+ * Never throws: every failure comes back as an `ok: false` variant, including
+ * "no billing service configured", which is the self-hosted default rather
+ * than an error. The Redis write is best-effort for the same reason it always
+ * was - a Redis outage must degrade the credits CARD, never the credit GATE
+ * this call primarily exists to feed.
+ */
+async function fetchAndCachePartnerCredits(partnerId: string): Promise<PartnerCreditsFetch> {
+  const billingUrl = process.env.BILLING_SERVICE_URL;
+  const billingKey = process.env.BILLING_SERVICE_API_KEY;
+  if (!billingUrl || !billingKey) return { ok: false, reason: 'unconfigured' };
+
+  try {
+    const res = await fetch(`${billingUrl}/api/internal/partners/${partnerId}/ai-credits`, {
+      headers: { 'Authorization': `Bearer ${billingKey}` },
+    });
+
+    if (!res.ok) return { ok: false, reason: 'http', status: res.status };
+
+    const payload = await res.json() as BillingCreditsPayload;
+
+    // Cached per PARTNER, not per org: the balance is partner-wide.
+    const credits: CachedPartnerCredits = {
+      remaining: payload.remainingCredits,
+      includedBalance: payload.includedBalance ?? 0,
+      purchasedBalance: payload.purchasedBalance ?? 0,
+      fetchedAt: new Date().toISOString(),
+    };
+
+    const redis = getRedis();
+    if (redis) {
+      void redis.set(
+        `ai:credits:${partnerId}`,
+        JSON.stringify(credits),
+        'EX',
+        PARTNER_CREDITS_CACHE_TTL_SECONDS,
+      ).catch(() => undefined);
+    }
+
+    return { ok: true, payload, credits };
+  } catch (error) {
+    return { ok: false, reason: 'transport', error };
+  }
+}
+
 /**
  * Legacy string-or-null facade over {@link checkBillingCreditsDetailed}, kept
  * because a dozen call sites branch on `if (creditError) return 402`. New
@@ -184,86 +277,61 @@ export async function checkBillingCreditsDetailed(
     return null;
   }
 
-  try {
-    const res = await fetch(`${billingUrl}/api/internal/partners/${org.partnerId}/ai-credits`, {
-      headers: { 'Authorization': `Bearer ${billingKey}` },
-    });
+  // #4388 W04: the fetch and the `ai:credits:<partnerId>` cache write both
+  // live in fetchAndCachePartnerCredits, so the gate and the usage page share
+  // one HTTP path and one cache shape. It never throws; the failure variants
+  // are interpreted here, where the orgId needed to tag them is in scope.
+  const result = await fetchAndCachePartnerCredits(org.partnerId);
 
-    if (!res.ok) {
-      // Fail OPEN on purpose (a billing outage must not take AI down for every
-      // tenant) — but no longer fail SILENT: this branch also swallows a 401
-      // from a rotated BILLING_SERVICE_API_KEY, which looks exactly like
-      // "everyone has credits" from here.
+  if (!result.ok) {
+    // Fail OPEN on purpose (a billing outage must not take AI down for every
+    // tenant), but no longer fail SILENT: the HTTP branch also swallows a 401
+    // from a rotated BILLING_SERVICE_API_KEY, which looks exactly like
+    // "everyone has credits" from here.
+    if (result.reason === 'http') {
       console.error(
-        `[AI] Billing credit check returned HTTP ${res.status} for org=${orgId} — allowing the request (fail-open)`,
+        `[AI] Billing credit check returned HTTP ${result.status} for org=${orgId}, allowing the request (fail-open)`,
       );
       reportBillingIssueAtMostHourly(`credits-http:${orgId}`, () => {
         captureMessage('AI credit check failed; gate fell open', {
           eventCode: 'ai_billing_credits_check_failed',
-          tags: { org_id: orgId, ai_billing_http_status: String(res.status) },
+          tags: { org_id: orgId, ai_billing_http_status: String(result.status) },
         });
       });
-      return null;
-    }
-
-    const data = await res.json() as {
-      allowed: boolean;
-      remainingCredits: number;
-      plan: string;
-      /** breeze-billing added these alongside `remainingCredits` (in flight,
-       *  #4388 W04) — optional here so this deploys safely ahead of that
-       *  billing-service rollout; both default to 0 in the cached record
-       *  until the field actually starts arriving. */
-      includedBalance?: number;
-      purchasedBalance?: number;
-    };
-
-    // #4388 W04: cache the latest balance per PARTNER (not per org — the
-    // balance is partner-wide) so getUsageSummary can surface it on
-    // /ai/usage without its own billing-service round trip. Best-effort: a
-    // Redis outage must not affect the credit gate this function exists for.
-    const redis = getRedis();
-    if (redis) {
-      void redis.set(
-        `ai:credits:${org.partnerId}`,
-        JSON.stringify({
-          remaining: data.remainingCredits,
-          includedBalance: data.includedBalance ?? 0,
-          purchasedBalance: data.purchasedBalance ?? 0,
-          fetchedAt: new Date().toISOString(),
-        }),
-        'EX',
-        60,
-      ).catch(() => undefined);
-    }
-
-    if (!data.allowed) {
-      if (['free', 'starter'].includes(data.plan)) {
-        // A plan gate, not a spend cap: nothing about waiting changes it.
-        return denial('plan_gate', 'AI assistant requires the Community plan.');
-      }
-      if (billingSource === 'platform') {
-        return denial(
-          'credits_exhausted',
-          'You are out of AI credits. Purchase more credits to continue.',
-        );
-      }
-    }
-
-    return null;
-  } catch (err) {
-    console.error(
-      `[AI] Billing credit check failed for org=${orgId} — allowing the request (fail-open):`,
-      err instanceof Error ? err.message : String(err),
-    );
-    reportBillingIssueAtMostHourly(`credits-throw:${orgId}`, () => {
-      captureException(err, undefined, {
-        org_id: orgId,
-        ai_billing_http_status: 'transport_error',
+    } else if (result.reason === 'transport') {
+      const err = result.error;
+      console.error(
+        `[AI] Billing credit check failed for org=${orgId}, allowing the request (fail-open):`,
+        err instanceof Error ? err.message : String(err),
+      );
+      reportBillingIssueAtMostHourly(`credits-throw:${orgId}`, () => {
+        captureException(err, undefined, {
+          org_id: orgId,
+          ai_billing_http_status: 'transport_error',
+        });
       });
-    });
+    }
+    // 'unconfigured' cannot be reached here (the env check above returns
+    // first) and is deliberately unreported anyway: see that comment.
     return null;
   }
+
+  const data = result.payload;
+
+  if (!data.allowed) {
+    if (['free', 'starter'].includes(data.plan)) {
+      // A plan gate, not a spend cap: nothing about waiting changes it.
+      return denial('plan_gate', 'AI assistant requires the Community plan.');
+    }
+    if (billingSource === 'platform') {
+      return denial(
+        'credits_exhausted',
+        'You are out of AI credits. Purchase more credits to continue.',
+      );
+    }
+  }
+
+  return null;
 }
 
 /**
@@ -1286,9 +1354,49 @@ async function getRecentCatalogEntryIdForOrg(orgId: string): Promise<string | nu
 }
 
 /**
- * Get usage summary for an org.
+ * Read the partner's platform credit balance for the usage page: cache first,
+ * billing service on a miss.
+ *
+ * Read-through because the cache used to be written only by an actual AI turn
+ * (see {@link PARTNER_CREDITS_CACHE_TTL_SECONDS}), which meant the credits
+ * card essentially never had anything to render. Every failure mode - no
+ * partner row, Redis down, a corrupt cache entry, billing unreachable -
+ * degrades to `null` rather than a 500 on /ai/usage.
  */
-export async function getUsageSummary(orgId: string): Promise<{
+async function readPartnerCreditsForUsage(orgId: string): Promise<CachedPartnerCredits | null> {
+  try {
+    const [org] = await db
+      .select({ partnerId: organizations.partnerId })
+      .from(organizations)
+      .where(eq(organizations.id, orgId))
+      .limit(1);
+    if (!org?.partnerId) return null;
+
+    const redis = getRedis();
+    if (redis) {
+      const raw = await redis.get(`ai:credits:${org.partnerId}`);
+      // A cache hit must NOT hit billing: /ai/usage is polled by the header
+      // cost indicator on every page.
+      if (raw) return JSON.parse(raw) as CachedPartnerCredits;
+    }
+
+    const fetched = await fetchAndCachePartnerCredits(org.partnerId);
+    return fetched.ok ? fetched.credits : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get usage summary for an org.
+ *
+ * `includeCredits` gates the partner-wide credit pool, which an org-scoped
+ * caller must never see: it is the MSP's balance, shared across every one of
+ * its customers, so surfacing it to one customer's users leaks a partner-level
+ * figure across the tenancy boundary. Off by default so a new call site has to
+ * opt in deliberately (see the /ai/usage route).
+ */
+export async function getUsageSummary(orgId: string, options: { includeCredits?: boolean } = {}): Promise<{
   daily: { inputTokens: number; outputTokens: number; totalCostCents: number; messageCount: number };
   monthly: { inputTokens: number; outputTokens: number; totalCostCents: number; messageCount: number };
   budget: {
@@ -1305,12 +1413,12 @@ export async function getUsageSummary(orgId: string): Promise<{
   /** Name of the catalog endpoint the org's most recent session used, or null
    *  for direct-Anthropic / platform-key traffic (#3922 W4). */
   catalogEndpointName: string | null;
-  /** #4388 W04: the partner's platform-credit balance, as last cached by
-   *  checkBillingCreditsDetailed. `null` when billed to the partner's own
-   *  key (BYOK — no platform credits apply), when the org has no partner id,
-   *  or when nothing has been cached yet (no billing service, or the cache
-   *  entry expired/was never written). Never throws. */
-  credits: { remaining: number; includedBalance: number; purchasedBalance: number; fetchedAt: string } | null;
+  /** #4388 W04: the partner's platform-credit balance. `null` unless the
+   *  caller passed `includeCredits` (an org-scoped caller must not see the
+   *  partner-wide pool), when billed to the partner's own key (BYOK: no
+   *  platform credits apply), when the org has no partner id, or when neither
+   *  the cache nor the billing service can produce one. Never throws. */
+  credits: CachedPartnerCredits | null;
   /** #4388: threshold rungs already fired for the org's CURRENT daily and
    *  monthly periods (nothing from prior, rolled-over periods). */
   alerts: {
@@ -1369,26 +1477,13 @@ export async function getUsageSummary(orgId: string): Promise<{
     if (entryId) catalogEndpointName = await getCatalogEntryName(entryId);
   }
 
-  // #4388 W04: the cached partner credit balance. Only meaningful for
-  // platform-billed orgs (a partner_key/BYOK org spends against its own
-  // Anthropic account, not platform credits). Wrapped so a Redis outage, a
-  // missing/deleted org row, or a corrupt cache entry all degrade to `null`
-  // rather than a 500 on /ai/usage.
-  let credits: { remaining: number; includedBalance: number; purchasedBalance: number; fetchedAt: string } | null = null;
-  if (billedTo === 'platform') {
-    try {
-      const [org] = await db
-        .select({ partnerId: organizations.partnerId })
-        .from(organizations)
-        .where(eq(organizations.id, orgId))
-        .limit(1);
-      const redis = org?.partnerId ? getRedis() : null;
-      const raw = redis ? await redis.get(`ai:credits:${org?.partnerId}`) : null;
-      if (raw) credits = JSON.parse(raw);
-    } catch {
-      credits = null;
-    }
-  }
+  // #4388 W04: the partner credit balance. Withheld from org-scoped callers
+  // (see the `includeCredits` note on this function), and only meaningful for
+  // platform-billed orgs at all - a partner_key/BYOK org spends against its
+  // own Anthropic account, not platform credits.
+  const credits = options.includeCredits && billedTo === 'platform'
+    ? await readPartnerCreditsForUsage(orgId)
+    : null;
 
   return {
     daily: {

--- a/apps/web/src/components/ai/AiCostIndicator.test.tsx
+++ b/apps/web/src/components/ai/AiCostIndicator.test.tsx
@@ -56,7 +56,7 @@ describe('AiCostIndicator polling behavior', () => {
 });
 
 // #4388 W04: when /ai/usage carries a cached partner credit balance, append
-// it to the same cost-summary text the indicator already shows — no separate
+// it to the same cost-summary text the indicator already shows: no separate
 // UI slot, just a trailing " · N credits" clause.
 describe('AiCostIndicator credit balance (#4388 W04)', () => {
   beforeEach(() => {
@@ -86,6 +86,28 @@ describe('AiCostIndicator credit balance (#4388 W04)', () => {
     });
 
     expect(container.textContent).toContain('1,240 credits');
+  });
+
+  // An exhausted balance is exactly when the clause matters most, so the
+  // suffix must survive `remaining: 0` rather than being dropped the way a
+  // truthiness check on the number would drop it.
+  it('still appends the clause, showing 0, when the balance is exhausted', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({
+        daily: { totalCostCents: 0, messageCount: 0 },
+        monthly: { totalCostCents: 0, messageCount: 0 },
+        budget: null,
+        credits: { remaining: 0, includedBalance: 0, purchasedBalance: 0, fetchedAt: '2026-09-01T00:00:00.000Z' },
+      }),
+    );
+
+    const { container } = render(<AiCostIndicator />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain('0 credits');
   });
 
   it('does not append anything when usage.credits is null', async () => {

--- a/apps/web/src/components/ai/AiCostIndicator.test.tsx
+++ b/apps/web/src/components/ai/AiCostIndicator.test.tsx
@@ -55,6 +55,59 @@ describe('AiCostIndicator polling behavior', () => {
   });
 });
 
+// #4388 W04: when /ai/usage carries a cached partner credit balance, append
+// it to the same cost-summary text the indicator already shows — no separate
+// UI slot, just a trailing " · N credits" clause.
+describe('AiCostIndicator credit balance (#4388 W04)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    useAuthStoreMock.mockImplementation((selector: any) => selector({ isAuthenticated: true }));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('appends the credit balance to the cost summary when usage.credits is present', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({
+        daily: { totalCostCents: 0, messageCount: 0 },
+        monthly: { totalCostCents: 0, messageCount: 0 },
+        budget: null,
+        credits: { remaining: 1240, includedBalance: 0, purchasedBalance: 1240, fetchedAt: '2026-09-01T00:00:00.000Z' },
+      }),
+    );
+
+    const { container } = render(<AiCostIndicator />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain('1,240 credits');
+  });
+
+  it('does not append anything when usage.credits is null', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({
+        daily: { totalCostCents: 0, messageCount: 0 },
+        monthly: { totalCostCents: 0, messageCount: 0 },
+        budget: null,
+        credits: null,
+      }),
+    );
+
+    const { container } = render(<AiCostIndicator />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).not.toContain('credits');
+  });
+});
+
 describe('AiCostIndicator post-turn refresh (defect: stale header through a completed exchange)', () => {
   beforeEach(() => {
     vi.useFakeTimers();

--- a/apps/web/src/components/ai/AiCostIndicator.tsx
+++ b/apps/web/src/components/ai/AiCostIndicator.tsx
@@ -15,6 +15,9 @@ interface UsageData {
     monthlyUsedCents: number;
     dailyUsedCents: number;
   } | null;
+  /** #4388 W04: the partner's cached platform-credit balance. `null`/absent
+   *  when BYOK, no partner id, or nothing cached yet. */
+  credits?: { remaining: number; includedBalance: number; purchasedBalance: number; fetchedAt: string } | null;
 }
 
 interface AiCostIndicatorProps {
@@ -114,9 +117,11 @@ export default function AiCostIndicator({
     ? Math.min((monthlyUsed / monthlyBudget) * 100, 100)
     : 0;
 
-  const costDisplay = monthlyBudget
-    ? `${formatCurrency(monthlyUsed / 100)} / ${formatCurrency(monthlyBudget / 100)}`
-    : `${formatCurrency(monthlyUsed / 100)} this month`;
+  const costDisplay = (
+    monthlyBudget
+      ? `${formatCurrency(monthlyUsed / 100)} / ${formatCurrency(monthlyBudget / 100)}`
+      : `${formatCurrency(monthlyUsed / 100)} this month`
+  ) + (usage.credits ? ` · ${usage.credits.remaining.toLocaleString()} credits` : '');
 
   const barColor =
     percentage > 90

--- a/apps/web/src/components/ai/AiCostIndicator.tsx
+++ b/apps/web/src/components/ai/AiCostIndicator.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { Coins } from "lucide-react";
 import { fetchWithAuth, useAuthStore } from "../../stores/auth";
 import { cn, widthPercentClass } from "@/lib/utils";
-import { formatCurrency } from "@/lib/i18n/format";
+import { formatCurrency, formatNumber } from "@/lib/i18n/format";
 import { useTranslation } from "react-i18next";
 
 interface UsageData {
@@ -121,7 +121,7 @@ export default function AiCostIndicator({
     monthlyBudget
       ? `${formatCurrency(monthlyUsed / 100)} / ${formatCurrency(monthlyBudget / 100)}`
       : `${formatCurrency(monthlyUsed / 100)} this month`
-  ) + (usage.credits ? ` · ${usage.credits.remaining.toLocaleString()} credits` : '');
+  ) + (usage.credits ? ` · ${formatNumber(usage.credits.remaining)} credits` : '');
 
   const barColor =
     percentage > 90

--- a/apps/web/src/components/settings/AiUsagePage.test.tsx
+++ b/apps/web/src/components/settings/AiUsagePage.test.tsx
@@ -83,7 +83,7 @@ describe('AiUsagePage billedTo indicator', () => {
 });
 
 // #4388 W04: the credits StatCard only appears when the API actually sent a
-// cached partner balance — the existing `usageBody()` fixture never sets it,
+// cached partner balance: the existing `usageBody()` fixture never sets it,
 // so every other describe block in this file keeps proving the card stays
 // hidden by default.
 describe('AiUsagePage credits stat card (#4388 W04)', () => {
@@ -101,6 +101,17 @@ describe('AiUsagePage credits stat card (#4388 W04)', () => {
 
     await waitFor(() => expect(screen.getByText('Breeze AI credits remaining')).toBeInTheDocument());
     expect(screen.getByText('1,240')).toBeInTheDocument();
+  });
+
+  // A zero balance is exactly when the card matters most: the object is
+  // present, so the card must render "0" rather than vanish the way a
+  // truthiness check on `remaining` would make it.
+  it('still renders the card, showing 0, when the balance is exhausted', async () => {
+    mockUsageWithCredits({ remaining: 0, includedBalance: 0, purchasedBalance: 0, fetchedAt: '2026-09-01T00:00:00.000Z' });
+    render(<AiUsagePage />);
+
+    await waitFor(() => expect(screen.getByText('Breeze AI credits remaining')).toBeInTheDocument());
+    expect(screen.getByText('0')).toBeInTheDocument();
   });
 
   it('does not render the credits stat card when usage.credits is null', async () => {

--- a/apps/web/src/components/settings/AiUsagePage.test.tsx
+++ b/apps/web/src/components/settings/AiUsagePage.test.tsx
@@ -82,6 +82,44 @@ describe('AiUsagePage billedTo indicator', () => {
   });
 });
 
+// #4388 W04: the credits StatCard only appears when the API actually sent a
+// cached partner balance — the existing `usageBody()` fixture never sets it,
+// so every other describe block in this file keeps proving the card stays
+// hidden by default.
+describe('AiUsagePage credits stat card (#4388 W04)', () => {
+  function mockUsageWithCredits(credits: { remaining: number; includedBalance: number; purchasedBalance: number; fetchedAt: string } | null) {
+    fetchWithAuth.mockImplementation((url: string) => {
+      if (url === '/ai/usage') return Promise.resolve(jsonRes({ ...usageBody(), credits }));
+      if (url.startsWith('/ai/admin/sessions')) return Promise.resolve(jsonRes({ data: [] }));
+      return Promise.resolve(jsonRes({ data: [] }));
+    });
+  }
+
+  it('renders the credits remaining stat card when usage.credits is present', async () => {
+    mockUsageWithCredits({ remaining: 1240, includedBalance: 0, purchasedBalance: 1240, fetchedAt: '2026-09-01T00:00:00.000Z' });
+    render(<AiUsagePage />);
+
+    await waitFor(() => expect(screen.getByText('Breeze AI credits remaining')).toBeInTheDocument());
+    expect(screen.getByText('1,240')).toBeInTheDocument();
+  });
+
+  it('does not render the credits stat card when usage.credits is null', async () => {
+    mockUsageWithCredits(null);
+    render(<AiUsagePage />);
+
+    await waitFor(() => expect(screen.getByText('Budget Configuration')).toBeInTheDocument());
+    expect(screen.queryByText('Breeze AI credits remaining')).toBeNull();
+  });
+
+  it('does not render the credits stat card when the response omits credits (older API)', async () => {
+    mockUsage('platform');
+    render(<AiUsagePage />);
+
+    await waitFor(() => expect(screen.getByText('Budget Configuration')).toBeInTheDocument());
+    expect(screen.queryByText('Breeze AI credits remaining')).toBeNull();
+  });
+});
+
 describe('AiUsagePage effective-settings parallel fetch', () => {
   beforeEach(() => {
     orgState.currentOrgId = 'org-1';

--- a/apps/web/src/components/settings/AiUsagePage.tsx
+++ b/apps/web/src/components/settings/AiUsagePage.tsx
@@ -262,7 +262,7 @@ export default function AiUsagePage() {
           <StatCard
             icon={Coins}
             label={t('aiUsagePage.creditsRemaining')}
-            value={usage.credits.remaining.toLocaleString()}
+            value={formatNumber(usage.credits.remaining)}
           />
         )}
       </div>

--- a/apps/web/src/components/settings/AiUsagePage.tsx
+++ b/apps/web/src/components/settings/AiUsagePage.tsx
@@ -1,7 +1,7 @@
 import '@/lib/i18n';
 import { useTranslation } from 'react-i18next';
 import { useState, useEffect, useCallback } from 'react';
-import { Bot, DollarSign, Flag, MessageSquare, Zap, Save, Loader2, Lock } from 'lucide-react';
+import { Bot, Coins, DollarSign, Flag, MessageSquare, Zap, Save, Loader2, Lock } from 'lucide-react';
 import { fetchWithAuth } from '../../stores/auth';
 import { useOrgStore } from '../../stores/orgStore';
 import { formatDate, formatDateTime } from '@/lib/dateTimeFormat';
@@ -26,6 +26,9 @@ interface UsageData {
    *  billed to the partner key via a platform-vetted third-party endpoint
    *  rather than direct Anthropic (#3922 W4). */
   catalogEndpointName?: string | null;
+  /** #4388 W04: the partner's cached platform-credit balance. `null`/absent
+   *  when BYOK, no partner id, or nothing cached yet. */
+  credits?: { remaining: number; includedBalance: number; purchasedBalance: number; fetchedAt: string } | null;
   budget: {
     enabled: boolean;
     monthlyBudgetCents: number | null;
@@ -255,6 +258,13 @@ export default function AiUsagePage() {
             output: formatTokens(usage?.monthly.outputTokens ?? 0)
           })}
         />
+        {usage?.credits && (
+          <StatCard
+            icon={Coins}
+            label={t('aiUsagePage.creditsRemaining')}
+            value={usage.credits.remaining.toLocaleString()}
+          />
+        )}
       </div>
 
       {usage?.alerts?.fired?.length ? (

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -1333,7 +1333,7 @@
     "likeActionPlanPlusLiveScreenshotsBetweenStepsAndAPersist": "Wie ein Aktionsplan, plus Live-Screenshots zwischen den Schritten und eine dauerhafte Stopp-Schaltfläche.",
     "untitled": "Ohne Titel",
     "billedToPartnerKey": "Abrechnung über Ihren Schlüssel — die KI-Nutzung läuft über Ihr eigenes Anthropic-Konto, nicht über Breeze-KI-Guthaben",
-    "billedToPartnerKeyViaEndpoint": "Abrechnung über Ihren Schlüssel via {{name}} — die KI-Nutzung läuft über Ihr eigenes Anthropic-Konto, nicht über Breeze-KI-Guthaben",
+    "billedToPartnerKeyViaEndpoint": "Abrechnung über Ihren Schlüssel via {{name}}: die KI-Nutzung läuft über Ihr eigenes Anthropic-Konto, nicht über Breeze-KI-Guthaben",
     "creditsRemaining": "Verbleibendes Breeze-KI-Guthaben"
   },
   "aiAgentsPage": {

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -1333,7 +1333,8 @@
     "likeActionPlanPlusLiveScreenshotsBetweenStepsAndAPersist": "Wie ein Aktionsplan, plus Live-Screenshots zwischen den Schritten und eine dauerhafte Stopp-Schaltfläche.",
     "untitled": "Ohne Titel",
     "billedToPartnerKey": "Abrechnung über Ihren Schlüssel — die KI-Nutzung läuft über Ihr eigenes Anthropic-Konto, nicht über Breeze-KI-Guthaben",
-    "billedToPartnerKeyViaEndpoint": "Abrechnung über Ihren Schlüssel via {{name}} — die KI-Nutzung läuft über Ihr eigenes Anthropic-Konto, nicht über Breeze-KI-Guthaben"
+    "billedToPartnerKeyViaEndpoint": "Abrechnung über Ihren Schlüssel via {{name}} — die KI-Nutzung läuft über Ihr eigenes Anthropic-Konto, nicht über Breeze-KI-Guthaben",
+    "creditsRemaining": "Verbleibendes Breeze-KI-Guthaben"
   },
   "aiAgentsPage": {
     "schedules": {

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -1333,7 +1333,8 @@
     "likeActionPlanPlusLiveScreenshotsBetweenStepsAndAPersist": "Like Action Plan, plus live screenshots between steps and a persistent Stop button.",
     "untitled": "Untitled",
     "billedToPartnerKey": "Billed to your key — AI usage goes to your own Anthropic account, not Breeze AI credits",
-    "billedToPartnerKeyViaEndpoint": "Billed to your key via {{name}} — AI usage goes to your own Anthropic account, not Breeze AI credits"
+    "billedToPartnerKeyViaEndpoint": "Billed to your key via {{name}} — AI usage goes to your own Anthropic account, not Breeze AI credits",
+    "creditsRemaining": "Breeze AI credits remaining"
   },
   "aiAgentsPage": {
     "schedules": {

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -1333,7 +1333,7 @@
     "likeActionPlanPlusLiveScreenshotsBetweenStepsAndAPersist": "Like Action Plan, plus live screenshots between steps and a persistent Stop button.",
     "untitled": "Untitled",
     "billedToPartnerKey": "Billed to your key — AI usage goes to your own Anthropic account, not Breeze AI credits",
-    "billedToPartnerKeyViaEndpoint": "Billed to your key via {{name}} — AI usage goes to your own Anthropic account, not Breeze AI credits",
+    "billedToPartnerKeyViaEndpoint": "Billed to your key via {{name}}: AI usage goes to your own Anthropic account, not Breeze AI credits",
     "creditsRemaining": "Breeze AI credits remaining"
   },
   "aiAgentsPage": {

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -1333,7 +1333,8 @@
     "likeActionPlanPlusLiveScreenshotsBetweenStepsAndAPersist": "Como Plan de acción, además de capturas de pantalla en vivo entre los pasos y un botón Detener persistente.",
     "untitled": "Sin título",
     "billedToPartnerKey": "Facturado a tu clave: el uso de IA se cobra a tu propia cuenta de Anthropic, no a los créditos de IA de Breeze",
-    "billedToPartnerKeyViaEndpoint": "Facturado a tu clave a través de {{name}}: el uso de IA se cobra a tu propia cuenta de Anthropic, no a los créditos de IA de Breeze"
+    "billedToPartnerKeyViaEndpoint": "Facturado a tu clave a través de {{name}}: el uso de IA se cobra a tu propia cuenta de Anthropic, no a los créditos de IA de Breeze",
+    "creditsRemaining": "Créditos de IA de Breeze restantes"
   },
   "aiAgentsPage": {
     "schedules": {

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -1333,7 +1333,7 @@
     "likeActionPlanPlusLiveScreenshotsBetweenStepsAndAPersist": "Comme Action Plan, plus des captures d’écran en direct entre les étapes et un bouton Stop persistant.",
     "untitled": "Sans titre",
     "billedToPartnerKey": "Facturé sur votre clé — l'utilisation de l'IA est portée à votre propre compte Anthropic, et non aux crédits IA de Breeze",
-    "billedToPartnerKeyViaEndpoint": "Facturé sur votre clé via {{name}} — l'utilisation de l'IA est portée à votre propre compte Anthropic, et non aux crédits IA de Breeze",
+    "billedToPartnerKeyViaEndpoint": "Facturé sur votre clé via {{name}}: l'utilisation de l'IA est portée à votre propre compte Anthropic, et non aux crédits IA de Breeze",
     "creditsRemaining": "Crédits IA Breeze restants"
   },
   "aiAgentsPage": {

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -1333,7 +1333,8 @@
     "likeActionPlanPlusLiveScreenshotsBetweenStepsAndAPersist": "Comme Action Plan, plus des captures d’écran en direct entre les étapes et un bouton Stop persistant.",
     "untitled": "Sans titre",
     "billedToPartnerKey": "Facturé sur votre clé — l'utilisation de l'IA est portée à votre propre compte Anthropic, et non aux crédits IA de Breeze",
-    "billedToPartnerKeyViaEndpoint": "Facturé sur votre clé via {{name}} — l'utilisation de l'IA est portée à votre propre compte Anthropic, et non aux crédits IA de Breeze"
+    "billedToPartnerKeyViaEndpoint": "Facturé sur votre clé via {{name}} — l'utilisation de l'IA est portée à votre propre compte Anthropic, et non aux crédits IA de Breeze",
+    "creditsRemaining": "Crédits IA Breeze restants"
   },
   "aiAgentsPage": {
     "schedules": {

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -1333,7 +1333,7 @@
     "likeActionPlanPlusLiveScreenshotsBetweenStepsAndAPersist": "Comme Action Plan, plus des captures d’écran en direct entre les étapes et un bouton Stop persistant.",
     "untitled": "Sans titre",
     "billedToPartnerKey": "Facturé sur votre clé — l'utilisation de l'IA est portée à votre propre compte Anthropic, et non aux crédits IA de Breeze",
-    "billedToPartnerKeyViaEndpoint": "Facturé sur votre clé via {{name}} — l'utilisation de l'IA est portée à votre propre compte Anthropic, et non aux crédits IA de Breeze",
+    "billedToPartnerKeyViaEndpoint": "Facturé sur votre clé via {{name}}: l'utilisation de l'IA est portée à votre propre compte Anthropic, et non aux crédits IA de Breeze",
     "creditsRemaining": "Crédits IA Breeze restants"
   },
   "aiAgentsPage": {

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -1333,7 +1333,8 @@
     "likeActionPlanPlusLiveScreenshotsBetweenStepsAndAPersist": "Comme Action Plan, plus des captures d’écran en direct entre les étapes et un bouton Stop persistant.",
     "untitled": "Sans titre",
     "billedToPartnerKey": "Facturé sur votre clé — l'utilisation de l'IA est portée à votre propre compte Anthropic, et non aux crédits IA de Breeze",
-    "billedToPartnerKeyViaEndpoint": "Facturé sur votre clé via {{name}} — l'utilisation de l'IA est portée à votre propre compte Anthropic, et non aux crédits IA de Breeze"
+    "billedToPartnerKeyViaEndpoint": "Facturé sur votre clé via {{name}} — l'utilisation de l'IA est portée à votre propre compte Anthropic, et non aux crédits IA de Breeze",
+    "creditsRemaining": "Crédits IA Breeze restants"
   },
   "aiAgentsPage": {
     "schedules": {

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -1333,7 +1333,8 @@
     "likeActionPlanPlusLiveScreenshotsBetweenStepsAndAPersist": "Come Piano d'azione, più screenshot live tra i passaggi e un pulsante Interrompi persistente.",
     "untitled": "Senza titolo",
     "billedToPartnerKey": "Addebitato sulla tua chiave: l'utilizzo dell'IA va sul tuo account Anthropic, non sui crediti IA di Breeze",
-    "billedToPartnerKeyViaEndpoint": "Addebitato sulla tua chiave tramite {{name}}: l'utilizzo dell'IA va sul tuo account Anthropic, non sui crediti IA di Breeze"
+    "billedToPartnerKeyViaEndpoint": "Addebitato sulla tua chiave tramite {{name}}: l'utilizzo dell'IA va sul tuo account Anthropic, non sui crediti IA di Breeze",
+    "creditsRemaining": "Crediti IA Breeze rimanenti"
   },
   "aiAgentsPage": {
     "schedules": {

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -1333,7 +1333,7 @@
     "likeActionPlanPlusLiveScreenshotsBetweenStepsAndAPersist": "Como o Plano de Ação, além de capturas de tela ao vivo entre as etapas e um botão Parar persistente.",
     "untitled": "Sem título",
     "billedToPartnerKey": "Cobrado na sua chave — o uso de IA vai para a sua própria conta da Anthropic, não para os créditos de IA do Breeze",
-    "billedToPartnerKeyViaEndpoint": "Cobrado na sua chave via {{name}} — o uso de IA vai para a sua própria conta da Anthropic, não para os créditos de IA do Breeze",
+    "billedToPartnerKeyViaEndpoint": "Cobrado na sua chave via {{name}}: o uso de IA vai para a sua própria conta da Anthropic, não para os créditos de IA do Breeze",
     "creditsRemaining": "Créditos de IA Breeze restantes"
   },
   "aiAgentsPage": {

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -1333,7 +1333,8 @@
     "likeActionPlanPlusLiveScreenshotsBetweenStepsAndAPersist": "Como o Plano de Ação, além de capturas de tela ao vivo entre as etapas e um botão Parar persistente.",
     "untitled": "Sem título",
     "billedToPartnerKey": "Cobrado na sua chave — o uso de IA vai para a sua própria conta da Anthropic, não para os créditos de IA do Breeze",
-    "billedToPartnerKeyViaEndpoint": "Cobrado na sua chave via {{name}} — o uso de IA vai para a sua própria conta da Anthropic, não para os créditos de IA do Breeze"
+    "billedToPartnerKeyViaEndpoint": "Cobrado na sua chave via {{name}} — o uso de IA vai para a sua própria conta da Anthropic, não para os créditos de IA do Breeze",
+    "creditsRemaining": "Créditos de IA Breeze restantes"
   },
   "aiAgentsPage": {
     "schedules": {

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -1333,7 +1333,7 @@
     "likeActionPlanPlusLiveScreenshotsBetweenStepsAndAPersist": "Eylem Planını beğenin, artı adımlar arasında canlı ekran görüntüleri ve kalıcı Durdur düğmesi.",
     "untitled": "Başlıksız",
     "billedToPartnerKey": "Anahtarınıza faturalandırılır — yapay zeka kullanımı Breeze yapay zeka kredilerine değil, kendi Anthropic hesabınıza yansır",
-    "billedToPartnerKeyViaEndpoint": "{{name}} üzerinden anahtarınıza faturalandırılır — yapay zeka kullanımı Breeze yapay zeka kredilerine değil, kendi Anthropic hesabınıza yansır",
+    "billedToPartnerKeyViaEndpoint": "{{name}} üzerinden anahtarınıza faturalandırılır: yapay zeka kullanımı Breeze yapay zeka kredilerine değil, kendi Anthropic hesabınıza yansır",
     "creditsRemaining": "Kalan Breeze yapay zeka kredisi"
   },
   "aiAgentsPage": {

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -1333,7 +1333,8 @@
     "likeActionPlanPlusLiveScreenshotsBetweenStepsAndAPersist": "Eylem Planını beğenin, artı adımlar arasında canlı ekran görüntüleri ve kalıcı Durdur düğmesi.",
     "untitled": "Başlıksız",
     "billedToPartnerKey": "Anahtarınıza faturalandırılır — yapay zeka kullanımı Breeze yapay zeka kredilerine değil, kendi Anthropic hesabınıza yansır",
-    "billedToPartnerKeyViaEndpoint": "{{name}} üzerinden anahtarınıza faturalandırılır — yapay zeka kullanımı Breeze yapay zeka kredilerine değil, kendi Anthropic hesabınıza yansır"
+    "billedToPartnerKeyViaEndpoint": "{{name}} üzerinden anahtarınıza faturalandırılır — yapay zeka kullanımı Breeze yapay zeka kredilerine değil, kendi Anthropic hesabınıza yansır",
+    "creditsRemaining": "Kalan Breeze yapay zeka kredisi"
   },
   "aiAgentsPage": {
     "schedules": {


### PR DESCRIPTION
Wave 4 (breeze side) of #4388, pre-cap AI budget alerts: the partner credit balance on `GET /ai/usage`, the AI usage page, and the AI cost indicator. Spec section 5.3 of `docs/superpowers/specs/ai-mcp/2026-09-01-ai-budget-threshold-alerts-design.md`. Companion billing PR: LanternOps/breeze-billing#15.

Stacked on #4517 (W03), which is stacked on #4496 (W02) and #4487 (W01). Base is `feature/4388-ai-budget-alerts/wave-4391`; retarget to `main` once the parents merge. CI is dispatched manually for this branch because the base is not `main`.

Closes #4392

## What changed
- `checkBillingCreditsDetailed` and `getUsageSummary` share one helper that fetches the partner balance from breeze-billing and caches it in Redis under `ai:credits:<partnerId>` for 15 minutes; `getUsageSummary` fills the cache on a miss. The helper never throws.
- `GET /ai/usage` returns `credits: { remaining, includedBalance, purchasedBalance, fetchedAt } | null`. It is `null` for organization-scoped tokens (the pool is partner-wide), for orgs billed to their own key, when there is no billing service, and on any cache or transport error.
- Web: a "Breeze AI credits remaining" stat card on the AI usage page and a credits suffix in the AI cost indicator, both formatted with the app locale, both rendered when the value is zero. Locale key in all eight `settings.json` files.

## Safe to merge before the billing deploy
breeze-billing `main` already returns `includedBalance` and `purchasedBalance` from `GET /api/internal/partners/:id/ai-credits`, so the response shape is unchanged; only the alerting behind it lands with the billing PR. Recommended order is billing first, then this.

## Verification
- API: `aiCostTracker`, `ai_admin`, `ai.ticket` suites green (144 tests); `tsc --noEmit` clean; eslint clean.
- Web: 97 files / 1101 tests including the whole `src/lib/i18n` guard directory; `astro check` 0 errors; eslint clean.
- Reviews: per-task review, an opus whole-branch review across both repos, one fix wave, and a scoped re-review.

## Follow-ups (not in this PR)
- The hardcoded English "credits" word in the AI cost indicator suffix (matches the existing "this month" in the same expression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyYQpa3oMfjMRSjET5WnEr
