### PR TITLE
feat(mobile): New ticket screen behind a + on the Tickets tab

### DIFF
--- a/apps/mobile/src/navigation/MainNavigator.tsx
+++ b/apps/mobile/src/navigation/MainNavigator.tsx
@@ -15,6 +15,7 @@ import { HomeScreen } from '../screens/chat/HomeScreen';
 import { SystemsScreen } from '../screens/systems/SystemsScreen';
 import { TicketsScreen } from '../screens/tickets/TicketsScreen';
 import { TicketDetailScreen } from '../screens/tickets/TicketDetailScreen';
+import { CreateTicketScreen } from '../screens/tickets/CreateTicketScreen';
 import { AttachmentViewerScreen } from '../screens/tickets/AttachmentViewerScreen';
 import { TimesheetScreen } from '../screens/time/TimesheetScreen';
 import { TimeSuggestionsScreen } from '../screens/time/TimeSuggestionsScreen';
@@ -33,6 +34,7 @@ export type SystemsStackParamList = {
 
 export type TicketsStackParamList = {
   Tickets: undefined;
+  CreateTicket: undefined;
   TicketDetail: { ticketId: string };
   /**
    * W11 (#4337). Carries `contentType` and `filename` as params rather than
@@ -96,6 +98,11 @@ function TicketsStackNavigator() {
         name="Tickets"
         component={TicketsScreen}
         options={{ headerShown: false }}
+      />
+      <TicketsStack.Screen
+        name="CreateTicket"
+        component={CreateTicketScreen}
+        options={{ title: 'New ticket' }}
       />
       <TicketsStack.Screen
         name="TicketDetail"

--- a/apps/mobile/src/screens/tickets/CreateTicketScreen.tsx
+++ b/apps/mobile/src/screens/tickets/CreateTicketScreen.tsx
@@ -1,0 +1,287 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+
+import { palette, radii, spacing, type } from '../../theme';
+import { useAppSelector } from '../../store';
+import { createTicket, type TicketPriority } from '../../services/tickets';
+import { listOrganizations } from '../../services/organizations';
+import type { TicketsStackParamList } from '../../navigation/MainNavigator';
+import { Toast } from '../../components/Toast';
+import { reportInternalError } from '../../lib/errorReporting';
+
+import { priorityColor, priorityLabel } from './ticketCopy';
+import {
+  buildCreateTicketBody,
+  canSubmitTicket,
+  DEFAULT_TICKET_PRIORITY,
+  preselectOrg,
+  SUBJECT_MAX_LENGTH,
+  TICKET_PRIORITY_OPTIONS,
+  type OrgOption,
+} from './createTicketForm';
+
+type Nav = NativeStackNavigationProp<TicketsStackParamList, 'CreateTicket'>;
+
+/** Above this many orgs the picker gets a search box (server-side search). */
+const SEARCH_THRESHOLD = 8;
+
+export function CreateTicketScreen() {
+  const navigation = useNavigation<Nav>();
+  const user = useAppSelector((state) => state.auth.user);
+
+  const [orgs, setOrgs] = useState<OrgOption[] | null>(null);
+  const [orgTotal, setOrgTotal] = useState(0);
+  const [orgSearch, setOrgSearch] = useState('');
+  const [orgError, setOrgError] = useState<string | null>(null);
+  const [orgId, setOrgId] = useState<string | null>(null);
+  const [subject, setSubject] = useState('');
+  const [description, setDescription] = useState('');
+  const [priority, setPriority] = useState<TicketPriority>(DEFAULT_TICKET_PRIORITY);
+  const [busy, setBusy] = useState(false);
+  const [toast, setToast] = useState<{ kind: 'success' | 'error'; text: string } | null>(null);
+
+  const loadOrgs = useCallback(
+    async (search: string) => {
+      setOrgError(null);
+      try {
+        const result = await listOrganizations(search);
+        setOrgs(result.orgs);
+        setOrgTotal(result.total);
+        // Only preselect on the unfiltered load: a search result of one org is
+        // the user narrowing, not the app choosing for them.
+        if (!search) setOrgId((current) => current ?? preselectOrg(result.orgs, user?.organizationId));
+      } catch (err) {
+        reportInternalError(err, 'CreateTicketScreen.loadOrgs');
+        setOrgs([]);
+        setOrgError('Could not load organisations. Pull to retry.');
+      }
+    },
+    [user?.organizationId]
+  );
+
+  useEffect(() => {
+    void loadOrgs('');
+  }, [loadOrgs]);
+
+  const submit = async () => {
+    const built = buildCreateTicketBody({ orgId, subject, description, priority });
+    if (!built.ok) return;
+    setBusy(true);
+    try {
+      const created = await createTicket(built.body);
+      // Land on the ticket itself. `replace` keeps Back from returning to a
+      // half-filled form; the list refetches on focus (TicketsScreen's
+      // useFocusEffect), so the new ticket is there when the user gets back.
+      navigation.replace('TicketDetail', { ticketId: created.id });
+    } catch (err) {
+      reportInternalError(err, 'CreateTicketScreen.submit');
+      setToast({ kind: 'error', text: 'Could not create the ticket. Check the connection and try again.' });
+      setBusy(false);
+    }
+  };
+
+  const sendable = canSubmitTicket({ orgId, subject, busy });
+  const showSearch = orgTotal > SEARCH_THRESHOLD || orgSearch.length > 0;
+  const selectedOrg = orgs?.find((o) => o.id === orgId) ?? null;
+  // The user's own org is the only one an org-scoped technician can see, so
+  // the picker is noise for them; show the name and move on.
+  const lockedOrg = orgs !== null && orgs.length === 1 && orgId === orgs[0].id;
+
+  return (
+    <KeyboardAvoidingView style={styles.screen} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
+      <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
+        <Text style={styles.label}>ORGANISATION</Text>
+        {orgs === null ? (
+          <ActivityIndicator color={palette.dark.textLo} style={styles.spinner} />
+        ) : lockedOrg ? (
+          <Text style={styles.lockedOrg}>{orgs[0].name}</Text>
+        ) : (
+          <>
+            {showSearch ? (
+              <TextInput
+                style={styles.input}
+                placeholder="Search organisations"
+                placeholderTextColor={palette.dark.textLo}
+                value={orgSearch}
+                onChangeText={(text) => {
+                  setOrgSearch(text);
+                  void loadOrgs(text);
+                }}
+                autoCorrect={false}
+                autoCapitalize="none"
+                accessibilityLabel="Search organisations"
+              />
+            ) : null}
+            {orgError ? (
+              <Pressable onPress={() => void loadOrgs(orgSearch)} accessibilityRole="button">
+                <Text style={styles.error}>{orgError}</Text>
+              </Pressable>
+            ) : null}
+            {orgs.length === 0 && !orgError ? (
+              <Text style={styles.hint}>No organisations match.</Text>
+            ) : null}
+            <View style={styles.orgList}>
+              {orgs.map((org) => {
+                const active = org.id === orgId;
+                return (
+                  <Pressable
+                    key={org.id}
+                    onPress={() => setOrgId(org.id)}
+                    accessibilityRole="button"
+                    accessibilityState={{ selected: active }}
+                    style={[styles.orgRow, active && styles.orgRowActive]}
+                  >
+                    <Text style={[styles.orgName, active && styles.orgNameActive]} numberOfLines={1}>
+                      {org.name}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+            {selectedOrg === null && orgSearch.length > 0 && orgId ? (
+              // The chosen org is filtered out of the current search results;
+              // say so rather than let the selection look lost.
+              <Text style={styles.hint}>Selected organisation is not in these results.</Text>
+            ) : null}
+          </>
+        )}
+
+        <Text style={styles.label}>SUBJECT</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="What is wrong?"
+          placeholderTextColor={palette.dark.textLo}
+          value={subject}
+          onChangeText={setSubject}
+          maxLength={SUBJECT_MAX_LENGTH}
+          returnKeyType="next"
+          accessibilityLabel="Subject"
+        />
+
+        <Text style={styles.label}>DESCRIPTION</Text>
+        <TextInput
+          style={[styles.input, styles.multiline]}
+          placeholder="Optional details, steps tried, who reported it"
+          placeholderTextColor={palette.dark.textLo}
+          value={description}
+          onChangeText={setDescription}
+          multiline
+          accessibilityLabel="Description"
+        />
+
+        <Text style={styles.label}>PRIORITY</Text>
+        <View style={styles.priorityRow}>
+          {TICKET_PRIORITY_OPTIONS.map((option) => {
+            const active = option === priority;
+            return (
+              <Pressable
+                key={option}
+                onPress={() => setPriority(option)}
+                accessibilityRole="button"
+                accessibilityState={{ selected: active }}
+                style={[styles.chip, active && styles.chipActive]}
+              >
+                <View style={[styles.priorityDot, { backgroundColor: priorityColor(option) }]} />
+                <Text style={[styles.chipText, active && styles.chipTextActive]}>{priorityLabel(option)}</Text>
+              </Pressable>
+            );
+          })}
+        </View>
+
+        <Pressable
+          onPress={() => void submit()}
+          disabled={!sendable}
+          accessibilityRole="button"
+          accessibilityState={{ disabled: !sendable }}
+          style={[styles.submit, !sendable && styles.submitDisabled]}
+        >
+          {busy ? (
+            <ActivityIndicator color={palette.dark.textHi} />
+          ) : (
+            <Text style={styles.submitText}>Create ticket</Text>
+          )}
+        </Pressable>
+      </ScrollView>
+      <Toast
+        visible={toast !== null}
+        text={toast?.text ?? ''}
+        kind={toast?.kind ?? 'error'}
+        onHidden={() => setToast(null)}
+      />
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: { flex: 1, backgroundColor: palette.dark.bg0 },
+  content: { padding: spacing['4'], paddingBottom: spacing['8'] },
+  label: {
+    ...type.metaCaps,
+    color: palette.dark.textLo,
+    marginTop: spacing['4'],
+  },
+  spinner: { marginTop: spacing['3'], alignSelf: 'flex-start' },
+  lockedOrg: { ...type.body, color: palette.dark.textHi, marginTop: spacing['2'] },
+  input: {
+    ...type.body,
+    color: palette.dark.textHi,
+    backgroundColor: palette.dark.bg1,
+    borderRadius: radii.md,
+    borderWidth: 1,
+    borderColor: palette.dark.border,
+    padding: spacing['3'],
+    marginTop: spacing['2'],
+  },
+  multiline: { minHeight: 112, textAlignVertical: 'top' },
+  orgList: { marginTop: spacing['2'], gap: spacing['1'] },
+  orgRow: {
+    paddingHorizontal: spacing['3'],
+    paddingVertical: spacing['3'],
+    borderRadius: radii.md,
+    borderWidth: 1,
+    borderColor: palette.dark.border,
+    backgroundColor: palette.dark.bg1,
+  },
+  orgRowActive: { borderColor: palette.brand.base, backgroundColor: palette.dark.bg2 },
+  orgName: { ...type.body, color: palette.dark.textMd },
+  orgNameActive: { color: palette.dark.textHi },
+  hint: { ...type.meta, color: palette.dark.textLo, marginTop: spacing['2'] },
+  error: { ...type.meta, color: palette.deny.base, marginTop: spacing['2'] },
+  priorityRow: { flexDirection: 'row', flexWrap: 'wrap', gap: spacing['2'], marginTop: spacing['2'] },
+  chip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing['2'],
+    paddingHorizontal: spacing['3'],
+    paddingVertical: spacing['2'],
+    borderRadius: radii.full,
+    borderWidth: 1,
+    borderColor: palette.dark.border,
+    backgroundColor: palette.dark.bg1,
+  },
+  chipActive: { borderColor: palette.brand.base, backgroundColor: palette.dark.bg2 },
+  chipText: { ...type.meta, color: palette.dark.textMd },
+  chipTextActive: { color: palette.dark.textHi },
+  priorityDot: { width: 8, height: 8, borderRadius: 4 },
+  submit: {
+    marginTop: spacing['6'],
+    paddingVertical: spacing['3'],
+    borderRadius: radii.md,
+    backgroundColor: palette.brand.base,
+    alignItems: 'center',
+  },
+  submitDisabled: { opacity: 0.4 },
+  submitText: { ...type.bodyMd, color: palette.dark.textHi },
+});

--- a/apps/mobile/src/screens/tickets/TicketsScreen.tsx
+++ b/apps/mobile/src/screens/tickets/TicketsScreen.tsx
@@ -115,7 +115,18 @@ export function TicketsScreen() {
 
   return (
     <View style={[styles.screen, { paddingTop: insets.top + spacing['3'] }]}>
-      <Text style={styles.title}>Tickets</Text>
+      <View style={styles.titleRow}>
+        <Text style={styles.title}>Tickets</Text>
+        <Pressable
+          onPress={() => navigation.navigate('CreateTicket')}
+          accessibilityRole="button"
+          accessibilityLabel="New ticket"
+          hitSlop={8}
+          style={styles.addButton}
+        >
+          <Text style={styles.addButtonText}>+</Text>
+        </Pressable>
+      </View>
 
       <View style={styles.filters}>
         <Chip label="Open" active={queue === 'open'} onPress={() => dispatch(setQueue('open'))} />
@@ -181,7 +192,25 @@ export function TicketsScreen() {
 
 const styles = StyleSheet.create({
   screen: { flex: 1, backgroundColor: palette.dark.bg0 },
-  title: { ...type.title, color: palette.dark.textHi, paddingHorizontal: spacing['4'] },
+  titleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing['4'],
+  },
+  title: { ...type.title, color: palette.dark.textHi },
+  addButton: {
+    width: 32,
+    height: 32,
+    borderRadius: radii.full,
+    borderWidth: 1,
+    borderColor: palette.dark.border,
+    backgroundColor: palette.dark.bg1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  // The glyph sits a hair high in most fonts; the line height keeps it centred.
+  addButtonText: { ...type.title, color: palette.dark.textHi, lineHeight: 30 },
   filters: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/apps/mobile/src/screens/tickets/createTicketForm.test.ts
+++ b/apps/mobile/src/screens/tickets/createTicketForm.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildCreateTicketBody,
+  canSubmitTicket,
+  DEFAULT_TICKET_PRIORITY,
+  preselectOrg,
+  TICKET_PRIORITY_OPTIONS,
+} from './createTicketForm';
+
+describe('buildCreateTicketBody', () => {
+  it('trims the subject, omits an empty description and always sends the priority', () => {
+    expect(
+      buildCreateTicketBody({ orgId: 'o1', subject: '  Printer offline ', description: '   ', priority: 'high' })
+    ).toEqual({ ok: true, body: { orgId: 'o1', subject: 'Printer offline', priority: 'high' } });
+  });
+
+  it('keeps a trimmed description when present', () => {
+    const r = buildCreateTicketBody({ orgId: 'o1', subject: 'x', description: ' Paper jam on tray 2 ', priority: 'normal' });
+    expect(r).toEqual({
+      ok: true,
+      body: { orgId: 'o1', subject: 'x', description: 'Paper jam on tray 2', priority: 'normal' },
+    });
+  });
+
+  it('refuses without an organisation, before checking the subject', () => {
+    expect(buildCreateTicketBody({ orgId: null, subject: '', description: '', priority: 'normal' })).toEqual({
+      ok: false,
+      reason: 'org',
+    });
+  });
+
+  it('refuses a blank subject (the API rejects it too, but the form should not round-trip)', () => {
+    expect(buildCreateTicketBody({ orgId: 'o1', subject: '   ', description: 'd', priority: 'normal' })).toEqual({
+      ok: false,
+      reason: 'subject',
+    });
+  });
+
+  it('caps the subject at the API limit of 255 characters', () => {
+    const r = buildCreateTicketBody({ orgId: 'o1', subject: 'a'.repeat(256), description: '', priority: 'low' });
+    expect(r).toEqual({ ok: false, reason: 'subject' });
+  });
+});
+
+describe('canSubmitTicket', () => {
+  it('is false while busy even when the form is complete', () => {
+    expect(canSubmitTicket({ orgId: 'o1', subject: 'x', busy: true })).toBe(false);
+    expect(canSubmitTicket({ orgId: 'o1', subject: 'x', busy: false })).toBe(true);
+    expect(canSubmitTicket({ orgId: null, subject: 'x', busy: false })).toBe(false);
+    expect(canSubmitTicket({ orgId: 'o1', subject: '  ', busy: false })).toBe(false);
+  });
+});
+
+describe('preselectOrg', () => {
+  const orgs = [
+    { id: 'a', name: 'Acme' },
+    { id: 'b', name: 'Bolt' },
+  ];
+  it('prefers the signed-in user\'s own organisation when it is in the list', () => {
+    expect(preselectOrg(orgs, 'b')).toBe('b');
+  });
+  it('picks the only organisation when there is exactly one', () => {
+    expect(preselectOrg([orgs[0]], undefined)).toBe('a');
+  });
+  it('leaves the choice to the user otherwise', () => {
+    expect(preselectOrg(orgs, undefined)).toBeNull();
+    expect(preselectOrg(orgs, 'zzz')).toBeNull();
+    expect(preselectOrg([], undefined)).toBeNull();
+  });
+});
+
+describe('priority options', () => {
+  it('offers every API priority in escalation order and defaults to normal', () => {
+    expect(TICKET_PRIORITY_OPTIONS).toEqual(['low', 'normal', 'high', 'urgent']);
+    expect(DEFAULT_TICKET_PRIORITY).toBe('normal');
+  });
+});

--- a/apps/mobile/src/screens/tickets/createTicketForm.ts
+++ b/apps/mobile/src/screens/tickets/createTicketForm.ts
@@ -1,0 +1,69 @@
+// Type-only import: erased at runtime, so it does not pull services/tickets'
+// react-native graph into this node-testable module (same as ticketCopy.ts).
+import type { TicketPriority } from '../../services/tickets';
+
+// Leaf module: imports no react-native, so it stays node-testable (same rule
+// as ticketCopy.ts and commentMode.ts).
+
+/** Every API priority, in escalation order, for the chip row. */
+export const TICKET_PRIORITY_OPTIONS: readonly TicketPriority[] = ['low', 'normal', 'high', 'urgent'];
+
+/** Matches the service-side fallback when priority is absent. */
+export const DEFAULT_TICKET_PRIORITY: TicketPriority = 'normal';
+
+/** The API's subject limit (`createTicketSchema`: max 255). */
+export const SUBJECT_MAX_LENGTH = 255;
+
+export interface OrgOption {
+  id: string;
+  name: string;
+}
+
+export interface CreateTicketBody {
+  orgId: string;
+  subject: string;
+  description?: string;
+  priority: TicketPriority;
+}
+
+export type BuildResult =
+  | { ok: true; body: CreateTicketBody }
+  | { ok: false; reason: 'org' | 'subject' };
+
+/**
+ * The exact JSON the screen POSTs to `/tickets`, or the first reason it must
+ * not. Priority is always sent: the server falls back to 'normal' when absent,
+ * but the chip row shows a selection, so what is on screen is what is sent.
+ */
+export function buildCreateTicketBody(input: {
+  orgId: string | null;
+  subject: string;
+  description: string;
+  priority: TicketPriority;
+}): BuildResult {
+  if (!input.orgId) return { ok: false, reason: 'org' };
+  const subject = input.subject.trim();
+  if (!subject || subject.length > SUBJECT_MAX_LENGTH) return { ok: false, reason: 'subject' };
+  const description = input.description.trim();
+  const body: CreateTicketBody = { orgId: input.orgId, subject, priority: input.priority };
+  if (description) body.description = description;
+  return { ok: true, body };
+}
+
+export function canSubmitTicket(input: { orgId: string | null; subject: string; busy: boolean }): boolean {
+  if (input.busy) return false;
+  return buildCreateTicketBody({ ...input, description: '', priority: DEFAULT_TICKET_PRIORITY }).ok;
+}
+
+/**
+ * Which organisation to start on: the signed-in user's own org when it is in
+ * the list (org-scoped technicians only ever see one), else the only org when
+ * there is exactly one, else nothing — a partner user with several customers
+ * has to choose, and a silent default would file tickets against the wrong
+ * customer.
+ */
+export function preselectOrg(orgs: readonly OrgOption[], userOrgId: string | undefined): string | null {
+  if (userOrgId && orgs.some((o) => o.id === userOrgId)) return userOrgId;
+  if (orgs.length === 1) return orgs[0].id;
+  return null;
+}

--- a/apps/mobile/src/services/organizations.test.ts
+++ b/apps/mobile/src/services/organizations.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const coreRequest = vi.fn();
+vi.mock('./api', () => ({ coreRequest: (...args: unknown[]) => coreRequest(...args) }));
+
+import { listOrganizations } from './organizations';
+
+beforeEach(() => { coreRequest.mockReset(); });
+
+describe('listOrganizations', () => {
+  it('asks for the server maximum page and narrows to id + name', async () => {
+    coreRequest.mockResolvedValue({
+      data: [
+        { id: 'a', name: 'Acme', status: 'active', extra: 1 },
+        { id: 'b', name: 'Bolt', status: 'active' },
+      ],
+      pagination: { page: 1, limit: 100, total: 2 },
+    });
+    const r = await listOrganizations();
+    expect(coreRequest).toHaveBeenCalledWith('/orgs/organizations?limit=100');
+    expect(r).toEqual({ orgs: [{ id: 'a', name: 'Acme' }, { id: 'b', name: 'Bolt' }], total: 2 });
+  });
+
+  it('passes a trimmed search through and drops an empty one', async () => {
+    coreRequest.mockResolvedValue({ data: [], pagination: { page: 1, limit: 100, total: 0 } });
+    await listOrganizations('  acm ');
+    expect(coreRequest).toHaveBeenCalledWith('/orgs/organizations?limit=100&search=acm');
+    await listOrganizations('   ');
+    expect(coreRequest).toHaveBeenLastCalledWith('/orgs/organizations?limit=100');
+  });
+
+  it('tolerates an empty body', async () => {
+    coreRequest.mockResolvedValue({});
+    expect(await listOrganizations()).toEqual({ orgs: [], total: 0 });
+  });
+});

--- a/apps/mobile/src/services/organizations.ts
+++ b/apps/mobile/src/services/organizations.ts
@@ -1,0 +1,29 @@
+import { coreRequest } from './api';
+
+export interface OrganizationSummary {
+  id: string;
+  name: string;
+}
+
+/** The server clamps `limit` to 100 (see `getPagination`); ask for that. */
+const PAGE_LIMIT = 100;
+
+/**
+ * One page of the organisations the caller can see, for pickers. A partner
+ * with more than 100 customers narrows with `search` (server-side, so the
+ * cap is on the result, not the universe). `total` says whether that was
+ * needed.
+ */
+export async function listOrganizations(
+  search?: string
+): Promise<{ orgs: OrganizationSummary[]; total: number }> {
+  const params = new URLSearchParams({ limit: String(PAGE_LIMIT) });
+  const trimmed = search?.trim();
+  if (trimmed) params.set('search', trimmed);
+  const response = await coreRequest<{
+    data?: Array<{ id: string; name: string }>;
+    pagination?: { total?: number };
+  }>(`/orgs/organizations?${params.toString()}`);
+  const orgs = (response.data ?? []).map((o) => ({ id: o.id, name: o.name }));
+  return { orgs, total: response.pagination?.total ?? orgs.length };
+}

--- a/apps/mobile/src/services/tickets.test.ts
+++ b/apps/mobile/src/services/tickets.test.ts
@@ -5,6 +5,7 @@ vi.mock('./api', () => ({ coreRequest: (...args: unknown[]) => coreRequest(...ar
 
 import {
   addTicketComment,
+  createTicket,
   allowedQuickStatuses,
   buildTicketListQuery,
   canTransition,
@@ -196,5 +197,17 @@ describe('SYSTEM_COMMENT_TYPES', () => {
     );
     expect(SYSTEM_COMMENT_TYPES.has('comment')).toBe(false);
     expect(SYSTEM_COMMENT_TYPES.has('internal')).toBe(false);
+  });
+});
+
+describe('createTicket', () => {
+  it('posts the body to /tickets and returns the created ticket', async () => {
+    coreRequest.mockResolvedValue({ data: { id: 'new-1', internalNumber: 'T-2026-0004', subject: 'x' } });
+    const created = await createTicket({ orgId: 'o1', subject: 'x', priority: 'normal' });
+    expect(coreRequest).toHaveBeenCalledWith('/tickets', {
+      method: 'POST',
+      body: JSON.stringify({ orgId: 'o1', subject: 'x', priority: 'normal' }),
+    });
+    expect(created).toMatchObject({ id: 'new-1', internalNumber: 'T-2026-0004' });
   });
 });

--- a/apps/mobile/src/services/tickets.ts
+++ b/apps/mobile/src/services/tickets.ts
@@ -139,6 +139,25 @@ export async function getTickets(params: ListTicketsParams = {}): Promise<Ticket
   };
 }
 
+export interface CreateTicketInput {
+  orgId: string;
+  subject: string;
+  description?: string;
+  priority: TicketPriority;
+}
+
+/**
+ * `POST /tickets` (`createTicketSchema`). The server allocates the internal
+ * number and stamps `source: 'manual'`; the response is the full ticket row.
+ */
+export async function createTicket(input: CreateTicketInput): Promise<TicketSummary> {
+  const response = await coreRequest<{ data: TicketSummary }>('/tickets', {
+    method: 'POST',
+    body: JSON.stringify(input),
+  });
+  return response.data;
+}
+
 export async function getTicket(id: string): Promise<TicketDetail> {
   const response = await coreRequest<{ data: TicketDetail }>(`/tickets/${id}`);
   const ticket = response.data;


### PR DESCRIPTION
## Summary

The mobile app could work an existing ticket but not open one. This adds a "+" on the Tickets tab that opens a **New ticket** screen.

- **Organisation picker.** Preselected for org-scoped users and single-org partners (then shown as a fixed label, not a list). Above eight organisations the picker gains a search box that queries the server (`GET /orgs/organizations?limit=100&search=`), since the server clamps a page to 100.
- **Subject** (required, 255 max), **description** (optional), **priority** chips in escalation order defaulting to normal, matching the service fallback.
- On success it lands on the new ticket via `navigation.replace`, so Back does not return to a half-filled form. The list refetches on focus, so the ticket is in the queue when the user returns.
- Failure shows a toast and keeps the form.

## Structure

- `screens/tickets/createTicketForm.ts` is a leaf module (no react-native import) holding `buildCreateTicketBody`, `canSubmitTicket`, `preselectOrg` and the priority options. The screen never trims or validates on its own; the body it POSTs comes from one tested function.
- `services/organizations.ts` (`listOrganizations`) and `createTicket` in `services/tickets.ts`.
- `CreateTicket` route on the Tickets stack.

## Verification

- Red first: `createTicketForm.test.ts`, `organizations.test.ts` and the `createTicket` case in `tickets.test.ts` all failed on missing modules / unmocked calls before the implementation, then passed.
- `tsc --noEmit` clean; `vitest run` 92 files, 1206 passed.
- Not run on a device. The screen uses only components and tokens already in use elsewhere in the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpzNXnfbR6mdMqnMSkECPK
