### PR TITLE
fix(api): only stamp AI field provenance on a real change (#4466)

### DIFF
--- a/apps/api/src/__tests__/integration/aiAgentTicketTriage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/aiAgentTicketTriage.integration.test.ts
@@ -44,6 +44,7 @@ import {
   actionIntents,
   aiAgentRuns,
   aiAgents,
+  ticketCategories,
   ticketComments,
   ticketDrafts,
   tickets,
@@ -55,6 +56,7 @@ import { handleTicketCreatedEvent } from '../../services/aiAgents/ticketHelpdesk
 import { registerAgentRunEnqueuer, type AgentRunEnqueuer } from '../../services/aiAgents/runService';
 import { persistTicketTriage } from '../../services/aiAgents/ticketTriageFindings';
 import { releaseApprovedIntent } from '../../jobs/intentReleaseWorker';
+import { applyAiFieldUpdates } from '../../services/ticketService';
 import type { BreezeEvent } from '../../services/eventBus';
 
 // publishEvent writes to a Redis stream — spy on it so admission/release
@@ -514,5 +516,89 @@ describe('ticket-triage release pipeline — persistTicketTriage -> intents -> r
       .from(ticketComments)
       .where(and(eq(ticketComments.ticketId, ticket.id), eq(ticketComments.originPrincipalKind, 'ai_agent')));
     expect(noteRows).toHaveLength(0);
+  });
+});
+
+/**
+ * #4466, at the level the triage pipeline cannot reach: `fixtureProposal`
+ * only ever proposes `priority`, so the `categoryId` arm of the CAS predicate
+ * — which carries a DIFFERENT cast (`::uuid` vs `::ticket_priority`) — has no
+ * live-Postgres coverage through that route, and neither does the case where
+ * both arms are concatenated into one statement. `PgDialect().sqlToQuery()`
+ * compiles happily against a schema it never consults, so only real Postgres
+ * settles whether these casts and the merged `field_provenance` write actually
+ * behave.
+ */
+describe('applyAiFieldUpdates — real-change guard against live Postgres (#4466)', () => {
+  it('stamps only the field that really changed when one arm confirms and the other changes', async () => {
+    const scenario = await seedTriageScenario(true);
+    const adminDb = getTestDb() as any;
+    const [category] = await adminDb.insert(ticketCategories).values({
+      partnerId: scenario.partner.id,
+      name: `Printers ${randomUUID().slice(0, 8)}`,
+    }).returning();
+
+    // Both fields already hold a value; the AI re-asserts the category
+    // verbatim while genuinely raising the priority.
+    const ticket = await seedTicket(scenario, { categoryId: category.id, priority: 'normal' });
+
+    const result = await withSystemDbAccessContext(() =>
+      applyAiFieldUpdates(
+        ticket.id,
+        scenario.org.id,
+        {
+          categoryId: { value: category.id, expectedCurrent: category.id },
+          priority: { value: 'urgent', expectedCurrent: 'normal' },
+        },
+        randomUUID(),
+      ),
+    );
+
+    // Both report applied — the outcome is read off the RETURNING row, so it
+    // says the field HOLDS the proposed value, not that this call wrote it.
+    expect(result).toEqual({ categoryId: { applied: true }, priority: { applied: true } });
+
+    const afterTicket = await loadTicket(ticket.id);
+    expect(afterTicket.categoryId).toBe(category.id);
+    expect(afterTicket.priority).toBe('urgent');
+    // Provenance is where ownership actually lands: the real change is stamped,
+    // the confirmation is not — and the two arms merged without clobbering.
+    expect(afterTicket.fieldProvenance).toEqual({ priority: 'ai_agent' });
+  });
+
+  it('leaves a human-stamped category alone even when the AI proposes a genuinely different one', async () => {
+    const scenario = await seedTriageScenario(true);
+    const adminDb = getTestDb() as any;
+    const [current] = await adminDb.insert(ticketCategories).values({
+      partnerId: scenario.partner.id,
+      name: `Chosen by a human ${randomUUID().slice(0, 8)}`,
+    }).returning();
+    const [proposed] = await adminDb.insert(ticketCategories).values({
+      partnerId: scenario.partner.id,
+      name: `Proposed by the AI ${randomUUID().slice(0, 8)}`,
+    }).returning();
+
+    const ticket = await seedTicket(scenario, {
+      categoryId: current.id,
+      fieldProvenance: { categoryId: 'user' },
+    });
+
+    const result = await withSystemDbAccessContext(() =>
+      applyAiFieldUpdates(
+        ticket.id,
+        scenario.org.id,
+        { categoryId: { value: proposed.id, expectedCurrent: current.id } },
+        randomUUID(),
+      ),
+    );
+
+    // A real change blocked by the human stamp is the one shape that DOES
+    // surface as a skip — proof the third conjunct did not swallow the
+    // pre-existing 'user' guard.
+    expect(result.categoryId).toEqual({ applied: false, skipped: 'human_set' });
+
+    const afterTicket = await loadTicket(ticket.id);
+    expect(afterTicket.categoryId).toBe(current.id);
+    expect(afterTicket.fieldProvenance).toEqual({ categoryId: 'user' });
   });
 });

--- a/apps/api/src/__tests__/integration/aiAgentTicketTriage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/aiAgentTicketTriage.integration.test.ts
@@ -452,6 +452,39 @@ describe('ticket-triage release pipeline — persistTicketTriage -> intents -> r
     expect(afterTicket.fieldProvenance).toMatchObject({ priority: 'user' });
   });
 
+  it('an AI confirming the value already on the ticket leaves field_provenance alone (#4466)', async () => {
+    const scenario = await seedTriageScenario(true);
+    // The ticket ALREADY sits at 'high' — exactly what `fixtureProposal`
+    // proposes — and carries no provenance entry for it, so the `<> 'user'`
+    // guard cannot help: this is the shape where a human set the value
+    // through a path that never stamped.
+    const ticket = await seedTicket(scenario, { priority: 'high' });
+    const run = await seedTicketTriageRun(scenario, ticket.id);
+    const auth = agentAuthFor(scenario, run);
+
+    const persisted = await persistTicketTriage(
+      { id: run.id, orgId: run.orgId, agentId: run.agentId, ticketId: run.ticketId, policySnapshot: run.policySnapshot, maxActionsPerRun: 5 },
+      fixtureProposal({ draftReply: undefined }),
+      auth,
+    );
+
+    // `filterEligibleFields` screens on provenance and the confidence floor
+    // ONLY — it never compares the proposal against the ticket's current
+    // value. So the fields intent really is minted and really does reach
+    // `applyAiFieldUpdates`; the ownership question is settled by the CAS
+    // predicate in Postgres, which is the point of asserting it here.
+    expect(persisted.intentIds).toHaveLength(2);
+
+    for (const intentId of persisted.approvedIntentIds) {
+      await releaseApprovedIntent(intentId);
+    }
+
+    const afterTicket = await loadTicket(ticket.id);
+    expect(afterTicket.priority).toBe('high');
+    // Nothing changed, so the AI must not have taken ownership of the field.
+    expect(afterTicket.fieldProvenance).not.toHaveProperty('priority');
+  });
+
   it('a ticket closed after intent creation fails release with agent_scope_lost — the intent completes failed, not silently dropped', async () => {
     const scenario = await seedTriageScenario(true);
     const ticket = await seedTicket(scenario);

--- a/apps/api/src/services/ticketService.aiExecutors.test.ts
+++ b/apps/api/src/services/ticketService.aiExecutors.test.ts
@@ -218,6 +218,122 @@ describe('applyAiFieldUpdates — CAS predicate (P2-4, #4191)', () => {
   });
 });
 
+/**
+ * #4466. The CAS predicate proves only that the field has not MOVED since the
+ * caller observed it — it says nothing about whether the AI is actually
+ * changing anything. So an AI that merely re-asserts the value already on the
+ * ticket used to satisfy the predicate and stamp `field_provenance` to
+ * 'ai_agent' anyway. On a field a human set through a path that left no
+ * provenance entry (the stamp COALESCEs to '' and sails past the `<> 'user'`
+ * guard), that silently transferred ownership of a human's value to the AI —
+ * exactly the guarantee the provenance guard exists to provide.
+ *
+ * The guard is a distinctness check against the PROPOSED value, folded into
+ * the same predicate that drives the field write, so the stamp and the write
+ * can never drift apart. Asserted on compiled SQL for the reason the suite
+ * header gives: a mock that echoes `.set()` back cannot tell a real predicate
+ * from a missing one.
+ */
+describe('applyAiFieldUpdates — a same-value confirmation must not take ownership (#4466)', () => {
+  /** The `field_provenance || CASE ... END` arm that stamps `field`. */
+  function provenanceArm(fragment: unknown, field: 'categoryId' | 'priority') {
+    const compiled = sqlOf(fragment);
+    // Each arm is its own `||` operand, and neither a jsonb literal nor
+    // `->>` contains `||`, so splitting on it isolates them cleanly.
+    const arm = compiled.sql.split('||').find((part) => part.includes(`'{"${field}":"ai_agent"}'`));
+    expect(arm, `no provenance arm for ${field} in: ${compiled.sql}`).toBeDefined();
+    return { arm: arm!, params: compiled.params };
+  }
+
+  /** The value a `$n` placeholder inside `arm` is bound to. */
+  function boundValue(arm: string, params: unknown[], pattern: RegExp) {
+    const match = pattern.exec(arm);
+    expect(match, `expected ${pattern} in: ${arm}`).not.toBeNull();
+    return params[Number(match![1]) - 1];
+  }
+
+  const NOT_DISTINCT = /"priority" is not distinct from \$(\d+)/i;
+  const DISTINCT = /"priority" is distinct from \$(\d+)/i;
+
+  it('does not stamp provenance when the proposed priority is the value already on the ticket', async () => {
+    queueSelect(tickets, [{ id: TICKET_ID, orgId: ORG_ID, partnerId: PARTNER_ID }]);
+    // The ticket already sits at 'high' with NO provenance entry for it — a
+    // human set it via a path that never stamped, so the `<> 'user'` guard
+    // alone cannot protect it. The AI re-proposes the same 'high'.
+    dbState.updateReturningQueue.push([{ categoryId: null, priority: 'high', fieldProvenance: {} }]);
+
+    const result = await applyAiFieldUpdates(
+      TICKET_ID,
+      ORG_ID,
+      { priority: { value: 'high', expectedCurrent: 'high' } },
+      RUN_ID,
+    );
+
+    const { arm, params } = provenanceArm((setMock.mock.calls[0]![0] as Record<string, unknown>).fieldProvenance, 'priority');
+    // The CAS half and the human guard both survive...
+    expect(arm.toLowerCase()).toContain('is not distinct from');
+    expect(arm.toLowerCase()).toContain("<> 'user'");
+    // ...and both comparisons bind the SAME value, which makes the predicate
+    // `x IS NOT DISTINCT FROM 'high' AND x IS DISTINCT FROM 'high'`
+    // unsatisfiable: Postgres cannot reach the stamp on this call at all.
+    expect(boundValue(arm, params, NOT_DISTINCT)).toBe('high');
+    expect(boundValue(arm, params, DISTINCT)).toBe('high');
+
+    // ...and the caller still sees the field as being in the desired state —
+    // a confirmation is not a concurrent-change skip.
+    expect(result.priority).toEqual({ applied: true });
+  });
+
+  it('still stamps ai_agent when the proposed priority is a real change', async () => {
+    queueSelect(tickets, [{ id: TICKET_ID, orgId: ORG_ID, partnerId: PARTNER_ID }]);
+    dbState.updateReturningQueue.push([{ categoryId: null, priority: 'urgent', fieldProvenance: { priority: 'ai_agent' } }]);
+
+    const result = await applyAiFieldUpdates(
+      TICKET_ID,
+      ORG_ID,
+      { priority: { value: 'urgent', expectedCurrent: 'normal' } },
+      RUN_ID,
+    );
+
+    const { arm, params } = provenanceArm((setMock.mock.calls[0]![0] as Record<string, unknown>).fieldProvenance, 'priority');
+    // The distinctness guard compares against the PROPOSED value, not the
+    // observed one — comparing against `expectedCurrent` would be the same
+    // tautology the CAS half already covers and would never block anything.
+    expect(boundValue(arm, params, NOT_DISTINCT)).toBe('normal');
+    expect(boundValue(arm, params, DISTINCT)).toBe('urgent');
+
+    expect(result.priority).toEqual({ applied: true });
+  });
+
+  it('gates the categoryId stamp on a real change too', async () => {
+    queueSelect(tickets, [{ id: TICKET_ID, orgId: ORG_ID, partnerId: PARTNER_ID }]);
+    queueSelect(ticketCategories, [{ id: CATEGORY_ID, partnerId: PARTNER_ID, responseSlaMinutes: null, resolutionSlaMinutes: null }]);
+    dbState.updateReturningQueue.push([{ categoryId: CATEGORY_ID, priority: 'normal', fieldProvenance: {} }]);
+
+    await applyAiFieldUpdates(
+      TICKET_ID,
+      ORG_ID,
+      { categoryId: { value: CATEGORY_ID, expectedCurrent: CATEGORY_ID } },
+      RUN_ID,
+    );
+
+    const { arm, params } = provenanceArm((setMock.mock.calls[0]![0] as Record<string, unknown>).fieldProvenance, 'categoryId');
+    expect(boundValue(arm, params, /"category_id" is not distinct from \$(\d+)/i)).toBe(CATEGORY_ID);
+    expect(boundValue(arm, params, /"category_id" is distinct from \$(\d+)/i)).toBe(CATEGORY_ID);
+  });
+
+  it('leaves an untouched field out of the write entirely (only the proposed field is set)', async () => {
+    queueSelect(tickets, [{ id: TICKET_ID, orgId: ORG_ID, partnerId: PARTNER_ID }]);
+    dbState.updateReturningQueue.push([{ categoryId: null, priority: 'high', fieldProvenance: {} }]);
+
+    await applyAiFieldUpdates(TICKET_ID, ORG_ID, { priority: { value: 'high', expectedCurrent: 'high' } }, RUN_ID);
+
+    const setArg = setMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(setArg.categoryId).toBeUndefined();
+    expect(sqlOf(setArg.fieldProvenance).sql).not.toContain('categoryId');
+  });
+});
+
 describe('addAiTriageNote — AI-origin internal comment (P2-4, #4191)', () => {
   it('inserts an internal, non-public comment with no users-FK id and the AI origin columns stamped', async () => {
     queueSelect(tickets, [{ id: TICKET_ID, orgId: ORG_ID, partnerId: PARTNER_ID }]);

--- a/apps/api/src/services/ticketService.aiExecutors.test.ts
+++ b/apps/api/src/services/ticketService.aiExecutors.test.ts
@@ -216,6 +216,17 @@ describe('applyAiFieldUpdates — CAS predicate (P2-4, #4191)', () => {
       applyAiFieldUpdates(TICKET_ID, ORG_ID, { priority: { value: 'high', expectedCurrent: 'normal' } }, RUN_ID),
     ).rejects.toThrow(TicketServiceError);
   });
+
+  it('leaves an unproposed field out of the write entirely (only the proposed field is set)', async () => {
+    queueSelect(tickets, [{ id: TICKET_ID, orgId: ORG_ID, partnerId: PARTNER_ID }]);
+    dbState.updateReturningQueue.push([{ categoryId: null, priority: 'high', fieldProvenance: {} }]);
+
+    await applyAiFieldUpdates(TICKET_ID, ORG_ID, { priority: { value: 'high', expectedCurrent: 'normal' } }, RUN_ID);
+
+    const setArg = setMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(setArg.categoryId).toBeUndefined();
+    expect(sqlOf(setArg.fieldProvenance).sql).not.toContain('categoryId');
+  });
 });
 
 /**
@@ -322,15 +333,67 @@ describe('applyAiFieldUpdates — a same-value confirmation must not take owners
     expect(boundValue(arm, params, /"category_id" is distinct from \$(\d+)/i)).toBe(CATEGORY_ID);
   });
 
-  it('leaves an untouched field out of the write entirely (only the proposed field is set)', async () => {
+  it('stamps only the field that really changed when one arm confirms and the other changes', async () => {
     queueSelect(tickets, [{ id: TICKET_ID, orgId: ORG_ID, partnerId: PARTNER_ID }]);
-    dbState.updateReturningQueue.push([{ categoryId: null, priority: 'high', fieldProvenance: {} }]);
+    queueSelect(ticketCategories, [{ id: CATEGORY_ID, partnerId: PARTNER_ID, responseSlaMinutes: null, resolutionSlaMinutes: null }]);
+    dbState.updateReturningQueue.push([{ categoryId: CATEGORY_ID, priority: 'urgent', fieldProvenance: { priority: 'ai_agent' } }]);
 
-    await applyAiFieldUpdates(TICKET_ID, ORG_ID, { priority: { value: 'high', expectedCurrent: 'high' } }, RUN_ID);
+    const result = await applyAiFieldUpdates(
+      TICKET_ID,
+      ORG_ID,
+      {
+        // categoryId is a no-op confirmation; priority is a real change.
+        categoryId: { value: CATEGORY_ID, expectedCurrent: CATEGORY_ID },
+        priority: { value: 'urgent', expectedCurrent: 'normal' },
+      },
+      RUN_ID,
+    );
 
-    const setArg = setMock.mock.calls[0]![0] as Record<string, unknown>;
-    expect(setArg.categoryId).toBeUndefined();
-    expect(sqlOf(setArg.fieldProvenance).sql).not.toContain('categoryId');
+    // Both arms are concatenated into ONE fragment, so their `$n` placeholders
+    // are numbered across the whole statement — the case most likely to expose
+    // a param-index or arm-ordering mistake, and the reason each arm is
+    // resolved back to its bound value rather than matched as a bare string.
+    const provenance = (setMock.mock.calls[0]![0] as Record<string, unknown>).fieldProvenance;
+
+    const category = provenanceArm(provenance, 'categoryId');
+    expect(boundValue(category.arm, category.params, /"category_id" is not distinct from \$(\d+)/i)).toBe(CATEGORY_ID);
+    expect(boundValue(category.arm, category.params, /"category_id" is distinct from \$(\d+)/i)).toBe(CATEGORY_ID);
+
+    const priority = provenanceArm(provenance, 'priority');
+    expect(boundValue(priority.arm, priority.params, NOT_DISTINCT)).toBe('normal');
+    expect(boundValue(priority.arm, priority.params, DISTINCT)).toBe('urgent');
+
+    expect(result).toEqual({ categoryId: { applied: true }, priority: { applied: true } });
+  });
+
+  /**
+   * Two claims in one, because they are easy to conflate: the outcome is
+   * derived from the RETURNING row, so `applied: true` means "the field holds
+   * the proposed value" and never "this call wrote it" (that half holds with
+   * or without the fix) — while the predicate that would stamp the field is
+   * unsatisfiable twice over (that half is #4466 and fails on revert). This is
+   * the shape a future reader is most likely to misread as "the AI took the
+   * field", so both halves are pinned together.
+   */
+  it('reports applied:true — never a human_set skip — when a user-stamped field already holds the proposed value', async () => {
+    queueSelect(tickets, [{ id: TICKET_ID, orgId: ORG_ID, partnerId: PARTNER_ID }]);
+    dbState.updateReturningQueue.push([{ categoryId: null, priority: 'high', fieldProvenance: { priority: 'user' } }]);
+
+    const result = await applyAiFieldUpdates(
+      TICKET_ID,
+      ORG_ID,
+      { priority: { value: 'high', expectedCurrent: 'high' } },
+      RUN_ID,
+    );
+
+    expect(result.priority).toEqual({ applied: true });
+    // ...and `applied: true` here is emphatically NOT the AI taking the field:
+    // the predicate that gates the stamp fails twice over — the human guard
+    // AND the same-value guard — so Postgres cannot reach it.
+    const { arm, params } = provenanceArm((setMock.mock.calls[0]![0] as Record<string, unknown>).fieldProvenance, 'priority');
+    expect(arm.toLowerCase()).toContain("<> 'user'");
+    expect(boundValue(arm, params, NOT_DISTINCT)).toBe('high');
+    expect(boundValue(arm, params, DISTINCT)).toBe('high');
   });
 });
 

--- a/apps/api/src/services/ticketService.ts
+++ b/apps/api/src/services/ticketService.ts
@@ -1579,13 +1579,27 @@ export type AiFieldUpdateOutcome =
  * — CAS-guarded so an autonomous write can never clobber a field a human has
  * since touched, or one that changed concurrently since the caller last
  * observed it. One UPDATE, per-field `CASE WHEN <value unchanged since
- * expectedCurrent> AND <no human stamp on this field> THEN <new value> ELSE
- * <current value> END` — the CAS predicate is evaluated by Postgres against
+ * expectedCurrent> AND <no human stamp on this field> AND <new value actually
+ * differs> THEN <new value> ELSE <current value> END` — the CAS predicate is
+ * evaluated by Postgres against
  * the row under the UPDATE's own row lock, so this is atomic without a
  * separate `SELECT ... FOR UPDATE`. `field_provenance` is stamped to
  * 'ai_agent' with the SAME predicate, so a skipped field's provenance is left
  * exactly as it was (see `updateTicketFields`'s "AI writes never overwrite a
  * 'user' stamp" contract this implements).
+ *
+ * The predicate also requires the write to be a REAL change
+ * (`<column> IS DISTINCT FROM <new value>`, #4466). The CAS half only proves
+ * the field has not MOVED since the caller observed it, so without this an AI
+ * that merely re-asserts the value already on the ticket satisfied the
+ * predicate and stamped 'ai_agent' anyway — silently taking ownership of a
+ * value a human had set through a path that left no provenance entry (an
+ * absent stamp COALESCEs to '' and sails past the `<> 'user'` guard). The
+ * guard sits in the shared predicate rather than only on the provenance arm so
+ * the stamp and the field write can never drift apart; on the value arm it is
+ * a no-op by construction, since writing a column the value it already holds
+ * changes nothing. This mirrors the human path, where `updateTicketFields`
+ * likewise stamps only the fields its own diff found changed.
  *
  * `categoryId`'s value is validated against `ticket_categories` for the
  * ticket's PARTNER before the UPDATE runs — a cross-partner categoryId must
@@ -1619,11 +1633,15 @@ export async function applyAiFieldUpdates(
     await assertCategoryInPartner(updates.categoryId.value, await resolveTicketPartnerId(ticket));
   }
 
+  // Three conjuncts, and all three are load-bearing: the CAS half (the value
+  // has not moved since the caller observed it), the human-stamp guard, and
+  // the real-change guard (#4466 — an AI re-asserting the value already on
+  // the ticket must not take ownership of it; see the doc block above).
   const categoryCond = updates.categoryId
-    ? sql`(${tickets.categoryId} IS NOT DISTINCT FROM ${updates.categoryId.expectedCurrent} AND COALESCE(${tickets.fieldProvenance}->>'categoryId', '') <> 'user')`
+    ? sql`(${tickets.categoryId} IS NOT DISTINCT FROM ${updates.categoryId.expectedCurrent} AND COALESCE(${tickets.fieldProvenance}->>'categoryId', '') <> 'user' AND ${tickets.categoryId} IS DISTINCT FROM ${updates.categoryId.value}::uuid)`
     : null;
   const priorityCond = updates.priority
-    ? sql`(${tickets.priority} IS NOT DISTINCT FROM ${updates.priority.expectedCurrent} AND COALESCE(${tickets.fieldProvenance}->>'priority', '') <> 'user')`
+    ? sql`(${tickets.priority} IS NOT DISTINCT FROM ${updates.priority.expectedCurrent} AND COALESCE(${tickets.fieldProvenance}->>'priority', '') <> 'user' AND ${tickets.priority} IS DISTINCT FROM ${updates.priority.value}::ticket_priority)`
     : null;
 
   const setClause: Record<string, unknown> = { updatedAt: new Date() };

--- a/apps/api/src/services/ticketService.ts
+++ b/apps/api/src/services/ticketService.ts
@@ -1581,9 +1581,8 @@ export type AiFieldUpdateOutcome =
  * observed it. One UPDATE, per-field `CASE WHEN <value unchanged since
  * expectedCurrent> AND <no human stamp on this field> AND <new value actually
  * differs> THEN <new value> ELSE <current value> END` — the CAS predicate is
- * evaluated by Postgres against
- * the row under the UPDATE's own row lock, so this is atomic without a
- * separate `SELECT ... FOR UPDATE`. `field_provenance` is stamped to
+ * evaluated by Postgres against the row under the UPDATE's own row lock, so
+ * this is atomic without a separate `SELECT ... FOR UPDATE`. `field_provenance` is stamped to
  * 'ai_agent' with the SAME predicate, so a skipped field's provenance is left
  * exactly as it was (see `updateTicketFields`'s "AI writes never overwrite a
  * 'user' stamp" contract this implements).
@@ -1600,6 +1599,14 @@ export type AiFieldUpdateOutcome =
  * a no-op by construction, since writing a column the value it already holds
  * changes nothing. This mirrors the human path, where `updateTicketFields`
  * likewise stamps only the fields its own diff found changed.
+ *
+ * Read `applied: true` as "the field HOLDS the proposed value now", NOT as
+ * "this call wrote it" — the outcome is derived from the RETURNING row, which
+ * cannot distinguish a write from a field that already agreed. So a same-value
+ * confirmation reports `applied: true` having written and stamped nothing, and
+ * so does one against a field already stamped 'user' that happens to hold the
+ * proposed value. Anything asking "did the AI take ownership of this field?"
+ * must read `field_provenance`, never this flag.
  *
  * `categoryId`'s value is validated against `ticket_categories` for the
  * ticket's PARTNER before the UPDATE runs — a cross-partner categoryId must


### PR DESCRIPTION
Closes #4466

## The bug

`applyAiFieldUpdates` (`apps/api/src/services/ticketService.ts`) guards every autonomous ticket-field write with a CAS predicate:

```sql
<column> IS NOT DISTINCT FROM <expectedCurrent>
  AND COALESCE(field_provenance->><field>, '') <> 'user'
```

That predicate proves the field has not **moved** since the caller observed it. It never asks whether the AI is actually **changing** anything — and the stamp to `'ai_agent'` rides the very same predicate. So an AI that merely re-asserts the value already on the ticket satisfied it and took ownership of the field with no edit behind it.

It bites hardest on exactly the fields that most need protecting: one a human set through a path that left no provenance entry. An absent stamp `COALESCE`s to `''`, sails past the `<> 'user'` guard, and the human's value becomes AI-owned — weakening the "human-set fields are never overwritten" guarantee the provenance map exists to provide.

**This is reachable in the real triage pipeline, not just via the tool API.** `filterEligibleFields` (`aiAgents/ticketTriageFindings.ts`) screens proposals on provenance and the confidence floor only — it never compares against the ticket's current value. A confirming proposal therefore mints a `fields` intent and releases straight into the CAS.

## The fix

One more conjunct: `<column> IS DISTINCT FROM <new value>`.

It goes in the **shared** predicate that drives both the field write and the provenance stamp, not just on the stamp — so the two can never drift apart under a later edit. On the value arm it is a no-op by construction: writing a column the value it already holds changes nothing. When value and `expectedCurrent` coincide the predicate becomes `x IS NOT DISTINCT FROM 'high' AND x IS DISTINCT FROM 'high'` — unsatisfiable, so Postgres cannot reach the stamp at all.

This also aligns the AI path with the human one: `updateTicketFields` already stamps only the fields its own diff found changed.

**CAS semantics and the `'user'` guard are untouched**, and so is outcome classification — a confirmation still reports `applied: true` (the field *is* in the desired state), never a spurious `concurrent_change` skip.

## Verification

Red first, both ways.

- **Unit** — `apps/api/src/services/ticketService.aiExecutors.test.ts`, 4 new cases on **compiled SQL** (`PgDialect().sqlToQuery`), matching the suite's existing convention: a mock that echoes `.set()` back cannot tell a real predicate from a missing one. The same-value case resolves both `$n` placeholders and asserts they bind the same value — that *is* the unsatisfiability proof. The changed-value case pins the distinctness check to the **proposed** value, not the observed one; comparing against `expectedCurrent` would just restate the tautology the CAS half already covers and would block nothing.
- **Integration (live Postgres)** — `aiAgentTicketTriage.integration.test.ts`, driving the full `persistTicketTriage → intents → releaseApprovedIntent` pipeline against a ticket already at the proposed priority. **Reverting only the source change turns it red** with `field_provenance` at `{ priority: 'ai_agent' }`; with the fix it stays `{}`.

| Check | Result |
|---|---|
| `vitest run` × 5 affected unit files | 291 passed |
| `vitest run --config vitest.integration.config.ts aiAgentTicketTriage` | 8 passed |
| `tsc --noEmit` (apps/api) | exit 0 |
| `eslint` (3 touched files) | clean |

No migration, no schema change, no tenancy surface touched.

## Noted, deliberately out of scope

`updatedAt` is still bumped unconditionally, so a fully no-op AI confirmation makes the ticket look freshly touched in any list sorted by it — the same root cause, but changing it alters behaviour for the existing `human_set` skip path too and affects ticket ordering. That is a separate behavioural call, not a silent rider on a provenance fix. Happy to take it in a follow-up if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBxF7C8E5GxFnNcGf6kBVP
