### PR TITLE
fix(web): refetch the mounted approximate-total line on a partner currency reset (#4472)

### DIFF
--- a/apps/web/src/lib/__tests__/useApproximateTotal.test.tsx
+++ b/apps/web/src/lib/__tests__/useApproximateTotal.test.tsx
@@ -368,3 +368,64 @@ describe('useApproximateTotal — a partner reporting-currency change invalidate
     expect(fetchWithAuth).toHaveBeenCalledTimes(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// #4472: the cache generation was not in the effect's dependency list, so an
+// already-mounted line — never unmounted, no other prop/state change — kept
+// its stale state after `resetPartnerCurrencyCache()` and only picked up the
+// new currency on a later remount. Every test above unmounts and remounts
+// (`first.unmount()` then a fresh `render()`), which happens to work because
+// a brand-new mount always computes a fresh key — it never exercised the
+// actually-broken path. These do.
+// ---------------------------------------------------------------------------
+describe('useApproximateTotal — an ALREADY-MOUNTED line reacts to a reset in place (#4472)', () => {
+  it('refetches without unmounting when a same-tab reporting-currency save resets the cache', async () => {
+    fetchWithAuth.mockResolvedValueOnce(jsonRes({ data: AVAILABLE }));
+    render(<Probe id="a" date="2026-08-21" />);
+    await waitFor(() => expect(screen.getByTestId('a').textContent).toBe('available:22940.00:CAD'));
+
+    // What PartnerBillingSettings.tsx does after a reporting-currency save —
+    // the mounted Probe is never unmounted or given new props.
+    fetchWithAuth.mockResolvedValueOnce(
+      jsonRes({ data: { ...AVAILABLE, targetCurrencyCode: 'EUR', total: '17000.00' } }),
+    );
+    resetPartnerCurrencyCache();
+
+    await waitFor(() => expect(screen.getByTestId('a').textContent).toBe('available:17000.00:EUR'));
+    expect(fetchWithAuth).toHaveBeenCalledTimes(2);
+  });
+
+  it('a stale response discarded by the generation guard self-heals instead of pinning `failed`', async () => {
+    let resolveFirst: (r: Response) => void = () => {};
+    fetchWithAuth.mockReturnValueOnce(new Promise<Response>((r) => { resolveFirst = r; }));
+    render(<Probe id="a" date="2026-08-21" />);
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalledTimes(1));
+
+    // Reset while the first request is still in flight; the mounted line
+    // must start a second, post-reset request on its own.
+    fetchWithAuth.mockResolvedValueOnce(
+      jsonRes({ data: { ...AVAILABLE, targetCurrencyCode: 'EUR', total: '17000.00' } }),
+    );
+    resetPartnerCurrencyCache();
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.getByTestId('a').textContent).toBe('available:17000.00:EUR'));
+
+    // The stale pre-reset response finally lands and is discarded by the
+    // generation guard — it must not clobber the healthy state with `failed`.
+    resolveFirst(jsonRes({ data: AVAILABLE }));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(screen.getByTestId('a').dataset.failed).toBe('false');
+    expect(screen.getByTestId('a').textContent).toBe('available:17000.00:EUR');
+  });
+
+  it('a mounted line survives a plain resetApproximateTotalCache() (logout) too', async () => {
+    fetchWithAuth.mockResolvedValueOnce(jsonRes({ data: AVAILABLE }));
+    render(<Probe id="a" date="2026-08-21" />);
+    await waitFor(() => expect(screen.getByTestId('a').textContent).toBe('available:22940.00:CAD'));
+
+    fetchWithAuth.mockResolvedValueOnce(jsonRes({ data: AVAILABLE }));
+    resetApproximateTotalCache();
+
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalledTimes(2));
+  });
+});

--- a/apps/web/src/lib/__tests__/useApproximateTotal.test.tsx
+++ b/apps/web/src/lib/__tests__/useApproximateTotal.test.tsx
@@ -428,4 +428,26 @@ describe('useApproximateTotal — an ALREADY-MOUNTED line reacts to a reset in p
 
     await waitFor(() => expect(fetchWithAuth).toHaveBeenCalledTimes(2));
   });
+
+  it('two simultaneously-mounted lines with DIFFERENT keys both react to one reset', async () => {
+    // The real fix is a shared `listeners: Set<() => void>` in
+    // approximateTotalCache.ts feeding a `useSyncExternalStore` in every hook
+    // instance — a dashboard's realistic failure mode is several rollup lines
+    // mounted at once, so a fan-out bug (e.g. only the first subscriber
+    // re-rendering) would hide behind the single-instance tests above.
+    fetchWithAuth.mockResolvedValue(jsonRes({ data: AVAILABLE }));
+    render(<><Probe id="a" date="2026-08-21" /><Probe id="b" date="2026-08-20" /></>);
+    await waitFor(() => expect(screen.getByTestId('a').textContent).toBe('available:22940.00:CAD'));
+    await waitFor(() => expect(screen.getByTestId('b').textContent).toBe('available:22940.00:CAD'));
+    expect(fetchWithAuth).toHaveBeenCalledTimes(2);
+
+    fetchWithAuth.mockResolvedValue(
+      jsonRes({ data: { ...AVAILABLE, targetCurrencyCode: 'EUR', total: '17000.00' } }),
+    );
+    resetPartnerCurrencyCache();
+
+    await waitFor(() => expect(screen.getByTestId('a').textContent).toBe('available:17000.00:EUR'));
+    await waitFor(() => expect(screen.getByTestId('b').textContent).toBe('available:17000.00:EUR'));
+    expect(fetchWithAuth).toHaveBeenCalledTimes(4);
+  });
 });

--- a/apps/web/src/lib/approximateTotalCache.ts
+++ b/apps/web/src/lib/approximateTotalCache.ts
@@ -15,8 +15,20 @@
 // `generation` binds every request to the reset epoch it started in, so a
 // response that lands after a logout can neither commit the previous partner's
 // total nor clear the newer in-flight slot (the #3777 review F7 shape).
+//
+// Invalidation on a partner-currency change used to be LAZY: it only ran
+// inside `approximateTotalCacheKey()`, so it fired only on the next render
+// that happened to compute a key. An already-mounted `useApproximateTotal`
+// line with no other reason to re-render (the normal case: nothing else on
+// its props/state changed) never called that function again, so it neither
+// noticed the reset nor refetched — the "never refetches" half of #4472.
+// `subscribePartnerCurrencyCache` below makes invalidation EAGER: it fires
+// the instant `resetPartnerCurrencyCache()` runs, clearing this cache and
+// notifying `subscribeApproximateTotalCache` listeners so a mounted hook can
+// force its own re-render via `useSyncExternalStore` even with nothing else
+// changing.
 
-import { partnerCurrencyCache } from './partnerCurrencyCache';
+import { partnerCurrencyCache, subscribePartnerCurrencyCache } from './partnerCurrencyCache';
 import type { ReportingTotalResponse } from './reporting/approximateTotal';
 
 export const approximateTotalCache: {
@@ -32,34 +44,74 @@ export const approximateTotalCache: {
   partnerCurrencyGeneration: partnerCurrencyCache.generation,
 };
 
+const listeners = new Set<() => void>();
+
+/** Notified synchronously every time `approximateTotalCache.generation`
+ *  changes (a partner-currency reset observed below, or
+ *  `resetApproximateTotalCache()` itself — e.g. logout). Returns an
+ *  unsubscribe function. `useApproximateTotal` uses this with
+ *  `useSyncExternalStore` so an already-mounted line re-renders — and its
+ *  effect re-runs — the instant a reset happens, not on the next render it
+ *  would have had anyway. */
+export function subscribeApproximateTotalCache(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => { listeners.delete(listener); };
+}
+
+function notify(): void {
+  listeners.forEach((listener) => listener());
+}
+
+/** Clear this cache and bump its generation if the partner-currency cache has
+ *  moved on to a new epoch since we last observed it. Idempotent: a no-op if
+ *  already caught up (e.g. the eager subscription below already ran). */
+function syncToPartnerCurrencyGeneration(): boolean {
+  if (approximateTotalCache.partnerCurrencyGeneration === partnerCurrencyCache.generation) return false;
+  approximateTotalCache.partnerCurrencyGeneration = partnerCurrencyCache.generation;
+  approximateTotalCache.values.clear();
+  approximateTotalCache.inflight.clear();
+  approximateTotalCache.generation += 1;
+  return true;
+}
+
+// Wired once at module load: react to a partner-currency reset the instant it
+// happens rather than waiting for some unrelated render to notice lazily.
+subscribePartnerCurrencyCache(() => {
+  if (syncToPartnerCurrencyGeneration()) notify();
+});
+
 /**
  * THE key for one cached total — every read and write goes through here.
  *
- * The key is `${date}|${groupsParam}`, but each entry is denominated in the
- * SERVER-derived partner reporting currency, which the key cannot name (the
- * client never asks for a target; an organization-scoped viewer cannot even
- * read `/orgs/partners/me`). So an admin who changes the partner reporting
- * currency in the same tab would keep reading — and formatting — figures in the
- * OLD currency until logout.
+ * The key is `${generation}|${date}|${groupsParam}`: the generation prefix is
+ * what makes a discarded in-flight response self-heal instead of pinning a
+ * stale `failed` status. Without it, a response that lands mid-flight for a
+ * generation that has since moved on could still be read back against a
+ * same-named key later — the generation guard in `loadApproximateTotal`
+ * already refuses to COMMIT such a response, but a mounted line's own effect
+ * needs the key itself to change so it re-subscribes to a fresh request
+ * rather than resolving into the discarded one silently (#4472). Each entry
+ * is denominated in the SERVER-derived partner reporting currency, which the
+ * key otherwise could not name (the client never asks for a target; an
+ * organization-scoped viewer cannot even read `/orgs/partners/me`), so
+ * without the generation prefix an admin who changes the partner reporting
+ * currency in the same tab would keep reading — and formatting — figures in
+ * the OLD currency until logout.
  *
  * Rather than guess the target, the cache is bound to the partner-currency
  * cache's reset epoch: whatever invalidates THAT (logout, saving partner
- * billing settings) invalidates these totals in the same motion. Observing a
- * new epoch clears the values AND bumps our own generation, so an answer
- * already in flight under the previous currency is discarded by the existing
- * generation check instead of committing.
+ * billing settings) invalidates these totals in the same motion — eagerly,
+ * via the `subscribePartnerCurrencyCache` listener above, not just here. This
+ * lazy check is kept as a fallback for any caller that reads the cache
+ * without having been subscribed (e.g. a render that raced module
+ * evaluation); it is idempotent with the eager path.
  *
  * Resolving the partner currency for the first time is not a change and does
  * not bump the generation, so ordinary de-duplication is untouched.
  */
 export function approximateTotalCacheKey(date: string, groupsParam: string): string {
-  if (approximateTotalCache.partnerCurrencyGeneration !== partnerCurrencyCache.generation) {
-    approximateTotalCache.partnerCurrencyGeneration = partnerCurrencyCache.generation;
-    approximateTotalCache.values.clear();
-    approximateTotalCache.inflight.clear();
-    approximateTotalCache.generation += 1;
-  }
-  return `${date}|${groupsParam}`;
+  if (syncToPartnerCurrencyGeneration()) notify();
+  return `${approximateTotalCache.generation}|${date}|${groupsParam}`;
 }
 
 /** Forget every cached approximate total and invalidate all in-flight
@@ -71,4 +123,5 @@ export function resetApproximateTotalCache(): void {
   approximateTotalCache.values.clear();
   approximateTotalCache.inflight.clear();
   approximateTotalCache.generation += 1;
+  notify();
 }

--- a/apps/web/src/lib/approximateTotalCache.ts
+++ b/apps/web/src/lib/approximateTotalCache.ts
@@ -28,6 +28,8 @@
 // force its own re-render via `useSyncExternalStore` even with nothing else
 // changing.
 
+import * as Sentry from '@sentry/astro';
+
 import { partnerCurrencyCache, subscribePartnerCurrencyCache } from './partnerCurrencyCache';
 import type { ReportingTotalResponse } from './reporting/approximateTotal';
 
@@ -58,8 +60,19 @@ export function subscribeApproximateTotalCache(listener: () => void): () => void
   return () => { listeners.delete(listener); };
 }
 
+/** Each listener runs in its own try/catch: `Set.forEach` aborts on the first
+ *  throw, which would otherwise propagate into whatever caller triggered the
+ *  reset (e.g. `resetPartnerCurrencyCache()`'s own listener, from inside a
+ *  billing-settings save) and silently skip every listener registered after
+ *  the throwing one — reintroducing #4472 for those subscribers. */
 function notify(): void {
-  listeners.forEach((listener) => listener());
+  listeners.forEach((listener) => {
+    try {
+      listener();
+    } catch (error) {
+      Sentry.captureException(error);
+    }
+  });
 }
 
 /** Clear this cache and bump its generation if the partner-currency cache has

--- a/apps/web/src/lib/partnerCurrencyCache.ts
+++ b/apps/web/src/lib/partnerCurrencyCache.ts
@@ -16,6 +16,14 @@
 // than discovering it lazily on the next unrelated render — a reset that
 // nobody happens to re-render for is otherwise invisible until something
 // else forces one (#4472).
+//
+// Each listener is called in its own try/catch: `Set.forEach` aborts on the
+// first throw, which would otherwise (a) propagate into whatever CALLER
+// triggered the reset — e.g. the billing-settings save success handler — and
+// (b) silently skip every listener registered after the throwing one,
+// reintroducing #4472 for those subscribers with no signal anywhere.
+
+import * as Sentry from '@sentry/astro';
 
 export const partnerCurrencyCache: {
   value: string | null;
@@ -39,5 +47,11 @@ export function resetPartnerCurrencyCache(): void {
   partnerCurrencyCache.value = null;
   partnerCurrencyCache.inflight = null;
   partnerCurrencyCache.generation += 1;
-  listeners.forEach((listener) => listener());
+  listeners.forEach((listener) => {
+    try {
+      listener();
+    } catch (error) {
+      Sentry.captureException(error);
+    }
+  });
 }

--- a/apps/web/src/lib/partnerCurrencyCache.ts
+++ b/apps/web/src/lib/partnerCurrencyCache.ts
@@ -10,12 +10,27 @@
 // (logout) bumps it, so a request started under partner A that resolves after
 // partner B logged in can neither commit A's currency over B's cache nor clear
 // B's newer in-flight request (#3777 review F7).
+//
+// `subscribePartnerCurrencyCache` lets a DOWNSTREAM module-level cache
+// (approximateTotalCache.ts) react to a reset the instant it happens, rather
+// than discovering it lazily on the next unrelated render — a reset that
+// nobody happens to re-render for is otherwise invisible until something
+// else forces one (#4472).
 
 export const partnerCurrencyCache: {
   value: string | null;
   inflight: Promise<string | null> | null;
   generation: number;
 } = { value: null, inflight: null, generation: 0 };
+
+const listeners = new Set<() => void>();
+
+/** Notified synchronously every time `resetPartnerCurrencyCache()` runs.
+ *  Returns an unsubscribe function. */
+export function subscribePartnerCurrencyCache(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => { listeners.delete(listener); };
+}
 
 /** Forget the cached partner currency and invalidate every request already in
  *  flight. Called on logout so a partner switch in the same tab never renders
@@ -24,4 +39,5 @@ export function resetPartnerCurrencyCache(): void {
   partnerCurrencyCache.value = null;
   partnerCurrencyCache.inflight = null;
   partnerCurrencyCache.generation += 1;
+  listeners.forEach((listener) => listener());
 }

--- a/apps/web/src/lib/useApproximateTotal.ts
+++ b/apps/web/src/lib/useApproximateTotal.ts
@@ -20,10 +20,15 @@
 // got a line that simply never appeared. Every non-2xx — including the 409
 // NO_REPORTING_CURRENCY a partner can effectively never hit — lands here and
 // reads the same to the user.
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useSyncExternalStore } from 'react';
 
 import { fetchWithAuth } from '../stores/auth';
-import { approximateTotalCache, approximateTotalCacheKey, resetApproximateTotalCache } from './approximateTotalCache';
+import {
+  approximateTotalCache,
+  approximateTotalCacheKey,
+  resetApproximateTotalCache,
+  subscribeApproximateTotalCache,
+} from './approximateTotalCache';
 import { buildGroupsParam, type ReportingTotalResponse } from './reporting/approximateTotal';
 
 export { resetApproximateTotalCache };
@@ -147,6 +152,16 @@ export function useApproximateTotal(
   byCurrency: readonly { code: string; amount: string | number }[],
   date?: string,
 ): ApproximateTotalState {
+  // Force a re-render the instant a partner-currency (or logout) reset bumps
+  // the cache generation — an already-mounted line has no other reason to
+  // re-render when a module-level cache changes underneath it, which is
+  // exactly why the reset used to go unnoticed here (#4472).
+  const generation = useSyncExternalStore(
+    subscribeApproximateTotalCache,
+    () => approximateTotalCache.generation,
+    () => approximateTotalCache.generation,
+  );
+
   const query = buildGroupsParam(byCurrency);
   const groupsParam = query.kind === 'query' ? query.value : '';
   // An empty book has nothing to say; a book we could not encode is a failure
@@ -188,7 +203,11 @@ export function useApproximateTotal(
         : { response: null, loading: false, failed: true });
     });
     return () => { cancelled = true; };
-  }, [key, groupsParam, requestDate, unbuildable]);
+    // `key` already embeds `generation` (approximateTotalCacheKey), but it is
+    // listed explicitly too: the whole bug (#4472) was this effect running
+    // stale on a reset it had no dependency on, so the cache generation
+    // belongs in this list on its own, not only folded into a derived string.
+  }, [key, groupsParam, requestDate, unbuildable, generation]);
 
   return state;
 }

--- a/apps/web/src/lib/useApproximateTotal.ts
+++ b/apps/web/src/lib/useApproximateTotal.ts
@@ -195,9 +195,17 @@ export function useApproximateTotal(
     }
 
     let cancelled = false;
+    // Captured so the `.then` below can tell "discarded by a reset" apart
+    // from "genuinely failed" WITHOUT relying solely on `cancelled`. Cleanup
+    // setting `cancelled = true` only wins that race in practice because
+    // `notify()` (approximateTotalCache.ts) runs synchronously while a fetch
+    // resolution takes further microtask hops — real today, but not a
+    // structural guarantee, and a false `failed` on an otherwise-healthy
+    // newer state is exactly the silent failure #4472 was already about.
+    const startedGeneration = approximateTotalCache.generation;
     setState({ response: null, loading: true, failed: false });
     void loadApproximateTotal(groupsParam, requestDate).then((response) => {
-      if (cancelled) return;
+      if (cancelled || approximateTotalCache.generation !== startedGeneration) return;
       setState(response
         ? { response, loading: false, failed: false }
         : { response: null, loading: false, failed: true });


### PR DESCRIPTION
## Summary

- The approximate-total cache's generation was only synced **lazily** inside `approximateTotalCacheKey()`, which runs during render — so an already-mounted `useApproximateTotal` line with no other reason to re-render never noticed `resetPartnerCurrencyCache()` (a same-tab partner reporting-currency save in `PartnerBillingSettings.tsx`) and kept its stale total. Every existing test happened to unmount + remount around the reset, which sidesteps this: a fresh mount always computes a fresh key.
- The cache key also didn't encode generation, so a stale in-flight response discarded by the existing generation guard (`loadApproximateTotal`) could leave a mounted line pinned on "could not load exchange rates" with nothing to self-heal it.

## Fix

- `apps/web/src/lib/partnerCurrencyCache.ts`: add `subscribePartnerCurrencyCache()` so a reset notifies listeners synchronously the instant it happens, instead of only being observable lazily on the next unrelated render.
- `apps/web/src/lib/approximateTotalCache.ts`: subscribe to that eagerly at module load (clearing this cache and bumping its own generation the moment the partner-currency cache resets), fold the generation into `approximateTotalCacheKey()`'s return value, and expose `subscribeApproximateTotalCache()` for consumers. The old lazy check is kept as an idempotent fallback.
- `apps/web/src/lib/useApproximateTotal.ts`: use `useSyncExternalStore` on the new subscription so a mounted line force-renders on a reset (a module-level mutation React otherwise has no way to notice), and list the generation explicitly in the effect's own dependency array alongside the now generation-scoped `key`.

## Test plan

- [x] New tests in `useApproximateTotal.test.tsx` cover the case none of the existing tests did: a **single mounted instance, never unmounted**, that must refetch in place after `resetPartnerCurrencyCache()`, self-heal from a stale in-flight response discarded by the generation guard, and survive a plain `resetApproximateTotalCache()` (logout) too.
- [x] `cd apps/web && npx vitest run src/lib/__tests__/useApproximateTotal.test.tsx` — 29 passed
- [x] `cd apps/web && npx vitest run src/lib/__tests__/usePartnerCurrency.test.tsx src/components/billing/PartnerBillingSettings.test.tsx` — 26 passed
- [x] `cd apps/web && npx tsc --noEmit` — clean
- [x] `cd apps/web && npx eslint` on the four changed files — clean

Closes #4472

🤖 Generated with [Claude Code](https://claude.com/claude-code)