### PR TITLE
fix(web): persist Remote Tools tab in the URL hash and let the terminal fill the viewport (#4512, #4510)

### DIFF
--- a/apps/web/src/components/remote/RemoteTerminal.test.tsx
+++ b/apps/web/src/components/remote/RemoteTerminal.test.tsx
@@ -582,3 +582,22 @@ describe('RemoteTerminal hostname prop lifecycle (#4152)', () => {
     expect(MockWebSocket.instances).toHaveLength(1);
   });
 });
+
+describe('RemoteTerminal layout fills its flex parent (#4510)', () => {
+  it('gives the root wrapper flex-1 min-h-0 so it grows inside a flex column parent', () => {
+    const { container } = renderTerminal();
+
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toMatch(/\bflex-1\b/);
+    expect(root.className).toMatch(/\bmin-h-0\b/);
+    expect(root.className).toMatch(/\bflex-col\b/);
+  });
+
+  it('keeps the xterm container growing to fill the wrapper while retaining the 400px floor', () => {
+    const { container } = renderTerminal();
+
+    const xtermContainer = container.querySelector('.u-min-h-px-400') as HTMLElement | null;
+    expect(xtermContainer).not.toBeNull();
+    expect(xtermContainer!.className).toMatch(/\bflex-1\b/);
+  });
+});

--- a/apps/web/src/components/remote/RemoteTerminal.tsx
+++ b/apps/web/src/components/remote/RemoteTerminal.tsx
@@ -677,7 +677,12 @@ export default function RemoteTerminal({
   return (
     <div
       className={cn(
-        'flex flex-col rounded-lg border bg-card shadow-xs overflow-hidden',
+        // flex-1 min-h-0 (#4510): lets the pane grow to fill a flex-column
+        // parent's available height (RemoteToolsPage's terminal tab panel)
+        // instead of shrinking to the header + the inner 400px floor below.
+        // Inert when the parent isn't a flex container (e.g. RemoteTerminalPage,
+        // which sizes this via the `className` prop instead).
+        'flex flex-1 min-h-0 flex-col rounded-lg border bg-card shadow-xs overflow-hidden',
         isFullscreen && 'fixed inset-4 z-50',
         className
       )}
@@ -758,13 +763,10 @@ export default function RemoteTerminal({
       </div>
 
       {/* Terminal Container */}
-      <div className={cn('relative flex-1 flex flex-col', isFullscreen && 'min-h-0')}>
+      <div className="relative flex-1 min-h-0 flex flex-col">
         <div
           ref={terminalContainerRef}
-          className={cn(
-            'flex-1 u-min-h-px-400 bg-[#1a1b26] text-[#f8f8f2] cursor-text p-2 overflow-hidden',
-            isFullscreen && 'min-h-0'
-          )}
+          className="flex-1 min-h-0 u-min-h-px-400 bg-[#1a1b26] text-[#f8f8f2] cursor-text p-2 overflow-hidden"
           onClick={() => terminalRef.current?.focus()}
         />
         {/* Disconnect overlay (issue #2871): a dead session must be unmissable,

--- a/apps/web/src/components/remote/RemoteToolsPage.test.tsx
+++ b/apps/web/src/components/remote/RemoteToolsPage.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen, waitFor, act, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import RemoteToolsPage from './RemoteToolsPage';
+import { fetchWithAuth } from '@/stores/auth';
+
+vi.mock('@/stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+// The real button drives desktop-session launch/deep-link flows unrelated to
+// tab/hash behavior; only its presence matters for this suite.
+vi.mock('./ConnectDesktopButton', () => ({
+  default: () => <button type="button">connect</button>,
+}));
+
+// RemoteTerminal lazy-imports xterm.js and opens a WebSocket on mount — that
+// machinery is covered by RemoteTerminal.test.tsx. Here we only need proof
+// that RemoteToolsPage mounted the Terminal tab's content, so stub it out
+// with a marker element.
+vi.mock('./RemoteTerminal', () => ({
+  default: () => <div data-testid="remote-terminal-stub" />,
+}));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const makeResponse = (payload: unknown = {}, ok = false): Response =>
+  ({
+    ok,
+    status: ok ? 200 : 404,
+    json: vi.fn().mockResolvedValue(payload),
+  } as unknown as Response);
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  // Nothing under test here depends on real device/process/service data —
+  // every fetch resolves not-ok so effects bail out quietly.
+  fetchMock.mockResolvedValue(makeResponse());
+  window.location.hash = '';
+});
+
+afterEach(() => {
+  window.location.hash = '';
+  cleanup();
+});
+
+const renderPage = () =>
+  render(<RemoteToolsPage deviceId="device-1" deviceName="host-1" deviceOs="windows" />);
+
+describe('RemoteToolsPage tab hash persistence (#4512)', () => {
+  it('activates the Terminal tab on mount when the URL hash is #terminal', async () => {
+    window.location.hash = '#terminal';
+
+    renderPage();
+
+    expect(await screen.findByTestId('remote-terminal-stub')).toBeInTheDocument();
+  });
+
+  it('defaults to the Processes tab when there is no hash', async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('remote-terminal-stub')).not.toBeInTheDocument();
+    });
+  });
+
+  it('falls back to the default tab when the hash names an unknown tab', async () => {
+    window.location.hash = '#not-a-real-tab';
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('remote-terminal-stub')).not.toBeInTheDocument();
+    });
+  });
+
+  it('writes the clicked tab id to the URL hash and renders that tab', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const terminalTabButton = await screen.findByRole('button', { name: 'Terminal' });
+    await user.click(terminalTabButton);
+
+    expect(window.location.hash).toBe('#terminal');
+    expect(await screen.findByTestId('remote-terminal-stub')).toBeInTheDocument();
+  });
+
+  it('re-syncs the active tab on a hashchange event (back/forward navigation)', async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('remote-terminal-stub')).not.toBeInTheDocument();
+    });
+
+    act(() => {
+      window.location.hash = '#terminal';
+      window.dispatchEvent(new Event('hashchange'));
+    });
+
+    expect(await screen.findByTestId('remote-terminal-stub')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/remote/RemoteToolsPage.test.tsx
+++ b/apps/web/src/components/remote/RemoteToolsPage.test.tsx
@@ -100,4 +100,18 @@ describe('RemoteToolsPage tab hash persistence (#4512)', () => {
 
     expect(await screen.findByTestId('remote-terminal-stub')).toBeInTheDocument();
   });
+
+  it('falls back to the Processes tab when the hash names a windows-only tab on a non-Windows device (regression: hash bypasses OS gating)', async () => {
+    window.location.hash = '#services';
+
+    render(<RemoteToolsPage deviceId="device-1" deviceName="host-1" deviceOs="linux" />);
+
+    // 'services' is windows-only and this device is linux, so the page must
+    // not get stuck on a tab whose button/content never render.
+    await waitFor(() => {
+      expect(window.location.hash).toBe('#processes');
+    });
+    const processesButton = await screen.findByRole('button', { name: 'Processes' });
+    expect(processesButton.className).toMatch(/border-primary/);
+  });
 });

--- a/apps/web/src/components/remote/RemoteToolsPage.tsx
+++ b/apps/web/src/components/remote/RemoteToolsPage.tsx
@@ -14,6 +14,7 @@ import {
 } from 'lucide-react';
 import { fetchWithAuth } from '@/stores/auth';
 import { navigateTo } from '@/lib/navigation';
+import { useHashTab } from '@/lib/useHashState';
 
 // Import actual components
 import ProcessManager, { type Process, type ProcessStatus } from './ProcessManager';
@@ -48,6 +49,11 @@ const tabs: { id: ToolTab; label: string; icon: typeof Activity; windowsOnly?: b
   { id: 'terminal', label: 'Terminal', icon: Terminal },
   { id: 'files', label: 'File Browser', icon: FolderOpen }
 ];
+
+// The full set of tab ids, used to validate a deep-linked hash (#4512) — every
+// id in `tabs` above, regardless of `windowsOnly`, since the hash can be
+// followed before the device's OS (and therefore tab availability) resolves.
+const VALID_TABS: readonly ToolTab[] = tabs.map((tab) => tab.id);
 
 type DeviceOs = 'windows' | 'macos' | 'linux';
 
@@ -396,7 +402,13 @@ export default function RemoteToolsPage({
   showClose = false
 }: RemoteToolsPageProps) {
   const { t } = useTranslation('remote');
-  const [activeTab, setActiveTab] = useState<ToolTab>(initialTab);
+  // Tab selection is persisted in the URL hash (#4512) rather than plain
+  // component state, so a browser refresh (or a deep link) lands back on the
+  // tab the user was on instead of always resetting to Processes — same
+  // pattern as DeviceDetails.tsx / DnsSecurityPage.tsx (CLAUDE.md "URL State
+  // in Components": hash, not query params). `useHashTab` is SSR-safe: the
+  // first render uses `initialTab` and the hash is adopted post-mount.
+  const [activeTab, setActiveTabState] = useHashTab<ToolTab>(VALID_TABS, initialTab);
   const [resolvedDeviceName, setResolvedDeviceName] = useState(deviceName);
   const [resolvedDeviceOs, setResolvedDeviceOs] = useState<DeviceOs>(normalizeDeviceOs(deviceOs));
   const [isHeadless, setIsHeadless] = useState(false);
@@ -428,6 +440,13 @@ export default function RemoteToolsPage({
   const availableTabs = tabs.filter(tab => !tab.windowsOnly || isWindows);
   const shouldShowClose = showClose || Boolean(onClose);
   const deviceOsLabel = formatDeviceOs(resolvedDeviceOs);
+
+  // Reflect tab clicks into the URL hash (CLAUDE.md "URL State in
+  // Components") — matches DnsSecurityPage.tsx's switchTab.
+  const switchTab = useCallback((tab: ToolTab) => {
+    window.location.hash = tab;
+    setActiveTabState(tab);
+  }, [setActiveTabState]);
 
   const handleClose = useCallback(() => {
     if (onClose) {
@@ -849,7 +868,7 @@ export default function RemoteToolsPage({
           return (
             <button
               key={tab.id}
-              onClick={() => setActiveTab(tab.id)}
+              onClick={() => switchTab(tab.id)}
               className={`flex items-center gap-2 border-b-2 px-4 py-3 text-sm font-medium transition-colors ${
                 isActive
                   ? 'border-primary text-primary'

--- a/apps/web/src/components/remote/RemoteToolsPage.tsx
+++ b/apps/web/src/components/remote/RemoteToolsPage.tsx
@@ -448,6 +448,21 @@ export default function RemoteToolsPage({
     setActiveTabState(tab);
   }, [setActiveTabState]);
 
+  // A hash can restore a windows-only tab (bookmarked/shared link, or a stale
+  // fragment left over from a different device) for a device that turns out
+  // not to be Windows. `availableTabs` below already hides that tab's button
+  // and none of the tab-content branches render for it, so without this the
+  // page would silently show no active tab and an empty content pane — the
+  // hash gives that state a second, unguarded path that clicking a tab button
+  // never could. Reset to the always-available Processes tab when that
+  // happens, and reflect the correction into the hash too.
+  useEffect(() => {
+    const tabDef = tabs.find(tab => tab.id === activeTab);
+    if (tabDef?.windowsOnly && !isWindows) {
+      switchTab('processes');
+    }
+  }, [activeTab, isWindows, switchTab]);
+
   const handleClose = useCallback(() => {
     if (onClose) {
       onClose();


### PR DESCRIPTION
## Summary

**#4512** — `RemoteToolsPage.tsx` kept the active tab in plain `useState(initialTab)` with nothing syncing it to `window.location.hash`, and `tools.astro` never passed an `initialTab`, so a browser refresh while on the Terminal tab always landed back on Processes. Switched to the repo's existing `useHashTab` hook (`apps/web/src/lib/useHashState.ts`) — the same pattern already used by `DnsSecurityPage.tsx` / `DeviceDetails.tsx` (CLAUDE.md "URL State in Components": hash, not query params). The hash is read post-mount (SSR-safe) and written on every tab click via a new `switchTab` callback.

**#4510** — `RemoteTerminal.tsx`'s root wrapper had no `flex-1`/`min-h-0`, so it never grew to fill `RemoteToolsPage`'s `flex-1 min-h-0` tab content area — it only ever sized to its header plus the inner container's 400px floor (`u-min-h-px-400`). Added `flex-1 min-h-0` to the root wrapper and the inner "Terminal Container"/xterm-mount divs so the pane fills whatever height its flex parent gives it, while keeping the 400px floor. The component already had a `ResizeObserver` that calls `fitAddon.fit()` on resize, and xterm's `onResize` already forwards the new cols/rows to the server — no protocol change was needed, this was purely a CSS/layout bug.

## Test plan
- [x] Red-first: added `RemoteToolsPage.test.tsx` (hash-driven tab activation on mount, hash written on tab click, hashchange re-sync, default/unknown-hash fallback) and two new cases in `RemoteTerminal.test.tsx` (wrapper carries `flex-1`/`min-h-0`/`flex-col`; xterm container keeps `flex-1` + the 400px floor) — confirmed all 4 new assertions failed against pre-fix code, then passed after the fix.
- [x] `cd apps/web && npx vitest run src/components/remote` — 20 files / 151 tests passed.
- [x] `cd apps/web && npx tsc --noEmit -p .` — clean.
- [x] `npx eslint` scoped to the touched files — clean.

Closes #4512
Closes #4510

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xr3ZNTFRkCM1t4gEjPttTg