### PR TITLE
fix(web): add Billing to the Settings sidebar section

### DIFF
--- a/apps/web/src/components/layout/Sidebar.nav.test.tsx
+++ b/apps/web/src/components/layout/Sidebar.nav.test.tsx
@@ -62,6 +62,13 @@ function hrefsOf(id: string) {
 }
 
 describe('navSections structure (#1321, #1324)', () => {
+  it('includes a Billing entry in the Settings section (#4605)', () => {
+    const settings = section('settings');
+    const billingItem = settings.items.find((i) => i.href === '/settings/billing');
+    expect(billingItem, 'Settings section should link to /settings/billing').toBeDefined();
+    expect(billingItem?.labelKey).toBe('nav.billing');
+  });
+
   it('has a dedicated Backup section with Backup, Cloud Backup, Disaster Recovery, in that order', () => {
     const backup = section('backup');
     expect(backup.label).toBe('Backup');

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
   FileText,
   FileSignature,
   Receipt,
+  CreditCard,
   Tags,
   FileSpreadsheet,
   Building,
@@ -306,6 +307,7 @@ export const navSections: NavSection[] = [
     icon: Building,
     items: [
       { name: 'Partner', labelKey: 'nav.partner', href: '/settings/partner', icon: Building, partnerScopeOnly: true },
+      { name: 'Billing', labelKey: 'nav.billing', href: '/settings/billing', icon: CreditCard, partnerScopeOnly: true, requiredPermission: { resource: 'invoices', action: 'write' } },
       { name: 'Organizations', labelKey: 'nav.organizations', href: '/settings/organizations', icon: Building2, requiredPermission: { resource: 'organizations', action: 'read' } },
       // Users + Roles are both served by the users routes (users:read).
       { name: 'Users', labelKey: 'nav.users', href: '/settings/users', icon: Users, requiredPermission: { resource: 'users', action: 'read' } },

--- a/apps/web/src/locales/de-DE/common.json
+++ b/apps/web/src/locales/de-DE/common.json
@@ -41,6 +41,7 @@
     "auditTrail": "Audit-Protokoll",
     "eventLogs": "Ereignisprotokolle",
     "partner": "Partner",
+    "billing": "Abrechnung",
     "organizations": "Organisationen",
     "aiUsageBudget": "KI-Nutzung und Budget",
     "aiAgents": "KI-Agenten",

--- a/apps/web/src/locales/en/common.json
+++ b/apps/web/src/locales/en/common.json
@@ -41,6 +41,7 @@
     "auditTrail": "Audit Trail",
     "eventLogs": "Event Logs",
     "partner": "Partner",
+    "billing": "Billing",
     "organizations": "Organizations",
     "aiUsageBudget": "AI Usage & Budget",
     "aiAgents": "AI Agents",

--- a/apps/web/src/locales/es-419/common.json
+++ b/apps/web/src/locales/es-419/common.json
@@ -41,6 +41,7 @@
     "auditTrail": "Pista de auditoría",
     "eventLogs": "Registros de eventos",
     "partner": "Socio",
+    "billing": "Facturación",
     "organizations": "Organizaciones",
     "aiUsageBudget": "AI Uso y presupuesto",
     "aiAgents": "Agentes de IA",

--- a/apps/web/src/locales/fr-CA/common.json
+++ b/apps/web/src/locales/fr-CA/common.json
@@ -41,6 +41,7 @@
     "auditTrail": "Trace d’audit",
     "eventLogs": "Journaux d’événements",
     "partner": "Partenaire",
+    "billing": "Facturation",
     "organizations": "Organisations",
     "aiUsageBudget": "Utilisation et budget de l’IA",
     "aiAgents": "Agents IA",

--- a/apps/web/src/locales/fr-FR/common.json
+++ b/apps/web/src/locales/fr-FR/common.json
@@ -41,6 +41,7 @@
     "auditTrail": "Trace d’audit",
     "eventLogs": "Journaux d’événements",
     "partner": "Partenaire",
+    "billing": "Facturation",
     "organizations": "Organisations",
     "aiUsageBudget": "Utilisation et budget de l’IA",
     "aiAgents": "Agents IA",

--- a/apps/web/src/locales/it-IT/common.json
+++ b/apps/web/src/locales/it-IT/common.json
@@ -41,6 +41,7 @@
     "auditTrail": "Registro di controllo",
     "eventLogs": "Registri eventi",
     "partner": "Partner",
+    "billing": "Fatturazione",
     "organizations": "Organizzazioni",
     "aiUsageBudget": "Utilizzo e budget AI",
     "aiAgents": "Agenti AI",

--- a/apps/web/src/locales/pt-BR/common.json
+++ b/apps/web/src/locales/pt-BR/common.json
@@ -41,6 +41,7 @@
     "auditTrail": "Trilha de Auditoria",
     "eventLogs": "Logs de Eventos",
     "partner": "Parceiro",
+    "billing": "Faturamento",
     "organizations": "Organizações",
     "aiUsageBudget": "Uso e Orçamento de IA",
     "aiAgents": "Agentes de IA",

--- a/apps/web/src/locales/tr-TR/common.json
+++ b/apps/web/src/locales/tr-TR/common.json
@@ -41,6 +41,7 @@
     "auditTrail": "Denetim İzi",
     "eventLogs": "Olay Günlükleri",
     "partner": "Ortak",
+    "billing": "Faturalandırma",
     "organizations": "Organizasyonlar",
     "aiUsageBudget": "Yapay Zeka Kullanımı ve Bütçe",
     "aiAgents": "Yapay Zeka Aracıları",


### PR DESCRIPTION
## Summary
- The Settings section of the sidebar (`apps/web/src/components/layout/Sidebar.tsx`) listed Partner, Organizations, Users, Roles, SSO, Access Reviews, Enrollment Keys, Integrations, Custom Fields, Variables, and Saved Filters, but had no entry for `/settings/billing` — even though the page exists and is not gated behind a hosted-only flag. The only discoverable path was the avatar menu in the header.
- Add a `Billing` item next to `Partner` in the Settings section, gated `partnerScopeOnly: true` (the billing settings page and its `/partner/billing-settings` API are partner-scope only per `apps/api/src/routes/invoices/settings.ts`) and `requiredPermission: { resource: 'invoices', action: 'write' }` (matching the write endpoint's actual permission gate).
- Added the `nav.billing` i18n key ("Billing") to all 8 locale `common.json` files to keep locale parity green.

Closes #4605

## Test plan
- [x] Red first: added a test in `Sidebar.nav.test.tsx` asserting the Settings section contains an item with href `/settings/billing` and `labelKey: 'nav.billing'`; confirmed it failed before the fix.
- [x] `cd apps/web && npx vitest run src/components/layout/Sidebar.nav.test.tsx src/components/layout/Sidebar.billing.test.tsx src/components/layout/Sidebar.rbac.test.tsx src/components/layout/Sidebar.featuregate.test.tsx src/components/layout/Sidebar.extensions.test.tsx src/components/layout/Sidebar.scrollpersist.test.tsx src/components/layout/Sidebar.staleness.test.tsx` → 7 files / 46 tests passed
- [x] `cd apps/web && npx vitest run src/lib/i18n/localeParity.test.ts` → 1 file / 79 tests passed
- [x] `cd apps/web && npx tsc --noEmit -p .` → clean, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xr3ZNTFRkCM1t4gEjPttTg