### PR TITLE
test(api): bracket the fixWatch recovery cutoff instead of asserting it backwards

### DIFF
--- a/apps/api/src/services/aiAgents/fixWatch.test.ts
+++ b/apps/api/src/services/aiAgents/fixWatch.test.ts
@@ -630,6 +630,7 @@ describe('listPendingWatchesForRecovery', () => {
     const before = Date.now();
 
     const rows = await listPendingWatchesForRecovery(120_000);
+    const after = Date.now();
 
     expect(rows.map((row) => row.id)).toEqual([WATCH_ID, 'watch-2']);
     const compiled = dialect.sqlToQuery(state.selectWheres[0] as SQL);
@@ -644,7 +645,11 @@ describe('listPendingWatchesForRecovery', () => {
     const cutoffParam = compiled.params.find((param) => param !== 'pending');
     const cutoff = new Date(String(cutoffParam));
     expect(Number.isNaN(cutoff.getTime())).toBe(false);
-    expect(cutoff.getTime()).toBeLessThanOrEqual(before - 120_000);
+    // Bracket the cutoff between the clock readings taken around the call: the
+    // lower bound proves the reader did not use a stale clock, the upper bound
+    // proves the subtraction happened (a dropped one would land near `after`).
+    expect(cutoff.getTime()).toBeGreaterThanOrEqual(before - 120_000);
+    expect(cutoff.getTime()).toBeLessThanOrEqual(after - 120_000);
   });
 
   it('reads one PAGE, ordered (created_at, id) — the tuple the cursor compares', async () => {


### PR DESCRIPTION
## Summary
- `listPendingWatchesForRecovery` cutoff test captured `before = Date.now()` and then asserted the cutoff computed inside the call was `<= before - 120s`. That holds only when the clock does not advance between the two reads, so it flaked by 1 ms on CI (run 33653599096, \`expected 1788365662590 to be less than or equal to 1788365662589\`).
- Bracket the cutoff between `before` and `after` readings. The upper bound still catches a dropped subtraction (cutoff would land near `after`), the lower bound catches a stale clock.

## Verification
- Verified: `npx vitest run src/services/aiAgents/fixWatch.test.ts` 3× locally, 75/75 each.
- Not checked: no production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyYQpa3oMfjMRSjET5WnEr