### PR TITLE
fix(mobile): reload the timesheet on focus

### DIFF
--- a/apps/mobile/src/screens/time/TimesheetScreen.tsx
+++ b/apps/mobile/src/screens/time/TimesheetScreen.tsx
@@ -11,6 +11,7 @@ import {
   View,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useFocusEffect } from '@react-navigation/native';
 
 import { palette, radii, spacing, type } from '../../theme';
 import { useAppDispatch, useAppSelector } from '../../store';
@@ -189,9 +190,16 @@ export function TimesheetScreen({ navigation }: TimesheetProps = {}) {
     [dispatch]
   );
 
-  useEffect(() => {
-    void load(weekStart);
-  }, [load, weekStart]);
+  // Reload on every focus, not just on mount or week change: a timer stopped on
+  // a ticket and then the Time tab opened is the reviewer's exact path, and the
+  // tab used to keep the week it fetched the first time, so the new entry was
+  // simply not there until the week was paged away and back. The screen has no
+  // pull-to-refresh either, so focus is the only natural refresh point.
+  useFocusEffect(
+    useCallback(() => {
+      void load(weekStart);
+    }, [load, weekStart])
+  );
 
   const days = useMemo(() => daysOfWeek(weekStart), [weekStart]);
   // Only data actually loaded FOR the displayed week counts. Anything else is


### PR DESCRIPTION
## Summary

Found on the iPhone simulator against the App Review tenant: stop a timer on a ticket, open the Time tab, and the week still says "No time logged". The tab kept the payload from its first mount; only paging the week away and back refetched it, and there is no pull-to-refresh. That is the reviewer's path for the time-entry item.

`useFocusEffect` replaces the mount/week-change `useEffect`, so the current week is refetched whenever the tab gains focus (same pattern as `TicketsScreen`). The load is generation-guarded already, so a focus during an in-flight fetch cannot publish a stale week.

## Verification
- `tsc --noEmit` clean; `vitest run src/screens/time` 5 files, 57 tests.
- Reproduced before the change on the simulator (entry appeared only after paging weeks); re-verified after via Metro reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpzNXnfbR6mdMqnMSkECPK
