### PR TITLE
fix(web): link org name in device breadcrumb to org settings page (#3839)

### DIFF
--- a/apps/web/src/components/devices/DeviceDetailPage.orgBreadcrumb.test.tsx
+++ b/apps/web/src/components/devices/DeviceDetailPage.orgBreadcrumb.test.tsx
@@ -1,0 +1,78 @@
+import '@/lib/i18n';
+
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import DeviceDetailPage from './DeviceDetailPage';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+vi.mock('../../hooks/useEventStream', () => ({ useEventStream: () => ({ subscribe: vi.fn() }) }));
+vi.mock('@/stores/aiStore', () => ({ useAiStore: () => vi.fn() }));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+vi.mock('../../services/deviceActions', () => ({
+  sendDeviceCommand: vi.fn(),
+  executeScript: vi.fn(),
+  toggleMaintenanceMode: vi.fn(),
+  decommissionDevice: vi.fn(),
+  clearDeviceSessions: vi.fn(),
+  restoreDevice: vi.fn(),
+  permanentDeleteDevice: vi.fn(),
+  sendWakeCommand: vi.fn(),
+  watchWakeOutcome: vi.fn(),
+  WakeCommandError: class WakeCommandError extends Error {},
+  wakeFriendlyErrorMessage: vi.fn(),
+}));
+vi.mock('./DeviceDetails', () => ({ default: () => null }));
+vi.mock('./DeviceSettingsModal', () => ({ default: () => null }));
+vi.mock('./ChangeSiteModal', () => ({ default: () => null }));
+vi.mock('./ScriptPickerModal', () => ({ default: () => null }));
+
+const DEVICE_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+
+// #3839 (Discord ask): a tech looking at a device wants a one-click way to
+// jump to the device's Organization page instead of using the OrgSwitcher
+// dropdown at the top of the window and searching for the org there. The
+// breadcrumb ("the path", per the issue) is the natural one-click target —
+// it's already rendered on every device detail page.
+describe('DeviceDetailPage organization breadcrumb (#3839)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('links the organization name in the breadcrumb to the org settings page', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue(new Response(JSON.stringify({
+      id: DEVICE_ID,
+      hostname: 'alpha-01',
+      osType: 'windows',
+      status: 'online',
+      orgId: 'org-42',
+      orgName: 'Acme Corp',
+      siteId: 'site-1',
+      siteName: 'HQ',
+    }), { status: 200 }));
+
+    render(<DeviceDetailPage deviceId={DEVICE_ID} />);
+
+    const orgLink = await screen.findByRole('link', { name: 'Acme Corp' });
+    expect(orgLink).toHaveAttribute('href', '/settings/organizations/org-42');
+  });
+
+  it('omits the organization crumb when the device has no orgId', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue(new Response(JSON.stringify({
+      id: DEVICE_ID,
+      hostname: 'alpha-01',
+      osType: 'windows',
+      status: 'online',
+      orgId: '',
+      orgName: '',
+      siteId: 'site-1',
+    }), { status: 200 }));
+
+    render(<DeviceDetailPage deviceId={DEVICE_ID} />);
+
+    await screen.findByText('alpha-01');
+    expect(screen.queryByRole('link', { name: 'Unknown Org' })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/devices/DeviceDetailPage.tsx
+++ b/apps/web/src/components/devices/DeviceDetailPage.tsx
@@ -552,6 +552,13 @@ export default function DeviceDetailPage({ deviceId }: DeviceDetailPageProps) {
     <div className="space-y-6">
       <Breadcrumbs
         items={[
+          // #3839 (Discord ask): one-click jump to the device's Organization
+          // page from the device breadcrumb, instead of using the OrgSwitcher
+          // dropdown + search. Omitted when the device has no orgId (defensive
+          // — the detail fetch always sets one for a real device).
+          ...(device.orgId
+            ? [{ label: device.orgName, href: `/settings/organizations/${device.orgId}` }]
+            : []),
           { label: t("deviceDetailPage.devices"), href: "/devices" },
           { label: device.hostname || "Device" },
         ]}


### PR DESCRIPTION
## Summary
- A tech viewing a device wanted a one-click way to jump to that device's Organization page, instead of using the OrgSwitcher dropdown at the top of the window and searching for the org there (Discord feature request, filed by @breeze-discord triage).
- The device detail breadcrumb already renders a path (`Devices > hostname`) but never surfaced the organization at all, even though the device fetch already carries `orgId`/`orgName`.
- Prepend an **Organization** crumb (linking to `/settings/organizations/:id`, the same route `OrganizationsPage` already links to) ahead of the existing `Devices > hostname` crumbs, whenever the device has an `orgId`. One click from the device page to the org.

Closes #3839

## Test plan
- [x] `cd apps/web && npx vitest run src/components/devices/DeviceDetailPage.orgBreadcrumb.test.tsx` — new test, red before the fix (asserted), green after.
- [x] `cd apps/web && npx vitest run src/components/devices/DeviceDetailPage.permanentDelete.test.tsx src/components/devices/DeviceDetailPage.scriptAdmission.test.tsx src/components/devices/DeviceDetails.hashNavigation.test.tsx src/components/devices/DeviceDetails.possibleReplacement.test.tsx` — sibling device-detail suites unaffected, all green.
- [x] `npx tsc --noEmit -p tsconfig.json` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)