### PR TITLE
fix(api): reject WebP catalog item images at the upload boundary (#4521)

### DIFF
--- a/apps/api/src/routes/catalog/catalog.test.ts
+++ b/apps/api/src/routes/catalog/catalog.test.ts
@@ -43,6 +43,7 @@ vi.mock('../../services/catalogImageStorage', () => ({
   fetchImageFromUrl: vi.fn(),
   sniffImageMime: vi.fn(),
   MAX_CATALOG_IMAGE_SIZE_BYTES: 5 * 1024 * 1024,
+  CATALOG_IMAGE_WEBP_REJECTED_MESSAGE: "WebP images can't be used in quote PDFs — please upload a PNG or JPEG image instead.",
 }));
 
 vi.mock('../../services/tdSynnexDigitalBridge', () => ({
@@ -192,6 +193,21 @@ describe('catalog item image routes', () => {
     expect(imgSvc.writeCatalogItemImage).not.toHaveBeenCalled();
   });
 
+  // #4521 — catalog item images reach quote PDFs (pdfkit, PNG/JPEG only) via line
+  // thumbnails, so WebP — a format sniffImageMime happily recognizes — must be
+  // rejected explicitly, distinct from the generic "unsniffable" 415 above.
+  it('POST /:id/image rejects a sniffed WebP with the clear PDF-specific message (415)', async () => {
+    (svc.getCatalogItem as any).mockResolvedValue({ item: { id: ID } });
+    (imgSvc.sniffImageMime as any).mockReturnValue('image/webp');
+    const form = new FormData();
+    form.append('file', new File([new Uint8Array([1, 2, 3, 4])], 'p.webp', { type: 'image/webp' }));
+    const res = await app().request(`/${ID}/image`, { method: 'POST', body: form });
+    expect(res.status).toBe(415);
+    const body = await res.json();
+    expect(body.error).toBe(imgSvc.CATALOG_IMAGE_WEBP_REJECTED_MESSAGE);
+    expect(imgSvc.writeCatalogItemImage).not.toHaveBeenCalled();
+  });
+
   it('POST /:id/image 404s when the item is not the partner’s', async () => {
     (svc.getCatalogItem as any).mockRejectedValue(new (svc as any).CatalogServiceError('not found', 404, 'NOT_FOUND'));
     const form = new FormData();
@@ -226,6 +242,20 @@ describe('catalog item image routes', () => {
       body: JSON.stringify({ url: 'https://internal.example/p.png' })
     });
     expect(res.status).toBe(400);
+    expect(imgSvc.writeCatalogItemImage).not.toHaveBeenCalled();
+  });
+
+  it('POST /:id/image/from-url rejects a WebP download with the clear PDF-specific message (415)', async () => {
+    (svc.getCatalogItem as any).mockResolvedValue({ item: { id: ID } });
+    (imgSvc.fetchImageFromUrl as any).mockRejectedValue(new Error(imgSvc.CATALOG_IMAGE_WEBP_REJECTED_MESSAGE));
+    const res = await app().request(`/${ID}/image/from-url`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ url: 'https://example.com/p.webp' })
+    });
+    expect(res.status).toBe(415);
+    const body = await res.json();
+    expect(body.error).toBe(imgSvc.CATALOG_IMAGE_WEBP_REJECTED_MESSAGE);
     expect(imgSvc.writeCatalogItemImage).not.toHaveBeenCalled();
   });
 

--- a/apps/api/src/routes/catalog/catalog.ts
+++ b/apps/api/src/routes/catalog/catalog.ts
@@ -13,7 +13,7 @@ import {
 } from '../../services/catalogService';
 import {
   writeCatalogItemImage, readCatalogItemImage, deleteCatalogItemImage,
-  fetchImageFromUrl, sniffImageMime, MAX_CATALOG_IMAGE_SIZE_BYTES,
+  fetchImageFromUrl, sniffImageMime, MAX_CATALOG_IMAGE_SIZE_BYTES, CATALOG_IMAGE_WEBP_REJECTED_MESSAGE,
 } from '../../services/catalogImageStorage';
 
 export const catalogItemRoutes = new Hono();
@@ -99,7 +99,8 @@ catalogItemRoutes.post('/:id/image',
       if (file.size > MAX_CATALOG_IMAGE_SIZE_BYTES) return c.json({ error: 'Image too large (max 5 MB)' }, 413);
       const buffer = Buffer.from(await file.arrayBuffer());
       const mime = sniffImageMime(buffer);
-      if (!mime) return c.json({ error: 'Unsupported image format. Allowed: PNG, JPEG, WebP.' }, 415);
+      if (!mime) return c.json({ error: 'Unsupported image format. Allowed: PNG, JPEG.' }, 415);
+      if (mime === 'image/webp') return c.json({ error: CATALOG_IMAGE_WEBP_REJECTED_MESSAGE }, 415);
       const written = await writeCatalogItemImage(id, actor.partnerId, mime, buffer);
       return c.json({ data: { imageId: written.id, mime, byteSize: written.byteSize } });
     } catch (err) { return handleServiceError(c, err); }
@@ -122,7 +123,10 @@ catalogItemRoutes.post('/:id/image/from-url',
       let mime: string, buffer: Buffer;
       try {
         ({ mime, buffer } = await fetchImageFromUrl(url));
-      } catch {
+      } catch (err) {
+        if (err instanceof Error && err.message === CATALOG_IMAGE_WEBP_REJECTED_MESSAGE) {
+          return c.json({ error: CATALOG_IMAGE_WEBP_REJECTED_MESSAGE }, 415);
+        }
         return c.json({ error: 'Could not download a valid image from that URL.' }, 400);
       }
       const written = await writeCatalogItemImage(id, actor.partnerId, mime, buffer);

--- a/apps/api/src/services/catalogImageStorage.test.ts
+++ b/apps/api/src/services/catalogImageStorage.test.ts
@@ -10,7 +10,7 @@ const sniffImageMime = vi.fn();
 vi.mock('./avatarStorage', () => ({ sniffImageMime: (...a: unknown[]) => sniffImageMime(...a) }));
 vi.mock('../db', () => ({ db: {} }));
 
-import { fetchImageFromUrl, MAX_CATALOG_IMAGE_SIZE_BYTES } from './catalogImageStorage';
+import { fetchImageFromUrl, MAX_CATALOG_IMAGE_SIZE_BYTES, CATALOG_IMAGE_WEBP_REJECTED_MESSAGE } from './catalogImageStorage';
 
 function fakeRes(opts: { ok?: boolean; status?: number; headers?: Record<string, string>; body?: Uint8Array }) {
   const { ok = true, status = 200, headers = {}, body = new Uint8Array([1, 2, 3]) } = opts;
@@ -59,5 +59,15 @@ describe('fetchImageFromUrl', () => {
     safeFetch.mockResolvedValue(fakeRes({ body: new Uint8Array([0, 0, 0]) }));
     sniffImageMime.mockReturnValue(null);
     await expect(fetchImageFromUrl('https://x.test')).rejects.toThrow(/unsupported/i);
+  });
+
+  // #4521 — catalog item images reach quotePdf.ts (which uses pdfkit, PNG/JPEG
+  // only) via quote line thumbnails, so a WebP sniffed here must be rejected
+  // even though it IS a recognized image format — mirrors the quote-image
+  // upload fix (#3483, PR #4408).
+  it('rejects a sniffed WebP with the clear PDF-specific message, not the generic "unsupported" one', async () => {
+    safeFetch.mockResolvedValue(fakeRes({ body: new Uint8Array([1, 2, 3, 4]) }));
+    sniffImageMime.mockReturnValue('image/webp');
+    await expect(fetchImageFromUrl('https://x.test')).rejects.toThrow(CATALOG_IMAGE_WEBP_REJECTED_MESSAGE);
   });
 });

--- a/apps/api/src/services/catalogImageStorage.ts
+++ b/apps/api/src/services/catalogImageStorage.ts
@@ -28,7 +28,8 @@ export const CATALOG_IMAGE_WEBP_REJECTED_MESSAGE = "WebP images can't be used in
  * addresses; a 10s timeout bounds the request. Size is checked twice: an early
  * Content-Length reject, then the actual byte count after read. The format is
  * confirmed by magic-byte sniffing (the Content-Type header is untrusted).
- * Throws plain Errors; the route maps them to a generic 4xx.
+ * Throws plain Errors; the route maps most of them to a generic 4xx, except
+ * the WebP case above, which it recognizes by message and maps to 415.
  */
 export async function fetchImageFromUrl(url: string): Promise<{ mime: string; buffer: Buffer }> {
   const res = await safeFetch(url, { timeoutMs: 10_000 });

--- a/apps/api/src/services/catalogImageStorage.ts
+++ b/apps/api/src/services/catalogImageStorage.ts
@@ -9,6 +9,20 @@ export { sniffImageMime };
 export const MAX_CATALOG_IMAGE_SIZE_BYTES = 5 * 1024 * 1024; // reuse the avatar/quote cap
 
 /**
+ * Quote PDFs are rendered with pdfkit, which can only embed PNG and JPEG — calling
+ * `doc.image()` on WebP bytes throws, and quotePdf.ts's per-image catch-and-continue
+ * silently drops the image from the exported PDF. Catalog item images reach that
+ * same render path via quote line thumbnails (`loadCustomerLineImage` in
+ * quoteImageStorage.ts), so — mirroring the quote-image upload fix (#3483,
+ * PR #4408) — WebP is rejected here too, at the catalog image upload boundary,
+ * for both the multipart route and the URL-import path below. Catalog images
+ * served directly (the admin/catalog UI) never hit pdfkit, but a single upload
+ * boundary that's consistent with quotes is simpler than tracking which images
+ * end up on a PDF and which don't.
+ */
+export const CATALOG_IMAGE_WEBP_REJECTED_MESSAGE = "WebP images can't be used in quote PDFs — please upload a PNG or JPEG image instead.";
+
+/**
  * Download a product image from a user-supplied URL, SSRF-guarded. The fetch goes
  * through `safeFetch` (never global fetch) so a tenant URL can't reach internal
  * addresses; a 10s timeout bounds the request. Size is checked twice: an early
@@ -30,7 +44,8 @@ export async function fetchImageFromUrl(url: string): Promise<{ mime: string; bu
   if (buffer.length > MAX_CATALOG_IMAGE_SIZE_BYTES) throw new Error('Image too large (max 5 MB)');
 
   const mime = sniffImageMime(buffer);
-  if (!mime) throw new Error('Unsupported image format. Allowed: PNG, JPEG, WebP.');
+  if (!mime) throw new Error('Unsupported image format. Allowed: PNG, JPEG.');
+  if (mime === 'image/webp') throw new Error(CATALOG_IMAGE_WEBP_REJECTED_MESSAGE);
 
   return { mime, buffer };
 }

--- a/apps/web/src/components/settings/CatalogItemEditorDrawer.tsx
+++ b/apps/web/src/components/settings/CatalogItemEditorDrawer.tsx
@@ -826,7 +826,7 @@ export default function CatalogItemEditorDrawer({ open, item, allItems, onClose,
                     <input
                       ref={imageInputRef}
                       type="file"
-                      accept="image/png,image/jpeg,image/webp"
+                      accept="image/png,image/jpeg"
                       disabled={imageBusy}
                       onChange={(e) => { const f = e.target.files?.[0]; if (f) void uploadImage(f); }}
                       className="block w-full text-xs file:mr-2 file:rounded-md file:border file:bg-muted file:px-2 file:py-1 file:text-xs file:font-medium disabled:opacity-50"

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -2113,7 +2113,7 @@
     "remove": "Entfernen",
     "httpsExampleComProductPng": "https://example.com/product.png",
     "importFromURL": "Import aus URL",
-    "pNGJPEGOrWebPUpTo5MB": "PNG, JPEG oder WebP bis zu 5 MB.",
+    "pNGJPEGOrWebPUpTo5MB": "PNG oder JPEG, bis zu 5 MB.",
     "saveTheItemFirstThenAddAProductImage": "Speichern Sie zunächst den Artikel und fügen Sie dann ein Produktbild hinzu.",
     "thisItemIsABundle": "Bei diesem Artikel handelt es sich um ein Bundle",
     "groupsOtherCatalogItemsSoldTogether": "Gruppiert andere zusammen verkaufte Katalogartikel.",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -2113,7 +2113,7 @@
     "remove": "Remove",
     "httpsExampleComProductPng": "https://example.com/product.png",
     "importFromURL": "Import from URL",
-    "pNGJPEGOrWebPUpTo5MB": "PNG, JPEG, or WebP up to 5 MB.",
+    "pNGJPEGOrWebPUpTo5MB": "PNG or JPEG, up to 5 MB.",
     "saveTheItemFirstThenAddAProductImage": "Save the item first, then add a product image.",
     "thisItemIsABundle": "This item is a bundle",
     "groupsOtherCatalogItemsSoldTogether": "Groups other catalog items sold together.",

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -2113,7 +2113,7 @@
     "remove": "Eliminar",
     "httpsExampleComProductPng": "https://example.com/product.png",
     "importFromURL": "Importar desde URL",
-    "pNGJPEGOrWebPUpTo5MB": "PNG, JPEG o WebP hasta 5 MB.",
+    "pNGJPEGOrWebPUpTo5MB": "PNG o JPEG, hasta 5 MB.",
     "saveTheItemFirstThenAddAProductImage": "Primero guarde el artículo y luego agregue una imagen del producto.",
     "thisItemIsABundle": "Este artículo es un paquete.",
     "groupsOtherCatalogItemsSoldTogether": "Agrupa otros artículos del catálogo vendidos juntos.",

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -2108,7 +2108,7 @@
     "remove": "Retirer",
     "httpsExampleComProductPng": "https://example.com/product.png",
     "importFromURL": "Importation depuis URL",
-    "pNGJPEGOrWebPUpTo5MB": "PNG ou JPEG, jusqu'à 5 MB.",
+    "pNGJPEGOrWebPUpTo5MB": "PNG ou JPEG, jusqu’à 5 Mo.",
     "saveTheItemFirstThenAddAProductImage": "enregistrez d’abord l’article, puis ajoutez une image produit.",
     "thisItemIsABundle": "Cet élément est un paquet",
     "groupsOtherCatalogItemsSoldTogether": "Regroupe d’autres articles de catalogue vendus ensemble.",

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -2108,7 +2108,7 @@
     "remove": "Retirer",
     "httpsExampleComProductPng": "https://example.com/product.png",
     "importFromURL": "Importation depuis URL",
-    "pNGJPEGOrWebPUpTo5MB": "PNG, JPEG ou WebP jusqu’à 5 Mo.",
+    "pNGJPEGOrWebPUpTo5MB": "PNG ou JPEG, jusqu'à 5 MB.",
     "saveTheItemFirstThenAddAProductImage": "enregistrez d’abord l’article, puis ajoutez une image produit.",
     "thisItemIsABundle": "Cet élément est un paquet",
     "groupsOtherCatalogItemsSoldTogether": "Regroupe d’autres articles de catalogue vendus ensemble.",

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -2113,7 +2113,7 @@
     "remove": "Retirer",
     "httpsExampleComProductPng": "https://example.com/product.png",
     "importFromURL": "Importation depuis URL",
-    "pNGJPEGOrWebPUpTo5MB": "PNG, JPEG ou WebP jusqu’à 5 Mo.",
+    "pNGJPEGOrWebPUpTo5MB": "PNG ou JPEG, jusqu'à 5 MB.",
     "saveTheItemFirstThenAddAProductImage": "enregistrez d’abord l’article, puis ajoutez une image produit.",
     "thisItemIsABundle": "Cet élément est un paquet",
     "groupsOtherCatalogItemsSoldTogether": "Regroupe d’autres articles de catalogue vendus ensemble.",

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -2113,7 +2113,7 @@
     "remove": "Retirer",
     "httpsExampleComProductPng": "https://example.com/product.png",
     "importFromURL": "Importation depuis URL",
-    "pNGJPEGOrWebPUpTo5MB": "PNG ou JPEG, jusqu'à 5 MB.",
+    "pNGJPEGOrWebPUpTo5MB": "PNG ou JPEG, jusqu’à 5 Mo.",
     "saveTheItemFirstThenAddAProductImage": "enregistrez d’abord l’article, puis ajoutez une image produit.",
     "thisItemIsABundle": "Cet élément est un paquet",
     "groupsOtherCatalogItemsSoldTogether": "Regroupe d’autres articles de catalogue vendus ensemble.",

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -2108,7 +2108,7 @@
     "remove": "Rimuovi",
     "httpsExampleComProductPng": "https://example.com/product.png",
     "importFromURL": "Importa da URL",
-    "pNGJPEGOrWebPUpTo5MB": "PNG, JPEG o WebP fino a 5 MB.",
+    "pNGJPEGOrWebPUpTo5MB": "PNG o JPEG, fino a 5 MB.",
     "saveTheItemFirstThenAddAProductImage": "Salva prima l'articolo, poi aggiungi un'immagine prodotto.",
     "thisItemIsABundle": "Questo articolo è un bundle",
     "groupsOtherCatalogItemsSoldTogether": "Raggruppa altri articoli del catalogo venduti insieme.",

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -2113,7 +2113,7 @@
     "remove": "Remover",
     "httpsExampleComProductPng": "https://example.com/product.png",
     "importFromURL": "Importar do URL",
-    "pNGJPEGOrWebPUpTo5MB": "PNG, JPEG ou WebP até 5 MB.",
+    "pNGJPEGOrWebPUpTo5MB": "PNG ou JPEG, até 5 MB.",
     "saveTheItemFirstThenAddAProductImage": "Salve o item primeiro e depois adicione uma imagem do produto.",
     "thisItemIsABundle": "Este item é um pacote",
     "groupsOtherCatalogItemsSoldTogether": "Agrupa outros itens do catálogo vendidos juntos.",

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -2113,7 +2113,7 @@
     "remove": "Kaldır",
     "httpsExampleComProductPng": "https://example.com/product.png",
     "importFromURL": "URL'den içe aktar",
-    "pNGJPEGOrWebPUpTo5MB": "PNG, JPEG veya WebP 5 MB'a kadar.",
+    "pNGJPEGOrWebPUpTo5MB": "PNG veya JPEG, 5 MB'a kadar.",
     "saveTheItemFirstThenAddAProductImage": "Önce öğeyi kaydedin, ardından bir ürün resmi ekleyin.",
     "thisItemIsABundle": "Bu öğe bir pakettir",
     "groupsOtherCatalogItemsSoldTogether": "Birlikte satılan diğer katalog ürünlerini gruplandırır.",


### PR DESCRIPTION
## Summary

PR #4408 (#3483) rejected WebP at the **quote image** upload boundary because pdfkit (used to render quote PDFs) cannot embed WebP — `doc.image()` throws, and the render loop's catch-and-continue silently dropped the image from the exported PDF.

Catalog item images still accepted WebP. Those images reach the *same* `quotePdf.ts` render path via quote line thumbnails (`loadCustomerLineImage` → `readCatalogItemImage` when a line has no per-line override), so a WebP catalog image vanished from quote PDFs the same way, with no error surfaced anywhere.

This mirrors PR #4408's fix (option 2 from the original issue: reject at the upload boundary — `apps/api` has no image-transcoding dependency) at the catalog image upload boundary instead.

## Changes

- `apps/api/src/services/catalogImageStorage.ts` — `fetchImageFromUrl` (URL-import path) now rejects a sniffed `image/webp` mime with a clear `CATALOG_IMAGE_WEBP_REJECTED_MESSAGE`, and the generic "unsupported format" message no longer advertises WebP as allowed.
- `apps/api/src/routes/catalog/catalog.ts` — the multipart `POST /:id/image` route applies the same WebP rejection (415), and the `POST /:id/image/from-url` route now surfaces the specific WebP message (415) instead of folding it into the generic "could not download" 400.
- `apps/web/src/components/settings/CatalogItemEditorDrawer.tsx` — the file-picker `accept` attribute drops `image/webp` to match what the API now actually accepts.
- `apps/web/src/locales/*/settings.json` (all 8 locales) — the catalog image help copy (`pNGJPEGOrWebPUpTo5MB`) drops the WebP mention, matching the equivalent quote-image copy already updated in #4408.

## Tests

- `apps/api/src/services/catalogImageStorage.test.ts` — new test proving `fetchImageFromUrl` rejects a sniffed WebP with the clear message, not the generic "unsupported" one.
- `apps/api/src/routes/catalog/catalog.test.ts` — new tests: multipart upload rejects WebP with 415 + the clear message (and never persists), and the URL-import path surfaces the same 415 + message when `fetchImageFromUrl` throws it (rather than the generic 400).

## Test plan

- [x] `vitest run src/services/catalogImageStorage.test.ts src/routes/catalog/catalog.test.ts --pool=threads --maxWorkers=2` (apps/api) — 64/64 passed
- [x] `vitest run src/lib/i18n/localeParity.test.ts src/lib/i18n/i18n.test.ts src/components/settings/CatalogItemEditorDrawer.test.tsx --pool=threads --maxWorkers=2` (apps/web) — 116/116 passed
- [x] `tsc --noEmit` clean in `apps/api` and `apps/web`
- [x] `eslint` clean on all touched files

Closes #4521

🤖 Generated with [Claude Code](https://claude.com/claude-code)