### PR TITLE
fix(api/auth): a rejected MFA proof is 400 + a stable code, not 401 (#4470)

### DIFF
--- a/apps/api/src/__tests__/integration/recoveryCode.integration.test.ts
+++ b/apps/api/src/__tests__/integration/recoveryCode.integration.test.ts
@@ -101,7 +101,7 @@ describe('POST /auth/mfa/verify (method: recovery) — real-PG single-use concur
     tempTokens.length = 0;
   });
 
-  it('identical-code race: exactly one 200, one 401, persisted array has exactly 2 hashes (no double-spend)', async () => {
+  it('identical-code race: exactly one 200, one 400, persisted array has exactly 2 hashes (no double-spend)', async () => {
     const userId = await seedUserWithRecoveryCodes();
     const { getRedis } = await import('../../services');
     const redis = getRedis();
@@ -118,8 +118,12 @@ describe('POST /auth/mfa/verify (method: recovery) — real-PG single-use concur
 
     const [r1, r2] = await Promise.all([verify(app, tokenX, CODE_A), verify(app, tokenY, CODE_A)]);
 
+    // #4470: the loser's rejection is a REJECTED PROOF (its code is gone), so
+    // it answers 400 `mfa_code_invalid` — not the bearer guard's 401.
     const statuses = [r1.status, r2.status].sort((a, b) => a - b);
-    expect(statuses).toEqual([200, 401]);
+    expect(statuses).toEqual([200, 400]);
+    const loser = r1.status === 400 ? r1 : r2;
+    expect(await loser.json()).toMatchObject({ code: 'mfa_code_invalid' });
 
     const remaining = await readRecoveryCodes(userId);
     expect(remaining).toHaveLength(2);

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -1044,6 +1044,10 @@ API requests are rate-limited to ensure fair usage. Rate limit headers are inclu
               }
             }
           },
+          // #4470: a rejected proof (wrong code) is 400 with a stable `code`
+          // (`mfa_code_invalid`); 401 is reserved for a dead credential —
+          // an invalid/expired tempToken or bearer.
+          '400': { $ref: '#/components/responses/BadRequest' },
           '401': { $ref: '#/components/responses/Unauthorized' },
           '429': { $ref: '#/components/responses/TooManyRequests' }
         }
@@ -1356,6 +1360,10 @@ API requests are rate-limited to ensure fair usage. Rate limit headers are inclu
               }
             }
           },
+          // #4470: a rejected proof (wrong code) is 400 with a stable `code`
+          // (`mfa_code_invalid`); 401 is reserved for a dead credential —
+          // an invalid/expired tempToken or bearer.
+          '400': { $ref: '#/components/responses/BadRequest' },
           '401': { $ref: '#/components/responses/Unauthorized' },
           '429': { $ref: '#/components/responses/TooManyRequests' }
         }
@@ -1451,6 +1459,10 @@ API requests are rate-limited to ensure fair usage. Rate limit headers are inclu
               }
             }
           },
+          // #4470: a rejected proof (wrong code) is 400 with a stable `code`
+          // (`mfa_code_invalid`); 401 is reserved for a dead credential —
+          // an invalid/expired tempToken or bearer.
+          '400': { $ref: '#/components/responses/BadRequest' },
           '401': { $ref: '#/components/responses/Unauthorized' },
           '429': { $ref: '#/components/responses/TooManyRequests' }
         }

--- a/apps/api/src/routes/auth.passkeys.test.ts
+++ b/apps/api/src/routes/auth.passkeys.test.ts
@@ -561,7 +561,37 @@ describe('passkey MFA auth routes', () => {
       body: JSON.stringify({ currentPassword: 'wrong-password' }),
     });
 
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(400);
+    expect(passkeyMocks.generatePasskeyRegistrationOptions).not.toHaveBeenCalled();
+  });
+
+  // #4470: the two statuses above are the whole point, so pin them apart.
+  // `ProfilePage.handleAddPasskey` calls this endpoint through `fetchWithAuth`
+  // with no 401 opt-out, so while a wrong step-up password answered 401 it was
+  // fed to refresh-and-replay and could sign the user out of the settings page
+  // for a typo. A MISSING bearer must still be the 401 that refreshes.
+  it('#4470: a wrong step-up password is 400 invalid_credentials, a missing bearer is still 401', async () => {
+    vi.mocked(verifyPassword).mockResolvedValueOnce(false);
+    dbState.selectQueue.push([{ passwordHash: '$argon2id$hash' }]);
+
+    const rejected = await app.request('/auth/passkeys/register/options', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer access-token' },
+      body: JSON.stringify({ currentPassword: 'wrong-password' }),
+    });
+    expect(rejected.status).toBe(400);
+    expect(await rejected.json()).toEqual({
+      error: 'Invalid credentials',
+      message: 'Invalid credentials',
+      code: 'invalid_credentials',
+    });
+
+    const noBearer = await app.request('/auth/passkeys/register/options', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ currentPassword: 'correct-password' }),
+    });
+    expect(noBearer.status).toBe(401);
     expect(passkeyMocks.generatePasskeyRegistrationOptions).not.toHaveBeenCalled();
   });
 
@@ -682,7 +712,7 @@ describe('passkey MFA auth routes', () => {
       expect(passkeyMocks.generatePasskeyRegistrationOptions).toHaveBeenCalled();
     });
 
-    it('register/options returns the opaque 401 for a passwordless account with an invalid/expired grant', async () => {
+    it('register/options returns the opaque 400 for a passwordless account with an invalid/expired grant', async () => {
       dbState.selectQueue.push([{ passwordHash: null }]); // resolveEnrollmentStepUp probe
       dbState.selectQueue.push([{ mfaEnabled: false, passkeyCount: 0 }]); // resolveEnrollmentStepUp's userIsMfaProtected
       vi.mocked(validateStepUpGrant).mockResolvedValueOnce(false);
@@ -693,7 +723,7 @@ describe('passkey MFA auth routes', () => {
         body: JSON.stringify({ ssoReauthGrantId: '11111111-1111-4111-8111-111111111111' }),
       });
 
-      expect(res.status).toBe(401);
+      expect(res.status).toBe(400);
       expect(await res.json()).toEqual({
         error: 'Invalid credentials',
         message: 'Invalid credentials',
@@ -725,7 +755,7 @@ describe('passkey MFA auth routes', () => {
       );
     });
 
-    it('register/verify returns the opaque 401 for a passwordless account with an invalid/expired grant (no passkey written)', async () => {
+    it('register/verify returns the opaque 400 for a passwordless account with an invalid/expired grant (no passkey written)', async () => {
       dbState.selectQueue.push([{ mfaEnabled: false, passkeyCount: 0 }]); // enforceExistingFactorStepUp's userIsMfaProtected
       dbState.selectQueue.push([{ passwordHash: null }]); // resolveEnrollmentStepUp probe
       dbState.selectQueue.push([{ mfaEnabled: false, passkeyCount: 0 }]); // resolveEnrollmentStepUp's userIsMfaProtected
@@ -740,7 +770,7 @@ describe('passkey MFA auth routes', () => {
         }),
       });
 
-      expect(res.status).toBe(401);
+      expect(res.status).toBe(400);
       expect(await res.json()).toEqual({
         error: 'Invalid credentials',
         message: 'Invalid credentials',
@@ -762,7 +792,7 @@ describe('passkey MFA auth routes', () => {
       }),
     });
 
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(400);
     expect(await res.json()).toMatchObject({ error: expect.stringMatching(/challenge|expired|invalid/i) });
   });
 
@@ -1688,7 +1718,7 @@ describe('passkey MFA auth routes', () => {
       body: JSON.stringify({ currentPassword: 'wrong-password' }),
     });
 
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(400);
     // No passkey delete and no users update should run when the password is wrong.
     expect(dbState.updateSets).toHaveLength(0);
   });

--- a/apps/api/src/routes/auth.passkeys.test.ts
+++ b/apps/api/src/routes/auth.passkeys.test.ts
@@ -694,7 +694,11 @@ describe('passkey MFA auth routes', () => {
       });
 
       expect(res.status).toBe(401);
-      expect(await res.json()).toEqual({ error: 'Invalid credentials' });
+      expect(await res.json()).toEqual({
+        error: 'Invalid credentials',
+        message: 'Invalid credentials',
+        code: 'invalid_credentials',
+      });
       expect(passkeyMocks.generatePasskeyRegistrationOptions).not.toHaveBeenCalled();
     });
 
@@ -737,7 +741,11 @@ describe('passkey MFA auth routes', () => {
       });
 
       expect(res.status).toBe(401);
-      expect(await res.json()).toEqual({ error: 'Invalid credentials' });
+      expect(await res.json()).toEqual({
+        error: 'Invalid credentials',
+        message: 'Invalid credentials',
+        code: 'invalid_credentials',
+      });
     });
   });
 

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -1407,6 +1407,36 @@ describe('auth routes', () => {
       });
     }
 
+    // #4470: the LOGIN half of the contract, and the branch that had no test
+    // at all before. A wrong TOTP at the MFA challenge is a rejected proof
+    // (400) — the pending session it was typed against is still perfectly
+    // alive, and the login page has to keep the challenge on screen for a
+    // retry rather than restarting the whole flow. The `Invalid or expired MFA
+    // session` 401 below is what a DEAD session looks like; the two must stay
+    // distinguishable by status, not just by message text.
+    it('#4470: a wrong TOTP at the login challenge is 400 mfa_code_invalid and leaves the pending session alive for a retry', async () => {
+      getMock.mockResolvedValue(pendingRecord());
+      vi.mocked(consumeMFAToken).mockResolvedValueOnce(false);
+
+      const res = await postMfaVerify({ tempToken: 'temp-token', code: '000000' });
+
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({
+        error: 'Invalid MFA code',
+        message: 'Invalid MFA code',
+        code: 'mfa_code_invalid',
+      });
+      expect(createTokenPair).not.toHaveBeenCalled();
+      // The pending record must SURVIVE: a mistyped digit cannot cost the user
+      // their challenge.
+      expect(delMock).not.toHaveBeenCalled();
+
+      // ...and the very same tempToken completes on the correct code.
+      vi.mocked(consumeMFAToken).mockResolvedValueOnce(true);
+      const good = await postMfaVerify({ tempToken: 'temp-token', code: '123456' });
+      expect(good.status).toBe(200);
+    });
+
     it('rejects with a generic 401 and mints nothing when the live mfaEpoch has advanced past the pending record, consuming the pending key', async () => {
       getMock.mockResolvedValue(pendingRecord({ mfaEpoch: 1 }));
       vi.mocked(getUserEpochs).mockResolvedValue({ authEpoch: 1, mfaEpoch: 2 });
@@ -1496,8 +1526,12 @@ describe('auth routes', () => {
         method: 'recovery',
       });
 
-      expect(res.status).toBe(401);
-      expect(await res.json()).toEqual({ error: 'Invalid MFA code' });
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({
+        error: 'Invalid MFA code',
+        message: 'Invalid MFA code',
+        code: 'mfa_code_invalid',
+      });
       expect(consumeRecoveryCode).not.toHaveBeenCalled();
       expect(consumeMFAToken).not.toHaveBeenCalled();
       expect(delMock).not.toHaveBeenCalled();
@@ -1549,7 +1583,7 @@ describe('auth routes', () => {
       expect(setCookie).toContain('breeze_refresh_token=');
     });
 
-    it('hands recovery-code authority to the link finalizer and maps an invalid code to 401', async () => {
+    it('hands recovery-code authority to the link finalizer and maps an invalid code to 400', async () => {
       getMock.mockResolvedValue(pendingRecord({ ssoLinkTokenHash: 'link-hash-1' }));
       vi.mocked(finalizeSsoPendingLink).mockResolvedValue({ ok: false, error: 'invalid_mfa_code' } as any);
 
@@ -1558,7 +1592,7 @@ describe('auth routes', () => {
         { 'x-breeze-auth-transition': 'v1' },
       );
 
-      expect(res.status).toBe(401);
+      expect(res.status).toBe(400);
       expect((await res.json() as Record<string, unknown>).error).toBe('Invalid MFA code');
       expect(finalizeSsoPendingLink).toHaveBeenCalledWith(
         expect.anything(),
@@ -1755,14 +1789,14 @@ describe('auth routes', () => {
       expect(delMock).toHaveBeenCalledWith('mfa:pending:temp-token');
     });
 
-    it('rejects an unknown recovery code with 401 and no code/hash material in the audit trail', async () => {
+    it('rejects an unknown recovery code with 400 and no code/hash material in the audit trail', async () => {
       getMock.mockResolvedValue(pendingRecord());
       const unknownCode = 'ZZZZ-0000';
       vi.mocked(consumeRecoveryCode).mockRejectedValueOnce(new RecoveryCodeInvalidError());
 
       const res = await postMfaVerify({ tempToken: 'temp-token', code: unknownCode, method: 'recovery' });
 
-      expect(res.status).toBe(401);
+      expect(res.status).toBe(400);
       const body = await res.json() as Record<string, unknown>;
       expect(body).toMatchObject({ error: 'Invalid MFA code' });
       expect(createTokenPair).not.toHaveBeenCalled();
@@ -1789,7 +1823,7 @@ describe('auth routes', () => {
 
       const res = await postMfaVerify({ tempToken: 'temp-token', code: recoveryCode, method: 'recovery' });
 
-      expect(res.status).toBe(401);
+      expect(res.status).toBe(400);
       expect(createTokenPair).not.toHaveBeenCalled();
     });
   });
@@ -1930,12 +1964,12 @@ describe('auth routes', () => {
     // The dead end review finding 7 is about, seen from the server: a client
     // that lost its single-use grant sends nothing, and a generic
     // `Invalid credentials` would render on a screen with no password field.
-    it('answers enrollment_proof_required — not a generic 401 — when NO proof is sent', async () => {
+    it('answers enrollment_proof_required — not a generic invalid-credentials rejection — when NO proof is sent', async () => {
       mockPasswordlessPendingSetup();
 
       const res = await confirm({ code: '123456' });
 
-      expect(res.status).toBe(401);
+      expect(res.status).toBe(400);
       expect(await res.json()).toMatchObject({
         error: 'enrollment_proof_required',
         reauthUrl: '/sso/reauth/start',
@@ -1943,14 +1977,18 @@ describe('auth routes', () => {
       expect(db.update).not.toHaveBeenCalled();
     });
 
-    it('401s a grant that no longer validates (replayed, wrong session, bumped epoch)', async () => {
+    it('400s a grant that no longer validates (replayed, wrong session, bumped epoch)', async () => {
       mockPasswordlessPendingSetup();
       useGrantStore([]); // empty store: the grant is gone
 
       const res = await confirm({ code: '123456', ssoReauthGrantId: SSO_GRANT_ID });
 
-      expect(res.status).toBe(401);
-      expect(await res.json()).toMatchObject({ error: 'Invalid credentials' });
+      expect(res.status).toBe(400);
+      expect(await res.json()).toMatchObject({
+        error: 'Invalid credentials',
+        message: 'Invalid credentials',
+        code: 'invalid_credentials',
+      });
       expect(db.update).not.toHaveBeenCalled();
     });
 
@@ -2096,7 +2134,7 @@ describe('auth routes', () => {
       vi.mocked(consumeMFAToken).mockResolvedValueOnce(false);
       const bad = await confirmSetup({ code: '000000', stepUpGrantId: 'grant-1' });
 
-      expect(bad.status).toBe(401);
+      expect(bad.status).toBe(400);
       expect(consumeStepUpGrant).not.toHaveBeenCalled();
       expect(validateStepUpGrant).toHaveBeenCalledWith('grant-1', expect.objectContaining({ userId: 'user-123' }));
       expect(grants.has('grant-1')).toBe(true);
@@ -3209,7 +3247,7 @@ describe('auth routes', () => {
       vi.mocked(consumeMFAToken).mockResolvedValueOnce(false);
       const bad = await postMfaEnable({ code: '000000', stepUpGrantId: 'grant-1' });
 
-      expect(bad.status).toBe(401);
+      expect(bad.status).toBe(400);
       // The grant must NOT have been consumed by the failed attempt.
       expect(consumeStepUpGrant).not.toHaveBeenCalled();
       expect(validateStepUpGrant).toHaveBeenCalledWith('grant-1', expect.objectContaining({ userId: 'user-123' }));
@@ -3256,9 +3294,12 @@ describe('auth routes', () => {
     });
 
     // #4018: BOTH enrollment proofs are optional in the schema now, so "no
-    // proof at all" is resolveEnrollmentStepUp's opaque 401 rather than a 400
-    // from zod. That is the point: the shape of the rejection must not tell an
-    // attacker whether this account has a password.
+    // proof at all" is resolveEnrollmentStepUp's opaque rejection rather than
+    // a 400 from zod. That is the point: the shape of the rejection must not
+    // tell an attacker whether this account has a password. #4470: the MFA
+    // factor-management routes now opt the opaque rejection into status 400
+    // (uniform with a rejected password/code on these routes) instead of 401
+    // — the uniformity is what matters, not the particular status.
     it('POST /auth/mfa/enable should reject missing currentPassword (G1)', async () => {
       vi.mocked(db.select).mockReturnValue({
         from: vi.fn().mockReturnValue({
@@ -3277,12 +3318,16 @@ describe('auth routes', () => {
         body: JSON.stringify({ code: '123456' })
       });
 
-      expect(res.status).toBe(401);
-      expect(await res.json()).toEqual({ error: 'Invalid credentials' });
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({
+        error: 'Invalid credentials',
+        message: 'Invalid credentials',
+        code: 'invalid_credentials',
+      });
       expect(db.transaction).not.toHaveBeenCalled();
     });
 
-    it('POST /auth/mfa/enable should return 401 on wrong password (G1)', async () => {
+    it('POST /auth/mfa/enable should return 400 on wrong password (G1)', async () => {
       vi.mocked(verifyPassword).mockResolvedValue(false);
       vi.mocked(db.select).mockReturnValue({
         from: vi.fn().mockReturnValue({
@@ -3301,11 +3346,13 @@ describe('auth routes', () => {
         body: JSON.stringify({ code: '123456', currentPassword: 'WrongPass' })
       });
 
-      expect(res.status).toBe(401);
+      expect(res.status).toBe(400);
     });
 
     // #4018: see the /mfa/enable G1 note above — no proof at all is now an
-    // opaque 401, not a 400.
+    // opaque 400, not a 400 from zod (the point is the opacity, not the
+    // status: the rejection shape must not tell an attacker whether this
+    // account has a password).
     it('POST /auth/mfa/setup should reject missing currentPassword (G1)', async () => {
       vi.mocked(db.select).mockReturnValue({
         from: vi.fn().mockReturnValue({
@@ -3324,11 +3371,15 @@ describe('auth routes', () => {
         body: JSON.stringify({})
       });
 
-      expect(res.status).toBe(401);
-      expect(await res.json()).toEqual({ error: 'Invalid credentials' });
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({
+        error: 'Invalid credentials',
+        message: 'Invalid credentials',
+        code: 'invalid_credentials',
+      });
     });
 
-    it('POST /auth/mfa/setup should return 401 on wrong password (G1)', async () => {
+    it('POST /auth/mfa/setup should return 400 on wrong password (G1)', async () => {
       vi.mocked(verifyPassword).mockResolvedValue(false);
       vi.mocked(db.select).mockReturnValue({
         from: vi.fn().mockReturnValue({
@@ -3347,7 +3398,7 @@ describe('auth routes', () => {
         body: JSON.stringify({ currentPassword: 'WrongPass' })
       });
 
-      expect(res.status).toBe(401);
+      expect(res.status).toBe(400);
     });
 
     it('POST /auth/mfa/setup rejects a direct TOTP enrollment when policy disallows it', async () => {
@@ -3378,8 +3429,8 @@ describe('auth routes', () => {
     // sent, `passwordHash: null` on the account) with zero existing factors
     // and a fresh `enroll_first_factor` grant from GET /sso/callback (reauth
     // mode) must be able to complete the whole setup -> enable flow; an
-    // invalid/expired grant must be rejected with the same opaque 401 the
-    // password road uses.
+    // invalid/expired grant must be rejected with the same opaque 400 the
+    // password road uses on these routes.
     describe('#4018 SSO re-auth road on /mfa/setup and /mfa/enable', () => {
       it('POST /auth/mfa/setup SUCCEEDS for a passwordless, zero-factor account with a valid enrollment grant (validates, does not consume)', async () => {
         const mockRedis = { get: vi.fn(), setex: vi.fn(), del: vi.fn() };
@@ -3434,7 +3485,7 @@ describe('auth routes', () => {
         expect(mockRedis.setex).toHaveBeenCalled();
       });
 
-      it('POST /auth/mfa/setup returns the opaque 401 for a passwordless account with an invalid/expired grant', async () => {
+      it('POST /auth/mfa/setup returns the opaque 400 for a passwordless account with an invalid/expired grant', async () => {
         vi.mocked(validateStepUpGrant).mockResolvedValueOnce(false);
         vi.mocked(db.select)
           .mockReturnValueOnce({
@@ -3461,8 +3512,12 @@ describe('auth routes', () => {
           body: JSON.stringify({ ssoReauthGrantId: '11111111-1111-4111-8111-111111111111' })
         });
 
-        expect(res.status).toBe(401);
-        expect(await res.json()).toEqual({ error: 'Invalid credentials' });
+        expect(res.status).toBe(400);
+        expect(await res.json()).toEqual({
+          error: 'Invalid credentials',
+          message: 'Invalid credentials',
+          code: 'invalid_credentials',
+        });
       });
 
       it('POST /auth/mfa/enable SUCCEEDS for a passwordless, zero-factor account with a valid enrollment grant (consumes it at the terminal write)', async () => {
@@ -3517,7 +3572,7 @@ describe('auth routes', () => {
         );
       });
 
-      it('POST /auth/mfa/enable returns the opaque 401 for a passwordless account with an invalid/expired grant (no factor written)', async () => {
+      it('POST /auth/mfa/enable returns the opaque 400 for a passwordless account with an invalid/expired grant (no factor written)', async () => {
         const mockRedis = {
           get: vi.fn().mockResolvedValue(JSON.stringify({
             secret: 'MFASECRET123',
@@ -3550,8 +3605,12 @@ describe('auth routes', () => {
           body: JSON.stringify({ code: '123456', ssoReauthGrantId: '11111111-1111-4111-8111-111111111111' })
         });
 
-        expect(res.status).toBe(401);
-        expect(await res.json()).toEqual({ error: 'Invalid credentials' });
+        expect(res.status).toBe(400);
+        expect(await res.json()).toEqual({
+          error: 'Invalid credentials',
+          message: 'Invalid credentials',
+          code: 'invalid_credentials',
+        });
         expect(consumeMFAToken).not.toHaveBeenCalled();
       });
     });
@@ -3664,7 +3723,7 @@ describe('auth routes', () => {
         body: JSON.stringify({ currentPassword: 'WrongPass' })
       });
 
-      expect(res.status).toBe(401);
+      expect(res.status).toBe(400);
     });
   });
 
@@ -3726,7 +3785,7 @@ describe('auth routes', () => {
       }));
     });
 
-    it('returns 401 without minting a grant when the passkey assertion does not verify', async () => {
+    it('returns 400 without minting a grant when the passkey assertion does not verify', async () => {
       vi.mocked(verifyStepUpPasskeyAssertion).mockResolvedValueOnce(false);
 
       const res = await app.request('/auth/mfa/step-up', {
@@ -3735,7 +3794,12 @@ describe('auth routes', () => {
         body: JSON.stringify({ method: 'passkey', credential: { id: 'credential-1', response: {} } })
       });
 
-      expect(res.status).toBe(401);
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({
+        error: 'Invalid credentials',
+        message: 'Invalid credentials',
+        code: 'mfa_proof_invalid',
+      });
       expect(mintStepUpGrant).not.toHaveBeenCalled();
     });
 
@@ -3766,7 +3830,7 @@ describe('auth routes', () => {
     // on the row. This is the check that defeats the takeover where an attacker
     // swapped their own number in via /phone/confirm and then tries to mint a
     // grant here. A TOTP-protected victim (mfaMethod !== 'sms') must be rejected
-    // 401 WITHOUT Twilio ever being consulted and WITHOUT a grant minted.
+    // 400 WITHOUT Twilio ever being consulted and WITHOUT a grant minted.
     it('C1: SMS step-up rejects when the active factor is not SMS (swapped-in phone cannot mint a grant)', async () => {
       const checkVerificationCode = vi.fn().mockResolvedValue({ valid: true });
       vi.mocked(getTwilioService).mockReturnValue({
@@ -3791,7 +3855,12 @@ describe('auth routes', () => {
         body: JSON.stringify({ method: 'sms', code: '123456' })
       });
 
-      expect(res.status).toBe(401);
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({
+        error: 'Invalid credentials',
+        message: 'Invalid credentials',
+        code: 'mfa_proof_invalid',
+      });
       expect(checkVerificationCode).not.toHaveBeenCalled();
       expect(mintStepUpGrant).not.toHaveBeenCalled();
     });
@@ -3839,6 +3908,144 @@ describe('auth routes', () => {
       expect(res.status).toBe(429);
       expect(mintStepUpGrant).not.toHaveBeenCalled();
       expect(vi.mocked(rateLimiter).mock.calls.some(([, key]) => String(key) === 'mfa:stepup-rl:user-123')).toBe(true);
+    });
+  });
+
+  // ── #4470 ────────────────────────────────────────────────────────────────
+  // A rejected FACTOR PROOF (the TOTP/SMS/recovery code or the step-up
+  // password the user typed INTO THE REQUEST BODY) is a request-validation
+  // failure, not an authentication failure. It must never share a status with
+  // the bearer guard: every browser client funnels a 401 into
+  // refresh-and-replay -> handleSessionExpired, which signed the user out
+  // mid-enrollment for a typo (#4413/#4414). 401 stays reserved for "the
+  // credential that authenticates THIS request is missing/expired/invalid" —
+  // the bearer, or the login challenge's tempToken.
+  describe('#4470: a rejected MFA proof answers 400 + a stable code, never 401', () => {
+    function pendingSetupUser(overrides: Record<string, unknown> = {}) {
+      const mockRedis = {
+        get: vi.fn().mockResolvedValue(JSON.stringify({ secret: 'MFASECRET123' })),
+        setex: vi.fn(),
+        del: vi.fn().mockResolvedValue(1),
+      };
+      vi.mocked(getRedis).mockReturnValue(mockRedis as any);
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([
+              { passwordHash: '$argon2id$hash', mfaEnabled: false, passkeyCount: 0, ...overrides },
+            ]),
+          }),
+        }),
+      } as any);
+      return mockRedis;
+    }
+
+    function post(path: string, body: Record<string, unknown>) {
+      return app.request(path, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer valid-token', 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+    }
+
+    it('POST /auth/mfa/enable — a wrong TOTP code is 400 mfa_code_invalid, not 401', async () => {
+      pendingSetupUser();
+      vi.mocked(verifyPassword).mockResolvedValue(true);
+      vi.mocked(consumeMFAToken).mockResolvedValue(false);
+
+      const res = await post('/auth/mfa/enable', { code: '000000', currentPassword: 'OldStrongPass123' });
+
+      expect(res.status).toBe(400);
+      expect(await res.json()).toMatchObject({ code: 'mfa_code_invalid', error: 'Invalid MFA code' });
+      expect(db.transaction).not.toHaveBeenCalled();
+    });
+
+    it('POST /auth/mfa/enable — a wrong step-up password is 400 invalid_credentials, not 401', async () => {
+      pendingSetupUser();
+      vi.mocked(verifyPassword).mockResolvedValue(false);
+
+      const res = await post('/auth/mfa/enable', { code: '123456', currentPassword: 'WrongPass' });
+
+      expect(res.status).toBe(400);
+      expect(await res.json()).toMatchObject({ code: 'invalid_credentials', error: 'Invalid credentials' });
+      expect(consumeMFAToken).not.toHaveBeenCalled();
+    });
+
+    it('POST /auth/mfa/setup — a wrong step-up password is 400 invalid_credentials, not 401', async () => {
+      pendingSetupUser();
+      vi.mocked(verifyPassword).mockResolvedValue(false);
+
+      const res = await post('/auth/mfa/setup', { currentPassword: 'WrongPass' });
+
+      expect(res.status).toBe(400);
+      expect(await res.json()).toMatchObject({ code: 'invalid_credentials' });
+    });
+
+    it('POST /auth/mfa/disable — a wrong TOTP code is 400 mfa_code_invalid, not 401', async () => {
+      vi.mocked(verifyPassword).mockResolvedValue(true);
+      vi.mocked(consumeMFAToken).mockResolvedValue(false);
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([
+              {
+                passwordHash: '$argon2id$hash',
+                mfaEnabled: true,
+                mfaMethod: 'totp',
+                mfaSecret: encryptMfaSecret('PLAINTEXTSECRET'),
+                phoneNumber: null,
+              },
+            ]),
+          }),
+        }),
+      } as any);
+
+      const res = await post('/auth/mfa/disable', { code: '000000', currentPassword: 'OldStrongPass123' });
+
+      expect(res.status).toBe(400);
+      expect(await res.json()).toMatchObject({ code: 'mfa_code_invalid' });
+    });
+
+    it('POST /auth/mfa/step-up — a rejected factor proof is 400 mfa_proof_invalid, not 401', async () => {
+      vi.mocked(verifyStepUpPasskeyAssertion).mockResolvedValueOnce(false);
+
+      const res = await post('/auth/mfa/step-up', { method: 'passkey', credential: { id: 'credential-1', response: {} } });
+
+      expect(res.status).toBe(400);
+      expect(await res.json()).toMatchObject({ code: 'mfa_proof_invalid' });
+      expect(mintStepUpGrant).not.toHaveBeenCalled();
+    });
+
+    it('POST /auth/mfa/recovery-codes — a wrong password is 400 invalid_credentials, not 401', async () => {
+      vi.mocked(verifyPassword).mockResolvedValue(false);
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ passwordHash: '$argon2id$hash' }]),
+          }),
+        }),
+      } as any);
+
+      const res = await post('/auth/mfa/recovery-codes', { currentPassword: 'WrongPass' });
+
+      expect(res.status).toBe(400);
+      expect(await res.json()).toMatchObject({ code: 'invalid_credentials' });
+    });
+
+    // The other half of the contract: a dead SESSION credential still 401s, so
+    // the login page can keep telling these two apart.
+    it('POST /auth/mfa/verify — an unknown tempToken still answers 401 (session, not proof)', async () => {
+      const mockRedis = { get: vi.fn().mockResolvedValue(null), setex: vi.fn(), del: vi.fn() };
+      vi.mocked(getRedis).mockReturnValue(mockRedis as any);
+
+      const res = await app.request('/auth/mfa/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code: '123456', tempToken: 'dead-token' }),
+      });
+
+      expect(res.status).toBe(401);
+      expect(await res.json()).toMatchObject({ error: 'Invalid or expired MFA session' });
     });
   });
 

--- a/apps/api/src/routes/auth/helpers.enrollmentStepUp.test.ts
+++ b/apps/api/src/routes/auth/helpers.enrollmentStepUp.test.ts
@@ -188,7 +188,11 @@ describe('resolveEnrollmentStepUp', () => {
       const res = await resolveEnrollmentStepUp(ctx(), authCtx(), { currentPassword: 'nope' }, TERMINAL);
 
       expect((res as any).__status).toBe(401);
-      expect((res as any).__body).toEqual({ error: 'Invalid credentials' });
+      expect((res as any).__body).toEqual({
+        error: 'Invalid credentials',
+        message: 'Invalid credentials',
+        code: 'invalid_credentials',
+      });
       expect(consumeStepUpGrant).not.toHaveBeenCalled();
     });
 
@@ -303,7 +307,11 @@ describe('resolveEnrollmentStepUp', () => {
       const res = await resolveEnrollmentStepUp(ctx(), authCtx(), { ssoReauthGrantId: GRANT }, TERMINAL);
 
       expect((res as any).__status).toBe(401);
-      expect((res as any).__body).toEqual({ error: 'Invalid credentials' });
+      expect((res as any).__body).toEqual({
+        error: 'Invalid credentials',
+        message: 'Invalid credentials',
+        code: 'invalid_credentials',
+      });
     });
 
     it('401s when neither proof is supplied', async () => {
@@ -340,7 +348,11 @@ describe('resolveEnrollmentStepUp', () => {
       const res = await resolveEnrollmentStepUp(ctx(), authCtx(), { ssoReauthGrantId: GRANT }, TERMINAL);
 
       expect((res as any).__status).toBe(401);
-      expect((res as any).__body).toEqual({ error: 'Invalid credentials' });
+      expect((res as any).__body).toEqual({
+        error: 'Invalid credentials',
+        message: 'Invalid credentials',
+        code: 'invalid_credentials',
+      });
     });
   });
 
@@ -367,7 +379,11 @@ describe('resolveEnrollmentStepUp', () => {
       const res = await resolveEnrollmentStepUp(ctx(), authCtx(), { ssoReauthGrantId: GRANT }, TERMINAL);
 
       expect((res as any).__status).toBe(401);
-      expect((res as any).__body).toEqual({ error: 'Invalid credentials' });
+      expect((res as any).__body).toEqual({
+        error: 'Invalid credentials',
+        message: 'Invalid credentials',
+        code: 'invalid_credentials',
+      });
       // Refused BEFORE the grant is touched: a rejected enrollment must not
       // burn the caller's single-use grant.
       expect(consumeStepUpGrant).not.toHaveBeenCalled();

--- a/apps/api/src/routes/auth/helpers.mfaStepUp.test.ts
+++ b/apps/api/src/routes/auth/helpers.mfaStepUp.test.ts
@@ -107,15 +107,24 @@ describe('requireFreshMfaStepUp', () => {
     consumeMFAToken.mockResolvedValue(false);
     const c = makeContext();
     const result = await requireFreshMfaStepUp(c, USER_ID, '000000');
-    expect(c.json).toHaveBeenCalledWith({ error: 'Invalid credentials' }, 401);
-    expect(result).toEqual({ __body: { error: 'Invalid credentials' }, __status: 401 });
+    expect(c.json).toHaveBeenCalledWith(
+      { error: 'Invalid credentials', message: 'Invalid credentials', code: 'invalid_credentials' },
+      401,
+    );
+    expect(result).toEqual({
+      __body: { error: 'Invalid credentials', message: 'Invalid credentials', code: 'invalid_credentials' },
+      __status: 401,
+    });
   });
 
   it('returns 401 when MFA is disabled', async () => {
     mockUserRow({ mfaEnabled: false, mfaSecret: 'enc-secret', mfaMethod: 'totp' });
     const c = makeContext();
     await requireFreshMfaStepUp(c, USER_ID, '123456');
-    expect(c.json).toHaveBeenCalledWith({ error: 'Invalid credentials' }, 401);
+    expect(c.json).toHaveBeenCalledWith(
+      { error: 'Invalid credentials', message: 'Invalid credentials', code: 'invalid_credentials' },
+      401,
+    );
     expect(consumeMFAToken).not.toHaveBeenCalled();
   });
 
@@ -123,7 +132,10 @@ describe('requireFreshMfaStepUp', () => {
     mockUserRow({ mfaEnabled: true, mfaSecret: 'enc-secret', mfaMethod: 'sms' });
     const c = makeContext();
     await requireFreshMfaStepUp(c, USER_ID, '123456');
-    expect(c.json).toHaveBeenCalledWith({ error: 'Invalid credentials' }, 401);
+    expect(c.json).toHaveBeenCalledWith(
+      { error: 'Invalid credentials', message: 'Invalid credentials', code: 'invalid_credentials' },
+      401,
+    );
     expect(consumeMFAToken).not.toHaveBeenCalled();
   });
 
@@ -131,7 +143,10 @@ describe('requireFreshMfaStepUp', () => {
     mockUserRow({ mfaEnabled: true, mfaSecret: 'enc-secret', mfaMethod: 'passkey' });
     const c = makeContext();
     await requireFreshMfaStepUp(c, USER_ID, '123456');
-    expect(c.json).toHaveBeenCalledWith({ error: 'Invalid credentials' }, 401);
+    expect(c.json).toHaveBeenCalledWith(
+      { error: 'Invalid credentials', message: 'Invalid credentials', code: 'invalid_credentials' },
+      401,
+    );
     expect(consumeMFAToken).not.toHaveBeenCalled();
   });
 
@@ -139,7 +154,10 @@ describe('requireFreshMfaStepUp', () => {
     mockUserRow({ mfaEnabled: true, mfaSecret: null, mfaMethod: 'totp' });
     const c = makeContext();
     await requireFreshMfaStepUp(c, USER_ID, '123456');
-    expect(c.json).toHaveBeenCalledWith({ error: 'Invalid credentials' }, 401);
+    expect(c.json).toHaveBeenCalledWith(
+      { error: 'Invalid credentials', message: 'Invalid credentials', code: 'invalid_credentials' },
+      401,
+    );
     expect(consumeMFAToken).not.toHaveBeenCalled();
   });
 
@@ -147,7 +165,10 @@ describe('requireFreshMfaStepUp', () => {
     decryptMfaTotpSecret.mockReturnValue(null);
     const c = makeContext();
     await requireFreshMfaStepUp(c, USER_ID, '123456');
-    expect(c.json).toHaveBeenCalledWith({ error: 'Invalid credentials' }, 401);
+    expect(c.json).toHaveBeenCalledWith(
+      { error: 'Invalid credentials', message: 'Invalid credentials', code: 'invalid_credentials' },
+      401,
+    );
     expect(consumeMFAToken).not.toHaveBeenCalled();
   });
 
@@ -155,7 +176,10 @@ describe('requireFreshMfaStepUp', () => {
     mockUserRow(undefined);
     const c = makeContext();
     await requireFreshMfaStepUp(c, USER_ID, '123456');
-    expect(c.json).toHaveBeenCalledWith({ error: 'Invalid credentials' }, 401);
+    expect(c.json).toHaveBeenCalledWith(
+      { error: 'Invalid credentials', message: 'Invalid credentials', code: 'invalid_credentials' },
+      401,
+    );
   });
 
   it('returns 429 when rate-limited', async () => {

--- a/apps/api/src/routes/auth/helpers.ts
+++ b/apps/api/src/routes/auth/helpers.ts
@@ -305,10 +305,12 @@ export async function requireFreshMfaStepUp(
   userId: string,
   code: string,
   keyPrefix = 'auth:mfa-stepup',
-  /** #4470 — see {@link requireCurrentPasswordStepUp}. Same default, same reason. */
-  opts: { rejectionStatus?: ProofRejectionStatus } = {},
 ): Promise<Response | null> {
-  const rejectionStatus = opts.rejectionStatus ?? 401;
+  // #4470: no `rejectionStatus` opt-in here — unlike its siblings this helper
+  // has no factor-management caller (only approvals/PAM L4 re-auth), so an
+  // unused knob would just be untested dead code. Add it when a caller needs
+  // it. The BODY is uniform with the siblings so a client sees one shape.
+  const rejectionStatus: ProofRejectionStatus = 401;
   const redis = getRedis();
   if (!redis) {
     return c.json({ error: 'Service temporarily unavailable' }, 503);

--- a/apps/api/src/routes/auth/helpers.ts
+++ b/apps/api/src/routes/auth/helpers.ts
@@ -297,7 +297,7 @@ export async function requireCurrentPasswordStepUp(
  * no password to satisfy {@link requireCurrentPasswordStepUp}. Verifies a fresh
  * TOTP code against the user's enrolled MFA secret. Mirrors the password
  * step-up's shape (rate limit → lookup → verify) and returns the same opaque
- * 401/429/503 responses so callers can `if (err) return err` uniformly. Only
+ * rejection/429/503 responses so callers can `if (err) return err` uniformly. Only
  * TOTP step-up is supported here; SMS/passkey L4 re-auth is out of scope.
  */
 export async function requireFreshMfaStepUp(
@@ -305,7 +305,10 @@ export async function requireFreshMfaStepUp(
   userId: string,
   code: string,
   keyPrefix = 'auth:mfa-stepup',
+  /** #4470 — see {@link requireCurrentPasswordStepUp}. Same default, same reason. */
+  opts: { rejectionStatus?: ProofRejectionStatus } = {},
 ): Promise<Response | null> {
+  const rejectionStatus = opts.rejectionStatus ?? 401;
   const redis = getRedis();
   if (!redis) {
     return c.json({ error: 'Service temporarily unavailable' }, 503);
@@ -329,12 +332,12 @@ export async function requireFreshMfaStepUp(
   // Allowlist on the method (not a denylist) so any non-TOTP/unset method is
   // rejected even if a stale secret lingers — defense-in-depth for the auth path.
   if (!user?.mfaEnabled || user.mfaMethod !== 'totp' || !user.mfaSecret) {
-    return c.json({ error: 'Invalid credentials' }, 401);
+    return rejectProof(c, 'Invalid credentials', INVALID_CREDENTIALS_CODE, rejectionStatus);
   }
 
   const secret = decryptMfaTotpSecret(user.mfaSecret);
   if (!secret) {
-    return c.json({ error: 'Invalid credentials' }, 401);
+    return rejectProof(c, 'Invalid credentials', INVALID_CREDENTIALS_CODE, rejectionStatus);
   }
 
   // consumeMFAToken (not verifyMFAToken): enforce single-use of the TOTP step
@@ -342,7 +345,7 @@ export async function requireFreshMfaStepUp(
   // its validity window. This L4 path had no other single-use binding. (sec review #2)
   const valid = await consumeMFAToken(secret, code, userId);
   if (!valid) {
-    return c.json({ error: 'Invalid credentials' }, 401);
+    return rejectProof(c, 'Invalid credentials', INVALID_CREDENTIALS_CODE, rejectionStatus);
   }
 
   return null;

--- a/apps/api/src/routes/auth/helpers.ts
+++ b/apps/api/src/routes/auth/helpers.ts
@@ -192,12 +192,75 @@ export function getClientRateLimitKey(c: RequestLike): string {
   return `fp:${digest}`;
 }
 
+// ============================================
+// #4470: rejected-proof responses
+// ============================================
+
+/**
+ * #4470: a rejected FACTOR PROOF — the TOTP/SMS/recovery code, or the
+ * current-password / enrollment grant the user supplied IN THE REQUEST BODY —
+ * is a request-validation failure, NOT an authentication failure. It must
+ * never share a status with the bearer guard.
+ *
+ * Why this matters more than HTTP pedantry: every browser client funnels a 401
+ * into refresh-and-replay and then `handleSessionExpired` (see
+ * `apps/web/src/stores/auth.ts` `fetchWithAuth`). When a mistyped 6-digit code
+ * answered 401, that logged the user out mid-enrollment (#4413/#4414). PR
+ * #4439 patched it client-side with an opt-in `skipUnauthorizedRetry` flag,
+ * which every future caller has to remember; this is the server-side fix that
+ * makes the flag unnecessary.
+ *
+ * The invariant: **401 means "the credential that authenticates THIS request
+ * is missing, expired, or invalid"** — the bearer token, or the login
+ * challenge's `tempToken`. Everything else the user typed is body data, and a
+ * rejection of it is a 400 carrying a stable machine-readable `code`.
+ *
+ * Clients must branch on `code`, never on the human `error`/`message` text.
+ */
+export const MFA_CODE_INVALID = 'mfa_code_invalid';
+/** A step-up factor proof (TOTP/SMS/passkey) was rejected, or no usable factor exists. */
+export const MFA_PROOF_INVALID = 'mfa_proof_invalid';
+/** A step-up / enrollment credential (password, SSO re-auth grant) was rejected. */
+export const INVALID_CREDENTIALS_CODE = 'invalid_credentials';
+
+/** The status a rejected body-supplied proof answers with. */
+export type ProofRejectionStatus = 400 | 401;
+
+/**
+ * Build the uniform rejected-proof body: `{ error, message, code }`.
+ *
+ * `error` and `message` are BOTH populated because the existing clients read
+ * `data.error ?? data.message`; `code` is the stable contract.
+ *
+ * `status` is a parameter rather than a constant because the shared step-up
+ * helpers below are also used by routes whose clients still key on 401 (mobile
+ * `approvals.ts` maps a 401 decision to `STEP_UP_FAILED`). Those keep 401 by
+ * default; the MFA factor-management routes opt in to 400.
+ */
+export function rejectProof(
+  c: Context,
+  message: string,
+  code: string,
+  status: ProofRejectionStatus,
+  extra?: Record<string, unknown>,
+): Response {
+  return c.json({ error: message, message, code, ...extra }, status);
+}
+
 export async function requireCurrentPasswordStepUp(
   c: Context,
   userId: string,
   currentPassword: string,
-  keyPrefix = 'auth:pwd-stepup'
+  keyPrefix = 'auth:pwd-stepup',
+  /**
+   * #4470: MFA factor-management routes pass 400 so a mistyped password is not
+   * mistaken for bearer expiry by the web client's generic 401 handler.
+   * Defaults to 401 for every pre-existing caller whose client contract keys
+   * on it (approvals/PAM step-up, users email-change, authenticator).
+   */
+  opts: { rejectionStatus?: ProofRejectionStatus } = {},
 ): Promise<Response | null> {
+  const rejectionStatus = opts.rejectionStatus ?? 401;
   const redis = getRedis();
   if (!redis) {
     return c.json({ error: 'Service temporarily unavailable' }, 503);
@@ -218,12 +281,12 @@ export async function requireCurrentPasswordStepUp(
     .limit(1);
 
   if (!user?.passwordHash) {
-    return c.json({ error: 'Invalid credentials' }, 401);
+    return rejectProof(c, 'Invalid credentials', INVALID_CREDENTIALS_CODE, rejectionStatus);
   }
 
   const valid = await verifyPassword(user.passwordHash, currentPassword);
   if (!valid) {
-    return c.json({ error: 'Invalid credentials' }, 401);
+    return rejectProof(c, 'Invalid credentials', INVALID_CREDENTIALS_CODE, rejectionStatus);
   }
 
   return null;
@@ -407,12 +470,15 @@ export async function enforceExistingFactorStepUp(
  * (SR2-20), which exists precisely to require proving an EXISTING factor
  * before adding a new one. The predicate is {@link userIsMfaProtected} — the
  * same one SR2-20 uses — so the two gates can never drift apart. A protected
- * passwordless account is REFUSED this road outright (401); it does not fall
+ * passwordless account is REFUSED this road outright; it does not fall
  * through to any other step-up here. Its route back in is the SR2-20 path,
  * proving the factor it already holds.
  *
- * Every rejection is the same opaque `Invalid credentials` 401 the password
- * path already returns, so the response never reveals whether the account has
+ * Every rejection is the same opaque `Invalid credentials` response the
+ * password path already returns — SAME status, same body, whichever road was
+ * refused (#4470 moved that status behind `opts.rejectionStatus`, so it is
+ * uniform per call site rather than globally). The response never reveals
+ * whether the account has
  * a password, has a factor, or exists at all — with ONE deliberate exception:
  * a passwordless account that offered NO proof at all gets
  * `enrollment_proof_required`. That case is not a failed authentication
@@ -440,15 +506,27 @@ export async function resolveEnrollmentStepUp(
   c: Context,
   auth: AuthContext,
   input: { currentPassword?: string; ssoReauthGrantId?: string },
-  opts: { keyPrefix: string; consume: boolean; passwordAlreadyProven?: boolean },
+  opts: {
+    keyPrefix: string;
+    consume: boolean;
+    passwordAlreadyProven?: boolean;
+    /**
+     * #4470: the status EVERY rejection below answers with. It must stay
+     * uniform within a call site or the status itself becomes the oracle the
+     * opacity rule above exists to close. MFA factor-management routes pass
+     * 400; callers that have not migrated their clients keep the 401 default.
+     */
+    rejectionStatus?: ProofRejectionStatus;
+  },
 ): Promise<Response | null> {
+  const rejectionStatus = opts.rejectionStatus ?? 401;
   // Road 1, FIRST and byte-for-byte the historical path: a password was
   // offered, so a password is what must check out. requireCurrentPasswordStepUp
   // already returns the same opaque 401 when the account has no hash at all, so
   // a passwordless account that offers a password is rejected here rather than
   // sliding onto the SSO road — one request, one road, chosen by what it sent.
   if (input.currentPassword) {
-    return requireCurrentPasswordStepUp(c, auth.user.id, input.currentPassword, opts.keyPrefix);
+    return requireCurrentPasswordStepUp(c, auth.user.id, input.currentPassword, opts.keyPrefix, { rejectionStatus });
   }
 
   // No password offered. Decide whether this account is even eligible for the
@@ -469,7 +547,7 @@ export async function resolveEnrollmentStepUp(
       .where(eq(users.id, auth.user.id))
       .limit(1)
   );
-  if (!user) return c.json({ error: 'Invalid credentials' }, 401);
+  if (!user) return rejectProof(c, 'Invalid credentials', INVALID_CREDENTIALS_CODE, rejectionStatus);
 
   if (user.passwordHash != null) {
     // The gate of this flow already verified the password; nothing is left for
@@ -477,20 +555,24 @@ export async function resolveEnrollmentStepUp(
     // assumption that the gate ran — this must fail CLOSED for a passwordless
     // account that reaches a terminal write with no grant.
     if (opts.passwordAlreadyProven) return null;
-    return c.json({ error: 'Invalid credentials' }, 401);
+    return rejectProof(c, 'Invalid credentials', INVALID_CREDENTIALS_CODE, rejectionStatus);
   }
 
   if (!input.ssoReauthGrantId) {
     // Distinguishable ON PURPOSE — see the doc comment. `reauthUrl` mirrors the
     // `stepUpUrl` affordance enforceExistingFactorStepUp already returns, so a
     // client can offer the one action that resolves this.
-    return c.json({ error: 'enrollment_proof_required', reauthUrl: '/sso/reauth/start' }, 401);
+    // #4470: shares `rejectionStatus` with every sibling rejection above. A
+    // status that differed here would re-open the password/passwordless oracle
+    // through the status line even though the BODY is distinguishable on
+    // purpose.
+    return c.json({ error: 'enrollment_proof_required', reauthUrl: '/sso/reauth/start' }, rejectionStatus);
   }
 
   // FIRST factor only — see the doc comment above. Checked BEFORE the grant is
   // consumed so a refused enrollment never burns the caller's grant.
   if (await userIsMfaProtected(auth.user.id)) {
-    return c.json({ error: 'Invalid credentials' }, 401);
+    return rejectProof(c, 'Invalid credentials', INVALID_CREDENTIALS_CODE, rejectionStatus);
   }
 
   const epochs = await getUserEpochs(auth.user.id);
@@ -514,7 +596,7 @@ export async function resolveEnrollmentStepUp(
     ? await consumeStepUpGrant(input.ssoReauthGrantId, bind)
     : await validateStepUpGrant(input.ssoReauthGrantId, bind);
   if (!ok) {
-    return c.json({ error: 'Invalid credentials' }, 401);
+    return rejectProof(c, 'Invalid credentials', INVALID_CREDENTIALS_CODE, rejectionStatus);
   }
 
   return null;

--- a/apps/api/src/routes/auth/mfa.ts
+++ b/apps/api/src/routes/auth/mfa.ts
@@ -64,6 +64,9 @@ import {
   parsePendingMfa,
   evaluatePendingMfa,
   evaluatePendingMfaMethod,
+  rejectProof,
+  MFA_CODE_INVALID,
+  MFA_PROOF_INVALID,
   mintLoginRegisterGrant,
   isAuthTransitionV1Request,
   authClientUpgradeRequiredResponse,
@@ -73,6 +76,27 @@ import { installAuthBindingReplacement, requestAuthBinding } from './binding';
 import { finalizeSsoPendingLink } from './ssoLinkCompletion';
 
 const { db, withSystemDbAccessContext, runOutsideDbContext } = dbModule;
+
+/**
+ * #4470: every rejected proof on these routes answers 400, never 401.
+ *
+ * A wrong TOTP/SMS/recovery code — or a wrong step-up password — is the user
+ * mistyping a field of the request body. The bearer that authenticated the
+ * request is still perfectly valid. Answering 401 made the two
+ * indistinguishable to the clients, and `fetchWithAuth`
+ * (`apps/web/src/stores/auth.ts`) turns a 401 into refresh-and-replay and then
+ * `handleSessionExpired` — so a single typo signed the user out in the middle
+ * of MFA enrollment (#4413/#4414).
+ *
+ * 401 survives on these routes for exactly two things, both of which really
+ * ARE "the credential authenticating this request is dead":
+ *   - the bearer guard (`authMiddleware`), and
+ *   - the login challenge's `tempToken` (`Invalid or expired MFA session`) and
+ *     the SSO-link ceremony (`sso_link_expired`) — the login page keys on
+ *     those to send the user back to the start instead of asking for another
+ *     code.
+ */
+const MFA_PROOF_REJECTION_STATUS = 400;
 
 function authTransitionClientClass(c: Context): 'web' | 'native' {
   return readMobileDeviceId(c) ? 'native' : 'web';
@@ -116,10 +140,13 @@ const passwordOnlySchema = z.object({
 
 // #4018: the FIRST-FACTOR ENROLLMENT endpoints accept either proof. Both are
 // optional HERE and resolveEnrollmentStepUp decides which road this account is
-// allowed to take — "neither supplied" must be its opaque 401, not a 400 from
-// this schema, because the shape of the rejection must not tell an attacker
-// whether the account has a password. `passwordOnlySchema` above stays
-// password-only: /mfa/recovery-codes is not an enrollment.
+// allowed to take — "neither supplied" must be that helper's own opaque
+// rejection, not a zod rejection from this schema, because the shape of the
+// rejection must not tell an attacker whether the account has a password.
+// (#4470 moved that rejection's status from 401 to 400 on these routes; the
+// point stands unchanged — it is the UNIFORMITY that closes the oracle, not
+// the particular status.) `passwordOnlySchema` above stays password-only:
+// /mfa/recovery-codes is not an enrollment.
 const enrollmentStepUpSchema = z.object({
   currentPassword: z.string().min(1).max(256).optional(),
   ssoReauthGrantId: z.string().uuid().optional()
@@ -187,7 +214,7 @@ mfaRoutes.post('/mfa/setup', authMiddleware, zValidator('json', enrollmentStepUp
     c,
     auth,
     { currentPassword, ssoReauthGrantId },
-    { keyPrefix: 'mfa:pwd', consume: false }
+    { keyPrefix: 'mfa:pwd', consume: false, rejectionStatus: MFA_PROOF_REJECTION_STATUS }
   );
   if (stepUpError) return stepUpError;
 
@@ -333,7 +360,7 @@ mfaRoutes.post('/mfa/verify', zValidator('json', mfaVerifySchema), async (c) => 
         reason: 'mfa_method_not_allowed',
         details: { method: effectiveMethod, phase: methodVerdict.reason },
       });
-      return c.json({ error: 'Invalid MFA code' }, 401);
+      return rejectProof(c, 'Invalid MFA code', MFA_CODE_INVALID, MFA_PROOF_REJECTION_STATUS);
     }
 
     let capability: AuthIssuanceCapability | null = null;
@@ -418,7 +445,7 @@ mfaRoutes.post('/mfa/verify', zValidator('json', mfaVerifySchema), async (c) => 
         reason: 'mfa_invalid_code',
         details: { method: effectiveMethod }
       });
-      return c.json({ error: 'Invalid MFA code' }, 401);
+      return rejectProof(c, 'Invalid MFA code', MFA_CODE_INVALID, MFA_PROOF_REJECTION_STATUS);
     }
 
     // #4067: this MFA step may be the continuation of a link-on-first-SSO-
@@ -442,7 +469,7 @@ mfaRoutes.post('/mfa/verify', zValidator('json', mfaVerifySchema), async (c) => 
             userId: user.id, email: user.email, name: user.name,
             reason: 'mfa_recovery_code_invalid', details: { method: 'recovery' },
           });
-          return c.json({ error: 'Invalid MFA code' }, 401);
+          return rejectProof(c, 'Invalid MFA code', MFA_CODE_INVALID, MFA_PROOF_REJECTION_STATUS);
         }
         if (outcome.error === 'identity_in_use') {
           return c.json({ error: 'identity_in_use' }, 409);
@@ -531,7 +558,7 @@ mfaRoutes.post('/mfa/verify', zValidator('json', mfaVerifySchema), async (c) => 
             userId: user.id, email: user.email, name: user.name,
             reason: 'mfa_recovery_code_invalid', details: { method: 'recovery' },
           });
-          return c.json({ error: 'Invalid MFA code' }, 401);
+          return rejectProof(c, 'Invalid MFA code', MFA_CODE_INVALID, MFA_PROOF_REJECTION_STATUS);
         }
         const response = authIssuanceAdmissionError(c, error);
         if (!response) throw error;
@@ -554,7 +581,7 @@ mfaRoutes.post('/mfa/verify', zValidator('json', mfaVerifySchema), async (c) => 
             userId: user.id, email: user.email, name: user.name,
             reason: 'mfa_recovery_code_invalid', details: { method: 'recovery' },
           });
-          return c.json({ error: 'Invalid MFA code' }, 401);
+          return rejectProof(c, 'Invalid MFA code', MFA_CODE_INVALID, MFA_PROOF_REJECTION_STATUS);
         }
       }
       recordAuthTransitionLegacyIssuer(issuer, authTransitionClientClass(c));
@@ -664,7 +691,7 @@ mfaRoutes.post('/mfa/verify', zValidator('json', mfaVerifySchema), async (c) => 
       email: auth.user.email,
       details: { phase: 'setup_confirmation' }
     });
-    return c.json({ error: 'Invalid MFA code' }, 401);
+    return rejectProof(c, 'Invalid MFA code', MFA_CODE_INVALID, MFA_PROOF_REJECTION_STATUS);
   }
 
   // Terminal factor write: NOW consume the grant (single-use). Re-checks the
@@ -685,7 +712,7 @@ mfaRoutes.post('/mfa/verify', zValidator('json', mfaVerifySchema), async (c) => 
     c,
     auth,
     { ssoReauthGrantId: c.req.valid('json').ssoReauthGrantId },
-    { keyPrefix: 'mfa:pwd', consume: true, passwordAlreadyProven: true }
+    { keyPrefix: 'mfa:pwd', consume: true, passwordAlreadyProven: true, rejectionStatus: MFA_PROOF_REJECTION_STATUS }
   );
   if (enrollmentConsumeError) return enrollmentConsumeError;
 
@@ -789,7 +816,9 @@ mfaRoutes.post('/mfa/disable', authMiddleware, zValidator('json', mfaDisableSche
   // possession of the second factor; the password proves the user is at
   // the keyboard right now (vs an attacker on a stolen access token who
   // somehow got an MFA code, e.g. social-engineered SMS).
-  const passwordError = await requireCurrentPasswordStepUp(c, auth.user.id, currentPassword, 'mfa:pwd');
+  const passwordError = await requireCurrentPasswordStepUp(c, auth.user.id, currentPassword, 'mfa:pwd', {
+    rejectionStatus: MFA_PROOF_REJECTION_STATUS,
+  });
   if (passwordError) return passwordError;
 
   // MFA policy blocks self-disable when effective policy (role OR org/partner
@@ -848,7 +877,7 @@ mfaRoutes.post('/mfa/disable', authMiddleware, zValidator('json', mfaDisableSche
         email: auth.user.email,
         details: { method: 'sms' }
       });
-      return c.json({ error: 'Invalid verification code' }, 401);
+      return rejectProof(c, 'Invalid verification code', MFA_CODE_INVALID, MFA_PROOF_REJECTION_STATUS);
     }
   } else {
     // TOTP
@@ -868,7 +897,7 @@ mfaRoutes.post('/mfa/disable', authMiddleware, zValidator('json', mfaDisableSche
         email: auth.user.email,
         details: { method: 'totp' }
       });
-      return c.json({ error: 'Invalid MFA code' }, 401);
+      return rejectProof(c, 'Invalid MFA code', MFA_CODE_INVALID, MFA_PROOF_REJECTION_STATUS);
     }
   }
 
@@ -917,7 +946,7 @@ mfaRoutes.post('/mfa/enable', authMiddleware, zValidator('json', mfaEnableWithSt
     c,
     auth,
     { currentPassword, ssoReauthGrantId },
-    { keyPrefix: 'mfa:pwd', consume: false }
+    { keyPrefix: 'mfa:pwd', consume: false, rejectionStatus: MFA_PROOF_REJECTION_STATUS }
   );
   if (enrollmentError) return enrollmentError;
 
@@ -975,8 +1004,7 @@ mfaRoutes.post('/mfa/enable', authMiddleware, zValidator('json', mfaEnableWithSt
       email: auth.user.email,
       details: { phase: 'setup_confirmation' }
     });
-    const message = 'Invalid MFA code';
-    return c.json({ error: message, message }, 401);
+    return rejectProof(c, 'Invalid MFA code', MFA_CODE_INVALID, MFA_PROOF_REJECTION_STATUS);
   }
 
   // Terminal factor write: NOW consume the grant (single-use). Re-checks the
@@ -1003,7 +1031,7 @@ mfaRoutes.post('/mfa/enable', authMiddleware, zValidator('json', mfaEnableWithSt
     c,
     auth,
     { ssoReauthGrantId },
-    { keyPrefix: 'mfa:pwd', consume: true, passwordAlreadyProven: true }
+    { keyPrefix: 'mfa:pwd', consume: true, passwordAlreadyProven: true, rejectionStatus: MFA_PROOF_REJECTION_STATUS }
   );
   if (enrollmentConsumeError) return enrollmentConsumeError;
 
@@ -1143,7 +1171,9 @@ mfaRoutes.post('/mfa/step-up', authMiddleware, zValidator('json', mfaStepUpSchem
       .where(eq(users.id, auth.user.id))
       .limit(1);
     if (!u?.mfaEnabled || u.mfaMethod !== 'sms' || u.phoneVerified !== true || !u.phoneNumber) {
-      return c.json({ error: 'Invalid credentials' }, 401);
+      // Same response as a wrong code below — a distinguishable rejection here
+      // would tell an attacker which factor the account actually holds.
+      return rejectProof(c, 'Invalid credentials', MFA_PROOF_INVALID, MFA_PROOF_REJECTION_STATUS);
     }
     const twilio = getTwilioService();
     if (!twilio) return c.json({ error: 'SMS not available' }, 400);
@@ -1165,7 +1195,7 @@ mfaRoutes.post('/mfa/step-up', authMiddleware, zValidator('json', mfaStepUpSchem
       email: auth.user.email,
       details: { method: body.method }
     });
-    return c.json({ error: 'Invalid credentials' }, 401);
+    return rejectProof(c, 'Invalid credentials', MFA_PROOF_INVALID, MFA_PROOF_REJECTION_STATUS);
   }
 
   const epochs = await getUserEpochs(auth.user.id);
@@ -1207,7 +1237,9 @@ mfaRoutes.post('/mfa/recovery-codes', authMiddleware, zValidator('json', passwor
   const auth = c.get('auth');
   const { currentPassword } = c.req.valid('json');
 
-  const passwordError = await requireCurrentPasswordStepUp(c, auth.user.id, currentPassword, 'mfa:pwd');
+  const passwordError = await requireCurrentPasswordStepUp(c, auth.user.id, currentPassword, 'mfa:pwd', {
+    rejectionStatus: MFA_PROOF_REJECTION_STATUS,
+  });
   if (passwordError) return passwordError;
 
   const [user] = await db

--- a/apps/api/src/routes/auth/passkeys.ts
+++ b/apps/api/src/routes/auth/passkeys.ts
@@ -228,10 +228,17 @@ passkeyRoutes.post('/passkeys/register/verify', authMiddleware, zValidator('json
     });
   } catch (err) {
     if (err instanceof PasskeyChallengeError) {
-      // #4470: a rejected/expired REGISTRATION CHALLENGE, not a dead bearer.
-      // The challenge is single-use, so refresh-and-replaying this body could
-      // only ever fail again — and on the settings page that logged the user
-      // out for it.
+      // #4470: the registration challenge could not be redeemed — usually
+      // because it is missing or expired. Whatever the cause, it is not a dead
+      // bearer, and the challenge is single-use, so refresh-and-replaying this
+      // body could only ever fail again. On the settings page that 401 logged
+      // the user out for it.
+      //
+      // `PasskeyChallengeError` also covers "Redis unavailable" and a corrupt
+      // record, which are infra failures rather than rejected proofs and would
+      // be better served by a 503. That conflation predates this change (they
+      // shared the old 401 too) and is left for a follow-up — 400 at least
+      // keeps the user signed in where 401 did not.
       return rejectProof(c, err.message, MFA_PROOF_INVALID, PASSKEY_PROOF_REJECTION_STATUS);
     }
     throw err;

--- a/apps/api/src/routes/auth/passkeys.ts
+++ b/apps/api/src/routes/auth/passkeys.ts
@@ -55,6 +55,8 @@ import {
   requireCurrentPasswordStepUp,
   resolveCurrentUserTokenContext,
   resolveEnrollmentStepUp,
+  rejectProof,
+  MFA_PROOF_INVALID,
   installAuthorizedUserSessionCookies,
   installLegacyUserSessionCookiesDuringTransition,
   toPublicTokens,
@@ -159,6 +161,23 @@ passkeyRoutes.get('/passkeys', authMiddleware, async (c) => {
   return c.json({ passkeys: rows.map(toPublicPasskey) });
 });
 
+/**
+ * #4470: the AUTHENTICATED passkey factor-management routes
+ * (`/passkeys/register/options`, `/passkeys/register/verify`,
+ * `DELETE /passkeys/:id`) answer a rejected proof with 400, exactly like
+ * `./mfa.ts`. `ProfilePage.handleAddPasskey` / `handleDeletePasskey` call all
+ * three through `fetchWithAuth` with no opt-out and no status branch, so while
+ * these answered 401 a mistyped step-up password — or a stale registration
+ * challenge — was handed to the generic refresh-and-replay path and could sign
+ * the user out mid-enrollment. Same bug, same fix.
+ *
+ * The LOGIN-time passkey routes further down (`/mfa/passkey/options`,
+ * `/mfa/passkey/verify`) deliberately keep their 401s: they are pre-session,
+ * scoped to a `tempToken` rather than a bearer, and are reached with a plain
+ * `fetch` that has no refresh path to mislead.
+ */
+const PASSKEY_PROOF_REJECTION_STATUS = 400;
+
 passkeyRoutes.post('/passkeys/register/options', authMiddleware, zValidator('json', registerOptionsSchema), async (c) => {
   if (!ENABLE_2FA) {
     return mfaDisabledResponse(c);
@@ -174,7 +193,7 @@ passkeyRoutes.post('/passkeys/register/options', authMiddleware, zValidator('jso
     c,
     auth,
     { currentPassword, ssoReauthGrantId },
-    { keyPrefix: 'passkey:pwd', consume: false }
+    { keyPrefix: 'passkey:pwd', consume: false, rejectionStatus: PASSKEY_PROOF_REJECTION_STATUS }
   );
   if (enrollmentError) return enrollmentError;
 
@@ -209,7 +228,11 @@ passkeyRoutes.post('/passkeys/register/verify', authMiddleware, zValidator('json
     });
   } catch (err) {
     if (err instanceof PasskeyChallengeError) {
-      return c.json({ error: err.message }, 401);
+      // #4470: a rejected/expired REGISTRATION CHALLENGE, not a dead bearer.
+      // The challenge is single-use, so refresh-and-replaying this body could
+      // only ever fail again — and on the settings page that logged the user
+      // out for it.
+      return rejectProof(c, err.message, MFA_PROOF_INVALID, PASSKEY_PROOF_REJECTION_STATUS);
     }
     throw err;
   }
@@ -224,7 +247,7 @@ passkeyRoutes.post('/passkeys/register/verify', authMiddleware, zValidator('json
       email: auth.user.email,
       details: { method: 'passkey' }
     });
-    return c.json({ error: 'Passkey registration failed' }, 401);
+    return rejectProof(c, 'Passkey registration failed', MFA_PROOF_INVALID, PASSKEY_PROOF_REJECTION_STATUS);
   }
 
   const fields = registrationInfoToPasskeyFields(verification, credential);
@@ -244,7 +267,7 @@ passkeyRoutes.post('/passkeys/register/verify', authMiddleware, zValidator('json
     c,
     auth,
     { ssoReauthGrantId },
-    { keyPrefix: 'passkey:pwd', consume: true, passwordAlreadyProven: true }
+    { keyPrefix: 'passkey:pwd', consume: true, passwordAlreadyProven: true, rejectionStatus: PASSKEY_PROOF_REJECTION_STATUS }
   );
   if (enrollmentConsumeError) return enrollmentConsumeError;
 
@@ -853,7 +876,9 @@ passkeyRoutes.delete('/passkeys/:id', authMiddleware, zValidator('json', deleteP
     return c.json({ error: 'MFA verification is required to delete a passkey' }, 403);
   }
 
-  const passwordError = await requireCurrentPasswordStepUp(c, auth.user.id, currentPassword, 'passkey:pwd');
+  const passwordError = await requireCurrentPasswordStepUp(c, auth.user.id, currentPassword, 'passkey:pwd', {
+    rejectionStatus: PASSKEY_PROOF_REJECTION_STATUS,
+  });
   if (passwordError) return passwordError;
 
   const [passkey] = await findOwnedPasskey(id, auth.user.id);

--- a/apps/api/src/routes/auth/phone.test.ts
+++ b/apps/api/src/routes/auth/phone.test.ts
@@ -428,7 +428,7 @@ describe('phone routes', () => {
 
       const res = await send();
 
-      expect(res.status).toBe(401);
+      expect(res.status).toBe(400);
       expect(redis.del).not.toHaveBeenCalled();
       expect(sendVerificationCode).not.toHaveBeenCalled();
     });
@@ -454,7 +454,7 @@ describe('phone routes', () => {
 
       const res = await send();
 
-      expect(res.status).toBe(401);
+      expect(res.status).toBe(400);
       expect(redis.del).toHaveBeenCalledWith('mfa:pending:temp-token');
       expect(sendVerificationCode).not.toHaveBeenCalled();
     });
@@ -639,7 +639,7 @@ describe('phone routes', () => {
         }),
       });
 
-      expect(res.status).toBe(401);
+      expect(res.status).toBe(400);
       // Only the non-consuming validate ran — the grant is still spendable.
       expect(enforceExistingFactorStepUp).toHaveBeenCalledTimes(1);
       expect(enforceExistingFactorStepUp).toHaveBeenCalledWith(

--- a/apps/api/src/routes/auth/phone.ts
+++ b/apps/api/src/routes/auth/phone.ts
@@ -44,7 +44,19 @@ import {
   auditUserLoginFailure,
   installAuthorizedUserSessionCookies,
   toPublicTokens,
+  rejectProof,
+  MFA_CODE_INVALID,
 } from './helpers';
+
+/**
+ * #4470: same contract as `./mfa.ts` — these are SMS-factor proof endpoints and
+ * a wrong code (or a wrong step-up password) is body data the server refused,
+ * not a dead bearer. 401 here made the web client's generic 401 handler sign
+ * the user out mid-enrollment. The `Invalid or expired MFA session` rejections
+ * below KEEP their 401: the `tempToken` genuinely is the credential that
+ * authenticates a pre-login request.
+ */
+const MFA_PROOF_REJECTION_STATUS = 400;
 import { installAuthBindingReplacement, requestAuthBinding } from './binding';
 
 const { db, withSystemDbAccessContext } = dbModule;
@@ -75,7 +87,9 @@ phoneRoutes.post('/phone/verify', authMiddleware, zValidator('json', phoneVerify
   const auth = c.get('auth');
   const { phoneNumber, currentPassword } = c.req.valid('json');
 
-  const passwordError = await requireCurrentPasswordStepUp(c, auth.user.id, currentPassword, 'mfa:pwd');
+  const passwordError = await requireCurrentPasswordStepUp(c, auth.user.id, currentPassword, 'mfa:pwd', {
+    rejectionStatus: MFA_PROOF_REJECTION_STATUS,
+  });
   if (passwordError) return passwordError;
 
   const twilio = getTwilioService();
@@ -140,7 +154,9 @@ phoneRoutes.post('/phone/confirm', authMiddleware, zValidator('json', phoneConfi
   const auth = c.get('auth');
   const { phoneNumber, code, currentPassword, stepUpGrantId } = c.req.valid('json');
 
-  const passwordError = await requireCurrentPasswordStepUp(c, auth.user.id, currentPassword, 'mfa:pwd');
+  const passwordError = await requireCurrentPasswordStepUp(c, auth.user.id, currentPassword, 'mfa:pwd', {
+    rejectionStatus: MFA_PROOF_REJECTION_STATUS,
+  });
   if (passwordError) return passwordError;
 
   // SR2-20/C1: replacing/verifying the phone on an ALREADY-PROTECTED account is
@@ -195,7 +211,7 @@ phoneRoutes.post('/phone/confirm', authMiddleware, zValidator('json', phoneConfi
       email: auth.user.email,
       details: { phoneLast4: phoneNumber.slice(-4) }
     });
-    return c.json({ error: 'Invalid verification code' }, 401);
+    return rejectProof(c, 'Invalid verification code', MFA_CODE_INVALID, MFA_PROOF_REJECTION_STATUS);
   }
 
   // Terminal phone write: NOW consume the grant (single-use). Re-checks the
@@ -264,7 +280,9 @@ phoneRoutes.post('/mfa/sms/enable', authMiddleware, zValidator('json', smsMfaEna
   const auth = c.get('auth');
   const { currentPassword, stepUpGrantId } = c.req.valid('json');
 
-  const passwordError = await requireCurrentPasswordStepUp(c, auth.user.id, currentPassword, 'mfa:pwd');
+  const passwordError = await requireCurrentPasswordStepUp(c, auth.user.id, currentPassword, 'mfa:pwd', {
+    rejectionStatus: MFA_PROOF_REJECTION_STATUS,
+  });
   if (passwordError) return passwordError;
 
   // SR2-20: adding a factor to an ALREADY-PROTECTED account additionally
@@ -478,7 +496,7 @@ phoneRoutes.post('/mfa/sms/send', zValidator('json', smsSendSchema), async (c) =
       reason: 'mfa_method_not_allowed',
       details: { method: 'sms', phase: methodVerdict.reason, continuation: 'send' },
     });
-    return c.json({ error: 'Invalid MFA code' }, 401);
+    return rejectProof(c, 'Invalid MFA code', MFA_CODE_INVALID, MFA_PROOF_REJECTION_STATUS);
   }
   const phoneNumber = smsUser.phoneNumber!;
 

--- a/apps/docs/src/content/docs/reference/users-and-roles.mdx
+++ b/apps/docs/src/content/docs/reference/users-and-roles.mdx
@@ -214,8 +214,22 @@ If the primary method is `totp` or `sms` but `passkeyAvailable` is `true`, the u
 
 MFA verification is rate-limited separately from login.
 
-<Aside type="caution" title="Integrators: a wrong code and an expired session share a status code">
-  A wrong six-digit code and an expired or invalid `tempToken` both return **`401`**. Do not branch on the status code alone — a client that treats every `401` here as "session expired" will silently restart the login flow when the user simply mistyped a digit. Distinguish them by the response body: a bad code returns `{ "error": "Invalid MFA code" }`, while a dead session returns `{ "error": "Invalid or expired MFA session" }`.
+<Aside type="note" title="Integrators: a wrong code and an expired session have different status codes">
+  A **rejected proof** — a wrong six-digit code, a wrong recovery code, or a wrong step-up password — returns **`400`** with a stable machine-readable `code`:
+
+  ```json
+  { "error": "Invalid MFA code", "message": "Invalid MFA code", "code": "mfa_code_invalid" }
+  ```
+
+  A **dead credential** — an expired or invalid `tempToken`, or an expired bearer token — returns **`401`**:
+
+  ```json
+  { "error": "Invalid or expired MFA session" }
+  ```
+
+  Branch on the status code, and on `code` when you need the specific reason. `401` from these endpoints means "re-authenticate"; it never means "you mistyped a digit". The codes in use are `mfa_code_invalid` (wrong TOTP/SMS/recovery code), `mfa_proof_invalid` (a rejected `POST /auth/mfa/step-up` factor proof), and `invalid_credentials` (a rejected step-up password or enrollment grant). Never branch on the human-readable `error`/`message` text — it is not part of the contract.
+
+  This applies to `/auth/mfa/*` and `/auth/phone/*`. Earlier releases answered `401` for both cases, which is why a client that auto-refreshes on `401` could sign the user out mid-enrollment for a mistyped digit.
 </Aside>
 
 ### Disabling MFA

--- a/apps/web/src/components/settings/ApproverDevicesSection.test.tsx
+++ b/apps/web/src/components/settings/ApproverDevicesSection.test.tsx
@@ -127,6 +127,32 @@ describe('ApproverDevicesSection', () => {
     expect((screen.getByTestId('approver-device-label-input') as HTMLInputElement).value).toBe('My workstation');
   });
 
+  // #4470: the TOTP/passkey tiers mint through POST /auth/mfa/step-up, which
+  // now rejects a bad proof with 400 + `code: 'mfa_proof_invalid'` instead of
+  // a 401. Without a branch on the code this would fall through to the raw
+  // server string and lose the tier-specific copy.
+  it.each([
+    ['totp' as const, 'mfa_proof_invalid', 'Incorrect code.'],
+    ['password' as const, 'invalid_credentials', 'Incorrect password.'],
+  ])('maps the #4470 400 proof rejection for the %s tier', async (tier, code, expected) => {
+    const err = Object.assign(new Error('Invalid credentials'), { status: 400, code });
+    registerApproverDeviceMock.mockRejectedValueOnce(err);
+    render(<ApproverDevicesSection passkeyCount={0} mfaMethod={tier === 'totp' ? 'totp' : null} />);
+    await screen.findByTestId('approver-device-dev-1');
+
+    fireEvent.change(
+      screen.getByTestId(tier === 'totp' ? 'approver-stepup-code' : 'approver-stepup-password'),
+      { target: { value: tier === 'totp' ? '123456' : 'wrong' } },
+    );
+    fireEvent.click(screen.getByTestId('approver-device-register'));
+
+    await waitFor(() => expect(showToastMock).toHaveBeenCalledWith({ type: 'error', message: expected }));
+    expect(showToastMock).not.toHaveBeenCalledWith({
+      type: 'error',
+      message: 'Session expired — reload the page and try again.',
+    });
+  });
+
   it('shows a session-expired error (not "Incorrect password") on a 401 whose message is NOT the credential-failure string', async () => {
     // A rejected bearer token (auth middleware) also 401s, but with a message
     // like "Invalid or expired token" rather than the literal "Invalid

--- a/apps/web/src/components/settings/ApproverDevicesSection.tsx
+++ b/apps/web/src/components/settings/ApproverDevicesSection.tsx
@@ -95,24 +95,32 @@ export default function ApproverDevicesSection({
       return t('approverDevicesSection.registrationCancelled');
     }
     const status = (err as { status?: number })?.status;
-    if (status === 401) {
-      // Because the mint calls use `skipUnauthorizedRetry`, a 401 here is
-      // EITHER a rejected re-auth proof (wrong password/code, burned/replayed
-      // WebAuthn assertion — the handler returns the literal string
-      // "Invalid credentials", see routes/auth/helpers.ts and routes/auth/mfa.ts)
-      // OR a rejected bearer token (auth middleware — various messages, e.g.
-      // "Invalid or expired token"; see middleware/auth.ts). Only the former
-      // is fixed by retyping the same field; the latter needs a page reload.
-      const isCredentialFailure = err instanceof Error && err.message === 'Invalid credentials';
-      if (!isCredentialFailure) return t('approverDevicesSection.sessionExpiredReloadAndTryAgain');
+    const code = (err as { code?: string })?.code;
+
+    // A rejected re-auth PROOF: retyping the same field is what fixes it.
+    //
+    // Two shapes reach here, because the two mint roads sit on different
+    // endpoints:
+    //   - #4470 road: POST /auth/mfa/step-up (TOTP + passkey tiers) now answers
+    //     400 with a stable `code`. Branch on the code — never the message.
+    //   - legacy road: POST /authenticator/register-grant (password tier) still
+    //     answers 401 with the literal string "Invalid credentials", the only
+    //     discriminator it has, since that route has not migrated. A 401 whose
+    //     message is anything else is a rejected BEARER (middleware/auth.ts,
+    //     e.g. "Invalid or expired token") and needs a page reload, not a retype.
+    const isProofRejection =
+      (status === 400 && (code === 'mfa_proof_invalid' || code === 'invalid_credentials'))
+      || (status === 401 && err instanceof Error && err.message === 'Invalid credentials');
+
+    if (isProofRejection) {
       if (tier === 'totp') return t('approverDevicesSection.incorrectCode');
-      // The passkey tier never shows a password field — a credential-failure
-      // 401 here means the WebAuthn assertion itself was rejected
-      // (burned/replayed challenge), not a wrong password, so "Incorrect
-      // password." would be nonsensical.
+      // The passkey tier never shows a password field — a rejection here means
+      // the WebAuthn assertion itself was refused (burned/replayed challenge),
+      // not a wrong password, so "Incorrect password." would be nonsensical.
       if (tier === 'passkey') return t('approverDevicesSection.passkeyVerificationFailed');
       return t('approverDevicesSection.incorrectPassword');
     }
+    if (status === 401) return t('approverDevicesSection.sessionExpiredReloadAndTryAgain');
     if (status === 429) return t('approverDevicesSection.tooManyAttemptsTryAgainInAFewMinutes');
     if (status === 403) {
       // POST /authenticator/register-grant (and the step-up mint) 403 for two

--- a/apps/web/src/components/settings/MFASettings.tsx
+++ b/apps/web/src/components/settings/MFASettings.tsx
@@ -36,8 +36,8 @@ type MFASettingsProps = {
    * It lives only in the parent's React state and the `#ssoReauthGrant=`
    * fragment is stripped at mount, so a reload while the QR is on screen — or
    * a session restore, or opening the page in a second tab — loses it. Without
-   * this the Verify button would post no proof at all, the server would 401,
-   * and the user would be staring at that error on a screen with no password
+   * this the Verify button would post no proof at all, the server would refuse
+   * it, and the user would be staring at that error on a screen with no password
    * field and no way to re-verify. Defaults to `true` so the password road and
    * any caller that does not pass it are unaffected.
    */
@@ -48,8 +48,8 @@ type MFASettingsProps = {
   qrCodeDataUrl?: string;
   recoveryCodes?: string[];
   /**
-   * #4413: resolve to `false` when the write was REJECTED (e.g. the 401 a
-   * mistyped TOTP earns). `undefined` — what a handler that only sets
+   * #4413: resolve to `false` when the write was REJECTED (e.g. the 400
+   * `mfa_code_invalid` a mistyped TOTP earns — #4470). `undefined` — what a handler that only sets
    * `errorMessage` returns — is treated as success, matching `onRequestSetup`
    * and keeping the prop back-compatible. Without a verdict the panel used to
    * collapse on every outcome, discarding a secret the server will never
@@ -264,8 +264,8 @@ export default function MFASettings({
     // the parent supplies the SSO re-auth grant instead, so requiring a
     // non-empty password here would make the Verify button permanently inert.
     // But a passwordless account with NO grant left has no proof at all, and
-    // firing the request anyway just buys a 401 on a screen with nothing to
-    // retry with. Refuse to issue it; the view offers re-verification instead.
+    // firing the request anyway just buys a rejection on a screen with nothing
+    // to retry with. Refuse to issue it; the view offers re-verification instead.
     if (isLoading || isSubmitting || code.length !== DIGIT_COUNT
       || needsSsoReVerify
       || (!isPasswordless && !currentPassword)) {
@@ -298,7 +298,7 @@ export default function MFASettings({
         // #4413: stay on the QR. Leaving this view discards a secret the server
         // will not re-issue, so a mistyped digit would cost a whole re-
         // enrollment — and the password collected at the gate has to survive
-        // with it, or the retry 401s for an entirely different reason.
+        // with it, or the retry is refused for an entirely different reason.
         focusIndex(0);
       }
     }
@@ -903,7 +903,7 @@ export default function MFASettings({
 
         {/* #4018: the single-use grant is gone (reload, restored session, or a
             second tab), so there is no proof left to send. Say so and offer the
-            only thing that fixes it rather than letting the submit 401. */}
+            only thing that fixes it rather than letting the submit be refused. */}
         {needsSsoReVerify && (
           <p data-testid="mfa-sso-grant-lost" className="text-sm text-muted-foreground">
             {t('mFASettings.ssoReauthProofExpired')}

--- a/apps/web/src/components/settings/ProfilePage.mfaEnrollment.test.tsx
+++ b/apps/web/src/components/settings/ProfilePage.mfaEnrollment.test.tsx
@@ -7,11 +7,19 @@ import { fetchWithAuth } from '../../stores/auth';
 /**
  * #4413 — a wrong TOTP during enrollment must NOT fail silently.
  *
- * `POST /auth/mfa/enable` answers 401 `Invalid MFA code` for a mistyped code.
- * The panel used to collapse straight back to the status card and drop the
+ * `POST /auth/mfa/enable` answers `Invalid MFA code` for a mistyped code. The
+ * panel used to collapse straight back to the status card and drop the
  * QR/secret, so a user who fat-fingered one digit was left with a dead
  * authenticator entry, no error, and no way to retry that same secret.
+ *
+ * #4470 changed that rejection's STATUS from 401 to 400 + a stable
+ * `code: 'mfa_code_invalid'`, so it can no longer be mistaken for bearer
+ * expiry by fetchWithAuth. These specs pin the new status end to end and
+ * assert the `skipUnauthorizedRetry` stopgap is gone with it.
  */
+
+/** The API's #4470 rejected-proof body. */
+const rejectedProof = (error: string, code = 'mfa_code_invalid') => ({ error, message: error, code });
 
 vi.mock('../../stores/auth', () => ({
   createPasskeyCredential: vi.fn(),
@@ -79,7 +87,7 @@ describe('ProfilePage — MFA enrollment rejects a wrong TOTP (#4413)', () => {
         return makeJsonResponse({ qrCodeDataUrl: 'data:image/png;base64,abc' });
       }
       if (String(url) === '/auth/mfa/enable') {
-        return makeJsonResponse({ error: 'Invalid MFA code' }, false, 401);
+        return makeJsonResponse(rejectedProof('Invalid MFA code'), false, 400);
       }
       return undefined as unknown as Response;
     });
@@ -92,7 +100,7 @@ describe('ProfilePage — MFA enrollment rejects a wrong TOTP (#4413)', () => {
     fillCode();
     fireEvent.click(screen.getByRole('button', { name: /Verify and enable/i }));
 
-    // The 401 must be VISIBLE, not swallowed.
+    // The rejection must be VISIBLE, not swallowed.
     expect(await screen.findByText(/Invalid MFA code/i)).toBeTruthy();
 
     // ...and the panel must NOT have collapsed back to the status card: the
@@ -119,7 +127,7 @@ describe('ProfilePage — MFA enrollment rejects a wrong TOTP (#4413)', () => {
       );
       expect(enableCalls.length).toBe(2);
       // The password collected at the gate must survive the first rejection,
-      // otherwise the retry 401s for a completely different reason.
+      // otherwise the retry is refused for a completely different reason.
       expect(JSON.parse(String(enableCalls[1][1]?.body)))
         .toEqual({ code: '654321', currentPassword: 'hunter2-pw' });
     });
@@ -131,7 +139,7 @@ describe('ProfilePage — MFA enrollment rejects a wrong TOTP (#4413)', () => {
     expect(setupCalls.length).toBe(1);
   });
 
-  it('does not let fetchWithAuth mistake the wrong-code 401 for an expired session', async () => {
+  it('#4470: the wrong-code rejection is a 400 the client renders, with no 401 opt-out flag left', async () => {
     render(<ProfilePage initialUser={BASE_USER} />);
 
     await openEnrollmentPanel();
@@ -139,16 +147,18 @@ describe('ProfilePage — MFA enrollment rejects a wrong TOTP (#4413)', () => {
     fireEvent.click(screen.getByRole('button', { name: /Verify and enable/i }));
     await screen.findByText(/Invalid MFA code/i);
 
-    // A 401 meaning "you typed the wrong digits" must never be handed to the
-    // refresh-and-replay path: that either replays a single-use code or (when
-    // the refresh does not restore) logs the user out mid-enrollment.
+    // "You typed the wrong digits" can no longer reach fetchWithAuth's
+    // refresh-and-replay path, because it is no longer a 401 at all. The
+    // #4413 `skipUnauthorizedRetry` stopgap therefore has to be GONE — a
+    // leftover flag would silently suppress a REAL bearer expiry on the
+    // forced-enrollment page, whose only token comes from that refresh.
     const enableCall = fetchWithAuthMock.mock.calls.find(
       ([url]) => String(url) === '/auth/mfa/enable'
     );
     expect(enableCall).toBeDefined();
     expect(
       (enableCall![1] as { skipUnauthorizedRetry?: boolean } | undefined)?.skipUnauthorizedRetry
-    ).toBe(true);
+    ).toBeUndefined();
   });
 
   it('shows the retry hint on rejection, and clears it on the next enrollment', async () => {
@@ -170,11 +180,11 @@ describe('ProfilePage — MFA enrollment rejects a wrong TOTP (#4413)', () => {
     expect(screen.queryByTestId('mfa-code-rejected-hint')).toBeNull();
   });
 
-  it('keeps the rejected 401 off the refresh-and-replay path for disable and recovery codes', async () => {
+  it('#4470: disable and recovery-codes also drop the opt-out flag and render the 400', async () => {
     fetchWithAuthMock.mockImplementation(async (url) => {
       if (String(url) === '/auth/passkeys') return makeJsonResponse({ passkeys: [] });
       if (String(url) === '/auth/mfa/disable') {
-        return makeJsonResponse({ error: 'Invalid MFA code' }, false, 401);
+        return makeJsonResponse(rejectedProof('Invalid MFA code'), false, 400);
       }
       if (String(url) === '/auth/mfa/recovery-codes') {
         return makeJsonResponse({ recoveryCodes: ['NEW-0001'] });
@@ -198,7 +208,7 @@ describe('ProfilePage — MFA enrollment rejects a wrong TOTP (#4413)', () => {
       expect(call).toBeDefined();
       expect(
         (call![1] as { skipUnauthorizedRetry?: boolean } | undefined)?.skipUnauthorizedRetry
-      ).toBe(true);
+      ).toBeUndefined();
     });
     expect(await screen.findByText('NEW-0001')).toBeTruthy();
 
@@ -220,7 +230,7 @@ describe('ProfilePage — MFA enrollment rejects a wrong TOTP (#4413)', () => {
       expect(call).toBeDefined();
       expect(
         (call![1] as { skipUnauthorizedRetry?: boolean } | undefined)?.skipUnauthorizedRetry
-      ).toBe(true);
+      ).toBeUndefined();
     });
     expect(await screen.findByText(/Invalid MFA code/i)).toBeTruthy();
   });

--- a/apps/web/src/components/settings/ProfilePage.tsx
+++ b/apps/web/src/components/settings/ProfilePage.tsx
@@ -785,6 +785,10 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
         ? { ssoReauthGrantId }
         : { currentPassword: passkeyPassword };
       const verifyProof = isPasswordless ? { ssoReauthGrantId } : {};
+      // #4470: `/auth/passkeys/register/{options,verify}` and the delete below
+      // answer a rejected step-up password (or a stale registration challenge)
+      // with 400 + a stable `code`, so these calls need no 401 opt-out — a 401
+      // from them now means only that the bearer expired, which SHOULD refresh.
       const optionsResponse = await fetchWithAuth('/auth/passkeys/register/options', {
         method: 'POST',
         body: JSON.stringify({ ...optionsProof, name: label })

--- a/apps/web/src/components/settings/ProfilePage.tsx
+++ b/apps/web/src/components/settings/ProfilePage.tsx
@@ -651,13 +651,11 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
           : {};
       const response = await fetchWithAuth('/auth/mfa/enable', {
         method: 'POST',
-        // #4413: this endpoint answers 401 for "that TOTP is wrong", not for
-        // "your bearer expired". Handing that to fetchWithAuth's generic 401
-        // path either replays a single-use code or — when the refresh does not
-        // restore — signs the user out mid-enrollment (auth.ts handleSessionExpired).
-        // Take the raw 401 and render it ourselves. The durable fix is on the
-        // API side (400/422 + a stable code for a rejected factor proof).
-        skipUnauthorizedRetry: true,
+        // #4470 landed the durable API-side fix the #4413 stopgap was waiting
+        // for: a rejected TOTP or step-up proof is now 400 + a stable `code`,
+        // so it never reaches fetchWithAuth's 401 refresh-and-evict path and
+        // the opt-out flag is no longer needed. A 401 from here now means only
+        // "your bearer expired", which SHOULD refresh.
         body: JSON.stringify({ code, ...proof })
       });
 
@@ -694,8 +692,6 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
       setMfaLoading(true);
       const response = await fetchWithAuth('/auth/mfa/disable', {
         method: 'POST',
-        // Same overloaded 401 as /mfa/enable above — see the comment there.
-        skipUnauthorizedRetry: true,
         body: JSON.stringify({ code, currentPassword })
       });
 
@@ -731,9 +727,6 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
       setMfaLoading(true);
       const response = await fetchWithAuth('/auth/mfa/recovery-codes', {
         method: 'POST',
-        // Same overloaded 401 as /mfa/enable above — a wrong password here is a
-        // rejected proof, not an expired session.
-        skipUnauthorizedRetry: true,
         body: JSON.stringify({ currentPassword })
       });
 

--- a/apps/web/src/stores/auth.test.ts
+++ b/apps/web/src/stores/auth.test.ts
@@ -2325,14 +2325,18 @@ describe('MFA enrollment API bindings', () => {
     });
   });
 
-  // #4413: /auth/mfa/enable answers 401 for "that TOTP is wrong", which is not
-  // an expired bearer. Letting fetchWithAuth's generic 401 path have it either
-  // replays the code or — on the forced-enrollment page, where the user has
-  // nowhere else to go — signs them out for a typo.
-  it('treats a wrong-code 401 as a rejection, not an expired session', async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValue(makeResponse({ error: 'Invalid MFA code' }, false, 401));
+  // #4470 (was #4413): /auth/mfa/enable now answers 400 + `code:
+  // 'mfa_code_invalid'` for "that TOTP is wrong", so a typo can no longer
+  // reach fetchWithAuth's 401 refresh-and-evict path at all. This replaces the
+  // client-side `skipUnauthorizedRetry` stopgap: the status itself carries the
+  // distinction now, so a NEW caller cannot re-inherit the logout bug by
+  // forgetting a flag.
+  it('treats a wrong-code 400 as a rejection: no refresh, no replay, still signed in', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeResponse(
+      { error: 'Invalid MFA code', message: 'Invalid MFA code', code: 'mfa_code_invalid' },
+      false,
+      400,
+    ));
     vi.stubGlobal('fetch', fetchMock);
 
     await expect(apiEnableTotpMfa('123456', 'password')).resolves.toEqual({
@@ -2341,6 +2345,34 @@ describe('MFA enrollment API bindings', () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(1); // no refresh, no replay
+    expect(refreshCallsOf(fetchMock)).toHaveLength(0);
+    expect(useAuthStore.getState().isAuthenticated).toBe(true);
+    expect(useAuthStore.getState().sessionExpiredReason).toBeNull();
+    // The stopgap flag is gone WITH the overloaded status, not instead of it.
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit & { skipUnauthorizedRetry?: boolean }];
+    expect(init.skipUnauthorizedRetry).toBeUndefined();
+  });
+
+  // The other half of #4470: dropping the opt-out flag is only safe because a
+  // 401 from this endpoint now means ONLY "your bearer is dead" — and that
+  // still has to refresh and replay, or the forced-enrollment page (which
+  // always loads with an empty in-memory token) can never complete.
+  it('a genuine bearer 401 from /auth/mfa/enable still refreshes and replays', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(makeResponse({ error: 'Unauthorized' }, false, 401))
+      .mockResolvedValueOnce(makeResponse({ tokens: { accessToken: 'fresh', expiresInSeconds: 900 } }, true, 200))
+      .mockResolvedValueOnce(makeResponse({
+        success: true,
+        recoveryCodes: ['RC-ONE'],
+        tokens: { accessToken: 'replacement', expiresInSeconds: 900 },
+      }, true, 200));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(apiEnableTotpMfa('123456', 'password')).resolves.toMatchObject({ success: true });
+
+    expect(refreshCallsOf(fetchMock)).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(useAuthStore.getState().isAuthenticated).toBe(true);
   });
 

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -2044,11 +2044,13 @@ export async function apiEnableTotpMfa(code: string, currentPassword: string): P
   try {
     const response = await fetchWithAuth('/auth/mfa/enable', {
       method: 'POST',
-      // #4413: a rejected TOTP comes back as 401, same status the bearer guard
-      // uses. Without this the generic 401 path replays the code, or evicts the
-      // session outright — on the forced-enrollment page that strands the user
-      // with no way back in. The caller already renders the raw error.
-      skipUnauthorizedRetry: true,
+      // #4470: no `skipUnauthorizedRetry` here any more. The API now answers a
+      // rejected TOTP (or a rejected step-up password) with 400 +
+      // `code: 'mfa_code_invalid'` / `'invalid_credentials'`, so a typo can no
+      // longer reach fetchWithAuth's 401 refresh-and-evict path at all. A 401
+      // from this endpoint now means only what it says — the bearer is dead —
+      // and refreshing it is the right response. The #4413 stopgap flag is
+      // gone with the status it was working around.
       body: JSON.stringify({ code, currentPassword }),
     });
     const data = await response.json().catch(() => null);

--- a/apps/web/src/stores/authenticator.ts
+++ b/apps/web/src/stores/authenticator.ts
@@ -39,16 +39,28 @@ export type RegisterReauth =
 
 class RegisterStepError extends Error {
   status?: number;
-  constructor(message: string, status?: number) {
+  /**
+   * #4470: the API's stable machine code for a rejected proof
+   * (`mfa_proof_invalid`, `invalid_credentials`, ...). Carried through so the
+   * UI can branch on it instead of string-matching the human message, which
+   * was the only discriminator available while every rejection was a 401.
+   */
+  code?: string;
+  constructor(message: string, status?: number, code?: string) {
     super(message);
     this.status = status;
+    this.code = code;
   }
 }
 
 async function jsonOrThrow(response: Response, fallback: string): Promise<any> {
   if (!response.ok) {
     const data = await response.json().catch(() => null);
-    throw new RegisterStepError(data?.error ?? fallback, response.status);
+    throw new RegisterStepError(
+      data?.error ?? fallback,
+      response.status,
+      typeof data?.code === 'string' ? data.code : undefined,
+    );
   }
   // A 2xx with an unparseable body (empty body, truncated proxy response) must
   // not silently resolve to `null` — every caller immediately reads a field
@@ -105,9 +117,11 @@ async function mintRegisterGrant(reauth: RegisterReauth): Promise<string> {
     await fetchWithAuth('/auth/mfa/step-up', {
       method: 'POST',
       body: JSON.stringify(stepUpBody),
-      // Same reasoning: a 401 means the TOTP code / passkey assertion was
-      // rejected (wrong code, or the assertion is already burned), not that
-      // the access token is stale — never replay it.
+      // #4470 moved a REJECTED proof here to 400 + `code: 'mfa_proof_invalid'`,
+      // so a 401 no longer means "wrong code". The opt-out stays anyway for the
+      // reason the flag actually documents: the passkey body carries a
+      // single-use WebAuthn assertion the server has already burned, and
+      // replaying it after a refresh can only fail again.
       skipUnauthorizedRetry: true,
     }),
     'Verification failed.'

--- a/apps/web/src/stores/authenticator.ts
+++ b/apps/web/src/stores/authenticator.ts
@@ -117,12 +117,13 @@ async function mintRegisterGrant(reauth: RegisterReauth): Promise<string> {
     await fetchWithAuth('/auth/mfa/step-up', {
       method: 'POST',
       body: JSON.stringify(stepUpBody),
-      // #4470 moved a REJECTED proof here to 400 + `code: 'mfa_proof_invalid'`,
-      // so a 401 no longer means "wrong code". The opt-out stays anyway for the
-      // reason the flag actually documents: the passkey body carries a
-      // single-use WebAuthn assertion the server has already burned, and
-      // replaying it after a refresh can only fail again.
-      skipUnauthorizedRetry: true,
+      // #4470: no opt-out here any more. A rejected proof is now 400
+      // `mfa_proof_invalid`, and the handler has no 401 path left at all — so
+      // every 401 from this endpoint comes from `authMiddleware`, BEFORE the
+      // handler runs. The passkey assertion in this body is therefore still
+      // unburned, and refreshing the bearer and replaying it is exactly right.
+      // Keeping the flag would instead have signed the user out for an access
+      // token that simply aged out mid-ceremony.
     }),
     'Verification failed.'
   );


### PR DESCRIPTION
Closes #4470

## The bug

`POST /auth/mfa/enable` — and every sibling proof endpoint — answered a wrong TOTP with **401**, the same status the bearer guard uses. `fetchWithAuth` (`apps/web/src/stores/auth.ts`) hands any 401 to refresh-and-replay → `handleSessionExpired` → logout + redirect. One mistyped digit signed the user out mid-enrollment (the mechanism behind #4413/#4414).

PR #4439 stopped the bleeding client-side with `skipUnauthorizedRetry` on the MFA calls. That flag is a trap: **any new caller that forgets it re-inherits the logout.** This is the server-side fix it was waiting for.

## The contract

On `/auth/mfa/*` and `/auth/phone/*`, a **rejected proof** — the TOTP/SMS/recovery code or the step-up password the user typed *into the request body* — now answers **400** with `{ error, message, code }`:

| `code` | meaning |
|---|---|
| `mfa_code_invalid` | wrong TOTP / SMS / recovery code |
| `mfa_proof_invalid` | rejected `POST /auth/mfa/step-up` factor proof (TOTP, SMS, passkey) |
| `invalid_credentials` | rejected step-up password or enrollment grant |

**401 is reserved** for "the credential authenticating *this* request is dead":

- the bearer guard (`authMiddleware`),
- the login challenge's `tempToken` — `{ error: 'Invalid or expired MFA session' }`,
- `{ error: 'sso_link_expired' }`.

Those bodies are **unchanged**, so the login page can still tell "retype your code" from "start the login over". A new test pins that: a dead `tempToken` still 401s.

Clients must branch on `code`, never on the human `error`/`message` text.

## Scope control (why this isn't a 7-route breaking change)

`requireCurrentPasswordStepUp` / `requireFreshMfaStepUp` / `resolveEnrollmentStepUp` are shared by 7 route files. They now take an opt-in `rejectionStatus` that **defaults to 401**, so `approvals`, `pam`, `users` (email change) and `authenticator` keep the contract their clients already key on — notably mobile `approvals.ts`, which maps a 401 decision to `STEP_UP_FAILED`. Only the **factor-management** routes opt in: `/auth/mfa/*`, `/auth/phone/*`, and the authenticated passkey routes.

Those unchanged callers **do** gain `message` + `code` in the body at the same 401. That is the one wire change outside the MFA routes.

Rejections stay **uniform per call site**: `enrollment_proof_required` follows the same status as its siblings, because a status that differed there would re-open the password-vs-passwordless oracle the #4018 opacity rule exists to close. It is the uniformity that closes the oracle, not the particular number.

## Client changes

- Dropped `skipUnauthorizedRetry` from the three MFA calls in the web app. A 401 from those endpoints now means *only* "your bearer expired" — which **should** refresh; the forced-enrollment page has no other way to get a token. A test pins both halves: a 400 never refreshes, a 401 still does.
- `ApproverDevicesSection` branched on `status === 401` + a string match on `'Invalid credentials'` to pick its tier-specific copy ("Incorrect code." / "Incorrect password." / passkey). `/auth/mfa/step-up` moving to 400 would have silently degraded that to the raw server string. It now branches on the stable `code` (plumbed through `RegisterStepError`) and keeps the 401 branch for `/authenticator/register-grant`, which has **not** migrated.
- `authenticator.ts` keeps `skipUnauthorizedRetry` on `/auth/mfa/step-up` — justified now by the reason the flag actually documents (the passkey body carries a single-use WebAuthn assertion), not by the overloaded status.

Also fixes the same latent logout on **`/auth/mfa/setup`, `/auth/phone/verify`, `/auth/phone/confirm`, `/auth/mfa/sms/enable`, `/auth/passkeys/register/options`, `/auth/passkeys/register/verify` and `DELETE /auth/passkeys/:id`** — none of which ever carried the client-side flag, so a wrong password there logs users out on `main` today.

The **login-time** passkey routes (`/auth/mfa/passkey/options`, `/auth/mfa/passkey/verify`) deliberately keep their 401s: pre-session, `tempToken`-scoped, and reached with a plain `fetch` that has no refresh path to mislead.

## Design note

Consequential API-surface change, so it went through the advisor quorum (CLAUDE.md): independent read-only Codex review agreed on 400-over-422 (matches `zValidator`'s existing 400), on the `{error, message, code}` body, on keeping the login-path `tempToken` rejection at 401, and on the opt-in default for the shared helpers.

Codex also ranked a transport-level discriminator higher long-term — `authMiddleware` emitting `WWW-Authenticate: Bearer` and `fetchWithAuth`/`runAction` refreshing only on *that*, which would immunise every remaining application-level 401 in the app (approvals, PAM, passkey enrollment). **Deliberately not in this PR**: it inverts the refresh path app-wide, and if the header is ever lost (CORS `Access-Control-Expose-Headers`, a proxy) token refresh silently stops working everywhere — a worse failure than the bug being fixed. Worth its own issue.

## Audit-trail note

The global fallback-audit middleware (`apps/api/src/index.ts`) classifies 401/403 as `denied` and other 4xx as `failure`, so these rejections shift `denied` → `failure` on the *fallback* row. The explicit `writeAuthAudit` rows these handlers already emit (`auth.mfa.setup.failed` / `auth.mfa.disable.failed`, reason `invalid_mfa_code`) were and remain `failure`, and nothing alerts on the fallback `denied` (the only `result = 'denied'` query in the repo is scoped to `action = 'agent.enroll'`).

## Docs

`apps/docs/.../users-and-roles.mdx` carried a public `<Aside type="caution">` telling integrators that a wrong code and an expired session **share** a 401 and must be told apart by message text. That is now false and is rewritten to document the split plus the `code` values.

## Tests

- **New #4470 contract block** (`auth.test.ts`, 8 tests): wrong TOTP on enable, wrong password on enable/setup/recovery-codes, wrong code on disable, rejected step-up proof — each asserting the exact `code` — plus the negative control that a dead `tempToken` still answers 401.
- **New login-path test** for `/auth/mfa/verify` with a wrong TOTP. That branch had **no coverage at all** before. It also asserts the pending challenge **survives** the typo and the same `tempToken` completes on the correct code.
- **New `ApproverDevicesSection` case** for the 400 → tier-specific-copy mapping.
- **New web-store tests**: a 400 never refreshes and never sets `sessionExpiredReason`; a genuine 401 from the same endpoint still refreshes and replays.
- `recoveryCode.integration.test.ts` identical-code race updated (loser is now 400 `mfa_code_invalid`).
- 26 pre-existing assertions moved to the new statuses/bodies. **No assertion was weakened, skipped, or deleted** — every `toEqual` stayed a `toEqual` and gained the new fields explicitly.

## Review round (findings addressed in `e6244a7`)

Two independent Sonnet reviews ran — one adversarial security lens (enumeration/opacity, skipped side effects, rate limiting, disclosure, replay safety) and one correctness/silent-failure lens.

Security review: **no HIGH findings.** It confirmed the #4018 opacity rule survives (every `resolveEnrollmentStepUp` exit shares one status per call site, `enrollment_proof_required` included), the C1 swapped-phone defense on `/mfa/step-up` still returns an identical response for "no active SMS factor" and "wrong code", every converted site still returns early / still audits / still refuses to burn a grant, TOTP time-step, recovery code or pending-MFA key, rate-limiter ordering is unchanged, and no unmigrated call site gained a new discriminator.

Correctness review raised **one HIGH, now fixed**: `passkeys.ts` still 401'd rejected proofs on the three authenticated passkey routes, which `ProfilePage` calls through `fetchWithAuth` completely unguarded — the exact bug this PR exists to remove. Migrated, plus three LOWs (uniform `requireFreshMfaStepUp` body, the now-unnecessary `/auth/mfa/step-up` client opt-out, and stale `openapi.ts` response lists).

One review note deliberately **not** actioned: `ApproverDevicesSection`'s catch-all for "400 with no `code`" surfaces the server string rather than localized copy. No live path reaches it (every 400 from those two mint endpoints sets `code`), and for the ones that could — a zod validation 400, the `agent_rollback` binding 400 — showing the server's message is the correct behaviour, not a degradation.

**Verification (after the review round):** `apps/api` auth-adjacent suites **947/947** pass; `apps/web` stores + settings + lib **2321/2321** pass; `tsc --noEmit` clean in both `apps/api` and `apps/web`; `pnpm lint` clean. Verified on a base with current `origin/main` (7d5ebb4f3) merged in.

## Overlap with #4480

A sibling fix is in flight on #4480 (recovery-code regeneration + `mfa_epoch`). Contact points, both small:

- `POST /auth/mfa/recovery-codes` — this PR touches only its `requireCurrentPasswordStepUp` call (adds the `rejectionStatus` option); the rotation body is untouched.
- `mfa.ts` recovery-code rejection sites (`RecoveryCodeInvalidError`) — status/body only, no logic change.

Whichever lands second should expect a trivial conflict in those two spots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
