### PR TITLE
feat(portal): W02 portal visibility read-model foundation (#4562)

### DIFF
--- a/apps/api/migrations/2026-10-04-100003-portal-visibility-indexes.sql
+++ b/apps/api/migrations/2026-10-04-100003-portal-visibility-indexes.sql
@@ -1,0 +1,36 @@
+-- Portal visibility Wave 1 read-model query indexes.
+-- autoMigrate owns the transaction; do not add BEGIN or COMMIT.
+
+CREATE INDEX IF NOT EXISTS device_patches_org_installed_at_idx
+  ON device_patches (org_id, installed_at)
+  WHERE status = 'installed';
+
+CREATE INDEX IF NOT EXISTS security_threats_org_detected_at_idx
+  ON security_threats (org_id, detected_at);
+
+CREATE INDEX IF NOT EXISTS security_threats_org_resolved_at_idx
+  ON security_threats (org_id, resolved_at)
+  WHERE resolved_at IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS s1_threats_org_detected_at_idx
+  ON s1_threats (org_id, detected_at)
+  WHERE detected_at IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS s1_threats_org_resolved_at_idx
+  ON s1_threats (org_id, resolved_at)
+  WHERE resolved_at IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS huntress_incidents_org_reported_at_idx
+  ON huntress_incidents (org_id, reported_at)
+  WHERE reported_at IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS huntress_incidents_org_resolved_at_idx
+  ON huntress_incidents (org_id, resolved_at)
+  WHERE resolved_at IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS backup_verifications_org_completed_at_idx
+  ON backup_verifications (org_id, completed_at);
+
+CREATE INDEX IF NOT EXISTS time_entries_org_started_at_idx
+  ON time_entries (org_id, started_at)
+  WHERE org_id IS NOT NULL;

--- a/apps/api/src/__tests__/integration/multiCurrencyWave6QuoteAcceptance.integration.test.ts
+++ b/apps/api/src/__tests__/integration/multiCurrencyWave6QuoteAcceptance.integration.test.ts
@@ -84,6 +84,7 @@ function portalApp(orgId: string) {
       user: { id: 'portal-user-gate', orgId, email: PORTAL_EMAIL, name: 'Gate Signer', contactId: null, receiveNotifications: true, status: 'active' },
       token: 't',
       authMethod: 'bearer',
+      timezone: 'UTC',
     });
     const ctx: DbAccessContext = { scope: 'organization', orgId, accessibleOrgIds: [orgId], accessiblePartnerIds: [], userId: null };
     if (isSelfManagedDbContextRoute(c.req.method, c.req.path)) return next();

--- a/apps/api/src/__tests__/integration/portalQuotePay.integration.test.ts
+++ b/apps/api/src/__tests__/integration/portalQuotePay.integration.test.ts
@@ -87,6 +87,7 @@ function app(orgId: string) {
       // do not read it, so the null (contact-less login) case is stated.
       user: { id: 'pu1', orgId, email: 'c@example.test', name: 'Cust', contactId: null, receiveNotifications: true, status: 'active' },
       token: 't', authMethod: 'bearer',
+      timezone: 'UTC',
     });
     if (isSelfManagedDbContextRoute(c.req.method, c.req.path)) return next();
     return withDbAccessContext(portalCtx(orgId), () => next());

--- a/apps/api/src/__tests__/integration/portalVisibilityRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/portalVisibilityRls.integration.test.ts
@@ -1,0 +1,355 @@
+import './setup';
+import { randomUUID } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { sql } from 'drizzle-orm';
+import {
+  db,
+  withDbAccessContext,
+  type DbAccessContext,
+} from '../../db';
+import {
+  backupConfigs,
+  backupJobs,
+  backupVerifications,
+  devices,
+  portalUsers,
+  reports,
+  reportRuns,
+  securityPostureOrgSnapshots,
+  securityStatus,
+  sites,
+  tickets,
+  timeEntries,
+} from '../../db/schema';
+import {
+  supportUsageForOrg,
+} from '../../services/portal/supportUsage';
+import {
+  createOrganization,
+  createPartner,
+  createUser,
+} from './db-utils';
+import { getTestDb } from './setup';
+
+async function seedDevice(
+  admin: ReturnType<typeof getTestDb>,
+  orgId: string,
+  label: string,
+) {
+  const [site] = await admin
+    .insert(sites)
+    .values({ orgId, name: `${label} Site` })
+    .returning({ id: sites.id });
+  if (!site) throw new Error('site insert failed');
+
+  const [device] = await admin
+    .insert(devices)
+    .values({
+      orgId,
+      siteId: site.id,
+      agentId: `${label}-${randomUUID()}`,
+      hostname: `${label}-host`,
+      osType: 'windows',
+      osVersion: '11',
+      architecture: 'x86_64',
+      agentVersion: 'test',
+      status: 'online',
+    })
+    .returning({ id: devices.id });
+  if (!device) throw new Error('device insert failed');
+
+  return device.id;
+}
+
+describe('portal visibility RLS', () => {
+  it('hides organization B evidence from organization A', async () => {
+    const admin = getTestDb();
+    const partner = await createPartner();
+    const orgA = await createOrganization({
+      partnerId: partner.id,
+    });
+    const orgB = await createOrganization({
+      partnerId: partner.id,
+    });
+    const technician = await createUser({
+      partnerId: partner.id,
+      orgId: null,
+    });
+
+    const [portalA] = await admin
+      .insert(portalUsers)
+      .values({
+        orgId: orgA.id,
+        email: `portal-${randomUUID()}@example.test`,
+        name: 'Portal A',
+        status: 'active',
+      })
+      .returning({ id: portalUsers.id });
+    if (!portalA) throw new Error('portal user insert failed');
+
+    const deviceA = await seedDevice(admin, orgA.id, 'a');
+    const deviceB = await seedDevice(admin, orgB.id, 'b');
+
+    await admin.insert(securityStatus).values([
+      {
+        orgId: orgA.id,
+        deviceId: deviceA,
+        provider: 'windows_defender',
+        realTimeProtection: true,
+        avProducts: [{ displayName: 'Defender' }],
+      },
+      {
+        orgId: orgB.id,
+        deviceId: deviceB,
+        provider: 'windows_defender',
+        realTimeProtection: true,
+        avProducts: [{ displayName: 'Defender' }],
+      },
+    ]);
+
+    const score = {
+      overallScore: 80,
+      devicesAudited: 1,
+      lowRiskDevices: 1,
+      mediumRiskDevices: 0,
+      highRiskDevices: 0,
+      criticalRiskDevices: 0,
+      patchComplianceScore: 80,
+      encryptionScore: 80,
+      avHealthScore: 80,
+      firewallScore: 80,
+      openPortsScore: 80,
+      passwordPolicyScore: 80,
+      osCurrencyScore: 80,
+      adminExposureScore: 80,
+    };
+
+    await admin.insert(securityPostureOrgSnapshots).values([
+      { orgId: orgA.id, ...score },
+      { orgId: orgB.id, ...score },
+    ]);
+
+    const configs = await admin
+      .insert(backupConfigs)
+      .values([
+        {
+          orgId: orgA.id,
+          name: 'A',
+          type: 'file',
+          provider: 'local',
+          providerConfig: {},
+        },
+        {
+          orgId: orgB.id,
+          name: 'B',
+          type: 'file',
+          provider: 'local',
+          providerConfig: {},
+        },
+      ])
+      .returning({
+        id: backupConfigs.id,
+        orgId: backupConfigs.orgId,
+      });
+    const configByOrg = new Map(
+      configs.map((row) => [row.orgId, row.id]),
+    );
+
+    const jobs = await admin
+      .insert(backupJobs)
+      .values([
+        {
+          orgId: orgA.id,
+          configId: configByOrg.get(orgA.id)!,
+          deviceId: deviceA,
+          status: 'completed',
+        },
+        {
+          orgId: orgB.id,
+          configId: configByOrg.get(orgB.id)!,
+          deviceId: deviceB,
+          status: 'completed',
+        },
+      ])
+      .returning({
+        id: backupJobs.id,
+        orgId: backupJobs.orgId,
+      });
+    const jobByOrg = new Map(
+      jobs.map((row) => [row.orgId, row.id]),
+    );
+
+    await admin.insert(backupVerifications).values([
+      {
+        orgId: orgA.id,
+        deviceId: deviceA,
+        backupJobId: jobByOrg.get(orgA.id)!,
+        verificationType: 'integrity',
+        status: 'passed',
+        startedAt: new Date(),
+        completedAt: new Date(),
+      },
+      {
+        orgId: orgB.id,
+        deviceId: deviceB,
+        backupJobId: jobByOrg.get(orgB.id)!,
+        verificationType: 'integrity',
+        status: 'passed',
+        startedAt: new Date(),
+        completedAt: new Date(),
+      },
+    ]);
+
+    const reportRows = await admin
+      .insert(reports)
+      .values([
+        {
+          orgId: orgA.id,
+          name: 'A',
+          type: 'device_inventory',
+          config: {},
+          schedule: 'one_time',
+          format: 'csv',
+        },
+        {
+          orgId: orgB.id,
+          name: 'B',
+          type: 'device_inventory',
+          config: {},
+          schedule: 'one_time',
+          format: 'csv',
+        },
+      ])
+      .returning({
+        id: reports.id,
+        orgId: reports.orgId,
+      });
+    const reportByOrg = new Map(
+      reportRows.map((row) => [row.orgId, row.id]),
+    );
+
+    const runs = await admin
+      .insert(reportRuns)
+      .values([
+        {
+          reportId: reportByOrg.get(orgA.id)!,
+          status: 'completed',
+        },
+        {
+          reportId: reportByOrg.get(orgB.id)!,
+          status: 'completed',
+        },
+      ])
+      .returning({
+        id: reportRuns.id,
+        reportId: reportRuns.reportId,
+      });
+    const runA = runs.find(
+      (row) => row.reportId === reportByOrg.get(orgA.id),
+    )!.id;
+    const runB = runs.find(
+      (row) => row.reportId === reportByOrg.get(orgB.id),
+    )!.id;
+
+    const [ticketB] = await admin
+      .insert(tickets)
+      .values({
+        orgId: orgB.id,
+        partnerId: partner.id,
+        ticketNumber: `B-${randomUUID()}`,
+        subject: 'B secret',
+        source: 'portal',
+      })
+      .returning({ id: tickets.id });
+    if (!ticketB) throw new Error('ticket insert failed');
+
+    await admin.insert(timeEntries).values({
+      partnerId: partner.id,
+      orgId: orgB.id,
+      ticketId: ticketB.id,
+      userId: technician.id,
+      startedAt: new Date(),
+      endedAt: new Date(),
+      durationMinutes: 75,
+      isBillable: true,
+      billingStatus: 'billed',
+      isApproved: true,
+      currencyCode: 'USD',
+    });
+
+    const context: DbAccessContext = {
+      scope: 'organization',
+      orgId: orgA.id,
+      accessibleOrgIds: [orgA.id],
+      accessiblePartnerIds: [],
+      userId: null,
+      currentPartnerId: null,
+    };
+
+    await withDbAccessContext(context, async () => {
+      expect(
+        (await db.select({
+          orgId: securityStatus.orgId,
+        }).from(securityStatus)).map((row) => row.orgId),
+      ).toEqual([orgA.id]);
+
+      expect(
+        (await db.select({
+          orgId: securityPostureOrgSnapshots.orgId,
+        }).from(securityPostureOrgSnapshots))
+          .map((row) => row.orgId),
+      ).toEqual([orgA.id]);
+
+      expect(
+        (await db.select({
+          orgId: backupVerifications.orgId,
+        }).from(backupVerifications)).map((row) => row.orgId),
+      ).toEqual([orgA.id]);
+
+      const visibleRuns = await db
+        .select({ id: reportRuns.id })
+        .from(reportRuns);
+      expect(visibleRuns.map((row) => row.id)).toContain(runA);
+      expect(visibleRuns.map((row) => row.id)).not.toContain(runB);
+
+      await expect(
+        db.select({ id: timeEntries.id }).from(timeEntries),
+      ).resolves.toEqual([]);
+
+      const usage = await supportUsageForOrg({
+        orgId: orgA.id,
+        month: new Date().toISOString().slice(0, 7),
+        timezone: 'UTC',
+        portalUserId: portalA.id,
+      });
+
+      expect(
+        Object.values(usage.totals).map((value) => value.minutes),
+      ).toEqual([0, 0, 0, 0]);
+    });
+  });
+
+  it('installs every portal visibility query index', async () => {
+    const expected = [
+      'device_patches_org_installed_at_idx',
+      'security_threats_org_detected_at_idx',
+      'security_threats_org_resolved_at_idx',
+      's1_threats_org_detected_at_idx',
+      's1_threats_org_resolved_at_idx',
+      'huntress_incidents_org_reported_at_idx',
+      'huntress_incidents_org_resolved_at_idx',
+      'backup_verifications_org_completed_at_idx',
+      'time_entries_org_started_at_idx',
+    ];
+
+    const result = (await getTestDb().execute(sql`
+      SELECT indexname
+      FROM pg_indexes
+      WHERE schemaname = 'public'
+        AND indexname IN ${expected}
+    `)) as unknown as Array<{ indexname: string }>;
+
+    expect(new Set(result.map((row) => row.indexname)))
+      .toEqual(new Set(expected));
+  });
+});

--- a/apps/api/src/__tests__/integration/portalVisibilityRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/portalVisibilityRls.integration.test.ts
@@ -251,6 +251,32 @@ describe('portal visibility RLS', () => {
       (row) => row.reportId === reportByOrg.get(orgB.id),
     )!.id;
 
+    const [ticketA] = await admin
+      .insert(tickets)
+      .values({
+        orgId: orgA.id,
+        partnerId: partner.id,
+        ticketNumber: `A-${randomUUID()}`,
+        subject: 'A visible',
+        source: 'portal',
+      })
+      .returning({ id: tickets.id });
+    if (!ticketA) throw new Error('ticket insert failed');
+
+    await admin.insert(timeEntries).values({
+      partnerId: partner.id,
+      orgId: orgA.id,
+      ticketId: ticketA.id,
+      userId: technician.id,
+      startedAt: new Date(),
+      endedAt: new Date(),
+      durationMinutes: 45,
+      isBillable: true,
+      billingStatus: 'billed',
+      isApproved: true,
+      currencyCode: 'USD',
+    });
+
     const [ticketB] = await admin
       .insert(tickets)
       .values({
@@ -323,9 +349,13 @@ describe('portal visibility RLS', () => {
         portalUserId: portalA.id,
       });
 
-      expect(
-        Object.values(usage.totals).map((value) => value.minutes),
-      ).toEqual([0, 0, 0, 0]);
+      // Positive control: org A's own billed time entry must surface a
+      // non-zero minutes value — proving the query actually reads org A's
+      // rows, not merely that it excludes org B's.
+      expect(usage.totals.billed.minutes).toBe(45);
+      expect(usage.totals.toBeBilled.minutes).toBe(0);
+      expect(usage.totals.coveredByContract.minutes).toBe(0);
+      expect(usage.totals.pendingReview.minutes).toBe(0);
     });
   });
 

--- a/apps/api/src/__tests__/integration/portalVisibilityRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/portalVisibilityRls.integration.test.ts
@@ -359,6 +359,124 @@ describe('portal visibility RLS', () => {
     });
   });
 
+  it('resolves the month boundary in the caller-supplied timezone, not UTC', async () => {
+    const admin = getTestDb();
+    const partner = await createPartner();
+    const orgA = await createOrganization({
+      partnerId: partner.id,
+    });
+    const technician = await createUser({
+      partnerId: partner.id,
+      orgId: null,
+    });
+
+    const [portalA] = await admin
+      .insert(portalUsers)
+      .values({
+        orgId: orgA.id,
+        email: `portal-${randomUUID()}@example.test`,
+        name: 'Portal A',
+        status: 'active',
+      })
+      .returning({ id: portalUsers.id });
+    if (!portalA) throw new Error('portal user insert failed');
+
+    const [ticketAug] = await admin
+      .insert(tickets)
+      .values({
+        orgId: orgA.id,
+        partnerId: partner.id,
+        ticketNumber: `AUG-${randomUUID()}`,
+        subject: 'Straddles into August in Denver',
+        source: 'portal',
+      })
+      .returning({ id: tickets.id });
+    if (!ticketAug) throw new Error('ticket insert failed');
+
+    // 2026-09-01T03:00:00Z is 2026-08-31T21:00:00 in America/Denver
+    // (UTC-6 in summer) — belongs to the August 2026 window in Denver,
+    // but to September in UTC.
+    await admin.insert(timeEntries).values({
+      partnerId: partner.id,
+      orgId: orgA.id,
+      ticketId: ticketAug.id,
+      userId: technician.id,
+      startedAt: new Date('2026-09-01T03:00:00Z'),
+      endedAt: new Date('2026-09-01T03:30:00Z'),
+      durationMinutes: 30,
+      isBillable: true,
+      billingStatus: 'billed',
+      isApproved: true,
+      currencyCode: 'USD',
+    });
+
+    const [ticketJul] = await admin
+      .insert(tickets)
+      .values({
+        orgId: orgA.id,
+        partnerId: partner.id,
+        ticketNumber: `JUL-${randomUUID()}`,
+        subject: 'Belongs to July in Denver',
+        source: 'portal',
+      })
+      .returning({ id: tickets.id });
+    if (!ticketJul) throw new Error('ticket insert failed');
+
+    // 2026-08-01T04:00:00Z is 2026-07-31T22:00:00 in America/Denver —
+    // belongs to July in Denver (excluded from the August window), but
+    // to August in UTC.
+    await admin.insert(timeEntries).values({
+      partnerId: partner.id,
+      orgId: orgA.id,
+      ticketId: ticketJul.id,
+      userId: technician.id,
+      startedAt: new Date('2026-08-01T04:00:00Z'),
+      endedAt: new Date('2026-08-01T04:20:00Z'),
+      durationMinutes: 20,
+      isBillable: true,
+      billingStatus: 'billed',
+      isApproved: true,
+      currencyCode: 'USD',
+    });
+
+    const context: DbAccessContext = {
+      scope: 'organization',
+      orgId: orgA.id,
+      accessibleOrgIds: [orgA.id],
+      accessiblePartnerIds: [],
+      userId: null,
+      currentPartnerId: null,
+    };
+
+    await withDbAccessContext(context, async () => {
+      const denverUsage = await supportUsageForOrg({
+        orgId: orgA.id,
+        month: '2026-08',
+        timezone: 'America/Denver',
+        portalUserId: portalA.id,
+      });
+
+      // Only the entry that falls in Denver's August window counts; the
+      // one that is August only in UTC must be excluded.
+      expect(denverUsage.totals.billed.minutes).toBe(30);
+
+      const utcUsage = await supportUsageForOrg({
+        orgId: orgA.id,
+        month: '2026-08',
+        timezone: 'UTC',
+        portalUserId: portalA.id,
+      });
+
+      // Under UTC, the first entry (Sep 1 03:00Z) is September and stays
+      // excluded, while the second entry (Aug 1 04:00Z, July in Denver)
+      // is now August and included — the two calls disagree on which
+      // entry belongs to the month, which is only possible if the
+      // boundary is actually computed in the caller's timezone rather
+      // than always in UTC.
+      expect(utcUsage.totals.billed.minutes).toBe(20);
+    });
+  });
+
   it('installs every portal visibility query index', async () => {
     const expected = [
       'device_patches_org_installed_at_idx',

--- a/apps/api/src/__tests__/integration/ticketAttachmentsRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ticketAttachmentsRls.integration.test.ts
@@ -272,7 +272,7 @@ describe('portal attachment read path (REAL route, real Postgres)', () => {
   function buildPortalApp(user: { id: string; orgId: string }) {
     const app = new Hono();
     app.use('*', async (c, next) => {
-      c.set('portalAuth' as never, { user, token: 'tok', authMethod: 'bearer' } as never);
+      c.set('portalAuth' as never, { user, token: 'tok', authMethod: 'bearer', timezone: 'UTC' } as never);
       await next();
     });
     app.route('/', portalTicketRoutes);

--- a/apps/api/src/db/schema/backupVerification.ts
+++ b/apps/api/src/db/schema/backupVerification.ts
@@ -32,6 +32,8 @@ export const backupVerifications = pgTable('backup_verifications', {
 }, (table) => ({
   orgDeviceIdx: index('backup_verify_org_device_idx').on(table.orgId, table.deviceId),
   statusIdx: index('backup_verify_status_idx').on(table.status),
+  orgCompletedAtIdx: index('backup_verifications_org_completed_at_idx')
+    .on(table.orgId, table.completedAt),
 }));
 
 export const recoveryReadiness = pgTable('recovery_readiness', {

--- a/apps/api/src/db/schema/huntress.ts
+++ b/apps/api/src/db/schema/huntress.ts
@@ -114,4 +114,10 @@ export const huntressIncidents = pgTable('huntress_incidents', {
 }, (table) => ({
   incidentIdIdx: uniqueIndex('huntress_incidents_external_idx').on(table.integrationId, table.huntressIncidentId),
   orgStatusIdx: index('huntress_incidents_org_status_idx').on(table.orgId, table.status),
+  orgReportedAtIdx: index('huntress_incidents_org_reported_at_idx')
+    .on(table.orgId, table.reportedAt)
+    .where(sql`${table.reportedAt} IS NOT NULL`),
+  orgResolvedAtIdx: index('huntress_incidents_org_resolved_at_idx')
+    .on(table.orgId, table.resolvedAt)
+    .where(sql`${table.resolvedAt} IS NOT NULL`),
 }));

--- a/apps/api/src/db/schema/patches.ts
+++ b/apps/api/src/db/schema/patches.ts
@@ -215,7 +215,10 @@ export const devicePatches = pgTable('device_patches', {
   devicePatchUnique: uniqueIndex('device_patches_device_patch_unique').on(table.deviceId, table.patchId),
   userScopeIdx: index('idx_device_patches_user_scope').on(table.deviceId).where(sql`scope = 'user'`),
   // Backs the `patches.pending` device-filter field (#968).
-  pendingIdx: index('idx_device_patches_pending').on(table.deviceId).where(sql`status = 'pending'`)
+  pendingIdx: index('idx_device_patches_pending').on(table.deviceId).where(sql`status = 'pending'`),
+  orgInstalledAtIdx: index('device_patches_org_installed_at_idx')
+    .on(table.orgId, table.installedAt)
+    .where(sql`${table.status} = 'installed'`)
 }));
 
 export const patchJobs = pgTable('patch_jobs', {

--- a/apps/api/src/db/schema/security.ts
+++ b/apps/api/src/db/schema/security.ts
@@ -11,6 +11,7 @@ import {
   index,
   uniqueIndex
 } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
 import { devices } from './devices';
 import { users } from './users';
 import { organizations, partners } from './orgs';
@@ -96,7 +97,12 @@ export const securityThreats = pgTable('security_threats', {
 }, (table) => ({
   deviceDetectedIdx: index('security_threats_device_detected_idx').on(table.deviceId, table.detectedAt),
   statusIdx: index('security_threats_status_idx').on(table.status),
-  deviceStatusDetectedIdx: index('security_threats_device_status_detected_idx').on(table.deviceId, table.status, table.detectedAt)
+  deviceStatusDetectedIdx: index('security_threats_device_status_detected_idx').on(table.deviceId, table.status, table.detectedAt),
+  orgDetectedAtIdx: index('security_threats_org_detected_at_idx')
+    .on(table.orgId, table.detectedAt),
+  orgResolvedAtIdx: index('security_threats_org_resolved_at_idx')
+    .on(table.orgId, table.resolvedAt)
+    .where(sql`${table.resolvedAt} IS NOT NULL`)
 }));
 
 export const securityScans = pgTable('security_scans', {

--- a/apps/api/src/db/schema/sentinelOne.ts
+++ b/apps/api/src/db/schema/sentinelOne.ts
@@ -81,7 +81,13 @@ export const s1Threats = pgTable('s1_threats', {
   orgSeverityStatusIdx: index('s1_threats_org_severity_status_idx').on(table.orgId, table.severity, table.status),
   integrationIdx: index('s1_threats_integration_idx').on(table.integrationId),
   integrationDetectedIdx: index('s1_threats_integration_detected_idx').on(table.integrationId, table.detectedAt),
-  deviceIdx: index('s1_threats_device_idx').on(table.deviceId)
+  deviceIdx: index('s1_threats_device_idx').on(table.deviceId),
+  orgDetectedAtIdx: index('s1_threats_org_detected_at_idx')
+    .on(table.orgId, table.detectedAt)
+    .where(sql`${table.detectedAt} IS NOT NULL`),
+  orgResolvedAtIdx: index('s1_threats_org_resolved_at_idx')
+    .on(table.orgId, table.resolvedAt)
+    .where(sql`${table.resolvedAt} IS NOT NULL`)
 }));
 
 export const s1Actions = pgTable('s1_actions', {

--- a/apps/api/src/db/schema/timeTracking.ts
+++ b/apps/api/src/db/schema/timeTracking.ts
@@ -52,7 +52,10 @@ export const timeEntries = pgTable('time_entries', {
   uniqueIndex('time_entries_one_running_per_user_uq').on(t.userId).where(sqlIsRunning(t)),
   index('time_entries_partner_started_idx').on(t.partnerId, t.startedAt),
   index('time_entries_ticket_idx').on(t.ticketId),
-  index('time_entries_user_started_idx').on(t.userId, t.startedAt)
+  index('time_entries_user_started_idx').on(t.userId, t.startedAt),
+  index('time_entries_org_started_at_idx')
+    .on(t.orgId, t.startedAt)
+    .where(sql`${t.orgId} IS NOT NULL`)
 ]);
 
 export const ticketParts = pgTable('ticket_parts', {

--- a/apps/api/src/jobs/reportScheduleWorker.ts
+++ b/apps/api/src/jobs/reportScheduleWorker.ts
@@ -47,8 +47,6 @@ import { getEmailService } from '../services/email';
 import { renderLayout, renderButton, renderParagraph, escapeHtml } from '../services/emailLayout';
 import { getBullMQConnection, isRedisAvailable } from '../services/redis';
 import {
-  resolveEffectiveTimezone,
-  canonicalizeTimezone,
   rowsToCsv,
   lastOccurrenceKey,
   isDue,
@@ -58,6 +56,10 @@ import {
 import { buildReportPdf, type ReportBranding } from '@breeze/shared/reportPdf';
 import type { PostureSummary, ExecutiveSummary } from '@breeze/shared';
 import { loadReportBrandingForOrg } from '../services/reportBranding';
+import {
+  resolveOrgTimezone,
+  resolveTimezoneFromRows,
+} from '../services/portal/timezone';
 import { captureException } from '../services/sentry';
 import { attachWorkerObservability } from './workerObservability';
 import {
@@ -118,35 +120,6 @@ type DueCandidate = {
 function scheduleConfigOf(config: Record<string, unknown>): ScheduleConfig {
   const raw = config.schedule;
   return raw && typeof raw === 'object' ? (raw as ScheduleConfig) : {};
-}
-
-// Org -> partner -> UTC timezone chain (no site axis for org-level reports),
-// same source-of-truth rules as featureConfigResolver's partnerTimezoneFrom.
-function timezoneFor(
-  orgSettings: unknown,
-  partnerTzColumn: string | null,
-  partnerSettings: unknown,
-): string {
-  const orgTz =
-    orgSettings && typeof orgSettings === 'object'
-      ? (orgSettings as Record<string, unknown>).timezone
-      : null;
-  const partnerColumn = canonicalizeTimezone(partnerTzColumn);
-  const partnerFromSettings =
-    partnerSettings && typeof partnerSettings === 'object'
-      ? (partnerSettings as Record<string, unknown>).timezone
-      : null;
-  const partnerTz =
-    partnerColumn !== null && partnerColumn !== 'UTC'
-      ? partnerColumn
-      : typeof partnerFromSettings === 'string' && partnerFromSettings.length > 0
-        ? partnerFromSettings
-        : partnerColumn;
-  return resolveEffectiveTimezone({
-    siteTz: null,
-    orgTz: typeof orgTz === 'string' ? orgTz : null,
-    partnerTz,
-  });
 }
 
 /**
@@ -225,7 +198,7 @@ export async function findDueReports(
       schedule: row.schedule as ScheduleCadence,
       lastGeneratedAt: row.lastGeneratedAt,
       config: (row.config ?? {}) as Record<string, unknown>,
-      timeZone: timezoneFor(row.orgSettings, row.partnerTimezone, row.partnerSettings),
+      timeZone: resolveTimezoneFromRows(row.orgSettings, row.partnerTimezone, row.partnerSettings),
     };
     const key = lastOccurrenceKey(now, candidate.schedule, scheduleConfigOf(candidate.config), candidate.timeZone);
     if (isDue(candidate.lastGeneratedAt, key, candidate.timeZone)) {
@@ -622,13 +595,7 @@ export async function processRunScheduledReport(
         // transient failure in either lookup can't sink a no-recipient run's
         // occurrence-keyed job (a failed job blocks re-enqueue of that
         // occurrence, and by this point the run row is already stored).
-        const [tzRow] = await db
-          .select({ orgSettings: organizations.settings, partnerTimezone: partners.timezone, partnerSettings: partners.settings })
-          .from(organizations)
-          .leftJoin(partners, eq(organizations.partnerId, partners.id))
-          .where(eq(organizations.id, report.orgId))
-          .limit(1);
-        const timeZone = timezoneFor(tzRow?.orgSettings ?? null, tzRow?.partnerTimezone ?? null, tzRow?.partnerSettings ?? null);
+        const timeZone = await resolveOrgTimezone(report.orgId);
         const branding = await loadReportBrandingForOrg(report.orgId).catch((err) => {
           console.error('[ReportScheduleWorker] Branding load failed; sending unbranded:', err);
           return { name: null, logoDataUrl: null, logoAspect: null };

--- a/apps/api/src/routes/portal.compat.test.ts
+++ b/apps/api/src/routes/portal.compat.test.ts
@@ -48,6 +48,17 @@ vi.mock('../services/tenantStatus', () => ({
   getActiveOrgTenant: vi.fn(async (orgId: string) => ({ orgId, partnerId: 'partner-1' })),
 }));
 
+// portalAuthMiddleware resolves the org's timezone once during hydration
+// (services/portal/timezone.ts) via a real DB left-join query this suite's
+// generic `../db` mock cannot satisfy, and `../db/schema` here doesn't export
+// `organizations`/`partners` at all. Mock the resolver BOUNDARY, same pattern
+// as the tenantStatus mock immediately above — the resolver itself is covered
+// directly by `services/portal/timezone.test.ts` and the hydration contract by
+// `routes/portal/authOrgStatusGate.test.ts`.
+vi.mock('../services/portal/timezone', () => ({
+  resolveOrgTimezone: vi.fn(async () => 'UTC'),
+}));
+
 vi.mock('../db/schema', () => ({
   assetCheckouts: {},
   devices: {},

--- a/apps/api/src/routes/portal.test.ts
+++ b/apps/api/src/routes/portal.test.ts
@@ -67,6 +67,17 @@ vi.mock('../services/tenantStatus', () => ({
   getActiveOrgTenant: vi.fn(async (orgId: string) => ({ orgId, partnerId: 'partner-1' })),
 }));
 
+// portalAuthMiddleware resolves the org's timezone once during hydration
+// (services/portal/timezone.ts) via a real DB left-join query this suite's
+// generic `../db` mock cannot satisfy, and `../db/schema` here doesn't export
+// `organizations`/`partners` at all. Mock the resolver BOUNDARY, same pattern
+// as the tenantStatus mock immediately above — the resolver itself is covered
+// directly by `services/portal/timezone.test.ts` and the hydration contract by
+// `routes/portal/authOrgStatusGate.test.ts`.
+vi.mock('../services/portal/timezone', () => ({
+  resolveOrgTimezone: vi.fn(async () => 'UTC'),
+}));
+
 vi.mock('../services/ticketService', () => ({
   createTicket: createTicketMock,
   TicketServiceError: class TicketServiceError extends Error {

--- a/apps/api/src/routes/portal/auth.ts
+++ b/apps/api/src/routes/portal/auth.ts
@@ -11,6 +11,7 @@ import { getEmailService } from '../../services/email';
 import { getRedis } from '../../services/redis';
 import { getActiveOrgTenant } from '../../services/tenantStatus';
 import { rateLimitIpKey } from '../../services/clientIp';
+import { resolveOrgTimezone } from '../../services/portal/timezone';
 import {
   loginSchema,
   forgotPasswordSchema,
@@ -120,8 +121,8 @@ export async function portalAuthMiddleware(c: Context, next: Next) {
   // but the portal_users row lives behind org-forced RLS. Run this lookup
   // under system scope so it resolves under the unprivileged breeze_app pool —
   // the same pattern authMiddleware uses for its pre-auth users lookup.
-  const [user] = await withSystemDbAccessContext(() =>
-    db
+  const { user, timezone } = await withSystemDbAccessContext(async () => {
+    const [user] = await db
       .select({
         id: portalUsers.id,
         orgId: portalUsers.orgId,
@@ -138,8 +139,18 @@ export async function portalAuthMiddleware(c: Context, next: Next) {
       })
       .from(portalUsers)
       .where(and(eq(portalUsers.id, sessionData.portalUserId), eq(portalUsers.orgId, sessionData.orgId)))
-      .limit(1)
-  );
+      .limit(1);
+
+    return {
+      user,
+      // Resolved here (not per-route/per-read-model) so every portal read
+      // model can consume `auth.timezone` without its own DB round trip —
+      // see services/portal/timezone.ts.
+      timezone: user
+        ? await resolveOrgTimezone(sessionData.orgId)
+        : null,
+    };
+  });
 
   if (!user) {
     if (PORTAL_USE_REDIS) {
@@ -214,7 +225,7 @@ export async function portalAuthMiddleware(c: Context, next: Next) {
     setPortalSessionCookies(c, token);
   }
 
-  c.set('portalAuth', { user, token, authMethod });
+  c.set('portalAuth', { user, token, authMethod, timezone: timezone ?? 'UTC' });
 
   // #1448 — a small set of routes (the Stripe pay route) opt OUT of the auto
   // request-transaction so a slow outbound HTTP call (Checkout sessions.create)

--- a/apps/api/src/routes/portal/authOrgStatusGate.test.ts
+++ b/apps/api/src/routes/portal/authOrgStatusGate.test.ts
@@ -21,6 +21,14 @@ const { portalUserRow, activeOrgResult } = vi.hoisted(() => ({
   activeOrgResult: { current: null as { orgId: string; partnerId: string } | null },
 }));
 
+const resolveOrgTimezone = vi.hoisted(() =>
+  vi.fn(async () => 'UTC'),
+);
+
+vi.mock('../../services/portal/timezone', () => ({
+  resolveOrgTimezone,
+}));
+
 // The select mock APPLIES the projection rather than echoing the whole fixture
 // row. Without that, `select({ id, orgId, ... })` is unobservable and any
 // assertion about which columns the middleware hydrates is vacuous — deleting
@@ -88,7 +96,11 @@ function makeApp() {
   // portal ticket read is `submitted_by = me OR requester_contact_id = my
   // contact`, so an un-hydrated contactId is a silently narrowed query, not a
   // type error.
-  app.get('/protected', (c) => c.json({ ok: true, user: c.get('portalAuth').user }));
+  app.get('/protected', (c) => c.json({
+    ok: true,
+    user: c.get('portalAuth').user,
+    timezone: c.get('portalAuth').timezone,
+  }));
   return app;
 }
 
@@ -128,6 +140,18 @@ describe('portalAuthMiddleware org-status gate', () => {
     expect(getActiveOrgTenant).toHaveBeenCalledWith(ORG_ID);
     // A passing gate must not disturb the session.
     expect(portalSessions.has(TOKEN)).toBe(true);
+  });
+
+  it('hydrates the organization timezone exactly once into portalAuth', async () => {
+    resolveOrgTimezone.mockResolvedValue('America/Denver');
+    seedSession();
+
+    const res = await call();
+
+    expect(res.status).toBe(200);
+    expect((await res.json() as { timezone: string }).timezone).toBe('America/Denver');
+    expect(resolveOrgTimezone).toHaveBeenCalledTimes(1);
+    expect(resolveOrgTimezone).toHaveBeenCalledWith(ORG_ID);
   });
 
   it("rejects a session whose org is fenced for a merge ('merging')", async () => {

--- a/apps/api/src/routes/portal/invoices.test.ts
+++ b/apps/api/src/routes/portal/invoices.test.ts
@@ -102,6 +102,7 @@ function app(orgId = ORG_ID, authMethod: 'bearer' | 'cookie' = 'bearer') {
       // do not read it, so the null (contact-less login) case is stated.
       user: { id: 'pu1', orgId, email: 'c@example.test', name: 'Cust', contactId: null, receiveNotifications: true, status: 'active' },
       token: 't', authMethod,
+      timezone: 'UTC',
     });
     await next();
   });

--- a/apps/api/src/routes/portal/quotes.test.ts
+++ b/apps/api/src/routes/portal/quotes.test.ts
@@ -80,6 +80,7 @@ function app(orgId = ORG_ID, options: { authMethod?: 'bearer' | 'cookie'; email?
       // do not read it, so the null (contact-less login) case is stated.
       user: { id: 'pu1', orgId, email: options.email ?? 'c@example.test', name: 'Cust', contactId: null, receiveNotifications: true, status: 'active' },
       token: 't', authMethod: options.authMethod ?? 'bearer',
+      timezone: 'UTC',
     });
     await next();
   });

--- a/apps/api/src/routes/portal/schemas.ts
+++ b/apps/api/src/routes/portal/schemas.ts
@@ -39,6 +39,12 @@ export type PortalAuthContext = {
   };
   token: string;
   authMethod: 'bearer' | 'cookie';
+  /**
+   * Org -> partner -> UTC timezone chain, resolved once by
+   * `portalAuthMiddleware` (`services/portal/timezone.ts`). Read models must
+   * never resolve this themselves — they consume `auth.timezone`.
+   */
+  timezone: string;
 };
 
 declare module 'hono' {

--- a/apps/api/src/routes/portal/tickets.test.ts
+++ b/apps/api/src/routes/portal/tickets.test.ts
@@ -143,7 +143,7 @@ function compileWhere(args: unknown[]): { sql: string; params: unknown[] } {
 function buildApp(user: Record<string, unknown> = PORTAL_USER) {
   const app = new Hono();
   app.use('*', async (c, next) => {
-    c.set('portalAuth' as never, { user, token: 'tok-1', authMethod: 'bearer' });
+    c.set('portalAuth' as never, { user, token: 'tok-1', authMethod: 'bearer', timezone: 'UTC' });
     await next();
   });
   app.route('/', ticketRoutes);
@@ -508,7 +508,7 @@ describe('GET /tickets/forms — index.ts mount wiring', () => {
       if (!c.req.header('Authorization')) {
         return c.json({ error: 'Authentication required' }, 401);
       }
-      c.set('portalAuth' as never, { user: PORTAL_USER, token: 'tok-1', authMethod: 'bearer' });
+      c.set('portalAuth' as never, { user: PORTAL_USER, token: 'tok-1', authMethod: 'bearer', timezone: 'UTC' });
       await next();
     });
     app.route('/', ticketRoutes);
@@ -574,7 +574,7 @@ const CREATED_TICKET = {
 function buildPostApp() {
   const app = new Hono();
   app.use('*', async (c, next) => {
-    c.set('portalAuth' as never, { user: PORTAL_USER, token: 'tok-1', authMethod: 'bearer' });
+    c.set('portalAuth' as never, { user: PORTAL_USER, token: 'tok-1', authMethod: 'bearer', timezone: 'UTC' });
     await next();
   });
   app.route('/', ticketRoutes);
@@ -971,7 +971,7 @@ describe('portalTicketsEnabledMiddleware — enable_tickets gate (#2345)', () =>
   function buildGatedApp() {
     const app = new Hono();
     app.use('/tickets/*', async (c, next) => {
-      c.set('portalAuth' as never, { user: PORTAL_USER, token: 'tok-1', authMethod: 'bearer' });
+      c.set('portalAuth' as never, { user: PORTAL_USER, token: 'tok-1', authMethod: 'bearer', timezone: 'UTC' });
       await next();
     });
     app.use('/tickets/*', portalTicketsEnabledMiddleware);

--- a/apps/api/src/services/portal/protection.test.ts
+++ b/apps/api/src/services/portal/protection.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import type { securityStatus as securityStatusTable } from '../../db/schema';
+import { classifyDeviceProtection } from './protection';
+
+type SecurityProvider = (typeof securityStatusTable.$inferSelect)['provider'];
+
+function status(
+  overrides: Partial<{
+    provider: SecurityProvider;
+    realTimeProtection: boolean | null;
+  }> = {},
+) {
+  return {
+    provider: 'windows_defender' as const,
+    realTimeProtection: true,
+    ...overrides,
+  };
+}
+
+describe('classifyDeviceProtection', () => {
+  it.each([
+    {
+      name: 'S1 agent takes precedence over an absent status row',
+      securityStatus: null,
+      hasS1Agent: true,
+      hasHuntressAgent: false,
+      expected: 'protected',
+    },
+    {
+      name: 'absent row is unknown',
+      securityStatus: null,
+      hasS1Agent: false,
+      hasHuntressAgent: false,
+      expected: 'unknown',
+    },
+    {
+      name: 'stale Defender with RTP on remains protected',
+      securityStatus: status(),
+      hasS1Agent: false,
+      hasHuntressAgent: false,
+      observedAt: new Date('2026-07-04T12:00:00.000Z'),
+      expected: 'protected',
+    },
+    {
+      name: 'fresh provider other is unprotected',
+      securityStatus: status({ provider: 'other' }),
+      hasS1Agent: false,
+      hasHuntressAgent: false,
+      observedAt: new Date('2026-09-02T12:00:00.000Z'),
+      expected: 'unprotected',
+    },
+    {
+      name: 'RTP null is unprotected',
+      securityStatus: status({ realTimeProtection: null }),
+      hasS1Agent: false,
+      hasHuntressAgent: false,
+      expected: 'unprotected',
+    },
+  ])('$name', ({ expected, securityStatus, hasS1Agent, hasHuntressAgent }) => {
+    expect(classifyDeviceProtection({
+      securityStatus,
+      hasS1Agent,
+      hasHuntressAgent,
+    })).toBe(expected);
+  });
+
+  it.each([
+    ['base dev-1 managed Huntress', status(), false, true, 'protected', 'protected'],
+    ['base dev-2 other/RTP-off', status({ provider: 'other', realTimeProtection: false }), false, false, 'unprotected', 'unprotected'],
+    ['base dev-3 absent', null, false, false, 'unknown', 'unprotected'],
+    ['Elastic Defend RTP-on', status({ provider: 'elastic_defend' }), false, false, 'protected', 'protected'],
+    ['fresh Defender', status(), false, false, 'protected', 'protected'],
+    ['60-day stale Defender', status(), false, false, 'protected', 'protected'],
+    ['10-day Defender under seven-day maximum', status(), false, false, 'protected', 'protected'],
+    ['assessed Defender', status(), false, false, 'protected', 'protected'],
+    ['assessed-set stale Defender', status(), false, false, 'protected', 'protected'],
+    ['assessed-set absent row', null, false, false, 'unknown', 'unprotected'],
+    ['exact 30-day cutoff', status(), false, false, 'protected', 'protected'],
+    ['31 days past cutoff', status(), false, false, 'protected', 'protected'],
+    ['missing updatedAt legacy row', status(), false, false, 'protected', 'protected'],
+    ['inventory other/RTP-off', status({ provider: 'other', realTimeProtection: false }), false, false, 'unprotected', 'unprotected'],
+    ['SentinelOne managed row', status({ provider: 'sentinelone' }), true, false, 'protected', 'protected'],
+    ['native Defender row', status(), false, false, 'protected', 'protected'],
+    ['other provider with RTP on', status({ provider: 'other' }), false, false, 'unprotected', 'unprotected'],
+    ['CrowdStrike with RTP off', status({ provider: 'crowdstrike', realTimeProtection: false }), false, false, 'unprotected', 'unprotected'],
+    ['coverage dev-1 Defender', status(), false, false, 'protected', 'protected'],
+    ['coverage dev-2 Defender', status(), false, false, 'protected', 'protected'],
+    ['coverage dev-3 Defender', status(), false, false, 'protected', 'protected'],
+    ['coverage dev-4 Defender', status(), false, false, 'protected', 'protected'],
+    ['coverage dev-5 managed SentinelOne', status({ provider: 'sentinelone' }), true, false, 'protected', 'protected'],
+    ['coverage dev-6 managed SentinelOne/RTP-off', status({ provider: 'sentinelone', realTimeProtection: false }), true, false, 'protected', 'protected'],
+  ] as const)(
+    'matches report fixture %s and its existing report bucket',
+    (_, securityStatus, hasS1Agent, hasHuntressAgent, expected, reportBucket) => {
+      const actual = classifyDeviceProtection({
+        securityStatus,
+        hasS1Agent,
+        hasHuntressAgent,
+      });
+
+      expect(actual).toBe(expected);
+      expect(actual === 'protected' ? 'protected' : 'unprotected')
+        .toBe(reportBucket);
+    },
+  );
+});

--- a/apps/api/src/services/portal/protection.ts
+++ b/apps/api/src/services/portal/protection.ts
@@ -1,11 +1,9 @@
 import type { securityStatus } from '../../db/schema';
+import type { ProtectionState } from '@breeze/shared';
+
+export type { ProtectionState };
 
 type SecurityProvider = (typeof securityStatus.$inferSelect)['provider'];
-
-export type ProtectionState =
-  | 'protected'
-  | 'unprotected'
-  | 'unknown';
 
 /**
  * Direct extraction of the posture report's device-protection rule

--- a/apps/api/src/services/portal/protection.ts
+++ b/apps/api/src/services/portal/protection.ts
@@ -1,0 +1,39 @@
+import type { securityStatus } from '../../db/schema';
+
+type SecurityProvider = (typeof securityStatus.$inferSelect)['provider'];
+
+export type ProtectionState =
+  | 'protected'
+  | 'unprotected'
+  | 'unknown';
+
+/**
+ * Direct extraction of the posture report's device-protection rule
+ * (`securityComplianceReport.ts`). Either managed-agent table (SentinelOne or
+ * Huntress) takes precedence over status-row presence and native AV state. An
+ * absent `security_status` row is 'unknown' — the caller decides how to bucket
+ * that (the posture report folds it into "unprotected" to preserve its
+ * existing public contract). Deliberately does NOT consume `updatedAt`, `now`,
+ * or `maxSecurityStatusAgeDays`: this rule has no freshness gate.
+ */
+export function classifyDeviceProtection(input: {
+  securityStatus: {
+    provider: SecurityProvider;
+    realTimeProtection: boolean | null;
+  } | null;
+  hasS1Agent: boolean;
+  hasHuntressAgent: boolean;
+}): ProtectionState {
+  if (input.hasS1Agent || input.hasHuntressAgent) {
+    return 'protected';
+  }
+
+  if (input.securityStatus === null) {
+    return 'unknown';
+  }
+
+  return input.securityStatus.provider !== 'other' &&
+    input.securityStatus.realTimeProtection === true
+    ? 'protected'
+    : 'unprotected';
+}

--- a/apps/api/src/services/portal/supportUsage.test.ts
+++ b/apps/api/src/services/portal/supportUsage.test.ts
@@ -105,6 +105,20 @@ describe('supportUsageForOrg', () => {
     expect(where.params).toContain(args.orgId);
   });
 
+  it('compares the naive started_at column against the timezone-aware boundary via AT TIME ZONE', async () => {
+    await supportUsageForOrg(args);
+
+    const dialect = new PgDialect();
+    const where = dialect.sqlToQuery(state.where as SQL);
+
+    // time_entries.started_at is `timestamp` (no tz). Comparing it directly
+    // to make_timestamptz(...) would coerce through the session TimeZone GUC
+    // (which the app never sets) instead of the caller's requested timezone.
+    expect(where.sql).toContain(
+      '"time_entries"."started_at" AT TIME ZONE \'UTC\'',
+    );
+  });
+
   it('rejects an invalid month before querying', async () => {
     await expect(supportUsageForOrg({
       ...args,

--- a/apps/api/src/services/portal/supportUsage.test.ts
+++ b/apps/api/src/services/portal/supportUsage.test.ts
@@ -6,23 +6,27 @@ const state = vi.hoisted(() => ({
   rows: [] as Record<string, unknown>[],
   join: undefined as SQL | undefined,
   where: undefined as SQL | undefined,
+  columns: undefined as Record<string, unknown> | undefined,
 }));
 
 vi.mock('../../db', () => ({
   db: {
-    select: vi.fn(() => ({
-      from: vi.fn(() => ({
-        innerJoin: vi.fn((_table, join: SQL) => {
-          state.join = join;
-          return {
-            where: vi.fn(async (where: SQL) => {
-              state.where = where;
-              return state.rows;
-            }),
-          };
-        }),
-      })),
-    })),
+    select: vi.fn((columns: Record<string, unknown>) => {
+      state.columns = columns;
+      return {
+        from: vi.fn(() => ({
+          innerJoin: vi.fn((_table, join: SQL) => {
+            state.join = join;
+            return {
+              where: vi.fn(async (where: SQL) => {
+                state.where = where;
+                return state.rows;
+              }),
+            };
+          }),
+        })),
+      };
+    }),
   },
   runOutsideDbContext: vi.fn(async (
     fn: () => Promise<unknown>,
@@ -48,6 +52,7 @@ describe('supportUsageForOrg', () => {
     state.rows = [];
     state.join = undefined;
     state.where = undefined;
+    state.columns = undefined;
   });
 
   it('places minutes into the four approved buckets', async () => {
@@ -103,6 +108,22 @@ describe('supportUsageForOrg', () => {
     expect(join.params).toContain(args.orgId);
     expect(where.sql).toContain('"time_entries"."org_id" = $');
     expect(where.params).toContain(args.orgId);
+  });
+
+  it('binds portalUserId into the compiled title-mask CASE expression', async () => {
+    await supportUsageForOrg(args);
+
+    const dialect = new PgDialect();
+    const title = dialect.sqlToQuery(
+      (state.columns as { title: SQL }).title,
+    );
+
+    // The title is only revealed when the ticket was submitted by the
+    // requesting portal user — dropping the portalUserId binding would
+    // leak every ticket's subject (or mask every one), so the compiled
+    // SQL must reference submitted_by and actually bind portalUserId.
+    expect(title.sql).toContain('"tickets"."submitted_by" = $');
+    expect(title.params).toContain(args.portalUserId);
   });
 
   it('compares the naive started_at column against the timezone-aware boundary via AT TIME ZONE', async () => {

--- a/apps/api/src/services/portal/supportUsage.test.ts
+++ b/apps/api/src/services/portal/supportUsage.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+
+const state = vi.hoisted(() => ({
+  rows: [] as Record<string, unknown>[],
+  join: undefined as SQL | undefined,
+  where: undefined as SQL | undefined,
+}));
+
+vi.mock('../../db', () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        innerJoin: vi.fn((_table, join: SQL) => {
+          state.join = join;
+          return {
+            where: vi.fn(async (where: SQL) => {
+              state.where = where;
+              return state.rows;
+            }),
+          };
+        }),
+      })),
+    })),
+  },
+  runOutsideDbContext: vi.fn(async (
+    fn: () => Promise<unknown>,
+  ) => fn()),
+  withSystemDbAccessContext: vi.fn(async (
+    fn: () => Promise<unknown>,
+  ) => fn()),
+}));
+
+import {
+  supportUsageForOrg,
+} from './supportUsage';
+
+const args = {
+  orgId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+  month: '2026-09',
+  timezone: 'America/Denver',
+  portalUserId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+};
+
+describe('supportUsageForOrg', () => {
+  beforeEach(() => {
+    state.rows = [];
+    state.join = undefined;
+    state.where = undefined;
+  });
+
+  it('places minutes into the four approved buckets', async () => {
+    state.rows = [
+      {
+        ticketNumber: 'T-1',
+        title: 'Visible',
+        durationMinutes: 15,
+        billingStatus: 'billed',
+        isApproved: true,
+      },
+      {
+        ticketNumber: 'T-2',
+        title: null,
+        durationMinutes: 30,
+        billingStatus: 'not_billed',
+        isApproved: true,
+      },
+      {
+        ticketNumber: 'T-3',
+        title: null,
+        durationMinutes: 45,
+        billingStatus: 'contract',
+        isApproved: true,
+      },
+      {
+        ticketNumber: 'T-4',
+        title: null,
+        durationMinutes: 60,
+        billingStatus: 'not_billed',
+        isApproved: false,
+      },
+    ];
+
+    const result = await supportUsageForOrg(args);
+
+    expect(result.totals).toEqual({
+      billed: { minutes: 15, hours: 0.25 },
+      toBeBilled: { minutes: 30, hours: 0.5 },
+      coveredByContract: { minutes: 45, hours: 0.75 },
+      pendingReview: { minutes: 60, hours: 1 },
+    });
+  });
+
+  it('contains both organization predicates in compiled SQL', async () => {
+    await supportUsageForOrg(args);
+
+    const dialect = new PgDialect();
+    const join = dialect.sqlToQuery(state.join as SQL);
+    const where = dialect.sqlToQuery(state.where as SQL);
+
+    expect(join.sql).toContain('"tickets"."org_id" = $');
+    expect(join.params).toContain(args.orgId);
+    expect(where.sql).toContain('"time_entries"."org_id" = $');
+    expect(where.params).toContain(args.orgId);
+  });
+
+  it('rejects an invalid month before querying', async () => {
+    await expect(supportUsageForOrg({
+      ...args,
+      month: 'September',
+    })).rejects.toThrow('month must use YYYY-MM');
+  });
+});

--- a/apps/api/src/services/portal/supportUsage.ts
+++ b/apps/api/src/services/portal/supportUsage.ts
@@ -1,0 +1,145 @@
+import type { SupportUsageDto } from '@breeze/shared';
+import {
+  and,
+  eq,
+  isNotNull,
+  isNull,
+  ne,
+  sql,
+} from 'drizzle-orm';
+import {
+  db,
+  runOutsideDbContext,
+  withSystemDbAccessContext,
+} from '../../db';
+import { tickets, timeEntries } from '../../db/schema';
+
+type UsageRow = {
+  ticketNumber: string;
+  title: string | null;
+  durationMinutes: number | null;
+  billingStatus:
+    | 'not_billed'
+    | 'billed'
+    | 'no_charge'
+    | 'contract';
+  isApproved: boolean;
+};
+
+function amount(minutes: number) {
+  return {
+    minutes,
+    hours: minutes / 60,
+  };
+}
+
+export async function supportUsageForOrg(args: {
+  orgId: string;
+  month: string;
+  timezone: string;
+  portalUserId: string;
+}): Promise<SupportUsageDto> {
+  if (!/^\d{4}-(0[1-9]|1[0-2])$/.test(args.month)) {
+    throw new Error('month must use YYYY-MM');
+  }
+
+  const [year, month] = args.month.split('-').map(Number);
+  const start = sql`make_timestamptz(
+    ${year},
+    ${month},
+    1,
+    0,
+    0,
+    0,
+    ${args.timezone}
+  )`;
+  const end = sql`${start} + interval '1 month'`;
+
+  const rows = await runOutsideDbContext(() =>
+    withSystemDbAccessContext(() =>
+      db
+        .select({
+          ticketNumber: tickets.ticketNumber,
+          title: sql<string | null>`
+            CASE
+              WHEN ${tickets.submittedBy} = ${args.portalUserId}
+              THEN ${tickets.subject}
+              ELSE NULL
+            END
+          `,
+          durationMinutes: timeEntries.durationMinutes,
+          billingStatus: timeEntries.billingStatus,
+          isApproved: timeEntries.isApproved,
+        })
+        .from(timeEntries)
+        .innerJoin(
+          tickets,
+          and(
+            eq(tickets.id, timeEntries.ticketId),
+            eq(tickets.orgId, args.orgId),
+          ),
+        )
+        .where(and(
+          eq(timeEntries.orgId, args.orgId),
+          isNotNull(timeEntries.ticketId),
+          eq(timeEntries.isBillable, true),
+          ne(timeEntries.billingStatus, 'no_charge'),
+          isNull(tickets.deletedAt),
+          sql`${timeEntries.startedAt} >= ${start}`,
+          sql`${timeEntries.startedAt} < ${end}`,
+        )) as Promise<UsageRow[]>,
+    ),
+  );
+
+  let billed = 0;
+  let toBeBilled = 0;
+  let coveredByContract = 0;
+  let pendingReview = 0;
+
+  const ticketsByNumber = new Map<
+    string,
+    SupportUsageDto['tickets'][number]
+  >();
+
+  for (const row of rows) {
+    const minutes = row.durationMinutes ?? 0;
+    const ticket = ticketsByNumber.get(row.ticketNumber) ?? {
+      ticketNumber: row.ticketNumber,
+      title: row.title,
+      billedMinutes: 0,
+      toBeBilledMinutes: 0,
+      coveredByContractMinutes: 0,
+      pendingReviewMinutes: 0,
+    };
+
+    if (!row.isApproved) {
+      pendingReview += minutes;
+      ticket.pendingReviewMinutes += minutes;
+    } else if (row.billingStatus === 'billed') {
+      billed += minutes;
+      ticket.billedMinutes += minutes;
+    } else if (row.billingStatus === 'contract') {
+      coveredByContract += minutes;
+      ticket.coveredByContractMinutes += minutes;
+    } else {
+      toBeBilled += minutes;
+      ticket.toBeBilledMinutes += minutes;
+    }
+
+    ticketsByNumber.set(row.ticketNumber, ticket);
+  }
+
+  return {
+    dataStatus: rows.length > 0 ? 'ok' : 'no_data',
+    asOf: new Date().toISOString(),
+    month: args.month,
+    timezone: args.timezone,
+    totals: {
+      billed: amount(billed),
+      toBeBilled: amount(toBeBilled),
+      coveredByContract: amount(coveredByContract),
+      pendingReview: amount(pendingReview),
+    },
+    tickets: [...ticketsByNumber.values()],
+  };
+}

--- a/apps/api/src/services/portal/supportUsage.ts
+++ b/apps/api/src/services/portal/supportUsage.ts
@@ -85,8 +85,8 @@ export async function supportUsageForOrg(args: {
           eq(timeEntries.isBillable, true),
           ne(timeEntries.billingStatus, 'no_charge'),
           isNull(tickets.deletedAt),
-          sql`${timeEntries.startedAt} >= ${start}`,
-          sql`${timeEntries.startedAt} < ${end}`,
+          sql`${timeEntries.startedAt} AT TIME ZONE 'UTC' >= ${start}`,
+          sql`${timeEntries.startedAt} AT TIME ZONE 'UTC' < ${end}`,
         )) as Promise<UsageRow[]>,
     ),
   );
@@ -112,6 +112,10 @@ export async function supportUsageForOrg(args: {
       pendingReviewMinutes: 0,
     };
 
+    // Bucket precedence: an unapproved entry always lands in pendingReview,
+    // regardless of its billingStatus — approval gates billed/contract/
+    // toBeBilled classification, so those three are only considered once a
+    // row is approved.
     if (!row.isApproved) {
       pendingReview += minutes;
       ticket.pendingReviewMinutes += minutes;

--- a/apps/api/src/services/portal/timezone.test.ts
+++ b/apps/api/src/services/portal/timezone.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+
+const state = vi.hoisted(() => ({
+  rows: [] as Record<string, unknown>[],
+  where: undefined as SQL | undefined,
+}));
+
+vi.mock('../../db', () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        leftJoin: vi.fn(() => ({
+          where: vi.fn((where: SQL) => {
+            state.where = where;
+            return {
+              limit: vi.fn(async () => state.rows),
+            };
+          }),
+        })),
+      })),
+    })),
+  },
+}));
+
+import {
+  resolveOrgTimezone,
+  resolveTimezoneFromRows,
+} from './timezone';
+
+describe('portal timezone resolution', () => {
+  beforeEach(() => {
+    state.rows = [];
+    state.where = undefined;
+  });
+
+  it.each([
+    [{ timezone: 'America/Denver' }, 'Europe/Berlin', { timezone: 'Asia/Tokyo' }, 'America/Denver'],
+    [{}, 'Europe/Berlin', { timezone: 'Asia/Tokyo' }, 'Europe/Berlin'],
+    [{}, 'UTC', { timezone: 'Asia/Tokyo' }, 'Asia/Tokyo'],
+    [{}, 'utc', {}, 'UTC'],
+    [{ timezone: 'not/a-zone' }, 'not/a-zone', { timezone: 'Asia/Tokyo' }, 'Asia/Tokyo'],
+    [null, null, null, 'UTC'],
+  ])(
+    'uses the worker precedence with canonicalization and validation',
+    (orgSettings, partnerTimezone, partnerSettings, expected) => {
+      expect(resolveTimezoneFromRows(
+        orgSettings,
+        partnerTimezone,
+        partnerSettings,
+      )).toBe(expected);
+    },
+  );
+
+  it('queries the requested organization with a left join', async () => {
+    state.rows = [{
+      orgSettings: {},
+      partnerTimezone: 'UTC',
+      partnerSettings: {},
+    }];
+
+    await expect(resolveOrgTimezone(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    )).resolves.toBe('UTC');
+
+    const query = new PgDialect().sqlToQuery(state.where as SQL);
+    expect(query.sql).toContain(
+      '"organizations"."id" = $1',
+    );
+    expect(query.params).toEqual([
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    ]);
+  });
+});

--- a/apps/api/src/services/portal/timezone.ts
+++ b/apps/api/src/services/portal/timezone.ts
@@ -1,0 +1,60 @@
+import { eq } from 'drizzle-orm';
+import {
+  canonicalizeTimezone,
+  resolveEffectiveTimezone,
+} from '@breeze/shared';
+import { db } from '../../db';
+import { organizations, partners } from '../../db/schema';
+
+// Org -> partner -> UTC timezone chain (no site axis for org-level portal
+// reads), same source-of-truth rules as the report schedule worker's
+// timezoneFor / featureConfigResolver's partnerTimezoneFrom.
+export function resolveTimezoneFromRows(
+  orgSettings: unknown,
+  partnerTimezone: string | null,
+  partnerSettings: unknown,
+): string {
+  const orgTz = orgSettings && typeof orgSettings === 'object'
+    ? (orgSettings as Record<string, unknown>).timezone
+    : null;
+  const partnerColumn = canonicalizeTimezone(partnerTimezone);
+  const partnerFromSettings = partnerSettings && typeof partnerSettings === 'object'
+    ? (partnerSettings as Record<string, unknown>).timezone
+    : null;
+  const partnerTz = partnerColumn !== null && partnerColumn !== 'UTC'
+    ? partnerColumn
+    : typeof partnerFromSettings === 'string' && partnerFromSettings.length > 0
+      ? partnerFromSettings
+      : partnerColumn;
+
+  return resolveEffectiveTimezone({
+    siteTz: null,
+    orgTz: typeof orgTz === 'string' ? orgTz : null,
+    partnerTz,
+  });
+}
+
+// The lookup deliberately does not open a system context itself: callers are
+// responsible for their own DB access scope. `portalAuthMiddleware` calls
+// this inside its existing system-context hydration; worker callers already
+// run under worker system authority.
+export async function resolveOrgTimezone(
+  orgId: string,
+): Promise<string> {
+  const [row] = await db
+    .select({
+      orgSettings: organizations.settings,
+      partnerTimezone: partners.timezone,
+      partnerSettings: partners.settings,
+    })
+    .from(organizations)
+    .leftJoin(partners, eq(partners.id, organizations.partnerId))
+    .where(eq(organizations.id, orgId))
+    .limit(1);
+
+  return resolveTimezoneFromRows(
+    row?.orgSettings,
+    row?.partnerTimezone ?? null,
+    row?.partnerSettings,
+  );
+}

--- a/apps/api/src/services/portal/vulnerabilityCatalog.test.ts
+++ b/apps/api/src/services/portal/vulnerabilityCatalog.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => ({
+  selectMock: vi.fn(),
+  batches: [] as string[][],
+  rows: [] as Array<{
+    id: string;
+    severity: string | null;
+    knownExploited: boolean | null;
+  }>,
+  systemCalls: 0,
+}));
+
+vi.mock('../../db', () => ({
+  db: {
+    select: (...args: unknown[]) => state.selectMock(...args),
+  },
+  runOutsideDbContext: vi.fn(async (
+    fn: () => Promise<unknown>,
+  ) => fn()),
+  withSystemDbAccessContext: vi.fn(async (
+    fn: () => Promise<unknown>,
+  ) => {
+    state.systemCalls += 1;
+    return fn();
+  }),
+}));
+
+vi.mock('../../db/schema', () => ({
+  vulnerabilities: {
+    id: 'vulnerabilities.id',
+    severity: 'vulnerabilities.severity',
+    knownExploited: 'vulnerabilities.knownExploited',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  inArray: (column: unknown, values: string[]) => ({
+    op: 'inArray',
+    column,
+    values,
+  }),
+}));
+
+import {
+  vulnerabilitySeverityForFindings,
+} from './vulnerabilityCatalog';
+
+describe('vulnerabilitySeverityForFindings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    state.batches = [];
+    state.rows = [];
+    state.systemCalls = 0;
+    state.selectMock.mockImplementation(() => ({
+      from: () => ({
+        where: async (predicate: { values: string[] }) => {
+          state.batches.push(predicate.values);
+          return state.rows.filter((row) =>
+            predicate.values.includes(row.id),
+          );
+        },
+      }),
+    }));
+  });
+
+  it('does not enter system context for an empty input', async () => {
+    await expect(vulnerabilitySeverityForFindings([]))
+      .resolves.toEqual(new Map());
+    expect(state.systemCalls).toBe(0);
+  });
+
+  it('normalizes severity and KEV metadata', async () => {
+    state.rows = [{
+      id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      severity: 'CRITICAL',
+      knownExploited: true,
+    }];
+
+    await expect(vulnerabilitySeverityForFindings([
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    ])).resolves.toEqual(new Map([
+      ['aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', {
+        severity: 'critical',
+        isKev: true,
+      }],
+    ]));
+  });
+
+  it('maps findings absent from the catalog to unknown', async () => {
+    await expect(vulnerabilitySeverityForFindings([
+      'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+    ])).resolves.toEqual(new Map([
+      ['bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb', {
+        severity: 'unknown',
+        isKev: false,
+      }],
+    ]));
+  });
+
+  it('reads more than 10,000 ids in bounded batches', async () => {
+    const ids = Array.from(
+      { length: 10_001 },
+      (_, index) => `${String(index).padStart(8, '0')}-0000-4000-8000-000000000000`,
+    );
+
+    await vulnerabilitySeverityForFindings(ids);
+
+    expect(state.batches.map((batch) => batch.length))
+      .toEqual([10_000, 1]);
+    expect(state.systemCalls).toBe(1);
+  });
+});

--- a/apps/api/src/services/portal/vulnerabilityCatalog.test.ts
+++ b/apps/api/src/services/portal/vulnerabilityCatalog.test.ts
@@ -87,15 +87,10 @@ describe('vulnerabilitySeverityForFindings', () => {
     ]));
   });
 
-  it('maps findings absent from the catalog to unknown', async () => {
+  it('omits ids absent from the catalog rather than back-filling unknown', async () => {
     await expect(vulnerabilitySeverityForFindings([
       'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
-    ])).resolves.toEqual(new Map([
-      ['bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb', {
-        severity: 'unknown',
-        isKev: false,
-      }],
-    ]));
+    ])).resolves.toEqual(new Map());
   });
 
   it('reads more than 10,000 ids in bounded batches', async () => {

--- a/apps/api/src/services/portal/vulnerabilityCatalog.ts
+++ b/apps/api/src/services/portal/vulnerabilityCatalog.ts
@@ -45,14 +45,5 @@ export async function vulnerabilitySeverityForFindings(
     }),
   );
 
-  for (const id of ids) {
-    if (!result.has(id)) {
-      result.set(id, {
-        severity: 'unknown',
-        isKev: false,
-      });
-    }
-  }
-
   return result;
 }

--- a/apps/api/src/services/portal/vulnerabilityCatalog.ts
+++ b/apps/api/src/services/portal/vulnerabilityCatalog.ts
@@ -1,0 +1,58 @@
+import { inArray } from 'drizzle-orm';
+import {
+  db,
+  runOutsideDbContext,
+  withSystemDbAccessContext,
+} from '../../db';
+import { vulnerabilities } from '../../db/schema';
+
+const BATCH_SIZE = 10_000;
+
+export async function vulnerabilitySeverityForFindings(
+  vulnIds: string[],
+): Promise<Map<string, {
+  severity: string;
+  isKev: boolean;
+}>> {
+  const ids = [...new Set(vulnIds)];
+  if (ids.length === 0) return new Map();
+
+  const result = new Map<string, {
+    severity: string;
+    isKev: boolean;
+  }>();
+
+  await runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () => {
+      for (let offset = 0; offset < ids.length; offset += BATCH_SIZE) {
+        const batch = ids.slice(offset, offset + BATCH_SIZE);
+        const rows = await db
+          .select({
+            id: vulnerabilities.id,
+            severity: vulnerabilities.severity,
+            knownExploited: vulnerabilities.knownExploited,
+          })
+          .from(vulnerabilities)
+          .where(inArray(vulnerabilities.id, batch));
+
+        for (const row of rows) {
+          result.set(row.id, {
+            severity: row.severity?.toLowerCase() ?? 'unknown',
+            isKev: row.knownExploited === true,
+          });
+        }
+      }
+    }),
+  );
+
+  for (const id of ids) {
+    if (!result.has(id)) {
+      result.set(id, {
+        severity: 'unknown',
+        isKev: false,
+      });
+    }
+  }
+
+  return result;
+}

--- a/apps/api/src/services/securityComplianceReport.test.ts
+++ b/apps/api/src/services/securityComplianceReport.test.ts
@@ -540,4 +540,270 @@ describe('generateSecurityCompliancePostureReport', () => {
     expect(r.rows).toEqual([]);
     expect((r.summary as any).controls.backupRequired).toBe(false);
   });
+
+  // Parity for the `classifyDeviceProtection` extraction (portal/protection.ts):
+  // every protection/freshness fixture group already exercised above is
+  // replayed here, and the full protection-relevant slice of the report
+  // (edrCoveragePct, anyAvCoveragePct, unprotectedCount, and each row's
+  // protectionManaged/protection/realTimeProtection) is asserted against
+  // values independently derived from the pre-extraction rule
+  // (`isManaged || (provider !== 'other' && realTimeProtection === true)`),
+  // not from the new helper itself. The helper has no freshness gate, so a
+  // stale row with RTP on is still protected, and an absent status row is
+  // 'unknown' from the helper but folds into the report's existing
+  // unprotected bucket — the report exposes no third bucket.
+  describe('protection extraction parity (byte-for-byte with the pre-extraction rule)', () => {
+    async function protectionSlice(overrides: Partial<Record<number, any[]>>) {
+      mockGeneratorQueries(overrides);
+      const r = await generateSecurityCompliancePostureReport(ORG, {});
+      const c = (r.summary as any).controls;
+      return {
+        edrCoveragePct: c.edrCoveragePct,
+        anyAvCoveragePct: c.anyAvCoveragePct,
+        unprotectedCount: c.unprotectedCount,
+        rows: (r.rows as any[]).map((row) => ({
+          hostname: row.hostname,
+          protectionManaged: row.protectionManaged,
+          realTimeProtection: row.realTimeProtection,
+        })),
+      };
+    }
+
+    it('base Defender/other rows (lines 71-72): Huntress-managed + other/RTP-off + no-row', async () => {
+      // dev-1 Huntress-managed (protected); dev-2 provider 'other' (unprotected);
+      // dev-3 no status row (unknown → unprotected bucket).
+      expect(await protectionSlice({})).toEqual({
+        edrCoveragePct: 33,
+        anyAvCoveragePct: 33,
+        unprotectedCount: 2,
+        rows: [
+          { hostname: 'pc-1', protectionManaged: true, realTimeProtection: true },
+          { hostname: 'pc-2', protectionManaged: false, realTimeProtection: false },
+          { hostname: 'pc-3', protectionManaged: false, realTimeProtection: null },
+        ],
+      });
+    });
+
+    it('Elastic Defend (line 175): native RTP-on provider counts as protected, not "other"', async () => {
+      expect(await protectionSlice({
+        3: [
+          { deviceId: 'dev-2', provider: 'elastic_defend', realTimeProtection: true, definitionsDate: new Date(), encryptionStatus: 'encrypted', firewallEnabled: true, passwordPolicySummary: { minLength: 12, lockoutThreshold: 5 }, localAdminSummary: { adminCount: 1 } }
+        ]
+      })).toEqual({
+        edrCoveragePct: 33,
+        anyAvCoveragePct: 67,
+        unprotectedCount: 1,
+        rows: [
+          { hostname: 'pc-1', protectionManaged: true, realTimeProtection: null },
+          { hostname: 'pc-2', protectionManaged: false, realTimeProtection: true },
+          { hostname: 'pc-3', protectionManaged: false, realTimeProtection: null },
+        ],
+      });
+    });
+
+    it('fresh/stale rows (lines 205-206): staleness never affects protection, only enc/fw', async () => {
+      const stale = new Date(Date.now() - 60 * 86400000);
+      mockGeneratorQueries({
+        2: [
+          { id: 'fresh', hostname: 'pc-fresh', osType: 'windows', siteName: 'S' },
+          { id: 'stale', hostname: 'pc-stale', osType: 'windows', siteName: 'S' },
+        ],
+        3: [
+          { deviceId: 'fresh', provider: 'windows_defender', realTimeProtection: true, definitionsDate: new Date(), encryptionStatus: 'encrypted', firewallEnabled: true, passwordPolicySummary: { minLength: 12, lockoutThreshold: 5 }, localAdminSummary: { adminCount: 1 }, updatedAt: new Date() },
+          { deviceId: 'stale', provider: 'windows_defender', realTimeProtection: true, definitionsDate: new Date(), encryptionStatus: 'unencrypted', firewallEnabled: false, passwordPolicySummary: { minLength: 4 }, localAdminSummary: { adminCount: 5 }, updatedAt: stale },
+        ],
+        4: [],
+        5: [],
+      });
+      const r = await generateSecurityCompliancePostureReport(ORG, {});
+      const c = (r.summary as any).controls;
+      // Both native Defender rows with RTP on remain protected regardless of
+      // staleness — the rule has no freshness gate.
+      expect(c.edrCoveragePct).toBe(0);
+      expect(c.anyAvCoveragePct).toBe(100);
+      expect(c.unprotectedCount).toBe(0);
+    });
+
+    it('custom-age row (line 232): a 10-day-old Defender row with RTP on remains protected', async () => {
+      const tenDaysAgo = new Date(Date.now() - 10 * 86400000);
+      mockGeneratorQueries({
+        2: [{ id: 'd', hostname: 'h', osType: 'windows', siteName: 'S' }],
+        3: [
+          { deviceId: 'd', provider: 'windows_defender', realTimeProtection: true, definitionsDate: new Date(), encryptionStatus: 'encrypted', firewallEnabled: true, passwordPolicySummary: null, localAdminSummary: null, updatedAt: tenDaysAgo },
+        ],
+        4: [],
+        5: [],
+      });
+      // maxSecurityStatusAgeDays: 7 makes this row "stale" for enc/fw, but
+      // protection ignores freshness entirely.
+      const r = await generateSecurityCompliancePostureReport(ORG, { maxSecurityStatusAgeDays: 7 });
+      const c = (r.summary as any).controls;
+      expect(c.unprotectedCount).toBe(0);
+      expect(c.anyAvCoveragePct).toBe(100);
+    });
+
+    it('assessed/stale rows (lines 254-255): a no-row device is unknown → unprotected bucket', async () => {
+      const stale = new Date(Date.now() - 60 * 86400000);
+      expect(await protectionSlice({
+        2: [
+          { id: 'assessed', hostname: 'pc-a', osType: 'windows', siteName: 'S' },
+          { id: 'stale', hostname: 'pc-s', osType: 'windows', siteName: 'S' },
+          { id: 'norow', hostname: 'pc-n', osType: 'windows', siteName: 'S' },
+        ],
+        3: [
+          { deviceId: 'assessed', provider: 'windows_defender', realTimeProtection: true, definitionsDate: new Date(), encryptionStatus: 'encrypted', firewallEnabled: true, passwordPolicySummary: null, localAdminSummary: null, updatedAt: new Date() },
+          { deviceId: 'stale', provider: 'windows_defender', realTimeProtection: true, definitionsDate: new Date(), encryptionStatus: 'encrypted', firewallEnabled: true, passwordPolicySummary: null, localAdminSummary: null, updatedAt: stale },
+        ],
+        4: [],
+        5: [],
+      })).toEqual({
+        edrCoveragePct: 0,
+        anyAvCoveragePct: 67,
+        unprotectedCount: 1,
+        rows: [
+          { hostname: 'pc-a', protectionManaged: false, realTimeProtection: true },
+          { hostname: 'pc-s', protectionManaged: false, realTimeProtection: true },
+          { hostname: 'pc-n', protectionManaged: false, realTimeProtection: null },
+        ],
+      });
+    });
+
+    it('exact-cutoff/past-cutoff rows (lines 279-280): both remain protected', async () => {
+      expect(await protectionSlice({
+        2: [
+          { id: 'edge', hostname: 'pc-edge', osType: 'windows', siteName: 'S' },
+          { id: 'past', hostname: 'pc-past', osType: 'windows', siteName: 'S' },
+        ],
+        3: [
+          { deviceId: 'edge', provider: 'windows_defender', realTimeProtection: true, definitionsDate: new Date(), encryptionStatus: 'encrypted', firewallEnabled: true, passwordPolicySummary: null, localAdminSummary: null, updatedAt: new Date(Date.now() - 30 * 86400000) },
+          { deviceId: 'past', provider: 'windows_defender', realTimeProtection: true, definitionsDate: new Date(), encryptionStatus: 'encrypted', firewallEnabled: true, passwordPolicySummary: null, localAdminSummary: null, updatedAt: new Date(Date.now() - 31 * 86400000) },
+        ],
+        4: [],
+        5: [],
+      })).toEqual({
+        edrCoveragePct: 0,
+        anyAvCoveragePct: 100,
+        unprotectedCount: 0,
+        rows: [
+          { hostname: 'pc-edge', protectionManaged: false, realTimeProtection: true },
+          { hostname: 'pc-past', protectionManaged: false, realTimeProtection: true },
+        ],
+      });
+    });
+
+    it('missing-updatedAt row (line 299): a legacy row with no updatedAt still classifies on provider/RTP alone', async () => {
+      expect(await protectionSlice({
+        2: [{ id: 'd', hostname: 'h', osType: 'windows', siteName: 'S' }],
+        3: [
+          { deviceId: 'd', provider: 'windows_defender', realTimeProtection: true, definitionsDate: new Date(), encryptionStatus: 'encrypted', firewallEnabled: true, passwordPolicySummary: null, localAdminSummary: null },
+        ],
+        4: [],
+        5: [],
+      })).toEqual({
+        edrCoveragePct: 0,
+        anyAvCoveragePct: 100,
+        unprotectedCount: 0,
+        rows: [
+          { hostname: 'h', protectionManaged: false, realTimeProtection: true },
+        ],
+      });
+    });
+
+    it('"other" provider row (line 392): unprotected regardless of RTP value', async () => {
+      expect(await protectionSlice({
+        2: [{ id: 'd', hostname: 'h', osType: 'windows', siteName: 'S' }],
+        3: [{ deviceId: 'd', provider: 'other', realTimeProtection: false, definitionsDate: null, encryptionStatus: 'unknown', firewallEnabled: null, passwordPolicySummary: null, localAdminSummary: null }],
+        4: [],
+        5: []
+      })).toEqual({
+        edrCoveragePct: 0,
+        anyAvCoveragePct: 0,
+        unprotectedCount: 1,
+        rows: [
+          { hostname: 'h', protectionManaged: false, realTimeProtection: false },
+        ],
+      });
+    });
+
+    it('SentinelOne/native rows (lines 429-430): managed SentinelOne and native Defender both protected', async () => {
+      expect(await protectionSlice({
+        2: [
+          { id: 'a', hostname: 'pc-a', osType: 'windows', siteName: 'S' },
+          { id: 'n', hostname: 'pc-n', osType: 'windows', siteName: 'S' }
+        ],
+        3: [
+          { deviceId: 'a', provider: 'sentinelone', realTimeProtection: true, definitionsDate: new Date(), encryptionStatus: 'encrypted', firewallEnabled: true, passwordPolicySummary: { minLength: 12, lockoutThreshold: 5 }, localAdminSummary: { adminCount: 1 } },
+          { deviceId: 'n', provider: 'windows_defender', realTimeProtection: true, definitionsDate: new Date(), encryptionStatus: 'encrypted', firewallEnabled: true, passwordPolicySummary: { minLength: 12, lockoutThreshold: 5 }, localAdminSummary: { adminCount: 1 } }
+        ],
+        4: [{ deviceId: 'a' }],
+        5: []
+      })).toEqual({
+        edrCoveragePct: 50,
+        anyAvCoveragePct: 100,
+        unprotectedCount: 0,
+        rows: [
+          { hostname: 'pc-a', protectionManaged: true, realTimeProtection: true },
+          { hostname: 'pc-n', protectionManaged: false, realTimeProtection: true },
+        ],
+      });
+    });
+
+    it('"other"/RTP-off rows (lines 455-456): both excluded from protection', async () => {
+      expect(await protectionSlice({
+        2: [
+          { id: 'o', hostname: 'pc-o', osType: 'windows', siteName: 'S' },
+          { id: 'f', hostname: 'pc-f', osType: 'windows', siteName: 'S' }
+        ],
+        3: [
+          { deviceId: 'o', provider: 'other', realTimeProtection: true, definitionsDate: null, encryptionStatus: 'unknown', firewallEnabled: null, passwordPolicySummary: null, localAdminSummary: null },
+          { deviceId: 'f', provider: 'crowdstrike', realTimeProtection: false, definitionsDate: new Date(), encryptionStatus: 'unknown', firewallEnabled: null, passwordPolicySummary: null, localAdminSummary: null }
+        ],
+        4: [],
+        5: []
+      })).toEqual({
+        edrCoveragePct: 0,
+        anyAvCoveragePct: 0,
+        unprotectedCount: 2,
+        rows: [
+          { hostname: 'pc-o', protectionManaged: false, realTimeProtection: true },
+          { hostname: 'pc-f', protectionManaged: false, realTimeProtection: false },
+        ],
+      });
+    });
+
+    it('six coverage rows (lines 504-509): four native Defender + two managed SentinelOne, all protected', async () => {
+      expect(await protectionSlice({
+        2: [
+          { id: 'dev-1', hostname: 'pc-1', osType: 'windows', siteName: 'HQ' },
+          { id: 'dev-2', hostname: 'pc-2', osType: 'windows', siteName: 'HQ' },
+          { id: 'dev-3', hostname: 'pc-3', osType: 'windows', siteName: 'Remote' },
+          { id: 'dev-4', hostname: 'pc-4', osType: 'windows', siteName: 'Remote' },
+          { id: 'dev-5', hostname: 'pc-5', osType: 'windows', siteName: 'HQ' },
+          { id: 'dev-6', hostname: 'pc-6', osType: 'windows', siteName: 'Remote' },
+        ],
+        3: [
+          { deviceId: 'dev-1', provider: 'windows_defender', realTimeProtection: true, definitionsDate: new Date(), encryptionStatus: 'encrypted', firewallEnabled: true, passwordPolicySummary: null, localAdminSummary: null },
+          { deviceId: 'dev-2', provider: 'windows_defender', realTimeProtection: true, definitionsDate: new Date(), encryptionStatus: 'encrypted', firewallEnabled: true, passwordPolicySummary: null, localAdminSummary: null },
+          { deviceId: 'dev-3', provider: 'windows_defender', realTimeProtection: true, definitionsDate: new Date(), encryptionStatus: 'encrypted', firewallEnabled: true, passwordPolicySummary: null, localAdminSummary: null },
+          { deviceId: 'dev-4', provider: 'windows_defender', realTimeProtection: true, definitionsDate: new Date(), encryptionStatus: 'encrypted', firewallEnabled: true, passwordPolicySummary: null, localAdminSummary: null },
+          { deviceId: 'dev-5', provider: 'sentinelone', realTimeProtection: true, definitionsDate: new Date(), encryptionStatus: 'encrypted', firewallEnabled: true, passwordPolicySummary: null, localAdminSummary: null },
+          { deviceId: 'dev-6', provider: 'sentinelone', realTimeProtection: false, definitionsDate: new Date(), encryptionStatus: 'encrypted', firewallEnabled: true, passwordPolicySummary: null, localAdminSummary: null },
+        ],
+        4: [{ deviceId: 'dev-5' }, { deviceId: 'dev-6' }],
+        5: [],
+      })).toEqual({
+        edrCoveragePct: 33,
+        anyAvCoveragePct: 100,
+        unprotectedCount: 0,
+        rows: [
+          { hostname: 'pc-1', protectionManaged: false, realTimeProtection: true },
+          { hostname: 'pc-2', protectionManaged: false, realTimeProtection: true },
+          { hostname: 'pc-3', protectionManaged: false, realTimeProtection: true },
+          { hostname: 'pc-4', protectionManaged: false, realTimeProtection: true },
+          { hostname: 'pc-5', protectionManaged: true, realTimeProtection: true },
+          { hostname: 'pc-6', protectionManaged: true, realTimeProtection: false },
+        ],
+      });
+    });
+  });
 });

--- a/apps/api/src/services/securityComplianceReport.ts
+++ b/apps/api/src/services/securityComplianceReport.ts
@@ -33,6 +33,7 @@ import {
   type SecurityProductEvidence
 } from './securityComplianceReportProducts';
 import { loadOpenVulnerabilityCounts } from './securityComplianceReportVulnerabilities';
+import { classifyDeviceProtection } from './portal/protection';
 
 const pct = (num: number, denom: number): number =>
   denom === 0 ? 0 : Math.round((num / denom) * 100);
@@ -432,12 +433,24 @@ export async function generateSecurityCompliancePostureReport(
     const isManaged = managed.length > 0;
     const rtp = ss?.realTimeProtection ?? null;
     const hasNativeAv = Boolean(ss && ss.provider && ss.provider !== 'other' && rtp === true);
-    const protectedDevice = isManaged || hasNativeAv;
+
+    const protection = classifyDeviceProtection({
+      securityStatus: ss
+        ? {
+            provider: ss.provider,
+            realTimeProtection: ss.realTimeProtection,
+          }
+        : null,
+      hasS1Agent: s1Devices.has(d.id),
+      hasHuntressAgent: huntressDevices.has(d.id),
+    });
 
     if (ss) reporting += 1;
     if (isManaged) managedEdr += 1;
-    if (isManaged || hasNativeAv) anyAv += 1;
-    if (!protectedDevice) unprotected += 1;
+    if (protection === 'protected') anyAv += 1;
+    // The report has no unknown protection bucket. An absent status row has
+    // always counted as unprotected here, so preserve that public contract.
+    if (protection !== 'protected') unprotected += 1;
 
     // Firewall/encryption are live device states that stop updating when a device
     // goes offline, so a row older than the cutoff is treated as unknown rather

--- a/apps/api/src/services/securityComplianceReportVulnerabilities.test.ts
+++ b/apps/api/src/services/securityComplianceReportVulnerabilities.test.ts
@@ -67,6 +67,15 @@ describe('aggregateVulnerabilityCounts', () => {
 
     expect(counts.get('d1')).toBeUndefined();
   });
+
+  it('fails instead of publishing zeroes when referenced catalog rows are missing', () => {
+    expect(() =>
+      aggregateVulnerabilityCounts(
+        [{ deviceId: 'd1', vulnerabilityId: 'missing' }],
+        [],
+      ),
+    ).toThrow('Vulnerability catalog lookup incomplete');
+  });
 });
 
 describe('loadOpenVulnerabilityCounts', () => {
@@ -102,6 +111,25 @@ describe('loadOpenVulnerabilityCounts', () => {
     expect(runOutsideDbContext).toHaveBeenCalledTimes(1);
     expect(withSystemDbAccessContext).toHaveBeenCalledTimes(1);
     expect(counts.get('device-1')).toEqual({ high: 10_001, critical: 0 });
+  });
+
+  it('propagates the catalog-incomplete failure end to end when a referenced row is missing from the catalog table', async () => {
+    const findings = [{ deviceId: 'device-1', vulnerabilityId: 'vuln-missing' }];
+
+    selectMock.mockImplementation(() => ({
+      from: (table: unknown) => ({
+        where: (predicate: { values?: unknown[] }) => {
+          if (table === deviceVulnerabilities) return Promise.resolve(findings);
+          expect(table).toBe(vulnerabilities);
+          // Catalog table has no row for 'vuln-missing' — simulates the row
+          // being unreadable (e.g. an org-context RLS bypass returning zero rows).
+          return Promise.resolve([]);
+        },
+      }),
+    }));
+
+    await expect(loadOpenVulnerabilityCounts(['device-1']))
+      .rejects.toThrow('Vulnerability catalog lookup incomplete');
   });
 
   it('returns an empty map without querying or changing context for empty input', async () => {

--- a/apps/api/src/services/securityComplianceReportVulnerabilities.test.ts
+++ b/apps/api/src/services/securityComplianceReportVulnerabilities.test.ts
@@ -19,6 +19,7 @@ vi.mock('../db/schema', () => ({
     table: 'vulnerabilities',
     id: 'vulnerabilities.id',
     severity: 'vulnerabilities.severity',
+    knownExploited: 'vulnerabilities.knownExploited',
   },
 }));
 
@@ -58,13 +59,13 @@ describe('aggregateVulnerabilityCounts', () => {
     expect(counts.get('d2')).toEqual({ high: 1, critical: 1 });
   });
 
-  it('fails instead of publishing zeroes when referenced catalog rows are missing', () => {
-    expect(() =>
-      aggregateVulnerabilityCounts(
-        [{ deviceId: 'd1', vulnerabilityId: 'missing' }],
-        [],
-      ),
-    ).toThrow('Vulnerability catalog lookup incomplete');
+  it('treats a catalog entry mapped to unknown severity as contributing no counts', () => {
+    const counts = aggregateVulnerabilityCounts(
+      [{ deviceId: 'd1', vulnerabilityId: 'missing' }],
+      [{ id: 'missing', severity: 'unknown' }],
+    );
+
+    expect(counts.get('d1')).toBeUndefined();
   });
 });
 

--- a/apps/api/src/services/securityComplianceReportVulnerabilities.ts
+++ b/apps/api/src/services/securityComplianceReportVulnerabilities.ts
@@ -1,14 +1,13 @@
 import { and, eq, inArray } from 'drizzle-orm';
 
-import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
-import { deviceVulnerabilities, vulnerabilities } from '../db/schema';
+import { db } from '../db';
+import { deviceVulnerabilities } from '../db/schema';
+import { vulnerabilitySeverityForFindings } from './portal/vulnerabilityCatalog';
 
 export type DeviceVulnerabilityCounts = { critical: number; high: number };
 
 type FindingRow = { deviceId: string; vulnerabilityId: string };
 type CatalogRow = { id: string; severity: string | null };
-
-const VULNERABILITY_CATALOG_BATCH_SIZE = 10_000;
 
 export function aggregateVulnerabilityCounts(
   findings: FindingRow[],
@@ -64,25 +63,13 @@ export async function loadOpenVulnerabilityCounts(
   ];
   if (vulnerabilityIds.length === 0) return new Map();
 
-  const catalogRows = await runOutsideDbContext(() =>
-    withSystemDbAccessContext(async () => {
-      const rows: CatalogRow[] = [];
-      for (
-        let offset = 0;
-        offset < vulnerabilityIds.length;
-        offset += VULNERABILITY_CATALOG_BATCH_SIZE
-      ) {
-        const batch = vulnerabilityIds.slice(
-          offset,
-          offset + VULNERABILITY_CATALOG_BATCH_SIZE,
-        );
-        const batchRows = await db
-          .select({ id: vulnerabilities.id, severity: vulnerabilities.severity })
-          .from(vulnerabilities)
-          .where(inArray(vulnerabilities.id, batch));
-        rows.push(...batchRows);
-      }
-      return rows;
+  const severityByVulnerability =
+    await vulnerabilitySeverityForFindings(vulnerabilityIds);
+
+  const catalogRows: CatalogRow[] = [...severityByVulnerability].map(
+    ([id, metadata]) => ({
+      id,
+      severity: metadata.severity,
     }),
   );
 

--- a/apps/api/src/services/securityComplianceReportVulnerabilities.ts
+++ b/apps/api/src/services/securityComplianceReportVulnerabilities.ts
@@ -66,6 +66,8 @@ export async function loadOpenVulnerabilityCounts(
   const severityByVulnerability =
     await vulnerabilitySeverityForFindings(vulnerabilityIds);
 
+  // Only pass through rows the catalog actually produced — aggregateVulnerabilityCounts'
+  // missingIds guard must stay reachable, never invent zeros for a missing catalog row.
   const catalogRows: CatalogRow[] = [...severityByVulnerability].map(
     ([id, metadata]) => ({
       id,

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -816,6 +816,12 @@ export * from './postureReport';
 export * from './executiveSummaryReport';
 
 // ============================================
+// Portal Visibility DTOs (Wave 1 - #4562)
+// ============================================
+
+export * from './portalVisibility';
+
+// ============================================
 // Public login-context wire contract (#2183)
 // ============================================
 

--- a/packages/shared/src/types/portalVisibility.test.ts
+++ b/packages/shared/src/types/portalVisibility.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import type {
+  BackupDeviceRow,
+  BackupOverviewDto,
+  DashboardDto,
+  EnrichedPortalDevice,
+  PortalRunDto,
+  SecurityDeviceRow,
+  SecurityOverviewDto,
+  SlaDto,
+  SupportUsageDto,
+  TileStatus,
+} from './portalVisibility';
+
+describe('portal visibility DTOs', () => {
+  it('keeps tile and protection states closed unions', () => {
+    expectTypeOf<TileStatus>().toEqualTypeOf<
+      'ok' | 'no_data' | 'not_configured' | 'stale'
+    >();
+
+    expectTypeOf<SecurityDeviceRow['protection']>().toEqualTypeOf<
+      'protected' | 'unprotected' | 'unknown'
+    >();
+
+    expectTypeOf<SlaDto['status']>().toEqualTypeOf<
+      | 'breached'
+      | 'at_risk'
+      | 'paused'
+      | 'on_track'
+      | 'met'
+      | 'not_configured'
+    >();
+  });
+
+  it('exports every approved top-level DTO', () => {
+    expectTypeOf<DashboardDto>().toBeObject();
+    expectTypeOf<SecurityOverviewDto>().toBeObject();
+    expectTypeOf<SecurityDeviceRow>().toBeObject();
+    expectTypeOf<BackupOverviewDto>().toBeObject();
+    expectTypeOf<BackupDeviceRow>().toBeObject();
+    expectTypeOf<SupportUsageDto>().toBeObject();
+    expectTypeOf<SlaDto>().toBeObject();
+    expectTypeOf<PortalRunDto>().toBeObject();
+    expectTypeOf<EnrichedPortalDevice>().toBeObject();
+
+    const status: TileStatus = 'no_data';
+    expect(status).toBe('no_data');
+  });
+});

--- a/packages/shared/src/types/portalVisibility.ts
+++ b/packages/shared/src/types/portalVisibility.ts
@@ -10,6 +10,15 @@ export type SecurityScoreBand =
   | 'fair'
   | 'at_risk';
 
+/**
+ * Device protection state classification from security compliance analysis.
+ * Reflects agent-provided and policy-provided signals.
+ */
+export type ProtectionState =
+  | 'protected'
+  | 'unprotected'
+  | 'unknown';
+
 export interface PaginationDto {
   page: number;
   limit: number;
@@ -131,7 +140,7 @@ export interface SecurityOverviewDto {
 export interface SecurityDeviceRow {
   id: string;
   name: string;
-  protection: 'protected' | 'unprotected' | 'unknown';
+  protection: ProtectionState;
   avProducts: string[];
   realTimeProtection: boolean | null;
   definitionsAgeDays: number | null;
@@ -251,7 +260,7 @@ export interface EnrichedPortalDevice {
   status: string;
   lastSeenAt: string | null;
   lastPatchAt: string | null;
-  protection: 'protected' | 'unprotected' | 'unknown';
+  protection: ProtectionState;
   encryption: string | null;
   lastBackupAt: string | null;
   warrantyEndsAt: string | null;

--- a/packages/shared/src/types/portalVisibility.ts
+++ b/packages/shared/src/types/portalVisibility.ts
@@ -1,0 +1,258 @@
+export type TileStatus =
+  | 'ok'
+  | 'no_data'
+  | 'not_configured'
+  | 'stale';
+
+export type SecurityScoreBand =
+  | 'strong'
+  | 'good'
+  | 'fair'
+  | 'at_risk';
+
+export interface PaginationDto {
+  page: number;
+  limit: number;
+  total: number;
+}
+
+export interface CountHoursDto {
+  minutes: number;
+  hours: number;
+}
+
+export interface SecurityScoreTileDto {
+  status: TileStatus;
+  score: number | null;
+  band: SecurityScoreBand | null;
+  delta30d: number | null;
+  capturedAt: string | null;
+}
+
+export interface DevicesProtectedTileDto {
+  status: TileStatus;
+  protected: number | null;
+  unprotected: number | null;
+  unknown: number | null;
+  total: number | null;
+  asOf: string | null;
+}
+
+export interface PatchesAppliedTileDto {
+  status: TileStatus;
+  applied: number | null;
+  devicesWithOutstandingCritical: number | null;
+  month: string;
+  timezone: string;
+  asOf: string;
+}
+
+export interface BackupTileDto {
+  status: TileStatus;
+  completedAt: string | null;
+  verificationType: string | null;
+  configured: number | null;
+  total: number | null;
+  asOf: string;
+}
+
+export interface SupportTileDto {
+  status: TileStatus;
+  openTickets: number | null;
+  averageFirstResponseMinutes: number | null;
+  sampleSize: number;
+  month: string;
+  timezone: string;
+  asOf: string;
+}
+
+export interface ActionItemsTileDto {
+  status: TileStatus;
+  count: number | null;
+  topIssues: string[];
+  asOf: string;
+}
+
+export interface AwaitingYouTileDto {
+  status: TileStatus;
+  proposals: number | null;
+  invoices: number | null;
+  asOf: string;
+}
+
+export interface DashboardDto {
+  asOf: string;
+  timezone: string;
+  securityScore: SecurityScoreTileDto;
+  devicesProtected: DevicesProtectedTileDto;
+  patchesApplied: PatchesAppliedTileDto;
+  backup: BackupTileDto;
+  support: SupportTileDto;
+  actionItems: ActionItemsTileDto;
+  awaitingYou: AwaitingYouTileDto;
+}
+
+export interface SecurityTrendPoint {
+  capturedAt: string;
+  score: number;
+}
+
+export interface ThreatSourceCounts {
+  native: number;
+  sentinelOne: number;
+  huntress: number;
+}
+
+export interface ThreatWeekDto {
+  weekStart: string;
+  detected: number;
+  resolved: number;
+  detectedBySource: ThreatSourceCounts;
+  resolvedBySource: ThreatSourceCounts;
+}
+
+export interface SecurityOverviewDto {
+  dataStatus: TileStatus;
+  asOf: string;
+  score: number | null;
+  band: SecurityScoreBand | null;
+  scoreHistory: SecurityTrendPoint[];
+  threatEvents: {
+    label: 'endpoint threat events';
+    weeks: ThreatWeekDto[];
+  };
+  vulnerabilities: {
+    openBySeverity: Record<string, number>;
+    kevCount: number;
+    lastDetectedAt: string | null;
+  };
+}
+
+export interface SecurityDeviceRow {
+  id: string;
+  name: string;
+  protection: 'protected' | 'unprotected' | 'unknown';
+  avProducts: string[];
+  realTimeProtection: boolean | null;
+  definitionsAgeDays: number | null;
+  encryption: string | null;
+  firewall: boolean | null;
+  pendingCriticalPatches: number;
+  observedAt: string | null;
+}
+
+export interface SecurityDevicesDto {
+  dataStatus: TileStatus;
+  asOf: string;
+  data: SecurityDeviceRow[];
+  pagination: PaginationDto;
+}
+
+export interface BackupDeviceRow {
+  id: string;
+  name: string;
+  configured: boolean;
+  lastRestorePointAt: string | null;
+  lastRestorePointDegraded: boolean;
+  lastTestRestore: {
+    status: string;
+    completedAt: string | null;
+    restoreTimeSeconds: number | null;
+  } | null;
+  openBreaches: string[];
+  readinessScore: number | null;
+  estimatedRtoMinutes: number | null;
+  estimatedRpoMinutes: number | null;
+}
+
+export interface BackupOverviewDto {
+  dataStatus: TileStatus;
+  asOf: string;
+  protected: number | null;
+  unprotected: number | null;
+  total: number | null;
+  lastPassedVerification: {
+    completedAt: string;
+    verificationType: string;
+  } | null;
+  lastTestRestoreAt: string | null;
+  openRpoBreaches: number | null;
+  openRtoBreaches: number | null;
+  meanReadinessScore: number | null;
+}
+
+export interface BackupDevicesDto {
+  dataStatus: TileStatus;
+  asOf: string;
+  data: BackupDeviceRow[];
+  pagination: PaginationDto;
+}
+
+export interface SupportUsageTicketDto {
+  ticketNumber: string;
+  title: string | null;
+  billedMinutes: number;
+  toBeBilledMinutes: number;
+  coveredByContractMinutes: number;
+  pendingReviewMinutes: number;
+}
+
+export interface SupportUsageDto {
+  dataStatus: TileStatus;
+  asOf: string;
+  month: string;
+  timezone: string;
+  totals: {
+    billed: CountHoursDto;
+    toBeBilled: CountHoursDto;
+    coveredByContract: CountHoursDto;
+    pendingReview: CountHoursDto;
+  };
+  tickets: SupportUsageTicketDto[];
+}
+
+export interface SlaDto {
+  firstResponseMinutes: number | null;
+  resolutionMinutes: number | null;
+  responseTargetMinutes: number | null;
+  resolutionTargetMinutes: number | null;
+  status:
+    | 'breached'
+    | 'at_risk'
+    | 'paused'
+    | 'on_track'
+    | 'met'
+    | 'not_configured';
+}
+
+export interface PortalRunDto {
+  id: string;
+  reportId: string;
+  type: 'security_compliance_posture' | 'executive_summary';
+  name: string;
+  status: 'pending' | 'running' | 'completed' | 'failed';
+  startedAt: string | null;
+  completedAt: string | null;
+  rowCount: number | null;
+  createdAt: string;
+}
+
+export interface PortalRunsDto {
+  data: PortalRunDto[];
+  pagination: PaginationDto;
+}
+
+export interface EnrichedPortalDevice {
+  id: string;
+  hostname: string;
+  displayName: string | null;
+  osType: string;
+  osVersion: string;
+  status: string;
+  lastSeenAt: string | null;
+  lastPatchAt: string | null;
+  protection: 'protected' | 'unprotected' | 'unknown';
+  encryption: string | null;
+  lastBackupAt: string | null;
+  warrantyEndsAt: string | null;
+}


### PR DESCRIPTION
## Summary

Wave 2 of the customer-portal visibility feature (#4562): the read-model foundation that W03–W08 build on. No routes, no UI, no new tables.

- **Shared DTOs** — `packages/shared/src/types/portalVisibility.ts`: tile/status contract (`status ∈ ok | no_data | not_configured | stale`, nullable values, lowercase score bands).
- **Protection classifier** — `services/portal/protection.ts` extracted from the posture report's inline rule with no freshness gate; the report folds `unknown` into unprotected. Parity proven by driving the real generator (11 fixture groups).
- **Org timezone** — `services/portal/timezone.ts` (org → partner → UTC) wraps the schedule worker's `timezoneFor`; `portalAuthMiddleware` resolves it once inside its existing system-context hydration and exposes `auth.timezone`. Read models take timezone as a parameter.
- **Support usage** — `supportUsageForOrg` (org-wide ticket counts/minutes, titles only for the current portal user's tickets) under a system context, org id from the session only; unit test asserts the org predicate on the compiled SQL.
- **Vulnerability catalog adapter** — `vulnerabilitySeverityForFindings` reads the shared CVE catalog under a system context and returns only catalog-found rows, so the posture report's fail-loud "catalog incomplete" guard stays live (never invent zeros).
- **Indexes + RLS contract** — `2026-10-04-100003-portal-visibility-indexes.sql` (9 idempotent read indexes, matching Drizzle declarations, drift-clean) and `portalVisibilityRls.integration.test.ts` forging cross-tenant reads under the ambient portal org context with an org-A positive control.

These are the only two new `runOutsideDbContext` + `withSystemDbAccessContext` uses; `breeze_has_org_access` is not widened. No new `org_id` tables or columns, so no cascade/export-policy registration is due.

Plan: `docs/superpowers/plans/portal/2026-09-02-portal-visibility-wave1-part-a.md` (Tasks 2.1–2.6). Deviations from the plan text: migration renamed to sort after the newest committed migration; `SQL` type imported from `drizzle-orm` root (pg-core has no such export); the vulnerability adapter no longer back-fills `unknown` (plan step 2.5.3 contradicted the spec's never-invent-zeros rule, spec wins); `portal.test.ts` / `portal.compat.test.ts` mock the timezone service at the same boundary as `tenantStatus`.

## Verification (local, at ef7eaa570)

- `apps/api` unit: `src/services/portal`, `src/services/securityComplianceReport*`, `src/routes/portal*` (both siblings), `src/jobs/reportScheduleWorker`, `src/db/autoMigrate.test.ts` — 20 files, 410 tests, 0 failed.
- Integration (private test stack): `portalVisibilityRls`, `ticketAttachmentsRls`, `portal-routes-rls`, `portalUserInvite`, `portalQuotePay`, `multiCurrencyWave6QuoteAcceptance` — all green.
- `tsc --noEmit` (apps/api, packages/shared new files), eslint on every changed file, `pnpm db:check-drift` — clean.
- Independent whole-branch review (three Important findings fixed in the last commit, re-reviewed clean).

Independent of #4626 (W01). W03 depends on this.

Closes #4570

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WvK35ZoQELCL9xdsgWjCaw