### PR TITLE
fix(agent): declare Windows 10 / Server 2016 as the agent OS floor (#4608)

### DIFF
--- a/agent/installer/breeze.wxs
+++ b/agent/installer/breeze.wxs
@@ -125,6 +125,18 @@
     </InstallExecuteSequence>
 
     <Launch Condition="VersionNT64" Message="Breeze Agent requires 64-bit Windows." />
+    <!-- Go 1.22+ (agent/go.mod pins a newer toolchain) structurally requires
+         Windows 10 / Server 2016 or later -- Go 1.21 was the last release
+         that ran on Windows 7/8/8.1/Server 2008 R2/2012/2012 R2, and the
+         agent binary compiled against the current toolchain would install
+         successfully on a legacy box and then fail at runtime with no
+         useful message (issue #4608, Option C: declare the floor and block
+         at install time instead). VersionNT is Windows Installer's OS
+         version property (major*100+minor); Windows 10 and every Windows
+         Server release from 2016 onward all report NT 10.0, i.e. 1000, so
+         `>= 1000` is exactly the Windows-10/Server-2016 floor -- it is not
+         a magic threshold pointing at one specific release. -->
+    <Launch Condition="VersionNT >= 1000" Message="Breeze Agent requires Windows 10 or Windows Server 2016 or later. Legacy Windows versions (7, 8, 8.1, Server 2008 R2 through 2012 R2) are not supported." />
     <Launch Condition="(NOT SERVER_URL AND NOT ENROLLMENT_KEY) OR (SERVER_URL AND ENROLLMENT_KEY)" Message="SERVER_URL and ENROLLMENT_KEY must be provided together." />
 
     <?ifdef ServerUrlDefault ?>

--- a/apps/api/src/config/agentInstallerOsFloor.test.ts
+++ b/apps/api/src/config/agentInstallerOsFloor.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// apps/api/src/config -> repo root is 4 levels up (same as composeBindMounts.test.ts).
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
+const WXS_PATH = path.join(REPO_ROOT, 'agent/installer/breeze.wxs');
+
+/**
+ * Why this test exists
+ * ---------------------
+ * Issue #4608 (Option C, decision recorded 2026-09-02): the agent's Go
+ * toolchain (agent/go.mod) requires Go 1.22+, which structurally cannot run
+ * on Windows 7/8/8.1/Server 2008 R2 through 2012 R2 -- only Windows 10 /
+ * Server 2016 and later. Before this fix the MSI only checked bitness
+ * (`VersionNT64`), so it would install successfully on a legacy box and the
+ * service would then fail at runtime with no useful message. This asserts
+ * the MSI has a LaunchCondition that blocks the install up front, with a
+ * message identifying the real floor -- so a future edit to breeze.wxs
+ * can't silently drop the guard.
+ */
+describe('agent installer minimum-OS LaunchCondition (#4608)', () => {
+  const wxs = readFileSync(WXS_PATH, 'utf8');
+
+  it('blocks install below the Windows 10 / Server 2016 floor', () => {
+    // VersionNT is Windows Installer's OS-version property
+    // (major*100+minor). Windows 10 and every Server release from 2016
+    // onward report NT 10.0, i.e. VersionNT=1000, so ">= 1000" is exactly
+    // the Windows-10/Server-2016 floor.
+    expect(wxs).toMatch(/<Launch\s+Condition="VersionNT\s*>=\s*1000"/);
+  });
+
+  it('gives a clear message naming the supported floor', () => {
+    const match = wxs.match(/<Launch\s+Condition="VersionNT\s*>=\s*1000"\s+Message="([^"]+)"/);
+    expect(match).not.toBeNull();
+    const message = match?.[1] ?? '';
+    expect(message).toContain('Windows 10');
+    expect(message).toContain('Server 2016');
+  });
+
+  it('keeps the existing 64-bit-Windows LaunchCondition intact', () => {
+    // Regression guard: the new condition must be additive, not a
+    // replacement of the pre-existing bitness check.
+    expect(wxs).toMatch(/<Launch Condition="VersionNT64" Message="Breeze Agent requires 64-bit Windows\." \/>/);
+  });
+});

--- a/apps/docs/src/content/docs/agents/installation.mdx
+++ b/apps/docs/src/content/docs/agents/installation.mdx
@@ -20,6 +20,33 @@ The Breeze agent is a single Go binary (~8 MB) with no runtime dependencies. It 
 | macOS | arm64 (Apple Silicon) | `breeze-agent-darwin-arm64` |
 | Windows | amd64 | `breeze-agent-windows-amd64.exe` |
 
+### Supported Windows Versions
+
+The agent requires **Windows 10 or Windows Server 2016 or later**. This is a
+hard floor set by the Go toolchain the agent is built with (Go 1.22+ dropped
+support for older Windows kernels) -- it is not a Breeze-specific choice and
+cannot be worked around by an older agent build.
+
+| Windows version | Supported |
+|---|---|
+| Windows 10 / 11 | Yes |
+| Windows Server 2016 / 2019 / 2022 / 2025 | Yes |
+| Windows 8.1 / Server 2012 R2 and earlier | No |
+| Windows 7 / Server 2008 R2 | No |
+
+Legacy boxes are not silently accepted: the MSI installer refuses to run
+below this floor (`Breeze Agent requires Windows 10 or Windows Server 2016 or
+later.`), and the PowerShell quick-install command checks the same floor
+before it downloads anything, so an unsupported machine fails fast with a
+clear message instead of installing a binary that can't run.
+
+<Aside type="note">
+  Monitoring a Windows 7 / Server 2008 R2 fleet? There's no supported Breeze
+  agent path today. Agentless coverage (SNMP/WMI from a modern jump-box
+  agent) and a legacy build track are both open roadmap questions, not
+  shipped features -- reach out if this is blocking you.
+</Aside>
+
 ## Quick Install
 
 <Tabs>
@@ -55,6 +82,12 @@ The Breeze agent is a single Go binary (~8 MB) with no runtime dependencies. It 
   </TabItem>
   <TabItem label="Windows">
     ```powershell
+    # Check the minimum supported OS before downloading anything
+    $osv = [System.Environment]::OSVersion.Version
+    if ($osv.Major -lt 10) {
+      throw "Breeze: Windows 10 or Windows Server 2016 or later is required (detected $($osv.Major).$($osv.Minor))"
+    }
+
     # Download the agent
     Invoke-WebRequest -Uri "https://breeze.yourdomain.com/api/v1/agents/download/windows/amd64" `
       -OutFile "breeze-agent.exe"

--- a/apps/web/src/lib/installCommands.test.ts
+++ b/apps/web/src/lib/installCommands.test.ts
@@ -110,6 +110,11 @@ describe('buildInstallCommands', () => {
       // can never run the agent.
       const { windows } = buildInstallCommands(base);
       expect(windows).toContain('OSVersion.Version');
+      // Assert the actual comparison, not just surrounding text — a wrong
+      // operator/threshold/field (-gt instead of -lt, .Minor instead of
+      // .Major, a dropped `if`) would still leave the message text and
+      // OSVersion.Version substring present.
+      expect(windows).toContain('$osv.Major -lt 10');
       expect(windows).toContain('Windows 10 or Windows Server 2016 or later');
       expect(windows.indexOf('OSVersion')).toBeLessThan(windows.indexOf('Invoke-WebRequest'));
     });

--- a/apps/web/src/lib/installCommands.test.ts
+++ b/apps/web/src/lib/installCommands.test.ts
@@ -102,6 +102,17 @@ describe('buildInstallCommands', () => {
       expect(withSecret.windows).toContain('--enrollment-secret "s3cret"');
       expect(buildInstallCommands(base).windows).not.toContain('--enrollment-secret');
     });
+
+    it('blocks below Windows 10 / Server 2016 before downloading anything (#4608)', () => {
+      // Go 1.22+ (the agent's pinned toolchain) cannot run below Windows 10 /
+      // Server 2016 -- surface the same floor + message as the MSI
+      // LaunchCondition (breeze.wxs) before wasting a download on a box that
+      // can never run the agent.
+      const { windows } = buildInstallCommands(base);
+      expect(windows).toContain('OSVersion.Version');
+      expect(windows).toContain('Windows 10 or Windows Server 2016 or later');
+      expect(windows.indexOf('OSVersion')).toBeLessThan(windows.indexOf('Invoke-WebRequest'));
+    });
   });
 
   it('strips trailing slashes from apiUrl', () => {

--- a/apps/web/src/lib/installCommands.ts
+++ b/apps/web/src/lib/installCommands.ts
@@ -54,12 +54,23 @@ export function buildInstallCommands(opts: InstallCommandOptions): InstallComman
   // native exe exit codes do not trip $ErrorActionPreference.
   const winSecretFlag = enrollmentSecret ? ` --enrollment-secret "${enrollmentSecret}"` : '';
   const winThrow = (step: string) => `if($LASTEXITCODE){throw "Breeze: ${step} failed (exit code $LASTEXITCODE)"}`;
+  // Go 1.22+ (the agent's pinned toolchain, agent/go.mod) cannot run below
+  // Windows 10 / Server 2016 (#4608) -- check the OS floor before spending a
+  // download on a box that can never run the agent. Mirrors the MSI's
+  // `VersionNT >= 1000` LaunchCondition in agent/installer/breeze.wxs:
+  // Windows 10 and every Server release from 2016 onward report OS major
+  // version 10, so `.Major -lt 10` is exactly that same floor.
+  const winOsFloorCheck =
+    `$osv=[System.Environment]::OSVersion.Version; ` +
+    `if($osv.Major -lt 10)` +
+    `{throw "Breeze: Windows 10 or Windows Server 2016 or later is required (detected $($osv.Major).$($osv.Minor))"}`;
   const winMzCheck =
     `$b=[IO.File]::ReadAllBytes("$pwd\\breeze-agent.exe"); ` +
     `if($b.Length -lt 2 -or $b[0] -ne 0x4D -or $b[1] -ne 0x5A)` +
     `{throw "Breeze: downloaded file is not a Windows executable - a captive portal or web filter may be intercepting this network"}`;
   const windows =
     `$ErrorActionPreference='Stop'; ` +
+    `${winOsFloorCheck}; ` +
     `Invoke-WebRequest -Uri "${apiUrl}/api/v1/agents/download/windows/amd64" -OutFile breeze-agent.exe; ` +
     `${winMzCheck}; ` +
     `.\\breeze-agent.exe service install; ${winThrow('service install')}; ` +


### PR DESCRIPTION
## Summary

Implements **Option C** from #4608 (decision recorded 2026-09-02): declare the
agent's minimum supported OS as Windows 10 / Server 2016 and enforce it at
install time, instead of letting a legacy box install a binary that
structurally cannot run (agent/go.mod pins a Go 1.22+ toolchain, which
dropped support for Windows 7/8/8.1/Server 2008 R2 through 2012 R2).

- `agent/installer/breeze.wxs`: new `VersionNT >= 1000` MSI `LaunchCondition`
  (Windows 10 and every Server release from 2016 onward report NT 10.0) that
  blocks install up front with a clear message, additive to the existing
  `VersionNT64` bitness check.
- `apps/web/src/lib/installCommands.ts`: the generated Windows PowerShell
  quick-install command checks `[System.Environment]::OSVersion.Version`
  before downloading the agent binary, throwing the same message as the MSI.
- `apps/docs/src/content/docs/agents/installation.mdx`: documents the
  supported Windows OS matrix and applies the same pre-download check to the
  manual Quick Install PowerShell snippet.

Per the issue, this does **not** build a legacy Go 1.21 lane — that (Option A)
and agentless coverage (Option B) remain separate, un-scoped roadmap
questions, called out in the new docs note.

Closes #4608

## Test plan

- [x] `apps/api/src/config/agentInstallerOsFloor.test.ts` (new) — verified
      red without the wxs change, green with it.
- [x] `apps/web/src/lib/installCommands.test.ts` — new PowerShell-floor case,
      plus full file + `AddDeviceModal.test.tsx` + `EnrollDeviceStep.test.tsx`
      green (45 tests).
- [x] `npx tsc --noEmit` clean in `apps/web` and `apps/api`.
- [x] `npx astro check` clean in `apps/docs`.
- [x] `pnpm lint` (targeted eslint) clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)