### PR TITLE
feat(devices): link Patches tab to the device's patch policy (#4671)

### DIFF
--- a/apps/web/src/components/devices/DevicePatchStatusTab.test.tsx
+++ b/apps/web/src/components/devices/DevicePatchStatusTab.test.tsx
@@ -770,6 +770,94 @@ describe('DevicePatchStatusTab', () => {
     expect(fetchWithAuthMock).toHaveBeenCalledWith(`/configuration-policies/effective/${deviceId}`);
   });
 
+  it('falls back to the policy id as the link label when sourcePolicyName is missing (#4671)', async () => {
+    fetchWithAuthMock.mockImplementation(async (url: string) => {
+      if (typeof url === 'string' && url.includes('/configuration-policies/effective/')) {
+        return makeJsonResponse({
+          deviceId,
+          features: {
+            patch: {
+              featureType: 'patch',
+              featurePolicyId: 'feature-policy-1',
+              inlineSettings: null,
+              sourceLevel: 'organization',
+              sourceTargetId: 'org-1',
+              sourcePolicyId: 'policy-xyz'
+              // sourcePolicyName intentionally omitted
+            }
+          },
+          inheritanceChain: []
+        });
+      }
+      return makeJsonResponse({
+        data: { compliancePercent: 90, pending: [], installed: [] }
+      });
+    });
+
+    render(<DevicePatchStatusTab deviceId={deviceId} osType="windows" />);
+
+    const policyLink = await screen.findByRole('link', { name: 'policy-xyz' });
+    expect(policyLink.getAttribute('href')).toBe('/configuration-policies/policy-xyz');
+  });
+
+  it('degrades to no policy link (without crashing) when the effective-config fetch fails (#4671)', async () => {
+    fetchWithAuthMock.mockImplementation(async (url: string) => {
+      if (typeof url === 'string' && url.includes('/configuration-policies/effective/')) {
+        throw new Error('network error');
+      }
+      return makeJsonResponse({
+        data: { compliancePercent: 90, pending: [], installed: [] }
+      });
+    });
+
+    render(<DevicePatchStatusTab deviceId={deviceId} osType="windows" />);
+
+    // The rest of the tab still renders normally.
+    await screen.findByRole('link', { name: /manage patches/i });
+    expect(screen.queryByText(/managed by policy/i)).toBeNull();
+  });
+
+  it('clears a previously-resolved policy link when the effective-config fetch returns a non-OK response (#4671)', async () => {
+    let effectiveCallCount = 0;
+    fetchWithAuthMock.mockImplementation(async (url: string) => {
+      if (typeof url === 'string' && url.includes('/configuration-policies/effective/')) {
+        effectiveCallCount += 1;
+        if (effectiveCallCount === 1) {
+          return makeJsonResponse({
+            deviceId,
+            features: {
+              patch: {
+                featureType: 'patch',
+                featurePolicyId: 'feature-policy-1',
+                inlineSettings: null,
+                sourceLevel: 'organization',
+                sourceTargetId: 'org-1',
+                sourcePolicyId: 'policy-abc',
+                sourcePolicyName: 'Standard Patch Ring'
+              }
+            },
+            inheritanceChain: []
+          });
+        }
+        return makeJsonResponse({ error: 'server error' }, false, 500);
+      }
+      return makeJsonResponse({
+        data: { compliancePercent: 90, pending: [], installed: [] }
+      });
+    });
+
+    const { rerender } = render(<DevicePatchStatusTab deviceId={deviceId} osType="windows" />);
+
+    await screen.findByRole('link', { name: 'Standard Patch Ring' });
+
+    // Re-render with a different device id to trigger a re-fetch that now 500s.
+    rerender(<DevicePatchStatusTab deviceId="22222222-2222-2222-2222-222222222222" osType="windows" />);
+
+    await waitFor(() => {
+      expect(screen.queryByText(/managed by policy/i)).toBeNull();
+    });
+  });
+
   it('does not show a policy link when no patch policy is assigned to the device (#4671)', async () => {
     fetchWithAuthMock.mockImplementation(async (url: string) => {
       if (typeof url === 'string' && url.includes('/configuration-policies/effective/')) {

--- a/apps/web/src/components/devices/DevicePatchStatusTab.test.tsx
+++ b/apps/web/src/components/devices/DevicePatchStatusTab.test.tsx
@@ -730,6 +730,70 @@ describe('DevicePatchStatusTab', () => {
     await screen.findByText(/pending approval/i);
   });
 
+  it('links to the fleet Patches page and the device\'s assigned patch policy (#4671)', async () => {
+    fetchWithAuthMock.mockImplementation(async (url: string) => {
+      if (typeof url === 'string' && url.includes('/configuration-policies/effective/')) {
+        return makeJsonResponse({
+          deviceId,
+          features: {
+            patch: {
+              featureType: 'patch',
+              featurePolicyId: 'feature-policy-1',
+              inlineSettings: null,
+              sourceLevel: 'organization',
+              sourceTargetId: 'org-1',
+              sourcePolicyId: 'policy-abc',
+              sourcePolicyName: 'Standard Patch Ring',
+              sourcePriority: 1
+            }
+          },
+          inheritanceChain: []
+        });
+      }
+      return makeJsonResponse({
+        data: {
+          compliancePercent: 90,
+          pending: [],
+          installed: []
+        }
+      });
+    });
+
+    render(<DevicePatchStatusTab deviceId={deviceId} osType="windows" />);
+
+    const manageLink = await screen.findByRole('link', { name: /manage patches/i });
+    expect(manageLink.getAttribute('href')).toBe('/patches');
+
+    const policyLink = await screen.findByRole('link', { name: 'Standard Patch Ring' });
+    expect(policyLink.getAttribute('href')).toBe('/configuration-policies/policy-abc');
+
+    expect(fetchWithAuthMock).toHaveBeenCalledWith(`/configuration-policies/effective/${deviceId}`);
+  });
+
+  it('does not show a policy link when no patch policy is assigned to the device (#4671)', async () => {
+    fetchWithAuthMock.mockImplementation(async (url: string) => {
+      if (typeof url === 'string' && url.includes('/configuration-policies/effective/')) {
+        return makeJsonResponse({
+          deviceId,
+          features: {},
+          inheritanceChain: []
+        });
+      }
+      return makeJsonResponse({
+        data: {
+          compliancePercent: 90,
+          pending: [],
+          installed: []
+        }
+      });
+    });
+
+    render(<DevicePatchStatusTab deviceId={deviceId} osType="windows" />);
+
+    await screen.findByRole('link', { name: /manage patches/i });
+    expect(screen.queryByText(/managed by policy/i)).toBeNull();
+  });
+
   it('renders "Installed (date unknown)" when an installed patch has null installedAt (#3589)', async () => {
     const patchData = {
       data: {

--- a/apps/web/src/components/devices/DevicePatchStatusTab.tsx
+++ b/apps/web/src/components/devices/DevicePatchStatusTab.tsx
@@ -715,11 +715,17 @@ export default function DevicePatchStatusTab({ deviceId, timezone, osType }: Dev
   // Resolve the device's effective patch policy so the tab can link straight
   // to it instead of making a tech search for it (#4671, split from #4280).
   // Best-effort: a failure here should not block the patch status view, so
-  // errors are swallowed and simply leave the link absent.
+  // the link is just left absent -- but any absent-vs-not-yet-loaded state is
+  // still reset (not left stale) and logged, matching the sibling
+  // fetchRecentLinuxInstalls pattern in this file.
   const fetchPatchPolicyLink = useCallback(async () => {
     try {
       const response = await fetchWithAuth(`/configuration-policies/effective/${deviceId}`);
-      if (!response.ok) return;
+      if (!response.ok) {
+        console.error(`[DevicePatchStatusTab] Failed to fetch effective patch policy: ${response.status} ${response.statusText}`);
+        setPatchPolicyLink(null);
+        return;
+      }
       const json: EffectiveConfigPatchResponse = await response.json();
       const patchFeature = json?.features?.patch;
       if (patchFeature && patchFeature.sourceLevel !== 'default' && patchFeature.sourcePolicyId) {
@@ -730,7 +736,8 @@ export default function DevicePatchStatusTab({ deviceId, timezone, osType }: Dev
       } else {
         setPatchPolicyLink(null);
       }
-    } catch {
+    } catch (err) {
+      console.error('[DevicePatchStatusTab] Failed to fetch patch policy link:', err);
       setPatchPolicyLink(null);
     }
   }, [deviceId]);

--- a/apps/web/src/components/devices/DevicePatchStatusTab.tsx
+++ b/apps/web/src/components/devices/DevicePatchStatusTab.tsx
@@ -108,6 +108,22 @@ type DevicePatchStatusTabProps = {
   osType?: OSType;
 };
 
+// Minimal shape of the resolved `patch` feature from
+// GET /configuration-policies/effective/:deviceId — only the fields this tab
+// needs to link to the device's assigned patch policy (#4671). See
+// DeviceEffectiveConfigTab.tsx for the full effective-configuration shape.
+type ResolvedPatchFeature = {
+  sourceLevel?: string;
+  sourcePolicyId?: string;
+  sourcePolicyName?: string;
+};
+
+type EffectiveConfigPatchResponse = {
+  features?: {
+    patch?: ResolvedPatchFeature;
+  };
+};
+
 const categoryBadges: Record<string, { label: string; className: string }> = {
   system: { label: 'System', className: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300' },
   security: { label: 'Security', className: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300' },
@@ -639,6 +655,11 @@ export default function DevicePatchStatusTab({ deviceId, timezone, osType }: Dev
   >(null);
   const [controlNotice, setControlNotice] = useState<{ kind: 'success' | 'error' | 'info'; message: string } | null>(null);
 
+  // The device's assigned patch policy (if any), for the "Managed by policy"
+  // deep link (#4671) — resolved separately from `/devices/:id/patches`
+  // because that endpoint carries no policy/job reference at all.
+  const [patchPolicyLink, setPatchPolicyLink] = useState<{ policyId: string; policyName: string } | null>(null);
+
   // Track per-patch install in progress: patchId -> true
   const [installingPatchIds, setInstallingPatchIds] = useState<Set<string>>(new Set());
 
@@ -690,6 +711,33 @@ export default function DevicePatchStatusTab({ deviceId, timezone, osType }: Dev
   useEffect(() => {
     fetchPatchStatus();
   }, [fetchPatchStatus]);
+
+  // Resolve the device's effective patch policy so the tab can link straight
+  // to it instead of making a tech search for it (#4671, split from #4280).
+  // Best-effort: a failure here should not block the patch status view, so
+  // errors are swallowed and simply leave the link absent.
+  const fetchPatchPolicyLink = useCallback(async () => {
+    try {
+      const response = await fetchWithAuth(`/configuration-policies/effective/${deviceId}`);
+      if (!response.ok) return;
+      const json: EffectiveConfigPatchResponse = await response.json();
+      const patchFeature = json?.features?.patch;
+      if (patchFeature && patchFeature.sourceLevel !== 'default' && patchFeature.sourcePolicyId) {
+        setPatchPolicyLink({
+          policyId: patchFeature.sourcePolicyId,
+          policyName: patchFeature.sourcePolicyName ?? patchFeature.sourcePolicyId
+        });
+      } else {
+        setPatchPolicyLink(null);
+      }
+    } catch {
+      setPatchPolicyLink(null);
+    }
+  }, [deviceId]);
+
+  useEffect(() => {
+    fetchPatchPolicyLink();
+  }, [fetchPatchPolicyLink]);
 
   const fetchRecentLinuxInstalls = useCallback(async (clear = false) => {
     if (normalizedOsType !== 'linux') {
@@ -1069,16 +1117,36 @@ export default function DevicePatchStatusTab({ deviceId, timezone, osType }: Dev
                 {t('devicePatchStatusTab.perUserNotScanned')}
               </p>
             )}
+            {patchPolicyLink && (
+              <p className="mt-1 text-xs text-muted-foreground">
+                {t('devicePatchStatusTab.controls.managedByPolicy')}{' '}
+                <a
+                  href={`/configuration-policies/${patchPolicyLink.policyId}`}
+                  className="font-medium text-primary hover:underline"
+                >
+                  {patchPolicyLink.policyName}
+                </a>
+              </p>
+            )}
           </div>
-          <button
-            type="button"
-            onClick={() => refreshPatchView()}
-            disabled={isBusy}
-            className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            <RefreshCw className={`h-3.5 w-3.5 ${isPolling ? 'animate-spin' : ''}`} />
-            {isPolling ? t('devicePatchStatusTab.controls.polling') : t('devicePatchStatusTab.controls.refreshPatchData')}
-          </button>
+          <div className="flex flex-col items-end gap-2">
+            <button
+              type="button"
+              onClick={() => refreshPatchView()}
+              disabled={isBusy}
+              className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <RefreshCw className={`h-3.5 w-3.5 ${isPolling ? 'animate-spin' : ''}`} />
+              {isPolling ? t('devicePatchStatusTab.controls.polling') : t('devicePatchStatusTab.controls.refreshPatchData')}
+            </button>
+            <a
+              href="/patches"
+              className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
+            >
+              {t('devicePatchStatusTab.controls.managePatches')}
+              <ExternalLink className="h-3 w-3" />
+            </a>
+          </div>
         </div>
 
         <div className="mt-4 grid gap-2 sm:grid-cols-2">

--- a/apps/web/src/locales/de-DE/devices.json
+++ b/apps/web/src/locales/de-DE/devices.json
@@ -1227,6 +1227,8 @@
       "installOsPatches": "Ausstehende Betriebssystem-Patches installieren ({{count}})",
       "installThirdPartyPatches": "Installieren Sie Patches von Drittanbietern ({{count}})",
       "lastScan": "Letzter Scan: {{label}}",
+      "managePatches": "Patches verwalten",
+      "managedByPolicy": "Verwaltet durch Richtlinie:",
       "pendingApprovalCount": "({{count}} bis zur Genehmigung)",
       "polling": "Abfrage läuft...",
       "refreshPatchData": "Patchdaten aktualisieren",

--- a/apps/web/src/locales/en/devices.json
+++ b/apps/web/src/locales/en/devices.json
@@ -1227,6 +1227,8 @@
       "installOsPatches": "Install pending OS patches ({{count}})",
       "installThirdPartyPatches": "Install 3rd-party patches ({{count}})",
       "lastScan": "Last scan: {{label}}",
+      "managePatches": "Manage Patches",
+      "managedByPolicy": "Managed by policy:",
       "pendingApprovalCount": "({{count}} pending approval)",
       "polling": "Polling...",
       "refreshPatchData": "Refresh patch data",

--- a/apps/web/src/locales/es-419/devices.json
+++ b/apps/web/src/locales/es-419/devices.json
@@ -1227,6 +1227,8 @@
       "installOsPatches": "Aplicar parches OS pendientes ({{count}})",
       "installThirdPartyPatches": "Aplicar parches de terceros ({{count}})",
       "lastScan": "Último escaneo: {{label}}",
+      "managePatches": "Administrar parches",
+      "managedByPolicy": "Administrado por la política:",
       "pendingApprovalCount": "({{count}} pendiente de aprobación)",
       "polling": "Consultando...",
       "refreshPatchData": "Actualizar datos del parche",

--- a/apps/web/src/locales/fr-CA/devices.json
+++ b/apps/web/src/locales/fr-CA/devices.json
@@ -1227,6 +1227,8 @@
       "installOsPatches": "Installer les correctifs du système d’exploitation en attente ({{count}})",
       "installThirdPartyPatches": "Installer des correctifs tiers ({{count}})",
       "lastScan": "Dernier scan : {{label}}",
+      "managePatches": "Gérer les patches",
+      "managedByPolicy": "Géré par la politique :",
       "pendingApprovalCount": "({{count}} en attente d’approbation)",
       "polling": "Sondages...",
       "refreshPatchData": "Actualiser les données des correctifs",

--- a/apps/web/src/locales/fr-FR/devices.json
+++ b/apps/web/src/locales/fr-FR/devices.json
@@ -1227,6 +1227,8 @@
       "installOsPatches": "Installer les correctifs du système d’exploitation en attente ({{count}})",
       "installThirdPartyPatches": "Installer des correctifs tiers ({{count}})",
       "lastScan": "Dernier scan : {{label}}",
+      "managePatches": "Gérer les patches",
+      "managedByPolicy": "Géré par la politique :",
       "pendingApprovalCount": "({{count}} en attente d’approbation)",
       "polling": "Sondages...",
       "refreshPatchData": "Actualiser les données des correctifs",

--- a/apps/web/src/locales/it-IT/devices.json
+++ b/apps/web/src/locales/it-IT/devices.json
@@ -1227,6 +1227,8 @@
       "installOsPatches": "Installa patch OS in sospeso ({{count}})",
       "installThirdPartyPatches": "Installa patch di terze parti ({{count}})",
       "lastScan": "Ultima scansione: {{label}}",
+      "managePatches": "Gestisci patch",
+      "managedByPolicy": "Gestito dal criterio:",
       "pendingApprovalCount": "({{count}} in attesa di approvazione)",
       "polling": "Polling...",
       "refreshPatchData": "Aggiorna dati patch",

--- a/apps/web/src/locales/pt-BR/devices.json
+++ b/apps/web/src/locales/pt-BR/devices.json
@@ -1227,6 +1227,8 @@
       "installOsPatches": "Instalar patches pendentes do OS ({{count}})",
       "installThirdPartyPatches": "Instalar patches de terceiros ({{count}})",
       "lastScan": "Última verificação: {{label}}",
+      "managePatches": "Gerenciar patches",
+      "managedByPolicy": "Gerenciado pela política:",
       "pendingApprovalCount": "({{count}} aguardando aprovação)",
       "polling": "Consultando...",
       "refreshPatchData": "Atualizar dados dos patches",

--- a/apps/web/src/locales/tr-TR/devices.json
+++ b/apps/web/src/locales/tr-TR/devices.json
@@ -1227,6 +1227,8 @@
       "installOsPatches": "Bekleyen işletim sistemi yamalarını yükleyin ({{count}})",
       "installThirdPartyPatches": "3. taraf yamaları yükleyin ({{count}})",
       "lastScan": "Son tarama: {{label}}",
+      "managePatches": "Yamaları yönet",
+      "managedByPolicy": "Şu politika tarafından yönetiliyor:",
       "pendingApprovalCount": "({{count}} onay bekleniyor)",
       "polling": "Oylama...",
       "refreshPatchData": "Yama verilerini yenile",


### PR DESCRIPTION
## Summary
- Discord ask split from #4280: "On Device view > Patches, can provide a link to manage patches" — a tech had no way to reach the patch policy governing a device, or the fleet-wide Patches page, from the device's Patches tab without searching for it manually.
- Adds a **"Manage Patches"** link (always visible) to the fleet-wide `/patches` page, and a **"Managed by policy: <name>"** deep link to `/configuration-policies/:id` when the device resolves to an assigned patch policy.
- The policy link reuses the existing `GET /configuration-policies/effective/:deviceId` endpoint and the same link pattern `DeviceEffectiveConfigTab.tsx` already uses for its inheritance-chain table — no new API route needed.

## Scope note
The issue title also mentions linking to "the patch job it created." Investigated and confirmed there is currently **no** patch-job list/detail UI anywhere in the web app (`patch_jobs` rows have no route, list, or detail page) — building one is a separate, larger feature, out of scope for what the issue itself describes as a "small navigation change." This PR implements the policy-link half, which is directly actionable today and matches the literal Discord ask ("link to manage patches").

## Test plan
- [x] `DevicePatchStatusTab.test.tsx` — 2 new tests (policy link renders/links correctly; no policy link when unassigned), all 17 tests in the file pass
- [x] `localeParity.test.ts`, `translationCoverage.test.ts`, `extractionQuality.test.ts` — pass (added `managePatches` / `managedByPolicy` keys + real translations to all 7 non-English locales)
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed files

Closes #4671

🤖 Generated with [Claude Code](https://claude.com/claude-code)