### PR TITLE
ci: non-blocking portal dev-mode e2e job (hydration guard for #3906)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2475,6 +2475,168 @@ jobs:
             kill "$(cat auth-browser-transition-api.pid)" || true
           fi
 
+  # ─── Portal dev-mode hydration guard (#3906) ─────────────────────────────
+  # Regression cover for #3906: every portal React island SSR'd correctly
+  # behind Caddy in a dev-mode stack and then silently failed to hydrate, so
+  # the portal e2e assertions kept passing against dead markup. The guard that
+  # actually catches it is `waitForHydration()` (e2e-tests/pages/hydration.ts),
+  # which can only fail against a REAL dev-mode stack with Caddy in front of
+  # the portal at /portal — the exact shape PR #4540 fixed and the one shape
+  # nothing in CI ran. (The other Playwright job here,
+  # auth-browser-transition-browser-contract, uses a narrow config with a bare
+  # API process, no web/portal dev servers and no Caddy.) Until this job
+  # existed, a #3906-class regression could only be caught in a hand-brought-up
+  # stack.
+  #
+  # NON-BLOCKING FOR NOW: `continue-on-error: true`, and deliberately absent
+  # from `ci-success`'s `needs` list and from its result checks — a flake or a
+  # Docker hiccup in a job this heavy must not red a PR while we learn how
+  # stable it is.
+  # PROMOTION CRITERION: after a week of green runs on main, drop
+  # `continue-on-error`, add `portal-dev-e2e` to `ci-success`'s `needs`, and
+  # add a `PORTAL_DEV_E2E_RESULT != "success"` clause to its check script.
+  portal-dev-e2e:
+    name: Portal Dev E2E (hydration, non-blocking)
+    runs-on: ubuntu-latest
+    needs: [lint, typecheck]
+    continue-on-error: true
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version-file: .node-version
+
+      # The stack is brought up by the repo's own wt-stack tooling
+      # (scripts/dev/wt-stack) rather than a CI-only compose invocation, so this
+      # job tracks the dev stack developers actually run: pg + redis + api + web
+      # + portal + caddy from docker-compose.yml + .override.yml.dev +
+      # .override.yml.worktree, code-mounted, on ephemeral host ports, with
+      # e2e-tests/seed-fixtures.sql seeded into Postgres and a descriptor
+      # (.breeze-stack.json) that playwright.config.ts already knows how to read.
+      #
+      # wt-stack requires a root .env: the base compose file guards a dozen
+      # values with `${VAR:?}` and resolves every image ref from it. wt-stack
+      # writes .env.stack itself for the dev-only values and passes it LAST, so
+      # for the handful of keys set in both places (POSTGRES_*, the peppers,
+      # TURN_SECRET, BREEZE_PORTAL_IMAGE_REF) .env.stack wins; they are repeated
+      # here only so this file stays valid if that list ever changes.
+      #
+      # BREEZE_BOOTSTRAP_ADMIN_* is deliberately NOT set: with NODE_ENV
+      # development (docker-compose.override.yml.dev) the API's first-boot seed
+      # then creates admin@breeze.local / BreezeAdmin123!, which is the account
+      # the wt-stack descriptor hands to Playwright.
+      - name: Create .env for the dev stack
+        run: |
+          cat > .env <<'EOF'
+          BREEZE_VERSION=ci-portal-dev-e2e
+          POSTGRES_USER=breeze
+          POSTGRES_PASSWORD=breeze
+          POSTGRES_DB=breeze
+          REDIS_PASSWORD=ci-portal-dev-e2e-redis-pw
+          JWT_SECRET=ci-portal-dev-e2e-k7x9Qm4pR2vL8nW5jT3yF6hB0cA1dE4gI7
+          # Signs partner reconstruction export cursors (#2506). 32 random bytes, base64.
+          PARTNER_API_CURSOR_SIGNING_KEY=nJ4B7uS2xielQGyxLoBLcPCPey5FyilPeVQbGL10CDo=
+          AGENT_ENROLLMENT_SECRET=ci-portal-dev-e2e-agent-enrollment-Hy4Bz9Mp2Wq6
+          APP_ENCRYPTION_KEY=e9367714341ea19491ff7cd095d1a97e15ae3f7962416723ecfb29a89ed71eb9
+          MFA_ENCRYPTION_KEY=e86f8b88f2c058d428de55c4abec1b50a3cd960a7205dffdb65be8130abbb777
+          ENROLLMENT_KEY_PEPPER=ci-portal-dev-e2e-enrollment-pepper-Hy4Bz9Mp2W
+          MFA_RECOVERY_CODE_PEPPER=ci-portal-dev-e2e-mfa-recovery-pepper-Nq8Zx2
+          TURN_SECRET=ci-portal-dev-e2e-turn-secret
+          # Wave 3.5d / Wave 4 runtime config — `${VAR:?}` guards in the base compose.
+          EVENT_PERMISSION_EPOCH_MODE=compat
+          REMOTE_ACCESS_ADMISSION_MODE=open
+          REMOTE_WS_AUTH_MODE=post_upgrade
+          REMOTE_WS_REDIS_TOPOLOGY=standalone-single-primary
+          # Caddy terminates plain HTTP on an ephemeral port here (the dev stack
+          # has no TLS), so the API must not demand https on forwarded requests.
+          FORCE_HTTPS=false
+          # The built-in Workspace extension defaults ON in the dev override; its
+          # migrations are pure cost for a portal hydration run, so keep it off.
+          BREEZE_WORKSPACE_ENABLED=false
+          # Image refs — the base docker-compose.yml requires all of these via
+          # `${VAR:?}` before profile filtering, even though the dev override
+          # builds api/web/portal from this checkout and stubs binaries-init.
+          BREEZE_API_IMAGE_REF=ghcr.io/lanternops/breeze/api:latest
+          BREEZE_WEB_IMAGE_REF=ghcr.io/lanternops/breeze/web:latest
+          BREEZE_PORTAL_IMAGE_REF=ghcr.io/lanternops/breeze/portal:latest
+          BREEZE_BINARIES_IMAGE_REF=ghcr.io/lanternops/breeze/binaries:latest
+          CADDY_IMAGE_REF=caddy:2-alpine
+          POSTGRES_IMAGE_REF=pgvector/pgvector:pg16
+          REDIS_IMAGE_REF=redis:7-alpine
+          COTURN_IMAGE_REF=coturn/coturn:latest
+          EOF
+
+      # e2e-tests is deliberately OUTSIDE the pnpm workspace
+      # (pnpm-workspace.yaml covers apps/*, packages/* and ee/* only), so it
+      # installs standalone. It ships no pnpm-lock.yaml — only the
+      # package-lock.json the auth-browser-transition job's `npm ci` uses — and
+      # pnpm's CI frozen-lockfile default is a no-op when no pnpm lockfile
+      # exists, so this resolves fresh rather than failing.
+      - name: Install e2e-tests dependencies
+        working-directory: e2e-tests
+        run: pnpm install --ignore-workspace
+
+      - name: Install Chromium
+        working-directory: e2e-tests
+        run: pnpm exec playwright install --with-deps chromium
+
+      # `pnpm wt-stack up` without a workspace install: the CLI imports nothing
+      # but node builtins and its own sibling modules, so e2e-tests' tsx runs it
+      # directly and a multi-minute root `pnpm install` is avoided. It must run
+      # from the repo root — the CLI derives the compose project name, the
+      # env-file paths and the descriptor location from process.cwd().
+      - name: Bring up the dev-mode stack (Caddy fronting the portal at /portal)
+        run: ./e2e-tests/node_modules/.bin/tsx scripts/dev/wt-stack/cli.ts up --rebuild
+
+      - name: Show the stack descriptor
+        run: cat .breeze-stack.json
+
+      # multi-currency.spec.ts is the only spec whose flow reaches the portal
+      # through `waitForHydration` — its `public-quote-accept` step is the exact
+      # assertion #3906 broke and #4540 fixed.
+      # `quote-contract-proposal.spec.ts` is the only other `waitForHydration`
+      # caller and is EXCLUDED on purpose: it has a known, unrelated
+      # pre-existing failure earlier in the WEB flow (AuthOverlay /
+      # session-expired on the contracts tab) and never gets as far as its
+      # portal step. Add it here once that is fixed.
+      - name: Run the portal hydration specs
+        run: ./e2e-tests/node_modules/.bin/tsx scripts/dev/wt-stack/cli.ts test -- tests/multi-currency.spec.ts
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: portal-dev-e2e-playwright-report
+          path: |
+            e2e-tests/playwright-report
+            e2e-tests/test-results
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Container logs on failure
+        if: failure()
+        run: |
+          for c in $(docker ps -aq); do
+            echo "===== $(docker inspect -f '{{ .Name }}' "${c}") ====="
+            docker logs --tail 200 "${c}" 2>&1 || true
+          done
+
+      - name: Teardown
+        if: always()
+        run: ./e2e-tests/node_modules/.bin/tsx scripts/dev/wt-stack/cli.ts down || true
+
   # Summary job that depends on all other jobs for branch protection
   ci-success:
     name: CI Success

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2588,9 +2588,21 @@ jobs:
         working-directory: e2e-tests
         run: pnpm install --ignore-workspace
 
+      # `--with-deps` shells out to `apt-get update`, which intermittently 403s
+      # on packages.microsoft.com from Azure-hosted runners and takes the whole
+      # browser install down with it (exit 100). That repo holds nothing
+      # Playwright needs, so drop it first; if apt still fails, fall back to the
+      # browser-only install — the ubuntu-24.04 runner image already ships
+      # Chromium's shared libraries — and say so loudly rather than silently.
       - name: Install Chromium
         working-directory: e2e-tests
-        run: pnpm exec playwright install --with-deps chromium
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list \
+                     /etc/apt/sources.list.d/microsoft*.sources || true
+          if ! pnpm exec playwright install --with-deps chromium; then
+            echo "::warning::playwright install --with-deps failed (apt); retrying without system deps"
+            pnpm exec playwright install chromium
+          fi
 
       # `pnpm wt-stack up` without a workspace install: the CLI imports nothing
       # but node builtins and its own sibling modules, so e2e-tests' tsx runs it
@@ -2633,9 +2645,17 @@ jobs:
             docker logs --tail 200 "${c}" 2>&1 || true
           done
 
+      # `wt-stack down` passes --env-file .env.stack, which only exists once
+      # `up` has started; guard so a failure before that leaves a one-line note
+      # instead of a compose stack trace in the log.
       - name: Teardown
         if: always()
-        run: ./e2e-tests/node_modules/.bin/tsx scripts/dev/wt-stack/cli.ts down || true
+        run: |
+          if [ -f .env.stack ]; then
+            ./e2e-tests/node_modules/.bin/tsx scripts/dev/wt-stack/cli.ts down || true
+          else
+            echo "No .env.stack — the stack was never brought up; nothing to tear down."
+          fi
 
   # Summary job that depends on all other jobs for branch protection
   ci-success:

--- a/apps/api/src/config/ciSuccessGatingContract.test.ts
+++ b/apps/api/src/config/ciSuccessGatingContract.test.ts
@@ -49,6 +49,12 @@ const UNGATED_JOBS = new Set([
   'ci-success', // the aggregate itself
   'main-red-alert', // runs after ci-success, alerts on a red main
   'rust-check-windows', // deliberately excluded, documented at its job definition: path-filtered and usually skipped
+  // Deliberately non-blocking WHILE IT EARNS TRUST, not a gap: it builds three dev images
+  // and boots a six-service stack (pg+redis+api+web+portal+caddy) to run the #3906 portal
+  // hydration guard, so an infra hiccup there must not red a PR yet. The promotion
+  // criterion — a week of green, then move it into ci-success needs: with an env var and a
+  // blocking assertion — is recorded at its job definition in ci.yml.
+  'portal-dev-e2e',
   'check-migrations', // KNOWN GAP, not policy - see comment below
   'lint-agent', // KNOWN GAP
   'test-agent-race', // KNOWN GAP


### PR DESCRIPTION
## What this adds

A new `portal-dev-e2e` job in `.github/workflows/ci.yml` that brings up a **dev-mode** stack and runs the portal hydration guards against it.

- **Stack:** the repo's own wt-stack tooling (`scripts/dev/wt-stack`), i.e. `docker-compose.yml` + `docker-compose.override.yml.dev` + `docker-compose.override.yml.worktree` — pg + redis + api + web + portal + caddy, code-mounted, with **Caddy fronting the portal at `/portal`**. That path is the whole point: #3906 was a routing/emission bug that only exists when the portal dev server is reached through the `/portal` prefix. Using the dev tooling instead of a CI-only compose invocation means the job tracks the stack developers actually run.
- **Seed:** `e2e-tests/seed-fixtures.sql`, exactly as `wt-stack up` seeds it (and again via `global-setup.ts`, which is idempotent).
- **Deps:** `pnpm install --ignore-workspace` inside `e2e-tests` — that package is outside the pnpm workspace (`pnpm-workspace.yaml` covers `apps/*`, `packages/*`, `ee/*` only). `wt-stack` itself is run through that install's `tsx`, so the job skips a multi-minute root workspace install; the CLI imports nothing but node builtins.
- **Specs:** `tests/multi-currency.spec.ts`. Its `public-quote-accept` step is the exact `waitForHydration()` assertion #3906 broke and #4540 fixed.
- **On failure:** the Playwright HTML report + traces upload as an artifact, and every container's last 200 log lines are dumped.
- **Always:** the stack is torn down (`wt-stack down`, volumes removed).
- Bounded with `timeout-minutes: 45`.

### Why only `multi-currency.spec.ts`

`waitForHydration` has exactly two spec-level callers (directly or via `QuotesPage`/`InvoicesPage`): `multi-currency.spec.ts` and `quote-contract-proposal.spec.ts`. The latter is **excluded on purpose** — it has a known, unrelated pre-existing failure earlier in the **web** flow (AuthOverlay / session-expired on the contracts tab) and never reaches its portal step. That exclusion is noted inline in the workflow, with a pointer to add it back once the web-side failure is fixed.

## Why this job is needed

#3906 was invisible to CI for weeks. Portal pages SSR'd correctly and then died silently, so `data-testid` assertions passed against markup with no React attached. The guard that discriminates is `waitForHydration()` in `e2e-tests/pages/hydration.ts`, and it can only fail against a real dev-mode stack behind Caddy. Today the only Playwright job in CI (`auth-browser-transition-browser-contract`) uses the narrow `playwright.auth-browser-transition.config.ts` against a bare API process — no web, no portal, no Caddy — and the main `e2e-tests/playwright.config.ts` has no `webServer`, so it has always needed a hand-brought-up stack. A #3906-class regression could therefore only ever be caught by a human running `pnpm wt-stack up`.

## Why non-blocking (for now)

`continue-on-error: true`, and the job is deliberately **absent from the `ci-success` aggregate** — neither in its `needs` list nor in its result checks — so a flake or a Docker hiccup in a job this heavy (three dev image builds + a six-service stack + a browser) cannot red a PR while we learn how stable it is. This mirrors the `smoke-test` / `guided-setup-smoke` posture, except those are already required on `main` pushes; this one is non-blocking everywhere until it has a track record.

**Promotion criterion (also recorded inline in the workflow):** after a week of green runs on `main`, drop `continue-on-error`, add `portal-dev-e2e` to `ci-success`'s `needs`, and add a `PORTAL_DEV_E2E_RESULT != "success"` clause to its check script.

## Verification

- `actionlint .github/workflows/ci.yml` — no new findings (the one SC2155 warning it reports at line 1186 is pre-existing on `main`, byte-identical).
- Workflow YAML parses; `portal-dev-e2e` is present, `continue-on-error: true`, `timeout-minutes: 45`, and `ci-success.needs` does **not** contain it.
- `pnpm install --ignore-workspace` verified clean-slate under `CI=true` in `e2e-tests` (no pnpm lockfile there — pnpm's CI frozen-lockfile default is a no-op when none exists, so it resolves fresh rather than failing).
- `./e2e-tests/node_modules/.bin/tsx scripts/dev/wt-stack/cli.ts` runs the wt-stack CLI from the repo root.
- The real proof is this PR's own run of the new job — see the checks below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## First green run on this PR

Run [33664542770](https://github.com/LanternOps/breeze/actions/runs/33664542770) → job `Portal Dev E2E (hydration, non-blocking)` = **success**, wall clock **4m31s** (18:05:16Z → 18:09:47Z), well inside the 45-minute bound.

Not a vacuous green — from the job log:

- All three dev images built from this checkout: `naming to docker.io/library/breeze-portal:dev`, `breeze-api:dev`, `breeze-web:dev`.
- All six services reached `Healthy` (postgres, redis, api, portal, web — and caddy, which gates on the other three).
- Fixtures seeded: `NOTICE: E2E fixtures seeded for org 10296351-…`.
- Stack descriptor: `"portalUrl": "http://localhost:32770/portal"` — Caddy fronting the portal under `/portal`, which is the shape #3906 broke.
- `Running 1 test using 1 worker` → **`1 passed (57.4s)`**. One test discovered, one test run — not a zero-test no-op. The 57.4s matches the 48.8s PR #4540 measured for the same spec on a hand-brought-up stack.

The passing path runs through `waitForHydration(publicPage, 'public-quote-accept')` on `${origin}/portal/quote/<token>`, so the green itself proves an island hydrated behind Caddy under `/portal`. That this assertion goes **red** on pre-#4540 code is established by #4540's own verification and by the reproduction recorded in #3906 ("multi-currency.spec.ts fails at waitForHydration(publicPage, 'public-quote-accept') … the guard is doing its job") — inherited evidence, not re-proven here.

### One fix during bring-up

The first attempt failed in 22s: `playwright install --with-deps` shells out to `apt-get update`, which 403'd on `packages.microsoft.com` from the Azure-hosted runner and took the browser install down with it (exit 100). Fixed in be56ec0 by dropping that (unneeded) apt source first, with a loud-warning fallback to the browser-only install if apt breaks again. The same commit guards the teardown so a failure before `up` logs one line instead of a compose stack trace. On the green run the `--with-deps` path succeeded and the fallback did not fire.


### Gating-contract decision (caught by the repo's own guard)

`apps/api/src/config/ciSuccessGatingContract.test.ts` reds any top-level `ci.yml` job that has no explicit gating decision, and it caught this one:

```
Jobs without a gating decision: portal-dev-e2e. A new job was added to ci.yml without
deciding whether it gates a merge; add it to ci-success needs: (plus its env var and
blocking assertion) or to UNGATED_JOBS with a reason.
```

That is the guard doing its job. 31a857e records `portal-dev-e2e` in `UNGATED_JOBS` as **deliberately non-blocking while it earns trust** (not a "KNOWN GAP"), with a pointer to the promotion criterion at the job definition. Mutation-checked locally: removing the entry reds the assertion with that exact message, restoring it greens 8/8.

## Final state

Run [33667014886](https://github.com/LanternOps/breeze/actions/runs/33667014886) — **entire run green**, zero failed jobs:

| Job | Result |
|---|---|
| `Portal Dev E2E (hydration, non-blocking)` | **success**, 4m20s — `Running 1 test using 1 worker` → `1 passed (52.5s)`, `portalUrl: http://localhost:32770/portal` |
| `Test API` (the gating contract) | success |
| `Test Web` | success |
| `CI Success` | success |

Two consecutive green runs of the new job (4m31s and 4m20s), both non-vacuous. The `Test Web` red on the earlier run (`AiUsagePage.test.tsx`) was transient and unrelated — it is green here and main is green too.
