### PR TITLE
feat(web): warn when a portal invite could not link a contact (#3258 follow-up)

### DIFF
--- a/apps/web/src/components/settings/OrgPortalUsersEditor.test.tsx
+++ b/apps/web/src/components/settings/OrgPortalUsersEditor.test.tsx
@@ -5,6 +5,12 @@ const fetchWithAuth = vi.fn();
 vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: any[]) => fetchWithAuth(...a) }));
 vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
 
+// runAction surfaces success/warning/error toasts via showToast from ../shared/Toast.
+const showToastMock = vi.fn();
+vi.mock('../shared/Toast', () => ({
+  showToast: (...a: unknown[]) => showToastMock(...a),
+}));
+
 import OrgPortalUsersEditor from './OrgPortalUsersEditor';
 
 const ORG_ID = '7c0a1f7e-1111-4222-8333-444455556666';
@@ -52,6 +58,41 @@ describe('OrgPortalUsersEditor', () => {
       expect.objectContaining({ method: 'POST' })
     ));
   });
+
+  it('warns when the invite could not link a contact because several contacts share the address', async () => {
+    fetchWithAuth
+      .mockResolvedValueOnce(ok({ data: [] }))                                                                          // initial list
+      .mockResolvedValueOnce(ok({ data: { id: 'pu-new', email: 'new@acme.example', status: 'invited', contactLink: 'ambiguous' }, emailSent: true })) // invite
+      .mockResolvedValueOnce(ok({ data: [] }));                                                                         // reload
+    render(<OrgPortalUsersEditor orgId={ORG_ID} />);
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByTestId('portal-users-invite-open'));
+    fireEvent.change(screen.getByTestId('portal-users-invite-email'), { target: { value: 'new@acme.example' } });
+    fireEvent.click(screen.getByTestId('portal-users-invite-submit'));
+
+    await waitFor(() => expect(showToastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'warning', message: expect.stringContaining('not see tickets') })
+    ));
+    expect(showToastMock).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+  });
+
+  it.each(['created', 'linked'] as const)(
+    'does not warn when the invite contactLink is %s',
+    async (contactLink) => {
+      fetchWithAuth
+        .mockResolvedValueOnce(ok({ data: [] }))
+        .mockResolvedValueOnce(ok({ data: { id: 'pu-new', email: 'new@acme.example', status: 'invited', contactLink }, emailSent: true }))
+        .mockResolvedValueOnce(ok({ data: [] }));
+      render(<OrgPortalUsersEditor orgId={ORG_ID} />);
+      await waitFor(() => expect(fetchWithAuth).toHaveBeenCalledTimes(1));
+      fireEvent.click(screen.getByTestId('portal-users-invite-open'));
+      fireEvent.change(screen.getByTestId('portal-users-invite-email'), { target: { value: 'new@acme.example' } });
+      fireEvent.click(screen.getByTestId('portal-users-invite-submit'));
+
+      await waitFor(() => expect(showToastMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' })));
+      expect(showToastMock).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'warning' }));
+    }
+  );
 
   it('guards the invite email client-side: invalid disables Send, valid enables it', async () => {
     fetchWithAuth.mockResolvedValueOnce(ok({ data: [] }));

--- a/apps/web/src/components/settings/OrgPortalUsersEditor.tsx
+++ b/apps/web/src/components/settings/OrgPortalUsersEditor.tsx
@@ -4,6 +4,7 @@ import '@/lib/i18n';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, ActionError } from '@/lib/runAction';
+import { showToast } from '../shared/Toast';
 import { isValidEmail } from '@/lib/email';
 import { ConfirmDialog } from '../shared/ConfirmDialog';
 
@@ -64,16 +65,25 @@ export default function OrgPortalUsersEditor({ orgId }: { orgId: string }) {
   const invite = async () => {
     if (!emailValid) return;
     try {
-      await runAction({
+      const result = await runAction<{ data: { contactLink?: string } }>({
         request: () => fetchWithAuth(`${base(orgId)}/invite`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ email, name: name || undefined, message: message || undefined })
         }),
         errorFallback: t('orgPortalUsersEditor.errors.sendInvite'),
-        successMessage: t('orgPortalUsersEditor.toasts.inviteSent'),
         onUnauthorized: () => void navigateTo('/login', { replace: true })
       });
+      // 'ambiguous' means the org has several contacts sharing this email, so
+      // the invite was created with no contact link — the new login will not
+      // see tickets that person emailed in until a contact is linked by hand.
+      // A plain success toast here would hide that silently, so this one gets
+      // a warning instead of (not in addition to) the generic success toast.
+      if (result.data?.contactLink === 'ambiguous') {
+        showToast({ message: t('orgPortalUsersEditor.toasts.inviteSentAmbiguousContact'), type: 'warning' });
+      } else {
+        showToast({ message: t('orgPortalUsersEditor.toasts.inviteSent'), type: 'success' });
+      }
       setInviteOpen(false); setEmail(''); setName(''); setMessage('');
       await load();
     } catch (err) {

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -1053,6 +1053,7 @@
     },
     "toasts": {
       "inviteSent": "Einladung gesendet",
+      "inviteSentAmbiguousContact": "Einladung gesendet, aber es konnte kein Kontakt verknüpft werden – mehrere Kontakte teilen sich diese E-Mail-Adresse. Dieser Benutzer sieht keine per E-Mail eingereichten Tickets, bis ein Kontakt verknüpft ist.",
       "pendingInvited": "Eingeladene {{count}} ausstehende(r) Benutzer",
       "inviteResent": "Einladung erneut gesendet",
       "reactivated": "Benutzer reaktiviert",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -1053,6 +1053,7 @@
     },
     "toasts": {
       "inviteSent": "Invite sent",
+      "inviteSentAmbiguousContact": "Invite sent, but no contact could be linked — several contacts share this email. This user will not see tickets that were emailed in until a contact is linked.",
       "pendingInvited": "Invited {{count}} pending user(s)",
       "inviteResent": "Invite resent",
       "reactivated": "User reactivated",

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -1053,6 +1053,7 @@
     },
     "toasts": {
       "inviteSent": "Invitación enviada",
+      "inviteSentAmbiguousContact": "Invitación enviada, pero no se pudo vincular ningún contacto porque varios contactos comparten este correo electrónico. Este usuario no verá los tickets enviados por correo hasta que se vincule un contacto.",
       "pendingInvited": "Usuario(s) pendiente(s) {{count}} invitado(s)",
       "inviteResent": "invitar a resentir",
       "reactivated": "Usuario reactivado",

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -1053,6 +1053,7 @@
     },
     "toasts": {
       "inviteSent": "Invitation envoyée",
+      "inviteSentAmbiguousContact": "Invitation envoyée, mais aucun contact n'a pu être lié — plusieurs contacts partagent cette adresse courriel. Cet utilisateur ne verra pas les tickets reçus par courriel tant qu'un contact ne sera pas lié.",
       "pendingInvited": "Invité {{count}} utilisateur(s) en attente",
       "inviteResent": "Invitation résignée",
       "reactivated": "Utilisateur réactivé",

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -1053,6 +1053,7 @@
     },
     "toasts": {
       "inviteSent": "Invitation envoyée",
+      "inviteSentAmbiguousContact": "Invitation envoyée, mais aucun contact n'a pu être lié — plusieurs contacts partagent cette adresse e-mail. Cet utilisateur ne verra pas les tickets reçus par e-mail tant qu'un contact ne sera pas lié.",
       "pendingInvited": "Invité {{count}} utilisateur(s) en attente",
       "inviteResent": "Invitation résignée",
       "reactivated": "Utilisateur réactivé",

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -1053,6 +1053,7 @@
     },
     "toasts": {
       "inviteSent": "Invito inviato",
+      "inviteSentAmbiguousContact": "Invito inviato, ma non è stato possibile collegare alcun contatto: più contatti condividono questo indirizzo email. Questo utente non vedrà i ticket ricevuti via email finché non verrà collegato un contatto.",
       "pendingInvited": "Invitati {{count}} utenti in sospeso",
       "inviteResent": "Invito reinviato",
       "reactivated": "Utente riattivato",

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -1053,6 +1053,7 @@
     },
     "toasts": {
       "inviteSent": "Convite enviado",
+      "inviteSentAmbiguousContact": "Convite enviado, mas nenhum contato pôde ser vinculado — vários contatos compartilham este e-mail. Este usuário não verá os tickets recebidos por e-mail até que um contato seja vinculado.",
       "pendingInvited": "{{count}} usuário(s) pendente(s) convidado(s)",
       "inviteResent": "Convite reenviado",
       "reactivated": "Usuário reativado",

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -1053,6 +1053,7 @@
     },
     "toasts": {
       "inviteSent": "Davet gönderildi",
+      "inviteSentAmbiguousContact": "Davet gönderildi, ancak birden fazla kişi bu e-posta adresini paylaştığı için hiçbir kişi bağlanamadı. Bir kişi bağlanana kadar bu kullanıcı e-posta yoluyla gelen talepleri göremeyecek.",
       "pendingInvited": "Davet edildi {{count}} bekleyen kullanıcı(lar)",
       "inviteResent": "Yeniden davet et",
       "reactivated": "Kullanıcı yeniden etkinleştirildi",


### PR DESCRIPTION
## What this adds
`POST /orgs/organizations/:id/portal-users/invite` (added in PR #4557) returns `contactLink: 'linked' | 'created' | 'ambiguous' | 'kept'`. `ambiguous` means several contacts in the org share the invited email, so the new portal login was created with no contact link — and a login without a link will not see tickets that person emailed in (`submitted_by = me OR requester_contact_id = my contact`).

Previously the web invite flow showed a plain "Invite sent" success toast regardless of `contactLink`, silently hiding this case. Now:
- `contactLink === 'ambiguous'` shows a **warning** toast: "Invite sent, but no contact could be linked — several contacts share this email. This user will not see tickets that were emailed in until a contact is linked." (translated in all 8 locales)
- any other `contactLink` value keeps the existing plain success toast

No UI exists yet to link a contact by hand, so the copy intentionally does not point at one.

## Tests
- `apps/web/src/components/settings/OrgPortalUsersEditor.test.tsx`: red-first — added a test asserting a warning toast with the translated copy on `contactLink: 'ambiguous'` (failed before the implementation, confirming the assertion discriminates), plus a parametrized test confirming no warning fires for `'created'`/`'linked'`.
- `cd apps/web && npx vitest run src/components/settings/OrgPortalUsersEditor.test.tsx` → 8/8 pass
- `cd apps/web && npx vitest run src/lib/i18n src/lib/__tests__/no-silent-mutations.test.ts` → 263/263 pass (localeParity, translationCoverage, keyUsage, extractionQuality, terminologyQuality all green — no new English-duplicate translations introduced)
- `cd apps/web && npx eslint src/components/settings/OrgPortalUsersEditor.tsx src/components/settings/OrgPortalUsersEditor.test.tsx` → clean
- `cd apps/web && npx tsc --noEmit` → clean

Refs #3258

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015tHmJsqrTy5iHcqgpadtMp
