### PR TITLE
feat(trust): command dispatch chokepoints (W03, #4549)

### DIFF
--- a/apps/api/src/jobs/pamActuationWorker.test.ts
+++ b/apps/api/src/jobs/pamActuationWorker.test.ts
@@ -5,6 +5,9 @@ import canonical from '../../../../packages/shared/src/fixtures/pam-lifetime-v2-
 const { executeMock } = vi.hoisted(() => ({
   executeMock: vi.fn(),
 }));
+const { assertDeviceExecuteAllowedMock } = vi.hoisted(() => ({
+  assertDeviceExecuteAllowedMock: vi.fn(async () => undefined),
+}));
 
 vi.mock('bullmq', () => ({ Queue: class {}, Worker: class {}, Job: class {} }));
 vi.mock('../db', () => ({
@@ -13,8 +16,13 @@ vi.mock('../db', () => ({
 }));
 vi.mock('../services/redis', () => ({ getBullMQConnection: () => ({}) }));
 vi.mock('../services/sentry', () => ({ captureException: vi.fn() }));
+vi.mock('../services/partnerTrust.commands', async () => ({
+  ...(await vi.importActual<typeof import('../services/partnerTrust.commands')>('../services/partnerTrust.commands')),
+  assertDeviceExecuteAllowed: assertDeviceExecuteAllowedMock,
+}));
 
 import { processPamActuationEvent } from './pamActuationWorker';
+import { TrustDeniedError } from '../services/partnerTrust.commands';
 
 const current = {
   id: '30000000-0000-4000-8000-000000000001',
@@ -66,6 +74,7 @@ describe('processPamActuationEvent', () => {
       .mockResolvedValueOnce({ rows: [] });
     await expect(processPamActuationEvent({ actuationId: current.id, generation: 4 }))
       .resolves.toBe('dispatched');
+    expect(assertDeviceExecuteAllowedMock).toHaveBeenCalledWith(current.device_id, 'pam_apply_v2', null);
     expect(commandPayloadAt(1)).toEqual(canonical.apply);
 
     executeMock.mockReset().mockResolvedValueOnce({
@@ -103,6 +112,23 @@ describe('processPamActuationEvent', () => {
       .resolves.toBe('blocked');
     const sqlText = executeMock.mock.calls.map(([query]) => JSON.stringify(query)).join('\n');
     expect(sqlText).toContain('identity_mismatch');
+    expect(sqlText).not.toContain('INSERT INTO device_commands');
+  });
+
+  it('marks a trust-denied actuation failed without inserting a command', async () => {
+    executeMock
+      .mockResolvedValueOnce({ rows: [current] })
+      .mockResolvedValueOnce({ rows: [] });
+    assertDeviceExecuteAllowedMock.mockRejectedValueOnce(
+      new TrustDeniedError('TRUST_RESTRICTED', 'Partner access is restricted.', current.device_id, 'pam_apply_v2'),
+    );
+
+    await expect(processPamActuationEvent({ actuationId: current.id, generation: 4 }))
+      .resolves.toBe('blocked');
+
+    expect(executeMock).toHaveBeenCalledTimes(2);
+    const sqlText = executeMock.mock.calls.map(([query]) => JSON.stringify(query)).join('\n');
+    expect(sqlText).toContain('TRUST_RESTRICTED');
     expect(sqlText).not.toContain('INSERT INTO device_commands');
   });
 

--- a/apps/api/src/jobs/pamActuationWorker.ts
+++ b/apps/api/src/jobs/pamActuationWorker.ts
@@ -5,6 +5,7 @@ import { db, withSystemDbAccessContext } from '../db';
 import { getBullMQConnection } from '../services/redis';
 import { captureException } from '../services/sentry';
 import { buildPamActuationCommand } from './pamActuationCommandPayload';
+import { assertDeviceExecuteAllowed, TrustDeniedError } from '../services/partnerTrust.commands';
 
 const PAM_QUEUE_NAME = 'pam-actuation';
 
@@ -97,6 +98,18 @@ export async function processPamActuationEvent(input: PamActuationJobData): Prom
       await tx.execute(sql`
         UPDATE pam_actuations SET observed_state = 'failed',
           failure_code = ${built.failureCode}, updated_at = now()
+        WHERE id = ${actuation.id} AND generation = ${actuation.generation}
+      `);
+      return 'blocked';
+    }
+
+    try {
+      await assertDeviceExecuteAllowed(actuation.device_id, built.commandType, null);
+    } catch (error) {
+      if (!(error instanceof TrustDeniedError)) throw error;
+      await tx.execute(sql`
+        UPDATE pam_actuations SET observed_state = 'failed',
+          failure_code = ${error.code}, updated_at = now()
         WHERE id = ${actuation.id} AND generation = ${actuation.generation}
       `);
       return 'blocked';

--- a/apps/api/src/routes/agentWs.test.ts
+++ b/apps/api/src/routes/agentWs.test.ts
@@ -204,6 +204,17 @@ vi.mock('../services/redis', () => ({
   getRedis: vi.fn(() => null)
 }));
 
+vi.mock('../config/partnerTrustMode', () => ({
+  partnerTrustMode: vi.fn(() => 'off'),
+}));
+
+vi.mock('../services/partnerTrust', () => ({
+  evaluateCapability: vi.fn(async () => ({ allow: true })),
+  isLifecycleCommand: vi.fn((type: string) => type === 'self_uninstall'),
+  loadTrustState: vi.fn(async () => ({ trustState: 'trusted', probationEnrollments: 0 })),
+  partnerIdForDevice: vi.fn(async () => 'p1'),
+}));
+
 // Wave 3.5b (#4084): presence lifecycle wiring. Defaults are chosen so every
 // OTHER describe block in this file — which never asserts on presence — sees
 // harmless, non-throwing behaviour: refresh "succeeds" so the self-heal branch
@@ -330,6 +341,8 @@ import {
   disconnectAgent,
   isAgentConnected,
   sendCommandToAgent,
+  handleTrustChanged,
+  registerConnection,
   processOrphanedCommandResult,
   __resetCrossTenantDropsForTest,
   AGENT_WS_CAPABILITIES,
@@ -337,6 +350,8 @@ import {
 import { sendCommandToAgentAwaitResult } from '../services/agentCommandAwait';
 import { applySoftwareInstallResult } from '../services/softwareDeploymentResult';
 import { isRedisAvailable } from '../services/redis';
+import { partnerTrustMode } from '../config/partnerTrustMode';
+import { evaluateCapability } from '../services/partnerTrust';
 import {
   clearAgentPresence,
   clearAgentPresenceUnfenced,
@@ -418,6 +433,45 @@ async function connectedAgent(
   await connectAgentSocket(handlers, ws);
   return { handlers, ws };
 }
+
+describe('partner-trust WebSocket fast path', () => {
+  beforeEach(() => {
+    vi.mocked(partnerTrustMode).mockReturnValue('enforce');
+    vi.mocked(evaluateCapability).mockClear();
+  });
+
+  it('fast path refuses a gated command for a probation connection and returns false', () => {
+    const fakeWs = wsMock();
+    registerConnection('trust-agent-1', fakeWs, { partnerId: 'p1', trustState: 'probation' });
+
+    expect(sendCommandToAgent('trust-agent-1', { id: 'c1', type: 'script', payload: {} })).toBe(false);
+    expect(fakeWs.send).not.toHaveBeenCalled();
+  });
+
+  it('fast path sends lifecycle commands regardless of trust', () => {
+    const fakeWs = wsMock();
+    registerConnection('trust-agent-2', fakeWs, { partnerId: 'p1', trustState: 'probation' });
+
+    expect(sendCommandToAgent('trust-agent-2', {
+      id: 'c2',
+      type: 'self_uninstall',
+      payload: {},
+    })).toBe(true);
+    expect(fakeWs.send).toHaveBeenCalledOnce();
+  });
+
+  it('a partner-trust:changed message updates every cached connection for that partner', async () => {
+    const firstWs = wsMock();
+    const secondWs = wsMock();
+    registerConnection('trust-agent-3', firstWs, { partnerId: 'p1', trustState: 'probation' });
+    registerConnection('trust-agent-4', secondWs, { partnerId: 'p1', trustState: 'probation' });
+
+    await handleTrustChanged({ partnerId: 'p1', trustState: 'trusted' });
+
+    expect(sendCommandToAgent('trust-agent-3', { id: 'c3', type: 'script', payload: {} })).toBe(true);
+    expect(sendCommandToAgent('trust-agent-4', { id: 'c4', type: 'script', payload: {} })).toBe(true);
+  });
+});
 
 describe('validateAgentToken — tenant-status gate', () => {
   const TOKEN = 'brz_ws_test_token';

--- a/apps/api/src/routes/agentWs.test.ts
+++ b/apps/api/src/routes/agentWs.test.ts
@@ -351,7 +351,11 @@ import { sendCommandToAgentAwaitResult } from '../services/agentCommandAwait';
 import { applySoftwareInstallResult } from '../services/softwareDeploymentResult';
 import { isRedisAvailable } from '../services/redis';
 import { partnerTrustMode } from '../config/partnerTrustMode';
-import { evaluateCapability } from '../services/partnerTrust';
+import {
+  evaluateCapability,
+  loadTrustState,
+  partnerIdForDevice,
+} from '../services/partnerTrust';
 import {
   clearAgentPresence,
   clearAgentPresenceUnfenced,
@@ -438,6 +442,91 @@ describe('partner-trust WebSocket fast path', () => {
   beforeEach(() => {
     vi.mocked(partnerTrustMode).mockReturnValue('enforce');
     vi.mocked(evaluateCapability).mockClear();
+    vi.mocked(loadTrustState).mockClear();
+    vi.mocked(partnerIdForDevice).mockClear();
+    vi.mocked(loadTrustState).mockResolvedValue({ trustState: 'trusted', probationEnrollments: 0 });
+    vi.mocked(partnerIdForDevice).mockResolvedValue('p1');
+  });
+
+  it('mode off skips trust resolution and caches a trusted connection', async () => {
+    vi.mocked(partnerTrustMode).mockReturnValue('off');
+    const { ws } = await connectedAgent(
+      'trust-agent-off',
+      { deviceId: 'device-trust-off', orgId: 'org-trust-off' },
+    );
+
+    expect(partnerIdForDevice).not.toHaveBeenCalled();
+    expect(loadTrustState).not.toHaveBeenCalled();
+    expect(ws.close).not.toHaveBeenCalled();
+
+    vi.mocked(partnerTrustMode).mockReturnValue('enforce');
+    expect(sendCommandToAgent('trust-agent-off', {
+      id: 'c-off',
+      type: 'script',
+      payload: {},
+    })).toBe(true);
+  });
+
+  it('keeps the connection open and caches restricted when the partner is unresolved', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.mocked(partnerIdForDevice).mockResolvedValueOnce(null);
+
+    const { ws } = await connectedAgent(
+      'trust-agent-null-partner',
+      { deviceId: 'device-null-partner', orgId: 'org-null-partner' },
+    );
+
+    expect(ws.close).not.toHaveBeenCalled();
+    expect(loadTrustState).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('device-null-partner'));
+    expect(sendCommandToAgent('trust-agent-null-partner', {
+      id: 'c-null-partner',
+      type: 'script',
+      payload: {},
+    })).toBe(false);
+    warn.mockRestore();
+  });
+
+  it('keeps the connection open and caches restricted when the trust row is missing', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.mocked(loadTrustState).mockResolvedValueOnce(null);
+
+    const { ws } = await connectedAgent(
+      'trust-agent-null-row',
+      { deviceId: 'device-null-row', orgId: 'org-null-row' },
+    );
+
+    expect(ws.close).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('device-null-row'));
+    expect(sendCommandToAgent('trust-agent-null-row', {
+      id: 'c-null-row',
+      type: 'script',
+      payload: {},
+    })).toBe(false);
+    warn.mockRestore();
+  });
+
+  it('keeps the connection open and caches restricted when partner resolution throws', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.mocked(partnerIdForDevice).mockRejectedValueOnce(new Error('database unavailable'));
+
+    const { ws } = await connectedAgent(
+      'trust-agent-throw',
+      { deviceId: 'device-trust-throw', orgId: 'org-trust-throw' },
+    );
+
+    expect(ws.close).not.toHaveBeenCalled();
+    expect(loadTrustState).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('device-trust-throw'));
+    expect(sendCommandToAgent('trust-agent-throw', {
+      id: 'c-throw',
+      type: 'script',
+      payload: {},
+    })).toBe(false);
+    warn.mockRestore();
   });
 
   it('fast path refuses a gated command for a probation connection and returns false', () => {

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -198,7 +198,7 @@ const TERMINAL_TRANSITION_FAMILIES_ON_VALIDATION_FAILURE = new Set<CriticalResul
 
 interface ActiveAgentConnection {
   ws: WSContext;
-  partnerId: string;
+  partnerId: string | null;
   trustState: PartnerTrustState;
 }
 
@@ -1983,7 +1983,10 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
 
   return {
     onOpen: async (_event: unknown, ws: WSContext) => {
-      await initializePartnerTrustSubscription();
+      const trustMode = partnerTrustMode();
+      if (trustMode !== 'off') {
+        await initializePartnerTrustSubscription();
+      }
       // Finding #4: enforce the one-socket-per-agent invariant. A second socket
       // for the same agentId would otherwise overwrite the map entry WITHOUT
       // closing the previous socket, leaving an orphaned-but-authorized socket
@@ -2007,20 +2010,32 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
         agentPingStates.delete(agentId);
       }
 
-      // Resolve and cache the partner trust snapshot once for this connection.
-      // Missing partner/trust rows retain evaluateCapability's existing allow behavior.
-      const partnerId = await partnerIdForDevice(agentDb.deviceId);
-      if (!partnerId) {
-        ws.close(1011, 'Unable to resolve partner trust state');
-        return;
+      // Trust mode off preserves the pre-gate connection path without trust DB reads.
+      // Shadow/enforce keep the socket open but fail closed in the cached snapshot
+      // whenever partner or trust resolution is missing or unavailable.
+      let partnerId: string | null = null;
+      let trustState: PartnerTrustState = 'trusted';
+      if (trustMode !== 'off') {
+        try {
+          partnerId = await partnerIdForDevice(agentDb.deviceId);
+          const trust = partnerId ? await loadTrustState(partnerId) : null;
+          if (!trust) {
+            trustState = 'restricted';
+            console.warn(`[AgentWs] Partner trust unresolved for device ${agentDb.deviceId}; restricting connection`);
+          } else {
+            trustState = trust.trustState;
+          }
+        } catch {
+          trustState = 'restricted';
+          console.warn(`[AgentWs] Partner trust resolution failed for device ${agentDb.deviceId}; restricting connection`);
+        }
       }
-      const trust = await loadTrustState(partnerId);
 
       // Store connection and stamp this socket's delivery epoch.
       activeConnections.set(agentId, {
         ws,
         partnerId,
-        trustState: trust?.trustState ?? 'trusted',
+        trustState,
       });
       socketEpoch = installAgentSocketEpoch(agentId);
       void setAgentPresence(agentId, { instanceId: INSTANCE_ID, connectionToken });
@@ -3237,11 +3252,13 @@ export function sendCommandToAgent(agentId: string, command: AgentCommand): bool
   const mode = partnerTrustMode();
   if (mode !== 'off' && conn.trustState !== 'trusted' && !isLifecycleCommand(command.type)) {
     if (mode === 'enforce') return false;
-    void evaluateCapability('device_execute', {
-      partnerId: conn.partnerId,
-      commandType: command.type,
-      detail: { via: 'ws_fast_path' },
-    });
+    if (conn.partnerId) {
+      void evaluateCapability('device_execute', {
+        partnerId: conn.partnerId,
+        commandType: command.type,
+        detail: { via: 'ws_fast_path' },
+      });
+    }
   }
 
   try {

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import type { WSContext } from 'hono/ws';
+import type Redis from 'ioredis';
 import { z } from 'zod';
 import { eq, and, notInArray, sql } from 'drizzle-orm';
 import { createHash, randomUUID } from 'crypto';
@@ -18,7 +19,7 @@ import { enqueueDiscoveryResults, type DiscoveredHostResult, type DeviceAdjacenc
 import { enqueueBackupResults } from '../jobs/backupWorker';
 import { enqueueSnmpPollResults, type SnmpMetricResult } from '../jobs/snmpWorker';
 import { enqueueMonitorCheckResult, recordMonitorCheckResult, type MonitorCheckResult } from '../jobs/monitorWorker';
-import { isRedisAvailable } from '../services/redis';
+import { getRedis, isRedisAvailable } from '../services/redis';
 import { isIP } from 'node:net';
 import { processDeviceIPHistoryUpdate } from '../services/deviceIpHistory';
 import { processBackupVerificationResult } from './backup/verificationService';
@@ -77,6 +78,14 @@ import { redactResultAgainstCommandSecrets } from '../services/commandSecretReda
 import { INSTANCE_ID } from '../services/instanceIdentity';
 import { clearAgentPresence, clearAgentPresenceUnfenced, setAgentPresence, refreshAgentPresence } from '../services/agentPresence';
 import { breezeRole } from '../config/env';
+import { partnerTrustMode } from '../config/partnerTrustMode';
+import type { PartnerTrustState } from '../db/schema/orgs';
+import {
+  evaluateCapability,
+  isLifecycleCommand,
+  loadTrustState,
+  partnerIdForDevice,
+} from '../services/partnerTrust';
 /** Capabilities advertised to agents in the post-connect `connected` message. */
 export const AGENT_WS_CAPABILITIES = ['terminal_output_base64', 'backup_run_async'] as const;
 
@@ -187,9 +196,72 @@ const TERMINAL_TRANSITION_FAMILIES_ON_VALIDATION_FAILURE = new Set<CriticalResul
   'restore',
 ]);
 
-// Store active WebSocket connections by agentId
-// Map<agentId, WSContext>
-const activeConnections = new Map<string, WSContext>();
+interface ActiveAgentConnection {
+  ws: WSContext;
+  partnerId: string;
+  trustState: PartnerTrustState;
+}
+
+// Store active WebSocket connections and their connect-time trust snapshot by agentId.
+const activeConnections = new Map<string, ActiveAgentConnection>();
+
+const PARTNER_TRUST_CHANGED_CHANNEL = 'partner-trust:changed';
+let partnerTrustSubscriber: Redis | null = null;
+let partnerTrustSubscriptionPromise: Promise<void> | null = null;
+
+export async function handleTrustChanged(msg: unknown): Promise<void> {
+  let parsed: unknown = msg;
+  if (typeof msg === 'string') {
+    try {
+      parsed = JSON.parse(msg);
+    } catch {
+      return;
+    }
+  }
+  if (!parsed || typeof parsed !== 'object') return;
+
+  const { partnerId, trustState } = parsed as {
+    partnerId?: unknown;
+    trustState?: unknown;
+  };
+  if (
+    typeof partnerId !== 'string'
+    || !['probation', 'trusted', 'restricted'].includes(String(trustState))
+  ) {
+    return;
+  }
+
+  for (const connection of activeConnections.values()) {
+    if (connection.partnerId === partnerId) {
+      connection.trustState = trustState as PartnerTrustState;
+    }
+  }
+}
+
+function initializePartnerTrustSubscription(): Promise<void> {
+  if (partnerTrustSubscriptionPromise) return partnerTrustSubscriptionPromise;
+  const redis = getRedis();
+  if (!redis || typeof redis.duplicate !== 'function') return Promise.resolve();
+
+  const subscriber = redis.duplicate({ connectionName: 'breeze:agent-ws:partner-trust' });
+  partnerTrustSubscriber = subscriber;
+  subscriber.on('message', (channel: string, message: string) => {
+    if (channel === PARTNER_TRUST_CHANGED_CHANNEL) {
+      void handleTrustChanged(message);
+    }
+  });
+  subscriber.on('error', (error: Error) => {
+    console.error('[AgentWs] Partner-trust Redis subscriber error:', error.message);
+  });
+  partnerTrustSubscriptionPromise = subscriber.subscribe(PARTNER_TRUST_CHANGED_CHANNEL)
+    .then(() => undefined)
+    .catch((error: unknown) => {
+      console.error('[AgentWs] Failed to subscribe to partner-trust changes:', error);
+      partnerTrustSubscriber = null;
+      partnerTrustSubscriptionPromise = null;
+    });
+  return partnerTrustSubscriptionPromise;
+}
 
 // Delivery epoch, monotonic per agent. Bumped every time a socket is installed
 // in `activeConnections`, so every command is dispatched on a known epoch.
@@ -216,7 +288,7 @@ function installAgentSocketEpoch(agentId: string): number {
  * identity rules out a socket that was never installed at all.
  */
 function ownsCurrentAgentSocket(agentId: string, ws: WSContext, epoch: number): boolean {
-  return agentSocketEpochs.get(agentId) === epoch && activeConnections.get(agentId) === ws;
+  return agentSocketEpochs.get(agentId) === epoch && activeConnections.get(agentId)?.ws === ws;
 }
 
 /**
@@ -1911,6 +1983,7 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
 
   return {
     onOpen: async (_event: unknown, ws: WSContext) => {
+      await initializePartnerTrustSubscription();
       // Finding #4: enforce the one-socket-per-agent invariant. A second socket
       // for the same agentId would otherwise overwrite the map entry WITHOUT
       // closing the previous socket, leaving an orphaned-but-authorized socket
@@ -1918,7 +1991,7 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
       // revocation/disconnect (which only act on the mapped socket) miss it.
       // Close the previous socket before replacing it so `activeConnections`
       // stays authoritative and disconnectAgent can never miss a live socket.
-      const previousWs = activeConnections.get(agentId);
+      const previousWs = activeConnections.get(agentId)?.ws;
       if (previousWs && previousWs !== ws) {
         try {
           previousWs.close(4002, 'Superseded by newer connection');
@@ -1934,8 +2007,21 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
         agentPingStates.delete(agentId);
       }
 
+      // Resolve and cache the partner trust snapshot once for this connection.
+      // Missing partner/trust rows retain evaluateCapability's existing allow behavior.
+      const partnerId = await partnerIdForDevice(agentDb.deviceId);
+      if (!partnerId) {
+        ws.close(1011, 'Unable to resolve partner trust state');
+        return;
+      }
+      const trust = await loadTrustState(partnerId);
+
       // Store connection and stamp this socket's delivery epoch.
-      activeConnections.set(agentId, ws);
+      activeConnections.set(agentId, {
+        ws,
+        partnerId,
+        trustState: trust?.trustState ?? 'trusted',
+      });
       socketEpoch = installAgentSocketEpoch(agentId);
       void setAgentPresence(agentId, { instanceId: INSTANCE_ID, connectionToken });
       console.log(`Agent ${agentId} connected via WebSocket. Active connections: ${activeConnections.size}`);
@@ -2099,7 +2185,7 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
             void refreshAgentPresence(agentId, connectionToken).then((refreshed) => {
               // Self-heal: an evict-path unconditional delete may have raced a
               // reconnect; if we are still the live socket, re-establish the lease.
-              if (!refreshed && activeConnections.get(agentId) === ws) {
+              if (!refreshed && activeConnections.get(agentId)?.ws === ws) {
                 return setAgentPresence(agentId, { instanceId: INSTANCE_ID, connectionToken });
               }
             });
@@ -2113,7 +2199,7 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
           if (state) {
             state.lastPongAt = Date.now();
             void refreshAgentPresence(agentId, connectionToken).then((refreshed) => {
-              if (!refreshed && activeConnections.get(agentId) === ws) {
+              if (!refreshed && activeConnections.get(agentId)?.ws === ws) {
                 return setAgentPresence(agentId, { instanceId: INSTANCE_ID, connectionToken });
               }
             });
@@ -2663,7 +2749,7 @@ onClose: async (_event: unknown, ws: WSContext) => {
       // Only remove from active connections if this ws is still the current one.
       // A reconnecting agent may have already replaced us in the map — deleting
       // the new connection's entry would make the agent unreachable.
-      if (activeConnections.get(agentId) === ws) {
+      if (activeConnections.get(agentId)?.ws === ws) {
         activeConnections.delete(agentId);
         if (agentSocketEpochs.get(agentId) === socketEpoch) {
           agentSocketEpochs.delete(agentId);
@@ -2724,7 +2810,7 @@ onClose: async (_event: unknown, ws: WSContext) => {
         clearInterval(pingState.pingInterval);
         agentPingStates.delete(agentId);
       }
-if (activeConnections.get(agentId) === ws) {
+if (activeConnections.get(agentId)?.ws === ws) {
         activeConnections.delete(agentId);
         if (agentSocketEpochs.get(agentId) === socketEpoch) {
           agentSocketEpochs.delete(agentId);
@@ -2994,7 +3080,7 @@ function recordCrossTenantDrop(agentId: string, deviceId: string | undefined, ki
     }
 
     // Close any active WS for this agent so it has to re-auth (and fail).
-    const activeWs = activeConnections.get(agentId);
+    const activeWs = activeConnections.get(agentId)?.ws;
     if (activeWs) {
       try {
         activeWs.close(4001, 'Token suspended');
@@ -3034,12 +3120,23 @@ export function __resetCrossTenantDropsForTest() {
 // wave 3.5b (#4084) relay integration suite, which needs a "locally connected"
 // agent on ONE simulated process while dispatching from another. Never usable
 // in production — a real socket must come through createAgentWsHandlers.
-export function __installAgentSocketForTest(agentId: string, ws: { send(data: string): void }): void {
+export function registerConnection(
+  agentId: string,
+  ws: { send(data: string): void },
+  trust: { partnerId: string; trustState: PartnerTrustState } = {
+    partnerId: 'test-partner',
+    trustState: 'trusted',
+  },
+): void {
   if (process.env.NODE_ENV === 'production') {
-    throw new Error('__installAgentSocketForTest is test-only');
+    throw new Error('registerConnection is test-only');
   }
-  activeConnections.set(agentId, ws as never);
+  activeConnections.set(agentId, { ws: ws as never, ...trust });
   installAgentSocketEpoch(agentId);
+}
+
+export function __installAgentSocketForTest(agentId: string, ws: { send(data: string): void }): void {
+  registerConnection(agentId, ws);
 }
 
 /**
@@ -3132,15 +3229,25 @@ function assertSocketLocalDispatchAllowed(fn: string): void {
  */
 export function sendCommandToAgent(agentId: string, command: AgentCommand): boolean {
   assertSocketLocalDispatchAllowed('sendCommandToAgent');
-  const ws = activeConnections.get(agentId);
-  if (!ws) {
+  const conn = activeConnections.get(agentId);
+  if (!conn) {
     return false;
+  }
+
+  const mode = partnerTrustMode();
+  if (mode !== 'off' && conn.trustState !== 'trusted' && !isLifecycleCommand(command.type)) {
+    if (mode === 'enforce') return false;
+    void evaluateCapability('device_execute', {
+      partnerId: conn.partnerId,
+      commandType: command.type,
+      detail: { via: 'ws_fast_path' },
+    });
   }
 
   try {
     const json = JSON.stringify(command);
     // Send command directly - agent expects {id, type, payload} at top level
-    ws.send(json);
+    conn.ws.send(json);
     recordOrphanedResultExpectation(agentId, command);
     return true;
   } catch (error) {
@@ -3171,10 +3278,10 @@ export type AgentWsDisconnectResult = 'closed' | 'close-failed' | 'not-connected
  * a live-but-orphaned socket.
  */
 export function disconnectAgent(agentId: string, code: number = 4040, reason: string = 'orgId changed, reconnect required'): AgentWsDisconnectResult {
-  const ws = activeConnections.get(agentId);
-  if (!ws) return 'not-connected';
+  const conn = activeConnections.get(agentId);
+  if (!conn) return 'not-connected';
   try {
-    ws.close(code, reason);
+    conn.ws.close(code, reason);
   } catch (error) {
     console.error(`disconnectAgent(${agentId.slice(0,12)}) close threw:`, error);
     captureException(error instanceof Error ? error : new Error(String(error)));
@@ -3217,13 +3324,13 @@ export function broadcastToAgents(
   let sent = 0;
   const payload = JSON.stringify(message);
 
-  for (const [agentId, ws] of activeConnections) {
+  for (const [agentId, conn] of activeConnections) {
     if (filter && !filter(agentId)) {
       continue;
     }
 
     try {
-      ws.send(payload);
+      conn.ws.send(payload);
       sent++;
     } catch (error) {
       console.error(`Failed to broadcast to agent ${agentId}:`, error);

--- a/apps/api/src/routes/devices/actuateElevation.test.ts
+++ b/apps/api/src/routes/devices/actuateElevation.test.ts
@@ -6,6 +6,7 @@ const {
   requireScopeMock,
   requirePermissionMock,
   requireMfaMock,
+  assertDeviceExecuteAllowedMock,
 } = vi.hoisted(() => ({
   authMiddlewareMock: vi.fn(),
   requireScopeMock: vi.fn(() => async (_c: any, next: any) => next()),
@@ -23,6 +24,7 @@ const {
     return next();
   }),
   requireMfaMock: vi.fn(() => async (_c: any, next: any) => next()),
+  assertDeviceExecuteAllowedMock: vi.fn(),
 }));
 
 vi.mock('../../db', () => ({
@@ -50,6 +52,11 @@ vi.mock('./helpers', async (importOriginal) => ({
 
 vi.mock('../../services/auditEvents', () => ({
   writeRouteAudit: vi.fn(),
+}));
+
+vi.mock('../../services/partnerTrust.commands', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../services/partnerTrust.commands')>()),
+  assertDeviceExecuteAllowed: assertDeviceExecuteAllowedMock,
 }));
 
 import { db } from '../../db';
@@ -194,6 +201,7 @@ describe('POST /devices/:id/actuate-elevation', () => {
     // Default: enable the PAM actuator so existing tests continue to pass.
     savedPamEnv = process.env.PAM_ACTUATOR_ENABLED;
     process.env.PAM_ACTUATOR_ENABLED = 'true';
+    assertDeviceExecuteAllowedMock.mockResolvedValue(undefined);
     setAuth();
     app = new Hono();
     app.route('/devices', actuateElevationRoutes);
@@ -481,6 +489,38 @@ describe('POST /devices/:id/actuate-elevation', () => {
       vi.mocked(getDeviceWithOrgCheck).mockResolvedValue(SAMPLE_DEVICE as never);
     });
 
+    it('returns a trust probation denial without inserting a device command', async () => {
+      const { TrustDeniedError } = await import('../../services/partnerTrust.commands');
+      assertDeviceExecuteAllowedMock.mockRejectedValueOnce(
+        new TrustDeniedError(
+          'TRUST_PROBATION',
+          'probation_default_deny',
+          DEVICE_ID,
+          'actuate_elevation',
+        ),
+      );
+      const { commandValues } = rigTransaction({ elevationRow: SAMPLE_ELEVATION });
+
+      const res = await app.request(`/devices/${DEVICE_ID}/actuate-elevation`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ elevationRequestId: ELEVATION_ID }),
+      });
+
+      expect(res.status).toBe(403);
+      expect(await res.json()).toMatchObject({
+        error: 'TRUST_PROBATION',
+        capability: 'device_execute',
+        reason: 'probation_default_deny',
+      });
+      expect(assertDeviceExecuteAllowedMock).toHaveBeenCalledWith(
+        DEVICE_ID,
+        'actuate_elevation',
+        USER_ID,
+      );
+      expect(commandValues).not.toHaveBeenCalled();
+    });
+
     it('queues actuate_elevation with go-signal payload only', async () => {
       const { commandValues } = rigTransaction({
         elevationRow: SAMPLE_ELEVATION,
@@ -524,6 +564,11 @@ describe('POST /devices/:id/actuate-elevation', () => {
             timeoutMs: 5000,
           }),
         }),
+      );
+      expect(assertDeviceExecuteAllowedMock).toHaveBeenCalledWith(
+        DEVICE_ID,
+        'actuate_elevation',
+        USER_ID,
       );
       const queued = commandValues.mock.calls[0]![0] as any;
       expect(queued.payload).not.toHaveProperty('username');

--- a/apps/api/src/routes/devices/actuateElevation.ts
+++ b/apps/api/src/routes/devices/actuateElevation.ts
@@ -18,6 +18,11 @@ import {
 import { PERMISSIONS } from '../../services/permissions';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { type UserPermissions } from '../../services/permissions';
+import {
+  assertDeviceExecuteAllowed,
+  TrustDeniedError,
+} from '../../services/partnerTrust.commands';
+import { trustDenyBody } from '../../services/partnerTrust';
 import { getDeviceWithOrgCheck, canAccessDeviceSite } from './helpers';
 
 export const actuateElevationRoutes = new Hono();
@@ -117,7 +122,9 @@ actuateElevationRoutes.post(
     // wrong-status — must land in `elevation_audit` with the cause. 404/decommission
     // paths above can't write elevation_audit (no valid FK target), so they get only
     // the route-level audit at the outer scope.
-    const result = await db.transaction(async (tx) => {
+    let result;
+    try {
+      result = await db.transaction(async (tx) => {
       const [elevation] = await tx
         .select({
           id: elevationRequests.id,
@@ -196,6 +203,7 @@ actuateElevationRoutes.post(
       // routes/agents/elevationRequests.ts), not a first-class column;
       // same extraction pattern as routes/pam.ts's `commandLine` field.
       const metadata = (elevation.metadata ?? {}) as Record<string, unknown>;
+      await assertDeviceExecuteAllowed(deviceId, 'actuate_elevation', auth.user.id);
       const [command] = await tx
         .insert(deviceCommands)
         .values({
@@ -239,7 +247,21 @@ actuateElevationRoutes.post(
       });
 
       return { kind: 'success' as const, command };
-    });
+      });
+    } catch (e) {
+      if (e instanceof TrustDeniedError) {
+        return c.json(
+          trustDenyBody({
+            allow: false,
+            code: e.code,
+            capability: 'device_execute',
+            reason: e.reason,
+          }, false),
+          403,
+        );
+      }
+      throw e;
+    }
 
     if (result.kind === 'not_found') {
       // Route-level audit only — no elevation_audit because the FK target

--- a/apps/api/src/routes/devices/commands.test.ts
+++ b/apps/api/src/routes/devices/commands.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
 
+const { assertDeviceExecuteAllowedMock } = vi.hoisted(() => ({
+  assertDeviceExecuteAllowedMock: vi.fn(async () => undefined),
+}));
+
 vi.mock('../../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
   withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
@@ -79,11 +83,17 @@ vi.mock('../../services/clientIp', () => ({
   getTrustedClientIpOrUndefined: vi.fn(() => '127.0.0.1'),
 }));
 
+vi.mock('../../services/partnerTrust.commands', async () => ({
+  ...(await vi.importActual<typeof import('../../services/partnerTrust.commands')>('../../services/partnerTrust.commands')),
+  assertDeviceExecuteAllowed: assertDeviceExecuteAllowedMock,
+}));
+
 import { commandsRoutes } from './commands';
 import { db } from '../../db';
 import { getDeviceWithOrgCheck } from './helpers';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { dispatchWake } from '../../services/wakeOnLan';
+import { TrustDeniedError } from '../../services/partnerTrust.commands';
 
 describe('device commands routes', () => {
   let app: Hono;
@@ -131,6 +141,42 @@ describe('device commands routes', () => {
           message: 'Cannot send commands to a decommissioned device.',
         },
       ]);
+      expect(assertDeviceExecuteAllowedMock).toHaveBeenCalledWith(
+        '11111111-1111-1111-1111-111111111111',
+        'reboot',
+        'user-123',
+      );
+    });
+
+    it('reports trust-denied devices per-device without inserting or aborting the bulk request', async () => {
+      const deniedId = '11111111-1111-1111-1111-111111111111';
+      const allowedId = '22222222-2222-2222-2222-222222222222';
+      vi.mocked(getDeviceWithOrgCheck)
+        .mockResolvedValueOnce({ id: deniedId, orgId: 'org-123', hostname: 'denied', status: 'online' } as never)
+        .mockResolvedValueOnce({ id: allowedId, orgId: 'org-123', hostname: 'allowed', status: 'online' } as never);
+      assertDeviceExecuteAllowedMock
+        .mockRejectedValueOnce(new TrustDeniedError('TRUST_PROBATION', 'Partner verification is required.', deniedId, 'reboot'))
+        .mockResolvedValueOnce(undefined);
+      vi.mocked(db.insert).mockReturnValueOnce({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{
+            id: 'cmd-allowed', deviceId: allowedId, type: 'reboot', status: 'pending', createdAt: new Date(),
+          }]),
+        }),
+      } as never);
+
+      const res = await app.request('/devices/bulk/commands', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ deviceIds: [deniedId, allowedId], type: 'reboot' }),
+      });
+
+      expect(res.status).toBe(201);
+      expect(await res.json()).toMatchObject({
+        commands: [{ deviceId: allowedId }],
+        failed: [{ deviceId: deniedId, code: 'TRUST_PROBATION', message: 'Partner verification is required.' }],
+      });
+      expect(db.insert).toHaveBeenCalledTimes(1);
     });
 
     it('bulk refresh_inventory dedups already-pending devices, skips silently (caught by @xxiaoxiong on #831)', async () => {
@@ -636,6 +682,30 @@ describe('device commands routes', () => {
   });
 
   describe('POST /devices/:id/commands', () => {
+    it('returns the shared trust denial body without inserting', async () => {
+      vi.mocked(getDeviceWithOrgCheck).mockResolvedValueOnce({
+        id: 'device-a', orgId: 'org-123', hostname: 'host-a', status: 'online',
+      } as never);
+      assertDeviceExecuteAllowedMock.mockRejectedValueOnce(
+        new TrustDeniedError('TRUST_RESTRICTED', 'Partner access is restricted.', 'device-a', 'reboot'),
+      );
+
+      const res = await app.request('/devices/device-a/commands', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ type: 'reboot' }),
+      });
+
+      expect(res.status).toBe(403);
+      expect(await res.json()).toMatchObject({
+        error: 'TRUST_RESTRICTED',
+        capability: 'device_execute',
+        reason: 'Partner access is restricted.',
+        reviewRequested: false,
+      });
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
     it('writes sanitized command payload details to audit logs', async () => {
       vi.mocked(getDeviceWithOrgCheck).mockResolvedValueOnce({
         id: 'device-a',
@@ -1083,6 +1153,25 @@ describe('device commands routes', () => {
     });
 
   describe('POST /devices/:id/auto-update', () => {
+    it('returns a trust denial without inserting an auto-update command', async () => {
+      vi.mocked(getDeviceWithOrgCheck).mockResolvedValueOnce({
+        id: 'device-a', orgId: 'org-123', hostname: 'test-host', status: 'online',
+      } as never);
+      assertDeviceExecuteAllowedMock.mockRejectedValueOnce(
+        new TrustDeniedError('TRUST_PROBATION', 'Partner verification is required.', 'device-a', 'set_auto_update'),
+      );
+
+      const res = await app.request('/devices/device-a/auto-update', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled: true }),
+      });
+
+      expect(res.status).toBe(403);
+      expect(await res.json()).toMatchObject({ error: 'TRUST_PROBATION', capability: 'device_execute' });
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
     it('queues set_auto_update command when enabled=true', async () => {
       vi.mocked(getDeviceWithOrgCheck).mockResolvedValueOnce({
         id: 'device-a',

--- a/apps/api/src/routes/devices/commands.ts
+++ b/apps/api/src/routes/devices/commands.ts
@@ -13,12 +13,15 @@ import { writeRouteAudit } from '../../services/auditEvents';
 import { commandAuditDetails, sanitizeCommandForHistory } from '../../services/commandAudit';
 import { dispatchWake, type WakeFailureCode } from '../../services/wakeOnLan';
 import { getTrustedClientIpOrUndefined } from '../../services/clientIp';
+import { assertDeviceExecuteAllowed, TrustDeniedError } from '../../services/partnerTrust.commands';
+import { trustDenyBody, type TrustDenyCode } from '../../services/partnerTrust';
 
 export const commandsRoutes = new Hono();
 
 commandsRoutes.use('*', authMiddleware);
 
 const COMMAND_SET_AUTO_UPDATE = 'set_auto_update';
+const COMMAND_WAKE_ON_LAN = 'wake_on_lan';
 
 // POST /devices/bulk/commands - Queue a command for multiple devices
 commandsRoutes.post(
@@ -55,7 +58,7 @@ commandsRoutes.post(
       }> = [];
       const failed: Array<{
         deviceId: string;
-        code: WakeFailureCode | 'DECOMMISSIONED' | 'TARGET_NOT_FOUND' | 'SITE_ACCESS_DENIED';
+        code: WakeFailureCode | 'DECOMMISSIONED' | 'TARGET_NOT_FOUND' | 'SITE_ACCESS_DENIED' | TrustDenyCode;
         message: string;
       }> = [];
       const ipAddress = getTrustedClientIpOrUndefined(c);
@@ -88,6 +91,13 @@ commandsRoutes.post(
           }
           if (device.status === 'decommissioned') {
             failed.push({ deviceId, code: 'DECOMMISSIONED', message: 'Cannot wake a decommissioned device.' });
+            continue;
+          }
+          try {
+            await assertDeviceExecuteAllowed(deviceId, COMMAND_WAKE_ON_LAN, auth.user.id);
+          } catch (error) {
+            if (!(error instanceof TrustDeniedError)) throw error;
+            failed.push({ deviceId, code: error.code, message: error.reason });
             continue;
           }
           const result = await dispatchWake(deviceId, auth.user.id, {
@@ -132,7 +142,8 @@ commandsRoutes.post(
       | 'TARGET_NOT_FOUND'
       | 'SITE_ACCESS_DENIED'
       | 'DECOMMISSIONED'
-      | 'INSERT_FAILED';
+      | 'INSERT_FAILED'
+      | TrustDenyCode;
     const failed: Array<{ deviceId: string; code: BulkFailureCode; message: string }> = [];
     // Devices that completed successfully on a prior call and would queue
     // a duplicate now (currently only the refresh_inventory dedup path).
@@ -156,6 +167,14 @@ commandsRoutes.post(
       }
       if (device.status === 'decommissioned') {
         failed.push({ deviceId, code: 'DECOMMISSIONED', message: 'Cannot send commands to a decommissioned device.' });
+        continue;
+      }
+
+      try {
+        await assertDeviceExecuteAllowed(deviceId, data.type, auth.user.id);
+      } catch (error) {
+        if (!(error instanceof TrustDeniedError)) throw error;
+        failed.push({ deviceId, code: error.code, message: error.reason });
         continue;
       }
 
@@ -267,6 +286,22 @@ commandsRoutes.post(
     // Don't allow commands to decommissioned devices
     if (device.status === 'decommissioned') {
       return c.json({ error: 'Cannot send commands to a decommissioned device' }, 400);
+    }
+
+    try {
+      await assertDeviceExecuteAllowed(
+        deviceId,
+        data.type === 'wake' ? COMMAND_WAKE_ON_LAN : data.type,
+        auth.user.id,
+      );
+    } catch (error) {
+      if (!(error instanceof TrustDeniedError)) throw error;
+      return c.json(trustDenyBody({
+        allow: false,
+        code: error.code,
+        capability: 'device_execute',
+        reason: error.reason,
+      }, false), 403);
     }
 
     // Dedup refresh_inventory: each click fans out ~12 collectors on the
@@ -436,6 +471,18 @@ commandsRoutes.post(
     }
     if (device.status === 'decommissioned') {
       return c.json({ error: 'Cannot send commands to a decommissioned device' }, 400);
+    }
+
+    try {
+      await assertDeviceExecuteAllowed(deviceId, COMMAND_SET_AUTO_UPDATE, auth.user.id);
+    } catch (error) {
+      if (!(error instanceof TrustDeniedError)) throw error;
+      return c.json(trustDenyBody({
+        allow: false,
+        code: error.code,
+        capability: 'device_execute',
+        reason: error.reason,
+      }, false), 403);
     }
 
     const [command] = await db

--- a/apps/api/src/routes/mobile.test.ts
+++ b/apps/api/src/routes/mobile.test.ts
@@ -26,6 +26,7 @@ const {
   emitAlertStateFeedbackMock,
   writeRouteAuditMock,
   executeScriptOnDevicesMock,
+  assertDeviceExecuteAllowedMock,
   rateLimitState,
   authState
 } = vi.hoisted(() => ({
@@ -34,6 +35,7 @@ const {
   emitAlertStateFeedbackMock: vi.fn().mockResolvedValue(undefined),
   writeRouteAuditMock: vi.fn(),
   executeScriptOnDevicesMock: vi.fn(),
+  assertDeviceExecuteAllowedMock: vi.fn(),
   rateLimitState: { allowed: true },
   authState: {
     permissions: undefined as { allowedSiteIds?: string[] } | undefined,
@@ -106,6 +108,11 @@ vi.mock('../services/alertCooldown', () => ({
 
 vi.mock('../services/scriptExecution', () => ({
   executeScriptOnDevices: executeScriptOnDevicesMock
+}));
+
+vi.mock('../services/partnerTrust.commands', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../services/partnerTrust.commands')>()),
+  assertDeviceExecuteAllowed: assertDeviceExecuteAllowedMock,
 }));
 
 vi.mock('../services/mlFeedbackEmitters', () => ({
@@ -237,6 +244,7 @@ describe('mobile routes', () => {
     rateLimitState.allowed = true;
     vi.mocked(db.transaction).mockReset();
     executeScriptOnDevicesMock.mockReset();
+    assertDeviceExecuteAllowedMock.mockResolvedValue(undefined);
     _resetRegistrationFallbackReportsForTests();
     app = new Hono();
     app.route('/mobile', mobileRoutes);
@@ -1679,8 +1687,43 @@ describe('mobile routes', () => {
       expect('ignoredParameters' in body).toBe(false);
     });
 
-    it.skip('should submit device action commands', async () => {
-      // Skipped: Complex command submission mock required
+    it('returns a trust probation denial without inserting a device command', async () => {
+      const { TrustDeniedError } = await import('../services/partnerTrust.commands');
+      vi.mocked(db.select).mockReturnValue(
+        mockSelectLimitChain([
+          { id: mobileDeviceId, orgId: 'org-123', status: 'online', siteId: null }
+        ]) as any
+      );
+      assertDeviceExecuteAllowedMock.mockRejectedValueOnce(
+        new TrustDeniedError(
+          'TRUST_PROBATION',
+          'probation_default_deny',
+          mobileDeviceId,
+          'reboot',
+        ),
+      );
+
+      const res = await app.request(`/mobile/devices/${mobileDeviceId}/actions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'reboot' })
+      });
+
+      expect(res.status).toBe(403);
+      expect(await res.json()).toMatchObject({
+        error: 'TRUST_PROBATION',
+        capability: 'device_execute',
+        reason: 'probation_default_deny',
+      });
+      expect(assertDeviceExecuteAllowedMock).toHaveBeenCalledWith(
+        mobileDeviceId,
+        'reboot',
+        'user-123',
+      );
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('should submit device action commands when trust allows execution', async () => {
       vi.mocked(db.select).mockReturnValue(
         mockSelectLimitChain([
           { id: '11111111-2222-4333-8444-555555555555', orgId: 'org-123', status: 'online' }
@@ -1701,6 +1744,11 @@ describe('mobile routes', () => {
       expect(res.status).toBe(201);
       const body = await res.json();
       expect(body.commandId).toBe('cmd-1');
+      expect(assertDeviceExecuteAllowedMock).toHaveBeenCalledWith(
+        mobileDeviceId,
+        'reboot',
+        'user-123',
+      );
     });
 
     // #3409 PR0 Task 3: the org-equality invariant itself now lives inside

--- a/apps/api/src/routes/mobile.ts
+++ b/apps/api/src/routes/mobile.ts
@@ -38,6 +38,11 @@ import { captureMessage } from '../services/sentry';
 import { createReportThrottle } from '../utils/reportThrottle';
 import { isPgUniqueViolation } from '../utils/pgErrors';
 import { UUID_REGEX } from '../utils/uuid';
+import {
+  assertDeviceExecuteAllowed,
+  TrustDeniedError,
+} from '../services/partnerTrust.commands';
+import { trustDenyBody } from '../services/partnerTrust';
 // Shared with the web device routes rather than re-declared locally. This file
 // used to carry a byte-identical private copy, which is precisely why the #2968
 // uuid guard — added to the shared helper — silently did not apply to
@@ -1315,16 +1320,33 @@ mobileRoutes.post(
       }, 202);
     }
 
-    const cmdResult = await db
-      .insert(deviceCommands)
-      .values({
-        deviceId: device.id,
-        type: data.action,
-        payload: { source: 'mobile' },
-        status: 'pending',
-        createdBy: auth.user.id
-      })
-      .returning();
+    let cmdResult;
+    try {
+      await assertDeviceExecuteAllowed(device.id, data.action, auth.user.id);
+      cmdResult = await db
+        .insert(deviceCommands)
+        .values({
+          deviceId: device.id,
+          type: data.action,
+          payload: { source: 'mobile' },
+          status: 'pending',
+          createdBy: auth.user.id
+        })
+        .returning();
+    } catch (e) {
+      if (e instanceof TrustDeniedError) {
+        return c.json(
+          trustDenyBody({
+            allow: false,
+            code: e.code,
+            capability: 'device_execute',
+            reason: e.reason,
+          }, false),
+          403,
+        );
+      }
+      throw e;
+    }
     const cmd = cmdResult[0];
 
     if (!cmd) {

--- a/apps/api/src/services/aiToolsBrowser.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsBrowser.siteScope.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+const { assertDeviceExecuteAllowedMock } = vi.hoisted(() => ({
+  assertDeviceExecuteAllowedMock: vi.fn(async () => undefined),
+}));
+
 // aiToolsBrowser imports the db hub (which pulls commandQueue), so the db mock
 // must expose the context helpers too — same shape as aiTools.verifyDeviceAccess.test.ts.
 vi.mock('../db', () => ({
@@ -9,10 +13,17 @@ vi.mock('../db', () => ({
   db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn() },
 }));
 
+vi.mock('./eventBus', () => ({ publishEvent: vi.fn(async () => undefined) }));
+vi.mock('./partnerTrust.commands', async () => ({
+  ...(await vi.importActual<typeof import('./partnerTrust.commands')>('./partnerTrust.commands')),
+  assertDeviceExecuteAllowed: assertDeviceExecuteAllowedMock,
+}));
+
 import { db } from '../db';
 import { policyWithinSiteWriteScope, registerBrowserTools } from './aiToolsBrowser';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
+import { TrustDeniedError } from './partnerTrust.commands';
 
 const mockDb = db as unknown as {
   select: ReturnType<typeof vi.fn>;
@@ -129,6 +140,59 @@ describe('manage_browser_policy — site write scope (mutations)', () => {
     );
     expect(result).not.toContain('"error"');
     expect(mockDb.insert).toHaveBeenCalled();
+  });
+
+  it('apply: trust denial returns the tool error shape without inserting', async () => {
+    mockDb.select
+      .mockReturnValueOnce({
+        from: () => ({ where: () => ({ limit: () => Promise.resolve([{
+          id: 'p1', orgId: 'org-1', name: 'Policy', targetType: 'org', targetIds: null, isActive: true,
+          allowedExtensions: [], blockedExtensions: [], requiredExtensions: [], settings: {},
+        }]) }) }),
+      })
+      .mockReturnValueOnce({
+        from: () => ({ where: () => Promise.resolve([{ id: 'd1', hostname: 'host-1' }]) }),
+      });
+    assertDeviceExecuteAllowedMock.mockRejectedValueOnce(
+      new TrustDeniedError('TRUST_PROBATION', 'Partner verification is required.', 'd1', 'apply_browser_policy'),
+    );
+
+    const result = await handlerFor('manage_browser_policy')(
+      { action: 'apply', policyId: 'p1' },
+      makeAuth(undefined),
+    );
+
+    expect(JSON.parse(result)).toEqual({
+      error: 'TRUST_PROBATION',
+      message: 'Remote control and device changes are not available until this account is verified.',
+    });
+    expect(assertDeviceExecuteAllowedMock).toHaveBeenCalledWith('d1', 'apply_browser_policy', 'u1');
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+
+  it('apply: queues the same command when trust allows execution', async () => {
+    mockDb.select
+      .mockReturnValueOnce({
+        from: () => ({ where: () => ({ limit: () => Promise.resolve([{
+          id: 'p1', orgId: 'org-1', name: 'Policy', targetType: 'org', targetIds: null, isActive: true,
+          allowedExtensions: [], blockedExtensions: [], requiredExtensions: [], settings: {},
+        }]) }) }),
+      })
+      .mockReturnValueOnce({
+        from: () => ({ where: () => Promise.resolve([{ id: 'd1', hostname: 'host-1' }]) }),
+      });
+    mockDb.insert.mockReturnValue({
+      values: () => ({ returning: () => Promise.resolve([{ id: 'cmd-1', deviceId: 'd1' }]) }),
+    });
+
+    const result = JSON.parse(await handlerFor('manage_browser_policy')(
+      { action: 'apply', policyId: 'p1' },
+      makeAuth(undefined),
+    ));
+
+    expect(result.success).toBe(true);
+    expect(result.queuedCommands).toBe(1);
+    expect(mockDb.insert).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/api/src/services/aiToolsBrowser.ts
+++ b/apps/api/src/services/aiToolsBrowser.ts
@@ -18,6 +18,7 @@ import { eq, and, desc, sql, inArray, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { publishEvent } from './eventBus';
+import { assertDeviceExecuteAllowed, TrustDeniedError } from './partnerTrust.commands';
 
 type AiToolTier = 1 | 2 | 3 | 4;
 
@@ -453,6 +454,18 @@ export function registerBrowserTools(aiTools: Map<string, AiTool>): void {
 
         if (targetDevices.length === 0) {
           return JSON.stringify({ error: 'No target devices found' });
+        }
+
+        try {
+          for (const device of targetDevices) {
+            await assertDeviceExecuteAllowed(device.id, 'apply_browser_policy', auth.user.id);
+          }
+        } catch (error) {
+          if (!(error instanceof TrustDeniedError)) throw error;
+          return JSON.stringify({
+            error: error.code,
+            message: 'Remote control and device changes are not available until this account is verified.',
+          });
         }
 
         const queued = await db

--- a/apps/api/src/services/commandQueue.test.ts
+++ b/apps/api/src/services/commandQueue.test.ts
@@ -154,10 +154,17 @@ describe('command queue service', () => {
       }),
     } as any);
 
-    await expect(executeCommand('d1', 'script', {})).resolves.toMatchObject({
-      success: false,
+    const result = await executeCommand('d1', 'script', {});
+
+    expect(result).toMatchObject({
+      status: 'failed',
       error: 'TRUST_PROBATION',
+      trust: { reason: 'probation_default_deny' },
     });
+    // Regression guard: the legacy `{ success: false }` shape must never
+    // come back — callers (e.g. routes/backup/vss.ts) check
+    // `result.status === 'failed'`, not `result.success`.
+    expect((result as any).success).toBeUndefined();
   });
 
   it('refuses to re-arm a desktop stop row whose payload is not exact', async () => {

--- a/apps/api/src/services/commandQueue.test.ts
+++ b/apps/api/src/services/commandQueue.test.ts
@@ -20,6 +20,21 @@ import {
   claimPendingCommandForDelivery,
   releaseClaimedCommandDelivery,
 } from './commandDispatch';
+import { TrustDeniedError } from './partnerTrust.commands';
+
+const partnerTrustCommandMocks = vi.hoisted(() => ({
+  assertDeviceExecuteAllowed: vi.fn(),
+}));
+
+vi.mock('./partnerTrust.commands', async () => {
+  const actual = await vi.importActual<typeof import('./partnerTrust.commands')>(
+    './partnerTrust.commands',
+  );
+  return {
+    ...actual,
+    assertDeviceExecuteAllowed: partnerTrustCommandMocks.assertDeviceExecuteAllowed,
+  };
+});
 
 vi.mock('../db', () => ({
   db: {
@@ -71,10 +86,78 @@ vi.mock('../db/schema', async (importOriginal) => {
 describe('command queue service', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    partnerTrustCommandMocks.assertDeviceExecuteAllowed.mockImplementation(
+      async (_deviceId, type) => {
+        if (type === 'script') {
+          throw new TrustDeniedError(
+            'TRUST_PROBATION',
+            'probation_default_deny',
+            'd1',
+            'script',
+          );
+        }
+      },
+    );
   });
 
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it('queueCommand refuses a gated type for a probation partner and inserts nothing', async () => {
+    await expect(queueCommand('d1', 'script', {}, 'u1')).rejects.toBeInstanceOf(
+      TrustDeniedError,
+    );
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('queueCommand still queues self_uninstall', async () => {
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{ id: 'u1' }]),
+        }),
+      }),
+    } as any);
+    vi.mocked(db.insert).mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{ id: 'cmd-self-uninstall' }]),
+      }),
+    } as any);
+
+    await expect(
+      queueCommand('d1', 'self_uninstall', { removeConfig: true }, 'u1'),
+    ).resolves.toBeTruthy();
+  });
+
+  it('queueCommandForExecution returns a structured trust error instead of throwing', async () => {
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{ id: 'd1', status: 'online' }]),
+        }),
+      }),
+    } as any);
+
+    await expect(queueCommandForExecution('d1', 'script', {})).resolves.toMatchObject({
+      error: 'TRUST_PROBATION',
+      trust: { reason: 'probation_default_deny' },
+    });
+  });
+
+  it('executeCommand returns a failed CommandResult with the trust code', async () => {
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{ id: 'd1', status: 'online' }]),
+        }),
+      }),
+    } as any);
+
+    await expect(executeCommand('d1', 'script', {})).resolves.toMatchObject({
+      success: false,
+      error: 'TRUST_PROBATION',
+    });
   });
 
   it('refuses to re-arm a desktop stop row whose payload is not exact', async () => {

--- a/apps/api/src/services/commandQueue.ts
+++ b/apps/api/src/services/commandQueue.ts
@@ -1003,12 +1003,10 @@ export async function executeCommand(
   } catch (e) {
     if (e instanceof TrustDeniedError) {
       return {
-        success: false,
+        status: 'failed',
         error: e.code,
-        output: '',
-        exitCode: null,
         trust: { capability: e.capability, reason: e.reason },
-      } as unknown as CommandResult;
+      };
     }
     throw e;
   }

--- a/apps/api/src/services/commandQueue.ts
+++ b/apps/api/src/services/commandQueue.ts
@@ -13,6 +13,7 @@ import {
   AGENT_BINARY_UPDATE_COMMAND_TYPES,
   agentBinaryUpdateDispatchRefusal,
 } from './agentEditionCompat';
+import { assertDeviceExecuteAllowed, TrustDeniedError } from './partnerTrust.commands';
 import { recordCommandDispatch } from './anomalyMetrics';
 import {
   decryptCommandForDelivery,
@@ -217,6 +218,7 @@ export interface CommandResult {
   error?: string;
   durationMs?: number;
   data?: unknown;
+  trust?: { capability: 'device_execute'; reason: string };
   /**
    * The device_commands row id, attached by executeCommand once a command row
    * exists (success or failure). Lets callers point at the persisted result
@@ -275,6 +277,7 @@ const runOutsideDbContextSafe = runOutsideDbContext;
 export interface QueueCommandForExecutionResult {
   command?: QueuedCommand;
   error?: string;
+  trust?: { capability: 'device_execute'; reason: string };
 }
 
 export type RearmIdempotentCommandResult =
@@ -624,6 +627,8 @@ export async function queueCommand(
     );
   }
 
+  await assertDeviceExecuteAllowed(deviceId, type, userId);
+
   // Never stamp `userId` verbatim — it may be a synthetic-auth id with no
   // `users` row, which would fail the created_by FK with 23503 (#3978).
   const safeUserId = await resolveCommandCreatedBy(deviceId, userId);
@@ -842,6 +847,18 @@ export async function queueCommandForExecution(
     return { error: `Device is ${device.status}, cannot execute command` };
   }
 
+  try {
+    await assertDeviceExecuteAllowed(deviceId, type, userId);
+  } catch (e) {
+    if (e instanceof TrustDeniedError) {
+      return {
+        error: e.code,
+        trust: { capability: e.capability, reason: e.reason },
+      };
+    }
+    throw e;
+  }
+
   const command = await queueCommand(deviceId, type, payload, userId);
 
   if (device.agentId && !preferHeartbeat) {
@@ -979,6 +996,21 @@ export async function executeCommand(
 
   if (!device) {
     return { status: 'failed', error: 'Device not found' };
+  }
+
+  try {
+    await assertDeviceExecuteAllowed(deviceId, type, userId);
+  } catch (e) {
+    if (e instanceof TrustDeniedError) {
+      return {
+        success: false,
+        error: e.code,
+        output: '',
+        exitCode: null,
+        trust: { capability: e.capability, reason: e.reason },
+      } as unknown as CommandResult;
+    }
+    throw e;
   }
 
   // #4093 — artifact-edition gate for agent-binary updates, at the dispatch

--- a/apps/api/src/services/partnerTrust.commands.test.ts
+++ b/apps/api/src/services/partnerTrust.commands.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect, vi } from 'vitest';
+const evaluate = vi.hoisted(() => vi.fn());
+vi.mock('./partnerTrust', () => ({ evaluateCapability: evaluate, partnerIdForDevice: async () => 'p1', isLifecycleCommand: (t: string) => t === 'self_uninstall' }));
+import { assertDeviceExecuteAllowed, TrustDeniedError } from './partnerTrust.commands';
+
+it('throws TrustDeniedError on deny', async () => {
+  evaluate.mockResolvedValueOnce({ allow: false, code: 'TRUST_PROBATION', capability: 'device_execute', reason: 'probation_default_deny' });
+  await expect(assertDeviceExecuteAllowed('d1', 'script', 'u1')).rejects.toBeInstanceOf(TrustDeniedError);
+});
+it('returns on allow', async () => {
+  evaluate.mockResolvedValueOnce({ allow: true });
+  await expect(assertDeviceExecuteAllowed('d1', 'script', 'u1')).resolves.toBeUndefined();
+});
+it('skips the lookup entirely for lifecycle commands', async () => {
+  evaluate.mockClear();
+  await assertDeviceExecuteAllowed('d1', 'self_uninstall');
+  expect(evaluate).not.toHaveBeenCalled();
+});

--- a/apps/api/src/services/partnerTrust.commands.test.ts
+++ b/apps/api/src/services/partnerTrust.commands.test.ts
@@ -1,18 +1,37 @@
 import { describe, it, expect, vi } from 'vitest';
 const evaluate = vi.hoisted(() => vi.fn());
-vi.mock('./partnerTrust', () => ({ evaluateCapability: evaluate, partnerIdForDevice: async () => 'p1', isLifecycleCommand: (t: string) => t === 'self_uninstall' }));
+const partnerIdForDeviceMock = vi.hoisted(() => vi.fn());
+const modeFunc = vi.hoisted(() => vi.fn());
+vi.mock('./partnerTrust', () => ({ evaluateCapability: evaluate, partnerIdForDevice: partnerIdForDeviceMock, isLifecycleCommand: (t: string) => t === 'self_uninstall' }));
+vi.mock('../config/partnerTrustMode', () => ({ partnerTrustMode: modeFunc }));
 import { assertDeviceExecuteAllowed, TrustDeniedError } from './partnerTrust.commands';
 
-it('throws TrustDeniedError on deny', async () => {
-  evaluate.mockResolvedValueOnce({ allow: false, code: 'TRUST_PROBATION', capability: 'device_execute', reason: 'probation_default_deny' });
-  await expect(assertDeviceExecuteAllowed('d1', 'script', 'u1')).rejects.toBeInstanceOf(TrustDeniedError);
-});
-it('returns on allow', async () => {
-  evaluate.mockResolvedValueOnce({ allow: true });
-  await expect(assertDeviceExecuteAllowed('d1', 'script', 'u1')).resolves.toBeUndefined();
-});
-it('skips the lookup entirely for lifecycle commands', async () => {
-  evaluate.mockClear();
-  await assertDeviceExecuteAllowed('d1', 'self_uninstall');
-  expect(evaluate).not.toHaveBeenCalled();
+describe('assertDeviceExecuteAllowed', () => {
+  it('throws TrustDeniedError on deny', async () => {
+    modeFunc.mockReturnValueOnce('enforce');
+    partnerIdForDeviceMock.mockResolvedValueOnce('p1');
+    evaluate.mockResolvedValueOnce({ allow: false, code: 'TRUST_PROBATION', capability: 'device_execute', reason: 'probation_default_deny' });
+    await expect(assertDeviceExecuteAllowed('d1', 'script', 'u1')).rejects.toBeInstanceOf(TrustDeniedError);
+  });
+  it('returns on allow', async () => {
+    modeFunc.mockReturnValueOnce('enforce');
+    partnerIdForDeviceMock.mockResolvedValueOnce('p1');
+    evaluate.mockResolvedValueOnce({ allow: true });
+    await expect(assertDeviceExecuteAllowed('d1', 'script', 'u1')).resolves.toBeUndefined();
+  });
+  it('skips the lookup entirely for lifecycle commands', async () => {
+    modeFunc.mockReturnValueOnce('enforce');
+    evaluate.mockClear();
+    partnerIdForDeviceMock.mockClear();
+    await assertDeviceExecuteAllowed('d1', 'self_uninstall');
+    expect(evaluate).not.toHaveBeenCalled();
+  });
+  it('returns early when partnerTrustMode is off without calling DB', async () => {
+    modeFunc.mockReturnValueOnce('off');
+    partnerIdForDeviceMock.mockClear();
+    evaluate.mockClear();
+    await assertDeviceExecuteAllowed('d1', 'script', 'u1');
+    expect(partnerIdForDeviceMock).not.toHaveBeenCalled();
+    expect(evaluate).not.toHaveBeenCalled();
+  });
 });

--- a/apps/api/src/services/partnerTrust.commands.ts
+++ b/apps/api/src/services/partnerTrust.commands.ts
@@ -1,4 +1,5 @@
 import { evaluateCapability, partnerIdForDevice, isLifecycleCommand, type TrustDenyCode } from './partnerTrust';
+import { partnerTrustMode } from '../config/partnerTrustMode';
 
 export class TrustDeniedError extends Error {
   readonly code: TrustDenyCode; readonly capability = 'device_execute' as const; readonly reason: string; readonly deviceId: string; readonly commandType: string;
@@ -9,6 +10,7 @@ export class TrustDeniedError extends Error {
 }
 
 export async function assertDeviceExecuteAllowed(deviceId: string, commandType: string, userId?: string | null): Promise<void> {
+  if (partnerTrustMode() === 'off') return;
   if (isLifecycleCommand(commandType)) return;
   const partnerId = await partnerIdForDevice(deviceId);
   if (!partnerId) return;

--- a/apps/api/src/services/partnerTrust.commands.ts
+++ b/apps/api/src/services/partnerTrust.commands.ts
@@ -1,0 +1,17 @@
+import { evaluateCapability, partnerIdForDevice, isLifecycleCommand, type TrustDenyCode } from './partnerTrust';
+
+export class TrustDeniedError extends Error {
+  readonly code: TrustDenyCode; readonly capability = 'device_execute' as const; readonly reason: string; readonly deviceId: string; readonly commandType: string;
+  constructor(code: TrustDenyCode, reason: string, deviceId: string, commandType: string) {
+    super(`Partner trust ${code}: ${commandType} on ${deviceId} (${reason})`);
+    this.name = 'TrustDeniedError'; this.code = code; this.reason = reason; this.deviceId = deviceId; this.commandType = commandType;
+  }
+}
+
+export async function assertDeviceExecuteAllowed(deviceId: string, commandType: string, userId?: string | null): Promise<void> {
+  if (isLifecycleCommand(commandType)) return;
+  const partnerId = await partnerIdForDevice(deviceId);
+  if (!partnerId) return;
+  const d = await evaluateCapability('device_execute', { partnerId, deviceId, userId: userId ?? undefined, commandType });
+  if (!d.allow) throw new TrustDeniedError(d.code, d.reason, deviceId, commandType);
+}

--- a/apps/api/src/services/partnerTrust.sites.test.ts
+++ b/apps/api/src/services/partnerTrust.sites.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { isLifecycleCommand } from './partnerTrust';
+
+const intentionallyUngatedSystemSites = [
+  '../routes/agents/helpers.ts',
+  './tenantOffboarding.ts',
+  './desktopSessionStop.ts',
+  './wakeOnLan.ts',
+  './deviceUninstallDrain.ts',
+  '../routes/admin/abuse.ts',
+] as const;
+
+function literalCommandTypes(source: string): string[] {
+  const types: string[] = [];
+  const insertPattern = /\.insert\(deviceCommands\)/g;
+  for (const match of source.matchAll(insertPattern)) {
+    const statement = source.slice(match.index, source.indexOf(';', match.index));
+    for (const typeMatch of statement.matchAll(/\btype:\s*'([^']+)'/g)) {
+      types.push(typeMatch[1]!);
+    }
+  }
+  return types;
+}
+
+describe('intentionally ungated system device-command sites', () => {
+  it.each(intentionallyUngatedSystemSites)('%s uses only lifecycle command literals', (relativePath) => {
+    const path = resolve(import.meta.dirname, relativePath);
+    const source = readFileSync(path, 'utf8');
+    for (const type of literalCommandTypes(source)) {
+      expect(isLifecycleCommand(type), `${relativePath} inserts non-lifecycle command ${type}`).toBe(true);
+    }
+  });
+
+  it('covers at least one literal device command', () => {
+    const types = intentionallyUngatedSystemSites.flatMap((relativePath) =>
+      literalCommandTypes(readFileSync(resolve(import.meta.dirname, relativePath), 'utf8')),
+    );
+    expect(types.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/api/src/services/partnerTrust.sites.test.ts
+++ b/apps/api/src/services/partnerTrust.sites.test.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { isLifecycleCommand } from './partnerTrust';
 
@@ -12,31 +12,153 @@ const intentionallyUngatedSystemSites = [
   '../routes/admin/abuse.ts',
 ] as const;
 
-function literalCommandTypes(source: string): string[] {
+// Heartbeat-driven threshold scan: the agent, not an operator, triggers it and no
+// operator content/target is involved. The operator-driven filesystem_analysis path
+// (AI tool) dispatches through the gated commandQueue. Any other type appearing
+// here must be lifecycle.
+const SYSTEM_INITIATED_EXCEPTIONS: Record<string, readonly string[]> = {
+  '../routes/agents/helpers.ts': ['filesystem_analysis'],
+};
+
+// `CommandTypes.NAME` references resolve through this map, built once from the
+// real `export const CommandTypes = { ... } as const` object in commandQueue.ts
+// so a renamed/added constant is picked up automatically.
+function loadCommandTypesByName(): Map<string, string> {
+  const commandQueuePath = resolve(import.meta.dirname, './commandQueue.ts');
+  const source = readFileSync(commandQueuePath, 'utf8');
+  const block = source.match(/export const CommandTypes\s*=\s*\{([\s\S]*?)\}\s*as const/);
+  if (!block) {
+    throw new Error('CommandTypes constants object must remain discoverable in commandQueue.ts');
+  }
+  const byName = new Map<string, string>();
+  for (const match of block[1]!.matchAll(/\b([A-Z][A-Z0-9_]*)\s*:\s*'([^']+)'/g)) {
+    byName.set(match[1]!, match[2]!);
+  }
+  return byName;
+}
+
+const commandTypesByName = loadCommandTypesByName();
+
+// Finds `import { ..., <identifier>, ... } from '<module>'` in `source` and
+// returns the resolved absolute path of that module (as a .ts file), or null
+// if `identifier` isn't named in any import.
+function resolveImportedModulePath(identifier: string, source: string, fromFilePath: string): string | null {
+  for (const importMatch of source.matchAll(/import\s+(?:type\s+)?\{([^}]*)\}\s*from\s*'([^']+)'/g)) {
+    const names = importMatch[1]!
+      .split(',')
+      .map((n) => n.trim().split(/\s+as\s+/)[0]!.replace(/^type\s+/, '').trim());
+    if (names.includes(identifier)) {
+      const specifier = importMatch[2]!;
+      if (!specifier.startsWith('.')) return null; // not a local module we can inspect
+      return resolve(dirname(fromFilePath), `${specifier}.ts`);
+    }
+  }
+  return null;
+}
+
+// Resolves a bare identifier (e.g. `filesystemAnalysisCommandType`) to its
+// literal command-type string by looking for `const <identifier> = '<literal>'`
+// or `const <identifier> = CommandTypes.NAME` — first in `source` itself, then
+// (one level) in whichever local module `source` imports it from.
+function resolveIdentifierValue(identifier: string, source: string, filePath: string): string | null {
+  const literalDecl = source.match(new RegExp(`\\bconst\\s+${identifier}\\s*=\\s*'([^']+)'`));
+  if (literalDecl) return literalDecl[1]!;
+
+  const commandTypesDecl = source.match(new RegExp(`\\bconst\\s+${identifier}\\s*=\\s*CommandTypes\\.([A-Za-z0-9_]+)`));
+  if (commandTypesDecl) return commandTypesByName.get(commandTypesDecl[1]!) ?? null;
+
+  const importedModulePath = resolveImportedModulePath(identifier, source, filePath);
+  if (!importedModulePath) return null;
+
+  const importedSource = readFileSync(importedModulePath, 'utf8');
+  const importedLiteralDecl = importedSource.match(new RegExp(`\\bexport const\\s+${identifier}\\s*=\\s*'([^']+)'`));
+  if (importedLiteralDecl) return importedLiteralDecl[1]!;
+
+  const importedCommandTypesDecl = importedSource.match(
+    new RegExp(`\\bexport const\\s+${identifier}\\s*=\\s*CommandTypes\\.([A-Za-z0-9_]+)`),
+  );
+  if (importedCommandTypesDecl) return commandTypesByName.get(importedCommandTypesDecl[1]!) ?? null;
+
+  return null;
+}
+
+// Extracts the command type at each `deviceCommands` insert site in `source`,
+// resolving string literals, `CommandTypes.NAME` references, and bare
+// identifiers (imported or locally declared) back to their literal value.
+function resolvedCommandTypes(source: string, filePath: string): string[] {
   const types: string[] = [];
   const insertPattern = /\.insert\(deviceCommands\)/g;
   for (const match of source.matchAll(insertPattern)) {
     const statement = source.slice(match.index, source.indexOf(';', match.index));
-    for (const typeMatch of statement.matchAll(/\btype:\s*'([^']+)'/g)) {
-      types.push(typeMatch[1]!);
+    for (const typeMatch of statement.matchAll(
+      /\btype:\s*(?:'([^']+)'|([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?))/g,
+    )) {
+      const literal = typeMatch[1];
+      if (literal) {
+        types.push(literal);
+        continue;
+      }
+      const expression = typeMatch[2]!;
+      const [head, member] = expression.split('.');
+      if (member) {
+        if (head !== 'CommandTypes') {
+          throw new Error(`${filePath}: cannot resolve command type expression '${expression}'`);
+        }
+        const resolved = commandTypesByName.get(member);
+        if (!resolved) {
+          throw new Error(`${filePath}: CommandTypes.${member} is not a known command type`);
+        }
+        types.push(resolved);
+        continue;
+      }
+      const resolved = resolveIdentifierValue(head!, source, filePath);
+      if (!resolved) {
+        throw new Error(`${filePath}: could not resolve command type identifier '${head}'`);
+      }
+      types.push(resolved);
     }
   }
   return types;
 }
 
 describe('intentionally ungated system device-command sites', () => {
-  it.each(intentionallyUngatedSystemSites)('%s uses only lifecycle command literals', (relativePath) => {
+  it.each(intentionallyUngatedSystemSites)('%s uses only lifecycle command literals or approved exceptions', (relativePath) => {
     const path = resolve(import.meta.dirname, relativePath);
     const source = readFileSync(path, 'utf8');
-    for (const type of literalCommandTypes(source)) {
-      expect(isLifecycleCommand(type), `${relativePath} inserts non-lifecycle command ${type}`).toBe(true);
+    const types = resolvedCommandTypes(source, path);
+    expect(types.length, `${relativePath} yielded zero resolved command types — the scanner can no longer see its deviceCommands inserts`).toBeGreaterThan(0);
+    for (const type of types) {
+      const isApproved = isLifecycleCommand(type) || SYSTEM_INITIATED_EXCEPTIONS[relativePath]?.includes(type);
+      expect(isApproved, `${relativePath} inserts non-lifecycle command ${type} without an approved exception`).toBe(true);
     }
   });
 
   it('covers at least one literal device command', () => {
-    const types = intentionallyUngatedSystemSites.flatMap((relativePath) =>
-      literalCommandTypes(readFileSync(resolve(import.meta.dirname, relativePath), 'utf8')),
-    );
+    const types = intentionallyUngatedSystemSites.flatMap((relativePath) => {
+      const path = resolve(import.meta.dirname, relativePath);
+      return resolvedCommandTypes(readFileSync(path, 'utf8'), path);
+    });
     expect(types.length).toBeGreaterThan(0);
+  });
+
+  it('validates that all exception entries refer to scanned files and types that actually appear in them', () => {
+    const scannedFiles = new Set(intentionallyUngatedSystemSites);
+    const scannedTypesByFile = new Map<string, Set<string>>();
+
+    for (const relativePath of intentionallyUngatedSystemSites) {
+      const path = resolve(import.meta.dirname, relativePath);
+      const source = readFileSync(path, 'utf8');
+      const types = resolvedCommandTypes(source, path);
+      scannedTypesByFile.set(relativePath, new Set(types));
+    }
+
+    for (const [file, exceptions] of Object.entries(SYSTEM_INITIATED_EXCEPTIONS)) {
+      expect(scannedFiles.has(file), `Exception entry references file ${file} which is not in the scanned list`).toBe(true);
+      const typesInFile = scannedTypesByFile.get(file);
+      expect(typesInFile, `Could not find scanned types for exception file ${file}`).toBeDefined();
+      for (const exceptionType of exceptions) {
+        expect(typesInFile!.has(exceptionType), `Exception type ${exceptionType} in ${file} was not found in that file`).toBe(true);
+      }
+    }
   });
 });

--- a/apps/api/src/services/partnerTrust.sites.test.ts
+++ b/apps/api/src/services/partnerTrust.sites.test.ts
@@ -142,7 +142,7 @@ describe('intentionally ungated system device-command sites', () => {
   });
 
   it('validates that all exception entries refer to scanned files and types that actually appear in them', () => {
-    const scannedFiles = new Set(intentionallyUngatedSystemSites);
+    const scannedFiles = new Set<string>(intentionallyUngatedSystemSites);
     const scannedTypesByFile = new Map<string, Set<string>>();
 
     for (const relativePath of intentionallyUngatedSystemSites) {

--- a/apps/api/src/services/partnerTrust.test.ts
+++ b/apps/api/src/services/partnerTrust.test.ts
@@ -3,8 +3,9 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { audit, state } = vi.hoisted(() => ({
+const { audit, publish, state } = vi.hoisted(() => ({
   audit: vi.fn(async () => {}),
+  publish: vi.fn(async () => 1),
   state: {
     trustState: 'probation' as 'probation' | 'trusted' | 'restricted',
     probationEnrollments: 0,
@@ -13,6 +14,7 @@ const { audit, state } = vi.hoisted(() => ({
 }));
 
 vi.mock('./auditService', () => ({ createAuditLog: audit }));
+vi.mock('./redis', () => ({ getRedis: vi.fn(() => ({ publish })) }));
 vi.mock('../config/partnerTrustMode', () => ({ partnerTrustMode: vi.fn(() => 'enforce') }));
 vi.mock('../db', () => ({
   db: {},
@@ -31,7 +33,9 @@ import {
   GATED_COMMAND_TYPES,
   isLifecycleCommand,
   LIFECYCLE_COMMAND_TYPES,
+  setTrustState,
 } from './partnerTrust';
+import { writeTrust } from './partnerTrust.repo';
 
 function sourceFilesUnder(directory: string): string[] {
   return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
@@ -141,9 +145,25 @@ function agentDispatcherCommandTypes(): { commandTypes: string[]; unresolvedCons
 
 beforeEach(() => {
   audit.mockClear();
+  publish.mockClear();
+  vi.mocked(writeTrust).mockClear();
   state.trustState = 'probation';
   state.probationEnrollments = 0;
   vi.mocked(partnerTrustMode).mockReturnValue('enforce');
+});
+
+describe('setTrustState', () => {
+  it('publishes the new trust state after persisting it', async () => {
+    await setTrustState('p1', 'trusted', 'review approved', 'user-1');
+
+    expect(writeTrust).toHaveBeenCalledWith('p1', 'trusted', 'review approved', 'user-1');
+    expect(publish).toHaveBeenCalledWith(
+      'partner-trust:changed',
+      JSON.stringify({ partnerId: 'p1', trustState: 'trusted' }),
+    );
+    expect(vi.mocked(writeTrust).mock.invocationCallOrder[0])
+      .toBeLessThan(publish.mock.invocationCallOrder[0]!);
+  });
 });
 
 describe('evaluateCapability', () => {

--- a/apps/api/src/services/partnerTrust.test.ts
+++ b/apps/api/src/services/partnerTrust.test.ts
@@ -35,7 +35,7 @@ import {
   LIFECYCLE_COMMAND_TYPES,
   setTrustState,
 } from './partnerTrust';
-import { writeTrust } from './partnerTrust.repo';
+import { readTrust, writeTrust } from './partnerTrust.repo';
 
 function sourceFilesUnder(directory: string): string[] {
   return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
@@ -184,6 +184,25 @@ describe('evaluateCapability', () => {
       .toMatchObject({ allow: false, code: 'TRUST_RESTRICTED' });
   });
 
+  it('denies an unresolved partner in enforce mode and audits the denial', async () => {
+    vi.mocked(readTrust).mockResolvedValueOnce(null);
+
+    expect(await evaluateCapability('remote_control', { partnerId: 'missing-partner' })).toEqual({
+      allow: false,
+      code: 'TRUST_RESTRICTED',
+      capability: 'remote_control',
+      reason: 'partner_unresolved',
+    });
+    expect(audit).toHaveBeenCalledWith(expect.objectContaining({
+      resourceId: 'missing-partner',
+      result: 'denied',
+      details: expect.objectContaining({
+        code: 'TRUST_RESTRICTED',
+        reason: 'partner_unresolved',
+      }),
+    }));
+  });
+
   it('allows everything when trusted and writes no audit row', async () => {
     state.trustState = 'trusted';
     expect(await evaluateCapability('remote_control', { partnerId: 'p1' })).toEqual({ allow: true });
@@ -250,6 +269,23 @@ describe('evaluateCapability', () => {
     expect(audit).toHaveBeenCalledWith(expect.objectContaining({
       action: 'partner.trust.capability_denied',
       details: expect.objectContaining({ mode: 'shadow' }),
+    }));
+  });
+
+  it('shadow mode allows an unresolved partner and records the would-deny', async () => {
+    vi.mocked(partnerTrustMode).mockReturnValue('shadow');
+    vi.mocked(readTrust).mockResolvedValueOnce(null);
+
+    expect(await evaluateCapability('remote_control', { partnerId: 'missing-partner' })).toEqual({
+      allow: true,
+      shadowDenied: { code: 'TRUST_RESTRICTED', reason: 'partner_unresolved' },
+    });
+    expect(audit).toHaveBeenCalledWith(expect.objectContaining({
+      result: 'success',
+      details: expect.objectContaining({
+        mode: 'shadow',
+        reason: 'partner_unresolved',
+      }),
     }));
   });
 

--- a/apps/api/src/services/partnerTrust.ts
+++ b/apps/api/src/services/partnerTrust.ts
@@ -225,8 +225,9 @@ export async function evaluateCapability(cap: GatedCapability, ctx: GateContext)
   const mode = partnerTrustMode();
   if (mode === 'off') return { allow: true };
   const row = await readTrust(ctx.partnerId);
-  if (!row) return { allow: true };
-  const denial = decide(cap, row, ctx);
+  const denial = row
+    ? decide(cap, row, ctx)
+    : { code: 'TRUST_RESTRICTED' as const, reason: 'partner_unresolved' };
   if (!denial) return { allow: true };
   await createAuditLog({
     orgId: ctx.orgId ?? null,

--- a/apps/api/src/services/partnerTrust.ts
+++ b/apps/api/src/services/partnerTrust.ts
@@ -4,6 +4,7 @@ import type { PartnerTrustState } from '../db/schema/orgs';
 import { ANONYMOUS_ACTOR_ID } from './auditEvents';
 import { createAuditLog } from './auditService';
 import { partnerForDevice, readTrust, writeTrust } from './partnerTrust.repo';
+import { getRedis } from './redis';
 
 export type GatedCapability = 'remote_control' | 'device_execute' | 'installer_distribute' | 'agent_enroll';
 export type TrustDenyCode = 'TRUST_PROBATION' | 'TRUST_RESTRICTED';
@@ -290,6 +291,14 @@ export async function setTrustState(
 ): Promise<void> {
   const before = await readTrust(partnerId);
   await writeTrust(partnerId, next, reason, actorUserId);
+  try {
+    await getRedis()?.publish(
+      'partner-trust:changed',
+      JSON.stringify({ partnerId, trustState: next }),
+    );
+  } catch (error) {
+    console.warn('[partnerTrust] Failed to publish trust-state change:', error);
+  }
   await createAuditLog({
     orgId: null,
     actorType: actorUserId ? 'user' : 'system',

--- a/apps/api/src/services/peripheralPolicyState.test.ts
+++ b/apps/api/src/services/peripheralPolicyState.test.ts
@@ -1,13 +1,41 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { assertDeviceExecuteAllowedMock, loadEffectivePolicyMock, txMock } = vi.hoisted(() => ({
+  assertDeviceExecuteAllowedMock: vi.fn(async () => undefined),
+  loadEffectivePolicyMock: vi.fn(),
+  txMock: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withSystemDbAccessContext: vi.fn((fn: () => unknown) => fn()),
+  db: {
+    transaction: vi.fn((fn: (tx: typeof txMock) => unknown) => fn(txMock)),
+  },
+}));
+vi.mock('./peripheralEffectivePolicy', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./peripheralEffectivePolicy')>()),
+  loadAndResolveEffectivePeripheralPolicySetInCurrentDbContext: loadEffectivePolicyMock,
+}));
+vi.mock('./partnerTrust.commands', async () => ({
+  ...(await vi.importActual<typeof import('./partnerTrust.commands')>('./partnerTrust.commands')),
+  assertDeviceExecuteAllowed: assertDeviceExecuteAllowedMock,
+}));
 import {
   planPeripheralPolicyReconciliation,
   planPeripheralPolicyResult,
+  reconcilePeripheralPolicyDevice,
   type PeripheralPolicyStateSnapshot,
 } from './peripheralPolicyState';
 import type {
   PeripheralDeviceIdentity,
   PeripheralPolicyV2,
 } from './peripheralEffectivePolicy';
+import { TrustDeniedError } from './partnerTrust.commands';
 
 const identity: PeripheralDeviceIdentity = {
   deviceId: '00000000-0000-4000-8000-000000000001',
@@ -222,5 +250,73 @@ describe('planPeripheralPolicyResult', () => {
       lastErrorCode: null,
       scheduleEnforce: true,
     });
+  });
+});
+
+describe('reconcilePeripheralPolicyDevice trust gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    txMock.select
+      .mockReturnValueOnce({
+        from: () => ({
+          where: () => ({
+            limit: () => ({
+              for: () => Promise.resolve([{
+                id: identity.deviceId,
+                orgId: identity.orgId,
+                peripheralPolicyProtocolVersion: 2,
+              }]),
+            }),
+          }),
+        }),
+      })
+      .mockReturnValueOnce({
+        from: () => ({
+          where: () => ({ limit: () => ({ for: () => Promise.resolve([]) }) }),
+        }),
+      });
+    loadEffectivePolicyMock.mockResolvedValue({ identity, effectivePolicies });
+  });
+
+  it('warns and skips all writes when partner trust denies the policy push', async () => {
+    assertDeviceExecuteAllowedMock.mockRejectedValueOnce(
+      new TrustDeniedError(
+        'TRUST_PROBATION',
+        'Partner verification is required.',
+        identity.deviceId,
+        'peripheral_policy_sync_v2',
+      ),
+    );
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await expect(reconcilePeripheralPolicyDevice(identity.deviceId, 'policy_changed'))
+      .resolves.toBe('incompatible');
+
+    expect(assertDeviceExecuteAllowedMock).toHaveBeenCalledWith(
+      identity.deviceId,
+      'peripheral_policy_sync_v2',
+      null,
+    );
+    expect(txMock.insert).not.toHaveBeenCalled();
+    expect(txMock.update).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      'Skipping peripheral policy push because partner trust denied device execution',
+      { deviceId: identity.deviceId, code: 'TRUST_PROBATION' },
+    );
+    warn.mockRestore();
+  });
+
+  it('preserves the existing queued flow when partner trust allows the policy push', async () => {
+    txMock.insert
+      .mockReturnValueOnce({ values: vi.fn().mockResolvedValue(undefined) })
+      .mockReturnValueOnce({
+        values: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([{ id: 'command-1' }]) }),
+      })
+      .mockReturnValueOnce({ values: vi.fn().mockResolvedValue(undefined) });
+
+    await expect(reconcilePeripheralPolicyDevice(identity.deviceId, 'policy_changed'))
+      .resolves.toBe('queued');
+
+    expect(txMock.insert).toHaveBeenCalledTimes(3);
   });
 });

--- a/apps/api/src/services/peripheralPolicyState.ts
+++ b/apps/api/src/services/peripheralPolicyState.ts
@@ -15,6 +15,7 @@ import {
   peripheralPolicyDeliveryEvents,
   peripheralPolicyDeviceStates,
 } from '../db/schema';
+import { assertDeviceExecuteAllowed, TrustDeniedError } from './partnerTrust.commands';
 
 export type PeripheralReconcileReason =
   | 'policy_changed'
@@ -212,6 +213,17 @@ export async function reconcilePeripheralPolicyDevice(
       reason,
     });
     if (plan.kind === 'coalesced') return 'coalesced';
+
+    try {
+      await assertDeviceExecuteAllowed(deviceId, 'peripheral_policy_sync_v2', null);
+    } catch (error) {
+      if (!(error instanceof TrustDeniedError)) throw error;
+      console.warn('Skipping peripheral policy push because partner trust denied device execution', {
+        deviceId,
+        code: error.code,
+      });
+      return 'incompatible';
+    }
 
     const now = new Date(generatedAt);
     if (current) {


### PR DESCRIPTION
## Summary
Wave 3 of **Partner Trust Probation** (#4549). Stacked on W02 (#4567); GitHub retargets to `main` when W02 merges. Under `enforce`, a probation/restricted partner can no longer execute anything on a device through any path; under `off` (every self-hosted install) nothing here runs, not even a DB read.

- **`services/partnerTrust.commands.ts`** — `assertDeviceExecuteAllowed(deviceId, type, userId)`: returns immediately when the flag is `off` (no DB access), returns for lifecycle types, otherwise resolves device → partner and throws `TrustDeniedError` on deny.
- **`services/commandQueue.ts`** — `queueCommand`, `queueCommandForExecution`, `executeCommand` gated before any insert or WS dispatch; `executeCommand` returns a real `status: 'failed'` `CommandResult` carrying `error` + `trust` (review caught that the plan's legacy shape would have made backup routes treat a denial as success).
- **`routes/agentWs.ts`** — per-connection `{ ws, partnerId, trustState }` cached at connect (system context; **fails closed** to `restricted` on a null/failed lookup; under `off` no lookup at all and the socket is never closed for resolution problems). `sendCommandToAgent` stays synchronous and returns `false` for gated types on non-trusted connections so callers fall back to the gated queue; a `partner-trust:changed` Redis message (published by `setTrustState`, wrapped so Redis failure cannot fail the write) updates cached state.
- **Raw-insert sites gated** (a grep found four the plan missed): `routes/devices/commands.ts` (bulk reports per-device denials, single routes 403), `routes/devices/actuateElevation.ts`, `routes/mobile.ts`, `services/aiToolsBrowser.ts`, `jobs/pamActuationWorker.ts` (raw SQL), `services/peripheralPolicyState.ts`. `partnerTrust.sites.test.ts` pins the intentionally ungated system sites to lifecycle types (resolving `CommandTypes.X` and imported identifiers; heartbeat `filesystem_analysis` in `agents/helpers.ts` is an explicit, validated exception).
- Test hygiene: `maintenance.test.ts` orgs mock now spreads the real module (also cherry-picked to W02).

## Test plan
- [x] Full API unit suite: 1769 files pass; only the 4 `contractRenewal*.integration` cases fail, and only because a local `DATABASE_URL` makes them run (skipped in CI)
- [x] `pnpm --filter @breeze/api lint` clean; tsc clean
- [x] Every task reviewed by a fresh reviewer (Sonnet) + scoped re-review after each fix round

Closes #4552

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FAXi39eBUAUyw5j61AFFxh