### PR TITLE
test(web): scope AiUsagePage test queries to their own render container (#4601)

### DIFF
--- a/apps/web/src/components/settings/AiUsagePage.test.tsx
+++ b/apps/web/src/components/settings/AiUsagePage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { fireEvent, render, screen, waitFor, act } from '@testing-library/react';
+import { fireEvent, render, within, waitFor, act } from '@testing-library/react';
 
 const fetchWithAuth = vi.fn();
 vi.mock('../../stores/auth', () => ({ fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a) }));
@@ -7,6 +7,20 @@ const orgState: { currentOrgId: string | null } = { currentOrgId: null };
 vi.mock('../../stores/orgStore', () => ({ useOrgStore: () => ({ currentOrgId: orgState.currentOrgId }) }));
 
 import AiUsagePage from './AiUsagePage';
+
+// Every test below scopes its queries to its OWN render's container via
+// `within(container)` instead of the shared `screen` (which binds to
+// `document.body`). Under real suite-order/CPU-load conditions a previous
+// test's `cleanup()` can still be settling when this test's body starts (both
+// are async and RTL's afterEach isn't guaranteed to have unmounted yet), so a
+// global `screen` query can silently match the PRIOR test's still-mounted
+// instance instead of this one. Scoping to `container` makes every query
+// order-independent regardless of how fast a neighbouring test's teardown
+// runs (#4601).
+function renderPage() {
+  const { container, ...utils } = render(<AiUsagePage />);
+  return { container, ...utils, ...within(container) };
+}
 
 function jsonRes(body: unknown, status = 200) {
   return {
@@ -41,43 +55,43 @@ beforeEach(() => {
 describe('AiUsagePage billedTo indicator', () => {
   it('renders the partner-key billing note when usage is billed to the partner key', async () => {
     mockUsage('partner_key');
-    render(<AiUsagePage />);
+    const { getByTestId } = renderPage();
 
-    await waitFor(() => expect(screen.getByTestId('ai-usage-billed-to-note')).toBeInTheDocument());
-    expect(screen.getByTestId('ai-usage-billed-to-note').textContent)
+    await waitFor(() => expect(getByTestId('ai-usage-billed-to-note')).toBeInTheDocument());
+    expect(getByTestId('ai-usage-billed-to-note').textContent)
       .toContain('Billed to your key — AI usage goes to your own Anthropic account, not Breeze AI credits');
   });
 
   it('does not render the note when usage is billed to the platform', async () => {
     mockUsage('platform');
-    render(<AiUsagePage />);
+    const { getByText, queryByTestId } = renderPage();
 
-    await waitFor(() => expect(screen.getByText('Budget Configuration')).toBeInTheDocument());
-    expect(screen.queryByTestId('ai-usage-billed-to-note')).toBeNull();
+    await waitFor(() => expect(getByText('Budget Configuration')).toBeInTheDocument());
+    expect(queryByTestId('ai-usage-billed-to-note')).toBeNull();
   });
 
   it('does not render the note when the response omits billedTo (older API)', async () => {
     mockUsage(undefined);
-    render(<AiUsagePage />);
+    const { getByText, queryByTestId } = renderPage();
 
-    await waitFor(() => expect(screen.getByText('Budget Configuration')).toBeInTheDocument());
-    expect(screen.queryByTestId('ai-usage-billed-to-note')).toBeNull();
+    await waitFor(() => expect(getByText('Budget Configuration')).toBeInTheDocument());
+    expect(queryByTestId('ai-usage-billed-to-note')).toBeNull();
   });
 
   it('names the catalog endpoint when session provenance carries one (#3922 W4)', async () => {
     mockUsage('partner_key', 'OpenRouter');
-    render(<AiUsagePage />);
+    const { getByTestId } = renderPage();
 
-    await waitFor(() => expect(screen.getByTestId('ai-usage-billed-to-note')).toBeInTheDocument());
-    expect(screen.getByTestId('ai-usage-billed-to-note').textContent).toContain('OpenRouter');
+    await waitFor(() => expect(getByTestId('ai-usage-billed-to-note')).toBeInTheDocument());
+    expect(getByTestId('ai-usage-billed-to-note').textContent).toContain('OpenRouter');
   });
 
   it('falls back to the generic partner-key note when no catalog endpoint is named', async () => {
     mockUsage('partner_key', null);
-    render(<AiUsagePage />);
+    const { getByTestId } = renderPage();
 
-    await waitFor(() => expect(screen.getByTestId('ai-usage-billed-to-note')).toBeInTheDocument());
-    expect(screen.getByTestId('ai-usage-billed-to-note').textContent)
+    await waitFor(() => expect(getByTestId('ai-usage-billed-to-note')).toBeInTheDocument());
+    expect(getByTestId('ai-usage-billed-to-note').textContent)
       .toContain('Billed to your key — AI usage goes to your own Anthropic account, not Breeze AI credits');
   });
 });
@@ -97,10 +111,10 @@ describe('AiUsagePage credits stat card (#4388 W04)', () => {
 
   it('renders the credits remaining stat card when usage.credits is present', async () => {
     mockUsageWithCredits({ remaining: 1240, includedBalance: 0, purchasedBalance: 1240, fetchedAt: '2026-09-01T00:00:00.000Z' });
-    render(<AiUsagePage />);
+    const { getByText } = renderPage();
 
-    await waitFor(() => expect(screen.getByText('Breeze AI credits remaining')).toBeInTheDocument());
-    expect(screen.getByText('1,240')).toBeInTheDocument();
+    await waitFor(() => expect(getByText('Breeze AI credits remaining')).toBeInTheDocument());
+    expect(getByText('1,240')).toBeInTheDocument();
   });
 
   // A zero balance is exactly when the card matters most: the object is
@@ -108,26 +122,26 @@ describe('AiUsagePage credits stat card (#4388 W04)', () => {
   // truthiness check on `remaining` would make it.
   it('still renders the card, showing 0, when the balance is exhausted', async () => {
     mockUsageWithCredits({ remaining: 0, includedBalance: 0, purchasedBalance: 0, fetchedAt: '2026-09-01T00:00:00.000Z' });
-    render(<AiUsagePage />);
+    const { getByText } = renderPage();
 
-    await waitFor(() => expect(screen.getByText('Breeze AI credits remaining')).toBeInTheDocument());
-    expect(screen.getByText('0')).toBeInTheDocument();
+    await waitFor(() => expect(getByText('Breeze AI credits remaining')).toBeInTheDocument());
+    expect(getByText('0')).toBeInTheDocument();
   });
 
   it('does not render the credits stat card when usage.credits is null', async () => {
     mockUsageWithCredits(null);
-    render(<AiUsagePage />);
+    const { getByText, queryByText } = renderPage();
 
-    await waitFor(() => expect(screen.getByText('Budget Configuration')).toBeInTheDocument());
-    expect(screen.queryByText('Breeze AI credits remaining')).toBeNull();
+    await waitFor(() => expect(getByText('Budget Configuration')).toBeInTheDocument());
+    expect(queryByText('Breeze AI credits remaining')).toBeNull();
   });
 
   it('does not render the credits stat card when the response omits credits (older API)', async () => {
     mockUsage('platform');
-    render(<AiUsagePage />);
+    const { getByText, queryByText } = renderPage();
 
-    await waitFor(() => expect(screen.getByText('Budget Configuration')).toBeInTheDocument());
-    expect(screen.queryByText('Breeze AI credits remaining')).toBeNull();
+    await waitFor(() => expect(getByText('Budget Configuration')).toBeInTheDocument());
+    expect(queryByText('Breeze AI credits remaining')).toBeNull();
   });
 });
 
@@ -155,7 +169,7 @@ describe('AiUsagePage effective-settings parallel fetch', () => {
       return Promise.resolve(jsonRes({}));
     });
 
-    render(<AiUsagePage />);
+    renderPage();
 
     // Flush a microtask tick without resolving any of the three promises, so
     // this only passes if effective-settings was requested in the same
@@ -208,24 +222,24 @@ describe('AiUsagePage alert threshold ladder', () => {
 
   it('sends alertThresholdPercents: null when the ladder is cleared', async () => {
     mockUsageWithBudget([50, 80, 95]);
-    render(<AiUsagePage />);
+    const { findByTestId, getByTestId } = renderPage();
 
-    const input = await screen.findByTestId('ai-budget-thresholds-input');
+    const input = await findByTestId('ai-budget-thresholds-input');
     fireEvent.change(input, { target: { value: '' } });
     fireEvent.blur(input);
-    fireEvent.click(screen.getByTestId('ai-budget-save'));
+    fireEvent.click(getByTestId('ai-budget-save'));
 
     await waitFor(() => expect(budgetPutBody()).toHaveProperty('alertThresholdPercents', null));
   });
 
   it('sends the edited ladder', async () => {
     mockUsageWithBudget(undefined);
-    render(<AiUsagePage />);
+    const { findByTestId, getByTestId } = renderPage();
 
-    const input = await screen.findByTestId('ai-budget-thresholds-input');
+    const input = await findByTestId('ai-budget-thresholds-input');
     fireEvent.change(input, { target: { value: '60, 90' } });
     fireEvent.blur(input);
-    fireEvent.click(screen.getByTestId('ai-budget-save'));
+    fireEvent.click(getByTestId('ai-budget-save'));
 
     await waitFor(() => expect(budgetPutBody()).toHaveProperty('alertThresholdPercents', [60, 90]));
   });
@@ -235,10 +249,10 @@ describe('AiUsagePage alert threshold ladder', () => {
   // onto the org row as an explicit choice.
   it('omits alertThresholdPercents entirely when the field was never edited', async () => {
     mockUsageWithBudget([50, 80, 95]);
-    render(<AiUsagePage />);
+    const { findByTestId, getByTestId } = renderPage();
 
-    await screen.findByTestId('ai-budget-thresholds-input');
-    fireEvent.click(screen.getByTestId('ai-budget-save'));
+    await findByTestId('ai-budget-thresholds-input');
+    fireEvent.click(getByTestId('ai-budget-save'));
 
     await waitFor(() => expect(budgetPutBody()).toHaveProperty('monthlyBudgetCents', 5000));
     expect(budgetPutBody()).not.toHaveProperty('alertThresholdPercents');
@@ -246,15 +260,15 @@ describe('AiUsagePage alert threshold ladder', () => {
 
   it('disables Save while the ladder text does not parse', async () => {
     mockUsageWithBudget([50, 80, 95]);
-    render(<AiUsagePage />);
+    const { findByTestId, getByTestId } = renderPage();
 
-    const input = await screen.findByTestId('ai-budget-thresholds-input');
-    const save = screen.getByTestId('ai-budget-save') as HTMLButtonElement;
+    const input = await findByTestId('ai-budget-thresholds-input');
+    const save = getByTestId('ai-budget-save') as HTMLButtonElement;
     expect(save.disabled).toBe(false);
 
     fireEvent.change(input, { target: { value: '100' } });
     fireEvent.blur(input);
-    expect(screen.getByTestId('ai-budget-thresholds-error')).toBeInTheDocument();
+    expect(getByTestId('ai-budget-thresholds-error')).toBeInTheDocument();
     expect(save.disabled).toBe(true);
 
     fireEvent.change(input, { target: { value: '95' } });


### PR DESCRIPTION
## Summary

Fixes the flaky `AiUsagePage alert threshold ladder` test reported in #4601 (`Test Web` failed once on PR #4593 with 1 of 699 files red; the same test always passed in isolation).

**Root cause (proven, not guessed):** every test in `AiUsagePage.test.tsx` queried the shared `screen` object, which binds to `document.body`, not to any one render. Under real CPU contention — the state a full `Test Web` run puts the host in — a preceding test's RTL `cleanup()` can still be settling when the next test's async `it()` body starts. When that happens, a `screen.findByTestId(...)` in the "next" test can transiently match the **prior** test's still-mounted, already-edited component instance instead of its own freshly-rendered one.

I reproduced this directly (not just theorized it): pinned the host CPU with several busy-loops on top of an already-loaded box, added temporary debug logging to `AiBudgetThresholdsInput`'s `commit()` and `AiUsagePage`'s `handleSaveBudget`, and caught the exact mechanism in the logs — the "sends the edited ladder" test's own `commit()` fired with `text=""` (the *previous* test's already-cleared value) instead of the `"60, 90"` it had just typed, because its `findByTestId` had matched the previous, not-yet-unmounted instance. The console output also showed describe blocks interleaving out of file declaration order under pressure, confirming genuine cross-test overlap rather than a same-test logic bug.

**Fix:** every test now scopes its queries to its own render's container via `within(container)` (wrapped in a small `renderPage()` helper) instead of the global `screen`. A query can then never match another test's DOM, regardless of how fast (or slow) a neighbouring test's teardown runs — independent of suite order, as the issue asked for.

Per repo precedent (#3277), I deliberately did **not** raise any `waitFor`/test timeout — that was tried twice for a similar-looking flake in `InvoiceWorkspace.test.tsx` and never held, because the underlying condition never became true (see the comment on that file). This fix instead removes the actual cross-instance query ambiguity at its source.

**Honesty on residual risk:** under the same injected CPU pressure, the failure rate dropped from readily reproducible (pre-fix) to 3/120 runs post-fix — one was the same PUT-body-mismatch symptom, two were a different "element not found" flavor. That pressure (6 saturating busy-loops stacked on an already-heavily-loaded 18-core dev box) is more extreme than a real CI runner sees, so this is a substantial, evidence-based improvement rather than a mathematically-proven elimination of all possible timing windows.

## Test plan
- [x] `AiUsagePage.test.tsx` in isolation: 14/14 passed
- [x] `AiUsagePage.test.tsx` under injected CPU pressure, 120 runs: reliably reproduced the original failure pre-fix; 3/120 residual failures post-fix (down from readily reproducible)
- [x] Full `apps/web` suite run 1 (normal load, `--pool=threads --maxWorkers=2`): 700/700 files, 7379/7379 tests passed
- [x] Full `apps/web` suite run 2 (same config): 700/700 files, 7379/7379 tests passed
- [x] `npx tsc --noEmit` on `apps/web`: clean
- [x] `npx eslint` on the changed file: clean

Closes #4601

🤖 Generated with [Claude Code](https://claude.com/claude-code)