### PR TITLE
fix(ai-agents,approvals): partner ceiling hint in Shadow, collapse per-intent links, client BATCH_MAX guard

### DIFF
--- a/apps/api/src/services/approvals/batchDecide.ts
+++ b/apps/api/src/services/approvals/batchDecide.ts
@@ -13,7 +13,7 @@ import {
   type AssuranceDecision,
 } from '../authenticatorAssurance';
 import { decideApprovalRequest, type DecideApprovalResult } from './decideApprovalRequest';
-import type { ApprovalProof, RiskTier } from '@breeze/shared';
+import { APPROVAL_BATCH_MAX, type ApprovalProof, type RiskTier } from '@breeze/shared';
 
 /**
  * P2-2 (#4189): decide MANY approval cards with ONE assertion ceremony.
@@ -45,8 +45,12 @@ import type { ApprovalProof, RiskTier } from '@breeze/shared';
  */
 
 /** Hard cap on one batch. Matches the inbox page size (`PENDING_PAGE_MAX`),
- *  so "select everything on this page" is always expressible in one call. */
-export const BATCH_MAX = 50;
+ *  so "select everything on this page" is always expressible in one call.
+ *  Re-exported under the historical local name — the value itself lives in
+ *  `@breeze/shared`'s `APPROVAL_BATCH_MAX` so the web inbox's client-side
+ *  guard (#4460) can import the exact same number instead of a copy that
+ *  could drift. */
+export const BATCH_MAX = APPROVAL_BATCH_MAX;
 
 /**
  * The `approvalId` namespace ONE ceremony is minted and verified under, so the

--- a/apps/web/src/components/aiAgents/RunDetailPage.test.tsx
+++ b/apps/web/src/components/aiAgents/RunDetailPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
@@ -697,6 +697,31 @@ describe('RunDetailPage ticket triage proposal', () => {
     expect(intentRow).toHaveTextContent('approved');
 
     expect(screen.getByTestId('ai-agent-run-triage-draft-draft-91')).toBeInTheDocument();
+  });
+
+  // #4468: a ticket-triage run can propose several intents (one row each),
+  // but they all resolve to the SAME /approvals inbox — a link repeated once
+  // per row added nothing and read as N distinct destinations. Only one
+  // collapsed link should render for the whole intents list.
+  it('collapses repeated per-intent /approvals links into a single link', async () => {
+    const secondIntent = { ...TICKET_INTENT, id: 'intent-43', actionName: 'manage_tickets:add_note', status: 'pending' };
+    mockEndpoints({
+      detail: {
+        ...RUN_DETAIL,
+        ticketProposal: { ...TICKET_PROPOSAL, intentIds: ['intent-42', 'intent-43'] },
+        intents: [TICKET_INTENT, secondIntent],
+      },
+    });
+    render(<RunDetailPage runId="run-1" />);
+
+    const intentsSection = await screen.findByTestId('ai-agent-run-triage-intents');
+    await screen.findByTestId('ai-agent-run-triage-intent-intent-42');
+    await screen.findByTestId('ai-agent-run-triage-intent-intent-43');
+
+    const approvalsLinks = within(intentsSection)
+      .getAllByRole('link')
+      .filter((link) => link.getAttribute('href') === '/approvals');
+    expect(approvalsLinks).toHaveLength(1);
   });
 
   it('never renders raw tool args/input/output anywhere in the triage section', async () => {

--- a/apps/web/src/components/aiAgents/RunDetailPage.tsx
+++ b/apps/web/src/components/aiAgents/RunDetailPage.tsx
@@ -534,13 +534,21 @@ function TicketProposalSection({
                   <span className="text-xs text-muted-foreground">
                     {intent?.status ?? t('aiAgentsPage.runs.triage.intentUnknown')}
                   </span>
-                  <a href="/approvals" className="text-primary hover:underline">
-                    {t('aiAgentsPage.runs.detail.intents.viewAll')}
-                  </a>
                 </li>
               );
             })}
           </ul>
+          {/* #4468: every intentId above resolves to the SAME /approvals
+              inbox — a link repeated once per row added nothing over a
+              single link for the whole batchable set, and read as N
+              separate destinations rather than one. */}
+          <a
+            href="/approvals"
+            data-testid="ai-agent-run-triage-intents-approvals-link"
+            className="mt-1 inline-block text-primary hover:underline"
+          >
+            {t('aiAgentsPage.runs.detail.intents.viewAll')}
+          </a>
         </div>
       )}
 

--- a/apps/web/src/components/approvals/ApprovalsInbox.test.tsx
+++ b/apps/web/src/components/approvals/ApprovalsInbox.test.tsx
@@ -536,6 +536,28 @@ describe('ApprovalsInbox — grouped agent cards and batch decisions', () => {
     expect(navigateToMock).not.toHaveBeenCalled();
   });
 
+  // #4460: the server hard-caps one batch at BATCH_MAX (50,
+  // services/approvals/batchDecide.ts) and previously that was the ONLY
+  // place enforcing it — a group larger than 50 would round-trip to the
+  // server just to learn that. Mirrors it client-side via the shared
+  // `APPROVAL_BATCH_MAX` constant so an oversized group is refused locally,
+  // with the same "whole batch" inline messaging as the other refusal
+  // kinds, and never reaches the network.
+  it('refuses to submit a group larger than the batch max without calling the server', async () => {
+    const oversizedGroup = Array.from({ length: 51 }, (_, i) => agentCard(`ap-${i}`));
+    routeFetch(oversizedGroup);
+    render(<ApprovalsInbox />);
+    await screen.findByTestId(`approval-group-${GROUP_KEY}`);
+
+    fireEvent.click(screen.getByTestId(`approval-group-approve-${GROUP_KEY}`));
+
+    const error = await screen.findByTestId(`approval-group-error-${GROUP_KEY}`);
+    expect(error).toHaveTextContent(/too many/i);
+    expect(batchCalls()).toHaveLength(0);
+    expect(authenticatorMock.getBatchApprovalAssertion).not.toHaveBeenCalled();
+    expect(screen.getByTestId('approval-row-ap-0')).toBeInTheDocument();
+  });
+
   it('leaves every row in place and explains a 422 batch_not_homogeneous', async () => {
     routeFetch([agentCard('ap-a'), agentCard('ap-b')], {
       status: 422,

--- a/apps/web/src/components/approvals/ApprovalsInbox.tsx
+++ b/apps/web/src/components/approvals/ApprovalsInbox.tsx
@@ -4,6 +4,7 @@ import { AlertTriangle, Bot, Check, CheckCheck, Layers, Loader2, ShieldCheck, X 
 import { useTranslation } from 'react-i18next';
 import {
   AI_AGENT_KINDS,
+  APPROVAL_BATCH_MAX,
   type AiAgentGraduationDto,
   type AiAgentGraduationRowDto,
   type AiAgentKind,
@@ -49,7 +50,7 @@ type DecisionErrorKind =
   | 'decisionFailed';
 /** Group headers add the two WHOLE-batch refusals, which are never per-row:
  *  nothing was decided, so they belong above the cards, not on one of them. */
-type GroupErrorKind = DecisionErrorKind | 'batchStepUp' | 'batchNotHomogeneous';
+type GroupErrorKind = DecisionErrorKind | 'batchStepUp' | 'batchNotHomogeneous' | 'batchTooLarge';
 
 interface PendingApproval {
   id: string;
@@ -679,6 +680,18 @@ export default function ApprovalsInbox() {
   ) => {
     if (busy) return;
     const ids = group.members.map((member) => member.id);
+
+    // #4460: mirror the server's hard cap (`BATCH_MAX` in
+    // services/approvals/batchDecide.ts, sourced from the same
+    // `APPROVAL_BATCH_MAX` constant) client-side. Unreachable today at the
+    // 25-row inbox page size, but the two limits are independent numbers —
+    // this is what keeps a future page-size bump from silently outrunning
+    // the batch cap and turning "Approve all" into a guaranteed 422 with no
+    // WebAuthn ceremony even attempted.
+    if (ids.length > APPROVAL_BATCH_MAX) {
+      setGroupError(group.identity, 'batchTooLarge');
+      return;
+    }
 
     setDecidingIds(new Set(ids));
     clearRowErrors(ids);

--- a/apps/web/src/components/approvals/ApprovalsInbox.tsx
+++ b/apps/web/src/components/approvals/ApprovalsInbox.tsx
@@ -719,6 +719,14 @@ export default function ApprovalsInbox() {
         setGroupError(group.identity, 'batchNotHomogeneous');
         return;
       }
+      // Defense-in-depth only: the client-side APPROVAL_BATCH_MAX check above
+      // refuses an oversized group before this call is ever made, so the
+      // server only answers `batch_too_large` on a stale bundle or a group
+      // that grew between render and submit.
+      if (outcome.outcome === 'batch_too_large') {
+        setGroupError(group.identity, 'batchTooLarge');
+        return;
+      }
 
       const decided = new Set<string>();
       const failures: Record<string, DecisionErrorKind> = {};

--- a/apps/web/src/components/settings/AiAgentForm.tsx
+++ b/apps/web/src/components/settings/AiAgentForm.tsx
@@ -673,11 +673,18 @@ export default function AiAgentForm({
         )}
 
         {/* Wave 5 Part B (#3827). Gated the same way as the act-warning block
-            above (draft.mode === 'act' only) — the "act acknowledgement
-            pattern": this is additional unattended authority an operator is
-            opting into only once they are already looking at the act-mode
-            warning, never offered for shadow/off. */}
-        {draft.mode === 'act' && (
+            above (draft.mode === 'act' only) for ORG rows — the "act
+            acknowledgement pattern": this is additional unattended authority
+            an operator is opting into only once they are already looking at
+            the act-mode warning, never offered for shadow/off.
+            PARTNER rows are the exception (#4583): per P2-5 (#4192) a
+            partner row's keys are a CEILING on org grants, not authority the
+            partner row exercises itself — ticking a key here authorizes
+            nothing on its own regardless of the partner row's own mode, so
+            gating the editor (and its ceiling hint) behind the partner row's
+            act mode hid the warning precisely when it mattered: while
+            editing a Shadow-mode baseline. */}
+        {(draft.mode === 'act' || draft.ownerScope === 'partner') && (
           <fieldset className="space-y-2 rounded-md border p-3 md:col-span-2" data-testid="ai-agent-policy-decide">
             <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
               {t('aiAgentsPage.sections.policyDecide')}

--- a/apps/web/src/components/settings/AiAgentGraduationPanel.test.tsx
+++ b/apps/web/src/components/settings/AiAgentGraduationPanel.test.tsx
@@ -5,6 +5,7 @@ import type {
   AiAgentGraduationByOrgDto,
   AiAgentGraduationDto,
   AiAgentGraduationRowDto,
+  AiAgentMode,
 } from '@breeze/shared';
 
 const fetchWithAuth = vi.fn();
@@ -372,12 +373,12 @@ describe('AiAgentGraduationPanel — states with nothing to fetch', () => {
 });
 
 describe('AiAgentForm — partner ceiling hint', () => {
-  const agent = (ownerScope: 'partner' | 'organization'): AiAgentDto => ({
+  const agent = (ownerScope: 'partner' | 'organization', mode: AiAgentMode = 'act'): AiAgentDto => ({
     id: 'agent-1',
     kind: 'patch',
     name: 'Patch agent',
     enabled: true,
-    mode: 'act',
+    mode,
     model: null,
     orgId: ownerScope === 'organization' ? 'org-1' : null,
     partnerId: 'partner-1',
@@ -397,13 +398,13 @@ describe('AiAgentForm — partner ceiling hint', () => {
     updatedAt: '2026-08-01T00:00:00.000Z',
   });
 
-  function renderForm(ownerScope: 'partner' | 'organization') {
+  function renderForm(ownerScope: 'partner' | 'organization', mode: AiAgentMode = 'act') {
     mockGraduation(dto());
     scopeState.orgId = ownerScope === 'organization' ? 'org-1' : null;
     scopeState.isPartnerScope = ownerScope === 'partner';
     render(
       <AiAgentForm
-        agent={agent(ownerScope)}
+        agent={agent(ownerScope, mode)}
         agents={[]}
         showOwnerScope={ownerScope === 'partner'}
         defaultOwnerScope={ownerScope}
@@ -422,5 +423,25 @@ describe('AiAgentForm — partner ceiling hint', () => {
     renderForm('organization');
     await screen.findByTestId('ai-agent-policy-decide');
     expect(screen.queryByTestId('ai-agent-supervised-keys-ceiling-hint')).toBeNull();
+  });
+
+  // #4583: partner-level supervisedActionKeys are a CEILING that bounds org
+  // grants regardless of the partner row's OWN mode (P2-5, #4533) — a partner
+  // admin editing keys on a Shadow-mode baseline still needs the warning that
+  // orgs must be granted individually, so the editor (and its hint) must not
+  // be hidden behind the partner row's own act-mode gate.
+  it('shows the policy-decide editor and ceiling hint on a Shadow-mode partner form', async () => {
+    renderForm('partner', 'shadow');
+    await screen.findByTestId('ai-agent-policy-decide');
+    expect(await screen.findByTestId('ai-agent-supervised-keys-ceiling-hint')).toBeTruthy();
+  });
+
+  // An org row's editor still represents live, self-granted authority (not a
+  // ceiling), so the "only offered once already in act mode" gate remains for
+  // org-owned rows — this stays hidden in Shadow.
+  it('still hides the policy-decide editor on a Shadow-mode org form', async () => {
+    renderForm('organization', 'shadow');
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalled());
+    expect(screen.queryByTestId('ai-agent-policy-decide')).toBeNull();
   });
 });

--- a/apps/web/src/lib/intentApprovals.test.ts
+++ b/apps/web/src/lib/intentApprovals.test.ts
@@ -299,6 +299,21 @@ describe('decideIntentApprovalBatch', () => {
       expect(fetchWithAuth).not.toHaveBeenCalled();
     });
 
+    it('maps a 400 batch_too_large to its own outcome, not a ceremony failure', async () => {
+      // #4460: ApprovalsInbox's client-side APPROVAL_BATCH_MAX guard refuses
+      // an oversized group before this ever runs, so this only fires on a
+      // stale bundle or a group that grew between render and submit — but it
+      // must still be reported honestly rather than as a fingerprint failure.
+      getBatchApprovalAssertion.mockRejectedValue(
+        new AssertionChallengeError('batch_too_large', 400, 'batch_too_large'),
+      );
+
+      const outcome = await decideIntentApprovalBatch(IDS, 'approve');
+
+      expect(outcome).toEqual({ outcome: 'batch_too_large' });
+      expect(fetchWithAuth).not.toHaveBeenCalled();
+    });
+
     it('still throws CeremonyError for any OTHER challenge failure', async () => {
       // The two branches above must be narrow: a 500 is a real outage and has
       // to stay a ceremony failure, not be laundered into a tidy outcome.
@@ -348,6 +363,15 @@ describe('decideIntentApprovalBatch', () => {
 
       expect(outcome).toEqual({ outcome: 'batch_not_homogeneous', offending: ['ap-2'] });
       expect(toastMessages()[0].message).toMatch(/no longer be decided together/i);
+    });
+
+    it('maps a 400 batch_too_large to its own outcome with actionable copy', async () => {
+      respond({ error: 'batch_too_large', max: 50 }, 400);
+
+      const outcome = await decideIntentApprovalBatch(IDS, 'approve');
+
+      expect(outcome).toEqual({ outcome: 'batch_too_large' });
+      expect(toastMessages()[0].message).toMatch(/too many/i);
     });
 
     it('rethrows a 401 assertion_failed — a real proof rejection is not a step-up', async () => {

--- a/apps/web/src/lib/intentApprovals.ts
+++ b/apps/web/src/lib/intentApprovals.ts
@@ -26,7 +26,8 @@ export type IntentBatchOutcome =
   | { outcome: 'decided'; results: BatchRowResult[] }
   | { outcome: 'needs_device' }
   | { outcome: 'batch_step_up' }
-  | { outcome: 'batch_not_homogeneous'; offending: string[] };
+  | { outcome: 'batch_not_homogeneous'; offending: string[] }
+  | { outcome: 'batch_too_large' };
 
 /**
  * Wraps any failure of the WebAuthn (Touch ID / Windows Hello) ceremony.
@@ -106,6 +107,15 @@ export function isBatchNotHomogeneous(err: unknown): boolean {
   return errorToken(err) === 'batch_not_homogeneous';
 }
 
+/** The server's 400 `batch_too_large` (services/approvals/batchDecide.ts's
+ *  `BATCH_MAX`). The client mirrors this cap in `ApprovalsInbox` (#4460) so
+ *  the request is normally never sent, but a stale client bundle or a second
+ *  tab that grew a group past the cap between renders can still reach the
+ *  server — this is that defense-in-depth path, not the primary one. */
+export function isBatchTooLarge(err: unknown): boolean {
+  return errorToken(err) === 'batch_too_large';
+}
+
 /**
  * The batch route's 401 `reauth_required`. On the SINGLE-card path this is a
  * WebAuthn proof rejection ("your scan failed, try again"); on the batch path
@@ -134,6 +144,7 @@ export function batchDecideErrorCopy(token: string): string | undefined {
     return i18n.t('approvals:errors.batchStepUp');
   }
   if (token === 'batch_not_homogeneous') return i18n.t('approvals:errors.batchNotHomogeneous');
+  if (token === 'batch_too_large') return i18n.t('approvals:errors.batchTooLarge');
   return decideErrorCopy(token);
 }
 
@@ -238,7 +249,7 @@ export async function decideIntentApproval(
  * and answers 422 for the whole set rather than partially deciding one the
  * approver may have misread.
  *
- * Returns per-row outcomes on a 200; the three refusal variants mean NOTHING
+ * Returns per-row outcomes on a 200; the four refusal variants mean NOTHING
  * was decided:
  *   - `needs_device`      — no registered approver device (no POST happened)
  *   - `batch_step_up`     — 403 `step_up_required` OR 401 `reauth_required`:
@@ -249,6 +260,11 @@ export async function decideIntentApproval(
  *   - `batch_not_homogeneous` — 422: the set drifted (a row was decided
  *                           elsewhere, an intent settled); the cards remain
  *                           individually decidable
+ *   - `batch_too_large`   — 400: the set exceeds `BATCH_MAX`. The caller
+ *                           (`ApprovalsInbox`) mirrors this cap client-side
+ *                           (#4460) and refuses before calling in, so this
+ *                           only fires on a stale bundle or a drifted group —
+ *                           the cards remain individually decidable
  *
  * Deny skips the ceremony (no proof required) and carries the ONE reason the
  * group collected. Throws CeremonyError on a cancelled/failed ceremony (nothing
@@ -287,6 +303,11 @@ export async function decideIntentApprovalBatch(
           return { outcome: 'batch_not_homogeneous', offending: [] };
         }
         if (err.token === 'step_up_required') return { outcome: 'batch_step_up' };
+        // Same BATCH_MAX check the decide call would hit (loadHomogeneousBatch
+        // runs it before minting a challenge too) — reported here rather than
+        // falling through to CeremonyError below, which would tell the
+        // approver their fingerprint scan failed when no ceremony ran at all.
+        if (err.token === 'batch_too_large') return { outcome: 'batch_too_large' };
       }
       throw new CeremonyError(err);
     }
@@ -340,6 +361,9 @@ export async function decideIntentApprovalBatch(
     }
     if (isStepUpRequired(err) || isBatchReauthRequired(err)) {
       return { outcome: 'batch_step_up' };
+    }
+    if (isBatchTooLarge(err)) {
+      return { outcome: 'batch_too_large' };
     }
     throw err;
   }

--- a/apps/web/src/locales/de-DE/approvals.json
+++ b/apps/web/src/locales/de-DE/approvals.json
@@ -39,7 +39,8 @@
     "expired": "Diese Anfrage ist abgelaufen, bevor eine Entscheidung getroffen wurde.",
     "decisionFailed": "Die Entscheidung konnte nicht gesendet werden. Versuchen Sie es erneut.",
     "batchStepUp": "Für diesen Stapel ist eine stärkere Anmeldung erforderlich. Genehmigen Sie die Anfragen einzeln.",
-    "batchNotHomogeneous": "Über diese Anfragen kann nicht mehr gemeinsam entschieden werden."
+    "batchNotHomogeneous": "Über diese Anfragen kann nicht mehr gemeinsam entschieden werden.",
+    "batchTooLarge": "Dieser Stapel enthält zu viele Anfragen, um sie gemeinsam zu entscheiden. Genehmigen Sie sie in kleineren Gruppen."
   },
   "registerDevice": "Gerät registrieren",
   "alwaysAllow": {

--- a/apps/web/src/locales/en/approvals.json
+++ b/apps/web/src/locales/en/approvals.json
@@ -39,7 +39,8 @@
     "expired": "This request expired before it could be decided.",
     "decisionFailed": "The decision could not be submitted. Try again.",
     "batchStepUp": "This batch needs a stronger sign-in. Approve the requests one at a time.",
-    "batchNotHomogeneous": "These requests can no longer be decided together."
+    "batchNotHomogeneous": "These requests can no longer be decided together.",
+    "batchTooLarge": "This batch has too many requests to decide together. Approve them in smaller groups."
   },
   "registerDevice": "Register device",
   "alwaysAllow": {

--- a/apps/web/src/locales/es-419/approvals.json
+++ b/apps/web/src/locales/es-419/approvals.json
@@ -39,7 +39,8 @@
     "expired": "Esta solicitud venció antes de que se pudiera decidir.",
     "decisionFailed": "No se pudo enviar la decisión. Inténtalo de nuevo.",
     "batchStepUp": "Este lote requiere un inicio de sesión más seguro. Aprueba las solicitudes de una en una.",
-    "batchNotHomogeneous": "Estas solicitudes ya no se pueden decidir en conjunto."
+    "batchNotHomogeneous": "Estas solicitudes ya no se pueden decidir en conjunto.",
+    "batchTooLarge": "Este lote tiene demasiadas solicitudes para decidirlas juntas. Apruébalas en grupos más pequeños."
   },
   "registerDevice": "Registrar dispositivo",
   "alwaysAllow": {

--- a/apps/web/src/locales/fr-CA/approvals.json
+++ b/apps/web/src/locales/fr-CA/approvals.json
@@ -39,7 +39,8 @@
     "expired": "Cette demande a expiré avant qu’une décision soit prise.",
     "decisionFailed": "Impossible d’envoyer la décision. Réessayez.",
     "batchStepUp": "Ce lot exige une connexion plus forte. Approuvez les demandes une à la fois.",
-    "batchNotHomogeneous": "Ces demandes ne peuvent plus être traitées ensemble."
+    "batchNotHomogeneous": "Ces demandes ne peuvent plus être traitées ensemble.",
+    "batchTooLarge": "Ce lot contient trop de demandes pour être traité ensemble. Approuvez-les par groupes plus petits."
   },
   "registerDevice": "Enregistrer l’appareil",
   "alwaysAllow": {

--- a/apps/web/src/locales/fr-FR/approvals.json
+++ b/apps/web/src/locales/fr-FR/approvals.json
@@ -39,7 +39,8 @@
     "expired": "Cette demande a expiré avant qu’une décision ne soit prise.",
     "decisionFailed": "Impossible d’envoyer la décision. Réessayez.",
     "batchStepUp": "Ce lot nécessite une connexion plus forte. Approuvez les demandes une par une.",
-    "batchNotHomogeneous": "Ces demandes ne peuvent plus être traitées ensemble."
+    "batchNotHomogeneous": "Ces demandes ne peuvent plus être traitées ensemble.",
+    "batchTooLarge": "Ce lot contient trop de demandes pour être traité ensemble. Approuvez-les par groupes plus petits."
   },
   "registerDevice": "Enregistrer l’appareil",
   "alwaysAllow": {

--- a/apps/web/src/locales/it-IT/approvals.json
+++ b/apps/web/src/locales/it-IT/approvals.json
@@ -39,7 +39,8 @@
     "expired": "Questa richiesta è scaduta prima che si potesse decidere.",
     "decisionFailed": "Impossibile inviare la decisione. Riprova.",
     "batchStepUp": "Questo gruppo richiede un accesso più sicuro. Approva le richieste una alla volta.",
-    "batchNotHomogeneous": "Non è più possibile decidere queste richieste insieme."
+    "batchNotHomogeneous": "Non è più possibile decidere queste richieste insieme.",
+    "batchTooLarge": "Questo gruppo contiene troppe richieste per essere deciso insieme. Approvale in gruppi più piccoli."
   },
   "registerDevice": "Registra dispositivo",
   "alwaysAllow": {

--- a/apps/web/src/locales/pt-BR/approvals.json
+++ b/apps/web/src/locales/pt-BR/approvals.json
@@ -39,7 +39,8 @@
     "expired": "Esta solicitação expirou antes que fosse possível decidir.",
     "decisionFailed": "Não foi possível enviar a decisão. Tente novamente.",
     "batchStepUp": "Este lote exige um login mais seguro. Aprove as solicitações uma de cada vez.",
-    "batchNotHomogeneous": "Estas solicitações não podem mais ser decididas em conjunto."
+    "batchNotHomogeneous": "Estas solicitações não podem mais ser decididas em conjunto.",
+    "batchTooLarge": "Este lote tem solicitações demais para decidir em conjunto. Aprove-as em grupos menores."
   },
   "registerDevice": "Registrar dispositivo",
   "alwaysAllow": {

--- a/apps/web/src/locales/tr-TR/approvals.json
+++ b/apps/web/src/locales/tr-TR/approvals.json
@@ -39,7 +39,8 @@
     "expired": "Bu istek, karar verilmeden önce sona erdi.",
     "decisionFailed": "Karar gönderilemedi. Yeniden deneyin.",
     "batchStepUp": "Bu toplu işlem için daha güçlü bir oturum açma gerekiyor. İstekleri tek tek onaylayın.",
-    "batchNotHomogeneous": "Bu isteklere artık birlikte karar verilemez."
+    "batchNotHomogeneous": "Bu isteklere artık birlikte karar verilemez.",
+    "batchTooLarge": "Bu toplu işlemde birlikte karar verilemeyecek kadar çok istek var. Bunları daha küçük gruplar halinde onaylayın."
   },
   "registerDevice": "Cihazı kaydet",
   "alwaysAllow": {

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -142,6 +142,15 @@ export const MAX_PAGE_SIZE = 100;
 // friendly message) so the two can never drift.
 export const BULK_ID_LIMIT = 50;
 
+// Hard cap on one AI-agent approvals batch decide (services/approvals/
+// batchDecide.ts's `BATCH_MAX`, which re-exports this). Matches the inbox
+// page size, so "select everything on this page" is always expressible in
+// one call. Shared by the server's enforcement (`loadHomogeneousBatch`
+// 422s `batch_too_large` past it) and the web inbox's client-side guard
+// (#4460) so the two can never drift — the group tap is refused inline
+// instead of round-tripping to learn the cap the hard way.
+export const APPROVAL_BATCH_MAX = 50;
+
 // Session timeouts
 export const ACCESS_TOKEN_EXPIRY = '15m';
 export const REFRESH_TOKEN_EXPIRY = '7d';


### PR DESCRIPTION
## Summary

Three small AI-agents web/approvals items, triaged and bundled as one cluster (all from the #4187 follow-up sweep):

- **#4583** — `AiAgentForm.tsx`'s partner-ceiling hint (`aiAgentsPage.graduation.ceilingHint`) and the whole `supervisedActionKeys` editor fieldset were nested under `draft.mode === 'act'`. Since P2-5 (#4533) a partner row's `supervisedActionKeys` are a ceiling on org grants regardless of the partner row's own mode (ticking a key on a partner row authorizes nothing on its own), a partner admin editing keys on a Shadow-mode baseline never saw the warning that orgs must be granted individually. Fixed by rendering the fieldset for partner rows regardless of mode; org rows keep the original act-only gate, since an org row's keys really are live, self-granted authority.

- **#4468** — the ticket-triage run detail (`RunDetailPage.tsx`'s `TicketProposalSection`) rendered one identical `/approvals` link per proposed intent, which repeats when a run creates several ticket-scoped intents. Every `intentId` resolves to the same `/approvals` inbox, so the per-row links are collapsed into a single link below the intents list.

- **#4460** — batch approve/decide (wave P2-2) is capped at `BATCH_MAX` (50) server-side (`services/approvals/batchDecide.ts`), but the web inbox (`ApprovalsInbox.tsx`) had no client-side guard, so an oversized group would only learn the cap from a server error. `BATCH_MAX` moved to `@breeze/shared` as `APPROVAL_BATCH_MAX` (mirroring the existing `BULK_ID_LIMIT` pattern); `batchDecide.ts` re-exports it as `BATCH_MAX` so no server call sites changed. `ApprovalsInbox.decideGroup` now checks the group size against it before starting a ceremony/decide, reusing the existing whole-batch inline-error pattern (new `batchTooLarge` `GroupErrorKind`, translated in all 8 locales). This is currently unreachable at the 25-row inbox page size but guards against a future page-size bump silently outrunning the batch cap.

## Test plan

- [x] Red-first: added/extended unit tests for all three fixes before implementing, confirmed each failed against the pre-fix code.
- [x] `cd apps/web && npx vitest run src/components/settings/AiAgentGraduationPanel.test.tsx` — 26 passed (partner ceiling hint, incl. new Shadow-mode partner/org cases)
- [x] `cd apps/web && npx vitest run src/components/aiAgents/RunDetailPage.test.tsx` — 37 passed (incl. new collapsed-link test)
- [x] `cd apps/web && npx vitest run src/components/approvals/ApprovalsInbox.test.tsx` — 42 passed (incl. new 51-card batch-too-large test)
- [x] `cd apps/web && npx vitest run src/lib/i18n/localeParity.test.ts src/lib/i18n/i18n.test.ts` — 95 passed (new `batchTooLarge` key across all 8 locales)
- [x] `cd apps/web && npx vitest run src/lib/__tests__/no-silent-mutations.test.ts` — 129 passed
- [x] `cd apps/api && npx vitest run src/services/approvals/batchDecide.test.ts` — 15 passed (shared-constant re-export unchanged behavior)
- [x] `cd packages/shared && npx vitest run src/constants/index.test.ts src/browserSafeBarrel.test.ts` — 5 passed
- [x] `apps/web`: `npx tsc --noEmit` clean; `npx astro check` — 0 errors
- [x] `apps/api`: `npx tsc --noEmit` clean (needed `NODE_OPTIONS=--max-old-space-size=8192` on this host — OOM is a host-load artifact, not related to this diff)
- [x] `packages/shared`: `npx tsc --noEmit` — pre-existing errors in `validators/quotes.test.ts` only (unmodified by this PR, confirmed no diff vs `origin/main`); nothing new
- [x] eslint clean on all touched files

Closes #4583
Closes #4468
Closes #4460

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ev8ZdUuDYsqQFfPkwGKnfC