### PR TITLE
fix(ops): wire the worker /metrics endpoint into Prometheus scrape config (#4523)

### DIFF
--- a/apps/api/src/config/monitoringPrometheusScrapeConfig.test.ts
+++ b/apps/api/src/config/monitoringPrometheusScrapeConfig.test.ts
@@ -30,6 +30,7 @@ interface ScrapeConfig {
   scheme?: string;
   static_configs?: Array<{ targets?: string[] }>;
   authorization?: { type?: string; credentials_file?: string };
+  relabel_configs?: Array<{ source_labels?: string[]; target_label?: string }>;
 }
 
 interface PrometheusConfig {
@@ -51,6 +52,12 @@ describe('monitoring/prometheus.yml worker scrape target (#4523)', () => {
   });
 
   it('scrapes the worker container on its own job, distinct from breeze-api', () => {
+    // Exactly one — a duplicate job_name (e.g. from a bad merge) would have
+    // Prometheus scrape the same target twice under identical labels, which
+    // silently double-counts the worker's series the same way an unfiltered
+    // dashboard would double-count across roles.
+    expect(jobs.filter((j) => j.job_name === 'breeze-worker')).toHaveLength(1);
+
     const workerJob = jobs.find((j) => j.job_name === 'breeze-worker');
     expect(workerJob).toBeDefined();
     expect(workerJob!.job_name).not.toBe('breeze-api');
@@ -58,10 +65,15 @@ describe('monitoring/prometheus.yml worker scrape target (#4523)', () => {
     const targets = workerJob!.static_configs?.flatMap((sc) => sc.targets ?? []) ?? [];
     expect(targets).toContain('worker:3001');
 
-    // The worker exposes `/metrics` (unauthenticated path shape differs from
-    // the api role's `/api/metrics/scrape`) — see worker.ts and
-    // docs/deploy/worker-split.md.
+    // The worker's Bearer-authenticated scrape endpoint is `/metrics` — a
+    // different path shape than the api role's `/api/metrics/scrape` — see
+    // worker.ts and docs/deploy/worker-split.md.
     expect(workerJob!.metrics_path).toBe('/metrics');
+
+    // Same instance-relabel rule as breeze-api, so `instance` carries the
+    // bare hostname (not `worker:3001`) and dashboard/alert queries that
+    // join on `instance` across both jobs still line up.
+    expect(workerJob!.relabel_configs?.[0]?.target_label).toBe('instance');
   });
 
   it('authenticates the worker scrape with the same bearer token as breeze-api', () => {
@@ -69,8 +81,12 @@ describe('monitoring/prometheus.yml worker scrape target (#4523)', () => {
     const workerJob = jobs.find((j) => j.job_name === 'breeze-worker')!;
 
     expect(workerJob.authorization?.type).toBe('Bearer');
-    // Same credentials_file as the api job — one METRICS_SCRAPE_TOKEN secret,
-    // shared via the `x-api-env` anchor both containers already read from.
+    // Same credentials_file as the api job — both point at the one
+    // `metrics_scrape_token` Docker secret declared in
+    // docker-compose.monitoring.yml (mounted into the prometheus container at
+    // /run/secrets/...), not the api/worker containers' own METRICS_SCRAPE_TOKEN
+    // env var (that one is what the *servers* check against; this is what
+    // Prometheus itself presents as the scraper).
     expect(workerJob.authorization?.credentials_file).toBe(apiJob.authorization?.credentials_file);
   });
 });

--- a/apps/api/src/config/monitoringPrometheusScrapeConfig.test.ts
+++ b/apps/api/src/config/monitoringPrometheusScrapeConfig.test.ts
@@ -1,0 +1,76 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { load } from 'js-yaml';
+import { describe, expect, it } from 'vitest';
+
+// apps/api/src/config -> repo root is 4 levels up (same as composeBindMounts.test.ts).
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
+
+/**
+ * Why this test exists
+ * --------------------
+ * #4423 gave the worker container its own `/metrics` Prometheus target on
+ * port 3001 (docs/deploy/worker-split.md), but nothing scraped it: the
+ * checked-in monitoring stack (`monitoring/prometheus.yml`, brought up by
+ * `docker-compose.monitoring.yml`) only had a `breeze-api` job. Series from
+ * the worker container — the one running the heavy scheduled jobs — never
+ * reached Prometheus, and no alert could fire on worker pool exhaustion or
+ * event-loop lag there (#4523).
+ *
+ * This guards the fix mechanically so the scrape job can't silently regress
+ * (e.g. a future prometheus.yml edit that drops or misconfigures it) the way
+ * the cascade-registration lists do for RLS — parsing the tracked config is
+ * cheaper and more reliable than expecting review to notice a missing job.
+ */
+
+interface ScrapeConfig {
+  job_name: string;
+  metrics_path?: string;
+  scheme?: string;
+  static_configs?: Array<{ targets?: string[] }>;
+  authorization?: { type?: string; credentials_file?: string };
+}
+
+interface PrometheusConfig {
+  scrape_configs?: ScrapeConfig[];
+}
+
+function loadPrometheusConfig(): PrometheusConfig {
+  const abs = path.join(REPO_ROOT, 'monitoring/prometheus.yml');
+  return load(readFileSync(abs, 'utf8')) as PrometheusConfig;
+}
+
+describe('monitoring/prometheus.yml worker scrape target (#4523)', () => {
+  const config = loadPrometheusConfig();
+  const jobs = config.scrape_configs ?? [];
+
+  it('parses and still has the existing breeze-api job (sanity check)', () => {
+    expect(jobs.length).toBeGreaterThan(0);
+    expect(jobs.some((j) => j.job_name === 'breeze-api')).toBe(true);
+  });
+
+  it('scrapes the worker container on its own job, distinct from breeze-api', () => {
+    const workerJob = jobs.find((j) => j.job_name === 'breeze-worker');
+    expect(workerJob).toBeDefined();
+    expect(workerJob!.job_name).not.toBe('breeze-api');
+
+    const targets = workerJob!.static_configs?.flatMap((sc) => sc.targets ?? []) ?? [];
+    expect(targets).toContain('worker:3001');
+
+    // The worker exposes `/metrics` (unauthenticated path shape differs from
+    // the api role's `/api/metrics/scrape`) — see worker.ts and
+    // docs/deploy/worker-split.md.
+    expect(workerJob!.metrics_path).toBe('/metrics');
+  });
+
+  it('authenticates the worker scrape with the same bearer token as breeze-api', () => {
+    const apiJob = jobs.find((j) => j.job_name === 'breeze-api')!;
+    const workerJob = jobs.find((j) => j.job_name === 'breeze-worker')!;
+
+    expect(workerJob.authorization?.type).toBe('Bearer');
+    // Same credentials_file as the api job — one METRICS_SCRAPE_TOKEN secret,
+    // shared via the `x-api-env` anchor both containers already read from.
+    expect(workerJob.authorization?.credentials_file).toBe(apiJob.authorization?.credentials_file);
+  });
+});

--- a/deploy/prometheus-remote-scrape.example.yml
+++ b/deploy/prometheus-remote-scrape.example.yml
@@ -75,6 +75,40 @@ scrape_configs:
         regex: '([^:]+)(:\d+)?'
         replacement: '${1}'
 
+# ===========================================================================
+# (A2) WORKER TARGET (optional — only on droplets running the worker-split
+#      Compose profile, see docs/deploy/worker-split.md). Same Tailscale path,
+#      a DIFFERENT host port (the worker container also listens on 3001
+#      internally, so it needs its own published port to avoid colliding with
+#      api's :3001 bind on the same droplet).
+# ===========================================================================
+#   - job_name: 'breeze-worker-eu'
+#     metrics_path: /metrics
+#     scheme: http
+#     static_configs:
+#       - targets: ['<EU_TAILSCALE_IP>:3002']
+#         labels:
+#           region: 'eu'
+#           service: 'breeze-worker'
+#     authorization:
+#       type: Bearer
+#       credentials_file: /etc/prometheus/secrets/breeze_metrics_token_eu
+#     scrape_interval: 15s
+#     scrape_timeout: 10s
+#     relabel_configs:
+#       - source_labels: [__address__]
+#         target_label: instance
+#         regex: '([^:]+)(:\d+)?'
+#         replacement: '${1}'
+#   # ...and a matching breeze-worker-us job targeting <US_TAILSCALE_IP>:3002
+#
+# #4523: the worker publishes only the role-agnostic runtime series
+# (event-loop lag, DB pool health) on `/metrics` — not the api's
+# HTTP/business/fleet series on `/metrics/scrape`. Filter on
+# `job="breeze-worker"` vs `job="breeze-api"` rather than assuming a single
+# `breeze_*` source, or the two roles' series can be double-counted once both
+# report.
+
 # If EU and US share the same token you can point both jobs at a single
 # credentials_file. They currently each have their own 32-char token, so keep
 # two files unless you deliberately unify them.
@@ -95,6 +129,19 @@ scrape_configs:
 #   http://<DROPLET_TAILSCALE_IP>:3001/metrics/scrape | head
 # Lock down further with a tailnet ACL allowing only the Prometheus node ->
 # tag:breeze-api:3001.
+#
+# To also scrape the worker (if that droplet runs the worker-split profile),
+# bind-publish IT to a different host port on the same Tailscale IP:
+#
+#   worker:
+#     ports:
+#       - '<DROPLET_TAILSCALE_IP>:3002:3001'   # tailnet-only, distinct port
+#
+# Then: docker compose up -d worker
+# Verify: curl -H "Authorization: Bearer <token>" \
+#   http://<DROPLET_TAILSCALE_IP>:3002/metrics | head
+# Lock down further with a tailnet ACL allowing only the Prometheus node ->
+# tag:breeze-worker:3002 (or a shared tag covering both ports).
 
 # ===========================================================================
 # (B) PUBLIC-EDGE FALLBACK (if you do NOT put the droplets on Tailscale)
@@ -117,3 +164,11 @@ scrape_configs:
 #     scrape_interval: 15s
 #     scrape_timeout: 10s
 #   # ...and a matching breeze-api-us job targeting us.your-domain.example.com
+#
+# NOTE: this fallback does not extend to the worker target. The worker isn't
+# proxied through Caddy at all (docker/Caddyfile.prod has no route for it),
+# and its scrape gate deliberately ignores X-Forwarded-For — it authenticates
+# the DIRECT peer only, ignoring METRICS_SCRAPE_IP_ALLOWLIST forwarding rules
+# an edge proxy would rely on (see apps/api/src/services/metricsScrapeAuth.ts
+# and docs/deploy/worker-split.md). Use the Tailscale path (A2) for the
+# worker, or leave it unscraped.

--- a/deploy/prometheus-remote-scrape.example.yml
+++ b/deploy/prometheus-remote-scrape.example.yml
@@ -137,7 +137,7 @@ scrape_configs:
 #     ports:
 #       - '<DROPLET_TAILSCALE_IP>:3002:3001'   # tailnet-only, distinct port
 #
-# Then: docker compose up -d worker
+# Then: docker compose --profile worker-split up -d worker
 # Verify: curl -H "Authorization: Bearer <token>" \
 #   http://<DROPLET_TAILSCALE_IP>:3002/metrics | head
 # Lock down further with a tailnet ACL allowing only the Prometheus node ->

--- a/docs/deploy/worker-split.md
+++ b/docs/deploy/worker-split.md
@@ -35,10 +35,21 @@ Design docs:
 
 The `worker` container publishes its own Prometheus series on
 `http://<worker>:3001/metrics` — **a separate scrape target from the api
-container's `/api/metrics/scrape`**. Add it to your Prometheus config when you
-adopt the split, or the process that runs the heavy jobs is invisible: before
-#4143 its series were not stale or zero, they were ABSENT, and `up` for it did
-not exist at all.
+container's `/api/metrics/scrape`**. Before #4143 its series were not stale or
+zero, they were ABSENT, and `up` for it did not exist at all.
+
+**Scrape wiring (#4523):**
+
+- The local/optional monitoring stack (`docker-compose.monitoring.yml`) scrapes
+  it out of the box as the `breeze-worker` job in `monitoring/prometheus.yml`
+  — no action needed once you `docker compose --profile worker-split up -d
+  worker` on the same host; Prometheus resolves `worker:3001` over the shared
+  `breeze` Docker network.
+- For a **remote** multi-region Prometheus (the droplet pattern), the worker
+  is NOT scraped automatically — it has no host port published by default and
+  isn't proxied through Caddy. See the "(A2) WORKER TARGET" block in
+  `deploy/prometheus-remote-scrape.example.yml` for the Tailscale bind-publish
+  + job config needed on each droplet that adopts the split.
 
 - **Auth is the same gate as the api role's `/api/metrics/scrape`**:
   `METRICS_SCRAPE_TOKEN` as a bearer token (503 when unset), the optional

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -55,9 +55,10 @@ scrape_configs:
   # that's expected outside a split deployment.
   #
   # Unlike breeze-api, the worker publishes `/metrics` directly (no `/api`
-  # prefix, no request-route auth) via a slim raw-node:http server, and only
-  # the role-agnostic runtime series (event-loop lag, DB pool health) — not
-  # the HTTP/business/fleet series `breeze-api` exposes. Filter dashboards and
+  # prefix) via a slim raw-node:http server rather than the Hono route graph
+  # — same bearer/IP-allowlist scrape gate either way (metricsScrapeAuth.ts) —
+  # and only the role-agnostic runtime series (event-loop lag, DB pool health),
+  # not the HTTP/business/fleet series `breeze-api` exposes. Filter dashboards and
   # alerts on `job="breeze-worker"` vs `job="breeze-api"` rather than
   # assuming a single `breeze_*` source, or the two roles' series can be
   # double-counted once both report (#4523).

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -48,6 +48,35 @@ scrape_configs:
         regex: '([^:]+)(:\d+)?'
         replacement: '${1}'
 
+  # Breeze Worker (optional — only present when the worker-split Compose
+  # profile is enabled: `docker compose --profile worker-split up -d worker`;
+  # see docs/deploy/worker-split.md). If the container isn't running, this
+  # target is simply down (same as the redis/postgres/node exporters below) —
+  # that's expected outside a split deployment.
+  #
+  # Unlike breeze-api, the worker publishes `/metrics` directly (no `/api`
+  # prefix, no request-route auth) via a slim raw-node:http server, and only
+  # the role-agnostic runtime series (event-loop lag, DB pool health) — not
+  # the HTTP/business/fleet series `breeze-api` exposes. Filter dashboards and
+  # alerts on `job="breeze-worker"` vs `job="breeze-api"` rather than
+  # assuming a single `breeze_*` source, or the two roles' series can be
+  # double-counted once both report (#4523).
+  - job_name: 'breeze-worker'
+    static_configs:
+      - targets: ['worker:3001']
+    metrics_path: /metrics
+    scheme: http
+    authorization:
+      type: Bearer
+      credentials_file: /run/secrets/metrics_scrape_token
+    scrape_interval: 10s
+    scrape_timeout: 5s
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: instance
+        regex: '([^:]+)(:\d+)?'
+        replacement: '${1}'
+
   # Redis Exporter (optional - requires redis_exporter container)
   - job_name: 'redis'
     static_configs:


### PR DESCRIPTION
## The problem

#4423 gave the worker container its own `/metrics` Prometheus target on port 3001 (event-loop lag + DB pool health monitors, `breeze_role` Sentry tag). Two operational gaps remained (#4523):

1. **Nothing scrapes it.** `docker-compose.monitoring.yml` / the checked-in Prometheus config only had a `breeze-api` job. Until a scrape job is added, the worker's series never reach Grafana and no alert can fire on worker pool exhaustion — the container running the heavy scheduled jobs stayed invisible.
2. **Series parity is partial by design.** The worker only publishes the role-agnostic runtime set (event-loop lag, DB pool health) — not the HTTP/business/fleet series or extension/backup/S1 counters, which are bound in `routes/metrics.ts` (a file a worker-role process must never import). Dashboards assuming a single `breeze_*` source need to filter by job or risk double-counting once both roles report.

## The fix

- **`monitoring/prometheus.yml`**: add a `breeze-worker` scrape job (the local/optional `docker-compose.monitoring.yml` stack), reusing the same `METRICS_SCRAPE_TOKEN` bearer auth and `credentials_file` as `breeze-api`. Resolves `worker:3001` over the shared `breeze` Docker network — no host port publish needed locally, and it's simply "down" if the worker-split profile isn't enabled (same optional-target pattern as the redis/postgres/node exporters already in this file).
- **`deploy/prometheus-remote-scrape.example.yml`**: add the equivalent multi-region Tailscale template block ("(A2) WORKER TARGET") for droplets that adopt the worker-split profile, including the distinct host-port bind-publish needed (the worker also listens on 3001 internally, so it can't share api's `:3001` bind on the same droplet). Also documents that the public-edge fallback path does **not** extend to the worker: it isn't proxied through Caddy at all, and its scrape gate deliberately ignores `X-Forwarded-For` (direct-peer auth only, per `metricsScrapeAuth.ts`).
- **`docs/deploy/worker-split.md`**: clarifies what's now wired automatically (local stack) vs what still needs manual droplet-side setup (remote multi-region Prometheus).
- No internal hostnames/IPs added — the remote-scrape example already used placeholder tokens (`<EU_TAILSCALE_IP>`, etc.) and the new content follows the same convention.

**Filed #4685** for the separate, larger ask (recorder extraction so the worker can publish full series parity) — the issue itself calls this "file or fold in," and it's a bigger leaf-module refactor than scrape wiring, so it gets its own PR.

## Verification

- **New regression test** (`apps/api/src/config/monitoringPrometheusScrapeConfig.test.ts`), red-first: parses `monitoring/prometheus.yml` with `js-yaml` and asserts the `breeze-worker` job exists, targets `worker:3001`, serves `/metrics`, and shares the same bearer `credentials_file` as `breeze-api`. Confirmed it failed before the fix (job missing) and passes after.
  ```
  cd apps/api && npx vitest run src/config/monitoringPrometheusScrapeConfig.test.ts src/config/composeBindMounts.test.ts src/config/envComposeParity.test.ts
  # 3 files passed, 40 tests passed
  ```
- **Typecheck:** `NODE_OPTIONS="--max-old-space-size=8192" npx tsc --noEmit --project apps/api/tsconfig.json` — clean.
- **Lint:** `npx eslint src/config/monitoringPrometheusScrapeConfig.test.ts` — clean.
- Manually parsed both YAML files with `js-yaml` to confirm they're well-formed after editing (the worker jobs in the remote-scrape example are template blocks, commented like the existing public-edge fallback block, by design).

Closes #4523

🤖 Generated with [Claude Code](https://claude.com/claude-code)