### PR TITLE
fix(mobile): break the api.ts and tokenRefresh.ts require cycle

### DIFF
--- a/apps/mobile/src/services/aiChat.test.ts
+++ b/apps/mobile/src/services/aiChat.test.ts
@@ -26,9 +26,14 @@ vi.mock('./fetchWithTimeout', () => ({
 
 // api.ts pulls in Sentry/installation-id modules that don't exist in the node
 // test environment — mock the whole module, we only need refreshToken.
-vi.mock('./api', () => ({
-  refreshToken: vi.fn(),
-}));
+vi.mock('./api', async () => {
+  // Mock the low-level POST, but build the single-flight refresher from the
+  // real factory around it, so these cases exercise the shared refresh logic
+  // (persist, generation guard, null on failure) rather than a stand-in.
+  const { createTokenRefresher } = await import('./tokenRefresh');
+  const refreshToken = vi.fn();
+  return { refreshToken, refreshAccessToken: createTokenRefresher(refreshToken) };
+});
 
 vi.mock('./auth', () => ({
   storeToken: vi.fn().mockResolvedValue(undefined),

--- a/apps/mobile/src/services/aiChat.ts
+++ b/apps/mobile/src/services/aiChat.ts
@@ -4,7 +4,7 @@ import * as Sentry from '@sentry/react-native';
 import { getServerUrl } from './serverConfig';
 import { fetchWithTimeout } from './fetchWithTimeout';
 import type { ApiError } from './api';
-import { refreshAccessToken } from './tokenRefresh';
+import { refreshAccessToken } from './api';
 
 const FALLBACK_API_BASE_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3001';
 const API_CORE_PREFIX = '/api/v1';

--- a/apps/mobile/src/services/api.refresh.test.ts
+++ b/apps/mobile/src/services/api.refresh.test.ts
@@ -35,8 +35,7 @@ vi.mock('./csrfToken', () => ({
   readCsrfCookie: vi.fn(() => ({ kind: 'absent' })),
 }));
 
-import { coreRequest } from './api';
-import { refreshAccessToken } from './tokenRefresh';
+import { coreRequest, refreshAccessToken } from './api';
 import { AUTH_TOKEN_KEY } from './authSessionKeys';
 
 function response(status: number, body: unknown = {}): Response {

--- a/apps/mobile/src/services/api.ts
+++ b/apps/mobile/src/services/api.ts
@@ -18,10 +18,7 @@ import {
 import { beginSessionInvalidation } from './sessionAuthority';
 import { noteServerDate } from './serverClock';
 import { AUTH_TOKEN_KEY, NATIVE_AUTH_BINDING_KEY } from './authSessionKeys';
-// Function-only cycle (tokenRefresh imports refreshToken from here); both
-// bindings are hoisted declarations used at call time, so evaluation order
-// does not matter.
-import { refreshAccessToken } from './tokenRefresh';
+import { createTokenRefresher } from './tokenRefresh';
 
 export const FALLBACK_API_BASE_URL =
   process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3001';
@@ -753,6 +750,13 @@ export async function refreshToken(): Promise<{ token: string }> {
   }
   return { token };
 }
+
+/**
+ * The app's single token refresher: the request core calls it on a 401 and
+ * aiChat reopens its stream through it, so concurrent 401s share one
+ * /auth/refresh. See tokenRefresh.ts for why it is built here.
+ */
+export const refreshAccessToken = createTokenRefresher(refreshToken);
 
 export async function changePassword(currentPassword: string, newPassword: string): Promise<void> {
   await requestWithPrefix('/auth/change-password', API_CORE_PREFIX, {

--- a/apps/mobile/src/services/tokenRefresh.ts
+++ b/apps/mobile/src/services/tokenRefresh.ts
@@ -1,37 +1,40 @@
 import * as Sentry from '@sentry/react-native';
-import type { ApiError } from './api';
-import { refreshToken } from './api';
 import { storeToken } from './auth';
 import { commitIfCurrent, currentSessionGeneration } from './sessionGeneration';
 
 /**
  * The one place the mobile app refreshes its access token.
  *
- * Lives in its own module rather than in api.ts so that api.ts (the request
- * core, which calls this on a 401) and aiChat.ts (which reopens its SSE stream
- * on a 401) share exactly one in-flight refresh, and so tests of either caller
- * can mock `./api`'s low-level `refreshToken` while exercising this logic for
- * real.
+ * A factory rather than a module-level function so this file does not import
+ * api.ts (which imports it): api.ts builds the one shared instance from its
+ * own `refreshToken`, and the request core and aiChat's SSE stream both use
+ * that instance, so there is exactly one in-flight refresh app-wide. Tests of
+ * either caller can hand the factory a mocked `refresh` and still exercise
+ * this logic for real.
  */
-// Single-flight guard so N concurrent 401s trigger one /auth/refresh, not N.
-// Cleared once the refresh settles; callers that grabbed the promise still
-// receive its result. /auth/refresh rotates the refresh cookie and replaying a
-// rotated token revokes the whole token family, which is why this lives here,
-// shared by every caller, rather than per service.
-let refreshInFlight: Promise<string | null> | null = null;
+type RefreshFailure = { statusCode?: number; message?: string } | null | undefined;
 
-/**
- * Refresh the access token and persist it so every reader of the token key
- * picks it up. Returns the new token, or null when refresh failed (expired
- * refresh cookie, offline, /auth/refresh outage) or the session was superseded
- * meanwhile; callers then surface their original 401. Never throws.
- */
-export async function refreshAccessToken(): Promise<string | null> {
+export function createTokenRefresher(
+  refresh: () => Promise<{ token: string }>
+): () => Promise<string | null> {
+  // Single-flight guard so N concurrent 401s trigger one /auth/refresh, not N.
+  // Cleared once the refresh settles; callers that grabbed the promise still
+  // receive its result. /auth/refresh rotates the refresh cookie and replaying
+  // a rotated token revokes the whole token family.
+  let refreshInFlight: Promise<string | null> | null = null;
+
+  /**
+   * Refresh the access token and persist it so every reader of the token key
+   * picks it up. Returns the new token, or null when refresh failed (expired
+   * refresh cookie, offline, /auth/refresh outage) or the session was
+   * superseded meanwhile; callers then surface their original 401. Never throws.
+   */
+  return async function refreshAccessToken(): Promise<string | null> {
   if (!refreshInFlight) {
     refreshInFlight = (async () => {
       const generation = currentSessionGeneration();
       try {
-        const { token } = await refreshToken();
+        const { token } = await refresh();
         try {
           const committed = await commitIfCurrent(generation, async () => {
             await storeToken(token);
@@ -56,8 +59,8 @@ export async function refreshAccessToken(): Promise<string | null> {
           level: 'warning',
           tags: { area: 'token-refresh' },
           extra: {
-            statusCode: (e as ApiError)?.statusCode,
-            message: (e as ApiError)?.message ?? String(e),
+            statusCode: (e as RefreshFailure)?.statusCode,
+            message: (e as RefreshFailure)?.message ?? String(e),
           },
         });
         return null;
@@ -67,4 +70,5 @@ export async function refreshAccessToken(): Promise<string | null> {
     })();
   }
   return refreshInFlight;
+  };
 }


### PR DESCRIPTION
Follow-up to #4568. Metro warned `Require cycle: api.ts -> tokenRefresh.ts -> api.ts` on every dev launch. It worked (hoisted functions), but the shape was fragile.

`tokenRefresh.ts` now exports `createTokenRefresher(refresh)` and imports nothing from `api.ts`; `api.ts` builds the single shared instance from its own `refreshToken` and exports it as `refreshAccessToken`. `aiChat.ts` imports that instance, so there is still exactly one in-flight refresh app-wide. The aiChat tests mock the low-level `refreshToken` but compose the real factory around it.

Verification: `tsc --noEmit` clean; `vitest run` full mobile suite green; the Metro warning no longer appears on relaunch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpzNXnfbR6mdMqnMSkECPK