### PR TITLE
fix(mobile): surface alert category from the rule's template (#4535)

### DIFF
--- a/apps/api/src/routes/mobile.test.ts
+++ b/apps/api/src/routes/mobile.test.ts
@@ -159,19 +159,24 @@ const mockSelectOrderChain = (result: unknown) => ({
   })
 });
 
-const mockSelectLeftJoinChain = (result: unknown) => ({
-  from: vi.fn().mockReturnValue({
-    leftJoin: vi.fn().mockReturnValue({
-      where: vi.fn().mockReturnValue({
-        orderBy: vi.fn().mockReturnValue({
-          limit: vi.fn().mockReturnValue({
-            offset: vi.fn().mockResolvedValue(result)
-          })
-        })
+// Supports any number of chained `.leftJoin(...)` calls before `.where(...)` —
+// the inbox query joins devices, alert_rules and alert_templates in sequence
+// (#4535), so a fixed single-leftJoin shape would throw
+// "leftJoin is not a function" on the second call.
+const mockSelectLeftJoinChain = (result: unknown) => {
+  const joinable: { leftJoin: unknown; where: unknown } = {} as never;
+  joinable.leftJoin = vi.fn().mockReturnValue(joinable);
+  joinable.where = vi.fn().mockReturnValue({
+    orderBy: vi.fn().mockReturnValue({
+      limit: vi.fn().mockReturnValue({
+        offset: vi.fn().mockResolvedValue(result)
       })
     })
-  })
-});
+  });
+  return {
+    from: vi.fn().mockReturnValue(joinable)
+  };
+};
 
 const objectContains = (value: unknown, needle: string, seen = new WeakSet<object>()): boolean => {
   if (typeof value === 'string') return value === needle;
@@ -715,7 +720,8 @@ describe('mobile routes', () => {
               deviceId: '11111111-2222-4333-8444-555555555555',
               deviceHostname: 'host-1',
               deviceOsType: 'linux',
-              deviceStatus: 'online'
+              deviceStatus: 'online',
+              category: 'Security'
             },
             {
               id: 'alert-2',
@@ -730,7 +736,10 @@ describe('mobile routes', () => {
               deviceId: null,
               deviceHostname: null,
               deviceOsType: null,
-              deviceStatus: null
+              deviceStatus: null,
+              // Alerts can be created without a rule, so the joined category
+              // is nullable.
+              category: null
             }
           ]) as any
         );
@@ -745,6 +754,11 @@ describe('mobile routes', () => {
       expect(body.pagination.total).toBe(2);
       expect(body.data[0].device).toBeDefined();
       expect(body.data[1].device).toBeNull();
+      // The alert category comes from the rule's template (#4535) — the
+      // client mapper needs it to show something other than the always-'alert'
+      // constant the removed TYPE row used to display.
+      expect(body.data[0].category).toBe('Security');
+      expect(body.data[1].category).toBeNull();
     });
 
     it('should require organization context for org scope', async () => {
@@ -790,32 +804,39 @@ describe('mobile routes', () => {
         } as any)
         .mockReturnValueOnce({
           from: vi.fn().mockReturnValue({
+            // devices -> alert_rules -> alert_templates: three chained
+            // leftJoins before the where clause (#4535).
             leftJoin: vi.fn().mockReturnValue({
-              where: vi.fn((where: unknown) => {
-                captured.rowsWhere = where;
-                return {
-                  orderBy: vi.fn().mockReturnValue({
-                    limit: vi.fn().mockReturnValue({
-                      offset: vi.fn().mockResolvedValue([
-                        {
-                          id: 'alert-allowed',
-                          orgId: 'org-123',
-                          status: 'active',
-                          severity: 'critical',
-                          title: 'Allowed alert',
-                          message: 'Allowed device alert',
-                          triggeredAt: new Date(),
-                          acknowledgedAt: null,
-                          resolvedAt: null,
-                          deviceId: DEVICE_ALLOWED,
-                          deviceHostname: 'allowed-host',
-                          deviceOsType: 'linux',
-                          deviceStatus: 'online'
-                        }
-                      ])
-                    })
+              leftJoin: vi.fn().mockReturnValue({
+                leftJoin: vi.fn().mockReturnValue({
+                  where: vi.fn((where: unknown) => {
+                    captured.rowsWhere = where;
+                    return {
+                      orderBy: vi.fn().mockReturnValue({
+                        limit: vi.fn().mockReturnValue({
+                          offset: vi.fn().mockResolvedValue([
+                            {
+                              id: 'alert-allowed',
+                              orgId: 'org-123',
+                              status: 'active',
+                              severity: 'critical',
+                              title: 'Allowed alert',
+                              message: 'Allowed device alert',
+                              triggeredAt: new Date(),
+                              acknowledgedAt: null,
+                              resolvedAt: null,
+                              deviceId: DEVICE_ALLOWED,
+                              deviceHostname: 'allowed-host',
+                              deviceOsType: 'linux',
+                              deviceStatus: 'online',
+                              category: null
+                            }
+                          ])
+                        })
+                      })
+                    };
                   })
-                };
+                })
               })
             })
           })

--- a/apps/api/src/routes/mobile.ts
+++ b/apps/api/src/routes/mobile.ts
@@ -854,10 +854,17 @@ mobileRoutes.get(
         deviceId: alerts.deviceId,
         deviceHostname: devices.hostname,
         deviceOsType: devices.osType,
-        deviceStatus: devices.status
+        deviceStatus: devices.status,
+        // Alerts carry no type/category of their own — only a rule reference.
+        // The category one hop away on the rule's template is the closest
+        // thing mobile has to a meaningful alert "type" (#4535). Nullable:
+        // alerts can be created without a rule.
+        category: alertTemplates.category
       })
       .from(alerts)
       .leftJoin(devices, eq(alerts.deviceId, devices.id))
+      .leftJoin(alertRules, eq(alerts.ruleId, alertRules.id))
+      .leftJoin(alertTemplates, eq(alertRules.templateId, alertTemplates.id))
       .where(whereCondition)
       .orderBy(desc(alerts.triggeredAt), desc(alerts.id))
       .limit(fetchLimit)
@@ -884,6 +891,7 @@ mobileRoutes.get(
       triggeredAt: alert.triggeredAt,
       acknowledgedAt: alert.acknowledgedAt,
       resolvedAt: alert.resolvedAt,
+      category: alert.category ?? null,
       device: alert.deviceId ? {
         id: alert.deviceId,
         hostname: alert.deviceHostname,

--- a/apps/mobile/src/screens/alerts/AlertDetailScreen.tsx
+++ b/apps/mobile/src/screens/alerts/AlertDetailScreen.tsx
@@ -151,6 +151,14 @@ export function AlertDetailScreen({ route }: Props) {
         {alert.message}
       </Text>
 
+      {alert.category ? (
+        <DetailRow
+          label="CATEGORY"
+          value={alert.category}
+          textHi={theme.textHi}
+          textLo={theme.textLo}
+        />
+      ) : null}
       {alert.deviceName ? (
         <DetailRow
           label="DEVICE"

--- a/apps/mobile/src/services/alertsInbox.test.ts
+++ b/apps/mobile/src/services/alertsInbox.test.ts
@@ -61,4 +61,26 @@ describe('getAlerts inbox query', () => {
     // empties the filtered view.
     expect((alerts[0].metadata as Record<string, unknown>).orgId).toBe('org-1');
   });
+
+  it('surfaces the rule template category from the inbox row (#4535)', async () => {
+    jsonOnce({
+      data: [
+        { id: 'a1', title: 't', message: 'm', severity: 'high', status: 'active',
+          orgId: 'org-1', triggeredAt: '2026-08-18T00:00:00Z', category: 'Security' },
+      ],
+    });
+    const alerts = await getAlerts();
+    expect(alerts[0].category).toBe('Security');
+  });
+
+  it('leaves category undefined for alerts with no rule (nullable join)', async () => {
+    jsonOnce({
+      data: [
+        { id: 'a2', title: 't', message: 'm', severity: 'low', status: 'active',
+          orgId: 'org-1', triggeredAt: '2026-08-18T00:00:00Z', category: null },
+      ],
+    });
+    const alerts = await getAlerts();
+    expect(alerts[0].category).toBeUndefined();
+  });
 });

--- a/apps/mobile/src/services/api.ts
+++ b/apps/mobile/src/services/api.ts
@@ -73,6 +73,9 @@ export interface Alert {
   message: string;
   severity: 'critical' | 'high' | 'medium' | 'low' | 'info';
   type: string;
+  /** Rule-template category (e.g. "Security", "Performance"); absent for
+   * alerts created without a rule. */
+  category?: string;
   deviceId?: string;
   deviceName?: string;
   acknowledged: boolean;
@@ -268,6 +271,12 @@ type MobileAlertRecord = {
   acknowledgedBy?: string | null;
   resolvedAt?: string | null;
   type?: string;
+  /**
+   * The rule's alert-template category, joined server-side (#4535). Alerts
+   * created without a rule carry no category, hence nullable rather than
+   * always-present.
+   */
+  category?: string | null;
   deviceId?: string | null;
   deviceName?: string | null;
   device?: {
@@ -575,6 +584,7 @@ function mapAlert(alert: MobileAlertRecord): Alert {
     message: alert.message,
     severity: normalizedSeverity,
     type: alert.type || 'alert',
+    category: alert.category ?? undefined,
     deviceId: alert.device?.id || alert.deviceId || undefined,
     deviceName: alert.device?.hostname || alert.deviceName || undefined,
     acknowledged: alert.status === 'acknowledged' || alert.status === 'resolved' || Boolean(alert.acknowledgedAt),


### PR DESCRIPTION
## Summary

- The mobile alert detail screen used to render a TYPE row from `alert.type`, which is a client-side constant (`type: alert.type || 'alert'`) — the `alerts` table carries no type/category column, only a rule reference. PR #4534 removed that misleading row.
- Surfaces the real category, which lives one join away: `alerts.rule_id -> alert_rules.id -> alert_rules.template_id -> alert_templates.id -> alert_templates.category`.
- `/mobile/alerts/inbox` now left-joins `alert_rules` and `alert_templates` and exposes `category` (nullable — alerts can be created without a rule).
- Mobile API mapper (`apps/mobile/src/services/api.ts`) maps `category` through onto `MobileAlertRecord`/`Alert`.
- `AlertDetailScreen` renders a CATEGORY row only when the value is present.

The single-alert lookup mentioned in the issue (`getAlertWithOrgCheck`, ~mobile.ts:215) turned out to be out of scope: `AlertDetailScreen` receives its `alert` object via navigation params from the already-fixed inbox list fetch, not a separate detail-screen fetch, so no change was needed there. (The client's `getAlert(id)` helper that would call a per-id endpoint has no callers in the mobile app.)

Closes #4535

## Test plan

- [x] `apps/api`: `npx vitest run src/routes/mobile.test.ts` — 70 passed, 2 skipped (updated mock join-chain helper + new category assertions for the inbox route)
- [x] `apps/mobile`: `npx vitest run src/services/alertsInbox.test.ts` — 5 passed (2 new tests: category present / nullable)
- [x] `apps/api`: `tsc --noEmit` clean
- [x] `apps/mobile`: `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)