### PR TITLE
fix(alerts): skip baseline notification fan-out for suppressed/dismissed alerts (#4123)

### DIFF
--- a/apps/api/src/services/notificationDispatcher.orderingGuards.test.ts
+++ b/apps/api/src/services/notificationDispatcher.orderingGuards.test.ts
@@ -167,6 +167,40 @@ describe('processAlertNotifications status guard (a)', () => {
   });
 });
 
+describe('processAlertNotifications status guard (#4123, table-driven)', () => {
+  it.each([
+    { status: 'resolved', expectSkip: true },
+    { status: 'suppressed', expectSkip: true },
+    { status: 'dismissed', expectSkip: true },
+    { status: 'active', expectSkip: false }
+  ])('status=$status → skip baseline fan-out: $expectSkip', async ({ status, expectSkip }) => {
+    if (expectSkip) {
+      selectQueue.push([makeAlert({ status })]);
+    } else {
+      selectQueue.push(
+        [makeAlert({ status })], // alert
+        [{ id: 'device-1', displayName: 'Server-1' }], // device
+        [{ partnerId: null }], // org (partnerIdForOrg)
+        [], // routing rules (no match)
+        [{ id: 'channel-1' }], // org channels fallback
+        [{ id: 'channel-1' }] // validChannels
+      );
+    }
+
+    const result = await processAlertNotifications({ type: 'process-alert', alertId: 'alert-1' });
+
+    if (expectSkip) {
+      expect(result).toEqual({ queued: 0, inAppSent: false, durationMs: expect.any(Number) });
+      expect(sendInAppNotificationMock).not.toHaveBeenCalled();
+      expect(queueAddBulkMock).not.toHaveBeenCalled();
+    } else {
+      expect(result.queued).toBe(1);
+      expect(sendInAppNotificationMock).toHaveBeenCalledTimes(1);
+      expect(queueAddBulkMock).toHaveBeenCalledTimes(1);
+    }
+  });
+});
+
 describe('processAlertNotifications baseline send jobId (c)', () => {
   it('enqueues baseline sends with a stable jobId so a retried process-alert cannot duplicate the fan-out', async () => {
     selectQueue.push(

--- a/apps/api/src/services/notificationDispatcher.ts
+++ b/apps/api/src/services/notificationDispatcher.ts
@@ -207,14 +207,17 @@ export async function processAlertNotifications(data: ProcessAlertJobData): Prom
     return { queued: 0, inAppSent: false, durationMs: Date.now() - startTime };
   }
 
-  // Durable status guard (#4085): `cancelAlertEscalations` only removes jobs
-  // that are DELAYED at the moment it runs — an optimization, not the
-  // correctness mechanism. Under queue delivery, `alert.resolved` can
-  // process before a retried `alert.triggered` delivery, which would
-  // otherwise re-fan-out the whole baseline notification set for an alert
-  // that is already closed. Acknowledged still gets the baseline — only
-  // escalations are cancelled on ack (today's semantics, preserved).
-  if (alert.status === 'resolved') {
+  // Durable status guard (#4085, widened #4123): `cancelAlertEscalations`
+  // only removes jobs that are DELAYED at the moment it runs — an
+  // optimization, not the correctness mechanism. Under queue delivery,
+  // `alert.resolved` can process before a retried `alert.triggered`
+  // delivery, which would otherwise re-fan-out the whole baseline
+  // notification set for an alert that is already closed. A `process-alert`
+  // job landing after a tech suppresses/dismisses an alert has the same
+  // exposure — it must not send the full baseline into the snooze window.
+  // Acknowledged still gets the baseline — only escalations are cancelled
+  // on ack (today's semantics, preserved; decision: issue #4123).
+  if (alert.status === 'resolved' || alert.status === 'suppressed' || alert.status === 'dismissed') {
     return { queued: 0, inAppSent: false, durationMs: Date.now() - startTime };
   }
 


### PR DESCRIPTION
## Summary
- `processAlertNotifications` (`apps/api/src/services/notificationDispatcher.ts`) only skipped the baseline in-app/channel fan-out for `resolved` alerts. A `process-alert` job landing after a tech suppresses or dismisses an alert would still send the full baseline (email/SMS/Slack/etc.) into the snooze window.
- Widen the guard to also skip `suppressed` and `dismissed`, per the decision recorded on #4123 (2026-09-02, handoff board D5). `acknowledged` is unchanged — it still gets the baseline fan-out (only escalations are cancelled on ack, per #4085).
- Added a table-driven test (`resolved` / `suppressed` / `dismissed` → skip; `active` → still fans out) to `notificationDispatcher.orderingGuards.test.ts`, alongside the existing resolved/acknowledged guard tests.

Closes #4123

## Test plan
- [x] New table-driven test written first and confirmed red against the old guard (suppressed/dismissed fanned out) before the fix
- [x] `cd apps/api && npx vitest run src/services/notificationDispatcher.orderingGuards.test.ts src/services/notificationDispatcher.test.ts src/services/notificationDispatcher.dedupe.test.ts src/services/notificationDispatcher.claimCasSql.test.ts src/services/notificationDispatcher.routingSites.test.ts src/services/notificationDispatcher.sms.test.ts` — 46/46 passed
- [x] `NODE_OPTIONS="--max-old-space-size=8192" npx tsc --noEmit -p apps/api` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)