### PR TITLE
fix(tickets): scope AI draft card action lock to its own draft id (#4469)

### DIFF
--- a/apps/web/src/components/tickets/TicketWorkbench.test.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.test.tsx
@@ -935,6 +935,54 @@ describe('TicketWorkbench AI drafts (#4191, Task 11)', () => {
     resolveTk2Drafts(makeJsonResponse({ data: [resolutionDraft] }));
     await screen.findByTestId('ticket-ai-draft-resolution_note');
   });
+
+  // #4469 — the two draft cards are independent operations (different draft
+  // ids); acting on one must not block the other. Holds the reply's send
+  // request open (never resolved during the assertion) so the resolution_note
+  // card's discard click happens while sendingDraftId is still set to the
+  // OTHER draft's id — a regression that guards on "any in-flight action"
+  // rather than "this draft's own in-flight action" would silently swallow
+  // the discard click here (the button isn't visually disabled, but the
+  // handler's guard clause no-ops before the fetch fires).
+  it('#4469: discarding one draft while the other is mid-send still fires the discard request', async () => {
+    let resolveSend!: (value: Response) => void;
+    const sendPromise = new Promise<Response>((resolve) => { resolveSend = resolve; });
+
+    mockDraftsApi([replyDraft, resolutionDraft], (url, init) => {
+      if (url === '/tickets/tk-1/ai-drafts/draft-reply-1/send' && init?.method === 'POST') {
+        return sendPromise as unknown as Response;
+      }
+      return null;
+    });
+
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+    await screen.findByTestId('ticket-ai-draft-reply');
+    await screen.findByTestId('ticket-ai-draft-resolution_note');
+
+    fireEvent.click(screen.getByTestId('ticket-ai-draft-reply-send'));
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/tickets/tk-1/ai-drafts/draft-reply-1/send',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+
+    // Reply's send is still in flight (sendPromise unresolved) when the
+    // resolution_note card is discarded.
+    fireEvent.click(screen.getByTestId('ticket-ai-draft-resolution_note-discard'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/tickets/tk-1/ai-drafts/draft-note-1/discard',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+
+    resolveSend(makeJsonResponse({ success: true }));
+    await waitFor(() => {
+      expect(screen.queryByTestId('ticket-ai-draft-reply')).toBeNull(); // send completed, card removed
+    });
+  });
 });
 
 describe('TicketWorkbench pending/on_hold prompt', () => {

--- a/apps/web/src/components/tickets/TicketWorkbench.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.tsx
@@ -686,7 +686,11 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
   // only; the API 409s a resolution_note draft here (it's consumed only via
   // the resolve flow's aiDraftId, below).
   const sendAiDraft = useCallback(async (draft: TicketAiDraft) => {
-    if (sendingDraftId || discardingDraftId) return;
+    // Scoped to this draft's own id — each draft card is an independent
+    // operation (#4469). Guarding on "any in-flight action" blocked acting on
+    // one card while the other was mid-request, even though the button
+    // itself wasn't visually disabled.
+    if (sendingDraftId === draft.id || discardingDraftId === draft.id) return;
     const content = (draftContent[draft.id] ?? draft.content).trim();
     if (!content) return;
     setSendingDraftId(draft.id);
@@ -718,7 +722,8 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
 
   // Discards a draft (either kind) without acting on it.
   const discardAiDraft = useCallback(async (draft: TicketAiDraft) => {
-    if (sendingDraftId || discardingDraftId) return;
+    // Scoped to this draft's own id — see sendAiDraft above (#4469).
+    if (sendingDraftId === draft.id || discardingDraftId === draft.id) return;
     setDiscardingDraftId(draft.id);
     try {
       await runAction({


### PR DESCRIPTION
## Summary
- The ticket workbench's reply-draft and resolution-note-draft AI cards are independent (`ticket_drafts_active_uq`: at most one active `reply` + one active `resolution_note` per ticket), but `sendAiDraft`/`discardAiDraft` guarded on "any in-flight action" (`if (sendingDraftId || discardingDraftId) return;`) instead of the specific draft being acted on.
- Effect: clicking discard on the resolution_note card while the reply card's send was in flight silently no-opped — the button wasn't visually disabled (its `disabled` prop was already correctly scoped per draft id), but the handler's own guard clause returned before the fetch ever fired.
- Fix: scope both guards to `draft.id` (`sendingDraftId === draft.id || discardingDraftId === draft.id`) so the two cards can be acted on concurrently, matching the already-correct `disabled` UI state.

Closes #4469

## Test plan
- [x] Added a regression test (`#4469: discarding one draft while the other is mid-send still fires the discard request`) that holds the reply card's send request open and asserts the resolution_note card's discard POST still fires — confirmed **red** against the pre-fix code (discard fetch never called), then **green** after the fix.
- [x] `cd apps/web && npx vitest run src/components/tickets/TicketWorkbench.test.tsx` — 102 passed.
- [x] `cd apps/web && npx tsc --noEmit -p .` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)