### PR TITLE
fix(api/ai): don't evict an actively-processing Anthropic session; expire the row on both staleness paths (#4514)

### DIFF
--- a/apps/api/src/services/sentry.ts
+++ b/apps/api/src/services/sentry.ts
@@ -105,6 +105,16 @@ const ALLOWED_TAG_NAMES = new Set([
   // cluster groupable and actionable.
   'body_limit_rule',
   'body_limit_max_size',
+  // #4514: the AI session cap alarm fires when EVERY in-memory session is
+  // mid-turn, so LRU can evict nothing and MAX_ACTIVE_SESSIONS is exceeded.
+  // `scrubEvent` deletes `message`, so without this the event says only that it
+  // happened — and a single-request blip is then byte-identical to a manager
+  // wedged at several times its cap, which is exactly the distinction that
+  // decides whether to page. Closed four-value set from
+  // `bucketSessionOvershoot` (services/streamingSessionManager.ts); the raw
+  // count would be unbounded cardinality, and the bucket carries no tenant,
+  // device or session identifier.
+  'ai_session_cap_bucket',
   // BREEZE-18: the required `captureMessage` discriminator. `scrubEvent`
   // deletes `message`, `logentry` and `extra` from every event, so before this
   // existed any captureMessage that happened not to carry one of the tags above

--- a/apps/api/src/services/streamingSessionManager.eviction.test.ts
+++ b/apps/api/src/services/streamingSessionManager.eviction.test.ts
@@ -364,6 +364,31 @@ describe('StreamingSessionManager eviction (#4514)', () => {
       expect(capacityAlarms()).toHaveLength(1);
     });
 
+    it('tags the capacity alarm with a magnitude bucket that actually varies', () => {
+      // `scrubEvent` deletes `message` from every outbound event, so a tag is
+      // the alarm's only surviving channel. Without a varying one, a blip and a
+      // wedged manager are byte-identical in Sentry.
+      const small = new StreamingSessionManager();
+      const huge = new StreamingSessionManager();
+      try {
+        seed(small, 's1', 'org-a', { idleFor: MINUTE, state: 'processing' });
+        for (let i = 0; i < MAX_ACTIVE_SESSIONS * 2 + 1; i++) {
+          seed(huge, `h-${i}`, 'org-a', { idleFor: MINUTE, state: 'processing' });
+        }
+
+        internals(small).evictLeastRecentlyActive();
+        internals(huge).evictLeastRecentlyActive();
+
+        const buckets = capacityAlarms().map(
+          (c) => (c[1] as { tags?: Record<string, string> }).tags?.ai_session_cap_bucket,
+        );
+        expect(buckets).toEqual(['at-cap', 'runaway']);
+      } finally {
+        small.shutdown();
+        huge.shutdown();
+      }
+    });
+
     it('throttles the capacity alarm instead of firing it on every request', () => {
       seed(manager, 's1', 'org-a', { idleFor: 5 * MINUTE, state: 'processing' });
 
@@ -664,7 +689,14 @@ describe('StreamingSessionManager eviction (#4514)', () => {
       await settle();
       await settle();
 
-      expect(captureExceptionMock).toHaveBeenCalled();
+      // `org_id` is allowlisted (sentry.ts ALLOWED_TAG_NAMES) and survives the
+      // scrubber. Without it every org's failure collapses into one
+      // untriageable issue and the on-call cannot tell WHICH tenant is stranded.
+      expect(captureExceptionMock).toHaveBeenCalledWith(
+        expect.any(Error),
+        undefined,
+        { org_id: 'org-a' },
+      );
       // org-b must still be retired — abandoning the loop strands exactly the
       // 'active' rows this helper exists to clean up.
       expect(capturedExpires).toHaveLength(2);

--- a/apps/api/src/services/streamingSessionManager.eviction.test.ts
+++ b/apps/api/src/services/streamingSessionManager.eviction.test.ts
@@ -1,0 +1,737 @@
+/**
+ * Eviction contract for the DEFAULT (Anthropic) session manager — issue #4514,
+ * the deferred twin of #4384/#4406 (llm/openaiSessionManager.eviction.test.ts).
+ *
+ * Two defects are pinned here:
+ *   1. Neither eviction path checked `state === 'processing'`, so under cap
+ *      pressure the least-recently-*created-or-resumed* session could be the one
+ *      currently streaming — `remove()` aborts its controller and closes the SDK
+ *      query and the event bus mid-turn.
+ *   2. Only the 24h-age branch retired the DB row; idle eviction left
+ *      `ai_sessions.status = 'active'` on a session that no longer exists.
+ *
+ * Protection is deliberately NOT `state` alone — see PROCESSING_STALL_TIMEOUT_MS.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { SQL } from 'drizzle-orm';
+
+const {
+  queryMock,
+  dbUpdateMock,
+  capturedExpires,
+  mockState,
+  contextStore,
+  captureExceptionMock,
+  captureMessageMock,
+} = vi.hoisted(() => {
+  const { AsyncLocalStorage } = require('node:async_hooks') as typeof import('node:async_hooks');
+  return {
+    queryMock: vi.fn(),
+    dbUpdateMock: vi.fn(),
+    capturedExpires: [] as {
+      context: unknown;
+      set: Record<string, unknown>;
+      where: SQL;
+    }[],
+    mockState: {
+      /** Context in force at the moment the UPDATE is issued. */
+      effectiveContext: null as unknown,
+      /** Rows the next UPDATE resolves with. Empty = the RLS-denial signature. */
+      nextRows: [{ id: 'row' }] as { id: string }[],
+      /** Org ids whose UPDATE should reject, to prove the loop keeps going. */
+      failOrgIds: new Set<string>(),
+    },
+    /**
+     * The REAL primitive the db module uses, not a hand-rolled stand-in. A
+     * synchronous save/restore would diverge the moment the implementation
+     * awaits between writes: `AsyncLocalStorage.exit()` covers the whole async
+     * subtree scheduled inside it, a flag restored in a `finally` does not.
+     * Using the same primitive means this mock cannot drift from the contract
+     * it stands in for.
+     */
+    contextStore: new AsyncLocalStorage<unknown>(),
+    captureExceptionMock: vi.fn(),
+    captureMessageMock: vi.fn(),
+  };
+});
+
+vi.mock('@anthropic-ai/claude-agent-sdk', () => ({ query: queryMock }));
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(() => Promise.resolve([{ approvalMode: 'per_step' }])),
+        })),
+      })),
+    })),
+    insert: vi.fn(() => ({ values: vi.fn(() => Promise.resolve()) })),
+    update: dbUpdateMock,
+  },
+  withDbAccessContext: vi.fn(async (ctx: unknown, fn: () => unknown) => {
+    // Real semantics (db/index.ts): an already-open context is JOINED, and the
+    // caller's GUCs win over the context handed in here.
+    const ambient = contextStore.getStore();
+    if (ambient !== undefined) {
+      mockState.effectiveContext = ambient;
+      return await fn();
+    }
+    return await contextStore.run(ctx, async () => {
+      mockState.effectiveContext = ctx;
+      return await fn();
+    });
+  }),
+  withSystemDbAccessContext: vi.fn(async (fn: () => unknown) => await fn()),
+  runOutsideDbContext: vi.fn(<T,>(fn: () => T): T => contextStore.exit(fn)),
+}));
+
+// `dbWriteExpectingRows` is deliberately NOT mocked: it is the code under test's
+// only zero-row alarm, and stubbing it would make the RLS-signature assertion
+// below prove nothing. It reaches captureMessage through this same mocked module.
+vi.mock('./sentry', () => ({
+  captureException: captureExceptionMock,
+  captureMessage: captureMessageMock,
+}));
+
+vi.mock('./aiCostTracker', () => ({
+  recordUsageFromSdkResult: vi.fn(() => Promise.resolve()),
+  calculateCostCents: vi.fn(() => 0),
+  calculateCatalogCostCents: vi.fn(() => 0),
+  sumInputTokens: (u: Record<string, number | null | undefined> | null | undefined) =>
+    (u?.input_tokens ?? 0) + (u?.cache_read_input_tokens ?? 0) + (u?.cache_creation_input_tokens ?? 0),
+}));
+vi.mock('./aiAgent', () => ({ sanitizeErrorForClient: (e: unknown) => String(e) }));
+vi.mock('./aiAgentSdkTools', () => ({
+  createBreezeMcpServer: vi.fn(() => ({ type: 'sdk' })),
+  BREEZE_MCP_TOOL_NAMES: ['mcp__breeze__query_devices'],
+}));
+vi.mock('./aiAgentSdk', () => ({
+  createSessionPreToolUse: vi.fn(() => vi.fn()),
+  createSessionPostToolUse: vi.fn(() => vi.fn()),
+  settleApprovalWaits: vi.fn(),
+}));
+vi.mock('./aiToolOutput', () => ({
+  redactAiToolOutputText: (s: string) => s,
+  redactSensitiveToolInput: (i: unknown) => i,
+}));
+vi.mock('./clientIp', () => ({ getTrustedClientIpOrUndefined: () => undefined }));
+
+import {
+  StreamingSessionManager,
+  SessionEventBus,
+  PROCESSING_STALL_TIMEOUT_MS,
+  type ActiveSession,
+  type SessionState,
+} from './streamingSessionManager';
+import type { AuthContext } from '../middleware/auth';
+import type { UsableLlmConfig } from './llm/llmConfigResolver';
+
+const MINUTE = 60 * 1000;
+const HOUR = 60 * MINUTE;
+const MAX_ACTIVE_SESSIONS = 200;
+
+const dialect = new PgDialect();
+
+/** Private surface, exercised directly. */
+type ManagerInternals = {
+  sessions: Map<string, ActiveSession>;
+  evictStaleSessions(): void;
+  evictLeastRecentlyActive(): void;
+};
+const internals = (m: StreamingSessionManager): ManagerInternals =>
+  m as unknown as ManagerInternals;
+
+/**
+ * Build a session with everything `remove()` and the eviction paths touch, and
+ * register it. Direct Map injection rather than `getOrCreate()`: the real
+ * constructor spawns an SDK subprocess per session, and several cases here need
+ * a whole 200-session cohort. The one test that must prove the WIRING — that
+ * the cap check actually reaches the protected LRU path — goes through the real
+ * `getOrCreate()` instead.
+ */
+function seed(
+  manager: StreamingSessionManager,
+  id: string,
+  orgId: string,
+  opts: { idleFor?: number; ageFor?: number; state?: SessionState } = {},
+): ActiveSession {
+  const now = Date.now();
+  const session = {
+    breezeSessionId: id,
+    orgId,
+    deviceId: null,
+    model: 'claude-sonnet-4-5',
+    sdkSessionId: null,
+    query: { close: vi.fn(), interrupt: vi.fn() },
+    abortController: new AbortController(),
+    inputController: { close: vi.fn() },
+    eventBus: new SessionEventBus(),
+    state: opts.state ?? 'idle',
+    lastActivityAt: now - (opts.idleFor ?? 0),
+    createdAt: now - (opts.ageFor ?? 0),
+    turnTimeoutId: null,
+    toolUseIdQueue: [],
+    pendingApprovalWaits: 0,
+    approvalWaitDeadline: null,
+    approvalWaitAbort: null,
+  } as unknown as ActiveSession;
+  internals(manager).sessions.set(id, session);
+  return session;
+}
+
+/** The expire write is fire-and-forget; let its microtasks settle. */
+const flush = () => Promise.resolve();
+
+/**
+ * Drain the macrotask queue. Required wherever the assertion is about something
+ * that happens AFTER the write's `await` (the row-count check, the next org in
+ * the loop): the first write is issued synchronously, so any wait keyed on
+ * `capturedExpires` resolves long before that code runs.
+ */
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+function expectExpiredWrite(index: number, sessionIds: string[], orgId: string) {
+  const write = capturedExpires[index]!;
+  expect(write.set.status).toBe('expired');
+  expect(write.set.updatedAt).toBeInstanceOf(Date);
+  expect(write.context).toEqual({
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+  });
+  // Guarded on status='active' so a row the user already closed is never
+  // re-stamped as expired.
+  const { sql: whereSql, params } = dialect.sqlToQuery(write.where);
+  for (const id of sessionIds) expect(params).toContain(id);
+  expect(params).toContain('active');
+  // Bind the params to their columns — asserting membership alone would still
+  // pass if the id were compared against some other text column.
+  expect(whereSql).toMatch(/"id"\s+in/i);
+  expect(whereSql).toMatch(/"status"\s*=/i);
+}
+
+const capacityAlarms = () =>
+  captureMessageMock.mock.calls.filter(
+    (c) => (c[1] as { eventCode?: string } | undefined)?.eventCode === 'ai_session_cap_all_in_flight',
+  );
+const zeroRowAlarms = () =>
+  captureMessageMock.mock.calls.filter(
+    (c) => (c[1] as { eventCode?: string } | undefined)?.eventCode === 'db_write_expecting_rows_zero',
+  );
+
+// ── fixtures for the one test that drives the real getOrCreate path ──────────
+const ORG = '0c0c0c0c-1111-4222-8333-444455556666';
+const DB_SESSION = {
+  orgId: ORG,
+  sdkSessionId: null,
+  model: 'claude-sonnet-4-5-20250929',
+  maxTurns: 50,
+  turnCount: 0,
+  systemPrompt: null,
+};
+const AUTH = {
+  orgId: ORG,
+  scope: 'organization',
+  accessibleOrgIds: [ORG],
+  user: { id: 'beefbeef-1111-4222-8333-444455556666', email: 'tech@contoso.com' },
+} as unknown as AuthContext;
+const PLATFORM_CONFIG = {
+  source: 'platform' as const,
+  apiKey: 'platform-key',
+  model: 'claude-sonnet-4-6',
+} as unknown as UsableLlmConfig;
+
+function mockSdkQuery(messages: unknown[], gate: Promise<void> = Promise.resolve()) {
+  queryMock.mockImplementation(() => ({
+    async *[Symbol.asyncIterator]() {
+      // The gate lets a test back-date lastActivityAt AFTER getOrCreate returns
+      // but BEFORE any stream event lands — otherwise the processor may already
+      // have drained the messages and the assertion proves nothing.
+      await gate;
+      yield* messages as never[];
+    },
+    interrupt: vi.fn(),
+    close: vi.fn(),
+  }));
+}
+
+function gatedSdkQuery(messages: unknown[]): () => void {
+  let release!: () => void;
+  const gate = new Promise<void>((r) => { release = r; });
+  mockSdkQuery(messages, gate);
+  return release;
+}
+const textDelta = (text: string) => ({
+  type: 'stream_event',
+  event: { type: 'content_block_delta', delta: { type: 'text_delta', text } },
+});
+const messageStart = () => ({ type: 'stream_event', event: { type: 'message_start' } });
+const RESULT_MSG = {
+  type: 'result',
+  subtype: 'success',
+  total_cost_usd: 0.01,
+  usage: { input_tokens: 10, output_tokens: 5 },
+  num_turns: 1,
+};
+
+describe('StreamingSessionManager eviction (#4514)', () => {
+  let manager: StreamingSessionManager;
+
+  beforeEach(() => {
+    capturedExpires.length = 0;
+    mockState.effectiveContext = null;
+    mockState.nextRows = [{ id: 'row' }];
+    mockState.failOrgIds = new Set();
+    // Targeted resets, never vi.clearAllMocks(): a blanket reset would wipe the
+    // dbUpdateMock implementation installed here and the hoisted context store's
+    // semantics along with it.
+    captureMessageMock.mockClear();
+    captureExceptionMock.mockClear();
+    queryMock.mockReset();
+    dbUpdateMock.mockReset();
+    dbUpdateMock.mockImplementation(() => ({
+      set: (values: Record<string, unknown>) => ({
+        where: (clause: SQL) => ({
+          returning: () => {
+            const ctx = mockState.effectiveContext as { orgId?: string } | null;
+            capturedExpires.push({ context: ctx, set: values, where: clause });
+            if (ctx?.orgId && mockState.failOrgIds.has(ctx.orgId)) {
+              return Promise.reject(new Error(`write failed for ${ctx.orgId}`));
+            }
+            return Promise.resolve(mockState.nextRows);
+          },
+        }),
+      }),
+    }));
+    manager = new StreamingSessionManager();
+  });
+
+  afterEach(() => {
+    manager.shutdown();
+    vi.useRealTimers();
+  });
+
+  // ==========================================================================
+  describe('a turn in flight is never aborted by eviction', () => {
+    it('LRU skips the least-recently-active session when it is mid-turn', () => {
+      // The streaming session is the LRU victim by lastActivityAt precisely
+      // because the pre-fix code refreshed that stamp only in getOrCreate().
+      const streaming = seed(manager, 'streaming', 'org-a', {
+        idleFor: 5 * MINUTE,
+        state: 'processing',
+      });
+      seed(manager, 'idle-older', 'org-b', { idleFor: 2 * MINUTE, state: 'idle' });
+      seed(manager, 'idle-newer', 'org-c', { idleFor: 1 * MINUTE, state: 'idle' });
+
+      internals(manager).evictLeastRecentlyActive();
+
+      expect(manager.get('streaming')).toBeDefined();
+      expect(streaming.abortController.signal.aborted).toBe(false);
+      expect(streaming.state).toBe('processing');
+      // The oldest *evictable* session is the victim instead.
+      expect(manager.get('idle-older')).toBeUndefined();
+      expect(manager.get('idle-newer')).toBeDefined();
+    });
+
+    it('the 24h age branch defers to the in-flight turn instead of killing it', async () => {
+      // Past the 24h hard cap, but actively streaming right now.
+      const streaming = seed(manager, 'aged-streaming', 'org-a', {
+        idleFor: 10 * 1000,
+        ageFor: 25 * HOUR,
+        state: 'processing',
+      });
+
+      internals(manager).evictStaleSessions();
+      await settle();
+
+      expect(manager.get('aged-streaming')).toBeDefined();
+      expect(streaming.abortController.signal.aborted).toBe(false);
+      // And nothing was retired: the session is still live.
+      expect(capturedExpires).toHaveLength(0);
+    });
+
+    it('evicts nothing when every session is mid-turn rather than corrupting a live turn', () => {
+      seed(manager, 's1', 'org-a', { idleFor: 5 * MINUTE, state: 'processing' });
+      seed(manager, 's2', 'org-b', { idleFor: 4 * MINUTE, state: 'processing' });
+
+      internals(manager).evictLeastRecentlyActive();
+
+      expect(manager.activeCount).toBe(2);
+      // Overshooting the soft cap is self-correcting; corrupting a live turn is
+      // not. But the breach must still reach Sentry, not just stdout.
+      expect(capacityAlarms()).toHaveLength(1);
+    });
+
+    it('throttles the capacity alarm instead of firing it on every request', () => {
+      seed(manager, 's1', 'org-a', { idleFor: 5 * MINUTE, state: 'processing' });
+
+      internals(manager).evictLeastRecentlyActive();
+      internals(manager).evictLeastRecentlyActive();
+      internals(manager).evictLeastRecentlyActive();
+
+      expect(capacityAlarms()).toHaveLength(1);
+    });
+
+    it('protects the in-flight turn on the REAL cap path, not just the private method', async () => {
+      // Fill to the cap with live turns, then let getOrCreate trip the check at
+      // `this.sessions.size >= MAX_ACTIVE_SESSIONS`. This is the wiring the
+      // private-method tests above cannot see.
+      for (let i = 0; i < MAX_ACTIVE_SESSIONS; i++) {
+        // Staggered but all well inside PROCESSING_STALL_TIMEOUT_MS, so every
+        // one of them is genuinely in flight.
+        seed(manager, `live-${i}`, 'org-a', { idleFor: (i + 1) * 1000, state: 'processing' });
+      }
+      // Gated: the background processor removes its own session once the SDK
+      // stream ends, so the assertions have to run while the turn is still open.
+      const release = gatedSdkQuery([RESULT_MSG]);
+
+      const created = await manager.getOrCreate(
+        'sess-new', DB_SESSION, AUTH, undefined, 'PROMPT', undefined, PLATFORM_CONFIG,
+      );
+
+      // Not one of the 200 live turns was taken.
+      for (let i = 0; i < MAX_ACTIVE_SESSIONS; i++) {
+        expect(manager.get(`live-${i}`)).toBeDefined();
+      }
+      // The cap is deliberately overshot instead: that self-corrects as soon as
+      // any turn ends, whereas a corrupted live turn does not.
+      expect(manager.get('sess-new')).toBeDefined();
+      expect(manager.activeCount).toBe(MAX_ACTIVE_SESSIONS + 1);
+      expect(capacityAlarms()).toHaveLength(1);
+
+      release();
+      await created.processorPromise;
+    });
+
+    it('refreshes lastActivityAt when a turn starts, so a live session is not the LRU victim', () => {
+      const session = seed(manager, 'starting', 'org-a', { idleFor: 90 * MINUTE, state: 'idle' });
+      const before = session.lastActivityAt;
+
+      expect(manager.tryTransitionToProcessing(session)).toBe(true);
+
+      expect(session.lastActivityAt).toBeGreaterThan(before);
+      expect(Date.now() - session.lastActivityAt).toBeLessThan(1000);
+    });
+  });
+
+  // ==========================================================================
+  describe('stream progress keeps a long turn alive', () => {
+    it('refreshes lastActivityAt on every content delta', async () => {
+      const release = gatedSdkQuery([textDelta('hello'), textDelta(' world'), RESULT_MSG]);
+      const session = await manager.getOrCreate(
+        'sess-delta', DB_SESSION, AUTH, undefined, 'PROMPT', undefined, PLATFORM_CONFIG,
+      );
+      // Back-date so only a delta keepalive can move it forward.
+      session.lastActivityAt = Date.now() - 3 * HOUR;
+      const before = session.lastActivityAt;
+
+      release();
+      await session.processorPromise;
+
+      expect(session.eventBus.getReplayEvents().filter((e) => e.type === 'content_delta')).toHaveLength(2);
+      expect(session.lastActivityAt).toBeGreaterThan(before);
+    });
+
+    it('refreshes lastActivityAt at message_start, so a tool-only turn is not silent', async () => {
+      // A turn that emits no text delta at all still makes progress. Unlike the
+      // OpenAI twin, this path can spend minutes in approval waits and tool
+      // execution between message boundaries.
+      const release = gatedSdkQuery([messageStart(), RESULT_MSG]);
+      const session = await manager.getOrCreate(
+        'sess-tool-only', DB_SESSION, AUTH, undefined, 'PROMPT', undefined, PLATFORM_CONFIG,
+      );
+      session.lastActivityAt = Date.now() - 3 * HOUR;
+      const before = session.lastActivityAt;
+
+      release();
+      await session.processorPromise;
+
+      expect(session.lastActivityAt).toBeGreaterThan(before);
+    });
+  });
+
+  // ==========================================================================
+  describe('a stalled turn stays evictable (no immortal session)', () => {
+    it('evicts a processing session that has made no progress past the stall window', async () => {
+      // runBackgroundProcessor can leave `state` pinned at 'processing' after a
+      // throw; without the stall window that session would never be reclaimed.
+      seed(manager, 'wedged', 'org-a', {
+        idleFor: 3 * HOUR,
+        state: 'processing',
+      });
+
+      internals(manager).evictStaleSessions();
+      await settle();
+
+      expect(manager.get('wedged')).toBeUndefined();
+      expectExpiredWrite(0, ['wedged'], 'org-a');
+    });
+
+    it('protects a processing session at exactly the stall window', () => {
+      // Frozen clock: seed() and the sweep both read Date.now(), so a single
+      // elapsed millisecond would move an at-edge session past the window and
+      // the test would assert position rather than protection.
+      vi.useFakeTimers();
+      // A fresh manager: each boundary case must be the SOLE candidate, so LRU
+      // spares it by protection rather than by position.
+      const m = new StreamingSessionManager();
+      try {
+        const atEdge = seed(m, 'at-edge', 'org-a', {
+          idleFor: PROCESSING_STALL_TIMEOUT_MS,
+          state: 'processing',
+        });
+        seed(m, 'newer-idle', 'org-b', { idleFor: 1000, state: 'idle' });
+
+        internals(m).evictLeastRecentlyActive();
+
+        expect(m.get('at-edge')).toBeDefined();
+        expect(atEdge.abortController.signal.aborted).toBe(false);
+        expect(m.get('newer-idle')).toBeUndefined();
+      } finally {
+        m.shutdown();
+      }
+    });
+
+    it('releases a processing session one millisecond past the stall window', () => {
+      vi.useFakeTimers();
+      const m = new StreamingSessionManager();
+      try {
+        seed(m, 'past-edge', 'org-a', {
+          idleFor: PROCESSING_STALL_TIMEOUT_MS + 1,
+          state: 'processing',
+        });
+        seed(m, 'newer-idle', 'org-b', { idleFor: 1000, state: 'idle' });
+
+        internals(m).evictLeastRecentlyActive();
+
+        expect(m.get('past-edge')).toBeUndefined();
+        expect(m.get('newer-idle')).toBeDefined();
+      } finally {
+        m.shutdown();
+      }
+    });
+
+    it('LRU can reclaim a stalled processing session', () => {
+      seed(manager, 'wedged', 'org-a', {
+        idleFor: PROCESSING_STALL_TIMEOUT_MS + MINUTE,
+        state: 'processing',
+      });
+      seed(manager, 'healthy', 'org-b', { idleFor: 1 * MINUTE, state: 'idle' });
+
+      internals(manager).evictLeastRecentlyActive();
+
+      expect(manager.get('wedged')).toBeUndefined();
+      expect(manager.get('healthy')).toBeDefined();
+      // Capacity eviction never expires — even for a wedged session.
+      expect(capturedExpires).toHaveLength(0);
+    });
+  });
+
+  // ==========================================================================
+  describe('every staleness eviction path retires the row', () => {
+    it('idle-timeout eviction expires the row', async () => {
+      seed(manager, 'idled', 'org-a', { idleFor: 3 * HOUR, ageFor: 4 * HOUR, state: 'idle' });
+
+      internals(manager).evictStaleSessions();
+      await settle();
+
+      expect(manager.get('idled')).toBeUndefined();
+      expect(capturedExpires).toHaveLength(1);
+      expectExpiredWrite(0, ['idled'], 'org-a');
+    });
+
+    it('24h age eviction still expires the row', async () => {
+      seed(manager, 'aged', 'org-a', { idleFor: 1 * MINUTE, ageFor: 25 * HOUR, state: 'idle' });
+
+      internals(manager).evictStaleSessions();
+      await settle();
+
+      expect(manager.get('aged')).toBeUndefined();
+      expectExpiredWrite(0, ['aged'], 'org-a');
+    });
+
+    it('LRU eviction does NOT expire the row — a capacity drop stays resumable', async () => {
+      seed(manager, 'victim', 'org-a', { idleFor: 5 * MINUTE, state: 'idle' });
+
+      internals(manager).evictLeastRecentlyActive();
+      await settle();
+
+      expect(manager.get('victim')).toBeUndefined();
+      // History lives in ai_messages and the row resumes from sdkSessionId, so
+      // stamping 'expired' would turn a transient capacity condition into a hard
+      // 410 for a conversation minutes old.
+      expect(capturedExpires).toHaveLength(0);
+    });
+
+    it('expires the evicted session under ITS OWN org scope, escaping any request context', async () => {
+      seed(manager, 'victim', 'org-victim', { idleFor: 3 * HOUR, state: 'idle' });
+
+      // A requester's context genuinely open around the sweep. Today the timer
+      // is armed at module load with no ambient context, but LRU already runs
+      // from getOrCreate on the request path — this pins the escape so a future
+      // caller cannot silently inherit someone else's GUCs.
+      await contextStore.run(
+        { scope: 'organization', orgId: 'org-requester', accessibleOrgIds: ['org-requester'] },
+        async () => {
+          internals(manager).evictStaleSessions();
+          await flush();
+        },
+      );
+      await settle();
+
+      expect(capturedExpires).toHaveLength(1);
+      // Joining the requester's context would make this UPDATE match zero rows
+      // under RLS — green mock, dead code in production.
+      expect(capturedExpires[0]!.context).toEqual({
+        scope: 'organization',
+        orgId: 'org-victim',
+        accessibleOrgIds: ['org-victim'],
+      });
+    });
+
+    it('keeps every org in a cohort on its OWN scope, including after the first await', async () => {
+      // The regression a single hoisted `runOutsideDbContext` produces:
+      // AsyncLocalStorage.exit() covers the synchronous call and what it
+      // schedules, but iteration 2+ resumes with the caller's context live.
+      seed(manager, 'v-a', 'org-a', { idleFor: 3 * HOUR, state: 'idle' });
+      seed(manager, 'v-b', 'org-b', { idleFor: 3 * HOUR, state: 'idle' });
+      seed(manager, 'v-c', 'org-c', { idleFor: 3 * HOUR, state: 'idle' });
+
+      await contextStore.run(
+        { scope: 'organization', orgId: 'org-requester', accessibleOrgIds: ['org-requester'] },
+        async () => {
+          internals(manager).evictStaleSessions();
+          await flush();
+        },
+      );
+      await settle();
+      await settle();
+
+      expect(capturedExpires).toHaveLength(3);
+      expect(capturedExpires.map((w) => (w.context as { orgId: string }).orgId)).toEqual([
+        'org-a', 'org-b', 'org-c',
+      ]);
+    });
+
+    it('surfaces a zero-row expire — the RLS-denial signature is otherwise silent', async () => {
+      mockState.nextRows = [];
+      seed(manager, 'victim', 'org-a', { idleFor: 3 * HOUR, state: 'idle' });
+
+      internals(manager).evictStaleSessions();
+      await settle();
+      await settle();
+
+      // An UPDATE under the wrong tenant's GUCs does not raise under forced RLS
+      // — it matches zero rows and reports success.
+      expect(zeroRowAlarms()).toHaveLength(1);
+    });
+
+    it('stays quiet when the expire actually lands', async () => {
+      seed(manager, 'victim', 'org-a', { idleFor: 3 * HOUR, state: 'idle' });
+
+      internals(manager).evictStaleSessions();
+      await settle();
+      await settle();
+
+      expect(zeroRowAlarms()).toHaveLength(0);
+    });
+
+    it('batches a whole idle cohort into ONE statement per org', async () => {
+      for (const id of ['a1', 'a2', 'a3']) {
+        seed(manager, id, 'org-a', { idleFor: 3 * HOUR, state: 'idle' });
+      }
+      seed(manager, 'b1', 'org-b', { idleFor: 3 * HOUR, state: 'idle' });
+
+      internals(manager).evictStaleSessions();
+      await settle();
+      await settle();
+
+      // One transaction per session would put up to MAX_ACTIVE_SESSIONS of them
+      // against a pool of DB_POOL_MAX shared with live request traffic.
+      expect(capturedExpires).toHaveLength(2);
+      expectExpiredWrite(0, ['a1', 'a2', 'a3'], 'org-a');
+      expectExpiredWrite(1, ['b1'], 'org-b');
+    });
+
+    it('keeps expiring later orgs when one org write fails', async () => {
+      mockState.failOrgIds = new Set(['org-a']);
+      seed(manager, 'v-a', 'org-a', { idleFor: 3 * HOUR, state: 'idle' });
+      seed(manager, 'v-b', 'org-b', { idleFor: 3 * HOUR, state: 'idle' });
+
+      internals(manager).evictStaleSessions();
+      await settle();
+      await settle();
+
+      expect(captureExceptionMock).toHaveBeenCalled();
+      // org-b must still be retired — abandoning the loop strands exactly the
+      // 'active' rows this helper exists to clean up.
+      expect(capturedExpires).toHaveLength(2);
+      expect((capturedExpires[1]!.context as { orgId: string }).orgId).toBe('org-b');
+    });
+
+    it('still retires the sessions already dropped when the sweep throws mid-way', async () => {
+      const first = seed(manager, 'first', 'org-a', { idleFor: 3 * HOUR, state: 'idle' });
+      seed(manager, 'second', 'org-b', { idleFor: 3 * HOUR, state: 'idle' });
+      // Blow up on the SECOND session, after the first has been removed.
+      const second = manager.get('second')!;
+      (second as unknown as { eventBus: unknown }).eventBus = {
+        publish: () => { throw new Error('bus exploded'); },
+        closeAll: () => {},
+      };
+
+      expect(() => internals(manager).evictStaleSessions()).toThrow('bus exploded');
+      await settle();
+      await settle();
+
+      expect(first.state).toBe('closed');
+      expect(capturedExpires).toHaveLength(1);
+      expectExpiredWrite(0, ['first'], 'org-a');
+    });
+
+    it('does not expire rows for sessions it leaves in place', async () => {
+      seed(manager, 'fresh', 'org-a', { idleFor: 1 * MINUTE, ageFor: 1 * HOUR, state: 'idle' });
+
+      internals(manager).evictStaleSessions();
+      await settle();
+
+      expect(manager.get('fresh')).toBeDefined();
+      expect(capturedExpires).toHaveLength(0);
+    });
+
+    it('still notifies the client on the stale-eviction path', async () => {
+      const session = seed(manager, 'idled', 'org-a', { idleFor: 3 * HOUR, state: 'idle' });
+      const events = session.eventBus.getReplayEvents();
+
+      internals(manager).evictStaleSessions();
+      await settle();
+
+      const published = session.eventBus.getReplayEvents().slice(events.length);
+      expect(published.some((e) => e.type === 'error')).toBe(true);
+      expect(published.some((e) => e.type === 'done')).toBe(true);
+    });
+
+    it('still notifies the client on the LRU path', async () => {
+      const session = seed(manager, 'victim', 'org-a', { idleFor: 5 * MINUTE, state: 'idle' });
+
+      internals(manager).evictLeastRecentlyActive();
+      await settle();
+
+      const published = session.eventBus.getReplayEvents();
+      expect(published.some((e) => e.type === 'error')).toBe(true);
+      expect(published.some((e) => e.type === 'done')).toBe(true);
+    });
+
+    it('does not expire rows on shutdown — sessions stay resumable across a deploy', async () => {
+      seed(manager, 's1', 'org-a', { idleFor: 3 * HOUR, state: 'idle' });
+      seed(manager, 's2', 'org-b', { idleFor: 3 * HOUR, state: 'idle' });
+
+      manager.shutdown();
+      await settle();
+
+      expect(manager.activeCount).toBe(0);
+      expect(capturedExpires).toHaveLength(0);
+    });
+  });
+});

--- a/apps/api/src/services/streamingSessionManager.ts
+++ b/apps/api/src/services/streamingSessionManager.ts
@@ -17,7 +17,7 @@ import type { Query, SDKResultMessage, SDKUserMessage, McpSdkServerConfigWithIns
 import { db, withDbAccessContext, withSystemDbAccessContext, runOutsideDbContext } from '../db';
 import { dbWriteExpectingRows } from '../db/dbWriteExpectingRows';
 import { aiSessions, aiMessages, aiBudgets } from '../db/schema';
-import { eq, and, isNull } from 'drizzle-orm';
+import { eq, and, isNull, inArray } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import { buildOrgAccessClosures } from '../middleware/auth';
 import type { AiStreamEvent, AiApprovalMode } from '@breeze/shared/types/ai';
@@ -30,7 +30,7 @@ import {
   type CatalogPricingSnapshot,
 } from './aiCostTracker';
 import { sanitizeErrorForClient } from './aiAgent';
-import { captureException } from './sentry';
+import { captureException, captureMessage } from './sentry';
 import { createBreezeMcpServer, BREEZE_MCP_TOOL_NAMES } from './aiAgentSdkTools';
 import { createSessionPreToolUse, createSessionPostToolUse, settleApprovalWaits } from './aiAgentSdk';
 import type { RequestLike } from './auditEvents';
@@ -46,6 +46,30 @@ const SESSION_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24h hard limit
 const EVICTION_INTERVAL_MS = 60 * 1000; // Check every 60s
 const MAX_ACTIVE_SESSIONS = 200;
 const EVENT_RING_BUFFER_SIZE = 100;
+/**
+ * How long a `processing` session may go without stream progress before
+ * eviction stops treating it as a live turn.
+ *
+ * Eviction protects an in-flight turn (see `isTurnInFlight`), and `state` alone
+ * would make that protection unbounded: `runBackgroundProcessor` can leave a
+ * session in `processing` after a throw or an aborted subprocess, and a hung
+ * provider never emits another event — so a wedged session would be pinned in
+ * memory forever, and under cap pressure a handful of them would wedge the
+ * whole manager. `lastActivityAt` is refreshed when a turn starts and on every
+ * assistant-message boundary and text delta, so a live stream never approaches
+ * this window; anything past it is a dead turn, and reclaiming it costs
+ * nothing.
+ *
+ * Sized against this path's real worst case, which is longer than the OpenAI
+ * twin's: a tier-3 tool can block on `waitForApproval` (300s, aiAgentSdk.ts)
+ * and then execute under a 120s vision budget without emitting a single text
+ * delta, i.e. ~7 min of legitimate silence — see SDK_TURN_TIMEOUT_MS above.
+ * 10 min clears that with headroom while still bounding a wedge.
+ */
+export const PROCESSING_STALL_TIMEOUT_MS = 10 * 60 * 1000;
+
+/** Throttle for the all-in-flight capacity alarm, so it cannot flood Sentry. */
+const CAPACITY_ALARM_THROTTLE_MS = 5 * 60 * 1000;
 /**
  * 6 min per-turn timeout. Sized to accept a single approval wait
  * (`waitForApproval`, aiAgentSdk.ts, 300_000ms = 5 min) plus headroom for
@@ -601,7 +625,18 @@ export class StreamingSessionManager {
   private sessions = new Map<string, ActiveSession>();
   private evictionTimer: ReturnType<typeof setInterval> | null = null;
 
+  private lastCapacityAlarmAt = 0;
+
   constructor() {
+    // No `runOutsideDbContext` wrapper around this `setInterval`, unlike the
+    // OpenAI twin (llm/openaiSessionManager.ts). That manager is a LAZY
+    // singleton first constructed inside an AI request handler, so its timer
+    // would inherit the requester's AsyncLocalStorage scope on every tick for
+    // the life of the process. This one is a MODULE-LEVEL singleton
+    // (bottom of file), constructed at import time with no ambient context, so
+    // the sweep starts clean. `markSessionsExpired` still re-enters the escape
+    // per statement — that is what actually guarantees the write's context,
+    // and it does not depend on this construction-order accident holding.
     this.evictionTimer = setInterval(() => this.evictStaleSessions(), EVICTION_INTERVAL_MS);
   }
 
@@ -616,6 +651,11 @@ export class StreamingSessionManager {
       return false;
     }
     session.state = 'processing';
+    // The state and its staleness clock move together: eviction reads
+    // lastActivityAt to tell a live turn from a wedged one, and before this the
+    // stamp was refreshed only in getOrCreate() — so a session that had been
+    // sitting idle stayed the LRU victim for the whole turn it was streaming.
+    session.lastActivityAt = Date.now();
     return true;
   }
 
@@ -1159,9 +1199,16 @@ export class StreamingSessionManager {
               messageStarted = true;
               // Reset turn timeout — SDK is actively producing output
               this.startTurnTimeout(session);
+              // Same signal, for eviction: a new assistant message is stream
+              // progress. Unlike the OpenAI twin, a turn here can run entirely
+              // through tool_use blocks and emit no text delta at all, so the
+              // message boundary is the only keepalive some turns ever get.
+              session.lastActivityAt = Date.now();
               session.eventBus.publish({ type: 'message_start', messageId: currentMessageId });
             } else if (event.type === 'content_block_delta') {
               if ('delta' in event && event.delta.type === 'text_delta') {
+                // Stream progress keeps the turn alive for eviction purposes.
+                session.lastActivityAt = Date.now();
                 session.eventBus.publish({ type: 'content_delta', delta: event.delta.text });
               }
             } else if (event.type === 'content_block_start') {
@@ -1674,14 +1721,122 @@ export class StreamingSessionManager {
   // Eviction
   // ============================================
 
+  /**
+   * True while a turn is actively streaming for this session.
+   *
+   * Eviction must never take such a session: `remove()` aborts its
+   * AbortController, closes the SDK query and closes the event bus mid-turn, so
+   * the client's SSE stream ends on a capacity error in place of the answer it
+   * was already receiving, and the assistant text produced so far is lost
+   * without ever being persisted.
+   *
+   * Liveness is `state` AND recent progress, never `state` alone — see
+   * PROCESSING_STALL_TIMEOUT_MS for why a wedged turn must stay reclaimable.
+   */
+  private isTurnInFlight(session: ActiveSession, now: number): boolean {
+    return (
+      session.state === 'processing'
+      && now - session.lastActivityAt <= PROCESSING_STALL_TIMEOUT_MS
+    );
+  }
+
+  /**
+   * Retire the DB rows for sessions that staleness eviction has just dropped.
+   *
+   * An evicted session is gone from memory and its client has been told to
+   * start a new one, so leaving `status = 'active'` strands the row and every
+   * caller keyed on active sessions overcounts. This mirrors what
+   * `runPreFlightChecks` would have written lazily on the next request
+   * (services/aiAgentSdk.ts) — eviction just stops deferring it.
+   *
+   * `runOutsideDbContextSafe` is re-entered on EVERY iteration, never once
+   * around the loop. `withDbAccessContext` JOINS an already-open context
+   * instead of replacing it (db/index.ts), and `AsyncLocalStorage.exit()`
+   * covers the synchronous call plus what it schedules — but an iteration
+   * resuming after `await` sees the caller's ambient context live again, so a
+   * single hoisted escape would leave orgs 2..N running under someone else's
+   * GUCs, matching zero rows under RLS while reporting success. Today the only
+   * caller is the module-level eviction timer, which has no ambient context and
+   * makes this a no-op; the escape is here so that stays true if this is ever
+   * reached from a request path (issue #4514 calls that dependence out
+   * explicitly).
+   *
+   * The `status = 'active'` guard keeps a row already closed by the user from
+   * being re-stamped as expired.
+   */
+  private markSessionsExpired(sessionIdsByOrg: Map<string, string[]>): void {
+    if (sessionIdsByOrg.size === 0) return;
+    void (async () => {
+      // One org per statement, one statement at a time. A single tick can
+      // retire a whole cohort that idled out together, and a transaction per
+      // session would put up to MAX_ACTIVE_SESSIONS (200) of them against a
+      // pool of DB_POOL_MAX (30) shared with live request traffic. Eviction is
+      // background work with no deadline, so it yields to that traffic.
+      for (const [orgId, sessionIds] of sessionIdsByOrg) {
+        try {
+          // `.returning()` + dbWriteExpectingRows because an UPDATE evaluated
+          // under the WRONG tenant's GUCs does not raise under forced RLS — it
+          // matches zero rows and reports success. That is exactly the failure
+          // the context escape exists to prevent, so it has to be observable
+          // rather than assumed. A partial count is normal (the
+          // status='active' guard skips rows the user already closed); zero
+          // across a whole batch is the RLS signature.
+          await runOutsideDbContextSafe(() =>
+            withDbAccessContext(
+              { scope: 'organization', orgId, accessibleOrgIds: [orgId] },
+              () => dbWriteExpectingRows(
+                'streamingSessionManager.expireEvictedSessions',
+                () => db.update(aiSessions)
+                  .set({ status: 'expired', updatedAt: new Date() })
+                  .where(and(
+                    inArray(aiSessions.id, sessionIds),
+                    eq(aiSessions.status, 'active'),
+                  ))
+                  .returning({ id: aiSessions.id }),
+              ),
+            ),
+          );
+        } catch (err) {
+          // Never abandon the remaining orgs: a failure here strands rows as
+          // 'active', which is the very defect this helper exists to fix.
+          // Session ids go in the log line, not a Sentry tag — the scrubber
+          // allowlist deliberately voids tenant-scoped tags, so a tag here
+          // would silently vanish rather than aid correlation.
+          captureException(err);
+          console.error(
+            `[StreamingSessionManager] Failed to expire ${sessionIds.length} session(s) for org ${orgId} (${sessionIds.join(', ')}):`,
+            err,
+          );
+        }
+      }
+    })().catch((err) => {
+      // The loop body is fully guarded, so arriving here means the guard itself
+      // threw. Terminate the promise regardless: this helper's whole purpose is
+      // that an eviction never silently leaves a row 'active'.
+      captureException(err);
+      console.error('[StreamingSessionManager] Expire sweep failed:', err);
+    });
+  }
+
   private evictStaleSessions(): void {
     const now = Date.now();
+    const expiredByOrg = new Map<string, string[]>();
 
-    for (const [sessionId, session] of [...this.sessions.entries()]) {
-      const idle = now - session.lastActivityAt;
-      const age = now - session.createdAt;
+    try {
+      for (const [sessionId, session] of [...this.sessions.entries()]) {
+        const idle = now - session.lastActivityAt;
+        const age = now - session.createdAt;
 
-      if (idle > SESSION_IDLE_TIMEOUT_MS || age > SESSION_MAX_AGE_MS) {
+        if (idle <= SESSION_IDLE_TIMEOUT_MS && age <= SESSION_MAX_AGE_MS) continue;
+
+        // Applies to the 24h hard cap too: a session that reaches it mid-stream
+        // is evicted on the first tick after its turn ends (bounded by
+        // SDK_TURN_TIMEOUT_MS, not by this interval). Turns cannot chain to
+        // hold it open indefinitely — runPreFlightChecks enforces the same 24h
+        // cap before any NEW turn starts, so the slip is one turn at most.
+        // Deferring briefly beats cutting an answer off mid-sentence.
+        if (this.isTurnInFlight(session, now)) continue;
+
         console.log(`[StreamingSessionManager] Evicting session ${sessionId} (idle=${idle}ms, age=${age}ms)`);
 
         // Notify connected SSE clients before removing
@@ -1695,37 +1850,70 @@ export class StreamingSessionManager {
 
         this.remove(sessionId);
 
-        if (age > SESSION_MAX_AGE_MS) {
-          withDbAccessContext(
-            { scope: 'organization', orgId: session.orgId, accessibleOrgIds: [session.orgId] },
-            () =>
-              db.update(aiSessions)
-                .set({ status: 'expired', updatedAt: new Date() })
-                .where(and(eq(aiSessions.id, sessionId), eq(aiSessions.status, 'active')))
-          ).catch((err) => { captureException(err); console.error('[StreamingSessionManager] Failed to expire session:', err); });
-        }
+        // BOTH staleness paths retire the row, not just the 24h one. An
+        // idle-evicted session is as dead to the client as an aged-out one, and
+        // preflight would have stamped it 'expired' on the next request anyway.
+        const forOrg = expiredByOrg.get(session.orgId);
+        if (forOrg) forOrg.push(sessionId);
+        else expiredByOrg.set(session.orgId, [sessionId]);
       }
+    } finally {
+      // In a `finally` so a throw mid-sweep still retires the sessions already
+      // dropped from the Map. Losing them here would strand exactly the
+      // 'active' rows this method exists to clean up, with no record of which.
+      this.markSessionsExpired(expiredByOrg);
     }
   }
 
   private evictLeastRecentlyActive(): void {
+    const now = Date.now();
     let oldest: { id: string; lastActivity: number } | null = null;
 
     for (const [id, session] of this.sessions) {
+      // Under cap pressure the least-recently-active session is often the one
+      // mid-stream: its stamp predates the turn it is currently serving.
+      if (this.isTurnInFlight(session, now)) continue;
       if (!oldest || session.lastActivityAt < oldest.lastActivity) {
         oldest = { id, lastActivity: session.lastActivityAt };
       }
     }
 
-    if (oldest) {
-      console.log(`[StreamingSessionManager] LRU evicting session ${oldest.id}`);
-      const session = this.sessions.get(oldest.id);
-      if (session) {
-        session.eventBus.publish({ type: 'error', message: 'Session evicted due to server capacity. Please start a new session.' });
-        session.eventBus.publish({ type: 'done' });
+    if (!oldest) {
+      // Every session is mid-turn. Overshooting the soft cap is self-correcting
+      // — the next getOrCreate reclaims space as soon as any turn ends — while
+      // corrupting a live turn is not. But the cap IS being breached and the
+      // caller proceeds to add anyway, so this is a resource-exhaustion signal
+      // and must reach more than stdout. Throttled: under sustained pressure
+      // this fires once per window rather than once per request.
+      console.warn(
+        `[StreamingSessionManager] LRU eviction skipped: all ${this.sessions.size} sessions have a turn in flight; cap ${MAX_ACTIVE_SESSIONS} exceeded`,
+      );
+      if (now - this.lastCapacityAlarmAt >= CAPACITY_ALARM_THROTTLE_MS) {
+        this.lastCapacityAlarmAt = now;
+        captureMessage('AI session cap exceeded: every session mid-turn', {
+          eventCode: 'ai_session_cap_all_in_flight',
+        });
       }
-      this.remove(oldest.id);
+      return;
     }
+
+    console.log(`[StreamingSessionManager] LRU evicting session ${oldest.id}`);
+    const session = this.sessions.get(oldest.id);
+    if (session) {
+      session.eventBus.publish({ type: 'error', message: 'Session evicted due to server capacity. Please start a new session.' });
+      session.eventBus.publish({ type: 'done' });
+    }
+    this.remove(oldest.id);
+    // Deliberately NOT expired, matching the OpenAI twin (#4406). Unlike the
+    // staleness paths, an LRU victim is a perfectly usable conversation dropped
+    // for OUR capacity reasons: history lives in ai_messages and the session
+    // resumes from `sdkSessionId`, so the user's next message transparently
+    // recreates it — exactly like a deploy, which shutdown() is likewise
+    // careful not to expire. Stamping 'expired' here would turn a transient
+    // server condition into a hard 410 for a conversation minutes old, since
+    // runPreFlightChecks rejects on status before getOrCreate ever runs. The
+    // row stays truthful: 'active' means resumable, and preflight still expires
+    // it lazily once it genuinely goes idle or ages out.
   }
 }
 

--- a/apps/api/src/services/streamingSessionManager.ts
+++ b/apps/api/src/services/streamingSessionManager.ts
@@ -70,6 +70,22 @@ export const PROCESSING_STALL_TIMEOUT_MS = 10 * 60 * 1000;
 
 /** Throttle for the all-in-flight capacity alarm, so it cannot flood Sentry. */
 const CAPACITY_ALARM_THROTTLE_MS = 5 * 60 * 1000;
+
+/**
+ * Bucket how far past MAX_ACTIVE_SESSIONS the manager has been pushed, for the
+ * capacity alarm's only scrubber-surviving channel (a tag).
+ *
+ * Closed four-value set by construction, carrying no tenant, device or session
+ * identifier — the shape ALLOWED_TAG_NAMES requires. The raw count would be
+ * unbounded cardinality; the bucket still separates "one turn over" from "the
+ * manager is wedged", which is the distinction that decides whether to page.
+ */
+function bucketSessionOvershoot(size: number): string {
+  if (size <= MAX_ACTIVE_SESSIONS) return 'at-cap';
+  if (size <= MAX_ACTIVE_SESSIONS * 1.25) return 'over-cap';
+  if (size <= MAX_ACTIVE_SESSIONS * 2) return 'far-over-cap';
+  return 'runaway';
+}
 /**
  * 6 min per-turn timeout. Sized to accept a single approval wait
  * (`waitForApproval`, aiAgentSdk.ts, 300_000ms = 5 min) plus headroom for
@@ -1799,10 +1815,13 @@ export class StreamingSessionManager {
         } catch (err) {
           // Never abandon the remaining orgs: a failure here strands rows as
           // 'active', which is the very defect this helper exists to fix.
-          // Session ids go in the log line, not a Sentry tag — the scrubber
-          // allowlist deliberately voids tenant-scoped tags, so a tag here
-          // would silently vanish rather than aid correlation.
-          captureException(err);
+          //
+          // `org_id` IS in sentry.ts's ALLOWED_TAG_NAMES and survives the
+          // scrubber, so it goes on the event — without it every org's failure
+          // collapses into one untriageable Sentry issue and the on-call has to
+          // go log-diving to learn which tenant is stranded. The SESSION ids are
+          // the part the allowlist voids, so those stay in the log line only.
+          captureException(err, undefined, { org_id: orgId });
           console.error(
             `[StreamingSessionManager] Failed to expire ${sessionIds.length} session(s) for org ${orgId} (${sessionIds.join(', ')}):`,
             err,
@@ -1890,8 +1909,13 @@ export class StreamingSessionManager {
       );
       if (now - this.lastCapacityAlarmAt >= CAPACITY_ALARM_THROTTLE_MS) {
         this.lastCapacityAlarmAt = now;
+        // The magnitude has to ride on a TAG: `scrubEvent` deletes `message`
+        // from every outbound event, so without this a single-request blip and a
+        // sustained runaway produce byte-identical Sentry issues — and the
+        // difference is exactly what decides whether anyone should be paged.
         captureMessage('AI session cap exceeded: every session mid-turn', {
           eventCode: 'ai_session_cap_all_in_flight',
+          tags: { ai_session_cap_bucket: bucketSessionOvershoot(this.sessions.size) },
         });
       }
       return;


### PR DESCRIPTION
Closes #4514

Ports #4406 (the openai-compatible manager, #4384) to `streamingSessionManager` — the **default** path, used unless `MCP_LLM_PROVIDER=openai-compatible`. #4406's commit body deferred this file explicitly rather than doubling that PR into the primary AI path.

## What was wrong

**1. Eviction could abort an actively-processing turn.** `session.lastActivityAt` was assigned in exactly one place — the reuse branch of `getOrCreate()` — and neither `evictStaleSessions()` nor `evictLeastRecentlyActive()` checked `state === 'processing'`. Under cap pressure the least-recently-*created-or-resumed* session could be the one currently streaming, and `remove()` aborts its controller, closes the SDK query and closes the event bus mid-turn.

**2. Idle eviction never retired the DB row.** Only the `age > SESSION_MAX_AGE_MS` branch wrote `status: 'expired'`; the idle branch dropped the session from memory and left `ai_sessions.status = 'active'` on a session that no longer exists.

## The fix

**In-flight turns are protected.** Both eviction paths skip a session with a turn in flight. Liveness is `state` **and** recent stream progress, never `state` alone: `lastActivityAt` is refreshed at `tryTransitionToProcessing`, at `message_start` and on every text delta, and a processing session with no progress for `PROCESSING_STALL_TIMEOUT_MS` (10 min) is a dead turn that stays reclaimable. Without that, a background processor that leaves `state` pinned at `processing` would wedge a session forever. When *every* session is mid-turn, LRU evicts nothing and raises a throttled capacity alarm — overshooting the soft cap is self-correcting, corrupting a live turn is not.

**Two keepalives, not one — the one real deviation from the twin.** #4406 refreshes on content deltas only. This path can spend ~7 min inside a single turn with no text delta at all (a tier-3 tool blocking on `waitForApproval` for 300s, then executing under a 120s vision budget — see the `SDK_TURN_TIMEOUT_MS` comment), so `message_start` is a keepalive too; otherwise a tool-only turn is indistinguishable from a wedge. That worst case is also what sizes the 10-minute window here.

**Both staleness paths retire the row; capacity eviction does not.** The idle and 24h paths now write `'expired'` (an existing enum value, no migration), matching what `runPreFlightChecks` writes lazily on the next request — and that preflight branch already reports an expired session as *expired* (410, not 400) since #4406, so one contract holds however the row got there.

LRU deliberately does **not** expire, matching #4406 and the issue's own note ("Capacity eviction should probably NOT expire the row … the two managers should agree"). An LRU victim is a healthy conversation dropped for our own capacity reasons: history lives in `ai_messages` and the session resumes from `sdkSessionId`, so the user's next message transparently recreates it — exactly like a deploy, which `shutdown()` is likewise careful not to expire. Stamping `'expired'` would turn a transient server condition into a hard 410 for a conversation minutes old.

## Tenancy

Expire writes are grouped one statement per org (`inArray`) and serialized: previously this could open one transaction per session — up to `MAX_ACTIVE_SESSIONS` (200) — against a `DB_POOL_MAX` of 30 shared with live traffic, and idle cohorts expire together after a spike.

`runOutsideDbContext` is re-entered **per statement**, never hoisted around the loop: `withDbAccessContext` JOINS an already-open context instead of replacing it, and `AsyncLocalStorage.exit()` does not cover iterations resuming after an `await`, so a hoisted escape strands orgs 2..N under the caller's GUCs where the UPDATE matches zero rows under RLS and reports success. Today the only caller is the module-level eviction timer (no ambient context), so this is defense in depth — but the issue calls that safety out as an accident of construction order, and the sibling LRU path already runs from `getOrCreate()` on the request path. `dbWriteExpectingRows` makes a zero-row batch — the RLS signature — visible rather than silent.

The constructor does **not** need #4406's `setInterval` escape: that manager is a *lazy* singleton built inside a request, so its timer inherits the requester's scope on every tick; this one is module-level and starts clean. That difference is documented in the constructor rather than left implicit.

No schema change, no migration, no new registration lists.

## Verification

- **`streamingSessionManager.eviction.test.ts` — 26 tests, confirmed red first: 17 failed / 9 passed against the unfixed source.** Every load-bearing assertion was mutation-tested rather than assumed:

  | Mutation | Result |
  |---|---|
  | Flip `<=` to `<` at the stall boundary | 1 test fails |
  | Hoist the context escape out of the per-org loop | 1 test fails |
  | Remove the `content_delta` keepalive | 1 test fails |
  | Remove the `message_start` keepalive | 1 test fails |
  | Expire on the LRU path too (the literal reading) | 2 tests fail |
  | Zero-row control: make the "stays quiet" fixture return no rows | 1 test fails |

  Two boundary tests passed *vacuously* in the red run — the unfixed module exports no `PROCESSING_STALL_TIMEOUT_MS`, so the offset is `undefined` — and are covered by the boundary mutation instead. They also needed `vi.useFakeTimers()`: with a live clock the at-edge session drifted one millisecond past the window and was spared by position, not by protection.

- `vitest run src/services/streamingSessionManager src/services/aiAgentSdk.test.ts src/services/sentryEventCodes.test.ts` — **9 files, 221 passed**.
- `vitest run src/routes/ai src/routes/scriptAi src/services/llm src/services/aiAgent` — **98 files, 2474 passed**.
- `tsc --noEmit` exit 0; `eslint` clean on both touched files.

The db mock uses a real `AsyncLocalStorage` rather than a save/restore flag, so it cannot drift from the join-if-open contract it stands in for, and `dbWriteExpectingRows` is left unmocked so the zero-row alarm is genuinely exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBxF7C8E5GxFnNcGf6kBVP
