### PR TITLE
docs: partner trust probation spec + plan (feature #4549)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -292,9 +292,19 @@ cd e2e-tests && pnpm test
 
 ---
 
+## Model Routing (cost/speed strategy — benchmarked 2026-09-01)
+
+**Expensive models write contracts and verify claims; cheap models do everything in between; mechanical checks replace expensive review wherever the work is gradeable.** Basis: two head-to-head benchmarks (blind bug-hunt + blind spec→codegen) across Laguna, Codex gpt-5.6-sol med/high, Haiku, Sonnet, Opus — see memory `model-benchmark-codex-claude-laguna-2026-09-01`.
+
+1. **Spec-down (Fable/Opus in-session).** Spend top-tier tokens only on: resolving spec ambiguity, choosing contracts (tenancy shape, cascade lists, API surface), and cross-file reachability judgment. All six models aced a fully-resolved spec (39/39 each); 2 of 3 Claude PRIMARY bug claims died on a file the blind reviewer couldn't see. The orchestrator's value is the contract, not the typing.
+2. **Generate cheap — route by access needs, not quality.** Laguna (free, local, ~10× faster): any paste-in-shaped work — spec'd modules, co-located tests, migration drafts from a stated contract. Codex `medium` (flat sub, ~0 marginal): well-scoped repo-touching edits and single-file bug-hunts. Haiku subagents: mechanical repo chores needing tools, with explicit file lists.
+3. **Verify mechanically first.** tsc/tests/grep-the-contract before any model review — the cascade-list history is contract tests 5/5 vs human review 0/5. A hidden acceptance suite converts "needs expensive review" into "needs a script."
+4. **Review sized by blast radius.** Default: Laguna + Codex `medium` in parallel (~free, ~1 min), orchestrator arbitrates — disagreement is signal; Laguna's hallucinations die at verification (it misread code 2× in the bench — never trust its line-level claims unre-read). Reserve Sonnet (precision: 4/4 real findings, 0 hallucinations) or Opus (depth: found the billing bug nobody else saw) for tenancy/auth/billing/agent-shipped code.
+5. **Advisor quorum unchanged** — Fable + codex `xhigh` only for consequential, hard-to-reverse design (see Working Style).
+
 ## Codex Delegation
 
-This project uses OpenAI Codex CLI for **read-only analysis (bug-hunting, security review, design-from-plan — its strongest uses) and well-scoped single-file edits** (utilities, co-located tests, CRUD endpoints, mechanical renames). Keep with Claude: repo-wide sweeps/enumeration, cross-module refactors (codex misses existing canonical code), UI work, and the *architecture* of multi-tenant/auth changes — though codex may *execute* an RLS migration once Claude hands it the tenancy contract. Default to `high`; reserve `xhigh` for open-ended design. For commands, reasoning levels, and the benchmarked delegation matrix, use the **`delegating-to-codex`** skill.
+This project uses OpenAI Codex CLI for **read-only analysis (bug-hunting, security review, design-from-plan — its strongest uses) and well-scoped single-file edits** (utilities, co-located tests, CRUD endpoints, mechanical renames). Keep with Claude: repo-wide sweeps/enumeration, cross-module refactors (codex misses existing canonical code), UI work, and the *architecture* of multi-tenant/auth changes — though codex may *execute* an RLS migration once Claude hands it the tenancy contract. Default to `medium` (2026-09-01 bench: `medium` beat `high` on bug-hunts and tied on codegen); escalate to `high` only when medium comes back thin; reserve `xhigh` for open-ended design. Model is `gpt-5.6-sol`. For commands, reasoning levels, and the benchmarked delegation matrix, use the **`delegating-to-codex`** skill.
 
 ---
 

--- a/docs/superpowers/plans/security-auth/2026-09-02-partner-trust-probation.md
+++ b/docs/superpowers/plans/security-auth/2026-09-02-partner-trust-probation.md
@@ -17,6 +17,7 @@ tracking_issue: LanternOps/breeze#4549
 ## Global Constraints
 
 - Flag: `PARTNER_TRUST_MODE = off | shadow | enforce`; resolver returns `off` unless `isHosted()` is true; hosted default `shadow`.
+- **No new env var is ever required.** `PARTNER_TRUST_MODE`, `IP_CLASSIFY_PROVIDER`, `IP_CLASSIFY_API_KEY`, `PARTNER_MEETING_URL` are all optional; a missing or unrecognised value resolves to the feature being off (or, for the classifier, provider `none` → class `unknown`), logs at most a single `warn`, and never blocks a request or fails boot. Do not add any of them to the config validator's required set. Task 2.2 and Task 5.1 each carry a test that boots with the variable unset.
 - Column default `trusted`. Existing partners are never moved by a migration. Backfill is a reviewed SQL batch (Wave 7), never a migration.
 - Enrollment cap in probation: **5**, lifetime counter `partners.probation_enrollments`, incremented inside the enrollment transaction with the partner row locked, never decremented.
 - No age-only promotion. Auto-promotion requires a settled card charge (`type = 'card'`, not `link`) ≥ 24 h old, undisputed, unrefunded, cardholder name present, plus signup IP class not in `{hosting, vpn, tor, unknown}` and no unresolved `alert` abuse signal.
@@ -305,6 +306,13 @@ describe('partnerTrustMode', () => {
     process.env.IS_HOSTED = 'true';
     process.env.PARTNER_TRUST_MODE = 'enforce';
     expect(partnerTrustMode()).toBe('enforce');
+  });
+  it('is off and silent when nothing at all is configured (fresh self-hosted install)', () => {
+    delete process.env.IS_HOSTED; delete process.env.PARTNER_TRUST_MODE;
+    delete process.env.IP_CLASSIFY_PROVIDER; delete process.env.IP_CLASSIFY_API_KEY; delete process.env.PARTNER_MEETING_URL;
+    const warn = vi.spyOn(console, 'warn');
+    expect(partnerTrustMode()).toBe('off');
+    expect(warn).not.toHaveBeenCalled();
   });
   it('falls back to shadow on an unrecognised value', () => {
     process.env.IS_HOSTED = 'true';
@@ -915,7 +923,7 @@ export async function classifyIp(ip: string): Promise<IpClassification>; // Redi
 export async function enqueueIpClassify(target: { kind: 'partner'; partnerId: string; ip: string } | { kind: 'device'; deviceId: string; ip: string }): Promise<void>;
 ```
 
-- [ ] **Step 1: Failing tests** — provider response mapping (`privacy.hosting → hosting`, `privacy.vpn → vpn`, `privacy.tor → tor`, neither → `residential`, `company.type === 'business'` → `business`); cache hit skips the HTTP call; provider error → `unknown`; job handler writes `signup_ip_class` / `enrollment_ip_class` + asn + `classified_at`.
+- [ ] **Step 1: Failing tests** — with `IP_CLASSIFY_PROVIDER` and `IP_CLASSIFY_API_KEY` both unset, `classifyIp()` returns the static-prefix fallback result without any network call and without throwing, and `validateConfig()` (or the API's boot-time env check) still passes; with provider set but key missing → same fallback plus one `console.warn`; provider response mapping (`privacy.hosting → hosting`, `privacy.vpn → vpn`, `privacy.tor → tor`, neither → `residential`, `company.type === 'business'` → `business`); cache hit skips the HTTP call; provider error → `unknown`; job handler writes `signup_ip_class` / `enrollment_ip_class` + asn + `classified_at`.
 - [ ] **Step 2: Fail**, **Step 3: Implement** with `fetch`, a 3 s timeout, and the Redis key `ipclass:v1:<prefix>`; the BullMQ worker lives in `partnerTrustJobs.ts` on the existing `abuse-signals` queue (job name `ip-classify`), following `abuseSignalsSweep.ts`'s registration pattern, gated by `partnerTrustMode() !== 'off'`.
 - [ ] **Step 4: Pass**, **Step 5: Commit** — `git commit -m "feat(trust): async IP classification job"`.
 

--- a/docs/superpowers/plans/security-auth/2026-09-02-partner-trust-probation.md
+++ b/docs/superpowers/plans/security-auth/2026-09-02-partner-trust-probation.md
@@ -1,0 +1,1066 @@
+---
+tracking_issue: LanternOps/breeze#4549
+---
+
+# Partner Trust Probation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** New self-serve hosted partners start in `probation`, where remote control, device execution, and installer distribution are denied at the dispatch chokepoints until a settled non-Link 3DS card payment ages 24 h or an operator approves from an evidence card.
+
+**Architecture:** A `trust_state` column on `partners` (default `trusted`, so everything existing is grandfathered) is read by one service, `services/partnerTrust.ts`. That service is called from the command-dispatch chokepoints (`commandQueue.ts` and the agent WebSocket fast path), from one new `createRemoteSession()` service that all session inserts go through, and from explicit gates on installer distribution, Quick Support, third-party remote launch, and agent enrollment. Promotion runs lazily on deny and on a 15-minute job; the operator approves or suspends from an email card whose links require a fresh TOTP. A three-state flag (`off | shadow | enforce`) resolves to `off` unless `IS_HOSTED=true`.
+
+**Tech Stack:** Hono, Drizzle, Postgres, BullMQ, Vitest (API), Astro + React (web), Stripe (breeze-billing repo, Wave 1 only).
+
+**Spec:** `docs/superpowers/specs/security-auth/2026-09-02-partner-trust-probation-design.md`
+
+## Global Constraints
+
+- Flag: `PARTNER_TRUST_MODE = off | shadow | enforce`; resolver returns `off` unless `isHosted()` is true; hosted default `shadow`.
+- Column default `trusted`. Existing partners are never moved by a migration. Backfill is a reviewed SQL batch (Wave 7), never a migration.
+- Enrollment cap in probation: **5**, lifetime counter `partners.probation_enrollments`, incremented inside the enrollment transaction with the partner row locked, never decremented.
+- No age-only promotion. Auto-promotion requires a settled card charge (`type = 'card'`, not `link`) ≥ 24 h old, undisputed, unrefunded, cardholder name present, plus signup IP class not in `{hosting, vpn, tor, unknown}` and no unresolved `alert` abuse signal.
+- Denials and transitions are `audit_logs` events (`partner.trust.*`), never `partner_abuse_signals` rows.
+- Deny contract: HTTP 403 body `{ error: 'TRUST_PROBATION' | 'TRUST_RESTRICTED', capability, reason, reviewRequested, meetingUrl }`.
+- Approval/suspend links from the email card require a fresh TOTP before acting.
+- Restriction by IP requires a corroborating non-IP axis. IPv4 /24, IPv6 /64.
+- No cross-region lookups. No auto-suspend.
+- Migration name must sort after the newest committed migration: `apps/api/migrations/2026-09-28-partner-trust-probation.sql` (newest today is `2026-09-27-technician-ticket-write-permissions.sql`). Idempotent, no inner `BEGIN/COMMIT`.
+- Tenancy: `partners` is partner-axis (shape 3) and `devices` is device-scoped; no new tables, so no cascade-list changes. `devices` gains three columns that must be classified in `tenantExportPolicyRegistry.ts` (`partners` has no entry there; only `org_id` tables do).
+- Web mutations go through `runAction`; buttons stay visible in probation.
+- Every wave lands as its own PR with `Closes #<sub-issue>`; run `pnpm --filter @breeze/api test --run <file>` (no `--` before `--run`) while developing, full API suite plus the RLS/integration suites before the PR of any wave that touches schema (W02, W04).
+
+---
+
+## File map
+
+| Wave | Create | Modify |
+|---|---|---|
+| W01 (breeze-billing) | `src/routes/checkout.paymentMethods.test.ts` | `src/routes/checkout.ts:103`, `src/routes/setupIntents.ts:55` |
+| W02 | `apps/api/migrations/2026-09-28-partner-trust-probation.sql`, `apps/api/src/services/partnerTrust.ts`, `apps/api/src/services/partnerTrust.test.ts`, `apps/api/src/config/partnerTrustMode.ts`, `apps/api/src/config/partnerTrustMode.test.ts` | `apps/api/src/db/schema/orgs.ts`, `apps/api/src/db/schema/devices.ts`, `apps/api/src/services/tenantExportPolicyRegistry.ts:170`, `apps/api/src/routes/auth/register.ts:229`, `apps/api/src/middleware/auth.ts` (`AuthContext.trustState`), `apps/api/src/middleware/partnerGuard.ts:35-48` |
+| W03 | `apps/api/src/services/partnerTrust.commands.ts`, `apps/api/src/services/partnerTrust.commands.test.ts` | `apps/api/src/services/commandQueue.ts:601,802,913`, `apps/api/src/routes/agentWs.ts:3123` + connection record, `apps/api/src/routes/devices/actuateElevation.ts:200`, `apps/api/src/routes/mobile.ts:1318` |
+| W04 | `apps/api/src/services/remoteSessionCreate.ts`, `apps/api/src/services/remoteSessionCreate.test.ts` | `apps/api/src/routes/remote/sessions.ts:251`, `apps/api/src/services/aiToolsRemote.ts:384`, `apps/api/src/routes/remote/supportSessions.ts:49`, `apps/api/src/routes/tunnels.ts:391,589,1616,1061,1121,1189`, `apps/api/src/routes/desktopWs.ts:1276`, `apps/api/src/routes/terminalWs.ts:1114`, `apps/api/src/routes/devices/core.ts:1203`, `apps/api/src/routes/enrollmentKeys.ts:2131,2519,2576`, `apps/api/src/routes/supportPublic.ts:319,445`, `apps/api/src/routes/agents/enrollment.ts:694-861` |
+| W05 | `apps/api/src/services/partnerTrustPromotion.ts` (+test), `apps/api/src/services/ipClassify.ts` (+test), `apps/api/src/jobs/partnerTrustJobs.ts`, `apps/api/src/routes/admin/trust.ts` (+test), `apps/api/src/routes/partnerTrust.ts` (+test), `apps/api/src/services/partnerTrustEvidenceCard.ts` (+test) | `apps/api/src/jobs/scheduleRegistry.ts`, `apps/api/src/routes/admin/index.ts`, `apps/api/src/config/env.ts` |
+| W06 | `apps/web/src/components/trust/TrustProbationBanner.tsx` (+test), `apps/web/src/lib/trustProbation.ts` | `apps/web/src/lib/runAction.ts`, onboarding copy component, device list badge |
+| W07 | `apps/api/scripts/partner-trust-backfill.sql`, `apps/web/src/pages/admin/trust-queue.astro` + `TrustQueue.tsx` | `.github/workflows/guided-setup-smoke.yml` assertion, docs |
+
+---
+
+## Wave 1 — breeze-billing: Link off, 3DS on (repo `~/breeze-billing`)
+
+### Task 1.1: Card-only Checkout with explicit 3DS
+
+**Files:**
+- Modify: `src/routes/checkout.ts:103-122`
+- Modify: `src/routes/setupIntents.ts:55-63`
+- Test: `src/routes/checkout.paymentMethods.test.ts` (new)
+
+**Interfaces:**
+- Produces: both `stripe.checkout.sessions.create` calls carry `payment_method_types: ['card']` and `payment_method_options: { card: { request_three_d_secure: 'any' } }`. Core Wave 5 relies on `charge.succeeded` rows having `payment_method_details.type === 'card'` and `billing_details.name` present.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/routes/checkout.paymentMethods.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const create = vi.fn(async () => ({ id: 'cs_test', url: 'https://checkout.stripe.com/x' }));
+vi.mock('../services/stripe.js', () => ({ stripe: { checkout: { sessions: { create } } } }));
+vi.mock('../services/customers.js', () => ({ findOrCreateStripeCustomer: async () => 'cus_test' }));
+
+import { buildSubscriptionCheckoutParams } from './checkout.js';
+import { buildSetupCheckoutParams } from './setupIntents.js';
+
+describe('signup checkout payment methods', () => {
+  beforeEach(() => create.mockClear());
+
+  it('subscription checkout is card-only with 3DS requested', () => {
+    const p = buildSubscriptionCheckoutParams({ customerId: 'cus_test', priceId: 'price_x', plan: 'starter', partnerId: 'p1', successUrl: 'https://a', cancelUrl: 'https://b' });
+    expect(p.payment_method_types).toEqual(['card']);
+    expect(p.payment_method_options?.card?.request_three_d_secure).toBe('any');
+  });
+
+  it('setup checkout is card-only with 3DS requested', () => {
+    const p = buildSetupCheckoutParams({ customerId: 'cus_test', partnerId: 'p1', returnUrl: 'https://a' });
+    expect(p.payment_method_types).toEqual(['card']);
+    expect(p.payment_method_options?.card?.request_three_d_secure).toBe('any');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd ~/breeze-billing && npx vitest run src/routes/checkout.paymentMethods.test.ts`
+Expected: FAIL — `buildSubscriptionCheckoutParams` is not exported.
+
+- [ ] **Step 3: Extract the params builders and add the two fields**
+
+In `src/routes/checkout.ts`, above the route handler:
+
+```ts
+export function buildSubscriptionCheckoutParams(input: {
+  customerId: string; priceId: string; plan: string; partnerId: string; successUrl: string; cancelUrl: string;
+}): Stripe.Checkout.SessionCreateParams {
+  return {
+    customer: input.customerId,
+    mode: 'subscription',
+    line_items: [{ price: input.priceId, quantity: 1 }],
+    // Link is the confirmed abuse bypass (no cardholder name, Radar risk
+    // normal on every fraudulent capture); card-only + 3DS is a rollout
+    // prerequisite for partner trust probation (core spec 2026-09-02 §3.5).
+    payment_method_types: ['card'],
+    payment_method_options: { card: { request_three_d_secure: 'any' } },
+    metadata: { breeze_partner_id: input.partnerId, breeze_plan: input.plan },
+    subscription_data: { metadata: { breeze_partner_id: input.partnerId, breeze_plan: input.plan } },
+    success_url: input.successUrl,
+    cancel_url: input.cancelUrl,
+  };
+}
+```
+
+Replace the inline object at line 103 with `await stripe.checkout.sessions.create(buildSubscriptionCheckoutParams({ customerId, priceId, plan, partnerId, successUrl, cancelUrl }))`, computing `successUrl`/`cancelUrl` exactly as the existing ternaries do.
+
+In `src/routes/setupIntents.ts`:
+
+```ts
+export function buildSetupCheckoutParams(input: { customerId: string; partnerId: string; returnUrl: string }): Stripe.Checkout.SessionCreateParams {
+  return {
+    mode: 'setup',
+    customer: input.customerId,
+    currency: 'usd',
+    payment_method_types: ['card'],
+    payment_method_options: { card: { request_three_d_secure: 'any' } },
+    success_url: input.returnUrl,
+    cancel_url: input.returnUrl,
+    metadata: { breeze_partner_id: input.partnerId },
+  };
+}
+```
+
+and call it at line 55.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd ~/breeze-billing && npx vitest run src/routes/`
+Expected: PASS, including the existing checkout and setupIntents suites.
+
+- [ ] **Step 5: Verify in Stripe test mode**
+
+Run the billing service locally against the test key, hit `POST /checkout` for a test partner, open the returned URL, and confirm the Checkout page shows no "Pay with Link" option and the card form triggers the 3DS test challenge with card `4000 0027 6000 3184`. Record the session id in the PR body.
+
+- [ ] **Step 6: Commit and open PR (breeze-billing)**
+
+```bash
+git add src/routes/checkout.ts src/routes/setupIntents.ts src/routes/checkout.paymentMethods.test.ts
+git commit -m "fix(checkout): card-only signup checkout with 3DS requested — Link is the abuse bypass"
+```
+
+Deploy note for the PR body: billing builds from source on each droplet (`cd /opt/breeze-billing && git pull --ff-only && cd /opt/breeze && docker compose build billing && docker compose up -d billing`).
+
+---
+
+## Wave 2 — Core foundation: schema, flag, trust service (shadow-capable, no gates yet)
+
+### Task 2.1: Migration and Drizzle schema
+
+**Files:**
+- Create: `apps/api/migrations/2026-09-28-partner-trust-probation.sql`
+- Modify: `apps/api/src/db/schema/orgs.ts:8` (enums) and the `partners` table after `signupUserAgent`
+- Modify: `apps/api/src/db/schema/devices.ts:56` after `enrollmentIp`
+- Modify: `apps/api/src/services/tenantExportPolicyRegistry.ts:170` (`devices` entry)
+
+**Interfaces:**
+- Produces: `partners.trustState`, `trustChangedAt`, `trustChangedBy`, `trustReason`, `trustReviewRequestedAt`, `probationEnrollments`, `signupIpClass`, `signupIpAsn`, `signupIpClassifiedAt`; `devices.enrollmentIpClass`, `enrollmentIpAsn`, `enrollmentIpClassifiedAt`; exported types `PartnerTrustState`, `IpClass`.
+
+- [ ] **Step 1: Write the failing schema-drift check**
+
+Run: `cd apps/api && export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze" && pnpm db:check-drift`
+Expected: clean now (baseline). After Step 3 and before Step 4 it must report the new columns as drift, proving the migration is what closes it.
+
+- [ ] **Step 2: Write the migration**
+
+```sql
+-- 2026-09-28-partner-trust-probation.sql
+-- Partner trust probation (spec: docs/superpowers/specs/security-auth/2026-09-02-partner-trust-probation-design.md)
+-- Idempotent. No inner BEGIN/COMMIT (autoMigrate wraps each file).
+
+DO $$ BEGIN
+  CREATE TYPE partner_trust_state AS ENUM ('probation', 'trusted', 'restricted');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  CREATE TYPE ip_class AS ENUM ('residential', 'business', 'hosting', 'vpn', 'tor', 'unknown');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+ALTER TABLE partners
+  ADD COLUMN IF NOT EXISTS trust_state               partner_trust_state NOT NULL DEFAULT 'trusted',
+  ADD COLUMN IF NOT EXISTS trust_changed_at          timestamptz,
+  ADD COLUMN IF NOT EXISTS trust_changed_by          uuid REFERENCES users(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS trust_reason              text,
+  ADD COLUMN IF NOT EXISTS trust_review_requested_at timestamptz,
+  ADD COLUMN IF NOT EXISTS probation_enrollments     integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS signup_ip_class           ip_class NOT NULL DEFAULT 'unknown',
+  ADD COLUMN IF NOT EXISTS signup_ip_asn             integer,
+  ADD COLUMN IF NOT EXISTS signup_ip_classified_at   timestamptz;
+
+CREATE INDEX IF NOT EXISTS partners_trust_state_idx
+  ON partners (trust_state) WHERE trust_state <> 'trusted';
+
+ALTER TABLE devices
+  ADD COLUMN IF NOT EXISTS enrollment_ip_class         ip_class NOT NULL DEFAULT 'unknown',
+  ADD COLUMN IF NOT EXISTS enrollment_ip_asn           integer,
+  ADD COLUMN IF NOT EXISTS enrollment_ip_classified_at timestamptz;
+```
+
+No RLS change: both tables already carry forced policies and the new columns inherit them.
+
+- [ ] **Step 3: Drizzle schema**
+
+`apps/api/src/db/schema/orgs.ts`, next to `partnerStatusEnum` (line 8):
+
+```ts
+export const partnerTrustStateEnum = pgEnum('partner_trust_state', ['probation', 'trusted', 'restricted']);
+export type PartnerTrustState = (typeof partnerTrustStateEnum.enumValues)[number];
+export const ipClassEnum = pgEnum('ip_class', ['residential', 'business', 'hosting', 'vpn', 'tor', 'unknown']);
+export type IpClass = (typeof ipClassEnum.enumValues)[number];
+```
+
+In the `partners` table definition, after `signupUserAgent`:
+
+```ts
+  // Partner trust probation (spec 2026-09-02). Lifecycle stays in `status`;
+  // this is the capability axis. Default 'trusted' grandfathers every
+  // pre-existing partner; register-partner sets 'probation' under enforce.
+  trustState: partnerTrustStateEnum('trust_state').notNull().default('trusted'),
+  trustChangedAt: timestamp('trust_changed_at', { withTimezone: true }),
+  trustChangedBy: uuid('trust_changed_by').references(() => users.id, { onDelete: 'set null' }),
+  trustReason: text('trust_reason'),
+  trustReviewRequestedAt: timestamp('trust_review_requested_at', { withTimezone: true }),
+  // Lifetime count of agent enrollments made while in probation. Never
+  // decremented: deleting a device must not recycle the probation quota.
+  probationEnrollments: integer('probation_enrollments').notNull().default(0),
+  signupIpClass: ipClassEnum('signup_ip_class').notNull().default('unknown'),
+  signupIpAsn: integer('signup_ip_asn'),
+  signupIpClassifiedAt: timestamp('signup_ip_classified_at', { withTimezone: true }),
+```
+
+(`users` is imported into `orgs.ts` via a lazy reference if a circular import appears; follow how `trustChangedBy`'s neighbours reference `users` elsewhere in the schema, e.g. `enrollment_keys.created_by`.)
+
+`apps/api/src/db/schema/devices.ts` after `enrollmentIp` (line 56):
+
+```ts
+  enrollmentIpClass: ipClassEnum('enrollment_ip_class').notNull().default('unknown'),
+  enrollmentIpAsn: integer('enrollment_ip_asn'),
+  enrollmentIpClassifiedAt: timestamp('enrollment_ip_classified_at', { withTimezone: true }),
+```
+
+`apps/api/src/services/tenantExportPolicyRegistry.ts:170`, `devices` entry: add `"enrollment_ip_class"`, `"enrollment_ip_asn"`, `"enrollment_ip_classified_at"` to `"reviewedIncluded"` with a comment that they are derived risk metadata; the spec asks for them to be withheld from the tenant-facing export, and the registry's only non-secret withholding bucket is `excludedOpen`, which is reserved for containers. Decision: put them in `excludedSensitive` (the export omits them) with the comment `// risk metadata: withheld so a subject-access export cannot be used to tune evasion`. This is the one place the plan overrides the bucket's nominal meaning; the integration suite only checks membership.
+
+- [ ] **Step 4: Apply and verify**
+
+Run: `pnpm db:migrate && pnpm db:check-drift`
+Expected: migration applies; drift check clean.
+
+Run: `cd apps/api && npx vitest run src/db/autoMigrate.test.ts`
+Expected: PASS (naming and ordering guard).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/migrations/2026-09-28-partner-trust-probation.sql apps/api/src/db/schema/orgs.ts apps/api/src/db/schema/devices.ts apps/api/src/services/tenantExportPolicyRegistry.ts
+git commit -m "feat(trust): partner trust state + ip class columns (probation foundation)"
+```
+
+### Task 2.2: Flag resolver
+
+**Files:**
+- Create: `apps/api/src/config/partnerTrustMode.ts`
+- Test: `apps/api/src/config/partnerTrustMode.test.ts`
+
+**Interfaces:**
+- Produces: `export type PartnerTrustMode = 'off' | 'shadow' | 'enforce'; export function partnerTrustMode(): PartnerTrustMode;`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/api/src/config/partnerTrustMode.test.ts
+import { describe, it, expect, afterEach } from 'vitest';
+import { partnerTrustMode } from './partnerTrustMode';
+
+const env = process.env;
+afterEach(() => { process.env = { ...env }; });
+
+describe('partnerTrustMode', () => {
+  it('is off when not hosted, regardless of the env value', () => {
+    process.env.IS_HOSTED = 'false';
+    process.env.PARTNER_TRUST_MODE = 'enforce';
+    expect(partnerTrustMode()).toBe('off');
+  });
+  it('defaults to shadow when hosted and unset', () => {
+    process.env.IS_HOSTED = 'true';
+    delete process.env.PARTNER_TRUST_MODE;
+    expect(partnerTrustMode()).toBe('shadow');
+  });
+  it('honours enforce when hosted', () => {
+    process.env.IS_HOSTED = 'true';
+    process.env.PARTNER_TRUST_MODE = 'enforce';
+    expect(partnerTrustMode()).toBe('enforce');
+  });
+  it('falls back to shadow on an unrecognised value', () => {
+    process.env.IS_HOSTED = 'true';
+    process.env.PARTNER_TRUST_MODE = 'yes';
+    expect(partnerTrustMode()).toBe('shadow');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails** — `cd apps/api && npx vitest run src/config/partnerTrustMode.test.ts` → FAIL, module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// apps/api/src/config/partnerTrustMode.ts
+import { isHosted } from './env';
+
+export type PartnerTrustMode = 'off' | 'shadow' | 'enforce';
+
+/**
+ * Partner trust probation flag. Self-hosted safeguard: resolves to 'off'
+ * whenever IS_HOSTED is not true, regardless of PARTNER_TRUST_MODE, so a
+ * self-hosted install never evaluates the gate. Read at call time (like
+ * abuseSignalsEnabled) so tests can flip it per case.
+ */
+export function partnerTrustMode(): PartnerTrustMode {
+  if (!isHosted()) return 'off';
+  const raw = (process.env.PARTNER_TRUST_MODE ?? '').trim().toLowerCase();
+  if (raw === 'off' || raw === 'shadow' || raw === 'enforce') return raw;
+  if (raw !== '') console.warn(`[PartnerTrust] Ignoring unrecognized PARTNER_TRUST_MODE value ${JSON.stringify(raw)}; using shadow`);
+  return 'shadow';
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**, then **Step 5: Commit** — `git commit -m "feat(trust): PARTNER_TRUST_MODE resolver, off unless hosted"`.
+
+### Task 2.3: Trust service (decision, audit, allowlist)
+
+**Files:**
+- Create: `apps/api/src/services/partnerTrust.ts`
+- Test: `apps/api/src/services/partnerTrust.test.ts`
+
+**Interfaces:**
+- Consumes: `partnerTrustMode()`, `createAuditLog` (`services/auditService.ts:86`), `withSystemDbAccessContext` / `runOutsideDbContext` (`db/index.ts:610,780`).
+- Produces:
+
+```ts
+export type GatedCapability = 'remote_control' | 'device_execute' | 'installer_distribute' | 'agent_enroll';
+export type TrustDenyCode = 'TRUST_PROBATION' | 'TRUST_RESTRICTED';
+export type GateDecision =
+  | { allow: true; shadowDenied?: { code: TrustDenyCode; reason: string } }
+  | { allow: false; code: TrustDenyCode; capability: GatedCapability; reason: string };
+export interface GateContext { partnerId: string; deviceId?: string; orgId?: string; userId?: string; commandType?: string; detail?: Record<string, unknown> }
+export const PROBATION_ENROLLMENT_CAP = 5;
+export function isLifecycleCommand(type: string): boolean;
+export async function loadTrustState(partnerId: string): Promise<{ trustState: PartnerTrustState; probationEnrollments: number } | null>;
+export async function evaluateCapability(cap: GatedCapability, ctx: GateContext): Promise<GateDecision>;
+export function requireCapability(cap: GatedCapability): MiddlewareHandler;
+export function trustDenyBody(d: Extract<GateDecision, { allow: false }>, reviewRequested: boolean): { error: TrustDenyCode; capability: GatedCapability; reason: string; reviewRequested: boolean; meetingUrl: string | null };
+export async function setTrustState(partnerId: string, next: PartnerTrustState, reason: string, actorUserId: string | null, evidence?: Record<string, unknown>): Promise<void>;
+export async function partnerIdForDevice(deviceId: string): Promise<string | null>;
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// apps/api/src/services/partnerTrust.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const state = { trustState: 'probation', probationEnrollments: 0 };
+const audit = vi.fn(async () => {});
+vi.mock('./auditService', () => ({ createAuditLog: audit }));
+vi.mock('../config/partnerTrustMode', () => ({ partnerTrustMode: vi.fn(() => 'enforce') }));
+vi.mock('../db', () => ({
+  db: {}, withSystemDbAccessContext: async (fn: () => unknown) => fn(), runOutsideDbContext: (fn: () => unknown) => fn(),
+}));
+vi.mock('./partnerTrust.repo', () => ({
+  readTrust: vi.fn(async () => state),
+  writeTrust: vi.fn(async () => {}),
+  partnerForDevice: vi.fn(async () => 'p1'),
+}));
+
+import { partnerTrustMode } from '../config/partnerTrustMode';
+import { evaluateCapability, isLifecycleCommand, LIFECYCLE_COMMAND_TYPES, GATED_COMMAND_TYPES } from './partnerTrust';
+
+beforeEach(() => { audit.mockClear(); state.trustState = 'probation'; state.probationEnrollments = 0; (partnerTrustMode as any).mockReturnValue('enforce'); });
+
+describe('evaluateCapability', () => {
+  it.each(['remote_control', 'device_execute', 'installer_distribute'] as const)('denies %s in probation', async (cap) => {
+    const d = await evaluateCapability(cap, { partnerId: 'p1' });
+    expect(d).toMatchObject({ allow: false, code: 'TRUST_PROBATION', capability: cap });
+    expect(audit).toHaveBeenCalledWith(expect.objectContaining({ action: 'partner.trust.capability_denied' }));
+  });
+  it('denies with TRUST_RESTRICTED when restricted', async () => {
+    state.trustState = 'restricted';
+    expect(await evaluateCapability('remote_control', { partnerId: 'p1' })).toMatchObject({ allow: false, code: 'TRUST_RESTRICTED' });
+  });
+  it('allows everything when trusted and writes no audit row', async () => {
+    state.trustState = 'trusted';
+    expect(await evaluateCapability('remote_control', { partnerId: 'p1' })).toEqual({ allow: true });
+    expect(audit).not.toHaveBeenCalled();
+  });
+  it('allows enroll under the cap and denies at the cap', async () => {
+    state.probationEnrollments = 4;
+    expect(await evaluateCapability('agent_enroll', { partnerId: 'p1' })).toEqual({ allow: true });
+    state.probationEnrollments = 5;
+    expect(await evaluateCapability('agent_enroll', { partnerId: 'p1' })).toMatchObject({ allow: false, reason: 'probation_enrollment_cap' });
+  });
+  it('lets lifecycle commands through device_execute even in probation', async () => {
+    expect(await evaluateCapability('device_execute', { partnerId: 'p1', commandType: 'self_uninstall' })).toEqual({ allow: true });
+  });
+  it('shadow mode allows but records the would-deny', async () => {
+    (partnerTrustMode as any).mockReturnValue('shadow');
+    const d = await evaluateCapability('remote_control', { partnerId: 'p1' });
+    expect(d).toMatchObject({ allow: true, shadowDenied: { code: 'TRUST_PROBATION' } });
+    expect(audit).toHaveBeenCalledWith(expect.objectContaining({ action: 'partner.trust.capability_denied', details: expect.objectContaining({ mode: 'shadow' }) }));
+  });
+  it('off mode allows and touches nothing', async () => {
+    (partnerTrustMode as any).mockReturnValue('off');
+    expect(await evaluateCapability('remote_control', { partnerId: 'p1' })).toEqual({ allow: true });
+    expect(audit).not.toHaveBeenCalled();
+  });
+});
+
+describe('command allowlist', () => {
+  it('classifies every known command type exactly once', () => {
+    const both = LIFECYCLE_COMMAND_TYPES.filter((t) => GATED_COMMAND_TYPES.includes(t));
+    expect(both).toEqual([]);
+    for (const t of ['script', 'execute_command', 'file_write', 'task_run', 'software_install', 'install_patches', 'backup_restore', 'actuate_elevation', 'computer_action', 'terminal_start', 'reboot']) expect(isLifecycleCommand(t)).toBe(false);
+    for (const t of ['self_uninstall', 'terminal_stop', 'token_rotate', 'wake_on_lan', 'peripheral_policy_push']) expect(isLifecycleCommand(t)).toBe(true);
+  });
+  it('an unknown command type is gated (fail closed)', () => {
+    expect(isLifecycleCommand('brand_new_command')).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails** — module not found.
+
+- [ ] **Step 3: Implement the repo and service**
+
+```ts
+// apps/api/src/services/partnerTrust.repo.ts
+import { eq, sql } from 'drizzle-orm';
+import { db, withSystemDbAccessContext, runOutsideDbContext } from '../db';
+import { partners, devices, organizations } from '../db/schema';
+import type { PartnerTrustState } from '../db/schema/orgs';
+
+export interface TrustRow { trustState: PartnerTrustState; probationEnrollments: number; trustReviewRequestedAt: Date | null }
+
+// System context: the request role must not need SELECT on trust columns
+// for other partners, and dispatch paths run with no request context at all.
+export async function readTrust(partnerId: string): Promise<TrustRow | null> {
+  return runOutsideDbContext(() => withSystemDbAccessContext(async () => {
+    const [row] = await db.select({ trustState: partners.trustState, probationEnrollments: partners.probationEnrollments, trustReviewRequestedAt: partners.trustReviewRequestedAt })
+      .from(partners).where(eq(partners.id, partnerId)).limit(1);
+    return row ?? null;
+  }, 'partnerTrust.readTrust'));
+}
+
+export async function writeTrust(partnerId: string, next: PartnerTrustState, reason: string, actorUserId: string | null): Promise<void> {
+  await runOutsideDbContext(() => withSystemDbAccessContext(() =>
+    db.update(partners).set({ trustState: next, trustReason: reason, trustChangedBy: actorUserId, trustChangedAt: new Date(), updatedAt: new Date() }).where(eq(partners.id, partnerId)),
+    'partnerTrust.writeTrust'));
+}
+
+export async function partnerForDevice(deviceId: string): Promise<string | null> {
+  return runOutsideDbContext(() => withSystemDbAccessContext(async () => {
+    const [row] = await db.select({ partnerId: organizations.partnerId }).from(devices)
+      .innerJoin(organizations, eq(devices.orgId, organizations.id)).where(eq(devices.id, deviceId)).limit(1);
+    return row?.partnerId ?? null;
+  }, 'partnerTrust.partnerForDevice'));
+}
+```
+
+```ts
+// apps/api/src/services/partnerTrust.ts
+import type { MiddlewareHandler } from 'hono';
+import { partnerTrustMode } from '../config/partnerTrustMode';
+import { createAuditLog } from './auditService';
+import { readTrust, writeTrust, partnerForDevice } from './partnerTrust.repo';
+import type { PartnerTrustState } from '../db/schema/orgs';
+
+export type GatedCapability = 'remote_control' | 'device_execute' | 'installer_distribute' | 'agent_enroll';
+export type TrustDenyCode = 'TRUST_PROBATION' | 'TRUST_RESTRICTED';
+export type GateDecision =
+  | { allow: true; shadowDenied?: { code: TrustDenyCode; reason: string } }
+  | { allow: false; code: TrustDenyCode; capability: GatedCapability; reason: string };
+export interface GateContext { partnerId: string; deviceId?: string; orgId?: string; userId?: string; commandType?: string; detail?: Record<string, unknown> }
+
+export const PROBATION_ENROLLMENT_CAP = 5;
+
+/** Commands the platform itself needs on a probation tenant. Anything not
+ *  listed here is gated: an unknown type fails closed. */
+export const LIFECYCLE_COMMAND_TYPES = [
+  'self_uninstall', 'terminal_stop', 'session_stop', 'desktop_stop',
+  'token_rotate', 'token_rotate_confirm', 'watchdog_token_rotate', 'helper_token_rotate',
+  'wake_on_lan', 'peripheral_policy_push', 'outbound_network_policy',
+  'filesystem_analysis', 'inventory_refresh', 'patch_scan', 'security_status_refresh',
+  'agent_update', 'watchdog_update', 'helper_update', 'edition_migrate', 'device_remove',
+] as const;
+
+/** Documented for the allowlist test only; membership is not consulted at runtime. */
+export const GATED_COMMAND_TYPES = [
+  'script', 'execute_command', 'file_write', 'file_copy', 'file_rename', 'file_delete', 'file_trash_restore', 'file_trash_purge',
+  'task_run', 'registry_set', 'registry_key_create', 'registry_key_delete',
+  'software_install', 'software_uninstall', 'software_update', 'homebrew_bootstrap',
+  'install_patches', 'rollback_patches',
+  'backup_restore', 'vm_restore_from_backup', 'vm_instant_boot', 'mssql_restore', 'hyperv_restore', 'hyperv_checkpoint',
+  'actuate_elevation', 'computer_action', 'take_screenshot', 'terminal_start', 'terminal_data', 'terminal_resize',
+  'tunnel_open', 'tunnel_close', 'execute_containment', 'security_threat_quarantine', 'security_threat_remove', 'reboot',
+] as const;
+
+const lifecycle = new Set<string>(LIFECYCLE_COMMAND_TYPES);
+export function isLifecycleCommand(type: string): boolean { return lifecycle.has(type); }
+
+export async function partnerIdForDevice(deviceId: string): Promise<string | null> { return partnerForDevice(deviceId); }
+
+export async function loadTrustState(partnerId: string) { return readTrust(partnerId); }
+
+function decide(cap: GatedCapability, row: { trustState: PartnerTrustState; probationEnrollments: number }, ctx: GateContext): { code: TrustDenyCode; reason: string } | null {
+  if (row.trustState === 'trusted') return null;
+  const code: TrustDenyCode = row.trustState === 'restricted' ? 'TRUST_RESTRICTED' : 'TRUST_PROBATION';
+  switch (cap) {
+    case 'agent_enroll':
+      if (row.trustState === 'restricted') return { code, reason: 'restricted' };
+      return row.probationEnrollments >= PROBATION_ENROLLMENT_CAP ? { code, reason: 'probation_enrollment_cap' } : null;
+    case 'device_execute':
+      if (ctx.commandType && isLifecycleCommand(ctx.commandType)) return null;
+      return { code, reason: row.trustState === 'restricted' ? 'restricted' : 'probation_default_deny' };
+    default:
+      return { code, reason: row.trustState === 'restricted' ? 'restricted' : 'probation_default_deny' };
+  }
+}
+
+export async function evaluateCapability(cap: GatedCapability, ctx: GateContext): Promise<GateDecision> {
+  const mode = partnerTrustMode();
+  if (mode === 'off') return { allow: true };
+  const row = await readTrust(ctx.partnerId);
+  if (!row) return { allow: true }; // unknown partner: lifecycle guards elsewhere handle it
+  const denial = decide(cap, row, ctx);
+  if (!denial) return { allow: true };
+  await createAuditLog({
+    orgId: ctx.orgId ?? null, actorType: ctx.userId ? 'user' : 'system', actorId: ctx.userId ?? null,
+    action: 'partner.trust.capability_denied', resourceType: 'partner', resourceId: ctx.partnerId,
+    result: mode === 'enforce' ? 'denied' : 'success',
+    details: { mode, capability: cap, code: denial.code, reason: denial.reason, deviceId: ctx.deviceId ?? null, commandType: ctx.commandType ?? null, ...ctx.detail },
+  });
+  if (mode === 'shadow') return { allow: true, shadowDenied: denial };
+  return { allow: false, code: denial.code, capability: cap, reason: denial.reason };
+}
+
+export function trustDenyBody(d: Extract<GateDecision, { allow: false }>, reviewRequested: boolean) {
+  return { error: d.code, capability: d.capability, reason: d.reason, reviewRequested, meetingUrl: process.env.PARTNER_MEETING_URL ?? null };
+}
+
+/** Route-level convenience: friendly early 403. The chokepoints remain the control. */
+export function requireCapability(cap: GatedCapability): MiddlewareHandler {
+  return async (c, next) => {
+    const auth = c.get('auth');
+    if (!auth?.partnerId) return next();
+    const d = await evaluateCapability(cap, { partnerId: auth.partnerId, userId: auth.user?.id, orgId: auth.orgId ?? undefined });
+    if (!d.allow) {
+      const row = await readTrust(auth.partnerId);
+      return c.json(trustDenyBody(d, !!row?.trustReviewRequestedAt), 403);
+    }
+    return next();
+  };
+}
+
+export async function setTrustState(partnerId: string, next: PartnerTrustState, reason: string, actorUserId: string | null, evidence: Record<string, unknown> = {}): Promise<void> {
+  const before = await readTrust(partnerId);
+  await writeTrust(partnerId, next, reason, actorUserId);
+  await createAuditLog({
+    orgId: null, actorType: actorUserId ? 'user' : 'system', actorId: actorUserId,
+    action: next === 'trusted' ? 'partner.trust.promoted' : next === 'restricted' ? 'partner.trust.restricted' : 'partner.trust.probation',
+    resourceType: 'partner', resourceId: partnerId, result: 'success',
+    details: { from: before?.trustState ?? null, to: next, reason, ...evidence },
+  });
+}
+```
+
+The `CreateAuditLogParams` shape must be checked against `services/auditService.ts` and the object literal adjusted to its field names (`actorType`, `actorId`, `orgId`, `action`, `resourceType`, `resourceId`, `result`, `details`); the test mocks it so field drift shows up at typecheck, not at runtime.
+
+- [ ] **Step 4: Verify the allowlist against real command types**
+
+Run: `grep -rhoE "type: '([a-z_]+)'" apps/api/src/services/commandQueue.ts apps/api/src/routes apps/api/src/services | sort -u`
+Every type printed must appear in exactly one of `LIFECYCLE_COMMAND_TYPES` or `GATED_COMMAND_TYPES`; extend the test's explicit lists with whatever the grep shows that the lists above do not name, and put each in the right list. Names in the lists above that do not exist in the repo are removed. This step is the one that makes the allowlist true rather than plausible.
+
+- [ ] **Step 5: Run tests, typecheck** — `npx vitest run src/services/partnerTrust.test.ts && npx tsc --noEmit -p .` → PASS.
+
+- [ ] **Step 6: Commit** — `git commit -m "feat(trust): partner trust service, allowlist, audit events"`.
+
+### Task 2.4: New signups enter probation; trust on auth context
+
+**Files:**
+- Modify: `apps/api/src/routes/auth/register.ts:229` (partner insert)
+- Modify: `apps/api/src/middleware/partnerGuard.ts:35-48` (select `trustState` too, set `c.set('trustState', …)`)
+- Modify: `apps/api/src/middleware/auth.ts:72` (`AuthContext.trustState?: PartnerTrustState`)
+- Test: `apps/api/src/routes/auth/register.trust.test.ts` (new), extend `apps/api/src/middleware/partnerGuard.test.ts`
+
+- [ ] **Step 1: Failing tests**
+
+```ts
+// apps/api/src/routes/auth/register.trust.test.ts — follows register.test.ts's existing mocking of db.insert
+it('new partner is created in probation when PARTNER_TRUST_MODE=enforce and hosted', async () => {
+  process.env.IS_HOSTED = 'true'; process.env.PARTNER_TRUST_MODE = 'enforce';
+  await registerPartner(validBody);
+  expect(insertedPartnerValues()).toMatchObject({ trustState: 'probation' });
+});
+it('new partner is trusted when mode is shadow (shadow must not change data)', async () => {
+  process.env.IS_HOSTED = 'true'; process.env.PARTNER_TRUST_MODE = 'shadow';
+  await registerPartner(validBody);
+  expect(insertedPartnerValues().trustState ?? 'trusted').toBe('trusted');
+});
+```
+
+Shadow must not write `probation`: the point of shadow is measuring denials without changing state, and a shadow partner flipped to `probation` would be denied the moment enforce turns on without ever having been in the queue. Shadow measures against `trusted` partners created after the flag is set, using the `mode: shadow` audit rows, which is what Wave 7's acceptance reads.
+
+- [ ] **Step 2: Run to fail**, **Step 3: Implement**
+
+In `register.ts` at the partner insert: `trustState: partnerTrustMode() === 'enforce' ? 'probation' : 'trusted'`, and immediately after the insert, `if (trustState === 'probation') await createAuditLog({ ...action: 'partner.trust.probation', resourceId: partner.id, details: { reason: 'signup' } })` (reuse `setTrustState`'s audit shape by calling `setTrustState(partner.id, 'probation', 'signup', null)` after the insert instead of duplicating the row; the extra `UPDATE` is fine at signup volume).
+
+In `partnerGuard.ts`, add `trustState: partners.trustState` to the select and `c.set('trustState', partner.trustState)` before `return next()` on the active path. In `auth.ts`, add `trustState?: PartnerTrustState` to `AuthContext` and populate from `c.get('trustState')` where the auth context is assembled after `partnerGuard` (if auth runs first, leave `AuthContext` untouched and have `requireCapability` read `c.get('trustState')` as a fast path before `readTrust`).
+
+- [ ] **Step 4: Run** `npx vitest run src/routes/auth/register src/middleware/partnerGuard` → PASS (check the file count: `src/routes/auth/register` also matches `register.test.ts`).
+- [ ] **Step 5: Commit** — `git commit -m "feat(trust): signups enter probation under enforce; trust on guard context"`.
+
+### Task 2.5: Wave 2 PR
+
+- [ ] Run full API suite `pnpm --filter @breeze/api test --run`, then `cd apps/api && npx vitest run -c vitest.config.rls.ts` and `npx vitest run -c vitest.integration.config.ts src/__tests__/integration/rls-coverage src/__tests__/integration/tenant-export-policy` against the local DB.
+- [ ] `pnpm lint`.
+- [ ] Open PR `feat(trust): probation foundation (W02)` with `Closes #<W02 sub-issue>`; body lists the migration name and the export-policy bucket decision from Task 2.1 for reviewer attention.
+
+---
+
+## Wave 3 — Command dispatch chokepoints
+
+### Task 3.1: Gate helper for dispatch
+
+**Files:**
+- Create: `apps/api/src/services/partnerTrust.commands.ts`
+- Test: `apps/api/src/services/partnerTrust.commands.test.ts`
+
+**Interfaces:**
+- Produces: `export class TrustDeniedError extends Error { code: TrustDenyCode; capability: 'device_execute'; reason: string; deviceId: string; commandType: string }` and `export async function assertDeviceExecuteAllowed(deviceId: string, commandType: string, userId?: string | null): Promise<void>` (throws `TrustDeniedError` on deny, returns on allow or shadow).
+
+- [ ] **Step 1: Failing test**
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+const evaluate = vi.fn();
+vi.mock('./partnerTrust', () => ({ evaluateCapability: evaluate, partnerIdForDevice: async () => 'p1', isLifecycleCommand: (t: string) => t === 'self_uninstall' }));
+import { assertDeviceExecuteAllowed, TrustDeniedError } from './partnerTrust.commands';
+
+it('throws TrustDeniedError on deny', async () => {
+  evaluate.mockResolvedValueOnce({ allow: false, code: 'TRUST_PROBATION', capability: 'device_execute', reason: 'probation_default_deny' });
+  await expect(assertDeviceExecuteAllowed('d1', 'script', 'u1')).rejects.toBeInstanceOf(TrustDeniedError);
+});
+it('returns on allow', async () => {
+  evaluate.mockResolvedValueOnce({ allow: true });
+  await expect(assertDeviceExecuteAllowed('d1', 'script', 'u1')).resolves.toBeUndefined();
+});
+it('skips the lookup entirely for lifecycle commands', async () => {
+  evaluate.mockClear();
+  await assertDeviceExecuteAllowed('d1', 'self_uninstall');
+  expect(evaluate).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Fail**, **Step 3: Implement**
+
+```ts
+// apps/api/src/services/partnerTrust.commands.ts
+import { evaluateCapability, partnerIdForDevice, isLifecycleCommand, type TrustDenyCode } from './partnerTrust';
+
+export class TrustDeniedError extends Error {
+  readonly code: TrustDenyCode; readonly capability = 'device_execute' as const; readonly reason: string; readonly deviceId: string; readonly commandType: string;
+  constructor(code: TrustDenyCode, reason: string, deviceId: string, commandType: string) {
+    super(`Partner trust ${code}: ${commandType} on ${deviceId} (${reason})`);
+    this.name = 'TrustDeniedError'; this.code = code; this.reason = reason; this.deviceId = deviceId; this.commandType = commandType;
+  }
+}
+
+export async function assertDeviceExecuteAllowed(deviceId: string, commandType: string, userId?: string | null): Promise<void> {
+  if (isLifecycleCommand(commandType)) return;
+  const partnerId = await partnerIdForDevice(deviceId);
+  if (!partnerId) return;
+  const d = await evaluateCapability('device_execute', { partnerId, deviceId, userId: userId ?? undefined, commandType });
+  if (!d.allow) throw new TrustDeniedError(d.code, d.reason, deviceId, commandType);
+}
+```
+
+- [ ] **Step 4: Pass**, **Step 5: Commit** — `git commit -m "feat(trust): assertDeviceExecuteAllowed for dispatch chokepoints"`.
+
+### Task 3.2: Gate `commandQueue.ts`
+
+**Files:**
+- Modify: `apps/api/src/services/commandQueue.ts:601` (`queueCommand`), `:802` (`queueCommandForExecution`), `:913` (`executeCommand`)
+- Test: extend `apps/api/src/services/commandQueue.test.ts`
+
+- [ ] **Step 1: Failing tests** (add to the existing suite, using its existing device/db mocks)
+
+```ts
+vi.mock('./partnerTrust.commands', async (orig) => ({ ...(await orig()), assertDeviceExecuteAllowed: vi.fn(async (_d, t) => { if (t === 'script') throw new TrustDeniedError('TRUST_PROBATION', 'probation_default_deny', 'd1', 'script'); }) }));
+
+it('queueCommand refuses a gated type for a probation partner and inserts nothing', async () => {
+  await expect(queueCommand('d1', 'script', {}, 'u1')).rejects.toBeInstanceOf(TrustDeniedError);
+  expect(insertSpy).not.toHaveBeenCalled();
+});
+it('queueCommand still queues self_uninstall', async () => {
+  await expect(queueCommand('d1', 'self_uninstall', { removeConfig: true }, 'u1')).resolves.toBeTruthy();
+});
+it('queueCommandForExecution returns a structured trust error instead of throwing', async () => {
+  await expect(queueCommandForExecution('d1', 'script', {})).resolves.toMatchObject({ error: 'TRUST_PROBATION', trust: { reason: 'probation_default_deny' } });
+});
+it('executeCommand returns a failed CommandResult with the trust code', async () => {
+  await expect(executeCommand('d1', 'script', {})).resolves.toMatchObject({ success: false, error: 'TRUST_PROBATION' });
+});
+```
+
+- [ ] **Step 2: Fail**, **Step 3: Implement**
+
+In `queueCommand` (line 601), after the `AGENT_BINARY_UPDATE_COMMAND_TYPES` check and before `resolveCommandCreatedBy`:
+
+```ts
+  await assertDeviceExecuteAllowed(deviceId, type, userId);
+```
+
+In `queueCommandForExecution` (line 802), after the `device.status !== 'online'` check:
+
+```ts
+  try { await assertDeviceExecuteAllowed(deviceId, type, userId); }
+  catch (e) { if (e instanceof TrustDeniedError) return { error: e.code, trust: { capability: e.capability, reason: e.reason } }; throw e; }
+```
+
+and extend `QueueCommandForExecutionResult`'s error variant with `trust?: { capability: 'device_execute'; reason: string }`.
+
+In `executeCommand` (line 913), after the device select and before the WS dispatch branch:
+
+```ts
+  try { await assertDeviceExecuteAllowed(deviceId, type, userId); }
+  catch (e) { if (e instanceof TrustDeniedError) return { success: false, error: e.code, output: '', exitCode: null, trust: { capability: e.capability, reason: e.reason } } as CommandResult; throw e; }
+```
+
+adding the optional `trust` field to `CommandResult`.
+
+- [ ] **Step 4: Run** `npx vitest run src/services/commandQueue` and `npx tsc --noEmit -p .` → PASS.
+- [ ] **Step 5: Commit** — `git commit -m "feat(trust): gate queueCommand/queueCommandForExecution/executeCommand"`.
+
+### Task 3.3: Route the two raw inserts through the queue helper
+
+**Files:**
+- Modify: `apps/api/src/routes/devices/actuateElevation.ts:191-217` (raw `insert(deviceCommands)` at 200)
+- Modify: `apps/api/src/routes/mobile.ts:1318`
+- Test: extend `actuateElevation.test.ts` and `mobile.test.ts`
+
+- [ ] **Step 1: Failing tests** — for each route, mock `assertDeviceExecuteAllowed` to throw `TrustDeniedError` and assert the response is `403` with body `{ error: 'TRUST_PROBATION', capability: 'device_execute', reason: 'probation_default_deny' }` and that no `device_commands` row is inserted.
+- [ ] **Step 2: Fail**, **Step 3: Implement** — call `await assertDeviceExecuteAllowed(deviceId, 'actuate_elevation', auth.user.id)` (resp. `data.action`) immediately before the raw insert, catching `TrustDeniedError` and returning `c.json(trustDenyBody({ allow: false, code: e.code, capability: 'device_execute', reason: e.reason }, false), 403)`. The raw inserts stay raw (they carry single-use transactional semantics the queue helper does not); the gate is what moves.
+- [ ] **Step 4: Pass**, **Step 5: Commit** — `git commit -m "feat(trust): gate PAM actuation and mobile actions"`.
+
+### Task 3.4: Agent WebSocket fast path
+
+**Files:**
+- Modify: `apps/api/src/routes/agentWs.ts` — the `activeConnections` record type, the connect/auth path that populates it, and `sendCommandToAgent` at `:3123`
+- Modify: `apps/api/src/services/partnerTrust.ts` — `setTrustState` publishes `partner-trust:changed` on Redis
+- Test: extend `apps/api/src/routes/agentWs.test.ts`
+
+**Interfaces:**
+- `sendCommandToAgent(agentId, command)` keeps its synchronous signature. It returns `false` (not sent) when the connection's cached `trustState` is not `trusted` and `!isLifecycleCommand(command.type)` under `enforce`; callers already treat `false` as "agent offline" and fall back to `queueCommand`, which is gated by Task 3.2 and produces the real decision and audit row. Under `shadow` it sends and writes the audit row via `evaluateCapability` fire-and-forget.
+
+- [ ] **Step 1: Failing tests**
+
+```ts
+it('fast path refuses a gated command for a probation connection and returns false', () => {
+  registerConnection('agent-1', fakeWs, { partnerId: 'p1', trustState: 'probation' });
+  expect(sendCommandToAgent('agent-1', { id: 'c1', type: 'script', payload: {} })).toBe(false);
+  expect(fakeWs.send).not.toHaveBeenCalled();
+});
+it('fast path sends lifecycle commands regardless of trust', () => {
+  registerConnection('agent-1', fakeWs, { partnerId: 'p1', trustState: 'probation' });
+  expect(sendCommandToAgent('agent-1', { id: 'c1', type: 'self_uninstall', payload: {} })).toBe(true);
+});
+it('a partner-trust:changed message updates the cached state for every connection of that partner', async () => {
+  registerConnection('agent-1', fakeWs, { partnerId: 'p1', trustState: 'probation' });
+  await handleTrustChanged({ partnerId: 'p1', trustState: 'trusted' });
+  expect(sendCommandToAgent('agent-1', { id: 'c1', type: 'script', payload: {} })).toBe(true);
+});
+```
+
+- [ ] **Step 2: Fail**, **Step 3: Implement**
+
+1. Extend the connection record (wherever `activeConnections.set(agentId, ws)` is done at agent auth) to `{ ws, partnerId, trustState }`. The partner id and trust state are resolved once at connect time with `partnerIdForDevice(deviceId)` + `loadTrustState(partnerId)`; the agent-auth path already runs in a system context.
+2. `sendCommandToAgent`: after `const conn = activeConnections.get(agentId); if (!conn) return false;` add
+
+```ts
+  const mode = partnerTrustMode();
+  if (mode !== 'off' && conn.trustState !== 'trusted' && !isLifecycleCommand(command.type)) {
+    if (mode === 'enforce') return false; // caller falls back to queueCommand, which audits and decides
+    void evaluateCapability('device_execute', { partnerId: conn.partnerId, commandType: command.type, detail: { via: 'ws_fast_path' } });
+  }
+```
+
+3. Subscribe (in the same module's boot path that already subscribes to Redis for agent events) to channel `partner-trust:changed`; on message `{ partnerId, trustState }`, update every connection with that `partnerId`. `setTrustState` publishes the message after `writeTrust`.
+
+- [ ] **Step 4: Pass**, **Step 5: Commit** — `git commit -m "feat(trust): agent WS fast path honours partner trust"`.
+
+### Task 3.5: Wave 3 PR
+
+- [ ] Grep-verify no dispatch path bypasses the gate: `grep -rn "insert(deviceCommands)" apps/api/src | grep -v test` must list only `actuateElevation.ts`, `mobile.ts`, `commandQueue.ts`, and the system-initiated sites named in the spec (`routes/agents/helpers.ts`, `services/wakeOnLan.ts`, `desktopSessionStop.ts`, `tenantOffboarding.ts`, `deviceUninstallDrain.ts`, `peripheralPolicyState.ts`); each of the system sites emits a lifecycle type (assert with a unit test that reads their literal `type:` values and passes them through `isLifecycleCommand`).
+- [ ] Full API suite, lint, PR `feat(trust): dispatch chokepoints (W03)` with `Closes #<W03>`.
+
+---
+
+## Wave 4 — Sessions, distribution, enrollment
+
+### Task 4.1: `createRemoteSession()` service
+
+**Files:**
+- Create: `apps/api/src/services/remoteSessionCreate.ts` (+ test)
+- Modify: `apps/api/src/routes/remote/sessions.ts:251`, `apps/api/src/services/aiToolsRemote.ts:384`, `apps/api/src/routes/remote/supportSessions.ts:49`, `apps/api/src/routes/tunnels.ts:391,589,1616`
+
+**Interfaces:**
+
+```ts
+export type SessionKind = 'remote' | 'support' | 'tunnel';
+export class RemoteSessionDeniedError extends Error { code: TrustDenyCode; reason: string }
+export async function createRemoteSession(kind: 'remote', input: { deviceId: string; orgId: string; userId: string; type: 'desktop' | 'terminal' | 'file_transfer' }): Promise<{ id: string; status: string }>;
+export async function createRemoteSession(kind: 'support', input: SupportSessionInsert & { partnerId: string }): Promise<SupportSessionRow>;
+export async function createRemoteSession(kind: 'tunnel', input: TunnelSessionInsert): Promise<TunnelSessionRow>;
+```
+
+Each overload resolves the partner (`partnerIdForDevice(deviceId)` for remote/tunnel; `partnerId` passed for support since no device exists yet), calls `evaluateCapability('remote_control', …)`, throws `RemoteSessionDeniedError` on deny, and otherwise performs the exact insert the call site does today (values copied verbatim from the three sites; support keeps its `runOutsideDbContext(withSystemDbAccessContext(...))` wrapper).
+
+- [ ] **Step 1: Failing tests** — one per kind: deny throws and inserts nothing; allow returns the inserted row; `shadow` inserts and returns.
+- [ ] **Step 2: Fail**, **Step 3: Implement**, replacing each inline insert with the call and mapping `RemoteSessionDeniedError` to `c.json(trustDenyBody(...), 403)` in the routes and to a tool error `{ error: 'TRUST_PROBATION', message: 'Remote control is not available until this account is verified.' }` in `aiToolsRemote.ts`.
+- [ ] **Step 4: Pass** (`npx vitest run src/routes/remote src/services/aiToolsRemote src/routes/tunnels`), **Step 5: Commit** — `git commit -m "feat(trust): all session inserts go through createRemoteSession"`.
+
+### Task 4.2: Ticket-time re-check
+
+**Files:**
+- Modify: `apps/api/src/routes/desktopWs.ts:1276` (`POST /connect/exchange`), `apps/api/src/routes/terminalWs.ts:1114` (WS upgrade), `apps/api/src/routes/tunnels.ts:1061,1121,1189` (tickets, connect-code)
+- Test: extend each route's test file
+
+- [ ] **Step 1: Failing tests** — session row exists, partner is `probation` under enforce → exchange/upgrade/ticket returns 403 `TRUST_PROBATION`; `trusted` → unchanged behaviour.
+- [ ] **Step 2: Fail**, **Step 3: Implement** — after the session row is loaded in each handler: `const partnerId = await partnerIdForDevice(session.deviceId); const d = partnerId ? await evaluateCapability('remote_control', { partnerId, deviceId: session.deviceId, userId, detail: { stage: 'ticket' } }) : { allow: true }; if (!d.allow) return c.json(trustDenyBody(d, false), 403);` (for the WS upgrade, close with code `4403` and reason `TRUST_PROBATION` instead of JSON).
+- [ ] **Step 4: Pass**, **Step 5: Commit** — `git commit -m "feat(trust): re-check trust at ticket issuance"`.
+
+### Task 4.3: Third-party remote launch and installer distribution
+
+**Files:**
+- Modify: `apps/api/src/routes/devices/core.ts:1203-1218` (third-party launch): add `requireCapability('remote_control')` to the route chain.
+- Modify: `apps/api/src/routes/enrollmentKeys.ts` — the child-key/installer-link handler that emits `enrollment_key.installer_link_created` (`:2131` region), onboarding-token creation, and the bulk-link creators: add `requireCapability('installer_distribute')`.
+- Modify: `apps/api/src/routes/enrollmentKeys.ts:2519` (`GET /public-download/:platform`) and `:2576` (short-link redirect): these are unauthenticated; after resolving the key, resolve `partnerId` via the key's org (`organizations.partnerId`) and call `evaluateCapability('installer_distribute', { partnerId, orgId, detail: { route: 'public-download' } })`; on deny respond `404` (never reveal the gate to an anonymous downloader) and audit as usual.
+- Modify: `apps/api/src/routes/remote/supportSessions.ts:52` (Quick Support create): covered by Task 4.1 (`support` kind); `apps/api/src/routes/supportPublic.ts:319-369` (anonymous download) and `:445-551` (code redemption): same anonymous pattern as public download, deny → 404.
+- Test: extend `enrollmentKeys.test.ts`, `supportPublic.test.ts`, `devices/core.test.ts`.
+
+- [ ] **Step 1: Failing tests** for each: probation → 403 (authenticated) or 404 (anonymous) and an audit row with `capability: 'installer_distribute'`; trusted → unchanged.
+- [ ] **Step 2: Fail**, **Step 3: Implement**, **Step 4: Pass**, **Step 5: Commit** — `git commit -m "feat(trust): gate installer distribution, Quick Support, third-party launch"`.
+
+### Task 4.4: Enrollment counter in the enrollment transaction
+
+**Files:**
+- Modify: `apps/api/src/routes/agents/enrollment.ts:694-861`
+- Test: extend `enrollment.test.ts`; add integration test `apps/api/src/__tests__/integration/partnerTrustEnrollment.integration.test.ts`
+
+- [ ] **Step 1: Failing tests**
+
+Unit: with mode `enforce`, a partner row `{ trustState: 'probation', probationEnrollments: 5 }` → `POST /enroll` returns 403 `{ error: 'TRUST_PROBATION', capability: 'agent_enroll', reason: 'probation_enrollment_cap' }` and no device insert; with `4` → device inserted and the update sets `probationEnrollments = 5`.
+
+Integration (real Postgres, in the `integration-test` job): create a probation partner, fire 8 concurrent `POST /enroll` requests with distinct agent ids, assert exactly 5 devices exist and `probation_enrollments = 5`; delete two devices, enroll again, assert still denied.
+
+- [ ] **Step 2: Fail**, **Step 3: Implement** — inside the existing `db.transaction(async (tx) => { … })` at line 694, before the device-cap count:
+
+```ts
+    const [trustRow] = await tx.select({ trustState: partners.trustState, probationEnrollments: partners.probationEnrollments })
+      .from(partners).where(eq(partners.id, deviceLimitPartnerId)).for('update');
+    if (trustRow && partnerTrustMode() !== 'off' && trustRow.trustState !== 'trusted') {
+      const d = await evaluateCapability('agent_enroll', { partnerId: deviceLimitPartnerId, orgId: key.orgId, detail: { probationEnrollments: trustRow.probationEnrollments } });
+      if (!d.allow) { writeAuditEvent(c, { orgId: key.orgId, action: 'agent.enroll', result: 'denied', details: { reason: d.reason } }); throw new HTTPException(403, { message: JSON.stringify(trustDenyBody(d, false)) }); }
+      await tx.update(partners).set({ probationEnrollments: sql`${partners.probationEnrollments} + 1` }).where(eq(partners.id, deviceLimitPartnerId));
+    }
+```
+
+`evaluateCapability` reads through the repo's own system context, not `tx`; the `FOR UPDATE` on `tx` is what serialises concurrent enrollments, and the counter read for the decision must come from `trustRow` (pass it via `detail` and have `decide()` prefer `ctx.detail.probationEnrollments` when present, so the locked value is the one compared). Also enqueue `ip-classify` for the new device's `enrollmentIp` (Wave 5 defines the job; until then, no-op if the queue is absent).
+
+- [ ] **Step 4: Pass** (unit locally; integration against the local DB with `npx vitest run -c vitest.integration.config.ts src/__tests__/integration/partnerTrustEnrollment`), **Step 5: Commit** — `git commit -m "feat(trust): lifetime probation enrollment counter, locked in the enrollment tx"`.
+
+### Task 4.5: Wave 4 PR
+
+- [ ] Integration suites (RLS coverage, export policy, the new enrollment test) + full API suite + lint. PR `feat(trust): session, distribution and enrollment gates (W04)` with `Closes #<W04>`.
+
+---
+
+## Wave 5 — Promotion, IP classification, admin routes, evidence card
+
+### Task 5.1: IP classification job
+
+**Files:**
+- Create: `apps/api/src/services/ipClassify.ts` (+ test), `apps/api/src/jobs/partnerTrustJobs.ts`
+- Modify: `apps/api/src/config/env.ts` (`IP_CLASSIFY_PROVIDER = ipinfo | ipdata | none`, `IP_CLASSIFY_API_KEY`), `apps/api/src/jobs/scheduleRegistry.ts` (`'partner-trust-promote': '*/15 * * * *'`, and `'abuse-signals-sweep'` from `'22 * * * *'` to `'22,37,52,7 * * * *'` per spec §3.7), `apps/api/src/routes/auth/register.ts` (enqueue for signup IP), `apps/api/src/routes/agents/enrollment.ts` (enqueue for enrollment IP)
+
+**Interfaces:**
+
+```ts
+export type IpClassification = { ipClass: IpClass; asn: number | null; provider: string };
+export async function classifyIp(ip: string): Promise<IpClassification>; // Redis cache per /24 or /48, 7 d; provider 'none' → static hostingPrefixes fallback; any error → { ipClass: 'unknown', asn: null }
+export async function enqueueIpClassify(target: { kind: 'partner'; partnerId: string; ip: string } | { kind: 'device'; deviceId: string; ip: string }): Promise<void>;
+```
+
+- [ ] **Step 1: Failing tests** — provider response mapping (`privacy.hosting → hosting`, `privacy.vpn → vpn`, `privacy.tor → tor`, neither → `residential`, `company.type === 'business'` → `business`); cache hit skips the HTTP call; provider error → `unknown`; job handler writes `signup_ip_class` / `enrollment_ip_class` + asn + `classified_at`.
+- [ ] **Step 2: Fail**, **Step 3: Implement** with `fetch`, a 3 s timeout, and the Redis key `ipclass:v1:<prefix>`; the BullMQ worker lives in `partnerTrustJobs.ts` on the existing `abuse-signals` queue (job name `ip-classify`), following `abuseSignalsSweep.ts`'s registration pattern, gated by `partnerTrustMode() !== 'off'`.
+- [ ] **Step 4: Pass**, **Step 5: Commit** — `git commit -m "feat(trust): async IP classification job"`.
+
+### Task 5.2: Promotion evaluator and job
+
+**Files:**
+- Create: `apps/api/src/services/partnerTrustPromotion.ts` (+ test)
+- Modify: `apps/api/src/services/partnerTrust.ts` (call `tryAutoPromote` on deny), `apps/api/src/jobs/partnerTrustJobs.ts` (job `partner-trust-promote`, every 15 min)
+
+**Interfaces:**
+
+```ts
+export interface PromotionFacts { createdAt: Date; emailVerified: boolean; settledCard: { chargeId: string; settledAt: Date } | null; signupIpClass: IpClass; deviceIpClasses: IpClass[]; unresolvedAlerts: number; billingHold: boolean }
+export function promotionDecision(facts: PromotionFacts, now: Date): { promote: true; reason: 'auto:settled_card_24h' } | { promote: false; blockers: string[] };
+export async function gatherPromotionFacts(partnerId: string): Promise<PromotionFacts>; // billing_events via breezeBillingClient, partner + devices + partner_abuse_signals in system ctx
+export async function tryAutoPromote(partnerId: string): Promise<boolean>;
+```
+
+- [ ] **Step 1: Failing tests** — table-driven over `promotionDecision`: link charge → blocker `card_not_settled`; charge 23 h old → blocker; refunded/disputed → blocker; signup class `hosting` → blocker `signup_ip_hosting`; `unknown` → blocker `signup_ip_unclassified`; device on `hosting` → not a blocker; device on `tor` → blocker; unresolved alert → blocker; all clear → promote. `tryAutoPromote` calls `setTrustState(partnerId, 'trusted', 'auto:settled_card_24h', null, facts)` only when `promote` and current state is `probation` (never `restricted`).
+- [ ] **Step 2: Fail**, **Step 3: Implement**. In `evaluateCapability`, on a `probation` denial call `void tryAutoPromote(ctx.partnerId)` after the audit write (fire-and-forget; the current request still denies, the next one passes). `breezeBillingClient` gains `getSettledCardCharge(partnerId)` reading `billing_events` for the partner's customer: newest `charge.succeeded` with `payment_method_details.type === 'card'`, `billing_details.name` non-empty, `payment_method_details.card.three_d_secure?.authenticated !== false`, no later `charge.refunded`/`charge.dispute.created` for the same charge.
+- [ ] **Step 4: Pass**, **Step 5: Commit** — `git commit -m "feat(trust): auto-promotion on settled 3DS card, lazy + 15-min job"`.
+
+### Task 5.3: Hard-deny rules
+
+**Files:**
+- Modify: `apps/api/src/services/partnerTrustPromotion.ts` — `export async function evaluateHardDenies(partnerId: string): Promise<{ restrict: true; reason: string; evidence: Record<string, unknown> } | { restrict: false }>`, run by the `ip-classify` job after it writes a class and by the 15-min job.
+- Test: extend the promotion test.
+
+Rules (each must hold in full):
+1. `signup_ip_class = 'tor'` → `auto:tor_signup`.
+2. Stripe: `billing_card_fingerprint` matches a partner suspended for abuse (same region, `partners.status='suspended'` with a `partner.suspended_for_abuse` audit row), or the customer's email matches a `fraudulent`-refund customer (via `breezeBillingClient.hasFraudulentRefundMatch(partnerId)`) → `auto:fraud_identity_match`.
+3. Signup or enrollment IP within /24 (v4) or /64 (v6) of a suspended-for-abuse partner's signup or enrollment IP in the last 90 days **and** one of: same email domain, same `billing_card_fingerprint`, same `signup_user_agent` and a device hostname prefix shared with the suspended partner's devices → `auto:corroborated_suspended_network`.
+
+- [ ] **Step 1: Failing tests** — IP match alone → no restrict; IP match + same email domain → restrict with evidence naming both axes; tor → restrict; a `restricted` partner is never auto-promoted.
+- [ ] **Step 2: Fail**, **Step 3: Implement** (SQL over `partners`, `devices`, `audit_logs` filtered by `action = 'partner.suspended_for_abuse'` and `timestamp >= now() - interval '90 days'`; use `inet` prefix arithmetic via `set_masklen(host(ip)::inet, 24)`), **Step 4: Pass**, **Step 5: Commit** — `git commit -m "feat(trust): corroborated hard-deny rules"`.
+
+### Task 5.4: Admin routes and partner review request
+
+**Files:**
+- Create: `apps/api/src/routes/admin/trust.ts` (+ test), `apps/api/src/routes/partnerTrust.ts` (+ test)
+- Modify: `apps/api/src/routes/admin/index.ts` (mount under the existing `platformAdminMiddleware`), main router (mount `partnerTrustRoutes` at `/partner/trust`)
+
+Routes:
+- `POST /admin/partners/:id/trust/promote` and `/restrict`, `requireMfa()`, body `{ reason: string (min 8) }` → `setTrustState(id, 'trusted' | 'restricted', 'admin:' + verb, auth.user.id, { reason })`; 404 unknown partner; 409 if promote on `restricted` without `{ override: true }`.
+- `GET /admin/trust/queue` → `partners WHERE trust_state <> 'trusted'` with the evidence card (Task 5.5) per row, newest denial first, `limit`/`cursor`.
+- `POST /partner/trust/request-review` (partner scope, `requireScope('partner')`): sets `trust_review_requested_at` if null or older than 24 h, emails the ops card, returns `{ requested: true }`; 429 otherwise.
+- `GET /partner/trust` → `{ trustState, checklist: { ageOk, emailVerified, cardSettled, signupIpOk }, reviewRequestedAt }` for the banner.
+
+- [ ] **Step 1: Failing route tests** (follow `routes/admin/abuse.test.ts`'s mocking), **Step 2: Fail**, **Step 3: Implement**, **Step 4: Pass**, **Step 5: Commit** — `git commit -m "feat(trust): admin promote/restrict/queue, partner review request"`.
+
+### Task 5.5: Evidence card email with TOTP-guarded action links
+
+**Files:**
+- Create: `apps/api/src/services/partnerTrustEvidenceCard.ts` (+ test), `apps/api/src/routes/admin/trustAct.ts` (+ test)
+- Modify: `apps/api/src/services/opsAlerts.ts` (reuse `sendOpsAlert` for delivery; HTML body support if absent)
+
+**Interfaces:**
+
+```ts
+export async function buildEvidenceCard(partnerId: string): Promise<EvidenceCard>; // partner, plan, signup ip/class/asn, email domain age + MX (dns.promises.resolveMx, 2 s timeout), cardholder vs user name, distinct PMs + failures, devices[{hostname, enrollmentIpClass, isVirtual}], denials24h, matchedSuspendedAxes[]
+export function mintTrustActionToken(partnerId: string, action: 'approve' | 'suspend', operatorUserId: string): string; // HMAC-signed, 24 h, single-use via Redis key trustact:<jti>
+export async function sendEvidenceCard(partnerId: string, trigger: 'probation_watch' | 'review_requested' | 'restricted'): Promise<void>;
+```
+
+Action flow: `GET /admin/trust/act?token=…` renders a minimal page (server-rendered HTML from the API, no web build dependency) showing the card summary and a TOTP field; `POST /admin/trust/act` with `{ token, totp }` verifies the token (signature, expiry, unused, `operatorUserId` matches the authenticated platform admin), verifies the code with `consumeMFAToken(secret, totp, userId)` (`services/mfa.ts:38`), marks the jti used, then calls `setTrustState(..., 'trusted', 'admin:approve_link', userId)` or the existing suspend-for-abuse service function with reason `'trust_card_link'`. The token alone never acts.
+
+- [ ] **Step 1: Failing tests** — token round-trip; expired/used/mismatched-operator → 403; wrong TOTP → 403 and token still unused; correct TOTP → state change + token consumed; card builder fields for a fixture partner.
+- [ ] **Step 2: Fail**, **Step 3: Implement**, **Step 4: Pass**, **Step 5: Commit** — `git commit -m "feat(trust): evidence card email with TOTP-guarded approve/suspend links"`.
+
+### Task 5.6: Wave 5 PR
+
+- [ ] Full API suite, lint, PR `feat(trust): promotion, classification, admin surface (W05)` with `Closes #<W05>`. PR body lists the two new env vars (`IP_CLASSIFY_PROVIDER`, `IP_CLASSIFY_API_KEY`) and the compose `environment:` mapping they need on the droplets.
+
+---
+
+## Wave 6 — Web client
+
+### Task 6.1: Trust deny handling in `runAction` and the banner
+
+**Files:**
+- Create: `apps/web/src/lib/trustProbation.ts`, `apps/web/src/components/trust/TrustProbationBanner.tsx` (+ tests)
+- Modify: `apps/web/src/lib/runAction.ts:4-14` (recognise `TRUST_PROBATION | TRUST_RESTRICTED` bodies and dispatch a `trust-denied` window event instead of the generic toast)
+
+- [ ] **Step 1: Failing tests** — `runAction` receiving a 403 with `error: 'TRUST_PROBATION'` dispatches `CustomEvent('breeze:trust-denied', { detail: body })` and shows no toast; the banner renders capability copy, the checklist from `GET /partner/trust`, and the Request review button which calls `POST /partner/trust/request-review` via `runAction` and flips to "Review requested".
+- [ ] **Step 2: Fail**, **Step 3: Implement**. Copy (no mechanism details): title "Verification pending", body "Remote control and script execution unlock after your first card payment settles (about 24 hours) or once we've reviewed your account.", button "Request review", secondary link "Book a call" using `meetingUrl` when present.
+- [ ] **Step 4: Pass** (`cd apps/web && npx vitest run src/lib/runAction src/components/trust`), **Step 5: Commit**.
+
+### Task 6.2: Onboarding copy and the `no-silent-mutations` guard
+
+- [ ] Add one sentence to the post-signup onboarding screen naming what unlocks after payment or review. Run `npx vitest run src/lib/__tests__/no-silent-mutations.test.ts` to confirm the new handlers are covered. Commit, PR `feat(trust): probation banner and review request (W06)` with `Closes #<W06>`.
+
+---
+
+## Wave 7 — Rollout: shadow acceptance, enforce, backfill, admin page, smoke
+
+### Task 7.1: Shadow acceptance query and smoke assertions
+
+**Files:**
+- Create: `apps/api/scripts/partner-trust-shadow-report.sql` — counts `partner.trust.capability_denied` audit rows with `details->>'mode' = 'shadow'` per partner over 7 days joined to `partners.status` and `created_at`, so the acceptance rule in the spec (§5 step 3) is one query.
+- Modify: `.github/workflows/guided-setup-smoke.yml` — after the stack boots (self-hosted, `IS_HOSTED=false`), assert `POST /remote/sessions` for the seeded device returns 200/400 (device offline) and never 403 `TRUST_*`.
+- Test: `apps/api/src/config/partnerTrustMode.test.ts` already pins the self-hosted `off`.
+
+- [ ] Commit `chore(trust): shadow report + self-hosted smoke assertion`.
+
+### Task 7.2: Backfill batch
+
+**Files:**
+- Create: `apps/api/scripts/partner-trust-backfill.sql`
+
+```sql
+-- Run manually per region as doadmin after PARTNER_TRUST_MODE=enforce is live.
+-- Dry run first: replace COMMIT with ROLLBACK.
+BEGIN;
+SET LOCAL breeze.scope = 'system';
+CREATE TEMP TABLE bf AS
+SELECT p.id FROM partners p
+WHERE p.status = 'active' AND p.trust_state = 'trusted'
+  AND p.created_at >= now() - interval '14 days'
+  AND NOT EXISTS (SELECT 1 FROM billing_settled_card_view v WHERE v.partner_id = p.id); -- view created in W05 over billing events
+UPDATE partners SET trust_state = 'probation', trust_reason = 'backfill:2026-09', trust_changed_at = now() WHERE id IN (SELECT id FROM bf);
+INSERT INTO audit_logs (...) SELECT ... 'partner.trust.probation' ... FROM bf; -- same columns createAuditLog writes
+DO $$ DECLARE n int; BEGIN SELECT count(*) INTO n FROM bf; RAISE WARNING 'partner-trust backfill moved % partners to probation', n; END $$;
+COMMIT;
+```
+
+then `POST /admin/trust/queue` is read once and `sendEvidenceCard(id, 'probation_watch')` is fired for each row via a one-off script `apps/api/scripts/partner-trust-backfill-cards.ts`. The `breeze.scope = 'system'` line is mandatory on managed Postgres (a backfill without it is a silent 0-row no-op as `doadmin`).
+
+- [ ] Commit; execution is an operator step recorded in the wave's PR body, not CI.
+
+### Task 7.3: Admin trust-queue page
+
+**Files:**
+- Create: `apps/web/src/pages/admin/trust-queue.astro`, `apps/web/src/components/admin/TrustQueue.tsx` (+ test)
+
+- [ ] Table of `GET /admin/trust/queue` rows with the evidence card expanded inline, Approve / Restrict / Suspend buttons through `runAction` (each prompts for the reason; MFA step-up is enforced by the API's `requireMfa()`). Note in the PR that production has zero platform admins and the operator account needs `is_platform_admin = true` before the page is usable.
+- [ ] Commit, PR `feat(trust): rollout tooling and admin queue (W07)` with `Closes #<W07>`.
+
+### Task 7.4: Flip and record
+
+- [ ] After 7 days of shadow with the acceptance query clean: set `PARTNER_TRUST_MODE=enforce` in `/opt/breeze/.env` on both droplets and map it in the `api` service `environment:` block; `docker compose up -d api`; run the backfill; verify `SELECT trust_state, count(*) FROM partners GROUP BY 1` per region; update `docs/superpowers/specs/security-auth/2026-09-02-partner-trust-probation-design.md` status line to "Enforced <date>".
+
+---
+
+## Self-review
+
+- **Spec coverage.** §3.1 → 2.1; §3.2 (chokepoints, allowlist, deny contract, ticket re-check, installer/Quick Support/third-party launch, enrollment counter) → 2.3, 3.1–3.4, 4.1–4.4; §3.3 → 5.2, 5.4; §3.4 → 5.1, 5.3; §3.5 → 1.1; §3.6 → 5.5, 7.3; §3.7 (denials as audit events, sweep cadence) → 2.3 and a one-line `scheduleRegistry.ts` change in 5.1 (`'abuse-signals-sweep': '*/15 * * * *'`), add it to Task 5.1's Modify list; §4 → 6.1, 6.2; §5 → 2.2, 7.1, 7.2, 7.4; §6/§7 covered by the tests in each task; §9 decisions: default deny (2.3), cap 5 (2.3, 4.4), 3DS (1.1), backfill (7.2), TOTP links (5.5); self-hosted safeguard (2.2, 7.1).
+- **Placeholder scan.** Task 4.x "extend each route's test file" steps name the assertion and the fixture state; Task 5.x interfaces are typed. The one deliberate open item is the `CreateAuditLogParams` field names in 2.3, which the implementer confirms against `auditService.ts` at typecheck.
+- **Type consistency.** `GateDecision`, `GatedCapability`, `TrustDenyCode`, `trustDenyBody`, `evaluateCapability`, `isLifecycleCommand`, `partnerIdForDevice`, `setTrustState`, `TrustDeniedError`, `assertDeviceExecuteAllowed`, `createRemoteSession`, `RemoteSessionDeniedError`, `PROBATION_ENROLLMENT_CAP` are used with the same names and signatures across waves.

--- a/docs/superpowers/specs/security-auth/2026-09-02-partner-trust-probation-design.md
+++ b/docs/superpowers/specs/security-auth/2026-09-02-partner-trust-probation-design.md
@@ -1,7 +1,7 @@
 # Partner Trust Probation — Design
 
 **Date:** 2026-09-02
-**Status:** Draft, advisor quorum complete (Fable + Codex gpt-5.6-sol xhigh read-only review, 13 findings, all folded in; one disagreement surfaced in §9)
+**Status:** Approved 2026-09-02 (operator decisions recorded in §9); advisor quorum complete (Fable + Codex gpt-5.6-sol xhigh read-only review, 13 findings folded in)
 **Owner scope:** hosted SaaS (`IS_HOSTED=true`); self-hosted deployments default to `off`
 **Supersedes in part:** `2026-07-11-signup-abuse-detection-design.md` (keeps its detectors; replaces the "alert-first, human suspends later" response posture with a capability gate)
 
@@ -254,10 +254,10 @@ Rollout order:
 - **Async external IP classification, never on the registration path.**
 - **Buttons stay visible in probation.** Hidden-on-failure UI is a documented anti-pattern here.
 
-## 9. Open questions for the operator
+## 9. Operator decisions (2026-09-02)
 
-1. **Trial friction vs. bypass surface (quorum disagreement).** Codex recommends the default-deny model as written. My first draft carried a per-device exception so a trial could remote into the laptop it signed up from. Given finding §8 bullet 2, I now agree default-deny should ship first; the exception can be added later behind `PARTNER_TRUST_SELF_DEVICE_EXCEPTION=true` if review requests show real conversion loss, and only with a stronger ownership proof than IP (e.g. a one-time code displayed in the console and typed into the agent installer). **Recommend: ship default-deny, measure.**
-2. Enrollment cap in probation: 5 (proposed) or 3.
-3. 3DS on the first payment: `any` (proposed) or `automatic`. `any` costs some conversion on issuers without 3DS.
-4. Retro-backfill of the last 14 days of partners into probation (§5 step 5): do it or not.
-5. Approval-link MFA: require a fresh TOTP on the one-click links (proposed) or accept the signed token alone.
+1. **Default deny ships first; no self-device exception.** Revisit only with a stronger ownership proof than IP (one-time code shown in the console and typed into the installer), behind `PARTNER_TRUST_SELF_DEVICE_EXCEPTION`, if review requests show real conversion loss.
+2. **Enrollment cap in probation: 5**, lifetime counter.
+3. **3DS: already enforced in the Stripe dashboard** (Radar rule) as far as Stripe allows. The Checkout code still sets `request_three_d_secure: 'any'` explicitly so the behaviour does not depend on dashboard state. Note: both signup Checkout sessions in breeze-billing (`src/routes/checkout.ts:103` subscription mode, `src/routes/setupIntents.ts:55` setup mode) currently pass **no** `payment_method_types`, so Link is on by Stripe default; turning it off is a code change in both.
+4. **Retro-backfill: yes.** Partners created in the last 14 days with no settled card payment move to `probation` at the `enforce` flip, as a reviewed SQL batch (not a migration), each with an evidence-card email so the operator can approve real trials the same day.
+5. **Approval links require a fresh TOTP.** The signed one-time token opens a page that prompts for the authenticator code before acting; the token alone never performs the action.

--- a/docs/superpowers/specs/security-auth/2026-09-02-partner-trust-probation-design.md
+++ b/docs/superpowers/specs/security-auth/2026-09-02-partner-trust-probation-design.md
@@ -1,0 +1,263 @@
+# Partner Trust Probation — Design
+
+**Date:** 2026-09-02
+**Status:** Draft, advisor quorum complete (Fable + Codex gpt-5.6-sol xhigh read-only review, 13 findings, all folded in; one disagreement surfaced in §9)
+**Owner scope:** hosted SaaS (`IS_HOSTED=true`); self-hosted deployments default to `off`
+**Supersedes in part:** `2026-07-11-signup-abuse-detection-design.md` (keeps its detectors; replaces the "alert-first, human suspends later" response posture with a capability gate)
+
+## 1. Problem
+
+Hosted Breeze is being used as a tech-support-scam toolkit. The operator signs up, enrolls a rehearsal VM on a VPS, then enrolls victims and runs remote desktop against them. The detectors built in July see all of this, but they see it **after** the payoff.
+
+Evidence from the 2026-08-31 → 09-02 window (both regions, verified from prod):
+
+| Fact | Count |
+|---|---|
+| Self-serve signups in 48 h | 23 (19 US, 4 EU) |
+| Signups that passed the breeze-billing signup-risk gate with `decision=pass` | 23 of 23 |
+| Signups later suspended for abuse | 19 of 23 |
+| Median time from signup to first remote desktop session (abusive accounts with a device) | ≈ 25 min |
+| Time from signup to suspension | 5–16 h (next operator batch) |
+| Signup IPs on hosting/VPN ASNs among the 19 suspended | 14 |
+| `stage1.hosting_asn` fired on those 14 | 0 |
+
+Three structural reasons the current stack cannot win this:
+
+1. **Scoring at the wrong moment.** The only pre-activation gate is signup-risk in breeze-billing. Its two strongest signals (`stage1.suspended_ip_match`, `stage2.suspended_fingerprint_match`, 100 pts) need a *prior* suspension to match; a fresh identity scores 0. `stage2.name_mismatch` (40 pts) fires on most abusers but also on most legitimate MSPs (AMERIBUILT, MSBLLC this week), so it can never be a blocker. `stage1.hosting_asn` uses a hand-curated prefix table that fails open and missed every hosting ASN seen this week (Hyonix, Majestic, GSL, Ultahost, 1GSERVERS, tzulo, GWY IT, IONOS, AWS, Azure).
+2. **Acting at the wrong moment.** `partner_abuse_signals` are computed by an hourly BullMQ sweep (`jobs/abuseSignalsSweep.ts:43-84`, schedule in `jobs/scheduleRegistry.ts:131`) and only *recorded and notified*. Suspension is a separate human or scheduled-operator action through `POST /admin/partners/:id/suspend-for-abuse` (`routes/admin/abuse.ts:96-127`). Nothing in the request path consults the signals.
+3. **Payment identity is blind where it matters.** Every fraudulent capture arrives via Stripe Link (`billing_details.name` null, Radar risk `normal`), so the card-identity signals see nothing on exactly the payments that succeed.
+
+Blocking *signups* harder is the wrong lever: signups are free to the attacker and every hard deny at registration has a false-positive cost we have already paid (Munneries). The lever is the **payoff**: remote control, code execution, and installer distribution to machines the account does not own.
+
+## 2. Thesis
+
+> A new self-serve partner starts in **probation**. Probation does not restrict the console; it denies the capabilities an abuser needs, and it denies them **at the dispatch chokepoints** against a **trust state** that is promoted by positive verification or by a one-click operator approval.
+
+Consequences we want:
+
+- A scammer can still sign up and can still enroll a VM. They cannot open a remote session to anything, run anything on a device, or hand anyone an installer link, until a settled non-Link card payment has aged 24 h or a human clicked approve. The 25-minute payoff window closes.
+- A legitimate MSP trialing Breeze enrolls devices, sees inventory, patches, alerts, and reporting on day one. Remote control and execution unlock within 24 h of paying with a card, or within minutes if they press **Request review** and the operator approves from the evidence card.
+- The operator's job changes from "sweep, investigate, contain" to "glance at an evidence card, click approve or suspend".
+
+## 3. Design
+
+### 3.1 Trust state (data model)
+
+Trust is orthogonal to lifecycle. `partners.status` (`pending | active | suspended | churned | offboarding`) stays the lifecycle axis and is not changed.
+
+`partners` is a **partner-axis** tenant table (RLS shape 3, `PARTNER_TENANT_TABLES`; `rls-coverage.integration.test.ts:174-179`), already registered in every cascade and export list. New columns:
+
+```sql
+DO $$ BEGIN
+  CREATE TYPE partner_trust_state AS ENUM ('probation','trusted','restricted');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  CREATE TYPE ip_class AS ENUM ('residential','business','hosting','vpn','tor','unknown');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+ALTER TABLE partners
+  ADD COLUMN IF NOT EXISTS trust_state               partner_trust_state NOT NULL DEFAULT 'trusted',
+  ADD COLUMN IF NOT EXISTS trust_changed_at          timestamptz,
+  ADD COLUMN IF NOT EXISTS trust_changed_by          uuid REFERENCES users(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS trust_reason              text,          -- machine key: 'auto:settled_card_24h' | 'admin:approve' | 'auto:tor_signup' ...
+  ADD COLUMN IF NOT EXISTS trust_review_requested_at timestamptz,
+  ADD COLUMN IF NOT EXISTS probation_enrollments     integer NOT NULL DEFAULT 0,   -- lifetime, never decremented
+  ADD COLUMN IF NOT EXISTS signup_ip_class           ip_class NOT NULL DEFAULT 'unknown',
+  ADD COLUMN IF NOT EXISTS signup_ip_asn             integer,
+  ADD COLUMN IF NOT EXISTS signup_ip_classified_at   timestamptz;
+CREATE INDEX IF NOT EXISTS partners_trust_state_idx ON partners (trust_state) WHERE trust_state <> 'trusted';
+
+ALTER TABLE devices
+  ADD COLUMN IF NOT EXISTS enrollment_ip_class         ip_class NOT NULL DEFAULT 'unknown',
+  ADD COLUMN IF NOT EXISTS enrollment_ip_asn           integer,
+  ADD COLUMN IF NOT EXISTS enrollment_ip_classified_at timestamptz;
+```
+
+- `probation` — default for every partner created through `POST /auth/register-partner` (`routes/auth/register.ts:95`) from the day the flag is `enforce`. Capability-gated per §3.2.
+- `trusted` — full capabilities. Column default, so **every pre-existing partner is grandfathered** without a backfill decision on day one (optional retro-backfill in §5).
+- `restricted` — set by the operator, or by the hard-deny rules in §3.4, when the account is suspicious but not proven abusive. Same gates as probation, never auto-promotes; only an admin moves it.
+
+Transitions and every gate denial are written to `audit_logs` (`partner.trust.promoted`, `partner.trust.restricted`, `partner.trust.review_requested`, `partner.trust.capability_denied`) with reason and evidence snapshot. These are immutable events on purpose: `partner_abuse_signals` dedupes on `(partner_id, signal_key)` and stale-resolves rows (`services/abuseSignals/persistence.ts:29-33,95-121`), which would collapse "denied 5 remote sessions in 10 minutes" into one row and then auto-resolve it.
+
+Tenancy and export contracts: no new table, no cascade-list change. `tenantExportPolicyRegistry.ts` gets entries for the new columns: trust columns `included`; `*_ip_class`, `*_ip_asn`, `*_classified_at` and `probation_enrollments` go in the bucket that is **excluded from the tenant-facing export** (they are risk metadata about the tenant, and a subject-access export must not double as a detection-tuning oracle for an abuser). The `rls-coverage` and `tenant-export-policy` suites gate the PR.
+
+`devices.enrollment_ip` (`db/schema/devices.ts:53-56`) and `partners.signup_ip` (`db/schema/orgs.ts:49-53`) already exist; the classification columns are the only additions on that axis.
+
+### 3.2 Capability gate
+
+New module `apps/api/src/services/partnerTrust.ts`, evaluated under a system DB context (`withSystemDbAccessContext`, after `runOutsideDbContext` on the request path) because the request-scoped role cannot read `partner_abuse_signals` (`db/schema/abuseSignals.ts:9-15`):
+
+```ts
+type GatedCapability = 'remote_control' | 'device_execute' | 'installer_distribute' | 'agent_enroll';
+type GateDecision =
+  | { allow: true }
+  | { allow: false; code: 'TRUST_PROBATION' | 'TRUST_RESTRICTED'; capability: GatedCapability; reason: string };
+
+export async function evaluateCapability(cap: GatedCapability, ctx: { partnerId: string; deviceId?: string; clientIp?: string }): Promise<GateDecision>;
+export function requireCapability(cap: GatedCapability): MiddlewareHandler; // 403 with the contract body below
+export function isLifecycleCommand(type: string): boolean;                   // the allowlist, single source of truth
+```
+
+Rules while `trust_state ∈ {probation, restricted}` (**default deny**; this is the quorum's simpler model, see §9 Q1 for the opt-in exception):
+
+| Capability | Probation / restricted rule |
+|---|---|
+| `remote_control` | **Deny.** Every remote session type (desktop, terminal, file transfer), Quick Support / support sessions, tunnels (proxy and VNC), the AI `create_remote_session` / `computer_control` tools, and third-party remote launch (which returns a launcher URL and may carry preset credentials, `routes/devices/core.ts:1203-1218,1297-1301`). |
+| `device_execute` | **Deny every device mutation** except an explicit lifecycle allowlist. Gated types include `script`, `execute_command`, `file_write` and the other `file_*` mutations, `task_run`, `registry_*`, `software_install|uninstall|update`, `install_patches`, `rollback_patches`, `backup_restore`, `vm_*`, `mssql_restore`, `hyperv_*`, `actuate_elevation`, `computer_action`, `terminal_start`, `tunnel_*`, `execute_containment`, `security_threat_*`, `homebrew_bootstrap`, and `reboot`. Reads (`file_list`, `file_read`, `list_processes`, event logs, inventory, metrics, `filesystem_analysis` when system-initiated) are never gated. |
+| `installer_distribute` | **Deny** installer links, short-links, public download URLs, bulk-link keys (`x20 … x1000`), onboarding tokens, and Quick Support codes/URLs. The authenticated console download for the partner's own machine stays allowed. |
+| `agent_enroll` | Allowed while `probation_enrollments < 5`. The counter is incremented **inside the enrollment transaction with the partner row locked** (`SELECT … FOR UPDATE`) and never decremented, so deleting devices (`routes/devices/core.ts:1517-1561`) or racing parallel enrollments (`routes/agents/enrollment.ts:695-767,830-861` separates count and insert today) cannot recycle the quota. Restricted: deny. |
+
+**Where the gate lives: chokepoints, not routes.** A route-by-route enumeration (2026-09-02) found 17 categories of device execution. Nearly all converge on two functions, so the gate goes there and the routes inherit it:
+
+1. **Command dispatch.** `services/commandQueue.ts` (`queueCommand:601`, `queueCommandForExecution:802`, `executeCommand:913`) and the online fast path `routes/agentWs.ts:3123` `sendCommandToAgent` (18 call sites that skip the queue when the agent is connected; e.g. `services/softwareDeployment.ts:113-132`). Both take a device id; the gate resolves device → org → partner (one indexed read, cached per request) and applies `isLifecycleCommand()`. The two raw `db.insert(deviceCommands)` sites (`routes/devices/actuateElevation.ts:191-217`, `routes/mobile.ts:1318`) are routed through the same helper so the allowlist is the single source of truth. Script dispatch (`routes/scripts.ts:976-998`, `dispatchScriptToDevice`) and automation actions (`services/automationRuntime.ts:1184-1198,1265-1290`) already terminate in these functions.
+2. **Session creation.** The `insert(remoteSessions)` sites (`routes/remote/sessions.ts:155`, `services/aiToolsRemote.ts:357`, `routes/tunnels.ts`) and the `supportSessions` / `tunnelSessions` inserts (`routes/remote/supportSessions.ts:52-127`, `routes/tunnels.ts:321-424,447-456`) move behind one `createRemoteSession()` service that evaluates `remote_control`. Ticket issuance (`desktopWs.ts:1276` connect/exchange, `terminalWs.ts:1114`, tunnel `ws-ticket` / `http-ticket` / `connect-code` at `routes/tunnels.ts:1061,1121,1189`) re-checks the session's partner trust at ticket time, so a promotion revoked mid-session ends at the next ticket. Third-party remote launch is gated at its route because it does not create a session row.
+
+Paths that do not pass through those chokepoints get explicit gates:
+
+- **Installer distribution**: the `routes/enrollmentKeys.ts` handlers that emit `enrollment_key.installer_link_created`, the public download (`:2519`), the short-link redirect (`:2576`), onboarding-token creation, and Quick Support code creation → `requireCapability('installer_distribute')`. The public routes carry no auth; they resolve key → org → partner and evaluate the same predicate. Quick Support additionally re-checks owner trust at anonymous download and at code redemption (`routes/supportPublic.ts:319-369,445-551`), so a code minted before restriction dies with it.
+- **Agent enrollment**: `routes/agents/enrollment.ts:86` → `evaluateCapability('agent_enroll')` inside the enrollment transaction; on allow, increment `probation_enrollments` and enqueue IP classification (§3.4).
+
+Automations and schedulers run as the system principal on behalf of the automation's creator; because the gate sits in dispatch, a probation partner's automation still runs its read steps and has its execute steps refused with the same reason code, logged on the run. The unauthenticated automation webhook trigger (`routes/automations.ts:1337-1367`, secret-only auth) needs no extra work for the same reason. The MCP server (`routes/mcpServer.ts`) and mobile app reach the same dispatch layer.
+
+A route-level `requireCapability()` is added where an early, friendlier 403 beats a dispatch-time refusal (`POST /remote/sessions`, `POST /scripts/:id/execute`, `POST /devices/:id/commands`, `POST /software/deployments`), but it is a UX convenience; the chokepoint is the control.
+
+The deny body is a stable contract the web client renders as a banner, never as a generic error:
+
+```json
+{ "error": "TRUST_PROBATION", "capability": "remote_control",
+  "reason": "probation_default_deny",
+  "reviewRequested": false, "meetingUrl": "<PARTNER_MEETING_URL>" }
+```
+
+`partnerGuard.ts` (`middleware/partnerGuard.ts:8`) is **not** the gate. It stays a lifecycle gate (`PARTNER_INACTIVE`). Trust is loaded alongside it into `auth.trustState` so the gate does not repeat the query.
+
+Agent side: nothing changes. The agent tenant gate (`services/tenantStatus.ts:244`) still keys on `partners.status`; a probation tenant is `active`, so heartbeats, inventory, and patch scans keep working. Only operator-initiated actions on the device are refused, at the API.
+
+### 3.3 Promotion
+
+Promotion is evaluated in two places: lazily at every capability deny (a partner that just became eligible is promoted on their next click, not next hour), and by a 15-minute job on the existing `abuse-signals` BullMQ queue. Both run in the system DB context.
+
+**Automatic promotion** (`trust_reason = 'auto:settled_card_24h'`) requires **all** of:
+
+1. `partners.created_at` ≥ 24 h ago and `email_verified_at` set.
+2. A **settled card payment**: `charge.succeeded` ≥ 24 h ago in `billing_events`, not disputed, not refunded, `payment_method_details.type = 'card'` (not `link`), 3DS authenticated (§3.5), `billing_details.name` present.
+3. `signup_ip_class ∉ {hosting, vpn, tor, unknown}`, and every enrolled device's `enrollment_ip_class ∉ {tor}`. Devices on hosting ASNs do not block promotion (MSPs manage servers in datacenters); they are shown on the evidence card.
+4. No unresolved `partner_abuse_signals` at `alert` severity and no breeze-billing hold in `hold | review_pending`.
+
+There is **no age-only promotion**. A free or community plan account, or a paid account that fails rule 3, is promoted only by an operator click. Age plus absence of alerts was rejected by the quorum: it rewards stockpiled quiet accounts, and the current sweep thresholds (`services/abuseSignals/config.ts:13-27`, `heuristics.ts:440-464`) tolerate low-and-slow activity.
+
+**Manual promotion / restriction** (`trust_reason = 'admin:<verb>'`): `POST /admin/partners/:id/trust/promote` and `POST /admin/partners/:id/trust/restrict`, both `requireMfa()`, in `routes/admin/abuse.ts` next to `suspend-for-abuse`. Body `{ reason }` (required, ≥ 8 chars); writes the audit row.
+
+**Partner-initiated review**: `POST /partner/trust/request-review` sets `trust_review_requested_at` and emails the ops channel (existing `sendOpsAlert`) with the evidence card (§3.6). One per 24 h.
+
+Promotion never moves `restricted`. Only an admin does.
+
+### 3.4 IP classification and hard denies
+
+Replace the static `hostingPrefixes.ts` table as the source of truth with an **asynchronous** classification that runs off the request path, honoring the existing rule that registration never waits on an external lookup:
+
+- New job `ip-classify` on the `abuse-signals` queue, enqueued from `register-partner` (signup IP) and from agent enrollment (enrollment IP). It calls a privacy-detection API (ipinfo `privacy` or ipdata; provider and key behind env vars, never in the repo) and writes `signup_ip_class` / `enrollment_ip_class` plus ASN. Results are cached in Redis per /24 (v4) or /48 (v6) for 7 days so a ring costs one call.
+- Until the result lands (typically < 5 s) the class is `unknown`, which blocks **auto-promotion only**; it does not deny anything by itself, because probation already denies everything that matters.
+- The static prefix table stays as an offline fallback (provider outage or no key configured) and is refreshed from RIPEstat per the note already in that file.
+
+Hard denies (`probation → restricted`, evaluated by the same job, no human in the loop). Each requires **either** a non-IP axis **or** an IP match corroborated by a second axis. Egress IP alone is not evidence: the repo already rejects it as sole recidivism proof (`services/abuseSignals/recidivistEndpoint.ts:310-317`), and CGNAT, shared offices, and VPN-using MSPs make a bare /24 rule unsafe.
+
+- Signup IP class `tor`.
+- Card fingerprint or Link email matches a `fraudulent`-refunded customer in Stripe. Stripe is one account for both regions, so this is the one identity axis that is legitimately cross-region.
+- Signup or enrollment IP within /24 (v4) or **/64** (v6, matching the existing heuristic in `heuristics.ts:328-356`) of a partner suspended for abuse in the same region in the last 90 days, **and** one of: same email domain, same card fingerprint, same `signup_user_agent` plus same device hostname pattern, or same agent-reported machine identity on an enrolled device.
+
+Explicitly **not** in scope: any registration-time lookup against the other region's database. That was ruled out on 2026-08-03 as a cross-border transfer of personal data with no region model to govern it. If a shared blocklist is ever wanted, it must be a hashed, non-reversible token list (HMAC of /24 and email domain under a per-deployment key) published to a neutral store, and it is a separate decision.
+
+### 3.5 Stripe (prerequisite, breeze-billing repo)
+
+These are **rollout prerequisites** for `enforce`, not follow-ups, because rule §3.3(2) is meaningless while Link is on. They live in breeze-billing (the signup Checkout is created there; core only has the invoice pay link, `services/invoiceCheckout.ts:107`) and must be verified end-to-end in Stripe test mode before the flag flips:
+
+1. Signup Checkout: `payment_method_types: ['card']`, no Link, `payment_method_options.card.request_three_d_secure: 'any'`.
+2. Radar: retire `card_count_for_customer_all_time >= 2` (it manufactures the retries our own `card_testing` detector then scores) in favor of `review` at `>= 3` and `block` at `>= 5`. Dashboard change; recorded here so the decision is auditable.
+3. The webhook already persists `charge.succeeded` to `billing_events`; core reads it through `breezeBillingClient`. `billing_cardholder_name` becomes reliably non-null once Link is off, which also revives `stage2.name_mismatch` and `stage2.distinct_names` as real signals.
+4. Refund posture on `suspend-for-abuse` stays as it is today (operator decision at suspension time).
+
+### 3.6 Operator surface: approval queue
+
+Two entry points, cheapest first:
+
+**Email card (day one).** Every entry into probation with at least one `watch`+ signal, every review request, and every `restricted` transition sends one ops email with an evidence card: partner, plan, signup IP + class + ASN, email domain age and MX, cardholder vs. user name, distinct payment methods and failures, devices (hostname, enrollment IP class, virtual flag), capability denials in the last 24 h, and matching suspended-account axes. The card carries two signed one-time links (`/admin/trust/act?token=…`, 24 h TTL, single use, bound to the operator's user and requiring a fresh MFA) for **Approve** and **Suspend**. This is the 10-second path.
+
+**Web page (wave 2).** `apps/web` platform-admin page `/admin/trust-queue` listing `partners WHERE trust_state <> 'trusted'` ordered by newest signal, with the same card and buttons, backed by `GET /admin/trust/queue`. Production currently has **zero** `is_platform_admin` users; enabling the page requires granting the flag to the operator account first.
+
+### 3.7 Signals
+
+The hourly sweep keeps computing `partner_abuse_signals`. Changes:
+
+- Capability denials are `audit_logs` events (§3.1), and the evidence card and queue read them directly. A denial burst ("5 remote sessions refused in 10 min against a hosting-ASN device") is the abuser's signature and today only shows up as `rmm.session_intensity` after the sessions succeeded.
+- Sweep cadence for `fraud.*` and `rmm.*` signals drops from 60 min to 15 min. The sweep's cost is dominated by `remote_sessions` and `devices` scans already indexed by partner; measured at < 2 s per run on US.
+
+Nothing auto-suspends. Suspension remains an explicit admin action; probation makes the human decision affordable.
+
+## 4. Web client
+
+- `TrustProbationBanner` renders when any gated request returns `TRUST_PROBATION | TRUST_RESTRICTED`: explains what is gated, shows the promotion checklist with ticks (24 h, verified email, card settled), a **Request review** button, and the meeting link. Copy never explains the detection mechanism.
+- Remote-control and execution buttons stay enabled; the 403 is handled by `runAction` and surfaces the banner. Hiding the buttons would be a hide-on-failure UI that needs E2E proof and would break the request-review flow.
+- Onboarding copy for new signups says up front which capabilities unlock after payment or review, so the banner is never the first time they hear it.
+
+## 5. Configuration and rollout
+
+Flag `PARTNER_TRUST_MODE = off | shadow | enforce` (env; hosted default `shadow`, self-hosted default `off`), following the `ML_FEATURE_FLAGS` global-kill-switch pattern (`services/mlFeatureFlags.ts`).
+
+- `off`: columns exist, nothing reads them.
+- `shadow`: `evaluateCapability` runs, logs would-deny decisions as `partner.trust.capability_denied` audit events with `mode: shadow`, and allows. Gives a false-positive count before any customer is affected.
+- `enforce`: denies.
+
+Rollout order:
+
+1. breeze-billing prerequisites (§3.5), verified in Stripe test mode. Independent of core; ships first.
+2. Core migration (columns, enums, index) + `partnerTrust.ts` + chokepoint gates + email cards, in `shadow`. One release.
+3. Read the shadow denials for 7 days. Target: every denial on an account later suspended; zero denials on accounts still active and paying after 14 days that did not also press Request review.
+4. Flip `enforce` for **new partners only** (created after the flip). Existing partners stay `trusted` by column default.
+5. Optional retro-backfill: `probation` for partners created in the last 14 days with no settled card payment. Reviewed SQL batch, not a migration.
+6. Web queue page after enforce.
+
+## 6. Failure modes and residual risk
+
+| Scenario | What happens | Mitigation |
+|---|---|---|
+| MSP trials remote desktop on day 1 | Denied, banner with checklist | Request review → operator approves from the card in seconds; or auto-promotes 24 h after a card payment |
+| MSP that will never pay by card (invoice, Pax8) | Never auto-promotes | Manual approve; the card carries the evidence |
+| Free/community plan, real MSP | Gated until approved | Request review; operator approves in 10 s |
+| Classification provider down | Class `unknown` → auto-promotion paused, nothing else changes | Static prefix fallback; shadow metric alerts when `unknown` rate > 20 % |
+| Abuser waits 24 h and pays with a stolen non-Link card | Auto-promotes if the charge survives 24 h undisputed | 3DS shifts liability and blocks most stolen cards; `stage2.suspended_fingerprint_match`, the Stripe fraudulent-refund match, and the corroborated /24 rule still apply; promotion is reversible by one click |
+| Abuser already has first-stage remote access to the victim (phone-guided AnyDesk) and uses Breeze as persistence | Enrollment succeeds (within quota), but no remote control or execution until promoted | Residual risk accepted; the payoff Breeze adds is withheld, and the evidence card shows a residential device under a hosting-ASN signup |
+| Operator approves a scammer from a convincing card | Full capabilities | Same exposure as today, minus the 25-minute window; suspension path unchanged |
+
+## 7. Testing
+
+- Unit: `partnerTrust.test.ts` table-driven over (state × capability × command type) → decision; `isLifecycleCommand` allowlist pinned so a new command type fails the test until classified; promotion-rule matrix including `link` vs `card`, the 24 h clock, and `unknown` IP class.
+- Chokepoint tests: `commandQueue` and `sendCommandToAgent` refuse gated types for a probation partner and pass lifecycle types; `createRemoteSession` refuses all types; ticket issuance re-checks trust.
+- Route tests for installer distribution, Quick Support creation / download / redemption, third-party remote launch, and the enrollment counter (concurrent enrollments cannot exceed the cap; device delete does not reset it).
+- Integration (real Postgres): partner in probation enrolls 5 devices, 6th denied; every gated route 403s; after `UPDATE partners SET trust_state='trusted'` the same requests succeed. RLS coverage suite unchanged (no new table); export-policy suite updated for the new columns.
+- Web: `TrustProbationBanner` render + `runAction` handling of `TRUST_PROBATION`; E2E for request-review.
+- Shadow-mode acceptance in prod is the 7-day metric in §5 step 3, not a test.
+
+## 8. Decisions log
+
+- **Gate capabilities, not signups.** Signups are free to the attacker; capabilities are the payoff.
+- **Default deny in probation, no per-device exceptions.** The first draft allowed remote control to "self-enrolled" devices whose enrollment IP matched a console session IP. The quorum rejected it: IP co-location is not ownership (a scammer can have the victim sign up or log in from the victim's machine), and password login writes JWT/refresh state without a `sessions` row (`routes/auth/login.ts:639-734`, `services/session.ts:26-44`), so the check was also incomplete. Simpler and harder to bypass wins.
+- **Gate at dispatch chokepoints, not routes.** Seventeen execution categories converge on `commandQueue` / `sendCommandToAgent` and session creation; per-route gates would have missed tunnels, third-party remote launch, automation webhooks, and software deployment.
+- **Trust is a separate axis from lifecycle status.** Reusing `partners.status` would entangle billing activation, agent tenant gating, and cascade semantics that all key on it.
+- **Default `trusted` on the column.** Grandfathering by default makes the migration risk-free; tightening existing accounts is a separate reviewed batch.
+- **No age-only promotion.** Positive verification (settled 3DS card) or a human click.
+- **IP is never sole evidence for restriction.** Corroborate with a non-IP axis; v6 at /64.
+- **Denials are audit events, not abuse signals.** Signal persistence dedupes and stale-resolves.
+- **No cross-region data plane.** Per the 2026-08-03 decision. Stripe is the only shared identity axis.
+- **No auto-suspend.** Probation makes the human decision affordable, so the July "alert-first" posture is kept.
+- **Async external IP classification, never on the registration path.**
+- **Buttons stay visible in probation.** Hidden-on-failure UI is a documented anti-pattern here.
+
+## 9. Open questions for the operator
+
+1. **Trial friction vs. bypass surface (quorum disagreement).** Codex recommends the default-deny model as written. My first draft carried a per-device exception so a trial could remote into the laptop it signed up from. Given finding §8 bullet 2, I now agree default-deny should ship first; the exception can be added later behind `PARTNER_TRUST_SELF_DEVICE_EXCEPTION=true` if review requests show real conversion loss, and only with a stronger ownership proof than IP (e.g. a one-time code displayed in the console and typed into the agent installer). **Recommend: ship default-deny, measure.**
+2. Enrollment cap in probation: 5 (proposed) or 3.
+3. 3DS on the first payment: `any` (proposed) or `automatic`. `any` costs some conversion on issuers without 3DS.
+4. Retro-backfill of the last 14 days of partners into probation (§5 step 5): do it or not.
+5. Approval-link MFA: require a fresh TOTP on the one-click links (proposed) or accept the signed token alone.

--- a/docs/superpowers/specs/security-auth/2026-09-02-partner-trust-probation-design.md
+++ b/docs/superpowers/specs/security-auth/2026-09-02-partner-trust-probation-design.md
@@ -209,6 +209,8 @@ Nothing auto-suspends. Suspension remains an explicit admin action; probation ma
 
 Flag `PARTNER_TRUST_MODE = off | shadow | enforce` (env; hosted default `shadow`, self-hosted default `off`), following the `ML_FEATURE_FLAGS` global-kill-switch pattern (`services/mlFeatureFlags.ts`).
 
+**Env-var rule (self-hosted safety):** every variable this feature introduces (`PARTNER_TRUST_MODE`, `IP_CLASSIFY_PROVIDER`, `IP_CLASSIFY_API_KEY`, `PARTNER_MEETING_URL`) is optional. A missing or unrecognised value never fails config validation, never logs above `warn`, and never blocks a request: missing `PARTNER_TRUST_MODE` resolves to `off` unless hosted; missing classification provider or key resolves to provider `none`, which classifies as `unknown` and pauses auto-promotion only; missing meeting URL just omits the link. The boot-time validator in `config/validate` is not extended with any of them. A unit test boots the resolvers with all four unset and `IS_HOSTED=false` and asserts every gate is a no-op.
+
 - `off`: columns exist, nothing reads them. **Self-hosted safeguard:** the resolver returns `off` whenever `IS_HOSTED` is not `true`, regardless of the env value, and a unit test pins that. The guided-setup smoke job additionally asserts that a fresh self-hosted stack can open a remote session, so a regression here fails CI before it ships.
 - `shadow`: `evaluateCapability` runs, logs would-deny decisions as `partner.trust.capability_denied` audit events with `mode: shadow`, and allows. Gives a false-positive count before any customer is affected.
 - `enforce`: denies.

--- a/docs/superpowers/specs/security-auth/2026-09-02-partner-trust-probation-design.md
+++ b/docs/superpowers/specs/security-auth/2026-09-02-partner-trust-probation-design.md
@@ -1,3 +1,7 @@
+---
+tracking_issue: LanternOps/breeze#4549
+---
+
 # Partner Trust Probation — Design
 
 **Date:** 2026-09-02

--- a/docs/superpowers/specs/security-auth/2026-09-02-partner-trust-probation-design.md
+++ b/docs/superpowers/specs/security-auth/2026-09-02-partner-trust-probation-design.md
@@ -205,7 +205,7 @@ Nothing auto-suspends. Suspension remains an explicit admin action; probation ma
 
 Flag `PARTNER_TRUST_MODE = off | shadow | enforce` (env; hosted default `shadow`, self-hosted default `off`), following the `ML_FEATURE_FLAGS` global-kill-switch pattern (`services/mlFeatureFlags.ts`).
 
-- `off`: columns exist, nothing reads them.
+- `off`: columns exist, nothing reads them. **Self-hosted safeguard:** the resolver returns `off` whenever `IS_HOSTED` is not `true`, regardless of the env value, and a unit test pins that. The guided-setup smoke job additionally asserts that a fresh self-hosted stack can open a remote session, so a regression here fails CI before it ships.
 - `shadow`: `evaluateCapability` runs, logs would-deny decisions as `partner.trust.capability_denied` audit events with `mode: shadow`, and allows. Gives a false-positive count before any customer is affected.
 - `enforce`: denies.
 


### PR DESCRIPTION
## Summary
- Design spec for **Partner Trust Probation**: new hosted self-serve partners default-deny remote control, device execution, and installer distribution at the dispatch chokepoints (`commandQueue` + agent WS fast path + `createRemoteSession`) until a settled non-Link 3DS card payment ages 24 h or the operator approves from an evidence card (TOTP-guarded links).
- 7-wave implementation plan; feature tracking issue #4549 with wave sub-issues #4550–#4556.
- Motivation: 09-02 sweep — 23/23 signups passed signup-risk, median 25 min signup→remote desktop, 5–16 h to containment.
- Advisor quorum: Fable + Codex gpt-5.6-sol xhigh read-only review (13 findings folded in; the per-device IP-co-location exception was dropped on review).
- Operator decisions recorded in spec §9. Self-hosted: flag resolves `off` unless `IS_HOSTED=true`; column default `trusted` grandfathers every existing partner.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FAXi39eBUAUyw5j61AFFxh