### PR TITLE
feat(agent): reboot deferral state machine (#3207 W2)

### DIFF
--- a/agent/internal/heartbeat/handlers_patch.go
+++ b/agent/internal/heartbeat/handlers_patch.go
@@ -11,6 +11,19 @@ import (
 	"github.com/breeze-rmm/agent/internal/remote/tools"
 )
 
+// Accepted bounds for the schedule_reboot deferral budget (#3207). They mirror
+// the API-side CHECK constraints and zod validator exactly
+// (apps/api/src/services/patchRebootHandler.ts: MAX_REBOOT_DEFERRALS,
+// MIN/MAX_REBOOT_DEFERRAL_MINUTES). Duplicated rather than derived because the
+// agent must reject a payload the API could not have produced, whatever version
+// of the API sent it.
+const (
+	minPayloadDeferrals       = 1
+	maxPayloadDeferrals       = 10
+	minPayloadDeferralMinutes = 5
+	maxPayloadDeferralMinutes = 1440
+)
+
 func init() {
 	handlerRegistry[tools.CmdPatchScan] = handlePatchScan
 	handlerRegistry[tools.CmdInstallPatches] = handleInstallPatches
@@ -228,14 +241,51 @@ func handleScheduleReboot(h *Heartbeat, cmd Command) tools.CommandResult {
 	delay := time.Duration(delayMinutes) * time.Minute
 	deadline := time.Now().Add(delay)
 
-	// Allow overriding deadline via payload
+	// Allow overriding deadline via payload. Strict since #3207: a malformed
+	// deadline used to be swallowed, leaving deadline = now+delay, which now
+	// silently collapses the deferral budget to nothing. Fail the command
+	// instead of quietly delivering a different policy than the API asked for.
 	if deadlineStr := tools.GetPayloadString(cmd.Payload, "deadline", ""); deadlineStr != "" {
-		if parsed, err := time.Parse(time.RFC3339, deadlineStr); err == nil {
-			deadline = parsed
+		parsed, err := time.Parse(time.RFC3339, deadlineStr)
+		if err != nil {
+			return tools.NewErrorResult(fmt.Errorf("invalid deadline %q: %w", deadlineStr, err), time.Since(start).Milliseconds())
+		}
+		deadline = parsed
+	}
+
+	// Deferral budget (#3207). Absent keys mean OFF: an old API never sends
+	// them, and "not mentioned" must never widen what the agent will do.
+	// Ranges mirror the API-side CHECK constraints so a forged or corrupted
+	// payload is REJECTED rather than clamped — a silent clamp is how #3373
+	// turned a malformed delayMinutes into a 60-minute reboot.
+	opts := patching.RebootOptions{}
+	if tools.GetPayloadBool(cmd.Payload, "allowDeferral", false) {
+		maxDeferrals, err := tools.ParsePayloadInt(cmd.Payload, "maxDeferrals", 0)
+		if err != nil {
+			return tools.NewErrorResult(err, time.Since(start).Milliseconds())
+		}
+		deferralMinutes, err := tools.ParsePayloadInt(cmd.Payload, "deferralMinutes", 0)
+		if err != nil {
+			return tools.NewErrorResult(err, time.Since(start).Milliseconds())
+		}
+		if maxDeferrals < minPayloadDeferrals || maxDeferrals > maxPayloadDeferrals {
+			return tools.NewErrorResult(
+				fmt.Errorf("maxDeferrals must be %d-%d, got %d", minPayloadDeferrals, maxPayloadDeferrals, maxDeferrals),
+				time.Since(start).Milliseconds())
+		}
+		if deferralMinutes < minPayloadDeferralMinutes || deferralMinutes > maxPayloadDeferralMinutes {
+			return tools.NewErrorResult(
+				fmt.Errorf("deferralMinutes must be %d-%d, got %d", minPayloadDeferralMinutes, maxPayloadDeferralMinutes, deferralMinutes),
+				time.Since(start).Milliseconds())
+		}
+		opts.Deferral = patching.DeferralPolicy{
+			Allowed:         true,
+			MaxDeferrals:    maxDeferrals,
+			DeferralMinutes: deferralMinutes,
 		}
 	}
 
-	if err := h.rebootMgr.Schedule(delay, deadline, reason, source); err != nil {
+	if err := h.rebootMgr.ScheduleWithOptions(delay, deadline, reason, source, opts); err != nil {
 		return tools.NewErrorResult(err, time.Since(start).Milliseconds())
 	}
 

--- a/agent/internal/heartbeat/handlers_patch.go
+++ b/agent/internal/heartbeat/handlers_patch.go
@@ -259,6 +259,15 @@ func handleScheduleReboot(h *Heartbeat, cmd Command) tools.CommandResult {
 	// payload is REJECTED rather than clamped — a silent clamp is how #3373
 	// turned a malformed delayMinutes into a 60-minute reboot.
 	opts := patching.RebootOptions{}
+	// GetPayloadBool swallows a non-boolean, which fails safe (deferral stays
+	// off) but is otherwise invisible. Say so, or "why does this device not
+	// offer postponements" has no signal at all to start from.
+	if raw, present := cmd.Payload["allowDeferral"]; present {
+		if _, ok := raw.(bool); !ok {
+			log.Warn("schedule_reboot allowDeferral is not a boolean; treating deferral as disabled",
+				"got", fmt.Sprintf("%T", raw))
+		}
+	}
 	if tools.GetPayloadBool(cmd.Payload, "allowDeferral", false) {
 		maxDeferrals, err := tools.ParsePayloadInt(cmd.Payload, "maxDeferrals", 0)
 		if err != nil {

--- a/agent/internal/heartbeat/handlers_patch_test.go
+++ b/agent/internal/heartbeat/handlers_patch_test.go
@@ -1,0 +1,193 @@
+package heartbeat
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/patching"
+)
+
+func newTestHeartbeatWithRebootManager(t *testing.T) *Heartbeat {
+	t.Helper()
+	mgr := patching.NewRebootManager(func(string, string, string) {}, 3)
+	t.Cleanup(mgr.Stop)
+	return &Heartbeat{rebootMgr: mgr}
+}
+
+func scheduleRebootResultMap(t *testing.T, res any) map[string]any {
+	t.Helper()
+	stdout, ok := res.(string)
+	if !ok {
+		t.Fatalf("result stdout is %T, want string", res)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	return got
+}
+
+func TestScheduleRebootDefaultsDeferralOffWhenTheApiOmitsIt(t *testing.T) {
+	// An OLD API sends only delayMinutes/reason/source. The absent keys must
+	// mean deferral OFF — never "enabled".
+	h := newTestHeartbeatWithRebootManager(t)
+	res := handleScheduleReboot(h, Command{Payload: map[string]any{
+		"delayMinutes": float64(15), "reason": "Patch", "source": "patch_job",
+	}})
+	if res.Status != "completed" {
+		t.Fatalf("status = %q (%s)", res.Status, res.Error)
+	}
+	st := h.rebootMgr.State()
+	if st.DeferralAllowed {
+		t.Error("deferral enabled from a payload that never mentioned it")
+	}
+	if st.MaxDeferrals != 0 || st.DeferralMinutes != 0 {
+		t.Errorf("budget = %d x %dm, want 0", st.MaxDeferrals, st.DeferralMinutes)
+	}
+	// The absent deadline still falls back to the scheduled reboot time, which
+	// is exactly what an agent predating #3207 did.
+	if st.Deadline.IsZero() {
+		t.Error("Deadline is zero — an absent deadline must fall back to now+delay")
+	}
+
+	// get_reboot_status reports the budget with no handler change.
+	got := scheduleRebootResultMap(t, res.Stdout)
+	if got["deferralAllowed"] != false {
+		t.Errorf("reported deferralAllowed = %v, want false", got["deferralAllowed"])
+	}
+}
+
+func TestScheduleRebootHonoursTheDeferralBudget(t *testing.T) {
+	h := newTestHeartbeatWithRebootManager(t)
+	deadline := time.Now().Add(3 * time.Hour).UTC().Truncate(time.Second)
+	res := handleScheduleReboot(h, Command{Payload: map[string]any{
+		"delayMinutes": float64(15), "reason": "Patch", "source": "patch_job",
+		"deadline":     deadline.Format(time.RFC3339),
+		"allowDeferral": true, "maxDeferrals": float64(2), "deferralMinutes": float64(60),
+	}})
+	if res.Status != "completed" {
+		t.Fatalf("status = %q (%s)", res.Status, res.Error)
+	}
+	st := h.rebootMgr.State()
+	if !st.DeferralAllowed || st.MaxDeferrals != 2 || st.DeferralMinutes != 60 {
+		t.Fatalf("state = %+v", st)
+	}
+	if !st.Deadline.Equal(deadline) {
+		t.Errorf("Deadline = %v, want the payload's %v", st.Deadline, deadline)
+	}
+}
+
+// Forward compatibility: a NEWER API may add payload keys this agent has never
+// heard of. They must be ignored, not rejected.
+func TestScheduleRebootIgnoresUnknownPayloadKeys(t *testing.T) {
+	h := newTestHeartbeatWithRebootManager(t)
+	res := handleScheduleReboot(h, Command{Payload: map[string]any{
+		"delayMinutes": float64(15),
+		"allowDeferral": true, "maxDeferrals": float64(1), "deferralMinutes": float64(30),
+		"deferralChoices": []any{"15m", "1h"}, "somethingFromTheFuture": map[string]any{"a": 1},
+	}})
+	if res.Status != "completed" {
+		t.Fatalf("status = %q (%s)", res.Status, res.Error)
+	}
+	if st := h.rebootMgr.State(); !st.DeferralAllowed || st.MaxDeferrals != 1 {
+		t.Errorf("state = %+v", st)
+	}
+}
+
+// allowDeferral is the only switch. A payload carrying a budget without the
+// flag — a stale or hand-edited command — stays off.
+func TestScheduleRebootIgnoresABudgetWithoutTheFlag(t *testing.T) {
+	h := newTestHeartbeatWithRebootManager(t)
+	for _, payload := range []map[string]any{
+		{"delayMinutes": float64(15), "maxDeferrals": float64(5), "deferralMinutes": float64(60)},
+		{"delayMinutes": float64(15), "allowDeferral": false, "maxDeferrals": float64(5), "deferralMinutes": float64(60)},
+		// A non-boolean allowDeferral is not a boolean true.
+		{"delayMinutes": float64(15), "allowDeferral": "true", "maxDeferrals": float64(5), "deferralMinutes": float64(60)},
+	} {
+		res := handleScheduleReboot(h, Command{Payload: payload})
+		if res.Status != "completed" {
+			t.Fatalf("payload %v: status = %q (%s)", payload, res.Status, res.Error)
+		}
+		if st := h.rebootMgr.State(); st.DeferralAllowed || st.MaxDeferrals != 0 {
+			t.Errorf("payload %v: state = %+v, want deferral off", payload, st)
+		}
+	}
+}
+
+// Ranges mirror the API-side CHECK constraints. A forged or corrupted budget is
+// REJECTED rather than clamped — a silent clamp is how #3373 turned a malformed
+// delayMinutes into a 60-minute reboot.
+func TestScheduleRebootRejectsAnOutOfRangeDeferralBudget(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload map[string]any
+	}{
+		{"maxDeferrals above the ceiling", map[string]any{
+			"delayMinutes": float64(15), "allowDeferral": true,
+			"maxDeferrals": float64(99), "deferralMinutes": float64(60)}},
+		{"maxDeferrals below the floor", map[string]any{
+			"delayMinutes": float64(15), "allowDeferral": true,
+			"maxDeferrals": float64(0), "deferralMinutes": float64(60)}},
+		{"maxDeferrals negative", map[string]any{
+			"delayMinutes": float64(15), "allowDeferral": true,
+			"maxDeferrals": float64(-1), "deferralMinutes": float64(60)}},
+		{"maxDeferrals missing", map[string]any{
+			"delayMinutes": float64(15), "allowDeferral": true,
+			"deferralMinutes": float64(60)}},
+		{"maxDeferrals malformed", map[string]any{
+			"delayMinutes": float64(15), "allowDeferral": true,
+			"maxDeferrals": "lots", "deferralMinutes": float64(60)}},
+		{"deferralMinutes below the floor", map[string]any{
+			"delayMinutes": float64(15), "allowDeferral": true,
+			"maxDeferrals": float64(2), "deferralMinutes": float64(1)}},
+		{"deferralMinutes above the ceiling", map[string]any{
+			"delayMinutes": float64(15), "allowDeferral": true,
+			"maxDeferrals": float64(2), "deferralMinutes": float64(5000)}},
+		{"deferralMinutes missing", map[string]any{
+			"delayMinutes": float64(15), "allowDeferral": true,
+			"maxDeferrals": float64(2)}},
+		{"deferralMinutes malformed", map[string]any{
+			"delayMinutes": float64(15), "allowDeferral": true,
+			"maxDeferrals": float64(2), "deferralMinutes": "an hour"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHeartbeatWithRebootManager(t)
+			res := handleScheduleReboot(h, Command{Payload: tc.payload})
+			if res.Status == "completed" {
+				t.Fatalf("payload %v was accepted; a bad budget must be rejected, not clamped", tc.payload)
+			}
+			if st := h.rebootMgr.State(); st.RebootScheduled {
+				t.Error("a rejected schedule_reboot still scheduled a reboot")
+			}
+		})
+	}
+}
+
+// A malformed deadline used to be swallowed, leaving deadline = now+delay. With
+// deferral live that silently collapses the budget to nothing, so it now fails
+// the command instead.
+func TestScheduleRebootRejectsAMalformedDeadline(t *testing.T) {
+	h := newTestHeartbeatWithRebootManager(t)
+	res := handleScheduleReboot(h, Command{Payload: map[string]any{
+		"delayMinutes": float64(15), "deadline": "next tuesday",
+	}})
+	if res.Status == "completed" {
+		t.Fatal("a malformed deadline was swallowed; it must fail the command")
+	}
+	if res.Error == "" {
+		t.Error("no error message on a rejected deadline")
+	}
+	if h.rebootMgr.State().RebootScheduled {
+		t.Error("a rejected schedule_reboot still scheduled a reboot")
+	}
+}
+
+func TestScheduleRebootWithoutARebootManagerFails(t *testing.T) {
+	res := handleScheduleReboot(&Heartbeat{}, Command{Payload: map[string]any{"delayMinutes": float64(15)}})
+	if res.Status == "completed" {
+		t.Fatal("schedule_reboot succeeded with no reboot manager")
+	}
+}

--- a/agent/internal/heartbeat/handlers_patch_test.go
+++ b/agent/internal/heartbeat/handlers_patch_test.go
@@ -63,7 +63,7 @@ func TestScheduleRebootHonoursTheDeferralBudget(t *testing.T) {
 	deadline := time.Now().Add(3 * time.Hour).UTC().Truncate(time.Second)
 	res := handleScheduleReboot(h, Command{Payload: map[string]any{
 		"delayMinutes": float64(15), "reason": "Patch", "source": "patch_job",
-		"deadline":     deadline.Format(time.RFC3339),
+		"deadline":      deadline.Format(time.RFC3339),
 		"allowDeferral": true, "maxDeferrals": float64(2), "deferralMinutes": float64(60),
 	}})
 	if res.Status != "completed" {
@@ -83,7 +83,7 @@ func TestScheduleRebootHonoursTheDeferralBudget(t *testing.T) {
 func TestScheduleRebootIgnoresUnknownPayloadKeys(t *testing.T) {
 	h := newTestHeartbeatWithRebootManager(t)
 	res := handleScheduleReboot(h, Command{Payload: map[string]any{
-		"delayMinutes": float64(15),
+		"delayMinutes":  float64(15),
 		"allowDeferral": true, "maxDeferrals": float64(1), "deferralMinutes": float64(30),
 		"deferralChoices": []any{"15m", "1h"}, "somethingFromTheFuture": map[string]any{"a": 1},
 	}})

--- a/agent/internal/heartbeat/handlers_patch_test.go
+++ b/agent/internal/heartbeat/handlers_patch_test.go
@@ -2,12 +2,18 @@ package heartbeat
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/breeze-rmm/agent/internal/patching"
 )
 
+// NOTE: this manager keeps the production deferral-ledger path, which these
+// tests never write to — they only ever call handleScheduleReboot, and the
+// ledger READ treats a missing file as zero. A test at this layer that calls
+// Defer() would touch the real agent data dir, so seam the ledger first (the
+// field is unexported in package patching, so that needs an exported option).
 func newTestHeartbeatWithRebootManager(t *testing.T) *Heartbeat {
 	t.Helper()
 	mgr := patching.NewRebootManager(func(string, string, string) {}, 3)
@@ -189,5 +195,34 @@ func TestScheduleRebootWithoutARebootManagerFails(t *testing.T) {
 	res := handleScheduleReboot(&Heartbeat{}, Command{Payload: map[string]any{"delayMinutes": float64(15)}})
 	if res.Status == "completed" {
 		t.Fatal("schedule_reboot succeeded with no reboot manager")
+	}
+}
+
+// The bounds are inclusive on both ends. Only rejections were tested, so an
+// off-by-one (`<` becoming `<=`, or vice versa) on any of the four comparisons
+// would silently refuse a legal edge-of-range policy and nothing would notice.
+func TestScheduleRebootAcceptsTheBoundaryBudgetValues(t *testing.T) {
+	cases := []struct {
+		maxDeferrals    int
+		deferralMinutes int
+	}{
+		{1, 5}, {1, 1440}, {10, 5}, {10, 1440},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("max=%d window=%d", tc.maxDeferrals, tc.deferralMinutes), func(t *testing.T) {
+			h := newTestHeartbeatWithRebootManager(t)
+			res := handleScheduleReboot(h, Command{Payload: map[string]any{
+				"delayMinutes": float64(15), "allowDeferral": true,
+				"maxDeferrals": float64(tc.maxDeferrals), "deferralMinutes": float64(tc.deferralMinutes),
+			}})
+			if res.Status != "completed" {
+				t.Fatalf("status = %q (%s) — the bounds are inclusive", res.Status, res.Error)
+			}
+			st := h.rebootMgr.State()
+			if st.MaxDeferrals != tc.maxDeferrals || st.DeferralMinutes != tc.deferralMinutes {
+				t.Errorf("state = %d x %dm, want %d x %dm",
+					st.MaxDeferrals, st.DeferralMinutes, tc.maxDeferrals, tc.deferralMinutes)
+			}
+		})
 	}
 }

--- a/agent/internal/patching/reboot_deferral.go
+++ b/agent/internal/patching/reboot_deferral.go
@@ -150,11 +150,11 @@ func SaveDeferralLedger(path string, deadline time.Time, used int) error {
 		_ = os.Remove(tmpName)
 	}()
 	if err := tmp.Chmod(0o600); err != nil {
-		tmp.Close()
+		_ = tmp.Close()
 		return err
 	}
 	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
+		_ = tmp.Close()
 		return err
 	}
 	if err := tmp.Close(); err != nil {

--- a/agent/internal/patching/reboot_deferral.go
+++ b/agent/internal/patching/reboot_deferral.go
@@ -53,23 +53,43 @@ type DeferralOutcome struct {
 // ComputeDeferral is pure: no clock, no disk, no locks. Everything that decides
 // whether a user may postpone their restart lives here so it can be asserted
 // exhaustively without driving timers.
-func ComputeDeferral(policy DeferralPolicy, used int, now, deadline time.Time) DeferralOutcome {
+//
+// The window is added to the CURRENTLY SCHEDULED time, not to now. Computing it
+// from now instead looks equivalent and is not: with a 120-minute reboot delay
+// and a 60-minute postponement — both well inside the configurable ranges —
+// "now + 60m" moves the restart an hour EARLIER, so the user who pressed
+// Postpone loses an hour. It also has to be this way to agree with the deadline
+// the API derives, `scheduledAt + maxDeferrals * deferralMinutes`
+// (apps/api/src/services/patchRebootHandler.ts): spending the whole budget then
+// lands exactly on the deadline rather than short of it.
+func ComputeDeferral(policy DeferralPolicy, used int, now, scheduledAt, deadline time.Time) DeferralOutcome {
 	if !policy.Allowed || policy.MaxDeferrals <= 0 || policy.DeferralMinutes <= 0 {
 		return DeferralOutcome{Reason: deferralReasonNotEnabled}
 	}
 	if used >= policy.MaxDeferrals {
 		return DeferralOutcome{Reason: deferralReasonNoneRemaining}
 	}
-	want := time.Duration(policy.DeferralMinutes) * time.Minute
-	// The clamp. A zero or past deadline yields a non-positive remainder and so
-	// falls through to the refusal below rather than granting anything.
-	if remaining := deadline.Sub(now); remaining < want {
-		want = remaining
+
+	// An overdue schedule would otherwise push off a time already in the past.
+	base := scheduledAt
+	if base.Before(now) {
+		base = now
 	}
-	if want < MinRebootDelay {
+	target := base.Add(time.Duration(policy.DeferralMinutes) * time.Minute)
+	// The clamp: the deadline is the guarantee (#3253).
+	if target.After(deadline) {
+		target = deadline
+	}
+	// A deadline at or before the current schedule leaves nothing to postpone
+	// into, and clamping to it would pull the restart forward — refuse instead.
+	if target.Before(base) {
 		return DeferralOutcome{Reason: deferralReasonDeadlineReached}
 	}
-	return DeferralOutcome{Granted: true, NewDelay: want}
+	delay := target.Sub(now)
+	if delay < MinRebootDelay {
+		return DeferralOutcome{Reason: deferralReasonDeadlineReached}
+	}
+	return DeferralOutcome{Granted: true, NewDelay: delay}
 }
 
 // DeferralLedger persists the count for ONE reboot campaign, keyed by its hard
@@ -154,6 +174,13 @@ func SaveDeferralLedger(path string, deadline time.Time, used int) error {
 		return err
 	}
 	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	// Flush to the device before the rename, so a power loss cannot leave the
+	// renamed file present but empty. An empty file reads back as corrupt, which
+	// means "zero used" — i.e. the user silently gets their whole budget again.
+	if err := tmp.Sync(); err != nil {
 		_ = tmp.Close()
 		return err
 	}

--- a/agent/internal/patching/reboot_deferral.go
+++ b/agent/internal/patching/reboot_deferral.go
@@ -1,0 +1,167 @@
+// Deferral arithmetic and its on-disk ledger (issue #3207).
+//
+// Untagged on purpose, for the same reason reboot_plan.go is: ./internal/patching
+// is not in the test-agent-windows package allowlist (#3019, #3046), so anything
+// behind a build tag is tested nowhere in CI.
+//
+// The COUNTER is a UX affordance; the DEADLINE is the guarantee. A deferral is
+// always clamped to the deadline the API sent, and refused outright when the
+// clamp leaves less room than MinRebootDelay. That is what finally gives
+// RebootState.Deadline a job (#3253: stored and reported, never enforced).
+package patching
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/config"
+)
+
+const deferralLedgerFile = "reboot_deferrals.json"
+
+// Refusal reasons. These are shown to the signed-in user verbatim (W3), so they
+// are phrased as statements about their restart rather than about the agent.
+const (
+	deferralReasonNotEnabled      = "deferral is not enabled by policy"
+	deferralReasonNoneRemaining   = "no postponements remaining"
+	deferralReasonDeadlineReached = "the restart deadline has been reached"
+)
+
+// DeferralPolicy is the budget for ONE scheduled reboot, resolved server-side
+// and delivered on the schedule_reboot payload. Its zero value is "no deferral",
+// which is what every pre-#3207 call site and every old API produces — an absent
+// policy must never widen what the agent will do.
+type DeferralPolicy struct {
+	Allowed         bool
+	MaxDeferrals    int
+	DeferralMinutes int
+}
+
+// DeferralOutcome is the verdict on one postponement request.
+type DeferralOutcome struct {
+	Granted bool
+	// NewDelay is the delay to re-schedule under. Only set when Granted.
+	NewDelay time.Duration
+	// Reason explains a refusal and is intended to be shown to the user. Only
+	// set when the request was refused.
+	Reason string
+}
+
+// ComputeDeferral is pure: no clock, no disk, no locks. Everything that decides
+// whether a user may postpone their restart lives here so it can be asserted
+// exhaustively without driving timers.
+func ComputeDeferral(policy DeferralPolicy, used int, now, deadline time.Time) DeferralOutcome {
+	if !policy.Allowed || policy.MaxDeferrals <= 0 || policy.DeferralMinutes <= 0 {
+		return DeferralOutcome{Reason: deferralReasonNotEnabled}
+	}
+	if used >= policy.MaxDeferrals {
+		return DeferralOutcome{Reason: deferralReasonNoneRemaining}
+	}
+	want := time.Duration(policy.DeferralMinutes) * time.Minute
+	// The clamp. A zero or past deadline yields a non-positive remainder and so
+	// falls through to the refusal below rather than granting anything.
+	if remaining := deadline.Sub(now); remaining < want {
+		want = remaining
+	}
+	if want < MinRebootDelay {
+		return DeferralOutcome{Reason: deferralReasonDeadlineReached}
+	}
+	return DeferralOutcome{Granted: true, NewDelay: want}
+}
+
+// DeferralLedger persists the count for ONE reboot campaign, keyed by its hard
+// deadline truncated to the minute. A schedule carrying a different deadline is
+// a different administrator decision (Schedule is documented last-writer-wins),
+// so it legitimately starts a fresh budget — the deadline still bounds it.
+//
+// Best-effort by design: a missing, corrupt, or expired ledger means zero
+// deferrals used, never an error that blocks a reboot. Losing the count costs
+// the user an extra postponement after an agent restart; it can never let them
+// postpone past the deadline, because the deadline is enforced separately.
+type DeferralLedger struct {
+	Deadline time.Time `json:"deadline"`
+	Used     int       `json:"used"`
+}
+
+func deferralLedgerPath() string {
+	return filepath.Join(config.GetDataDir(), deferralLedgerFile)
+}
+
+// LoadDeferralLedger returns how many postponements this campaign has already
+// used. Zero for anything it cannot positively confirm.
+func LoadDeferralLedger(path string, deadline, now time.Time) int {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		// Missing is the normal case on the first deferral of a campaign; a
+		// genuine read error is still only worth a debug line because the
+		// consequence is bounded (one extra postponement, never a missed
+		// deadline) — unlike the reboot-history file, which IS the circuit
+		// breaker's memory and therefore warns.
+		if !os.IsNotExist(err) {
+			log.Debug("reboot deferral ledger unreadable; postponement count resets to zero",
+				"path", path, "error", err)
+		}
+		return 0
+	}
+	var ledger DeferralLedger
+	if err := json.Unmarshal(data, &ledger); err != nil {
+		log.Warn("reboot deferral ledger is corrupt; postponement count resets to zero",
+			"path", path, "error", err)
+		return 0
+	}
+	if !ledger.Deadline.Truncate(time.Minute).Equal(deadline.Truncate(time.Minute)) {
+		return 0
+	}
+	if !ledger.Deadline.After(now) {
+		return 0
+	}
+	if ledger.Used < 0 {
+		return 0
+	}
+	return ledger.Used
+}
+
+// SaveDeferralLedger records the count for this campaign.
+//
+// Written atomically (temp file in the same directory, then rename) so a crash
+// or a full disk mid-write leaves the previous count in place instead of a
+// truncated file. A torn ledger would read back as zero used, which quietly
+// hands the user their whole budget again.
+func SaveDeferralLedger(path string, deadline time.Time, used int) error {
+	data, err := json.Marshal(DeferralLedger{Deadline: deadline, Used: used})
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, deferralLedgerFile+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() {
+		// No-op once the rename succeeded; on any failure path this is what
+		// keeps the temp file from accumulating in the data dir.
+		_ = os.Remove(tmpName)
+	}()
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("rename deferral ledger into place: %w", err)
+	}
+	return nil
+}

--- a/agent/internal/patching/reboot_deferral_test.go
+++ b/agent/internal/patching/reboot_deferral_test.go
@@ -1,0 +1,240 @@
+// Untagged on purpose — see reboot_plan_test.go and reboot_deferral.go.
+package patching
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestComputeDeferral(t *testing.T) {
+	now := time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
+	pol := DeferralPolicy{Allowed: true, MaxDeferrals: 2, DeferralMinutes: 60}
+
+	cases := []struct {
+		name     string
+		policy   DeferralPolicy
+		used     int
+		deadline time.Time
+		want     DeferralOutcome
+	}{
+		{
+			name:   "policy disabled refuses",
+			policy: DeferralPolicy{Allowed: false, MaxDeferrals: 5, DeferralMinutes: 60},
+			used:   0, deadline: now.Add(9 * time.Hour),
+			want: DeferralOutcome{Granted: false, Reason: deferralReasonNotEnabled},
+		},
+		{
+			// The zero value of DeferralPolicy is what every pre-#3207 call site
+			// produces. It must refuse, never fall through to a default budget.
+			name:   "zero-valued policy refuses",
+			policy: DeferralPolicy{},
+			used:   0, deadline: now.Add(9 * time.Hour),
+			want: DeferralOutcome{Granted: false, Reason: deferralReasonNotEnabled},
+		},
+		{
+			name:   "allowed but zero count refuses",
+			policy: DeferralPolicy{Allowed: true, MaxDeferrals: 0, DeferralMinutes: 60},
+			used:   0, deadline: now.Add(9 * time.Hour),
+			want: DeferralOutcome{Granted: false, Reason: deferralReasonNotEnabled},
+		},
+		{
+			name:   "allowed but zero window refuses",
+			policy: DeferralPolicy{Allowed: true, MaxDeferrals: 2, DeferralMinutes: 0},
+			used:   0, deadline: now.Add(9 * time.Hour),
+			want: DeferralOutcome{Granted: false, Reason: deferralReasonNotEnabled},
+		},
+		{
+			name: "budget exhausted refuses", policy: pol, used: 2,
+			deadline: now.Add(9 * time.Hour),
+			want:     DeferralOutcome{Granted: false, Reason: deferralReasonNoneRemaining},
+		},
+		{
+			// A ledger that somehow overshoots must still refuse, not wrap around.
+			name: "budget overshot refuses", policy: pol, used: 7,
+			deadline: now.Add(9 * time.Hour),
+			want:     DeferralOutcome{Granted: false, Reason: deferralReasonNoneRemaining},
+		},
+		{
+			name:   "grants the full window when the deadline is far away",
+			policy: pol, used: 0, deadline: now.Add(9 * time.Hour),
+			want: DeferralOutcome{Granted: true, NewDelay: 60 * time.Minute},
+		},
+		{
+			name:   "grants the last postponement in the budget",
+			policy: pol, used: 1, deadline: now.Add(9 * time.Hour),
+			want: DeferralOutcome{Granted: true, NewDelay: 60 * time.Minute},
+		},
+		{
+			// #3253: the deadline is what actually bounds a deferral. A 60-minute
+			// window with 20 minutes left must yield 20, not 60.
+			name:   "clamps the window to the hard deadline",
+			policy: pol, used: 1, deadline: now.Add(20 * time.Minute),
+			want: DeferralOutcome{Granted: true, NewDelay: 20 * time.Minute},
+		},
+		{
+			// Exactly MinRebootDelay is still schedulable: PlanReboot's floor is
+			// this same constant, so the closing notice still has room to render.
+			name:   "grants a clamp landing exactly on MinRebootDelay",
+			policy: pol, used: 0, deadline: now.Add(MinRebootDelay),
+			want: DeferralOutcome{Granted: true, NewDelay: MinRebootDelay},
+		},
+		{
+			name:   "refuses when the clamp leaves less than MinRebootDelay",
+			policy: pol, used: 0, deadline: now.Add(30 * time.Second),
+			want: DeferralOutcome{Granted: false, Reason: deferralReasonDeadlineReached},
+		},
+		{
+			name:   "refuses a deadline already in the past",
+			policy: pol, used: 0, deadline: now.Add(-time.Minute),
+			want: DeferralOutcome{Granted: false, Reason: deferralReasonDeadlineReached},
+		},
+		{
+			// A caller that never received a deadline must not get an unbounded
+			// postponement out of the zero time.
+			name:   "refuses a zero deadline",
+			policy: pol, used: 0, deadline: time.Time{},
+			want: DeferralOutcome{Granted: false, Reason: deferralReasonDeadlineReached},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ComputeDeferral(tc.policy, tc.used, now, tc.deadline)
+			if got.Granted != tc.want.Granted || got.NewDelay != tc.want.NewDelay {
+				t.Fatalf("got %+v, want %+v", got, tc.want)
+			}
+			if !got.Granted {
+				if got.Reason != tc.want.Reason {
+					t.Errorf("reason = %q, want %q", got.Reason, tc.want.Reason)
+				}
+				if got.NewDelay != 0 {
+					t.Errorf("refused outcome carries NewDelay=%v, want 0", got.NewDelay)
+				}
+			}
+			if got.Granted && got.Reason != "" {
+				t.Errorf("granted outcome carries Reason=%q, want empty", got.Reason)
+			}
+		})
+	}
+}
+
+// A granted deferral must never schedule the machine down after the deadline —
+// that is the whole guarantee the counter does not provide.
+func TestComputeDeferralNeverExceedsTheDeadline(t *testing.T) {
+	now := time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
+	pol := DeferralPolicy{Allowed: true, MaxDeferrals: 10, DeferralMinutes: 240}
+
+	for offset := time.Minute; offset <= 8*time.Hour; offset += 37 * time.Second {
+		deadline := now.Add(offset)
+		got := ComputeDeferral(pol, 0, now, deadline)
+		if !got.Granted {
+			continue
+		}
+		if landing := now.Add(got.NewDelay); landing.After(deadline) {
+			t.Fatalf("offset %v: deferral lands at %v, past the deadline %v", offset, landing, deadline)
+		}
+		if got.NewDelay < MinRebootDelay {
+			t.Fatalf("offset %v: granted %v, below MinRebootDelay", offset, got.NewDelay)
+		}
+	}
+}
+
+func TestDeferralLedgerRoundTripsOnMatchingDeadline(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "reboot_deferrals.json")
+	now := time.Now()
+	deadline := now.Add(2 * time.Hour).Truncate(time.Minute)
+
+	if err := SaveDeferralLedger(path, deadline, 2); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if got := LoadDeferralLedger(path, deadline, now); got != 2 {
+		t.Errorf("same-deadline reload = %d, want 2 (the budget must survive an agent restart)", got)
+	}
+	// Sub-minute jitter in the deadline is still the same campaign: the API
+	// re-sends an ISO timestamp with milliseconds, and a re-dispatch must not
+	// hand the user a fresh budget just because the string differs.
+	if got := LoadDeferralLedger(path, deadline.Add(20*time.Second), now); got != 2 {
+		t.Errorf("same-minute reload = %d, want 2", got)
+	}
+	// A different deadline is a different administrator decision: fresh budget.
+	if got := LoadDeferralLedger(path, deadline.Add(time.Hour), now); got != 0 {
+		t.Errorf("different-deadline reload = %d, want 0", got)
+	}
+	// An expired ledger never resurrects.
+	if got := LoadDeferralLedger(path, deadline, deadline.Add(time.Minute)); got != 0 {
+		t.Errorf("expired reload = %d, want 0", got)
+	}
+}
+
+func TestDeferralLedgerMissingOrCorruptFileMeansZero(t *testing.T) {
+	dir := t.TempDir()
+	if got := LoadDeferralLedger(filepath.Join(dir, "nope.json"), time.Now().Add(time.Hour), time.Now()); got != 0 {
+		t.Errorf("missing file = %d, want 0", got)
+	}
+	bad := filepath.Join(dir, "bad.json")
+	if err := os.WriteFile(bad, []byte("{not json"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if got := LoadDeferralLedger(bad, time.Now().Add(time.Hour), time.Now()); got != 0 {
+		t.Errorf("corrupt file = %d, want 0", got)
+	}
+
+	// A hand-edited negative count must not become extra postponements.
+	negative := filepath.Join(dir, "negative.json")
+	deadline := time.Now().Add(time.Hour)
+	data, err := json.Marshal(DeferralLedger{Deadline: deadline, Used: -3})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(negative, data, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if got := LoadDeferralLedger(negative, deadline, time.Now()); got != 0 {
+		t.Errorf("negative count = %d, want 0", got)
+	}
+}
+
+func TestSaveDeferralLedgerOverwritesAndIsPrivate(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "data")
+	path := filepath.Join(dir, "reboot_deferrals.json")
+	deadline := time.Now().Add(90 * time.Minute)
+
+	if err := SaveDeferralLedger(path, deadline, 1); err != nil {
+		t.Fatalf("first save: %v", err)
+	}
+	if err := SaveDeferralLedger(path, deadline, 2); err != nil {
+		t.Fatalf("second save: %v", err)
+	}
+	if got := LoadDeferralLedger(path, deadline, time.Now()); got != 2 {
+		t.Errorf("after overwrite = %d, want 2", got)
+	}
+
+	// No stray temp files left behind by the atomic write.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "reboot_deferrals.json" {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("ledger directory = %v, want exactly [reboot_deferrals.json]", names)
+	}
+
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat: %v", err)
+		}
+		// The ledger sits in the agent data dir alongside reboot_history.json;
+		// keep it root-only for the same reason.
+		if perm := info.Mode().Perm(); perm != 0o600 {
+			t.Errorf("ledger mode = %o, want 600", perm)
+		}
+	}
+}

--- a/agent/internal/patching/reboot_deferral_test.go
+++ b/agent/internal/patching/reboot_deferral_test.go
@@ -14,12 +14,16 @@ func TestComputeDeferral(t *testing.T) {
 	now := time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
 	pol := DeferralPolicy{Allowed: true, MaxDeferrals: 2, DeferralMinutes: 60}
 
+	// scheduledAt defaults to `now` in these cases unless a case sets it, so the
+	// table reads as "postpone a restart that is due right now" — the strictest
+	// framing, since any extra headroom only makes a grant easier.
 	cases := []struct {
-		name     string
-		policy   DeferralPolicy
-		used     int
-		deadline time.Time
-		want     DeferralOutcome
+		name        string
+		policy      DeferralPolicy
+		used        int
+		scheduledAt time.Time
+		deadline    time.Time
+		want        DeferralOutcome
 	}{
 		{
 			name:   "policy disabled refuses",
@@ -99,11 +103,48 @@ func TestComputeDeferral(t *testing.T) {
 			policy: pol, used: 0, deadline: time.Time{},
 			want: DeferralOutcome{Granted: false, Reason: deferralReasonDeadlineReached},
 		},
+		{
+			// The window is added to the SCHEDULE, not to now. Computed from now
+			// this would be 60m, which moves a restart that was two hours away an
+			// hour CLOSER — the user pressed Postpone and lost an hour.
+			name:   "adds the window to the scheduled time, never pulling it earlier",
+			policy: pol, used: 0,
+			scheduledAt: now.Add(2 * time.Hour), deadline: now.Add(4 * time.Hour),
+			want: DeferralOutcome{Granted: true, NewDelay: 3 * time.Hour},
+		},
+		{
+			// Which is also what makes the counter and the API's derived deadline
+			// agree: scheduledAt + maxDeferrals*window IS the deadline, so the last
+			// postponement lands exactly on it.
+			name:   "the last postponement lands exactly on the derived deadline",
+			policy: pol, used: 1,
+			scheduledAt: now.Add(3 * time.Hour), deadline: now.Add(4 * time.Hour),
+			want: DeferralOutcome{Granted: true, NewDelay: 4 * time.Hour},
+		},
+		{
+			// An overdue schedule pushes off from now, not from a past instant.
+			name:   "an overdue schedule postpones from now",
+			policy: pol, used: 0,
+			scheduledAt: now.Add(-30 * time.Minute), deadline: now.Add(4 * time.Hour),
+			want: DeferralOutcome{Granted: true, NewDelay: 60 * time.Minute},
+		},
+		{
+			// A deadline behind the schedule must refuse rather than clamp, which
+			// would drag the restart forward in the name of postponing it.
+			name:   "refuses a deadline that sits before the current schedule",
+			policy: pol, used: 0,
+			scheduledAt: now.Add(2 * time.Hour), deadline: now.Add(time.Hour),
+			want: DeferralOutcome{Granted: false, Reason: deferralReasonDeadlineReached},
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := ComputeDeferral(tc.policy, tc.used, now, tc.deadline)
+			scheduledAt := tc.scheduledAt
+			if scheduledAt.IsZero() {
+				scheduledAt = now
+			}
+			got := ComputeDeferral(tc.policy, tc.used, now, scheduledAt, tc.deadline)
 			if got.Granted != tc.want.Granted || got.NewDelay != tc.want.NewDelay {
 				t.Fatalf("got %+v, want %+v", got, tc.want)
 			}
@@ -130,15 +171,23 @@ func TestComputeDeferralNeverExceedsTheDeadline(t *testing.T) {
 
 	for offset := time.Minute; offset <= 8*time.Hour; offset += 37 * time.Second {
 		deadline := now.Add(offset)
-		got := ComputeDeferral(pol, 0, now, deadline)
-		if !got.Granted {
-			continue
-		}
-		if landing := now.Add(got.NewDelay); landing.After(deadline) {
-			t.Fatalf("offset %v: deferral lands at %v, past the deadline %v", offset, landing, deadline)
-		}
-		if got.NewDelay < MinRebootDelay {
-			t.Fatalf("offset %v: granted %v, below MinRebootDelay", offset, got.NewDelay)
+		for _, sched := range []time.Duration{-time.Hour, 0, time.Minute, offset / 2, offset, offset + time.Hour} {
+			scheduledAt := now.Add(sched)
+			got := ComputeDeferral(pol, 0, now, scheduledAt, deadline)
+			if !got.Granted {
+				continue
+			}
+			landing := now.Add(got.NewDelay)
+			if landing.After(deadline) {
+				t.Fatalf("offset %v sched %v: lands at %v, past the deadline %v", offset, sched, landing, deadline)
+			}
+			if landing.Before(scheduledAt) {
+				t.Fatalf("offset %v sched %v: lands at %v, EARLIER than the current schedule %v",
+					offset, sched, landing, scheduledAt)
+			}
+			if got.NewDelay < MinRebootDelay {
+				t.Fatalf("offset %v sched %v: granted %v, below MinRebootDelay", offset, sched, got.NewDelay)
+			}
 		}
 	}
 }

--- a/agent/internal/patching/reboot_manager.go
+++ b/agent/internal/patching/reboot_manager.go
@@ -54,6 +54,23 @@ type RebootState struct {
 	// now" and "the reboot failed and the machine is still up", which left a
 	// failed reboot visible only in agent logs. Cleared by the next Schedule.
 	LastError string `json:"lastError,omitempty"`
+
+	// Deferral budget for the current schedule (#3207). Zero-valued when the
+	// policy did not enable it, which is the default and reproduces the
+	// pre-#3207 behaviour exactly. Not omitempty: the console needs to tell
+	// "this restart cannot be postponed" apart from "this agent predates
+	// deferral", and an omitted field reads as the latter.
+	DeferralAllowed bool `json:"deferralAllowed"`
+	DeferralsUsed   int  `json:"deferralsUsed"`
+	MaxDeferrals    int  `json:"maxDeferrals"`
+	DeferralMinutes int  `json:"deferralMinutes"`
+}
+
+// RebootOptions carries everything about a schedule that is not part of the
+// pre-#3207 signature. A zero RebootOptions is exactly today's behaviour, which
+// is what lets Schedule stay a thin wrapper and every old call site stay put.
+type RebootOptions struct {
+	Deferral DeferralPolicy
 }
 
 // NotifyFunc is called to send a notification to the logged-in user.
@@ -61,7 +78,14 @@ type NotifyFunc func(title, body, urgency string)
 
 // RebootManager handles reboot scheduling, notification, and execution.
 type RebootManager struct {
-	mu               sync.Mutex
+	mu sync.Mutex
+	// deferMu serialises whole Defer calls. mu alone is not enough: Defer has to
+	// release mu to re-enter ScheduleWithOptions, and two callers interleaving in
+	// that window would both read the same pre-increment count and both be
+	// granted. W3 fans the prompt out to every helper session and takes the first
+	// answer, so simultaneous requests are the expected shape, not a hypothetical.
+	// Always acquired BEFORE mu; never held by anything else.
+	deferMu          sync.Mutex
 	state            RebootState
 	notifyTimers     []*time.Timer
 	osTimer          *time.Timer
@@ -83,15 +107,22 @@ type RebootManager struct {
 	// generation it was armed under and does nothing if it no longer matches.
 	generation uint64
 
+	// deferral is the budget the API sent with the current schedule, and
+	// deferralsUsed how much of it this campaign has spent. Both are reset by
+	// every Schedule: an absent policy must never mean "enabled".
+	deferral      DeferralPolicy
+	deferralsUsed int
+
 	// Injectable seams for deterministic tests, following the repo's nowFn
 	// convention (sessionbroker.Broker, watchdog.Clock). afterFunc in
 	// particular is what lets the notification ladder be asserted without
 	// waiting real minutes — the plan's shortest schedule is a minute long.
-	nowFn         func() time.Time
-	afterFunc     func(time.Duration, func()) *time.Timer
-	execOSReboot  func(grace time.Duration) error
-	abortOSReboot func() error
-	historyPath   func() string
+	nowFn          func() time.Time
+	afterFunc      func(time.Duration, func()) *time.Timer
+	execOSReboot   func(grace time.Duration) error
+	abortOSReboot  func() error
+	historyPath    func() string
+	deferralLedger func() string
 }
 
 // NewRebootManager creates a new RebootManager with circuit breaker protection.
@@ -108,6 +139,7 @@ func NewRebootManager(notifyFn NotifyFunc, maxRebootsPerDay int) *RebootManager 
 		execOSReboot:     execOSReboot,
 		abortOSReboot:    abortOSReboot,
 		historyPath:      rebootHistoryPath,
+		deferralLedger:   deferralLedgerPath,
 	}
 	rm.loadRebootHistory()
 	return rm
@@ -133,6 +165,14 @@ func (r *RebootManager) State() RebootState {
 // (always emitted, #3197) is what tells them, which is precisely why the lead
 // notification is unconditional rather than threshold-gated.
 func (r *RebootManager) Schedule(delay time.Duration, deadline time.Time, reason, source string) error {
+	return r.ScheduleWithOptions(delay, deadline, reason, source, RebootOptions{})
+}
+
+// ScheduleWithOptions is Schedule plus the #3207 deferral budget. Kept as a
+// separate entry point rather than a wider Schedule signature so that every
+// pre-existing caller — and every pre-existing test — keeps today's behaviour
+// with no edit at all.
+func (r *RebootManager) ScheduleWithOptions(delay time.Duration, deadline time.Time, reason, source string, opts RebootOptions) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -167,6 +207,20 @@ func (r *RebootManager) Schedule(delay time.Duration, deadline time.Time, reason
 
 	plan := PlanReboot(delay)
 	now := r.nowFn()
+
+	// Reset the budget from the incoming policy on every schedule. A schedule
+	// that says nothing about deferral is not deferrable, whatever the previous
+	// one allowed.
+	r.deferral = opts.Deferral
+	r.deferralsUsed = 0
+	if opts.Deferral.Allowed {
+		// Resume a count from a previous process lifetime, but only for THIS
+		// campaign (same deadline). Best-effort: a missing ledger means zero,
+		// which costs at most one extra postponement and can never push past
+		// the deadline.
+		r.deferralsUsed = LoadDeferralLedger(r.ledgerPath(), deadline, now)
+	}
+
 	r.state = RebootState{
 		PendingReboot:        true,
 		RebootScheduled:      true,
@@ -175,6 +229,10 @@ func (r *RebootManager) Schedule(delay time.Duration, deadline time.Time, reason
 		Reason:               reason,
 		Source:               source,
 		NotificationsPlanned: len(plan.Notifications),
+		DeferralAllowed:      opts.Deferral.Allowed,
+		DeferralsUsed:        r.deferralsUsed,
+		MaxDeferrals:         opts.Deferral.MaxDeferrals,
+		DeferralMinutes:      opts.Deferral.DeferralMinutes,
 		// LastError intentionally omitted: a fresh schedule clears any previous
 		// failure, so the field describes only the most recent attempt.
 	}
@@ -200,9 +258,85 @@ func (r *RebootManager) Schedule(delay time.Duration, deadline time.Time, reason
 		"osInvokeAt", plan.OSInvokeAt.String(),
 		"osGrace", plan.OSGrace.String(),
 		"reason", reason,
-		"source", source)
+		"source", source,
+		"deferralAllowed", opts.Deferral.Allowed,
+		"deferralsUsed", r.deferralsUsed,
+		"maxDeferrals", opts.Deferral.MaxDeferrals)
 
 	return nil
+}
+
+// Defer postpones the scheduled reboot by the policy's deferral window, clamped
+// to the hard deadline. Returns the new delay, or an error whose message is
+// intended to be shown to the user.
+//
+// Refused once osInvoked is true: past OSInvokeAt the countdown lives in the OS
+// and abortOSReboot cannot be honoured on every platform (macOS BSD shutdown(8)
+// has no cancel flag), so granting a deferral there would report success while
+// the machine still went down — the same class of lie Cancel() documents.
+func (r *RebootManager) Defer() (time.Duration, error) {
+	// Whole-call serialisation; see deferMu. Held across the re-entrant
+	// ScheduleWithOptions call, which takes only mu.
+	r.deferMu.Lock()
+	defer r.deferMu.Unlock()
+
+	r.mu.Lock()
+	if r.stopped {
+		r.mu.Unlock()
+		return 0, fmt.Errorf("reboot manager is stopped")
+	}
+	if r.osInvoked {
+		r.mu.Unlock()
+		return 0, fmt.Errorf("the restart countdown has already started and cannot be postponed")
+	}
+	if !r.state.RebootScheduled {
+		r.mu.Unlock()
+		return 0, fmt.Errorf("no reboot scheduled")
+	}
+	outcome := ComputeDeferral(r.deferral, r.deferralsUsed, r.nowFn(), r.state.Deadline)
+	if !outcome.Granted {
+		r.mu.Unlock()
+		return 0, fmt.Errorf("%s", outcome.Reason)
+	}
+	deadline, reason, source := r.state.Deadline, r.state.Reason, r.state.Source
+	used := r.deferralsUsed + 1
+	policy := r.deferral
+	r.mu.Unlock()
+
+	// Re-Schedule under the same options; it cancels the in-flight timers,
+	// bumps the generation and emits a fresh lead notification quoting the new
+	// time — which is exactly how the user learns the countdown moved.
+	if err := r.ScheduleWithOptions(outcome.NewDelay, deadline, reason, source, RebootOptions{Deferral: policy}); err != nil {
+		return 0, err
+	}
+
+	// ScheduleWithOptions reset the count from the ledger, so the increment is
+	// re-applied here, after it. Ordering matters — do not fold this into the
+	// re-schedule; TestDeferRefusesPastTheBudget pins it.
+	r.mu.Lock()
+	r.deferralsUsed = used
+	r.state.DeferralsUsed = used
+	path := r.ledgerPath()
+	r.mu.Unlock()
+
+	if err := SaveDeferralLedger(path, deadline, used); err != nil {
+		// Best-effort: losing the ledger costs the user an extra postponement
+		// after an agent restart, it never lets them exceed the DEADLINE.
+		log.Warn("failed to persist reboot deferral ledger", "error", err)
+	}
+	log.Info("reboot postponed by user",
+		"newDelay", outcome.NewDelay.String(), "used", used, "max", policy.MaxDeferrals)
+	return outcome.NewDelay, nil
+}
+
+// ledgerPath resolves the deferral ledger location through the test seam,
+// falling back to the real data dir. Nil-safe because RebootManager is also
+// built as a struct literal in tests.
+func (r *RebootManager) ledgerPath() string {
+	if r.deferralLedger != nil {
+		return r.deferralLedger()
+	}
+	return deferralLedgerPath()
 }
 
 // Cancel cancels a scheduled reboot.
@@ -225,6 +359,15 @@ func (r *RebootManager) Cancel() error {
 	r.state.ScheduledAt = time.Time{}
 	r.state.Deadline = time.Time{}
 	r.state.NotificationsPlanned = 0
+	// A cancelled reboot has no budget left to spend, and no deadline to clamp
+	// one against. Clearing both the reported and the internal copy keeps the
+	// two from disagreeing if a prompt answer arrives after the cancellation.
+	r.deferral = DeferralPolicy{}
+	r.deferralsUsed = 0
+	r.state.DeferralAllowed = false
+	r.state.DeferralsUsed = 0
+	r.state.MaxDeferrals = 0
+	r.state.DeferralMinutes = 0
 	abort := r.abortOSReboot
 	osInvoked := r.osInvoked
 	r.osInvoked = false

--- a/agent/internal/patching/reboot_manager.go
+++ b/agent/internal/patching/reboot_manager.go
@@ -78,15 +78,11 @@ type NotifyFunc func(title, body, urgency string)
 
 // RebootManager handles reboot scheduling, notification, and execution.
 type RebootManager struct {
-	mu sync.Mutex
-	// deferMu serialises whole Defer calls, including the ledger write that
-	// happens after mu is released — without it two concurrent postponements can
-	// write their counts to disk in the wrong order, leaving a lower count
-	// persisted than was actually granted. W3 fans the prompt out to every helper
-	// session and takes the first answer, so simultaneous requests are the
-	// expected shape, not a hypothetical. Always acquired BEFORE mu; never held
-	// by anything else, so it cannot invert.
-	deferMu          sync.Mutex
+	// mu guards everything below it. Defer holds it for its whole
+	// decide-reschedule-persist sequence — W3 fans the prompt out to every
+	// helper session and takes the first answer, so simultaneous postponement
+	// requests are the expected shape, not a hypothetical.
+	mu               sync.Mutex
 	state            RebootState
 	notifyTimers     []*time.Timer
 	osTimer          *time.Timer
@@ -183,6 +179,16 @@ func (r *RebootManager) ScheduleWithOptions(delay time.Duration, deadline time.T
 // that Defer can run its checks and its re-schedule as ONE atomic step. Callers
 // must hold r.mu.
 func (r *RebootManager) scheduleLocked(delay time.Duration, deadline time.Time, reason, source string, opts RebootOptions) error {
+	return r.scheduleLockedAt(r.nowFn(), delay, deadline, reason, source, opts)
+}
+
+// scheduleLockedAt takes the instant the delay is measured from, so a caller
+// that has already sampled the clock uses that ONE sample. Defer needs this:
+// re-sampling here would place the reboot at (second sample + a delay computed
+// against the first), which lands just past the deadline whenever the deferral
+// was clamped to it — and arbitrarily past it if the wall clock steps. Callers
+// must hold r.mu.
+func (r *RebootManager) scheduleLockedAt(now time.Time, delay time.Duration, deadline time.Time, reason, source string, opts RebootOptions) error {
 	if r.stopped {
 		return fmt.Errorf("reboot manager is stopped")
 	}
@@ -213,7 +219,6 @@ func (r *RebootManager) scheduleLocked(delay time.Duration, deadline time.Time, 
 	gen := r.generation
 
 	plan := PlanReboot(delay)
-	now := r.nowFn()
 
 	// Reset the budget from the incoming policy on every schedule. A schedule
 	// that says nothing about deferral is not deferrable, whatever the previous
@@ -282,36 +287,41 @@ func (r *RebootManager) scheduleLocked(delay time.Duration, deadline time.Time, 
 // has no cancel flag), so granting a deferral there would report success while
 // the machine still went down — the same class of lie Cancel() documents.
 func (r *RebootManager) Defer() (time.Duration, error) {
-	// deferMu covers the whole call INCLUDING the ledger write, so two
-	// postponements can never write their counts to disk out of order. mu covers
-	// the state mutation.
-	r.deferMu.Lock()
-	defer r.deferMu.Unlock()
-
-	// One atomic section: check, re-schedule, and record the increment without
-	// ever releasing mu. Splitting it — checking, unlocking, then re-entering
-	// ScheduleWithOptions — leaves a window in which a concurrent Cancel()
-	// succeeds and the re-schedule then RESURRECTS the reboot the operator just
-	// cancelled. That is not hypothetical: a technician cancelling from the
-	// console while the signed-in user answers the prompt is exactly the shape
-	// W3 creates, and widening the window by a millisecond reproduces it on the
-	// first iteration (TestDeferNeverResurrectsACancelledReboot).
+	// ONE atomic section: check, re-schedule, record the increment and persist
+	// it, without ever releasing mu. Every split version of this has a hole:
+	//
+	//   - Unlocking before re-entering ScheduleWithOptions lets a concurrent
+	//     Cancel() succeed inside the gap, after which the re-schedule
+	//     RESURRECTS the reboot the operator just cancelled. Not hypothetical —
+	//     a technician cancelling from the console while the signed-in user
+	//     answers the prompt is exactly the shape W3 creates, and widening the
+	//     window by a millisecond reproduces it on the first iteration
+	//     (TestDeferNeverResurrectsACancelledReboot).
+	//   - Unlocking before the ledger write lets a concurrent schedule for the
+	//     same campaign reload the stale on-disk count and hand back a
+	//     postponement that was already spent.
+	//
+	// The cost is a small file write under the lock, which briefly blocks
+	// State() and the timer callbacks. That is the right trade: the write is a
+	// few syscalls, and the alternative is a budget the user can exceed.
 	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	if r.stopped {
-		r.mu.Unlock()
 		return 0, fmt.Errorf("reboot manager is stopped")
 	}
 	if r.osInvoked {
-		r.mu.Unlock()
 		return 0, fmt.Errorf("the restart countdown has already started and cannot be postponed")
 	}
 	if !r.state.RebootScheduled {
-		r.mu.Unlock()
 		return 0, fmt.Errorf("no reboot scheduled")
 	}
-	outcome := ComputeDeferral(r.deferral, r.deferralsUsed, r.nowFn(), r.state.Deadline)
+
+	// One clock sample for both the decision and the re-schedule; see
+	// scheduleLockedAt.
+	now := r.nowFn()
+	outcome := ComputeDeferral(r.deferral, r.deferralsUsed, now, r.state.ScheduledAt, r.state.Deadline)
 	if !outcome.Granted {
-		r.mu.Unlock()
 		return 0, fmt.Errorf("%s", outcome.Reason)
 	}
 	deadline, reason, source := r.state.Deadline, r.state.Reason, r.state.Source
@@ -321,23 +331,22 @@ func (r *RebootManager) Defer() (time.Duration, error) {
 	// Re-schedule under the same options: it cancels the in-flight timers, bumps
 	// the generation and emits a fresh lead notification quoting the new time —
 	// which is exactly how the user learns the countdown moved.
-	if err := r.scheduleLocked(outcome.NewDelay, deadline, reason, source, RebootOptions{Deferral: policy}); err != nil {
-		r.mu.Unlock()
+	if err := r.scheduleLockedAt(now, outcome.NewDelay, deadline, reason, source, RebootOptions{Deferral: policy}); err != nil {
 		return 0, err
 	}
 
-	// scheduleLocked reset the count from the ledger, so the increment is
+	// scheduleLockedAt reset the count from the ledger, so the increment is
 	// re-applied after it. Ordering matters — do not fold this into the
 	// re-schedule; TestDeferRefusesPastTheBudget pins it.
 	r.deferralsUsed = used
 	r.state.DeferralsUsed = used
-	path := r.ledgerPath()
-	r.mu.Unlock()
 
+	path := r.ledgerPath()
 	if err := SaveDeferralLedger(path, deadline, used); err != nil {
 		// Best-effort: losing the ledger costs the user an extra postponement
 		// after an agent restart, it never lets them exceed the DEADLINE.
-		log.Warn("failed to persist reboot deferral ledger", "error", err)
+		log.Warn("failed to persist reboot deferral ledger",
+			"path", path, "deadline", deadline, "used", used, "error", err)
 	}
 	log.Info("reboot postponed by user",
 		"newDelay", outcome.NewDelay.String(), "used", used, "max", policy.MaxDeferrals)

--- a/agent/internal/patching/reboot_manager.go
+++ b/agent/internal/patching/reboot_manager.go
@@ -79,12 +79,13 @@ type NotifyFunc func(title, body, urgency string)
 // RebootManager handles reboot scheduling, notification, and execution.
 type RebootManager struct {
 	mu sync.Mutex
-	// deferMu serialises whole Defer calls. mu alone is not enough: Defer has to
-	// release mu to re-enter ScheduleWithOptions, and two callers interleaving in
-	// that window would both read the same pre-increment count and both be
-	// granted. W3 fans the prompt out to every helper session and takes the first
-	// answer, so simultaneous requests are the expected shape, not a hypothetical.
-	// Always acquired BEFORE mu; never held by anything else.
+	// deferMu serialises whole Defer calls, including the ledger write that
+	// happens after mu is released — without it two concurrent postponements can
+	// write their counts to disk in the wrong order, leaving a lower count
+	// persisted than was actually granted. W3 fans the prompt out to every helper
+	// session and takes the first answer, so simultaneous requests are the
+	// expected shape, not a hypothetical. Always acquired BEFORE mu; never held
+	// by anything else, so it cannot invert.
 	deferMu          sync.Mutex
 	state            RebootState
 	notifyTimers     []*time.Timer
@@ -175,7 +176,13 @@ func (r *RebootManager) Schedule(delay time.Duration, deadline time.Time, reason
 func (r *RebootManager) ScheduleWithOptions(delay time.Duration, deadline time.Time, reason, source string, opts RebootOptions) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	return r.scheduleLocked(delay, deadline, reason, source, opts)
+}
 
+// scheduleLocked is the whole of ScheduleWithOptions with r.mu already held, so
+// that Defer can run its checks and its re-schedule as ONE atomic step. Callers
+// must hold r.mu.
+func (r *RebootManager) scheduleLocked(delay time.Duration, deadline time.Time, reason, source string, opts RebootOptions) error {
 	if r.stopped {
 		return fmt.Errorf("reboot manager is stopped")
 	}
@@ -275,11 +282,20 @@ func (r *RebootManager) ScheduleWithOptions(delay time.Duration, deadline time.T
 // has no cancel flag), so granting a deferral there would report success while
 // the machine still went down — the same class of lie Cancel() documents.
 func (r *RebootManager) Defer() (time.Duration, error) {
-	// Whole-call serialisation; see deferMu. Held across the re-entrant
-	// ScheduleWithOptions call, which takes only mu.
+	// deferMu covers the whole call INCLUDING the ledger write, so two
+	// postponements can never write their counts to disk out of order. mu covers
+	// the state mutation.
 	r.deferMu.Lock()
 	defer r.deferMu.Unlock()
 
+	// One atomic section: check, re-schedule, and record the increment without
+	// ever releasing mu. Splitting it — checking, unlocking, then re-entering
+	// ScheduleWithOptions — leaves a window in which a concurrent Cancel()
+	// succeeds and the re-schedule then RESURRECTS the reboot the operator just
+	// cancelled. That is not hypothetical: a technician cancelling from the
+	// console while the signed-in user answers the prompt is exactly the shape
+	// W3 creates, and widening the window by a millisecond reproduces it on the
+	// first iteration (TestDeferNeverResurrectsACancelledReboot).
 	r.mu.Lock()
 	if r.stopped {
 		r.mu.Unlock()
@@ -301,19 +317,18 @@ func (r *RebootManager) Defer() (time.Duration, error) {
 	deadline, reason, source := r.state.Deadline, r.state.Reason, r.state.Source
 	used := r.deferralsUsed + 1
 	policy := r.deferral
-	r.mu.Unlock()
 
-	// Re-Schedule under the same options; it cancels the in-flight timers,
-	// bumps the generation and emits a fresh lead notification quoting the new
-	// time — which is exactly how the user learns the countdown moved.
-	if err := r.ScheduleWithOptions(outcome.NewDelay, deadline, reason, source, RebootOptions{Deferral: policy}); err != nil {
+	// Re-schedule under the same options: it cancels the in-flight timers, bumps
+	// the generation and emits a fresh lead notification quoting the new time —
+	// which is exactly how the user learns the countdown moved.
+	if err := r.scheduleLocked(outcome.NewDelay, deadline, reason, source, RebootOptions{Deferral: policy}); err != nil {
+		r.mu.Unlock()
 		return 0, err
 	}
 
-	// ScheduleWithOptions reset the count from the ledger, so the increment is
-	// re-applied here, after it. Ordering matters — do not fold this into the
+	// scheduleLocked reset the count from the ledger, so the increment is
+	// re-applied after it. Ordering matters — do not fold this into the
 	// re-schedule; TestDeferRefusesPastTheBudget pins it.
-	r.mu.Lock()
 	r.deferralsUsed = used
 	r.state.DeferralsUsed = used
 	path := r.ledgerPath()

--- a/agent/internal/patching/reboot_manager_deferral_test.go
+++ b/agent/internal/patching/reboot_manager_deferral_test.go
@@ -358,3 +358,44 @@ func TestConcurrentDefersRespectTheBudget(t *testing.T) {
 		t.Errorf("DeferralsUsed = %d, want 2", got)
 	}
 }
+
+// A postponement must never resurrect a reboot an operator has cancelled.
+// Cancel and Defer race whenever a technician cancels from the console while
+// the signed-in user is answering the prompt, and Defer re-schedules — so if
+// Defer's checks and its re-schedule are not one atomic step, the cancelled
+// reboot comes back with a fresh countdown.
+//
+// The invariant is decidable regardless of which goroutine wins: Cancel here
+// always has something to cancel, so it always succeeds, and a successful
+// Cancel must leave nothing scheduled. Either Defer finished first (and Cancel
+// then cancelled the deferred schedule) or Cancel finished first (and Defer
+// must refuse).
+func TestDeferNeverResurrectsACancelledReboot(t *testing.T) {
+	for i := 0; i < 300; i++ {
+		rm, timers, _, _, clock, _ := newDeferralTestManager(t, 3)
+		if err := rm.ScheduleWithOptions(15*time.Minute, clock.now().Add(6*time.Hour), "Patch", "patch_job", allowDeferral(5, 60)); err != nil {
+			t.Fatalf("iteration %d: ScheduleWithOptions: %v", i, err)
+		}
+		timers.runAt(0)
+
+		var wg sync.WaitGroup
+		var cancelErr error
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			cancelErr = rm.Cancel()
+		}()
+		go func() {
+			defer wg.Done()
+			_, _ = rm.Defer()
+		}()
+		wg.Wait()
+
+		if cancelErr != nil {
+			t.Fatalf("iteration %d: Cancel: %v", i, cancelErr)
+		}
+		if st := rm.State(); st.RebootScheduled {
+			t.Fatalf("iteration %d: a cancelled reboot was resurrected by a concurrent Defer: %+v", i, st)
+		}
+	}
+}

--- a/agent/internal/patching/reboot_manager_deferral_test.go
+++ b/agent/internal/patching/reboot_manager_deferral_test.go
@@ -1,0 +1,360 @@
+// Deferral behaviour at the manager level (issue #3207).
+//
+// Kept in its own file so reboot_manager_test.go — the #3197 invariant suite —
+// stays byte-for-byte unmodified: "with deferral disabled nothing changes" is
+// only a real claim if those tests never had to be adjusted.
+package patching
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeClock makes the deadline arithmetic exact instead of "within a few
+// microseconds of time.Now()".
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func (c *fakeClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(d)
+}
+
+// newDeferralTestManager wraps newTestManager with the two extra seams deferral
+// needs: a temp-dir ledger path and a controllable clock.
+func newDeferralTestManager(t *testing.T, maxPerDay int) (*RebootManager, *fakeTimers, *[]notifyCall, *[]time.Duration, *fakeClock, string) {
+	t.Helper()
+	rm, timers, notifications, osCalls := newTestManager(t, maxPerDay)
+	dir := t.TempDir()
+	ledger := filepath.Join(dir, "reboot_deferrals.json")
+	clock := &fakeClock{t: time.Now().Truncate(time.Second)}
+	rm.nowFn = clock.now
+	rm.deferralLedger = func() string { return ledger }
+	return rm, timers, notifications, osCalls, clock, ledger
+}
+
+func allowDeferral(max, minutes int) RebootOptions {
+	return RebootOptions{Deferral: DeferralPolicy{Allowed: true, MaxDeferrals: max, DeferralMinutes: minutes}}
+}
+
+func TestScheduleKeepsDeferralOffByDefault(t *testing.T) {
+	rm, _, _, _, clock, ledger := newDeferralTestManager(t, 3)
+
+	if err := rm.Schedule(15*time.Minute, clock.now().Add(15*time.Minute), "Patch", "patch_job"); err != nil {
+		t.Fatalf("Schedule: %v", err)
+	}
+	st := rm.State()
+	if st.DeferralAllowed {
+		t.Fatal("plain Schedule must not enable deferral — old call sites keep today's behaviour")
+	}
+	if st.MaxDeferrals != 0 || st.DeferralMinutes != 0 || st.DeferralsUsed != 0 {
+		t.Errorf("deferral fields = %+v, want all zero", st)
+	}
+	if _, err := rm.Defer(); err == nil {
+		t.Fatal("Defer must refuse when the policy did not enable it")
+	}
+	// Nothing may be written to disk for a schedule that cannot be deferred.
+	if got := LoadDeferralLedger(ledger, clock.now().Add(15*time.Minute), clock.now()); got != 0 {
+		t.Errorf("ledger read back %d, want 0 — deferral-off must not touch the ledger", got)
+	}
+}
+
+// The deferral fields must reach the console through get_reboot_status, which
+// marshals RebootState wholesale (rebootStateToMap) with no handler change.
+func TestRebootStateSerialisesTheDeferralBudget(t *testing.T) {
+	rm, _, _, _, clock, _ := newDeferralTestManager(t, 3)
+	if err := rm.ScheduleWithOptions(15*time.Minute, clock.now().Add(3*time.Hour), "Patch", "patch_job", allowDeferral(2, 60)); err != nil {
+		t.Fatalf("ScheduleWithOptions: %v", err)
+	}
+
+	data, err := json.Marshal(rm.State())
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for key, want := range map[string]any{
+		"deferralAllowed": true,
+		"deferralsUsed":   float64(0),
+		"maxDeferrals":    float64(2),
+		"deferralMinutes": float64(60),
+	} {
+		if got[key] != want {
+			t.Errorf("%s = %v, want %v", key, got[key], want)
+		}
+	}
+}
+
+func TestDeferReschedulesAndReNotifies(t *testing.T) {
+	rm, timers, notifications, osCalls, clock, _ := newDeferralTestManager(t, 3)
+	deadline := clock.now().Add(3 * time.Hour)
+	if err := rm.ScheduleWithOptions(15*time.Minute, deadline, "Patch", "patch_job", allowDeferral(2, 60)); err != nil {
+		t.Fatalf("ScheduleWithOptions: %v", err)
+	}
+	timers.runAt(0)
+	before := len(*notifications)
+
+	newDelay, err := rm.Defer()
+	if err != nil {
+		t.Fatalf("Defer: %v", err)
+	}
+	if newDelay != 60*time.Minute {
+		t.Errorf("newDelay = %v, want 60m", newDelay)
+	}
+	st := rm.State()
+	if st.DeferralsUsed != 1 {
+		t.Errorf("DeferralsUsed = %d, want 1", st.DeferralsUsed)
+	}
+	if !st.RebootScheduled {
+		t.Error("RebootScheduled = false after a deferral — the reboot must still be coming")
+	}
+	if !st.Deadline.Equal(deadline) {
+		t.Errorf("Deadline = %v, want it unchanged at %v — a deferral may not move the hard stop", st.Deadline, deadline)
+	}
+	if want := clock.now().Add(60 * time.Minute); !st.ScheduledAt.Equal(want) {
+		t.Errorf("ScheduledAt = %v, want %v", st.ScheduledAt, want)
+	}
+	// The re-schedule must emit its own lead notification (#3197 invariant:
+	// the user is told, at offset 0, every time the countdown changes).
+	timers.runAt(0)
+	if len(*notifications) <= before {
+		t.Error("deferral did not re-announce the new restart time")
+	}
+	if len(*osCalls) != 0 {
+		t.Fatal("deferral must not invoke the OS reboot")
+	}
+}
+
+func TestDeferRefusesPastTheBudget(t *testing.T) {
+	rm, timers, _, _, clock, _ := newDeferralTestManager(t, 3)
+	if err := rm.ScheduleWithOptions(15*time.Minute, clock.now().Add(3*time.Hour), "Patch", "patch_job", allowDeferral(1, 60)); err != nil {
+		t.Fatalf("ScheduleWithOptions: %v", err)
+	}
+	timers.runAt(0)
+	if _, err := rm.Defer(); err != nil {
+		t.Fatalf("first Defer: %v", err)
+	}
+	if _, err := rm.Defer(); err == nil {
+		t.Fatal("second Defer must be refused at MaxDeferrals=1")
+	}
+	if got := rm.State().DeferralsUsed; got != 1 {
+		t.Errorf("DeferralsUsed = %d after a refused deferral, want 1", got)
+	}
+}
+
+// D5 / #3253: the deadline, not the counter, is the guarantee. A 60-minute
+// window with 20 minutes of headroom yields 20, and the next request is refused
+// because the clamp would leave less than MinRebootDelay.
+func TestDeferClampsToTheHardDeadline(t *testing.T) {
+	rm, timers, _, _, clock, _ := newDeferralTestManager(t, 3)
+	deadline := clock.now().Add(20 * time.Minute)
+	if err := rm.ScheduleWithOptions(5*time.Minute, deadline, "Patch", "patch_job", allowDeferral(5, 60)); err != nil {
+		t.Fatalf("ScheduleWithOptions: %v", err)
+	}
+	timers.runAt(0)
+
+	newDelay, err := rm.Defer()
+	if err != nil {
+		t.Fatalf("Defer: %v", err)
+	}
+	if newDelay != 20*time.Minute {
+		t.Fatalf("newDelay = %v, want 20m clamped to the deadline", newDelay)
+	}
+	if landing := rm.State().ScheduledAt; landing.After(deadline) {
+		t.Errorf("ScheduledAt %v is past the deadline %v", landing, deadline)
+	}
+
+	// Walk up to the deadline; the budget is nowhere near spent but there is no
+	// room left, so the counter must not be able to buy any.
+	clock.advance(20 * time.Minute)
+	if _, err := rm.Defer(); err == nil {
+		t.Fatal("Defer at the deadline must be refused even with postponements remaining")
+	}
+	if got := rm.State().DeferralsUsed; got != 1 {
+		t.Errorf("DeferralsUsed = %d, want 1 — a refused deferral must not spend budget", got)
+	}
+}
+
+func TestDeferDoesNotConsumeCircuitBreakerBudget(t *testing.T) {
+	// D6: rebootHistory is appended only inside runOSReboot. Deferring must
+	// leave the maxRebootsPerDay breaker completely untouched.
+	rm, timers, _, osCalls, clock, _ := newDeferralTestManager(t, 1)
+	if err := rm.ScheduleWithOptions(15*time.Minute, clock.now().Add(5*time.Hour), "Patch", "patch_job", allowDeferral(3, 60)); err != nil {
+		t.Fatalf("ScheduleWithOptions: %v", err)
+	}
+	timers.runAt(0)
+	for i := 0; i < 3; i++ {
+		if _, err := rm.Defer(); err != nil {
+			t.Fatalf("Defer %d: %v", i, err)
+		}
+	}
+	if got := len(rm.rebootHistory); got != 0 {
+		t.Fatalf("rebootHistory has %d entries after three deferrals, want 0", got)
+	}
+	// Budget exhausted; let the final schedule run to completion.
+	plan := PlanReboot(60 * time.Minute)
+	timers.runAt(plan.OSInvokeAt)
+	if len(*osCalls) != 1 {
+		t.Fatalf("osCalls = %d, want 1 — three deferrals must not have burned the breaker", len(*osCalls))
+	}
+}
+
+func TestDeferIsRefusedOnceTheOSCountdownHasStarted(t *testing.T) {
+	// After OSInvokeAt the countdown lives in the OS, not this process. Granting
+	// a deferral there would report success while the machine still went down.
+	rm, timers, _, _, clock, _ := newDeferralTestManager(t, 3)
+	if err := rm.ScheduleWithOptions(5*time.Minute, clock.now().Add(3*time.Hour), "Patch", "patch_job", allowDeferral(3, 60)); err != nil {
+		t.Fatalf("ScheduleWithOptions: %v", err)
+	}
+	plan := PlanReboot(5 * time.Minute)
+	timers.runAt(plan.OSInvokeAt)
+	if _, err := rm.Defer(); err == nil {
+		t.Fatal("Defer must be refused once the OS countdown is running")
+	}
+}
+
+func TestDeferIsRefusedWhenNothingIsScheduled(t *testing.T) {
+	rm, _, _, _, clock, _ := newDeferralTestManager(t, 3)
+	if _, err := rm.Defer(); err == nil {
+		t.Fatal("Defer with no schedule must be refused")
+	}
+
+	if err := rm.ScheduleWithOptions(15*time.Minute, clock.now().Add(3*time.Hour), "Patch", "patch_job", allowDeferral(2, 60)); err != nil {
+		t.Fatalf("ScheduleWithOptions: %v", err)
+	}
+	if err := rm.Cancel(); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	if _, err := rm.Defer(); err == nil {
+		t.Fatal("Defer after Cancel must be refused")
+	}
+
+	if err := rm.ScheduleWithOptions(15*time.Minute, clock.now().Add(3*time.Hour), "Patch", "patch_job", allowDeferral(2, 60)); err != nil {
+		t.Fatalf("re-ScheduleWithOptions: %v", err)
+	}
+	rm.Stop()
+	if _, err := rm.Defer(); err == nil {
+		t.Fatal("Defer after Stop must be refused")
+	}
+}
+
+// A later plain Schedule is a fresh administrator decision with no deferral
+// budget: the previous campaign's allowance must not survive it.
+func TestPlainRescheduleClearsTheDeferralBudget(t *testing.T) {
+	rm, timers, _, _, clock, _ := newDeferralTestManager(t, 3)
+	if err := rm.ScheduleWithOptions(15*time.Minute, clock.now().Add(3*time.Hour), "Patch", "patch_job", allowDeferral(2, 60)); err != nil {
+		t.Fatalf("ScheduleWithOptions: %v", err)
+	}
+	timers.runAt(0)
+	if _, err := rm.Defer(); err != nil {
+		t.Fatalf("Defer: %v", err)
+	}
+
+	if err := rm.Schedule(30*time.Minute, clock.now().Add(3*time.Hour), "Second", "manual"); err != nil {
+		t.Fatalf("Schedule: %v", err)
+	}
+	st := rm.State()
+	if st.DeferralAllowed || st.MaxDeferrals != 0 || st.DeferralsUsed != 0 {
+		t.Fatalf("deferral state after a plain re-Schedule = %+v, want cleared", st)
+	}
+	if _, err := rm.Defer(); err == nil {
+		t.Fatal("Defer must be refused after a plain re-Schedule")
+	}
+}
+
+// The count has to survive an agent restart, or a user could reboot the service
+// and postpone forever. Same campaign (same deadline) resumes; a new deadline
+// is a new administrator decision and legitimately starts fresh.
+func TestScheduleResumesTheLedgerForTheSameCampaign(t *testing.T) {
+	rm, timers, _, _, clock, ledgerPath := newDeferralTestManager(t, 3)
+	deadline := clock.now().Add(4 * time.Hour)
+	if err := rm.ScheduleWithOptions(15*time.Minute, deadline, "Patch", "patch_job", allowDeferral(3, 60)); err != nil {
+		t.Fatalf("ScheduleWithOptions: %v", err)
+	}
+	timers.runAt(0)
+	for i := 0; i < 2; i++ {
+		if _, err := rm.Defer(); err != nil {
+			t.Fatalf("Defer %d: %v", i, err)
+		}
+	}
+	if got := LoadDeferralLedger(ledgerPath, deadline, clock.now()); got != 2 {
+		t.Fatalf("ledger on disk = %d, want 2", got)
+	}
+
+	// A fresh manager over the same ledger: same campaign resumes the count.
+	restarted, _, _, _ := newTestManager(t, 3)
+	restarted.nowFn = clock.now
+	restarted.deferralLedger = func() string { return ledgerPath }
+	if err := restarted.ScheduleWithOptions(15*time.Minute, deadline, "Patch", "patch_job", allowDeferral(3, 60)); err != nil {
+		t.Fatalf("restarted ScheduleWithOptions: %v", err)
+	}
+	if got := restarted.State().DeferralsUsed; got != 2 {
+		t.Fatalf("resumed DeferralsUsed = %d, want 2 — restarting the agent must not refill the budget", got)
+	}
+	if _, err := restarted.Defer(); err != nil {
+		t.Fatalf("third Defer: %v", err)
+	}
+	if _, err := restarted.Defer(); err == nil {
+		t.Fatal("fourth Defer must be refused — the resumed count exhausted the budget")
+	}
+
+	// A different deadline is a different campaign: fresh budget.
+	other, _, _, _ := newTestManager(t, 3)
+	other.nowFn = clock.now
+	other.deferralLedger = func() string { return ledgerPath }
+	if err := other.ScheduleWithOptions(15*time.Minute, deadline.Add(time.Hour), "Patch", "patch_job", allowDeferral(3, 60)); err != nil {
+		t.Fatalf("other ScheduleWithOptions: %v", err)
+	}
+	if got := other.State().DeferralsUsed; got != 0 {
+		t.Errorf("new-campaign DeferralsUsed = %d, want 0", got)
+	}
+}
+
+// W3 fans the prompt out to every helper session and takes the first answer, so
+// two sessions can answer at once. Concurrent grants must never exceed the
+// budget.
+func TestConcurrentDefersRespectTheBudget(t *testing.T) {
+	rm, timers, _, _, clock, _ := newDeferralTestManager(t, 3)
+	if err := rm.ScheduleWithOptions(15*time.Minute, clock.now().Add(6*time.Hour), "Patch", "patch_job", allowDeferral(2, 60)); err != nil {
+		t.Fatalf("ScheduleWithOptions: %v", err)
+	}
+	timers.runAt(0)
+
+	const callers = 8
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	granted := 0
+	wg.Add(callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			defer wg.Done()
+			if _, err := rm.Defer(); err == nil {
+				mu.Lock()
+				granted++
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if granted != 2 {
+		t.Fatalf("%d concurrent Defer calls granted %d, want exactly 2 (MaxDeferrals)", callers, granted)
+	}
+	if got := rm.State().DeferralsUsed; got != 2 {
+		t.Errorf("DeferralsUsed = %d, want 2", got)
+	}
+}

--- a/agent/internal/patching/reboot_manager_deferral_test.go
+++ b/agent/internal/patching/reboot_manager_deferral_test.go
@@ -7,7 +7,9 @@ package patching
 
 import (
 	"encoding/json"
+	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -112,8 +114,10 @@ func TestDeferReschedulesAndReNotifies(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Defer: %v", err)
 	}
-	if newDelay != 60*time.Minute {
-		t.Errorf("newDelay = %v, want 60m", newDelay)
+	// The 60-minute window is added to the 15-minute schedule, not to now — a
+	// postponement pushes the restart out, it never pulls it in.
+	if newDelay != 75*time.Minute {
+		t.Errorf("newDelay = %v, want 75m (15m schedule + the 60m window)", newDelay)
 	}
 	st := rm.State()
 	if st.DeferralsUsed != 1 {
@@ -125,7 +129,7 @@ func TestDeferReschedulesAndReNotifies(t *testing.T) {
 	if !st.Deadline.Equal(deadline) {
 		t.Errorf("Deadline = %v, want it unchanged at %v — a deferral may not move the hard stop", st.Deadline, deadline)
 	}
-	if want := clock.now().Add(60 * time.Minute); !st.ScheduledAt.Equal(want) {
+	if want := clock.now().Add(75 * time.Minute); !st.ScheduledAt.Equal(want) {
 		t.Errorf("ScheduledAt = %v, want %v", st.ScheduledAt, want)
 	}
 	// The re-schedule must emit its own lead notification (#3197 invariant:
@@ -205,8 +209,9 @@ func TestDeferDoesNotConsumeCircuitBreakerBudget(t *testing.T) {
 	if got := len(rm.rebootHistory); got != 0 {
 		t.Fatalf("rebootHistory has %d entries after three deferrals, want 0", got)
 	}
-	// Budget exhausted; let the final schedule run to completion.
-	plan := PlanReboot(60 * time.Minute)
+	// Budget exhausted; let the final schedule run to completion. Each
+	// postponement adds its window to the schedule: 15 -> 75 -> 135 -> 195.
+	plan := PlanReboot(195 * time.Minute)
 	timers.runAt(plan.OSInvokeAt)
 	if len(*osCalls) != 1 {
 		t.Fatalf("osCalls = %d, want 1 — three deferrals must not have burned the breaker", len(*osCalls))
@@ -397,5 +402,145 @@ func TestDeferNeverResurrectsACancelledReboot(t *testing.T) {
 		if st := rm.State(); st.RebootScheduled {
 			t.Fatalf("iteration %d: a cancelled reboot was resurrected by a concurrent Defer: %+v", i, st)
 		}
+	}
+}
+
+// A postponement must never make the restart happen SOONER. With a policy
+// window shorter than the remaining countdown — a 2-hour reboot delay and a
+// 60-minute postponement, both well inside the configurable ranges — computing
+// the new delay from "now" rather than from the scheduled time pulls the
+// restart an hour forward. The user pressed Postpone and lost an hour.
+//
+// It also has to agree with the deadline the API derives
+// (scheduledAt + maxDeferrals * deferralMinutes, see patchRebootHandler.ts):
+// spending the whole budget must land exactly on the deadline, not short of it.
+func TestDeferNeverPullsTheRestartEarlier(t *testing.T) {
+	rm, timers, _, _, clock, _ := newDeferralTestManager(t, 3)
+	start := clock.now()
+	// Exactly what the API sends for a 120-minute delay with 2 x 60m deferrals.
+	deadline := start.Add(120*time.Minute + 2*60*time.Minute)
+	if err := rm.ScheduleWithOptions(120*time.Minute, deadline, "Patch", "patch_job", allowDeferral(2, 60)); err != nil {
+		t.Fatalf("ScheduleWithOptions: %v", err)
+	}
+	timers.runAt(0)
+	firstScheduledAt := rm.State().ScheduledAt
+
+	newDelay, err := rm.Defer()
+	if err != nil {
+		t.Fatalf("Defer: %v", err)
+	}
+	if newDelay != 180*time.Minute {
+		t.Errorf("newDelay = %v, want 180m (the scheduled 120m pushed out by the 60m window)", newDelay)
+	}
+	afterFirst := rm.State().ScheduledAt
+	if !afterFirst.After(firstScheduledAt) {
+		t.Fatalf("postponing moved the restart from %v to %v — a postponement must never pull it earlier",
+			firstScheduledAt, afterFirst)
+	}
+
+	// The second and last postponement must land exactly on the deadline.
+	if _, err := rm.Defer(); err != nil {
+		t.Fatalf("second Defer: %v", err)
+	}
+	afterSecond := rm.State().ScheduledAt
+	if !afterSecond.After(afterFirst) {
+		t.Errorf("second postponement moved the restart from %v to %v", afterFirst, afterSecond)
+	}
+	if !afterSecond.Equal(deadline) {
+		t.Errorf("after spending the whole budget ScheduledAt = %v, want the deadline %v", afterSecond, deadline)
+	}
+	if _, err := rm.Defer(); err == nil {
+		t.Error("a third Defer must be refused at MaxDeferrals=2")
+	}
+}
+
+// The on-disk count must never lag the in-memory one. If it can, the user gets
+// back a postponement they already spent the next time the agent restarts.
+// Measured before the ledger write was moved inside the lock: 141 of 300 trials
+// disagreed. It is now written in the same critical section as the increment,
+// so the two cannot diverge.
+func TestConcurrentDefersLeaveTheLedgerAgreeingWithMemory(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		rm, timers, _, _, clock, ledgerPath := newDeferralTestManager(t, 3)
+		deadline := clock.now().Add(12 * time.Hour)
+		if err := rm.ScheduleWithOptions(15*time.Minute, deadline, "Patch", "patch_job", allowDeferral(4, 60)); err != nil {
+			t.Fatalf("iteration %d: ScheduleWithOptions: %v", i, err)
+		}
+		timers.runAt(0)
+
+		var wg sync.WaitGroup
+		wg.Add(4)
+		for j := 0; j < 4; j++ {
+			go func() {
+				defer wg.Done()
+				_, _ = rm.Defer()
+			}()
+		}
+		wg.Wait()
+
+		inMemory := rm.State().DeferralsUsed
+		onDisk := LoadDeferralLedger(ledgerPath, deadline, clock.now())
+		if onDisk != inMemory {
+			t.Fatalf("iteration %d: ledger says %d postponements used, memory says %d — a restart would refill the budget",
+				i, onDisk, inMemory)
+		}
+	}
+}
+
+// The ledger is best-effort by contract: a write failure must be logged and
+// swallowed, never turned into a refused postponement. A mutation that
+// propagated the error would strand the user with an un-postponable restart
+// because of a permissions problem in the data dir.
+func TestDeferSucceedsWhenTheLedgerCannotBeWritten(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory mode bits do not gate writes the same way on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root, which ignores the directory mode that makes the write fail")
+	}
+	rm, timers, _, _, clock, _ := newDeferralTestManager(t, 3)
+	dir := t.TempDir()
+	readOnly := filepath.Join(dir, "locked")
+	if err := os.Mkdir(readOnly, 0o500); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	rm.deferralLedger = func() string { return filepath.Join(readOnly, "reboot_deferrals.json") }
+
+	if err := rm.ScheduleWithOptions(15*time.Minute, clock.now().Add(6*time.Hour), "Patch", "patch_job", allowDeferral(2, 60)); err != nil {
+		t.Fatalf("ScheduleWithOptions: %v", err)
+	}
+	timers.runAt(0)
+
+	newDelay, err := rm.Defer()
+	if err != nil {
+		t.Fatalf("Defer returned %v; an unwritable ledger must not refuse the postponement", err)
+	}
+	if newDelay != 75*time.Minute {
+		t.Errorf("newDelay = %v, want 75m", newDelay)
+	}
+	if got := rm.State().DeferralsUsed; got != 1 {
+		t.Errorf("DeferralsUsed = %d, want 1 — the in-memory count still holds for this process", got)
+	}
+}
+
+// Cancel clears the reported budget, not just the schedule. A console showing a
+// cancelled restart must not still advertise postponements against it.
+func TestCancelClearsTheReportedDeferralBudget(t *testing.T) {
+	rm, timers, _, _, clock, _ := newDeferralTestManager(t, 3)
+	if err := rm.ScheduleWithOptions(15*time.Minute, clock.now().Add(6*time.Hour), "Patch", "patch_job", allowDeferral(3, 60)); err != nil {
+		t.Fatalf("ScheduleWithOptions: %v", err)
+	}
+	timers.runAt(0)
+	if _, err := rm.Defer(); err != nil {
+		t.Fatalf("Defer: %v", err)
+	}
+	if err := rm.Cancel(); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+
+	st := rm.State()
+	if st.DeferralAllowed || st.MaxDeferrals != 0 || st.DeferralMinutes != 0 || st.DeferralsUsed != 0 {
+		t.Errorf("deferral fields after Cancel = allowed:%v used:%d max:%d window:%d, want all zero",
+			st.DeferralAllowed, st.DeferralsUsed, st.MaxDeferrals, st.DeferralMinutes)
 	}
 }


### PR DESCRIPTION
Closes #4662. Wave 2 of #3207 (end-user reboot prompts with deferral).

The agent's `RebootManager` gains a deferral state machine: it understands the
budget W1 started shipping on the `schedule_reboot` payload, can execute a
postponement, clamps every one against the hard deadline, and persists the count
across agent restarts. **Nobody can trigger a deferral yet** — the prompt is W3.
This wave exists so the state machine is provably inert when the policy is off
*before* any UI can drive it.

## What changed

| File | Why |
|---|---|
| `agent/internal/patching/reboot_deferral.go` *(new, untagged)* | `DeferralPolicy`, `ComputeDeferral` (pure clamp arithmetic), `DeferralLedger` persistence |
| `agent/internal/patching/reboot_manager.go` | `RebootOptions`, `ScheduleWithOptions`, `Defer()`, four deferral fields on `RebootState` |
| `agent/internal/heartbeat/handlers_patch.go` | parse `allowDeferral` / `maxDeferrals` / `deferralMinutes`; strict `deadline` parse |
| 3 new `_test.go` files | table-driven coverage of the clamp, the ledger, the manager and the payload |

### The deadline is the guarantee, the counter is an affordance

`RebootState.Deadline` has been stored and reported since #3421 but never
enforced (#3253). A postponement is now
`min(scheduledAt + deferralMinutes, deadline)`, and one that would leave less
than `MinRebootDelay` is refused outright — so a maintenance-window reboot
cannot be postponed past the close of its window no matter how much counter
budget is left.

**The window is added to the scheduled time, not to now.** Review caught this
independently twice: measured from `now`, a 120-minute reboot delay postponed by
a 60-minute window moved the restart an *hour earlier*, and every test in the
first draft masked it by using a window larger than the remaining countdown.
It is also the semantics the merged API already assumed — it derives the
deadline as `scheduledAt + maxDeferrals * deferralMinutes`, so spending the
whole budget lands exactly on the deadline rather than short of it.

A property test sweeps the deadline across an 8-hour range × six scheduled
times and asserts a granted postponement never lands past the deadline and
never lands earlier than the restart already scheduled.

### Backward compatibility, both directions

- **Old agent, new API** — the new keys ride a `map[string]any` payload and are
  ignored by construction. Pinned by `TestScheduleRebootIgnoresUnknownPayloadKeys`.
- **New agent, old API** — the keys are absent, `GetPayloadBool(..., false)`
  yields `false`, deferral is off, `deadline` falls back to `now + delay`:
  today's behaviour exactly. `allowDeferral` is the *only* switch, so a payload
  carrying a budget without the flag (stale or forged) also stays off.
- **`Schedule(...)` keeps its exact 4-arg signature and semantics** and delegates
  to `ScheduleWithOptions` with a zero `RebootOptions`. Every existing call site
  and every existing test keeps today's behaviour with **no edit** — the #3197
  invariant suites (`reboot_manager_test.go`, `reboot_plan_test.go`) are
  byte-for-byte unmodified on this branch, which is why the new manager tests
  live in their own file.

### Deferral does not touch the circuit breaker

`rebootHistory` is appended only inside `runOSReboot`, and deferring never
reaches it (D6). `TestDeferDoesNotConsumeCircuitBreakerBudget` runs three
deferrals against a `maxRebootsPerDay: 1` manager and asserts the history is
still empty and the eventual reboot still fires.

### Concurrency

`Defer()` holds `mu` from its first check through the ledger write. Splitting
that sequence — which the plan's shape does — opens two holes, both found and
then closed on this branch:

- **Releasing `mu` before re-entering `ScheduleWithOptions`** lets a concurrent
  `Cancel()` succeed in the gap, after which the re-schedule **resurrects the
  reboot the operator just cancelled** — the machine goes down after the console
  said it would not. Proven rather than argued: widening the gap with a
  one-millisecond sleep made `TestDeferNeverResurrectsACancelledReboot` fail on
  iteration 0 with `RebootScheduled: true` after a successful `Cancel`. The same
  probe moved inside the atomic section passes.
- **Writing the ledger outside `mu`** lets a concurrent schedule for the same
  campaign reload the stale on-disk count and hand back a postponement already
  spent. Measured at 141 disagreements in 300 trials;
  `TestConcurrentDefersLeaveTheLedgerAgreeingWithMemory` now pins it.

`TestConcurrentDefersRespectTheBudget` runs 8 goroutines against
`MaxDeferrals: 2` under `-race` and asserts exactly 2 grants.

### Refusals that matter

- After `OSInvokeAt` the countdown lives in the OS and macOS BSD `shutdown(8)`
  has no cancel flag, so `Defer()` is refused there rather than reporting a
  success the machine would contradict — the same class of lie `Cancel()`
  documents.
- After `Cancel()` or `Stop()`, and when nothing is scheduled.
- A later plain `Schedule` clears the budget: a fresh administrator decision
  carries no allowance from the previous campaign.

### Ledger

Persisted next to `reboot_history.json`, keyed by the deadline truncated to the
minute, so restarting the agent mid-countdown does not refill the budget. Sub-minute
jitter in the re-sent ISO timestamp is the same campaign; a different deadline is
a different administrator decision and legitimately starts fresh. Missing,
corrupt, expired or negative all mean **zero used** — best-effort, never an error
that blocks a reboot. Losing it costs the user one extra postponement; it can
never push past the deadline, which is enforced separately.

## Deviations from the plan

1. **`ComputeDeferral` takes the currently scheduled time** and adds the window
   to *it*, rather than the plan's `min(now + deferralMinutes, deadline)`. See
   above — the plan's arithmetic makes a postponement pull the restart earlier,
   and disagrees with the deadline W1 already ships.
2. **`Defer()` is one atomic `mu` section** covering the checks, the
   re-schedule, the increment *and* the ledger write (the plan released `mu`
   between the checks and the re-schedule, and wrote the ledger outside it). Two
   distinct bugs came out of that gap — see the concurrency section below. The
   cost is a small file write under the lock, which briefly blocks `State()` and
   the timer callbacks; that is the right trade against a budget the user can
   exceed.
3. **The ledger is written atomically** (temp file, `fsync`, `rename`, mode
   0600) rather than a plain `os.WriteFile`. A torn write reads back as
   corrupt — which means "zero used", quietly handing the user their whole
   budget again.
4. **`Cancel()` also clears the deferral budget** (plan was silent). Keeps the
   reported and internal copies from disagreeing if a prompt answer arrives
   after the cancellation.
5. **Manager tests live in `reboot_manager_deferral_test.go`**, not appended to
   `reboot_manager_test.go` — "with deferral disabled nothing changes" is only a
   real claim if the #3197 suite never had to be adjusted.
6. **The plan's sample heartbeat tests assert `res.Status == "success"`; the real
   constructor emits `"completed"`.** Tests use the actual value.
7. Payload range bounds are named constants mirroring
   `patchRebootHandler.ts`'s `MAX_REBOOT_DEFERRALS` / `MIN|MAX_REBOOT_DEFERRAL_MINUTES`
   rather than inline literals. Same values (1-10, 5-1440); deliberately
   duplicated, not derived, because the agent must reject a budget the API could
   not have produced whatever version sent it.
8. Extra coverage beyond the plan's list: ledger resume across process lifetimes,
   unknown-key tolerance, budget-without-flag, malformed `deadline`, `Cancel`/`Stop`
   refusals, and the `get_reboot_status` JSON surface.

Also hardens the `deadline` parse, which has swallowed malformed values since
#3421. That was cosmetic while nothing read `Deadline`; it now silently collapses
the deferral budget to nothing, so it fails the command instead.

## Test evidence

**verified** (all Go 1.26.6 = `GO_VERSION`, in a `golang:1.26.6` Linux container,
because this host has a pre-existing cgo crash — see below):

- `go test -race -count=1 ./internal/heartbeat/ ./internal/patching/` → **both ok**
  (heartbeat 29.7s, patching 1.8s), re-run after every review fix. 30 new test
  functions across the three new files.
- `CGO_ENABLED=0 go test -count=1 ./...` (the **test-agent** CI job's exact
  command) → green except `TestCollectHardwareOnly` (no CPU model in a container)
  and `TestConfigureRunAsElevatedWhenNotRoot` (runs as root, so no sudo path).
  **Both reproduce identically on the unmodified base checkout in the same
  container** — environment, not this change.
- `go vet ./...` → clean.
- `golangci-lint v2.12.2` (the CI pin) over `./internal/patching/... ./internal/heartbeat/...`
  → **0 issues in any of the six touched files**; the 48 remaining are the
  pre-existing backlog CI already excludes via `--new-from-rev`.
- `GOOS=windows|darwin|linux go build ./...` → all clean.
- Red-first: every test in this PR was run and observed failing (compile-undefined
  for the two new APIs; 10 assertion failures for the payload parsing) before the
  implementation landed.

**not-run:**

- Any macOS/Windows runtime behaviour — this wave adds no platform-specific code
  and every new file is untagged (`grep -L 'go:build'` returns all four).
- End-to-end deferral: there is no way to trigger one until W3 ships the prompt.
- `-race` on this dev host: `go-m1cpu`'s cgo `init` segfaults here on **both**
  Go 1.26.6 and 1.27 (reproduced on unmodified `main` with `-run XXXNoSuchTest`),
  so every race run above was done in the Linux container instead. CI's
  `test-agent-race` job runs on `macos-latest` and is unaffected.

Cross-refs #3253 without closing it — the deadline is now enforced for
deferrals; the broader "deadline should bound the schedule generally" question
stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Ua3dk5TZk7PXWkYR7NipG
