### PR TITLE
feat(scripts): add help tooltip for UDF (custom field) read/write (#4198)

### DIFF
--- a/apps/web/src/components/scripts/ScriptForm.test.tsx
+++ b/apps/web/src/components/scripts/ScriptForm.test.tsx
@@ -720,9 +720,9 @@ describe('ScriptForm sourced parameters', () => {
       />
     );
 
-    expect(
-      await screen.findByRole('button', { name: 'About the device custom field binding' })
-    ).toBeInTheDocument();
+    const trigger = await screen.findByRole('button', { name: 'About the device custom field binding' });
+    fireEvent.click(trigger);
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(/PATCH request/i);
   });
 
   it('clears the previous arm\'s binding key when the source changes', async () => {

--- a/apps/web/src/components/scripts/ScriptForm.test.tsx
+++ b/apps/web/src/components/scripts/ScriptForm.test.tsx
@@ -707,6 +707,24 @@ describe('ScriptForm sourced parameters', () => {
     });
   });
 
+  it('shows a help affordance explaining how scripts read/write a bound device custom field', async () => {
+    render(
+      <ScriptForm
+        isNew
+        defaultValues={{
+          ...draft,
+          parameters: [
+            { name: 'asset_tag', type: 'string', source: 'deviceCustomField', fieldKey: 'asset_tag' },
+          ],
+        }}
+      />
+    );
+
+    expect(
+      await screen.findByRole('button', { name: 'About the device custom field binding' })
+    ).toBeInTheDocument();
+  });
+
   it('clears the previous arm\'s binding key when the source changes', async () => {
     render(
       <ScriptForm

--- a/apps/web/src/components/scripts/ScriptForm.tsx
+++ b/apps/web/src/components/scripts/ScriptForm.tsx
@@ -25,6 +25,7 @@ import CollapsibleSection from './CollapsibleSection';
 import ScriptVariablePicker from './ScriptVariablePicker';
 import TenantVariableMenu from './TenantVariableMenu';
 import { findUnknownVariableKeys, useTenantVariables, type TenantVariableEntry } from '@/lib/tenantVariableTokens';
+import HelpTooltip from '../shared/HelpTooltip';
 import { cn } from '@/lib/utils';
 import { configureMonacoLoader } from '@/lib/monacoLoader';
 import { useScriptAiStore } from '@/stores/scriptAiStore';
@@ -919,7 +920,13 @@ export default function ScriptForm({
                   )}
                   {source === 'deviceCustomField' && (
                     <div className="space-y-1 sm:col-span-2">
-                      <label className="text-xs font-medium text-muted-foreground">{t('scriptForm.parameterBinding.fieldLabel')}</label>
+                      <label className="flex items-center gap-1 text-xs font-medium text-muted-foreground">
+                        {t('scriptForm.parameterBinding.fieldLabel')}
+                        <HelpTooltip
+                          text={t('scriptForm.parameterBinding.fieldHelp')}
+                          ariaLabel={t('scriptForm.parameterBinding.fieldHelpAriaLabel')}
+                        />
+                      </label>
                       <input
                         placeholder={t('scriptForm.parameterBinding.fieldPlaceholder')}
                         className="h-9 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"

--- a/apps/web/src/components/settings/CustomFieldsPage.test.tsx
+++ b/apps/web/src/components/settings/CustomFieldsPage.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import '@/lib/i18n';
+
+const fetchWithAuth = vi.fn();
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: (...args: unknown[]) => fetchWithAuth(...args),
+}));
+
+import CustomFieldsPage from './CustomFieldsPage';
+
+const json = (payload: unknown, ok = true, status = 200): Response =>
+  ({ ok, status, statusText: 'OK', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+describe('CustomFieldsPage — field key help (issue #4198)', () => {
+  beforeEach(() => {
+    fetchWithAuth.mockReset();
+    fetchWithAuth.mockResolvedValue(json([]));
+  });
+
+  it('shows a help affordance next to Field Key explaining how scripts read/write it', async () => {
+    render(<CustomFieldsPage />);
+
+    await waitFor(() => expect(fetchWithAuth).toHaveBeenCalled());
+    fireEvent.click(await screen.findByRole('button', { name: 'Add your first custom field' }));
+
+    expect(
+      await screen.findByRole('button', { name: 'About using this field in scripts' })
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/settings/CustomFieldsPage.test.tsx
+++ b/apps/web/src/components/settings/CustomFieldsPage.test.tsx
@@ -25,8 +25,8 @@ describe('CustomFieldsPage — field key help (issue #4198)', () => {
     await waitFor(() => expect(fetchWithAuth).toHaveBeenCalled());
     fireEvent.click(await screen.findByRole('button', { name: 'Add your first custom field' }));
 
-    expect(
-      await screen.findByRole('button', { name: 'About using this field in scripts' })
-    ).toBeInTheDocument();
+    const trigger = await screen.findByRole('button', { name: 'About using this field in scripts' });
+    fireEvent.click(trigger);
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(/PATCH request/i);
   });
 });

--- a/apps/web/src/components/settings/CustomFieldsPage.tsx
+++ b/apps/web/src/components/settings/CustomFieldsPage.tsx
@@ -5,6 +5,7 @@ import { Plus, Pencil, Trash2, Search, Settings, ChevronDown, AlertCircle } from
 import { fetchWithAuth } from '../../stores/auth';
 import type { CustomFieldDefinition, CustomFieldType, CustomFieldOptions } from '@breeze/shared';
 import { asList } from '@/lib/asList';
+import HelpTooltip from '../shared/HelpTooltip';
 
 interface CustomField extends Omit<CustomFieldDefinition, 'createdAt' | 'updatedAt'> {
   createdAt: string | Date;
@@ -475,7 +476,13 @@ export default function CustomFieldsPage() {
                   />
                 </div>
                 <div>
-                  <label className="text-sm font-medium">{t('customFieldsPage.form.fieldKey')}</label>
+                  <label className="flex items-center gap-1 text-sm font-medium">
+                    {t('customFieldsPage.form.fieldKey')}
+                    <HelpTooltip
+                      text={t('customFieldsPage.form.fieldKeyScriptHelp')}
+                      ariaLabel={t('customFieldsPage.form.fieldKeyScriptHelpAriaLabel')}
+                    />
+                  </label>
                   <input
                     type="text"
                     value={formFieldKey}

--- a/apps/web/src/locales/de-DE/scripts.json
+++ b/apps/web/src/locales/de-DE/scripts.json
@@ -1035,6 +1035,8 @@
       "variablePlaceholder": "z.B. vendor_token",
       "fieldLabel": "Schlüssel des benutzerdefinierten Felds",
       "fieldPlaceholder": "z.B. asset_tag",
+      "fieldHelp": "Geben Sie den Feldschlüssel ein, der unter Einstellungen → Benutzerdefinierte Felder angezeigt wird (Groß-/Kleinschreibung beachten). Lesen: Sobald die Bindung besteht, wird der aufgelöste Wert wie ein normaler Parameter an das Skript übergeben — es erscheint keine Eingabeaufforderung. Schreiben: Um einen neuen Wert zurückzuschreiben, lassen Sie das Skript die Custom-Fields-API des Geräts mit einer PATCH-Anfrage und einem API-Schlüssel aufrufen.",
+      "fieldHelpAriaLabel": "Über die Bindung des benutzerdefinierten Gerätefelds",
       "builtinLabel": "Eigenschaft",
       "chooseTitle": "Variable auswählen",
       "secretRejected": "„{{key}}“ ist geheim – das Speichern wird abgelehnt. Wählen Sie eine Variable, die nicht geheim ist.",

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -3870,6 +3870,8 @@
       "fieldKey": "Feldschlüssel",
       "fieldKeyPlaceholder": "z. B. asset_tag",
       "fieldKeyHelp": "Wird in Filtern und API verwendet. Kann nach der Erstellung nicht mehr geändert werden.",
+      "fieldKeyScriptHelp": "Dieser Schlüssel wird von Skripten zum Lesen und Schreiben des Felds verwendet. Lesen: Binden Sie die Quelle eines Skriptparameters mit diesem Schlüssel an „Aus einem benutzerdefinierten Gerätefeld“. Schreiben: Lassen Sie das Skript die Custom-Fields-API des Geräts mit einer PATCH-Anfrage und einem API-Schlüssel aufrufen, um einen neuen Wert zu speichern.",
+      "fieldKeyScriptHelpAriaLabel": "Über die Verwendung dieses Felds in Skripten",
       "fieldType": "Feldtyp",
       "dropdownChoices": "Dropdown-Auswahl",
       "choiceLabel": "Etikett",

--- a/apps/web/src/locales/en/scripts.json
+++ b/apps/web/src/locales/en/scripts.json
@@ -1035,6 +1035,8 @@
       "variablePlaceholder": "e.g. vendor_token",
       "fieldLabel": "Custom field key",
       "fieldPlaceholder": "e.g. asset_tag",
+      "fieldHelp": "Enter the Field Key shown in Settings → Custom Fields (case-sensitive). Read: once bound, the resolved value is delivered to the script just like a normal parameter — no prompt is shown. Write: to save a new value back, have the script call the device's custom-fields API with a PATCH request and an API key.",
+      "fieldHelpAriaLabel": "About the device custom field binding",
       "builtinLabel": "Property",
       "chooseTitle": "Choose a variable",
       "secretRejected": "\"{{key}}\" is a secret — the save will be rejected. Choose a variable that is not a secret.",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -3923,6 +3923,8 @@
       "fieldKey": "Field Key",
       "fieldKeyPlaceholder": "e.g., asset_tag",
       "fieldKeyHelp": "Used in filters and API. Cannot be changed after creation.",
+      "fieldKeyScriptHelp": "This key is what scripts use to read and write the field. Read: bind a script parameter's source to \"From a device custom field\" using this key. Write: have the script call the device's custom-fields API with a PATCH request and an API key to save a new value.",
+      "fieldKeyScriptHelpAriaLabel": "About using this field in scripts",
       "fieldType": "Field Type",
       "dropdownChoices": "Dropdown Choices",
       "choiceLabel": "Label",

--- a/apps/web/src/locales/es-419/scripts.json
+++ b/apps/web/src/locales/es-419/scripts.json
@@ -1035,6 +1035,8 @@
       "variablePlaceholder": "p.ej. vendor_token",
       "fieldLabel": "Clave del campo personalizado",
       "fieldPlaceholder": "p.ej. asset_tag",
+      "fieldHelp": "Ingresa la Clave de Campo que se muestra en Configuración → Campos Personalizados (distingue mayúsculas de minúsculas). Lectura: una vez vinculado, el valor resuelto se entrega al script como cualquier parámetro normal, sin mostrar ninguna solicitud. Escritura: para guardar un nuevo valor, haz que el script llame a la API de campos personalizados del dispositivo con una solicitud PATCH y una clave de API.",
+      "fieldHelpAriaLabel": "Acerca de la vinculación de campo personalizado del dispositivo",
       "builtinLabel": "Propiedad",
       "chooseTitle": "Elegir una variable",
       "secretRejected": "\"{{key}}\" es secreta: se rechazará el guardado. Elige una variable que no sea secreta.",

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -3870,6 +3870,8 @@
       "fieldKey": "Clave de campo",
       "fieldKeyPlaceholder": "p. ej., asset_tag",
       "fieldKeyHelp": "Utilizado en filtros y API. No se puede cambiar después de la creación.",
+      "fieldKeyScriptHelp": "Esta clave es lo que los scripts usan para leer y escribir el campo. Lectura: vincula el origen de un parámetro del script a \"Desde un campo personalizado del dispositivo\" usando esta clave. Escritura: haz que el script llame a la API de campos personalizados del dispositivo con una solicitud PATCH y una clave de API para guardar un nuevo valor.",
+      "fieldKeyScriptHelpAriaLabel": "Acerca de usar este campo en scripts",
       "fieldType": "Tipo de campo",
       "dropdownChoices": "Opciones desplegables",
       "choiceLabel": "Etiqueta",

--- a/apps/web/src/locales/fr-CA/scripts.json
+++ b/apps/web/src/locales/fr-CA/scripts.json
@@ -1035,6 +1035,8 @@
       "variablePlaceholder": "p. ex. vendor_token",
       "fieldLabel": "Clé du champ personnalisé",
       "fieldPlaceholder": "p. ex. asset_tag",
+      "fieldHelp": "Saisissez la Clé du champ affichée dans Paramètres → Champs personnalisés (sensible à la casse). Lecture : une fois liée, la valeur résolue est transmise au script comme un paramètre normal — aucune invite n’est affichée. Écriture : pour enregistrer une nouvelle valeur, faites appeler par le script l’API des champs personnalisés de l’appareil avec une requête PATCH et une clé API.",
+      "fieldHelpAriaLabel": "À propos de la liaison du champ personnalisé de l’appareil",
       "builtinLabel": "Propriété",
       "chooseTitle": "Choisir une variable",
       "secretRejected": "« {{key}} » est un secret — l’enregistrement sera refusé. Choisissez une variable non secrète.",

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -3918,6 +3918,8 @@
       "fieldKey": "Clé de Terrain",
       "fieldKeyPlaceholder": "par exemple, asset_tag",
       "fieldKeyHelp": "Utilisé dans les filtres et API. Ne peut pas être modifié après la création.",
+      "fieldKeyScriptHelp": "Cette clé est ce que les scripts utilisent pour lire et écrire le champ. Lecture : associez la source d’un paramètre de script à « À partir d’un champ personnalisé de l’appareil » en utilisant cette clé. Écriture : faites appeler par le script l’API des champs personnalisés de l’appareil avec une requête PATCH et une clé API pour enregistrer une nouvelle valeur.",
+      "fieldKeyScriptHelpAriaLabel": "À propos de l’utilisation de ce champ dans les scripts",
       "fieldType": "Type de champ",
       "dropdownChoices": "Choix déroulants",
       "choiceLabel": "Libellé",

--- a/apps/web/src/locales/fr-FR/scripts.json
+++ b/apps/web/src/locales/fr-FR/scripts.json
@@ -1035,6 +1035,8 @@
       "variablePlaceholder": "p. ex. vendor_token",
       "fieldLabel": "Clé du champ personnalisé",
       "fieldPlaceholder": "p. ex. asset_tag",
+      "fieldHelp": "Saisissez la Clé du champ affichée dans Paramètres → Champs personnalisés (sensible à la casse). Lecture : une fois liée, la valeur résolue est transmise au script comme un paramètre normal — aucune invite n’est affichée. Écriture : pour enregistrer une nouvelle valeur, faites appeler par le script l’API des champs personnalisés de l’appareil avec une requête PATCH et une clé API.",
+      "fieldHelpAriaLabel": "À propos de la liaison du champ personnalisé de l’appareil",
       "builtinLabel": "Propriété",
       "chooseTitle": "Choisir une variable",
       "secretRejected": "« {{key}} » est un secret — l’enregistrement sera refusé. Choisissez une variable non secrète.",

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -3870,6 +3870,8 @@
       "fieldKey": "Clé de Terrain",
       "fieldKeyPlaceholder": "par exemple, asset_tag",
       "fieldKeyHelp": "Utilisé dans les filtres et API. Ne peut pas être modifié après la création.",
+      "fieldKeyScriptHelp": "Cette clé est ce que les scripts utilisent pour lire et écrire le champ. Lecture : associez la source d’un paramètre de script à « À partir d’un champ personnalisé de l’appareil » en utilisant cette clé. Écriture : faites appeler par le script l’API des champs personnalisés de l’appareil avec une requête PATCH et une clé API pour enregistrer une nouvelle valeur.",
+      "fieldKeyScriptHelpAriaLabel": "À propos de l’utilisation de ce champ dans les scripts",
       "fieldType": "Type de champ",
       "dropdownChoices": "Choix déroulants",
       "choiceLabel": "Libellé",

--- a/apps/web/src/locales/it-IT/scripts.json
+++ b/apps/web/src/locales/it-IT/scripts.json
@@ -1035,6 +1035,8 @@
       "variablePlaceholder": "es. vendor_token",
       "fieldLabel": "Chiave del campo personalizzato",
       "fieldPlaceholder": "es. asset_tag",
+      "fieldHelp": "Inserisci la Chiave del campo mostrata in Impostazioni → Campi personalizzati (sensibile a maiuscole/minuscole). Lettura: una volta associato, il valore risolto viene consegnato allo script come un parametro normale: non viene mostrata alcuna richiesta. Scrittura: per salvare un nuovo valore, fai in modo che lo script chiami l'API dei campi personalizzati del dispositivo con una richiesta PATCH e una chiave API.",
+      "fieldHelpAriaLabel": "Informazioni sull'associazione del campo personalizzato del dispositivo",
       "builtinLabel": "Proprietà",
       "chooseTitle": "Scegli una variabile",
       "secretRejected": "\"{{key}}\" è segreta: il salvataggio verrà rifiutato. Scegli una variabile non segreta.",

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -3918,6 +3918,8 @@
       "fieldKey": "Chiave campo",
       "fieldKeyPlaceholder": "ad es. asset_tag",
       "fieldKeyHelp": "Usata in filtri e API. Non può essere modificata dopo la creazione.",
+      "fieldKeyScriptHelp": "Questa chiave è ciò che gli script usano per leggere e scrivere il campo. Lettura: associa l'origine di un parametro dello script a \"Da un campo personalizzato del dispositivo\" usando questa chiave. Scrittura: fai in modo che lo script chiami l'API dei campi personalizzati del dispositivo con una richiesta PATCH e una chiave API per salvare un nuovo valore.",
+      "fieldKeyScriptHelpAriaLabel": "Informazioni sull'uso di questo campo negli script",
       "fieldType": "Tipo campo",
       "dropdownChoices": "Scelte dropdown",
       "choiceLabel": "Etichetta",

--- a/apps/web/src/locales/pt-BR/scripts.json
+++ b/apps/web/src/locales/pt-BR/scripts.json
@@ -1035,6 +1035,8 @@
       "variablePlaceholder": "ex.: vendor_token",
       "fieldLabel": "Chave do campo personalizado",
       "fieldPlaceholder": "ex.: asset_tag",
+      "fieldHelp": "Digite a Chave do Campo exibida em Configurações → Campos Personalizados (diferencia maiúsculas de minúsculas). Leitura: uma vez vinculado, o valor resolvido é entregue ao script como qualquer parâmetro normal — nenhum prompt é exibido. Gravação: para salvar um novo valor, faça o script chamar a API de campos personalizados do dispositivo com uma requisição PATCH e uma chave de API.",
+      "fieldHelpAriaLabel": "Sobre a vinculação de campo personalizado do dispositivo",
       "builtinLabel": "Propriedade",
       "chooseTitle": "Escolher uma variável",
       "secretRejected": "\"{{key}}\" é secreta — o salvamento será rejeitado. Escolha uma variável que não seja secreta.",

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -3923,6 +3923,8 @@
       "fieldKey": "Chave de campo",
       "fieldKeyPlaceholder": "por exemplo, asset_tag",
       "fieldKeyHelp": "Usado em filtros e API. Não pode ser alterado após a criação.",
+      "fieldKeyScriptHelp": "Esta chave é o que os scripts usam para ler e gravar o campo. Leitura: vincule a origem de um parâmetro de script a \"De um campo personalizado do dispositivo\" usando esta chave. Gravação: faça o script chamar a API de campos personalizados do dispositivo com uma requisição PATCH e uma chave de API para salvar um novo valor.",
+      "fieldKeyScriptHelpAriaLabel": "Sobre usar este campo em scripts",
       "fieldType": "Tipo de campo",
       "dropdownChoices": "Opções suspensas",
       "choiceLabel": "Rótulo",

--- a/apps/web/src/locales/tr-TR/scripts.json
+++ b/apps/web/src/locales/tr-TR/scripts.json
@@ -971,6 +971,8 @@
       "variablePlaceholder": "ör. vendor_token",
       "fieldLabel": "Özel alan anahtarı",
       "fieldPlaceholder": "ör. asset_tag",
+      "fieldHelp": "Ayarlar → Özel Alanlar bölümünde gösterilen Alan Anahtarını girin (büyük/küçük harfe duyarlıdır). Okuma: bağlandıktan sonra, çözümlenen değer normal bir parametre gibi betiğe iletilir — herhangi bir istem gösterilmez. Yazma: yeni bir değeri geri kaydetmek için betiğin, bir API anahtarıyla birlikte PATCH isteği kullanarak cihazın özel alan API'sini çağırmasını sağlayın.",
+      "fieldHelpAriaLabel": "Cihaz özel alan bağlaması hakkında",
       "builtinLabel": "Özellik",
       "chooseTitle": "Bir değişken seçin",
       "secretRejected": "\"{{key}}\" bir gizli bilgidir — kaydetme reddedilir. Gizli olmayan bir değişken seçin.",

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -3923,6 +3923,8 @@
       "fieldKey": "Alan Tuşu",
       "fieldKeyPlaceholder": "örneğin, asset_tag",
       "fieldKeyHelp": "Filtrelerde ve API kullanılır. Oluşturulduktan sonra değiştirilemez.",
+      "fieldKeyScriptHelp": "Bu anahtar, betiklerin alanı okumak ve yazmak için kullandığı şeydir. Okuma: bir betik parametresinin kaynağını bu anahtarı kullanarak \"Cihaz özel alanından\" olarak bağlayın. Yazma: yeni bir değeri kaydetmek için betiğin, bir API anahtarıyla birlikte PATCH isteği kullanarak cihazın özel alan API'sini çağırmasını sağlayın.",
+      "fieldKeyScriptHelpAriaLabel": "Bu alanın betiklerde kullanımı hakkında",
       "fieldType": "Alan Türü",
       "dropdownChoices": "Açılır Seçenekler",
       "choiceLabel": "Etiket",


### PR DESCRIPTION
## Summary
- Fast-tracked item from #4198 (decision comment: nav restructure declined, this concrete tooltip/help item split out).
- The custom-field key inputs — on the Script parameter binding UI (source = "From a device custom field") and on the Settings → Custom Fields form — only said "Used in filters and API", with no explanation of *how* a script actually reads or writes the value.
- Adds a `HelpTooltip` (existing shared component) to both inputs:
  - **ScriptForm.tsx**: explains the key must match a Settings → Custom Fields key, that the resolved value is delivered to the script like any other bound parameter, and that a script can write a new value back via a `PATCH` request to the device's custom-fields API with an API key.
  - **CustomFieldsPage.tsx**: explains the same read binding (quoting the actual dropdown label) and the write path, from the field-definition side.
- Translated the four new strings (2 per file) into all 7 supported locales (pt-BR, es-419, fr-FR, fr-CA, de-DE, it-IT, tr-TR), verified against `localeParity.test.ts` (structure, interpolation, protected literals — `PATCH`, `API`).

## Test plan
- [x] `npx vitest run src/components/scripts/ScriptForm.test.tsx` — red before the fix (new assertion), green after (36 passed)
- [x] `npx vitest run src/components/settings/CustomFieldsPage.test.tsx` — new test file, red before the fix, green after (1 passed)
- [x] `npx vitest run src/lib/i18n/localeParity.test.ts` — 79 passed (all 7 non-English locales structurally/technically consistent with the new keys)
- [x] `npx tsc --noEmit -p .` — clean

Closes #4198

🤖 Generated with [Claude Code](https://claude.com/claude-code)