### PR TITLE
ci: guard every playwright install against the runner apt 403 (composite action)

### DIFF
--- a/.github/actions/install-chromium/action.yml
+++ b/.github/actions/install-chromium/action.yml
@@ -1,0 +1,30 @@
+name: Install Playwright Chromium
+description: >-
+  Runs `playwright install --with-deps chromium` with a guard against the
+  Azure-hosted runner's packages.microsoft.com apt source, which intermittently
+  returns 403 and takes the whole install down (exit 100). That repo holds
+  nothing Playwright needs, so it is removed first; if apt still fails, the
+  browser-only install runs as a loud fallback (the ubuntu-24.04 image already
+  ships Chromium's shared libraries).
+inputs:
+  run-prefix:
+    description: Command prefix that resolves the playwright binary, e.g. `npx`, `pnpm exec`, `pnpm --filter @breeze/web exec`.
+    required: false
+    default: npx
+  working-directory:
+    description: Directory to run in.
+    required: false
+    default: .
+runs:
+  using: composite
+  steps:
+    - name: Install Chromium
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        sudo rm -f /etc/apt/sources.list.d/microsoft*.list \
+                   /etc/apt/sources.list.d/microsoft*.sources || true
+        if ! ${{ inputs.run-prefix }} playwright install --with-deps chromium; then
+          echo "::warning::playwright install --with-deps failed (apt); retrying without system deps"
+          ${{ inputs.run-prefix }} playwright install chromium
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1004,7 +1004,9 @@ jobs:
         run: pnpm build --filter=@breeze/web
 
       - name: Install Chromium for CSP guard
-        run: pnpm --filter @breeze/web exec playwright install --with-deps chromium
+        uses: ./.github/actions/install-chromium
+        with:
+          run-prefix: pnpm --filter @breeze/web exec
 
       - name: CSP drift guard (real-browser)
         run: pnpm --filter @breeze/web run csp:guard
@@ -2448,8 +2450,9 @@ jobs:
         run: npm ci
 
       - name: Install Chromium
-        working-directory: e2e-tests
-        run: npx playwright install --with-deps chromium
+        uses: ./.github/actions/install-chromium
+        with:
+          working-directory: e2e-tests
 
       - name: Migrate and seed auth contract database
         run: |
@@ -2589,21 +2592,12 @@ jobs:
         working-directory: e2e-tests
         run: pnpm install --ignore-workspace
 
-      # `--with-deps` shells out to `apt-get update`, which intermittently 403s
-      # on packages.microsoft.com from Azure-hosted runners and takes the whole
-      # browser install down with it (exit 100). That repo holds nothing
-      # Playwright needs, so drop it first; if apt still fails, fall back to the
-      # browser-only install — the ubuntu-24.04 runner image already ships
-      # Chromium's shared libraries — and say so loudly rather than silently.
+      # apt 403 guard lives in the composite action (see its description).
       - name: Install Chromium
-        working-directory: e2e-tests
-        run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft*.list \
-                     /etc/apt/sources.list.d/microsoft*.sources || true
-          if ! pnpm exec playwright install --with-deps chromium; then
-            echo "::warning::playwright install --with-deps failed (apt); retrying without system deps"
-            pnpm exec playwright install chromium
-          fi
+        uses: ./.github/actions/install-chromium
+        with:
+          run-prefix: pnpm exec
+          working-directory: e2e-tests
 
       # `pnpm wt-stack up` without a workspace install: the CLI imports nothing
       # but node builtins and its own sibling modules, so e2e-tests' tsx runs it


### PR DESCRIPTION
## What

Moves the \`playwright install --with-deps\` apt-403 guard added in #4563 into a composite action, \`.github/actions/install-chromium\`, and uses it from all three Chromium installs in \`ci.yml\`:

- web CSP drift guard (was unguarded)
- auth-browser-transition (was unguarded)
- portal-dev-e2e (guard previously inline)

## Why

Verified: run 33663812719 failed in 22s because \`apt-get update\` inside \`--with-deps\` got \`403 Forbidden\` from \`packages.microsoft.com\` on the Azure-hosted runner, and Playwright exited 100. That apt source holds nothing Playwright needs. The two older jobs have not hit it on main in the last 30 runs, so it is intermittent, but the exposure is identical.

The guard removes the Microsoft apt source, tries \`--with-deps\`, and on failure emits a workflow warning and falls back to the browser-only install (the ubuntu-24.04 image already ships Chromium's shared libraries).

## Verification

- actionlint on \`ci.yml\`: only the pre-existing SC2155 warning on an unrelated step.
- Job names and gating unchanged, so \`ciSuccessGatingContract.test.ts\` is unaffected.
- Real test is this PR's own CI: all three jobs must install Chromium through the action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)