### PR TITLE
fix(mobile): refresh the access token on 401 for every request

### DIFF
--- a/apps/mobile/src/services/aiChat.ts
+++ b/apps/mobile/src/services/aiChat.ts
@@ -4,9 +4,7 @@ import * as Sentry from '@sentry/react-native';
 import { getServerUrl } from './serverConfig';
 import { fetchWithTimeout } from './fetchWithTimeout';
 import type { ApiError } from './api';
-import { refreshToken } from './api';
-import { storeToken } from './auth';
-import { commitIfCurrent, currentSessionGeneration } from './sessionGeneration';
+import { refreshAccessToken } from './tokenRefresh';
 
 const FALLBACK_API_BASE_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3001';
 const API_CORE_PREFIX = '/api/v1';
@@ -32,69 +30,6 @@ async function getToken(): Promise<string | null> {
   }
 }
 
-// Single-flight guard so N concurrent 401s trigger one /auth/refresh, not N.
-// Cleared once the refresh settles; callers that grabbed the promise still
-// receive its result. NOTE: /auth/refresh rotates the refresh cookie and
-// replaying a rotated token revokes the whole token family, so this guard is
-// only safe while aiChat is the sole mobile refresh caller — if another
-// service starts calling refreshToken(), move the single-flight into a shared
-// module.
-let refreshInFlight: Promise<string | null> | null = null;
-
-/**
- * Refresh the access token via the shared `refreshToken()` helper (api.ts) and
- * persist it so every service reading `breeze_auth_token` picks it up.
- * Returns the new token, or null when refresh failed (e.g. the refresh cookie
- * itself expired) — callers then surface the original 401.
- */
-async function refreshAccessToken(): Promise<string | null> {
-  if (!refreshInFlight) {
-    refreshInFlight = (async () => {
-      const generation = currentSessionGeneration();
-      try {
-        const { token } = await refreshToken();
-        try {
-          const committed = await commitIfCurrent(generation, async () => {
-            await storeToken(token);
-            return token;
-          });
-          if (committed === undefined) return null;
-        } catch (e) {
-          // Persisting failed (locked keychain, etc.) — the in-memory token is
-          // still valid for the retry, so don't turn a usable refresh into a
-          // hard failure. But a phone that can't persist tokens will silently
-          // double every aiChat round-trip while all non-refreshing services
-          // hard-401, so make the real cause observable in production
-          // (console.* goes nowhere on release RN builds).
-          Sentry.captureException(e, {
-            tags: { area: 'aichat-token-refresh' },
-            extra: { stage: 'persist' },
-          });
-          if (generation !== currentSessionGeneration()) return null;
-        }
-        if (generation !== currentSessionGeneration()) return null;
-        return token;
-      } catch (e) {
-        // Refresh failed — expired refresh cookie, offline, or a
-        // /auth/refresh outage. We return null so the caller surfaces the
-        // original 401 to the UI either way, but record which failure mode it
-        // was: without this, "users see 401s" is undiagnosable in production.
-        Sentry.captureMessage('aiChat token refresh failed', {
-          level: 'warning',
-          tags: { area: 'aichat-token-refresh' },
-          extra: {
-            statusCode: (e as ApiError)?.statusCode,
-            message: (e as ApiError)?.message ?? String(e),
-          },
-        });
-        return null;
-      } finally {
-        refreshInFlight = null;
-      }
-    })();
-  }
-  return refreshInFlight;
-}
 
 async function doAuthedFetch(
   path: string,

--- a/apps/mobile/src/services/api.refresh.test.ts
+++ b/apps/mobile/src/services/api.refresh.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Same harness as api.logout.test.ts: SecureStore, server URL, fetch and CSRF
+// are stubbed so `coreRequest` runs end to end against scripted responses.
+const secureValues = new Map<string, string>();
+const fetchWithTimeout = vi.fn();
+const serverConfig = vi.hoisted(() => ({
+  getServerUrl: vi.fn(async () => 'https://api.example.test'),
+}));
+const secureStore = vi.hoisted(() => ({
+  getItemAsync: vi.fn(async (key: string) => secureValues.get(key) ?? null),
+  setItemAsync: vi.fn(async (key: string, value: string) => { secureValues.set(key, value); }),
+  deleteItemAsync: vi.fn(async (key: string) => { secureValues.delete(key); }),
+}));
+vi.mock('expo-secure-store', () => ({
+  WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'device-only',
+  getItemAsync: (...args: Parameters<typeof secureStore.getItemAsync>) => secureStore.getItemAsync(...args),
+  setItemAsync: (...args: Parameters<typeof secureStore.setItemAsync>) => secureStore.setItemAsync(...args),
+  deleteItemAsync: (...args: Parameters<typeof secureStore.deleteItemAsync>) => secureStore.deleteItemAsync(...args),
+}));
+vi.mock('@sentry/react-native', () => ({ captureMessage: vi.fn(), captureException: vi.fn() }));
+vi.mock('./serverConfig', () => ({ getServerUrl: () => serverConfig.getServerUrl() }));
+vi.mock('./installationId', () => ({
+  getOrCreateInstallationId: vi.fn(async () => 'install-1'),
+}));
+vi.mock('./fetchWithTimeout', () => ({
+  fetchWithTimeout: (...args: unknown[]) => fetchWithTimeout(...args),
+}));
+vi.mock('./csrfToken', () => ({
+  CSRF_TOKEN_KEY: 'breeze_csrf_token',
+  applyCsrfSignal: vi.fn(async () => undefined),
+  forgetCsrfToken: vi.fn(async () => undefined),
+  clearCsrfToken: vi.fn(async () => undefined),
+  getCsrfHeaderValue: vi.fn(async () => 'csrf'),
+  readCsrfCookie: vi.fn(() => ({ kind: 'absent' })),
+}));
+
+import { coreRequest } from './api';
+import { refreshAccessToken } from './tokenRefresh';
+import { AUTH_TOKEN_KEY } from './authSessionKeys';
+
+function response(status: number, body: unknown = {}): Response {
+  return new Response(status === 204 ? null : JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+/** Every fetch call as `[method, path, bearer]`, in order. */
+function calls(): Array<[string, string, string | undefined]> {
+  return fetchWithTimeout.mock.calls.map(([url, init]) => [
+    ((init as RequestInit)?.method ?? 'GET').toUpperCase(),
+    new URL(url as string).pathname,
+    ((init as RequestInit)?.headers as Record<string, string>)?.Authorization,
+  ]);
+}
+
+beforeEach(() => {
+  secureValues.clear();
+  secureValues.set(AUTH_TOKEN_KEY, 'stale-token');
+  fetchWithTimeout.mockReset();
+});
+
+describe('401 -> refresh -> retry on every core request', () => {
+  it('refreshes once, persists the new token, and retries the original request with it', async () => {
+    fetchWithTimeout
+      .mockResolvedValueOnce(response(401, { error: 'Invalid token' }))
+      .mockResolvedValueOnce(response(200, { tokens: { accessToken: 'fresh-token' } }))
+      .mockResolvedValueOnce(response(200, { data: [{ id: 'd1' }] }));
+
+    await expect(coreRequest('/devices?limit=50')).resolves.toEqual({ data: [{ id: 'd1' }] });
+    expect(calls()).toEqual([
+      ['GET', '/api/v1/devices', 'Bearer stale-token'],
+      ['POST', '/api/v1/auth/refresh', 'Bearer stale-token'],
+      ['GET', '/api/v1/devices', 'Bearer fresh-token'],
+    ]);
+    expect(secureValues.get(AUTH_TOKEN_KEY)).toBe('fresh-token');
+  });
+
+  it('single-flights: two requests that 401 together share one refresh', async () => {
+    let resolveRefresh!: (r: Response) => void;
+    fetchWithTimeout.mockImplementation((url: string, init?: RequestInit) => {
+      const path = new URL(url).pathname;
+      const bearer = (init?.headers as Record<string, string>)?.Authorization;
+      if (path.endsWith('/auth/refresh')) {
+        return new Promise<Response>((resolve) => { resolveRefresh = resolve; });
+      }
+      if (bearer === 'Bearer fresh-token') return Promise.resolve(response(200, { data: path }));
+      return Promise.resolve(response(401, { error: 'Invalid token' }));
+    });
+
+    const a = coreRequest('/devices');
+    const b = coreRequest('/alerts');
+    await vi.waitFor(() => expect(calls().filter(([, p]) => p.endsWith('/auth/refresh'))).toHaveLength(1));
+    resolveRefresh(response(200, { tokens: { accessToken: 'fresh-token' } }));
+    await expect(a).resolves.toEqual({ data: '/api/v1/devices' });
+    await expect(b).resolves.toEqual({ data: '/api/v1/alerts' });
+    expect(calls().filter(([, p]) => p.endsWith('/auth/refresh'))).toHaveLength(1);
+  });
+
+  it('surfaces the original 401 when the refresh itself fails, without looping', async () => {
+    fetchWithTimeout
+      .mockResolvedValueOnce(response(401, { error: 'Invalid token' }))
+      .mockResolvedValueOnce(response(401, { error: 'refresh expired' }));
+
+    await expect(coreRequest('/devices')).rejects.toMatchObject({ statusCode: 401, message: 'Invalid token' });
+    expect(calls().map(([, p]) => p)).toEqual(['/api/v1/devices', '/api/v1/auth/refresh']);
+  });
+
+  it('retries at most once: a 401 after a successful refresh is final', async () => {
+    fetchWithTimeout
+      .mockResolvedValueOnce(response(401, { error: 'Invalid token' }))
+      .mockResolvedValueOnce(response(200, { tokens: { accessToken: 'fresh-token' } }))
+      .mockResolvedValueOnce(response(401, { error: 'still no' }));
+
+    await expect(coreRequest('/devices')).rejects.toMatchObject({ statusCode: 401, message: 'still no' });
+    expect(fetchWithTimeout).toHaveBeenCalledTimes(3);
+  });
+
+  it('never refreshes for the auth endpoints themselves or when signed out', async () => {
+    fetchWithTimeout.mockResolvedValue(response(401, { error: 'bad credentials' }));
+    await expect(coreRequest('/auth/login', { method: 'POST', body: '{}' })).rejects.toMatchObject({ statusCode: 401 });
+    expect(fetchWithTimeout).toHaveBeenCalledTimes(1);
+
+    fetchWithTimeout.mockClear();
+    secureValues.delete(AUTH_TOKEN_KEY);
+    await expect(coreRequest('/devices')).rejects.toMatchObject({ statusCode: 401 });
+    expect(fetchWithTimeout).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('refreshAccessToken', () => {
+  it('returns null (not a throw) when refresh fails, so callers surface their own 401', async () => {
+    fetchWithTimeout.mockResolvedValueOnce(response(401, { error: 'refresh expired' }));
+    await expect(refreshAccessToken()).resolves.toBeNull();
+  });
+});

--- a/apps/mobile/src/services/api.ts
+++ b/apps/mobile/src/services/api.ts
@@ -18,6 +18,10 @@ import {
 import { beginSessionInvalidation } from './sessionAuthority';
 import { noteServerDate } from './serverClock';
 import { AUTH_TOKEN_KEY, NATIVE_AUTH_BINDING_KEY } from './authSessionKeys';
+// Function-only cycle (tokenRefresh imports refreshToken from here); both
+// bindings are hoisted declarations used at call time, so evaluation order
+// does not matter.
+import { refreshAccessToken } from './tokenRefresh';
 
 export const FALLBACK_API_BASE_URL =
   process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3001';
@@ -344,6 +348,19 @@ export async function getAuthImageHeaders(): Promise<Record<string, string>> {
 }
 
 // Request helper
+/**
+ * Whether a 401 on this request should be answered with a token refresh. Only
+ * the auth endpoints are excluded: a 401 from /auth/login is bad credentials,
+ * and /auth/refresh must never trigger itself. /auth/me is a normal session
+ * probe (cold-start revalidation) and does refresh.
+ */
+function canRefreshFor(prefix: string, endpoint: string): boolean {
+  if (prefix !== API_CORE_PREFIX) return true;
+  const path = endpoint.split('?')[0];
+  return !path.startsWith('/auth/') || path === '/auth/me';
+}
+
+
 async function requestWithPrefix<T>(
   endpoint: string,
   prefix: string,
@@ -364,12 +381,18 @@ async function requestWithPrefix<T>(
   const nativeAuthIssuer = prefix === API_CORE_PREFIX
     && NATIVE_AUTH_ISSUER_ENDPOINTS.has(endpoint);
   let retriedBindingBootstrap = false;
+  // One refresh-and-retry per request. Set by the 401 branch below; the token
+  // read prefers it so the retry cannot race a slow keychain write and re-send
+  // the token that just expired.
+  let retriedAuth = false;
+  let refreshedToken: string | null = null;
 
   while (true) {
     assertCurrentSession(capturedGeneration);
-    const token = Object.prototype.hasOwnProperty.call(sessionContext, 'bearerToken')
-      ? sessionContext.bearerToken ?? null
-      : await getToken();
+    const token = refreshedToken
+      ?? (Object.prototype.hasOwnProperty.call(sessionContext, 'bearerToken')
+        ? sessionContext.bearerToken ?? null
+        : await getToken());
     const method = (options.method ?? 'GET').toUpperCase();
     const multipart = isFormData(options.body);
     const headers: Record<string, string> = {
@@ -459,6 +482,26 @@ async function requestWithPrefix<T>(
     if (!response.ok) {
       const body = await response.json().catch(() => ({} as Record<string, unknown>));
       assertCurrentSession(capturedGeneration);
+      // Access tokens live JWT_EXPIRES_IN (15 minutes in production) and the
+      // refresh cookie lives days. Until this branch existed only the AI chat
+      // path refreshed, so every other screen hard-401'd a quarter of an hour
+      // after sign-in and the cold-start revalidation then signed the user
+      // out. Refresh once and replay; a second 401 is final. The auth
+      // endpoints themselves are excluded so /auth/refresh can never recurse.
+      if (
+        response.status === 401
+        && !retriedAuth
+        && token
+        && canRefreshFor(prefix, endpoint)
+      ) {
+        retriedAuth = true;
+        const fresh = await refreshAccessToken();
+        assertCurrentSession(capturedGeneration);
+        if (fresh) {
+          refreshedToken = fresh;
+          continue;
+        }
+      }
       const code = typeof body.code === 'string' ? body.code : undefined;
       if (code === DEVICE_BLOCKED_CODE) {
         const reason = typeof body.reason === 'string' ? body.reason : null;

--- a/apps/mobile/src/services/tokenRefresh.ts
+++ b/apps/mobile/src/services/tokenRefresh.ts
@@ -1,0 +1,70 @@
+import * as Sentry from '@sentry/react-native';
+import type { ApiError } from './api';
+import { refreshToken } from './api';
+import { storeToken } from './auth';
+import { commitIfCurrent, currentSessionGeneration } from './sessionGeneration';
+
+/**
+ * The one place the mobile app refreshes its access token.
+ *
+ * Lives in its own module rather than in api.ts so that api.ts (the request
+ * core, which calls this on a 401) and aiChat.ts (which reopens its SSE stream
+ * on a 401) share exactly one in-flight refresh, and so tests of either caller
+ * can mock `./api`'s low-level `refreshToken` while exercising this logic for
+ * real.
+ */
+// Single-flight guard so N concurrent 401s trigger one /auth/refresh, not N.
+// Cleared once the refresh settles; callers that grabbed the promise still
+// receive its result. /auth/refresh rotates the refresh cookie and replaying a
+// rotated token revokes the whole token family, which is why this lives here,
+// shared by every caller, rather than per service.
+let refreshInFlight: Promise<string | null> | null = null;
+
+/**
+ * Refresh the access token and persist it so every reader of the token key
+ * picks it up. Returns the new token, or null when refresh failed (expired
+ * refresh cookie, offline, /auth/refresh outage) or the session was superseded
+ * meanwhile; callers then surface their original 401. Never throws.
+ */
+export async function refreshAccessToken(): Promise<string | null> {
+  if (!refreshInFlight) {
+    refreshInFlight = (async () => {
+      const generation = currentSessionGeneration();
+      try {
+        const { token } = await refreshToken();
+        try {
+          const committed = await commitIfCurrent(generation, async () => {
+            await storeToken(token);
+            return token;
+          });
+          if (committed === undefined) return null;
+        } catch (e) {
+          // Persisting failed (locked keychain, etc.). The in-memory token is
+          // still valid for the retry, so don't turn a usable refresh into a
+          // hard failure, but make the cause observable: a phone that cannot
+          // persist tokens refreshes on every request.
+          Sentry.captureException(e, {
+            tags: { area: 'token-refresh' },
+            extra: { stage: 'persist' },
+          });
+          if (generation !== currentSessionGeneration()) return null;
+        }
+        if (generation !== currentSessionGeneration()) return null;
+        return token;
+      } catch (e) {
+        Sentry.captureMessage('token refresh failed', {
+          level: 'warning',
+          tags: { area: 'token-refresh' },
+          extra: {
+            statusCode: (e as ApiError)?.statusCode,
+            message: (e as ApiError)?.message ?? String(e),
+          },
+        });
+        return null;
+      } finally {
+        refreshInFlight = null;
+      }
+    })();
+  }
+  return refreshInFlight;
+}


### PR DESCRIPTION
## Summary

Found on the iPhone simulator against the App Review tenant on production: about fifteen minutes after sign-in every tab started failing ("Could not load devices.", "Failed to load systems data."), and relaunching the app landed on Sign in.

The US API log shows why. `JWT_EXPIRES_IN` is `15m`, the refresh cookie lives 7 days, and only the AI-chat path ever called `/auth/refresh`. Every other request surfaced the 401 (`/mobile/*`, `/time-entries/*`), and the cold-start revalidation (`/auth/me` 401) then signed the user out. A reviewer who spends a quarter of an hour in the app hits this.

## Change

- `services/tokenRefresh.ts`: the single-flight `refreshAccessToken` moved out of `aiChat.ts`, behaviour unchanged (persists via `storeToken`, generation-guarded, never throws). One module so the request core and the SSE stream share a single in-flight refresh; `/auth/refresh` rotates the cookie, so two concurrent refreshes would revoke the token family.
- `services/api.ts`: on a 401 with a bearer present, refresh once and replay the request with the new token; a second 401 is final. Auth endpoints are excluded (a 401 from `/auth/login` is bad credentials; `/auth/refresh` must never trigger itself). `/auth/me` does refresh, so the cold-start probe recovers instead of logging out.
- `aiChat.ts` imports the shared helper. Its tests are unchanged and pass against the real helper through their existing `./api` mock.

## Verification

- Red first: `api.refresh.test.ts` (refresh and retry, single-flight across concurrent 401s, failed refresh surfaces the original 401, at most one retry, auth endpoints and signed-out requests never refresh) failed on the request core before the change, then passed.
- `tsc --noEmit` clean; `vitest run` 93 files, 1212 tests.
- Live check pending: sign in on the simulator, wait past the 15-minute TTL, confirm `/auth/refresh` 200 followed by 200s on `/mobile/*` in the API log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpzNXnfbR6mdMqnMSkECPK
