### PR TITLE
fix(mobile): refresh on 401 for services that fetch outside the request core

### DIFF
--- a/apps/mobile/src/services/approvals.ts
+++ b/apps/mobile/src/services/approvals.ts
@@ -1,6 +1,6 @@
 import * as SecureStore from 'expo-secure-store';
 import { getServerUrl } from './serverConfig';
-import { fetchWithTimeout } from './fetchWithTimeout';
+import { fetchWithAuthRefresh } from './authedFetch';
 
 const FALLBACK_API_BASE_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3001';
 const PREFIX = '/api/v1/mobile/approvals';
@@ -51,10 +51,14 @@ export interface ApprovalRequest {
   createdAt: string;
 }
 
-async function authedFetch(path: string, init?: RequestInit) {
+async function authedFetch(
+  path: string,
+  init?: RequestInit,
+  opts?: { retryOnAuthFailure?: boolean }
+) {
   const token = await SecureStore.getItemAsync(TOKEN_KEY);
   const baseUrl = (await getServerUrl()) || FALLBACK_API_BASE_URL;
-  const res = await fetchWithTimeout(`${baseUrl}${path}`, {
+  const res = await fetchWithAuthRefresh(`${baseUrl}${path}`, {
     ...init,
     headers: {
       'Content-Type': 'application/json',
@@ -62,7 +66,7 @@ async function authedFetch(path: string, init?: RequestInit) {
       [CSRF_HEADER_NAME]: CSRF_HEADER_VALUE,
       ...(init?.headers ?? {}),
     },
-  });
+  }, undefined, opts);
   return res;
 }
 
@@ -98,7 +102,9 @@ export async function approveRequest(id: string, stepUp?: ApproveStepUp): Promis
   const body = stepUp && (stepUp.proof || stepUp.pin)
     ? JSON.stringify({ proof: stepUp.proof, pin: stepUp.pin })
     : undefined;
-  const res = await authedFetch(`${PREFIX}/${id}/approve`, { method: 'POST', body });
+  // A 401 on a decision is a failed step-up (see STEP_UP_FAILED below), not an
+  // expired token, so it must not be refreshed and replayed.
+  const res = await authedFetch(`${PREFIX}/${id}/approve`, { method: 'POST', body }, { retryOnAuthFailure: false });
   if (res.status === 409) throw new Error('ALREADY_DECIDED');
   if (res.status === 410) throw new Error('EXPIRED');
   if (res.status === 401) throw new Error('STEP_UP_FAILED');
@@ -111,7 +117,7 @@ export async function denyRequest(id: string, reason?: string): Promise<Approval
   const res = await authedFetch(`${PREFIX}/${id}/deny`, {
     method: 'POST',
     body: JSON.stringify({ reason }),
-  });
+  }, { retryOnAuthFailure: false });
   if (res.status === 409) throw new Error('ALREADY_DECIDED');
   if (res.status === 410) throw new Error('EXPIRED');
   if (!res.ok) throw new Error(`Deny failed: ${res.status}`);

--- a/apps/mobile/src/services/approverDevice.ts
+++ b/apps/mobile/src/services/approverDevice.ts
@@ -17,7 +17,7 @@ import * as SecureStore from 'expo-secure-store';
 import { getServerUrl } from './serverConfig';
 import { getHardwareSigner, type HardwareSigner } from './hardwareSigner';
 import { getOrCreateInstallationId } from './installationId';
-import { fetchWithTimeout } from './fetchWithTimeout';
+import { fetchWithAuthRefresh } from './authedFetch';
 
 const FALLBACK_API_BASE_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3001';
 const TOKEN_KEY = 'breeze_auth_token';
@@ -35,7 +35,7 @@ async function authedFetch(path: string, init?: RequestInit): Promise<Response> 
   const token = await SecureStore.getItemAsync(TOKEN_KEY);
   const deviceId = await getOrCreateInstallationId();
   const baseUrl = (await getServerUrl()) || FALLBACK_API_BASE_URL;
-  return fetchWithTimeout(`${baseUrl}${path}`, {
+  return fetchWithAuthRefresh(`${baseUrl}${path}`, {
     ...init,
     headers: {
       'Content-Type': 'application/json',

--- a/apps/mobile/src/services/authedFetch.test.ts
+++ b/apps/mobile/src/services/authedFetch.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fetchWithTimeout = vi.fn();
+const refreshAccessToken = vi.fn();
+vi.mock('./fetchWithTimeout', () => ({ fetchWithTimeout: (...a: unknown[]) => fetchWithTimeout(...a) }));
+vi.mock('./api', () => ({ refreshAccessToken: () => refreshAccessToken() }));
+
+import { fetchWithAuthRefresh } from './authedFetch';
+
+const res = (status: number) => ({ status, ok: status < 300 }) as Response;
+const auth = (token: string) => ({ headers: { Authorization: `Bearer ${token}`, Accept: 'application/json' } });
+
+beforeEach(() => { fetchWithTimeout.mockReset(); refreshAccessToken.mockReset(); });
+
+describe('fetchWithAuthRefresh', () => {
+  it('passes a non-401 response through untouched and never refreshes', async () => {
+    fetchWithTimeout.mockResolvedValueOnce(res(200));
+    const r = await fetchWithAuthRefresh('https://x/api/v1/systems', auth('t1'), 5000);
+    expect(r.status).toBe(200);
+    expect(refreshAccessToken).not.toHaveBeenCalled();
+    expect(fetchWithTimeout).toHaveBeenCalledWith('https://x/api/v1/systems', auth('t1'), 5000);
+  });
+
+  it('on 401 refreshes once and replays with the new bearer, keeping every other header', async () => {
+    fetchWithTimeout.mockResolvedValueOnce(res(401)).mockResolvedValueOnce(res(200));
+    refreshAccessToken.mockResolvedValueOnce('t2');
+    const r = await fetchWithAuthRefresh('https://x/api/v1/systems', { ...auth('t1'), method: 'POST', body: '{}' });
+    expect(r.status).toBe(200);
+    expect(fetchWithTimeout.mock.calls[1][1]).toEqual({
+      method: 'POST',
+      body: '{}',
+      headers: { Authorization: 'Bearer t2', Accept: 'application/json' },
+    });
+  });
+
+  it('returns the original 401 when the refresh fails, with no retry', async () => {
+    fetchWithTimeout.mockResolvedValueOnce(res(401));
+    refreshAccessToken.mockResolvedValueOnce(null);
+    const r = await fetchWithAuthRefresh('https://x/api/v1/systems', auth('t1'));
+    expect(r.status).toBe(401);
+    expect(fetchWithTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries at most once: a second 401 is returned as-is', async () => {
+    fetchWithTimeout.mockResolvedValueOnce(res(401)).mockResolvedValueOnce(res(401));
+    refreshAccessToken.mockResolvedValueOnce('t2');
+    const r = await fetchWithAuthRefresh('https://x/api/v1/systems', auth('t1'));
+    expect(r.status).toBe(401);
+    expect(refreshAccessToken).toHaveBeenCalledTimes(1);
+    expect(fetchWithTimeout).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not refresh when the request carried no bearer, or when opted out', async () => {
+    fetchWithTimeout.mockResolvedValue(res(401));
+    await fetchWithAuthRefresh('https://x/api/v1/systems', { headers: { Accept: 'application/json' } });
+    await fetchWithAuthRefresh('https://x/api/v1/approvals/1/approve', auth('t1'), undefined, { retryOnAuthFailure: false });
+    expect(refreshAccessToken).not.toHaveBeenCalled();
+    expect(fetchWithTimeout).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/mobile/src/services/authedFetch.ts
+++ b/apps/mobile/src/services/authedFetch.ts
@@ -1,0 +1,62 @@
+import { fetchWithTimeout } from './fetchWithTimeout';
+
+/**
+ * `fetchWithTimeout` for services that build their own bearer request instead
+ * of going through `coreRequest`: on a 401 it refreshes the access token once
+ * (through the app's single shared refresher) and replays the request with the
+ * new bearer, keeping every other header and the body. A second 401 is
+ * returned as-is, and so is the first when no bearer was sent, when the
+ * refresh fails, or when the caller opts out because a 401 means something
+ * else on that endpoint (step-up failure on an approval decision).
+ *
+ * Without this, these services hard-401'd from JWT_EXPIRES_IN (15 minutes)
+ * after sign-in until some coreRequest call happened to refresh the token.
+ */
+export async function fetchWithAuthRefresh(
+  url: string,
+  init: RequestInit,
+  timeoutMs?: number,
+  opts: { retryOnAuthFailure?: boolean } = {}
+): Promise<Response> {
+  const res = await fetchWithTimeout(url, init, timeoutMs);
+  if (res.status !== 401 || opts.retryOnAuthFailure === false) return res;
+  if (!readHeader(init.headers, 'Authorization')) return res;
+  // Lazy: api.ts drags react-native into the module graph, and the services
+  // that use this wrapper are node-testable precisely because they do not.
+  const { refreshAccessToken } = await import('./api');
+  const fresh = await refreshAccessToken();
+  if (!fresh) return res;
+  return fetchWithTimeout(
+    url,
+    { ...init, headers: withHeader(init.headers, 'Authorization', `Bearer ${fresh}`) },
+    timeoutMs
+  );
+}
+
+// The callers pass plain records, but RequestInit admits Headers and tuple
+// arrays too, so handle all three rather than narrowing the parameter type.
+function readHeader(headers: HeadersInit | undefined, name: string): string | null {
+  if (!headers) return null;
+  if (headers instanceof Headers) return headers.get(name);
+  if (Array.isArray(headers)) {
+    const hit = headers.find(([k]) => k.toLowerCase() === name.toLowerCase());
+    return hit ? hit[1] : null;
+  }
+  const key = Object.keys(headers).find((k) => k.toLowerCase() === name.toLowerCase());
+  return key ? headers[key] : null;
+}
+
+function withHeader(headers: HeadersInit | undefined, name: string, value: string): HeadersInit {
+  if (headers instanceof Headers) {
+    const next = new Headers(headers);
+    next.set(name, value);
+    return next;
+  }
+  if (Array.isArray(headers)) {
+    return [...headers.filter(([k]) => k.toLowerCase() !== name.toLowerCase()), [name, value]];
+  }
+  const rest = Object.fromEntries(
+    Object.entries(headers ?? {}).filter(([k]) => k.toLowerCase() !== name.toLowerCase())
+  );
+  return { ...rest, [name]: value };
+}

--- a/apps/mobile/src/services/connectedApps.ts
+++ b/apps/mobile/src/services/connectedApps.ts
@@ -3,7 +3,7 @@ import * as SecureStore from 'expo-secure-store';
 import { getServerUrl } from './serverConfig';
 import { getOrCreateInstallationId } from './installationId';
 import { MOBILE_DEVICE_ID_HEADER } from './api';
-import { fetchWithTimeout } from './fetchWithTimeout';
+import { fetchWithAuthRefresh } from './authedFetch';
 
 const FALLBACK_API_BASE_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3001';
 const TOKEN_KEY = 'breeze_auth_token';
@@ -39,7 +39,7 @@ async function call<T>(path: string, init: RequestInit = {}): Promise<T> {
     headers[CSRF_HEADER_NAME] = '1';
   }
 
-  const res = await fetchWithTimeout(`${baseUrl}/api/v1${path}`, {
+  const res = await fetchWithAuthRefresh(`${baseUrl}/api/v1${path}`, {
     ...init,
     headers,
     credentials: 'include',

--- a/apps/mobile/src/services/mobileDevices.ts
+++ b/apps/mobile/src/services/mobileDevices.ts
@@ -3,7 +3,7 @@ import * as SecureStore from 'expo-secure-store';
 import { getServerUrl } from './serverConfig';
 import { getOrCreateInstallationId } from './installationId';
 import { MOBILE_DEVICE_ID_HEADER } from './api';
-import { fetchWithTimeout } from './fetchWithTimeout';
+import { fetchWithAuthRefresh } from './authedFetch';
 
 const FALLBACK_API_BASE_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3001';
 const TOKEN_KEY = 'breeze_auth_token';
@@ -53,7 +53,7 @@ async function call<T>(path: string, init: RequestInit = {}): Promise<T> {
     headers[CSRF_HEADER_NAME] = '1';
   }
 
-  const res = await fetchWithTimeout(`${baseUrl}/api/v1${path}`, {
+  const res = await fetchWithAuthRefresh(`${baseUrl}/api/v1${path}`, {
     ...init,
     headers,
     credentials: 'include',

--- a/apps/mobile/src/services/search.ts
+++ b/apps/mobile/src/services/search.ts
@@ -1,7 +1,7 @@
 import * as SecureStore from 'expo-secure-store';
 
 import { getServerUrl } from './serverConfig';
-import { fetchWithTimeout } from './fetchWithTimeout';
+import { fetchWithAuthRefresh } from './authedFetch';
 
 const FALLBACK_API_BASE_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3001';
 const API_PREFIX = '/api/v1/mobile';
@@ -93,7 +93,7 @@ export async function searchAll(
   };
   if (token) headers['Authorization'] = `Bearer ${token}`;
 
-  const res = await fetchWithTimeout(url, {
+  const res = await fetchWithAuthRefresh(url, {
     method: 'GET',
     headers,
     credentials: 'include',

--- a/apps/mobile/src/services/systems.ts
+++ b/apps/mobile/src/services/systems.ts
@@ -1,7 +1,7 @@
 import * as SecureStore from 'expo-secure-store';
 
 import { getServerUrl } from './serverConfig';
-import { fetchWithTimeout } from './fetchWithTimeout';
+import { fetchWithAuthRefresh } from './authedFetch';
 
 const FALLBACK_API_BASE_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3001';
 const TOKEN_KEY = 'breeze_auth_token';
@@ -33,7 +33,7 @@ async function authedGet<T>(path: string, errLabel: string): Promise<T> {
     'Content-Type': 'application/json',
   };
   if (token) headers['Authorization'] = `Bearer ${token}`;
-  const res = await fetchWithTimeout(url, { headers, credentials: 'include' });
+  const res = await fetchWithAuthRefresh(url, { headers, credentials: 'include' });
   if (!res.ok) throw new Error(`${errLabel} failed: ${res.status}`);
   return res.json();
 }

--- a/apps/mobile/src/services/systemsRealtime.ts
+++ b/apps/mobile/src/services/systemsRealtime.ts
@@ -86,9 +86,8 @@ async function defaultFetchTicket(): Promise<{ ticket: string; baseUrl: string }
   // Lazy-import RN-only modules so this file is importable from a node test runner.
   const SecureStore = await import('expo-secure-store');
   const { getServerUrl } = await import('./serverConfig');
-  // fetchWithTimeout is itself RN-free, but keep it on the lazy path so this
-  // module's "no static RN-adjacent imports" rule stays a single, simple rule.
-  const { fetchWithTimeout } = await import('./fetchWithTimeout');
+  // authedFetch pulls in api.ts (RN-adjacent), so it must stay on the lazy path.
+  const { fetchWithAuthRefresh } = await import('./authedFetch');
 
   const baseUrl = (await getServerUrl()) || FALLBACK_API_BASE_URL;
   let token: string | null = null;
@@ -105,7 +104,7 @@ async function defaultFetchTicket(): Promise<{ ticket: string; baseUrl: string }
   const url = `${baseUrl}${API_CORE_PREFIX}/events/ws-ticket?allOrgs=1`;
   let res: Response;
   try {
-    res = await fetchWithTimeout(url, {
+    res = await fetchWithAuthRefresh(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary

Follow-up to #4568. That PR added refresh-and-retry to `coreRequest`, but seven services build their own bearer request with `fetchWithTimeout` and never went through it: `systems`, `systemsRealtime`, `search`, `approvals`, `approverDevice`, `mobileDevices`, `connectedApps`. Seen live on the simulator after #4568: relaunching past the 15-minute TTL refreshed `/auth/me` correctly, yet a `/mobile/*` call still returned 401 because it came from one of these. The Systems tab's "Failed to load systems data." was the same thing.

## Change

`services/authedFetch.ts` exports `fetchWithAuthRefresh`, a `fetchWithTimeout` wrapper: on a 401 with a bearer present it refreshes once through the shared refresher and replays the request with the new bearer, keeping every other header and the body. A second 401 is returned as-is, and so is the first when no bearer was sent or the refresh fails. `api.ts` is imported lazily so these services stay node-testable (their existing tests mock `fetchWithTimeout` only).

Approval decisions opt out (`retryOnAuthFailure: false`): a 401 on approve/deny is a failed step-up (`STEP_UP_FAILED`), not an expired token, and must not be replayed.

## Verification

- Red first: `authedFetch.test.ts` (pass-through, refresh and replay with headers preserved, failed refresh returns the original 401, at most one retry, no bearer or opted out never refreshes) failed on the missing module, then passed.
- `tsc --noEmit` clean; `vitest run` 94 files, 1217 tests.
- Live check on the simulator against production pending the next TTL expiry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpzNXnfbR6mdMqnMSkECPK