### PR TITLE
fix(db): same-org composite FK on portal_users.contact_id (#3258 follow-up)

### DIFF
--- a/apps/api/migrations/2026-10-04-100002-portal-users-contact-composite-fk.sql
+++ b/apps/api/migrations/2026-10-04-100002-portal-users-contact-composite-fk.sql
@@ -1,0 +1,120 @@
+-- portal_users.contact_id: same-org composite FK (#3258 follow-up to W03)
+--
+-- 2026-08-19-contacts.sql gave `portal_users` a `contact_id` with a PLAIN
+-- single-column FK (`portal_users_contact_fk` -> contacts(id)). Nothing in the
+-- schema forced the LOGIN and the CONTACT behind it into the same
+-- organization, so a cross-org link was representable at the DB level even
+-- though every writer happened to be org-bounded. After W03
+-- (2026-10-04-100000-ticket-requester-contact.sql) this is the LAST plain FK
+-- into `contacts`: `tickets.requester_contact_id` and `contacts.site_id` are
+-- both composite already.
+--
+-- That gap was not theoretical. W03 derives a ticket's requester from the
+-- filer's login (`readPortalUserContactLink` in services/ticketService.ts), so
+-- one drifted `portal_users` row would have proposed a cross-org
+-- `tickets.requester_contact_id` — which the composite FK there rejects as a
+-- raw 23503. W03's own backfill had to carry an `EXISTS (SELECT 1 FROM
+-- contacts c WHERE c.id = pu.contact_id AND c.org_id = t.org_id)` guard purely
+-- to stop such a row aborting the whole migration file. This migration removes
+-- the drift at the source instead of defending against it downstream.
+--
+-- Shape (copied from `tickets_requester_contact_org_fk`, which copied
+-- `contacts_site_org_fk`): the FK is COMPOSITE against
+-- `contacts_id_org_id_uniq (id, org_id)`, so a cross-org login/contact pair is
+-- unrepresentable rather than merely validated. Two non-obvious clauses:
+--   * `ON DELETE SET NULL (contact_id)` — the COLUMN LIST form (PG 15+). A
+--     bare composite SET NULL would also null `org_id`, which is NOT NULL, so
+--     deleting a contact would fail instead of unlinking the login. Preserving
+--     "deleting a contact never destroys someone's portal login" is the whole
+--     reason the original FK was ON DELETE SET NULL, and org erasure
+--     (tenantCascade deletes `contacts` before `portal_users`, alphabetically)
+--     depends on it too.
+--   * `DEFERRABLE INITIALLY IMMEDIATE` — required of every composite FK whose
+--     referenced side includes an `org_id` column by
+--     orgLifecycleFoundations.integration.test.ts. Org merge runs
+--     `SET CONSTRAINTS ALL DEFERRED` and re-points `portal_users` and
+--     `contacts` in separate statements of one transaction (both are in the
+--     merge registry: `portal_users` is a plain repoint, `contacts` a custom
+--     repoint), so a non-deferrable constraint here would abort the merge
+--     mid-walk.
+--
+-- Registration (CLAUDE.md cascade table): NOTHING to add. No new table and no
+-- new column — `portal_users` is already in CORE_ORG_CASCADE_DELETE_ORDER and
+-- its `contact_id` is already classified `included` in CORE_TENANT_EXPORT_POLICY
+-- (tenantExportPolicyRegistry.ts). The export-policy list is the one that fires
+-- on a new COLUMN, and this migration adds none.
+
+-- `portal_users` is ENABLE + FORCE ROW LEVEL SECURITY and
+-- `breeze_current_scope()` defaults to 'none' (deny), so the cleanup UPDATE
+-- below would match ZERO rows on managed Postgres where the migration role is
+-- not a superuser — a silent no-op reporting a truthful-looking "cleaned 0".
+-- `is_local = true` scopes this to autoMigrate's per-file transaction.
+-- See 2026-09-30-100000-rls-scoped-backfill-replay.sql for the full write-up.
+SELECT set_config('breeze.scope', 'system', true);
+
+-- Cleanup BEFORE the constraint: any pre-existing drifted row would make the
+-- ADD CONSTRAINT below fail its initial validation and abort the whole file on
+-- every database that has the drift, with no way to skip it. Nulling the link
+-- is the recoverable direction (a technician can re-invite; the login itself
+-- and its ticket history are untouched), and it is exactly what
+-- `ON DELETE SET NULL (contact_id)` would have done had the contact been
+-- deleted instead of moved.
+--
+-- The count is reported UNCONDITIONALLY. A non-zero count is evidence that a
+-- login was pointing at a person in another tenant — potentially a
+-- tenant-isolation incident — and the forensic trail has to survive even when
+-- the number is 0, because a suppressed 0 is indistinguishable from the RLS
+-- no-op the `breeze.scope` note above describes.
+DO $$
+DECLARE
+  n bigint;
+BEGIN
+  UPDATE portal_users pu
+     SET contact_id = NULL
+    FROM contacts c
+   WHERE c.id = pu.contact_id
+     AND c.org_id <> pu.org_id;
+  GET DIAGNOSTICS n = ROW_COUNT;
+  RAISE WARNING 'cleaned % cross-org portal_users.contact_id link(s)', n;
+END $$;
+
+-- Drop the plain single-column FK. The name is the one 2026-08-19-contacts.sql
+-- declared explicitly (`portal_users_contact_fk`), not a Drizzle-generated
+-- `portal_users_contact_id_contacts_id_fk` — the column was added by
+-- hand-written SQL, and `db:check-drift` never generated a migration for it.
+-- Guarded so a re-apply is a no-op rather than an error.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conname = 'portal_users_contact_fk'
+       AND conrelid = 'portal_users'::regclass
+  ) THEN
+    ALTER TABLE portal_users DROP CONSTRAINT portal_users_contact_fk;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conname = 'portal_users_contact_org_fk'
+       AND conrelid = 'portal_users'::regclass
+  ) THEN
+    ALTER TABLE portal_users
+      ADD CONSTRAINT portal_users_contact_org_fk
+      FOREIGN KEY (contact_id, org_id)
+      REFERENCES contacts (id, org_id)
+      ON DELETE SET NULL (contact_id)
+      DEFERRABLE INITIALLY IMMEDIATE;
+  END IF;
+END $$;
+
+-- The partial index from 2026-08-19-contacts.sql stays: dropping the plain FK
+-- does not drop it (it was created separately), and the composite FK's own
+-- index requirement is on the REFERENCED side (contacts_id_org_id_uniq), not
+-- here. Re-stated with IF NOT EXISTS so a database that somehow lost it is
+-- repaired rather than left without the index behind "tickets for this
+-- contact's login".
+CREATE INDEX IF NOT EXISTS portal_users_contact_idx
+  ON portal_users (contact_id) WHERE contact_id IS NOT NULL;

--- a/apps/api/migrations/2026-10-04-100002-portal-users-contact-composite-fk.sql
+++ b/apps/api/migrations/2026-10-04-100002-portal-users-contact-composite-fk.sql
@@ -24,11 +24,19 @@
 -- unrepresentable rather than merely validated. Two non-obvious clauses:
 --   * `ON DELETE SET NULL (contact_id)` — the COLUMN LIST form (PG 15+). A
 --     bare composite SET NULL would also null `org_id`, which is NOT NULL, so
---     deleting a contact would fail instead of unlinking the login. Preserving
---     "deleting a contact never destroys someone's portal login" is the whole
---     reason the original FK was ON DELETE SET NULL, and org erasure
---     (tenantCascade deletes `contacts` before `portal_users`, alphabetically)
---     depends on it too.
+--     deleting a contact would fail instead of unlinking the login.
+--     Preserving "deleting a contact never destroys someone's portal login" is
+--     the whole reason the original FK was ON DELETE SET NULL, and the path
+--     that exercises it is the INTERACTIVE one: `deleteContact` on a contact
+--     that some login is bound to.
+--
+--     It is NOT org erasure. `cascadeDeleteOrg` orders its DELETEs with
+--     `topologicalCascadeOrder()`, whose pg_constraint read counts every FK
+--     edge regardless of `confdeltype` — so this very constraint makes
+--     `portal_users` a CHILD of `contacts` and it is deleted FIRST. The
+--     referential action never fires during an erasure. (Which is also why
+--     adding this FK cannot reorder an erasure into an FK violation: it moves
+--     `portal_users` earlier, never later.)
 --   * `DEFERRABLE INITIALLY IMMEDIATE` — required of every composite FK whose
 --     referenced side includes an `org_id` column by
 --     orgLifecycleFoundations.integration.test.ts. Org merge runs
@@ -78,20 +86,36 @@ BEGIN
   RAISE WARNING 'cleaned % cross-org portal_users.contact_id link(s)', n;
 END $$;
 
--- Drop the plain single-column FK. The name is the one 2026-08-19-contacts.sql
--- declared explicitly (`portal_users_contact_fk`), not a Drizzle-generated
--- `portal_users_contact_id_contacts_id_fk` — the column was added by
--- hand-written SQL, and `db:check-drift` never generated a migration for it.
--- Guarded so a re-apply is a no-op rather than an error.
+-- Drop the superseded single-column FK, by SHAPE rather than by name.
+--
+-- On a database migrated from this repo the name is the one
+-- 2026-08-19-contacts.sql declared explicitly (`portal_users_contact_fk`), but
+-- a developer database built with `drizzle-kit push` carries the generated
+-- alias `portal_users_contact_id_contacts_id_fk` instead, and a hand-repaired
+-- one could carry anything. Matching on "single-column FK from portal_users to
+-- contacts" converges all of them, and cannot touch the composite added below
+-- (cardinality 2) or the org_id FK (a different `confrelid`).
+--
+-- Leaving one behind would not re-open the cross-org hole — Postgres evaluates
+-- FK constraints conjunctively, so a surviving single-column FK is redundant
+-- rather than permissive — but it WOULD leave two SET NULL actions racing on
+-- one column and a second, unnecessary lock on `contacts`. The suite asserts
+-- exactly one FK from portal_users to contacts survives.
 DO $$
+DECLARE
+  fk record;
 BEGIN
-  IF EXISTS (
-    SELECT 1 FROM pg_constraint
-     WHERE conname = 'portal_users_contact_fk'
+  FOR fk IN
+    SELECT conname
+      FROM pg_constraint
+     WHERE contype = 'f'
        AND conrelid = 'portal_users'::regclass
-  ) THEN
-    ALTER TABLE portal_users DROP CONSTRAINT portal_users_contact_fk;
-  END IF;
+       AND confrelid = 'contacts'::regclass
+       AND cardinality(conkey) = 1
+  LOOP
+    EXECUTE format('ALTER TABLE portal_users DROP CONSTRAINT %I', fk.conname);
+    RAISE WARNING 'dropped superseded single-column FK portal_users.% -> contacts', fk.conname;
+  END LOOP;
 END $$;
 
 DO $$

--- a/apps/api/src/__tests__/integration/contactsBackfillMigration.integration.test.ts
+++ b/apps/api/src/__tests__/integration/contactsBackfillMigration.integration.test.ts
@@ -47,6 +47,17 @@ import { createOrganization, createPartner, createSite } from './db-utils';
 import { getTestDb } from './setup';
 
 const MIGRATION_FILE = join(__dirname, '../../../migrations/2026-08-19-contacts.sql');
+// #3258 follow-up. 2026-08-19's FK guard is name-only (`IF NOT EXISTS (SELECT 1
+// FROM pg_constraint WHERE conname = 'portal_users_contact_fk')`), so replaying
+// that file RE-CREATES the superseded single-column FK this later migration
+// dropped. Replaying this one straight after puts the schema back — it drops
+// any single-column portal_users -> contacts FK by shape and re-asserts the
+// composite. Without it the replay leaks schema damage into every suite
+// sharing this database (portalUserContactCompositeFk runs in the same shard).
+const PORTAL_USER_FK_MIGRATION_FILE = join(
+  __dirname,
+  '../../../migrations/2026-10-04-100002-portal-users-contact-composite-fk.sql',
+);
 
 const runDb = it.runIf(!!process.env.DATABASE_URL);
 
@@ -58,6 +69,21 @@ const runDb = it.runIf(!!process.env.DATABASE_URL);
  */
 async function replayMigration() {
   await getTestDb().execute(sql.raw(readFileSync(MIGRATION_FILE, 'utf8')));
+  // Restore the schema this file's name-only FK guard just walked backwards.
+  await getTestDb().execute(sql.raw(readFileSync(PORTAL_USER_FK_MIGRATION_FILE, 'utf8')));
+  const rows = (await getTestDb().execute(sql`
+    SELECT count(*)::int AS count
+      FROM pg_constraint
+     WHERE contype = 'f'
+       AND conrelid = 'portal_users'::regclass
+       AND confrelid = 'contacts'::regclass
+       AND cardinality(conkey) = 1
+  `)) as unknown as Array<{ count: number }>;
+  const count = rows[0]?.count ?? -1;
+  // Fail HERE, not three suites later in whichever file shares the database.
+  if (count !== 0) {
+    throw new Error(`replayMigration left ${count} single-column portal_users -> contacts FK(s) behind`);
+  }
 }
 
 const unique = () => `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;

--- a/apps/api/src/__tests__/integration/inboundEmailContactRequester.integration.test.ts
+++ b/apps/api/src/__tests__/integration/inboundEmailContactRequester.integration.test.ts
@@ -59,6 +59,13 @@ import * as orgMergeModule from '../../services/orgMerge';
 import { devices, sites } from '../../db/schema';
 
 const MIGRATION_FILE = join(__dirname, '../../../migrations/2026-10-04-100000-ticket-requester-contact.sql');
+// The follow-up that made portal_users.contact_id same-org (#3258). Needed here
+// only to RESTORE that constraint after the drift-tolerance test forges a row
+// it forbids.
+const PORTAL_USER_FK_MIGRATION_FILE = join(
+  __dirname,
+  '../../../migrations/2026-10-04-100002-portal-users-contact-composite-fk.sql',
+);
 
 const uniqueSuffix = () => `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 const admin = () => getTestDb() as any;
@@ -519,11 +526,18 @@ describe('2026-10-04-100000-ticket-requester-contact.sql', () => {
   });
 
   it('skips a login whose contact lives in ANOTHER org instead of aborting the file', async () => {
-    // portal_users.contact_id is a SINGLE-column FK to contacts(id): nothing in
-    // the schema forces the login and its contact into the same org. Such a
-    // drifted row makes the backfill propose a pair the composite FK rejects,
-    // and a 23503 inside a migration aborts the WHOLE file — on every database
-    // that has the drift, with no way to skip it.
+    // When THIS migration shipped, portal_users.contact_id was a SINGLE-column
+    // FK to contacts(id): nothing in the schema forced the login and its
+    // contact into the same org. Such a drifted row makes the backfill propose
+    // a pair the composite FK rejects, and a 23503 inside a migration aborts
+    // the WHOLE file — on every database that has the drift, with no way to
+    // skip it. The `EXISTS ... c.org_id = t.org_id` guard in the backfill is
+    // what keeps that from happening, and this is its test.
+    //
+    // 2026-10-04-100002-portal-users-contact-composite-fk.sql later closed the
+    // gap at the source, so the drift is no longer representable and has to be
+    // forged with that constraint dropped — which is exactly the state a
+    // database replaying migrations in order is in when THIS file runs.
     const otherOrg = await createOrganization({ partnerId: fx.partnerId });
     seeded.orgIds.push(otherOrg.id);
     const suffix = uniqueSuffix();
@@ -531,30 +545,40 @@ describe('2026-10-04-100000-ticket-requester-contact.sql', () => {
       .insert(contacts)
       .values({ orgId: otherOrg.id, email: `drift-${suffix}@example.test`, name: 'Drifted' })
       .returning({ id: contacts.id });
-    const [login] = await admin()
-      .insert(portalUsers)
-      .values({ orgId: fx.orgId, email: `drift-${suffix}@example.test`, name: 'Drifted', contactId: foreignContact.id })
-      .returning({ id: portalUsers.id });
-    const [ticket] = await admin()
-      .insert(tickets)
-      .values({
-        orgId: fx.orgId,
-        partnerId: fx.partnerId,
-        ticketNumber: `DRIFT-${suffix}`,
-        internalNumber: `T-2026-${suffix.slice(-4)}`,
-        subject: 'Drifted login',
-        status: 'open',
-        source: 'portal',
-        submittedBy: login.id,
-      })
-      .returning({ id: tickets.id });
+    await admin().execute(sql`ALTER TABLE portal_users DROP CONSTRAINT IF EXISTS portal_users_contact_org_fk`);
+    let ticketId: string;
+    try {
+      const [login] = await admin()
+        .insert(portalUsers)
+        .values({ orgId: fx.orgId, email: `drift-${suffix}@example.test`, name: 'Drifted', contactId: foreignContact.id })
+        .returning({ id: portalUsers.id });
+      const [ticket] = await admin()
+        .insert(tickets)
+        .values({
+          orgId: fx.orgId,
+          partnerId: fx.partnerId,
+          ticketNumber: `DRIFT-${suffix}`,
+          internalNumber: `T-2026-${suffix.slice(-4)}`,
+          subject: 'Drifted login',
+          status: 'open',
+          source: 'portal',
+          submittedBy: login.id,
+        })
+        .returning({ id: tickets.id });
+      ticketId = ticket.id;
 
-    await expect(admin().execute(sql.raw(readFileSync(MIGRATION_FILE, 'utf8')))).resolves.toBeDefined();
+      await expect(admin().execute(sql.raw(readFileSync(MIGRATION_FILE, 'utf8')))).resolves.toBeDefined();
+    } finally {
+      // Restore the constraint for the rest of the shard. Replaying the later
+      // migration is the honest way to do it — it nulls the forged link on its
+      // way past, which is the cleanup that file exists to perform.
+      await admin().execute(sql.raw(readFileSync(PORTAL_USER_FK_MIGRATION_FILE, 'utf8')));
+    }
 
     const [row] = await admin()
       .select({ requesterContactId: tickets.requesterContactId })
       .from(tickets)
-      .where(eq(tickets.id, ticket.id));
+      .where(eq(tickets.id, ticketId!));
     // Left unlinked — recoverable — rather than blocking the deploy.
     expect(row.requesterContactId).toBeNull();
   });

--- a/apps/api/src/__tests__/integration/inboundEmailContactRequester.integration.test.ts
+++ b/apps/api/src/__tests__/integration/inboundEmailContactRequester.integration.test.ts
@@ -575,6 +575,19 @@ describe('2026-10-04-100000-ticket-requester-contact.sql', () => {
       await admin().execute(sql.raw(readFileSync(PORTAL_USER_FK_MIGRATION_FILE, 'utf8')));
     }
 
+    // Assert the restore landed HERE, at its source. Leaving portal_users
+    // unconstrained would blame whichever suite in this shard next touches
+    // contact_id — and a replay of 2026-08-19-contacts.sql (whose FK guard is
+    // name-only) would quietly resurrect the superseded single-column FK too.
+    const restored = (await admin().execute(sql`
+      SELECT conname FROM pg_constraint
+       WHERE contype = 'f'
+         AND conrelid = 'portal_users'::regclass
+         AND confrelid = 'contacts'::regclass
+       ORDER BY conname
+    `)) as unknown as Array<{ conname: string }>;
+    expect(restored.map((r) => r.conname)).toEqual(['portal_users_contact_org_fk']);
+
     const [row] = await admin()
       .select({ requesterContactId: tickets.requesterContactId })
       .from(tickets)

--- a/apps/api/src/__tests__/integration/portalUserContactCompositeFk.integration.test.ts
+++ b/apps/api/src/__tests__/integration/portalUserContactCompositeFk.integration.test.ts
@@ -1,0 +1,307 @@
+/**
+ * #3258 follow-up — `portal_users.contact_id` is same-org at the DATABASE level.
+ *
+ * W03 left `portal_users.contact_id` as the last PLAIN single-column FK into
+ * `contacts`, so a login in org A pointing at a person in org B was
+ * representable even though every writer happened to be org-bounded. That is
+ * exactly the state W03's own ticket backfill had to defend against with an
+ * `EXISTS ... AND c.org_id = t.org_id` guard, because such a row would have
+ * proposed a cross-org `tickets.requester_contact_id` and aborted the whole
+ * migration file.
+ *
+ * Only a real Postgres can prove the four claims that matter:
+ *
+ *  1. A cross-org login/contact pair is REJECTED, on INSERT and on UPDATE, by
+ *     `portal_users_contact_org_fk` — not by an app-layer check that a second
+ *     writer could forget. The write itself is the test.
+ *  2. Deleting the contact still unlinks the login instead of failing. The
+ *     column-list `ON DELETE SET NULL (contact_id)` is what makes that true; a
+ *     bare composite SET NULL would try to null the NOT NULL `org_id`. Org
+ *     erasure depends on this (tenantCascade deletes `contacts` before
+ *     `portal_users`).
+ *  3. Org MERGE keeps the link. Both tables re-tenant to the survivor in one
+ *     transaction under `SET CONSTRAINTS ALL DEFERRED`, which only works
+ *     because the constraint is DEFERRABLE — nulling the link there would
+ *     silently destroy the customer's portal ownership of their own history.
+ *  4. The migration is replayable and its cleanup really nulls a pre-existing
+ *     drifted row (autoMigrate re-applies by filename; a half-applied
+ *     constraint would abort boot).
+ *
+ * Fixtures are written with the admin/superuser handle, deliberately bypassing
+ * the app-layer guards: the point is what the DATABASE refuses, which is what
+ * makes those guards a nicety rather than the boundary.
+ */
+import './setup';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { eq, sql } from 'drizzle-orm';
+
+import { contacts, devices, organizations, partners, sites } from '../../db/schema';
+import { portalUsers } from '../../db/schema/portal';
+import { createOrganization, createPartner } from './db-utils';
+import { getTestDb } from './setup';
+import * as orgMergeModule from '../../services/orgMerge';
+
+const MIGRATION_FILE = join(
+  __dirname,
+  '../../../migrations/2026-10-04-100002-portal-users-contact-composite-fk.sql',
+);
+
+const uniqueSuffix = () => `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+const admin = () => getTestDb() as any;
+
+const seeded = { partnerIds: [] as string[], orgIds: [] as string[] };
+
+let fx: { partnerId: string; orgId: string };
+
+beforeEach(async () => {
+  const partner = await createPartner();
+  const org = await createOrganization({ partnerId: partner.id });
+  seeded.partnerIds.push(partner.id);
+  seeded.orgIds.push(org.id);
+  fx = { partnerId: partner.id, orgId: org.id };
+});
+
+afterAll(async () => {
+  const db = admin();
+  if (seeded.partnerIds.length === 0) return;
+  const partnerList = sql.join(seeded.partnerIds.map((id) => sql`${id}`), sql`, `);
+  const orgList = sql.join(seeded.orgIds.map((id) => sql`${id}`), sql`, `);
+
+  await db.delete(portalUsers).where(sql`${portalUsers.orgId} IN (${orgList})`);
+  await db.delete(contacts).where(sql`${contacts.orgId} IN (${orgList})`);
+  await db.execute(sql`DELETE FROM audit_logs WHERE org_id IN (${orgList})`);
+  await db.execute(sql`DELETE FROM org_merge_events WHERE partner_id IN (${partnerList})`);
+  await db.delete(devices).where(sql`${devices.orgId} IN (${orgList})`);
+  await db.delete(sites).where(sql`${sites.orgId} IN (${orgList})`);
+  await db.delete(organizations).where(sql`${organizations.id} IN (${orgList})`);
+  await db.delete(partners).where(sql`${partners.id} IN (${partnerList})`);
+});
+
+/** A contact in `orgId`. */
+async function seedContact(orgId: string, label = 'Person') {
+  const suffix = uniqueSuffix();
+  const [row] = await admin()
+    .insert(contacts)
+    .values({ orgId, email: `pu-fk-${suffix}@example.test`, name: label })
+    .returning({ id: contacts.id });
+  return row.id as string;
+}
+
+/** A portal LOGIN in `orgId`, optionally already linked to `contactId`. */
+async function seedLogin(orgId: string, contactId: string | null = null) {
+  const suffix = uniqueSuffix();
+  const [row] = await admin()
+    .insert(portalUsers)
+    .values({
+      orgId,
+      email: `login-${suffix}@example.test`,
+      name: 'Login Person',
+      passwordHash: null,
+      contactId,
+    })
+    .returning({ id: portalUsers.id });
+  return row.id as string;
+}
+
+/** A second org under the same partner, registered for teardown. */
+async function otherOrg() {
+  const org = await createOrganization({ partnerId: fx.partnerId });
+  seeded.orgIds.push(org.id);
+  return org.id as string;
+}
+
+describe('portal_users_contact_org_fk — the composite same-org FK', () => {
+  it('refuses an INSERT of a login in org A naming a contact in org B', async () => {
+    const foreignContact = await seedContact(await otherOrg(), 'Foreign');
+
+    const forge = admin()
+      .insert(portalUsers)
+      .values({
+        orgId: fx.orgId,
+        email: `forge-${uniqueSuffix()}@example.test`,
+        name: 'Cross-tenant login',
+        passwordHash: null,
+        contactId: foreignContact,
+      });
+
+    // Drizzle wraps the driver error, so the pg code lives on `cause`. The
+    // CONSTRAINT NAME is asserted too: a bare 23503 would also be satisfied by
+    // the org_id FK, which is not what this test is about.
+    await expect(forge).rejects.toMatchObject({
+      cause: { code: '23503', constraint_name: 'portal_users_contact_org_fk' },
+    });
+  });
+
+  it('refuses an UPDATE that repoints an existing login at a contact in another org', async () => {
+    const loginId = await seedLogin(fx.orgId, await seedContact(fx.orgId, 'Home'));
+    const foreignContact = await seedContact(await otherOrg(), 'Foreign');
+
+    // The INSERT case alone would leave the drift reachable by any writer that
+    // patches contact_id on a row that already exists — the invite route's
+    // `contactPatch` is exactly that shape.
+    const forge = admin()
+      .update(portalUsers)
+      .set({ contactId: foreignContact })
+      .where(eq(portalUsers.id, loginId));
+
+    await expect(forge).rejects.toMatchObject({
+      cause: { code: '23503', constraint_name: 'portal_users_contact_org_fk' },
+    });
+  });
+
+  it('accepts a same-org link (the constraint is not simply rejecting everything)', async () => {
+    const contactId = await seedContact(fx.orgId, 'Home');
+    const loginId = await seedLogin(fx.orgId, contactId);
+
+    const [row] = await admin()
+      .select({ contactId: portalUsers.contactId })
+      .from(portalUsers)
+      .where(eq(portalUsers.id, loginId));
+    expect(row.contactId).toBe(contactId);
+  });
+
+  it('unlinks the login when the contact is deleted, without nulling its org_id', async () => {
+    // The column-list `ON DELETE SET NULL (contact_id)` form. A bare composite
+    // SET NULL would try to null org_id (NOT NULL) and the DELETE would fail —
+    // which would also break org erasure, where tenantCascade deletes
+    // `contacts` before `portal_users`.
+    const contactId = await seedContact(fx.orgId, 'Doomed');
+    const loginId = await seedLogin(fx.orgId, contactId);
+
+    await admin().delete(contacts).where(eq(contacts.id, contactId));
+
+    const [row] = await admin()
+      .select({ contactId: portalUsers.contactId, orgId: portalUsers.orgId })
+      .from(portalUsers)
+      .where(eq(portalUsers.id, loginId));
+    expect(row.contactId).toBeNull();
+    expect(row.orgId).toBe(fx.orgId);
+  });
+
+  it('is DEFERRABLE, and the superseded single-column FK is gone', async () => {
+    const [row] = await admin().execute(sql`
+      SELECT condeferrable, condeferred
+        FROM pg_constraint
+       WHERE conname = 'portal_users_contact_org_fk'
+         AND conrelid = 'portal_users'::regclass
+    `);
+    // INITIALLY IMMEDIATE: deferred only when org merge asks for it.
+    expect(row).toMatchObject({ condeferrable: true, condeferred: false });
+
+    const [{ count }] = await admin().execute(sql`
+      SELECT count(*)::int AS count
+        FROM pg_constraint
+       WHERE conname = 'portal_users_contact_fk'
+         AND conrelid = 'portal_users'::regclass
+    `);
+    // Leaving the plain FK in place would keep single-column cross-org links
+    // representable through it, defeating the whole migration.
+    expect(count).toBe(0);
+  });
+});
+
+describe('org merge KEEPS the portal user’s contact link', () => {
+  let priorDrain: string | undefined;
+
+  beforeEach(() => {
+    priorDrain = process.env.ORG_MERGE_FENCE_DRAIN_MS;
+    process.env.ORG_MERGE_FENCE_DRAIN_MS = '0';
+  });
+  afterEach(() => {
+    if (priorDrain === undefined) delete process.env.ORG_MERGE_FENCE_DRAIN_MS;
+    else process.env.ORG_MERGE_FENCE_DRAIN_MS = priorDrain;
+  });
+
+  it('re-tenants login AND contact to the survivor with the link intact', async () => {
+    // `portal_users` is a plain repoint in the merge registry and `contacts` a
+    // custom one, so their org_id UPDATEs land in SEPARATE statements of one
+    // transaction. Only `SET CONSTRAINTS ALL DEFERRED` plus a DEFERRABLE
+    // constraint lets the pair cross the org boundary together; a
+    // NOT DEFERRABLE composite FK here would abort the merge mid-walk.
+    const survivorId = await otherOrg();
+    const contactId = await seedContact(fx.orgId, 'Merging Person');
+    const loginId = await seedLogin(fx.orgId, contactId);
+
+    await orgMergeModule.executeOrgMerge({
+      loserOrgId: fx.orgId,
+      survivorOrgId: survivorId,
+      partnerId: fx.partnerId,
+      performedBy: randomUUID(),
+      performedByEmail: `merge-actor-${uniqueSuffix()}@example.test`,
+    });
+
+    const [loginRow] = await admin()
+      .select({ orgId: portalUsers.orgId, contactId: portalUsers.contactId })
+      .from(portalUsers)
+      .where(eq(portalUsers.id, loginId));
+    const [contactRow] = await admin()
+      .select({ orgId: contacts.orgId })
+      .from(contacts)
+      .where(eq(contacts.id, contactId));
+
+    expect(loginRow.orgId).toBe(survivorId);
+    expect(contactRow.orgId).toBe(survivorId);
+    // The whole point: SAME contact, still linked.
+    expect(loginRow.contactId).toBe(contactId);
+  });
+});
+
+describe('2026-10-04-100002-portal-users-contact-composite-fk.sql', () => {
+  it('is idempotent — a second apply is a no-op, not a duplicate-constraint abort', async () => {
+    const text = readFileSync(MIGRATION_FILE, 'utf8');
+    await admin().execute(sql.raw(text));
+    await admin().execute(sql.raw(text));
+
+    const [{ count: fkCount }] = await admin().execute(sql`
+      SELECT count(*)::int AS count FROM pg_constraint
+       WHERE conname = 'portal_users_contact_org_fk' AND conrelid = 'portal_users'::regclass
+    `);
+    expect(fkCount).toBe(1);
+    const [{ count: idxCount }] = await admin().execute(
+      sql`SELECT count(*)::int AS count FROM pg_indexes WHERE indexname = 'portal_users_contact_idx'`,
+    );
+    expect(idxCount).toBe(1);
+  });
+
+  it('nulls a pre-existing cross-org link instead of aborting the ADD CONSTRAINT', async () => {
+    // The drift this simulates is unrepresentable once the constraint exists,
+    // so it has to be forged with the constraint off — which is precisely the
+    // state every database is in the instant BEFORE this migration runs. A
+    // drifted row left in place would fail the ADD CONSTRAINT's initial
+    // validation and abort the whole file on every affected database.
+    const foreignContact = await seedContact(await otherOrg(), 'Drifted');
+    const loginId = await seedLogin(fx.orgId, null);
+
+    await admin().execute(
+      sql`ALTER TABLE portal_users DROP CONSTRAINT portal_users_contact_org_fk`,
+    );
+    try {
+      await admin()
+        .update(portalUsers)
+        .set({ contactId: foreignContact })
+        .where(eq(portalUsers.id, loginId));
+
+      // Applying the migration must SUCCEED (not 23503) and clean the row.
+      await expect(
+        admin().execute(sql.raw(readFileSync(MIGRATION_FILE, 'utf8'))),
+      ).resolves.toBeDefined();
+    } finally {
+      // The migration re-adds the constraint on its way through; if it threw
+      // before that point, restore it so the rest of the shard is not left
+      // running against an unconstrained table.
+      await admin().execute(sql.raw(readFileSync(MIGRATION_FILE, 'utf8')));
+    }
+
+    const [row] = await admin()
+      .select({ contactId: portalUsers.contactId, orgId: portalUsers.orgId })
+      .from(portalUsers)
+      .where(eq(portalUsers.id, loginId));
+    // Unlinked — recoverable by re-inviting — rather than blocking the deploy,
+    // and the login itself survives with its org intact.
+    expect(row.contactId).toBeNull();
+    expect(row.orgId).toBe(fx.orgId);
+  });
+});

--- a/apps/api/src/__tests__/integration/portalUserContactCompositeFk.integration.test.ts
+++ b/apps/api/src/__tests__/integration/portalUserContactCompositeFk.integration.test.ts
@@ -9,27 +9,37 @@
  * proposed a cross-org `tickets.requester_contact_id` and aborted the whole
  * migration file.
  *
- * Only a real Postgres can prove the four claims that matter:
+ * Only a real Postgres can prove the claims that matter:
  *
  *  1. A cross-org login/contact pair is REJECTED, on INSERT and on UPDATE, by
  *     `portal_users_contact_org_fk` — not by an app-layer check that a second
  *     writer could forget. The write itself is the test.
- *  2. Deleting the contact still unlinks the login instead of failing. The
- *     column-list `ON DELETE SET NULL (contact_id)` is what makes that true; a
- *     bare composite SET NULL would try to null the NOT NULL `org_id`. Org
- *     erasure depends on this (tenantCascade deletes `contacts` before
- *     `portal_users`).
- *  3. Org MERGE keeps the link. Both tables re-tenant to the survivor in one
+ *  2. Exactly ONE FK runs from `portal_users` to `contacts` afterwards, and it
+ *     is the composite. (A surviving single-column FK would not re-open the
+ *     hole — Postgres evaluates FK constraints conjunctively, so it is
+ *     redundant, never permissive — but it would leave two SET NULL actions on
+ *     one column and a second lock on `contacts`.)
+ *  3. Deleting the contact still unlinks the login instead of failing, for the
+ *     ORDINARY app role as well as the superuser. The column-list
+ *     `ON DELETE SET NULL (contact_id)` is what makes that true; a bare
+ *     composite SET NULL would try to null the NOT NULL `org_id`. The path
+ *     that exercises it is the interactive `deleteContact`, NOT org erasure:
+ *     `topologicalCascadeOrder()` counts every FK edge regardless of
+ *     `confdeltype`, so this constraint makes `portal_users` a CHILD of
+ *     `contacts` and it is deleted FIRST.
+ *  4. Org MERGE keeps the link. Both tables re-tenant to the survivor in one
  *     transaction under `SET CONSTRAINTS ALL DEFERRED`, which only works
  *     because the constraint is DEFERRABLE — nulling the link there would
  *     silently destroy the customer's portal ownership of their own history.
- *  4. The migration is replayable and its cleanup really nulls a pre-existing
- *     drifted row (autoMigrate re-applies by filename; a half-applied
- *     constraint would abort boot).
+ *  5. The migration is replayable; its cleanup really nulls a pre-existing
+ *     drifted row; that cleanup is RLS-scoped by
+ *     `set_config('breeze.scope','system')` and matches nothing without it;
+ *     and it reports its count as a WARNING even when the count is zero.
  *
  * Fixtures are written with the admin/superuser handle, deliberately bypassing
  * the app-layer guards: the point is what the DATABASE refuses, which is what
- * makes those guards a nicety rather than the boundary.
+ * makes those guards a nicety rather than the boundary. The two cases that are
+ * ABOUT the unprivileged role say so and use `getAppDb()` / `db` instead.
  */
 import './setup';
 import { readFileSync } from 'node:fs';
@@ -37,20 +47,36 @@ import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { eq, sql } from 'drizzle-orm';
+import postgres from 'postgres';
 
+import { db, withDbAccessContext, type DbAccessContext } from '../../db';
 import { contacts, devices, organizations, partners, sites } from '../../db/schema';
 import { portalUsers } from '../../db/schema/portal';
 import { createOrganization, createPartner } from './db-utils';
-import { getTestDb } from './setup';
+import { getAppDb, getTestDb } from './setup';
 import * as orgMergeModule from '../../services/orgMerge';
 
 const MIGRATION_FILE = join(
   __dirname,
   '../../../migrations/2026-10-04-100002-portal-users-contact-composite-fk.sql',
 );
+const migrationSql = () => readFileSync(MIGRATION_FILE, 'utf8');
+
+const DATABASE_URL =
+  process.env.DATABASE_URL ?? 'postgresql://breeze_test:breeze_test@localhost:5433/breeze_test';
 
 const uniqueSuffix = () => `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 const admin = () => getTestDb() as any;
+
+function orgCtx(orgId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    currentPartnerId: null,
+  };
+}
 
 const seeded = { partnerIds: [] as string[], orgIds: [] as string[] };
 
@@ -65,20 +91,44 @@ beforeEach(async () => {
 });
 
 afterAll(async () => {
-  const db = admin();
+  const db_ = admin();
   if (seeded.partnerIds.length === 0) return;
   const partnerList = sql.join(seeded.partnerIds.map((id) => sql`${id}`), sql`, `);
   const orgList = sql.join(seeded.orgIds.map((id) => sql`${id}`), sql`, `);
 
-  await db.delete(portalUsers).where(sql`${portalUsers.orgId} IN (${orgList})`);
-  await db.delete(contacts).where(sql`${contacts.orgId} IN (${orgList})`);
-  await db.execute(sql`DELETE FROM audit_logs WHERE org_id IN (${orgList})`);
-  await db.execute(sql`DELETE FROM org_merge_events WHERE partner_id IN (${partnerList})`);
-  await db.delete(devices).where(sql`${devices.orgId} IN (${orgList})`);
-  await db.delete(sites).where(sql`${sites.orgId} IN (${orgList})`);
-  await db.delete(organizations).where(sql`${organizations.id} IN (${orgList})`);
-  await db.delete(partners).where(sql`${partners.id} IN (${partnerList})`);
+  await db_.delete(portalUsers).where(sql`${portalUsers.orgId} IN (${orgList})`);
+  await db_.delete(contacts).where(sql`${contacts.orgId} IN (${orgList})`);
+  await db_.execute(sql`DELETE FROM audit_logs WHERE org_id IN (${orgList})`);
+  await db_.execute(sql`DELETE FROM org_merge_events WHERE partner_id IN (${partnerList})`);
+  await db_.delete(devices).where(sql`${devices.orgId} IN (${orgList})`);
+  await db_.delete(sites).where(sql`${sites.orgId} IN (${orgList})`);
+  await db_.delete(organizations).where(sql`${organizations.id} IN (${orgList})`);
+  await db_.delete(partners).where(sql`${partners.id} IN (${partnerList})`);
 });
+
+/**
+ * Every FK from `portal_users` to `contacts`, by name.
+ *
+ * The single source of truth for both "the composite exists" and "nothing
+ * redundant survives" — and the restore-check after any test that drops the
+ * constraint to forge a row it forbids, so a failed restore reports at its own
+ * source instead of as a mystery failure three suites later.
+ */
+async function contactFkNames(): Promise<string[]> {
+  const rows = (await admin().execute(sql`
+    SELECT conname
+      FROM pg_constraint
+     WHERE contype = 'f'
+       AND conrelid = 'portal_users'::regclass
+       AND confrelid = 'contacts'::regclass
+     ORDER BY conname
+  `)) as unknown as Array<{ conname: string }>;
+  return rows.map((r) => r.conname);
+}
+
+async function expectOnlyCompositeFk() {
+  expect(await contactFkNames()).toEqual(['portal_users_contact_org_fk']);
+}
 
 /** A contact in `orgId`. */
 async function seedContact(orgId: string, label = 'Person') {
@@ -111,6 +161,36 @@ async function otherOrg() {
   const org = await createOrganization({ partnerId: fx.partnerId });
   seeded.orgIds.push(org.id);
   return org.id as string;
+}
+
+/**
+ * Forge the cross-org drift the constraint forbids, run `body`, then put the
+ * constraint back.
+ *
+ * Dropping it is the only way to reach this state — which is precisely the
+ * state every database is in the instant BEFORE this migration runs, so the
+ * forge is faithful rather than a contrivance. The restore replays the
+ * migration itself (guarded and idempotent), and is ASSERTED, because a silent
+ * failure here would leave the rest of the shard running against an
+ * unconstrained table and blame the next suite.
+ */
+async function withDriftForged<T>(
+  loginId: string,
+  foreignContactId: string,
+  body: () => Promise<T>,
+): Promise<T> {
+  await admin().execute(
+    sql`ALTER TABLE portal_users DROP CONSTRAINT IF EXISTS portal_users_contact_org_fk`,
+  );
+  try {
+    await admin()
+      .update(portalUsers)
+      .set({ contactId: foreignContactId })
+      .where(eq(portalUsers.id, loginId));
+    return await body();
+  } finally {
+    await admin().execute(sql.raw(migrationSql()));
+  }
 }
 
 describe('portal_users_contact_org_fk — the composite same-org FK', () => {
@@ -165,9 +245,10 @@ describe('portal_users_contact_org_fk — the composite same-org FK', () => {
 
   it('unlinks the login when the contact is deleted, without nulling its org_id', async () => {
     // The column-list `ON DELETE SET NULL (contact_id)` form. A bare composite
-    // SET NULL would try to null org_id (NOT NULL) and the DELETE would fail —
-    // which would also break org erasure, where tenantCascade deletes
-    // `contacts` before `portal_users`.
+    // SET NULL would try to null org_id (NOT NULL) and the DELETE would fail.
+    // The path this protects is the INTERACTIVE deleteContact — org erasure
+    // deletes portal_users FIRST (it is the FK child), so the referential
+    // action never fires there.
     const contactId = await seedContact(fx.orgId, 'Doomed');
     const loginId = await seedLogin(fx.orgId, contactId);
 
@@ -181,7 +262,31 @@ describe('portal_users_contact_org_fk — the composite same-org FK', () => {
     expect(row.orgId).toBe(fx.orgId);
   });
 
-  it('is DEFERRABLE, and the superseded single-column FK is gone', async () => {
+  it('unlinks the login when the APP role deletes the contact under org RLS', async () => {
+    // The superuser case above proves the clause is well-formed; this proves
+    // it works for the role production actually runs as. `portal_users` is
+    // ENABLE + FORCE ROW LEVEL SECURITY, and the app role here holds an
+    // ORGANIZATION context (not system) — the SET NULL still lands, because
+    // referential-action triggers run with row security off. If they did not,
+    // deleting a contact through the API would either fail or silently strand
+    // the login pointing at a deleted row.
+    const contactId = await seedContact(fx.orgId, 'App-deleted');
+    const loginId = await seedLogin(fx.orgId, contactId);
+
+    const deleted = await withDbAccessContext(orgCtx(fx.orgId), () =>
+      db.delete(contacts).where(eq(contacts.id, contactId)).returning({ id: contacts.id }),
+    );
+    expect(deleted).toHaveLength(1);
+
+    const [row] = await admin()
+      .select({ contactId: portalUsers.contactId, orgId: portalUsers.orgId })
+      .from(portalUsers)
+      .where(eq(portalUsers.id, loginId));
+    expect(row.contactId).toBeNull();
+    expect(row.orgId).toBe(fx.orgId);
+  });
+
+  it('is DEFERRABLE, and is the ONLY FK from portal_users to contacts', async () => {
     const [row] = await admin().execute(sql`
       SELECT condeferrable, condeferred
         FROM pg_constraint
@@ -191,15 +296,13 @@ describe('portal_users_contact_org_fk — the composite same-org FK', () => {
     // INITIALLY IMMEDIATE: deferred only when org merge asks for it.
     expect(row).toMatchObject({ condeferrable: true, condeferred: false });
 
-    const [{ count }] = await admin().execute(sql`
-      SELECT count(*)::int AS count
-        FROM pg_constraint
-       WHERE conname = 'portal_users_contact_fk'
-         AND conrelid = 'portal_users'::regclass
-    `);
-    // Leaving the plain FK in place would keep single-column cross-org links
-    // representable through it, defeating the whole migration.
-    expect(count).toBe(0);
+    // The superseded single-column FK is REDUNDANT once the composite exists
+    // (Postgres evaluates FK constraints conjunctively — a surviving one could
+    // never permit a cross-org pair the composite rejects), but leaving it
+    // would mean two SET NULL actions on one column and a second lock on
+    // `contacts`. The migration drops it by SHAPE, so an alias-named one from
+    // a `drizzle-kit push` dev database converges here too.
+    await expectOnlyCompositeFk();
   });
 });
 
@@ -251,15 +354,10 @@ describe('org merge KEEPS the portal user’s contact link', () => {
 
 describe('2026-10-04-100002-portal-users-contact-composite-fk.sql', () => {
   it('is idempotent — a second apply is a no-op, not a duplicate-constraint abort', async () => {
-    const text = readFileSync(MIGRATION_FILE, 'utf8');
-    await admin().execute(sql.raw(text));
-    await admin().execute(sql.raw(text));
+    await admin().execute(sql.raw(migrationSql()));
+    await admin().execute(sql.raw(migrationSql()));
 
-    const [{ count: fkCount }] = await admin().execute(sql`
-      SELECT count(*)::int AS count FROM pg_constraint
-       WHERE conname = 'portal_users_contact_org_fk' AND conrelid = 'portal_users'::regclass
-    `);
-    expect(fkCount).toBe(1);
+    await expectOnlyCompositeFk();
     const [{ count: idxCount }] = await admin().execute(
       sql`SELECT count(*)::int AS count FROM pg_indexes WHERE indexname = 'portal_users_contact_idx'`,
     );
@@ -267,33 +365,24 @@ describe('2026-10-04-100002-portal-users-contact-composite-fk.sql', () => {
   });
 
   it('nulls a pre-existing cross-org link instead of aborting the ADD CONSTRAINT', async () => {
-    // The drift this simulates is unrepresentable once the constraint exists,
-    // so it has to be forged with the constraint off — which is precisely the
-    // state every database is in the instant BEFORE this migration runs. A
-    // drifted row left in place would fail the ADD CONSTRAINT's initial
+    // A drifted row left in place would fail the ADD CONSTRAINT's initial
     // validation and abort the whole file on every affected database.
     const foreignContact = await seedContact(await otherOrg(), 'Drifted');
     const loginId = await seedLogin(fx.orgId, null);
 
-    await admin().execute(
-      sql`ALTER TABLE portal_users DROP CONSTRAINT portal_users_contact_org_fk`,
-    );
-    try {
-      await admin()
-        .update(portalUsers)
-        .set({ contactId: foreignContact })
+    await withDriftForged(loginId, foreignContact, async () => {
+      const [drifted] = await admin()
+        .select({ contactId: portalUsers.contactId })
+        .from(portalUsers)
         .where(eq(portalUsers.id, loginId));
+      // Control: the forge really landed, so the assertions below are about
+      // the cleanup rather than about a row that was never drifted.
+      expect(drifted.contactId).toBe(foreignContact);
+    });
 
-      // Applying the migration must SUCCEED (not 23503) and clean the row.
-      await expect(
-        admin().execute(sql.raw(readFileSync(MIGRATION_FILE, 'utf8'))),
-      ).resolves.toBeDefined();
-    } finally {
-      // The migration re-adds the constraint on its way through; if it threw
-      // before that point, restore it so the rest of the shard is not left
-      // running against an unconstrained table.
-      await admin().execute(sql.raw(readFileSync(MIGRATION_FILE, 'utf8')));
-    }
+    // withDriftForged's finally IS the migration apply. It must have SUCCEEDED
+    // (not raised 23503) and left the constraint in place.
+    await expectOnlyCompositeFk();
 
     const [row] = await admin()
       .select({ contactId: portalUsers.contactId, orgId: portalUsers.orgId })
@@ -303,5 +392,85 @@ describe('2026-10-04-100002-portal-users-contact-composite-fk.sql', () => {
     // and the login itself survives with its org intact.
     expect(row.contactId).toBeNull();
     expect(row.orgId).toBe(fx.orgId);
+  });
+
+  it("cleanup matches NOTHING without set_config('breeze.scope','system')", async () => {
+    // The migration's `SELECT set_config('breeze.scope', 'system', true)` is
+    // invisible in CI, where every test runs as a superuser that RLS does not
+    // apply to. `getAppDb()` is the unprivileged `breeze_app` role with NO
+    // `breeze.*` GUCs set — the same scope='none' (deny) state a managed
+    // Postgres migration role lands in. Without the set_config the cleanup is
+    // a silent zero-row no-op that still reports a truthful-looking
+    // "cleaned 0"; this is the test that would go red if the line were dropped.
+    const foreignContact = await seedContact(await otherOrg(), 'RLS-scoped');
+    const loginId = await seedLogin(fx.orgId, null);
+
+    const CLEANUP = sql`
+      UPDATE portal_users pu
+         SET contact_id = NULL
+        FROM contacts c
+       WHERE c.id = pu.contact_id
+         AND c.org_id <> pu.org_id
+      RETURNING pu.id
+    `;
+
+    await withDriftForged(loginId, foreignContact, async () => {
+      const withoutScope = await getAppDb().transaction((tx) => tx.execute(CLEANUP));
+      expect(Array.from(withoutScope as unknown as unknown[])).toHaveLength(0);
+
+      // Read back with admin: the app role cannot see the row it just failed
+      // to update, so asserting through it would be vacuous either way.
+      const [stillDrifted] = await admin()
+        .select({ contactId: portalUsers.contactId })
+        .from(portalUsers)
+        .where(eq(portalUsers.id, loginId));
+      expect(stillDrifted.contactId).toBe(foreignContact);
+
+      const withScope = await getAppDb().transaction(async (tx) => {
+        await tx.execute(sql`SELECT set_config('breeze.scope', 'system', true)`);
+        return tx.execute(CLEANUP);
+      });
+      expect(Array.from(withScope as unknown as unknown[])).toHaveLength(1);
+
+      const [cleaned] = await admin()
+        .select({ contactId: portalUsers.contactId, orgId: portalUsers.orgId })
+        .from(portalUsers)
+        .where(eq(portalUsers.id, loginId));
+      expect(cleaned.contactId).toBeNull();
+      expect(cleaned.orgId).toBe(fx.orgId);
+    });
+
+    await expectOnlyCompositeFk();
+  });
+
+  it('RAISEs the cleaned count as a WARNING — 1 when it cleans, 0 when it does not', async () => {
+    // The count exists so the forensic trail survives in the Postgres log. An
+    // assertion that only checks the ROW EFFECT would still pass if the
+    // RAISE were deleted, which is exactly the "suppressed 0" the migration
+    // header argues against. Capture the notices the server actually sends.
+    const notices: string[] = [];
+    const client = postgres(DATABASE_URL, {
+      max: 1,
+      onnotice: (n) => notices.push(String(n.message ?? '')),
+    });
+    const foreignContact = await seedContact(await otherOrg(), 'Noticed');
+    const loginId = await seedLogin(fx.orgId, null);
+
+    try {
+      await withDriftForged(loginId, foreignContact, async () => {
+        notices.length = 0;
+        await client.unsafe(migrationSql());
+      });
+      expect(notices.join('\n')).toMatch(/cleaned 1 cross-org portal_users\.contact_id link/);
+
+      // Zero case: nothing left to clean, and the line must STILL be emitted.
+      notices.length = 0;
+      await client.unsafe(migrationSql());
+      expect(notices.join('\n')).toMatch(/cleaned 0 cross-org portal_users\.contact_id link/);
+    } finally {
+      await client.end();
+    }
+
+    await expectOnlyCompositeFk();
   });
 });

--- a/apps/api/src/__tests__/integration/tenantCascadeExecution.integration.test.ts
+++ b/apps/api/src/__tests__/integration/tenantCascadeExecution.integration.test.ts
@@ -409,4 +409,45 @@ describe('cascadeDeleteOrg — end-to-end', () => {
     )) as unknown as unknown[];
     expect(controlDeliveryRows.length).toBe(1);
   });
+
+  // #3258 follow-up: portal_users.contact_id became a COMPOSITE
+  // (contact_id, org_id) -> contacts (id, org_id) FK, which adds a new edge to
+  // the graph topologicalCascadeOrder() reads. Its pg_constraint query counts
+  // every FK edge regardless of `confdeltype`, so the new edge makes
+  // `portal_users` a CHILD of `contacts` and moves it EARLIER in the erasure.
+  //
+  // Two failure modes this rules out: a 23503 if the order had come out
+  // parents-first, and a 23502 if the referential action had been a BARE
+  // composite `SET NULL` (which would target the NOT NULL org_id) and fired
+  // here. Neither is visible from the cascade-list contract test, which reads
+  // the Drizzle schema and never deletes a row.
+  it('erases an org whose portal login is linked to one of its contacts', async () => {
+    const testDb = getTestDb();
+
+    const [contact] = (await testDb.execute(sql`
+      INSERT INTO contacts (org_id, name, email, created_at, updated_at)
+      VALUES (${handles.orgIdToErase}, 'Erased Person', ${`erase-${Date.now()}@example.test`}, now(), now())
+      RETURNING id
+    `)) as unknown as Array<{ id: string }>;
+    const [login] = (await testDb.execute(sql`
+      INSERT INTO portal_users (org_id, email, name, contact_id, created_at, updated_at)
+      VALUES (${handles.orgIdToErase}, ${`erase-login-${Date.now()}@example.test`}, 'Erased Login', ${contact!.id}, now(), now())
+      RETURNING id
+    `)) as unknown as Array<{ id: string }>;
+
+    // The assertion that matters: this does not throw.
+    const stats = await cascadeDeleteOrg(handles.orgIdToErase, handles.userId);
+    expect(stats.tablesDeleted.contacts).toBe(1);
+    expect(stats.tablesDeleted.portal_users).toBe(1);
+
+    // No orphan on either side.
+    const remainingLogins = (await testDb.execute(
+      sql`SELECT id FROM portal_users WHERE id = ${login!.id}`,
+    )) as unknown as unknown[];
+    expect(remainingLogins.length).toBe(0);
+    const remainingContacts = (await testDb.execute(
+      sql`SELECT id FROM contacts WHERE id = ${contact!.id}`,
+    )) as unknown as unknown[];
+    expect(remainingContacts.length).toBe(0);
+  });
 });

--- a/apps/api/src/db/schema/portal.ts
+++ b/apps/api/src/db/schema/portal.ts
@@ -1,6 +1,5 @@
 import { pgTable, uuid, varchar, text, integer, timestamp, boolean, jsonb, pgEnum } from 'drizzle-orm/pg-core';
 import { organizations, partners } from './orgs';
-import { contacts } from './contacts';
 import { devices } from './devices';
 import { users } from './users';
 
@@ -65,11 +64,17 @@ export const portalUsers = pgTable('portal_users', {
   // Rows can therefore still have a null link (Entra SSO provisioning and the
   // Outlook add-in's "create contact" both create logins without one).
   //
-  // ON DELETE SET NULL so deleting a contact never silently destroys someone's
-  // portal login. The FK is single-column, so it does NOT prove login and
-  // contact share an org — routes that derive a ticket's requester from this
-  // column compare the orgs explicitly (ticketService.createTicket).
-  contactId: uuid('contact_id').references(() => contacts.id, { onDelete: 'set null' }),
+  // Declared as a plain nullable uuid on purpose: the real constraint is the
+  // COMPOSITE same-org FK `portal_users_contact_org_fk` (contact_id, org_id)
+  // -> contacts (id, org_id), DEFERRABLE INITIALLY IMMEDIATE with a column-list
+  // `ON DELETE SET NULL (contact_id)` so deleting a contact unlinks the login
+  // instead of failing on the NOT NULL org_id. A login and its contact
+  // therefore CANNOT belong to different organizations — that is a database
+  // guarantee now, not a convention every writer has to honour. It lives in
+  // SQL only (2026-10-04-100002-portal-users-contact-composite-fk.sql), the
+  // same convention as tickets.requesterContactId below and this table's
+  // partial unique index on the Entra identity.
+  contactId: uuid('contact_id'),
   receiveNotifications: boolean('receive_notifications').notNull().default(true),
   lastLoginAt: timestamp('last_login_at'),
   status: varchar('status', { length: 20 }).notNull().default('active'),

--- a/apps/api/src/routes/orgPortalUsers.ts
+++ b/apps/api/src/routes/orgPortalUsers.ts
@@ -211,6 +211,13 @@ export function registerOrgPortalUsersRoutes(orgRoutes: Hono) {
       // set it (the 2026-08-19 backfill, a previous invite, a tech editing the
       // contact) knew more than an email string does. Skipping the lookup also
       // stops a re-invite from minting a duplicate contact.
+      //
+      // `resolveInviteContact` only ever returns a contact in `org.id`, and
+      // this row is in `org.id` too — but that is no longer the only thing
+      // keeping the pair same-org: `portal_users_contact_org_fk`
+      // (contact_id, org_id) -> contacts (id, org_id) makes a cross-org link
+      // unrepresentable, so a future writer that forgets the org bound gets a
+      // 23503 rather than a silent tenant leak (#3258 follow-up).
       const contactPatch: { contactId?: string } = {};
       if (existing.contactId) {
         contactLink = 'kept';

--- a/apps/api/src/services/ticketService.ts
+++ b/apps/api/src/services/ticketService.ts
@@ -383,6 +383,11 @@ async function assertRequesterContactInOrg(contactId: string, orgId: string) {
  * the caller can reach — an invisible row degrades to "no link", which is the
  * stricter outcome. The explicit org comparison at the call site remains the
  * security boundary either way.
+ *
+ * `contactId` needs no org of its own: `portal_users_contact_org_fk`
+ * (contact_id, org_id) -> contacts (id, org_id) makes the contact's org
+ * IDENTICAL to the `orgId` returned here (#3258 follow-up), so comparing that
+ * one value against the ticket's org settles both.
  */
 async function readPortalUserContactLink(
   portalUserId: string
@@ -599,11 +604,15 @@ export async function createTicket(input: CreateTicketInput, actor: TicketActor)
     // assertRequesterInOrg on the staff branch; the portal/email branch trusts
     // its caller's submittedBy and has not read anything yet.
     const link = validatedPortalUser ?? (await readPortalUserContactLink(resolvedSubmittedBy));
-    // A login from another org would produce a contact from another org, which
-    // the composite FK rejects as a raw 23503 (a 500 carrying a Postgres
-    // message). Assert it here for the same typed 400 every other requester
-    // tenant guard returns. A MISSING login is not an error — it simply yields
-    // no link, matching the pre-existing behaviour.
+    // A login from another org carries a contact from that other org —
+    // `portal_users_contact_org_fk` makes login-org and contact-org provably
+    // equal (#3258 follow-up), so this ONE comparison is the complete
+    // cross-tenant boundary for the derived link, not an approximation of it.
+    // Kept as an explicit guard rather than left to the database: without it
+    // the write reaches `tickets_requester_contact_org_fk` and comes back as a
+    // raw 23503 (a 500 carrying a Postgres message) instead of the typed 400
+    // every other requester tenant guard returns. A MISSING login is not an
+    // error — it simply yields no link, matching the pre-existing behaviour.
     if (link && link.orgId !== input.orgId) {
       throw new TicketServiceError(
         'Requester contact must belong to the ticket organization',


### PR DESCRIPTION
## What this adds

W03 (#4557) gave `tickets.requester_contact_id` a composite same-org FK and
left **`portal_users.contact_id` as the last plain single-column FK into
`contacts`**. Nothing in the schema forced a portal LOGIN and the CONTACT
behind it into the same organization — every writer happened to be
org-bounded, but that was a convention, not a guarantee.

The gap fed straight back into W03. `readPortalUserContactLink`
(`services/ticketService.ts`) derives a ticket's requester from the filer's
login, so a single drifted row would have proposed a cross-org
`tickets.requester_contact_id`; W03's backfill had to carry an
`EXISTS (... c.org_id = t.org_id)` guard purely so such a row would not raise
23503 and abort the entire migration file. This closes the gap at the source
rather than defending against it downstream.

- **`apps/api/migrations/2026-10-04-100002-portal-users-contact-composite-fk.sql`**
  — cleanup of any pre-existing cross-org link, then a drop of the superseded
  FK **by shape** (`conrelid = portal_users`, `confrelid = contacts`,
  `cardinality(conkey) = 1`) rather than by the one name
  `2026-08-19-contacts.sql` happens to use, so a `drizzle-kit push` dev
  database carrying the generated alias converges too; then
  `portal_users_contact_org_fk FOREIGN KEY (contact_id, org_id) REFERENCES
  contacts (id, org_id) ON DELETE SET NULL (contact_id) DEFERRABLE INITIALLY
  IMMEDIATE`. The partial index `portal_users_contact_idx` is kept.
- **Drizzle** (`db/schema/portal.ts`) — `contactId` becomes a plain nullable
  uuid, the composite FK living in SQL only. Same convention as
  `tickets.requesterContactId` a few lines below it in the same file. (The
  now-unused `contacts` import is dropped.)
- **Comments** — the wrong-org guards in `ticketService.ts` are **kept** as
  defence in depth: they turn what would be a raw 23503 (a 500 carrying a
  Postgres message) into the typed 400 every other requester tenant guard
  returns. Their reasoning is updated now that login-org == contact-org is a
  database guarantee, which makes the single `link.orgId !== input.orgId`
  comparison the *complete* boundary rather than an approximation of it.

## Tenancy notes

- **Shape** copied from `tickets_requester_contact_org_fk`, which copied
  `contacts_site_org_fk`. The composite target `contacts_id_org_id_uniq
  (id, org_id)` already exists.
- **`ON DELETE SET NULL (contact_id)`** is the **column-list** form. A bare
  composite `SET NULL` would also null `org_id`, which is `NOT NULL`, so
  deleting a contact would abort instead of unlinking the login. The path that
  exercises it is the **interactive** `deleteContact` — *not* org erasure:
  `topologicalCascadeOrder()` counts every FK edge regardless of
  `confdeltype`, so this constraint makes `portal_users` a **child** of
  `contacts` and it is deleted **first**. (Which is also why adding the FK
  cannot reorder an erasure into an FK violation: it moves `portal_users`
  earlier, never later. There is now a `tenantCascadeExecution` case erasing an
  org whose login is contact-linked.)
- **`DEFERRABLE INITIALLY IMMEDIATE`** is required of every composite FK whose
  referenced side includes `org_id`, by
  `orgLifecycleFoundations.integration.test.ts`. Org merge runs
  `SET CONSTRAINTS ALL DEFERRED` and re-points `portal_users` (plain repoint)
  and `contacts` (custom repoint) in **separate statements** of one
  transaction; a non-deferrable constraint here would abort the merge
  mid-walk.
- **Registration: nothing to add.** No new table and no new column.
  `portal_users` is already in `CORE_ORG_CASCADE_DELETE_ORDER`, and its
  `contact_id` is already classified `included` in `CORE_TENANT_EXPORT_POLICY`
  (`tenantExportPolicyRegistry.ts:290`) — checked explicitly, since the
  export-policy list is the one that fires on a new *column*.
- **Writer sweep** (repo-wide, `portal_users.contact_id` / `portalUsers.contactId`):
  the 2026-08-19 backfill (org-joined), and the invite route's
  `resolveInviteContact` insert + `contactPatch` update — both bounded to
  `org.id`. The generic PATCH at `orgPortalUsers.ts:250` spreads `...body`,
  but `updatePortalUserSchema` is `.strict()` over name/receiveNotifications/
  status only, so `contactId` cannot arrive through it. Entra provisioning
  (`clientAiExchange.ts`), the Outlook add-in (`officeAddin/addinContacts.ts`),
  portal auth and portal profile never write the column. No Go, portal-app or
  `ee/` writer exists.

## Operational notes

- **Locking.** The `DROP CONSTRAINT` takes `ACCESS EXCLUSIVE` on **`contacts`**
  (the referenced side) as well as `portal_users`, held for the file's
  transaction. Fine at boot on an idle database; worth knowing if a second API
  instance is serving traffic while the migration runs, since it will block on
  any `contacts` read for the duration.
- **Semantics of the SET NULL.** When a contact is deleted, its login's
  `contact_id` goes null, which narrows that login's portal ticket view to
  `submitted_by`-only tickets (it loses the `requester_contact_id = my contact`
  half of `portalTicketOwnership`). That is pre-existing behaviour — the
  original FK was already `ON DELETE SET NULL` — and it is recoverable by
  re-inviting, which re-links the login to a contact.
- **Postgres floor.** The column-list `ON DELETE SET NULL (col)` syntax
  requires **Postgres 15+**. W03 shipped the same construction in
  `2026-10-04-100000`, so the floor is already in place rather than newly
  introduced here; the local test stack is 16.15. Worth confirming production's
  server_version before the next release all the same.

## Cleanup semantics

The cleanup runs **before** the `ADD CONSTRAINT`: a drifted row left in place
would fail the constraint's initial validation and abort the whole file on
every affected database, with no way to skip it. Nulling the link is the
recoverable direction — the login and its ticket history are untouched and a
technician can re-invite — and is exactly what `ON DELETE SET NULL
(contact_id)` would have done had the contact been deleted instead of moved.

The count is reported **unconditionally** via `RAISE WARNING`. A non-zero
count is evidence a login was pointing at a person in another tenant; a zero
still has to be recorded, because a suppressed 0 is indistinguishable from the
RLS no-op that `SELECT set_config('breeze.scope','system',true)` (present, at
the top of the file) exists to prevent on managed Postgres.

## Tests

New: `apps/api/src/__tests__/integration/portalUserContactCompositeFk.integration.test.ts`
(8 tests, real Postgres). **Red-first evidence** — with the migration file
moved aside so `autoMigrate` never applied it, 5 of the 8 failed, and the two
forge cases failed for the right reason (`promise resolved "[]" instead of
rejecting`): the cross-org INSERT and the cross-org UPDATE both **succeeded**
against the pre-migration schema. With the migration restored, 8/8 pass.

| Behaviour | Red without the migration |
|---|---|
| cross-org **INSERT** rejected 23503 / `portal_users_contact_org_fk` | insert succeeded |
| cross-org **UPDATE** rejected 23503 / `portal_users_contact_org_fk` | update succeeded |
| constraint is DEFERRABLE + plain `portal_users_contact_fk` gone | `undefined` / old FK still present |
| migration replay is a no-op (1 constraint, 1 index) | ENOENT |
| cleanup NULLs a forged drifted row, `org_id` intact | constraint absent |
| same-org link accepted | (green either way — regression guard) |
| contact DELETE unlinks the login, `org_id` intact | (green either way — regression guard) |
| **org merge keeps the link**, both rows re-tenanted to the survivor | (green either way — regression guard) |

Updated: `inboundEmailContactRequester.integration.test.ts` — W03's "skips a
login whose contact lives in ANOTHER org" case forges precisely the drift this
PR makes unrepresentable. It now drops the new constraint to forge the row
(which *is* the state a database replaying migrations in order is in when the
W03 file runs) and restores it by replaying this PR's migration, whose cleanup
nulls the forged link on its way past.

**Review round (code / tenancy / test lenses) added:** an RLS-scoped proof that
the cleanup matches nothing without `set_config('breeze.scope','system')`
(`getAppDb()` = `breeze_app` under FORCE RLS — the migration's set_config line
was otherwise untestable, since every test runs as a superuser); observation of
the `cleaned N` WARNING itself through a dedicated `onnotice` client, for both
the 1 and the 0 case, **verified discriminating by mutation** (RAISE removed →
red, only the index NOTICE left); an org-erasure case with a contact-linked
login; and an app-role contact delete under an organization RLS context.

It also fixed a **deterministic cross-file CI red**: `2026-08-19-contacts.sql`
guards its FK by *name only*, so `contactsBackfillMigration`'s seven replays
**resurrected** the single-column FK this PR drops, in the same shard. Proven
by running this suite against the resurrected state — `['portal_users_contact_fk',
'portal_users_contact_org_fk']` vs the expected single entry. `replayMigration()`
now re-applies this migration afterwards and asserts zero single-column FKs
survive.

**Run live** against a private worktree Postgres (`pnpm test-stack`), all green
unless noted:

- `portalUserContactCompositeFk` — 11/11
- `contactsBackfillMigration`, `inboundEmailContactRequester`,
  `tenantCascadeExecution` + this suite — 36/37 in one invocation (the 1 is the
  pre-existing failure below); earlier batch with `tenant-export-policy`,
  `tenantExportErasureRoundtrip`, `tenantCascade`, `contactsRls`,
  `ticket-move-org` — 44/45
- `orgLifecycleFoundations` — the deferrable-FK contract **fails on a base
  already red on main** (#4490). Offenders are exactly
  `ai_agent_op_evidence.ai_agent_op_evidence_run_org_fk`,
  `ai_agent_graduation.ai_agent_graduation_intent_org_fk`,
  `ai_agent_fix_watches.ai_agent_fix_watches_intent_org_fk` — a sibling PR
  owns those. **`portal_users_contact_org_fk` is not among them**, and this
  PR's own test asserts `condeferrable = true, condeferred = false` directly.
- RLS coverage (`vitest.config.rls-coverage.ts`) — 100/100
- Unit: `autoMigrate` 63/63; `orgPortalUsers`, `ticketService`, `routes/portal/*`
  — 446/446 across 10 files

`pnpm db:check-drift` clean (632 files match the ledger), `eslint` clean on all
touched files, `tsc --noEmit` exit 0, `scripts/check-migration-naming.sh` OK.
Stack torn down afterwards.

Refs #3258

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015tHmJsqrTy5iHcqgpadtMp

