### PR TITLE
feat(web,contacts): W04 contacts tab, CSV import UI, migration-guide docs (#3258)

### DIFF
--- a/apps/docs/src/content/docs/migration/atera.mdx
+++ b/apps/docs/src/content/docs/migration/atera.mdx
@@ -26,7 +26,7 @@ Atera is flat — Customers contain Agents, with an optional Site/Folder layer t
 | **Customer** | **Organization** | Direct match. |
 | Site / folder | **Site** | If unused, create one `Main` site per organization. |
 | Agent | Device | |
-| Contact | — | Breeze cannot create contacts programmatically today; enter them by hand or via your PSA. |
+| **Contact** | **Contact** | First-class records, organization-level or pinned to a site. Bulk-load with [Recipe 1c](/migration/toolkit/#recipe-1c--import-contacts) — matched on `externalId` so re-imports are idempotent, with fuzzy email/name matches held back for an explicit acknowledgement. |
 
 ---
 
@@ -74,7 +74,7 @@ Generate an API key under **Admin → API**. Everything below uses `X-API-KEY` a
 
    List your configured fields in **Admin → Custom Fields** first, then loop that call across agents.
 
-4. **Export contacts and tickets if you are leaving Atera's PSA.** `GET /contacts` and `GET /tickets`. Ticket history does not migrate into Breeze — export it to storage for reference before you cancel.
+4. **Export contacts and tickets if you are leaving Atera's PSA.** `GET /contacts` and `GET /tickets`. Contacts do land in Breeze — save the export as CSV and feed it to [Recipe 1c](/migration/toolkit/#recipe-1c--import-contacts). Ticket history does not — export it to storage for reference before you cancel.
 
 </Steps>
 

--- a/apps/docs/src/content/docs/migration/connectwise-automate.mdx
+++ b/apps/docs/src/content/docs/migration/connectwise-automate.mdx
@@ -25,7 +25,7 @@ Read [Migrating to Breeze](/migration/overview/) first.
 | **Location** | **Site** | Direct match. Automate always creates a default location per client. |
 | Computer group (static/auto-join) | Device Group | Auto-join groups map to Breeze [dynamic device groups](/features/device-groups/). |
 | Computer | Device | |
-| Contact | — | Breeze cannot create contacts programmatically today; enter them by hand or keep them in your PSA. |
+| **Contact** | **Contact** | First-class records, organization-level or pinned to a site. Bulk-load with [Recipe 1c](/migration/toolkit/#recipe-1c--import-contacts) — matched on `externalId` so re-imports are idempotent, with fuzzy email/name matches held back for an explicit acknowledgement. |
 
 ---
 

--- a/apps/docs/src/content/docs/migration/datto-rmm.mdx
+++ b/apps/docs/src/content/docs/migration/datto-rmm.mdx
@@ -27,6 +27,7 @@ Datto RMM is flat: an account contains **Sites**, and a Site contains Devices. T
 | — | Site | Create one site per org (name it `Main`) unless the customer genuinely has multiple locations. |
 | Device Group / filter | Device Group | Datto's saved device filters map to Breeze [dynamic device groups](/features/device-groups/). |
 | Device | Device | |
+| — | **Contact** | Breeze contacts are first-class records, organization-level or pinned to a site. Load them from your PSA export with [Recipe 1c](/migration/toolkit/#recipe-1c--import-contacts). |
 
 <Aside type="caution">
   Resist the temptation to map Datto Sites onto Breeze *Sites* under one big organization. Breeze scopes tenancy, RLS, billing, and portal access at the **organization** level — a customer that is only a Site cannot be isolated, billed, or given portal access independently. One customer, one organization.

--- a/apps/docs/src/content/docs/migration/kaseya-vsa.mdx
+++ b/apps/docs/src/content/docs/migration/kaseya-vsa.mdx
@@ -27,6 +27,7 @@ Kaseya's identity for a machine is `machineName.groupName.orgName` — the machi
 | **Machine Group** | **Site** | Machine groups are usually locations or departments. Nested subgroups (`hq.acme`) flatten to one site each. |
 | View / filter | Device Group | VSA Views map to Breeze [dynamic device groups](/features/device-groups/). |
 | Agent | Device | |
+| Staff member | **Contact** | An org's staff records, including the one designated its primary contact. Bulk-load with [Recipe 1c](/migration/toolkit/#recipe-1c--import-contacts); Breeze keeps one primary per organization and one per site. |
 
 <Aside type="tip">
   If your machine groups are departmental rather than geographic (`accounting.acme`, `warehouse.acme`), map them to Breeze **device groups** under a single site instead of to sites. Breeze sites carry a timezone and drive maintenance-window and patch scheduling; a department is not a timezone.

--- a/apps/docs/src/content/docs/migration/n-central.mdx
+++ b/apps/docs/src/content/docs/migration/n-central.mdx
@@ -25,6 +25,7 @@ Read [Migrating to Breeze](/migration/overview/) first.
 | **Site** | **Site** | Direct match. Many N-central estates only use the implicit single site per customer. |
 | Device filter | Device Group | N-central filters map to Breeze [dynamic device groups](/features/device-groups/). |
 | Device | Device | |
+| — | **Contact** | Breeze contacts are first-class records, organization-level or pinned to a site. Load them from your PSA export with [Recipe 1c](/migration/toolkit/#recipe-1c--import-contacts). |
 | **Probe** | — | Replaced by Breeze [network discovery](/features/discovery/) and [SNMP monitoring](/features/snmp/). See below. |
 
 ---

--- a/apps/docs/src/content/docs/migration/ninjaone.mdx
+++ b/apps/docs/src/content/docs/migration/ninjaone.mdx
@@ -23,6 +23,7 @@ Read [Migrating to Breeze](/migration/overview/) first.
 | **Location** | **Site** | Direct match, including the "Main Office" default. |
 | Device role / group | Device Group | Ninja's device roles map well to Breeze [dynamic device groups](/features/device-groups/). |
 | Device | Device | |
+| **Contact** | **Contact** | Direct match, plus an optional site pin. Export the organization's contacts and bulk-load them with [Recipe 1c](/migration/toolkit/#recipe-1c--import-contacts). |
 
 This is as close to a lift-and-shift as RMM tenancy gets.
 

--- a/apps/docs/src/content/docs/migration/other-rmms.mdx
+++ b/apps/docs/src/content/docs/migration/other-rmms.mdx
@@ -143,19 +143,22 @@ Breeze [remote access](/features/remote-access/) replaces it functionally. The m
 
 ## Adapting the Playbook to an Unlisted RMM
 
-Every guide in this section is the same seven questions. Answer them for your platform and you have a migration plan.
+Every guide in this section is the same eight questions. Answer them for your platform and you have a migration plan.
 
 | # | Question | Feeds |
 |---|---|---|
 | 1 | What is the tenancy hierarchy, and how does it map to `Organization → Site → Device Group`? | [Recipe 1](/migration/toolkit/#recipe-1--bootstrap-the-tenancy-tree-from-csv) |
 | 2 | How do I export the client/site tree and the device list as CSV? | Recipe 1, [Recipe 4](/migration/toolkit/#recipe-4--reconcile-enrollment) |
-| 3 | Can its script engine run PowerShell/bash as SYSTEM on a schedule? | [Recipe 3](/migration/toolkit/#recipe-3--the-push-payload) |
-| 4 | Are its scripts text-based (port) or step-based (re-author)? | [Recipe 6](/migration/toolkit/#recipe-6--bulk-script-import) |
-| 5 | Where do its custom fields / UDFs live, and which are populated? | [Custom fields](/features/custom-fields/) |
-| 6 | Which alerts actually generated tickets in the last 90 days? | [Monitors](/features/service-monitoring/) + [alert rules](/features/alerts/) |
-| 7 | What is the silent uninstall command, and does the platform bundle a *separate* remote-access agent? | [Recipe 5](/migration/toolkit/#recipe-5--find-endpoints-still-running-the-old-agent) |
+| 3 | Where do its customer contacts live — in the RMM, or only in the PSA? | [Recipe 1c](/migration/toolkit/#recipe-1c--import-contacts) |
+| 4 | Can its script engine run PowerShell/bash as SYSTEM on a schedule? | [Recipe 3](/migration/toolkit/#recipe-3--the-push-payload) |
+| 5 | Are its scripts text-based (port) or step-based (re-author)? | [Recipe 6](/migration/toolkit/#recipe-6--bulk-script-import) |
+| 6 | Where do its custom fields / UDFs live, and which are populated? | [Custom fields](/features/custom-fields/) |
+| 7 | Which alerts actually generated tickets in the last 90 days? | [Monitors](/features/service-monitoring/) + [alert rules](/features/alerts/) |
+| 8 | What is the silent uninstall command, and does the platform bundle a *separate* remote-access agent? | [Recipe 5](/migration/toolkit/#recipe-5--find-endpoints-still-running-the-old-agent) |
 
-Question 7 is the one people miss. Datto, Atera, Syncro, and ConnectWise all ship remote-access components installed separately from the RMM agent, and all of them can survive the RMM uninstall.
+Question 8 is the one people miss. Datto, Atera, Syncro, and ConnectWise all ship remote-access components installed separately from the RMM agent, and all of them can survive the RMM uninstall.
+
+Question 3 is the newly answerable one. Contacts are a real migration target now that Breeze holds them as first-class records rather than a single field on the organization, so wherever they live in the RMM, export them alongside the tenancy tree and load them through the same preview → commit pair.
 
 <Aside type="tip">
   If your platform is not listed and you work through this checklist, please open an issue or a pull request on the [Breeze repository](https://github.com/LanternOps/breeze) with what you found. These guides are built from real migrations.

--- a/apps/docs/src/content/docs/migration/overview.mdx
+++ b/apps/docs/src/content/docs/migration/overview.mdx
@@ -107,7 +107,7 @@ This is the single largest variable in migration cost, and it is determined enti
    | Atera Customer | Organization |
    | Pulseway Organization → Site → Group | Organization → Site → Device Group |
 
-   Breeze has no bulk import UI today, so this is scripted against the API — `POST /orgs/organizations` and `POST /orgs/sites`. The [Migration Toolkit](/migration/toolkit/) has a ready-to-run script that reads a two-column CSV and builds the whole tree, and each per-vendor page has the export query that produces that CSV.
+   Breeze has no bulk import UI for the tenancy tree (organizations and sites) today, so this phase is scripted against the API — `POST /orgs/organizations` and `POST /orgs/sites`. Contacts do have one (Settings → Organizations → Contacts → Import CSV, see Recipe 1c). The [Migration Toolkit](/migration/toolkit/) has a ready-to-run script that reads a two-column CSV and builds the whole tree, and each per-vendor page has the export query that produces that CSV.
 
 4. ### Phase 3 — Deploy the Breeze agent from the incumbent
 

--- a/apps/docs/src/content/docs/migration/overview.mdx
+++ b/apps/docs/src/content/docs/migration/overview.mdx
@@ -42,6 +42,7 @@ Set expectations with your team and your customers before you start. Nothing bel
 | Category | Status | Notes |
 |---|---|---|
 | Customer / site / device tree | **You rebuild it** | Scripted from the incumbent's API. See [Phase 2](#phase-2--rebuild-the-tenancy-tree). |
+| Customer contacts | **Scriptable** | First-class records in Breeze, organization-level or pinned to a site. Export from the incumbent or your PSA and load them with the [contacts importer](/migration/toolkit/#recipe-1c--import-contacts). |
 | Hardware & software inventory | **Regenerates** | Full inventory lands within minutes of enrollment. No migration needed. |
 | Patch state & compliance | **Regenerates** | Breeze re-scans; missing-patch state is accurate on first scan cycle. |
 | Performance / metric history | **Lost** | Starts from zero at enrollment. Keep the incumbent read-only if you need historical charts. |
@@ -144,6 +145,7 @@ This is the single largest variable in migration cost, and it is determined enti
    - Re-point your **PSA** so tickets are created by Breeze, not the incumbent. Connect via [PSA integrations](/features/psa-integrations/) and map organizations. Run both alert sources briefly, then disable alerting in the incumbent so you are not double-ticketing.
    - Migrate scripts (see the portability split above).
    - Re-create monitors, thresholds, and custom fields.
+   - Import each organization's contacts — see [Recipe 1c](/migration/toolkit/#recipe-1c--import-contacts). Rows carrying the incumbent's contact ID match on that link, so a later re-import is idempotent.
    - Re-point EDR, DNS filtering, backup, and documentation integrations.
    - Re-create technician accounts, roles, and MFA. Do this properly rather than mirroring the incumbent's grown-over-time permission sprawl.
 

--- a/apps/docs/src/content/docs/migration/syncro.mdx
+++ b/apps/docs/src/content/docs/migration/syncro.mdx
@@ -27,7 +27,7 @@ Syncro is flat — Customers own Assets, with no site layer.
 | — | **Site** | Create one `Main` site per organization. Use the customer's address to set a real timezone. |
 | Asset tag / policy folder | Device Group | Map to Breeze [dynamic device groups](/features/device-groups/). |
 | Asset | Device | Syncro assets include non-agent records (manually added hardware) — filter to agent-managed only. |
-| Contact | — | Breeze cannot create contacts programmatically today. |
+| **Contact** | **Contact** | First-class records, organization-level or pinned to a site. Bulk-load with [Recipe 1c](/migration/toolkit/#recipe-1c--import-contacts) — matched on `externalId` so re-imports are idempotent, with fuzzy email/name matches held back for an explicit acknowledgement. |
 
 ---
 
@@ -71,7 +71,7 @@ Generate an API token under **Admin → API Tokens** with read permissions on cu
 
    Filter on `asset_type` — only Syncro RMM assets have an agent. Manually created asset records are inventory, not migration targets.
 
-3. **Export what you are keeping from the PSA side.** If you are leaving Syncro entirely: `GET /tickets`, `GET /invoices`, `GET /contacts`, `GET /estimates`. None of this migrates into Breeze automatically. Export it to storage before you cancel — Syncro is your system of record for billing history.
+3. **Export what you are keeping from the PSA side.** If you are leaving Syncro entirely: `GET /contacts`, `GET /tickets`, `GET /invoices`, `GET /estimates`. Contacts do land in Breeze — save them as CSV and feed them to [Recipe 1c](/migration/toolkit/#recipe-1c--import-contacts). Tickets, invoices, and estimates do not. Export those to storage before you cancel — Syncro is your system of record for billing history.
 
 </Steps>
 

--- a/apps/docs/src/content/docs/migration/toolkit.mdx
+++ b/apps/docs/src/content/docs/migration/toolkit.mdx
@@ -117,7 +117,7 @@ Commit re-derives every row's annotation against fresh database state and reject
 
 Commit-only per-row fields: `expectedAnnotation`, `expectedOrganizationId`, `reactivate`. Top-level: `mode` (`skip` default, or `update`).
 
-The import covers **organizations and sites** (plus their external-link rows). It does not import devices — devices arrive by enrolling agents (Recipes 2–3). The single-record endpoints (`POST /orgs/organizations`, `POST /orgs/sites`) still exist for one-offs and carry fields the import rows don't (`contractStart`, `billingContact`, …).
+The import covers **organizations and sites** (plus their external-link rows). It does not import devices — devices arrive by enrolling agents (Recipes 2–3) — and its `contact` field carries only one headline contact per row; the many-contacts-per-organization case has its own importer in [Recipe 1c](#recipe-1c--import-contacts). The single-record endpoints (`POST /orgs/organizations`, `POST /orgs/sites`) still exist for one-offs and carry fields the import rows don't (`contractStart`, `billingContact`, …).
 
 ### Recipe 1b — Import Companies from Your PSA
 
@@ -126,6 +126,91 @@ If your company list already lives in a PSA, skip the CSV: a connected PSA can f
 In the web UI, open **Integrations → PSA** and choose **Import companies** on a connection. Scripted, the same preview → commit pair lives at `POST /psa/connections/:id/import/preview` and `POST /psa/connections/:id/import` (partner scope, MFA, and both org- and site-write permissions required). The PSA's companies come back as ordinary import rows with the same annotation vocabulary as the CSV import (create / matched / conflict), and each imported organization gets an external-link row carrying the PSA's stable company ID — so re-imports and later PSA syncs match by identity, not by name. Companies already linked to an organization are filtered out of the preview.
 
 The preview is bounded: a company cap, a wall-clock budget, and a page guard each stop a runaway listing, and the response says whether (and why) it was truncated — import a batch, then preview again for the rest.
+
+### Recipe 1c — Import Contacts
+
+Contacts are first-class records in Breeze — an organization's people, each either organization-level or pinned to one of that organization's sites — so they load through their own preview → commit pair: `POST /orgs/contacts/import/preview` and `POST /orgs/contacts/import`. Same partner-admin JWT with MFA satisfied as Recipe 1, same **1,000 rows per request** cap. Neither path is organization-scoped: every row names its own organization, so one file covers the whole estate.
+
+The web UI does the same job at **Settings → Organizations → *(an organization)* → Contacts**, which handles the upload, the column mapping, and the acknowledgement handshake below for you.
+
+**Row fields for `POST /orgs/contacts/import` and `/orgs/contacts/import/preview`**
+
+| Field | Required | Notes |
+|---|---|---|
+| `organizationId` *or* `organization` | yes | A UUID, or a name resolved within your own partner |
+| `site` | no | Site **name** within that organization; omit for an organization-level contact |
+| `name`, `email`, `phone`, `mobile` | one of | At least one must be non-blank — that is the identifier rule, and the database enforces it |
+| `title` | no | ≤255 chars |
+| `roles` | no | `billing`, `technical`, `escalation`, `admin`, `site`, `after_hours`, `portal` |
+| `externalId` / `externalSystem` | no | The source's stable contact ID, stored as a `contact_external_links` row. `externalSystem` defaults to `csv` |
+
+Commit-only per-row fields: `expectedAnnotation`, `expectedContactId`. Top-level: `mode` (`skip` default, or `update`), and `partnerId` when a system-scoped caller has to name the partner explicitly.
+
+A row carrying none of `name`/`email`/`phone`/`mobile` is a wire-contract violation, and **one malformed row rejects the whole request** with a `400`. Filter the trailing blank line every spreadsheet export leaves behind before you upload.
+
+Preview annotates every row and writes nothing:
+
+| Annotation | Meaning |
+|---|---|
+| `create` | A new contact will be created |
+| `link-match` | Matched through the durable `(organization, externalSystem, externalId)` link — the stable match, and the link *is* the acknowledgement |
+| `email-match` | Matched an existing contact by email alone — a hint, never applied unless acknowledged |
+| `name-match` | Matched an existing contact by name alone — a hint, never applied unless acknowledged |
+| `conflict` | Row can't proceed (see `conflictReason`) |
+| `org-not-found` | No such organization under your partner — also the answer when the organization exists but is not yours |
+
+A row may additionally carry a `warning`. That is a **non-fatal disclosure**: the row still applies exactly as its annotation says. There is one case today — an email or name hint matched several existing contacts, and the row resolved to `create` anyway because it carries its own `externalId`. Without that `externalId` the same ambiguity is a `conflict`.
+
+To commit a fuzzy match, echo back **both** `expectedAnnotation` and `expectedContactId` — the contact the preview named. Commit re-derives every annotation against fresh state and rejects a row whose annotation moved; the identity pin is what stops an acknowledgement you gave for one person being applied to whoever took over that address between preview and commit. `link-match` rows need no acknowledgement. `conflict` and `org-not-found` rows cannot be committed at all.
+
+Top-level `mode` decides what happens to a `link-match`: `skip` (the default) leaves the linked contact untouched and reports it under `skipped`, so re-uploading an unchanged file writes nothing; `update` applies the row. Either way the import **merges** — a blank or absent column never clears stored data, and `roles` is replaced only when the row supplies a non-empty list. Clearing a field is a deliberate act and lives on `PATCH /orgs/contacts/:contactId`, where an explicit `null` really does clear.
+
+```bash
+#!/usr/bin/env bash
+# import-contacts.sh — preview, then commit, a contacts CSV.
+# Columns: organization,site,name,email,phone,title,externalId
+# Usage: ./import-contacts.sh contacts.csv
+set -euo pipefail
+: "${BREEZE_URL:?}" "${BREEZE_TOKEN:?}"
+CSV="$1"
+AUTH=(-H "Authorization: Bearer $BREEZE_TOKEN" -H "Content-Type: application/json")
+
+# CSV → {"rows":[…]} (≤1000 rows per request). Blank cells are dropped rather
+# than sent: the import merges, so an empty column is "no data", never "clear".
+payload=$(tail -n +2 "$CSV" | jq -Rnc '
+  [inputs | split(",") | select((.[0] // "") != "")
+   | {organization: .[0], site: .[1], name: .[2], email: .[3],
+      phone: .[4], title: .[5], externalId: .[6], externalSystem: "csv"}
+   | with_entries(select(.value != null and .value != ""))]
+  | {rows: .}')
+
+# 1. Preview — writes nothing. Everything that is not a plain create wants eyes.
+curl -sf "${AUTH[@]}" -X POST "$BREEZE_URL/orgs/contacts/import/preview" -d "$payload" \
+  | jq -r '.rows[] | select(.annotation != "create" or .warning)
+           | [.annotation, (.organizationName // .organization),
+              (.name // .email),
+              (.matchedContactEmail // .conflictReason // .warning // "")] | @tsv'
+
+# 2. Commit. mode=skip leaves already-linked contacts alone, so re-runs are idempotent.
+curl -sf "${AUTH[@]}" -X POST "$BREEZE_URL/orgs/contacts/import" \
+  -d "$(jq -c '. + {mode:"skip"}' <<<"$payload")" \
+  | jq '{imported: (.imported|length), updated: (.updated|length),
+         skipped: (.skipped|length), errors: .errors}'
+```
+
+Commit always answers **`200`**, including on a partial failure — `{ imported, updated, skipped, errors }`, so the rows that did land are never hidden behind the rows that didn't. Branch on each error's `code`, never on its `error` text, which is display copy and gets reworded:
+
+| `code` | Meaning |
+|---|---|
+| `row-conflict` | The row is malformed, or ambiguous against existing state |
+| `org-not-found` | No such organization under your partner |
+| `annotation-changed` | The re-derived annotation differs from your acknowledgement |
+| `match-changed` | The contact you acknowledged is no longer the one the row resolves to |
+| `match-unconfirmed` | An `email-match` / `name-match` was never acknowledged |
+| `no-identifier` | The merged row would be left with no name, email, phone, or mobile |
+| `invalid-role` | A role outside the vocabulary above |
+| `site-not-in-org` | The named site does not belong to that organization |
+| `write-failed` | The database write failed |
 
 ---
 

--- a/apps/docs/src/content/docs/migration/toolkit.mdx
+++ b/apps/docs/src/content/docs/migration/toolkit.mdx
@@ -19,7 +19,7 @@ Everything here uses only documented, stable endpoints — see the [API Referenc
 Two credentials matter here, and they split cleanly by job:
 
 - **A partner service principal** — for anything unattended: Recipe 2's provisioning loop, scheduled syncs, anything that must run without a human at the keyboard. It authenticates against the Partner API (`$BREEZE_URL/partner-api/*`) via the `X-API-Key` header, never touches MFA, and never expires mid-run. Deliberately create-only: it can mint orgs, sites, and enrollment keys, but there is **no** DELETE surface — tearing down tenancy stays a human, MFA-gated act.
-- **A partner-admin user JWT** — for the bulk endpoints that live on the main API: org/site import (Recipe 1) and script bundles (Recipe 6). These are `requireMfa()`-gated: log in as a partner admin, complete the MFA challenge (when `ENABLE_2FA` is on, the JWT must carry `mfa: true` — a bare `POST /auth/login` token gets `403 MFA required`), and export the access token. Tokens are short-lived, so long runs should refresh via `POST /auth/refresh`.
+- **A partner-admin user JWT** — for the bulk endpoints that live on the main API: org/site import (Recipe 1), contact import (Recipe 1c), and script bundles (Recipe 6). These are `requireMfa()`-gated: log in as a partner admin, complete the MFA challenge (when `ENABLE_2FA` is on, the JWT must carry `mfa: true` — a bare `POST /auth/login` token gets `403 MFA required`), and export the access token. Tokens are short-lived, so long runs should refresh via `POST /auth/refresh`.
 
 <Aside title="Setting up the service principal (once, as a human)">
   Creating the principal is itself MFA-gated — that's the point: one interactive act mints a credential your scripts use unattended afterwards.
@@ -32,7 +32,7 @@ Two credentials matter here, and they split cleanly by job:
 
 ```bash
 export BREEZE_URL="https://breeze.yourdomain.com/api/v1"
-export BREEZE_TOKEN="eyJ..."         # partner-admin JWT with MFA satisfied (Recipes 1, 6)
+export BREEZE_TOKEN="eyJ..."         # partner-admin JWT with MFA satisfied (Recipes 1, 1c, 6)
 export BREEZE_PARTNER_KEY="..."      # partner service principal key (Recipe 2)
 
 # Sanity check the JWT — should return your partner record

--- a/apps/docs/src/content/docs/reference/organizations-and-sites.mdx
+++ b/apps/docs/src/content/docs/reference/organizations-and-sites.mdx
@@ -298,6 +298,42 @@ Only `orgId` and `name` are required. `timezone`, `address`, `contact`, and `set
 
 ---
 
+## Contacts
+
+A **Contact** is a person attached to an organisation -- a billing contact, a technical escalation, an after-hours number. Contacts belong to the organisation, and each one is either **organisation-level** or pinned to a single site within that organisation via `siteId`.
+
+### Contact Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | `uuid` | Auto-generated primary key. |
+| `orgId` | `uuid` | FK to the parent organisation. Required. |
+| `siteId` | `uuid` | Optional FK to a site in the same organisation. Null means an organisation-level contact. |
+| `name` | `varchar(255)` | Display name. |
+| `email` | `varchar(320)` | Stored lower-cased. |
+| `phone` | `varchar(64)` | Primary telephone number. |
+| `mobile` | `varchar(64)` | Mobile number. |
+| `title` | `varchar(255)` | Job title. |
+| `roles` | `text[]` | Validated role vocabulary. Defaults to empty. |
+| `isPrimary` | `boolean` | Marks the headline contact for its scope. Defaults to `false`. |
+| `notes` | `text` | Free text, up to 5,000 characters. |
+| `createdAt` | `timestamp` | Record creation time. |
+| `updatedAt` | `timestamp` | Last modification time. |
+
+**Every contact needs an identifier.** At least one of `name`, `email`, `phone`, or `mobile` must be non-blank -- a contact known only by an email address is a real contact, but an empty one is not. It is enforced by a database constraint as well as request validation, so nothing can write past it, and violating it returns `400` with `code: "no-identifier"`.
+
+**Roles are a fixed vocabulary:** `billing`, `technical`, `escalation`, `admin`, `site`, `after_hours`, and `portal`. A contact can hold any number of them. An unrecognised role returns `400` with `code: "invalid-role"`, and a `siteId` belonging to a different organisation returns `400` with `code: "site-not-in-org"`.
+
+**One primary per scope.** `isPrimary` marks the headline contact for its scope, where a scope is either *the organisation* (`siteId` null) or *one site*. Setting it demotes whichever contact previously held it in that same scope -- so an organisation can have one organisation-level primary plus one primary per site, and never two in the same place.
+
+On `PATCH`, an explicit `null` clears a field and an omitted key leaves it alone. That distinction is the reason clearing a field lives here rather than in the contacts importer, which merges and never clears.
+
+<Aside type="note">
+  `organizations.billingContact` and `sites.contact` are still present and still readable, but they are now maintained as **compatibility projections** of whichever contact holds the primary flag for that scope. The `contacts` table is the system of record; write to it, and the projections follow.
+</Aside>
+
+---
+
 ## Multi-Tenant Access Control
 
 All routes under `/api/v1/orgs` require JWT authentication. Access is governed by the caller's **scope**, which is one of three levels:
@@ -414,9 +450,24 @@ These endpoints allow partner-scoped users to view and update their own partner 
 | `PATCH` | `/orgs/sites/:id` | `organization`, `partner`, `system` | Update a site. `orgId` cannot be changed. Returns `400` if no fields provided. |
 | `DELETE` | `/orgs/sites/:id` | `organization`, `partner`, `system` | **Hard-delete** a site. The record is permanently removed. Returns `{ success: true }`. |
 
+### Contact Endpoints
+
+| Method | Path | Scope | Description |
+|---|---|---|---|
+| `GET` | `/orgs/organizations/:id/contacts` | `organization`, `partner`, `system` | List an organisation's contacts. Supports `siteId` (a site UUID, or the literal `none` for organisation-level contacts only), `role`, `page`, and `limit`. |
+| `POST` | `/orgs/organizations/:id/contacts` | `organization`, `partner`, `system` | Create a contact. Returns the created record with a `201` status. |
+| `PATCH` | `/orgs/contacts/:contactId` | `organization`, `partner`, `system` | Update a contact. No organisation in the path. An explicit `null` clears a field; an omitted key leaves it alone. |
+| `DELETE` | `/orgs/contacts/:contactId` | `organization`, `partner`, `system` | Delete a contact. Returns `{ success: true }`. |
+| `POST` | `/orgs/contacts/import/preview` | `organization`, `partner`, `system` | Annotate a batch of contact rows against existing state without writing anything. Up to 1,000 rows. |
+| `POST` | `/orgs/contacts/import` | `organization`, `partner`, `system` | Commit a previewed batch. Always answers `200` with `{ imported, updated, skipped, errors }`, including on a partial failure. |
+
+Reads require `organizations:read`. Every write requires `organizations:write` **and a satisfied MFA challenge**. `sites:write` is deliberately *not* required, even for a contact pinned to a site: contacts are organisation-owned records, and whoever can write the organisation can manage its people. The site axis is still enforced separately -- a caller confined to a subset of an organisation's sites cannot reach a contact pinned outside that subset.
+
+Neither import path is organisation-scoped, because each row names its own organisation. See [Recipe 1c](/migration/toolkit/#recipe-1c--import-contacts) in the Migration Toolkit for the row fields, the annotation vocabulary, and the acknowledgement handshake.
+
 ### Pagination
 
-Paginated endpoints (`GET /partners`, `GET /organizations`, `GET /sites`) accept these query parameters:
+Paginated endpoints (`GET /partners`, `GET /organizations`, `GET /sites`, `GET /organizations/:id/contacts`) accept these query parameters:
 
 | Parameter | Type | Default | Max | Description |
 |---|---|---|---|---|
@@ -504,6 +555,25 @@ curl -X POST https://breeze.example.com/api/v1/orgs/sites \
     }
   }'
 ```
+
+#### Create a Contact
+
+```bash
+curl -X POST https://breeze.example.com/api/v1/orgs/organizations/<org-uuid>/contacts \
+  -H "Authorization: Bearer <partner-token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "siteId": "<site-uuid>",
+    "name": "Dana Reyes",
+    "email": "dana.reyes@contoso.example",
+    "phone": "+13035551234",
+    "title": "Office Manager",
+    "roles": ["billing", "escalation"],
+    "isPrimary": true
+  }'
+```
+
+Omit `siteId` (or send `null`) for an organisation-level contact.
 
 #### List Sites with Organisation Filter
 

--- a/apps/docs/src/content/docs/reference/organizations-and-sites.mdx
+++ b/apps/docs/src/content/docs/reference/organizations-and-sites.mdx
@@ -329,7 +329,7 @@ A **Contact** is a person attached to an organisation -- a billing contact, a te
 On `PATCH`, an explicit `null` clears a field and an omitted key leaves it alone. That distinction is the reason clearing a field lives here rather than in the contacts importer, which merges and never clears.
 
 <Aside type="note">
-  `organizations.billingContact` and `sites.contact` are still present and still readable, but they are now maintained as **compatibility projections** of whichever contact holds the primary flag for that scope. The `contacts` table is the system of record; write to it, and the projections follow.
+  `organizations.billingContact` and `sites.contact` are still present, still readable, and still **writable** through the organisation and site routes (`POST`/`PATCH /orgs/organizations` and `/orgs/sites` accept them). They are maintained as **compatibility projections** of whichever contact holds the primary flag for that scope, and every write to either representation is kept in sync with the other — so the two never drift, whichever one you write. The `contacts` table is the system of record for people.
 </Aside>
 
 ---

--- a/apps/web/src/components/organizations/BulkContactImport.test.tsx
+++ b/apps/web/src/components/organizations/BulkContactImport.test.tsx
@@ -46,6 +46,26 @@ async function uploadCsv(csv = CSV) {
   );
 }
 
+/** Uploads a file without waiting for the mapping grid — for files that produce none. */
+function uploadRaw(csv: string, name = 'contacts.csv') {
+  const file = new File([csv], name, { type: 'text/csv' });
+  Object.defineProperty(file, 'text', { value: () => Promise.resolve(csv) });
+  fireEvent.change(screen.getByTestId('bulk-contact-import-file-input'), {
+    target: { files: [file] },
+  });
+}
+
+/** A file whose `text()` rejects, the way a revoked/renamed local file does. */
+function uploadUnreadableFile() {
+  const file = new File(['x'], 'contacts.csv', { type: 'text/csv' });
+  Object.defineProperty(file, 'text', {
+    value: () => Promise.reject(new Error('NotReadableError')),
+  });
+  fireEvent.change(screen.getByTestId('bulk-contact-import-file-input'), {
+    target: { files: [file] },
+  });
+}
+
 const PREVIEW_ROWS: AnnotatedContactRow[] = [
   {
     index: 0, name: 'Ada Byron', email: 'ada@acme.test', site: 'HQ', externalId: 'cw-1',
@@ -306,5 +326,246 @@ describe('BulkContactImport', () => {
     await uploadCsv('Site,Contact ID\nHQ,cw-1\n');
     expect(screen.getByTestId('bulk-contact-import-preview')).toBeDisabled();
     expect(screen.getByTestId('bulk-contact-import-identifier-hint')).toBeInTheDocument();
+  });
+});
+
+describe('BulkContactImport failure attribution', () => {
+  it('names the contact the server actually refused, not the row at that preview index', async () => {
+    render(<BulkContactImport orgId={ORG_ID} />);
+    await uploadAndPreview();
+
+    // Drop the first pre-checked row and opt the fuzzy row in, so the SUBMITTED
+    // array is [Grace H, Alan T] — preview indexes 1 and 2, submitted 0 and 1.
+    fireEvent.click(screen.getByTestId('bulk-contact-import-select-0'));
+    fireEvent.click(screen.getByTestId('bulk-contact-import-select-2'));
+
+    fetchWithAuthMock.mockReturnValueOnce(
+      jsonResponse({
+        imported: [{ index: 0, organizationId: ORG_ID, contactId: 'c-grace', name: 'Grace H', createdLink: false }],
+        updated: [],
+        skipped: [],
+        // Submitted position 1 is Alan T, NOT the preview row with index 1.
+        errors: [{ index: 1, error: 'Match changed since preview', code: 'match-changed' }],
+      }),
+    );
+    fireEvent.click(screen.getByTestId('bulk-contact-import-submit'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('bulk-contact-import-failure-1')).toBeInTheDocument(),
+    );
+    const failure = screen.getByTestId('bulk-contact-import-failure-1');
+    expect(failure).toHaveTextContent('Alan T');
+    expect(failure).not.toHaveTextContent('Grace H');
+  });
+});
+
+describe('BulkContactImport dropped rows', () => {
+  it('says how many rows were dropped for having no identifier', async () => {
+    render(<BulkContactImport orgId={ORG_ID} />);
+    await uploadCsv();
+    // The trailing all-comma line satisfies no identifier and never leaves the
+    // browser; silently shrinking the count is how an operator loses a row.
+    expect(screen.getByTestId('bulk-contact-import-dropped')).toHaveTextContent('1 row');
+    expect(screen.getByTestId('bulk-contact-import-dropped')).toHaveTextContent('no name');
+  });
+
+  it('explains a file whose every row was dropped rather than offering "Check 0 rows"', async () => {
+    render(<BulkContactImport orgId={ORG_ID} />);
+    await uploadCsv('Full Name,Site\n,HQ\n,Depot\n');
+    expect(screen.getByTestId('bulk-contact-import-preview')).toBeDisabled();
+    expect(screen.getByTestId('bulk-contact-import-dropped')).toHaveTextContent('2 rows');
+  });
+
+  it('shows no dropped notice when every row carries an identifier', async () => {
+    render(<BulkContactImport orgId={ORG_ID} />);
+    await uploadCsv('Full Name,Email Address\nAda,ada@acme.test\n');
+    expect(screen.queryByTestId('bulk-contact-import-dropped')).not.toBeInTheDocument();
+  });
+
+  it('refuses to preview a file past the server row cap', async () => {
+    const rows = Array.from({ length: 1001 }, (_, i) => `Person ${i},p${i}@acme.test`);
+    render(<BulkContactImport orgId={ORG_ID} />);
+    await uploadCsv(['Full Name,Email Address', ...rows].join('\n') + '\n');
+    expect(screen.getByTestId('bulk-contact-import-too-many')).toHaveTextContent('1000');
+    expect(screen.getByTestId('bulk-contact-import-preview')).toBeDisabled();
+  });
+});
+
+describe('BulkContactImport file failures', () => {
+  it('toasts a file that cannot be read instead of going silent', async () => {
+    render(<BulkContactImport orgId={ORG_ID} />);
+    uploadUnreadableFile();
+    await waitFor(() =>
+      expect(showToastMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' })),
+    );
+    // The panel resets rather than keeping a half-loaded file on screen.
+    expect(screen.queryByTestId('bulk-contact-import-map-name')).not.toBeInTheDocument();
+  });
+
+  it('explains a file that parses to no columns at all', async () => {
+    render(<BulkContactImport orgId={ORG_ID} />);
+    uploadRaw('\n\n');
+    await waitFor(() =>
+      expect(screen.getByTestId('bulk-contact-import-no-columns')).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId('bulk-contact-import-map-name')).not.toBeInTheDocument();
+  });
+});
+
+describe('BulkContactImport commit outcomes', () => {
+  it('does not call a commit that wrote nothing a success', async () => {
+    const onImported = vi.fn();
+    render(<BulkContactImport orgId={ORG_ID} onImported={onImported} />);
+    await uploadAndPreview();
+
+    // The default re-import path: link-match rows are pre-ticked and skip mode
+    // leaves them alone, so the server writes nothing at all.
+    fetchWithAuthMock.mockReturnValueOnce(
+      jsonResponse({
+        imported: [],
+        updated: [],
+        skipped: [
+          { index: 0, organizationId: ORG_ID, contactId: 'c-ada', reason: 'already_linked' },
+          { index: 1, organizationId: ORG_ID, contactId: 'c-grace', reason: 'already_linked' },
+        ],
+        errors: [],
+      }),
+    );
+    fireEvent.click(screen.getByTestId('bulk-contact-import-submit'));
+    await waitFor(() => expect(showToastMock).toHaveBeenCalled());
+
+    expect(showToastMock).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+    expect(showToastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('Nothing imported') }),
+    );
+    expect(onImported).not.toHaveBeenCalled();
+  });
+
+  it('lists every skipped row with its contact and a translated reason', async () => {
+    render(<BulkContactImport orgId={ORG_ID} />);
+    await uploadAndPreview();
+
+    fetchWithAuthMock.mockReturnValueOnce(
+      jsonResponse({
+        imported: [{ index: 0, organizationId: ORG_ID, contactId: 'c-ada', name: 'Ada Byron', createdLink: true }],
+        updated: [],
+        // Submitted position 1 is Grace H (the pre-ticked link-match).
+        skipped: [{ index: 1, organizationId: ORG_ID, contactId: 'c-grace', reason: 'already_linked' }],
+        errors: [],
+      }),
+    );
+    fireEvent.click(screen.getByTestId('bulk-contact-import-submit'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('bulk-contact-import-skipped')).toBeInTheDocument(),
+    );
+    const row = screen.getByTestId('bulk-contact-import-skipped-1');
+    expect(row).toHaveTextContent('Grace H');
+    expect(row).toHaveTextContent('already linked to an existing contact');
+    // The raw server token is never the thing the operator reads.
+    expect(row).not.toHaveTextContent('already_linked');
+  });
+
+  it('translates a server error code and keeps the server text as detail', async () => {
+    render(<BulkContactImport orgId={ORG_ID} />);
+    await uploadAndPreview();
+
+    fetchWithAuthMock.mockReturnValueOnce(
+      jsonResponse({
+        imported: [{ index: 0, organizationId: ORG_ID, contactId: 'c-ada', name: 'Ada Byron', createdLink: true }],
+        updated: [],
+        skipped: [],
+        errors: [{
+          index: 1,
+          error: 'expectedContactId is required for an email-match acknowledgement',
+          code: 'match-unconfirmed',
+        }],
+      }),
+    );
+    fireEvent.click(screen.getByTestId('bulk-contact-import-submit'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('bulk-contact-import-failure-1')).toBeInTheDocument(),
+    );
+    const failure = screen.getByTestId('bulk-contact-import-failure-1');
+    // The remedy the operator can act on, not the server's field name.
+    expect(failure).toHaveTextContent('Tick the row and import again');
+    // Nothing is lost: the server's own words stay available as detail.
+    expect(screen.getByTestId('bulk-contact-import-failure-detail-1'))
+      .toHaveTextContent('expectedContactId is required');
+  });
+
+  it('falls back to the server text for a code it does not know', async () => {
+    render(<BulkContactImport orgId={ORG_ID} />);
+    await uploadAndPreview();
+
+    fetchWithAuthMock.mockReturnValueOnce(
+      jsonResponse({
+        imported: [],
+        updated: [],
+        skipped: [],
+        errors: [{ index: 0, error: 'Something new went wrong', code: 'brand-new-code' }],
+      }),
+    );
+    fireEvent.click(screen.getByTestId('bulk-contact-import-submit'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('bulk-contact-import-failure-0')).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId('bulk-contact-import-failure-0'))
+      .toHaveTextContent('Something new went wrong');
+  });
+});
+
+describe('parseRoles normalisation', () => {
+  it('accepts comma, semicolon and pipe separators and normalises the labels', async () => {
+    render(<BulkContactImport orgId={ORG_ID} />);
+    await uploadCsv('Full Name,Roles\nAda,"After Hours;portal|billing"\n');
+    fetchWithAuthMock.mockReturnValueOnce(jsonResponse({ rows: [] }));
+    fireEvent.click(screen.getByTestId('bulk-contact-import-preview'));
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalledTimes(1));
+    expect(commitBody(0).rows[0].roles).toEqual(['after_hours', 'portal', 'billing']);
+  });
+
+  it('sends an unrecognised role through untouched rather than guessing a near one', async () => {
+    render(<BulkContactImport orgId={ORG_ID} />);
+    await uploadCsv('Full Name,Roles\nAda,Chief Vibes\n');
+    fetchWithAuthMock.mockReturnValueOnce(jsonResponse({ rows: [] }));
+    fireEvent.click(screen.getByTestId('bulk-contact-import-preview'));
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalledTimes(1));
+    expect(commitBody(0).rows[0].roles).toEqual(['chief_vibes']);
+  });
+});
+
+describe('BulkContactImport preview lifecycle', () => {
+  it('clears a stale preview when the mapping changes', async () => {
+    render(<BulkContactImport orgId={ORG_ID} />);
+    await uploadAndPreview();
+    expect(screen.getByTestId('bulk-contact-import-table')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId('bulk-contact-import-map-title'), {
+      target: { value: '' },
+    });
+    expect(screen.queryByTestId('bulk-contact-import-table')).not.toBeInTheDocument();
+  });
+
+  it('clears the preview after a successful commit and leaves a summary line', async () => {
+    render(<BulkContactImport orgId={ORG_ID} />);
+    await uploadAndPreview();
+
+    fetchWithAuthMock.mockReturnValueOnce(
+      jsonResponse({
+        imported: [{ index: 0, organizationId: ORG_ID, contactId: 'c-ada', name: 'Ada Byron', createdLink: true }],
+        updated: [],
+        skipped: [],
+        errors: [],
+      }),
+    );
+    fireEvent.click(screen.getByTestId('bulk-contact-import-submit'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('bulk-contact-import-summary')).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId('bulk-contact-import-table')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/organizations/BulkContactImport.test.tsx
+++ b/apps/web/src/components/organizations/BulkContactImport.test.tsx
@@ -1,0 +1,310 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import BulkContactImport from './BulkContactImport';
+import type { AnnotatedContactRow } from './ContactImportPreviewTable';
+
+const fetchWithAuthMock = vi.fn();
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: (...a: unknown[]) => fetchWithAuthMock(...a),
+}));
+
+const showToastMock = vi.fn();
+vi.mock('../shared/Toast', () => ({
+  showToast: (...a: unknown[]) => showToastMock(...a),
+}));
+
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+
+function jsonResponse(body: unknown, status = 200) {
+  return Promise.resolve(
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+}
+
+const CSV = [
+  'Full Name,Email Address,Phone,Mobile,Job Title,Roles,Site,Contact ID',
+  'Ada Byron,ada@acme.test,555-0100,555-0199,CTO,"billing,Technical",HQ,cw-1',
+  'Grace H,grace@acme.test,,,,,,cw-2',
+  'Alan T,alan@acme.test,,,,,,',
+  'Katherine J,,555-0111,,,,,',
+  ',,,,,,,',
+].join('\n') + '\n';
+
+async function uploadCsv(csv = CSV) {
+  const file = new File([csv], 'contacts.csv', { type: 'text/csv' });
+  if (typeof file.text !== 'function') {
+    Object.defineProperty(file, 'text', { value: () => Promise.resolve(csv) });
+  }
+  fireEvent.change(screen.getByTestId('bulk-contact-import-file-input'), {
+    target: { files: [file] },
+  });
+  await waitFor(() =>
+    expect(screen.getByTestId('bulk-contact-import-map-name')).toBeInTheDocument(),
+  );
+}
+
+const PREVIEW_ROWS: AnnotatedContactRow[] = [
+  {
+    index: 0, name: 'Ada Byron', email: 'ada@acme.test', site: 'HQ', externalId: 'cw-1',
+    annotation: 'create', organizationId: ORG_ID, siteId: 'site-hq', contactId: null,
+  },
+  {
+    index: 1, name: 'Grace H', email: 'grace@acme.test', externalId: 'cw-2',
+    annotation: 'link-match', organizationId: ORG_ID, siteId: null, contactId: 'c-grace',
+    matchedContactName: 'Grace Hopper',
+  },
+  {
+    index: 2, name: 'Alan T', email: 'alan@acme.test',
+    annotation: 'email-match', organizationId: ORG_ID, siteId: null, contactId: 'c-alan',
+    matchedContactName: 'Alan Turing', matchedContactEmail: 'alan@acme.test',
+  },
+  {
+    index: 3, name: 'Katherine J', phone: '555-0111',
+    annotation: 'conflict', organizationId: ORG_ID, siteId: null, contactId: null,
+    conflictReason: '2 contacts in Acme are named "Katherine J"',
+  },
+];
+
+async function uploadAndPreview(rows: AnnotatedContactRow[] = PREVIEW_ROWS) {
+  await uploadCsv();
+  fetchWithAuthMock.mockReturnValueOnce(jsonResponse({ rows }));
+  fireEvent.click(screen.getByTestId('bulk-contact-import-preview'));
+  await waitFor(() =>
+    expect(screen.getByTestId('bulk-contact-import-table')).toBeInTheDocument(),
+  );
+}
+
+function commitBody(callIndex = -1) {
+  const call = fetchWithAuthMock.mock.calls.at(callIndex)!;
+  return JSON.parse((call[1] as RequestInit).body as string);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('BulkContactImport', () => {
+  it('auto-guesses the column mapping from CSV headers', async () => {
+    render(<BulkContactImport orgId={ORG_ID} />);
+    await uploadCsv();
+    expect(screen.getByTestId('bulk-contact-import-map-name')).toHaveValue('Full Name');
+    expect(screen.getByTestId('bulk-contact-import-map-email')).toHaveValue('Email Address');
+    expect(screen.getByTestId('bulk-contact-import-map-phone')).toHaveValue('Phone');
+    expect(screen.getByTestId('bulk-contact-import-map-mobile')).toHaveValue('Mobile');
+    expect(screen.getByTestId('bulk-contact-import-map-title')).toHaveValue('Job Title');
+    expect(screen.getByTestId('bulk-contact-import-map-roles')).toHaveValue('Roles');
+    expect(screen.getByTestId('bulk-contact-import-map-site')).toHaveValue('Site');
+    expect(screen.getByTestId('bulk-contact-import-map-externalId')).toHaveValue('Contact ID');
+  });
+
+  it('pins every row to this organization and drops rows with no identifier', async () => {
+    render(<BulkContactImport orgId={ORG_ID} />);
+    await uploadAndPreview();
+
+    const call = fetchWithAuthMock.mock.calls[0]!;
+    expect(call[0]).toBe('/orgs/contacts/import/preview');
+    expect((call[1] as RequestInit).method).toBe('POST');
+    const body = commitBody(0);
+    // The trailing all-blank CSV line satisfies no identifier; sending it would
+    // 400 the WHOLE request, so it never leaves the browser.
+    expect(body.rows).toHaveLength(4);
+    for (const row of body.rows) expect(row.organizationId).toBe(ORG_ID);
+    expect(body.rows[0]).toEqual({
+      organizationId: ORG_ID,
+      name: 'Ada Byron',
+      email: 'ada@acme.test',
+      phone: '555-0100',
+      mobile: '555-0199',
+      title: 'CTO',
+      roles: ['billing', 'technical'],
+      site: 'HQ',
+      externalId: 'cw-1',
+    });
+    // Blank cells are omitted, not sent as empty strings.
+    expect(body.rows[2]).toEqual({
+      organizationId: ORG_ID,
+      name: 'Alan T',
+      email: 'alan@acme.test',
+    });
+  });
+
+  it('renders a badge per annotation and pre-checks only create + link-match', async () => {
+    render(<BulkContactImport orgId={ORG_ID} />);
+    await uploadAndPreview();
+
+    expect(screen.getByTestId('bulk-contact-import-badge-0')).toHaveTextContent('New');
+    expect(screen.getByTestId('bulk-contact-import-badge-1')).toHaveTextContent('Already linked');
+    expect(screen.getByTestId('bulk-contact-import-badge-2')).toHaveTextContent('Email match');
+    expect(screen.getByTestId('bulk-contact-import-badge-3')).toHaveTextContent('Conflict');
+
+    expect(screen.getByTestId('bulk-contact-import-select-0')).toBeChecked();
+    expect(screen.getByTestId('bulk-contact-import-select-1')).toBeChecked();
+    // A fuzzy hint needs a deliberate human tick.
+    expect(screen.getByTestId('bulk-contact-import-select-2')).not.toBeChecked();
+    // A conflict can never be committed at all.
+    expect(screen.getByTestId('bulk-contact-import-select-3')).toBeDisabled();
+  });
+
+  it('leaves a fuzzy row unticked when select-all is used', async () => {
+    render(<BulkContactImport orgId={ORG_ID} />);
+    await uploadAndPreview();
+    // Clear the default selection, then select-all: the fuzzy row must not be
+    // swept in by a bulk toggle.
+    fireEvent.click(screen.getByTestId('bulk-contact-import-select-all'));
+    fireEvent.click(screen.getByTestId('bulk-contact-import-select-all'));
+    expect(screen.getByTestId('bulk-contact-import-select-0')).toBeChecked();
+    expect(screen.getByTestId('bulk-contact-import-select-1')).toBeChecked();
+    expect(screen.getByTestId('bulk-contact-import-select-2')).not.toBeChecked();
+  });
+
+  it('renders a non-fatal warning on a row that still imports', async () => {
+    const warned: AnnotatedContactRow = {
+      index: 0, name: 'Ada Byron', email: 'shared@acme.test', externalId: 'cw-1',
+      annotation: 'create', organizationId: ORG_ID, siteId: null, contactId: null,
+      warning: '3 existing contacts in Acme share shared@acme.test; creating another,'
+        + ' because this row carries its own externalId',
+    };
+    render(<BulkContactImport orgId={ORG_ID} />);
+    await uploadAndPreview([warned]);
+    expect(screen.getByTestId('bulk-contact-import-warning-0'))
+      .toHaveTextContent('3 existing contacts in Acme share shared@acme.test');
+    expect(screen.getByTestId('bulk-contact-import-select-0')).toBeChecked();
+  });
+
+  it('commits the acknowledged rows with mode and the fuzzy match pin', async () => {
+    render(<BulkContactImport orgId={ORG_ID} />);
+    await uploadAndPreview();
+
+    // Acknowledge the email-match deliberately, and ask for update mode.
+    fireEvent.click(screen.getByTestId('bulk-contact-import-select-2'));
+    fireEvent.change(screen.getByTestId('bulk-contact-import-mode'), {
+      target: { value: 'update' },
+    });
+
+    fetchWithAuthMock.mockReturnValueOnce(
+      jsonResponse({
+        imported: [{ index: 0, organizationId: ORG_ID, contactId: 'c-ada', name: 'Ada Byron', createdLink: true }],
+        updated: [{ index: 1, organizationId: ORG_ID, contactId: 'c-grace', name: 'Grace H', createdLink: false }],
+        skipped: [],
+        errors: [],
+      }),
+    );
+    fireEvent.click(screen.getByTestId('bulk-contact-import-submit'));
+    await waitFor(() => expect(showToastMock).toHaveBeenCalled());
+
+    const call = fetchWithAuthMock.mock.calls.at(-1)!;
+    expect(call[0]).toBe('/orgs/contacts/import');
+    const body = commitBody();
+    expect(body.mode).toBe('update');
+    expect(body.rows).toHaveLength(3); // create + link-match + acknowledged email-match
+    expect(body.rows.map((r: { expectedAnnotation: string }) => r.expectedAnnotation))
+      .toEqual(['create', 'link-match', 'email-match']);
+    const fuzzy = body.rows[2];
+    expect(fuzzy.expectedAnnotation).toBe('email-match');
+    // Required by the server whenever the acknowledgement is fuzzy.
+    expect(fuzzy.expectedContactId).toBe('c-alan');
+    expect(showToastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'success' }),
+    );
+  });
+
+  it('defaults mode to skip', async () => {
+    render(<BulkContactImport orgId={ORG_ID} />);
+    await uploadAndPreview();
+    expect(screen.getByTestId('bulk-contact-import-mode')).toHaveValue('skip');
+
+    fetchWithAuthMock.mockReturnValueOnce(
+      jsonResponse({ imported: [], updated: [], skipped: [], errors: [] }),
+    );
+    fireEvent.click(screen.getByTestId('bulk-contact-import-submit'));
+    await waitFor(() => expect(showToastMock).toHaveBeenCalled());
+    expect(commitBody().mode).toBe('skip');
+  });
+
+  it('warns and lists per-row failures on a partial import', async () => {
+    const onImported = vi.fn();
+    render(<BulkContactImport orgId={ORG_ID} onImported={onImported} />);
+    await uploadAndPreview();
+
+    fetchWithAuthMock.mockReturnValueOnce(
+      jsonResponse({
+        imported: [{ index: 0, organizationId: ORG_ID, contactId: 'c-ada', name: 'Ada Byron', createdLink: true }],
+        updated: [],
+        skipped: [{ index: 1, organizationId: ORG_ID, contactId: 'c-grace', reason: 'already_linked' }],
+        errors: [
+          { index: 1, error: 'Match changed since preview', code: 'match-changed' },
+        ],
+      }),
+    );
+    fireEvent.click(screen.getByTestId('bulk-contact-import-submit'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('bulk-contact-import-failures')).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId('bulk-contact-import-failure-1'))
+      .toHaveTextContent('Match changed since preview');
+    expect(showToastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'warning' }),
+    );
+    // A partial success still wrote something, so the host refetches.
+    expect(onImported).toHaveBeenCalled();
+  });
+
+  it('reports an all-failed commit as an error rather than a success', async () => {
+    const onImported = vi.fn();
+    render(<BulkContactImport orgId={ORG_ID} onImported={onImported} />);
+    await uploadAndPreview();
+
+    fetchWithAuthMock.mockReturnValueOnce(
+      jsonResponse({
+        imported: [],
+        updated: [],
+        skipped: [],
+        errors: [
+          { index: 0, error: 'Annotation changed since preview', code: 'annotation-changed' },
+          { index: 1, error: 'Site does not belong to this organization', code: 'site-not-in-org' },
+        ],
+      }),
+    );
+    fireEvent.click(screen.getByTestId('bulk-contact-import-submit'));
+    await waitFor(() => expect(showToastMock).toHaveBeenCalled());
+    expect(showToastMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+    expect(onImported).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a failed preview through runAction and shows no table', async () => {
+    render(<BulkContactImport orgId={ORG_ID} />);
+    await uploadCsv();
+    fetchWithAuthMock.mockReturnValueOnce(
+      jsonResponse({ error: 'Access to this site denied' }, 403),
+    );
+    fireEvent.click(screen.getByTestId('bulk-contact-import-preview'));
+
+    await waitFor(() =>
+      expect(showToastMock).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'error', message: 'Access to this site denied' }),
+      ),
+    );
+    expect(screen.queryByTestId('bulk-contact-import-table')).not.toBeInTheDocument();
+  });
+
+  it('routes a 401 to the host rather than toasting it', async () => {
+    const onUnauthorized = vi.fn();
+    render(<BulkContactImport orgId={ORG_ID} onUnauthorized={onUnauthorized} />);
+    await uploadCsv();
+    fetchWithAuthMock.mockReturnValueOnce(jsonResponse({ error: 'Unauthorized' }, 401));
+    fireEvent.click(screen.getByTestId('bulk-contact-import-preview'));
+    await waitFor(() => expect(onUnauthorized).toHaveBeenCalled());
+    expect(showToastMock).not.toHaveBeenCalled();
+  });
+
+  it('refuses to preview a file with no identifier column mapped', async () => {
+    render(<BulkContactImport orgId={ORG_ID} />);
+    await uploadCsv('Site,Contact ID\nHQ,cw-1\n');
+    expect(screen.getByTestId('bulk-contact-import-preview')).toBeDisabled();
+    expect(screen.getByTestId('bulk-contact-import-identifier-hint')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/organizations/BulkContactImport.tsx
+++ b/apps/web/src/components/organizations/BulkContactImport.tsx
@@ -1,0 +1,427 @@
+import { useMemo, useRef, useState, type DragEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+import '@/lib/i18n';
+import { fetchWithAuth } from '../../stores/auth';
+import { runAction } from '../../lib/runAction';
+import { showToast } from '../shared/Toast';
+import { parseCsv, type ParsedCsv } from '../../lib/csvParse';
+import ContactImportPreviewTable, {
+  defaultContactPreviewSelection,
+  toContactCommitRow,
+  type AnnotatedContactRow,
+  type CommitContactRowInput,
+  type ContactImportSummary,
+} from './ContactImportPreviewTable';
+
+/**
+ * CSV contact importer (#3258 W04), hosted inside one organization's Contacts
+ * tab.
+ *
+ * Unlike BulkOrgImport there is no `organization` column: the tab already knows
+ * which organization it is looking at, so every row is pinned to `orgId` here
+ * rather than resolved by name server-side. That removes the whole
+ * `org-not-found` class from the normal path — the annotation still exists on
+ * the wire and the preview table still renders it, because a row can be
+ * refused if the caller's reach changes between preview and commit.
+ */
+
+type MappableField =
+  | 'name' | 'email' | 'phone' | 'mobile' | 'title'
+  | 'roles' | 'site' | 'externalId' | 'externalSystem';
+
+/**
+ * Order matters: `guessMapping` claims headers first-come, so a field whose
+ * guesses overlap another's must be resolved earlier. `title` precedes `roles`
+ * so a bare `Title` column is a job title rather than a role list.
+ */
+const MAPPABLE_FIELDS: MappableField[] = [
+  'name', 'email', 'phone', 'mobile', 'title', 'roles', 'site', 'externalId', 'externalSystem',
+];
+
+/**
+ * The subset that satisfies `contacts_identifiable_chk`. A row carrying none of
+ * these is rejected by the server — and because a malformed row fails the WHOLE
+ * request, such rows are dropped client-side rather than sent.
+ */
+const IDENTIFIER_FIELDS = ['name', 'email', 'phone', 'mobile'] as const;
+
+// Header auto-guess, first match wins. Compared against the lowercased,
+// space/underscore/hyphen-stripped header.
+const FIELD_GUESSES: Record<MappableField, string[]> = {
+  name: ['name', 'fullname', 'contactname', 'displayname', 'contact'],
+  email: ['email', 'emailaddress', 'mail', 'primaryemail', 'workemail'],
+  phone: ['phone', 'phonenumber', 'telephone', 'tel', 'workphone', 'officephone', 'businessphone'],
+  mobile: ['mobile', 'mobilephone', 'cell', 'cellphone', 'cellular', 'mobilenumber'],
+  title: ['title', 'jobtitle', 'position', 'jobrole'],
+  roles: ['roles', 'role', 'contactroles', 'contacttype', 'type'],
+  site: ['site', 'sitename', 'location', 'branch', 'office'],
+  externalId: ['externalid', 'contactid', 'uid', 'guid', 'id'],
+  externalSystem: ['externalsystem', 'system', 'source', 'vendor'],
+};
+
+function guessMapping(headers: string[]): Partial<Record<MappableField, string>> {
+  const normalized = headers.map((h) => h.toLowerCase().replace(/[\s_-]+/g, ''));
+  const mapping: Partial<Record<MappableField, string>> = {};
+  const claimed = new Set<string>();
+  for (const field of MAPPABLE_FIELDS) {
+    for (const guess of FIELD_GUESSES[field]) {
+      const idx = normalized.findIndex((h, i) => h === guess && !claimed.has(headers[i]!));
+      if (idx >= 0) {
+        mapping[field] = headers[idx]!;
+        claimed.add(headers[idx]!);
+        break;
+      }
+    }
+  }
+  return mapping;
+}
+
+/**
+ * Split a roles cell into the server's vocabulary.
+ *
+ * Accepts comma, semicolon and pipe separators, and normalises `After Hours` /
+ * `after-hours` to the stored `after_hours` — an exported spreadsheet writes
+ * the human label, not the token. An unrecognised value still reaches the
+ * server, which refuses the row with `invalid-role` and names it; guessing a
+ * "closest" role here would silently file people under the wrong one.
+ */
+function parseRoles(cell: string): string[] {
+  return cell
+    .split(/[,;|]/)
+    .map((r) => r.trim().toLowerCase().replace(/[\s-]+/g, '_'))
+    .filter((r) => r !== '');
+}
+
+interface Props {
+  /** The organization every row is pinned to — the tab's organization. */
+  orgId: string;
+  /** Called after a commit that imported or updated at least one row. */
+  onImported?: () => void;
+  onUnauthorized?: () => void;
+  onClose?: () => void;
+}
+
+export default function BulkContactImport({ orgId, onImported, onUnauthorized, onClose }: Props) {
+  const { t } = useTranslation('settings');
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [fileName, setFileName] = useState<string | null>(null);
+  const [csv, setCsv] = useState<ParsedCsv | null>(null);
+  const [mapping, setMapping] = useState<Partial<Record<MappableField, string>>>({});
+  const [dragActive, setDragActive] = useState(false);
+  const [previewRows, setPreviewRows] = useState<AnnotatedContactRow[] | null>(null);
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [mode, setMode] = useState<'skip' | 'update'>('skip');
+  const [previewing, setPreviewing] = useState(false);
+  const [importing, setImporting] = useState(false);
+  const [failures, setFailures] = useState<ContactImportSummary['errors']>([]);
+  /** Row index → a human label, so a failure names the person, not a number. */
+  const [failureLabels, setFailureLabels] = useState<Record<number, string>>({});
+  const [lastSummary, setLastSummary] = useState<string | null>(null);
+
+  const importRows = useMemo<CommitContactRowInput[]>(() => {
+    if (!csv) return [];
+    const col = (field: MappableField) => {
+      const header = mapping[field];
+      return header ? csv.headers.indexOf(header) : -1;
+    };
+    const idx = Object.fromEntries(
+      MAPPABLE_FIELDS.map((f) => [f, col(f)]),
+    ) as Record<MappableField, number>;
+
+    const rows: CommitContactRowInput[] = [];
+    for (const raw of csv.rows) {
+      const cell = (i: number) => (i >= 0 ? (raw[i] ?? '').trim() : '');
+      // The organization is the TAB's, never the file's.
+      const row: CommitContactRowInput = { organizationId: orgId };
+      for (const field of MAPPABLE_FIELDS) {
+        if (field === 'roles') continue;
+        const value = cell(idx[field]);
+        if (value) row[field] = value;
+      }
+      const roles = parseRoles(cell(idx.roles));
+      if (roles.length > 0) row.roles = roles;
+      // Blank spreadsheet tail rows satisfy no identifier; one of them would
+      // fail Zod and reject every other row in the request with it.
+      if (!IDENTIFIER_FIELDS.some((f) => row[f])) continue;
+      rows.push(row);
+    }
+    return rows;
+  }, [csv, mapping, orgId]);
+
+  const hasIdentifierColumn = IDENTIFIER_FIELDS.some((f) => mapping[f]);
+
+  function resetPreview() {
+    setPreviewRows(null);
+    setSelected(new Set());
+  }
+
+  function loadFile(file: File) {
+    void file.text().then((text) => {
+      const parsed = parseCsv(text);
+      setFileName(file.name);
+      setCsv(parsed);
+      setMapping(guessMapping(parsed.headers));
+      resetPreview();
+      setFailures([]);
+      setFailureLabels({});
+      setLastSummary(null);
+    });
+  }
+
+  function handleDrop(e: DragEvent<HTMLDivElement>) {
+    e.preventDefault();
+    setDragActive(false);
+    const file = e.dataTransfer.files?.[0];
+    if (file) loadFile(file);
+  }
+
+  async function preview() {
+    setPreviewing(true);
+    setFailures([]);
+    setFailureLabels({});
+    setLastSummary(null);
+    try {
+      const res = await runAction<{ rows: AnnotatedContactRow[] }>({
+        request: () =>
+          fetchWithAuth('/orgs/contacts/import/preview', {
+            method: 'POST',
+            body: JSON.stringify({ rows: importRows }),
+          }),
+        errorFallback: t('bulkContactImport.errors.previewFailed'),
+        onUnauthorized,
+      });
+      setPreviewRows(res.rows);
+      // create + link-match pre-checked; an email/name hint is a per-person
+      // judgement and must be ticked deliberately; conflict and org-not-found
+      // are never selectable.
+      setSelected(defaultContactPreviewSelection(res.rows));
+    } catch {
+      // runAction already toasted (or routed the 401).
+    } finally {
+      setPreviewing(false);
+    }
+  }
+
+  async function commit() {
+    if (!previewRows) return;
+    const chosen = previewRows.filter((r) => selected.has(r.index));
+    if (chosen.length === 0) return;
+    const labels = Object.fromEntries(
+      chosen.map((r) => [r.index, r.name ?? r.email ?? r.phone ?? r.mobile ?? `#${r.index + 1}`]),
+    );
+    setImporting(true);
+    try {
+      // The endpoint always answers HTTP 200 with a summary — partial success is
+      // a feature — so runAction cannot tell a total failure from a win. The
+      // outcome toast is owned here; no `successMessage`, which only emits green.
+      const s = await runAction<ContactImportSummary>({
+        request: () =>
+          fetchWithAuth('/orgs/contacts/import', {
+            method: 'POST',
+            body: JSON.stringify({ rows: chosen.map(toContactCommitRow), mode }),
+          }),
+        errorFallback: t('bulkContactImport.errors.importFailed'),
+        onUnauthorized,
+      });
+      const parts = [t('bulkContactImport.summary.imported', { count: s.imported.length })];
+      if (s.updated.length) parts.push(t('bulkContactImport.summary.updated', { count: s.updated.length }));
+      if (s.skipped.length) parts.push(t('bulkContactImport.summary.skipped', { count: s.skipped.length }));
+      if (s.errors.length) parts.push(t('bulkContactImport.summary.failed', { count: s.errors.length }));
+      const message = parts.join(', ');
+      const wrote = s.imported.length > 0 || s.updated.length > 0;
+      if (!wrote && s.errors.length > 0) {
+        showToast({ type: 'error', message: t('bulkContactImport.summary.allFailed', { summary: message }) });
+      } else if (s.errors.length > 0) {
+        showToast({ type: 'warning', message: `${message}.` });
+      } else {
+        showToast({ type: 'success', message: `${message}.` });
+      }
+      setFailures(s.errors);
+      setFailureLabels(labels);
+      setLastSummary(message);
+      resetPreview();
+      if (wrote) onImported?.();
+    } catch {
+      // runAction already toasted the request-level failure (non-200 / thrown).
+    } finally {
+      setImporting(false);
+    }
+  }
+
+  return (
+    <div data-testid="bulk-contact-import-panel" className="rounded-lg border bg-card p-4 shadow-xs">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-sm font-semibold">{t('bulkContactImport.title')}</h2>
+          <p className="mt-0.5 text-xs text-muted-foreground">{t('bulkContactImport.description')}</p>
+        </div>
+        {onClose && (
+          <button
+            type="button"
+            data-testid="bulk-contact-import-close"
+            onClick={onClose}
+            className="rounded-md px-2 py-1 text-sm text-muted-foreground hover:bg-muted"
+          >
+            {t('bulkContactImport.actions.close')}
+          </button>
+        )}
+      </div>
+
+      {/* Step 1: file */}
+      <div
+        data-testid="bulk-contact-import-dropzone"
+        onDragOver={(e) => { e.preventDefault(); setDragActive(true); }}
+        onDragLeave={() => setDragActive(false)}
+        onDrop={handleDrop}
+        className={`mt-4 flex cursor-pointer flex-col items-center justify-center rounded-md border border-dashed px-4 py-6 text-center text-sm ${
+          dragActive ? 'border-primary bg-primary/5' : 'border-border text-muted-foreground'
+        }`}
+        onClick={() => fileInputRef.current?.click()}
+      >
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".csv,text/csv"
+          data-testid="bulk-contact-import-file-input"
+          className="hidden"
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (file) loadFile(file);
+            e.target.value = '';
+          }}
+        />
+        {fileName
+          ? <span className="font-medium text-foreground">{fileName}</span>
+          : <span>{t('bulkContactImport.dropzone')}</span>}
+        <span className="mt-1 text-xs">{t('bulkContactImport.dropzoneHint')}</span>
+      </div>
+
+      {/* Step 2: column mapping */}
+      {csv && csv.headers.length > 0 && (
+        <div className="mt-4">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            {t('bulkContactImport.mapping.heading')}
+          </h3>
+          <div className="mt-2 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {MAPPABLE_FIELDS.map((field) => (
+              <label key={field} className="block text-xs">
+                <span className="text-muted-foreground">
+                  {t(/* i18n-dynamic */ `bulkContactImport.mapping.fields.${field}`)}
+                </span>
+                <select
+                  data-testid={`bulk-contact-import-map-${field}`}
+                  value={mapping[field] ?? ''}
+                  onChange={(e) => {
+                    const value = e.target.value || undefined;
+                    setMapping((prev) => ({ ...prev, [field]: value }));
+                    resetPreview();
+                  }}
+                  className="mt-1 h-8 w-full rounded-md border bg-background px-2 text-sm"
+                >
+                  <option value="">{t('bulkContactImport.mapping.unmapped')}</option>
+                  {csv.headers.map((h) => (
+                    <option key={h} value={h}>{h}</option>
+                  ))}
+                </select>
+              </label>
+            ))}
+          </div>
+
+          <div className="mt-3 flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              data-testid="bulk-contact-import-preview"
+              onClick={preview}
+              disabled={previewing || importRows.length === 0}
+              className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+            >
+              {previewing
+                ? t('bulkContactImport.actions.previewing')
+                : t('bulkContactImport.actions.preview', { count: importRows.length })}
+            </button>
+            {!hasIdentifierColumn && (
+              <span
+                data-testid="bulk-contact-import-identifier-hint"
+                className="text-xs text-muted-foreground"
+              >
+                {t('bulkContactImport.mapping.identifierRequired')}
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Step 3: preview table */}
+      {previewRows && (
+        <div className="mt-4">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {t('bulkContactImport.preview.heading')}
+            </h3>
+            <label className="flex items-center gap-2 text-xs text-muted-foreground">
+              <span>{t('bulkContactImport.mode.label')}</span>
+              <select
+                data-testid="bulk-contact-import-mode"
+                value={mode}
+                onChange={(e) => setMode(e.target.value as 'skip' | 'update')}
+                className="h-7 rounded-md border bg-background px-2 text-xs"
+              >
+                <option value="skip">{t('bulkContactImport.mode.skip')}</option>
+                <option value="update">{t('bulkContactImport.mode.update')}</option>
+              </select>
+            </label>
+          </div>
+
+          <ContactImportPreviewTable
+            rows={previewRows}
+            selected={selected}
+            onSelectedChange={setSelected}
+            testIdPrefix="bulk-contact-import"
+          />
+
+          <div className="mt-3">
+            <button
+              type="button"
+              data-testid="bulk-contact-import-submit"
+              onClick={commit}
+              disabled={importing || selected.size === 0}
+              className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+            >
+              {importing
+                ? t('bulkContactImport.actions.importing')
+                : t('bulkContactImport.actions.import', { count: selected.size })}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {lastSummary && !previewRows && (
+        <p className="mt-4 text-sm text-muted-foreground" data-testid="bulk-contact-import-summary">
+          {lastSummary}.
+        </p>
+      )}
+
+      {failures.length > 0 && (
+        <div
+          className="mt-4 rounded-md border border-destructive/40 bg-destructive/10 p-3"
+          data-testid="bulk-contact-import-failures"
+        >
+          <p className="text-sm font-medium text-destructive">
+            {t('bulkContactImport.failures.title', { count: failures.length })}
+          </p>
+          <ul className="mt-2 space-y-1 text-xs text-destructive">
+            {failures.map((f) => (
+              <li key={f.index} data-testid={`bulk-contact-import-failure-${f.index}`}>
+                <span className="font-medium">
+                  {failureLabels[f.index] ?? f.organization ?? `#${f.index + 1}`}
+                </span>
+                {': '}
+                {f.error}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/organizations/BulkContactImport.tsx
+++ b/apps/web/src/components/organizations/BulkContactImport.tsx
@@ -10,6 +10,7 @@ import ContactImportPreviewTable, {
   toContactCommitRow,
   type AnnotatedContactRow,
   type CommitContactRowInput,
+  type ContactImportErrorCode,
   type ContactImportSummary,
 } from './ContactImportPreviewTable';
 
@@ -30,9 +31,11 @@ type MappableField =
   | 'roles' | 'site' | 'externalId' | 'externalSystem';
 
 /**
- * Order matters: `guessMapping` claims headers first-come, so a field whose
- * guesses overlap another's must be resolved earlier. `title` precedes `roles`
- * so a bare `Title` column is a job title rather than a role list.
+ * Iteration order for `guessMapping`, which claims each header first-come. The
+ * nine guess lists below are pairwise disjoint today, so no header is contested
+ * and this order changes nothing; it is fixed only so that ADDING an overlapping
+ * guess later resolves deterministically (earlier field wins) instead of by
+ * whatever order the record happens to enumerate in.
  */
 const MAPPABLE_FIELDS: MappableField[] = [
   'name', 'email', 'phone', 'mobile', 'title', 'roles', 'site', 'externalId', 'externalSystem',
@@ -44,6 +47,14 @@ const MAPPABLE_FIELDS: MappableField[] = [
  * request, such rows are dropped client-side rather than sent.
  */
 const IDENTIFIER_FIELDS = ['name', 'email', 'phone', 'mobile'] as const;
+
+/**
+ * Mirrors MAX_IMPORT_ROWS in apps/api/src/services/contacts/types.ts, which the
+ * preview and commit routes both enforce with `.max()`. Over the cap Zod refuses
+ * the WHOLE request, so the file is stopped here with a count the operator can
+ * act on rather than a generic 400.
+ */
+const MAX_IMPORT_ROWS = 1000;
 
 // Header auto-guess, first match wins. Compared against the lowercased,
 // space/underscore/hyphen-stripped header.
@@ -114,12 +125,18 @@ export default function BulkContactImport({ orgId, onImported, onUnauthorized, o
   const [previewing, setPreviewing] = useState(false);
   const [importing, setImporting] = useState(false);
   const [failures, setFailures] = useState<ContactImportSummary['errors']>([]);
-  /** Row index → a human label, so a failure names the person, not a number. */
+  const [skipped, setSkipped] = useState<ContactImportSummary['skipped']>([]);
+  /**
+   * SUBMITTED position → a human label, so an outcome names the person rather
+   * than a number. Keyed by position in the array actually sent, because that is
+   * what the server's `errors[].index` and `skipped[].index` count — NOT the
+   * preview row's own `index`, which still numbers the deselected rows.
+   */
   const [failureLabels, setFailureLabels] = useState<Record<number, string>>({});
   const [lastSummary, setLastSummary] = useState<string | null>(null);
 
-  const importRows = useMemo<CommitContactRowInput[]>(() => {
-    if (!csv) return [];
+  const mapped = useMemo<{ rows: CommitContactRowInput[]; dropped: number }>(() => {
+    if (!csv) return { rows: [], dropped: 0 };
     const col = (field: MappableField) => {
       const header = mapping[field];
       return header ? csv.headers.indexOf(header) : -1;
@@ -129,6 +146,7 @@ export default function BulkContactImport({ orgId, onImported, onUnauthorized, o
     ) as Record<MappableField, number>;
 
     const rows: CommitContactRowInput[] = [];
+    let dropped = 0;
     for (const raw of csv.rows) {
       const cell = (i: number) => (i >= 0 ? (raw[i] ?? '').trim() : '');
       // The organization is the TAB's, never the file's.
@@ -141,18 +159,35 @@ export default function BulkContactImport({ orgId, onImported, onUnauthorized, o
       const roles = parseRoles(cell(idx.roles));
       if (roles.length > 0) row.roles = roles;
       // Blank spreadsheet tail rows satisfy no identifier; one of them would
-      // fail Zod and reject every other row in the request with it.
-      if (!IDENTIFIER_FIELDS.some((f) => row[f])) continue;
+      // fail Zod and reject every other row in the request with it. Counted, not
+      // silently swallowed: a mis-mapped identifier column drops EVERY row, and
+      // an unexplained "Check 0 rows" is indistinguishable from an empty file.
+      if (!IDENTIFIER_FIELDS.some((f) => row[f])) {
+        dropped += 1;
+        continue;
+      }
       rows.push(row);
     }
-    return rows;
+    return { rows, dropped };
   }, [csv, mapping, orgId]);
 
+  const importRows = mapped.rows;
+  const droppedRows = mapped.dropped;
+  const tooManyRows = importRows.length > MAX_IMPORT_ROWS;
   const hasIdentifierColumn = IDENTIFIER_FIELDS.some((f) => mapping[f]);
+  /** A file that parsed but produced no header row at all — nothing to map. */
+  const noColumns = csv !== null && csv.headers.length === 0;
 
   function resetPreview() {
     setPreviewRows(null);
     setSelected(new Set());
+  }
+
+  function clearOutcome() {
+    setFailures([]);
+    setSkipped([]);
+    setFailureLabels({});
+    setLastSummary(null);
   }
 
   function loadFile(file: File) {
@@ -162,9 +197,18 @@ export default function BulkContactImport({ orgId, onImported, onUnauthorized, o
       setCsv(parsed);
       setMapping(guessMapping(parsed.headers));
       resetPreview();
-      setFailures([]);
-      setFailureLabels({});
-      setLastSummary(null);
+      clearOutcome();
+    }).catch((err: unknown) => {
+      // A rejected read (the file was moved, renamed or its permission revoked
+      // between picking and reading) used to leave the panel looking idle, with
+      // the operator waiting on a preview that would never come.
+      console.warn('[BulkContactImport] file read failed', err);
+      showToast({ type: 'error', message: t('bulkContactImport.errors.fileRead') });
+      setFileName(null);
+      setCsv(null);
+      setMapping({});
+      resetPreview();
+      clearOutcome();
     });
   }
 
@@ -177,9 +221,7 @@ export default function BulkContactImport({ orgId, onImported, onUnauthorized, o
 
   async function preview() {
     setPreviewing(true);
-    setFailures([]);
-    setFailureLabels({});
-    setLastSummary(null);
+    clearOutcome();
     try {
       const res = await runAction<{ rows: AnnotatedContactRow[] }>({
         request: () =>
@@ -206,8 +248,11 @@ export default function BulkContactImport({ orgId, onImported, onUnauthorized, o
     if (!previewRows) return;
     const chosen = previewRows.filter((r) => selected.has(r.index));
     if (chosen.length === 0) return;
+    // Keyed by SUBMITTED position: the server counts `errors[].index` and
+    // `skipped[].index` against the array it received, so keying by the preview
+    // row's own index names the wrong person the moment a row is deselected.
     const labels = Object.fromEntries(
-      chosen.map((r) => [r.index, r.name ?? r.email ?? r.phone ?? r.mobile ?? `#${r.index + 1}`]),
+      chosen.map((r, i) => [i, r.name ?? r.email ?? r.phone ?? r.mobile ?? `#${r.index + 1}`]),
     );
     setImporting(true);
     try {
@@ -233,10 +278,22 @@ export default function BulkContactImport({ orgId, onImported, onUnauthorized, o
         showToast({ type: 'error', message: t('bulkContactImport.summary.allFailed', { summary: message }) });
       } else if (s.errors.length > 0) {
         showToast({ type: 'warning', message: `${message}.` });
+      } else if (!wrote) {
+        // Nothing failed, but nothing was written either — the DEFAULT re-import
+        // path, since link-match rows arrive pre-ticked and skip mode leaves them
+        // alone. Green here reads as "imported", which is exactly backwards.
+        // Toast has no neutral/info type, so warning is the honest one.
+        showToast({
+          type: 'warning',
+          message: s.skipped.length > 0
+            ? t('bulkContactImport.summary.nothingImported', { count: s.skipped.length })
+            : t('bulkContactImport.summary.nothingImportedEmpty'),
+        });
       } else {
         showToast({ type: 'success', message: `${message}.` });
       }
       setFailures(s.errors);
+      setSkipped(s.skipped);
       setFailureLabels(labels);
       setLastSummary(message);
       resetPreview();
@@ -246,6 +303,39 @@ export default function BulkContactImport({ orgId, onImported, onUnauthorized, o
     } finally {
       setImporting(false);
     }
+  }
+
+  /** The person behind a submitted position, for an error or a skip line. */
+  function outcomeLabel(index: number, organization?: string): string {
+    return failureLabels[index] ?? organization ?? `#${index + 1}`;
+  }
+
+  /**
+   * Translated copy for a refusal. Branches on the CODE, never on `error`: the
+   * server's string is English and phrased for a developer (`match-unconfirmed`
+   * names a JSON field the operator has never seen). An unknown code — a server
+   * newer than this bundle — falls through to that string rather than to nothing.
+   */
+  function failureCopy(code: ContactImportErrorCode, serverText: string): string {
+    switch (code) {
+      case 'row-conflict': return t('bulkContactImport.errorCodes.rowConflict');
+      case 'org-not-found': return t('bulkContactImport.errorCodes.orgNotFound');
+      case 'annotation-changed': return t('bulkContactImport.errorCodes.annotationChanged');
+      case 'match-changed': return t('bulkContactImport.errorCodes.matchChanged');
+      case 'match-unconfirmed': return t('bulkContactImport.errorCodes.matchUnconfirmed');
+      case 'write-failed': return t('bulkContactImport.errorCodes.writeFailed');
+      case 'no-identifier': return t('bulkContactImport.errorCodes.noIdentifier');
+      case 'invalid-role': return t('bulkContactImport.errorCodes.invalidRole');
+      case 'site-not-in-org': return t('bulkContactImport.errorCodes.siteNotInOrg');
+      default: return serverText;
+    }
+  }
+
+  /** `skipped[].reason` is a machine token; only `already_linked` exists today. */
+  function skipCopy(reason: string): string {
+    return reason === 'already_linked'
+      ? t('bulkContactImport.skipped.reasons.alreadyLinked')
+      : reason;
   }
 
   return (
@@ -296,6 +386,15 @@ export default function BulkContactImport({ orgId, onImported, onUnauthorized, o
         <span className="mt-1 text-xs">{t('bulkContactImport.dropzoneHint')}</span>
       </div>
 
+      {noColumns && (
+        <p
+          data-testid="bulk-contact-import-no-columns"
+          className="mt-3 text-xs text-destructive"
+        >
+          {t('bulkContactImport.errors.noColumns')}
+        </p>
+      )}
+
       {/* Step 2: column mapping */}
       {csv && csv.headers.length > 0 && (
         <div className="mt-4">
@@ -332,7 +431,7 @@ export default function BulkContactImport({ orgId, onImported, onUnauthorized, o
               type="button"
               data-testid="bulk-contact-import-preview"
               onClick={preview}
-              disabled={previewing || importRows.length === 0}
+              disabled={previewing || importRows.length === 0 || tooManyRows}
               className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
             >
               {previewing
@@ -345,6 +444,25 @@ export default function BulkContactImport({ orgId, onImported, onUnauthorized, o
                 className="text-xs text-muted-foreground"
               >
                 {t('bulkContactImport.mapping.identifierRequired')}
+              </span>
+            )}
+            {droppedRows > 0 && (
+              <span
+                data-testid="bulk-contact-import-dropped"
+                className="text-xs text-amber-700 dark:text-amber-400"
+              >
+                {t('bulkContactImport.mapping.droppedRows', { count: droppedRows })}
+              </span>
+            )}
+            {tooManyRows && (
+              <span
+                data-testid="bulk-contact-import-too-many"
+                className="text-xs text-destructive"
+              >
+                {t('bulkContactImport.mapping.tooManyRows', {
+                  count: importRows.length,
+                  max: MAX_IMPORT_ROWS,
+                })}
               </span>
             )}
           </div>
@@ -401,6 +519,26 @@ export default function BulkContactImport({ orgId, onImported, onUnauthorized, o
         </p>
       )}
 
+      {skipped.length > 0 && (
+        <div
+          className="mt-4 rounded-md border border-border bg-muted/40 p-3"
+          data-testid="bulk-contact-import-skipped"
+        >
+          <p className="text-sm font-medium">
+            {t('bulkContactImport.skipped.title', { count: skipped.length })}
+          </p>
+          <ul className="mt-2 space-y-1 text-xs text-muted-foreground">
+            {skipped.map((row) => (
+              <li key={row.index} data-testid={`bulk-contact-import-skipped-${row.index}`}>
+                <span className="font-medium text-foreground">{outcomeLabel(row.index)}</span>
+                {': '}
+                {skipCopy(row.reason)}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
       {failures.length > 0 && (
         <div
           className="mt-4 rounded-md border border-destructive/40 bg-destructive/10 p-3"
@@ -410,15 +548,27 @@ export default function BulkContactImport({ orgId, onImported, onUnauthorized, o
             {t('bulkContactImport.failures.title', { count: failures.length })}
           </p>
           <ul className="mt-2 space-y-1 text-xs text-destructive">
-            {failures.map((f) => (
-              <li key={f.index} data-testid={`bulk-contact-import-failure-${f.index}`}>
-                <span className="font-medium">
-                  {failureLabels[f.index] ?? f.organization ?? `#${f.index + 1}`}
-                </span>
-                {': '}
-                {f.error}
-              </li>
-            ))}
+            {failures.map((f) => {
+              const copy = failureCopy(f.code, f.error);
+              return (
+                <li key={f.index} data-testid={`bulk-contact-import-failure-${f.index}`}>
+                  <span className="font-medium">{outcomeLabel(f.index, f.organization)}</span>
+                  {': '}
+                  {copy}
+                  {/* The server's own sentence, kept as detail so a support
+                      thread can still quote it verbatim. */}
+                  {copy !== f.error && (
+                    <span
+                      data-testid={`bulk-contact-import-failure-detail-${f.index}`}
+                      className="mt-0.5 block text-[11px] opacity-75"
+                      title={f.error}
+                    >
+                      {f.error}
+                    </span>
+                  )}
+                </li>
+              );
+            })}
           </ul>
         </div>
       )}

--- a/apps/web/src/components/organizations/ContactImportPreviewTable.test.tsx
+++ b/apps/web/src/components/organizations/ContactImportPreviewTable.test.tsx
@@ -1,0 +1,261 @@
+import { describe, it, expect, vi } from 'vitest';
+import { useState } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ContactImportPreviewTable, {
+  bulkSelectableContactRows,
+  defaultContactPreviewSelection,
+  isContactRowSelectable,
+  toContactCommitRow,
+  type AnnotatedContactRow,
+} from './ContactImportPreviewTable';
+
+const ROWS: AnnotatedContactRow[] = [
+  {
+    index: 0, name: 'Ada Byron', email: 'ada@acme.test', site: 'HQ',
+    annotation: 'create', organizationId: 'org-1', siteId: 'site-hq', contactId: null,
+  },
+  {
+    index: 1, name: 'Grace H', email: 'grace@acme.test', externalId: 'cw-9',
+    annotation: 'link-match', organizationId: 'org-1', siteId: null, contactId: 'c-grace',
+    matchedContactName: 'Grace Hopper', matchedContactEmail: 'grace@acme.test',
+  },
+  {
+    index: 2, name: 'Alan T', email: 'alan@acme.test',
+    annotation: 'email-match', organizationId: 'org-1', siteId: null, contactId: 'c-alan',
+    matchedContactName: 'Alan Turing', matchedContactEmail: 'alan@acme.test',
+  },
+  {
+    index: 3, name: 'Katherine J',
+    annotation: 'name-match', organizationId: 'org-1', siteId: null, contactId: 'c-kat',
+    matchedContactName: 'Katherine Johnson',
+  },
+  {
+    index: 4, email: 'shared@acme.test',
+    annotation: 'conflict', organizationId: 'org-1', siteId: null, contactId: null,
+    conflictReason: '3 contacts in Acme already use shared@acme.test',
+  },
+  {
+    index: 5, name: 'Nobody', organization: 'Ghost Co',
+    annotation: 'org-not-found', organizationId: null, siteId: null, contactId: null,
+    conflictReason: 'No such organization under this partner',
+  },
+];
+
+/**
+ * A `create` row that ALSO carries a non-fatal warning: the address matched
+ * several existing contacts, and the row was created anyway because it carries
+ * its own external id. The row still applies exactly as annotated.
+ */
+const WARNED_ROW: AnnotatedContactRow = {
+  index: 6,
+  name: 'Ada Byron',
+  email: 'shared@acme.test',
+  externalId: 'cw-42',
+  annotation: 'create',
+  organizationId: 'org-1',
+  siteId: null,
+  contactId: null,
+  warning: '3 existing contacts in Acme share shared@acme.test; creating another,'
+    + ' because this row carries its own externalId',
+};
+
+function nextSelection(
+  onSelectedChange: ReturnType<typeof vi.fn>,
+  prev: Iterable<number>,
+  callIndex = -1,
+): Set<number> {
+  const arg = onSelectedChange.mock.calls.at(callIndex)![0] as unknown;
+  expect(typeof arg, 'setState must be called with a functional updater').toBe('function');
+  return (arg as (p: Set<number>) => Set<number>)(new Set(prev));
+}
+
+function renderTable(
+  overrides: Partial<React.ComponentProps<typeof ContactImportPreviewTable>> = {},
+) {
+  const onSelectedChange = vi.fn();
+  render(
+    <ContactImportPreviewTable
+      rows={ROWS}
+      selected={new Set<number>()}
+      onSelectedChange={onSelectedChange}
+      testIdPrefix="x-contacts"
+      {...overrides}
+    />,
+  );
+  return { onSelectedChange };
+}
+
+/** Host that owns the selection state, like BulkContactImport does. */
+function StatefulTable({ rows, initial }: { rows: AnnotatedContactRow[]; initial?: Set<number> }) {
+  const [selected, setSelected] = useState<Set<number>>(initial ?? new Set());
+  return (
+    <ContactImportPreviewTable
+      rows={rows}
+      selected={selected}
+      onSelectedChange={setSelected}
+      testIdPrefix="x-contacts"
+    />
+  );
+}
+
+describe('contact preview selection rules', () => {
+  it('never lets a conflict or org-not-found row be selected', () => {
+    expect(isContactRowSelectable(ROWS[0]!)).toBe(true);
+    expect(isContactRowSelectable(ROWS[1]!)).toBe(true);
+    expect(isContactRowSelectable(ROWS[2]!)).toBe(true);
+    expect(isContactRowSelectable(ROWS[3]!)).toBe(true);
+    expect(isContactRowSelectable(ROWS[4]!)).toBe(false);
+    expect(isContactRowSelectable(ROWS[5]!)).toBe(false);
+  });
+
+  it('restricts select-all to create + link-match', () => {
+    expect(bulkSelectableContactRows(ROWS).map((r) => r.index)).toEqual([0, 1]);
+  });
+
+  it('pre-checks only create + link-match, leaving fuzzy hints unticked', () => {
+    expect([...defaultContactPreviewSelection(ROWS)].sort()).toEqual([0, 1]);
+  });
+});
+
+describe('toContactCommitRow', () => {
+  it('echoes the row fields plus the acknowledgement for a create row', () => {
+    expect(toContactCommitRow(ROWS[0]!)).toEqual({
+      organizationId: 'org-1',
+      name: 'Ada Byron',
+      email: 'ada@acme.test',
+      site: 'HQ',
+      expectedAnnotation: 'create',
+    });
+  });
+
+  it('pins expectedContactId on a link-match', () => {
+    expect(toContactCommitRow(ROWS[1]!)).toMatchObject({
+      expectedAnnotation: 'link-match',
+      expectedContactId: 'c-grace',
+      externalId: 'cw-9',
+    });
+  });
+
+  it('pins expectedContactId on an acknowledged email-match', () => {
+    expect(toContactCommitRow(ROWS[2]!)).toMatchObject({
+      expectedAnnotation: 'email-match',
+      expectedContactId: 'c-alan',
+    });
+  });
+
+  it('sends no acknowledgement at all for an unacknowledgeable annotation', () => {
+    // `conflict` / `org-not-found` are not in the commit enum: sending one would
+    // 400 the WHOLE batch, not just this row.
+    expect(toContactCommitRow(ROWS[4]!).expectedAnnotation).toBeUndefined();
+    expect(toContactCommitRow(ROWS[5]!).expectedAnnotation).toBeUndefined();
+  });
+
+  it('drops a fuzzy acknowledgement that has no contact to pin', () => {
+    // The server REQUIRES expectedContactId whenever expectedAnnotation is
+    // email-match/name-match, and rejects the entire request when it is absent.
+    const unpinned: AnnotatedContactRow = { ...ROWS[3]!, contactId: null };
+    const commit = toContactCommitRow(unpinned);
+    expect(commit.expectedAnnotation).toBeUndefined();
+    expect(commit.expectedContactId).toBeUndefined();
+  });
+
+  it('omits blank optional fields rather than sending empty strings', () => {
+    const sparse: AnnotatedContactRow = {
+      index: 9, name: 'Solo', annotation: 'create',
+      organizationId: 'org-1', siteId: null, contactId: null,
+    };
+    expect(toContactCommitRow(sparse)).toEqual({
+      organizationId: 'org-1',
+      name: 'Solo',
+      expectedAnnotation: 'create',
+    });
+  });
+});
+
+describe('ContactImportPreviewTable', () => {
+  it('renders a badge per annotation', () => {
+    renderTable();
+    expect(screen.getByTestId('x-contacts-badge-0')).toHaveTextContent('New');
+    expect(screen.getByTestId('x-contacts-badge-1')).toHaveTextContent('Already linked');
+    expect(screen.getByTestId('x-contacts-badge-2')).toHaveTextContent('Email match');
+    expect(screen.getByTestId('x-contacts-badge-3')).toHaveTextContent('Name match');
+    expect(screen.getByTestId('x-contacts-badge-4')).toHaveTextContent('Conflict');
+    expect(screen.getByTestId('x-contacts-badge-5')).toHaveTextContent('Organization not found');
+  });
+
+  it('disables the checkbox on rows that can never be committed', () => {
+    renderTable();
+    expect(screen.getByTestId('x-contacts-select-0')).toBeEnabled();
+    expect(screen.getByTestId('x-contacts-select-2')).toBeEnabled();
+    expect(screen.getByTestId('x-contacts-select-4')).toBeDisabled();
+    expect(screen.getByTestId('x-contacts-select-5')).toBeDisabled();
+  });
+
+  it('shows the matched contact beside a fuzzy hint', () => {
+    renderTable();
+    expect(screen.getByTestId('x-contacts-match-2')).toHaveTextContent('Alan Turing');
+    expect(screen.getByTestId('x-contacts-match-3')).toHaveTextContent('Katherine Johnson');
+  });
+
+  it('renders a conflict reason for a row that cannot be applied', () => {
+    renderTable();
+    expect(screen.getByTestId('x-contacts-conflict-4'))
+      .toHaveTextContent('3 contacts in Acme already use shared@acme.test');
+  });
+
+  it('renders a non-fatal warning distinctly from a conflict reason', () => {
+    render(
+      <ContactImportPreviewTable
+        rows={[WARNED_ROW]}
+        selected={new Set([6])}
+        onSelectedChange={vi.fn()}
+        testIdPrefix="x-contacts"
+      />,
+    );
+    const warning = screen.getByTestId('x-contacts-warning-6');
+    expect(warning).toHaveTextContent('3 existing contacts in Acme share shared@acme.test');
+    // A warning is advisory, not fatal: the row is still an applicable `create`.
+    expect(screen.getByTestId('x-contacts-select-6')).toBeEnabled();
+    expect(screen.getByTestId('x-contacts-badge-6')).toHaveTextContent('New');
+    expect(screen.queryByTestId('x-contacts-conflict-6')).not.toBeInTheDocument();
+    // Amber, not the destructive red the conflict reason uses.
+    expect(warning.className).toContain('amber');
+  });
+
+  it('attributes an org-level row to the organization rather than a site', () => {
+    renderTable();
+    expect(screen.getByTestId('x-contacts-row-0')).toHaveTextContent('HQ');
+    expect(screen.getByTestId('x-contacts-row-1')).toHaveTextContent('Organization');
+  });
+
+  it('toggles a row through a functional updater', () => {
+    const { onSelectedChange } = renderTable();
+    fireEvent.click(screen.getByTestId('x-contacts-select-2'));
+    expect([...nextSelection(onSelectedChange, [0, 1])].sort()).toEqual([0, 1, 2]);
+  });
+
+  it('never adds an unselectable row even when clicked', () => {
+    const { onSelectedChange } = renderTable();
+    // The checkbox is disabled, so drive the handler the way a stale host would.
+    fireEvent.click(screen.getByTestId('x-contacts-select-0'));
+    const updater = onSelectedChange.mock.calls.at(-1)![0] as (p: Set<number>) => Set<number>;
+    expect([...updater(new Set([4]))].sort()).toEqual([0, 4]);
+  });
+
+  it('select-all spans only create + link-match, leaving acknowledged hints alone', () => {
+    render(<StatefulTable rows={ROWS} initial={new Set([2])} />);
+    fireEvent.click(screen.getByTestId('x-contacts-select-all'));
+    expect(screen.getByTestId('x-contacts-select-0')).toBeChecked();
+    expect(screen.getByTestId('x-contacts-select-1')).toBeChecked();
+    expect(screen.getByTestId('x-contacts-select-2')).toBeChecked(); // untouched opt-in
+    expect(screen.getByTestId('x-contacts-select-3')).not.toBeChecked();
+  });
+
+  it('deselect-all clears only the bulk set, keeping explicit opt-ins', () => {
+    render(<StatefulTable rows={ROWS} initial={new Set([0, 1, 3])} />);
+    fireEvent.click(screen.getByTestId('x-contacts-select-all'));
+    expect(screen.getByTestId('x-contacts-select-0')).not.toBeChecked();
+    expect(screen.getByTestId('x-contacts-select-1')).not.toBeChecked();
+    expect(screen.getByTestId('x-contacts-select-3')).toBeChecked();
+  });
+});

--- a/apps/web/src/components/organizations/ContactImportPreviewTable.test.tsx
+++ b/apps/web/src/components/organizations/ContactImportPreviewTable.test.tsx
@@ -234,12 +234,37 @@ describe('ContactImportPreviewTable', () => {
     expect([...nextSelection(onSelectedChange, [0, 1])].sort()).toEqual([0, 1, 2]);
   });
 
-  it('never adds an unselectable row even when clicked', () => {
+  it('never adds an unselectable row even when its own checkbox fires', () => {
     const { onSelectedChange } = renderTable();
-    // The checkbox is disabled, so drive the handler the way a stale host would.
-    fireEvent.click(screen.getByTestId('x-contacts-select-0'));
+    // Row 4 is the `conflict` row. Its checkbox is disabled, so a real click
+    // emits nothing — clear the disabled property to drive the row's OWN
+    // onChange, which is what a stale or re-rendered host would reach.
+    const conflictBox = screen.getByTestId('x-contacts-select-4') as HTMLInputElement;
+    conflictBox.disabled = false;
+    fireEvent.click(conflictBox);
+
     const updater = onSelectedChange.mock.calls.at(-1)![0] as (p: Set<number>) => Set<number>;
-    expect([...updater(new Set([4]))].sort()).toEqual([0, 4]);
+    // `conflict` is absent from the server's commit enum: acknowledging one
+    // fails Zod and rejects the WHOLE batch, not just this row.
+    expect([...updater(new Set([0, 1]))].sort()).toEqual([0, 1]);
+  });
+
+  it('always allows un-ticking an unselectable row a stale host handed it', () => {
+    const { onSelectedChange } = renderTable();
+    const orgMissingBox = screen.getByTestId('x-contacts-select-5') as HTMLInputElement;
+    orgMissingBox.disabled = false;
+    fireEvent.click(orgMissingBox);
+
+    const updater = onSelectedChange.mock.calls.at(-1)![0] as (p: Set<number>) => Set<number>;
+    expect([...updater(new Set([0, 5]))].sort()).toEqual([0]);
+  });
+
+  it('leaves select-all unchecked when no row is bulk-selectable', () => {
+    const fuzzyOnly = ROWS.filter((r) => r.annotation === 'email-match' || r.annotation === 'conflict');
+    render(<StatefulTable rows={fuzzyOnly} initial={new Set([2])} />);
+    // An empty bulk set must not render as "everything is selected" — `every`
+    // on an empty array is vacuously true.
+    expect(screen.getByTestId('x-contacts-select-all')).not.toBeChecked();
   });
 
   it('select-all spans only create + link-match, leaving acknowledged hints alone', () => {

--- a/apps/web/src/components/organizations/ContactImportPreviewTable.tsx
+++ b/apps/web/src/components/organizations/ContactImportPreviewTable.tsx
@@ -1,0 +1,330 @@
+import type { Dispatch, SetStateAction } from 'react';
+import { useTranslation } from 'react-i18next';
+import '@/lib/i18n';
+
+/**
+ * Preview table for the CONTACT importer (#3258 W04).
+ *
+ * A sibling of OrgImportPreviewTable, deliberately not a generalization of it:
+ * the two importers share a workflow (preview → acknowledge → commit) but not a
+ * row contract, an annotation vocabulary, or a selection rule. `link-match`
+ * here needs no acknowledgement (the durable external link IS the
+ * acknowledgement), the two FUZZY annotations must pin the contact they
+ * matched, and `org-not-found` has no org-importer analogue at all. Folding
+ * them into one component would mean a union type whose every branch is
+ * `if (kind === 'contact')`.
+ *
+ * Mirrors apps/api/src/services/contacts/types.ts — the JSON contract of
+ * POST /orgs/contacts/import/preview and POST /orgs/contacts/import.
+ */
+
+export type ContactRowAnnotation =
+  | 'create'
+  | 'link-match'
+  | 'email-match'
+  | 'name-match'
+  | 'conflict'
+  | 'org-not-found';
+
+/** The four annotations a client may acknowledge into a write. */
+export type CommittableContactAnnotation = Exclude<
+  ContactRowAnnotation,
+  'conflict' | 'org-not-found'
+>;
+
+export interface ContactImportRow {
+  organizationId?: string;
+  organization?: string;
+  /** The site NAME, not its id — resolved server-side within the organization. */
+  site?: string;
+  name?: string;
+  email?: string;
+  phone?: string;
+  mobile?: string;
+  title?: string;
+  roles?: string[];
+  externalId?: string;
+  externalSystem?: string;
+}
+
+export interface AnnotatedContactRow extends Omit<ContactImportRow, 'organizationId'> {
+  /** Position in the submitted rows array. */
+  index: number;
+  annotation: ContactRowAnnotation;
+  /** The RESOLVED organization, explicitly null when the row could not be placed. */
+  organizationId: string | null;
+  organizationName?: string;
+  /** The resolved site pin; null means an organization-level contact. */
+  siteId?: string | null;
+  /** The matched contact (link-match / email-match / name-match). */
+  contactId: string | null;
+  matchedContactName?: string | null;
+  matchedContactEmail?: string | null;
+  /** Populated for `conflict` and `org-not-found`. */
+  conflictReason?: string;
+  /**
+   * NON-FATAL disclosure: the row still applies exactly as `annotation` says.
+   * Set when resolution made a judgement call — today, an email or name hint
+   * that matched several contacts and was overridden into a `create` because
+   * the row carries its own external id. Rendered amber beside the badge, never
+   * red: a warning row is selectable and will be written.
+   */
+  warning?: string;
+}
+
+/** A row as submitted to a commit — mirrors `commitContactImportRowSchema`. */
+export interface CommitContactRowInput extends ContactImportRow {
+  expectedAnnotation?: CommittableContactAnnotation;
+  expectedContactId?: string;
+}
+
+/** Mirrors `ContactImportErrorCode`. Branch on this, never on `error`. */
+export type ContactImportErrorCode =
+  | 'row-conflict'
+  | 'org-not-found'
+  | 'annotation-changed'
+  | 'match-changed'
+  | 'match-unconfirmed'
+  | 'write-failed'
+  | 'no-identifier'
+  | 'invalid-role'
+  | 'site-not-in-org';
+
+export interface ContactImportResultEntry {
+  index: number;
+  organizationId: string;
+  contactId: string;
+  name: string | null;
+  createdLink: boolean;
+}
+
+export interface ContactImportSummary {
+  imported: ContactImportResultEntry[];
+  updated: ContactImportResultEntry[];
+  skipped: Array<{ index: number; organizationId: string; contactId: string; reason: string }>;
+  errors: Array<{
+    index: number;
+    organization?: string;
+    error: string;
+    code: ContactImportErrorCode;
+  }>;
+}
+
+const BADGE_STYLES: Record<ContactRowAnnotation, string> = {
+  'create': 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400',
+  'link-match': 'border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-400',
+  'email-match': 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-400',
+  'name-match': 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-400',
+  'conflict': 'border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-400',
+  'org-not-found': 'border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-400',
+};
+
+const BADGE_LABEL_KEYS: Record<ContactRowAnnotation, string> = {
+  'create': 'contactImportPreview.badges.create',
+  'link-match': 'contactImportPreview.badges.linkMatch',
+  'email-match': 'contactImportPreview.badges.emailMatch',
+  'name-match': 'contactImportPreview.badges.nameMatch',
+  'conflict': 'contactImportPreview.badges.conflict',
+  'org-not-found': 'contactImportPreview.badges.orgNotFound',
+};
+
+/** The two annotations that are HINTS: applied only on an explicit tick. */
+const FUZZY_ANNOTATIONS: ReadonlySet<ContactRowAnnotation> = new Set(['email-match', 'name-match']);
+
+/**
+ * Every row the table lets the user tick. `conflict` and `org-not-found` are
+ * absent from the server's commit enum — a row carrying either as an
+ * acknowledgement fails Zod and rejects the WHOLE batch, not just that row.
+ */
+export function isContactRowSelectable(row: AnnotatedContactRow): boolean {
+  return row.annotation !== 'conflict' && row.annotation !== 'org-not-found';
+}
+
+/**
+ * The rows select-all is allowed to touch. A fuzzy email/name hint is a per-row
+ * human judgement ("yes, that really is the same person"), so a bulk toggle
+ * must never opt 500 of them into merging onto contacts nobody looked at.
+ */
+export function bulkSelectableContactRows(
+  rows: readonly AnnotatedContactRow[],
+): AnnotatedContactRow[] {
+  return rows.filter((r) => r.annotation === 'create' || r.annotation === 'link-match');
+}
+
+/** The selection a fresh preview starts with: create + link-match only. */
+export function defaultContactPreviewSelection(
+  rows: readonly AnnotatedContactRow[],
+): Set<number> {
+  return new Set(bulkSelectableContactRows(rows).map((r) => r.index));
+}
+
+/**
+ * Map an acknowledged preview row onto its commit payload.
+ *
+ * A fuzzy acknowledgement is dropped wholesale when the row carries no
+ * `contactId` to pin: the server REQUIRES `expectedContactId` alongside an
+ * `email-match`/`name-match` acknowledgement and rejects the entire request
+ * without it, so half an acknowledgement would cost the operator every other
+ * row in the file. Sending none instead lets the commit apply its own
+ * unconfirmed-match refusal to this row alone.
+ */
+export function toContactCommitRow(row: AnnotatedContactRow): CommitContactRowInput {
+  const committable = isContactRowSelectable(row);
+  const pinned = row.contactId ?? undefined;
+  const fuzzyWithoutPin = FUZZY_ANNOTATIONS.has(row.annotation) && pinned === undefined;
+  return {
+    ...(row.organizationId ? { organizationId: row.organizationId } : {}),
+    ...(row.organization ? { organization: row.organization } : {}),
+    ...(row.site ? { site: row.site } : {}),
+    ...(row.name ? { name: row.name } : {}),
+    ...(row.email ? { email: row.email } : {}),
+    ...(row.phone ? { phone: row.phone } : {}),
+    ...(row.mobile ? { mobile: row.mobile } : {}),
+    ...(row.title ? { title: row.title } : {}),
+    ...(row.roles && row.roles.length > 0 ? { roles: row.roles } : {}),
+    ...(row.externalId ? { externalId: row.externalId } : {}),
+    ...(row.externalSystem ? { externalSystem: row.externalSystem } : {}),
+    ...(committable && !fuzzyWithoutPin
+      ? {
+          expectedAnnotation: row.annotation as CommittableContactAnnotation,
+          // Pin the identity the user acknowledged: commit re-derives the match
+          // and refuses the row if it now resolves to a DIFFERENT contact.
+          ...(pinned ? { expectedContactId: pinned } : {}),
+        }
+      : {}),
+  };
+}
+
+interface Props {
+  rows: AnnotatedContactRow[];
+  /** Indexes the user has acknowledged for commit. Owned by the host. */
+  selected: ReadonlySet<number>;
+  /**
+   * A `useState` setter, NOT a plain callback: every selection change derives
+   * from the previous selection, so the table always passes a functional
+   * updater and two toggles in one tick cannot drop each other.
+   */
+  onSelectedChange: Dispatch<SetStateAction<Set<number>>>;
+  /**
+   * Prefix for every `data-testid` this table emits, e.g. `bulk-contact-import`
+   * yields `-table`, `-select-all`, `-row-N`, `-select-N`, `-badge-N`. E2E
+   * specs key off these, so a host must not change its prefix once shipped.
+   */
+  testIdPrefix: string;
+}
+
+export default function ContactImportPreviewTable({
+  rows,
+  selected,
+  onSelectedChange,
+  testIdPrefix,
+}: Props) {
+  const { t } = useTranslation('settings');
+  const bulkRows = bulkSelectableContactRows(rows);
+
+  function toggleRow(row: AnnotatedContactRow) {
+    onSelectedChange((prev) => {
+      const next = new Set(prev);
+      if (next.has(row.index)) next.delete(row.index);
+      // Un-ticking an unselectable row is always allowed (a host may hand us a
+      // stale selection); ticking one never is.
+      else if (isContactRowSelectable(row)) next.add(row.index);
+      return next;
+    });
+  }
+
+  function toggleAll() {
+    onSelectedChange((prev) => {
+      const next = new Set(prev);
+      if (bulkRows.every((r) => next.has(r.index))) {
+        // Deselect the bulk set only; an explicit fuzzy opt-in stays ticked.
+        for (const r of bulkRows) next.delete(r.index);
+      } else {
+        for (const r of bulkRows) next.add(r.index);
+      }
+      return next;
+    });
+  }
+
+  return (
+    <div className="mt-2 max-h-96 overflow-y-auto rounded-md border">
+      <table className="w-full text-sm" data-testid={`${testIdPrefix}-table`}>
+        <thead>
+          <tr className="border-b bg-muted/50 text-left text-xs text-muted-foreground">
+            <th className="w-8 px-2 py-1.5">
+              <input
+                type="checkbox"
+                data-testid={`${testIdPrefix}-select-all`}
+                aria-label={t('contactImportPreview.selectAll')}
+                checked={bulkRows.length > 0 && bulkRows.every((r) => selected.has(r.index))}
+                onChange={toggleAll}
+              />
+            </th>
+            <th className="px-2 py-1.5">{t('contactImportPreview.columns.name')}</th>
+            <th className="px-2 py-1.5">{t('contactImportPreview.columns.email')}</th>
+            <th className="px-2 py-1.5">{t('contactImportPreview.columns.site')}</th>
+            <th className="px-2 py-1.5">{t('contactImportPreview.columns.status')}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr
+              key={r.index}
+              data-testid={`${testIdPrefix}-row-${r.index}`}
+              className="border-b border-border/50 last:border-0"
+            >
+              <td className="px-2 py-1.5">
+                <input
+                  type="checkbox"
+                  data-testid={`${testIdPrefix}-select-${r.index}`}
+                  checked={selected.has(r.index)}
+                  disabled={!isContactRowSelectable(r)}
+                  onChange={() => toggleRow(r)}
+                />
+              </td>
+              <td className="px-2 py-1.5">{r.name ?? '—'}</td>
+              <td className="px-2 py-1.5 text-muted-foreground">{r.email ?? '—'}</td>
+              <td className="px-2 py-1.5 text-muted-foreground">
+                {r.site ?? t('contactImportPreview.organizationLevel')}
+              </td>
+              <td className="px-2 py-1.5">
+                <span
+                  data-testid={`${testIdPrefix}-badge-${r.index}`}
+                  className={`inline-flex rounded-full border px-2 py-0.5 text-xs ${BADGE_STYLES[r.annotation]}`}
+                >
+                  {t(/* i18n-dynamic */ BADGE_LABEL_KEYS[r.annotation])}
+                </span>
+                {FUZZY_ANNOTATIONS.has(r.annotation) && r.matchedContactName && (
+                  <span
+                    data-testid={`${testIdPrefix}-match-${r.index}`}
+                    className="ml-2 text-xs text-muted-foreground"
+                  >
+                    {t('contactImportPreview.matches', { name: r.matchedContactName })}
+                  </span>
+                )}
+                {/* Advisory, not fatal: the row still applies as annotated, so
+                    this reads amber and the checkbox above stays enabled. */}
+                {r.warning && (
+                  <span
+                    data-testid={`${testIdPrefix}-warning-${r.index}`}
+                    className="ml-2 text-xs text-amber-700 dark:text-amber-400"
+                  >
+                    {r.warning}
+                  </span>
+                )}
+                {!isContactRowSelectable(r) && r.conflictReason && (
+                  <span
+                    data-testid={`${testIdPrefix}-conflict-${r.index}`}
+                    className="ml-2 text-xs text-red-700 dark:text-red-400"
+                  >
+                    {r.conflictReason}
+                  </span>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/ContactsCard.test.tsx
+++ b/apps/web/src/components/settings/ContactsCard.test.tsx
@@ -1,0 +1,354 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ContactsCard from './ContactsCard';
+
+const fetchWithAuthMock = vi.fn();
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: (...a: unknown[]) => fetchWithAuthMock(...a),
+}));
+
+const navigateToMock = vi.fn();
+vi.mock('@/lib/navigation', () => ({
+  navigateTo: (...a: unknown[]) => navigateToMock(...a),
+}));
+
+const showToastMock = vi.fn();
+vi.mock('../shared/Toast', () => ({
+  showToast: (...a: unknown[]) => showToastMock(...a),
+}));
+
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+const SITE_HQ = '22222222-2222-4222-8222-222222222222';
+const SITE_DEPOT = '33333333-3333-4333-8333-333333333333';
+
+function jsonResponse(body: unknown, status = 200) {
+  return Promise.resolve(
+    new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } }),
+  );
+}
+
+const SITES = [
+  { id: SITE_HQ, orgId: ORG_ID, name: 'HQ' },
+  { id: SITE_DEPOT, orgId: ORG_ID, name: 'Depot' },
+];
+
+const CONTACTS = [
+  {
+    id: 'c-ada', orgId: ORG_ID, siteId: null, name: 'Ada Byron', email: 'ada@acme.test',
+    phone: '555-0100', mobile: null, title: 'CTO', roles: ['technical', 'escalation'],
+    isPrimary: true, notes: null, createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  },
+  {
+    id: 'c-grace', orgId: ORG_ID, siteId: SITE_HQ, name: 'Grace Hopper',
+    email: 'grace@acme.test', phone: null, mobile: '555-0199', title: 'Site lead',
+    roles: ['site'], isPrimary: true, notes: null, createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  },
+  {
+    id: 'c-alan', orgId: ORG_ID, siteId: SITE_DEPOT, name: 'Alan Turing',
+    email: null, phone: '555-0111', mobile: null, title: null, roles: [],
+    isPrimary: false, notes: null, createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  },
+];
+
+/** Routes by URL so the contacts list and the sites list can't shadow each other. */
+function mockApi(options: {
+  contacts?: unknown;
+  contactsStatus?: number;
+  sites?: unknown;
+  sitesStatus?: number;
+} = {}) {
+  fetchWithAuthMock.mockImplementation((url: string) => {
+    if (url.startsWith('/orgs/sites')) {
+      return jsonResponse(
+        options.sites ?? { data: SITES, pagination: { page: 1, limit: 50, total: SITES.length } },
+        options.sitesStatus ?? 200,
+      );
+    }
+    return jsonResponse(
+      options.contacts
+        ?? { data: CONTACTS, pagination: { page: 1, limit: 25, total: CONTACTS.length } },
+      options.contactsStatus ?? 200,
+    );
+  });
+}
+
+/** Every contacts-list URL requested so far, oldest first. */
+function listCalls(): string[] {
+  return fetchWithAuthMock.mock.calls
+    .map((c) => c[0] as string)
+    .filter((u) => u.includes('/contacts') && !u.startsWith('/orgs/sites'));
+}
+
+function mutationCalls(): Array<[string, RequestInit]> {
+  return fetchWithAuthMock.mock.calls
+    .filter((c) => typeof c[1] === 'object' && c[1] !== null && 'method' in (c[1] as object))
+    .map((c) => [c[0] as string, c[1] as RequestInit]);
+}
+
+async function renderCard() {
+  render(<ContactsCard orgId={ORG_ID} />);
+  await waitFor(() => expect(screen.getByTestId('org-contacts-table')).toBeInTheDocument());
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(window, 'confirm').mockReturnValue(true);
+});
+
+describe('ContactsCard list', () => {
+  it('renders every contact with its site attribution and primary marker', async () => {
+    mockApi();
+    await renderCard();
+
+    expect(screen.getByTestId('org-contacts-row-c-ada')).toHaveTextContent('Ada Byron');
+    expect(screen.getByTestId('org-contacts-row-c-grace')).toHaveTextContent('Grace Hopper');
+
+    // An org-level contact is attributed to the organization, not to a site.
+    expect(screen.getByTestId('org-contacts-site-c-ada')).toHaveTextContent('Organization');
+    // A site-pinned contact resolves to the site NAME, not its uuid.
+    expect(screen.getByTestId('org-contacts-site-c-grace')).toHaveTextContent('HQ');
+    expect(screen.getByTestId('org-contacts-site-c-alan')).toHaveTextContent('Depot');
+
+    // Primary is per SCOPE: an org can hold an org-level primary and one per site.
+    expect(screen.getByTestId('org-contacts-primary-c-ada')).toHaveTextContent('Primary (organization)');
+    expect(screen.getByTestId('org-contacts-primary-c-grace')).toHaveTextContent('Primary (HQ)');
+    expect(screen.queryByTestId('org-contacts-primary-c-alan')).not.toBeInTheDocument();
+  });
+
+  it('renders roles as badges', async () => {
+    mockApi();
+    await renderCard();
+    const roles = screen.getByTestId('org-contacts-roles-c-ada');
+    expect(roles).toHaveTextContent('Technical');
+    expect(roles).toHaveTextContent('Escalation');
+  });
+
+  it('reads its sites from the tab organization, not the globally selected one', async () => {
+    mockApi();
+    await renderCard();
+    const siteCall = fetchWithAuthMock.mock.calls.find((c) => (c[0] as string).startsWith('/orgs/sites'));
+    expect(siteCall?.[0]).toBe(`/orgs/sites?organizationId=${ORG_ID}&limit=100`);
+  });
+
+  it('shows an empty state rather than a bare table', async () => {
+    mockApi({ contacts: { data: [], pagination: { page: 1, limit: 25, total: 0 } } });
+    render(<ContactsCard orgId={ORG_ID} />);
+    await waitFor(() => expect(screen.getByTestId('org-contacts-empty')).toBeInTheDocument());
+  });
+
+  it('shows a retryable error when the list fails', async () => {
+    mockApi({ contacts: { error: 'boom' }, contactsStatus: 500 });
+    render(<ContactsCard orgId={ORG_ID} />);
+    await waitFor(() => expect(screen.getByTestId('org-contacts-load-error')).toBeInTheDocument());
+  });
+
+  it('redirects to login on a 401 rather than rendering an error', async () => {
+    mockApi({ contacts: { error: 'Unauthorized' }, contactsStatus: 401 });
+    render(<ContactsCard orgId={ORG_ID} />);
+    await waitFor(() => expect(navigateToMock).toHaveBeenCalledWith('/login', { replace: true }));
+    expect(screen.queryByTestId('org-contacts-load-error')).not.toBeInTheDocument();
+  });
+});
+
+describe('ContactsCard filters', () => {
+  it('sends siteId=none for the organization-level filter', async () => {
+    mockApi();
+    await renderCard();
+    fireEvent.change(screen.getByTestId('org-contacts-filter-site'), { target: { value: 'none' } });
+    await waitFor(() => expect(listCalls().at(-1)).toContain('siteId=none'));
+  });
+
+  it('sends the site uuid when a site is picked', async () => {
+    mockApi();
+    await renderCard();
+    fireEvent.change(screen.getByTestId('org-contacts-filter-site'), { target: { value: SITE_HQ } });
+    await waitFor(() => expect(listCalls().at(-1)).toContain(`siteId=${SITE_HQ}`));
+  });
+
+  it('sends the role filter and omits it again when cleared', async () => {
+    mockApi();
+    await renderCard();
+    fireEvent.change(screen.getByTestId('org-contacts-filter-role'), { target: { value: 'billing' } });
+    await waitFor(() => expect(listCalls().at(-1)).toContain('role=billing'));
+
+    fireEvent.change(screen.getByTestId('org-contacts-filter-role'), { target: { value: '' } });
+    await waitFor(() => expect(listCalls().at(-1)).not.toContain('role='));
+  });
+
+  it('returns to page 1 when a filter changes', async () => {
+    mockApi({ contacts: { data: CONTACTS, pagination: { page: 2, limit: 25, total: 60 } } });
+    await renderCard();
+    fireEvent.click(screen.getByTestId('org-contacts-next'));
+    await waitFor(() => expect(listCalls().at(-1)).toContain('page=2'));
+
+    fireEvent.change(screen.getByTestId('org-contacts-filter-role'), { target: { value: 'admin' } });
+    await waitFor(() => expect(listCalls().at(-1)).toContain('page=1'));
+  });
+});
+
+describe('ContactsCard mutations', () => {
+  async function openAddForm() {
+    fireEvent.click(screen.getByTestId('org-contacts-add-button'));
+    await waitFor(() => expect(screen.getByTestId('contact-form')).toBeInTheDocument());
+  }
+
+  it('creates a contact and refetches the list instead of patching state locally', async () => {
+    mockApi();
+    await renderCard();
+    const listsBefore = listCalls().length;
+    await openAddForm();
+
+    fireEvent.change(screen.getByTestId('contact-form-name-input'), { target: { value: 'Katherine Johnson' } });
+    fireEvent.change(screen.getByTestId('contact-form-email-input'), { target: { value: 'kj@acme.test' } });
+    fireEvent.change(screen.getByTestId('contact-form-site-select'), { target: { value: SITE_HQ } });
+    fireEvent.click(screen.getByTestId('contact-form-role-billing'));
+    fireEvent.click(screen.getByTestId('contact-form-primary-input'));
+    fireEvent.click(screen.getByTestId('contact-form-submit'));
+
+    await waitFor(() => expect(mutationCalls().length).toBe(1));
+    const [url, init] = mutationCalls()[0]!;
+    expect(url).toBe(`/orgs/organizations/${ORG_ID}/contacts`);
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toEqual({
+      siteId: SITE_HQ,
+      name: 'Katherine Johnson',
+      email: 'kj@acme.test',
+      roles: ['billing'],
+      isPrimary: true,
+    });
+
+    // Promoting a primary DEMOTES the previous one server-side, so the list is
+    // refetched rather than patched — a local patch would leave two rows
+    // claiming the same scope.
+    await waitFor(() => expect(listCalls().length).toBeGreaterThan(listsBefore));
+  });
+
+  it('updates a contact through the contact-scoped PATCH path', async () => {
+    mockApi();
+    await renderCard();
+    fireEvent.click(screen.getByTestId('org-contacts-edit-c-alan'));
+    await waitFor(() => expect(screen.getByTestId('contact-form')).toBeInTheDocument());
+
+    expect(screen.getByTestId('contact-form-name-input')).toHaveValue('Alan Turing');
+    fireEvent.change(screen.getByTestId('contact-form-title-input'), { target: { value: 'Cryptanalyst' } });
+    fireEvent.click(screen.getByTestId('contact-form-submit'));
+
+    await waitFor(() => expect(mutationCalls().length).toBe(1));
+    const [url, init] = mutationCalls()[0]!;
+    // The update route carries no organization — reach is re-asserted server-side.
+    expect(url).toBe('/orgs/contacts/c-alan');
+    expect(init.method).toBe('PATCH');
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      title: 'Cryptanalyst',
+      name: 'Alan Turing',
+      siteId: SITE_DEPOT,
+    });
+  });
+
+  it('clears a field with an explicit null rather than an empty string', async () => {
+    mockApi();
+    await renderCard();
+    fireEvent.click(screen.getByTestId('org-contacts-edit-c-ada'));
+    await waitFor(() => expect(screen.getByTestId('contact-form')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByTestId('contact-form-phone-input'), { target: { value: '' } });
+    fireEvent.click(screen.getByTestId('contact-form-submit'));
+
+    await waitFor(() => expect(mutationCalls().length).toBe(1));
+    const body = JSON.parse(mutationCalls()[0]![1].body as string);
+    // An omitted key would leave the stored value alone; only an explicit null clears.
+    expect(body.phone).toBeNull();
+    // siteId null un-pins to organization level.
+    expect(body.siteId).toBeNull();
+  });
+
+  it('deletes a contact after confirmation and refetches', async () => {
+    mockApi();
+    await renderCard();
+    const listsBefore = listCalls().length;
+    fireEvent.click(screen.getByTestId('org-contacts-delete-c-alan'));
+
+    await waitFor(() => expect(mutationCalls().length).toBe(1));
+    const [url, init] = mutationCalls()[0]!;
+    expect(url).toBe('/orgs/contacts/c-alan');
+    expect(init.method).toBe('DELETE');
+    await waitFor(() => expect(listCalls().length).toBeGreaterThan(listsBefore));
+  });
+
+  it('does not delete when the confirmation is declined', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    mockApi();
+    await renderCard();
+    fireEvent.click(screen.getByTestId('org-contacts-delete-c-alan'));
+    expect(mutationCalls()).toHaveLength(0);
+  });
+
+  it('surfaces a server 400 through runAction and keeps the form filled', async () => {
+    mockApi();
+    await renderCard();
+    await openAddForm();
+    fireEvent.change(screen.getByTestId('contact-form-name-input'), { target: { value: 'Katherine Johnson' } });
+
+    fetchWithAuthMock.mockReturnValueOnce(
+      jsonResponse({ error: 'Site does not belong to this organization', code: 'site-not-in-org' }, 400),
+    );
+    fireEvent.click(screen.getByTestId('contact-form-submit'));
+
+    await waitFor(() =>
+      expect(showToastMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error',
+          message: 'Site does not belong to this organization',
+        }),
+      ),
+    );
+    // The form stays open with the operator's input intact — a refused save that
+    // wipes the draft costs them the retype.
+    expect(screen.getByTestId('contact-form')).toBeInTheDocument();
+    expect(screen.getByTestId('contact-form-name-input')).toHaveValue('Katherine Johnson');
+  });
+
+  it('refuses to submit a contact with no identifier', async () => {
+    mockApi();
+    await renderCard();
+    await openAddForm();
+    expect(screen.getByTestId('contact-form-submit')).toBeDisabled();
+    expect(screen.getByTestId('contact-form-identifier-hint')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId('contact-form-phone-input'), { target: { value: '555-0000' } });
+    expect(screen.getByTestId('contact-form-submit')).toBeEnabled();
+  });
+
+  it('routes a 401 on save to the login redirect without a toast', async () => {
+    mockApi();
+    await renderCard();
+    await openAddForm();
+    fireEvent.change(screen.getByTestId('contact-form-name-input'), { target: { value: 'Katherine' } });
+
+    fetchWithAuthMock.mockReturnValueOnce(jsonResponse({ error: 'Unauthorized' }, 401));
+    fireEvent.click(screen.getByTestId('contact-form-submit'));
+    await waitFor(() => expect(navigateToMock).toHaveBeenCalledWith('/login', { replace: true }));
+    expect(showToastMock).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+  });
+});
+
+describe('ContactsCard import panel', () => {
+  it('toggles the CSV importer inline and refetches once it imports', async () => {
+    mockApi();
+    await renderCard();
+    expect(screen.queryByTestId('bulk-contact-import-panel')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('org-contacts-import-button'));
+    await waitFor(() =>
+      expect(screen.getByTestId('bulk-contact-import-panel')).toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByTestId('bulk-contact-import-close'));
+    await waitFor(() =>
+      expect(screen.queryByTestId('bulk-contact-import-panel')).not.toBeInTheDocument(),
+    );
+  });
+});

--- a/apps/web/src/components/settings/ContactsCard.test.tsx
+++ b/apps/web/src/components/settings/ContactsCard.test.tsx
@@ -75,11 +75,25 @@ function mockApi(options: {
   });
 }
 
-/** Every contacts-list URL requested so far, oldest first. */
+const LIST_PREFIX = `/orgs/organizations/${ORG_ID}/contacts`;
+
+/**
+ * Every contacts-LIST GET requested so far, oldest first.
+ *
+ * Deliberately not "every URL containing /contacts": the create POST shares this
+ * exact URL and the delete DELETE also matches that substring, so a looser
+ * filter counts the mutation itself as the refetch and the "refetches" assertion
+ * passes even with the refetch deleted.
+ */
 function listCalls(): string[] {
   return fetchWithAuthMock.mock.calls
-    .map((c) => c[0] as string)
-    .filter((u) => u.includes('/contacts') && !u.startsWith('/orgs/sites'));
+    .filter((c) => {
+      const url = c[0] as string;
+      if (!url.startsWith(LIST_PREFIX)) return false;
+      const method = (c[1] as RequestInit | undefined)?.method;
+      return method === undefined || method.toUpperCase() === 'GET';
+    })
+    .map((c) => c[0] as string);
 }
 
 function mutationCalls(): Array<[string, RequestInit]> {
@@ -226,26 +240,77 @@ describe('ContactsCard mutations', () => {
     await waitFor(() => expect(listCalls().length).toBeGreaterThan(listsBefore));
   });
 
-  it('updates a contact through the contact-scoped PATCH path', async () => {
+  it('updates a contact through the contact-scoped PATCH path, sending the whole form', async () => {
     mockApi();
     await renderCard();
-    fireEvent.click(screen.getByTestId('org-contacts-edit-c-alan'));
+    // c-ada carries roles and isPrimary, so a partial assertion here would miss
+    // the fields the PATCH actually overwrites — the whole draft is sent.
+    fireEvent.click(screen.getByTestId('org-contacts-edit-c-ada'));
     await waitFor(() => expect(screen.getByTestId('contact-form')).toBeInTheDocument());
 
-    expect(screen.getByTestId('contact-form-name-input')).toHaveValue('Alan Turing');
-    fireEvent.change(screen.getByTestId('contact-form-title-input'), { target: { value: 'Cryptanalyst' } });
+    expect(screen.getByTestId('contact-form-name-input')).toHaveValue('Ada Byron');
+    fireEvent.change(screen.getByTestId('contact-form-title-input'), { target: { value: 'Chief Analyst' } });
     fireEvent.click(screen.getByTestId('contact-form-submit'));
 
     await waitFor(() => expect(mutationCalls().length).toBe(1));
     const [url, init] = mutationCalls()[0]!;
     // The update route carries no organization — reach is re-asserted server-side.
-    expect(url).toBe('/orgs/contacts/c-alan');
+    expect(url).toBe('/orgs/contacts/c-ada');
     expect(init.method).toBe('PATCH');
-    expect(JSON.parse(init.body as string)).toMatchObject({
-      title: 'Cryptanalyst',
-      name: 'Alan Turing',
-      siteId: SITE_DEPOT,
+    expect(JSON.parse(init.body as string)).toEqual({
+      siteId: null,
+      name: 'Ada Byron',
+      email: 'ada@acme.test',
+      phone: '555-0100',
+      mobile: null,
+      title: 'Chief Analyst',
+      notes: null,
+      roles: ['technical', 'escalation'],
+      isPrimary: true,
     });
+  });
+
+  it('un-pins a site-scoped contact to organization level with an explicit null', async () => {
+    mockApi();
+    await renderCard();
+    fireEvent.click(screen.getByTestId('org-contacts-edit-c-grace'));
+    await waitFor(() => expect(screen.getByTestId('contact-form')).toBeInTheDocument());
+    expect(screen.getByTestId('contact-form-site-select')).toHaveValue(SITE_HQ);
+
+    fireEvent.change(screen.getByTestId('contact-form-site-select'), { target: { value: '' } });
+    fireEvent.click(screen.getByTestId('contact-form-submit'));
+
+    await waitFor(() => expect(mutationCalls().length).toBe(1));
+    const body = JSON.parse(mutationCalls()[0]![1].body as string);
+    expect(body.siteId).toBeNull();
+    // Un-pinning must not quietly drop the rest of the person.
+    expect(body.roles).toEqual(['site']);
+    expect(body.isPrimary).toBe(true);
+  });
+
+  it('refetches after an isPrimary toggle, because the server demotes the old primary', async () => {
+    mockApi();
+    await renderCard();
+    const listsBefore = listCalls().length;
+    fireEvent.click(screen.getByTestId('org-contacts-edit-c-alan'));
+    await waitFor(() => expect(screen.getByTestId('contact-form')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('contact-form-primary-input'));
+    fireEvent.click(screen.getByTestId('contact-form-submit'));
+
+    await waitFor(() => expect(mutationCalls().length).toBe(1));
+    expect(JSON.parse(mutationCalls()[0]![1].body as string).isPrimary).toBe(true);
+    await waitFor(() => expect(listCalls().length).toBeGreaterThan(listsBefore));
+  });
+
+  it('closes the form once a create succeeds', async () => {
+    mockApi();
+    await renderCard();
+    fireEvent.click(screen.getByTestId('org-contacts-add-button'));
+    await waitFor(() => expect(screen.getByTestId('contact-form')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('contact-form-name-input'), { target: { value: 'Katherine Johnson' } });
+    fireEvent.click(screen.getByTestId('contact-form-submit'));
+    await waitFor(() => expect(screen.queryByTestId('contact-form')).not.toBeInTheDocument());
   });
 
   it('clears a field with an explicit null rather than an empty string', async () => {
@@ -336,7 +401,7 @@ describe('ContactsCard mutations', () => {
 });
 
 describe('ContactsCard import panel', () => {
-  it('toggles the CSV importer inline and refetches once it imports', async () => {
+  it('toggles the CSV importer inline', async () => {
     mockApi();
     await renderCard();
     expect(screen.queryByTestId('bulk-contact-import-panel')).not.toBeInTheDocument();
@@ -350,5 +415,193 @@ describe('ContactsCard import panel', () => {
     await waitFor(() =>
       expect(screen.queryByTestId('bulk-contact-import-panel')).not.toBeInTheDocument(),
     );
+  });
+
+  it('refetches the list once the embedded importer actually writes', async () => {
+    mockApi();
+    await renderCard();
+    fireEvent.click(screen.getByTestId('org-contacts-import-button'));
+    await waitFor(() =>
+      expect(screen.getByTestId('bulk-contact-import-panel')).toBeInTheDocument(),
+    );
+
+    const csv = 'Full Name,Email Address\nAda Byron,ada@acme.test\n';
+    const file = new File([csv], 'contacts.csv', { type: 'text/csv' });
+    Object.defineProperty(file, 'text', { value: () => Promise.resolve(csv) });
+    fireEvent.change(screen.getByTestId('bulk-contact-import-file-input'), {
+      target: { files: [file] },
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId('bulk-contact-import-map-name')).toBeInTheDocument(),
+    );
+
+    fetchWithAuthMock.mockReturnValueOnce(jsonResponse({
+      rows: [{
+        index: 0, name: 'Ada Byron', email: 'ada@acme.test', annotation: 'create',
+        organizationId: ORG_ID, siteId: null, contactId: null,
+      }],
+    }));
+    fireEvent.click(screen.getByTestId('bulk-contact-import-preview'));
+    await waitFor(() =>
+      expect(screen.getByTestId('bulk-contact-import-table')).toBeInTheDocument(),
+    );
+
+    const listsBefore = listCalls().length;
+    fetchWithAuthMock.mockReturnValueOnce(jsonResponse({
+      imported: [{ index: 0, organizationId: ORG_ID, contactId: 'c-new', name: 'Ada Byron', createdLink: false }],
+      updated: [], skipped: [], errors: [],
+    }));
+    fireEvent.click(screen.getByTestId('bulk-contact-import-submit'));
+
+    // onImported fires only when the commit actually wrote something.
+    await waitFor(() => expect(listCalls().length).toBeGreaterThan(listsBefore));
+  });
+});
+
+describe('ContactsCard sites', () => {
+  it('keeps the contact list usable and says so when the sites call fails', async () => {
+    mockApi({ sites: { error: 'boom' }, sitesStatus: 500 });
+    await renderCard();
+
+    expect(screen.getByTestId('org-contacts-sites-error')).toBeInTheDocument();
+    // The contacts themselves are org-scoped and unaffected.
+    expect(screen.getByTestId('org-contacts-row-c-ada')).toHaveTextContent('Ada Byron');
+    // A site whose name never arrived reads as unavailable, not as a permission
+    // verdict — the server already intersected the caller's allowed sites.
+    expect(screen.getByTestId('org-contacts-site-c-grace')).toHaveTextContent('Site unavailable');
+  });
+
+  it('re-requests the sites when the notice is retried', async () => {
+    mockApi({ sites: { error: 'boom' }, sitesStatus: 500 });
+    await renderCard();
+    const sitesBefore = fetchWithAuthMock.mock.calls
+      .filter((c) => (c[0] as string).startsWith('/orgs/sites')).length;
+
+    mockApi();
+    fireEvent.click(screen.getByTestId('org-contacts-sites-retry'));
+    await waitFor(() =>
+      expect(screen.queryByTestId('org-contacts-sites-error')).not.toBeInTheDocument(),
+    );
+    expect(
+      fetchWithAuthMock.mock.calls.filter((c) => (c[0] as string).startsWith('/orgs/sites')).length,
+    ).toBeGreaterThan(sitesBefore);
+    expect(screen.getByTestId('org-contacts-site-c-grace')).toHaveTextContent('HQ');
+  });
+});
+
+describe('ContactsCard pagination', () => {
+  it('summarises the range and disables the bound the page sits on', async () => {
+    mockApi({ contacts: { data: CONTACTS, pagination: { page: 1, limit: 25, total: 60 } } });
+    await renderCard();
+    expect(screen.getByTestId('org-contacts-page')).toHaveTextContent('Showing 1 to 25 of 60');
+    expect(screen.getByTestId('org-contacts-prev')).toBeDisabled();
+    expect(screen.getByTestId('org-contacts-next')).toBeEnabled();
+
+    fireEvent.click(screen.getByTestId('org-contacts-next'));
+    await waitFor(() => expect(listCalls().at(-1)).toContain('page=2'));
+    fireEvent.click(screen.getByTestId('org-contacts-next'));
+    await waitFor(() => expect(listCalls().at(-1)).toContain('page=3'));
+    expect(screen.getByTestId('org-contacts-next')).toBeDisabled();
+    expect(screen.getByTestId('org-contacts-prev')).toBeEnabled();
+  });
+
+  it('falls back to the last page when a delete empties the page it was on', async () => {
+    const filler = Array.from({ length: 25 }, (_, i) => ({
+      ...CONTACTS[2]!, id: `c-filler-${i}`, name: `Person ${i}`,
+    }));
+    const last = { ...CONTACTS[2]!, id: 'c-last', name: 'Last Person' };
+    let deleted = false;
+    fetchWithAuthMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.startsWith('/orgs/sites')) {
+        return jsonResponse({ data: SITES, pagination: { page: 1, limit: 50, total: SITES.length } });
+      }
+      if (init?.method === 'DELETE') {
+        deleted = true;
+        return jsonResponse({ success: true });
+      }
+      const page = new URLSearchParams(url.slice(url.indexOf('?') + 1)).get('page');
+      const total = deleted ? 25 : 26;
+      const data = page === '2' ? (deleted ? [] : [last]) : filler;
+      return jsonResponse({ data, pagination: { page: Number(page), limit: 25, total } });
+    });
+
+    await renderCard();
+    fireEvent.click(screen.getByTestId('org-contacts-next'));
+    await waitFor(() => expect(screen.getByTestId('org-contacts-row-c-last')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('org-contacts-delete-c-last'));
+
+    // An empty page 2 must send the operator back to page 1, not to "No contacts yet".
+    await waitFor(() => expect(listCalls().at(-1)).toContain('page=1'));
+    await waitFor(() => expect(screen.getAllByTestId(/^org-contacts-row-/)).toHaveLength(25));
+    expect(screen.queryByTestId('org-contacts-empty')).not.toBeInTheDocument();
+  });
+});
+
+describe('ContactsCard in-flight states', () => {
+  it('marks the first load so a slow list is distinguishable from an empty one', async () => {
+    fetchWithAuthMock.mockImplementation((url: string) => {
+      if (url.startsWith('/orgs/sites')) {
+        return jsonResponse({ data: SITES, pagination: { page: 1, limit: 50, total: SITES.length } });
+      }
+      return new Promise<Response>(() => { /* never settles */ });
+    });
+    render(<ContactsCard orgId={ORG_ID} />);
+    await waitFor(() => expect(screen.getByTestId('org-contacts-loading')).toBeInTheDocument());
+    expect(screen.queryByTestId('org-contacts-empty')).not.toBeInTheDocument();
+  });
+
+  it('disables the row delete button while its DELETE is in flight', async () => {
+    let releaseDelete: ((r: Response) => void) | undefined;
+    fetchWithAuthMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.startsWith('/orgs/sites')) {
+        return jsonResponse({ data: SITES, pagination: { page: 1, limit: 50, total: SITES.length } });
+      }
+      if (init?.method === 'DELETE') {
+        return new Promise<Response>((resolve) => { releaseDelete = resolve; });
+      }
+      return jsonResponse({ data: CONTACTS, pagination: { page: 1, limit: 25, total: CONTACTS.length } });
+    });
+    await renderCard();
+
+    fireEvent.click(screen.getByTestId('org-contacts-delete-c-alan'));
+    await waitFor(() => expect(screen.getByTestId('org-contacts-delete-c-alan')).toBeDisabled());
+    // A second click while the first is in flight would delete nothing but toast twice.
+    fireEvent.click(screen.getByTestId('org-contacts-delete-c-alan'));
+    expect(mutationCalls()).toHaveLength(1);
+
+    releaseDelete?.(new Response(JSON.stringify({ success: true }), {
+      status: 200, headers: { 'Content-Type': 'application/json' },
+    }));
+    await waitFor(() => expect(screen.getByTestId('org-contacts-delete-c-alan')).toBeEnabled());
+  });
+});
+
+describe('ContactsCard roles', () => {
+  it('renders a role token it does not know rather than dropping it', async () => {
+    mockApi({
+      contacts: {
+        data: [{ ...CONTACTS[0]!, roles: ['technical', 'chief_vibes'] }],
+        pagination: { page: 1, limit: 25, total: 1 },
+      },
+    });
+    await renderCard();
+    const roles = screen.getByTestId('org-contacts-roles-c-ada');
+    expect(roles).toHaveTextContent('Technical');
+    expect(roles).toHaveTextContent('chief_vibes');
+  });
+});
+
+describe('ContactsCard load failures', () => {
+  it('re-requests the list when the error notice is retried', async () => {
+    mockApi({ contacts: { error: 'boom' }, contactsStatus: 500 });
+    render(<ContactsCard orgId={ORG_ID} />);
+    await waitFor(() => expect(screen.getByTestId('org-contacts-load-error')).toBeInTheDocument());
+    const before = listCalls().length;
+
+    mockApi();
+    fireEvent.click(screen.getByText('Try again'));
+    await waitFor(() => expect(screen.getByTestId('org-contacts-table')).toBeInTheDocument());
+    expect(listCalls().length).toBeGreaterThan(before);
   });
 });

--- a/apps/web/src/components/settings/ContactsCard.tsx
+++ b/apps/web/src/components/settings/ContactsCard.tsx
@@ -1,9 +1,9 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import '@/lib/i18n';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
-import { runAction, ActionError } from '@/lib/runAction';
+import { runAction, handleActionError } from '@/lib/runAction';
 import BulkContactImport from '../organizations/BulkContactImport';
 
 /**
@@ -148,40 +148,79 @@ export default function ContactsCard({ orgId }: ContactsCardProps) {
   const [roleFilter, setRoleFilter] = useState('');
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState(false);
+  const [sitesError, setSitesError] = useState(false);
+  /** Bumped by the sites retry button; the sites effect keys off it. */
+  const [sitesAttempt, setSitesAttempt] = useState(0);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
   const [showImport, setShowImport] = useState(false);
   const [editing, setEditing] = useState<Contact | null>(null);
   const [formOpen, setFormOpen] = useState(false);
   const [draft, setDraft] = useState<Draft>(EMPTY_DRAFT);
   const [saving, setSaving] = useState(false);
+  /**
+   * Monotonic request id. `loadContacts` is fired from an effect AND from every
+   * mutation, so two loads can be in flight at once (change a filter mid-delete);
+   * without this the slower response wins and paints a list nobody asked for.
+   */
+  const loadSeq = useRef(0);
 
   const unauthorized = useCallback(() => { void navigateTo('/login', { replace: true }); }, []);
 
+  /**
+   * Site id → name, or null when this screen has no name for it. Reachable in
+   * ordinary use, so the fallback copy must NOT read as a permission verdict:
+   * the list route already intersects the caller's allowed sites, and the picker
+   * above fetches `limit=100` without paging, so an organization's 101st site
+   * resolves to nothing here purely because the name was never fetched. A failed
+   * sites call (see `sitesError`) takes the same path.
+   */
   const siteName = useCallback(
     (siteId: string | null) => sites.find((s) => s.id === siteId)?.name ?? null,
     [sites],
   );
 
   const loadContacts = useCallback(async () => {
+    const seq = (loadSeq.current += 1);
+    const superseded = () => seq !== loadSeq.current;
     setLoading(true);
     setLoadError(false);
     const params = new URLSearchParams({ page: String(page), limit: String(PAGE_SIZE) });
     if (siteFilter) params.set('siteId', siteFilter);
     if (roleFilter) params.set('role', roleFilter);
+    // Set only on the clamp path below, where `loading` must stay true across the
+    // re-fetch so the emptied page never flashes as "No contacts yet".
+    let clamping = false;
     try {
       const res = await fetchWithAuth(`/orgs/organizations/${orgId}/contacts?${params.toString()}`);
+      if (superseded()) return;
       if (res.status === 401) return unauthorized();
       if (!res.ok) throw new Error(`contacts load failed: ${res.status}`);
       const body = (await res.json()) as {
         data: Contact[];
         pagination: { total: number };
       };
-      setContacts(body.data ?? []);
-      setTotal(body.pagination?.total ?? 0);
+      if (superseded()) return;
+      const rows = body.data ?? [];
+      const count = body.pagination?.total ?? 0;
+      const lastPage = Math.max(1, Math.ceil(count / PAGE_SIZE));
+      // Deleting the last row of page N leaves that page empty and the pagination
+      // block unmounted, stranding the operator on "No contacts yet" with rows
+      // still on page N-1. Walk back to the page that now holds the end of the
+      // list and let the effect re-fetch it.
+      if (rows.length === 0 && page > 1 && lastPage < page) {
+        clamping = true;
+        setTotal(count);
+        setPage(lastPage);
+        return;
+      }
+      setContacts(rows);
+      setTotal(count);
     } catch (err) {
+      if (superseded()) return;
       console.warn('[ContactsCard] contacts load failed', err);
       setLoadError(true);
     } finally {
-      setLoading(false);
+      if (!clamping && !superseded()) setLoading(false);
     }
   }, [orgId, page, siteFilter, roleFilter, unauthorized]);
 
@@ -197,18 +236,23 @@ export default function ContactsCard({ orgId }: ContactsCardProps) {
       try {
         const res = await fetchWithAuth(`/orgs/sites?organizationId=${orgId}&limit=100`);
         if (res.status === 401) return unauthorized();
-        if (!res.ok) return;
+        if (!res.ok) throw new Error(`sites load failed: ${res.status}`);
         const body = (await res.json()) as { data?: SiteOption[] } | SiteOption[];
         const data = Array.isArray(body) ? body : (body.data ?? []);
-        if (!cancelled) setSites(data.map((s) => ({ id: s.id, name: s.name })));
+        if (cancelled) return;
+        setSites(data.map((s) => ({ id: s.id, name: s.name })));
+        setSitesError(false);
       } catch (err) {
-        // Site names are decoration on this screen: a failure downgrades the
-        // attribution column, it does not break the contact list.
+        // Site names are not decoration: they also populate the site FILTER and
+        // the form's site select, so a silent failure looks like an organization
+        // with no sites. Surfaced as a non-blocking notice — the contacts
+        // themselves are organization-scoped and stay fully usable.
         console.warn('[ContactsCard] sites load failed', err);
+        if (!cancelled) setSitesError(true);
       }
     })();
     return () => { cancelled = true; };
-  }, [orgId, unauthorized]);
+  }, [orgId, unauthorized, sitesAttempt]);
 
   function changeFilter(next: () => void) {
     // A filter narrows the result set, so whatever page the user was on is
@@ -262,15 +306,19 @@ export default function ContactsCard({ orgId }: ContactsCardProps) {
       await loadContacts();
     } catch (err) {
       // A refused save leaves the form open with the operator's input intact.
-      if (!(err instanceof ActionError)) throw err;
+      // Never rethrow: `save` is called through `void save()`, so a throw here
+      // becomes an unhandled rejection rather than anything the user can see.
+      handleActionError(err, t('contactsCard.errors.update'));
     } finally {
       setSaving(false);
     }
   }
 
   async function remove(contact: Contact) {
+    if (deletingId) return;
     const label = contact.name ?? contact.email ?? contact.phone ?? contact.mobile ?? '';
     if (!window.confirm(t('contactsCard.confirmDelete', { name: label }))) return;
+    setDeletingId(contact.id);
     try {
       await runAction({
         request: () => fetchWithAuth(`/orgs/contacts/${contact.id}`, { method: 'DELETE' }),
@@ -280,7 +328,11 @@ export default function ContactsCard({ orgId }: ContactsCardProps) {
       });
       await loadContacts();
     } catch (err) {
-      if (!(err instanceof ActionError)) throw err;
+      // Same contract as `save`: called through `void remove(c)`, so a rethrow
+      // would surface as an unhandled rejection instead of a toast.
+      handleActionError(err, t('contactsCard.errors.delete'));
+    } finally {
+      setDeletingId(null);
     }
   }
 
@@ -362,6 +414,23 @@ export default function ContactsCard({ orgId }: ContactsCardProps) {
           </label>
         </div>
       </div>
+
+      {sitesError && (
+        <div
+          data-testid="org-contacts-sites-error"
+          className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-xs text-amber-700 dark:text-amber-400"
+        >
+          {t('contactsCard.errors.sites')}{' '}
+          <button
+            type="button"
+            data-testid="org-contacts-sites-retry"
+            onClick={() => setSitesAttempt((n) => n + 1)}
+            className="underline hover:text-foreground"
+          >
+            {t('contactsCard.actions.retry')}
+          </button>
+        </div>
+      )}
 
       {showImport && (
         <BulkContactImport
@@ -508,7 +577,9 @@ export default function ContactsCard({ orgId }: ContactsCardProps) {
       )}
 
       {loading && contacts.length === 0 && !loadError && (
-        <p className="text-sm text-muted-foreground">{t('contactsCard.loading')}</p>
+        <p data-testid="org-contacts-loading" className="text-sm text-muted-foreground">
+          {t('contactsCard.loading')}
+        </p>
       )}
 
       {loadError && (
@@ -602,7 +673,8 @@ export default function ContactsCard({ orgId }: ContactsCardProps) {
                         type="button"
                         data-testid={`org-contacts-delete-${c.id}`}
                         onClick={() => void remove(c)}
-                        className="ml-1 rounded-md px-2 py-1 text-xs text-destructive underline hover:bg-muted"
+                        disabled={deletingId !== null}
+                        className="ml-1 rounded-md px-2 py-1 text-xs text-destructive underline hover:bg-muted disabled:opacity-50"
                       >
                         {t('contactsCard.actions.delete')}
                       </button>

--- a/apps/web/src/components/settings/ContactsCard.tsx
+++ b/apps/web/src/components/settings/ContactsCard.tsx
@@ -1,0 +1,647 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import '@/lib/i18n';
+import { fetchWithAuth } from '../../stores/auth';
+import { navigateTo } from '@/lib/navigation';
+import { runAction, ActionError } from '@/lib/runAction';
+import BulkContactImport from '../organizations/BulkContactImport';
+
+/**
+ * First-class organization contacts (#3258 W04) — the whole `#contacts` tab of
+ * the organization settings page.
+ *
+ * Contract: apps/api/src/routes/orgContacts.ts. Note the asymmetry in the
+ * paths — the list and create routes are organization-scoped
+ * (`/orgs/organizations/:id/contacts`) while update and delete are not
+ * (`/orgs/contacts/:contactId`), because the server re-asserts reach from the
+ * contact's own scope rather than trusting an organization in the URL.
+ */
+
+const PAGE_SIZE = 25;
+
+/** Mirrors CONTACT_ROLES in apps/api/src/services/contacts/types.ts. */
+const CONTACT_ROLES = [
+  'billing', 'technical', 'escalation', 'admin', 'site', 'after_hours', 'portal',
+] as const;
+type ContactRole = (typeof CONTACT_ROLES)[number];
+
+/**
+ * Role → label key. A record of full key strings rather than a template, so a
+ * role token that is not camelCase (`after_hours`) needs no transformation at
+ * the call site.
+ */
+const ROLE_LABEL_KEYS: Record<ContactRole, string> = {
+  'billing': 'contactsCard.roles.billing',
+  'technical': 'contactsCard.roles.technical',
+  'escalation': 'contactsCard.roles.escalation',
+  'admin': 'contactsCard.roles.admin',
+  'site': 'contactsCard.roles.site',
+  'after_hours': 'contactsCard.roles.afterHours',
+  'portal': 'contactsCard.roles.portal',
+};
+
+function isKnownRole(role: string): role is ContactRole {
+  return (CONTACT_ROLES as readonly string[]).includes(role);
+}
+
+type Contact = {
+  id: string;
+  orgId: string;
+  siteId: string | null;
+  name: string | null;
+  email: string | null;
+  phone: string | null;
+  mobile: string | null;
+  title: string | null;
+  roles: string[];
+  isPrimary: boolean;
+  notes: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type SiteOption = { id: string; name: string };
+
+/** The four fields `contacts_identifiable_chk` accepts; a row needs one. */
+const IDENTIFIER_FIELDS = ['name', 'email', 'phone', 'mobile'] as const;
+
+type Draft = {
+  siteId: string;
+  name: string;
+  email: string;
+  phone: string;
+  mobile: string;
+  title: string;
+  notes: string;
+  roles: string[];
+  isPrimary: boolean;
+};
+
+const EMPTY_DRAFT: Draft = {
+  siteId: '', name: '', email: '', phone: '', mobile: '', title: '', notes: '',
+  roles: [], isPrimary: false,
+};
+
+function draftFrom(contact: Contact): Draft {
+  return {
+    siteId: contact.siteId ?? '',
+    name: contact.name ?? '',
+    email: contact.email ?? '',
+    phone: contact.phone ?? '',
+    mobile: contact.mobile ?? '',
+    title: contact.title ?? '',
+    notes: contact.notes ?? '',
+    roles: [...contact.roles],
+    isPrimary: contact.isPrimary,
+  };
+}
+
+/**
+ * Blank means CLEAR, not "leave alone": every field the form renders is one the
+ * operator can see, so an emptied box is a deliberate erasure. The server
+ * distinguishes the two — an explicit `null` clears, an omitted key does not —
+ * and sending `''` instead would be rejected for `siteId` and stored as a blank
+ * string nowhere else. (The IMPORTER takes the opposite reading, because a
+ * blank CSV cell is overwhelmingly an exporter with nothing to say.)
+ */
+function nullable(value: string): string | null {
+  const trimmed = value.trim();
+  return trimmed === '' ? null : trimmed;
+}
+
+function draftBody(draft: Draft): Record<string, unknown> {
+  return {
+    siteId: draft.siteId === '' ? null : draft.siteId,
+    name: nullable(draft.name),
+    email: nullable(draft.email),
+    phone: nullable(draft.phone),
+    mobile: nullable(draft.mobile),
+    title: nullable(draft.title),
+    notes: nullable(draft.notes),
+    roles: draft.roles,
+    isPrimary: draft.isPrimary,
+  };
+}
+
+/** A create sends only what was filled in — the server refines on the whole object. */
+function createBody(draft: Draft): Record<string, unknown> {
+  const full = draftBody(draft);
+  const body: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(full)) {
+    if (value === null) continue;
+    if (Array.isArray(value) && value.length === 0) continue;
+    if (value === false) continue;
+    body[key] = value;
+  }
+  return body;
+}
+
+type ContactsCardProps = { orgId: string };
+
+export default function ContactsCard({ orgId }: ContactsCardProps) {
+  const { t } = useTranslation('settings');
+  const [contacts, setContacts] = useState<Contact[]>([]);
+  const [total, setTotal] = useState(0);
+  const [sites, setSites] = useState<SiteOption[]>([]);
+  const [page, setPage] = useState(1);
+  const [siteFilter, setSiteFilter] = useState('');
+  const [roleFilter, setRoleFilter] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+  const [showImport, setShowImport] = useState(false);
+  const [editing, setEditing] = useState<Contact | null>(null);
+  const [formOpen, setFormOpen] = useState(false);
+  const [draft, setDraft] = useState<Draft>(EMPTY_DRAFT);
+  const [saving, setSaving] = useState(false);
+
+  const unauthorized = useCallback(() => { void navigateTo('/login', { replace: true }); }, []);
+
+  const siteName = useCallback(
+    (siteId: string | null) => sites.find((s) => s.id === siteId)?.name ?? null,
+    [sites],
+  );
+
+  const loadContacts = useCallback(async () => {
+    setLoading(true);
+    setLoadError(false);
+    const params = new URLSearchParams({ page: String(page), limit: String(PAGE_SIZE) });
+    if (siteFilter) params.set('siteId', siteFilter);
+    if (roleFilter) params.set('role', roleFilter);
+    try {
+      const res = await fetchWithAuth(`/orgs/organizations/${orgId}/contacts?${params.toString()}`);
+      if (res.status === 401) return unauthorized();
+      if (!res.ok) throw new Error(`contacts load failed: ${res.status}`);
+      const body = (await res.json()) as {
+        data: Contact[];
+        pagination: { total: number };
+      };
+      setContacts(body.data ?? []);
+      setTotal(body.pagination?.total ?? 0);
+    } catch (err) {
+      console.warn('[ContactsCard] contacts load failed', err);
+      setLoadError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [orgId, page, siteFilter, roleFilter, unauthorized]);
+
+  useEffect(() => { void loadContacts(); }, [loadContacts]);
+
+  // Sites come from THIS organization, not from useOrgStore().sites: the store
+  // holds the globally selected org's sites, which is a different org whenever
+  // an admin opens one tenant's settings while another is selected in the
+  // header. A stale list here would mislabel every site attribution on screen.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetchWithAuth(`/orgs/sites?organizationId=${orgId}&limit=100`);
+        if (res.status === 401) return unauthorized();
+        if (!res.ok) return;
+        const body = (await res.json()) as { data?: SiteOption[] } | SiteOption[];
+        const data = Array.isArray(body) ? body : (body.data ?? []);
+        if (!cancelled) setSites(data.map((s) => ({ id: s.id, name: s.name })));
+      } catch (err) {
+        // Site names are decoration on this screen: a failure downgrades the
+        // attribution column, it does not break the contact list.
+        console.warn('[ContactsCard] sites load failed', err);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [orgId, unauthorized]);
+
+  function changeFilter(next: () => void) {
+    // A filter narrows the result set, so whatever page the user was on is
+    // almost certainly past the end of the new one.
+    setPage(1);
+    next();
+  }
+
+  function openCreate() {
+    setEditing(null);
+    setDraft(EMPTY_DRAFT);
+    setFormOpen(true);
+  }
+
+  function openEdit(contact: Contact) {
+    setEditing(contact);
+    setDraft(draftFrom(contact));
+    setFormOpen(true);
+  }
+
+  const draftHasIdentifier = IDENTIFIER_FIELDS.some((f) => draft[f].trim() !== '');
+
+  async function save() {
+    if (saving || !draftHasIdentifier) return;
+    setSaving(true);
+    try {
+      await runAction({
+        request: () => (editing
+          ? fetchWithAuth(`/orgs/contacts/${editing.id}`, {
+              method: 'PATCH',
+              body: JSON.stringify(draftBody(draft)),
+            })
+          : fetchWithAuth(`/orgs/organizations/${orgId}/contacts`, {
+              method: 'POST',
+              body: JSON.stringify(createBody(draft)),
+            })),
+        errorFallback: editing
+          ? t('contactsCard.errors.update')
+          : t('contactsCard.errors.create'),
+        successMessage: editing
+          ? t('contactsCard.toasts.updated')
+          : t('contactsCard.toasts.created'),
+        onUnauthorized: unauthorized,
+      });
+      setFormOpen(false);
+      setEditing(null);
+      setDraft(EMPTY_DRAFT);
+      // Refetch rather than patch: promoting a primary DEMOTES the previous one
+      // in the same scope server-side, and no client-side guess reproduces that
+      // without re-implementing the scope rule.
+      await loadContacts();
+    } catch (err) {
+      // A refused save leaves the form open with the operator's input intact.
+      if (!(err instanceof ActionError)) throw err;
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function remove(contact: Contact) {
+    const label = contact.name ?? contact.email ?? contact.phone ?? contact.mobile ?? '';
+    if (!window.confirm(t('contactsCard.confirmDelete', { name: label }))) return;
+    try {
+      await runAction({
+        request: () => fetchWithAuth(`/orgs/contacts/${contact.id}`, { method: 'DELETE' }),
+        errorFallback: t('contactsCard.errors.delete'),
+        successMessage: t('contactsCard.toasts.deleted'),
+        onUnauthorized: unauthorized,
+      });
+      await loadContacts();
+    } catch (err) {
+      if (!(err instanceof ActionError)) throw err;
+    }
+  }
+
+  const pageCount = Math.max(1, Math.ceil(total / PAGE_SIZE));
+  const rangeFrom = total === 0 ? 0 : (page - 1) * PAGE_SIZE + 1;
+  const rangeTo = Math.min(page * PAGE_SIZE, total);
+
+  const roleOptions = useMemo(
+    () => CONTACT_ROLES.map((role) => ({ role, key: ROLE_LABEL_KEYS[role] })),
+    [],
+  );
+
+  function toggleRole(role: ContactRole) {
+    setDraft((prev) => ({
+      ...prev,
+      roles: prev.roles.includes(role)
+        ? prev.roles.filter((r) => r !== role)
+        : [...prev.roles, role],
+    }));
+  }
+
+  return (
+    <div data-testid="org-contacts-card" className="space-y-4">
+      <div className="rounded-lg border bg-card p-6 shadow-xs">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-semibold">{t('contactsCard.title')}</h2>
+            <p className="mt-1 text-sm text-muted-foreground">{t('contactsCard.description')}</p>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              data-testid="org-contacts-import-button"
+              onClick={() => setShowImport((v) => !v)}
+              className="rounded-md border px-3 py-1.5 text-sm font-medium hover:bg-muted"
+            >
+              {t('contactsCard.actions.import')}
+            </button>
+            <button
+              type="button"
+              data-testid="org-contacts-add-button"
+              onClick={openCreate}
+              className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:opacity-90"
+            >
+              {t('contactsCard.actions.add')}
+            </button>
+          </div>
+        </div>
+
+        <div className="mt-4 flex flex-wrap items-end gap-3">
+          <label className="block text-xs">
+            <span className="text-muted-foreground">{t('contactsCard.filters.site')}</span>
+            <select
+              data-testid="org-contacts-filter-site"
+              value={siteFilter}
+              onChange={(e) => changeFilter(() => setSiteFilter(e.target.value))}
+              className="mt-1 h-8 w-48 rounded-md border bg-background px-2 text-sm"
+            >
+              <option value="">{t('contactsCard.filters.allSites')}</option>
+              <option value="none">{t('contactsCard.organizationLevel')}</option>
+              {sites.map((s) => (
+                <option key={s.id} value={s.id}>{s.name}</option>
+              ))}
+            </select>
+          </label>
+          <label className="block text-xs">
+            <span className="text-muted-foreground">{t('contactsCard.filters.role')}</span>
+            <select
+              data-testid="org-contacts-filter-role"
+              value={roleFilter}
+              onChange={(e) => changeFilter(() => setRoleFilter(e.target.value))}
+              className="mt-1 h-8 w-48 rounded-md border bg-background px-2 text-sm"
+            >
+              <option value="">{t('contactsCard.filters.allRoles')}</option>
+              {roleOptions.map(({ role, key }) => (
+                <option key={role} value={role}>{t(/* i18n-dynamic */ key)}</option>
+              ))}
+            </select>
+          </label>
+        </div>
+      </div>
+
+      {showImport && (
+        <BulkContactImport
+          orgId={orgId}
+          onImported={() => { void loadContacts(); }}
+          onUnauthorized={unauthorized}
+          onClose={() => setShowImport(false)}
+        />
+      )}
+
+      {formOpen && (
+        <div data-testid="contact-form" className="rounded-lg border bg-card p-6 shadow-xs">
+          <h3 className="text-sm font-semibold">
+            {editing ? t('contactsCard.form.editHeading') : t('contactsCard.form.addHeading')}
+          </h3>
+          <div className="mt-4 grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            <label className="block text-xs">
+              <span className="text-muted-foreground">{t('contactsCard.form.fields.name')}</span>
+              <input
+                data-testid="contact-form-name-input"
+                value={draft.name}
+                onChange={(e) => setDraft((p) => ({ ...p, name: e.target.value }))}
+                className="mt-1 h-9 w-full rounded-md border bg-background px-2 text-sm"
+              />
+            </label>
+            <label className="block text-xs">
+              <span className="text-muted-foreground">{t('contactsCard.form.fields.email')}</span>
+              <input
+                type="email"
+                data-testid="contact-form-email-input"
+                value={draft.email}
+                onChange={(e) => setDraft((p) => ({ ...p, email: e.target.value }))}
+                className="mt-1 h-9 w-full rounded-md border bg-background px-2 text-sm"
+              />
+            </label>
+            <label className="block text-xs">
+              <span className="text-muted-foreground">{t('contactsCard.form.fields.phone')}</span>
+              <input
+                data-testid="contact-form-phone-input"
+                value={draft.phone}
+                onChange={(e) => setDraft((p) => ({ ...p, phone: e.target.value }))}
+                className="mt-1 h-9 w-full rounded-md border bg-background px-2 text-sm"
+              />
+            </label>
+            <label className="block text-xs">
+              <span className="text-muted-foreground">{t('contactsCard.form.fields.mobile')}</span>
+              <input
+                data-testid="contact-form-mobile-input"
+                value={draft.mobile}
+                onChange={(e) => setDraft((p) => ({ ...p, mobile: e.target.value }))}
+                className="mt-1 h-9 w-full rounded-md border bg-background px-2 text-sm"
+              />
+            </label>
+            <label className="block text-xs">
+              <span className="text-muted-foreground">{t('contactsCard.form.fields.title')}</span>
+              <input
+                data-testid="contact-form-title-input"
+                value={draft.title}
+                onChange={(e) => setDraft((p) => ({ ...p, title: e.target.value }))}
+                className="mt-1 h-9 w-full rounded-md border bg-background px-2 text-sm"
+              />
+            </label>
+            <label className="block text-xs">
+              <span className="text-muted-foreground">{t('contactsCard.form.fields.site')}</span>
+              <select
+                data-testid="contact-form-site-select"
+                value={draft.siteId}
+                onChange={(e) => setDraft((p) => ({ ...p, siteId: e.target.value }))}
+                className="mt-1 h-9 w-full rounded-md border bg-background px-2 text-sm"
+              >
+                <option value="">{t('contactsCard.organizationLevel')}</option>
+                {sites.map((s) => (
+                  <option key={s.id} value={s.id}>{s.name}</option>
+                ))}
+              </select>
+            </label>
+          </div>
+
+          <fieldset className="mt-4">
+            <legend className="text-xs text-muted-foreground">
+              {t('contactsCard.form.fields.roles')}
+            </legend>
+            <div className="mt-2 flex flex-wrap gap-3">
+              {roleOptions.map(({ role, key }) => (
+                <label key={role} className="flex items-center gap-1.5 text-xs">
+                  <input
+                    type="checkbox"
+                    data-testid={`contact-form-role-${role}`}
+                    checked={draft.roles.includes(role)}
+                    onChange={() => toggleRole(role)}
+                  />
+                  <span>{t(/* i18n-dynamic */ key)}</span>
+                </label>
+              ))}
+            </div>
+          </fieldset>
+
+          <label className="mt-4 block text-xs">
+            <span className="text-muted-foreground">{t('contactsCard.form.fields.notes')}</span>
+            <textarea
+              data-testid="contact-form-notes-input"
+              value={draft.notes}
+              rows={2}
+              onChange={(e) => setDraft((p) => ({ ...p, notes: e.target.value }))}
+              className="mt-1 w-full rounded-md border bg-background px-2 py-1.5 text-sm"
+            />
+          </label>
+
+          <label className="mt-4 flex items-center gap-2 text-xs">
+            <input
+              type="checkbox"
+              data-testid="contact-form-primary-input"
+              checked={draft.isPrimary}
+              onChange={(e) => setDraft((p) => ({ ...p, isPrimary: e.target.checked }))}
+            />
+            <span>{t('contactsCard.form.fields.isPrimary')}</span>
+          </label>
+
+          <div className="mt-5 flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              data-testid="contact-form-submit"
+              onClick={() => void save()}
+              disabled={saving || !draftHasIdentifier}
+              className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+            >
+              {saving ? t('contactsCard.actions.saving') : t('contactsCard.actions.save')}
+            </button>
+            <button
+              type="button"
+              data-testid="contact-form-cancel"
+              onClick={() => { setFormOpen(false); setEditing(null); }}
+              className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
+            >
+              {t('contactsCard.actions.cancel')}
+            </button>
+            {!draftHasIdentifier && (
+              <span data-testid="contact-form-identifier-hint" className="text-xs text-muted-foreground">
+                {t('contactsCard.form.identifierRequired')}
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+
+      {loading && contacts.length === 0 && !loadError && (
+        <p className="text-sm text-muted-foreground">{t('contactsCard.loading')}</p>
+      )}
+
+      {loadError && (
+        <div className="rounded-lg border bg-card p-6 text-sm text-muted-foreground" data-testid="org-contacts-load-error">
+          {t('contactsCard.errors.load')}{' '}
+          <button type="button" onClick={() => void loadContacts()} className="underline hover:text-foreground">
+            {t('contactsCard.actions.retry')}
+          </button>
+        </div>
+      )}
+
+      {!loadError && !loading && contacts.length === 0 && (
+        <div className="rounded-lg border bg-card p-6 text-sm text-muted-foreground" data-testid="org-contacts-empty">
+          {t('contactsCard.empty')}
+        </div>
+      )}
+
+      {!loadError && contacts.length > 0 && (
+        <div className="overflow-x-auto rounded-lg border bg-card shadow-xs">
+          <table className="w-full text-sm" data-testid="org-contacts-table">
+            <thead>
+              <tr className="border-b bg-muted/50 text-left text-xs text-muted-foreground">
+                <th className="px-3 py-2">{t('contactsCard.columns.name')}</th>
+                <th className="px-3 py-2">{t('contactsCard.columns.reach')}</th>
+                <th className="px-3 py-2">{t('contactsCard.columns.jobTitle')}</th>
+                <th className="px-3 py-2">{t('contactsCard.columns.roles')}</th>
+                <th className="px-3 py-2">{t('contactsCard.columns.site')}</th>
+                <th className="px-3 py-2 text-right">{t('contactsCard.columns.actions')}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {contacts.map((c) => {
+                const pinned = siteName(c.siteId);
+                return (
+                  <tr
+                    key={c.id}
+                    data-testid={`org-contacts-row-${c.id}`}
+                    className="border-b border-border/50 last:border-0"
+                  >
+                    <td className="px-3 py-2">
+                      <span className="font-medium">{c.name ?? '—'}</span>
+                      {c.isPrimary && (
+                        <span
+                          data-testid={`org-contacts-primary-${c.id}`}
+                          className="ml-2 inline-flex rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 text-xs text-primary"
+                        >
+                          {c.siteId === null
+                            ? t('contactsCard.primary.organization')
+                            : t('contactsCard.primary.site', {
+                                site: pinned ?? t('contactsCard.unknownSite'),
+                              })}
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 text-muted-foreground">
+                      <div>{c.email ?? '—'}</div>
+                      <div>{c.phone ?? c.mobile ?? '—'}</div>
+                    </td>
+                    <td className="px-3 py-2 text-muted-foreground">{c.title ?? '—'}</td>
+                    <td className="px-3 py-2" data-testid={`org-contacts-roles-${c.id}`}>
+                      {c.roles.length === 0 ? '—' : (
+                        <span className="flex flex-wrap gap-1">
+                          {c.roles.map((role) => (
+                            <span
+                              key={role}
+                              className="inline-flex rounded-full border bg-muted px-2 py-0.5 text-xs"
+                            >
+                              {isKnownRole(role)
+                                ? t(/* i18n-dynamic */ ROLE_LABEL_KEYS[role])
+                                : role}
+                            </span>
+                          ))}
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 text-muted-foreground" data-testid={`org-contacts-site-${c.id}`}>
+                      {c.siteId === null
+                        ? t('contactsCard.organizationLevel')
+                        : (pinned ?? t('contactsCard.unknownSite'))}
+                    </td>
+                    <td className="px-3 py-2 text-right">
+                      <button
+                        type="button"
+                        data-testid={`org-contacts-edit-${c.id}`}
+                        onClick={() => openEdit(c)}
+                        className="rounded-md px-2 py-1 text-xs underline hover:bg-muted"
+                      >
+                        {t('contactsCard.actions.edit')}
+                      </button>
+                      <button
+                        type="button"
+                        data-testid={`org-contacts-delete-${c.id}`}
+                        onClick={() => void remove(c)}
+                        className="ml-1 rounded-md px-2 py-1 text-xs text-destructive underline hover:bg-muted"
+                      >
+                        {t('contactsCard.actions.delete')}
+                      </button>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {!loadError && total > PAGE_SIZE && (
+        <div className="flex items-center justify-between text-xs text-muted-foreground">
+          <span data-testid="org-contacts-page">
+            {t('contactsCard.pagination.summary', { from: rangeFrom, to: rangeTo, total })}
+          </span>
+          <span className="flex gap-2">
+            <button
+              type="button"
+              data-testid="org-contacts-prev"
+              disabled={page <= 1}
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              className="rounded-md border px-2 py-1 hover:bg-muted disabled:opacity-50"
+            >
+              {t('contactsCard.pagination.previous')}
+            </button>
+            <button
+              type="button"
+              data-testid="org-contacts-next"
+              disabled={page >= pageCount}
+              onClick={() => setPage((p) => Math.min(pageCount, p + 1))}
+              className="rounded-md border px-2 py-1 hover:bg-muted disabled:opacity-50"
+            >
+              {t('contactsCard.pagination.next')}
+            </button>
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/OrgSettingsPage.test.tsx
+++ b/apps/web/src/components/settings/OrgSettingsPage.test.tsx
@@ -42,6 +42,9 @@ vi.mock('./OrgRemoteAccessSettings', () => ({
   },
 }));
 vi.mock('./OrgTicketSettingsEditor', () => ({ default: () => <div data-testid="org-ticket-settings" /> }));
+vi.mock('./ContactsCard', () => ({
+  default: ({ orgId }: { orgId: string }) => <div data-testid="contacts-card">{orgId}</div>,
+}));
 vi.mock('../organizations/Pax8OrgTab', () => ({ default: ({ orgId }: { orgId: string }) => <div data-testid="pax8-org-tab">{orgId}</div> }));
 vi.mock('../extensions/ExtensionSlotHost', () => ({
   default: (props: Record<string, unknown>) => (
@@ -404,6 +407,18 @@ describe('OrgSettingsPage sidebar nav & save-state honesty', () => {
     // EXACT documented shape — no name/slug/status/settings/etc. leak through.
     expect(props.context).toEqual({ contractVersion: 1, organizationId: 'org-1' });
     expect(Object.keys(props.context).sort()).toEqual(['contractVersion', 'organizationId'].sort());
+  });
+
+  it('deep-links #contacts to the Contacts tab and hands it the tab organization (#3258 W04)', async () => {
+    window.location.hash = '#contacts';
+    render(<OrgSettingsPage orgId="org-1" />);
+
+    const link = await screen.findByRole('link', { name: /^contacts$/i });
+    expect(link.getAttribute('aria-current')).toBe('page');
+    // The card fetches for the org whose settings are open, NOT the globally
+    // selected one — the two differ whenever an admin opens one tenant while
+    // another is selected in the header.
+    expect(screen.getByTestId('contacts-card')).toHaveTextContent('org-1');
   });
 
   it('offers the compact section select for narrow viewports', async () => {

--- a/apps/web/src/components/settings/OrgSettingsPage.tsx
+++ b/apps/web/src/components/settings/OrgSettingsPage.tsx
@@ -7,6 +7,7 @@ import {
   Bell,
   Building2,
   CheckCircle2,
+  Contact,
   Copy,
   Check,
   CreditCard,
@@ -21,6 +22,7 @@ import {
   Shield,
   Ticket
 } from 'lucide-react';
+import ContactsCard from './ContactsCard';
 import ContractsList from '../contracts/ContractsList';
 import OrgBillingSettings from '../billing/OrgBillingSettings';
 import SettingsSectionNav, { type SettingsNavGroup } from './SettingsSectionNav';
@@ -44,7 +46,7 @@ import Pax8OrgTab from '../organizations/Pax8OrgTab';
 import ExtensionSlotHost from '../extensions/ExtensionSlotHost';
 
 type TabKey =
-  | 'general' | 'branding' | 'portal' | 'notifications' | 'security'
+  | 'general' | 'contacts' | 'branding' | 'portal' | 'notifications' | 'security'
   | 'approval-security' | 'event-logs' | 'remote-access' | 'ticketing' | 'contracts' | 'billing' | 'pax8'
   | 'extensions';
 
@@ -55,6 +57,7 @@ const TAB_GROUPS: (Omit<SettingsNavGroup, 'items'> & { items: (SettingsNavGroup[
     label: 'orgSettingsPage.nav.organization',
     items: [
       { key: 'general', hash: 'general', label: 'orgSettingsPage.nav.general', description: 'orgSettingsPage.nav.generalDescription', icon: Building2 },
+      { key: 'contacts', hash: 'contacts', label: 'orgSettingsPage.nav.contacts', description: 'orgSettingsPage.nav.contactsDescription', icon: Contact },
       { key: 'contracts', hash: 'contracts', label: 'orgSettingsPage.nav.contracts', description: 'orgSettingsPage.nav.contractsDescription', icon: FileSignature },
       { key: 'billing', hash: 'billing', label: 'orgSettingsPage.nav.billing', description: 'orgSettingsPage.nav.billingDescription', icon: CreditCard },
       { key: 'pax8', hash: 'pax8', label: 'orgSettingsPage.nav.pax8', description: 'orgSettingsPage.nav.pax8Description', icon: PackageOpen },
@@ -595,6 +598,14 @@ export default function OrgSettingsPage({ orgId: propOrgId }: OrgSettingsPagePro
             onDirty={handleDirty}
             onSave={() => handleSave()}
           />
+        ) : null;
+      case 'contacts':
+        // No onDirty: the card persists every change through its own request,
+        // so this tab never holds unsaved draft state.
+        return effectiveOrgId ? (
+          <div data-testid="org-tab-contacts">
+            <ContactsCard orgId={effectiveOrgId} />
+          </div>
         ) : null;
       case 'contracts':
         return effectiveOrgId ? (

--- a/apps/web/src/components/settings/SiteDetailPage.test.tsx
+++ b/apps/web/src/components/settings/SiteDetailPage.test.tsx
@@ -145,6 +145,16 @@ describe('SiteDetailPage — address/contact round-trip', () => {
     });
   });
 
+  it('links the primary-contact editor to the organization contact list (#3258 W04)', async () => {
+    mockApi();
+    render(<SiteDetailPage siteId={SITE_ID} />);
+
+    const link = await screen.findByTestId('site-detail-all-contacts-link');
+    // The full list lives on the org settings Contacts tab; this editor still
+    // writes the site's single primary through the compatibility projection.
+    expect(link).toHaveAttribute('href', `/settings/organizations/${ORG_ID}#contacts`);
+  });
+
   it('marks the form dirty and PATCHes a newly picked zone', async () => {
     mockApi();
     render(<SiteDetailPage siteId={SITE_ID} />);

--- a/apps/web/src/components/settings/SiteDetailPage.tsx
+++ b/apps/web/src/components/settings/SiteDetailPage.tsx
@@ -554,7 +554,23 @@ export default function SiteDetailPage({ siteId }: { siteId: string }) {
               </section>
 
               <section className="rounded-lg border bg-card p-6 shadow-xs">
-                <h2 className="text-lg font-semibold">{t('siteForm.primaryContact')}</h2>
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <h2 className="text-lg font-semibold">{t('siteForm.primaryContact')}</h2>
+                  {/* This editor still writes the site's single primary contact
+                      (server-side it lands through the compatibility
+                      projection). Everyone ELSE at this customer lives on the
+                      organization's Contacts tab, so point there rather than
+                      growing a second contact list here. */}
+                  {site?.orgId && (
+                    <a
+                      data-testid="site-detail-all-contacts-link"
+                      href={`/settings/organizations/${site.orgId}#contacts`}
+                      className="text-sm text-primary underline hover:opacity-80"
+                    >
+                      {t('siteDetailPage.allContactsLink')}
+                    </a>
+                  )}
+                </div>
                 <div className="mt-4 grid gap-4 md:grid-cols-3">
                   <div className="space-y-2">
                     <label className="text-sm font-medium">{t('common:labels.name')}</label>

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -200,6 +200,12 @@ const TARGET_GLOBS = [
   // the partner's tenant tree from a remote list. A silent failure would leave
   // the tech believing a tenant tree was provisioned when nothing was written.
   'src/components/psa/PsaCompanyImport.tsx',
+  // Contact CSV import (#3258 W04): preview is advisory, but the commit writes
+  // customer PII across a whole organization in one click. The preview table is
+  // listed alongside its host because this guard's TARGET_GLOBS is a literal
+  // file list, not directory-wide.
+  'src/components/organizations/BulkContactImport.tsx',
+  'src/components/organizations/ContactImportPreviewTable.tsx',
   // Fleet findings: the lifecycle PATCH (acknowledge/dismiss/reopen) lives in
   // the service, and the two components must not grow their own bare mutations
   // alongside it.
@@ -526,8 +532,10 @@ describe('no silent mutations in targeted set', () => {
     // (P2-6 Task 11, #4193), plus AccountingSyncCard.tsx (QuickBooks invoice
     // push, Phase C Task 7), plus QuickbooksIntegration.tsx (QuickBooks payment
     // pull-back, Phase D Task 7 — the pull-payments PATCH and the "Sync now"
-    // enqueue joined four pre-existing unguarded mutations in that file).
-    expect(absoluteFiles.length).toBe(108);
+    // enqueue joined four pre-existing unguarded mutations in that file),
+    // plus BulkContactImport.tsx and ContactImportPreviewTable.tsx (#3258 W04,
+    // the contact CSV importer).
+    expect(absoluteFiles.length).toBe(110);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -206,6 +206,9 @@ const TARGET_GLOBS = [
   // file list, not directory-wide.
   'src/components/organizations/BulkContactImport.tsx',
   'src/components/organizations/ContactImportPreviewTable.tsx',
+  // Contact CRUD (#3258 W04): create/update/delete write customer PII, and a
+  // silent failure would leave a tech believing a contact was filed.
+  'src/components/settings/ContactsCard.tsx',
   // Fleet findings: the lifecycle PATCH (acknowledge/dismiss/reopen) lives in
   // the service, and the two components must not grow their own bare mutations
   // alongside it.
@@ -533,9 +536,9 @@ describe('no silent mutations in targeted set', () => {
     // push, Phase C Task 7), plus QuickbooksIntegration.tsx (QuickBooks payment
     // pull-back, Phase D Task 7 — the pull-payments PATCH and the "Sync now"
     // enqueue joined four pre-existing unguarded mutations in that file),
-    // plus BulkContactImport.tsx and ContactImportPreviewTable.tsx (#3258 W04,
-    // the contact CSV importer).
-    expect(absoluteFiles.length).toBe(110);
+    // plus BulkContactImport.tsx, ContactImportPreviewTable.tsx and
+    // ContactsCard.tsx (#3258 W04, the contacts tab and its CSV importer).
+    expect(absoluteFiles.length).toBe(111);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/apps/web/src/lib/i18n/translationCoverage.test.ts
+++ b/apps/web/src/lib/i18n/translationCoverage.test.ts
@@ -165,7 +165,10 @@ const namespaceDuplicateBaselines = {
     // rather than root-caused here).
     // +4: aiAgentsPage.runs (#3828 Task 4) — "Manual" and "Ticket" are the
     // same cognate in es-419, and "OK"/"Error" are locale-invariant.
-    'settings.json': 121,
+    // +3: contactsCard / bulkContactImport (#3258 W04) — "Roles" is the same
+    // word in Spanish (plural of "rol"), and the contacts UI labels it in
+    // three places (the list column, the form fieldset and the CSV mapping row).
+    'settings.json': 124,
     // +1: ticketTimeBilling.noAmount — the em-dash placeholder for a row with
     // no amount is locale-invariant punctuation, identical in every catalog.
     // +1: ticketWorkbench.invoice.missingRateEntry "{{description}} — {{hours}} h" is two
@@ -256,7 +259,11 @@ const namespaceDuplicateBaselines = {
     // same word in French, and "OK" is locale-invariant.
     // +1: aiAgentsPage.runs.triage.notesTitle (P2-4, #4191) — "Notes" is the
     // same word in French.
-    'settings.json': 160,
+    // +5: contactsCard / bulkContactImport / contactImportPreview (#3258 W04)
+    // — "Contacts" and "Site" are the same words in French, and
+    // TERMINOLOGY.md pins site → site for both French locales, so the three
+    // site labels plus the tab title and its nav entry stay identical.
+    'settings.json': 165,
     // +1: ticketTimeBilling.noAmount — the em-dash placeholder for a row with
     // no amount is locale-invariant punctuation, identical in every catalog.
     // +1: ticketWorkbench.invoice.missingRateEntry "{{description}} — {{hours}} h" is two
@@ -341,7 +348,11 @@ const namespaceDuplicateBaselines = {
     // same word in French, and "OK" is locale-invariant.
     // +1: aiAgentsPage.runs.triage.notesTitle (P2-4, #4191) — "Notes" is the
     // same word in French.
-    'settings.json': 165,
+    // +5: contactsCard / bulkContactImport / contactImportPreview (#3258 W04)
+    // — "Contacts" and "Site" are the same words in Canadian French, and
+    // TERMINOLOGY.md pins site → site for both French locales, so the three
+    // site labels plus the tab title and its nav entry stay identical.
+    'settings.json': 170,
     // +1: ticketTimeBilling.noAmount — the em-dash placeholder for a row with
     // no amount is locale-invariant punctuation, identical in every catalog.
     // +1: ticketWorkbench.invoice.missingRateEntry "{{description}} — {{hours}} h" is two
@@ -417,7 +428,11 @@ const namespaceDuplicateBaselines = {
     // rather than root-caused here).
     // +10: aiAgentsPage.runs (#3828 Task 4) — "Agent", "Status", "Ticket" and
     // "Tool" are the same words in German, and "OK" is locale-invariant.
-    'settings.json': 179,
+    // +4: contactsCard / bulkContactImport / contactImportPreview (#3258 W04)
+    // — "Name" is the same word in German, and the contacts UI labels it in
+    // four places (the list column, the form field, the CSV mapping row and
+    // the import preview column).
+    'settings.json': 183,
     // +1: ticketTimeBilling.noAmount — the em-dash placeholder for a row with
     // no amount is locale-invariant punctuation, identical in every catalog.
     // +1: ticketWorkbench.invoice.missingRateEntry "{{description}} — {{hours}} h" is two
@@ -537,7 +552,10 @@ const namespaceDuplicateBaselines = {
     // (see the pt-BR block's note above — same root cause, carried forward
     // rather than root-caused here). aiAgentsPage.runs (#3828 Task 4) itself
     // introduced zero new tr-TR duplicates.
-    'settings.json': 65,
+    // +3: contactsCard / bulkContactImport / contactImportPreview (#3258 W04)
+    // — "Site" is the established loanword in tr-TR (bulkOrgImport already
+    // uses it), so the three site labels stay identical.
+    'settings.json': 68,
     // +1: ticketTimeBilling.noAmount — the em-dash placeholder for a row with
     // no amount is locale-invariant punctuation, identical in every catalog.
     'tickets.json': 12,

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -4097,7 +4097,7 @@
     "title": "Kontakte",
     "description": "Die Personen, die Ihr Team bei diesem Kunden erreicht. Ein Kontakt kann an einen Standort gebunden sein oder für die gesamte Organisation gelten.",
     "organizationLevel": "Organisation",
-    "unknownSite": "Ein Standort, den Sie nicht einsehen dürfen",
+    "unknownSite": "Standort nicht verfügbar",
     "empty": "Noch keine Kontakte. Legen Sie einen an oder importieren Sie eine CSV-Datei aus Ihrem bisherigen Werkzeug.",
     "loading": "Kontakte werden geladen…",
     "confirmDelete": "{{name}} löschen? Das lässt sich nicht rückgängig machen.",
@@ -4166,6 +4166,7 @@
     },
     "errors": {
       "load": "Die Kontakte dieser Organisation konnten nicht geladen werden.",
+      "sites": "Die Standorte dieser Organisation konnten nicht geladen werden. Standortnamen und der Standortfilter bleiben bis dahin nicht verfügbar.",
       "create": "Der Kontakt konnte nicht hinzugefügt werden.",
       "update": "Der Kontakt konnte nicht gespeichert werden.",
       "delete": "Der Kontakt konnte nicht gelöscht werden."
@@ -4187,6 +4188,9 @@
       "heading": "Spaltenzuordnung",
       "unmapped": "Nicht zugeordnet",
       "identifierRequired": "Ordnen Sie eine Spalte mit Name, E-Mail-Adresse, Telefon oder Mobilnummer zu, um fortzufahren.",
+      "droppedRows_one": "{{count}} Zeile übersprungen: kein Name, keine E-Mail-Adresse, keine Telefon- oder Mobilnummer.",
+      "droppedRows_other": "{{count}} Zeilen übersprungen: kein Name, keine E-Mail-Adresse, keine Telefon- oder Mobilnummer.",
+      "tooManyRows": "Diese Datei ordnet {{count}} Zeilen zu, mehr als die {{max}} pro Import zulässigen. Teilen Sie sie in kleinere Dateien auf.",
       "fields": {
         "name": "Name",
         "email": "E-Mail-Adresse",
@@ -4212,15 +4216,37 @@
       "updated": "{{count}} zusammengeführt",
       "skipped": "{{count}} unverändert",
       "failed": "{{count}} abgelehnt",
-      "allFailed": "Nichts wurde importiert — {{summary}}."
+      "allFailed": "Nichts wurde importiert — {{summary}}.",
+      "nothingImported": "Nichts importiert: {{count}} bereits verknüpft.",
+      "nothingImportedEmpty": "Es wurde nichts importiert."
     },
     "failures": {
       "title_one": "{{count}} Zeile wurde abgelehnt",
       "title_other": "{{count}} Zeilen wurden abgelehnt"
     },
+    "skipped": {
+      "title_one": "{{count}} Zeile blieb unverändert",
+      "title_other": "{{count}} Zeilen blieben unverändert",
+      "reasons": {
+        "alreadyLinked": "bereits mit einem vorhandenen Kontakt verknüpft"
+      }
+    },
+    "errorCodes": {
+      "rowConflict": "Die Zeile ist gegenüber den bereits vorhandenen Kontakten mehrdeutig.",
+      "orgNotFound": "Diese Organisation ist für Sie nicht mehr erreichbar.",
+      "annotationChanged": "Diese Zeile hat sich seit der Vorschau geändert. Prüfen Sie die Datei erneut.",
+      "matchChanged": "Diese Zeile passt jetzt zu einem anderen Kontakt. Prüfen Sie die Datei erneut.",
+      "matchUnconfirmed": "Haken Sie die Zeile an und importieren Sie erneut, um die Zuordnung zu bestätigen.",
+      "writeFailed": "Die Datenbank hat den Schreibvorgang abgelehnt. Für diese Zeile wurde nichts gespeichert.",
+      "noIdentifier": "Der Zeile bleibt weder Name noch E-Mail-Adresse, Telefon- oder Mobilnummer.",
+      "invalidRole": "Die Zeile nennt eine Rolle, die Breeze nicht kennt.",
+      "siteNotInOrg": "Der Standort in dieser Zeile gehört nicht zu dieser Organisation."
+    },
     "errors": {
       "previewFailed": "Die Datei konnte nicht mit den vorhandenen Kontakten abgeglichen werden.",
-      "importFailed": "Die ausgewählten Kontakte konnten nicht importiert werden."
+      "importFailed": "Die ausgewählten Kontakte konnten nicht importiert werden.",
+      "fileRead": "Die Datei konnte nicht gelesen werden. Wählen Sie sie erneut aus.",
+      "noColumns": "Diese Datei hat keine Kopfzeile, es gibt also nichts zuzuordnen."
     }
   },
   "contactImportPreview": {

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -3052,6 +3052,8 @@
       "organization": "Organisation",
       "general": "Allgemein",
       "generalDescription": "Profil und Standardeinstellungen",
+      "contacts": "Kontakte",
+      "contactsDescription": "Ansprechpartner bei diesem Kunden, je Standort oder organisationsweit",
       "contracts": "Verträge",
       "contractsDescription": "Wiederkehrende Vereinbarungen",
       "billing": "Abrechnung",
@@ -3651,7 +3653,8 @@
       "title": "Geräte",
       "assigned": "Geräte, die dieser Standort zugewiesen sind",
       "viewAll": "Alle Geräte anzeigen"
-    }
+    },
+    "allContactsLink": "Alle Kontakte dieses Kunden"
   },
   "siteForm": {
     "description": "Es ist nur der Standort-Name erforderlich. Adresse und Kontakt sind optional – Sie können diese später ausfüllen.",
@@ -4089,5 +4092,154 @@
     "saveFailed": "Zeiterfassungseinstellungen konnten nicht gespeichert werden",
     "minSessionRange": "Die Mindestdauer der Sitzung muss zwischen {{min}} und {{max}} Sekunden liegen",
     "mergeGapRange": "Das Zusammenführungsintervall muss zwischen {{min}} und {{max}} Minuten liegen"
+  },
+  "contactsCard": {
+    "title": "Kontakte",
+    "description": "Die Personen, die Ihr Team bei diesem Kunden erreicht. Ein Kontakt kann an einen Standort gebunden sein oder für die gesamte Organisation gelten.",
+    "organizationLevel": "Organisation",
+    "unknownSite": "Ein Standort, den Sie nicht einsehen dürfen",
+    "empty": "Noch keine Kontakte. Legen Sie einen an oder importieren Sie eine CSV-Datei aus Ihrem bisherigen Werkzeug.",
+    "loading": "Kontakte werden geladen…",
+    "confirmDelete": "{{name}} löschen? Das lässt sich nicht rückgängig machen.",
+    "actions": {
+      "add": "Kontakt hinzufügen",
+      "import": "CSV importieren",
+      "edit": "Bearbeiten",
+      "delete": "Löschen",
+      "save": "Kontakt speichern",
+      "saving": "Wird gespeichert…",
+      "cancel": "Abbrechen",
+      "retry": "Erneut versuchen"
+    },
+    "filters": {
+      "site": "Nach Standort filtern",
+      "role": "Nach Rolle filtern",
+      "allSites": "Alle Standorte",
+      "allRoles": "Alle Rollen"
+    },
+    "columns": {
+      "name": "Name",
+      "reach": "Erreichbarkeit",
+      "jobTitle": "Position",
+      "roles": "Rollen",
+      "site": "Gehört zu",
+      "actions": "Aktionen"
+    },
+    "primary": {
+      "organization": "Hauptkontakt (Organisation)",
+      "site": "Hauptkontakt ({{site}})"
+    },
+    "roles": {
+      "billing": "Buchhaltung",
+      "technical": "Technik",
+      "escalation": "Eskalation",
+      "admin": "Verwaltung",
+      "site": "Standort",
+      "afterHours": "Außerhalb der Geschäftszeiten",
+      "portal": "Kundenportal"
+    },
+    "form": {
+      "addHeading": "Neuer Kontakt",
+      "editHeading": "Kontakt bearbeiten",
+      "identifierRequired": "Füllen Sie mindestens eines aus: Name, E-Mail-Adresse, Telefon oder Mobilnummer.",
+      "fields": {
+        "name": "Name",
+        "email": "E-Mail-Adresse",
+        "phone": "Telefon",
+        "mobile": "Mobilnummer",
+        "title": "Position",
+        "site": "Gehört zu",
+        "roles": "Rollen",
+        "notes": "Notizen",
+        "isPrimary": "Als Hauptkontakt für den oben gewählten Bereich festlegen"
+      }
+    },
+    "pagination": {
+      "summary": "{{from}} bis {{to}} von {{total}}",
+      "previous": "Zurück",
+      "next": "Weiter"
+    },
+    "toasts": {
+      "created": "Kontakt hinzugefügt",
+      "updated": "Kontakt gespeichert",
+      "deleted": "Kontakt gelöscht"
+    },
+    "errors": {
+      "load": "Die Kontakte dieser Organisation konnten nicht geladen werden.",
+      "create": "Der Kontakt konnte nicht hinzugefügt werden.",
+      "update": "Der Kontakt konnte nicht gespeichert werden.",
+      "delete": "Der Kontakt konnte nicht gelöscht werden."
+    }
+  },
+  "bulkContactImport": {
+    "title": "Kontakte aus CSV importieren",
+    "description": "Laden Sie einen Kontaktexport aus Ihrem bisherigen RMM oder PSA hoch. Jede Zeile wird dieser Organisation zugeordnet.",
+    "dropzone": "CSV-Datei hier ablegen oder klicken zum Auswählen",
+    "dropzoneHint": "Ordnen Sie mindestens eines zu: Name, E-Mail-Adresse, Telefon oder Mobilnummer — ohne eines davon geht es nicht.",
+    "actions": {
+      "close": "Schließen",
+      "preview": "{{count}} Zeilen prüfen",
+      "previewing": "Wird geprüft…",
+      "import": "{{count}} ausgewählte importieren",
+      "importing": "Import läuft…"
+    },
+    "mapping": {
+      "heading": "Spaltenzuordnung",
+      "unmapped": "Nicht zugeordnet",
+      "identifierRequired": "Ordnen Sie eine Spalte mit Name, E-Mail-Adresse, Telefon oder Mobilnummer zu, um fortzufahren.",
+      "fields": {
+        "name": "Name",
+        "email": "E-Mail-Adresse",
+        "phone": "Telefon",
+        "mobile": "Mobilnummer",
+        "title": "Position",
+        "roles": "Rollen",
+        "site": "Standort",
+        "externalId": "Kontakt-Kennung im Quellsystem",
+        "externalSystem": "Quellsystem"
+      }
+    },
+    "mode": {
+      "label": "Bereits verknüpfte Kontakte",
+      "skip": "Unverändert lassen",
+      "update": "Datei in sie einpflegen"
+    },
+    "preview": {
+      "heading": "Was geschehen wird"
+    },
+    "summary": {
+      "imported": "{{count}} hinzugefügt",
+      "updated": "{{count}} zusammengeführt",
+      "skipped": "{{count}} unverändert",
+      "failed": "{{count}} abgelehnt",
+      "allFailed": "Nichts wurde importiert — {{summary}}."
+    },
+    "failures": {
+      "title_one": "{{count}} Zeile wurde abgelehnt",
+      "title_other": "{{count}} Zeilen wurden abgelehnt"
+    },
+    "errors": {
+      "previewFailed": "Die Datei konnte nicht mit den vorhandenen Kontakten abgeglichen werden.",
+      "importFailed": "Die ausgewählten Kontakte konnten nicht importiert werden."
+    }
+  },
+  "contactImportPreview": {
+    "selectAll": "Alle neuen und verknüpften Zeilen auswählen",
+    "organizationLevel": "Organisation",
+    "matches": "entspricht „{{name}}“",
+    "columns": {
+      "name": "Name",
+      "email": "E-Mail-Adresse",
+      "site": "Standort",
+      "status": "Ergebnis"
+    },
+    "badges": {
+      "create": "Neu",
+      "linkMatch": "Bereits verknüpft",
+      "emailMatch": "E-Mail-Treffer — bestätigen",
+      "nameMatch": "Namenstreffer — bestätigen",
+      "conflict": "Konflikt",
+      "orgNotFound": "Organisation nicht gefunden"
+    }
   }
 }

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -3105,6 +3105,8 @@
       "organization": "Organization",
       "general": "General",
       "generalDescription": "Profile and defaults",
+      "contacts": "Contacts",
+      "contactsDescription": "People to reach at this customer, by site or organization-wide",
       "contracts": "Contracts",
       "contractsDescription": "Recurring agreements",
       "billing": "Billing",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -4089,5 +4089,76 @@
     "saveFailed": "Could not save time tracking settings",
     "minSessionRange": "Minimum session length must be between {{min}} and {{max}} seconds",
     "mergeGapRange": "Merge gap must be between {{min}} and {{max}} minutes"
+  },
+  "contactImportPreview": {
+    "selectAll": "Select all new and linked rows",
+    "organizationLevel": "Organization",
+    "matches": "matches “{{name}}”",
+    "columns": {
+      "name": "Name",
+      "email": "Email address",
+      "site": "Site",
+      "status": "Status"
+    },
+    "badges": {
+      "create": "New",
+      "linkMatch": "Already linked",
+      "emailMatch": "Email match — confirm",
+      "nameMatch": "Name match — confirm",
+      "conflict": "Conflict",
+      "orgNotFound": "Organization not found"
+    }
+  },
+  "bulkContactImport": {
+    "title": "Import contacts from CSV",
+    "description": "Upload a contact export from your previous RMM or PSA. Every row is filed under this organization.",
+    "dropzone": "Drop a CSV file here or click to browse",
+    "dropzoneHint": "Map at least one of name, email address, phone, or mobile — a contact needs one of them.",
+    "actions": {
+      "close": "Close",
+      "preview": "Check {{count}} rows",
+      "previewing": "Checking…",
+      "import": "Import {{count}} selected",
+      "importing": "Importing…"
+    },
+    "mapping": {
+      "heading": "Column mapping",
+      "unmapped": "Not mapped",
+      "identifierRequired": "Map a name, email address, phone, or mobile column to continue.",
+      "fields": {
+        "name": "Name",
+        "email": "Email address",
+        "phone": "Phone",
+        "mobile": "Mobile",
+        "title": "Job title",
+        "roles": "Roles",
+        "site": "Site",
+        "externalId": "Contact ID in the source system",
+        "externalSystem": "Source system"
+      }
+    },
+    "mode": {
+      "label": "Contacts already linked",
+      "skip": "Leave them as they are",
+      "update": "Merge the file into them"
+    },
+    "preview": {
+      "heading": "What will happen"
+    },
+    "summary": {
+      "imported": "{{count}} added",
+      "updated": "{{count}} merged",
+      "skipped": "{{count}} left alone",
+      "failed": "{{count}} refused",
+      "allFailed": "Nothing was imported — {{summary}}."
+    },
+    "failures": {
+      "title_one": "{{count}} row was refused",
+      "title_other": "{{count}} rows were refused"
+    },
+    "errors": {
+      "previewFailed": "Could not check the file against existing contacts.",
+      "importFailed": "Could not import the selected contacts."
+    }
   }
 }

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -4128,6 +4128,9 @@
       "heading": "Column mapping",
       "unmapped": "Not mapped",
       "identifierRequired": "Map a name, email address, phone, or mobile column to continue.",
+      "droppedRows_one": "{{count}} row skipped: no name, email address, phone or mobile.",
+      "droppedRows_other": "{{count}} rows skipped: no name, email address, phone or mobile.",
+      "tooManyRows": "This file maps {{count}} rows, more than the {{max}} one import accepts. Split it into smaller files.",
       "fields": {
         "name": "Name",
         "email": "Email address",
@@ -4153,22 +4156,44 @@
       "updated": "{{count}} merged",
       "skipped": "{{count}} left alone",
       "failed": "{{count}} refused",
-      "allFailed": "Nothing was imported — {{summary}}."
+      "allFailed": "Nothing was imported — {{summary}}.",
+      "nothingImported": "Nothing imported: {{count}} already linked.",
+      "nothingImportedEmpty": "Nothing was imported."
     },
     "failures": {
       "title_one": "{{count}} row was refused",
       "title_other": "{{count}} rows were refused"
     },
+    "skipped": {
+      "title_one": "{{count}} row was left as it is",
+      "title_other": "{{count}} rows were left as they are",
+      "reasons": {
+        "alreadyLinked": "already linked to an existing contact"
+      }
+    },
+    "errorCodes": {
+      "rowConflict": "The row is ambiguous against the contacts already here.",
+      "orgNotFound": "This organization is no longer one you can reach.",
+      "annotationChanged": "This row changed since the preview. Check the file again.",
+      "matchChanged": "This row now matches a different contact. Check the file again.",
+      "matchUnconfirmed": "Tick the row and import again to confirm the match.",
+      "writeFailed": "The database refused the write. Nothing was saved for this row.",
+      "noIdentifier": "The row is left with no name, email address, phone or mobile.",
+      "invalidRole": "The row names a role Breeze does not recognize.",
+      "siteNotInOrg": "The site on this row does not belong to this organization."
+    },
     "errors": {
       "previewFailed": "Could not check the file against existing contacts.",
-      "importFailed": "Could not import the selected contacts."
+      "importFailed": "Could not import the selected contacts.",
+      "fileRead": "Could not read that file. Choose it again.",
+      "noColumns": "That file has no header row, so there is nothing to map."
     }
   },
   "contactsCard": {
     "title": "Contacts",
     "description": "The people your team reaches at this customer. One contact can be pinned to a site or belong to the organization as a whole.",
     "organizationLevel": "Organization",
-    "unknownSite": "A site you cannot see",
+    "unknownSite": "Site unavailable",
     "empty": "No contacts yet. Add one, or import a CSV from your previous tool.",
     "loading": "Loading contacts…",
     "confirmDelete": "Delete {{name}}? This cannot be undone.",
@@ -4237,6 +4262,7 @@
     },
     "errors": {
       "load": "Could not load the contacts for this organization.",
+      "sites": "Could not load this organization's sites. Site names and the site filter stay unavailable until they load.",
       "create": "Could not add the contact.",
       "update": "Could not save the contact.",
       "delete": "Could not delete the contact."

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -4160,5 +4160,83 @@
       "previewFailed": "Could not check the file against existing contacts.",
       "importFailed": "Could not import the selected contacts."
     }
+  },
+  "contactsCard": {
+    "title": "Contacts",
+    "description": "The people your team reaches at this customer. One contact can be pinned to a site or belong to the organization as a whole.",
+    "organizationLevel": "Organization",
+    "unknownSite": "A site you cannot see",
+    "empty": "No contacts yet. Add one, or import a CSV from your previous tool.",
+    "loading": "Loading contacts…",
+    "confirmDelete": "Delete {{name}}? This cannot be undone.",
+    "actions": {
+      "add": "Add contact",
+      "import": "Import CSV",
+      "edit": "Edit",
+      "delete": "Delete",
+      "save": "Save contact",
+      "saving": "Saving…",
+      "cancel": "Cancel",
+      "retry": "Try again"
+    },
+    "filters": {
+      "site": "Filter by site",
+      "role": "Filter by role",
+      "allSites": "Every site",
+      "allRoles": "Every role"
+    },
+    "columns": {
+      "name": "Name",
+      "reach": "How to reach them",
+      "jobTitle": "Job title",
+      "roles": "Roles",
+      "site": "Belongs to",
+      "actions": "Actions"
+    },
+    "primary": {
+      "organization": "Primary (organization)",
+      "site": "Primary ({{site}})"
+    },
+    "roles": {
+      "billing": "Billing",
+      "technical": "Technical",
+      "escalation": "Escalation",
+      "admin": "Admin",
+      "site": "Site",
+      "afterHours": "After hours",
+      "portal": "Portal"
+    },
+    "form": {
+      "addHeading": "New contact",
+      "editHeading": "Edit contact",
+      "identifierRequired": "Fill in at least one of name, email address, phone, or mobile.",
+      "fields": {
+        "name": "Name",
+        "email": "Email address",
+        "phone": "Phone",
+        "mobile": "Mobile",
+        "title": "Job title",
+        "site": "Belongs to",
+        "roles": "Roles",
+        "notes": "Notes",
+        "isPrimary": "Make this the primary contact for the scope above"
+      }
+    },
+    "pagination": {
+      "summary": "Showing {{from}} to {{to}} of {{total}}",
+      "previous": "Previous",
+      "next": "Next"
+    },
+    "toasts": {
+      "created": "Contact added",
+      "updated": "Contact saved",
+      "deleted": "Contact deleted"
+    },
+    "errors": {
+      "load": "Could not load the contacts for this organization.",
+      "create": "Could not add the contact.",
+      "update": "Could not save the contact.",
+      "delete": "Could not delete the contact."
+    }
   }
 }

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -3706,7 +3706,8 @@
       "title": "Devices",
       "assigned": "devices assigned to this site",
       "viewAll": "View all devices"
-    }
+    },
+    "allContactsLink": "All contacts for this customer"
   },
   "siteForm": {
     "description": "Only the site name is required. Address and contact are optional — you can fill these in later.",

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -3052,6 +3052,8 @@
       "organization": "Organización",
       "general": "General",
       "generalDescription": "Perfil y valores predeterminados",
+      "contacts": "Contactos",
+      "contactsDescription": "Personas con quienes hablar en este cliente, por sitio o en toda la organización",
       "contracts": "Contratos",
       "contractsDescription": "Acuerdos recurrentes",
       "billing": "Facturación",
@@ -3651,7 +3653,8 @@
       "title": "Dispositivos",
       "assigned": "dispositivos asignados a este sitio",
       "viewAll": "Ver todos los dispositivos"
-    }
+    },
+    "allContactsLink": "Todos los contactos de este cliente"
   },
   "siteForm": {
     "description": "Sólo se requiere el nombre del sitio. La dirección y el contacto son opcionales; puede completarlos más tarde.",
@@ -4089,5 +4092,154 @@
     "saveFailed": "No se pudo guardar la configuración de seguimiento de tiempo",
     "minSessionRange": "La duración mínima de la sesión debe estar entre {{min}} y {{max}} segundos",
     "mergeGapRange": "El intervalo de fusión debe estar entre {{min}} y {{max}} minutos"
+  },
+  "contactsCard": {
+    "title": "Contactos",
+    "description": "Las personas con las que su equipo habla en este cliente. Un contacto puede quedar fijado a un sitio o valer para toda la organización.",
+    "organizationLevel": "Organización",
+    "unknownSite": "Un sitio que usted no puede ver",
+    "empty": "Todavía no hay contactos. Agregue uno o importe un CSV de su herramienta anterior.",
+    "loading": "Cargando contactos…",
+    "confirmDelete": "¿Eliminar a {{name}}? Esta acción no se puede deshacer.",
+    "actions": {
+      "add": "Agregar contacto",
+      "import": "Importar CSV",
+      "edit": "Editar",
+      "delete": "Eliminar",
+      "save": "Guardar contacto",
+      "saving": "Guardando…",
+      "cancel": "Cancelar",
+      "retry": "Reintentar"
+    },
+    "filters": {
+      "site": "Filtrar por sitio",
+      "role": "Filtrar por rol",
+      "allSites": "Todos los sitios",
+      "allRoles": "Todos los roles"
+    },
+    "columns": {
+      "name": "Nombre",
+      "reach": "Cómo comunicarse",
+      "jobTitle": "Cargo",
+      "roles": "Roles",
+      "site": "Pertenece a",
+      "actions": "Acciones"
+    },
+    "primary": {
+      "organization": "Principal (organización)",
+      "site": "Principal ({{site}})"
+    },
+    "roles": {
+      "billing": "Facturación",
+      "technical": "Técnico",
+      "escalation": "Escalamiento",
+      "admin": "Administración",
+      "site": "Sitio",
+      "afterHours": "Fuera de horario",
+      "portal": "Portal del cliente"
+    },
+    "form": {
+      "addHeading": "Nuevo contacto",
+      "editHeading": "Editar contacto",
+      "identifierRequired": "Complete al menos uno: nombre, correo electrónico, teléfono o celular.",
+      "fields": {
+        "name": "Nombre",
+        "email": "Correo electrónico",
+        "phone": "Teléfono",
+        "mobile": "Celular",
+        "title": "Cargo",
+        "site": "Pertenece a",
+        "roles": "Roles",
+        "notes": "Notas",
+        "isPrimary": "Marcar como contacto principal del alcance elegido arriba"
+      }
+    },
+    "pagination": {
+      "summary": "Mostrando {{from}} a {{to}} de {{total}}",
+      "previous": "Anterior",
+      "next": "Siguiente"
+    },
+    "toasts": {
+      "created": "Contacto agregado",
+      "updated": "Contacto guardado",
+      "deleted": "Contacto eliminado"
+    },
+    "errors": {
+      "load": "No se pudieron cargar los contactos de esta organización.",
+      "create": "No se pudo agregar el contacto.",
+      "update": "No se pudo guardar el contacto.",
+      "delete": "No se pudo eliminar el contacto."
+    }
+  },
+  "bulkContactImport": {
+    "title": "Importar contactos desde un CSV",
+    "description": "Cargue una exportación de contactos de su RMM o PSA anterior. Cada fila queda archivada en esta organización.",
+    "dropzone": "Suelte un archivo CSV aquí o haga clic para buscar",
+    "dropzoneHint": "Asigne al menos uno: nombre, correo electrónico, teléfono o celular; sin alguno de ellos no hay contacto.",
+    "actions": {
+      "close": "Cerrar",
+      "preview": "Revisar {{count}} filas",
+      "previewing": "Revisando…",
+      "import": "Importar {{count}} seleccionadas",
+      "importing": "Importando…"
+    },
+    "mapping": {
+      "heading": "Asignación de columnas",
+      "unmapped": "Sin asignar",
+      "identifierRequired": "Asigne una columna de nombre, correo electrónico, teléfono o celular para continuar.",
+      "fields": {
+        "name": "Nombre",
+        "email": "Correo electrónico",
+        "phone": "Teléfono",
+        "mobile": "Celular",
+        "title": "Cargo",
+        "roles": "Roles",
+        "site": "Sitio",
+        "externalId": "Identificador del contacto en el sistema de origen",
+        "externalSystem": "Sistema de origen"
+      }
+    },
+    "mode": {
+      "label": "Contactos ya vinculados",
+      "skip": "Dejarlos como están",
+      "update": "Combinar el archivo con ellos"
+    },
+    "preview": {
+      "heading": "Qué va a pasar"
+    },
+    "summary": {
+      "imported": "{{count}} agregados",
+      "updated": "{{count}} combinados",
+      "skipped": "{{count}} sin cambios",
+      "failed": "{{count}} rechazados",
+      "allFailed": "No se importó nada: {{summary}}."
+    },
+    "failures": {
+      "title_one": "Se rechazó {{count}} fila",
+      "title_other": "Se rechazaron {{count}} filas"
+    },
+    "errors": {
+      "previewFailed": "No se pudo comparar el archivo con los contactos existentes.",
+      "importFailed": "No se pudieron importar los contactos seleccionados."
+    }
+  },
+  "contactImportPreview": {
+    "selectAll": "Seleccionar todas las filas nuevas y vinculadas",
+    "organizationLevel": "Organización",
+    "matches": "coincide con «{{name}}»",
+    "columns": {
+      "name": "Nombre",
+      "email": "Correo electrónico",
+      "site": "Sitio",
+      "status": "Resultado"
+    },
+    "badges": {
+      "create": "Nuevo",
+      "linkMatch": "Ya vinculado",
+      "emailMatch": "Coincide el correo: confirme",
+      "nameMatch": "Coincide el nombre: confirme",
+      "conflict": "Conflicto",
+      "orgNotFound": "Organización no encontrada"
+    }
   }
 }

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -4097,7 +4097,7 @@
     "title": "Contactos",
     "description": "Las personas con las que su equipo habla en este cliente. Un contacto puede quedar fijado a un sitio o valer para toda la organización.",
     "organizationLevel": "Organización",
-    "unknownSite": "Un sitio que usted no puede ver",
+    "unknownSite": "Sitio no disponible",
     "empty": "Todavía no hay contactos. Agregue uno o importe un CSV de su herramienta anterior.",
     "loading": "Cargando contactos…",
     "confirmDelete": "¿Eliminar a {{name}}? Esta acción no se puede deshacer.",
@@ -4166,6 +4166,7 @@
     },
     "errors": {
       "load": "No se pudieron cargar los contactos de esta organización.",
+      "sites": "No se pudieron cargar los sitios de esta organización. Los nombres de sitio y el filtro por sitio seguirán sin estar disponibles hasta que carguen.",
       "create": "No se pudo agregar el contacto.",
       "update": "No se pudo guardar el contacto.",
       "delete": "No se pudo eliminar el contacto."
@@ -4187,6 +4188,9 @@
       "heading": "Asignación de columnas",
       "unmapped": "Sin asignar",
       "identifierRequired": "Asigne una columna de nombre, correo electrónico, teléfono o celular para continuar.",
+      "droppedRows_one": "{{count}} fila omitida: sin nombre, correo electrónico, teléfono ni celular.",
+      "droppedRows_other": "{{count}} filas omitidas: sin nombre, correo electrónico, teléfono ni celular.",
+      "tooManyRows": "Este archivo asigna {{count}} filas, más de las {{max}} que acepta una importación. Divídalo en archivos más pequeños.",
       "fields": {
         "name": "Nombre",
         "email": "Correo electrónico",
@@ -4212,15 +4216,37 @@
       "updated": "{{count}} combinados",
       "skipped": "{{count}} sin cambios",
       "failed": "{{count}} rechazados",
-      "allFailed": "No se importó nada: {{summary}}."
+      "allFailed": "No se importó nada: {{summary}}.",
+      "nothingImported": "No se importó nada: {{count}} ya vinculados.",
+      "nothingImportedEmpty": "No se importó nada."
     },
     "failures": {
       "title_one": "Se rechazó {{count}} fila",
       "title_other": "Se rechazaron {{count}} filas"
     },
+    "skipped": {
+      "title_one": "Se dejó {{count}} fila sin cambios",
+      "title_other": "Se dejaron {{count}} filas sin cambios",
+      "reasons": {
+        "alreadyLinked": "ya vinculado a un contacto existente"
+      }
+    },
+    "errorCodes": {
+      "rowConflict": "La fila es ambigua frente a los contactos que ya están aquí.",
+      "orgNotFound": "Esta organización ya no está a su alcance.",
+      "annotationChanged": "Esta fila cambió desde la vista previa. Revise el archivo de nuevo.",
+      "matchChanged": "Esta fila ahora coincide con otro contacto. Revise el archivo de nuevo.",
+      "matchUnconfirmed": "Marque la fila e importe de nuevo para confirmar la coincidencia.",
+      "writeFailed": "La base de datos rechazó la escritura. No se guardó nada de esta fila.",
+      "noIdentifier": "La fila queda sin nombre, correo electrónico, teléfono ni celular.",
+      "invalidRole": "La fila nombra un rol que Breeze no reconoce.",
+      "siteNotInOrg": "El sitio de esta fila no pertenece a esta organización."
+    },
     "errors": {
       "previewFailed": "No se pudo comparar el archivo con los contactos existentes.",
-      "importFailed": "No se pudieron importar los contactos seleccionados."
+      "importFailed": "No se pudieron importar los contactos seleccionados.",
+      "fileRead": "No se pudo leer ese archivo. Selecciónelo de nuevo.",
+      "noColumns": "Ese archivo no tiene fila de encabezado, así que no hay nada que asignar."
     }
   },
   "contactImportPreview": {

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -4097,7 +4097,7 @@
     "title": "Contacts",
     "description": "Les personnes que votre équipe joint chez ce client. Un contact peut être rattaché à un site ou viser l’organisation entière.",
     "organizationLevel": "Organisation",
-    "unknownSite": "Un site que vous n’avez pas le droit de voir",
+    "unknownSite": "Site indisponible",
     "empty": "Aucun contact pour le moment. Ajoutez-en un, ou importez un CSV de votre ancien outil.",
     "loading": "Chargement des contacts…",
     "confirmDelete": "Supprimer {{name}} ? Cette opération est irréversible.",
@@ -4166,6 +4166,7 @@
     },
     "errors": {
       "load": "Impossible de charger les contacts de cette organisation.",
+      "sites": "Impossible de charger les sites de cette organisation. Les noms de site et le filtre par site restent indisponibles.",
       "create": "Impossible d’ajouter le contact.",
       "update": "Impossible d’enregistrer le contact.",
       "delete": "Impossible de supprimer le contact."
@@ -4187,6 +4188,9 @@
       "heading": "Correspondance des colonnes",
       "unmapped": "Non associée",
       "identifierRequired": "Associez une colonne nom, adresse courriel, téléphone ou cellulaire pour continuer.",
+      "droppedRows_one": "{{count}} ligne ignorée : ni nom, ni adresse courriel, ni téléphone, ni cellulaire.",
+      "droppedRows_other": "{{count}} lignes ignorées : ni nom, ni adresse courriel, ni téléphone, ni cellulaire.",
+      "tooManyRows": "Ce fichier associe {{count}} lignes, soit plus que les {{max}} acceptées par importation. Divisez-le en fichiers plus petits.",
       "fields": {
         "name": "Nom",
         "email": "Adresse courriel",
@@ -4212,15 +4216,37 @@
       "updated": "{{count}} fusionnés",
       "skipped": "{{count}} laissés tels quels",
       "failed": "{{count}} refusées",
-      "allFailed": "Rien n’a été importé — {{summary}}."
+      "allFailed": "Rien n’a été importé — {{summary}}.",
+      "nothingImported": "Rien d’importé : {{count}} déjà liés.",
+      "nothingImportedEmpty": "Rien n’a été importé."
     },
     "failures": {
       "title_one": "{{count}} ligne a été refusée",
       "title_other": "{{count}} lignes ont été refusées"
     },
+    "skipped": {
+      "title_one": "{{count}} ligne a été laissée telle quelle",
+      "title_other": "{{count}} lignes ont été laissées telles quelles",
+      "reasons": {
+        "alreadyLinked": "déjà lié à un contact existant"
+      }
+    },
+    "errorCodes": {
+      "rowConflict": "La ligne est ambiguë par rapport aux contacts déjà présents.",
+      "orgNotFound": "Cette organisation n’est plus à votre portée.",
+      "annotationChanged": "Cette ligne a changé depuis l’aperçu. Vérifiez le fichier de nouveau.",
+      "matchChanged": "Cette ligne correspond maintenant à un autre contact. Vérifiez le fichier de nouveau.",
+      "matchUnconfirmed": "Cochez la ligne et relancez l’importation pour confirmer la correspondance.",
+      "writeFailed": "La base de données a refusé l’écriture. Rien n’a été enregistré pour cette ligne.",
+      "noIdentifier": "Il ne reste à la ligne ni nom, ni adresse courriel, ni téléphone, ni cellulaire.",
+      "invalidRole": "La ligne nomme un rôle que Breeze ne connaît pas.",
+      "siteNotInOrg": "Le site de cette ligne n’appartient pas à cette organisation."
+    },
     "errors": {
       "previewFailed": "Impossible de comparer le fichier aux contacts déjà présents.",
-      "importFailed": "Impossible d’importer les contacts sélectionnés."
+      "importFailed": "Impossible d’importer les contacts sélectionnés.",
+      "fileRead": "Impossible de lire ce fichier. Sélectionnez-le de nouveau.",
+      "noColumns": "Ce fichier n’a pas de ligne d’en-tête : il n’y a donc rien à associer."
     }
   },
   "contactImportPreview": {

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -3100,6 +3100,8 @@
       "organization": "Organisation",
       "general": "Généralités",
       "generalDescription": "Profil et paramètres par défaut",
+      "contacts": "Contacts",
+      "contactsDescription": "Personnes à joindre chez ce client, par site ou pour toute l’organisation",
       "contracts": "Contrats",
       "contractsDescription": "Accords récurrents",
       "billing": "Facturation",
@@ -3699,7 +3701,8 @@
       "title": "Appareils",
       "assigned": "Appareils attribués à ce site",
       "viewAll": "Voir tous les appareils"
-    }
+    },
+    "allContactsLink": "Tous les contacts de ce client"
   },
   "siteForm": {
     "description": "Seul le nom du site est requis. L’adresse et le contact sont optionnels — vous pourrez les remplir plus tard.",
@@ -4089,5 +4092,154 @@
     "saveFailed": "Impossible d’enregistrer les paramètres de suivi du temps",
     "minSessionRange": "La durée minimale de session doit être comprise entre {{min}} et {{max}} secondes",
     "mergeGapRange": "L’intervalle de fusion doit être compris entre {{min}} et {{max}} minutes"
+  },
+  "contactsCard": {
+    "title": "Contacts",
+    "description": "Les personnes que votre équipe joint chez ce client. Un contact peut être rattaché à un site ou viser l’organisation entière.",
+    "organizationLevel": "Organisation",
+    "unknownSite": "Un site que vous n’avez pas le droit de voir",
+    "empty": "Aucun contact pour le moment. Ajoutez-en un, ou importez un CSV de votre ancien outil.",
+    "loading": "Chargement des contacts…",
+    "confirmDelete": "Supprimer {{name}} ? Cette opération est irréversible.",
+    "actions": {
+      "add": "Ajouter un contact",
+      "import": "Importer un CSV",
+      "edit": "Modifier",
+      "delete": "Supprimer",
+      "save": "Enregistrer le contact",
+      "saving": "Enregistrement en cours…",
+      "cancel": "Annuler",
+      "retry": "Réessayer"
+    },
+    "filters": {
+      "site": "Filtrer par site",
+      "role": "Filtrer par rôle",
+      "allSites": "Tous les sites",
+      "allRoles": "Tous les rôles"
+    },
+    "columns": {
+      "name": "Nom",
+      "reach": "Comment les joindre",
+      "jobTitle": "Titre du poste",
+      "roles": "Rôles",
+      "site": "Rattaché à",
+      "actions": "Opérations"
+    },
+    "primary": {
+      "organization": "Principal (organisation)",
+      "site": "Principal ({{site}})"
+    },
+    "roles": {
+      "billing": "Facturation",
+      "technical": "Technique",
+      "escalation": "Escalade",
+      "admin": "Administration",
+      "site": "Site",
+      "afterHours": "En dehors des heures d’ouverture",
+      "portal": "Portail"
+    },
+    "form": {
+      "addHeading": "Nouveau contact",
+      "editHeading": "Modifier le contact",
+      "identifierRequired": "Remplissez au moins un champ : nom, adresse courriel, téléphone ou cellulaire.",
+      "fields": {
+        "name": "Nom",
+        "email": "Adresse courriel",
+        "phone": "Téléphone",
+        "mobile": "Cellulaire",
+        "title": "Titre du poste",
+        "site": "Rattaché à",
+        "roles": "Rôles",
+        "notes": "Remarques",
+        "isPrimary": "Faire de ce contact le principal pour la portée choisie ci-dessus"
+      }
+    },
+    "pagination": {
+      "summary": "Affichage de {{from}} à {{to}} sur {{total}}",
+      "previous": "Précédent",
+      "next": "Suivant"
+    },
+    "toasts": {
+      "created": "Contact ajouté",
+      "updated": "Contact enregistré",
+      "deleted": "Contact supprimé"
+    },
+    "errors": {
+      "load": "Impossible de charger les contacts de cette organisation.",
+      "create": "Impossible d’ajouter le contact.",
+      "update": "Impossible d’enregistrer le contact.",
+      "delete": "Impossible de supprimer le contact."
+    }
+  },
+  "bulkContactImport": {
+    "title": "Importer des contacts à partir d’un CSV",
+    "description": "Téléversez un export de contacts de votre ancien RMM ou PSA. Chaque ligne est classée sous cette organisation.",
+    "dropzone": "Déposez un fichier CSV ici ou cliquez pour parcourir",
+    "dropzoneHint": "Associez au moins un champ : nom, adresse courriel, téléphone ou cellulaire — il en faut un.",
+    "actions": {
+      "close": "Fermer",
+      "preview": "Vérifier {{count}} lignes",
+      "previewing": "Vérification en cours…",
+      "import": "Importer les {{count}} sélectionnées",
+      "importing": "Importation en cours…"
+    },
+    "mapping": {
+      "heading": "Correspondance des colonnes",
+      "unmapped": "Non associée",
+      "identifierRequired": "Associez une colonne nom, adresse courriel, téléphone ou cellulaire pour continuer.",
+      "fields": {
+        "name": "Nom",
+        "email": "Adresse courriel",
+        "phone": "Téléphone",
+        "mobile": "Cellulaire",
+        "title": "Titre du poste",
+        "roles": "Rôles",
+        "site": "Site",
+        "externalId": "Identifiant du contact dans le système source",
+        "externalSystem": "Système source"
+      }
+    },
+    "mode": {
+      "label": "Contacts déjà liés",
+      "skip": "Les laisser tels quels",
+      "update": "Y fusionner le fichier"
+    },
+    "preview": {
+      "heading": "Ce qui va se produire"
+    },
+    "summary": {
+      "imported": "{{count}} ajoutés",
+      "updated": "{{count}} fusionnés",
+      "skipped": "{{count}} laissés tels quels",
+      "failed": "{{count}} refusées",
+      "allFailed": "Rien n’a été importé — {{summary}}."
+    },
+    "failures": {
+      "title_one": "{{count}} ligne a été refusée",
+      "title_other": "{{count}} lignes ont été refusées"
+    },
+    "errors": {
+      "previewFailed": "Impossible de comparer le fichier aux contacts déjà présents.",
+      "importFailed": "Impossible d’importer les contacts sélectionnés."
+    }
+  },
+  "contactImportPreview": {
+    "selectAll": "Sélectionner toutes les lignes nouvelles et liées",
+    "organizationLevel": "Organisation",
+    "matches": "correspond à « {{name}} »",
+    "columns": {
+      "name": "Nom",
+      "email": "Adresse courriel",
+      "site": "Site",
+      "status": "Résultat"
+    },
+    "badges": {
+      "create": "Nouveau",
+      "linkMatch": "Déjà lié",
+      "emailMatch": "Correspondance de courriel — à confirmer",
+      "nameMatch": "Correspondance de nom — à confirmer",
+      "conflict": "Conflit",
+      "orgNotFound": "Organisation introuvable"
+    }
   }
 }

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -3052,6 +3052,8 @@
       "organization": "Organisation",
       "general": "Généralités",
       "generalDescription": "Profil et paramètres par défaut",
+      "contacts": "Contacts",
+      "contactsDescription": "Personnes à joindre chez ce client, par site ou pour toute l’organisation",
       "contracts": "Contrats",
       "contractsDescription": "Accords récurrents",
       "billing": "Facturation",
@@ -3651,7 +3653,8 @@
       "title": "Dispositifs",
       "assigned": "Appareils attribués à ce site",
       "viewAll": "Voir tous les appareils"
-    }
+    },
+    "allContactsLink": "Tous les contacts de ce client"
   },
   "siteForm": {
     "description": "Seul le nom du site est requis. L’adresse et le contact sont optionnels — vous pourrez les remplir plus tard.",
@@ -4089,5 +4092,154 @@
     "saveFailed": "Impossible d’enregistrer les paramètres de suivi du temps",
     "minSessionRange": "La durée minimale de session doit être comprise entre {{min}} et {{max}} secondes",
     "mergeGapRange": "L’intervalle de fusion doit être compris entre {{min}} et {{max}} minutes"
+  },
+  "contactsCard": {
+    "title": "Contacts",
+    "description": "Les personnes que votre équipe joint chez ce client. Un contact peut être rattaché à un site ou valoir pour toute l’organisation.",
+    "organizationLevel": "Organisation",
+    "unknownSite": "Un site que vous ne pouvez pas voir",
+    "empty": "Aucun contact pour l’instant. Ajoutez-en un, ou importez un CSV depuis votre ancien outil.",
+    "loading": "Chargement des contacts…",
+    "confirmDelete": "Supprimer {{name}} ? Cette action est irréversible.",
+    "actions": {
+      "add": "Ajouter un contact",
+      "import": "Importer un CSV",
+      "edit": "Modifier",
+      "delete": "Supprimer",
+      "save": "Enregistrer le contact",
+      "saving": "Enregistrement…",
+      "cancel": "Annuler",
+      "retry": "Réessayer"
+    },
+    "filters": {
+      "site": "Filtrer par site",
+      "role": "Filtrer par rôle",
+      "allSites": "Tous les sites",
+      "allRoles": "Tous les rôles"
+    },
+    "columns": {
+      "name": "Nom",
+      "reach": "Comment les joindre",
+      "jobTitle": "Fonction",
+      "roles": "Rôles",
+      "site": "Rattaché à",
+      "actions": "Opérations"
+    },
+    "primary": {
+      "organization": "Principal (organisation)",
+      "site": "Principal ({{site}})"
+    },
+    "roles": {
+      "billing": "Facturation",
+      "technical": "Technique",
+      "escalation": "Escalade",
+      "admin": "Administration",
+      "site": "Site",
+      "afterHours": "Hors heures ouvrées",
+      "portal": "Portail"
+    },
+    "form": {
+      "addHeading": "Nouveau contact",
+      "editHeading": "Modifier le contact",
+      "identifierRequired": "Renseignez au moins un élément : nom, adresse e-mail, téléphone ou portable.",
+      "fields": {
+        "name": "Nom",
+        "email": "Adresse e-mail",
+        "phone": "Téléphone",
+        "mobile": "Portable",
+        "title": "Fonction",
+        "site": "Rattaché à",
+        "roles": "Rôles",
+        "notes": "Remarques",
+        "isPrimary": "Définir comme contact principal du périmètre choisi ci-dessus"
+      }
+    },
+    "pagination": {
+      "summary": "Affichage de {{from}} à {{to}} sur {{total}}",
+      "previous": "Précédent",
+      "next": "Suivant"
+    },
+    "toasts": {
+      "created": "Contact ajouté",
+      "updated": "Contact enregistré",
+      "deleted": "Contact supprimé"
+    },
+    "errors": {
+      "load": "Impossible de charger les contacts de cette organisation.",
+      "create": "Impossible d’ajouter le contact.",
+      "update": "Impossible d’enregistrer le contact.",
+      "delete": "Impossible de supprimer le contact."
+    }
+  },
+  "bulkContactImport": {
+    "title": "Importer des contacts depuis un CSV",
+    "description": "Téléversez un export de contacts de votre ancien RMM ou PSA. Chaque ligne est rattachée à cette organisation.",
+    "dropzone": "Déposez un fichier CSV ici ou cliquez pour parcourir",
+    "dropzoneHint": "Associez au moins un élément : nom, adresse e-mail, téléphone ou portable — sans cela il n’y a pas de contact.",
+    "actions": {
+      "close": "Fermer",
+      "preview": "Vérifier {{count}} lignes",
+      "previewing": "Vérification…",
+      "import": "Importer {{count}} sélectionnées",
+      "importing": "Import en cours…"
+    },
+    "mapping": {
+      "heading": "Correspondance des colonnes",
+      "unmapped": "Non associée",
+      "identifierRequired": "Associez une colonne nom, adresse e-mail, téléphone ou portable pour continuer.",
+      "fields": {
+        "name": "Nom",
+        "email": "Adresse e-mail",
+        "phone": "Téléphone",
+        "mobile": "Portable",
+        "title": "Fonction",
+        "roles": "Rôles",
+        "site": "Site",
+        "externalId": "Identifiant du contact dans le système source",
+        "externalSystem": "Système source"
+      }
+    },
+    "mode": {
+      "label": "Contacts déjà liés",
+      "skip": "Les laisser inchangés",
+      "update": "Y fusionner le fichier"
+    },
+    "preview": {
+      "heading": "Ce qui va se passer"
+    },
+    "summary": {
+      "imported": "{{count}} ajoutés",
+      "updated": "{{count}} fusionnés",
+      "skipped": "{{count}} inchangés",
+      "failed": "{{count}} refusées",
+      "allFailed": "Rien n’a été importé — {{summary}}."
+    },
+    "failures": {
+      "title_one": "{{count}} ligne a été refusée",
+      "title_other": "{{count}} lignes ont été refusées"
+    },
+    "errors": {
+      "previewFailed": "Impossible de comparer le fichier aux contacts existants.",
+      "importFailed": "Impossible d’importer les contacts sélectionnés."
+    }
+  },
+  "contactImportPreview": {
+    "selectAll": "Sélectionner toutes les lignes nouvelles et liées",
+    "organizationLevel": "Organisation",
+    "matches": "correspond à « {{name}} »",
+    "columns": {
+      "name": "Nom",
+      "email": "Adresse e-mail",
+      "site": "Site",
+      "status": "Résultat"
+    },
+    "badges": {
+      "create": "Nouveau",
+      "linkMatch": "Déjà lié",
+      "emailMatch": "Correspondance d’e-mail — à confirmer",
+      "nameMatch": "Correspondance de nom — à confirmer",
+      "conflict": "Conflit",
+      "orgNotFound": "Organisation introuvable"
+    }
   }
 }

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -4097,7 +4097,7 @@
     "title": "Contacts",
     "description": "Les personnes que votre équipe joint chez ce client. Un contact peut être rattaché à un site ou valoir pour toute l’organisation.",
     "organizationLevel": "Organisation",
-    "unknownSite": "Un site que vous ne pouvez pas voir",
+    "unknownSite": "Site indisponible",
     "empty": "Aucun contact pour l’instant. Ajoutez-en un, ou importez un CSV depuis votre ancien outil.",
     "loading": "Chargement des contacts…",
     "confirmDelete": "Supprimer {{name}} ? Cette action est irréversible.",
@@ -4166,6 +4166,7 @@
     },
     "errors": {
       "load": "Impossible de charger les contacts de cette organisation.",
+      "sites": "Impossible de charger les sites de cette organisation. Les noms de site et le filtre par site restent indisponibles.",
       "create": "Impossible d’ajouter le contact.",
       "update": "Impossible d’enregistrer le contact.",
       "delete": "Impossible de supprimer le contact."
@@ -4187,6 +4188,9 @@
       "heading": "Correspondance des colonnes",
       "unmapped": "Non associée",
       "identifierRequired": "Associez une colonne nom, adresse e-mail, téléphone ou portable pour continuer.",
+      "droppedRows_one": "{{count}} ligne ignorée : ni nom, ni adresse e-mail, ni téléphone, ni portable.",
+      "droppedRows_other": "{{count}} lignes ignorées : ni nom, ni adresse e-mail, ni téléphone, ni portable.",
+      "tooManyRows": "Ce fichier associe {{count}} lignes, soit plus que les {{max}} acceptées par import. Découpez-le en fichiers plus petits.",
       "fields": {
         "name": "Nom",
         "email": "Adresse e-mail",
@@ -4212,15 +4216,37 @@
       "updated": "{{count}} fusionnés",
       "skipped": "{{count}} inchangés",
       "failed": "{{count}} refusées",
-      "allFailed": "Rien n’a été importé — {{summary}}."
+      "allFailed": "Rien n’a été importé — {{summary}}.",
+      "nothingImported": "Rien d’importé : {{count}} déjà liés.",
+      "nothingImportedEmpty": "Rien n’a été importé."
     },
     "failures": {
       "title_one": "{{count}} ligne a été refusée",
       "title_other": "{{count}} lignes ont été refusées"
     },
+    "skipped": {
+      "title_one": "{{count}} ligne a été laissée inchangée",
+      "title_other": "{{count}} lignes ont été laissées inchangées",
+      "reasons": {
+        "alreadyLinked": "déjà lié à un contact existant"
+      }
+    },
+    "errorCodes": {
+      "rowConflict": "La ligne est ambiguë par rapport aux contacts déjà présents.",
+      "orgNotFound": "Cette organisation n’est plus accessible pour vous.",
+      "annotationChanged": "Cette ligne a changé depuis l’aperçu. Vérifiez à nouveau le fichier.",
+      "matchChanged": "Cette ligne correspond désormais à un autre contact. Vérifiez à nouveau le fichier.",
+      "matchUnconfirmed": "Cochez la ligne puis relancez l’import pour confirmer la correspondance.",
+      "writeFailed": "La base de données a refusé l’écriture. Rien n’a été enregistré pour cette ligne.",
+      "noIdentifier": "Il ne reste à la ligne ni nom, ni adresse e-mail, ni téléphone, ni portable.",
+      "invalidRole": "La ligne nomme un rôle que Breeze ne connaît pas.",
+      "siteNotInOrg": "Le site de cette ligne n’appartient pas à cette organisation."
+    },
     "errors": {
       "previewFailed": "Impossible de comparer le fichier aux contacts existants.",
-      "importFailed": "Impossible d’importer les contacts sélectionnés."
+      "importFailed": "Impossible d’importer les contacts sélectionnés.",
+      "fileRead": "Impossible de lire ce fichier. Sélectionnez-le à nouveau.",
+      "noColumns": "Ce fichier n’a pas de ligne d’en-tête : il n’y a donc rien à associer."
     }
   },
   "contactImportPreview": {

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -4097,7 +4097,7 @@
     "title": "Contatti",
     "description": "Le persone che il vostro team raggiunge presso questo cliente. Un contatto può essere legato a un sito oppure valere per l’intera organizzazione.",
     "organizationLevel": "Organizzazione",
-    "unknownSite": "Un sito che non potete vedere",
+    "unknownSite": "Sito non disponibile",
     "empty": "Nessun contatto per ora. Aggiungetene uno oppure importate un CSV dal vostro strumento precedente.",
     "loading": "Caricamento dei contatti…",
     "confirmDelete": "Eliminare {{name}}? L’operazione non è reversibile.",
@@ -4166,6 +4166,7 @@
     },
     "errors": {
       "load": "Impossibile caricare i contatti di questa organizzazione.",
+      "sites": "Impossibile caricare i siti di questa organizzazione. I nomi dei siti e il filtro per sito restano non disponibili.",
       "create": "Impossibile aggiungere il contatto.",
       "update": "Impossibile salvare il contatto.",
       "delete": "Impossibile eliminare il contatto."
@@ -4187,6 +4188,9 @@
       "heading": "Corrispondenza delle colonne",
       "unmapped": "Non associata",
       "identifierRequired": "Associate una colonna nome, indirizzo e-mail, telefono o cellulare per proseguire.",
+      "droppedRows_one": "{{count}} riga ignorata: nessun nome, e-mail, telefono o cellulare.",
+      "droppedRows_other": "{{count}} righe ignorate: nessun nome, e-mail, telefono o cellulare.",
+      "tooManyRows": "Questo file mappa {{count}} righe, più delle {{max}} accettate da una singola importazione. Suddividetelo in file più piccoli.",
       "fields": {
         "name": "Nome",
         "email": "Indirizzo e-mail",
@@ -4212,15 +4216,37 @@
       "updated": "{{count}} uniti",
       "skipped": "{{count}} invariati",
       "failed": "{{count}} rifiutate",
-      "allFailed": "Non è stato importato nulla — {{summary}}."
+      "allFailed": "Non è stato importato nulla — {{summary}}.",
+      "nothingImported": "Non è stato importato nulla: {{count}} già collegati.",
+      "nothingImportedEmpty": "Non è stato importato nulla."
     },
     "failures": {
       "title_one": "{{count}} riga è stata rifiutata",
       "title_other": "{{count}} righe sono state rifiutate"
     },
+    "skipped": {
+      "title_one": "{{count}} riga è rimasta invariata",
+      "title_other": "{{count}} righe sono rimaste invariate",
+      "reasons": {
+        "alreadyLinked": "già collegato a un contatto esistente"
+      }
+    },
+    "errorCodes": {
+      "rowConflict": "La riga è ambigua rispetto ai contatti già presenti.",
+      "orgNotFound": "Questa organizzazione non è più alla vostra portata.",
+      "annotationChanged": "Questa riga è cambiata dopo l’anteprima. Ricontrollate il file.",
+      "matchChanged": "Questa riga ora corrisponde a un altro contatto. Ricontrollate il file.",
+      "matchUnconfirmed": "Spuntate la riga e importate di nuovo per confermare la corrispondenza.",
+      "writeFailed": "Il database ha rifiutato la scrittura. Per questa riga non è stato salvato nulla.",
+      "noIdentifier": "Alla riga non resta né nome, né e-mail, né telefono, né cellulare.",
+      "invalidRole": "La riga indica un ruolo che Breeze non riconosce.",
+      "siteNotInOrg": "Il sito di questa riga non appartiene a questa organizzazione."
+    },
     "errors": {
       "previewFailed": "Impossibile confrontare il file con i contatti esistenti.",
-      "importFailed": "Impossibile importare i contatti selezionati."
+      "importFailed": "Impossibile importare i contatti selezionati.",
+      "fileRead": "Impossibile leggere quel file. Selezionatelo di nuovo.",
+      "noColumns": "Quel file non ha una riga di intestazione, quindi non c’è nulla da mappare."
     }
   },
   "contactImportPreview": {

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -3100,6 +3100,8 @@
       "organization": "Organizzazione",
       "general": "Generale",
       "generalDescription": "Profilo e predefiniti",
+      "contacts": "Contatti",
+      "contactsDescription": "Persone da raggiungere presso questo cliente, per sito o per l’intera organizzazione",
       "contracts": "Contratti",
       "contractsDescription": "Accordi ricorrenti",
       "billing": "Fatturazione",
@@ -3699,7 +3701,8 @@
       "title": "Dispositivi",
       "assigned": "dispositivi assegnati a questo sito",
       "viewAll": "Visualizza tutti i dispositivi"
-    }
+    },
+    "allContactsLink": "Tutti i contatti di questo cliente"
   },
   "siteForm": {
     "description": "È richiesto solo il nome del sito. Indirizzo e contatto sono facoltativi: puoi compilarli più tardi.",
@@ -4089,5 +4092,154 @@
     "saveFailed": "Impossibile salvare le impostazioni di tracciamento tempo",
     "minSessionRange": "La durata minima della sessione deve essere compresa tra {{min}} e {{max}} secondi",
     "mergeGapRange": "L’intervallo di unione deve essere compreso tra {{min}} e {{max}} minuti"
+  },
+  "contactsCard": {
+    "title": "Contatti",
+    "description": "Le persone che il vostro team raggiunge presso questo cliente. Un contatto può essere legato a un sito oppure valere per l’intera organizzazione.",
+    "organizationLevel": "Organizzazione",
+    "unknownSite": "Un sito che non potete vedere",
+    "empty": "Nessun contatto per ora. Aggiungetene uno oppure importate un CSV dal vostro strumento precedente.",
+    "loading": "Caricamento dei contatti…",
+    "confirmDelete": "Eliminare {{name}}? L’operazione non è reversibile.",
+    "actions": {
+      "add": "Aggiungi contatto",
+      "import": "Importa CSV",
+      "edit": "Modifica",
+      "delete": "Elimina",
+      "save": "Salva contatto",
+      "saving": "Salvataggio…",
+      "cancel": "Annulla",
+      "retry": "Riprova"
+    },
+    "filters": {
+      "site": "Filtra per sito",
+      "role": "Filtra per ruolo",
+      "allSites": "Tutti i siti",
+      "allRoles": "Tutti i ruoli"
+    },
+    "columns": {
+      "name": "Nome",
+      "reach": "Come raggiungerli",
+      "jobTitle": "Qualifica",
+      "roles": "Ruoli",
+      "site": "Appartiene a",
+      "actions": "Azioni"
+    },
+    "primary": {
+      "organization": "Principale (organizzazione)",
+      "site": "Principale ({{site}})"
+    },
+    "roles": {
+      "billing": "Fatturazione",
+      "technical": "Tecnico",
+      "escalation": "Inoltro urgente",
+      "admin": "Amministrazione",
+      "site": "Sito",
+      "afterHours": "Fuori orario",
+      "portal": "Portale"
+    },
+    "form": {
+      "addHeading": "Nuovo contatto",
+      "editHeading": "Modifica contatto",
+      "identifierRequired": "Compilate almeno uno fra nome, indirizzo e-mail, telefono o cellulare.",
+      "fields": {
+        "name": "Nome",
+        "email": "Indirizzo e-mail",
+        "phone": "Telefono",
+        "mobile": "Cellulare",
+        "title": "Qualifica",
+        "site": "Appartiene a",
+        "roles": "Ruoli",
+        "notes": "Note",
+        "isPrimary": "Imposta come contatto principale per l’ambito scelto sopra"
+      }
+    },
+    "pagination": {
+      "summary": "Da {{from}} a {{to}} di {{total}}",
+      "previous": "Precedente",
+      "next": "Successivo"
+    },
+    "toasts": {
+      "created": "Contatto aggiunto",
+      "updated": "Contatto salvato",
+      "deleted": "Contatto eliminato"
+    },
+    "errors": {
+      "load": "Impossibile caricare i contatti di questa organizzazione.",
+      "create": "Impossibile aggiungere il contatto.",
+      "update": "Impossibile salvare il contatto.",
+      "delete": "Impossibile eliminare il contatto."
+    }
+  },
+  "bulkContactImport": {
+    "title": "Importa contatti da un CSV",
+    "description": "Caricate un’esportazione di contatti dal vostro precedente RMM o PSA. Ogni riga viene archiviata sotto questa organizzazione.",
+    "dropzone": "Trascinate qui un file CSV oppure fate clic per sceglierlo",
+    "dropzoneHint": "Associate almeno uno fra nome, indirizzo e-mail, telefono o cellulare: senza, non c’è contatto.",
+    "actions": {
+      "close": "Chiudi",
+      "preview": "Controlla {{count}} righe",
+      "previewing": "Controllo in corso…",
+      "import": "Importa {{count}} selezionate",
+      "importing": "Importazione in corso…"
+    },
+    "mapping": {
+      "heading": "Corrispondenza delle colonne",
+      "unmapped": "Non associata",
+      "identifierRequired": "Associate una colonna nome, indirizzo e-mail, telefono o cellulare per proseguire.",
+      "fields": {
+        "name": "Nome",
+        "email": "Indirizzo e-mail",
+        "phone": "Telefono",
+        "mobile": "Cellulare",
+        "title": "Qualifica",
+        "roles": "Ruoli",
+        "site": "Sito",
+        "externalId": "Identificativo del contatto nel sistema di origine",
+        "externalSystem": "Sistema di origine"
+      }
+    },
+    "mode": {
+      "label": "Contatti già collegati",
+      "skip": "Lasciarli invariati",
+      "update": "Unirvi il contenuto del file"
+    },
+    "preview": {
+      "heading": "Che cosa succederà"
+    },
+    "summary": {
+      "imported": "{{count}} aggiunti",
+      "updated": "{{count}} uniti",
+      "skipped": "{{count}} invariati",
+      "failed": "{{count}} rifiutate",
+      "allFailed": "Non è stato importato nulla — {{summary}}."
+    },
+    "failures": {
+      "title_one": "{{count}} riga è stata rifiutata",
+      "title_other": "{{count}} righe sono state rifiutate"
+    },
+    "errors": {
+      "previewFailed": "Impossibile confrontare il file con i contatti esistenti.",
+      "importFailed": "Impossibile importare i contatti selezionati."
+    }
+  },
+  "contactImportPreview": {
+    "selectAll": "Seleziona tutte le righe nuove e collegate",
+    "organizationLevel": "Organizzazione",
+    "matches": "corrisponde a “{{name}}”",
+    "columns": {
+      "name": "Nome",
+      "email": "Indirizzo e-mail",
+      "site": "Sito",
+      "status": "Esito"
+    },
+    "badges": {
+      "create": "Nuovo",
+      "linkMatch": "Già collegato",
+      "emailMatch": "Corrispondenza e-mail — confermare",
+      "nameMatch": "Corrispondenza nome — confermare",
+      "conflict": "Conflitto",
+      "orgNotFound": "Organizzazione non trovata"
+    }
   }
 }

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -4097,7 +4097,7 @@
     "title": "Contatos",
     "description": "As pessoas que sua equipe procura neste cliente. Um contato pode ficar preso a um local ou valer para toda a organização.",
     "organizationLevel": "Organização",
-    "unknownSite": "Um local que você não pode ver",
+    "unknownSite": "Local indisponível",
     "empty": "Nenhum contato ainda. Adicione um ou importe um CSV da sua ferramenta anterior.",
     "loading": "Carregando contatos…",
     "confirmDelete": "Excluir {{name}}? Isso não pode ser desfeito.",
@@ -4166,6 +4166,7 @@
     },
     "errors": {
       "load": "Não foi possível carregar os contatos desta organização.",
+      "sites": "Não foi possível carregar os locais desta organização. Os nomes de local e o filtro por local ficam indisponíveis até carregarem.",
       "create": "Não foi possível adicionar o contato.",
       "update": "Não foi possível salvar o contato.",
       "delete": "Não foi possível excluir o contato."
@@ -4187,6 +4188,9 @@
       "heading": "Mapeamento de colunas",
       "unmapped": "Não mapeada",
       "identifierRequired": "Mapeie uma coluna de nome, endereço de e-mail, telefone ou celular para continuar.",
+      "droppedRows_one": "{{count}} linha ignorada: sem nome, e-mail, telefone ou celular.",
+      "droppedRows_other": "{{count}} linhas ignoradas: sem nome, e-mail, telefone ou celular.",
+      "tooManyRows": "Este arquivo mapeia {{count}} linhas, mais do que as {{max}} aceitas por importação. Divida-o em arquivos menores.",
       "fields": {
         "name": "Nome",
         "email": "Endereço de e-mail",
@@ -4212,15 +4216,37 @@
       "updated": "{{count}} mesclados",
       "skipped": "{{count}} sem alteração",
       "failed": "{{count}} recusadas",
-      "allFailed": "Nada foi importado — {{summary}}."
+      "allFailed": "Nada foi importado — {{summary}}.",
+      "nothingImported": "Nada foi importado: {{count}} já vinculados.",
+      "nothingImportedEmpty": "Nada foi importado."
     },
     "failures": {
       "title_one": "{{count}} linha foi recusada",
       "title_other": "{{count}} linhas foram recusadas"
     },
+    "skipped": {
+      "title_one": "{{count}} linha ficou sem alteração",
+      "title_other": "{{count}} linhas ficaram sem alteração",
+      "reasons": {
+        "alreadyLinked": "já vinculado a um contato existente"
+      }
+    },
+    "errorCodes": {
+      "rowConflict": "A linha é ambígua diante dos contatos que já existem aqui.",
+      "orgNotFound": "Esta organização não está mais ao seu alcance.",
+      "annotationChanged": "Esta linha mudou desde a prévia. Confira o arquivo novamente.",
+      "matchChanged": "Esta linha agora corresponde a outro contato. Confira o arquivo novamente.",
+      "matchUnconfirmed": "Marque a linha e importe novamente para confirmar a correspondência.",
+      "writeFailed": "O banco de dados recusou a gravação. Nada desta linha foi salvo.",
+      "noIdentifier": "A linha fica sem nome, e-mail, telefone ou celular.",
+      "invalidRole": "A linha indica um papel que o Breeze não reconhece.",
+      "siteNotInOrg": "O local desta linha não pertence a esta organização."
+    },
     "errors": {
       "previewFailed": "Não foi possível comparar o arquivo com os contatos existentes.",
-      "importFailed": "Não foi possível importar os contatos selecionados."
+      "importFailed": "Não foi possível importar os contatos selecionados.",
+      "fileRead": "Não foi possível ler esse arquivo. Selecione-o novamente.",
+      "noColumns": "Esse arquivo não tem linha de cabeçalho, então não há nada a mapear."
     }
   },
   "contactImportPreview": {

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -3105,6 +3105,8 @@
       "organization": "Organização",
       "general": "Geral",
       "generalDescription": "Perfil e padrões",
+      "contacts": "Contatos",
+      "contactsDescription": "Pessoas para procurar neste cliente, por local ou em toda a organização",
       "contracts": "Contratos",
       "contractsDescription": "Acordos recorrentes",
       "billing": "Cobrança",
@@ -3704,7 +3706,8 @@
       "title": "Dispositivos",
       "assigned": "dispositivos atribuídos a este site",
       "viewAll": "Ver todos os dispositivos"
-    }
+    },
+    "allContactsLink": "Todos os contatos deste cliente"
   },
   "siteForm": {
     "description": "Apenas o nome do site é obrigatório. Endereço e contato são opcionais – você pode preenchê-los mais tarde.",
@@ -4089,5 +4092,154 @@
     "saveFailed": "Não foi possível salvar as configurações de controle de tempo",
     "minSessionRange": "A duração mínima da sessão deve estar entre {{min}} e {{max}} segundos",
     "mergeGapRange": "O intervalo de mesclagem deve estar entre {{min}} e {{max}} minutos"
+  },
+  "contactsCard": {
+    "title": "Contatos",
+    "description": "As pessoas que sua equipe procura neste cliente. Um contato pode ficar preso a um local ou valer para toda a organização.",
+    "organizationLevel": "Organização",
+    "unknownSite": "Um local que você não pode ver",
+    "empty": "Nenhum contato ainda. Adicione um ou importe um CSV da sua ferramenta anterior.",
+    "loading": "Carregando contatos…",
+    "confirmDelete": "Excluir {{name}}? Isso não pode ser desfeito.",
+    "actions": {
+      "add": "Adicionar contato",
+      "import": "Importar CSV",
+      "edit": "Editar",
+      "delete": "Excluir",
+      "save": "Salvar contato",
+      "saving": "Salvando…",
+      "cancel": "Cancelar",
+      "retry": "Tentar novamente"
+    },
+    "filters": {
+      "site": "Filtrar por local",
+      "role": "Filtrar por função",
+      "allSites": "Todos os locais",
+      "allRoles": "Todas as funções"
+    },
+    "columns": {
+      "name": "Nome",
+      "reach": "Como falar com a pessoa",
+      "jobTitle": "Cargo",
+      "roles": "Funções",
+      "site": "Pertence a",
+      "actions": "Ações"
+    },
+    "primary": {
+      "organization": "Principal (organização)",
+      "site": "Principal ({{site}})"
+    },
+    "roles": {
+      "billing": "Faturamento",
+      "technical": "Técnico",
+      "escalation": "Escalonamento",
+      "admin": "Administração",
+      "site": "Local",
+      "afterHours": "Fora do horário",
+      "portal": "Portal do cliente"
+    },
+    "form": {
+      "addHeading": "Novo contato",
+      "editHeading": "Editar contato",
+      "identifierRequired": "Preencha pelo menos um: nome, endereço de e-mail, telefone ou celular.",
+      "fields": {
+        "name": "Nome",
+        "email": "Endereço de e-mail",
+        "phone": "Telefone",
+        "mobile": "Celular",
+        "title": "Cargo",
+        "site": "Pertence a",
+        "roles": "Funções",
+        "notes": "Observações",
+        "isPrimary": "Tornar este o contato principal do escopo escolhido acima"
+      }
+    },
+    "pagination": {
+      "summary": "Exibindo {{from}} a {{to}} de {{total}}",
+      "previous": "Anterior",
+      "next": "Próxima"
+    },
+    "toasts": {
+      "created": "Contato adicionado",
+      "updated": "Contato salvo",
+      "deleted": "Contato excluído"
+    },
+    "errors": {
+      "load": "Não foi possível carregar os contatos desta organização.",
+      "create": "Não foi possível adicionar o contato.",
+      "update": "Não foi possível salvar o contato.",
+      "delete": "Não foi possível excluir o contato."
+    }
+  },
+  "bulkContactImport": {
+    "title": "Importar contatos de um CSV",
+    "description": "Envie uma exportação de contatos do seu RMM ou PSA anterior. Cada linha fica arquivada nesta organização.",
+    "dropzone": "Solte um arquivo CSV aqui ou clique para procurar",
+    "dropzoneHint": "Mapeie pelo menos um: nome, endereço de e-mail, telefone ou celular — sem isso não existe contato.",
+    "actions": {
+      "close": "Fechar",
+      "preview": "Conferir {{count}} linhas",
+      "previewing": "Conferindo…",
+      "import": "Importar {{count}} selecionadas",
+      "importing": "Importando…"
+    },
+    "mapping": {
+      "heading": "Mapeamento de colunas",
+      "unmapped": "Não mapeada",
+      "identifierRequired": "Mapeie uma coluna de nome, endereço de e-mail, telefone ou celular para continuar.",
+      "fields": {
+        "name": "Nome",
+        "email": "Endereço de e-mail",
+        "phone": "Telefone",
+        "mobile": "Celular",
+        "title": "Cargo",
+        "roles": "Funções",
+        "site": "Local",
+        "externalId": "Identificador do contato no sistema de origem",
+        "externalSystem": "Sistema de origem"
+      }
+    },
+    "mode": {
+      "label": "Contatos já vinculados",
+      "skip": "Deixar como estão",
+      "update": "Mesclar o arquivo neles"
+    },
+    "preview": {
+      "heading": "O que vai acontecer"
+    },
+    "summary": {
+      "imported": "{{count}} adicionados",
+      "updated": "{{count}} mesclados",
+      "skipped": "{{count}} sem alteração",
+      "failed": "{{count}} recusadas",
+      "allFailed": "Nada foi importado — {{summary}}."
+    },
+    "failures": {
+      "title_one": "{{count}} linha foi recusada",
+      "title_other": "{{count}} linhas foram recusadas"
+    },
+    "errors": {
+      "previewFailed": "Não foi possível comparar o arquivo com os contatos existentes.",
+      "importFailed": "Não foi possível importar os contatos selecionados."
+    }
+  },
+  "contactImportPreview": {
+    "selectAll": "Selecionar todas as linhas novas e vinculadas",
+    "organizationLevel": "Organização",
+    "matches": "corresponde a “{{name}}”",
+    "columns": {
+      "name": "Nome",
+      "email": "Endereço de e-mail",
+      "site": "Local",
+      "status": "Resultado"
+    },
+    "badges": {
+      "create": "Novo",
+      "linkMatch": "Já vinculado",
+      "emailMatch": "E-mail coincide — confirme",
+      "nameMatch": "Nome coincide — confirme",
+      "conflict": "Conflito",
+      "orgNotFound": "Organização não encontrada"
+    }
   }
 }

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -4097,7 +4097,7 @@
     "title": "Kişiler",
     "description": "Ekibinizin bu müşteride ulaştığı kişiler. Bir kişi tek bir siteye bağlanabilir ya da kuruluşun tamamı için geçerli olabilir.",
     "organizationLevel": "Kuruluş",
-    "unknownSite": "Göremediğiniz bir site",
+    "unknownSite": "Site kullanılamıyor",
     "empty": "Henüz kişi yok. Bir tane ekleyin ya da önceki aracınızdan bir CSV içe aktarın.",
     "loading": "Kişiler yükleniyor…",
     "confirmDelete": "{{name}} silinsin mi? Bu geri alınamaz.",
@@ -4166,6 +4166,7 @@
     },
     "errors": {
       "load": "Bu kuruluşun kişileri yüklenemedi.",
+      "sites": "Bu kuruluşun siteleri yüklenemedi. Site adları ve site filtresi yüklenene kadar kullanılamaz.",
       "create": "Kişi eklenemedi.",
       "update": "Kişi kaydedilemedi.",
       "delete": "Kişi silinemedi."
@@ -4187,6 +4188,9 @@
       "heading": "Sütun eşleme",
       "unmapped": "Eşlenmedi",
       "identifierRequired": "Devam etmek için ad, e-posta adresi, telefon veya cep telefonu sütunu eşleyin.",
+      "droppedRows_one": "{{count}} satır atlandı: ad, e-posta adresi, telefon veya cep telefonu yok.",
+      "droppedRows_other": "{{count}} satır atlandı: ad, e-posta adresi, telefon veya cep telefonu yok.",
+      "tooManyRows": "Bu dosya {{count}} satır eşliyor; tek bir içe aktarmanın kabul ettiği {{max}} satırdan fazla. Dosyayı daha küçük parçalara bölün.",
       "fields": {
         "name": "Ad",
         "email": "E-posta adresi",
@@ -4212,15 +4216,37 @@
       "updated": "{{count}} birleştirildi",
       "skipped": "{{count}} değiştirilmedi",
       "failed": "{{count}} reddedildi",
-      "allFailed": "Hiçbir şey içe aktarılmadı — {{summary}}."
+      "allFailed": "Hiçbir şey içe aktarılmadı — {{summary}}.",
+      "nothingImported": "Hiçbir şey içe aktarılmadı: {{count}} zaten bağlı.",
+      "nothingImportedEmpty": "Hiçbir kayıt içe aktarılmadı."
     },
     "failures": {
       "title_one": "{{count}} satır reddedildi",
       "title_other": "{{count}} satır reddedildi"
     },
+    "skipped": {
+      "title_one": "{{count}} satır olduğu gibi bırakıldı",
+      "title_other": "{{count}} satır olduğu gibi bırakıldı",
+      "reasons": {
+        "alreadyLinked": "zaten mevcut bir kişiye bağlı"
+      }
+    },
+    "errorCodes": {
+      "rowConflict": "Satır, burada zaten bulunan kişiler karşısında belirsiz.",
+      "orgNotFound": "Bu kuruluş artık erişiminizde değil.",
+      "annotationChanged": "Bu satır önizlemeden bu yana değişti. Dosyayı yeniden denetleyin.",
+      "matchChanged": "Bu satır artık başka bir kişiyle eşleşiyor. Dosyayı yeniden denetleyin.",
+      "matchUnconfirmed": "Eşleşmeyi onaylamak için satırı işaretleyip yeniden içe aktarın.",
+      "writeFailed": "Veritabanı yazma işlemini reddetti. Bu satır için hiçbir şey kaydedilmedi.",
+      "noIdentifier": "Satırda ad, e-posta adresi, telefon veya cep telefonu kalmıyor.",
+      "invalidRole": "Satır, Breeze’in tanımadığı bir rol belirtiyor.",
+      "siteNotInOrg": "Bu satırdaki site bu kuruluşa ait değil."
+    },
     "errors": {
       "previewFailed": "Dosya mevcut kişilerle karşılaştırılamadı.",
-      "importFailed": "Seçilen kişiler içe aktarılamadı."
+      "importFailed": "Seçilen kişiler içe aktarılamadı.",
+      "fileRead": "Bu dosya okunamadı. Lütfen yeniden seçin.",
+      "noColumns": "Bu dosyada başlık satırı yok, dolayısıyla eşlenecek bir şey de yok."
     }
   },
   "contactImportPreview": {

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -3105,6 +3105,8 @@
       "organization": "Organizasyon",
       "general": "Genel",
       "generalDescription": "Profil ve varsayılanlar",
+      "contacts": "Kişiler",
+      "contactsDescription": "Bu müşteride ulaşılacak kişiler; siteye göre veya kuruluş genelinde",
       "contracts": "Sözleşmeler",
       "contractsDescription": "Yinelenen anlaşmalar",
       "billing": "Faturalandırma",
@@ -3704,7 +3706,8 @@
       "title": "Cihazlar\nBu siteye atanmış ",
       "assigned": "cihazlar",
       "viewAll": "Tüm cihazları görüntüle"
-    }
+    },
+    "allContactsLink": "Bu müşterinin tüm kişileri"
   },
   "siteForm": {
     "description": "Yalnızca site adı gereklidir. Adres ve iletişim bilgileri isteğe bağlıdır; bunları daha sonra doldurabilirsiniz.",
@@ -4089,5 +4092,154 @@
     "saveFailed": "Zaman takibi ayarları kaydedilemedi",
     "minSessionRange": "Minimum oturum süresi {{min}} ile {{max}} saniye arasında olmalıdır",
     "mergeGapRange": "Birleştirme aralığı {{min}} ile {{max}} dakika arasında olmalıdır"
+  },
+  "contactsCard": {
+    "title": "Kişiler",
+    "description": "Ekibinizin bu müşteride ulaştığı kişiler. Bir kişi tek bir siteye bağlanabilir ya da kuruluşun tamamı için geçerli olabilir.",
+    "organizationLevel": "Kuruluş",
+    "unknownSite": "Göremediğiniz bir site",
+    "empty": "Henüz kişi yok. Bir tane ekleyin ya da önceki aracınızdan bir CSV içe aktarın.",
+    "loading": "Kişiler yükleniyor…",
+    "confirmDelete": "{{name}} silinsin mi? Bu geri alınamaz.",
+    "actions": {
+      "add": "Kişi ekle",
+      "import": "CSV içe aktar",
+      "edit": "Düzenle",
+      "delete": "Sil",
+      "save": "Kişiyi kaydet",
+      "saving": "Kaydediliyor…",
+      "cancel": "Vazgeç",
+      "retry": "Yeniden dene"
+    },
+    "filters": {
+      "site": "Siteye göre süz",
+      "role": "Role göre süz",
+      "allSites": "Tüm siteler",
+      "allRoles": "Tüm roller"
+    },
+    "columns": {
+      "name": "Ad",
+      "reach": "Nasıl ulaşılır",
+      "jobTitle": "Unvan",
+      "roles": "Roller",
+      "site": "Bağlı olduğu yer",
+      "actions": "İşlemler"
+    },
+    "primary": {
+      "organization": "Birincil (kuruluş)",
+      "site": "Birincil ({{site}})"
+    },
+    "roles": {
+      "billing": "Faturalama",
+      "technical": "Teknik",
+      "escalation": "Yükseltme",
+      "admin": "Yönetim",
+      "site": "Site",
+      "afterHours": "Mesai dışı",
+      "portal": "Müşteri portalı"
+    },
+    "form": {
+      "addHeading": "Yeni kişi",
+      "editHeading": "Kişiyi düzenle",
+      "identifierRequired": "Ad, e-posta adresi, telefon veya cep telefonundan en az birini doldurun.",
+      "fields": {
+        "name": "Ad",
+        "email": "E-posta adresi",
+        "phone": "Telefon",
+        "mobile": "Cep telefonu",
+        "title": "Unvan",
+        "site": "Bağlı olduğu yer",
+        "roles": "Roller",
+        "notes": "Notlar",
+        "isPrimary": "Yukarıda seçilen kapsam için birincil kişi yap"
+      }
+    },
+    "pagination": {
+      "summary": "{{total}} kayıttan {{from}}-{{to}} arası gösteriliyor",
+      "previous": "Önceki",
+      "next": "Sonraki"
+    },
+    "toasts": {
+      "created": "Kişi eklendi",
+      "updated": "Kişi kaydedildi",
+      "deleted": "Kişi silindi"
+    },
+    "errors": {
+      "load": "Bu kuruluşun kişileri yüklenemedi.",
+      "create": "Kişi eklenemedi.",
+      "update": "Kişi kaydedilemedi.",
+      "delete": "Kişi silinemedi."
+    }
+  },
+  "bulkContactImport": {
+    "title": "CSV dosyasından kişi içe aktar",
+    "description": "Önceki RMM veya PSA aracınızdan aldığınız kişi dışa aktarımını yükleyin. Her satır bu kuruluşun altına kaydedilir.",
+    "dropzone": "Buraya bir CSV dosyası bırakın veya göz atmak için tıklayın",
+    "dropzoneHint": "Ad, e-posta adresi, telefon veya cep telefonundan en az birini eşleyin; biri olmadan kişi oluşmaz.",
+    "actions": {
+      "close": "Kapat",
+      "preview": "{{count}} satırı denetle",
+      "previewing": "Denetleniyor…",
+      "import": "Seçilen {{count}} satırı içe aktar",
+      "importing": "İçe aktarılıyor…"
+    },
+    "mapping": {
+      "heading": "Sütun eşleme",
+      "unmapped": "Eşlenmedi",
+      "identifierRequired": "Devam etmek için ad, e-posta adresi, telefon veya cep telefonu sütunu eşleyin.",
+      "fields": {
+        "name": "Ad",
+        "email": "E-posta adresi",
+        "phone": "Telefon",
+        "mobile": "Cep telefonu",
+        "title": "Unvan",
+        "roles": "Roller",
+        "site": "Site",
+        "externalId": "Kaynak sistemdeki kişi kimliği",
+        "externalSystem": "Kaynak sistem"
+      }
+    },
+    "mode": {
+      "label": "Halihazırda bağlı kişiler",
+      "skip": "Olduğu gibi bırak",
+      "update": "Dosyayı onlarla birleştir"
+    },
+    "preview": {
+      "heading": "Ne olacak"
+    },
+    "summary": {
+      "imported": "{{count}} eklendi",
+      "updated": "{{count}} birleştirildi",
+      "skipped": "{{count}} değiştirilmedi",
+      "failed": "{{count}} reddedildi",
+      "allFailed": "Hiçbir şey içe aktarılmadı — {{summary}}."
+    },
+    "failures": {
+      "title_one": "{{count}} satır reddedildi",
+      "title_other": "{{count}} satır reddedildi"
+    },
+    "errors": {
+      "previewFailed": "Dosya mevcut kişilerle karşılaştırılamadı.",
+      "importFailed": "Seçilen kişiler içe aktarılamadı."
+    }
+  },
+  "contactImportPreview": {
+    "selectAll": "Yeni ve bağlı tüm satırları seç",
+    "organizationLevel": "Kuruluş",
+    "matches": "“{{name}}” ile eşleşiyor",
+    "columns": {
+      "name": "Ad",
+      "email": "E-posta adresi",
+      "site": "Site",
+      "status": "Sonuç"
+    },
+    "badges": {
+      "create": "Yeni",
+      "linkMatch": "Zaten bağlı",
+      "emailMatch": "E-posta eşleşmesi — onaylayın",
+      "nameMatch": "Ad eşleşmesi — onaylayın",
+      "conflict": "Çakışma",
+      "orgNotFound": "Kuruluş bulunamadı"
+    }
   }
 }


### PR DESCRIPTION
W04 is the browser half of organization contacts. W02 shipped the CRUD routes, the CSV importer and the `add_contact` AI tool; until now none of it had a UI, and the migration guides still told partners that Breeze could not create contacts at all.

## What this adds

**Contacts tab** (`/settings/organizations/<id>#contacts`) — a new section of the existing organization settings shell, between General and Contracts. No new Astro page.

**`ContactsCard.tsx`** — the tab's whole content. Lists contacts with role badges, site attribution and a per-scope primary marker; filters by site (including `siteId=none` for organization-level) and by role; paginates; adds, edits and deletes; and hosts the CSV importer inline.

**`BulkContactImport.tsx` + `ContactImportPreviewTable.tsx`** — CSV → column mapping with auto-guess → preview → commit, with the fuzzy-match acknowledgement handshake done for the operator.

**Site detail link** — the site page keeps its single Primary Contact editor (it writes through the compatibility projection server-side) and gains a link to the org's full list.

**Docs** — the three guides that asserted "Breeze cannot create contacts programmatically today" are corrected, six guides that were silent gain coverage, and the toolkit and API reference document the endpoints.

## Decisions

**Tab placement.** `#contacts` sits in the Organization group between General and Contracts — people before paperwork, alongside the other org-level records. Mounted *without* `onDirty` for the same reason Remote Access is (#3432): the card persists every change through its own request and holds no draft state, so an onDirty channel could only strand the page as permanently unsaved.

**Primary UX via refetch, not local patching.** Promoting a primary demotes the previous holder *in the same scope* server-side, where a scope is either the organization (`siteId` null) or one site. No client-side patch reproduces that without re-implementing the scope rule, so every mutation refetches. The marker reads "Primary (organization)" or "Primary (&lt;site&gt;)" accordingly.

**Site picker source.** Sites come from an independent `GET /orgs/sites?organizationId=<tab org>`, deliberately **not** `useOrgStore().sites`. The store holds the *globally selected* org's sites, which is a different org whenever an admin opens one tenant's settings while another is selected in the header — a stale list there would mislabel every attribution on screen.

**Warning rendering.** The importer's `warning` is a non-fatal disclosure: the row still applies exactly as annotated. It renders **amber beside the badge with the checkbox left enabled**, visually distinct from the red `conflictReason` on a row that cannot be applied. That distinction is the field's whole purpose — a deliberate near-duplicate that renders as an ordinary fresh contact is indistinguishable from an import mistake.

**Its own `mode` copy.** `bulkContactImport.mode.*` rather than reusing the org importer's strings: "Skip (leave untouched)" / "Update from file" reads wrong for contacts, where the choice is what happens to an *already-linked person*. New keys say "Leave them as they are" / "Merge the file into them".

**A separate preview table, not a generalized one.** `ContactImportPreviewTable` is a sibling of `OrgImportPreviewTable`, not a refactor of it. The two share a workflow but not a row contract, an annotation vocabulary, or a selection rule: `link-match` here needs no acknowledgement (the durable external link *is* the acknowledgement), the two fuzzy annotations must pin the contact they matched, and `org-not-found` has no org-importer analogue. Folding them together would produce a union type whose every branch is `if (kind === 'contact')`.

**Selection mirrors the server's refusals.** `conflict` and `org-not-found` are absent from the commit enum, so a row carrying either as an acknowledgement fails Zod and rejects the **whole batch** — those rows are never selectable. Select-all spans only `create` + `link-match`. And `toContactCommitRow` drops a fuzzy acknowledgement wholesale when there is no `contactId` to pin, because the server requires `expectedContactId` alongside it and would otherwise refuse every other row in the file too.

**Blank means clear in the form, "no data" in the importer.** The form sends an explicit `null` for an emptied box — every field it renders is one the operator can see. The importer never clears, because a blank CSV cell is overwhelmingly an exporter with nothing to say. That split is the server's own documented ruling, not an inconsistency.

### Note: three paths in the wave brief were wrong

Built against the shipped API, not the brief. Update and delete are `PATCH`/`DELETE /orgs/contacts/:contactId` — no organization in the path, because the server re-asserts reach from the contact's own scope. The importer is `POST /orgs/contacts/import{,/preview}`, not organization-scoped either; each row names its own organization, and this UI pins every row to the tab's org.

## Tests

Red-first throughout. Two assertions were additionally mutation-checked (removing `setPage(1)` and swapping `nullable()` for a raw string each reddened exactly the tests that claim them).

| Suite | Files | Tests |
|---|---|---|
| `ContactsCard` | 1 | 19 |
| `BulkContactImport` | 1 | 12 |
| `ContactImportPreviewTable` | 1 | 19 |
| `OrgSettingsPage` + `SiteDetailPage` (extended) | 2 | 26 |
| guards + i18n (`no-silent-mutations`, `no-hash-in-usestate`, `src/lib/i18n`) | 9 | 274 |
| **full `apps/web` suite** | **697** | **7279** |

Full suite green; `npx tsc --noEmit` and `npx eslint` both exit 0. One `VulnerabilityTable` failure appeared in the first full run and did not reproduce in a second full run or in isolation — an ordering flake, untouched by this branch.

Three files are registered in `no-silent-mutations` `TARGET_GLOBS` (a literal file list, so each needs its own entry) and the count assertion moved 108 → 111.

### i18n

106 new leaves in all eight catalogs with identical key sets and interpolation-token multisets. Five `settings.json` duplicate baselines are bumped by exactly the count each locale gained, with the reason on each — every one is a single word whose honest translation *is* the English (de-DE "Name" ×4, es-419 "Roles" ×3, fr-FR/fr-CA "Contacts" + "Site" ×5, tr-TR "Site" ×3). it-IT and pt-BR needed no bump. Distorting a correct translation to dodge the check would have been the worse trade.

pt-BR strings are machine-drafted pending native review
es-419, fr-FR, fr-CA, de-DE, and it-IT strings are machine-drafted pending native review

## Docs touched

`astro build` verified green at 168 pages, with the new `#recipe-1c--import-contacts` anchor present in the built HTML and every inbound link to it resolving.

- `migration/atera.mdx`, `migration/connectwise-automate.mdx`, `migration/syncro.mdx` — the false "cannot create contacts" rows, plus the Phase 0 export steps that lumped contacts in with ticket/invoice history that genuinely does not migrate.
- `migration/datto-rmm.mdx`, `kaseya-vsa.mdx`, `n-central.mdx`, `ninjaone.mdx`, `other-rmms.mdx`, `overview.mdx` — were silent; each gains a row or step in its own shape. Where the incumbent's own contact object could not be verified (Datto RMM, N-central) the left column stays `—` rather than inventing a term.
- `migration/toolkit.mdx` — new Recipe 1c: row fields, the six annotations, the `expectedAnnotation` + `expectedContactId` handshake, the non-fatal `warning`, `mode` skip/update, merge-never-clears, the 1,000-row cap, and the nine machine-readable error codes.
- `reference/organizations-and-sites.mdx` — a Contacts section and a Contact Endpoints table, including the ruling that writes need `organizations:write` **plus MFA** but deliberately not `sites:write`, and an Aside recording that `organizations.billingContact` / `sites.contact` survive as compatibility projections of the primary contact.

## Follow-ups noticed, not fixed here

- `migration/overview.mdx` Phase 2 still says "Breeze has no bulk import UI today", which `toolkit.mdx` Recipe 1 already contradicts. Predates this wave.
- The new Contacts tab route may warrant a `scripts/docs-review/mapping.json` help-panel entry.

Closes #4528
Refs #3258

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015tHmJsqrTy5iHcqgpadtMp
