### PR TITLE
feat(ai-agents): register ai.agent.circuit.opened event type (#4205)

### DIFF
--- a/apps/api/src/services/aiAgents/agentCircuit.test.ts
+++ b/apps/api/src/services/aiAgents/agentCircuit.test.ts
@@ -130,6 +130,12 @@ vi.mock('../auditService', () => ({
   createAuditLogAsync: (...args: unknown[]) => createAuditLogAsyncMock(...args),
 }));
 
+const publishEventMock = vi.fn();
+vi.mock('../eventBus', () => ({
+  EVENT_TYPES: { AI_AGENT_CIRCUIT_OPENED: 'ai.agent.circuit.opened' },
+  publishEvent: (...args: unknown[]) => publishEventMock(...args),
+}));
+
 import {
   classifyTerminal,
   getCircuitState,
@@ -179,6 +185,7 @@ beforeEach(() => {
   resolveRecipientUserIdsMock.mockReset().mockResolvedValue([]);
   createNotificationMock.mockReset().mockResolvedValue('notif-id');
   createAuditLogAsyncMock.mockReset().mockResolvedValue(undefined);
+  publishEventMock.mockReset().mockResolvedValue('event-id');
 });
 
 afterEach(() => {
@@ -425,6 +432,7 @@ describe('recordRunTerminal', () => {
     expect(state.updateCount).toBe(0); // no open-transition update attempted
     expect(createNotificationMock).not.toHaveBeenCalled();
     expect(createAuditLogAsyncMock).not.toHaveBeenCalled();
+    expect(publishEventMock).not.toHaveBeenCalled();
   });
 
   it('increment at threshold opens the circuit exactly once, then notifies + audits', async () => {
@@ -457,6 +465,22 @@ describe('recordRunTerminal', () => {
       resourceId: AGENT_ID,
       actorType: 'system',
     }));
+
+    // #4205 — first-class registered event so webhooks/automations can react,
+    // not just the notification + audit row.
+    expect(publishEventMock).toHaveBeenCalledTimes(1);
+    expect(publishEventMock).toHaveBeenCalledWith(
+      'ai.agent.circuit.opened',
+      ORG_ID,
+      expect.objectContaining({
+        agentId: AGENT_ID,
+        orgId: ORG_ID,
+        triggeringRunId: RUN_ID,
+        consecutiveFailures: 3,
+        threshold: 3,
+      }),
+      expect.any(String),
+    );
   });
 
   it('opens exactly once: a second increment landing on an already-open row notifies nobody again', async () => {
@@ -473,6 +497,7 @@ describe('recordRunTerminal', () => {
     expect(resolveEffectiveAgentSystemMock).not.toHaveBeenCalled();
     expect(createNotificationMock).not.toHaveBeenCalled();
     expect(createAuditLogAsyncMock).not.toHaveBeenCalled();
+    expect(publishEventMock).not.toHaveBeenCalled();
   });
 
   it('opens exactly once: the CAS losing to a concurrent opener suppresses this notify', async () => {
@@ -488,6 +513,7 @@ describe('recordRunTerminal', () => {
 
     expect(createNotificationMock).not.toHaveBeenCalled();
     expect(createAuditLogAsyncMock).not.toHaveBeenCalled();
+    expect(publishEventMock).not.toHaveBeenCalled();
   });
 
   it('falls back to the shared default threshold when no effective policy resolves', async () => {

--- a/apps/api/src/services/aiAgents/agentCircuit.test.ts
+++ b/apps/api/src/services/aiAgents/agentCircuit.test.ts
@@ -483,6 +483,22 @@ describe('recordRunTerminal', () => {
     );
   });
 
+  it('a rejected publishEvent does not stop the notification or audit log from firing', async () => {
+    state.selectQueue.push([agentRow()]);
+    state.selectQueue.push([{ partnerId: PARTNER_ID }]);
+    state.insertReturningQueue.push([circuitRow({ consecutiveFailures: 3, state: 'closed' })]);
+    state.updateReturningQueue.push([circuitRow({ consecutiveFailures: 3, state: 'open', openedAt: new Date() })]);
+    resolveEffectiveAgentSystemMock.mockResolvedValue(resolvedPolicy(3));
+    resolveRecipientUserIdsMock.mockResolvedValue([USER_ID]);
+    publishEventMock.mockRejectedValueOnce(new Error('redis unavailable'));
+
+    await recordRunTerminal(run, 'failed', 'sdk_error', null);
+
+    expect(publishEventMock).toHaveBeenCalledTimes(1);
+    expect(createNotificationMock).toHaveBeenCalledTimes(1);
+    expect(createAuditLogAsyncMock).toHaveBeenCalledTimes(1);
+  });
+
   it('opens exactly once: a second increment landing on an already-open row notifies nobody again', async () => {
     state.selectQueue.push([agentRow()]);
     state.selectQueue.push([{ partnerId: PARTNER_ID }]);

--- a/apps/api/src/services/aiAgents/agentCircuit.ts
+++ b/apps/api/src/services/aiAgents/agentCircuit.ts
@@ -42,6 +42,7 @@ import { aiAgents } from '../../db/schema/aiAgents';
 import { organizations } from '../../db/schema/orgs';
 import { ANONYMOUS_ACTOR_ID } from '../auditEvents';
 import { createAuditLogAsync } from '../auditService';
+import { EVENT_TYPES, publishEvent } from '../eventBus';
 import { createNotification } from '../userNotifications';
 import { resolveEffectiveAgentSystem } from './effectivePolicy';
 import { resolveRecipientUserIds } from './recipients';
@@ -530,6 +531,29 @@ export async function recordRunTerminal(
     }
   } catch (error) {
     console.error('[agentCircuit] failed to notify recipients of a circuit open (non-fatal)', {
+      orgId: run.orgId, agentId: run.agentId, error,
+    });
+  }
+
+  // #4205 — first-class registered event so webhooks/automations can react to
+  // a circuit open, not just the notification + audit row above. Best-effort,
+  // same posture as both: never allowed to fail this best-effort accounting
+  // path.
+  try {
+    await publishEvent(
+      EVENT_TYPES.AI_AGENT_CIRCUIT_OPENED,
+      run.orgId,
+      {
+        agentId: run.agentId,
+        orgId: run.orgId,
+        triggeringRunId: run.id,
+        consecutiveFailures: justOpened.consecutiveFailures,
+        threshold: justOpened.threshold,
+      },
+      'ai-agent-circuit',
+    );
+  } catch (error) {
+    console.error('[agentCircuit] failed to publish a circuit open event (non-fatal)', {
       orgId: run.orgId, agentId: run.agentId, error,
     });
   }

--- a/apps/api/src/services/aiAgents/agentCircuit.ts
+++ b/apps/api/src/services/aiAgents/agentCircuit.ts
@@ -554,7 +554,7 @@ export async function recordRunTerminal(
     );
   } catch (error) {
     console.error('[agentCircuit] failed to publish a circuit open event (non-fatal)', {
-      orgId: run.orgId, agentId: run.agentId, error,
+      orgId: run.orgId, agentId: run.agentId, triggeringRunId: run.id, error,
     });
   }
 

--- a/apps/api/src/services/eventBus.ts
+++ b/apps/api/src/services/eventBus.ts
@@ -174,6 +174,14 @@ export type EventType =
   | 'ai.agent.run.completed'
   | 'ai.agent.run.failed'
   | 'ai.agent.run.skipped'
+  // #4205 — follow-up to #3828/PR #4168: the per-org circuit breaker
+  // (`agentCircuit.ts`'s `recordRunTerminal`) previously only fired a
+  // notification + audit row when it opened. Published from the SAME
+  // best-effort, outside-the-transaction fan-out as those two, right after
+  // the CAS-guarded open-transition UPDATE commits — so it shares their
+  // "opens exactly once per episode" guarantee. Payload:
+  // { agentId, orgId, triggeringRunId, consecutiveFailures, threshold }.
+  | 'ai.agent.circuit.opened'
   // #4388 — an org crossed an AI budget rung; org-level, no device/site.
   | 'ai.budget.threshold_crossed'
   // Wave 2 (#3823). Addressed to ONE user, never broadcast — see
@@ -656,6 +664,8 @@ export const EVENT_TYPES = {
   AI_AGENT_RUN_COMPLETED: 'ai.agent.run.completed' as const,
   AI_AGENT_RUN_FAILED: 'ai.agent.run.failed' as const,
   AI_AGENT_RUN_SKIPPED: 'ai.agent.run.skipped' as const,
+  // #4205
+  AI_AGENT_CIRCUIT_OPENED: 'ai.agent.circuit.opened' as const,
   // #4388
   AI_BUDGET_THRESHOLD_CROSSED: 'ai.budget.threshold_crossed' as const,
   // Wave 2 (#3823). Addressed to one user via publishUserEvent — never


### PR DESCRIPTION
## Summary

Follow-up to #3828 (PR #4168), deferred there for event-registry ceremony churn. The per-org circuit breaker (`ai_agent_circuit_state`, keyed `(org_id, agent_id)`) previously only fired a user notification and an audit row (`ai_agent.circuit_opened`) when it opened — there was no first-class event, so webhooks and automations had no way to react to a circuit opening.

- Registered `ai.agent.circuit.opened` in the `EventType` union and `EVENT_TYPES` const (`apps/api/src/services/eventBus.ts`).
- `recordRunTerminal` (`apps/api/src/services/aiAgents/agentCircuit.ts`) now publishes it via `publishEvent`, in the same best-effort, outside-the-transaction fan-out as the existing notification/audit — so it shares their "fires exactly once per open episode" guarantee (the notification's `dedupeKey` is per-triggering-run; the event fires from the same `justOpened` result, once per CAS-won open transition).
- Payload: `{ agentId, orgId, triggeringRunId, consecutiveFailures, threshold }`.
- Publish failures are caught and logged, never allowed to affect the run-terminalization or notify/audit paths (same non-fatal posture as the sibling calls).

## Test plan

- [x] `agentCircuit.test.ts`: extended the "increment at threshold opens the circuit" test to assert `publishEvent` is called once with the expected payload; added `publishEvent` non-call assertions to the below-threshold, already-open, and CAS-loses negative paths. Written red-first (confirmed failing before the implementation change).
- [x] `eventBus.types.test.ts` (the union ⟺ `EVENT_TYPES` mutual-completeness contract test) — green, no manual sync step needed.
- [x] `eventBus.test.ts`, `eventSubscribers.contract.test.ts` — green.
- [x] `npx tsc --noEmit -p apps/api` — clean.

```
apps/api/src/services/aiAgents/agentCircuit.test.ts | 60 tests passed
apps/api/src/services/eventBus.types.test.ts        | passed
apps/api/src/services/eventBus.test.ts               | passed
apps/api/src/services/eventSubscribers.contract.test.ts | passed
```

Closes #4205

🤖 Generated with [Claude Code](https://claude.com/claude-code)