### PR TITLE
fix(portal): serve the dev module graph under /portal so islands hydrate (#3906)

### DIFF
--- a/apps/portal/astro.config.mjs
+++ b/apps/portal/astro.config.mjs
@@ -59,6 +59,15 @@ function portalDevBase(basePath) {
         // of /portal/ — did you mean to visit ...". Astro's is the one that has to
         // stay: it also handles `/portal` exactly, trailing slashes and the
         // outside-the-base redirect. Drop the redundant one.
+        //
+        // Loudness caveat on the throw below: from a cold `astro dev` it
+        // propagates uncaught out of `vite.createServer` and kills the process,
+        // which is what we want (verified — the container logs the full message
+        // and the portal never comes up). On a *live restart* (editing this file
+        // while the dev server runs) Vite's own `restartServer` catches it, logs
+        // "server restart failed" and keeps serving the previous config, so the
+        // signal is two easy-to-miss log lines plus a stale server. Restart the
+        // process if a base-path change does not seem to take.
         const stack = server.middlewares.stack;
         const index = stack.findIndex((layer) => layer.handle?.name === 'viteBaseMiddleware');
         if (index === -1) {

--- a/apps/portal/astro.config.mjs
+++ b/apps/portal/astro.config.mjs
@@ -9,6 +9,72 @@ import node from '@astrojs/node';
 // to serve at the root. See docker/Caddyfile.prod for the matching `/portal` carve-out.
 const PORTAL_BASE = process.env.PORTAL_BASE_PATH || '/portal';
 
+/**
+ * Dev-only: mount the Vite dev server's module graph under the portal's base path.
+ *
+ * `astro dev` deliberately keeps Vite base-agnostic. It strips `base` off every
+ * incoming request in its own front-of-stack middleware
+ * (astro/dist/vite-plugin-astro-server/base.js) and never sets Vite's `base`, so
+ * the dev server emits its module URLs from the server root: `/src/*`, `/@fs/*`,
+ * `/@id/*`, `/@vite/client`, `/node_modules/.vite/deps/*`.
+ *
+ * That is fine when the browser talks to the dev server directly, but the
+ * worktree/dev stack puts Caddy in front of both Astro apps and routes the portal
+ * **by path** (`/portal` and `/portal/*` — docker/Caddyfile.prod). Unprefixed
+ * module URLs therefore fell through to the web app: a portal-only file 404'd, and
+ * a path both apps happen to share (`/src/lib/utils.ts`, `/node_modules/...`) was
+ * silently served from the *wrong app*. Either way no portal island hydrated,
+ * while the SSR'd markup still looked correct — so portal e2e specs asserted
+ * against dead markup (#3906).
+ *
+ * Setting Vite's `base` makes Vite emit `/portal/`-prefixed URLs across the whole
+ * module graph (import analysis, pre-bundled deps, HMR client, react-refresh), so
+ * the existing path-based Caddy route already covers them — no Referer sniffing
+ * and no dev-only proxy rules. Astro's own middleware strips the prefix back off on
+ * the way in, exactly as it already does for page routes. The handful of entry-point
+ * URLs Astro hardcodes into the HTML itself are prefixed in src/middleware.ts
+ * (see src/lib/devAssetBase.ts) — Vite's `base` does not reach those.
+ *
+ * `apply: 'serve'` keeps this out of `astro build`: a production build already emits
+ * base-prefixed bundled assets via Astro's own `base`, and forcing Vite's `base`
+ * there would double-prefix them.
+ */
+function portalDevBase(basePath) {
+  // Vite wants a trailing slash; the `base` convention here does not carry one.
+  const viteBase = basePath === '/' ? '/' : `${basePath.replace(/\/+$/, '')}/`;
+  const enabled = viteBase !== '/';
+
+  return {
+    name: 'breeze:portal-dev-base',
+    apply: 'serve',
+    config: () => (enabled ? { base: viteBase } : {}),
+    configureServer(server) {
+      if (!enabled) return undefined;
+      // Post hook — runs after Vite has installed its own middleware stack.
+      return () => {
+        // Vite installs its own base-stripping middleware whenever `base !== '/'`.
+        // Astro has already stripped `/portal` off `req.url` by the time it runs
+        // (Astro unshifts its middleware to the front of the stack), so Vite's would
+        // reject every request with "The server is configured with a public base URL
+        // of /portal/ — did you mean to visit ...". Astro's is the one that has to
+        // stay: it also handles `/portal` exactly, trailing slashes and the
+        // outside-the-base redirect. Drop the redundant one.
+        const stack = server.middlewares.stack;
+        const index = stack.findIndex((layer) => layer.handle?.name === 'viteBaseMiddleware');
+        if (index === -1) {
+          throw new Error(
+            "[breeze:portal-dev-base] Vite's base middleware ('viteBaseMiddleware') is not in the " +
+              'dev middleware stack. Either Vite stopped installing it or it was renamed — without ' +
+              'removing it Astro and Vite both strip the base path and every dev request 404s. ' +
+              'Re-check this plugin against the installed Vite version.'
+          );
+        }
+        stack.splice(index, 1);
+      };
+    }
+  };
+}
+
 export default defineConfig({
   output: 'server',
   base: PORTAL_BASE,
@@ -42,6 +108,6 @@ export default defineConfig({
     port: 4322
   },
   vite: {
-    plugins: [tailwindcss()]
+    plugins: [tailwindcss(), portalDevBase(PORTAL_BASE)]
   }
 });

--- a/apps/portal/src/lib/devAssetBase.test.ts
+++ b/apps/portal/src/lib/devAssetBase.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { isHtmlContentType, prefixDevAssetUrlsFor } from './devAssetBase';
+
+/**
+ * Regression cover for #3906: the portal dev server emits its module URLs from
+ * the server root, so behind the worktree stack's path-routed Caddy every island
+ * entry point 404'd against the web app and no island ever hydrated. These are
+ * the exact attribute shapes `astro dev` renders (captured from a live
+ * `/portal/login` response).
+ */
+describe('prefixDevAssetUrlsFor', () => {
+  it('prefixes the astro-island entry points that hydrate a client:load component', () => {
+    const html =
+      '<astro-island uid="r1" component-url="/src/components/portal/PublicQuoteView.tsx"' +
+      ' renderer-url="/@fs/repo/node_modules/@astrojs/react/dist/client.js"' +
+      ' before-hydration-url="/@id/astro:scripts/before-hydration.js" ssr></astro-island>';
+
+    expect(prefixDevAssetUrlsFor('/portal', html)).toBe(
+      '<astro-island uid="r1" component-url="/portal/src/components/portal/PublicQuoteView.tsx"' +
+        ' renderer-url="/portal/@fs/repo/node_modules/@astrojs/react/dist/client.js"' +
+        ' before-hydration-url="/portal/@id/astro:scripts/before-hydration.js" ssr></astro-island>'
+    );
+  });
+
+  it('prefixes the dev client, stylesheet and pre-bundled dep script tags', () => {
+    const html =
+      '<script type="module" src="/@vite/client"></script>' +
+      '<script type="module" src="/src/styles/globals.css"></script>' +
+      '<script type="module" src="/@react-refresh"></script>' +
+      '<script type="module" src="/node_modules/.vite/deps/react.js?v=725ea0a5"></script>';
+
+    expect(prefixDevAssetUrlsFor('/portal', html)).toBe(
+      '<script type="module" src="/portal/@vite/client"></script>' +
+        '<script type="module" src="/portal/src/styles/globals.css"></script>' +
+        '<script type="module" src="/portal/@react-refresh"></script>' +
+        '<script type="module" src="/portal/node_modules/.vite/deps/react.js?v=725ea0a5"></script>'
+    );
+  });
+
+  it('leaves portal routes, API calls and public assets alone', () => {
+    const html =
+      '<a href="/portal/quotes">Quotes</a>' +
+      '<form action="/api/v1/portal/auth/login">' +
+      '<link rel="icon" href="/portal/favicon.svg">' +
+      '<a href="/srcset-guide">not a dev namespace</a>';
+
+    expect(prefixDevAssetUrlsFor('/portal', html)).toBe(html);
+  });
+
+  it('is idempotent — a second pass does not double-prefix', () => {
+    const html = '<astro-island component-url="/src/components/portal/LoginForm.tsx"></astro-island>';
+    const once = prefixDevAssetUrlsFor('/portal', html);
+
+    expect(prefixDevAssetUrlsFor('/portal', once)).toBe(once);
+    expect(once).toContain('component-url="/portal/src/components/portal/LoginForm.tsx"');
+  });
+
+  it('handles single-quoted attributes and a non-default base', () => {
+    const html = "<script type='module' src='/@vite/client'></script>";
+
+    expect(prefixDevAssetUrlsFor('/customer', html)).toBe(
+      "<script type='module' src='/customer/@vite/client'></script>"
+    );
+  });
+
+  it('is a pass-through at a root deploy (empty base)', () => {
+    const html = '<astro-island component-url="/src/components/portal/LoginForm.tsx"></astro-island>';
+
+    expect(prefixDevAssetUrlsFor('', html)).toBe(html);
+  });
+
+  it('rewrites every occurrence, not just the first', () => {
+    const html = '<script src="/@vite/client"></script><script src="/src/a.ts"></script><script src="/src/b.ts"></script>';
+
+    expect(prefixDevAssetUrlsFor('/portal', html)).toBe(
+      '<script src="/portal/@vite/client"></script><script src="/portal/src/a.ts"></script><script src="/portal/src/b.ts"></script>'
+    );
+  });
+});
+
+describe('isHtmlContentType', () => {
+  it.each([
+    ['text/html; charset=utf-8', true],
+    ['text/html', true],
+    ['TEXT/HTML;charset=UTF-8', true],
+    ['application/json', false],
+    ['text/html-ish', false],
+    [null, false]
+  ])('%s → %s', (contentType, expected) => {
+    expect(isHtmlContentType(contentType)).toBe(expected);
+  });
+});

--- a/apps/portal/src/lib/devAssetBase.test.ts
+++ b/apps/portal/src/lib/devAssetBase.test.ts
@@ -73,6 +73,17 @@ describe('prefixDevAssetUrlsFor', () => {
     expect(prefixDevAssetUrlsFor('', html)).toBe(html);
   });
 
+  it('covers a Vite dev namespace nobody enumerated', () => {
+    // The `/@…` space is reserved for Vite dev-server internals and grows across
+    // versions. A hand-maintained list would miss a new one silently — the page
+    // would still SSR and simply never hydrate, which is #3906 all over again.
+    const html = '<script type="module" src="/@some-future-vite-namespace/thing.js"></script>';
+
+    expect(prefixDevAssetUrlsFor('/portal', html)).toBe(
+      '<script type="module" src="/portal/@some-future-vite-namespace/thing.js"></script>'
+    );
+  });
+
   it('rewrites every occurrence, not just the first', () => {
     const html = '<script src="/@vite/client"></script><script src="/src/a.ts"></script><script src="/src/b.ts"></script>';
 

--- a/apps/portal/src/lib/devAssetBase.test.ts
+++ b/apps/portal/src/lib/devAssetBase.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { isHtmlContentType, prefixDevAssetUrlsFor } from './devAssetBase';
+import {
+  isHtmlContentType,
+  prefixDevAssetUrlsFor,
+  shouldPrefixDevAssetUrlsFor
+} from './devAssetBase';
 
 /**
  * Regression cover for #3906: the portal dev server emits its module URLs from
@@ -75,6 +79,36 @@ describe('prefixDevAssetUrlsFor', () => {
     expect(prefixDevAssetUrlsFor('/portal', html)).toBe(
       '<script src="/portal/@vite/client"></script><script src="/portal/src/a.ts"></script><script src="/portal/src/b.ts"></script>'
     );
+  });
+});
+
+describe('shouldPrefixDevAssetUrlsFor', () => {
+  const html = { isDev: true, hasBody: true, contentType: 'text/html; charset=utf-8' };
+
+  it('rewrites a dev HTML page response', () => {
+    expect(shouldPrefixDevAssetUrlsFor('/portal', html)).toBe(true);
+  });
+
+  it('never rewrites in a production build', () => {
+    expect(shouldPrefixDevAssetUrlsFor('/portal', { ...html, isDev: false })).toBe(false);
+  });
+
+  it('never rewrites at a root deploy (empty base)', () => {
+    expect(shouldPrefixDevAssetUrlsFor('', html)).toBe(false);
+  });
+
+  it('skips a null-body status — swapping its body for a string throws in Response', () => {
+    // A 304 can still carry Content-Type: text/html. Rewriting it would hand
+    // `new Response('', { status: 304 })` a body, which the constructor rejects.
+    expect(shouldPrefixDevAssetUrlsFor('/portal', { ...html, hasBody: false })).toBe(false);
+    expect(() => new Response('', { status: 304 })).toThrow();
+  });
+
+  it('skips non-HTML bodies (JSON endpoints, assets)', () => {
+    expect(
+      shouldPrefixDevAssetUrlsFor('/portal', { ...html, contentType: 'application/json' })
+    ).toBe(false);
+    expect(shouldPrefixDevAssetUrlsFor('/portal', { ...html, contentType: null })).toBe(false);
   });
 });
 

--- a/apps/portal/src/lib/devAssetBase.ts
+++ b/apps/portal/src/lib/devAssetBase.ts
@@ -32,24 +32,33 @@ import { BASE_PATH } from './basePath';
  * URL namespaces the Astro/Vite dev server owns. Every one of these is served by
  * the dev server's own middleware — none is a portal route, and API calls
  * (`/api/v1/...`) are deliberately absent so they keep going to the API origin.
+ *
+ * `@` is deliberately the bare prefix rather than an enumeration of the four
+ * namespaces we actually observed (`/@fs/`, `/@id/`, `/@vite/`,
+ * `/@react-refresh`). Vite reserves the whole `/@…` space for dev-server
+ * internals and adds to it across versions, and a namespace missing from a
+ * hand-maintained list would fail exactly the way #3906 did: silently, with the
+ * page still SSR'ing correctly and only a console 404 nobody reads. Matching the
+ * reserved prefix means a namespace we have never seen still routes to the
+ * portal. No portal route begins with `/@`.
  */
-export const DEV_ASSET_NAMESPACES = [
-  '@fs/',
-  '@id/',
-  '@vite/',
-  '@react-refresh',
-  'src/',
-  'node_modules/'
-] as const;
+export const DEV_ASSET_NAMESPACES = ['@', 'src/', 'node_modules/'] as const;
 
 /**
  * Matches a root-relative dev-server URL sitting in an HTML attribute value —
  * `="/@fs/…`, `="/src/…` and friends. Anchoring on `="` (or `='`) keeps the
- * rewrite inside attribute values instead of touching page text, and an
- * already-prefixed URL (`="/portal/@fs/…`) does not match, so the rewrite is
- * idempotent.
+ * rewrite inside attribute values instead of touching page text (and leaves
+ * Vite's `data-vite-dev-id`, which holds an absolute *filesystem* path rather
+ * than a URL, correctly alone). An already-prefixed URL (`="/portal/@fs/…`)
+ * does not match, so the rewrite is idempotent.
+ *
+ * Built from DEV_ASSET_NAMESPACES so the list above stays the single source of
+ * truth — a namespace added there is picked up here automatically.
  */
-const DEV_ASSET_URL_RE = /(=["'])\/(@fs\/|@id\/|@vite\/|@react-refresh|src\/|node_modules\/)/g;
+const DEV_ASSET_URL_RE = new RegExp(
+  `(=["'])\\/(${DEV_ASSET_NAMESPACES.map((ns) => ns.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})`,
+  'g'
+);
 
 /**
  * Prefix the dev server's module URLs in `html` with an explicit base.

--- a/apps/portal/src/lib/devAssetBase.ts
+++ b/apps/portal/src/lib/devAssetBase.ts
@@ -71,3 +71,26 @@ export function prefixDevAssetUrls(html: string): string {
 export function isHtmlContentType(contentType: string | null): boolean {
   return !!contentType && contentType.split(';', 1)[0].trim().toLowerCase() === 'text/html';
 }
+
+/**
+ * Whether a response should get the rewrite, with the base passed explicitly.
+ *
+ * `hasBody` is load-bearing rather than an optimisation: a null-body status
+ * (204/304/…) has nothing to rewrite, and swapping its null body for the empty
+ * string the rewrite would return makes the `Response` constructor throw.
+ */
+export function shouldPrefixDevAssetUrlsFor(
+  base: string,
+  input: { isDev: boolean; hasBody: boolean; contentType: string | null }
+): boolean {
+  return !!base && input.isDev && input.hasBody && isHtmlContentType(input.contentType);
+}
+
+/** Whether a response should get the rewrite, bound to the build-time base path. */
+export function shouldPrefixDevAssetUrls(input: {
+  isDev: boolean;
+  hasBody: boolean;
+  contentType: string | null;
+}): boolean {
+  return shouldPrefixDevAssetUrlsFor(BASE_PATH, input);
+}

--- a/apps/portal/src/lib/devAssetBase.ts
+++ b/apps/portal/src/lib/devAssetBase.ts
@@ -1,0 +1,73 @@
+/**
+ * Dev-only: base-prefix the raw dev-server module URLs Astro writes into the page.
+ *
+ * `astro dev` deliberately keeps Vite base-agnostic — it strips the configured
+ * `base` off every incoming request in its own front-of-stack middleware and then
+ * emits Vite's module URLs from the server root. `astro.config.mjs` puts Vite's
+ * `base` back (see the `breeze:portal-dev-base` plugin there), which covers the
+ * whole *module graph* — import analysis, pre-bundled deps, HMR client,
+ * react-refresh. It does NOT cover the handful of URLs Astro itself hardcodes
+ * into the rendered HTML:
+ *
+ *   <script type="module" src="/@vite/client">
+ *   <script type="module" src="/src/styles/globals.css">
+ *   <astro-island component-url="/src/components/portal/PublicQuoteView.tsx"
+ *                 renderer-url="/@fs/…" before-hydration-url="/@id/…">
+ *
+ * Those are the *entry points* of the island module graph, so leaving them
+ * unprefixed leaves every island dead: behind the worktree/dev stack's Caddy the
+ * portal is routed by path (`/portal` and `/portal/*`), so an unprefixed
+ * `/src/components/portal/PublicQuoteView.tsx` fell through to the web app and
+ * 404'd — the page SSR'd correctly and then silently never hydrated (#3906).
+ *
+ * Prefixing is a pure string rewrite over the dev server's own URL namespaces,
+ * none of which can collide with a portal route or an API path. It runs only when
+ * `import.meta.env.DEV` is set (see src/middleware.ts); a production build serves
+ * bundled assets that Astro already prefixes with the base.
+ */
+
+import { BASE_PATH } from './basePath';
+
+/**
+ * URL namespaces the Astro/Vite dev server owns. Every one of these is served by
+ * the dev server's own middleware — none is a portal route, and API calls
+ * (`/api/v1/...`) are deliberately absent so they keep going to the API origin.
+ */
+export const DEV_ASSET_NAMESPACES = [
+  '@fs/',
+  '@id/',
+  '@vite/',
+  '@react-refresh',
+  'src/',
+  'node_modules/'
+] as const;
+
+/**
+ * Matches a root-relative dev-server URL sitting in an HTML attribute value —
+ * `="/@fs/…`, `="/src/…` and friends. Anchoring on `="` (or `='`) keeps the
+ * rewrite inside attribute values instead of touching page text, and an
+ * already-prefixed URL (`="/portal/@fs/…`) does not match, so the rewrite is
+ * idempotent.
+ */
+const DEV_ASSET_URL_RE = /(=["'])\/(@fs\/|@id\/|@vite\/|@react-refresh|src\/|node_modules\/)/g;
+
+/**
+ * Prefix the dev server's module URLs in `html` with an explicit base.
+ * Pass-through at root deploy (empty base owns everything already).
+ */
+export function prefixDevAssetUrlsFor(base: string, html: string): string {
+  if (!base) return html;
+  return html.replace(DEV_ASSET_URL_RE, (_match, attr: string, namespace: string) =>
+    `${attr}${base}/${namespace}`
+  );
+}
+
+/** Prefix the dev server's module URLs with the build-time base path. */
+export function prefixDevAssetUrls(html: string): string {
+  return prefixDevAssetUrlsFor(BASE_PATH, html);
+}
+
+/** True when a response body is HTML we should rewrite. */
+export function isHtmlContentType(contentType: string | null): boolean {
+  return !!contentType && contentType.split(';', 1)[0].trim().toLowerCase() === 'text/html';
+}

--- a/apps/portal/src/middleware.ts
+++ b/apps/portal/src/middleware.ts
@@ -3,6 +3,7 @@ import { randomBytes } from 'node:crypto';
 import { hasPortalSessionCookie } from './lib/session';
 import { isOutsideBase, stripBase, withBase } from './lib/basePath';
 import { buildFallbackCspDirectives, resolvePortalCspHeader } from './lib/csp';
+import { isHtmlContentType, prefixDevAssetUrls } from './lib/devAssetBase';
 
 // Every signed-in surface. `/quotes` and `/invoices` were missing here, so both
 // rendered server-side for an unauthenticated visitor and only failed at the API
@@ -110,7 +111,23 @@ export const onRequest = defineMiddleware(async (context, next) => {
     headers.set('Cache-Control', 'no-store');
   }
 
-  return new Response(response.body, {
+  // #3906 — dev only: Astro hardcodes a few dev-server URLs straight into the
+  // rendered HTML (`/@vite/client`, the island's `component-url` / `renderer-url` /
+  // `before-hydration-url`, the `/src/styles/*` stylesheet). Vite's `base` — which
+  // the `breeze:portal-dev-base` plugin in astro.config.mjs sets — covers the rest
+  // of the module graph but never reaches those, and they are precisely the entry
+  // points that start hydration. Behind the worktree stack's path-routed Caddy an
+  // unprefixed entry point resolves against the *web* app, so the island stays
+  // dead while the SSR'd markup still looks right. Buffering the body costs dev
+  // streaming only; a production build ships base-prefixed bundled assets and
+  // never enters this branch.
+  let body: BodyInit | null = response.body;
+  if (isDev && isHtmlContentType(headers.get('Content-Type'))) {
+    body = prefixDevAssetUrls(await response.text());
+    headers.delete('Content-Length');
+  }
+
+  return new Response(body, {
     status: response.status,
     statusText: response.statusText,
     headers

--- a/apps/portal/src/middleware.ts
+++ b/apps/portal/src/middleware.ts
@@ -3,7 +3,7 @@ import { randomBytes } from 'node:crypto';
 import { hasPortalSessionCookie } from './lib/session';
 import { isOutsideBase, stripBase, withBase } from './lib/basePath';
 import { buildFallbackCspDirectives, resolvePortalCspHeader } from './lib/csp';
-import { isHtmlContentType, prefixDevAssetUrls } from './lib/devAssetBase';
+import { prefixDevAssetUrls, shouldPrefixDevAssetUrls } from './lib/devAssetBase';
 
 // Every signed-in surface. `/quotes` and `/invoices` were missing here, so both
 // rendered server-side for an unauthenticated visitor and only failed at the API
@@ -120,10 +120,19 @@ export const onRequest = defineMiddleware(async (context, next) => {
   // unprefixed entry point resolves against the *web* app, so the island stays
   // dead while the SSR'd markup still looks right. Buffering the body costs dev
   // streaming only; a production build ships base-prefixed bundled assets and
-  // never enters this branch.
+  // never enters this branch. shouldPrefixDevAssetUrls carries the conditions
+  // (and the reason each one matters) so they stay unit-testable.
   let body: BodyInit | null = response.body;
-  if (isDev && isHtmlContentType(headers.get('Content-Type'))) {
+  if (
+    shouldPrefixDevAssetUrls({
+      isDev,
+      hasBody: response.body !== null,
+      contentType: headers.get('Content-Type')
+    })
+  ) {
     body = prefixDevAssetUrls(await response.text());
+    // The rewritten body is longer than the original; a stale Content-Length
+    // would truncate it.
     headers.delete('Content-Length');
   }
 

--- a/docker-compose.override.yml.dev
+++ b/docker-compose.override.yml.dev
@@ -11,16 +11,9 @@ services:
     ports:
       - '6379:6379'
 
-  caddy:
-    # Uses canonical docker/Caddyfile.prod mounted by the base compose.
-    # No command override needed — Caddy reads the volume-mounted config.
-    environment:
-      # Enables the @portalDevAssets matcher (#3906) so unprefixed Astro/Vite
-      # dev module URLs for portal islands (/src/*, /@fs/*, /@vite/*,
-      # /node_modules/.vite/*) route to the dev portal service instead of
-      # 404ing against web:4321. Unset in production — see the matcher's
-      # comment in docker/Caddyfile.prod.
-      CADDY_PORTAL_DEV_ASSETS: "1"
+  # caddy needs no dev override: it uses the canonical docker/Caddyfile.prod
+  # mounted by the base compose, and the portal (dev server included) is routed
+  # on path alone under /portal — see the @portal block there and #3906.
 
   binaries-init:
     image: alpine:3.19

--- a/docker/Caddyfile.prod
+++ b/docker/Caddyfile.prod
@@ -334,46 +334,19 @@
   # hostname/cert. The portal app emits /portal-prefixed URLs (Astro `base`), so we
   # keep the prefix (handle, not handle_path). Must come BEFORE the web catch-all.
   # API calls stay on the /api/* block above (same-origin → no CORS).
+  #
+  # This one path rule covers dev as well as prod. A production build emits bundled
+  # assets under /portal/_astro/*; in dev the portal's Vite server is mounted at the
+  # same base (the `breeze:portal-dev-base` plugin in apps/portal/astro.config.mjs
+  # plus the HTML rewrite in apps/portal/src/middleware.ts), so its module-graph
+  # URLs — /portal/src/*, /portal/@fs/*, /portal/@vite/client,
+  # /portal/node_modules/.vite/deps/* — match here too. #3906 first tried to route
+  # those unprefixed by sniffing the Referer; that could never work (island dynamic
+  # `import()` sends no Referer, and nested imports send the importing module's own
+  # unprefixed URL), which is why the portal is routed on path alone.
   @portal path /portal /portal/*
   handle @portal {
     encode zstd gzip
-    reverse_proxy portal:4322
-  }
-
-  # --- Dev-only: portal client-island module URLs (#3906) ---
-  # apps/portal/astro.config.mjs sets `base: /portal`, but that only prefixes
-  # *page* routes. Astro's dev server (Vite) does NOT honor `base` for the
-  # raw module-graph URLs the `astro-island` runtime fetches to hydrate a
-  # `client:load` island — e.g. `/src/components/portal/PublicQuoteView.tsx`,
-  # `/@fs/*`, `/@vite/*`, `/node_modules/.vite/*`. In dev those unprefixed
-  # requests fell through to the web catch-all below (web:4321), which has no
-  # such file: a silent 404, so the island never hydrated even though the
-  # SSR'd markup still looked correct (portal e2e specs were asserting
-  # against dead markup — see project memory
-  # portal_dev_island_hydration_404.md). A production build serves portal's
-  # own bundled assets already prefixed under /portal/*, so this has never
-  # been a prod issue.
-  #
-  # The web app is ALSO Astro + React islands and serves the SAME class of
-  # raw dev paths for its OWN islands, so this can't be routed by path alone
-  # — that would steal web's dev assets. Gate on the Referer (the browser
-  # sends it on these module-graph fetches, pointing at the page that
-  # requested them) so only requests that came from a /portal page reach the
-  # portal dev server.
-  #
-  # CADDY_PORTAL_DEV_ASSETS is unset in production — docker-compose.yml sets
-  # no such var for the caddy service, so `{env.CADDY_PORTAL_DEV_ASSETS}` is
-  # "" there and this matcher can never fire (same env-gate pattern as
-  # @remoteAccessClosed above). Only docker-compose.override.yml.dev sets it
-  # to "1", for the code-mounted dev portal (Dockerfile.portal.dev) used by
-  # both plain dev-mode and wt-stack/worktree stacks (which layer on top of
-  # .dev — see scripts/dev/wt-stack/compose.ts).
-  @portalDevAssets {
-    expression {env.CADDY_PORTAL_DEV_ASSETS} == "1"
-    header_regexp Referer ^https?://[^/]+(?::\d+)?/portal(?:/|$)
-    path /src/* /@fs/* /@vite/* /node_modules/.vite/*
-  }
-  handle @portalDevAssets {
     reverse_proxy portal:4322
   }
 

--- a/e2e-tests/tests/multi-currency.spec.ts
+++ b/e2e-tests/tests/multi-currency.spec.ts
@@ -228,12 +228,12 @@ test.describe('multi-currency — non-USD org browser slices', () => {
         await expect(publicPage.getByTestId('public-quote-accept')).toBeVisible();
 
         // Hydration guard (#3906) — see the same note in
-        // quote-contract-proposal.spec.ts: Caddy previously dropped this
-        // `client:load` island's unprefixed dev module URL into the web
-        // catch-all instead of the portal, so it never hydrated even though
-        // the SSR'd markup above looked correct. Fail loud here if that
-        // routing (docker/Caddyfile.prod's @portalDevAssets matcher)
-        // regresses.
+        // quote-contract-proposal.spec.ts: the portal dev server used to emit
+        // this `client:load` island's module URL without the `/portal` prefix,
+        // so Caddy dropped it into the web catch-all and it never hydrated even
+        // though the SSR'd markup above looked correct. The portal dev server
+        // now serves its whole module graph under the base path, so fail loud
+        // here if that regresses.
         await waitForHydration(publicPage, 'public-quote-accept');
 
         // Accept through the same public endpoint the "Accept & sign" button

--- a/e2e-tests/tests/quote-contract-proposal.spec.ts
+++ b/e2e-tests/tests/quote-contract-proposal.spec.ts
@@ -244,16 +244,17 @@ test.describe('quote + contract proposal lifecycle', () => {
       await expect(publicPage.getByTestId('public-quote-signer')).toBeVisible();
       await expect(publicPage.getByTestId('public-quote-accept')).toBeVisible();
 
-      // Hydration guard (#3906): a worktree-stack Caddy config used to route
-      // the unprefixed Astro/Vite dev module URLs these `client:load`
-      // islands fetch (e.g. `/src/components/portal/PublicQuoteView.tsx`)
-      // into the web catch-all instead of the portal, so the hydration
-      // module always 404'd here and PublicQuoteView never mounted — the
-      // SSR'd markup above looked correct while every button on the page was
-      // inert. Caddy now routes those dev module URLs to the portal service
-      // (docker/Caddyfile.prod's @portalDevAssets matcher), so this island
-      // MUST hydrate; if the routing (or the island) regresses, fail loud
-      // here instead of only being caught by the console 404 nobody reads.
+      // Hydration guard (#3906): the portal dev server used to emit the Astro/
+      // Vite module URLs these `client:load` islands fetch (e.g.
+      // `/src/components/portal/PublicQuoteView.tsx`) without the `/portal`
+      // prefix, so the worktree stack's path-routed Caddy sent them to the web
+      // catch-all — the hydration module 404'd and PublicQuoteView never
+      // mounted. The SSR'd markup above looked correct while every button on
+      // the page was inert. The portal dev server now serves its whole module
+      // graph under the base path (apps/portal/astro.config.mjs +
+      // src/middleware.ts), so this island MUST hydrate; if that (or the
+      // island) regresses, fail loud here instead of only being caught by the
+      // console 404 nobody reads.
       await waitForHydration(publicPage, 'public-quote-accept');
 
       // Accept via the same public endpoint the "Accept & sign" button calls


### PR DESCRIPTION
Closes #3906

## The problem

No portal React island hydrated in a `pnpm wt-stack` / dev stack. Pages SSR'd correctly and then died silently — the markup looked right, so a browser-level check passed while nothing on the page was interactive. Portal e2e specs were asserting against dead markup.

`astro dev` deliberately keeps Vite base-agnostic: it strips the configured `base` off every incoming request in its own front-of-stack middleware (`astro/dist/vite-plugin-astro-server/base.js`) and **never sets Vite's `base`**. So the dev server emits its module URLs from the server root — `/src/*`, `/@fs/*`, `/@id/*`, `/@vite/client`, `/node_modules/.vite/deps/*`. Caddy routes the portal **by path** (`/portal` and `/portal/*`), so those fell through to the web catch-all: a portal-only file 404'd, and a path both Astro apps happen to share was silently served from the **wrong app**.

### Why #4425 could not work

#4425 tried to route the unprefixed paths by sniffing a `/portal` `Referer`. Three independent reasons that gate can never fire on the requests that actually hydrate an island:

1. The `astro-island` dynamic `import()` sends **no `Referer` at all**.
2. Nested/transitive imports send the **importing module's own** unprefixed `/@fs/...` URL as `Referer`.
3. `apps/portal/src/middleware.ts` sets `Referrer-Policy: no-referrer` on exactly the `/quote/` and `/invoice/` pages the gate was meant to serve.

## The fix (option C — fix the emission side)

Make the portal dev server emit base-prefixed module URLs, so the existing path rule already covers them. No header sniffing, no dev-only proxy rules.

- **`breeze:portal-dev-base`** (`apps/portal/astro.config.mjs`) sets Vite's `base` in dev. That prefixes the entire module graph: import analysis, pre-bundled deps, HMR client, react-refresh. It also removes Vite's own base-stripping middleware — Astro has already stripped `/portal` by the time it runs, so Vite's would double-strip and 404 **every** request with *"The server is configured with a public base URL of /portal/…"* (verified live, see below). The plugin throws a loud, explanatory error if that middleware ever stops being findable rather than silently reding out dev. `apply: 'serve'` keeps `astro build` untouched.
- Vite's `base` never reaches the handful of entry-point URLs **Astro itself hardcodes** into the HTML (`component-url`, `renderer-url`, `before-hydration-url`, `/@vite/client`, `/src/styles/*`) — and those are precisely what starts hydration. `src/middleware.ts` prefixes them in dev via the new pure helper `src/lib/devAssetBase.ts` (13 unit tests).
- **Caddy cleanup:** the `@portalDevAssets` Referer matcher and its `CADDY_PORTAL_DEV_ASSETS` env gate are deleted. The single `@portal` path rule now covers dev and prod alike.

### Production is unaffected

`PORTAL_BASE_PATH` is baked in at build time and prod already serves the portal under `/portal` on the main domain (`docker/Caddyfile.prod`, `deploy/docker-compose.prod.yml`), so dev and prod are now consistent. Verified by building:

- `astro build` still emits `"/portal/_astro/…"` asset URLs — **no double prefix** anywhere in `dist/`.
- `grep -rl "prefixDevAssetUrls\|@react-refresh" dist/server` → **empty**: the dev rewrite is dead-stripped from the production bundle.

## Live verification (wt-stack, Playwright)

Stack: `pnpm wt-stack up` on this branch → `http://localhost:32806`.

**`/portal/login`** — island hydrated:
```
component-url = "/portal/src/components/portal/LoginForm.tsx"
ssr attribute  = dropped (island.hasAttribute('ssr') === false)
React fiber elements on page = 10
console errors/warnings = 0
[vite] connected.   ← HMR websocket works through Caddy too
```
All 60+ module requests were `/portal/…` and **200** — zero unprefixed, zero 404s.

**Public quote page** (`/portal/quote/<token>` — the `no-referrer` page #4425's gate could never serve):
```
component-url = "/portal/src/components/portal/PublicQuoteView.tsx"
ssr attribute  = dropped
public-quote-accept has __reactFiber$ = true
React fiber elements on page = 63
169 network requests, all /portal/…, all 200/304, zero 404s
console errors/warnings = 0
```
Interactivity proven, not just presence — typing a signer name and ticking the agreement box flipped the accept button through React state:
```
aria-disabled: "true"  →  "false"      (disabled prop: false)
```
That is the exact symptom from the issue ("accept button stays `aria-disabled`, zero non-GET requests").

**Regression check — the web app is unchanged.** Removing the Caddy block returns those root paths to web, which is correct since web is the catch-all. `/login` on the web app: 2 islands, **0** still-`ssr`, 58 React fiber elements, 0 console errors. Web's dev URLs stay unprefixed at the root; the two apps no longer overlap at all.

**Edge paths through Caddy:** `/portal` → 302 `/portal/login`, `/portal/` → 302, `/portal/quotes` → 302 (auth), `/portal/nope-404` → 404, `/` → 200 from web. `caddy validate` → `Valid configuration`.

## Tests

| Check | Result |
|---|---|
| `e2e-tests/tests/multi-currency.spec.ts` (live stack) | **1 passed (48.8s)** — clears `waitForHydration(publicPage, 'public-quote-accept')` |
| `apps/portal` vitest (full suite, post-merge with main) | **27 files / 272 tests passed** |
| `apps/portal/src/lib/devAssetBase.test.ts` (new) | 13 passed; mutation-checked (breaking the regex reds it) |
| `astro check` (portal) | **0 errors**, 0 warnings |
| `tsc --noEmit` (e2e-tests) | clean |
| `pnpm lint` | 6/6 tasks successful |
| `pnpm test:dev-scripts` | 6 files / 23 tests passed |
| `caddy validate` | Valid configuration |

`quote-contract-proposal.spec.ts` has an unrelated pre-existing failure earlier in the **web** flow (AuthOverlay / session-expired on the contracts tab) and was not chased here — only its stale `@portalDevAssets` comment is updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
