### PR TITLE
fix(api/auth): change-password and account-deletion 400 a rejected password, not 401 (#4660)

### DIFF
--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -1257,6 +1257,10 @@ API requests are rate-limited to ensure fair usage. Rate limit headers are inclu
               }
             }
           },
+          // #4660 (extends #4470): a rejected `currentPassword` is 400 with a
+          // stable `code` (`invalid_credentials`), alongside the pre-existing
+          // 400s for a passwordless account and a too-weak new password. 401
+          // is reserved for a dead bearer.
           '400': { $ref: '#/components/responses/BadRequest' },
           '401': { $ref: '#/components/responses/Unauthorized' }
         }

--- a/apps/api/src/routes/auth/accountDeletion.test.ts
+++ b/apps/api/src/routes/auth/accountDeletion.test.ts
@@ -205,16 +205,58 @@ describe('POST /account-deletion-request', () => {
     );
   });
 
-  it('returns 401 when the password does not match', async () => {
+  // #4660 (follows #4470/#4651): the password is body data, not the credential
+  // that authenticates this request, so rejecting it is a 400 with a stable
+  // `code`. A 401 here was handed to `fetchWithAuth`'s refresh-and-replay path
+  // (apps/web/src/stores/auth.ts) and then `handleSessionExpired` — a typo on
+  // the delete-account form signed the user out instead of telling them the
+  // password was wrong. 401 stays reserved for a dead bearer.
+  it('returns 400 + code invalid_credentials when the password does not match (#4660)', async () => {
     verifyPasswordMock.mockResolvedValueOnce(false);
     const res = await postRequest({ password: 'wrong' });
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body).toEqual({ error: 'Invalid password' });
+    expect(body).toEqual({
+      error: 'Invalid password',
+      message: 'Invalid password',
+      code: 'invalid_credentials',
+    });
     expect(insertReturningMock).not.toHaveBeenCalled();
     expect(writeAuthAudit).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ action: 'user.account_deletion.requested', result: 'failure', reason: 'invalid_password' })
+    );
+  });
+
+  // Opacity control for the pair. This endpoint deliberately answers the
+  // "account has no password at all" branch with the SAME body as "wrong
+  // password", so a caller cannot use it to probe whether an account is
+  // SSO-only. Both branches must move to 400 together — a status that differed
+  // between them would reopen that oracle, which is exactly the failure mode
+  // #4018 closed elsewhere. This test fails if only one branch is migrated.
+  it('answers a passwordless account identically to a wrong password — no oracle (#4660)', async () => {
+    dbState.userRow = {
+      id: 'u-1',
+      email: 'user@example.test',
+      name: 'Sample User',
+      passwordHash: null,
+      partnerId: 'p-1',
+      orgId: 'o-1',
+    };
+    buildSelectChain();
+
+    const res = await postRequest({ password: 'anything' });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: 'Invalid password',
+      message: 'Invalid password',
+      code: 'invalid_credentials',
+    });
+    expect(verifyPasswordMock).not.toHaveBeenCalled();
+    expect(insertReturningMock).not.toHaveBeenCalled();
+    expect(writeAuthAudit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'user.account_deletion.requested', result: 'denied', reason: 'no_password' })
     );
   });
 

--- a/apps/api/src/routes/auth/accountDeletion.test.ts
+++ b/apps/api/src/routes/auth/accountDeletion.test.ts
@@ -260,6 +260,18 @@ describe('POST /account-deletion-request', () => {
     );
   });
 
+  // Redis backs the attempt limiter, so losing it must fail CLOSED (503) —
+  // never fall through to the password check unthrottled. Untested before
+  // #4660; added here because this PR reworks the rejection statuses on the
+  // very next lines and a silent 503->200 regression would be invisible.
+  it('fails closed with 503 when Redis is unavailable', async () => {
+    vi.mocked(getRedis).mockReturnValueOnce(null as never);
+    const res = await postRequest({ password: 'correct-horse' });
+    expect(res.status).toBe(503);
+    expect(verifyPasswordMock).not.toHaveBeenCalled();
+    expect(insertReturningMock).not.toHaveBeenCalled();
+  });
+
   it('returns 429 when rate-limited', async () => {
     vi.mocked(rateLimiter).mockResolvedValueOnce({
       allowed: false,

--- a/apps/api/src/routes/auth/accountDeletion.ts
+++ b/apps/api/src/routes/auth/accountDeletion.ts
@@ -23,6 +23,8 @@ import {
   getClientRateLimitKey,
   resolveUserAuditOrgId,
   writeAuthAudit,
+  rejectProof,
+  INVALID_CREDENTIALS_CODE,
 } from './helpers';
 
 const { db } = dbModule;
@@ -262,7 +264,12 @@ accountDeletionRoutes.post(
         userId: auth.user.id,
         email: auth.user.email,
       });
-      return c.json({ error: 'Invalid password' }, 401);
+      // #4660: 400, not 401 — see the wrong-password branch below. This
+      // "account has no password at all" case deliberately answers with the
+      // IDENTICAL body, so the endpoint cannot be used to probe whether an
+      // account is SSO-only; both branches must therefore always carry the
+      // same status too. Migrating only one would reopen that oracle.
+      return rejectProof(c, 'Invalid password', INVALID_CREDENTIALS_CODE, 400);
     }
 
     const passwordOk = await verifyPassword(userRow.passwordHash, password);
@@ -274,7 +281,14 @@ accountDeletionRoutes.post(
         userId: auth.user.id,
         email: auth.user.email,
       });
-      return c.json({ error: 'Invalid password' }, 401);
+      // #4660 (extends the #4470 contract): the password arrived in the
+      // request BODY and is data this handler validates — the credential that
+      // authenticates the request is the bearer, already checked by
+      // `authMiddleware`. A 401 here was handed to `fetchWithAuth`'s
+      // refresh-and-replay path (apps/web/src/stores/auth.ts) and on to
+      // `handleSessionExpired`, so a mistyped password on the delete-account
+      // form signed the user out instead of showing the error.
+      return rejectProof(c, 'Invalid password', INVALID_CREDENTIALS_CODE, 400);
     }
 
     // Idempotency: return the existing pending request if one exists.

--- a/apps/api/src/routes/auth/password.test.ts
+++ b/apps/api/src/routes/auth/password.test.ts
@@ -135,7 +135,7 @@ vi.mock('./ssoPolicy', () => ({
 
 import { passwordRoutes } from './password';
 import { db, withSystemDbAccessContext } from '../../db';
-import { invalidateAllUserSessions } from '../../services';
+import { invalidateAllUserSessions, verifyPassword } from '../../services';
 import { writeAuthAudit } from './helpers';
 import { getPasswordResetEligibility } from '../../services/passwordResetEligibility';
 import { enqueuePasswordResetRequest } from '../../services/authEmailQueue';
@@ -687,6 +687,51 @@ describe('password reset eligibility (#719)', () => {
       const body = await res.json() as { success: boolean };
       expect(body.success).toBe(true);
       expect(runPostCommitCleanupMock).toHaveBeenCalledWith('u-1');
+    });
+
+    // #4660 (follows #4470/#4651): the `currentPassword` the user typed into
+    // the request BODY is request data, not the credential that authenticates
+    // this request. Rejecting it must therefore never be a 401 — the web
+    // client's `fetchWithAuth` (apps/web/src/stores/auth.ts) hands any 401 to
+    // refresh-and-replay and then `handleSessionExpired`, so a single typo on
+    // the profile page signed the user out mid-flow. 401 stays reserved for a
+    // dead bearer. Clients branch on `code`, never on the message text.
+    it('answers a wrong current password with 400 + code invalid_credentials, not 401 (#4660)', async () => {
+      vi.mocked(verifyPassword).mockResolvedValueOnce(false);
+
+      const res = await postJson('/change-password', {
+        currentPassword: 'wrong-old-pw-1234',
+        newPassword: 'new-strong-pw-1234',
+      });
+
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({
+        error: 'Current password is incorrect',
+        message: 'Current password is incorrect',
+        code: 'invalid_credentials',
+      });
+      // The rejection is terminal: nothing was rotated or revoked.
+      expect(db.transaction).not.toHaveBeenCalled();
+      expect(invalidateAllUserSessions).not.toHaveBeenCalled();
+      expect(runPostCommitCleanupMock).not.toHaveBeenCalled();
+    });
+
+    // The other half of the #4660 contract: the SSO-only (no password hash)
+    // branch was ALREADY 400 and keeps its own distinct message, so moving the
+    // wrong-password branch to 400 does not create a new oracle here —
+    // `GET /auth/me` already publishes `hasPassword` (#4018).
+    it('still answers a passwordless account with its own 400 body (#4660)', async () => {
+      vi.mocked(db.select).mockReturnValue(selectChain([{ passwordHash: null }]) as any);
+
+      const res = await postJson('/change-password', {
+        currentPassword: 'anything-1234',
+        newPassword: 'new-strong-pw-1234',
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json() as { error: string };
+      expect(body.error).toBe('Password authentication is not available for this account');
+      expect(db.transaction).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/routes/auth/password.ts
+++ b/apps/api/src/routes/auth/password.ts
@@ -26,7 +26,9 @@ import {
   revokeCurrentRefreshTokenJti,
   resolveUserAuditOrgId,
   writeAuthAudit,
-  authResponseFloorPromise
+  authResponseFloorPromise,
+  rejectProof,
+  INVALID_CREDENTIALS_CODE
 } from './helpers';
 import { assertPasswordAuthAllowedBySso, SsoPasswordAuthRequiredError } from './ssoPolicy';
 import { advanceUserEpochs, revokeAllRefreshFamilies, runPostCommitCleanup } from '../../services/authLifecycle';
@@ -306,8 +308,16 @@ passwordRoutes.post('/change-password', authMiddleware, zValidator('json', chang
 
   const validCurrentPassword = await verifyPassword(user.passwordHash, currentPassword);
   if (!validCurrentPassword) {
-    const message = 'Current password is incorrect';
-    return c.json({ error: message, message }, 401);
+    // #4660 (extends the #4470 contract): 400, not 401. `currentPassword`
+    // arrived in the request BODY — it is data this handler validates, not the
+    // credential that authenticates the request (that is the bearer, already
+    // checked by `authMiddleware` above). The web client's `fetchWithAuth`
+    // (apps/web/src/stores/auth.ts) funnels every 401 into refresh-and-replay
+    // and then `handleSessionExpired`, so answering 401 here signed the user
+    // out mid-flow for a single typo. The two neighbouring rejections — no
+    // password hash above, weak new password below — are already 400, so this
+    // also makes the endpoint's own statuses consistent.
+    return rejectProof(c, 'Current password is incorrect', INVALID_CREDENTIALS_CODE, 400);
   }
 
   const passwordCheck = isPasswordStrong(newPassword);

--- a/apps/docs/src/content/docs/reference/users-and-roles.mdx
+++ b/apps/docs/src/content/docs/reference/users-and-roles.mdx
@@ -229,7 +229,7 @@ MFA verification is rate-limited separately from login.
 
   Branch on the status code, and on `code` when you need the specific reason. `401` from these endpoints means "re-authenticate"; it never means "you mistyped a digit". The codes in use are `mfa_code_invalid` (wrong TOTP/SMS/recovery code), `mfa_proof_invalid` (a rejected `POST /auth/mfa/step-up` factor proof), and `invalid_credentials` (a rejected step-up password or enrollment grant). Never branch on the human-readable `error`/`message` text — it is not part of the contract.
 
-  This applies to `/auth/mfa/*` and `/auth/phone/*`. Earlier releases answered `401` for both cases, which is why a client that auto-refreshes on `401` could sign the user out mid-enrollment for a mistyped digit.
+  This applies to `/auth/mfa/*` and `/auth/phone/*`, and — since the release noted below — to the two other endpoints that verify a password supplied in the request body: `POST /auth/change-password` and `POST /auth/account-deletion-request`. Both answer a rejected password with `400` and `code: "invalid_credentials"`. Earlier releases answered `401` for both cases, which is why a client that auto-refreshes on `401` could sign the user out mid-enrollment for a mistyped digit — or, on those two endpoints, mid-flow for a mistyped password.
 </Aside>
 
 ### Disabling MFA
@@ -278,6 +278,8 @@ Authenticated users can change their password via `POST /auth/change-password` b
 <Aside type="tip">
   SSO-provisioned users do not have a password. The change password endpoint returns `400` for these accounts.
 </Aside>
+
+A **wrong `currentPassword`** also returns `400`, with the stable body `{ "error": "Current password is incorrect", "message": "Current password is incorrect", "code": "invalid_credentials" }`. It previously returned `401`; branch on the status and on `code`, never on the message text. `401` from this endpoint now means only that the bearer token is dead.
 
 ---
 

--- a/apps/docs/src/content/docs/reference/users-and-roles.mdx
+++ b/apps/docs/src/content/docs/reference/users-and-roles.mdx
@@ -229,7 +229,7 @@ MFA verification is rate-limited separately from login.
 
   Branch on the status code, and on `code` when you need the specific reason. `401` from these endpoints means "re-authenticate"; it never means "you mistyped a digit". The codes in use are `mfa_code_invalid` (wrong TOTP/SMS/recovery code), `mfa_proof_invalid` (a rejected `POST /auth/mfa/step-up` factor proof), and `invalid_credentials` (a rejected step-up password or enrollment grant). Never branch on the human-readable `error`/`message` text — it is not part of the contract.
 
-  This applies to `/auth/mfa/*` and `/auth/phone/*`, and — since the release noted below — to the two other endpoints that verify a password supplied in the request body: `POST /auth/change-password` and `POST /auth/account-deletion-request`. Both answer a rejected password with `400` and `code: "invalid_credentials"`. Earlier releases answered `401` for both cases, which is why a client that auto-refreshes on `401` could sign the user out mid-enrollment for a mistyped digit — or, on those two endpoints, mid-flow for a mistyped password.
+  This applies to `/auth/mfa/*` and `/auth/phone/*`, and to the two other endpoints that verify a password supplied in the request body: `POST /auth/change-password` and `POST /auth/account-deletion-request`. Both answer a rejected password with `400` and `code: "invalid_credentials"`. Earlier releases answered `401` for both cases, which is why a client that auto-refreshes on `401` could sign the user out mid-enrollment for a mistyped digit — or, on those two endpoints, mid-flow for a mistyped password.
 </Aside>
 
 ### Disabling MFA

--- a/apps/web/src/components/settings/ProfilePage.test.tsx
+++ b/apps/web/src/components/settings/ProfilePage.test.tsx
@@ -458,6 +458,66 @@ describe('ProfilePage MFA setup', () => {
   });
 });
 
+describe('ProfilePage — change password (#4660)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // #4660: POST /auth/change-password used to reject a wrong currentPassword
+  // with a bare 401; it now answers 400 with a body carrying `message:
+  // 'Current password is incorrect'`, which handlePasswordChange reads via
+  // `errorData.message` (not `errorData.error`). This pins that the server's
+  // actual reason reaches the user inline instead of silently falling back
+  // to the generic "failed to change password" copy.
+  it('shows the server-provided message when currentPassword is rejected with 400', async () => {
+    fetchWithAuthMock.mockImplementation(async (url) => {
+      if (String(url) === '/auth/passkeys') {
+        return makeJsonResponse({ passkeys: [] });
+      }
+      if (String(url) === '/auth/change-password') {
+        return makeJsonResponse(
+          {
+            error: 'Current password is incorrect',
+            message: 'Current password is incorrect',
+            code: 'invalid_credentials'
+          },
+          false,
+          400
+        );
+      }
+      return undefined as unknown as Response;
+    });
+
+    render(
+      <ProfilePage
+        initialUser={{
+          id: 'user-1',
+          name: 'Casey Admin',
+          email: 'casey@example.com',
+          mfaEnabled: false,
+          hasPassword: true
+        }}
+      />
+    );
+
+    // The page has two "Current password" inputs (the MFA confirm-password
+    // prompt and this Change Password form); query the change-password
+    // form's fields by their unambiguous ids rather than by label text.
+    const currentPasswordInput = document.getElementById('currentPassword') as HTMLInputElement;
+    const newPasswordInput = document.getElementById('newPassword') as HTMLInputElement;
+    const confirmPasswordInput = document.getElementById('confirmPassword') as HTMLInputElement;
+    expect(currentPasswordInput).not.toBeNull();
+
+    fireEvent.change(currentPasswordInput, { target: { value: 'wrong-current-pw' } });
+    fireEvent.change(newPasswordInput, { target: { value: 'brand-new-pw-1' } });
+    fireEvent.change(confirmPasswordInput, { target: { value: 'brand-new-pw-1' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Change password' }));
+
+    expect(await screen.findByText('Current password is incorrect')).toBeTruthy();
+  });
+});
+
 // ── #4018: MFA enrollment for a PASSWORDLESS, SSO-provisioned account ────────
 // Such an account cannot satisfy the password step-up the enrollment endpoints
 // normally demand, so it proves identity with a fresh, forced IdP round-trip

--- a/apps/web/src/stores/auth.test.ts
+++ b/apps/web/src/stores/auth.test.ts
@@ -2482,3 +2482,120 @@ describe('replacement-session adoption (#4480)', () => {
     expect(useAuthStore.getState().tokens).toEqual(newerTokens);
   });
 });
+
+// #4660: `POST /auth/change-password` and `POST /auth/account-deletion-request`
+// verify a password the user typed into the request BODY. Until this fix both
+// answered a rejection with 401 — the same status the bearer guard uses — and
+// neither caller passes `skipUnauthorizedRetry`, so `fetchWithAuth` handed the
+// rejection to refresh-and-replay and then `handleSessionExpired`: a single
+// typo signed the user out mid-flow instead of showing "that password is
+// wrong". The server now answers 400 + `code: 'invalid_credentials'`.
+//
+// These tests pin the mechanism at the transport layer, where the bug actually
+// lived, rather than at the component's copy. The 401 halves are the negative
+// controls: they prove the tests would still catch a regression that moved the
+// status back, and that a genuinely dead bearer on these paths must STILL
+// refresh (both pages load with an empty in-memory access token after a
+// reload, so removing that would break them a different way).
+describe('fetchWithAuth — a rejected body password never looks like session death (#4660)', () => {
+  const REJECTED = {
+    error: 'Current password is incorrect',
+    message: 'Current password is incorrect',
+    code: 'invalid_credentials',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.removeItem('breeze-auth');
+    document.cookie = 'breeze_csrf_token=csrf-test-token; path=/';
+    useAuthStore.getState().login(baseUser, baseTokens);
+  });
+
+  it.each([
+    ['/auth/change-password', REJECTED],
+    ['/auth/account-deletion-request', {
+      error: 'Invalid password',
+      message: 'Invalid password',
+      code: 'invalid_credentials',
+    }],
+  ] as const)('a 400 from %s is returned to the caller: no refresh, no logout', async (path, body) => {
+    const fetchMock = vi.fn().mockResolvedValue(makeResponse(body, false, 400));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await fetchWithAuth(path, {
+      method: 'POST',
+      body: JSON.stringify({ currentPassword: 'wrong', newPassword: 'new-strong-pw-1234' }),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual(body);
+    // The single most important assertion: one call out, no refresh attempt.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(refreshCallsOf(fetchMock)).toHaveLength(0);
+    expect(useAuthStore.getState().isAuthenticated).toBe(true);
+    expect(useAuthStore.getState().sessionExpiredReason).toBeNull();
+  });
+
+  it.each([
+    '/auth/change-password',
+    '/auth/account-deletion-request',
+  ])('a genuine bearer 401 from %s still refreshes and replays', async (path) => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(makeResponse({ error: 'Unauthorized' }, false, 401))
+      .mockResolvedValueOnce(makeResponse({ tokens: { accessToken: 'fresh', expiresInSeconds: 900 } }, true, 200))
+      .mockResolvedValueOnce(makeResponse({ success: true }, true, 200));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await fetchWithAuth(path, { method: 'POST', body: JSON.stringify({}) });
+
+    expect(response.status).toBe(200);
+    expect(refreshCallsOf(fetchMock)).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(useAuthStore.getState().isAuthenticated).toBe(true);
+  });
+
+  // The fix is the STATUS, not a client-side opt-out. #4470 showed that
+  // `skipUnauthorizedRetry` is a trap — any new caller that forgets it
+  // re-inherits the logout — so neither of these call sites should acquire it.
+  it('neither call site opts out of the 401 retry path', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeResponse(REJECTED, false, 400));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchWithAuth('/auth/change-password', { method: 'POST', body: '{}' });
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit & { skipUnauthorizedRetry?: boolean }];
+    expect(init.skipUnauthorizedRetry).toBeUndefined();
+  });
+
+  // The harm, demonstrated rather than asserted. This is the shape #4660
+  // describes: with the OLD 401 the rejection entered the refresh path, and
+  // whenever that refresh could not restore the session — a refresh cookie
+  // that has aged out on a long-open profile page is the common case — the
+  // user was logged out and bounced to /login. They mistyped a password; they
+  // got signed out. Nothing about the wrong password made the session dead.
+  //
+  // Kept as a live test (not a comment) because it is the reason the server
+  // change is worth a wire-contract break: if a future change routes 400s
+  // through the refresh path too, the first test above goes red and this one
+  // explains why that matters.
+  it('demonstrates the pre-fix harm: a 401 rejection whose refresh fails evicts the session', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(makeResponse({ error: 'Current password is incorrect' }, false, 401))
+      .mockResolvedValueOnce(makeResponse({ error: 'refresh denied' }, false, 401));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { replace, restore } = mockLocation('/settings/profile');
+    try {
+      await fetchWithAuth('/auth/change-password', { method: 'POST', body: '{}' });
+    } finally {
+      restore();
+    }
+
+    expect(useAuthStore.getState().isAuthenticated).toBe(false);
+    expect(useAuthStore.getState().sessionExpiredReason).toBe('session-expired');
+    expect(replace).toHaveBeenCalledWith(
+      `/login?next=${encodeURIComponent('/settings/profile')}&reason=session-expired`,
+    );
+  });
+});


### PR DESCRIPTION
Closes #4660

## The bug

`POST /auth/change-password` and `POST /auth/account-deletion-request` both answered a **rejected body-supplied password** with **401** — the same status the bearer guard uses. `fetchWithAuth` (`apps/web/src/stores/auth.ts:1313`) hands any 401 to refresh-and-replay and then `handleSessionExpired` → logout + redirect, and **neither caller passes `skipUnauthorizedRetry`**. So a user who mistyped their current password on the profile page, or their password on the delete-account form, could be **signed out mid-flow** instead of being told the password was wrong.

Same bug class as #4470, different endpoints. It was deliberately left out of #4651 because these are not MFA proof endpoints and changing password-change / account-deletion semantics deserved its own review.

## The contract (unchanged from #4470 — this extends its reach)

**401 means "the credential that authenticates THIS request is dead"** — the bearer, or the login challenge's `tempToken`. A proof the user typed into the request **body** is request data, and rejecting it is a **400** with a stable machine-readable `code`.

| Endpoint | Was | Now |
|---|---|---|
| `POST /auth/change-password` — wrong `currentPassword` | `401 {error, message}` | `400 {error, message, code: 'invalid_credentials'}` |
| `POST /auth/account-deletion-request` — wrong password | `401 {error: 'Invalid password'}` | `400 {error, message, code: 'invalid_credentials'}` |
| `POST /auth/account-deletion-request` — account has no password hash | `401 {error: 'Invalid password'}` | `400 {error, message, code: 'invalid_credentials'}` |

Both use `rejectProof(...)` from `apps/api/src/routes/auth/helpers.ts`, so the body shape is identical to the one #4651 landed. Clients branch on `code`, never on the human `error`/`message` text.

### Why 400 is the *consistent* status here, not just the safe one

Each endpoint already answered its **other** input problems with 400, so the old 401 was the outlier:

- `password.ts` — the passwordless-account rejection (`:302`) and the weak-new-password rejection (`:317`) were both already 400. The endpoint is now self-consistent.
- Both are behind `authMiddleware`, which has *already* validated the bearer by the time these lines run. A 401 emitted after that guard passed is, by construction, never about the request's own credential.

### The opacity pair on account-deletion (why both branches moved together)

`accountDeletion.ts` answers "this account has no password hash at all" and "the password is wrong" with the **identical** body, deliberately — otherwise the endpoint becomes an oracle for whether an account is SSO-only. Uniformity is what closes that oracle, so **both branches had to move together**; a status that differed between them would have reopened it. There is now a test that fails if only one is migrated.

Note this reasoning does **not** apply to `change-password`, where the passwordless branch keeps its own distinct 400 message — that account state is already public on `GET /auth/me` as `hasPassword` (#4018), so there is nothing to conceal.

## Client changes: none needed, and that is the point

All three web callers already branch on `res.ok` and read `error` / `message`, and **none of them carried the `skipUnauthorizedRetry` stopgap** — so unlike #4651 there is no client flag to drop:

- `apps/web/src/components/settings/ProfilePage.tsx:434` — reads `errorData.message`.
- `apps/web/src/components/setup/AccountSetupStep.tsx:108` — `extractApiError(data, fallback)`, which returns `body.error` verbatim and ignores the added `code`.
- `apps/web/src/components/account/AccountDeletionPage.tsx:98` — reads `data.error`.

The added `message` / `code` fields are additive; every caller renders the same copy it did before, now without the logout.

**Mobile was never affected.** `apps/mobile/src/services/api.ts` gates its refresh-and-retry on `canRefreshFor()`, which excludes every `/auth/*` path except `/auth/me` **by path rather than by status** — so mobile never had the bug the web client had, and the status change is inert there. (`ChangePasswordSheet.tsx` only reads `err.message`; mobile has no account-deletion caller at all.)

## Scope

Held to the two endpoints the issue names. The issue's "also worth sweeping" section is **deliberately not in this PR** and remains open on #4660:

- `apps/api/src/routes/users.ts:665` (email-change step-up) and `apps/api/src/routes/authenticator.ts:149` (`register-grant`) still take the `rejectionStatus` 401 default. Their clients *do* branch on 401 today, so migrating them needs a paired client change — notably `ApproverDevicesSection`, which keeps a 401 branch specifically for `register-grant`.
- `PasskeyChallengeError` (`apps/api/src/services/passkeys.ts:238-263`) conflates an expired challenge with **Redis being unavailable** and a corrupt record; the latter two should be 503, not a rejected-proof status. Pre-existing and orthogonal.

`/auth/account-deletion-request` has no entry in `openapi.ts` at all (pre-existing gap, unrelated to this change) — not added here rather than documenting a whole new endpoint in a fix PR.

## Verification

Red first: the three migrated assertions were written against the new contract and confirmed failing on `401` before the handlers changed.

- **API** — `src/routes/auth` suite, **654/654** pass (24 files), including:
  - new `POST /change-password` test: wrong current password → 400 + exact `{error, message, code}`, and the rejection is terminal (`db.transaction`, `invalidateAllUserSessions`, `runPostCommitCleanup` all untouched);
  - a control that the passwordless branch keeps its own distinct 400 body;
  - `accountDeletion` wrong-password test migrated 401 → 400 with the full body (the audit-row assertion was kept, not weakened);
  - **new opacity test**: a passwordless account answers *identically* to a wrong password, `verifyPassword` is never called, and the `denied` / `no_password` audit row still fires.
- **Web** — `stores/auth` + `components/{settings,setup,account}` + `lib/apiError`, **1122/1122** pass (93 files).
  - **New `ProfilePage` test** — the one that actually discriminates this diff on the client. It drives the real Change Password form and asserts the server's `message` renders as the inline error, so a 400 whose body shape drifted would surface the generic "failed to change password" fallback and turn this red. Mutation-verified: pointing `handlePasswordChange` at a non-existent field fails it.
  - **New `#4660` block in `stores/auth.test.ts`** — an honest caveat, raised by the test-coverage review and worth stating plainly: these stub `fetch` and set the status themselves, so they **would pass unchanged on `origin/main`**. They document the client half of the contract (a 400 makes exactly one fetch with zero refresh calls and leaves `sessionExpiredReason` null; a genuine bearer 401 still refreshes and replays; neither call site acquires `skipUnauthorizedRetry`) and guard against a future change routing 400s into the refresh path. They are **not** evidence the server fix works — the API tests are. One of them deliberately *demonstrates* the pre-fix harm rather than asserting it: the old 401, when the refresh cannot restore the session, evicts it and redirects to `/login?...&reason=session-expired`.
- `tsc --noEmit` clean in `apps/api` and `apps/web`; `eslint` clean on all changed files.
- Repo-wide sweep for other callers/assertions/docs of these two endpoints (API, web, portal, mobile, e2e, packages, docs): **no other breaks or stale references**.

## Audit-trail note

The global fallback-audit middleware (`apps/api/src/index.ts:801`) classifies 401/403 as `denied` and other 4xx as `failure`, so these three rejections shift `denied` → `failure` on the **fallback** row. Same footnote #4651 carried, and verified inert here: the explicit `writeAuthAudit` rows in `accountDeletion.ts` pass `result` literally and are unaffected, and no consumer distinguishes the two values for these actions — `userRiskScoring.ts:581` buckets `['failure','denied']` together, and the only per-value filter (`routes/devices/events.ts:207`) is scoped to `resourceId = deviceId`, which auth rows never populate.

## Two pre-existing issues found while reviewing (NOT fixed here)

Both are outside the two routes this PR is scoped to, and neither is a regression from it:

- **Mobile discards the server's message entirely.** `ApiError` (`apps/mobile/src/services/api.ts:158`) is a plain `interface` and the throw site (`:532`) throws an object literal, so `err instanceof Error` in `ChangePasswordSheet.tsx:175` is **always false** — mobile shows the generic "Could not change password" for every failure, on any status, before and after this change. Verified by reading all three sites.
- **`/auth/change-password` has no rate limit on current-password guesses.** Unlike its siblings it inlines its own `verifyPassword` rather than using `requireCurrentPasswordStepUp`, which throttles 5 per 5 min. Pre-existing — the old 401 didn't throttle either, it just triggered a refresh that succeeded and replayed — but it means a stolen access token can brute-force the current password unthrottled to take over the account permanently.

## Release note

**Wire-contract change (401 → 400).** `POST /auth/change-password` and `POST /auth/account-deletion-request` now answer a **rejected password** with **`400`** and `code: "invalid_credentials"` instead of `401`. `401` from these endpoints now means only that the bearer token is dead. API clients that treated a 401 from either endpoint as "wrong password" must branch on `400` + `code`; clients that auto-refresh on `401` no longer sign the user out for a typo. First-party web and mobile clients need no change. Documented in `apps/docs/.../reference/users-and-roles.mdx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBxF7C8E5GxFnNcGf6kBVP

