### PR TITLE
feat(api): populate currentPartnerId on agent DB contexts (#4675)

### DIFF
--- a/apps/api/src/__tests__/integration/agentContextPartnerWideFanout.integration.test.ts
+++ b/apps/api/src/__tests__/integration/agentContextPartnerWideFanout.integration.test.ts
@@ -1,0 +1,512 @@
+/**
+ * #4673 Wave 2 (#4675) — the agent DB context carries `currentPartnerId`, and
+ * that is what makes partner-wide config reachable on agent paths WITHOUT a
+ * system-context escape.
+ *
+ * Wave 1 shipped SELECT-only RLS branches across the configuration-policy
+ * chain:
+ *
+ *   USING (org_id IS NULL AND partner_id = public.breeze_current_partner_id())
+ *
+ * `breeze_current_partner_id()` reads the `breeze.current_partner_id` GUC,
+ * which `db/index.ts` SET LOCALs from `DbAccessContext.currentPartnerId`. Until
+ * Wave 2 the agent context hard-coded that field to `null`, so on agent paths
+ * the branch could never be true: a partner-wide policy read as ZERO ROWS with
+ * no error. That silent-zero is exactly why the agent-facing resolvers had to
+ * escape to a system context (`withPartnerWideVisibility`), which double-holds
+ * a pooled connection and bypasses RLS wholesale (#1105, #2417).
+ *
+ * WHY A SEPARATE FILE FROM agentPolicyResolversPartnerWide.integration.test.ts:
+ * that suite proves the RESOLVERS return partner-wide config, but it passes
+ * today with `currentPartnerId: null` because the resolvers still escalate
+ * internally. It therefore cannot detect whether Wave 2 works. This suite
+ * removes that confound by issuing PLAIN, UN-ESCALATED queries under the agent
+ * context and letting RLS alone decide — which is the precondition Wave 3
+ * depends on before it deletes the escapes.
+ *
+ * The load-bearing test in here is the NEGATIVE CONTROL
+ * ("the pre-Wave-2 agent context sees nothing"): it re-runs the identical query
+ * under an otherwise identical context whose only difference is
+ * `currentPartnerId: null`. Without it, every positive assertion below could be
+ * satisfied by some unrelated policy widening and nobody would notice.
+ *
+ * If this file were deleted: flipping `currentPartnerId` back to `null` in
+ * agentAuth.ts / heartbeat.ts / reliability.ts / agentWs.ts would compile,
+ * pass every unit test (they mock the DB and never evaluate RLS), and pass the
+ * resolver suite (which escalates) — while silently cutting every agent off
+ * from its MSP's shared configuration.
+ */
+import './setup';
+import { afterEach, describe, expect, it } from 'vitest';
+import { randomUUID } from 'crypto';
+import { eq, sql } from 'drizzle-orm';
+import { db, withDbAccessContext, type DbAccessContext } from '../../db';
+import {
+  configurationPolicies,
+  configPolicyFeatureLinks,
+  configPolicyAssignments,
+  configPolicyEventLogSettings,
+  devices,
+  organizations,
+} from '../../db/schema';
+import { buildEventLogConfigUpdate, EVENT_LOG_DEFAULTS } from '../../routes/agents/helpers';
+import { getRedis } from '../../services/redis';
+import { createPartner, createOrganization, createSite } from './db-utils';
+
+const SYSTEM_CTX: DbAccessContext = {
+  scope: 'system',
+  orgId: null,
+  accessibleOrgIds: null,
+  accessiblePartnerIds: null,
+  userId: null,
+};
+
+/**
+ * The POST-Wave-2 agent context, byte-for-byte the shape agentAuth.ts now
+ * builds (and that heartbeat.ts / reliability.ts / agentWs.ts hand-build from
+ * `agent.partnerId`).
+ *
+ * Note `accessiblePartnerIds: []`. That array gates `breeze_has_partner_access`
+ * — the partner-AXIS predicate that admits WRITES. Leaving it empty while
+ * setting `currentPartnerId` is the whole point: read visibility widens, write
+ * capability does not. If a future edit fills this array, the write assertions
+ * further down are what should start failing.
+ */
+function agentContext(orgId: string, partnerId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    currentPartnerId: partnerId,
+    userId: null,
+  };
+}
+
+/** The PRE-Wave-2 agent context — identical except for the one field. */
+function legacyAgentContext(orgId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    currentPartnerId: null,
+    userId: null,
+  };
+}
+
+const createdPolicies: string[] = [];
+const createdDevices: string[] = [];
+
+afterEach(async () => {
+  await withDbAccessContext(SYSTEM_CTX, async () => {
+    for (const id of createdDevices) {
+      await db.delete(devices).where(eq(devices.id, id));
+    }
+    for (const id of createdPolicies) {
+      await db.delete(configurationPolicies).where(eq(configurationPolicies.id, id));
+    }
+  });
+  createdDevices.length = 0;
+  createdPolicies.length = 0;
+});
+
+async function seedDevice(orgId: string, siteId: string) {
+  return withDbAccessContext(SYSTEM_CTX, async () => {
+    const [d] = await db
+      .insert(devices)
+      .values({
+        orgId,
+        siteId,
+        agentId: `agent-${randomUUID()}`,
+        hostname: `host-${randomUUID().slice(0, 8)}`,
+        osType: 'windows',
+        osVersion: '1.0',
+        architecture: 'amd64',
+        agentVersion: '1.0.0',
+        status: 'online',
+        deviceRole: 'workstation',
+      })
+      .returning();
+    createdDevices.push(d!.id);
+    return d!;
+  });
+}
+
+/**
+ * Seeds a partner-wide (`org_id NULL`) event_log policy plus its feature link,
+ * settings row and partner-level assignment — i.e. the whole chain an agent
+ * must traverse, not just the head row.
+ */
+async function seedPartnerWideEventLogPolicy(partnerId: string, maxEventsPerCycle: number) {
+  return withDbAccessContext(SYSTEM_CTX, async () => {
+    const [policy] = await db
+      .insert(configurationPolicies)
+      .values({
+        orgId: null,
+        partnerId,
+        name: `w02 event_log policy ${randomUUID()}`,
+        status: 'active',
+      })
+      .returning();
+    createdPolicies.push(policy!.id);
+    const [link] = await db
+      .insert(configPolicyFeatureLinks)
+      .values({ configPolicyId: policy!.id, featureType: 'event_log' })
+      .returning();
+    const [settings] = await db
+      .insert(configPolicyEventLogSettings)
+      .values({ featureLinkId: link!.id, maxEventsPerCycle })
+      .returning();
+    const [assignment] = await db
+      .insert(configPolicyAssignments)
+      .values({ configPolicyId: policy!.id, level: 'partner', targetId: partnerId, priority: 0 })
+      .returning();
+    return {
+      policyId: policy!.id,
+      linkId: link!.id,
+      settingsId: settings!.id,
+      assignmentId: assignment!.id,
+    };
+  });
+}
+
+/**
+ * Drizzle wraps the driver error, so the pg SQLSTATE lives on `.cause` — a bare
+ * `rejects.toThrow(/42501/)` matches the wrapper's "Failed query: ..." text and
+ * would pass for ANY failure (a typo, a NOT NULL violation). Unwrap and assert
+ * the code.
+ */
+async function captureCause(
+  fn: () => Promise<unknown>,
+): Promise<{ code?: string; message?: string } | undefined> {
+  try {
+    await fn();
+    return undefined;
+  } catch (err) {
+    return (err as { cause?: { code?: string; message?: string } }).cause;
+  }
+}
+
+async function purgeEventLogCache(deviceId: string) {
+  const redis = getRedis();
+  if (!redis) return;
+  await redis.del(`eventlog:settings:device:${deviceId}`);
+}
+
+/** A plain, UN-escalated read of the policy head row under whatever context is active. */
+function readPartnerWidePolicy(policyId: string) {
+  return db
+    .select({ id: configurationPolicies.id, name: configurationPolicies.name })
+    .from(configurationPolicies)
+    .where(eq(configurationPolicies.id, policyId));
+}
+
+describe('#4673 W02 — agent context currentPartnerId unlocks partner-wide reads', () => {
+  // Non-vacuity guard, FIRST. Every negative assertion in this file ("the
+  // foreign partner sees zero rows", "the legacy context sees zero rows", "the
+  // UPDATE affects zero rows") passes trivially if the code-under-test pool is
+  // a BYPASSRLS superuser — and equally, the POSITIVE assertions would pass for
+  // the wrong reason, since a BYPASSRLS role sees partner-wide rows regardless
+  // of the GUC. A worktree missing its `.env.test` is exactly how that happens.
+  // Fail loudly here rather than reporting a green suite that proved nothing.
+  it('runs as a non-BYPASSRLS role with RLS actually enforced', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+
+    const rows = await withDbAccessContext(agentContext(org!.id, partner.id), () =>
+      db.execute(
+        sql`SELECT current_user AS who, rolbypassrls FROM pg_roles WHERE rolname = current_user`,
+      ),
+    );
+    const row = (rows as unknown as Array<{ who: string; rolbypassrls: boolean }>)[0];
+    expect(row?.rolbypassrls).toBe(false);
+  });
+
+  describe('the device auth join resolves the owning MSP', () => {
+    // agentAuth.ts and agentWs.ts both resolve the partner id with
+    // `.from(devices).innerJoin(organizations, eq(organizations.id, devices.orgId))`.
+    // This pins that join against the REAL schema: a wrong join column or a
+    // nullable assumption here would feed a wrong (or null) partner into every
+    // context below, and the unit tests — which mock drizzle entirely — cannot
+    // tell the difference.
+    it('yields the org owning partner for an authenticated device', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const site = await createSite({ orgId: org!.id });
+      const device = await seedDevice(org!.id, site!.id);
+
+      const [row] = await withDbAccessContext(SYSTEM_CTX, () =>
+        db
+          .select({ orgId: devices.orgId, partnerId: organizations.partnerId })
+          .from(devices)
+          .innerJoin(organizations, eq(organizations.id, devices.orgId))
+          .where(eq(devices.agentId, device.agentId))
+          .limit(1),
+      );
+
+      expect(row?.orgId).toBe(org!.id);
+      expect(row?.partnerId).toBe(partner.id);
+    });
+  });
+
+  describe('positive: the agent sees its own MSP partner-wide config with NO escalation', () => {
+    it('reads the partner-wide policy head row under a plain org-scoped context', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const { policyId } = await seedPartnerWideEventLogPolicy(partner.id, 555);
+
+      const rows = await withDbAccessContext(agentContext(org!.id, partner.id), () =>
+        readPartnerWidePolicy(policyId),
+      );
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.id).toBe(policyId);
+    });
+
+    it('reads the whole chain — feature link, settings child and assignment', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const { linkId, settingsId, assignmentId } = await seedPartnerWideEventLogPolicy(
+        partner.id,
+        556,
+      );
+
+      const seen = await withDbAccessContext(agentContext(org!.id, partner.id), async () => {
+        const links = await db
+          .select({ id: configPolicyFeatureLinks.id })
+          .from(configPolicyFeatureLinks)
+          .where(eq(configPolicyFeatureLinks.id, linkId));
+        const settings = await db
+          .select({ id: configPolicyEventLogSettings.id, max: configPolicyEventLogSettings.maxEventsPerCycle })
+          .from(configPolicyEventLogSettings)
+          .where(eq(configPolicyEventLogSettings.id, settingsId));
+        const assignments = await db
+          .select({ id: configPolicyAssignments.id })
+          .from(configPolicyAssignments)
+          .where(eq(configPolicyAssignments.id, assignmentId));
+        return { links, settings, assignments };
+      });
+
+      // The EXISTS-join children route back to configuration_policies, so a
+      // branch present on the head row but missing on a child would show up
+      // here as a partially-visible chain — config that resolves to defaults
+      // for no visible reason.
+      expect(seen.links).toHaveLength(1);
+      expect(seen.settings).toHaveLength(1);
+      expect(seen.settings[0]?.max).toBe(556);
+      expect(seen.assignments).toHaveLength(1);
+    });
+
+    it('delivers the partner-wide value through the real agent config resolver', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const site = await createSite({ orgId: org!.id });
+      const device = await seedDevice(org!.id, site!.id);
+      await purgeEventLogCache(device.id);
+
+      await seedPartnerWideEventLogPolicy(partner.id, 557);
+
+      const result = await withDbAccessContext(agentContext(org!.id, partner.id), () =>
+        buildEventLogConfigUpdate(device.id),
+      );
+
+      // 557 is not the 100 default — the partner-wide policy genuinely resolved
+      // rather than silently falling back.
+      expect(result.max_events_per_cycle).toBe(557);
+      expect(result.max_events_per_cycle).not.toBe(EVENT_LOG_DEFAULTS.maxEventsPerCycle);
+    });
+  });
+
+  describe('negative control: the PRE-Wave-2 context (currentPartnerId null) sees nothing', () => {
+    // This is what makes every positive assertion above non-vacuous. Same
+    // partner, same org, same rows, same query — the ONLY difference is the
+    // field Wave 2 populates. If this ever starts returning rows, the branch is
+    // matching for some reason other than the GUC and the positives prove
+    // nothing.
+    it('returns zero rows for the identical query with currentPartnerId null', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const { policyId } = await seedPartnerWideEventLogPolicy(partner.id, 558);
+
+      const withPartner = await withDbAccessContext(agentContext(org!.id, partner.id), () =>
+        readPartnerWidePolicy(policyId),
+      );
+      const withoutPartner = await withDbAccessContext(legacyAgentContext(org!.id), () =>
+        readPartnerWidePolicy(policyId),
+      );
+
+      expect(withPartner).toHaveLength(1);
+      expect(withoutPartner).toHaveLength(0);
+    });
+
+    it('confirms the GUC is what the branch keys on', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+
+      const guc = await withDbAccessContext(agentContext(org!.id, partner.id), () =>
+        db.execute(sql`select public.breeze_current_partner_id() as pid`),
+      );
+      const legacyGuc = await withDbAccessContext(legacyAgentContext(org!.id), () =>
+        db.execute(sql`select public.breeze_current_partner_id() as pid`),
+      );
+
+      expect((guc as unknown as Array<{ pid: string | null }>)[0]?.pid).toBe(partner.id);
+      // Fail-closed: an empty GUC resolves to NULL, and `partner_id = NULL` is
+      // never true — it does not error, it just matches nothing.
+      expect((legacyGuc as unknown as Array<{ pid: string | null }>)[0]?.pid).toBeNull();
+    });
+  });
+
+  describe('isolation: a FOREIGN MSP partner-wide config stays invisible', () => {
+    it('does not leak partner Q rows to an agent of partner P', async () => {
+      const partnerP = await createPartner();
+      const orgP = await createOrganization({ partnerId: partnerP.id });
+      const partnerQ = await createPartner();
+      const { policyId: qPolicyId } = await seedPartnerWideEventLogPolicy(partnerQ.id, 559);
+
+      const rows = await withDbAccessContext(agentContext(orgP!.id, partnerP.id), () =>
+        readPartnerWidePolicy(qPolicyId),
+      );
+
+      expect(rows).toHaveLength(0);
+    });
+
+    it('does not deliver a foreign MSP partner-wide policy through the resolver', async () => {
+      const partnerP = await createPartner();
+      const orgP = await createOrganization({ partnerId: partnerP.id });
+      const siteP = await createSite({ orgId: orgP!.id });
+      const deviceP = await seedDevice(orgP!.id, siteP!.id);
+      await purgeEventLogCache(deviceP.id);
+
+      const partnerQ = await createPartner();
+      await seedPartnerWideEventLogPolicy(partnerQ.id, 560);
+
+      const result = await withDbAccessContext(agentContext(orgP!.id, partnerP.id), () =>
+        buildEventLogConfigUpdate(deviceP.id),
+      );
+
+      expect(result.max_events_per_cycle).toBe(EVENT_LOG_DEFAULTS.maxEventsPerCycle);
+      expect(result.max_events_per_cycle).not.toBe(560);
+    });
+  });
+
+  describe('the widening is READ-ONLY: writes are not targetable', () => {
+    // Wave 1's branches are FOR SELECT. Postgres does not consult FOR SELECT
+    // policies when computing UPDATE/DELETE target rows, so a partner-wide row
+    // an agent can READ must still be un-writable. RLS hides it from the write
+    // command silently — 0 rows affected, NOT a 42501 — so these assertions
+    // MUST check the row count. Asserting "no error" would pass trivially.
+    it('UPDATE against a visible partner-wide policy affects zero rows', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const { policyId } = await seedPartnerWideEventLogPolicy(partner.id, 561);
+
+      const { visible, updated } = await withDbAccessContext(
+        agentContext(org!.id, partner.id),
+        async () => {
+          const visible = await readPartnerWidePolicy(policyId);
+          const updated = await db
+            .update(configurationPolicies)
+            .set({ name: 'hijacked-by-agent' })
+            .where(eq(configurationPolicies.id, policyId))
+            .returning({ id: configurationPolicies.id });
+          return { visible, updated };
+        },
+      );
+
+      expect(visible).toHaveLength(1); // readable ...
+      expect(updated).toHaveLength(0); // ... but not writable.
+
+      // And the row is genuinely untouched, checked from a system context so
+      // the assertion cannot itself be fooled by RLS.
+      const [after] = await withDbAccessContext(SYSTEM_CTX, () =>
+        db
+          .select({ name: configurationPolicies.name })
+          .from(configurationPolicies)
+          .where(eq(configurationPolicies.id, policyId)),
+      );
+      expect(after?.name).not.toBe('hijacked-by-agent');
+    });
+
+    it('DELETE against a visible partner-wide policy affects zero rows', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const { policyId } = await seedPartnerWideEventLogPolicy(partner.id, 562);
+
+      const deleted = await withDbAccessContext(agentContext(org!.id, partner.id), () =>
+        db
+          .delete(configurationPolicies)
+          .where(eq(configurationPolicies.id, policyId))
+          .returning({ id: configurationPolicies.id }),
+      );
+      expect(deleted).toHaveLength(0);
+
+      const survivors = await withDbAccessContext(SYSTEM_CTX, () =>
+        db
+          .select({ id: configurationPolicies.id })
+          .from(configurationPolicies)
+          .where(eq(configurationPolicies.id, policyId)),
+      );
+      expect(survivors).toHaveLength(1);
+    });
+
+    it('INSERT of a forged partner-wide policy is refused (42501)', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+
+      // An agent can now READ this partner's partner-wide rows; it must still
+      // be unable to MINT one. Wave 1 touched no INSERT policy / WITH CHECK, so
+      // this is the loud failure mode (unlike UPDATE/DELETE above, which are
+      // silent 0-row no-ops).
+      const cause = await captureCause(() =>
+        withDbAccessContext(agentContext(org!.id, partner.id), () =>
+          db.insert(configurationPolicies).values({
+            orgId: null,
+            partnerId: partner.id,
+            name: `forged by agent ${randomUUID()}`,
+            status: 'active',
+          }),
+        ),
+      );
+
+      expect(cause?.code).toBe('42501');
+      expect(cause?.message).toMatch(/new row violates row-level security policy/i);
+    });
+  });
+
+  describe('org-owned rows are unaffected by the new branch', () => {
+    it('still sees its own org policies, and still cannot see another org rows', async () => {
+      const partner = await createPartner();
+      const orgA = await createOrganization({ partnerId: partner.id });
+      const orgB = await createOrganization({ partnerId: partner.id });
+
+      const [policyA] = await withDbAccessContext(SYSTEM_CTX, () =>
+        db
+          .insert(configurationPolicies)
+          .values({ orgId: orgA!.id, partnerId: null, name: `org A ${randomUUID()}`, status: 'active' })
+          .returning(),
+      );
+      createdPolicies.push(policyA!.id);
+      const [policyB] = await withDbAccessContext(SYSTEM_CTX, () =>
+        db
+          .insert(configurationPolicies)
+          .values({ orgId: orgB!.id, partnerId: null, name: `org B ${randomUUID()}`, status: 'active' })
+          .returning(),
+      );
+      createdPolicies.push(policyB!.id);
+
+      const seen = await withDbAccessContext(agentContext(orgA!.id, partner.id), async () => ({
+        own: await readPartnerWidePolicy(policyA!.id),
+        // Same partner, DIFFERENT org. The new branch is `org_id IS NULL AND
+        // partner_id = ...`; if it were ever loosened to "same partner", this
+        // sibling org's row would become visible and cross-tenant isolation
+        // inside one MSP would be gone.
+        sibling: await readPartnerWidePolicy(policyB!.id),
+      }));
+
+      expect(seen.own).toHaveLength(1);
+      expect(seen.sibling).toHaveLength(0);
+    });
+  });
+});

--- a/apps/api/src/__tests__/integration/agentWs-consent-ingest.integration.test.ts
+++ b/apps/api/src/__tests__/integration/agentWs-consent-ingest.integration.test.ts
@@ -38,11 +38,12 @@ async function sendDeskStartResult(
   agentId: string,
   deviceId: string,
   orgId: string,
+  partnerId: string,
   sessionId: string,
   result: Record<string, unknown>,
   status: 'completed' | 'failed' = 'completed',
 ): Promise<void> {
-  const handlers = createAgentWsHandlers(agentId, { deviceId, orgId });
+  const handlers = createAgentWsHandlers(agentId, { deviceId, orgId, partnerId });
   const event = {
     data: JSON.stringify({
       type: 'command_result',
@@ -130,7 +131,7 @@ describe('agentWs consent ingestion (real onMessage, breeze_app)', () => {
     const dev = await insertDevice(env.organization.id, env.site.id);
     const sessionId = await insertSession({ deviceId: dev.id, orgId: env.organization.id, userId: env.user.id });
 
-    await sendDeskStartResult(dev.agentId, dev.id, env.organization.id, sessionId, {
+    await sendDeskStartResult(dev.agentId, dev.id, env.organization.id, env.partner.id, sessionId, {
       event: 'consent_denied',
       sessionId,
       reason: 'user',
@@ -147,7 +148,7 @@ describe('agentWs consent ingestion (real onMessage, breeze_app)', () => {
     const dev = await insertDevice(env.organization.id, env.site.id);
     const sessionId = await insertSession({ deviceId: dev.id, orgId: env.organization.id, userId: env.user.id });
 
-    await sendDeskStartResult(dev.agentId, dev.id, env.organization.id, sessionId, {
+    await sendDeskStartResult(dev.agentId, dev.id, env.organization.id, env.partner.id, sessionId, {
       event: 'consent_denied',
       sessionId,
       reason: 'no_user',
@@ -170,7 +171,7 @@ describe('agentWs consent ingestion (real onMessage, breeze_app)', () => {
     const sessionId = await insertSession({ deviceId: devA.id, orgId: env.organization.id, userId: env.user.id });
 
     // devB's agent reports a denial for devA's session.
-    await sendDeskStartResult(devB.agentId, devB.id, env.organization.id, sessionId, {
+    await sendDeskStartResult(devB.agentId, devB.id, env.organization.id, env.partner.id, sessionId, {
       event: 'consent_denied',
       sessionId,
       reason: 'user',
@@ -188,7 +189,7 @@ describe('agentWs consent ingestion (real onMessage, breeze_app)', () => {
     const dev = await insertDevice(env.organization.id, env.site.id);
     const sessionId = await insertSession({ deviceId: dev.id, orgId: env.organization.id, userId: env.user.id, status: 'active' });
 
-    await sendDeskStartResult(dev.agentId, dev.id, env.organization.id, sessionId, {
+    await sendDeskStartResult(dev.agentId, dev.id, env.organization.id, env.partner.id, sessionId, {
       event: 'consent_denied',
       sessionId,
       reason: 'user',
@@ -206,7 +207,7 @@ describe('agentWs consent ingestion (real onMessage, breeze_app)', () => {
     const dev = await insertDevice(env.organization.id, env.site.id);
     const sessionId = await insertSession({ deviceId: dev.id, orgId: env.organization.id, userId: env.user.id });
 
-    await sendDeskStartResult(dev.agentId, dev.id, env.organization.id, sessionId, {
+    await sendDeskStartResult(dev.agentId, dev.id, env.organization.id, env.partner.id, sessionId, {
       sessionId,
       answer: 'v=0\r\no=- 0 0 IN IP4 0.0.0.0\r\n', // minimal SDP-ish string
       consentReason: 'user',

--- a/apps/api/src/__tests__/integration/lateCommandResultRecovery.integration.test.ts
+++ b/apps/api/src/__tests__/integration/lateCommandResultRecovery.integration.test.ts
@@ -58,6 +58,7 @@ const fakeWs = { send: () => {} } as unknown as Parameters<
 
 interface Fixture {
   orgId: string;
+  partnerId: string;
   siteId: string;
   deviceId: string;
   agentId: string;
@@ -101,6 +102,7 @@ async function makeFixture(): Promise<Fixture> {
 
   return {
     orgId: env.organization.id,
+    partnerId: env.partner.id,
     siteId: env.site.id,
     deviceId: device.id,
     agentId,
@@ -172,6 +174,7 @@ async function sendWsResult(
   const handlers = createAgentWsHandlers(fx.agentId, {
     deviceId: fx.deviceId,
     orgId: fx.orgId,
+    partnerId: fx.partnerId,
   });
   const event = {
     data: JSON.stringify({ type: 'command_result', commandId, ...body }),
@@ -200,6 +203,7 @@ async function sendHttpResult(
       deviceId: fx.deviceId,
       agentId: fx.agentId,
       orgId: fx.orgId,
+      partnerId: fx.partnerId,
       siteId: fx.siteId,
       role: 'agent',
     });

--- a/apps/api/src/__tests__/integration/pamActuationResults.integration.test.ts
+++ b/apps/api/src/__tests__/integration/pamActuationResults.integration.test.ts
@@ -11,7 +11,7 @@ import { getTestDb } from './setup';
 import { createOrganization, createPartner } from './db-utils';
 
 type Fixture = {
-  orgId: string; siteId: string; deviceId: string; requestId: string; actuationId: string;
+  orgId: string; partnerId: string; siteId: string; deviceId: string; requestId: string; actuationId: string;
   commandId: string; agentId: string;
 };
 
@@ -51,8 +51,8 @@ async function createFixture(): Promise<Fixture> {
     )
     SELECT device.id AS "deviceId", device.site_id AS "siteId", request.id AS "requestId", command.id AS "commandId",
            actuation.id AS "actuationId" FROM device, request, command, actuation
-  `) as unknown as Array<Omit<Fixture, 'orgId' | 'agentId'>>;
-  return { orgId: org.id, agentId, ...row! };
+  `) as unknown as Array<Omit<Fixture, 'orgId' | 'agentId' | 'partnerId'>>;
+  return { orgId: org.id, partnerId: partner.id, agentId, ...row! };
 }
 
 function resultFor(fixture: Fixture, overrides: Partial<PamAgentResultV2> = {}): PamAgentResultV2 {
@@ -69,6 +69,7 @@ function restApp(fixture: Fixture): Hono {
     c.set('agent', {
       deviceId: fixture.deviceId,
       orgId: fixture.orgId,
+      partnerId: fixture.partnerId,
       agentId: fixture.agentId,
       siteId: fixture.siteId,
       role: 'agent',

--- a/apps/api/src/__tests__/integration/pamReceivedObservation.integration.test.ts
+++ b/apps/api/src/__tests__/integration/pamReceivedObservation.integration.test.ts
@@ -21,6 +21,7 @@ vi.mock('../../services/pamReconciliationRateLimit', () => ({
 
 type Fixture = {
   orgId: string;
+  partnerId: string;
   siteId: string;
   deviceId: string;
   requestId: string;
@@ -87,8 +88,8 @@ async function createFixture(): Promise<Fixture> {
            request.id AS "requestId", command.id AS "commandId",
            actuation.id AS "actuationId"
     FROM device, request, command, actuation
-  `) as unknown as Array<Omit<Fixture, 'orgId' | 'agentId'>>;
-  return { orgId: org.id, agentId, ...row! };
+  `) as unknown as Array<Omit<Fixture, 'orgId' | 'agentId' | 'partnerId'>>;
+  return { orgId: org.id, partnerId: partner.id, agentId, ...row! };
 }
 
 function receivedFor(fixture: Fixture): PamAgentResultV2 & { state: 'received' } {
@@ -123,6 +124,7 @@ function appFor(fixture: Fixture): Hono {
     c.set('agent', {
       deviceId: fixture.deviceId,
       orgId: fixture.orgId,
+      partnerId: fixture.partnerId,
       agentId: fixture.agentId,
       siteId: fixture.siteId,
       role: 'agent',

--- a/apps/api/src/middleware/agentAuth.test.ts
+++ b/apps/api/src/middleware/agentAuth.test.ts
@@ -28,6 +28,11 @@ vi.mock('../db/schema', () => ({
     lastSeenIp: 'lastSeenIp',
     mtlsCertSerialNumber: 'mtlsCertSerialNumber',
   },
+  // #4673 W02 — the device auth select inner-joins this for the owning MSP.
+  organizations: {
+    id: 'organizations.id',
+    partnerId: 'organizations.partnerId',
+  },
   // Security remediation Wave 5, Task 6 — services/agentCertificateBinding.ts
   // (imported transitively via agentAuthMiddleware) reads this table.
   deviceMtlsCertificates: {
@@ -276,11 +281,19 @@ const VALID_TOKEN = 'brz_test_token';
 const VALID_HASH = sha(VALID_TOKEN);
 
 function buildSelectMock(result: unknown[]) {
+  // #4673 W02 — the device auth select is now
+  // `.from(devices).innerJoin(organizations, ...).where(...).limit(1)`.
+  // `innerJoin` returns the same terminal shape so callers that do NOT join
+  // (the certificate-binding lookups) keep working against this mock.
+  const terminal = {
+    where: vi.fn().mockReturnValue({
+      limit: vi.fn().mockResolvedValue(result),
+    }),
+  };
   vi.mocked(db.select).mockReturnValue({
     from: vi.fn().mockReturnValue({
-      where: vi.fn().mockReturnValue({
-        limit: vi.fn().mockResolvedValue(result),
-      }),
+      innerJoin: vi.fn().mockReturnValue(terminal),
+      ...terminal,
     }),
   } as any);
 }
@@ -291,6 +304,10 @@ function makeDevice(overrides: Record<string, unknown> = {}) {
     agentId: 'agent-1',
     orgId: 'org-1',
     siteId: 'site-1',
+    // #4673 W02 — the device auth select now inner-joins `organizations` to
+    // pull the owning MSP's partner id. `organizations.partner_id` is NOT
+    // NULL, so a real join always yields a value here.
+    partnerId: 'partner-1',
     agentTokenHash: VALID_HASH,
     previousTokenHash: null,
     previousTokenExpiresAt: null,
@@ -436,6 +453,127 @@ describe('agentAuthMiddleware - tenant-status gate', () => {
   });
 });
 
+// #4673 Wave 2 (#4675) — populate `currentPartnerId` on the agent DB context.
+//
+// Wave 1 shipped a SELECT-only RLS branch
+// `(org_id IS NULL AND partner_id = public.breeze_current_partner_id())` across
+// the whole configuration-policy chain. That branch reads the
+// `breeze.current_partner_id` GUC, which `db/index.ts` SET LOCALs from
+// `DbAccessContext.currentPartnerId`. The agent context hard-coded that field
+// to `null`, so for agents the branch could never be true and partner-wide
+// config was invisible — which is exactly why the agent-facing resolvers had to
+// escape to a system context (`withPartnerWideVisibility`).
+//
+// These tests pin BOTH halves of the fix and, just as importantly, the part
+// that must NOT change: the GUC feeds SELECT-only policies, so `partnerId`
+// widens READS to the device's own MSP and nothing else. `accessiblePartnerIds`
+// stays `[]`, which is what gates `breeze_has_partner_access` — the partner-AXIS
+// (write-capable) predicate. If a future edit "helpfully" fills
+// `accessiblePartnerIds` too, agents gain write targeting on partner-axis tables;
+// the assertion below is the tripwire for that.
+describe('agentAuthMiddleware - currentPartnerId population (#4673 W02)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    vi.mocked(getRedis).mockReturnValue({} as any);
+    vi.mocked(getAgentTenantState).mockResolvedValue('active');
+    vi.mocked(rateLimiter).mockResolvedValue({
+      allowed: true,
+      remaining: 100,
+      resetAt: Date.now() + 60_000,
+    } as any);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('sets currentPartnerId on the request-long org context from the device org partner', async () => {
+    buildSelectMock([makeDevice()]);
+
+    const c = createContext({
+      token: VALID_TOKEN,
+      path: '/api/v1/agents/agent-1/commands/cmd-1/result',
+    });
+    const next = vi.fn().mockResolvedValue(undefined);
+
+    await agentAuthMiddleware(c, next);
+
+    expect(vi.mocked(withDbAccessContext)).toHaveBeenCalledTimes(1);
+    const dbContext = vi.mocked(withDbAccessContext).mock.calls[0]?.[0] as unknown as Record<string, unknown>;
+    expect(dbContext.currentPartnerId).toBe('partner-1');
+    expect(dbContext.scope).toBe('organization');
+    expect(dbContext.orgId).toBe('org-1');
+  });
+
+  it('does NOT widen the partner-AXIS write capability when populating currentPartnerId', async () => {
+    buildSelectMock([makeDevice()]);
+
+    const c = createContext({
+      token: VALID_TOKEN,
+      path: '/api/v1/agents/agent-1/commands/cmd-1/result',
+    });
+
+    await agentAuthMiddleware(c, vi.fn().mockResolvedValue(undefined));
+
+    const dbContext = vi.mocked(withDbAccessContext).mock.calls[0]?.[0] as unknown as Record<string, unknown>;
+    // The read branch is SELECT-only; the write axis must stay empty.
+    expect(dbContext.accessiblePartnerIds).toEqual([]);
+    expect(dbContext.accessibleOrgIds).toEqual(['org-1']);
+  });
+
+  // The three SELF_MANAGED_DB_CONTEXT_ACTIONS routes (heartbeat, reliability,
+  // commands) skip the request-long wrap and hand-build their own org context.
+  // They can only populate `currentPartnerId` if the middleware surfaces the
+  // partner id on the agent context — so it must be there even on the routes
+  // where the middleware itself opens no transaction at all.
+  it('surfaces partnerId on the agent context for the self-managed heartbeat route', async () => {
+    buildSelectMock([makeDevice()]);
+
+    const c = createContext({ token: VALID_TOKEN, path: '/api/v1/agents/agent-1/heartbeat' });
+    const next = vi.fn().mockResolvedValue(undefined);
+
+    await agentAuthMiddleware(c, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    // Middleware opened no wrap of its own for this route ...
+    expect(vi.mocked(withDbAccessContext)).not.toHaveBeenCalled();
+    // ... so the handler must be able to build one itself.
+    expect((c.get('agent') as unknown as { partnerId: string }).partnerId).toBe('partner-1');
+    expect((c.get('agent') as unknown as { orgId: string }).orgId).toBe('org-1');
+  });
+
+  it('surfaces partnerId on the agent context for the self-managed reliability route', async () => {
+    buildSelectMock([makeDevice()]);
+
+    const c = createContext({ token: VALID_TOKEN, path: '/api/v1/agents/agent-1/reliability' });
+
+    await agentAuthMiddleware(c, vi.fn().mockResolvedValue(undefined));
+
+    expect((c.get('agent') as unknown as { partnerId: string }).partnerId).toBe('partner-1');
+  });
+
+  // Devices in a DIFFERENT org must carry THAT org's partner, never a stale or
+  // hard-coded one. A join that silently resolved to the wrong row would hand an
+  // agent read visibility into a foreign MSP's partner-wide config — the exact
+  // cross-tenant shape this whole chain exists to prevent.
+  it('carries the joined partner id of the device own org, not a fixed value', async () => {
+    buildSelectMock([makeDevice({ orgId: 'org-9', partnerId: 'partner-9' })]);
+
+    const c = createContext({
+      token: VALID_TOKEN,
+      path: '/api/v1/agents/agent-1/commands/cmd-1/result',
+    });
+
+    await agentAuthMiddleware(c, vi.fn().mockResolvedValue(undefined));
+
+    const dbContext = vi.mocked(withDbAccessContext).mock.calls[0]?.[0] as unknown as Record<string, unknown>;
+    expect(dbContext.currentPartnerId).toBe('partner-9');
+    expect(dbContext.orgId).toBe('org-9');
+    expect((c.get('agent') as unknown as { partnerId: string }).partnerId).toBe('partner-9');
+  });
+});
+
 // Security remediation Wave 5, Task 6 — the shared certificate/device
 // binding decision (services/agentCertificateBinding.ts) runs inside
 // agentAuthMiddleware after bearer + tenant-status checks. Sequenced select
@@ -445,12 +583,18 @@ const ACTIVE_SERIAL = 'AABBCCDDEEFF00112233';
 const OTHER_SERIAL = '00112233AABBCCDDEEFF';
 
 function queueSelectOnce(rows: unknown[]) {
+  // See buildSelectMock — `.innerJoin(...)` must be chainable for the device
+  // auth select (#4673 W02) without disturbing the un-joined lookups.
+  const terminal = {
+    where: vi.fn().mockReturnValue({
+      limit: vi.fn().mockResolvedValue(rows),
+      orderBy: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) }),
+    }),
+  };
   vi.mocked(db.select).mockReturnValueOnce({
     from: vi.fn().mockReturnValue({
-      where: vi.fn().mockReturnValue({
-        limit: vi.fn().mockResolvedValue(rows),
-        orderBy: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) }),
-      }),
+      innerJoin: vi.fn().mockReturnValue(terminal),
+      ...terminal,
     }),
   } as any);
 }

--- a/apps/api/src/middleware/agentAuth.ts
+++ b/apps/api/src/middleware/agentAuth.ts
@@ -3,7 +3,7 @@ import { HTTPException } from 'hono/http-exception';
 import { createHash, timingSafeEqual } from 'crypto';
 import { and, eq, isNull } from 'drizzle-orm';
 import { db, withDbAccessContext, withSystemDbAccessContext } from '../db';
-import { devices } from '../db/schema';
+import { devices, organizations } from '../db/schema';
 import { getRedis, rateLimiter } from '../services';
 import { type AgentTokenSuspendReason } from '../services/agentTokenSuspension';
 import { enforceAgentCertificateBinding, readAgentCertificateAssertion } from '../services/agentCertificateBinding';
@@ -23,6 +23,24 @@ export interface AgentAuthContext {
   agentId: string;
   orgId: string;
   siteId: string;
+  /**
+   * #4673 W02 — the partner (MSP) that OWNS this device's organization,
+   * resolved by the device auth select's join to `organizations`.
+   * `organizations.partner_id` is NOT NULL, so this is always populated for an
+   * authenticated agent.
+   *
+   * Its ONLY job is to feed `DbAccessContext.currentPartnerId`, which
+   * `db/index.ts` SET LOCALs as the `breeze.current_partner_id` GUC. Wave 1 of
+   * #4673 added SELECT-ONLY RLS branches
+   * (`org_id IS NULL AND partner_id = public.breeze_current_partner_id()`)
+   * across the configuration-policy chain, so this widens agent READS to its
+   * own MSP's partner-wide config rows and nothing else.
+   *
+   * It is NOT a write capability and must never be spread into
+   * `accessiblePartnerIds` — that array gates `breeze_has_partner_access`, the
+   * partner-AXIS predicate that DOES admit writes. Agents stay `[]` there.
+   */
+  partnerId: string;
   role: AgentCredentialRole;
   /**
    * SHA-256 hex of the bearer token that actually authenticated this request —
@@ -514,8 +532,16 @@ export async function agentAuthMiddleware(c: Context, next: Next) {
         agentTokenSuspendedAt: devices.agentTokenSuspendedAt,
         hostname: devices.hostname,
         lastSeenIp: devices.lastSeenIp,
+        // #4673 W02 — the owning MSP, for `currentPartnerId`. An INNER join is
+        // correct rather than a LEFT one: `devices.org_id` and
+        // `organizations.partner_id` are both NOT NULL with an FK between them,
+        // so a device whose org row is missing is not an agent we should
+        // authenticate at all. A LEFT join would instead hand that device a
+        // NULL partner and silently degrade it to the pre-W02 blind behaviour.
+        partnerId: organizations.partnerId,
       })
       .from(devices)
+      .innerJoin(organizations, eq(organizations.id, devices.orgId))
       .where(eq(devices.agentId, agentId))
       .limit(1);
     return row ?? null;
@@ -857,6 +883,11 @@ export async function agentAuthMiddleware(c: Context, next: Next) {
     agentId: device.agentId,
     orgId: device.orgId,
     siteId: device.siteId,
+    // #4673 W02 — surfaced here (not just baked into the wrap below) because
+    // the three SELF_MANAGED_DB_CONTEXT_ACTIONS routes skip that wrap and
+    // hand-build their own org context; they read this to populate
+    // `currentPartnerId` themselves.
+    partnerId: device.partnerId,
     role: match.role,
     // The exact hash that authenticated this request (current token). For a
     // rotation-required previous-token match this is still the previous-token
@@ -905,17 +936,25 @@ export async function agentAuthMiddleware(c: Context, next: Next) {
       scope: 'organization',
       orgId: device.orgId,
       accessibleOrgIds: [device.orgId],
-      // Agents are org-scoped; they have no access to partner-level tables.
+      // Agents have no partner-AXIS access: this array gates
+      // `breeze_has_partner_access`, which admits WRITES to partner-owned rows.
+      // It stays empty. `currentPartnerId` below is a strictly separate,
+      // read-only axis — do not merge the two.
       accessiblePartnerIds: [],
-      // Agents don't browse the catalog as org users and partnerId isn't in
-      // scope here; null disables EVERY partner-wide read branch (catalog,
-      // cis_baselines, tenant_variables, and as of #2468 the whole
-      // configuration-policy chain). Fail-closed: `partner_id = NULL` is NULL,
-      // never true. Agent paths that must see partner-wide config therefore
-      // still escalate to a system context — wave 2 of #4673 populates this
-      // field from the device org's partner and removes those escalations.
-      // Do not flip it to a real partner id without that wave's sweep.
-      currentPartnerId: null
+      // #4673 W02 — the device org's owning MSP, from the `organizations` join
+      // in the auth select above. Feeds the `breeze.current_partner_id` GUC,
+      // which Wave 1's SELECT-ONLY branches
+      // (`org_id IS NULL AND partner_id = breeze_current_partner_id()`) read
+      // across the configuration-policy chain, plus the pre-existing catalog /
+      // cis_baselines / tenant_variables branches.
+      //
+      // This lets an agent SEE its own MSP's partner-wide config directly,
+      // which is what removes the need for the nested system-context escapes
+      // on agent paths (`withPartnerWideVisibility`) in Wave 3. Because every
+      // consuming policy is FOR SELECT, it grants no write targeting: a
+      // foreign partner's rows stay invisible, and UPDATE/DELETE still see
+      // only the org-owned rows they saw before.
+      currentPartnerId: device.partnerId
     },
     async () => {
       await next();

--- a/apps/api/src/routes/agentWs.test.ts
+++ b/apps/api/src/routes/agentWs.test.ts
@@ -32,6 +32,14 @@ vi.mock('../db', () => ({
 }));
 
 vi.mock('../db/schema', () => ({
+  // #4673 W02 — validateAgentToken innerJoins organizations to resolve the
+  // owning MSP's partnerId; the query is fully mocked at each call site, but
+  // the module still evaluates `organizations.partnerId` when building the
+  // select projection, so the mock needs the export to exist.
+  organizations: {
+    id: 'organizations.id',
+    partnerId: 'organizations.partnerId',
+  },
   devices: {
     id: 'devices.id',
     agentId: 'devices.agentId',
@@ -430,7 +438,7 @@ async function connectAgentSocket(
  */
 async function connectedAgent(
   agentId: string,
-  preValidatedAgent: { deviceId: string; orgId: string },
+  preValidatedAgent: { deviceId: string; orgId: string; partnerId: string },
 ) {
   const handlers = createAgentWsHandlers(agentId, preValidatedAgent);
   const ws = wsMock();
@@ -452,7 +460,7 @@ describe('partner-trust WebSocket fast path', () => {
     vi.mocked(partnerTrustMode).mockReturnValue('off');
     const { ws } = await connectedAgent(
       'trust-agent-off',
-      { deviceId: 'device-trust-off', orgId: 'org-trust-off' },
+      { deviceId: 'device-trust-off', orgId: 'org-trust-off', partnerId: 'partner-trust-off' },
     );
 
     expect(partnerIdForDevice).not.toHaveBeenCalled();
@@ -473,7 +481,7 @@ describe('partner-trust WebSocket fast path', () => {
 
     const { ws } = await connectedAgent(
       'trust-agent-null-partner',
-      { deviceId: 'device-null-partner', orgId: 'org-null-partner' },
+      { deviceId: 'device-null-partner', orgId: 'org-null-partner', partnerId: 'partner-null-partner' },
     );
 
     expect(ws.close).not.toHaveBeenCalled();
@@ -494,7 +502,7 @@ describe('partner-trust WebSocket fast path', () => {
 
     const { ws } = await connectedAgent(
       'trust-agent-null-row',
-      { deviceId: 'device-null-row', orgId: 'org-null-row' },
+      { deviceId: 'device-null-row', orgId: 'org-null-row', partnerId: 'partner-null-row' },
     );
 
     expect(ws.close).not.toHaveBeenCalled();
@@ -514,7 +522,7 @@ describe('partner-trust WebSocket fast path', () => {
 
     const { ws } = await connectedAgent(
       'trust-agent-throw',
-      { deviceId: 'device-trust-throw', orgId: 'org-trust-throw' },
+      { deviceId: 'device-trust-throw', orgId: 'org-trust-throw', partnerId: 'partner-trust-throw' },
     );
 
     expect(ws.close).not.toHaveBeenCalled();
@@ -567,6 +575,7 @@ describe('validateAgentToken — tenant-status gate', () => {
   const deviceRow = {
     id: 'device-1',
     orgId: 'org-1',
+    partnerId: 'partner-1',
     agentTokenHash: createHash('sha256').update(TOKEN).digest('hex'),
     previousTokenHash: null,
     previousTokenExpiresAt: null,
@@ -580,7 +589,9 @@ describe('validateAgentToken — tenant-status gate', () => {
   function queueDeviceSelect(row: unknown | undefined) {
     vi.mocked(db.select).mockReturnValueOnce({
       from: vi.fn(() => ({
-        where: vi.fn(() => ({ limit: vi.fn().mockResolvedValue(row ? [row] : []) })),
+        innerJoin: vi.fn(() => ({
+          where: vi.fn(() => ({ limit: vi.fn().mockResolvedValue(row ? [row] : []) })),
+        })),
       })),
     } as any);
   }
@@ -595,7 +606,7 @@ describe('validateAgentToken — tenant-status gate', () => {
 
     const result = await validateAgentToken('agent-1', TOKEN);
 
-    expect(result).toEqual({ ok: true, ctx: { deviceId: 'device-1', orgId: 'org-1', role: 'agent' } });
+    expect(result).toEqual({ ok: true, ctx: { deviceId: 'device-1', orgId: 'org-1', partnerId: 'partner-1', role: 'agent' } });
     expect(getAgentTenantState).toHaveBeenCalledWith('org-1');
   });
 
@@ -632,6 +643,7 @@ describe('validateAgentToken — certificate/device binding (Wave 5 Task 6)', ()
   const deviceRow = {
     id: 'device-1',
     orgId: 'org-1',
+    partnerId: 'partner-1',
     agentTokenHash: createHash('sha256').update(TOKEN).digest('hex'),
     previousTokenHash: null,
     previousTokenExpiresAt: null,
@@ -641,6 +653,20 @@ describe('validateAgentToken — certificate/device binding (Wave 5 Task 6)', ()
     status: 'online',
     agentTokenSuspendedAt: null,
   };
+
+  // The device lookup innerJoins organizations (#4673 W02); every later
+  // select in the same test (certificate identity lookups) does not.
+  function queueDeviceSelectOnce(rows: unknown[]) {
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn(() => ({
+        innerJoin: vi.fn(() => ({
+          where: vi.fn(() => ({
+            limit: vi.fn().mockResolvedValue(rows),
+          })),
+        })),
+      })),
+    } as any);
+  }
 
   function queueSelectOnce(rows: unknown[]) {
     vi.mocked(db.select).mockReturnValueOnce({
@@ -673,7 +699,7 @@ describe('validateAgentToken — certificate/device binding (Wave 5 Task 6)', ()
   });
 
   it('mode off (default): never queries the certificate identity table', async () => {
-    queueSelectOnce([deviceRow]);
+    queueDeviceSelectOnce([deviceRow]);
 
     const result = await validateAgentToken('agent-1', TOKEN);
 
@@ -683,7 +709,7 @@ describe('validateAgentToken — certificate/device binding (Wave 5 Task 6)', ()
 
   it('mode enforce: allows through with a trusted, matching certificate assertion', async () => {
     process.env.AGENT_MTLS_BINDING_MODE = 'enforce';
-    queueSelectOnce([deviceRow]);
+    queueDeviceSelectOnce([deviceRow]);
     queueSelectOnce([{ serialNumber: ACTIVE_SERIAL, state: 'active' }]);
 
     const result = await validateAgentToken(
@@ -692,12 +718,12 @@ describe('validateAgentToken — certificate/device binding (Wave 5 Task 6)', ()
       assertion({ assertionTrusted: true, assertedVerified: true, assertedSerial: ACTIVE_SERIAL }),
     );
 
-    expect(result).toEqual({ ok: true, ctx: { deviceId: 'device-1', orgId: 'org-1', role: 'agent' } });
+    expect(result).toEqual({ ok: true, ctx: { deviceId: 'device-1', orgId: 'org-1', partnerId: 'partner-1', role: 'agent' } });
   });
 
   it('mode enforce: refuses the upgrade when no assertion is presented and an active cert is on file', async () => {
     process.env.AGENT_MTLS_BINDING_MODE = 'enforce';
-    queueSelectOnce([deviceRow]);
+    queueDeviceSelectOnce([deviceRow]);
     queueSelectOnce([{ serialNumber: ACTIVE_SERIAL, state: 'active' }]);
 
     const result = await validateAgentToken('agent-1', TOKEN, assertion());
@@ -707,7 +733,7 @@ describe('validateAgentToken — certificate/device binding (Wave 5 Task 6)', ()
 
   it("mode enforce: refuses an assertion naming a DIFFERENT device's serial (bearer token cannot choose another device's identity)", async () => {
     process.env.AGENT_MTLS_BINDING_MODE = 'enforce';
-    queueSelectOnce([deviceRow]);
+    queueDeviceSelectOnce([deviceRow]);
     queueSelectOnce([{ serialNumber: ACTIVE_SERIAL, state: 'active' }]);
 
     const result = await validateAgentToken(
@@ -721,7 +747,7 @@ describe('validateAgentToken — certificate/device binding (Wave 5 Task 6)', ()
 
   it('mode enforce: ignores a verified claim from an untrusted source (spoofed header) and refuses', async () => {
     process.env.AGENT_MTLS_BINDING_MODE = 'enforce';
-    queueSelectOnce([deviceRow]);
+    queueDeviceSelectOnce([deviceRow]);
     queueSelectOnce([{ serialNumber: ACTIVE_SERIAL, state: 'active' }]);
 
     const result = await validateAgentToken(
@@ -735,7 +761,7 @@ describe('validateAgentToken — certificate/device binding (Wave 5 Task 6)', ()
 
   it('mode audit: a mismatched assertion is observed but never blocks the upgrade', async () => {
     process.env.AGENT_MTLS_BINDING_MODE = 'audit';
-    queueSelectOnce([deviceRow]);
+    queueDeviceSelectOnce([deviceRow]);
     queueSelectOnce([{ serialNumber: ACTIVE_SERIAL, state: 'active' }]);
 
     const result = await validateAgentToken(
@@ -749,7 +775,7 @@ describe('validateAgentToken — certificate/device binding (Wave 5 Task 6)', ()
 
   it('mode enforce: a legacy device with no certificate identity at all is allowed through (compatibility)', async () => {
     process.env.AGENT_MTLS_BINDING_MODE = 'enforce';
-    queueSelectOnce([deviceRow]);
+    queueDeviceSelectOnce([deviceRow]);
     queueSelectOnce([]); // no active row
     queueSelectOnce([]); // no historical row either
     queueSelectOnce([{ legacySerial: null }]); // no legacy column either
@@ -765,7 +791,7 @@ describe('validateAgentToken — certificate/device binding (Wave 5 Task 6)', ()
   // the pure decision function REST also calls.
   it('produces the same decision the pure checkAgentCertificateBinding function would for identical inputs', async () => {
     process.env.AGENT_MTLS_BINDING_MODE = 'enforce';
-    queueSelectOnce([deviceRow]);
+    queueDeviceSelectOnce([deviceRow]);
     queueSelectOnce([{ serialNumber: ACTIVE_SERIAL, state: 'active' }]);
 
     const result = await validateAgentToken(
@@ -835,7 +861,7 @@ describe('agent websocket handshake', () => {
   });
 
   it('advertises terminal_output_base64 in the connected message', async () => {
-    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
 
     vi.mocked(db.update).mockReturnValue(updateResult() as any);
     vi.mocked(db.select).mockReturnValue(selectAgentDevice([]) as any);
@@ -853,7 +879,7 @@ describe('agent websocket handshake', () => {
 
   it('decodes base64 terminal_output and relays UTF-8 to the terminal consumer', async () => {
     const sessionId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
-    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
 
     vi.mocked(getActiveTerminalSession).mockReturnValue({
       agentId: 'agent-123',
@@ -901,7 +927,7 @@ describe('WS lifecycle status writes — terminal-status guard (#2230)', () => {
   }
 
   it('excludes decommissioned/quarantined rows when flipping a device online on connect', async () => {
-    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
     const { whereMock, setMock } = rigStatusUpdateCapture();
     vi.mocked(db.select).mockReturnValue(selectAgentDevice([]) as any);
 
@@ -915,7 +941,7 @@ describe('WS lifecycle status writes — terminal-status guard (#2230)', () => {
   });
 
   it('excludes decommissioned/quarantined rows when flipping a device offline on disconnect', async () => {
-    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
 
     const handlers = createAgentWsHandlers('agent-123', preValidatedAgent);
     const ws = wsMock();
@@ -942,7 +968,7 @@ describe('WS lifecycle status writes — terminal-status guard (#2230)', () => {
   });
 
   it('excludes decommissioned/quarantined rows when a WS heartbeat flips a device online', async () => {
-    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
     const { whereMock, setMock } = rigStatusUpdateCapture();
     vi.mocked(db.select).mockReturnValue(selectAgentDevice([]) as any);
 
@@ -961,7 +987,7 @@ describe('WS lifecycle status writes — terminal-status guard (#2230)', () => {
   });
 
   it('excludes decommissioned/quarantined rows when update_status flips a device to updating', async () => {
-    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
     const { whereMock, setMock } = rigStatusUpdateCapture();
 
     const handlers = createAgentWsHandlers('agent-123', preValidatedAgent);
@@ -984,7 +1010,7 @@ describe('agent websocket command results', () => {
 
   it('rejects cross-device command result updates', async () => {
     // Auth is now pre-validated before WS upgrade, so we pass the context directly
-    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
     const { handlers, ws } = await connectedAgent('agent-123', preValidatedAgent);
 
     vi.mocked(db.select)
@@ -1008,7 +1034,7 @@ describe('agent websocket command results', () => {
   });
 
   it('updates command result when command belongs to connected agent', async () => {
-    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
     const { handlers, ws } = await connectedAgent('agent-123', preValidatedAgent);
 
     vi.mocked(db.select)
@@ -1040,7 +1066,7 @@ describe('agent websocket command results', () => {
   it.each(['pam_apply_v2', 'pam_cleanup_v2'])(
     'dispatches authenticated %s results through the shared PAM transaction',
     async (commandType) => {
-      const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+      const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
       const { handlers, ws } = await connectedAgent('agent-123', preValidatedAgent);
       const commandId = '11111111-1111-4111-8111-111111111111';
       vi.mocked(db.select).mockReturnValueOnce(selectOwnedCommandResult([{
@@ -1067,7 +1093,7 @@ describe('agent websocket command results', () => {
   );
 
   it('keeps terminal PAM WebSocket results on orphan handling without supplemental dispatch', async () => {
-    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
     const { handlers, ws } = await connectedAgent('agent-123', preValidatedAgent);
     const commandId = '11111111-1111-4111-8111-111111111111';
 
@@ -1102,7 +1128,7 @@ describe('agent websocket command results', () => {
   });
 
   it('stores capture_pprof stdout byte-for-byte on the WS leg (secret redaction would corrupt the base64 profiles, #2401)', async () => {
-    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
     const { handlers, ws } = await connectedAgent('agent-123', preValidatedAgent);
 
     vi.mocked(db.select)
@@ -1146,7 +1172,7 @@ describe('agent websocket command results', () => {
   });
 
   it('rejects watchdog-targeted command results on the agent websocket', async () => {
-    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
     const { handlers, ws } = await connectedAgent('agent-123', preValidatedAgent);
 
     vi.mocked(db.select)
@@ -1177,7 +1203,7 @@ describe('agent websocket command results', () => {
   });
 
   it('ignores replayed command results when no in-flight command row exists', async () => {
-    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
     const { handlers, ws } = await connectedAgent('agent-123', preValidatedAgent);
 
     vi.mocked(db.select)
@@ -1201,7 +1227,7 @@ describe('agent websocket command results', () => {
   });
 
   it('reconciles orphaned restore results using restore_jobs.command_id and inferred command type', async () => {
-    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
     const { handlers, ws } = await connectedAgent('agent-123', preValidatedAgent);
 
     vi.mocked(db.select)
@@ -1255,7 +1281,7 @@ describe('agent websocket command results', () => {
   });
 
   it('bypasses device_commands lookup for non-UUID command IDs', async () => {
-    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
     const { handlers, ws } = await connectedAgent('agent-123', preValidatedAgent);
 
     await handlers.onMessage({
@@ -1271,7 +1297,7 @@ describe('agent websocket command results', () => {
   });
 
   it('does not register tunnel ownership when a tunnel open result is not DB-bound to the authenticated device', async () => {
-    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
     const { handlers, ws } = await connectedAgent('agent-123', preValidatedAgent);
 
     vi.mocked(db.update).mockReturnValue(updateResult([]) as any);
@@ -1290,7 +1316,7 @@ describe('agent websocket command results', () => {
   });
 
   it('registers tunnel ownership only after a DB-backed transition for the authenticated device', async () => {
-    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
     const { handlers, ws } = await connectedAgent('agent-123', preValidatedAgent);
 
     vi.mocked(db.update).mockReturnValue(updateResult([
@@ -1310,7 +1336,7 @@ describe('agent websocket command results', () => {
   });
 
   it('rejects unexpected orphaned monitor results without a recorded dispatch', async () => {
-    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
     const { handlers, ws } = await connectedAgent('agent-123', preValidatedAgent);
 
     await handlers.onMessage({
@@ -1338,7 +1364,7 @@ describe('agent websocket command results', () => {
   // not release the outer transaction's connection — dispatching after the
   // context closes is the deeper #1105 fix).
   it('enqueues an accepted monitor result via runOutsideDbContext (#1105, BREEZE-H)', async () => {
-    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
 
     // onOpen: register the socket so sendCommandToAgent records the
     // orphaned-result expectation the monitor result is matched against.
@@ -1396,7 +1422,7 @@ describe('agent websocket command results', () => {
   });
 
   it('drops terminal output for sessions not owned by the connected agent', async () => {
-    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
 
     vi.mocked(getActiveTerminalSession).mockReturnValue({
       agentId: 'agent-999',
@@ -1424,7 +1450,7 @@ describe('agent websocket command results', () => {
   });
 
   it('does not activate a desktop session from a desk-stop result', async () => {
-    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
 
     const handlers = createAgentWsHandlers('agent-123', preValidatedAgent);
     const ws = wsMock();
@@ -1452,7 +1478,7 @@ describe('agent websocket command results', () => {
   // The strict result schema must accept the key instead of dropping the
   // message as a malformed desk-command_result.
   it('accepts a desk-stop result carrying {"stopped": true} without a malformed-drop warn (#2307)', async () => {
-    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
     const handlers = createAgentWsHandlers('agent-123', preValidatedAgent);
     const ws = wsMock();
     await connectAgentSocket(handlers, ws);
@@ -1477,7 +1503,7 @@ describe('agent websocket command results', () => {
   });
 
   it('rejects desktop disconnect results with mismatched session IDs', async () => {
-    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
 
     const handlers = createAgentWsHandlers('agent-123', preValidatedAgent);
     const ws = wsMock();
@@ -1502,7 +1528,7 @@ describe('agent websocket command results', () => {
   });
 
   it('rejects desktop start failures with mismatched session IDs', async () => {
-    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
 
     const handlers = createAgentWsHandlers('agent-123', preValidatedAgent);
     const ws = wsMock();
@@ -1527,7 +1553,7 @@ describe('agent websocket command results', () => {
   });
 
   it('rejects mismatched discovery job IDs in command results', async () => {
-    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
     const { handlers, ws } = await connectedAgent('agent-123', preValidatedAgent);
 
     vi.mocked(db.select)
@@ -1559,7 +1585,7 @@ describe('agent websocket command results', () => {
   });
 
   it('skips downstream processing when the command row was already completed by another result', async () => {
-    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
     const { handlers, ws } = await connectedAgent('agent-123', preValidatedAgent);
 
     vi.mocked(db.select)
@@ -1591,7 +1617,7 @@ describe('agent websocket command results', () => {
   });
 
   it('fails the backup_verifications record when a critical verification payload is malformed (not left running)', async () => {
-    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
     const { handlers, ws } = await connectedAgent('agent-123', preValidatedAgent);
 
     vi.mocked(db.select)
@@ -1640,7 +1666,7 @@ describe('agent websocket command results', () => {
   });
 
   it('fails the backup_verifications record when verification stdout exceeds the size limit', async () => {
-    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
     const { handlers, ws } = await connectedAgent('agent-123', preValidatedAgent);
 
     vi.mocked(db.select)
@@ -1681,7 +1707,7 @@ describe('agent websocket command results', () => {
   });
 
   it('rejects mismatched SNMP device IDs in command results', async () => {
-    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
     const { handlers, ws } = await connectedAgent('agent-123', preValidatedAgent);
 
     vi.mocked(db.select)
@@ -1714,7 +1740,7 @@ describe('agent websocket command results', () => {
 
   // H5: malformed term-* command_result is dropped without DB call
   it('drops malformed term-* command_result without touching DB (H5)', async () => {
-    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
     const handlers = createAgentWsHandlers('agent-123', preValidatedAgent);
     const ws = wsMock();
     await connectAgentSocket(handlers, ws);
@@ -1740,7 +1766,7 @@ describe('agent websocket command results', () => {
   });
 
   it('drops malformed terminal_output without invoking handleTerminalOutput (H5)', async () => {
-    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
     const handlers = createAgentWsHandlers('agent-123', preValidatedAgent);
     const ws = wsMock();
 
@@ -1762,7 +1788,7 @@ describe('agent websocket command results', () => {
   // M-D1: 10 cross-tenant drops within 5 min triggers warn
   it('emits cross-tenant probe warning after threshold drops (M-D1)', async () => {
     __resetCrossTenantDropsForTest();
-    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
     const handlers = createAgentWsHandlers('agent-malicious', preValidatedAgent);
     const ws = wsMock();
     await connectAgentSocket(handlers, ws);
@@ -1816,7 +1842,7 @@ describe('agent websocket command results', () => {
   describe('Task 18 — agent token auto-suspend on cross-tenant probe', () => {
     it('suspends the agent token after SUSPEND_THRESHOLD (5) cross-tenant drops', async () => {
       __resetCrossTenantDropsForTest();
-      const preValidatedAgent = { deviceId: 'device-abc', orgId: 'org-abc' };
+      const preValidatedAgent = { deviceId: 'device-abc', orgId: 'org-abc', partnerId: 'partner-abc' };
       const handlers = createAgentWsHandlers('agent-task18-suspend', preValidatedAgent);
       const ws = wsMock();
       await connectAgentSocket(handlers, ws);
@@ -1874,7 +1900,7 @@ describe('agent websocket command results', () => {
 
     it('does NOT suspend after only 4 drops (below the threshold)', async () => {
       __resetCrossTenantDropsForTest();
-      const preValidatedAgent = { deviceId: 'device-not-yet', orgId: 'org-x' };
+      const preValidatedAgent = { deviceId: 'device-not-yet', orgId: 'org-x', partnerId: 'partner-x' };
       const handlers = createAgentWsHandlers('agent-task18-undercount', preValidatedAgent);
       const ws = wsMock();
       await connectAgentSocket(handlers, ws);
@@ -1918,7 +1944,7 @@ describe('agent websocket command results', () => {
 
     it('suspends only once even when probes continue past threshold', async () => {
       __resetCrossTenantDropsForTest();
-      const preValidatedAgent = { deviceId: 'device-once', orgId: 'org-y' };
+      const preValidatedAgent = { deviceId: 'device-once', orgId: 'org-y', partnerId: 'partner-y' };
       const handlers = createAgentWsHandlers('agent-task18-once', preValidatedAgent);
       const ws = wsMock();
       await connectAgentSocket(handlers, ws);
@@ -2019,7 +2045,7 @@ describe('agent websocket command results', () => {
 // one-shot expectation survives for the real terminal result), while a
 // genuine failure or a completed result still falls through to consume it.
 describe('backup command_result non-terminal guards (guard ordering integration)', () => {
-  const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+  const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
   const jobId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
   const backupJobRow = { id: jobId, orgId: 'org-123', deviceId: 'device-123', agentId: 'agent-123' };
 
@@ -2277,7 +2303,7 @@ describe('Finding #4 — one-socket-per-agent invariant', () => {
   });
 
   it('closes the previous socket when a second socket opens for the same agent', async () => {
-    const preValidatedAgent = { deviceId: 'device-dup', orgId: 'org-dup' };
+    const preValidatedAgent = { deviceId: 'device-dup', orgId: 'org-dup', partnerId: 'partner-dup' };
     vi.mocked(db.update).mockReturnValue(updateResult() as any);
     // Empty device select: onOpen registers the socket without reaching the
     // (unmocked) command-claim path.
@@ -2296,7 +2322,7 @@ describe('Finding #4 — one-socket-per-agent invariant', () => {
   });
 
   it('disconnectAgent closes the current authoritative socket', async () => {
-    const preValidatedAgent = { deviceId: 'device-auth', orgId: 'org-auth' };
+    const preValidatedAgent = { deviceId: 'device-auth', orgId: 'org-auth', partnerId: 'partner-auth' };
     vi.mocked(db.update).mockReturnValue(updateResult() as any);
     vi.mocked(db.select).mockReturnValue(selectAgentDevice([]) as any);
 
@@ -2311,7 +2337,7 @@ describe('Finding #4 — one-socket-per-agent invariant', () => {
   });
 
   it('an orphaned socket cannot outlive its replacement — onClose of the orphan never evicts the live socket', async () => {
-    const preValidatedAgent = { deviceId: 'device-orphan', orgId: 'org-orphan' };
+    const preValidatedAgent = { deviceId: 'device-orphan', orgId: 'org-orphan', partnerId: 'partner-orphan' };
     vi.mocked(db.update).mockReturnValue(updateResult() as any);
     vi.mocked(db.select).mockReturnValue(selectAgentDevice([]) as any);
 
@@ -2355,7 +2381,7 @@ describe('presence lifecycle (wave 3.5b #4084)', () => {
   }
 
   it('onOpen sets a fenced presence lease bound to this instance with a fresh token', async () => {
-    const handlers = createAgentWsHandlers('agent-p1', { deviceId: 'device-p1', orgId: 'org-p1' });
+    const handlers = createAgentWsHandlers('agent-p1', { deviceId: 'device-p1', orgId: 'org-p1', partnerId: 'partner-p1' });
 
     await handlers.onOpen({}, wsMock() as any);
 
@@ -2368,7 +2394,7 @@ describe('presence lifecycle (wave 3.5b #4084)', () => {
   });
 
   it("a pong message refreshes the presence lease with this connection's token", async () => {
-    const handlers = createAgentWsHandlers('agent-p2', { deviceId: 'device-p2', orgId: 'org-p2' });
+    const handlers = createAgentWsHandlers('agent-p2', { deviceId: 'device-p2', orgId: 'org-p2', partnerId: 'partner-p2' });
     const ws = wsMock();
     await handlers.onOpen({}, ws as any);
     const token = connectionTokenFromSetCall();
@@ -2379,7 +2405,7 @@ describe('presence lifecycle (wave 3.5b #4084)', () => {
   });
 
   it('a heartbeat message also refreshes the presence lease', async () => {
-    const handlers = createAgentWsHandlers('agent-p2b', { deviceId: 'device-p2b', orgId: 'org-p2b' });
+    const handlers = createAgentWsHandlers('agent-p2b', { deviceId: 'device-p2b', orgId: 'org-p2b', partnerId: 'partner-p2b' });
     const ws = wsMock();
     await handlers.onOpen({}, ws as any);
     const token = connectionTokenFromSetCall();
@@ -2391,7 +2417,7 @@ describe('presence lifecycle (wave 3.5b #4084)', () => {
 
   it('self-heals by re-setting the lease when refresh fails but this socket is still live', async () => {
     vi.mocked(refreshAgentPresence).mockResolvedValue(false);
-    const handlers = createAgentWsHandlers('agent-p3', { deviceId: 'device-p3', orgId: 'org-p3' });
+    const handlers = createAgentWsHandlers('agent-p3', { deviceId: 'device-p3', orgId: 'org-p3', partnerId: 'partner-p3' });
     const ws = wsMock();
     await handlers.onOpen({}, ws as any);
     const token = connectionTokenFromSetCall();
@@ -2408,7 +2434,7 @@ describe('presence lifecycle (wave 3.5b #4084)', () => {
 
   it('does NOT self-heal when the pong arrives on a superseded socket', async () => {
     vi.mocked(refreshAgentPresence).mockResolvedValue(false);
-    const handlers = createAgentWsHandlers('agent-p4', { deviceId: 'device-p4', orgId: 'org-p4' });
+    const handlers = createAgentWsHandlers('agent-p4', { deviceId: 'device-p4', orgId: 'org-p4', partnerId: 'partner-p4' });
     const ws1 = wsMock();
     const ws2 = wsMock();
     await handlers.onOpen({}, ws1 as any);
@@ -2423,7 +2449,7 @@ describe('presence lifecycle (wave 3.5b #4084)', () => {
   });
 
   it('onClose clears the presence lease for the current socket', async () => {
-    const handlers = createAgentWsHandlers('agent-p5', { deviceId: 'device-p5', orgId: 'org-p5' });
+    const handlers = createAgentWsHandlers('agent-p5', { deviceId: 'device-p5', orgId: 'org-p5', partnerId: 'partner-p5' });
     const ws = wsMock();
     await handlers.onOpen({}, ws as any);
     const token = connectionTokenFromSetCall();
@@ -2434,7 +2460,7 @@ describe('presence lifecycle (wave 3.5b #4084)', () => {
   });
 
   it("onClose of a superseded (orphan) socket does NOT clear the live socket's lease", async () => {
-    const handlers = createAgentWsHandlers('agent-p6', { deviceId: 'device-p6', orgId: 'org-p6' });
+    const handlers = createAgentWsHandlers('agent-p6', { deviceId: 'device-p6', orgId: 'org-p6', partnerId: 'partner-p6' });
     const ws1 = wsMock();
     const ws2 = wsMock();
     await handlers.onOpen({}, ws1 as any);
@@ -2446,7 +2472,7 @@ describe('presence lifecycle (wave 3.5b #4084)', () => {
   });
 
   it('onError clears the presence lease for the current socket', async () => {
-    const handlers = createAgentWsHandlers('agent-p7', { deviceId: 'device-p7', orgId: 'org-p7' });
+    const handlers = createAgentWsHandlers('agent-p7', { deviceId: 'device-p7', orgId: 'org-p7', partnerId: 'partner-p7' });
     const ws = wsMock();
     await handlers.onOpen({}, ws as any);
     const token = connectionTokenFromSetCall();
@@ -2509,7 +2535,7 @@ describe('Finding #3 — lifecycle recheck on sensitive operations', () => {
   });
 
   it('severs the socket on a command result when the device was quarantined after connect', async () => {
-    const preValidatedAgent = { deviceId: 'device-q', orgId: 'org-q' };
+    const preValidatedAgent = { deviceId: 'device-q', orgId: 'org-q', partnerId: 'partner-q' };
     vi.mocked(db.update).mockReturnValue(updateResult([{ id: 'cmd-1' }]) as any);
     vi.mocked(db.select).mockReturnValue(selectAgentDevice([]) as any); // onOpen: register only
 
@@ -2542,7 +2568,7 @@ describe('Finding #3 — lifecycle recheck on sensitive operations', () => {
   });
 
   it('severs the socket on a heartbeat when the token was suspended after connect', async () => {
-    const preValidatedAgent = { deviceId: 'device-s', orgId: 'org-s' };
+    const preValidatedAgent = { deviceId: 'device-s', orgId: 'org-s', partnerId: 'partner-s' };
     vi.mocked(db.update).mockReturnValue(updateResult() as any);
     vi.mocked(db.select).mockReturnValue(selectAgentDevice([]) as any); // onOpen: register only
 
@@ -2565,7 +2591,7 @@ describe('Finding #3 — lifecycle recheck on sensitive operations', () => {
   });
 
   it('severs the socket on a heartbeat when the device was decommissioned after connect', async () => {
-    const preValidatedAgent = { deviceId: 'device-d', orgId: 'org-d' };
+    const preValidatedAgent = { deviceId: 'device-d', orgId: 'org-d', partnerId: 'partner-d' };
     vi.mocked(db.update).mockReturnValue(updateResult() as any);
     vi.mocked(db.select).mockReturnValue(selectAgentDevice([]) as any); // onOpen: register only
 
@@ -2598,7 +2624,7 @@ describe('Findings #8 / #5 — WS command-result audit + secret redaction', () =
   });
 
   it('emits agent.command.result.submit exactly once after a real terminal transition', async () => {
-    const preValidatedAgent = { deviceId: 'device-a', orgId: 'org-a' };
+    const preValidatedAgent = { deviceId: 'device-a', orgId: 'org-a', partnerId: 'partner-a' };
     const { handlers, ws } = await connectedAgent('agent-a', preValidatedAgent);
     vi.mocked(db.select).mockReturnValueOnce(selectOwnedCommandResult([
       { id: 'cmd-1', type: 'run_script', payload: {}, deviceId: 'device-a' },
@@ -2635,7 +2661,7 @@ describe('Findings #8 / #5 — WS command-result audit + secret redaction', () =
   });
 
   it('does NOT audit when the compare-and-set no-ops (duplicate/late result)', async () => {
-    const preValidatedAgent = { deviceId: 'device-a', orgId: 'org-a' };
+    const preValidatedAgent = { deviceId: 'device-a', orgId: 'org-a', partnerId: 'partner-a' };
     const { handlers, ws } = await connectedAgent('agent-a', preValidatedAgent);
     vi.mocked(db.select).mockReturnValueOnce(selectOwnedCommandResult([
       { id: 'cmd-1', type: 'run_script', payload: {}, deviceId: 'device-a' },
@@ -2658,7 +2684,7 @@ describe('Findings #8 / #5 — WS command-result audit + secret redaction', () =
   });
 
   it('redacts a PEM private key from stdout, stderr, AND error before persistence (#2419)', async () => {
-    const preValidatedAgent = { deviceId: 'device-r', orgId: 'org-r' };
+    const preValidatedAgent = { deviceId: 'device-r', orgId: 'org-r', partnerId: 'partner-r' };
     const { handlers, ws } = await connectedAgent('agent-r', preValidatedAgent);
     vi.mocked(db.select).mockReturnValueOnce(selectOwnedCommandResult([
       { id: 'cmd-1', type: 'run_script', payload: {}, deviceId: 'device-r' },
@@ -2699,7 +2725,7 @@ describe('Findings #8 / #5 — WS command-result audit + secret redaction', () =
   // a secret sits next to a recognized key name, so a bare echoed credential
   // survives it. These pin the exact-value layer at the WS chokepoint.
   it('redacts the exact secret values the command carried, from stdout/stderr/error', async () => {
-    const preValidatedAgent = { deviceId: 'device-s', orgId: 'org-s' };
+    const preValidatedAgent = { deviceId: 'device-s', orgId: 'org-s', partnerId: 'partner-s' };
     const { handlers, ws } = await connectedAgent('agent-s', preValidatedAgent);
 
     // The AAD binds the command id and device id, so seal with the same pair
@@ -2742,7 +2768,7 @@ describe('Findings #8 / #5 — WS command-result audit + secret redaction', () =
   });
 
   it('discards all output when the command envelope will not open', async () => {
-    const preValidatedAgent = { deviceId: 'device-t', orgId: 'org-t' };
+    const preValidatedAgent = { deviceId: 'device-t', orgId: 'org-t', partnerId: 'partner-t' };
     const { handlers, ws } = await connectedAgent('agent-t', preValidatedAgent);
 
     // Sealed against a DIFFERENT device: the AAD will not verify, so the
@@ -2792,7 +2818,7 @@ describe('WS frames never claim pending commands (#2407)', () => {
   });
 
   it('onOpen sends the welcome frame without pendingCommands and claims nothing', async () => {
-    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
 
     vi.mocked(db.update).mockReturnValue(updateResult() as any);
     vi.mocked(db.select).mockReturnValue(selectAgentDevice([]) as any);
@@ -2809,7 +2835,7 @@ describe('WS frames never claim pending commands (#2407)', () => {
   });
 
   it('heartbeat_ack always carries an empty commands array and claims nothing', async () => {
-    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
+    const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' };
 
     vi.mocked(db.update).mockReturnValue(updateResult() as any);
     vi.mocked(db.select).mockReturnValue(selectAgentDevice([]) as any);
@@ -2860,7 +2886,7 @@ describe('Quick Support — support_sessions claimed -> ready on agent connect',
       id: 'device-eph', siteId: null, hostname: 'quick-support-pc', agentVersion: '1.0.0', isEphemeral: true,
     });
 
-    const handlers = createAgentWsHandlers('agent-eph', { deviceId: 'device-eph', orgId: 'org-qs' });
+    const handlers = createAgentWsHandlers('agent-eph', { deviceId: 'device-eph', orgId: 'org-qs', partnerId: 'partner-qs' });
     await handlers.onOpen({}, wsMock() as any);
 
     const sessionUpdate = updates.find(u => u.table === supportSessions);
@@ -2876,7 +2902,7 @@ describe('Quick Support — support_sessions claimed -> ready on agent connect',
       id: 'device-normal', siteId: 'site-1', hostname: 'workstation-7', agentVersion: '1.0.0', isEphemeral: false,
     });
 
-    const handlers = createAgentWsHandlers('agent-normal', { deviceId: 'device-normal', orgId: 'org-1' });
+    const handlers = createAgentWsHandlers('agent-normal', { deviceId: 'device-normal', orgId: 'org-1', partnerId: 'partner-1' });
     await handlers.onOpen({}, wsMock() as any);
 
     expect(updates.some(u => u.table === supportSessions)).toBe(false);
@@ -2894,7 +2920,7 @@ describe('#2434 — secret redaction on non-device_commands persistence surfaces
   });
 
   it('redacts stdout/stderr/errorMessage persisted to script_executions', async () => {
-    const preValidatedAgent = { deviceId: 'device-se', orgId: 'org-se' };
+    const preValidatedAgent = { deviceId: 'device-se', orgId: 'org-se', partnerId: 'partner-se' };
     const { handlers, ws } = await connectedAgent('agent-se', preValidatedAgent);
     vi.mocked(db.select).mockReturnValueOnce(selectOwnedCommandResult([
       { id: 'cmd-se', type: 'script', payload: { executionId: '0e1c1e1a-1111-4111-8111-111111111111' }, deviceId: 'device-se' },
@@ -2941,7 +2967,7 @@ describe('#2434 — secret redaction on non-device_commands persistence surfaces
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     try {
-      const preValidatedAgent = { deviceId: 'device-syn', orgId: 'org-syn' };
+      const preValidatedAgent = { deviceId: 'device-syn', orgId: 'org-syn', partnerId: 'partner-syn' };
       const { handlers, ws } = await connectedAgent('agent-syn', preValidatedAgent);
       vi.mocked(db.select).mockReturnValueOnce(selectOwnedCommandResult([
         {
@@ -2989,7 +3015,7 @@ describe('#2434 — secret redaction on non-device_commands persistence surfaces
   // would start silently discarding real script output again — the exact class
   // of bug #3162 was.
   it('still persists results for a uuid Postgres accepts but RFC-4122 rejects', async () => {
-    const preValidatedAgent = { deviceId: 'device-nil', orgId: 'org-nil' };
+    const preValidatedAgent = { deviceId: 'device-nil', orgId: 'org-nil', partnerId: 'partner-nil' };
     const { handlers, ws } = await connectedAgent('agent-nil', preValidatedAgent);
     vi.mocked(db.select).mockReturnValueOnce(selectOwnedCommandResult([
       {
@@ -3026,7 +3052,7 @@ describe('#2434 — secret redaction on non-device_commands persistence surfaces
   });
 
   it('redacts tunnel_sessions.errorMessage on a failed tun-open result (orphaned-path chokepoint)', async () => {
-    const preValidatedAgent = { deviceId: 'device-tn', orgId: 'org-tn' };
+    const preValidatedAgent = { deviceId: 'device-tn', orgId: 'org-tn', partnerId: 'partner-tn' };
     const { handlers, ws } = await connectedAgent('agent-tn', preValidatedAgent);
     const tunnelSetSpy = vi.fn().mockReturnValue({
       where: vi.fn().mockReturnValue({
@@ -3057,7 +3083,7 @@ describe('#2434 — secret redaction on non-device_commands persistence surfaces
     // chokepoint leaves every other suite green while raw key material lands in
     // cis_baseline_results. `backup_verify` is the probe: its handler is mocked,
     // so we can assert exactly what the dispatch handed it.
-    const preValidatedAgent = { deviceId: 'device-ck', orgId: 'org-ck' };
+    const preValidatedAgent = { deviceId: 'device-ck', orgId: 'org-ck', partnerId: 'partner-ck' };
     const { handlers, ws } = await connectedAgent('agent-ck', preValidatedAgent);
     vi.mocked(db.select).mockReturnValueOnce(selectOwnedCommandResult([
       { id: 'cmd-ck', type: 'backup_verify', payload: {}, deviceId: 'device-ck' },
@@ -3084,7 +3110,7 @@ describe('#2434 — secret redaction on non-device_commands persistence surfaces
   });
 
   it('redacts remote_sessions.errorMessage on a failed desk-start result (fast path)', async () => {
-    const preValidatedAgent = { deviceId: 'device-rs', orgId: 'org-rs' };
+    const preValidatedAgent = { deviceId: 'device-rs', orgId: 'org-rs', partnerId: 'partner-rs' };
 
     const handlers = createAgentWsHandlers('agent-rs', preValidatedAgent);
     const ws = wsMock();
@@ -3145,7 +3171,7 @@ describe('device_commands access context on the WS result path (#1375)', () => {
   it('runs the device_commands write inside a system context nested in runOutsideDbContext, and the read outside any context', async () => {
     // Open first, before the wrapper/DB spies below, so the handshake's own
     // traffic can never land in `observed`.
-    const { handlers, ws } = await connectedAgent('agent-123', { deviceId: 'device-123', orgId: 'org-123' });
+    const { handlers, ws } = await connectedAgent('agent-123', { deviceId: 'device-123', orgId: 'org-123', partnerId: 'partner-123' });
 
     // Track the ACTIVE WRAPPER STACK, not just depth counters. Depth counters
     // are order-blind: `system(outside(write))` — the inverted nesting, which
@@ -3252,7 +3278,7 @@ describe('#3021: command_result opens no message-level org context', () => {
   it('runs the device_commands steps with no enclosing org context and the per-type handler under a short org wrap', async () => {
     // Open first, before the wrapper/DB spies below, so the handshake's own
     // traffic can never land in `observed`.
-    const { handlers, ws } = await connectedAgent('agent-3021', { deviceId: 'device-3021', orgId: 'org-3021' });
+    const { handlers, ws } = await connectedAgent('agent-3021', { deviceId: 'device-3021', orgId: 'org-3021', partnerId: 'partner-3021' });
 
     // Track the ACTIVE WRAPPER STACK at the moment of every DB call. An
     // `org:*` frame present during the deviceCommands select/update or the
@@ -3381,6 +3407,7 @@ describe('#3021: command_result opens no message-level org context', () => {
     const { handlers, ws } = await connectedAgent('agent-3021c', {
       deviceId: undefined as unknown as string,
       orgId: 'org-3021c',
+      partnerId: 'partner-3021c',
     });
 
     const stack: string[] = [];
@@ -3477,7 +3504,7 @@ describe('#3021: command_result opens no message-level org context', () => {
   });
 
   it('wraps a non-UUID orphaned result in the short orphaned org context, not a message-level wrap', async () => {
-    const { handlers, ws } = await connectedAgent('agent-3021b', { deviceId: 'device-3021b', orgId: 'org-3021b' });
+    const { handlers, ws } = await connectedAgent('agent-3021b', { deviceId: 'device-3021b', orgId: 'org-3021b', partnerId: 'partner-3021b' });
 
     const orgLabels: string[] = [];
     vi.mocked(withDbAccessContext).mockImplementation((async (ctx: any, fn: any) => {
@@ -3532,6 +3559,7 @@ describe('BREEZE-X: WS terminal CAS reports why it moved 0 rows', () => {
     const { handlers, ws } = await connectedAgent('agent-cas', {
       deviceId: 'device-cas',
       orgId: 'org-cas',
+      partnerId: 'partner-cas',
     });
 
     const commandSelects: unknown[][] = [];
@@ -3628,7 +3656,7 @@ describe('BREEZE-X: WS terminal CAS reports why it moved 0 rows', () => {
 // delivered on.
 // ---------------------------------------------------------------------------
 describe('superseded agent socket cannot submit results (delivery epoch)', () => {
-  const preValidatedAgent = { deviceId: 'device-sup', orgId: 'org-sup' };
+  const preValidatedAgent = { deviceId: 'device-sup', orgId: 'org-sup', partnerId: 'partner-sup' };
   const SESSION_ID = 'ffffffff-ffff-4fff-8fff-ffffffffffff';
 
   beforeEach(() => {
@@ -3836,6 +3864,7 @@ describe('superseded agent socket cannot submit results (delivery epoch)', () =>
 // ---------------------------------------------------------------------------
 describe('late terminal_start failure binds to the exact terminal generation', () => {
   const TERM_ORG_ID = 'org-term-epoch';
+  const TERM_PARTNER_ID = 'partner-term-epoch';
   const TERM_DEVICE_ID = 'device-term-epoch';
   let terminalUserCounter = 0;
 
@@ -3878,7 +3907,7 @@ describe('late terminal_start failure binds to the exact terminal generation', (
 
   /** Connect an agent socket the terminal route can dispatch commands onto. */
   async function openAgentSocket(agentId: string, deviceId: string) {
-    const handlers = createAgentWsHandlers(agentId, { deviceId, orgId: TERM_ORG_ID });
+    const handlers = createAgentWsHandlers(agentId, { deviceId, orgId: TERM_ORG_ID, partnerId: TERM_PARTNER_ID });
     const ws = wsMock();
     await connectAgentSocket(handlers, ws);
     return { handlers, ws };

--- a/apps/api/src/routes/agentWs.test.ts
+++ b/apps/api/src/routes/agentWs.test.ts
@@ -3391,7 +3391,19 @@ describe('#3021: command_result opens no message-level org context', () => {
     // The short wrap carries the authenticated agent's org, and no context
     // anywhere in the message used the removed message-level label.
     const handlerCtx = orgContexts.find((c) => c.label === 'agentWs.commandResult.handler');
-    expect(handlerCtx).toMatchObject({ scope: 'organization', orgId: 'org-3021', accessibleOrgIds: ['org-3021'] });
+    // #4673 W02 — `currentPartnerId` is asserted here because
+    // `runWithAgentOrgDbAccess(label, orgId, partnerId, fn)` takes orgId and
+    // partnerId as ADJACENT positional strings across five call sites in
+    // processCommandResult. Transposing them typechecks cleanly (both are
+    // `string`), so only a value assertion catches it — and reverting the field
+    // to `null` otherwise passes this whole file (verified by mutation).
+    expect(handlerCtx).toMatchObject({
+      scope: 'organization',
+      orgId: 'org-3021',
+      accessibleOrgIds: ['org-3021'],
+      currentPartnerId: 'partner-3021',
+      accessiblePartnerIds: [],
+    });
     expect(orgContexts.map((c) => c.label)).not.toContain('agentWs.commandResult');
 
     expect(ws.send).toHaveBeenCalledWith(expect.stringContaining('"ack"'));

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -7,7 +7,7 @@ import { createHash, randomUUID } from 'crypto';
 import { db, withDbAccessContext, withSystemDbAccessContext, runOutsideDbContext } from '../db';
 import { dbWriteExpectingRows } from '../db/dbWriteExpectingRows';
 import { commandCasPriorStatusTags } from '../services/commandCasDiagnostics';
-import { devices, deviceCommands, discoveryJobs, scriptExecutions, scriptExecutionBatches, remoteSessions, backupJobs, restoreJobs, tunnelSessions, supportSessions } from '../db/schema';
+import { devices, deviceCommands, discoveryJobs, scriptExecutions, scriptExecutionBatches, remoteSessions, backupJobs, restoreJobs, tunnelSessions, supportSessions, organizations } from '../db/schema';
 import {
   handleTerminalOutput,
   getActiveTerminalSession,
@@ -702,6 +702,16 @@ export interface AgentCommand {
 type AgentDbContext = {
   deviceId: string;
   orgId: string;
+  /**
+   * #4673 W02 — the MSP that owns this device's org, from the auth select's
+   * join to `organizations` (NOT NULL, so always present after a successful
+   * token validation). Feeds `currentPartnerId` on every org context this
+   * socket opens, so Wave 1's SELECT-only partner-wide branches can match.
+   *
+   * Read-only axis. It must never be spread into `accessiblePartnerIds`,
+   * which is the write-capable partner-AXIS predicate.
+   */
+  partnerId: string;
   role?: AgentCredentialRole;
 };
 
@@ -806,8 +816,14 @@ export async function validateAgentToken(
         pendingTokenExpiresAt: devices.pendingTokenExpiresAt,
         status: devices.status,
         agentTokenSuspendedAt: devices.agentTokenSuspendedAt,
+        // #4673 W02 — owning MSP, for `currentPartnerId` on this socket's org
+        // contexts. INNER join: org_id and partner_id are both NOT NULL behind
+        // an FK, so a device with no org row is not authenticable anyway, and a
+        // LEFT join would silently degrade it to the pre-W02 blind behaviour.
+        partnerId: organizations.partnerId,
       })
       .from(devices)
+      .innerJoin(organizations, eq(organizations.id, devices.orgId))
       .where(eq(devices.agentId, agentId))
       .limit(1);
     return row ?? null;
@@ -890,6 +906,7 @@ export async function validateAgentToken(
     ctx: {
       deviceId: device.id,
       orgId: device.orgId,
+      partnerId: device.partnerId,
       role: match.role,
     },
   };
@@ -1567,17 +1584,26 @@ export async function processOrphanedCommandResult(
  * follow-up, now bounded by short per-operation wraps instead of a
  * message-long one.
  */
-async function runWithAgentOrgDbAccess<T>(label: string, orgId: string, fn: () => Promise<T>): Promise<T> {
+async function runWithAgentOrgDbAccess<T>(
+  label: string,
+  orgId: string,
+  partnerId: string,
+  fn: () => Promise<T>,
+): Promise<T> {
   return withDbAccessContext(
     {
       scope: 'organization',
       orgId,
       accessibleOrgIds: [orgId],
-      // Agents are org-scoped; they have no access to partner-level tables.
+      // Partner-AXIS access gates `breeze_has_partner_access`, which admits
+      // WRITES to partner-owned rows. Agents get none of it — this stays empty.
       accessiblePartnerIds: [],
-      // Agents don't browse the catalog as org users; null disables the
-      // partner-wide read branch (safe).
-      currentPartnerId: null,
+      // #4673 W02 — the device org's owning MSP. Feeds the
+      // `breeze.current_partner_id` GUC that Wave 1's SELECT-ONLY branches read
+      // (`org_id IS NULL AND partner_id = breeze_current_partner_id()`), so an
+      // agent socket can see its own MSP's partner-wide config directly.
+      // A separate, read-only axis from `accessiblePartnerIds` above.
+      currentPartnerId: partnerId,
       label
     },
     fn
@@ -1607,7 +1633,12 @@ async function processCommandResult(
   agentId: string,
   result: z.infer<typeof commandResultSchema>,
   deviceId: string | undefined,
-  orgId: string
+  orgId: string,
+  // #4673 W02 — threaded in (rather than re-looked-up) so every short-lived
+  // org context this function opens carries the same `currentPartnerId` the
+  // socket authenticated with. Without it these contexts would be the one
+  // remaining agent path where partner-wide rows stay invisible.
+  partnerId: string
 ): Promise<void> {
   try {
     // #2434 chokepoint — FIRST statement, so "any agent result that enters this
@@ -1638,7 +1669,7 @@ async function processCommandResult(
     // the ambient db, so they need the tenant context the removed
     // message-level wrap used to provide.
     if (!UUID_REGEX.test(result.commandId)) {
-      await runWithAgentOrgDbAccess('agentWs.commandResult.orphaned', orgId, () =>
+      await runWithAgentOrgDbAccess('agentWs.commandResult.orphaned', orgId, partnerId, () =>
         processOrphanedCommandResult(agentId, deviceId ?? '', result)
       );
       return;
@@ -1723,7 +1754,7 @@ async function processCommandResult(
       // Discovery and SNMP commands are dispatched directly via WebSocket
       // without creating a deviceCommands record. Handle them here (short org
       // wrap for the same reason as the non-UUID branch above, #3021).
-      await runWithAgentOrgDbAccess('agentWs.commandResult.orphaned', orgId, () =>
+      await runWithAgentOrgDbAccess('agentWs.commandResult.orphaned', orgId, partnerId, () =>
         processOrphanedCommandResult(agentId, deviceId ?? '', result)
       );
       return;
@@ -1880,7 +1911,7 @@ async function processCommandResult(
           try {
             // Short org wrap (#3021): handlers touch RLS-guarded org tables
             // through the ambient db (same as the happy-path dispatch below).
-            await runWithAgentOrgDbAccess('agentWs.commandResult.handler', orgId, () =>
+            await runWithAgentOrgDbAccess('agentWs.commandResult.handler', orgId, partnerId, () =>
               rejectedHandler({ agentId, command, commandId: result.commandId, result: normalizedResult, resolvedDeviceId: resolvedDeviceId!, stdout })
             );
           } catch (handlerErr) {
@@ -1903,7 +1934,7 @@ async function processCommandResult(
         const { handleDrCommandResult } = await import('./backup/drResultHandler');
         // Short org wrap (#3021): DR result persistence reads/writes
         // RLS-guarded org tables through the ambient db.
-        await runWithAgentOrgDbAccess('agentWs.commandResult.drResult', orgId, () =>
+        await runWithAgentOrgDbAccess('agentWs.commandResult.drResult', orgId, partnerId, () =>
           handleDrCommandResult({
             commandId: result.commandId,
             commandType: command.type,
@@ -1937,7 +1968,7 @@ async function processCommandResult(
     // why the wrap sits here instead of around the whole message.
     const handler = commandResultHandlers[command.type];
     if (handler) {
-      await runWithAgentOrgDbAccess('agentWs.commandResult.handler', orgId, () =>
+      await runWithAgentOrgDbAccess('agentWs.commandResult.handler', orgId, partnerId, () =>
         handler({ agentId, command, commandId: result.commandId, result: normalizedResult, resolvedDeviceId: resolvedDeviceId!, stdout })
       );
     }
@@ -1968,7 +1999,7 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
    * sessionId) — they become a Sentry tag and part of the grouping message.
    */
   const runWithAgentDbAccess = async <T>(label: string, fn: () => Promise<T>): Promise<T> => {
-    return runWithAgentOrgDbAccess(label, agentDb.orgId, fn);
+    return runWithAgentOrgDbAccess(label, agentDb.orgId, agentDb.partnerId, fn);
   };
 
   // The delivery epoch this handler set owns, stamped when its socket is
@@ -2595,7 +2626,8 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
               agentId,
               parsed.data as z.infer<typeof commandResultSchema>,
               authenticatedAgent.deviceId,
-              authenticatedAgent.orgId
+              authenticatedAgent.orgId,
+              authenticatedAgent.partnerId
             );
             ws.send(JSON.stringify({
               type: 'ack',

--- a/apps/api/src/routes/agents/commands.test.ts
+++ b/apps/api/src/routes/agents/commands.test.ts
@@ -193,6 +193,7 @@ describe('agent commands routes', () => {
         deviceId: 'device-1',
         agentId: 'agent-1',
         orgId: 'org-1',
+        partnerId: 'partner-1',
         siteId: 'site-1',
         role: 'agent',
       });
@@ -620,6 +621,7 @@ describe('agent commands routes', () => {
         deviceId: 'device-1',
         agentId: 'agent-1',
         orgId: 'org-1',
+        partnerId: 'partner-1',
         siteId: 'site-1',
         role: 'agent',
         tenantDraining: true,
@@ -889,6 +891,7 @@ describe('agent commands routes', () => {
         deviceId: deviceUuid,
         agentId: 'agent-1',
         orgId: 'org-1',
+        partnerId: 'partner-1',
         siteId: 'site-1',
         role: 'agent',
       });
@@ -940,6 +943,7 @@ describe('agent commands routes', () => {
           deviceId: deviceUuid,
           agentId: 'agent-1',
           orgId: 'org-1',
+          partnerId: 'partner-1',
           siteId: 'site-1',
           role: 'agent',
         });
@@ -1343,6 +1347,7 @@ describe('POST /agents/:id/commands/:commandId/result — drain narrowing (#3986
         deviceId: opts.deviceId ?? 'device-1',
         agentId: 'agent-1',
         orgId: 'org-1',
+        partnerId: 'partner-1',
         siteId: 'site-1',
         role: 'agent',
         ...drainContext,

--- a/apps/api/src/routes/agents/elevationRequests.test.ts
+++ b/apps/api/src/routes/agents/elevationRequests.test.ts
@@ -132,6 +132,7 @@ function buildApp(opts: { skipAuth?: boolean } = {}): Hono {
       c.set('agent', {
         deviceId: 'device-1',
         orgId: 'org-1',
+        partnerId: 'partner-1',
         agentId: 'agent-123',
         siteId: 'site-1',
         role: 'agent',

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -308,6 +308,7 @@ function buildApp(): Hono {
       deviceId: 'device-1',
       agentId: 'agent-1',
       orgId: 'org-1',
+      partnerId: 'partner-1',
       siteId: 'site-1',
       role: 'agent',
     });
@@ -324,6 +325,7 @@ function buildWatchdogApp(): Hono {
       deviceId: 'device-1',
       agentId: 'agent-1',
       orgId: 'org-1',
+      partnerId: 'partner-1',
       siteId: 'site-1',
       role: 'watchdog',
     });
@@ -342,6 +344,7 @@ function buildDrainingApp(role: 'agent' | 'watchdog' = 'agent'): Hono {
       deviceId: 'device-1',
       agentId: 'agent-1',
       orgId: 'org-1',
+      partnerId: 'partner-1',
       siteId: 'site-1',
       role,
       tenantDraining: true,
@@ -367,6 +370,7 @@ function buildDeviceDrainApp(): Hono {
       deviceId: 'device-1',
       agentId: 'agent-1',
       orgId: 'org-1',
+      partnerId: 'partner-1',
       siteId: 'site-1',
       role: 'agent',
       tenantDraining: false,

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -13,6 +13,8 @@ const ingestRollbackObservationMock = vi.hoisted(() => vi.fn());
 // manifest-trust-keyset fetch happens AFTER the org DB context closes
 // (the #1105 pool-poison fix). Reset per test.
 const callOrder: string[] = [];
+// #4673 W02 — org contexts opened by the heartbeat's self-managed wrap.
+const orgDbContexts: Array<Record<string, unknown>> = [];
 
 const recordAgentHealthObservationMock = vi.hoisted(() => vi.fn(async (_input: unknown) => ({
   observationId: 'health-observation-1',
@@ -46,7 +48,13 @@ vi.mock('../../db', () => ({
   // Pass-through that records when the org-scoped context opens and when its
   // callback resolves — in production the org transaction is released at the
   // latter point.
-  withDbAccessContext: async (_ctx: unknown, fn: () => Promise<unknown>) => {
+  // #4673 W02 — also RECORDS the context object. The heartbeat is in
+  // SELF_MANAGED_DB_CONTEXT_ACTIONS, so it skips agentAuthMiddleware's
+  // request-long wrap and hand-builds this context itself; the only way to
+  // prove it copies `currentPartnerId` across from the agent context is to
+  // inspect what it passed.
+  withDbAccessContext: async (ctx: unknown, fn: () => Promise<unknown>) => {
+    orgDbContexts.push(ctx as Record<string, unknown>);
     callOrder.push('dbContext:opened');
     const result = await fn();
     callOrder.push('dbContext:released');
@@ -449,6 +457,38 @@ describe('POST /agents/:id/heartbeat — reachability ownership', () => {
     insertMock.mockReset();
     getActiveTrustKeysetMock.mockResolvedValue([]);
     getActiveManifestKeyDelegationsMock.mockResolvedValue([]);
+    orgDbContexts.length = 0;
+  });
+
+  // #4673 W02 — the heartbeat is THE agent config-delivery path, and it is in
+  // SELF_MANAGED_DB_CONTEXT_ACTIONS: it skips agentAuthMiddleware's
+  // request-long wrap and hand-builds its own org context. So it must copy
+  // `currentPartnerId` over from the agent context explicitly — nothing
+  // inherits it here.
+  //
+  // Reverting that field to `null` in heartbeat.ts passes every other test in
+  // this file (verified by mutation), while silently making Wave 1's
+  // partner-wide SELECT branches unmatched for every heartbeat — the exact
+  // silent-zero bug this wave fixes. This assertion is the only thing that
+  // catches it.
+  it('carries currentPartnerId from the agent context onto its self-managed org context (#4673 W02)', async () => {
+    selectMock.mockReturnValueOnce(selectChainResolving([pendingDevice]));
+    selectMock.mockReturnValue(selectChainResolving([]));
+    updateMock.mockReturnValue({ set: vi.fn(() => ({ where: vi.fn(() => whereResultWithReturning()) })) });
+    insertMock.mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) });
+
+    const response = await buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(minimalHeartbeatBody),
+    });
+
+    expect(response.status).toBe(200);
+    const orgCtx = orgDbContexts.find((c) => c.scope === 'organization');
+    expect(orgCtx).toBeDefined();
+    expect(orgCtx!.currentPartnerId).toBe('partner-1');
+    // Read-only axis only — the write-capable partner AXIS stays empty.
+    expect(orgCtx!.accessiblePartnerIds).toEqual([]);
   });
 
   it('an authenticated main-agent heartbeat promotes pending to online and advances lastSeenAt', async () => {

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -390,10 +390,16 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
     scope: 'organization' as const,
     orgId: agent.orgId,
     accessibleOrgIds: [agent.orgId],
+    // Partner-AXIS access (breeze_has_partner_access → writes) stays empty.
     accessiblePartnerIds: [],
-    // Agent path; no partner in scope and agents don't browse the catalog
-    // as org users. null disables the partner-wide read branch (safe).
-    currentPartnerId: null,
+    // #4673 W02 — this route opts out of agentAuthMiddleware's request-long
+    // wrap, so the partner id has to be carried over from the agent context
+    // rather than inherited. Without it the `breeze.current_partner_id` GUC is
+    // empty here and Wave 1's SELECT-only partner-wide branches can never
+    // match — the heartbeat is THE agent config-delivery path, so that is
+    // precisely where partner-wide policies would silently vanish.
+    // Read-only widening to the device's own MSP; see agentAuth.ts.
+    currentPartnerId: agent.partnerId,
   };
 
   // Org > General > Agent update policy — governs whether we may hand the agent

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -395,9 +395,17 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
     // #4673 W02 — this route opts out of agentAuthMiddleware's request-long
     // wrap, so the partner id has to be carried over from the agent context
     // rather than inherited. Without it the `breeze.current_partner_id` GUC is
-    // empty here and Wave 1's SELECT-only partner-wide branches can never
-    // match — the heartbeat is THE agent config-delivery path, so that is
-    // precisely where partner-wide policies would silently vanish.
+    // empty here and Wave 1's SELECT-only partner-wide branches can never match.
+    //
+    // Scope note, so nobody over-reads this: as of W02 the field is INERT on
+    // this route. Every config-delivery read the heartbeat performs
+    // (event-log, monitoring, PAM, patch-source, OneDrive, helper settings,
+    // the update-policy gate) still runs in its own withSystemDbAccessContext,
+    // which bypasses RLS and already saw partner-wide rows. Nothing inside the
+    // org-scoped block below reads a partner-wide-branched table directly.
+    // It becomes load-bearing in Wave 3, when those escapes are removed and
+    // this GUC is the only thing keeping partner-wide config reaching agents.
+    // Set it now so Wave 3 is a deletion, not a deletion plus a scavenger hunt.
     // Read-only widening to the device's own MSP; see agentAuth.ts.
     currentPartnerId: agent.partnerId,
   };

--- a/apps/api/src/routes/agents/helpers.ts
+++ b/apps/api/src/routes/agents/helpers.ts
@@ -1165,12 +1165,20 @@ export async function handleCisCommandResult(
       return;
     }
 
-    // Resolve the baseline in a SYSTEM context. This handler runs inside the
-    // agent's ORG-scoped RLS context, where breeze_current_partner_id() is
-    // NULL — so a partner-wide baseline (org_id NULL) is invisible and this
-    // lookup would return nothing. Both callers swallow the error, so the
-    // failure mode is every scheduled scan result silently discarded with
-    // only a log line. The read is by primary key and the result is
+    // Resolve the baseline in a SYSTEM context.
+    //
+    // This escape originally existed because the agent's ORG-scoped RLS
+    // context had breeze_current_partner_id() NULL, making a partner-wide
+    // baseline (org_id NULL) invisible and this lookup return nothing. As of
+    // #4673 W02 that is no longer true — agent contexts now carry the device
+    // org's partner, so `cis_baselines_partner_wide_select` would match here.
+    // The escape is kept only because #4673 Wave 3 owns removing it together
+    // with the other `withPartnerWideVisibility` sites, as one reviewable
+    // change; do not read this comment as evidence that the GUC is still null.
+    //
+    // Why it stays safe meanwhile: both callers swallow the error, so the
+    // failure mode of a miss is every scheduled scan result silently discarded
+    // with only a log line. The read is by primary key and the result is
     // immediately re-checked against the device's own org below.
     const [baseline] = await runOutsideDbContext(() =>
       withSystemDbAccessContext(() =>

--- a/apps/api/src/routes/agents/pamObservations.test.ts
+++ b/apps/api/src/routes/agents/pamObservations.test.ts
@@ -64,6 +64,7 @@ function buildApp(options: {
       c.set('agent', {
         deviceId: DEVICE_ID,
         orgId: '40000000-0000-4000-8000-000000000001',
+        partnerId: '70000000-0000-4000-8000-000000000001',
         agentId: options.agentId ?? AGENT_ID,
         siteId: '50000000-0000-4000-8000-000000000001',
         role: options.role ?? 'agent',

--- a/apps/api/src/routes/agents/pamReconciliation.test.ts
+++ b/apps/api/src/routes/agents/pamReconciliation.test.ts
@@ -27,6 +27,7 @@ function buildApp(role: 'agent' | 'watchdog' = 'agent'): Hono {
     c.set('agent', {
       deviceId: '30000000-0000-4000-8000-000000000001',
       orgId: '40000000-0000-4000-8000-000000000001',
+      partnerId: '70000000-0000-4000-8000-000000000001',
       agentId: 'agent-primary',
       siteId: '50000000-0000-4000-8000-000000000001',
       role,

--- a/apps/api/src/routes/agents/reliability.test.ts
+++ b/apps/api/src/routes/agents/reliability.test.ts
@@ -322,6 +322,31 @@ describe('agent reliability ingestion route', () => {
     expect(auditDepth).toBe(0); // audit is OUTSIDE the org transaction
     expect(vi.mocked(withDbAccessContext)).toHaveBeenCalled(); // insert WAS wrapped
   });
+
+  // #4673 W02 — this route is in SELF_MANAGED_DB_CONTEXT_ACTIONS, so it skips
+  // agentAuthMiddleware's request-long wrap and hand-builds its own context.
+  // That means it must copy `currentPartnerId` across from the agent context
+  // itself; nothing inherits it for free here.
+  //
+  // Without this assertion, reverting `currentPartnerId` to `null` in
+  // reliability.ts passes every other test in this file (verified by mutation)
+  // — the exact silent-zero regression #4673 exists to prevent, just scoped to
+  // one route.
+  it('carries currentPartnerId from the agent context onto its self-managed org context (#4673 W02)', async () => {
+    const app = buildApp();
+    const res = await app.request('/agents/agent-123/reliability', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+
+    expect(res.status).toBe(200);
+    const ctx = vi.mocked(withDbAccessContext).mock.calls[0]?.[0] as unknown as Record<string, unknown>;
+    expect(ctx.currentPartnerId).toBe('partner-1');
+    expect(ctx.orgId).toBe('org-1');
+    // Read-only axis only — the write-capable partner AXIS stays empty.
+    expect(ctx.accessiblePartnerIds).toEqual([]);
+  });
 });
 
 describe('reliability ingest — requireAgentRole gate (F8)', () => {

--- a/apps/api/src/routes/agents/reliability.test.ts
+++ b/apps/api/src/routes/agents/reliability.test.ts
@@ -93,6 +93,7 @@ function buildApp(): Hono {
     c.set('agent', {
       deviceId: 'device-1',
       orgId: 'org-1',
+      partnerId: 'partner-1',
       agentId: 'agent-123',
       siteId: 'site-1',
       role: 'agent',

--- a/apps/api/src/routes/agents/reliability.ts
+++ b/apps/api/src/routes/agents/reliability.ts
@@ -24,7 +24,7 @@ type LookupResult =
 reliabilityRoutes.post('/:id/reliability', zValidator('json', reliabilityMetricsSchema), async (c) => {
   const agentId = c.req.param('id');
   const metrics = c.req.valid('json');
-  const agent = c.get('agent') as { orgId?: string; agentId?: string } | undefined;
+  const agent = c.get('agent') as { orgId?: string; agentId?: string; partnerId?: string } | undefined;
 
   // Fail fast on a token that authenticated but carries no org. Building a vacuous
   // org-scoped RLS context (orgId '', accessibleOrgIds []) would make the device
@@ -44,8 +44,20 @@ reliabilityRoutes.post('/:id/reliability', zValidator('json', reliabilityMetrics
     scope: 'organization' as const,
     orgId,
     accessibleOrgIds: [orgId],
+    // Partner-AXIS access (breeze_has_partner_access → writes) stays empty.
     accessiblePartnerIds: [],
-    currentPartnerId: null,
+    // #4673 W02 — self-managed context, so the partner id must be carried from
+    // the agent context explicitly (see heartbeat.ts / agentAuth.ts). Read-only
+    // visibility of this device's own MSP partner-wide rows.
+    //
+    // `?? null` rather than a fail-fast: unlike `orgId` above (whose absence
+    // would silently RLS-deny the device lookup and masquerade as a 404), this
+    // route reads NO partner-wide table — it does a device lookup and an insert.
+    // A null here is therefore genuinely inert, and 401-ing a reliability ingest
+    // over it would trade a no-op for lost fleet posture data. The middleware
+    // always populates it (`AgentAuthContext.partnerId` is required); this is
+    // just the local narrowing being defensive.
+    currentPartnerId: agent.partnerId ?? null,
   };
 
   const lookup = await withDbAccessContext(dbContext, async (): Promise<LookupResult> => {

--- a/apps/api/src/routes/agents/token.test.ts
+++ b/apps/api/src/routes/agents/token.test.ts
@@ -78,6 +78,7 @@ function buildApp(opts?: {
     c.set('agent', {
       deviceId: 'device-1',
       orgId: 'org-1',
+      partnerId: 'partner-1',
       agentId: 'agent-123',
       siteId: 'site-1',
       role: 'agent',

--- a/apps/api/src/routes/agents/wingetBootstrap.test.ts
+++ b/apps/api/src/routes/agents/wingetBootstrap.test.ts
@@ -37,6 +37,12 @@ vi.mock('../../db/schema', () => ({
     hostname: 'hostname',
     lastSeenIp: 'lastSeenIp',
   },
+  // #4673 W02 — agentAuthMiddleware's device select inner-joins this to
+  // resolve the org's owning MSP for `currentPartnerId`.
+  organizations: {
+    id: 'organizations.id',
+    partnerId: 'organizations.partnerId',
+  },
 }));
 
 vi.mock('drizzle-orm', () => ({
@@ -93,6 +99,8 @@ function makeDevice(overrides: Record<string, unknown> = {}) {
     agentId: AGENT_ID,
     orgId: 'org-1',
     siteId: 'site-1',
+    // #4673 W02 — supplied by the organizations join in the auth select.
+    partnerId: 'partner-1',
     agentTokenHash: VALID_HASH,
     previousTokenHash: null,
     previousTokenExpiresAt: null,
@@ -108,11 +116,19 @@ function makeDevice(overrides: Record<string, unknown> = {}) {
 }
 
 function buildSelectMock(result: unknown[]) {
+  // #4673 W02 — the device auth select is now
+  // `.from(devices).innerJoin(organizations, ...).where(...).limit(1)`.
+  // `innerJoin` returns the same terminal shape, so un-joined selects that
+  // go straight from `from` to `where` keep working against this mock.
+  const terminal = {
+    where: vi.fn().mockReturnValue({
+      limit: vi.fn().mockResolvedValue(result),
+    }),
+  };
   vi.mocked(db.select).mockReturnValue({
     from: vi.fn().mockReturnValue({
-      where: vi.fn().mockReturnValue({
-        limit: vi.fn().mockResolvedValue(result),
-      }),
+      innerJoin: vi.fn().mockReturnValue(terminal),
+      ...terminal,
     }),
   } as any);
 }


### PR DESCRIPTION
Wave 2 of #4673 (origin #2468). Plan: `docs/superpowers/plans/tenancy-rls/2026-08-16-2468-partner-current-partner-id-select-branch.md`

## The bug this closes

Wave 1 ([on main](https://github.com/LanternOps/breeze/blob/main/apps/api/migrations/2026-10-05-110000-config-policy-partner-wide-select.sql)) shipped SELECT-only RLS branches across the configuration-policy chain:

```sql
USING (org_id IS NULL AND partner_id = public.breeze_current_partner_id())
```

That branch reads the `breeze.current_partner_id` GUC, which `db/index.ts` `SET LOCAL`s from `DbAccessContext.currentPartnerId`. **Every agent context hard-coded that field to `null`**, so on agent paths the branch could never be true — a partner-wide config row read as **zero rows, with no error**.

That silent-zero is precisely why the agent-facing resolvers must escape to a system context (`withPartnerWideVisibility`), which double-holds a pooled connection and bypasses RLS wholesale (#1105, #2417). This wave resolves the device org's owning MSP and threads it through every agent-authenticated DB context, so **Wave 3 can delete those escapes**.

## Changes

| File | Change |
|---|---|
| `middleware/agentAuth.ts` | Device auth select inner-joins `organizations` for `partner_id`. `AgentAuthContext` gains a required `partnerId`. The request-long org wrap sets `currentPartnerId` from it. |
| `routes/agents/heartbeat.ts` | In `SELF_MANAGED_DB_CONTEXT_ACTIONS` — skips that wrap and hand-builds its own context, so it reads `agent.partnerId` explicitly. **This is THE agent config-delivery path.** |
| `routes/agents/reliability.ts` | Same self-managed shape. |
| `routes/agentWs.ts` | Same join on the socket auth select; `AgentDbContext` gains `partnerId`; threaded through `runWithAgentOrgDbAccess` and `processCommandResult`'s five short-lived contexts. |

**The join is total, not a narrowing.** `devices.org_id` is `NOT NULL` with an FK to `organizations`, and `organizations.partner_id` is `NOT NULL`, so an INNER join can never drop an authenticable device. A LEFT join would have been worse — it would hand an orphan device a NULL partner and silently degrade it to the pre-W02 blind behaviour.

## Read-only by construction — and proven, not asserted

`accessiblePartnerIds` stays `[]` on every agent context. That array gates `breeze_has_partner_access`, the write-capable partner **AXIS**; `currentPartnerId` feeds `FOR SELECT` policies only. The two axes are deliberately not merged, and there's a unit tripwire if someone later merges them.

The new suite proves the read/write split rather than assuming it:
- a partner-wide row an agent **can read** is still **un-targetable** by UPDATE/DELETE — asserted as **0 rows affected**, since RLS hides rows from write commands silently rather than raising;
- and **un-forgeable** by INSERT — asserted on the **unwrapped pg `cause.code === '42501'`**, because drizzle wraps the driver error and a bare `rejects.toThrow(/42501/)` would match the wrapper's "Failed query:" text and pass for *any* failure.

## Deliberately NOT in this wave

- **`portal/auth.ts` and `clientAiAuth`** — client end-users seeing MSP-wide config is a product decision, not a mechanical sweep. Left `null`.
- **`commandQueue.ts`'s audit-log context** — a write-only `audit_logs` INSERT that reads no partner-wide table; a lookup there would cost a query on a hot path for zero benefit.
- The ~40 AI-agent-SDK / streaming-session contexts, which all already have `session.auth.partnerId` in scope — a separate, non-agent surface.

## Blast radius

**Behaviour is inert until Wave 3.** Every agent-path config reader either already escalates (so already saw these rows) or filters on `org_id = <device org>` / `level = 'organization'`, which partner-wide rows (`org_id NULL`, level `partner`) can never match — verified by sweeping `configurationPolicies` readers in `routes/agents/helpers.ts`. Org/user tokens were already widened by Wave 1 via `buildDbAccessContext`, so this PR's blast radius is **agent paths only**.

## Tests

**New: `agentContextPartnerWideFanout.integration.test.ts`** — the real-DB fan-out proof, against the RLS-forced `breeze_app` role.

It deliberately does *not* reuse `agentPolicyResolversPartnerWide.integration.test.ts`, which passes today with `currentPartnerId: null` because the resolvers still escalate internally — so that suite structurally cannot detect whether this wave works. The new suite issues **plain, un-escalated** queries and lets RLS alone decide.

Two guards make it non-vacuous:
1. **BYPASSRLS non-vacuity guard, first test.** A worktree missing `.env.test` runs as a superuser, under which every negative assertion passes trivially *and* the positives pass for the wrong reason. Fails loudly instead.
2. **The negative control** (load-bearing): the identical query under a context differing **only** by `currentPartnerId: null` returns zero rows, plus a direct assertion that `breeze_current_partner_id()` returns the partner vs `NULL`. Without this, every positive assertion could be satisfied by some unrelated policy widening.

Also covers: the auth join pinned against the real schema, whole-chain visibility (feature link → settings child → assignment), end-to-end delivery through the real `buildEventLogConfigUpdate` resolver, foreign-MSP isolation, and sibling-org isolation *within* one MSP (guards against the branch ever being loosened to "same partner").

| Suite | Result |
|---|---|
| `agentContextPartnerWideFanout.integration` (new) | **13 passed** |
| Affected unit suites (9 files: agentAuth, agentWs, commands, heartbeat, reliability, token, elevationRequests, pamObservations, pamReconciliation) | **537 passed** |
| `rls-coverage` contract (`test:rls-coverage`) | **100 passed** |
| RLS contract (`vitest.config.rls.ts`) | **26 passed, 5 skipped** |
| Partner-wide regression (agentPolicyResolvers, configPolicyPartnerWideSelect, normalizedConfigPolicyRls, backupProfilesPartnerRls, partnerAxisSystemContext, configurationPolicyOrgScopedPartnerWide) | **72 passed** |
| Agent integration suites touched by the fixture change | **25 passed** |
| `tsc --noEmit` (whole `apps/api`) | **clean** |
| `eslint` on changed sources · `check-migration-naming` · `autoMigrate.test.ts` | **clean · OK · 67 passed** |

Red-first: the four new `agentAuth` unit tests were written against `currentPartnerId: null` / `partnerId: undefined` and observed failing before the implementation landed.

No migration in this wave.

## Rollback

Revert the PR — no schema involvement. Wave 1's policies are additive and stay correct with the field back at `null`.

Closes #4675

🤖 Generated with [Claude Code](https://claude.com/claude-code)
