### PR TITLE
chore(deploy): map outbox/anomaly retention knobs into droplet compose (follow-up to #4400)

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -226,6 +226,23 @@ STRIPE_COMMUNITY_PRICE_ID=
 # EXCHANGE_RATE_SYNC_ENABLED=true
 # FRANKFURTER_BASE_URL=https://api.frankfurter.dev/v2
 
+# ── Outbox / anomaly-incident retention (#4210) ──────────────────────
+# ticket_outbox, intent_outbox and metric_anomaly_incidents are transactional
+# outbox tables drained within seconds by their own publisher workers, but
+# nothing previously deleted the drained rows. These three daily jobs prune
+# rows once they are terminal: delivered (published_at/dispatched_at set) or
+# permanently stuck (publish/dispatch attempts exhausted — see the matching
+# publisher job's MAX_PUBLISH_ATTEMPTS). All optional; defaults shown below.
+# TICKET_OUTBOX_RETENTION_DAYS=14
+# TICKET_OUTBOX_RETENTION_BATCH_SIZE=5000
+# TICKET_OUTBOX_RETENTION_MAX_BATCHES=50
+# INTENT_OUTBOX_RETENTION_DAYS=14
+# INTENT_OUTBOX_RETENTION_BATCH_SIZE=5000
+# INTENT_OUTBOX_RETENTION_MAX_BATCHES=50
+# METRIC_ANOMALY_INCIDENT_RETENTION_DAYS=14
+# METRIC_ANOMALY_INCIDENT_RETENTION_BATCH_SIZE=5000
+# METRIC_ANOMALY_INCIDENT_RETENTION_MAX_BATCHES=50
+
 # ── Observability ───────────────────────────────────────────────────
 LOG_LEVEL=info
 METRICS_SCRAPE_TOKEN=

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -286,6 +286,21 @@ x-api-env: &api-env
   # Empty === unset for both readers, so unset keeps the code defaults.
   EXCHANGE_RATE_SYNC_ENABLED: ${EXCHANGE_RATE_SYNC_ENABLED:-}
   FRANKFURTER_BASE_URL: ${FRANKFURTER_BASE_URL:-}
+  # Outbox / anomaly-incident retention (#4210). Read by the three daily
+  # prune jobs (jobs/*Retention.ts), which are `global` placement and so run
+  # in the worker role — the worker service inherits this same *api-env
+  # anchor, so mapping them here reaches both containers. Empty === unset for
+  # every reader, so the `${VAR:-}` form keeps the code defaults
+  # (14 days / 5000 rows per batch / 50 batches per run).
+  TICKET_OUTBOX_RETENTION_DAYS: ${TICKET_OUTBOX_RETENTION_DAYS:-}
+  TICKET_OUTBOX_RETENTION_BATCH_SIZE: ${TICKET_OUTBOX_RETENTION_BATCH_SIZE:-}
+  TICKET_OUTBOX_RETENTION_MAX_BATCHES: ${TICKET_OUTBOX_RETENTION_MAX_BATCHES:-}
+  INTENT_OUTBOX_RETENTION_DAYS: ${INTENT_OUTBOX_RETENTION_DAYS:-}
+  INTENT_OUTBOX_RETENTION_BATCH_SIZE: ${INTENT_OUTBOX_RETENTION_BATCH_SIZE:-}
+  INTENT_OUTBOX_RETENTION_MAX_BATCHES: ${INTENT_OUTBOX_RETENTION_MAX_BATCHES:-}
+  METRIC_ANOMALY_INCIDENT_RETENTION_DAYS: ${METRIC_ANOMALY_INCIDENT_RETENTION_DAYS:-}
+  METRIC_ANOMALY_INCIDENT_RETENTION_BATCH_SIZE: ${METRIC_ANOMALY_INCIDENT_RETENTION_BATCH_SIZE:-}
+  METRIC_ANOMALY_INCIDENT_RETENTION_MAX_BATCHES: ${METRIC_ANOMALY_INCIDENT_RETENTION_MAX_BATCHES:-}
 
 services:
   binaries-init:


### PR DESCRIPTION
## Summary

PR #4400 added nine retention env vars (`TICKET_OUTBOX_RETENTION_*`, `INTENT_OUTBOX_RETENTION_*`, `METRIC_ANOMALY_INCIDENT_RETENTION_*`) for the three daily outbox/anomaly-incident prune jobs. They were mapped into root `docker-compose.yml` but never threaded into the droplet's `deploy/docker-compose.prod.yml`, so droplets have been running these jobs on their code defaults (14 days / 5000 rows per batch / 50 batches) with no way to tune them.

- Threads all nine vars into the shared `*api-env` anchor in `deploy/docker-compose.prod.yml`, matching the `${VAR:-}` pattern used for other optional knobs (e.g. `EXCHANGE_RATE_SYNC_ENABLED`). The anchor is reused by both the `api` and `worker` services, so this reaches the worker role that actually runs the prune jobs.
- Documents the same nine vars, with the same comments and commented-out defaults, in `deploy/.env.example`.

## Test plan

- [x] `pnpm --filter @breeze/api exec vitest run --pool=threads --maxWorkers=2 src/config/envComposeParity.test.ts` — 34/34 passed, confirming both the self-host and droplet `.env.example` ↔ compose pairs stay in parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)