### PR TITLE
fix(selfhost): backfill CADDY_LOCAL_CERTS wiring into release-pinned templates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
           bash scripts/check-guided-setup-default-project.sh
           bash scripts/check-selfhost-db-urls.sh
           bash scripts/check-guided-setup-env-roundtrip.sh
+          bash scripts/check-guided-setup-local-certs-backfill.sh
           bash scripts/check-guided-setup-placeholders.sh
           bash scripts/check-guided-setup-systemd-unit.sh
 

--- a/scripts/check-guided-setup-local-certs-backfill.sh
+++ b/scripts/check-guided-setup-local-certs-backfill.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+#
+# guided-setup.sh downloads docker-compose.yml and docker/Caddyfile.prod pinned
+# to the SELECTED release tag, but the script itself is whatever the operator
+# fetched — usually newer. A script feature that depends on template content
+# (the CADDY_LOCAL_CERTS opt-in needs the compose env wiring AND the Caddyfile
+# placeholder) is therefore a silent no-op against any tag that predates it:
+# the operator answers "n" to the Let's Encrypt prompt, the .env is written,
+# and Caddy still fails the ACME order (SSL_ERROR_INTERNAL_ERROR_ALERT).
+#
+# This guard exercises ensure_caddy_local_certs_template_support against
+# templates shaped like a pre-fix release (the current files with the two
+# CADDY_LOCAL_CERTS lines stripped), and asserts that:
+#   1. both templates gain the wiring, and it lands INSIDE the caddy service /
+#      the global options block, not somewhere yaml/caddy would ignore;
+#   2. a second run is a no-op (no duplicate lines, no extra backup);
+#   3. current templates that already carry the wiring are left untouched
+#      (no backup written, bytes identical).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+FUNCTIONS_FILE="${TMP_DIR}/guided-setup-functions.sh"
+sed '/^main "\$@"$/d' "${REPO_ROOT}/scripts/guided-setup.sh" > "${FUNCTIONS_FILE}"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+# The wiring must exist in the current templates, otherwise "strip it" below
+# would be stripping nothing and the legacy fixture would be identical to HEAD.
+grep -q 'CADDY_LOCAL_CERTS' "${REPO_ROOT}/docker-compose.yml" \
+  || fail "docker-compose.yml no longer wires CADDY_LOCAL_CERTS; this guard's fixture is stale."
+grep -q '{\$CADDY_LOCAL_CERTS' "${REPO_ROOT}/docker/Caddyfile.prod" \
+  || fail "docker/Caddyfile.prod no longer carries the {\$CADDY_LOCAL_CERTS} placeholder; this guard's fixture is stale."
+
+make_work_dir() {
+  local name="$1" legacy="$2"
+  local work_dir="${TMP_DIR}/${name}"
+  mkdir -p "${work_dir}/docker"
+  if [[ "${legacy}" == "true" ]]; then
+    grep -v 'CADDY_LOCAL_CERTS' "${REPO_ROOT}/docker-compose.yml" > "${work_dir}/docker-compose.yml"
+    grep -v 'CADDY_LOCAL_CERTS' "${REPO_ROOT}/docker/Caddyfile.prod" > "${work_dir}/docker/Caddyfile.prod"
+  else
+    cp "${REPO_ROOT}/docker-compose.yml" "${work_dir}/docker-compose.yml"
+    cp "${REPO_ROOT}/docker/Caddyfile.prod" "${work_dir}/docker/Caddyfile.prod"
+  fi
+  cp "${REPO_ROOT}/.env.example" "${work_dir}/.env.example"
+  printf '%s\n' "${work_dir}"
+}
+
+run_backfill() {
+  local work_dir="$1"
+  (
+    set -- --work-dir "${work_dir}" --env-file "${work_dir}/.env" --no-download --no-up -y
+    # shellcheck source=/dev/null
+    source "${FUNCTIONS_FILE}"
+    # shellcheck disable=SC2034  # read by ensure_caddy_local_certs_template_support
+    REVERSE_PROXY_MODE="caddy"
+    ensure_caddy_local_certs_template_support
+  )
+}
+
+count_backups() {
+  local work_dir="$1"
+  find "${work_dir}" -name '*.bak.*' | wc -l | tr -d ' '
+}
+
+# --- Case 1: legacy templates gain the wiring, in the right place ------------
+LEGACY="$(make_work_dir legacy true)"
+grep -q 'CADDY_LOCAL_CERTS' "${LEGACY}/docker-compose.yml" && fail "legacy fixture still contains CADDY_LOCAL_CERTS in compose."
+grep -q 'CADDY_LOCAL_CERTS' "${LEGACY}/docker/Caddyfile.prod" && fail "legacy fixture still contains CADDY_LOCAL_CERTS in Caddyfile."
+
+run_backfill "${LEGACY}" > "${TMP_DIR}/legacy.log" 2>&1 || {
+  cat "${TMP_DIR}/legacy.log" >&2
+  fail "ensure_caddy_local_certs_template_support exited non-zero on legacy templates."
+}
+
+# Compose: exactly one wiring line, and it sits inside the caddy service's
+# environment block (between `  caddy:` and the next top-level service key).
+compose_hits="$(grep -c '^      CADDY_LOCAL_CERTS: \${CADDY_LOCAL_CERTS:-}$' "${LEGACY}/docker-compose.yml" || true)"
+[[ "${compose_hits}" == "1" ]] || fail "expected exactly one CADDY_LOCAL_CERTS env line in compose, found ${compose_hits}."
+awk '
+  /^  caddy:[[:space:]]*$/ { in_caddy = 1; next }
+  in_caddy && /^  [a-z][a-z0-9_-]*:[[:space:]]*$/ { in_caddy = 0 }
+  in_caddy && /^      CADDY_LOCAL_CERTS: / { found = 1 }
+  END { exit found ? 0 : 1 }
+' "${LEGACY}/docker-compose.yml" || fail "CADDY_LOCAL_CERTS env line is not inside the caddy service."
+
+# Caddyfile: exactly one placeholder, inside the global options block that
+# opens the file (the first line that is a bare `{`).
+caddy_hits="$(grep -c '^  {\$CADDY_LOCAL_CERTS}$' "${LEGACY}/docker/Caddyfile.prod" || true)"
+[[ "${caddy_hits}" == "1" ]] || fail "expected exactly one {\$CADDY_LOCAL_CERTS} placeholder in Caddyfile, found ${caddy_hits}."
+awk '
+  !opened && /^\{[[:space:]]*$/ { opened = 1; next }
+  opened && /^\}[[:space:]]*$/ { opened = 0; closed = 1 }
+  opened && !closed && /^  \{\$CADDY_LOCAL_CERTS\}$/ { found = 1 }
+  END { exit found ? 0 : 1 }
+' "${LEGACY}/docker/Caddyfile.prod" || fail "{\$CADDY_LOCAL_CERTS} placeholder is not inside the global options block."
+
+[[ "$(count_backups "${LEGACY}")" == "2" ]] || fail "expected one backup per rewritten template (2), found $(count_backups "${LEGACY}")."
+
+# The patched templates must match what HEAD ships, modulo comment lines, so
+# the backfill cannot drift from the real wiring.
+diff <(grep -v '^\s*#' "${LEGACY}/docker/Caddyfile.prod") <(grep -v '^\s*#' "${REPO_ROOT}/docker/Caddyfile.prod") \
+  || fail "backfilled Caddyfile differs from HEAD's Caddyfile outside comments."
+diff <(grep -v '^\s*#' "${LEGACY}/docker-compose.yml") <(grep -v '^\s*#' "${REPO_ROOT}/docker-compose.yml") \
+  || fail "backfilled compose differs from HEAD's compose outside comments."
+
+# --- Case 2: second run is a no-op ------------------------------------------
+cp "${LEGACY}/docker-compose.yml" "${TMP_DIR}/legacy-compose.once"
+cp "${LEGACY}/docker/Caddyfile.prod" "${TMP_DIR}/legacy-caddy.once"
+run_backfill "${LEGACY}" > /dev/null 2>&1 || fail "second run exited non-zero."
+cmp -s "${LEGACY}/docker-compose.yml" "${TMP_DIR}/legacy-compose.once" || fail "second run modified compose."
+cmp -s "${LEGACY}/docker/Caddyfile.prod" "${TMP_DIR}/legacy-caddy.once" || fail "second run modified Caddyfile."
+[[ "$(count_backups "${LEGACY}")" == "2" ]] || fail "second run wrote an extra backup."
+
+# --- Case 3: current templates untouched ------------------------------------
+CURRENT="$(make_work_dir current false)"
+run_backfill "${CURRENT}" > /dev/null 2>&1 || fail "run against current templates exited non-zero."
+cmp -s "${CURRENT}/docker-compose.yml" "${REPO_ROOT}/docker-compose.yml" || fail "current compose was modified."
+cmp -s "${CURRENT}/docker/Caddyfile.prod" "${REPO_ROOT}/docker/Caddyfile.prod" || fail "current Caddyfile was modified."
+[[ "$(count_backups "${CURRENT}")" == "0" ]] || fail "backup written although current templates needed no change."
+
+printf 'guided setup CADDY_LOCAL_CERTS template backfill guard passed\n'

--- a/scripts/guided-setup.sh
+++ b/scripts/guided-setup.sh
@@ -3626,6 +3626,107 @@ apply_reverse_proxy_env() {
 #
 # Skipped for localhost and bare IPv4 addresses: Caddy never attempts ACME for
 # either, so it already falls back to its internal CA without being told to.
+# The templates this script downloads are pinned to the SELECTED release tag,
+# while the script itself is whatever the operator fetched — usually newer. The
+# internal-CA opt-in needs two template edits to take effect: the compose
+# `caddy` service must pass CADDY_LOCAL_CERTS through, and the Caddyfile's
+# global options block must carry the `{$CADDY_LOCAL_CERTS}` placeholder.
+# Against a tag that predates both, writing CADDY_LOCAL_CERTS=local_certs to
+# .env is a silent no-op: Caddy still attempts the ACME order, fails it, and
+# aborts the handshake with SSL_ERROR_INTERNAL_ERROR_ALERT — exactly the
+# symptom the prompt exists to prevent (reported on v0.109.0 templates).
+#
+# So backfill the two lines when they are missing. Idempotent: a template that
+# already carries the wiring is left byte-for-byte alone (no backup either).
+ensure_caddy_local_certs_template_support() {
+  [[ "${REVERSE_PROXY_MODE}" == "caddy" ]] || return 0
+
+  if [[ -f "${COMPOSE_FILE}" ]] && ! grep -q 'CADDY_LOCAL_CERTS' "${COMPOSE_FILE}"; then
+    backfill_compose_caddy_local_certs
+  fi
+
+  if [[ -f "${CADDYFILE_FILE}" ]] && ! grep -q '{\$CADDY_LOCAL_CERTS' "${CADDYFILE_FILE}"; then
+    backfill_caddyfile_local_certs_placeholder
+  fi
+}
+
+# Adds `CADDY_LOCAL_CERTS: ${CADDY_LOCAL_CERTS:-}` directly after the
+# `ACME_EMAIL:` line of the `caddy` service — the same block and indentation the
+# current docker-compose.yml uses. Anchored on the service, not on the first
+# ACME_EMAIL in the file, so a future service that also takes ACME_EMAIL cannot
+# receive the line by mistake.
+backfill_compose_caddy_local_certs() {
+  local tmp
+
+  if ! grep -Eq '^  caddy:[[:space:]]*$' "${COMPOSE_FILE}"; then
+    fail "${COMPOSE_FILE} does not contain the packaged Caddy service; cannot enable the internal CA. Restore a fresh Compose file with --download."
+  fi
+
+  tmp="$(mktemp "${COMPOSE_FILE}.tmp.XXXXXX")"
+  backup_file "${COMPOSE_FILE}"
+
+  if ! awk '
+    /^  caddy:[[:space:]]*$/ { in_caddy = 1; print; next }
+    in_caddy && /^  [a-z][a-z0-9_-]*:[[:space:]]*$/ { in_caddy = 0 }
+    {
+      print
+      if (in_caddy && !done && /^      ACME_EMAIL:/) {
+        print "      CADDY_LOCAL_CERTS: ${CADDY_LOCAL_CERTS:-}"
+        done = 1
+      }
+    }
+  ' "${COMPOSE_FILE}" > "${tmp}"; then
+    rm -f "${tmp}"
+    fail "Failed to add CADDY_LOCAL_CERTS to the caddy service; ${COMPOSE_FILE} was left unchanged."
+  fi
+
+  [[ -s "${tmp}" ]] || fail_compose_rewrite "${tmp}" "Generated Compose file was empty; ${COMPOSE_FILE} was left unchanged."
+  assert_generated_compose_contains "${tmp}" '      CADDY_LOCAL_CERTS: ${CADDY_LOCAL_CERTS:-}' "the CADDY_LOCAL_CERTS pass-through on the caddy service"
+  if ! mv "${tmp}" "${COMPOSE_FILE}"; then
+    rm -f "${tmp}"
+    fail "Failed to replace ${COMPOSE_FILE} with the CADDY_LOCAL_CERTS-enabled Compose file."
+  fi
+  log "Added CADDY_LOCAL_CERTS pass-through to the caddy service in ${COMPOSE_FILE} (release template predates the internal-CA option)."
+}
+
+# Inserts the bare `{$CADDY_LOCAL_CERTS}` placeholder as the first entry of the
+# global options block — the block that opens the file with a lone `{`. A bare
+# placeholder expands to `local_certs` when set and to a blank line when empty,
+# which the Caddyfile adapter discards; see docker/Caddyfile.prod.
+backfill_caddyfile_local_certs_placeholder() {
+  local tmp
+
+  if ! grep -Eq '^\{[[:space:]]*$' "${CADDYFILE_FILE}"; then
+    fail "${CADDYFILE_FILE} has no global options block; cannot enable the internal CA. Restore a fresh Caddyfile with --download."
+  fi
+
+  tmp="$(mktemp "${CADDYFILE_FILE}.tmp.XXXXXX")"
+  backup_file "${CADDYFILE_FILE}"
+
+  if ! awk '
+    {
+      print
+      if (!done && /^\{[[:space:]]*$/) {
+        print "  {$CADDY_LOCAL_CERTS}"
+        done = 1
+      }
+    }
+  ' "${CADDYFILE_FILE}" > "${tmp}"; then
+    rm -f "${tmp}"
+    fail "Failed to add the CADDY_LOCAL_CERTS placeholder; ${CADDYFILE_FILE} was left unchanged."
+  fi
+
+  if [[ ! -s "${tmp}" ]] || ! grep -Fq -- '  {$CADDY_LOCAL_CERTS}' "${tmp}"; then
+    rm -f "${tmp}"
+    fail "Generated Caddyfile is missing the CADDY_LOCAL_CERTS placeholder; ${CADDYFILE_FILE} was left unchanged."
+  fi
+  if ! mv "${tmp}" "${CADDYFILE_FILE}"; then
+    rm -f "${tmp}"
+    fail "Failed to replace ${CADDYFILE_FILE} with the CADDY_LOCAL_CERTS-enabled Caddyfile."
+  fi
+  log "Added the CADDY_LOCAL_CERTS placeholder to ${CADDYFILE_FILE} (release template predates the internal-CA option)."
+}
+
 configure_caddy_local_certs() {
   local domain="$1"
   local existing default_answer
@@ -3654,6 +3755,7 @@ configure_caddy_local_certs() {
     return 0
   fi
 
+  ensure_caddy_local_certs_template_support
   set_env_value "CADDY_LOCAL_CERTS" "local_certs"
   log "Caddy will issue certificates for ${domain} from its own internal CA instead of Let's Encrypt."
   log "Browsers will warn on every visit until that CA root is trusted on each machine. Export it with:"


### PR DESCRIPTION
## The problem

Follow-up to #4479. The self-hoster who reported the original `SSL_ERROR_INTERNAL_ERROR_ALERT` re-ran the updated `guided-setup.sh`, answered **n** to "Can Let's Encrypt reach this domain?", saw the internal-CA message, and still got the same TLS alert on their own domain (localhost worked).

**Verified cause.** `guided-setup.sh` downloads `docker-compose.yml` and `docker/Caddyfile.prod` pinned to the *selected release tag* (`resolve_template_remote_base` → `raw.githubusercontent.com/<repo>/<tag>/...`), while the script itself is whatever the operator fetched. The internal-CA opt-in needs two template edits to have any effect:

- the compose `caddy` service must pass `CADDY_LOCAL_CERTS: ${CADDY_LOCAL_CERTS:-}` through, and
- the Caddyfile global options block must carry the bare `{$CADDY_LOCAL_CERTS}` placeholder.

`v0.109.0` (the newest tag, so what every install downloads today) has neither:

```
$ for t in v0.109.0 v0.108.0; do git show $t:docker/Caddyfile.prod | grep -c CADDY_LOCAL_CERTS; git show $t:docker-compose.yml | grep -c CADDY_LOCAL_CERTS; done
0 0
0 0
```

So the script wrote `CADDY_LOCAL_CERTS=local_certs` into `.env`, compose never forwarded it, the Caddyfile could not have read it anyway, and Caddy went down the ACME path exactly as before.

## The change

When the operator opts into the internal CA, `ensure_caddy_local_certs_template_support` now backfills the two lines into the downloaded templates if they are missing:

- **compose**: inserts the pass-through directly after the `ACME_EMAIL:` line *inside the `caddy` service* (anchored on the service, not the first `ACME_EMAIL` in the file).
- **Caddyfile**: inserts `  {$CADDY_LOCAL_CERTS}` as the first entry of the global options block (the leading bare `{`).

Both back up the file first (existing `backup_file`), assert the line landed before `mv`, and are idempotent: a template that already carries the wiring is left byte-for-byte alone with no backup. Templates from a release that ships the wiring (v0.110+) are untouched.

## Proof

- **Real v0.109.0 templates**: ran the function against `git show v0.109.0:` copies, then `caddy adapt` on the result with `caddy:2-alpine`:
  - `CADDY_LOCAL_CERTS=local_certs` → `"issuers":[{"module":"internal"}]` present
  - `CADDY_LOCAL_CERTS=` → zero occurrences of `"internal"`
- **New guard** `scripts/check-guided-setup-local-certs-backfill.sh` (wired into the required **Lint** job next to the other guided-setup guards). Written red-first (`command not found`), then green. It builds a legacy fixture by stripping the `CADDY_LOCAL_CERTS` lines from HEAD's templates and asserts: exactly one line added to each; the compose line is inside the `caddy` service and the placeholder inside the global options block; the patched files equal HEAD's outside comments; exactly one backup per rewritten file; a second run changes nothing and writes no backup; current templates are byte-identical and un-backed-up.
- `bash -n`, `shellcheck -S warning` clean on both scripts; all five existing `check-guided-setup-*` guards green.

## Operator note

Re-running the updated installer and answering **n** again is the whole fix: it patches the two downloaded files and `docker compose up -d` recreates `breeze-caddy` because its environment changed. Browsers will then show a *certificate warning* (untrusted internal CA) rather than the protocol error, until the root from `docker compose exec caddy cat /data/caddy/pki/authorities/local/root.crt` is trusted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lttqi957CD2hVxpcgY7P36