### PR TITLE
fix(web): quote editor line grid no longer scrolls at 1280px with sidebar open (#4668)

### DIFF
--- a/apps/web/src/components/billing/quotes/QuoteBlockCard.gridwidth.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteBlockCard.gridwidth.test.tsx
@@ -1,0 +1,126 @@
+// Regression guard for #4668: at 1280px viewport with the left nav sidebar
+// open, the quote editor's pricing table horizontally scrolled to reach the
+// Total column (it fit fine with the sidebar collapsed). Root cause: the
+// pricing table carried a blanket `min-w-[36rem]` floor plus a `min-w-[12rem]`
+// floor on the Item column — together wider than the ~576px actually
+// available for the table at that viewport/sidebar combination (1280 −
+// 256px sidebar − 48px page padding − 300px rail − 24px grid gap − 76px
+// canvas padding), so the table's declared minimum exceeded its container by
+// a hairline and `overflow-x-auto` kicked in on any rendering variance
+// (scrollbar, border, subpixel rounding).
+//
+// jsdom has no real layout engine, so this can't assert on-screen pixels or
+// scroll state directly. Instead it locks the column-priority contract in
+// Tailwind class form: Item (the lowest-priority column — it already
+// degrades via its own text input / title tooltip) carries the smaller
+// floor and shrinks first, while the table's blanket floor is reduced enough
+// that Qty/Unit Price/Total/actions are never squeezed below their natural
+// content width. See QuoteBlockCard.tsx / QuoteLineRows.tsx for the full
+// math. Manual verification: apps/web dev server, quote editor at 1280px
+// viewport with the sidebar expanded — Total is visible with no horizontal
+// scrollbar on the pricing table; re-check at 1440/1920 for no regression.
+import { render, screen, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteEditor from './QuoteEditor';
+import type { QuoteDetail as QuoteDetailData } from './quoteTypes';
+
+vi.mock('../../../stores/auth', () => ({
+  registerOrgIdProvider: vi.fn(),
+  fetchWithAuth: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: {} }) } as unknown as Response,
+  ),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../../shared/Toast', () => ({ showToast: vi.fn() }));
+
+vi.mock('../../../lib/api/catalog', () => ({
+  listCatalog: vi.fn().mockResolvedValue(
+    { ok: true, status: 200, statusText: 'OK', json: vi.fn().mockResolvedValue({ data: [] }) } as unknown as Response,
+  ),
+  createCatalogItem: vi.fn(),
+}));
+
+vi.mock('../../../lib/api/quotes', () => ({
+  addBlock: vi.fn(),
+  deleteBlock: vi.fn(),
+  updateBlock: vi.fn(),
+  addManualLine: vi.fn(),
+  addCatalogLine: vi.fn(),
+  updateLine: vi.fn(),
+  removeLine: vi.fn(),
+  moveLine: vi.fn(),
+  uploadQuoteImage: vi.fn(),
+  quoteImageUrl: vi.fn().mockReturnValue('/quotes/q-1/images/img-1'),
+}));
+
+const baseQuote: QuoteDetailData['quote'] = {
+  id: 'q-1', quoteNumber: null, partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
+  currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '100.00', taxRate: null,
+  taxTotal: '0.00', total: '100.00', oneTimeTotal: '100.00', monthlyRecurringTotal: '0.00',
+  annualRecurringTotal: '0.00', billToName: null, introNotes: null, terms: null,
+  termsAndConditions: null, sellerSnapshot: null, acceptedAt: null, declinedAt: null,
+  convertedAt: null, convertedInvoiceId: null, sentAt: null, viewedAt: null, createdBy: null,
+  createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+};
+
+const lines: QuoteDetailData['lines'] = [
+  {
+    id: 'line-1', quoteId: 'q-1', blockId: 'blk-1', orgId: 'org-1', sourceType: 'manual',
+    catalogItemId: null, parentLineId: null, unitCost: null, sku: null, partNumber: null,
+    name: 'Managed support', description: null, quantity: '1.00',
+    unitPrice: '100.00', taxable: false, customerVisible: true, lineTotal: '100.00',
+    recurrence: 'one_time', termMonths: null, billingFrequency: null, sortOrder: 0,
+    createdAt: '2026-06-01T00:00:00Z',
+  },
+];
+
+const detail: QuoteDetailData = {
+  quote: baseQuote,
+  blocks: [{
+    id: 'blk-1', quoteId: 'q-1', orgId: 'org-1', blockType: 'line_items',
+    content: { label: 'Monthly services' },
+    sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
+  }],
+  lines,
+};
+
+describe('QuoteBlockCard pricing table — column-priority width contract (#4668)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('reduces the table\'s blanket min-width floor below the old 36rem value', async () => {
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    const table = screen.getByTestId('quote-block-lines-blk-1');
+    // The old blanket floor (36rem = 576px) matched the space actually
+    // available at 1280px-with-sidebar-open to the pixel, so any rendering
+    // variance (scrollbar, border, subpixel rounding) tipped it into
+    // horizontal scroll. It must be meaningfully smaller now.
+    expect(table.className).not.toMatch(/min-w-\[36rem\]/);
+  });
+
+  it('makes the Item column the lowest-priority (smallest floor) column, not the old 12rem', async () => {
+    render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    const table = screen.getByTestId('quote-block-lines-blk-1');
+    const headerRow = table.querySelector('thead tr');
+    expect(headerRow).not.toBeNull();
+    const itemHeader = within(headerRow as HTMLElement).getAllByRole('columnheader')[0];
+    expect(itemHeader.className).not.toMatch(/min-w-\[12rem\]/);
+
+    // The body cell's floor must track the header's floor (auto table layout
+    // takes the wider of the two — a mismatch would silently keep the old
+    // 12rem floor alive on the body side even if the header shrank).
+    const nameInput = screen.getByTestId('quote-line-name-line-1');
+    const itemCell = nameInput.closest('td');
+    expect(itemCell).not.toBeNull();
+    expect(itemCell!.className).not.toMatch(/min-w-\[12rem\]/);
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteBlockCard.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteBlockCard.tsx
@@ -469,21 +469,29 @@ export function BlockCard({
                 {t('quotes.editor.table.showSubtotal')}
               </label>
             )}
-            {/* Four data columns (Item flexes, Qty/Price/Total are content-sized) so
-                the per-line Total — the most-checked figure on a quote — is always
-                visible without sideways scrolling at desktop widths. Billing cadence
-                rides in the Price cell; Taxable moved to each line's controls row;
-                per-line tax renders as a sub-line under the Total. The wrapper only
-                scrolls HORIZONTALLY on genuinely narrow screens (phone) — the page is
-                the editor's single vertical scroller. An earlier design capped this
-                div at max-h-[70vh] to make sticky header cells work, but a vertical
-                scrollport per pricing block made the editor read as nested boxes of
+            {/* Four data columns, ranked by priority (#4668): Item is the
+                lowest-priority column and the one that gives — it already has
+                its own text input plus a title tooltip for overflow, so it
+                shrinks first. Qty/Price/Total are content-sized (never
+                squeezed below their own natural width) and Total — the
+                most-checked figure on a quote — stays on-screen without
+                sideways scrolling at desktop widths, including 1280px with
+                the left nav sidebar expanded (the sidebar's 256px plus the
+                rail's 300px left ~576px for the table there; the table's own
+                floor must stay safely under that). Billing cadence rides in
+                the Price cell; Taxable moved to each line's controls row;
+                per-line tax renders as a sub-line under the Total. The
+                wrapper only scrolls HORIZONTALLY on genuinely narrow screens
+                (phone) — the page is the editor's single vertical scroller.
+                An earlier design capped this div at max-h-[70vh] to make
+                sticky header cells work, but a vertical scrollport per
+                pricing block made the editor read as nested boxes of
                 scrollbars, so the block now grows to its content instead. */}
             <div className="overflow-x-auto rounded-md focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring" role="region" aria-label={t('quotes.editor.table.scrollAria')} tabIndex={0}>
-            <table className="w-full min-w-[36rem] text-sm" data-testid={`quote-block-lines-${block.id}`}>
+            <table className="w-full min-w-[26rem] text-sm" data-testid={`quote-block-lines-${block.id}`}>
               <thead>
                 <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
-                  <th className="min-w-[12rem] px-1.5 py-2 font-medium">{t('quotes.editor.table.item')}</th>
+                  <th className="min-w-[8rem] px-1.5 py-2 font-medium">{t('quotes.editor.table.item')}</th>
                   <th className="px-1.5 py-2 text-right font-medium">{t('quotes.editor.table.qty')}</th>
                   <th className="px-1.5 py-2 text-right font-medium">{t('quotes.editor.table.unitPrice')}</th>
                   <th className="px-1.5 py-2 text-right font-medium">{t('quotes.editor.table.total')}</th>

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -2554,10 +2554,16 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
         </div>
       )}
 
-      {/* The rail joins as a second column only at xl: below that the two-column
-          split starves the pricing table (at 1100px the blocks track is ~420px
-          against a ~650px table minimum) and forces sideways scrolling on the
-          most-checked figures. Stacked, the table gets the full content width. */}
+      {/* The rail joins as a second column only at xl (1280px): below that the
+          two-column split starves the pricing table and forces sideways
+          scrolling on the most-checked figures. Stacked, the table gets the
+          full content width. Even at xl, this breakpoint tracks VIEWPORT
+          width, not the width actually left for the blocks column — with the
+          left nav sidebar expanded (256px) the table's real budget is closer
+          to ~576px at exactly 1280px (#4668), which is why the table's own
+          min-width floor (QuoteBlockCard.tsx) has to stay well under that,
+          not just under the full 650px this column could theoretically
+          offer. */}
       <div className="grid gap-6 xl:grid-cols-[1fr_300px]">
         {/* ── blocks ─────────────────────────────────────────────────── */}
         {/* min-w-0: this 1fr grid track holds a pricing table with a min-width

--- a/apps/web/src/components/billing/quotes/QuoteLineRows.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteLineRows.tsx
@@ -1017,10 +1017,14 @@ export function EditableLineRow({
   return (
     <>
     <tr ref={rowRef} className={`group/row border-t align-top [&>td]:pt-4 ${dragging ? 'opacity-40' : ''}`} data-testid={`quote-line-${line.id}`}>
-      {/* Column min-width (min-w-[12rem]) is declared on the cell so table
+      {/* Column min-width (min-w-[8rem]) is declared on the cell so table
           auto-layout reserves the name column instead of squeezing it below the
-          input's width (which used to overflow into the qty cell). */}
-      <td className="min-w-[12rem] px-1.5 py-2">
+          input's width (which used to overflow into the qty cell). Item is the
+          lowest-priority column (#4668) — this floor must match the header
+          th's in QuoteBlockCard.tsx, and stay well under the space available
+          at 1280px with the left nav sidebar open, so Qty/Price/Total never
+          get pushed into horizontal scroll to make room for it. */}
+      <td className="min-w-[8rem] px-1.5 py-2">
         <div className="flex min-w-0 items-start gap-2">
           {/* Bulk-select checkbox — leading, in the same quiet reveal grammar as
               the gutter grip: hidden at rest, shown on row hover/focus-within,


### PR DESCRIPTION
## Summary
- At 1280px viewport with the left nav sidebar expanded, the quote editor's pricing table horizontally scrolled to reach the **Total** column. Root cause: the table's blanket `min-w-[36rem]` (576px) plus the Item column's own `min-w-[12rem]` (192px) floor summed to exactly the ~576px actually available at that viewport/sidebar combination, so any rendering variance (scrollbar, border, subpixel rounding) tipped it into `overflow-x-auto`.
- Restructured column priority: Item is the lowest-priority column (it already degrades gracefully via its own text input and `title` tooltip on overflow) — its floor drops from `12rem` to `8rem`, and the table's blanket floor drops from `36rem` to `26rem`. Qty/Unit Price/Total/actions are untouched — they were never the columns that needed to shrink; they're already content-sized/fixed-width and were never at risk of squeezing.
- Updated the adjacent layout comments (`QuoteEditor.tsx`'s `xl:grid-cols-[1fr_300px]` rail-breakpoint note, `QuoteBlockCard.tsx`'s column doc, `QuoteLineRows.tsx`'s cell doc) so the numbers and reasoning stay accurate for the next person who touches this.

Closes #4668

## Test plan
- [x] New regression test `apps/web/src/components/billing/quotes/QuoteBlockCard.gridwidth.test.tsx` — red-first (confirmed failing against the old `min-w-[36rem]`/`min-w-[12rem]` classes), now green. jsdom has no real layout engine so it can't assert on-screen pixels/scroll state directly; it locks the column-priority contract in Tailwind-class form (table's blanket floor shrunk; Item's floor shrunk on both header `<th>` and body `<td>`, catching a header/body mismatch too).
- [x] Full quotes test suite: `cd apps/web && npx vitest run src/components/billing/quotes` — 58 files / 510 tests passed.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint` on all touched files — clean.
- [ ] **Manual verification (not run here — no browser/dev-server access in this session):** apps/web dev server, open a quote in the editor at exactly 1280px viewport with the left nav sidebar expanded — Total should be visible with no horizontal scrollbar on the pricing table. Re-check 1440px and 1920px for no regression (both already had comfortable margin before this change and gain more here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)