### PR TITLE
fix(mobile): pre-submission pass (time-entry labels, empty-activity gate, build 8, privacy manifest)

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -9,18 +9,28 @@
     "ios": {
       "supportsTablet": false,
       "bundleIdentifier": "com.breeze.rmm",
-      "buildNumber": "7",
+      "buildNumber": "8",
       "associatedDomains": [
         "webcredentials:us.2breeze.app",
         "webcredentials:eu.2breeze.app"
       ],
       "infoPlist": {
+        "ITSAppUsesNonExemptEncryption": false,
         "NSFaceIDUsageDescription": "Use Face ID to unlock the app",
         "NSCameraUsageDescription": "Take photos of hardware, screens and cabling to attach to a ticket.",
         "NSPhotoLibraryUsageDescription": "Choose photos of hardware, screens and cabling to attach to a ticket.",
         "NSMotionUsageDescription": "Use device motion to support responsive interface animations.",
         "NSSpeechRecognitionUsageDescription": "Use voice to ask Breeze about your fleet.",
         "NSMicrophoneUsageDescription": "Use voice to ask Breeze about your fleet."
+      },
+      "privacyManifests": {
+        "NSPrivacyTracking": false,
+        "NSPrivacyAccessedAPITypes": [
+          { "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryUserDefaults", "NSPrivacyAccessedAPITypeReasons": ["CA92.1"] },
+          { "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryFileTimestamp", "NSPrivacyAccessedAPITypeReasons": ["C617.1"] },
+          { "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategorySystemBootTime", "NSPrivacyAccessedAPITypeReasons": ["35F9.1"] },
+          { "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryDiskSpace", "NSPrivacyAccessedAPITypeReasons": ["E174.1"] }
+        ]
       }
     },
     "android": {

--- a/apps/mobile/src/components/TimerBar.tsx
+++ b/apps/mobile/src/components/TimerBar.tsx
@@ -390,7 +390,10 @@ export function TimerBar({ onOpenTimesheet }: { onOpenTimesheet?: () => void } =
     ? tickets.find((candidate) => candidate.id === running.ticketId)
     : undefined;
   const label = running?.ticketId
-    ? (ticketRef({ internalNumber: ticket?.internalNumber ?? null }) ?? ticket?.subject ?? 'Ticket')
+    ? (ticketRef({ internalNumber: running.ticketNumber ?? ticket?.internalNumber ?? null }) ??
+      running.ticketSubject ??
+      ticket?.subject ??
+      'Ticket')
     : 'No ticket';
 
   const bar = (

--- a/apps/mobile/src/screens/tickets/TicketDetailScreen.tsx
+++ b/apps/mobile/src/screens/tickets/TicketDetailScreen.tsx
@@ -691,7 +691,10 @@ export function TicketDetailScreen() {
         <Text style={styles.sectionHeader}>
           ACTIVITY{activityCount ? ` (${activityCount})` : ''}
         </Text>
-        {ticket.comments.length === 0 ? (
+        {/* Gate on the rendered count, not the raw array: a ticket whose only
+            rows are blank system entries would otherwise show the header over
+            nothing at all. */}
+        {activityCount === 0 ? (
           <Text style={styles.metaDim}>No comments yet.</Text>
         ) : (
           ticket.comments.map((c) => {

--- a/apps/mobile/src/screens/time/TimesheetScreen.tsx
+++ b/apps/mobile/src/screens/time/TimesheetScreen.tsx
@@ -274,7 +274,10 @@ export function TimesheetScreen({ navigation }: TimesheetProps = {}) {
         <View style={styles.entryHeader}>
           <Text style={styles.entryRef}>
             {entry.ticketId
-              ? (ticketRef({ internalNumber: ticket?.internalNumber ?? null }) ?? ticket?.subject ?? 'Ticket')
+              ? (ticketRef({ internalNumber: entry.ticketNumber ?? ticket?.internalNumber ?? null }) ??
+                entry.ticketSubject ??
+                ticket?.subject ??
+                'Ticket')
               : 'No ticket'}
           </Text>
           <Text style={styles.entryDuration}>{formatMinutes(entry.durationMinutes)}</Text>

--- a/apps/mobile/src/services/timeEntries.test.ts
+++ b/apps/mobile/src/services/timeEntries.test.ts
@@ -16,6 +16,11 @@ import {
 const ENTRY = {
   id: 'e1', ticketId: 'k1', startedAt: '2026-08-23T10:00:00Z', endedAt: null,
   durationMinutes: null, isBillable: true, billingStatus: 'not_billed', isApproved: false, description: null,
+  // The API joins the ticket onto every entry (entrySelection in
+  // timeEntryService.ts) so the timesheet can label a row without the ticket
+  // being in the phone's filter-scoped ticket list, which excludes resolved
+  // and other people's tickets.
+  ticketNumber: 'T-2026-0002', ticketSubject: 'Printer offline',
 };
 
 beforeEach(() => { coreRequest.mockReset(); });
@@ -34,7 +39,10 @@ describe('getRunningTimer', () => {
 
   it('narrows the running-timer payload', async () => {
     coreRequest.mockResolvedValue({
-      data: { id: 't1', ticketId: 'k1', startedAt: '2026-08-23T10:00:00Z', description: 'onsite', extra: 'ignored' },
+      data: {
+        id: 't1', ticketId: 'k1', startedAt: '2026-08-23T10:00:00Z', description: 'onsite',
+        ticketNumber: 'T-2026-0002', ticketSubject: 'Printer offline', extra: 'ignored',
+      },
     });
     const timer = await getRunningTimer();
     // `localId: null` is the marker that the SERVER owns this timer, as
@@ -45,7 +53,17 @@ describe('getRunningTimer', () => {
       ticketId: 'k1',
       startedAt: '2026-08-23T10:00:00Z',
       description: 'onsite',
+      ticketNumber: 'T-2026-0002',
+      ticketSubject: 'Printer offline',
     });
+  });
+
+  it('defaults the ticket label fields to null when the entry has no ticket', async () => {
+    coreRequest.mockResolvedValue({
+      data: { id: 't2', ticketId: null, startedAt: '2026-08-23T10:00:00Z', description: null },
+    });
+    const timer = await getRunningTimer();
+    expect(timer).toMatchObject({ ticketId: null, ticketNumber: null, ticketSubject: null });
   });
 });
 
@@ -139,6 +157,8 @@ describe('createTimeEntry', () => {
     expect(entry).toEqual({
       id: 'e2',
       ticketId: null,
+      ticketNumber: null,
+      ticketSubject: null,
       startedAt: '2026-08-23T10:00:00Z',
       endedAt: null,
       durationMinutes: null,

--- a/apps/mobile/src/services/timeEntries.ts
+++ b/apps/mobile/src/services/timeEntries.ts
@@ -27,6 +27,15 @@ export interface RunningTimer {
   /** Set while the timer is device-only; null once the server owns it. */
   localId: string | null;
   ticketId: string | null;
+  /**
+   * Ticket label fields, joined server-side onto every entry so a row can be
+   * labelled without the ticket being in the phone's ticket list — that list
+   * is filter-scoped (open, assigned to me, first 50), so resolved tickets and
+   * other people's tickets are never in it. Null for device-only timers and
+   * entries with no ticket.
+   */
+  ticketNumber?: string | null;
+  ticketSubject?: string | null;
   startedAt: string;
   description: string | null;
 }
@@ -34,6 +43,9 @@ export interface RunningTimer {
 export interface TimeEntry {
   id: string;
   ticketId: string | null;
+  /** See RunningTimer.ticketNumber. */
+  ticketNumber?: string | null;
+  ticketSubject?: string | null;
   startedAt: string;
   endedAt: string | null;
   durationMinutes: number | null;
@@ -115,6 +127,8 @@ function narrowRunningTimer(row: ServerTimeEntry): RunningTimer {
     id: row.id,
     localId: null,
     ticketId: row.ticketId ?? null,
+    ticketNumber: row.ticketNumber ?? null,
+    ticketSubject: row.ticketSubject ?? null,
     startedAt: row.startedAt,
     description: row.description ?? null,
   };
@@ -124,6 +138,8 @@ function narrowTimeEntry(row: ServerTimeEntry): TimeEntry {
   return {
     id: row.id,
     ticketId: row.ticketId ?? null,
+    ticketNumber: row.ticketNumber ?? null,
+    ticketSubject: row.ticketSubject ?? null,
     startedAt: row.startedAt,
     endedAt: row.endedAt ?? null,
     durationMinutes: row.durationMinutes ?? null,


### PR DESCRIPTION
## Summary

Follow-ups from a static pass over every App Review walkthrough flow (auth and onboarding, tickets and time, alerts, devices, AI, approvals, store config) on `main` after #4534, #4536 and #4508 landed. Four read-only reviewers plus direct verification of each consequential claim.

### Time entries label by ticket again
The timesheet and timer bar resolved a row's label from the phone's ticket list, which is filter-scoped (open, assigned to me, first 50). Entries on resolved tickets or on other technicians' tickets found nothing, and after the ticket-reference change in #4534 every such row read "Ticket". The API already joins `ticketNumber` and `ticketSubject` onto every entry (`entrySelection` in `timeEntryService.ts`); the client dropped them. `TimeEntry` and `RunningTimer` now carry both and the two screens prefer them. Red-first tests on the narrowing (`timeEntries.test.ts`).

### Ticket detail
"No comments yet." now gates on the rendered activity count, not the raw comments array, so a ticket whose only rows are blank system entries does not show the ACTIVITY header over nothing.

### Store config
- `buildNumber` 7 to 8. `ci_post_clone.sh` does not manage the build number and 7 has been the value since 2026-08-20, so it is the number on the rejected upload.
- `ITSAppUsesNonExemptEncryption: false` (standard HTTPS only) so TestFlight stops asking on every upload.
- `ios.privacyManifests` declares the required-reason APIs the Expo template ships. `ios/` is regenerated by prebuild on every Xcode Cloud clone, so this is now in config rather than an untracked file.

## Verification
- `tsc --noEmit` clean, `vitest run` 90 files, 1192 passed.
- Not run on a device.

## Review findings not in this PR (pre-existing)
- Tickets list has no pagination past the first 50 and no first-load spinner.
- No global 401 handling outside cold start and AI chat; a revoked token shows per-tab errors instead of sending the user to sign in.
- `ApprovalGate` replaces the tab tree while an approval is focused, so a ticket push tapped at that moment is dropped (`navigateToTicket` only buffers when the container is not ready).
- Attachment upload 429 maps to the wrong error and is marked non-retryable.
- A dead self-hosted server URL surfaces as a raw "Network request failed" on the login screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpzNXnfbR6mdMqnMSkECPK
