### PR TITLE
fix(api/ai): always notify on auto-demote, even with no readable run (#4582)

### DIFF
--- a/apps/api/src/services/aiAgents/fixWatch.ts
+++ b/apps/api/src/services/aiAgents/fixWatch.ts
@@ -880,6 +880,14 @@ export async function checkFixWatchPhase2(watchId: string): Promise<FixWatchPhas
     console.error('[fixWatch] failed to notify a recurrence (non-fatal — the watch state is already committed)', {
       watchId, error,
     });
+    // #4582 — a console line is invisible in production, and both catches
+    // below/above swallow the only signal a human would ever get that a
+    // committed verdict went unannounced. Identifiers only in the message.
+    captureException(
+      new Error(`recurrence notification failed for fix watch ${watchId}; the verdict is committed`, {
+        cause: error,
+      }),
+    );
   }
   // Separately caught: a failing recurrence notification must not suppress
   // the revoke notice, which is the more consequential of the two (an
@@ -892,6 +900,16 @@ export async function checkFixWatchPhase2(watchId: string): Promise<FixWatchPhas
       console.error('[fixWatch] failed to notify a supervised-key revoke (non-fatal — the revoke is already committed)', {
         watchId, opKey: demotion.opKey, error,
       });
+      // #4582 — the revoke is COMMITTED: an org just lost unattended
+      // authority. `notifyDemotion` reports its own no-recipient outcomes, so
+      // a throw reaching here is the last remaining way that becomes silent.
+      captureException(
+        new Error(
+          `supervised-key revoke notification failed for fix watch ${watchId} `
+          + `(op key "${demotion.opKey}"); the revoke is committed`,
+          { cause: error },
+        ),
+      );
     }
   }
   return { action: 'recurred' };

--- a/apps/api/src/services/aiAgents/supervisedKeyDemote.test.ts
+++ b/apps/api/src/services/aiAgents/supervisedKeyDemote.test.ts
@@ -22,6 +22,10 @@ const RUN_ID = '00000000-0000-4000-8000-0000000000b5';
 const WATCH_ID = '00000000-0000-4000-8000-0000000000b6';
 const INTENT_ID = '00000000-0000-4000-8000-0000000000b7';
 const USER_ID = '00000000-0000-4000-8000-0000000000b8';
+/** Named on the PARTNER baseline row's `recipients`. */
+const PARTNER_USER_ID = '00000000-0000-4000-8000-0000000000b9';
+/** Named ONLY on the ORG override's `recipients` — the half the baseline column drops. */
+const ORG_USER_ID = '00000000-0000-4000-8000-0000000000ba';
 const SCRIPT_ID = '00000000-0000-4000-8000-0000000000bf';
 const OP_KEY = 'manage_services:restart';
 const OTHER_KEY = 'manage_alerts:acknowledge';
@@ -457,8 +461,22 @@ describe('notifyDemotion', () => {
     ...overrides,
   });
 
+  /** The PARTNER baseline row `agentId` names — read in full so the run-less
+   *  fallback can merge its policy with the org override's. */
+  function baselineRow(overrides: Record<string, unknown> = {}) {
+    return {
+      ...orgRow([OP_KEY]),
+      id: AGENT_ID,
+      orgId: null,
+      partnerId: PARTNER_ID,
+      name: 'Disk Cleaner',
+      recipients: { userIds: [PARTNER_USER_ID], roleIds: [] },
+      ...overrides,
+    };
+  }
+
   function queueNotify(opts: { agent?: unknown[]; run?: unknown[] } = {}): void {
-    state.selectQueue.push(opts.agent ?? [{ name: 'Disk Cleaner', orgId: null, partnerId: PARTNER_ID }]);
+    state.selectQueue.push(opts.agent ?? [baselineRow()]);
     state.selectQueue.push(
       opts.run ?? [{ policySnapshot: { effective: { recipients: { userIds: [USER_ID] } } } }],
     );
@@ -516,19 +534,106 @@ describe('notifyDemotion', () => {
     expect(createNotificationMock).not.toHaveBeenCalled();
   });
 
-  it('sends nothing when the run whose snapshot names the recipients is gone', async () => {
-    queueNotify({ run: [] });
+  // #4582 — a revoke that notifies nobody is a silent loss of unattended
+  // authority. The run snapshot stays the PREFERRED recipient source; when it
+  // cannot be read the effective policy is the fallback, never a stand-down.
+  describe('#4582 — a demotion with no readable run still notifies', () => {
+    /** The reads of the run-less path: baseline agent row, then the ORG override. */
+    function queueFallback(opts: { agent?: unknown[]; org?: unknown[] } = {}): void {
+      state.selectQueue.push(opts.agent ?? [baselineRow()]);
+      state.selectQueue.push(opts.org ?? [orgRow([OP_KEY], {
+        recipients: { userIds: [ORG_USER_ID], roleIds: [] },
+      })]);
+    }
 
-    await notify();
+    it('notifies the EFFECTIVE recipients — partner baseline UNION org override — when there is no run id', async () => {
+      queueFallback();
 
-    expect(createNotificationMock).not.toHaveBeenCalled();
-  });
+      await notify({ runId: null, watchId: WATCH_ID, reason: 'recurrence' });
 
-  it('sends nothing when there is no run to resolve recipients from', async () => {
-    state.selectQueue.push([{ name: 'Disk Cleaner', orgId: null, partnerId: PARTNER_ID }]);
+      // Not the baseline row's own `recipients` column: that silently drops
+      // everyone the organization added through its override.
+      expect(resolveRecipientUserIdsMock).toHaveBeenCalledWith(
+        {
+          orgId: null,
+          partnerId: PARTNER_ID,
+          recipients: { userIds: [PARTNER_USER_ID, ORG_USER_ID], roleIds: [] },
+        },
+        ORG_ID,
+      );
+      expect(createNotificationMock).toHaveBeenCalledTimes(1);
+      const sent = createNotificationMock.mock.calls[0]![0] as Record<string, unknown>;
+      expect(sent).toMatchObject({
+        userId: USER_ID,
+        orgId: ORG_ID,
+        priority: 'high',
+        // The episode is the WATCH when there is no run — the dedupe key the
+        // P2-5 plan specified (`<runId ?? watchId>`).
+        dedupeKey: `graduation-demote-${ORG_AGENT_ID}-${OP_KEY}-${WATCH_ID}`,
+        metadata: { runId: null, watchId: WATCH_ID, reason: 'recurrence' },
+      });
+      // No run to link to, so the link points at the page whose state changed.
+      expect(sent.link).toBe('/settings/ai-agents');
+      expect(sent.message).toContain(OP_KEY);
+    });
 
-    await notify({ runId: null, watchId: WATCH_ID });
+    it('falls back to the effective recipients when the run row is gone, still keyed by the run', async () => {
+      state.selectQueue.push([baselineRow()]);
+      state.selectQueue.push([]); // the run no longer exists
+      state.selectQueue.push([orgRow([OP_KEY], {
+        recipients: { userIds: [ORG_USER_ID], roleIds: [] },
+      })]);
 
-    expect(createNotificationMock).not.toHaveBeenCalled();
+      await notify({ watchId: WATCH_ID });
+
+      expect(createNotificationMock).toHaveBeenCalledTimes(1);
+      const sent = createNotificationMock.mock.calls[0]![0] as Record<string, unknown>;
+      // The episode identity is the run id whether or not its row is readable.
+      expect(sent.dedupeKey).toBe(`graduation-demote-${ORG_AGENT_ID}-${OP_KEY}-${RUN_ID}`);
+      // The run page would 404, so the link degrades with the recipient source.
+      expect(sent.link).toBe('/settings/ai-agents');
+    });
+
+    it('still notifies with NO dedupe key when neither a run nor a watch identifies the episode', async () => {
+      queueFallback();
+
+      await notify({ runId: null, watchId: null });
+
+      expect(createNotificationMock).toHaveBeenCalledTimes(1);
+      const sent = createNotificationMock.mock.calls[0]![0] as Record<string, unknown>;
+      // A literal placeholder would collapse every FUTURE demotion of this
+      // tuple into the first one; with no episode there are no siblings to
+      // collapse, so the notice carries no dedupe key at all.
+      expect(sent.dedupeKey).toBeNull();
+    });
+
+    it('sends nothing when the effective policy names no recipient at all', async () => {
+      state.selectQueue.push([baselineRow({ recipients: { userIds: [], roleIds: [] } })]);
+      state.selectQueue.push([orgRow([OP_KEY], { recipients: { userIds: [], roleIds: [] } })]);
+      resolveRecipientUserIdsMock.mockResolvedValueOnce([]);
+
+      await notify({ runId: null, watchId: WATCH_ID });
+
+      // The fallback RAN — this is an empty recipient set, not the old
+      // stand-down that skipped resolution altogether.
+      expect(resolveRecipientUserIdsMock).toHaveBeenCalledWith(
+        expect.objectContaining({ recipients: { userIds: [], roleIds: [] } }),
+        ORG_ID,
+      );
+      expect(createNotificationMock).not.toHaveBeenCalled();
+    });
+
+    it('notifies from the partner baseline alone when the org override row is gone', async () => {
+      state.selectQueue.push([baselineRow()]);
+      state.selectQueue.push([]); // no org override row
+
+      await notify({ runId: null, watchId: WATCH_ID });
+
+      expect(resolveRecipientUserIdsMock).toHaveBeenCalledWith(
+        expect.objectContaining({ recipients: { userIds: [PARTNER_USER_ID], roleIds: [] } }),
+        ORG_ID,
+      );
+      expect(createNotificationMock).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/apps/api/src/services/aiAgents/supervisedKeyDemote.test.ts
+++ b/apps/api/src/services/aiAgents/supervisedKeyDemote.test.ts
@@ -154,6 +154,18 @@ vi.mock('../userNotifications', () => ({
   createNotification: (...args: unknown[]) => createNotificationMock(...args),
 }));
 
+/** #4582 — every way this module can end WITHOUT paging a human must be
+ *  Sentry-visible, so the capture is asserted, not just the absent notice. */
+const captureExceptionMock = vi.hoisted(() => vi.fn());
+vi.mock('../sentry', () => ({
+  captureException: (...args: unknown[]) => captureExceptionMock(...args),
+}));
+
+/** The messages of every Sentry report this call made. */
+function capturedMessages(): string[] {
+  return captureExceptionMock.mock.calls.map((call) => (call[0] as Error).message);
+}
+
 import { db } from '../../db';
 import { aiAgents } from '../../db/schema/aiAgents';
 import { ANONYMOUS_ACTOR_ID } from '../auditEvents';
@@ -526,12 +538,27 @@ describe('notifyDemotion', () => {
     expect(sent.message).not.toContain('attempt failed');
   });
 
-  it('sends nothing when the agent row is gone', async () => {
+  it('reports to Sentry — not just the console — when the agent row is gone', async () => {
     queueNotify({ agent: [] });
 
     await notify();
 
+    // Nothing to build a notice from, so this one genuinely cannot notify.
+    // It must still be LOUD: the revoke is already committed.
     expect(createNotificationMock).not.toHaveBeenCalled();
+    expect(capturedMessages()).toEqual([expect.stringContaining('notified NOBODY')]);
+  });
+
+  it('treats a run row whose snapshot is null as empty recipients, not a throw', async () => {
+    queueNotify({ run: [{ policySnapshot: null }] });
+    resolveRecipientUserIdsMock.mockResolvedValueOnce([]);
+
+    await expect(notify()).resolves.toBeUndefined();
+
+    expect(resolveRecipientUserIdsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ recipients: {} }),
+      ORG_ID,
+    );
   });
 
   // #4582 — a revoke that notifies nobody is a silent loss of unattended
@@ -607,7 +634,24 @@ describe('notifyDemotion', () => {
       expect(sent.dedupeKey).toBeNull();
     });
 
-    it('sends nothing when the effective policy names no recipient at all', async () => {
+    it('reads the org override pinned by org_id + kind + not-disabled', async () => {
+      queueFallback();
+
+      await notify({ runId: null, watchId: WATCH_ID });
+
+      // Two selects on this path: the baseline by id, then the org override.
+      // Asserted as COMPILED SQL — the capture-and-replay mock hands back the
+      // queued row whatever the predicate is, so a dropped `org_id` filter
+      // would otherwise sail through every test in this block.
+      expect(state.selects).toHaveLength(2);
+      const where = sqlText(state.selects[1]!.where);
+      expect(where).toContain('"org_id" = $1');
+      expect(where).toContain('"kind" = $2');
+      expect(where).toContain('"disabled_at" is null');
+      expect(sqlParams(state.selects[1]!.where)).toEqual([ORG_ID, 'triage']);
+    });
+
+    it('reports to Sentry when the effective policy names no recipient at all', async () => {
       state.selectQueue.push([baselineRow({ recipients: { userIds: [], roleIds: [] } })]);
       state.selectQueue.push([orgRow([OP_KEY], { recipients: { userIds: [], roleIds: [] } })]);
       resolveRecipientUserIdsMock.mockResolvedValueOnce([]);
@@ -621,6 +665,13 @@ describe('notifyDemotion', () => {
         ORG_ID,
       );
       expect(createNotificationMock).not.toHaveBeenCalled();
+      // The outcome #4582 is about, reached by the one route this function
+      // cannot fix — so it is reported rather than passed over in silence.
+      // Two distinct reports: the run was unreadable, AND nobody resolved.
+      expect(capturedMessages()).toEqual([
+        expect.stringContaining('no readable run'),
+        expect.stringContaining('ZERO recipients'),
+      ]);
     });
 
     it('notifies from the partner baseline alone when the org override row is gone', async () => {

--- a/apps/api/src/services/aiAgents/supervisedKeyDemote.ts
+++ b/apps/api/src/services/aiAgents/supervisedKeyDemote.ts
@@ -76,6 +76,7 @@ import {
 import { aiAgentGraduation } from '../../db/schema/aiAgentGraduation';
 import { aiAgentRuns, aiAgents } from '../../db/schema/aiAgents';
 import { organizations } from '../../db/schema/orgs';
+import { captureException } from '../sentry';
 import { createAuditLogAsync } from '../auditService';
 import { ANONYMOUS_ACTOR_ID } from '../auditEvents';
 import { createNotification } from '../userNotifications';
@@ -310,26 +311,39 @@ const DEMOTE_REASON_CLAUSE: Record<AiAgentDemoteReason, string> = {
  * cannot distinguish from a real one. Callers wrap it: a failure here is
  * logged, never allowed to unwind a committed revoke.
  *
- * **Every auto-demote notifies (#4582, spec §4.5 / P2-5 Task 16).** The run's
- * snapshot is the PREFERRED recipient source, not a precondition: it is the
- * policy the run actually executed under, so it names exactly the people who
- * were on the hook for the operation being graded. When no run identifies the
- * demotion (a fix-watch recurrence whose run id does not resolve) the
- * fallback is the org's EFFECTIVE recipients — the partner baseline's
- * `recipients` merged with the org override's, through the canonical
- * `mergeAgentPolicies` so the union rule can never drift from the one every
- * other reader sees. The baseline row's own column alone would NOT do: it is
- * the PARTNER's list and silently drops everyone the organization added.
+ * **An unreadable run no longer suppresses the notice (#4582, spec §4.5 /
+ * P2-5 Task 16).** The run's snapshot is the PREFERRED recipient source, not a
+ * precondition: it is the policy the run actually executed under, so it names
+ * exactly the people who were on the hook for the operation being graded. When
+ * it cannot be read the fallback is the org's EFFECTIVE recipients — the
+ * partner baseline's `recipients` merged with the org override's, through the
+ * canonical `mergeAgentPolicies` so the union rule can never drift from the one
+ * every other reader sees. The baseline row's own column alone would NOT do: it
+ * is the PARTNER's list and silently drops everyone the organization added.
  *
- * The previous stand-down (skip when no run resolves) was the bug: a revoke
- * that no recipient hears about is a silent loss of unattended authority, and
- * it is precisely the recurrence path — the one that fires when a fix did not
- * hold — that reached it. An empty recipient set is still a legitimate
- * outcome; an unattempted resolution is not.
+ * The previous stand-down was the bug: the demote transaction has already
+ * COMMITTED by the time this runs, so returning early leaves an organization
+ * stripped of unattended authority with nobody told. An empty recipient set is
+ * still a legitimate outcome; an unattempted resolution is not.
+ *
+ * Reachability, stated precisely because the dropped branch was justified as
+ * unreachable once already: `runId === null` cannot be produced by either
+ * caller today (`ai_agent_fix_watches.run_id` is NOT NULL, and the release
+ * worker returns before building an input when `requesting_agent_run_id` is
+ * absent), so that arm is a contract guarantee for this function's exported
+ * `string | null` signature. The arm that IS reachable is a run row that no
+ * longer resolves — `ai_agent_runs` is org-cascade registered, so an erasure
+ * racing a fix-watch phase-2 job hits exactly this path.
  *
  * `resolveRecipientUserIds` re-derives live membership against THIS org in
  * either case, so the fallback cannot widen the audience beyond people who
  * currently have access to the org the notice describes.
+ *
+ * The three ways this can still end without a page — no agent row, no
+ * resolvable recipient, a throw — are all Sentry-captured rather than logged
+ * to a console nobody reads in production. A committed revoke that notifies
+ * nobody must be visible however it happens; only the ROUTE differs from the
+ * bug this closed.
  */
 export async function notifyDemotion(input: NotifyDemotionInput): Promise<void> {
   const { orgId, agentId, orgAgentId, opKey, reason, runId, watchId } = input;
@@ -344,9 +358,19 @@ export async function notifyDemotion(input: NotifyDemotionInput): Promise<void> 
       .where(eq(aiAgents.id, agentId))
       .limit(1);
     if (!agentRow) {
-      console.warn('[supervisedKeyDemote] agent no longer exists — skipping demote notify', {
-        orgId, agentId, orgAgentId, opKey,
-      });
+      // Nothing to build a notice FROM — no name, no recipients — so this one
+      // really cannot notify. It is read by primary key, the same id the
+      // caller resolved moments earlier, so a miss is a genuine anomaly and
+      // gets a Sentry report rather than the console line it used to get.
+      // Identifiers only, per this module's leak rules.
+      captureException(
+        new Error(
+          `[supervisedKeyDemote] agent ${agentId} no longer exists; the revoke of "${opKey}" `
+          + `on org agent ${orgAgentId} notified NOBODY`,
+        ),
+        undefined,
+        { org_id: orgId },
+      );
       return;
     }
 
@@ -381,9 +405,17 @@ export async function notifyDemotion(input: NotifyDemotionInput): Promise<void> 
         orgAgentRow ? normalizeAgentPolicy(orgAgentRow) : null,
         { allowedModels: null },
       ).effective.recipients;
-      console.warn(
-        '[supervisedKeyDemote] no readable run — notifying the effective recipients instead',
-        { orgId, agentId, orgAgentId, opKey, runId, watchId },
+      // Not a failure — the notice still goes out — but the recipient list
+      // just came from the live policy rather than the run's immutable
+      // snapshot, and the missing run row is itself worth a look.
+      captureException(
+        new Error(
+          `[supervisedKeyDemote] no readable run (run ${runId ?? 'none'}, watch ${watchId ?? 'none'}) `
+          + `for the revoke of "${opKey}" on org agent ${orgAgentId}; `
+          + 'used the effective-policy recipients instead',
+        ),
+        undefined,
+        { org_id: orgId },
       );
     }
 
@@ -391,6 +423,21 @@ export async function notifyDemotion(input: NotifyDemotionInput): Promise<void> 
       { orgId: agentRow.orgId, partnerId: agentRow.partnerId, recipients },
       orgId,
     );
+    if (userIds.length === 0) {
+      // The outcome #4582 is ultimately about, reached by the one route this
+      // function cannot fix: the recipients resolved to nobody. Legitimate on
+      // its face (memberships lapse), but an act-mode agent is only allowed to
+      // start with a resolvable recipient (`hasResolvableAgentRecipient`), so
+      // a granted-then-revoked key with zero is worth an operator's attention.
+      captureException(
+        new Error(
+          `[supervisedKeyDemote] the revoke of "${opKey}" on org agent ${orgAgentId} `
+          + 'resolved to ZERO recipients; nobody was notified',
+        ),
+        undefined,
+        { org_id: orgId },
+      );
+    }
 
     // One notice per (org row, key, episode). N sibling watches of one run
     // that all revoke the same key collapse into one page; a second, genuinely

--- a/apps/api/src/services/aiAgents/supervisedKeyDemote.ts
+++ b/apps/api/src/services/aiAgents/supervisedKeyDemote.ts
@@ -79,7 +79,7 @@ import { organizations } from '../../db/schema/orgs';
 import { createAuditLogAsync } from '../auditService';
 import { ANONYMOUS_ACTOR_ID } from '../auditEvents';
 import { createNotification } from '../userNotifications';
-import { normalizeAgentPolicy } from './effectivePolicy';
+import { mergeAgentPolicies, normalizeAgentPolicy } from './effectivePolicy';
 import { withGraduationLock } from './graduationService';
 import { resolveRecipientUserIds } from './recipients';
 
@@ -310,16 +310,36 @@ const DEMOTE_REASON_CLAUSE: Record<AiAgentDemoteReason, string> = {
  * cannot distinguish from a real one. Callers wrap it: a failure here is
  * logged, never allowed to unwind a committed revoke.
  *
- * With no readable run there is no correct recipient set, so nothing is sent
- * — the same stand-down `sendRecurrenceNotifications` takes, and the reason
- * `runId` is part of the input rather than re-derived here.
+ * **Every auto-demote notifies (#4582, spec §4.5 / P2-5 Task 16).** The run's
+ * snapshot is the PREFERRED recipient source, not a precondition: it is the
+ * policy the run actually executed under, so it names exactly the people who
+ * were on the hook for the operation being graded. When no run identifies the
+ * demotion (a fix-watch recurrence whose run id does not resolve) the
+ * fallback is the org's EFFECTIVE recipients — the partner baseline's
+ * `recipients` merged with the org override's, through the canonical
+ * `mergeAgentPolicies` so the union rule can never drift from the one every
+ * other reader sees. The baseline row's own column alone would NOT do: it is
+ * the PARTNER's list and silently drops everyone the organization added.
+ *
+ * The previous stand-down (skip when no run resolves) was the bug: a revoke
+ * that no recipient hears about is a silent loss of unattended authority, and
+ * it is precisely the recurrence path — the one that fires when a fix did not
+ * hold — that reached it. An empty recipient set is still a legitimate
+ * outcome; an unattempted resolution is not.
+ *
+ * `resolveRecipientUserIds` re-derives live membership against THIS org in
+ * either case, so the fallback cannot widen the audience beyond people who
+ * currently have access to the org the notice describes.
  */
 export async function notifyDemotion(input: NotifyDemotionInput): Promise<void> {
   const { orgId, agentId, orgAgentId, opKey, reason, runId, watchId } = input;
 
   await inSystemDbContext(async () => {
+    // The FULL baseline row, not just its name: `kind` pairs it with the org
+    // override (there is no FK between them), and its policy columns are the
+    // partner half of the run-less fallback below. One read either way.
     const [agentRow] = await db
-      .select({ name: aiAgents.name, orgId: aiAgents.orgId, partnerId: aiAgents.partnerId })
+      .select()
       .from(aiAgents)
       .where(eq(aiAgents.id, agentId))
       .limit(1);
@@ -330,29 +350,63 @@ export async function notifyDemotion(input: NotifyDemotionInput): Promise<void> 
       return;
     }
 
-    if (!runId) {
-      console.warn('[supervisedKeyDemote] no run to resolve recipients from — skipping demote notify', {
-        orgId, agentId, orgAgentId, opKey, watchId,
-      });
-      return;
-    }
-    const [runRow] = await db
-      .select({ policySnapshot: aiAgentRuns.policySnapshot })
-      .from(aiAgentRuns)
-      .where(and(eq(aiAgentRuns.id, runId), eq(aiAgentRuns.orgId, orgId)))
-      .limit(1);
-    if (!runRow) {
-      console.warn('[supervisedKeyDemote] run no longer exists — skipping demote notify', {
-        orgId, agentId, orgAgentId, opKey, runId,
-      });
-      return;
+    const runSnapshot = runId
+      ? (await db
+        .select({ policySnapshot: aiAgentRuns.policySnapshot })
+        .from(aiAgentRuns)
+        .where(and(eq(aiAgentRuns.id, runId), eq(aiAgentRuns.orgId, orgId)))
+        .limit(1))[0]
+      : undefined;
+
+    let recipients: Partial<AiAgentRecipients>;
+    if (runSnapshot) {
+      recipients = runSnapshot.policySnapshot?.effective?.recipients ?? {};
+    } else {
+      // NOT a skip (#4582). The org override row is read by `(org_id, kind)`
+      // — the same pairing the demote executor used to find the row it
+      // revoked from — and merged through the canonical tighten-only merge,
+      // whose `recipients` rule is a UNION of both layers. A missing override
+      // degrades to the partner's own list rather than to silence.
+      const [orgAgentRow] = await db
+        .select()
+        .from(aiAgents)
+        .where(and(
+          eq(aiAgents.orgId, orgId),
+          eq(aiAgents.kind, agentRow.kind),
+          isNull(aiAgents.disabledAt),
+        ))
+        .limit(1);
+      recipients = mergeAgentPolicies(
+        normalizeAgentPolicy(agentRow),
+        orgAgentRow ? normalizeAgentPolicy(orgAgentRow) : null,
+        { allowedModels: null },
+      ).effective.recipients;
+      console.warn(
+        '[supervisedKeyDemote] no readable run — notifying the effective recipients instead',
+        { orgId, agentId, orgAgentId, opKey, runId, watchId },
+      );
     }
 
-    const recipients: Partial<AiAgentRecipients> = runRow.policySnapshot?.effective?.recipients ?? {};
     const userIds = await resolveRecipientUserIds(
       { orgId: agentRow.orgId, partnerId: agentRow.partnerId, recipients },
       orgId,
     );
+
+    // One notice per (org row, key, episode). N sibling watches of one run
+    // that all revoke the same key collapse into one page; a second, genuinely
+    // distinct episode carries a different run id. `<runId ?? watchId>` is
+    // what the P2-5 plan specified: with no run the WATCH is the episode.
+    //
+    // Null — no dedupe key at all — when neither identifies the episode. A
+    // literal placeholder would be worse than nothing: `(user_id, dedupe_key)`
+    // is a partial unique index with no time bound, so a fixed suffix would
+    // collapse every FUTURE demotion of this tuple into the first one. With no
+    // episode there are no siblings to collapse. `runId`/`watchId` ride in
+    // `metadata` either way, so the notice stays traceable.
+    const episodeId = runId ?? watchId;
+    // The run page would 404 without a readable run, so the link degrades with
+    // the recipient source, to the page whose state actually changed.
+    const link = runSnapshot ? `/ai-agents/runs/${runId}` : '/settings/ai-agents';
 
     for (const userId of userIds) {
       await createNotification({
@@ -363,19 +417,10 @@ export async function notifyDemotion(input: NotifyDemotionInput): Promise<void> 
         message:
           `${agentRow.name} no longer runs "${opKey}" without approval — `
           + DEMOTE_REASON_CLAUSE[reason],
-        link: `/ai-agents/runs/${runId}`,
+        link,
         priority: 'high',
         metadata: { agentId, orgAgentId, opKey, reason, runId, watchId },
-        // One notice per (org row, key, episode). N sibling watches of one run
-        // that all revoke the same key collapse into one page; a second,
-        // genuinely distinct episode carries a different run id.
-        //
-        // The plan spells this `<runId ?? watchId>`. The fallback is dropped
-        // rather than carried as an unreachable branch: the recipient set
-        // itself comes from the RUN's snapshot, so a demotion with no run
-        // sends nothing at all and could never reach this line. `watchId`
-        // still rides in `metadata`, so the episode stays identifiable.
-        dedupeKey: `graduation-demote-${orgAgentId}-${opKey}-${runId}`,
+        dedupeKey: episodeId ? `graduation-demote-${orgAgentId}-${opKey}-${episodeId}` : null,
       });
     }
   });


### PR DESCRIPTION
Closes #4582

## The bug

`notifyDemotion` (`apps/api/src/services/aiAgents/supervisedKeyDemote.ts`) stood down whenever the run's policy snapshot could not be read — either no `runId` on the input, or the run row not readable in the org:

```ts
if (!runId) { console.warn('… — skipping demote notify', …); return; }
…
if (!runRow) { console.warn('… — skipping demote notify', …); return; }
```

The auto-demote transaction had already **committed** by then: the key was removed from the org row, the audit entry written, the graduation row stamped `demoted`. So an organization lost a supervised action key — its unattended authority for that operation — with **no recipient notified**.

Spec §4.5 / P2-5 plan Task 16 require notifying `recipients` at high priority on every auto-demote. The plan also specified the dedupe key as `graduation-demote-<orgAgentId>-<opKey>-<runId ?? watchId>`; the `?? watchId` branch had been dropped as "unreachable", justified by the very stand-down that is the bug.

### Reachability — stated precisely

Because "this branch is unreachable" is exactly the reasoning that dropped the notification, this PR does not repeat it loosely:

- **`runId === null` is NOT reachable from either caller today.** `ai_agent_fix_watches.run_id` is `NOT NULL`, and `intentReleaseWorker` returns before building a `NotifyDemotionInput` when `requesting_agent_run_id` is absent. That arm is a contract guarantee for this exported function's `string | null` signature, not a live regression path. (verified against the schema and both call sites)
- **A run row that no longer resolves IS reachable.** `ai_agent_runs` is org-cascade registered, so a tenant erasure racing a fix-watch phase-2 job lands on exactly this path. (verified — `ai_agent_runs` is in `CORE_ORG_CASCADE_DELETE_ORDER`)

So: one live path, one contract path, both closed.

## The fix

**The run snapshot stays the preferred recipient source, but is no longer a precondition.** It is the policy the run actually executed under, so it names exactly the people who were on the hook for the operation being graded — that reasoning is unchanged when it *is* readable.

When it is not, the fallback is the org's **effective** recipients: the partner baseline's `recipients` unioned with the org override's, resolved through the canonical `mergeAgentPolicies` so the union rule cannot drift from what every other reader sees. The baseline row's own `recipients` column alone would **not** do — it is the PARTNER's list and silently drops everyone the organization added through its override, which is the objection the original docstring already recorded.

`resolveRecipientUserIds` re-derives live membership against **this** org either way, so the fallback cannot widen the audience beyond people who currently have access to the org the notice describes. An empty recipient set is still a legitimate outcome; an *unattempted resolution* is not.

Three smaller consequences:

- **Dedupe key** is restored to the planned `<runId ?? watchId>`. With neither id present the notice carries **no dedupe key at all** rather than a literal placeholder — `(user_id, dedupe_key)` is a partial unique index with no time bound, so a fixed suffix would collapse every *future* demotion of that tuple into the first one. With no episode there are no siblings to collapse, and `runId`/`watchId` ride in `metadata` regardless.
- **Link** degrades with the recipient source: `/settings/ai-agents` (the page whose state actually changed, and where `AiAgentGraduationPanel` lives) instead of `/ai-agents/runs/<id>`, which would 404 without a readable run.
- The baseline agent row is now read in full rather than three columns — `kind` pairs it with the org override (there is no FK between them) and its policy columns are the partner half of the merge. One read either way on the hot path; the fallback adds exactly one more.

### Every remaining way this goes quiet is now loud

Review raised that closing one silent path while leaving its siblings on `console.warn` — invisible in production — is not much of a fix. `supervisedKeyDemote.ts` now Sentry-captures all three:

| Path | Behaviour |
|---|---|
| No agent row | Cannot build a notice at all (no name, no recipients) — still returns, now **captured**. Read by primary key, so a miss is a genuine anomaly. |
| No readable run | Notifies from the effective policy — **captured**, since the recipient list differs from the run's snapshot and the missing row is worth a look. |
| Recipients resolve to nobody | Notifies no one — **captured**. An act-mode agent may only start with a resolvable recipient (`hasResolvableAgentRecipient`), so zero on a granted-then-revoked key is worth attention. |

Identifiers only in every message (per the module's leak rules); `org_id` is the only tag, since `services/sentry.ts` scrubs anything outside its allowlist.

`fixWatch.ts`'s two post-commit notification catches logged to `console.error` with no Sentry capture, so a throw out of `notifyDemotion` — the last remaining route to silence — was invisible. Both now capture. (This also closes the `sendRecurrenceNotifications` gap noted as "not fixed" in the first revision of this description.)

## Tests

`supervisedKeyDemote.test.ts` — the two tests that pinned the stand-down are inverted, `../sentry` is now mocked so "loud, not silent" is an asserted contract rather than a claim, and eight tests cover the new behaviour:

- no run id → notifies the **union** of partner-baseline and org-override recipients (proves it is not just the baseline column), dedupe key keyed by `watchId`, link `/settings/ai-agents`;
- run row gone → same fallback, dedupe key still keyed by `runId` (the episode identity does not depend on the row being readable);
- neither run nor watch → still notifies, with a **null** dedupe key;
- run row present but `policySnapshot` null → falls through to empty recipients rather than throwing;
- effective policy names nobody → sends nothing, asserts the resolution **ran** and that both Sentry reports fired;
- org override row gone → notifies from the partner baseline alone;
- agent row gone → sends nothing, asserts the Sentry report;
- **the new org-override read's predicate asserted as compiled SQL** (`org_id`, `kind`, `disabled_at IS NULL`) — the capture-and-replay mock hands back the queued row whatever the query shape is, so without this a dropped `org_id` filter would pass every other test in the block. **Verified by mutation**: removing `eq(aiAgents.orgId, orgId)` from the implementation fails this test and only this test.

Verification (all run locally, single-fork):

- `npx vitest run src/services/aiAgents/supervisedKeyDemote.test.ts` — 22 passed (red first: 4 failed before the implementation).
- `npx vitest run` over `supervisedKeyDemote` + `fixWatch` + `fixWatch.sql` + `supervisedKeyGrant` + `effectivePolicy` + `intentReleaseWorker` + `workerEntrypointClosure.contract` — **360 passed**. The closure contract matters: `supervisedKeyDemote` is in `fixWatchWorker`'s import graph, and both new imports (`mergeAgentPolicies` from `effectivePolicy.ts`, `captureException` from `services/sentry.ts`) were already in that closure — no new edge.
- `npx tsc --noEmit` — clean. `npx eslint` on all three changed files — clean.

No schema, migration, tenancy or cascade surface is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)