### PR TITLE
fix(mobile): App Review layout pass (ticket activity, alert detail, onboarding, MFA, status pill)

### DIFF
--- a/apps/mobile/src/components/TimerBar.tsx
+++ b/apps/mobile/src/components/TimerBar.tsx
@@ -390,7 +390,7 @@ export function TimerBar({ onOpenTimesheet }: { onOpenTimesheet?: () => void } =
     ? tickets.find((candidate) => candidate.id === running.ticketId)
     : undefined;
   const label = running?.ticketId
-    ? ticketRef({ id: running.ticketId, internalNumber: ticket?.internalNumber ?? null })
+    ? (ticketRef({ internalNumber: ticket?.internalNumber ?? null }) ?? ticket?.subject ?? 'Ticket')
     : 'No ticket';
 
   const bar = (

--- a/apps/mobile/src/lib/osLabel.test.ts
+++ b/apps/mobile/src/lib/osLabel.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+
+// No mocks needed: osLabel lives in lib/ and imports nothing, so it loads in the
+// Vitest environment directly. (It previously lived in DeviceDetailScreen.tsx,
+// where reaching it meant stubbing every native import that screen pulls in.)
+import { osLabel } from './osLabel';
+
+describe('osLabel', () => {
+  it('maps every known OS_TYPES value (packages/shared/src/constants) to its product name', () => {
+    expect(osLabel('windows')).toBe('Windows');
+    expect(osLabel('macos')).toBe('macOS');
+    expect(osLabel('linux')).toBe('Linux');
+  });
+
+  it('is case-insensitive on the raw enum value', () => {
+    expect(osLabel('WINDOWS')).toBe('Windows');
+    expect(osLabel('MacOS')).toBe('macOS');
+  });
+
+  it('falls back to a capitalized form of an unrecognized value, rather than hiding it', () => {
+    expect(osLabel('freebsd')).toBe('Freebsd');
+    expect(osLabel('')).toBe('');
+  });
+});

--- a/apps/mobile/src/lib/osLabel.ts
+++ b/apps/mobile/src/lib/osLabel.ts
@@ -1,0 +1,28 @@
+/**
+ * Display name for a device's OS.
+ *
+ * `device.os` / `MobileDeviceRecord.osType` carries the raw backend enum
+ * (`windows` / `macos` / `linux` — see OS_TYPES in packages/shared/src/constants)
+ * rather than something a technician should read. Both device screens render it,
+ * so the mapping lives here rather than in either screen: a helper imported from
+ * a sibling *screen* makes the list screen depend on the detail screen's module
+ * graph for one pure string function.
+ *
+ * Lives in lib/ (next to relativeTime.ts) and imports nothing, so it stays
+ * node-testable without dragging react-native into the Vitest runner.
+ */
+export function osLabel(osType: string): string {
+  switch (osType.toLowerCase()) {
+    case 'windows':
+      return 'Windows';
+    case 'macos':
+      return 'macOS';
+    case 'linux':
+      return 'Linux';
+    default:
+      // Unrecognized value (a future OS type, or bad data) — show it rather
+      // than hide it, but at least capitalized so it doesn't read as a raw
+      // enum slug.
+      return osType.charAt(0).toUpperCase() + osType.slice(1);
+  }
+}

--- a/apps/mobile/src/navigation/MainNavigator.tsx
+++ b/apps/mobile/src/navigation/MainNavigator.tsx
@@ -153,7 +153,14 @@ function SystemsStackNavigator() {
       <SystemsStack.Screen
         name="SystemsDevices"
         component={DevicesListScreen}
-        options={{ headerShown: false }}
+        // `title` still drives the BACK BUTTON label on whatever screen gets
+        // pushed on top of this one, even with the header itself hidden here —
+        // react-navigation falls back to the raw ROUTE NAME ("SystemsDevices",
+        // no space) when a headerless screen has no title. Every other
+        // headerless route in this file (Systems, Tickets, Timesheet) happens
+        // to already be a single readable word, so this is the only one that
+        // needed an explicit title.
+        options={{ headerShown: false, title: 'Devices' }}
       />
       <SystemsStack.Screen
         name="SystemsAlertDetail"

--- a/apps/mobile/src/screens/alerts/AlertDetailScreen.tsx
+++ b/apps/mobile/src/screens/alerts/AlertDetailScreen.tsx
@@ -4,6 +4,7 @@ import { Alert, Pressable, ScrollView, Text, View } from 'react-native';
 import { useAppDispatch } from '../../store';
 import { acknowledgeAlertAsync } from '../../store/alertsSlice';
 import type { Alert as AlertModel } from '../../services/api';
+import { relativeTime } from '../../lib/relativeTime';
 import {
   useApprovalTheme,
   palette,
@@ -11,6 +12,17 @@ import {
   spacing,
   type,
 } from '../../theme';
+
+/**
+ * Relative time reads at a glance, but an absolute timestamp is genuinely
+ * useful on a detail screen, so this keeps both rather than picking one (same
+ * approach as DeviceDetailScreen's LAST SEEN row).
+ */
+function formatTimestamp(iso: string): string {
+  const rel = relativeTime(iso);
+  const abs = new Date(iso).toLocaleString();
+  return rel ? `${rel} · ${abs}` : abs;
+}
 
 interface Props {
   route: { params: { alert: AlertModel } };
@@ -139,12 +151,6 @@ export function AlertDetailScreen({ route }: Props) {
         {alert.message}
       </Text>
 
-      <DetailRow
-        label="TYPE"
-        value={alert.type}
-        textHi={theme.textHi}
-        textLo={theme.textLo}
-      />
       {alert.deviceName ? (
         <DetailRow
           label="DEVICE"
@@ -155,14 +161,14 @@ export function AlertDetailScreen({ route }: Props) {
       ) : null}
       <DetailRow
         label="CREATED"
-        value={new Date(alert.createdAt).toLocaleString()}
+        value={formatTimestamp(alert.createdAt)}
         textHi={theme.textHi}
         textLo={theme.textLo}
       />
       {alert.acknowledgedAt ? (
         <DetailRow
           label="ACKNOWLEDGED AT"
-          value={new Date(alert.acknowledgedAt).toLocaleString()}
+          value={formatTimestamp(alert.acknowledgedAt)}
           textHi={theme.textHi}
           textLo={theme.textLo}
         />

--- a/apps/mobile/src/screens/auth/MfaChallengeScreen.test.ts
+++ b/apps/mobile/src/screens/auth/MfaChallengeScreen.test.ts
@@ -1,5 +1,10 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
+import ts from 'typescript';
 import type { MfaChallenge } from '../../services/api';
+import { type as typeTokens } from '../../theme/typography';
 import {
   getInitialNativeMfaMethod,
   getSupportedNativeMfaMethods,
@@ -49,5 +54,79 @@ describe('MfaChallengeScreen presentation contract', () => {
     const raw = '  ABCD EFGH-IJKL  ';
     expect(normalizeNativeMfaInput('recovery', raw)).toBe(raw);
     expect(normalizeNativeMfaSubmission('recovery', raw)).toBe('ABCD EFGH-IJKL');
+  });
+});
+
+// MfaChallengeScreen.tsx cannot be imported here: it (transitively, via the
+// store and services layers) pulls in react-native, @sentry/react-native,
+// react-native-svg, react-native-reanimated, expo-haptics and expo-secure-store
+// — none of which have a test runtime under this project's vitest config
+// (see the comment atop vitest.config.ts: component .tsx modules are
+// deliberately kept out of the test graph). So instead of rendering the
+// screen, this parses its real source with the TypeScript compiler API and
+// inspects the literal style object the code-entry TextInput actually uses —
+// that keeps the assertion honest against the shipped code without requiring
+// a React Native test runtime.
+describe('MfaChallengeScreen code input style', () => {
+  function findCodeInputStyleOverride(): { fontSize?: number; lineHeight?: number } {
+    const sourcePath = join(dirname(fileURLToPath(import.meta.url)), 'MfaChallengeScreen.tsx');
+    const source = readFileSync(sourcePath, 'utf8');
+    const sourceFile = ts.createSourceFile(
+      sourcePath,
+      source,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TSX,
+    );
+
+    let override: { fontSize?: number; lineHeight?: number } | null = null;
+
+    function visit(node: ts.Node) {
+      if (ts.isObjectLiteralExpression(node)) {
+        const hasFontSize = node.properties.some(
+          (p) =>
+            ts.isPropertyAssignment(p) && ts.isIdentifier(p.name) && p.name.text === 'fontSize',
+        );
+        if (hasFontSize) {
+          const found: { fontSize?: number; lineHeight?: number } = {};
+          for (const prop of node.properties) {
+            if (!ts.isPropertyAssignment(prop) || !ts.isIdentifier(prop.name)) continue;
+            if (
+              (prop.name.text === 'fontSize' || prop.name.text === 'lineHeight') &&
+              ts.isNumericLiteral(prop.initializer)
+            ) {
+              found[prop.name.text as 'fontSize' | 'lineHeight'] = Number(prop.initializer.text);
+            }
+          }
+          override = found;
+        }
+      }
+      ts.forEachChild(node, visit);
+    }
+    visit(sourceFile);
+
+    if (!override) {
+      throw new Error(
+        'Could not find the code-input style override (an inline object literal with a ' +
+          '`fontSize` property) in MfaChallengeScreen.tsx — did the style structure change?',
+      );
+    }
+    return override;
+  }
+
+  it('gives the code input a lineHeight tall enough for its overridden fontSize on iOS', () => {
+    const override = findCodeInputStyleOverride();
+
+    // The code input's style is `[type.mono, { ...override }]` — React Native
+    // flattens that left-to-right, so an explicit `lineHeight` in the override
+    // wins; otherwise type.mono's lineHeight (sized for mono's own 14pt
+    // fontSize) leaks through unchanged. At a 22pt override fontSize with a
+    // 22pt inherited lineHeight, iOS clips the glyphs from the top — exactly
+    // the reported bug. Require real headroom, not just fontSize <= lineHeight.
+    expect(override.fontSize).toBe(22);
+    const effectiveFontSize = override.fontSize as number;
+    const effectiveLineHeight = override.lineHeight ?? typeTokens.mono.lineHeight;
+
+    expect(effectiveLineHeight).toBeGreaterThanOrEqual(effectiveFontSize + 4);
   });
 });

--- a/apps/mobile/src/screens/auth/MfaChallengeScreen.tsx
+++ b/apps/mobile/src/screens/auth/MfaChallengeScreen.tsx
@@ -224,6 +224,12 @@ export function MfaChallengeScreen() {
                     minHeight: 48,
                     flex: 1,
                     fontSize: 22,
+                    // type.mono's lineHeight (22) is sized for its own 14pt
+                    // fontSize, not this input's 22pt override — left as-is
+                    // it gives zero headroom above the font size, and iOS
+                    // clips glyphs from the top when that happens. 28 matches
+                    // the app's own 22pt/28 line-height pairing (type.title).
+                    lineHeight: 28,
                     letterSpacing: isRecovery ? 1 : 6,
                     textAlign: 'center',
                   },

--- a/apps/mobile/src/screens/chat/components/SettingsSheet.tsx
+++ b/apps/mobile/src/screens/chat/components/SettingsSheet.tsx
@@ -410,6 +410,9 @@ function SheetBody({
           paddingTop: insetTop + spacing[6],
           paddingBottom: spacing[8],
         }}
+        // The bar itself is drawn over by the cap below, so keep the scroll
+        // indicator out from under it rather than letting it run to y=0.
+        scrollIndicatorInsets={{ top: insetTop }}
       >
         <View
           style={{
@@ -551,6 +554,24 @@ function SheetBody({
           {buildVersion}
         </Text>
       </View>
+
+      {/* `insetTop` only positions the RESTING layout — it does nothing once the
+          list is scrolled, and the avatar, account name and email then ride up
+          into the status bar and collide with the clock and the Dynamic Island.
+          An opaque cap in the sheet's own surface colour, painted last so it
+          sits above the list, gives that strip something to disappear behind.
+          Not pressable: taps in the status-bar strip belong to the OS. */}
+      <View
+        pointerEvents="none"
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          height: insetTop,
+          backgroundColor: theme.bg1,
+        }}
+      />
     </View>
   );
 }

--- a/apps/mobile/src/screens/chat/components/StatusPill.test.ts
+++ b/apps/mobile/src/screens/chat/components/StatusPill.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Alert } from '../../../services/api';
+
+// StatusPill.tsx is a screen component (imports react-native, reanimated,
+// react-navigation, ...) and this app has no RN test renderer configured for
+// vitest (see the "Pure-logic smoke tests only" note in vitest.config.ts —
+// component imports are deliberately kept out of it). Every direct import of
+// StatusPill.tsx is stubbed here so the module can load far enough to expose
+// `selectAlertCounts`, which is what this suite actually exercises.
+vi.mock('react-native', () => ({
+  Pressable: () => null,
+  Text: () => null,
+  View: () => null,
+}));
+vi.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: vi.fn() }),
+}));
+vi.mock('../../../theme', () => ({
+  useApprovalTheme: () => ({}),
+  palette: { deny: {}, warning: {}, brand: {} },
+  radii: {},
+  spacing: {},
+  type: {},
+}));
+vi.mock('../../../lib/motion', () => ({ haptic: { tap: vi.fn() } }));
+vi.mock('../../../lib/useNetworkConnected', () => ({ useNetworkConnected: () => true }));
+// A trivial stand-in for the real store: selectAlertCounts is built on top of
+// `selectAlerts`, and this suite only needs that one selector to behave like
+// the real one (read `state.alerts.alerts`) — pulling in the actual redux
+// store would drag services/api.ts (expo-secure-store, ...) in with it.
+vi.mock('../../../store', () => ({
+  useAppSelector: vi.fn(),
+  selectAlerts: (state: { alerts: { alerts: unknown[] } }) => state.alerts.alerts,
+}));
+
+const { selectAlertCounts } = await import('./StatusPill');
+
+// TypeScript checks this file against the REAL `selectAlerts` / `Alert`
+// types (vi.mock only swaps the runtime module, not its type), so the
+// fixtures below carry the full `Alert` and `AlertsState` shapes even though
+// selectAlertCounts only ever reads `acknowledged` and `severity`.
+function alert(over: Partial<Alert> & Pick<Alert, 'acknowledged' | 'severity'>, id: string): Alert {
+  return {
+    id,
+    title: 'Alert',
+    message: 'Alert',
+    type: 'alert',
+    createdAt: '2026-08-18T00:00:00Z',
+    updatedAt: '2026-08-18T00:00:00Z',
+    ...over,
+  };
+}
+
+function stateWith(alerts: Alert[]) {
+  return {
+    alerts: { alerts, isLoading: false, error: null, filter: 'all' as const, lastFetched: null },
+  };
+}
+
+describe('selectAlertCounts', () => {
+  it('counts unacknowledged critical and (high | medium) severities, skipping acknowledged and low', () => {
+    const alerts: Alert[] = [
+      alert({ acknowledged: false, severity: 'critical' }, '1'),
+      alert({ acknowledged: false, severity: 'critical' }, '2'),
+      alert({ acknowledged: true, severity: 'critical' }, '3'), // acknowledged -> skipped
+      alert({ acknowledged: false, severity: 'high' }, '4'),
+      alert({ acknowledged: false, severity: 'medium' }, '5'),
+      alert({ acknowledged: false, severity: 'low' }, '6'), // low -> not counted at all
+      alert({ acknowledged: true, severity: 'high' }, '7'), // acknowledged -> skipped
+    ];
+
+    expect(selectAlertCounts(stateWith(alerts))).toEqual({ critical: 2, warning: 2 });
+  });
+
+  it('returns the SAME object reference across calls when the alerts array reference is unchanged', () => {
+    // This is the regression case for the "Selector ... returned a different
+    // result" warning: the inline selector StatusPill used to pass allocated
+    // a brand-new { critical, warning } object on every call, so useSelector
+    // saw a new reference (and re-rendered) even when nothing relevant
+    // changed. A real dispatch replaces the root state object on every
+    // action, so the fix has to be robust to a NEW outer `state` wrapping
+    // the SAME `alerts.alerts` array — which is exactly what happens when an
+    // unrelated slice (tickets, auth, timer ticks, ...) updates.
+    const alerts: Alert[] = [alert({ acknowledged: false, severity: 'critical' }, '1')];
+    const state1 = stateWith(alerts);
+    const state2 = stateWith(alerts); // new outer object, same inner array reference
+
+    const result1 = selectAlertCounts(state1);
+    const result2 = selectAlertCounts(state2);
+
+    expect(result2).toBe(result1);
+  });
+
+  it('recomputes (a new reference) once the alerts array reference actually changes', () => {
+    const alerts1: Alert[] = [alert({ acknowledged: false, severity: 'critical' }, '1')];
+    const alerts2: Alert[] = [alert({ acknowledged: false, severity: 'critical' }, '1')];
+
+    const result1 = selectAlertCounts(stateWith(alerts1));
+    const result2 = selectAlertCounts(stateWith(alerts2));
+
+    expect(result2).toEqual(result1);
+    expect(result2).not.toBe(result1);
+  });
+});

--- a/apps/mobile/src/screens/chat/components/StatusPill.tsx
+++ b/apps/mobile/src/screens/chat/components/StatusPill.tsx
@@ -1,12 +1,38 @@
 import { Pressable, Text, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
+import { createSelector } from '@reduxjs/toolkit';
 
 import { useApprovalTheme, palette, radii, spacing, type } from '../../../theme';
-import { useAppSelector } from '../../../store';
+import { useAppSelector, selectAlerts } from '../../../store';
 import { haptic } from '../../../lib/motion';
 import { useNetworkConnected } from '../../../lib/useNetworkConnected';
 import type { MainTabParamList } from '../../../navigation/MainNavigator';
+
+/**
+ * Module-scope (not per-render) so `createSelector`'s memoization actually
+ * holds: it caches on the identity of `selectAlerts(state)`, i.e. the alerts
+ * array reference. Redux/immer only gives that array a new reference when an
+ * alerts-slice reducer actually ran, so any unrelated dispatch (tickets,
+ * auth, timer ticks, ...) returns the SAME `{ critical, warning }` object —
+ * which is what stops useSelector from re-rendering this component on every
+ * store update (the "Selector ... returned a different result" warning).
+ * An inline selector here would allocate a brand-new object every call
+ * regardless of whether the alerts array changed, which is what caused it.
+ */
+// Exported for StatusPill.test.ts, which imports it directly rather than
+// mounting the component (this app has no RN test renderer configured — see
+// vitest.config.ts).
+export const selectAlertCounts = createSelector([selectAlerts], (alerts) => {
+  let critical = 0;
+  let warning = 0;
+  for (const a of alerts) {
+    if (a.acknowledged) continue;
+    if (a.severity === 'critical') critical++;
+    else if (a.severity === 'high' || a.severity === 'medium') warning++;
+  }
+  return { critical, warning };
+});
 
 // Copy ladder, in priority order:
 //   1. Offline → deny-red, "Offline · Approvals still work"  (deferred — needs NetInfo)
@@ -21,17 +47,7 @@ export function StatusPill() {
   const navigation = useNavigation<BottomTabNavigationProp<MainTabParamList>>();
   const connected = useNetworkConnected();
 
-  const counts = useAppSelector((state) => {
-    const alerts = state.alerts.alerts;
-    let critical = 0;
-    let warning = 0;
-    for (const a of alerts) {
-      if (a.acknowledged) continue;
-      if (a.severity === 'critical') critical++;
-      else if (a.severity === 'high' || a.severity === 'medium') warning++;
-    }
-    return { critical, warning };
-  });
+  const counts = useAppSelector(selectAlertCounts);
 
   // Copy ladder, top wins:
   //   1. Offline → deny-red, "Offline · Approvals still work"

--- a/apps/mobile/src/screens/devices/DeviceDetailScreen.tsx
+++ b/apps/mobile/src/screens/devices/DeviceDetailScreen.tsx
@@ -18,9 +18,22 @@ import {
 } from '../../theme';
 import { Spinner } from '../../components/Spinner';
 import { reportInternalError } from '../../lib/errorReporting';
+import { osLabel } from '../../lib/osLabel';
+import { relativeTime } from '../../lib/relativeTime';
 
 interface Props {
   route: { params: { device: Device } };
+}
+
+/**
+ * Relative time reads at a glance, but an absolute timestamp is genuinely
+ * useful on a detail screen (matching against agent logs, ticket timestamps,
+ * etc.), so this keeps both rather than picking one.
+ */
+function formatTimestamp(iso: string): string {
+  const rel = relativeTime(iso);
+  const abs = new Date(iso).toLocaleString();
+  return rel ? `${rel} · ${abs}` : abs;
 }
 
 function statusDotColor(status: Device['status']): string {
@@ -280,7 +293,7 @@ export function DeviceDetailScreen({ route }: Props) {
         {device.os ? (
           <DetailRow
             label="OPERATING SYSTEM"
-            value={device.os}
+            value={osLabel(device.os)}
             textHi={theme.textHi}
             textLo={theme.textLo}
             border={theme.border}
@@ -298,7 +311,7 @@ export function DeviceDetailScreen({ route }: Props) {
         {device.lastSeen ? (
           <DetailRow
             label="LAST SEEN"
-            value={new Date(device.lastSeen).toLocaleString()}
+            value={formatTimestamp(device.lastSeen)}
             textHi={theme.textHi}
             textLo={theme.textLo}
             border={theme.border}

--- a/apps/mobile/src/screens/devices/DevicesListScreen.tsx
+++ b/apps/mobile/src/screens/devices/DevicesListScreen.tsx
@@ -17,6 +17,9 @@ import { getDevices, type Device } from '../../services/api';
 import { relativeTime } from '../../lib/relativeTime';
 import { reportInternalError } from '../../lib/errorReporting';
 import type { SystemsStackParamList } from '../../navigation/MainNavigator';
+// Imported from the sibling detail screen so the raw osType -> display name
+// mapping (windows -> Windows, macos -> macOS, ...) lives in one place.
+import { osLabel } from '../../lib/osLabel';
 
 import {
   shapeDeviceList,
@@ -63,7 +66,9 @@ function DeviceRow({ device, onPress }: { device: Device; onPress: () => void })
           {device.name}
         </Text>
         <Text style={styles.meta} numberOfLines={1}>
-          {[device.os, device.siteName].filter(Boolean).join(' · ') || '—'}
+          {[device.os ? osLabel(device.os) : null, device.siteName]
+            .filter(Boolean)
+            .join(' · ') || '—'}
         </Text>
       </View>
       <Text style={styles.seen}>

--- a/apps/mobile/src/screens/onboarding/OnboardingScreen.tsx
+++ b/apps/mobile/src/screens/onboarding/OnboardingScreen.tsx
@@ -88,6 +88,9 @@ export function OnboardingScreen({ onComplete }: Props) {
         onScroll={handleScroll}
         scrollEventThrottle={16}
         bounces={false}
+        // Explicit now that the dot rail below is a flow sibling rather than an
+        // overlay: the pager takes the height the rail leaves, and nothing else.
+        style={{ flex: 1 }}
       >
         <Page width={width}>
           <ApprovalPreview />
@@ -117,13 +120,21 @@ export function OnboardingScreen({ onComplete }: Props) {
         </Page>
       </ScrollView>
 
+      {/* The rail sits in normal flow rather than absolutely over the pager.
+          Overlaying it forced every page to reserve the rail's height as bottom
+          padding, and slide 1 — the tallest — outgrew that reservation:
+          `justifyContent: 'center'` overflows a too-small box in BOTH
+          directions, so its body copy centred itself down underneath the dots.
+          As a flow sibling it takes its own height out of the pager's before any
+          page is laid out, so the reservation is exact by construction and no
+          page can reach it however tall its content or the reader's type size.
+          The equal-height spacer that stands in for the last page's CTA still
+          does its job — the rail keeps the same height on every page, so the
+          dots do not jump when the CTA swaps in. */}
       <View
         style={{
-          position: 'absolute',
-          left: 0,
-          right: 0,
-          bottom: insets.bottom + spacing[5],
           paddingHorizontal: spacing[6],
+          paddingBottom: insets.bottom + spacing[5],
         }}
       >
         <View
@@ -173,17 +184,33 @@ export function OnboardingScreen({ onComplete }: Props) {
 function Page({ width, children }: { width: number; children: React.ReactNode }) {
   const insets = useSafeAreaInsets();
   return (
-    <View
-      style={{
-        width,
-        flex: 1,
-        paddingTop: insets.top + spacing[12],
-        paddingBottom: insets.bottom + spacing[20] + spacing[10],
-        paddingHorizontal: spacing[6],
-        justifyContent: 'center',
-      }}
-    >
-      {children}
+    <View style={{ width, flex: 1 }}>
+      {/* Scrollable so a page whose content is taller than the pager scrolls
+          instead of overflowing it — the pager clips, so an un-scrollable tall
+          page would simply lose its last lines on a short phone or at a large
+          Dynamic Type size. `flexGrow: 1` + `justifyContent: 'center'` keeps
+          every page that DOES fit centred exactly as it was before.
+          The horizontal padding stays on the content container, not on the View
+          above, so the previews that bleed to the screen edge with
+          `marginHorizontal: -spacing[6]` still pull against the same gutter
+          rather than being clipped by the scroll view's bounds. */}
+      <ScrollView
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{
+          flexGrow: 1,
+          justifyContent: 'center',
+          // Tight on purpose. Slide 1 carries the tallest preview, and the
+          // rail below now takes real height out of the pager, so generous
+          // padding here is what pushes its body copy past the fold — the
+          // ScrollView then clips mid-sentence, which reads as broken even
+          // though it technically scrolls. Onboarding copy has to FIT.
+          paddingTop: insets.top + spacing[4],
+          paddingBottom: spacing[2],
+          paddingHorizontal: spacing[6],
+        }}
+      >
+        {children}
+      </ScrollView>
     </View>
   );
 }
@@ -198,8 +225,10 @@ function Copy({
   body: string;
 }) {
   const theme = useApprovalTheme('dark');
+  // Was spacing[10]; trimmed for the same reason as the page padding above —
+  // slide 1's copy has to clear the dot rail without scrolling.
   return (
-    <View style={{ marginTop: spacing[10] }}>
+    <View style={{ marginTop: spacing[6] }}>
       <Text style={[type.metaCaps, { color: palette.brand.soft }]}>{eyebrow}</Text>
       <Text
         style={[
@@ -278,18 +307,17 @@ function ApprovalPreview() {
         borderColor: theme.border,
         // Negative horizontal margin lets the inner components keep their
         // native paddingHorizontal: spacing[6] without doubling up.
-        paddingVertical: spacing[5],
+        // Vertical padding and the ring are deliberately tighter than the real
+        // approval screen's: this card is DECORATION on a slide whose copy is
+        // the actual message, and slide 1 is the tallest of the three. Every
+        // point spent here is a point the body paragraph loses to the dot rail.
+        paddingVertical: spacing[3],
         marginHorizontal: spacing[2],
         overflow: 'hidden',
       }}
     >
-      <View
-        style={{
-          alignItems: 'center',
-          paddingTop: spacing[2],
-        }}
-      >
-        <CountdownRing expiresAt={expiresAt} size={64} stroke={3} />
+      <View style={{ alignItems: 'center' }}>
+        <CountdownRing expiresAt={expiresAt} size={56} stroke={3} />
       </View>
 
       <RequesterRow

--- a/apps/mobile/src/screens/tickets/TicketDetailScreen.tsx
+++ b/apps/mobile/src/screens/tickets/TicketDetailScreen.tsx
@@ -543,6 +543,9 @@ export function TicketDetailScreen() {
   // what's on screen: a prior version counted only non-system comments while
   // the list rendered system rows too, so the header undercounted.
   const activityCount = visibleActivityCount(ticket.comments);
+  // Null when the ticket has no internal number (hand-inserted rows only);
+  // hide the reference rather than invent one, as the web queue does.
+  const ref = ticketRef(ticket);
 
   return (
     <KeyboardAvoidingView
@@ -551,7 +554,7 @@ export function TicketDetailScreen() {
     >
       <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
         <View style={styles.header}>
-          <Text style={styles.ref}>{ticketRef(ticket)}</Text>
+          {ref ? <Text style={styles.ref}>{ref}</Text> : null}
           <View style={[styles.priorityDot, { backgroundColor: priorityColor(ticket.priority) }]} />
           <Text style={styles.priority}>{priorityLabel(ticket.priority)}</Text>
         </View>

--- a/apps/mobile/src/screens/tickets/TicketDetailScreen.tsx
+++ b/apps/mobile/src/screens/tickets/TicketDetailScreen.tsx
@@ -64,7 +64,14 @@ import { Toast } from '../../components/Toast';
 import { relativeTime } from '../../lib/relativeTime';
 import { reportInternalError } from '../../lib/errorReporting';
 
-import { priorityColor, priorityLabel, statusLabel, ticketRef } from './ticketCopy';
+import {
+  isVisibleActivityEntry,
+  priorityColor,
+  priorityLabel,
+  statusLabel,
+  ticketRef,
+  visibleActivityCount,
+} from './ticketCopy';
 import { startForTicket, stopRunningTimer } from './timerActions';
 import { startOutcomeEffects, stopOutcomeEffects } from './timerOutcomeEffects';
 import { CommentAttachments } from './CommentAttachments';
@@ -529,11 +536,13 @@ export function TicketDetailScreen() {
   const attachBlocked = attachDisabledReason({ connected, chips });
   const sendable = canSend({ chips, text: comment, busy });
   const quickStatuses = allowedQuickStatuses(ticket.status, QUICK_STATUS_CANDIDATES);
-  // Only person-authored entries are "comments"; the rest of the array is
-  // activity (status changes, assignments, time entries).
-  const commentCount = ticket.comments.filter(
-    (c) => !c.commentType || !SYSTEM_COMMENT_TYPES.has(c.commentType)
-  ).length;
+  // The "ACTIVITY" header counts every row the feed below actually renders —
+  // person comments AND system rows (status changes, assignments, time
+  // entries) — via the same predicate the render loop uses to skip blank
+  // system rows (see `isVisibleActivityEntry`). It must not diverge from
+  // what's on screen: a prior version counted only non-system comments while
+  // the list rendered system rows too, so the header undercounted.
+  const activityCount = visibleActivityCount(ticket.comments);
 
   return (
     <KeyboardAvoidingView
@@ -642,13 +651,20 @@ export function TicketDetailScreen() {
         )}
 
         <Text style={styles.sectionHeader}>
-          ACTIVITY{commentCount ? ` (${commentCount})` : ''}
+          ACTIVITY{activityCount ? ` (${activityCount})` : ''}
         </Text>
         {ticket.comments.length === 0 ? (
           <Text style={styles.metaDim}>No comments yet.</Text>
         ) : (
           ticket.comments.map((c) => {
             const isSystem = Boolean(c.commentType && SYSTEM_COMMENT_TYPES.has(c.commentType));
+            // A system row with no content carries no information — it has
+            // no author chip or subject line to anchor it, so rendering it
+            // blank reads as a bug (observed live: a row with only a "10w
+            // ago" timestamp and no text). Skip it rather than render it
+            // empty; `activityCount` above is computed the same way so the
+            // header stays consistent with what's actually on screen.
+            if (isSystem && !isVisibleActivityEntry(c)) return null;
             if (isSystem) {
               // Activity entries are not comments: no author chip, no INTERNAL
               // badge (they are non-public by nature), and dimmed.

--- a/apps/mobile/src/screens/tickets/TicketsScreen.tsx
+++ b/apps/mobile/src/screens/tickets/TicketsScreen.tsx
@@ -55,10 +55,11 @@ function Chip({
 
 function TicketRow({ ticket, onPress }: { ticket: TicketSummary; onPress: () => void }) {
   const breached = isBreached(ticket);
+  const ref = ticketRef(ticket);
   return (
     <Pressable onPress={onPress} accessibilityRole="button" style={styles.row}>
       <View style={styles.rowHeader}>
-        <Text style={styles.ref}>{ticketRef(ticket)}</Text>
+        {ref ? <Text style={styles.ref}>{ref}</Text> : null}
         <View style={[styles.priorityDot, { backgroundColor: priorityColor(ticket.priority) }]} />
         <Text style={styles.priority}>{priorityLabel(ticket.priority)}</Text>
         {breached ? <Text style={styles.breach}>SLA</Text> : null}

--- a/apps/mobile/src/screens/tickets/ticketCopy.test.ts
+++ b/apps/mobile/src/screens/tickets/ticketCopy.test.ts
@@ -24,38 +24,27 @@ describe('statusLabel', () => {
 
 describe('ticketRef', () => {
   it('uses the internal number when present', () => {
-    expect(ticketRef({ internalNumber: '1041', id: 'abcdef01-1111' })).toBe('#1041');
+    expect(ticketRef({ internalNumber: '1041' })).toBe('#1041');
   });
 
   it('does not double-prefix a number that already carries a #', () => {
-    expect(ticketRef({ internalNumber: '#1041', id: 'abcdef01-1111' })).toBe('#1041');
+    expect(ticketRef({ internalNumber: '#1041' })).toBe('#1041');
   });
 
   it('preserves a non-numeric internal reference verbatim', () => {
-    expect(ticketRef({ internalNumber: 'TKT-1041', id: 'abcdef01' })).toBe('#TKT-1041');
+    expect(ticketRef({ internalNumber: 'TKT-1041' })).toBe('#TKT-1041');
   });
 
-  it('falls back to an id-derived reference when the tenant has no internal number', () => {
-    expect(ticketRef({ internalNumber: null, id: 'abcdef0123456789' })).toBe('ID ef0123456789');
-    expect(ticketRef({ internalNumber: '   ', id: 'abcdef0123456789' })).toBe('ID ef0123456789');
-  });
-
-  it('does not present the fallback as a real ticket number', () => {
-    // The old fallback ("#abcdef01") wore the same '#'-prefixed shape as a
-    // genuine internalNumber, so a tenant with no numbering scheme saw what
-    // looked like a real, distinct ticket number on every ticket.
-    const ref = ticketRef({ internalNumber: null, id: 'abcdef0123456789' });
-    expect(ref.startsWith('#')).toBe(false);
-  });
-
-  it('does not collide when two ticket ids share a common prefix (review-tenant regression)', () => {
-    // Apple review tenant: every seeded ticket id starts `11110000-...`, so
-    // slicing the first 8 hex chars produced the SAME "#11110000" reference
-    // for three different tickets. The distinguishing digits live at the end
-    // of these ids, so the fallback must draw from there, not the front.
-    const a = ticketRef({ internalNumber: null, id: '11110000-0000-0000-0000-000000000001' });
-    const b = ticketRef({ internalNumber: null, id: '11110000-0000-0000-0000-000000000002' });
-    expect(a).not.toBe(b);
+  it('returns null when the ticket has no internal number, so callers hide the reference', () => {
+    // Web precedent: the queue renders nothing when internalNumber is null
+    // rather than inventing a reference. A production ticket always has one
+    // because the service allocates it on create; only hand-inserted rows
+    // (fixtures, the App Review tenant's seed) lack it. No fallback also
+    // closes the review-tenant regression where every seeded id started
+    // `11110000-...` and an id-derived fallback showed three different
+    // tickets as the same "#11110000".
+    expect(ticketRef({ internalNumber: null })).toBeNull();
+    expect(ticketRef({ internalNumber: '   ' })).toBeNull();
   });
 });
 

--- a/apps/mobile/src/screens/tickets/ticketCopy.test.ts
+++ b/apps/mobile/src/screens/tickets/ticketCopy.test.ts
@@ -4,9 +4,11 @@ import {
   emptyStateCopy,
   emptyStateKind,
   isBreached,
+  isVisibleActivityEntry,
   priorityLabel,
   statusLabel,
   ticketRef,
+  visibleActivityCount,
 } from './ticketCopy';
 
 describe('statusLabel', () => {
@@ -33,9 +35,27 @@ describe('ticketRef', () => {
     expect(ticketRef({ internalNumber: 'TKT-1041', id: 'abcdef01' })).toBe('#TKT-1041');
   });
 
-  it('falls back to a short id when the tenant has no internal number', () => {
-    expect(ticketRef({ internalNumber: null, id: 'abcdef0123456789' })).toBe('#abcdef01');
-    expect(ticketRef({ internalNumber: '   ', id: 'abcdef0123456789' })).toBe('#abcdef01');
+  it('falls back to an id-derived reference when the tenant has no internal number', () => {
+    expect(ticketRef({ internalNumber: null, id: 'abcdef0123456789' })).toBe('ID ef0123456789');
+    expect(ticketRef({ internalNumber: '   ', id: 'abcdef0123456789' })).toBe('ID ef0123456789');
+  });
+
+  it('does not present the fallback as a real ticket number', () => {
+    // The old fallback ("#abcdef01") wore the same '#'-prefixed shape as a
+    // genuine internalNumber, so a tenant with no numbering scheme saw what
+    // looked like a real, distinct ticket number on every ticket.
+    const ref = ticketRef({ internalNumber: null, id: 'abcdef0123456789' });
+    expect(ref.startsWith('#')).toBe(false);
+  });
+
+  it('does not collide when two ticket ids share a common prefix (review-tenant regression)', () => {
+    // Apple review tenant: every seeded ticket id starts `11110000-...`, so
+    // slicing the first 8 hex chars produced the SAME "#11110000" reference
+    // for three different tickets. The distinguishing digits live at the end
+    // of these ids, so the fallback must draw from there, not the front.
+    const a = ticketRef({ internalNumber: null, id: '11110000-0000-0000-0000-000000000001' });
+    const b = ticketRef({ internalNumber: null, id: '11110000-0000-0000-0000-000000000002' });
+    expect(a).not.toBe(b);
   });
 });
 
@@ -81,5 +101,57 @@ describe('emptyStateKind', () => {
     // and the old gate rendered "The open queue is clear." right under the
     // error line.
     expect(emptyStateKind(false, 'Network request failed')).toBe('error');
+  });
+});
+
+describe('isVisibleActivityEntry', () => {
+  it('renders a system entry that has content', () => {
+    expect(isVisibleActivityEntry({ commentType: 'status_change', content: 'Status changed to Open' })).toBe(
+      true
+    );
+  });
+
+  it('skips a system entry with blank content — it carries no information', () => {
+    // Live-tenant regression: a system row rendered with NO text on the left,
+    // only the "10w ago" timestamp on the right, because `c.content` was
+    // interpolated unguarded. Unlike a person's comment (which has an author
+    // chip and can legitimately be attachment-only), a system row has
+    // nothing else to anchor an empty one — so it should be skipped, not
+    // rendered blank.
+    expect(isVisibleActivityEntry({ commentType: 'status_change', content: '' })).toBe(false);
+    expect(isVisibleActivityEntry({ commentType: 'time_entry', content: '   ' })).toBe(false);
+  });
+
+  it('always renders a person comment, even with empty content', () => {
+    // Person comments can be legitimately attachment-only, and the render
+    // path has its own placeholder/attachment handling — that decision is
+    // not this function's job.
+    expect(isVisibleActivityEntry({ commentType: undefined, content: '' })).toBe(true);
+    expect(isVisibleActivityEntry({ commentType: 'comment', content: '' })).toBe(true);
+  });
+});
+
+describe('visibleActivityCount', () => {
+  it('counts every row the feed actually renders, system rows included', () => {
+    const comments = [
+      { commentType: 'status_change' as const, content: 'Status changed to Open' },
+      { commentType: 'assignment' as const, content: 'Assigned to Dana' },
+      { commentType: 'comment' as const, content: 'Looking into it' },
+    ];
+    expect(visibleActivityCount(comments)).toBe(3);
+  });
+
+  it('does not count a system row that will be skipped as blank', () => {
+    // The live-tenant regression: the header read "ACTIVITY (1)" over FIVE
+    // visible rows (4 system + 1 comment) because the count only tallied
+    // non-system comments while the list below also rendered the system
+    // rows. The header count must track what's on screen, not a different
+    // subset of it.
+    const comments = [
+      { commentType: 'status_change' as const, content: 'Status changed to Open' },
+      { commentType: 'assignment' as const, content: '' }, // skipped by isVisibleActivityEntry
+      { commentType: 'comment' as const, content: 'Looking into it' },
+    ];
+    expect(visibleActivityCount(comments)).toBe(2);
   });
 });

--- a/apps/mobile/src/screens/tickets/ticketCopy.ts
+++ b/apps/mobile/src/screens/tickets/ticketCopy.ts
@@ -53,23 +53,22 @@ export function priorityColor(priority: TicketPriority): string {
 }
 
 /**
- * `#1041` when the tenant has internal numbers, else an id-derived fallback.
- * `internalNumber` (not `ticketNumber`) is the display reference — it is what
- * the web queue renders, and it is a nullable varchar rather than an integer.
+ * `#1041` when the ticket has an internal number, else `null` so the caller
+ * hides the reference entirely.
  *
- * The fallback is NOT `#` + a slice of the id: seeded/fixture data (and any
- * UUIDv4 batch minted close together) can share a long, identical-looking
- * prefix, so `id.slice(0, 8)` isn't guaranteed to differ between tickets —
- * three distinct tickets in the Apple review tenant all rendered as the
- * identical "#11110000" because every seeded id there starts `11110000-`.
- * Two changes fix that: draw from the END of the id, where sequentially- or
- * closely-minted ids actually diverge, and drop the '#' so a fallback can
- * never be mistaken for a genuine internal number.
+ * `internalNumber` (not `ticketNumber`) is the display reference: it is what the
+ * web queue renders, and it is a nullable varchar rather than an integer. The
+ * service allocates one on every create (`T-YYYY-NNNN`), so a production ticket
+ * always has one; only hand-inserted rows (fixtures, a seeded review tenant)
+ * lack it. Web renders nothing for those rather than inventing a reference, and
+ * so does mobile: an id-derived fallback either collides (seeded ids share a
+ * long prefix, so `id.slice(0, 8)` showed three tickets as the same "#11110000")
+ * or looks like a real number it is not.
  */
-export function ticketRef(ticket: Pick<TicketSummary, 'internalNumber' | 'id'>): string {
+export function ticketRef(ticket: Pick<TicketSummary, 'internalNumber'>): string | null {
   const n = ticket.internalNumber?.trim();
-  if (n) return n.startsWith('#') ? n : `#${n}`;
-  return `ID ${ticket.id.replace(/-/g, '').slice(-12)}`;
+  if (!n) return null;
+  return n.startsWith('#') ? n : `#${n}`;
 }
 
 export function isBreached(ticket: Pick<TicketSummary, 'slaBreachedAt'>): boolean {

--- a/apps/mobile/src/screens/tickets/ticketCopy.ts
+++ b/apps/mobile/src/screens/tickets/ticketCopy.ts
@@ -1,4 +1,13 @@
-import type { TicketPriority, TicketStatus, TicketSummary } from '../../services/tickets';
+import type {
+  TicketComment,
+  TicketPriority,
+  TicketStatus,
+  TicketSummary,
+} from '../../services/tickets';
+// Value import, deliberately from the leaf module rather than services/tickets:
+// that module pulls `./api` (expo-secure-store, react-native) and would drag the
+// RN runtime into this otherwise node-testable copy module.
+import { SYSTEM_COMMENT_TYPES } from '../../services/ticketCommentTypes';
 // Import the pure token module rather than the `../../theme` barrel: the barrel
 // re-exports `useApprovalTheme`, which imports `useColorScheme` from react-native
 // and drags the RN runtime into this otherwise node-testable copy module.
@@ -44,14 +53,23 @@ export function priorityColor(priority: TicketPriority): string {
 }
 
 /**
- * `#1041` when the tenant has internal numbers, else a short id fallback.
+ * `#1041` when the tenant has internal numbers, else an id-derived fallback.
  * `internalNumber` (not `ticketNumber`) is the display reference — it is what
  * the web queue renders, and it is a nullable varchar rather than an integer.
+ *
+ * The fallback is NOT `#` + a slice of the id: seeded/fixture data (and any
+ * UUIDv4 batch minted close together) can share a long, identical-looking
+ * prefix, so `id.slice(0, 8)` isn't guaranteed to differ between tickets —
+ * three distinct tickets in the Apple review tenant all rendered as the
+ * identical "#11110000" because every seeded id there starts `11110000-`.
+ * Two changes fix that: draw from the END of the id, where sequentially- or
+ * closely-minted ids actually diverge, and drop the '#' so a fallback can
+ * never be mistaken for a genuine internal number.
  */
 export function ticketRef(ticket: Pick<TicketSummary, 'internalNumber' | 'id'>): string {
   const n = ticket.internalNumber?.trim();
   if (n) return n.startsWith('#') ? n : `#${n}`;
-  return `#${ticket.id.slice(0, 8)}`;
+  return `ID ${ticket.id.replace(/-/g, '').slice(-12)}`;
 }
 
 export function isBreached(ticket: Pick<TicketSummary, 'slaBreachedAt'>): boolean {
@@ -92,4 +110,41 @@ export function emptyStateKind(
 ): 'none' | 'error' | 'empty' {
   if (loading) return 'none';
   return error ? 'error' : 'empty';
+}
+
+/**
+ * Whether an activity-feed row should be rendered at all.
+ *
+ * A system entry (status change, assignment, time entry) with blank
+ * `content` carries no information: the row has only `content` and a
+ * timestamp, no author chip or subject line to anchor it, so an empty one
+ * rendered as a lone "10w ago" with nothing to its left — observed live
+ * against a real tenant. Skip it rather than render it blank.
+ *
+ * A person comment always renders, even with empty content: it can
+ * legitimately be attachment-only, and its own render branch already has
+ * placeholder handling (soft-deleted / attachment-only) — that's not this
+ * function's call to make.
+ */
+export function isVisibleActivityEntry(
+  comment: Pick<TicketComment, 'commentType' | 'content'>
+): boolean {
+  const isSystem = Boolean(comment.commentType && SYSTEM_COMMENT_TYPES.has(comment.commentType));
+  if (!isSystem) return true;
+  return Boolean(comment.content && comment.content.trim());
+}
+
+/**
+ * Count of rows the "ACTIVITY" feed actually renders below its header.
+ *
+ * Must stay in lockstep with `isVisibleActivityEntry` above — the header
+ * previously counted only non-system comments while the list below also
+ * rendered every system row, so a tenant saw "ACTIVITY (1)" printed over
+ * five visible rows (four system rows plus one comment). Counting exactly
+ * what's rendered keeps the number honest.
+ */
+export function visibleActivityCount(
+  comments: ReadonlyArray<Pick<TicketComment, 'commentType' | 'content'>>
+): number {
+  return comments.filter(isVisibleActivityEntry).length;
 }

--- a/apps/mobile/src/screens/time/TimesheetScreen.tsx
+++ b/apps/mobile/src/screens/time/TimesheetScreen.tsx
@@ -274,7 +274,7 @@ export function TimesheetScreen({ navigation }: TimesheetProps = {}) {
         <View style={styles.entryHeader}>
           <Text style={styles.entryRef}>
             {entry.ticketId
-              ? ticketRef({ id: entry.ticketId, internalNumber: ticket?.internalNumber ?? null })
+              ? (ticketRef({ internalNumber: ticket?.internalNumber ?? null }) ?? ticket?.subject ?? 'Ticket')
               : 'No ticket'}
           </Text>
           <Text style={styles.entryDuration}>{formatMinutes(entry.durationMinutes)}</Text>

--- a/apps/mobile/src/screens/time/TimesheetScreen.tsx
+++ b/apps/mobile/src/screens/time/TimesheetScreen.tsx
@@ -10,6 +10,7 @@ import {
   TextInput,
   View,
 } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { palette, radii, spacing, type } from '../../theme';
 import { useAppDispatch, useAppSelector } from '../../store';
@@ -53,6 +54,12 @@ interface TimesheetProps {
 }
 
 export function TimesheetScreen({ navigation }: TimesheetProps = {}) {
+  // TimeStack mounts this screen with `headerShown: false`, so nothing above it
+  // reserves the status bar: without this the week bar draws at y=0 and the
+  // Dynamic Island bisects the week title while the clock and the battery icons
+  // sit on top of the two week chevrons. Same inset and same gap as
+  // TicketsScreen so the Time tab starts on the line the Tickets tab does.
+  const insets = useSafeAreaInsets();
   const dispatch = useAppDispatch();
   const suggestionsEnabled = useAppSelector(selectSuggestionsEnabled);
   const unloggedCount = useAppSelector(selectUnloggedCount);
@@ -348,7 +355,7 @@ export function TimesheetScreen({ navigation }: TimesheetProps = {}) {
 
   return (
     <KeyboardAvoidingView
-      style={styles.screen}
+      style={[styles.screen, { paddingTop: insets.top + spacing['3'] }]}
       behavior={Platform.OS === 'ios' ? 'padding' : undefined}
     >
       {suggestionsBannerVisible ? (

--- a/apps/mobile/src/services/ticketCommentTypes.ts
+++ b/apps/mobile/src/services/ticketCommentTypes.ts
@@ -1,0 +1,36 @@
+/**
+ * The ticket-comment kind vocabulary, split out as a leaf module.
+ *
+ * **This module imports nothing — not react-native, not `./api` — and must stay
+ * that way.** Its sibling `tickets.ts` imports `coreRequest` from `./api`, which
+ * transitively loads `expo-secure-store` and `react-native`'s Flow-typed source;
+ * Vitest cannot parse that, which is why `tickets.test.ts` has to `vi.mock('./api')`
+ * before it can touch a single constant. Screens' pure copy/logic modules
+ * (`screens/tickets/ticketCopy.ts`) must be node-testable WITHOUT that mock, so
+ * they need a value import that costs them no module graph. Same reasoning, and
+ * the same shape, as `ticketAttachmentContract.ts`.
+ *
+ * Before this split the set was duplicated into `ticketCopy.ts` with a
+ * "keep in sync" comment. That is precisely the kind of drift that silently
+ * reintroduces a fixed bug: `TicketDetailScreen` decides whether a row IS a
+ * system entry from this set, while the visibility predicate used its copy, so
+ * a fifth kind added here would render as a system row but be classified as a
+ * person comment — resurrecting the blank-activity-row and the miscounted
+ * ACTIVITY header. One definition, imported by both, makes that unrepresentable.
+ */
+
+export type TicketCommentType =
+  | 'comment'
+  | 'internal'
+  | 'status_change'
+  | 'assignment'
+  | 'time_entry'
+  | 'system';
+
+/** Entry kinds the API emits as activity rather than a person's comment. */
+export const SYSTEM_COMMENT_TYPES: ReadonlySet<TicketCommentType> = new Set([
+  'status_change',
+  'assignment',
+  'time_entry',
+  'system',
+]);

--- a/apps/mobile/src/services/tickets.ts
+++ b/apps/mobile/src/services/tickets.ts
@@ -1,4 +1,5 @@
 import { coreRequest } from './api';
+import type { TicketCommentType } from './ticketCommentTypes';
 import type { TicketAttachmentMeta } from './ticketAttachmentContract';
 
 /**
@@ -47,21 +48,11 @@ export interface TicketSummary {
   statusColor: string | null;
 }
 
-export type TicketCommentType =
-  | 'comment'
-  | 'internal'
-  | 'status_change'
-  | 'assignment'
-  | 'time_entry'
-  | 'system';
-
-/** Entry kinds the API emits as activity rather than a person's comment. */
-export const SYSTEM_COMMENT_TYPES: ReadonlySet<TicketCommentType> = new Set([
-  'status_change',
-  'assignment',
-  'time_entry',
-  'system',
-]);
+// Defined in a leaf module so pure copy/logic modules can import the VALUE
+// without dragging this file's `./api` (and therefore react-native) graph into
+// the Vitest runner. Re-exported here so existing importers are unaffected.
+export type { TicketCommentType } from './ticketCommentTypes';
+export { SYSTEM_COMMENT_TYPES } from './ticketCommentTypes';
 
 export interface TicketComment {
   id: string;


### PR DESCRIPTION
## Summary

On-device layout and bug pass against the App Review tenant, ahead of the resubmission build. Every change was verified on an iPhone against a live tenant.

### Tickets
- **ACTIVITY header counts what the feed renders.** It counted only person comments while the list also rendered system rows, so "(1)" sat over five visible rows. `visibleActivityCount` and the render loop now share one predicate.
- **Blank system rows are skipped.** A status change / assignment / time entry with no content rendered as a lone "10w ago" with nothing beside it.
- **Ticket reference fallback no longer collides.** Seeded ids share a long prefix, so `#` + `id.slice(0, 8)` rendered three different tickets as the same "#11110000". The fallback now draws from the end of the id and drops the `#` so it cannot be mistaken for a real internal number. (Follow-up commit on this PR: hide the reference entirely when there is no internal number, matching the web queue.)
- `SYSTEM_COMMENT_TYPES` moves to a leaf module (`services/ticketCommentTypes.ts`) so pure copy modules can import the value without dragging react-native into Vitest. `services/tickets.ts` re-exports it, so importers are unaffected.

### Alerts
- **TYPE row removed.** The value was a client-side constant (`type: alert.type || 'alert'`), not data. The `alerts` table has no type or category column; a real category would come from joining the rule to its template. Tracked as a separate low-priority issue.
- CREATED / ACKNOWLEDGED AT show relative and absolute time, matching the device LAST SEEN row.

### Elsewhere
- Onboarding, MFA challenge, device list and detail, timesheet, chat settings sheet, status pill: spacing, safe-area, and copy fixes found on device.
- `lib/osLabel.ts`: one shared OS label formatter for both device screens.
- Tests added for MfaChallengeScreen helpers, StatusPill's memoised selector, ticketCopy.

## Verification
- `tsc --noEmit` clean in `apps/mobile`.
- `vitest run`: 88 files, 1163 tests passed, 3 skipped.
- On-device pass on iPhone 15 Pro Max against the review tenant.

## Notes
- Independent of #4508 (iPhone-only); rebased onto `main`.
- A separate PR adds the Reply / Internal comment toggle and defaults mobile comments to internal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VHPuR4tB5B2DitLJNQqFwf
