### PR TITLE
fix(db): make the AI-agent graduation composite FKs deferrable; scope the test-side FK repair helper so CI can catch it (#4187 follow-up)

### DIFF
--- a/apps/api/migrations/2026-10-04-100001-ai-agents-graduation-fks-deferrable.sql
+++ b/apps/api/migrations/2026-10-04-100001-ai-agents-graduation-fks-deferrable.sql
@@ -1,0 +1,59 @@
+-- Fix-forward for 2026-10-01-100000-ai-agents-graduation-evidence.sql (#4187 P2-5).
+--
+-- That migration added three composite (x, org_id) foreign keys without a
+-- DEFERRABLE clause, so Postgres created them NOT DEFERRABLE:
+--
+--   ai_agent_op_evidence.ai_agent_op_evidence_run_org_fk
+--   ai_agent_graduation.ai_agent_graduation_intent_org_fk
+--   ai_agent_fix_watches.ai_agent_fix_watches_intent_org_fk
+--
+-- The org-merge contract requires every composite FK that references an
+-- `org_id` column to be DEFERRABLE INITIALLY IMMEDIATE: orgMerge.ts runs
+-- `SET CONSTRAINTS ALL DEFERRED` and re-points the parent's and the child's
+-- `org_id` in separate statements, which a non-deferrable composite FK aborts
+-- mid-merge. 2026-09-12-100001-org-lifecycle-foundations.sql Section 2 swept
+-- the 19 FKs that existed when it shipped; these three were created after it
+-- and so were never covered.
+--
+-- The shipped file is content-hash immutable, so this fixes forward. The
+-- deferrability of an existing FK is changed in place with ALTER CONSTRAINT
+-- (the same statement Section 2 of the org-lifecycle migration uses) — no
+-- DROP + re-ADD, which would take the same lock but additionally re-validate
+-- every existing row and require the column list, referenced table and
+-- ON DELETE action to be restated by hand.
+--
+-- Scoped to these three constraint names ON PURPOSE. A blanket sweep would
+-- also silently repair any future non-deferrable composite org_id FK that
+-- happened to be in the database when it ran, which is precisely the failure
+-- this migration exists to correct: the contract test must stay the thing that
+-- catches a new offender.
+--
+-- Idempotent: the loop selects only `condeferrable = false`, so a second run
+-- matches nothing and does nothing.
+
+DO $$
+DECLARE
+  fk record;
+  n integer := 0;
+BEGIN
+  FOR fk IN
+    SELECT con.conname, con.conrelid::regclass AS child_table
+    FROM pg_constraint con
+    WHERE con.contype = 'f'
+      AND con.condeferrable = false
+      AND con.connamespace = 'public'::regnamespace
+      AND con.conname IN (
+        'ai_agent_op_evidence_run_org_fk',
+        'ai_agent_graduation_intent_org_fk',
+        'ai_agent_fix_watches_intent_org_fk'
+      )
+    ORDER BY con.conrelid::regclass::text, con.conname
+  LOOP
+    EXECUTE format('ALTER TABLE %s ALTER CONSTRAINT %I DEFERRABLE INITIALLY IMMEDIATE',
+                   fk.child_table, fk.conname);
+    n := n + 1;
+  END LOOP;
+  IF n > 0 THEN
+    RAISE WARNING 'ai-agents graduation: made % composite org_id FKs deferrable', n;
+  END IF;
+END $$;

--- a/apps/api/migrations/2026-10-04-100001-ai-agents-graduation-fks-deferrable.sql
+++ b/apps/api/migrations/2026-10-04-100001-ai-agents-graduation-fks-deferrable.sql
@@ -12,8 +12,8 @@
 -- `SET CONSTRAINTS ALL DEFERRED` and re-points the parent's and the child's
 -- `org_id` in separate statements, which a non-deferrable composite FK aborts
 -- mid-merge. 2026-09-12-100001-org-lifecycle-foundations.sql Section 2 swept
--- the 19 FKs that existed when it shipped; these three were created after it
--- and so were never covered.
+-- the composite org_id FKs that existed when it shipped; these three were
+-- created after it and so were never covered.
 --
 -- The shipped file is content-hash immutable, so this fixes forward. The
 -- deferrability of an existing FK is changed in place with ALTER CONSTRAINT

--- a/apps/api/src/__tests__/integration/agentIntentConstraints.integration.test.ts
+++ b/apps/api/src/__tests__/integration/agentIntentConstraints.integration.test.ts
@@ -377,7 +377,9 @@ describe('agent-originated action_intents constraints', () => {
     // clause, so replaying it here undoes the org-lifecycle branch's
     // deferrable-FK contract (migrations/2026-09-12-100001-org-lifecycle-foundations.sql
     // Section 2). Restore it rather than editing the shipped migration.
-    await reapplyOrgIdFkDeferrability(getTestDb());
+    await reapplyOrgIdFkDeferrability(getTestDb(), [
+      'action_intents_requesting_agent_run_id_org_id_fkey',
+    ]);
 
     // The re-added composite FK validated existing rows; the pre-existing
     // agent intent must have survived, and the constraints must still fire.

--- a/apps/api/src/__tests__/integration/db-utils.ts
+++ b/apps/api/src/__tests__/integration/db-utils.ts
@@ -529,15 +529,15 @@ export async function createIntegrationTestClient(
 
 /**
  * Restores the org-lifecycle deferrable-FK contract
- * (`migrations/2026-09-12-100001-org-lifecycle-foundations.sql` Section 2):
- * every composite FK referencing an `org_id` column must be
- * `DEFERRABLE INITIALLY IMMEDIATE`, because the org-merge transaction
- * (Wave 2) runs `SET CONSTRAINTS ALL DEFERRED` and re-points parent+child
- * `org_id` in separate statements — a non-deferrable composite FK breaks it.
- * `orgLifecycleFoundations.integration.test.ts` asserts this against live
- * `pg_constraint` state at test-run time, so it cannot distinguish "never
- * fixed" from "fixed, then un-fixed by a later migration replay in the same
- * shared test DB."
+ * (`migrations/2026-09-12-100001-org-lifecycle-foundations.sql` Section 2)
+ * for the NAMED constraints only: every composite FK referencing an `org_id`
+ * column must be `DEFERRABLE INITIALLY IMMEDIATE`, because the org-merge
+ * transaction (Wave 2) runs `SET CONSTRAINTS ALL DEFERRED` and re-points
+ * parent+child `org_id` in separate statements — a non-deferrable composite
+ * FK breaks it. `orgLifecycleFoundations.integration.test.ts` asserts this
+ * against live `pg_constraint` state at test-run time, so it cannot
+ * distinguish "never fixed" from "fixed, then un-fixed by a later migration
+ * replay in the same shared test DB."
  *
  * A handful of already-shipped migrations, replayed raw by other integration
  * suites for their own idempotency/regression coverage, unconditionally
@@ -546,40 +546,63 @@ export async function createIntegrationTestClient(
  * hardening migration, and unconditional `DROP CONSTRAINT` + `ADD CONSTRAINT`
  * (with no `DEFERRABLE` clause) in the m365 graph-read-consent and
  * agent-originated-intents migrations. Per CLAUDE.md, never edit a shipped
- * migration to "fix" this — and never re-run the org-lifecycle migration's DO
- * block from inside `orgLifecycleFoundations.integration.test.ts` itself,
- * which would silently paper over genuinely new non-deferrable composite FKs
- * from unrelated future PRs. Instead, every suite that replays one of these
- * migrations raw must call this helper immediately after, to restore the
- * contract the replay just undid.
+ * migration to "fix" this. Instead, every suite that replays one of these
+ * migrations raw must call this helper immediately after, naming the
+ * constraint(s) its own replay just un-deferred.
  *
- * The DO block below is copied verbatim from that migration file's Section 2
- * — keep it in sync if that block ever changes.
+ * `constraintNames` is REQUIRED and the repair is scoped to it. This helper
+ * used to run the migration's whole-database sweep, which repaired every
+ * non-deferrable composite `org_id` FK it found — including ones no replay
+ * had touched. That silently papered over a genuine defect: the three FKs
+ * added non-deferrable by `2026-10-01-100000-ai-agents-graduation-evidence.sql`
+ * were repaired by `m365ConnectionsRls` and `agentIntentConstraints` running
+ * earlier in the same CI shard, so the contract test read GREEN in CI for
+ * days while failing on any fresh database. A blanket sweep here cannot tell
+ * "damaged by the replay I just ran" from "shipped broken", and the second is
+ * exactly what the contract test exists to catch — so it must not be repaired.
+ *
+ * Throws when a named constraint does not exist, so a rename fails loudly here
+ * instead of silently leaving the contract un-restored.
  */
-export async function reapplyOrgIdFkDeferrability(db: TestDatabase = getTestDb()): Promise<void> {
-  await db.execute(sql`
-    DO $$
-    DECLARE
-      fk record;
-      n integer := 0;
-    BEGIN
-      FOR fk IN
-        SELECT con.conname, con.conrelid::regclass AS child_table
-        FROM pg_constraint con
-        WHERE con.contype = 'f'
-          AND con.condeferrable = false
-          AND con.connamespace = 'public'::regnamespace
-          AND EXISTS (
-            SELECT 1 FROM unnest(con.confkey) AS ck(attnum)
-            JOIN pg_attribute a ON a.attrelid = con.confrelid AND a.attnum = ck.attnum
-            WHERE a.attname = 'org_id'
-          )
-        ORDER BY con.conrelid::regclass::text, con.conname
-      LOOP
-        EXECUTE format('ALTER TABLE %s ALTER CONSTRAINT %I DEFERRABLE INITIALLY IMMEDIATE',
-                       fk.child_table, fk.conname);
-        n := n + 1;
-      END LOOP;
-    END $$;
-  `);
+export async function reapplyOrgIdFkDeferrability(
+  db: TestDatabase,
+  constraintNames: readonly string[],
+): Promise<void> {
+  if (constraintNames.length === 0) {
+    throw new Error(
+      'reapplyOrgIdFkDeferrability: name the constraint(s) your migration replay un-deferred. ' +
+        'A blanket sweep would hide genuinely non-deferrable composite org_id FKs from ' +
+        'orgLifecycleFoundations.integration.test.ts.',
+    );
+  }
+
+  const rows = (await db.execute(sql`
+    SELECT con.conname, con.conrelid::regclass::text AS child_table
+    FROM pg_constraint con
+    WHERE con.contype = 'f'
+      AND con.connamespace = 'public'::regnamespace
+      AND con.conname IN (${sql.join(
+        constraintNames.map((name) => sql`${name}`),
+        sql`, `,
+      )})
+  `)) as unknown as Array<{ conname: string; child_table: string }>;
+
+  const byName = new Map(rows.map((row) => [row.conname, row.child_table]));
+  const missing = constraintNames.filter((name) => !byName.has(name));
+  if (missing.length > 0) {
+    throw new Error(
+      `reapplyOrgIdFkDeferrability: no such foreign-key constraint(s) in public: ${missing.join(', ')}. ` +
+        'Was one renamed by a later migration? Update the caller.',
+    );
+  }
+
+  for (const [conname, childTable] of byName) {
+    // `child_table` comes from regclass::text, which Postgres already quotes
+    // when the identifier needs it; conname is quoted here for the same reason.
+    await db.execute(
+      sql.raw(
+        `ALTER TABLE ${childTable} ALTER CONSTRAINT "${conname}" DEFERRABLE INITIALLY IMMEDIATE`,
+      ),
+    );
+  }
 }

--- a/apps/api/src/__tests__/integration/db-utils.ts
+++ b/apps/api/src/__tests__/integration/db-utils.ts
@@ -563,6 +563,17 @@ export async function createIntegrationTestClient(
  *
  * Throws when a named constraint does not exist, so a rename fails loudly here
  * instead of silently leaving the contract un-restored.
+ *
+ * The initial mode is read from the catalog rather than hard-coded: the org
+ * lifecycle sweep's `INITIALLY IMMEDIATE` is the right default for the FKs it
+ * converted, but several later migrations declare a composite `org_id` FK
+ * `DEFERRABLE INITIALLY DEFERRED` on purpose
+ * (`2026-09-13-agent-rollback-lifecycle.sql`,
+ * `2026-09-28-100002-software-inventory-observations.sql`). Forcing IMMEDIATE
+ * would silently downgrade one the first time a caller named it, changing when
+ * Postgres checks that FK for the rest of the shard.
+ *
+ * Contract test: `orgIdFkDeferrabilityHelper.integration.test.ts`.
  */
 export async function reapplyOrgIdFkDeferrability(
   db: TestDatabase,
@@ -577,7 +588,7 @@ export async function reapplyOrgIdFkDeferrability(
   }
 
   const rows = (await db.execute(sql`
-    SELECT con.conname, con.conrelid::regclass::text AS child_table
+    SELECT con.conname, con.conrelid::regclass::text AS child_table, con.condeferred
     FROM pg_constraint con
     WHERE con.contype = 'f'
       AND con.connamespace = 'public'::regnamespace
@@ -585,9 +596,9 @@ export async function reapplyOrgIdFkDeferrability(
         constraintNames.map((name) => sql`${name}`),
         sql`, `,
       )})
-  `)) as unknown as Array<{ conname: string; child_table: string }>;
+  `)) as unknown as Array<{ conname: string; child_table: string; condeferred: boolean }>;
 
-  const byName = new Map(rows.map((row) => [row.conname, row.child_table]));
+  const byName = new Map(rows.map((row) => [row.conname, row]));
   const missing = constraintNames.filter((name) => !byName.has(name));
   if (missing.length > 0) {
     throw new Error(
@@ -596,13 +607,15 @@ export async function reapplyOrgIdFkDeferrability(
     );
   }
 
-  for (const [conname, childTable] of byName) {
+  for (const { conname, child_table: childTable, condeferred } of byName.values()) {
+    // Keep whatever initial mode the constraint currently carries; a replay
+    // that knocked it to NOT DEFERRABLE also cleared condeferred, so those
+    // come back INITIALLY IMMEDIATE as the org-lifecycle sweep intends.
+    const initialMode = condeferred ? 'INITIALLY DEFERRED' : 'INITIALLY IMMEDIATE';
     // `child_table` comes from regclass::text, which Postgres already quotes
     // when the identifier needs it; conname is quoted here for the same reason.
     await db.execute(
-      sql.raw(
-        `ALTER TABLE ${childTable} ALTER CONSTRAINT "${conname}" DEFERRABLE INITIALLY IMMEDIATE`,
-      ),
+      sql.raw(`ALTER TABLE ${childTable} ALTER CONSTRAINT "${conname}" DEFERRABLE ${initialMode}`),
     );
   }
 }

--- a/apps/api/src/__tests__/integration/m365ConnectionsRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/m365ConnectionsRls.integration.test.ts
@@ -48,7 +48,7 @@ async function replayGraphReadConsentMigration(): Promise<void> {
   // carries no DEFERRABLE clause, so replaying it undoes the org-lifecycle branch's
   // deferrable-FK contract (migrations/2026-09-12-100001-org-lifecycle-foundations.sql
   // Section 2). Restore it here rather than editing the shipped migration.
-  await reapplyOrgIdFkDeferrability(getTestDb());
+  await reapplyOrgIdFkDeferrability(getTestDb(), ['m365_consent_sessions_connection_identity_fkey']);
 }
 
 async function seedFixture() {

--- a/apps/api/src/__tests__/integration/orgIdFkDeferrabilityHelper.integration.test.ts
+++ b/apps/api/src/__tests__/integration/orgIdFkDeferrabilityHelper.integration.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Contract for `reapplyOrgIdFkDeferrability` (db-utils.ts).
+ *
+ * That helper is the one piece of test code allowed to change FK deferrability
+ * in the shared integration database, which makes it the one piece of test code
+ * able to invalidate `orgLifecycleFoundations.integration.test.ts` — the org-merge
+ * contract that reads live `pg_constraint` state. It already did exactly that:
+ * as a whole-database sweep it silently repaired the three non-deferrable
+ * composite org_id FKs shipped by 2026-10-01-100000-ai-agents-graduation-evidence.sql,
+ * so the contract read green in CI while failing on every fresh database.
+ *
+ * The rules below were prose in a docstring; this file makes them executable.
+ * Everything runs against purpose-built probe tables that are dropped in
+ * `afterAll`, so no shipped constraint is mutated and nothing leaks into the
+ * contract test's or rls-coverage's view of the schema.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { getTestDb } from './setup';
+import { reapplyOrgIdFkDeferrability } from './db-utils';
+
+const PARENT = 'fk_deferrability_probe_parent';
+const CHILD = 'fk_deferrability_probe_child';
+const TARGET_FK = 'fk_deferrability_probe_target_fk';
+const BYSTANDER_FK = 'fk_deferrability_probe_bystander_fk';
+const DEFERRED_FK = 'fk_deferrability_probe_deferred_fk';
+
+async function dropProbeTables(): Promise<void> {
+  await getTestDb().execute(sql.raw(`DROP TABLE IF EXISTS ${CHILD} CASCADE`));
+  await getTestDb().execute(sql.raw(`DROP TABLE IF EXISTS ${PARENT} CASCADE`));
+}
+
+/** condeferrable / condeferred straight from the catalog, for one constraint. */
+async function readMode(conname: string): Promise<{ deferrable: boolean; deferred: boolean }> {
+  const rows = (await getTestDb().execute(sql`
+    SELECT con.condeferrable, con.condeferred
+    FROM pg_constraint con
+    WHERE con.conname = ${conname} AND con.connamespace = 'public'::regnamespace
+  `)) as unknown as Array<{ condeferrable: boolean; condeferred: boolean }>;
+  expect(rows.length, `probe constraint ${conname} is missing`).toBe(1);
+  return { deferrable: rows[0]!.condeferrable, deferred: rows[0]!.condeferred };
+}
+
+describe('reapplyOrgIdFkDeferrability contract', () => {
+  beforeAll(async () => {
+    // Defensive: a crashed earlier run could have leaked these.
+    await dropProbeTables();
+    // The referenced column is genuinely named org_id, so these probe FKs are
+    // exactly what orgLifecycleFoundations' pg_constraint scan looks for.
+    await getTestDb().execute(
+      sql.raw(`
+        CREATE TABLE ${PARENT} (
+          id uuid NOT NULL,
+          org_id uuid NOT NULL,
+          PRIMARY KEY (id, org_id)
+        )
+      `),
+    );
+    await getTestDb().execute(
+      sql.raw(`
+        CREATE TABLE ${CHILD} (
+          id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+          target_ref uuid,
+          bystander_ref uuid,
+          deferred_ref uuid,
+          org_id uuid,
+          CONSTRAINT ${TARGET_FK} FOREIGN KEY (target_ref, org_id)
+            REFERENCES ${PARENT} (id, org_id),
+          CONSTRAINT ${BYSTANDER_FK} FOREIGN KEY (bystander_ref, org_id)
+            REFERENCES ${PARENT} (id, org_id),
+          CONSTRAINT ${DEFERRED_FK} FOREIGN KEY (deferred_ref, org_id)
+            REFERENCES ${PARENT} (id, org_id) DEFERRABLE INITIALLY DEFERRED
+        )
+      `),
+    );
+  });
+
+  afterAll(async () => {
+    // Must run even when a test above failed: a leaked probe table is a
+    // non-deferrable composite org_id FK, which would redden the org-merge
+    // contract test for reasons that have nothing to do with the schema.
+    await dropProbeTables();
+  });
+
+  it('refuses an empty constraint list rather than sweeping the database', async () => {
+    await expect(reapplyOrgIdFkDeferrability(getTestDb(), [])).rejects.toThrow(
+      /name the constraint\(s\)/i,
+    );
+  });
+
+  it('refuses a constraint name that does not exist', async () => {
+    await expect(
+      reapplyOrgIdFkDeferrability(getTestDb(), ['fk_deferrability_probe_nope_fkey']),
+    ).rejects.toThrow(/no such foreign-key constraint/i);
+  });
+
+  it('repairs only the named constraint and leaves an unrelated offender non-deferrable', async () => {
+    expect(await readMode(TARGET_FK)).toEqual({ deferrable: false, deferred: false });
+    expect(await readMode(BYSTANDER_FK)).toEqual({ deferrable: false, deferred: false });
+
+    await reapplyOrgIdFkDeferrability(getTestDb(), [TARGET_FK]);
+
+    expect(await readMode(TARGET_FK)).toEqual({ deferrable: true, deferred: false });
+    // The whole point: a non-deferrable composite org_id FK the caller did not
+    // name stays broken, so orgLifecycleFoundations still catches it.
+    expect(await readMode(BYSTANDER_FK)).toEqual({ deferrable: false, deferred: false });
+  });
+
+  it('preserves INITIALLY DEFERRED instead of downgrading it to IMMEDIATE', async () => {
+    expect(await readMode(DEFERRED_FK)).toEqual({ deferrable: true, deferred: true });
+
+    await reapplyOrgIdFkDeferrability(getTestDb(), [DEFERRED_FK]);
+
+    // Several shipped FKs are DEFERRABLE INITIALLY DEFERRED on purpose
+    // (2026-09-13-agent-rollback-lifecycle.sql,
+    // 2026-09-28-100002-software-inventory-observations.sql). A helper that
+    // hard-codes INITIALLY IMMEDIATE would silently downgrade one the moment a
+    // caller named it.
+    expect(await readMode(DEFERRED_FK)).toEqual({ deferrable: true, deferred: true });
+  });
+});

--- a/apps/api/src/__tests__/integration/orgLifecycleFoundations.integration.test.ts
+++ b/apps/api/src/__tests__/integration/orgLifecycleFoundations.integration.test.ts
@@ -54,6 +54,15 @@ describe('Org lifecycle foundations contract', () => {
     // Merge (Wave 2) runs SET CONSTRAINTS ALL DEFERRED and re-points parent+child
     // org_id in separate statements. A non-deferrable composite FK here breaks it.
     // New composite (x, org_id) FKs MUST be declared DEFERRABLE INITIALLY IMMEDIATE.
+    //
+    // This reads LIVE pg_constraint state in a database shared with every other
+    // file in the shard, so it can only be trusted if no earlier test repairs
+    // deferrability it did not itself break. `reapplyOrgIdFkDeferrability`
+    // (db-utils.ts) therefore takes an explicit constraint-name list: its earlier
+    // whole-database sweep silently repaired the three non-deferrable FKs shipped
+    // by 2026-10-01-100000-ai-agents-graduation-evidence.sql, and this assertion
+    // read green in CI for days while failing on every fresh database. Never widen
+    // that helper back to a sweep, and never repair schema state from here.
     expect(offenders).toEqual([]);
   });
 });

--- a/apps/api/src/__tests__/integration/partnerApiReconstructionWatermark.integration.test.ts
+++ b/apps/api/src/__tests__/integration/partnerApiReconstructionWatermark.integration.test.ts
@@ -53,7 +53,7 @@ describe('partner reconstruction resource watermarks', () => {
     // (migrations/2026-09-12-100001-org-lifecycle-foundations.sql Section 2,
     // which lists devices_site_org_fk among the 16 constraints it converts).
     // Restore it rather than editing the shipped migration.
-    await reapplyOrgIdFkDeferrability(db);
+    await reapplyOrgIdFkDeferrability(db, ['devices_site_org_fk']);
     const sourceId = '55555555-5555-4555-8555-555555555555';
     const [identity] = await db.execute<{ value: string }>(sql`
       SELECT public.breeze_partner_export_stable_uuid(


### PR DESCRIPTION
## Cause

`apps/api/migrations/2026-10-01-100000-ai-agents-graduation-evidence.sql` (`02716187d`, #4490) added three composite `(x, org_id)` foreign keys with no `DEFERRABLE` clause, so Postgres created them `NOT DEFERRABLE`:

| Constraint | Table | References | ON DELETE |
|---|---|---|---|
| `ai_agent_op_evidence_run_org_fk` | `ai_agent_op_evidence (run_id, org_id)` | `ai_agent_runs (id, org_id)` | `SET NULL (run_id)` |
| `ai_agent_graduation_intent_org_fk` | `ai_agent_graduation (promoted_intent_id, org_id)` | `action_intents (id, org_id)` | `SET NULL (promoted_intent_id)` |
| `ai_agent_fix_watches_intent_org_fk` | `ai_agent_fix_watches (intent_id, org_id)` | `action_intents (id, org_id)` | `CASCADE` |

The org-merge contract requires every composite FK referencing an `org_id` column to be `DEFERRABLE INITIALLY IMMEDIATE`: `services/orgMerge.ts` runs `SET CONSTRAINTS ALL DEFERRED` and re-points the parent's and the child's `org_id` in separate statements, which a non-deferrable composite FK aborts mid-merge. `2026-09-12-100001-org-lifecycle-foundations.sql` Section 2 swept the 19 FKs that existed when it shipped; these three were created after it and were never covered.

**Verified** on a fresh local stack (real Postgres 16, full `autoMigrate`), as the superuser and as `breeze_app` — identical results, so catalog visibility is not a factor:

```
              conname               | condeferrable | condeferred
------------------------------------+---------------+-------------
 ai_agent_fix_watches_intent_org_fk | f             | f
 ai_agent_graduation_intent_org_fk  | f             | f
 ai_agent_op_evidence_run_org_fk    | f             | f
```

### Why CI reported this green

`orgLifecycleFoundations.integration.test.ts:39` reads live `pg_constraint` state in a database shared with every other file in its shard. Three suites replay shipped migrations raw and then called `reapplyOrgIdFkDeferrability()` (`db-utils.ts`) to undo what the replay broke — but that helper ran the org-lifecycle migration's **whole-database sweep**, repairing every non-deferrable composite `org_id` FK in the database, not only the one its own replay damaged.

**Verified** from the CI log of run `33668113575`, Integration Tests shard 2 — same shard, same database, ordered by timestamp:

```
18:44:39  [auto-migrate] Applying: 2026-10-01-100000-ai-agents-graduation-evidence.sql   (applied cleanly; no swallowed error)
18:46:49  ✓ m365ConnectionsRls.integration.test.ts          → sweeps every non-deferrable composite org_id FK
18:47:39  ✓ agentIntentConstraints.integration.test.ts      → sweeps again
18:53:12  ✓ orgLifecycleFoundations.integration.test.ts (4 tests)   ← reads an already-repaired catalog
```

Every other candidate was ruled out: the migration applied with no `NOTICE`/`ERROR` around the `DO` blocks (nothing was swallowed by `EXCEPTION WHEN duplicate_object`); `DATABASE_URL` and `DATABASE_URL_APP` in `ci.yml` point at the same `localhost:5433/breeze_test`; `pg_constraint` returns identical rows to both roles; and the log names all four tests, including the deferrable one.

**Verified by direct local reproduction** (not inference): on a fresh stack with this migration absent and the *original* helper, running only those three replay suites flips all three constraints to `condeferrable = t`, after which the contract test passes 4/4 — CI's exact result.

## What changed

- **`apps/api/migrations/2026-10-04-100001-ai-agents-graduation-fks-deferrable.sql`** (new) — `ALTER CONSTRAINT ... DEFERRABLE INITIALLY IMMEDIATE` for exactly those three constraint names. Same statement the org-lifecycle sweep uses, so no `DROP` + re-`ADD`: no re-validation of existing rows, and no restating the column list, referenced table or `ON DELETE` action by hand. Idempotent — the loop selects only `condeferrable = false`. Reports a row count via `RAISE WARNING`, per the migration-authoring rules. Scoped to three names deliberately: a blanket sweep would rebuild the same blind spot at migration level.
- **`reapplyOrgIdFkDeferrability`** now takes a **required** constraint-name list and repairs only those, throwing when a named constraint does not exist so a rename fails loudly rather than silently leaving the contract un-restored. Each caller names what its own replay un-defers. **Verified** against a real database by replaying each migration and diffing the offender set — each un-defers exactly one constraint:
  - `m365ConnectionsRls` → `m365_consent_sessions_connection_identity_fkey`
  - `agentIntentConstraints` → `action_intents_requesting_agent_run_id_org_id_fkey`
  - `partnerApiReconstructionWatermark` → `devices_site_org_fk`
- **`orgLifecycleFoundations.integration.test.ts`** — comment recording why no test may repair schema state this assertion reads.

No table or column is added, so no cascade / export-policy registration changes are required; all three tables were already registered by #4490.

## How verified

Fresh per-worktree stack (`pnpm test-stack`, Postgres 16), torn down afterwards.

1. **Repro (fresh DB, `main` as-is):** contract RED, offenders exactly the three FKs above.
2. **Control (fresh DB, migration absent, original helper):** three replay suites → all three constraints `condeferrable = t` → contract **4/4 green**. Reproduces the false CI green locally.
3. **CI-side fix would have caught it (fresh DB, migration absent, scoped helper):** three replay suites 35/35 green and they restore only their own three constraints (`m365_consent_sessions_connection_identity_fkey`, `action_intents_requesting_agent_run_id_org_id_fkey`, `devices_site_org_fk` → `t`; the three AI-agent FKs stay `f`) → contract **RED**, naming all three.
4. **Fix (fresh DB, migration present):** `autoMigrate` applies it once — `WARNING: ai-agents graduation: made 3 composite org_id FKs deferrable` — contract **4/4 green**.
5. **Idempotency, twice on a fresh DB:** re-applying the file raw is a silent no-op; all three end `condeferrable = t, condeferred = f`. A second `autoMigrate` pass is a ledger skip and the contract stays green.
6. **Together:** the three replay suites + the contract in one run → **39/39 green**.
7. `tsc --noEmit` clean, `eslint` clean on all five touched TS files, `bash scripts/check-migration-naming.sh` OK (whole-dir and `--staged`), `vitest run src/db/autoMigrate.test.ts` **63/63**.

## Risk

Low. The migration touches only FK *deferrability* — no data, no schema shape, nothing modelled in Drizzle. `ALTER CONSTRAINT` takes a brief `ACCESS EXCLUSIVE` lock on the three tables but performs no table scan or row re-validation. `INITIALLY IMMEDIATE` means normal transactions still check these FKs at statement time exactly as before; only an explicit `SET CONSTRAINTS ... DEFERRED` (i.e. org merge) changes behaviour. The helper change is test-only, and its failure direction is safe: a future replay that damages an unlisted constraint makes the contract test go red rather than silently pass.

Refs #4187

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015tHmJsqrTy5iHcqgpadtMp
