### PR TITLE
fix(integrations): send epoch-millisecond from/to to the Umbrella reporting API (#4597)

### DIFF
--- a/apps/api/src/services/dnsProviders/umbrella.test.ts
+++ b/apps/api/src/services/dnsProviders/umbrella.test.ts
@@ -75,6 +75,23 @@ describe('UmbrellaProvider OAuth2 client-credentials auth (#3271)', () => {
     expect(initOf(apiCall).headers?.Authorization).toBe('Bearer tok-1');
   });
 
+  it('sends from/to as epoch-millisecond strings, not ISO 8601 (#4597)', async () => {
+    queueTokenThen({ requests: [] });
+
+    const since = new Date('2026-08-14T00:30:00.151Z');
+    const until = new Date('2026-08-15T00:30:00.151Z');
+    await makeProvider().syncEvents(since, until);
+
+    const apiCall = requestJsonMock.mock.calls[1]!;
+    const params = new URL(urlOf(apiCall)).searchParams;
+    // Cisco's reporting API rejects ISO strings ("invalid timestamp"); it
+    // wants Unix epoch milliseconds as a numeric string.
+    expect(params.get('from')).toBe(String(since.getTime()));
+    expect(params.get('to')).toBe(String(until.getTime()));
+    expect(params.get('from')).toMatch(/^\d+$/);
+    expect(params.get('to')).toMatch(/^\d+$/);
+  });
+
   it('sends the bearer token to the policies API too', async () => {
     queueTokenThen({});
 

--- a/apps/api/src/services/dnsProviders/umbrella.ts
+++ b/apps/api/src/services/dnsProviders/umbrella.ts
@@ -134,8 +134,12 @@ export class UmbrellaProvider implements DnsProvider {
 
     for (let i = 0; i < maxPages; i++) {
       const url = new URL(`https://reports.api.umbrella.com/v2/organizations/${orgId}/security-activity`);
-      url.searchParams.set('from', since.toISOString());
-      url.searchParams.set('to', until.toISOString());
+      // Cisco's reporting API v2 rejects ISO 8601 strings here with
+      // {"errors":[{"param":"from","msg":"invalid timestamp"...}]}; per its
+      // OpenAPI spec, from/to must be Unix epoch milliseconds as a numeric
+      // string (#4597).
+      url.searchParams.set('from', String(since.getTime()));
+      url.searchParams.set('to', String(until.getTime()));
       url.searchParams.set('limit', String(limit));
       if (cursor) {
         url.searchParams.set('cursor', cursor);


### PR DESCRIPTION
## Summary

Cisco Umbrella's Reporting API v2 `security-activity` endpoint rejects ISO 8601 timestamps for the `from`/`to` query params:

```
{"errors":[{"param":"from","value":"2026-08-14T00:30:00.151Z","error":"invalid timestamp specified"},{"param":"to","value":"2026-08-15T00:30:00.151Z","error":"invalid timestamp specified"}]}
```

Per Cisco's OpenAPI spec for this endpoint, `from`/`to` must be Unix epoch milliseconds as a numeric string (e.g. `"1639146300000"`), not ISO 8601.

`UmbrellaProvider.syncEvents` (`apps/api/src/services/dnsProviders/umbrella.ts:137-138`) was sending `since.toISOString()`/`until.toISOString()`. Switched both to `String(since.getTime())`/`String(until.getTime())`. Grepped the rest of the file for other `toISOString()` call sites used as request params — this was the only one.

This is a follow-up to the OAuth2 client-credentials fix in #3275: with that live, auth succeeds but the sync call itself was still failing on the timestamp format.

Closes #4597

## Test plan

- [x] Added a red-first regression test asserting `from`/`to` are numeric epoch-ms strings, watched it fail against the pre-fix code (`AssertionError: expected '2026-08-14T00:30:00.151Z' to be '1786667400151'`), then applied the fix and watched it pass.
- [x] `cd apps/api && npx vitest run src/services/dnsProviders` — 5 files, 67 tests, all passed.
- [x] `cd apps/api && npx tsc --noEmit -p .` — clean, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xr3ZNTFRkCM1t4gEjPttTg