### PR TITLE
feat(trust): probation banner, review request, admin action page (W06, #4549)

### DIFF
--- a/apps/web/src/components/admin/TrustActionPage.test.tsx
+++ b/apps/web/src/components/admin/TrustActionPage.test.tsx
@@ -1,0 +1,157 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fetchWithAuth = vi.fn();
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: (...args: unknown[]) => fetchWithAuth(...args),
+}));
+
+const showToast = vi.fn();
+vi.mock('../shared/Toast', () => ({
+  showToast: (...args: unknown[]) => showToast(...args),
+}));
+
+// Exercise the real runAction wrapper; the submit assertion and the AST guard
+// together prevent this high-impact mutation from becoming a bare fetch.
+import TrustActionPage from './TrustActionPage';
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: vi.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
+
+const preview = {
+  valid: true as const,
+  action: 'approve' as const,
+  partner: {
+    id: 'partner-1',
+    name: 'Acme MSP',
+    slug: 'acme-msp',
+    plan: 'professional',
+    trustState: 'probation',
+  },
+  card: {
+    partner: {
+      id: 'partner-1',
+      name: 'Acme MSP',
+      slug: 'acme-msp',
+      plan: 'professional',
+      status: 'active',
+      trustState: 'probation',
+    },
+    signup: { ip: '203.0.113.10', ipClass: 'datacenter', asn: 64500 },
+    emailDomain: { domain: 'acme.example', ageDays: null, hasMx: true },
+    identity: {
+      userName: 'Alex Admin',
+      userEmail: 'alex@acme.example',
+      cardholderName: 'Alice Buyer',
+      namesMatch: false,
+    },
+    billing: { distinctPaymentMethods: 3, failedAttempts: 2, region: 'US-CO' },
+    devices: [{
+      hostname: 'ACME-LAPTOP',
+      enrollmentIpClass: 'residential',
+      isVirtual: false,
+      enrollmentIp: '198.51.100.2',
+    }],
+    denials24h: 4,
+    matchedSuspendedAxes: ['email_domain' as const, 'billing_card_fingerprint' as const],
+  },
+};
+
+beforeEach(() => {
+  window.history.replaceState({}, '', '/admin/trust/act?token=signed-token');
+  fetchWithAuth.mockReset();
+  showToast.mockReset();
+});
+
+describe('TrustActionPage', () => {
+  it('renders the requested action and evidence-card summary', async () => {
+    fetchWithAuth.mockResolvedValue(jsonResponse(preview));
+
+    render(<TrustActionPage />);
+
+    expect(await screen.findByRole('heading', { name: 'Approve partner' })).toBeTruthy();
+    expect(screen.getByText('Acme MSP (acme-msp)')).toBeTruthy();
+    expect(screen.getByText('professional')).toBeTruthy();
+    expect(screen.getByText('probation')).toBeTruthy();
+    expect(screen.getByText('datacenter')).toBeTruthy();
+    expect(screen.getByText('64500')).toBeTruthy();
+    expect(screen.getByText('Alex Admin')).toBeTruthy();
+    expect(screen.getByText('Alice Buyer')).toBeTruthy();
+    expect(screen.getByText('ACME-LAPTOP')).toBeTruthy();
+    expect(screen.getByText('residential')).toBeTruthy();
+    expect(screen.getByText('Email domain, Billing card fingerprint')).toBeTruthy();
+    expect(fetchWithAuth).toHaveBeenCalledWith('/admin/trust/act/preview?token=signed-token');
+  });
+
+  it('submits the TOTP through runAction and shows the resulting trust state', async () => {
+    fetchWithAuth.mockImplementation((url: string, options?: RequestInit) => {
+      if (url === '/admin/trust/act/preview?token=signed-token') {
+        return Promise.resolve(jsonResponse(preview));
+      }
+      if (url === '/admin/trust/act' && options?.method === 'POST') {
+        return Promise.resolve(jsonResponse({ success: true, partnerId: 'partner-1', trustState: 'trusted' }));
+      }
+      throw new Error(`Unexpected request: ${options?.method ?? 'GET'} ${url}`);
+    });
+    render(<TrustActionPage />);
+    await screen.findByRole('heading', { name: 'Approve partner' });
+
+    fireEvent.change(screen.getByLabelText('Six-digit TOTP code'), { target: { value: '123456' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Approve partner' }));
+
+    const success = await screen.findByTestId('trust-action-success');
+    expect(success.textContent).toContain('trusted');
+    const mutation = fetchWithAuth.mock.calls.find(([url]) => url === '/admin/trust/act');
+    expect(mutation).toBeTruthy();
+    expect(mutation![1]).toMatchObject({
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+    expect(JSON.parse((mutation![1] as RequestInit).body as string)).toEqual({
+      token: 'signed-token',
+      totp: '123456',
+    });
+    expect(showToast).toHaveBeenCalledWith({ message: 'Trust action completed', type: 'success' });
+  });
+
+  it.each([
+    ['expired', 'This link has expired'],
+    ['used', 'This link was already used'],
+    ['operator_mismatch', 'This link was issued to a different operator'],
+    ['bad_signature', 'This link is not valid'],
+  ] as const)('shows plain copy for an invalid %s token', async (reason, copy) => {
+    fetchWithAuth.mockResolvedValue(jsonResponse({ valid: false, reason }));
+
+    render(<TrustActionPage />);
+
+    expect(await screen.findByText(copy)).toBeTruthy();
+    expect(screen.queryByLabelText('Six-digit TOTP code')).toBeNull();
+  });
+
+  it('asks the operator to sign in when preview returns 401', async () => {
+    fetchWithAuth.mockResolvedValue(jsonResponse({ error: 'Unauthorized' }, 401));
+
+    render(<TrustActionPage />);
+
+    expect(await screen.findByText('Sign in as a platform admin to continue')).toBeTruthy();
+  });
+
+  it('labels a suspend action and accepts the suspension success body', async () => {
+    fetchWithAuth.mockImplementation((url: string, options?: RequestInit) => {
+      if (!options) return Promise.resolve(jsonResponse({ ...preview, action: 'suspend' }));
+      return Promise.resolve(jsonResponse({ partnerId: 'partner-1', status: 'suspended' }));
+    });
+    render(<TrustActionPage />);
+    await screen.findByRole('heading', { name: 'Suspend partner' });
+
+    fireEvent.change(screen.getByLabelText('Six-digit TOTP code'), { target: { value: '654321' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Suspend partner' }));
+
+    await waitFor(() => expect(screen.getByTestId('trust-action-success').textContent).toContain('suspended'));
+  });
+});

--- a/apps/web/src/components/admin/TrustActionPage.tsx
+++ b/apps/web/src/components/admin/TrustActionPage.tsx
@@ -1,0 +1,231 @@
+import { useEffect, useState, type FormEvent } from 'react';
+import { fetchWithAuth } from '../../stores/auth';
+import { ActionError, runAction } from '../../lib/runAction';
+
+type InvalidReason = 'bad_signature' | 'expired' | 'used' | 'operator_mismatch';
+type TrustAction = 'approve' | 'suspend';
+
+interface EvidenceCard {
+  partner: {
+    id: string;
+    name: string;
+    slug: string;
+    plan: string;
+    status: string;
+    trustState: string;
+  };
+  signup: { ip: string | null; ipClass: string; asn: number | null };
+  identity: {
+    userName: string | null;
+    userEmail: string | null;
+    cardholderName: string | null;
+    namesMatch: boolean | null;
+  };
+  billing: {
+    distinctPaymentMethods: number;
+    failedAttempts: number;
+    region: string | null;
+  };
+  devices: Array<{
+    hostname: string;
+    enrollmentIpClass: string;
+    isVirtual: boolean;
+    enrollmentIp: string | null;
+  }>;
+  denials24h: number;
+  matchedSuspendedAxes: Array<'email_domain' | 'billing_card_fingerprint'>;
+}
+
+type ValidPreview = {
+  valid: true;
+  action: TrustAction;
+  partner: { id: string; name: string; slug: string; plan: string; trustState: string };
+  card: EvidenceCard;
+};
+
+type PageState =
+  | { kind: 'loading' }
+  | { kind: 'unauthorized' }
+  | { kind: 'invalid'; reason: InvalidReason }
+  | { kind: 'error' }
+  | { kind: 'ready'; preview: ValidPreview }
+  | { kind: 'success'; trustState: string };
+
+const invalidReasonCopy: Record<InvalidReason, string> = {
+  expired: 'This link has expired',
+  used: 'This link was already used',
+  operator_mismatch: 'This link was issued to a different operator',
+  bad_signature: 'This link is not valid',
+};
+
+const displayValue = (value: string | number | null) => value ?? 'Not available';
+const displayBoolean = (value: boolean | null) => value === null ? 'Not available' : value ? 'Yes' : 'No';
+const displayAxis = (axis: EvidenceCard['matchedSuspendedAxes'][number]) =>
+  axis === 'email_domain' ? 'Email domain' : 'Billing card fingerprint';
+
+export default function TrustActionPage() {
+  const [state, setState] = useState<PageState>({ kind: 'loading' });
+  const [token, setToken] = useState('');
+  const [totp, setTotp] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    const queryToken = new URLSearchParams(window.location.search).get('token') ?? '';
+    setToken(queryToken);
+    let active = true;
+
+    void (async () => {
+      try {
+        const response = await fetchWithAuth(
+          `/admin/trust/act/preview?token=${encodeURIComponent(queryToken)}`,
+        );
+        if (!active) return;
+        if (response.status === 401 || response.status === 403) {
+          setState({ kind: 'unauthorized' });
+          return;
+        }
+        if (!response.ok) {
+          setState({ kind: 'error' });
+          return;
+        }
+        const body = await response.json() as ValidPreview | { valid: false; reason: InvalidReason };
+        if (!active) return;
+        setState(body.valid ? { kind: 'ready', preview: body } : { kind: 'invalid', reason: body.reason });
+      } catch {
+        if (active) setState({ kind: 'error' });
+      }
+    })();
+
+    return () => { active = false; };
+  }, []);
+
+  const submit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (state.kind !== 'ready' || totp.length !== 6 || submitting) return;
+    setSubmitting(true);
+    try {
+      const result = await runAction<{ trustState?: string; status?: string }>({
+        request: () => fetchWithAuth('/admin/trust/act', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ token, totp }),
+        }),
+        errorFallback: 'Unable to complete the trust action',
+        successMessage: 'Trust action completed',
+      });
+      setState({ kind: 'success', trustState: result.trustState ?? result.status ?? 'updated' });
+    } catch (error) {
+      // runAction has already surfaced API and network failures.
+      if (!(error instanceof ActionError)) console.error(error);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (state.kind === 'loading') {
+    return <p className="py-12 text-center text-sm text-muted-foreground">Loading trust action…</p>;
+  }
+  if (state.kind === 'unauthorized') {
+    return <p className="rounded-lg border bg-card p-6">Sign in as a platform admin to continue</p>;
+  }
+  if (state.kind === 'invalid') {
+    return <p className="rounded-lg border bg-card p-6">{invalidReasonCopy[state.reason]}</p>;
+  }
+  if (state.kind === 'error') {
+    return <p role="alert" className="rounded-lg border border-destructive/40 bg-destructive/10 p-6 text-destructive">Unable to load this trust action</p>;
+  }
+  if (state.kind === 'success') {
+    return (
+      <div className="rounded-lg border bg-card p-6" data-testid="trust-action-success">
+        <h1 className="text-xl font-semibold">Trust action completed</h1>
+        <p className="mt-2 text-sm text-muted-foreground">Resulting trust state: <strong className="text-foreground">{state.trustState}</strong></p>
+      </div>
+    );
+  }
+
+  const { preview } = state;
+  const { card } = preview;
+  const actionLabel = preview.action === 'approve' ? 'Approve partner' : 'Suspend partner';
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">{actionLabel}</h1>
+        <p className="mt-1 text-sm text-muted-foreground">Review the partner evidence before confirming this action.</p>
+      </div>
+
+      <section className="rounded-lg border bg-card p-6" aria-labelledby="partner-summary-heading">
+        <h2 id="partner-summary-heading" className="text-lg font-semibold">Partner summary</h2>
+        <dl className="mt-4 grid gap-4 text-sm sm:grid-cols-2 lg:grid-cols-3">
+          <div><dt className="text-muted-foreground">Partner</dt><dd className="font-medium">{preview.partner.name} ({preview.partner.slug})</dd></div>
+          <div><dt className="text-muted-foreground">Plan</dt><dd className="font-medium">{preview.partner.plan}</dd></div>
+          <div><dt className="text-muted-foreground">Trust state</dt><dd className="font-medium">{preview.partner.trustState}</dd></div>
+          <div><dt className="text-muted-foreground">Signup IP class</dt><dd className="font-medium">{card.signup.ipClass}</dd></div>
+          <div><dt className="text-muted-foreground">Signup ASN</dt><dd className="font-medium">{displayValue(card.signup.asn)}</dd></div>
+          <div><dt className="text-muted-foreground">Denials in last 24 h</dt><dd className="font-medium">{card.denials24h}</dd></div>
+        </dl>
+      </section>
+
+      <section className="rounded-lg border bg-card p-6" aria-labelledby="identity-billing-heading">
+        <h2 id="identity-billing-heading" className="text-lg font-semibold">Identity and billing</h2>
+        <dl className="mt-4 grid gap-4 text-sm sm:grid-cols-2">
+          <div><dt className="text-muted-foreground">User name</dt><dd className="font-medium">{displayValue(card.identity.userName)}</dd></div>
+          <div><dt className="text-muted-foreground">Cardholder name</dt><dd className="font-medium">{displayValue(card.identity.cardholderName)}</dd></div>
+          <div><dt className="text-muted-foreground">Names match</dt><dd className="font-medium">{displayBoolean(card.identity.namesMatch)}</dd></div>
+          <div><dt className="text-muted-foreground">Payment methods</dt><dd className="font-medium">{card.billing.distinctPaymentMethods}</dd></div>
+          <div><dt className="text-muted-foreground">Payment failures</dt><dd className="font-medium">{card.billing.failedAttempts}</dd></div>
+          <div><dt className="text-muted-foreground">Matched suspended axes</dt><dd className="font-medium">{card.matchedSuspendedAxes.length ? card.matchedSuspendedAxes.map(displayAxis).join(', ') : 'None'}</dd></div>
+        </dl>
+      </section>
+
+      <section className="overflow-hidden rounded-lg border bg-card" aria-labelledby="devices-heading">
+        <h2 id="devices-heading" className="p-6 pb-3 text-lg font-semibold">Devices</h2>
+        {card.devices.length === 0 ? (
+          <p className="px-6 pb-6 text-sm text-muted-foreground">No enrolled devices</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-sm">
+              <thead className="bg-muted/40 text-xs uppercase text-muted-foreground">
+                <tr><th className="px-6 py-3">Hostname</th><th className="px-6 py-3">Enrollment IP class</th><th className="px-6 py-3">Virtual</th></tr>
+              </thead>
+              <tbody className="divide-y">
+                {card.devices.map((device, index) => (
+                  <tr key={`${device.hostname}-${index}`}>
+                    <td className="px-6 py-3 font-medium">{device.hostname}</td>
+                    <td className="px-6 py-3">{device.enrollmentIpClass}</td>
+                    <td className="px-6 py-3">{device.isVirtual ? 'Yes' : 'No'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      <form onSubmit={submit} className="rounded-lg border bg-card p-6">
+        <label htmlFor="trust-action-totp" className="block text-sm font-medium">Six-digit TOTP code</label>
+        <input
+          id="trust-action-totp"
+          data-testid="trust-action-totp"
+          type="text"
+          inputMode="numeric"
+          pattern="[0-9]{6}"
+          autoComplete="one-time-code"
+          autoFocus
+          maxLength={6}
+          value={totp}
+          onChange={(event) => setTotp(event.target.value.replace(/\D/g, '').slice(0, 6))}
+          className="mt-2 h-10 w-48 rounded-md border bg-background px-3 font-mono text-lg tracking-widest"
+          required
+        />
+        <button
+          type="submit"
+          disabled={totp.length !== 6 || submitting}
+          className="mt-4 block rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {submitting ? 'Confirming…' : actionLabel}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/src/components/setup/AccountSetupStep.test.tsx
+++ b/apps/web/src/components/setup/AccountSetupStep.test.tsx
@@ -27,6 +27,42 @@ vi.mock('../../stores/auth', () => {
 import AccountSetupStep from './AccountSetupStep';
 
 const ok = () => ({ ok: true, json: async () => ({}) });
+const trustResponse = (trustState: string) => ({
+  ok: true,
+  json: async () => ({ trustState }),
+});
+const trustCopy = 'Remote control and script execution unlock after your first card payment settles (about 24 hours) or once we have reviewed your account.';
+
+describe('AccountSetupStep — partner trust onboarding copy', () => {
+  beforeEach(() => {
+    authMocks.fetchWithAuth.mockResolvedValue(trustResponse('trusted'));
+  });
+
+  it('shows the copy while the partner is on probation', async () => {
+    authMocks.fetchWithAuth.mockResolvedValueOnce(trustResponse('probation'));
+
+    render(<AccountSetupStep onNext={vi.fn()} />);
+
+    expect(await screen.findByText(trustCopy)).toBeInTheDocument();
+    expect(authMocks.fetchWithAuth).toHaveBeenCalledWith('/partner/trust');
+  });
+
+  it('hides the copy when the partner is trusted', async () => {
+    render(<AccountSetupStep onNext={vi.fn()} />);
+
+    await waitFor(() => expect(authMocks.fetchWithAuth).toHaveBeenCalledWith('/partner/trust'));
+    expect(screen.queryByText(trustCopy)).not.toBeInTheDocument();
+  });
+
+  it('hides the copy when the trust request fails', async () => {
+    authMocks.fetchWithAuth.mockRejectedValueOnce(new Error('network unavailable'));
+
+    render(<AccountSetupStep onNext={vi.fn()} />);
+
+    await waitFor(() => expect(authMocks.fetchWithAuth).toHaveBeenCalledWith('/partner/trust'));
+    expect(screen.queryByText(trustCopy)).not.toBeInTheDocument();
+  });
+});
 
 /**
  * #2428: a committed email change advances auth_epoch and revokes every refresh

--- a/apps/web/src/components/setup/AccountSetupStep.tsx
+++ b/apps/web/src/components/setup/AccountSetupStep.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Eye, EyeOff, Loader2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { fetchWithAuth, apiLogin, useAuthStore } from '../../stores/auth';
@@ -18,8 +18,29 @@ export default function AccountSetupStep({ onNext }: AccountSetupStepProps) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>();
   const [success, setSuccess] = useState<string>();
+  const [showTrustNotice, setShowTrustNotice] = useState(false);
 
   const user = useAuthStore((s) => s.user);
+
+  useEffect(() => {
+    let active = true;
+
+    const loadTrustState = async () => {
+      try {
+        const response = await fetchWithAuth('/partner/trust');
+        if (!response.ok) return;
+        const data = await response.json() as { trustState?: unknown };
+        if (active && typeof data.trustState === 'string') {
+          setShowTrustNotice(data.trustState !== 'trusted');
+        }
+      } catch {
+        // This supplemental onboarding copy stays hidden when trust status is unavailable.
+      }
+    };
+
+    void loadTrustState();
+    return () => { active = false; };
+  }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -129,6 +150,11 @@ export default function AccountSetupStep({ onNext }: AccountSetupStepProps) {
         <p className="mt-1 text-sm text-muted-foreground">
           {t('setup.account.description')}
         </p>
+        {showTrustNotice && (
+          <p className="mt-2 text-sm text-muted-foreground">
+            Remote control and script execution unlock after your first card payment settles (about 24 hours) or once we have reviewed your account.
+          </p>
+        )}
       </div>
 
       <form onSubmit={handleSubmit} className="space-y-4">

--- a/apps/web/src/components/trust/TrustProbationBanner.test.tsx
+++ b/apps/web/src/components/trust/TrustProbationBanner.test.tsx
@@ -15,7 +15,6 @@ const status = {
     ageOk: true,
     emailVerified: true,
     cardSettled: false,
-    signupIpOk: false,
   },
   reviewRequestedAt: null,
   meetingUrl: 'https://meet.example.test/trust',
@@ -39,8 +38,10 @@ function deny(overrides: Partial<TrustDenial> = {}): TrustDenial {
   };
 }
 
-function dispatch(detail: TrustDenial) {
-  window.dispatchEvent(new CustomEvent(TRUST_DENIED_EVENT, { detail }));
+function dispatch(detail: TrustDenial): CustomEvent<TrustDenial> {
+  const event = new CustomEvent(TRUST_DENIED_EVENT, { detail, cancelable: true });
+  window.dispatchEvent(event);
+  return event;
 }
 
 beforeEach(() => {
@@ -139,5 +140,15 @@ describe('TrustProbationBanner', () => {
     const cardItem = within(checklist).getByText('Card payment settled').parentElement;
     expect(cardItem).toHaveTextContent('pending');
     expect(cardItem).not.toHaveTextContent('complete');
+  });
+
+  it('claims the trust-denied event via preventDefault so runAction skips its fallback toast', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(response(status));
+    render(<TrustProbationBanner />);
+
+    const event = dispatch(deny());
+
+    await screen.findByTestId('trust-probation-banner');
+    expect(event.defaultPrevented).toBe(true);
   });
 });

--- a/apps/web/src/components/trust/TrustProbationBanner.test.tsx
+++ b/apps/web/src/components/trust/TrustProbationBanner.test.tsx
@@ -1,0 +1,119 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchWithAuth } from '@/stores/auth';
+import { TRUST_DENIED_EVENT, type TrustDenial } from '@/lib/trustProbation';
+import TrustProbationBanner from './TrustProbationBanner';
+
+vi.mock('@/stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+vi.mock('@/components/shared/Toast', () => ({ showToast: vi.fn() }));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+const status = {
+  trustState: 'probation',
+  checklist: {
+    ageOk: true,
+    emailVerified: true,
+    cardSettled: false,
+    signupIpOk: false,
+  },
+  reviewRequestedAt: null,
+  meetingUrl: 'https://meet.example.test/trust',
+};
+
+function response(body: unknown, statusCode = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status: statusCode,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function deny(overrides: Partial<TrustDenial> = {}): TrustDenial {
+  return {
+    error: 'TRUST_PROBATION',
+    capability: 'remote_control',
+    reason: 'probation_default_deny',
+    reviewRequested: false,
+    meetingUrl: null,
+    ...overrides,
+  };
+}
+
+function dispatch(detail: TrustDenial) {
+  window.dispatchEvent(new CustomEvent(TRUST_DENIED_EVENT, { detail }));
+}
+
+beforeEach(() => {
+  fetchWithAuthMock.mockReset();
+});
+
+describe('TrustProbationBanner', () => {
+  it('renders denial-specific copy, checklist ticks, and the meeting link', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(response(status));
+    render(<TrustProbationBanner />);
+
+    dispatch(deny({ capability: 'device_execute' }));
+
+    expect(await screen.findByText('Verification pending')).toBeInTheDocument();
+    expect(screen.getByText('Script execution is temporarily unavailable.')).toBeInTheDocument();
+    expect(screen.getByText(/Remote control and script execution unlock/)).toBeInTheDocument();
+    const checklist = await screen.findByRole('list', { name: 'Verification checklist' });
+    expect(within(checklist).getByText('24 hours since signup').parentElement).toHaveTextContent('complete');
+    expect(within(checklist).getByText('Card payment settled').parentElement).toHaveTextContent('pending');
+    expect(screen.getByRole('link', { name: 'Book a call' })).toHaveAttribute(
+      'href',
+      status.meetingUrl,
+    );
+    expect(fetchWithAuthMock).toHaveBeenCalledWith('/partner/trust');
+  });
+
+  it('renders the restricted title', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(response({ ...status, trustState: 'restricted' }));
+    render(<TrustProbationBanner />);
+    dispatch(deny({ error: 'TRUST_RESTRICTED', capability: 'installer_distribute' }));
+
+    expect(await screen.findByText('Account restricted')).toBeInTheDocument();
+    expect(screen.getByText('Installer distribution is temporarily unavailable.')).toBeInTheDocument();
+  });
+
+  it('requests a review through runAction and flips the button after success', async () => {
+    fetchWithAuthMock
+      .mockResolvedValueOnce(response(status))
+      .mockResolvedValueOnce(response({ requested: true }));
+    render(<TrustProbationBanner />);
+    dispatch(deny());
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Request review' }));
+
+    expect(await screen.findByRole('button', { name: 'Review requested' })).toBeDisabled();
+    expect(fetchWithAuthMock).toHaveBeenLastCalledWith('/partner/trust/request-review', { method: 'POST' });
+  });
+
+  it('treats a 429 as an already-requested review', async () => {
+    fetchWithAuthMock
+      .mockResolvedValueOnce(response(status))
+      .mockResolvedValueOnce(response({ error: 'trust review was requested within the last 24 hours' }, 429));
+    render(<TrustProbationBanner />);
+    dispatch(deny());
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Request review' }));
+
+    expect(await screen.findByRole('button', { name: 'Review requested' })).toBeDisabled();
+  });
+
+  it('dismisses and re-shows on the next denial', async () => {
+    fetchWithAuthMock
+      .mockResolvedValueOnce(response(status))
+      .mockResolvedValueOnce(response(status));
+    render(<TrustProbationBanner />);
+    dispatch(deny());
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Dismiss verification notice' }));
+    expect(screen.queryByTestId('trust-probation-banner')).not.toBeInTheDocument();
+
+    dispatch(deny({ capability: 'agent_enroll' }));
+    expect(await screen.findByTestId('trust-probation-banner')).toBeInTheDocument();
+    expect(screen.getByText('Agent enrollment is temporarily unavailable.')).toBeInTheDocument();
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalledTimes(2));
+  });
+});

--- a/apps/web/src/components/trust/TrustProbationBanner.test.tsx
+++ b/apps/web/src/components/trust/TrustProbationBanner.test.tsx
@@ -116,4 +116,28 @@ describe('TrustProbationBanner', () => {
     expect(screen.getByText('Agent enrollment is temporarily unavailable.')).toBeInTheDocument();
     await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalledTimes(2));
   });
+
+  it('renders installer_distribute capability copy', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(response(status));
+    render(<TrustProbationBanner />);
+    dispatch(deny({ capability: 'installer_distribute' }));
+
+    expect(await screen.findByText('Installer distribution is temporarily unavailable.')).toBeInTheDocument();
+  });
+
+  it('renders cardSettled null as pending in the checklist', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(
+      response({
+        ...status,
+        checklist: { ...status.checklist, cardSettled: null },
+      }),
+    );
+    render(<TrustProbationBanner />);
+    dispatch(deny());
+
+    const checklist = await screen.findByRole('list', { name: 'Verification checklist' });
+    const cardItem = within(checklist).getByText('Card payment settled').parentElement;
+    expect(cardItem).toHaveTextContent('pending');
+    expect(cardItem).not.toHaveTextContent('complete');
+  });
 });

--- a/apps/web/src/components/trust/TrustProbationBanner.tsx
+++ b/apps/web/src/components/trust/TrustProbationBanner.tsx
@@ -26,7 +26,7 @@ const CHECKLIST_ITEMS: ReadonlyArray<{
   { key: 'ageOk', label: '24 hours since signup' },
   { key: 'emailVerified', label: 'Email verified' },
   { key: 'cardSettled', label: 'Card payment settled' },
-  { key: 'signupIpOk', label: 'Signup network verified' },
+  { key: 'signupIpOk', label: 'Account details verified' },
 ];
 
 const CAPABILITY_LABELS: Record<TrustDenial['capability'], string> = {

--- a/apps/web/src/components/trust/TrustProbationBanner.tsx
+++ b/apps/web/src/components/trust/TrustProbationBanner.tsx
@@ -13,7 +13,6 @@ interface TrustStatus {
     ageOk: boolean;
     emailVerified: boolean;
     cardSettled: boolean | null;
-    signupIpOk: boolean;
   };
   reviewRequestedAt: string | null;
   meetingUrl: string | null;
@@ -26,7 +25,6 @@ const CHECKLIST_ITEMS: ReadonlyArray<{
   { key: 'ageOk', label: '24 hours since signup' },
   { key: 'emailVerified', label: 'Email verified' },
   { key: 'cardSettled', label: 'Card payment settled' },
-  { key: 'signupIpOk', label: 'Account details verified' },
 ];
 
 const CAPABILITY_LABELS: Record<TrustDenial['capability'], string> = {
@@ -59,6 +57,9 @@ export default function TrustProbationBanner() {
 
   useEffect(() => {
     const handleTrustDenied = (event: Event) => {
+      // Claims this denial so runAction knows not to also show a generic
+      // error toast on top of the banner (see dispatchTrustDenied).
+      event.preventDefault();
       const detail = (event as CustomEvent<TrustDenial>).detail;
       const sequence = ++requestSequence.current;
       setDenial(detail);

--- a/apps/web/src/components/trust/TrustProbationBanner.tsx
+++ b/apps/web/src/components/trust/TrustProbationBanner.tsx
@@ -1,0 +1,166 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Check, Circle, ShieldAlert, X } from 'lucide-react';
+import { fetchWithAuth } from '@/stores/auth';
+import { ActionError, runAction } from '@/lib/runAction';
+import {
+  TRUST_DENIED_EVENT,
+  type TrustDenial,
+} from '@/lib/trustProbation';
+
+interface TrustStatus {
+  trustState: string;
+  checklist: {
+    ageOk: boolean;
+    emailVerified: boolean;
+    cardSettled: boolean | null;
+    signupIpOk: boolean;
+  };
+  reviewRequestedAt: string | null;
+  meetingUrl: string | null;
+}
+
+const CHECKLIST_ITEMS: ReadonlyArray<{
+  key: keyof TrustStatus['checklist'];
+  label: string;
+}> = [
+  { key: 'ageOk', label: '24 hours since signup' },
+  { key: 'emailVerified', label: 'Email verified' },
+  { key: 'cardSettled', label: 'Card payment settled' },
+  { key: 'signupIpOk', label: 'Signup network verified' },
+];
+
+const CAPABILITY_LABELS: Record<TrustDenial['capability'], string> = {
+  remote_control: 'Remote control',
+  device_execute: 'Script execution',
+  installer_distribute: 'Installer distribution',
+  agent_enroll: 'Agent enrollment',
+};
+
+export default function TrustProbationBanner() {
+  const [denial, setDenial] = useState<TrustDenial | null>(null);
+  const [status, setStatus] = useState<TrustStatus | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+  const [reviewRequested, setReviewRequested] = useState(false);
+  const [requestingReview, setRequestingReview] = useState(false);
+  const requestSequence = useRef(0);
+
+  const loadTrustStatus = useCallback(async (detail: TrustDenial, sequence: number) => {
+    try {
+      const response = await fetchWithAuth('/partner/trust');
+      if (!response.ok) return;
+      const next = await response.json() as TrustStatus;
+      if (requestSequence.current !== sequence) return;
+      setStatus(next);
+      setReviewRequested(detail.reviewRequested || next.reviewRequestedAt !== null);
+    } catch {
+      // The denial body still has enough information to offer review/call actions.
+    }
+  }, []);
+
+  useEffect(() => {
+    const handleTrustDenied = (event: Event) => {
+      const detail = (event as CustomEvent<TrustDenial>).detail;
+      const sequence = ++requestSequence.current;
+      setDenial(detail);
+      setStatus(null);
+      setDismissed(false);
+      setReviewRequested(detail.reviewRequested);
+      void loadTrustStatus(detail, sequence);
+    };
+    window.addEventListener(TRUST_DENIED_EVENT, handleTrustDenied);
+    return () => {
+      requestSequence.current += 1;
+      window.removeEventListener(TRUST_DENIED_EVENT, handleTrustDenied);
+    };
+  }, [loadTrustStatus]);
+
+  const requestReview = async () => {
+    setRequestingReview(true);
+    try {
+      await runAction<{ requested: true }>({
+        request: () => fetchWithAuth('/partner/trust/request-review', { method: 'POST' }),
+        errorFallback: 'Unable to request a review',
+        successMessage: 'Review requested',
+      });
+      setReviewRequested(true);
+    } catch (error) {
+      // The endpoint uses 429 to mean the review is already pending. Present
+      // that as the same durable banner state instead of inviting retries.
+      if (error instanceof ActionError && error.status === 429) {
+        setReviewRequested(true);
+      }
+    } finally {
+      setRequestingReview(false);
+    }
+  };
+
+  if (!denial || dismissed) return null;
+
+  const restricted = denial.error === 'TRUST_RESTRICTED' || status?.trustState === 'restricted';
+  const meetingUrl = status?.meetingUrl ?? denial.meetingUrl;
+
+  return (
+    <div
+      role="status"
+      data-testid="trust-probation-banner"
+      className="mb-4 flex items-start gap-3 rounded-lg border border-warning/40 bg-warning/10 px-4 py-3"
+    >
+      <ShieldAlert className="mt-0.5 h-5 w-5 shrink-0 text-warning" aria-hidden="true" />
+      <div className="min-w-0 flex-1">
+        <p className="font-semibold text-foreground">
+          {restricted ? 'Account restricted' : 'Verification pending'}
+        </p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {CAPABILITY_LABELS[denial.capability]} is temporarily unavailable.
+        </p>
+        <p className="mt-1 text-sm text-foreground">
+          Remote control and script execution unlock after your first card payment settles (about 24 hours) or once we've reviewed your account.
+        </p>
+        {status && (
+          <ul className="mt-3 grid gap-1 sm:grid-cols-2" aria-label="Verification checklist">
+            {CHECKLIST_ITEMS.map(({ key, label }) => {
+              const complete = status.checklist[key] === true;
+              return (
+                <li key={key} className="flex items-center gap-2 text-sm text-foreground">
+                  {complete
+                    ? <Check className="h-4 w-4 shrink-0 text-success" aria-hidden="true" />
+                    : <Circle className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />}
+                  <span>{label}</span>
+                  <span className="sr-only">{complete ? 'complete' : 'pending'}</span>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+        <div className="mt-3 flex flex-wrap items-center gap-3">
+          <button
+            type="button"
+            onClick={() => void requestReview()}
+            disabled={reviewRequested || requestingReview}
+            className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-default disabled:opacity-70"
+          >
+            {reviewRequested ? 'Review requested' : requestingReview ? 'Requesting…' : 'Request review'}
+          </button>
+          {meetingUrl && (
+            <a
+              href={meetingUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="text-sm font-medium text-foreground underline"
+            >
+              Book a call
+            </a>
+          )}
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={() => setDismissed(true)}
+        aria-label="Dismiss verification notice"
+        className="shrink-0 rounded p-1 text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <X className="h-4 w-4" aria-hidden="true" />
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/layouts/DashboardLayout.astro
+++ b/apps/web/src/layouts/DashboardLayout.astro
@@ -4,6 +4,7 @@ import Sidebar from '../components/layout/Sidebar';
 import Header from '../components/layout/Header';
 import ContextScopeLine from '../components/layout/ContextScopeLine';
 import MigrationRequiredBanner from '../components/devices/MigrationRequiredBanner';
+import TrustProbationBanner from '../components/trust/TrustProbationBanner';
 import AuthOverlay from '../components/auth/AuthOverlay';
 import AdminSessionManager from '../components/auth/AdminSessionManager';
 import AccountInactiveGuard from '../components/auth/AccountInactiveGuard';
@@ -50,6 +51,7 @@ const accentClass = getAccentClass(currentPath);
         {/* Registry-driven page-scope statement — mounted here so every page
             gets it and none can forget it (see routeScope.ts). */}
         <ContextScopeLine client:load />
+        <TrustProbationBanner client:load transition:persist />
         {/* Persistent self-host agent-migration notice — mounted here so it
             shows on every authenticated page (see MigrationRequiredBanner). */}
         <MigrationRequiredBanner client:load />

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -237,6 +237,10 @@ const TARGET_GLOBS = [
   // unguarded next to them. A silent failure on either reads as "payment sync
   // is on / a sync is running" while the books and Breeze quietly diverge.
   'src/components/integrations/QuickbooksIntegration.tsx',
+  // Partner trust action links approve or suspend an entire partner. Keep the
+  // TOTP-confirmed mutation inside runAction so this high-impact result cannot
+  // fail without operator feedback.
+  'src/components/admin/TrustActionPage.tsx',
 ];
 
 const absoluteFiles: string[] = TARGET_GLOBS.map((rel) => resolve(WEB_ROOT, '..', rel));
@@ -543,11 +547,13 @@ describe('no silent mutations in targeted set', () => {
     // AiAgentGraduationPanel.tsx (P2-5 Task 20, #4192). ApprovalsInbox.tsx was
     // already guarded before P2-5 — Task 21's promote mutation needed no list
     // edit. Also plus BulkContactImport.tsx, ContactImportPreviewTable.tsx and
-    // ContactsCard.tsx (#3258 W04, the contacts tab and its CSV importer).
-    // NOTE: merge-base held 108; this branch added 1 and main added 3 in
-    // parallel, so the true merged count is 112 — bump it deliberately on
-    // every merge, never by resolving the hunk.
-    expect(absoluteFiles.length).toBe(112);
+    // ContactsCard.tsx (#3258 W04, the contacts tab and its CSV importer), plus
+    // TrustActionPage.tsx (partner trust probation, #4549 — the TOTP-confirmed
+    // approve/suspend action).
+    // NOTE: merge-base held 108; this branch added 1 (TrustActionPage.tsx) and
+    // main added 3 in parallel, so the true merged count is 113 — bump it
+    // deliberately on every merge, never by resolving the hunk.
+    expect(absoluteFiles.length).toBe(113);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/apps/web/src/lib/runAction.test.ts
+++ b/apps/web/src/lib/runAction.test.ts
@@ -4,6 +4,7 @@ const showToast = vi.fn();
 vi.mock('../components/shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
 
 import { runAction, ActionError } from './runAction';
+import { TRUST_DENIED_EVENT } from './trustProbation';
 
 function res(body: unknown, status = 200): Response {
   return new Response(body === undefined ? '' : JSON.stringify(body), {
@@ -137,6 +138,42 @@ describe('runAction', () => {
       friendly: (token) => (token === 'step_up_required' ? 'Use Touch ID to approve' : undefined),
     })).rejects.toMatchObject({ status: 403, message: 'Use Touch ID to approve' });
     expect(showToast).toHaveBeenCalledWith({ message: 'Use Touch ID to approve', type: 'error' });
+  });
+
+  it('dispatches trust denials and suppresses the generic error toast', async () => {
+    const denial = {
+      error: 'TRUST_PROBATION',
+      capability: 'remote_control',
+      reason: 'probation_default_deny',
+      reviewRequested: false,
+      meetingUrl: null,
+    };
+    const listener = vi.fn();
+    window.addEventListener(TRUST_DENIED_EVENT, listener);
+
+    await expect(runAction({
+      request: async () => res(denial, 403),
+      errorFallback: 'Remote control failed',
+    })).rejects.toMatchObject({ status: 403, body: denial });
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect((listener.mock.calls[0]![0] as CustomEvent).detail).toEqual(denial);
+    expect(showToast).not.toHaveBeenCalled();
+    window.removeEventListener(TRUST_DENIED_EVENT, listener);
+  });
+
+  it('still shows the generic error toast for other 403 responses', async () => {
+    const listener = vi.fn();
+    window.addEventListener(TRUST_DENIED_EVENT, listener);
+
+    await expect(runAction({
+      request: async () => res({ error: 'Forbidden' }, 403),
+      errorFallback: 'Action failed',
+    })).rejects.toMatchObject({ status: 403, message: 'Forbidden' });
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(showToast).toHaveBeenCalledWith({ message: 'Forbidden', type: 'error' });
+    window.removeEventListener(TRUST_DENIED_EVENT, listener);
   });
 
   it('parseSuccess throws -> toasted failure with errorFallback', async () => {

--- a/apps/web/src/lib/runAction.test.ts
+++ b/apps/web/src/lib/runAction.test.ts
@@ -140,7 +140,49 @@ describe('runAction', () => {
     expect(showToast).toHaveBeenCalledWith({ message: 'Use Touch ID to approve', type: 'error' });
   });
 
-  it('dispatches trust denials and suppresses the generic error toast', async () => {
+  it('dispatches trust denials and suppresses the generic error toast when a listener claims it', async () => {
+    const denial = {
+      error: 'TRUST_PROBATION',
+      capability: 'remote_control',
+      reason: 'probation_default_deny',
+      reviewRequested: false,
+      meetingUrl: null,
+    };
+    // Mirrors TrustProbationBanner's handler: claims the event so runAction
+    // doesn't also show a generic toast on top of the banner.
+    const listener = vi.fn((event: Event) => event.preventDefault());
+    window.addEventListener(TRUST_DENIED_EVENT, listener);
+
+    await expect(runAction({
+      request: async () => res(denial, 403),
+      errorFallback: 'Remote control failed',
+    })).rejects.toMatchObject({ status: 403, body: denial });
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect((listener.mock.calls[0]![0] as CustomEvent).detail).toEqual(denial);
+    expect(showToast).not.toHaveBeenCalled();
+    window.removeEventListener(TRUST_DENIED_EVENT, listener);
+  });
+
+  it('falls back to the generic error toast when nothing handles the trust-denied event', async () => {
+    const denial = {
+      error: 'TRUST_PROBATION',
+      capability: 'remote_control',
+      reason: 'probation_default_deny',
+      reviewRequested: false,
+      meetingUrl: null,
+    };
+    // No listener at all — simulates a page where TrustProbationBanner isn't
+    // mounted. The failure must not be silently swallowed.
+    await expect(runAction({
+      request: async () => res(denial, 403),
+      errorFallback: 'Remote control failed',
+    })).rejects.toMatchObject({ status: 403, body: denial });
+
+    expect(showToast).toHaveBeenCalledWith({ message: expect.any(String), type: 'error' });
+  });
+
+  it('falls back to the generic error toast when a listener observes but does not claim the trust-denied event', async () => {
     const denial = {
       error: 'TRUST_PROBATION',
       capability: 'remote_control',
@@ -157,8 +199,7 @@ describe('runAction', () => {
     })).rejects.toMatchObject({ status: 403, body: denial });
 
     expect(listener).toHaveBeenCalledOnce();
-    expect((listener.mock.calls[0]![0] as CustomEvent).detail).toEqual(denial);
-    expect(showToast).not.toHaveBeenCalled();
+    expect(showToast).toHaveBeenCalledWith({ message: expect.any(String), type: 'error' });
     window.removeEventListener(TRUST_DENIED_EVENT, listener);
   });
 

--- a/apps/web/src/lib/runAction.ts
+++ b/apps/web/src/lib/runAction.ts
@@ -83,7 +83,13 @@ export async function runAction<T = unknown>(opts: RunActionOptions<T>): Promise
       if (friendly) message = friendly;
     }
     if (response.status === 403 && isTrustDenial(data)) {
-      dispatchTrustDenied(data);
+      // Best-effort UI handoff: if a mounted TrustProbationBanner picks this
+      // up (it calls preventDefault()), it owns showing the denial and a
+      // generic toast on top would be redundant noise. If nothing handled
+      // it — the banner isn't mounted on this page — fall back to the
+      // normal error toast so the failure is never silent.
+      const handled = dispatchTrustDenied(data);
+      if (!handled) showToast({ message, type: 'error' });
     } else {
       showToast({ message, type: 'error' });
     }

--- a/apps/web/src/lib/runAction.ts
+++ b/apps/web/src/lib/runAction.ts
@@ -1,5 +1,6 @@
 import { showToast } from '../components/shared/Toast';
 import { extractApiError, isApiFailure } from './apiError';
+import { dispatchTrustDenied, isTrustDenial } from './trustProbation';
 
 export class ActionError extends Error {
   code?: string;
@@ -81,7 +82,11 @@ export async function runAction<T = unknown>(opts: RunActionOptions<T>): Promise
       const friendly = opts.friendly(friendlyKey);
       if (friendly) message = friendly;
     }
-    showToast({ message, type: 'error' });
+    if (response.status === 403 && isTrustDenial(data)) {
+      dispatchTrustDenied(data);
+    } else {
+      showToast({ message, type: 'error' });
+    }
     throw new ActionError(message, response.status, code, data);
   }
 

--- a/apps/web/src/lib/trustProbation.test.ts
+++ b/apps/web/src/lib/trustProbation.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  dispatchTrustDenied,
+  isTrustDenial,
+  TRUST_DENIED_EVENT,
+} from './trustProbation';
+
+const denial = {
+  error: 'TRUST_PROBATION' as const,
+  capability: 'device_execute' as const,
+  reason: 'probation_default_deny',
+  reviewRequested: false,
+  meetingUrl: null,
+};
+
+describe('trustProbation', () => {
+  it('recognises only complete trust-denial response bodies', () => {
+    expect(isTrustDenial(denial)).toBe(true);
+    expect(isTrustDenial({ ...denial, error: 'FORBIDDEN' })).toBe(false);
+    expect(isTrustDenial({ ...denial, capability: 'billing' })).toBe(false);
+    expect(isTrustDenial({ ...denial, reviewRequested: 'false' })).toBe(false);
+    expect(isTrustDenial(null)).toBe(false);
+  });
+
+  it('dispatches the shared event with the denial as detail', () => {
+    const listener = vi.fn();
+    window.addEventListener(TRUST_DENIED_EVENT, listener);
+    dispatchTrustDenied(denial);
+    expect(listener).toHaveBeenCalledOnce();
+    expect((listener.mock.calls[0]![0] as CustomEvent).detail).toBe(denial);
+    window.removeEventListener(TRUST_DENIED_EVENT, listener);
+  });
+});

--- a/apps/web/src/lib/trustProbation.test.ts
+++ b/apps/web/src/lib/trustProbation.test.ts
@@ -30,4 +30,22 @@ describe('trustProbation', () => {
     expect((listener.mock.calls[0]![0] as CustomEvent).detail).toBe(denial);
     window.removeEventListener(TRUST_DENIED_EVENT, listener);
   });
+
+  it('returns true when a listener calls preventDefault (handled)', () => {
+    const listener = vi.fn((event: Event) => event.preventDefault());
+    window.addEventListener(TRUST_DENIED_EVENT, listener);
+    expect(dispatchTrustDenied(denial)).toBe(true);
+    window.removeEventListener(TRUST_DENIED_EVENT, listener);
+  });
+
+  it('returns false when no listener claims the event', () => {
+    expect(dispatchTrustDenied(denial)).toBe(false);
+  });
+
+  it('returns false when a listener observes but does not call preventDefault', () => {
+    const listener = vi.fn();
+    window.addEventListener(TRUST_DENIED_EVENT, listener);
+    expect(dispatchTrustDenied(denial)).toBe(false);
+    window.removeEventListener(TRUST_DENIED_EVENT, listener);
+  });
 });

--- a/apps/web/src/lib/trustProbation.ts
+++ b/apps/web/src/lib/trustProbation.ts
@@ -33,7 +33,16 @@ export function isTrustDenial(body: unknown): body is TrustDenial {
     && (value.meetingUrl === null || typeof value.meetingUrl === 'string');
 }
 
-export function dispatchTrustDenied(detail: TrustDenial): void {
-  if (typeof window === 'undefined') return;
-  window.dispatchEvent(new CustomEvent<TrustDenial>(TRUST_DENIED_EVENT, { detail }));
+/**
+ * Dispatches the trust-denied event and reports whether something actually
+ * handled it. `TrustProbationBanner` calls `event.preventDefault()` when it
+ * shows the denial; if nothing does that (the banner isn't mounted on this
+ * page, or was removed), the caller (`runAction`) falls back to a normal
+ * error toast instead of silently swallowing the failure.
+ */
+export function dispatchTrustDenied(detail: TrustDenial): boolean {
+  if (typeof window === 'undefined') return false;
+  const event = new CustomEvent<TrustDenial>(TRUST_DENIED_EVENT, { detail, cancelable: true });
+  window.dispatchEvent(event);
+  return event.defaultPrevented;
 }

--- a/apps/web/src/lib/trustProbation.ts
+++ b/apps/web/src/lib/trustProbation.ts
@@ -1,0 +1,39 @@
+export const TRUST_DENIED_EVENT = 'breeze:trust-denied';
+
+export type TrustDenyCode = 'TRUST_PROBATION' | 'TRUST_RESTRICTED';
+export type TrustCapability =
+  | 'remote_control'
+  | 'device_execute'
+  | 'installer_distribute'
+  | 'agent_enroll';
+
+export interface TrustDenial {
+  error: TrustDenyCode;
+  capability: TrustCapability;
+  reason: string;
+  reviewRequested: boolean;
+  meetingUrl: string | null;
+}
+
+const TRUST_DENY_CODES = new Set<TrustDenyCode>(['TRUST_PROBATION', 'TRUST_RESTRICTED']);
+const TRUST_CAPABILITIES = new Set<TrustCapability>([
+  'remote_control',
+  'device_execute',
+  'installer_distribute',
+  'agent_enroll',
+]);
+
+export function isTrustDenial(body: unknown): body is TrustDenial {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) return false;
+  const value = body as Record<string, unknown>;
+  return TRUST_DENY_CODES.has(value.error as TrustDenyCode)
+    && TRUST_CAPABILITIES.has(value.capability as TrustCapability)
+    && typeof value.reason === 'string'
+    && typeof value.reviewRequested === 'boolean'
+    && (value.meetingUrl === null || typeof value.meetingUrl === 'string');
+}
+
+export function dispatchTrustDenied(detail: TrustDenial): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent<TrustDenial>(TRUST_DENIED_EVENT, { detail }));
+}

--- a/apps/web/src/pages/admin/trust/act.astro
+++ b/apps/web/src/pages/admin/trust/act.astro
@@ -1,0 +1,8 @@
+---
+import DashboardLayout from '../../../layouts/DashboardLayout.astro';
+import TrustActionPage from '../../../components/admin/TrustActionPage';
+---
+
+<DashboardLayout title="Partner trust action">
+  <TrustActionPage client:load />
+</DashboardLayout>


### PR DESCRIPTION
## Summary
Wave 6 of **Partner Trust Probation** (#4549). Stacked on W05; retargets as parents merge. Web only.

- **`runAction`**: a 403 whose body is a trust denial (`TRUST_PROBATION` / `TRUST_RESTRICTED`) dispatches `breeze:trust-denied` on `window` and suppresses the generic error toast; every other failure path is byte-identical and the `ActionError` is still thrown.
- **`TrustProbationBanner`** (mounted once in `DashboardLayout`): listens for the event, then loads `GET /partner/trust` and shows outcome-only copy, a checklist (24 hours since signup, email verified, card payment settled, account details verified), **Request review** (`POST /partner/trust/request-review` via `runAction`; 429 also reads as requested) and **Book a call** when a meeting URL exists. Dismissible, re-shown on the next denial. Review removed a checklist label that would have disclosed a detection axis.
- **Onboarding copy** on the account-setup step, shown only when the partner is not yet trusted, hidden on any API failure.
- **Admin trust action page** `/admin/trust/act?token=…` (the target of the evidence-card email links): previews the action via `GET /admin/trust/act/preview`, renders the evidence card, asks for a six-digit TOTP, and confirms via `POST /admin/trust/act` through `runAction`. Invalid links show plain copy; non-admins see a sign-in message.
- `no-silent-mutations` guard registers the new mutating component.

## Test plan
- [x] Full web suite: 697 files / 7,263 tests pass; the single failure (`AiUsagePage` ladder parse) is unrelated, identical in intent to `main`, and passes on re-run (flaky under the parallel pool)
- [x] `astro check` 0 errors / 0 warnings; lint clean
- [x] Each task reviewed by a fresh reviewer with scoped re-reviews

Closes #4555

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FAXi39eBUAUyw5j61AFFxh