### PR TITLE
fix(api): apply the new-partner inbound default on every creation path (#4520)

### DIFF
--- a/apps/api/src/db/seed.ts
+++ b/apps/api/src/db/seed.ts
@@ -3,6 +3,7 @@
 import '../config/normalizeNodeEnv';
 import { db, withSystemDbAccessContext } from './index';
 import { roles, permissions, rolePermissions, scripts, alertTemplates, partners, organizations, sites, users, partnerUsers } from './schema';
+import { applyNewPartnerDefaultSettings } from '../services/partnerDefaultSettings';
 import { seedSystemTicketStatuses } from '../services/ticketConfigService';
 import { eq, and } from 'drizzle-orm';
 import { hashPassword } from '../services/password';
@@ -1091,7 +1092,10 @@ export async function seedDefaultAdmin() {
           name: 'Default Partner',
           slug: 'default-partner',
           type: 'msp',
-          plan: 'enterprise'
+          plan: 'enterprise',
+          // #4520: keep the seeded dev partner on the same inbound opt-out
+          // default real partners get, so local behaviour matches production.
+          settings: applyNewPartnerDefaultSettings()
         })
         .returning();
       await seedSystemTicketStatuses(tx, newPartner!.id);

--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -469,6 +469,107 @@ describe('org routes', () => {
         'partner-1'
       );
     });
+
+    // Issue #4520: this platform-admin path inserts partners directly instead of
+    // going through createPartner(), so it used to miss the #3608 opt-out default
+    // and fall back to the readers' absent-means-enabled behaviour.
+    describe('new-partner default settings (#4520)', () => {
+      const captureInsertedValues = () => {
+        const captured: Record<string, unknown>[] = [];
+        vi.mocked(db.select).mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([])
+            })
+          })
+        } as any);
+        vi.mocked(db.transaction).mockImplementation(async (fn: (tx: any) => any) => {
+          const tx = {
+            insert: vi.fn(() => ({
+              values: vi.fn((vals: Record<string, unknown>) => {
+                captured.push(vals);
+                return { returning: vi.fn().mockResolvedValue([{ id: 'partner-1' }]) };
+              })
+            }))
+          };
+          return fn(tx);
+        });
+        return captured;
+      };
+
+      it('writes settings.ticketing.inbound.enabled=false when the caller sends no settings', async () => {
+        const captured = captureInsertedValues();
+
+        const res = await app.request('/orgs/partners', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: 'Partner', slug: 'partner' })
+        });
+
+        expect(res.status).toBe(201);
+        expect(captured[0]?.settings).toEqual({ ticketing: { inbound: { enabled: false } } });
+      });
+
+      it('adds the default alongside caller-supplied settings without clobbering them', async () => {
+        const captured = captureInsertedValues();
+
+        const res = await app.request('/orgs/partners', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            name: 'Partner',
+            slug: 'partner',
+            settings: {
+              security: { ipAllowlist: ['10.0.0.0/8'] },
+              ticketing: { inbound: { unknownSenderMode: 'triage' } }
+            }
+          })
+        });
+
+        expect(res.status).toBe(201);
+        expect(captured[0]?.settings).toEqual({
+          security: { ipAllowlist: ['10.0.0.0/8'] },
+          ticketing: { inbound: { unknownSenderMode: 'triage', enabled: false } }
+        });
+      });
+
+      it('respects an explicit ticketing.inbound.enabled=true from the caller', async () => {
+        const captured = captureInsertedValues();
+
+        const res = await app.request('/orgs/partners', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            name: 'Partner',
+            slug: 'partner',
+            settings: { ticketing: { inbound: { enabled: true } } }
+          })
+        });
+
+        expect(res.status).toBe(201);
+        expect(captured[0]?.settings).toEqual({ ticketing: { inbound: { enabled: true } } });
+      });
+
+      it('still folds the legacy allowedMfaMethods alias while applying the default', async () => {
+        const captured = captureInsertedValues();
+
+        const res = await app.request('/orgs/partners', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            name: 'Partner',
+            slug: 'partner',
+            settings: { security: { allowedMfaMethods: { totp: true } } }
+          })
+        });
+
+        expect(res.status).toBe(201);
+        expect(captured[0]?.settings).toEqual({
+          security: { allowedMethods: { totp: true } },
+          ticketing: { inbound: { enabled: false } }
+        });
+      });
+    });
   });
 
   describe('GET /orgs/partners/:id', () => {

--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -488,7 +488,14 @@ describe('org routes', () => {
             insert: vi.fn(() => ({
               values: vi.fn((vals: Record<string, unknown>) => {
                 captured.push(vals);
-                return { returning: vi.fn().mockResolvedValue([{ id: 'partner-1' }]) };
+                // Model the real `.returning(partnerPublicColumns())`, which
+                // projects the PERSISTED row — settings included. That echo is
+                // what tells an admin caller what actually landed.
+                return {
+                  returning: vi.fn().mockResolvedValue([
+                    { id: 'partner-1', settings: vals.settings }
+                  ])
+                };
               })
             }))
           };
@@ -567,6 +574,27 @@ describe('org routes', () => {
         expect(captured[0]?.settings).toEqual({
           security: { allowedMethods: { totp: true } },
           ticketing: { inbound: { enabled: false } }
+        });
+      });
+
+      // `settings` is `z.any()`, so a malformed value reaches the handler. It
+      // cannot carry the flag, and the readers treat an untraversable path as
+      // absent (= inbound ENABLED), so it is normalized rather than persisted.
+      // The 201 body echoes the persisted row, so the caller is not left
+      // guessing what landed — assert that end-to-end, not just the insert.
+      it('normalizes a non-object settings value and echoes the result in the 201 body', async () => {
+        const captured = captureInsertedValues();
+
+        const res = await app.request('/orgs/partners', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: 'Partner', slug: 'partner', settings: 'nonsense' })
+        });
+
+        expect(res.status).toBe(201);
+        expect(captured[0]?.settings).toEqual({ ticketing: { inbound: { enabled: false } } });
+        expect(await res.json()).toMatchObject({
+          settings: { ticketing: { inbound: { enabled: false } } }
         });
       });
     });

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -50,6 +50,7 @@ import { isAllowedLauncherScheme, isValidIanaTimezone, canonicalizeTimezone, isV
 import type { IpAllowlistStatus, ResolvedEnrollmentDefaults, SupportedLocale } from '@breeze/shared';
 import { getEnrollmentDefaultsForOrg } from '../services/enrollmentDefaults';
 import { isValidIpOrCidr } from '../services/ipMatch';
+import { applyNewPartnerDefaultSettings } from '../services/partnerDefaultSettings';
 import { seedSystemTicketStatuses } from '../services/ticketConfigService';
 import { getTrustedClientIpOrUndefined } from '../services/clientIp';
 import { canManagePartnerWidePolicies } from '../services/partnerWideAccess';
@@ -484,6 +485,11 @@ orgRoutes.post('/partners', requireScope('system'), requireOrgWrite, requireMfa(
   // without this a create carrying the alias persists a key the resolver ignores
   // (silent no-op the alias-fold set out to kill).
   data.settings = foldAllowedMfaMethodsAlias(data.settings);
+  // #4520: this handler inserts partners directly rather than going through
+  // createPartner(), so it has to apply the shared new-partner defaults itself —
+  // otherwise it mints `{}`-settings partners that the inbound readers' legacy
+  // absent-means-enabled fallback treats as opted IN (the #3608 regression).
+  data.settings = applyNewPartnerDefaultSettings(data.settings);
 
   const clash = await db
     .select({ id: partners.id })

--- a/apps/api/src/services/partnerCreate.ts
+++ b/apps/api/src/services/partnerCreate.ts
@@ -11,6 +11,7 @@ import {
 } from '../db/schema';
 import type { PartnerStatus } from '../db/schema/orgs';
 import { partnerTrustMode } from '../config/partnerTrustMode';
+import { applyNewPartnerDefaultSettings } from './partnerDefaultSettings';
 import { seedSystemTicketStatuses } from './ticketConfigService';
 import type { Tx as AuthLifecycleTransaction } from './authLifecycle';
 
@@ -85,16 +86,11 @@ export async function createPartner(
         mcpOriginUserAgent: mcpOrigin ? (input.origin as { userAgent?: string }).userAgent ?? null : null,
         signupIp: !mcpOrigin ? (input.origin as { ip?: string }).ip ?? null : null,
         signupUserAgent: !mcpOrigin ? (input.origin as { userAgent?: string }).userAgent ?? null : null,
-        // Issue #3608 (decision: Option B, 2026-08-16): new partners opt IN to
-        // inbound email-to-ticket rather than inheriting the readers'
-        // "absent flag reads as true" fallback. That fallback
-        // (`loadPartnerInboundPolicy` in inboundEmail/resolveOrg.ts and
-        // `getTicketConfig` in ticketConfigService.ts, both `enabled !== false`)
-        // stays as-is — it exists solely as the pre-#3606 upgrade path for
-        // partners created before this default existed. Do NOT "fix" the
-        // readers to match this new-partner default; the two are deliberately
-        // different concerns. Do NOT backfill existing partners' settings.
-        settings: { ticketing: { inbound: { enabled: false } } },
+        // Issue #3608 / #4520: new partners opt IN to inbound email-to-ticket.
+        // The shape (and the reasoning for leaving the readers alone) lives in
+        // services/partnerDefaultSettings.ts — shared with the platform-admin
+        // POST /orgs/partners route and the dev seed so no creation path drifts.
+        settings: applyNewPartnerDefaultSettings(),
       })
       .returning();
 

--- a/apps/api/src/services/partnerDefaultSettings.test.ts
+++ b/apps/api/src/services/partnerDefaultSettings.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { applyNewPartnerDefaultSettings } from './partnerDefaultSettings';
+
+describe('applyNewPartnerDefaultSettings (#3608 / #4520)', () => {
+  it('produces the inbound opt-out default when no settings are supplied', () => {
+    expect(applyNewPartnerDefaultSettings()).toEqual({
+      ticketing: { inbound: { enabled: false } },
+    });
+  });
+
+  it('treats null settings as absent', () => {
+    expect(applyNewPartnerDefaultSettings(null)).toEqual({
+      ticketing: { inbound: { enabled: false } },
+    });
+  });
+
+  it('preserves unrelated caller-supplied settings', () => {
+    expect(
+      applyNewPartnerDefaultSettings({
+        security: { ipAllowlist: ['10.0.0.0/8'] },
+        branding: { color: 'blue' },
+      }),
+    ).toEqual({
+      security: { ipAllowlist: ['10.0.0.0/8'] },
+      branding: { color: 'blue' },
+      ticketing: { inbound: { enabled: false } },
+    });
+  });
+
+  it('preserves sibling keys under ticketing and ticketing.inbound', () => {
+    expect(
+      applyNewPartnerDefaultSettings({
+        ticketing: {
+          slaHours: 4,
+          inbound: { defaultTriageOrgId: 'org-1', unknownSenderMode: 'triage' },
+        },
+      }),
+    ).toEqual({
+      ticketing: {
+        slaHours: 4,
+        inbound: {
+          defaultTriageOrgId: 'org-1',
+          unknownSenderMode: 'triage',
+          enabled: false,
+        },
+      },
+    });
+  });
+
+  it('does not override an explicit enabled:true from the caller', () => {
+    expect(
+      applyNewPartnerDefaultSettings({ ticketing: { inbound: { enabled: true } } }),
+    ).toEqual({ ticketing: { inbound: { enabled: true } } });
+  });
+
+  it('does not override an explicit enabled:false from the caller', () => {
+    expect(
+      applyNewPartnerDefaultSettings({ ticketing: { inbound: { enabled: false } } }),
+    ).toEqual({ ticketing: { inbound: { enabled: false } } });
+  });
+
+  it('does not mutate the caller-supplied object', () => {
+    const input = { ticketing: { inbound: { unknownSenderMode: 'triage' } } };
+    const snapshot = structuredClone(input);
+    const out = applyNewPartnerDefaultSettings(input);
+
+    expect(input).toEqual(snapshot);
+    expect(out).not.toBe(input);
+    expect(out.ticketing).not.toBe(input.ticketing);
+  });
+
+  it('replaces a non-object ticketing branch rather than leaving the reader fail-open', () => {
+    // `loadPartnerInboundPolicy` reads `settings.ticketing.inbound.enabled` and
+    // treats anything it cannot traverse as absent → enabled. A garbage branch
+    // must therefore be replaced, not preserved.
+    expect(applyNewPartnerDefaultSettings({ ticketing: 'nonsense' })).toEqual({
+      ticketing: { inbound: { enabled: false } },
+    });
+    expect(applyNewPartnerDefaultSettings({ ticketing: { inbound: 7 } })).toEqual({
+      ticketing: { inbound: { enabled: false } },
+    });
+    expect(applyNewPartnerDefaultSettings({ ticketing: { inbound: null } })).toEqual({
+      ticketing: { inbound: { enabled: false } },
+    });
+  });
+
+  it('normalizes a non-object settings value to the defaults object', () => {
+    expect(applyNewPartnerDefaultSettings('nonsense')).toEqual({
+      ticketing: { inbound: { enabled: false } },
+    });
+    expect(applyNewPartnerDefaultSettings([1, 2, 3])).toEqual({
+      ticketing: { inbound: { enabled: false } },
+    });
+  });
+});

--- a/apps/api/src/services/partnerDefaultSettings.ts
+++ b/apps/api/src/services/partnerDefaultSettings.ts
@@ -1,0 +1,58 @@
+/**
+ * Settings defaults applied to every newly-created partner, on EVERY creation
+ * path.
+ *
+ * Deliberately dependency-free (no db, no schema, no config imports) so any
+ * creation path — service, route handler, or seed — can call it without
+ * dragging a module graph along, and so suites that mock `../db/schema` with a
+ * non-partial factory can import it safely.
+ *
+ * Issue #3608 (decision: Option B, 2026-08-16): new partners opt IN to inbound
+ * email-to-ticket rather than inheriting the readers' "absent flag reads as
+ * true" fallback. That fallback (`loadPartnerInboundPolicy` in
+ * `inboundEmail/resolveOrg.ts` and `getTicketConfig` in `ticketConfigService.ts`,
+ * both `enabled !== false`) stays as-is — it exists solely as the pre-#3606
+ * upgrade path for partners created before this default existed. Do NOT "fix"
+ * the readers to match this new-partner default; the two are deliberately
+ * different concerns. Do NOT backfill existing partners' settings.
+ *
+ * Issue #4520: the default originally lived inline in `createPartner()`, so the
+ * platform-admin `POST /orgs/partners` handler — which inserts partners
+ * directly — silently missed it and minted `{}`-settings partners that read as
+ * inbound-enabled. Extracted here so all creation paths share one definition;
+ * add the call to any NEW partner-insert site rather than re-inlining the shape.
+ */
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+/**
+ * Merge the new-partner defaults into caller-supplied settings.
+ *
+ * Caller intent wins: an explicit `ticketing.inbound.enabled` (true or false)
+ * is preserved, and every unrelated key is carried through untouched. The
+ * default is only filled in where the caller left the flag absent.
+ *
+ * Values that cannot hold the flag are normalized rather than preserved. The
+ * readers traverse `settings.ticketing.inbound.enabled` and treat anything
+ * untraversable as absent — i.e. enabled — so preserving a non-object at any
+ * level along that path would fail OPEN, which is exactly what #3608 set out to
+ * stop. Nothing usable is lost: no reader can interpret those shapes anyway,
+ * and the admin route echoes the persisted `settings` back in its 201 response,
+ * so a caller who sent a malformed value sees what actually landed.
+ *
+ * Returns a fresh object; the caller's input is never mutated.
+ */
+export function applyNewPartnerDefaultSettings(settings?: unknown): Record<string, unknown> {
+  const base = isPlainObject(settings) ? { ...settings } : {};
+  const ticketing = isPlainObject(base.ticketing) ? { ...base.ticketing } : {};
+  const inbound = isPlainObject(ticketing.inbound) ? { ...ticketing.inbound } : {};
+
+  if (inbound.enabled === undefined) {
+    inbound.enabled = false;
+  }
+
+  ticketing.inbound = inbound;
+  base.ticketing = ticketing;
+  return base;
+}


### PR DESCRIPTION
## Problem

PR #4420 (#3608) made new partners opt **in** to inbound email-to-ticket by writing an explicit `settings.ticketing.inbound.enabled = false` at creation — but the default lived **inline** in `createPartner()`.

The platform-admin `POST /orgs/partners` handler (`requireScope('system')`, `apps/api/src/routes/orgs.ts`) inserts partners directly and never calls `createPartner()`. Partners minted that way still landed with `{}` settings and fell through to the readers' `enabled !== false` fallback — i.e. inbound email-to-ticket silently **on**, the exact behaviour #3608 set out to stop.

## Fix

Routing the admin endpoint through `createPartner()` isn't viable — that function also mints an admin user, role, permission set, default org and default site from a required `adminEmail`/`adminName`/`passwordHash`, none of which the admin endpoint has or wants. So this takes the issue's second option: **extract the default-settings builder**.

New dependency-free module `apps/api/src/services/partnerDefaultSettings.ts` exporting `applyNewPartnerDefaultSettings()`, called from **all three** partner-insert sites (`grep -rn 'insert(partners)' apps ee packages --include='*.ts'` — these are the only three outside tests; no raw-SQL partner inserts in migrations):

| Site | Before | After |
|---|---|---|
| `services/partnerCreate.ts` | inline literal | calls the builder |
| `routes/orgs.ts` — admin `POST /partners` | **missing** (the bug) | calls the builder |
| `db/seed.ts` — dev "Default Partner" | **missing** | calls the builder |

The seed is included so local dev matches production behaviour rather than quietly testing a config prod never has.

### Merge semantics

The admin route accepts caller-supplied `settings` (`z.any()`), so the builder **merges** instead of overwriting:

- An explicit `ticketing.inbound.enabled` from the caller — `true` **or** `false` — is preserved. The default only fills the flag in where it is absent.
- Unrelated keys, and siblings under `ticketing` / `ticketing.inbound`, pass through untouched.
- The caller's object is never mutated; a fresh object is returned. The copy depth (three levels) matches exactly the three levels written.
- Values that *cannot* hold the flag (a non-object at `settings`, `ticketing`, or `inbound`) are normalized rather than preserved. The readers traverse that path and treat anything untraversable as absent → enabled, so preserving a malformed branch would fail **open**. Nothing usable is lost — no reader can interpret those shapes — and the handler's `.returning(partnerPublicColumns())` projects the persisted row (settings included) into the 201 body, so a caller sees exactly what landed. That echo is now asserted end-to-end by a route-level test, not just argued.

Ordering with the existing `foldAllowedMfaMethodsAlias` canonicalization is preserved and covered by a test.

The readers (`loadPartnerInboundPolicy` in `inboundEmail/resolveOrg.ts`, `getTicketConfig` in `ticketConfigService.ts`) are **unchanged** and still serve as the pre-#3606 upgrade path. No backfill of existing partners' settings — same scope decision as #4420.

## Test plan

Red-first: the new admin-route assertions and the helper suite were confirmed failing against the unfixed handler before implementing. The added normalization/echo test was separately re-verified by reverting the handler call and watching it fail.

- [x] `vitest run src/routes/orgs.test.ts src/routes/orgs.listQuery.test.ts src/services/partnerDefaultSettings.test.ts src/services/partnerCreate.test.ts` — **304/304 passed**. 9 new helper cases (absent/null/non-object settings, sibling preservation at both levels, explicit true and false, no-mutation, malformed-branch normalization) + 5 new admin-route cases (default lands with no settings; merges alongside caller settings; respects explicit `enabled: true`; still folds the MFA alias; normalizes a non-object value and echoes it in the 201 body).
- [x] `vitest run src/services/ticketConfigService.test.ts src/services/inboundEmail` — 197/197 passed (the readers this decision deliberately leaves unchanged).
- [x] `vitest run src/routes/auth/register.test.ts src/__tests__/partner-wide-write-coverage.test.ts` — 33/33 passed.
- [x] `npx tsc --noEmit -p apps/api` — clean.
- [x] `npx eslint` on every touched file — clean.

No schema or migration changes, so no RLS/cascade/export-policy registration applies.

**Coverage caveat:** the `db/seed.ts` call site has no direct test — it is a local dev-seed path whose only obligation is calling the builder with no arguments, which the helper suite already characterizes fully. Verified by inspection and typecheck, not by a test.

## Reviewed

Three independent reviews (code-reviewer, silent-failure-hunter, pr-test-analyzer): **0 MUST-FIX**. The test-coverage finding above was addressed in 9d9d702. Two suggestions were consciously declined:

- **Narrow `settings: z.any()` to a record schema so malformed input 400s instead of normalizing.** Reasonable, but it tightens a public API's accepted input domain beyond this issue, and `z.any()` for `settings` is systemic in this file (`createPartnerSchema`, `updatePartnerSchema`, and the org schemas) — changing only the create path would leave the update path inconsistent. Wants its own change that sweeps all of them.
- **Log when a malformed `settings` value is discarded.** The 201 body already carries the ground truth, the branch is only reachable by an MFA-gated platform admin, and `partnerDefaultSettings.ts` is deliberately import-free so any creation path (including the seed and suites that mock `../db/schema`) can use it.

## Noted, deliberately not in scope

`PATCH /orgs/partners/:id` writes `settings` **wholesale**. A platform-admin update that omits `ticketing` therefore drops the opt-out flag and re-enables inbound at the readers — the same fail-open class as the `ipAllowlist` case that `preserveIpAllowlistOnOmit` already guards on that handler. Whether an admin clearing settings *intends* to re-enable inbound is a product call, so it wants its own decision rather than a guess bundled here.

Closes #4520

🤖 Generated with [Claude Code](https://claude.com/claude-code)