### PR TITLE
chore(deps): pin fast-uri to 3.1.7 for six HIGH advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
       "fast-xml-parser@<5.5.7": ">=5.5.7",
       "fast-xml-parser@<5.7.0": ">=5.7.0",
       "fast-xml-parser@<5.10.1": ">=5.10.1",
-      "fast-uri@>=3.0.0 <3.1.5": "3.1.5",
+      "fast-uri@>=3.0.0 <3.1.7": "3.1.7",
       "brace-expansion@<1.1.18": ">=1.1.18",
       "brace-expansion@>=2.0.0 <2.1.4": ">=5.0.9",
       "brace-expansion@>=4.0.0 <5.0.9": ">=5.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
   fast-xml-parser@<5.5.7: '>=5.5.7'
   fast-xml-parser@<5.7.0: '>=5.7.0'
   fast-xml-parser@<5.10.1: '>=5.10.1'
-  fast-uri@>=3.0.0 <3.1.5: 3.1.5
+  fast-uri@>=3.0.0 <3.1.7: 3.1.7
   brace-expansion@<1.1.18: '>=1.1.18'
   brace-expansion@>=2.0.0 <2.1.4: '>=5.0.9'
   brace-expansion@>=4.0.0 <5.0.9: '>=5.0.9'
@@ -8000,8 +8000,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -17830,7 +17830,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -19793,7 +19793,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.7: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:


### PR DESCRIPTION
Bumps the `pnpm.overrides` pin for `fast-uri` from 3.1.5 to 3.1.7. Only consumer in the lockfile is `ajv@8.20.0`.

**Advisories closed:**
- 3.1.6: GHSA-5jgf-p345-68v8 (CVE-2026-75931), GHSA-f65p-4m7j-42xc (CVE-2026-75975), GHSA-fph4-wmhf-6fwf (CVE-2026-75899), GHSA-jqff-g426-hqxp (CVE-2026-76172). SSRF via malformed IPv6 normalization and repeated hostname percent-decoding; host confusion via skipped IDN canonicalization and percent-encoded scheme normalization.
- 3.1.7 (same-day follow-up release): GHSA-qw65-cvwx-89v3 (authority injection via unvalidated port in `serialize()`), GHSA-58mr-gqgx-xq4g (host confusion via unbalanced IP-literal brackets).

**Why an exact pin:** `>=3.1.7` resolves to 4.1.4, which is outside ajv's `^3.0.1` range. Kept the existing exact-pin style.

Verified locally: `pnpm install --frozen-lockfile` clean; lockfile diff is the four fast-uri lines only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xr3ZNTFRkCM1t4gEjPttTg