### PR TITLE
perf(api): bounded nightly audit-chain verification — incremental from the anchor + rolling 30-night re-scan

### DIFF
--- a/apps/api/migrations/2026-10-03-audit-chain-verify-range.sql
+++ b/apps/api/migrations/2026-10-03-audit-chain-verify-range.sql
@@ -1,0 +1,264 @@
+-- Bounded audit-chain verification (incremental + rolling re-scan).
+--
+-- WHY
+-- ---
+-- audit_log_verify_chain(org) (2026-06-11-h) walks EVERY audit_log_chain row
+-- for the org, point-reads the matching audit_logs row and recomputes both
+-- hashes, then makes a second anti-join pass over audit_logs for unsealed
+-- rows. That is O(total chain) per org per night. Measured on the US
+-- production database on 2026-09-02 (5M audit rows, 4.2 GB + 2.7 GB chain,
+-- one org with 2.4M chain rows, 1 vCPU / 391 MB shared_buffers): 865 calls
+-- over 66h consumed 118,000s of execution (mean 136s, max 2.2h). The daily
+-- sweep ran ~13h, its random reads evicted the buffer cache (hit ratio 79%),
+-- and every other query on the primary — including the postgres_exporter
+-- scrape, which then tripped DOPostgresExporterDown — slowed down with it.
+--
+-- WHAT
+-- ----
+-- (1) audit_log_verify_chain_range(org, from_seq, to_seq): the chain-row
+--     checks of the full walk (linkage, chain hash, content hash against the
+--     live audit row) restricted to chain_seq BETWEEN from_seq AND to_seq.
+--     The linkage check is seeded from the row immediately BEFORE from_seq;
+--     when there is none the first row's prev is the trusted anchor, exactly
+--     as the full function treats a retention-pruned prefix. It does NOT look
+--     for unsealed audit rows — that is the caller's job (see below), because
+--     an unsealed row has no chain_seq to be "in range".
+-- (2) audit_log_verify_chain_incremental(org, slices, slice_index, block_rows):
+--     the nightly plan the job runs.
+--       a. INCREMENTAL — from the org's SECOND-latest anchor head to the live
+--          head (the latest anchor if only one exists). The anchor job
+--          (2026-06-13-c, 04:48 UTC) records the head after this job (04:13)
+--          has run, so starting one anchor back means a night whose verify
+--          failed or was skipped for the org is still covered the next night
+--          at roughly twice the daily row cost. Starting AT the anchored row
+--          (not after it) re-proves the watermark's own linkage and content.
+--          An org with no anchor yet gets the full walk (new, therefore small).
+--       b. UNSEALED ROWS, recent — audit_logs rows in the incremental window
+--          (timestamp >= first sealed_at of the range, open-ended) that have no
+--          chain row. audit_logs.timestamp can be an agent-supplied event time,
+--          so this is only a fast path for the common forge (default `now()`
+--          timestamp); the exhaustive check is (d).
+--       c. ROLLING RE-SCAN — the chain_seq space is cut into fixed blocks of
+--          `block_rows` sequence values; block b is re-verified on nights where
+--          b % slices = slice_index. Block membership never moves with min/max
+--          or retention, so with the job passing (utc-epoch-day % slices) every
+--          historical row's content hash is re-checked at least once every
+--          `slices` nights, with contiguous (cheap) ranges, no persisted cursor.
+--       d. FULL UNSEALED SWEEP — on slice 0 only, the same anti-join the full
+--          walk does. Once per `slices` nights per org.
+--     The result contract (broken_id, expected, actual) is unchanged so the
+--     job's incident path is untouched.
+--
+-- THREAT MODEL DELTA
+-- ------------------
+-- The daily full walk caught an edited audit_logs row the same night; the
+-- rolling re-scan catches it within `slices` nights. Everything a forger can
+-- do to the CHAIN (edit / delete / re-seal) still surfaces the same night: a
+-- rewritten checksum at row k breaks row k+1's linkage inside the incremental
+-- range or moves the head checksum, which audit_chain_verify_anchor() flags;
+-- a forged anchor inserted to skip the incremental range (head_chain_seq
+-- ahead of the live head) trips that same check as seq_regressed. breeze_app
+-- cannot UPDATE or DELETE either table (REVOKE + immutability triggers), so
+-- the residual window only applies to a superuser-level compromise, for
+-- which the anchor is the primary control anyway.
+--
+-- Idempotent: CREATE OR REPLACE only. No inner BEGIN/COMMIT (autoMigrate
+-- wraps each file).
+
+CREATE OR REPLACE FUNCTION audit_log_verify_chain_range(
+  p_org_id uuid,
+  p_from_seq bigint,
+  p_to_seq bigint
+)
+RETURNS TABLE (broken_id uuid, expected varchar, actual varchar)
+LANGUAGE plpgsql AS $$
+DECLARE
+  c record;
+  a audit_logs;
+  prev varchar(128) := NULL;
+  is_first boolean := true;
+  expected_hash varchar(128);
+BEGIN
+  IF p_from_seq IS NULL OR p_to_seq IS NULL OR p_to_seq < p_from_seq THEN
+    RETURN;
+  END IF;
+
+  -- Seed the linkage check from the row immediately before the range. When
+  -- there is none (range starts at the org's first surviving entry) the first
+  -- row's prev is the trusted anchor and is not compared — same rule as the
+  -- full walk.
+  SELECT ch.chain_checksum INTO prev
+  FROM audit_log_chain ch
+  WHERE ch.org_id IS NOT DISTINCT FROM p_org_id
+    AND ch.chain_seq < p_from_seq
+  ORDER BY ch.chain_seq DESC
+  LIMIT 1;
+  is_first := NOT FOUND;
+
+  FOR c IN
+    SELECT ch.chain_seq, ch.audit_id, ch.content_checksum, ch.prev_chain_checksum,
+           ch.chain_checksum
+    FROM audit_log_chain ch
+    WHERE ch.org_id IS NOT DISTINCT FROM p_org_id
+      AND ch.chain_seq BETWEEN p_from_seq AND p_to_seq
+    ORDER BY ch.chain_seq
+  LOOP
+    -- Linkage.
+    IF NOT is_first AND c.prev_chain_checksum IS DISTINCT FROM prev THEN
+      broken_id := c.audit_id; expected := prev; actual := c.prev_chain_checksum;
+      RETURN NEXT;
+    END IF;
+    is_first := false;
+
+    -- Chain-hash integrity.
+    expected_hash := encode(sha256(convert_to(
+      COALESCE(c.prev_chain_checksum, '') || '|' || c.content_checksum, 'UTF8')), 'hex');
+    IF c.chain_checksum IS DISTINCT FROM expected_hash THEN
+      broken_id := c.audit_id; expected := expected_hash; actual := c.chain_checksum;
+      RETURN NEXT;
+    END IF;
+
+    -- Content integrity, recomputed from the live audit row.
+    SELECT * INTO a FROM audit_logs WHERE id = c.audit_id;
+    IF NOT FOUND THEN
+      broken_id := c.audit_id; expected := c.content_checksum; actual := NULL;
+      RETURN NEXT;
+    ELSE
+      expected_hash := encode(sha256(convert_to(audit_log_canonical_payload(a, NULL), 'UTF8')), 'hex');
+      IF expected_hash IS DISTINCT FROM c.content_checksum THEN
+        broken_id := c.audit_id; expected := expected_hash; actual := c.content_checksum;
+        RETURN NEXT;
+      END IF;
+    END IF;
+
+    prev := c.chain_checksum;
+  END LOOP;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION audit_log_verify_chain_incremental(
+  p_org_id uuid,
+  p_slices integer DEFAULT 30,
+  p_slice_index integer DEFAULT 0,
+  p_block_rows bigint DEFAULT 100000
+)
+RETURNS TABLE (broken_id uuid, expected varchar, actual varchar)
+LANGUAGE plpgsql AS $$
+DECLARE
+  a audit_logs;
+  v_anchor_head bigint;
+  v_min_seq bigint;
+  v_max_seq bigint;
+  v_from_seq bigint;
+  v_window_start timestamptz;
+  v_slices integer := GREATEST(COALESCE(p_slices, 30), 1);
+  v_slice integer := ((COALESCE(p_slice_index, 0) % GREATEST(COALESCE(p_slices, 30), 1))
+                      + GREATEST(COALESCE(p_slices, 30), 1)) % GREATEST(COALESCE(p_slices, 30), 1);
+  v_block bigint := GREATEST(COALESCE(p_block_rows, 100000), 1);
+  v_block_no bigint;
+  v_block_from bigint;
+  v_block_to bigint;
+BEGIN
+  SELECT min(ch.chain_seq), max(ch.chain_seq) INTO v_min_seq, v_max_seq
+  FROM audit_log_chain ch
+  WHERE ch.org_id IS NOT DISTINCT FROM p_org_id;
+
+  IF v_max_seq IS NULL THEN
+    -- Empty chain: the only meaningful check is for unsealed rows, and the
+    -- full walk is exactly that (and cheap) when there is no chain.
+    RETURN QUERY SELECT * FROM audit_log_verify_chain(p_org_id);
+    RETURN;
+  END IF;
+
+  -- Second-latest anchor head for this org (latest if only one). NULL org =
+  -- system chain.
+  SELECT an.head_chain_seq INTO v_anchor_head
+  FROM audit_chain_anchors an
+  WHERE an.org_id IS NOT DISTINCT FROM p_org_id
+  ORDER BY an.anchor_seq DESC
+  OFFSET 1 LIMIT 1;
+  IF NOT FOUND THEN
+    SELECT an.head_chain_seq INTO v_anchor_head
+    FROM audit_chain_anchors an
+    WHERE an.org_id IS NOT DISTINCT FROM p_org_id
+    ORDER BY an.anchor_seq DESC
+    LIMIT 1;
+  END IF;
+
+  IF v_anchor_head IS NULL THEN
+    -- No watermark yet: new org, walk it all.
+    RETURN QUERY SELECT * FROM audit_log_verify_chain(p_org_id);
+    RETURN;
+  END IF;
+
+  -- (a) Incremental: from the anchored row itself to the live head. Clamped
+  -- into [min, max] so a retention-pruned anchor starts at the first surviving
+  -- row and a forged, ahead-of-head anchor still verifies the live head (the
+  -- anchor job pages on that anchor separately).
+  v_from_seq := LEAST(GREATEST(v_anchor_head, v_min_seq), v_max_seq);
+  RETURN QUERY
+    SELECT * FROM audit_log_verify_chain_range(p_org_id, v_from_seq, v_max_seq);
+
+  -- (b) Recent unsealed rows: anything stamped at or after the start of the
+  -- incremental window (1 minute of slack for the transaction-start vs
+  -- commit skew between audit_logs.timestamp and sealed_at) with no chain row.
+  SELECT ch.sealed_at - interval '1 minute' INTO v_window_start
+  FROM audit_log_chain ch
+  WHERE ch.org_id IS NOT DISTINCT FROM p_org_id AND ch.chain_seq = v_from_seq;
+  IF v_window_start IS NOT NULL THEN
+    FOR a IN
+      SELECT al.* FROM audit_logs al
+      WHERE al.org_id IS NOT DISTINCT FROM p_org_id
+        AND al.timestamp >= v_window_start
+        AND NOT EXISTS (SELECT 1 FROM audit_log_chain ch WHERE ch.audit_id = al.id)
+      ORDER BY al.timestamp, al.id
+    LOOP
+      broken_id := a.id; expected := 'sealed'; actual := NULL;
+      RETURN NEXT;
+    END LOOP;
+  END IF;
+
+  -- (c) Rolling re-scan of the historical chain strictly below the anchored
+  -- row, in fixed blocks of the global chain_seq space. Block b is due when
+  -- b % slices = slice.
+  IF v_anchor_head > v_min_seq THEN
+    v_block_no := v_min_seq / v_block;
+    WHILE v_block_no * v_block < v_anchor_head LOOP
+      IF v_block_no % v_slices = v_slice THEN
+        v_block_from := GREATEST(v_block_no * v_block, v_min_seq);
+        v_block_to := LEAST((v_block_no + 1) * v_block - 1, v_anchor_head - 1);
+        IF v_block_to >= v_block_from THEN
+          RETURN QUERY
+            SELECT * FROM audit_log_verify_chain_range(p_org_id, v_block_from, v_block_to);
+        END IF;
+      END IF;
+      v_block_no := v_block_no + 1;
+    END LOOP;
+  END IF;
+
+  -- (d) Exhaustive unsealed sweep once per cycle (slice 0): the same anti-join
+  -- the full walk performs, for rows whose timestamp is outside window (b).
+  IF v_slice = 0 THEN
+    FOR a IN
+      SELECT al.* FROM audit_logs al
+      WHERE al.org_id IS NOT DISTINCT FROM p_org_id
+        AND (v_window_start IS NULL OR al.timestamp < v_window_start)
+        AND NOT EXISTS (SELECT 1 FROM audit_log_chain ch WHERE ch.audit_id = al.id)
+      ORDER BY al.timestamp, al.id
+    LOOP
+      broken_id := a.id; expected := 'sealed'; actual := NULL;
+      RETURN NEXT;
+    END LOOP;
+  END IF;
+END;
+$$;
+
+-- breeze_app runs the nightly job under the system context; function EXECUTE
+-- is granted to PUBLIC by default so this is belt-and-braces only.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'breeze_app') THEN
+    GRANT EXECUTE ON FUNCTION audit_log_verify_chain_range(uuid, bigint, bigint) TO breeze_app;
+    GRANT EXECUTE ON FUNCTION audit_log_verify_chain_incremental(uuid, integer, integer, bigint) TO breeze_app;
+  END IF;
+END $$;

--- a/apps/api/src/__tests__/integration/audit-chain-verify-range.integration.test.ts
+++ b/apps/api/src/__tests__/integration/audit-chain-verify-range.integration.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Integration test for the BOUNDED audit-chain verifier
+ * (migration 2026-10-03-audit-chain-verify-range.sql).
+ *
+ * audit_log_verify_chain(org) walks the org's whole chain every night, which
+ * is O(total rows) and was measured at ~13h/day of random reads on the US
+ * production primary. The bounded plan verifies (a) everything after the org's
+ * latest anchor and (b) one rolling slice of the historical chain, and must
+ * detect the same tamper classes within the slice window.
+ *
+ * Runs against real Postgres through the `breeze_app` pool
+ * (withSystemDbAccessContext) so RLS and the append-only triggers apply.
+ * getTestDb() is the privileged harness pool used to FORGE tampers the app
+ * role can never perform.
+ */
+import './setup';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import { getTestDb } from './setup';
+import { createPartner, createOrganization } from './db-utils';
+
+interface BreakRow {
+  broken_id: string;
+  expected: string | null;
+  actual: string | null;
+}
+interface ChainRow {
+  chain_seq: number;
+  audit_id: string;
+}
+
+async function seedAuditRows(orgId: string, n: number, prefix = 'verify.seed.'): Promise<void> {
+  await withSystemDbAccessContext(async () => {
+    for (let i = 0; i < n; i++) {
+      await db.execute(sql`
+        INSERT INTO audit_logs (org_id, actor_type, actor_id, action, resource_type, result)
+        VALUES (${orgId}, 'system', gen_random_uuid(), ${prefix + i}, 'test', 'success')
+      `);
+    }
+  });
+}
+
+async function chainRows(orgId: string): Promise<ChainRow[]> {
+  const rows = (await getTestDb().execute(sql`
+    SELECT chain_seq, audit_id FROM audit_log_chain
+    WHERE org_id = ${orgId}::uuid ORDER BY chain_seq
+  `)) as unknown as ChainRow[];
+  return rows.map((r) => ({ ...r, chain_seq: Number(r.chain_seq) }));
+}
+
+async function writeAnchor(orgId: string): Promise<void> {
+  await withSystemDbAccessContext(async () => {
+    await db.execute(sql`SELECT anchor_seq FROM audit_chain_anchor_head(${orgId}::uuid)`);
+  });
+}
+
+/** What the nightly job runs (system context, breeze_app role). */
+async function verifyIncremental(
+  orgId: string,
+  slices: number,
+  sliceIndex: number,
+  blockRows = 1, // one chain_seq per block so tests can reason per row
+): Promise<BreakRow[]> {
+  return withSystemDbAccessContext(async () => {
+    const rows = (await db.execute(sql`
+      SELECT broken_id, expected, actual
+      FROM audit_log_verify_chain_incremental(
+        ${orgId}::uuid, ${slices}::int, ${sliceIndex}::int, ${blockRows}::bigint)
+    `)) as unknown as BreakRow[];
+    return rows;
+  });
+}
+
+async function verifyRange(orgId: string, from: number, to: number): Promise<BreakRow[]> {
+  return withSystemDbAccessContext(async () => {
+    const rows = (await db.execute(sql`
+      SELECT broken_id, expected, actual
+      FROM audit_log_verify_chain_range(${orgId}::uuid, ${from}::bigint, ${to}::bigint)
+    `)) as unknown as BreakRow[];
+    return rows;
+  });
+}
+
+async function verifyFull(orgId: string): Promise<BreakRow[]> {
+  return withSystemDbAccessContext(async () => {
+    const rows = (await db.execute(sql`
+      SELECT broken_id, expected, actual FROM audit_log_verify_chain(${orgId}::uuid)
+    `)) as unknown as BreakRow[];
+    return rows;
+  });
+}
+
+/** Superuser forge: edit an audit row's content without touching the chain. */
+async function tamperAuditContent(auditId: string): Promise<void> {
+  const sudo = getTestDb();
+  await sudo.execute(sql`ALTER TABLE audit_logs DISABLE TRIGGER audit_log_block_update`);
+  try {
+    await sudo.execute(sql`UPDATE audit_logs SET action = 'tampered' WHERE id = ${auditId}::uuid`);
+  } finally {
+    await sudo.execute(sql`ALTER TABLE audit_logs ENABLE TRIGGER audit_log_block_update`);
+  }
+}
+
+/** Superuser forge: rewrite a chain row's checksum (breaks its successor's link). */
+async function tamperChainChecksum(chainSeq: number): Promise<void> {
+  const sudo = getTestDb();
+  await sudo.execute(sql`ALTER TABLE audit_log_chain DISABLE TRIGGER audit_log_chain_block_update`);
+  try {
+    await sudo.execute(sql`
+      UPDATE audit_log_chain SET chain_checksum = repeat('0', 64) WHERE chain_seq = ${chainSeq}::bigint
+    `);
+  } finally {
+    await sudo.execute(sql`ALTER TABLE audit_log_chain ENABLE TRIGGER audit_log_chain_block_update`);
+  }
+}
+
+/** Superuser forge: drop the chain row for one audit row (leaves it unsealed). */
+async function unsealAuditRow(chainSeq: number): Promise<void> {
+  const sudo = getTestDb();
+  await sudo.execute(sql`ALTER TABLE audit_log_chain DISABLE TRIGGER audit_log_chain_block_delete`);
+  try {
+    await sudo.execute(sql`DELETE FROM audit_log_chain WHERE chain_seq = ${chainSeq}::bigint`);
+  } finally {
+    await sudo.execute(sql`ALTER TABLE audit_log_chain ENABLE TRIGGER audit_log_chain_block_delete`);
+  }
+}
+
+describe('audit_log_verify_chain_incremental / _range', () => {
+  let orgId: string;
+
+  beforeEach(async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    orgId = org.id;
+  });
+
+  it('reports clean for an intact chain in every mode', async () => {
+    await seedAuditRows(orgId, 4);
+    await writeAnchor(orgId);
+    await seedAuditRows(orgId, 3, 'verify.after.');
+    const rows = await chainRows(orgId);
+    expect(rows).toHaveLength(7);
+
+    expect(await verifyFull(orgId)).toEqual([]);
+    expect(await verifyRange(orgId, rows[0]!.chain_seq, rows[6]!.chain_seq)).toEqual([]);
+    for (let slice = 0; slice < 3; slice++) {
+      expect(await verifyIncremental(orgId, 3, slice)).toEqual([]);
+    }
+  });
+
+  it('falls back to the full walk for an org that has no anchor yet', async () => {
+    await seedAuditRows(orgId, 3);
+    const rows = await chainRows(orgId);
+    await tamperAuditContent(rows[0]!.audit_id);
+
+    const breaks = await verifyIncremental(orgId, 30, 5);
+    expect(breaks.map((b) => b.broken_id)).toEqual([rows[0]!.audit_id]);
+  });
+
+  it('catches a content edit above the anchor the same night, in every slice', async () => {
+    await seedAuditRows(orgId, 4);
+    await writeAnchor(orgId);
+    await seedAuditRows(orgId, 3, 'verify.after.');
+    const rows = await chainRows(orgId);
+    const victim = rows[5]!; // sealed after the anchor
+    await tamperAuditContent(victim.audit_id);
+
+    for (let slice = 0; slice < 30; slice += 7) {
+      const breaks = await verifyIncremental(orgId, 30, slice);
+      expect(breaks.map((b) => b.broken_id)).toEqual([victim.audit_id]);
+    }
+  });
+
+  it('re-proves the anchored head row itself every night', async () => {
+    await seedAuditRows(orgId, 3);
+    await writeAnchor(orgId);
+    const rows = await chainRows(orgId);
+    const head = rows[2]!;
+    await tamperAuditContent(head.audit_id);
+
+    const breaks = await verifyIncremental(orgId, 30, 0);
+    expect(breaks.map((b) => b.broken_id)).toEqual([head.audit_id]);
+  });
+
+  it('catches a content edit below the anchor within one pass over the slices', async () => {
+    await seedAuditRows(orgId, 10);
+    await writeAnchor(orgId);
+    await seedAuditRows(orgId, 2, 'verify.after.');
+    const rows = await chainRows(orgId);
+    const victim = rows[6]!; // historical, below the anchor (rows 0..9)
+    await tamperAuditContent(victim.audit_id);
+
+    const slices = 4;
+    const hits: number[] = [];
+    for (let slice = 0; slice < slices; slice++) {
+      const breaks = await verifyIncremental(orgId, slices, slice);
+      if (breaks.some((b) => b.broken_id === victim.audit_id)) hits.push(slice);
+      // No slice may report anything else.
+      expect(breaks.filter((b) => b.broken_id !== victim.audit_id)).toEqual([]);
+    }
+    expect(hits).toHaveLength(1);
+    // The pass with a single slice is a full historical re-scan.
+    expect((await verifyIncremental(orgId, 1, 0)).map((b) => b.broken_id)).toEqual([victim.audit_id]);
+  });
+
+  it('slice boundaries cover every historical row exactly once', async () => {
+    await seedAuditRows(orgId, 11); // prime count → uneven slices
+    await writeAnchor(orgId);
+    const rows = await chainRows(orgId);
+    const historical = rows.slice(0, 10); // everything strictly below the anchored head
+
+    for (const victim of historical) {
+      await tamperAuditContent(victim.audit_id);
+    }
+    const seen = new Map<string, number>();
+    for (let slice = 0; slice < 3; slice++) {
+      for (const b of await verifyIncremental(orgId, 3, slice)) {
+        seen.set(b.broken_id, (seen.get(b.broken_id) ?? 0) + 1);
+      }
+    }
+    expect([...seen.keys()].sort()).toEqual(historical.map((r) => r.audit_id).sort());
+    expect([...seen.values()].every((n) => n === 1)).toBe(true);
+  });
+
+  it('range seeds the linkage check from the row before the range', async () => {
+    await seedAuditRows(orgId, 4);
+    const rows = await chainRows(orgId);
+    await tamperChainChecksum(rows[1]!.chain_seq);
+
+    // Verifying only row 2: its prev must equal row 1's (now forged) checksum.
+    const breaks = await verifyRange(orgId, rows[2]!.chain_seq, rows[2]!.chain_seq);
+    expect(breaks.map((b) => b.broken_id)).toEqual([rows[2]!.audit_id]);
+    expect(breaks[0]!.expected).toBe('0'.repeat(64));
+
+    // A range that starts at the org's first row treats its prev as trusted.
+    expect(await verifyRange(orgId, rows[0]!.chain_seq, rows[0]!.chain_seq)).toEqual([]);
+  });
+
+  it('flags an unsealed audit row after the anchor', async () => {
+    await seedAuditRows(orgId, 2);
+    await writeAnchor(orgId);
+    await seedAuditRows(orgId, 2, 'verify.after.');
+    const rows = await chainRows(orgId);
+    const victim = rows[3]!; // newest
+    await unsealAuditRow(victim.chain_seq);
+
+    const breaks = await verifyIncremental(orgId, 30, 0);
+    expect(breaks).toEqual([{ broken_id: victim.audit_id, expected: 'sealed', actual: null }]);
+  });
+
+  it('flags a backdated unsealed historical row on the slice-0 sweep only', async () => {
+    // A row whose event timestamp is far older than its seal: the recent
+    // window (b) cannot see it, the exhaustive sweep (d) must.
+    await withSystemDbAccessContext(async () => {
+      await db.execute(sql`
+        INSERT INTO audit_logs (org_id, actor_type, actor_id, action, resource_type, result, timestamp)
+        VALUES (${orgId}, 'system', gen_random_uuid(), 'verify.backdated', 'test', 'success', now() - interval '10 days')
+      `);
+    });
+    await seedAuditRows(orgId, 3);
+    await writeAnchor(orgId);
+    await seedAuditRows(orgId, 1, 'verify.after.');
+    const rows = await chainRows(orgId);
+    const victim = rows[0]!;
+    await unsealAuditRow(victim.chain_seq);
+
+    const sweep = await verifyIncremental(orgId, 3, 0, 1000);
+    expect(sweep).toEqual([{ broken_id: victim.audit_id, expected: 'sealed', actual: null }]);
+    expect(await verifyIncremental(orgId, 3, 1, 1000)).toEqual([]);
+    expect(await verifyIncremental(orgId, 3, 2, 1000)).toEqual([]);
+  });
+
+  it('returns nothing for an inverted or empty range', async () => {
+    await seedAuditRows(orgId, 2);
+    const rows = await chainRows(orgId);
+    expect(await verifyRange(orgId, rows[1]!.chain_seq, rows[0]!.chain_seq)).toEqual([]);
+    expect(await verifyRange(orgId, rows[1]!.chain_seq + 1000, rows[1]!.chain_seq + 2000)).toEqual([]);
+  });
+});

--- a/apps/api/src/jobs/auditChainVerify.test.ts
+++ b/apps/api/src/jobs/auditChainVerify.test.ts
@@ -272,6 +272,105 @@ describe('auditChainVerify worker', () => {
     });
   });
 
+  describe('verify plan (incremental vs full)', () => {
+    const ORIGINAL_MODE = process.env.AUDIT_CHAIN_VERIFY_MODE;
+    const ORIGINAL_SLICES = process.env.AUDIT_CHAIN_VERIFY_RESCAN_SLICES;
+
+    function mockOrgs(orgIds: string[]) {
+      dbExecuteMock.mockResolvedValueOnce(orgIds.map((id) => ({ id })));
+    }
+
+    afterEach(() => {
+      if (ORIGINAL_MODE === undefined) delete process.env.AUDIT_CHAIN_VERIFY_MODE;
+      else process.env.AUDIT_CHAIN_VERIFY_MODE = ORIGINAL_MODE;
+      if (ORIGINAL_SLICES === undefined) delete process.env.AUDIT_CHAIN_VERIFY_RESCAN_SLICES;
+      else process.env.AUDIT_CHAIN_VERIFY_RESCAN_SLICES = ORIGINAL_SLICES;
+      vi.useRealTimers();
+    });
+
+    /** Flatten a drizzle `sql` tag into its text plus bound params, in order. */
+    function flatten(q: unknown): { text: string; params: unknown[] } {
+      const sqlObj = q as { queryChunks?: Array<unknown> };
+      const params: unknown[] = [];
+      const text = (sqlObj.queryChunks ?? [])
+        .map((c) => {
+          // StringChunk carries its literal text in `value: string[]`; every
+          // other chunk is an interpolated parameter.
+          if (c && typeof c === 'object' && Array.isArray((c as { value?: unknown }).value)) {
+            return ((c as { value: string[] }).value).join('');
+          }
+          params.push(c);
+          return '?';
+        })
+        .join('');
+      return { text, params };
+    }
+
+    it('defaults to the bounded incremental verifier with a 30-slice rolling re-scan', async () => {
+      delete process.env.AUDIT_CHAIN_VERIFY_MODE;
+      delete process.env.AUDIT_CHAIN_VERIFY_RESCAN_SLICES;
+      vi.useFakeTimers({ toFake: ['Date'] });
+      vi.setSystemTime(new Date('2026-09-17T04:13:00Z'));
+
+      mockOrgs(['org-1']);
+      dbExecuteMock.mockResolvedValueOnce([]);
+
+      await verifyAuditChains();
+
+      const { text, params } = flatten(dbExecuteMock.mock.calls[1]![0]);
+      expect(text).toMatch(/audit_log_verify_chain_incremental\(/);
+      expect(text).not.toMatch(/audit_log_verify_chain\(/);
+      expect(params).toEqual(['org-1', 30, Math.floor(Date.UTC(2026, 8, 17) / 86_400_000) % 30]);
+    });
+
+    it('advances one slice per UTC day and wraps at the slice count', () => {
+      const day = (iso: string) => __testOnly.rescanSliceIndex(7, new Date(iso));
+      expect(day('2026-02-28T04:13:00Z') + 1).toBe(day('2026-03-01T04:13:00Z') === 0 ? 7 : day('2026-03-01T04:13:00Z'));
+      expect(day('2026-03-01T04:13:00Z')).toBe((day('2026-02-28T04:13:00Z') + 1) % 7);
+      expect(__testOnly.rescanSlices()).toBe(30);
+      expect(__testOnly.verifyMode()).toBe('incremental');
+    });
+
+    it('honours AUDIT_CHAIN_VERIFY_RESCAN_SLICES and wraps the slice index', async () => {
+      process.env.AUDIT_CHAIN_VERIFY_RESCAN_SLICES = '7';
+      vi.useFakeTimers({ toFake: ['Date'] });
+      vi.setSystemTime(new Date('2026-09-30T04:13:00Z'));
+
+      mockOrgs(['org-1']);
+      dbExecuteMock.mockResolvedValueOnce([]);
+
+      await verifyAuditChains();
+
+      const { params } = flatten(dbExecuteMock.mock.calls[1]![0]);
+      expect(params).toEqual(['org-1', 7, Math.floor(Date.UTC(2026, 8, 30) / 86_400_000) % 7]);
+    });
+
+    it('AUDIT_CHAIN_VERIFY_MODE=full keeps the legacy whole-chain walk', async () => {
+      process.env.AUDIT_CHAIN_VERIFY_MODE = 'full';
+
+      mockOrgs(['org-1']);
+      dbExecuteMock.mockResolvedValueOnce([]);
+
+      await verifyAuditChains();
+
+      const { text, params } = flatten(dbExecuteMock.mock.calls[1]![0]);
+      expect(text).toMatch(/audit_log_verify_chain\(/);
+      expect(text).not.toMatch(/audit_log_verify_chain_incremental/);
+      expect(params).toEqual(['org-1']);
+    });
+
+    it('still raises an incident from an incremental break row', async () => {
+      mockOrgs(['org-1']);
+      dbExecuteMock.mockResolvedValueOnce([{ broken_id: 'row-x', expected: 'e', actual: 'a' }]);
+
+      const stats = await verifyAuditChains();
+
+      expect(stats.orgsBroken).toBe(1);
+      expect(stats.alertsRaised).toBe(1);
+      expect(dbInsertMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('worker processor', () => {
     it('runs the sweep for the scheduled job name', async () => {
       // Build the worker to capture its processor.

--- a/apps/api/src/jobs/auditChainVerify.ts
+++ b/apps/api/src/jobs/auditChainVerify.ts
@@ -80,6 +80,42 @@ function isEnabled(): boolean {
   return !(v === '0' || v === 'false' || v === 'no' || v === 'off');
 }
 
+export type ChainVerifyMode = 'incremental' | 'full';
+
+/**
+ * `AUDIT_CHAIN_VERIFY_MODE`: `incremental` (default) runs the bounded plan
+ * from migration 2026-10-03 — everything after the org's latest anchor plus
+ * one rolling slice of the historical chain — so a night's work is O(new rows
+ * + chain/slices) instead of O(whole chain). `full` keeps the legacy
+ * whole-chain walk (audit_log_verify_chain) for incident response or a
+ * one-off complete re-verification.
+ */
+function verifyMode(): ChainVerifyMode {
+  const raw = (process.env.AUDIT_CHAIN_VERIFY_MODE ?? '').trim().toLowerCase();
+  return raw === 'full' ? 'full' : 'incremental';
+}
+
+const DEFAULT_RESCAN_SLICES = 30;
+
+/**
+ * `AUDIT_CHAIN_VERIFY_RESCAN_SLICES`: how many nightly slices the historical
+ * chain (below the anchor) is cut into. Every row is re-verified at least once
+ * per that many days. Default 30 ≈ monthly full coverage.
+ */
+function rescanSlices(): number {
+  const n = Number.parseInt(process.env.AUDIT_CHAIN_VERIFY_RESCAN_SLICES ?? '', 10);
+  return Number.isFinite(n) && n >= 1 ? n : DEFAULT_RESCAN_SLICES;
+}
+
+/**
+ * Zero-based slice for tonight: UTC epoch-day modulo `slices`, so consecutive
+ * nights walk consecutive slices with no month-length gaps (a day-of-month
+ * scheme would skip slices 29/30 in February).
+ */
+function rescanSliceIndex(slices: number, now: Date = new Date()): number {
+  return Math.floor(now.getTime() / 86_400_000) % slices;
+}
+
 const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
   if (typeof dbModule.withSystemDbAccessContext !== 'function') {
     throw new Error(
@@ -124,11 +160,21 @@ const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout
  */
 async function verifyOrgChain(orgId: string): Promise<ChainBreakRow[]> {
   return runWithSystemDbAccess(async () => {
-    const rows = (await dbModule.db.execute(sql`
-      SELECT broken_id, expected, actual
-      FROM audit_log_verify_chain(${orgId}::uuid)
-    `)) as unknown as ChainBreakRow[];
-    return Array.isArray(rows) ? rows : [];
+    let rows: unknown;
+    if (verifyMode() === 'full') {
+      rows = await dbModule.db.execute(sql`
+        SELECT broken_id, expected, actual
+        FROM audit_log_verify_chain(${orgId}::uuid)
+      `);
+    } else {
+      const slices = rescanSlices();
+      const sliceIndex = rescanSliceIndex(slices);
+      rows = await dbModule.db.execute(sql`
+        SELECT broken_id, expected, actual
+        FROM audit_log_verify_chain_incremental(${orgId}::uuid, ${slices}::int, ${sliceIndex}::int)
+      `);
+    }
+    return Array.isArray(rows) ? (rows as ChainBreakRow[]) : [];
   });
 }
 
@@ -390,4 +436,7 @@ export const __testOnly = {
   DAILY_CRON,
   INCIDENT_CLASSIFICATION,
   isEnabled,
+  verifyMode,
+  rescanSlices,
+  rescanSliceIndex,
 };


### PR DESCRIPTION
## Problem (measured on US prod, 2026-09-02)

`audit_log_verify_chain(org)` walks the org's **entire** `audit_log_chain` every night, point-reading and re-hashing the matching `audit_logs` row for each entry, then does a second full anti-join for unsealed rows. That is O(total chain) per org per night.

| | |
|---|---|
| audit_logs / audit_log_chain | 5.0M rows, 4.2 GB / 2.7 GB; one org holds 2.4M chain rows |
| DB | db-intel-1vcpu-2gb, `shared_buffers` 391 MB, cache hit 79% |
| `audit_log_verify_chain` since 08-30 stats reset | 865 calls, **118,000 s** exec (mean 136 s, max 2.2 h) |
| Nightly sweep wall time | ~13 h (starts 04:13 UTC, no "Verified" line within 13 h of API logs) |

Side effect that surfaced it: every postgres_exporter collector reported ~4.4 s under this IO pressure, the scrape exceeded Prometheus's default 10 s `scrape_timeout`, and `DOPostgresExporterDown` flapped for three days (hourly `up` avg fell from 94% on 08-30 to 18–60% on 09-02). The deploy was coincidental.

## Change

**Migration `2026-10-03-audit-chain-verify-range.sql`** (CREATE OR REPLACE only, idempotent):

- `audit_log_verify_chain_range(org, from_seq, to_seq)` — the same linkage / chain-hash / content-hash checks, bounded to a `chain_seq` range. Linkage is seeded from the row immediately before the range; a range starting at the org's first surviving row treats its prev as trusted, exactly like the full walk does for a retention-pruned prefix.
- `audit_log_verify_chain_incremental(org, slices=30, slice_index=0, block_rows=100000)` — the nightly plan:
  1. **Incremental**: from the org's *second-latest* `audit_chain_anchors` head (latest if only one) to the live head, starting *at* the anchored row so the watermark itself is re-proved. One anchor back means a night whose verify failed or was skipped is re-covered the next night at ~2× daily row cost. Clamped into `[min,max]` so a pruned anchor starts at the first surviving row and a forged ahead-of-head anchor still verifies the live head (the anchor job pages on that anchor separately as `seq_regressed`).
  2. **Recent unsealed rows**: anti-join bounded to `timestamp >= first sealed_at of the range − 1 min`, open-ended. Fast path only — `audit_logs.timestamp` can be agent-supplied.
  3. **Rolling re-scan**: the global `chain_seq` space is cut into fixed 100k blocks; block `b` is verified on nights where `b % slices = slice_index`. Membership never moves with min/max or retention, so every historical row's content hash is re-checked at least once per `slices` nights, always as contiguous ranges, with no persisted cursor.
  4. **Exhaustive unsealed sweep** once per cycle (slice 0).
  - No anchor yet (new org) → full walk. Empty chain → full walk (cheap).

**Job (`auditChainVerify.ts`)**: calls the incremental function by default with `slice_index = utc-epoch-day % slices` (not day-of-month, which skips slices in February). `AUDIT_CHAIN_VERIFY_MODE=full` keeps the legacy whole-chain walk for incident response; `AUDIT_CHAIN_VERIFY_RESCAN_SLICES` (default 30) sets the cycle. Result contract and the incident path are unchanged. No compose/env changes are required — defaults apply.

Expected nightly cost for the 2.4M-row org: ~2 × 130k new rows + 2.4M/30 ≈ 340k row lookups instead of 2.4M, and the full anti-join once a month instead of nightly. Ops stop-gap until this deploys: `AUDIT_CHAIN_VERIFY_ENABLED=false` on the droplet.

## Threat-model delta (documented in the migration header)

- Edited `audit_logs` row without touching the chain: previously caught the same night, now within `slices` (30) nights. Only a superuser-level compromise can do this (breeze_app has REVOKE + immutability triggers on both tables), and the anchor is the primary control for that class.
- Everything done to the **chain** (edit / delete / re-seal / forged anchor) still surfaces the same night via the incremental range or `audit_chain_verify_anchor()`.

Design was run past Codex (`xhigh`, read-only). Its three substantive objections — anchor-as-watermark after a failed night, unstable slice boundaries under a moving min/max, and the timestamp-bounded unsealed check being unsound on its own — are what produced the second-latest anchor, fixed-block scheme, and the once-per-cycle exhaustive sweep above. Its set-based `lag()` rewrite of the range verifier is a reasonable follow-up, not needed for the win here.

## Tests

- `auditChainVerify.test.ts` (+4): default plan calls `audit_log_verify_chain_incremental(org, 30, epochDay % 30)`, env overrides for slices and `full` mode, epoch-day wrap across a month boundary, incident still raised from an incremental break.
- `audit-chain-verify-range.integration.test.ts` (new, 10 cases, real Postgres as `breeze_app`, tampers forged via the superuser harness pool): clean chain in every mode; no-anchor fallback; edit above the anchor caught in every slice; anchored head row re-proved; edit below the anchor caught in exactly one slice per cycle and by a 1-slice pass; every historical row covered exactly once across a cycle (block_rows=1); predecessor-seeded linkage on a single-row range; unsealed row after the anchor; backdated unsealed historical row caught by the slice-0 sweep only; inverted/empty ranges.
- `autoMigrate.test.ts` (ordering/reference guard) and `scripts/check-migration-naming.sh` pass; tsc and eslint clean.

## Follow-ups (not in this PR)

- `audit_chain_anchor_head()` still does a full `count(*)` of the org's chain nightly (88 s for the big org on prod) — the anchor job's 20-minute run.
- `audit_logs` / `audit_log_chain` have never been autovacuumed or analyzed on US prod (planner sees 376k rows vs 5M real). An `ANALYZE` is a one-off ops action.
- The real fix for the table size is #4340 / #4021 (97% of `audit_logs` is agent telemetry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jcvj28WeRuLah6uE4Fmuf
