### PR TITLE
fix(agent): treat a never-provisioned elevation account as clean in PAM cleanup (#4587)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1320,11 +1320,26 @@ jobs:
       # sessionbroker. Note the #3007 bug itself was NOT a data race — sendSeq
       # was already atomic — so -race would not have caught it; the regression
       # test asserts receiver-visible ordering instead.
+      #
+      # ./internal/elevaccount is the fourth instance of the eventlog/logging
+      # gap, found by #4587: the whole package is netapi32 account lifecycle
+      # behind //go:build windows, and the only Windows-tagged test it had was
+      # a compile-time interface assertion that no job ran. The bug it shipped
+      # was precisely a netapi32 status code the Windows-only code mishandled
+      # (NERR_UserNotFound on an account that was never provisioned, which is
+      # the DEFAULT state of every agent that never enabled PAM), so a gate
+      # that never executes on Windows could not have caught it and cannot
+      # catch the next one. Verified the same way as logging and ipc: with
+      # GOOS=windows GOARCH=amd64 CGO_ENABLED=0 the package vets, its test
+      # binary compiles, and its Windows dependency graph contains no
+      # remote/desktop and no cgo. Its two behavioural tests assert against the
+      # real netapi32 and skip loudly, rather than pass, on a host where
+      # ~breeze_elev exists or local-account queries are not permitted.
       - name: Run Windows Go tests
         working-directory: agent
         env:
           CGO_ENABLED: "0"
-        run: go test ./internal/sessionbroker ./internal/eventlog ./internal/ipc ./internal/logging ./internal/state ./internal/watchdog ./internal/backup/vss ./cmd/breeze-watchdog
+        run: go test ./internal/sessionbroker ./internal/eventlog ./internal/elevaccount ./internal/ipc ./internal/logging ./internal/state ./internal/watchdog ./internal/backup/vss ./cmd/breeze-watchdog
 
       # Software inventory has platform-specific registry behavior. Keep this
       # filtered until the inherited Windows package backlog in #2523 is green,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1341,6 +1341,30 @@ jobs:
           CGO_ENABLED: "0"
         run: go test ./internal/sessionbroker ./internal/eventlog ./internal/elevaccount ./internal/ipc ./internal/logging ./internal/state ./internal/watchdog ./internal/backup/vss ./cmd/breeze-watchdog
 
+      # The step above runs without -v, so a t.Skip is indistinguishable from a
+      # pass in its output. That matters here more than usual: elevaccount's two
+      # behavioural tests are the ONLY live-syscall coverage anywhere of the
+      # #4587 fix, and they skip by design when ~breeze_elev already exists or
+      # when local-account queries are refused. A silent skip would leave the
+      # real netapi32 path — the actual blast radius of the bug — with zero
+      # coverage while CI stayed green, which is the same vacuous-gate failure
+      # the collectors and backup steps below already guard against. Assert both
+      # actually PASSED.
+      - name: Run Windows elevation-account absence tests (must not skip)
+        working-directory: agent
+        env:
+          CGO_ENABLED: "0"
+        shell: pwsh
+        run: |
+          $out = go test ./internal/elevaccount -run '^Test(VerifyClean|Deprovision)TreatsAbsentAccountAsClean$' -v 2>&1
+          $exit = $LASTEXITCODE
+          $out | ForEach-Object { Write-Host $_ }
+          if ($exit -ne 0) { throw "go test failed (exit $exit)" }
+          $passes = @($out | Select-String -Pattern '^--- PASS: Test').Count
+          $skips = @($out | Select-String -Pattern '^--- SKIP: Test').Count
+          if ($skips -ne 0) { throw "$skips of the absent-account tests SKIPPED - the runner could not reach the never-provisioned state they assert against, so the #4587 netapi32 fix has no live coverage here" }
+          if ($passes -ne 2) { throw "expected exactly 2 top-level PASS lines, got $passes - a test in the -run filter was renamed, removed, or added without updating this count" }
+
       # Software inventory has platform-specific registry behavior. Keep this
       # filtered until the inherited Windows package backlog in #2523 is green,
       # and count PASS lines so a rename cannot turn the gate vacuously green.

--- a/agent/internal/elevaccount/absent.go
+++ b/agent/internal/elevaccount/absent.go
@@ -2,6 +2,7 @@ package elevaccount
 
 import (
 	"errors"
+	"fmt"
 	"syscall"
 )
 
@@ -36,22 +37,50 @@ const (
 // agent re-ran the same cleanup and logged the same ERROR on every heartbeat.
 //
 // Only the two "no such account" statuses match. Every other status — access
-// denied, a locked SAM, an unreachable computer — stays a real error so
-// genuine cleanup failures keep failing closed. The status has to arrive as a
-// wrapped syscall.Errno, which is how the netapi32 and LSA wrappers report it;
-// it is never scraped out of the message text.
+// denied, a locked SAM, an invalid computer name — stays a real error so
+// genuine cleanup failures keep failing closed. The status has to arrive as,
+// or unwrap to, a syscall.Errno, which is how the netapi32 and LSA wrappers
+// report it; it is never scraped out of the message text.
+//
+// This is a classifier for ONE call's status, and callers must treat it that
+// way. It says nothing about which account the call was about, so it is only
+// meaningful applied to a call that names the elevation account. Aggregate
+// callers, which see a single error out of a sequence of syscalls, must use
+// errAccountAbsent instead — see cleanIfAbsent.
 func IsAccountAbsent(err error) bool {
 	return errors.Is(err, syscall.Errno(nerrUserNotFound)) ||
 		errors.Is(err, syscall.Errno(errorNoneMapped))
 }
 
+// errAccountAbsent marks an error as proof that the ELEVATION ACCOUNT itself
+// does not exist. Only a probe may attach it, and only from the one syscall in
+// that probe which names the account.
+//
+// The distinction is not pedantic. A probe runs more than one lookup, and the
+// others are about different principals entirely: accountInAdministrators and
+// localGroupMembersCall both resolve the builtin Administrators alias
+// (S-1-5-32-544) first, and that lookup can fail with the very same
+// ERROR_NONE_MAPPED. Matching the status code at the aggregate level would
+// read "the machine cannot resolve its own Administrators group" as "the
+// elevation account is absent, everything is clean" — inverting a security
+// check on the strength of an unrelated failure.
+var errAccountAbsent = errors.New("elevation account does not exist")
+
+// absentAccountErr tags a probe failure as proof of absence. Call it ONLY for
+// the status of a syscall that named the elevation account.
+func absentAccountErr(err error) error {
+	return fmt.Errorf("%w: %w", errAccountAbsent, err)
+}
+
 // cleanIfAbsent decides what a FAILED account probe means for the caller.
 //
-// When the failure means the account does not exist, that is positive proof of
-// a clean state rather than a cleanup failure, so it yields clean evidence and
-// no error. Every other failure is passed through untouched.
+// When the failure is tagged as the account being absent, that is positive
+// proof of a clean state rather than a cleanup failure, so it yields clean
+// evidence and no error. Every other failure is passed through untouched —
+// including a raw ERROR_NONE_MAPPED from some other principal's lookup, which
+// is exactly what this must not mistake for absence.
 //
-// All four probe sites in Deprovision and VerifyClean route through this one
+// Each probe site in Deprovision and VerifyClean routes through this one
 // function so the tolerance is defined — and tested — in a single place. Only
 // the first probe in each of those functions is reachable in the
 // never-provisioned case that motivated it, so per-site copies of this
@@ -62,9 +91,31 @@ func cleanIfAbsent(err error) (AccountEvidence, error) {
 		// Misuse: this helper interprets a failure, so a nil error here means
 		// a caller is about to claim a clean account it never probed.
 		return AccountEvidence{}, errors.New("elevaccount: cleanIfAbsent called without a probe failure")
-	case IsAccountAbsent(err):
+	case errors.Is(err, errAccountAbsent):
 		return AccountEvidence{Enabled: false, InAdministrators: false}, nil
 	default:
 		return AccountEvidence{}, err
+	}
+}
+
+// evidenceAfterAdminProbe decides VerifyClean's outcome once the account's
+// enabled state has already been MEASURED and the Administrators probe has
+// reported. It lives here, untagged, so both of its failure branches are unit
+// tested: on a never-provisioned host the first probe always fails first, so a
+// copy of this decision inlined in the Windows-only VerifyClean would ship
+// unexercised.
+func evidenceAfterAdminProbe(enabled, inAdministrators bool, err error) (AccountEvidence, error) {
+	switch {
+	case err == nil:
+		return AccountEvidence{Enabled: enabled, InAdministrators: inAdministrators}, nil
+	case enabled && errors.Is(err, errAccountAbsent):
+		// NetUserGetInfo just measured this account as ENABLED and the very
+		// next call says it does not exist. One of the two is wrong, so
+		// nothing here is proven: never discard a measured "enabled" in favour
+		// of clean evidence.
+		return AccountEvidence{}, fmt.Errorf(
+			"contradictory evidence for %s: measured enabled, then reported absent: %w", AccountName, err)
+	default:
+		return cleanIfAbsent(err)
 	}
 }

--- a/agent/internal/elevaccount/absent.go
+++ b/agent/internal/elevaccount/absent.go
@@ -44,3 +44,27 @@ func IsAccountAbsent(err error) bool {
 	return errors.Is(err, syscall.Errno(nerrUserNotFound)) ||
 		errors.Is(err, syscall.Errno(errorNoneMapped))
 }
+
+// cleanIfAbsent decides what a FAILED account probe means for the caller.
+//
+// When the failure means the account does not exist, that is positive proof of
+// a clean state rather than a cleanup failure, so it yields clean evidence and
+// no error. Every other failure is passed through untouched.
+//
+// All four probe sites in Deprovision and VerifyClean route through this one
+// function so the tolerance is defined — and tested — in a single place. Only
+// the first probe in each of those functions is reachable in the
+// never-provisioned case that motivated it, so per-site copies of this
+// decision would ship unexercised.
+func cleanIfAbsent(err error) (AccountEvidence, error) {
+	switch {
+	case err == nil:
+		// Misuse: this helper interprets a failure, so a nil error here means
+		// a caller is about to claim a clean account it never probed.
+		return AccountEvidence{}, errors.New("elevaccount: cleanIfAbsent called without a probe failure")
+	case IsAccountAbsent(err):
+		return AccountEvidence{Enabled: false, InAdministrators: false}, nil
+	default:
+		return AccountEvidence{}, err
+	}
+}

--- a/agent/internal/elevaccount/absent.go
+++ b/agent/internal/elevaccount/absent.go
@@ -1,0 +1,46 @@
+package elevaccount
+
+import (
+	"errors"
+	"syscall"
+)
+
+// Windows status codes meaning "the named local account does not exist on this
+// host". They live in this untagged file, rather than beside the other
+// netapi32 constants in elevaccount_windows.go, so that IsAccountAbsent is
+// compiled and unit tested on every platform: the classification below decides
+// whether the agent reports a PAM cleanup failure, and it is worth more
+// coverage than the Windows-only build of this package currently gets.
+// absent_windows_test.go asserts errorNoneMapped still matches x/sys/windows.
+const (
+	// nerrUserNotFound is netapi32's NERR_UserNotFound. NetUserSetInfo,
+	// NetUserGetInfo and NetUserGetLocalGroups all return it when the local
+	// account named in the call does not exist.
+	nerrUserNotFound = 2221
+
+	// errorNoneMapped is ERROR_NONE_MAPPED, returned by the LSA account-name
+	// lookup behind windows.LookupSID when a name maps to no SID at all.
+	errorNoneMapped = 1332
+)
+
+// IsAccountAbsent reports whether err means the dormant elevation account
+// (~breeze_elev) does not exist on this host.
+//
+// That is the default state: the account is only provisioned when PAM is
+// enabled, so on the majority of the fleet it was never created. An account
+// that does not exist is provably not enabled, provably not a member of
+// Administrators, and provably has no process holding a token for it, so the
+// cleanup and verification paths treat this as "already clean" rather than as
+// a failure. Reporting it as a failure is issue #4587: the PAM lifecycle
+// manager only clears its enabled flag on success, so a never-provisioned
+// agent re-ran the same cleanup and logged the same ERROR on every heartbeat.
+//
+// Only the two "no such account" statuses match. Every other status — access
+// denied, a locked SAM, an unreachable computer — stays a real error so
+// genuine cleanup failures keep failing closed. The status has to arrive as a
+// wrapped syscall.Errno, which is how the netapi32 and LSA wrappers report it;
+// it is never scraped out of the message text.
+func IsAccountAbsent(err error) bool {
+	return errors.Is(err, syscall.Errno(nerrUserNotFound)) ||
+		errors.Is(err, syscall.Errno(errorNoneMapped))
+}

--- a/agent/internal/elevaccount/absent_test.go
+++ b/agent/internal/elevaccount/absent_test.go
@@ -13,6 +13,10 @@ import (
 // wrap shapes verbatim so IsAccountAbsent is exercised against the exact error
 // values Deprovision, VerifyClean and VerifyNoPrivilegedToken see in the
 // field, rather than against a bare errno the production path never returns.
+// adminAliasSIDForTest mirrors the windows-only adminAliasSID constant, which
+// an untagged test file cannot reference.
+const adminAliasSIDForTest = "S-1-5-32-544"
+
 func wrappedSetInfoErr(status uint32) error {
 	return fmt.Errorf("NetUserSetInfo level %d failed: %w", 1003, syscall.Errno(status))
 }
@@ -87,7 +91,7 @@ func TestIsAccountAbsentClassifiesOnlyMissingAccountStatuses(t *testing.T) {
 // shipping unverified.
 func TestCleanIfAbsentConvertsOnlyAbsenceIntoCleanEvidence(t *testing.T) {
 	t.Run("absent account becomes clean evidence", func(t *testing.T) {
-		evidence, err := cleanIfAbsent(wrappedSetInfoErr(nerrUserNotFound))
+		evidence, err := cleanIfAbsent(absentAccountErr(wrappedSetInfoErr(nerrUserNotFound)))
 		if err != nil {
 			t.Fatalf("cleanIfAbsent(absent) error = %v, want nil", err)
 		}
@@ -97,7 +101,7 @@ func TestCleanIfAbsentConvertsOnlyAbsenceIntoCleanEvidence(t *testing.T) {
 	})
 
 	t.Run("unresolvable name becomes clean evidence", func(t *testing.T) {
-		evidence, err := cleanIfAbsent(syscall.Errno(errorNoneMapped))
+		evidence, err := cleanIfAbsent(absentAccountErr(syscall.Errno(errorNoneMapped)))
 		if err != nil {
 			t.Fatalf("cleanIfAbsent(none mapped) error = %v, want nil", err)
 		}
@@ -129,6 +133,88 @@ func TestCleanIfAbsentConvertsOnlyAbsenceIntoCleanEvidence(t *testing.T) {
 		evidence, err := cleanIfAbsent(nil)
 		if err == nil {
 			t.Fatalf("cleanIfAbsent(nil) returned evidence %+v and no error; it must not invent a clean result", evidence)
+		}
+	})
+}
+
+// TestCleanIfAbsentIgnoresAbsenceStatusesFromOtherPrincipals is the regression
+// test for the review finding that motivated errAccountAbsent. Both
+// accountInAdministrators and localGroupMembersCall resolve the builtin
+// Administrators alias (S-1-5-32-544) BEFORE they touch the elevation account,
+// and that lookup fails with the very same ERROR_NONE_MAPPED. Classifying on
+// the status code alone would read "this machine cannot resolve its own
+// Administrators group" as "the elevation account is absent, all clean" —
+// inverting the security check on an unrelated failure.
+func TestCleanIfAbsentIgnoresAbsenceStatusesFromOtherPrincipals(t *testing.T) {
+	aliasLookupFailures := []error{
+		// What administratorsGroupName() returns: a bare errno from
+		// LookupAccountSid on the builtin alias, untagged by any probe.
+		syscall.Errno(errorNoneMapped),
+		fmt.Errorf("LookupAccountSid %s: %w", adminAliasSIDForTest, syscall.Errno(errorNoneMapped)),
+		syscall.Errno(nerrUserNotFound),
+	}
+
+	for _, aliasErr := range aliasLookupFailures {
+		evidence, err := cleanIfAbsent(aliasErr)
+		if err == nil {
+			t.Fatalf("cleanIfAbsent(%v) returned evidence %+v and no error; an alias-lookup failure is not proof the elevation account is absent", aliasErr, evidence)
+		}
+		if !errors.Is(err, aliasErr) {
+			t.Fatalf("cleanIfAbsent(%v) error = %v, want the original failure passed through", aliasErr, err)
+		}
+		if evidence != (AccountEvidence{}) {
+			t.Fatalf("cleanIfAbsent(%v) evidence = %+v, want zero evidence", aliasErr, evidence)
+		}
+	}
+
+	// The identical status IS absence once the probe that named the account
+	// tags it. Same errno, opposite meaning — which is the whole point.
+	if _, err := cleanIfAbsent(absentAccountErr(syscall.Errno(errorNoneMapped))); err != nil {
+		t.Fatalf("cleanIfAbsent(tagged absence) = %v, want nil", err)
+	}
+}
+
+// TestEvidenceAfterAdminProbeNeverDiscardsAMeasuredEnabledAccount covers the
+// second VerifyClean probe, which is unreachable on a never-provisioned host
+// because the first probe fails first.
+func TestEvidenceAfterAdminProbeNeverDiscardsAMeasuredEnabledAccount(t *testing.T) {
+	t.Run("both probes succeeded", func(t *testing.T) {
+		evidence, err := evidenceAfterAdminProbe(true, true, nil)
+		if err != nil {
+			t.Fatalf("error = %v, want nil", err)
+		}
+		if !evidence.Enabled || !evidence.InAdministrators {
+			t.Fatalf("evidence = %+v, want the measured values preserved", evidence)
+		}
+	})
+
+	t.Run("disabled account reported absent is clean", func(t *testing.T) {
+		evidence, err := evidenceAfterAdminProbe(false, false, absentAccountErr(syscall.Errno(nerrUserNotFound)))
+		if err != nil {
+			t.Fatalf("error = %v, want nil", err)
+		}
+		if evidence.Enabled || evidence.InAdministrators {
+			t.Fatalf("evidence = %+v, want both false", evidence)
+		}
+	})
+
+	// The contradiction: NetUserGetInfo measured the account ENABLED, then the
+	// next call says it does not exist. Returning clean evidence here would
+	// throw away the one measurement that says the account is dangerous.
+	t.Run("enabled account reported absent fails closed", func(t *testing.T) {
+		evidence, err := evidenceAfterAdminProbe(true, false, absentAccountErr(syscall.Errno(nerrUserNotFound)))
+		if err == nil {
+			t.Fatalf("returned evidence %+v and no error; a measured enabled account must never be discarded as clean", evidence)
+		}
+		if evidence != (AccountEvidence{}) {
+			t.Fatalf("evidence = %+v, want zero evidence alongside the error", evidence)
+		}
+	})
+
+	t.Run("alias lookup failure propagates even when disabled", func(t *testing.T) {
+		aliasErr := syscall.Errno(errorNoneMapped)
+		if _, err := evidenceAfterAdminProbe(false, false, aliasErr); !errors.Is(err, aliasErr) {
+			t.Fatalf("error = %v, want the alias-lookup failure passed through", err)
 		}
 	})
 }

--- a/agent/internal/elevaccount/absent_test.go
+++ b/agent/internal/elevaccount/absent_test.go
@@ -79,3 +79,56 @@ func TestIsAccountAbsentClassifiesOnlyMissingAccountStatuses(t *testing.T) {
 		})
 	}
 }
+
+// TestCleanIfAbsentConvertsOnlyAbsenceIntoCleanEvidence covers the decision
+// every probe site in Deprovision and VerifyClean delegates to. Only the first
+// probe in each of those functions is reachable on a never-provisioned host,
+// so exercising the shared helper here is what keeps the later sites from
+// shipping unverified.
+func TestCleanIfAbsentConvertsOnlyAbsenceIntoCleanEvidence(t *testing.T) {
+	t.Run("absent account becomes clean evidence", func(t *testing.T) {
+		evidence, err := cleanIfAbsent(wrappedSetInfoErr(nerrUserNotFound))
+		if err != nil {
+			t.Fatalf("cleanIfAbsent(absent) error = %v, want nil", err)
+		}
+		if evidence.Enabled || evidence.InAdministrators {
+			t.Fatalf("cleanIfAbsent(absent) evidence = %+v, want both false", evidence)
+		}
+	})
+
+	t.Run("unresolvable name becomes clean evidence", func(t *testing.T) {
+		evidence, err := cleanIfAbsent(syscall.Errno(errorNoneMapped))
+		if err != nil {
+			t.Fatalf("cleanIfAbsent(none mapped) error = %v, want nil", err)
+		}
+		if evidence.Enabled || evidence.InAdministrators {
+			t.Fatalf("cleanIfAbsent(none mapped) evidence = %+v, want both false", evidence)
+		}
+	})
+
+	t.Run("every other failure passes through unchanged", func(t *testing.T) {
+		for _, probeErr := range []error{
+			wrappedSetInfoErr(5),    // ERROR_ACCESS_DENIED
+			wrappedGetInfoErr(2224), // NERR_UserExists
+			errors.New("SAM database is locked"),
+		} {
+			evidence, err := cleanIfAbsent(probeErr)
+			if !errors.Is(err, probeErr) {
+				t.Fatalf("cleanIfAbsent(%v) error = %v, want the original failure", probeErr, err)
+			}
+			if evidence != (AccountEvidence{}) {
+				t.Fatalf("cleanIfAbsent(%v) evidence = %+v, want zero evidence alongside a real error", probeErr, evidence)
+			}
+		}
+	})
+
+	// Misuse must fail closed rather than manufacture a clean result: this
+	// helper interprets a failure, so a nil error means the caller is about to
+	// claim an account state it never probed.
+	t.Run("nil probe failure is refused", func(t *testing.T) {
+		evidence, err := cleanIfAbsent(nil)
+		if err == nil {
+			t.Fatalf("cleanIfAbsent(nil) returned evidence %+v and no error; it must not invent a clean result", evidence)
+		}
+	})
+}

--- a/agent/internal/elevaccount/absent_test.go
+++ b/agent/internal/elevaccount/absent_test.go
@@ -1,0 +1,81 @@
+package elevaccount
+
+import (
+	"errors"
+	"fmt"
+	"syscall"
+	"testing"
+)
+
+// The netapi32 and LSA wrappers in elevaccount_windows.go and
+// pamlifetime/job_windows.go all report a failed status as
+// fmt.Errorf(..., %w, syscall.Errno(status)). These helpers reproduce those
+// wrap shapes verbatim so IsAccountAbsent is exercised against the exact error
+// values Deprovision, VerifyClean and VerifyNoPrivilegedToken see in the
+// field, rather than against a bare errno the production path never returns.
+func wrappedSetInfoErr(status uint32) error {
+	return fmt.Errorf("NetUserSetInfo level %d failed: %w", 1003, syscall.Errno(status))
+}
+
+func wrappedGetInfoErr(status uint32) error {
+	return fmt.Errorf("NetUserGetInfo %s failed: %w", AccountName, syscall.Errno(status))
+}
+
+func wrappedLocalGroupsErr(status uint32) error {
+	return fmt.Errorf("NetUserGetLocalGroups %s failed: %w", AccountName, syscall.Errno(status))
+}
+
+// TestIsAccountAbsentClassifiesOnlyMissingAccountStatuses pins the classifier
+// behind issue #4587. On a Windows deployment that never enabled PAM the
+// dormant ~breeze_elev account was never created, so every netapi32 call that
+// names it fails with NERR_UserNotFound and every LSA name lookup fails with
+// ERROR_NONE_MAPPED. Those two statuses mean "the account does not exist",
+// which is provably clean; every other status is a real failure and must keep
+// failing closed.
+func TestIsAccountAbsentClassifiesOnlyMissingAccountStatuses(t *testing.T) {
+	const (
+		nerrSuccessStatus     = 0    // NERR_Success
+		accessDeniedStatus    = 5    // ERROR_ACCESS_DENIED
+		nerrUserExistsStatus  = 2224 // NERR_UserExists
+		nerrNotInGroupStatus  = 2237 // NERR_UserNotInGroup
+		invalidComputerStatus = 2351 // NERR_InvalidComputer
+	)
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"NetUserSetInfo user not found", wrappedSetInfoErr(nerrUserNotFound), true},
+		{"NetUserGetInfo user not found", wrappedGetInfoErr(nerrUserNotFound), true},
+		{"NetUserGetLocalGroups user not found", wrappedLocalGroupsErr(nerrUserNotFound), true},
+		{"LookupSID none mapped", fmt.Errorf("lookup %s: %w", AccountName, syscall.Errno(errorNoneMapped)), true},
+		{"bare NERR_UserNotFound", syscall.Errno(nerrUserNotFound), true},
+		{"bare ERROR_NONE_MAPPED", syscall.Errno(errorNoneMapped), true},
+		{"wrapped twice", fmt.Errorf("verify account clean: %w", wrappedSetInfoErr(nerrUserNotFound)), true},
+
+		{"nil", nil, false},
+		{"access denied", wrappedSetInfoErr(accessDeniedStatus), false},
+		{"success status", wrappedSetInfoErr(nerrSuccessStatus), false},
+		{"user already exists", wrappedSetInfoErr(nerrUserExistsStatus), false},
+		{"user not in group", wrappedSetInfoErr(nerrNotInGroupStatus), false},
+		{"invalid computer", wrappedSetInfoErr(invalidComputerStatus), false},
+		{"one below user not found", wrappedSetInfoErr(nerrUserNotFound - 1), false},
+		{"one above user not found", wrappedSetInfoErr(nerrUserNotFound + 1), false},
+		{"one below none mapped", wrappedSetInfoErr(errorNoneMapped - 1), false},
+		{"one above none mapped", wrappedSetInfoErr(errorNoneMapped + 1), false},
+		// The status must be carried as a wrapped errno, never scraped out of
+		// the message text: a real failure whose text happens to contain 2221
+		// (a PID, a byte count) must not be read as a missing account.
+		{"status only in message text", errors.New("NetUserSetInfo level 1003 failed: 2221"), false},
+		{"wrapped non-errno error", fmt.Errorf("deprovision: %w", errors.New("ledger unavailable")), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsAccountAbsent(tt.err); got != tt.want {
+				t.Fatalf("IsAccountAbsent(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/agent/internal/elevaccount/absent_windows_test.go
+++ b/agent/internal/elevaccount/absent_windows_test.go
@@ -1,0 +1,68 @@
+//go:build windows
+
+package elevaccount
+
+import (
+	"context"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+// TestAbsentStatusCodesMatchWin32 keeps the platform-independent copies in
+// absent.go honest. absent.go carries the numeric statuses so the classifier
+// can be unit tested on every platform, which means it cannot reference
+// x/sys/windows; this is the only place the two can be compared.
+func TestAbsentStatusCodesMatchWin32(t *testing.T) {
+	if got := uint32(windows.ERROR_NONE_MAPPED); got != errorNoneMapped {
+		t.Fatalf("errorNoneMapped = %d, but windows.ERROR_NONE_MAPPED = %d", errorNoneMapped, got)
+	}
+}
+
+// requireAbsentElevationAccount asserts the precondition the tests below need:
+// ~breeze_elev does not exist on this host. That is the state of every machine
+// that has never enabled PAM, including a CI runner, and it is the state
+// issue #4587 was reported against.
+func requireAbsentElevationAccount(t *testing.T) {
+	t.Helper()
+	_, err := accountEnabled(AccountName)
+	if err == nil {
+		t.Skipf("%s exists on this host; these tests only cover the never-provisioned case", AccountName)
+	}
+	if !IsAccountAbsent(err) {
+		t.Skipf("cannot confirm %s is absent (NetUserGetInfo: %v); needs a host where querying local accounts is permitted", AccountName, err)
+	}
+}
+
+// TestVerifyCleanTreatsAbsentAccountAsClean exercises the real netapi32 path
+// behind issue #4587. An account that was never created is provably not
+// enabled and provably not in Administrators, so VerifyClean must report clean
+// evidence rather than NERR_UserNotFound. Before the fix this returned
+// "NetUserGetInfo ~breeze_elev failed: 2221", which the PAM lifecycle manager
+// turned into an ERROR log line on every single heartbeat.
+func TestVerifyCleanTreatsAbsentAccountAsClean(t *testing.T) {
+	requireAbsentElevationAccount(t)
+
+	evidence, err := NewVerified().VerifyClean(context.Background())
+	if err != nil {
+		t.Fatalf("VerifyClean on an absent account = %v, want nil", err)
+	}
+	if evidence.Enabled || evidence.InAdministrators {
+		t.Fatalf("VerifyClean evidence = %+v, want both false for an account that does not exist", evidence)
+	}
+}
+
+// TestDeprovisionTreatsAbsentAccountAsClean covers the other half. The call is
+// non-destructive here precisely because the account is absent: the first
+// netapi32 write reports NERR_UserNotFound and nothing is modified.
+func TestDeprovisionTreatsAbsentAccountAsClean(t *testing.T) {
+	requireAbsentElevationAccount(t)
+
+	evidence, err := NewVerified().Deprovision(context.Background())
+	if err != nil {
+		t.Fatalf("Deprovision on an absent account = %v, want nil", err)
+	}
+	if evidence.Enabled || evidence.InAdministrators {
+		t.Fatalf("Deprovision evidence = %+v, want both false for an account that does not exist", evidence)
+	}
+}

--- a/agent/internal/elevaccount/elevaccount_windows.go
+++ b/agent/internal/elevaccount/elevaccount_windows.go
@@ -4,7 +4,6 @@ package elevaccount
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"syscall"
@@ -47,9 +46,9 @@ const (
 	accountEnabledFlags  = ufNormalAccount | ufPasswdCantChange | ufDontExpirePassword
 
 	nerrSuccess        = 0
-	nerrUserNotFound   = 2221
 	nerrUserExists     = 2224
 	nerrUserNotInGroup = 2237
+	// nerrUserNotFound lives in absent.go alongside IsAccountAbsent.
 
 	errorMemberInAlias    = 1378
 	errorMemberNotInAlias = 1377
@@ -147,6 +146,12 @@ func (*windowsManager) Demote(ctx context.Context) error {
 	return err
 }
 
+// absentAccountEvidence is what an account that does not exist proves: it
+// cannot be enabled and it cannot be in Administrators. See IsAccountAbsent.
+func absentAccountEvidence() AccountEvidence {
+	return AccountEvidence{Enabled: false, InAdministrators: false}
+}
+
 func (*windowsManager) Deprovision(ctx context.Context) (AccountEvidence, error) {
 	if err := ctx.Err(); err != nil {
 		return AccountEvidence{}, err
@@ -156,11 +161,15 @@ func (*windowsManager) Deprovision(ctx context.Context) (AccountEvidence, error)
 		return AccountEvidence{}, err
 	}
 	if err := setPassword(AccountName, password); err != nil {
+		if IsAccountAbsent(err) {
+			return absentAccountEvidence(), nil
+		}
 		return AccountEvidence{}, err
 	}
 	if err := ctx.Err(); err != nil {
 		return AccountEvidence{}, err
 	}
+	// removeFromAdministrators already maps an absent account to nil.
 	if err := removeFromAdministrators(AccountName); err != nil {
 		return AccountEvidence{}, err
 	}
@@ -168,6 +177,9 @@ func (*windowsManager) Deprovision(ctx context.Context) (AccountEvidence, error)
 		return AccountEvidence{}, err
 	}
 	if err := setUserFlags(AccountName, accountDisabledFlags); err != nil {
+		if IsAccountAbsent(err) {
+			return absentAccountEvidence(), nil
+		}
 		return AccountEvidence{}, err
 	}
 	return (&windowsManager{}).VerifyClean(ctx)
@@ -179,10 +191,16 @@ func (*windowsManager) VerifyClean(ctx context.Context) (AccountEvidence, error)
 	}
 	enabled, err := accountEnabled(AccountName)
 	if err != nil {
+		if IsAccountAbsent(err) {
+			return absentAccountEvidence(), nil
+		}
 		return AccountEvidence{}, err
 	}
 	inAdministrators, err := accountInAdministrators(AccountName)
 	if err != nil {
+		if IsAccountAbsent(err) {
+			return absentAccountEvidence(), nil
+		}
 		return AccountEvidence{}, err
 	}
 	return AccountEvidence{Enabled: enabled, InAdministrators: inAdministrators}, nil
@@ -277,7 +295,9 @@ func addToAdministrators(username string) error {
 func removeFromAdministrators(username string) error {
 	status, err := localGroupMembersCall(procNetLocalGroupDelMembers, username)
 	if err != nil {
-		if errors.Is(err, windows.ERROR_NONE_MAPPED) {
+		// The SID lookup fails with ERROR_NONE_MAPPED when the account does
+		// not exist, which is nothing to remove.
+		if IsAccountAbsent(err) {
 			return nil
 		}
 		return err

--- a/agent/internal/elevaccount/elevaccount_windows.go
+++ b/agent/internal/elevaccount/elevaccount_windows.go
@@ -4,6 +4,7 @@ package elevaccount
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"syscall"
@@ -182,10 +183,7 @@ func (*windowsManager) VerifyClean(ctx context.Context) (AccountEvidence, error)
 		return cleanIfAbsent(err)
 	}
 	inAdministrators, err := accountInAdministrators(AccountName)
-	if err != nil {
-		return cleanIfAbsent(err)
-	}
-	return AccountEvidence{Enabled: enabled, InAdministrators: inAdministrators}, nil
+	return evidenceAfterAdminProbe(enabled, inAdministrators, err)
 }
 
 func netUserAddDisabled(username, password string) error {
@@ -256,7 +254,13 @@ func netUserSetInfo(namePtr *uint16, level uint32, info unsafe.Pointer) error {
 		uintptr(unsafe.Pointer(&parmErr)),
 	)
 	if status != nerrSuccess {
-		return fmt.Errorf("NetUserSetInfo level %d failed: %w", level, syscall.Errno(status))
+		// This call named the elevation account, so NERR_UserNotFound here is
+		// proof the account itself is gone.
+		err := fmt.Errorf("NetUserSetInfo level %d failed: %w", level, syscall.Errno(status))
+		if uint32(status) == nerrUserNotFound {
+			return absentAccountErr(err)
+		}
+		return err
 	}
 	return nil
 }
@@ -277,9 +281,10 @@ func addToAdministrators(username string) error {
 func removeFromAdministrators(username string) error {
 	status, err := localGroupMembersCall(procNetLocalGroupDelMembers, username)
 	if err != nil {
-		// The SID lookup fails with ERROR_NONE_MAPPED when the account does
-		// not exist, which is nothing to remove.
-		if IsAccountAbsent(err) {
+		// Nothing to remove from a group if the account itself is gone. Only
+		// the tagged failure counts: an alias-lookup failure carries the same
+		// errno and must stay an error.
+		if errors.Is(err, errAccountAbsent) {
 			return nil
 		}
 		return err
@@ -293,6 +298,10 @@ func removeFromAdministrators(username string) error {
 }
 
 func localGroupMembersCall(proc *syscall.LazyProc, username string) (uint32, error) {
+	// NOT an absence signal: the builtin Administrators alias is a different
+	// principal, and its lookup fails with the same ERROR_NONE_MAPPED. Reading
+	// that as "the elevation account is absent" would report a machine that
+	// cannot resolve its own Administrators group as clean.
 	groupName, err := administratorsGroupName()
 	if err != nil {
 		return 0, err
@@ -303,6 +312,10 @@ func localGroupMembersCall(proc *syscall.LazyProc, username string) (uint32, err
 	}
 	userSID, _, _, err := windows.LookupSID("", username)
 	if err != nil {
+		// This lookup DID name the elevation account.
+		if IsAccountAbsent(err) {
+			return 0, absentAccountErr(fmt.Errorf("LookupSID %s failed: %w", username, err))
+		}
 		return 0, err
 	}
 	info := localGroupMembersInfo0{SID: userSID}
@@ -338,7 +351,11 @@ func accountEnabled(username string) (bool, error) {
 	}
 	var buffer *byte
 	if err := windows.NetUserGetInfo(nil, namePtr, userInfoLevel1, &buffer); err != nil {
-		return false, fmt.Errorf("NetUserGetInfo %s failed: %w", username, err)
+		wrapped := fmt.Errorf("NetUserGetInfo %s failed: %w", username, err)
+		if IsAccountAbsent(err) {
+			return false, absentAccountErr(wrapped)
+		}
+		return false, wrapped
 	}
 	defer windows.NetApiBufferFree(buffer)
 	info := (*userInfo1)(unsafe.Pointer(buffer))
@@ -350,6 +367,8 @@ func accountInAdministrators(username string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	// NOT an absence signal: this resolves the builtin Administrators alias,
+	// not the elevation account. Its failure must propagate as a real error.
 	adminName, err := administratorsGroupName()
 	if err != nil {
 		return false, err
@@ -367,7 +386,11 @@ func accountInAdministrators(username string) (bool, error) {
 		uintptr(unsafe.Pointer(&totalEntries)),
 	)
 	if uint32(status) != nerrSuccess {
-		return false, fmt.Errorf("NetUserGetLocalGroups %s failed: %w", username, syscall.Errno(status))
+		err := fmt.Errorf("NetUserGetLocalGroups %s failed: %w", username, syscall.Errno(status))
+		if uint32(status) == nerrUserNotFound {
+			return false, absentAccountErr(err)
+		}
+		return false, err
 	}
 	if buffer == nil {
 		return false, nil

--- a/agent/internal/elevaccount/elevaccount_windows.go
+++ b/agent/internal/elevaccount/elevaccount_windows.go
@@ -146,12 +146,6 @@ func (*windowsManager) Demote(ctx context.Context) error {
 	return err
 }
 
-// absentAccountEvidence is what an account that does not exist proves: it
-// cannot be enabled and it cannot be in Administrators. See IsAccountAbsent.
-func absentAccountEvidence() AccountEvidence {
-	return AccountEvidence{Enabled: false, InAdministrators: false}
-}
-
 func (*windowsManager) Deprovision(ctx context.Context) (AccountEvidence, error) {
 	if err := ctx.Err(); err != nil {
 		return AccountEvidence{}, err
@@ -161,10 +155,7 @@ func (*windowsManager) Deprovision(ctx context.Context) (AccountEvidence, error)
 		return AccountEvidence{}, err
 	}
 	if err := setPassword(AccountName, password); err != nil {
-		if IsAccountAbsent(err) {
-			return absentAccountEvidence(), nil
-		}
-		return AccountEvidence{}, err
+		return cleanIfAbsent(err)
 	}
 	if err := ctx.Err(); err != nil {
 		return AccountEvidence{}, err
@@ -177,10 +168,7 @@ func (*windowsManager) Deprovision(ctx context.Context) (AccountEvidence, error)
 		return AccountEvidence{}, err
 	}
 	if err := setUserFlags(AccountName, accountDisabledFlags); err != nil {
-		if IsAccountAbsent(err) {
-			return absentAccountEvidence(), nil
-		}
-		return AccountEvidence{}, err
+		return cleanIfAbsent(err)
 	}
 	return (&windowsManager{}).VerifyClean(ctx)
 }
@@ -191,17 +179,11 @@ func (*windowsManager) VerifyClean(ctx context.Context) (AccountEvidence, error)
 	}
 	enabled, err := accountEnabled(AccountName)
 	if err != nil {
-		if IsAccountAbsent(err) {
-			return absentAccountEvidence(), nil
-		}
-		return AccountEvidence{}, err
+		return cleanIfAbsent(err)
 	}
 	inAdministrators, err := accountInAdministrators(AccountName)
 	if err != nil {
-		if IsAccountAbsent(err) {
-			return absentAccountEvidence(), nil
-		}
-		return AccountEvidence{}, err
+		return cleanIfAbsent(err)
 	}
 	return AccountEvidence{Enabled: enabled, InAdministrators: inAdministrators}, nil
 }

--- a/agent/internal/pamlifetime/job_contract_test.go
+++ b/agent/internal/pamlifetime/job_contract_test.go
@@ -270,8 +270,11 @@ func (f *fakeWindowsPrimitives) CloseJob(job jobOwnership) {
 type fakeAccountLifecycle struct {
 	order            *[]string
 	deprovision      elevaccount.AccountEvidence
+	deprovisionErr   error
 	verified         elevaccount.AccountEvidence
+	verifiedErr      error
 	deprovisionCount int
+	verifiedCount    int
 }
 
 func (f *fakeAccountLifecycle) Promote(context.Context) (elevaccount.Credential, error) {
@@ -282,11 +285,18 @@ func (f *fakeAccountLifecycle) Promote(context.Context) (elevaccount.Credential,
 func (f *fakeAccountLifecycle) Deprovision(context.Context) (elevaccount.AccountEvidence, error) {
 	f.deprovisionCount++
 	*f.order = append(*f.order, "rotate password, remove Administrators, disable account")
+	if f.deprovisionErr != nil {
+		return elevaccount.AccountEvidence{}, f.deprovisionErr
+	}
 	return f.deprovision, nil
 }
 
 func (f *fakeAccountLifecycle) VerifyClean(context.Context) (elevaccount.AccountEvidence, error) {
+	f.verifiedCount++
 	*f.order = append(*f.order, "verify account disabled and non-admin")
+	if f.verifiedErr != nil {
+		return elevaccount.AccountEvidence{}, f.verifiedErr
+	}
 	return f.verified, nil
 }
 

--- a/agent/internal/pamlifetime/job_windows.go
+++ b/agent/internal/pamlifetime/job_windows.go
@@ -316,6 +316,15 @@ func (*nativeWindowsPrimitives) VerifyProcessIdentityGone(ctx context.Context, p
 }
 
 func (*nativeWindowsPrimitives) VerifyNoPrivilegedToken(ctx context.Context, username string) (bool, error) {
+	// Do NOT special-case "no such account" here, however tempting it looks:
+	// an unresolvable name is not on its own proof that no token exists. A
+	// Windows process keeps its token, and therefore the elevated SID, after
+	// the account behind it is deleted, so on a host that HAS actuated, this
+	// error can be the only trace of exactly the orphaned elevated process
+	// this scan exists to catch. The one context where absence is genuinely
+	// proof — an agent whose ledger has never recorded an actuation, so the
+	// account was never created — is handled by the caller, which knows that:
+	// see verifyAccountClean's neverActuated parameter in manager.go (#4587).
 	targetSID, _, _, err := windows.LookupSID("", username)
 	if err != nil {
 		return false, err

--- a/agent/internal/pamlifetime/manager.go
+++ b/agent/internal/pamlifetime/manager.go
@@ -9,8 +9,11 @@ import (
 	"time"
 
 	"github.com/breeze-rmm/agent/internal/elevaccount"
+	"github.com/breeze-rmm/agent/internal/logging"
 	"github.com/google/uuid"
 )
+
+var log = logging.L("pamlifetime")
 
 const (
 	createSuspended                 uint32 = 0x00000004
@@ -34,6 +37,9 @@ type lifetimeStore interface {
 	ClearProcessIdentity(string, uint64) error
 	Entry(string) (LedgerEntry, bool)
 	Entries() []LedgerEntry
+	// LoadError reports a ledger that could not be read. Entries() returns an
+	// empty slice in that case, so emptiness alone never means "no actuation".
+	LoadError() error
 }
 
 type suspendedLaunchSpec struct {
@@ -435,8 +441,7 @@ func (m *lifecycleManager) reconcileActiveLocked(ctx context.Context, entry Ledg
 			return m.result(entry.ActuationID, entry.Generation, ResultVerifiedActive, evidence), true
 		}
 	}
-	// A ledger entry is being reconciled, so an actuation is on record.
-	verifiedEvidence, code, verified := m.verifyAccountClean(ctx, evidence, false)
+	verifiedEvidence, code, verified := m.verifyAccountClean(ctx, evidence)
 	result := m.result(entry.ActuationID, entry.Generation, ResultFailed, verifiedEvidence)
 	if code != "" {
 		result.FailureCode = code
@@ -451,13 +456,17 @@ func (m *lifecycleManager) reconcileActiveLocked(ctx context.Context, entry Ledg
 // verifyAccountClean proves the dormant elevation account is deprovisioned,
 // disabled, out of Administrators and holding no live token.
 //
-// neverActuated is true only for the disable path with an empty ledger, where
-// this agent has no record of ever having applied an actuation. That is the
-// one context in which the account legitimately may not exist at all: it is
-// provisioned lazily when PAM is first enabled, so the majority of the fleet
-// has never created it. Every other caller reconciles a recorded actuation,
-// where a missing account is anomalous and must keep failing closed.
-func (m *lifecycleManager) verifyAccountClean(ctx context.Context, evidence ResultEvidence, neverActuated bool) (ResultEvidence, string, bool) {
+// An absent account is tolerated in exactly one situation: this agent has no
+// record of ever having applied an actuation. The account is provisioned
+// lazily when PAM is first enabled, so on the majority of the fleet it was
+// never created. Reconciling a recorded actuation is the opposite case, where
+// a missing account is anomalous and must keep failing closed.
+//
+// That condition is derived here rather than passed in by the caller. It is
+// not simply "the ledger is empty": a ledger that could not be READ also
+// yields zero entries, and on such a device the actuation history is unknown,
+// not absent.
+func (m *lifecycleManager) verifyAccountClean(ctx context.Context, evidence ResultEvidence) (ResultEvidence, string, bool) {
 	deprovisioned, err := m.account.Deprovision(ctx)
 	if err != nil {
 		return evidence, "account_cleanup_failed", false
@@ -466,7 +475,9 @@ func (m *lifecycleManager) verifyAccountClean(ctx context.Context, evidence Resu
 	if err != nil || verified.Enabled || verified.InAdministrators || deprovisioned.Enabled || deprovisioned.InAdministrators {
 		return evidence, "account_verification_failed", false
 	}
+	neverActuated := len(m.store.Entries()) == 0 && m.store.LoadError() == nil
 	privileged, err := m.windows.VerifyNoPrivilegedToken(ctx, elevaccount.AccountName)
+	tokenScanned := true
 	switch {
 	case err != nil:
 		// The scan needs the account's SID, so it fails outright when the name
@@ -479,12 +490,23 @@ func (m *lifecycleManager) verifyAccountClean(ctx context.Context, evidence Resu
 		if !neverActuated || !elevaccount.IsAccountAbsent(err) {
 			return evidence, "privileged_token_verification_failed", false
 		}
+		// Logged because a skipped security check should never be invisible.
+		// This fires once per agent lifetime, not once per heartbeat: the
+		// disable settles, and the next call returns at SetEnabled's early
+		// return without reaching this code.
+		tokenScanned = false
+		log.Info("PAM token scan skipped: elevation account absent and no actuation on record",
+			"account", elevaccount.AccountName)
 	case privileged:
 		return evidence, "privileged_token_verification_failed", false
 	}
 	evidence.AccountEnabled = boolPtr(false)
 	evidence.AccountInAdministrators = boolPtr(false)
-	evidence.PrivilegedTokenPresent = boolPtr(false)
+	if tokenScanned {
+		// Left nil when the scan was skipped: not measured is not the same
+		// claim as measured absent.
+		evidence.PrivilegedTokenPresent = boolPtr(false)
+	}
 	return evidence, "", true
 }
 
@@ -521,12 +543,20 @@ func (m *lifecycleManager) SetEnabled(ctx context.Context, enabled bool) error {
 	m.mu.Unlock()
 	entries := m.store.Entries()
 	var failures []string
-	if len(entries) == 0 {
+	if loadErr := m.store.LoadError(); loadErr != nil {
+		// An unreadable ledger reports zero entries, the same shape as "this
+		// device never actuated" — but it is not the same claim. The actuation
+		// history is unknown, so nothing about the account may be concluded
+		// from emptiness. Fail closed; here the repeating heartbeat ERROR is
+		// the correct signal, because this is a genuine failure state.
+		failures = append(failures, "account:ledger_unavailable")
+		m.markUnresolved("__account__", 0)
+	} else if len(entries) == 0 {
 		bootID, bootErr := m.currentBootID(ctx)
 		if bootErr != nil {
 			failures = append(failures, "account:boot_id_unavailable")
 			m.markUnresolved("__account__", 0)
-		} else if _, code, verified := m.verifyAccountClean(ctx, ResultEvidence{BootID: bootID}, true); !verified {
+		} else if _, code, verified := m.verifyAccountClean(ctx, ResultEvidence{BootID: bootID}); !verified {
 			failures = append(failures, "account:"+code)
 			m.markUnresolved("__account__", 0)
 		} else {

--- a/agent/internal/pamlifetime/manager.go
+++ b/agent/internal/pamlifetime/manager.go
@@ -435,7 +435,8 @@ func (m *lifecycleManager) reconcileActiveLocked(ctx context.Context, entry Ledg
 			return m.result(entry.ActuationID, entry.Generation, ResultVerifiedActive, evidence), true
 		}
 	}
-	verifiedEvidence, code, verified := m.verifyAccountClean(ctx, evidence)
+	// A ledger entry is being reconciled, so an actuation is on record.
+	verifiedEvidence, code, verified := m.verifyAccountClean(ctx, evidence, false)
 	result := m.result(entry.ActuationID, entry.Generation, ResultFailed, verifiedEvidence)
 	if code != "" {
 		result.FailureCode = code
@@ -447,7 +448,16 @@ func (m *lifecycleManager) reconcileActiveLocked(ctx context.Context, entry Ledg
 	return result, verified
 }
 
-func (m *lifecycleManager) verifyAccountClean(ctx context.Context, evidence ResultEvidence) (ResultEvidence, string, bool) {
+// verifyAccountClean proves the dormant elevation account is deprovisioned,
+// disabled, out of Administrators and holding no live token.
+//
+// neverActuated is true only for the disable path with an empty ledger, where
+// this agent has no record of ever having applied an actuation. That is the
+// one context in which the account legitimately may not exist at all: it is
+// provisioned lazily when PAM is first enabled, so the majority of the fleet
+// has never created it. Every other caller reconciles a recorded actuation,
+// where a missing account is anomalous and must keep failing closed.
+func (m *lifecycleManager) verifyAccountClean(ctx context.Context, evidence ResultEvidence, neverActuated bool) (ResultEvidence, string, bool) {
 	deprovisioned, err := m.account.Deprovision(ctx)
 	if err != nil {
 		return evidence, "account_cleanup_failed", false
@@ -457,7 +467,19 @@ func (m *lifecycleManager) verifyAccountClean(ctx context.Context, evidence Resu
 		return evidence, "account_verification_failed", false
 	}
 	privileged, err := m.windows.VerifyNoPrivilegedToken(ctx, elevaccount.AccountName)
-	if err != nil || privileged {
+	switch {
+	case err != nil:
+		// The scan needs the account's SID, so it fails outright when the name
+		// resolves to nothing. On a never-actuated agent that means the
+		// dormant account was never created: nothing has ever logged on as it,
+		// so no process can be holding a token for it (#4587). Any other
+		// error, and any error at all once an actuation is on record — where a
+		// deleted account can still leave a live orphaned token behind — stays
+		// a verification failure.
+		if !neverActuated || !elevaccount.IsAccountAbsent(err) {
+			return evidence, "privileged_token_verification_failed", false
+		}
+	case privileged:
 		return evidence, "privileged_token_verification_failed", false
 	}
 	evidence.AccountEnabled = boolPtr(false)
@@ -504,7 +526,7 @@ func (m *lifecycleManager) SetEnabled(ctx context.Context, enabled bool) error {
 		if bootErr != nil {
 			failures = append(failures, "account:boot_id_unavailable")
 			m.markUnresolved("__account__", 0)
-		} else if _, code, verified := m.verifyAccountClean(ctx, ResultEvidence{BootID: bootID}); !verified {
+		} else if _, code, verified := m.verifyAccountClean(ctx, ResultEvidence{BootID: bootID}, true); !verified {
 			failures = append(failures, "account:"+code)
 			m.markUnresolved("__account__", 0)
 		} else {

--- a/agent/internal/pamlifetime/manager.go
+++ b/agent/internal/pamlifetime/manager.go
@@ -487,6 +487,17 @@ func (m *lifecycleManager) verifyAccountClean(ctx context.Context, evidence Resu
 		// error, and any error at all once an actuation is on record — where a
 		// deleted account can still leave a live orphaned token behind — stays
 		// a verification failure.
+		//
+		// IsAccountAbsent classifies ONE call's status, and this error comes
+		// out of a primitive that makes several, so the hazard that the
+		// elevaccount sentinel exists to prevent applies here in principle.
+		// It is sound today only because the single call in
+		// VerifyNoPrivilegedToken that can produce these statuses —
+		// LookupSID, on the elevation account's own name — is the first thing
+		// it does; the snapshot, process and token calls after it cannot
+		// return either status. If that primitive ever grows a second name
+		// lookup (another principal, a group), this must move to a tagged
+		// sentinel the way elevaccount's probes did.
 		if !neverActuated || !elevaccount.IsAccountAbsent(err) {
 			return evidence, "privileged_token_verification_failed", false
 		}

--- a/agent/internal/pamlifetime/manager_never_enabled_test.go
+++ b/agent/internal/pamlifetime/manager_never_enabled_test.go
@@ -57,14 +57,19 @@ func managerState(t *testing.T, m *lifecycleManager) (enabled, admissionOpen, av
 	return m.enabled, m.admissionOpen, m.available, len(m.unresolved)
 }
 
-// TestSetEnabledFalseOnNeverProvisionedAgentIsAQuietIdempotentNoOp is the
-// manager half of issue #4587. The manager is constructed enabled:true, and
-// every heartbeat with no UAC-interception policy calls SetEnabled(ctx, false).
-// With an empty ledger that runs verifyAccountClean against an account that was
-// never provisioned. That must settle on the FIRST call — returning nil and
-// clearing m.enabled — because m.enabled is only cleared on success: as long as
-// it fails, the next heartbeat repeats the whole cleanup and logs the failure
-// at ERROR again, forever.
+// TestSetEnabledFalseOnNeverProvisionedAgentIsAQuietIdempotentNoOp pins the
+// amplifier that turned one failed probe into issue #4587's unbounded ERROR
+// stream. The manager is constructed enabled:true, and every heartbeat with no
+// UAC-interception policy calls SetEnabled(ctx, false); with an empty ledger
+// that runs verifyAccountClean. Because m.enabled is only cleared on success,
+// the disable has to settle on the FIRST call — returning nil, clearing
+// m.enabled and leaving the manager available — or the next heartbeat repeats
+// the whole cleanup and logs again, forever.
+//
+// This test passes with and without the absent-account fix: given clean
+// evidence it exercises the idempotence contract, not the tolerance. The
+// regression detector for the fix itself is
+// TestSetEnabledFalseToleratesUnresolvableAccountNameInTokenScan below.
 func TestSetEnabledFalseOnNeverProvisionedAgentIsAQuietIdempotentNoOp(t *testing.T) {
 	account := &fakeAccountLifecycle{}
 	manager := newNeverEnabledManager(t, account, nil)

--- a/agent/internal/pamlifetime/manager_never_enabled_test.go
+++ b/agent/internal/pamlifetime/manager_never_enabled_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"syscall"
 	"testing"
@@ -299,4 +300,92 @@ func TestReconcileDoesNotTolerateUnresolvableAccountNameInTokenScan(t *testing.T
 	if manager.Available() {
 		t.Fatal("manager reports available after an unverified reconcile")
 	}
+}
+
+// TestSetEnabledFalseFailsClosedWhenTheLedgerCannotBeRead is the regression
+// test for the review finding that an unreadable ledger is indistinguishable
+// from an empty one. Store.Entries() returns zero entries either way, so the
+// disable path would have concluded "this device never actuated", tolerated an
+// absent account and skipped the privileged-token scan — on a device whose
+// actuation history is simply unknown. That has to fail closed, and the
+// account manager must not be touched at all.
+func TestSetEnabledFalseFailsClosedWhenTheLedgerCannotBeRead(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ledger.json")
+	if err := os.WriteFile(path, []byte("{ this is not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store := NewStore(path)
+	if store.LoadError() == nil {
+		t.Fatal("setup: a corrupt ledger must report a load error")
+	}
+	if entries := store.Entries(); len(entries) != 0 {
+		t.Fatalf("setup: corrupt ledger reported %d entries; the test depends on it looking empty", len(entries))
+	}
+
+	var order []string
+	account := &fakeAccountLifecycle{order: &order}
+	win := &fakeWindowsPrimitives{order: &order, privilegedTokenErr: unresolvableAccountErr()}
+	manager := newLifecycleManager(store, win, account, nil)
+
+	err := manager.SetEnabled(context.Background(), false)
+	if err == nil {
+		t.Fatal("SetEnabled(false) returned nil on a device whose actuation history could not be read")
+	}
+	if got, want := err.Error(), "PAM disable cleanup unverified: account:ledger_unavailable"; got != want {
+		t.Fatalf("SetEnabled(false) error = %q, want %q", got, want)
+	}
+	if account.deprovisionCount != 0 || account.verifiedCount != 0 {
+		t.Fatalf("account manager was called (%d Deprovision / %d VerifyClean) despite an unreadable ledger",
+			account.deprovisionCount, account.verifiedCount)
+	}
+
+	enabled, admissionOpen, available, unresolved := managerState(t, manager)
+	if !enabled {
+		t.Fatal("m.enabled must remain set so the next heartbeat retries")
+	}
+	if admissionOpen {
+		t.Fatal("m.admissionOpen must be closed while cleanup is unverified")
+	}
+	if available {
+		t.Fatal("m.available must be false while the ledger cannot be read")
+	}
+	if unresolved != 1 {
+		t.Fatalf("unresolved cleanup evidence = %d, want 1", unresolved)
+	}
+}
+
+// TestToleratedTokenScanLeavesPrivilegedTokenEvidenceUnmeasured pins the
+// difference between "measured, and no token was present" and "never
+// measured". Reporting boolPtr(false) for a scan that was skipped would put a
+// claim on the wire the agent never verified.
+func TestToleratedTokenScanLeavesPrivilegedTokenEvidenceUnmeasured(t *testing.T) {
+	t.Run("skipped scan reports no privileged-token evidence", func(t *testing.T) {
+		manager := newNeverEnabledManager(t, &fakeAccountLifecycle{},
+			&fakeWindowsPrimitives{privilegedTokenErr: unresolvableAccountErr()})
+
+		evidence, code, verified := manager.verifyAccountClean(context.Background(), ResultEvidence{BootID: "windows-boot-42"})
+
+		if !verified || code != "" {
+			t.Fatalf("verifyAccountClean = (%q, %v), want verified with no failure code", code, verified)
+		}
+		if evidence.PrivilegedTokenPresent != nil {
+			t.Fatalf("PrivilegedTokenPresent = %v, want nil: the scan was skipped, not performed", *evidence.PrivilegedTokenPresent)
+		}
+		if evidence.AccountEnabled == nil || *evidence.AccountEnabled {
+			t.Fatalf("AccountEnabled = %v, want a measured false", evidence.AccountEnabled)
+		}
+	})
+
+	t.Run("performed scan does report it", func(t *testing.T) {
+		manager := newNeverEnabledManager(t, &fakeAccountLifecycle{}, &fakeWindowsPrimitives{})
+
+		evidence, code, verified := manager.verifyAccountClean(context.Background(), ResultEvidence{BootID: "windows-boot-42"})
+
+		if !verified || code != "" {
+			t.Fatalf("verifyAccountClean = (%q, %v), want verified with no failure code", code, verified)
+		}
+		if evidence.PrivilegedTokenPresent == nil || *evidence.PrivilegedTokenPresent {
+			t.Fatalf("PrivilegedTokenPresent = %v, want a measured false", evidence.PrivilegedTokenPresent)
+		}
+	})
 }

--- a/agent/internal/pamlifetime/manager_never_enabled_test.go
+++ b/agent/internal/pamlifetime/manager_never_enabled_test.go
@@ -1,0 +1,297 @@
+package pamlifetime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/elevaccount"
+)
+
+// Windows status codes the token scan can fail with. ERROR_NONE_MAPPED is what
+// windows.LookupSID returns for an account name that exists nowhere on the
+// host, which is the never-provisioned ~breeze_elev of issue #4587.
+const (
+	errorNoneMappedStatus  = 1332 // ERROR_NONE_MAPPED
+	errorAccessDenied      = 5    // ERROR_ACCESS_DENIED
+	errorInvalidParameter  = 87   // ERROR_INVALID_PARAMETER
+	unresolvableAccountFmt = "lookup account name %s: %w"
+)
+
+// unresolvableAccountErr is the shape VerifyNoPrivilegedToken returns when its
+// first statement, windows.LookupSID("", "~breeze_elev"), finds no such name.
+func unresolvableAccountErr() error {
+	return fmt.Errorf(unresolvableAccountFmt, elevaccount.AccountName, syscall.Errno(errorNoneMappedStatus))
+}
+
+// newNeverEnabledManager builds the manager exactly as Heartbeat.SetStatePath
+// does on an agent that has never enabled PAM: an empty ledger, and an account
+// lifecycle that reports the dormant ~breeze_elev account as absent — clean
+// evidence and no error, which is what elevaccount returns once it treats
+// NERR_UserNotFound / ERROR_NONE_MAPPED as "the account does not exist".
+func newNeverEnabledManager(t *testing.T, account *fakeAccountLifecycle, win *fakeWindowsPrimitives) *lifecycleManager {
+	t.Helper()
+	var order []string
+	account.order = &order
+	if win == nil {
+		win = &fakeWindowsPrimitives{}
+	}
+	win.order = &order
+	store := NewStore(filepath.Join(t.TempDir(), "ledger.json"))
+	if store.loadErr != nil {
+		t.Fatalf("NewStore: %v", store.loadErr)
+	}
+	if entries := store.Entries(); len(entries) != 0 {
+		t.Fatalf("ledger has %d entries, want an empty ledger", len(entries))
+	}
+	return newLifecycleManager(store, win, account, nil)
+}
+
+func managerState(t *testing.T, m *lifecycleManager) (enabled, admissionOpen, available bool, unresolved int) {
+	t.Helper()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.enabled, m.admissionOpen, m.available, len(m.unresolved)
+}
+
+// TestSetEnabledFalseOnNeverProvisionedAgentIsAQuietIdempotentNoOp is the
+// manager half of issue #4587. The manager is constructed enabled:true, and
+// every heartbeat with no UAC-interception policy calls SetEnabled(ctx, false).
+// With an empty ledger that runs verifyAccountClean against an account that was
+// never provisioned. That must settle on the FIRST call — returning nil and
+// clearing m.enabled — because m.enabled is only cleared on success: as long as
+// it fails, the next heartbeat repeats the whole cleanup and logs the failure
+// at ERROR again, forever.
+func TestSetEnabledFalseOnNeverProvisionedAgentIsAQuietIdempotentNoOp(t *testing.T) {
+	account := &fakeAccountLifecycle{}
+	manager := newNeverEnabledManager(t, account, nil)
+
+	if enabled, _, _, _ := managerState(t, manager); !enabled {
+		t.Fatal("manager must start enabled; the never-enabled heartbeat path depends on SetEnabled(false) doing real work on the first call")
+	}
+
+	if err := manager.SetEnabled(context.Background(), false); err != nil {
+		t.Fatalf("first SetEnabled(false) = %v, want nil (nothing was ever provisioned, so there is nothing to clean up)", err)
+	}
+
+	enabled, admissionOpen, available, unresolved := managerState(t, manager)
+	if enabled {
+		t.Fatal("m.enabled still true after a successful disable; every subsequent heartbeat would re-run account cleanup")
+	}
+	if admissionOpen {
+		t.Fatal("m.admissionOpen still true after a disable")
+	}
+	if !available {
+		t.Fatal("m.available false after a successful disable; PAM would report itself unavailable and refuse to enable later")
+	}
+	if unresolved != 0 {
+		t.Fatalf("unresolved cleanup evidence = %d, want 0", unresolved)
+	}
+	if account.deprovisionCount != 1 || account.verifiedCount != 1 {
+		t.Fatalf("first disable made %d Deprovision / %d VerifyClean calls, want 1 / 1",
+			account.deprovisionCount, account.verifiedCount)
+	}
+
+	// The second heartbeat must hit the early return, not the account manager.
+	if err := manager.SetEnabled(context.Background(), false); err != nil {
+		t.Fatalf("second SetEnabled(false) = %v, want nil", err)
+	}
+	if account.deprovisionCount != 1 || account.verifiedCount != 1 {
+		t.Fatalf("two disables made %d Deprovision / %d VerifyClean calls, want 1 / 1 — the disable path is not idempotent and re-runs on every heartbeat",
+			account.deprovisionCount, account.verifiedCount)
+	}
+	if enabled, _, available, unresolved := managerState(t, manager); enabled || !available || unresolved != 0 {
+		t.Fatalf("state after second disable: enabled=%v available=%v unresolved=%d, want false/true/0", enabled, available, unresolved)
+	}
+}
+
+// TestSetEnabledFalseStillFailsClosedOnGenuineAccountCleanupFailure is the
+// other half: tolerating a missing account must not tolerate a cleanup that
+// actually failed. A real error (access denied, a locked SAM) still has to
+// surface as account_cleanup_failed, leave m.enabled set so the next heartbeat
+// retries, and mark the evidence unresolved so PAM reports itself unavailable.
+func TestSetEnabledFalseStillFailsClosedOnGenuineAccountCleanupFailure(t *testing.T) {
+	account := &fakeAccountLifecycle{
+		deprovisionErr: errors.New("NetUserSetInfo level 1003 failed: Access is denied."),
+	}
+	manager := newNeverEnabledManager(t, account, nil)
+
+	err := manager.SetEnabled(context.Background(), false)
+	if err == nil {
+		t.Fatal("SetEnabled(false) returned nil despite a failing Deprovision")
+	}
+	if got, want := err.Error(), "PAM disable cleanup unverified: account:account_cleanup_failed"; got != want {
+		t.Fatalf("SetEnabled(false) error = %q, want %q", got, want)
+	}
+
+	enabled, admissionOpen, available, unresolved := managerState(t, manager)
+	if !enabled {
+		t.Fatal("a failed disable must stay fail-closed: m.enabled must remain true so the next heartbeat retries the cleanup")
+	}
+	if admissionOpen {
+		t.Fatal("m.admissionOpen must be closed while cleanup is unverified")
+	}
+	if available {
+		t.Fatal("m.available must be false while cleanup evidence is unresolved")
+	}
+	if unresolved != 1 {
+		t.Fatalf("unresolved cleanup evidence = %d, want 1", unresolved)
+	}
+
+	// Retrying is the intended behaviour for a genuine failure, unlike the
+	// absent-account case above.
+	if retryErr := manager.SetEnabled(context.Background(), false); retryErr == nil {
+		t.Fatal("retry of a still-failing disable returned nil")
+	}
+	if account.deprovisionCount != 2 {
+		t.Fatalf("Deprovision called %d times across two failing disables, want 2", account.deprovisionCount)
+	}
+}
+
+// TestSetEnabledFalseReportsVerificationFailureSeparately keeps the two
+// account failure codes distinguishable. Deprovision succeeding but the
+// follow-up verification reporting the account still enabled is a different
+// operator problem from Deprovision itself erroring, and #4587 turned on being
+// able to read the code in the log line.
+func TestSetEnabledFalseReportsVerificationFailureSeparately(t *testing.T) {
+	tests := []struct {
+		name    string
+		account *fakeAccountLifecycle
+	}{
+		{"verification errored", &fakeAccountLifecycle{verifiedErr: errors.New("NetUserGetInfo failed: Access is denied.")}},
+		{"account still enabled", func() *fakeAccountLifecycle {
+			a := &fakeAccountLifecycle{}
+			a.verified.Enabled = true
+			return a
+		}()},
+		{"account still in Administrators", func() *fakeAccountLifecycle {
+			a := &fakeAccountLifecycle{}
+			a.verified.InAdministrators = true
+			return a
+		}()},
+		{"deprovision evidence contradicts a clean verify", func() *fakeAccountLifecycle {
+			a := &fakeAccountLifecycle{}
+			a.deprovision.InAdministrators = true
+			return a
+		}()},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := newNeverEnabledManager(t, tt.account, nil)
+
+			err := manager.SetEnabled(context.Background(), false)
+			if err == nil {
+				t.Fatal("SetEnabled(false) returned nil despite unverified account evidence")
+			}
+			if got, want := err.Error(), "PAM disable cleanup unverified: account:account_verification_failed"; got != want {
+				t.Fatalf("SetEnabled(false) error = %q, want %q", got, want)
+			}
+			if enabled, _, _, _ := managerState(t, manager); !enabled {
+				t.Fatal("an unverified disable must leave m.enabled set so the next heartbeat retries")
+			}
+		})
+	}
+}
+
+// TestSetEnabledFalseToleratesUnresolvableAccountNameInTokenScan is the second
+// half of issue #4587, and the one that keeps the ERROR loop alive after
+// elevaccount stops reporting a missing account as a cleanup failure.
+// VerifyNoPrivilegedToken starts by resolving ~breeze_elev to a SID; on a host
+// that never provisioned the account there is no such name, so the scan errors
+// before it inspects a single process. With an empty ledger that is the
+// never-provisioned default, not a leak: no process has ever logged on as an
+// account that was never created.
+func TestSetEnabledFalseToleratesUnresolvableAccountNameInTokenScan(t *testing.T) {
+	tokenErr := unresolvableAccountErr()
+	if !elevaccount.IsAccountAbsent(tokenErr) {
+		t.Fatalf("fixture %v is not classified as an absent account; the test would not exercise the tolerance", tokenErr)
+	}
+
+	account := &fakeAccountLifecycle{}
+	manager := newNeverEnabledManager(t, account, &fakeWindowsPrimitives{privilegedTokenErr: tokenErr})
+
+	if err := manager.SetEnabled(context.Background(), false); err != nil {
+		t.Fatalf("SetEnabled(false) = %v, want nil when the account name resolves to nothing on a never-actuated agent", err)
+	}
+	enabled, _, available, unresolved := managerState(t, manager)
+	if enabled || !available || unresolved != 0 {
+		t.Fatalf("state after disable: enabled=%v available=%v unresolved=%d, want false/true/0", enabled, available, unresolved)
+	}
+}
+
+// TestSetEnabledFalseStillFailsOnEveryOtherTokenScanFailure keeps the
+// tolerance above pinned to the one status that proves absence. A scan that
+// failed for any other reason proved nothing about live tokens and must stay a
+// failure — as must a scan that actually found a privileged token.
+func TestSetEnabledFalseStillFailsOnEveryOtherTokenScanFailure(t *testing.T) {
+	tests := []struct {
+		name string
+		win  *fakeWindowsPrimitives
+	}{
+		{"access denied", &fakeWindowsPrimitives{
+			privilegedTokenErr: fmt.Errorf(unresolvableAccountFmt, elevaccount.AccountName, syscall.Errno(errorAccessDenied)),
+		}},
+		{"invalid parameter", &fakeWindowsPrimitives{
+			privilegedTokenErr: fmt.Errorf("open process 1234 while verifying PAM token absence: %w", syscall.Errno(errorInvalidParameter)),
+		}},
+		{"non-errno failure", &fakeWindowsPrimitives{
+			privilegedTokenErr: errors.New("CreateToolhelp32Snapshot failed"),
+		}},
+		{"status only in the message text", &fakeWindowsPrimitives{
+			privilegedTokenErr: errors.New("lookup account name ~breeze_elev: 1332"),
+		}},
+		{"privileged token found", &fakeWindowsPrimitives{privilegedToken: true}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := newNeverEnabledManager(t, &fakeAccountLifecycle{}, tt.win)
+
+			err := manager.SetEnabled(context.Background(), false)
+			if err == nil {
+				t.Fatal("SetEnabled(false) returned nil on an unproven token scan")
+			}
+			if got, want := err.Error(), "PAM disable cleanup unverified: account:privileged_token_verification_failed"; got != want {
+				t.Fatalf("SetEnabled(false) error = %q, want %q", got, want)
+			}
+			if enabled, _, available, _ := managerState(t, manager); !enabled || available {
+				t.Fatalf("state after an unproven disable: enabled=%v available=%v, want true/false", enabled, available)
+			}
+		})
+	}
+}
+
+// TestReconcileDoesNotTolerateUnresolvableAccountNameInTokenScan is the safety
+// boundary on the tolerance above. Once the ledger carries an actuation, the
+// account demonstrably existed at some point, and a Windows process keeps its
+// token — and therefore the elevated SID — after the account behind it is
+// deleted. An unresolvable name there could be hiding exactly the orphaned
+// elevated process this scan exists to catch, so it must keep failing closed.
+func TestReconcileDoesNotTolerateUnresolvableAccountNameInTokenScan(t *testing.T) {
+	var order []string
+	win := &fakeWindowsPrimitives{
+		order:              &order,
+		bootID:             "windows-boot-after-reboot",
+		privilegedTokenErr: unresolvableAccountErr(),
+	}
+	store := &recordingLifetimeStore{Store: NewStore(filepath.Join(t.TempDir(), "ledger.json")), order: &order}
+	durableActiveEntry(t, store.Store, validApply(1), crashedIdentity)
+	clean := elevaccount.AccountEvidence{Enabled: false, InAdministrators: false}
+	manager := newLifecycleManager(store, win, &fakeAccountLifecycle{order: &order, deprovision: clean, verified: clean}, nil)
+
+	results := manager.Reconcile(context.Background())
+
+	if len(results) != 1 {
+		t.Fatalf("Reconcile returned %d results, want 1", len(results))
+	}
+	if results[0].State != ResultFailed || results[0].FailureCode != "privileged_token_verification_failed" {
+		t.Fatalf("reconcile result = %+v, want failed/privileged_token_verification_failed: an actuation is on record, so an unresolvable account name proves nothing", results[0])
+	}
+	if manager.Available() {
+		t.Fatal("manager reports available after an unverified reconcile")
+	}
+}

--- a/agent/internal/pamlifetime/store.go
+++ b/agent/internal/pamlifetime/store.go
@@ -219,6 +219,12 @@ func (s *Store) Entry(actuationID string) (LedgerEntry, bool) {
 	return entry, ok
 }
 
+// LoadError reports the sticky failure from reading the ledger at startup, if
+// any. Entries() cannot express it: an unreadable ledger yields an empty
+// slice, which is indistinguishable from a device that never actuated. Any
+// caller that draws a conclusion FROM emptiness must consult this first.
+func (s *Store) LoadError() error { return s.loadErr }
+
 func (s *Store) Entries() []LedgerEntry {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
## Root cause

The dormant `~breeze_elev` account is only created when `cfg.PAMEnabled` is set, so on the majority of the fleet it does not exist. Every heartbeat without a UAC-interception policy calls `pamLifetimeManager.SetEnabled(ctx, false)`; with an empty ledger that runs `verifyAccountClean` against that missing account, which failed. Because `m.enabled` is only cleared on success, the next heartbeat repeated the whole cleanup — hence `PAM disable cleanup could not be verified` at ERROR on every heartbeat, forever, on every never-PAM Windows agent.

There were **two independent failure points**, not the one in the issue. `elevaccount`'s `Deprovision`/`VerifyClean` returned `NERR_UserNotFound` (2221) from `NetUserSetInfo`, `NetUserGetInfo` and `NetUserGetLocalGroups` as a real error — but `verifyAccountClean` then calls `VerifyNoPrivilegedToken`, whose first statement resolves the account name to a SID and fails with `ERROR_NONE_MAPPED` (1332) when no such account exists. Fixing only `elevaccount` would have swapped `account_cleanup_failed` for `privileged_token_verification_failed` and left the loop running. Confirmed by an independent audit of the call chain before writing the fix.

## What changed

- **`agent/internal/elevaccount/absent.go`** (new, untagged): one predicate, `IsAccountAbsent`, matching `NERR_UserNotFound` and `ERROR_NONE_MAPPED` as wrapped `syscall.Errno` values. It is deliberately not behind `//go:build windows` so the classification that decides whether the agent reports a cleanup failure is compiled and unit-tested on every platform.
- **`elevaccount_windows.go`**: `Deprovision` and `VerifyClean` return `AccountEvidence{Enabled: false, InAdministrators: false}, nil` when the account is reported absent — an account that does not exist is provably not enabled and provably not in Administrators. Every other status stays a real error.
- **Absence is decided by the probe that names the account**, not by a status code seen at the aggregate level. `accountInAdministrators` and `localGroupMembersCall` both resolve the builtin Administrators alias (`S-1-5-32-544`) *before* they touch the elevation account, and that lookup fails with the very same `ERROR_NONE_MAPPED` — so a machine that cannot resolve its own Administrators group would have read as "elevation account absent, all clean". A package sentinel `errAccountAbsent` is attached only by the syscall that named the account (`NetUserSetInfo`/`NetUserGetInfo`/`NetUserGetLocalGroups` 2221, `LookupSID(username)` 1332); `cleanIfAbsent` and `removeFromAdministrators` match that and nothing else. `IsAccountAbsent` stays as a documented single-call classifier. A measured `enabled == true` followed by an absent report is a contradiction that now fails closed instead of returning clean.
- **`pamlifetime/store.go`**: `Store.Entries()` ignored `loadErr`, so an unreadable ledger was indistinguishable from a device that never actuated. `LoadError()` is now part of the `lifetimeStore` contract, `SetEnabled(false)` fails closed with `account:ledger_unavailable` before the empty-ledger branch, and the never-actuated condition is derived inside `verifyAccountClean` from both signals rather than trusting a caller-supplied bool.
- **`pamlifetime/manager.go`**: the token scan is **not** softened at the primitive. `VerifyNoPrivilegedToken` is also called while reconciling a recorded actuation, and a Windows process keeps its elevated SID after the account behind it is deleted — so an unresolvable name there could be hiding exactly the orphaned elevated process the scan exists to catch. Instead `verifyAccountClean` takes an explicit `neverActuated` flag, true only on the empty-ledger disable path, and tolerates an absent-account lookup failure only there. `reconcileActiveLocked` passes `false`. Every other error, and every error at all once an actuation is on record, still fails closed.
- **Evidence and observability**: a skipped token scan leaves `PrivilegedTokenPresent` nil rather than `boolPtr(false)` — not measured is not the same claim as measured absent — and the skip emits one INFO line, once per agent lifetime (the settled disable returns at the early return on every later call).
- **`.github/workflows/ci.yml`**: `./internal/elevaccount` joins the Windows Go test job. The package is entirely `//go:build windows` netapi32 code whose only Windows-tagged test was a compile-time interface assertion that no CI job ever ran — which is why a mishandled status code in the *default* configuration shipped. Verified the same way the job's comment requires for `logging`/`ipc`: under `GOOS=windows GOARCH=amd64 CGO_ENABLED=0` the package vets, its test binary compiles, and its Windows dependency graph contains no `remote/desktop` and no cgo.

## Tests

Written first and watched fail:

- `elevaccount/absent_test.go` — 20-case table over `IsAccountAbsent`. Runs on **every** platform (so it executes in the existing Linux `Test Agent` job). Covers both wrap shapes the production wrappers use, double wrapping, and negatives: access denied, `NERR_UserExists`, `NERR_UserNotInGroup`, off-by-one on both statuses, a non-errno error, and an error carrying `2221` only in its message text (proves it is not a string match). **Red before the fix**: `undefined: IsAccountAbsent`.
- `pamlifetime/manager_never_enabled_test.go` — `TestSetEnabledFalseToleratesUnresolvableAccountNameInTokenScan` is the genuine regression test. **Verified red before the fix** by flipping `neverActuated` to `false`: `SetEnabled(false) = PAM disable cleanup unverified: account:privileged_token_verification_failed, want nil`. Alongside it: the disable path is a quiet idempotent no-op and a second call does not re-enter the account manager (`Deprovision`/`VerifyClean` call counts pinned at 1); genuine `account_cleanup_failed` and `account_verification_failed` still surface, stay fail-closed and retry; five other token-scan failures (access denied, invalid parameter, non-errno, status-in-text, and an actually-found privileged token) still fail; and `TestReconcileDoesNotTolerateUnresolvableAccountNameInTokenScan` pins the safety boundary — with an actuation on record the same error must still fail.
- `elevaccount/absent_windows_test.go` (Windows-only) — exercises the real netapi32 path: `Deprovision` and `VerifyClean` against the never-provisioned `~breeze_elev`. They skip by design if the account exists or local-account queries are refused, so `ci.yml` also gets a counted step (the shape the `collectors` and `backup` steps already use) that runs exactly these two with `-v` and fails on a SKIP or on a PASS count other than two. The shared Windows step runs without `-v`, where a skip is indistinguishable from a pass — and these are the only live-syscall coverage anywhere of this fix. Also asserts the untagged `errorNoneMapped` constant still equals `windows.ERROR_NONE_MAPPED`.
- `elevaccount/absent_test.go` — `TestCleanIfAbsentConvertsOnlyAbsenceIntoCleanEvidence` covers the shared `cleanIfAbsent` decision all four probe sites delegate to, including the misuse case (handed a nil error it returns an error rather than manufacturing clean evidence for an account nobody probed).

Commands run locally, foreground:

```
cd agent && go build ./... && GOOS=windows GOARCH=amd64 go build ./...
  -> both OK (the elevaccount change is Windows-only code; it cross-compiles)

cd agent && CGO_ENABLED=0 go test -count=1 ./internal/elevaccount/ ./internal/pamlifetime/ ./internal/heartbeat/
  ok  internal/elevaccount   0.238s   (30 PASS, incl. subtests)
  ok  internal/pamlifetime   1.221s   (99 PASS, incl. subtests)
  ok  internal/heartbeat    34.483s

cd agent && go vet ./internal/elevaccount/... ./internal/pamlifetime/...
cd agent && GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go vet ./internal/elevaccount/... ./internal/pamlifetime/...
  -> both clean

cd agent && GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go test -c ./internal/elevaccount/
  -> Windows test binary compiles
```

`go test -race` was also run and is green for `elevaccount` and `pamlifetime`. It cannot be used for `heartbeat` on this machine: `-race` forces cgo on darwin/arm64 and `github.com/shoenig/go-m1cpu` SIGSEGVs in its package `init`, before any test runs. That is pre-existing and environment-specific — CI runs the agent suite with `CGO_ENABLED=0`, which is the command reported above.

## Review round

Three lenses ran (`silent-failure-hunter`, `code-reviewer`, `pr-test-analyzer`). `code-reviewer`: 0 findings. The other two raised three, all addressed in `47a4965` and `5464dc7`:

1. **The fail-closed guarantee was implicit.** For an agent with an actuation on record it rested on `VerifyNoPrivilegedToken` happening to resolve the account name as its first statement — and because the pamlifetime tests drive a *fake* primitive, a future refactor that special-cased "no such account" there would void the contract without reddening a single test. There is now a comment at that `LookupSID` call stating why absence must not be interpreted locally, pointing at `verifyAccountClean`'s `neverActuated` parameter.
2. **Two of the four absence guards shipped unexercised.** Only the first probe in each of `Deprovision`/`VerifyClean` is reachable on a never-provisioned host, so per-site copies of the decision were dead in context. They now share one untagged, unit-tested helper.
3. **A test doc comment overclaimed.** `TestSetEnabledFalseOnNeverProvisionedAgentIsAQuietIdempotentNoOp` called itself "the manager half of issue #4587" but passes with and without the fix — it pins the idempotence contract that turns one failure into an unbounded ERROR loop, not the tolerance. Corrected, and it now names the test that does detect the regression. The reviewer confirmed by reverting `manager.go` wholesale that exactly one test fails: `TestSetEnabledFalseToleratesUnresolvableAccountNameInTokenScan`.

One finding was considered and **not** taken: threading `neverActuated` down into `elevaccount.Deprovision`/`VerifyClean` themselves. Ledger state is manager policy, not something the account layer should know about; scoping it at the caller keeps `elevaccount` reporting facts about the account and leaves one place that decides what they mean.

### Second round (five lenses)

A second independent round found that round one's shared classifier was applied at the wrong level. All findings fixed in `c085c5e`, each red-first:

1. **HIGH — absence inferred from the wrong principal's failure.** Details in "What changed" above. Red-first proof: with `cleanIfAbsent` back on the aggregate errno match, `TestCleanIfAbsentIgnoresAbsenceStatusesFromOtherPrincipals` fails with `cleanIfAbsent(errno 1332) returned evidence {false false} and no error`. This was a defect introduced by round one's own widening of the predicate.
2. **MEDIUM — an unreadable ledger read as "never actuated".** Red-first: without the guard, `TestSetEnabledFalseFailsClosedWhenTheLedgerCannotBeRead` gets `privileged_token_verification_failed` instead of `ledger_unavailable`, and the account manager gets called on a device whose history is unknown.
3. **MEDIUM — unmeasured token evidence reported as measured-false.** Red-first: `TestToleratedTokenScanLeavesPrivilegedTokenEvidenceUnmeasured/skipped_scan` fails with `PrivilegedTokenPresent = false, want nil`.
4. **MEDIUM — the tolerance was invisible.** Now one INFO line on the skipped-scan branch.
5. **Comment accuracy** (`comment-analyzer`): an errno may arrive as *or unwrap to* a `syscall.Errno`; `NERR_InvalidComputer` is an invalid computer name, not an unreachable one; dropped a literal probe-site count that would rot.

**Follow-up, deliberately not in this PR:** surfacing `AccountNeverProvisioned` on `ResultEvidence` so the server can see the tolerated path. The evidence value is discarded on that code path today, so it would need a separate change to be observable end to end.

## Deliberately not done

The issue's optional hardening — gating PAM lifecycle manager construction on `cfg.PAMEnabled` in `Heartbeat.SetStatePath` — is **out of scope for this PR**. It interacts with the reconciliation and `pamReceivedObservationReady` readiness contract and deserves its own change; this PR fixes the reported bug without touching that wiring.

Fixes #4587

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbAcVYJNziZHQtGoGYph9N


