### PR TITLE
fix(api): register local user-helper binaries (#4682)

### DIFF
--- a/apps/api/src/services/binarySync.test.ts
+++ b/apps/api/src/services/binarySync.test.ts
@@ -788,6 +788,124 @@ describe("binarySync", () => {
     });
   });
 
+  // #4682: local mode must register the Windows interactive-session helper
+  // just as the GitHub release path does. Without this row, the helper binary
+  // can exist on disk and be served by the download route while the verified
+  // updater still has no component version to resolve.
+  describe("local-binary user-helper registration (#4682)", () => {
+    function setLocalEnv() {
+      process.env.BINARY_SOURCE = "local";
+      process.env.AGENT_BINARY_DIR = "/fake/agent/bin";
+      process.env.BINARY_VERSION_FILE = "/fake/version";
+      delete process.env.BREEZE_VERSION;
+      fsMocks.stat.mockResolvedValue({ isFile: () => true, size: 4096 } as any);
+      mockReadFileVersionOnly("0.65.9");
+    }
+
+    it("registers a component=user-helper row alongside the agent when the binary is present", async () => {
+      setLocalEnv();
+      fsMocks.readdir.mockResolvedValue([
+        "breeze-agent-windows-amd64.exe",
+        "breeze-user-helper-windows-amd64.exe",
+      ] as any);
+
+      await syncBinaries();
+
+      const insertCalls = dbMocks.insertValues.mock.calls.map(
+        (call: any[]) => call[0] as Record<string, unknown>,
+      );
+      expect(insertCalls.some((v) => v.component === "agent")).toBe(true);
+
+      const userHelperInsert = insertCalls.find(
+        (v) => v.component === "user-helper",
+      );
+      expect(userHelperInsert).toMatchObject({
+        version: "0.65.9",
+        platform: "windows",
+        architecture: "amd64",
+        component: "user-helper",
+        isLatest: true,
+        downloadUrl:
+          "http://localhost:3001/api/v1/agents/download/user-helper/windows/amd64",
+      });
+      expect(JSON.parse(userHelperInsert!.releaseManifest as string)).toMatchObject({
+        version: "0.65.9",
+        component: "user-helper",
+        platform: "windows",
+        arch: "amd64",
+      });
+    });
+
+    it("succeeds without user-helper row when the binary is missing (pre-#816 release backward-compat)", async () => {
+      setLocalEnv();
+      fsMocks.readdir.mockResolvedValue([
+        "breeze-agent-windows-amd64.exe",
+      ] as any);
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      await syncBinaries();
+
+      const insertCalls = dbMocks.insertValues.mock.calls.map(
+        (call: any[]) => call[0] as Record<string, unknown>,
+      );
+      // The agent still registers, while an older volume without the helper
+      // remains a silent no-op just like the GitHub release path.
+      expect(insertCalls.some((v) => v.component === "agent")).toBe(true);
+      expect(insertCalls.some((v) => v.component === "user-helper")).toBe(false);
+      expect(
+        warnSpy.mock.calls.some((args) =>
+          String(args[0] ?? "").includes("user-helper"),
+        ),
+      ).toBe(false);
+      warnSpy.mockRestore();
+    });
+
+    it("isolates user-helper registration failures after the agent succeeds", async () => {
+      setLocalEnv();
+      fsMocks.readdir.mockResolvedValue([
+        "breeze-agent-windows-amd64.exe",
+        "breeze-user-helper-windows-amd64.exe",
+      ] as any);
+      const defaultTxImpl = async (fn: (tx: any) => Promise<void>) =>
+        fn(dbMocks.tx);
+      dbMocks.transaction.mockImplementation(
+        async (fn: (tx: any) => Promise<void>) => {
+          const insertWrap = vi.fn((row: Record<string, unknown>) => {
+            if (row.component === "user-helper") {
+              throw new Error("simulated local user-helper upsert failure");
+            }
+            return (dbMocks.insertValues as any)(row);
+          });
+          return fn({
+            update: dbMocks.tx.update,
+            insert: vi.fn(() => ({ values: insertWrap })),
+          });
+        },
+      );
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      try {
+        await expect(syncBinaries()).resolves.toBeUndefined();
+
+        const insertCalls = dbMocks.insertValues.mock.calls.map(
+          (call: any[]) => call[0] as Record<string, unknown>,
+        );
+        expect(insertCalls.some((v) => v.component === "agent")).toBe(true);
+        expect(insertCalls.some((v) => v.component === "user-helper")).toBe(false);
+        expect(
+          errorSpy.mock.calls.some((args) =>
+            String(args[0] ?? "").includes(
+              "Failed to register local user-helper binaries",
+            ),
+          ),
+        ).toBe(true);
+      } finally {
+        errorSpy.mockRestore();
+        dbMocks.transaction.mockImplementation(defaultTxImpl);
+      }
+    });
+  });
+
   // #1802: the local-binary path historically registered ONLY the agent
   // component, so self-hosters on BINARY_SOURCE=local never got watchdog
   // auto-update. It now also scans + registers breeze-watchdog-* siblings.

--- a/apps/api/src/services/binarySync.ts
+++ b/apps/api/src/services/binarySync.ts
@@ -1029,11 +1029,11 @@ export async function syncBinaries(): Promise<void> {
     }
   }
 
-  // Scan and register agent binaries in DB. The watchdog and backup binaries
-  // ship in the same directory as their per-arch siblings
-  // (breeze-watchdog-{os}-{arch}[.exe], breeze-backup-{os}-{arch}[.exe]) and are
-  // served by the matching /download/watchdog and /download/backup routes.
+  // Scan and register agent binaries in DB. The user-helper, watchdog, and
+  // backup binaries ship in the same directory as their per-arch siblings and
+  // are served by their matching component download routes.
   const binaries = await scanBinaryDir(agentBinaryDir);
+  const userHelperBinaries = await scanBinaryDir(agentBinaryDir, "user-helper");
   const watchdogBinaries = await scanBinaryDir(agentBinaryDir, "watchdog");
   const backupBinaries = await scanBinaryDir(agentBinaryDir, "backup");
 
@@ -1089,6 +1089,57 @@ export async function syncBinaries(): Promise<void> {
       console.log(
         `[binarySync] Registered ${remainingAgentBinaries.length} agent binaries via per-deployment re-signing (version: ${version})`,
       );
+    }
+
+    // #4682: register the Windows user-helper in local mode too. GitHub mode
+    // already registers this companion component, but local deployments only
+    // scanned agent/watchdog/backup binaries and therefore never created the
+    // agent_versions row that heartbeat's verified updater resolves.
+    if (userHelperBinaries.length > 0) {
+      try {
+        let coveredUserHelperFilenames = new Set<string>();
+        let excludedUserHelperFilenames = new Set<string>();
+        if (officialManifest) {
+          const result = await registerFromOfficialManifest({
+            binaries: userHelperBinaries,
+            component: "user-helper",
+            version,
+            manifestBytes: officialManifest.manifestBytes,
+            signatureBytes: officialManifest.signatureBytes,
+            downloadUrlFor: (osParam, arch) =>
+              `${serverUrl}/api/v1/agents/download/user-helper/${osParam}/${arch}`,
+          });
+          coveredUserHelperFilenames = result.registeredFilenames;
+          excludedUserHelperFilenames = result.excludedFilenames;
+          if (coveredUserHelperFilenames.size > 0) {
+            console.log(
+              `[binarySync] Registered ${coveredUserHelperFilenames.size} user-helper binaries from the official release manifest (version: ${version})`,
+            );
+          }
+        }
+        const remainingUserHelperBinaries = userHelperBinaries.filter(
+          (b) =>
+            !coveredUserHelperFilenames.has(b.filename) &&
+            !excludedUserHelperFilenames.has(b.filename),
+        );
+        if (remainingUserHelperBinaries.length > 0) {
+          await registerLocalBinaries({
+            binaries: remainingUserHelperBinaries,
+            component: "user-helper",
+            version,
+            keyId,
+            downloadUrlFor: (osParam, arch) =>
+              `${serverUrl}/api/v1/agents/download/user-helper/${osParam}/${arch}`,
+          });
+          console.log(
+            `[binarySync] Registered ${remainingUserHelperBinaries.length} user-helper binaries via per-deployment re-signing (version: ${version})`,
+          );
+        }
+      } catch (err) {
+        console.error(
+          `[binarySync] Failed to register local user-helper binaries — interactive-session helper auto-update unavailable: ${err instanceof Error ? err.message : err}`,
+        );
+      }
     }
 
     // #1802: register the watchdog component too, so self-hosters on


### PR DESCRIPTION
## Summary

- discover `breeze-user-helper-*` artifacts during local binary sync
- register the helper as `component=user-helper` with the dedicated server-relative download route, preserving official-manifest verification and per-deployment signing fallback
- isolate helper registration failures and add regression coverage for present, absent, and failed-registration cases

## Linked Issues

Closes #4682

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] CI / build / tooling
- [ ] Other:

## Testing

- [x] Existing tests pass (`pnpm test --filter=@breeze/api`: 1,788 files / 32,784 tests passed)
- [x] Added new tests
- [ ] Manual testing

Additional checks:

- `pnpm --filter @breeze/api test --run src/services/binarySync.test.ts`
- `pnpm lint`
- `pnpm exec tsc --noEmit --project apps/api/tsconfig.json`
- `pnpm build --filter=@breeze/api`
- `bash scripts/security/preflight.sh --fast` (all required checks passed; optional unavailable-tool/image checks skipped)

## Checklist

- [x] My code follows the project's code style
- [x] I have reviewed my own changes
- [ ] I have tested on the relevant platforms
- [x] No secrets, credentials, or personal data included
