### PR TITLE
fix(web): force TLS 1.2 in the generated Windows install one-liner

### DIFF
--- a/apps/docs/src/content/docs/agents/advanced-install.mdx
+++ b/apps/docs/src/content/docs/agents/advanced-install.mdx
@@ -172,6 +172,11 @@ For MDM, configuration management (Ansible, Chef, Puppet, Salt), golden images, 
   </TabItem>
   <TabItem label="Windows">
     ```powershell
+    # Older PowerShell/.NET defaults (e.g. Windows Server 2016) can omit
+    # TLS 1.2, which makes Invoke-WebRequest fail outright.
+    [Net.ServicePointManager]::SecurityProtocol = `
+      [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+
     Invoke-WebRequest `
       -Uri "https://breeze.yourdomain.com/api/v1/agents/download/windows/amd64" `
       -OutFile "C:\Program Files\Breeze\breeze-agent.exe"

--- a/apps/docs/src/content/docs/agents/installation.mdx
+++ b/apps/docs/src/content/docs/agents/installation.mdx
@@ -88,6 +88,11 @@ clear message instead of installing a binary that can't run.
       throw "Breeze: Windows 10 or Windows Server 2016 or later is required (detected $($osv.Major).$($osv.Minor))"
     }
 
+    # Older PowerShell/.NET defaults (e.g. Windows Server 2016) can omit
+    # TLS 1.2, which makes Invoke-WebRequest fail outright.
+    [Net.ServicePointManager]::SecurityProtocol = `
+      [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+
     # Download the agent
     Invoke-WebRequest -Uri "https://breeze.yourdomain.com/api/v1/agents/download/windows/amd64" `
       -OutFile "breeze-agent.exe"

--- a/apps/web/src/lib/installCommands.test.ts
+++ b/apps/web/src/lib/installCommands.test.ts
@@ -64,6 +64,20 @@ describe('buildInstallCommands', () => {
       expect(windows).toContain('Invoke-WebRequest');
     });
 
+    it('forces TLS 1.2 before the download for older PowerShell/.NET defaults (#4586)', () => {
+      // Windows Server 2016 / PS 5.1 hosts can default SecurityProtocol to
+      // Ssl3, Tls (no Tls12), which makes Invoke-WebRequest fail outright
+      // with "Could not create SSL/TLS secure channel." Bitwise-OR the flag
+      // in rather than replacing the value, so Tls13 (where present) stays
+      // enabled alongside it.
+      const { windows } = buildInstallCommands(base);
+      expect(windows).toContain(
+        '[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12'
+      );
+      // Must run before the download, not after.
+      expect(windows.indexOf('SecurityProtocol')).toBeLessThan(windows.indexOf('Invoke-WebRequest'));
+    });
+
     it('downloads the agent from the server, not GitHub (#4441)', () => {
       // The server's download route is what serves BYO / self-hosted signed
       // binaries (BINARY_SOURCE=local, or a custom BINARY_GITHUB_REPOSITORY).

--- a/apps/web/src/lib/installCommands.ts
+++ b/apps/web/src/lib/installCommands.ts
@@ -68,9 +68,18 @@ export function buildInstallCommands(opts: InstallCommandOptions): InstallComman
     `$b=[IO.File]::ReadAllBytes("$pwd\\breeze-agent.exe"); ` +
     `if($b.Length -lt 2 -or $b[0] -ne 0x4D -or $b[1] -ne 0x5A)` +
     `{throw "Breeze: downloaded file is not a Windows executable - a captive portal or web filter may be intercepting this network"}`;
+  // Older Windows PowerShell 5.1 hosts (e.g. Windows Server 2016) can default
+  // SecurityProtocol to Ssl3, Tls with no Tls12, which makes
+  // Invoke-WebRequest fail before the agent is even downloaded ("Could not
+  // create SSL/TLS secure channel", #4586). OR the flag into the existing
+  // value rather than replacing it, so Tls13 stays enabled where present.
+  const winTlsCheck =
+    `[Net.ServicePointManager]::SecurityProtocol = ` +
+    `[Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12`;
   const windows =
     `$ErrorActionPreference='Stop'; ` +
     `${winOsFloorCheck}; ` +
+    `${winTlsCheck}; ` +
     `Invoke-WebRequest -Uri "${apiUrl}/api/v1/agents/download/windows/amd64" -OutFile breeze-agent.exe; ` +
     `${winMzCheck}; ` +
     `.\\breeze-agent.exe service install; ${winThrow('service install')}; ` +


### PR DESCRIPTION
## Summary

Refs #4586 (TLS half only — see below).

The PowerShell one-liner generated by `buildInstallCommands` (`apps/web/src/lib/installCommands.ts`) runs `Invoke-WebRequest` without first setting `[Net.ServicePointManager]::SecurityProtocol = ... Tls12`. On older Windows PowerShell 5.1 hosts with legacy defaults (reported: Windows Server 2016, default `Ssl3, Tls`), this makes the download fail outright with:

```
Invoke-WebRequest : The request was aborted: Could not create SSL/TLS secure channel.
```

- Adds a TLS 1.2 line before the download step, **bitwise-OR'd into the existing `SecurityProtocol` value** (`-bor`) rather than replacing it, so `Tls13` stays enabled on hosts where it's already present.
- Swept the repo for other generated PowerShell install/bootstrap one-liners sharing the gap (`grep -i "Invoke-WebRequest|iwr"` under `apps/web/src`, `apps/api/src`, `apps/docs`, `scripts/`):
  - `apps/api/src/services/systemScriptLibrary.ts` (edition-migration script) — already sets `Tls12`, no gap.
  - `apps/docs/src/content/docs/migration/toolkit.mdx` (Recipe 3 push payload) — already sets `Tls12`, no gap.
  - `apps/docs/src/content/docs/agents/installation.mdx` (Windows tab) — **had the gap, fixed**.
  - `apps/docs/src/content/docs/agents/advanced-install.mdx` (Windows tab) — **had the gap, fixed**.
  - Nothing under `scripts/` matched.
- Extended `apps/web/src/lib/installCommands.test.ts` with a red-first test asserting the exact `-bor` expression is present and runs before `Invoke-WebRequest`.

## Explicitly out of scope

This PR does **not** touch the Windows `service install` idempotency half of #4586 (Go agent: stopping an existing service before replace, updating an already-registered service instead of failing with "service already exists", the `agent.yaml.partial` rename contention). That needs its own design — issue stays open, using `Refs #4586` rather than `Closes #4586`.

## Test plan

- [x] Red first: new test failed against the pre-fix `installCommands.ts` (`SecurityProtocol` substring absent).
- [x] `cd apps/web && npx vitest run src/lib/installCommands.test.ts` — 13/13 passed (single-fork, targeted).
- [x] `cd apps/web && npx vitest run src/components/setup/EnrollDeviceStep.test.tsx src/components/devices/AddDeviceModal.test.tsx` — 33/33 passed (consumers of `buildInstallCommands`, no coupling to the exact PS string).
- [x] `cd apps/web && npx tsc --noEmit -p .` — clean, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)