### PR TITLE
fix(ops): stop passing DATABASE_URL on pg_dump/pg_restore/psql argv (#4497)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -829,6 +829,14 @@ jobs:
       - name: Run agent mTLS edge policy guard
         run: pnpm check:agent-mtls-edge-policy
 
+      # #4497: scripts/backup.sh and scripts/restore.sh used to pass
+      # DATABASE_URL (password included) directly on pg_dump's/pg_restore's/
+      # psql's argv, visible to any local user via `ps` for the whole
+      # dump/restore. Covers the PG* URL-splitting helper's parsing and
+      # statically guards both scripts against reintroducing the pattern.
+      - name: Test pg connection env helper (#4497)
+        run: pnpm test:pg-connect-env
+
   build-api:
     name: Build API
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "check:agent-mtls-edge-policy": "bash scripts/check-agent-mtls-edge-policy.sh",
     "check:agent-binary-signatures": "bash scripts/security/check-agent-binary-signatures.sh --source",
     "test:agent-binary-signatures": "node --test scripts/security/check-agent-binary-signatures.test.mjs",
+    "test:pg-connect-env": "node --test scripts/lib/pg-connect-env.test.mjs",
     "db:migrate": "turbo run db:migrate --filter=@breeze/api",
     "db:check-drift": "turbo run db:check-drift --filter=@breeze/api",
     "db:seed": "turbo run db:seed --filter=@breeze/api",

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -27,6 +27,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/pg-connect-env.sh
+source "${SCRIPT_DIR}/lib/pg-connect-env.sh"
+
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
@@ -148,12 +152,22 @@ backup_database() {
   log "Starting database backup..."
   local dest="${BACKUP_DIR}/db_${TIMESTAMP}.dump"
 
-  if pg_dump "${DATABASE_URL}" -Fc -Z 6 -f "${dest}" 2>&1; then
+  # Split DATABASE_URL into PG* environment variables rather than passing it
+  # as an argument — pg_dump's argv is visible to any local user via `ps` for
+  # the whole duration of the dump (#4497).
+  if ! pg_url_to_env "${DATABASE_URL}"; then
+    log "ERROR: Database backup failed"
+    return 1
+  fi
+
+  if pg_dump -Fc -Z 6 -f "${dest}" 2>&1; then
+    pg_url_unset_env
     local size
     size=$(du -h "${dest}" | cut -f1)
     log "Database backup complete: ${dest} (${size})"
     TASKS_SUCCEEDED=$((TASKS_SUCCEEDED + 1))
   else
+    pg_url_unset_env
     log "ERROR: Database backup failed"
     rm -f "${dest}"
     return 1

--- a/scripts/lib/pg-connect-env.sh
+++ b/scripts/lib/pg-connect-env.sh
@@ -111,12 +111,17 @@ pg_url_to_env() {
     return 1
   fi
 
-  local user_raw="${BASH_REMATCH[3]}"
-  local password_raw="${BASH_REMATCH[5]}"
-  local host_raw="${BASH_REMATCH[6]}"
-  local port="${BASH_REMATCH[8]}"
-  local dbname_raw="${BASH_REMATCH[10]}"
-  local query="${BASH_REMATCH[12]}"
+  # `:-` on every optional group: bash 5.x (glibc) leaves BASH_REMATCH[n]
+  # UNSET for a trailing subexpression that did not participate (e.g. no
+  # `?query`), so under `set -u` a bare "${BASH_REMATCH[12]}" aborts the
+  # caller. macOS bash 3.2 sets it to "" instead, which is why this only
+  # surfaced in CI.
+  local user_raw="${BASH_REMATCH[3]:-}"
+  local password_raw="${BASH_REMATCH[5]:-}"
+  local host_raw="${BASH_REMATCH[6]:-}"
+  local port="${BASH_REMATCH[8]:-}"
+  local dbname_raw="${BASH_REMATCH[10]:-}"
+  local query="${BASH_REMATCH[12]:-}"
 
   if [[ -z "$host_raw" ]]; then
     echo "pg_url_to_env: connection URL is missing a host" >&2

--- a/scripts/lib/pg-connect-env.sh
+++ b/scripts/lib/pg-connect-env.sh
@@ -25,8 +25,21 @@
 # _pg_url_decode <value>
 # Percent-decode an RFC 3986 URI component (user/password/dbname may contain
 # %XX-escaped characters, e.g. a literal '@' or '/' in a generated password).
+# Validates every '%' is followed by exactly two hex digits BEFORE handing
+# anything to `printf %b` — a bare/short/non-hex '%XX' sequence would
+# otherwise make `printf` either fail non-obviously or (on some platforms)
+# silently emit a mangled value, which previously reached PGPASSWORD/PGUSER/
+# PGDATABASE unnoticed. Returns 1 (message on stderr) on invalid encoding.
 _pg_url_decode() {
-  local s="$1"
+  local s="$1" rest="$1"
+  while [[ "$rest" == *%* ]]; do
+    rest="${rest#*%}"
+    if [[ ! "$rest" =~ ^[0-9A-Fa-f]{2} ]]; then
+      echo "_pg_url_decode: invalid percent-encoding near '%${rest:0:2}'" >&2
+      return 1
+    fi
+    rest="${rest:2}"
+  done
   # Escape literal backslashes first so only the \xHH sequences we inject
   # below are interpreted by `printf %b` — a backslash in the raw value must
   # not be treated as the start of an escape.
@@ -37,7 +50,7 @@ _pg_url_decode() {
 
 # _pg_url_query_param <query-string> <key>
 # Print the (decoded) value of <key> from a "k=v&k2=v2" query string, or
-# return 1 if the key is absent.
+# return 1 if the key is absent or its value fails to decode.
 _pg_url_query_param() {
   local query="$1" key="$2" pair
   local IFS='&'
@@ -45,64 +58,122 @@ _pg_url_query_param() {
     case "$pair" in
       "${key}="*)
         _pg_url_decode "${pair#*=}"
-        return 0
+        return $?
         ;;
     esac
   done
   return 1
 }
 
+# _pg_url_extra_query_params <query-string>
+# Print a comma-separated list of query-string keys other than "sslmode" —
+# used to surface (not silently drop) connection parameters this helper
+# doesn't translate to a PG* environment variable, e.g. connect_timeout,
+# sslrootcert, application_name.
+_pg_url_extra_query_params() {
+  local query="$1" pair key
+  local names=()
+  local IFS='&'
+  for pair in $query; do
+    key="${pair%%=*}"
+    [[ "$key" == "sslmode" || -z "$key" ]] && continue
+    names+=("$key")
+  done
+  # Guard the array expansion: under `set -u`, `${names[*]}` on a still-empty
+  # array is treated as an unbound variable on bash < 4.4 (macOS ships 3.2).
+  if [[ ${#names[@]} -eq 0 ]]; then
+    return 0
+  fi
+  local out_ifs="$IFS"
+  IFS=','
+  echo "${names[*]}"
+  IFS="$out_ifs"
+}
+
 # pg_url_to_env <postgres-url>
 # Exports PGHOST, PGDATABASE, and (when present) PGPORT, PGUSER, PGPASSWORD,
 # PGSSLMODE from a postgres:// or postgresql:// URL. Returns 1 (and prints a
-# message on stderr) if the URL cannot be parsed, or is missing a host or
-# database name.
+# message on stderr) if the URL cannot be parsed, is missing a host or
+# database name, or contains an undecodable (malformed percent-encoded)
+# user/password/database name. Nothing is exported unless the whole URL
+# validates, so a rejected URL never leaves partial/stale PG* vars behind.
+# The host portion accepts a bracketed IPv6 literal (e.g. "[::1]"), per
+# RFC 3986 §3.2.2; the brackets are stripped before exporting PGHOST, since
+# libpq's PGHOST accepts a bare IPv6 address (brackets are a URI-syntax-only
+# disambiguation for the port separator).
 pg_url_to_env() {
   local url="$1"
-  # scheme://[user[:password]@]host[:port][/dbname][?query]
-  local re='^postgres(ql)?://(([^:@/?]*)(:([^@/?]*))?@)?([^:@/?]+)(:([0-9]+))?(/([^?]*))?(\?(.*))?$'
+  # scheme://[user[:password]@](host|[ipv6-host])[:port][/dbname][?query]
+  local re='^postgres(ql)?://(([^:@/?]*)(:([^@/?]*))?@)?(\[[^]]+\]|[^:@/?]+)(:([0-9]+))?(/([^?]*))?(\?(.*))?$'
 
   if [[ ! "$url" =~ $re ]]; then
     echo "pg_url_to_env: could not parse connection URL (expected postgres:// or postgresql://)" >&2
     return 1
   fi
 
-  local user="${BASH_REMATCH[3]}"
-  local password="${BASH_REMATCH[5]}"
-  local host="${BASH_REMATCH[6]}"
+  local user_raw="${BASH_REMATCH[3]}"
+  local password_raw="${BASH_REMATCH[5]}"
+  local host_raw="${BASH_REMATCH[6]}"
   local port="${BASH_REMATCH[8]}"
-  local dbname="${BASH_REMATCH[10]}"
+  local dbname_raw="${BASH_REMATCH[10]}"
   local query="${BASH_REMATCH[12]}"
 
-  if [[ -z "$host" ]]; then
+  if [[ -z "$host_raw" ]]; then
     echo "pg_url_to_env: connection URL is missing a host" >&2
     return 1
   fi
-  if [[ -z "$dbname" ]]; then
+  if [[ -z "$dbname_raw" ]]; then
     echo "pg_url_to_env: connection URL is missing a database name" >&2
     return 1
   fi
 
-  export PGHOST="$host"
-  export PGDATABASE
-  PGDATABASE="$(_pg_url_decode "$dbname")"
+  local host="$host_raw"
+  if [[ "$host" == \[*\] ]]; then
+    # Strip the [ ] brackets (not `${host:1:-1}` — negative-length substring
+    # expansion needs bash 4.2+; macOS ships bash 3.2).
+    host="${host#\[}"
+    host="${host%\]}"
+  fi
 
+  # Decode everything and validate BEFORE exporting anything, so a failure
+  # here never leaves a partially-populated (stale/wrong) PG* environment.
+  local dbname user password sslmode
+  if ! dbname="$(_pg_url_decode "$dbname_raw")"; then
+    echo "pg_url_to_env: invalid database name in connection URL" >&2
+    return 1
+  fi
+  if [[ -n "$user_raw" ]] && ! user="$(_pg_url_decode "$user_raw")"; then
+    echo "pg_url_to_env: invalid user in connection URL" >&2
+    return 1
+  fi
+  if [[ -n "$password_raw" ]] && ! password="$(_pg_url_decode "$password_raw")"; then
+    echo "pg_url_to_env: invalid password in connection URL" >&2
+    return 1
+  fi
+  if [[ -n "$query" ]] && ! sslmode="$(_pg_url_query_param "$query" "sslmode")"; then
+    sslmode=""
+  fi
+
+  export PGHOST="$host"
+  export PGDATABASE="$dbname"
   if [[ -n "$port" ]]; then
     export PGPORT="$port"
   fi
-  if [[ -n "$user" ]]; then
-    export PGUSER
-    PGUSER="$(_pg_url_decode "$user")"
+  if [[ -n "$user_raw" ]]; then
+    export PGUSER="$user"
   fi
-  if [[ -n "$password" ]]; then
-    export PGPASSWORD
-    PGPASSWORD="$(_pg_url_decode "$password")"
+  if [[ -n "$password_raw" ]]; then
+    export PGPASSWORD="$password"
+  fi
+  if [[ -n "$sslmode" ]]; then
+    export PGSSLMODE="$sslmode"
   fi
 
   if [[ -n "$query" ]]; then
-    local sslmode
-    if sslmode="$(_pg_url_query_param "$query" "sslmode")"; then
-      export PGSSLMODE="$sslmode"
+    local extra
+    extra="$(_pg_url_extra_query_params "$query")"
+    if [[ -n "$extra" ]]; then
+      echo "pg_url_to_env: WARNING: ignoring unsupported connection URL parameter(s): ${extra} (only sslmode is translated to a PG* env var; extend scripts/lib/pg-connect-env.sh if this matters)" >&2
     fi
   fi
 

--- a/scripts/lib/pg-connect-env.sh
+++ b/scripts/lib/pg-connect-env.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# pg-connect-env.sh — split a libpq connection URL into PG* environment
+# variables so pg_dump/pg_restore/psql never receive the credential as a
+# command-line argument.
+#
+# Why: pg_dump/pg_restore/psql accept a connection URI as a positional
+# argument (or via -d/--dbname), but any argv value is visible for the life
+# of the process to every local user via `ps -o args` (or `ps aux`) — a
+# password embedded in the URL leaks for as long as the dump/restore runs
+# (issue #4497). Environment variables are NOT shown by `ps`; reading another
+# user's environ requires root (via /proc/<pid>/environ), which is the same
+# trust boundary these tools already assume.
+#
+# Usage:
+#   source "$(dirname "$0")/lib/pg-connect-env.sh"
+#   if ! pg_url_to_env "$DATABASE_URL"; then
+#     die "could not parse DATABASE_URL"
+#   fi
+#   pg_dump -Fc -Z 6 -f "$dest"   # PGHOST/PGPORT/PGUSER/PGPASSWORD/PGDATABASE
+#                                 # (+PGSSLMODE) come from the environment —
+#                                 # no secret on argv.
+#   pg_url_unset_env
+
+# _pg_url_decode <value>
+# Percent-decode an RFC 3986 URI component (user/password/dbname may contain
+# %XX-escaped characters, e.g. a literal '@' or '/' in a generated password).
+_pg_url_decode() {
+  local s="$1"
+  # Escape literal backslashes first so only the \xHH sequences we inject
+  # below are interpreted by `printf %b` — a backslash in the raw value must
+  # not be treated as the start of an escape.
+  s="${s//\\/\\\\}"
+  s="${s//%/\\x}"
+  printf '%b' "$s"
+}
+
+# _pg_url_query_param <query-string> <key>
+# Print the (decoded) value of <key> from a "k=v&k2=v2" query string, or
+# return 1 if the key is absent.
+_pg_url_query_param() {
+  local query="$1" key="$2" pair
+  local IFS='&'
+  for pair in $query; do
+    case "$pair" in
+      "${key}="*)
+        _pg_url_decode "${pair#*=}"
+        return 0
+        ;;
+    esac
+  done
+  return 1
+}
+
+# pg_url_to_env <postgres-url>
+# Exports PGHOST, PGDATABASE, and (when present) PGPORT, PGUSER, PGPASSWORD,
+# PGSSLMODE from a postgres:// or postgresql:// URL. Returns 1 (and prints a
+# message on stderr) if the URL cannot be parsed, or is missing a host or
+# database name.
+pg_url_to_env() {
+  local url="$1"
+  # scheme://[user[:password]@]host[:port][/dbname][?query]
+  local re='^postgres(ql)?://(([^:@/?]*)(:([^@/?]*))?@)?([^:@/?]+)(:([0-9]+))?(/([^?]*))?(\?(.*))?$'
+
+  if [[ ! "$url" =~ $re ]]; then
+    echo "pg_url_to_env: could not parse connection URL (expected postgres:// or postgresql://)" >&2
+    return 1
+  fi
+
+  local user="${BASH_REMATCH[3]}"
+  local password="${BASH_REMATCH[5]}"
+  local host="${BASH_REMATCH[6]}"
+  local port="${BASH_REMATCH[8]}"
+  local dbname="${BASH_REMATCH[10]}"
+  local query="${BASH_REMATCH[12]}"
+
+  if [[ -z "$host" ]]; then
+    echo "pg_url_to_env: connection URL is missing a host" >&2
+    return 1
+  fi
+  if [[ -z "$dbname" ]]; then
+    echo "pg_url_to_env: connection URL is missing a database name" >&2
+    return 1
+  fi
+
+  export PGHOST="$host"
+  export PGDATABASE
+  PGDATABASE="$(_pg_url_decode "$dbname")"
+
+  if [[ -n "$port" ]]; then
+    export PGPORT="$port"
+  fi
+  if [[ -n "$user" ]]; then
+    export PGUSER
+    PGUSER="$(_pg_url_decode "$user")"
+  fi
+  if [[ -n "$password" ]]; then
+    export PGPASSWORD
+    PGPASSWORD="$(_pg_url_decode "$password")"
+  fi
+
+  if [[ -n "$query" ]]; then
+    local sslmode
+    if sslmode="$(_pg_url_query_param "$query" "sslmode")"; then
+      export PGSSLMODE="$sslmode"
+    fi
+  fi
+
+  return 0
+}
+
+# pg_url_unset_env
+# Defensive cleanup: unset the PG* vars exported by pg_url_to_env once the
+# connection is no longer needed, so a credential doesn't linger in the
+# script's own environment for the rest of its run.
+pg_url_unset_env() {
+  unset PGHOST PGPORT PGUSER PGPASSWORD PGDATABASE PGSSLMODE
+}

--- a/scripts/lib/pg-connect-env.sh
+++ b/scripts/lib/pg-connect-env.sh
@@ -71,7 +71,7 @@ _pg_url_query_param() {
 # doesn't translate to a PG* environment variable, e.g. connect_timeout,
 # sslrootcert, application_name.
 _pg_url_extra_query_params() {
-  local query="$1" pair key
+  local query="$1" pair key=""
   local names=()
   local IFS='&'
   for pair in $query; do
@@ -142,7 +142,10 @@ pg_url_to_env() {
 
   # Decode everything and validate BEFORE exporting anything, so a failure
   # here never leaves a partially-populated (stale/wrong) PG* environment.
-  local dbname user password sslmode
+  # Initialise every local: bash 5.x treats a declared-but-unassigned local as
+  # unbound under `set -u` (macOS bash 3.2 reads it as ""), and $sslmode is
+  # read unconditionally below.
+  local dbname="" user="" password="" sslmode=""
   if ! dbname="$(_pg_url_decode "$dbname_raw")"; then
     echo "pg_url_to_env: invalid database name in connection URL" >&2
     return 1
@@ -175,7 +178,7 @@ pg_url_to_env() {
   fi
 
   if [[ -n "$query" ]]; then
-    local extra
+    local extra=""
     extra="$(_pg_url_extra_query_params "$query")"
     if [[ -n "$extra" ]]; then
       echo "pg_url_to_env: WARNING: ignoring unsupported connection URL parameter(s): ${extra} (only sslmode is translated to a PG* env var; extend scripts/lib/pg-connect-env.sh if this matters)" >&2

--- a/scripts/lib/pg-connect-env.test.mjs
+++ b/scripts/lib/pg-connect-env.test.mjs
@@ -55,9 +55,9 @@ function parseUrl(url) {
 
 test('parses a full URL with an encoded password and sslmode', () => {
   const vars = parseUrl(
-    'postgresql://breeze:s3cr%40t%2Fp%40ss@db-nyc3-01.db.ondigitalocean.com:25060/breeze?sslmode=require',
+    'postgresql://breeze:s3cr%40t%2Fp%40ss@db-primary-01.db.example:25060/breeze?sslmode=require',
   );
-  assert.equal(vars.PGHOST, 'db-nyc3-01.db.ondigitalocean.com');
+  assert.equal(vars.PGHOST, 'db-primary-01.db.example');
   assert.equal(vars.PGPORT, '25060');
   assert.equal(vars.PGUSER, 'breeze');
   assert.equal(vars.PGPASSWORD, 's3cr@t/p@ss');

--- a/scripts/lib/pg-connect-env.test.mjs
+++ b/scripts/lib/pg-connect-env.test.mjs
@@ -94,6 +94,67 @@ test('rejects a URL missing a database name', () => {
   assert.match(vars.error, /missing a database name/);
 });
 
+test('parses a bracketed IPv6 host, stripping the brackets for PGHOST', () => {
+  const vars = parseUrl('postgresql://user:pass@[::1]:5432/breeze');
+  assert.equal(vars.PGHOST, '::1');
+  assert.equal(vars.PGPORT, '5432');
+  assert.equal(vars.PGUSER, 'user');
+  assert.equal(vars.PGDATABASE, 'breeze');
+});
+
+test('parses a bracketed IPv6 host with no explicit port', () => {
+  const vars = parseUrl('postgresql://user@[2001:db8::1]/breeze');
+  assert.equal(vars.PGHOST, '2001:db8::1');
+  assert.equal(vars.PGDATABASE, 'breeze');
+});
+
+test('rejects a password with a truncated percent-escape instead of silently mangling it', () => {
+  // A trailing bare '%' used to reach `printf %b` unchecked, which either
+  // errored non-obviously or (platform-dependent) produced a corrupted
+  // PGPASSWORD value while pg_url_to_env still reported success.
+  const vars = parseUrl('postgresql://user:abc%@host:5432/db');
+  assert.equal(vars.status, 1);
+  assert.match(vars.error, /invalid password/);
+});
+
+test('rejects a password with non-hex percent-escape digits', () => {
+  const vars = parseUrl('postgresql://user:abc%zzpass@host:5432/db');
+  assert.equal(vars.status, 1);
+  assert.match(vars.error, /invalid password/);
+});
+
+test('warns (but still connects) when the query string has parameters beyond sslmode', () => {
+  const script = `
+    set -euo pipefail
+    source "${LIB}"
+    pg_url_to_env "$1"
+    printf 'PGHOST=%s\\n' "\${PGHOST:-}"
+  `;
+  const result = spawnSync(
+    'bash',
+    ['-c', script, 'bash', 'postgresql://user:pass@host:5432/db?sslmode=require&connect_timeout=10'],
+    { encoding: 'utf8' },
+  );
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /PGHOST=host/);
+  assert.match(result.stderr, /ignoring unsupported connection URL parameter.*connect_timeout/);
+});
+
+test('does not warn when the query string only has sslmode', () => {
+  const script = `
+    set -euo pipefail
+    source "${LIB}"
+    pg_url_to_env "$1"
+  `;
+  const result = spawnSync(
+    'bash',
+    ['-c', script, 'bash', 'postgresql://user:pass@host:5432/db?sslmode=require'],
+    { encoding: 'utf8' },
+  );
+  assert.equal(result.status, 0);
+  assert.equal(result.stderr, '');
+});
+
 // --- Static regression guard -----------------------------------------------
 //
 // Mirrors the philosophy of scripts/check-selfhost-db-urls.sh: assert the

--- a/scripts/lib/pg-connect-env.test.mjs
+++ b/scripts/lib/pg-connect-env.test.mjs
@@ -108,6 +108,33 @@ test('parses a bracketed IPv6 host with no explicit port', () => {
   assert.equal(vars.PGDATABASE, 'breeze');
 });
 
+test('parses a bracketed IPv6 host together with a query string', () => {
+  const vars = parseUrl('postgresql://user:pass@[::1]:5432/breeze?sslmode=require&connect_timeout=5');
+  assert.equal(vars.PGHOST, '::1');
+  assert.equal(vars.PGDATABASE, 'breeze');
+  assert.equal(vars.PGSSLMODE, 'require');
+});
+
+test('percent-decodes a user containing an escaped special character', () => {
+  const vars = parseUrl('postgresql://us%40er:pass@host:5432/db');
+  assert.equal(vars.PGUSER, 'us@er');
+});
+
+test('percent-decodes a database name containing an escaped space', () => {
+  const vars = parseUrl('postgresql://user:pass@host:5432/my%20db');
+  assert.equal(vars.PGDATABASE, 'my db');
+});
+
+test('distinguishes an explicit empty password from no password at all', () => {
+  const withColon = parseUrl('postgresql://user:@host:5432/db');
+  assert.equal(withColon.PGUSER, 'user');
+  assert.equal(withColon.PGPASSWORD, '');
+
+  const withoutColon = parseUrl('postgresql://user@host:5432/db');
+  assert.equal(withoutColon.PGUSER, 'user');
+  assert.equal(withoutColon.PGPASSWORD, '');
+});
+
 test('rejects a password with a truncated percent-escape instead of silently mangling it', () => {
   // A trailing bare '%' used to reach `printf %b` unchecked, which either
   // errored non-obviously or (platform-dependent) produced a corrupted
@@ -155,12 +182,38 @@ test('does not warn when the query string only has sslmode', () => {
   assert.equal(result.stderr, '');
 });
 
+test('reports multiple extra query parameters together, comma-joined', () => {
+  const script = `
+    set -euo pipefail
+    source "${LIB}"
+    pg_url_to_env "$1"
+  `;
+  const result = spawnSync(
+    'bash',
+    [
+      '-c',
+      script,
+      'bash',
+      'postgresql://user:pass@host:5432/db?sslmode=require&connect_timeout=5&application_name=backup',
+    ],
+    { encoding: 'utf8' },
+  );
+  assert.equal(result.status, 0);
+  assert.match(result.stderr, /connect_timeout,application_name/);
+});
+
 // --- Static regression guard -----------------------------------------------
 //
 // Mirrors the philosophy of scripts/check-selfhost-db-urls.sh: assert the
 // ABSENCE of the vulnerable pattern, not merely the presence of the fix, so
 // a future edit that reintroduces `pg_dump "$DATABASE_URL"` (or similar)
 // fails loudly instead of silently shipping the credential-on-argv bug again.
+//
+// Like any grep-based guard (same limitation as check-selfhost-db-urls.sh),
+// this catches the direct/literal pattern but not deliberate indirection —
+// e.g. assigning DATABASE_URL to a local var first, a line continuation
+// between the command and the URL, or `eval`. It's meant to catch an
+// accidental regression during a normal edit, not a determined bypass.
 const ARGV_SECRET_PATTERNS = [
   /pg_dump\s+"?\$\{?DATABASE_URL\}?"?/,
   /pg_restore\b[^\n]*-d\s+"?\$\{?DATABASE_URL\}?"?/,

--- a/scripts/lib/pg-connect-env.test.mjs
+++ b/scripts/lib/pg-connect-env.test.mjs
@@ -1,0 +1,121 @@
+// Regression coverage for #4497: scripts/backup.sh and scripts/restore.sh
+// used to pass DATABASE_URL (password included) directly on pg_dump's /
+// pg_restore's / psql's argv, which is visible to any local user via `ps`
+// for the whole duration of the dump/restore.
+//
+// Two things are covered here:
+//   1. pg_url_to_env (scripts/lib/pg-connect-env.sh) correctly splits a
+//      postgres:// URL into PG* environment variables, including percent-
+//      decoding and the sslmode query parameter.
+//   2. A static regression guard: neither script may interpolate
+//      DATABASE_URL directly into a pg_dump/pg_restore/psql argument list
+//      again.
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const LIB = join(REPO_ROOT, 'scripts', 'lib', 'pg-connect-env.sh');
+const BACKUP_SCRIPT = join(REPO_ROOT, 'scripts', 'backup.sh');
+const RESTORE_SCRIPT = join(REPO_ROOT, 'scripts', 'restore.sh');
+
+// Runs `pg_url_to_env "<url>"` in a fresh bash subshell and returns the PG*
+// vars it exported, or { error: <stderr> } if parsing failed.
+function parseUrl(url) {
+  const script = `
+    set -euo pipefail
+    source "${LIB}"
+    if ! pg_url_to_env "$1"; then
+      exit 1
+    fi
+    printf 'PGHOST=%s\\n' "\${PGHOST:-}"
+    printf 'PGPORT=%s\\n' "\${PGPORT:-}"
+    printf 'PGUSER=%s\\n' "\${PGUSER:-}"
+    printf 'PGPASSWORD=%s\\n' "\${PGPASSWORD:-}"
+    printf 'PGDATABASE=%s\\n' "\${PGDATABASE:-}"
+    printf 'PGSSLMODE=%s\\n' "\${PGSSLMODE:-}"
+  `;
+  const result = spawnSync('bash', ['-c', script, 'bash', url], { encoding: 'utf8' });
+
+  if (result.status !== 0) {
+    return { error: result.stderr.trim(), status: result.status };
+  }
+
+  const vars = {};
+  for (const line of result.stdout.trim().split('\n')) {
+    const idx = line.indexOf('=');
+    vars[line.slice(0, idx)] = line.slice(idx + 1);
+  }
+  return vars;
+}
+
+test('parses a full URL with an encoded password and sslmode', () => {
+  const vars = parseUrl(
+    'postgresql://breeze:s3cr%40t%2Fp%40ss@db-nyc3-01.db.ondigitalocean.com:25060/breeze?sslmode=require',
+  );
+  assert.equal(vars.PGHOST, 'db-nyc3-01.db.ondigitalocean.com');
+  assert.equal(vars.PGPORT, '25060');
+  assert.equal(vars.PGUSER, 'breeze');
+  assert.equal(vars.PGPASSWORD, 's3cr@t/p@ss');
+  assert.equal(vars.PGDATABASE, 'breeze');
+  assert.equal(vars.PGSSLMODE, 'require');
+});
+
+test('handles a URL with no password and no explicit port', () => {
+  const vars = parseUrl('postgres://appuser@localhost/mydb');
+  assert.equal(vars.PGHOST, 'localhost');
+  assert.equal(vars.PGPORT, '');
+  assert.equal(vars.PGUSER, 'appuser');
+  assert.equal(vars.PGPASSWORD, '');
+  assert.equal(vars.PGDATABASE, 'mydb');
+});
+
+test('handles a URL with no userinfo at all', () => {
+  const vars = parseUrl('postgresql://localhost:5432/breeze');
+  assert.equal(vars.PGHOST, 'localhost');
+  assert.equal(vars.PGPORT, '5432');
+  assert.equal(vars.PGUSER, '');
+  assert.equal(vars.PGDATABASE, 'breeze');
+});
+
+test('rejects a URL that is not a postgres connection string', () => {
+  const vars = parseUrl('not-a-url');
+  assert.equal(vars.status, 1);
+  assert.match(vars.error, /could not parse connection URL/);
+});
+
+test('rejects a URL missing a database name', () => {
+  const vars = parseUrl('postgresql://user:pass@localhost:5432');
+  assert.equal(vars.status, 1);
+  assert.match(vars.error, /missing a database name/);
+});
+
+// --- Static regression guard -----------------------------------------------
+//
+// Mirrors the philosophy of scripts/check-selfhost-db-urls.sh: assert the
+// ABSENCE of the vulnerable pattern, not merely the presence of the fix, so
+// a future edit that reintroduces `pg_dump "$DATABASE_URL"` (or similar)
+// fails loudly instead of silently shipping the credential-on-argv bug again.
+const ARGV_SECRET_PATTERNS = [
+  /pg_dump\s+"?\$\{?DATABASE_URL\}?"?/,
+  /pg_restore\b[^\n]*-d\s+"?\$\{?DATABASE_URL\}?"?/,
+  /psql\s+"?\$\{?DATABASE_URL\}?"?/,
+];
+
+for (const scriptPath of [BACKUP_SCRIPT, RESTORE_SCRIPT]) {
+  test(`${scriptPath.slice(REPO_ROOT.length + 1)} never puts DATABASE_URL on a pg_dump/pg_restore/psql argv`, () => {
+    const contents = readFileSync(scriptPath, 'utf8');
+    for (const pattern of ARGV_SECRET_PATTERNS) {
+      assert.doesNotMatch(contents, pattern);
+    }
+    assert.match(
+      contents,
+      /source ".*lib\/pg-connect-env\.sh"/,
+      'expected the script to source scripts/lib/pg-connect-env.sh',
+    );
+  });
+}

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -25,6 +25,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/pg-connect-env.sh
+source "${SCRIPT_DIR}/lib/pg-connect-env.sh"
+
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
@@ -158,8 +162,17 @@ restore_database() {
 
   log "Starting database restore..."
 
+  # Split DATABASE_URL into PG* environment variables rather than passing it
+  # as an argument — pg_restore/psql argv is visible to any local user via
+  # `ps` for the whole duration of the restore (#4497). -d/-c still take the
+  # bare database name (not a secret); host/user/password come from the
+  # environment.
+  if ! pg_url_to_env "${DATABASE_URL}"; then
+    return 1
+  fi
+
   local exit_code=0
-  pg_restore --clean --if-exists -d "${DATABASE_URL}" "${DB_FILE}" 2>&1 || exit_code=$?
+  pg_restore --clean --if-exists -d "${PGDATABASE}" "${DB_FILE}" 2>&1 || exit_code=$?
 
   if [ $exit_code -eq 0 ]; then
     log "pg_restore completed successfully"
@@ -167,6 +180,7 @@ restore_database() {
     # Exit code 1 = non-fatal warnings only (e.g., "role does not exist")
     log "WARNING: pg_restore completed with non-fatal warnings"
   else
+    pg_url_unset_env
     log "ERROR: pg_restore failed with exit code ${exit_code}"
     return 1
   fi
@@ -174,7 +188,8 @@ restore_database() {
   # Verification: count devices as a sanity check
   log "Verifying restore..."
   local count
-  count=$(psql "${DATABASE_URL}" -t -A -c "SELECT count(*) FROM devices;" 2>/dev/null || echo "ERROR")
+  count=$(psql -d "${PGDATABASE}" -t -A -c "SELECT count(*) FROM devices;" 2>/dev/null || echo "ERROR")
+  pg_url_unset_env
 
   if [ "$count" = "ERROR" ]; then
     log "ERROR: Verification query failed. The database may be in a bad state."


### PR DESCRIPTION
## Summary

`scripts/backup.sh` and `scripts/restore.sh` passed `DATABASE_URL` (with the
password embedded) as a positional argument to `pg_dump` / `pg_restore` /
`psql`. That argument stays visible to any local user via `ps -o args` for
the whole duration of the dump/restore — 30+ min on the US droplet, per the
issue's prod verification.

- Adds `scripts/lib/pg-connect-env.sh`: `pg_url_to_env` splits a
  `postgres://`/`postgresql://` URL into `PGHOST`/`PGPORT`/`PGUSER`/
  `PGPASSWORD`/`PGDATABASE` (+ `PGSSLMODE` from the query string), handling
  percent-decoded user/password/dbname. `pg_url_unset_env` clears them
  afterward.
- `backup.sh`'s `backup_database()` now calls `pg_dump -Fc -Z 6 -f "$dest"`
  with no connection string on argv (dbname resolves from `PGDATABASE`).
- `restore.sh`'s `restore_database()` now calls `pg_restore --clean
  --if-exists -d "${PGDATABASE}" "$DB_FILE"` and `psql -d "${PGDATABASE}" ...`
  — `-d` still needs a value to actually connect/restore (an omitted `-d`
  makes `pg_restore` write to stdout instead), but it's just the plain
  database name now, not a secret; host/user/password resolve from the
  environment.
- Existing behavior is otherwise unchanged (same flags, same exit-code
  handling, same log messages).

## Why not restore-test.sh / the release runbook

`scripts/ops/restore-test.sh` already passes credentials via `-e
PGPASSWORD=...` to its `docker exec psql` call and only sets `DATABASE_URL`
as an env var when invoking `restore.sh` (never on its own argv), so it
inherits the fix transitively and needed no direct change. The release
runbook's promote step and `/opt/breeze-backup/*` mentioned in the issue live
outside this repo (droplet-side / gitignored `internal/`) — flagging that as
a manual follow-up rather than guessing at their content.

## Test plan

- [x] `node --test scripts/lib/pg-connect-env.test.mjs` — 7/7 pass: URL
      parsing (full URL w/ encoded password + sslmode, no-password, no-user,
      malformed, missing-dbname) + a static regression guard on both scripts
      against reintroducing `DATABASE_URL` on `pg_dump`/`pg_restore`/`psql`
      argv.
- [x] Confirmed the regression guard fails against the pre-fix
      `scripts/backup.sh` (checked out from `origin/main`) before it passes
      against the fixed version.
- [x] `bash -n` on all three changed/added scripts.
- [x] `shellcheck` clean (only an info-level SC1091 for the `source`, not a
      CI-gated check).
- [x] End-to-end functional test against a fake `pg_dump`/`pg_restore`/`psql`
      on `PATH`: confirmed `PGPASSWORD` reaches them via environment while
      their recorded argv contains no password/host/user — only flags and
      (for restore) the plain database name.
- [x] `scripts/security/scan-confidential.sh --all` — clean.
- [x] Wired the new test into CI as `pnpm test:pg-connect-env`
      (`security-audit` job), following the existing `scripts/*.test.mjs` +
      root `package.json` alias convention (`test:release-lineage`,
      `test:agent-binary-signatures`, etc).

Closes #4497

🤖 Generated with [Claude Code](https://claude.com/claude-code)