### PR TITLE
feat(workspace): let users rename AI Workspace chat tabs (#4280)

### DIFF
--- a/apps/web/src/components/workspace/WorkspacePage.tsx
+++ b/apps/web/src/components/workspace/WorkspacePage.tsx
@@ -11,6 +11,7 @@ export default function WorkspacePage() {
     createTab,
     closeTab,
     switchTab,
+    renameTab,
     restoreWorkspace,
     cleanupAllStreams,
   } = useWorkspaceStore();
@@ -63,6 +64,7 @@ export default function WorkspacePage() {
             activeTabId={activeTabId}
             onSelectTab={switchTab}
             onCloseTab={closeTab}
+            onRenameTab={(tabId, title) => void renameTab(tabId, title)}
             onNewTab={() => createTab()}
           />
           {activeTab ? (

--- a/apps/web/src/components/workspace/WorkspaceTab.test.tsx
+++ b/apps/web/src/components/workspace/WorkspaceTab.test.tsx
@@ -1,0 +1,111 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import WorkspaceTab from './WorkspaceTab';
+
+function renderTab(overrides: Partial<React.ComponentProps<typeof WorkspaceTab>> = {}) {
+  const onSelect = vi.fn();
+  const onClose = vi.fn();
+  const onRename = vi.fn();
+  render(
+    <WorkspaceTab
+      id="tab-1"
+      title="Printer troubleshooting"
+      isActive={false}
+      unreadCount={0}
+      hasApprovalPending={false}
+      isStreaming={false}
+      onSelect={onSelect}
+      onClose={onClose}
+      onRename={onRename}
+      {...overrides}
+    />,
+  );
+  return { onSelect, onClose, onRename };
+}
+
+describe('WorkspaceTab rename', () => {
+  it('renders the title as plain text (not editable) by default', () => {
+    renderTab();
+    expect(screen.getByTestId('workspace-tab-title')).toHaveTextContent('Printer troubleshooting');
+    expect(screen.queryByTestId('workspace-tab-rename-input')).not.toBeInTheDocument();
+  });
+
+  it('double-clicking the title swaps it for an editable input, pre-filled with the current title', () => {
+    renderTab();
+
+    fireEvent.doubleClick(screen.getByTestId('workspace-tab-title'));
+
+    const input = screen.getByTestId('workspace-tab-rename-input') as HTMLInputElement;
+    expect(input).toBeInTheDocument();
+    expect(input.value).toBe('Printer troubleshooting');
+  });
+
+  it('commits the new title on Enter', () => {
+    const { onRename } = renderTab();
+    fireEvent.doubleClick(screen.getByTestId('workspace-tab-title'));
+
+    const input = screen.getByTestId('workspace-tab-rename-input');
+    fireEvent.change(input, { target: { value: 'Renamed chat' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onRename).toHaveBeenCalledWith('Renamed chat');
+    expect(screen.queryByTestId('workspace-tab-rename-input')).not.toBeInTheDocument();
+    expect(screen.getByTestId('workspace-tab-title')).toHaveTextContent('Printer troubleshooting');
+  });
+
+  it('commits the new title on blur', () => {
+    const { onRename } = renderTab();
+    fireEvent.doubleClick(screen.getByTestId('workspace-tab-title'));
+
+    const input = screen.getByTestId('workspace-tab-rename-input');
+    fireEvent.change(input, { target: { value: 'Renamed via blur' } });
+    fireEvent.blur(input);
+
+    expect(onRename).toHaveBeenCalledWith('Renamed via blur');
+  });
+
+  it('discards the edit on Escape without calling onRename', () => {
+    const { onRename } = renderTab();
+    fireEvent.doubleClick(screen.getByTestId('workspace-tab-title'));
+
+    const input = screen.getByTestId('workspace-tab-rename-input');
+    fireEvent.change(input, { target: { value: 'Should not save' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    expect(onRename).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('workspace-tab-rename-input')).not.toBeInTheDocument();
+    expect(screen.getByTestId('workspace-tab-title')).toHaveTextContent('Printer troubleshooting');
+  });
+
+  it('does not call onRename when the title is unchanged', () => {
+    const { onRename } = renderTab();
+    fireEvent.doubleClick(screen.getByTestId('workspace-tab-title'));
+
+    const input = screen.getByTestId('workspace-tab-rename-input');
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onRename).not.toHaveBeenCalled();
+  });
+
+  it('does not call onRename when the new title is blank', () => {
+    const { onRename } = renderTab();
+    fireEvent.doubleClick(screen.getByTestId('workspace-tab-title'));
+
+    const input = screen.getByTestId('workspace-tab-rename-input');
+    fireEvent.change(input, { target: { value: '   ' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onRename).not.toHaveBeenCalled();
+  });
+
+  it('does not fire onSelect when double-clicking the title to rename', () => {
+    const { onSelect } = renderTab();
+    fireEvent.doubleClick(screen.getByTestId('workspace-tab-title'));
+
+    // The dblclick itself is stopped from bubbling to the tab button; a
+    // regular click still selects the tab as usual, so onSelect isn't
+    // expected to have been suppressed globally — only the rename trigger.
+    expect(screen.getByTestId('workspace-tab-rename-input')).toBeInTheDocument();
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/workspace/WorkspaceTab.tsx
+++ b/apps/web/src/components/workspace/WorkspaceTab.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from "react";
 import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
@@ -11,7 +12,16 @@ interface WorkspaceTabProps {
   isStreaming: boolean;
   onSelect: () => void;
   onClose: () => void;
+  onRename: (title: string) => void;
 }
+
+const tabShellClassName = (isActive: boolean) =>
+  cn(
+    "group relative flex min-w-0 max-w-[200px] items-center gap-1.5 rounded-t-lg border border-b-0 px-3 py-2 text-sm font-medium transition-colors",
+    isActive
+      ? "border-gray-300 bg-gray-50 text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+      : "border-transparent bg-gray-50/50 text-gray-500 hover:bg-gray-100/50 hover:text-gray-700 dark:bg-gray-900/50 dark:text-gray-400 dark:hover:bg-gray-800/50 dark:hover:text-gray-300",
+  );
 
 export default function WorkspaceTab({
   title,
@@ -21,24 +31,93 @@ export default function WorkspaceTab({
   isStreaming,
   onSelect,
   onClose,
+  onRename,
 }: WorkspaceTabProps) {
   const { t } = useTranslation("ai");
+  const [isEditing, setIsEditing] = useState(false);
+  const [draftTitle, setDraftTitle] = useState(title);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isEditing) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [isEditing]);
+
+  const startEditing = () => {
+    setDraftTitle(title);
+    setIsEditing(true);
+  };
+
+  const commitRename = () => {
+    const trimmed = draftTitle.trim();
+    if (trimmed && trimmed !== title) {
+      onRename(trimmed);
+    }
+    setIsEditing(false);
+  };
+
+  const cancelRename = () => {
+    setDraftTitle(title);
+    setIsEditing(false);
+  };
+
+  // An <input> cannot be a descendant of the tab's <button> (invalid HTML —
+  // interactive content inside interactive content), so the editing state
+  // renders a plain <div> shell instead of swapping content inside the button.
+  if (isEditing) {
+    return (
+      <div className={tabShellClassName(isActive)} data-testid="workspace-tab-editing">
+        {isStreaming && (
+          <span className="h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-purple-400" />
+        )}
+        <input
+          ref={inputRef}
+          type="text"
+          value={draftTitle}
+          onChange={(e) => setDraftTitle(e.target.value)}
+          onBlur={commitRename}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              commitRename();
+            } else if (e.key === "Escape") {
+              e.preventDefault();
+              cancelRename();
+            }
+          }}
+          maxLength={255}
+          aria-label={t("workspaceTab.renameLabel")}
+          data-testid="workspace-tab-rename-input"
+          className="min-w-0 max-w-[150px] rounded border border-purple-400 bg-white px-1 py-0.5 text-sm text-gray-900 focus:outline-none focus:ring-1 focus:ring-purple-500 dark:border-purple-500 dark:bg-gray-800 dark:text-gray-100"
+        />
+      </div>
+    );
+  }
+
   return (
     <button
       onClick={onSelect}
-      className={cn(
-        "group relative flex min-w-0 max-w-[200px] items-center gap-1.5 rounded-t-lg border border-b-0 px-3 py-2 text-sm font-medium transition-colors",
-        isActive
-          ? "border-gray-300 bg-gray-50 text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
-          : "border-transparent bg-gray-50/50 text-gray-500 hover:bg-gray-100/50 hover:text-gray-700 dark:bg-gray-900/50 dark:text-gray-400 dark:hover:bg-gray-800/50 dark:hover:text-gray-300",
-      )}
+      className={tabShellClassName(isActive)}
+      data-testid="workspace-tab"
     >
       {/* Streaming indicator */}
       {isStreaming && (
         <span className="h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-purple-400" />
       )}
 
-      <span className="truncate">{title}</span>
+      <span
+        className="truncate"
+        data-testid="workspace-tab-title"
+        title={t("workspaceTab.renameHint")}
+        onDoubleClick={(e) => {
+          e.stopPropagation();
+          startEditing();
+        }}
+      >
+        {title}
+      </span>
 
       {/* Unread badge */}
       {unreadCount > 0 && !isActive && (

--- a/apps/web/src/components/workspace/WorkspaceTabBar.tsx
+++ b/apps/web/src/components/workspace/WorkspaceTabBar.tsx
@@ -10,6 +10,7 @@ interface WorkspaceTabBarProps {
   activeTabId: string | null;
   onSelectTab: (tabId: string) => void;
   onCloseTab: (tabId: string) => void;
+  onRenameTab: (tabId: string, title: string) => void;
   onNewTab: () => void;
 }
 
@@ -18,6 +19,7 @@ export default function WorkspaceTabBar({
   activeTabId,
   onSelectTab,
   onCloseTab,
+  onRenameTab,
   onNewTab,
 }: WorkspaceTabBarProps) {
   const { t } = useTranslation("ai");
@@ -34,6 +36,7 @@ export default function WorkspaceTabBar({
           isStreaming={tab.isStreaming}
           onSelect={() => onSelectTab(tab.id)}
           onClose={() => onCloseTab(tab.id)}
+          onRename={(title) => onRenameTab(tab.id, title)}
         />
       ))}
 

--- a/apps/web/src/locales/de-DE/ai.json
+++ b/apps/web/src/locales/de-DE/ai.json
@@ -424,7 +424,9 @@
     "limit": "Bis zu 5 gleichzeitige Unterhaltungen"
   },
   "workspaceTab": {
-    "approvalPending": "Genehmigung ausstehend"
+    "approvalPending": "Genehmigung ausstehend",
+    "renameLabel": "Chat umbenennen",
+    "renameHint": "Doppelklicken zum Umbenennen"
   },
   "workspaceTabBar": {
     "newTabShortcut": "Neuer Tab (Cmd+Shift+N)",

--- a/apps/web/src/locales/en/ai.json
+++ b/apps/web/src/locales/en/ai.json
@@ -424,7 +424,9 @@
     "limit": "Up to 5 concurrent conversations"
   },
   "workspaceTab": {
-    "approvalPending": "Approval pending"
+    "approvalPending": "Approval pending",
+    "renameLabel": "Rename chat",
+    "renameHint": "Double-click to rename"
   },
   "workspaceTabBar": {
     "newTabShortcut": "New tab (Cmd+Shift+N)",

--- a/apps/web/src/locales/es-419/ai.json
+++ b/apps/web/src/locales/es-419/ai.json
@@ -424,7 +424,9 @@
     "limit": "Hasta 5 conversaciones simultáneas"
   },
   "workspaceTab": {
-    "approvalPending": "Aprobación pendiente"
+    "approvalPending": "Aprobación pendiente",
+    "renameLabel": "Renombrar chat",
+    "renameHint": "Haga doble clic para renombrar"
   },
   "workspaceTabBar": {
     "newTabShortcut": "Nueva pestaña (Cmd+Mayús+N)",

--- a/apps/web/src/locales/fr-CA/ai.json
+++ b/apps/web/src/locales/fr-CA/ai.json
@@ -424,7 +424,9 @@
     "limit": "Jusqu’à 5 conversations simultanées"
   },
   "workspaceTab": {
-    "approvalPending": "Approbation en attente"
+    "approvalPending": "Approbation en attente",
+    "renameLabel": "Renommer la conversation",
+    "renameHint": "Double-cliquez pour renommer"
   },
   "workspaceTabBar": {
     "newTabShortcut": "Nouvel onglet (Cmd+Shift+N)",

--- a/apps/web/src/locales/fr-FR/ai.json
+++ b/apps/web/src/locales/fr-FR/ai.json
@@ -424,7 +424,9 @@
     "limit": "Jusqu’à 5 conversations simultanées"
   },
   "workspaceTab": {
-    "approvalPending": "Approbation en attente"
+    "approvalPending": "Approbation en attente",
+    "renameLabel": "Renommer la conversation",
+    "renameHint": "Double-cliquez pour renommer"
   },
   "workspaceTabBar": {
     "newTabShortcut": "Nouvel onglet (Cmd+Shift+N)",

--- a/apps/web/src/locales/it-IT/ai.json
+++ b/apps/web/src/locales/it-IT/ai.json
@@ -424,7 +424,9 @@
     "limit": "Fino a 5 conversazioni simultanee"
   },
   "workspaceTab": {
-    "approvalPending": "Approvazione in sospeso"
+    "approvalPending": "Approvazione in sospeso",
+    "renameLabel": "Rinomina chat",
+    "renameHint": "Fai doppio clic per rinominare"
   },
   "workspaceTabBar": {
     "newTabShortcut": "Nuova scheda (Cmd+Shift+N)",

--- a/apps/web/src/locales/pt-BR/ai.json
+++ b/apps/web/src/locales/pt-BR/ai.json
@@ -424,7 +424,9 @@
     "limit": "Até 5 conversas simultâneas"
   },
   "workspaceTab": {
-    "approvalPending": "Aprovação pendente"
+    "approvalPending": "Aprovação pendente",
+    "renameLabel": "Renomear conversa",
+    "renameHint": "Clique duas vezes para renomear"
   },
   "workspaceTabBar": {
     "newTabShortcut": "Nova guia (Cmd+Shift+N)",

--- a/apps/web/src/locales/tr-TR/ai.json
+++ b/apps/web/src/locales/tr-TR/ai.json
@@ -424,7 +424,9 @@
     "limit": "5'e kadar eşzamanlı görüşme"
   },
   "workspaceTab": {
-    "approvalPending": "Onay bekleniyor"
+    "approvalPending": "Onay bekleniyor",
+    "renameLabel": "Sohbeti yeniden adlandır",
+    "renameHint": "Yeniden adlandırmak için çift tıklayın"
   },
   "workspaceTabBar": {
     "newTabShortcut": "Yeni sekme (Cmd+Shift+N)",

--- a/apps/web/src/stores/workspaceStore.test.ts
+++ b/apps/web/src/stores/workspaceStore.test.ts
@@ -224,6 +224,33 @@ describe('workspace store renameTab', () => {
     expect(tabById('tab-1').title).toBe('Pre-session rename');
     expect(tabById('tab-1').isTitleCustom).toBe(true);
   });
+
+  it('does not let a stale (superseded) rename failure clobber a newer, already-successful rename', async () => {
+    // Two renames fired back-to-back with no in-flight guard on the UI side:
+    // the FIRST PATCH ("A") stays pending while the SECOND ("B") resolves
+    // successfully. When A's failure response finally arrives, it must not
+    // roll the tab back over B's already-confirmed title.
+    let resolveFirst!: (value: Response) => void;
+    const firstPatch = new Promise<Response>((resolve) => {
+      resolveFirst = resolve;
+    });
+    fetchWithAuthMock
+      .mockImplementationOnce(() => firstPatch)
+      .mockResolvedValueOnce(makeResponse({ success: true, title: 'Second rename' }));
+
+    const firstRename = useWorkspaceStore.getState().renameTab('tab-1', 'First rename');
+    await useWorkspaceStore.getState().renameTab('tab-1', 'Second rename');
+
+    expect(tabById('tab-1').title).toBe('Second rename');
+    expect(tabById('tab-1').isTitleCustom).toBe(true);
+
+    resolveFirst(makeResponse({ error: 'boom' }, false, 500));
+    await firstRename;
+
+    expect(tabById('tab-1').title).toBe('Second rename');
+    expect(tabById('tab-1').isTitleCustom).toBe(true);
+    expect(tabById('tab-1').error).toBeNull();
+  });
 });
 
 describe('workspace store sendMessage title handling', () => {
@@ -274,6 +301,83 @@ describe('workspace store sendMessage title handling', () => {
       method: 'POST',
       body: JSON.stringify({ pageContext: undefined, title: undefined }),
     });
+  });
+
+  it('PATCHes the session with a newer title if the tab was renamed while its session was still being created', async () => {
+    useWorkspaceStore.setState({
+      tabs: [tab({ id: 'tab-1', sessionId: null, title: 'New Chat', isTitleCustom: false })],
+      activeTabId: 'tab-1',
+    });
+
+    let resolveCreate!: (value: Response) => void;
+    const createPromise = new Promise<Response>((resolve) => {
+      resolveCreate = resolve;
+    });
+    fetchWithAuthMock
+      .mockImplementationOnce(() => createPromise) // POST /ai/sessions — stays pending
+      .mockResolvedValueOnce(makeResponse({ success: true, title: 'Renamed mid-flight' })) // PATCH sync
+      .mockResolvedValueOnce(makeStreamResponse()); // POST .../messages
+
+    const sendPromise = useWorkspaceStore.getState().sendMessage('tab-1', 'hello');
+
+    // renameTab is a local-only no-op against the API while sessionId is
+    // still null — this must not be lost once the session exists.
+    await useWorkspaceStore.getState().renameTab('tab-1', 'Renamed mid-flight');
+    expect(fetchWithAuthMock).toHaveBeenCalledTimes(1);
+
+    resolveCreate(makeResponse({ id: 'session-1' }));
+    await sendPromise;
+
+    expect(fetchWithAuthMock).toHaveBeenNthCalledWith(2, '/ai/sessions/session-1', {
+      method: 'PATCH',
+      body: JSON.stringify({ title: 'Renamed mid-flight' }),
+    });
+  });
+});
+
+describe('workspace store title_updated SSE handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storageHarness.data.clear();
+  });
+
+  const makeSseResponse = (events: Array<Record<string, unknown>>): Response => {
+    const encoder = new TextEncoder();
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const event of events) {
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+        }
+        controller.close();
+      },
+    });
+    return { ok: true, status: 200, body } as unknown as Response;
+  };
+
+  it('applies a title_updated event when the tab title is not custom (server auto-title)', async () => {
+    useWorkspaceStore.setState({
+      tabs: [tab({ id: 'tab-1', sessionId: 'session-1', title: 'New Chat', isTitleCustom: false })],
+      activeTabId: 'tab-1',
+      _readers: new Map(),
+    });
+    fetchWithAuthMock.mockResolvedValueOnce(makeSseResponse([{ type: 'title_updated', title: 'Auto-generated title' }]));
+
+    await useWorkspaceStore.getState().sendMessage('tab-1', 'hello');
+
+    expect(useWorkspaceStore.getState().tabs.find(t => t.id === 'tab-1')!.title).toBe('Auto-generated title');
+  });
+
+  it('ignores a title_updated event once the tab has a user-set custom title', async () => {
+    useWorkspaceStore.setState({
+      tabs: [tab({ id: 'tab-1', sessionId: 'session-1', title: 'My Custom Title', isTitleCustom: true })],
+      activeTabId: 'tab-1',
+      _readers: new Map(),
+    });
+    fetchWithAuthMock.mockResolvedValueOnce(makeSseResponse([{ type: 'title_updated', title: 'Auto-generated title' }]));
+
+    await useWorkspaceStore.getState().sendMessage('tab-1', 'hello');
+
+    expect(useWorkspaceStore.getState().tabs.find(t => t.id === 'tab-1')!.title).toBe('My Custom Title');
   });
 });
 

--- a/apps/web/src/stores/workspaceStore.test.ts
+++ b/apps/web/src/stores/workspaceStore.test.ts
@@ -49,6 +49,7 @@ function tab(over: Partial<TabState> = {}): TabState {
     id: 'tab-1',
     sessionId: 'session-1',
     title: 'Chat',
+    isTitleCustom: false,
     contextLabel: null,
     pageContext: null,
     messages: [],
@@ -137,6 +138,142 @@ describe('workspace store clearPendingApproval', () => {
     expect(tabById('tab-1').pendingApproval).not.toBeNull();
     expect(tabById('tab-1').hasApprovalPending).toBe(true);
     expect(tabById('tab-2').hasApprovalPending).toBe(true);
+  });
+});
+
+describe('workspace store renameTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storageHarness.data.clear();
+    useWorkspaceStore.setState({
+      tabs: [tab({ id: 'tab-1', sessionId: 'session-1', title: 'New Chat', isTitleCustom: false })],
+      activeTabId: 'tab-1',
+      _readers: new Map(),
+    });
+  });
+
+  const tabById = (id: string) => useWorkspaceStore.getState().tabs.find(t => t.id === id)!;
+
+  it('optimistically renames and persists via PATCH /ai/sessions/:id', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(makeResponse({ success: true, title: 'Printer troubleshooting' }));
+
+    await useWorkspaceStore.getState().renameTab('tab-1', 'Printer troubleshooting');
+
+    expect(fetchWithAuthMock).toHaveBeenCalledWith('/ai/sessions/session-1', {
+      method: 'PATCH',
+      body: JSON.stringify({ title: 'Printer troubleshooting' }),
+    });
+    expect(tabById('tab-1').title).toBe('Printer troubleshooting');
+    expect(tabById('tab-1').isTitleCustom).toBe(true);
+  });
+
+  it('trims whitespace before persisting', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(makeResponse({ success: true, title: 'Trimmed' }));
+
+    await useWorkspaceStore.getState().renameTab('tab-1', '  Trimmed  ');
+
+    expect(fetchWithAuthMock).toHaveBeenCalledWith('/ai/sessions/session-1', {
+      method: 'PATCH',
+      body: JSON.stringify({ title: 'Trimmed' }),
+    });
+    expect(tabById('tab-1').title).toBe('Trimmed');
+  });
+
+  it('is a no-op for an empty/whitespace-only title', async () => {
+    await useWorkspaceStore.getState().renameTab('tab-1', '   ');
+
+    expect(fetchWithAuthMock).not.toHaveBeenCalled();
+    expect(tabById('tab-1').title).toBe('New Chat');
+    expect(tabById('tab-1').isTitleCustom).toBe(false);
+  });
+
+  it('is a no-op for an unknown tab id', async () => {
+    await useWorkspaceStore.getState().renameTab('tab-missing', 'Whatever');
+
+    expect(fetchWithAuthMock).not.toHaveBeenCalled();
+  });
+
+  it('rolls back the title and custom flag when the PATCH fails', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce(makeResponse({ error: 'Session not found' }, false, 404));
+
+    await useWorkspaceStore.getState().renameTab('tab-1', 'Will fail');
+
+    expect(tabById('tab-1').title).toBe('New Chat');
+    expect(tabById('tab-1').isTitleCustom).toBe(false);
+    expect(tabById('tab-1').error).toBe('Session not found');
+  });
+
+  it('rolls back on a network error', async () => {
+    fetchWithAuthMock.mockRejectedValueOnce(new Error('network down'));
+
+    await useWorkspaceStore.getState().renameTab('tab-1', 'Will fail');
+
+    expect(tabById('tab-1').title).toBe('New Chat');
+    expect(tabById('tab-1').isTitleCustom).toBe(false);
+    expect(tabById('tab-1').error).toBe('Failed to rename chat');
+  });
+
+  it('updates local state without calling the API when the tab has no session yet', async () => {
+    useWorkspaceStore.setState({
+      tabs: [tab({ id: 'tab-1', sessionId: null, title: 'New Chat', isTitleCustom: false })],
+    });
+
+    await useWorkspaceStore.getState().renameTab('tab-1', 'Pre-session rename');
+
+    expect(fetchWithAuthMock).not.toHaveBeenCalled();
+    expect(tabById('tab-1').title).toBe('Pre-session rename');
+    expect(tabById('tab-1').isTitleCustom).toBe(true);
+  });
+});
+
+describe('workspace store sendMessage title handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storageHarness.data.clear();
+    useWorkspaceStore.setState({ tabs: [], activeTabId: null, _readers: new Map() });
+  });
+
+  const makeStreamResponse = (): Response => {
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.close();
+      },
+    });
+    return { ok: true, status: 200, body } as unknown as Response;
+  };
+
+  it('sends the custom title when creating a session for a manually-renamed tab', async () => {
+    useWorkspaceStore.setState({
+      tabs: [tab({ id: 'tab-1', sessionId: null, title: 'My Renamed Chat', isTitleCustom: true })],
+      activeTabId: 'tab-1',
+    });
+    fetchWithAuthMock
+      .mockResolvedValueOnce(makeResponse({ id: 'session-1' }))
+      .mockResolvedValueOnce(makeStreamResponse());
+
+    await useWorkspaceStore.getState().sendMessage('tab-1', 'hello');
+
+    expect(fetchWithAuthMock).toHaveBeenNthCalledWith(1, '/ai/sessions', {
+      method: 'POST',
+      body: JSON.stringify({ pageContext: undefined, title: 'My Renamed Chat' }),
+    });
+  });
+
+  it('omits the title when the tab still has its default (non-custom) title', async () => {
+    useWorkspaceStore.setState({
+      tabs: [tab({ id: 'tab-1', sessionId: null, title: 'New Chat', isTitleCustom: false })],
+      activeTabId: 'tab-1',
+    });
+    fetchWithAuthMock
+      .mockResolvedValueOnce(makeResponse({ id: 'session-1' }))
+      .mockResolvedValueOnce(makeStreamResponse());
+
+    await useWorkspaceStore.getState().sendMessage('tab-1', 'hello');
+
+    expect(fetchWithAuthMock).toHaveBeenNthCalledWith(1, '/ai/sessions', {
+      method: 'POST',
+      body: JSON.stringify({ pageContext: undefined, title: undefined }),
+    });
   });
 });
 

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -199,6 +199,17 @@ export const useWorkspaceStore = create<WorkspaceState>()(
 
           if (!tab.sessionId) return;
 
+          // Only roll back if THIS call's title is still the tab's current
+          // title. Two renames can be in flight at once (fire-and-forget from
+          // the UI, no in-flight guard) and their PATCH responses can arrive
+          // out of order — without this check, an older call's failure could
+          // stomp a newer, already-successful rename.
+          const rollbackIfStillCurrent = (patch: Partial<TabState>) => {
+            if (getTab(tabId)?.title === trimmed) {
+              updateTab(tabId, { title: previousTitle, isTitleCustom: previousIsTitleCustom, ...patch });
+            }
+          };
+
           try {
             const res = await fetchWithAuth(`/ai/sessions/${tab.sessionId}`, {
               method: 'PATCH',
@@ -206,19 +217,11 @@ export const useWorkspaceStore = create<WorkspaceState>()(
             });
             if (!res.ok) {
               const data = await res.json().catch(() => null);
-              updateTab(tabId, {
-                title: previousTitle,
-                isTitleCustom: previousIsTitleCustom,
-                error: extractApiError(data, 'Failed to rename chat'),
-              });
+              rollbackIfStillCurrent({ error: extractApiError(data, 'Failed to rename chat') });
             }
           } catch (err) {
             console.error('[Workspace] Rename failed:', err);
-            updateTab(tabId, {
-              title: previousTitle,
-              isTitleCustom: previousIsTitleCustom,
-              error: 'Failed to rename chat',
-            });
+            rollbackIfStillCurrent({ error: 'Failed to rename chat' });
           }
         },
 
@@ -233,6 +236,15 @@ export const useWorkspaceStore = create<WorkspaceState>()(
           let sessionId = tab.sessionId;
           if (!sessionId) {
             updateTab(tabId, { isLoading: true, error: null });
+            // Snapshot the title sent with session creation. renameTab() is a
+            // no-op against the API while sessionId is still null (there's no
+            // session yet to PATCH), so a rename that lands *during* this
+            // await would otherwise be silently dropped — the tab shows the
+            // new title locally, but the backend record it's about to create
+            // never carries it, and nothing ever revisits it. Compare against
+            // the tab's title once a sessionId exists below and PATCH if it
+            // has since diverged.
+            const titleAtCreation = tab.isTitleCustom ? tab.title : undefined;
             try {
               const res = await fetchWithAuth('/ai/sessions', {
                 method: 'POST',
@@ -241,7 +253,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
                   // Carry a user-set title through to the new session so the
                   // server's first-message auto-title (gated on `!title`)
                   // never clobbers a rename made before the first message.
-                  title: tab.isTitleCustom ? tab.title : undefined,
+                  title: titleAtCreation,
                 }),
               });
               if (!res.ok) {
@@ -251,6 +263,14 @@ export const useWorkspaceStore = create<WorkspaceState>()(
               const data = await res.json();
               sessionId = data.id;
               updateTab(tabId, { sessionId, isLoading: false });
+
+              const latestTab = getTab(tabId);
+              if (latestTab?.isTitleCustom && latestTab.title !== titleAtCreation) {
+                fetchWithAuth(`/ai/sessions/${sessionId}`, {
+                  method: 'PATCH',
+                  body: JSON.stringify({ title: latestTab.title }),
+                }).catch((err) => console.error('[Workspace] Failed to sync title after session creation:', err));
+              }
             } catch (err) {
               updateTab(tabId, {
                 error: err instanceof Error ? err.message : 'Failed to create session',

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -20,6 +20,14 @@ export interface TabState {
   id: string;
   sessionId: string | null;
   title: string;
+  /**
+   * True once the user has explicitly renamed this tab (vs. the "New Chat"
+   * placeholder or a server auto-generated title). Gates two things: whether
+   * a `title_updated` SSE event from the backend's first-message auto-title
+   * is allowed to overwrite it, and whether the title is sent along when the
+   * session is first created so it survives past that auto-title step.
+   */
+  isTitleCustom: boolean;
   contextLabel: string | null;
   pageContext: AiPageContext | null;
   messages: AiMessage[];
@@ -42,6 +50,7 @@ function createEmptyTab(title?: string): TabState {
     id: crypto.randomUUID(),
     sessionId: null,
     title: title ?? 'New Chat',
+    isTitleCustom: false,
     contextLabel: null,
     pageContext: null,
     messages: [],
@@ -69,7 +78,14 @@ interface WorkspaceState {
   createTab: (title?: string, context?: AiPageContext) => void;
   closeTab: (tabId: string) => void;
   switchTab: (tabId: string) => void;
-  renameTab: (tabId: string, title: string) => void;
+  /**
+   * Renames a tab. Updates local state immediately; if the tab already has a
+   * backing session, persists the rename via PATCH /ai/sessions/:id and rolls
+   * the local title back if that call fails. A tab with no session yet stays
+   * local-only — the title is sent along when the session is created (see
+   * sendMessage) so it isn't lost.
+   */
+  renameTab: (tabId: string, title: string) => Promise<void>;
 
   // Chat actions (tab-scoped)
   sendMessage: (tabId: string, content: string) => Promise<void>;
@@ -100,7 +116,7 @@ interface WorkspaceState {
 }
 
 type PersistedWorkspace = {
-  tabs: Array<{ id: string; sessionId: string | null; title: string; contextLabel: string | null; pageContext: AiPageContext | null }>;
+  tabs: Array<{ id: string; sessionId: string | null; title: string; isTitleCustom: boolean; contextLabel: string | null; pageContext: AiPageContext | null }>;
   activeTabId: string | null;
 };
 
@@ -169,8 +185,41 @@ export const useWorkspaceStore = create<WorkspaceState>()(
           updateTab(tabId, { unreadCount: 0, hasApprovalPending: false });
         },
 
-        renameTab: (tabId: string, title: string) => {
-          updateTab(tabId, { title });
+        renameTab: async (tabId: string, title: string) => {
+          const trimmed = title.trim();
+          if (!trimmed) return;
+
+          const tab = getTab(tabId);
+          if (!tab) return;
+          if (trimmed === tab.title && tab.isTitleCustom) return;
+
+          const previousTitle = tab.title;
+          const previousIsTitleCustom = tab.isTitleCustom;
+          updateTab(tabId, { title: trimmed, isTitleCustom: true });
+
+          if (!tab.sessionId) return;
+
+          try {
+            const res = await fetchWithAuth(`/ai/sessions/${tab.sessionId}`, {
+              method: 'PATCH',
+              body: JSON.stringify({ title: trimmed }),
+            });
+            if (!res.ok) {
+              const data = await res.json().catch(() => null);
+              updateTab(tabId, {
+                title: previousTitle,
+                isTitleCustom: previousIsTitleCustom,
+                error: extractApiError(data, 'Failed to rename chat'),
+              });
+            }
+          } catch (err) {
+            console.error('[Workspace] Rename failed:', err);
+            updateTab(tabId, {
+              title: previousTitle,
+              isTitleCustom: previousIsTitleCustom,
+              error: 'Failed to rename chat',
+            });
+          }
         },
 
         sendMessage: async (tabId: string, content: string) => {
@@ -187,7 +236,13 @@ export const useWorkspaceStore = create<WorkspaceState>()(
             try {
               const res = await fetchWithAuth('/ai/sessions', {
                 method: 'POST',
-                body: JSON.stringify({ pageContext: tab.pageContext ?? undefined }),
+                body: JSON.stringify({
+                  pageContext: tab.pageContext ?? undefined,
+                  // Carry a user-set title through to the new session so the
+                  // server's first-message auto-title (gated on `!title`)
+                  // never clobbers a rename made before the first message.
+                  title: tab.isTitleCustom ? tab.title : undefined,
+                }),
               });
               if (!res.ok) {
                 const data = await res.json().catch(() => null);
@@ -308,9 +363,15 @@ export const useWorkspaceStore = create<WorkspaceState>()(
                       }
                     }
 
-                    // Update title from title_updated events
+                    // Update title from title_updated events — but never
+                    // stomp on a title the user explicitly set (guards a race
+                    // where the rename lands after the auto-title generation
+                    // already started server-side).
                     if (event.type === 'title_updated') {
-                      updateTab(tabId, { title: event.title });
+                      const currentTab = getTab(tabId);
+                      if (!currentTab?.isTitleCustom) {
+                        updateTab(tabId, { title: event.title });
+                      }
                     }
 
                     currentAssistantId = processStreamEvent(
@@ -601,6 +662,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
           id: t.id,
           sessionId: t.sessionId,
           title: t.title,
+          isTitleCustom: t.isTitleCustom,
           contextLabel: t.contextLabel,
           pageContext: t.pageContext,
         })),
@@ -616,6 +678,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
             ...createEmptyTab(t.title),
             id: t.id,
             sessionId: t.sessionId,
+            isTitleCustom: t.isTitleCustom ?? false,
             contextLabel: t.contextLabel,
             pageContext: t.pageContext,
           })),


### PR DESCRIPTION
## Summary

- AI Workspace chat tabs can now be renamed: double-click a tab's title to swap it for an inline text input; commit with Enter or blur, discard with Escape.
- The backend `PATCH /ai/sessions/:id` endpoint (title update, MFA-gated) already existed and was fully registered for tenancy/RLS/cascade — this PR is purely client-side wiring, closing two real gaps found while wiring it up:
  - `workspaceStore.renameTab()` was dead code: it only patched local Zustand state and never called the API, so a rename never survived a page reload's session restore.
  - A tab renamed *before* its first message (no backing session yet) would have that manual title silently clobbered the moment the first message triggered the server's auto-title generation (`generateSessionTitle`, gated on `!session.title`). Fixed by tracking `isTitleCustom` on the tab and carrying a custom title through to session creation (`POST /ai/sessions` already accepted an optional `title` field, previously unused by the client), and by having the `title_updated` SSE handler skip tabs with a custom title.

Scope note: issue #4280 was split by a maintainer comment into three separate issues; this PR covers **chat naming only** (the original ask). Device-naming policy engine (#4670) and the Patches-tab link (#4671) are out of scope.

## Test plan

- [x] `apps/web`: `npx vitest run src/stores/workspaceStore.test.ts` — 17 passed (new `renameTab` + `sendMessage` title-handling coverage)
- [x] `apps/web`: `npx vitest run src/components/workspace/WorkspaceTab.test.tsx` — 8 passed (new: rename UI affordance — enter/blur commit, escape discard, no-op on unchanged/blank title, no accidental tab-select)
- [x] `apps/web`: `npx vitest run src/components/workspace/WorkspaceChatPanel.test.tsx src/lib/i18n/localeParity.test.ts src/lib/i18n/translationCoverage.test.ts src/lib/__tests__/no-silent-mutations.test.ts` — 229 passed
- [x] `apps/web`: `npx vitest run src/lib/i18n/` (full i18n suite, all 8 locales) — 135 passed
- [x] `apps/web`: `npx tsc --noEmit` — clean
- [x] `npx eslint` on all changed files — clean
- [x] All 8 edited `ai.json` locale files parse as valid JSON

Closes #4280

🤖 Generated with [Claude Code](https://claude.com/claude-code)