### PR TITLE
fix(web): AI agents UI critique pass — approver trust, dark mode, empty states, revoke

### DIFF
--- a/apps/api/src/routes/aiAgents.test.ts
+++ b/apps/api/src/routes/aiAgents.test.ts
@@ -26,6 +26,7 @@ import { buildOrgAccessClosures } from '../middleware/auth';
 const {
   selectMock,
   hasPermMock,
+  authOkMock,
   mfaOkMock,
   getAgentMock,
   resolveEffectiveAgentMock,
@@ -48,6 +49,11 @@ const {
   // impl, and `tsc` (not vitest) then rejects both the two-arg call inside the
   // requirePermission mock and the two-arg assertion below.
   hasPermMock: vi.fn<(resource: string, action: string) => boolean>(() => true),
+  // The router-level `aiAgentsRoutes.use('*', authMiddleware)` gate, made
+  // refusable. Every handler here sits behind it, so a route registered
+  // OUTSIDE that gate (or on a second, ungated router) is observable as a
+  // request that reaches its handler while this returns false.
+  authOkMock: vi.fn(() => true),
   mfaOkMock: vi.fn(() => true),
   getAgentMock: vi.fn(),
   resolveEffectiveAgentMock: vi.fn(),
@@ -87,7 +93,10 @@ vi.mock('../middleware/auth', async (importOriginal) => {
   // shape authMiddleware installs, not a test-only approximation of it.
   const actual = await importOriginal<typeof import('../middleware/auth')>();
   return {
-    authMiddleware: async (_c: unknown, next: () => Promise<void>) => next(),
+    authMiddleware: async (
+      c: { json: (body: unknown, status: number) => Response },
+      next: () => Promise<void>,
+    ) => (authOkMock() ? next() : c.json({ error: 'Unauthorized' }, 401)),
     requireScope: () => async (_c: unknown, next: () => Promise<void>) => next(),
     requireMfa: () => async (c: { json: (body: unknown, status: number) => Response }, next: () => Promise<void>) => (
       mfaOkMock() ? next() : c.json({ error: 'MFA required', code: 'MFA_REQUIRED' }, 403)
@@ -248,6 +257,18 @@ vi.mock('../services/aiAgents/graduationService', () => ({
   loadActOpReliability: loadActOpReliabilityMock,
 }));
 
+// POST /graduation/revoke — `demoteSupervisedKey` is the SAME executor the
+// intent-release worker and the fix-watch verdict path already drive, and it
+// has full unit coverage of its own (supervisedKeyDemote.test.ts: the partner
+// re-pin, the advisory lock, the org-row CAS, the graduation upsert). Mocked
+// here so these tests exercise only routing, RBAC, the promoted-grant
+// precondition and the argument the route hands it — the same convention as
+// createActionIntent above.
+const demoteSupervisedKeyMock = vi.hoisted(() => vi.fn());
+vi.mock('../services/aiAgents/supervisedKeyDemote', () => ({
+  demoteSupervisedKey: demoteSupervisedKeyMock,
+}));
+
 const envMock = vi.hoisted(() => ({ policyDecideEnabled: vi.fn(() => true) }));
 vi.mock('../config/env', () => ({ policyDecideEnabled: envMock.policyDecideEnabled }));
 
@@ -335,6 +356,7 @@ function trigger(app: Hono, body: unknown = { deviceId: DEVICE_ID }, id = AGENT_
 beforeEach(() => {
   vi.clearAllMocks();
   hasPermMock.mockReturnValue(true);
+  authOkMock.mockReturnValue(true);
   mfaOkMock.mockReturnValue(true);
   getAgentMock.mockResolvedValue(agent());
   verifyDeviceAccessMock.mockResolvedValue({
@@ -2435,6 +2457,234 @@ describe('POST /ai-agents/graduation/promote', () => {
 
     expect(res.status).toBe(400);
     expect(await res.json()).toMatchObject({ error: 'org_argument_mismatch' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /graduation/revoke — the operator-facing mirror of promote.
+// ---------------------------------------------------------------------------
+
+describe('POST /ai-agents/graduation/revoke', () => {
+  const OP_KEY = 'manage_services:restart';
+  const ORG_AGENT_ID = '99999999-9999-4999-8999-999999999999';
+  const OTHER_AGENT_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+  const body = { orgId: ORG_ID, opKey: OP_KEY };
+
+  /** One `ai_agent_graduation` row as the route's precondition read sees it. */
+  function gradRow(overrides: Record<string, unknown> = {}) {
+    return { agentId: AGENT_ID, state: 'promoted', ...overrides };
+  }
+
+  function revoke(app: Hono, payload: unknown = body) {
+    return app.request('/ai-agents/graduation/revoke', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+  }
+
+  beforeEach(() => {
+    selectMock.mockReturnValue(selectChain([gradRow()]));
+    demoteSupervisedKeyMock.mockResolvedValue({ revoked: true, orgAgentId: ORG_AGENT_ID });
+  });
+
+  it('is refused unauthenticated by the router-level auth gate', async () => {
+    authOkMock.mockReturnValue(false);
+
+    const res = await revoke(buildApp());
+
+    expect(res.status).toBe(401);
+    expect(selectMock).not.toHaveBeenCalled();
+    expect(demoteSupervisedKeyMock).not.toHaveBeenCalled();
+  });
+
+  it('denies a read-only token (ai_agents:write is required)', async () => {
+    hasPermMock.mockImplementation((resource: string, action: string) => (
+      !(resource === 'ai_agents' && action === 'write')
+    ));
+
+    const res = await revoke(buildApp());
+
+    expect(res.status).toBe(403);
+    // The literal is the public permission contract: revoking must sit behind
+    // the SAME write capability that promoting does, never ai_agents:read.
+    expect(hasPermMock).toHaveBeenCalledWith('ai_agents', 'write');
+    expect(demoteSupervisedKeyMock).not.toHaveBeenCalled();
+  });
+
+  it("denies another partner's org, the same way promote does", async () => {
+    const app = buildApp(false, {
+      scope: 'partner',
+      orgId: null,
+      partnerId: PARTNER_ID,
+      canAccessOrg: (id: string) => id === ORG_ID,
+    });
+
+    const res = await revoke(app, { ...body, orgId: OTHER_ORG_ID });
+
+    expect(res.status).toBe(403);
+    expect(selectMock).not.toHaveBeenCalled();
+    expect(demoteSupervisedKeyMock).not.toHaveBeenCalled();
+  });
+
+  it('is 404 when no graduation row exists for the key', async () => {
+    selectMock.mockReturnValue(selectChain([]));
+
+    const res = await revoke(buildApp());
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual(expect.objectContaining({ error: 'no_promoted_grant' }));
+    expect(demoteSupervisedKeyMock).not.toHaveBeenCalled();
+  });
+
+  it('is 404 when the key is tracked but was never promoted', async () => {
+    selectMock.mockReturnValue(selectChain([gradRow({ state: 'eligible' })]));
+
+    const res = await revoke(buildApp());
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual(expect.objectContaining({ error: 'no_promoted_grant' }));
+    expect(demoteSupervisedKeyMock).not.toHaveBeenCalled();
+  });
+
+  it('is 409 when the grant is already demoted', async () => {
+    selectMock.mockReturnValue(selectChain([gradRow({ state: 'demoted' })]));
+
+    const res = await revoke(buildApp());
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual(expect.objectContaining({ error: 'already_demoted' }));
+    expect(demoteSupervisedKeyMock).not.toHaveBeenCalled();
+  });
+
+  it('revokes the grant and audits the accountable human actor', async () => {
+    const res = await revoke(buildApp(), { ...body, reason: 'Customer asked us to stop' });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      revoked: true,
+      orgAgentId: ORG_AGENT_ID,
+      state: 'demoted',
+    });
+    expect(demoteSupervisedKeyMock).toHaveBeenCalledWith({
+      orgId: ORG_ID,
+      agentId: AGENT_ID,
+      opKey: OP_KEY,
+      reason: 'operator',
+      runId: null,
+      watchId: null,
+      intentId: null,
+    });
+    expect(writeRouteAuditMock).toHaveBeenCalledTimes(1);
+    expect(writeRouteAuditMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        orgId: ORG_ID,
+        action: 'ai_agent.graduation.revoke',
+        resourceType: 'ai_agent',
+        resourceId: ORG_AGENT_ID,
+        result: 'success',
+        details: {
+          agentId: AGENT_ID,
+          orgAgentId: ORG_AGENT_ID,
+          opKey: OP_KEY,
+          reason: 'Customer asked us to stop',
+        },
+      }),
+    );
+  });
+
+  it('pins the precondition read to the named org and op key', async () => {
+    const predicates: unknown[] = [];
+    selectMock.mockReturnValue(selectChain([gradRow()], (p) => predicates.push(p)));
+
+    // The REAL closure builder, not a stand-in: this proves the tenancy pin
+    // the route stacks on top of RLS is the same eq/inArray shape
+    // authMiddleware installs.
+    const { orgCondition } = buildOrgAccessClosures([ORG_ID]);
+    const res = await revoke(buildApp(false, { orgCondition }));
+
+    expect(res.status).toBe(200);
+    expect(predicates).toHaveLength(1);
+    expect(sqlParams(predicates[0])).toEqual(expect.arrayContaining([ORG_ID, OP_KEY]));
+  });
+
+  it('records a null reason when the operator supplied none', async () => {
+    const res = await revoke(buildApp());
+
+    expect(res.status).toBe(200);
+    expect(writeRouteAuditMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ details: expect.objectContaining({ reason: null }) }),
+    );
+  });
+
+  it('revokes while BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED is off', async () => {
+    // The mirror of promote's 409: turning the flag off must stop new grants,
+    // never strand a live one. supervisedKeyDemote.ts is always-on for the
+    // same reason, and this route must not re-introduce the gate.
+    envMock.policyDecideEnabled.mockReturnValue(false);
+
+    const res = await revoke(buildApp());
+
+    expect(res.status).toBe(200);
+    expect(demoteSupervisedKeyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('is 409, not a false success, when the key was already off the org row', async () => {
+    demoteSupervisedKeyMock.mockResolvedValue({ revoked: false, orgAgentId: ORG_AGENT_ID });
+
+    const res = await revoke(buildApp());
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual(expect.objectContaining({ error: 'already_revoked' }));
+    expect(writeRouteAuditMock).not.toHaveBeenCalled();
+  });
+
+  it('refuses to guess when two agents hold the same key', async () => {
+    selectMock.mockReturnValue(selectChain([gradRow(), gradRow({ agentId: OTHER_AGENT_ID })]));
+
+    const res = await revoke(buildApp());
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual(expect.objectContaining({ error: 'ambiguous_op_key' }));
+    expect(demoteSupervisedKeyMock).not.toHaveBeenCalled();
+  });
+
+  it('disambiguates two holders through the resolved agent for `kind`', async () => {
+    selectMock.mockReturnValue(selectChain([gradRow(), gradRow({ agentId: OTHER_AGENT_ID })]));
+    resolveEffectiveAgentSystemMock.mockResolvedValue({ agentId: OTHER_AGENT_ID, kind: 'patch' });
+
+    const res = await revoke(buildApp(), { ...body, kind: 'patch' });
+
+    expect(res.status).toBe(200);
+    expect(resolveEffectiveAgentSystemMock).toHaveBeenCalledWith(ORG_ID, 'patch');
+    expect(demoteSupervisedKeyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: OTHER_AGENT_ID }),
+    );
+  });
+
+  it('is 404 when `kind` names no active agent policy', async () => {
+    resolveEffectiveAgentSystemMock.mockResolvedValue(null);
+
+    const res = await revoke(buildApp(), { ...body, kind: 'patch' });
+
+    expect(res.status).toBe(404);
+    expect(demoteSupervisedKeyMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a dot-form act-op key (only colon keys are ever granted)', async () => {
+    const res = await revoke(buildApp(), { ...body, opKey: 'manage_services.restart' });
+
+    expect(res.status).toBe(400);
+    expect(demoteSupervisedKeyMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a reason longer than 500 characters', async () => {
+    const res = await revoke(buildApp(), { ...body, reason: 'x'.repeat(501) });
+
+    expect(res.status).toBe(400);
+    expect(demoteSupervisedKeyMock).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/routes/aiAgents.ts
+++ b/apps/api/src/routes/aiAgents.ts
@@ -27,7 +27,7 @@ import {
 import { zValidator } from '../lib/validation';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import {
-  actionIntents, aiAgentRuns, aiAgents, aiToolExecutions, devices, organizations,
+  actionIntents, aiAgentGraduation, aiAgentRuns, aiAgents, aiToolExecutions, devices, organizations,
   reportRuns, reports, ticketDrafts, type AiAgentRow,
 } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';
@@ -55,6 +55,7 @@ import {
 } from '../services/aiAgents/agentService';
 import { resolveEffectiveAgent, resolveEffectiveAgentSystem } from '../services/aiAgents/effectivePolicy';
 import { loadActOpReliability, loadGraduationRows } from '../services/aiAgents/graduationService';
+import { demoteSupervisedKey } from '../services/aiAgents/supervisedKeyDemote';
 import { POLICY_DECIDABLE_TIER3 } from '../services/actionIntents/policyDecidable';
 import { ActionIntentError, createActionIntent } from '../services/actionIntents/intentService';
 import { computeExposureBudget } from '../services/actionIntents/exposureBudget';
@@ -557,6 +558,168 @@ aiAgentsRoutes.post(
       }
       throw err;
     }
+  },
+);
+
+/**
+ * Body of `POST /graduation/revoke`. Kept local to this route rather than
+ * added beside `promoteSupervisedKeyRequestSchema` in `@breeze/shared`: the
+ * promote body crosses the wire into an action intent's ARGUMENTS (the
+ * effect-digest resolver re-reads it), so it has to be canonical in a package
+ * both ends import. A revoke is a plain request body that never leaves this
+ * handler.
+ *
+ * `opKey` carries promote's colon-form restriction verbatim: a dot-form
+ * act-op key is outcome evidence and was never grantable, so it can never be
+ * revocable either — rejecting it at the schema is what keeps a typo from
+ * reading as "no such grant".
+ *
+ * `kind` is OPTIONAL and exists only to disambiguate. Policy-decidable keys
+ * are not kind-scoped (`POLICY_DECIDABLE_TIER3` is one flat registry), and
+ * `ai_agent_graduation` is unique on `(org_id, agent_id, op_key)` — so one
+ * org CAN hold the same key under two agents of different kinds. The panel
+ * always knows the kind it is rendering; a caller that omits it gets served
+ * only while the answer is unambiguous.
+ */
+const revokeSupervisedKeyRequestSchema = z.object({
+  orgId: z.string().guid(),
+  opKey: z.string().min(3).max(120).regex(/^[a-z0-9_]+:[a-z0-9_]+$/),
+  kind: z.enum(AI_AGENT_KINDS).optional(),
+  /** Operator-authored note. Recorded on the audit row, never on the agent policy. */
+  reason: z.string().trim().min(1).max(500).optional(),
+}).strict();
+
+/**
+ * How many graduation rows the precondition read pulls for one
+ * `(org_id, op_key)`. Only "one, or more than one" is ever asked — the extra
+ * rows exist so the ambiguity branch below can fire instead of the route
+ * silently revoking whichever holder Postgres returned first.
+ */
+const GRADUATION_REVOKE_CANDIDATE_LIMIT = 5;
+
+/**
+ * The operator-facing mirror of `POST /graduation/promote`: hand a promoted
+ * key back to the approval queue.
+ *
+ * NO FOUR-EYES, and that is the whole point of it being a route rather than
+ * a second `manage_ai_agents` action. Promote's four-eyes ceremony exists
+ * because granting unattended authority is irreversible-in-effect once an
+ * action runs; revoking strictly REDUCES privilege, so requiring a second
+ * human would mean an operator who has just watched an agent misbehave
+ * cannot stop it without finding a colleague. Same `scopes` and the same
+ * `requireAiWrite` capability as promote; no `requireMfa()`, matching what
+ * promote asks of its FIRST approver.
+ *
+ * NOT GATED ON `BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED`, deliberately, and
+ * for the exact reason promote IS: the flag going dark must stop new grants
+ * without stranding a live one on an agent an operator wants stopped.
+ * `supervisedKeyDemote.ts` is always-on for the same reason.
+ *
+ * TENANCY. The precondition read runs in the CALLER's own request context —
+ * `ai_agent_graduation` is Shape 1 (`breeze_has_org_access(org_id)`), so RLS
+ * is a real gate here and elevating would throw it away (the same reasoning
+ * `countEligibleGraduations` records). `auth.orgCondition` is stacked on top
+ * because partner scope means ACCESSIBLE orgs, not every org under the
+ * partner. Only the EXECUTOR elevates, and it does so itself: unlike
+ * promote's `createActionIntent` (a bare system wrapper, which is a no-op
+ * inside a request context — hence promote's `runOutsideDbContext`),
+ * `demoteSupervisedKey`'s own `inSystemDbContext` already exits the request
+ * context before establishing system visibility, so this handler must NOT
+ * wrap it.
+ *
+ * Refusals are all "nothing was revoked", never a false success:
+ *   404 `no_promoted_grant`  — no row, or none that ever reached `promoted`
+ *   409 `already_demoted`    — this key is already back in the queue
+ *   409 `ambiguous_op_key`   — two agents hold it; re-send with `kind`
+ *   409 `already_revoked`    — the key had already left the org row (a manual
+ *                              PATCH, or a partner-ceiling-only grant), so
+ *                              the executor wrote nothing and the stored
+ *                              state is stale-promoted. Reporting 200 here
+ *                              would claim a `demoted` row that does not
+ *                              exist.
+ */
+aiAgentsRoutes.post(
+  '/graduation/revoke',
+  scopes,
+  requireAiWrite,
+  zValidator('json', revokeSupervisedKeyRequestSchema),
+  async (c) => {
+    const auth = c.get('auth');
+    const { orgId, opKey, kind, reason } = c.req.valid('json');
+
+    if (!auth.canAccessOrg(orgId)) {
+      return c.json({ error: 'Organization not accessible' }, 403);
+    }
+
+    const rows = await db
+      .select({ agentId: aiAgentGraduation.agentId, state: aiAgentGraduation.state })
+      .from(aiAgentGraduation)
+      .where(and(
+        auth.orgCondition(aiAgentGraduation.orgId),
+        eq(aiAgentGraduation.orgId, orgId),
+        eq(aiAgentGraduation.opKey, opKey),
+      ))
+      .limit(GRADUATION_REVOKE_CANDIDATE_LIMIT);
+
+    let candidates = rows;
+    if (kind !== undefined) {
+      // Server-side resolution, never a caller-supplied agent id — the same
+      // rule GET /graduation states: an org token carries a partnerId but
+      // cannot read the partner baseline row itself.
+      const resolved = await resolveEffectiveAgentSystem(orgId, kind);
+      if (!resolved) {
+        return c.json({ error: 'No active agent policy for this organization/kind' }, 404);
+      }
+      candidates = rows.filter((row) => row.agentId === resolved.agentId);
+    }
+
+    const promoted = candidates.filter((row) => row.state === 'promoted');
+    if (promoted.length === 0) {
+      if (candidates.some((row) => row.state === 'demoted')) {
+        return c.json({ error: 'already_demoted' }, 409);
+      }
+      return c.json({ error: 'no_promoted_grant' }, 404);
+    }
+    if (promoted.length > 1) {
+      return c.json({
+        error: 'ambiguous_op_key',
+        message: 'More than one agent holds this key for the organization — re-send with `kind`',
+      }, 409);
+    }
+
+    const { agentId } = promoted[0]!;
+    const { revoked, orgAgentId } = await demoteSupervisedKey({
+      orgId,
+      agentId,
+      opKey,
+      reason: 'operator',
+      // No disqualifying evidence produced this — a human decided it. The
+      // accountable human is on the audit row below, which is also why the
+      // executor is left to write its own `ai.agent.supervised_key.revoked`
+      // row unchanged: that one records the AUTHORITY CHANGE (and is the same
+      // row the two automatic callers produce), this one records WHO.
+      runId: null,
+      watchId: null,
+      intentId: null,
+    });
+    if (!revoked) {
+      return c.json({ error: 'already_revoked', orgAgentId }, 409);
+    }
+
+    writeRouteAudit(c, {
+      orgId,
+      action: 'ai_agent.graduation.revoke',
+      resourceType: 'ai_agent',
+      resourceId: orgAgentId,
+      // The operator's own note is the one piece of free text on this row.
+      // It is a HUMAN's words, not a tool result, an alert message or any
+      // model-authored rationale — the class `supervisedKeyDemote.ts`'s leak
+      // rule excludes from operator-facing surfaces.
+      details: { agentId, orgAgentId, opKey, reason: reason ?? null },
+      result: 'success',
+    });
+
+    return c.json({ revoked: true, orgAgentId, state: 'demoted' as const });
   },
 );
 

--- a/apps/api/src/routes/approvals.test.ts
+++ b/apps/api/src/routes/approvals.test.ts
@@ -488,16 +488,29 @@ beforeEach(() => {
 // GET /pending now joins action_intents (Task 8) — db.select() for this
 // route returns `{approval, intent}` pairs via a `.from().leftJoin().where()
 // .orderBy()` chain, rather than raw approval_requests rows directly.
+//
+// The handler also runs up to THREE more batched lookups over the resulting
+// page (customer tenant, target device, org name) — each its own db.select()
+// call, in a DIFFERENT chain shape (`.from().innerJoin()...` /
+// `.from().where()`), that only fires when the page actually has something
+// to look up. Rather than hand-code every possible extra shape, this stub is
+// a single self-chaining node: every chain method returns the SAME node, so
+// it satisfies `.from().leftJoin().where().orderBy()` (resolving `rows`, via
+// the real mocked `.orderBy()` promise) AND any shorter chain that stops at
+// `.where()` (which returns the node itself, and the node is `then`-able,
+// resolving empty) — regardless of how many extra times db.select() is
+// called, or in what shape. A test that needs to assert on one of THOSE
+// batched lookups' own output queues an explicit `mockReturnValueOnce` ahead
+// of this persistent fallback instead (see the orgName tests below).
 function mockPendingJoinResolves(rows: Array<{ approval: unknown; intent: unknown | null }>) {
-  vi.mocked(db.select).mockReturnValue({
-    from: vi.fn().mockReturnValue({
-      leftJoin: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          orderBy: vi.fn().mockResolvedValue(rows),
-        }),
-      }),
-    }),
-  } as any);
+  const node: any = {};
+  node.from = vi.fn().mockReturnValue(node);
+  node.leftJoin = vi.fn().mockReturnValue(node);
+  node.innerJoin = vi.fn().mockReturnValue(node);
+  node.where = vi.fn().mockReturnValue(node);
+  node.orderBy = vi.fn().mockResolvedValue(rows);
+  node.then = (resolve: (v: unknown[]) => void) => resolve([]);
+  vi.mocked(db.select).mockReturnValue(node);
 }
 
 function buildPendingApproval(overrides: Record<string, unknown> = {}) {
@@ -534,7 +547,76 @@ describe('GET /approvals/pending', () => {
     const body = await res.json();
     expect(body.approvals).toHaveLength(1);
     expect(body.approvals[0].id).toBe('a1');
+    // No linked intent → no orgId to resolve a name for, and no org-name
+    // lookup select at all (see the batched-lookup tests below).
+    expect(body.approvals[0].orgName).toBeNull();
     expect(body.nextCursor).toBeNull();
+  });
+
+  it("projects orgName from the linked intent's org (single batched lookup)", async () => {
+    const approval = buildPendingApproval({ id: 'a-org', intentId: 'intent-org' });
+    const intent = {
+      id: 'intent-org',
+      orgId: 'org-9',
+      status: 'pending_approval',
+      approvalScope: 'four_eyes',
+      requestedByUserId: 'requester-9',
+    };
+    // 1) the pending join; 2) the batched org-name lookup.
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          leftJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockResolvedValue([{ approval, intent }]),
+            }),
+          }),
+        }),
+      } as any)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ id: 'org-9', name: 'Acme Dental' }]),
+        }),
+      } as any);
+
+    const res = await buildApp().request('/approvals/pending');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.approvals[0].orgId).toBe('org-9');
+    expect(body.approvals[0].orgName).toBe('Acme Dental');
+  });
+
+  it('serializes orgName: null when the linked org no longer exists', async () => {
+    const approval = buildPendingApproval({ id: 'a-org-missing', intentId: 'intent-org-missing' });
+    const intent = {
+      id: 'intent-org-missing',
+      orgId: 'org-deleted',
+      status: 'pending_approval',
+      approvalScope: 'four_eyes',
+      requestedByUserId: 'requester-9',
+    };
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          leftJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockResolvedValue([{ approval, intent }]),
+            }),
+          }),
+        }),
+      } as any)
+      // The org row is gone — the lookup returns zero rows, not an error.
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      } as any);
+
+    const res = await buildApp().request('/approvals/pending');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.approvals[0].orgId).toBe('org-deleted');
+    expect(body.approvals[0].orgName).toBeNull();
   });
 
   it('excludes a four_eyes intent-linked row once the approver no longer holds approvals:decide (demoted approver)', async () => {

--- a/apps/api/src/routes/approvals.ts
+++ b/apps/api/src/routes/approvals.ts
@@ -8,6 +8,7 @@ import { authMiddleware, isInteractiveUserSession } from '../middleware/auth';
 import { approvalRequests } from '../db/schema/approvals';
 import { aiToolExecutions, aiSessions } from '../db/schema/ai';
 import { delegantM365Connections } from '../db/schema/delegant';
+import { organizations } from '../db/schema/orgs';
 import { writeAuditEventAsync } from '../services/auditEvents';
 import { captureException } from '../services/sentry';
 import {
@@ -380,6 +381,11 @@ approvalRoutes.get('/pending', async (c) => {
   const targetDevices = await resolveTargetDevices(
     page.map(({ approval, targetRef }) => ({ key: approval.id, intent: targetRef })),
   );
+  // Batched lookup: one query resolves the display name for every DISTINCT
+  // org on this page (no N+1) — see `lookupOrgNames`. Deliberately last among
+  // the page's batched lookups so a page with no orgId at all (every row
+  // intent-less) never issues it at all.
+  const orgNames = await lookupOrgNames(page.map(({ targetRef }) => targetRef?.orgId ?? null));
   return c.json({
     approvals: page.map(({ approval, approvalScope, attribution, targetRef }) =>
       serialize(
@@ -389,6 +395,7 @@ approvalRoutes.get('/pending', async (c) => {
         attribution,
         targetDevices.get(approval.id) ?? null,
         targetRef?.orgId ?? null,
+        (targetRef?.orgId && orgNames.get(targetRef.orgId)) || null,
       ),
     ),
     nextCursor,
@@ -1282,4 +1289,37 @@ async function lookupCustomerTenants(
     }
   }
   return map;
+}
+
+/**
+ * Resolve display names for a page's DISTINCT org ids in ONE query (no N+1) —
+ * same batching shape as `lookupCustomerTenants` above. Callers pass the exact
+ * `orgId` value (or null) they're about to hand `serialize` for each row, so a
+ * row with no linked intent (orgId null) is simply never a key here and
+ * serializes `orgName: null` — same for an orgId whose organization row no
+ * longer exists (a dangling id resolves to no map entry, not an error).
+ *
+ * System-scoped, same reasoning as `resolveTargetDevices` above: `orgId` here
+ * is always the linked intent's org, which the row's live-authorization check
+ * has ALREADY exposed to the caller in this very payload (as `orgId` itself) —
+ * a supervised row is authorized by REQUESTER IDENTITY, not org membership, so
+ * the caller's own ambient request context (their `organization_users` row,
+ * or lack of one for a partner approver) is not a reliable signal for whether
+ * they can see the org's name. Resolving a name for an org id already in the
+ * response is not a fresh authorization decision.
+ */
+async function lookupOrgNames(orgIds: (string | null)[]): Promise<Map<string, string>> {
+  const distinctIds = [...new Set(orgIds.filter((id): id is string => !!id))];
+  if (distinctIds.length === 0) return new Map();
+
+  const rows = await runOutsideDbContext(() =>
+    withSystemDbAccessContext(() =>
+      db
+        .select({ id: organizations.id, name: organizations.name })
+        .from(organizations)
+        .where(inArray(organizations.id, distinctIds)),
+    ),
+  );
+
+  return new Map(rows.map((row) => [row.id, row.name]));
 }

--- a/apps/api/src/services/aiAgents/supervisedKeyDemote.ts
+++ b/apps/api/src/services/aiAgents/supervisedKeyDemote.ts
@@ -4,14 +4,23 @@
  * `supervisedKeyGrant.ts`.
  *
  * The one and only writer that REMOVES a colon key from an organization's
- * `ai_agents.actAssets.supervisedActionKeys`. Two events reach it, and they
- * are the two ways an unattended operation proves it should not have been
- * unattended:
+ * `ai_agents.actAssets.supervisedActionKeys`. Two AUTOMATIC events reach it,
+ * and they are the two ways an unattended operation proves it should not have
+ * been unattended:
  *
  *   - an ATTEMPTED failure of a released intent (`intentReleaseWorker.ts` —
  *     the terminal write stamped `executed_at`, so the provider-side call
  *     really happened and really failed);
  *   - a fix-watch `recurred` verdict (`fixWatch.ts` — the fix did not hold).
+ *
+ * A third caller is a HUMAN: `POST /ai/agents/graduation/revoke`
+ * (`routes/aiAgents.ts`) with `reason: 'operator'`, the operator-facing
+ * mirror of promote. It carries no `runId`/`watchId` — there is no
+ * disqualifying evidence, only a decision — and it deliberately does NOT
+ * notify (see `notifyDemotion`). Everything below applies to it unchanged
+ * except the savepoint: the route holds no evidence transaction to nest in,
+ * so it takes the `database` default and this executor opens its own system
+ * context.
  *
  * Three properties make this safe to run unattended, and all three are the
  * reason it exists as its own module rather than as a second half of
@@ -84,8 +93,21 @@ import { mergeAgentPolicies, normalizeAgentPolicy } from './effectivePolicy';
 import { withGraduationLock } from './graduationService';
 import { resolveRecipientUserIds } from './recipients';
 
-/** Which disqualifying signal revoked the key. Persisted as `demote_reason`. */
-export type AiAgentDemoteReason = 'attempted_failure' | 'recurrence';
+/**
+ * Which disqualifying signal revoked the key. Persisted as `demote_reason`.
+ *
+ * The column is plain `text` with NO check constraint
+ * (`2026-10-01-100000-ai-agents-graduation-evidence.sql`), so this union is
+ * the only place the value set is pinned — widening it needs no migration,
+ * but nothing else may write the column either.
+ *
+ * `operator` is the one member with no evidence behind it: a human used
+ * `POST /ai/agents/graduation/revoke` to hand the key back to the approval
+ * queue. It carries no `runId`/`watchId` for that reason, and the operator
+ * who did it is named by the route's own `ai_agent.graduation.revoke` audit
+ * row rather than by this table (there is no `demoted_by` column).
+ */
+export type AiAgentDemoteReason = 'attempted_failure' | 'recurrence' | 'operator';
 
 /**
  * The executor the caller's transaction is running on. Defaults to the
@@ -296,6 +318,12 @@ export interface NotifyDemotionInput {
 const DEMOTE_REASON_CLAUSE: Record<AiAgentDemoteReason, string> = {
   attempted_failure: 'its last attempt failed.',
   recurrence: 'the alert it fixed recurred.',
+  // Unreachable in practice — the operator route deliberately does not notify
+  // (the person who revoked the key does not need to be told, and there is no
+  // run to resolve recipients from, so `notifyDemotion` stands down before it
+  // gets here). Present because the `Record` is total, and worded so it would
+  // still read correctly if a future caller did notify.
+  operator: 'an operator revoked it.',
 };
 
 /**

--- a/apps/api/src/services/approvals/decideApprovalRequest.ts
+++ b/apps/api/src/services/approvals/decideApprovalRequest.ts
@@ -217,6 +217,15 @@ export function serialize(
   /** The linked intent's org, so a partner-scope inbox can group by customer
    *  without a second fetch. Null for a row with no intent. */
   orgId: string | null = null,
+  /**
+   * The `orgId` organization's display name, resolved server-side (#4187 UI
+   * critique) so a client never has to bulk-fetch `/orgs/organizations` and
+   * map names itself. Null for a row with no intent (no `orgId` to resolve)
+   * or when the org row no longer exists. Resolved by the caller (which
+   * batches ONE `inArray(organizations.id, …)` read per page, mirroring
+   * `customerTenant`'s batching); this function stays I/O-free.
+   */
+  orgName: string | null = null,
 ) {
   const isAgentOriginated = attribution?.requestingAgentRunId != null;
   const actionArguments = r.actionArguments as Record<string, unknown> | null;
@@ -235,6 +244,7 @@ export function serialize(
     // is not action-multiplexed or the value is not a plain string.
     action: typeof actionArguments?.action === 'string' ? actionArguments.action : null,
     orgId,
+    orgName,
     targetDevice,
     riskTier: r.riskTier,
     riskSummary: r.riskSummary,

--- a/apps/web/src/components/aiAgents/ImpactPage.test.tsx
+++ b/apps/web/src/components/aiAgents/ImpactPage.test.tsx
@@ -197,15 +197,20 @@ describe('ImpactPage', () => {
     expect(screen.getByTestId('ai-impact-tile-llm-cents')).toHaveTextContent('$43.21');
   });
 
-  it('lists the effective weights in the estimate tile tooltip', async () => {
+  it('shows the six effective weights in an accessible, closed-by-default disclosure (not a title= tooltip)', async () => {
     mockImpact(dto());
     render(<ImpactPage />);
 
     await waitFor(() => expect(screen.getByTestId('ai-impact-tile-est-seconds-saved')).toBeInTheDocument());
-    const title = screen.getByTestId('ai-impact-tile-est-seconds-saved').getAttribute('title') ?? '';
+    // Never a bare title= tooltip — the methodology must be reachable without hover.
+    expect(screen.getByTestId('ai-impact-tile-est-seconds-saved')).not.toHaveAttribute('title');
+
+    const disclosure = screen.getByTestId('ai-impact-est-seconds-saved-disclosure');
+    expect(disclosure).not.toHaveAttribute('open');
+    expect(disclosure).toHaveTextContent('How is this estimated?');
     // Six priced outcomes, in minutes: 90s, 240s, 360s, 300s, 900s, 1800s.
     for (const minutes of ['1.5', '4', '6', '5', '15', '30']) {
-      expect(title).toContain(minutes);
+      expect(disclosure).toHaveTextContent(minutes);
     }
   });
 
@@ -257,6 +262,133 @@ describe('ImpactPage', () => {
       ticketsTriaged: 23,
       fixesExecuted: 26,
     });
+  });
+
+  it('collapses the tile grid and chart into one EmptyState when the window has no outcomes at all', async () => {
+    // A 30-day window returns 30 zero buckets, not an empty series — the
+    // all-zero-buckets case, not the (theoretical) empty-array case.
+    const zero = dto({
+      totals: {
+        alertsJudged: 0,
+        noiseFlagged: 0,
+        suppressionsApplied: 0,
+        ticketsTriaged: 0,
+        draftsSent: 0,
+        fixesProposed: 0,
+        fixesExecuted: 0,
+        fixWatchesHeld: 0,
+        fixWatchesRecurred: 0,
+        narrativesDelivered: 0,
+        estSecondsSaved: 0,
+        llmCents: 0,
+      },
+      series: [
+        {
+          day: '2026-08-30',
+          alertsJudged: 0,
+          noiseFlagged: 0,
+          suppressionsApplied: 0,
+          ticketsTriaged: 0,
+          draftsSent: 0,
+          fixesProposed: 0,
+          fixesExecuted: 0,
+          fixWatchesHeld: 0,
+          fixWatchesRecurred: 0,
+          narrativesDelivered: 0,
+          estSecondsSaved: 0,
+          llmCents: 0,
+        },
+      ],
+      positiveFeedback: { up: 0, down: 0, rate: null },
+    });
+    mockImpact(zero);
+    render(<ImpactPage />);
+
+    await waitFor(() => expect(screen.getByTestId('ai-impact-empty')).toBeInTheDocument());
+    expect(screen.queryByTestId('ai-impact-tile-alerts-judged')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('ai-impact-chart')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('ai-impact-chart-empty')).not.toBeInTheDocument();
+    // The page EmptyState sits under the page h1, so its own heading must be
+    // an h2, not the default h3 (which would skip a level).
+    expect(screen.getByTestId('ai-impact-empty').querySelector('h2')).toHaveTextContent(
+      'No AI outcomes in this window yet',
+    );
+    // Header controls (window switcher) stay usable so the user can widen the window.
+    expect(screen.getByTestId('ai-impact-window-90')).toBeInTheDocument();
+  });
+
+  it('renders the populated tile groups and chart when the window has outcomes', async () => {
+    mockImpact(dto());
+    render(<ImpactPage />);
+
+    await waitFor(() => expect(screen.getByTestId('ai-impact-tile-alerts-judged')).toBeInTheDocument());
+    expect(screen.queryByTestId('ai-impact-empty')).not.toBeInTheDocument();
+    expect(screen.getByTestId('ai-impact-chart')).toBeInTheDocument();
+  });
+
+  it('shows the tile groups (with real, non-zero numbers) even when nothing feeds the chart — a drafts-only agent', async () => {
+    // Only draftsSent (and its priced time) is non-zero. None of the four
+    // series the bar chart stacks (noiseFlagged/alertsJudgedNet/
+    // ticketsTriaged/fixesExecuted) carry anything — a drafts-only or
+    // narrative-only agent must still see its own real numbers on the tiles,
+    // not the "no impact yet" EmptyState the OLD chart-only gate produced.
+    const draftsOnly = dto({
+      totals: {
+        alertsJudged: 0,
+        noiseFlagged: 0,
+        suppressionsApplied: 0,
+        ticketsTriaged: 0,
+        draftsSent: 9,
+        fixesProposed: 0,
+        fixesExecuted: 0,
+        fixWatchesHeld: 0,
+        fixWatchesRecurred: 0,
+        narrativesDelivered: 0,
+        estSecondsSaved: 2_700,
+        llmCents: 150,
+      },
+      series: [
+        {
+          day: '2026-08-30',
+          alertsJudged: 0,
+          noiseFlagged: 0,
+          suppressionsApplied: 0,
+          ticketsTriaged: 0,
+          draftsSent: 9,
+          fixesProposed: 0,
+          fixesExecuted: 0,
+          fixWatchesHeld: 0,
+          fixWatchesRecurred: 0,
+          narrativesDelivered: 0,
+          estSecondsSaved: 2_700,
+          llmCents: 150,
+        },
+      ],
+    });
+    mockImpact(draftsOnly);
+    render(<ImpactPage />);
+
+    // Tiles render with the REAL numbers — not hidden behind an empty state.
+    await waitFor(() => expect(screen.getByTestId('ai-impact-tile-drafts-sent')).toBeInTheDocument());
+    expect(screen.getByTestId('ai-impact-tile-drafts-sent')).toHaveTextContent('9');
+    expect(screen.getByTestId('ai-impact-tile-est-seconds-saved')).toHaveTextContent('0.8');
+    expect(screen.getByTestId('ai-impact-tile-llm-cents')).toHaveTextContent('$1.50');
+    expect(screen.queryByTestId('ai-impact-empty')).not.toBeInTheDocument();
+
+    // But the chart itself — which draws none of these fields — shows its
+    // OWN, narrower empty message instead of the chart.
+    expect(screen.queryByTestId('ai-impact-chart')).not.toBeInTheDocument();
+    expect(screen.getByTestId('ai-impact-chart-empty')).toHaveTextContent(
+      'No outcomes were recorded in this window.',
+    );
+  });
+
+  it('the promotion-eligible tile is a navigable link (link role), not just a styled div', async () => {
+    mockImpact(dto());
+    render(<ImpactPage />);
+
+    const tile = await screen.findByTestId('ai-impact-tile-promote-eligible');
+    expect(screen.getByRole('link', { name: /promotion-eligible/i })).toBe(tile);
   });
 
   it('hides the per-org table when byOrg is empty', async () => {
@@ -369,6 +501,76 @@ describe('ImpactPage', () => {
       await vi.advanceTimersByTimeAsync(30_000);
     });
     expect(fetchMock.mock.calls.length).toBe(settled);
+  });
+
+  it('captures the rebuild baseline AFTER the trigger POST resolves, so a concurrent reload cannot make the first poll tick falsely report success', async () => {
+    // Reproduces the race the fix closes: dto's rebuiltAt advances (from
+    // something entirely unrelated to this click — e.g. an org-scope switch
+    // reloading the page) WHILE our own rebuild POST is still in flight. The
+    // baseline must reflect that advance, not a snapshot read before it.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    let rebuiltAt = '2026-09-01T02:00:00.000Z';
+    let resolveRebuildPost!: () => void;
+    fetchMock.mockImplementation((url: string) => {
+      if (url.startsWith('/api/ai/agents/impact/rebuild')) {
+        return new Promise<Response>((resolve) => {
+          resolveRebuildPost = () =>
+            resolve(json({ queued: 1, from: '2026-06-03', through: '2026-08-31' }, true, 202));
+        });
+      }
+      if (url.startsWith('/api/ai/agents/impact')) {
+        return Promise.resolve(json({ data: dto({ rebuiltAt }) }));
+      }
+      return Promise.resolve(json({ data: null }, false, 404));
+    });
+    const view = render(<ImpactPage />);
+
+    await vi.waitFor(() =>
+      expect(screen.getByTestId('ai-impact-tile-alerts-judged')).toBeInTheDocument(),
+    );
+    const callsBeforeRefresh = fetchMock.mock.calls.length;
+
+    fireEvent.click(screen.getByTestId('ai-impact-refresh'));
+    // The rebuild POST is deliberately held open — nothing has resolved it yet,
+    // so `handleRefresh` is suspended mid-`await`.
+
+    // WHILE that POST is in flight, rebuiltAt advances and something entirely
+    // unrelated (an org-scope switch) forces a fresh reload of `dto`. The
+    // rerender + fetch + setDto + ref-sync-effect chain must actually settle
+    // (not just the fetch mock's call count) before the POST is allowed to
+    // resolve below — advancing fake time by 0 drains the intervening
+    // microtasks inside `act` so React commits the update and runs effects.
+    rebuiltAt = '2026-09-01T05:00:00.000Z';
+    mockCurrentOrgId = 'org-2';
+    view.rerender(<ImpactPage />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(callsBeforeRefresh);
+
+    // NOW let the rebuild POST resolve — the baseline must be captured at
+    // THIS point (the already-advanced rebuiltAt), not the stale value that
+    // was current when the button was first clicked.
+    resolveRebuildPost();
+    await vi.waitFor(() => expect(screen.getByTestId('ai-impact-refresh')).toBeDisabled());
+    // The enqueue itself already toasted its own "rebuild queued" success —
+    // snapshot the count so the assertion below is about the FIRST POLL
+    // TICK specifically, not this unrelated toast.
+    const toastsAfterEnqueue = toasts.length;
+
+    // First poll tick: the server still reports the SAME rebuiltAt the
+    // baseline was captured with — nothing has changed since, so this must
+    // NOT read as "our rebuild finished". The old, pre-fix baseline (the
+    // stale 02:00 snapshot) would have made this tick see 05:00 > 02:00 and
+    // falsely toast success for a rebuild that never actually ran.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+    expect(screen.getByTestId('ai-impact-refresh')).toBeDisabled();
+    expect(toasts.length).toBe(toastsAfterEnqueue);
+    expect(
+      toasts.some((toast) => toast.message === 'The impact report has been rebuilt.'),
+    ).toBe(false);
   });
 
   it('gives up polling after two minutes with a toast', async () => {
@@ -512,6 +714,21 @@ describe('ImpactPage', () => {
     await waitFor(() => expect(screen.getByTestId('ai-impact-tile-alerts-judged')).toBeInTheDocument());
   });
 
+  it('announces the loading/error region to screen readers via aria-live', async () => {
+    fetchMock.mockResolvedValue(json({ error: 'boom' }, false, 500));
+    render(<ImpactPage />);
+
+    // The loading text and the error card that replaces it must both sit
+    // inside the SAME aria-live="polite" container so a screen reader
+    // announces the transition, not just whichever one happened to render at
+    // mount.
+    const loadingRegion = screen.getByTestId('ai-impact-loading').closest('[aria-live="polite"]');
+    expect(loadingRegion).not.toBeNull();
+
+    await waitFor(() => expect(screen.getByTestId('ai-impact-error')).toBeInTheDocument());
+    expect(screen.getByTestId('ai-impact-error').closest('[aria-live="polite"]')).not.toBeNull();
+  });
+
   it('shows the edit-weights button only when canEditWeights is true', async () => {
     mockImpact(dto({ canEditWeights: false }));
     const view = render(<ImpactPage />);
@@ -554,6 +771,37 @@ describe('ImpactPage', () => {
     fireEvent.click(screen.getByTestId('stub-drawer-close'));
     expect(screen.queryByTestId('ai-impact-weights-drawer-stub')).not.toBeInTheDocument();
     expect(fetchMock.mock.calls.length).toBe(beforeClose);
+  });
+
+  it('closes the mobile overflow menu after choosing "Edit weights", instead of leaving it open over the page', async () => {
+    mockImpact(dto({ canEditWeights: true }));
+    render(<ImpactPage />);
+    await waitFor(() => expect(screen.getByTestId('ai-impact-overflow-menu')).toBeInTheDocument());
+
+    const details = screen.getByTestId('ai-impact-overflow-menu').closest('details') as HTMLDetailsElement;
+    details.open = true;
+    expect(details.open).toBe(true);
+
+    fireEvent.click(screen.getByTestId('ai-impact-edit-weights-overflow'));
+
+    expect(details.open).toBe(false);
+    // The selection itself still went through — closing is additive, not a
+    // substitute for the action.
+    expect(screen.getByTestId('ai-impact-weights-drawer-stub')).toBeInTheDocument();
+  });
+
+  it('closes the mobile overflow menu after choosing "Export PDF" too', async () => {
+    mockImpact(dto());
+    render(<ImpactPage />);
+    await waitFor(() => expect(screen.getByTestId('ai-impact-overflow-menu')).toBeInTheDocument());
+
+    const details = screen.getByTestId('ai-impact-overflow-menu').closest('details') as HTMLDetailsElement;
+    details.open = true;
+
+    fireEvent.click(screen.getByTestId('ai-impact-export-pdf-overflow'));
+
+    expect(details.open).toBe(false);
+    await waitFor(() => expect(exportReportCalls.length).toBe(1));
   });
 
   it('exports the PDF with reportType ai_agent_impact, UTC timezone, and uniform metric/value rows', async () => {

--- a/apps/web/src/components/aiAgents/ImpactPage.tsx
+++ b/apps/web/src/components/aiAgents/ImpactPage.tsx
@@ -1,7 +1,15 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import '@/lib/i18n';
-import { Download, RefreshCw, Settings2, TrendingUp } from 'lucide-react';
+import {
+  ChevronRight,
+  Download,
+  MoreHorizontal,
+  RefreshCw,
+  Settings2,
+  TrendingUp,
+} from 'lucide-react';
 import {
   Bar,
   BarChart,
@@ -20,6 +28,7 @@ import { useHashState } from '@/lib/useHashState';
 import { formatCurrency, formatNumber, formatPercent } from '@/lib/i18n/format';
 import { formatDateTime } from '@/lib/dateTimeFormat';
 import { exportReport } from '../reports/reportExport';
+import { EmptyState } from '../shared/EmptyState';
 import ImpactWeightsDrawer from './ImpactWeightsDrawer';
 import {
   AI_AGENT_IMPACT_BY_ORG_LIMIT,
@@ -40,6 +49,31 @@ import type {
 const DEFAULT_WINDOW: AiAgentImpactWindow = 30;
 const POLL_INTERVAL_MS = 5_000;
 const POLL_TIMEOUT_MS = 120_000;
+
+/**
+ * Scoped light/dark chart-fill custom properties for the outcomes bar chart.
+ * No global `--chart-*` categorical palette exists yet in globals.css (only
+ * `--chart-neutral`, for the unrelated "inactive segment" meter convention),
+ * so these are defined here rather than invented as a new global contract.
+ * Hues are chosen distinctly from the app's status semantics (destructive
+ * ~4deg, warning ~36deg, success ~152deg, info ~205deg, primary ~225deg) —
+ * "noise flagged" in particular must never land on amber/warning, since
+ * amber means warning everywhere else in the product.
+ */
+const AI_IMPACT_CHART_FILL_CSS = `
+  .ai-impact-chart-fills {
+    --ai-impact-chart-noise: 265 55% 50%;
+    --ai-impact-chart-judged: 300 48% 46%;
+    --ai-impact-chart-tickets: 330 55% 48%;
+    --ai-impact-chart-fixes: 92 40% 34%;
+  }
+  .dark .ai-impact-chart-fills {
+    --ai-impact-chart-noise: 265 65% 72%;
+    --ai-impact-chart-judged: 300 60% 70%;
+    --ai-impact-chart-tickets: 330 65% 72%;
+    --ai-impact-chart-fixes: 92 45% 58%;
+  }
+`;
 
 /** Leading `#` already stripped by useHashState, so this is SSR-safe. */
 export function windowFromHash(hash: string): AiAgentImpactWindow | undefined {
@@ -209,19 +243,27 @@ function Tile({
   testId,
   label,
   value,
-  title,
+  caption,
+  disclosure,
   href,
 }: {
   testId: string;
   label: string;
   value: string;
-  title?: string;
+  /** Visible one-line explainer, replacing a `title=`-only tooltip. */
+  caption?: string;
+  /** Extra accessible content rendered below the caption (e.g. a weights disclosure). */
+  disclosure?: ReactNode;
   href?: string;
 }) {
   const body = (
     <>
-      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className="min-h-[2rem] text-xs font-medium uppercase leading-tight tracking-wide text-muted-foreground">
+        {label}
+      </p>
       <p className="mt-1 text-2xl font-semibold tabular-nums">{value}</p>
+      {caption && <p className="mt-1 text-xs text-muted-foreground">{caption}</p>}
+      {disclosure}
     </>
   );
   if (href) {
@@ -229,15 +271,15 @@ function Tile({
       <a
         data-testid={testId}
         href={href}
-        title={title}
-        className="block rounded-lg border bg-card p-4 transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        className="group flex items-start justify-between gap-2 rounded-lg border bg-card p-4 transition-colors hover:bg-accent hover:ring-1 hover:ring-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
-        {body}
+        <div className="min-w-0 flex-1">{body}</div>
+        <ChevronRight className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
       </a>
     );
   }
   return (
-    <div data-testid={testId} title={title} className="rounded-lg border bg-card p-4">
+    <div data-testid={testId} className="rounded-lg border bg-card p-4">
       {body}
     </div>
   );
@@ -275,6 +317,18 @@ export default function ImpactPage() {
   // freshness stamp captured BEFORE the POST, so the poll can tell a finished
   // rebuild from the pre-existing rollup.
   const [poll, setPoll] = useState<{ startedAt: number; rebuiltAt: string | null } | null>(null);
+
+  // Kept in sync with `dto` (effect below) so `handleRefresh` can read the
+  // FRESHEST known rebuiltAt right after the trigger POST resolves, instead
+  // of a snapshot closed over BEFORE the await. A pre-await read risks being
+  // stale — if `dto` updates from some other cause while our POST is still
+  // in flight, that update predates OUR rebuild, so using it as the baseline
+  // would let the very first poll tick see it as an "advance" and falsely
+  // announce that OUR rebuild finished.
+  const dtoRebuiltAtRef = useRef<string | null>(null);
+  useEffect(() => {
+    dtoRebuiltAtRef.current = dto?.rebuiltAt ?? null;
+  }, [dto]);
 
   const requestImpact = useCallback(async (): Promise<AiAgentImpactDto> => {
     const response = await fetchWithAuth(`/api/ai/agents/impact?window=${windowDays}`);
@@ -347,7 +401,6 @@ export default function ImpactPage() {
   }, [poll, requestImpact, t]);
 
   const handleRefresh = useCallback(async () => {
-    const baselineRebuiltAt = dto?.rebuiltAt ?? null;
     try {
       await runAction({
         request: () => fetchWithAuth('/api/ai/agents/impact/rebuild', { method: 'POST' }),
@@ -378,8 +431,20 @@ export default function ImpactPage() {
       }
       return;
     }
-    setPoll({ startedAt: Date.now(), rebuiltAt: baselineRebuiltAt });
-  }, [dto?.rebuiltAt, t]);
+    // Baseline captured AFTER the trigger resolved — see dtoRebuiltAtRef's
+    // comment above.
+    setPoll({ startedAt: Date.now(), rebuiltAt: dtoRebuiltAtRef.current });
+  }, [t]);
+
+  // The mobile overflow `<details>` menu (~line 578) has no native
+  // "close on selection" behavior — left alone it stays open, floating over
+  // whatever the selected action changed underneath it. `open = false`
+  // (rather than removeAttribute, which is equivalent but less explicit)
+  // closes it exactly like clicking the summary again would.
+  const overflowMenuRef = useRef<HTMLDetailsElement>(null);
+  const closeOverflowMenu = useCallback(() => {
+    if (overflowMenuRef.current) overflowMenuRef.current.open = false;
+  }, []);
 
   const [weightsDrawerOpen, setWeightsDrawerOpen] = useState(false);
 
@@ -408,21 +473,37 @@ export default function ImpactPage() {
   }, [dto, t]);
 
   const weights: ImpactWeights = dto?.weights.effective ?? DEFAULT_IMPACT_WEIGHTS;
-  const weightsTooltip = useMemo(
-    () =>
-      [
-        t('aiAgentsPage.impact.weightsTooltipTitle'),
-        ...IMPACT_WEIGHT_KEYS.map((key) =>
-          t('aiAgentsPage.impact.weightsTooltipLine', {
-            label: weightLabel(t, key),
-            minutes: formatNumber(weights[key] / 60, { maximumFractionDigits: 1 }),
-          }),
-        ),
-      ].join('\n'),
-    [t, weights],
-  );
 
   const chartRows = useMemo(() => buildImpactChartRows(dto?.series ?? []), [dto?.series]);
+  // Gates the tile groups AND the page-level EmptyState: true whenever the
+  // DTO carries evidence of ANY activity in the window, across every counter
+  // (not just the four the bar chart stacks) plus the two derived/measured
+  // numbers beside it. A drafts-only or narrative-only agent must not hide
+  // non-zero Drafts sent / Estimated time saved / LLM spend behind "no
+  // impact yet" just because none of its outcomes happen to be chart series.
+  const hasAnyOutcome = useMemo(() => {
+    if (!dto) return false;
+    const totals = dto.totals;
+    return (
+      AI_AGENT_IMPACT_COUNTER_KEYS.some((key) => totals[key] > 0) ||
+      totals.estSecondsSaved > 0 ||
+      totals.llmCents > 0
+    );
+  }, [dto]);
+  // A 30-day window always returns 30 buckets, even when every counter in
+  // every bucket is zero — `chartRows.length` is never 0 in practice, so it
+  // cannot gate the chart's own empty message. This sums the four DISJOINT
+  // series fields actually drawn on the chart (real field names, not the raw
+  // DTO totals) — narrower than `hasAnyOutcome` above, which also covers
+  // counters the chart never draws (drafts, narratives, suppressions, ...).
+  // Gates ONLY the chart panel, never the tile groups or the page EmptyState.
+  const hasChartOutcome = useMemo(
+    () =>
+      chartRows.some(
+        (r) => r.noiseFlagged + r.alertsJudgedNet + r.ticketsTriaged + r.fixesExecuted > 0,
+      ),
+    [chartRows],
+  );
 
   return (
     <div className="space-y-6" data-testid="ai-impact-page">
@@ -467,37 +548,81 @@ export default function ImpactPage() {
             data-testid="ai-impact-refresh"
             onClick={() => void handleRefresh()}
             disabled={poll !== null}
-            className="inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+            aria-label={poll ? t('aiAgentsPage.impact.refreshing') : t('aiAgentsPage.impact.refresh')}
+            className="inline-flex h-9 w-9 items-center justify-center rounded-md border hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
           >
             <RefreshCw className={`h-4 w-4 ${poll ? 'animate-spin' : ''}`} />
-            {poll ? t('aiAgentsPage.impact.refreshing') : t('aiAgentsPage.impact.refresh')}
           </button>
 
-          {dto && (
-            <button
-              type="button"
-              data-testid="ai-impact-export-pdf"
-              onClick={() => void handleExportPdf()}
-              className="inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm hover:bg-muted"
-            >
-              <Download className="h-4 w-4" />
-              {t('aiAgentsPage.impact.exportPdf')}
-            </button>
-          )}
+          {/* Two secondary buttons at md+, collapsed into a single overflow
+              menu below md so the header never wraps to 2-3 rows. */}
+          <div className="hidden items-center gap-2 md:flex">
+            {dto && (
+              <button
+                type="button"
+                data-testid="ai-impact-export-pdf"
+                onClick={() => void handleExportPdf()}
+                className="inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm hover:bg-muted"
+              >
+                <Download className="h-4 w-4" />
+                {t('aiAgentsPage.impact.exportPdf')}
+              </button>
+            )}
 
-          {/* The server 403s a caller without canManagePartnerWidePolicies —
-              hiding the button for that case is a UX convenience, not the
-              real gate. */}
-          {dto?.canEditWeights && (
-            <button
-              type="button"
-              data-testid="ai-impact-edit-weights"
-              onClick={() => setWeightsDrawerOpen(true)}
-              className="inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm hover:bg-muted"
-            >
-              <Settings2 className="h-4 w-4" />
-              {t('aiAgentsPage.impact.editWeights')}
-            </button>
+            {/* The server 403s a caller without canManagePartnerWidePolicies —
+                hiding the button for that case is a UX convenience, not the
+                real gate. */}
+            {dto?.canEditWeights && (
+              <button
+                type="button"
+                data-testid="ai-impact-edit-weights"
+                onClick={() => setWeightsDrawerOpen(true)}
+                className="inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm hover:bg-muted"
+              >
+                <Settings2 className="h-4 w-4" />
+                {t('aiAgentsPage.impact.editWeights')}
+              </button>
+            )}
+          </div>
+
+          {dto && (
+            <details ref={overflowMenuRef} className="relative md:hidden">
+              <summary
+                data-testid="ai-impact-overflow-menu"
+                aria-label={t('aiAgentsPage.impact.moreActions')}
+                className="flex h-9 w-9 cursor-pointer list-none items-center justify-center rounded-md border hover:bg-muted [&::-webkit-details-marker]:hidden"
+              >
+                <MoreHorizontal className="h-4 w-4" />
+              </summary>
+              <div className="absolute right-0 z-10 mt-1 w-56 rounded-md border bg-popover p-1 shadow-md">
+                <button
+                  type="button"
+                  data-testid="ai-impact-export-pdf-overflow"
+                  onClick={() => {
+                    closeOverflowMenu();
+                    void handleExportPdf();
+                  }}
+                  className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-muted"
+                >
+                  <Download className="h-4 w-4" />
+                  {t('aiAgentsPage.impact.exportPdf')}
+                </button>
+                {dto.canEditWeights && (
+                  <button
+                    type="button"
+                    data-testid="ai-impact-edit-weights-overflow"
+                    onClick={() => {
+                      closeOverflowMenu();
+                      setWeightsDrawerOpen(true);
+                    }}
+                    className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-muted"
+                  >
+                    <Settings2 className="h-4 w-4" />
+                    {t('aiAgentsPage.impact.editWeights')}
+                  </button>
+                )}
+              </div>
+            </details>
           )}
         </div>
       </div>
@@ -510,91 +635,131 @@ export default function ImpactPage() {
         onSaved={handleWeightsSaved}
       />
 
-      {loading && (
-        <p className="text-sm text-muted-foreground" data-testid="ai-impact-loading">
-          {t('aiAgentsPage.impact.loading')}
-        </p>
-      )}
+      {/* aria-live so a screen reader announces the loading -> loaded/error
+          transition, same as RunsListPage's async status region. */}
+      <div aria-live="polite">
+        {loading && (
+          <p className="text-sm text-muted-foreground" data-testid="ai-impact-loading">
+            {t('aiAgentsPage.impact.loading')}
+          </p>
+        )}
 
-      {!loading && error && (
-        <div
-          data-testid="ai-impact-error"
-          className="rounded-lg border border-destructive/40 bg-destructive/10 p-6 text-center"
-        >
-          <p className="text-sm text-destructive">{error}</p>
-          <button
-            type="button"
-            data-testid="ai-impact-retry"
-            onClick={() => setReloadToken((token) => token + 1)}
-            className="mt-4 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+        {!loading && error && (
+          <div
+            data-testid="ai-impact-error"
+            className="rounded-lg border border-destructive/40 bg-destructive/10 p-6 text-center"
           >
-            {t('aiAgentsPage.impact.retry')}
-          </button>
-        </div>
-      )}
+            <p className="text-sm text-destructive">{error}</p>
+            <button
+              type="button"
+              data-testid="ai-impact-retry"
+              onClick={() => setReloadToken((token) => token + 1)}
+              className="mt-4 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+            >
+              {t('aiAgentsPage.impact.retry')}
+            </button>
+          </div>
+        )}
+      </div>
 
       {!loading && !error && dto && (
         <>
-          <div
-            className={`grid grid-cols-2 gap-3 lg:grid-cols-4 ${
-              dto.promoteEligibleCount === null ? 'xl:grid-cols-7' : 'xl:grid-cols-8'
-            }`}
-          >
-            <Tile
-              testId="ai-impact-tile-alerts-judged"
-              label={t('aiAgentsPage.impact.tiles.alertsJudged')}
-              value={formatNumber(dto.totals.alertsJudged)}
-            />
-            <Tile
-              testId="ai-impact-tile-noise-flagged"
-              label={t('aiAgentsPage.impact.tiles.noiseFlagged')}
-              value={formatNumber(dto.totals.noiseFlagged)}
-            />
-            <Tile
-              testId="ai-impact-tile-tickets-triaged"
-              label={t('aiAgentsPage.impact.tiles.ticketsTriaged')}
-              value={formatNumber(dto.totals.ticketsTriaged)}
-            />
-            <Tile
-              testId="ai-impact-tile-drafts-sent"
-              label={t('aiAgentsPage.impact.tiles.draftsSent')}
-              value={formatNumber(dto.totals.draftsSent)}
-            />
-            <Tile
-              testId="ai-impact-tile-fixes-executed"
-              label={t('aiAgentsPage.impact.tiles.fixesExecuted')}
-              value={formatNumber(dto.totals.fixesExecuted)}
-            />
-            {/* The estimate and the one actually-measured number on this page
-                sit side by side, deliberately — see the plan's honest-labelling
-                rule. */}
-            <Tile
-              testId="ai-impact-tile-est-seconds-saved"
-              label={t('aiAgentsPage.impact.tiles.estTimeSaved')}
-              value={t('aiAgentsPage.impact.tiles.estTimeSavedValue', {
-                hours: formatNumber(dto.totals.estSecondsSaved / 3600, {
-                  maximumFractionDigits: 1,
-                }),
-              })}
-              title={weightsTooltip}
-            />
-            <Tile
-              testId="ai-impact-tile-llm-cents"
-              label={t('aiAgentsPage.impact.tiles.llmSpend')}
-              value={formatCurrency(dto.totals.llmCents / 100)}
-            />
-            {/* P2-6b: a nudge, not a list — the graduation panel re-derives state per
-                read, so the exact rows live there and this only ever links to them. */}
-            {dto.promoteEligibleCount !== null && (
-              <Tile
-                testId="ai-impact-tile-promote-eligible"
-                label={t('aiAgentsPage.impact.tiles.promoteEligible')}
-                value={formatNumber(dto.promoteEligibleCount)}
-                title={t('aiAgentsPage.impact.tiles.promoteEligibleHint')}
-                href="/settings/ai-agents"
-              />
-            )}
-          </div>
+          {hasAnyOutcome && (
+            <div className="space-y-4">
+              <div>
+                <h2 className="mb-2 text-sm font-semibold text-muted-foreground">
+                  {t('aiAgentsPage.impact.tileGroups.judged')}
+                </h2>
+                <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+                  <Tile
+                    testId="ai-impact-tile-alerts-judged"
+                    label={t('aiAgentsPage.impact.tiles.alertsJudged')}
+                    value={formatNumber(dto.totals.alertsJudged)}
+                  />
+                  <Tile
+                    testId="ai-impact-tile-noise-flagged"
+                    label={t('aiAgentsPage.impact.tiles.noiseFlagged')}
+                    value={formatNumber(dto.totals.noiseFlagged)}
+                  />
+                  <Tile
+                    testId="ai-impact-tile-tickets-triaged"
+                    label={t('aiAgentsPage.impact.tiles.ticketsTriaged')}
+                    value={formatNumber(dto.totals.ticketsTriaged)}
+                  />
+                  <Tile
+                    testId="ai-impact-tile-drafts-sent"
+                    label={t('aiAgentsPage.impact.tiles.draftsSent')}
+                    value={formatNumber(dto.totals.draftsSent)}
+                  />
+                </div>
+              </div>
+
+              <div>
+                <h2 className="mb-2 text-sm font-semibold text-muted-foreground">
+                  {t('aiAgentsPage.impact.tileGroups.executed')}
+                </h2>
+                <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+                  <Tile
+                    testId="ai-impact-tile-fixes-executed"
+                    label={t('aiAgentsPage.impact.tiles.fixesExecuted')}
+                    value={formatNumber(dto.totals.fixesExecuted)}
+                  />
+                  {/* The estimate and the one actually-measured number on this page
+                      sit side by side, deliberately — see the plan's honest-labelling
+                      rule. */}
+                  <Tile
+                    testId="ai-impact-tile-est-seconds-saved"
+                    label={t('aiAgentsPage.impact.tiles.estTimeSaved')}
+                    value={t('aiAgentsPage.impact.tiles.estTimeSavedValue', {
+                      hours: formatNumber(dto.totals.estSecondsSaved / 3600, {
+                        maximumFractionDigits: 1,
+                      }),
+                    })}
+                    caption={t('aiAgentsPage.impact.tiles.estTimeSavedCaption')}
+                    disclosure={
+                      <details
+                        data-testid="ai-impact-est-seconds-saved-disclosure"
+                        className="mt-1 text-xs text-muted-foreground"
+                      >
+                        <summary className="cursor-pointer select-none hover:text-foreground">
+                          {t('aiAgentsPage.impact.tiles.howEstimatedToggle')}
+                        </summary>
+                        <p className="mt-1">{t('aiAgentsPage.impact.weightsTooltipTitle')}</p>
+                        <ul className="mt-1 space-y-0.5">
+                          {IMPACT_WEIGHT_KEYS.map((key) => (
+                            <li key={key}>
+                              {t('aiAgentsPage.impact.weightsTooltipLine', {
+                                label: weightLabel(t, key),
+                                minutes: formatNumber(weights[key] / 60, {
+                                  maximumFractionDigits: 1,
+                                }),
+                              })}
+                            </li>
+                          ))}
+                        </ul>
+                      </details>
+                    }
+                  />
+                  <Tile
+                    testId="ai-impact-tile-llm-cents"
+                    label={t('aiAgentsPage.impact.tiles.llmSpend')}
+                    value={formatCurrency(dto.totals.llmCents / 100)}
+                  />
+                  {/* P2-6b: a nudge, not a list — the graduation panel re-derives state per
+                      read, so the exact rows live there and this only ever links to them. */}
+                  {dto.promoteEligibleCount !== null && (
+                    <Tile
+                      testId="ai-impact-tile-promote-eligible"
+                      label={t('aiAgentsPage.impact.tiles.promoteEligible')}
+                      value={formatNumber(dto.promoteEligibleCount)}
+                      caption={t('aiAgentsPage.impact.tiles.promoteEligibleCaption')}
+                      href="/settings/ai-agents"
+                    />
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
 
           <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-muted-foreground">
             <p data-testid="ai-impact-freshness">
@@ -619,50 +784,88 @@ export default function ImpactPage() {
             )}
           </div>
 
-          <div className="rounded-lg border p-4">
-            <h2 className="mb-3 text-sm font-semibold">{t('aiAgentsPage.impact.chart.title')}</h2>
-            {chartRows.length === 0 ? (
-              <p className="text-sm text-muted-foreground" data-testid="ai-impact-chart-empty">
-                {t('aiAgentsPage.impact.chart.empty')}
-              </p>
-            ) : (
-              <div className="h-72" data-testid="ai-impact-chart">
-                <ResponsiveContainer width="100%" height="100%">
-                  <BarChart data={chartRows}>
-                    <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                    <XAxis dataKey="day" tick={{ fontSize: 11 }} />
-                    <YAxis tick={{ fontSize: 11 }} allowDecimals={false} />
-                    <Tooltip />
-                    <Legend />
-                    <Bar
-                      stackId="outcomes"
-                      dataKey="noiseFlagged"
-                      name={t('aiAgentsPage.impact.chart.noiseFlagged')}
-                      fill="#f59e0b"
-                    />
-                    <Bar
-                      stackId="outcomes"
-                      dataKey="alertsJudgedNet"
-                      name={t('aiAgentsPage.impact.chart.alertsJudgedNet')}
-                      fill="#3b82f6"
-                    />
-                    <Bar
-                      stackId="outcomes"
-                      dataKey="ticketsTriaged"
-                      name={t('aiAgentsPage.impact.chart.ticketsTriaged')}
-                      fill="#14b8a6"
-                    />
-                    <Bar
-                      stackId="outcomes"
-                      dataKey="fixesExecuted"
-                      name={t('aiAgentsPage.impact.chart.fixesExecuted')}
-                      fill="#8b5cf6"
-                    />
-                  </BarChart>
-                </ResponsiveContainer>
+          {hasAnyOutcome ? (
+            hasChartOutcome ? (
+              <div className="rounded-lg border p-4">
+                <h2 className="mb-3 text-sm font-semibold">{t('aiAgentsPage.impact.chart.title')}</h2>
+                <div className="ai-impact-chart-fills h-72" data-testid="ai-impact-chart">
+                  <style>{AI_IMPACT_CHART_FILL_CSS}</style>
+                  <ResponsiveContainer width="100%" height="100%">
+                    <BarChart data={chartRows}>
+                      <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+                      <XAxis
+                        dataKey="day"
+                        tick={{ fontSize: 11, fill: 'hsl(var(--muted-foreground))' }}
+                      />
+                      <YAxis
+                        tick={{ fontSize: 11, fill: 'hsl(var(--muted-foreground))' }}
+                        allowDecimals={false}
+                      />
+                      <Tooltip wrapperClassName="chart-tooltip" />
+                      <Legend wrapperStyle={{ color: 'hsl(var(--muted-foreground))' }} />
+                      {/* Categorical hues chosen to be distinct from status semantics
+                          (danger/warning/success/info) — "noise flagged" in particular
+                          must never be amber, since amber means warning everywhere else
+                          in the product. */}
+                      <Bar
+                        stackId="outcomes"
+                        dataKey="noiseFlagged"
+                        name={t('aiAgentsPage.impact.chart.noiseFlagged')}
+                        fill="hsl(var(--ai-impact-chart-noise))"
+                      />
+                      <Bar
+                        stackId="outcomes"
+                        dataKey="alertsJudgedNet"
+                        name={t('aiAgentsPage.impact.chart.alertsJudgedNet')}
+                        fill="hsl(var(--ai-impact-chart-judged))"
+                      />
+                      <Bar
+                        stackId="outcomes"
+                        dataKey="ticketsTriaged"
+                        name={t('aiAgentsPage.impact.chart.ticketsTriaged')}
+                        fill="hsl(var(--ai-impact-chart-tickets))"
+                      />
+                      <Bar
+                        stackId="outcomes"
+                        dataKey="fixesExecuted"
+                        name={t('aiAgentsPage.impact.chart.fixesExecuted')}
+                        fill="hsl(var(--ai-impact-chart-fixes))"
+                      />
+                    </BarChart>
+                  </ResponsiveContainer>
+                </div>
               </div>
-            )}
-          </div>
+            ) : (
+              // hasAnyOutcome but NOT hasChartOutcome: e.g. a drafts-only or
+              // narrative-only agent — real activity, just none of the four
+              // series the bar chart stacks. A lighter inline message, not
+              // the page EmptyState (the tile groups above already show the
+              // real numbers, so this is not an empty page).
+              <div
+                className="rounded-lg border p-4 text-center text-sm text-muted-foreground"
+                data-testid="ai-impact-chart-empty"
+              >
+                {t('aiAgentsPage.impact.chart.empty')}
+              </div>
+            )
+          ) : (
+            <EmptyState
+              testId="ai-impact-empty"
+              icon={<TrendingUp className="h-7 w-7" />}
+              title={t('aiAgentsPage.impact.emptyState.title')}
+              description={t('aiAgentsPage.impact.emptyState.description')}
+              headingLevel={2}
+              action={
+                <a
+                  href="/settings/ai-agents"
+                  data-testid="ai-impact-empty-action"
+                  className="inline-flex items-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+                >
+                  {t('aiAgentsPage.impact.emptyState.action')}
+                </a>
+              }
+            />
+          )}
 
           {dto.byOrg.length > 0 && (
             <div className="overflow-hidden rounded-lg border" data-testid="ai-impact-by-org">

--- a/apps/web/src/components/aiAgents/ImpactWeightsDrawer.tsx
+++ b/apps/web/src/components/aiAgents/ImpactWeightsDrawer.tsx
@@ -4,6 +4,7 @@ import '@/lib/i18n';
 import { Drawer } from '../shared/Drawer';
 import { fetchWithAuth } from '../../stores/auth';
 import { runAction } from '@/lib/runAction';
+import { badgeClass } from './statusBadge';
 import { DEFAULT_IMPACT_WEIGHTS, IMPACT_WEIGHT_KEYS, IMPACT_WEIGHT_MAX_SECONDS } from '@breeze/shared';
 import type { ImpactWeightOverrides, ImpactWeights } from '@breeze/shared';
 
@@ -164,7 +165,7 @@ export default function ImpactWeightsDrawer({
             {overrides?.[key] !== undefined && (
               <span
                 data-testid={`ai-impact-weight-${key}-customized`}
-                className="ml-2 text-xs text-amber-600 dark:text-amber-400"
+                className={`ml-2 ${badgeClass('accent', { size: 'sm' })}`}
               >
                 {t('aiAgentsPage.impact.weightsDrawer.customized')}
               </span>

--- a/apps/web/src/components/aiAgents/RunDetailPage.test.tsx
+++ b/apps/web/src/components/aiAgents/RunDetailPage.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
 vi.mock('../reports/reportExport', () => ({
@@ -414,13 +414,19 @@ describe('RunDetailPage sweep findings', () => {
     expect(row).toHaveTextContent('The watched Spooler service has been stopped since 09:12.');
   });
 
-  it('renders evidence as key/value pairs rather than a raw JSON blob', async () => {
+  it('renders evidence as a definition list of key/value pairs rather than a raw JSON blob or a flattened string', async () => {
     mockEndpoints({ detail: { ...RUN_DETAIL, sweep: SWEEP } });
     const { container } = render(<RunDetailPage runId="run-1" />);
 
     await waitFor(() => expect(screen.getByTestId('ai-agent-run-sweep-finding-0')).toBeInTheDocument());
-    expect(screen.getByTestId('ai-agent-run-sweep-finding-0-evidence')).toHaveTextContent('serviceName: Spooler');
-    expect(screen.getByTestId('ai-agent-run-sweep-finding-0-evidence')).toHaveTextContent('state: stopped');
+    const evidence = screen.getByTestId('ai-agent-run-sweep-finding-0-evidence');
+    // A real <dl> with <dt>/<dd> pairs — not a flattened "k: v · k: v" string
+    // — so a screen reader gets term/value structure.
+    expect(evidence.tagName).toBe('DL');
+    const terms = evidence.querySelectorAll('dt');
+    const values = evidence.querySelectorAll('dd');
+    expect(Array.from(terms).map((el) => el.textContent)).toEqual(['serviceName:', 'state:']);
+    expect(Array.from(values).map((el) => el.textContent)).toEqual(['Spooler', 'stopped']);
     // A JSON dump would carry the object punctuation; the k/v rendering never does.
     expect(container.innerHTML).not.toContain('{&quot;serviceName&quot;');
   });
@@ -663,7 +669,10 @@ describe('RunDetailPage ticket triage proposal', () => {
     render(<RunDetailPage runId="run-1" />);
 
     const categoryRow = await screen.findByTestId('ai-agent-run-triage-field-categoryId');
-    expect(categoryRow).toHaveTextContent('cat-hardware-printer');
+    // Critique finding #6: the DTO carries no resolved category NAME, only a
+    // raw internal category UUID (`fields.categoryId.value`) — that id must
+    // never reach the DOM. Only its confidence is shown.
+    expect(categoryRow).not.toHaveTextContent('cat-hardware-printer');
     expect(categoryRow).toHaveTextContent('82');
 
     const priorityRow = screen.getByTestId('ai-agent-run-triage-field-priority');
@@ -766,5 +775,226 @@ describe('RunDetailPage ticket triage proposal', () => {
 
     await waitFor(() => screen.getByTestId('ai-agent-run-triage'));
     expect(screen.queryByTestId('ai-agent-run-triage-skipped')).not.toBeInTheDocument();
+  });
+});
+
+// Critique finding #5 — the document outline must run h1 → h2 → h3 with no
+// skipped level. The exposure-budget card used to be an h3 sandwiched
+// between the page h1 and the next section's h2.
+describe('RunDetailPage heading order', () => {
+  it('keeps every top-level section at h2, sibling to the exposure-budget card', async () => {
+    mockEndpoints({ detail: { ...RUN_DETAIL, sweep: SWEEP } });
+    render(<RunDetailPage runId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('run-detail-budget-card')).toBeInTheDocument());
+
+    const h1s = screen.getAllByRole('heading', { level: 1 });
+    expect(h1s).toHaveLength(1);
+
+    const budgetHeading = screen.getByText('Exposure budget');
+    expect(budgetHeading.tagName).toBe('H2');
+
+    const sweepHeading = screen.getByText('Sweep findings');
+    expect(sweepHeading.tagName).toBe('H2');
+
+    const traceHeading = screen.getByText('Execution trace');
+    expect(traceHeading.tagName).toBe('H2');
+  });
+});
+
+// Critique finding #6 — the ledger must never print the raw AiToolStatus
+// enum token; it goes through i18n first.
+describe('RunDetailPage ledger status labels', () => {
+  it('translates the ledger status instead of printing the raw enum', async () => {
+    mockEndpoints();
+    render(<RunDetailPage runId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('run-detail-ledger')).toBeInTheDocument());
+    const row = screen.getByTestId('run-detail-ledger').querySelector('tbody tr');
+    expect(row).not.toBeNull();
+    // RUN_DETAIL.ledger[0].status is the raw enum 'completed' — the cell
+    // must show the translated label, not the bare lowercase token.
+    expect(row).toHaveTextContent('Completed');
+  });
+});
+
+// Critique finding #3 — bare muted <p> empty states become a structured
+// EmptyState with a description of what will appear.
+describe('RunDetailPage empty states', () => {
+  it('renders a not-found EmptyState with a description and a way back to the list', async () => {
+    mockEndpoints({ detailOk: false, detailStatus: 404 });
+    render(<RunDetailPage runId="missing" />);
+
+    await waitFor(() => expect(screen.getByTestId('run-detail-not-found')).toBeInTheDocument());
+    expect(screen.getByText('Run not found.')).toBeInTheDocument();
+    expect(screen.getByText(/deleted|out of date/i)).toBeInTheDocument();
+    expect(screen.getByText('Back to runs')).toHaveAttribute('href', '/ai-agents/runs');
+  });
+
+  it('renders a description in the empty trace/ledger/intents sections instead of a bare line', async () => {
+    mockEndpoints({ detail: { ...RUN_DETAIL, trace: [], ledger: [], intents: [] } });
+    render(<RunDetailPage runId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('run-detail-header')).toBeInTheDocument());
+    expect(screen.getByText('No trace entries recorded.')).toBeInTheDocument();
+    expect(screen.getByText('Tool calls the agent proposes or executes will be listed here.')).toBeInTheDocument();
+    expect(screen.getByText('No tool executions recorded.')).toBeInTheDocument();
+    expect(screen.getByText('No linked approvals.')).toBeInTheDocument();
+  });
+});
+
+// Critique finding #1 — an in-flight run must update on its own; the page
+// polls silently (no full-page reload flicker) while status is non-terminal,
+// stops once terminal, and pauses while the tab is hidden.
+describe('RunDetailPage live polling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' });
+  });
+
+  it('polls every 5s while the run is running and reflects the updated status', async () => {
+    mockEndpoints({ detail: { ...RUN_DETAIL, status: 'running' as const } });
+    render(<RunDetailPage runId="run-1" />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('run-detail-header')).toHaveTextContent('Running');
+    expect(screen.getByTestId('run-live-indicator')).toBeInTheDocument();
+
+    mockEndpoints({ detail: { ...RUN_DETAIL, status: 'completed' as const } });
+    await act(async () => {
+      vi.advanceTimersByTime(5_000);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId('run-detail-header')).toHaveTextContent('Completed');
+    expect(screen.queryByTestId('run-live-indicator')).not.toBeInTheDocument();
+  });
+
+  it('never flips the page back to the full-page loading state while polling', async () => {
+    mockEndpoints({ detail: { ...RUN_DETAIL, status: 'running' as const } });
+    render(<RunDetailPage runId="run-1" />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('run-detail-page')).toBeInTheDocument();
+
+    await act(async () => {
+      vi.advanceTimersByTime(5_000);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // The header/page stayed mounted throughout — a naive poll that reused
+    // `load()` would have flipped `loading` and replaced this with
+    // `run-detail-loading` on every tick.
+    expect(screen.queryByTestId('run-detail-loading')).not.toBeInTheDocument();
+    expect(screen.getByTestId('run-detail-page')).toBeInTheDocument();
+  });
+
+  it('stops polling once the run is already terminal on first load', async () => {
+    mockEndpoints({ detail: { ...RUN_DETAIL, status: 'completed' as const } });
+    render(<RunDetailPage runId="run-1" />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const callsAfterLoad = fetchMock.mock.calls.length;
+
+    await act(async () => {
+      vi.advanceTimersByTime(30_000);
+      await Promise.resolve();
+    });
+
+    expect(fetchMock.mock.calls.length).toBe(callsAfterLoad);
+  });
+
+  it('pauses polling while the document is hidden', async () => {
+    mockEndpoints({ detail: { ...RUN_DETAIL, status: 'running' as const } });
+    render(<RunDetailPage runId="run-1" />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'hidden' });
+    const callsAfterLoad = fetchMock.mock.calls.length;
+
+    await act(async () => {
+      vi.advanceTimersByTime(5_000);
+      await Promise.resolve();
+    });
+
+    expect(fetchMock.mock.calls.length).toBe(callsAfterLoad);
+  });
+
+  // Review finding P2-2 (#4187 critique): overlapping poll responses must
+  // apply in request order, not resolution order.
+  it('discards a stale poll response that resolves after a newer one', async () => {
+    mockEndpoints({ detail: { ...RUN_DETAIL, status: 'running' as const } });
+    render(<RunDetailPage runId="run-1" />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('run-detail-header')).toHaveTextContent('Running');
+
+    let resolveOlder!: (value: Response) => void;
+    let resolveNewer!: (value: Response) => void;
+    const detailResponses = [
+      new Promise<Response>((resolve) => {
+        resolveOlder = resolve;
+      }),
+      new Promise<Response>((resolve) => {
+        resolveNewer = resolve;
+      }),
+    ];
+    let call = 0;
+    fetchMock.mockImplementation((url: string) => {
+      if (url.startsWith('/ai/agents/runs/')) {
+        return detailResponses[call++] ?? Promise.resolve(json({ data: RUN_DETAIL }));
+      }
+      if (url.startsWith('/ai/agents/exposure-budget')) {
+        return Promise.resolve(json({ data: BUDGET }));
+      }
+      return Promise.resolve(json({ data: [] }));
+    });
+
+    // Two poll ticks fire back to back (5s cadence while running) before
+    // either response resolves.
+    await act(async () => {
+      vi.advanceTimersByTime(5_000);
+      await Promise.resolve();
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(5_000);
+      await Promise.resolve();
+    });
+
+    // Resolve the NEWER request first with a fresh status, then the OLDER
+    // request with a stale one — the stale one must not win.
+    resolveNewer(json({ data: { ...RUN_DETAIL, status: 'completed' as const } }));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    resolveOlder(json({ data: { ...RUN_DETAIL, status: 'running' as const } }));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId('run-detail-header')).toHaveTextContent('Completed');
   });
 });

--- a/apps/web/src/components/aiAgents/RunDetailPage.tsx
+++ b/apps/web/src/components/aiAgents/RunDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import '@/lib/i18n';
 import { ArrowLeft, Bot, Download, ExternalLink, Loader2 } from 'lucide-react';
@@ -6,8 +6,12 @@ import { fetchWithAuth } from '../../stores/auth';
 import { exportReport, getBrowserTimezone } from '../reports/reportExport';
 import { formatDate, formatDateTime } from '@/lib/dateTimeFormat';
 import { formatCurrency, formatNumber } from '@/lib/i18n/format';
+import { badgeClass, runStatusTone, verdictTone } from './statusBadge';
+import { EmptyState } from '../shared/EmptyState';
 import type {
   AiAgentRunDetailDto,
+  AiAgentRunLedgerEntryDto,
+  AiAgentRunStatus,
   AiAgentRunSweepFindingDto,
   AiAgentRunTicketProposalDto,
   AiAgentRunTraceEntryDto,
@@ -23,40 +27,38 @@ interface RunDetailPageProps {
   runId: string;
 }
 
+/** Every status NOT in this set is "live" — mirrors RunsListPage's
+ * TERMINAL_RUN_STATUSES so both surfaces agree on when a run stops updating. */
+const TERMINAL_RUN_STATUSES = new Set<AiAgentRunStatus>([
+  'completed', 'failed', 'cancelled', 'expired', 'skipped',
+]);
+function isLiveRunStatus(status: AiAgentRunStatus): boolean {
+  return !TERMINAL_RUN_STATUSES.has(status);
+}
+
+const DETAIL_POLL_INTERVAL_MS = 5_000;
+
+/** See RunsListPage's `LiveIndicator` — same decorative-dot + sr-only-label
+ * contract, duplicated locally rather than shared since it is a two-line
+ * component and these two files intentionally don't share a module. */
+function LiveIndicator({ label }: { label: string }) {
+  return (
+    <span className="ml-1.5 inline-flex items-center" data-testid="run-live-indicator">
+      <span className="relative flex h-2 w-2" aria-hidden="true">
+        <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-sky-500 opacity-75" />
+        <span className="relative inline-flex h-2 w-2 rounded-full bg-sky-500" />
+      </span>
+      <span className="sr-only">{label}</span>
+    </span>
+  );
+}
+
 function formatDuration(ms: number | null): string {
   if (ms === null || Number.isNaN(ms)) return '—';
   const totalSeconds = Math.round(ms / 1000);
   const minutes = Math.floor(totalSeconds / 60);
   const seconds = totalSeconds % 60;
   return minutes > 0 ? `${minutes}m ${seconds}s` : `${seconds}s`;
-}
-
-function statusBadgeClass(status: string): string {
-  switch (status) {
-    case 'completed':
-      return 'bg-emerald-500/10 text-emerald-600';
-    case 'failed':
-      return 'bg-red-500/10 text-red-600';
-    case 'running':
-      return 'bg-blue-500/10 text-blue-600';
-    case 'awaiting_approval':
-      return 'bg-amber-500/10 text-amber-700';
-    default:
-      return 'bg-muted text-muted-foreground';
-  }
-}
-
-function verdictBadgeClass(verdict: string | null): string {
-  switch (verdict) {
-    case 'remediated':
-      return 'bg-emerald-500/10 text-emerald-600';
-    case 'partial':
-      return 'bg-amber-500/10 text-amber-700';
-    case 'needs_attention':
-      return 'bg-red-500/10 text-red-600';
-    default:
-      return 'bg-muted text-muted-foreground';
-  }
 }
 
 function verdictLabel(t: (key: string) => string, value: string | null): string {
@@ -114,6 +116,27 @@ function triggerLabel(t: (key: string) => string, value: string): string {
   }
 }
 
+/** `AiAgentRunLedgerEntryDto.status` (`AiToolStatus`) → i18n label, so the
+ * ledger never prints the raw enum token (critique finding #6). */
+function ledgerStatusLabel(t: (key: string) => string, value: AiAgentRunLedgerEntryDto['status']): string {
+  switch (value) {
+    case 'pending':
+      return t('aiAgentsRuns.detail.ledger.statuses.pending');
+    case 'approved':
+      return t('aiAgentsRuns.detail.ledger.statuses.approved');
+    case 'executing':
+      return t('aiAgentsRuns.detail.ledger.statuses.executing');
+    case 'completed':
+      return t('aiAgentsRuns.detail.ledger.statuses.completed');
+    case 'failed':
+      return t('aiAgentsRuns.detail.ledger.statuses.failed');
+    case 'rejected':
+      return t('aiAgentsRuns.detail.ledger.statuses.rejected');
+    default:
+      return value;
+  }
+}
+
 function traceKindLabel(t: (key: string) => string, kind: AiAgentRunTraceEntryDto['kind']): string {
   switch (kind) {
     case 'executed':
@@ -160,13 +183,13 @@ function verificationLabel(t: (key: string) => string, value: string): string {
 function traceEntryBadgeClass(kind: AiAgentRunTraceEntryDto['kind']): string {
   switch (kind) {
     case 'executed':
-      return 'bg-blue-500/10 text-blue-600';
+      return badgeClass('info', { size: 'sm' });
     case 'proposed':
-      return 'bg-amber-500/10 text-amber-700';
+      return badgeClass('warning', { size: 'sm' });
     case 'denied':
-      return 'bg-red-500/10 text-red-600';
+      return badgeClass('danger', { size: 'sm' });
     default:
-      return 'bg-muted text-muted-foreground';
+      return badgeClass('neutral', { size: 'sm' });
   }
 }
 
@@ -176,6 +199,12 @@ function traceEntryBadgeClass(kind: AiAgentRunTraceEntryDto['kind']): string {
  * ever carry a raw tool input/output, by construction (see the DTO file's
  * header comment). `intentsById` links a `proposed` entry with an
  * `intentId` onward to `/approvals`, never to the intent's own content.
+ *
+ * UI critique finding #6: the DTO carries a `durationMs` for an `executed`
+ * entry but NO timestamp field on any of the three trace-entry variants
+ * (`AiAgentRunTraceEntryDto` in packages/shared/src/types/aiAgentRuns.ts) —
+ * there is nothing here to format. Rendering a start time is therefore out
+ * of scope for this component; it needs a wire-level field added first.
  */
 function TraceEntryRow({
   entry,
@@ -189,7 +218,7 @@ function TraceEntryRow({
   return (
     <li data-testid={`run-detail-trace-entry-${index}`} className="flex flex-col gap-1 border-b py-3 last:border-b-0">
       <div className="flex flex-wrap items-center gap-2">
-        <span className={`inline-flex rounded px-1.5 py-0.5 text-xs font-medium ${traceEntryBadgeClass(entry.kind)}`}>
+        <span className={traceEntryBadgeClass(entry.kind)}>
           {traceKindLabel(t, entry.kind)}
         </span>
         <span className="font-medium">{entry.tool}</span>
@@ -253,16 +282,18 @@ function TraceEntryRow({
  * Same leak-impossible contract as the trace above: `AiAgentRunSweepDto` is
  * the SAFE projection (packages/shared/src/types/aiAgentRuns.ts), so nothing
  * rendered here can be a raw tool input/output. `evidence` is the bounded
- * scalar map the finding schema enforces and is rendered as `key: value`
- * pairs — never `JSON.stringify`d, which is how an unexpectedly nested value
- * would end up dumped verbatim into the DOM.
+ * scalar map the finding schema enforces and is rendered as a `<dl>` of
+ * term/value pairs (never `JSON.stringify`d, which is how an unexpectedly
+ * nested value would end up dumped verbatim into the DOM) — a `<dl>` rather
+ * than a flattened "k: v · k: v" string so a screen reader gets real
+ * term/value structure instead of one opaque run of text.
  */
 const SWEEP_SEVERITY_BADGE: Record<AiSweepSeverity, string> = {
-  critical: 'bg-red-500/10 text-red-600',
-  high: 'bg-orange-500/10 text-orange-700',
-  medium: 'bg-amber-500/10 text-amber-700',
-  low: 'bg-blue-500/10 text-blue-600',
-  info: 'bg-muted text-muted-foreground',
+  critical: badgeClass('danger', { size: 'sm' }),
+  high: badgeClass('warning', { size: 'sm' }),
+  medium: badgeClass('warning', { size: 'sm' }),
+  low: badgeClass('info', { size: 'sm' }),
+  info: badgeClass('neutral', { size: 'sm' }),
 };
 
 /**
@@ -294,11 +325,28 @@ function sweepReasonLabel(t: (key: string) => string, reason: string | null): st
   return t(/* i18n-dynamic */ `aiAgentsPage.runs.sweep.reasons.${reason}`);
 }
 
-/** `k: v · k: v` — the bounded scalar evidence map, never a JSON dump. */
-function formatSweepEvidence(evidence: AiAgentRunSweepFindingDto['evidence']): string {
-  return Object.entries(evidence)
-    .map(([key, value]) => `${key}: ${value === null ? '—' : String(value)}`)
-    .join(' · ');
+/** The bounded scalar evidence map, rendered as `<dt>`/`<dd>` pairs — never a
+ * JSON dump, and never a flattened "k: v" string a screen reader would read
+ * as one undifferentiated run of text. */
+function SweepEvidenceList({
+  evidence,
+  testId,
+}: {
+  evidence: AiAgentRunSweepFindingDto['evidence'];
+  testId: string;
+}) {
+  const entries = Object.entries(evidence);
+  if (entries.length === 0) return null;
+  return (
+    <dl className="mt-1 space-y-0.5 text-xs" data-testid={testId}>
+      {entries.map(([key, value]) => (
+        <div key={key} className="flex gap-1">
+          <dt className="text-muted-foreground">{key}:</dt>
+          <dd>{value === null ? '—' : String(value)}</dd>
+        </div>
+      ))}
+    </dl>
+  );
 }
 
 function SweepFindingRow({
@@ -310,16 +358,13 @@ function SweepFindingRow({
   index: number;
   t: (key: string) => string;
 }) {
-  const evidence = formatSweepEvidence(finding.evidence);
   const { proposal } = finding;
 
   return (
     <tr data-testid={`ai-agent-run-sweep-finding-${index}`} className="align-top">
       <td className="px-2 py-2 whitespace-nowrap">{sweepKindLabel(t, finding.kind)}</td>
       <td className="px-2 py-2">
-        <span
-          className={`inline-flex rounded px-1.5 py-0.5 text-xs font-medium ${SWEEP_SEVERITY_BADGE[finding.severity] ?? 'bg-muted text-muted-foreground'}`}
-        >
+        <span className={SWEEP_SEVERITY_BADGE[finding.severity] ?? badgeClass('neutral', { size: 'sm' })}>
           {sweepSeverityLabel(t, finding.severity)}
         </span>
       </td>
@@ -329,14 +374,7 @@ function SweepFindingRow({
       <td className="px-2 py-2 font-medium">{finding.title}</td>
       <td className="px-2 py-2 text-muted-foreground">
         <span>{finding.detail}</span>
-        {evidence && (
-          <span
-            className="mt-1 block text-xs"
-            data-testid={`ai-agent-run-sweep-finding-${index}-evidence`}
-          >
-            {evidence}
-          </span>
-        )}
+        <SweepEvidenceList evidence={finding.evidence} testId={`ai-agent-run-sweep-finding-${index}-evidence`} />
       </td>
       <td className="px-2 py-2" data-testid={`ai-agent-run-sweep-finding-${index}-proposal`}>
         {proposal === null ? (
@@ -449,6 +487,13 @@ function skipReasonLabel(t: (key: string) => string, reason: TicketTriageSkip['r
  * cross-reference by id, falling back to the bare id if the run's intents
  * projection ever disagrees with it (defensive only; in practice
  * `intentIds` is populated FROM the same `action_intents` rows).
+ *
+ * UI critique finding #6: `fields.categoryId.value` is a raw internal
+ * category UUID — the DTO carries no resolved category name anywhere
+ * (`TicketTriageProposal` in packages/shared/src/types/ticketTriage.ts only
+ * ever ships `{ value, confidence }`). Rather than leak that id to the user,
+ * it is hidden; only the confidence is shown, with a note that the name
+ * could not be resolved on this surface.
  */
 function TicketProposalSection({
   proposal,
@@ -479,13 +524,9 @@ function TicketProposalSection({
           <ul className="space-y-1 text-sm">
             {proposal.fields?.categoryId && (
               <li data-testid="ai-agent-run-triage-field-categoryId">
-                {/* I3 (#4191 final review): this value is a raw category UUID
-                    (no catalog fetch here to resolve it to a name) — the
-                    "ID" label plus monospace styling makes that legible
-                    instead of reading as a broken/garbled category name. */}
-                <span className="font-medium">{t('aiAgentsPage.runs.triage.fields.categoryIdLabel')}</span>
+                <span className="font-medium">{t('aiAgentsRuns.detail.triage.categoryLabel')}</span>
                 {': '}
-                <span className="font-mono text-xs">{proposal.fields.categoryId.value}</span>{' '}
+                <span className="text-muted-foreground">{t('aiAgentsRuns.detail.triage.categoryUnresolved')}</span>{' '}
                 <span className="text-xs text-muted-foreground">
                   {t('aiAgentsPage.runs.triage.confidence', {
                     value: Math.round(proposal.fields.categoryId.confidence * 100),
@@ -660,7 +701,10 @@ function ExposureBudgetCard({ orgId, kind, t }: { orgId: string; kind: string; t
 
   return (
     <div data-testid="run-detail-budget-card" className="rounded-lg border bg-card p-4">
-      <h3 className="text-sm font-semibold">{t('aiAgentsPage.runs.detail.budget.title')}</h3>
+      {/* Sibling to the other top-level sections (sweep/narrative/trace/
+          ledger/intents all use h2) — was h3, which produced an h1 → h3 → h2
+          document-outline gap (critique finding #5). */}
+      <h2 className="text-sm font-semibold">{t('aiAgentsPage.runs.detail.budget.title')}</h2>
 
       {loading && (
         <p className="mt-2 text-sm text-muted-foreground" data-testid="run-detail-budget-loading">
@@ -687,7 +731,7 @@ function ExposureBudgetCard({ orgId, kind, t }: { orgId: string; kind: string; t
             {t('aiAgentsPage.runs.detail.budget.caption', { hours: budget.windowHours })}
           </p>
           {budget.accountingMode === 'partial' && (
-            <p className="text-xs text-amber-700" data-testid="run-detail-budget-partial-note">
+            <p className="mt-1 text-xs text-amber-700 dark:text-amber-400" data-testid="run-detail-budget-partial-note">
               {t('aiAgentsPage.runs.detail.budget.partialNote')}
             </p>
           )}
@@ -705,6 +749,14 @@ function ExposureBudgetCard({ orgId, kind, t }: { orgId: string; kind: string; t
  * exposure-budget readout. Nothing on this page can ever be a raw tool
  * input/output — the DTO union makes that impossible by construction (see
  * `packages/shared/src/types/aiAgentRuns.ts`).
+ *
+ * UI critique fix: while `run.status` is still live (queued/running/
+ * awaiting_approval), the page silently re-fetches every
+ * `DETAIL_POLL_INTERVAL_MS` — without flipping the full-page `loading` state,
+ * which would otherwise blank the whole page every 5 seconds — so an
+ * in-flight run's trace/ledger/status update without a manual reload.
+ * Polling stops once the run reaches a terminal status and pauses while the
+ * tab is hidden.
  */
 export default function RunDetailPage({ runId }: RunDetailPageProps) {
   const { t } = useTranslation('settings');
@@ -715,12 +767,31 @@ export default function RunDetailPage({ runId }: RunDetailPageProps) {
   const [downloadingNarrative, setDownloadingNarrative] = useState(false);
   const [narrativeDownloadError, setNarrativeDownloadError] = useState<string>();
 
+  // Monotonic request id shared by `load` and `refreshSilently` (review
+  // finding P2-2, #4187 critique — same pattern as RunsListPage's
+  // `fetchPage`/`pollListSilently`): whichever of the two started most
+  // recently wins, so a poll response that resolves after a newer `load()`
+  // (e.g. the user hit Retry, or the runId changed) can't regress the page,
+  // and out-of-order poll responses can't either.
+  const requestIdRef = useRef(0);
+  // Guards every setState here against firing after unmount.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
   const load = useCallback(async () => {
+    requestIdRef.current += 1;
+    const requestId = requestIdRef.current;
     setLoading(true);
     setError(undefined);
     setNotFound(false);
     try {
       const response = await fetchWithAuth(`/ai/agents/runs/${runId}`);
+      if (!mountedRef.current || requestId !== requestIdRef.current) return;
       if (response.status === 404) {
         setNotFound(true);
         return;
@@ -730,21 +801,55 @@ export default function RunDetailPage({ runId }: RunDetailPageProps) {
         return;
       }
       const body = (await response.json()) as { data?: AiAgentRunDetailDto };
+      if (!mountedRef.current || requestId !== requestIdRef.current) return;
       if (!body.data) {
         setError(t('aiAgentsPage.runs.detail.errors.load'));
         return;
       }
       setRun(body.data);
     } catch {
+      if (!mountedRef.current || requestId !== requestIdRef.current) return;
       setError(t('aiAgentsPage.runs.detail.errors.load'));
     } finally {
-      setLoading(false);
+      if (mountedRef.current && requestId === requestIdRef.current) setLoading(false);
     }
   }, [runId, t]);
 
   useEffect(() => {
     void load();
   }, [load]);
+
+  /**
+   * Background poll: refetches the run detail without touching `loading` (a
+   * silent refresh — flipping `loading` here would blank the whole page on
+   * every tick). Best-effort: a failed poll just tries again next tick,
+   * leaving whatever is currently on screen alone. Shares `requestIdRef`
+   * with `load` (review finding P2-2) so an older response landing after a
+   * newer one — from either function — is discarded instead of overwriting
+   * fresher data; `mountedRef` guards against setting state after unmount.
+   */
+  const refreshSilently = useCallback(async () => {
+    requestIdRef.current += 1;
+    const requestId = requestIdRef.current;
+    try {
+      const response = await fetchWithAuth(`/ai/agents/runs/${runId}`);
+      if (!mountedRef.current || requestId !== requestIdRef.current) return;
+      if (!response.ok) return;
+      const body = (await response.json()) as { data?: AiAgentRunDetailDto };
+      if (!mountedRef.current || requestId !== requestIdRef.current) return;
+      if (body.data) setRun(body.data);
+    } catch {
+      // Best-effort background refresh; keep showing the last good data.
+    }
+  }, [runId]);
+
+  useEffect(() => {
+    if (!run || !isLiveRunStatus(run.status)) return undefined;
+    const interval = setInterval(() => {
+      if (document.visibilityState === 'visible') void refreshSilently();
+    }, DETAIL_POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [run?.status, refreshSilently]);
 
   /**
    * Phase 2 wave P2-3 (#4190) — "Download PDF" on the narrative section.
@@ -796,9 +901,16 @@ export default function RunDetailPage({ runId }: RunDetailPageProps) {
 
   if (notFound) {
     return (
-      <p className="text-sm text-muted-foreground" data-testid="run-detail-not-found">
-        {t('aiAgentsPage.runs.detail.notFound')}
-      </p>
+      <EmptyState
+        testId="run-detail-not-found"
+        title={t('aiAgentsPage.runs.detail.notFound')}
+        description={t('aiAgentsRuns.detail.notFoundDescription')}
+        secondary={
+          <a href="/ai-agents/runs" className="text-primary hover:underline">
+            {t('aiAgentsPage.runs.detail.back')}
+          </a>
+        }
+      />
     );
   }
 
@@ -820,6 +932,7 @@ export default function RunDetailPage({ runId }: RunDetailPageProps) {
   const durationMs = run.startedAt && run.finishedAt
     ? new Date(run.finishedAt).getTime() - new Date(run.startedAt).getTime()
     : null;
+  const runIsLive = isLiveRunStatus(run.status);
 
   return (
     <div className="space-y-6" data-testid="run-detail-page">
@@ -832,10 +945,14 @@ export default function RunDetailPage({ runId }: RunDetailPageProps) {
         <div className="flex flex-wrap items-center gap-2">
           <Bot className="h-5 w-5 text-muted-foreground" />
           <h1 className="text-lg font-semibold">{run.agentName ?? t('aiAgentsPage.runs.noAgent')}</h1>
-          <span className={`inline-flex rounded px-1.5 py-0.5 text-xs font-medium ${statusBadgeClass(run.status)}`}>
+          <span
+            className={badgeClass(runStatusTone(run.status), { size: 'sm' })}
+            aria-live={runIsLive ? 'polite' : undefined}
+          >
             {statusLabel(t, run.status)}
           </span>
-          <span className={`inline-flex rounded px-1.5 py-0.5 text-xs font-medium ${verdictBadgeClass(run.runVerdict)}`}>
+          {runIsLive && <LiveIndicator label={t('aiAgentsRuns.live.label')} />}
+          <span className={badgeClass(verdictTone(run.runVerdict ?? ''), { size: 'sm' })}>
             {verdictLabel(t, run.runVerdict)}
           </span>
           {/* P2-4 (#4191, Task 12) — the detail DTO carries no `profile`
@@ -843,10 +960,7 @@ export default function RunDetailPage({ runId }: RunDetailPageProps) {
               the discriminator, same as the sweep/narrative sections below
               gating on their own null-checked field. */}
           {run.ticketProposal && (
-            <span
-              data-testid="run-detail-profile-triage"
-              className="inline-flex rounded bg-teal-500/10 px-1.5 py-0.5 text-xs font-medium text-teal-700"
-            >
+            <span data-testid="run-detail-profile-triage" className={badgeClass('muted', { size: 'sm' })}>
               {t('aiAgentsPage.runs.profile.triage')}
             </span>
           )}
@@ -901,7 +1015,7 @@ export default function RunDetailPage({ runId }: RunDetailPageProps) {
           <a
             href={`/devices/${run.deviceId}#anomalies`}
             data-testid="run-detail-anomaly-link"
-            className="mt-3 inline-flex items-center gap-1 text-sm font-medium text-sky-700 hover:underline"
+            className="mt-3 inline-flex items-center gap-1 text-sm font-medium text-sky-700 hover:underline dark:text-sky-400"
           >
             {t('aiAgentsPage.runs.detail.anomalyLink')}
             <ExternalLink className="h-3 w-3" />
@@ -911,17 +1025,17 @@ export default function RunDetailPage({ runId }: RunDetailPageProps) {
         {(run.budgetExceeded || run.wallClockExceeded || run.maxTurnsExceeded) && (
           <div className="mt-3 flex flex-wrap gap-2" data-testid="run-detail-flags">
             {run.budgetExceeded && (
-              <span className="rounded bg-amber-500/10 px-2 py-0.5 text-xs text-amber-700">
+              <span className={badgeClass('warning', { size: 'sm' })}>
                 {t('aiAgentsPage.runs.detail.flags.budgetExceeded')}
               </span>
             )}
             {run.wallClockExceeded && (
-              <span className="rounded bg-amber-500/10 px-2 py-0.5 text-xs text-amber-700">
+              <span className={badgeClass('warning', { size: 'sm' })}>
                 {t('aiAgentsPage.runs.detail.flags.wallClockExceeded')}
               </span>
             )}
             {run.maxTurnsExceeded && (
-              <span className="rounded bg-amber-500/10 px-2 py-0.5 text-xs text-amber-700">
+              <span className={badgeClass('warning', { size: 'sm' })}>
                 {t('aiAgentsPage.runs.detail.flags.maxTurnsExceeded')}
               </span>
             )}
@@ -961,7 +1075,7 @@ export default function RunDetailPage({ runId }: RunDetailPageProps) {
           </p>
 
           {run.sweep.evidenceTruncated && (
-            <p className="mt-2 text-xs text-amber-700" data-testid="ai-agent-run-sweep-truncated">
+            <p className="mt-2 text-xs text-amber-700 dark:text-amber-400" data-testid="ai-agent-run-sweep-truncated">
               {t('aiAgentsPage.runs.sweep.evidenceTruncated')}
             </p>
           )}
@@ -1015,7 +1129,7 @@ export default function RunDetailPage({ runId }: RunDetailPageProps) {
           )}
 
           {run.narrative.contextTruncated && (
-            <p className="mt-2 text-xs text-amber-700" data-testid="ai-agent-run-narrative-truncated">
+            <p className="mt-2 text-xs text-amber-700 dark:text-amber-400" data-testid="ai-agent-run-narrative-truncated">
               {t('aiAgentsPage.runs.narrative.truncatedNote')}
             </p>
           )}
@@ -1064,7 +1178,12 @@ export default function RunDetailPage({ runId }: RunDetailPageProps) {
       <div className="rounded-lg border bg-card p-4">
         <h2 className="text-sm font-semibold">{t('aiAgentsPage.runs.detail.trace.title')}</h2>
         {run.trace.length === 0 ? (
-          <p className="mt-2 text-sm text-muted-foreground">{t('aiAgentsPage.runs.detail.trace.empty')}</p>
+          <EmptyState
+            size="sm"
+            headingLevel={3}
+            title={t('aiAgentsPage.runs.detail.trace.empty')}
+            description={t('aiAgentsRuns.detail.trace.emptyDescription')}
+          />
         ) : (
           <ul data-testid="run-detail-trace" className="mt-2">
             {run.trace.map((entry, index) => (
@@ -1077,7 +1196,12 @@ export default function RunDetailPage({ runId }: RunDetailPageProps) {
       <div className="rounded-lg border bg-card p-4">
         <h2 className="text-sm font-semibold">{t('aiAgentsPage.runs.detail.ledger.title')}</h2>
         {run.ledger.length === 0 ? (
-          <p className="mt-2 text-sm text-muted-foreground">{t('aiAgentsPage.runs.detail.ledger.empty')}</p>
+          <EmptyState
+            size="sm"
+            headingLevel={3}
+            title={t('aiAgentsPage.runs.detail.ledger.empty')}
+            description={t('aiAgentsRuns.detail.ledger.emptyDescription')}
+          />
         ) : (
           <div className="mt-2 overflow-x-auto">
             <table className="min-w-full divide-y text-sm" data-testid="run-detail-ledger">
@@ -1094,7 +1218,7 @@ export default function RunDetailPage({ runId }: RunDetailPageProps) {
                 {run.ledger.map((entry, index) => (
                   <tr key={index}>
                     <td className="px-2 py-2 font-medium">{entry.toolName}</td>
-                    <td className="px-2 py-2 text-muted-foreground">{entry.status}</td>
+                    <td className="px-2 py-2 text-muted-foreground">{ledgerStatusLabel(t, entry.status)}</td>
                     <td className="px-2 py-2 text-muted-foreground">{formatDuration(entry.durationMs)}</td>
                     <td className="px-2 py-2 text-muted-foreground">{formatDateTime(entry.createdAt)}</td>
                     <td className="px-2 py-2 text-destructive">{entry.errorMessage ?? '—'}</td>
@@ -1109,7 +1233,12 @@ export default function RunDetailPage({ runId }: RunDetailPageProps) {
       <div className="rounded-lg border bg-card p-4">
         <h2 className="text-sm font-semibold">{t('aiAgentsPage.runs.detail.intents.title')}</h2>
         {run.intents.length === 0 ? (
-          <p className="mt-2 text-sm text-muted-foreground">{t('aiAgentsPage.runs.detail.intents.empty')}</p>
+          <EmptyState
+            size="sm"
+            headingLevel={3}
+            title={t('aiAgentsPage.runs.detail.intents.empty')}
+            description={t('aiAgentsRuns.detail.intents.emptyDescription')}
+          />
         ) : (
           <ul data-testid="run-detail-intents" className="mt-2 space-y-1 text-sm">
             {run.intents.map((intent) => (

--- a/apps/web/src/components/aiAgents/RunsListPage.test.tsx
+++ b/apps/web/src/components/aiAgents/RunsListPage.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
 
@@ -110,11 +110,26 @@ describe('RunsListPage', () => {
     await waitFor(() => expect(screen.getByTestId('runs-list-error')).toBeInTheDocument());
   });
 
-  it('shows the empty state when there are no runs', async () => {
+  it('shows the empty state when there are no runs, with a description and a link to configure agents', async () => {
     mockEndpoints({ runs: [] });
     render(<RunsListPage />);
 
     await waitFor(() => expect(screen.getByTestId('runs-list-empty')).toBeInTheDocument());
+    expect(screen.getByText('No runs yet.')).toBeInTheDocument();
+    expect(screen.getByText(/will appear here/i)).toBeInTheDocument();
+    const link = screen.getByText('Configure AI agents');
+    expect(link).toHaveAttribute('href', '/settings/ai-agents');
+  });
+
+  it('shows a Clear filters action in the filtered-empty state instead of the settings link', async () => {
+    mockEndpoints({ runs: [] });
+    render(<RunsListPage />);
+    await waitFor(() => expect(screen.getByTestId('runs-list-empty')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByTestId('runs-list-filter-status'), { target: { value: 'failed' } });
+    await waitFor(() => expect(screen.getByText('No runs match these filters.')).toBeInTheDocument());
+    expect(screen.queryByText('Configure AI agents')).not.toBeInTheDocument();
+    expect(screen.getAllByText('Clear filters').length).toBeGreaterThan(0);
   });
 
   it('shows a Load more button when a nextCursor is returned, and appends on click', async () => {
@@ -254,5 +269,273 @@ describe('RunsListPage', () => {
 
     await waitFor(() => expect(screen.getByTestId('runs-list-row-run-1')).toBeInTheDocument());
     expect(screen.queryByText('Acme Corp')).not.toBeInTheDocument();
+  });
+});
+
+// Critique finding #4 — the whole row is a click target, not just the
+// agent-name link, and clicking the link itself must not double-navigate.
+describe('RunsListPage row navigation', () => {
+  function withMockedLocation() {
+    const realLocation = window.location;
+    const assign = vi.fn();
+    Object.defineProperty(window, 'location', { configurable: true, value: { ...realLocation, assign } });
+    return {
+      assign,
+      restore: () => Object.defineProperty(window, 'location', { configurable: true, value: realLocation }),
+    };
+  }
+
+  it('navigates to the run detail page when clicking anywhere in the row', async () => {
+    mockEndpoints();
+    const { assign, restore } = withMockedLocation();
+    try {
+      render(<RunsListPage />);
+      await waitFor(() => expect(screen.getByTestId('runs-list-row-run-1')).toBeInTheDocument());
+
+      fireEvent.click(screen.getByTestId('runs-list-row-run-1'));
+      expect(assign).toHaveBeenCalledWith('/ai-agents/runs/run-1');
+    } finally {
+      restore();
+    }
+  });
+
+  it('does not double-navigate when the agent-name link itself is clicked', async () => {
+    mockEndpoints();
+    const { assign, restore } = withMockedLocation();
+    try {
+      render(<RunsListPage />);
+      await waitFor(() => expect(screen.getByTestId('runs-list-row-link-run-1')).toBeInTheDocument());
+
+      fireEvent.click(screen.getByTestId('runs-list-row-link-run-1'));
+      // The link's own click handler stops propagation, so the row's
+      // click-anywhere handler must not also fire.
+      expect(assign).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+});
+
+// Critique finding #8 — a single "Clear filters" affordance, shown only
+// when a filter is active.
+describe('RunsListPage clear filters', () => {
+  it('hides the clear-filters control when no filter is active', async () => {
+    mockEndpoints();
+    render(<RunsListPage />);
+    await waitFor(() => expect(screen.getByTestId('runs-list-row-run-1')).toBeInTheDocument());
+
+    expect(screen.queryByTestId('runs-list-clear-filters')).not.toBeInTheDocument();
+  });
+
+  it('shows the control once a filter is active, and clears both filters on click', async () => {
+    mockEndpoints();
+    render(<RunsListPage />);
+    await waitFor(() => expect(screen.getByTestId('runs-list-row-run-1')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByTestId('runs-list-filter-status'), { target: { value: 'failed' } });
+    await waitFor(() => expect(screen.getByTestId('runs-list-clear-filters')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('runs-list-clear-filters'));
+    await waitFor(() => expect(screen.queryByTestId('runs-list-clear-filters')).not.toBeInTheDocument());
+    expect(screen.getByTestId('runs-list-filter-status')).toHaveValue('');
+    expect(screen.getByTestId('runs-list-filter-agent')).toHaveValue('');
+  });
+});
+
+// Critique finding #1 — a non-terminal row must update on its own: the page
+// polls page 1 every 10s while any visible row is live, merging fresh rows
+// in by id, stops once every row is terminal, and pauses while hidden.
+describe('RunsListPage polling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' });
+  });
+
+  it('polls every 10s while a row is non-terminal and merges the fresh status in', async () => {
+    mockEndpoints({ runs: [{ ...RUN_1, status: 'running' as const }] });
+    render(<RunsListPage />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('runs-list-row-run-1')).toHaveTextContent('Running');
+    expect(screen.getByTestId('run-live-indicator')).toBeInTheDocument();
+
+    mockEndpoints({ runs: [{ ...RUN_1, status: 'completed' as const }] });
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId('runs-list-row-run-1')).toHaveTextContent('Completed');
+    expect(screen.queryByTestId('run-live-indicator')).not.toBeInTheDocument();
+  });
+
+  // Review finding P2-1 (#4187 critique): a filtered, all-terminal result set
+  // is inert (the filter itself pins the rows it can contain), so it keeps
+  // the pre-fix "stop entirely" behavior. The unfiltered idle-poll cases are
+  // covered below.
+  it('does not poll when filtered and every visible row is already terminal', async () => {
+    mockEndpoints(); // RUN_1 completed, RUN_2 failed — both terminal.
+    render(<RunsListPage />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('runs-list-row-run-1')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId('runs-list-filter-status'), { target: { value: 'failed' } });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const callsAfterLoad = fetchMock.mock.calls.length;
+
+    await act(async () => {
+      vi.advanceTimersByTime(30_000);
+      await Promise.resolve();
+    });
+
+    expect(fetchMock.mock.calls.length).toBe(callsAfterLoad);
+  });
+
+  // Review finding P2-1 (#4187 critique): merging by id alone can never
+  // surface a run that started after the initial page load — polling must
+  // also stay alive with nothing on screen, at a slower idle cadence, and
+  // prepend ids it hasn't seen yet.
+  it('keeps a slow idle poll on the unfiltered page-1 view even when nothing is live, and prepends a newly started run', async () => {
+    mockEndpoints(); // RUN_1 completed, RUN_2 failed — both terminal, unfiltered.
+    render(<RunsListPage />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('runs-list-row-run-1')).toBeInTheDocument();
+    const callsAfterLoad = fetchMock.mock.calls.length;
+
+    // Under 30s: idle cadence hasn't elapsed yet, no extra poll.
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+      await Promise.resolve();
+    });
+    expect(fetchMock.mock.calls.length).toBe(callsAfterLoad);
+
+    // A run that started after the initial load — not merged into the
+    // existing rows by id, so a naive merge-by-id poll would drop it.
+    const RUN_3 = { ...RUN_1, id: 'run-3', status: 'running' as const, queuedAt: '2026-08-21T10:00:00.000Z' };
+    mockEndpoints({ runs: [RUN_3, RUN_1, RUN_2] });
+
+    await act(async () => {
+      vi.advanceTimersByTime(20_000); // total 30s — the idle cadence.
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(callsAfterLoad);
+    expect(screen.getByTestId('runs-list-row-run-3')).toBeInTheDocument();
+    expect(screen.getByTestId('runs-list-row-run-1')).toBeInTheDocument();
+    expect(screen.getByTestId('runs-list-row-run-2')).toBeInTheDocument();
+    // Prepended: run-3 renders before run-1 in the table.
+    const rows = screen.getAllByRole('row').map((row) => row.getAttribute('data-testid'));
+    expect(rows.indexOf('runs-list-row-run-3')).toBeLessThan(rows.indexOf('runs-list-row-run-1'));
+  });
+
+  it('polls at the fast 10s cadence (not the 30s idle cadence) once a row is live', async () => {
+    mockEndpoints({ runs: [{ ...RUN_1, status: 'running' as const }] });
+    render(<RunsListPage />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('runs-list-row-run-1')).toBeInTheDocument();
+    const callsAfterLoad = fetchMock.mock.calls.length;
+
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(callsAfterLoad);
+  });
+
+  // Review finding P2-2 (#4187 critique): overlapping poll responses must
+  // apply in request order, not resolution order.
+  it('discards a stale poll response that resolves after a newer one', async () => {
+    mockEndpoints({ runs: [{ ...RUN_1, status: 'running' as const }] });
+    render(<RunsListPage />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('runs-list-row-run-1')).toBeInTheDocument();
+
+    let resolveOlder!: (value: Response) => void;
+    let resolveNewer!: (value: Response) => void;
+    const responses = [
+      new Promise<Response>((resolve) => {
+        resolveOlder = resolve;
+      }),
+      new Promise<Response>((resolve) => {
+        resolveNewer = resolve;
+      }),
+    ];
+    let call = 0;
+    fetchMock.mockImplementation((url: string) => {
+      if (url.startsWith('/ai/agents/runs')) {
+        return responses[call++] ?? Promise.resolve(json({ data: [], nextCursor: null }));
+      }
+      return Promise.resolve(json({ data: [] }));
+    });
+
+    // Two poll ticks fire back to back (10s cadence while live) before either
+    // response resolves.
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+      await Promise.resolve();
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+      await Promise.resolve();
+    });
+
+    // Resolve the NEWER request first with a fresh status, then the OLDER
+    // request with a stale one — the stale one must not win.
+    resolveNewer(json({ data: [{ ...RUN_1, status: 'completed' as const }], nextCursor: null }));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    resolveOlder(json({ data: [{ ...RUN_1, status: 'running' as const }], nextCursor: null }));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId('runs-list-row-run-1')).toHaveTextContent('Completed');
+  });
+
+  it('pauses polling while the document is hidden', async () => {
+    mockEndpoints({ runs: [{ ...RUN_1, status: 'running' as const }] });
+    render(<RunsListPage />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'hidden' });
+    const callsAfterLoad = fetchMock.mock.calls.length;
+
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+      await Promise.resolve();
+    });
+
+    expect(fetchMock.mock.calls.length).toBe(callsAfterLoad);
   });
 });

--- a/apps/web/src/components/aiAgents/RunsListPage.tsx
+++ b/apps/web/src/components/aiAgents/RunsListPage.tsx
@@ -6,6 +6,8 @@ import { fetchWithAuth } from '../../stores/auth';
 import { useOrgStore } from '../../stores/orgStore';
 import { formatDateTime } from '@/lib/dateTimeFormat';
 import { formatCurrency } from '@/lib/i18n/format';
+import { badgeClass, runStatusTone, verdictTone } from './statusBadge';
+import { EmptyState } from '../shared/EmptyState';
 import type { AiAgentRunListItemDto, AiAgentRunStatus } from '@breeze/shared';
 import { AI_AGENT_RUN_STATUSES } from '@breeze/shared';
 
@@ -21,32 +23,45 @@ interface AgentOption {
 
 const PAGE_LIMIT = 25;
 
-function verdictBadgeClass(verdict: string | null): string {
-  switch (verdict) {
-    case 'remediated':
-      return 'bg-emerald-500/10 text-emerald-600';
-    case 'partial':
-      return 'bg-amber-500/10 text-amber-700';
-    case 'needs_attention':
-      return 'bg-red-500/10 text-red-600';
-    default:
-      return 'bg-muted text-muted-foreground';
-  }
+/** Every status NOT in this set is "live" — treat an unrecognized future
+ * status as live too, so a run never silently stops updating just because
+ * this list predates it. */
+const TERMINAL_RUN_STATUSES = new Set<AiAgentRunStatus>([
+  'completed', 'failed', 'cancelled', 'expired', 'skipped',
+]);
+function isLiveRunStatus(status: AiAgentRunStatus): boolean {
+  return !TERMINAL_RUN_STATUSES.has(status);
 }
 
-function statusBadgeClass(status: AiAgentRunStatus): string {
-  switch (status) {
-    case 'completed':
-      return 'bg-emerald-500/10 text-emerald-600';
-    case 'failed':
-      return 'bg-red-500/10 text-red-600';
-    case 'running':
-      return 'bg-blue-500/10 text-blue-600';
-    case 'awaiting_approval':
-      return 'bg-amber-500/10 text-amber-700';
-    default:
-      return 'bg-muted text-muted-foreground';
-  }
+const LIST_POLL_INTERVAL_MS = 10_000;
+/**
+ * Review finding P2-1 (#4187 critique): a run started after the initial page
+ * load never appeared, because polling stopped entirely once every visible
+ * row was terminal. While unfiltered and on page 1, a run can start at any
+ * time (not just while another run is already live), so keep a slow idle
+ * poll going even with nothing live on screen — same mechanism, longer
+ * cadence.
+ */
+const LIST_IDLE_POLL_INTERVAL_MS = 30_000;
+
+/**
+ * Decorative pulse next to a live row's status badge. The dot itself is
+ * `aria-hidden` — it is a sighted-user cue only; the substantive
+ * accessibility signal is the `aria-live="polite"` region on the status text
+ * itself (screen readers announce the status word changing), plus the
+ * sr-only label here so an accessibility tree still names what the dot means
+ * for a screen-reader user who tabs to it.
+ */
+function LiveIndicator({ label }: { label: string }) {
+  return (
+    <span className="ml-1.5 inline-flex items-center" data-testid="run-live-indicator">
+      <span className="relative flex h-2 w-2" aria-hidden="true">
+        <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-sky-500 opacity-75" />
+        <span className="relative inline-flex h-2 w-2 rounded-full bg-sky-500" />
+      </span>
+      <span className="sr-only">{label}</span>
+    </span>
+  );
 }
 
 // Literal-key label lookups (not dynamic t()) so the keyUsage guard can verify
@@ -117,6 +132,15 @@ function triggerLabel(t: (key: string) => string, value: string): string {
  * `window.location.hash`-only rule for transient UI state (CLAUDE.md) extends
  * to pagination cursors, which are exactly that: a "load more" position, not
  * a shareable/bookmarkable view.
+ *
+ * UI critique fixes: the whole page polls the first page every
+ * `LIST_POLL_INTERVAL_MS` while any visible row is still in flight
+ * (`hasLiveRun`), merging fresh rows in by id so a "Load more" page beyond
+ * the first isn't clobbered; polling pauses while the tab is hidden.
+ * When unfiltered, a run started after the initial load is prepended (not
+ * just merged by id), and polling never stops outright — it drops to a slow
+ * `LIST_IDLE_POLL_INTERVAL_MS` cadence once nothing visible is live, so a
+ * brand-new run still surfaces without a manual reload.
  */
 export default function RunsListPage() {
   const { t } = useTranslation('settings');
@@ -139,11 +163,31 @@ export default function RunsListPage() {
 
   const [agentFilter, setAgentFilter] = useState('');
   const [statusFilter, setStatusFilter] = useState<AiAgentRunStatus | ''>('');
+  const hasActiveFilter = Boolean(agentFilter || statusFilter);
+
+  const clearFilters = useCallback(() => {
+    setAgentFilter('');
+    setStatusFilter('');
+  }, []);
 
   // Monotonic request id — same stale-response guard as DeviceChangeHistoryTab:
   // a fresh page-1 load (filter change) bumps it so a late "Load more" response
   // can detect it's stale and bail before clobbering the new filter's rows.
+  // The background poll (below) shares this counter too (review finding
+  // P2-2, #4187 critique), so an out-of-order poll response — or a poll that
+  // resolves after a filter change already started a fresh page-1 load — is
+  // detected as stale and discarded rather than regressing the screen.
   const requestIdRef = useRef(0);
+
+  // Guards every setState in the background poll against firing after
+  // unmount (review finding P2-2).
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -228,6 +272,78 @@ export default function RunsListPage() {
     void fetchPage(null, false);
   }, [fetchPage]);
 
+  /**
+   * Background poll: re-fetches page 1 under the current filters.
+   *
+   * Known ids are merged in place (never replacing the whole array), so an
+   * accumulated "Load more" tail past the first page survives a poll tick.
+   * When unfiltered, ids in the response that aren't in `runs` yet are
+   * genuinely new runs — those are prepended (review finding P2-1) rather
+   * than silently dropped, which is what merge-by-id alone did. If the view
+   * hasn't been paginated past page 1 (no "Load more" yet), the result is
+   * trimmed back to `PAGE_LIMIT` so the page-1 window mirrors what the
+   * server just returned; an already-loaded tail beyond page 1 is left
+   * alone. Filtered views skip the prepend — a filtered page 1 isn't
+   * necessarily "everything newer", so a naive prepend could misorder rows
+   * the filter itself is meant to control.
+   *
+   * Shares `requestIdRef` with `fetchPage` (review finding P2-2): an
+   * overlapping or out-of-order response — including one that resolves
+   * after a filter change already kicked off a fresh page-1 load — is
+   * detected as stale via the id check and discarded. `mountedRef` guards
+   * against setting state after unmount.
+   *
+   * Best-effort — a failed poll just tries again next tick, without
+   * disturbing whatever is already on screen.
+   */
+  const pollListSilently = useCallback(async () => {
+    requestIdRef.current += 1;
+    const requestId = requestIdRef.current;
+    try {
+      const params = new URLSearchParams({ limit: String(PAGE_LIMIT) });
+      if (agentFilter) params.set('agentId', agentFilter);
+      if (statusFilter) params.set('status', statusFilter);
+      const response = await fetchWithAuth(`/ai/agents/runs?${params.toString()}`);
+      if (!mountedRef.current || requestId !== requestIdRef.current) return;
+      if (!response.ok) return;
+      const body = (await response.json()) as Partial<RunsResponse>;
+      if (!mountedRef.current || requestId !== requestIdRef.current) return;
+      if (!Array.isArray(body.data)) return;
+      const page = body.data;
+      const unfiltered = !agentFilter && !statusFilter;
+      setRuns((prev) => {
+        const byId = new Map(page.map((run) => [run.id, run] as const));
+        const merged = prev.map((run) => byId.get(run.id) ?? run);
+        if (!unfiltered) return merged;
+        const knownIds = new Set(prev.map((run) => run.id));
+        const freshRows = page.filter((run) => !knownIds.has(run.id));
+        if (freshRows.length === 0) return merged;
+        const combined = [...freshRows, ...merged];
+        return prev.length > PAGE_LIMIT ? combined : combined.slice(0, PAGE_LIMIT);
+      });
+    } catch {
+      // Best-effort background refresh; keep showing the last good data.
+    }
+  }, [agentFilter, statusFilter]);
+
+  const hasLiveRun = runs.some((run) => isLiveRunStatus(run.status));
+
+  useEffect(() => {
+    // Nothing to poll for: a filtered view with nothing live won't change on
+    // its own (review finding P2-1 only asks for the idle cadence on the
+    // unfiltered page-1 view — a filtered terminal-only result set is inert).
+    if (!hasLiveRun && hasActiveFilter) return undefined;
+    const intervalMs = hasLiveRun ? LIST_POLL_INTERVAL_MS : LIST_IDLE_POLL_INTERVAL_MS;
+    const interval = setInterval(() => {
+      if (document.visibilityState === 'visible') void pollListSilently();
+    }, intervalMs);
+    return () => clearInterval(interval);
+  }, [hasLiveRun, hasActiveFilter, pollListSilently]);
+
+  const handleRowNavigate = useCallback((runId: string) => {
+    window.location.assign(`/ai-agents/runs/${runId}`);
+  }, []);
+
   return (
     <div className="space-y-6" data-testid="runs-list-page">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
@@ -269,6 +385,17 @@ export default function RunsListPage() {
               </option>
             ))}
           </select>
+
+          {hasActiveFilter && (
+            <button
+              type="button"
+              data-testid="runs-list-clear-filters"
+              onClick={clearFilters}
+              className="text-sm text-muted-foreground hover:text-foreground hover:underline"
+            >
+              {t('aiAgentsRuns.list.clearFilters')}
+            </button>
+          )}
         </div>
       </div>
 
@@ -295,11 +422,36 @@ export default function RunsListPage() {
       )}
 
       {!loading && !error && runs.length === 0 && (
-        <p className="text-sm text-muted-foreground" data-testid="runs-list-empty">
-          {agentFilter || statusFilter
-            ? t('aiAgentsPage.runs.emptyFiltered')
-            : t('aiAgentsPage.runs.empty')}
-        </p>
+        <EmptyState
+          size="sm"
+          headingLevel={2}
+          testId="runs-list-empty"
+          icon={<History className="h-5 w-5" />}
+          title={hasActiveFilter ? t('aiAgentsPage.runs.emptyFiltered') : t('aiAgentsPage.runs.empty')}
+          description={
+            hasActiveFilter
+              ? t('aiAgentsRuns.list.emptyFilteredDescription')
+              : t('aiAgentsRuns.list.emptyDescription')
+          }
+          action={
+            hasActiveFilter ? (
+              <button
+                type="button"
+                onClick={clearFilters}
+                className="rounded-md border px-4 py-2 text-sm text-muted-foreground hover:bg-muted hover:text-foreground"
+              >
+                {t('aiAgentsRuns.list.clearFilters')}
+              </button>
+            ) : undefined
+          }
+          secondary={
+            !hasActiveFilter ? (
+              <a href="/settings/ai-agents" className="text-primary hover:underline">
+                {t('aiAgentsRuns.list.emptyConfigureLink')}
+              </a>
+            ) : undefined
+          }
+        />
       )}
 
       {!loading && !error && runs.length > 0 && (
@@ -319,77 +471,87 @@ export default function RunsListPage() {
                 </tr>
               </thead>
               <tbody className="divide-y">
-                {runs.map((run) => (
-                  <tr key={run.id} data-testid={`runs-list-row-${run.id}`} className="text-sm hover:bg-muted/30">
-                    <td className="px-4 py-3 font-medium">
-                      <a
-                        href={`/ai-agents/runs/${run.id}`}
-                        data-testid={`runs-list-row-link-${run.id}`}
-                        className="text-primary hover:underline"
-                      >
-                        {run.agentName ?? t('aiAgentsPage.runs.noAgent')}
-                      </a>
-                    </td>
-                    {isFleetView && (
-                      <td className="px-4 py-3 text-muted-foreground">{run.orgName ?? '—'}</td>
-                    )}
-                    <td className="px-4 py-3">
-                      <span
-                        className={`inline-flex rounded px-1.5 py-0.5 text-xs font-medium ${statusBadgeClass(run.status)}`}
-                      >
-                        {statusLabel(t, run.status)}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3 text-muted-foreground">{triggerLabel(t, run.triggerKind)}</td>
-                    <td className="px-4 py-3">
-                      <span
-                        className={`inline-flex rounded px-1.5 py-0.5 text-xs font-medium ${verdictBadgeClass(run.runVerdict)}`}
-                      >
-                        {verdictLabel(t, run.runVerdict)}
-                      </span>
-                      {run.profile === 'sweep' && (
-                        <span
-                          data-testid={`ai-agent-run-profile-sweep-${run.id}`}
-                          className="ml-1.5 inline-flex rounded bg-sky-500/10 px-1.5 py-0.5 text-xs font-medium text-sky-700"
+                {runs.map((run) => {
+                  const live = isLiveRunStatus(run.status);
+                  return (
+                    <tr
+                      key={run.id}
+                      data-testid={`runs-list-row-${run.id}`}
+                      className="cursor-pointer text-sm hover:bg-muted/30"
+                      onClick={() => handleRowNavigate(run.id)}
+                    >
+                      <td className="px-4 py-3 font-medium">
+                        <a
+                          href={`/ai-agents/runs/${run.id}`}
+                          data-testid={`runs-list-row-link-${run.id}`}
+                          className="text-primary hover:underline"
+                          onClick={(event) => event.stopPropagation()}
                         >
-                          {t('aiAgentsPage.runs.profile.sweep')}
-                        </span>
+                          {run.agentName ?? t('aiAgentsPage.runs.noAgent')}
+                        </a>
+                      </td>
+                      {isFleetView && (
+                        <td className="px-4 py-3 text-muted-foreground">{run.orgName ?? '—'}</td>
                       )}
-                      {/* Phase 2 wave P2-3 (#4190) — a narrative-profile run
-                          is the weekly org report, not a device outcome; the
-                          badge is what tells the two apart in a mixed list. */}
-                      {run.profile === 'narrative' && (
+                      <td className="px-4 py-3">
                         <span
-                          data-testid={`ai-agent-run-profile-narrative-${run.id}`}
-                          className="ml-1.5 inline-flex rounded bg-violet-500/10 px-1.5 py-0.5 text-xs font-medium text-violet-700"
+                          className={badgeClass(runStatusTone(run.status), { size: 'sm' })}
+                          aria-live={live ? 'polite' : undefined}
                         >
-                          {t('aiAgentsPage.runs.profile.narrative')}
+                          {statusLabel(t, run.status)}
                         </span>
-                      )}
-                      {/* Phase 2 wave P2-4 (#4191, Task 12) — a triage-profile
-                          run is a ticket outcome, not a device incident; same
-                          "tell the two apart in a mixed list" rationale as
-                          the sweep/narrative badges above. */}
-                      {run.profile === 'triage' && (
-                        <span
-                          data-testid={`ai-agent-run-profile-triage-${run.id}`}
-                          className="ml-1.5 inline-flex rounded bg-teal-500/10 px-1.5 py-0.5 text-xs font-medium text-teal-700"
-                        >
-                          {t('aiAgentsPage.runs.profile.triage')}
+                        {live && <LiveIndicator label={t('aiAgentsRuns.live.label')} />}
+                      </td>
+                      <td className="px-4 py-3 text-muted-foreground">{triggerLabel(t, run.triggerKind)}</td>
+                      <td className="px-4 py-3">
+                        <span className={badgeClass(verdictTone(run.runVerdict ?? ''), { size: 'sm' })}>
+                          {verdictLabel(t, run.runVerdict)}
                         </span>
-                      )}
-                    </td>
-                    <td className="px-4 py-3 whitespace-nowrap text-muted-foreground">
-                      {formatDateTime(run.queuedAt)}
-                    </td>
-                    <td className="px-4 py-3 whitespace-nowrap text-muted-foreground">
-                      {run.finishedAt ? formatDateTime(run.finishedAt) : '—'}
-                    </td>
-                    <td className="px-4 py-3 whitespace-nowrap text-muted-foreground">
-                      {formatCurrency(run.costCents / 100)}
-                    </td>
-                  </tr>
-                ))}
+                        {run.profile === 'sweep' && (
+                          <span
+                            data-testid={`ai-agent-run-profile-sweep-${run.id}`}
+                            className={`ml-1.5 ${badgeClass('info', { size: 'sm' })}`}
+                          >
+                            {t('aiAgentsPage.runs.profile.sweep')}
+                          </span>
+                        )}
+                        {/* Phase 2 wave P2-3 (#4190) — a narrative-profile
+                            run is the weekly org report, not a device
+                            outcome; the badge is what tells the two apart in
+                            a mixed list. */}
+                        {run.profile === 'narrative' && (
+                          <span
+                            data-testid={`ai-agent-run-profile-narrative-${run.id}`}
+                            className={`ml-1.5 ${badgeClass('accent', { size: 'sm' })}`}
+                          >
+                            {t('aiAgentsPage.runs.profile.narrative')}
+                          </span>
+                        )}
+                        {/* Phase 2 wave P2-4 (#4191, Task 12) — a triage-profile
+                            run is a ticket outcome, not a device incident; same
+                            "tell the two apart in a mixed list" rationale as
+                            the sweep/narrative badges above. */}
+                        {run.profile === 'triage' && (
+                          <span
+                            data-testid={`ai-agent-run-profile-triage-${run.id}`}
+                            className={`ml-1.5 ${badgeClass('muted', { size: 'sm' })}`}
+                          >
+                            {t('aiAgentsPage.runs.profile.triage')}
+                          </span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 whitespace-nowrap text-muted-foreground">
+                        {formatDateTime(run.queuedAt)}
+                      </td>
+                      <td className="px-4 py-3 whitespace-nowrap text-muted-foreground">
+                        {run.finishedAt ? formatDateTime(run.finishedAt) : '—'}
+                      </td>
+                      <td className="px-4 py-3 whitespace-nowrap text-muted-foreground">
+                        {formatCurrency(run.costCents / 100)}
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>

--- a/apps/web/src/components/aiAgents/statusBadge.test.ts
+++ b/apps/web/src/components/aiAgents/statusBadge.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import { badgeClass, graduationTone, modeTone, runStatusTone, verdictTone, type BadgeTone } from './statusBadge';
+
+const ALL_TONES: BadgeTone[] = ['neutral', 'info', 'success', 'warning', 'danger', 'accent', 'muted'];
+
+describe('badgeClass', () => {
+  it('includes a dark: class for every tone', () => {
+    for (const tone of ALL_TONES) {
+      expect(badgeClass(tone)).toContain('dark:');
+    }
+  });
+
+  it('includes the base pill structure classes', () => {
+    const cls = badgeClass('info');
+    expect(cls).toContain('inline-flex');
+    expect(cls).toContain('rounded');
+    expect(cls).toContain('text-xs');
+    expect(cls).toContain('font-medium');
+  });
+
+  it('never returns a class containing -700 without a dark: counterpart', () => {
+    for (const tone of ALL_TONES) {
+      for (const size of ['sm', 'md'] as const) {
+        const cls = badgeClass(tone, { size });
+        if (/-700\b/.test(cls)) {
+          expect(cls).toContain('dark:');
+        }
+      }
+    }
+  });
+
+  it('supports sm and md sizes with different output', () => {
+    expect(badgeClass('neutral', { size: 'sm' })).not.toEqual(badgeClass('neutral', { size: 'md' }));
+  });
+});
+
+describe('runStatusTone', () => {
+  it('assigns non-neutral tones for every status RunsListPage colours', () => {
+    expect(runStatusTone('completed')).not.toBe('neutral');
+    expect(runStatusTone('failed')).not.toBe('neutral');
+    expect(runStatusTone('running')).not.toBe('neutral');
+    expect(runStatusTone('awaiting_approval')).not.toBe('neutral');
+  });
+
+  it('maps queued and running to info', () => {
+    expect(runStatusTone('queued')).toBe('info');
+    expect(runStatusTone('running')).toBe('info');
+  });
+
+  it('maps awaiting_approval to warning', () => {
+    expect(runStatusTone('awaiting_approval')).toBe('warning');
+  });
+
+  it('maps completed/succeeded to success', () => {
+    expect(runStatusTone('completed')).toBe('success');
+    expect(runStatusTone('succeeded')).toBe('success');
+  });
+
+  it('maps failed/errored to danger', () => {
+    expect(runStatusTone('failed')).toBe('danger');
+    expect(runStatusTone('errored')).toBe('danger');
+  });
+
+  // Review fix (#4187 UI critique, P2): `cancelled` is an operator-initiated
+  // stop, not a failure — main renders it neutral, and the danger tone this
+  // branch briefly carried made a deliberate cancel read as an error.
+  it('maps cancelled to neutral, not danger', () => {
+    expect(runStatusTone('cancelled')).toBe('neutral');
+  });
+
+  it('covers every value in RunsListPage status enum without throwing, defaulting unknowns to neutral', () => {
+    for (const status of ['queued', 'running', 'awaiting_approval', 'completed', 'failed', 'cancelled', 'expired', 'skipped']) {
+      expect(typeof runStatusTone(status)).toBe('string');
+    }
+    expect(runStatusTone('expired')).toBe('neutral');
+    expect(runStatusTone('skipped')).toBe('neutral');
+    expect(runStatusTone('totally-unknown')).toBe('neutral');
+  });
+});
+
+describe('verdictTone', () => {
+  it('maps remediated to success', () => {
+    expect(verdictTone('remediated')).toBe('success');
+  });
+
+  it('maps partial to warning', () => {
+    expect(verdictTone('partial')).toBe('warning');
+  });
+
+  it('maps needs_attention to danger', () => {
+    expect(verdictTone('needs_attention')).toBe('danger');
+  });
+
+  it('defaults no_action and unknown verdicts to neutral', () => {
+    expect(verdictTone('no_action')).toBe('neutral');
+    expect(verdictTone('unknown')).toBe('neutral');
+  });
+});
+
+describe('graduationTone', () => {
+  it('maps every AI_AGENT_GRADUATION_STATES value', () => {
+    expect(graduationTone('tracking')).toBe('neutral');
+    expect(graduationTone('eligible')).toBe('info');
+    expect(graduationTone('promoted')).toBe('success');
+    expect(graduationTone('demoted')).toBe('danger');
+  });
+
+  it('defaults unknown state to neutral', () => {
+    expect(graduationTone('unknown')).toBe('neutral');
+  });
+});
+
+describe('modeTone', () => {
+  it('maps AI_AGENT_MODES values', () => {
+    expect(modeTone('off')).toBe('muted');
+    expect(modeTone('shadow')).toBe('info');
+    expect(modeTone('act')).toBe('warning');
+  });
+
+  it('defaults unknown mode to neutral', () => {
+    expect(modeTone('unknown')).toBe('neutral');
+  });
+});

--- a/apps/web/src/components/aiAgents/statusBadge.ts
+++ b/apps/web/src/components/aiAgents/statusBadge.ts
@@ -1,0 +1,123 @@
+/**
+ * Shared badge tone system for AI Agents surfaces (runs list, run detail,
+ * graduation panel). Consolidates the light-only `bg-<hue>-500/10
+ * text-<hue>-700` badge pattern found in RunsListPage/RunDetailPage into a
+ * dark-mode-aware `bg-<hue>-100 text-<hue>-800 dark:bg-<hue>-950/50
+ * dark:text-<hue>-200` pattern, matching the convention already used by
+ * ApprovalsInbox's `riskClass` map.
+ */
+
+export type BadgeTone = 'neutral' | 'info' | 'success' | 'warning' | 'danger' | 'accent' | 'muted';
+
+/**
+ * Light/dark class pairs per tone. Every entry MUST carry a `dark:`
+ * counterpart for each colour utility — this is what keeps AA contrast in
+ * both themes and is asserted by statusBadge.test.ts.
+ */
+const TONE_CLASSES: Record<BadgeTone, string> = {
+  // Matches the muted-slate convention used elsewhere (NotificationCenter,
+  // SeverityBadge) for "no strong signal" states.
+  neutral: 'bg-slate-100 text-slate-800 dark:bg-slate-950/50 dark:text-slate-200',
+  // Distinct from `neutral`: lower-emphasis, for explicitly "off"/inactive
+  // states rather than "no signal yet".
+  muted: 'bg-zinc-100 text-zinc-600 dark:bg-zinc-800/60 dark:text-zinc-400',
+  info: 'bg-blue-100 text-blue-800 dark:bg-blue-950/50 dark:text-blue-200',
+  success: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-950/50 dark:text-emerald-200',
+  warning: 'bg-amber-100 text-amber-800 dark:bg-amber-950/50 dark:text-amber-200',
+  danger: 'bg-red-100 text-red-800 dark:bg-red-950/50 dark:text-red-200',
+  // Matches the violet used for the "narrative" run-profile tag in
+  // RunsListPage/RunDetailPage.
+  accent: 'bg-violet-100 text-violet-800 dark:bg-violet-950/50 dark:text-violet-200',
+};
+
+const SIZE_CLASSES: Record<'sm' | 'md', string> = {
+  sm: 'px-1.5 py-0.5 text-xs',
+  md: 'px-2.5 py-0.5 text-xs',
+};
+
+/**
+ * Tailwind classes for a pill badge; light + dark, AA contrast in both.
+ * Includes padding/rounded/text-xs/font-medium/inline-flex.
+ */
+export function badgeClass(tone: BadgeTone, opts?: { size?: 'sm' | 'md' }): string {
+  const size = opts?.size ?? 'md';
+  return `inline-flex items-center rounded-full font-medium ${SIZE_CLASSES[size]} ${TONE_CLASSES[tone]}`;
+}
+
+/**
+ * Run status → tone. Covers every `AiAgentRunStatus` value referenced in
+ * RunsListPage/RunDetailPage's status maps and label switches (queued,
+ * running, awaiting_approval, completed, failed, cancelled, expired,
+ * skipped), plus the `succeeded`/`errored` synonyms used elsewhere.
+ */
+export function runStatusTone(status: string): BadgeTone {
+  switch (status) {
+    case 'queued':
+    case 'running':
+      return 'info';
+    case 'awaiting_approval':
+      return 'warning';
+    case 'succeeded':
+    case 'completed':
+      return 'success';
+    case 'failed':
+    case 'errored':
+      return 'danger';
+    // Operator-initiated stop, not a failure — see statusBadge.test.ts.
+    case 'cancelled':
+      return 'neutral';
+    default:
+      return 'neutral';
+  }
+}
+
+/** Verdict → tone, matching RunsListPage's verdictBadgeClass map. */
+export function verdictTone(verdict: string): BadgeTone {
+  switch (verdict) {
+    case 'remediated':
+      return 'success';
+    case 'partial':
+      return 'warning';
+    case 'needs_attention':
+      return 'danger';
+    default:
+      return 'neutral';
+  }
+}
+
+/**
+ * Graduation state → tone, matching AI_AGENT_GRADUATION_STATES
+ * (`tracking` | `eligible` | `promoted` | `demoted`) from
+ * AiAgentGraduationPanel / packages/shared/src/types/aiAgentGraduation.ts.
+ */
+export function graduationTone(state: string): BadgeTone {
+  switch (state) {
+    case 'tracking':
+      return 'neutral';
+    case 'eligible':
+      return 'info';
+    case 'promoted':
+      return 'success';
+    case 'demoted':
+      return 'danger';
+    default:
+      return 'neutral';
+  }
+}
+
+/**
+ * Agent mode → tone, matching AI_AGENT_MODES (`off` | `shadow` | `act`) from
+ * packages/shared/src/types/aiAgents.ts.
+ */
+export function modeTone(mode: string): BadgeTone {
+  switch (mode) {
+    case 'off':
+      return 'muted';
+    case 'shadow':
+      return 'info';
+    case 'act':
+      return 'warning';
+    default:
+      return 'neutral';
+  }
+}

--- a/apps/web/src/components/approvals/ApprovalsInbox.test.tsx
+++ b/apps/web/src/components/approvals/ApprovalsInbox.test.tsx
@@ -63,7 +63,14 @@ const pendingApproval = {
   riskSummary: 'Interrupts active sessions',
   customerTenant: null,
   status: 'pending',
-  expiresAt: '2026-08-23T12:30:00.000Z',
+  // 30 real minutes out from whenever this file happens to load — critique
+  // #3 makes an expired card visibly different (badge, disabled actions), so
+  // a fixed past timestamp would render every default-fixture test as
+  // already-expired the moment real wall-clock time passes it. Tests that
+  // need a DETERMINISTIC expiry relationship override this alongside their
+  // own `vi.spyOn(Date, 'now')` / `vi.setSystemTime` instead of relying on
+  // the shared default.
+  expiresAt: new Date(Date.now() + 30 * 60_000).toISOString(),
   decidedAt: null,
   decisionReason: null,
   executionId: null,
@@ -74,6 +81,7 @@ const pendingApproval = {
   origin: 'human',
   agentName: null,
   orgId: 'org-1',
+  orgName: 'Acme Dental',
   action: null,
   targetDevice: null,
 };
@@ -277,8 +285,16 @@ describe('ApprovalsInbox', () => {
 
   it('shows how long is left to decide, not only when the request arrived', async () => {
     // Pin the clock rather than switching to fake timers: the component reads
-    // Date.now(), and fake timers would also stall the awaited fetch.
+    // Date.now(), and fake timers would also stall the awaited fetch. A fixed
+    // expiresAt (independent of the shared fixture's dynamic default — see
+    // its comment) keeps the "five minutes remain" relationship exact.
     vi.spyOn(Date, 'now').mockReturnValue(new Date('2026-08-23T12:25:00.000Z').getTime());
+    fetchMock.mockResolvedValue(
+      response({
+        approvals: [{ ...pendingApproval, expiresAt: '2026-08-23T12:30:00.000Z' }],
+        nextCursor: null,
+      }),
+    );
     render(<ApprovalsInbox />);
 
     // expiresAt is 12:30, so five minutes remain.
@@ -369,14 +385,21 @@ describe('ApprovalsInbox', () => {
     vi.useFakeTimers();
     render(<ApprovalsInbox />);
 
-    // Flush the mount load (the fetch mock resolves in microtasks).
+    // Flush the mount load (the fetch mock resolves in microtasks). Mount
+    // fires TWO calls: the pending list, and its companion total-count read
+    // — see loadApprovals' `withCount`. The org display name now rides on
+    // each row's own server-resolved `orgName` field, so there is no
+    // separate org-names lookup to count here.
     await act(async () => {});
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(30_000);
     });
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // The poll is silent and intentionally skips the count refresh (see
+    // `withCount` in loadApprovals), so it adds exactly ONE more call — the
+    // list itself.
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
   it('refreshes silently: no loading spinner while re-fetching an already-loaded list', async () => {
@@ -989,5 +1012,215 @@ describe('ApprovalsInbox — "Approve and always allow"', () => {
     expect(showToastMock).not.toHaveBeenCalled();
     // The ordinary Approve affordance is unaffected by the failed side fetch.
     expect(screen.getByTestId('approval-approve-ap-a')).toBeEnabled();
+  });
+});
+
+describe('ApprovalsInbox — organization identity, live expiry, paging, and copy polish', () => {
+  /** Routes the list GET (with and without a `cursor`), the unpaginated
+   *  count, and the batch POST all separately — each critique fix below
+   *  depends on a distinct endpoint the blanket `fetchMock.mockResolvedValue`
+   *  in the top-level `beforeEach` cannot answer meaningfully (it has no
+   *  `count`/second-page shape). The org display name now rides on each
+   *  row's own `orgName` field (server-resolved) rather than a separate
+   *  bulk `/orgs/organizations` lookup — see fixtures below for how tests
+   *  drive it. */
+  const routeFull = (options: {
+    page1: unknown[];
+    nextCursor?: string | null;
+    page2?: unknown[];
+    page2NextCursor?: string | null;
+    count?: number;
+  }) => {
+    fetchMock.mockImplementation((async (url: string) => {
+      const raw = String(url);
+      if (raw.includes('/batch/decide')) return response({ results: [] });
+      if (raw.includes('/approvals/pending/count')) {
+        return response({ count: options.count ?? options.page1.length });
+      }
+      if (raw.includes('/approvals/pending') && raw.includes('cursor=')) {
+        return response({ approvals: options.page2 ?? [], nextCursor: options.page2NextCursor ?? null });
+      }
+      return response({ approvals: options.page1, nextCursor: options.nextCursor ?? null });
+    }) as unknown as typeof fetchWithAuth);
+  };
+
+  it('shows the organization name as the first line of a card', async () => {
+    routeFull({ page1: [{ ...pendingApproval, orgName: 'Acme Dental' }] });
+    render(<ApprovalsInbox />);
+
+    const orgLine = await screen.findByTestId('approval-org-approval-1');
+    expect(orgLine).toHaveTextContent('Acme Dental');
+  });
+
+  it('falls back to "Unknown organization" when the org name cannot be resolved', async () => {
+    routeFull({ page1: [{ ...pendingApproval, orgName: null }] });
+    render(<ApprovalsInbox />);
+
+    const orgLine = await screen.findByTestId('approval-org-approval-1');
+    expect(orgLine).toHaveTextContent('Unknown organization');
+  });
+
+  it('clusters cards by organization first, even when the server interleaves orgs', async () => {
+    routeFull({
+      page1: [
+        { ...pendingApproval, id: 'r1', orgId: 'org-1', orgName: 'Acme' },
+        { ...pendingApproval, id: 'r2', orgId: 'org-2', orgName: 'Contoso' },
+        { ...pendingApproval, id: 'r3', orgId: 'org-1', orgName: 'Acme' },
+      ],
+    });
+    render(<ApprovalsInbox />);
+    await screen.findByTestId('approval-row-r3');
+
+    const order = screen
+      .getAllByTestId(/^approval-row-/)
+      .map((el) => el.getAttribute('data-testid'));
+    // org-1 appeared FIRST in the server's own order (r1), so both its cards
+    // (r1, r3) must render adjacent, ahead of org-2's r2 — even though r2
+    // arrived between them.
+    expect(order).toEqual(['approval-row-r1', 'approval-row-r3', 'approval-row-r2']);
+  });
+
+  it('shows a live "Expired" state between polls, driven by the ticking clock rather than a new fetch', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-23T12:00:00.000Z'));
+    routeFull({ page1: [{ ...pendingApproval, expiresAt: '2026-08-23T12:00:05.000Z' }] });
+    render(<ApprovalsInbox />);
+    await act(async () => {});
+
+    expect(screen.getByTestId('approval-approve-approval-1')).toBeEnabled();
+    expect(screen.queryByTestId('approval-expired-badge-approval-1')).not.toBeInTheDocument();
+
+    const callsBeforeTick = fetchMock.mock.calls.length;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+
+    expect(screen.getByTestId('approval-expired-badge-approval-1')).toBeInTheDocument();
+    expect(screen.getByTestId('approval-approve-approval-1')).toBeDisabled();
+    // Proves the flip came from the ticking clock, not a re-fetch.
+    expect(fetchMock.mock.calls.length).toBe(callsBeforeTick);
+  });
+
+  it('shows a live character counter on the deny reason', async () => {
+    routeFull({ page1: [pendingApproval] });
+    render(<ApprovalsInbox />);
+    await screen.findByTestId('approval-row-approval-1');
+
+    fireEvent.click(screen.getByTestId('approval-deny-approval-1'));
+    fireEvent.change(screen.getByTestId('approval-deny-reason-approval-1'), {
+      target: { value: 'Wrong window' },
+    });
+
+    expect(screen.getByTestId('approval-deny-reason-count-approval-1')).toHaveTextContent(
+      '12/500',
+    );
+  });
+
+  it('renders the shared EmptyState component for an empty inbox', async () => {
+    routeFull({ page1: [] });
+    render(<ApprovalsInbox />);
+
+    const empty = await screen.findByTestId('approvals-empty');
+    expect(empty).toHaveTextContent('No approvals waiting');
+    expect(empty).toHaveTextContent(
+      'New requests will appear here when your decision is needed.',
+    );
+  });
+
+  it('shows an honest "Showing N of M" and a working Load more for a capped page', async () => {
+    routeFull({
+      page1: [
+        { ...pendingApproval, id: 'r1' },
+        { ...pendingApproval, id: 'r2' },
+      ],
+      nextCursor: 'cursor-1',
+      page2: [{ ...pendingApproval, id: 'r3' }],
+      page2NextCursor: null,
+      count: 40,
+    });
+    render(<ApprovalsInbox />);
+
+    const pagination = await screen.findByTestId('approvals-pagination');
+    expect(pagination).toHaveTextContent('Showing 2 of 40');
+    expect(screen.getByTestId('approvals-load-more')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('approvals-load-more'));
+
+    await waitFor(() => expect(screen.getByTestId('approval-row-r3')).toBeInTheDocument());
+    // The server's second page reported no further cursor.
+    expect(screen.queryByTestId('approvals-load-more')).not.toBeInTheDocument();
+  });
+
+  it('preserves a loaded "Load more" page across the 30s poll refresh, with no duplicates', async () => {
+    // A flat limit=PAGE_SIZE(25) refresh on every poll tick used to silently
+    // discard anything pulled in past the first page — this only reproduces
+    // once MORE than PAGE_SIZE rows are loaded (below that, a flat 25-row
+    // refetch happens to cover everything anyway), so this fixture needs 30
+    // rows across two pages, not the two-row fixture the test above uses.
+    //
+    // A realistic paged "server": 30 distinct rows, sliced by the requested
+    // limit/cursor exactly like the real `GET /approvals/pending` does.
+    // Cursor tokens here are just the slice offset — the client only ever
+    // echoes them back opaquely, so this need not match the server's real
+    // cursor encoding.
+    vi.useFakeTimers();
+    const full = Array.from({ length: 30 }, (_, i) => ({ ...pendingApproval, id: `row-${i}` }));
+    fetchMock.mockImplementation((async (url: string) => {
+      const raw = String(url);
+      if (raw.includes('/batch/decide')) return response({ results: [] });
+      if (raw.includes('/approvals/pending/count')) return response({ count: full.length });
+      if (raw.includes('/approvals/pending')) {
+        const query = new URL(raw, 'http://local').searchParams;
+        const limit = Number(query.get('limit')) || 25;
+        const cursorParam = query.get('cursor');
+        const start = cursorParam ? Number(cursorParam) : 0;
+        const page = full.slice(start, start + limit);
+        const nextCursor = start + limit < full.length ? String(start + limit) : null;
+        return response({ approvals: page, nextCursor });
+      }
+      return response({ approvals: [], nextCursor: null });
+    }) as unknown as typeof fetchWithAuth);
+
+    render(<ApprovalsInbox />);
+    await act(async () => {});
+
+    expect(screen.getByTestId('approval-row-row-0')).toBeInTheDocument();
+    expect(screen.getByTestId('approval-row-row-24')).toBeInTheDocument();
+    expect(screen.queryByTestId('approval-row-row-25')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('approvals-load-more'));
+    await act(async () => {});
+
+    expect(screen.getAllByTestId(/^approval-row-/)).toHaveLength(30);
+
+    // The 30s poll fires — the OLD, flat limit=25 refresh would have dropped
+    // rows 25-29 back off the list here.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+
+    const rows = screen.getAllByTestId(/^approval-row-/);
+    expect(rows).toHaveLength(30);
+    const ids = rows.map((el) => el.getAttribute('data-testid'));
+    expect(new Set(ids).size).toBe(30);
+    expect(screen.getByTestId('approval-row-row-0')).toBeInTheDocument();
+    expect(screen.getByTestId('approval-row-row-29')).toBeInTheDocument();
+  });
+
+  it('shows a success toast naming the action and org after a single-card approve', async () => {
+    routeFull({ page1: [{ ...pendingApproval, orgName: 'Acme Dental' }] });
+    render(<ApprovalsInbox />);
+    await screen.findByTestId('approval-row-approval-1');
+
+    fireEvent.click(screen.getByTestId('approval-approve-approval-1'));
+
+    await waitFor(() =>
+      expect(showToastMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'success',
+          message: expect.stringContaining('Acme Dental'),
+        }),
+      ),
+    );
   });
 });

--- a/apps/web/src/components/approvals/ApprovalsInbox.tsx
+++ b/apps/web/src/components/approvals/ApprovalsInbox.tsx
@@ -24,7 +24,10 @@ import { navigateTo } from '@/lib/navigation';
 import { ActionError, runAction } from '@/lib/runAction';
 import { formatRelativeTime } from '@/lib/utils';
 import { fetchWithAuth } from '../../stores/auth';
+import { badgeClass } from '../aiAgents/statusBadge';
 import { ConfirmDialog } from '../shared/ConfirmDialog';
+import { EmptyState } from '../shared/EmptyState';
+import { showToast } from '../shared/Toast';
 
 const LIVE_REFETCH_DEBOUNCE_MS = 750;
 /** WS is only a nudge; polling is the guarantee. useEventStream gives up
@@ -32,6 +35,19 @@ const LIVE_REFETCH_DEBOUNCE_MS = 750;
  *  time-boxed — with no fallback they would arrive AND expire unseen. Same
  *  cadence as NotificationCenter's POLL_INTERVAL_MS. */
 const POLL_INTERVAL_MS = 30_000;
+/** First-page size for `GET /approvals/pending`. Matches the server's own
+ *  default page granularity — see `pagination.loadMore` below. */
+const PAGE_SIZE = 25;
+/** Mirrors `PENDING_PAGE_MAX` in `routes/approvals.ts` — the largest `limit`
+ *  the server will ever honour for `GET /approvals/pending`, regardless of
+ *  what is requested. A full reload's own `limit` is capped here too (see
+ *  `loadApprovals` below) so it never asks for more than the server would
+ *  clamp it to anyway. */
+const SERVER_PAGE_LIMIT_MAX = 50;
+/** Countdown refresh cadence. Cards are minutes-long, so a 10s tick keeps
+ *  "Expires in N min" (and the expired/disabled state) honest between the
+ *  30s poll without re-rendering the whole list every second. */
+const EXPIRY_TICK_MS = 10_000;
 /** Caps concurrent `GET /ai/agents/graduation` fan-out: each org issues up to
  *  AI_AGENT_KINDS.length (3) requests, so a batch of 5 orgs tops out at 15
  *  concurrent requests regardless of how many distinct supervised orgs are on
@@ -84,6 +100,10 @@ interface PendingApproval {
    *  discriminator, and the resolved target device. All three are null for a
    *  row with no intent; `action` is also null for a non-multiplexed tool. */
   orgId: string | null;
+  /** The `orgId` organization's display name, resolved server-side. Null for
+   *  a row with no intent (no orgId) or when the org row no longer exists —
+   *  either way the UI falls back to the "Unknown organization" copy. */
+  orgName: string | null;
   action: string | null;
   targetDevice: { id: string; hostname: string } | null;
 }
@@ -160,6 +180,44 @@ function groupTestKey(approval: PendingApproval): string {
   return groupParts(approval)
     .map((part) => part.replace(/[^A-Za-z0-9_-]+/g, '-'))
     .join('--');
+}
+
+/**
+ * Org is the OUTERMOST grouping (critique #1): two cards for different orgs
+ * that happen to share a `(tool, action)` must never render adjacent to each
+ * other as if they were the same request. This stable-sorts the rows so every
+ * org's cards sit together, in the org's own first-appearance order, WITHOUT
+ * touching each org's internal relative order — `buildSections` below still
+ * decides tool/action grouping exactly as before, it just runs over rows
+ * that are already clustered by org.
+ *
+ * Known, accepted trade-off: the server pages strictly by `createdAt`, but
+ * this reclusters by org (first-appearance order). A "Load more" page's rows
+ * can therefore land ABOVE some already-visible rows if they belong to an
+ * org that appeared earlier in the list — no row is ever lost or hidden,
+ * just not always appended at the visual bottom.
+ */
+function clusterByOrg(rows: PendingApproval[]): PendingApproval[] {
+  const buckets = new Map<string, PendingApproval[]>();
+  const order: string[] = [];
+  for (const row of rows) {
+    const key = row.orgId ?? '';
+    const bucket = buckets.get(key);
+    if (bucket) bucket.push(row);
+    else {
+      buckets.set(key, [row]);
+      order.push(key);
+    }
+  }
+  return order.flatMap((key) => buckets.get(key)!);
+}
+
+/** Whether a card's expiry has already passed as of `now`. `now` is a ticking
+ *  state value (not a fresh `Date.now()` read) so every card in the list
+ *  re-evaluates together on the same 10s tick instead of drifting apart. */
+function isExpired(expiresAt: string, now: number): boolean {
+  const remainingMs = new Date(expiresAt).getTime() - now;
+  return Number.isFinite(remainingMs) && remainingMs <= 0;
 }
 
 /**
@@ -387,26 +445,79 @@ export default function ApprovalsInbox() {
     kind: AiAgentKind;
   } | null>(null);
   const [alwaysAllowBusy, setAlwaysAllowBusy] = useState(false);
+  // Ticking clock for live expiry countdowns (critique #3): `expiryLabel`
+  // reads THIS instead of a fresh `Date.now()` so a card's remaining time —
+  // and whether it has flipped to expired — updates every EXPIRY_TICK_MS
+  // regardless of when the 30s poll last landed.
+  const [now, setNow] = useState(() => Date.now());
+  // Paging (critique #2): the server supports a `cursor`-based next page and
+  // an authoritative unpaginated count. `nextCursor` is only ever consumed by
+  // `loadMore` below (never sent back to the server after a full reload).
+  // A full reload (mount, poll, WS nudge, reconnect, post-decision) now
+  // requests enough rows to cover whatever is already loaded (see
+  // `loadApprovals`'s `refreshLimit`), so it no longer discards "Load more"
+  // pages the way a flat PAGE_SIZE fetch used to.
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [totalCount, setTotalCount] = useState<number | null>(null);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [loadMoreError, setLoadMoreError] = useState(false);
 
-  const loadApprovals = useCallback(async (options?: { silent?: boolean }) => {
+  const loadApprovals = useCallback(async (options?: { silent?: boolean; withCount?: boolean }) => {
     // Silent reloads (WS nudge, poll, reconnect, post-decision refresh) must
     // not flash the already-rendered list back to a spinner.
     const silent = options?.silent === true;
+    // The count refresh is a SEPARATE request from the list fetch. Doubling
+    // it onto every 30s poll tick would double the inbox's steady-state
+    // request rate for no real gain (the "of M" total does not need to be
+    // to-the-second fresh), so it defaults to firing only on a non-silent
+    // load (mount, Retry) — callers that DO want it alongside a silent
+    // reload (a decision was just made; the total just changed) pass
+    // `withCount: true` explicitly. The poll/WS-nudge/reconnect paths do not.
+    const withCount = options?.withCount ?? !silent;
     if (!silent) {
       setLoading(true);
       setLoadError(false);
     }
     try {
-      const response = await fetchWithAuth('/approvals/pending?limit=25');
+      // Every full reload (mount, poll, WS nudge, reconnect, post-decision)
+      // used to hard-replace the list with a flat PAGE_SIZE fetch, silently
+      // discarding every "Load more" page the user had already pulled in.
+      // Request enough rows to cover what is currently on screen instead —
+      // capped at the server's own page max, since asking for more just gets
+      // clamped there too.
+      const refreshLimit = Math.min(
+        Math.max(PAGE_SIZE, approvalsRef.current.length),
+        SERVER_PAGE_LIMIT_MAX,
+      );
+      const response = await fetchWithAuth(`/approvals/pending?limit=${refreshLimit}`);
       if (response.status === 401) {
         UNAUTHORIZED();
         return;
       }
       if (!response.ok) throw new Error('Unable to load approvals');
-      const body = (await response.json()) as { approvals?: PendingApproval[] };
+      const body = (await response.json()) as {
+        approvals?: PendingApproval[];
+        nextCursor?: string | null;
+      };
       const rows = Array.isArray(body.approvals) ? body.approvals : [];
-      approvalsRef.current = rows;
-      setApprovals(rows);
+      if (approvalsRef.current.length > SERVER_PAGE_LIMIT_MAX) {
+        // Rare case: more was already loaded (several "Load more" clicks)
+        // than the server will ever return in one page, so `refreshLimit`
+        // above was itself clamped and this fetch cannot possibly cover
+        // everything on screen. A flat replace would still silently drop the
+        // excess — merge by id instead, keeping whatever was already loaded
+        // beyond this fresh page. `nextCursor` is deliberately left as-is:
+        // this fetch's cursor only describes what comes after `rows`, and
+        // the preserved tail already covers that range.
+        const merged = [...rows, ...approvalsRef.current.filter((a) => !rows.some((r) => r.id === a.id))];
+        approvalsRef.current = merged;
+        setApprovals(merged);
+      } else {
+        approvalsRef.current = rows;
+        setApprovals(rows);
+        setNextCursor(typeof body.nextCursor === 'string' ? body.nextCursor : null);
+      }
+      setLoadMoreError(false);
       setLoadError(false);
     } catch {
       // A failed silent refresh keeps the list the user already has instead of
@@ -416,7 +527,56 @@ export default function ApprovalsInbox() {
     } finally {
       if (!silent) setLoading(false);
     }
+
+    if (!withCount) return;
+    // The total pending count is a light, best-effort companion read (same
+    // live-authorized set `/pending` itself computes, unpaginated) — it must
+    // never fail or delay the list load above; a failed/unexpected response
+    // just leaves the "of M" total off the paging line.
+    try {
+      const countRes = await fetchWithAuth('/approvals/pending/count');
+      if (countRes.ok) {
+        const countBody = (await countRes.json()) as { count?: unknown };
+        if (typeof countBody.count === 'number') setTotalCount(countBody.count);
+      }
+    } catch {
+      // Additive.
+    }
   }, []);
+
+  /** Fetches the next PAGE_SIZE rows after the last-loaded row and appends
+   *  them. A manual, per-view convenience: the next full reload (poll, WS
+   *  nudge, a decision anywhere in the list) resets back to the first page,
+   *  same as it always has — see the `nextCursor` state comment above. */
+  const loadMore = useCallback(async () => {
+    if (loadingMore || nextCursor === null) return;
+    setLoadingMore(true);
+    setLoadMoreError(false);
+    try {
+      const response = await fetchWithAuth(
+        `/approvals/pending?limit=${PAGE_SIZE}&cursor=${encodeURIComponent(nextCursor)}`,
+      );
+      if (response.status === 401) {
+        UNAUTHORIZED();
+        return;
+      }
+      if (!response.ok) throw new Error('Unable to load more approvals');
+      const body = (await response.json()) as {
+        approvals?: PendingApproval[];
+        nextCursor?: string | null;
+      };
+      const newRows = Array.isArray(body.approvals) ? body.approvals : [];
+      const existingIds = new Set(approvalsRef.current.map((a) => a.id));
+      const merged = [...approvalsRef.current, ...newRows.filter((row) => !existingIds.has(row.id))];
+      approvalsRef.current = merged;
+      setApprovals(merged);
+      setNextCursor(typeof body.nextCursor === 'string' ? body.nextCursor : null);
+    } catch {
+      setLoadMoreError(true);
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [loadingMore, nextCursor]);
 
   const { connected, subscribe, unsubscribe } = useEventStream({
     onEvent: (event) => {
@@ -433,6 +593,14 @@ export default function ApprovalsInbox() {
   useEffect(() => {
     void loadApprovals();
   }, [loadApprovals]);
+
+  // Live expiry countdown (critique #3): ticks `now` so "Expires in N min"
+  // and the expired/disabled card state stay honest between polls, instead
+  // of only refreshing every POLL_INTERVAL_MS.
+  useEffect(() => {
+    const interval = window.setInterval(() => setNow(Date.now()), EXPIRY_TICK_MS);
+    return () => window.clearInterval(interval);
+  }, []);
 
   // Drains `graduationQueueRef` ALWAYS_ALLOW_ORG_BATCH_SIZE orgs at a time.
   // Deliberately NOT scoped to any one effect's cleanup: a poll refresh, a WS
@@ -558,12 +726,14 @@ export default function ApprovalsInbox() {
     setApprovals(next);
   };
 
-  /** Relative expiry for a row. These requests are minutes-long, so an inbox
-   *  that shows only when a request arrived tells the approver nothing about
-   *  how long they still have to decide. */
+  /** Relative expiry for a row, evaluated against the ticking `now` state
+   *  (critique #3) rather than a fresh `Date.now()` read — a card whose
+   *  window closed since the last 30s poll shows as expired the moment the
+   *  next EXPIRY_TICK_MS tick lands, not only once the poll catches up. */
   const expiryLabel = (expiresAt: string): string => {
-    const remainingMs = new Date(expiresAt).getTime() - Date.now();
-    if (!Number.isFinite(remainingMs) || remainingMs < 60_000) return t('expiresSoon');
+    const remainingMs = new Date(expiresAt).getTime() - now;
+    if (!Number.isFinite(remainingMs) || remainingMs <= 0) return t('expired');
+    if (remainingMs < 60_000) return t('expiresSoon');
     return t('expiresIn', { minutes: Math.floor(remainingMs / 60_000) });
   };
 
@@ -610,7 +780,20 @@ export default function ApprovalsInbox() {
         return;
       }
       setDenyingId(null);
-      await loadApprovals({ silent: true });
+      // Critique #7: the row otherwise just vanishes with no confirmation
+      // that anything happened. Approve only — a denial's own form already
+      // stays open through the click, and the row disappearing IS the
+      // confirmation there.
+      if (decision === 'approve') {
+        showToast({
+          type: 'success',
+          message: t('approveToast', {
+            action: approval.actionLabel,
+            org: approval.orgName ?? t('unknownOrganization'),
+          }),
+        });
+      }
+      await loadApprovals({ silent: true, withCount: true });
     } catch (err) {
       const kind = classifyDecideError(err);
       // Genuine session expiry — send the user to login the same way
@@ -651,7 +834,7 @@ export default function ApprovalsInbox() {
         return;
       }
 
-      await loadApprovals({ silent: true });
+      await loadApprovals({ silent: true, withCount: true });
 
       try {
         await runAction({
@@ -817,15 +1000,28 @@ export default function ApprovalsInbox() {
       approval,
       approval.orgId !== null ? orgGraduation.get(approval.orgId) : undefined,
     );
+    // Critique #3: a card whose window closed since the last poll must read
+    // (and act) as expired the moment the ticking clock notices, not only
+    // once the next poll removes it.
+    const expired = isExpired(approval.expiresAt, now);
+    const actionsDisabled = busy || expired;
     return (
       <article
         key={approval.id}
-        className="border-b px-5 py-5 last:border-b-0"
+        className={`border-b px-5 py-5 last:border-b-0 ${expired ? 'opacity-60' : ''}`}
         data-testid={`approval-row-${approval.id}`}
       >
         <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
           <div className="min-w-0 flex-1">
-            <div className="flex flex-wrap items-center gap-2">
+            {/* Critique #1: the org name is the first line of every card —
+                two orgs' identically-named actions must never look alike. */}
+            <p
+              className="text-xs font-medium text-muted-foreground"
+              data-testid={`approval-org-${approval.id}`}
+            >
+              {approval.orgName ?? t('unknownOrganization')}
+            </p>
+            <div className="mt-0.5 flex flex-wrap items-center gap-2">
               <h2 className="text-base font-semibold text-foreground">
                 {approval.actionLabel}
               </h2>
@@ -834,6 +1030,11 @@ export default function ApprovalsInbox() {
               >
                 {t(/* i18n-dynamic */ `risk.${approval.riskTier}`)}
               </span>
+              {expired && (
+                <span className={badgeClass('muted')} data-testid={`approval-expired-badge-${approval.id}`}>
+                  {t('expired')}
+                </span>
+              )}
             </div>
             <p className="mt-1 text-sm text-muted-foreground">
               {approval.origin === 'ai_agent' ? (
@@ -899,6 +1100,12 @@ export default function ApprovalsInbox() {
                   onChange={(event) => setDenyReason(event.target.value)}
                   data-testid={`approval-deny-reason-${approval.id}`}
                 />
+                <p
+                  className="mt-1 text-right text-xs text-muted-foreground"
+                  data-testid={`approval-deny-reason-count-${approval.id}`}
+                >
+                  {t('charCount', { count: denyReason.length, max: 500 })}
+                </p>
                 <div className="mt-2 flex justify-end gap-2">
                   <button
                     type="button"
@@ -947,7 +1154,7 @@ export default function ApprovalsInbox() {
             <button
               type="button"
               onClick={() => openDenyForm(approval.id)}
-              disabled={busy}
+              disabled={actionsDisabled}
               aria-expanded={denyingId === approval.id}
               className="inline-flex h-10 items-center gap-2 rounded-lg border px-4 text-sm font-medium transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
               data-testid={`approval-deny-${approval.id}`}
@@ -958,8 +1165,11 @@ export default function ApprovalsInbox() {
             <button
               type="button"
               onClick={() => void decide(approval, 'approve')}
-              disabled={busy}
-              className="inline-flex h-10 items-center gap-2 rounded-lg bg-emerald-600 px-4 text-sm font-medium text-emerald-950 transition-colors hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={actionsDisabled}
+              // emerald-600 + white text is only ~3.8:1 (fails AA); emerald-700
+              // clears 4.5:1 in both themes (this button carries no dark:
+              // override — it is a solid fill, unaffected by page theme).
+              className="inline-flex h-10 items-center gap-2 rounded-lg bg-emerald-700 px-4 text-sm font-medium text-white transition-colors hover:bg-emerald-800 disabled:cursor-not-allowed disabled:opacity-50"
               data-testid={`approval-approve-${approval.id}`}
             >
               {isDeciding ? (
@@ -973,7 +1183,7 @@ export default function ApprovalsInbox() {
               <button
                 type="button"
                 onClick={() => openAlwaysAllow(approval, alwaysAllow.opKey, alwaysAllow.kind)}
-                disabled={busy}
+                disabled={actionsDisabled}
                 className="inline-flex h-10 items-center gap-2 rounded-lg border border-emerald-600 px-3 text-sm font-medium text-emerald-700 transition-colors hover:bg-emerald-50 disabled:cursor-not-allowed disabled:opacity-50 dark:text-emerald-300 dark:hover:bg-emerald-950/30"
                 data-testid={`approval-always-allow-${approval.id}`}
               >
@@ -1028,17 +1238,16 @@ export default function ApprovalsInbox() {
           </div>
         </div>
       ) : approvals.length === 0 ? (
-        <div
-          className="rounded-xl border border-dashed px-5 py-12 text-center"
-          data-testid="approvals-empty"
-        >
-          <ShieldCheck className="mx-auto h-7 w-7 text-muted-foreground" aria-hidden="true" />
-          <h2 className="mt-3 text-base font-semibold">{t('empty.title')}</h2>
-          <p className="mt-1 text-sm text-muted-foreground">{t('empty.description')}</p>
-        </div>
+        <EmptyState
+          testId="approvals-empty"
+          icon={<ShieldCheck className="h-7 w-7" />}
+          title={t('empty.title')}
+          description={t('empty.description')}
+          headingLevel={2}
+        />
       ) : (
         <div className="overflow-hidden rounded-xl border bg-card">
-          {buildSections(approvals, driftedIds).map((section) =>
+          {buildSections(clusterByOrg(approvals), driftedIds).map((section) =>
             section.kind === 'row' ? (
               renderRow(section.approval)
             ) : (
@@ -1048,15 +1257,26 @@ export default function ApprovalsInbox() {
                 data-testid={`approval-group-${section.group.testKey}`}
               >
                 <div className="flex flex-col gap-3 border-b bg-muted/40 px-5 py-3 md:flex-row md:items-center md:justify-between">
-                  <p className="flex min-w-0 items-center gap-2 text-sm font-semibold">
-                    <Layers className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
-                    <span className="truncate">
-                      {t('batch.groupTitle', {
-                        count: section.group.members.length,
-                        tool: section.group.tool,
-                      })}
-                    </span>
-                  </p>
+                  <div className="min-w-0">
+                    {/* Critique #1: same disambiguation as the card — a group
+                        header is the ONE place two different orgs' identical
+                        (tool, action) pairs could otherwise look alike. */}
+                    <p
+                      className="text-xs font-medium text-muted-foreground"
+                      data-testid={`approval-group-org-${section.group.testKey}`}
+                    >
+                      {section.group.members[0]?.orgName ?? t('unknownOrganization')}
+                    </p>
+                    <p className="mt-0.5 flex min-w-0 items-center gap-2 text-sm font-semibold">
+                      <Layers className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+                      <span className="truncate">
+                        {t('batch.groupTitle', {
+                          count: section.group.members.length,
+                          tool: section.group.tool,
+                        })}
+                      </span>
+                    </p>
+                  </div>
                   <div className="flex shrink-0 items-center gap-2">
                     <button
                       type="button"
@@ -1073,7 +1293,9 @@ export default function ApprovalsInbox() {
                       type="button"
                       onClick={() => void decideGroup(section.group, 'approve')}
                       disabled={busy}
-                      className="inline-flex h-9 items-center gap-2 rounded-lg bg-emerald-600 px-3 text-sm font-medium text-emerald-950 transition-colors hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-50"
+                      // See the single-card Approve button above: emerald-600 +
+                      // white fails AA (~3.8:1); emerald-700 clears 4.5:1.
+                      className="inline-flex h-9 items-center gap-2 rounded-lg bg-emerald-700 px-3 text-sm font-medium text-white transition-colors hover:bg-emerald-800 disabled:cursor-not-allowed disabled:opacity-50"
                       data-testid={`approval-group-approve-${section.group.testKey}`}
                     >
                       {groupIsDeciding(section.group) ? (
@@ -1107,6 +1329,12 @@ export default function ApprovalsInbox() {
                       onChange={(event) => setGroupDenyReason(event.target.value)}
                       data-testid={`approval-group-deny-reason-${section.group.testKey}`}
                     />
+                    <p
+                      className="mt-1 text-right text-xs text-muted-foreground"
+                      data-testid={`approval-group-deny-reason-count-${section.group.testKey}`}
+                    >
+                      {t('charCount', { count: groupDenyReason.length, max: 500 })}
+                    </p>
                     <div className="mt-2 flex justify-end gap-2">
                       <button
                         type="button"
@@ -1154,6 +1382,41 @@ export default function ApprovalsInbox() {
                 {section.group.members.map(renderRow)}
               </section>
             ),
+          )}
+        </div>
+      )}
+
+      {/* Critique #2: the server caps a single page at 50 and offers no total
+          on its own — without this line an approver has no way to tell "that's
+          everything" from "there's more you can't see". */}
+      {!loading && !loadError && approvals.length > 0 && (
+        <div
+          className="flex flex-col items-center gap-2 text-sm text-muted-foreground sm:flex-row sm:justify-between"
+          data-testid="approvals-pagination"
+        >
+          <span>
+            {totalCount !== null
+              ? t('pagination.showing', { shown: approvals.length, total: totalCount })
+              : t('pagination.showingCount', { shown: approvals.length })}
+          </span>
+          {nextCursor !== null && (
+            <div className="flex items-center gap-2">
+              {loadMoreError && (
+                <span className="text-destructive" role="alert">
+                  {t('pagination.loadMoreError')}
+                </span>
+              )}
+              <button
+                type="button"
+                onClick={() => void loadMore()}
+                disabled={loadingMore}
+                className="inline-flex h-9 items-center gap-2 rounded-lg border px-3 text-sm font-medium transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+                data-testid="approvals-load-more"
+              >
+                {loadingMore && <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />}
+                {t('pagination.loadMore')}
+              </button>
+            </div>
           )}
         </div>
       )}

--- a/apps/web/src/components/settings/AiAgentForm.tsx
+++ b/apps/web/src/components/settings/AiAgentForm.tsx
@@ -1,5 +1,14 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from 'react';
 import { useTranslation } from 'react-i18next';
+import { AlertTriangle } from 'lucide-react';
 import {
   AI_AGENT_KINDS,
   AI_AGENT_LIMIT_DEFAULTS,
@@ -105,6 +114,18 @@ const ACT_PREREQUISITE_COPY: Record<string, (t: (key: string) => string) => stri
 
 const inputCls = 'w-full rounded-md border bg-background px-2.5 py-1.5 text-sm';
 const INSTRUCTIONS_MAX = 2000;
+
+/**
+ * Mode is the only field on this form that decides whether the agent may
+ * touch a customer machine, so it is a three-card radiogroup rather than one
+ * more `<select>` of the same weight as Name — and it is the FIRST decision,
+ * above Kind and Name, because every field below it is read differently
+ * depending on the answer.
+ *
+ * The order is the privilege ladder (`AI_AGENT_MODE_RANK`), which is also the
+ * arrow-key order.
+ */
+const MODE_ORDER: readonly AiAgentMode[] = ['off', 'shadow', 'act'];
 
 /** Newline-separated textarea → trimmed, de-duplicated list. */
 function lines(value: string): string[] {
@@ -257,8 +278,128 @@ export default function AiAgentForm({
   const [issues, setIssues] = useState<string[]>([]);
   const [saving, setSaving] = useState(false);
   const [confirmDisable, setConfirmDisable] = useState(false);
+  /**
+   * Riley bug (#4187 UI critique): leaving act mode used to only HIDE the
+   * supervised-keys fieldset, so Save still submitted keys the operator
+   * could no longer see. The first fix over-corrected by CLEARING
+   * `draft.supervisedActionKeys` on the way out of act, which meant an
+   * act -> shadow -> act round trip silently lost a persisted grant list the
+   * operator never touched (P2 review finding).
+   *
+   * The keys now stay in the draft for the whole life of the form —
+   * `selectMode` below never touches them — and are omitted only from the
+   * SAVE PAYLOAD while `draft.mode !== 'act'` (see `save()`'s `actAssets`).
+   * This derived flag drives the announcement of that omission; it is not
+   * separate state, so it can never drift from what Save will actually send.
+   */
+  const actKeysWillBeOmitted = draft.mode !== 'act' && draft.supervisedActionKeys.length > 0;
 
   const patch = (values: Partial<Draft>) => setDraft((current) => ({ ...current, ...values }));
+
+  const permissionsHeadingId = useId();
+  const limitsBudgetId = useId();
+  const limitsTimingId = useId();
+  const toolSuggestInputId = useId();
+  const toolSuggestListId = useId();
+  const [toolSuggestion, setToolSuggestion] = useState('');
+
+  /**
+   * Autocomplete source for the tool allowlist. There is no tool-name
+   * registry endpoint: `ACT_ELIGIBLE_TOOL_NAMES` is API-only and the
+   * allowlist's own validator accepts any `TOOL_REF`-shaped string, so the
+   * closest thing the client can source is the policy-decidable registry it
+   * already fetched — offered as BOTH the bare tool name and the scoped
+   * `tool:action` form, the two shapes `checkAgentGuardrails` admits.
+   */
+  const toolSuggestions = useMemo(() => {
+    const names = new Set<string>();
+    for (const entry of policyKeys) {
+      names.add(entry.toolName);
+      names.add(entry.key);
+    }
+    return [...names].sort((a, b) => a.localeCompare(b));
+  }, [policyKeys]);
+
+  const addSuggestedTool = () => {
+    const value = toolSuggestion.trim();
+    if (value === '') return;
+    // `lines()` is the same de-duplicating reader the save body uses, so an
+    // entry already present (however the operator typed it) never doubles.
+    const next = [...new Set([...lines(draft.toolAllowlist), value])];
+    patch({ toolAllowlist: next.join('\n') });
+    setToolSuggestion('');
+  };
+
+  // ---- Mode: the privileged choice --------------------------------------
+  const modeHeadingId = useId();
+  const modeRefs = useRef<Partial<Record<AiAgentMode, HTMLButtonElement | null>>>({});
+  // The CREATE path has no `agent` DTO yet, so the fallback must be the shared
+  // constant and never `[]` — see the long note this file already carries on
+  // the old `<option disabled>`; the reasoning survived the control change.
+  const actSupported = (agent?.supportedModes ?? SUPPORTED_AGENT_MODES).includes('act');
+  const modeUnavailable = (mode: AiAgentMode) => mode === 'act' && !actSupported;
+
+  // Literal keys rather than a dynamic `t()` on the token: the closed
+  // three-member union is worth spelling out so the keyUsage guard verifies
+  // every label statically (same reason as AiAgentSchedulesSection's
+  // `scheduleKindLabel`).
+  const MODE_LABEL: Record<AiAgentMode, string> = {
+    off: t('aiAgentsPage.modeChoice.off'),
+    shadow: t('aiAgentsPage.modeChoice.shadow'),
+    act: t('aiAgentsPage.modeChoice.act'),
+  };
+  const MODE_CONSEQUENCE: Record<AiAgentMode, string> = {
+    off: t('aiAgentsPage.modeChoice.offConsequence'),
+    shadow: t('aiAgentsPage.modeChoice.shadowConsequence'),
+    act: t('aiAgentsPage.modeChoice.actConsequence'),
+  };
+
+  const selectMode = (next: AiAgentMode) => {
+    if (modeUnavailable(next) || next === draft.mode) return;
+    if (next === 'act') {
+      patch({ mode: next });
+      return;
+    }
+    // Leaving act: only the acknowledgement belongs to act mode alone — a
+    // genuine re-entry must ask again. `supervisedActionKeys` is NOT
+    // cleared: it stays in the draft so a later return to act restores the
+    // operator's selection, and `save()`'s payload is what keeps them out of
+    // effect while the mode isn't act (see `actKeysWillBeOmitted` above).
+    setActAck(false);
+    patch({ mode: next });
+  };
+
+  /** Roving-tabindex arrow navigation, per the radiogroup pattern: the group
+   *  holds one tab stop and the arrows move BOTH focus and selection. */
+  const onModeKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    const selectable = MODE_ORDER.filter((mode) => !modeUnavailable(mode));
+    if (selectable.length === 0) return;
+    const current = Math.max(0, selectable.indexOf(draft.mode));
+    let target: number;
+    switch (event.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+        target = (current + 1) % selectable.length;
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        target = (current - 1 + selectable.length) % selectable.length;
+        break;
+      case 'Home':
+        target = 0;
+        break;
+      case 'End':
+        target = selectable.length - 1;
+        break;
+      default:
+        return;
+    }
+    event.preventDefault();
+    const next = selectable[target];
+    if (!next) return;
+    selectMode(next);
+    modeRefs.current[next]?.focus();
+  };
 
   // Recipients are role IDs, never role names: `roles` is a tenant-scoped table
   // with partner-defined names, so the picker has to show the real rows.
@@ -363,7 +504,14 @@ export default function AiAgentForm({
       // scriptIds value survives a save that only ever touches
       // supervisedActionKeys. On create, the server's createAiAgentSchema
       // defaults the omitted scriptIds to [].
-      actAssets: { supervisedActionKeys: draft.supervisedActionKeys },
+      //
+      // P2 review fix: the draft KEEPS its supervisedActionKeys selection
+      // across a mode change (see `selectMode`'s doc), but a non-act mode
+      // can never use them — sent as [] rather than the draft's live value
+      // so leaving act genuinely revokes them server-side, not just in the
+      // UI, while still letting the operator's selection reappear if they
+      // return to act before saving.
+      actAssets: { supervisedActionKeys: draft.mode === 'act' ? draft.supervisedActionKeys : [] },
     };
 
     let saved = false;
@@ -514,398 +662,545 @@ export default function AiAgentForm({
     </label>
   );
 
-  return (
-    <section className="rounded-lg border bg-muted/20 p-4" data-testid="ai-agent-editor">
-      <h2 className="mb-3 text-sm font-semibold">
-        {isCreate ? t('aiAgentsPage.editor.newTitle') : t('aiAgentsPage.editor.editTitle')}
-      </h2>
+  // Roving-tabindex tab stop. Normally the checked option, but a stale row
+  // can have `draft.mode` set to an option that is now disabled (an agent
+  // saved while `act` was supported, whose partner later lost act
+  // eligibility, still stores `mode: 'act'`) — falling back to the first
+  // ENABLED option keeps the group reachable by Tab at all, rather than
+  // leaving every radio at tabIndex -1.
+  const tabStopMode = modeUnavailable(draft.mode)
+    ? MODE_ORDER.find((mode) => !modeUnavailable(mode))
+    : draft.mode;
 
-      {issues.length > 0 && (
-        <ul
-          className="mb-3 list-disc space-y-1 rounded-md border border-destructive/40 bg-destructive/10 px-6 py-2 text-sm text-destructive"
-          data-testid="ai-agent-issues"
+  /** The mode radiogroup. Rendered as the first block of the form, before
+   *  Kind and Name: it is the only choice here that can reach a device. */
+  const modeChoice = (
+    <div className="md:col-span-2" data-testid="ai-agent-mode-field">
+      <h3 id={modeHeadingId} className="text-sm font-semibold">
+        {t('aiAgentsPage.modeChoice.legend')}
+      </h3>
+      <div
+        role="radiogroup"
+        aria-labelledby={modeHeadingId}
+        onKeyDown={onModeKeyDown}
+        className="mt-2 grid gap-2 sm:grid-cols-3"
+        data-testid="ai-agent-mode"
+      >
+        {MODE_ORDER.map((mode) => {
+          const selected = draft.mode === mode;
+          const unavailable = modeUnavailable(mode);
+          return (
+            <button
+              key={mode}
+              type="button"
+              role="radio"
+              aria-checked={selected}
+              disabled={unavailable}
+              tabIndex={mode === tabStopMode ? 0 : -1}
+              ref={(node) => {
+                modeRefs.current[mode] = node;
+              }}
+              onClick={() => selectMode(mode)}
+              className={`rounded-lg border p-3 text-left transition-colors focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60 ${
+                selected
+                  ? 'border-primary bg-primary/10 ring-1 ring-primary'
+                  : 'bg-background hover:border-primary/50 hover:bg-muted/40'
+              }`}
+              data-testid={`ai-agent-mode-${mode}`}
+            >
+              <span className="flex items-center gap-2">
+                {/* Selection is encoded by SHAPE (a filled ring) as well as by
+                    colour, so the choice survives a colourblind read. */}
+                <span
+                  aria-hidden="true"
+                  className={`flex h-4 w-4 shrink-0 items-center justify-center rounded-full border ${
+                    selected ? 'border-primary' : 'border-muted-foreground/50'
+                  }`}
+                >
+                  {selected && <span className="h-2 w-2 rounded-full bg-primary" />}
+                </span>
+                <span className="text-sm font-medium">{MODE_LABEL[mode]}</span>
+                {mode === 'act' && (
+                  <AlertTriangle className="ml-auto h-4 w-4 shrink-0 text-warning-strong" aria-hidden="true" />
+                )}
+              </span>
+              <span className="mt-1.5 block text-xs text-muted-foreground">
+                {MODE_CONSEQUENCE[mode]}
+              </span>
+              {unavailable && (
+                <span
+                  className="mt-1.5 block text-xs text-muted-foreground"
+                  data-testid="ai-agent-mode-act-unavailable"
+                >
+                  {t('aiAgentsPage.modeChoice.actUnavailable')}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Attached to the choice, not floated below the rest of the fields:
+          the warning and its acknowledgement are what the act card MEANS. */}
+      {draft.mode === 'act' && (
+        <div
+          className="mt-2 space-y-2 rounded-lg border border-warning-strong/50 bg-warning/10 p-3 text-sm"
+          data-testid="ai-agent-act-warning"
         >
-          {issues.map((issue) => (
-            <li key={issue}>{issue}</li>
-          ))}
-        </ul>
+          <p className="flex items-start gap-2 font-medium">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-warning-strong" aria-hidden="true" />
+            <span>{t('aiAgentsPage.actWarning.title')}</span>
+          </p>
+          <ul className="list-disc space-y-1 pl-5 text-muted-foreground">
+            <li>{t('aiAgentsPage.actWarning.unattended')}</li>
+            <li>{t('aiAgentsPage.actWarning.verification')}</li>
+            <li>{t('aiAgentsPage.actWarning.noRollback')}</li>
+            <li>{t('aiAgentsPage.actWarning.singleDevice')}</li>
+            <li>{t('aiAgentsPage.actWarning.actionCap')}</li>
+          </ul>
+          {enteringActMode && (
+            <label className="flex items-start gap-2 pt-1 text-sm font-medium">
+              <input
+                type="checkbox"
+                checked={actAck}
+                onChange={(e) => setActAck(e.target.checked)}
+                data-testid="ai-agent-act-ack"
+              />
+              <span>{t('aiAgentsPage.actWarning.ack')}</span>
+            </label>
+          )}
+        </div>
       )}
 
-      <div className="grid gap-3 md:grid-cols-2">
-        {isCreate && showOwnerScope && (
-          <fieldset className="space-y-2 rounded-md border p-3 md:col-span-2" data-testid="ai-agent-ownerscope">
-            <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
-              {t('aiAgentsPage.editor.scopeLegend')}
-            </legend>
-            <label className="flex items-center gap-2 text-sm">
-              <input
-                type="radio"
-                name="ai-agent-owner"
-                value="partner"
-                checked={draft.ownerScope === 'partner'}
-                onChange={() => patch({ ownerScope: 'partner', kind: firstFreeKind(agents, 'partner', orgScope.orgId) ?? draft.kind })}
-                data-testid="ai-agent-owner-partner"
-              />
-              {t('aiAgentsPage.editor.allOrgs')}{' '}
-              <span className="text-muted-foreground">{t('aiAgentsPage.editor.allOrgsHint')}</span>
-            </label>
-            <label className="flex items-center gap-2 text-sm">
-              <input
-                type="radio"
-                name="ai-agent-owner"
-                value="organization"
-                checked={draft.ownerScope === 'organization'}
-                onChange={() => patch({ ownerScope: 'organization', kind: firstFreeKind(agents, 'organization', orgScope.orgId) ?? draft.kind })}
-                data-testid="ai-agent-owner-org"
-              />
-              {t('aiAgentsPage.editor.thisOrg')}
-            </label>
-          </fieldset>
-        )}
+      {/* Mounted UNCONDITIONALLY — only the text toggles. An aria-live
+          region (`role="status"`) only announces changes to content that was
+          already present in the accessibility tree; mounting it on demand
+          meant the FIRST thing it ever had to say was never announced. */}
+      <p
+        className="mt-2 text-xs text-muted-foreground"
+        role="status"
+        data-testid="ai-agent-act-keys-cleared"
+      >
+        {actKeysWillBeOmitted ? t('aiAgentsPage.fields.actKeysCleared') : ''}
+      </p>
+    </div>
+  );
 
-        {isCreate && availableKinds.length === 0 && (
-          <p className="text-sm text-muted-foreground md:col-span-2" data-testid="ai-agent-kinds-exhausted">
-            {t('aiAgentsPage.issues.allKindsTaken')}
-          </p>
-        )}
-
-        <label className="space-y-1 text-sm">
-          <span className="font-medium">{t('aiAgentsPage.fields.kind')}</span>
-          <select
-            className={inputCls}
-            value={draft.kind}
-            disabled={!isCreate}
-            onChange={(e) => patch({ kind: e.target.value as AiAgentKind })}
-            data-testid="ai-agent-kind"
+  return (
+    <div className="flex min-h-0 flex-1 flex-col" data-testid="ai-agent-editor">
+      <div className="min-h-0 flex-1 space-y-3 overflow-y-auto p-5">
+        {issues.length > 0 && (
+          <ul
+            className="list-disc space-y-1 rounded-md border border-destructive/40 bg-destructive/10 px-6 py-2 text-sm text-destructive"
+            data-testid="ai-agent-issues"
           >
-            {(isCreate ? availableKinds : AI_AGENT_KINDS).map((kind) => (
-              <option key={kind} value={kind}>
-                {t(/* i18n-dynamic */ `aiAgentsPage.kinds.${kind}`)}
-              </option>
+            {issues.map((issue) => (
+              <li key={issue}>{issue}</li>
             ))}
-          </select>
-          {!isCreate && (
-            <span className="block text-xs text-muted-foreground">
-              {t('aiAgentsPage.fields.kindImmutable')}
-            </span>
-          )}
-        </label>
-
-        <label className="space-y-1 text-sm">
-          <span className="font-medium">{t('aiAgentsPage.fields.name')}</span>
-          <input
-            className={inputCls}
-            maxLength={120}
-            value={draft.name}
-            onChange={(e) => patch({ name: e.target.value })}
-            data-testid="ai-agent-name"
-          />
-        </label>
-
-        <label className="space-y-1 text-sm">
-          <span className="font-medium">{t('aiAgentsPage.fields.mode')}</span>
-          <select
-            className={inputCls}
-            value={draft.mode}
-            onChange={(e) => patch({ mode: e.target.value as AiAgentMode })}
-            data-testid="ai-agent-mode"
-          >
-            <option value="off">{t('aiAgentsPage.modes.off')}</option>
-            <option value="shadow">{t('aiAgentsPage.modes.shadow')}</option>
-            {/* Not merely hidden: an operator needs to see that acting is a
-                real, deliberate next step rather than a missing feature.
-                Gated on the API's supportedModes (Task 6, #3826) — the
-                server's create/update prerequisites (recipient +
-                act-eligible surface) are the authoritative gate; the warning
-                banner and acknowledgement below are this form's contribution
-                on top of that. Review fix (#3826 final-review): the CREATE
-                path has no `agent` DTO yet (it is null until the first save),
-                so the fallback must be the shared `SUPPORTED_AGENT_MODES`
-                constant — not `[]` — or the option is permanently disabled on
-                every create form regardless of what the API actually
-                supports, which is exactly the drift the constant's own
-                docstring exists to prevent. */}
-            <option
-              value="act"
-              disabled={!(agent?.supportedModes ?? SUPPORTED_AGENT_MODES).includes('act')}
-              data-testid="ai-agent-mode-act"
-            >
-              {t('aiAgentsPage.modes.act')}
-            </option>
-          </select>
-        </label>
-
-        <label className="flex items-center gap-2 self-end text-sm">
-          <input
-            type="checkbox"
-            checked={draft.enabled}
-            onChange={(e) => patch({ enabled: e.target.checked })}
-            data-testid="ai-agent-enabled"
-          />
-          <span>{t('aiAgentsPage.fields.enabled')}</span>
-        </label>
-
-        {draft.mode === 'act' && (
-          <div
-            className="space-y-2 rounded-md border border-amber-500/50 bg-amber-500/10 p-3 text-sm md:col-span-2"
-            data-testid="ai-agent-act-warning"
-          >
-            <p className="font-medium">{t('aiAgentsPage.actWarning.title')}</p>
-            <ul className="list-disc space-y-1 pl-5 text-muted-foreground">
-              <li>{t('aiAgentsPage.actWarning.unattended')}</li>
-              <li>{t('aiAgentsPage.actWarning.verification')}</li>
-              <li>{t('aiAgentsPage.actWarning.noRollback')}</li>
-              <li>{t('aiAgentsPage.actWarning.singleDevice')}</li>
-              <li>{t('aiAgentsPage.actWarning.actionCap')}</li>
-            </ul>
-            {enteringActMode && (
-              <label className="flex items-start gap-2 pt-1 text-sm font-medium">
-                <input
-                  type="checkbox"
-                  checked={actAck}
-                  onChange={(e) => setActAck(e.target.checked)}
-                  data-testid="ai-agent-act-ack"
-                />
-                <span>{t('aiAgentsPage.actWarning.ack')}</span>
-              </label>
-            )}
-          </div>
+          </ul>
         )}
 
-        {/* Wave 5 Part B (#3827). Gated the same way as the act-warning block
-            above (draft.mode === 'act' only) for ORG rows — the "act
-            acknowledgement pattern": this is additional unattended authority
-            an operator is opting into only once they are already looking at
-            the act-mode warning, never offered for shadow/off.
-            PARTNER rows are the exception (#4583): per P2-5 (#4192) a
-            partner row's keys are a CEILING on org grants, not authority the
-            partner row exercises itself — ticking a key here authorizes
-            nothing on its own regardless of the partner row's own mode, so
-            gating the editor (and its ceiling hint) behind the partner row's
-            act mode hid the warning precisely when it mattered: while
-            editing a Shadow-mode baseline. */}
-        {(draft.mode === 'act' || draft.ownerScope === 'partner') && (
-          <fieldset className="space-y-2 rounded-md border p-3 md:col-span-2" data-testid="ai-agent-policy-decide">
-            <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
-              {t('aiAgentsPage.sections.policyDecide')}
-            </legend>
-            <p className="text-xs text-muted-foreground">{t('aiAgentsPage.fields.supervisedActionKeysHint')}</p>
-            {/* P2-5 (#4192). A partner row's keys are a CEILING, not an
-                inherited grant: with no org row the effective key set is empty,
-                so ticking a key here authorizes nothing on its own. Said only
-                on the partner form, because that is where the misreading is
-                possible — an org-owned agent's keys really are the live set. */}
-            {draft.ownerScope === 'partner' && (
-              <p
-                className="text-xs text-muted-foreground"
-                data-testid="ai-agent-supervised-keys-ceiling-hint"
-              >
-                {t('aiAgentsPage.graduation.ceilingHint')}
-              </p>
+        <div className="grid gap-3 md:grid-cols-2">
+          {modeChoice}
+
+          {isCreate && showOwnerScope && (
+            <fieldset className="space-y-2 rounded-md border p-3 md:col-span-2" data-testid="ai-agent-ownerscope">
+              <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
+                {t('aiAgentsPage.editor.scopeLegend')}
+              </legend>
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="radio"
+                  name="ai-agent-owner"
+                  value="partner"
+                  checked={draft.ownerScope === 'partner'}
+                  onChange={() => patch({ ownerScope: 'partner', kind: firstFreeKind(agents, 'partner', orgScope.orgId) ?? draft.kind })}
+                  data-testid="ai-agent-owner-partner"
+                />
+                {t('aiAgentsPage.editor.allOrgs')}{' '}
+                <span className="text-muted-foreground">{t('aiAgentsPage.editor.allOrgsHint')}</span>
+              </label>
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="radio"
+                  name="ai-agent-owner"
+                  value="organization"
+                  checked={draft.ownerScope === 'organization'}
+                  onChange={() => patch({ ownerScope: 'organization', kind: firstFreeKind(agents, 'organization', orgScope.orgId) ?? draft.kind })}
+                  data-testid="ai-agent-owner-org"
+                />
+                {t('aiAgentsPage.editor.thisOrg')}
+              </label>
+            </fieldset>
+          )}
+
+          {isCreate && availableKinds.length === 0 && (
+            <p className="text-sm text-muted-foreground md:col-span-2" data-testid="ai-agent-kinds-exhausted">
+              {t('aiAgentsPage.issues.allKindsTaken')}
+            </p>
+          )}
+
+          <label className="space-y-1 text-sm">
+            <span className="font-medium">{t('aiAgentsPage.fields.kind')}</span>
+            <select
+              className={inputCls}
+              value={draft.kind}
+              disabled={!isCreate}
+              onChange={(e) => patch({ kind: e.target.value as AiAgentKind })}
+              data-testid="ai-agent-kind"
+            >
+              {(isCreate ? availableKinds : AI_AGENT_KINDS).map((kind) => (
+                <option key={kind} value={kind}>
+                  {t(/* i18n-dynamic */ `aiAgentsPage.kinds.${kind}`)}
+                </option>
+              ))}
+            </select>
+            {!isCreate && (
+              <span className="block text-xs text-muted-foreground">
+                {t('aiAgentsPage.fields.kindImmutable')}
+              </span>
             )}
-            {policyKeysFailed ? (
-              <p className="text-sm text-destructive" data-testid="ai-agent-policy-keys-failed">
-                {t('aiAgentsPage.fields.supervisedActionKeysFailed')}
+          </label>
+
+          <label className="space-y-1 text-sm">
+            <span className="font-medium">{t('aiAgentsPage.fields.name')}</span>
+            <input
+              className={inputCls}
+              maxLength={120}
+              value={draft.name}
+              onChange={(e) => patch({ name: e.target.value })}
+              data-testid="ai-agent-name"
+            />
+          </label>
+
+          {/* `enabled` and `mode` are two independent gates, and BOTH have to
+              pass: runService's admission skips `agent_disabled` before it ever
+              looks at the mode, and skips `mode_off` right after. Representable
+              nonsense (`enabled: true, mode: 'off'`) is therefore real, and the
+              helper below is the only place the form says so. */}
+          <div className="space-y-1 self-end text-sm md:col-span-2">
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={draft.enabled}
+                onChange={(e) => patch({ enabled: e.target.checked })}
+                data-testid="ai-agent-enabled"
+              />
+              <span className="font-medium">{t('aiAgentsPage.fields.enabled')}</span>
+            </label>
+            <p className="pl-6 text-xs text-muted-foreground" data-testid="ai-agent-enabled-hint">
+              {t('aiAgentsPage.fields.enabledHint')}
+            </p>
+          </div>
+
+          {/* Wave 5 Part B (#3827). Gated the same way as the act-warning block
+              above (draft.mode === 'act' only) for ORG rows — the "act
+              acknowledgement pattern": this is additional unattended authority
+              an operator is opting into only once they are already looking at
+              the act-mode warning, never offered for shadow/off.
+              PARTNER rows are the exception (#4583): per P2-5 (#4192) a
+              partner row's keys are a CEILING on org grants, not authority the
+              partner row exercises itself — ticking a key here authorizes
+              nothing on its own regardless of the partner row's own mode, so
+              gating the editor (and its ceiling hint) behind the partner row's
+              act mode hid the warning precisely when it mattered: while
+              editing a Shadow-mode baseline. */}
+          {(draft.mode === 'act' || draft.ownerScope === 'partner') && (
+            <fieldset className="space-y-2 rounded-md border p-3 md:col-span-2" data-testid="ai-agent-policy-decide">
+              <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
+                {t('aiAgentsPage.sections.policyDecide')}
+              </legend>
+              <p className="text-xs text-muted-foreground">{t('aiAgentsPage.fields.supervisedActionKeysHint')}</p>
+              {/* P2-5 (#4192). A partner row's keys are a CEILING, not an
+                  inherited grant: with no org row the effective key set is empty,
+                  so ticking a key here authorizes nothing on its own. Said only
+                  on the partner form, because that is where the misreading is
+                  possible — an org-owned agent's keys really are the live set. */}
+              {draft.ownerScope === 'partner' && (
+                <p
+                  className="text-xs text-muted-foreground"
+                  data-testid="ai-agent-supervised-keys-ceiling-hint"
+                >
+                  {t('aiAgentsPage.graduation.ceilingHint')}
+                </p>
+              )}
+              {policyKeysFailed ? (
+                <p className="text-sm text-destructive" data-testid="ai-agent-policy-keys-failed">
+                  {t('aiAgentsPage.fields.supervisedActionKeysFailed')}
+                </p>
+              ) : policyKeys.length === 0 ? (
+                <p className="text-sm text-muted-foreground" data-testid="ai-agent-policy-keys-empty">
+                  {t('aiAgentsPage.fields.supervisedActionKeysEmpty')}
+                </p>
+              ) : (
+                <div className="space-y-2">
+                  {[...groupByTool(policyKeys).entries()].map(([toolName, entries]) => (
+                    <div key={toolName}>
+                      <p className="text-xs font-semibold">{toolName}</p>
+                      <div className="flex flex-wrap gap-3">
+                        {entries.map((entry) => (
+                          <label key={entry.key} className="flex items-center gap-1 text-sm">
+                            <input
+                              type="checkbox"
+                              checked={draft.supervisedActionKeys.includes(entry.key)}
+                              onChange={() =>
+                                patch({ supervisedActionKeys: toggle(draft.supervisedActionKeys, entry.key) })}
+                              data-testid={`ai-agent-supervised-key-${entry.key}`}
+                            />
+                            {entry.action ?? entry.toolName}
+                          </label>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </fieldset>
+          )}
+
+          {/* Graduation evidence (P2-5, #4192). Edit-only, for the same reason
+              the schedules section is: the evidence ledger is keyed to a
+              persisted agent that does not exist until the first save. NOT gated
+              on `draft.mode === 'act'` — evidence an agent already earned is a
+              fact about the past, so toggling an unsaved draft back to shadow
+              must not make it disappear. The panel is read-only-useful with
+              `BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED` off; see its module doc.
+              `agent.kind` (stored), not `draft.kind`, since kind is create-only.
+              An org-owned agent always reads its OWN org's evidence; a partner
+              baseline follows the org switcher, and falls through to the
+              partner-wide grouping when it is on "all organizations". */}
+          {!isCreate && (
+            <AiAgentGraduationPanel
+              orgId={agent.orgId ?? orgScope.orgId}
+              kind={agent.kind}
+              isPartnerScope={isPartnerScope}
+            />
+          )}
+
+          <fieldset className="space-y-2 rounded-md border p-3 md:col-span-2">
+            <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
+              {t('aiAgentsPage.sections.scope')}
+            </legend>
+            <div className="flex flex-wrap gap-3">
+              {SEVERITIES.map((severity) => (
+                <label key={severity} className="flex items-center gap-1 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={draft.severities.includes(severity)}
+                    onChange={() => patch({ severities: toggle(draft.severities, severity) })}
+                    data-testid={`ai-agent-severity-${severity}`}
+                  />
+                  {t(/* i18n-dynamic */ `aiAgentsPage.severities.${severity}`)}
+                </label>
+              ))}
+            </div>
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={draft.respectMaintenanceWindows}
+                onChange={(e) => patch({ respectMaintenanceWindows: e.target.checked })}
+                data-testid="ai-agent-respect-maintenance"
+              />
+              {t('aiAgentsPage.fields.respectMaintenanceWindows')}
+            </label>
+
+            {/* P2-4 (#4191) review fix — ticket-triggered runs are admitted
+                with `kind: 'helpdesk'` (ticketHelpdeskSubscriber.ts's
+                `admitTriageRun`: `createAndEnqueueAgentRun({ kind: 'helpdesk',
+                triggerKind: 'ticket', profile: 'triage', ... })`), and
+                runService.ts's `resolveEffectiveAgentSystem(orgId, kind)`
+                resolves the effective policy off THAT `kind` field — never
+                `triage`, which is a different agent kind entirely (the
+                scheduled-sweeps gate a few lines below IS genuinely
+                triage-only; do not copy this gate from that one again).
+                Disabled — never hidden — on a partner-wide row: the merge
+                reads ONLY the org's own override (effectivePolicy.ts), so a
+                partner baseline value can never take effect; hiding it
+                outright would look like the field vanished rather than
+                explain why it cannot be set here. */}
+            {draft.kind === 'helpdesk' && (
+              <div className="space-y-1">
+                <label className="flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={draft.ticketAutonomousWrites}
+                    disabled={draft.ownerScope !== 'organization'}
+                    onChange={(e) => patch({ ticketAutonomousWrites: e.target.checked })}
+                    data-testid="ai-agent-ticket-autonomous-writes"
+                  />
+                  {t('aiAgentsPage.fields.ticketAutonomousWrites')}
+                </label>
+                <p className="pl-6 text-xs text-muted-foreground">
+                  {t('aiAgentsPage.fields.ticketAutonomousWritesHint')}
+                </p>
+              </div>
+            )}
+          </fieldset>
+
+          {/* Permissions carries the widest blast radius of the remaining
+              sections, so it gets a real heading rather than one more 12px
+              uppercase legend of the same weight as "Limits". A <section> and
+              not a <fieldset>: <legend>'s content model is phrasing content, so
+              an <h3> cannot live inside one. */}
+          <section
+            className="space-y-2 rounded-md border p-3 md:col-span-2"
+            aria-labelledby={permissionsHeadingId}
+            data-testid="ai-agent-permissions"
+          >
+            <div>
+              <h3 id={permissionsHeadingId} className="text-sm font-semibold">
+                {t('aiAgentsPage.sections.permissions')}
+              </h3>
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                {t('aiAgentsPage.sections.permissionsDescription')}
               </p>
-            ) : policyKeys.length === 0 ? (
-              <p className="text-sm text-muted-foreground" data-testid="ai-agent-policy-keys-empty">
-                {t('aiAgentsPage.fields.supervisedActionKeysEmpty')}
+            </div>
+            <p className="text-xs text-muted-foreground">{t('aiAgentsPage.fields.toolAllowlistHint')}</p>
+            {listField('ai-agent-toolallowlist', t('aiAgentsPage.fields.toolAllowlist'), draft.toolAllowlist, (v) => patch({ toolAllowlist: v }), 4)}
+            {/* No tool-name registry endpoint exists (the API's
+                ACT_ELIGIBLE_TOOL_NAMES / the MCP tool set are server-only), so
+                this is autocomplete over the ONE name source the client already
+                holds — the policy-decidable registry this form fetches for the
+                act-mode section. Deliberately labelled as a partial list rather
+                than presented as the closed set of tools. */}
+            {toolSuggestions.length > 0 && (
+              <div className="space-y-1">
+                <label className="block text-xs font-medium" htmlFor={toolSuggestInputId}>
+                  {t('aiAgentsPage.fields.toolSuggestLabel')}
+                </label>
+                <div className="flex flex-wrap gap-2">
+                  <input
+                    id={toolSuggestInputId}
+                    className={`${inputCls} font-mono sm:w-64`}
+                    list={toolSuggestListId}
+                    value={toolSuggestion}
+                    onChange={(e) => setToolSuggestion(e.target.value)}
+                    data-testid="ai-agent-toolallowlist-suggest"
+                  />
+                  <datalist id={toolSuggestListId} data-testid="ai-agent-toolallowlist-suggestions">
+                    {toolSuggestions.map((name) => (
+                      <option key={name} value={name} />
+                    ))}
+                  </datalist>
+                  <button
+                    type="button"
+                    onClick={addSuggestedTool}
+                    disabled={toolSuggestion.trim() === ''}
+                    className="rounded-md border px-3 py-1.5 text-sm font-medium disabled:opacity-60"
+                    data-testid="ai-agent-toolallowlist-add"
+                  >
+                    {t('aiAgentsPage.fields.toolSuggestAdd')}
+                  </button>
+                </div>
+                <p className="text-xs text-muted-foreground">{t('aiAgentsPage.fields.toolSuggestHint')}</p>
+              </div>
+            )}
+            <p className="text-xs text-muted-foreground">{t('aiAgentsPage.fields.protectedHint')}</p>
+            <div className="grid gap-3 md:grid-cols-3">
+              {listField('ai-agent-services', t('aiAgentsPage.fields.protectedServices'), draft.services, (v) => patch({ services: v }), 2)}
+              {listField('ai-agent-paths', t('aiAgentsPage.fields.protectedPaths'), draft.paths, (v) => patch({ paths: v }), 2)}
+              {listField('ai-agent-registrykeys', t('aiAgentsPage.fields.protectedRegistryKeys'), draft.registryKeys, (v) => patch({ registryKeys: v }), 2)}
+            </div>
+          </section>
+
+          {/* Six unlabelled number inputs in one 3-column grid read as one
+              undifferentiated wall. Split into the two questions they actually
+              answer — how much may it spend and reach, and how long may it take
+              — with every control and every test id unchanged. */}
+          <fieldset className="space-y-3 rounded-md border p-3 md:col-span-2">
+            <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
+              {t('aiAgentsPage.sections.limits')}
+            </legend>
+            <div role="group" aria-labelledby={limitsBudgetId} className="space-y-1.5">
+              <p id={limitsBudgetId} className="text-xs font-medium">
+                {t('aiAgentsPage.sections.limitsBudget')}
+              </p>
+              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                {numberField('ai-agent-limit-devices', t('aiAgentsPage.fields.maxDevicesPerRun'), draft.limits.maxDevicesPerRun, 1, 50, (v) => patch({ limits: { ...draft.limits, maxDevicesPerRun: v } }))}
+                {numberField('ai-agent-limit-runs', t('aiAgentsPage.fields.maxRunsPerHour'), draft.limits.maxRunsPerHour, 1, 500, (v) => patch({ limits: { ...draft.limits, maxRunsPerHour: v } }))}
+                {numberField('ai-agent-limit-budget', t('aiAgentsPage.fields.maxBudgetCentsPerDay'), draft.limits.maxBudgetCentsPerDay, 1, 100000, (v) => patch({ limits: { ...draft.limits, maxBudgetCentsPerDay: v } }))}
+                {numberField('ai-agent-limit-fleet', t('aiAgentsPage.fields.maxFleetPercentPerDay'), draft.limits.maxFleetPercentPerDay, 1, 100, (v) => patch({ limits: { ...draft.limits, maxFleetPercentPerDay: v } }))}
+              </div>
+            </div>
+            <div role="group" aria-labelledby={limitsTimingId} className="space-y-1.5">
+              <p id={limitsTimingId} className="text-xs font-medium">
+                {t('aiAgentsPage.sections.limitsTiming')}
+              </p>
+              <div className="grid gap-3 sm:grid-cols-2">
+                {numberField('ai-agent-limit-wallclock', t('aiAgentsPage.fields.wallClockSeconds'), draft.limits.wallClockSeconds, 30, 1800, (v) => patch({ limits: { ...draft.limits, wallClockSeconds: v } }))}
+                {numberField('ai-agent-cooldown', t('aiAgentsPage.fields.cooldownSeconds'), draft.cooldownSeconds, 0, 86400, (v) => patch({ cooldownSeconds: v }))}
+              </div>
+            </div>
+          </fieldset>
+
+          <fieldset className="space-y-2 rounded-md border p-3 md:col-span-2">
+            <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
+              {t('aiAgentsPage.sections.notifications')}
+            </legend>
+            <p className="text-xs text-muted-foreground">{t('aiAgentsPage.fields.recipientRolesHint')}</p>
+            {rolesFailed ? (
+              <p className="text-sm text-destructive" data-testid="ai-agent-roles-failed">
+                {t('aiAgentsPage.fields.recipientRolesFailed')}
+              </p>
+            ) : roles.length === 0 ? (
+              <p className="text-sm text-muted-foreground" data-testid="ai-agent-roles-empty">
+                {t('aiAgentsPage.fields.recipientRolesEmpty')}
               </p>
             ) : (
-              <div className="space-y-2">
-                {[...groupByTool(policyKeys).entries()].map(([toolName, entries]) => (
-                  <div key={toolName}>
-                    <p className="text-xs font-semibold">{toolName}</p>
-                    <div className="flex flex-wrap gap-3">
-                      {entries.map((entry) => (
-                        <label key={entry.key} className="flex items-center gap-1 text-sm">
-                          <input
-                            type="checkbox"
-                            checked={draft.supervisedActionKeys.includes(entry.key)}
-                            onChange={() =>
-                              patch({ supervisedActionKeys: toggle(draft.supervisedActionKeys, entry.key) })}
-                            data-testid={`ai-agent-supervised-key-${entry.key}`}
-                          />
-                          {entry.action ?? entry.toolName}
-                        </label>
-                      ))}
-                    </div>
-                  </div>
+              <div className="flex flex-wrap gap-3">
+                {roles.map((role) => (
+                  <label key={role.id} className="flex items-center gap-1 text-sm">
+                    <input
+                      type="checkbox"
+                      checked={draft.roleIds.includes(role.id)}
+                      onChange={() => patch({ roleIds: toggle(draft.roleIds, role.id) })}
+                      data-testid={`ai-agent-role-${role.id}`}
+                    />
+                    {role.name}
+                  </label>
                 ))}
               </div>
             )}
           </fieldset>
-        )}
 
-        {/* Graduation evidence (P2-5, #4192). Edit-only, for the same reason
-            the schedules section is: the evidence ledger is keyed to a
-            persisted agent that does not exist until the first save. NOT gated
-            on `draft.mode === 'act'` — evidence an agent already earned is a
-            fact about the past, so toggling an unsaved draft back to shadow
-            must not make it disappear. The panel is read-only-useful with
-            `BREEZE_AI_AGENTS_POLICY_DECIDE_ENABLED` off; see its module doc.
-            `agent.kind` (stored), not `draft.kind`, since kind is create-only.
-            An org-owned agent always reads its OWN org's evidence; a partner
-            baseline follows the org switcher, and falls through to the
-            partner-wide grouping when it is on "all organizations". */}
-        {!isCreate && (
-          <AiAgentGraduationPanel
-            orgId={agent.orgId ?? orgScope.orgId}
-            kind={agent.kind}
-            isPartnerScope={isPartnerScope}
-          />
-        )}
-
-        <fieldset className="space-y-2 rounded-md border p-3 md:col-span-2">
-          <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
-            {t('aiAgentsPage.sections.scope')}
-          </legend>
-          <div className="flex flex-wrap gap-3">
-            {SEVERITIES.map((severity) => (
-              <label key={severity} className="flex items-center gap-1 text-sm">
-                <input
-                  type="checkbox"
-                  checked={draft.severities.includes(severity)}
-                  onChange={() => patch({ severities: toggle(draft.severities, severity) })}
-                  data-testid={`ai-agent-severity-${severity}`}
-                />
-                {t(/* i18n-dynamic */ `aiAgentsPage.severities.${severity}`)}
-              </label>
-            ))}
-          </div>
-          <label className="flex items-center gap-2 text-sm">
-            <input
-              type="checkbox"
-              checked={draft.respectMaintenanceWindows}
-              onChange={(e) => patch({ respectMaintenanceWindows: e.target.checked })}
-              data-testid="ai-agent-respect-maintenance"
+          {/* Scheduled sweeps (P2-2, #4189). Edit-only, because a schedule row
+              references a persisted agent id that does not exist until the first
+              save; triage-only, because the API refuses every other kind
+              (`agent_kind_not_triage`). Gated on the STORED kind, not the draft:
+              kind is create-only, so the two cannot diverge on this form. */}
+          {!isCreate && agent.kind === 'triage' && (
+            <AiAgentSchedulesSection
+              agentId={agent.id}
+              agentOwnerScope={agent.ownerScope}
+              isPartnerScope={isPartnerScope}
+              orgId={orgScope.orgId}
             />
-            {t('aiAgentsPage.fields.respectMaintenanceWindows')}
-          </label>
-
-          {/* P2-4 (#4191) review fix — ticket-triggered runs are admitted
-              with `kind: 'helpdesk'` (ticketHelpdeskSubscriber.ts's
-              `admitTriageRun`: `createAndEnqueueAgentRun({ kind: 'helpdesk',
-              triggerKind: 'ticket', profile: 'triage', ... })`), and
-              runService.ts's `resolveEffectiveAgentSystem(orgId, kind)`
-              resolves the effective policy off THAT `kind` field — never
-              `triage`, which is a different agent kind entirely (the
-              scheduled-sweeps gate a few lines below IS genuinely
-              triage-only; do not copy this gate from that one again).
-              Disabled — never hidden — on a partner-wide row: the merge
-              reads ONLY the org's own override (effectivePolicy.ts), so a
-              partner baseline value can never take effect; hiding it
-              outright would look like the field vanished rather than
-              explain why it cannot be set here. */}
-          {draft.kind === 'helpdesk' && (
-            <div className="space-y-1">
-              <label className="flex items-center gap-2 text-sm">
-                <input
-                  type="checkbox"
-                  checked={draft.ticketAutonomousWrites}
-                  disabled={draft.ownerScope !== 'organization'}
-                  onChange={(e) => patch({ ticketAutonomousWrites: e.target.checked })}
-                  data-testid="ai-agent-ticket-autonomous-writes"
-                />
-                {t('aiAgentsPage.fields.ticketAutonomousWrites')}
-              </label>
-              <p className="pl-6 text-xs text-muted-foreground">
-                {t('aiAgentsPage.fields.ticketAutonomousWritesHint')}
-              </p>
-            </div>
           )}
-        </fieldset>
 
-        <fieldset className="space-y-2 rounded-md border p-3 md:col-span-2">
-          <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
-            {t('aiAgentsPage.sections.permissions')}
-          </legend>
-          <p className="text-xs text-muted-foreground">{t('aiAgentsPage.fields.toolAllowlistHint')}</p>
-          {listField('ai-agent-toolallowlist', t('aiAgentsPage.fields.toolAllowlist'), draft.toolAllowlist, (v) => patch({ toolAllowlist: v }), 4)}
-          <p className="text-xs text-muted-foreground">{t('aiAgentsPage.fields.protectedHint')}</p>
-          <div className="grid gap-3 md:grid-cols-3">
-            {listField('ai-agent-services', t('aiAgentsPage.fields.protectedServices'), draft.services, (v) => patch({ services: v }), 2)}
-            {listField('ai-agent-paths', t('aiAgentsPage.fields.protectedPaths'), draft.paths, (v) => patch({ paths: v }), 2)}
-            {listField('ai-agent-registrykeys', t('aiAgentsPage.fields.protectedRegistryKeys'), draft.registryKeys, (v) => patch({ registryKeys: v }), 2)}
-          </div>
-        </fieldset>
-
-        <fieldset className="grid gap-3 rounded-md border p-3 md:col-span-2 md:grid-cols-3">
-          <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
-            {t('aiAgentsPage.sections.limits')}
-          </legend>
-          {numberField('ai-agent-limit-devices', t('aiAgentsPage.fields.maxDevicesPerRun'), draft.limits.maxDevicesPerRun, 1, 50, (v) => patch({ limits: { ...draft.limits, maxDevicesPerRun: v } }))}
-          {numberField('ai-agent-limit-runs', t('aiAgentsPage.fields.maxRunsPerHour'), draft.limits.maxRunsPerHour, 1, 500, (v) => patch({ limits: { ...draft.limits, maxRunsPerHour: v } }))}
-          {numberField('ai-agent-limit-budget', t('aiAgentsPage.fields.maxBudgetCentsPerDay'), draft.limits.maxBudgetCentsPerDay, 1, 100000, (v) => patch({ limits: { ...draft.limits, maxBudgetCentsPerDay: v } }))}
-          {numberField('ai-agent-limit-wallclock', t('aiAgentsPage.fields.wallClockSeconds'), draft.limits.wallClockSeconds, 30, 1800, (v) => patch({ limits: { ...draft.limits, wallClockSeconds: v } }))}
-          {numberField('ai-agent-limit-fleet', t('aiAgentsPage.fields.maxFleetPercentPerDay'), draft.limits.maxFleetPercentPerDay, 1, 100, (v) => patch({ limits: { ...draft.limits, maxFleetPercentPerDay: v } }))}
-          {numberField('ai-agent-cooldown', t('aiAgentsPage.fields.cooldownSeconds'), draft.cooldownSeconds, 0, 86400, (v) => patch({ cooldownSeconds: v }))}
-        </fieldset>
-
-        <fieldset className="space-y-2 rounded-md border p-3 md:col-span-2">
-          <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
-            {t('aiAgentsPage.sections.notifications')}
-          </legend>
-          <p className="text-xs text-muted-foreground">{t('aiAgentsPage.fields.recipientRolesHint')}</p>
-          {rolesFailed ? (
-            <p className="text-sm text-destructive" data-testid="ai-agent-roles-failed">
-              {t('aiAgentsPage.fields.recipientRolesFailed')}
+          <fieldset className="space-y-2 rounded-md border p-3 md:col-span-2">
+            <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
+              {t('aiAgentsPage.sections.instructions')}
+            </legend>
+            <p className="text-xs text-muted-foreground">{t('aiAgentsPage.fields.instructionsHint')}</p>
+            <textarea
+              className={inputCls}
+              rows={5}
+              maxLength={INSTRUCTIONS_MAX}
+              value={draft.instructions}
+              onChange={(e) => patch({ instructions: e.target.value })}
+              data-testid="ai-agent-instructions"
+            />
+            <p className="text-xs text-muted-foreground">
+              {t('aiAgentsPage.fields.charactersLeft', { count: INSTRUCTIONS_MAX - draft.instructions.length })}
             </p>
-          ) : roles.length === 0 ? (
-            <p className="text-sm text-muted-foreground" data-testid="ai-agent-roles-empty">
-              {t('aiAgentsPage.fields.recipientRolesEmpty')}
-            </p>
-          ) : (
-            <div className="flex flex-wrap gap-3">
-              {roles.map((role) => (
-                <label key={role.id} className="flex items-center gap-1 text-sm">
-                  <input
-                    type="checkbox"
-                    checked={draft.roleIds.includes(role.id)}
-                    onChange={() => patch({ roleIds: toggle(draft.roleIds, role.id) })}
-                    data-testid={`ai-agent-role-${role.id}`}
-                  />
-                  {role.name}
-                </label>
-              ))}
-            </div>
-          )}
-        </fieldset>
-
-        {/* Scheduled sweeps (P2-2, #4189). Edit-only, because a schedule row
-            references a persisted agent id that does not exist until the first
-            save; triage-only, because the API refuses every other kind
-            (`agent_kind_not_triage`). Gated on the STORED kind, not the draft:
-            kind is create-only, so the two cannot diverge on this form. */}
-        {!isCreate && agent.kind === 'triage' && (
-          <AiAgentSchedulesSection
-            agentId={agent.id}
-            agentOwnerScope={agent.ownerScope}
-            isPartnerScope={isPartnerScope}
-            orgId={orgScope.orgId}
-          />
-        )}
-
-        <fieldset className="space-y-2 rounded-md border p-3 md:col-span-2">
-          <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
-            {t('aiAgentsPage.sections.instructions')}
-          </legend>
-          <p className="text-xs text-muted-foreground">{t('aiAgentsPage.fields.instructionsHint')}</p>
-          <textarea
-            className={inputCls}
-            rows={5}
-            maxLength={INSTRUCTIONS_MAX}
-            value={draft.instructions}
-            onChange={(e) => patch({ instructions: e.target.value })}
-            data-testid="ai-agent-instructions"
-          />
-          <p className="text-xs text-muted-foreground">
-            {t('aiAgentsPage.fields.charactersLeft', { count: INSTRUCTIONS_MAX - draft.instructions.length })}
-          </p>
-        </fieldset>
+          </fieldset>
+        </div>
       </div>
 
-      <div className="mt-4 flex flex-wrap items-center gap-2">
+      {/* Outside the scroll area: in the drawer the form now opens in, Save
+          must stay reachable without scrolling past the schedules section and
+          two graduation tables. */}
+      <div className="flex flex-wrap items-center gap-2 border-t bg-card px-5 py-4">
         <button
           type="button"
           onClick={() => void save()}
@@ -934,6 +1229,6 @@ export default function AiAgentForm({
           </button>
         )}
       </div>
-    </section>
+    </div>
   );
 }

--- a/apps/web/src/components/settings/AiAgentGraduationPanel.test.tsx
+++ b/apps/web/src/components/settings/AiAgentGraduationPanel.test.tsx
@@ -247,6 +247,181 @@ describe('AiAgentGraduationPanel — promote affordance', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// #4187 UI critique — Revoke, the operator-facing mirror of Promote, and the
+// demotion cause a `demoted` pill used to leave unexplained.
+// ---------------------------------------------------------------------------
+
+const OP = 'manage_devices:restart_device';
+
+async function clickRevokeAndConfirm(opKey: string, reason?: string) {
+  fireEvent.click(await screen.findByTestId(`ai-agent-graduation-revoke-${opKey}`));
+  if (reason !== undefined) {
+    fireEvent.change(await screen.findByTestId('ai-agent-graduation-revoke-reason'), {
+      target: { value: reason },
+    });
+  }
+  fireEvent.click(await screen.findByTestId('ai-agent-graduation-revoke-confirm'));
+}
+
+describe('AiAgentGraduationPanel — revoke affordance', () => {
+  it.each(['tracking', 'eligible', 'demoted'] as const)('hides Revoke on a %s row', async (state) => {
+    mockGraduation(dto({ rows: [row({ state })] }));
+    render(<AiAgentGraduationPanel {...orgProps} />);
+
+    await screen.findByTestId(`ai-agent-graduation-row-${OP}`);
+    expect(screen.queryByTestId(`ai-agent-graduation-revoke-${OP}`)).toBeNull();
+  });
+
+  it('offers Revoke on a promoted row even while policy-decide is off', async () => {
+    // The route is deliberately not gated on the flag: turning it off must
+    // stop new grants without stranding a live one.
+    mockGraduation(dto({ rows: [row({ state: 'promoted' })], policyDecideEnabled: false }));
+    render(<AiAgentGraduationPanel {...orgProps} />);
+
+    expect(await screen.findByTestId(`ai-agent-graduation-revoke-${OP}`)).toBeTruthy();
+  });
+
+  it('POSTs the exact revoke body, including the typed reason and the panel kind', async () => {
+    mockGraduation(
+      dto({ rows: [row({ state: 'promoted' })] }),
+      () => json({ revoked: true, orgAgentId: 'org-agent-9', state: 'demoted' }),
+    );
+    render(<AiAgentGraduationPanel {...orgProps} />);
+    await clickRevokeAndConfirm(OP, 'Customer asked us to stop');
+
+    await waitFor(() => expect(lastMutation().method).toBe('POST'));
+    expect(lastMutation().url).toBe('/ai/agents/graduation/revoke');
+    expect(lastMutation().body).toEqual({
+      orgId: 'org-1',
+      opKey: OP,
+      // Sent so the route never has to guess between two agents holding the
+      // same key — the rows on screen belong to this kind's agent.
+      kind: 'patch',
+      reason: 'Customer asked us to stop',
+    });
+    await waitFor(() =>
+      expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' })));
+  });
+
+  it('omits `reason` entirely rather than sending an empty string', async () => {
+    // The route records `null` for "the operator supplied none"; '' is not that.
+    mockGraduation(
+      dto({ rows: [row({ state: 'promoted' })] }),
+      () => json({ revoked: true, orgAgentId: 'org-agent-9', state: 'demoted' }),
+    );
+    render(<AiAgentGraduationPanel {...orgProps} />);
+    await clickRevokeAndConfirm(OP, '   ');
+
+    await waitFor(() => expect(lastMutation().method).toBe('POST'));
+    expect(lastMutation().body).toEqual({ orgId: 'org-1', opKey: OP, kind: 'patch' });
+  });
+
+  it('caps the reason at 500 characters and counts down', async () => {
+    mockGraduation(dto({ rows: [row({ state: 'promoted' })] }));
+    render(<AiAgentGraduationPanel {...orgProps} />);
+    fireEvent.click(await screen.findByTestId(`ai-agent-graduation-revoke-${OP}`));
+
+    const textarea = await screen.findByTestId('ai-agent-graduation-revoke-reason');
+    expect(textarea).toHaveAttribute('maxlength', '500');
+    fireEvent.change(textarea, { target: { value: 'x'.repeat(40) } });
+    expect(screen.getByTestId('ai-agent-graduation-revoke-reason-count').textContent).toContain('460');
+  });
+
+  it('re-reads the ledger after a successful revoke rather than guessing the new state', async () => {
+    let reads = 0;
+    fetchWithAuth.mockImplementation((url: string, init?: RequestInit) => {
+      if (init?.method) return Promise.resolve(json({ revoked: true, orgAgentId: 'a', state: 'demoted' }));
+      if (typeof url === 'string' && url.startsWith('/ai/agents/graduation')) {
+        reads += 1;
+        return Promise.resolve(json(dto({
+          rows: [row(reads === 1
+            ? { state: 'promoted' }
+            : { state: 'demoted', demotedAt: '2026-09-02T10:00:00.000Z', demoteReason: 'operator' })],
+        })));
+      }
+      return Promise.resolve(json({ data: [] }));
+    });
+    render(<AiAgentGraduationPanel {...orgProps} />);
+    await clickRevokeAndConfirm(OP);
+
+    await waitFor(() => expect(reads).toBe(2));
+    expect(await screen.findByTestId(`ai-agent-graduation-demoted-${OP}`)).toBeTruthy();
+  });
+
+  it('maps every revoke refusal token to a sentence and keeps the row', async () => {
+    for (const token of ['no_promoted_grant', 'already_demoted', 'already_revoked', 'ambiguous_op_key']) {
+      showToast.mockClear();
+      mockGraduation(
+        dto({ rows: [row({ state: 'promoted' })] }),
+        () => json({ error: token }, false, 409),
+      );
+      const view = render(<AiAgentGraduationPanel {...orgProps} />);
+      await clickRevokeAndConfirm(OP);
+
+      await waitFor(() =>
+        expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' })));
+      const message = String((showToast.mock.calls.at(-1)?.[0] as { message: string }).message);
+      expect(message).not.toBe(token);
+      expect(message).not.toContain('aiAgentsPage.graduation');
+      expect(screen.getByTestId(`ai-agent-graduation-row-${OP}`)).toBeTruthy();
+      view.unmount();
+    }
+  });
+});
+
+describe('AiAgentGraduationPanel — demotion cause', () => {
+  it('names when and why a demoted grant was taken away', async () => {
+    mockGraduation(dto({
+      rows: [row({
+        state: 'demoted',
+        blockedReason: 'has_failures',
+        demotedAt: '2026-09-02T10:00:00.000Z',
+        demoteReason: 'operator',
+      })],
+    }));
+    render(<AiAgentGraduationPanel {...orgProps} />);
+
+    const cause = await screen.findByTestId(`ai-agent-graduation-demoted-${OP}`);
+    const lines = [...cause.querySelectorAll('span')].map((span) => span.textContent ?? '');
+    expect(lines).toHaveLength(2);
+    // The formatted timestamp, never the raw ISO string.
+    expect(lines[0]).not.toContain('2026-09-02T10:00:00.000Z');
+    expect(lines[0]).toContain('2026');
+    // A sentence, never the bare machine token or a missing catalog entry.
+    expect(lines[1]).not.toBe('operator');
+    expect(lines[1]).not.toContain('aiAgentsPage.graduation');
+    expect(lines[1]?.length).toBeGreaterThan('operator'.length);
+  });
+
+  it('gives each demote reason its own distinct sentence, never the raw token', async () => {
+    const reasons = ['attempted_failure', 'recurrence', 'operator'] as const;
+    const rendered: string[] = [];
+    for (const reason of reasons) {
+      mockGraduation(dto({ rows: [row({ state: 'demoted', demoteReason: reason })] }));
+      const view = render(<AiAgentGraduationPanel {...orgProps} />);
+
+      const text = (await screen.findByTestId(`ai-agent-graduation-demoted-${OP}`)).textContent ?? '';
+      // A snake_case token never occurs in prose, so its presence is proof the
+      // raw ledger value reached the operator. (`operator` is a real English
+      // word and legitimately appears in its own sentence, hence the guard.)
+      if (reason.includes('_')) expect(text).not.toContain(reason);
+      expect(text).not.toContain('aiAgentsPage.graduation');
+      rendered.push(text);
+      view.unmount();
+    }
+    expect(new Set(rendered).size).toBe(reasons.length);
+  });
+
+  it('renders nothing extra when the ledger carries neither field', async () => {
+    mockGraduation(dto({ rows: [row({ state: 'tracking' })] }));
+    render(<AiAgentGraduationPanel {...orgProps} />);
+
+    await screen.findByTestId(`ai-agent-graduation-row-${OP}`);
+    expect(screen.queryByTestId(`ai-agent-graduation-demoted-${OP}`)).toBeNull();
+  });
+});
+
 describe('AiAgentGraduationPanel — partner byOrg fan-out', () => {
   const byOrg: AiAgentGraduationByOrgDto = {
     version: 1,
@@ -369,6 +544,32 @@ describe('AiAgentGraduationPanel — states with nothing to fetch', () => {
 
     expect(await screen.findByTestId('ai-agent-graduation-error')).toBeTruthy();
     expect(screen.queryByTestId('ai-agent-graduation-empty')).toBeNull();
+  });
+
+  // Live smoke finding: an org override with no partner-wide baseline agent of
+  // this kind gets a 404 from GET /ai/agents/graduation — by design,
+  // `resolveEffectiveAgentSystem` resolves null and org overrides cannot
+  // self-enable (routes/aiAgents.ts). That is not a load FAILURE (retrying
+  // can never succeed until a baseline exists), so it must not render the
+  // generic error + a Try again button that is dead on arrival.
+  it('explains that graduation tracking needs a partner-wide baseline agent on a 404, with no retry button', async () => {
+    fetchWithAuth.mockResolvedValue(json({ error: 'agent_not_found' }, false, 404));
+    render(<AiAgentGraduationPanel {...orgProps} />);
+
+    expect(await screen.findByTestId('ai-agent-graduation-no-baseline')).toBeTruthy();
+    expect(screen.queryByTestId('ai-agent-graduation-error')).toBeNull();
+    expect(screen.queryByTestId('ai-agent-graduation-retry')).toBeNull();
+  });
+
+  // Every OTHER failure keeps the existing retryable-error path — the 404
+  // branch must not swallow a genuine outage.
+  it('keeps the retryable error (and retry button) for a non-404 failure', async () => {
+    fetchWithAuth.mockResolvedValue(json({ error: 'boom' }, false, 500));
+    render(<AiAgentGraduationPanel {...orgProps} />);
+
+    expect(await screen.findByTestId('ai-agent-graduation-error')).toBeTruthy();
+    expect(screen.getByTestId('ai-agent-graduation-retry')).toBeTruthy();
+    expect(screen.queryByTestId('ai-agent-graduation-no-baseline')).toBeNull();
   });
 });
 

--- a/apps/web/src/components/settings/AiAgentGraduationPanel.tsx
+++ b/apps/web/src/components/settings/AiAgentGraduationPanel.tsx
@@ -39,12 +39,33 @@ import {
 } from '@breeze/shared';
 import { fetchWithAuth } from '../../stores/auth';
 import { ConfirmDialog } from '../shared/ConfirmDialog';
+import { EmptyState } from '../shared/EmptyState';
+import { badgeClass, graduationTone } from '../aiAgents/statusBadge';
 import { handleActionError, runAction } from '@/lib/runAction';
 import { loginPathWithNext } from '@/lib/authScope';
 import { navigateTo } from '@/lib/navigation';
 import { formatDateTime } from '@/lib/dateTimeFormat';
 
 const UNAUTHORIZED = () => void navigateTo(loginPathWithNext(), { replace: true });
+
+/** `reason` is free text an operator types and the route stores on its audit
+ *  row; the schema caps it at 500 (`revokeSupervisedKeyRequestSchema`). */
+const REVOKE_REASON_MAX = 500;
+
+/**
+ * `POST /ai/agents/graduation/revoke`'s refusal tokens → operator-facing
+ * sentences. The route answers `{ error: <token> }` with no `code` field, so
+ * runAction's `friendly` hook is called with the token in `error` — the same
+ * shape AiAgentSchedulesSection's SCHEDULE_ERROR_COPY handles. Every one of
+ * them means "nothing was revoked", so the copy has to distinguish "it was
+ * already off" from "we could not tell which grant you meant".
+ */
+const REVOKE_ERROR_COPY: Record<string, ((t: (key: string) => string) => string) | undefined> = {
+  no_promoted_grant: (t) => t('aiAgentsPage.graduation.errors.noPromotedGrant'),
+  already_demoted: (t) => t('aiAgentsPage.graduation.errors.alreadyDemoted'),
+  already_revoked: (t) => t('aiAgentsPage.graduation.errors.alreadyRevoked'),
+  ambiguous_op_key: (t) => t('aiAgentsPage.graduation.errors.ambiguousOpKey'),
+};
 
 interface Props {
   /** The org whose evidence to read; null asks for the partner-wide grouping. */
@@ -148,10 +169,22 @@ export default function AiAgentGraduationPanel({ orgId, kind, isPartnerScope }: 
   const [loaded, setLoaded] = useState<Loaded | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // A 404 here is not a load FAILURE — `resolveEffectiveAgentSystem` resolves
+  // null by design when no partner-wide baseline agent of this kind exists
+  // yet, and an org override can never self-enable one. Retrying can never
+  // succeed until a baseline is created, so this gets its own explanatory
+  // empty state instead of the generic error + a dead-on-arrival retry button.
+  const [noBaseline, setNoBaseline] = useState(false);
   const [reloadToken, setReloadToken] = useState(0);
   const [pending, setPending] = useState<{ orgId: string; opKey: string } | null>(null);
   const [promoting, setPromoting] = useState(false);
   const [requested, setRequested] = useState(false);
+  // Revoke is the operator-facing mirror of promote and carries the same
+  // confirm ceremony — with a reason field, because unlike promote there is
+  // no four-eyes approval to record WHY. The route puts it on the audit row.
+  const [pendingRevoke, setPendingRevoke] = useState<{ orgId: string; opKey: string } | null>(null);
+  const [revokeReason, setRevokeReason] = useState('');
+  const [revoking, setRevoking] = useState(false);
 
   // An org-scoped session with no org selected has nothing to ask for: the
   // no-`orgId` form is partner-only and would 400. Say so rather than
@@ -162,17 +195,26 @@ export default function AiAgentGraduationPanel({ orgId, kind, isPartnerScope }: 
     if (!canRead) {
       setLoaded(null);
       setError(null);
+      setNoBaseline(false);
       return;
     }
     let cancelled = false;
     setLoading(true);
     setError(null);
+    setNoBaseline(false);
     void (async () => {
       try {
         const query = orgId === null
           ? `?kind=${encodeURIComponent(kind)}`
           : `?orgId=${encodeURIComponent(orgId)}&kind=${encodeURIComponent(kind)}`;
         const response = await fetchWithAuth(`/ai/agents/graduation${query}`);
+        if (response.status === 404) {
+          if (!cancelled) {
+            setLoaded(null);
+            setNoBaseline(true);
+          }
+          return;
+        }
         if (!response.ok) throw new Error(`GET /ai/agents/graduation ${response.status}`);
         const body: unknown = await response.json();
         if (!cancelled) setLoaded(normalize(body));
@@ -224,6 +266,76 @@ export default function AiAgentGraduationPanel({ orgId, kind, isPartnerScope }: 
     }
   }, [kind, pending, promoting, t]);
 
+  /**
+   * Hands a promoted key back to the approval queue. Sends `kind` even though
+   * the field is optional: without it the route 409s `ambiguous_op_key` as
+   * soon as two agents in the org hold the same colon key, and this panel is
+   * ALWAYS rendered for one specific kind — the rows on screen belong to that
+   * kind's effective agent, so guessing is never necessary.
+   *
+   * `reason` is omitted rather than sent empty: the route records `null` for
+   * "the operator supplied none", and an empty string is not that.
+   */
+  const revoke = useCallback(async () => {
+    if (!pendingRevoke || revoking) return;
+    const target = pendingRevoke;
+    const reason = revokeReason.trim();
+    setRevoking(true);
+    let revoked = false;
+    try {
+      await runAction({
+        // Inline thunk: the no-silent-mutations guard is a lexical AST check,
+        // so a hoisted request function reads as an unwrapped mutation (#2429).
+        request: () => fetchWithAuth('/ai/agents/graduation/revoke', {
+          method: 'POST',
+          body: JSON.stringify({
+            orgId: target.orgId,
+            opKey: target.opKey,
+            kind,
+            ...(reason === '' ? {} : { reason }),
+          }),
+        }),
+        successMessage: t('aiAgentsPage.graduation.toasts.revoked'),
+        errorFallback: t('aiAgentsPage.graduation.errors.revoke'),
+        friendly: (code) => REVOKE_ERROR_COPY[code]?.(t),
+        onUnauthorized: UNAUTHORIZED,
+      });
+      revoked = true;
+    } catch (err) {
+      // The row survives a failure on purpose: every refusal means nothing
+      // was revoked, so the grant is still live and still revocable.
+      handleActionError(err, t('aiAgentsPage.graduation.errors.revoke'));
+    } finally {
+      setRevoking(false);
+      setPendingRevoke(null);
+      setRevokeReason('');
+    }
+    // Outside the try: the reload re-reads the ledger so the row's state pill
+    // and its new demotion cause come from the server, never from an
+    // optimistic guess about what the executor wrote.
+    if (revoked) setReloadToken((token) => token + 1);
+  }, [kind, pendingRevoke, revokeReason, revoking, t]);
+
+  /** Machine token → sentence. `operator` is the one with no evidence behind
+   *  it (a human used the revoke route); the rest are the automatic
+   *  disqualifying signals in `supervisedKeyDemote.ts`. An unrecognized value
+   *  falls through to the raw token rather than rendering a key path. */
+  const demoteReasonLabel = useCallback(
+    (reason: string): string => {
+      switch (reason) {
+        case 'attempted_failure':
+          return t('aiAgentsPage.graduation.demoteReasons.attempted_failure');
+        case 'recurrence':
+          return t('aiAgentsPage.graduation.demoteReasons.recurrence');
+        case 'operator':
+          return t('aiAgentsPage.graduation.demoteReasons.operator');
+        default:
+          return reason;
+      }
+    },
+    [t],
+  );
+
   const blockedLabel = useCallback(
     (row: AiAgentGraduationRowDto) =>
       row.blockedReason === null
@@ -241,7 +353,9 @@ export default function AiAgentGraduationPanel({ orgId, kind, isPartnerScope }: 
       data-testid="ai-agent-graduation-panel"
     >
       <div>
-        <h3 className="text-xs font-medium uppercase text-muted-foreground">
+        {/* Same weight as the form's other real heading (Permissions), not a
+            12px uppercase label — this panel is a peer section, not a caption. */}
+        <h3 className="text-sm font-semibold">
           {t('aiAgentsPage.graduation.title')}
         </h3>
         <p className="mt-1 text-xs text-muted-foreground">{t('aiAgentsPage.graduation.description')}</p>
@@ -259,7 +373,17 @@ export default function AiAgentGraduationPanel({ orgId, kind, isPartnerScope }: 
         </p>
       )}
 
-      {!loading && error && (
+      {!loading && noBaseline && (
+        <EmptyState
+          size="sm"
+          headingLevel={4}
+          testId="ai-agent-graduation-no-baseline"
+          title={t('aiAgentsPage.graduation.noBaselineTitle')}
+          description={t('aiAgentsPage.graduation.noBaseline')}
+        />
+      )}
+
+      {!loading && !noBaseline && error && (
         <div data-testid="ai-agent-graduation-error" className="space-y-2">
           <p className="text-sm text-destructive">{error}</p>
           <button
@@ -314,9 +438,13 @@ export default function AiAgentGraduationPanel({ orgId, kind, isPartnerScope }: 
               kind gets no groups at all — the route omits them rather than
               reporting them empty. */}
           {loaded.groups.length === 0 && (
-            <p className="text-sm text-muted-foreground" data-testid="ai-agent-graduation-empty">
-              {t('aiAgentsPage.graduation.empty')}
-            </p>
+            <EmptyState
+              size="sm"
+              headingLevel={4}
+              testId="ai-agent-graduation-empty"
+              title={t('aiAgentsPage.graduation.emptyTitle')}
+              description={t('aiAgentsPage.graduation.empty')}
+            />
           )}
 
           {loaded.groups.map((group) => (
@@ -330,16 +458,17 @@ export default function AiAgentGraduationPanel({ orgId, kind, isPartnerScope }: 
               )}
 
               {group.rows.length === 0 && group.actOpReliability.length === 0 && (
-                <p
-                  className="text-sm text-muted-foreground"
-                  data-testid={
+                <EmptyState
+                  size="sm"
+                  headingLevel={4}
+                  testId={
                     group.orgId === null
                       ? 'ai-agent-graduation-empty'
                       : `ai-agent-graduation-empty-${group.orgId}`
                   }
-                >
-                  {t('aiAgentsPage.graduation.empty')}
-                </p>
+                  title={t('aiAgentsPage.graduation.emptyTitle')}
+                  description={t('aiAgentsPage.graduation.empty')}
+                />
               )}
 
               {group.rows.length > 0 && (
@@ -370,7 +499,7 @@ export default function AiAgentGraduationPanel({ orgId, kind, isPartnerScope }: 
                         >
                           <td className={`${cell} font-medium`}>{row.opKey}</td>
                           <td className={cell}>
-                            <span className="rounded-full border px-2 py-0.5 text-xs">
+                            <span className={badgeClass(graduationTone(row.state), { size: 'sm' })}>
                               {t(/* i18n-dynamic */ `aiAgentsPage.graduation.states.${row.state}`)}
                             </span>
                           </td>
@@ -404,7 +533,52 @@ export default function AiAgentGraduationPanel({ orgId, kind, isPartnerScope }: 
                                   {t('aiAgentsPage.graduation.promote')}
                                 </button>
                               )}
+                              {/* Not gated on `policyDecideEnabled`: the route
+                                  deliberately is not either, because turning
+                                  the flag off must stop new grants without
+                                  stranding a live one an operator wants
+                                  stopped. */}
+                              {row.state === 'promoted' && promoteOrgId !== null && (
+                                <button
+                                  type="button"
+                                  className="rounded-md border border-destructive/40 px-2 py-1 text-xs font-medium text-destructive"
+                                  onClick={() => {
+                                    setRevokeReason('');
+                                    setPendingRevoke({ orgId: promoteOrgId, opKey: row.opKey });
+                                  }}
+                                  data-testid={`ai-agent-graduation-revoke-${scopedTestId(group, row.opKey)}`}
+                                >
+                                  {t('aiAgentsPage.graduation.revoke')}
+                                </button>
+                              )}
                             </span>
+                            {/* A `demoted` pill with nothing beside it says a
+                                grant was taken away and refuses to say why.
+                                Both fields are optional on the DTO, so each is
+                                rendered only when the ledger actually carries
+                                it — there is no `demotedBy` column at all; the
+                                accountable human is on the audit row. */}
+                            {(row.demotedAt !== null || row.demoteReason !== null) && (
+                              <span
+                                className="mt-1 block text-xs text-muted-foreground"
+                                data-testid={`ai-agent-graduation-demoted-${scopedTestId(group, row.opKey)}`}
+                              >
+                                {row.demotedAt !== null && (
+                                  <span className="block">
+                                    {t('aiAgentsPage.graduation.demotedAt', {
+                                      at: formatDateTime(row.demotedAt),
+                                    })}
+                                  </span>
+                                )}
+                                {row.demoteReason !== null && (
+                                  <span className="block">
+                                    {t('aiAgentsPage.graduation.demotedReason', {
+                                      reason: demoteReasonLabel(row.demoteReason),
+                                    })}
+                                  </span>
+                                )}
+                              </span>
+                            )}
                           </td>
                         </tr>
                         );
@@ -462,6 +636,39 @@ export default function AiAgentGraduationPanel({ orgId, kind, isPartnerScope }: 
         confirmLabel={t('aiAgentsPage.graduation.confirm.action')}
         confirmTestId="ai-agent-graduation-promote-confirm"
       />
+
+      <ConfirmDialog
+        open={pendingRevoke !== null}
+        onClose={() => {
+          setPendingRevoke(null);
+          setRevokeReason('');
+        }}
+        onConfirm={() => void revoke()}
+        variant="destructive"
+        isLoading={revoking}
+        title={t('aiAgentsPage.graduation.revokeConfirm.title')}
+        message={t('aiAgentsPage.graduation.revokeConfirm.message', { opKey: pendingRevoke?.opKey ?? '' })}
+        confirmLabel={t('aiAgentsPage.graduation.revokeConfirm.action')}
+        confirmTestId="ai-agent-graduation-revoke-confirm"
+      >
+        <label className="block space-y-1 text-left text-sm">
+          <span className="font-medium">{t('aiAgentsPage.graduation.revokeConfirm.reasonLabel')}</span>
+          <textarea
+            className="w-full rounded-md border bg-background px-2.5 py-1.5 text-sm"
+            rows={3}
+            maxLength={REVOKE_REASON_MAX}
+            value={revokeReason}
+            onChange={(e) => setRevokeReason(e.target.value)}
+            data-testid="ai-agent-graduation-revoke-reason"
+          />
+          <span className="block text-xs text-muted-foreground">
+            {t('aiAgentsPage.graduation.revokeConfirm.reasonHint')}
+          </span>
+          <span className="block text-xs text-muted-foreground" data-testid="ai-agent-graduation-revoke-reason-count">
+            {t('aiAgentsPage.fields.charactersLeft', { count: REVOKE_REASON_MAX - revokeReason.length })}
+          </span>
+        </label>
+      </ConfirmDialog>
     </section>
   );
 }

--- a/apps/web/src/components/settings/AiAgentSchedulesSection.test.tsx
+++ b/apps/web/src/components/settings/AiAgentSchedulesSection.test.tsx
@@ -17,7 +17,10 @@ vi.mock('../shared/Toast', () => ({
 }));
 vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
 
-import AiAgentSchedulesSection from './AiAgentSchedulesSection';
+import AiAgentSchedulesSection, {
+  nextCronOccurrence,
+  parseFiveFieldCron,
+} from './AiAgentSchedulesSection';
 
 const json = (payload: unknown, ok = true, status = 200): Response =>
   ({ ok, status, statusText: 'OK', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
@@ -173,6 +176,27 @@ describe('AiAgentSchedulesSection', () => {
     await waitFor(() => expect(mutations()).toHaveLength(1));
   });
 
+  // Review fix (#4187 UI critique, P1): the client accepted a cron the server's
+  // hourly floor (`isHourlyFloorCron`) refuses — a `*/15` minute field is a
+  // structurally valid five-field cron, but a partner with hundreds of orgs
+  // fanning that out is exactly the cost the floor exists to prevent.
+  it('disables Save and shows the hint when the minute field is not a literal or comma-list (hourly floor)', async () => {
+    mockList([]);
+    render(<AiAgentSchedulesSection {...partnerProps} />);
+
+    fireEvent.click(await screen.findByTestId('ai-agent-schedule-add'));
+
+    fireEvent.change(screen.getByTestId('ai-agent-schedule-cron'), { target: { value: '*/15 * * * *' } });
+    expect(screen.getByTestId('ai-agent-schedule-save')).toBeDisabled();
+    expect(screen.getByTestId('ai-agent-schedule-cron-invalid')).toBeInTheDocument();
+
+    // A comma-separated list of literal minutes is fine — only the operators
+    // that could fire more than hourly are refused.
+    fireEvent.change(screen.getByTestId('ai-agent-schedule-cron'), { target: { value: '0,15,30,45 * * * *' } });
+    expect(screen.getByTestId('ai-agent-schedule-save')).not.toBeDisabled();
+    expect(screen.queryByTestId('ai-agent-schedule-cron-invalid')).toBeNull();
+  });
+
   it('patches an existing baseline instead of creating a second one', async () => {
     mockList([BASELINE], () => json({ data: BASELINE }));
     render(<AiAgentSchedulesSection {...partnerProps} />);
@@ -228,6 +252,31 @@ describe('AiAgentSchedulesSection', () => {
     expect(screen.queryByTestId('ai-agent-schedule-edit-s-1')).toBeNull();
     expect(screen.queryByTestId('ai-agent-schedule-delete')).toBeNull();
     expect(screen.getByTestId('ai-agent-schedule-override-s-1')).toBeInTheDocument();
+  });
+
+  // Review fix (#4187 UI critique, P3): `load`'s dependency array omitted
+  // `orgId`, so switching the org switcher while this section stayed mounted
+  // never re-fetched — the operator kept looking at the PREVIOUS org's
+  // merged overrides until some unrelated prop change (or a remount) forced
+  // a reload.
+  it('refetches schedules when the selected org changes', async () => {
+    mockList([BASELINE]);
+    const { rerender } = render(<AiAgentSchedulesSection {...orgProps} />);
+    await waitFor(() => expect(screen.getByTestId('ai-agent-schedule-s-1')).toBeInTheDocument());
+
+    const getsBefore = fetchWithAuth.mock.calls.filter(
+      ([url]) => typeof url === 'string' && url.startsWith('/ai/agents/schedules?'),
+    ).length;
+    expect(getsBefore).toBeGreaterThan(0);
+
+    rerender(<AiAgentSchedulesSection {...orgProps} orgId="org-2" />);
+
+    await waitFor(() => {
+      const getsAfter = fetchWithAuth.mock.calls.filter(
+        ([url]) => typeof url === 'string' && url.startsWith('/ai/agents/schedules?'),
+      ).length;
+      expect(getsAfter).toBeGreaterThan(getsBefore);
+    });
   });
 
   it('creates an org override with the tighten-only wire shape and offers no kind the baseline lacks', async () => {
@@ -474,5 +523,117 @@ describe('AiAgentSchedulesSection', () => {
     expect(await screen.findByTestId('ai-agent-schedules-partner-only')).toBeInTheDocument();
     expect(screen.queryByTestId('ai-agent-schedule-add')).toBeNull();
     expect(fetchWithAuth).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #4187 UI critique — the next-run preview. Structural cron validity is the
+// only feedback a five-field expression used to give, so a typo'd day-of-week
+// read as a working schedule until it failed to fire.
+// ---------------------------------------------------------------------------
+
+describe('nextCronOccurrence / parseFiveFieldCron', () => {
+  // Every case is asserted on WALL-CLOCK parts read as UTC — that is exactly
+  // what the function returns (see its module comment).
+  const at = (iso: string) => Date.parse(iso);
+  const next = (cron: string, fromIso: string) => {
+    const fields = parseFiveFieldCron(cron);
+    expect(fields).not.toBeNull();
+    return nextCronOccurrence(fields!, at(fromIso))?.toISOString() ?? null;
+  };
+
+  it.each([
+    // daily at 03:00, before and after today's occurrence
+    ['0 3 * * *', '2026-09-02T01:10:00Z', '2026-09-02T03:00:00.000Z'],
+    ['0 3 * * *', '2026-09-02T03:00:00Z', '2026-09-03T03:00:00.000Z'],
+    // step, list and range forms
+    ['*/15 * * * *', '2026-09-02T01:07:00Z', '2026-09-02T01:15:00.000Z'],
+    ['0 6,18 * * *', '2026-09-02T07:00:00Z', '2026-09-02T18:00:00.000Z'],
+    ['0 6 * * 1-5', '2026-09-05T00:00:00Z', '2026-09-07T06:00:00.000Z'],
+    // 2026-09-02 is a Wednesday; Monday is the 7th.
+    ['0 7 * * 1', '2026-09-02T09:00:00Z', '2026-09-07T07:00:00.000Z'],
+    // day-of-week names, and 7 as a second spelling of Sunday
+    ['0 7 * * mon', '2026-09-02T09:00:00Z', '2026-09-07T07:00:00.000Z'],
+    ['0 7 * * 7', '2026-09-02T09:00:00Z', '2026-09-06T07:00:00.000Z'],
+    // month rollover, and a month name
+    ['0 0 1 * *', '2026-09-20T00:00:00Z', '2026-10-01T00:00:00.000Z'],
+    ['0 0 1 jan *', '2026-09-20T00:00:00Z', '2027-01-01T00:00:00.000Z'],
+    // Vixie rule: with BOTH day fields restricted, EITHER may match. The 4th
+    // is a Friday, so a Monday-or-the-4th cron fires on the 4th first.
+    ['0 5 4 * 1', '2026-09-02T00:00:00Z', '2026-09-04T05:00:00.000Z'],
+  ])('resolves %s from %s', (cron, from, expected) => {
+    expect(next(cron, from)).toBe(expected);
+  });
+
+  it('returns null for a structurally valid cron that can never fire', () => {
+    // 30 February. `isStructurallyValidCron` accepts it (both fields are in
+    // range) — only evaluation can tell the operator it will never run.
+    expect(next('0 0 30 2 *', '2026-09-02T00:00:00Z')).toBeNull();
+  });
+
+  it.each([
+    '', 'every morning', '0 6 * *', '0 6 * * * *', '60 6 * * *', '0 6 * * 8', '0 6 * * 5-1', '0 6 * * ',
+  ])('refuses to parse %s', (cron) => {
+    expect(parseFiveFieldCron(cron)).toBeNull();
+  });
+});
+
+describe('AiAgentSchedulesSection next-run preview', () => {
+  it('shows a next run beside the stored cron', async () => {
+    mockList([BASELINE]);
+    render(<AiAgentSchedulesSection {...partnerProps} />);
+
+    const line = await screen.findByTestId('ai-agent-schedule-next-run-s-1');
+    // The schedule's own zone is named, never the viewer's.
+    expect(line.textContent).toContain('America/New_York');
+    expect(line.textContent).toMatch(/\d/);
+  });
+
+  // Review fix (#4187 UI critique, P3): the preview used to render alongside
+  // the "Enter a valid five-field cron expression" banner, showing "Invalid
+  // schedule" twice for the same problem. Now the preview is withheld
+  // entirely while `cronValid` is false — the cron-invalid banner alone says
+  // the expression is bad, so the preview's OWN "invalid" variant is only
+  // reachable for a cron the hourly-floor/weekly-literal rules accept but
+  // that still fails cron-conditions.ts's stricter five-field evaluator.
+  it('hides the next-run preview once the cron fails validation, leaving only the cron-invalid message', async () => {
+    mockList([BASELINE]);
+    render(<AiAgentSchedulesSection {...partnerProps} />);
+
+    fireEvent.click(await screen.findByTestId('ai-agent-schedule-edit-s-1'));
+    expect(await screen.findByTestId('ai-agent-schedule-editor-next-run')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId('ai-agent-schedule-cron'), { target: { value: 'every morning' } });
+
+    expect(await screen.findByTestId('ai-agent-schedule-cron-invalid')).toBeInTheDocument();
+    expect(screen.queryByTestId('ai-agent-schedule-editor-next-run')).toBeNull();
+    expect(screen.queryByTestId('ai-agent-schedule-editor-next-run-invalid')).toBeNull();
+    expect(screen.queryByTestId('ai-agent-schedule-editor-next-run-none')).toBeNull();
+
+    // Recovers once the expression is valid again.
+    fireEvent.change(screen.getByTestId('ai-agent-schedule-cron'), { target: { value: '0 3 * * *' } });
+    expect(await screen.findByTestId('ai-agent-schedule-editor-next-run')).toBeInTheDocument();
+  });
+
+  it('updates the preview live as a valid expression is edited', async () => {
+    mockList([BASELINE]);
+    render(<AiAgentSchedulesSection {...partnerProps} />);
+
+    fireEvent.click(await screen.findByTestId('ai-agent-schedule-edit-s-1'));
+    const before = (await screen.findByTestId('ai-agent-schedule-editor-next-run')).textContent;
+
+    fireEvent.change(screen.getByTestId('ai-agent-schedule-cron'), { target: { value: '17 4 * * *' } });
+
+    expect(screen.getByTestId('ai-agent-schedule-editor-next-run').textContent).not.toBe(before);
+  });
+
+  it('says so when a valid expression has no occurrence in the next year', async () => {
+    mockList([BASELINE]);
+    render(<AiAgentSchedulesSection {...partnerProps} />);
+
+    fireEvent.click(await screen.findByTestId('ai-agent-schedule-edit-s-1'));
+    fireEvent.change(await screen.findByTestId('ai-agent-schedule-cron'), { target: { value: '0 0 30 2 *' } });
+
+    expect(await screen.findByTestId('ai-agent-schedule-editor-next-run-none')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/settings/AiAgentSchedulesSection.tsx
+++ b/apps/web/src/components/settings/AiAgentSchedulesSection.tsx
@@ -38,12 +38,13 @@
 // Deletes use an INLINE two-step confirm, never `window.confirm`: a native
 // dialog cannot be dismissed by the browser-automation harness, so an E2E run
 // wedges on it.
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useId, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import '@/lib/i18n';
 import {
   AI_AGENT_SCHEDULE_KINDS,
   AI_SWEEP_KINDS,
+  isHourlyFloorCron,
   isStructurallyValidCron,
   isWeeklyLiteralCron,
   listIanaTimezones,
@@ -53,6 +54,8 @@ import {
   type AiSweepKind,
 } from '@breeze/shared';
 import { fetchWithAuth } from '../../stores/auth';
+import { badgeClass } from '../aiAgents/statusBadge';
+import { EmptyState } from '../shared/EmptyState';
 import { handleActionError, runAction } from '@/lib/runAction';
 import { loginPathWithNext } from '@/lib/authScope';
 import { navigateTo } from '@/lib/navigation';
@@ -104,6 +107,190 @@ const SCHEDULE_ERROR_COPY: Record<string, ((t: (key: string) => string) => strin
 /** The server's rule, restated client-side — see the module doc. */
 function isFiveFieldCron(value: string): boolean {
   return isStructurallyValidCron(value) && value.trim().split(/\s+/).length === 5;
+}
+
+// ---------------------------------------------------------------------------
+// Next-run preview
+//
+// A cron field is validated by `isStructurallyValidCron` but never EVALUATED
+// anywhere on the client, so `0 3 * * 7` and `0 3 * * 0` (Sunday, twice) look
+// identical to an operator and a typo'd day-of-week is invisible until the
+// sweep silently fails to fire for a week. `cron-parser` is not a dependency
+// of apps/web (only of apps/api, transitively through BullMQ), so this
+// evaluates the same grammar `isValidCronField` accepts — comma lists of `*`,
+// a value, or `a-b`, each optionally `/step`, with month and day names.
+//
+// TIMEZONE. The result is WALL-CLOCK TIME IN THE SCHEDULE'S OWN ZONE, and the
+// label says which zone, so no instant conversion is needed: "now" is read
+// into that zone's wall clock once and the search then walks a plain calendar.
+// The consequence is that a DST transition is not modelled — a preview one
+// hour off twice a year is the accepted cost of not shipping a tz library to
+// render a hint. The scheduler, not this function, decides when a sweep runs.
+// ---------------------------------------------------------------------------
+
+const CRON_MONTH_NAMES = ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec'];
+const CRON_DAY_NAMES = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'];
+
+/** Every value one cron field matches, or null when the field does not parse. */
+function expandCronField(
+  field: string,
+  min: number,
+  max: number,
+  names: readonly string[],
+): Set<number> | null {
+  const readValue = (token: string): number | null => {
+    const named = names.indexOf(token.toLowerCase());
+    // Month names are 1-based, day names 0-based — the same asymmetry
+    // `isValidCronField` encodes.
+    if (named >= 0) return names === CRON_MONTH_NAMES ? named + 1 : named;
+    if (!/^\d+$/.test(token)) return null;
+    const value = Number(token);
+    return value >= min && value <= max ? value : null;
+  };
+
+  const values = new Set<number>();
+  for (const listItem of field.split(',')) {
+    if (listItem === '') return null;
+    const [rangePart, stepPart, ...extra] = listItem.split('/');
+    if (extra.length > 0) return null;
+    if (stepPart !== undefined && !/^[1-9]\d*$/.test(stepPart)) return null;
+    const step = stepPart === undefined ? 1 : Number(stepPart);
+    let from: number;
+    let to: number;
+    if (rangePart === '*') {
+      from = min;
+      to = max;
+    } else {
+      const bounds = (rangePart ?? '').split('-');
+      if (bounds.length > 2) return null;
+      const parsed = bounds.map(readValue);
+      if (parsed.some((value) => value === null)) return null;
+      from = parsed[0] as number;
+      // A bare `5/15` means "from 5 to the end of the range, every 15" —
+      // a lone value with no step is just itself.
+      to = parsed.length === 2 ? (parsed[1] as number) : stepPart === undefined ? from : max;
+      if (from > to) return null;
+    }
+    for (let value = from; value <= to; value += step) values.add(value);
+  }
+  return values.size === 0 ? null : values;
+}
+
+interface CronFields {
+  minutes: Set<number>;
+  hours: Set<number>;
+  daysOfMonth: Set<number>;
+  months: Set<number>;
+  daysOfWeek: Set<number>;
+  domRestricted: boolean;
+  dowRestricted: boolean;
+}
+
+export function parseFiveFieldCron(cron: string): CronFields | null {
+  const parts = cron.trim().split(/\s+/);
+  if (parts.length !== 5) return null;
+  const minutes = expandCronField(parts[0]!, 0, 59, []);
+  const hours = expandCronField(parts[1]!, 0, 23, []);
+  const daysOfMonth = expandCronField(parts[2]!, 1, 31, []);
+  const months = expandCronField(parts[3]!, 1, 12, CRON_MONTH_NAMES);
+  const rawDaysOfWeek = expandCronField(parts[4]!, 0, 7, CRON_DAY_NAMES);
+  if (!minutes || !hours || !daysOfMonth || !months || !rawDaysOfWeek) return null;
+  return {
+    minutes,
+    hours,
+    daysOfMonth,
+    months,
+    // 7 and 0 are both Sunday.
+    daysOfWeek: new Set([...rawDaysOfWeek].map((day) => (day === 7 ? 0 : day))),
+    domRestricted: parts[2] !== '*',
+    dowRestricted: parts[4] !== '*',
+  };
+}
+
+/**
+ * First matching wall-clock minute strictly after `fromMs`, expressed as a
+ * floating instant (the Y-M-D H:M read as if it were UTC). Null when nothing
+ * matches inside a year — `0 0 30 2 *` is structurally valid and never fires.
+ */
+export function nextCronOccurrence(fields: CronFields, fromMs: number): Date | null {
+  const cursor = new Date(Math.floor(fromMs / 60000) * 60000 + 60000);
+  for (let day = 0; day < 400; day += 1) {
+    if (fields.months.has(cursor.getUTCMonth() + 1)) {
+      const domHit = fields.daysOfMonth.has(cursor.getUTCDate());
+      const dowHit = fields.daysOfWeek.has(cursor.getUTCDay());
+      // Vixie cron: when BOTH day fields are restricted the day matches if
+      // EITHER does; otherwise the unrestricted one is a no-op `*`.
+      const dayHit = fields.domRestricted && fields.dowRestricted ? domHit || dowHit : domHit && dowHit;
+      if (dayHit) {
+        const fromHour = cursor.getUTCHours();
+        for (let hour = fromHour; hour < 24; hour += 1) {
+          if (!fields.hours.has(hour)) continue;
+          const fromMinute = hour === fromHour ? cursor.getUTCMinutes() : 0;
+          for (let minute = fromMinute; minute < 60; minute += 1) {
+            if (!fields.minutes.has(minute)) continue;
+            return new Date(Date.UTC(
+              cursor.getUTCFullYear(),
+              cursor.getUTCMonth(),
+              cursor.getUTCDate(),
+              hour,
+              minute,
+            ));
+          }
+        }
+      }
+    }
+    cursor.setUTCDate(cursor.getUTCDate() + 1);
+    cursor.setUTCHours(0, 0, 0, 0);
+  }
+  return null;
+}
+
+/** "Now" as a floating instant on `timezone`'s wall clock. */
+function wallClockNow(timezone: string, now: Date): number {
+  try {
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      hour12: false,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).formatToParts(now);
+    const read = (type: string) => Number(parts.find((part) => part.type === type)?.value);
+    const year = read('year');
+    if (!Number.isFinite(year)) throw new Error('unreadable parts');
+    // `hour12: false` renders midnight as 24 in some ICU versions.
+    return Date.UTC(year, read('month') - 1, read('day'), read('hour') % 24, read('minute'));
+  } catch {
+    // An unknown zone must not blank the whole row — fall back to UTC and
+    // keep the label, which names the zone the schedule actually stores.
+    return Date.UTC(
+      now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), now.getUTCHours(), now.getUTCMinutes(),
+    );
+  }
+}
+
+type NextRun =
+  | { kind: 'invalid' }
+  | { kind: 'none' }
+  | { kind: 'at'; at: string };
+
+export function describeNextRun(cron: string, timezone: string, now = new Date()): NextRun {
+  const fields = parseFiveFieldCron(cron);
+  if (!fields) return { kind: 'invalid' };
+  const occurrence = nextCronOccurrence(fields, wallClockNow(timezone, now));
+  if (!occurrence) return { kind: 'none' };
+  // Formatted as UTC because the value IS a floating wall-clock instant; the
+  // zone it belongs to is named beside it, never inferred from the viewer's.
+  return {
+    kind: 'at',
+    at: new Intl.DateTimeFormat(undefined, {
+      timeZone: 'UTC',
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    }).format(occurrence),
+  };
 }
 
 /**
@@ -214,6 +401,7 @@ export default function AiAgentSchedulesSection({
   const [draft, setDraft] = useState<Draft | null>(null);
   const [saving, setSaving] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const allOrgsHintId = useId();
 
   const load = useCallback(async () => {
     if (!schedulable) return;
@@ -244,7 +432,13 @@ export default function AiAgentSchedulesSection({
     } finally {
       setLoading(false);
     }
-  }, [agentId, schedulable]);
+    // `orgId` is a dependency even though it never appears in the URL above:
+    // fetchWithAuth reads it from the org store to build the `?orgId=`
+    // query itself, but THIS callback still has to be re-created (and thus
+    // re-run by the effect below) when the org switcher changes, or the
+    // section keeps showing the previous org's merged overrides until some
+    // unrelated prop forces a reload.
+  }, [agentId, orgId, schedulable]);
 
   useEffect(() => {
     void load();
@@ -321,12 +515,15 @@ export default function AiAgentSchedulesSection({
     });
   };
 
-  // A narrative baseline must ALSO be a weekly literal (`isWeeklyLiteralCron`)
-  // — the same predicate the server applies, restated rather than approximated,
-  // so a cron this form accepts is never one the API then refuses.
+  // A SWEEP baseline must ALSO clear the server's hourly floor
+  // (`isHourlyFloorCron` — see the module doc), and a narrative baseline must
+  // ALSO be a weekly literal (`isWeeklyLiteralCron`) — both the same
+  // predicates the server applies, restated rather than approximated, so a
+  // cron this form accepts is never one the API then refuses.
   const cronValid = draft?.mode !== 'baseline'
     ? true
-    : isFiveFieldCron(draft.cron) && (draft.kind !== 'narrative' || isWeeklyLiteralCron(draft.cron));
+    : isFiveFieldCron(draft.cron)
+      && (draft.kind === 'narrative' ? isWeeklyLiteralCron(draft.cron) : isHourlyFloorCron(draft.cron));
   // `.min(1)` on a SWEEP baseline (a sweep baseline that sweeps nothing is
   // pointless); a narrative baseline evaluates no kinds at all, and an
   // override's `[]` is meaningful — "run no check for this org".
@@ -456,6 +653,34 @@ export default function AiAgentSchedulesSection({
       ? t('aiAgentsPage.schedules.noKinds')
       : kinds.map(kindLabel).join(', ');
 
+  /**
+   * "Next run" beside the raw cron. Without it the only feedback a five-field
+   * expression gives is structural validity, so a wrong day-of-week reads as
+   * a working schedule until it fails to fire.
+   */
+  const nextRunLine = (cron: string, timezone: string, testId: string) => {
+    const next = describeNextRun(cron, timezone);
+    if (next.kind === 'invalid') {
+      return (
+        <span className="block text-xs text-destructive" data-testid={`${testId}-invalid`}>
+          {t('aiAgentsPage.schedules.nextRunInvalid')}
+        </span>
+      );
+    }
+    if (next.kind === 'none') {
+      return (
+        <span className="block text-xs text-muted-foreground" data-testid={`${testId}-none`}>
+          {t('aiAgentsPage.schedules.nextRunNone')}
+        </span>
+      );
+    }
+    return (
+      <span className="block text-xs text-muted-foreground" data-testid={testId}>
+        {t('aiAgentsPage.schedules.nextRun', { at: next.at, timezone })}
+      </span>
+    );
+  };
+
   const editor = (drafted: Draft) => (
     <div className="mt-3 space-y-3 rounded-md border bg-background p-3" data-testid="ai-agent-schedule-editor">
       {/* CREATE only. `kind` is immutable once saved (the update schema is
@@ -503,6 +728,11 @@ export default function AiAgentSchedulesSection({
                 {t('aiAgentsPage.schedules.cronInvalid')}
               </span>
             )}
+            {/* Only while the cron actually validates — otherwise this and
+                the cronInvalid banner above say the same "this is broken"
+                thing twice, once as a generic banner and once as the
+                preview's own "Invalid schedule" state. */}
+            {cronValid && nextRunLine(drafted.cron, drafted.timezone, 'ai-agent-schedule-editor-next-run')}
           </label>
           <label className="space-y-1 text-sm">
             <span className="font-medium">{t('aiAgentsPage.schedules.timezone')}</span>
@@ -617,6 +847,7 @@ export default function AiAgentSchedulesSection({
         {t('aiAgentsPage.schedules.title')}
       </legend>
       <p className="text-xs text-muted-foreground">{t('aiAgentsPage.schedules.description')}</p>
+      <span id={allOrgsHintId} className="sr-only">{t('aiAgentsPage.allOrgsHint')}</span>
 
       {!schedulable ? (
         <p className="text-sm text-muted-foreground" data-testid="ai-agent-schedules-partner-only">
@@ -635,9 +866,12 @@ export default function AiAgentSchedulesSection({
             </p>
           )}
           {!loading && !failed && schedules.length === 0 && (
-            <p className="text-sm text-muted-foreground" data-testid="ai-agent-schedules-empty">
-              {t('aiAgentsPage.schedules.empty')}
-            </p>
+            <EmptyState
+              size="sm"
+              headingLevel={4}
+              testId="ai-agent-schedules-empty"
+              title={t('aiAgentsPage.schedules.empty')}
+            />
           )}
 
           {schedules.length > 0 && (
@@ -648,25 +882,34 @@ export default function AiAgentSchedulesSection({
                   <li key={schedule.id} className="p-3" data-testid={`ai-agent-schedule-${schedule.id}`}>
                     <div className="flex flex-wrap items-center gap-2 text-sm">
                       <span
-                        className="rounded bg-sky-500/10 px-2 py-0.5 text-xs font-medium text-sky-700"
+                        className={badgeClass('info', { size: 'sm' })}
                         data-testid={`ai-agent-schedule-kind-badge-${schedule.id}`}
                       >
                         {scheduleKindLabel(kindOf(schedule))}
                       </span>
                       <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">{schedule.cron}</code>
                       <span className="text-muted-foreground">{schedule.timezone}</span>
+                      {/* `title=` alone is invisible to touch and keyboard, so
+                          the explanation is a real described-by node. */}
                       <span
                         className="rounded bg-primary/10 px-2 py-0.5 text-xs text-primary"
-                        title={t('aiAgentsPage.allOrgsHint')}
+                        aria-describedby={allOrgsHintId}
                       >
                         {t('aiAgentsPage.allOrgs')}
                       </span>
-                      <span className="text-xs text-muted-foreground">
+                      <span className={badgeClass(schedule.enabled ? 'success' : 'muted', { size: 'sm' })}>
                         {schedule.enabled
                           ? t('aiAgentsPage.stateEnabled')
                           : t('aiAgentsPage.stateDisabled')}
                       </span>
                     </div>
+                    <p className="mt-1">
+                      {nextRunLine(
+                        schedule.cron,
+                        schedule.timezone,
+                        `ai-agent-schedule-next-run-${schedule.id}`,
+                      )}
+                    </p>
                     {/* A narrative row has no checks to name — "No checks"
                         would read as a misconfiguration rather than as the
                         kind's defining property. */}

--- a/apps/web/src/components/settings/AiAgentsPage.test.tsx
+++ b/apps/web/src/components/settings/AiAgentsPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
@@ -200,7 +200,7 @@ describe('AiAgentsPage', () => {
     // Not shown before the operator has selected act.
     expect(screen.queryByTestId('ai-agent-act-warning')).toBeNull();
 
-    fireEvent.change(await screen.findByTestId('ai-agent-mode'), { target: { value: 'act' } });
+    fireEvent.click(await screen.findByTestId('ai-agent-mode-act'));
 
     expect(await screen.findByTestId('ai-agent-act-warning')).toBeInTheDocument();
     expect(screen.getByTestId('ai-agent-act-ack')).not.toBeChecked();
@@ -248,7 +248,7 @@ describe('AiAgentsPage', () => {
     await waitFor(() => screen.getByTestId('ai-agent-edit-a1'));
     fireEvent.click(screen.getByTestId('ai-agent-edit-a1'));
 
-    fireEvent.change(await screen.findByTestId('ai-agent-mode'), { target: { value: 'act' } });
+    fireEvent.click(await screen.findByTestId('ai-agent-mode-act'));
     fireEvent.click(screen.getByTestId('ai-agent-act-ack'));
     fireEvent.click(screen.getByTestId('ai-agent-save'));
 
@@ -459,7 +459,7 @@ describe('AiAgentsPage', () => {
     // existing act-warning gating pattern.
     expect(screen.queryByTestId('ai-agent-supervised-key-manage_services:restart')).toBeNull();
 
-    fireEvent.change(await screen.findByTestId('ai-agent-mode'), { target: { value: 'act' } });
+    fireEvent.click(await screen.findByTestId('ai-agent-mode-act'));
 
     expect(await screen.findByTestId('ai-agent-supervised-key-manage_services:restart')).toBeInTheDocument();
     expect(screen.getByTestId('ai-agent-supervised-key-manage_services:stop')).toBeInTheDocument();
@@ -503,7 +503,7 @@ describe('AiAgentsPage', () => {
 
     await waitFor(() => screen.getByTestId('ai-agent-edit-a1'));
     fireEvent.click(screen.getByTestId('ai-agent-edit-a1'));
-    fireEvent.change(await screen.findByTestId('ai-agent-mode'), { target: { value: 'act' } });
+    fireEvent.click(await screen.findByTestId('ai-agent-mode-act'));
     fireEvent.click(screen.getByTestId('ai-agent-act-ack'));
     fireEvent.click(screen.getByTestId('ai-agent-save'));
 
@@ -524,7 +524,7 @@ describe('AiAgentsPage', () => {
 
     await waitFor(() => screen.getByTestId('ai-agent-edit-a1'));
     fireEvent.click(screen.getByTestId('ai-agent-edit-a1'));
-    fireEvent.change(await screen.findByTestId('ai-agent-mode'), { target: { value: 'act' } });
+    fireEvent.click(await screen.findByTestId('ai-agent-mode-act'));
 
     expect(await screen.findByTestId('ai-agent-policy-keys-failed')).toBeInTheDocument();
   });
@@ -547,6 +547,282 @@ describe('AiAgentsPage', () => {
         fetchMock.mock.calls.some(([, init]) => (init as RequestInit | undefined)?.method === 'DELETE'),
       ).toBe(true),
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #4187 UI critique — the mode control, the first-run panel, and the drawer.
+// ---------------------------------------------------------------------------
+
+const ACT_AGENT = { ...PARTNER_AGENT, supportedModes: ['off', 'shadow', 'act'] as const };
+
+/** The three-key policy registry every act-mode test below shares. */
+const REGISTRY = [
+  { key: 'manage_services:restart', toolName: 'manage_services', action: 'restart', note: 'Restarts a service.' },
+  { key: 'manage_services:stop', toolName: 'manage_services', action: 'stop', note: 'Stops a service.' },
+  { key: 'security_scan:quarantine', toolName: 'security_scan', action: 'quarantine', note: 'Quarantines a threat.' },
+];
+
+function mockActEndpoints(agent: unknown = ACT_AGENT, registry: unknown[] = REGISTRY) {
+  fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+    if (url === '/ai/agents/policy-decidable-keys') return Promise.resolve(json({ data: registry }));
+    if (url === '/ai/agents/a1' && init?.method === 'PATCH') return Promise.resolve(json({ data: agent }));
+    if (url.startsWith('/ai/agents/schedules')) return Promise.resolve(json({ data: [] }));
+    if (url.startsWith('/ai/agents')) return Promise.resolve(json({ data: [agent] }));
+    if (url === '/roles') return Promise.resolve(json({ data: [] }));
+    return Promise.resolve(json({ data: [] }));
+  });
+}
+
+function lastPatchBody() {
+  const patch = fetchMock.mock.calls.find(([, init]) => (init as RequestInit | undefined)?.method === 'PATCH');
+  return JSON.parse((patch?.[1] as RequestInit).body as string) as Record<string, unknown>;
+}
+
+describe('AiAgentsPage mode radiogroup (#4187 UI critique)', () => {
+  it('renders mode as a three-option radiogroup whose selection reflects the stored mode', async () => {
+    mockActEndpoints();
+    render(<AiAgentsPage />);
+
+    await waitFor(() => screen.getByTestId('ai-agent-edit-a1'));
+    fireEvent.click(screen.getByTestId('ai-agent-edit-a1'));
+
+    const group = await screen.findByTestId('ai-agent-mode');
+    expect(group).toHaveAttribute('role', 'radiogroup');
+    const radios = within(group).getAllByRole('radio');
+    expect(radios).toHaveLength(3);
+    // PARTNER_AGENT is stored as `shadow`.
+    expect(screen.getByTestId('ai-agent-mode-shadow')).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByTestId('ai-agent-mode-off')).toHaveAttribute('aria-checked', 'false');
+    expect(screen.getByTestId('ai-agent-mode-act')).toHaveAttribute('aria-checked', 'false');
+    // Roving tabindex: exactly one tab stop, on the selected option.
+    expect(radios.filter((radio) => radio.getAttribute('tabindex') === '0')).toHaveLength(1);
+  });
+
+  it('moves the selection with the arrow keys, wrapping at both ends', async () => {
+    mockActEndpoints();
+    render(<AiAgentsPage />);
+
+    await waitFor(() => screen.getByTestId('ai-agent-edit-a1'));
+    fireEvent.click(screen.getByTestId('ai-agent-edit-a1'));
+    const group = await screen.findByTestId('ai-agent-mode');
+
+    fireEvent.keyDown(group, { key: 'ArrowRight' });
+    expect(screen.getByTestId('ai-agent-mode-act')).toHaveAttribute('aria-checked', 'true');
+
+    // Wraps forward from the last option back to the first.
+    fireEvent.keyDown(group, { key: 'ArrowRight' });
+    expect(screen.getByTestId('ai-agent-mode-off')).toHaveAttribute('aria-checked', 'true');
+
+    fireEvent.keyDown(group, { key: 'ArrowLeft' });
+    expect(screen.getByTestId('ai-agent-mode-act')).toHaveAttribute('aria-checked', 'true');
+
+    fireEvent.keyDown(group, { key: 'Home' });
+    expect(screen.getByTestId('ai-agent-mode-off')).toHaveAttribute('aria-checked', 'true');
+  });
+
+  // Review fix (#4187 UI critique, P3): `onModeKeyDown` moves selection AND
+  // is documented as moving focus (the roving-tabindex pattern requires
+  // both), but nothing previously asserted the focus half — a regression
+  // that moved selection without calling `.focus()` would have passed every
+  // other test here.
+  it('moves DOM focus together with the selection on every arrow/Home/End key, wrapping at both ends', async () => {
+    mockActEndpoints();
+    render(<AiAgentsPage />);
+
+    await waitFor(() => screen.getByTestId('ai-agent-edit-a1'));
+    fireEvent.click(screen.getByTestId('ai-agent-edit-a1'));
+    const group = await screen.findByTestId('ai-agent-mode');
+
+    fireEvent.keyDown(group, { key: 'ArrowRight' });
+    expect(document.activeElement).toBe(screen.getByTestId('ai-agent-mode-act'));
+
+    // Wraps forward from the last option back to the first.
+    fireEvent.keyDown(group, { key: 'ArrowRight' });
+    expect(document.activeElement).toBe(screen.getByTestId('ai-agent-mode-off'));
+
+    // Wraps backward from the first option to the last.
+    fireEvent.keyDown(group, { key: 'ArrowLeft' });
+    expect(document.activeElement).toBe(screen.getByTestId('ai-agent-mode-act'));
+
+    fireEvent.keyDown(group, { key: 'Home' });
+    expect(document.activeElement).toBe(screen.getByTestId('ai-agent-mode-off'));
+
+    fireEvent.keyDown(group, { key: 'End' });
+    expect(document.activeElement).toBe(screen.getByTestId('ai-agent-mode-act'));
+  });
+
+  // Review fix (#4187 UI critique, P3): a stale row can have its CHECKED
+  // option itself disabled — an agent saved while `act` was supported, whose
+  // partner later lost act eligibility, still stores `mode: 'act'`. The old
+  // `tabIndex={selected ? 0 : -1}` left every radio at -1 in that case,
+  // making the whole group unreachable by keyboard (Tab skips it entirely).
+  it('falls back the roving tab stop to the first ENABLED option when the checked option is itself disabled', async () => {
+    const staleActAgent = { ...PARTNER_AGENT, mode: 'act' as const, supportedModes: ['off', 'shadow'] as const };
+    mockEndpoints([staleActAgent]);
+    render(<AiAgentsPage />);
+
+    await waitFor(() => screen.getByTestId('ai-agent-edit-a1'));
+    fireEvent.click(screen.getByTestId('ai-agent-edit-a1'));
+
+    const group = await screen.findByTestId('ai-agent-mode');
+    expect(screen.getByTestId('ai-agent-mode-act')).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByTestId('ai-agent-mode-act')).toBeDisabled();
+
+    const radios = within(group).getAllByRole('radio');
+    expect(radios.filter((radio) => radio.getAttribute('tabindex') === '0')).toHaveLength(1);
+    expect(screen.getByTestId('ai-agent-mode-off')).toHaveAttribute('tabindex', '0');
+    expect(screen.getByTestId('ai-agent-mode-act')).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('never lands on the act option with the arrow keys when the API does not support it', async () => {
+    // `PARTNER_AGENT.supportedModes` is ['off','shadow'] — the disabled card
+    // has to be skipped by the keyboard too, not just unclickable.
+    mockEndpoints();
+    render(<AiAgentsPage />);
+
+    await waitFor(() => screen.getByTestId('ai-agent-edit-a1'));
+    fireEvent.click(screen.getByTestId('ai-agent-edit-a1'));
+    const group = await screen.findByTestId('ai-agent-mode');
+
+    fireEvent.keyDown(group, { key: 'ArrowRight' });
+    expect(screen.getByTestId('ai-agent-mode-off')).toHaveAttribute('aria-checked', 'true');
+    fireEvent.keyDown(group, { key: 'End' });
+    expect(screen.getByTestId('ai-agent-mode-shadow')).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByTestId('ai-agent-mode-act')).toHaveAttribute('aria-checked', 'false');
+  });
+
+  // Review fix (#4187 UI critique, P2): the ORIGINAL Riley bug was that
+  // leaving act only HID the fieldset while Save still submitted keys the
+  // operator could no longer see. The FIRST fix over-corrected — it cleared
+  // `supervisedActionKeys` from the draft on the way out of act, so an
+  // act -> shadow -> act round trip silently lost a persisted grant list the
+  // operator never touched. The keys now stay in the draft the whole time;
+  // only the SAVE PAYLOAD omits them while the mode isn't act.
+  it('keeps supervisedActionKeys in the draft across an act -> shadow -> act round trip, and omits them from Save only while not in act', async () => {
+    mockActEndpoints();
+    render(<AiAgentsPage />);
+
+    await waitFor(() => screen.getByTestId('ai-agent-edit-a1'));
+    fireEvent.click(screen.getByTestId('ai-agent-edit-a1'));
+
+    fireEvent.click(await screen.findByTestId('ai-agent-mode-act'));
+    fireEvent.click(await screen.findByTestId('ai-agent-supervised-key-manage_services:restart'));
+    fireEvent.click(screen.getByTestId('ai-agent-act-ack'));
+    expect(screen.getByTestId('ai-agent-supervised-key-manage_services:restart')).toBeChecked();
+
+    fireEvent.click(screen.getByTestId('ai-agent-mode-shadow'));
+
+    // Announced: Save will not carry these keys while the mode stays shadow.
+    expect(await screen.findByTestId('ai-agent-act-keys-cleared')).toBeInTheDocument();
+    // The acknowledgement still resets — a genuine re-entry into act must ask
+    // again — but the KEY SELECTION itself is restored, not re-blanked.
+    fireEvent.click(screen.getByTestId('ai-agent-mode-act'));
+    expect(screen.getByTestId('ai-agent-act-ack')).not.toBeChecked();
+    expect(screen.getByTestId('ai-agent-supervised-key-manage_services:restart')).toBeChecked();
+    // Mounted unconditionally (see the dedicated test below) — back in act
+    // mode there is nothing to omit, so the text is empty rather than absent.
+    expect(screen.getByTestId('ai-agent-act-keys-cleared')).toHaveTextContent('');
+
+    // Saving from shadow omits the keys even though the draft still holds
+    // them — the draft is a form of "remembered while not in effect", never
+    // wire truth for a mode that cannot use them.
+    fireEvent.click(screen.getByTestId('ai-agent-mode-shadow'));
+    fireEvent.click(screen.getByTestId('ai-agent-save'));
+
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.some(([, init]) => (init as RequestInit | undefined)?.method === 'PATCH')).toBe(true),
+    );
+    const body = lastPatchBody();
+    expect(body.mode).toBe('shadow');
+    expect(body.actAssets).toEqual({ supervisedActionKeys: [] });
+  });
+
+  it('does not claim keys will be omitted when there were none to omit', async () => {
+    mockActEndpoints();
+    render(<AiAgentsPage />);
+
+    await waitFor(() => screen.getByTestId('ai-agent-edit-a1'));
+    fireEvent.click(screen.getByTestId('ai-agent-edit-a1'));
+
+    fireEvent.click(await screen.findByTestId('ai-agent-mode-act'));
+    fireEvent.click(screen.getByTestId('ai-agent-mode-off'));
+
+    // Review fix (#4187 UI critique, P3): the status region is now mounted
+    // UNCONDITIONALLY (see the radiogroup test below) so a screen reader
+    // hears the FIRST announcement too — an aria-live region only announces
+    // changes to content that was already in the DOM when it changed. So
+    // "not shown" is now "present with no text", not "absent".
+    const status = screen.getByTestId('ai-agent-act-keys-cleared');
+    expect(status).toHaveTextContent('');
+  });
+
+  // Review fix (#4187 UI critique, P3): `role="status"` mounted only once
+  // there was something to say, so the FIRST thing it ever announced was
+  // never heard — an aria-live region has to already be in the accessibility
+  // tree before its content changes for assistive tech to pick up the
+  // change. The element must always be there; only its text toggles.
+  it('mounts the act-keys status region unconditionally, gating only its text', async () => {
+    mockActEndpoints();
+    render(<AiAgentsPage />);
+
+    await waitFor(() => screen.getByTestId('ai-agent-edit-a1'));
+    fireEvent.click(screen.getByTestId('ai-agent-edit-a1'));
+
+    // Present even before act mode has ever been touched.
+    const status = await screen.findByTestId('ai-agent-act-keys-cleared');
+    expect(status).toHaveAttribute('role', 'status');
+    expect(status).toHaveTextContent('');
+
+    fireEvent.click(await screen.findByTestId('ai-agent-mode-act'));
+    fireEvent.click(screen.getByTestId('ai-agent-supervised-key-manage_services:restart'));
+    fireEvent.click(screen.getByTestId('ai-agent-mode-shadow'));
+
+    expect(screen.getByTestId('ai-agent-act-keys-cleared')).toHaveTextContent(/.+/);
+  });
+
+  it('explains that `enabled` and the mode are two gates', async () => {
+    mockEndpoints();
+    render(<AiAgentsPage />);
+
+    await waitFor(() => screen.getByTestId('ai-agent-edit-a1'));
+    fireEvent.click(screen.getByTestId('ai-agent-edit-a1'));
+
+    expect(await screen.findByTestId('ai-agent-enabled-hint')).toBeInTheDocument();
+  });
+});
+
+describe('AiAgentsPage first run and drawer (#4187 UI critique)', () => {
+  it('replaces the bare "no agents" line with a first-run panel that opens the create form', async () => {
+    mockEndpoints([]);
+    render(<AiAgentsPage />);
+
+    const empty = await screen.findByTestId('ai-agents-empty');
+    // Every kind is named, so an operator learns what is on offer before
+    // being asked to pick one.
+    expect(within(empty).getByText('Alert triage')).toBeInTheDocument();
+    expect(within(empty).getByText('Patching')).toBeInTheDocument();
+    expect(within(empty).getByText('Help desk')).toBeInTheDocument();
+
+    fireEvent.click(within(empty).getByTestId('ai-agents-empty-create'));
+    expect(await screen.findByTestId('ai-agent-editor')).toBeInTheDocument();
+    // New agents start in the safe mode the panel names.
+    expect(screen.getByTestId('ai-agent-mode-off')).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('opens the editor in a drawer and leaves the agent list on screen', async () => {
+    mockEndpoints([PARTNER_AGENT, ORG_AGENT]);
+    render(<AiAgentsPage />);
+
+    await waitFor(() => screen.getByTestId('ai-agent-edit-a1'));
+    expect(screen.queryByTestId('ai-agent-editor-drawer')).toBeNull();
+
+    fireEvent.click(screen.getByTestId('ai-agent-edit-a1'));
+
+    expect(await screen.findByTestId('ai-agent-editor-drawer')).toBeInTheDocument();
+    // The list is what the inline editor used to push below the fold.
+    expect(screen.getByTestId('ai-agents-list')).toBeInTheDocument();
+    expect(screen.getByTestId('ai-agent-row-a2')).toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/components/settings/AiAgentsPage.tsx
+++ b/apps/web/src/components/settings/AiAgentsPage.tsx
@@ -1,9 +1,13 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useId, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import '@/lib/i18n';
 import { Bot, Plus } from 'lucide-react';
+import { AI_AGENT_KINDS } from '@breeze/shared';
 import { fetchWithAuth } from '../../stores/auth';
 import { useDefaultOwnerScope } from '@/hooks/useDefaultOwnerScope';
+import { badgeClass, modeTone } from '../aiAgents/statusBadge';
+import { Drawer } from '../shared/Drawer';
+import { EmptyState } from '../shared/EmptyState';
 import AiAgentForm, { type AiAgentDto } from './AiAgentForm';
 
 type Editing = { agent: AiAgentDto | null } | null;
@@ -25,6 +29,21 @@ export default function AiAgentsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
   const [editing, setEditing] = useState<Editing>(null);
+  const allOrgsHintId = useId();
+
+  // Literal keys, not a dynamic `t()` on the token: the closed three-member
+  // union is spelled out so the keyUsage guard verifies every label and hint
+  // statically (same reason as AiAgentSchedulesSection's `scheduleKindLabel`).
+  const KIND_LABEL: Record<(typeof AI_AGENT_KINDS)[number], string> = {
+    triage: t('aiAgentsPage.kinds.triage'),
+    patch: t('aiAgentsPage.kinds.patch'),
+    helpdesk: t('aiAgentsPage.kinds.helpdesk'),
+  };
+  const KIND_HINT: Record<(typeof AI_AGENT_KINDS)[number], string> = {
+    triage: t('aiAgentsPage.kindHints.triage'),
+    patch: t('aiAgentsPage.kindHints.patch'),
+    helpdesk: t('aiAgentsPage.kindHints.helpdesk'),
+  };
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -84,24 +103,36 @@ export default function AiAgentsPage() {
         </div>
       )}
 
-      {editing && (
-        <AiAgentForm
-          // The draft lives in the form's own state, seeded once at mount. With
-          // the list still on screen, switching edit targets kept the previous
-          // draft and PATCHed the newly-selected agent with the old agent's
-          // policy. Keying on the target remounts it instead.
-          key={editing.agent?.id ?? 'new'}
-          agent={editing.agent}
-          agents={agents}
-          showOwnerScope={isPartnerScope}
-          defaultOwnerScope={defaultOwnerScope}
-          onClose={() => setEditing(null)}
-          onSaved={() => {
-            setEditing(null);
-            void load();
-          }}
-        />
-      )}
+      {/* The editor used to render INLINE, above the list, which pushed every
+          existing agent below the fold the moment you clicked Edit. It opens
+          in the app's Drawer instead — the same idiom as the impact-weights
+          editor — so the list you are editing against stays on screen. */}
+      <Drawer
+        open={editing !== null}
+        onClose={() => setEditing(null)}
+        title={editing?.agent ? t('aiAgentsPage.editor.editTitle') : t('aiAgentsPage.editor.newTitle')}
+        width="max-w-3xl"
+        dataTestId="ai-agent-editor-drawer"
+      >
+        {editing && (
+          <AiAgentForm
+            // The draft lives in the form's own state, seeded once at mount. With
+            // the list still on screen, switching edit targets kept the previous
+            // draft and PATCHed the newly-selected agent with the old agent's
+            // policy. Keying on the target remounts it instead.
+            key={editing.agent?.id ?? 'new'}
+            agent={editing.agent}
+            agents={agents}
+            showOwnerScope={isPartnerScope}
+            defaultOwnerScope={defaultOwnerScope}
+            onClose={() => setEditing(null)}
+            onSaved={() => {
+              setEditing(null);
+              void load();
+            }}
+          />
+        )}
+      </Drawer>
 
       {loading && (
         <p className="text-sm text-muted-foreground" data-testid="ai-agents-loading">
@@ -109,13 +140,44 @@ export default function AiAgentsPage() {
         </p>
       )}
 
+      {/* First run, not a blank line of muted text: this is the only place the
+          product explains what an agent IS before you are asked to configure
+          one, and the safe starting mode is named here rather than discovered
+          from the mode cards. */}
       {!loading && !error && agents.length === 0 && (
-        <p className="text-sm text-muted-foreground" data-testid="ai-agents-empty">
-          {t('aiAgentsPage.empty')}
-        </p>
+        <EmptyState
+          testId="ai-agents-empty"
+          headingLevel={2}
+          icon={<Bot className="h-7 w-7" />}
+          title={t('aiAgentsPage.emptyState.title')}
+          description={t('aiAgentsPage.emptyState.description')}
+          action={
+            <button
+              type="button"
+              onClick={() => setEditing({ agent: null })}
+              className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:opacity-90"
+              data-testid="ai-agents-empty-create"
+            >
+              <Plus className="h-4 w-4" />
+              {t('aiAgentsPage.emptyState.action')}
+            </button>
+          }
+          secondary={
+            <dl className="mx-auto max-w-md space-y-1 text-left text-xs text-muted-foreground">
+              {AI_AGENT_KINDS.map((kind) => (
+                <div key={kind} className="flex gap-2">
+                  <dt className="font-medium text-foreground">{KIND_LABEL[kind]}</dt>
+                  <dd>{KIND_HINT[kind]}</dd>
+                </div>
+              ))}
+            </dl>
+          }
+        />
       )}
 
       {agents.length > 0 && (
+        <>
+        <span id={allOrgsHintId} className="sr-only">{t('aiAgentsPage.allOrgsHint')}</span>
         <ul className="divide-y rounded-lg border" data-testid="ai-agents-list">
           {agents.map((agent) => (
             <li key={agent.id} className="flex flex-wrap items-center gap-3 p-3" data-testid={`ai-agent-row-${agent.id}`}>
@@ -126,19 +188,24 @@ export default function AiAgentsPage() {
                     {t(/* i18n-dynamic */ `aiAgentsPage.kinds.${agent.kind}`)}
                   </span>
                   {agent.allOrgs && (
+                    // `title=` alone is invisible to touch and to keyboard
+                    // users, so the explanation is a real described-by node.
                     <span
                       className="rounded bg-primary/10 px-2 py-0.5 text-xs text-primary"
-                      title={t('aiAgentsPage.allOrgsHint')}
+                      aria-describedby={allOrgsHintId}
                       data-testid={`ai-agent-allorgs-${agent.id}`}
                     >
                       {t('aiAgentsPage.allOrgs')}
                     </span>
                   )}
                 </div>
-                <p className="text-xs text-muted-foreground">
-                  {t(/* i18n-dynamic */ `aiAgentsPage.modes.${agent.mode}`)}
-                  {' · '}
-                  {agent.enabled ? t('aiAgentsPage.stateEnabled') : t('aiAgentsPage.stateDisabled')}
+                <p className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                  <span className={badgeClass(modeTone(agent.mode), { size: 'sm' })}>
+                    {t(/* i18n-dynamic */ `aiAgentsPage.modes.${agent.mode}`)}
+                  </span>
+                  <span className={badgeClass(agent.enabled ? 'success' : 'muted', { size: 'sm' })}>
+                    {agent.enabled ? t('aiAgentsPage.stateEnabled') : t('aiAgentsPage.stateDisabled')}
+                  </span>
                 </p>
               </div>
               <button
@@ -152,6 +219,7 @@ export default function AiAgentsPage() {
             </li>
           ))}
         </ul>
+        </>
       )}
     </div>
   );

--- a/apps/web/src/components/shared/Dialog.tsx
+++ b/apps/web/src/components/shared/Dialog.tsx
@@ -8,9 +8,9 @@ import {
   type MouseEvent,
 } from 'react';
 import { createPortal } from 'react-dom';
+import { acquireScrollLock } from './scrollLock';
 
 // Reference counter for stacked dialogs — only restore scroll when all dialogs close
-let scrollLockCount = 0;
 
 type DialogMaxWidth = 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl' | '5xl';
 
@@ -188,16 +188,8 @@ export function Dialog({
 
   useEffect(() => {
     if (!open) return;
-    scrollLockCount++;
-    if (scrollLockCount === 1) {
-      document.body.style.overflow = 'hidden';
-    }
-    return () => {
-      scrollLockCount--;
-      if (scrollLockCount === 0) {
-        document.body.style.overflow = '';
-      }
-    };
+    const release = acquireScrollLock();
+    return release;
   }, [open]);
 
   // #3705: arm the guard as the portal is torn out — but ONLY when a completed

--- a/apps/web/src/components/shared/Drawer.tsx
+++ b/apps/web/src/components/shared/Drawer.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useId, useRef, type KeyboardEvent, type MouseEvent, type ReactNode } from 'react';
+import { acquireScrollLock } from './scrollLock';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 
@@ -43,10 +44,10 @@ export function Drawer({
       const first = panelRef.current?.querySelector<HTMLElement>(FOCUSABLE);
       (first ?? panelRef.current)?.focus();
     });
-    document.body.style.overflow = 'hidden';
+    const releaseScrollLock = acquireScrollLock();
     return () => {
       cancelAnimationFrame(raf);
-      document.body.style.overflow = '';
+      releaseScrollLock();
       if (triggerRef.current instanceof HTMLElement) triggerRef.current.focus();
     };
   }, [open]);

--- a/apps/web/src/components/shared/EmptyState.test.tsx
+++ b/apps/web/src/components/shared/EmptyState.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { EmptyState } from './EmptyState';
+
+describe('EmptyState', () => {
+  it('renders the title and description', () => {
+    render(<EmptyState title="No runs yet" description="Runs will show up here once triggered." />);
+    expect(screen.getByText('No runs yet')).toBeInTheDocument();
+    expect(screen.getByText('Runs will show up here once triggered.')).toBeInTheDocument();
+  });
+
+  it('renders without a description', () => {
+    render(<EmptyState title="Nothing here" />);
+    expect(screen.getByText('Nothing here')).toBeInTheDocument();
+  });
+
+  it('renders the title as an h3 heading by default', () => {
+    render(<EmptyState title="No runs yet" />);
+    const heading = screen.getByRole('heading', { name: 'No runs yet' });
+    expect(heading.tagName).toBe('H3');
+  });
+
+  it('renders the title at the requested heading level', () => {
+    render(<EmptyState title="Page-level empty" headingLevel={2} />);
+    const heading = screen.getByRole('heading', { name: 'Page-level empty' });
+    expect(heading.tagName).toBe('H2');
+  });
+
+  it('renders the action slot', () => {
+    render(<EmptyState title="No runs yet" action={<button type="button">Create run</button>} />);
+    expect(screen.getByRole('button', { name: 'Create run' })).toBeInTheDocument();
+  });
+
+  it('renders the secondary slot', () => {
+    render(<EmptyState title="No runs yet" secondary={<a href="/docs">Learn more</a>} />);
+    expect(screen.getByRole('link', { name: 'Learn more' })).toBeInTheDocument();
+  });
+
+  it('passes through data-testid', () => {
+    render(<EmptyState title="No runs yet" testId="runs-empty" />);
+    expect(screen.getByTestId('runs-empty')).toBeInTheDocument();
+  });
+
+  it('renders a default icon when none is provided', () => {
+    render(<EmptyState title="No runs yet" testId="runs-empty" />);
+    const container = screen.getByTestId('runs-empty');
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('renders a custom icon when provided', () => {
+    render(
+      <EmptyState
+        title="No runs yet"
+        testId="runs-empty"
+        icon={<svg data-testid="custom-icon" />}
+      />,
+    );
+    expect(screen.getByTestId('custom-icon')).toBeInTheDocument();
+  });
+
+  it('uses a dashed border for the framed card', () => {
+    render(<EmptyState title="No runs yet" testId="runs-empty" />);
+    expect(screen.getByTestId('runs-empty').className).toContain('border-dashed');
+  });
+
+  it('applies a distinct className for the sm size vs md', () => {
+    const { container: smContainer } = render(<EmptyState title="Compact" size="sm" testId="sm-empty" />);
+    const { container: mdContainer } = render(<EmptyState title="Full" size="md" testId="md-empty" />);
+    const sm = smContainer.querySelector('[data-testid="sm-empty"]');
+    const md = mdContainer.querySelector('[data-testid="md-empty"]');
+    expect(sm?.className).not.toEqual(md?.className);
+  });
+
+  it('merges a passed-through className', () => {
+    render(<EmptyState title="No runs yet" testId="runs-empty" className="custom-extra" />);
+    expect(screen.getByTestId('runs-empty').className).toContain('custom-extra');
+  });
+});

--- a/apps/web/src/components/shared/EmptyState.tsx
+++ b/apps/web/src/components/shared/EmptyState.tsx
@@ -1,0 +1,83 @@
+import type { JSX, ReactNode } from 'react';
+import { Inbox } from 'lucide-react';
+
+export interface EmptyStateProps {
+  /** A lucide icon element. Defaults to an Inbox icon. */
+  icon?: ReactNode;
+  title: string;
+  description?: string;
+  /** Primary CTA slot (e.g. a "Create" button). */
+  action?: ReactNode;
+  /** Secondary link/help slot, rendered below `action`. */
+  secondary?: ReactNode;
+  /** `sm` = compact, for inline table/panel empties. `md` = page-level. Defaults to `md`. */
+  size?: 'sm' | 'md';
+  /** data-testid passthrough on the outerframed card. */
+  testId?: string;
+  className?: string;
+  /** Heading level for the title. Defaults to 3 (`<h3>`). */
+  headingLevel?: 2 | 3 | 4;
+}
+
+const SIZE_CONTAINER_CLASSES: Record<'sm' | 'md', string> = {
+  sm: 'px-4 py-6',
+  md: 'px-5 py-12',
+};
+
+const SIZE_ICON_CLASSES: Record<'sm' | 'md', string> = {
+  sm: 'h-5 w-5',
+  md: 'h-7 w-7',
+};
+
+const SIZE_TITLE_CLASSES: Record<'sm' | 'md', string> = {
+  sm: 'mt-2 text-sm font-semibold',
+  md: 'mt-3 text-base font-semibold',
+};
+
+const SIZE_DESCRIPTION_CLASSES: Record<'sm' | 'md', string> = {
+  sm: 'mt-1 text-xs text-muted-foreground',
+  md: 'mt-1 text-sm text-muted-foreground',
+};
+
+/**
+ * Reusable framed empty-state card, extracted from the pattern in
+ * ApprovalsInbox (`approvals-empty`): dashed border, centred icon, heading,
+ * description. `text-muted-foreground` / `border` are semantic tokens that
+ * are already dark-mode aware via CSS custom properties (see
+ * apps/web/src/styles/globals.css), so no explicit `dark:` classes are
+ * needed here.
+ */
+export function EmptyState({
+  icon,
+  title,
+  description,
+  action,
+  secondary,
+  size = 'md',
+  testId,
+  className,
+  headingLevel = 3,
+}: EmptyStateProps): JSX.Element {
+  const Heading = (`h${headingLevel}` as const) as 'h2' | 'h3' | 'h4';
+  const containerClassName = [
+    'rounded-xl border border-dashed text-center',
+    SIZE_CONTAINER_CLASSES[size],
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className={containerClassName} data-testid={testId}>
+      <div className="mx-auto flex w-fit items-center justify-center text-muted-foreground" aria-hidden="true">
+        {icon ?? <Inbox className={SIZE_ICON_CLASSES[size]} />}
+      </div>
+      <Heading className={SIZE_TITLE_CLASSES[size]}>{title}</Heading>
+      {description && <p className={`mx-auto max-w-sm ${SIZE_DESCRIPTION_CLASSES[size]}`}>{description}</p>}
+      {action && <div className="mt-4 flex justify-center">{action}</div>}
+      {secondary && <div className="mt-2 flex justify-center text-sm">{secondary}</div>}
+    </div>
+  );
+}
+
+export default EmptyState;

--- a/apps/web/src/components/shared/scrollLock.test.ts
+++ b/apps/web/src/components/shared/scrollLock.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { acquireScrollLock, scrollLockHolders } from './scrollLock';
+
+describe('acquireScrollLock', () => {
+  afterEach(() => {
+    document.body.style.overflow = '';
+  });
+
+  it('keeps the body locked until the last holder releases', () => {
+    const releaseDrawer = acquireScrollLock();
+    const releaseDialog = acquireScrollLock();
+    expect(document.body.style.overflow).toBe('hidden');
+    expect(scrollLockHolders()).toBe(2);
+
+    releaseDialog();
+    expect(document.body.style.overflow).toBe('hidden');
+
+    releaseDrawer();
+    expect(document.body.style.overflow).toBe('');
+    expect(scrollLockHolders()).toBe(0);
+  });
+
+  it('ignores a double release', () => {
+    const release = acquireScrollLock();
+    release();
+    release();
+    expect(scrollLockHolders()).toBe(0);
+    expect(document.body.style.overflow).toBe('');
+  });
+});

--- a/apps/web/src/components/shared/scrollLock.ts
+++ b/apps/web/src/components/shared/scrollLock.ts
@@ -1,0 +1,26 @@
+/**
+ * Refcounted <body> scroll lock shared by every overlay (Dialog, Drawer).
+ *
+ * Overlays nest — a ConfirmDialog opened from inside a Drawer is the common
+ * case — so each one must hold its own reference; releasing the last one
+ * restores scrolling. A per-component `document.body.style.overflow = ''`
+ * would let the page scroll behind a still-open parent overlay.
+ */
+let scrollLockCount = 0;
+
+export function acquireScrollLock(): () => void {
+  scrollLockCount++;
+  if (scrollLockCount === 1) document.body.style.overflow = 'hidden';
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    scrollLockCount--;
+    if (scrollLockCount === 0) document.body.style.overflow = '';
+  };
+}
+
+/** Test-only: number of overlays currently holding the lock. */
+export function scrollLockHolders(): number {
+  return scrollLockCount;
+}

--- a/apps/web/src/lib/i18n/translationCoverage.test.ts
+++ b/apps/web/src/lib/i18n/translationCoverage.test.ts
@@ -20,7 +20,9 @@ const namespaceDuplicateBaselines = {
     'admin.json': 25,
     'ai.json': 1,
     'alerts.json': 43,
-    'approvals.json': 0,
+    // +1: approvals charCount "{{count}}/{{max}}" is two interpolations and a
+    // slash — no wording to translate.
+    'approvals.json': 1,
     'auth.json': 14,
     'backup.json': 52,
     // +4: contract-template format strings + Portuguese cognate ("v{{number}} ·
@@ -101,7 +103,9 @@ const namespaceDuplicateBaselines = {
     'admin.json': 21,
     'ai.json': 4,
     'alerts.json': 39,
-    'approvals.json': 0,
+    // +1: approvals charCount "{{count}}/{{max}}" is two interpolations and a
+    // slash — no wording to translate.
+    'approvals.json': 1,
     'auth.json': 14,
     'backup.json': 30,
     // +3: contract-template format strings ("v{{number}} · {{status}}",
@@ -183,7 +187,9 @@ const namespaceDuplicateBaselines = {
     'admin.json': 34,
     'ai.json': 9,
     'alerts.json': 58,
-    'approvals.json': 0,
+    // +1: approvals charCount "{{count}}/{{max}}" is two interpolations and a
+    // slash — no wording to translate.
+    'approvals.json': 1,
     'auth.json': 13,
     'backup.json': 59,
     // +7: contract-template format strings + French cognates ("v{{number}} ·
@@ -278,7 +284,9 @@ const namespaceDuplicateBaselines = {
     'admin.json': 34,
     'ai.json': 9,
     'alerts.json': 59,
-    'approvals.json': 0,
+    // +1: approvals charCount "{{count}}/{{max}}" is two interpolations and a
+    // slash — no wording to translate.
+    'approvals.json': 1,
     'auth.json': 13,
     'backup.json': 60,
     // Contract-template format strings, French cognates, and locale-invariant
@@ -367,7 +375,9 @@ const namespaceDuplicateBaselines = {
     'admin.json': 31,
     'ai.json': 5,
     'alerts.json': 46,
-    'approvals.json': 0,
+    // +1: approvals charCount "{{count}}/{{max}}" is two interpolations and a
+    // slash — no wording to translate.
+    'approvals.json': 1,
     'auth.json': 15,
     'backup.json': 63,
     // +6: contract-template format strings + German cognates ("v{{number}} ·
@@ -447,7 +457,9 @@ const namespaceDuplicateBaselines = {
     'admin.json': 38,
     'ai.json': 12,
     'alerts.json': 57,
-    'approvals.json': 0,
+    // +1: approvals charCount "{{count}}/{{max}}" is two interpolations and a
+    // slash — no wording to translate.
+    'approvals.json': 1,
     'auth.json': 21,
     'backup.json': 45,
     // +1: unassigned.qtyPrice "{{qty}} × {{price}}" is two interpolations plus a
@@ -512,7 +524,9 @@ const namespaceDuplicateBaselines = {
     'admin.json': 19,
     'ai.json': 1,
     'alerts.json': 25,
-    'approvals.json': 0,
+    // +1: approvals charCount "{{count}}/{{max}}" is two interpolations and a
+    // slash — no wording to translate.
+    'approvals.json': 1,
     'auth.json': 14,
     'backup.json': 25,
     // +1: the quote/invoice bulk-result strings ("{{succeeded}} {{verb}}") are

--- a/apps/web/src/locales/de-DE/approvals.json
+++ b/apps/web/src/locales/de-DE/approvals.json
@@ -31,6 +31,16 @@
   "deciding": "Wird gesendet…",
   "expiresIn": "Läuft in {{minutes}} Min. ab",
   "expiresSoon": "Läuft in weniger als einer Minute ab",
+  "expired": "Abgelaufen",
+  "unknownOrganization": "Unbekannte Organisation",
+  "charCount": "{{count}}/{{max}}",
+  "approveToast": "{{action}} für {{org}} genehmigt",
+  "pagination": {
+    "showing": "{{shown}} von {{total}} werden angezeigt",
+    "showingCount": "{{shown}} werden angezeigt",
+    "loadMore": "Mehr laden",
+    "loadMoreError": "Weitere Elemente konnten nicht geladen werden. Versuchen Sie es erneut."
+  },
   "errors": {
     "noApproverDevice": "Registrieren Sie in Ihrem Profil ein Genehmigungsgerät und versuchen Sie es erneut.",
     "notSoleApprover": "Eine andere berechtigte Person muss diese Anfrage genehmigen.",

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -1,4 +1,39 @@
 {
+  "aiAgentsRuns": {
+    "live": {
+      "label": "Wird live aktualisiert"
+    },
+    "list": {
+      "clearFilters": "Filter zurücksetzen",
+      "emptyDescription": "Läufe, die durch Warnungen, Zeitpläne, Tickets und manuelle Aktionen ausgelöst werden, werden hier angezeigt, sobald ein Agent sie ausführt.",
+      "emptyFilteredDescription": "Keine Läufe entsprechen diesen Filtern. Versuchen Sie einen anderen Agenten oder Status.",
+      "emptyConfigureLink": "KI-Agenten konfigurieren"
+    },
+    "detail": {
+      "notFoundDescription": "Dieser Lauf wurde möglicherweise gelöscht, oder der Link ist veraltet.",
+      "trace": {
+        "emptyDescription": "Tool-Aufrufe, die der Agent vorschlägt oder ausführt, werden hier aufgelistet."
+      },
+      "ledger": {
+        "emptyDescription": "Tools, die der Agent tatsächlich aufgerufen hat, werden hier aufgelistet.",
+        "statuses": {
+          "pending": "Ausstehend",
+          "approved": "Genehmigt",
+          "executing": "Wird ausgeführt",
+          "completed": "Abgeschlossen",
+          "failed": "Fehlgeschlagen",
+          "rejected": "Abgelehnt"
+        }
+      },
+      "intents": {
+        "emptyDescription": "Genehmigungen, die dieser Lauf angefordert hat, werden hier aufgelistet."
+      },
+      "triage": {
+        "categoryLabel": "Kategorie",
+        "categoryUnresolved": "Vorgeschlagen — Name in dieser Ansicht nicht verfügbar"
+      }
+    }
+  },
   "partnerServicePrincipals": {
     "title": "Dienstprinzipale",
     "description": "Partnerweite Maschinenidentitäten und ihre Zugriffsschlüssel verwalten.",
@@ -1380,7 +1415,7 @@
       "deleteOverride": "Ausnahme entfernen",
       "confirmDelete": "Löschen bestätigen",
       "cron": "Cron-Ausdruck",
-      "cronHint": "Fünf Felder: Minute Stunde Tag-des-Monats Monat Wochentag. Beispiel: 0 3 * * * läuft täglich um 03:00 Uhr.",
+      "cronHint": "Fünf Felder: Minute Stunde Tag-des-Monats Monat Wochentag. Beispiel: 0 3 * * * läuft täglich um 03:00 Uhr. Das Minutenfeld muss eine literale Zahl oder eine durch Kommas getrennte Liste sein (kein *, / oder -Bereich) — Zeitpläne laufen höchstens stündlich.",
       "cronInvalid": "Geben Sie vor dem Speichern einen gültigen Cron-Ausdruck mit fünf Feldern ein.",
       "timezone": "Zeitzone",
       "kinds": {
@@ -1400,6 +1435,9 @@
       "tightenOnly": "Eine Ausnahme kann die Basis nur einschränken: Sie kann den Sweep deaktivieren oder Prüfungen entfernen, aber nie hinzufügen.",
       "noKinds": "Keine Prüfungen",
       "lastRun": "Letzter Lauf {{at}} · {{admitted}} von {{total}} Organisationen geprüft, {{skipped}} übersprungen.",
+      "nextRun": "Nächster Lauf {{at}} ({{timezone}})",
+      "nextRunInvalid": "Ungültiger Zeitplan",
+      "nextRunNone": "Im nächsten Jahr fällt kein Lauf an.",
       "kindLabels": {
         "disk_pressure": "Speicherplatzdruck",
         "stale_agents": "Veraltete Agenten",
@@ -1432,6 +1470,26 @@
     "title": "KI-Agenten",
     "description": "Benannte KI-Mitarbeiter mit einer Richtlinie. Partner legen die Grundlinie fest; Organisationen können sie nur verschärfen.",
     "empty": "Noch keine Agenten vorhanden.",
+    "kindHints": {
+      "triage": "Untersucht neue Warnungen und schlägt vor, was zu tun ist.",
+      "patch": "Prüft fehlende Patches und schlägt vor, was installiert werden soll.",
+      "helpdesk": "Nimmt Tickets auf und schlägt Antworten und nächste Schritte vor."
+    },
+    "emptyState": {
+      "title": "Noch keine Agenten",
+      "description": "Ein Agent ist eine gespeicherte Richtlinie, kein laufender Prozess: Er beobachtet die von Ihnen gewählten Warnungen, Patches oder Tickets, untersucht sie mit den von Ihnen erlaubten Werkzeugen und schlägt danach eine Lösung vor oder führt sie aus. Beginnen Sie im Schattenmodus, in dem der Agent vorschlägt und ein Mensch genehmigt, damit nichts ein Gerät erreicht, bevor Sie es sagen.",
+      "action": "Ersten Agenten erstellen"
+    },
+    "modeChoice": {
+      "legend": "Was dieser Agent tun darf",
+      "off": "Aus",
+      "offConsequence": "Es läuft nichts.",
+      "shadow": "Schatten",
+      "shadowConsequence": "Beobachtet und schlägt vor; ein Mensch genehmigt alles.",
+      "act": "Aktion",
+      "actConsequence": "Führt erlaubte Vorgänge ohne Klick aus. Kein automatisches Zurücksetzen.",
+      "actUnavailable": "Für diesen Agenten noch nicht verfügbar."
+    },
     "allOrgs": "Alle Organisationen",
     "allOrgsHint": "Partnerweit: gilt für jede Organisation, sofern eine Organisation die Richtlinie nicht verschärft.",
     "stateEnabled": "Aktiviert",
@@ -1477,8 +1535,11 @@
     "sections": {
       "scope": "Wann er ausgeführt wird",
       "permissions": "Berechtigungen",
+      "permissionsDescription": "Worauf dieser Agent zugreifen darf. Die Werkzeugliste erweitert seine Möglichkeiten; geschützte Ressourcen schränken sie ein und haben immer Vorrang.",
       "policyDecide": "Unbeaufsichtigte Richtlinienautorisierung",
       "limits": "Grenzwerte",
+      "limitsBudget": "Budget und Reichweite",
+      "limitsTiming": "Zeitverhalten",
       "notifications": "Benachrichtigungen",
       "instructions": "Anweisungen"
     },
@@ -1536,7 +1597,12 @@
       "supervisedActionKeysEmpty": "Es sind keine per Richtlinie entscheidbaren Aktionen registriert.",
       "supervisedActionKeysFailed": "Die Liste der per Richtlinie entscheidbaren Aktionen konnte nicht geladen werden, daher kann die unbeaufsichtigte Autorisierung derzeit nicht geändert werden.",
       "ticketAutonomousWrites": "Autonome Ticket-Schreibvorgänge",
-      "ticketAutonomousWritesHint": "Nur Organisationsüberschreibung — autonome Ticket-Schreibvorgänge erfordern den Aktionsmodus und diese Opt-in-Einstellung auf Organisationsebene"
+      "ticketAutonomousWritesHint": "Nur Organisationsüberschreibung — autonome Ticket-Schreibvorgänge erfordern den Aktionsmodus und diese Opt-in-Einstellung auf Organisationsebene",
+      "enabledHint": "„Aktiviert“ und der Modus sind getrennte Schalter, und ein Lauf braucht beide: Ist dies aus, läuft unabhängig vom Modus nichts, und im Modus „Aus“ läuft auch dann nichts, wenn dies eingeschaltet ist.",
+      "actKeysCleared": "Die Berechtigungen des Aktionsmodus bleiben erhalten, werden aber erst gespeichert, wenn dieser Agent wieder in den Aktionsmodus wechselt.",
+      "toolSuggestLabel": "Bekanntes Werkzeug hinzufügen",
+      "toolSuggestHint": "Die Vorschläge stammen aus dem Register richtlinienentscheidbarer Aktionen und sind nicht die vollständige Werkzeugliste. Alles andere, was dieser Agent nutzen darf, kann oben weiterhin eingetippt werden.",
+      "toolSuggestAdd": "Hinzufügen"
     },
     "loading": "Agenten werden geladen …",
     "runs": {
@@ -1781,6 +1847,7 @@
       "refresh": "Aktualisieren",
       "refreshing": "Wird neu aufgebaut…",
       "retry": "Erneut versuchen",
+      "moreActions": "Weitere Aktionen",
       "errors": {
         "load": "Der Wirkungsbericht konnte nicht geladen werden.",
         "rebuild": "Der Neuaufbau des Wirkungsberichts konnte nicht eingeplant werden.",
@@ -1793,6 +1860,15 @@
         "rebuildComplete": "Der Wirkungsbericht wurde neu aufgebaut.",
         "rebuildStillRunning": "Der Neuaufbau läuft noch. Laden Sie diese Seite in einigen Minuten neu, um die neuen Zahlen zu sehen."
       },
+      "emptyState": {
+        "title": "Noch keine KI-Ergebnisse in diesem Zeitraum",
+        "description": "Ergebnisse erscheinen hier, sobald Ihre KI-Agenten im Beobachtungs- oder Aktionsmodus eine Warnmeldung bewerten, ein Ticket sortieren oder eine Behebung ausführen. Erweitern Sie oben den Berichtszeitraum, oder richten Sie einen Agenten ein, um loszulegen.",
+        "action": "Agenten einrichten"
+      },
+      "tileGroups": {
+        "judged": "Bewertet",
+        "executed": "Ausgeführt"
+      },
       "tiles": {
         "alertsJudged": "Bewertete Warnmeldungen",
         "noiseFlagged": "Als Rauschen markiert",
@@ -1800,9 +1876,11 @@
         "draftsSent": "Gesendete Entwürfe",
         "fixesExecuted": "Ausgeführte Behebungen",
         "promoteEligible": "Für Freigabe geeignete Vorgänge",
-        "promoteEligibleHint": "Vorgänge mit ausreichend fehlerfreien Nachweisen für eine Vorabgenehmigung. Öffnen Sie Einstellungen → KI-Agenten, um sie zu prüfen und freizugeben.",
+        "promoteEligibleCaption": "Vorgänge mit ausreichend fehlerfreien Nachweisen für eine Vorabgenehmigung. Öffnen Sie Einstellungen → KI-Agenten, um sie zu prüfen und freizugeben.",
         "estTimeSaved": "Geschätzte Zeitersparnis",
         "estTimeSavedValue": "{{hours}} Std.",
+        "estTimeSavedCaption": "Geschätzt anhand eines festen Zeitwerts pro Ergebnis.",
+        "howEstimatedToggle": "Wie wird das geschätzt?",
         "llmSpend": "LLM-Ausgaben"
       },
       "weightsTooltipTitle": "Nur eine Schätzung — jedem Ergebnis wird ein fester Zeitwert gutgeschrieben:",
@@ -1886,6 +1964,8 @@
       "loading": "Nachweise werden geladen…",
       "error": "Die Nachweise konnten nicht geladen werden.",
       "retry": "Erneut versuchen",
+      "noBaselineTitle": "Noch kein Basis-Agent",
+      "noBaseline": "Die Nachverfolgung der Freigabestufen beginnt erst, sobald ein partnerweiter Basis-Agent dieser Art existiert. Erstellen Sie einen mit dem Geltungsbereich „Alle Organisationen“, um die Nachweise für diese Organisation zu erfassen.",
       "orgRequired": "Wählen Sie in der Organisationsauswahl eine einzelne Organisation aus, um deren Nachweise zu sehen.",
       "empty": "Für diesen Agenten wurden noch keine Nachweise erfasst.",
       "readOnlyNote": "Vorab genehmigte Ausführung ist in dieser Installation deaktiviert; diese Zahlen dienen nur zur Information.",
@@ -1894,6 +1974,22 @@
       "approvalsLink": "Diesen Antrag im Genehmigungseingang verfolgen",
       "ceilingHint": "Schlüssel auf Partnerebene sind eine Obergrenze, keine Erteilung. Der Agent jeder Organisation muss den Schlüssel gesondert erhalten — über die Freigabestufe oder durch Bearbeiten des Agenten dieser Organisation.",
       "promote": "Hochstufen",
+      "revoke": "Widerrufen",
+      "emptyTitle": "Noch keine Nachweise",
+      "demotedAt": "Widerrufen am {{at}}",
+      "demotedReason": "Grund: {{reason}}",
+      "demoteReasons": {
+        "attempted_failure": "ein Versuch ist fehlgeschlagen",
+        "recurrence": "die behobene Warnung ist wieder aufgetreten",
+        "operator": "eine Bedienperson hat den Vorgang widerrufen"
+      },
+      "revokeConfirm": {
+        "title": "Vorabgenehmigung widerrufen",
+        "message": "{{opKey}} kehrt für den Agenten dieser Organisation in die Genehmigungswarteschlange zurück. Ein bereits laufender Durchlauf bleibt unberührt; jeder spätere braucht wieder eine menschliche Entscheidung.",
+        "action": "Widerrufen",
+        "reasonLabel": "Grund (optional)",
+        "reasonHint": "Wird im Prüfprotokoll dieses Widerrufs festgehalten. Bis zu 500 Zeichen."
+      },
       "verifiedOfThreshold": "{{verified}} von {{threshold}}",
       "columns": {
         "opKey": "Vorgang",
@@ -1924,11 +2020,17 @@
         "action": "Genehmigung anfordern"
       },
       "toasts": {
-        "requested": "Vorabgenehmigung beantragt. Eine zweite Person muss sie genehmigen, bevor dieser Vorgang unbeaufsichtigt läuft, und sie gilt nur für künftige Läufe."
+        "requested": "Vorabgenehmigung beantragt. Eine zweite Person muss sie genehmigen, bevor dieser Vorgang unbeaufsichtigt läuft, und sie gilt nur für künftige Läufe.",
+        "revoked": "Vorabgenehmigung widerrufen. Dieser Vorgang braucht ab dem nächsten Lauf wieder eine menschliche Entscheidung."
       },
       "errors": {
         "promote": "Der Antrag auf Vorabgenehmigung konnte nicht gestellt werden.",
-        "policyDecideDisabled": "Vorab genehmigte Ausführung ist in dieser Installation deaktiviert, dieser Vorgang kann daher nicht hochgestuft werden."
+        "policyDecideDisabled": "Vorab genehmigte Ausführung ist in dieser Installation deaktiviert, dieser Vorgang kann daher nicht hochgestuft werden.",
+        "revoke": "Die Vorabgenehmigung konnte nicht widerrufen werden.",
+        "noPromotedGrant": "Dieser Vorgang ist für diese Organisation nicht vorab genehmigt, es gibt also nichts zu widerrufen.",
+        "alreadyDemoted": "Dieser Vorgang ist bereits wieder in der Genehmigungswarteschlange.",
+        "alreadyRevoked": "Dieser Vorgang war bereits vom Agenten entfernt, es hat sich nichts geändert.",
+        "ambiguousOpKey": "Mehr als ein Agent hält diesen Vorgang für diese Organisation. Öffnen Sie den gewünschten Agenten und widerrufen Sie ihn dort."
       },
       "reliability": {
         "caption": "Vorgänge im Act-Modus, nur zur Ansicht: Sie sind keine Richtlinienschlüssel und können daher nie vorab genehmigt werden."

--- a/apps/web/src/locales/en/approvals.json
+++ b/apps/web/src/locales/en/approvals.json
@@ -31,6 +31,16 @@
   "deciding": "Submitting…",
   "expiresIn": "Expires in {{minutes}} min",
   "expiresSoon": "Expires in under a minute",
+  "expired": "Expired",
+  "unknownOrganization": "Unknown organization",
+  "charCount": "{{count}}/{{max}}",
+  "approveToast": "Approved {{action}} for {{org}}",
+  "pagination": {
+    "showing": "Showing {{shown}} of {{total}}",
+    "showingCount": "Showing {{shown}}",
+    "loadMore": "Load more",
+    "loadMoreError": "Couldn't load more. Try again."
+  },
   "errors": {
     "noApproverDevice": "Register an approver device in your profile, then try again.",
     "notSoleApprover": "Another eligible approver must decide this request.",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -1,4 +1,39 @@
 {
+  "aiAgentsRuns": {
+    "live": {
+      "label": "Updating live"
+    },
+    "list": {
+      "clearFilters": "Clear filters",
+      "emptyDescription": "Runs triggered by alerts, schedules, tickets, and manual actions will appear here once an agent executes.",
+      "emptyFilteredDescription": "No runs match these filters. Try a different agent or status.",
+      "emptyConfigureLink": "Configure AI agents"
+    },
+    "detail": {
+      "notFoundDescription": "This run may have been deleted, or the link may be out of date.",
+      "trace": {
+        "emptyDescription": "Tool calls the agent proposes or executes will be listed here."
+      },
+      "ledger": {
+        "emptyDescription": "Tools the agent actually invoked will be listed here.",
+        "statuses": {
+          "pending": "Pending",
+          "approved": "Approved",
+          "executing": "Executing",
+          "completed": "Completed",
+          "failed": "Failed",
+          "rejected": "Rejected"
+        }
+      },
+      "intents": {
+        "emptyDescription": "Approvals this run requested will be listed here."
+      },
+      "triage": {
+        "categoryLabel": "Category",
+        "categoryUnresolved": "Suggested — name not available on this view"
+      }
+    }
+  },
   "partnerServicePrincipals": {
     "title": "Service principals",
     "description": "Manage partner-scoped machine identities and their access keys.",
@@ -1380,7 +1415,7 @@
       "deleteOverride": "Remove override",
       "confirmDelete": "Confirm delete",
       "cron": "Cron expression",
-      "cronHint": "Five fields: minute hour day-of-month month day-of-week. For example 0 3 * * * runs every day at 03:00.",
+      "cronHint": "Five fields: minute hour day-of-month month day-of-week. For example 0 3 * * * runs every day at 03:00. The minute field must be a literal number or comma-separated list (no *, /, or - ranges) — schedules fire at most hourly.",
       "cronInvalid": "Enter a valid five-field cron expression before saving.",
       "timezone": "Timezone",
       "kinds": {
@@ -1400,6 +1435,9 @@
       "tightenOnly": "An override can only narrow the baseline: it may disable the sweep or drop checks, never add one.",
       "noKinds": "No checks",
       "lastRun": "Last run {{at}} · {{admitted}} of {{total}} organizations swept, {{skipped}} skipped.",
+      "nextRun": "Next run {{at}} ({{timezone}})",
+      "nextRunInvalid": "Invalid schedule",
+      "nextRunNone": "No run falls in the next year.",
       "kindLabels": {
         "disk_pressure": "Disk pressure",
         "stale_agents": "Stale agents",
@@ -1432,6 +1470,26 @@
     "title": "AI Agents",
     "description": "Named AI workers with a policy. Partners set the baseline; organizations can only tighten it.",
     "empty": "No agents yet.",
+    "kindHints": {
+      "triage": "Investigates new alerts and proposes what to do about them.",
+      "patch": "Reviews missing patches and proposes what to install.",
+      "helpdesk": "Picks up tickets and proposes replies and next steps."
+    },
+    "emptyState": {
+      "title": "No agents yet",
+      "description": "An agent is a saved policy, not a running process: it watches the alerts, patches or tickets you choose, investigates with the tools you allow, and then either proposes a fix or carries one out. Start in shadow mode, where the agent proposes and a person approves, so nothing reaches a device until you say so.",
+      "action": "Create your first agent"
+    },
+    "modeChoice": {
+      "legend": "What this agent may do",
+      "off": "Off",
+      "offConsequence": "Nothing runs.",
+      "shadow": "Shadow",
+      "shadowConsequence": "Observes and proposes; a human approves everything.",
+      "act": "Act",
+      "actConsequence": "Executes allowed operations without a click. No automatic rollback.",
+      "actUnavailable": "Not available for this agent yet."
+    },
     "allOrgs": "All orgs",
     "allOrgsHint": "Partner-wide: applies to every organization unless an organization tightens it.",
     "stateEnabled": "Enabled",
@@ -1477,8 +1535,11 @@
     "sections": {
       "scope": "When it runs",
       "permissions": "Permissions",
+      "permissionsDescription": "What this agent may touch. The tool allowlist widens what it can do; protected resources narrow it, and always win.",
       "policyDecide": "Unattended policy authorization",
       "limits": "Limits",
+      "limitsBudget": "Budget and reach",
+      "limitsTiming": "Timing",
       "notifications": "Notifications",
       "instructions": "Instructions"
     },
@@ -1536,7 +1597,12 @@
       "supervisedActionKeysEmpty": "No policy-decidable actions are registered.",
       "supervisedActionKeysFailed": "Couldn't load the policy-decidable action list, so unattended authorization can't be changed right now.",
       "ticketAutonomousWrites": "Autonomous ticket writes",
-      "ticketAutonomousWritesHint": "Org override only — autonomous ticket writes require act mode and this org-level opt-in"
+      "ticketAutonomousWritesHint": "Org override only — autonomous ticket writes require act mode and this org-level opt-in",
+      "enabledHint": "Enabled and the mode are separate switches and a run needs both: with this off nothing runs whatever the mode says, and in Off mode nothing runs even while this is on.",
+      "actKeysCleared": "Act-mode permissions are kept but won't be saved unless this agent returns to Act mode.",
+      "toolSuggestLabel": "Add a known tool",
+      "toolSuggestHint": "Suggestions come from the policy-decidable action registry, which is not the full list of tools. Anything else this agent may use can still be typed above.",
+      "toolSuggestAdd": "Add"
     },
     "loading": "Loading agents…",
     "runs": {
@@ -1781,6 +1847,7 @@
       "refresh": "Refresh",
       "refreshing": "Rebuilding…",
       "retry": "Try again",
+      "moreActions": "More actions",
       "errors": {
         "load": "The impact report could not be loaded.",
         "rebuild": "The impact rebuild could not be queued.",
@@ -1793,6 +1860,15 @@
         "rebuildComplete": "The impact report has been rebuilt.",
         "rebuildStillRunning": "The rebuild is still running. Reload this page in a few minutes to see the new figures."
       },
+      "emptyState": {
+        "title": "No AI outcomes in this window yet",
+        "description": "Outcomes will appear here once your AI agents judge an alert, triage a ticket, or execute a fix in shadow or act mode. Widen the reporting window above, or set up an agent to get started.",
+        "action": "Set up an agent"
+      },
+      "tileGroups": {
+        "judged": "Judged",
+        "executed": "Executed"
+      },
       "tiles": {
         "alertsJudged": "Alerts judged",
         "noiseFlagged": "Flagged as noise",
@@ -1800,9 +1876,11 @@
         "draftsSent": "Drafts sent",
         "fixesExecuted": "Fixes executed",
         "promoteEligible": "Promotion-eligible operations",
-        "promoteEligibleHint": "Operations with enough clean evidence to be pre-authorized. Open Settings → AI Agents to review and promote them.",
+        "promoteEligibleCaption": "Enough clean evidence to pre-authorize. Review and promote in AI Agents settings.",
         "estTimeSaved": "Estimated time saved",
         "estTimeSavedValue": "{{hours}} hours",
+        "estTimeSavedCaption": "Estimated from a fixed time allowance per outcome.",
+        "howEstimatedToggle": "How is this estimated?",
         "llmSpend": "LLM spend"
       },
       "weightsTooltipTitle": "An estimate only — each outcome is credited with a fixed allowance:",
@@ -1886,6 +1964,8 @@
       "loading": "Loading graduation evidence…",
       "error": "The graduation evidence could not be loaded.",
       "retry": "Try again",
+      "noBaselineTitle": "No baseline agent yet",
+      "noBaseline": "Graduation tracking starts once a partner-wide baseline agent of this kind exists. Create one with the \"All organizations\" scope to begin tracking evidence for this org.",
       "orgRequired": "Choose a single organization in the organization switcher to see its graduation evidence.",
       "empty": "No evidence has been recorded for this agent yet.",
       "readOnlyNote": "Pre-authorized execution is turned off for this deployment; these figures are informational.",
@@ -1894,6 +1974,22 @@
       "approvalsLink": "Track this request in the approvals inbox",
       "ceilingHint": "Partner-level keys are a ceiling, not a grant. Each organization's agent must be granted the key separately — through graduation or by editing that organization's agent.",
       "promote": "Promote",
+      "revoke": "Revoke",
+      "emptyTitle": "No evidence yet",
+      "demotedAt": "Revoked {{at}}",
+      "demotedReason": "Reason: {{reason}}",
+      "demoteReasons": {
+        "attempted_failure": "an attempt failed",
+        "recurrence": "the alert it fixed came back",
+        "operator": "an operator revoked it"
+      },
+      "revokeConfirm": {
+        "title": "Revoke pre-authorization",
+        "message": "{{opKey}} goes back to the approval queue for this organization's agent. A run already under way is unaffected; every later one needs a human decision again.",
+        "action": "Revoke",
+        "reasonLabel": "Reason (optional)",
+        "reasonHint": "Recorded on the audit entry for this revocation. Up to 500 characters."
+      },
       "verifiedOfThreshold": "{{verified}} of {{threshold}}",
       "columns": {
         "opKey": "Operation",
@@ -1924,11 +2020,17 @@
         "action": "Request approval"
       },
       "toasts": {
-        "requested": "Pre-authorization requested. A second approver has to approve it before this operation runs unattended, and it applies to future runs only."
+        "requested": "Pre-authorization requested. A second approver has to approve it before this operation runs unattended, and it applies to future runs only.",
+        "revoked": "Pre-authorization revoked. This operation needs a human decision again, starting with the next run."
       },
       "errors": {
         "promote": "The pre-authorization request could not be raised.",
-        "policyDecideDisabled": "Pre-authorized execution is turned off for this deployment, so this operation cannot be promoted."
+        "policyDecideDisabled": "Pre-authorized execution is turned off for this deployment, so this operation cannot be promoted.",
+        "revoke": "The pre-authorization could not be revoked.",
+        "noPromotedGrant": "This operation is not pre-authorized for this organization, so there is nothing to revoke.",
+        "alreadyDemoted": "This operation is already back in the approval queue.",
+        "alreadyRevoked": "This operation had already been removed from the agent, so nothing changed.",
+        "ambiguousOpKey": "More than one agent holds this operation for this organization. Open the agent you want to change and revoke it there."
       },
       "reliability": {
         "caption": "Act-mode operations, read-only: these are not policy keys, so they can never be pre-authorized."

--- a/apps/web/src/locales/es-419/approvals.json
+++ b/apps/web/src/locales/es-419/approvals.json
@@ -31,6 +31,16 @@
   "deciding": "Enviando…",
   "expiresIn": "Vence en {{minutes}} min",
   "expiresSoon": "Vence en menos de un minuto",
+  "expired": "Vencida",
+  "unknownOrganization": "Organización desconocida",
+  "charCount": "{{count}}/{{max}}",
+  "approveToast": "Se aprobó {{action}} para {{org}}",
+  "pagination": {
+    "showing": "Mostrando {{shown}} de {{total}}",
+    "showingCount": "Mostrando {{shown}}",
+    "loadMore": "Cargar más",
+    "loadMoreError": "No se pudo cargar más. Inténtalo de nuevo."
+  },
   "errors": {
     "noApproverDevice": "Registra un dispositivo de aprobación en tu perfil y vuelve a intentarlo.",
     "notSoleApprover": "Otra persona autorizada debe decidir sobre esta solicitud.",

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -1,4 +1,39 @@
 {
+  "aiAgentsRuns": {
+    "live": {
+      "label": "Actualizando en vivo"
+    },
+    "list": {
+      "clearFilters": "Borrar filtros",
+      "emptyDescription": "Las ejecuciones activadas por alertas, horarios, tickets y acciones manuales aparecerán aquí una vez que un agente las ejecute.",
+      "emptyFilteredDescription": "Ninguna ejecución coincide con estos filtros. Prueba con otro agente o estado.",
+      "emptyConfigureLink": "Configurar agentes de IA"
+    },
+    "detail": {
+      "notFoundDescription": "Es posible que esta ejecución se haya eliminado, o que el enlace esté desactualizado.",
+      "trace": {
+        "emptyDescription": "Las llamadas a herramientas que el agente proponga o ejecute se mostrarán aquí."
+      },
+      "ledger": {
+        "emptyDescription": "Las herramientas que el agente realmente invocó se mostrarán aquí.",
+        "statuses": {
+          "pending": "Pendiente",
+          "approved": "Aprobado",
+          "executing": "Ejecutando",
+          "completed": "Completado",
+          "failed": "Fallido",
+          "rejected": "Rechazado"
+        }
+      },
+      "intents": {
+        "emptyDescription": "Las aprobaciones solicitadas por esta ejecución se mostrarán aquí."
+      },
+      "triage": {
+        "categoryLabel": "Categoría",
+        "categoryUnresolved": "Sugerido — nombre no disponible en esta vista"
+      }
+    }
+  },
   "partnerServicePrincipals": {
     "title": "Principales de servicio",
     "description": "Administra identidades de máquina a nivel de partner y sus claves de acceso.",
@@ -1380,7 +1415,7 @@
       "deleteOverride": "Quitar excepción",
       "confirmDelete": "Confirmar eliminación",
       "cron": "Expresión cron",
-      "cronHint": "Cinco campos: minuto hora día-del-mes mes día-de-la-semana. Por ejemplo, 0 3 * * * se ejecuta todos los días a las 03:00.",
+      "cronHint": "Cinco campos: minuto hora día-del-mes mes día-de-la-semana. Por ejemplo, 0 3 * * * se ejecuta todos los días a las 03:00. El campo de minutos debe ser un número literal o una lista separada por comas (sin *, / ni rango -); los horarios se ejecutan como máximo cada hora.",
       "cronInvalid": "Ingresa una expresión cron válida de cinco campos antes de guardar.",
       "timezone": "Zona horaria",
       "kinds": {
@@ -1400,6 +1435,9 @@
       "tightenOnly": "Una excepción solo puede restringir la línea base: puede desactivar el barrido o quitar comprobaciones, nunca agregarlas.",
       "noKinds": "Sin comprobaciones",
       "lastRun": "Última ejecución {{at}} · {{admitted}} de {{total}} organizaciones barridas, {{skipped}} omitidas.",
+      "nextRun": "Próxima ejecución {{at}} ({{timezone}})",
+      "nextRunInvalid": "Programación no válida",
+      "nextRunNone": "No hay ninguna ejecución en el próximo año.",
       "kindLabels": {
         "disk_pressure": "Presión de disco",
         "stale_agents": "Agentes obsoletos",
@@ -1432,6 +1470,26 @@
     "title": "Agentes de IA",
     "description": "Trabajadores de IA con nombre y una política. Los partners definen la línea base; las organizaciones solo pueden restringirla.",
     "empty": "Aún no hay agentes.",
+    "kindHints": {
+      "triage": "Investiga las alertas nuevas y propone qué hacer con ellas.",
+      "patch": "Revisa los parches faltantes y propone qué instalar.",
+      "helpdesk": "Toma tickets y propone respuestas y próximos pasos."
+    },
+    "emptyState": {
+      "title": "Aún no hay agentes",
+      "description": "Un agente es una política guardada, no un proceso en ejecución: observa las alertas, los parches o los tickets que elija, investiga con las herramientas que permita y luego propone una solución o la ejecuta. Empiece en modo sombra, donde el agente propone y una persona aprueba, así nada llega a un dispositivo hasta que usted lo diga.",
+      "action": "Cree su primer agente"
+    },
+    "modeChoice": {
+      "legend": "Qué puede hacer este agente",
+      "off": "Apagado",
+      "offConsequence": "No se ejecuta nada.",
+      "shadow": "Sombra",
+      "shadowConsequence": "Observa y propone; una persona aprueba todo.",
+      "act": "Actuación",
+      "actConsequence": "Ejecuta las operaciones permitidas sin un clic. No hay reversión automática.",
+      "actUnavailable": "Todavía no está disponible para este agente."
+    },
     "allOrgs": "Todas las organizaciones",
     "allOrgsHint": "Para todo el partner: se aplica a cada organización, salvo que una organización la restrinja.",
     "stateEnabled": "Habilitado",
@@ -1477,8 +1535,11 @@
     "sections": {
       "scope": "Cuándo se ejecuta",
       "permissions": "Permisos",
+      "permissionsDescription": "Qué puede tocar este agente. La lista de herramientas amplía lo que puede hacer; los recursos protegidos la limitan y siempre prevalecen.",
       "policyDecide": "Autorización de política no supervisada",
       "limits": "Límites",
+      "limitsBudget": "Presupuesto y alcance",
+      "limitsTiming": "Tiempos",
       "notifications": "Notificaciones",
       "instructions": "Instrucciones"
     },
@@ -1536,7 +1597,12 @@
       "supervisedActionKeysEmpty": "No hay acciones decidibles por política registradas.",
       "supervisedActionKeysFailed": "No se pudo cargar la lista de acciones decidibles por política, así que la autorización no supervisada no se puede cambiar en este momento.",
       "ticketAutonomousWrites": "Escrituras autónomas de tickets",
-      "ticketAutonomousWritesHint": "Solo anulación de la organización — las escrituras autónomas de tickets requieren el modo de actuación y esta activación a nivel de organización"
+      "ticketAutonomousWritesHint": "Solo anulación de la organización — las escrituras autónomas de tickets requieren el modo de actuación y esta activación a nivel de organización",
+      "enabledHint": "«Habilitado» y el modo son interruptores distintos y una ejecución necesita los dos: con esto apagado no se ejecuta nada sin importar el modo, y en modo Apagado no se ejecuta nada aunque esto esté encendido.",
+      "actKeysCleared": "Los permisos del modo de actuación se conservan, pero no se guardarán a menos que este agente vuelva al modo de actuación.",
+      "toolSuggestLabel": "Agregar una herramienta conocida",
+      "toolSuggestHint": "Las sugerencias vienen del registro de acciones decidibles por política, que no es la lista completa de herramientas. Cualquier otra que este agente pueda usar todavía se puede escribir arriba.",
+      "toolSuggestAdd": "Agregar"
     },
     "loading": "Cargando agentes…",
     "runs": {
@@ -1781,6 +1847,7 @@
       "refresh": "Actualizar",
       "refreshing": "Reconstruyendo…",
       "retry": "Reintentar",
+      "moreActions": "Más acciones",
       "errors": {
         "load": "No se pudo cargar el informe de impacto.",
         "rebuild": "No se pudo poner en cola la reconstrucción del informe.",
@@ -1793,6 +1860,15 @@
         "rebuildComplete": "El informe de impacto se reconstruyó.",
         "rebuildStillRunning": "La reconstrucción sigue en curso. Vuelva a cargar esta página en unos minutos para ver las cifras nuevas."
       },
+      "emptyState": {
+        "title": "Aún no hay resultados de IA en este período",
+        "description": "Los resultados aparecerán aquí en cuanto sus agentes de IA evalúen una alerta, clasifiquen un ticket o ejecuten una corrección en modo de observación o de acción. Amplíe el período de informe arriba, o configure un agente para comenzar.",
+        "action": "Configurar un agente"
+      },
+      "tileGroups": {
+        "judged": "Evaluados",
+        "executed": "Ejecutados"
+      },
       "tiles": {
         "alertsJudged": "Alertas evaluadas",
         "noiseFlagged": "Marcadas como ruido",
@@ -1800,9 +1876,11 @@
         "draftsSent": "Borradores enviados",
         "fixesExecuted": "Correcciones ejecutadas",
         "promoteEligible": "Operaciones aptas para promoción",
-        "promoteEligibleHint": "Operaciones con evidencia suficiente y sin fallas para autorizarse previamente. Abre Configuración → Agentes de IA para revisarlas y promoverlas.",
+        "promoteEligibleCaption": "Operaciones con evidencia suficiente y sin fallas para autorizarse previamente. Abre Configuración → Agentes de IA para revisarlas y promoverlas.",
         "estTimeSaved": "Tiempo ahorrado estimado",
         "estTimeSavedValue": "{{hours}} horas",
+        "estTimeSavedCaption": "Estimado a partir de un tiempo fijo por resultado.",
+        "howEstimatedToggle": "¿Cómo se estima esto?",
         "llmSpend": "Gasto en LLM"
       },
       "weightsTooltipTitle": "Solo es una estimación: a cada resultado se le acredita un tiempo fijo:",
@@ -1886,6 +1964,8 @@
       "loading": "Cargando la evidencia de graduación…",
       "error": "No se pudo cargar la evidencia de graduación.",
       "retry": "Reintentar",
+      "noBaselineTitle": "Todavía no hay un agente base",
+      "noBaseline": "El seguimiento de graduación comienza cuando existe un agente base de todo el partner de este tipo. Crea uno con el alcance \"Todas las organizaciones\" para empezar a registrar evidencia de esta organización.",
       "orgRequired": "Elige una sola organización en el selector de organizaciones para ver su evidencia de graduación.",
       "empty": "Todavía no se registró evidencia para este agente.",
       "readOnlyNote": "La ejecución preautorizada está desactivada en esta instalación; estas cifras son solo informativas.",
@@ -1894,6 +1974,22 @@
       "approvalsLink": "Seguir esta solicitud en la bandeja de aprobaciones",
       "ceilingHint": "Las claves del nivel de socio son un techo, no una concesión. El agente de cada organización debe recibir la clave por separado: mediante la graduación o editando el agente de esa organización.",
       "promote": "Promover",
+      "revoke": "Revocar",
+      "emptyTitle": "Todavía no hay evidencia",
+      "demotedAt": "Revocado el {{at}}",
+      "demotedReason": "Motivo: {{reason}}",
+      "demoteReasons": {
+        "attempted_failure": "un intento falló",
+        "recurrence": "la alerta que corrigió volvió a aparecer",
+        "operator": "una persona operadora lo revocó"
+      },
+      "revokeConfirm": {
+        "title": "Revocar la preautorización",
+        "message": "{{opKey}} vuelve a la cola de aprobación del agente de esta organización. Una ejecución en curso no se ve afectada; cada una posterior vuelve a necesitar una decisión humana.",
+        "action": "Revocar",
+        "reasonLabel": "Motivo (opcional)",
+        "reasonHint": "Se registra en la entrada de auditoría de esta revocación. Hasta 500 caracteres."
+      },
       "verifiedOfThreshold": "{{verified}} de {{threshold}}",
       "columns": {
         "opKey": "Operación",
@@ -1924,11 +2020,17 @@
         "action": "Solicitar aprobación"
       },
       "toasts": {
-        "requested": "Preautorización solicitada. Una segunda persona debe aprobarla antes de que esta operación se ejecute sin supervisión, y se aplica solo a ejecuciones futuras."
+        "requested": "Preautorización solicitada. Una segunda persona debe aprobarla antes de que esta operación se ejecute sin supervisión, y se aplica solo a ejecuciones futuras.",
+        "revoked": "Preautorización revocada. Esta operación vuelve a necesitar una decisión humana a partir de la próxima ejecución."
       },
       "errors": {
         "promote": "No se pudo presentar la solicitud de preautorización.",
-        "policyDecideDisabled": "La ejecución preautorizada está desactivada en esta instalación, así que esta operación no puede promoverse."
+        "policyDecideDisabled": "La ejecución preautorizada está desactivada en esta instalación, así que esta operación no puede promoverse.",
+        "revoke": "No se pudo revocar la preautorización.",
+        "noPromotedGrant": "Esta operación no está preautorizada para esta organización, así que no hay nada que revocar.",
+        "alreadyDemoted": "Esta operación ya está de vuelta en la cola de aprobación.",
+        "alreadyRevoked": "Esta operación ya se había quitado del agente, así que nada cambió.",
+        "ambiguousOpKey": "Más de un agente tiene esta operación para esta organización. Abra el agente que quiera cambiar y revóquela allí."
       },
       "reliability": {
         "caption": "Operaciones del modo de acción, solo lectura: no son claves de política, así que nunca pueden preautorizarse."

--- a/apps/web/src/locales/fr-CA/approvals.json
+++ b/apps/web/src/locales/fr-CA/approvals.json
@@ -31,6 +31,16 @@
   "deciding": "Envoi en cours…",
   "expiresIn": "Expire dans {{minutes}} min",
   "expiresSoon": "Expire dans moins d’une minute",
+  "expired": "Expirée",
+  "unknownOrganization": "Organisation inconnue",
+  "charCount": "{{count}}/{{max}}",
+  "approveToast": "{{action}} approuvé pour {{org}}",
+  "pagination": {
+    "showing": "Affichage de {{shown}} sur {{total}}",
+    "showingCount": "Affichage de {{shown}}",
+    "loadMore": "Charger plus",
+    "loadMoreError": "Impossible de charger plus d’éléments. Réessayez."
+  },
   "errors": {
     "noApproverDevice": "Enregistrez un appareil d’approbation dans votre profil, puis réessayez.",
     "notSoleApprover": "Une autre personne autorisée doit décider de cette demande.",

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -1,4 +1,39 @@
 {
+  "aiAgentsRuns": {
+    "live": {
+      "label": "Mise à jour en direct"
+    },
+    "list": {
+      "clearFilters": "Effacer les filtres",
+      "emptyDescription": "Les exécutions déclenchées par des alertes, des horaires, des billets et des actions manuelles apparaîtront ici une fois qu'un agent les aura exécutées.",
+      "emptyFilteredDescription": "Aucune exécution ne correspond à ces filtres. Essayez un autre agent ou statut.",
+      "emptyConfigureLink": "Configurer les agents IA"
+    },
+    "detail": {
+      "notFoundDescription": "Cette exécution a peut-être été supprimée, ou le lien est désuet.",
+      "trace": {
+        "emptyDescription": "Les appels d'outils que l'agent propose ou exécute seront répertoriés ici."
+      },
+      "ledger": {
+        "emptyDescription": "Les outils réellement invoqués par l'agent seront répertoriés ici.",
+        "statuses": {
+          "pending": "En attente",
+          "approved": "Approuvé",
+          "executing": "En cours d'exécution",
+          "completed": "Terminé",
+          "failed": "Échoué",
+          "rejected": "Rejeté"
+        }
+      },
+      "intents": {
+        "emptyDescription": "Les approbations demandées par cette exécution seront répertoriées ici."
+      },
+      "triage": {
+        "categoryLabel": "Catégorie",
+        "categoryUnresolved": "Suggéré — nom non disponible dans cette vue"
+      }
+    }
+  },
   "partnerServicePrincipals": {
     "title": "Principaux de service",
     "description": "Gérez les identités machines au niveau du partenaire et leurs clés d'accès.",
@@ -1380,7 +1415,7 @@
       "deleteOverride": "Retirer la dérogation",
       "confirmDelete": "Confirmer la suppression",
       "cron": "Expression cron",
-      "cronHint": "Cinq champs : minute heure jour-du-mois mois jour-de-la-semaine. Par exemple, 0 3 * * * s'exécute chaque jour à 3 h.",
+      "cronHint": "Cinq champs : minute heure jour-du-mois mois jour-de-la-semaine. Par exemple, 0 3 * * * s'exécute chaque jour à 3 h. Le champ des minutes doit être un nombre littéral ou une liste séparée par des virgules (sans *, / ni plage -) — les horaires s'exécutent au plus une fois par heure.",
       "cronInvalid": "Saisissez une expression cron valide à cinq champs avant d'enregistrer.",
       "timezone": "Fuseau horaire",
       "kinds": {
@@ -1400,6 +1435,9 @@
       "tightenOnly": "Une dérogation ne peut que restreindre la référence : elle peut désactiver le balayage ou retirer des contrôles, jamais en ajouter.",
       "noKinds": "Aucun contrôle",
       "lastRun": "Dernière exécution {{at}} · {{admitted}} organisations balayées sur {{total}}, {{skipped}} ignorées.",
+      "nextRun": "Prochaine exécution {{at}} ({{timezone}})",
+      "nextRunInvalid": "Horaire invalide",
+      "nextRunNone": "Aucune exécution dans la prochaine année.",
       "kindLabels": {
         "disk_pressure": "Pression sur le disque",
         "stale_agents": "Agents obsolètes",
@@ -1432,6 +1470,26 @@
     "title": "Agents IA",
     "description": "Des travailleurs IA nommés, dotés d’une politique. Les partenaires définissent la référence ; les organisations peuvent seulement la restreindre.",
     "empty": "Aucun agent pour l’instant.",
+    "kindHints": {
+      "triage": "Examine les nouvelles alertes et propose quoi faire.",
+      "patch": "Revoit les correctifs manquants et propose quoi installer.",
+      "helpdesk": "Prend les billets en charge et propose des réponses et des prochaines étapes."
+    },
+    "emptyState": {
+      "title": "Aucun agent pour l’instant",
+      "description": "Un agent est une politique enregistrée, pas un processus en cours : il surveille les alertes, les correctifs ou les billets que vous choisissez, enquête avec les outils que vous autorisez, puis propose une correction ou l’applique. Commencez en mode ombre, où l’agent propose et une personne approuve, pour que rien n’atteigne un appareil avant que vous le disiez.",
+      "action": "Créer votre premier agent"
+    },
+    "modeChoice": {
+      "legend": "Ce que cet agent peut faire",
+      "off": "Désactivé",
+      "offConsequence": "Rien ne s’exécute.",
+      "shadow": "Ombre",
+      "shadowConsequence": "Observe et propose; une personne approuve tout.",
+      "act": "Action",
+      "actConsequence": "Exécute les opérations autorisées sans clic. Aucune annulation automatique.",
+      "actUnavailable": "Pas encore disponible pour cet agent."
+    },
     "allOrgs": "Toutes les organisations",
     "allOrgsHint": "À l’échelle du partenaire : s’applique à chaque organisation, sauf si une organisation la restreint.",
     "stateEnabled": "Activé",
@@ -1477,8 +1535,11 @@
     "sections": {
       "scope": "Quand il s’exécute",
       "permissions": "Autorisations",
+      "permissionsDescription": "Ce que cet agent peut toucher. La liste d’outils élargit ce qu’il peut faire; les ressources protégées la restreignent et l’emportent toujours.",
       "policyDecide": "Autorisation de politique sans surveillance",
       "limits": "Limites",
+      "limitsBudget": "Budget et portée",
+      "limitsTiming": "Durées",
       "notifications": "Notifications",
       "instructions": "Directives"
     },
@@ -1536,7 +1597,12 @@
       "supervisedActionKeysEmpty": "Aucune action décidable par politique n’est enregistrée.",
       "supervisedActionKeysFailed": "Impossible de charger la liste des actions décidables par politique ; l’autorisation sans surveillance ne peut pas être modifiée pour le moment.",
       "ticketAutonomousWrites": "Écritures autonomes de tickets",
-      "ticketAutonomousWritesHint": "Dérogation d'organisation seulement — les écritures autonomes de tickets nécessitent le mode action et cette activation au niveau de l'organisation"
+      "ticketAutonomousWritesHint": "Dérogation d'organisation seulement — les écritures autonomes de tickets nécessitent le mode action et cette activation au niveau de l'organisation",
+      "enabledHint": "« Activé » et le mode sont deux interrupteurs distincts et une exécution a besoin des deux : si ceci est désactivé, rien ne s’exécute quel que soit le mode, et en mode Désactivé rien ne s’exécute même si ceci est activé.",
+      "actKeysCleared": "Les autorisations du mode action sont conservées, mais ne seront pas enregistrées tant que cet agent ne repasse pas en mode Action.",
+      "toolSuggestLabel": "Ajouter un outil connu",
+      "toolSuggestHint": "Les suggestions proviennent du registre des actions décidables par politique, qui n’est pas la liste complète des outils. Tout autre outil permis à cet agent peut encore être saisi ci-dessus.",
+      "toolSuggestAdd": "Ajouter"
     },
     "loading": "Chargement des agents en cours…",
     "runs": {
@@ -1781,6 +1847,7 @@
       "refresh": "Actualiser",
       "refreshing": "Reconstruction en cours…",
       "retry": "Réessayer",
+      "moreActions": "Plus d’actions",
       "errors": {
         "load": "Impossible de charger le rapport d’impact.",
         "rebuild": "Impossible de mettre la reconstruction du rapport en file d’attente.",
@@ -1793,6 +1860,15 @@
         "rebuildComplete": "Le rapport d’impact a été reconstruit.",
         "rebuildStillRunning": "La reconstruction est toujours en cours. Rechargez cette page dans quelques minutes pour voir les nouveaux chiffres."
       },
+      "emptyState": {
+        "title": "Aucun résultat d’IA pour cette période",
+        "description": "Les résultats apparaîtront ici dès que vos agents IA évalueront une alerte, trieront un ticket ou appliqueront un correctif en mode observation ou action. Élargissez la période de rapport ci-dessus, ou configurez un agent pour commencer.",
+        "action": "Configurer un agent"
+      },
+      "tileGroups": {
+        "judged": "Évalués",
+        "executed": "Exécutés"
+      },
       "tiles": {
         "alertsJudged": "Alertes évaluées",
         "noiseFlagged": "Signalées comme bruit",
@@ -1800,9 +1876,11 @@
         "draftsSent": "Brouillons envoyés",
         "fixesExecuted": "Correctifs appliqués",
         "promoteEligible": "Opérations admissibles à la promotion",
-        "promoteEligibleHint": "Opérations disposant d'assez de preuves sans échec pour être préautorisées. Ouvrez Paramètres → Agents IA pour les examiner et les promouvoir.",
+        "promoteEligibleCaption": "Opérations disposant d'assez de preuves sans échec pour être préautorisées. Ouvrez Paramètres → Agents IA pour les examiner et les promouvoir.",
         "estTimeSaved": "Temps gagné estimé",
         "estTimeSavedValue": "{{hours}} heures",
+        "estTimeSavedCaption": "Estimé à partir d’une durée fixe par résultat.",
+        "howEstimatedToggle": "Comment cette estimation est-elle calculée ?",
         "llmSpend": "Dépenses LLM"
       },
       "weightsTooltipTitle": "Une estimation uniquement — chaque résultat est crédité d’une durée fixe :",
@@ -1886,6 +1964,8 @@
       "loading": "Chargement des preuves d’habilitation…",
       "error": "Impossible de charger les preuves d’habilitation.",
       "retry": "Réessayer",
+      "noBaselineTitle": "Aucun agent de référence pour l’instant",
+      "noBaseline": "Le suivi de l’habilitation graduelle démarre dès qu’un agent de référence à l’échelle du partenaire de ce type existe. Créez-en un avec la portée « Toutes les organisations » pour commencer à suivre les preuves de cette organisation.",
       "orgRequired": "Choisissez une seule organisation dans le sélecteur d’organisations pour voir ses preuves d’habilitation.",
       "empty": "Aucune preuve n’a encore été consignée pour cet agent.",
       "readOnlyNote": "L’exécution préautorisée est désactivée dans ce déploiement; ces chiffres sont donnés à titre indicatif.",
@@ -1894,6 +1974,22 @@
       "approvalsLink": "Suivre cette demande dans la boîte des approbations",
       "ceilingHint": "Les clés au niveau du partenaire constituent un plafond, non une autorisation. L’agent de chaque organisation doit obtenir la clé séparément — par l’habilitation ou en modifiant l’agent de cette organisation.",
       "promote": "Promouvoir",
+      "revoke": "Révoquer",
+      "emptyTitle": "Aucune preuve pour l’instant",
+      "demotedAt": "Révoquée le {{at}}",
+      "demotedReason": "Motif : {{reason}}",
+      "demoteReasons": {
+        "attempted_failure": "une tentative a échoué",
+        "recurrence": "l’alerte corrigée est revenue",
+        "operator": "une personne opératrice l’a révoquée"
+      },
+      "revokeConfirm": {
+        "title": "Révoquer la préautorisation",
+        "message": "{{opKey}} retourne dans la file d’approbation de l’agent de cette organisation. Une exécution déjà en cours n’est pas touchée; chaque suivante exige de nouveau une décision humaine.",
+        "action": "Révoquer",
+        "reasonLabel": "Motif (facultatif)",
+        "reasonHint": "Consigné dans l’entrée de vérification de cette révocation. Jusqu’à 500 caractères."
+      },
       "verifiedOfThreshold": "{{verified}} sur {{threshold}}",
       "columns": {
         "opKey": "Opération",
@@ -1924,11 +2020,17 @@
         "action": "Demander l’approbation"
       },
       "toasts": {
-        "requested": "Préautorisation demandée. Une deuxième personne doit l’approuver avant que cette opération s’exécute sans surveillance, et cela s’applique uniquement aux exécutions futures."
+        "requested": "Préautorisation demandée. Une deuxième personne doit l’approuver avant que cette opération s’exécute sans surveillance, et cela s’applique uniquement aux exécutions futures.",
+        "revoked": "Préautorisation révoquée. Cette opération exige de nouveau une décision humaine, à partir de la prochaine exécution."
       },
       "errors": {
         "promote": "Impossible de soumettre la demande de préautorisation.",
-        "policyDecideDisabled": "L’exécution préautorisée est désactivée dans ce déploiement; cette opération ne peut donc pas être promue."
+        "policyDecideDisabled": "L’exécution préautorisée est désactivée dans ce déploiement; cette opération ne peut donc pas être promue.",
+        "revoke": "La préautorisation n’a pas pu être révoquée.",
+        "noPromotedGrant": "Cette opération n’est pas préautorisée pour cette organisation; il n’y a donc rien à révoquer.",
+        "alreadyDemoted": "Cette opération est déjà revenue dans la file d’approbation.",
+        "alreadyRevoked": "Cette opération avait déjà été retirée de l’agent; rien n’a changé.",
+        "ambiguousOpKey": "Plus d’un agent détient cette opération pour cette organisation. Ouvrez l’agent à modifier et révoquez-la là."
       },
       "reliability": {
         "caption": "Opérations du mode action, en lecture seule : ce ne sont pas des clés de politique, elles ne peuvent donc jamais être préautorisées."

--- a/apps/web/src/locales/fr-FR/approvals.json
+++ b/apps/web/src/locales/fr-FR/approvals.json
@@ -31,6 +31,16 @@
   "deciding": "Envoi en cours…",
   "expiresIn": "Expire dans {{minutes}} min",
   "expiresSoon": "Expire dans moins d’une minute",
+  "expired": "Expirée",
+  "unknownOrganization": "Organisation inconnue",
+  "charCount": "{{count}}/{{max}}",
+  "approveToast": "{{action}} approuvé pour {{org}}",
+  "pagination": {
+    "showing": "Affichage de {{shown}} sur {{total}}",
+    "showingCount": "Affichage de {{shown}}",
+    "loadMore": "Charger plus",
+    "loadMoreError": "Impossible de charger plus d’éléments. Réessayez."
+  },
   "errors": {
     "noApproverDevice": "Enregistrez un appareil d’approbation dans votre profil, puis réessayez.",
     "notSoleApprover": "Une autre personne habilitée doit décider de cette demande.",

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -1,4 +1,39 @@
 {
+  "aiAgentsRuns": {
+    "live": {
+      "label": "Mise à jour en direct"
+    },
+    "list": {
+      "clearFilters": "Effacer les filtres",
+      "emptyDescription": "Les exécutions déclenchées par des alertes, des horaires, des tickets et des actions manuelles apparaîtront ici une fois qu'un agent les aura exécutées.",
+      "emptyFilteredDescription": "Aucune exécution ne correspond à ces filtres. Essayez un autre agent ou statut.",
+      "emptyConfigureLink": "Configurer les agents IA"
+    },
+    "detail": {
+      "notFoundDescription": "Cette exécution a peut-être été supprimée, ou le lien est obsolète.",
+      "trace": {
+        "emptyDescription": "Les appels d'outils que l'agent propose ou exécute seront répertoriés ici."
+      },
+      "ledger": {
+        "emptyDescription": "Les outils réellement invoqués par l'agent seront répertoriés ici.",
+        "statuses": {
+          "pending": "En attente",
+          "approved": "Approuvé",
+          "executing": "En cours d'exécution",
+          "completed": "Terminé",
+          "failed": "Échoué",
+          "rejected": "Rejeté"
+        }
+      },
+      "intents": {
+        "emptyDescription": "Les approbations demandées par cette exécution seront répertoriées ici."
+      },
+      "triage": {
+        "categoryLabel": "Catégorie",
+        "categoryUnresolved": "Suggéré — nom non disponible dans cette vue"
+      }
+    }
+  },
   "partnerServicePrincipals": {
     "title": "Principaux de service",
     "description": "Gérez les identités machines au niveau du partenaire et leurs clés d'accès.",
@@ -1380,7 +1415,7 @@
       "deleteOverride": "Retirer la dérogation",
       "confirmDelete": "Confirmer la suppression",
       "cron": "Expression cron",
-      "cronHint": "Cinq champs : minute heure jour-du-mois mois jour-de-la-semaine. Par exemple, 0 3 * * * s'exécute chaque jour à 03h00.",
+      "cronHint": "Cinq champs : minute heure jour-du-mois mois jour-de-la-semaine. Par exemple, 0 3 * * * s'exécute chaque jour à 03h00. Le champ des minutes doit être un nombre littéral ou une liste séparée par des virgules (sans *, / ni plage -) — les planifications s'exécutent au plus une fois par heure.",
       "cronInvalid": "Saisissez une expression cron valide à cinq champs avant d'enregistrer.",
       "timezone": "Fuseau horaire",
       "kinds": {
@@ -1400,6 +1435,9 @@
       "tightenOnly": "Une dérogation ne peut que restreindre la référence : elle peut désactiver le balayage ou retirer des contrôles, jamais en ajouter.",
       "noKinds": "Aucun contrôle",
       "lastRun": "Dernière exécution {{at}} · {{admitted}} organisations balayées sur {{total}}, {{skipped}} ignorées.",
+      "nextRun": "Prochaine exécution {{at}} ({{timezone}})",
+      "nextRunInvalid": "Planification invalide",
+      "nextRunNone": "Aucune exécution dans l’année qui vient.",
       "kindLabels": {
         "disk_pressure": "Pression disque",
         "stale_agents": "Agents obsolètes",
@@ -1432,6 +1470,26 @@
     "title": "Agents IA",
     "description": "Des travailleurs IA nommés, dotés d’une politique. Les partenaires définissent la référence ; les organisations peuvent seulement la restreindre.",
     "empty": "Aucun agent pour l’instant.",
+    "kindHints": {
+      "triage": "Examine les nouvelles alertes et propose la marche à suivre.",
+      "patch": "Passe en revue les correctifs manquants et propose ceux à installer.",
+      "helpdesk": "Prend en charge les tickets et propose des réponses et des étapes suivantes."
+    },
+    "emptyState": {
+      "title": "Aucun agent pour l’instant",
+      "description": "Un agent est une politique enregistrée, pas un processus en cours : il surveille les alertes, les correctifs ou les tickets que vous choisissez, enquête avec les outils que vous autorisez, puis propose une correction ou l’applique. Commencez en mode ombre, où l’agent propose et une personne approuve, afin que rien n’atteigne un appareil avant que vous le décidiez.",
+      "action": "Créer votre premier agent"
+    },
+    "modeChoice": {
+      "legend": "Ce que cet agent peut faire",
+      "off": "Désactivé",
+      "offConsequence": "Rien ne s’exécute.",
+      "shadow": "Ombre",
+      "shadowConsequence": "Observe et propose ; une personne approuve tout.",
+      "act": "Action",
+      "actConsequence": "Exécute les opérations autorisées sans clic. Aucune annulation automatique.",
+      "actUnavailable": "Pas encore disponible pour cet agent."
+    },
     "allOrgs": "Toutes les organisations",
     "allOrgsHint": "À l’échelle du partenaire : s’applique à chaque organisation, sauf si une organisation la restreint.",
     "stateEnabled": "Activé",
@@ -1477,8 +1535,11 @@
     "sections": {
       "scope": "Quand il s’exécute",
       "permissions": "Autorisations",
+      "permissionsDescription": "Ce que cet agent peut toucher. La liste d’outils élargit ce qu’il peut faire ; les ressources protégées la restreignent et l’emportent toujours.",
       "policyDecide": "Autorisation de politique sans surveillance",
       "limits": "Limites",
+      "limitsBudget": "Budget et portée",
+      "limitsTiming": "Durées",
       "notifications": "Notifications",
       "instructions": "Consignes"
     },
@@ -1536,7 +1597,12 @@
       "supervisedActionKeysEmpty": "Aucune action décidable par politique n’est enregistrée.",
       "supervisedActionKeysFailed": "Impossible de charger la liste des actions décidables par politique ; l’autorisation sans surveillance ne peut pas être modifiée pour le moment.",
       "ticketAutonomousWrites": "Écritures autonomes de tickets",
-      "ticketAutonomousWritesHint": "Dérogation d'organisation uniquement — les écritures autonomes de tickets nécessitent le mode action et cette activation au niveau de l'organisation"
+      "ticketAutonomousWritesHint": "Dérogation d'organisation uniquement — les écritures autonomes de tickets nécessitent le mode action et cette activation au niveau de l'organisation",
+      "enabledHint": "« Activé » et le mode sont deux interrupteurs distincts et une exécution a besoin des deux : si ceci est désactivé, rien ne s’exécute quel que soit le mode, et en mode Désactivé rien ne s’exécute même si ceci est activé.",
+      "actKeysCleared": "Les autorisations du mode action sont conservées, mais ne seront pas enregistrées tant que cet agent ne repasse pas en mode Action.",
+      "toolSuggestLabel": "Ajouter un outil connu",
+      "toolSuggestHint": "Les suggestions proviennent du registre des actions décidables par politique, qui n’est pas la liste complète des outils. Tout autre outil autorisé pour cet agent peut encore être saisi ci-dessus.",
+      "toolSuggestAdd": "Ajouter"
     },
     "loading": "Chargement des agents…",
     "runs": {
@@ -1781,6 +1847,7 @@
       "refresh": "Actualiser",
       "refreshing": "Reconstruction en cours…",
       "retry": "Réessayer",
+      "moreActions": "Plus d’actions",
       "errors": {
         "load": "Impossible de charger le rapport d’impact.",
         "rebuild": "Impossible de mettre la reconstruction du rapport en file d’attente.",
@@ -1793,6 +1860,15 @@
         "rebuildComplete": "Le rapport d’impact a été reconstruit.",
         "rebuildStillRunning": "La reconstruction est toujours en cours. Rechargez cette page dans quelques minutes pour voir les nouveaux chiffres."
       },
+      "emptyState": {
+        "title": "Aucun résultat d’IA pour cette période",
+        "description": "Les résultats apparaîtront ici dès que vos agents IA évalueront une alerte, trieront un ticket ou appliqueront un correctif en mode observation ou action. Élargissez la période de rapport ci-dessus, ou configurez un agent pour commencer.",
+        "action": "Configurer un agent"
+      },
+      "tileGroups": {
+        "judged": "Évalués",
+        "executed": "Exécutés"
+      },
       "tiles": {
         "alertsJudged": "Alertes évaluées",
         "noiseFlagged": "Signalées comme bruit",
@@ -1800,9 +1876,11 @@
         "draftsSent": "Brouillons envoyés",
         "fixesExecuted": "Correctifs appliqués",
         "promoteEligible": "Opérations éligibles à la promotion",
-        "promoteEligibleHint": "Opérations disposant de suffisamment de preuves sans échec pour être préautorisées. Ouvrez Paramètres → Agents IA pour les examiner et les promouvoir.",
+        "promoteEligibleCaption": "Opérations disposant de suffisamment de preuves sans échec pour être préautorisées. Ouvrez Paramètres → Agents IA pour les examiner et les promouvoir.",
         "estTimeSaved": "Temps gagné estimé",
         "estTimeSavedValue": "{{hours}} heures",
+        "estTimeSavedCaption": "Estimé à partir d’une durée fixe par résultat.",
+        "howEstimatedToggle": "Comment cette estimation est-elle calculée ?",
         "llmSpend": "Dépenses LLM"
       },
       "weightsTooltipTitle": "Une estimation uniquement — chaque résultat est crédité d’une durée fixe :",
@@ -1886,6 +1964,8 @@
       "loading": "Chargement des preuves d’habilitation…",
       "error": "Les preuves d’habilitation n’ont pas pu être chargées.",
       "retry": "Réessayer",
+      "noBaselineTitle": "Aucun agent de référence pour l’instant",
+      "noBaseline": "Le suivi d’habilitation démarre dès qu’un agent de référence à l’échelle du partenaire de ce type existe. Créez-en un avec la portée « Toutes les organisations » pour commencer à suivre les preuves de cette organisation.",
       "orgRequired": "Choisissez une seule organisation dans le sélecteur d’organisations pour voir ses preuves d’habilitation.",
       "empty": "Aucune preuve n’a encore été enregistrée pour cet agent.",
       "readOnlyNote": "L’exécution préautorisée est désactivée sur ce déploiement ; ces chiffres sont fournis à titre indicatif.",
@@ -1894,6 +1974,22 @@
       "approvalsLink": "Suivre cette demande dans la boîte des approbations",
       "ceilingHint": "Les clés au niveau du partenaire sont un plafond, pas une autorisation. L’agent de chaque organisation doit recevoir la clé séparément — par l’habilitation ou en modifiant l’agent de cette organisation.",
       "promote": "Promouvoir",
+      "revoke": "Révoquer",
+      "emptyTitle": "Aucune preuve pour l’instant",
+      "demotedAt": "Révoquée le {{at}}",
+      "demotedReason": "Motif : {{reason}}",
+      "demoteReasons": {
+        "attempted_failure": "une tentative a échoué",
+        "recurrence": "l’alerte corrigée est revenue",
+        "operator": "une personne opératrice l’a révoquée"
+      },
+      "revokeConfirm": {
+        "title": "Révoquer la préautorisation",
+        "message": "{{opKey}} retourne dans la file d’approbation de l’agent de cette organisation. Une exécution déjà en cours n’est pas affectée ; chaque suivante exige de nouveau une décision humaine.",
+        "action": "Révoquer",
+        "reasonLabel": "Motif (facultatif)",
+        "reasonHint": "Consigné dans l’entrée d’audit de cette révocation. Jusqu’à 500 caractères."
+      },
       "verifiedOfThreshold": "{{verified}} sur {{threshold}}",
       "columns": {
         "opKey": "Opération",
@@ -1924,11 +2020,17 @@
         "action": "Demander l’approbation"
       },
       "toasts": {
-        "requested": "Préautorisation demandée. Une deuxième personne doit l’approuver avant que cette opération s’exécute sans surveillance, et cela ne vaut que pour les exécutions futures."
+        "requested": "Préautorisation demandée. Une deuxième personne doit l’approuver avant que cette opération s’exécute sans surveillance, et cela ne vaut que pour les exécutions futures.",
+        "revoked": "Préautorisation révoquée. Cette opération exige de nouveau une décision humaine, dès la prochaine exécution."
       },
       "errors": {
         "promote": "La demande de préautorisation n’a pas pu être déposée.",
-        "policyDecideDisabled": "L’exécution préautorisée est désactivée sur ce déploiement, cette opération ne peut donc pas être promue."
+        "policyDecideDisabled": "L’exécution préautorisée est désactivée sur ce déploiement, cette opération ne peut donc pas être promue.",
+        "revoke": "La préautorisation n’a pas pu être révoquée.",
+        "noPromotedGrant": "Cette opération n’est pas préautorisée pour cette organisation, il n’y a donc rien à révoquer.",
+        "alreadyDemoted": "Cette opération est déjà revenue dans la file d’approbation.",
+        "alreadyRevoked": "Cette opération avait déjà été retirée de l’agent, rien n’a changé.",
+        "ambiguousOpKey": "Plusieurs agents détiennent cette opération pour cette organisation. Ouvrez l’agent à modifier et révoquez-la depuis celui-ci."
       },
       "reliability": {
         "caption": "Opérations du mode action, en lecture seule : ce ne sont pas des clés de politique, elles ne peuvent donc jamais être préautorisées."

--- a/apps/web/src/locales/it-IT/approvals.json
+++ b/apps/web/src/locales/it-IT/approvals.json
@@ -31,6 +31,16 @@
   "deciding": "Invio in corso…",
   "expiresIn": "Scade tra {{minutes}} min",
   "expiresSoon": "Scade tra meno di un minuto",
+  "expired": "Scaduta",
+  "unknownOrganization": "Organizzazione sconosciuta",
+  "charCount": "{{count}}/{{max}}",
+  "approveToast": "{{action}} approvato per {{org}}",
+  "pagination": {
+    "showing": "Visualizzazione di {{shown}} su {{total}}",
+    "showingCount": "Visualizzazione di {{shown}}",
+    "loadMore": "Carica altro",
+    "loadMoreError": "Impossibile caricare altro. Riprova."
+  },
   "errors": {
     "noApproverDevice": "Registra un dispositivo di approvazione nel profilo e riprova.",
     "notSoleApprover": "Un’altra persona autorizzata deve decidere su questa richiesta.",

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -1,4 +1,39 @@
 {
+  "aiAgentsRuns": {
+    "live": {
+      "label": "Aggiornamento in tempo reale"
+    },
+    "list": {
+      "clearFilters": "Cancella filtri",
+      "emptyDescription": "Le esecuzioni attivate da avvisi, pianificazioni, ticket e azioni manuali appariranno qui una volta che un agente le avrà eseguite.",
+      "emptyFilteredDescription": "Nessuna esecuzione corrisponde a questi filtri. Prova un agente o uno stato diverso.",
+      "emptyConfigureLink": "Configura agenti IA"
+    },
+    "detail": {
+      "notFoundDescription": "Questa esecuzione potrebbe essere stata eliminata, oppure il link non è più valido.",
+      "trace": {
+        "emptyDescription": "Le chiamate agli strumenti proposte o eseguite dall'agente saranno elencate qui."
+      },
+      "ledger": {
+        "emptyDescription": "Gli strumenti effettivamente invocati dall'agente saranno elencati qui.",
+        "statuses": {
+          "pending": "In sospeso",
+          "approved": "Approvato",
+          "executing": "In esecuzione",
+          "completed": "Completato",
+          "failed": "Non riuscito",
+          "rejected": "Rifiutato"
+        }
+      },
+      "intents": {
+        "emptyDescription": "Le approvazioni richieste da questa esecuzione saranno elencate qui."
+      },
+      "triage": {
+        "categoryLabel": "Categoria",
+        "categoryUnresolved": "Suggerita — nome non disponibile in questa vista"
+      }
+    }
+  },
   "partnerServicePrincipals": {
     "title": "Entità servizio",
     "description": "Gestisci le identità macchina con ambito partner e le relative chiavi di accesso.",
@@ -1380,7 +1415,7 @@
       "deleteOverride": "Rimuovi eccezione",
       "confirmDelete": "Conferma eliminazione",
       "cron": "Espressione cron",
-      "cronHint": "Cinque campi: minuto ora giorno-del-mese mese giorno-della-settimana. Ad esempio, 0 3 * * * viene eseguito ogni giorno alle 03:00.",
+      "cronHint": "Cinque campi: minuto ora giorno-del-mese mese giorno-della-settimana. Ad esempio, 0 3 * * * viene eseguito ogni giorno alle 03:00. Il campo dei minuti deve essere un numero letterale o un elenco separato da virgole (senza *, / o intervallo -) — le pianificazioni vengono eseguite al massimo ogni ora.",
       "cronInvalid": "Inserisci un'espressione cron valida a cinque campi prima di salvare.",
       "timezone": "Fuso orario",
       "kinds": {
@@ -1400,6 +1435,9 @@
       "tightenOnly": "Un'eccezione può solo restringere la baseline: può disattivare la scansione o rimuovere controlli, mai aggiungerne.",
       "noKinds": "Nessun controllo",
       "lastRun": "Ultima esecuzione {{at}} · {{admitted}} organizzazioni su {{total}} analizzate, {{skipped}} saltate.",
+      "nextRun": "Prossima esecuzione {{at}} ({{timezone}})",
+      "nextRunInvalid": "Pianificazione non valida",
+      "nextRunNone": "Nessuna esecuzione nel prossimo anno.",
       "kindLabels": {
         "disk_pressure": "Pressione sul disco",
         "stale_agents": "Agenti non aggiornati",
@@ -1432,6 +1470,26 @@
     "title": "Agenti AI",
     "description": "Lavoratori AI con un nome e una policy. I partner definiscono la linea di base; le organizzazioni possono soltanto restringerla.",
     "empty": "Nessun agente per ora.",
+    "kindHints": {
+      "triage": "Analizza i nuovi avvisi e propone cosa fare.",
+      "patch": "Esamina le patch mancanti e propone cosa installare.",
+      "helpdesk": "Prende in carico i ticket e propone risposte e prossimi passi."
+    },
+    "emptyState": {
+      "title": "Nessun agente per ora",
+      "description": "Un agente è una policy salvata, non un processo in esecuzione: osserva gli avvisi, le patch o i ticket che scegliete, indaga con gli strumenti che consentite e poi propone una soluzione oppure la esegue. Iniziate in modalità ombra, in cui l’agente propone e una persona approva, così nulla raggiunge un dispositivo finché non lo decidete voi.",
+      "action": "Crea il primo agente"
+    },
+    "modeChoice": {
+      "legend": "Cosa può fare questo agente",
+      "off": "Disattivo",
+      "offConsequence": "Non viene eseguito nulla.",
+      "shadow": "Ombra",
+      "shadowConsequence": "Osserva e propone; una persona approva tutto.",
+      "act": "Azione",
+      "actConsequence": "Esegue le operazioni consentite senza un clic. Nessun ripristino automatico.",
+      "actUnavailable": "Non ancora disponibile per questo agente."
+    },
     "allOrgs": "Tutte le organizzazioni",
     "allOrgsHint": "A livello di partner: vale per ogni organizzazione, salvo che un’organizzazione la restringa.",
     "stateEnabled": "Attivo",
@@ -1477,8 +1535,11 @@
     "sections": {
       "scope": "Quando viene eseguito",
       "permissions": "Autorizzazioni",
+      "permissionsDescription": "Cosa può toccare questo agente. L’elenco degli strumenti amplia ciò che può fare; le risorse protette lo restringono e prevalgono sempre.",
       "policyDecide": "Autorizzazione della policy non presidiata",
       "limits": "Limiti",
+      "limitsBudget": "Budget e portata",
+      "limitsTiming": "Tempistiche",
       "notifications": "Notifiche",
       "instructions": "Istruzioni"
     },
@@ -1536,7 +1597,12 @@
       "supervisedActionKeysEmpty": "Nessuna azione decidibile tramite policy è registrata.",
       "supervisedActionKeysFailed": "Impossibile caricare l'elenco delle azioni decidibili tramite policy, quindi l'autorizzazione non presidiata non può essere modificata al momento.",
       "ticketAutonomousWrites": "Scritture autonome dei ticket",
-      "ticketAutonomousWritesHint": "Solo override a livello di organizzazione — le scritture autonome dei ticket richiedono la modalità azione e questa attivazione a livello di organizzazione"
+      "ticketAutonomousWritesHint": "Solo override a livello di organizzazione — le scritture autonome dei ticket richiedono la modalità azione e questa attivazione a livello di organizzazione",
+      "enabledHint": "«Attivo» e la modalità sono due interruttori distinti e un’esecuzione ha bisogno di entrambi: con questo spento non viene eseguito nulla qualunque sia la modalità, e in modalità Disattivo non viene eseguito nulla nemmeno se questo è acceso.",
+      "actKeysCleared": "Le autorizzazioni della modalità azione vengono mantenute, ma non verranno salvate finché questo agente non torna alla modalità Azione.",
+      "toolSuggestLabel": "Aggiungi uno strumento noto",
+      "toolSuggestHint": "I suggerimenti provengono dal registro delle azioni decidibili dalla policy, che non è l’elenco completo degli strumenti. Qualsiasi altro strumento consentito a questo agente si può comunque digitare qui sopra.",
+      "toolSuggestAdd": "Aggiungi"
     },
     "loading": "Caricamento degli agenti…",
     "runs": {
@@ -1781,6 +1847,7 @@
       "refresh": "Aggiorna",
       "refreshing": "Ricostruzione in corso…",
       "retry": "Riprova",
+      "moreActions": "Altre azioni",
       "errors": {
         "load": "Impossibile caricare il report di impatto.",
         "rebuild": "Impossibile accodare la ricostruzione del report.",
@@ -1793,6 +1860,15 @@
         "rebuildComplete": "Il report di impatto è stato ricostruito.",
         "rebuildStillRunning": "La ricostruzione è ancora in corso. Ricaricate questa pagina tra qualche minuto per vedere i nuovi dati."
       },
+      "emptyState": {
+        "title": "Nessun risultato IA in questo periodo",
+        "description": "I risultati appariranno qui non appena i tuoi agenti IA valuteranno un avviso, smisteranno un ticket o eseguiranno una correzione in modalità osservazione o azione. Amplia il periodo del report qui sopra, oppure configura un agente per iniziare.",
+        "action": "Configura un agente"
+      },
+      "tileGroups": {
+        "judged": "Valutati",
+        "executed": "Eseguiti"
+      },
       "tiles": {
         "alertsJudged": "Avvisi valutati",
         "noiseFlagged": "Contrassegnati come rumore",
@@ -1800,9 +1876,11 @@
         "draftsSent": "Bozze inviate",
         "fixesExecuted": "Correzioni eseguite",
         "promoteEligible": "Operazioni idonee alla promozione",
-        "promoteEligibleHint": "Operazioni con prove sufficienti e senza errori per essere preautorizzate. Apri Impostazioni → Agenti IA per esaminarle e promuoverle.",
+        "promoteEligibleCaption": "Operazioni con prove sufficienti e senza errori per essere preautorizzate. Apri Impostazioni → Agenti IA per esaminarle e promuoverle.",
         "estTimeSaved": "Tempo risparmiato stimato",
         "estTimeSavedValue": "{{hours}} ore",
+        "estTimeSavedCaption": "Stimato in base a un tempo fisso per risultato.",
+        "howEstimatedToggle": "Come viene stimato?",
         "llmSpend": "Spesa LLM"
       },
       "weightsTooltipTitle": "Solo una stima — a ogni risultato viene accreditato un tempo fisso:",
@@ -1886,6 +1964,8 @@
       "loading": "Caricamento delle prove di abilitazione…",
       "error": "Non è stato possibile caricare le prove di abilitazione.",
       "retry": "Riprova",
+      "noBaselineTitle": "Nessun agente di riferimento ancora",
+      "noBaseline": "Il monitoraggio dell’abilitazione inizia quando esiste un agente di riferimento a livello di partner di questo tipo. Creane uno con l’ambito \"Tutte le organizzazioni\" per iniziare a raccogliere le prove per questa organizzazione.",
       "orgRequired": "Scegli una sola organizzazione nel selettore delle organizzazioni per vedere le sue prove di abilitazione.",
       "empty": "Per questo agente non è stata ancora registrata alcuna prova.",
       "readOnlyNote": "L’esecuzione preautorizzata è disattivata in questa installazione; questi dati sono solo informativi.",
@@ -1894,6 +1974,22 @@
       "approvalsLink": "Segui questa richiesta nella casella delle approvazioni",
       "ceilingHint": "Le chiavi a livello di partner sono un limite massimo, non una concessione. L’agente di ogni organizzazione deve ricevere la chiave separatamente: tramite l’abilitazione o modificando l’agente di quella organizzazione.",
       "promote": "Promuovi",
+      "revoke": "Revoca",
+      "emptyTitle": "Ancora nessuna prova",
+      "demotedAt": "Revocata il {{at}}",
+      "demotedReason": "Motivo: {{reason}}",
+      "demoteReasons": {
+        "attempted_failure": "un tentativo è fallito",
+        "recurrence": "l’avviso corretto si è ripresentato",
+        "operator": "un operatore l’ha revocata"
+      },
+      "revokeConfirm": {
+        "title": "Revoca la preautorizzazione",
+        "message": "{{opKey}} torna nella coda di approvazione per l’agente di questa organizzazione. Un’esecuzione già in corso non viene toccata; ogni successiva richiede di nuovo una decisione umana.",
+        "action": "Revoca",
+        "reasonLabel": "Motivo (facoltativo)",
+        "reasonHint": "Registrato nella voce di audit di questa revoca. Fino a 500 caratteri."
+      },
       "verifiedOfThreshold": "{{verified}} su {{threshold}}",
       "columns": {
         "opKey": "Operazione",
@@ -1924,11 +2020,17 @@
         "action": "Richiedi approvazione"
       },
       "toasts": {
-        "requested": "Preautorizzazione richiesta. Una seconda persona deve approvarla prima che questa operazione venga eseguita senza supervisione e vale solo per le esecuzioni future."
+        "requested": "Preautorizzazione richiesta. Una seconda persona deve approvarla prima che questa operazione venga eseguita senza supervisione e vale solo per le esecuzioni future.",
+        "revoked": "Preautorizzazione revocata. Questa operazione richiede di nuovo una decisione umana, a partire dalla prossima esecuzione."
       },
       "errors": {
         "promote": "Non è stato possibile inoltrare la richiesta di preautorizzazione.",
-        "policyDecideDisabled": "L’esecuzione preautorizzata è disattivata in questa installazione, quindi questa operazione non può essere promossa."
+        "policyDecideDisabled": "L’esecuzione preautorizzata è disattivata in questa installazione, quindi questa operazione non può essere promossa.",
+        "revoke": "Non è stato possibile revocare la preautorizzazione.",
+        "noPromotedGrant": "Questa operazione non è preautorizzata per questa organizzazione, quindi non c’è nulla da revocare.",
+        "alreadyDemoted": "Questa operazione è già tornata nella coda di approvazione.",
+        "alreadyRevoked": "Questa operazione era già stata rimossa dall’agente, quindi non è cambiato nulla.",
+        "ambiguousOpKey": "Più di un agente detiene questa operazione per questa organizzazione. Aprite l’agente da modificare e revocatela lì."
       },
       "reliability": {
         "caption": "Operazioni della modalità azione, in sola lettura: non sono chiavi di criterio, quindi non possono mai essere preautorizzate."

--- a/apps/web/src/locales/pt-BR/approvals.json
+++ b/apps/web/src/locales/pt-BR/approvals.json
@@ -31,6 +31,16 @@
   "deciding": "Enviando…",
   "expiresIn": "Expira em {{minutes}} min",
   "expiresSoon": "Expira em menos de um minuto",
+  "expired": "Expirada",
+  "unknownOrganization": "Organização desconhecida",
+  "charCount": "{{count}}/{{max}}",
+  "approveToast": "{{action}} aprovado para {{org}}",
+  "pagination": {
+    "showing": "Mostrando {{shown}} de {{total}}",
+    "showingCount": "Mostrando {{shown}}",
+    "loadMore": "Carregar mais",
+    "loadMoreError": "Não foi possível carregar mais. Tente novamente."
+  },
   "errors": {
     "noApproverDevice": "Registre um dispositivo aprovador no seu perfil e tente novamente.",
     "notSoleApprover": "Outra pessoa autorizada precisa decidir esta solicitação.",

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -1,4 +1,39 @@
 {
+  "aiAgentsRuns": {
+    "live": {
+      "label": "Atualizando ao vivo"
+    },
+    "list": {
+      "clearFilters": "Limpar filtros",
+      "emptyDescription": "As execuções acionadas por alertas, agendamentos, tickets e ações manuais aparecerão aqui assim que um agente as executar.",
+      "emptyFilteredDescription": "Nenhuma execução corresponde a esses filtros. Tente outro agente ou status.",
+      "emptyConfigureLink": "Configurar agentes de IA"
+    },
+    "detail": {
+      "notFoundDescription": "Esta execução pode ter sido excluída, ou o link pode estar desatualizado.",
+      "trace": {
+        "emptyDescription": "As chamadas de ferramentas propostas ou executadas pelo agente serão listadas aqui."
+      },
+      "ledger": {
+        "emptyDescription": "As ferramentas realmente invocadas pelo agente serão listadas aqui.",
+        "statuses": {
+          "pending": "Pendente",
+          "approved": "Aprovado",
+          "executing": "Em execução",
+          "completed": "Concluído",
+          "failed": "Falhou",
+          "rejected": "Rejeitado"
+        }
+      },
+      "intents": {
+        "emptyDescription": "As aprovações solicitadas por esta execução serão listadas aqui."
+      },
+      "triage": {
+        "categoryLabel": "Categoria",
+        "categoryUnresolved": "Sugerida — nome não disponível nesta visualização"
+      }
+    }
+  },
   "partnerServicePrincipals": {
     "title": "Entidades de serviço",
     "description": "Gerencie identidades de máquina no nível do parceiro e suas chaves de acesso.",
@@ -1380,7 +1415,7 @@
       "deleteOverride": "Remover exceção",
       "confirmDelete": "Confirmar exclusão",
       "cron": "Expressão cron",
-      "cronHint": "Cinco campos: minuto hora dia-do-mês mês dia-da-semana. Por exemplo, 0 3 * * * é executado todos os dias às 03:00.",
+      "cronHint": "Cinco campos: minuto hora dia-do-mês mês dia-da-semana. Por exemplo, 0 3 * * * é executado todos os dias às 03:00. O campo de minutos deve ser um número literal ou uma lista separada por vírgulas (sem *, / ou intervalo -) — as programações são executadas no máximo a cada hora.",
       "cronInvalid": "Informe uma expressão cron válida de cinco campos antes de salvar.",
       "timezone": "Fuso horário",
       "kinds": {
@@ -1400,6 +1435,9 @@
       "tightenOnly": "Uma exceção só pode restringir a linha de base: pode desativar a varredura ou remover verificações, nunca adicioná-las.",
       "noKinds": "Nenhuma verificação",
       "lastRun": "Última execução {{at}} · {{admitted}} de {{total}} organizações varridas, {{skipped}} ignoradas.",
+      "nextRun": "Próxima execução {{at}} ({{timezone}})",
+      "nextRunInvalid": "Agendamento inválido",
+      "nextRunNone": "Nenhuma execução no próximo ano.",
       "kindLabels": {
         "disk_pressure": "Pressão de disco",
         "stale_agents": "Agentes desatualizados",
@@ -1432,6 +1470,26 @@
     "title": "Agentes de IA",
     "description": "Trabalhadores de IA nomeados, com uma política. Os parceiros definem a linha de base; as organizações só podem restringi-la.",
     "empty": "Nenhum agente ainda.",
+    "kindHints": {
+      "triage": "Investiga os alertas novos e propõe o que fazer com eles.",
+      "patch": "Revisa as correções pendentes e propõe o que instalar.",
+      "helpdesk": "Assume chamados e propõe respostas e próximos passos."
+    },
+    "emptyState": {
+      "title": "Nenhum agente ainda",
+      "description": "Um agente é uma política salva, não um processo em execução: ele observa os alertas, as correções ou os chamados que você escolher, investiga com as ferramentas que você permitir e então propõe uma solução ou a executa. Comece no modo sombra, em que o agente propõe e uma pessoa aprova, para que nada chegue a um dispositivo antes de você autorizar.",
+      "action": "Criar seu primeiro agente"
+    },
+    "modeChoice": {
+      "legend": "O que este agente pode fazer",
+      "off": "Desligado",
+      "offConsequence": "Nada é executado.",
+      "shadow": "Sombra",
+      "shadowConsequence": "Observa e propõe; uma pessoa aprova tudo.",
+      "act": "Ação",
+      "actConsequence": "Executa as operações permitidas sem um clique. Não há reversão automática.",
+      "actUnavailable": "Ainda não está disponível para este agente."
+    },
     "allOrgs": "Todas as organizações",
     "allOrgsHint": "Em todo o parceiro: vale para cada organização, a menos que uma organização a restrinja.",
     "stateEnabled": "Ativado",
@@ -1477,8 +1535,11 @@
     "sections": {
       "scope": "Quando é executado",
       "permissions": "Permissões",
+      "permissionsDescription": "O que este agente pode tocar. A lista de ferramentas amplia o que ele consegue fazer; os recursos protegidos a restringem e sempre prevalecem.",
       "policyDecide": "Autorização de política não supervisionada",
       "limits": "Limites",
+      "limitsBudget": "Orçamento e alcance",
+      "limitsTiming": "Tempos",
       "notifications": "Notificações",
       "instructions": "Instruções"
     },
@@ -1536,7 +1597,12 @@
       "supervisedActionKeysEmpty": "Nenhuma ação decidível por política está registrada.",
       "supervisedActionKeysFailed": "Não foi possível carregar a lista de ações decidíveis por política, então a autorização não supervisionada não pode ser alterada agora.",
       "ticketAutonomousWrites": "Gravações autônomas de chamados",
-      "ticketAutonomousWritesHint": "Somente substituição da organização — gravações autônomas de chamados exigem o modo de ação e a ativação neste nível de organização"
+      "ticketAutonomousWritesHint": "Somente substituição da organização — gravações autônomas de chamados exigem o modo de ação e a ativação neste nível de organização",
+      "enabledHint": "«Ativado» e o modo são chaves separadas e uma execução precisa das duas: com isto desligado nada roda, seja qual for o modo, e no modo Desligado nada roda mesmo com isto ligado.",
+      "actKeysCleared": "As permissões do modo de ação são mantidas, mas não serão salvas a menos que este agente volte ao modo de ação.",
+      "toolSuggestLabel": "Adicionar uma ferramenta conhecida",
+      "toolSuggestHint": "As sugestões vêm do registro de ações decidíveis por política, que não é a lista completa de ferramentas. Qualquer outra permitida a este agente ainda pode ser digitada acima.",
+      "toolSuggestAdd": "Adicionar"
     },
     "loading": "Carregando agentes…",
     "runs": {
@@ -1781,6 +1847,7 @@
       "refresh": "Atualizar",
       "refreshing": "Reconstruindo…",
       "retry": "Tentar novamente",
+      "moreActions": "Mais ações",
       "errors": {
         "load": "Não foi possível carregar o relatório de impacto.",
         "rebuild": "Não foi possível enfileirar a reconstrução do relatório.",
@@ -1793,6 +1860,15 @@
         "rebuildComplete": "O relatório de impacto foi reconstruído.",
         "rebuildStillRunning": "A reconstrução ainda está em andamento. Recarregue esta página em alguns minutos para ver os novos números."
       },
+      "emptyState": {
+        "title": "Ainda não há resultados de IA neste período",
+        "description": "Os resultados aparecerão aqui assim que seus agentes de IA avaliarem um alerta, triarem um chamado ou executarem uma correção no modo de observação ou de ação. Amplie o período do relatório acima ou configure um agente para começar.",
+        "action": "Configurar um agente"
+      },
+      "tileGroups": {
+        "judged": "Avaliados",
+        "executed": "Executados"
+      },
       "tiles": {
         "alertsJudged": "Alertas avaliados",
         "noiseFlagged": "Marcados como ruído",
@@ -1800,9 +1876,11 @@
         "draftsSent": "Rascunhos enviados",
         "fixesExecuted": "Correções executadas",
         "promoteEligible": "Operações elegíveis para promoção",
-        "promoteEligibleHint": "Operações com evidências suficientes e sem falhas para serem pré-autorizadas. Abra Configurações → Agentes de IA para revisar e promover.",
+        "promoteEligibleCaption": "Operações com evidências suficientes e sem falhas para serem pré-autorizadas. Abra Configurações → Agentes de IA para revisar e promover.",
         "estTimeSaved": "Tempo economizado estimado",
         "estTimeSavedValue": "{{hours}} horas",
+        "estTimeSavedCaption": "Estimado a partir de um tempo fixo por resultado.",
+        "howEstimatedToggle": "Como isso é estimado?",
         "llmSpend": "Gasto com LLM"
       },
       "weightsTooltipTitle": "Apenas uma estimativa — cada resultado recebe um tempo fixo:",
@@ -1886,6 +1964,8 @@
       "loading": "Carregando as evidências de graduação…",
       "error": "Não foi possível carregar as evidências de graduação.",
       "retry": "Tentar novamente",
+      "noBaselineTitle": "Ainda não há agente de referência",
+      "noBaseline": "O acompanhamento da graduação começa quando existir um agente de referência de todo o parceiro deste tipo. Crie um com o escopo \"Todas as organizações\" para começar a registrar evidências desta organização.",
       "orgRequired": "Escolha uma única organização no seletor de organizações para ver as evidências dela.",
       "empty": "Ainda não há evidências registradas para este agente.",
       "readOnlyNote": "A execução pré-autorizada está desligada nesta instalação; estes números são apenas informativos.",
@@ -1894,6 +1974,22 @@
       "approvalsLink": "Acompanhar esta solicitação na caixa de aprovações",
       "ceilingHint": "As chaves no nível do parceiro são um teto, não uma concessão. O agente de cada organização precisa receber a chave separadamente — pela graduação ou editando o agente daquela organização.",
       "promote": "Promover",
+      "revoke": "Revogar",
+      "emptyTitle": "Ainda não há evidências",
+      "demotedAt": "Revogada em {{at}}",
+      "demotedReason": "Motivo: {{reason}}",
+      "demoteReasons": {
+        "attempted_failure": "uma tentativa falhou",
+        "recurrence": "o alerta corrigido voltou",
+        "operator": "uma pessoa operadora a revogou"
+      },
+      "revokeConfirm": {
+        "title": "Revogar a pré-autorização",
+        "message": "{{opKey}} volta para a fila de aprovação do agente desta organização. Uma execução em andamento não é afetada; cada uma seguinte volta a exigir uma decisão humana.",
+        "action": "Revogar",
+        "reasonLabel": "Motivo (opcional)",
+        "reasonHint": "Registrado na entrada de auditoria desta revogação. Até 500 caracteres."
+      },
       "verifiedOfThreshold": "{{verified}} de {{threshold}}",
       "columns": {
         "opKey": "Operação",
@@ -1924,11 +2020,17 @@
         "action": "Solicitar aprovação"
       },
       "toasts": {
-        "requested": "Pré-autorização solicitada. Uma segunda pessoa precisa aprová-la antes que esta operação rode sem supervisão, e ela vale somente para execuções futuras."
+        "requested": "Pré-autorização solicitada. Uma segunda pessoa precisa aprová-la antes que esta operação rode sem supervisão, e ela vale somente para execuções futuras.",
+        "revoked": "Pré-autorização revogada. Esta operação volta a exigir uma decisão humana a partir da próxima execução."
       },
       "errors": {
         "promote": "Não foi possível abrir a solicitação de pré-autorização.",
-        "policyDecideDisabled": "A execução pré-autorizada está desligada nesta instalação, por isso esta operação não pode ser promovida."
+        "policyDecideDisabled": "A execução pré-autorizada está desligada nesta instalação, por isso esta operação não pode ser promovida.",
+        "revoke": "Não foi possível revogar a pré-autorização.",
+        "noPromotedGrant": "Esta operação não está pré-autorizada para esta organização, portanto não há o que revogar.",
+        "alreadyDemoted": "Esta operação já voltou para a fila de aprovação.",
+        "alreadyRevoked": "Esta operação já havia sido removida do agente, então nada mudou.",
+        "ambiguousOpKey": "Mais de um agente detém esta operação para esta organização. Abra o agente que deseja alterar e revogue-a por lá."
       },
       "reliability": {
         "caption": "Operações do modo de ação, somente leitura: não são chaves de política, portanto nunca podem ser pré-autorizadas."

--- a/apps/web/src/locales/tr-TR/approvals.json
+++ b/apps/web/src/locales/tr-TR/approvals.json
@@ -31,6 +31,16 @@
   "deciding": "Gönderiliyor…",
   "expiresIn": "{{minutes}} dk içinde sona erer",
   "expiresSoon": "Bir dakikadan kısa sürede sona erer",
+  "expired": "Süresi doldu",
+  "unknownOrganization": "Bilinmeyen kuruluş",
+  "charCount": "{{count}}/{{max}}",
+  "approveToast": "{{org}} için {{action}} onaylandı",
+  "pagination": {
+    "showing": "{{total}} kayıttan {{shown}} tanesi gösteriliyor",
+    "showingCount": "{{shown}} kayıt gösteriliyor",
+    "loadMore": "Daha fazla yükle",
+    "loadMoreError": "Daha fazlası yüklenemedi. Yeniden deneyin."
+  },
   "errors": {
     "noApproverDevice": "Profilinizde bir onay cihazı kaydedip yeniden deneyin.",
     "notSoleApprover": "Bu isteğe başka bir yetkili onaylayıcı karar vermelidir.",

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -1,4 +1,39 @@
 {
+  "aiAgentsRuns": {
+    "live": {
+      "label": "Canlı güncelleniyor"
+    },
+    "list": {
+      "clearFilters": "Filtreleri temizle",
+      "emptyDescription": "Uyarılar, zamanlamalar, biletler ve manuel eylemler tarafından tetiklenen çalıştırmalar, bir aracı bunları yürüttüğünde burada görünecektir.",
+      "emptyFilteredDescription": "Bu filtrelere uyan çalıştırma yok. Farklı bir aracı veya durum deneyin.",
+      "emptyConfigureLink": "AI aracılarını yapılandır"
+    },
+    "detail": {
+      "notFoundDescription": "Bu çalıştırma silinmiş olabilir veya bağlantı güncel olmayabilir.",
+      "trace": {
+        "emptyDescription": "Aracının önerdiği veya yürüttüğü araç çağrıları burada listelenecektir."
+      },
+      "ledger": {
+        "emptyDescription": "Aracının gerçekten çağırdığı araçlar burada listelenecektir.",
+        "statuses": {
+          "pending": "Beklemede",
+          "approved": "Onaylandı",
+          "executing": "Yürütülüyor",
+          "completed": "Tamamlandı",
+          "failed": "Başarısız",
+          "rejected": "Reddedildi"
+        }
+      },
+      "intents": {
+        "emptyDescription": "Bu çalıştırmanın istediği onaylar burada listelenecektir."
+      },
+      "triage": {
+        "categoryLabel": "Kategori",
+        "categoryUnresolved": "Önerildi — bu görünümde ad kullanılamıyor"
+      }
+    }
+  },
   "partnerServicePrincipals": {
     "title": "Hizmet sorumluları",
     "description": "İş ortağı kapsamındaki makine kimliklerini ve bunların erişim anahtarlarını yönetin.",
@@ -1380,7 +1415,7 @@
       "deleteOverride": "Geçersiz kılmayı kaldır",
       "confirmDelete": "Silmeyi onayla",
       "cron": "Cron ifadesi",
-      "cronHint": "Beş alan: dakika saat ayın-günü ay haftanın-günü. Örneğin 0 3 * * * her gün 03:00'te çalışır.",
+      "cronHint": "Beş alan: dakika saat ayın-günü ay haftanın-günü. Örneğin 0 3 * * * her gün 03:00'te çalışır. Dakika alanı, virgülle ayrılmış sabit sayılardan oluşmalıdır (*, / veya - kullanılamaz) — programlar en fazla saatte bir çalışır.",
       "cronInvalid": "Kaydetmeden önce geçerli, beş alanlı bir cron ifadesi girin.",
       "timezone": "Saat dilimi",
       "kinds": {
@@ -1400,6 +1435,9 @@
       "tightenOnly": "Geçersiz kılma temel çizgiyi yalnızca daraltabilir: taramayı kapatabilir veya denetim çıkarabilir, asla ekleyemez.",
       "noKinds": "Denetim yok",
       "lastRun": "Son çalışma {{at}} · {{total}} kuruluştan {{admitted}} tanesi tarandı, {{skipped}} atlandı.",
+      "nextRun": "Sonraki çalışma {{at}} ({{timezone}})",
+      "nextRunInvalid": "Geçersiz zamanlama",
+      "nextRunNone": "Önümüzdeki bir yıl içinde çalışma yok.",
       "kindLabels": {
         "disk_pressure": "Disk baskısı",
         "stale_agents": "Eskimiş aracılar",
@@ -1432,6 +1470,26 @@
     "title": "Yapay Zeka Aracıları",
     "description": "Bir politikaya sahip, adlandırılmış yapay zeka çalışanları. Temel çizgiyi iş ortakları belirler; kuruluşlar yalnızca daraltabilir.",
     "empty": "Henüz aracı yok.",
+    "kindHints": {
+      "triage": "Yeni uyarıları inceler ve ne yapılacağını önerir.",
+      "patch": "Eksik yamaları gözden geçirir ve nelerin kurulacağını önerir.",
+      "helpdesk": "Talepleri üstlenir; yanıt ve sonraki adım önerir."
+    },
+    "emptyState": {
+      "title": "Henüz aracı yok",
+      "description": "Aracı, çalışan bir süreç değil kayıtlı bir politikadır: seçtiğiniz uyarıları, yamaları ya da talepleri izler, izin verdiğiniz araçlarla inceler ve ardından bir çözüm önerir veya uygular. Gölge modunda başlayın: aracı önerir, bir kişi onaylar, böylece siz demeden hiçbir şey bir cihaza ulaşmaz.",
+      "action": "İlk aracınızı oluşturun"
+    },
+    "modeChoice": {
+      "legend": "Bu aracının yapabilecekleri",
+      "off": "Kapalı",
+      "offConsequence": "Hiçbir şey çalışmaz.",
+      "shadow": "Gölge",
+      "shadowConsequence": "İzler ve önerir; her şeyi bir kişi onaylar.",
+      "act": "Eylem",
+      "actConsequence": "İzin verilen işlemleri tıklama olmadan yürütür. Otomatik geri alma yoktur.",
+      "actUnavailable": "Bu aracı için henüz kullanılamıyor."
+    },
     "allOrgs": "Tüm kuruluşlar",
     "allOrgsHint": "İş ortağı genelinde: bir kuruluş daraltmadığı sürece her kuruluş için geçerlidir.",
     "stateEnabled": "Etkin",
@@ -1477,8 +1535,11 @@
     "sections": {
       "scope": "Ne zaman çalışır",
       "permissions": "İzinler",
+      "permissionsDescription": "Bu aracının nelere dokunabileceği. Araç listesi yapabileceklerini genişletir; korunan kaynaklar daraltır ve her zaman öncelikli olur.",
       "policyDecide": "Gözetimsiz politika yetkilendirmesi",
       "limits": "Sınırlar",
+      "limitsBudget": "Bütçe ve kapsam",
+      "limitsTiming": "Zamanlama",
       "notifications": "Bildirimler",
       "instructions": "Yönergeler"
     },
@@ -1536,7 +1597,12 @@
       "supervisedActionKeysEmpty": "Politikayla karar verilebilecek işlem kayıtlı değil.",
       "supervisedActionKeysFailed": "Politikayla karar verilebilecek işlem listesi yüklenemedi, bu nedenle gözetimsiz yetkilendirme şu anda değiştirilemiyor.",
       "ticketAutonomousWrites": "Otonom talep yazmaları",
-      "ticketAutonomousWritesHint": "Yalnızca organizasyon geçersiz kılması — otonom talep yazmaları eylem modunu ve bu organizasyon düzeyindeki katılımı gerektirir"
+      "ticketAutonomousWritesHint": "Yalnızca organizasyon geçersiz kılması — otonom talep yazmaları eylem modunu ve bu organizasyon düzeyindeki katılımı gerektirir",
+      "enabledHint": "«Etkin» ve mod ayrı anahtarlardır ve bir çalıştırma ikisini de gerektirir: bu kapalıyken mod ne olursa olsun hiçbir şey çalışmaz, Kapalı modda ise bu açık olsa bile hiçbir şey çalışmaz.",
+      "actKeysCleared": "Eylem modu izinleri saklanır, ancak bu araç yeniden Eylem moduna dönmedikçe kaydedilmez.",
+      "toolSuggestLabel": "Bilinen bir araç ekle",
+      "toolSuggestHint": "Öneriler, araçların tam listesi olmayan politikayla karara bağlanabilir eylemler kaydından gelir. Bu aracının kullanabileceği diğer araçlar yukarıya yine de yazılabilir.",
+      "toolSuggestAdd": "Ekle"
     },
     "loading": "Aracılar yükleniyor…",
     "runs": {
@@ -1781,6 +1847,7 @@
       "refresh": "Yenile",
       "refreshing": "Yeniden oluşturuluyor…",
       "retry": "Yeniden dene",
+      "moreActions": "Diğer işlemler",
       "errors": {
         "load": "Etki raporu yüklenemedi.",
         "rebuild": "Etki raporunun yeniden oluşturulması sıraya alınamadı.",
@@ -1793,6 +1860,15 @@
         "rebuildComplete": "Etki raporu yeniden oluşturuldu.",
         "rebuildStillRunning": "Yeniden oluşturma hâlâ sürüyor. Yeni rakamları görmek için bu sayfayı birkaç dakika sonra yeniden yükleyin."
       },
+      "emptyState": {
+        "title": "Bu dönemde henüz yapay zekâ sonucu yok",
+        "description": "Yapay zekâ ajanlarınız gölge veya eylem modunda bir uyarıyı değerlendirdiğinde, bir bileti sınıflandırdığında ya da bir düzeltme uyguladığında sonuçlar burada görünecek. Yukarıdaki raporlama dönemini genişletin veya başlamak için bir ajan kurun.",
+        "action": "Ajan kur"
+      },
+      "tileGroups": {
+        "judged": "Değerlendirilen",
+        "executed": "Uygulanan"
+      },
       "tiles": {
         "alertsJudged": "Değerlendirilen uyarılar",
         "noiseFlagged": "Gürültü olarak işaretlenenler",
@@ -1800,9 +1876,11 @@
         "draftsSent": "Gönderilen taslaklar",
         "fixesExecuted": "Uygulanan düzeltmeler",
         "promoteEligible": "Yükseltmeye uygun işlemler",
-        "promoteEligibleHint": "Ön yetkilendirme için yeterli ve hatasız kanıta sahip işlemler. İncelemek ve yükseltmek için Ayarlar → Yapay Zekâ Ajanları'nı açın.",
+        "promoteEligibleCaption": "Ön yetkilendirme için yeterli ve hatasız kanıta sahip işlemler. İncelemek ve yükseltmek için Ayarlar → Yapay Zekâ Ajanları'nı açın.",
         "estTimeSaved": "Tahmini kazanılan zaman",
         "estTimeSavedValue": "{{hours}} saat",
+        "estTimeSavedCaption": "Sonuç başına sabit bir süre üzerinden tahmin edilir.",
+        "howEstimatedToggle": "Bu nasıl tahmin ediliyor?",
         "llmSpend": "LLM harcaması"
       },
       "weightsTooltipTitle": "Yalnızca bir tahmin — her sonuca sabit bir süre yazılır:",
@@ -1886,6 +1964,8 @@
       "loading": "Yetkilendirme kanıtları yükleniyor…",
       "error": "Yetkilendirme kanıtları yüklenemedi.",
       "retry": "Yeniden dene",
+      "noBaselineTitle": "Henüz temel araç yok",
+      "noBaseline": "Kademeli yetkilendirme takibi, bu türde ortak genelinde bir temel araç oluşturulduğunda başlar. Bu kuruluş için kanıt takibini başlatmak üzere \"Tüm kuruluşlar\" kapsamıyla bir tane oluşturun.",
       "orgRequired": "Kanıtları görmek için kuruluş seçiciden tek bir kuruluş seçin.",
       "empty": "Bu araç için henüz hiç kanıt kaydedilmedi.",
       "readOnlyNote": "Önceden yetkili çalıştırma bu kurulumda kapalı; bu sayılar yalnızca bilgi amaçlıdır.",
@@ -1894,6 +1974,22 @@
       "approvalsLink": "Bu isteği onay kutusunda izleyin",
       "ceilingHint": "İş ortağı düzeyindeki anahtarlar bir tavandır, bir izin değildir. Her kuruluşun aracına anahtar ayrıca verilmelidir — kademeli yetkilendirmeyle ya da o kuruluşun aracını düzenleyerek.",
       "promote": "Yükselt",
+      "revoke": "Geri al",
+      "emptyTitle": "Henüz kanıt yok",
+      "demotedAt": "{{at}} tarihinde geri alındı",
+      "demotedReason": "Gerekçe: {{reason}}",
+      "demoteReasons": {
+        "attempted_failure": "bir deneme başarısız oldu",
+        "recurrence": "düzeltilen uyarı yeniden ortaya çıktı",
+        "operator": "bir operatör geri aldı"
+      },
+      "revokeConfirm": {
+        "title": "Ön yetkiyi geri al",
+        "message": "{{opKey}}, bu kuruluşun aracısı için onay kuyruğuna geri döner. Sürmekte olan bir çalıştırma etkilenmez; sonraki her çalıştırma yeniden insan kararı gerektirir.",
+        "action": "Geri al",
+        "reasonLabel": "Gerekçe (isteğe bağlı)",
+        "reasonHint": "Bu geri alma işleminin denetim kaydına yazılır. En çok 500 karakter."
+      },
       "verifiedOfThreshold": "{{threshold}} içinde {{verified}}",
       "columns": {
         "opKey": "İşlem",
@@ -1924,11 +2020,17 @@
         "action": "Onay iste"
       },
       "toasts": {
-        "requested": "Ön yetki istendi. Bu işlem gözetimsiz çalışmadan önce ikinci bir kişinin onaylaması gerekir ve yalnızca gelecekteki çalıştırmalar için geçerlidir."
+        "requested": "Ön yetki istendi. Bu işlem gözetimsiz çalışmadan önce ikinci bir kişinin onaylaması gerekir ve yalnızca gelecekteki çalıştırmalar için geçerlidir.",
+        "revoked": "Ön yetki geri alındı. Bu işlem, bir sonraki çalıştırmadan başlayarak yeniden insan kararı gerektirir."
       },
       "errors": {
         "promote": "Ön yetki isteği oluşturulamadı.",
-        "policyDecideDisabled": "Önceden yetkili çalıştırma bu kurulumda kapalı, bu yüzden bu işlem yükseltilemez."
+        "policyDecideDisabled": "Önceden yetkili çalıştırma bu kurulumda kapalı, bu yüzden bu işlem yükseltilemez.",
+        "revoke": "Ön yetki geri alınamadı.",
+        "noPromotedGrant": "Bu işlem bu kuruluş için önceden yetkilendirilmemiş, dolayısıyla geri alınacak bir şey yok.",
+        "alreadyDemoted": "Bu işlem zaten onay kuyruğuna geri dönmüş.",
+        "alreadyRevoked": "Bu işlem aracıdan zaten kaldırılmıştı, hiçbir şey değişmedi.",
+        "ambiguousOpKey": "Bu kuruluş için bu işlemi birden fazla aracı tutuyor. Değiştirmek istediğiniz aracıyı açıp orada geri alın."
       },
       "reliability": {
         "caption": "Eylem kipi işlemleri, salt okunur: bunlar politika anahtarı değildir, bu yüzden asla önceden yetkilendirilemez."


### PR DESCRIPTION
## Summary

Fix pass from an Impeccable design critique of the AI agents UI (`/impeccable critique`, score 21/40; snapshot in `.impeccable/critique/`, not committed). Covers all six priority issues plus the review-round findings. Follow-up to #4187.

### Approver trust
- **Customer name on every approval card and group header**, org-first grouping. Pending-approvals DTO gains `orgName` (one batched `organizations` lookup per page; rows were already caller-scoped and `orgId` was already in the payload).
- **Cursor paging** ("Showing N of M", Load more); polls and WS nudges keep loaded pages. Live expiry countdown, expired cards disabled. Approve button now AA in both themes.
- **Revoke** for promoted graduation rows: new `POST /ai/agents/graduation/revoke` `{ orgId, opKey, kind?, reason? }` with the same `scopes` + `ai_agents:write` + `canAccessOrg` gates as promote, RLS-scoped precondition read, `demoteSupervisedKey(reason: 'operator')`, audit `ai_agent.graduation.revoke`. No second approver by design (revoke reduces privilege). `demoted` rows show reason and time. No migration: `demote_reason` is unconstrained text.
- **Runs list/detail poll** while a run is live (10s / 5s), idle 30s on unfiltered page 1 so new runs appear, paused when hidden, stale-response guarded. `cancelled` stays neutral.

### Mode as the first decision
- Agent form: Mode is a three-option radiogroup with consequences on the face, act warning + acknowledgement attached to the act card, keyboard roving. Leaving act keeps the grant list in the draft and omits it at save time (previously destroyed on a misclick).
- Editor opens in a `Drawer`; Permissions gets a real heading; Limits split into two labelled groups; tool allowlist gets a datalist from the policy-decidable keys (no tool registry endpoint exists, noted below).
- Schedules: client-computed **Next run** for the server's cron subset, inline enforcement of the hourly-floor rule, preview only when valid.

### Dark mode and states
- New `aiAgents/statusBadge.ts` tone helper (light + dark, AA) replaces every light-only badge across 9 files; chart fills move to themed CSS variables and off amber.
- New `shared/EmptyState.tsx` replaces bare empty paragraphs at every entry point: first-run panel on `/settings/ai-agents`, single empty state on Impact when the window has no outcomes (the old `chartRows.length === 0` guard never fired on 30 zero buckets), graduation panel "no partner baseline yet" instead of a retryable error.
- `shared/scrollLock.ts`: refcounted body scroll lock shared by Dialog and Drawer (a confirm inside the drawer used to unlock the page).

### Verification
- Web: tsc clean, 703 files / 7482 tests green (full suite, pre-rebase), 661 in the touched suites post-fix; `localeParity`, `keyUsage`, `translationCoverage` (+1 baseline for format-only `{{count}}/{{max}}`), `no-silent-mutations` green. Impeccable detector: 0 findings.
- API: tsc clean, 272 tests in `routes/aiAgents` + `routes/approvals` (14 new revoke cases incl. cross-partner 403, ambiguity 409, already-revoked 409).
- One independent review round (Opus): all 3 P1 + 5 P2 findings fixed in this PR; revoke authorization and `orgName` scoping reviewed clean.
- Live smoke on a wt-stack at 1440/390, light/dark: all four pages pass; a real sweep run populated the runs list and dark badges verified legible.

### Not in this PR (filed as notes, no issue yet)
- No tool-name registry endpoint (`GET /ai/agents/tools`), so the allowlist stays free-text with a partial datalist.
- `ai_agent_graduation` has no `demoted_by` column; operator identity lives on the audit row only. Adding it needs a migration plus export-policy registration.
- Trace entries carry no timestamp on the wire, so the run narrative cannot be aligned with the ledger.
- Cron next-run does not model DST transitions (documented in the module).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EDZToQ9YjbpojJorSx28M2
