### PR TITLE
feat(trust): session, distribution and enrollment gates (W04, #4549)

### DIFF
--- a/apps/api/src/__tests__/integration/partnerTrustEnrollment.integration.test.ts
+++ b/apps/api/src/__tests__/integration/partnerTrustEnrollment.integration.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Real-Postgres proof that the probation enrollment cap is a lifetime counter
+ * serialized by the partner row lock, rather than a race-prone device count.
+ */
+import './setup';
+import { randomUUID } from 'node:crypto';
+import { and, eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
+import { db, withSystemDbAccessContext } from '../../db';
+import { devices, enrollmentKeys, partners } from '../../db/schema';
+import { enrollmentRoutes } from '../../routes/agents/enrollment';
+import { hashEnrollmentKey } from '../../services/enrollmentKeySecurity';
+import { createOrganization, createPartner, createSite } from './db-utils';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+function enrollmentApp(): Hono {
+  const app = new Hono();
+  app.route('/agents', enrollmentRoutes);
+  return app;
+}
+
+function enrollmentBody(rawKey: string, hostname: string) {
+  return {
+    enrollmentKey: rawKey,
+    hostname,
+    osType: 'linux' as const,
+    osVersion: 'Integration Linux',
+    architecture: 'amd64',
+    agentVersion: '1.0.0-test',
+  };
+}
+
+describe('partner trust probation enrollment cap — real Postgres (Task 4.4)', () => {
+  const originalIsHosted = process.env.IS_HOSTED;
+  const originalTrustMode = process.env.PARTNER_TRUST_MODE;
+
+  beforeEach(() => {
+    process.env.IS_HOSTED = 'true';
+    process.env.PARTNER_TRUST_MODE = 'enforce';
+  });
+
+  afterEach(() => {
+    if (originalIsHosted === undefined) delete process.env.IS_HOSTED;
+    else process.env.IS_HOSTED = originalIsHosted;
+    if (originalTrustMode === undefined) delete process.env.PARTNER_TRUST_MODE;
+    else process.env.PARTNER_TRUST_MODE = originalTrustMode;
+  });
+
+  runDb('admits exactly five concurrent enrollments and never recycles deleted-device quota', async () => {
+    const suffix = randomUUID();
+    const partner = await createPartner({ slug: `trust-enroll-${suffix}` });
+    const org = await createOrganization({ partnerId: partner.id });
+    const site = await createSite({ orgId: org.id });
+    const rawKey = `trust-enrollment-${suffix}`;
+
+    await withSystemDbAccessContext(async () => {
+      await db
+        .update(partners)
+        .set({ trustState: 'probation', probationEnrollments: 0 })
+        .where(eq(partners.id, partner.id));
+      await db.insert(enrollmentKeys).values({
+        orgId: org.id,
+        siteId: site.id,
+        name: 'Partner trust enrollment concurrency key',
+        key: hashEnrollmentKey(rawKey),
+        keySecretHash: null,
+        usageCount: 0,
+        maxUsage: null,
+        expiresAt: null,
+      });
+    });
+
+    const app = enrollmentApp();
+    const responses = await Promise.all(
+      Array.from({ length: 8 }, (_, index) => app.request('/agents/enroll', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(enrollmentBody(rawKey, `trust-host-${index}-${suffix}`)),
+      })),
+    );
+
+    expect(responses.filter((response) => response.status === 201)).toHaveLength(5);
+    expect(responses.filter((response) => response.status === 403)).toHaveLength(3);
+
+    const successfulBodies = await Promise.all(
+      responses
+        .filter((response) => response.status === 201)
+        .map((response) => response.json()),
+    );
+    expect(new Set(successfulBodies.map((body) => body.agentId))).toHaveProperty('size', 5);
+
+    const stateAfterRace = await withSystemDbAccessContext(async () => {
+      const partnerRows = await db
+        .select({ probationEnrollments: partners.probationEnrollments })
+        .from(partners)
+        .where(eq(partners.id, partner.id));
+      const deviceRows = await db
+        .select({ id: devices.id })
+        .from(devices)
+        .where(eq(devices.orgId, org.id));
+      return { probationEnrollments: partnerRows[0]?.probationEnrollments, deviceRows };
+    });
+
+    expect(stateAfterRace.deviceRows).toHaveLength(5);
+    expect(stateAfterRace.probationEnrollments).toBe(5);
+
+    await withSystemDbAccessContext(async () => {
+      await db.delete(devices).where(and(
+        eq(devices.orgId, org.id),
+        eq(devices.id, stateAfterRace.deviceRows[0]!.id),
+      ));
+      await db.delete(devices).where(and(
+        eq(devices.orgId, org.id),
+        eq(devices.id, stateAfterRace.deviceRows[1]!.id),
+      ));
+    });
+
+    const ninth = await app.request('/agents/enroll', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(enrollmentBody(rawKey, `trust-host-9-${suffix}`)),
+    });
+
+    expect(ninth.status).toBe(403);
+    expect(await ninth.json()).toEqual({
+      error: 'TRUST_PROBATION',
+      capability: 'agent_enroll',
+      reason: 'probation_enrollment_cap',
+      reviewRequested: false,
+      meetingUrl: null,
+    });
+
+    const finalState = await withSystemDbAccessContext(async () => {
+      const [partnerRow] = await db
+        .select({ probationEnrollments: partners.probationEnrollments })
+        .from(partners)
+        .where(eq(partners.id, partner.id));
+      const remainingDevices = await db
+        .select({ id: devices.id })
+        .from(devices)
+        .where(eq(devices.orgId, org.id));
+      return { partnerRow, remainingDevices };
+    });
+    expect(finalState.remainingDevices).toHaveLength(3);
+    expect(finalState.partnerRow?.probationEnrollments).toBe(5);
+  });
+});

--- a/apps/api/src/__tests__/integration/partnerTrustEnrollment.integration.test.ts
+++ b/apps/api/src/__tests__/integration/partnerTrustEnrollment.integration.test.ts
@@ -35,10 +35,19 @@ function enrollmentBody(rawKey: string, hostname: string) {
 describe('partner trust probation enrollment cap — real Postgres (Task 4.4)', () => {
   const originalIsHosted = process.env.IS_HOSTED;
   const originalTrustMode = process.env.PARTNER_TRUST_MODE;
+  const originalEnrollmentSecret = process.env.AGENT_ENROLLMENT_SECRET;
 
   beforeEach(() => {
     process.env.IS_HOSTED = 'true';
     process.env.PARTNER_TRUST_MODE = 'enforce';
+    // This suite exercises the probation-cap gate only, using enrollment-key
+    // fixtures with no per-key secret (keySecretHash: null). Whether a global
+    // AGENT_ENROLLMENT_SECRET is configured is orthogonal to that gate but
+    // gets read from whatever .env happens to be loaded in this environment
+    // (CI's integration-test job never sets it; a local worktree's .env
+    // often does, per wt-stack). Force it unset so this test's outcome
+    // doesn't depend on that unrelated, ambient configuration.
+    delete process.env.AGENT_ENROLLMENT_SECRET;
   });
 
   afterEach(() => {
@@ -46,6 +55,8 @@ describe('partner trust probation enrollment cap — real Postgres (Task 4.4)', 
     else process.env.IS_HOSTED = originalIsHosted;
     if (originalTrustMode === undefined) delete process.env.PARTNER_TRUST_MODE;
     else process.env.PARTNER_TRUST_MODE = originalTrustMode;
+    if (originalEnrollmentSecret === undefined) delete process.env.AGENT_ENROLLMENT_SECRET;
+    else process.env.AGENT_ENROLLMENT_SECRET = originalEnrollmentSecret;
   });
 
   runDb('admits exactly five concurrent enrollments and never recycles deleted-device quota', async () => {

--- a/apps/api/src/routes/agents/enrollment.test.ts
+++ b/apps/api/src/routes/agents/enrollment.test.ts
@@ -63,7 +63,12 @@ vi.mock('../../db/schema', () => ({
   deviceHardware: { deviceId: 'deviceId', serialNumber: 'serialNumber' },
   deviceNetwork: { deviceId: 'deviceId', macAddress: 'macAddress' },
   organizations: { id: 'id', partnerId: 'partnerId' },
-  partners: { id: 'id', maxDevices: 'maxDevices' },
+  partners: {
+    id: 'id',
+    maxDevices: 'maxDevices',
+    trustState: 'trustState',
+    probationEnrollments: 'probationEnrollments',
+  },
   supportSessions: {
     id: 'supportSessions.id',
     status: 'supportSessions.status',
@@ -127,6 +132,21 @@ vi.mock('../../services/deviceIdentityCollisionAlert', () => ({
   raiseDeviceIdentityCollisionAlert: vi.fn(async () => 'alert-1'),
 }));
 
+vi.mock('../../config/partnerTrustMode', () => ({
+  partnerTrustMode: vi.fn(() => 'off'),
+}));
+
+vi.mock('../../services/partnerTrust', () => ({
+  evaluateCapability: vi.fn(async () => ({ allow: true })),
+  trustDenyBody: vi.fn((decision: Record<string, unknown>, reviewRequested: boolean) => ({
+    error: decision.code,
+    capability: decision.capability,
+    reason: decision.reason,
+    reviewRequested,
+    meetingUrl: null,
+  })),
+}));
+
 // ---------- imports after mocks ----------
 
 import { db, withSystemDbAccessContext } from '../../db';
@@ -137,7 +157,14 @@ import * as manifestSigning from '../../services/manifestSigning';
 import { getTrustedClientIp } from '../../services/clientIp';
 import { queueWarrantySyncForDevice } from '../../services/warrantyWorker';
 import { raiseDeviceIdentityCollisionAlert } from '../../services/deviceIdentityCollisionAlert';
-import { devices as devicesTable, supportSessions as supportSessionsTable } from '../../db/schema';
+import { partnerTrustMode } from '../../config/partnerTrustMode';
+import { evaluateCapability } from '../../services/partnerTrust';
+import {
+  devices as devicesTable,
+  enrollmentKeys as enrollmentKeysTable,
+  partners as partnersTable,
+  supportSessions as supportSessionsTable,
+} from '../../db/schema';
 import { enrollmentRoutes } from './enrollment';
 
 function buildApp(): Hono {
@@ -332,6 +359,173 @@ describe('POST /agents/enroll — backup server URL delivery (#2288)', () => {
   it('omits/empty backupServerUrl when env unset', async () => {
     const body = await enrollOk();
     expect(body.backupServerUrl ?? '').toBe('');
+  });
+});
+
+describe('POST /agents/enroll — partner trust probation enrollment counter (Task 4.4)', () => {
+  function arrangeEnrollment() {
+    mockKeyLookup({
+      id: 'key-trust',
+      orgId: 'org-trust',
+      siteId: 'site-trust',
+      keySecretHash: null,
+      expiresAt: new Date(Date.now() + 3600_000),
+      maxUsage: null,
+      usageCount: 0,
+      supportSessionId: null,
+    });
+    mockSelectRows([{ partnerId: 'partner-trust' }]);
+    mockSelectRows([{ maxDevices: null }]);
+    mockSelectRows([]);
+  }
+
+  function installTrustTransaction(trustRow: {
+    trustState: 'probation' | 'trusted';
+    probationEnrollments: number;
+  }) {
+    const forUpdate = vi.fn().mockResolvedValue([trustRow]);
+    const select = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({ for: forUpdate }),
+      }),
+    });
+    const insertedDevice = {
+      id: 'device-trust',
+      orgId: 'org-trust',
+      siteId: 'site-trust',
+      hostname: 'host-1',
+    };
+    const insertedTables: unknown[] = [];
+    const updateCalls: Array<{ table: unknown; values: Record<string, unknown> }> = [];
+
+    vi.mocked(db.transaction).mockImplementation(async (fn: any) => fn({
+      select,
+      update: vi.fn((table: unknown) => ({
+        set: vi.fn((values: Record<string, unknown>) => {
+          updateCalls.push({ table, values });
+          const returning = table === enrollmentKeysTable
+            ? vi.fn().mockResolvedValue([{ id: 'key-trust' }])
+            : vi.fn().mockResolvedValue([]);
+          return {
+            where: vi.fn(() => Object.assign(Promise.resolve(undefined), { returning })),
+          };
+        }),
+      })),
+      insert: vi.fn((table: unknown) => {
+        insertedTables.push(table);
+        return {
+          values: vi.fn(() => ({
+            returning: vi.fn().mockResolvedValue([insertedDevice]),
+            onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+          })),
+        };
+      }),
+      delete: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+    }));
+
+    return { forUpdate, select, insertedTables, updateCalls };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.AGENT_ENROLLMENT_SECRET;
+    process.env.NODE_ENV = 'test';
+    vi.mocked(partnerTrustMode).mockReturnValue('enforce');
+    vi.mocked(evaluateCapability).mockResolvedValue({ allow: true });
+  });
+
+  afterEach(() => {
+    vi.mocked(partnerTrustMode).mockReturnValue('off');
+  });
+
+  it('denies the sixth probation enrollment with the trust contract and no device insert', async () => {
+    arrangeEnrollment();
+    const tx = installTrustTransaction({ trustState: 'probation', probationEnrollments: 5 });
+    vi.mocked(evaluateCapability).mockResolvedValue({
+      allow: false,
+      code: 'TRUST_PROBATION',
+      capability: 'agent_enroll',
+      reason: 'probation_enrollment_cap',
+    });
+
+    const resp = await buildApp().request('/agents/enroll', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(baseEnrollBody),
+    });
+
+    expect(resp.status).toBe(403);
+    expect(await resp.json()).toEqual({
+      error: 'TRUST_PROBATION',
+      capability: 'agent_enroll',
+      reason: 'probation_enrollment_cap',
+      reviewRequested: false,
+      meetingUrl: null,
+    });
+    expect(tx.forUpdate).toHaveBeenCalledWith('update');
+    expect(evaluateCapability).toHaveBeenCalledWith('agent_enroll', {
+      partnerId: 'partner-trust',
+      orgId: 'org-trust',
+      detail: { probationEnrollments: 5 },
+    });
+    expect(tx.insertedTables).not.toContain(devicesTable);
+    expect(writeAuditEvent).toHaveBeenCalledWith(expect.anything(), {
+      orgId: 'org-trust',
+      action: 'agent.enroll',
+      resourceType: 'device',
+      result: 'denied',
+      details: { reason: 'probation_enrollment_cap' },
+    });
+  });
+
+  it('serializes and increments the fifth probation enrollment before inserting the device', async () => {
+    arrangeEnrollment();
+    const tx = installTrustTransaction({ trustState: 'probation', probationEnrollments: 4 });
+
+    const resp = await buildApp().request('/agents/enroll', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(baseEnrollBody),
+    });
+
+    expect(resp.status).toBe(201);
+    expect(tx.insertedTables).toContain(devicesTable);
+    const partnerUpdate = tx.updateCalls.find((call) => call.table === partnersTable);
+    expect(partnerUpdate).toBeDefined();
+    expect(JSON.stringify(partnerUpdate?.values.probationEnrollments)).toContain('+ 1');
+  });
+
+  it('locks but does not increment a trusted partner', async () => {
+    arrangeEnrollment();
+    const tx = installTrustTransaction({ trustState: 'trusted', probationEnrollments: 5 });
+
+    const resp = await buildApp().request('/agents/enroll', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(baseEnrollBody),
+    });
+
+    expect(resp.status).toBe(201);
+    expect(tx.forUpdate).toHaveBeenCalledWith('update');
+    expect(evaluateCapability).not.toHaveBeenCalled();
+    expect(tx.updateCalls.some((call) => call.table === partnersTable)).toBe(false);
+  });
+
+  it('does not issue the partner SELECT FOR UPDATE when trust mode is off', async () => {
+    vi.mocked(partnerTrustMode).mockReturnValue('off');
+    arrangeEnrollment();
+    const tx = installTrustTransaction({ trustState: 'probation', probationEnrollments: 5 });
+
+    const resp = await buildApp().request('/agents/enroll', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(baseEnrollBody),
+    });
+
+    expect(resp.status).toBe(201);
+    expect(tx.select).not.toHaveBeenCalled();
+    expect(tx.forUpdate).not.toHaveBeenCalled();
+    expect(evaluateCapability).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/routes/agents/enrollment.ts
+++ b/apps/api/src/routes/agents/enrollment.ts
@@ -37,6 +37,8 @@ import {
   raiseDeviceIdentityCollisionAlert,
   type DeviceIdentityCollisionAlertInput,
 } from '../../services/deviceIdentityCollisionAlert';
+import { partnerTrustMode } from '../../config/partnerTrustMode';
+import { evaluateCapability, trustDenyBody } from '../../services/partnerTrust';
 
 export const enrollmentRoutes = new Hono();
 const ENROLLMENT_RATE_LIMIT = 10;
@@ -417,6 +419,7 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
     const enrollmentPartnerId = org?.partnerId ?? null;
 
     if (org) {
+      deviceLimitPartnerId = org.partnerId;
       const [partner] = await db
         .select({ maxDevices: partners.maxDevices })
         .from(partners)
@@ -424,7 +427,6 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
         .limit(1);
 
       if (partner?.maxDevices != null) {
-        deviceLimitPartnerId = org.partnerId;
         maxDevices = partner.maxDevices;
       }
     }
@@ -692,6 +694,43 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
     let device;
     try {
       device = await db.transaction(async (tx) => {
+      if (partnerTrustMode() !== 'off' && deviceLimitPartnerId) {
+        const [trustRow] = await tx
+          .select({
+            trustState: partners.trustState,
+            probationEnrollments: partners.probationEnrollments,
+          })
+          .from(partners)
+          .where(eq(partners.id, deviceLimitPartnerId))
+          .for('update');
+
+        if (trustRow && trustRow.trustState !== 'trusted') {
+          const decision = await evaluateCapability('agent_enroll', {
+            partnerId: deviceLimitPartnerId,
+            orgId: key.orgId,
+            detail: { probationEnrollments: trustRow.probationEnrollments },
+          });
+          if (!decision.allow) {
+            writeAuditEvent(c, {
+              orgId: key.orgId,
+              action: 'agent.enroll',
+              resourceType: 'device',
+              result: 'denied',
+              details: { reason: decision.reason },
+            });
+            throw new HTTPException(403, {
+              message: JSON.stringify(trustDenyBody(decision, false)),
+            });
+          }
+          await tx
+            .update(partners)
+            .set({ probationEnrollments: sql`${partners.probationEnrollments} + 1` })
+            .where(eq(partners.id, deviceLimitPartnerId));
+        }
+      }
+
+      // TODO(Task 5.1): enqueue ip-classify for the new device's enrollmentIp.
+
       // Device limit check inside transaction to prevent TOCTOU race.
       // Runs when no existing row OR when the decom-bypass-fresh-id path
       // (#914) is going to INSERT a new active row — both grow net active
@@ -984,6 +1023,13 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
           error: 'Enrollment key was just exhausted or expired — regenerate a fresh key or installer link',
           reason: 'enrollment_key_race_lost',
         }, 401);
+      }
+      if (err instanceof HTTPException) {
+        try {
+          return c.json(JSON.parse(err.message), err.status);
+        } catch {
+          // Preserve non-JSON HTTPExceptions for the application's normal handler.
+        }
       }
       throw err;
     }

--- a/apps/api/src/routes/desktopWs.ts
+++ b/apps/api/src/routes/desktopWs.ts
@@ -58,6 +58,12 @@ import {
   requireRemoteWsUpgrade,
   type RemoteWsUpgradeContext,
 } from '../services/remoteWsUpgrade';
+import { partnerTrustMode } from '../config/partnerTrustMode';
+import {
+  evaluateCapability,
+  partnerIdForDevice,
+  trustDenyBody,
+} from '../services/partnerTrust';
 
 // Zod validation for desktop user messages.
 // Exported for desktopWs_inputSchema.test.ts, which asserts this enum covers
@@ -1339,6 +1345,26 @@ export function createDesktopWsRoutes(
 
       if (!['pending', 'connecting', 'active'].includes(session.status)) {
         return c.json({ error: 'Session is not available for connection' }, 400);
+      }
+
+      if (partnerTrustMode() !== 'off') {
+        const partnerId = await partnerIdForDevice(session.deviceId);
+        if (partnerId) {
+          const decision = await evaluateCapability('remote_control', {
+            partnerId,
+            deviceId: session.deviceId,
+            userId: codeRecord.userId,
+            detail: { stage: 'ticket', kind: 'desktop' },
+          });
+          if (!decision.allow) {
+            return c.json(trustDenyBody({
+              allow: false,
+              code: decision.code,
+              capability: 'remote_control',
+              reason: decision.reason,
+            }, false), 403);
+          }
+        }
       }
 
       const accessToken = await createViewerAccessToken({

--- a/apps/api/src/routes/desktopWs_utils_http.test.ts
+++ b/apps/api/src/routes/desktopWs_utils_http.test.ts
@@ -4,6 +4,9 @@ const {
   revokeViewerSessionMock,
   persistDesktopFinalizationIntentMock,
   finalizeDesktopSessionOnceMock,
+  partnerTrustModeMock,
+  partnerIdForDeviceMock,
+  evaluateCapabilityMock,
 } = vi.hoisted(() => {
   const revokeViewerSessionMock = vi.fn(async (_sessionId: string) => undefined);
   return {
@@ -17,6 +20,9 @@ const {
       await revokeViewerSessionMock(input.sessionId);
       return 'finalized' as const;
     }),
+    partnerTrustModeMock: vi.fn((): 'off' | 'shadow' | 'enforce' => 'off'),
+    partnerIdForDeviceMock: vi.fn(),
+    evaluateCapabilityMock: vi.fn(),
   };
 });
 
@@ -56,6 +62,22 @@ vi.mock('../services/remoteSessionAuth', () => ({
   consumeWsTicket: vi.fn(),
   consumeDesktopConnectCode: vi.fn(),
   getViewerAccessTokenExpirySeconds: vi.fn(() => 900)
+}));
+
+vi.mock('../config/partnerTrustMode', () => ({
+  partnerTrustMode: partnerTrustModeMock,
+}));
+
+vi.mock('../services/partnerTrust', () => ({
+  partnerIdForDevice: partnerIdForDeviceMock,
+  evaluateCapability: evaluateCapabilityMock,
+  trustDenyBody: vi.fn((decision, reviewRequested) => ({
+    error: decision.code,
+    capability: decision.capability,
+    reason: decision.reason,
+    reviewRequested,
+    meetingUrl: null,
+  })),
 }));
 
 vi.mock('../services/jwt', () => ({
@@ -126,6 +148,7 @@ import {
   getViewerAccessTokenExpirySeconds,
 } from '../services/remoteSessionAuth';
 import { createViewerAccessToken, verifyViewerAccessToken } from '../services/jwt';
+import { evaluateCapability, partnerIdForDevice } from '../services/partnerTrust';
 import {
   isViewerJtiRevoked,
   isViewerSessionRevoked,
@@ -287,6 +310,7 @@ function buildApp() {
 describe('desktopWs', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    partnerTrustModeMock.mockReturnValue('off');
     __resetDesktopWsForTest();
   });
 
@@ -470,6 +494,102 @@ describe('desktopWs', () => {
       const body = await res.json();
       expect(body.accessToken).toBe('mock-access-token-xyz');
       expect(body.expiresInSeconds).toBe(900);
+    });
+
+    it('returns 403 without issuing a token when probation denies ticket exchange', async () => {
+      const userId = 'user-probation';
+      partnerTrustModeMock.mockReturnValue('enforce');
+      vi.mocked(partnerIdForDevice).mockResolvedValue('partner-1');
+      vi.mocked(evaluateCapability).mockResolvedValue({
+        allow: false,
+        code: 'TRUST_PROBATION',
+        capability: 'remote_control',
+        reason: 'Partner is in trust probation',
+      });
+      vi.mocked(consumeDesktopConnectCode).mockResolvedValue({
+        sessionId: SESSION_ID,
+        userId,
+        email: 'test@example.com',
+        expiresAt: Date.now() + 60_000,
+      });
+      vi.mocked(db.select).mockReturnValueOnce(mockSelectChain([{
+        id: SESSION_ID,
+        userId,
+        type: 'desktop',
+        status: 'pending',
+        deviceId: DEVICE_ID,
+      }]));
+
+      const res = await buildApp().request('/connect/exchange', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId: SESSION_ID, code: 'probation-code' }),
+      });
+
+      expect(res.status).toBe(403);
+      expect(await res.json()).toMatchObject({ error: 'TRUST_PROBATION' });
+      expect(evaluateCapability).toHaveBeenCalledWith('remote_control', {
+        partnerId: 'partner-1',
+        deviceId: DEVICE_ID,
+        userId,
+        detail: { stage: 'ticket', kind: 'desktop' },
+      });
+      expect(createViewerAccessToken).not.toHaveBeenCalled();
+    });
+
+    it('keeps trusted ticket exchange behavior unchanged under enforce mode', async () => {
+      const userId = 'user-trusted';
+      partnerTrustModeMock.mockReturnValue('enforce');
+      vi.mocked(partnerIdForDevice).mockResolvedValue('partner-1');
+      vi.mocked(evaluateCapability).mockResolvedValue({ allow: true });
+      vi.mocked(consumeDesktopConnectCode).mockResolvedValue({
+        sessionId: SESSION_ID,
+        userId,
+        email: 'test@example.com',
+        expiresAt: Date.now() + 60_000,
+      });
+      vi.mocked(db.select).mockReturnValueOnce(mockSelectChain([{
+        id: SESSION_ID,
+        userId,
+        type: 'desktop',
+        status: 'pending',
+        deviceId: DEVICE_ID,
+      }]));
+
+      const res = await buildApp().request('/connect/exchange', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId: SESSION_ID, code: 'trusted-code' }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(createViewerAccessToken).toHaveBeenCalledOnce();
+    });
+
+    it('does not resolve a partner when trust mode is off', async () => {
+      const userId = 'user-mode-off';
+      vi.mocked(consumeDesktopConnectCode).mockResolvedValue({
+        sessionId: SESSION_ID,
+        userId,
+        email: 'test@example.com',
+        expiresAt: Date.now() + 60_000,
+      });
+      vi.mocked(db.select).mockReturnValueOnce(mockSelectChain([{
+        id: SESSION_ID,
+        userId,
+        type: 'desktop',
+        status: 'pending',
+        deviceId: DEVICE_ID,
+      }]));
+
+      const res = await buildApp().request('/connect/exchange', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId: SESSION_ID, code: 'mode-off-code' }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(partnerIdForDevice).not.toHaveBeenCalled();
     });
 
     it('rejects a re-exchange of a consumed connect code (no re-exchange cache)', async () => {

--- a/apps/api/src/routes/devices.test.ts
+++ b/apps/api/src/routes/devices.test.ts
@@ -2,6 +2,36 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Hono } from 'hono';
 import { deviceRoutes } from './devices';
 
+const { evaluateCapability, partnerTrustMode, requireCapability } = vi.hoisted(() => {
+  const evaluateCapability = vi.fn(async (_cap?: string, _ctx?: unknown): Promise<any> => ({ allow: true }));
+  return {
+    evaluateCapability,
+    partnerTrustMode: vi.fn((): 'off' | 'shadow' | 'enforce' => 'off'),
+    requireCapability: vi.fn((capability: string) => async (c: any, next: any) => {
+      const auth = c.get('auth');
+      if (!auth?.partnerId) return next();
+      const decision = await evaluateCapability(capability, {
+        partnerId: auth.partnerId,
+        userId: auth.user?.id,
+        orgId: auth.orgId ?? undefined,
+      });
+      if (!decision.allow) {
+        return c.json({
+          error: decision.code,
+          capability: decision.capability,
+          reason: decision.reason,
+          reviewRequested: false,
+          meetingUrl: null,
+        }, 403);
+      }
+      return next();
+    }),
+  };
+});
+
+vi.mock('../services/partnerTrust', () => ({ evaluateCapability, requireCapability }));
+vi.mock('../config/partnerTrustMode', () => ({ partnerTrustMode }));
+
 vi.mock('../services', () => ({}));
 
 // core.ts (decommission handler) imports both terminateDeviceRemoteSessions and
@@ -208,6 +238,8 @@ describe('device routes', () => {
   let app: Hono;
 
   beforeEach(() => {
+    partnerTrustMode.mockReturnValue('off');
+    evaluateCapability.mockResolvedValue({ allow: true });
     // resetAllMocks clears mockReturnValueOnce queues, preventing test pollution
     vi.resetAllMocks();
     // Restore factory default chains
@@ -278,6 +310,44 @@ describe('device routes', () => {
   });
 
   describe('POST /devices/onboarding-token', () => {
+    it('returns 403 for probation before minting an onboarding token', async () => {
+      const { authMiddleware } = await import('../middleware/auth');
+      vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+        c.set('auth', {
+          user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
+          scope: 'organization',
+          orgId: 'org-123',
+          partnerId: 'partner-1',
+          accessibleOrgIds: ['org-123'],
+          canAccessOrg: (orgId: string) => orgId === 'org-123',
+          orgCondition: vi.fn(),
+        });
+        return next();
+      });
+      evaluateCapability.mockResolvedValueOnce({
+        allow: false,
+        code: 'TRUST_PROBATION',
+        capability: 'installer_distribute',
+        reason: 'probation_default_deny',
+      });
+
+      const res = await app.request('/devices/onboarding-token', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(403);
+      expect(await res.json()).toEqual(expect.objectContaining({
+        error: 'TRUST_PROBATION',
+        capability: 'installer_distribute',
+      }));
+      expect(evaluateCapability).toHaveBeenCalledWith('installer_distribute', expect.objectContaining({
+        partnerId: 'partner-1',
+      }));
+      expect(db.select).not.toHaveBeenCalled();
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
     it('should require orgId for partner/system contexts with multiple accessible orgs', async () => {
       const { authMiddleware } = await import('../middleware/auth');
       vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {

--- a/apps/api/src/routes/devices/core.remoteAccessLaunch.test.ts
+++ b/apps/api/src/routes/devices/core.remoteAccessLaunch.test.ts
@@ -2,6 +2,34 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
 import { getTableName, is, Table } from 'drizzle-orm';
 
+const { evaluateCapability, requireCapability } = vi.hoisted(() => {
+  const evaluateCapability = vi.fn(async (_cap?: string, _ctx?: unknown): Promise<any> => ({ allow: true }));
+  return {
+    evaluateCapability,
+    requireCapability: vi.fn((capability: string) => async (c: any, next: any) => {
+      const auth = c.get('auth');
+      if (!auth?.partnerId) return next();
+      const decision = await evaluateCapability(capability, {
+        partnerId: auth.partnerId,
+        userId: auth.user?.id,
+        orgId: auth.orgId ?? undefined,
+      });
+      if (!decision.allow) {
+        return c.json({
+          error: decision.code,
+          capability: decision.capability,
+          reason: decision.reason,
+          reviewRequested: false,
+          meetingUrl: null,
+        }, 403);
+      }
+      return next();
+    }),
+  };
+});
+
+vi.mock('../../services/partnerTrust', () => ({ evaluateCapability, requireCapability }));
+
 // Hold a configurable partner-settings value the mocked select chain returns.
 // Each test mutates this before calling app.request().
 let mockPartnerSettings: unknown = {};
@@ -69,7 +97,7 @@ vi.mock('../../middleware/auth', () => ({
       user: { id: '11111111-1111-1111-1111-111111111111', email: 'test@example.com', name: 'Test User' },
       scope: 'organization',
       orgId: 'org-123',
-      partnerId: null,
+      partnerId: '33333333-3333-4333-8333-333333333333',
       accessibleOrgIds: ['org-123'],
       // This route is reached by a person clicking Connect, so the mocked
       // context carries the same discriminator the real one would. The
@@ -151,9 +179,34 @@ describe('POST /devices/:id/remote-access-launch', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    evaluateCapability.mockResolvedValue({ allow: true });
     mockPartnerSettings = {};
     app = new Hono();
     app.route('/devices', coreRoutes);
+  });
+
+  it('returns 403 before resolving a credential-bearing URL when remote control is denied', async () => {
+    evaluateCapability.mockResolvedValueOnce({
+      allow: false,
+      code: 'TRUST_PROBATION',
+      capability: 'remote_control',
+      reason: 'probation_default_deny',
+    });
+
+    const res = await app.request(`/devices/${deviceId}/remote-access-launch`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual(expect.objectContaining({
+      error: 'TRUST_PROBATION',
+      capability: 'remote_control',
+    }));
+    expect(evaluateCapability).toHaveBeenCalledWith('remote_control', expect.objectContaining({
+      partnerId: '33333333-3333-4333-8333-333333333333',
+    }));
+    expect(getDeviceWithOrgAndSiteCheck).not.toHaveBeenCalled();
   });
 
   // Registration-time gate test. The launcher POST issues URLs that may carry
@@ -237,6 +290,7 @@ describe('POST /devices/:id/remote-access-launch', () => {
       headers: { Authorization: 'Bearer token' }
     });
     expect(res.status).toBe(200);
+    expect(evaluateCapability).toHaveBeenCalledWith('remote_control', expect.any(Object));
     const body = await res.json() as { launchUrl?: string; scheme?: string; providerId?: string };
     expect(body.launchUrl).toBe('rustdesk://294064193?password=p%23x');
     expect(body.scheme).toBe('rustdesk');

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -76,6 +76,7 @@ import {
 } from '../../extensions/tenancyRegistry';
 import { pgErrorCode, pgErrorNode } from '../../utils/pgErrors';
 import { schedulePeripheralPolicyDevice } from '../../jobs/peripheralJobs';
+import { requireCapability } from '../../services/partnerTrust';
 
 
 /**
@@ -449,6 +450,7 @@ coreRoutes.post(
   requireScope('organization', 'partner', 'system'),
   requirePermission(PERMISSIONS.ORGS_WRITE.resource, PERMISSIONS.ORGS_WRITE.action),
   requireMfa(),
+  requireCapability('installer_distribute'),
   optionalJsonValidator(onboardingTokenSchema),
   async (c) => {
     const auth = c.get('auth');
@@ -1264,6 +1266,7 @@ coreRoutes.post(
   // needs to match (not loosen) the existing remote-desktop session gate.
   requirePermission(PERMISSIONS.REMOTE_ACCESS.resource, PERMISSIONS.REMOTE_ACCESS.action),
   requireMfa(),
+  requireCapability('remote_control'),
   async (c) => {
     const auth = c.get('auth');
     const deviceId = c.req.param('id')!;

--- a/apps/api/src/routes/enrollmentKeys.test.ts
+++ b/apps/api/src/routes/enrollmentKeys.test.ts
@@ -2,6 +2,36 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Hono } from "hono";
 import { randomUUID } from "crypto";
 
+const { evaluateCapability, partnerTrustMode, requireCapability } = vi.hoisted(() => {
+  const evaluateCapability = vi.fn(async (_cap?: string, _ctx?: unknown): Promise<any> => ({ allow: true }));
+  return {
+    evaluateCapability,
+    partnerTrustMode: vi.fn((): "off" | "shadow" | "enforce" => "off"),
+    requireCapability: vi.fn((capability: string) => async (c: any, next: any) => {
+      const auth = c.get("auth");
+      if (!auth?.partnerId) return next();
+      const decision = await evaluateCapability(capability, {
+        partnerId: auth.partnerId,
+        userId: auth.user?.id,
+        orgId: auth.orgId ?? undefined,
+      });
+      if (!decision.allow) {
+        return c.json({
+          error: decision.code,
+          capability: decision.capability,
+          reason: decision.reason,
+          reviewRequested: false,
+          meetingUrl: null,
+        }, 403);
+      }
+      return next();
+    }),
+  };
+});
+
+vi.mock("../services/partnerTrust", () => ({ evaluateCapability, requireCapability }));
+vi.mock("../config/partnerTrustMode", () => ({ partnerTrustMode }));
+
 // ============================================================
 // Mocks — must appear before any `import` of the source
 // ============================================================
@@ -23,6 +53,7 @@ vi.mock("../db", () => ({
 
 vi.mock("../db/schema", () => ({
   enrollmentKeys: {},
+  organizations: { id: "organizations.id", partnerId: "organizations.partnerId" },
   installerBootstrapTokens: {},
 }));
 
@@ -46,6 +77,7 @@ vi.mock("../middleware/auth", () => ({
     c.set("auth", {
       scope: "system",
       orgId: null,
+      partnerId: "22222222-2222-4222-8222-222222222222",
       user: { id: "user-system", email: "system@example.com" },
       canAccessOrg: () => true,
       accessibleOrgIds: [],
@@ -227,10 +259,46 @@ function makeChildKeyRow(overrides: Record<string, unknown> = {}) {
 // that calls mockEnrollmentDefaults() would otherwise leak its cap into every
 // later test in the file.
 beforeEach(() => {
+  partnerTrustMode.mockReturnValue("off");
+  evaluateCapability.mockResolvedValue({ allow: true });
   assertTtlWithinCapMock.mockReset();
   assertTtlWithinCapMock.mockImplementation(async () => null);
   clampTtlToCapMock.mockReset();
   clampTtlToCapMock.mockImplementation(async (_orgId: string, ttlMinutes: number) => ttlMinutes);
+});
+
+describe("partner trust gates on authenticated installer distribution", () => {
+  it.each([
+    ["installer link", `/enrollment-keys/${KEY_ID}/installer-link`, "POST", { platform: "windows" }],
+    ["bootstrap token", `/enrollment-keys/${KEY_ID}/bootstrap-token`, "POST", {}],
+    ["installer child", `/enrollment-keys/${KEY_ID}/installer/windows`, "GET", undefined],
+  ])("returns 403 for probation before creating the %s", async (_name, path, method, body) => {
+    evaluateCapability.mockResolvedValueOnce({
+      allow: false,
+      code: "TRUST_PROBATION",
+      capability: "installer_distribute",
+      reason: "probation_default_deny",
+    });
+    const app = new Hono();
+    app.route("/enrollment-keys", enrollmentKeyRoutes);
+
+    const res = await app.request(path, {
+      method,
+      headers: body === undefined ? undefined : { "Content-Type": "application/json" },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual(expect.objectContaining({
+      error: "TRUST_PROBATION",
+      capability: "installer_distribute",
+    }));
+    expect(evaluateCapability).toHaveBeenCalledWith(
+      "installer_distribute",
+      expect.objectContaining({ partnerId: "22222222-2222-4222-8222-222222222222" }),
+    );
+    expect(db.select).not.toHaveBeenCalled();
+  });
 });
 
 // ============================================================
@@ -603,6 +671,47 @@ describe("GET /s/:code", () => {
     process.env.PUBLIC_API_URL = "https://api.example.com";
     app = new Hono();
     app.route("/s", publicShortLinkRoutes);
+  });
+
+  it("hides an installer-distribution trust denial behind 404", async () => {
+    partnerTrustMode.mockReturnValue("enforce");
+    evaluateCapability.mockResolvedValueOnce({
+      allow: false,
+      code: "TRUST_PROBATION",
+      capability: "installer_distribute",
+      reason: "probation_default_deny",
+    });
+    const shortLinkRow = makeKeyRow({
+      shortCode: "probation1",
+      installerPlatform: "windows",
+    });
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([shortLinkRow]),
+          }),
+        }),
+      } as any)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ partnerId: "partner-1" }]),
+          }),
+        }),
+      } as any);
+
+    const res = await app.request("/s/probation1");
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Not found" });
+    expect(evaluateCapability).toHaveBeenCalledWith("installer_distribute", {
+      partnerId: "partner-1",
+      orgId: ORG_ID,
+      detail: { route: "short-link" },
+    });
+    expect(db.update).not.toHaveBeenCalled();
+    expect(db.insert).not.toHaveBeenCalled();
   });
 
   it("serves installer for valid code", async () => {
@@ -1288,6 +1397,46 @@ describe("GET /public-download/:platform", () => {
     app.route("/enrollment-keys", publicEnrollmentRoutes);
   });
 
+  it("hides an installer-distribution trust denial behind 404", async () => {
+    partnerTrustMode.mockReturnValue("enforce");
+    evaluateCapability.mockResolvedValueOnce({
+      allow: false,
+      code: "TRUST_PROBATION",
+      capability: "installer_distribute",
+      reason: "probation_default_deny",
+    });
+    const row = makeKeyRow({ installerPlatform: "windows" });
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([row]),
+          }),
+        }),
+      } as any)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ partnerId: "partner-1" }]),
+          }),
+        }),
+      } as any);
+
+    const res = await app.request(
+      `/enrollment-keys/public-download/windows?h=dlh_${"1".repeat(32)}`,
+    );
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Invalid or expired download link" });
+    expect(evaluateCapability).toHaveBeenCalledWith("installer_distribute", {
+      partnerId: "partner-1",
+      orgId: ORG_ID,
+      detail: { route: "public-download" },
+    });
+    expect(db.insert).not.toHaveBeenCalled();
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
   it("does not bump child key usage_count on download — leaves the slot for the agent enroll call", async () => {
     // Regression test for the root cause of the MSI "401 Invalid or
     // expired enrollment key" bug. Previously serveInstaller ran
@@ -1359,13 +1508,22 @@ describe("GET /public-download/:platform", () => {
       usageCount: 0,
     });
 
-    vi.mocked(db.select).mockReturnValue({
-      from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([row]),
+    partnerTrustMode.mockReturnValue("enforce");
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([row]),
+          }),
         }),
-      }),
-    } as any);
+      } as any)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ partnerId: "partner-1" }]),
+          }),
+        }),
+      } as any);
 
     const issueSpy = vi
       .spyOn(installerBootstrapTokenIssuance, "issueBootstrapTokenForKey")
@@ -1381,6 +1539,11 @@ describe("GET /public-download/:platform", () => {
     );
 
     expect(res.status).toBe(200);
+    expect(evaluateCapability).toHaveBeenCalledWith("installer_distribute", {
+      partnerId: "partner-1",
+      orgId: ORG_ID,
+      detail: { route: "public-download" },
+    });
     expect(res.headers.get("Content-Type")).toBe("application/octet-stream");
     expect(res.headers.get("Content-Disposition")).toMatch(
       /^attachment; filename="Breeze Agent \(ABCDE12345@api\.example\.com\)\.msi"$/,

--- a/apps/api/src/routes/enrollmentKeys.test.ts
+++ b/apps/api/src/routes/enrollmentKeys.test.ts
@@ -271,7 +271,6 @@ describe("partner trust gates on authenticated installer distribution", () => {
   it.each([
     ["installer link", `/enrollment-keys/${KEY_ID}/installer-link`, "POST", { platform: "windows" }],
     ["bootstrap token", `/enrollment-keys/${KEY_ID}/bootstrap-token`, "POST", {}],
-    ["installer child", `/enrollment-keys/${KEY_ID}/installer/windows`, "GET", undefined],
   ])("returns 403 for probation before creating the %s", async (_name, path, method, body) => {
     evaluateCapability.mockResolvedValueOnce({
       allow: false,
@@ -298,6 +297,58 @@ describe("partner trust gates on authenticated installer distribution", () => {
       expect.objectContaining({ partnerId: "22222222-2222-4222-8222-222222222222" }),
     );
     expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it("GET /:id/installer/:platform is NOT gated on installer_distribute — a probation partner can still download their own installer", async () => {
+    // This is the console's authenticated own-device installer download
+    // (AddDeviceModal, EnrollDeviceStep, EnrollmentKeyManager), not the
+    // abuse-relevant distribution surface (installer-link / bootstrap-token /
+    // the anonymous public routes) — so it must behave identically for a
+    // probation partner as for a trusted one, even if evaluateCapability
+    // would have denied.
+    //
+    // Clear call history first: the preceding it.each cases in this describe
+    // block call evaluateCapability (via installer-link / bootstrap-token),
+    // and this describe has no local `vi.clearAllMocks()`, so their history
+    // would otherwise leak into the `not.toHaveBeenCalled()` assertion below.
+    // Deliberately NOT queuing a mockResolvedValueOnce deny here: this route
+    // must never consult evaluateCapability at all, so priming a deny value
+    // that's never consumed would only leak into (and pollute) a later test.
+    evaluateCapability.mockClear();
+    partnerTrustMode.mockReturnValue("enforce");
+
+    process.env.PUBLIC_API_URL = "https://api.example.com";
+    const app = new Hono();
+    app.route("/enrollment-keys", enrollmentKeyRoutes);
+
+    const parentRow = makeKeyRow();
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([parentRow]),
+        }),
+      }),
+    } as any);
+
+    const issueSpy = vi
+      .spyOn(installerBootstrapTokenIssuance, "issueBootstrapTokenForKey")
+      .mockResolvedValueOnce({
+        id: "token-row-uuid-1",
+        token: "ABC1234567",
+        expiresAt: new Date("2026-04-20T00:00:00.000Z"),
+        parentKeyName: "Test Key",
+      });
+
+    const res = await app.request(
+      `/enrollment-keys/${KEY_ID}/installer/windows`,
+    );
+
+    expect(res.status).toBe(200);
+    // The route never consults installer_distribute at all — same behavior
+    // regardless of trust state.
+    expect(evaluateCapability).not.toHaveBeenCalled();
+
+    issueSpy.mockRestore();
   });
 });
 
@@ -756,11 +807,22 @@ describe("GET /s/:code", () => {
         parentKeyName: "Test Key",
       });
 
+    // Precondition: mode 'off' (the module-level default from the outer
+    // beforeEach), so anonymousInstallerDistributionAllowed short-circuits
+    // before ever resolving a partner id.
+    expect(partnerTrustMode()).toBe("off");
+
     const res = await app.request("/s/abc1234567");
 
     expect(res.status).toBe(200);
     const buf = await res.arrayBuffer();
     expect(buf.byteLength).toBeGreaterThan(0);
+
+    // Under mode 'off' the trust gate must short-circuit entirely: no
+    // capability evaluation, and no second db.select for the org's partner id
+    // — only the one lookup-by-shortCode select above.
+    expect(evaluateCapability).not.toHaveBeenCalled();
+    expect(db.select).toHaveBeenCalledTimes(1);
 
     issueSpy.mockRestore();
   });
@@ -1487,12 +1549,23 @@ describe("GET /public-download/:platform", () => {
         parentKeyName: "Test Key",
       });
 
+    // Precondition: mode 'off' (the module-level default from the outer
+    // beforeEach), so anonymousInstallerDistributionAllowed short-circuits
+    // before ever resolving a partner id.
+    expect(partnerTrustMode()).toBe("off");
+
     const res = await app.request(
       `/enrollment-keys/public-download/windows?h=dlh_${"1".repeat(32)}`,
     );
 
     expect(res.status).toBe(200);
     expect(db.update).not.toHaveBeenCalled();
+
+    // Under mode 'off' the trust gate must short-circuit entirely: no
+    // capability evaluation, and no second db.select for the org's partner id
+    // — only the one lookup-by-token-hash select above.
+    expect(evaluateCapability).not.toHaveBeenCalled();
+    expect(db.select).toHaveBeenCalledTimes(1);
 
     issueSpy.mockRestore();
   });

--- a/apps/api/src/routes/enrollmentKeys.ts
+++ b/apps/api/src/routes/enrollmentKeys.ts
@@ -1406,7 +1406,11 @@ enrollmentKeyRoutes.get(
     PERMISSIONS.ORGS_WRITE.action,
   ),
   requireMfa(),
-  requireCapability("installer_distribute"),
+  // No requireCapability("installer_distribute") here: this is the console's
+  // authenticated own-device installer download (AddDeviceModal,
+  // EnrollDeviceStep, EnrollmentKeyManager) — not the abuse-relevant
+  // distribution surface. Distribution is gated below on bootstrap-token
+  // and installer-link, and on the anonymous evaluations.
   zValidator("query", installerQuerySchema),
   async (c) => {
     const auth = c.get("auth");

--- a/apps/api/src/routes/enrollmentKeys.ts
+++ b/apps/api/src/routes/enrollmentKeys.ts
@@ -54,6 +54,8 @@ import {
   hasNoLiveUnexhaustedBootstrapToken,
 } from "../services/enrollmentKeyPurgeGuards";
 import { captureException } from "../services/sentry";
+import { evaluateCapability, requireCapability } from "../services/partnerTrust";
+import { partnerTrustMode } from "../config/partnerTrustMode";
 
 // ============================================================
 // Signing-spend caps for the authenticated installer endpoint.
@@ -1404,6 +1406,7 @@ enrollmentKeyRoutes.get(
     PERMISSIONS.ORGS_WRITE.action,
   ),
   requireMfa(),
+  requireCapability("installer_distribute"),
   zValidator("query", installerQuerySchema),
   async (c) => {
     const auth = c.get("auth");
@@ -1903,6 +1906,7 @@ enrollmentKeyRoutes.post(
   ),
   userRateLimit("enroll-write", 10, 60),
   requireMfa(),
+  requireCapability("installer_distribute"),
   zValidator("param", idParamSchema),
   zValidator("json", bootstrapTokenBodySchema),
   async (c) => {
@@ -1987,6 +1991,7 @@ enrollmentKeyRoutes.post(
   ),
   userRateLimit("enroll-write", 10, 60),
   requireMfa(),
+  requireCapability("installer_distribute"),
   zValidator("json", installerLinkSchema),
   async (c) => {
     const auth = c.get("auth");
@@ -2511,6 +2516,27 @@ async function serveInstaller(
 
 export const publicEnrollmentRoutes = new Hono();
 
+async function anonymousInstallerDistributionAllowed(
+  orgId: string,
+  route: "public-download" | "short-link",
+): Promise<boolean> {
+  if (partnerTrustMode() === "off") return true;
+
+  const [org] = await db
+    .select({ partnerId: organizations.partnerId })
+    .from(organizations)
+    .where(eq(organizations.id, orgId))
+    .limit(1);
+  if (!org?.partnerId) return false;
+
+  const decision = await evaluateCapability("installer_distribute", {
+    partnerId: org.partnerId,
+    orgId,
+    detail: { route },
+  });
+  return decision.allow;
+}
+
 const publicDownloadQuerySchema = z
   .object({
     h: z
@@ -2566,6 +2592,10 @@ publicEnrollmentRoutes.get(
         return c.json({ error: "Invalid or expired download link" }, 404);
       }
 
+      if (!await anonymousInstallerDistributionAllowed(enrollmentKey.orgId, "public-download")) {
+        return c.json({ error: "Invalid or expired download link" }, 404);
+      }
+
       return serveInstaller(c, enrollmentKey, platform, finalToken);
     });
   },
@@ -2599,6 +2629,10 @@ publicShortLinkRoutes.get("/:code", async (c) => {
       row.installerPlatform !== "windows" &&
       row.installerPlatform !== "macos"
     ) {
+      return c.json({ error: "Not found" }, 404);
+    }
+
+    if (!await anonymousInstallerDistributionAllowed(row.orgId, "short-link")) {
       return c.json({ error: "Not found" }, 404);
     }
 

--- a/apps/api/src/routes/remote/sessions.test.ts
+++ b/apps/api/src/routes/remote/sessions.test.ts
@@ -29,6 +29,9 @@ const {
   teardownDisconnectedSessions,
   checkSessionRateLimit,
   checkUserSessionRateLimit,
+  evaluateCapability,
+  partnerIdForDevice,
+  partnerTrustMode,
 } = vi.hoisted(() => ({
   getDeviceWithOrgCheck: vi.fn(),
   getSessionWithOrgCheck: vi.fn(),
@@ -39,6 +42,9 @@ const {
   teardownDisconnectedSessions: vi.fn(() => Promise.resolve(undefined)),
   checkSessionRateLimit: vi.fn(() => Promise.resolve({ allowed: true, currentCount: 0 })),
   checkUserSessionRateLimit: vi.fn(() => Promise.resolve({ allowed: true, currentCount: 0 })),
+  evaluateCapability: vi.fn(async (): Promise<any> => ({ allow: true })),
+  partnerIdForDevice: vi.fn(() => Promise.resolve('partner-1')),
+  partnerTrustMode: vi.fn(() => 'off'),
 }));
 
 // `runOutsideDbContext` is synchronous (wraps AsyncLocalStorage.exit); the real
@@ -49,6 +55,7 @@ const {
 vi.mock('../../db', () => ({
   db: {
     select: vi.fn(),
+    insert: vi.fn(),
     update: vi.fn(),
   },
   runOutsideDbContext: vi.fn(<T>(fn: () => T): T => fn()),
@@ -167,6 +174,19 @@ vi.mock('../../services/remoteSessionAuth', () => ({
 vi.mock('../../services/clientIp', () => ({
   getTrustedClientIp: vi.fn(() => '10.0.0.1'),
   getTrustedClientIpOrUndefined: vi.fn(() => '10.0.0.1'),
+}));
+
+vi.mock('../../config/partnerTrustMode', () => ({ partnerTrustMode }));
+vi.mock('../../services/partnerTrust', () => ({
+  evaluateCapability,
+  partnerIdForDevice,
+  trustDenyBody: (d: Record<string, unknown>, reviewRequested: boolean) => ({
+    error: d.code,
+    capability: d.capability,
+    reason: d.reason,
+    reviewRequested,
+    meetingUrl: null,
+  }),
 }));
 
 vi.mock('./recordingUrl', () => ({ normalizeRecordingUrl: vi.fn((u: unknown) => u) }));
@@ -674,6 +694,41 @@ describe('remote sessions — site-scope enforcement', () => {
       // live stream running" hole.
       expect(teardownDisconnectedSessions).toHaveBeenCalledTimes(1);
       expect(teardownDisconnectedSessions).toHaveBeenCalledWith(staleRows);
+    });
+
+    it('maps partner-trust denial to a 403 without inserting', async () => {
+      getDeviceWithOrgCheck.mockResolvedValue({
+        id: DEVICE_IN_ALLOWED,
+        orgId: ORG_ID,
+        siteId: ALLOWED_SITE,
+        agentId: 'agent-1',
+        hostname: 'host-1',
+        osType: 'linux',
+        status: 'online',
+      });
+      vi.mocked(db.update).mockReturnValueOnce({
+        set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+      } as never);
+      partnerTrustMode.mockReturnValueOnce('enforce');
+      evaluateCapability.mockResolvedValueOnce({
+        allow: false,
+        code: 'TRUST_PROBATION',
+        capability: 'remote_control',
+        reason: 'probation_default_deny',
+      });
+
+      const res = await app.request('/remote/sessions', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ deviceId: DEVICE_IN_ALLOWED, type: 'desktop' }),
+      });
+
+      expect(res.status).toBe(403);
+      expect(await res.json()).toEqual(expect.objectContaining({
+        error: 'TRUST_PROBATION',
+        capability: 'remote_control',
+      }));
+      expect((db as any).insert).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/routes/remote/sessions.ts
+++ b/apps/api/src/routes/remote/sessions.ts
@@ -43,6 +43,8 @@ import { revokeViewerSession } from '../../services/viewerTokenRevocation';
 import { captureException } from '../../services/sentry';
 import { teardownDisconnectedSessions } from '../../services/remoteSessionTeardown';
 import { normalizeRecordingUrl } from './recordingUrl';
+import { createRemoteSession, RemoteSessionDeniedError } from '../../services/remoteSessionCreate';
+import { trustDenyBody } from '../../services/partnerTrust';
 import { canAccessSite, PERMISSIONS, type UserPermissions } from '../../services/permissions';
 
 export const sessionRoutes = new Hono();
@@ -249,17 +251,25 @@ sessionRoutes.post(
     }
 
     // Create session
-    const [session] = await db
-      .insert(remoteSessions)
-      .values({
+    let session: typeof remoteSessions.$inferSelect;
+    try {
+      session = await createRemoteSession('remote', {
         deviceId: data.deviceId,
         orgId: device.orgId,
         userId: auth.user.id,
         type: data.type,
-        status: 'pending',
-        iceCandidates: []
-      })
-      .returning();
+      }) as typeof remoteSessions.$inferSelect;
+    } catch (e) {
+      if (e instanceof RemoteSessionDeniedError) {
+        return c.json(trustDenyBody({
+          allow: false,
+          code: e.code,
+          capability: 'remote_control',
+          reason: e.reason,
+        }, false), 403);
+      }
+      throw e;
+    }
 
     if (!session) {
       return c.json({ error: 'Failed to create session' }, 500);

--- a/apps/api/src/routes/remote/supportSessions.test.ts
+++ b/apps/api/src/routes/remote/supportSessions.test.ts
@@ -10,10 +10,12 @@ import { Hono } from 'hono';
  * and a system token with no partner context has no org to provision into.
  */
 
-const { getOrCreateQuickSupportOrg, logSessionAudit, getTrustedClientIp } = vi.hoisted(() => ({
+const { getOrCreateQuickSupportOrg, logSessionAudit, getTrustedClientIp, evaluateCapability, partnerTrustMode } = vi.hoisted(() => ({
   getOrCreateQuickSupportOrg: vi.fn(() => Promise.resolve({ orgId: 'qs-org', siteId: 'qs-site' })),
   logSessionAudit: vi.fn(() => Promise.resolve()),
   getTrustedClientIp: vi.fn(() => '203.0.113.7'),
+  evaluateCapability: vi.fn(async (): Promise<any> => ({ allow: true })),
+  partnerTrustMode: vi.fn(() => 'off'),
 }));
 
 const { endSupportSession } = vi.hoisted(() => ({
@@ -30,6 +32,18 @@ vi.mock('../../services/quickSupportOrg', () => ({ getOrCreateQuickSupportOrg })
 vi.mock('../../services/quickSupportEnd', () => ({ endSupportSession }));
 vi.mock('./helpers', () => ({ logSessionAudit }));
 vi.mock('../../services/clientIp', () => ({ getTrustedClientIp }));
+vi.mock('../../config/partnerTrustMode', () => ({ partnerTrustMode }));
+vi.mock('../../services/partnerTrust', () => ({
+  evaluateCapability,
+  partnerIdForDevice: vi.fn(),
+  trustDenyBody: (d: Record<string, unknown>, reviewRequested: boolean) => ({
+    error: d.code,
+    capability: d.capability,
+    reason: d.reason,
+    reviewRequested,
+    meetingUrl: null,
+  }),
+}));
 
 // Scripted select results, consumed in call order.
 const selectResults: unknown[][] = [];
@@ -153,6 +167,26 @@ describe('POST /support-sessions', () => {
     expect((insertedValues[0] as { codeHash: string }).codeHash).toBe(hashSupportCode(raw));
     expect(body.landingUrl).toBe(`https://us.2breeze.app/quick?code=${raw}`);
     expect((insertedValues[0] as { orgId: string }).orgId).toBe('qs-org');
+  });
+
+  it('maps partner-trust denial to a 403 without inserting', async () => {
+    partnerTrustMode.mockReturnValueOnce('enforce');
+    evaluateCapability.mockResolvedValueOnce({
+      allow: false,
+      code: 'TRUST_PROBATION',
+      capability: 'remote_control',
+      reason: 'probation_default_deny',
+    });
+
+    const res = await buildApp().request('/support-sessions', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual(expect.objectContaining({ error: 'TRUST_PROBATION' }));
+    expect(insertedValues).toHaveLength(0);
   });
 
   it('never returns the code hash to the caller', async () => {

--- a/apps/api/src/routes/remote/supportSessions.ts
+++ b/apps/api/src/routes/remote/supportSessions.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import { zValidator } from '../../lib/validation';
 import { and, desc, eq, inArray } from 'drizzle-orm';
 import { createSupportSessionSchema, formatSupportCode } from '@breeze/shared';
-import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
+import { db } from '../../db';
 import { devices, remoteSessions, supportSessions } from '../../db/schema';
 import { getOrCreateQuickSupportOrg } from '../../services/quickSupportOrg';
 import {
@@ -14,6 +14,8 @@ import {
 import { getTrustedClientIp } from '../../services/clientIp';
 import { endSupportSession } from '../../services/quickSupportEnd';
 import { logSessionAudit } from './helpers';
+import { createRemoteSession, RemoteSessionDeniedError } from '../../services/remoteSessionCreate';
+import { trustDenyBody } from '../../services/partnerTrust';
 
 export const supportSessionRoutes = new Hono();
 
@@ -83,10 +85,10 @@ supportSessionRoutes.post(
     const code = generateSupportCode();
     const now = Date.now();
 
-    // System context: when the hidden org was just created it is not in this
-    // request's accessible_org_ids yet, so the RLS INSERT policy would reject.
-    const [created] = await runOutsideDbContext(() => withSystemDbAccessContext(() =>
-      db.insert(supportSessions).values({
+    let created: SupportSessionRow;
+    try {
+      created = await createRemoteSession('support', {
+        partnerId: auth.partnerId,
         orgId,
         createdByUserId: auth.user.id,
         codeHash: hashSupportCode(code),
@@ -94,8 +96,18 @@ supportSessionRoutes.post(
         hardExpiresAt: new Date(now + SUPPORT_SESSION_HARD_CAP_HOURS * 3_600_000),
         attributedOrgId: data.attributedOrgId ?? null,
         attributionLabel: data.attributionLabel ?? null,
-      }).returning()
-    ));
+      });
+    } catch (e) {
+      if (e instanceof RemoteSessionDeniedError) {
+        return c.json(trustDenyBody({
+          allow: false,
+          code: e.code,
+          capability: 'remote_control',
+          reason: e.reason,
+        }, false), 403);
+      }
+      throw e;
+    }
 
     // RETURNING on a single-row INSERT always yields a row; narrow it so a
     // future refactor that makes the insert conditional fails loudly here

--- a/apps/api/src/routes/supportPublic.test.ts
+++ b/apps/api/src/routes/supportPublic.test.ts
@@ -684,6 +684,11 @@ describe('POST /redeem', () => {
   });
 
   it('never hands out the global AGENT_ENROLLMENT_SECRET', async () => {
+    // Precondition: mode 'off' (the module-level default from the outer
+    // beforeEach), so the trust gate short-circuits before ever resolving a
+    // partner id.
+    expect(partnerTrustMode()).toBe('off');
+
     process.env.AGENT_ENROLLMENT_SECRET = 'super-secret-global-value';
     const session = pendingSession();
     selectResults.push([session]);
@@ -692,6 +697,11 @@ describe('POST /redeem', () => {
 
     const body = await (await redeem()).json();
     expect(JSON.stringify(body)).not.toContain('super-secret-global-value');
+    // Under mode 'off' the trust gate must short-circuit entirely: no
+    // capability evaluation, and no extra select for the org's partner id —
+    // only the session lookup and the site lookup above.
+    expect(evaluateCapability).not.toHaveBeenCalled();
+    expect(selectBuilders).toHaveLength(2);
     delete process.env.AGENT_ENROLLMENT_SECRET;
   });
 
@@ -835,12 +845,22 @@ describe('GET /download/:platform', () => {
   });
 
   it('proxies the release asset rather than redirecting to it', async () => {
+    // Precondition: mode 'off' (the module-level default from the outer
+    // beforeEach), so the trust gate short-circuits before ever resolving a
+    // partner id.
+    expect(partnerTrustMode()).toBe('off');
+
     selectResults.push([{ status: 'pending', codeExpiresAt: FUTURE }]);
     const res = await download();
     // A 302 would hand the browser GitHub's filename and lose the code.
     expect(res.status).toBe(200);
     expect(getGithubAgentUrl).toHaveBeenCalledWith('windows', 'amd64');
     expect(fetchMock).toHaveBeenCalledWith('https://gh.test/breeze-agent-windows-amd64.exe');
+    // Under mode 'off' the trust gate must short-circuit entirely: no
+    // capability evaluation, and no second select for the org's partner id —
+    // only the one lookup-by-code select above.
+    expect(evaluateCapability).not.toHaveBeenCalled();
+    expect(selectBuilders).toHaveLength(1);
   });
 
   it('normalizes the human-formatted code into the filename', async () => {

--- a/apps/api/src/routes/supportPublic.test.ts
+++ b/apps/api/src/routes/supportPublic.test.ts
@@ -6,16 +6,27 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
  * TTL, and that failures are indistinguishable from one another.
  */
 
-const { rateLimiter, getRedis, logSessionAudit, getTrustedClientIp } = vi.hoisted(() => ({
+const {
+  rateLimiter,
+  getRedis,
+  logSessionAudit,
+  getTrustedClientIp,
+  evaluateCapability,
+  partnerTrustMode,
+} = vi.hoisted(() => ({
   rateLimiter: vi.fn(() => Promise.resolve({ allowed: true, currentCount: 1 })),
   getRedis: vi.fn(() => ({}) as unknown),
   logSessionAudit: vi.fn(() => Promise.resolve()),
   getTrustedClientIp: vi.fn(() => '203.0.113.9'),
+  evaluateCapability: vi.fn(async (_cap?: string, _ctx?: unknown): Promise<any> => ({ allow: true })),
+  partnerTrustMode: vi.fn((): 'off' | 'shadow' | 'enforce' => 'off'),
 }));
 
 vi.mock('../services/rate-limit', () => ({ rateLimiter }));
 vi.mock('../services/redis', () => ({ getRedis }));
 vi.mock('./remote/helpers', () => ({ logSessionAudit }));
+vi.mock('../services/partnerTrust', () => ({ evaluateCapability }));
+vi.mock('../config/partnerTrustMode', () => ({ partnerTrustMode }));
 // clientIp is mocked, but rateLimitIpKey is NOT stubbed to identity — the real
 // implementation is re-exported so the key-shape assertions below stay honest.
 vi.mock('../services/clientIp', async () => {
@@ -141,6 +152,7 @@ vi.mock('../db', () => {
 vi.mock('../db/schema', () => ({
   supportSessions: {
     id: 'supportSessions.id',
+    orgId: 'supportSessions.orgId',
     codeHash: 'supportSessions.codeHash',
     status: 'supportSessions.status',
     codeExpiresAt: 'supportSessions.codeExpiresAt',
@@ -241,6 +253,8 @@ beforeEach(() => {
   rateLimiter.mockResolvedValue({ allowed: true, currentCount: 1 });
   getTrustedClientIp.mockReturnValue('203.0.113.9');
   getBinarySource.mockReturnValue('github');
+  partnerTrustMode.mockReturnValue('off');
+  evaluateCapability.mockResolvedValue({ allow: true });
   getGithubAgentUrl.mockImplementation((os: string, arch: string) => `https://gh.test/breeze-agent-${os}-${arch}.exe`);
   isS3Configured.mockReturnValue(false);
   fetchMock.mockResolvedValue(new Response(new Uint8Array([0x4d, 0x5a, 0x90]), {
@@ -610,9 +624,37 @@ describe('two-tier miss budget', () => {
 });
 
 describe('POST /redeem', () => {
+  it('hides an installer-distribution trust denial behind 404 before claiming the code', async () => {
+    partnerTrustMode.mockReturnValue('enforce');
+    evaluateCapability.mockResolvedValueOnce({
+      allow: false,
+      code: 'TRUST_PROBATION',
+      capability: 'installer_distribute',
+      reason: 'probation_default_deny',
+    });
+    const session = pendingSession();
+    selectResults.push([session]);
+    selectResults.push([{ partnerId: 'partner-1' }]);
+
+    const res = await redeem();
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'invalid or expired code' });
+    expect(evaluateCapability).toHaveBeenCalledWith('installer_distribute', {
+      partnerId: 'partner-1',
+      orgId: 'qs-org',
+      detail: { route: 'code-redemption' },
+    });
+    expect(updateWhereCalled).toBe(0);
+    expect(insertedValues).toHaveLength(0);
+    expect(logSessionAudit).not.toHaveBeenCalled();
+  });
+
   it('claims the session and mints a single-use key with its own secret', async () => {
+    partnerTrustMode.mockReturnValue('enforce');
     const session = pendingSession();
     selectResults.push([session]); // code lookup
+    selectResults.push([{ partnerId: 'partner-1' }]); // trust lookup
     updateResults.push([{ ...session, status: 'claimed' }]); // atomic claim wins
     selectResults.push([{ id: 'site-1' }]); // site lookup
 
@@ -624,6 +666,11 @@ describe('POST /redeem', () => {
     expect(body.enrollmentSecret).toMatch(/^[0-9a-f]{64}$/);
     expect(body.serverUrl).toBe('https://us.2breeze.app');
     expect(body.sessionId).toBe(session.id);
+    expect(evaluateCapability).toHaveBeenCalledWith('installer_distribute', {
+      partnerId: 'partner-1',
+      orgId: 'qs-org',
+      detail: { route: 'code-redemption' },
+    });
 
     const key = insertedValues[0] as Record<string, unknown>;
     expect(key.maxUsage).toBe(1);
@@ -743,11 +790,41 @@ describe('GET /download/:platform', () => {
     return supportPublicRoutes.request(`/download/${platform}${query}`);
   }
 
+  it('hides an installer-distribution trust denial behind 404 before serving a binary', async () => {
+    partnerTrustMode.mockReturnValue('enforce');
+    evaluateCapability.mockResolvedValueOnce({
+      allow: false,
+      code: 'TRUST_PROBATION',
+      capability: 'installer_distribute',
+      reason: 'probation_default_deny',
+    });
+    selectResults.push([{ status: 'pending', codeExpiresAt: FUTURE, orgId: 'qs-org' }]);
+    selectResults.push([{ partnerId: 'partner-1' }]);
+
+    const res = await download();
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'invalid or expired code' });
+    expect(evaluateCapability).toHaveBeenCalledWith('installer_distribute', {
+      partnerId: 'partner-1',
+      orgId: 'qs-org',
+      detail: { route: 'public-download' },
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('serves the agent binary named after the code and API host', async () => {
-    selectResults.push([{ status: 'pending', codeExpiresAt: FUTURE }]);
+    partnerTrustMode.mockReturnValue('enforce');
+    selectResults.push([{ status: 'pending', codeExpiresAt: FUTURE, orgId: 'qs-org' }]);
+    selectResults.push([{ partnerId: 'partner-1' }]);
 
     const res = await download();
     expect(res.status).toBe(200);
+    expect(evaluateCapability).toHaveBeenCalledWith('installer_distribute', {
+      partnerId: 'partner-1',
+      orgId: 'qs-org',
+      detail: { route: 'public-download' },
+    });
     // Exact wire format — the Go client parses this filename (Task 12).
     expect(res.headers.get('Content-Disposition'))
       .toBe('attachment; filename="breeze-support-234567892-us.2breeze.app.exe"');

--- a/apps/api/src/routes/supportPublic.ts
+++ b/apps/api/src/routes/supportPublic.ts
@@ -26,6 +26,8 @@ import {
   recordSupportCodeMiss,
 } from '../services/supportCodeMissBudget';
 import { logSessionAudit } from './remote/helpers';
+import { evaluateCapability } from '../services/partnerTrust';
+import { partnerTrustMode } from '../config/partnerTrustMode';
 
 /**
  * Public Quick Support endpoints — the one-time code IS the authentication.
@@ -84,6 +86,27 @@ const CHILD_KEY_TTL_MS = 15 * 60_000;
  * The column is partner-writable; anything else is dropped rather than trusted.
  */
 const HEX_COLOR = /^#[0-9a-fA-F]{6}$/;
+
+async function anonymousInstallerDistributionAllowed(
+  orgId: string,
+  route: 'public-download' | 'code-redemption',
+): Promise<boolean> {
+  if (partnerTrustMode() === 'off') return true;
+
+  const [org] = await withSystemDbAccessContext(() => db
+    .select({ partnerId: organizations.partnerId })
+    .from(organizations)
+    .where(eq(organizations.id, orgId))
+    .limit(1));
+  if (!org?.partnerId) return false;
+
+  const decision = await evaluateCapability('installer_distribute', {
+    partnerId: org.partnerId,
+    orgId,
+    detail: { route },
+  });
+  return decision.allow;
+}
 
 /** Display-only branding for the end-user page — never IDs, never tenant keys. */
 type CheckBranding = {
@@ -348,13 +371,18 @@ supportPublicRoutes.get('/download/:platform', async (c) => {
     .select({
       status: supportSessions.status,
       codeExpiresAt: supportSessions.codeExpiresAt,
+      orgId: supportSessions.orgId,
     })
     .from(supportSessions)
     .where(eq(supportSessions.codeHash, hashSupportCode(code)))
-    .limit(1)) as Array<{ status: string; codeExpiresAt: Date }>;
+    .limit(1)) as Array<{ status: string; codeExpiresAt: Date; orgId: string }>;
 
   if (!row || row.status !== 'pending' || row.codeExpiresAt <= new Date()) {
     await recordSupportCodeMiss(redis, ip);
+    return c.json({ error: 'invalid or expired code' }, 404, DOWNLOAD_CACHE_HEADERS);
+  }
+
+  if (!await anonymousInstallerDistributionAllowed(row.orgId, 'public-download')) {
     return c.json({ error: 'invalid or expired code' }, 404, DOWNLOAD_CACHE_HEADERS);
   }
 
@@ -477,6 +505,10 @@ supportPublicRoutes.post('/redeem', zValidator('json', redeemSupportSessionSchem
       || row.codeExpiresAt < now
       || row.hardExpiresAt < now) {
       lookupMissed = true;
+      return null;
+    }
+
+    if (!await anonymousInstallerDistributionAllowed(row.orgId, 'code-redemption')) {
       return null;
     }
 

--- a/apps/api/src/routes/terminalWs.ts
+++ b/apps/api/src/routes/terminalWs.ts
@@ -35,6 +35,8 @@ import {
   type RemoteConnectionIdentity,
   type RemoteConnectionLease,
 } from '../services/remoteWsOwnership';
+import { partnerTrustMode } from '../config/partnerTrustMode';
+import { evaluateCapability, partnerIdForDevice } from '../services/partnerTrust';
 
 // Zod validation for terminal user messages
 const terminalMessageSchema = z.discriminatedUnion('type', [
@@ -596,6 +598,23 @@ function createTerminalWsHandlers(
           await releaseOpeningReservation();
           ws.close(4001, 'Invalid session data');
           return;
+        }
+
+        if (partnerTrustMode() !== 'off') {
+          const partnerId = await partnerIdForDevice(session.deviceId);
+          if (partnerId) {
+            const decision = await evaluateCapability('remote_control', {
+              partnerId,
+              deviceId: session.deviceId,
+              userId,
+              detail: { stage: 'ticket', kind: 'terminal' },
+            });
+            if (!decision.allow) {
+              await releaseOpeningReservation();
+              ws.close(4403, decision.code);
+              return;
+            }
+          }
         }
 
         // Check if agent is connected

--- a/apps/api/src/routes/terminalWs_utils_onopen.test.ts
+++ b/apps/api/src/routes/terminalWs_utils_onopen.test.ts
@@ -1,5 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+const {
+  partnerTrustModeMock,
+  partnerIdForDeviceMock,
+  evaluateCapabilityMock,
+} = vi.hoisted(() => ({
+  partnerTrustModeMock: vi.fn((): 'off' | 'shadow' | 'enforce' => 'off'),
+  partnerIdForDeviceMock: vi.fn(),
+  evaluateCapabilityMock: vi.fn(),
+}));
+
 // -------------------------------------------------------------------
 // Mocks — must be declared before any import that triggers the modules
 // -------------------------------------------------------------------
@@ -32,6 +42,15 @@ vi.mock('../db/schema', () => ({
 
 vi.mock('../services/remoteSessionAuth', () => ({
   consumeWsTicket: vi.fn()
+}));
+
+vi.mock('../config/partnerTrustMode', () => ({
+  partnerTrustMode: partnerTrustModeMock,
+}));
+
+vi.mock('../services/partnerTrust', () => ({
+  partnerIdForDevice: partnerIdForDeviceMock,
+  evaluateCapability: evaluateCapabilityMock,
 }));
 
 vi.mock('./agentWs', () => ({
@@ -72,6 +91,7 @@ vi.mock('./remote/helpers', () => ({
 // -------------------------------------------------------------------
 import { db } from '../db';
 import { consumeWsTicket } from '../services/remoteSessionAuth';
+import { evaluateCapability, partnerIdForDevice } from '../services/partnerTrust';
 import { sendCommandToAgent, isAgentConnected } from './agentWs';
 import {
   handleTerminalOutput,
@@ -225,6 +245,7 @@ describe('terminalWs', () => {
     // legitimately refuse replacement, so start each test from a clean map.
     __resetTerminalWsForTest();
     vi.clearAllMocks();
+    partnerTrustModeMock.mockReturnValue('off');
   });
 
   // ==========================================
@@ -503,6 +524,61 @@ describe('terminalWs', () => {
       expect(getActiveTerminalSession(SESSION_ID)).toBeDefined();
       expect(getActiveTerminalSessionCount()).toBeGreaterThanOrEqual(1);
       expect(getActiveTerminalSessionIds()).toContain(SESSION_ID);
+    });
+
+    it('refuses probation with close code 4403 before starting the terminal', async () => {
+      const { userId } = setupSuccessfulValidation();
+      partnerTrustModeMock.mockReturnValue('enforce');
+      vi.mocked(partnerIdForDevice).mockResolvedValue('partner-1');
+      vi.mocked(evaluateCapability).mockResolvedValue({
+        allow: false,
+        code: 'TRUST_PROBATION',
+        capability: 'remote_control',
+        reason: 'Partner is in trust probation',
+      });
+      const handlers = captureWsHandlers(SESSION_ID, 'probation-ticket');
+      const ws = wsMock();
+
+      await handlers.onOpen({}, ws);
+
+      expect(ws.close).toHaveBeenCalledWith(4403, 'TRUST_PROBATION');
+      expect(evaluateCapability).toHaveBeenCalledWith('remote_control', {
+        partnerId: 'partner-1',
+        deviceId: DEVICE_ID,
+        userId,
+        detail: { stage: 'ticket', kind: 'terminal' },
+      });
+      expect(sendCommandToAgent).not.toHaveBeenCalled();
+      expect(db.update).not.toHaveBeenCalled();
+      expect(getActiveTerminalSession(SESSION_ID)).toBeUndefined();
+    });
+
+    it('keeps trusted terminal upgrade behavior unchanged under enforce mode', async () => {
+      setupSuccessfulValidation();
+      partnerTrustModeMock.mockReturnValue('enforce');
+      vi.mocked(partnerIdForDevice).mockResolvedValue('partner-1');
+      vi.mocked(evaluateCapability).mockResolvedValue({ allow: true });
+      const handlers = captureWsHandlers(SESSION_ID, 'trusted-ticket');
+      const ws = wsMock();
+
+      await handlers.onOpen({}, ws);
+
+      expect(sendCommandToAgent).toHaveBeenCalledWith(
+        AGENT_ID,
+        expect.objectContaining({ type: 'terminal_start' }),
+      );
+      expect(ws.close).not.toHaveBeenCalledWith(4403, expect.anything());
+    });
+
+    it('does not resolve a partner when trust mode is off', async () => {
+      setupSuccessfulValidation();
+      const handlers = captureWsHandlers(SESSION_ID, 'mode-off-ticket');
+      const ws = wsMock();
+
+      await handlers.onOpen({}, ws);
+
+      expect(partnerIdForDevice).not.toHaveBeenCalled();
+      expect(sendCommandToAgent).toHaveBeenCalled();
     });
 
     it('sends AGENT_SEND_FAILED when sendCommandToAgent fails', async () => {

--- a/apps/api/src/routes/tunnels.test.ts
+++ b/apps/api/src/routes/tunnels.test.ts
@@ -17,6 +17,12 @@ const { rateLimiterMock } = vi.hoisted(() => ({
   })),
 }));
 
+const { evaluateCapability, partnerIdForDevice, partnerTrustMode } = vi.hoisted(() => ({
+  evaluateCapability: vi.fn(async (): Promise<any> => ({ allow: true })),
+  partnerIdForDevice: vi.fn(() => Promise.resolve('pppppppp-pppp-4ppp-8ppp-pppppppppppp')),
+  partnerTrustMode: vi.fn(() => 'off'),
+}));
+
 // --- DB mock ---
 vi.mock('../db', () => ({
   db: {
@@ -152,6 +158,19 @@ vi.mock('../services/redis', () => ({
 
 vi.mock('../services/rate-limit', () => ({
   rateLimiter: rateLimiterMock,
+}));
+
+vi.mock('../config/partnerTrustMode', () => ({ partnerTrustMode }));
+vi.mock('../services/partnerTrust', () => ({
+  evaluateCapability,
+  partnerIdForDevice,
+  trustDenyBody: (d: Record<string, unknown>, reviewRequested: boolean) => ({
+    error: d.code,
+    capability: d.capability,
+    reason: d.reason,
+    reviewRequested,
+    meetingUrl: null,
+  }),
 }));
 
 // Partial mock: only the IP SOURCE is stubbed. rateLimitIpKey (the IPv6 /64
@@ -331,6 +350,26 @@ describe('POST /tunnels (VNC)', () => {
     expect(body).toHaveProperty('id', SESSION_ID);
     expect(body).toHaveProperty('type', 'vnc');
     expect(body).toHaveProperty('status', 'pending');
+  });
+
+  it('maps partner-trust denial to a 403 without inserting a tunnel session', async () => {
+    partnerTrustMode.mockReturnValueOnce('enforce');
+    evaluateCapability.mockResolvedValueOnce({
+      allow: false,
+      code: 'TRUST_RESTRICTED',
+      capability: 'remote_control',
+      reason: 'restricted',
+    });
+
+    const res = await app.request('/tunnels', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ deviceId: DEVICE_ID, type: 'vnc' }),
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual(expect.objectContaining({ error: 'TRUST_RESTRICTED' }));
+    expect(db.insert).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/routes/tunnels.test.ts
+++ b/apps/api/src/routes/tunnels.test.ts
@@ -614,6 +614,36 @@ describe('POST /tunnels/proxy-connect', () => {
     expect(body.tunnel).toMatchObject({ type: 'proxy', targetHost: '10.0.5.20', targetPort: 8080 });
     expect(body).not.toHaveProperty('ticket');
   });
+
+  it('maps partner-trust denial to a 403 without creating a tunnel session (allowlist rule still created)', async () => {
+    partnerTrustMode.mockReturnValueOnce('enforce');
+    evaluateCapability.mockResolvedValueOnce({
+      allow: false,
+      code: 'TRUST_RESTRICTED',
+      capability: 'remote_control',
+      reason: 'restricted',
+    });
+
+    vi.mocked(db.select)
+      .mockReturnValueOnce(makeSelectChain([onlineDevice]) as any)
+      .mockReturnValueOnce(makeSelectChain([assetRow]) as any)
+      .mockReturnValueOnce(makeSelectChain([]) as any);
+
+    vi.mocked(db.insert)
+      .mockReturnValueOnce(makeInsertChain([newRule]) as any)
+      .mockReturnValueOnce(makeAuditAwareInsertChain([]) as any);
+
+    const res = await app.request('/tunnels/proxy-connect', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(requestBody),
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual(expect.objectContaining({ error: 'TRUST_RESTRICTED' }));
+    // Only the allowlist-create insert + its audit row happened — no session insert.
+    expect(db.insert).toHaveBeenCalledTimes(2);
+  });
 });
 
 // ─── Malformed params/query ───────────────────────────────────────────────────
@@ -1369,7 +1399,7 @@ describe('POST /vnc-viewer/upgrade-to-webrtc', () => {
     expect(db.insert).not.toHaveBeenCalled();
   });
 
-  it('fails descendant issuance before creating or changing a desktop session', async () => {
+  it('fails descendant issuance after the desktop session already exists (the token can only be bound to a real, service-generated id)', async () => {
     vi.mocked(verifyViewerAccessToken).mockResolvedValueOnce({
       sub: USER_ID,
       email: 'test@example.com',
@@ -1381,6 +1411,20 @@ describe('POST /vnc-viewer/upgrade-to-webrtc', () => {
       mfaSatisfied: true,
       assuranceAbsoluteExpiresAt: 2_000,
     });
+    vi.mocked(db.select).mockReturnValueOnce(makeJoinedSelectChain([{
+      tunnelUserId: USER_ID,
+      tunnelOrgId: ORG_ID,
+      deviceId: DEVICE_ID,
+      tunnelType: 'vnc',
+      tunnelStatus: 'pending',
+      deviceStatus: 'online',
+      agentId: 'agent-abc',
+      userEmail: 'test@example.com',
+    }]) as any);
+    vi.mocked(db.update).mockReturnValue({
+      set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+    } as any);
+    vi.mocked(db.insert).mockReturnValue(makeInsertChain([{ id: 'ffffffff-ffff-4fff-8fff-fffffffffff1' }]) as any);
     vi.mocked(createViewerDescendantAccessToken).mockRejectedValueOnce(
       new Error('Viewer token lineage has expired'),
     );
@@ -1391,11 +1435,63 @@ describe('POST /vnc-viewer/upgrade-to-webrtc', () => {
     });
 
     expect(res.status).toBe(401);
-    expect(db.select).not.toHaveBeenCalled();
-    expect(db.update).not.toHaveBeenCalled();
-    expect(db.insert).not.toHaveBeenCalled();
+    // Unlike the sibling transition routes, the session must already exist
+    // (createRemoteSession('remote', ...) generates its own id) before we
+    // can mint a descendant token bound to it — so select/update/insert DID
+    // run by the time issuance fails.
+    expect(db.select).toHaveBeenCalled();
+    expect(db.update).toHaveBeenCalled();
+    expect(db.insert).toHaveBeenCalled();
     expect(sendCommandToAgent).not.toHaveBeenCalled();
     expect(createWsTicket).not.toHaveBeenCalled();
+  });
+
+  it('maps partner-trust denial to a 403 without creating a desktop session', async () => {
+    partnerTrustMode.mockReturnValueOnce('enforce');
+    evaluateCapability.mockResolvedValueOnce({
+      allow: false,
+      code: 'TRUST_RESTRICTED',
+      capability: 'remote_control',
+      reason: 'restricted',
+    });
+    vi.mocked(verifyViewerAccessToken).mockResolvedValueOnce({
+      sub: USER_ID,
+      email: 'test@example.com',
+      sessionId: SESSION_ID,
+      purpose: 'viewer',
+      jti: 'viewer-jti-deny',
+      iat: 1_000,
+      exp: 2_000,
+      mfaSatisfied: true,
+      assuranceAbsoluteExpiresAt: 2_000,
+    });
+    vi.mocked(db.select).mockReturnValueOnce(makeJoinedSelectChain([{
+      tunnelUserId: USER_ID,
+      tunnelOrgId: ORG_ID,
+      deviceId: DEVICE_ID,
+      tunnelType: 'vnc',
+      tunnelStatus: 'pending',
+      deviceStatus: 'online',
+      agentId: 'agent-abc',
+      userEmail: 'test@example.com',
+    }]) as any);
+    vi.mocked(db.update).mockReturnValue({
+      set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+    } as any);
+
+    const res = await app.request('/vnc-viewer/upgrade-to-webrtc', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer viewer-token' },
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual(expect.objectContaining({ error: 'TRUST_RESTRICTED' }));
+    // The gate lives inside createRemoteSession('remote', ...), so the
+    // straggler-disconnect update (which precedes the service call) has
+    // already run — only the session insert and the token mint are blocked.
+    expect(db.insert).not.toHaveBeenCalled();
+    expect(createViewerDescendantAccessToken).not.toHaveBeenCalled();
+    expect(sendCommandToAgent).not.toHaveBeenCalled();
   });
 });
 
@@ -1459,6 +1555,48 @@ describe('POST /vnc-viewer/downgrade-to-vnc assurance', () => {
     expect(db.insert).not.toHaveBeenCalled();
     expect(sendCommandToAgent).not.toHaveBeenCalled();
     expect(createWsTicket).not.toHaveBeenCalled();
+  });
+
+  it('maps partner-trust denial to a 403 without creating a tunnel or sending an agent command', async () => {
+    vi.clearAllMocks();
+    const app = new Hono();
+    app.route('/vnc-viewer', vncViewerRoutes);
+    partnerTrustMode.mockReturnValueOnce('enforce');
+    evaluateCapability.mockResolvedValueOnce({
+      allow: false,
+      code: 'TRUST_RESTRICTED',
+      capability: 'remote_control',
+      reason: 'restricted',
+    });
+    vi.mocked(verifyViewerAccessToken).mockResolvedValueOnce({
+      sub: USER_ID,
+      email: 'test@example.com',
+      sessionId: SESSION_ID,
+      purpose: 'viewer',
+      jti: 'viewer-jti-deny',
+      iat: 1_000,
+      exp: 2_000,
+      mfaSatisfied: true,
+      assuranceAbsoluteExpiresAt: 2_000,
+    });
+    vi.mocked(db.select).mockReturnValueOnce(makeJoinedSelectChain([{
+      userId: USER_ID,
+      orgId: ORG_ID,
+      deviceId: DEVICE_ID,
+      deviceStatus: 'online',
+      agentId: 'agent-abc',
+      userEmail: 'test@example.com',
+    }]) as any);
+
+    const res = await app.request('/vnc-viewer/downgrade-to-vnc', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer viewer-token' },
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual(expect.objectContaining({ error: 'TRUST_RESTRICTED' }));
+    expect(db.insert).not.toHaveBeenCalled();
+    expect(sendCommandToAgent).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/routes/tunnels.test.ts
+++ b/apps/api/src/routes/tunnels.test.ts
@@ -1226,6 +1226,89 @@ describe('POST /tunnels/:id/connect-code', () => {
   });
 });
 
+describe.each([
+  {
+    routeName: 'ws-ticket',
+    path: `/tunnels/${SESSION_ID}/ws-ticket`,
+    minted: () => vi.mocked(createWsTicket),
+  },
+  {
+    routeName: 'http-ticket',
+    path: `/tunnels/${SESSION_ID}/http-ticket`,
+    minted: () => vi.mocked(createWsTicket),
+  },
+  {
+    routeName: 'connect-code',
+    path: `/tunnels/${SESSION_ID}/connect-code`,
+    minted: () => vi.mocked(createVncConnectCode),
+  },
+])('ticket-time partner trust re-check: $routeName', ({ path, minted }) => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = new Hono();
+    app.route('/tunnels', tunnelRoutes);
+    vi.mocked(db.select).mockReturnValueOnce(makeSelectChain([sessionRecord]) as any);
+    vi.mocked(db.insert).mockReturnValue(makeAuditAwareInsertChain([]) as any);
+  });
+
+  it('returns TRUST_PROBATION under enforce without minting a ticket or code', async () => {
+    partnerTrustMode.mockReturnValueOnce('enforce');
+    evaluateCapability.mockResolvedValueOnce({
+      allow: false,
+      code: 'TRUST_PROBATION',
+      capability: 'remote_control',
+      reason: 'probation_default_deny',
+    });
+
+    const res = await app.request(path, { method: 'POST' });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual(expect.objectContaining({
+      error: 'TRUST_PROBATION',
+      capability: 'remote_control',
+      reason: 'probation_default_deny',
+      reviewRequested: false,
+    }));
+    expect(partnerIdForDevice).toHaveBeenCalledWith(DEVICE_ID);
+    expect(evaluateCapability).toHaveBeenCalledWith('remote_control', {
+      partnerId: PARTNER_ID,
+      deviceId: DEVICE_ID,
+      userId: USER_ID,
+      detail: { stage: 'ticket', kind: 'tunnel' },
+    });
+    expect(minted()).not.toHaveBeenCalled();
+  });
+
+  it('keeps ticket or code issuance unchanged for a trusted partner', async () => {
+    partnerTrustMode.mockReturnValueOnce('enforce');
+    evaluateCapability.mockResolvedValueOnce({ allow: true });
+
+    const res = await app.request(path, { method: 'POST' });
+
+    expect(res.status).toBe(200);
+    expect(partnerIdForDevice).toHaveBeenCalledWith(DEVICE_ID);
+    expect(evaluateCapability).toHaveBeenCalledWith('remote_control', expect.objectContaining({
+      partnerId: PARTNER_ID,
+      deviceId: DEVICE_ID,
+      userId: USER_ID,
+    }));
+    expect(minted()).toHaveBeenCalledOnce();
+  });
+
+  it('does not resolve the partner or evaluate trust when mode is off', async () => {
+    partnerTrustMode.mockReturnValueOnce('off');
+
+    const res = await app.request(path, { method: 'POST' });
+
+    expect(res.status).toBe(200);
+    expect(partnerIdForDevice).not.toHaveBeenCalled();
+    expect(evaluateCapability).not.toHaveBeenCalled();
+    expect(minted()).toHaveBeenCalledOnce();
+  });
+});
+
 // ─── POST /vnc-exchange/:code ─────────────────────────────────────────────────
 
 describe('POST /vnc-exchange/:code', () => {

--- a/apps/api/src/routes/tunnels.test.ts
+++ b/apps/api/src/routes/tunnels.test.ts
@@ -1399,7 +1399,7 @@ describe('POST /vnc-viewer/upgrade-to-webrtc', () => {
     expect(db.insert).not.toHaveBeenCalled();
   });
 
-  it('fails descendant issuance after the desktop session already exists (the token can only be bound to a real, service-generated id)', async () => {
+  it('fails descendant issuance before creating or changing a desktop session', async () => {
     vi.mocked(verifyViewerAccessToken).mockResolvedValueOnce({
       sub: USER_ID,
       email: 'test@example.com',
@@ -1411,20 +1411,6 @@ describe('POST /vnc-viewer/upgrade-to-webrtc', () => {
       mfaSatisfied: true,
       assuranceAbsoluteExpiresAt: 2_000,
     });
-    vi.mocked(db.select).mockReturnValueOnce(makeJoinedSelectChain([{
-      tunnelUserId: USER_ID,
-      tunnelOrgId: ORG_ID,
-      deviceId: DEVICE_ID,
-      tunnelType: 'vnc',
-      tunnelStatus: 'pending',
-      deviceStatus: 'online',
-      agentId: 'agent-abc',
-      userEmail: 'test@example.com',
-    }]) as any);
-    vi.mocked(db.update).mockReturnValue({
-      set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
-    } as any);
-    vi.mocked(db.insert).mockReturnValue(makeInsertChain([{ id: 'ffffffff-ffff-4fff-8fff-fffffffffff1' }]) as any);
     vi.mocked(createViewerDescendantAccessToken).mockRejectedValueOnce(
       new Error('Viewer token lineage has expired'),
     );
@@ -1435,13 +1421,9 @@ describe('POST /vnc-viewer/upgrade-to-webrtc', () => {
     });
 
     expect(res.status).toBe(401);
-    // Unlike the sibling transition routes, the session must already exist
-    // (createRemoteSession('remote', ...) generates its own id) before we
-    // can mint a descendant token bound to it — so select/update/insert DID
-    // run by the time issuance fails.
-    expect(db.select).toHaveBeenCalled();
-    expect(db.update).toHaveBeenCalled();
-    expect(db.insert).toHaveBeenCalled();
+    expect(db.select).not.toHaveBeenCalled();
+    expect(db.update).not.toHaveBeenCalled();
+    expect(db.insert).not.toHaveBeenCalled();
     expect(sendCommandToAgent).not.toHaveBeenCalled();
     expect(createWsTicket).not.toHaveBeenCalled();
   });
@@ -1486,11 +1468,11 @@ describe('POST /vnc-viewer/upgrade-to-webrtc', () => {
 
     expect(res.status).toBe(403);
     expect(await res.json()).toEqual(expect.objectContaining({ error: 'TRUST_RESTRICTED' }));
-    // The gate lives inside createRemoteSession('remote', ...), so the
-    // straggler-disconnect update (which precedes the service call) has
-    // already run — only the session insert and the token mint are blocked.
+    // The descendant token is minted up front (bound to the pre-generated
+    // transitionSessionId, before any DB write) and the straggler-disconnect
+    // update (which precedes the gated service call) has already run — only
+    // the session insert is blocked by the gate inside createRemoteSession.
     expect(db.insert).not.toHaveBeenCalled();
-    expect(createViewerDescendantAccessToken).not.toHaveBeenCalled();
     expect(sendCommandToAgent).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/tunnels.ts
+++ b/apps/api/src/routes/tunnels.ts
@@ -26,7 +26,8 @@ import { isViewerJtiRevoked, isViewerSessionRevoked, revokeViewerSession } from 
 import type { AuthContext } from '../middleware/auth';
 import { canAccessSite, PERMISSIONS, type UserPermissions } from '../services/permissions';
 import { createRemoteSession, RemoteSessionDeniedError } from '../services/remoteSessionCreate';
-import { trustDenyBody } from '../services/partnerTrust';
+import { evaluateCapability, partnerIdForDevice, trustDenyBody } from '../services/partnerTrust';
+import { partnerTrustMode } from '../config/partnerTrustMode';
 
 export const tunnelRoutes = new Hono();
 
@@ -54,6 +55,28 @@ const PROXY_IDLE_EXPIRY_MS = 10 * 60 * 1000;
 // enforces it at ticket-mint time so a caller can't refresh past a dead
 // session with a fresh ticket.
 const HTTP_TUNNEL_MAX_SESSION_MS = HTTP_TUNNEL_MAX_SESSION_HOURS * 60 * 60 * 1000;
+
+async function tunnelTicketTrustDenyBody(deviceId: string, userId: string) {
+  if (partnerTrustMode() === 'off') return null;
+
+  const partnerId = await partnerIdForDevice(deviceId);
+  if (!partnerId) return null;
+
+  const decision = await evaluateCapability('remote_control', {
+    partnerId,
+    deviceId,
+    userId,
+    detail: { stage: 'ticket', kind: 'tunnel' },
+  });
+  if (decision.allow) return null;
+
+  return trustDenyBody({
+    allow: false,
+    code: decision.code,
+    capability: 'remote_control',
+    reason: decision.reason,
+  }, false);
+}
 
 const createTunnelSchema = z.discriminatedUnion('type', [
   z.object({ deviceId: z.string().guid(), type: z.literal('vnc') }),
@@ -1105,6 +1128,9 @@ tunnelRoutes.post(
       }, 400);
     }
 
+    const trustDenial = await tunnelTicketTrustDenyBody(session.deviceId, auth.user.id);
+    if (trustDenial) return c.json(trustDenial, 403);
+
     const ticket = await createWsTicket({
       sessionId: id,
       sessionType: 'tunnel',
@@ -1173,6 +1199,9 @@ tunnelRoutes.post(
       }, 400);
     }
 
+    const trustDenial = await tunnelTicketTrustDenyBody(session.deviceId, auth.user.id);
+    if (trustDenial) return c.json(trustDenial, 403);
+
     const ticket = await createWsTicket({
       sessionId: id,
       sessionType: 'tunnel-http',
@@ -1239,6 +1268,9 @@ tunnelRoutes.post(
         status: session.status,
       }, 400);
     }
+
+    const trustDenial = await tunnelTicketTrustDenyBody(session.deviceId, auth.user.id);
+    if (trustDenial) return c.json(trustDenial, 403);
 
     try {
       const result = await createVncConnectCode({

--- a/apps/api/src/routes/tunnels.ts
+++ b/apps/api/src/routes/tunnels.ts
@@ -25,6 +25,8 @@ import { rateLimiter } from '../services/rate-limit';
 import { isViewerJtiRevoked, isViewerSessionRevoked, revokeViewerSession } from '../services/viewerTokenRevocation';
 import type { AuthContext } from '../middleware/auth';
 import { canAccessSite, PERMISSIONS, type UserPermissions } from '../services/permissions';
+import { createRemoteSession, RemoteSessionDeniedError } from '../services/remoteSessionCreate';
+import { trustDenyBody } from '../services/partnerTrust';
 
 export const tunnelRoutes = new Hono();
 
@@ -387,9 +389,9 @@ tunnelRoutes.post(
     }
 
     // Create session record
-    const [session] = await db
-      .insert(tunnelSessions)
-      .values({
+    let session: typeof tunnelSessions.$inferSelect;
+    try {
+      session = await createRemoteSession('tunnel', {
         deviceId: device.id,
         userId: auth.user.id,
         orgId: device.orgId,
@@ -400,8 +402,13 @@ tunnelRoutes.post(
         scheme,
         skipTlsVerify,
         sourceIp: sourceIp,
-      })
-      .returning();
+      });
+    } catch (e) {
+      if (e instanceof RemoteSessionDeniedError) {
+        return c.json(trustDenyBody({ allow: false, code: e.code, capability: 'remote_control', reason: e.reason }, false), 403);
+      }
+      throw e;
+    }
 
     // Send tunnel_open command to agent — skipped for proxy tunnels. The raw
     // TCP socket it opens is unused on the HTTP-proxy path (tunnelHttp.ts
@@ -585,9 +592,9 @@ tunnelRoutes.post(
     // Create session record — same row shape as the proxy branch of
     // POST /tunnels. tunnel_open is never sent for type:'proxy' (see above):
     // the raw TCP socket it opens is unused on the HTTP-proxy path.
-    const [session] = await db
-      .insert(tunnelSessions)
-      .values({
+    let session: typeof tunnelSessions.$inferSelect;
+    try {
+      session = await createRemoteSession('tunnel', {
         deviceId: device.id,
         userId: auth.user.id,
         orgId: device.orgId,
@@ -598,8 +605,13 @@ tunnelRoutes.post(
         scheme: body.scheme,
         skipTlsVerify,
         sourceIp,
-      })
-      .returning();
+      });
+    } catch (e) {
+      if (e instanceof RemoteSessionDeniedError) {
+        return c.json(trustDenyBody({ allow: false, code: e.code, capability: 'remote_control', reason: e.reason }, false), 403);
+      }
+      throw e;
+    }
 
     await logTunnelAudit(
       'tunnel.open',
@@ -1611,23 +1623,24 @@ vncViewerRoutes.post('/downgrade-to-vnc', async (c) => {
   }
 
   // Insert the tunnel session row, then kick the agent off.
-  const tunnel = await withSystemDbAccessContext(async () => {
-    const [row] = await db
-      .insert(tunnelSessions)
-      .values({
-        id: transitionTunnelId,
-        deviceId: bound.deviceId,
-        userId: bound.userId,
-        orgId: bound.orgId,
-        type: 'vnc',
-        status: 'pending',
-        targetHost: '127.0.0.1',
-        targetPort: 5900,
-        sourceIp: getClientIp(c),
-      })
-      .returning();
-    return row;
+  const tunnel = await withSystemDbAccessContext(() => createRemoteSession('tunnel', {
+    id: transitionTunnelId,
+    deviceId: bound.deviceId,
+    userId: bound.userId,
+    orgId: bound.orgId,
+    type: 'vnc',
+    status: 'pending',
+    targetHost: '127.0.0.1',
+    targetPort: 5900,
+    sourceIp: getClientIp(c),
+  })).catch((e: unknown) => {
+    if (e instanceof RemoteSessionDeniedError) return e;
+    throw e;
   });
+
+  if (tunnel instanceof RemoteSessionDeniedError) {
+    return c.json(trustDenyBody({ allow: false, code: tunnel.code, capability: 'remote_control', reason: tunnel.reason }, false), 403);
+  }
 
   if (!tunnel) {
     return c.json({ error: 'Failed to create tunnel' }, 500);

--- a/apps/api/src/routes/tunnels.ts
+++ b/apps/api/src/routes/tunnels.ts
@@ -1471,12 +1471,11 @@ vncViewerRoutes.get('/desktop-access', async (c) => {
 // sessionId + token to drive the standard `/desktop-ws/:sessionId/viewer/*`
 // endpoints for ICE, offer, ws-ticket, etc.
 vncViewerRoutes.post('/upgrade-to-webrtc', async (c) => {
-  // The descendant viewer token is minted below, once the gated session
-  // create (createRemoteSession('remote', ...)) returns a real id — that
-  // service always lets Postgres generate the row's id, so unlike the other
-  // transition routes in this file we can no longer pre-compute the id and
-  // bind the token to it up front.
-  const auth = await requireViewerToken(c, { requireAssuredTransition: true });
+  const transitionSessionId = randomUUID();
+  const auth = await requireViewerToken(c, {
+    requireAssuredTransition: true,
+    descendantSessionId: transitionSessionId,
+  });
   if (auth instanceof Response) return auth;
 
   const bound = await withSystemDbAccessContext(async () => {
@@ -1536,6 +1535,7 @@ vncViewerRoutes.post('/upgrade-to-webrtc', async (c) => {
           )
         );
       return createRemoteSession('remote', {
+        id: transitionSessionId,
         deviceId: bound.deviceId,
         orgId: bound.tunnelOrgId,
         userId: bound.tunnelUserId,
@@ -1553,15 +1553,7 @@ vncViewerRoutes.post('/upgrade-to-webrtc', async (c) => {
     return c.json({ error: 'Failed to create desktop session' }, 500);
   }
 
-  // Minted here (not up front like the sibling transition routes) because the
-  // service above generates the session id — we can't bind a descendant token
-  // to it until it exists.
-  let accessToken: string;
-  try {
-    accessToken = await createViewerDescendantAccessToken(auth, { sessionId: session.id });
-  } catch {
-    return c.json({ error: 'Invalid or expired token' }, 401);
-  }
+  const accessToken = auth.descendantAccessToken!;
 
   // Viewer-token auth — no JWT actor. Attribute the upgrade to the tunnel-bound
   // owner (the user who opened the originating VNC tunnel) so the credential
@@ -1569,7 +1561,7 @@ vncViewerRoutes.post('/upgrade-to-webrtc', async (c) => {
   await logTunnelAudit(
     'tunnel.upgrade_webrtc',
     'tunnel_session',
-    session.id,
+    transitionSessionId,
     bound.tunnelUserId,
     bound.tunnelOrgId,
     { deviceId: bound.deviceId, type: 'desktop', fromTunnelId: auth.sessionId },
@@ -1577,7 +1569,7 @@ vncViewerRoutes.post('/upgrade-to-webrtc', async (c) => {
   );
 
   return c.json({
-    sessionId: session.id,
+    sessionId: transitionSessionId,
     accessToken,
     expiresInSeconds: getViewerAccessTokenExpirySeconds(),
   });

--- a/apps/api/src/routes/tunnels.ts
+++ b/apps/api/src/routes/tunnels.ts
@@ -1471,11 +1471,12 @@ vncViewerRoutes.get('/desktop-access', async (c) => {
 // sessionId + token to drive the standard `/desktop-ws/:sessionId/viewer/*`
 // endpoints for ICE, offer, ws-ticket, etc.
 vncViewerRoutes.post('/upgrade-to-webrtc', async (c) => {
-  const transitionSessionId = randomUUID();
-  const auth = await requireViewerToken(c, {
-    requireAssuredTransition: true,
-    descendantSessionId: transitionSessionId,
-  });
+  // The descendant viewer token is minted below, once the gated session
+  // create (createRemoteSession('remote', ...)) returns a real id — that
+  // service always lets Postgres generate the row's id, so unlike the other
+  // transition routes in this file we can no longer pre-compute the id and
+  // bind the token to it up front.
+  const auth = await requireViewerToken(c, { requireAssuredTransition: true });
   if (auth instanceof Response) return auth;
 
   const bound = await withSystemDbAccessContext(async () => {
@@ -1520,38 +1521,47 @@ vncViewerRoutes.post('/upgrade-to-webrtc', async (c) => {
   }
 
   // Reuse the same pattern as /sessions: terminate stragglers first, insert
-  // new pending row, return its id.
-  const session = await withSystemDbAccessContext(async () => {
-    await db
-      .update(remoteSessions)
-      .set({ status: 'disconnected', endedAt: new Date() })
-      .where(
-        and(
-          eq(remoteSessions.deviceId, bound.deviceId),
-          eq(remoteSessions.type, 'desktop'),
-          inArray(remoteSessions.status, ['pending', 'connecting', 'active'])
-        )
-      );
-    const [row] = await db
-      .insert(remoteSessions)
-      .values({
-        id: transitionSessionId,
+  // new pending row via the partner-trust-gated service, return its id.
+  let session: typeof remoteSessions.$inferSelect;
+  try {
+    session = await withSystemDbAccessContext(async () => {
+      await db
+        .update(remoteSessions)
+        .set({ status: 'disconnected', endedAt: new Date() })
+        .where(
+          and(
+            eq(remoteSessions.deviceId, bound.deviceId),
+            eq(remoteSessions.type, 'desktop'),
+            inArray(remoteSessions.status, ['pending', 'connecting', 'active'])
+          )
+        );
+      return createRemoteSession('remote', {
         deviceId: bound.deviceId,
         orgId: bound.tunnelOrgId,
         userId: bound.tunnelUserId,
         type: 'desktop',
-        status: 'pending',
-        iceCandidates: [],
-      })
-      .returning();
-    return row;
-  });
+      });
+    }) as typeof remoteSessions.$inferSelect;
+  } catch (e) {
+    if (e instanceof RemoteSessionDeniedError) {
+      return c.json(trustDenyBody({ allow: false, code: e.code, capability: 'remote_control', reason: e.reason }, false), 403);
+    }
+    throw e;
+  }
 
   if (!session) {
     return c.json({ error: 'Failed to create desktop session' }, 500);
   }
 
-  const accessToken = auth.descendantAccessToken!;
+  // Minted here (not up front like the sibling transition routes) because the
+  // service above generates the session id — we can't bind a descendant token
+  // to it until it exists.
+  let accessToken: string;
+  try {
+    accessToken = await createViewerDescendantAccessToken(auth, { sessionId: session.id });
+  } catch {
+    return c.json({ error: 'Invalid or expired token' }, 401);
+  }
 
   // Viewer-token auth — no JWT actor. Attribute the upgrade to the tunnel-bound
   // owner (the user who opened the originating VNC tunnel) so the credential
@@ -1559,7 +1569,7 @@ vncViewerRoutes.post('/upgrade-to-webrtc', async (c) => {
   await logTunnelAudit(
     'tunnel.upgrade_webrtc',
     'tunnel_session',
-    transitionSessionId,
+    session.id,
     bound.tunnelUserId,
     bound.tunnelOrgId,
     { deviceId: bound.deviceId, type: 'desktop', fromTunnelId: auth.sessionId },
@@ -1567,7 +1577,7 @@ vncViewerRoutes.post('/upgrade-to-webrtc', async (c) => {
   );
 
   return c.json({
-    sessionId: transitionSessionId,
+    sessionId: session.id,
     accessToken,
     expiresInSeconds: getViewerAccessTokenExpirySeconds(),
   });

--- a/apps/api/src/services/aiToolsRemote.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsRemote.siteScope.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+const remoteSessionCreateMocks = vi.hoisted(() => {
+  class RemoteSessionDeniedError extends Error {
+    readonly capability = 'remote_control' as const;
+    constructor(readonly code: 'TRUST_PROBATION' | 'TRUST_RESTRICTED', readonly reason: string) {
+      super(reason);
+    }
+  }
+  return { createRemoteSession: vi.fn(), RemoteSessionDeniedError };
+});
+
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn: any) => fn()),
   withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
@@ -10,6 +20,7 @@ vi.mock('./commandQueue', () => ({
   executeCommand: vi.fn(),
   queueCommandForExecution: vi.fn(),
 }));
+vi.mock('./remoteSessionCreate', () => remoteSessionCreateMocks);
 
 import { PgDialect } from 'drizzle-orm/pg-core';
 import type { SQL } from 'drizzle-orm';
@@ -177,5 +188,38 @@ describe('list_remote_sessions — per-user ownership', () => {
     expect(resolveSiteCalled).toBe(false);
     // No userId filter for system scope.
     expect(renderWhere(captured).params).not.toContain('u1');
+  });
+});
+
+describe('create_remote_session — partner trust', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns the stable tool error when remote control is denied', async () => {
+    mockDb.select.mockReturnValueOnce({
+      from: () => ({
+        where: () => ({
+          limit: () => Promise.resolve([{
+            id: 'device-1',
+            orgId: 'org-1',
+            siteId: 'site-A',
+            hostname: 'host-1',
+            status: 'online',
+          }]),
+        }),
+      }),
+    });
+    remoteSessionCreateMocks.createRemoteSession.mockRejectedValueOnce(
+      new remoteSessionCreateMocks.RemoteSessionDeniedError('TRUST_PROBATION', 'probation_default_deny'),
+    );
+
+    const result = await handlerFor('create_remote_session')(
+      { deviceId: 'device-1', type: 'terminal' },
+      makeAuth(),
+    );
+
+    expect(JSON.parse(result)).toEqual({
+      error: 'TRUST_PROBATION',
+      message: 'Remote control is not available until this account is verified.',
+    });
   });
 });

--- a/apps/api/src/services/aiToolsRemote.ts
+++ b/apps/api/src/services/aiToolsRemote.ts
@@ -21,6 +21,7 @@ import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { resolveSiteAllowedDeviceIds, SITE_SCOPE_EMPTY_NOTE } from './aiToolsSiteScope';
 import { getToolTimeout } from './toolTimeouts';
+import { createRemoteSession, RemoteSessionDeniedError } from './remoteSessionCreate';
 
 type AiToolTier = 1 | 2 | 3 | 4;
 
@@ -381,20 +382,27 @@ export function registerRemoteTools(aiTools: Map<string, AiTool>): void {
       if ('error' in access) return JSON.stringify({ error: access.error });
 
       // Insert new remote session
-      const [session] = await db
-        .insert(remoteSessions)
-        .values({
+      let session: { id: string; status: string };
+      try {
+        session = await createRemoteSession('remote', {
           deviceId,
           orgId: access.device.orgId,
           userId: auth.user.id,
           type: sessionType as 'terminal' | 'file_transfer',
-          status: 'pending',
-        })
-        .returning({ id: remoteSessions.id, status: remoteSessions.status });
+        });
+      } catch (e) {
+        if (e instanceof RemoteSessionDeniedError) {
+          return JSON.stringify({
+            error: e.code,
+            message: 'Remote control is not available until this account is verified.',
+          });
+        }
+        throw e;
+      }
 
       return JSON.stringify({
-        id: session!.id,
-        status: session!.status,
+        id: session.id,
+        status: session.status,
         deviceId,
         type: sessionType,
       });

--- a/apps/api/src/services/partnerTrust.test.ts
+++ b/apps/api/src/services/partnerTrust.test.ts
@@ -236,6 +236,7 @@ describe('evaluateCapability', () => {
         probationEnrollments: 5,
         stage: 'dispatch',
         via: 'api',
+        route: 'GET /enrollment-keys/:id/installer/:platform',
         untrustedExtra: 'must-not-leak',
       },
     });
@@ -251,6 +252,7 @@ describe('evaluateCapability', () => {
         probationEnrollments: 5,
         stage: 'dispatch',
         via: 'api',
+        route: 'GET /enrollment-keys/:id/installer/:platform',
       },
     }));
   });

--- a/apps/api/src/services/partnerTrust.ts
+++ b/apps/api/src/services/partnerTrust.ts
@@ -249,6 +249,7 @@ export async function evaluateCapability(cap: GatedCapability, ctx: GateContext)
         : null,
       stage: typeof ctx.detail?.stage === 'string' ? ctx.detail.stage : null,
       via: typeof ctx.detail?.via === 'string' ? ctx.detail.via : null,
+      route: typeof ctx.detail?.route === 'string' ? ctx.detail.route : null,
     },
   });
   if (mode === 'shadow') return { allow: true, shadowDenied: denial };

--- a/apps/api/src/services/remoteSessionCreate.test.ts
+++ b/apps/api/src/services/remoteSessionCreate.test.ts
@@ -125,6 +125,12 @@ describe.each([
   });
 });
 
+it('uses a caller-supplied id for a remote session when provided', async () => {
+  const { values } = insertReturning({ id: 'caller-supplied-id', status: 'pending' });
+  await createRemoteSession('remote', { ...remoteInput, id: 'caller-supplied-id' });
+  expect(values).toHaveBeenCalledWith(expect.objectContaining({ id: 'caller-supplied-id' }));
+});
+
 it('passes tunnel values through verbatim', async () => {
   const { values } = insertReturning({ id: 'tunnel-1', status: 'pending' });
   await createRemoteSession('tunnel', tunnelInput);

--- a/apps/api/src/services/remoteSessionCreate.test.ts
+++ b/apps/api/src/services/remoteSessionCreate.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  evaluateCapability: vi.fn(),
+  partnerIdForDevice: vi.fn(),
+  partnerTrustMode: vi.fn(),
+  insert: vi.fn(),
+  runOutsideDbContext: vi.fn(<T>(fn: () => T): T => fn()),
+  withSystemDbAccessContext: vi.fn(async <T>(fn: () => Promise<T>): Promise<T> => fn()),
+}));
+
+vi.mock('./partnerTrust', () => ({
+  evaluateCapability: mocks.evaluateCapability,
+  partnerIdForDevice: mocks.partnerIdForDevice,
+}));
+vi.mock('../config/partnerTrustMode', () => ({ partnerTrustMode: mocks.partnerTrustMode }));
+vi.mock('../db', () => ({
+  db: { insert: mocks.insert },
+  runOutsideDbContext: mocks.runOutsideDbContext,
+  withSystemDbAccessContext: mocks.withSystemDbAccessContext,
+}));
+vi.mock('../db/schema', () => ({
+  remoteSessions: { table: 'remote' },
+  supportSessions: { table: 'support' },
+  tunnelSessions: { table: 'tunnel' },
+}));
+
+import { createRemoteSession, RemoteSessionDeniedError } from './remoteSessionCreate';
+
+const remoteInput = {
+  deviceId: 'device-1',
+  orgId: 'org-1',
+  userId: 'user-1',
+  type: 'desktop' as const,
+};
+const supportInput = {
+  partnerId: 'partner-1',
+  orgId: 'org-1',
+  createdByUserId: 'user-1',
+  codeHash: 'hash',
+  codeExpiresAt: new Date('2026-09-02T12:00:00Z'),
+  hardExpiresAt: new Date('2026-09-02T18:00:00Z'),
+};
+const tunnelInput = {
+  deviceId: 'device-1',
+  orgId: 'org-1',
+  userId: 'user-1',
+  type: 'vnc' as const,
+  status: 'pending' as const,
+  targetHost: '127.0.0.1',
+  targetPort: 5900,
+};
+
+function insertReturning(row: unknown) {
+  const returning = vi.fn().mockResolvedValue([row]);
+  const values = vi.fn().mockReturnValue({ returning });
+  mocks.insert.mockReturnValue({ values });
+  return { values, returning };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.partnerTrustMode.mockReturnValue('enforce');
+  mocks.partnerIdForDevice.mockResolvedValue('partner-1');
+  mocks.evaluateCapability.mockResolvedValue({ allow: true });
+});
+
+describe.each([
+  ['remote', remoteInput],
+  ['support', supportInput],
+  ['tunnel', tunnelInput],
+] as const)('createRemoteSession(%s)', (kind, input) => {
+  it('throws on deny and does not insert', async () => {
+    mocks.evaluateCapability.mockResolvedValue({
+      allow: false,
+      code: 'TRUST_PROBATION',
+      capability: 'remote_control',
+      reason: 'probation_default_deny',
+    });
+
+    await expect(createRemoteSession(kind as never, input as never)).rejects.toMatchObject({
+      code: 'TRUST_PROBATION',
+      reason: 'probation_default_deny',
+      capability: 'remote_control',
+    } satisfies Partial<RemoteSessionDeniedError>);
+    expect(mocks.insert).not.toHaveBeenCalled();
+  });
+
+  it('returns the inserted row when allowed', async () => {
+    const row = { id: `${kind}-1`, status: 'pending' };
+    insertReturning(row);
+    await expect(createRemoteSession(kind as never, input as never)).resolves.toBe(row);
+    expect(mocks.evaluateCapability).toHaveBeenCalledWith('remote_control', {
+      partnerId: 'partner-1',
+      deviceId: kind === 'support' ? undefined : 'device-1',
+      userId: 'user-1',
+      detail: { kind },
+    });
+    if (kind === 'support') {
+      expect(mocks.partnerIdForDevice).not.toHaveBeenCalled();
+    } else {
+      expect(mocks.partnerIdForDevice).toHaveBeenCalledWith('device-1');
+    }
+  });
+
+  it('inserts and returns in shadow mode', async () => {
+    mocks.partnerTrustMode.mockReturnValue('shadow');
+    mocks.evaluateCapability.mockResolvedValue({
+      allow: true,
+      shadowDenied: { code: 'TRUST_PROBATION', reason: 'probation_default_deny' },
+    });
+    const row = { id: `${kind}-shadow`, status: 'pending' };
+    insertReturning(row);
+    await expect(createRemoteSession(kind as never, input as never)).resolves.toBe(row);
+    expect(mocks.insert).toHaveBeenCalledOnce();
+  });
+
+  it('skips partner lookup and evaluation when mode is off', async () => {
+    mocks.partnerTrustMode.mockReturnValue('off');
+    const row = { id: `${kind}-off`, status: 'pending' };
+    insertReturning(row);
+    await expect(createRemoteSession(kind as never, input as never)).resolves.toBe(row);
+    expect(mocks.partnerIdForDevice).not.toHaveBeenCalled();
+    expect(mocks.evaluateCapability).not.toHaveBeenCalled();
+  });
+});
+
+it('passes tunnel values through verbatim', async () => {
+  const { values } = insertReturning({ id: 'tunnel-1', status: 'pending' });
+  await createRemoteSession('tunnel', tunnelInput);
+  expect(values).toHaveBeenCalledWith(tunnelInput);
+});
+
+it('keeps support inserts in the escaped system DB context and strips partnerId', async () => {
+  const { values } = insertReturning({ id: 'support-1', status: 'pending' });
+  await createRemoteSession('support', supportInput);
+  expect(mocks.runOutsideDbContext).toHaveBeenCalledOnce();
+  expect(mocks.withSystemDbAccessContext).toHaveBeenCalledOnce();
+  expect(values).toHaveBeenCalledWith(expect.not.objectContaining({ partnerId: expect.anything() }));
+});

--- a/apps/api/src/services/remoteSessionCreate.ts
+++ b/apps/api/src/services/remoteSessionCreate.ts
@@ -1,0 +1,100 @@
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { remoteSessions, supportSessions, tunnelSessions } from '../db/schema';
+import { partnerTrustMode } from '../config/partnerTrustMode';
+import {
+  evaluateCapability,
+  partnerIdForDevice,
+  type TrustDenyCode,
+} from './partnerTrust';
+
+export type SessionKind = 'remote' | 'support' | 'tunnel';
+export type SupportSessionInsert = typeof supportSessions.$inferInsert;
+export type SupportSessionRow = typeof supportSessions.$inferSelect;
+export type TunnelSessionInsert = typeof tunnelSessions.$inferInsert;
+export type TunnelSessionRow = typeof tunnelSessions.$inferSelect;
+
+type RemoteSessionInput = {
+  deviceId: string;
+  orgId: string;
+  userId: string;
+  type: 'desktop' | 'terminal' | 'file_transfer';
+};
+
+export class RemoteSessionDeniedError extends Error {
+  readonly capability = 'remote_control' as const;
+
+  constructor(
+    readonly code: TrustDenyCode,
+    readonly reason: string,
+  ) {
+    super(`Partner trust ${code}: remote control denied (${reason})`);
+    this.name = 'RemoteSessionDeniedError';
+  }
+}
+
+export async function createRemoteSession(
+  kind: 'remote',
+  input: RemoteSessionInput,
+): Promise<{ id: string; status: string }>;
+export async function createRemoteSession(
+  kind: 'support',
+  input: SupportSessionInsert & { partnerId: string },
+): Promise<SupportSessionRow>;
+export async function createRemoteSession(
+  kind: 'tunnel',
+  input: TunnelSessionInsert,
+): Promise<TunnelSessionRow>;
+export async function createRemoteSession(
+  kind: SessionKind,
+  input: RemoteSessionInput | (SupportSessionInsert & { partnerId: string }) | TunnelSessionInsert,
+): Promise<{ id: string; status: string } | SupportSessionRow | TunnelSessionRow> {
+  if (partnerTrustMode() !== 'off') {
+    const partnerId = kind === 'support'
+      ? (input as SupportSessionInsert & { partnerId: string }).partnerId
+      : await partnerIdForDevice((input as RemoteSessionInput | TunnelSessionInsert).deviceId);
+
+    if (partnerId) {
+      const decision = await evaluateCapability('remote_control', {
+        partnerId,
+        deviceId: kind === 'support' ? undefined : (input as RemoteSessionInput | TunnelSessionInsert).deviceId,
+        userId: kind === 'support'
+          ? (input as SupportSessionInsert & { partnerId: string }).createdByUserId
+          : (input as RemoteSessionInput | TunnelSessionInsert).userId,
+        detail: { kind },
+      });
+      if (!decision.allow) {
+        throw new RemoteSessionDeniedError(decision.code, decision.reason);
+      }
+    }
+  }
+
+  if (kind === 'remote') {
+    const remote = input as RemoteSessionInput;
+    const [created] = await db
+      .insert(remoteSessions)
+      .values({
+        deviceId: remote.deviceId,
+        orgId: remote.orgId,
+        userId: remote.userId,
+        type: remote.type,
+        status: 'pending',
+        iceCandidates: [],
+      })
+      .returning();
+    return created!;
+  }
+
+  if (kind === 'support') {
+    const { partnerId: _partnerId, ...values } = input as SupportSessionInsert & { partnerId: string };
+    const [created] = await runOutsideDbContext(() => withSystemDbAccessContext(() =>
+      db.insert(supportSessions).values(values).returning()
+    ));
+    return created!;
+  }
+
+  const [created] = await db
+    .insert(tunnelSessions)
+    .values(input as TunnelSessionInsert)
+    .returning();
+  return created!;
+}

--- a/apps/api/src/services/remoteSessionCreate.ts
+++ b/apps/api/src/services/remoteSessionCreate.ts
@@ -14,6 +14,7 @@ export type TunnelSessionInsert = typeof tunnelSessions.$inferInsert;
 export type TunnelSessionRow = typeof tunnelSessions.$inferSelect;
 
 type RemoteSessionInput = {
+  id?: string;
   deviceId: string;
   orgId: string;
   userId: string;
@@ -73,6 +74,7 @@ export async function createRemoteSession(
     const [created] = await db
       .insert(remoteSessions)
       .values({
+        ...(remote.id ? { id: remote.id } : {}),
         deviceId: remote.deviceId,
         orgId: remote.orgId,
         userId: remote.userId,


### PR DESCRIPTION
## Summary
Wave 4 of **Partner Trust Probation** (#4549). Stacked on W03 (#4588); retargets automatically as parents merge. With W03 this closes every remote-control, execution, and installer-distribution path for a probation/restricted partner under `enforce`; under `off` (all self-hosted installs) no code path here performs even a database read.

- **`services/remoteSessionCreate.ts`** — the single place that inserts `remote_sessions`, `support_sessions`, and `tunnel_sessions` (a grep test pins that no other insert exists). Gated on `remote_control`; accepts a caller-supplied id so the VNC→WebRTC upgrade keeps its token-before-DB ordering. Review caught one raw insert the plan missed (`tunnels.ts` upgrade path).
- **Ticket-time re-check** — desktop connect exchange, terminal WS upgrade (close `4403` before any `terminal_start`), and the three tunnel ticket/connect-code routes re-evaluate trust at issuance, so revoking promotion ends a session at its next ticket.
- **Installer distribution** — installer links, bootstrap and onboarding tokens gated (`installer_distribute`); the anonymous public download, short-link, Quick Support download and code redemption evaluate trust and answer a plain 404 on deny. The console's own-device installer download (`GET /:id/installer/:platform`) is deliberately **not** gated (review caught the initial over-gating that would have stranded every trial).
- **Third-party remote launch** gated (`remote_control`).
- **Enrollment counter** — `partners.probation_enrollments` read `FOR UPDATE` and incremented inside the enrollment transaction; never decremented. Integration test on real Postgres: 5 of 8 concurrent enrollments admitted, counter 5, deleting devices does not recycle quota, 9th enroll denied with the deny-body contract. (Also fixed a latent double-encoding of the pre-existing device-limit 403.)
- Audit rows for anonymous denies now record `route`.

## Test plan
- [x] Full API unit suite: 1770 files pass; only the 4 `contractRenewal*.integration` cases fail, and only because a local `DATABASE_URL` makes them run (skipped in CI)
- [x] `partnerTrustEnrollment.integration.test.ts` green on a fresh Postgres
- [x] `pnpm --filter @breeze/api lint` clean; `pnpm exec tsc --noEmit --project apps/api/tsconfig.json` clean (CI's exact invocation)
- [x] Every task reviewed by a fresh Sonnet reviewer with scoped re-reviews after each fix round

Closes #4553

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FAXi39eBUAUyw5j61AFFxh