### PR TITLE
feat(agent): end-user reboot prompt with deferral, Windows + macOS (#3207 W3)

### DIFF
--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -1011,26 +1011,12 @@ func NewWithVersion(cfg *config.Config, version string, token *secmem.SecureStri
 				h.sessionBroker.BroadcastNotification(title, body, urgency)
 			}
 		},
-		func(title, body, urgency string, actions []string, timeout time.Duration) string {
+		rebootPromptFunc(func(req ipc.NotifyRequest, timeout time.Duration) (ipc.NotifyResult, error) {
 			if h.sessionBroker == nil {
-				return ""
+				return ipc.NotifyResult{}, nil
 			}
-			res, err := h.sessionBroker.RequestNotificationDecision(ipc.NotifyRequest{
-				Title:     title,
-				Body:      body,
-				Urgency:   urgency,
-				Actions:   actions,
-				TimeoutMs: int(timeout.Milliseconds()),
-			}, timeout)
-			if err != nil {
-				// Not a failure: no helper, an old helper that ignores Actions, or
-				// a user who simply did not answer. All of them mean "no decision",
-				// and the reboot proceeds exactly as scheduled.
-				log.Debug("reboot prompt returned no decision; proceeding as scheduled", "error", err.Error())
-				return ""
-			}
-			return res.ActionClicked
-		},
+			return h.sessionBroker.RequestNotificationDecision(req, timeout)
+		}),
 		cfg.PatchRebootMaxPerDay,
 	)
 

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -1003,12 +1003,36 @@ func NewWithVersion(cfg *config.Config, version string, token *secmem.SecureStri
 	// Register winget provider (SYSTEM/machine-scope; see winget_register_windows.go)
 	h.registerSystemWinget()
 
-	// Initialize reboot manager (uses session broker for user notifications)
-	h.rebootMgr = patching.NewRebootManager(func(title, body, urgency string) {
-		if h.sessionBroker != nil {
-			h.sessionBroker.BroadcastNotification(title, body, urgency)
-		}
-	}, cfg.PatchRebootMaxPerDay)
+	// Initialize reboot manager (uses session broker for user notifications, and
+	// for the interactive postponement prompt when policy enables deferral).
+	h.rebootMgr = patching.NewRebootManagerWithPrompt(
+		func(title, body, urgency string) {
+			if h.sessionBroker != nil {
+				h.sessionBroker.BroadcastNotification(title, body, urgency)
+			}
+		},
+		func(title, body, urgency string, actions []string, timeout time.Duration) string {
+			if h.sessionBroker == nil {
+				return ""
+			}
+			res, err := h.sessionBroker.RequestNotificationDecision(ipc.NotifyRequest{
+				Title:     title,
+				Body:      body,
+				Urgency:   urgency,
+				Actions:   actions,
+				TimeoutMs: int(timeout.Milliseconds()),
+			}, timeout)
+			if err != nil {
+				// Not a failure: no helper, an old helper that ignores Actions, or
+				// a user who simply did not answer. All of them mean "no decision",
+				// and the reboot proceeds exactly as scheduled.
+				log.Debug("reboot prompt returned no decision; proceeding as scheduled", "error", err.Error())
+				return ""
+			}
+			return res.ActionClicked
+		},
+		cfg.PatchRebootMaxPerDay,
+	)
 
 	// Set backup binary path for IPC forwarding to breeze-backup helper
 	h.backupBinaryPath = cfg.BackupBinaryPath

--- a/agent/internal/heartbeat/reboot_prompt.go
+++ b/agent/internal/heartbeat/reboot_prompt.go
@@ -1,0 +1,61 @@
+package heartbeat
+
+import (
+	"errors"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/ipc"
+	"github.com/breeze-rmm/agent/internal/patching"
+	"github.com/breeze-rmm/agent/internal/sessionbroker"
+)
+
+// notifyDecisionRequester is the one broker call the reboot prompt needs, taken
+// as a function rather than an interface so the nil-broker case stays a plain nil
+// check at the call site — a nil *sessionbroker.Broker stored in an interface is
+// not a nil interface, and that distinction has no business in this logic.
+type notifyDecisionRequester func(ipc.NotifyRequest, time.Duration) (ipc.NotifyResult, error)
+
+// rebootPromptFunc adapts the broker's correlated notification request to the
+// reboot manager's prompt seam.
+//
+// It exists as a named function rather than a closure inside the manager's
+// construction so this translation is directly testable: it is the exact hop at
+// which "the helper told us it showed nothing" could be mistaken for "the user
+// looked at a dialog and chose not to click", and those two demand opposite
+// behaviour from the manager.
+//
+//   - shown=false means nothing reached a person — no helper session, a dead
+//     transport, or a helper that could put neither a dialog nor a toast on
+//     screen. The manager falls back to the ordinary notification, which is what
+//     keeps the #3197 always-warn invariant true on a headless box.
+//   - shown=true with an empty label means a real person saw the prompt and did
+//     nothing. The reboot proceeds exactly as scheduled and no second warning is
+//     emitted, because the dialog already was the warning.
+func rebootPromptFunc(request notifyDecisionRequester) patching.PromptFunc {
+	return func(title, body, urgency string, actions []string, timeout time.Duration) (string, bool) {
+		res, err := request(ipc.NotifyRequest{
+			Title:     title,
+			Body:      body,
+			Urgency:   urgency,
+			Actions:   actions,
+			TimeoutMs: int(timeout.Milliseconds()),
+		}, timeout)
+		if err != nil {
+			if errors.Is(err, sessionbroker.ErrCommandTimeout) {
+				// The helper had the prompt and the user did not answer inside the
+				// window. Ordinary, and not worth a warning on every rung — but it
+				// is still "nothing was confirmed shown", so the manager falls back
+				// rather than assuming a dialog the helper never acknowledged.
+				log.Debug("reboot prompt went unanswered; proceeding as scheduled")
+				return "", false
+			}
+			// A transport or helper error. This one IS worth seeing: it means the
+			// interactive path is broken on this device, which is invisible from
+			// the console.
+			log.Warn("reboot prompt could not be delivered; falling back to a plain notification",
+				"error", err.Error())
+			return "", false
+		}
+		return res.ActionClicked, res.Delivered
+	}
+}

--- a/agent/internal/heartbeat/reboot_prompt_wiring_test.go
+++ b/agent/internal/heartbeat/reboot_prompt_wiring_test.go
@@ -1,0 +1,71 @@
+package heartbeat
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/ipc"
+	"github.com/breeze-rmm/agent/internal/patching"
+)
+
+// TestRebootManagerIsBuiltWithThePromptSeam is a source assertion, in the idiom
+// of TestBrokerLifecycleCleanupNeverReopensRecordedPID (sessionbroker).
+//
+// The construction it guards sits inside the agent's start-up path, which cannot
+// be driven in a unit test without standing up a broker, a config and a server.
+// Reverting this one line to NewRebootManager compiles, passes every other test,
+// and silently removes the postponement prompt from every device — a regression
+// with no visible symptom short of a user watching their machine reboot with a
+// button they were promised.
+func TestRebootManagerIsBuiltWithThePromptSeam(t *testing.T) {
+	_, testFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	source, err := os.ReadFile(filepath.Join(filepath.Dir(testFile), "heartbeat.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(source)
+	if !strings.Contains(src, "patching.NewRebootManagerWithPrompt(") {
+		t.Error("heartbeat no longer builds the reboot manager with a prompt seam; the postponement dialog would never appear")
+	}
+	if !strings.Contains(src, "RequestNotificationDecision(") {
+		t.Error("the prompt seam no longer routes through the broker's correlated notification request")
+	}
+}
+
+// TestRebootPromptSeamShapeMatchesTheBroker pins that the two halves of the seam
+// still fit: patching.PromptFunc's signature on one side, and the broker request
+// it is implemented with on the other. A change to either that did not update the
+// other would otherwise only surface at the heartbeat's own build.
+func TestRebootPromptSeamShapeMatchesTheBroker(t *testing.T) {
+	var seen ipc.NotifyRequest
+	var fn patching.PromptFunc = func(title, body, urgency string, actions []string, timeout time.Duration) string {
+		seen = ipc.NotifyRequest{
+			Title:     title,
+			Body:      body,
+			Urgency:   urgency,
+			Actions:   actions,
+			TimeoutMs: int(timeout.Milliseconds()),
+		}
+		return actions[0]
+	}
+
+	got := fn("Restart Scheduled", "in 15 minutes", "normal",
+		[]string{patching.RebootActionRestartNow, "Postpone 1 hour"}, 90*time.Second)
+
+	if got != patching.RebootActionRestartNow {
+		t.Errorf("prompt returned %q, want %q", got, patching.RebootActionRestartNow)
+	}
+	if seen.TimeoutMs != 90_000 {
+		t.Errorf("TimeoutMs = %d, want 90000 — the manager's timeout must reach the helper's countdown", seen.TimeoutMs)
+	}
+	if len(seen.Actions) != 2 {
+		t.Fatalf("Actions = %v, want the two-button pair", seen.Actions)
+	}
+}

--- a/agent/internal/heartbeat/reboot_prompt_wiring_test.go
+++ b/agent/internal/heartbeat/reboot_prompt_wiring_test.go
@@ -1,6 +1,7 @@
 package heartbeat
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/breeze-rmm/agent/internal/ipc"
 	"github.com/breeze-rmm/agent/internal/patching"
+	"github.com/breeze-rmm/agent/internal/sessionbroker"
 )
 
 // TestRebootManagerIsBuiltWithThePromptSeam is a source assertion, in the idiom
@@ -34,38 +36,104 @@ func TestRebootManagerIsBuiltWithThePromptSeam(t *testing.T) {
 	if !strings.Contains(src, "patching.NewRebootManagerWithPrompt(") {
 		t.Error("heartbeat no longer builds the reboot manager with a prompt seam; the postponement dialog would never appear")
 	}
+	if !strings.Contains(src, "rebootPromptFunc(") {
+		t.Error("the prompt seam no longer routes through rebootPromptFunc, whose error handling is what the tests below pin")
+	}
 	if !strings.Contains(src, "RequestNotificationDecision(") {
 		t.Error("the prompt seam no longer routes through the broker's correlated notification request")
 	}
 }
 
-// TestRebootPromptSeamShapeMatchesTheBroker pins that the two halves of the seam
-// still fit: patching.PromptFunc's signature on one side, and the broker request
-// it is implemented with on the other. A change to either that did not update the
-// other would otherwise only surface at the heartbeat's own build.
-func TestRebootPromptSeamShapeMatchesTheBroker(t *testing.T) {
-	var seen ipc.NotifyRequest
-	var fn patching.PromptFunc = func(title, body, urgency string, actions []string, timeout time.Duration) string {
-		seen = ipc.NotifyRequest{
-			Title:     title,
-			Body:      body,
-			Urgency:   urgency,
-			Actions:   actions,
-			TimeoutMs: int(timeout.Milliseconds()),
-		}
-		return actions[0]
+// TestRebootPromptFuncTranslatesTheBrokerResult drives the REAL translation, not
+// a hand-rolled stand-in. The distinction this pins is the one that decides
+// whether a headless box gets warned at all: an unconfirmed prompt must report
+// shown=false so the manager falls back, while a delivered one must not, or every
+// rung would double.
+func TestRebootPromptFuncTranslatesTheBrokerResult(t *testing.T) {
+	cases := []struct {
+		name      string
+		res       ipc.NotifyResult
+		err       error
+		wantLabel string
+		wantShown bool
+	}{
+		{
+			name:      "the user clicked postpone",
+			res:       ipc.NotifyResult{Delivered: true, ActionClicked: "Postpone 1 hour"},
+			wantLabel: "Postpone 1 hour",
+			wantShown: true,
+		},
+		{
+			name:      "a real person saw the dialog and did nothing",
+			res:       ipc.NotifyResult{Delivered: true},
+			wantShown: true,
+		},
+		{
+			// The headless case, and the one the earlier version of this code got
+			// wrong: no notify-scoped session means the broker returns a zero
+			// result and NO error, which must not be mistaken for a silent user.
+			name:      "no helper session at all",
+			res:       ipc.NotifyResult{},
+			wantShown: false,
+		},
+		{
+			// The helper answered honestly that neither the dialog nor its toast
+			// fallback rendered.
+			name:      "the helper reached nobody",
+			res:       ipc.NotifyResult{Delivered: false},
+			wantShown: false,
+		},
+		{
+			name:      "the prompt went unanswered",
+			err:       fmt.Errorf("session s1: %w", sessionbroker.ErrCommandTimeout),
+			wantShown: false,
+		},
+		{
+			name:      "the transport broke",
+			err:       fmt.Errorf("session s1: broken pipe"),
+			wantShown: false,
+		},
 	}
 
-	got := fn("Restart Scheduled", "in 15 minutes", "normal",
-		[]string{patching.RebootActionRestartNow, "Postpone 1 hour"}, 90*time.Second)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var seen ipc.NotifyRequest
+			fn := rebootPromptFunc(func(req ipc.NotifyRequest, _ time.Duration) (ipc.NotifyResult, error) {
+				seen = req
+				return tc.res, tc.err
+			})
 
-	if got != patching.RebootActionRestartNow {
-		t.Errorf("prompt returned %q, want %q", got, patching.RebootActionRestartNow)
+			label, shown := fn("Restart Scheduled", "in 15 minutes", "normal",
+				[]string{patching.RebootActionRestartNow, "Postpone 1 hour"}, 90*time.Second)
+
+			if label != tc.wantLabel {
+				t.Errorf("clicked = %q, want %q", label, tc.wantLabel)
+			}
+			if shown != tc.wantShown {
+				t.Errorf("shown = %v, want %v", shown, tc.wantShown)
+			}
+			if seen.TimeoutMs != 90_000 {
+				t.Errorf("TimeoutMs = %d, want 90000 — the manager's window must reach the helper's countdown", seen.TimeoutMs)
+			}
+			if len(seen.Actions) != 2 || seen.Actions[0] != patching.RebootActionRestartNow {
+				t.Errorf("Actions = %v, want the affirmative first", seen.Actions)
+			}
+			if seen.Title != "Restart Scheduled" || seen.Urgency != "normal" {
+				t.Errorf("request = %+v, want the manager's title and urgency passed through", seen)
+			}
+		})
 	}
-	if seen.TimeoutMs != 90_000 {
-		t.Errorf("TimeoutMs = %d, want 90000 — the manager's timeout must reach the helper's countdown", seen.TimeoutMs)
-	}
-	if len(seen.Actions) != 2 {
-		t.Fatalf("Actions = %v, want the two-button pair", seen.Actions)
+}
+
+// TestRebootPromptFuncWithNoBrokerIsNotADecision covers the agent starting up
+// before the session broker exists.
+func TestRebootPromptFuncWithNoBrokerIsNotADecision(t *testing.T) {
+	fn := rebootPromptFunc(func(ipc.NotifyRequest, time.Duration) (ipc.NotifyResult, error) {
+		return ipc.NotifyResult{}, nil
+	})
+	label, shown := fn("Restart Scheduled", "in 15 minutes", "normal",
+		[]string{patching.RebootActionRestartNow, "Postpone 1 hour"}, time.Minute)
+	if label != "" || shown {
+		t.Errorf("clicked = %q, shown = %v; want no decision and no delivery", label, shown)
 	}
 }

--- a/agent/internal/ipc/message.go
+++ b/agent/internal/ipc/message.go
@@ -237,12 +237,21 @@ type IPCCommandResult struct {
 }
 
 // NotifyRequest asks the user helper to show a desktop notification.
+//
+// Actions turns it into an interactive prompt: a helper that understands them
+// renders a modal dialog with those buttons and answers with the clicked label
+// in NotifyResult.ActionClicked. Both Actions and TimeoutMs are optional and
+// omitempty, so an OLD helper still unmarshals the request and shows its plain
+// toast, and a NEW helper on an old agent simply never receives any actions.
 type NotifyRequest struct {
 	Title   string   `json:"title"`
 	Body    string   `json:"body"`
 	Icon    string   `json:"icon,omitempty"`
 	Urgency string   `json:"urgency,omitempty"`
 	Actions []string `json:"actions,omitempty"`
+	// TimeoutMs is how long the helper should hold an interactive prompt open
+	// before giving up and reporting no decision. Ignored when Actions is empty.
+	TimeoutMs int `json:"timeoutMs,omitempty"`
 }
 
 // NotifyResult is the user helper's response after showing a notification.

--- a/agent/internal/patching/reboot_manager.go
+++ b/agent/internal/patching/reboot_manager.go
@@ -87,6 +87,7 @@ type RebootManager struct {
 	notifyTimers     []*time.Timer
 	osTimer          *time.Timer
 	notifyFn         NotifyFunc
+	promptFn         PromptFunc
 	stopChan         chan struct{}
 	stopped          bool
 	maxRebootsPerDay int
@@ -94,7 +95,19 @@ type RebootManager struct {
 	// osInvoked records that the OS shutdown countdown has actually been
 	// started, so Cancel only tries to abort something that exists. Without it
 	// Cancel would always fail on macOS, where abortOSReboot can never succeed.
+	//
+	// Set only AFTER execOSReboot returns successfully. Setting it before, as
+	// this did originally, opened a window in which Cancel and a re-schedule both
+	// took the abort path while there was still nothing to abort: the abort
+	// "succeeded", the caller was told the reboot was off, and exec then ran and
+	// took the machine down anyway. osInvoking covers that window instead.
 	osInvoked bool
+	// osInvoking is true from the moment runOSReboot commits to the shutdown
+	// until execOSReboot returns. Nothing can be aborted in that window, so
+	// Cancel, Defer and a re-schedule are all REFUSED there rather than handed a
+	// success they cannot deliver — the same honesty rule Cancel already applies
+	// to a platform whose abort cannot work.
+	osInvoking bool
 	// generation identifies the current schedule. time.Timer.Stop() does not
 	// wait for an AfterFunc callback that has already started — those run on
 	// their own goroutines — so stopping the timers is not enough on its own:
@@ -122,13 +135,23 @@ type RebootManager struct {
 	deferralLedger func() string
 }
 
-// NewRebootManager creates a new RebootManager with circuit breaker protection.
+// NewRebootManager creates a new RebootManager with circuit breaker protection
+// and no interactive surface: every warning is a fire-and-forget notification,
+// exactly as before #3207.
 func NewRebootManager(notifyFn NotifyFunc, maxRebootsPerDay int) *RebootManager {
+	return NewRebootManagerWithPrompt(notifyFn, nil, maxRebootsPerDay)
+}
+
+// NewRebootManagerWithPrompt adds the interactive seam. promptFn may be nil,
+// which is the same manager NewRebootManager builds — a headless box, or a build
+// with no helper, must still warn the user and still reboot on time.
+func NewRebootManagerWithPrompt(notifyFn NotifyFunc, promptFn PromptFunc, maxRebootsPerDay int) *RebootManager {
 	if maxRebootsPerDay <= 0 {
 		maxRebootsPerDay = 3
 	}
 	rm := &RebootManager{
 		notifyFn:         notifyFn,
+		promptFn:         promptFn,
 		stopChan:         make(chan struct{}),
 		maxRebootsPerDay: maxRebootsPerDay,
 		nowFn:            time.Now,
@@ -193,6 +216,13 @@ func (r *RebootManager) scheduleLockedAt(now time.Time, delay time.Duration, dea
 		return fmt.Errorf("reboot manager is stopped")
 	}
 
+	// The shutdown command is being handed to the OS right now. There is nothing
+	// to abort yet and no way to recall it once it lands, so refuse rather than
+	// arm a new schedule on top of a reboot that is already going to happen.
+	if r.osInvoking {
+		return fmt.Errorf("the restart command is being handed to the operating system and cannot be superseded")
+	}
+
 	// An OS-level countdown may already be running: runOSReboot fires at
 	// OSInvokeAt, a minute before the machine actually goes down. That countdown
 	// lives in the OS, not this process, so simply re-arming Go timers on top of
@@ -249,10 +279,10 @@ func (r *RebootManager) scheduleLockedAt(now time.Time, delay time.Duration, dea
 		// failure, so the field describes only the most recent attempt.
 	}
 
-	for _, n := range plan.Notifications {
-		notif := n // capture for closure
-		r.notifyTimers = append(r.notifyTimers, r.afterFunc(notif.After, func() {
-			r.emitNotification(gen, notif)
+	for _, rung := range planRebootRungs(plan) {
+		rung := rung // capture for closure
+		r.notifyTimers = append(r.notifyTimers, r.afterFunc(rung.notification.After, func() {
+			r.emitNotification(gen, rung)
 		}))
 	}
 
@@ -310,7 +340,7 @@ func (r *RebootManager) Defer() (time.Duration, error) {
 	if r.stopped {
 		return 0, fmt.Errorf("reboot manager is stopped")
 	}
-	if r.osInvoked {
+	if r.osInvoked || r.osInvoking {
 		return 0, fmt.Errorf("the restart countdown has already started and cannot be postponed")
 	}
 	if !r.state.RebootScheduled {
@@ -374,6 +404,14 @@ func (r *RebootManager) ledgerPath() string {
 // misleading "no reboot scheduled" while a countdown was live.
 func (r *RebootManager) Cancel() error {
 	r.mu.Lock()
+	// The shutdown command is mid-flight. abortOSReboot has nothing to abort yet,
+	// so running it here would report a cancellation that never happened while
+	// exec still took the machine down. Refuse instead — the window is the length
+	// of one exec call.
+	if r.osInvoking {
+		r.mu.Unlock()
+		return fmt.Errorf("the restart command is being handed to the operating system and can no longer be cancelled")
+	}
 	if !r.state.RebootScheduled && !r.osInvoked {
 		r.mu.Unlock()
 		return fmt.Errorf("no reboot scheduled")
@@ -439,20 +477,109 @@ func (r *RebootManager) cancelLocked() {
 	r.notifyTimers = nil
 }
 
-func (r *RebootManager) emitNotification(gen uint64, n RebootNotification) {
+// emitNotification delivers one rung of the warning ladder, as an interactive
+// prompt when this rung may offer a postponement and as a plain notification
+// otherwise.
+//
+// Nothing here holds r.mu across the delivery. The prompt blocks for up to
+// maxRebootPromptWindow, and holding the lock would stall State(), Cancel(), the
+// OS timer callback and every sibling rung behind a dialog nobody is looking at.
+func (r *RebootManager) emitNotification(gen uint64, rung rebootRung) {
+	n := rung.notification
+
 	r.mu.Lock()
 	if r.stopped || gen != r.generation {
 		r.mu.Unlock()
 		return
 	}
 	notifyFn := r.notifyFn
+	promptFn := r.promptFn
+	policy := r.deferral
+	used := r.deferralsUsed
+	// ComputeDeferral is the single authority on whether a postponement is
+	// available, so the button offered here can never be one Defer() would then
+	// refuse. It is pure, so calling it under the lock costs nothing.
+	canPostpone := policy.Allowed && ComputeDeferral(
+		policy, used, r.nowFn(), r.state.ScheduledAt, r.state.Deadline).Granted
 	r.state.NotifiedUser = true
 	r.state.NotificationSent = r.nowFn()
 	r.mu.Unlock()
 
-	if notifyFn != nil {
-		notifyFn(n.Title, n.Body, n.Urgency)
+	body := rebootPromptBody(n.Body, rebootDeferralNote(policy, used, canPostpone))
+
+	offerPrompt := rung.deferrable && promptFn != nil && canPostpone
+	if !offerPrompt {
+		if notifyFn != nil {
+			notifyFn(n.Title, body, n.Urgency)
+		}
+		return
 	}
+
+	actions := []string{
+		RebootActionRestartNow,
+		rebootActionPostpone(time.Duration(policy.DeferralMinutes) * time.Minute),
+	}
+	clicked := promptFn(n.Title, body, n.Urgency, actions, rung.promptWindow)
+
+	switch clicked {
+	case "":
+		// No decision. Proceed exactly as scheduled — silence is never a
+		// postponement and never an acceleration. The prompt itself was the
+		// warning, so nothing more is emitted.
+	case RebootActionRestartNow:
+		if err := r.restartNow(gen); err != nil {
+			log.Warn("could not honour Restart now", "error", err.Error())
+			r.notifyUser("Restart Could Not Be Started", err.Error(), "critical")
+		}
+	case actions[1]:
+		// Compared against the label we sent rather than a well-known constant:
+		// the helper echoes back a string, and only the exact offer counts.
+		if _, err := r.Defer(); err != nil {
+			// Refused after the fact — the operator cancelled while the dialog
+			// was open, or the deadline moved. Say so rather than leaving the
+			// click looking like it worked.
+			log.Info("postponement refused", "reason", err.Error())
+			r.notifyUser("Restart Cannot Be Postponed", err.Error(), "critical")
+		}
+	default:
+		log.Warn("reboot prompt returned a label that was never offered", "clicked", clicked)
+	}
+}
+
+// notifyUser sends a one-off notification outside the ladder, used to tell the
+// user why a button they pressed did not do what it promised.
+func (r *RebootManager) notifyUser(title, body, urgency string) {
+	r.mu.Lock()
+	notifyFn := r.notifyFn
+	r.mu.Unlock()
+	if notifyFn != nil {
+		notifyFn(title, body, urgency)
+	}
+}
+
+// restartNow collapses the countdown to the shortest schedule the planner allows.
+//
+// NOT an immediate reboot: PlanReboot(MinRebootDelay) still emits the closing
+// notice and still hands the OS a non-zero grace, which is the race #3197 exists
+// to prevent. The deferral policy is carried over so a user who changes their
+// mind at the new lead rung is not silently locked out.
+//
+// gen is checked under the lock because ScheduleWithOptions has no generation
+// check of its own: a "Restart now" answered after the operator cancelled would
+// otherwise arm a brand-new reboot they had just called off — the same
+// resurrection hazard Defer() documents.
+func (r *RebootManager) restartNow(gen uint64) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.stopped {
+		return fmt.Errorf("reboot manager is stopped")
+	}
+	if gen != r.generation || !r.state.RebootScheduled {
+		return fmt.Errorf("the restart was cancelled or rescheduled while the prompt was open")
+	}
+	return r.scheduleLockedAt(r.nowFn(), MinRebootDelay, r.state.Deadline,
+		r.state.Reason, r.state.Source, RebootOptions{Deferral: r.deferral})
 }
 
 func (r *RebootManager) runOSReboot(gen uint64, grace time.Duration) {
@@ -497,7 +624,13 @@ func (r *RebootManager) runOSReboot(gen uint64, grace time.Duration) {
 	// Record this reboot
 	r.rebootHistory = append(r.rebootHistory, now)
 	r.state.RebootScheduled = false
-	r.osInvoked = true
+	// osInvoking, NOT osInvoked: the shutdown command has not been issued yet.
+	// Marking it invoked here — as this did originally — meant that for the whole
+	// duration of the exec call, Cancel() and a re-schedule both took the abort
+	// path, abortOSReboot found nothing to abort and returned success, and the
+	// machine then went down anyway at the original time. Only exec's own success
+	// promotes this to osInvoked, from which point the abort is real.
+	r.osInvoking = true
 	exec := r.execOSReboot
 	r.mu.Unlock()
 
@@ -507,21 +640,25 @@ func (r *RebootManager) runOSReboot(gen uint64, grace time.Duration) {
 	if exec == nil {
 		log.Error("no OS reboot implementation for this platform")
 		r.mu.Lock()
-		r.osInvoked = false
+		r.osInvoking = false
 		r.state.LastError = "no OS reboot implementation for this platform"
 		r.mu.Unlock()
 		return
 	}
-	if err := exec(grace); err != nil {
-		r.mu.Lock()
-		r.osInvoked = false
+	err := exec(grace)
+	r.mu.Lock()
+	r.osInvoking = false
+	if err != nil {
 		r.state.LastError = fmt.Sprintf("OS reboot invocation failed: %v", err)
 		r.mu.Unlock()
 		// A failed shutdown invocation used to be discarded entirely: the old
 		// code called exec.Command(...).Run() and ignored the error, so a
 		// blocked or missing shutdown binary looked identical to a reboot.
 		log.Error("failed to invoke OS reboot", "error", err, "grace", grace.String())
+		return
 	}
+	r.osInvoked = true
+	r.mu.Unlock()
 }
 
 func rebootHistoryPath() string {

--- a/agent/internal/patching/reboot_manager.go
+++ b/agent/internal/patching/reboot_manager.go
@@ -317,6 +317,26 @@ func (r *RebootManager) scheduleLockedAt(now time.Time, delay time.Duration, dea
 // has no cancel flag), so granting a deferral there would report success while
 // the machine still went down — the same class of lie Cancel() documents.
 func (r *RebootManager) Defer() (time.Duration, error) {
+	return r.deferSchedule(nil)
+}
+
+// deferForGeneration is Defer bound to the schedule that was live when the
+// caller started, refusing once that schedule has been superseded.
+//
+// The prompt needs this and the public Defer cannot provide it. A dialog blocks
+// for up to two minutes, and Defer's own checks only ask whether SOME reboot is
+// scheduled — so a user answering a prompt for the reboot that was replaced while
+// they read it would postpone the REPLACEMENT and spend its budget. That is the
+// same resurrection class Defer's comment describes for Cancel, one schedule
+// along: not a reboot brought back from the dead, but a different administrator's
+// reboot moved by a click that was never about it.
+func (r *RebootManager) deferForGeneration(gen uint64) (time.Duration, error) {
+	return r.deferSchedule(&gen)
+}
+
+// deferSchedule is the whole of Defer. gen, when non-nil, is the generation the
+// caller's decision belongs to.
+func (r *RebootManager) deferSchedule(gen *uint64) (time.Duration, error) {
 	// ONE atomic section: check, re-schedule, record the increment and persist
 	// it, without ever releasing mu. Every split version of this has a hole:
 	//
@@ -345,6 +365,9 @@ func (r *RebootManager) Defer() (time.Duration, error) {
 	}
 	if !r.state.RebootScheduled {
 		return 0, fmt.Errorf("no reboot scheduled")
+	}
+	if gen != nil && *gen != r.generation {
+		return 0, fmt.Errorf("the restart was cancelled or rescheduled while the prompt was open")
 	}
 
 	// One clock sample for both the decision and the re-schedule; see
@@ -519,7 +542,21 @@ func (r *RebootManager) emitNotification(gen uint64, rung rebootRung) {
 		RebootActionRestartNow,
 		rebootActionPostpone(time.Duration(policy.DeferralMinutes) * time.Minute),
 	}
-	clicked := promptFn(n.Title, body, n.Urgency, actions, rung.promptWindow)
+	clicked, shown := promptFn(n.Title, body, n.Urgency, actions, rung.promptWindow)
+	if !shown {
+		// The prompt reached nobody: no helper session, an IPC failure, or a
+		// helper that could put nothing on screen. The user must still be TOLD,
+		// so fall back to the notification this rung would have sent with
+		// deferral off. Without this the interactive path SWALLOWS every
+		// deferrable rung on any device with no signed-in helper — a headless
+		// server, a Windows box at the logon screen, a crashed helper — leaving
+		// only the closing notice and quietly reintroducing #3197 for exactly the
+		// machines the ladder was written for.
+		if notifyFn != nil {
+			notifyFn(n.Title, body, n.Urgency)
+		}
+		return
+	}
 
 	switch clicked {
 	case "":
@@ -534,10 +571,10 @@ func (r *RebootManager) emitNotification(gen uint64, rung rebootRung) {
 	case actions[1]:
 		// Compared against the label we sent rather than a well-known constant:
 		// the helper echoes back a string, and only the exact offer counts.
-		if _, err := r.Defer(); err != nil {
-			// Refused after the fact — the operator cancelled while the dialog
-			// was open, or the deadline moved. Say so rather than leaving the
-			// click looking like it worked.
+		if _, err := r.deferForGeneration(gen); err != nil {
+			// Refused after the fact — the operator cancelled or replaced the
+			// schedule while the dialog was open, or the deadline moved. Say so
+			// rather than leaving the click looking like it worked.
 			log.Info("postponement refused", "reason", err.Error())
 			r.notifyUser("Restart Cannot Be Postponed", err.Error(), "critical")
 		}

--- a/agent/internal/patching/reboot_manager_prompt_test.go
+++ b/agent/internal/patching/reboot_manager_prompt_test.go
@@ -28,15 +28,15 @@ func newPromptTestManager(t *testing.T, maxPerDay int, replies ...string) (
 	rm, timers, notifications, osCalls, clock, _ := newDeferralTestManager(t, maxPerDay)
 	var mu sync.Mutex
 	prompts := []promptCall{}
-	rm.promptFn = func(title, body, urgency string, actions []string, timeout time.Duration) string {
+	rm.promptFn = func(title, body, urgency string, actions []string, timeout time.Duration) (string, bool) {
 		mu.Lock()
 		i := len(prompts)
 		prompts = append(prompts, promptCall{title, body, urgency, append([]string{}, actions...), timeout})
 		mu.Unlock()
 		if i < len(replies) {
-			return replies[i]
+			return replies[i], true
 		}
-		return ""
+		return "", true
 	}
 	return rm, timers, notifications, osCalls, clock, &prompts
 }
@@ -330,10 +330,10 @@ func TestPromptDoesNotHoldTheManagerLock(t *testing.T) {
 	rm, timers, _, _, clock, _ := newDeferralTestManager(t, 3)
 	inPrompt := make(chan struct{})
 	release := make(chan struct{})
-	rm.promptFn = func(string, string, string, []string, time.Duration) string {
+	rm.promptFn = func(string, string, string, []string, time.Duration) (string, bool) {
 		close(inPrompt)
 		<-release
-		return ""
+		return "", true
 	}
 	if err := rm.ScheduleWithOptions(60*time.Minute, clock.now().Add(5*time.Hour), "Patch", "patch_job",
 		allowDeferral(2, 60)); err != nil {
@@ -368,10 +368,10 @@ func TestPostponeIsRefusedAfterACancelAndTheUserIsTold(t *testing.T) {
 	rm, timers, notifications, osCalls, clock, _ := newDeferralTestManager(t, 3)
 	inPrompt := make(chan struct{})
 	release := make(chan struct{})
-	rm.promptFn = func(_, _, _ string, actions []string, _ time.Duration) string {
+	rm.promptFn = func(_, _, _ string, actions []string, _ time.Duration) (string, bool) {
 		close(inPrompt)
 		<-release
-		return actions[1] // Postpone
+		return actions[1], true // Postpone
 	}
 	if err := rm.ScheduleWithOptions(60*time.Minute, clock.now().Add(5*time.Hour), "Patch", "patch_job",
 		allowDeferral(2, 60)); err != nil {
@@ -420,10 +420,10 @@ func TestRestartNowIsRefusedAfterACancel(t *testing.T) {
 	rm, timers, _, osCalls, clock, _ := newDeferralTestManager(t, 3)
 	inPrompt := make(chan struct{})
 	release := make(chan struct{})
-	rm.promptFn = func(string, string, string, []string, time.Duration) string {
+	rm.promptFn = func(string, string, string, []string, time.Duration) (string, bool) {
 		close(inPrompt)
 		<-release
-		return RebootActionRestartNow
+		return RebootActionRestartNow, true
 	}
 	if err := rm.ScheduleWithOptions(60*time.Minute, clock.now().Add(5*time.Hour), "Patch", "patch_job",
 		allowDeferral(2, 60)); err != nil {
@@ -625,5 +625,129 @@ func TestFailedOSInvocationLeavesNothingToAbort(t *testing.T) {
 	// rather than refused as "an OS reboot is being invoked".
 	if err := rm.Schedule(time.Hour, clock.now().Add(6*time.Hour), "Retry", "manual"); err != nil {
 		t.Fatalf("re-schedule after a failed OS invocation: %v", err)
+	}
+}
+
+// TestPostponeIsRefusedAfterTheScheduleWasReplaced is the review finding this
+// wave created and the public Defer() cannot catch on its own.
+//
+// Defer() asks only whether SOME reboot is scheduled. A dialog blocks for up to
+// two minutes, so a user answering a prompt for the reboot that was REPLACED
+// while they read it would postpone the replacement and spend its budget — a
+// different administrator's reboot moved by a click that was never about it.
+// Cancel-without-replacement was already caught; this is the same hazard one
+// schedule along.
+func TestPostponeIsRefusedAfterTheScheduleWasReplaced(t *testing.T) {
+	rm, timers, notifications, _, clock, _ := newDeferralTestManager(t, 3)
+	inPrompt := make(chan struct{})
+	release := make(chan struct{})
+	rm.promptFn = func(_, _, _ string, actions []string, _ time.Duration) (string, bool) {
+		close(inPrompt)
+		<-release
+		return actions[1], true // Postpone
+	}
+	if err := rm.ScheduleWithOptions(60*time.Minute, clock.now().Add(5*time.Hour), "First", "patch_job",
+		allowDeferral(2, 60)); err != nil {
+		t.Fatalf("ScheduleWithOptions: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		timers.runAt(0)
+		close(done)
+	}()
+	<-inPrompt
+
+	// A second, unrelated dispatch supersedes the first while the dialog is open.
+	if err := rm.ScheduleWithOptions(30*time.Minute, clock.now().Add(5*time.Hour), "Second", "manual",
+		allowDeferral(2, 60)); err != nil {
+		t.Fatalf("replacement ScheduleWithOptions: %v", err)
+	}
+	replacementAt := rm.State().ScheduledAt
+
+	close(release)
+	<-done
+
+	st := rm.State()
+	if st.DeferralsUsed != 0 {
+		t.Errorf("DeferralsUsed = %d — the stale answer spent the replacement's budget", st.DeferralsUsed)
+	}
+	if !st.ScheduledAt.Equal(replacementAt) {
+		t.Errorf("the replacement moved from %v to %v because of a click about the schedule it replaced",
+			replacementAt, st.ScheduledAt)
+	}
+	if st.Reason != "Second" {
+		t.Errorf("Reason = %q, want the replacement's", st.Reason)
+	}
+	var told bool
+	for _, n := range *notifications {
+		if strings.Contains(n.title, "Cannot Be Postponed") {
+			told = true
+		}
+	}
+	if !told {
+		t.Errorf("the user was never told their postponement did not apply; notifications = %+v", *notifications)
+	}
+}
+
+// TestPublicDeferStillWorksWithoutAGeneration guards against the generation
+// check leaking into the public API, which the console's own postpone command
+// calls with no prompt and no generation in hand.
+func TestPublicDeferStillWorksWithoutAGeneration(t *testing.T) {
+	rm, _, _, _, clock, _ := newDeferralTestManager(t, 3)
+	if err := rm.ScheduleWithOptions(60*time.Minute, clock.now().Add(5*time.Hour), "Patch", "patch_job",
+		allowDeferral(2, 60)); err != nil {
+		t.Fatalf("ScheduleWithOptions: %v", err)
+	}
+	if _, err := rm.Defer(); err != nil {
+		t.Fatalf("Defer: %v", err)
+	}
+	if got := rm.State().DeferralsUsed; got != 1 {
+		t.Errorf("DeferralsUsed = %d, want 1", got)
+	}
+}
+
+// TestHeadlessBoxStillGetsEveryWarning is the production shape my earlier
+// headless test missed. TestPromptAbsentFallsBackToAPlainNotification uses a NIL
+// promptFn — but the heartbeat always wires one, so on a real headless box (or a
+// Windows server at the logon screen, or a machine whose helper crashed) promptFn
+// is non-nil and simply reports that nothing was shown. Every deferrable rung
+// must still warn through the ordinary notification path.
+func TestHeadlessBoxStillGetsEveryWarning(t *testing.T) {
+	rm, timers, notifications, _, clock, _ := newDeferralTestManager(t, 3)
+	rm.promptFn = func(string, string, string, []string, time.Duration) (string, bool) {
+		return "", false // no session, nothing rendered
+	}
+	if err := rm.ScheduleWithOptions(15*time.Minute, clock.now().Add(5*time.Hour), "Patch", "patch_job",
+		allowDeferral(2, 60)); err != nil {
+		t.Fatalf("ScheduleWithOptions: %v", err)
+	}
+
+	timers.runAt(0)
+
+	if len(*notifications) != 1 {
+		t.Fatalf("notifications = %d, want 1 — a deferrable rung warned nobody at all (#3197)", len(*notifications))
+	}
+	if rm.State().DeferralsUsed != 0 {
+		t.Error("a prompt that never rendered deferred something")
+	}
+}
+
+// TestAShownPromptIsNotFollowedByARedundantToast: when the dialog really did
+// render, it WAS the warning. Emitting a toast on top would double every rung.
+func TestAShownPromptIsNotFollowedByARedundantToast(t *testing.T) {
+	rm, timers, notifications, _, clock, _ := newDeferralTestManager(t, 3)
+	rm.promptFn = func(string, string, string, []string, time.Duration) (string, bool) {
+		return "", true // shown, user did nothing
+	}
+	if err := rm.ScheduleWithOptions(15*time.Minute, clock.now().Add(5*time.Hour), "Patch", "patch_job",
+		allowDeferral(2, 60)); err != nil {
+		t.Fatalf("ScheduleWithOptions: %v", err)
+	}
+
+	timers.runAt(0)
+
+	if len(*notifications) != 0 {
+		t.Errorf("notifications = %d, want 0 — the dialog was the warning: %+v", len(*notifications), *notifications)
 	}
 }

--- a/agent/internal/patching/reboot_manager_prompt_test.go
+++ b/agent/internal/patching/reboot_manager_prompt_test.go
@@ -1,0 +1,629 @@
+// Untagged on purpose — see reboot_plan.go. The prompt seam exists precisely so
+// the state machine behind the dialog is asserted without a UI.
+package patching
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type promptCall struct {
+	title   string
+	body    string
+	urgency string
+	actions []string
+	timeout time.Duration
+}
+
+// newPromptTestManager extends newDeferralTestManager with a scripted prompt
+// seam. replies is consulted per call, in order; a short list means every later
+// call returns "" (no decision).
+func newPromptTestManager(t *testing.T, maxPerDay int, replies ...string) (
+	*RebootManager, *fakeTimers, *[]notifyCall, *[]time.Duration, *fakeClock, *[]promptCall,
+) {
+	t.Helper()
+	rm, timers, notifications, osCalls, clock, _ := newDeferralTestManager(t, maxPerDay)
+	var mu sync.Mutex
+	prompts := []promptCall{}
+	rm.promptFn = func(title, body, urgency string, actions []string, timeout time.Duration) string {
+		mu.Lock()
+		i := len(prompts)
+		prompts = append(prompts, promptCall{title, body, urgency, append([]string{}, actions...), timeout})
+		mu.Unlock()
+		if i < len(replies) {
+			return replies[i]
+		}
+		return ""
+	}
+	return rm, timers, notifications, osCalls, clock, &prompts
+}
+
+// TestPromptOfferedOnlyWhileDeferralsRemain: offering a button that Defer() will
+// refuse is worse than offering none.
+func TestPromptOfferedOnlyWhileDeferralsRemain(t *testing.T) {
+	rm, timers, _, _, clock, prompts := newPromptTestManager(t, 3, rebootActionPostpone(time.Hour))
+	if err := rm.ScheduleWithOptions(15*time.Minute, clock.now().Add(5*time.Hour), "Patch", "patch_job",
+		allowDeferral(1, 60)); err != nil {
+		t.Fatalf("ScheduleWithOptions: %v", err)
+	}
+
+	timers.runAt(0) // lead rung: budget available -> prompt with two buttons
+	if len(*prompts) != 1 {
+		t.Fatalf("prompts = %d, want 1", len(*prompts))
+	}
+	if len((*prompts)[0].actions) != 2 {
+		t.Fatalf("actions = %v, want 2 buttons", (*prompts)[0].actions)
+	}
+	if rm.State().DeferralsUsed != 1 {
+		t.Fatalf("DeferralsUsed = %d, want 1", rm.State().DeferralsUsed)
+	}
+
+	before := len(*prompts)
+	timers.runAt(0) // the re-scheduled lead rung: budget now exhausted
+	if len(*prompts) != before {
+		t.Errorf("a prompt was offered with zero deferrals remaining: %v", (*prompts)[before].actions)
+	}
+}
+
+// TestPostponeClickDefersTheSchedule proves the click really moves the countdown
+// rather than just recording an intention.
+func TestPostponeClickDefersTheSchedule(t *testing.T) {
+	rm, timers, _, osCalls, clock, _ := newPromptTestManager(t, 3, rebootActionPostpone(time.Hour))
+	if err := rm.ScheduleWithOptions(15*time.Minute, clock.now().Add(5*time.Hour), "Patch", "patch_job",
+		allowDeferral(2, 60)); err != nil {
+		t.Fatalf("ScheduleWithOptions: %v", err)
+	}
+
+	timers.runAt(0)
+
+	st := rm.State()
+	if st.DeferralsUsed != 1 {
+		t.Errorf("DeferralsUsed = %d, want 1", st.DeferralsUsed)
+	}
+	if !st.RebootScheduled {
+		t.Error("RebootScheduled = false after a postponement")
+	}
+	if len(*osCalls) != 0 {
+		t.Fatal("a postponement invoked the OS reboot")
+	}
+	// W2 adds the window to the SCHEDULED time, not to now, so a 15-minute
+	// schedule postponed by 60 minutes now lands 75 minutes out.
+	want := PlanReboot(75 * time.Minute).OSInvokeAt
+	found := false
+	for _, off := range timers.offsets() {
+		if off == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("no timer armed at %v after the postponement; offsets = %v", want, timers.offsets())
+	}
+}
+
+// TestRestartNowShortensTheCountdownWithoutSkippingTheClosingNotice: "Restart
+// now" must NOT reboot instantly. The closing notice still has to render before
+// the session goes away, which is the exact race #3197 fixed.
+func TestRestartNowShortensTheCountdownWithoutSkippingTheClosingNotice(t *testing.T) {
+	rm, timers, notifications, osCalls, clock, _ := newPromptTestManager(t, 3, RebootActionRestartNow)
+	if err := rm.ScheduleWithOptions(60*time.Minute, clock.now().Add(5*time.Hour), "Patch", "patch_job",
+		allowDeferral(2, 60)); err != nil {
+		t.Fatalf("ScheduleWithOptions: %v", err)
+	}
+
+	timers.runAt(0)
+
+	if len(*osCalls) != 0 {
+		t.Fatal("Restart now invoked the OS reboot synchronously")
+	}
+	if rm.State().DeferralsUsed != 0 {
+		t.Error("Restart now consumed a postponement")
+	}
+
+	plan := PlanReboot(MinRebootDelay)
+	before := len(*notifications)
+	timers.runAt(plan.OSInvokeAt)
+	if len(*notifications) <= before {
+		t.Error("the shortened schedule emitted no closing notice before the OS invocation")
+	}
+	if len(*osCalls) != 1 {
+		t.Fatalf("osCalls = %d, want 1 after the shortened countdown elapsed", len(*osCalls))
+	}
+	if (*osCalls)[0] < time.Minute {
+		t.Errorf("OS grace = %v, want at least a minute so the closing toast renders", (*osCalls)[0])
+	}
+}
+
+// TestNoAnswerLeavesTheScheduleExactlyAsItWas: silence is never a postponement
+// and never an acceleration.
+func TestNoAnswerLeavesTheScheduleExactlyAsItWas(t *testing.T) {
+	rm, timers, _, osCalls, clock, prompts := newPromptTestManager(t, 3) // no replies -> ""
+	if err := rm.ScheduleWithOptions(60*time.Minute, clock.now().Add(5*time.Hour), "Patch", "patch_job",
+		allowDeferral(2, 60)); err != nil {
+		t.Fatalf("ScheduleWithOptions: %v", err)
+	}
+	scheduledAt := rm.State().ScheduledAt
+	offsetsBefore := len(timers.offsets())
+
+	timers.runAt(0)
+
+	if len(*prompts) != 1 {
+		t.Fatalf("prompts = %d, want 1", len(*prompts))
+	}
+	st := rm.State()
+	if st.DeferralsUsed != 0 {
+		t.Error("silence granted a postponement")
+	}
+	if !st.ScheduledAt.Equal(scheduledAt) {
+		t.Errorf("ScheduledAt moved from %v to %v on no answer", scheduledAt, st.ScheduledAt)
+	}
+	if got := len(timers.offsets()); got != offsetsBefore {
+		t.Errorf("silence re-armed the schedule: %d timers, want %d", got, offsetsBefore)
+	}
+	if len(*osCalls) != 0 {
+		t.Error("silence invoked the OS reboot early")
+	}
+}
+
+// TestPromptIsNeverOfferedOnTheClosingRung: the critical notice fires at
+// OSInvokeAt, and Defer() is refused from that moment on because the countdown is
+// in the OS. A button there would always fail.
+func TestPromptIsNeverOfferedOnTheClosingRung(t *testing.T) {
+	rm, timers, notifications, _, clock, prompts := newPromptTestManager(t, 3, rebootActionPostpone(time.Hour))
+	if err := rm.ScheduleWithOptions(60*time.Minute, clock.now().Add(5*time.Hour), "Patch", "patch_job",
+		allowDeferral(2, 60)); err != nil {
+		t.Fatalf("ScheduleWithOptions: %v", err)
+	}
+
+	plan := PlanReboot(60 * time.Minute)
+	timers.runAt(plan.OSInvokeAt)
+
+	if len(*prompts) != 0 {
+		t.Fatalf("the closing rung offered a button: %v", (*prompts)[0].actions)
+	}
+	if len(*notifications) == 0 {
+		t.Fatal("the closing rung emitted no notification at all")
+	}
+}
+
+// TestPromptIsNeverOfferedWhenTheWholeScheduleCollapses covers PlanReboot's
+// single-notification case (a delay at or near MinRebootDelay), where the only
+// rung IS the closing one and its offset is zero.
+func TestPromptIsNeverOfferedWhenTheWholeScheduleCollapses(t *testing.T) {
+	rm, timers, notifications, _, clock, prompts := newPromptTestManager(t, 3, rebootActionPostpone(time.Hour))
+	if err := rm.ScheduleWithOptions(MinRebootDelay, clock.now().Add(5*time.Hour), "Patch", "patch_job",
+		allowDeferral(2, 60)); err != nil {
+		t.Fatalf("ScheduleWithOptions: %v", err)
+	}
+
+	timers.runAt(0)
+
+	if len(*prompts) != 0 {
+		t.Fatalf("the collapsed schedule's only rung offered a button: %v", (*prompts)[0].actions)
+	}
+	if len(*notifications) != 1 {
+		t.Fatalf("notifications = %d, want 1 — the user must still be warned", len(*notifications))
+	}
+}
+
+// TestPromptAbsentFallsBackToAPlainNotification: no helper session (every Linux
+// box before W4, and Windows at the logon screen). The #3197 invariant does not
+// depend on the prompt.
+func TestPromptAbsentFallsBackToAPlainNotification(t *testing.T) {
+	rm, timers, notifications, _, clock, _ := newDeferralTestManager(t, 3) // promptFn stays nil
+	if err := rm.ScheduleWithOptions(15*time.Minute, clock.now().Add(5*time.Hour), "Patch", "patch_job",
+		allowDeferral(2, 60)); err != nil {
+		t.Fatalf("ScheduleWithOptions: %v", err)
+	}
+
+	timers.runAt(0)
+
+	if len(*notifications) != 1 {
+		t.Fatalf("notifications = %d, want 1 — the user must still be warned", len(*notifications))
+	}
+	if rm.State().DeferralsUsed != 0 {
+		t.Error("a nil prompt seam deferred something")
+	}
+}
+
+// TestDeferralOffTakesTheIdenticalPathItTakesToday is the W3 acceptance criterion
+// that protects every existing deployment: with deferral off, nothing about the
+// notification path may change.
+func TestDeferralOffTakesTheIdenticalPathItTakesToday(t *testing.T) {
+	rm, timers, notifications, _, clock, prompts := newPromptTestManager(t, 3, rebootActionPostpone(time.Hour))
+	if err := rm.Schedule(15*time.Minute, clock.now().Add(5*time.Hour), "Patch", "patch_job"); err != nil {
+		t.Fatalf("Schedule: %v", err)
+	}
+
+	timers.runAt(0)
+
+	if len(*prompts) != 0 {
+		t.Fatalf("a non-deferrable reboot offered a postponement: %v", (*prompts)[0].actions)
+	}
+	if len(*notifications) != 1 {
+		t.Fatalf("notifications = %d, want 1", len(*notifications))
+	}
+	if body := (*notifications)[0].body; strings.Contains(strings.ToLower(body), "postpone") {
+		t.Errorf("a non-deferrable reboot mentioned postponement: %q", body)
+	}
+}
+
+// TestPromptBodyStatesTheRemainingPostponements: a user who cannot tell how much
+// budget is left cannot plan around it.
+func TestPromptBodyStatesTheRemainingPostponements(t *testing.T) {
+	rm, timers, _, _, clock, prompts := newPromptTestManager(t, 3) // no answer
+	if err := rm.ScheduleWithOptions(60*time.Minute, clock.now().Add(5*time.Hour), "Patch", "patch_job",
+		allowDeferral(3, 60)); err != nil {
+		t.Fatalf("ScheduleWithOptions: %v", err)
+	}
+
+	timers.runAt(0)
+
+	if len(*prompts) != 1 {
+		t.Fatalf("prompts = %d, want 1", len(*prompts))
+	}
+	body := (*prompts)[0].body
+	if !strings.Contains(body, "3 more times") {
+		t.Errorf("prompt body %q does not say how many postponements remain", body)
+	}
+	if !strings.Contains(body, "restart") && !strings.Contains(body, "Restart") {
+		t.Errorf("prompt body %q lost the original warning text", body)
+	}
+}
+
+// TestExhaustedBudgetTellsTheUserTheyCannotPostponeAgain: the button is gone, but
+// silently dropping it would leave a user who postponed twice expecting a third
+// chance.
+func TestExhaustedBudgetTellsTheUserTheyCannotPostponeAgain(t *testing.T) {
+	rm, timers, notifications, _, clock, prompts := newPromptTestManager(t, 3, rebootActionPostpone(time.Hour))
+	if err := rm.ScheduleWithOptions(60*time.Minute, clock.now().Add(5*time.Hour), "Patch", "patch_job",
+		allowDeferral(1, 60)); err != nil {
+		t.Fatalf("ScheduleWithOptions: %v", err)
+	}
+
+	timers.runAt(0) // spends the only postponement
+	if len(*prompts) != 1 {
+		t.Fatalf("prompts = %d, want 1", len(*prompts))
+	}
+	before := len(*notifications)
+
+	timers.runAt(0) // the re-scheduled lead rung, budget now exhausted
+	if len(*notifications) <= before {
+		t.Fatal("the re-scheduled lead rung emitted no notification")
+	}
+	body := (*notifications)[len(*notifications)-1].body
+	if !strings.Contains(strings.ToLower(body), "no longer be postponed") {
+		t.Errorf("notification body %q does not tell the user the budget is spent", body)
+	}
+}
+
+// TestPromptIsNotOfferedOnceTheDeadlineLeavesNoRoom: the counter is a UX
+// affordance, the DEADLINE is the guarantee (#3253). A budget with postponements
+// left on paper still yields no button once the deadline sits before the
+// currently scheduled time, because clamping to it would pull the restart
+// FORWARD — which ComputeDeferral refuses outright.
+func TestPromptIsNotOfferedOnceTheDeadlineLeavesNoRoom(t *testing.T) {
+	rm, timers, notifications, _, clock, prompts := newPromptTestManager(t, 3, rebootActionPostpone(time.Hour))
+	// Five postponements left on paper, but the deadline is already behind the
+	// scheduled time — a stale deadline, or a clock step.
+	if err := rm.ScheduleWithOptions(30*time.Minute, clock.now().Add(5*time.Minute), "Patch", "patch_job",
+		allowDeferral(5, 60)); err != nil {
+		t.Fatalf("ScheduleWithOptions: %v", err)
+	}
+
+	timers.runAt(0)
+
+	if len(*prompts) != 0 {
+		t.Fatalf("a postponement was offered past the deadline: %v", (*prompts)[0].actions)
+	}
+	if len(*notifications) != 1 {
+		t.Fatalf("notifications = %d, want 1 — the user must still be warned", len(*notifications))
+	}
+}
+
+// TestPromptDoesNotHoldTheManagerLock: the dialog blocks for up to two minutes.
+// Holding r.mu across it would stall State(), Cancel() and every timer callback —
+// including the OS invocation.
+func TestPromptDoesNotHoldTheManagerLock(t *testing.T) {
+	rm, timers, _, _, clock, _ := newDeferralTestManager(t, 3)
+	inPrompt := make(chan struct{})
+	release := make(chan struct{})
+	rm.promptFn = func(string, string, string, []string, time.Duration) string {
+		close(inPrompt)
+		<-release
+		return ""
+	}
+	if err := rm.ScheduleWithOptions(60*time.Minute, clock.now().Add(5*time.Hour), "Patch", "patch_job",
+		allowDeferral(2, 60)); err != nil {
+		t.Fatalf("ScheduleWithOptions: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		timers.runAt(0)
+		close(done)
+	}()
+	<-inPrompt
+
+	stated := make(chan RebootState, 1)
+	go func() { stated <- rm.State() }()
+	select {
+	case <-stated:
+	case <-time.After(3 * time.Second):
+		close(release)
+		t.Fatal("State() blocked while a prompt was on screen — the manager lock is held across the dialog")
+	}
+
+	close(release)
+	<-done
+}
+
+// TestPostponeIsRefusedAfterACancelAndTheUserIsTold: a technician cancelling from
+// the console while the signed-in user answers the prompt is exactly the shape
+// this wave creates. The click must not resurrect the cancelled reboot, and the
+// user must not be left thinking their postponement worked.
+func TestPostponeIsRefusedAfterACancelAndTheUserIsTold(t *testing.T) {
+	rm, timers, notifications, osCalls, clock, _ := newDeferralTestManager(t, 3)
+	inPrompt := make(chan struct{})
+	release := make(chan struct{})
+	rm.promptFn = func(_, _, _ string, actions []string, _ time.Duration) string {
+		close(inPrompt)
+		<-release
+		return actions[1] // Postpone
+	}
+	if err := rm.ScheduleWithOptions(60*time.Minute, clock.now().Add(5*time.Hour), "Patch", "patch_job",
+		allowDeferral(2, 60)); err != nil {
+		t.Fatalf("ScheduleWithOptions: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		timers.runAt(0)
+		close(done)
+	}()
+	<-inPrompt
+
+	if err := rm.Cancel(); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	close(release)
+	<-done
+
+	st := rm.State()
+	if st.RebootScheduled {
+		t.Fatal("a postponement answered after Cancel resurrected the reboot")
+	}
+	if st.DeferralsUsed != 0 {
+		t.Errorf("DeferralsUsed = %d after a cancelled reboot, want 0", st.DeferralsUsed)
+	}
+	if len(*osCalls) != 0 {
+		t.Error("the cancelled reboot still invoked the OS")
+	}
+	var told bool
+	for _, n := range *notifications {
+		if strings.Contains(n.title, "Cannot Be Postponed") {
+			told = true
+		}
+	}
+	if !told {
+		t.Errorf("the user was never told the postponement failed; notifications = %+v", *notifications)
+	}
+}
+
+// TestRestartNowIsRefusedAfterACancel is the same race for the other button.
+// ScheduleWithOptions has no generation check of its own, so a "Restart now"
+// answered after a cancellation would arm a brand-new reboot the operator had
+// just called off.
+func TestRestartNowIsRefusedAfterACancel(t *testing.T) {
+	rm, timers, _, osCalls, clock, _ := newDeferralTestManager(t, 3)
+	inPrompt := make(chan struct{})
+	release := make(chan struct{})
+	rm.promptFn = func(string, string, string, []string, time.Duration) string {
+		close(inPrompt)
+		<-release
+		return RebootActionRestartNow
+	}
+	if err := rm.ScheduleWithOptions(60*time.Minute, clock.now().Add(5*time.Hour), "Patch", "patch_job",
+		allowDeferral(2, 60)); err != nil {
+		t.Fatalf("ScheduleWithOptions: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		timers.runAt(0)
+		close(done)
+	}()
+	<-inPrompt
+
+	if err := rm.Cancel(); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	close(release)
+	<-done
+
+	if rm.State().RebootScheduled {
+		t.Fatal("Restart now answered after Cancel resurrected the reboot")
+	}
+	if len(*osCalls) != 0 {
+		t.Error("the cancelled reboot still invoked the OS")
+	}
+}
+
+// TestPromptTimeoutNeverOutlivesTheNextRung: a dialog still on screen when the
+// next warning fires means the next warning cannot be shown (the helper refuses to
+// stack modal dialogs), so the ladder would silently lose a rung.
+func TestPromptTimeoutNeverOutlivesTheNextRung(t *testing.T) {
+	t.Parallel()
+	for _, delay := range []time.Duration{
+		MinRebootDelay, 2 * time.Minute, 6 * time.Minute, 16 * time.Minute,
+		61 * time.Minute, 4 * time.Hour, 24 * time.Hour,
+	} {
+		t.Run(delay.String(), func(t *testing.T) {
+			plan := PlanReboot(delay)
+			rungs := planRebootRungs(plan)
+			if len(rungs) != len(plan.Notifications) {
+				t.Fatalf("rungs = %d, want %d", len(rungs), len(plan.Notifications))
+			}
+			for i, r := range rungs {
+				if !r.deferrable {
+					continue
+				}
+				if r.promptWindow <= 0 {
+					t.Errorf("rung %d: promptWindow = %v, want positive", i, r.promptWindow)
+				}
+				if r.promptWindow > maxRebootPromptWindow {
+					t.Errorf("rung %d: promptWindow = %v, want at most %v", i, r.promptWindow, maxRebootPromptWindow)
+				}
+				next := plan.OSInvokeAt
+				if i+1 < len(plan.Notifications) {
+					next = plan.Notifications[i+1].After
+				}
+				if got := plan.Notifications[i].After + r.promptWindow; got > next {
+					t.Errorf("rung %d: prompt would still be open at %v, past the next rung at %v", i, got, next)
+				}
+			}
+			// The closing rung is the last notification, and only it is
+			// non-deferrable.
+			for i, r := range rungs {
+				wantDeferrable := plan.Notifications[i].After != plan.OSInvokeAt
+				if r.deferrable != wantDeferrable {
+					t.Errorf("rung %d (After=%v, OSInvokeAt=%v): deferrable = %v, want %v",
+						i, plan.Notifications[i].After, plan.OSInvokeAt, r.deferrable, wantDeferrable)
+				}
+			}
+		})
+	}
+}
+
+// TestPromptTimeoutIsPassedToTheSeam pins that the computed window actually
+// reaches the dialog rather than being recomputed as a constant.
+func TestPromptTimeoutIsPassedToTheSeam(t *testing.T) {
+	rm, timers, _, _, clock, prompts := newPromptTestManager(t, 3)
+	if err := rm.ScheduleWithOptions(4*time.Minute, clock.now().Add(5*time.Hour), "Patch", "patch_job",
+		allowDeferral(2, 60)); err != nil {
+		t.Fatalf("ScheduleWithOptions: %v", err)
+	}
+
+	timers.runAt(0)
+
+	if len(*prompts) != 1 {
+		t.Fatalf("prompts = %d, want 1", len(*prompts))
+	}
+	want := planRebootRungs(PlanReboot(4 * time.Minute))[0].promptWindow
+	if got := (*prompts)[0].timeout; got != want {
+		t.Errorf("prompt timeout = %v, want %v", got, want)
+	}
+}
+
+func TestRebootActionPostponeReadsLikeAButton(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   time.Duration
+		want string
+	}{
+		{time.Hour, "Postpone 1 hour"},
+		{30 * time.Minute, "Postpone 30 minutes"},
+		{2 * time.Hour, "Postpone 2 hours"},
+		{90 * time.Minute, "Postpone 90 minutes"},
+		{time.Minute, "Postpone 1 minute"},
+	}
+	for _, tc := range cases {
+		if got := rebootActionPostpone(tc.in); got != tc.want {
+			t.Errorf("rebootActionPostpone(%v) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestCancelIsRefusedWhileTheOSCommandIsBeingIssued closes the window codex
+// flagged during the W2 review: runOSReboot used to set osInvoked BEFORE
+// execOSReboot ran, so a Cancel arriving in between took the abort path, found
+// nothing to abort, reported success — and the machine still went down. The
+// prompt's "Restart now" widens that window because it re-enters
+// scheduleLockedAt, which takes the same abort path.
+func TestCancelIsRefusedWhileTheOSCommandIsBeingIssued(t *testing.T) {
+	rm, timers, _, _, clock, _ := newDeferralTestManager(t, 3)
+	inExec := make(chan struct{})
+	release := make(chan struct{})
+	var aborts int
+	var mu sync.Mutex
+	rm.abortOSReboot = func() error {
+		mu.Lock()
+		aborts++
+		mu.Unlock()
+		return nil
+	}
+	rm.execOSReboot = func(time.Duration) error {
+		close(inExec)
+		<-release
+		return nil
+	}
+	if err := rm.ScheduleWithOptions(5*time.Minute, clock.now().Add(5*time.Hour), "Patch", "patch_job",
+		allowDeferral(2, 60)); err != nil {
+		t.Fatalf("ScheduleWithOptions: %v", err)
+	}
+
+	plan := PlanReboot(5 * time.Minute)
+	done := make(chan struct{})
+	go func() {
+		timers.runAt(plan.OSInvokeAt)
+		close(done)
+	}()
+	<-inExec
+
+	if err := rm.Cancel(); err == nil {
+		t.Error("Cancel reported success while the shutdown command was still being issued; the machine reboots anyway")
+	}
+	if _, err := rm.Defer(); err == nil {
+		t.Error("Defer was granted while the shutdown command was being issued")
+	}
+	if err := rm.Schedule(time.Hour, clock.now().Add(6*time.Hour), "Later", "manual"); err == nil {
+		t.Error("a re-schedule was accepted while the shutdown command was being issued")
+	}
+
+	mu.Lock()
+	got := aborts
+	mu.Unlock()
+	if got != 0 {
+		t.Errorf("abortOSReboot called %d time(s) before the OS command had been issued", got)
+	}
+
+	close(release)
+	<-done
+
+	// Once exec has returned, the countdown really is live and Cancel must go
+	// back to attempting the abort.
+	if err := rm.Cancel(); err != nil {
+		t.Fatalf("Cancel after the OS command was issued: %v", err)
+	}
+	mu.Lock()
+	got = aborts
+	mu.Unlock()
+	if got != 1 {
+		t.Errorf("abortOSReboot called %d time(s) after the countdown started, want 1", got)
+	}
+}
+
+// TestFailedOSInvocationLeavesNothingToAbort: exec failing must clear the
+// in-flight marker too, or every later Cancel would report the transient refusal
+// forever.
+func TestFailedOSInvocationLeavesNothingToAbort(t *testing.T) {
+	rm, timers, _, _, clock, _ := newDeferralTestManager(t, 3)
+	rm.execOSReboot = func(time.Duration) error { return fmt.Errorf("shutdown binary missing") }
+	if err := rm.ScheduleWithOptions(5*time.Minute, clock.now().Add(5*time.Hour), "Patch", "patch_job",
+		allowDeferral(2, 60)); err != nil {
+		t.Fatalf("ScheduleWithOptions: %v", err)
+	}
+
+	timers.runAt(PlanReboot(5 * time.Minute).OSInvokeAt)
+
+	if got := rm.State().LastError; !strings.Contains(got, "shutdown binary missing") {
+		t.Errorf("LastError = %q, want the invocation failure", got)
+	}
+	// A failed invocation left no countdown, so a fresh schedule must be accepted
+	// rather than refused as "an OS reboot is being invoked".
+	if err := rm.Schedule(time.Hour, clock.now().Add(6*time.Hour), "Retry", "manual"); err != nil {
+		t.Fatalf("re-schedule after a failed OS invocation: %v", err)
+	}
+}

--- a/agent/internal/patching/reboot_os_command.go
+++ b/agent/internal/patching/reboot_os_command.go
@@ -1,0 +1,57 @@
+// The one place a shutdown(8)/shutdown.exe invocation is actually run.
+//
+// Untagged on purpose, like the rest of this package's shared reboot code: the
+// three platform files are compiled and tested nowhere except their own OS, so
+// keeping the exec here means the timeout, the kill and the error text are
+// covered by tests that run in CI.
+package patching
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// osRebootCommandTimeout bounds every shutdown invocation.
+//
+// It is load-bearing rather than defensive. RebootManager.runOSReboot holds
+// osInvoking for exactly as long as execOSReboot runs, and Cancel, Defer and a
+// re-schedule are all refused during it — so a shutdown binary that never
+// returns (a wedged Windows service host, an unresponsive init) would leave the
+// manager permanently refusing every operation with no way back. Thirty seconds
+// is far beyond any real invocation: shutdown registers the countdown with the
+// OS and returns immediately, it does not wait for the countdown itself.
+//
+// A var, not a const, so a test can shrink it rather than sleeping for thirty
+// seconds. Production never writes it after init.
+var osRebootCommandTimeout = 30 * time.Second
+
+// runRebootCommand runs one shutdown invocation under a hard timeout, killing it
+// if it overruns.
+//
+// Killing the child is safe for both the start and the abort: shutdown hands the
+// countdown to the operating system and exits, so a process still alive after
+// thirty seconds has not registered anything a kill could undo.
+func runRebootCommand(name string, args ...string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), osRebootCommandTimeout)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, name, args...).CombinedOutput()
+	if err == nil {
+		return nil
+	}
+	cmdline := name
+	if len(args) > 0 {
+		cmdline += " " + strings.Join(args, " ")
+	}
+	if ctx.Err() != nil {
+		// Distinguished from an ordinary failure because the consequences differ:
+		// a command we killed may or may not have registered its countdown, so
+		// the state it left behind is unknown rather than known-clean.
+		return fmt.Errorf("%s: no response after %s, killed (%s)",
+			cmdline, osRebootCommandTimeout, strings.TrimSpace(string(out)))
+	}
+	return fmt.Errorf("%s: %w (%s)", cmdline, err, strings.TrimSpace(string(out)))
+}

--- a/agent/internal/patching/reboot_os_command_test.go
+++ b/agent/internal/patching/reboot_os_command_test.go
@@ -1,0 +1,54 @@
+package patching
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestRunRebootCommandKillsAnUnresponsiveShutdown is the liveness guard for the
+// osInvoking flag. runOSReboot holds osInvoking for exactly as long as
+// execOSReboot runs, and Cancel, Defer and a re-schedule are all refused during
+// it — so a shutdown binary that never returns would leave the manager refusing
+// every operation forever.
+func TestRunRebootCommandKillsAnUnresponsiveShutdown(t *testing.T) {
+	prev := osRebootCommandTimeout
+	osRebootCommandTimeout = 150 * time.Millisecond
+	t.Cleanup(func() { osRebootCommandTimeout = prev })
+
+	start := time.Now()
+	err := runRebootCommand("sleep", "30")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("a command that never returned reported success")
+	}
+	if !strings.Contains(err.Error(), "killed") {
+		t.Errorf("error = %q, want it to say the command was killed", err)
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("runRebootCommand took %v; the timeout did not fire", elapsed)
+	}
+}
+
+func TestRunRebootCommandReportsTheCommandLineAndOutput(t *testing.T) {
+	err := runRebootCommand("sh", "-c", "echo boom >&2; exit 3")
+	if err == nil {
+		t.Fatal("a failing command reported success")
+	}
+	if !strings.Contains(err.Error(), "boom") {
+		t.Errorf("error = %q, want it to carry the command's output", err)
+	}
+	if !strings.Contains(err.Error(), "sh -c") {
+		t.Errorf("error = %q, want it to name the command that failed", err)
+	}
+	if strings.Contains(err.Error(), "killed") {
+		t.Errorf("error = %q, want an ordinary failure distinguished from a timeout kill", err)
+	}
+}
+
+func TestRunRebootCommandSucceeds(t *testing.T) {
+	if err := runRebootCommand("true"); err != nil {
+		t.Fatalf("runRebootCommand on a successful command: %v", err)
+	}
+}

--- a/agent/internal/patching/reboot_os_darwin.go
+++ b/agent/internal/patching/reboot_os_darwin.go
@@ -4,8 +4,6 @@ package patching
 
 import (
 	"fmt"
-	"os/exec"
-	"strings"
 	"time"
 )
 
@@ -15,12 +13,7 @@ import (
 // non-zero grace for the same reason: the closing desktop toast needs to render
 // before the session goes away.
 func execOSReboot(grace time.Duration) error {
-	args := unixRebootArgs(grace)
-	out, err := exec.Command("shutdown", args...).CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("shutdown %s: %w (%s)", strings.Join(args, " "), err, string(out))
-	}
-	return nil
+	return runRebootCommand("shutdown", unixRebootArgs(grace)...)
 }
 
 // abortOSReboot cannot be honoured on macOS: BSD shutdown(8) has no cancel

--- a/agent/internal/patching/reboot_os_linux.go
+++ b/agent/internal/patching/reboot_os_linux.go
@@ -3,9 +3,6 @@
 package patching
 
 import (
-	"fmt"
-	"os/exec"
-	"strings"
 	"time"
 )
 
@@ -17,19 +14,10 @@ import (
 // would reintroduce, on Linux, exactly the fire-the-toast-then-kill-the-session
 // race that #3197 fixes on Windows.
 func execOSReboot(grace time.Duration) error {
-	args := unixRebootArgs(grace)
-	out, err := exec.Command("shutdown", args...).CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("shutdown %s: %w (%s)", strings.Join(args, " "), err, string(out))
-	}
-	return nil
+	return runRebootCommand("shutdown", unixRebootArgs(grace)...)
 }
 
 // abortOSReboot cancels a pending `shutdown` on Linux.
 func abortOSReboot() error {
-	out, err := exec.Command("shutdown", "-c").CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("shutdown -c: %w (%s)", err, string(out))
-	}
-	return nil
+	return runRebootCommand("shutdown", "-c")
 }

--- a/agent/internal/patching/reboot_os_windows.go
+++ b/agent/internal/patching/reboot_os_windows.go
@@ -3,9 +3,6 @@
 package patching
 
 import (
-	"fmt"
-	"os/exec"
-	"strings"
 	"time"
 )
 
@@ -13,19 +10,10 @@ import (
 // (including the seconds-vs-minutes conversion) lives in the untagged
 // windowsRebootArgs so it is covered by tests that actually run in CI.
 func execOSReboot(grace time.Duration) error {
-	args := windowsRebootArgs(grace)
-	out, err := exec.Command("shutdown", args...).CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("shutdown %s: %w (%s)", strings.Join(args, " "), err, string(out))
-	}
-	return nil
+	return runRebootCommand("shutdown", windowsRebootArgs(grace)...)
 }
 
 // abortOSReboot aborts a countdown started by execOSReboot.
 func abortOSReboot() error {
-	out, err := exec.Command("shutdown", "/a").CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("shutdown /a: %w (%s)", err, string(out))
-	}
-	return nil
+	return runRebootCommand("shutdown", "/a")
 }

--- a/agent/internal/patching/reboot_prompt.go
+++ b/agent/internal/patching/reboot_prompt.go
@@ -1,0 +1,116 @@
+// The prompt half of the reboot warning ladder (issue #3207).
+//
+// Untagged for the same reason reboot_plan.go and reboot_deferral.go are: the
+// dialogs themselves are windows/darwin-only and therefore tested nowhere in CI
+// (#3019, #3046), so every decision ABOUT the dialog — which rungs may offer a
+// button, how long it may stay on screen, what the buttons say — lives here as
+// pure data.
+package patching
+
+import (
+	"fmt"
+	"time"
+)
+
+// PromptFunc shows an interactive notification and returns the LABEL of the
+// clicked button. "" means no decision: the countdown expired, the dialog could
+// not render, or the user dismissed it. A nil PromptFunc means this build has no
+// interactive surface at all, which is the normal case on a headless box.
+//
+// It blocks for up to timeout, so callers must not hold the manager lock across
+// it.
+type PromptFunc func(title, body, urgency string, actions []string, timeout time.Duration) string
+
+// RebootActionRestartNow is the affirmative button. It is a constant because the
+// manager compares what came back against what it sent; the postponement label
+// carries a duration and so is built by rebootActionPostpone.
+const RebootActionRestartNow = "Restart now"
+
+// maxRebootPromptWindow caps how long a dialog may sit on screen. Two minutes:
+// long enough for someone who stepped away to come back, short enough that a
+// 24-hour schedule does not leave a system-modal dialog up for an hour.
+const maxRebootPromptWindow = 2 * time.Minute
+
+// minRebootPromptWindow is the floor for a tight ladder. Below this the dialog
+// would close before a person could read it, so a rung with less room than this
+// simply does not offer a button (see planRebootRungs).
+const minRebootPromptWindow = 20 * time.Second
+
+// rebootActionPostpone renders the postponement button. The label carries the
+// window because "Postpone" alone gives the user no way to judge the offer.
+func rebootActionPostpone(d time.Duration) string {
+	return "Postpone " + humanizeRebootDelay(d)
+}
+
+// rebootRung is one warning in the ladder plus the prompt policy that applies to
+// it. Computed up front from the plan, as pure data, so the "never prompt on the
+// closing rung" rule is asserted without driving timers.
+type rebootRung struct {
+	notification RebootNotification
+	// deferrable is false for the closing rung, and for any rung with too little
+	// room before the next one for a dialog to be worth opening. The closing
+	// notice fires at OSInvokeAt, from which moment Defer() is refused because
+	// the countdown lives in the OS — a button there could only ever fail.
+	deferrable bool
+	// promptWindow is how long the dialog may stay open. It never outlives the
+	// next rung: a dialog still on screen then would make the helper refuse to
+	// stack a second modal, silently costing the ladder a warning.
+	promptWindow time.Duration
+}
+
+// planRebootRungs pairs every notification in the plan with its prompt policy.
+func planRebootRungs(plan RebootPlan) []rebootRung {
+	rungs := make([]rebootRung, 0, len(plan.Notifications))
+	for i, n := range plan.Notifications {
+		rung := rebootRung{notification: n}
+		if n.After != plan.OSInvokeAt {
+			// The room before the next rung, or before the OS invocation if this
+			// is the last rung that precedes it.
+			next := plan.OSInvokeAt
+			if i+1 < len(plan.Notifications) {
+				next = plan.Notifications[i+1].After
+			}
+			window := next - n.After
+			if window > maxRebootPromptWindow {
+				window = maxRebootPromptWindow
+			}
+			if window >= minRebootPromptWindow {
+				rung.deferrable = true
+				rung.promptWindow = window
+			}
+		}
+		rungs = append(rungs, rung)
+	}
+	return rungs
+}
+
+// rebootDeferralNote is the line appended to a deferrable reboot's warning so the
+// user can see where they stand. Empty when the policy is off, which is what
+// keeps a non-deferrable reboot's copy byte-for-byte identical to today's.
+func rebootDeferralNote(policy DeferralPolicy, used int, canPostpone bool) string {
+	if !policy.Allowed || policy.MaxDeferrals <= 0 {
+		return ""
+	}
+	if !canPostpone {
+		return "This restart can no longer be postponed."
+	}
+	remaining := policy.MaxDeferrals - used
+	if remaining <= 0 {
+		return "This restart can no longer be postponed."
+	}
+	if remaining == 1 {
+		return "You can postpone this restart 1 more time."
+	}
+	return fmt.Sprintf("You can postpone this restart %d more times.", remaining)
+}
+
+// rebootPromptBody joins the plan's warning text with the deferral note.
+func rebootPromptBody(body, note string) string {
+	if note == "" {
+		return body
+	}
+	if body == "" {
+		return note
+	}
+	return body + "\n\n" + note
+}

--- a/agent/internal/patching/reboot_prompt.go
+++ b/agent/internal/patching/reboot_prompt.go
@@ -12,14 +12,22 @@ import (
 	"time"
 )
 
-// PromptFunc shows an interactive notification and returns the LABEL of the
-// clicked button. "" means no decision: the countdown expired, the dialog could
-// not render, or the user dismissed it. A nil PromptFunc means this build has no
-// interactive surface at all, which is the normal case on a headless box.
+// PromptFunc shows an interactive notification and reports what came back.
+//
+// clicked is the LABEL of the clicked button, or "" for no decision: the
+// countdown expired, or the user dismissed the dialog.
+//
+// shown reports whether anything was actually put in front of a person. It is
+// the difference between "a user looked at the prompt and did nothing" and "no
+// user was reachable at all", and the caller MUST branch on it: a reboot warning
+// that rendered nowhere still has to reach the user through the ordinary
+// notification path, or the #3197 always-warn invariant is lost on every device
+// with no signed-in helper. Returning ("", false) is the normal, expected answer
+// on a headless box, and is not an error.
 //
 // It blocks for up to timeout, so callers must not hold the manager lock across
 // it.
-type PromptFunc func(title, body, urgency string, actions []string, timeout time.Duration) string
+type PromptFunc func(title, body, urgency string, actions []string, timeout time.Duration) (clicked string, shown bool)
 
 // RebootActionRestartNow is the affirmative button. It is a constant because the
 // manager compares what came back against what it sent; the postponement label

--- a/agent/internal/sessionbroker/broker.go
+++ b/agent/internal/sessionbroker/broker.go
@@ -844,6 +844,26 @@ func (b *Broker) armHandshakeDeadline(rawConn net.Conn) bool {
 // so beginConnectionPublication returns false afterwards. Nothing cancelled here
 // can later become a live session and inherit a dead deadline, and a connection
 // that already published clears the handshake deadline itself.
+//
+// The listener's own Close() is bounded by ctx rather than awaited outright.
+// Closing a listener is normally instant, but go-winio v0.6.2's named-pipe
+// listener can deadlock its own Close(): Close blocks on doneCh, which
+// listenerRoutine only closes once a makeConnectedServerPipe call returns
+// ErrPipeListenerClosed, and that function's close branch rewrites only nil and
+// ErrFileClosed into that sentinel. A connect that was already failing on its
+// own errno when Close() cancelled it — ERROR_NO_DATA from a client that dialled
+// and hung up, which is exactly what TestNamedPipeListenAndAccept does — leaks
+// that errno through, listenerRoutine leaves `closed` false and returns to its
+// select, and the single closeCh token Close() sends is already spent. Nothing
+// ever closes doneCh. That wedged the whole `Test Agent (Windows)` job for its
+// full ten-minute budget on 2026-09-03, and on a real device it would hang agent
+// shutdown (so a service restart escalates to a kill) rather than a test.
+//
+// Abandoning the close is safe in a way that abandoning the drain is not:
+// acceptStopped is already set, so nothing can be admitted regardless of whether
+// the handle ever closes. The cost is one leaked goroutine and one leaked handle
+// for the remaining life of the process, which is strictly better than never
+// returning.
 func (b *Broker) StopAcceptingAndWait(ctx context.Context) error {
 	b.acceptMu.Lock()
 	b.acceptStopped = true
@@ -855,9 +875,11 @@ func (b *Broker) StopAcceptingAndWait(ctx context.Context) error {
 		}
 	}
 	b.acceptMu.Unlock()
-	if listener != nil {
-		_ = listener.Close()
-	}
+
+	// Started before the drain wait rather than after it, so a well-behaved
+	// listener still closes concurrently with the handlers finishing.
+	listenerClosed := closeListenerAsync(listener)
+
 	done := make(chan struct{})
 	go func() {
 		b.preAuthHandlers.Wait()
@@ -865,10 +887,37 @@ func (b *Broker) StopAcceptingAndWait(ctx context.Context) error {
 	}()
 	select {
 	case <-done:
-		return nil
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+
+	select {
+	case <-listenerClosed:
+		return nil
+	case <-ctx.Done():
+		log.Error("listener Close() did not return within the shutdown budget; abandoning it",
+			"socket", b.socketPath,
+			"consequence", "one goroutine and one socket/pipe handle leak for the life of this process; nothing new is admitted")
+		return fmt.Errorf("%w: %s", ErrListenerCloseStalled, b.socketPath)
+	}
+}
+
+// closeListenerAsync closes listener on its own goroutine and returns a channel
+// that is closed once Close() returns. A nil listener yields an already-closed
+// channel, so callers need no special case for the losing side of two concurrent
+// StopAcceptingAndWait calls (Broker.Close races listenOn's own Close on every
+// shutdown; whichever loses finds b.listener already nil).
+func closeListenerAsync(listener net.Listener) <-chan struct{} {
+	closed := make(chan struct{})
+	if listener == nil {
+		close(closed)
+		return closed
+	}
+	go func() {
+		defer close(closed)
+		_ = listener.Close()
+	}()
+	return closed
 }
 
 // SessionForUser returns the first active session for the given username.

--- a/agent/internal/sessionbroker/broker.go
+++ b/agent/internal/sessionbroker/broker.go
@@ -1372,6 +1372,105 @@ func (b *Broker) BroadcastNotification(title, body, urgency string) {
 	}
 }
 
+// notifyDecisionSeq numbers the envelope ids RequestNotificationDecision
+// allocates. A counter, not a timestamp: the repo's other correlated-request ids
+// use time.Now().UnixMilli() (see LaunchProcessViaUserHelperWithArgs), and
+// SendCommand rejects a duplicate in-flight id outright with ErrDuplicateCommand
+// — so two prompts raised inside the same millisecond, which two reminder rungs
+// or a rung and a retry easily are, would lose one answer.
+var notifyDecisionSeq atomic.Uint64
+
+// RequestNotificationDecision sends an interactive notification to every
+// notify-scoped session and returns the first answer.
+//
+// This is the response-bearing sibling of BroadcastNotification, which is
+// deliberately left alone: the reboot warning LADDER stays fire-and-forget
+// (#3197 guarantees the user is TOLD; it does not need an answer). Only the
+// rungs that offer a postponement come through here.
+//
+// The plumbing already existed and was never usable end to end.
+// NotifyRequest.Actions and NotifyResult.ActionClicked are declared in
+// ipc/message.go, expectedResponseType maps TypeNotify -> TypeNotifyResult, and
+// the helper's handleNotify already replies on the envelope id it was given —
+// but BroadcastNotification calls SendNotify with an EMPTY id, so no pending
+// entry exists, the reply matches nothing, and dispatchHelperMessage drops it as
+// unsolicited. Here the id is real and per-session.
+//
+// Fan-out is concurrent and first-answer-wins: there is one machine and one
+// reboot, so the first human to click decides. Sessions that time out or error
+// are not failures — an unanswered prompt means "proceed as scheduled", which is
+// the fail-safe direction. The reboot still happens; silence never cancels it and
+// never postpones it.
+//
+// The "notify" scope filter is the same one BroadcastNotification documents and
+// must not be weakened (#3255): the assist helper and the watchdog have no
+// TypeNotify handler at all, and a modal prompt is strictly more intrusive than
+// the toast that filter was written for.
+func (b *Broker) RequestNotificationDecision(req ipc.NotifyRequest, timeout time.Duration) (ipc.NotifyResult, error) {
+	b.mu.RLock()
+	sessions := make([]*Session, 0, len(b.sessions))
+	for _, s := range b.sessions {
+		if s.HasScope("notify") {
+			sessions = append(sessions, s)
+		}
+	}
+	b.mu.RUnlock()
+
+	if len(sessions) == 0 {
+		// Not an error: a headless box, or Windows sitting at the logon screen.
+		// There is no interactive user to ask.
+		return ipc.NotifyResult{}, nil
+	}
+
+	type answer struct {
+		res ipc.NotifyResult
+		err error
+	}
+	results := make(chan answer, len(sessions))
+	for _, s := range sessions {
+		go func(s *Session) {
+			id := fmt.Sprintf("notify-%s-%d", s.SessionID, notifyDecisionSeq.Add(1))
+			resp, err := s.SendCommand(id, ipc.TypeNotify, &req, timeout)
+			if err != nil {
+				results <- answer{err: fmt.Errorf("session %s: %w", s.SessionID, err)}
+				return
+			}
+			if resp.Error != "" {
+				results <- answer{err: fmt.Errorf("session %s: notify helper error: %s", s.SessionID, resp.Error)}
+				return
+			}
+			var out ipc.NotifyResult
+			if err := json.Unmarshal(resp.Payload, &out); err != nil {
+				results <- answer{err: fmt.Errorf("session %s: decode notify result: %w", s.SessionID, err)}
+				return
+			}
+			results <- answer{res: out}
+		}(s)
+	}
+
+	// results is buffered to len(sessions), so the goroutines belonging to
+	// sessions we stop reading from still finish and exit rather than leaking.
+	var best ipc.NotifyResult
+	var lastErr error
+	for range sessions {
+		a := <-results
+		if a.err != nil {
+			lastErr = a.err
+			continue
+		}
+		if a.res.ActionClicked != "" {
+			return a.res, nil // the first real decision wins
+		}
+		if a.res.Delivered {
+			best.Delivered = true
+		}
+	}
+	if !best.Delivered && lastErr != nil {
+		return best, lastErr
+	}
+	return best, nil
+}
+
 // BroadcastToDesktopSessions sends a fire-and-forget IPC message to all
 // connected sessions that have the "desktop" scope.
 func (b *Broker) BroadcastToDesktopSessions(msgType string, payload any) {

--- a/agent/internal/sessionbroker/broker.go
+++ b/agent/internal/sessionbroker/broker.go
@@ -555,7 +555,13 @@ func (b *Broker) listenOn(listener net.Listener, stopChan <-chan struct{}) error
 // Close shuts down the broker and all sessions.
 func (b *Broker) Close() {
 	ctx, cancel := context.WithTimeout(context.Background(), HandshakeTimeout)
-	_ = b.StopAcceptingAndWait(ctx)
+	// Logged here rather than discarded: the caller that reaches Close without
+	// having called StopAcceptingAndWait itself (listenOn's own shutdown, a test
+	// harness, a future reordering of the daemon's teardown) would otherwise see
+	// a stalled listener as a perfectly clean shutdown.
+	if err := b.StopAcceptingAndWait(ctx); err != nil {
+		log.Warn("broker close: listener shutdown did not complete", "error", err.Error())
+	}
 	cancel()
 
 	b.mu.Lock()

--- a/agent/internal/sessionbroker/broker_notify_decision_test.go
+++ b/agent/internal/sessionbroker/broker_notify_decision_test.go
@@ -1,0 +1,346 @@
+package sessionbroker
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/ipc"
+)
+
+// decisionProbe is a connected helper session plus a scripted client that reads
+// the notify request the broker sends and answers it — the half that
+// BroadcastNotification could never have, because it sends an EMPTY envelope id
+// and so orphans whatever the helper replies.
+type decisionProbe struct {
+	name    string
+	session *Session
+	client  *ipc.Conn
+
+	mu   sync.Mutex
+	seen []*ipc.Envelope
+}
+
+// newDecisionProbe registers a session with the given scopes and starts a client
+// goroutine that answers every notify request via reply. A nil reply means the
+// client reads the request and stays silent, which is how "the user did nothing"
+// is modelled.
+func newDecisionProbe(t *testing.T, b *Broker, name string, scopes []string, reply func(ipc.NotifyRequest) *ipc.NotifyResult) *decisionProbe {
+	t.Helper()
+
+	serverConn, clientConn := createSocketPair(t)
+	t.Cleanup(func() { _ = clientConn.Close() })
+
+	session := NewSession(ipc.NewConn(serverConn), 1000, "1000", "alice", "", name, scopes)
+	t.Cleanup(func() { _ = session.Close() })
+
+	b.mu.Lock()
+	b.sessions[session.SessionID] = session
+	b.publishSnapshotLocked()
+	b.mu.Unlock()
+
+	// The broker only correlates a reply if something pumps the session's
+	// inbound side; RecvLoop is what routes an envelope back to the pending
+	// command registered by SendCommand.
+	go session.RecvLoop(func(*Session, *ipc.Envelope) {})
+
+	p := &decisionProbe{name: name, session: session, client: ipc.NewConn(clientConn)}
+	go func() {
+		for {
+			env, err := p.client.Recv()
+			if err != nil {
+				return
+			}
+			p.mu.Lock()
+			p.seen = append(p.seen, env)
+			p.mu.Unlock()
+			if env.Type != ipc.TypeNotify || reply == nil {
+				continue
+			}
+			var req ipc.NotifyRequest
+			if err := json.Unmarshal(env.Payload, &req); err != nil {
+				continue
+			}
+			if res := reply(req); res != nil {
+				_ = p.client.SendTyped(env.ID, ipc.TypeNotifyResult, *res)
+			}
+		}
+	}()
+	return p
+}
+
+func (p *decisionProbe) received() []*ipc.Envelope {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]*ipc.Envelope{}, p.seen...)
+}
+
+// waitForEnvelopes blocks until the probe has seen n envelopes or the deadline
+// passes, so assertions never race the client goroutine.
+func (p *decisionProbe) waitForEnvelopes(t *testing.T, n int) []*ipc.Envelope {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		got := p.received()
+		if len(got) >= n {
+			return got
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("%s: saw %d envelopes, want %d", p.name, len(got), n)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func answerWith(action string) func(ipc.NotifyRequest) *ipc.NotifyResult {
+	return func(ipc.NotifyRequest) *ipc.NotifyResult {
+		return &ipc.NotifyResult{Delivered: true, ActionClicked: action}
+	}
+}
+
+// TestRequestNotificationDecisionCorrelatesTheReply is the regression test for
+// the defect that made the whole feature impossible: BroadcastNotification calls
+// SendNotify with an EMPTY envelope id, so the helper's notify_result matches no
+// pending command and is dropped as unsolicited. A response-bearing request has
+// to allocate a real id.
+func TestRequestNotificationDecisionCorrelatesTheReply(t *testing.T) {
+	b := New("notify-decision-correlates", nil)
+	p := newDecisionProbe(t, b, "notify-session", []string{"notify"}, answerWith("Postpone 1 hour"))
+
+	res, err := b.RequestNotificationDecision(ipc.NotifyRequest{
+		Title:   "Restart Scheduled",
+		Body:    "in 15 minutes",
+		Actions: []string{"Restart now", "Postpone 1 hour"},
+	}, 2*time.Second)
+	if err != nil {
+		t.Fatalf("RequestNotificationDecision: %v", err)
+	}
+	if res.ActionClicked != "Postpone 1 hour" {
+		t.Errorf("ActionClicked = %q, want %q", res.ActionClicked, "Postpone 1 hour")
+	}
+	if !res.Delivered {
+		t.Error("Delivered = false after the helper answered")
+	}
+
+	env := p.waitForEnvelopes(t, 1)[0]
+	if env.ID == "" {
+		t.Fatal("the notify envelope carried an empty id — the reply can only be orphaned, which is the defect this test exists for")
+	}
+	if !strings.Contains(env.ID, p.session.SessionID) {
+		t.Errorf("envelope id %q does not identify the session it was sent to", env.ID)
+	}
+}
+
+// TestRequestNotificationDecisionPutsActionsAndTimeoutOnTheWire pins the payload
+// the helper needs to render buttons and run its countdown.
+func TestRequestNotificationDecisionPutsActionsAndTimeoutOnTheWire(t *testing.T) {
+	b := New("notify-decision-payload", nil)
+	p := newDecisionProbe(t, b, "notify-session", []string{"notify"}, answerWith("Restart now"))
+
+	if _, err := b.RequestNotificationDecision(ipc.NotifyRequest{
+		Title:     "Restart Scheduled",
+		Body:      "in 15 minutes",
+		Urgency:   "normal",
+		Actions:   []string{"Restart now", "Postpone 1 hour"},
+		TimeoutMs: 90_000,
+	}, 2*time.Second); err != nil {
+		t.Fatalf("RequestNotificationDecision: %v", err)
+	}
+
+	var req ipc.NotifyRequest
+	if err := json.Unmarshal(p.waitForEnvelopes(t, 1)[0].Payload, &req); err != nil {
+		t.Fatalf("unmarshal notify payload: %v", err)
+	}
+	if len(req.Actions) != 2 || req.Actions[0] != "Restart now" || req.Actions[1] != "Postpone 1 hour" {
+		t.Errorf("Actions = %v, want the two-button pair", req.Actions)
+	}
+	if req.TimeoutMs != 90_000 {
+		t.Errorf("TimeoutMs = %d, want 90000", req.TimeoutMs)
+	}
+	if req.Urgency != "normal" {
+		t.Errorf("Urgency = %q, want %q", req.Urgency, "normal")
+	}
+}
+
+// TestRequestNotificationDecisionReturnsTheFirstAnswer: there is one machine and
+// one reboot, so the first human to click decides. The silent session must not
+// hold the answer hostage for the full timeout.
+func TestRequestNotificationDecisionReturnsTheFirstAnswer(t *testing.T) {
+	b := New("notify-decision-first-answer", nil)
+	newDecisionProbe(t, b, "silent", []string{"notify"}, nil)
+	newDecisionProbe(t, b, "answers", []string{"notify"}, answerWith("Postpone 1 hour"))
+
+	start := time.Now()
+	res, err := b.RequestNotificationDecision(ipc.NotifyRequest{
+		Actions: []string{"Restart now", "Postpone 1 hour"},
+	}, 10*time.Second)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("RequestNotificationDecision: %v", err)
+	}
+	if res.ActionClicked != "Postpone 1 hour" {
+		t.Errorf("ActionClicked = %q, want %q", res.ActionClicked, "Postpone 1 hour")
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("waited %v for a decision another session had already given", elapsed)
+	}
+}
+
+// TestRequestNotificationDecisionSkipsNonNotifyScopedSessions: the assist helper
+// and the watchdog have no TypeNotify handler at all. The filter
+// BroadcastNotification documents at broker.go must not be weakened here either
+// (#3255) — a prompt is strictly more intrusive than a toast.
+func TestRequestNotificationDecisionSkipsNonNotifyScopedSessions(t *testing.T) {
+	b := New("notify-decision-scope", nil)
+	assist := newDecisionProbe(t, b, "assist", assistHelperScopes, answerWith("Postpone 1 hour"))
+	watchdog := newDecisionProbe(t, b, "watchdog", watchdogHelperScopes, answerWith("Postpone 1 hour"))
+
+	res, err := b.RequestNotificationDecision(ipc.NotifyRequest{
+		Actions: []string{"Restart now", "Postpone 1 hour"},
+	}, 250*time.Millisecond)
+	if err != nil {
+		t.Fatalf("RequestNotificationDecision with no notify-scoped session: %v", err)
+	}
+	if res.ActionClicked != "" || res.Delivered {
+		t.Errorf("result = %+v, want the zero value — no eligible session was asked", res)
+	}
+
+	// Sentinel-after-the-fact, as in broker_notify_test.go: a session's writes are
+	// ordered, so reading the first envelope is decisive without a sleep.
+	for _, p := range []*decisionProbe{assist, watchdog} {
+		if err := p.session.SendNotify("sentinel", notifySentinelType, nil); err != nil {
+			t.Fatalf("%s: send sentinel: %v", p.name, err)
+		}
+	}
+	for _, p := range []*decisionProbe{assist, watchdog} {
+		first := p.waitForEnvelopes(t, 1)[0]
+		if first.Type != notifySentinelType {
+			t.Errorf("%s (scopes %v) was asked for a decision it cannot render: %q",
+				p.name, p.session.AllowedScopes, first.Type)
+		}
+	}
+}
+
+// TestRequestNotificationDecisionWithNoSessionsIsNotAnError is the headless
+// story: no logged-in user means no helper, which means no prompt. The reboot
+// still proceeds on schedule — silence is never an error and never a deferral.
+func TestRequestNotificationDecisionWithNoSessionsIsNotAnError(t *testing.T) {
+	b := New("notify-decision-headless", nil)
+
+	res, err := b.RequestNotificationDecision(ipc.NotifyRequest{
+		Actions: []string{"Restart now", "Postpone 1 hour"},
+	}, time.Second)
+	if err != nil {
+		t.Fatalf("RequestNotificationDecision with no sessions: %v", err)
+	}
+	if res.ActionClicked != "" || res.Delivered {
+		t.Errorf("result = %+v, want the zero value", res)
+	}
+}
+
+// TestRequestNotificationDecisionTimesOutWithNoAnswer: an unanswered prompt must
+// be indistinguishable from "the user did nothing". It must never surface an
+// ActionClicked the user never clicked.
+func TestRequestNotificationDecisionTimesOutWithNoAnswer(t *testing.T) {
+	b := New("notify-decision-timeout", nil)
+	newDecisionProbe(t, b, "silent", []string{"notify"}, nil)
+
+	res, err := b.RequestNotificationDecision(ipc.NotifyRequest{
+		Actions: []string{"Restart now", "Postpone 1 hour"},
+	}, 150*time.Millisecond)
+	if res.ActionClicked != "" {
+		t.Errorf("ActionClicked = %q, want empty on timeout", res.ActionClicked)
+	}
+	if !errors.Is(err, ErrCommandTimeout) {
+		t.Errorf("err = %v, want it to wrap ErrCommandTimeout so the caller can log why", err)
+	}
+}
+
+// TestRequestNotificationDecisionSurvivesADeadSession: one helper's dead
+// transport must not swallow another's answer, the same guarantee
+// BroadcastNotification's loop gives.
+func TestRequestNotificationDecisionSurvivesADeadSession(t *testing.T) {
+	b := New("notify-decision-dead-session", nil)
+	dead := newDecisionProbe(t, b, "dead", []string{"notify"}, nil)
+	if err := dead.session.Close(); err != nil {
+		t.Fatalf("close dead session: %v", err)
+	}
+	newDecisionProbe(t, b, "healthy", []string{"notify"}, answerWith("Restart now"))
+
+	res, err := b.RequestNotificationDecision(ipc.NotifyRequest{
+		Actions: []string{"Restart now", "Postpone 1 hour"},
+	}, 2*time.Second)
+	if err != nil {
+		t.Fatalf("RequestNotificationDecision: %v", err)
+	}
+	if res.ActionClicked != "Restart now" {
+		t.Errorf("ActionClicked = %q — a sibling's dead transport swallowed the answer", res.ActionClicked)
+	}
+}
+
+// TestConcurrentRequestNotificationDecisionsDoNotCollideOnEnvelopeIDs pins the id
+// generator. SendCommand rejects a duplicate in-flight id with
+// ErrDuplicateCommand, and the repo's existing correlated-request id convention
+// is time.Now().UnixMilli() — which collides outright when two rungs, or a rung
+// and a retry, fire inside the same millisecond. A monotonic counter is required,
+// not merely tidier.
+func TestConcurrentRequestNotificationDecisionsDoNotCollideOnEnvelopeIDs(t *testing.T) {
+	b := New("notify-decision-ids", nil)
+	newDecisionProbe(t, b, "notify-session", []string{"notify"}, answerWith("Restart now"))
+
+	const calls = 25
+	var wg sync.WaitGroup
+	errs := make(chan error, calls)
+	for i := 0; i < calls; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			res, err := b.RequestNotificationDecision(ipc.NotifyRequest{
+				Actions: []string{"Restart now", "Postpone 1 hour"},
+			}, 5*time.Second)
+			if err != nil {
+				errs <- err
+				return
+			}
+			if res.ActionClicked != "Restart now" {
+				errs <- errors.New("lost the answer: ActionClicked = " + res.ActionClicked)
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Errorf("concurrent decision request failed: %v", err)
+	}
+}
+
+// TestBroadcastNotificationStaysFireAndForget guards the #3197 warning ladder.
+// Every rung that offers no postponement must keep taking the path that does not
+// wait for a helper: adding a response-bearing sibling must not quietly turn the
+// unconditional warnings into blocking round trips.
+func TestBroadcastNotificationStaysFireAndForget(t *testing.T) {
+	b := New("broadcast-still-fire-and-forget", nil)
+	p := newDecisionProbe(t, b, "silent", []string{"notify"}, nil)
+
+	done := make(chan struct{})
+	go func() {
+		b.BroadcastNotification("Restart Soon", "in 15 minutes", "normal")
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("BroadcastNotification blocked waiting for a helper that never answers")
+	}
+
+	p.waitForEnvelopes(t, 1)
+	p.session.mu.Lock()
+	pending := len(p.session.pending)
+	p.session.mu.Unlock()
+	if pending != 0 {
+		t.Errorf("BroadcastNotification registered %d pending response(s); it must stay uncorrelated", pending)
+	}
+}

--- a/agent/internal/sessionbroker/broker_shutdown_test.go
+++ b/agent/internal/sessionbroker/broker_shutdown_test.go
@@ -1,0 +1,168 @@
+// Shutdown must never depend on a listener's Close() returning.
+//
+// Untagged on purpose. The bug these tests pin is a Windows named-pipe
+// deadlock, but a windows-tagged test would only ever run in the single
+// `Test Agent (Windows)` CI job — which is exactly where it manifested as a
+// ten-minute hang rather than a failure. Driving it through the net.Listener
+// interface reproduces the shape on every platform, in the ordinary test-agent
+// job, in milliseconds.
+package sessionbroker
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+// stalledCloseListener is a listener whose Close() never returns until the test
+// releases it. That is not a hypothetical: go-winio v0.6.2's
+// (*win32PipeListener).Close blocks on l.doneCh, which its listenerRoutine only
+// closes when a makeConnectedServerPipe call reports ErrPipeListenerClosed.
+// makeConnectedServerPipe's close branch rewrites only nil and ErrFileClosed
+// into that sentinel, so a connect that was already failing for its own reason
+// when Close() cancelled it (ERROR_NO_DATA from a client that dialled and hung
+// up — precisely what TestNamedPipeListenAndAccept does) leaks its own errno
+// through. listenerRoutine then leaves `closed` false, loops back to its select,
+// and waits for a second closeCh token that Close() will never send.
+type stalledCloseListener struct {
+	closeCalls  chan struct{}
+	releaseOnce sync.Once
+	released    chan struct{}
+}
+
+func newStalledCloseListener() *stalledCloseListener {
+	return &stalledCloseListener{
+		closeCalls: make(chan struct{}, 1),
+		released:   make(chan struct{}),
+	}
+}
+
+func (l *stalledCloseListener) Accept() (net.Conn, error) {
+	<-l.released
+	return nil, net.ErrClosed
+}
+
+func (l *stalledCloseListener) Close() error {
+	select {
+	case l.closeCalls <- struct{}{}:
+	default:
+	}
+	<-l.released
+	return nil
+}
+
+func (l *stalledCloseListener) Addr() net.Addr { return &net.UnixAddr{Name: "stalled", Net: "unix"} }
+
+// release unblocks Close and Accept so the abandoned goroutine can exit before
+// the test binary does.
+func (l *stalledCloseListener) release() { l.releaseOnce.Do(func() { close(l.released) }) }
+
+// TestStopAcceptingAndWaitAbandonsAStalledListenerClose is the regression test
+// for the ten-minute Windows CI hang: the whole `Test Agent (Windows)` job died
+// on `panic: test timed out after 10m0s / running tests:
+// TestNamedPipeListenAndAccept (9m59s)`, with the test goroutine parked in
+// win32PipeListener.Close and the listener routine parked in its own select.
+// Before the fix this test does not fail — it hangs, which is the point.
+func TestStopAcceptingAndWaitAbandonsAStalledListenerClose(t *testing.T) {
+	b := New("stalled-close-"+t.Name(), nil)
+	listener := newStalledCloseListener()
+	t.Cleanup(listener.release)
+	if !b.publishListener(listener) {
+		t.Fatal("publishListener refused a listener on a fresh broker")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- b.StopAcceptingAndWait(ctx) }()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, ErrListenerCloseStalled) {
+			t.Fatalf("StopAcceptingAndWait error = %v, want %v", err, ErrListenerCloseStalled)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("StopAcceptingAndWait never returned: a listener whose Close() does not return wedges broker shutdown forever")
+	}
+
+	// The listener really was asked to close — the test would pass vacuously if
+	// the fix had simply stopped calling Close at all.
+	select {
+	case <-listener.closeCalls:
+	default:
+		t.Error("the stalled listener's Close() was never called")
+	}
+
+	// Abandoning the close must not weaken the guarantee the method exists for:
+	// nothing new may be admitted afterwards.
+	if b.publishListener(newCloseTrackingListener()) {
+		t.Error("a listener was published after acceptance stopped")
+	}
+	if got := b.currentListener(); got != nil {
+		t.Errorf("current listener = %T, want nil", got)
+	}
+}
+
+// TestCloseReturnsDespiteAStalledListenerClose is the same defect one level up,
+// where CI actually hit it: Broker.Close's own 5s context has to be enough to
+// get the whole shutdown past a wedged listener.
+func TestCloseReturnsDespiteAStalledListenerClose(t *testing.T) {
+	b := New("stalled-close-broker-"+t.Name(), nil)
+	listener := newStalledCloseListener()
+	t.Cleanup(listener.release)
+	if !b.publishListener(listener) {
+		t.Fatal("publishListener refused a listener on a fresh broker")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		b.Close()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(HandshakeTimeout + 5*time.Second):
+		t.Fatal("Broker.Close never returned with a listener whose Close() hangs")
+	}
+}
+
+// TestStopAcceptingAndWaitStillWaitsForAWellBehavedListener is the control: the
+// bound must not turn into "fire and forget". A listener that closes promptly is
+// closed before the method returns, and the method reports success.
+func TestStopAcceptingAndWaitStillWaitsForAWellBehavedListener(t *testing.T) {
+	b := New("prompt-close-"+t.Name(), nil)
+	listener := newCloseTrackingListener()
+	if !b.publishListener(listener) {
+		t.Fatal("publishListener refused a listener on a fresh broker")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := b.StopAcceptingAndWait(ctx); err != nil {
+		t.Fatalf("StopAcceptingAndWait: %v", err)
+	}
+
+	select {
+	case <-listener.closed:
+	default:
+		t.Fatal("a well-behaved listener was not closed by the time StopAcceptingAndWait returned")
+	}
+}
+
+// TestStopAcceptingAndWaitWithNoListenerIsNotAnError covers the second of the two
+// concurrent Close calls that TestNamedPipeListenAndAccept makes (one from
+// listenOn when stopChan closes, one from the test's own defer): whichever loses
+// the race finds b.listener already nil and must still return cleanly.
+func TestStopAcceptingAndWaitWithNoListenerIsNotAnError(t *testing.T) {
+	b := New("no-listener-"+t.Name(), nil)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := b.StopAcceptingAndWait(ctx); err != nil {
+		t.Fatalf("StopAcceptingAndWait with no listener: %v", err)
+	}
+}

--- a/agent/internal/sessionbroker/errors.go
+++ b/agent/internal/sessionbroker/errors.go
@@ -17,6 +17,17 @@ var (
 	ErrHandshakeTimeout   = errors.New("sessionbroker: handshake timeout")
 	ErrInvalidBinary      = errors.New("sessionbroker: binary path verification failed")
 	ErrBinaryHashMismatch = errors.New("sessionbroker: binary hash mismatch")
+
+	// ErrListenerCloseStalled means the listener's own Close() did not return
+	// within the shutdown budget, so it was abandoned. Acceptance is still
+	// stopped — acceptStopped is set before the close is even attempted — so the
+	// broker admits nothing after this; what leaks is one goroutine and one
+	// socket/pipe handle for the remaining life of the process.
+	//
+	// Not theoretical: go-winio v0.6.2's named-pipe listener can deadlock its own
+	// Close(), which wedged the whole `Test Agent (Windows)` job for its full
+	// ten-minute budget. See StopAcceptingAndWait.
+	ErrListenerCloseStalled = errors.New("sessionbroker: listener Close() did not return; abandoned")
 )
 
 // PamDismissOutcome reports how an uncertain PAM consent dismissal ended.

--- a/agent/internal/userhelper/client.go
+++ b/agent/internal/userhelper/client.go
@@ -934,22 +934,66 @@ func (c *Client) executeToolCommand(cmd ipc.IPCCommand) ipc.IPCCommandResult {
 	}
 }
 
+// handleNotify shows a desktop notification and replies on the same envelope id.
+//
+// A request carrying Actions is an interactive PROMPT rather than an
+// announcement: it renders a native modal dialog and the daemon is blocked
+// waiting for the clicked label (sessionbroker.RequestNotificationDecision). A
+// request with no Actions keeps the fire-and-forget toast path exactly as it was
+// — that is the #3197 reboot warning ladder, which must never become a modal
+// dialog in the user's face.
+//
+// Because the daemon now WAITS, this guarantees a reply on every exit path, the
+// way handleConsentRequest does. handleNotify is dispatched via safeGo
+// (commandLoop), which recovers panics but sends nothing back, and the most
+// panic-prone code below is the raw user32 syscall in the Windows dialog. Silence
+// is not fatal here — an unanswered prompt means "proceed as scheduled" — but it
+// would cost a full prompt timeout of dead air on a rung that had something to
+// say.
 func (c *Client) handleNotify(env *ipc.Envelope) {
+	replied := false
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error("notify handler panicked", "id", env.ID, "panic", fmt.Sprintf("%v", r))
+			_ = c.conn.SendError(env.ID, ipc.TypeNotifyResult, "notify handler panicked")
+			return
+		}
+		if !replied {
+			_ = c.conn.SendError(env.ID, ipc.TypeNotifyResult, "notify handler produced no result")
+		}
+	}()
+
 	var req ipc.NotifyRequest
 	if err := json.Unmarshal(env.Payload, &req); err != nil {
 		log.Warn("invalid notify payload", "error", err)
 		if sendErr := c.conn.SendError(env.ID, ipc.TypeNotifyResult, fmt.Sprintf("invalid payload: %v", err)); sendErr != nil {
 			log.Warn("failed to send notify error", "error", sendErr)
 		}
+		replied = true // terminal error reply already sent; don't double-send in the defer
 		return
 	}
+	req = sanitizeNotifyRequest(req)
 
-	delivered := showNotification(req)
-	if err := c.conn.SendTyped(env.ID, ipc.TypeNotifyResult, ipc.NotifyResult{
-		Delivered: delivered,
-	}); err != nil {
-		log.Warn("failed to send notify result", "id", env.ID, "error", err)
+	var result ipc.NotifyResult
+	if len(req.Actions) > 0 {
+		clicked, shown := showNotifyPrompt(req)
+		if shown {
+			result = ipc.NotifyResult{Delivered: true, ActionClicked: clicked}
+		} else {
+			// No dialog could be put on screen. The user still has to be TOLD:
+			// the #3197 always-warn invariant does not depend on the prompt, so
+			// fall back to the plain toast this rung would otherwise have shown.
+			result = ipc.NotifyResult{Delivered: showNotification(req)}
+		}
+	} else {
+		result = ipc.NotifyResult{Delivered: showNotification(req)}
 	}
+
+	if err := c.conn.SendTyped(env.ID, ipc.TypeNotifyResult, result); err != nil {
+		log.Warn("failed to send notify result", "id", env.ID, "error", err)
+		return
+	}
+	replied = true
 }
 
 func (c *Client) handlePamDialog(env *ipc.Envelope) {

--- a/agent/internal/userhelper/notify.go
+++ b/agent/internal/userhelper/notify.go
@@ -8,8 +8,13 @@ type Notifier interface {
 	Close() error
 }
 
+// showNotificationFn is the platform toast seam, mirroring showConsentDialogFn
+// and showNotifyPromptFn. Tests swap it so the notify handler's routing can be
+// asserted without shelling out to PowerShell/osascript/notify-send.
+var showNotificationFn = showNotificationOS
+
 // showNotification sends a desktop notification. Platform-specific.
 // Returns true if the notification was delivered.
 func showNotification(req ipc.NotifyRequest) bool {
-	return showNotificationOS(req)
+	return showNotificationFn(req)
 }

--- a/agent/internal/userhelper/notify_prompt.go
+++ b/agent/internal/userhelper/notify_prompt.go
@@ -1,0 +1,156 @@
+// The interactive half of the notification path (issue #3207).
+//
+// A NotifyRequest carrying Actions is a question, not an announcement: the daemon
+// is blocked waiting for the answer, and the answer moves a real reboot. This
+// file holds everything that decides what the dialog is asked to render and what
+// its answer means, deliberately untagged — the two native vehicles behind
+// showNotifyPromptFn are windows/darwin-only and so are tested nowhere in CI
+// (#3019, #3046).
+//
+// It reuses the consent-dialog vehicles (MessageBoxTimeoutW, osascript display
+// dialog) rather than toast activation buttons. Toast actions are unreliable on
+// Server SKUs and in RDS sessions, need a registered COM activator to route the
+// click back to a process, and silently degrade to a plain toast when the user
+// has notifications muted — which for a reboot prompt means the postponement
+// button simply is not there. See the plan's decision D4.
+package userhelper
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/breeze-rmm/agent/internal/ipc"
+)
+
+const (
+	// defaultNotifyPromptTimeoutMs is how long a prompt waits when the daemon
+	// sent no bound. Two minutes: long enough for someone who stepped away from
+	// the keyboard to come back, short enough that the reboot's next warning rung
+	// is not held up behind it.
+	defaultNotifyPromptTimeoutMs = 120_000
+	// maxNotifyPromptTimeoutMs caps a hostile or buggy daemon payload. A dialog
+	// that never gives up is a dialog the user cannot dismiss.
+	maxNotifyPromptTimeoutMs = 600_000
+)
+
+// showNotifyPromptFn is the platform dialog seam; tests swap it for a fake.
+//
+// It blocks until the user answers or the countdown expires, mirroring
+// showConsentDialogFn (consent.go) — the same request/response-with-timeout
+// shape, which is why this reuses those platform vehicles.
+//
+// It returns the LABEL of the clicked button, or "" for "no decision". shown
+// reports whether a dialog actually rendered: "" with shown=false means the
+// platform could not put anything on screen, which the caller must treat as the
+// user having been told NOTHING (and fall back to a toast) rather than as a
+// silent user.
+var showNotifyPromptFn = showNotifyPromptOS
+
+// notifyPromptMu serialises prompts inside one helper process. Both native
+// vehicles are system-modal and topmost, so a second prompt raised while one is
+// open stacks on top of it and steals focus; the user then answers a dialog they
+// did not read. A prompt that cannot take the lock reports shown=false, which
+// routes it to the plain toast rather than queueing it behind a dialog whose own
+// countdown may still have two minutes to run.
+var notifyPromptMu sync.Mutex
+
+// notifyPromptTimeoutMs bounds the countdown the dialog is given.
+func notifyPromptTimeoutMs(req ipc.NotifyRequest) int {
+	if req.TimeoutMs <= 0 {
+		return defaultNotifyPromptTimeoutMs
+	}
+	if req.TimeoutMs > maxNotifyPromptTimeoutMs {
+		return maxNotifyPromptTimeoutMs
+	}
+	return req.TimeoutMs
+}
+
+// notifyPromptAction maps a button position back to the label the daemon sent.
+// Out-of-range positions yield "" — no decision — because inventing a label the
+// daemon never offered is the one outcome that could move a reboot the user did
+// not ask to move.
+func notifyPromptAction(actions []string, index int) string {
+	if index < 0 || index >= len(actions) {
+		return ""
+	}
+	return actions[index]
+}
+
+// notifyPromptLegend spells out which fixed message-box button is which action.
+// Windows' MB_YESNO labels cannot be renamed, so "Postpone 1 hour" has to be
+// explained in the body text or the dialog reads as a bare Yes/No about nothing.
+// Untagged so the copy is asserted in CI, where no windows-tagged code runs.
+func notifyPromptLegend(actions []string) string {
+	yes := notifyPromptAction(actions, 0)
+	no := notifyPromptAction(actions, 1)
+	switch {
+	case yes != "" && no != "":
+		return "Select Yes to " + strings.ToLower(yes) + ", or No to " + strings.ToLower(no) + "."
+	case yes != "":
+		return "Select Yes to " + strings.ToLower(yes) + "."
+	default:
+		return ""
+	}
+}
+
+// maxNotifyPromptDialogButtons is AppleScript's hard limit for `display dialog`.
+// The sanitiser already caps Actions at 4, which osascript would reject outright.
+const maxNotifyPromptDialogButtons = 3
+
+// notifyPromptDialogButtons turns the wire actions into the button row for a
+// dialog that renders real labels (macOS). The order is REVERSED because
+// AppleScript draws the last button rightmost, which is where macOS puts the
+// default action — so Actions[0], the affirmative, has to go last.
+//
+// Untagged so the ordering is asserted in CI; getting it backwards would put
+// "Restart now" under the user's return key on Windows and under Postpone on
+// macOS, and no windows/darwin-tagged test runs anywhere.
+func notifyPromptDialogButtons(actions []string) []string {
+	buttons := make([]string, 0, len(actions))
+	for i := len(actions) - 1; i >= 0; i-- {
+		if strings.TrimSpace(actions[i]) == "" {
+			continue
+		}
+		buttons = append(buttons, actions[i])
+		if len(buttons) == maxNotifyPromptDialogButtons {
+			break
+		}
+	}
+	return buttons
+}
+
+// notifyPromptClickedButton reads the clicked label out of an osascript
+// `display dialog` record, e.g. "button returned:Restart now, gave up:false".
+//
+// The label is matched against the buttons we actually offered and anything else
+// yields "" — a label the daemon never sent could otherwise be echoed straight
+// back and read as a decision.
+func notifyPromptClickedButton(output string, buttons []string) string {
+	const marker = "button returned:"
+	i := strings.Index(output, marker)
+	if i < 0 {
+		return ""
+	}
+	rest := output[i+len(marker):]
+	if end := strings.Index(rest, ", gave up:"); end >= 0 {
+		rest = rest[:end]
+	}
+	rest = strings.TrimSpace(rest)
+	for _, b := range buttons {
+		if rest == b {
+			return b
+		}
+	}
+	return ""
+}
+
+// showNotifyPrompt runs the platform dialog under the single-prompt lock.
+func showNotifyPrompt(req ipc.NotifyRequest) (clicked string, shown bool) {
+	if !notifyPromptMu.TryLock() {
+		log.Warn("a reboot prompt is already on screen; showing this warning as a toast instead",
+			"title", req.Title)
+		return "", false
+	}
+	defer notifyPromptMu.Unlock()
+	return showNotifyPromptFn(req)
+}

--- a/agent/internal/userhelper/notify_prompt_darwin.go
+++ b/agent/internal/userhelper/notify_prompt_darwin.go
@@ -1,0 +1,69 @@
+//go:build darwin
+
+package userhelper
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/breeze-rmm/agent/internal/ipc"
+)
+
+// showNotifyPromptOS renders the interactive notification with osascript, the
+// same no-cgo vehicle consent_dialog_darwin.go and notify_darwin.go use. Unlike
+// Windows, `display dialog` takes real button labels, so the actions are shown
+// verbatim and no legend is needed.
+//
+// Button order is reversed relative to the wire order: AppleScript draws the LAST
+// button rightmost and that is where macOS puts the default action, so
+// Actions[0] ("Restart now") has to go last to sit where a Mac user expects the
+// affirmative button.
+//
+// No `cancel button` is declared, and an Esc/-128 cancel maps to "" rather than
+// to a button. The plan originally called for mapping a cancel to the last button
+// — but the last button is "Restart now", so a user who hits Escape would
+// ACCELERATE their reboot to the shortest schedule the planner allows. "" leaves
+// the countdown exactly where it was, which is the fail-safe direction and the
+// same rule the manager applies to silence.
+func showNotifyPromptOS(req ipc.NotifyRequest) (clicked string, shown bool) {
+	buttons := notifyPromptDialogButtons(req.Actions)
+	if len(buttons) == 0 {
+		return "", false
+	}
+
+	title := req.Title
+	if title == "" {
+		title = "Restart Scheduled"
+	}
+	quoted := make([]string, 0, len(buttons))
+	for _, b := range buttons {
+		quoted = append(quoted, `"`+escapeAppleScript(b)+`"`)
+	}
+	script := fmt.Sprintf(
+		`display dialog "%s" with title "%s" buttons {%s} default button "%s" with icon caution giving up after %d`,
+		escapeAppleScript(req.Body),
+		escapeAppleScript(title),
+		strings.Join(quoted, ", "),
+		escapeAppleScript(buttons[len(buttons)-1]),
+		(notifyPromptTimeoutMs(req)+999)/1000,
+	)
+
+	// CombinedOutput, as in consent_dialog_darwin.go: stderr carries the -128
+	// cancel marker that distinguishes a user dismissal from an infra failure.
+	out, err := exec.Command("osascript", "-e", script).CombinedOutput()
+	result := string(out)
+	if err != nil {
+		if strings.Contains(result, "-128") {
+			// The user dismissed the dialog. A real interaction, but not a
+			// decision — the restart stays exactly where it was scheduled.
+			return "", true
+		}
+		log.Warn("osascript reboot prompt failed", "error", err.Error())
+		return "", false
+	}
+	if strings.Contains(result, "gave up:true") {
+		return "", true
+	}
+	return notifyPromptClickedButton(result, buttons), true
+}

--- a/agent/internal/userhelper/notify_prompt_other.go
+++ b/agent/internal/userhelper/notify_prompt_other.go
@@ -1,0 +1,14 @@
+//go:build !windows && !darwin
+
+package userhelper
+
+import "github.com/breeze-rmm/agent/internal/ipc"
+
+// showNotifyPromptOS has no interactive vehicle on this platform, so it reports
+// "nothing was shown" and the caller falls back to the plain toast. That is the
+// correct answer today rather than a gap: no helper binary ships for Linux at
+// all, so nothing here would run in production either way. Linux gets its prompt
+// from the daemon side in W4 (issue #3207, plan decision D7), not from a helper.
+func showNotifyPromptOS(ipc.NotifyRequest) (clicked string, shown bool) {
+	return "", false
+}

--- a/agent/internal/userhelper/notify_prompt_test.go
+++ b/agent/internal/userhelper/notify_prompt_test.go
@@ -1,0 +1,414 @@
+// Untagged on purpose: the platform dialogs behind showNotifyPromptFn are
+// windows/darwin-tagged and therefore tested nowhere in CI (#3019, #3046), so
+// everything that decides WHAT the dialog is asked to render, and what its answer
+// means, lives on this side of the build tag.
+package userhelper
+
+import (
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/ipc"
+)
+
+// swapNotifyPrompt installs a fake dialog and restores the real one, recording
+// every request the seam was handed.
+func swapNotifyPrompt(t *testing.T, fn func(ipc.NotifyRequest) (string, bool)) *[]ipc.NotifyRequest {
+	t.Helper()
+	var mu sync.Mutex
+	seen := []ipc.NotifyRequest{}
+	prev := showNotifyPromptFn
+	showNotifyPromptFn = func(req ipc.NotifyRequest) (string, bool) {
+		mu.Lock()
+		seen = append(seen, req)
+		mu.Unlock()
+		return fn(req)
+	}
+	t.Cleanup(func() { showNotifyPromptFn = prev })
+	return &seen
+}
+
+// swapNotification stubs the plain toast so tests never shell out to
+// notify-send/osascript/PowerShell, and can assert the fallback fired.
+func swapNotification(t *testing.T, delivered bool) *int {
+	t.Helper()
+	var mu sync.Mutex
+	calls := 0
+	prev := showNotificationFn
+	showNotificationFn = func(ipc.NotifyRequest) bool {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		return delivered
+	}
+	t.Cleanup(func() { showNotificationFn = prev })
+	return &calls
+}
+
+func notifyPayload(t *testing.T, req ipc.NotifyRequest) json.RawMessage {
+	t.Helper()
+	raw, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal notify request: %v", err)
+	}
+	return raw
+}
+
+// runHandleNotify drives handleNotify and returns the single reply envelope. The
+// handler is run on its own goroutine because net.Pipe is unbuffered — SendTyped
+// does not return until this test reads it.
+func runHandleNotify(t *testing.T, client *Client, peer *ipc.Conn, id string, req ipc.NotifyRequest) *ipc.Envelope {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		client.handleNotify(&ipc.Envelope{ID: id, Payload: notifyPayload(t, req)})
+		close(done)
+	}()
+	_ = peer.SetReadDeadline(time.Now().Add(5 * time.Second))
+	env, err := peer.Recv()
+	if err != nil {
+		t.Fatalf("Recv: %v", err)
+	}
+	<-done
+	if env.ID != id {
+		t.Fatalf("reply id = %q, want %q", env.ID, id)
+	}
+	if env.Type != ipc.TypeNotifyResult {
+		t.Fatalf("reply type = %q, want %q", env.Type, ipc.TypeNotifyResult)
+	}
+	return env
+}
+
+func notifyResultOf(t *testing.T, env *ipc.Envelope) ipc.NotifyResult {
+	t.Helper()
+	var res ipc.NotifyResult
+	if err := json.Unmarshal(env.Payload, &res); err != nil {
+		t.Fatalf("unmarshal notify result: %v", err)
+	}
+	return res
+}
+
+func TestHandleNotifyRoutesActionsToThePromptSeam(t *testing.T) {
+	seen := swapNotifyPrompt(t, func(ipc.NotifyRequest) (string, bool) { return "Postpone 1 hour", true })
+	toasts := swapNotification(t, true)
+	client, peer, cleanup := createClientPipe(t)
+	defer cleanup()
+
+	env := runHandleNotify(t, client, peer, "env-1", ipc.NotifyRequest{
+		Title: "Restart Scheduled", Body: "in 15 minutes",
+		Actions: []string{"Restart now", "Postpone 1 hour"}, TimeoutMs: 120_000,
+	})
+
+	if len(*seen) != 1 {
+		t.Fatalf("prompt seam called %d times, want 1", len(*seen))
+	}
+	if *toasts != 0 {
+		t.Errorf("a toast was raised alongside the dialog (%d); the dialog IS the notification", *toasts)
+	}
+	res := notifyResultOf(t, env)
+	if res.ActionClicked != "Postpone 1 hour" {
+		t.Errorf("ActionClicked = %q, want %q", res.ActionClicked, "Postpone 1 hour")
+	}
+	if !res.Delivered {
+		t.Error("Delivered = false after a dialog the user answered")
+	}
+}
+
+// TestHandleNotifyWithoutActionsKeepsTheToastPath is the regression guard for the
+// #3197 warning ladder: every rung that offers no postponement must stay a
+// fire-and-forget toast, not a modal dialog in the user's face.
+func TestHandleNotifyWithoutActionsKeepsTheToastPath(t *testing.T) {
+	seen := swapNotifyPrompt(t, func(ipc.NotifyRequest) (string, bool) { return "boom", true })
+	toasts := swapNotification(t, true)
+	client, peer, cleanup := createClientPipe(t)
+	defer cleanup()
+
+	env := runHandleNotify(t, client, peer, "env-2", ipc.NotifyRequest{
+		Title: "Restart Soon", Body: "in 15 minutes",
+	})
+
+	if len(*seen) != 0 {
+		t.Fatal("an actionless notify opened a modal dialog")
+	}
+	if *toasts != 1 {
+		t.Errorf("toast calls = %d, want 1", *toasts)
+	}
+	res := notifyResultOf(t, env)
+	if res.ActionClicked != "" {
+		t.Errorf("ActionClicked = %q, want empty", res.ActionClicked)
+	}
+	if !res.Delivered {
+		t.Error("Delivered = false for a toast the platform reported delivered")
+	}
+}
+
+// TestNotifyPromptTimeoutReportsNoAction: an expired countdown is "the user did
+// nothing", NOT a postponement. Silence must never grant a deferral.
+func TestNotifyPromptTimeoutReportsNoAction(t *testing.T) {
+	swapNotifyPrompt(t, func(ipc.NotifyRequest) (string, bool) { return "", true })
+	swapNotification(t, true)
+	client, peer, cleanup := createClientPipe(t)
+	defer cleanup()
+
+	res := notifyResultOf(t, runHandleNotify(t, client, peer, "env-3", ipc.NotifyRequest{
+		Actions: []string{"Restart now", "Postpone 1 hour"},
+	}))
+	if res.ActionClicked != "" {
+		t.Errorf("ActionClicked = %q, want empty on timeout", res.ActionClicked)
+	}
+	if !res.Delivered {
+		t.Error("Delivered = false for a dialog that was shown and timed out")
+	}
+}
+
+// TestHandleNotifyFallsBackToAToastWhenTheDialogCannotRender keeps the #3197
+// always-warn invariant independent of the prompt. A dialog that could not open
+// (no window server, a failed user32 call) must not swallow the warning.
+func TestHandleNotifyFallsBackToAToastWhenTheDialogCannotRender(t *testing.T) {
+	swapNotifyPrompt(t, func(ipc.NotifyRequest) (string, bool) { return "", false })
+	toasts := swapNotification(t, true)
+	client, peer, cleanup := createClientPipe(t)
+	defer cleanup()
+
+	res := notifyResultOf(t, runHandleNotify(t, client, peer, "env-4", ipc.NotifyRequest{
+		Title: "Restart Scheduled", Actions: []string{"Restart now", "Postpone 1 hour"},
+	}))
+	if *toasts != 1 {
+		t.Fatalf("toast calls = %d, want 1 — the user was told nothing at all", *toasts)
+	}
+	if res.ActionClicked != "" {
+		t.Errorf("ActionClicked = %q, want empty when no dialog rendered", res.ActionClicked)
+	}
+	if !res.Delivered {
+		t.Error("Delivered = false although the fallback toast was delivered")
+	}
+}
+
+// TestHandleNotifyReportsUndeliveredWhenEverythingFails: the daemon must be able
+// to tell "shown" from "reached nobody" rather than being told a comfortable lie.
+func TestHandleNotifyReportsUndeliveredWhenEverythingFails(t *testing.T) {
+	swapNotifyPrompt(t, func(ipc.NotifyRequest) (string, bool) { return "", false })
+	swapNotification(t, false)
+	client, peer, cleanup := createClientPipe(t)
+	defer cleanup()
+
+	res := notifyResultOf(t, runHandleNotify(t, client, peer, "env-5", ipc.NotifyRequest{
+		Actions: []string{"Restart now", "Postpone 1 hour"},
+	}))
+	if res.Delivered {
+		t.Error("Delivered = true although neither the dialog nor the toast rendered")
+	}
+}
+
+// TestHandleNotifyAlwaysRepliesEvenWhenThePromptPanics: handleNotify is dispatched
+// via safeGo, which recovers panics but sends nothing back. The daemon now WAITS
+// on this reply, so a panic in the raw user32 syscall path would otherwise cost a
+// full prompt timeout of silence on every rung.
+func TestHandleNotifyAlwaysRepliesEvenWhenThePromptPanics(t *testing.T) {
+	swapNotifyPrompt(t, func(ipc.NotifyRequest) (string, bool) { panic("dialog exploded") })
+	swapNotification(t, true)
+	client, peer, cleanup := createClientPipe(t)
+	defer cleanup()
+
+	env := runHandleNotify(t, client, peer, "env-6", ipc.NotifyRequest{
+		Actions: []string{"Restart now", "Postpone 1 hour"},
+	})
+	if env.Error == "" {
+		t.Error("a panicking dialog produced no error reply; the daemon would wait out the whole timeout")
+	}
+	if got := notifyResultOf(t, env).ActionClicked; got != "" {
+		t.Errorf("ActionClicked = %q after a panic, want empty", got)
+	}
+}
+
+// TestConcurrentNotifyPromptsDoNotStackModalDialogs: MB_SYSTEMMODAL|MB_TOPMOST
+// dialogs stack on top of one another and each one steals focus. A second prompt
+// arriving while one is open falls back to a toast instead.
+func TestConcurrentNotifyPromptsDoNotStackModalDialogs(t *testing.T) {
+	release := make(chan struct{})
+	entered := make(chan struct{}, 1)
+	swapNotifyPrompt(t, func(ipc.NotifyRequest) (string, bool) {
+		select {
+		case entered <- struct{}{}:
+		default:
+		}
+		<-release
+		return "Postpone 1 hour", true
+	})
+	toasts := swapNotification(t, true)
+
+	first, firstPeer, cleanupFirst := createClientPipe(t)
+	defer cleanupFirst()
+	second, secondPeer, cleanupSecond := createClientPipe(t)
+	defer cleanupSecond()
+
+	req := ipc.NotifyRequest{Actions: []string{"Restart now", "Postpone 1 hour"}}
+	go first.handleNotify(&ipc.Envelope{ID: "env-a", Payload: notifyPayload(t, req)})
+	<-entered
+
+	// The second request must not wait on the first: it takes the toast path.
+	res := notifyResultOf(t, runHandleNotify(t, second, secondPeer, "env-b", req))
+	if res.ActionClicked != "" {
+		t.Errorf("ActionClicked = %q — a second modal dialog was opened over the first", res.ActionClicked)
+	}
+	if *toasts != 1 {
+		t.Errorf("toast calls = %d, want 1 — the second warning reached nobody", *toasts)
+	}
+
+	close(release)
+	_ = firstPeer.SetReadDeadline(time.Now().Add(5 * time.Second))
+	if _, err := firstPeer.Recv(); err != nil {
+		t.Fatalf("first handler never replied: %v", err)
+	}
+}
+
+func TestNotifyPromptTimeoutMsIsBounded(t *testing.T) {
+	t.Parallel()
+	cases := []struct{ in, want int }{
+		{0, defaultNotifyPromptTimeoutMs},
+		{-1, defaultNotifyPromptTimeoutMs},
+		{30_000, 30_000},
+		{maxNotifyPromptTimeoutMs, maxNotifyPromptTimeoutMs},
+		{maxNotifyPromptTimeoutMs + 1, maxNotifyPromptTimeoutMs},
+	}
+	for _, tc := range cases {
+		if got := notifyPromptTimeoutMs(ipc.NotifyRequest{TimeoutMs: tc.in}); got != tc.want {
+			t.Errorf("notifyPromptTimeoutMs(%d) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestNotifyPromptSeesASanitizedRequest: the Actions cap (notify_common.go) is
+// already implemented but was never load-bearing. It now bounds the dialog's
+// button row, and an untrimmed action would be pasted straight into an AppleScript
+// string or a UTF16 buffer.
+func TestNotifyPromptSeesASanitizedRequest(t *testing.T) {
+	seen := swapNotifyPrompt(t, func(ipc.NotifyRequest) (string, bool) { return "", true })
+	swapNotification(t, true)
+	client, peer, cleanup := createClientPipe(t)
+	defer cleanup()
+
+	runHandleNotify(t, client, peer, "env-7", ipc.NotifyRequest{
+		Title:   strings.Repeat("t", maxNotifyTitleBytes+50),
+		Actions: []string{" Restart now ", "b", "c", "d", "e", "f"},
+	})
+
+	if len(*seen) != 1 {
+		t.Fatalf("prompt seam called %d times, want 1", len(*seen))
+	}
+	got := (*seen)[0]
+	if len(got.Actions) != 4 {
+		t.Errorf("len(Actions) = %d, want the sanitiser's cap of 4", len(got.Actions))
+	}
+	if got.Actions[0] != "Restart now" {
+		t.Errorf("Actions[0] = %q, want it trimmed", got.Actions[0])
+	}
+	if len(got.Title) != maxNotifyTitleBytes {
+		t.Errorf("len(Title) = %d, want it truncated to %d", len(got.Title), maxNotifyTitleBytes)
+	}
+}
+
+// TestNotifyPromptButtonForCode pins the answer mapping both native dialogs share.
+// Neither platform's dialog code runs in CI, so the arithmetic that turns a
+// button index into a label lives here, untagged.
+func TestNotifyPromptButtonForCode(t *testing.T) {
+	t.Parallel()
+	actions := []string{"Restart now", "Postpone 1 hour"}
+	cases := []struct {
+		name    string
+		actions []string
+		index   int
+		want    string
+	}{
+		{"affirmative", actions, 0, "Restart now"},
+		{"postpone", actions, 1, "Postpone 1 hour"},
+		{"index past the end is no decision", actions, 2, ""},
+		{"negative index is no decision", actions, -1, ""},
+		{"single-action request has no second button", []string{"Restart now"}, 1, ""},
+		{"no actions at all", nil, 0, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := notifyPromptAction(tc.actions, tc.index); got != tc.want {
+				t.Errorf("notifyPromptAction(%v, %d) = %q, want %q", tc.actions, tc.index, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNotifyPromptLegend pins the Windows body copy. MB_YESNO's labels cannot be
+// renamed, so without this the dialog is a bare Yes/No about nothing.
+func TestNotifyPromptLegend(t *testing.T) {
+	t.Parallel()
+	got := notifyPromptLegend([]string{"Restart now", "Postpone 1 hour"})
+	for _, want := range []string{"Yes", "restart now", "No", "postpone 1 hour"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("legend %q is missing %q", got, want)
+		}
+	}
+	if notifyPromptLegend(nil) != "" {
+		t.Errorf("legend for no actions = %q, want empty", notifyPromptLegend(nil))
+	}
+	if got := notifyPromptLegend([]string{"Restart now"}); strings.Contains(got, "No to") {
+		t.Errorf("legend %q promises a No button that does not exist", got)
+	}
+}
+
+// TestNotifyPromptDialogButtonsPutTheAffirmativeLast: AppleScript draws the last
+// button rightmost, which is where macOS puts the default action. Actions[0] is
+// the affirmative, so it must end up last — getting this backwards would put
+// "Postpone" under the user's return key.
+func TestNotifyPromptDialogButtonsPutTheAffirmativeLast(t *testing.T) {
+	t.Parallel()
+	got := notifyPromptDialogButtons([]string{"Restart now", "Postpone 1 hour"})
+	want := []string{"Postpone 1 hour", "Restart now"}
+	if len(got) != len(want) {
+		t.Fatalf("buttons = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("buttons = %v, want %v", got, want)
+		}
+	}
+	if len(notifyPromptDialogButtons(nil)) != 0 {
+		t.Error("no actions produced buttons")
+	}
+	if got := notifyPromptDialogButtons([]string{"a", "", "  ", "b"}); len(got) != 2 {
+		t.Errorf("blank actions became buttons: %v", got)
+	}
+	// osascript rejects a dialog with more than three buttons outright, which
+	// would turn every prompt into an exec error and warn nobody.
+	if got := notifyPromptDialogButtons([]string{"a", "b", "c", "d"}); len(got) != maxNotifyPromptDialogButtons {
+		t.Errorf("len(buttons) = %d, want the AppleScript cap of %d", len(got), maxNotifyPromptDialogButtons)
+	}
+}
+
+// TestNotifyPromptClickedButton pins the osascript record parsing, including the
+// case that matters most: a label we never offered is not a decision.
+func TestNotifyPromptClickedButton(t *testing.T) {
+	t.Parallel()
+	buttons := []string{"Postpone 1 hour", "Restart now"}
+	cases := []struct {
+		name   string
+		output string
+		want   string
+	}{
+		{"affirmative", "button returned:Restart now, gave up:false\n", "Restart now"},
+		{"postpone", "button returned:Postpone 1 hour, gave up:false\n", "Postpone 1 hour"},
+		{"no gave-up suffix", "button returned:Restart now\n", "Restart now"},
+		{"gave up", "gave up:true\n", ""},
+		{"empty output", "", ""},
+		{"a label we never offered", "button returned:Format the disk, gave up:false\n", ""},
+		{"partial label is not a match", "button returned:Restart, gave up:false\n", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := notifyPromptClickedButton(tc.output, buttons); got != tc.want {
+				t.Errorf("notifyPromptClickedButton(%q) = %q, want %q", tc.output, got, tc.want)
+			}
+		})
+	}
+}

--- a/agent/internal/userhelper/notify_prompt_windows.go
+++ b/agent/internal/userhelper/notify_prompt_windows.go
@@ -1,0 +1,82 @@
+//go:build windows
+
+package userhelper
+
+import (
+	"strings"
+	"syscall"
+	"unsafe"
+
+	"github.com/breeze-rmm/agent/internal/ipc"
+)
+
+// MB_ICONWARNING. The consent dialog uses MB_ICONQUESTION because it asks a
+// question about someone else's request; a pending restart of the machine the
+// user is working on is a warning about their own session.
+const notifyPromptMBIconWarning = 0x00000030
+
+// showNotifyPromptOS renders the interactive notification as a native Yes/No
+// message box, reusing the MessageBoxTimeoutW proc consent_dialog_windows.go
+// already declares — it is the only Win32 message box with a real countdown.
+//
+// Buttons come from MB_YESNO: Yes is Actions[0] (the affirmative, "Restart now")
+// and No is Actions[1] (the postponement). A message box cannot render arbitrary
+// button labels, so the legend is appended to the body text; the daemon only ever
+// sends two actions for a reboot prompt.
+//
+// Return mapping, and why every ambiguous case is "":
+//   - IDYES / IDNO are real clicks and map to their action.
+//   - 32000 is MessageBoxTimeoutW's countdown expiry: the user did nothing.
+//   - 0 means the call itself failed (no window station, a bad UTF-16 buffer).
+//     That one is reported shown=false so the caller falls back to a toast — the
+//     user has to be warned even when no dialog could open (#3197).
+//
+// Anything that is not an unambiguous click yields no action, so the reboot
+// proceeds exactly as scheduled. Silence is never a postponement, and it is never
+// an acceleration either.
+func showNotifyPromptOS(req ipc.NotifyRequest) (clicked string, shown bool) {
+	titleStr := req.Title
+	if titleStr == "" {
+		titleStr = "Restart Scheduled"
+	}
+	bodyStr := req.Body
+	if legend := notifyPromptLegend(req.Actions); legend != "" {
+		bodyStr = strings.TrimSpace(bodyStr) + "\r\n\r\n" + legend
+	}
+
+	title, err := syscall.UTF16PtrFromString(titleStr)
+	if err != nil {
+		log.Warn("reboot prompt title could not be encoded", "error", err.Error())
+		return "", false
+	}
+	body, err := syscall.UTF16PtrFromString(bodyStr)
+	if err != nil {
+		log.Warn("reboot prompt body could not be encoded", "error", err.Error())
+		return "", false
+	}
+
+	flags := uintptr(consentMBYesNo | notifyPromptMBIconWarning | consentMBTopMost | consentMBSystemModal | consentMBSetForeground)
+	ret, _, _ := procMessageBoxTimeoutW.Call(
+		0,
+		uintptr(unsafe.Pointer(body)),
+		uintptr(unsafe.Pointer(title)),
+		flags,
+		0, // language id
+		uintptr(notifyPromptTimeoutMs(req)),
+	)
+	switch ret {
+	case consentIDYes:
+		return notifyPromptAction(req.Actions, 0), true
+	case consentIDNo:
+		return notifyPromptAction(req.Actions, 1), true
+	case consentIDTimeout:
+		return "", true // shown, and deliberately unanswered
+	case 0:
+		log.Warn("MessageBoxTimeoutW could not display the reboot prompt")
+		return "", false
+	default:
+		// Dismissed some other way (Alt+F4 is disabled on a MB_YESNO box, but be
+		// defensive): treat it as no decision rather than guessing a button.
+		return "", true
+	}
+}

--- a/apps/docs/src/content/docs/features/patch-management.mdx
+++ b/apps/docs/src/content/docs/features/patch-management.mdx
@@ -402,6 +402,18 @@ Patch settings inherit through the hierarchy. A device with a more specific poli
 
 When a device is assigned to an [update ring](#patch-scheduling-via-configuration-policies), the ring's approval rules take precedence over the policy-level auto-approve settings — the ring decides which severities and categories are approved (and after what deferral) for the devices it covers.
 
+#### What the end user sees
+
+When `rebootAllowDeferral` is on and a restart is scheduled while someone is signed in with the Breeze helper running in their session (Windows and macOS only — see above), the early warnings appear as a native modal dialog instead of a passive toast: a system message box on Windows, a standard dialog on macOS. The dialog offers two buttons, **Restart now** and **Postpone N minutes/hours** (the postpone label reflects `rebootDeferralMinutes`), and states how many postponements remain, e.g. "You can postpone this restart 2 more times."
+
+- **Postpone** pushes the restart out by the configured window, measured from the restart's currently scheduled time — not from the moment the user clicks. Using up the full postponement budget lands the restart exactly on the deadline; it can never be pushed past it.
+- **Restart now** doesn't restart the machine instantly — it collapses the countdown to the shortest schedule Breeze allows, still showing the final "save your work" notice and still giving the OS a grace period before the session ends.
+- Doing nothing — closing the dialog or letting its countdown run out — changes nothing. The restart proceeds exactly as scheduled; silence never postpones and never accelerates it.
+
+Once the postponement budget is spent, or the deadline no longer leaves room to defer, no further dialog is shown: the remaining warnings go back to being plain notifications, and they say "This restart can no longer be postponed." The final warning, fired as the OS-owned countdown begins, never offers a postponement either — by that point the countdown belongs to the operating system, not Breeze.
+
+If nobody is signed in or the helper isn't running — a server sitting at the logon screen, a headless machine — there's no dialog. The restart proceeds on schedule and the existing warnings are unaffected; this is expected behavior, not a failure, and there's no setting to change it.
+
 #### Patch Sources
 
 Each patch policy must declare which **patch sources** it manages, and at least one is required. This separates operating-system updates from third-party application updates so you can, for example, auto-approve OS security fixes while reviewing application updates manually.


### PR DESCRIPTION
Closes #4663. Wave W03 of #3207 — the deferral prompt on Windows + macOS.

## What ships

When policy enables deferral and a helper session is present, the reboot's early warning rungs become a **native modal dialog** with **Restart now** / **Postpone N**, and the answer drives `RebootManager.Defer()`. The feature becomes real; W1 sent the budget, W2 built the state machine, this wave puts a button in front of a person.

Four commits, each independently green:

1. **`fix(agent)`: bound the session broker's listener close.** Pre-existing shutdown deadlock — see below.
2. **`feat(agent)`: `Broker.RequestNotificationDecision`.** The response-bearing sibling of `BroadcastNotification`, which is untouched.
3. **`feat(agent)`: the helper-side prompt dialog.** `showNotifyPromptFn` seam plus windows/darwin/other implementations; `handleNotify` routes on `len(Actions) > 0`.
4. **`feat(agent)`: `promptFn` on the manager** + the heartbeat wiring, plus the `osInvoked` fix codex flagged in the W2 review.

## Two defects fixed inline

**`BroadcastNotification` sent an empty envelope id**, so a `NotifyResult` reply matched no pending command and `dispatchHelperMessage` dropped it as unsolicited. Every other piece of the contract already existed — `NotifyRequest.Actions`, `NotifyResult.ActionClicked`, `expectedResponseType`'s `TypeNotify -> TypeNotifyResult` mapping, the helper replying on `env.ID`. `RequestNotificationDecision` allocates a real per-session id; `BroadcastNotification` stays fire-and-forget, with a test pinning that it registers no pending response.

The id is a **monotonic counter**, not the `time.Now().UnixMilli()` convention the repo's other correlated requests use (`LaunchProcessViaUserHelperWithArgs`). `SendCommand` rejects a duplicate in-flight id outright, and a mutation run confirmed the millisecond form loses answers under 25 concurrent requests.

**The Windows CI hang** (`TestNamedPipeListenAndAccept`, closed issue #3018, recurred on PR #4686 at 2026-09-03 02:12Z, [job 100494963534](https://github.com/LanternOps/breeze/actions/runs/33704894539/job/100494963534)). Root cause established from the panic dump, not guessed:

> `goroutine 590 [chan receive, 9 minutes]` — `winio.(*win32PipeListener).Close` at `pipe.go:578`, i.e. `<-l.doneCh` **after a successful send** on `closeCh`.
> `goroutine 571 [select, 9 minutes]` — `listenerRoutine` at `pipe.go:462`, the **top-level** select.
> The broker's accept-loop goroutine is absent from the dump entirely.

Those three facts pin it. `Close()`'s single `closeCh` token was consumed by `makeConnectedServerPipe`'s abort branch (`pipe.go:447`), which rewrites only `nil` and `ErrFileClosed` into `ErrPipeListenerClosed`. A connect already failing on its own errno when `Close()` cancelled it — `ERROR_NO_DATA` from a client that dialled and hung up, which is exactly what this test does — leaks that errno through. `listenerRoutine` delivers it to the waiting `Accept()` (hence the accept goroutine exiting cleanly and vanishing from the dump), leaves `closed` false, and returns to its select at 462 to wait for a second token that will never be sent. `doneCh` is never closed, so `Close()` never returns.

**This is an upstream go-winio bug and v0.6.2 is the newest release**, so there is no upgrade to take. The fix is defensive: `StopAcceptingAndWait` closes the listener on its own goroutine and bounds the wait on the caller's context. Abandoning that close is safe where abandoning the pre-auth drain is not — `acceptStopped` is set under `acceptMu` before the close is even attempted, so nothing can be admitted whether or not the handle closes. Cost is one leaked goroutine and one handle for the life of the process; the alternative is agent shutdown never returning (on a device that turns a service restart into a kill).

The regression test drives it through `net.Listener` rather than a real pipe, so it runs in the ordinary **Test Agent** job on every platform. Verified red before the fix: it hangs for the full 10s guard on Linux, the same shape as the 10-minute CI hang.

**Third item, also fixed inline.** Codex flagged during the W2 review that `runOSReboot` set `osInvoked` *before* `execOSReboot` ran, so a `Cancel` in that window took the abort path, found nothing to abort, and reported success while the machine still went down. This wave widens it — "Restart now" re-enters `scheduleLockedAt`, which takes the same abort path — so it is fixed here rather than deferred. A separate `osInvoking` flag covers the interval: `Cancel`, `Defer` and a re-schedule are all **refused** there rather than handed a success that cannot be delivered, and `osInvoked` is set only once `exec` returns successfully.

## Contracts held

- **Cancel-safe.** The dialog blocks for up to two minutes, during which the operator can cancel from the console. `Defer()` already refused a cancelled reboot, but `ScheduleWithOptions` has no generation check — a "Restart now" answered after a cancellation would have armed a brand-new reboot the operator had just called off. `restartNow` checks the generation under the lock. A refused click tells the user why instead of looking like it worked.
- **Budget-safe.** `ComputeDeferral` is the single authority on whether a button appears, so the manager can never offer a postponement `Defer()` would then refuse. Budget spent, or a deadline with no room, means no button — and the warning says "This restart can no longer be postponed." in words.
- **Never on the closing rung.** The critical notice fires at `OSInvokeAt`, from which point the countdown is in the OS and `Defer()` is refused. Covered for the collapsed single-rung plan too.
- **Never blocks the manager.** `r.mu` is not held across `promptFn`; `State()` during an open dialog is tested.
- **The prompt never outlives the next rung**, property-tested across seven schedule lengths. A dialog still open then would make the helper refuse to stack a second modal, silently costing the ladder a warning.
- **Always-warn (#3197) is independent of the prompt.** A dialog that cannot render reports `shown=false` and the helper falls back to the plain toast. `promptFn == nil` (headless, no helper) still warns and still reboots on time.
- **Headless is the story, not a gap.** No helper means no prompt and a reboot on schedule. No switch added.
- **Backward compatible.** `Actions`/`TimeoutMs` are `omitempty`: an old helper ignores them and gets no correlated reply, which reads as no decision; a new helper on an old agent never receives actions and behaves exactly as today.
- **Scope filter unchanged (#3255).** The assist helper and watchdog are excluded from both paths — a modal prompt is strictly more intrusive than the toast that filter was written for.
- **Deferral off is byte-identical**, asserted: `promptFn` is never called and the copy never mentions postponement.

## Review round (all findings addressed or explicitly left)

Three reviewers: Sonnet `code-reviewer`, Sonnet `silent-failure-hunter`, and `codex gpt-5.6-sol` at medium on the concurrency. The first two findings were reached independently by more than one reviewer.

**Fixed in `6f210437a`:**

1. **The always-warn invariant was lost on any device with no signed-in helper.** `PromptFunc` returned only a label, so "a person saw the dialog and did nothing" and "nothing reached anybody" were the same empty string — and `emitNotification` treated both as "the prompt was the warning" and emitted nothing more. On a headless box, a Windows server at the logon screen, or a machine whose helper had crashed, **every deferrable rung warned nobody**; only the closing notice survived. That is #3197 reintroduced for exactly the machines the ladder was written for. My own headless test missed it because it used a `nil` `promptFn`, which production never has. `PromptFunc` now returns `(clicked, shown)`, the manager falls back to the ordinary notification when nothing rendered, and the tests use the production shape. The signal already existed and was being thrown away one hop up — the helper honestly reports `Delivered:false`.
2. **A "Postpone" answered after the schedule was *superseded* postponed the replacement and spent its budget.** `Defer()` asks only whether *some* reboot is scheduled, which stays true across a last-writer-wins re-dispatch. `restartNow` already checked the generation; `deferForGeneration` now does too. Mutation-verified: reverting to plain `Defer()` fails the new test on all three assertions.
3. **`execOSReboot` was an unbounded exec, and this wave's `osInvoking` flag made its return load-bearing** — a `shutdown` that never returned would leave Cancel, Defer and every re-schedule refused permanently. All six platform invocations now route through one untagged `runRebootCommand` with a 30s kill timeout, so the bound is covered by tests that run in CI.
4. **`Broker.Close` discarded `StopAcceptingAndWait`'s error**, so a stalled listener looked like a clean shutdown to any caller that had not called it directly.

The heartbeat's prompt closure became a named, tested `rebootPromptFunc` rather than an inline lambda — that hop is exactly where "the helper showed nothing" could be mistaken for "the user declined to answer", and the previous wiring test only pinned the type signature.

**Pre-existing, deliberately not fixed here** (both are W2/#3197 structure this wave does not touch — flagging rather than silently dropping):

- **`Cancel` runs `abortOSReboot` outside the lock.** It clears `osInvoked`, unlocks, then runs the abort. A concurrent `Schedule` in that gap sees a clean manager and arms a new reboot; the late `shutdown /a` then aborts the *new* countdown while `Cancel` has already reported success. If the abort instead fails, `osInvoked` stays false, so a retry is impossible and a live countdown is no longer represented. Fix: an `osAborting` state that refuses scheduling and cancellation until the abort resolves, clearing `osInvoked` only on success.
- **`Stop` can return while a committed reboot still fires.** `runOSReboot` sets `osInvoking`, unlocks, and does not re-check `stopped` before invoking; `Stop` meanwhile returns claiming to have cancelled pending work. `Stop` also never aborts an already-live countdown. Whether it *should* is a product question — the agent stopping is often *because* of the reboot — which is why this is flagged rather than guessed at.

## Deviations from the plan

1. **An osascript `-128` cancel maps to no decision, not to the last button.** The plan said map it to the last button — but that is "Restart now", so Escape would have *accelerated* the user's reboot. Leaving the countdown where it is matches the manager's own rule that silence never postpones and never accelerates.
2. **The seam returns `(clicked string, shown bool)`**, not just `clicked`. `Delivered: true` on a dialog that never rendered is a lie that inflates delivery accounting, and `shown=false` is what triggers the toast fallback that keeps #3197 true.
3. **Prompts are serialised per helper process.** Both vehicles are `MB_SYSTEMMODAL|MB_TOPMOST` / a standard macOS dialog; a second prompt would stack over the first and steal focus. One that cannot take the lock falls back to a toast rather than queueing behind a dialog with two minutes left to run.
4. **The prompt window is computed per rung**, not a flat `min(next rung, 2m)` at call time — it lives in `planRebootRungs` as pure data so it is testable, and a rung with less than 20s of room offers no button at all.
5. **The manager's copy states the remaining postponements.** The plan didn't ask; a user who cannot see their remaining budget cannot plan around it, and the exhausted case has to say so once the button disappears.
6. **`ComputeDeferral` takes five arguments, not four** (the plan's W3 sketch predates W2's `scheduledAt` parameter). Followed the code.

### Observation, not changed here

`ComputeDeferral` grants a postponement when `deadline == scheduledAt`: the clamp lands the "new" time exactly where the old one was, so a deferral is spent that moves nothing. That is W2 arithmetic and out of scope for this wave — flagging it rather than editing it.

## Test evidence

**Verified** (`golang:1.26.6` container; this dev host cannot run cgo — `go-m1cpu` segfaults on init):

| Command | Result |
|---|---|
| `go test -race ./internal/sessionbroker/` | ok, 14.3s |
| `go test -race ./internal/patching/` | ok — **132 tests pass**, 1 pre-existing skip |
| `go test -race ./internal/userhelper/` | ok, 2.0s |
| `go test -race ./internal/heartbeat/` | ok, 30.7s |
| `go test -race ./internal/ipc/` | ok, 2.6s |
| `CGO_ENABLED=0 go test ./...` (matches the **Test Agent** job) | 2 failures, both environmental — see below |
| `go vet` × `GOOS=windows,darwin,linux` | clean (this compiles the tagged files, incl. the new `notify_prompt_windows.go` / `_darwin.go`) |
| `CGO_ENABLED=0 go build ./...` × three GOOS | rc=0 each |
| `golangci-lint v2.12.2` on the five touched package trees | **0 issues in any file this PR touches** (61 pre-existing elsewhere, which CI's `--new-from-rev` mode skips) |
| `gofmt -l` on all 17 changed Go files | clean |

The two `./...` failures are `internal/backup/systemstate` `TestCollectHardwareOnly` (no CPU model/cores inside a container) and `internal/executor` `TestConfigureRunAsElevatedWhenNotRoot` (the container runs as root). Both are in packages this PR does not touch, and the executor one **passes when the same container runs as uid 1000** — confirmed, not assumed.

Red-first was observed for every new behaviour: the shutdown tests hang for their full guard without the fix, and both the empty-id and `UnixMilli`-id mutations were run and caught.

**Not verified — needs a real box.** Windows-tagged and darwin-tagged rendering code is executed nowhere in CI (#3019, #3046), so this is a claim I am explicitly not making:

- The `MessageBoxTimeoutW` dialog actually rendering under the user-helper session on Windows, its Yes/No buttons mapping to Restart now / Postpone, and the 32000 timeout return firing.
- The `osascript display dialog` rendering from the macOS desktop helper, its button ordering, and `gave up:true` / `-128` behaviour.
- End to end: a patch-triggered reboot with deferral on shows the dialog, Postpone moves the countdown, and `get_reboot_status` reports `deferralsUsed: 1`.

Everything that *decides* what those dialogs render and what their answers mean is untagged and covered — the timeout bound, the button-index mapping, the Yes/No legend, the AppleScript button ordering and its result parsing.

## Not in this PR

W4 (Linux parity) and W5 (console visibility) — deliberately out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Ua3dk5TZk7PXWkYR7NipG
