### PR TITLE
fix(api/tenancy): sever ai_agent_runs.ticket_id on a ticket org-move (#4524)

### DIFF
--- a/apps/api/src/__tests__/integration/ticket-move-org.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ticket-move-org.integration.test.ts
@@ -887,15 +887,70 @@ describe('moveTicketOrg — ai_agent_runs.ticket_id detach (#4524)', () => {
       .returning();
     expect(aiComment.agentRunId).toBe(run.id);
 
+    // Control: an AI comment on a DIFFERENT ticket in the SAME source org.
+    // Rejects a detach scoped by org rather than by the moved ticket — e.g.
+    // `WHERE ticket_id IN (SELECT id FROM tickets WHERE org_id = source)`,
+    // which the single-comment case alone would pass.
+    const sibling = await seedSiblingTicket(orgA.id, partner.id);
+    const siblingRun = await seedRunOnTicket(orgA.id, agent.id, sibling.id, null);
+    const [siblingComment] = await adminDb
+      .insert(ticketComments)
+      .values({
+        ticketId: sibling.id,
+        authorType: 'internal',
+        commentType: 'comment',
+        content: 'Triage note on a ticket that never moves.',
+        isPublic: false,
+        originPrincipalKind: 'ai_agent',
+        agentRunId: siblingRun.id,
+      })
+      .returning();
+
     await withSystemDbAccessContext(() => moveTicketOrg(ticket.id, orgB.id, actor));
 
     const after = await readComment(aiComment.id);
     expect(after?.agentRunId).toBeNull();
+    // The sibling ticket never moved, so its comment keeps its run link.
+    expect((await readComment(siblingComment.id))?.agentRunId).toBe(siblingRun.id);
     // Only the cross-org link is dropped. The comment itself, its content and
     // its non-user provenance (which is what the helpdesk loop guard actually
     // keys on) all survive the move.
     expect(after?.ticketId).toBe(ticket.id);
     expect(after?.content).toBe('Proposed next step from triage.');
     expect(after?.originPrincipalKind).toBe('ai_agent');
+  });
+
+  it('rolls the detach back with the rest of the transaction when the currency guard blocks the move', async () => {
+    // The detach runs BEFORE assertTicketMoveCurrencyCompatible (deliberately —
+    // see the lock-order note at the statement), so a blocked move must unwind
+    // it along with everything else. Verified discriminating by mutation: hoist
+    // the detach out of db.transaction (its own withSystemDbAccessContext, as a
+    // "tidier" refactor might) and ONLY this case fails — every other test in
+    // this block still passes while the pointer is severed on a move that never
+    // happened. Note that swapping `tx` for `db` is NOT that mutation: `db` is
+    // an AsyncLocalStorage-bound proxy (db/index.ts) that resolves to the same
+    // pinned connection inside the callback, so it stays transactional.
+    const adminDb = getTestDb() as any;
+    const { orgA, orgB, partner, actor, ticket, timeEntry, ticketPart } = await seedMoveOrgFixture();
+    const agent = await seedTriageAgent(orgA.id, partner.id);
+    const run = await seedRunOnTicket(orgA.id, agent.id, ticket.id, null);
+
+    await setOrgCurrency(orgB.id, 'EUR');
+    await adminDb.update(timeEntries)
+      .set({ hourlyRate: '100.00', isBillable: false, billingStatus: 'not_billed' })
+      .where(eq(timeEntries.id, timeEntry.id));
+    await adminDb.delete(ticketParts).where(eq(ticketParts.id, ticketPart.id));
+
+    const err = await withSystemDbAccessContext(() =>
+      moveTicketOrg(ticket.id, orgB.id, actor)
+    ).catch((e) => e);
+    expect(err).toBeInstanceOf(TicketMoveCurrencyBlockedError);
+
+    // Nothing moved — and the pointer is still there, because the ticket is
+    // still the source org's.
+    expect((await readTicket(ticket.id))?.orgId).toBe(orgA.id);
+    const after = await readRun(run.id);
+    expect(after?.ticketId).toBe(ticket.id);
+    expect(after?.orgId).toBe(orgA.id);
   });
 });

--- a/apps/api/src/__tests__/integration/ticket-move-org.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ticket-move-org.integration.test.ts
@@ -730,3 +730,172 @@ describe('moveTicketOrg — requester contact detach (#3258 W03)', () => {
     expect(after.orgId).toBe(orgA.id);
   });
 });
+
+// ── #4524: the ai_agent_runs ↔ ticket pointer pair must be severed on a move ──
+
+/**
+ * Seeds one `ai_agent_runs` row pointing at `ticketId`. Unlike
+ * `seedTicketScopedIntent` (which needs a run only as an intent's requester
+ * and leaves `ticket_id` NULL), this is the shape #4524 is about: a
+ * trigger_kind='ticket' run whose `ticket_id` names the ticket.
+ *
+ * `deviceId` is parameterised because ticket-triggered runs are normally
+ * device-LESS (the ticket axis stamps ticket_id and leaves device_id NULL),
+ * while a device-triggered run can also carry a ticket_id — the ticket-keyed
+ * detach must reach both, and a `WHERE device_id IS NULL` narrowing must not
+ * pass.
+ */
+async function seedRunOnTicket(
+  orgId: string,
+  agentId: string,
+  ticketId: string,
+  deviceId: string | null = null,
+): Promise<{ id: string }> {
+  const adminDb = getTestDb() as any;
+  const [run] = await adminDb
+    .insert(aiAgentRuns)
+    .values({
+      agentId,
+      orgId,
+      triggerKind: 'ticket',
+      dedupeKey: `move-org-run-${uid()}`,
+      modeAtStart: 'shadow',
+      policySnapshot: { schemaVersion: 1 },
+      ticketId,
+      deviceId,
+    })
+    .returning();
+  return { id: run.id };
+}
+
+async function readRun(id: string) {
+  const adminDb = getTestDb() as any;
+  const [row] = await adminDb.select().from(aiAgentRuns).where(eq(aiAgentRuns.id, id)).limit(1);
+  return row as (typeof aiAgentRuns.$inferSelect) | undefined;
+}
+
+async function readComment(id: string) {
+  const adminDb = getTestDb() as any;
+  const [row] = await adminDb.select().from(ticketComments).where(eq(ticketComments.id, id)).limit(1);
+  return row as (typeof ticketComments.$inferSelect) | undefined;
+}
+
+/** A second ticket in the SAME source org, used as the "must not be touched" control. */
+async function seedSiblingTicket(orgId: string, partnerId: string): Promise<{ id: string }> {
+  const adminDb = getTestDb() as any;
+  const unique = uid();
+  const [row] = await adminDb
+    .insert(tickets)
+    .values({
+      orgId,
+      partnerId,
+      ticketNumber: `MO-SIB-${unique}`,
+      subject: `sibling ticket ${unique}`,
+      source: 'manual',
+    })
+    .returning();
+  return { id: row.id };
+}
+
+describe('moveTicketOrg — ai_agent_runs.ticket_id detach (#4524)', () => {
+  it('nulls ticket_id on every run pointing at the moved ticket, leaves the run in the source org, and spares runs on other tickets', async () => {
+    const { orgA, orgB, partner, actor, ticket, device } = await seedMoveOrgFixture();
+    const agent = await seedTriageAgent(orgA.id, partner.id);
+    const sibling = await seedSiblingTicket(orgA.id, partner.id);
+
+    // Device-LESS ticket run: the canonical trigger_kind='ticket' shape.
+    const ticketRun = await seedRunOnTicket(orgA.id, agent.id, ticket.id, null);
+    // Same ticket, but the run also names the device — proves the detach is
+    // keyed on ticket_id, not narrowed to device-less rows.
+    const deviceTicketRun = await seedRunOnTicket(orgA.id, agent.id, ticket.id, device.id);
+    // Control: a run on a DIFFERENT ticket that never leaves orgA. Rejects a
+    // blanket "null every ticket_id in the org".
+    const siblingRun = await seedRunOnTicket(orgA.id, agent.id, sibling.id, null);
+
+    // Fixture guard: the pointers exist before the move, so a post-move NULL
+    // is the detach and not an insert that never landed.
+    expect((await readRun(ticketRun.id))?.ticketId).toBe(ticket.id);
+    expect((await readRun(deviceTicketRun.id))?.ticketId).toBe(ticket.id);
+    expect((await readRun(siblingRun.id))?.ticketId).toBe(sibling.id);
+
+    await withSystemDbAccessContext(() => moveTicketOrg(ticket.id, orgB.id, actor));
+
+    expect((await readTicket(ticket.id))?.orgId).toBe(orgB.id);
+
+    // Both runs on the departed ticket are severed, and both STAY in the
+    // source org (org_id is trigger-immutable; run history never follows a
+    // move — owner decision 2026-08-23).
+    const movedRunA = await readRun(ticketRun.id);
+    expect(movedRunA?.ticketId).toBeNull();
+    expect(movedRunA?.orgId).toBe(orgA.id);
+    const movedRunB = await readRun(deviceTicketRun.id);
+    expect(movedRunB?.ticketId).toBeNull();
+    expect(movedRunB?.orgId).toBe(orgA.id);
+
+    // The sibling ticket never moved, so its run keeps its pointer.
+    const untouched = await readRun(siblingRun.id);
+    expect(untouched?.ticketId).toBe(sibling.id);
+    expect((await readTicket(sibling.id))?.orgId).toBe(orgA.id);
+  });
+
+  it('severs the pointer under a REAL partner-scoped RLS context, not just system scope', async () => {
+    // The route runs under withDbAccessContext, never withSystemDbAccessContext.
+    // ai_agent_runs is FORCE ROW LEVEL SECURITY with a breeze_has_org_access
+    // policy, so a detach that only works for `breeze.scope=system` would be a
+    // silent zero-row no-op on the one path that actually matters. Every other
+    // case in this file uses system scope, which cannot catch that.
+    const { orgA, orgB, partner, actor, ticket } = await seedMoveOrgFixture();
+    const agent = await seedTriageAgent(orgA.id, partner.id);
+    const run = await seedRunOnTicket(orgA.id, agent.id, ticket.id, null);
+
+    const partnerCtx: DbAccessContext = {
+      scope: 'partner',
+      orgId: null,
+      accessibleOrgIds: [orgA.id, orgB.id],
+      accessiblePartnerIds: [partner.id],
+      userId: actor.userId,
+    };
+    await withDbAccessContext(partnerCtx, () => moveTicketOrg(ticket.id, orgB.id, actor));
+
+    expect((await readTicket(ticket.id))?.orgId).toBe(orgB.id);
+    const after = await readRun(run.id);
+    expect(after?.ticketId).toBeNull();
+    expect(after?.orgId).toBe(orgA.id);
+  });
+
+  it('nulls the reverse pointer ticket_comments.agent_run_id on comments that travel with the ticket', async () => {
+    // ticket_comments has no org_id (child-via-parent tenancy), so every
+    // comment follows the ticket into the target org while the run it names
+    // stays behind — the same reverse-pointer class #3828 fixed for
+    // metric_anomaly_incidents.agent_run_id on the device axis.
+    const { orgA, orgB, partner, actor, ticket } = await seedMoveOrgFixture();
+    const agent = await seedTriageAgent(orgA.id, partner.id);
+    const run = await seedRunOnTicket(orgA.id, agent.id, ticket.id, null);
+    const adminDb = getTestDb() as any;
+
+    const [aiComment] = await adminDb
+      .insert(ticketComments)
+      .values({
+        ticketId: ticket.id,
+        authorType: 'internal',
+        commentType: 'comment',
+        content: 'Proposed next step from triage.',
+        isPublic: false,
+        originPrincipalKind: 'ai_agent',
+        agentRunId: run.id,
+      })
+      .returning();
+    expect(aiComment.agentRunId).toBe(run.id);
+
+    await withSystemDbAccessContext(() => moveTicketOrg(ticket.id, orgB.id, actor));
+
+    const after = await readComment(aiComment.id);
+    expect(after?.agentRunId).toBeNull();
+    // Only the cross-org link is dropped. The comment itself, its content and
+    // its non-user provenance (which is what the helpdesk loop guard actually
+    // keys on) all survive the move.
+    expect(after?.ticketId).toBe(ticket.id);
+    expect(after?.content).toBe('Proposed next step from triage.');
+    expect(after?.originPrincipalKind).toBe('ai_agent');
+  });
+});

--- a/apps/api/src/services/orgMergeRegistry.ts
+++ b/apps/api/src/services/orgMergeRegistry.ts
@@ -664,6 +664,20 @@ const REPOINT_TABLES: readonly string[] = [
   "ticket_forms",
   "ticket_outbox",
   "ticket_parts",
+  // #4524: a merge repoints tickets.org_id by direct SQL, so it changes a
+  // ticket's org WITHOUT going through moveTicketOrg — which is where the
+  // ai_agent_runs.ticket_id / ticket_comments.agent_run_id detach lives, and
+  // there is no `UPDATE OF org_id ON tickets` trigger to back it up (the device
+  // axis has breeze_cascade_device_org_id(); the ticket axis has nothing).
+  // That is deliberate and safe HERE, unlike a cross-org ticket move: Phase A
+  // fences the loser to status='merging' BEFORE this repoint runs, which drops
+  // it out of accessibleOrgIds and every ingress gate, so no token can read a
+  // loser-org run at all; and ai_agent_runs is `leave-for-erasure` above, so
+  // those rows are destroyed with the loser shell in Phase C rather than
+  // outliving it. Its ticket_id is also a plain single-column FK, so — unlike
+  // ticket_drafts above — it can never 23503 the repoint. No custom executor
+  // needed. If either premise ever changes (the loser stays readable, or
+  // ai_agent_runs starts repointing), this entry needs one.
   "tickets",
   "time_entries",
   "time_series_metrics",

--- a/apps/api/src/services/ticketService.test.ts
+++ b/apps/api/src/services/ticketService.test.ts
@@ -211,7 +211,11 @@ vi.mock('../db/schema', () => ({
     requesterContactId: 'requesterContactId',
     deletedAt: 'deletedAt'
   },
-  ticketComments: {},
+  // #4524: moveTicketOrg nulls the reverse pointer ticket_comments.agent_run_id,
+  // so these two columns must exist on the mock or the WHERE builds on undefined.
+  ticketComments: { ticketId: 'ticketId', agentRunId: 'agentRunId' },
+  // #4524: moveTicketOrg severs ai_agent_runs.ticket_id in the same transaction.
+  aiAgentRuns: { id: 'id', orgId: 'orgId', ticketId: 'ticketId' },
   ticketDrafts: {
     id: 'id', ticketId: 'ticketId', orgId: 'orgId', runId: 'runId', intentId: 'intentId',
     kind: 'kind', content: 'content', state: 'state', supersededBy: 'supersededBy',

--- a/apps/api/src/services/ticketService.ts
+++ b/apps/api/src/services/ticketService.ts
@@ -1,8 +1,8 @@
-import { and, asc, desc, eq, gt, inArray, isNull, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, gt, inArray, isNotNull, isNull, sql } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { matchContactByEmail } from './contacts/crud';
-import { tickets, ticketComments, ticketAlertLinks, organizations, alerts, devices, users, ticketCategories, portalUsers, contacts, ticketStatusEnum, ticketSourceEnum, ticketOutbox, ticketDrafts, actionIntents, type TicketOutboxEvent } from '../db/schema';
+import { tickets, ticketComments, ticketAlertLinks, organizations, alerts, devices, users, ticketCategories, portalUsers, contacts, ticketStatusEnum, ticketSourceEnum, ticketOutbox, ticketDrafts, actionIntents, aiAgentRuns, type TicketOutboxEvent } from '../db/schema';
 import { allocateInternalTicketNumber } from './ticketNumbers';
 import { emitTicketEvent } from './ticketEvents';
 import { createAuditLogAsync } from './auditService';
@@ -2156,6 +2156,13 @@ export async function restoreTicket(ticketId: string, actor: TicketActor): Promi
 // ticket-linked child tables in the same relative order; see the lock-order
 // comment at moveOrg.ts:~311. S3 objects are keyed by attachment id only
 // (spec D8) and are NOT touched by a move.
+// ticket_email_links is NOT here, and that is a known gap rather than a ruling:
+// it denormalizes org_id from its ticket (shape 1, FORCE RLS) yet is absent
+// from both this list and the device path's CUSTOM_ORG_REWRITE_TABLES, so a
+// moved ticket strands its link rows on the source org on BOTH axes. Left out
+// of the #4524 fix deliberately — closing it correctly spans this service and
+// routes/devices/moveOrg.ts and turns on the inbound-email tenancy model, so it
+// is tracked as its own issue rather than half-fixed on one axis here.
 const TICKET_ORG_DENORMALIZED_TABLES = ['time_entries', 'ticket_parts', 'ticket_alert_links', 'ticket_outbox', 'ticket_attachments'] as const;
 
 /**
@@ -2279,6 +2286,70 @@ export async function moveTicketOrg(
       .where(eq(tickets.id, ticketId))
       .returning();
     updated = row;
+    // #4524 — sever the ai_agent_runs <-> ticket pointer pair, BOTH directions.
+    //
+    // Agent-run history stays with the SOURCE org (owner decision 2026-08-23):
+    // ai_agent_runs.org_id is trigger-immutable (ai_agent_runs_immutable_guard,
+    // 2026-09-06-a) and the table is deliberately absent from
+    // TICKET_ORG_DENORMALIZED_TABLES above. So a run that triggered on this
+    // ticket keeps org_id = SOURCE while the ticket it names has just become
+    // the TARGET org's — a cross-tenant pointer, and /ai-agents/:id/runs would
+    // serve that now-foreign ticket id back to the source org.
+    //
+    // Unlike ticket_drafts and action_intents above, nothing forces the issue:
+    // ai_agent_runs.ticket_id is a PLAIN single-column FK to tickets(id) with
+    // ON DELETE SET NULL (aiAgents.ts), not a composite (ticket_id, org_id)
+    // tenant FK, so the ticket UPDATE above completes happily and the stale
+    // pointer survives silently. That is exactly why this detach may sit AFTER
+    // the UPDATE while those two must precede it.
+    //
+    // Ordering: it must still run BEFORE assertTicketMoveCurrencyCompatible
+    // below, which takes row locks on time_entries / ticket_parts. The
+    // device-move path (routes/devices/moveOrg.ts, and the
+    // breeze_cascade_device_org_id() trigger) locks ai_agent_runs immediately
+    // after the parent row flip and before any ticket-child table, so taking
+    // these two locks in the opposite order here would give a concurrent
+    // ticket-move and device-move an inverted lock pair — the deadlock shape
+    // the global lock-order comment at the top of this transaction exists to
+    // prevent.
+    //
+    // This is the ticket-axis twin of the device-axis statement added by #4215.
+    // There is no Postgres trigger on `UPDATE OF org_id ON tickets` (the device
+    // axis has breeze_cascade_device_org_id(); the ticket axis has no
+    // equivalent), so this service is the ONLY place the contract is enforced —
+    // see the note added beside orgMergeRegistry's `tickets` entry for why the
+    // org-merge path needs no equivalent.
+    await tx
+      .update(aiAgentRuns)
+      .set({ ticketId: null })
+      .where(eq(aiAgentRuns.ticketId, ticketId));
+    // Reverse direction: ticket_comments has no org_id (child-via-parent
+    // tenancy — see the TICKET_ORG_DENORMALIZED_TABLES comment above), so every
+    // comment on this ticket travels into the target org while the run that
+    // authored it stays behind. A retained agent_run_id would then name a
+    // source-org run from a target-org row — the same reverse-pointer class
+    // #3828 fixed for metric_anomaly_incidents.agent_run_id on the device axis,
+    // just the other end of this ticket's link.
+    //
+    // Only the cross-org link is dropped: origin_principal_kind is untouched,
+    // and that (not agent_run_id) is what the helpdesk loop guard keys on when
+    // it refuses to re-admit non-user content, so severing here cannot open a
+    // feedback loop. Nulling also drops the row out of the partial unique index
+    // ticket_comments_one_ai_note_per_run_uq, whose predicate requires
+    // agent_run_id IS NOT NULL, so it can never collide.
+    //
+    // Scope note: the DEVICE axis has this same reverse-pointer gap — a device
+    // org-move re-stamps its tickets (tickets is in
+    // breeze_device_child_orgid_tables()) and their comments travel along while
+    // the runs stay put — and it is NOT closed here, because closing it means a
+    // new migration replacing breeze_cascade_device_org_id(). Neither axis leaks
+    // today: nothing writes agent_run_id yet (the autonomous-note lane is
+    // deferred; see the column comment in db/schema/portal.ts). Tracked
+    // separately so the contract is in place before that lane ships.
+    await tx
+      .update(ticketComments)
+      .set({ agentRunId: null })
+      .where(and(eq(ticketComments.ticketId, ticketId), isNotNull(ticketComments.agentRunId)));
     guard = await assertTicketMoveCurrencyCompatible(tx, {
       ticketIds: [ticketId],
       sourceCurrency: sourceOrg.currencyCode,

--- a/apps/api/src/services/ticketService.ts
+++ b/apps/api/src/services/ticketService.ts
@@ -2162,7 +2162,7 @@ export async function restoreTicket(ticketId: string, actor: TicketActor): Promi
 // moved ticket strands its link rows on the source org on BOTH axes. Left out
 // of the #4524 fix deliberately — closing it correctly spans this service and
 // routes/devices/moveOrg.ts and turns on the inbound-email tenancy model, so it
-// is tracked as its own issue rather than half-fixed on one axis here.
+// is tracked in #4643 rather than half-fixed on one axis here.
 const TICKET_ORG_DENORMALIZED_TABLES = ['time_entries', 'ticket_parts', 'ticket_alert_links', 'ticket_outbox', 'ticket_attachments'] as const;
 
 /**
@@ -2212,7 +2212,7 @@ export async function moveTicketOrg(
     // select disjoint rows. That argument does NOT cover ticket_alert_links,
     // which both axes can reach for the same row in opposite order relative to
     // time_entries/ticket_parts — a pre-existing instance of the same deadlock
-    // class, tracked separately rather than reordered here.
+    // class, tracked in #4657 rather than reordered here.
     //
     // The org lock is the FIRST statement of this transaction and is held to
     // commit, so the source/target currency pair the guard compares cannot be
@@ -2369,8 +2369,8 @@ export async function moveTicketOrg(
     // the runs stay put — and it is NOT closed here, because closing it means a
     // new migration replacing breeze_cascade_device_org_id(). Neither axis leaks
     // today: nothing writes agent_run_id yet (the autonomous-note lane is
-    // deferred; see the column comment in db/schema/portal.ts). Tracked
-    // separately so the contract is in place before that lane ships.
+    // deferred; see the column comment in db/schema/portal.ts). Tracked in #4644
+    // so the contract is in place before that lane ships.
     await tx
       .update(ticketComments)
       .set({ agentRunId: null })

--- a/apps/api/src/services/ticketService.ts
+++ b/apps/api/src/services/ticketService.ts
@@ -2196,9 +2196,15 @@ export async function moveTicketOrg(
   await db.transaction(async (tx) => {
     // Lock order (global, #3778): organizations FOR SHARE (BOTH orgs, ascending
     // UUID so two concurrent moves between the same pair cannot deadlock) →
-    // tickets → time_entries → ticket_parts. The org lock is the FIRST statement
-    // of this transaction and is held to commit, so the source/target currency
-    // pair the guard compares cannot be restamped mid-move.
+    // ai_agent_runs → tickets → time_entries → ticket_parts. ai_agent_runs sits
+    // ahead of tickets (#4524) to match breeze_cascade_device_org_id(), which
+    // severs runs before re-stamping its child tables — `tickets` among them;
+    // the two paths must agree on that pair or a concurrent device-move and
+    // ticket-move over the same device-linked ticket deadlocks.
+    //
+    // The org lock is the FIRST statement of this transaction and is held to
+    // commit, so the source/target currency pair the guard compares cannot be
+    // restamped mid-move.
     const lockedOrgs = await readOrgStampingDefaultsMany(tx, [ticket.orgId, targetOrgId]);
     const orgRows = await tx
       .select({ id: organizations.id, partnerId: organizations.partnerId, name: organizations.name })
@@ -2266,6 +2272,42 @@ export async function moveTicketOrg(
     // move is the same accepted ruling used by the org-merge custom
     // executor for the same run-pinning conflict.
     await tx.delete(ticketDrafts).where(eq(ticketDrafts.ticketId, ticketId));
+    // #4524 — sever ai_agent_runs.ticket_id. Agent-run history stays with the
+    // SOURCE org (owner decision 2026-08-23): ai_agent_runs.org_id is
+    // trigger-immutable (ai_agent_runs_immutable_guard, 2026-09-06-a) and the
+    // table is deliberately absent from TICKET_ORG_DENORMALIZED_TABLES below.
+    // So a run that triggered on this ticket keeps org_id = SOURCE while the
+    // ticket it names becomes the TARGET org's — a cross-tenant pointer, and
+    // /ai-agents/:id/runs would serve that now-foreign ticket id back to the
+    // source org. This is the ticket-axis twin of the device-axis statement
+    // added by #4215.
+    //
+    // Nothing forces the issue the way it does for the two statements above:
+    // ai_agent_runs.ticket_id is a PLAIN single-column FK to tickets(id) with
+    // ON DELETE SET NULL (aiAgents.ts), not a composite (ticket_id, org_id)
+    // tenant FK, so the ticket UPDATE below would complete happily and the
+    // stale pointer would survive in silence. There is also no Postgres trigger
+    // on `UPDATE OF org_id ON tickets` (the device axis has
+    // breeze_cascade_device_org_id(); the ticket axis has no equivalent), so
+    // this service is the ONLY place the contract is enforced — see the note
+    // beside orgMergeRegistry's `tickets` entry for why the merge path is safe
+    // without one.
+    //
+    // Ordering — this must run BEFORE the tickets UPDATE, and that is a lock
+    // requirement, not a correctness one (the WHERE never reads `tickets`, and
+    // the plain FK cannot 23503 either way). breeze_cascade_device_org_id()
+    // severs ai_agent_runs FIRST and only then re-stamps its child tables, of
+    // which `tickets` is one, so the device axis takes ai_agent_runs BEFORE
+    // tickets. Taking them the other way round here would give a concurrent
+    // device-move and ticket-move over the same device-linked ticket a circular
+    // wait (each holding the lock the other needs) and one of them would die
+    // with 40P01. Matching the device axis's order is what keeps the pair
+    // consistent — see the global lock-order note at the top of this
+    // transaction.
+    await tx
+      .update(aiAgentRuns)
+      .set({ ticketId: null })
+      .where(eq(aiAgentRuns.ticketId, ticketId));
     // The UPDATE takes the ticket row lock; the currency guard then locks the
     // unbilled monetary children, and the org_id rewrites follow. A throw here
     // rolls this UPDATE back — nothing moves on a block.
@@ -2286,50 +2328,19 @@ export async function moveTicketOrg(
       .where(eq(tickets.id, ticketId))
       .returning();
     updated = row;
-    // #4524 — sever the ai_agent_runs <-> ticket pointer pair, BOTH directions.
-    //
-    // Agent-run history stays with the SOURCE org (owner decision 2026-08-23):
-    // ai_agent_runs.org_id is trigger-immutable (ai_agent_runs_immutable_guard,
-    // 2026-09-06-a) and the table is deliberately absent from
-    // TICKET_ORG_DENORMALIZED_TABLES above. So a run that triggered on this
-    // ticket keeps org_id = SOURCE while the ticket it names has just become
-    // the TARGET org's — a cross-tenant pointer, and /ai-agents/:id/runs would
-    // serve that now-foreign ticket id back to the source org.
-    //
-    // Unlike ticket_drafts and action_intents above, nothing forces the issue:
-    // ai_agent_runs.ticket_id is a PLAIN single-column FK to tickets(id) with
-    // ON DELETE SET NULL (aiAgents.ts), not a composite (ticket_id, org_id)
-    // tenant FK, so the ticket UPDATE above completes happily and the stale
-    // pointer survives silently. That is exactly why this detach may sit AFTER
-    // the UPDATE while those two must precede it.
-    //
-    // Ordering: it must still run BEFORE assertTicketMoveCurrencyCompatible
-    // below, which takes row locks on time_entries / ticket_parts. The
-    // device-move path (routes/devices/moveOrg.ts, and the
-    // breeze_cascade_device_org_id() trigger) locks ai_agent_runs immediately
-    // after the parent row flip and before any ticket-child table, so taking
-    // these two locks in the opposite order here would give a concurrent
-    // ticket-move and device-move an inverted lock pair — the deadlock shape
-    // the global lock-order comment at the top of this transaction exists to
-    // prevent.
-    //
-    // This is the ticket-axis twin of the device-axis statement added by #4215.
-    // There is no Postgres trigger on `UPDATE OF org_id ON tickets` (the device
-    // axis has breeze_cascade_device_org_id(); the ticket axis has no
-    // equivalent), so this service is the ONLY place the contract is enforced —
-    // see the note added beside orgMergeRegistry's `tickets` entry for why the
-    // org-merge path needs no equivalent.
-    await tx
-      .update(aiAgentRuns)
-      .set({ ticketId: null })
-      .where(eq(aiAgentRuns.ticketId, ticketId));
-    // Reverse direction: ticket_comments has no org_id (child-via-parent
+    // #4524, reverse direction: ticket_comments has no org_id (child-via-parent
     // tenancy — see the TICKET_ORG_DENORMALIZED_TABLES comment above), so every
     // comment on this ticket travels into the target org while the run that
     // authored it stays behind. A retained agent_run_id would then name a
     // source-org run from a target-org row — the same reverse-pointer class
     // #3828 fixed for metric_anomaly_incidents.agent_run_id on the device axis,
     // just the other end of this ticket's link.
+    //
+    // This one stays AFTER the ticket UPDATE, unlike the ai_agent_runs detach
+    // above: ticket_comments' UPDATE policy (breeze_ticket_parent_update)
+    // EXISTS-joins the parent ticket's CURRENT org_id, so it is the target org
+    // that has to be accessible here. No lock-order concern either way — the
+    // device axis never touches ticket_comments.
     //
     // Only the cross-org link is dropped: origin_principal_kind is untouched,
     // and that (not agent_run_id) is what the helpdesk loop guard keys on when

--- a/apps/api/src/services/ticketService.ts
+++ b/apps/api/src/services/ticketService.ts
@@ -2196,11 +2196,23 @@ export async function moveTicketOrg(
   await db.transaction(async (tx) => {
     // Lock order (global, #3778): organizations FOR SHARE (BOTH orgs, ascending
     // UUID so two concurrent moves between the same pair cannot deadlock) →
-    // ai_agent_runs → tickets → time_entries → ticket_parts. ai_agent_runs sits
-    // ahead of tickets (#4524) to match breeze_cascade_device_org_id(), which
-    // severs runs before re-stamping its child tables — `tickets` among them;
-    // the two paths must agree on that pair or a concurrent device-move and
-    // ticket-move over the same device-linked ticket deadlocks.
+    // action_intents → ticket_drafts → ai_agent_runs → tickets → ticket_comments
+    // → the TICKET_ORG_DENORMALIZED_TABLES loop (time_entries, ticket_parts,
+    // ticket_alert_links, ticket_outbox, ticket_attachments).
+    //
+    // ai_agent_runs sits ahead of tickets (#4524) to match
+    // breeze_cascade_device_org_id(), which severs runs before re-stamping its
+    // child tables — `tickets` among them; the two paths must agree on that pair
+    // or a concurrent device-move and ticket-move over the same device-linked
+    // ticket deadlocks. action_intents is ordered the other way round from the
+    // device axis, which is safe only because the two can never contend for a
+    // row: action_intents_scope_device_chk / _scope_ticket_chk make
+    // scope_device_id and scope_ticket_id mutually exclusive, so the device
+    // axis's `WHERE scope_device_id = D` and this path's `WHERE scope_ticket_id`
+    // select disjoint rows. That argument does NOT cover ticket_alert_links,
+    // which both axes can reach for the same row in opposite order relative to
+    // time_entries/ticket_parts — a pre-existing instance of the same deadlock
+    // class, tracked separately rather than reordered here.
     //
     // The org lock is the FIRST statement of this transaction and is held to
     // commit, so the source/target currency pair the guard compares cannot be
@@ -2336,11 +2348,13 @@ export async function moveTicketOrg(
     // #3828 fixed for metric_anomaly_incidents.agent_run_id on the device axis,
     // just the other end of this ticket's link.
     //
-    // This one stays AFTER the ticket UPDATE, unlike the ai_agent_runs detach
-    // above: ticket_comments' UPDATE policy (breeze_ticket_parent_update)
-    // EXISTS-joins the parent ticket's CURRENT org_id, so it is the target org
-    // that has to be accessible here. No lock-order concern either way — the
-    // device axis never touches ticket_comments.
+    // Placement: after the ticket UPDATE, where ticket_comments' UPDATE policy
+    // (breeze_ticket_parent_update) EXISTS-joins the parent ticket's now-TARGET
+    // org_id. Running it earlier would also work — every caller holds access to
+    // both orgs for the whole transaction, so the source-org join would pass
+    // too — so this is placement for readability, not a constraint. There is no
+    // lock-order concern either way: the device axis never touches
+    // ticket_comments.
     //
     // Only the cross-org link is dropped: origin_principal_kind is untouched,
     // and that (not agent_run_id) is what the helpdesk loop guard keys on when


### PR DESCRIPTION
Closes #4524

## The gap

`moveTicketOrg` (`apps/api/src/services/ticketService.ts`) moves a ticket between two organizations of the same partner. Agent-run history deliberately **stays with the SOURCE org** (owner decision 2026-08-23 — `ai_agent_runs.org_id` is trigger-immutable via `ai_agent_runs_immutable_guard`, and the table is intentionally absent from `TICKET_ORG_DENORMALIZED_TABLES`). But nothing severed `ai_agent_runs.ticket_id`, so after a move a source-org run kept pointing at a ticket the **target** org now owns, and `/ai-agents/:id/runs` would serve that foreign ticket id back to the source org.

**Why it never announced itself:** `ticket_drafts` and `action_intents` in the same function carry composite `(x, org_id) -> tickets(id, org_id)` tenant FKs and raise 23503 on a cross-org pointer — which is why they already have tombstone/delete statements. `ai_agent_runs.ticket_id` is a **plain single-column FK** with `ON DELETE SET NULL`, so the ticket UPDATE completed happily and the stale pointer survived in silence.

This is the ticket-axis twin of the device-axis detach shipped in #4215 / #4436. There is **no** Postgres trigger on `UPDATE OF org_id ON tickets` — the device axis has `breeze_cascade_device_org_id()`, the ticket axis has no equivalent — so this service is the only place the contract can be enforced.

## Changes

- **`moveTicketOrg` nulls `ai_agent_runs.ticket_id`** for the moved ticket, inside the same transaction. Placed after the ticket UPDATE but **before** `assertTicketMoveCurrencyCompatible`: that guard takes row locks on `time_entries`/`ticket_parts`, and the device-move path locks `ai_agent_runs` immediately after the parent row flip and before any ticket-child table — so the reverse order would give a concurrent ticket-move and device-move an inverted lock pair, the exact deadlock shape the function's global lock-order comment exists to prevent.
- **Also nulls the reverse pointer `ticket_comments.agent_run_id`.** `ticket_comments` has no `org_id` (child-via-parent tenancy), so every comment travels into the target org while the run that authored it stays behind — the same reverse-pointer class #3828 fixed for `metric_anomaly_incidents.agent_run_id` on the device axis, just the other end of this ticket's link. `origin_principal_kind` is untouched, and that (not `agent_run_id`) is what the helpdesk loop guard keys on, so severing cannot open a feedback loop.
- **Note beside `orgMergeRegistry`'s `tickets` entry** (as the issue asked) recording why the merge path needs no equivalent: a merge repoints `tickets.org_id` by direct SQL without going through `moveTicketOrg`, but Phase A fences the loser org to `status='merging'` **before** the repoint runs — dropping it out of `accessibleOrgIds` and every ingress gate — and `ai_agent_runs` is `leave-for-erasure`, so those rows are unreachable and then destroyed with the loser shell rather than outliving it. `ticket_id` being a plain FK also means it can never 23503 the repoint the way `ticket_drafts` does.

No migration: this is service logic only, and the schema is unchanged.

## Tests

Three real-Postgres cases in `apps/api/src/__tests__/integration/ticket-move-org.integration.test.ts`:

1. **Detach + controls** — nulls `ticket_id` on a device-less `trigger_kind='ticket'` run *and* on a run that names both the ticket and a device (rejects a `WHERE device_id IS NULL` narrowing), asserts both runs stay in the source org, and keeps a run on a **sibling ticket that never moved** intact (rejects a blanket "null every ticket_id").
2. **Real RLS context** — drives the move under a genuine partner-scoped `withDbAccessContext`, not `withSystemDbAccessContext`. `ai_agent_runs` is `FORCE ROW LEVEL SECURITY` with a `breeze_has_org_access(org_id)` policy, so a detach that only worked under `breeze.scope=system` would be a silent zero-row no-op on the one path that actually runs in production. Every other case in that file uses system scope and could not catch it.
3. **Reverse pointer** — an AI-authored comment's `agent_run_id` is nulled while its `ticket_id`, content and `origin_principal_kind` survive.

All three were confirmed **red before the fix** (`expected '<uuid>' to be null`) and green after.

### Verification

| Check | Result |
|---|---|
| `ticket-move-org.integration.test.ts` | 14 passed (11 pre-existing + 3 new) |
| `ticketAttachmentsRls` + `orgCurrencyCreationBarrier` + `agentRunMoveSemantics` integration | 29 passed |
| Unit: `ticketService`, `tickets/moveOrg`, `devices/moveOrg.coverage`, `aiToolsTicketing` ×2, `orgMerge` ×3, `ticketService.aiExecutors` | 349 passed |
| `tsc --noEmit` (apps/api) | clean |
| `eslint` on changed files | clean |

`ticketService.test.ts`'s `../db/schema` mock gained `aiAgentRuns` and the two `ticketComments` columns — without them the new statements threw `No "aiAgentRuns" export is defined on the mock`, which is incidentally a nice proof that the mocked path actually reaches them.

## Adjacent gaps found by the sweep (filed separately, not fixed here)

Sweeping every pointer between `tickets` and `ai_agent_runs` turned up three more stale-cross-org-state defects. Each spans **both** move axes (ticket and device) or a different subsystem, so fixing one axis here would reproduce exactly the asymmetry that created this issue:

- **#4643** — `ticket_email_links.org_id` is never re-stamped on a ticket move (absent from both `TICKET_ORG_DENORMALIZED_TABLES` and the device path's `CUSTOM_ORG_REWRITE_TABLES`). Live today. A `NOT`-here comment now marks it as a tracked gap rather than a ruling.
- **#4644** — `ticket_comments.agent_run_id` has the same reverse-pointer gap on the **device** axis; closing it means a new migration replacing `breeze_cascade_device_org_id()`. Nothing writes the column yet, so neither axis leaks today.
- **#4645** — `device_vulnerabilities.ticket_id` keeps naming a departed ticket. Consequence today is a dead link under RLS, and nulling it would discard a remediation linkage — a product call, not a mechanical one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
