### PR TITLE
fix(api): stop Number() parsing scientific notation in inboundEmail fixture (#4495)

### DIFF
--- a/apps/api/src/services/inboundEmail/fixtureNumbering.test.ts
+++ b/apps/api/src/services/inboundEmail/fixtureNumbering.test.ts
@@ -34,4 +34,29 @@ describe('fourDigitSuffix', () => {
     expect(next).toHaveLength(4);
     expect(next).not.toBe(base);
   });
+
+  it('wraps exactly at the 9999 -> 0000 boundary', () => {
+    // '07pr' is the base36 encoding of 9999 (parseInt('07pr', 36) === 9999),
+    // so this exercises the true top-of-range wraparound the previous test's
+    // name implied but 'zzzz' (-> 9615) doesn't actually reach.
+    expect(fourDigitSuffix('07pr')).toBe('9999');
+    expect(fourDigitSuffix('07pr', 1)).toBe('0000');
+  });
+
+  it('never throws or produces non-4-digit output for the real caller\'s edge-case suffix shapes', () => {
+    // The real fixture builds suffix as `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`.
+    // Math.random()'s base36 tail can be shorter than 4 chars (e.g. when the
+    // random value is close to 0), which pulls the epoch/suffix separator '-'
+    // into the 4-char slice (e.g. "0-i5"). Also cover a fully empty input and
+    // an all-'-' slice as hard edge cases, none of which should throw or
+    // produce output outside the 4-digit contract.
+    const edgeCaseSuffixes = ['0-i5', '5--a', '----', '', 'a', 'ab', 'abc'];
+    for (const suffix of edgeCaseSuffixes) {
+      for (const offset of [0, 1]) {
+        const result = fourDigitSuffix(suffix, offset);
+        expect(result).toHaveLength(4);
+        expect(result).toMatch(/^\d{4}$/);
+      }
+    }
+  });
 });

--- a/apps/api/src/services/inboundEmail/fixtureNumbering.test.ts
+++ b/apps/api/src/services/inboundEmail/fixtureNumbering.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { fourDigitSuffix } from './fixtureNumbering';
+
+describe('fourDigitSuffix', () => {
+  it('never exceeds 4 characters, even for scientific-notation-shaped slices (#4495)', () => {
+    // Regression inputs from #4495: Number('4e19') parses as scientific
+    // notation (4e19 === 40000000000000000000), which is the exact shape
+    // that overflowed tickets.internal_number varchar(20) in CI.
+    const sciNotationLikeSuffixes = ['4e19', '1e99', '2e05', '9e-1', '1e+5', '0e00'];
+    for (const suffix of sciNotationLikeSuffixes) {
+      const result = fourDigitSuffix(suffix);
+      expect(result).toHaveLength(4);
+      expect(result).toMatch(/^\d{4}$/);
+    }
+  });
+
+  it('never exceeds 4 characters with the +1 offset used to derive a second fixture number', () => {
+    for (const suffix of ['4e19', '9999', 'zzzz', '0000', '1e99']) {
+      const result = fourDigitSuffix(suffix, 1);
+      expect(result).toHaveLength(4);
+      expect(result).toMatch(/^\d{4}$/);
+    }
+  });
+
+  it('is deterministic for the same input', () => {
+    expect(fourDigitSuffix('ab12')).toBe(fourDigitSuffix('ab12'));
+    expect(fourDigitSuffix('4e19', 1)).toBe(fourDigitSuffix('4e19', 1));
+  });
+
+  it('wraps at the top of the range instead of growing past 4 digits', () => {
+    // 'zzzz' in base36 is the maximum 4-char value; +1 must wrap, not overflow.
+    const base = fourDigitSuffix('zzzz');
+    const next = fourDigitSuffix('zzzz', 1);
+    expect(next).toHaveLength(4);
+    expect(next).not.toBe(base);
+  });
+});

--- a/apps/api/src/services/inboundEmail/fixtureNumbering.ts
+++ b/apps/api/src/services/inboundEmail/fixtureNumbering.ts
@@ -1,0 +1,22 @@
+/**
+ * Deterministic 4-digit numeric suffix derived from an arbitrary base36
+ * string (e.g. a test fixture's `<epoch>-<random>` unique suffix).
+ *
+ * Callers building test fixtures previously did `Number(x.slice(-4))` to get
+ * a "numeric-looking" 4-digit tail. That silently breaks when the sliced
+ * 4 characters happen to parse as scientific notation (e.g. "4e19"):
+ * `Number('4e19')` is `4e19` (40000000000000000000), a 20-digit decimal once
+ * stringified, which overflows narrow fixed-width fixture columns such as
+ * `tickets.internal_number varchar(20)`. See #4495.
+ *
+ * This helper never calls `Number()` on the slice — it parses it explicitly
+ * as base36 (`parseInt(x, 36)`, which has no scientific-notation reading) and
+ * reduces mod 10000, so the result is always exactly 4 decimal digits
+ * regardless of what characters the slice contains.
+ */
+export function fourDigitSuffix(input: string, offset = 0): string {
+  const parsed = parseInt(input.slice(-4), 36);
+  const base = Number.isFinite(parsed) ? Math.abs(parsed) % 10000 : 0;
+  const n = (((base + offset) % 10000) + 10000) % 10000;
+  return n.toString().padStart(4, '0');
+}

--- a/apps/api/src/services/inboundEmail/fixtureNumbering.ts
+++ b/apps/api/src/services/inboundEmail/fixtureNumbering.ts
@@ -16,7 +16,7 @@
  */
 export function fourDigitSuffix(input: string, offset = 0): string {
   const parsed = parseInt(input.slice(-4), 36);
-  const base = Number.isFinite(parsed) ? Math.abs(parsed) % 10000 : 0;
+  const base = Number.isNaN(parsed) ? 0 : Math.abs(parsed) % 10000;
   const n = (((base + offset) % 10000) + 10000) % 10000;
   return n.toString().padStart(4, '0');
 }

--- a/apps/api/src/services/inboundEmail/inboundEmail.integration.test.ts
+++ b/apps/api/src/services/inboundEmail/inboundEmail.integration.test.ts
@@ -39,6 +39,7 @@ import {
 import { createOrganization, createPartner } from '../../__tests__/integration/db-utils';
 import { getTestDb } from '../../__tests__/integration/setup';
 import { processInboundEmail } from './inboundEmailService';
+import { fourDigitSuffix } from './fixtureNumbering';
 import type { NormalizedInboundEmail } from './types';
 
 const uniqueSuffix = () => `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -121,7 +122,14 @@ beforeEach(async () => {
   // Partner B's victim ticket. Known thread key + internal number so a forged
   // reference addressed to partner A could only match it if the guards failed.
   const bThreadKey = `<thread-b-${suffix}@b.test>`;
-  const bInternalNumber = `T-2026-${suffix.slice(-4)}`;
+  // Derived via fourDigitSuffix (never Number()) — see #4495: Number() on an
+  // arbitrary base36 slice can parse as scientific notation (e.g. "4e19") and
+  // overflow tickets.internal_number varchar(20).
+  const bInternalNumber = `T-2026-${fourDigitSuffix(suffix)}`;
+  // Fixture-level guard against a regression of #4495: tickets.internal_number
+  // is varchar(20) — assert here, not just rely on the formula, so a future
+  // edit to this fixture fails fast instead of flaking on an insert.
+  expect(bInternalNumber.length).toBeLessThanOrEqual(20);
   const [bTicket] = await db
     .insert(tickets)
     .values({
@@ -138,13 +146,15 @@ beforeEach(async () => {
 
   // A resolved partner-A ticket for the reopen case (distinct thread key).
   const aResolvedThreadKey = `<thread-a-${suffix}@a.test>`;
+  const aInternalNumber = `T-2026-${fourDigitSuffix(suffix, 1)}`;
+  expect(aInternalNumber.length).toBeLessThanOrEqual(20);
   const [aTicket] = await db
     .insert(tickets)
     .values({
       orgId: orgA.id,
       partnerId: partnerA.id,
       ticketNumber: `LEGACY-A-${suffix}`,
-      internalNumber: `T-2026-${(Number(suffix.slice(-4)) + 1).toString().padStart(4, '0')}`,
+      internalNumber: aInternalNumber,
       subject: 'Partner A laptop issue',
       status: 'resolved',
       source: 'email',


### PR DESCRIPTION
## Summary

The `inboundEmail.integration.test.ts` cross-partner isolation fixture (Task 12 of the ticketing phase-4 email-ingest plan) built a "numeric-looking" 4-digit `internal_number` suffix with `Number(suffix.slice(-4))`. `suffix` is `<epoch>-<6 base36 chars>`; when the last 4 characters of that string happen to parse as scientific notation (e.g. `"4e19"`), `Number('4e19')` returns `40000000000000000000` — a 20-digit decimal once stringified — and the composed `T-2026-<n>` value overflows `tickets.internal_number varchar(20)`, failing the insert. Probability ≈0.6%/run; it flaked CI on an unrelated PR (#4490) and required a shard re-run to land.

Root cause confirmed by direct repro against the exact reported input:
```
suffix.slice(-4)  => "4e19"
Number(...)       => 40000000000000000000
composed value     => "T-2026-40000000000000000000" (27 chars, overflows varchar(20))
```
This matches the value reported in the issue (`T-2026-40000000000000000000`) exactly.

## Fix

- New `apps/api/src/services/inboundEmail/fixtureNumbering.ts` — a pure helper `fourDigitSuffix(input, offset?)` that parses the slice explicitly as base36 (`parseInt(x, 36)`, which has no scientific-notation reading, unlike `Number()`) and reduces mod 10000, so the output is always exactly 4 decimal digits (`0000`–`9999`) regardless of what the slice contains.
- `inboundEmail.integration.test.ts` now uses `fourDigitSuffix(suffix)` / `fourDigitSuffix(suffix, 1)` instead of the raw slice / `Number()` formula, plus a fixture-level `expect(internalNumber.length).toBeLessThanOrEqual(20)` assertion as a belt-and-suspenders guard against a future regression of this fixture.
- Co-located `fixtureNumbering.test.ts` covers the regression directly: fed the reported `"4e19"` shape plus several other scientific-notation-like 4-char strings (`"1e99"`, `"2e05"`, `"9e-1"`, `"1e+5"`, `"0e00"`), with and without the `+1` offset, plus determinism and top-of-range wraparound.

**Red-first verification:** before restoring the fixed helper, I temporarily swapped in the exact old `Number()`-based formula and ran the new test file — it failed with `expected '40000000000000000000' to have a length of 4 but got 20` (and a `NaN` case on the offset path), reproducing the bug precisely. Reverting to the fixed helper turned all 4 assertions green.

## What I could / couldn't run

- **Could run:** the new unit-level `fixtureNumbering.test.ts` (pure function, no DB) — 4/4 passing, verified red against the old formula first. All 10 files / 138 tests under `src/services/inboundEmail/` (unit job) pass; the `.integration.test.ts` file is correctly excluded from that run (per `vitest.config.ts`'s existing exclusion for this suite, unaffected by this change). `tsc --noEmit` on `apps/api` — clean (required `NODE_OPTIONS=--max-old-space-size=8192` on this host to avoid an OOM in the type-checker itself, unrelated to the change).
- **Could not run:** `inboundEmail.integration.test.ts` itself — it needs a real Postgres (`__tests__/integration/setup`) which isn't available in this sandbox. The change to that file is a mechanical 1:1 substitution of the buggy inline formula for calls to the now-tested helper (same call sites, same shape of output), so the unit coverage of the helper is the practical proof; a maintainer with a DB can additionally run it directly via `vitest.integration.config.ts`.

Closes #4495

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBxF7C8E5GxFnNcGf6kBVP