### PR TITLE
feat(billing): contract line editing (#3205 W03)

### DIFF
--- a/apps/api/src/__tests__/integration/contractLineEditing.integration.test.ts
+++ b/apps/api/src/__tests__/integration/contractLineEditing.integration.test.ts
@@ -1,0 +1,304 @@
+/**
+ * #3205 W03 acceptance bar, real Postgres as breeze_app (forced RLS, no bypass).
+ *
+ * The headline is LINEAGE: editing a line in place leaves an already-generated
+ * draft invoice issuable, where delete-and-re-add wedges it with SOURCE_NOT_FOUND
+ * (invoiceService.ts:1194-1199). The delete path is the CONTROL in the same test,
+ * so the fix is provably the thing being measured.
+ *
+ * The asymmetry matrix is asserted on BOTH sides. Three of its five cases the
+ * database ACCEPTS — that is the point. Nobody may later "fix" one of these by
+ * assuming a constraint that does not exist; if a wave wants those constraints,
+ * that is a migration, not an assumption.
+ */
+import './setup';
+import { describe, it, expect } from 'vitest';
+import { eq, sql } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import { partners, organizations, sites, deviceGroups, contracts, contractLines, invoiceLines } from '../../db/schema';
+import {
+  addContractLineToContract, updateContractLine, removeContractLine, getContract,
+  generateDueInvoice, type ContractActorT,
+} from '../../services/contractService';
+import { issueInvoice } from '../../services/invoiceService';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+interface Fixture {
+  actor: ContractActorT; partnerId: string; orgId: string; otherOrgId: string;
+  siteId: string; otherSiteId: string; groupId: string; otherGroupId: string; contractId: string;
+}
+
+async function seed(status: 'draft' | 'active' | 'paused' | 'cancelled' = 'draft'): Promise<Fixture> {
+  return withSystemDbAccessContext(async () => {
+    const sfx = Math.random().toString(36).slice(2, 8);
+    const [p] = await db.insert(partners)
+      .values({ name: `EP ${sfx}`, slug: `ep-${sfx}`, type: 'msp', plan: 'pro', status: 'active' })
+      .returning({ id: partners.id });
+    const [oA, oB] = await db.insert(organizations).values([
+      { currencyCode: 'USD', partnerId: p!.id, name: 'EA', slug: `ea-${sfx}` },
+      { currencyCode: 'USD', partnerId: p!.id, name: 'EB', slug: `eb-${sfx}` },
+    ]).returning({ id: organizations.id });
+    const [sA] = await db.insert(sites).values({ orgId: oA!.id, name: `A-${sfx}` }).returning({ id: sites.id });
+    const [sB] = await db.insert(sites).values({ orgId: oB!.id, name: `B-${sfx}` }).returning({ id: sites.id });
+    const [gA] = await db.insert(deviceGroups).values({ orgId: oA!.id, name: `GA ${sfx}`, type: 'static' }).returning({ id: deviceGroups.id });
+    const [gB] = await db.insert(deviceGroups).values({ orgId: oB!.id, name: `GB ${sfx}`, type: 'static' }).returning({ id: deviceGroups.id });
+    const [c] = await db.insert(contracts).values({
+      partnerId: p!.id, orgId: oA!.id, name: `Edit ${sfx}`, status, intervalMonths: 1,
+      startDate: '2026-07-01', nextBillingAt: '2026-07-01', currencyCode: 'USD', billingTiming: 'advance',
+    }).returning({ id: contracts.id });
+    return {
+      actor: { userId: null as unknown as string, partnerId: p!.id, accessibleOrgIds: [oA!.id] },
+      partnerId: p!.id, orgId: oA!.id, otherOrgId: oB!.id, siteId: sA!.id, otherSiteId: sB!.id,
+      groupId: gA!.id, otherGroupId: gB!.id, contractId: c!.id,
+    };
+  });
+}
+
+/** Insert a line straight through SQL so the fixture is not bounded by the
+ *  writer's own validation — the point of the matrix is what the DB does. */
+async function rawLine(f: Fixture, cols: Record<string, unknown>): Promise<string> {
+  const rows = await withSystemDbAccessContext(() => db.insert(contractLines).values({
+    contractId: f.contractId, orgId: f.orgId, lineType: 'per_device', description: 'L',
+    unitPrice: '10.00', taxable: false, ...cols,
+  } as never).returning({ id: contractLines.id }));
+  return rows[0]!.id;
+}
+
+function pgErrorFields(error: unknown): { code?: string; constraint?: string } {
+  const wrapped = error as { code?: string; constraint_name?: string; cause?: { code?: string; constraint_name?: string } } | undefined;
+  const node = wrapped?.cause ?? wrapped;
+  return { code: node?.code, constraint: node?.constraint_name };
+}
+
+/** Forge the same row the service refused, as breeze_app, and report the verdict. */
+async function forge(lineId: string, setSql: ReturnType<typeof sql>): Promise<{ code?: string; constraint?: string } | 'accepted'> {
+  try {
+    await withSystemDbAccessContext(() => db.execute(sql`UPDATE contract_lines SET ${setSql} WHERE id = ${lineId}::uuid`));
+    return 'accepted';
+  } catch (err) {
+    return pgErrorFields(err);
+  }
+}
+
+describe('contract line editing (real DB) #3205 W03', () => {
+  // ---- asymmetry matrix: app verdict AND database verdict, every case -------
+  runDb('roles onto a per_device line: app 400, DB 23514 on contract_lines_device_roles_chk', async () => {
+    const f = await seed();
+    const id = await rawLine(f, {});
+    await expect(withSystemDbAccessContext(() => updateContractLine(f.contractId, id, { deviceRoles: ['server'] } as never, f.actor)))
+      .rejects.toMatchObject({ code: 'INVALID_LINE_PATCH', status: 400 });
+    expect(await forge(id, sql`device_roles = ARRAY['server']::text[]`))
+      .toEqual({ code: '23514', constraint: 'contract_lines_device_roles_chk' });
+  });
+
+  runDb('roles cleared from a per_device_role line: app 400, DB 23514', async () => {
+    const f = await seed();
+    const id = await rawLine(f, { lineType: 'per_device_role', deviceRoles: ['server'] });
+    // deviceRoles is not nullable in the patch schema, so the app-side proof is
+    // the merged-row rule reached through a sibling edit that cannot fix it.
+    await expect(withSystemDbAccessContext(() => updateContractLine(f.contractId, id, { deviceRoles: ['server', 'server'] } as never, f.actor)))
+      .rejects.toMatchObject({ status: 400 });
+    expect(await forge(id, sql`device_roles = NULL`))
+      .toEqual({ code: '23514', constraint: 'contract_lines_device_roles_chk' });
+  });
+
+  runDb('a site_id onto a per_device_group line: app 400, DB 23514 on contract_lines_device_group_chk', async () => {
+    const f = await seed();
+    const id = await rawLine(f, { lineType: 'per_device_group', deviceGroupId: f.groupId, deviceGroupName: 'GA' });
+    await expect(withSystemDbAccessContext(() => updateContractLine(f.contractId, id, { siteId: f.siteId } as never, f.actor)))
+      .rejects.toMatchObject({ code: 'INVALID_LINE_PATCH', status: 400 });
+    expect(await forge(id, sql`site_id = ${f.siteId}::uuid`))
+      .toEqual({ code: '23514', constraint: 'contract_lines_device_group_chk' });
+  });
+
+  runDb('device_group_name cleared on a per_device_group line: DB 23514 on contract_lines_device_group_chk', async () => {
+    const f = await seed();
+    const id = await rawLine(f, { lineType: 'per_device_group', deviceGroupId: f.groupId, deviceGroupName: 'GA' });
+    expect(await forge(id, sql`device_group_name = NULL`))
+      .toEqual({ code: '23514', constraint: 'contract_lines_device_group_chk' });
+  });
+
+  // `<@` is CONTAINMENT, not set equality — the helper is the only guard.
+  runDb('duplicate roles: app 400, DB ACCEPTS', async () => {
+    const f = await seed();
+    const id = await rawLine(f, { lineType: 'per_device_role', deviceRoles: ['server'] });
+    await expect(withSystemDbAccessContext(() => updateContractLine(f.contractId, id, { deviceRoles: ['server', 'server'] } as never, f.actor)))
+      .rejects.toMatchObject({ status: 400 });
+    expect(await forge(id, sql`device_roles = ARRAY['server','server']::text[]`)).toBe('accepted');
+  });
+
+  // There is NO CHECK on manual_quantity at all — the helper is the only guard.
+  runDb('manualQuantity on a flat line: app 400, DB ACCEPTS', async () => {
+    const f = await seed();
+    const id = await rawLine(f, { lineType: 'flat' });
+    await expect(withSystemDbAccessContext(() => updateContractLine(f.contractId, id, { manualQuantity: '5.00' } as never, f.actor)))
+      .rejects.toMatchObject({ code: 'INVALID_LINE_PATCH', status: 400 });
+    expect(await forge(id, sql`manual_quantity = 5.00`)).toBe('accepted');
+  });
+
+  // W02's CHECK forbids a site on per_device_group ONLY — the helper is the
+  // only guard for flat / manual / per_seat.
+  runDb('site_id on a flat line: app 400, DB ACCEPTS', async () => {
+    const f = await seed();
+    const id = await rawLine(f, { lineType: 'flat' });
+    await expect(withSystemDbAccessContext(() => updateContractLine(f.contractId, id, { siteId: f.siteId } as never, f.actor)))
+      .rejects.toMatchObject({ code: 'INVALID_LINE_PATCH', status: 400 });
+    expect(await forge(id, sql`site_id = ${f.siteId}::uuid`)).toBe('accepted');
+  });
+
+  // ---- the orphaned-group repair (decision 7) ------------------------------
+  runDb('re-points an orphaned group line at a live group and re-stamps the name; a foreign group is 400', async () => {
+    const f = await seed();
+    const id = await rawLine(f, { lineType: 'per_device_group', deviceGroupId: null, deviceGroupName: 'Retired group' });
+    const [replacement] = await withSystemDbAccessContext(() => db.insert(deviceGroups)
+      .values({ orgId: f.orgId, name: 'Replacement', type: 'static' }).returning({ id: deviceGroups.id }));
+    const { line } = await withSystemDbAccessContext(() => updateContractLine(f.contractId, id, { deviceGroupId: replacement!.id } as never, f.actor));
+    expect(line).toMatchObject({ deviceGroupId: replacement!.id, deviceGroupName: 'Replacement' });
+    await expect(withSystemDbAccessContext(() => updateContractLine(f.contractId, id, { deviceGroupId: f.otherGroupId } as never, f.actor)))
+      .rejects.toMatchObject({ code: 'GROUP_NOT_IN_ORG', status: 400 });
+  });
+
+  runDb('a site in another org is 400 SITE_NOT_IN_ORG', async () => {
+    const f = await seed();
+    const id = await rawLine(f, {});
+    await expect(withSystemDbAccessContext(() => updateContractLine(f.contractId, id, { siteId: f.otherSiteId } as never, f.actor)))
+      .rejects.toMatchObject({ code: 'SITE_NOT_IN_ORG', status: 400 });
+  });
+
+  // ---- bounds never reach Postgres ----------------------------------------
+  runDb('over-bounds unitPrice and sortOrder are rejected by the schema, so the service is never called', async () => {
+    const { updateContractLineSchema } = await import('@breeze/shared');
+    expect(updateContractLineSchema.safeParse({ unitPrice: '99999999999.00' }).success).toBe(false);
+    expect(updateContractLineSchema.safeParse({ sortOrder: 2147483648 }).success).toBe(false);
+    // And the value that IS in range round-trips through the column.
+    const f = await seed();
+    const id = await rawLine(f, {});
+    const { line } = await withSystemDbAccessContext(() => updateContractLine(f.contractId, id, { unitPrice: '9999999999.99', sortOrder: 2147483647 } as never, f.actor));
+    expect(line).toMatchObject({ unitPrice: '9999999999.99', sortOrder: 2147483647 });
+  });
+
+  // ---- deterministic ordering ---------------------------------------------
+  runDb('getContract returns equal sortOrder lines in (createdAt, id) order rather than heap order', async () => {
+    const f = await seed();
+    // Insert newest first so heap/insertion order is deliberately the opposite
+    // of the createdAt tie-breaker required after the equal sortOrder.
+    const newest = await rawLine(f, { description: 'newest', sortOrder: 0, createdAt: new Date('2026-07-03T00:00:00Z') });
+    const oldest = await rawLine(f, { description: 'oldest', sortOrder: 0, createdAt: new Date('2026-07-01T00:00:00Z') });
+    const middle = await rawLine(f, { description: 'middle', sortOrder: 0, createdAt: new Date('2026-07-02T00:00:00Z') });
+    const result = await withSystemDbAccessContext(() => getContract(f.contractId, f.actor));
+    expect(result.lines.map((l) => l.id)).toEqual([oldest, middle, newest]);
+  });
+
+  runDb('generateDueInvoice bills lines in (sortOrder, createdAt, id) order', async () => {
+    const f = await seed('active');
+    // As above, heap order starts newest-first and therefore differs from the
+    // total order the billing query must use.
+    const newest = await rawLine(f, { lineType: 'flat', description: 'newest', unitPrice: '1.00', sortOrder: 0, createdAt: new Date('2026-07-03T00:00:00Z') });
+    const oldest = await rawLine(f, { lineType: 'flat', description: 'oldest', unitPrice: '1.00', sortOrder: 0, createdAt: new Date('2026-07-01T00:00:00Z') });
+    const middle = await rawLine(f, { lineType: 'flat', description: 'middle', unitPrice: '1.00', sortOrder: 0, createdAt: new Date('2026-07-02T00:00:00Z') });
+    const gen = await withSystemDbAccessContext(() => db.transaction(() => generateDueInvoice(f.contractId, new Date('2026-07-01T06:00:00Z'))));
+    const rows = await withSystemDbAccessContext(() => db.select({ description: invoiceLines.description, sourceId: invoiceLines.sourceId })
+      .from(invoiceLines).where(eq(invoiceLines.invoiceId, gen.invoiceId!)));
+    expect(rows.map((r) => r.sourceId)).toEqual([oldest, middle, newest]);
+  });
+
+  // ---- LINEAGE (the headline) ---------------------------------------------
+  runDb('editing a source line leaves the drafted invoice byte-identical and still issuable; delete-and-re-add wedges it', async () => {
+    const f = await seed('active');
+    const lineId = await rawLine(f, { lineType: 'flat', description: 'Monthly fee', unitPrice: '100.00' });
+    const gen = await withSystemDbAccessContext(() => db.transaction(() => generateDueInvoice(f.contractId, new Date('2026-07-01T06:00:00Z'))));
+    expect(gen.generated).toBe(true);
+    const [beforeLine] = await withSystemDbAccessContext(() => db.select().from(invoiceLines).where(eq(invoiceLines.invoiceId, gen.invoiceId!)));
+
+    await withSystemDbAccessContext(() => updateContractLine(f.contractId, lineId, { unitPrice: '250.00', description: 'Renamed' } as never, f.actor));
+    const [afterLine] = await withSystemDbAccessContext(() => db.select().from(invoiceLines).where(eq(invoiceLines.invoiceId, gen.invoiceId!)));
+    expect(afterLine).toEqual(beforeLine);
+    await expect(withSystemDbAccessContext(() => issueInvoice(gen.invoiceId!, {
+      userId: null, partnerId: f.partnerId, accessibleOrgIds: [f.orgId],
+    } as never))).resolves.toBeDefined();
+
+    // CONTROL: the pre-W03 repair — delete and re-add — wedges the draft.
+    const g2 = await seed('active');
+    const lineId2 = await rawLine(g2, { lineType: 'flat', description: 'Monthly fee', unitPrice: '100.00' });
+    const gen2 = await withSystemDbAccessContext(() => db.transaction(() => generateDueInvoice(g2.contractId, new Date('2026-07-01T06:00:00Z'))));
+    await withSystemDbAccessContext(() => removeContractLine(g2.contractId, lineId2, g2.actor));
+    await withSystemDbAccessContext(() => addContractLineToContract(g2.contractId, {
+      lineType: 'flat', description: 'Monthly fee', unitPrice: '250.00', taxable: false,
+    } as never, g2.actor));
+    await expect(withSystemDbAccessContext(() => issueInvoice(gen2.invoiceId!, {
+      userId: null, partnerId: g2.partnerId, accessibleOrgIds: [g2.orgId],
+    } as never))).rejects.toMatchObject({ code: 'SOURCE_NOT_FOUND', status: 409 });
+  });
+
+  // ---- edit vs generation (decision 5) ------------------------------------
+  runDb('an edit fired during generation waits for the contract lock; the invoice keeps the PRE-edit price', async () => {
+    const f = await seed('active');
+    const lineId = await rawLine(f, { lineType: 'flat', description: 'Monthly fee', unitPrice: '100.00' });
+    // Both take contracts.id FOR UPDATE as their first statement, so they
+    // serialise. The hold makes the interleaving observable, not the outcome.
+    const generation = withSystemDbAccessContext(() => db.transaction(async () => {
+      const r = await generateDueInvoice(f.contractId, new Date('2026-07-01T06:00:00Z'));
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      return r;
+    }));
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    const edit = withSystemDbAccessContext(() => updateContractLine(f.contractId, lineId, { unitPrice: '250.00' } as never, f.actor));
+    const [gen] = await Promise.all([generation, edit]);
+    const [invLine] = await withSystemDbAccessContext(() => db.select().from(invoiceLines).where(eq(invoiceLines.invoiceId, gen.invoiceId!)));
+    expect(invLine!.unitPrice).toBe('100.00');
+    const [row] = await withSystemDbAccessContext(() => db.select().from(contractLines).where(eq(contractLines.id, lineId)));
+    expect(row!.unitPrice).toBe('250.00');
+  });
+
+  runDb('an edit that commits first is billed by the next generation', async () => {
+    const f = await seed('active');
+    const lineId = await rawLine(f, { lineType: 'flat', description: 'Monthly fee', unitPrice: '100.00' });
+    await withSystemDbAccessContext(() => updateContractLine(f.contractId, lineId, { unitPrice: '250.00' } as never, f.actor));
+    const gen = await withSystemDbAccessContext(() => db.transaction(() => generateDueInvoice(f.contractId, new Date('2026-07-01T06:00:00Z'))));
+    const [invLine] = await withSystemDbAccessContext(() => db.select().from(invoiceLines).where(eq(invoiceLines.invoiceId, gen.invoiceId!)));
+    expect(invLine!.unitPrice).toBe('250.00');
+  });
+
+  // ---- edit vs edit: last-writer-wins, documented not accidental -----------
+  runDb('concurrent patches to DIFFERENT fields both survive; sequential patches to the SAME field leave the later value', async () => {
+    const f = await seed();
+    const lineId = await rawLine(f, { lineType: 'flat', description: 'Original', unitPrice: '10.00' });
+    await Promise.all([
+      withSystemDbAccessContext(() => updateContractLine(f.contractId, lineId, { description: 'Renamed' } as never, f.actor)),
+      withSystemDbAccessContext(() => updateContractLine(f.contractId, lineId, { unitPrice: '11.00' } as never, f.actor)),
+    ]);
+    const [both] = await withSystemDbAccessContext(() => db.select().from(contractLines).where(eq(contractLines.id, lineId)));
+    expect(both).toMatchObject({ description: 'Renamed', unitPrice: '11.00' });
+
+    await withSystemDbAccessContext(() => updateContractLine(f.contractId, lineId, { unitPrice: '20.00' } as never, f.actor));
+    await withSystemDbAccessContext(() => updateContractLine(f.contractId, lineId, { unitPrice: '30.00' } as never, f.actor));
+    const [last] = await withSystemDbAccessContext(() => db.select().from(contractLines).where(eq(contractLines.id, lineId)));
+    expect(last!.unitPrice).toBe('30.00');
+  });
+
+  // ---- status and tenancy gates -------------------------------------------
+  runDb.each(['paused', 'cancelled'] as const)('editing a line on a %s contract is 409 INVALID_STATE', async (status) => {
+    const f = await seed();
+    const lineId = await rawLine(f, {});
+    await withSystemDbAccessContext(() => db.update(contracts).set({ status }).where(eq(contracts.id, f.contractId)));
+    await expect(withSystemDbAccessContext(() => updateContractLine(f.contractId, lineId, { description: 'x' } as never, f.actor)))
+      .rejects.toMatchObject({ code: 'INVALID_STATE', status: 409 });
+  });
+
+  runDb('an actor whose accessibleOrgIds excludes the org gets 403 and changes no row', async () => {
+    const f = await seed();
+    const lineId = await rawLine(f, { description: 'Original' });
+    const foreign: ContractActorT = { ...f.actor, accessibleOrgIds: [f.otherOrgId] };
+    await expect(withSystemDbAccessContext(() => updateContractLine(f.contractId, lineId, { description: 'Hijacked' } as never, foreign)))
+      .rejects.toMatchObject({ code: 'ORG_DENIED', status: 403 });
+    const [row] = await withSystemDbAccessContext(() => db.select().from(contractLines).where(eq(contractLines.id, lineId)));
+    expect(row!.description).toBe('Original');
+  });
+
+  runDb('DELETE for a line that does not exist is 404 LINE_NOT_FOUND', async () => {
+    const f = await seed();
+    await expect(withSystemDbAccessContext(() => removeContractLine(f.contractId, '99999999-9999-4999-8999-999999999999', f.actor)))
+      .rejects.toMatchObject({ code: 'LINE_NOT_FOUND', status: 404 });
+  });
+});

--- a/apps/api/src/__tests__/integration/contractLineEditing.integration.test.ts
+++ b/apps/api/src/__tests__/integration/contractLineEditing.integration.test.ts
@@ -1,5 +1,7 @@
 /**
- * #3205 W03 acceptance bar, real Postgres as breeze_app (forced RLS, no bypass).
+ * #3205 W03 acceptance bar, real Postgres as breeze_app. Fixtures and billing
+ * controls use system scope; every line update/remove uses tenant scope under
+ * forced RLS, including the explicit cross-tenant denial proof.
  *
  * The headline is LINEAGE: editing a line in place leaves an already-generated
  * draft invoice issuable, where delete-and-re-add wedges it with SOURCE_NOT_FOUND
@@ -14,7 +16,7 @@
 import './setup';
 import { describe, it, expect } from 'vitest';
 import { eq, sql } from 'drizzle-orm';
-import { db, withSystemDbAccessContext } from '../../db';
+import { db, withDbAccessContext, withSystemDbAccessContext } from '../../db';
 import { partners, organizations, sites, deviceGroups, contracts, contractLines, invoiceLines } from '../../db/schema';
 import {
   addContractLineToContract, updateContractLine, removeContractLine, getContract,
@@ -55,6 +57,16 @@ async function seed(status: 'draft' | 'active' | 'paused' | 'cancelled' = 'draft
   });
 }
 
+const requestCtx = (f: Fixture, orgId = f.orgId) => ({
+  scope: 'partner' as const,
+  partnerId: f.partnerId,
+  orgId: null,
+  userId: null,
+  accessibleOrgIds: [orgId],
+  accessiblePartnerIds: [f.partnerId],
+  currentPartnerId: f.partnerId,
+});
+
 /** Insert a line straight through SQL so the fixture is not bounded by the
  *  writer's own validation — the point of the matrix is what the DB does. */
 async function rawLine(f: Fixture, cols: Record<string, unknown>): Promise<string> {
@@ -86,18 +98,18 @@ describe('contract line editing (real DB) #3205 W03', () => {
   runDb('roles onto a per_device line: app 400, DB 23514 on contract_lines_device_roles_chk', async () => {
     const f = await seed();
     const id = await rawLine(f, {});
-    await expect(withSystemDbAccessContext(() => updateContractLine(f.contractId, id, { deviceRoles: ['server'] } as never, f.actor)))
+    await expect(withDbAccessContext(requestCtx(f), () => updateContractLine(f.contractId, id, { deviceRoles: ['server'] } as never, f.actor)))
       .rejects.toMatchObject({ code: 'INVALID_LINE_PATCH', status: 400 });
     expect(await forge(id, sql`device_roles = ARRAY['server']::text[]`))
       .toEqual({ code: '23514', constraint: 'contract_lines_device_roles_chk' });
   });
 
-  runDb('roles cleared from a per_device_role line: app 400, DB 23514', async () => {
+  runDb('duplicate roles on a per_device_role line: app 400; clearing roles in DB is 23514', async () => {
     const f = await seed();
     const id = await rawLine(f, { lineType: 'per_device_role', deviceRoles: ['server'] });
     // deviceRoles is not nullable in the patch schema, so the app-side proof is
     // the merged-row rule reached through a sibling edit that cannot fix it.
-    await expect(withSystemDbAccessContext(() => updateContractLine(f.contractId, id, { deviceRoles: ['server', 'server'] } as never, f.actor)))
+    await expect(withDbAccessContext(requestCtx(f), () => updateContractLine(f.contractId, id, { deviceRoles: ['server', 'server'] } as never, f.actor)))
       .rejects.toMatchObject({ status: 400 });
     expect(await forge(id, sql`device_roles = NULL`))
       .toEqual({ code: '23514', constraint: 'contract_lines_device_roles_chk' });
@@ -106,7 +118,7 @@ describe('contract line editing (real DB) #3205 W03', () => {
   runDb('a site_id onto a per_device_group line: app 400, DB 23514 on contract_lines_device_group_chk', async () => {
     const f = await seed();
     const id = await rawLine(f, { lineType: 'per_device_group', deviceGroupId: f.groupId, deviceGroupName: 'GA' });
-    await expect(withSystemDbAccessContext(() => updateContractLine(f.contractId, id, { siteId: f.siteId } as never, f.actor)))
+    await expect(withDbAccessContext(requestCtx(f), () => updateContractLine(f.contractId, id, { siteId: f.siteId } as never, f.actor)))
       .rejects.toMatchObject({ code: 'INVALID_LINE_PATCH', status: 400 });
     expect(await forge(id, sql`site_id = ${f.siteId}::uuid`))
       .toEqual({ code: '23514', constraint: 'contract_lines_device_group_chk' });
@@ -123,7 +135,7 @@ describe('contract line editing (real DB) #3205 W03', () => {
   runDb('duplicate roles: app 400, DB ACCEPTS', async () => {
     const f = await seed();
     const id = await rawLine(f, { lineType: 'per_device_role', deviceRoles: ['server'] });
-    await expect(withSystemDbAccessContext(() => updateContractLine(f.contractId, id, { deviceRoles: ['server', 'server'] } as never, f.actor)))
+    await expect(withDbAccessContext(requestCtx(f), () => updateContractLine(f.contractId, id, { deviceRoles: ['server', 'server'] } as never, f.actor)))
       .rejects.toMatchObject({ status: 400 });
     expect(await forge(id, sql`device_roles = ARRAY['server','server']::text[]`)).toBe('accepted');
   });
@@ -132,7 +144,7 @@ describe('contract line editing (real DB) #3205 W03', () => {
   runDb('manualQuantity on a flat line: app 400, DB ACCEPTS', async () => {
     const f = await seed();
     const id = await rawLine(f, { lineType: 'flat' });
-    await expect(withSystemDbAccessContext(() => updateContractLine(f.contractId, id, { manualQuantity: '5.00' } as never, f.actor)))
+    await expect(withDbAccessContext(requestCtx(f), () => updateContractLine(f.contractId, id, { manualQuantity: '5.00' } as never, f.actor)))
       .rejects.toMatchObject({ code: 'INVALID_LINE_PATCH', status: 400 });
     expect(await forge(id, sql`manual_quantity = 5.00`)).toBe('accepted');
   });
@@ -142,7 +154,7 @@ describe('contract line editing (real DB) #3205 W03', () => {
   runDb('site_id on a flat line: app 400, DB ACCEPTS', async () => {
     const f = await seed();
     const id = await rawLine(f, { lineType: 'flat' });
-    await expect(withSystemDbAccessContext(() => updateContractLine(f.contractId, id, { siteId: f.siteId } as never, f.actor)))
+    await expect(withDbAccessContext(requestCtx(f), () => updateContractLine(f.contractId, id, { siteId: f.siteId } as never, f.actor)))
       .rejects.toMatchObject({ code: 'INVALID_LINE_PATCH', status: 400 });
     expect(await forge(id, sql`site_id = ${f.siteId}::uuid`)).toBe('accepted');
   });
@@ -153,16 +165,16 @@ describe('contract line editing (real DB) #3205 W03', () => {
     const id = await rawLine(f, { lineType: 'per_device_group', deviceGroupId: null, deviceGroupName: 'Retired group' });
     const [replacement] = await withSystemDbAccessContext(() => db.insert(deviceGroups)
       .values({ orgId: f.orgId, name: 'Replacement', type: 'static' }).returning({ id: deviceGroups.id }));
-    const { line } = await withSystemDbAccessContext(() => updateContractLine(f.contractId, id, { deviceGroupId: replacement!.id } as never, f.actor));
+    const { line } = await withDbAccessContext(requestCtx(f), () => updateContractLine(f.contractId, id, { deviceGroupId: replacement!.id } as never, f.actor));
     expect(line).toMatchObject({ deviceGroupId: replacement!.id, deviceGroupName: 'Replacement' });
-    await expect(withSystemDbAccessContext(() => updateContractLine(f.contractId, id, { deviceGroupId: f.otherGroupId } as never, f.actor)))
+    await expect(withDbAccessContext(requestCtx(f), () => updateContractLine(f.contractId, id, { deviceGroupId: f.otherGroupId } as never, f.actor)))
       .rejects.toMatchObject({ code: 'GROUP_NOT_IN_ORG', status: 400 });
   });
 
   runDb('a site in another org is 400 SITE_NOT_IN_ORG', async () => {
     const f = await seed();
     const id = await rawLine(f, {});
-    await expect(withSystemDbAccessContext(() => updateContractLine(f.contractId, id, { siteId: f.otherSiteId } as never, f.actor)))
+    await expect(withDbAccessContext(requestCtx(f), () => updateContractLine(f.contractId, id, { siteId: f.otherSiteId } as never, f.actor)))
       .rejects.toMatchObject({ code: 'SITE_NOT_IN_ORG', status: 400 });
   });
 
@@ -174,7 +186,7 @@ describe('contract line editing (real DB) #3205 W03', () => {
     // And the value that IS in range round-trips through the column.
     const f = await seed();
     const id = await rawLine(f, {});
-    const { line } = await withSystemDbAccessContext(() => updateContractLine(f.contractId, id, { unitPrice: '9999999999.99', sortOrder: 2147483647 } as never, f.actor));
+    const { line } = await withDbAccessContext(requestCtx(f), () => updateContractLine(f.contractId, id, { unitPrice: '9999999999.99', sortOrder: 2147483647 } as never, f.actor));
     expect(line).toMatchObject({ unitPrice: '9999999999.99', sortOrder: 2147483647 });
   });
 
@@ -211,7 +223,7 @@ describe('contract line editing (real DB) #3205 W03', () => {
     expect(gen.generated).toBe(true);
     const [beforeLine] = await withSystemDbAccessContext(() => db.select().from(invoiceLines).where(eq(invoiceLines.invoiceId, gen.invoiceId!)));
 
-    await withSystemDbAccessContext(() => updateContractLine(f.contractId, lineId, { unitPrice: '250.00', description: 'Renamed' } as never, f.actor));
+    await withDbAccessContext(requestCtx(f), () => updateContractLine(f.contractId, lineId, { unitPrice: '250.00', description: 'Renamed' } as never, f.actor));
     const [afterLine] = await withSystemDbAccessContext(() => db.select().from(invoiceLines).where(eq(invoiceLines.invoiceId, gen.invoiceId!)));
     expect(afterLine).toEqual(beforeLine);
     await expect(withSystemDbAccessContext(() => issueInvoice(gen.invoiceId!, {
@@ -222,7 +234,7 @@ describe('contract line editing (real DB) #3205 W03', () => {
     const g2 = await seed('active');
     const lineId2 = await rawLine(g2, { lineType: 'flat', description: 'Monthly fee', unitPrice: '100.00' });
     const gen2 = await withSystemDbAccessContext(() => db.transaction(() => generateDueInvoice(g2.contractId, new Date('2026-07-01T06:00:00Z'))));
-    await withSystemDbAccessContext(() => removeContractLine(g2.contractId, lineId2, g2.actor));
+    await withDbAccessContext(requestCtx(g2), () => removeContractLine(g2.contractId, lineId2, g2.actor));
     await withSystemDbAccessContext(() => addContractLineToContract(g2.contractId, {
       lineType: 'flat', description: 'Monthly fee', unitPrice: '250.00', taxable: false,
     } as never, g2.actor));
@@ -237,13 +249,26 @@ describe('contract line editing (real DB) #3205 W03', () => {
     const lineId = await rawLine(f, { lineType: 'flat', description: 'Monthly fee', unitPrice: '100.00' });
     // Both take contracts.id FOR UPDATE as their first statement, so they
     // serialise. The hold makes the interleaving observable, not the outcome.
+    let generationLocked!: () => void;
+    const lockHeld = new Promise<void>((resolve) => { generationLocked = resolve; });
+    let releaseGeneration!: () => void;
+    const holdGeneration = new Promise<void>((resolve) => { releaseGeneration = resolve; });
     const generation = withSystemDbAccessContext(() => db.transaction(async () => {
       const r = await generateDueInvoice(f.contractId, new Date('2026-07-01T06:00:00Z'));
-      await new Promise((resolve) => setTimeout(resolve, 300));
+      generationLocked();
+      await holdGeneration;
       return r;
     }));
-    await new Promise((resolve) => setTimeout(resolve, 100));
-    const edit = withSystemDbAccessContext(() => updateContractLine(f.contractId, lineId, { unitPrice: '250.00' } as never, f.actor));
+    // Race against generation so an early throw fails fast instead of hanging on lockHeld.
+    await Promise.race([lockHeld, generation]);
+    let editIssued!: () => void;
+    const issued = new Promise<void>((resolve) => { editIssued = resolve; });
+    const edit = withDbAccessContext(requestCtx(f), () => {
+      editIssued();
+      return updateContractLine(f.contractId, lineId, { unitPrice: '250.00' } as never, f.actor);
+    });
+    await issued;
+    releaseGeneration();
     const [gen] = await Promise.all([generation, edit]);
     const [invLine] = await withSystemDbAccessContext(() => db.select().from(invoiceLines).where(eq(invoiceLines.invoiceId, gen.invoiceId!)));
     expect(invLine!.unitPrice).toBe('100.00');
@@ -254,7 +279,7 @@ describe('contract line editing (real DB) #3205 W03', () => {
   runDb('an edit that commits first is billed by the next generation', async () => {
     const f = await seed('active');
     const lineId = await rawLine(f, { lineType: 'flat', description: 'Monthly fee', unitPrice: '100.00' });
-    await withSystemDbAccessContext(() => updateContractLine(f.contractId, lineId, { unitPrice: '250.00' } as never, f.actor));
+    await withDbAccessContext(requestCtx(f), () => updateContractLine(f.contractId, lineId, { unitPrice: '250.00' } as never, f.actor));
     const gen = await withSystemDbAccessContext(() => db.transaction(() => generateDueInvoice(f.contractId, new Date('2026-07-01T06:00:00Z'))));
     const [invLine] = await withSystemDbAccessContext(() => db.select().from(invoiceLines).where(eq(invoiceLines.invoiceId, gen.invoiceId!)));
     expect(invLine!.unitPrice).toBe('250.00');
@@ -265,14 +290,14 @@ describe('contract line editing (real DB) #3205 W03', () => {
     const f = await seed();
     const lineId = await rawLine(f, { lineType: 'flat', description: 'Original', unitPrice: '10.00' });
     await Promise.all([
-      withSystemDbAccessContext(() => updateContractLine(f.contractId, lineId, { description: 'Renamed' } as never, f.actor)),
-      withSystemDbAccessContext(() => updateContractLine(f.contractId, lineId, { unitPrice: '11.00' } as never, f.actor)),
+      withDbAccessContext(requestCtx(f), () => updateContractLine(f.contractId, lineId, { description: 'Renamed' } as never, f.actor)),
+      withDbAccessContext(requestCtx(f), () => updateContractLine(f.contractId, lineId, { unitPrice: '11.00' } as never, f.actor)),
     ]);
     const [both] = await withSystemDbAccessContext(() => db.select().from(contractLines).where(eq(contractLines.id, lineId)));
     expect(both).toMatchObject({ description: 'Renamed', unitPrice: '11.00' });
 
-    await withSystemDbAccessContext(() => updateContractLine(f.contractId, lineId, { unitPrice: '20.00' } as never, f.actor));
-    await withSystemDbAccessContext(() => updateContractLine(f.contractId, lineId, { unitPrice: '30.00' } as never, f.actor));
+    await withDbAccessContext(requestCtx(f), () => updateContractLine(f.contractId, lineId, { unitPrice: '20.00' } as never, f.actor));
+    await withDbAccessContext(requestCtx(f), () => updateContractLine(f.contractId, lineId, { unitPrice: '30.00' } as never, f.actor));
     const [last] = await withSystemDbAccessContext(() => db.select().from(contractLines).where(eq(contractLines.id, lineId)));
     expect(last!.unitPrice).toBe('30.00');
   });
@@ -282,23 +307,30 @@ describe('contract line editing (real DB) #3205 W03', () => {
     const f = await seed();
     const lineId = await rawLine(f, {});
     await withSystemDbAccessContext(() => db.update(contracts).set({ status }).where(eq(contracts.id, f.contractId)));
-    await expect(withSystemDbAccessContext(() => updateContractLine(f.contractId, lineId, { description: 'x' } as never, f.actor)))
+    await expect(withDbAccessContext(requestCtx(f), () => updateContractLine(f.contractId, lineId, { description: 'x' } as never, f.actor)))
       .rejects.toMatchObject({ code: 'INVALID_STATE', status: 409 });
   });
 
-  runDb('an actor whose accessibleOrgIds excludes the org gets 403 and changes no row', async () => {
+  runDb("the OTHER org's forced-RLS context cannot read or update the line", async () => {
     const f = await seed();
     const lineId = await rawLine(f, { description: 'Original' });
     const foreign: ContractActorT = { ...f.actor, accessibleOrgIds: [f.otherOrgId] };
-    await expect(withSystemDbAccessContext(() => updateContractLine(f.contractId, lineId, { description: 'Hijacked' } as never, foreign)))
-      .rejects.toMatchObject({ code: 'ORG_DENIED', status: 403 });
+    const visible = await withDbAccessContext(requestCtx(f, f.otherOrgId), () => db.select()
+      .from(contractLines).where(eq(contractLines.id, lineId)));
+    expect(visible).toEqual([]);
+    const directlyUpdated = await withDbAccessContext(requestCtx(f, f.otherOrgId), () => db.update(contractLines)
+      .set({ description: 'Hijacked directly' }).where(eq(contractLines.id, lineId)).returning({ id: contractLines.id }));
+    expect(directlyUpdated).toEqual([]);
+    await expect(withDbAccessContext(requestCtx(f, f.otherOrgId), () => updateContractLine(
+      f.contractId, lineId, { description: 'Hijacked' } as never, foreign,
+    ))).rejects.toMatchObject({ code: 'CONTRACT_NOT_FOUND', status: 404 });
     const [row] = await withSystemDbAccessContext(() => db.select().from(contractLines).where(eq(contractLines.id, lineId)));
     expect(row!.description).toBe('Original');
   });
 
   runDb('DELETE for a line that does not exist is 404 LINE_NOT_FOUND', async () => {
     const f = await seed();
-    await expect(withSystemDbAccessContext(() => removeContractLine(f.contractId, '99999999-9999-4999-8999-999999999999', f.actor)))
+    await expect(withDbAccessContext(requestCtx(f), () => removeContractLine(f.contractId, '99999999-9999-4999-8999-999999999999', f.actor)))
       .rejects.toMatchObject({ code: 'LINE_NOT_FOUND', status: 404 });
   });
 });

--- a/apps/api/src/routes/contracts/contracts.test.ts
+++ b/apps/api/src/routes/contracts/contracts.test.ts
@@ -9,6 +9,14 @@ vi.mock('../../services/contractService', () => ({
   deleteDraftContract: vi.fn(),
   addContractLineToContract: vi.fn(),
   removeContractLine: vi.fn(),
+  updateContractLine: vi.fn(),
+  contractLineAuditDetails: vi.fn((audit: any) => ({
+    contractLineId: audit.contractLineId,
+    lineType: audit.lineType,
+    ...(audit.changedFields !== undefined ? { changedFields: audit.changedFields } : {}),
+    ...(audit.oldUnitPrice !== undefined ? { oldUnitPrice: audit.oldUnitPrice } : {}),
+    ...(audit.newUnitPrice !== undefined ? { newUnitPrice: audit.newUnitPrice } : {}),
+  })),
   activateContract: vi.fn(),
   pauseContract: vi.fn(),
   resumeContract: vi.fn(),
@@ -16,6 +24,12 @@ vi.mock('../../services/contractService', () => ({
   generateDueInvoice: vi.fn(),
   computeContractEstimate: vi.fn(),
   changeContractCurrency: vi.fn()
+}));
+
+// #3205 W03: the three line routes now audit. Stub the durable audit chain so
+// route tests assert the CALL, not the persistence path.
+vi.mock('../../services/auditEvents', () => ({
+  writeRouteAudit: vi.fn(),
 }));
 
 // Mock db context helpers used by /generate route.
@@ -61,6 +75,8 @@ vi.mock('../../middleware/auth', () => ({
 import { contractRoutes } from './index';
 import * as svc from '../../services/contractService';
 import { ContractServiceError } from '../../services/contractTypes';
+import { writeRouteAudit } from '../../services/auditEvents';
+import { contractLineRoutes } from './lines';
 
 function app() {
   // contractRoutes already applies authMiddleware internally
@@ -217,11 +233,161 @@ describe('contract line routes', () => {
     expect(svc.addContractLineToContract).not.toHaveBeenCalled();
   });
 
-  it('DELETE /:id/lines/:lineId removes a line', async () => {
-    (svc.removeContractLine as any).mockResolvedValue({ ok: true });
+  it('PATCH /:id/lines/:lineId forwards (contractId, lineId, patch, actor) and returns the line', async () => {
+    (svc.updateContractLine as any).mockResolvedValue({
+      line: { id: LINE_ID, description: 'Renamed', site: null, deviceGroup: null },
+      audit: { orgId: ORG_ID, contractId: CONTRACT_ID, contractName: 'Acme MSA', contractLineId: LINE_ID, lineType: 'flat', changedFields: ['description'] },
+    });
+    const res = await app().request(`/${CONTRACT_ID}/lines/${LINE_ID}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ description: 'Renamed' }),
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).data.description).toBe('Renamed');
+    expect(svc.updateContractLine).toHaveBeenCalledWith(CONTRACT_ID, LINE_ID, { description: 'Renamed' }, expect.anything());
+  });
+
+  it('PATCH rejects a body containing lineType, with no service call', async () => {
+    const res = await app().request(`/${CONTRACT_ID}/lines/${LINE_ID}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ description: 'Renamed', lineType: 'flat' }),
+    });
+    expect(res.status).toBe(400);
+    expect(svc.updateContractLine).not.toHaveBeenCalled();
+  });
+
+  it('PATCH rejects a non-GUID lineId param, with no service call', async () => {
+    const res = await app().request(`/${CONTRACT_ID}/lines/not-a-guid`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ description: 'Renamed' }),
+    });
+    expect(res.status).toBe(400);
+    expect(svc.updateContractLine).not.toHaveBeenCalled();
+  });
+
+  it('PATCH renders a ContractServiceError with code and details intact', async () => {
+    (svc.updateContractLine as any).mockRejectedValue(
+      new ContractServiceError('bad patch', 400, 'INVALID_LINE_PATCH', { issues: [{ path: 'siteId', message: 'nope' }] }),
+    );
+    const res = await app().request(`/${CONTRACT_ID}/lines/${LINE_ID}`, {
+      method: 'PATCH', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ siteId: null }),
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'bad patch', code: 'INVALID_LINE_PATCH', details: { issues: [{ path: 'siteId', message: 'nope' }] } });
+  });
+
+  it('PATCH maps a 409 INVALID_STATE through handleContractError', async () => {
+    (svc.updateContractLine as any).mockRejectedValue(new ContractServiceError('not editable', 409, 'INVALID_STATE'));
+    const res = await app().request(`/${CONTRACT_ID}/lines/${LINE_ID}`, {
+      method: 'PATCH', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ description: 'x' }),
+    });
+    expect(res.status).toBe(409);
+    expect((await res.json()).code).toBe('INVALID_STATE');
+  });
+
+  // ---- audit -------------------------------------------------------------
+  it('writes contract.line.updated once, against the CONTRACT id', async () => {
+    (svc.updateContractLine as any).mockResolvedValue({
+      line: { id: LINE_ID },
+      audit: { orgId: ORG_ID, contractId: CONTRACT_ID, contractName: 'Acme MSA', contractLineId: LINE_ID, lineType: 'flat', changedFields: ['unitPrice'], oldUnitPrice: '10.00', newUnitPrice: '12.00' },
+    });
+    await app().request(`/${CONTRACT_ID}/lines/${LINE_ID}`, {
+      method: 'PATCH', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ unitPrice: '12.00' }),
+    });
+    expect(writeRouteAudit).toHaveBeenCalledTimes(1);
+    expect((writeRouteAudit as any).mock.calls[0][1]).toEqual({
+      orgId: ORG_ID, action: 'contract.line.updated', resourceType: 'contract',
+      resourceId: CONTRACT_ID, resourceName: 'Acme MSA',
+      details: { contractLineId: LINE_ID, lineType: 'flat', changedFields: ['unitPrice'], oldUnitPrice: '10.00', newUnitPrice: '12.00' },
+    });
+  });
+
+  it('writes NO audit event when the service reports changedFields: []', async () => {
+    (svc.updateContractLine as any).mockResolvedValue({
+      line: { id: LINE_ID },
+      audit: { orgId: ORG_ID, contractId: CONTRACT_ID, contractName: 'Acme MSA', contractLineId: LINE_ID, lineType: 'flat', changedFields: [] },
+    });
+    const res = await app().request(`/${CONTRACT_ID}/lines/${LINE_ID}`, {
+      method: 'PATCH', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ description: 'same' }),
+    });
+    expect(res.status).toBe(200);
+    expect(writeRouteAudit).not.toHaveBeenCalled();
+  });
+
+  it('POST writes contract.line.added with the new price', async () => {
+    (svc.addContractLineToContract as any).mockResolvedValue({ id: LINE_ID, orgId: ORG_ID, lineType: 'flat', unitPrice: '150.00' });
+    await app().request(`/${CONTRACT_ID}/lines`, {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ lineType: 'flat', description: 'Monthly fee', unitPrice: '150.00', taxable: true }),
+    });
+    expect((writeRouteAudit as any).mock.calls[0][1]).toMatchObject({
+      action: 'contract.line.added', resourceType: 'contract', resourceId: CONTRACT_ID,
+      details: { contractLineId: LINE_ID, lineType: 'flat', newUnitPrice: '150.00' },
+    });
+  });
+
+  it('DELETE returns { ok: true } and writes contract.line.removed', async () => {
+    (svc.removeContractLine as any).mockResolvedValue({
+      orgId: ORG_ID, contractId: CONTRACT_ID, contractName: 'Acme MSA', contractLineId: LINE_ID, lineType: 'per_seat',
+    });
     const res = await app().request(`/${CONTRACT_ID}/lines/${LINE_ID}`, { method: 'DELETE' });
     expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ data: { ok: true } });
     expect(svc.removeContractLine).toHaveBeenCalledWith(CONTRACT_ID, LINE_ID, expect.anything());
+    expect((writeRouteAudit as any).mock.calls[0][1]).toMatchObject({
+      action: 'contract.line.removed', details: { contractLineId: LINE_ID, lineType: 'per_seat' },
+    });
+  });
+
+  it('DELETE returns 404 when the service throws LINE_NOT_FOUND', async () => {
+    (svc.removeContractLine as any).mockRejectedValue(new ContractServiceError('Contract line not found', 404, 'LINE_NOT_FOUND'));
+    const res = await app().request(`/${CONTRACT_ID}/lines/${LINE_ID}`, { method: 'DELETE' });
+    expect(res.status).toBe(404);
+    expect((await res.json()).code).toBe('LINE_NOT_FOUND');
+    expect(writeRouteAudit).not.toHaveBeenCalled();
+  });
+
+  // The suite stubs requirePermission, so a real 403 cannot be asserted here.
+  // What CAN be pinned is that PATCH is registered behind the same middleware
+  // chain as its siblings — scopes, writePerm, param validator (+ the json
+  // validator PATCH alone carries) — so it cannot ship unguarded.
+  it('PATCH is registered behind the same scope and permission middleware as DELETE, plus a body validator', () => {
+    const onPath = contractLineRoutes.routes.filter((r) => r.path === '/:id/lines/:lineId');
+    const patch = onPath.filter((r) => r.method === 'PATCH');
+    const del = onPath.filter((r) => r.method === 'DELETE');
+    expect(del.length).toBeGreaterThan(0);
+    expect(patch).toHaveLength(del.length + 1);
+  });
+
+  // Decision 6's no-free-text rule, enforced at the boundary that persists it.
+  it.each([
+    ['contract.line.added'],
+    ['contract.line.updated'],
+    ['contract.line.removed'],
+  ])('the %s details object carries no free text', async (action) => {
+    const AUDIT = { orgId: ORG_ID, contractId: CONTRACT_ID, contractName: 'Acme MSA', contractLineId: LINE_ID, lineType: 'flat' };
+    if (action === 'contract.line.added') {
+      (svc.addContractLineToContract as any).mockResolvedValue({ id: LINE_ID, orgId: ORG_ID, lineType: 'flat', unitPrice: '1.00' });
+      await app().request(`/${CONTRACT_ID}/lines`, {
+        method: 'POST', headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ lineType: 'flat', description: 'Secret name', unitPrice: '1.00', taxable: false }),
+      });
+    } else if (action === 'contract.line.updated') {
+      (svc.updateContractLine as any).mockResolvedValue({ line: { id: LINE_ID }, audit: { ...AUDIT, changedFields: ['description'] } });
+      await app().request(`/${CONTRACT_ID}/lines/${LINE_ID}`, {
+        method: 'PATCH', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ description: 'Secret name' }),
+      });
+    } else {
+      (svc.removeContractLine as any).mockResolvedValue(AUDIT);
+      await app().request(`/${CONTRACT_ID}/lines/${LINE_ID}`, { method: 'DELETE' });
+    }
+    const details = (writeRouteAudit as any).mock.calls[0][1].details as Record<string, unknown>;
+    const allowed = ['contractLineId', 'lineType', 'changedFields', 'oldUnitPrice', 'newUnitPrice'];
+    expect(Object.keys(details).every((k) => allowed.includes(k))).toBe(true);
+    expect(JSON.stringify(details)).not.toContain('Secret name');
   });
 });
 

--- a/apps/api/src/routes/contracts/contracts.test.ts
+++ b/apps/api/src/routes/contracts/contracts.test.ts
@@ -318,13 +318,16 @@ describe('contract line routes', () => {
   });
 
   it('POST writes contract.line.added with the new price', async () => {
-    (svc.addContractLineToContract as any).mockResolvedValue({ id: LINE_ID, orgId: ORG_ID, lineType: 'flat', unitPrice: '150.00' });
+    (svc.addContractLineToContract as any).mockResolvedValue({
+      id: LINE_ID, orgId: ORG_ID, lineType: 'flat', unitPrice: '150.00', contractName: 'Acme MSA',
+    });
     await app().request(`/${CONTRACT_ID}/lines`, {
       method: 'POST', headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ lineType: 'flat', description: 'Monthly fee', unitPrice: '150.00', taxable: true }),
     });
     expect((writeRouteAudit as any).mock.calls[0][1]).toMatchObject({
       action: 'contract.line.added', resourceType: 'contract', resourceId: CONTRACT_ID,
+      resourceName: 'Acme MSA',
       details: { contractLineId: LINE_ID, lineType: 'flat', newUnitPrice: '150.00' },
     });
   });

--- a/apps/api/src/routes/contracts/lines.ts
+++ b/apps/api/src/routes/contracts/lines.ts
@@ -48,9 +48,9 @@ const writeLineAudit = (c: AuditableContext, action: ContractLineAuditAction, a:
 contractLineRoutes.post('/:id/lines', scopes, writePerm, zValidator('param', idParam), zValidator('json', contractLineInputSchema), async (c) => {
   try {
     const contractId = c.req.valid('param').id;
-    const row = await addContractLineToContract(contractId, c.req.valid('json'), contractActorFrom(c));
+    const { contractName, ...row } = await addContractLineToContract(contractId, c.req.valid('json'), contractActorFrom(c));
     writeLineAudit(c, 'contract.line.added', {
-      orgId: row.orgId, contractId, contractLineId: row.id, lineType: row.lineType, newUnitPrice: row.unitPrice,
+      orgId: row.orgId, contractId, contractName, contractLineId: row.id, lineType: row.lineType, newUnitPrice: row.unitPrice,
     });
     return c.json({ data: row });
   }

--- a/apps/api/src/routes/contracts/lines.ts
+++ b/apps/api/src/routes/contracts/lines.ts
@@ -3,8 +3,15 @@ import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { requireScope, requirePermission } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';
-import { contractLineInputSchema } from '@breeze/shared';
-import { addContractLineToContract, removeContractLine } from '../../services/contractService';
+import { contractLineInputSchema, updateContractLineSchema } from '@breeze/shared';
+import {
+  addContractLineToContract,
+  contractLineAuditDetails,
+  removeContractLine,
+  updateContractLine,
+} from '../../services/contractService';
+import { writeRouteAudit } from '../../services/auditEvents';
+import type { ContractLineAudit } from '../../services/contractTypes';
 import { contractActorFrom, handleContractError } from './contracts';
 
 export const contractLineRoutes = new Hono();
@@ -13,11 +20,64 @@ const writePerm = requirePermission(PERMISSIONS.CONTRACTS_WRITE.resource, PERMIS
 const idParam = z.object({ id: z.string().guid() });
 const lineParam = z.object({ id: z.string().guid(), lineId: z.string().guid() });
 
+type AuditableContext = Parameters<typeof writeRouteAudit>[0];
+type ContractLineAuditAction = 'contract.line.added' | 'contract.line.removed' | 'contract.line.updated';
+
+/**
+ * #3205 W03: all three line mutations audit, through one helper so the call
+ * sites cannot drift. resourceType 'contract' with the CONTRACT id as
+ * resourceId (the line id lives in details), so filtering the audit log by a
+ * contract shows its whole line history together.
+ *
+ * NO FREE TEXT: only the line id, the lineType, the changed column NAMES and a
+ * numeric old/new unit price. No description, no site name, no group name.
+ * A no-op patch (changedFields: []) writes no event at all.
+ */
+const writeLineAudit = (c: AuditableContext, action: ContractLineAuditAction, a: ContractLineAudit): void => {
+  if (a.changedFields && a.changedFields.length === 0) return;
+  writeRouteAudit(c, {
+    orgId: a.orgId,
+    action,
+    resourceType: 'contract',
+    resourceId: a.contractId,
+    resourceName: a.contractName,
+    details: contractLineAuditDetails(a),
+  });
+};
+
 contractLineRoutes.post('/:id/lines', scopes, writePerm, zValidator('param', idParam), zValidator('json', contractLineInputSchema), async (c) => {
-  try { return c.json({ data: await addContractLineToContract(c.req.valid('param').id, c.req.valid('json'), contractActorFrom(c)) }); }
+  try {
+    const contractId = c.req.valid('param').id;
+    const row = await addContractLineToContract(contractId, c.req.valid('json'), contractActorFrom(c));
+    writeLineAudit(c, 'contract.line.added', {
+      orgId: row.orgId, contractId, contractLineId: row.id, lineType: row.lineType, newUnitPrice: row.unitPrice,
+    });
+    return c.json({ data: row });
+  }
   catch (err) { return handleContractError(c, err); }
 });
+
+// #3205 W03. Mount order needs no change: contractLineRoutes is registered
+// before contractCrudRoutes (routes/contracts/index.ts:19-20) and Hono matches
+// method+path, so PATCH /:id/lines/:lineId cannot shadow PATCH /:id.
+contractLineRoutes.patch('/:id/lines/:lineId', scopes, writePerm,
+  zValidator('param', lineParam), zValidator('json', updateContractLineSchema), async (c) => {
+  try {
+    const p = c.req.valid('param');
+    const { line, audit } = await updateContractLine(p.id, p.lineId, c.req.valid('json'), contractActorFrom(c));
+    writeLineAudit(c, 'contract.line.updated', audit);
+    return c.json({ data: line });
+  } catch (err) { return handleContractError(c, err); }
+});
+
 contractLineRoutes.delete('/:id/lines/:lineId', scopes, writePerm, zValidator('param', lineParam), async (c) => {
-  try { const p = c.req.valid('param'); return c.json({ data: await removeContractLine(p.id, p.lineId, contractActorFrom(c)) }); }
+  try {
+    const p = c.req.valid('param');
+    const audit = await removeContractLine(p.id, p.lineId, contractActorFrom(c));
+    writeLineAudit(c, 'contract.line.removed', audit);
+    // Was {"data":undefined} -> {} before W03; removeContractLine returns the
+    // pre-read audit payload now and 404s on a miss.
+    return c.json({ data: { ok: true } });
+  }
   catch (err) { return handleContractError(c, err); }
 });

--- a/apps/api/src/services/aiAgentSdkTools.ts
+++ b/apps/api/src/services/aiAgentSdkTools.ts
@@ -2419,6 +2419,7 @@ export function createBreezeMcpServer(
           'delete_draft',
           'add_line',
           'remove_line',
+          'update_line',
           'activate',
           'pause',
           'resume',

--- a/apps/api/src/services/aiGuardrails.ts
+++ b/apps/api/src/services/aiGuardrails.ts
@@ -642,6 +642,7 @@ export const TOOL_PERMISSIONS: Record<string, { resource: string; action: string
     delete_draft: { resource: 'contracts', action: 'write' },
     add_line: { resource: 'contracts', action: 'write' },
     remove_line: { resource: 'contracts', action: 'write' },
+    update_line: { resource: 'contracts', action: 'write' },
     activate: { resource: 'contracts', action: 'manage' },
     pause: { resource: 'contracts', action: 'manage' },
     resume: { resource: 'contracts', action: 'manage' },

--- a/apps/api/src/services/aiToolSchemas.ts
+++ b/apps/api/src/services/aiToolSchemas.ts
@@ -455,6 +455,7 @@ export const toolInputSchemas: Record<string, z.ZodType> = {
       'delete_draft',
       'add_line',
       'remove_line',
+      'update_line',
       'activate',
       'pause',
       'resume',

--- a/apps/api/src/services/aiToolsBilling.manageInvoices.test.ts
+++ b/apps/api/src/services/aiToolsBilling.manageInvoices.test.ts
@@ -82,6 +82,7 @@ function contractLineRow(
     unitPrice: '12.50',
     manualQuantity: null,
     siteId: null,
+    site: null,
     deviceRoles: null,
     deviceGroupId: null,
     deviceGroupName: null,

--- a/apps/api/src/services/aiToolsContracts.manageContracts.test.ts
+++ b/apps/api/src/services/aiToolsContracts.manageContracts.test.ts
@@ -32,7 +32,7 @@ vi.mock('./contractService', () => {
       audit: { orgId: 'org-1', contractId: 'contract-1', contractName: 'Acme MSA', contractLineId: 'line-1', lineType: 'flat', changedFields: ['description'] },
     }),
     deleteDraftContract: vi.fn().mockResolvedValue(undefined),
-    addContractLineToContract: vi.fn().mockResolvedValue({ id: 'line-1', contractId: 'contract-1', orgId: 'org-1', lineType: 'flat', unitPrice: '5.00' }),
+    addContractLineToContract: vi.fn().mockResolvedValue({ id: 'line-1', contractId: 'contract-1', orgId: 'org-1', lineType: 'flat', unitPrice: '5.00', contractName: 'Managed Services' }),
     removeContractLine: vi.fn().mockResolvedValue({ orgId: 'org-1', contractId: 'contract-1', contractName: 'Acme MSA', contractLineId: 'line-1', lineType: 'flat' }),
     contractLineAuditDetails: vi.fn((audit) => ({
       contractLineId: audit.contractLineId,
@@ -346,8 +346,11 @@ describe('manage_contracts update_line (#3205 W03)', () => {
   });
 
   it('add_line and remove_line audit too', async () => {
-    await run({ action: 'add_line', contractId: CONTRACT_ID, line: { lineType: 'flat', description: 'Fee', unitPrice: '5.00', taxable: false } });
-    expect(writeAuditEvent.mock.calls.at(-1)![1]).toMatchObject({ action: 'contract.line.added', initiatedBy: 'ai' });
+    const added = JSON.parse(await run({ action: 'add_line', contractId: CONTRACT_ID, line: { lineType: 'flat', description: 'Fee', unitPrice: '5.00', taxable: false } }));
+    // The audit-only contractName helper must feed resourceName and never reach the model.
+    expect(writeAuditEvent.mock.calls.at(-1)![1]).toMatchObject({ action: 'contract.line.added', initiatedBy: 'ai', resourceName: 'Managed Services' });
+    expect(added).not.toHaveProperty('contractName');
+    expect(added).toMatchObject({ id: 'line-1' });
     await run({ action: 'remove_line', contractId: CONTRACT_ID, lineId: LINE_ID });
     expect(writeAuditEvent.mock.calls.at(-1)![1]).toMatchObject({ action: 'contract.line.removed', initiatedBy: 'ai' });
   });

--- a/apps/api/src/services/aiToolsContracts.manageContracts.test.ts
+++ b/apps/api/src/services/aiToolsContracts.manageContracts.test.ts
@@ -1,11 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+// #3205 W03: the tool audits through the second door (writeAuditEvent +
+// requestLikeFromSnapshot), not writeRouteAudit — there is no Hono context here.
+const { writeAuditEvent } = vi.hoisted(() => ({ writeAuditEvent: vi.fn() }));
+vi.mock('./auditEvents', () => ({
+  writeAuditEvent,
+  requestLikeFromSnapshot: vi.fn(() => ({})),
+}));
+
 vi.mock('./contractService', () => {
   class ContractServiceError extends Error {
     constructor(
       message: string,
       public status: 400 | 403 | 404 | 409 | 500 = 400,
       public code?: string,
+      public details?: Record<string, unknown>,
     ) {
       super(message);
       this.name = 'ContractServiceError';
@@ -18,9 +27,20 @@ vi.mock('./contractService', () => {
     getContract: vi.fn(),
     createContract: vi.fn().mockResolvedValue({ id: 'contract-1', status: 'draft' }),
     updateContract: vi.fn().mockResolvedValue({ id: 'contract-1', name: 'Updated' }),
+    updateContractLine: vi.fn().mockResolvedValue({
+      line: { id: 'line-1', contractId: 'contract-1', description: 'Renamed' },
+      audit: { orgId: 'org-1', contractId: 'contract-1', contractName: 'Acme MSA', contractLineId: 'line-1', lineType: 'flat', changedFields: ['description'] },
+    }),
     deleteDraftContract: vi.fn().mockResolvedValue(undefined),
-    addContractLineToContract: vi.fn().mockResolvedValue({ id: 'line-1', contractId: 'contract-1' }),
-    removeContractLine: vi.fn().mockResolvedValue(undefined),
+    addContractLineToContract: vi.fn().mockResolvedValue({ id: 'line-1', contractId: 'contract-1', orgId: 'org-1', lineType: 'flat', unitPrice: '5.00' }),
+    removeContractLine: vi.fn().mockResolvedValue({ orgId: 'org-1', contractId: 'contract-1', contractName: 'Acme MSA', contractLineId: 'line-1', lineType: 'flat' }),
+    contractLineAuditDetails: vi.fn((audit) => ({
+      contractLineId: audit.contractLineId,
+      lineType: audit.lineType,
+      ...(audit.changedFields !== undefined ? { changedFields: audit.changedFields } : {}),
+      ...(audit.oldUnitPrice !== undefined ? { oldUnitPrice: audit.oldUnitPrice } : {}),
+      ...(audit.newUnitPrice !== undefined ? { newUnitPrice: audit.newUnitPrice } : {}),
+    })),
     activateContract: vi.fn().mockResolvedValue({ id: 'contract-1', status: 'active' }),
     pauseContract: vi.fn().mockResolvedValue({ id: 'contract-1', status: 'paused' }),
     resumeContract: vi.fn().mockResolvedValue({ id: 'contract-1', status: 'active' }),
@@ -119,7 +139,7 @@ describe('manage_contracts', () => {
       line,
       actor,
     );
-    expect(JSON.parse(out)).toEqual({ id: 'line-1', contractId: 'contract-1' });
+    expect(JSON.parse(out)).toMatchObject({ id: 'line-1', contractId: 'contract-1' });
   });
 
   it('remove_line calls removeContractLine with contractId, lineId, and actor', async () => {
@@ -230,7 +250,7 @@ describe('manage_contracts', () => {
     };
     const out = await getTool().handler({ action: 'add_line', contractId: 'contract-1', line }, auth);
     expect(contractService.addContractLineToContract).toHaveBeenCalledWith('contract-1', line, actor);
-    expect(JSON.parse(out)).toEqual({ id: 'line-1', contractId: 'contract-1' });
+    expect(JSON.parse(out)).toMatchObject({ id: 'line-1', contractId: 'contract-1' });
   });
 
   it('add_line with per_device_role but no deviceRoles returns VALIDATION_ERROR naming the field', async () => {
@@ -283,5 +303,71 @@ describe('manage_contracts', () => {
     for (const role of BILLABLE_DEVICE_ROLES) expect(desc).toContain(role);
     expect(desc.match(/unknown/g)).toHaveLength(1);
     expect(desc).toContain('never unknown');
+  });
+});
+
+describe('manage_contracts update_line (#3205 W03)', () => {
+  const CONTRACT_ID = '11111111-1111-4111-8111-111111111111';
+  const LINE_ID = '22222222-2222-4222-8222-222222222222';
+  const run = async (input: Record<string, unknown>) => getTool().handler(input, auth);
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it('requires contractId, lineId and patch before any coercion', async () => {
+    const missing = JSON.parse(await run({ action: 'update_line', contractId: CONTRACT_ID, patch: { description: 'x' } }));
+    expect(missing.code).toBe('VALIDATION_ERROR');
+    expect(JSON.stringify(missing)).toContain('lineId');
+    expect(contractService.updateContractLine).not.toHaveBeenCalled();
+  });
+
+  it('forwards the parsed patch and returns the line JSON', async () => {
+    const out = JSON.parse(await run({ action: 'update_line', contractId: CONTRACT_ID, lineId: LINE_ID, patch: { description: 'Renamed' } }));
+    expect(contractService.updateContractLine).toHaveBeenCalledWith(CONTRACT_ID, LINE_ID, { description: 'Renamed' }, actor);
+    expect(out).toMatchObject({ id: 'line-1', description: 'Renamed' });
+  });
+
+  // The payload parser wraps the value under its param name, so a ZodError path
+  // reads `patch.lineType` rather than a bare `lineType`.
+  it('rejects a patch containing lineType with a VALIDATION_ERROR naming patch.lineType', async () => {
+    const out = JSON.parse(await run({ action: 'update_line', contractId: CONTRACT_ID, lineId: LINE_ID, patch: { description: 'x', lineType: 'flat' } }));
+    expect(out.code).toBe('VALIDATION_ERROR');
+    expect(JSON.stringify(out)).toContain('patch');
+    expect(contractService.updateContractLine).not.toHaveBeenCalled();
+  });
+
+  it('writes the audit with tool_name manage_contracts and initiatedBy ai', async () => {
+    await run({ action: 'update_line', contractId: CONTRACT_ID, lineId: LINE_ID, patch: { description: 'Renamed' } });
+    expect(writeAuditEvent).toHaveBeenCalledTimes(1);
+    expect(writeAuditEvent.mock.calls[0]![1]).toMatchObject({
+      orgId: 'org-1', action: 'contract.line.updated', resourceType: 'contract', resourceId: 'contract-1',
+      initiatedBy: 'ai',
+      details: { contractLineId: 'line-1', lineType: 'flat', changedFields: ['description'], tool_name: 'manage_contracts' },
+    });
+  });
+
+  it('add_line and remove_line audit too', async () => {
+    await run({ action: 'add_line', contractId: CONTRACT_ID, line: { lineType: 'flat', description: 'Fee', unitPrice: '5.00', taxable: false } });
+    expect(writeAuditEvent.mock.calls.at(-1)![1]).toMatchObject({ action: 'contract.line.added', initiatedBy: 'ai' });
+    await run({ action: 'remove_line', contractId: CONTRACT_ID, lineId: LINE_ID });
+    expect(writeAuditEvent.mock.calls.at(-1)![1]).toMatchObject({ action: 'contract.line.removed', initiatedBy: 'ai' });
+  });
+
+  // Without this a model told "those changes aren't valid" has nothing to
+  // self-correct against.
+  it('surfaces ContractServiceError details in the JSON error', async () => {
+    (contractService.updateContractLine as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new ContractServiceError('bad patch', 400, 'INVALID_LINE_PATCH', { issues: [{ path: 'siteId', message: 'nope' }] }),
+    );
+    const out = JSON.parse(await run({ action: 'update_line', contractId: CONTRACT_ID, lineId: LINE_ID, patch: { siteId: null } }));
+    expect(out).toEqual({ error: 'bad patch', code: 'INVALID_LINE_PATCH', details: { issues: [{ path: 'siteId', message: 'nope' }] } });
+  });
+
+  it('the tool description explains the tri-state catalogItemId and the locked lineType', () => {
+    const props = getTool().definition.input_schema.properties as Record<string, { description?: string; enum?: string[] }>;
+    expect(props.action!.enum).toContain('update_line');
+    const desc = props.patch!.description!;
+    expect(desc).toContain('lineType');
+    expect(desc).toContain('refreshCatalogPrice');
+    expect(desc).toMatch(/future billing periods/i);
   });
 });

--- a/apps/api/src/services/aiToolsContracts.registryParity.contract.test.ts
+++ b/apps/api/src/services/aiToolsContracts.registryParity.contract.test.ts
@@ -1,0 +1,97 @@
+/**
+ * #3205 W03: `manage_contracts` has FOUR registration sites, and an action
+ * present in fewer than four is either invisible or FAIL-CLOSED DENIED:
+ *
+ *   1. aiToolsContracts.ts definition enum + MANAGE_CONTRACTS_REQUIRED + switch
+ *   2. aiToolSchemas.ts toolInputSchemas.manage_contracts.action
+ *   3. aiAgentSdkTools.ts tool('manage_contracts', …) action enum
+ *   4. aiGuardrails.ts TOOL_PERMISSIONS.manage_contracts
+ *
+ * Site 4 is the dangerous one: a missing entry denies with
+ * `Unknown action "<x>" for tool "manage_contracts"` (aiGuardrails.ts:1861-1870),
+ * which reads like a permissions bug rather than a registration bug.
+ *
+ * Table-driven over EVERY action, so the next one cannot drift either. Site 3's
+ * enum lives inside a tool() factory call and is not importable, so it is read
+ * from the source text — the extractor throws rather than silently matching
+ * nothing if that block is restructured.
+ *
+ * NOTE: no vi.mock — this suite needs the REAL registries, same rationale as
+ * aiGuardrails.readonly.contract.test.ts and aiAgentSdkTools.registryParity.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+import { registerContractTools } from './aiToolsContracts';
+import { toolInputSchemas } from './aiToolSchemas';
+import { TOOL_PERMISSIONS, requiredPermissionsForTool } from './aiGuardrails';
+import type { AiTool } from './aiTools';
+
+function definitionActions(): string[] {
+  const map = new Map<string, AiTool>();
+  registerContractTools(map);
+  const tool = map.get('manage_contracts');
+  if (!tool) throw new Error('manage_contracts is not registered');
+  const props = tool.definition.input_schema.properties as Record<string, { enum?: string[] }>;
+  const actions = props.action?.enum;
+  if (!actions) throw new Error('manage_contracts definition has no action enum');
+  return actions;
+}
+
+function centralSchemaActions(): string[] {
+  const schema = toolInputSchemas.manage_contracts as unknown as {
+    shape: { action: { options: readonly string[] } };
+  };
+  return [...schema.shape.action.options];
+}
+
+function sdkActions(): string[] {
+  const src = readFileSync(new URL('./aiAgentSdkTools.ts', import.meta.url), 'utf8');
+  const toolStart = src.indexOf("      'manage_contracts',");
+  if (toolStart < 0) throw new Error("tool('manage_contracts', …) block not found in aiAgentSdkTools.ts");
+  const enumStart = src.indexOf('action: z.enum([', toolStart);
+  const enumEnd = src.indexOf(']),', enumStart);
+  if (enumStart < 0 || enumEnd < 0) throw new Error('manage_contracts action enum not found in aiAgentSdkTools.ts');
+  return [...src.slice(enumStart, enumEnd).matchAll(/'([a-z_]+)'/g)].map((m) => m[1]!);
+}
+
+function guardrailActions(): string[] {
+  const entry = TOOL_PERMISSIONS.manage_contracts as Record<string, { resource: string; action: string }>;
+  return Object.keys(entry);
+}
+
+const ACTIONS = definitionActions();
+
+describe('manage_contracts four-site registry parity (#3205 W03)', () => {
+  it('registers update_line', () => {
+    expect(ACTIONS).toContain('update_line');
+  });
+
+  it.each(ACTIONS)('%s is present at every one of the four sites', (action) => {
+    expect(centralSchemaActions()).toContain(action);
+    expect(sdkActions()).toContain(action);
+    expect(guardrailActions()).toContain(action);
+  });
+
+  it.each([
+    ['central schema', centralSchemaActions],
+    ['SDK tool enum', sdkActions],
+    ['guardrail permissions', guardrailActions],
+  ])('%s advertises no action the tool cannot dispatch', (_name, read) => {
+    expect([...read()].sort()).toEqual([...ACTIONS].sort());
+  });
+
+  it('update_line resolves to contracts:write, not contracts:manage', () => {
+    const entry = TOOL_PERMISSIONS.manage_contracts as Record<string, { resource: string; action: string }>;
+    expect(entry.update_line).toEqual({ resource: 'contracts', action: 'write' });
+    expect(requiredPermissionsForTool('manage_contracts', { action: 'update_line' }))
+      .toEqual([{ resource: 'contracts', action: 'write' }]);
+  });
+
+  // The fail-closed path site 4 protects: an action with no TOOL_PERMISSIONS
+  // entry resolves to no requirements at all and is denied with
+  // `Unknown action "<x>" for tool "manage_contracts"` (aiGuardrails.ts:1861-1870).
+  it('denies an action that is not registered in TOOL_PERMISSIONS', () => {
+    expect(requiredPermissionsForTool('manage_contracts', { action: 'invented_action' })).toBeNull();
+  });
+});

--- a/apps/api/src/services/aiToolsContracts.test.ts
+++ b/apps/api/src/services/aiToolsContracts.test.ts
@@ -5,6 +5,7 @@ vi.mock('./contractService', () => ({
   getContract: vi.fn(),
   createContract: vi.fn(),
   updateContract: vi.fn(),
+  updateContractLine: vi.fn(),
   deleteDraftContract: vi.fn(),
   addContractLineToContract: vi.fn(),
   removeContractLine: vi.fn(),
@@ -12,10 +13,34 @@ vi.mock('./contractService', () => ({
   pauseContract: vi.fn(),
   resumeContract: vi.fn(),
   cancelContract: vi.fn(),
+  contractLineAuditDetails: vi.fn(),
 }));
 
 import { registerContractTools } from './aiToolsContracts';
+import { getContract } from './contractService';
 import type { AiTool } from './aiTools';
+import type { AuthContext } from '../middleware/auth';
+
+const auth: AuthContext = {
+  principal: { kind: 'user_session' },
+  user: { id: 'u-1', email: 'user@example.test', name: 'User', isPlatformAdmin: false },
+  token: {
+    sub: 'u-1',
+    email: 'user@example.test',
+    roleId: null,
+    orgId: null,
+    partnerId: 'p-1',
+    scope: 'partner',
+    type: 'access',
+    mfa: true,
+  },
+  partnerId: 'p-1',
+  orgId: null,
+  scope: 'partner',
+  accessibleOrgIds: ['org-1'],
+  orgCondition: () => undefined,
+  canAccessOrg: (orgId) => orgId === 'org-1',
+};
 
 function getTool(name: 'list_contracts' | 'get_contract' | 'manage_contracts'): AiTool {
   const tools = new Map<string, AiTool>();
@@ -35,5 +60,20 @@ describe('contract tool currency descriptions', () => {
 
   it('manage_contracts documents contract line prices and totals in currencyCode', () => {
     expect(getTool('manage_contracts').definition.description).toContain('currencyCode');
+  });
+});
+
+describe('get_contract line shape (#3205 W03)', () => {
+  it('passes the decorated site and deviceGroup through to the model', async () => {
+    const decorated = {
+      id: 'l1', lineType: 'per_device', description: 'Managed device', unitPrice: '10.00',
+      siteId: 'site-1', site: { id: 'site-1', name: 'HQ' },
+      deviceGroupId: null, deviceGroupName: null, deviceGroup: null,
+    };
+    (getContract as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      contract: { id: 'ct-1', currencyCode: 'USD' }, lines: [decorated], periods: [],
+    });
+    const out = JSON.parse(await getTool('get_contract').handler({ contractId: 'ct-1' }, auth));
+    expect(out.lines[0]).toMatchObject({ site: { id: 'site-1', name: 'HQ' }, deviceGroup: null });
   });
 });

--- a/apps/api/src/services/aiToolsContracts.ts
+++ b/apps/api/src/services/aiToolsContracts.ts
@@ -19,7 +19,7 @@
  */
 
 import { z } from 'zod';
-import { BILLABLE_DEVICE_ROLES, createContractSchema, updateContractSchema, contractLineInputSchema } from '@breeze/shared';
+import { BILLABLE_DEVICE_ROLES, createContractSchema, updateContractSchema, contractLineInputSchema, updateContractLineSchema } from '@breeze/shared';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool, AiToolTier } from './aiTools';
 import {
@@ -27,16 +27,19 @@ import {
   getContract,
   createContract,
   updateContract,
+  updateContractLine,
   deleteDraftContract,
   addContractLineToContract,
   removeContractLine,
+  contractLineAuditDetails,
   activateContract,
   pauseContract,
   resumeContract,
   cancelContract
 } from './contractService';
-import { ContractServiceError, type ContractActor } from './contractTypes';
+import { ContractServiceError, type ContractActor, type ContractLineAudit } from './contractTypes';
 import { missingParamsJson, zodErrorToJson } from './aiToolValidation';
+import { writeAuditEvent, requestLikeFromSnapshot } from './auditEvents';
 
 /**
  * Params each manage_contracts action requires, presence-checked BEFORE any
@@ -49,6 +52,7 @@ const MANAGE_CONTRACTS_REQUIRED: Record<string, readonly string[]> = {
   delete_draft: ['contractId'],
   add_line: ['contractId', 'line'],
   remove_line: ['contractId', 'lineId'],
+  update_line: ['contractId', 'lineId', 'patch'],
   activate: ['contractId'],
   pause: ['contractId'],
   resume: ['contractId'],
@@ -65,7 +69,10 @@ function actorFromAuth(auth: AuthContext): ContractActor {
 
 function serviceErrorToJson(err: unknown): string | null {
   if (err instanceof ContractServiceError) {
-    return JSON.stringify({ error: err.message, code: err.code });
+    // #3205 W03: HTTP returns `details` verbatim (routes/contracts/contracts.ts
+    // :50-57) while this door dropped it. A model that trips INVALID_LINE_PATCH
+    // and is told only "those changes aren't valid" cannot self-correct.
+    return JSON.stringify({ error: err.message, code: err.code, ...(err.details ? { details: err.details } : {}) });
   }
   return null;
 }
@@ -80,6 +87,39 @@ function serviceErrorToJson(err: unknown): string | null {
 const createPayload = z.object({ input: createContractSchema });
 const patchPayload = z.object({ patch: updateContractSchema });
 const linePayload = z.object({ line: contractLineInputSchema });
+const lineUpdatePayload = z.object({ patch: updateContractLineSchema });
+
+/** Best-effort audit write for the AI door (#3205 W03). Never blocks the tool
+ *  result. initiatedBy 'ai' is an explicit value of the initiated_by_type enum
+ *  (db/schema/audit.ts:14) and writeAuditEventAsync honours it over its
+ *  actor-type inference (auditEvents.ts:73-74). Same no-free-text payload as
+ *  the HTTP door. */
+function auditContractLineToolEvent(
+  auth: AuthContext,
+  action: 'contract.line.added' | 'contract.line.removed' | 'contract.line.updated',
+  audit: ContractLineAudit,
+): void {
+  if (audit.changedFields && audit.changedFields.length === 0) return;
+  try {
+    writeAuditEvent(requestLikeFromSnapshot({}), {
+      orgId: audit.orgId,
+      actorId: auth.user.id,
+      actorEmail: auth.user.email,
+      action,
+      resourceType: 'contract',
+      resourceId: audit.contractId,
+      resourceName: audit.contractName,
+      result: 'success',
+      initiatedBy: 'ai',
+      details: {
+        ...contractLineAuditDetails(audit),
+        tool_name: 'manage_contracts',
+      },
+    });
+  } catch (err) {
+    console.error('[manage_contracts] audit write failed', err);
+  }
+}
 
 export function registerContractTools(aiTools: Map<string, AiTool>): void {
   aiTools.set('list_contracts', {
@@ -172,6 +212,7 @@ export function registerContractTools(aiTools: Map<string, AiTool>): void {
               'delete_draft',
               'add_line',
               'remove_line',
+              'update_line',
               'activate',
               'pause',
               'resume',
@@ -181,7 +222,21 @@ export function registerContractTools(aiTools: Map<string, AiTool>): void {
           contractId: { type: 'string', description: 'Contract UUID' },
           lineId: { type: 'string', description: 'Contract line UUID' },
           input: { type: 'object', description: 'Full create-contract payload including orgId, name, and schedule fields' },
-          patch: { type: 'object', description: 'Contract update patch fields' },
+          patch: {
+            type: 'object',
+            description:
+              'For action "update": contract header fields. For action "update_line": the line patch. ' +
+              'update_line edits one line in place, keeping its id (and therefore its invoice lineage). ' +
+              'Every field of a line is editable EXCEPT lineType — sending lineType is rejected; to change the ' +
+              'type, remove_line then add_line. catalogItemId is three-valued: leave it out to keep the current ' +
+              'link AND the current stamped price, send a DIFFERENT item id to re-link and re-resolve price and ' +
+              'taxable in the contract\'s currency (any unitPrice/taxable you send is ignored), or send null to ' +
+              'unlink — which requires unitPrice AND taxable in the same call. Sending the item id the line ' +
+              'already has changes nothing; to re-price an unchanged link, send refreshCatalogPrice: true. ' +
+              'siteId accepts null to widen a site-scoped line to the whole org. Lines are only editable on ' +
+              'draft and active contracts. Edits apply to future billing periods; invoices already generated ' +
+              'are unchanged.',
+          },
           line: {
             type: 'object',
             description:
@@ -231,15 +286,31 @@ export function registerContractTools(aiTools: Map<string, AiTool>): void {
           case 'delete_draft':
             await deleteDraftContract(String(input.contractId), actor);
             return JSON.stringify({ ok: true });
-          case 'add_line':
-            return JSON.stringify(await addContractLineToContract(
+          case 'add_line': {
+            const row = await addContractLineToContract(
               String(input.contractId),
               linePayload.parse({ line: input.line }).line,
               actor
-            ));
-          case 'remove_line':
-            await removeContractLine(String(input.contractId), String(input.lineId), actor);
+            );
+            auditContractLineToolEvent(auth, 'contract.line.added', {
+              orgId: row.orgId, contractId: String(input.contractId),
+              contractLineId: row.id, lineType: row.lineType, newUnitPrice: row.unitPrice,
+            });
+            return JSON.stringify(row);
+          }
+          case 'remove_line': {
+            const audit = await removeContractLine(String(input.contractId), String(input.lineId), actor);
+            auditContractLineToolEvent(auth, 'contract.line.removed', audit);
             return JSON.stringify({ ok: true });
+          }
+          case 'update_line': {
+            const { line, audit } = await updateContractLine(
+              String(input.contractId), String(input.lineId),
+              lineUpdatePayload.parse({ patch: input.patch }).patch, actor,
+            );
+            auditContractLineToolEvent(auth, 'contract.line.updated', audit);
+            return JSON.stringify(line);
+          }
           case 'activate':
             return JSON.stringify(await activateContract(String(input.contractId), actor));
           case 'pause':

--- a/apps/api/src/services/aiToolsContracts.ts
+++ b/apps/api/src/services/aiToolsContracts.ts
@@ -287,13 +287,15 @@ export function registerContractTools(aiTools: Map<string, AiTool>): void {
             await deleteDraftContract(String(input.contractId), actor);
             return JSON.stringify({ ok: true });
           case 'add_line': {
-            const row = await addContractLineToContract(
+            // contractName is an audit-only helper on the service result: it feeds
+            // resourceName and never reaches the model (mirrors routes/contracts/lines.ts).
+            const { contractName, ...row } = await addContractLineToContract(
               String(input.contractId),
               linePayload.parse({ line: input.line }).line,
               actor
             );
             auditContractLineToolEvent(auth, 'contract.line.added', {
-              orgId: row.orgId, contractId: String(input.contractId),
+              orgId: row.orgId, contractId: String(input.contractId), contractName,
               contractLineId: row.id, lineType: row.lineType, newUnitPrice: row.unitPrice,
             });
             return JSON.stringify(row);

--- a/apps/api/src/services/contractService.test.ts
+++ b/apps/api/src/services/contractService.test.ts
@@ -192,6 +192,16 @@ describe('changeContractCurrency reprice (price-book reprice of catalog lines, #
     ).rejects.toMatchObject({ code: 'NO_PRICE_FOR_CURRENCY', status: 409, message: expect.stringContaining('Managed endpoint') });
     expect((db as unknown as Chain).set.mock.calls.length).toBe(0);
   });
+
+  it('maps a missing catalog item to CATALOG_ITEM_NOT_FOUND (400)', async () => {
+    queueResult([draft]);
+    queueResult([{ id: 'l1', catalogItemId: 'missing-cat' }]);
+    resolvePriceMock.mockRejectedValueOnce(new CatalogServiceError('Catalog item not found', 404, 'ITEM_NOT_FOUND'));
+    await expect(
+      svc.changeContractCurrency('c1', { currencyCode: 'EUR', reprice: true }, actor)
+    ).rejects.toMatchObject({ code: 'CATALOG_ITEM_NOT_FOUND', status: 400 });
+    expect((db as unknown as Chain).set.mock.calls.length).toBe(0);
+  });
 });
 
 // #3774 phantom-line race: contract line writers must take the contract row

--- a/apps/api/src/services/contractService.test.ts
+++ b/apps/api/src/services/contractService.test.ts
@@ -57,6 +57,7 @@ vi.mock('./catalogPricing', async (importOriginal) => {
 
 import * as svc from './contractService';
 import { db } from '../db';
+import { contractLines } from '../db/schema';
 import { resolvePrice, CatalogServiceError } from './catalogService';
 import { resolvePriceFrom } from './catalogPricing';
 import { createManualInvoice, addContractLine } from './invoiceService';
@@ -65,7 +66,13 @@ import { GroupEvaluationError } from './groupMembership';
 
 const resolvePriceMock = vi.mocked(resolvePrice);
 
-type Chain = { set: { mock: { calls: unknown[][] } }; delete: { mock: { calls: unknown[][] } } };
+type Chain = {
+  set: { mock: { calls: unknown[][] } };
+  delete: { mock: { calls: unknown[][] } };
+  update: { mock: { calls: unknown[][] } };
+  limit: { mock: { calls: unknown[][] } };
+  for: { mock: { calls: unknown[][] } };
+};
 
 const actor = { userId: 'u1', partnerId: 'p1', accessibleOrgIds: ['org1'] };
 
@@ -285,6 +292,7 @@ describe('contract line writers lock the contract row first (#3774)', () => {
 
   it('removeContractLine locks the contract row FOR UPDATE before deleting', async () => {
     queueResult([{ id: 'c1', status: 'active', orgId: 'org1', partnerId: 'p1', currencyCode: 'USD' }]); // lockContract (active is line-editable)
+    queueResult([{ id: 'l1', lineType: 'flat' }]); // pre-delete audit read
     queueResult([]); // delete (unused result)
 
     await svc.removeContractLine('c1', 'l1', actor);
@@ -330,6 +338,20 @@ describe('catalog contract lines price through the resolver (#3775)', () => {
         lineType: 'flat', description: 'Managed endpoint', taxable: false, catalogItemId: 'cat-1',
       } as never, actor)
     ).rejects.toMatchObject({ code: 'NO_PRICE_FOR_CURRENCY', status: 409 });
+    expect((db as unknown as ValuesChain).values.mock.calls.length).toBe(0);
+  });
+
+  it('addContractLineToContract maps ITEM_NOT_FOUND to non-enumerating CATALOG_ITEM_NOT_FOUND (400) and inserts nothing', async () => {
+    resolvePriceMock.mockRejectedValue(new CatalogServiceError('Catalog item cat-secret not found', 404, 'ITEM_NOT_FOUND'));
+    queueResult([{ id: 'c1', status: 'draft', orgId: 'org1', partnerId: 'p1', currencyCode: 'EUR' }]); // lockContract
+    await expect(
+      svc.addContractLineToContract('c1', {
+        lineType: 'flat', description: 'Managed endpoint', taxable: false, catalogItemId: 'cat-secret',
+      } as never, actor)
+    ).rejects.toMatchObject({
+      code: 'CATALOG_ITEM_NOT_FOUND', status: 400,
+      message: 'That catalog item is not available on this contract',
+    });
     expect((db as unknown as ValuesChain).values.mock.calls.length).toBe(0);
   });
 
@@ -1062,5 +1084,325 @@ describe('per_device_group quantities (#3205 W02)', () => {
 
     expect(out.has('org1')).toBe(false);
     expect(warn).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #3205 W03 — contract line editing.
+// The db mock is a single chain whose `then` shifts the next queued result, so
+// every awaited query consumes one queueResult() in call order. updateContractLine
+// issues, in order: lockContract SELECT, the line SELECT, [resolvePrice is mocked,
+// not queued], [assertSiteInOrg / assertGroupInOrg SELECTs when reached], UPDATE.
+// ---------------------------------------------------------------------------
+describe('updateContractLine (#3205 W03)', () => {
+  const CONTRACT = { id: 'c1', orgId: 'org1', partnerId: 'p1', name: 'Acme MSA', status: 'draft', currencyCode: 'USD' };
+  const CATALOG_A = '55555555-5555-4555-8555-555555555555';
+  const CATALOG_B = '66666666-6666-4666-8666-666666666666';
+  const SITE_B = '77777777-7777-4777-8777-777777777777';
+  const GROUP_B = '88888888-8888-4888-8888-888888888888';
+  const line = (over: Record<string, unknown> = {}) => ({
+    id: 'l1', contractId: 'c1', orgId: 'org1', lineType: 'per_device', description: 'Managed device',
+    catalogItemId: null, unitPrice: '10.00', manualQuantity: null, siteId: null, deviceRoles: null,
+    deviceGroupId: null, deviceGroupName: null, taxable: true, sortOrder: 0,
+    createdAt: new Date('2026-06-01T00:00:00Z'), ...over,
+  });
+  const setArgs = () => (db as unknown as Chain).set.mock.calls.at(-1)?.[0] as Record<string, unknown> | undefined;
+
+  beforeEach(() => { results.length = 0; vi.clearAllMocks(); });
+
+  it('locks the contract before reading the line', async () => {
+    // The line has no siteId and no deviceGroupId, so withLineRefs issues no
+    // extra query and three queued results are exactly what is consumed.
+    queueResult([CONTRACT]); queueResult([line()]); queueResult([line({ description: 'Renamed' })]);
+    await svc.updateContractLine('c1', 'l1', { description: 'Renamed' } as never, actor);
+    expect((db as unknown as Chain).for.mock.calls[0]).toEqual(['update']);
+  });
+
+  it.each(['paused', 'cancelled', 'expired'])('rejects a %s contract with INVALID_STATE (409)', async (status) => {
+    queueResult([{ ...CONTRACT, status }]);
+    await expect(svc.updateContractLine('c1', 'l1', { description: 'x' } as never, actor))
+      .rejects.toMatchObject({ code: 'INVALID_STATE', status: 409 });
+  });
+
+  it('throws LINE_NOT_FOUND (404) when the line is not on this contract', async () => {
+    queueResult([CONTRACT]); queueResult([]);
+    await expect(svc.updateContractLine('c1', 'l1', { description: 'x' } as never, actor))
+      .rejects.toMatchObject({ code: 'LINE_NOT_FOUND', status: 404 });
+  });
+
+  it('throws ORG_DENIED (403) for an inaccessible org', async () => {
+    queueResult([{ ...CONTRACT, orgId: 'other-org' }]);
+    await expect(svc.updateContractLine('c1', 'l1', { description: 'x' } as never, actor))
+      .rejects.toMatchObject({ code: 'ORG_DENIED', status: 403 });
+  });
+
+  // ---- catalog transition table, one test per row -------------------------
+  it('row 1: unlinked, link untouched — the client price is written', async () => {
+    queueResult([CONTRACT]); queueResult([line()]); queueResult([line({ unitPrice: '12.50' })]);
+    await svc.updateContractLine('c1', 'l1', { unitPrice: '12.50' } as never, actor);
+    expect(resolvePriceMock).not.toHaveBeenCalled();
+    expect(setArgs()).toMatchObject({ unitPrice: '12.50', catalogItemId: null });
+  });
+
+  it('row 2: linked, link untouched — no reprice and the client price is ignored', async () => {
+    queueResult([CONTRACT]); queueResult([line({ catalogItemId: CATALOG_A, unitPrice: '20.00' })]);
+    queueResult([line({ catalogItemId: CATALOG_A, unitPrice: '20.00', description: 'Renamed' })]);
+    await svc.updateContractLine('c1', 'l1', { description: 'Renamed', unitPrice: '1.00' } as never, actor);
+    expect(resolvePriceMock).not.toHaveBeenCalled();
+    expect(setArgs()).toMatchObject({ unitPrice: '20.00', description: 'Renamed' });
+  });
+
+  it('row 3: manual -> catalog re-resolves and ignores a client price in the same patch', async () => {
+    resolvePriceMock.mockResolvedValueOnce({ unitPrice: '7.25', taxable: false } as never);
+    queueResult([CONTRACT]); queueResult([line()]); queueResult([line({ catalogItemId: CATALOG_A, unitPrice: '7.25' })]);
+    await svc.updateContractLine('c1', 'l1', { catalogItemId: CATALOG_A, unitPrice: '1.00' } as never, actor);
+    expect(resolvePriceMock).toHaveBeenCalledWith(
+      CATALOG_A, 'USD', 'org1',
+      { userId: 'u1', partnerId: 'p1', accessibleOrgIds: ['org1'] },
+      expect.anything(),
+    );
+    expect(setArgs()).toMatchObject({ unitPrice: '7.25', taxable: false, catalogItemId: CATALOG_A });
+  });
+
+  it('row 4: the SAME catalog id is idempotent — no resolve, no price move', async () => {
+    queueResult([CONTRACT]); queueResult([line({ catalogItemId: CATALOG_A, unitPrice: '20.00' })]);
+    queueResult([line({ catalogItemId: CATALOG_A, unitPrice: '20.00' })]);
+    await svc.updateContractLine('c1', 'l1', { catalogItemId: CATALOG_A } as never, actor);
+    expect(resolvePriceMock).not.toHaveBeenCalled();
+    expect(setArgs()).toMatchObject({ unitPrice: '20.00', catalogItemId: CATALOG_A });
+  });
+
+  it('row 5: a DIFFERENT catalog id re-resolves against the new item', async () => {
+    resolvePriceMock.mockResolvedValueOnce({ unitPrice: '9.00', taxable: true } as never);
+    queueResult([CONTRACT]); queueResult([line({ catalogItemId: CATALOG_A, unitPrice: '20.00' })]);
+    queueResult([line({ catalogItemId: CATALOG_B, unitPrice: '9.00' })]);
+    await svc.updateContractLine('c1', 'l1', { catalogItemId: CATALOG_B } as never, actor);
+    expect(resolvePriceMock).toHaveBeenCalledWith(CATALOG_B, 'USD', 'org1', expect.anything(), expect.anything());
+    expect(setArgs()).toMatchObject({ unitPrice: '9.00', catalogItemId: CATALOG_B });
+  });
+
+  it('row 6a: unlink without unitPrice is 400 INVALID_LINE_PATCH', async () => {
+    queueResult([CONTRACT]); queueResult([line({ catalogItemId: CATALOG_A })]);
+    await expect(svc.updateContractLine('c1', 'l1', { catalogItemId: null, taxable: true } as never, actor))
+      .rejects.toMatchObject({ code: 'INVALID_LINE_PATCH', status: 400 });
+  });
+
+  it('row 6b: unlink without taxable is 400 INVALID_LINE_PATCH', async () => {
+    queueResult([CONTRACT]); queueResult([line({ catalogItemId: CATALOG_A })]);
+    await expect(svc.updateContractLine('c1', 'l1', { catalogItemId: null, unitPrice: '3.00' } as never, actor))
+      .rejects.toMatchObject({ code: 'INVALID_LINE_PATCH', status: 400 });
+  });
+
+  it('row 6c: unlink with both writes the hand-entered price and clears the link', async () => {
+    queueResult([CONTRACT]); queueResult([line({ catalogItemId: CATALOG_A, unitPrice: '20.00' })]);
+    queueResult([line({ catalogItemId: null, unitPrice: '3.00' })]);
+    await svc.updateContractLine('c1', 'l1', { catalogItemId: null, unitPrice: '3.00', taxable: false } as never, actor);
+    expect(setArgs()).toMatchObject({ catalogItemId: null, unitPrice: '3.00', taxable: false });
+  });
+
+  it('row 7: null on an already-unlinked line imposes no price requirement and still applies siblings', async () => {
+    queueResult([CONTRACT]); queueResult([line()]); queueResult([line({ description: 'Renamed' })]);
+    await svc.updateContractLine('c1', 'l1', { catalogItemId: null, description: 'Renamed' } as never, actor);
+    expect(setArgs()).toMatchObject({ catalogItemId: null, description: 'Renamed' });
+  });
+
+  it('refreshCatalogPrice re-resolves a linked row and is 400 on an unlinked one', async () => {
+    resolvePriceMock.mockResolvedValueOnce({ unitPrice: '11.00', taxable: true } as never);
+    queueResult([CONTRACT]); queueResult([line({ catalogItemId: CATALOG_A, unitPrice: '20.00' })]);
+    queueResult([line({ catalogItemId: CATALOG_A, unitPrice: '11.00' })]);
+    await svc.updateContractLine('c1', 'l1', { refreshCatalogPrice: true } as never, actor);
+    expect(setArgs()).toMatchObject({ unitPrice: '11.00' });
+
+    results.length = 0;
+    queueResult([CONTRACT]); queueResult([line()]);
+    await expect(svc.updateContractLine('c1', 'l1', { refreshCatalogPrice: true } as never, actor))
+      .rejects.toMatchObject({ code: 'INVALID_LINE_PATCH', status: 400, details: { issues: [{ path: 'refreshCatalogPrice' }] } });
+  });
+
+  it('refreshCatalogPrice combined with catalogItemId null is the same 400', async () => {
+    queueResult([CONTRACT]); queueResult([line({ catalogItemId: CATALOG_A })]);
+    await expect(svc.updateContractLine('c1', 'l1', { catalogItemId: null, refreshCatalogPrice: true, unitPrice: '1.00', taxable: false } as never, actor))
+      .rejects.toMatchObject({ code: 'INVALID_LINE_PATCH', status: 400 });
+  });
+
+  // ---- catalog error mapping ---------------------------------------------
+  it.each([
+    ['NO_PRICE_FOR_CURRENCY'],
+    ['PRICE_NOT_REPRESENTABLE'],
+  ])('maps CatalogServiceError %s to 409 with the code preserved', async (code) => {
+    resolvePriceMock.mockRejectedValueOnce(new CatalogServiceError('nope', 409, code as never));
+    queueResult([CONTRACT]); queueResult([line()]);
+    await expect(svc.updateContractLine('c1', 'l1', { catalogItemId: CATALOG_A } as never, actor))
+      .rejects.toMatchObject({ code, status: 409 });
+  });
+
+  // Non-enumerating on purpose: missing, foreign and RLS-invisible are ONE answer.
+  it('maps ITEM_NOT_FOUND to 400 CATALOG_ITEM_NOT_FOUND with a non-enumerating message', async () => {
+    resolvePriceMock.mockRejectedValueOnce(new CatalogServiceError('Catalog item not found', 404, 'ITEM_NOT_FOUND'));
+    queueResult([CONTRACT]); queueResult([line()]);
+    await expect(svc.updateContractLine('c1', 'l1', { catalogItemId: CATALOG_A } as never, actor))
+      .rejects.toMatchObject({
+        code: 'CATALOG_ITEM_NOT_FOUND', status: 400,
+        message: 'That catalog item is not available on this contract',
+      });
+  });
+
+  it('assertRepresentable fires for a hand-entered price on a non-catalog line', async () => {
+    queueResult([{ ...CONTRACT, currencyCode: 'JPY' }]); queueResult([line()]);
+    await expect(svc.updateContractLine('c1', 'l1', { unitPrice: '10.50' } as never, actor))
+      .rejects.toMatchObject({ code: 'PRICE_NOT_REPRESENTABLE', status: 400 });
+  });
+
+  // ---- merged-row invariants ---------------------------------------------
+  it('rejects roles onto a per_device line with INVALID_LINE_PATCH and the failing path', async () => {
+    queueResult([CONTRACT]); queueResult([line()]);
+    await expect(svc.updateContractLine('c1', 'l1', { deviceRoles: ['server'] } as never, actor))
+      .rejects.toMatchObject({ code: 'INVALID_LINE_PATCH', status: 400, details: { issues: [{ path: 'deviceRoles' }] } });
+  });
+
+  it('rejects a siteId onto a per_device_group line', async () => {
+    queueResult([CONTRACT]);
+    queueResult([line({ lineType: 'per_device_group', deviceGroupId: GROUP_B, deviceGroupName: 'VIP' })]);
+    await expect(svc.updateContractLine('c1', 'l1', { siteId: SITE_B } as never, actor))
+      .rejects.toMatchObject({ code: 'INVALID_LINE_PATCH', status: 400, details: { issues: [{ path: 'siteId' }] } });
+  });
+
+  // ---- ownership re-checks ------------------------------------------------
+  // lockContract and the line read each use .limit(1); assertSiteInOrg would be
+  // a third. Counting limit() calls is what distinguishes "checked" from "not".
+  it('does NOT re-check the site when the patch does not move it', async () => {
+    queueResult([CONTRACT]); queueResult([line({ siteId: SITE_B })]);
+    queueResult([line({ siteId: SITE_B, description: 'Renamed' })]);
+    queueResult([{ id: SITE_B, orgId: 'org1', name: 'HQ' }]);        // withLineRefs sites
+    await svc.updateContractLine('c1', 'l1', { description: 'Renamed' } as never, actor);
+    expect((db as unknown as Chain).limit.mock.calls).toHaveLength(2);
+  });
+
+  it('re-checks the site when the patch moves it', async () => {
+    queueResult([CONTRACT]); queueResult([line()]);
+    queueResult([{ id: SITE_B }]);                                   // assertSiteInOrg
+    queueResult([line({ siteId: SITE_B })]);
+    queueResult([{ id: SITE_B, orgId: 'org1', name: 'HQ' }]);        // withLineRefs sites
+    await svc.updateContractLine('c1', 'l1', { siteId: SITE_B } as never, actor);
+    expect((db as unknown as Chain).limit.mock.calls).toHaveLength(3);
+    expect(setArgs()).toMatchObject({ siteId: SITE_B });
+  });
+
+  it('re-stamps device_group_name from the resolved group', async () => {
+    queueResult([CONTRACT]);
+    queueResult([line({ lineType: 'per_device_group', deviceGroupId: GROUP_B, deviceGroupName: 'Old name' })]);
+    queueResult([{ id: GROUP_B, name: 'New name', type: 'static', siteId: null }]);  // assertGroupInOrg
+    queueResult([line({ lineType: 'per_device_group', deviceGroupId: GROUP_B, deviceGroupName: 'New name' })]);
+    queueResult([{ id: GROUP_B, orgId: 'org1', name: 'New name', type: 'static' }]); // withLineRefs groups
+    await svc.updateContractLine('c1', 'l1', { deviceGroupId: GROUP_B } as never, actor);
+    expect(setArgs()).toMatchObject({ deviceGroupId: GROUP_B, deviceGroupName: 'New name' });
+  });
+
+  it('maps a 23503 on contract_lines_device_group_org_fk to 400 GROUP_NOT_IN_ORG', async () => {
+    queueResult([CONTRACT]);
+    queueResult([line({ lineType: 'per_device_group', deviceGroupId: GROUP_B, deviceGroupName: 'VIP' })]);
+    queueResult([{ id: GROUP_B, name: 'VIP', type: 'static', siteId: null }]);
+    const chain = db as unknown as Chain & { update: ReturnType<typeof vi.fn> };
+    chain.update.mockImplementationOnce(() => { throw Object.assign(new Error('fk'), { code: '23503', constraint_name: 'contract_lines_device_group_org_fk' }); });
+    await expect(svc.updateContractLine('c1', 'l1', { deviceGroupId: GROUP_B } as never, actor))
+      .rejects.toMatchObject({ code: 'GROUP_NOT_IN_ORG', status: 400 });
+  });
+
+  it('throws LINE_NOT_FOUND (404) when the UPDATE loses a racing cascade delete', async () => {
+    queueResult([CONTRACT]); queueResult([line()]); queueResult([]);
+    await expect(svc.updateContractLine('c1', 'l1', { description: 'Renamed' } as never, actor))
+      .rejects.toMatchObject({ code: 'LINE_NOT_FOUND', status: 404 });
+  });
+
+  // ---- audit diff ---------------------------------------------------------
+  it('lists only genuinely changed columns and carries old/new price only on a price change', async () => {
+    queueResult([CONTRACT]); queueResult([line()]); queueResult([line({ unitPrice: '12.50', description: 'Renamed' })]);
+    const { audit } = await svc.updateContractLine('c1', 'l1', { unitPrice: '12.50', description: 'Renamed' } as never, actor);
+    expect(audit.changedFields!.sort()).toEqual(['description', 'unitPrice']);
+    expect(audit).toMatchObject({ oldUnitPrice: '10.00', newUnitPrice: '12.50', lineType: 'per_device', contractLineId: 'l1' });
+  });
+
+  it('does not treat a deviceRoles reorder as a change, and returns changedFields [] for a no-op patch', async () => {
+    const roleLine = line({ lineType: 'per_device_role', deviceRoles: ['server', 'switch'] });
+    queueResult([CONTRACT]); queueResult([roleLine]);
+    queueResult([line({ lineType: 'per_device_role', deviceRoles: ['switch', 'server'] })]);
+    const { audit } = await svc.updateContractLine('c1', 'l1', { deviceRoles: ['switch', 'server'] } as never, actor);
+    expect(audit.changedFields).toEqual([]);
+  });
+
+  // The no-free-text rule (decision 6): assert the KEY SET, so a future field
+  // cannot leak a description, a site name or a group name into the audit log.
+  it('never carries a value of any string column', async () => {
+    queueResult([CONTRACT]);
+    queueResult([line({ lineType: 'per_device_group', deviceGroupId: GROUP_B, deviceGroupName: 'VIP laptops', description: 'Secret' })]);
+    queueResult([{ id: GROUP_B, name: 'VIP laptops', type: 'static', siteId: null }]);
+    queueResult([line({ lineType: 'per_device_group', deviceGroupId: GROUP_B, deviceGroupName: 'VIP laptops', description: 'Also secret' })]);
+    const { audit } = await svc.updateContractLine('c1', 'l1', { deviceGroupId: GROUP_B, description: 'Also secret' } as never, actor);
+    expect(Object.keys(audit).sort()).toEqual(
+      ['changedFields', 'contractId', 'contractLineId', 'contractName', 'lineType', 'orgId'].sort(),
+    );
+    expect(JSON.stringify(audit)).not.toContain('VIP laptops');
+    expect(JSON.stringify(audit)).not.toContain('Also secret');
+  });
+
+  it('returns the line decorated with site and deviceGroup', async () => {
+    queueResult([CONTRACT]); queueResult([line({ siteId: SITE_B })]);
+    queueResult([line({ siteId: SITE_B, description: 'Renamed' })]);
+    queueResult([{ id: SITE_B, orgId: 'org1', name: 'HQ' }]);   // withLineRefs sites
+    const { line: decorated } = await svc.updateContractLine('c1', 'l1', { description: 'Renamed' } as never, actor);
+    expect(decorated).toMatchObject({ site: { id: SITE_B, name: 'HQ' }, deviceGroup: null });
+  });
+});
+
+describe('removeContractLine pre-read (#3205 W03)', () => {
+  beforeEach(() => { results.length = 0; vi.clearAllMocks(); });
+
+  it('returns the lineType read BEFORE the delete', async () => {
+    queueResult([{ id: 'c1', orgId: 'org1', partnerId: 'p1', name: 'Acme MSA', status: 'active', currencyCode: 'USD' }]);
+    queueResult([{ id: 'l1', lineType: 'per_seat' }]);
+    queueResult([]);
+    const audit = await svc.removeContractLine('c1', 'l1', actor);
+    expect(audit).toMatchObject({ orgId: 'org1', contractId: 'c1', contractName: 'Acme MSA', contractLineId: 'l1', lineType: 'per_seat' });
+    expect(audit.changedFields).toBeUndefined();
+  });
+
+  // Deliberate behaviour change: a DELETE for a line that does not exist was a
+  // silent 200. Its permissiveness is what would make the removal audit lie.
+  it('throws LINE_NOT_FOUND (404) when nothing matched, and never issues the delete', async () => {
+    queueResult([{ id: 'c1', orgId: 'org1', partnerId: 'p1', name: 'Acme MSA', status: 'active', currencyCode: 'USD' }]);
+    queueResult([]);
+    await expect(svc.removeContractLine('c1', 'missing', actor)).rejects.toMatchObject({ code: 'LINE_NOT_FOUND', status: 404 });
+    expect((db as unknown as Chain).delete.mock.calls).toHaveLength(0);
+  });
+});
+
+describe('deterministic line ordering (#3205 W03)', () => {
+  beforeEach(() => { results.length = 0; vi.clearAllMocks(); });
+
+  // generateDueInvoice's third read is covered behaviourally in
+  // contractLineEditing.integration.test.ts (its invoice lines come back in
+  // (sortOrder, createdAt, id) order) — mocking its whole transaction here
+  // would assert the mock, not the order.
+  it.each([
+    ['getContract', () => svc.getContract('c1', actor)],
+    ['computeContractEstimate', () => svc.computeContractEstimate('c1', actor)],
+  ])('%s orders by (sortOrder, createdAt, id)', async (_name, run) => {
+    queueResult([{ id: 'c1', orgId: 'org1', partnerId: 'p1', name: 'C', status: 'active', currencyCode: 'USD' }]);
+    queueResult([]); queueResult([]); queueResult([]);
+    await run();
+    const orderBy = (db as unknown as { orderBy: { mock: { calls: unknown[][] } } }).orderBy.mock.calls[0]!;
+    expect(orderBy).toEqual([contractLines.sortOrder, contractLines.createdAt, contractLines.id]);
+  });
+
+  it('generateDueInvoice orders by (sortOrder, createdAt, id)', async () => {
+    queueResult([{
+      id: 'c1', orgId: 'org1', partnerId: 'p1', status: 'active', currencyCode: 'USD',
+      startDate: '2026-07-01', intervalMonths: 1, billingTiming: 'advance', nextBillingAt: '2026-07-01',
+      endDate: null, autoIssue: false, createdBy: 'u1', notes: null, terms: null,
+    }]);
+    queueResult([]);
+    await svc.generateDueInvoice('c1', new Date('2026-07-01T06:00:00Z'));
+    const orderBy = (db as unknown as { orderBy: { mock: { calls: unknown[][] } } }).orderBy.mock.calls[0]!;
+    expect(orderBy).toEqual([contractLines.sortOrder, contractLines.createdAt, contractLines.id]);
   });
 });

--- a/apps/api/src/services/contractService.ts
+++ b/apps/api/src/services/contractService.ts
@@ -70,16 +70,17 @@ export type DecoratedContractLine = typeof contractLines.$inferSelect & {
  *  ON DELETE SET NULL). Two batched inArray selects, never a per-line query. */
 async function withLineRefs<T extends { siteId: string | null; deviceGroupId: string | null; orgId: string }>(
   lines: T[],
+  executor: DbExecutor = db,
 ): Promise<Array<T & {
   site: { id: string; name: string } | null;
   deviceGroup: { id: string; name: string; type: 'static' | 'dynamic' } | null;
 }>> {
   const siteIds = [...new Set(lines.map((l) => l.siteId).filter((x): x is string => x !== null))];
   const groupIds = [...new Set(lines.map((l) => l.deviceGroupId).filter((x): x is string => x !== null))];
-  const siteRows = siteIds.length === 0 ? [] : await db
+  const siteRows = siteIds.length === 0 ? [] : await executor
     .select({ id: sites.id, orgId: sites.orgId, name: sites.name })
     .from(sites).where(inArray(sites.id, siteIds));
-  const groupRows = groupIds.length === 0 ? [] : await db
+  const groupRows = groupIds.length === 0 ? [] : await executor
     .select({ id: deviceGroups.id, orgId: deviceGroups.orgId, name: deviceGroups.name, type: deviceGroups.type })
     .from(deviceGroups).where(inArray(deviceGroups.id, groupIds));
   const siteByKey = new Map(siteRows.map((s) => [`${s.id}|${s.orgId}`, { id: s.id, name: s.name }]));
@@ -1043,10 +1044,7 @@ export async function changeContractCurrency(
           try {
             resolved = await resolvePrice(line.catalogItemId!, input.currencyCode, c.orgId, catalogActor, tx);
           } catch (err) {
-            if (err instanceof CatalogServiceError && (err.code === 'NO_PRICE_FOR_CURRENCY' || err.code === 'PRICE_NOT_REPRESENTABLE')) {
-                throw new ContractServiceError(err.message, 409, err.code);
-            }
-            throw err;
+            mapCatalogResolveError(err);
           }
           await tx.update(contractLines).set({ unitPrice: resolved.unitPrice }).where(eq(contractLines.id, line.id));
         }
@@ -1164,7 +1162,7 @@ export async function addContractLineToContract(contractId: string, input: Contr
         deviceGroupName: group?.name ?? null,
         taxable, sortOrder: input.sortOrder ?? 0
       }).returning();
-      return row!;
+      return { ...row!, contractName: c.name };
     } catch (err) {
       if (isGroupFkViolation(err)) {
         throw new ContractServiceError('Device group does not belong to this organization', 400, 'GROUP_NOT_IN_ORG');
@@ -1193,7 +1191,7 @@ export async function addContractLineToContract(contractId: string, input: Contr
 export async function updateContractLine(
   contractId: string, lineId: string, patch: UpdateContractLineInput, actor: ContractActor,
 ): Promise<{ line: DecoratedContractLine; audit: ContractLineAudit }> {
-  const { before, after, contract } = await db.transaction(async (tx) => {
+  const { before, line, contract } = await db.transaction(async (tx) => {
     const c = await lockContract(tx, contractId, actor);
     assertEditable(c);
 
@@ -1292,11 +1290,11 @@ export async function updateContractLine(
       throw err;
     }
 
-    return { before: current, after: updated, contract: c };
+    const [line] = await withLineRefs([updated], tx);
+    return { before: current, line: line as DecoratedContractLine, contract: c };
   });
 
-  const [line] = await withLineRefs([after]);
-  return { line: line as DecoratedContractLine, audit: diffLineAudit(before, after, contract) };
+  return { line, audit: diffLineAudit(before, line, contract) };
 }
 
 export async function removeContractLine(

--- a/apps/api/src/services/contractService.ts
+++ b/apps/api/src/services/contractService.ts
@@ -1,9 +1,13 @@
 import { and, desc, eq, inArray, sql } from 'drizzle-orm';
 import { db } from '../db';
 import { contracts, contractLines, contractBillingPeriods, organizations, sites, deviceGroups, catalogItemPrices, catalogItemOrgPricing } from '../db/schema';
-import { ContractServiceError, actorCan, type ContractActor } from './contractTypes';
+import { ContractServiceError, actorCan, type ContractActor, type ContractLineAudit } from './contractTypes';
 import type { ContractLineInput, UpdateContractInput } from '@breeze/shared';
-import { BILLABLE_DEVICE_ROLES, isRepresentableInCurrency, minorUnitExponent, roundToCurrency, PERMISSION_GRANTS } from '@breeze/shared';
+import {
+  BILLABLE_DEVICE_ROLES, isRepresentableInCurrency, minorUnitExponent, roundToCurrency, PERMISSION_GRANTS,
+  contractLineInvariantIssues, mergeContractLinePatch, patchHasKey,
+  type DeviceRole, type UpdateContractLineInput,
+} from '@breeze/shared';
 import type { NewContractSpec } from './quoteToContract';
 import { periodIndexFor, nextBillingDate, computePeriod, isExpired, duePeriodStartFor } from './contractMath';
 import { emitContractEvent } from './contractEvents';
@@ -53,16 +57,87 @@ async function getOwnedContractOr404(contractId: string, actor: ContractActor) {
   return c;
 }
 
-/** #3205 W02: label group lines without a second fetch. Matched on (id, org_id)
- *  as defence in depth beside the composite FK; null when the group is gone
- *  (the stamped deviceGroupName still says what it was). */
-async function withDeviceGroup<T extends { deviceGroupId: string | null; orgId: string }>(lines: T[]) {
-  const ids = [...new Set(lines.map((l) => l.deviceGroupId).filter((x): x is string => x !== null))];
-  const groups = ids.length === 0 ? [] : await db
+export type DecoratedContractLine = typeof contractLines.$inferSelect & {
+  site: { id: string; name: string } | null;
+  deviceGroup: { id: string; name: string; type: 'static' | 'dynamic' } | null;
+};
+
+/** #3205 W03: one decorator for every line read. The group leg is W02's
+ *  (renamed from withDeviceGroup); the site leg is the W01-deferred detail-page
+ *  legibility fix — ContractDetail loads no sites of its own, so the name has to
+ *  travel on the line. Both legs match on (id, org_id): defence in depth beside
+ *  the composite FKs, and null when the referenced row is gone (site_id is
+ *  ON DELETE SET NULL). Two batched inArray selects, never a per-line query. */
+async function withLineRefs<T extends { siteId: string | null; deviceGroupId: string | null; orgId: string }>(
+  lines: T[],
+): Promise<Array<T & {
+  site: { id: string; name: string } | null;
+  deviceGroup: { id: string; name: string; type: 'static' | 'dynamic' } | null;
+}>> {
+  const siteIds = [...new Set(lines.map((l) => l.siteId).filter((x): x is string => x !== null))];
+  const groupIds = [...new Set(lines.map((l) => l.deviceGroupId).filter((x): x is string => x !== null))];
+  const siteRows = siteIds.length === 0 ? [] : await db
+    .select({ id: sites.id, orgId: sites.orgId, name: sites.name })
+    .from(sites).where(inArray(sites.id, siteIds));
+  const groupRows = groupIds.length === 0 ? [] : await db
     .select({ id: deviceGroups.id, orgId: deviceGroups.orgId, name: deviceGroups.name, type: deviceGroups.type })
-    .from(deviceGroups).where(inArray(deviceGroups.id, ids));
-  const byKey = new Map(groups.map((g) => [`${g.id}|${g.orgId}`, { id: g.id, name: g.name, type: g.type }]));
-  return lines.map((l) => ({ ...l, deviceGroup: l.deviceGroupId ? (byKey.get(`${l.deviceGroupId}|${l.orgId}`) ?? null) : null }));
+    .from(deviceGroups).where(inArray(deviceGroups.id, groupIds));
+  const siteByKey = new Map(siteRows.map((s) => [`${s.id}|${s.orgId}`, { id: s.id, name: s.name }]));
+  const groupByKey = new Map(groupRows.map((g) => [`${g.id}|${g.orgId}`, { id: g.id, name: g.name, type: g.type }]));
+  return lines.map((l) => ({
+    ...l,
+    site: l.siteId ? (siteByKey.get(`${l.siteId}|${l.orgId}`) ?? null) : null,
+    deviceGroup: l.deviceGroupId ? (groupByKey.get(`${l.deviceGroupId}|${l.orgId}`) ?? null) : null,
+  }));
+}
+
+/** Columns a line PATCH can move. The audit reports NAMES from this list only. */
+const AUDITED_LINE_COLUMNS = [
+  'description', 'unitPrice', 'taxable', 'catalogItemId', 'manualQuantity',
+  'siteId', 'deviceRoles', 'deviceGroupId', 'deviceGroupName', 'sortOrder',
+] as const;
+type AuditedLineColumn = typeof AUDITED_LINE_COLUMNS[number];
+type ContractLineRowT = typeof contractLines.$inferSelect;
+
+function lineColumnChanged(field: AuditedLineColumn, before: ContractLineRowT, after: ContractLineRowT): boolean {
+  if (field === 'deviceRoles') {
+    // A reorder is not a change: the set is what bills.
+    const norm = (v: readonly string[] | null) => (v === null ? null : JSON.stringify([...v].sort()));
+    return norm(before.deviceRoles) !== norm(after.deviceRoles);
+  }
+  // String()-normalise: Postgres hands numerics back as strings, and a numeric
+  // column round-tripped through Drizzle must not read as "changed".
+  const norm = (v: unknown) => (v === null || v === undefined ? null : String(v));
+  return norm(before[field]) !== norm(after[field]);
+}
+
+/** #3205 W03: changedFields comes from the PERSISTED rows, never from the patch
+ *  keys — an ignored client price (transition rows 2/4) must never claim to have
+ *  applied, and a patch that changes nothing must report []. */
+function diffLineAudit(
+  before: ContractLineRowT, after: ContractLineRowT,
+  c: { id: string; orgId: string; name: string },
+): ContractLineAudit {
+  const changedFields = AUDITED_LINE_COLUMNS.filter((f) => lineColumnChanged(f, before, after));
+  return {
+    orgId: c.orgId, contractId: c.id, contractName: c.name,
+    contractLineId: after.id, lineType: after.lineType,
+    changedFields: [...changedFields],
+    ...(changedFields.includes('unitPrice')
+      ? { oldUnitPrice: before.unitPrice, newUnitPrice: after.unitPrice }
+      : {}),
+  };
+}
+
+/** #3205 W03: the shared, no-free-text audit detail payload for HTTP and AI. */
+export function contractLineAuditDetails(audit: ContractLineAudit) {
+  return {
+    contractLineId: audit.contractLineId,
+    lineType: audit.lineType,
+    ...(audit.changedFields !== undefined ? { changedFields: audit.changedFields } : {}),
+    ...(audit.oldUnitPrice !== undefined ? { oldUnitPrice: audit.oldUnitPrice } : {}),
+    ...(audit.newUnitPrice !== undefined ? { newUnitPrice: audit.newUnitPrice } : {}),
+  };
 }
 
 function assertDraft(c: { status: string }): void {
@@ -166,11 +241,15 @@ export async function createContract(input: {
 
 export async function getContract(contractId: string, actor: ContractActor) {
   const contract = await getOwnedContractOr404(contractId, actor);
+  // #3205 W03: (sortOrder, createdAt, id). sortOrder alone is not a total order
+  // — addContractLineToContract defaults it to 0, so everything created through
+  // the editor ties — and Postgres was free to reshuffle the table on any edit.
   const lines = await db.select().from(contractLines)
-    .where(eq(contractLines.contractId, contractId)).orderBy(contractLines.sortOrder);
+    .where(eq(contractLines.contractId, contractId))
+    .orderBy(contractLines.sortOrder, contractLines.createdAt, contractLines.id);
   const periods = await db.select().from(contractBillingPeriods)
     .where(eq(contractBillingPeriods.contractId, contractId)).orderBy(desc(contractBillingPeriods.periodStart));
-  return { contract, lines: await withDeviceGroup(lines), periods };
+  return { contract, lines: await withLineRefs(lines), periods };
 }
 
 type ContractRow = typeof contracts.$inferSelect;
@@ -389,7 +468,8 @@ export interface ContractEstimate {
 export async function computeContractEstimate(contractId: string, actor: ContractActor): Promise<ContractEstimate> {
   const contract = await getOwnedContractOr404(contractId, actor);
   const lines = await db.select().from(contractLines)
-    .where(eq(contractLines.contractId, contractId)).orderBy(contractLines.sortOrder);
+    .where(eq(contractLines.contractId, contractId))
+    .orderBy(contractLines.sortOrder, contractLines.createdAt, contractLines.id);
   const dc: DeviceCache = new Map();
   const sc: SeatCache = new Map();
   let total = 0;
@@ -1012,6 +1092,30 @@ function assertRepresentable(value: string, currencyCode: string): void {
   }
 }
 
+/**
+ * #3205 W03: one mapping for every resolvePrice failure on a contract line.
+ *
+ * ITEM_NOT_FOUND was UNMAPPED on the add path: resolvePrice opens with
+ * getOwnedItemOr404, which throws CatalogServiceError('Catalog item not found',
+ * 404, 'ITEM_NOT_FOUND'), and handleContractError rethrows anything that is not
+ * a ContractServiceError — so a stale or foreign catalog item id on add was a
+ * live 500. 400, not 404: the contract line exists; the id in the body is what
+ * is wrong. The message deliberately does NOT distinguish missing / foreign /
+ * RLS-invisible, because a 404 that fires only for foreign ids is a
+ * partner-enumeration oracle.
+ */
+function mapCatalogResolveError(err: unknown): never {
+  if (err instanceof CatalogServiceError) {
+    if (err.code === 'NO_PRICE_FOR_CURRENCY' || err.code === 'PRICE_NOT_REPRESENTABLE') {
+      throw new ContractServiceError(err.message, 409, err.code);
+    }
+    if (err.code === 'ITEM_NOT_FOUND') {
+      throw new ContractServiceError('That catalog item is not available on this contract', 400, 'CATALOG_ITEM_NOT_FOUND');
+    }
+  }
+  throw err;
+}
+
 export async function addContractLineToContract(contractId: string, input: ContractLineInput, actor: ContractActor) {
   return db.transaction(async (tx) => {
     const c = await lockContract(tx, contractId, actor);
@@ -1029,10 +1133,7 @@ export async function addContractLineToContract(contractId: string, input: Contr
           tx
         );
       } catch (err) {
-        if (err instanceof CatalogServiceError && (err.code === 'NO_PRICE_FOR_CURRENCY' || err.code === 'PRICE_NOT_REPRESENTABLE')) {
-            throw new ContractServiceError(err.message, 409, err.code);
-        }
-        throw err;
+        mapCatalogResolveError(err);
       }
       unitPrice = resolved.unitPrice;
       taxable = resolved.taxable;
@@ -1073,11 +1174,147 @@ export async function addContractLineToContract(contractId: string, input: Contr
   });
 }
 
-export async function removeContractLine(contractId: string, lineId: string, actor: ContractActor) {
-  await db.transaction(async (tx) => {
+/**
+ * PATCH one contract line in place (#3205 W03). Keeping the line's id is the
+ * whole point: invoice_lines.source_id carries it, and issueInvoice refuses a
+ * draft whose source line is gone (invoiceService.ts:1194-1199), so
+ * delete-and-re-add wedges any unissued generated invoice.
+ *
+ * Lock order is the one every contract writer takes — contracts FOR UPDATE, then
+ * contract_lines — the same order issueInvoice/voidInvoice take, so there is no
+ * new deadlock edge. No FOR UPDATE on the line itself: the contract lock already
+ * excludes every other line writer.
+ *
+ * Edits affect FUTURE periods only, by construction rather than by a guard:
+ * invoice lines carry their own copies of description, quantity, unit price and
+ * taxable (invoiceService.ts:405-450), and nothing re-reads a contract line's
+ * CONTENT after generation.
+ */
+export async function updateContractLine(
+  contractId: string, lineId: string, patch: UpdateContractLineInput, actor: ContractActor,
+): Promise<{ line: DecoratedContractLine; audit: ContractLineAudit }> {
+  const { before, after, contract } = await db.transaction(async (tx) => {
     const c = await lockContract(tx, contractId, actor);
     assertEditable(c);
+
+    const [current] = await tx.select().from(contractLines)
+      .where(and(eq(contractLines.id, lineId), eq(contractLines.contractId, contractId))).limit(1);
+    if (!current) throw new ContractServiceError('Contract line not found', 404, 'LINE_NOT_FOUND');
+
+    // ---- catalog transition table (spec § Validators (d)) ------------------
+    const touchesLink = patchHasKey(patch, 'catalogItemId');
+    const targetItemId = touchesLink ? (patch.catalogItemId ?? null) : current.catalogItemId;
+    // Row 4 is excluded here on purpose: the SAME id re-sent is a no-op, not a
+    // reprice — a form echoing the current id must change nothing.
+    const relinking = touchesLink && patch.catalogItemId != null && patch.catalogItemId !== current.catalogItemId;
+    const unlinking = touchesLink && patch.catalogItemId === null && current.catalogItemId !== null;
+    const refreshing = patch.refreshCatalogPrice === true;
+
+    if (refreshing && targetItemId === null) {
+      throw new ContractServiceError('The line is not linked to a catalog item', 400, 'INVALID_LINE_PATCH', {
+        issues: [{ path: 'refreshCatalogPrice', message: 'the line is not linked to a catalog item' }],
+      });
+    }
+
+    let resolved: { unitPrice: string; taxable: boolean; catalogItemId: string | null } | undefined;
+    if (relinking || (refreshing && targetItemId !== null)) {
+      let priced: Awaited<ReturnType<typeof resolvePrice>>;
+      try {
+        priced = await resolvePrice(
+          targetItemId!, c.currencyCode, c.orgId,
+          { userId: actor.userId, partnerId: c.partnerId, accessibleOrgIds: actor.accessibleOrgIds },
+          tx,
+        );
+      } catch (err) {
+        mapCatalogResolveError(err);
+      }
+      resolved = { unitPrice: priced.unitPrice, taxable: priced.taxable, catalogItemId: targetItemId };
+    } else if (unlinking) {
+      // After an unlink nothing re-resolves this number ever again, so the
+      // operator has to supply it now.
+      if (patch.unitPrice === undefined || patch.taxable === undefined) {
+        throw new ContractServiceError('unitPrice and taxable are required when clearing catalogItemId', 400, 'INVALID_LINE_PATCH', {
+          issues: [{ path: 'unitPrice', message: 'unitPrice and taxable are required when clearing catalogItemId' }],
+        });
+      }
+      assertRepresentable(patch.unitPrice, c.currencyCode);
+    } else if (targetItemId === null && patch.unitPrice !== undefined) {
+      assertRepresentable(patch.unitPrice, c.currencyCode);
+    }
+    // When the merged row stays LINKED and no resolve ran (rows 2 and 4),
+    // mergeContractLinePatch drops patch.unitPrice / patch.taxable.
+
+    const merged = mergeContractLinePatch(current, patch, resolved);
+    const issues = contractLineInvariantIssues(merged, { mode: 'persisted' });
+    if (issues.length > 0) {
+      throw new ContractServiceError(issues[0]!.message, 400, 'INVALID_LINE_PATCH', { issues });
+    }
+
+    // Ownership checks, only when the patch actually moves them.
+    if (merged.siteId !== null && merged.siteId !== current.siteId) {
+      await assertSiteInOrg(tx, merged.siteId, c.orgId);
+    }
+    // Ordering note: the invariants above read deviceGroupName from `current`,
+    // which W02's CHECK guarantees non-null on any persisted group line.
+    // Re-stamping here changes the STRING, never its null-ness. Sound as
+    // written — do not reorder to "fix" an imagined dependency.
+    let deviceGroupName = current.deviceGroupName;
+    if (patch.deviceGroupId !== undefined) {
+      const group = await assertGroupInOrg(tx, patch.deviceGroupId, c.orgId);
+      deviceGroupName = group.name;
+    }
+
+    let updated: ContractLineRowT;
+    try {
+      const [row] = await tx.update(contractLines).set({
+        description: merged.description,
+        unitPrice: merged.unitPrice,
+        taxable: merged.taxable,
+        catalogItemId: merged.catalogItemId,
+        manualQuantity: merged.manualQuantity,
+        siteId: merged.siteId,
+        // The merged shape is readonly string[] for portability across the web
+        // editor; the column is DeviceRole[] and the schema edge already proved
+        // membership (z.enum(BILLABLE_DEVICE_ROLES)).
+        deviceRoles: merged.deviceRoles === null ? null : ([...merged.deviceRoles] as DeviceRole[]),
+        deviceGroupId: merged.deviceGroupId,
+        deviceGroupName,
+        sortOrder: merged.sortOrder,
+      }).where(and(eq(contractLines.id, lineId), eq(contractLines.contractId, contractId))).returning();
+      if (!row) throw new ContractServiceError('Contract line not found', 404, 'LINE_NOT_FOUND');
+      updated = row;
+    } catch (err) {
+      // The delete race: deleteDeviceGroup holds FOR UPDATE on the group row, so
+      // this update waited and then lost. Same answer as a cross-org group.
+      if (isGroupFkViolation(err)) {
+        throw new ContractServiceError('Device group does not belong to this organization', 400, 'GROUP_NOT_IN_ORG');
+      }
+      throw err;
+    }
+
+    return { before: current, after: updated, contract: c };
+  });
+
+  const [line] = await withLineRefs([after]);
+  return { line: line as DecoratedContractLine, audit: diffLineAudit(before, after, contract) };
+}
+
+export async function removeContractLine(
+  contractId: string, lineId: string, actor: ContractActor,
+): Promise<ContractLineAudit> {
+  return db.transaction(async (tx) => {
+    const c = await lockContract(tx, contractId, actor);
+    assertEditable(c);
+    // #3205 W03: read before deleting so contract.line.removed names the real
+    // lineType, and so a miss is a typed 404 rather than a silent 200 (the
+    // pre-W03 behaviour deleted by (id, contract_id) and never checked whether
+    // a row matched). Its permissiveness is exactly what would make the audit lie.
+    const [row] = await tx.select({ id: contractLines.id, lineType: contractLines.lineType })
+      .from(contractLines)
+      .where(and(eq(contractLines.id, lineId), eq(contractLines.contractId, contractId))).limit(1);
+    if (!row) throw new ContractServiceError('Contract line not found', 404, 'LINE_NOT_FOUND');
     await tx.delete(contractLines).where(and(eq(contractLines.id, lineId), eq(contractLines.contractId, contractId)));
+    return { orgId: c.orgId, contractId, contractName: c.name, contractLineId: row.id, lineType: row.lineType };
   });
 }
 
@@ -1252,10 +1489,12 @@ export async function generateDueInvoice(contractId: string, asOf: Date = new Da
     accessibleOrgIds: [c.orgId]
   };
   const lines = await db.select().from(contractLines)
-    .where(eq(contractLines.contractId, contractId)).orderBy(contractLines.sortOrder);
+    .where(eq(contractLines.contractId, contractId))
+    .orderBy(contractLines.sortOrder, contractLines.createdAt, contractLines.id);
 
   // Never bill an empty (zero-line) contract: don't create/claim/issue a $0 invoice.
-  // (removeContractLine stays permissive; this generation-side guard is the backstop.)
+  // This generation-side guard remains the backstop for an active contract whose
+  // final line was removed before the billing run.
   if (lines.length === 0) {
     return { generated: false, autoIssue: false, skipped: 'not_due', priceBookGaps: [], uncoveredDevices: null };
   }

--- a/apps/api/src/services/contractTypes.ts
+++ b/apps/api/src/services/contractTypes.ts
@@ -1,3 +1,5 @@
+import type { ContractLineType } from '@breeze/shared';
+
 export type ContractStatus = 'draft' | 'active' | 'paused' | 'cancelled' | 'expired';
 export type BillingTiming = 'advance' | 'arrears';
 
@@ -79,7 +81,16 @@ export type ContractServiceErrorCode =
   | 'ORPHANED_CONTRACT_SOURCE'
   // A billing period's invoice fails the explicit lineage check (cross-tenant,
   // unattributable, or a cyclic/over-deep replaces_invoice_id ancestry).
-  | 'BROKEN_CONTRACT_LINEAGE';
+  | 'BROKEN_CONTRACT_LINEAGE'
+  // #3205 W03: the patch, merged onto the current row, violates a contract-line
+  // invariant (roles on a non-role line, a site on a group line, an unlink with
+  // no price, a refresh with no link). `details.issues` carries the failing
+  // paths. Distinct from INVALID_STATE, which is about the CONTRACT's status.
+  | 'INVALID_LINE_PATCH'
+  // #3205 W03: resolvePrice could not reach the catalog item. Deliberately does
+  // NOT distinguish missing / foreign / RLS-invisible (catalogService.ts:680) —
+  // a 404 that fires only for foreign ids enumerates other partners' catalogs.
+  | 'CATALOG_ITEM_NOT_FOUND';
 
 export class ContractServiceError extends Error {
   constructor(
@@ -96,4 +107,29 @@ export class ContractServiceError extends Error {
     super(message);
     this.name = 'ContractServiceError';
   }
+}
+
+/**
+ * #3205 W03: what a line mutation tells the audit log. Both doors write it —
+ * the HTTP route through writeRouteAudit, the AI tool through writeAuditEvent
+ * with initiatedBy: 'ai'.
+ *
+ * NO FREE TEXT. No description, no site name, no group name: the audit log is
+ * queryable by support and none of that is incident data (same reasoning as the
+ * recipient-count rule at routes/invoices/lifecycle.ts:70-72).
+ */
+export interface ContractLineAudit {
+  orgId: string;
+  contractId: string;
+  /** Absent on `contract.line.added`: the add path derives its payload from the
+   *  inserted row, which carries no contract name, and its signature is
+   *  deliberately unchanged. Becomes the audit event's resourceName when set. */
+  contractName?: string;
+  contractLineId: string;
+  lineType: ContractLineType;
+  /** Column NAMES whose persisted value changed. Empty on a no-op patch.
+   *  Absent for add/remove. Never a value — see the no-free-text rule. */
+  changedFields?: string[];
+  oldUnitPrice?: string;   // only when unitPrice changed
+  newUnitPrice?: string;   // also set on add
 }

--- a/apps/docs/src/content/docs/features/contracts.mdx
+++ b/apps/docs/src/content/docs/features/contracts.mdx
@@ -45,6 +45,8 @@ Each line is one charge on the contract. Lines can resolve their quantity in dif
 
 Per-device and per-device-role lines can be scoped to a specific **site** so you bill only the devices at that location. A per-device-group line is not site-scoped: make the group itself site-bound instead. Per-seat lines always bill the organization's whole active-user count and cannot be site-scoped. A line can link to a [catalog item](/features/product-catalog/), which prefills its description and price.
 
+**Editing a line.** On a draft or active contract you can edit a line in place -- its description, price, tax flag, quantity, site, device roles, device group and catalog link -- from the contract editor. The line keeps its identity, so invoices already generated from it stay linked to it and any allowance you set later is preserved. **The line type cannot be changed**: remove the line and add a new one instead. A catalog-linked line keeps the price it was given when it was added; use **Refresh price from catalog** to re-price it. Clearing a catalog link asks you for a unit price, because nothing re-prices the line afterwards. Edits apply from the next billing period onward; invoices that have already been generated are never rewritten.
+
 Dynamic groups on a contract are evaluated live when the estimate or invoice is computed, not from the member list cached on the Device Groups page, so a device that changed since the group was last refreshed is still billed correctly. The one exception is a filter condition that tests membership in *another* group, which reads that group's cached list. A group billed by a draft, active or paused contract cannot be deleted until the line is removed; a group deleted after a contract ended stays on that contract's lines by name.
 
 Device roles come from the agent's automatic classification, a network discovery scan, or a manual override on the device. A device whose role is still **Unknown** is never billed by a per-device-role line. The contract's estimate and each generated invoice report how many devices on the organization are not billed by any line, broken down by role, so you can classify them or add a line before the next period.
@@ -56,7 +58,7 @@ A contract is priced in the customer organization's billing currency, which the 
 <Steps>
 1. Go to **Contracts** and click **New contract**.
 2. Select the customer organization, name the contract, and set the billing timing, interval, and start date.
-3. Add lines -- choose flat, per device, per device role, per seat, or manual, and set the price (and quantity or roles where applicable). Link a catalog item to prefill description and price.
+3. Add lines -- choose flat, per device, per device role, per device group, per seat, or manual, and set the price (and quantity, roles or group where applicable). Link a catalog item to prefill description and price. You can edit any line later from the same screen while the contract is a draft or active.
 4. Add any **terms** and notes.
 5. Review the **estimated value this period** -- per-device, per-device-role and per-seat lines resolve to live counts so the estimate is real, not a placeholder, and any devices no line bills are called out.
 6. **Activate** the contract to start billing.

--- a/apps/web/src/components/contracts/ContractDetail.cancel.test.tsx
+++ b/apps/web/src/components/contracts/ContractDetail.cancel.test.tsx
@@ -48,7 +48,7 @@ function detail(status: ContractStatus): ContractDetailData {
     lines: [
       {
         id: 'cl-1', contractId: 'ct-1', orgId: 'org-1', lineType: 'flat', description: 'Managed services',
-        catalogItemId: null, unitPrice: '500.00', manualQuantity: null, siteId: null, deviceRoles: null,
+        catalogItemId: null, unitPrice: '500.00', manualQuantity: null, siteId: null, site: null, deviceRoles: null,
         deviceGroupId: null, deviceGroupName: null, deviceGroup: null, taxable: false,
         sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
       },

--- a/apps/web/src/components/contracts/ContractDetail.generate.test.tsx
+++ b/apps/web/src/components/contracts/ContractDetail.generate.test.tsx
@@ -50,7 +50,7 @@ const detail: ContractDetailData = {
   lines: [
     {
       id: 'cl-1', contractId: 'ct-1', orgId: 'org-1', lineType: 'flat', description: 'Managed endpoint',
-      catalogItemId: 'cat-1', unitPrice: '80.00', manualQuantity: null, siteId: null, deviceRoles: null,
+      catalogItemId: 'cat-1', unitPrice: '80.00', manualQuantity: null, siteId: null, site: null, deviceRoles: null,
       deviceGroupId: null, deviceGroupName: null, deviceGroup: null, taxable: true,
       sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
     },

--- a/apps/web/src/components/contracts/ContractDetail.groups.test.tsx
+++ b/apps/web/src/components/contracts/ContractDetail.groups.test.tsx
@@ -38,7 +38,7 @@ const detail: ContractDetailData = {
 const groupLine = {
   id: 'cl-live', contractId: 'ct-1', orgId: 'org-1', lineType: 'per_device_group' as const,
   description: 'Managed group', catalogItemId: null, unitPrice: '12.00', manualQuantity: null,
-  siteId: null, deviceRoles: null, deviceGroupId: 'group-1', deviceGroupName: 'Live Servers',
+  siteId: null, site: null, deviceRoles: null, deviceGroupId: 'group-1', deviceGroupName: 'Live Servers',
   deviceGroup: { id: 'group-1', name: 'Live Servers', type: 'dynamic' as const },
   taxable: false, sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
 };

--- a/apps/web/src/components/contracts/ContractDetail.permissions.test.tsx
+++ b/apps/web/src/components/contracts/ContractDetail.permissions.test.tsx
@@ -49,7 +49,7 @@ function detail(status: ContractStatus): ContractDetailData {
     lines: [
       {
         id: 'cl-1', contractId: 'ct-1', orgId: 'org-1', lineType: 'flat', description: 'Managed services',
-        catalogItemId: null, unitPrice: '500.00', manualQuantity: null, siteId: null, deviceRoles: null,
+        catalogItemId: null, unitPrice: '500.00', manualQuantity: null, siteId: null, site: null, deviceRoles: null,
         deviceGroupId: null, deviceGroupName: null, deviceGroup: null, taxable: false,
         sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
       },

--- a/apps/web/src/components/contracts/ContractDetail.roles.test.tsx
+++ b/apps/web/src/components/contracts/ContractDetail.roles.test.tsx
@@ -44,7 +44,7 @@ const detail: ContractDetailData = {
   lines: [
     {
       id: 'cl-1', contractId: 'ct-1', orgId: 'org-1', lineType: 'flat', description: 'Managed endpoint',
-      catalogItemId: 'cat-1', unitPrice: '80.00', manualQuantity: null, siteId: null, deviceRoles: null,
+      catalogItemId: 'cat-1', unitPrice: '80.00', manualQuantity: null, siteId: null, site: null, deviceRoles: null,
       deviceGroupId: null, deviceGroupName: null, deviceGroup: null,
       taxable: true, sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
     },
@@ -54,7 +54,7 @@ const detail: ContractDetailData = {
 
 const roleLine = {
   id: 'cl-2', contractId: 'ct-1', orgId: 'org-1', lineType: 'per_device_role' as const, description: 'Network gear',
-  catalogItemId: null, unitPrice: '25.00', manualQuantity: null, siteId: null, deviceRoles: ['switch', 'firewall'],
+  catalogItemId: null, unitPrice: '25.00', manualQuantity: null, siteId: null, site: null, deviceRoles: ['switch', 'firewall'],
   deviceGroupId: null, deviceGroupName: null, deviceGroup: null,
   taxable: false, sortOrder: 1, createdAt: '2026-06-01T00:00:00Z',
 };

--- a/apps/web/src/components/contracts/ContractDetail.site.test.tsx
+++ b/apps/web/src/components/contracts/ContractDetail.site.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ContractDetail from './ContractDetail';
+import * as contractsApi from '../../lib/api/contracts';
+import type { ContractDetail as ContractDetailData, ContractLine } from '../../lib/api/contracts';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: Array<{ resource: string; action: string }> } }) => unknown) =>
+      selector({ user: { permissions: [] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+vi.mock('../../lib/api/contracts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/api/contracts')>();
+  return { ...actual, getContractEstimate: vi.fn() };
+});
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const resp = (payload: unknown): Response =>
+  ({ ok: true, status: 200, json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const detail: ContractDetailData = {
+  contract: {
+    id: 'ct-1', partnerId: 'p1', orgId: 'org-1', name: 'Acme MSA', status: 'active',
+    billingTiming: 'advance', intervalMonths: 1, startDate: '2026-06-01', endDate: null,
+    nextBillingAt: '2026-07-01', autoIssue: false, autoRenew: false, renewalTermMonths: null, renewalNoticeDays: null,
+    currencyCode: 'USD', notes: null, terms: null,
+    createdBy: null, createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+  },
+  lines: [],
+  periods: [],
+};
+
+const renderDetail = (lines: ContractLine[]) => {
+  vi.mocked(contractsApi.getContractEstimate).mockResolvedValue(resp({
+    data: { currencyCode: 'USD', periodTotal: '0.00', lines: [], uncoveredDevices: null },
+  }));
+  return render(<ContractDetail detail={{ ...detail, lines }} onChanged={vi.fn()} />);
+};
+
+describe('ContractDetail — line site sub-label (#3205 W03)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders only present line.site names and issues no /sites request', async () => {
+    renderDetail([{
+      id: 'l1', contractId: 'ct-1', orgId: 'org-1', lineType: 'per_device', description: 'Managed device',
+      catalogItemId: null, unitPrice: '10.00', manualQuantity: null, siteId: 'site-1',
+      site: { id: 'site-1', name: 'HQ' }, deviceRoles: null, deviceGroupId: null, deviceGroupName: null,
+      deviceGroup: null, taxable: false, sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
+    }, {
+      id: 'l2', contractId: 'ct-1', orgId: 'org-1', lineType: 'per_device', description: 'Org-wide device',
+      catalogItemId: null, unitPrice: '10.00', manualQuantity: null, siteId: null, site: null,
+      deviceRoles: null, deviceGroupId: null, deviceGroupName: null, deviceGroup: null,
+      taxable: false, sortOrder: 1, createdAt: '2026-06-01T00:00:00Z',
+    }]);
+    expect((await screen.findByTestId('contract-detail-line-site-l1')).textContent).toBe('Site: HQ');
+    expect(screen.getByTestId('contract-detail-line-l2')).toBeInTheDocument();
+    expect(screen.queryByTestId('contract-detail-line-site-l2')).toBeNull();
+    expect(fetchMock.mock.calls.some(([url]) => String(url).startsWith('/orgs/sites'))).toBe(false);
+  });
+});

--- a/apps/web/src/components/contracts/ContractDetail.tsx
+++ b/apps/web/src/components/contracts/ContractDetail.tsx
@@ -377,6 +377,9 @@ export default function ContractDetail({ detail, onChanged }: Props) {
                     <tr key={l.id} className="border-t" data-testid={`contract-detail-line-${l.id}`}>
                       <td className="px-3 py-2">
                         {t(/* i18n-dynamic */ LINE_TYPE_LABELS[l.lineType])}
+                        {l.site
+                          ? <span className="block text-xs text-muted-foreground" data-testid={`contract-detail-line-site-${l.id}`}>{t('contracts.shared.lineScope.site', { name: l.site.name })}</span>
+                          : null}
                         {l.lineType === 'per_device_role' && l.deviceRoles
                           ? <span className="block text-xs text-muted-foreground">{l.deviceRoles.map(getDeviceRoleLabel).join(', ')}</span>
                           : null}

--- a/apps/web/src/components/contracts/ContractEditor.autosave.test.tsx
+++ b/apps/web/src/components/contracts/ContractEditor.autosave.test.tsx
@@ -50,7 +50,7 @@ const draftDetail: ContractDetail = {
   lines: [
     {
       id: 'cl-1', contractId: 'ct-1', orgId: 'org-1', lineType: 'flat', description: 'Managed services',
-      catalogItemId: null, unitPrice: '500.00', manualQuantity: null, siteId: null, deviceRoles: null,
+      catalogItemId: null, unitPrice: '500.00', manualQuantity: null, siteId: null, site: null, deviceRoles: null,
       deviceGroupId: null, deviceGroupName: null, deviceGroup: null, taxable: false,
       sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
     },

--- a/apps/web/src/components/contracts/ContractEditor.editline.test.tsx
+++ b/apps/web/src/components/contracts/ContractEditor.editline.test.tsx
@@ -5,6 +5,7 @@ import ContractEditor from './ContractEditor';
 import { fetchWithAuth } from '../../stores/auth';
 import * as api from '../../lib/api/contracts';
 import type { ContractLine, ContractStatus } from '../../lib/api/contracts';
+import type { CatalogItem } from '../../lib/api/catalog';
 import { showToast } from '../shared/Toast';
 
 const authState = vi.hoisted(() => ({
@@ -21,9 +22,23 @@ vi.mock('../../stores/auth', () => ({
 }));
 vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
 vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
-vi.mock('../catalog/CatalogItemPicker', () => ({ default: () => null }));
+vi.mock('../catalog/CatalogItemPicker', () => ({
+  default: ({ items, onSelect }: { items: CatalogItem[]; onSelect: (item: CatalogItem) => void }) => (
+    <div>{items.map((item) => (
+      <button key={item.id} type="button" data-testid={`catalog-pick-${item.id}`} onClick={() => onSelect(item)}>
+        {item.name}
+      </button>
+    ))}</div>
+  ),
+}));
+const catalogRows = vi.hoisted(() => ({
+  items: [
+    { id: 'cat-1', name: 'Catalog one', isBundle: false },
+    { id: 'cat-2', name: 'Catalog two', isBundle: false },
+  ] as CatalogItem[],
+}));
 vi.mock('../../lib/api/catalog', () => ({
-  listCatalog: vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({ data: [] }) }),
+  listCatalog: vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({ data: catalogRows.items }) }),
   resolveCatalogPrice: vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({ data: null }) }),
 }));
 vi.mock('../../lib/api/contracts', async (importOriginal) => {
@@ -94,6 +109,15 @@ describe('ContractEditor — inline line edit (#3205 W03)', () => {
     expect(screen.queryByTestId('line-remove-0')).toBeNull();
   });
 
+  it.each(['paused', 'cancelled', 'expired'] as const)('disables Add on a %s contract', async (status) => {
+    renderEdit([baseLine], status as ContractStatus);
+    fireEvent.change(await screen.findByTestId('contract-line-desc'), { target: { value: 'Should not add' } });
+    const add = await screen.findByTestId('add-line-btn');
+    expect(add).toBeDisabled();
+    fireEvent.click(add);
+    expect(api.addContractLine).not.toHaveBeenCalled();
+  });
+
   it('renders no Edit or Remove affordance without contracts:write', async () => {
     authState.permissions = [];
     renderEdit();
@@ -162,12 +186,61 @@ describe('ContractEditor — inline line edit (#3205 W03)', () => {
     expect(patchBody()).toEqual({ catalogItemId: null, unitPrice: '20.00', taxable: true });
   });
 
+  it('relinks an unlinked line with only the new catalogItemId', async () => {
+    renderEdit();
+    fireEvent.click(await screen.findByTestId('line-edit-0'));
+    const form = await screen.findByTestId('line-edit-form-0');
+    fireEvent.click(within(form).getByTestId('catalog-pick-cat-2'));
+    expect(screen.getByTestId('line-edit-price-0')).toBeDisabled();
+    expect(screen.getByTestId('line-edit-price-source-0')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('line-edit-save-0'));
+    await waitFor(() => expect(api.updateContractLine).toHaveBeenCalled());
+    expect(patchBody()).toEqual({ catalogItemId: 'cat-2' });
+  });
+
+  it('relinks a linked line to a different item without sending price fields', async () => {
+    renderEdit([{ ...baseLine, catalogItemId: 'cat-1', unitPrice: '20.00', taxable: true }]);
+    fireEvent.click(await screen.findByTestId('line-edit-0'));
+    const form = await screen.findByTestId('line-edit-form-0');
+    fireEvent.click(within(form).getByTestId('catalog-pick-cat-2'));
+    fireEvent.click(screen.getByTestId('line-edit-save-0'));
+    await waitFor(() => expect(api.updateContractLine).toHaveBeenCalled());
+    expect(patchBody()).toEqual({ catalogItemId: 'cat-2' });
+  });
+
+  it('picking the already-linked item leaves Save disabled', async () => {
+    renderEdit([{ ...baseLine, catalogItemId: 'cat-1', unitPrice: '20.00' }]);
+    fireEvent.click(await screen.findByTestId('line-edit-0'));
+    const form = await screen.findByTestId('line-edit-form-0');
+    fireEvent.click(within(form).getByTestId('catalog-pick-cat-1'));
+    expect(screen.getByTestId('line-edit-save-0')).toBeDisabled();
+    expect(api.updateContractLine).not.toHaveBeenCalled();
+  });
+
+  it('restores the persisted catalog link after unlinking', async () => {
+    renderEdit([{ ...baseLine, catalogItemId: 'cat-1', unitPrice: '20.00' }]);
+    fireEvent.click(await screen.findByTestId('line-edit-0'));
+    fireEvent.click(screen.getByTestId('line-edit-unlink-0'));
+    fireEvent.click(screen.getByTestId('line-edit-restore-catalog-0'));
+    expect(screen.getByTestId('line-edit-price-0')).toBeDisabled();
+    expect(screen.getByTestId('line-edit-save-0')).toBeDisabled();
+  });
+
   it('"Refresh price from catalog" sends exactly { refreshCatalogPrice: true }', async () => {
     renderEdit([{ ...baseLine, catalogItemId: 'cat-1', unitPrice: '20.00' }]);
     fireEvent.click(await screen.findByTestId('line-edit-0'));
     fireEvent.click(screen.getByTestId('line-edit-refresh-0'));
     await waitFor(() => expect(api.updateContractLine).toHaveBeenCalled());
     expect(patchBody()).toEqual({ refreshCatalogPrice: true });
+  });
+
+  it('refreshes catalog price without discarding an unsaved description edit', async () => {
+    renderEdit([{ ...baseLine, catalogItemId: 'cat-1', unitPrice: '20.00' }]);
+    fireEvent.click(await screen.findByTestId('line-edit-0'));
+    fireEvent.change(screen.getByTestId('line-edit-desc-0'), { target: { value: 'Renamed before refresh' } });
+    fireEvent.click(screen.getByTestId('line-edit-refresh-0'));
+    await waitFor(() => expect(api.updateContractLine).toHaveBeenCalled());
+    expect(patchBody()).toEqual({ description: 'Renamed before refresh', refreshCatalogPrice: true });
   });
 
   it('shows a catalog-linked price read-only, and keeps Save disabled after an unlink until a price is entered', async () => {
@@ -188,6 +261,16 @@ describe('ContractEditor — inline line edit (#3205 W03)', () => {
     fireEvent.click(await screen.findByTestId('line-edit-0'));
     expect(screen.getByTestId('line-edit-save-0')).toBeDisabled();
     fireEvent.click(screen.getByTestId('line-edit-role-server-0'));
+    expect(screen.getByTestId('line-edit-save-0')).toBeDisabled();
+  });
+
+  it('disables Save when a manual line quantity is empty or invalid', async () => {
+    renderEdit([{ ...baseLine, lineType: 'manual', manualQuantity: '1.00' }]);
+    fireEvent.click(await screen.findByTestId('line-edit-0'));
+    const quantity = screen.getByTestId('line-edit-qty-0');
+    fireEvent.change(quantity, { target: { value: '' } });
+    expect(screen.getByTestId('line-edit-save-0')).toBeDisabled();
+    fireEvent.change(quantity, { target: { value: '1.234' } });
     expect(screen.getByTestId('line-edit-save-0')).toBeDisabled();
   });
 
@@ -214,6 +297,11 @@ describe('ContractEditor — inline line edit (#3205 W03)', () => {
 
   it('renders a site-scoped line with the labelled site sub-label from line.site', async () => {
     renderEdit([{ ...baseLine, siteId: 'site-1', site: { id: 'site-1', name: 'HQ' } }]);
+    expect((await screen.findByTestId('line-site-0')).textContent).toBe('Site: HQ');
+  });
+
+  it('renders the site sub-label whenever line.site is present', async () => {
+    renderEdit([{ ...baseLine, lineType: 'flat', siteId: 'site-1', site: { id: 'site-1', name: 'HQ' } }]);
     expect((await screen.findByTestId('line-site-0')).textContent).toBe('Site: HQ');
   });
 

--- a/apps/web/src/components/contracts/ContractEditor.editline.test.tsx
+++ b/apps/web/src/components/contracts/ContractEditor.editline.test.tsx
@@ -1,0 +1,250 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ContractEditor from './ContractEditor';
+import { fetchWithAuth } from '../../stores/auth';
+import * as api from '../../lib/api/contracts';
+import type { ContractLine, ContractStatus } from '../../lib/api/contracts';
+import { showToast } from '../shared/Toast';
+
+const authState = vi.hoisted(() => ({
+  permissions: [{ resource: '*', action: '*' }],
+}));
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: authState.permissions } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+vi.mock('../catalog/CatalogItemPicker', () => ({ default: () => null }));
+vi.mock('../../lib/api/catalog', () => ({
+  listCatalog: vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({ data: [] }) }),
+  resolveCatalogPrice: vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({ data: null }) }),
+}));
+vi.mock('../../lib/api/contracts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/api/contracts')>();
+  return {
+    ...actual,
+    createContract: vi.fn(), updateContract: vi.fn(), addContractLine: vi.fn(),
+    removeContractLine: vi.fn(), updateContractLine: vi.fn(), contractTransition: vi.fn(),
+    getContractEstimate: vi.fn(),
+  };
+});
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const resp = (payload: unknown, ok = true, status = ok ? 200 : 400): Response =>
+  ({ ok, status, statusText: 'OK', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const contract = {
+  id: 'ct-1', partnerId: 'p1', orgId: 'org-1', name: 'Acme MSA', status: 'draft', billingTiming: 'advance',
+  intervalMonths: 1, startDate: '2026-06-01', endDate: null, nextBillingAt: null, autoIssue: false, autoRenew: false,
+  renewalTermMonths: null, renewalNoticeDays: null, currencyCode: 'USD', notes: null, terms: null,
+  createdBy: null, createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+} as const;
+
+const baseLine: ContractLine = {
+  id: 'l1', contractId: 'ct-1', orgId: 'org-1', lineType: 'per_device', description: 'Managed device',
+  catalogItemId: null, unitPrice: '10.00', manualQuantity: null, siteId: null, deviceRoles: null,
+  deviceGroupId: null, deviceGroupName: null, deviceGroup: null, site: null, taxable: false, sortOrder: 0,
+  createdAt: '2026-06-01T00:00:00Z',
+};
+
+describe('ContractEditor — inline line edit (#3205 W03)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authState.permissions = [{ resource: '*', action: '*' }];
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.startsWith('/orgs/organizations')) return resp({ data: [{ id: 'org-1', name: 'Acme' }] });
+      if (url.startsWith('/orgs/sites')) return resp({ data: [{ id: 'site-1', name: 'HQ' }] });
+      if (url.startsWith('/device-groups')) return resp({ data: [{ id: 'g-1', name: 'VIP laptops', type: 'static' }] });
+      return resp({ data: {} });
+    });
+    (api.getContractEstimate as any).mockResolvedValue(resp({
+      data: { currencyCode: 'USD', periodTotal: '0.00', lines: [], uncoveredDevices: null },
+    }));
+    (api.updateContractLine as any).mockResolvedValue(resp({ data: { ...baseLine, description: 'Renamed' } }));
+  });
+
+  const detailFor = (lines: ContractLine[] = [baseLine], status: ContractStatus = 'draft') => ({
+    contract: { ...contract, status }, lines, periods: [],
+  });
+
+  const renderEdit = (lines: ContractLine[] = [baseLine], status: ContractStatus = 'draft') =>
+    render(<ContractEditor detail={detailFor(lines, status)} onChanged={vi.fn()} />);
+
+  const patchBody = () => (api.updateContractLine as any).mock.calls[0][2] as Record<string, unknown>;
+
+  // Decision 11: Remove was gated on permission alone and 409'd on click for a
+  // cancelled or expired contract. Edit and Remove now share one predicate.
+  it.each(['draft', 'active'] as const)('renders Edit and Remove on a %s contract', async (status) => {
+    renderEdit([baseLine], status);
+    expect(await screen.findByTestId('line-edit-0')).toBeInTheDocument();
+    expect(screen.getByTestId('line-remove-0')).toBeInTheDocument();
+  });
+
+  it.each(['paused', 'cancelled', 'expired'] as const)('renders NEITHER on a %s contract', async (status) => {
+    renderEdit([baseLine], status as ContractStatus);
+    await screen.findByTestId('line-row-0');
+    expect(screen.queryByTestId('line-edit-0')).toBeNull();
+    expect(screen.queryByTestId('line-remove-0')).toBeNull();
+  });
+
+  it('renders no Edit or Remove affordance without contracts:write', async () => {
+    authState.permissions = [];
+    renderEdit();
+    await screen.findByTestId('line-row-0');
+    expect(screen.queryByTestId('line-edit-0')).toBeNull();
+    expect(screen.queryByTestId('line-remove-0')).toBeNull();
+  });
+
+  it('moves focus into the form on open and returns it to Edit on cancel', async () => {
+    renderEdit();
+    const edit = await screen.findByTestId('line-edit-0');
+    fireEvent.click(edit);
+    expect(await screen.findByTestId('line-edit-desc-0')).toHaveFocus();
+    fireEvent.click(screen.getByTestId('line-edit-cancel-0'));
+    await waitFor(() => expect(screen.getByTestId('line-edit-0')).toHaveFocus());
+  });
+
+  it('discards draft changes on cancel and restores persisted row values', async () => {
+    renderEdit();
+    fireEvent.click(await screen.findByTestId('line-edit-0'));
+    fireEvent.change(screen.getByTestId('line-edit-desc-0'), { target: { value: 'Discard me' } });
+    fireEvent.click(screen.getByTestId('line-edit-cancel-0'));
+    expect(screen.getByTestId('line-row-0')).toHaveTextContent('Managed device');
+    fireEvent.click(screen.getByTestId('line-edit-0'));
+    expect(screen.getByTestId('line-edit-desc-0')).toHaveValue('Managed device');
+  });
+
+  it('shows the type as a locked label with no type select', async () => {
+    renderEdit();
+    fireEvent.click(await screen.findByTestId('line-edit-0'));
+    const form = await screen.findByTestId('line-edit-form-0');
+    expect(within(form).getByTestId('line-edit-type-locked').textContent).toMatch(/can.t be changed/i);
+    expect(within(form).queryByTestId('line-edit-type')).toBeNull();
+  });
+
+  it('sends ONLY the changed field for a description-only edit', async () => {
+    renderEdit();
+    fireEvent.click(await screen.findByTestId('line-edit-0'));
+    fireEvent.change(screen.getByTestId('line-edit-desc-0'), { target: { value: 'Renamed' } });
+    fireEvent.click(screen.getByTestId('line-edit-save-0'));
+    await waitFor(() => expect(api.updateContractLine).toHaveBeenCalled());
+    expect(patchBody()).toEqual({ description: 'Renamed' });
+  });
+
+  it('diffs against the immutable row snapshot captured when edit opened', async () => {
+    const view = renderEdit();
+    fireEvent.click(await screen.findByTestId('line-edit-0'));
+    view.rerender(<ContractEditor
+      detail={detailFor([{ ...baseLine, unitPrice: '12.00' }])}
+      onChanged={vi.fn()}
+    />);
+    fireEvent.change(screen.getByTestId('line-edit-desc-0'), { target: { value: 'Renamed' } });
+    fireEvent.click(screen.getByTestId('line-edit-save-0'));
+    await waitFor(() => expect(api.updateContractLine).toHaveBeenCalled());
+    expect(patchBody()).toEqual({ description: 'Renamed' });
+  });
+
+  // The unlink EXCEPTION to the minimal patch: transition row 6 requires all
+  // three, so a minimal patch would 400 on a legitimate gesture.
+  it('sends catalogItemId, unitPrice and taxable together on an unlink even when neither was retyped', async () => {
+    renderEdit([{ ...baseLine, catalogItemId: 'cat-1', unitPrice: '20.00', taxable: true }]);
+    fireEvent.click(await screen.findByTestId('line-edit-0'));
+    fireEvent.click(screen.getByTestId('line-edit-unlink-0'));
+    fireEvent.click(screen.getByTestId('line-edit-save-0'));
+    await waitFor(() => expect(api.updateContractLine).toHaveBeenCalled());
+    expect(patchBody()).toEqual({ catalogItemId: null, unitPrice: '20.00', taxable: true });
+  });
+
+  it('"Refresh price from catalog" sends exactly { refreshCatalogPrice: true }', async () => {
+    renderEdit([{ ...baseLine, catalogItemId: 'cat-1', unitPrice: '20.00' }]);
+    fireEvent.click(await screen.findByTestId('line-edit-0'));
+    fireEvent.click(screen.getByTestId('line-edit-refresh-0'));
+    await waitFor(() => expect(api.updateContractLine).toHaveBeenCalled());
+    expect(patchBody()).toEqual({ refreshCatalogPrice: true });
+  });
+
+  it('shows a catalog-linked price read-only, and keeps Save disabled after an unlink until a price is entered', async () => {
+    renderEdit([{ ...baseLine, catalogItemId: 'cat-1', unitPrice: '20.00', taxable: true }]);
+    fireEvent.click(await screen.findByTestId('line-edit-0'));
+    expect(screen.getByTestId('line-edit-price-0')).toBeDisabled();
+    expect(screen.getByTestId('line-edit-taxable-0')).toBeDisabled();
+    fireEvent.click(screen.getByTestId('line-edit-unlink-0'));
+    expect(screen.getByTestId('line-edit-price-0')).not.toBeDisabled();
+    fireEvent.change(screen.getByTestId('line-edit-price-0'), { target: { value: '' } });
+    expect(screen.getByTestId('line-edit-save-0')).toBeDisabled();
+    fireEvent.change(screen.getByTestId('line-edit-price-0'), { target: { value: '3.00' } });
+    expect(screen.getByTestId('line-edit-save-0')).not.toBeDisabled();
+  });
+
+  it('disables Save with no changes and with no roles left on a role line', async () => {
+    renderEdit([{ ...baseLine, lineType: 'per_device_role', deviceRoles: ['server'] }]);
+    fireEvent.click(await screen.findByTestId('line-edit-0'));
+    expect(screen.getByTestId('line-edit-save-0')).toBeDisabled();
+    fireEvent.click(screen.getByTestId('line-edit-role-server-0'));
+    expect(screen.getByTestId('line-edit-save-0')).toBeDisabled();
+  });
+
+  // The orphaned-group repair: Save stays disabled until a live group is picked,
+  // so a patch can never re-send the null the FK left behind.
+  it('disables Save on an orphaned group line until a group is picked', async () => {
+    renderEdit([{ ...baseLine, lineType: 'per_device_group', siteId: null, deviceGroupId: null, deviceGroupName: 'Retired', deviceGroup: null }]);
+    fireEvent.click(await screen.findByTestId('line-edit-0'));
+    expect(screen.getByTestId('line-edit-save-0')).toBeDisabled();
+    const select = await screen.findByTestId('line-edit-group-0');
+    expect(await within(select).findByTestId('line-edit-group-option-g-1')).toHaveTextContent('VIP laptops');
+    fireEvent.change(select, { target: { value: 'g-1' } });
+    expect(screen.getByTestId('line-edit-save-0')).not.toBeDisabled();
+    fireEvent.click(screen.getByTestId('line-edit-save-0'));
+    await waitFor(() => expect(api.updateContractLine).toHaveBeenCalled());
+    expect(patchBody()).toEqual({ deviceGroupId: 'g-1' });
+  });
+
+  it('disables Edit on every other row while one is open', async () => {
+    renderEdit([baseLine, { ...baseLine, id: 'l2', description: 'Second' }]);
+    fireEvent.click(await screen.findByTestId('line-edit-0'));
+    expect(screen.getByTestId('line-edit-1')).toBeDisabled();
+  });
+
+  it('renders a site-scoped line with the labelled site sub-label from line.site', async () => {
+    renderEdit([{ ...baseLine, siteId: 'site-1', site: { id: 'site-1', name: 'HQ' } }]);
+    expect((await screen.findByTestId('line-site-0')).textContent).toBe('Site: HQ');
+  });
+
+  it.each([
+    ['INVALID_STATE', 'Lines can only be edited on draft or active contracts.'],
+    ['INVALID_LINE_PATCH', 'Those changes aren’t valid for this line type.'],
+    ['LINE_NOT_FOUND', 'That line no longer exists. Refresh the contract.'],
+    ['SITE_NOT_IN_ORG', 'That site belongs to a different organization.'],
+    ['GROUP_NOT_IN_ORG', 'That device group belongs to a different organization.'],
+    ['CATALOG_ITEM_NOT_FOUND', 'That catalog item isn’t available on this contract.'],
+  ])('toasts the friendly message on %s and keeps the row in edit mode', async (code, message) => {
+    (api.updateContractLine as any).mockResolvedValue(
+      resp({ error: 'not editable', code }, false, 409),
+    );
+    renderEdit();
+    fireEvent.click(await screen.findByTestId('line-edit-0'));
+    fireEvent.change(screen.getByTestId('line-edit-desc-0'), { target: { value: 'Renamed' } });
+    fireEvent.click(screen.getByTestId('line-edit-save-0'));
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error', message }),
+    ));
+    expect(screen.getByTestId('line-edit-form-0')).toBeInTheDocument();
+  });
+
+  it('does not toast on a 401 — the auth redirect is the feedback', async () => {
+    (api.updateContractLine as any).mockResolvedValue(resp({ error: 'Unauthorized' }, false, 401));
+    renderEdit();
+    fireEvent.click(await screen.findByTestId('line-edit-0'));
+    fireEvent.change(screen.getByTestId('line-edit-desc-0'), { target: { value: 'Renamed' } });
+    fireEvent.click(screen.getByTestId('line-edit-save-0'));
+    await waitFor(() => expect(api.updateContractLine).toHaveBeenCalled());
+    expect(showToast).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+  });
+});

--- a/apps/web/src/components/contracts/ContractEditor.permissions.test.tsx
+++ b/apps/web/src/components/contracts/ContractEditor.permissions.test.tsx
@@ -57,7 +57,7 @@ const draftDetail: ContractDetail = {
   lines: [
     {
       id: 'cl-1', contractId: 'ct-1', orgId: 'org-1', lineType: 'flat', description: 'Managed services',
-      catalogItemId: null, unitPrice: '500.00', manualQuantity: null, siteId: null, deviceRoles: null,
+      catalogItemId: null, unitPrice: '500.00', manualQuantity: null, siteId: null, site: null, deviceRoles: null,
       deviceGroupId: null, deviceGroupName: null, deviceGroup: null, taxable: false,
       sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
     },

--- a/apps/web/src/components/contracts/ContractEditor.tsx
+++ b/apps/web/src/components/contracts/ContractEditor.tsx
@@ -81,6 +81,7 @@ function buildLinePatch(l: ContractLine, d: EditLineDraft): UpdateContractLinePa
     patch.unitPrice = d.unitPrice;
     patch.taxable = d.taxable;
   } else {
+    if (d.catalogItemId && d.catalogItemId !== l.catalogItemId) patch.catalogItemId = d.catalogItemId;
     if (d.catalogItemId === null && d.unitPrice !== l.unitPrice) patch.unitPrice = d.unitPrice;
     if (d.catalogItemId === null && d.taxable !== l.taxable) patch.taxable = d.taxable;
   }
@@ -96,6 +97,7 @@ function editDraftIncomplete(l: ContractLine, d: EditLineDraft): boolean {
   if (!d.description.trim()) return true;
   if (l.lineType === 'per_device_role' && d.deviceRoles.length === 0) return true;
   if (l.lineType === 'per_device_group' && !d.deviceGroupId) return true;
+  if (l.lineType === 'manual' && !MONEY_RE.test(d.manualQuantity)) return true;
   if (d.catalogItemId === null && !MONEY_RE.test(d.unitPrice)) return true;
   return false;
 }
@@ -677,7 +679,7 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
   }, [canWrite, isCreate, terms, contract, savePatch]);
 
   const addLine = useCallback(async () => {
-    if (busy || !contract || !lineDesc.trim() || catalogPriceUnresolved || roleLineMissingRoles || groupLineMissingGroup) return;
+    if (busy || !contract || !linesEditable || !lineDesc.trim() || catalogPriceUnresolved || roleLineMissingRoles || groupLineMissingGroup) return;
     setBusy(true);
     try {
       await runAction({
@@ -713,7 +715,7 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
     } finally {
       setBusy(false);
     }
-  }, [busy, contract, lineType, lineDesc, linePrice, lineQty, lineSiteId, lineRoles, lineGroupId, lineCatalogItem, lineTaxable, catalogPriceUnresolved, roleLineMissingRoles, groupLineMissingGroup, refresh, t]);
+  }, [busy, contract, linesEditable, lineType, lineDesc, linePrice, lineQty, lineSiteId, lineRoles, lineGroupId, lineCatalogItem, lineTaxable, catalogPriceUnresolved, roleLineMissingRoles, groupLineMissingGroup, refresh, t]);
 
   const removeLine = useCallback((lineId: string) =>
     runScoped(`remove-${lineId}`, async () => {
@@ -1120,6 +1122,19 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                                         {!d.deviceGroupId && <span className="text-amber-600 dark:text-amber-500">{t('contracts.contractEditor.addLine.deviceGroupRequired')}</span>}
                                       </label>
                                     )}
+                                    {catalogItems.length > 0 && (
+                                      <div className="flex flex-col gap-1 text-xs text-muted-foreground">
+                                        {t('contracts.contractEditor.addLine.linkCatalogItemOptional')}
+                                        <CatalogItemPicker
+                                          items={catalogItems}
+                                          currencyCode={contractCurrency ?? ''}
+                                          includeBundles={false}
+                                          onSelect={(item) => setEditDraft({ ...d, catalogItemId: item.id })}
+                                          testId={`line-edit-catalog-picker-${idx}`}
+                                          placeholder={t('contracts.contractEditor.addLine.searchCatalog')}
+                                        />
+                                      </div>
+                                    )}
                                     <label className="flex items-center gap-2 text-xs text-muted-foreground">
                                       <input
                                         type="checkbox" checked={d.taxable} disabled={d.catalogItemId !== null}
@@ -1180,7 +1195,7 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                                       <>
                                         <button
                                           type="button" disabled={isPending(`edit-${l.id}`)}
-                                          onClick={() => void saveLine(l, { refreshCatalogPrice: true })}
+                                          onClick={() => void saveLine(l, { ...(patch ?? {}), refreshCatalogPrice: true })}
                                           data-testid={`line-edit-refresh-${idx}`}
                                           className="inline-flex h-8 items-center rounded-md border px-3 text-xs font-medium hover:bg-muted disabled:opacity-50"
                                         >
@@ -1195,6 +1210,16 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                                         </button>
                                       </>
                                     )}
+                                    {l.catalogItemId !== null && d.catalogItemId === null && (
+                                      <button
+                                        type="button"
+                                        onClick={() => setEditDraft({ ...d, catalogItemId: l.catalogItemId })}
+                                        data-testid={`line-edit-restore-catalog-${idx}`}
+                                        className="inline-flex h-8 items-center rounded-md border px-3 text-xs font-medium hover:bg-muted"
+                                      >
+                                        {t('contracts.contractEditor.editLine.restoreCatalogLink')}
+                                      </button>
+                                    )}
                                     {patch && Object.keys(patch).length === 0 && (
                                       <span className="text-xs text-muted-foreground">{t('contracts.contractEditor.editLine.noChanges')}</span>
                                     )}
@@ -1205,7 +1230,7 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                               <>
                                 <td className="px-3 py-2">
                                   {t(/* i18n-dynamic */ LINE_TYPE_LABELS[l.lineType])}
-                                  {SITE_SCOPED_TYPES.has(l.lineType) && l.site
+                                  {l.site
                                     ? <span className="block text-xs text-muted-foreground" data-testid={`line-site-${idx}`}>{t('contracts.shared.lineScope.site', { name: l.site.name })}</span>
                                     : null}
                                   {l.lineType === 'per_device_role' && l.deviceRoles
@@ -1498,7 +1523,7 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                   </span>
                   {can('contracts', 'write') && (
                     <button
-                      type="button" onClick={() => void addLine()} disabled={busy || !lineDesc.trim() || catalogPriceUnresolved || roleLineMissingRoles || groupLineMissingGroup}
+                      type="button" onClick={() => void addLine()} disabled={busy || !linesEditable || !lineDesc.trim() || catalogPriceUnresolved || roleLineMissingRoles || groupLineMissingGroup}
                       data-testid="add-line-btn"
                       className="inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
                     >

--- a/apps/web/src/components/contracts/ContractEditor.tsx
+++ b/apps/web/src/components/contracts/ContractEditor.tsx
@@ -16,6 +16,7 @@ import {
   updateContract,
   addContractLine,
   removeContractLine,
+  updateContractLine,
   contractTransition,
   getContractEstimate,
   type ContractBillingTiming,
@@ -23,6 +24,7 @@ import {
   type ContractLine,
   type ContractLineType,
   type ContractEstimate,
+  type UpdateContractLinePatch,
 } from '../../lib/api/contracts';
 import CatalogItemPicker from '../catalog/CatalogItemPicker';
 import CatalogDistributorDrawer from '../settings/CatalogDistributorDrawer';
@@ -38,6 +40,65 @@ import DeviceCoverageNotice from './DeviceCoverageNotice';
 
 interface Organization { id: string; name: string }
 interface Site { id: string; name: string }
+
+interface EditLineDraft {
+  description: string;
+  unitPrice: string;
+  taxable: boolean;
+  manualQuantity: string;
+  siteId: string;
+  deviceRoles: Exclude<DeviceRole, 'unknown'>[];
+  deviceGroupId: string;
+  catalogItemId: string | null;
+}
+
+function draftFromLine(l: ContractLine): EditLineDraft {
+  return {
+    description: l.description,
+    unitPrice: l.unitPrice,
+    taxable: l.taxable,
+    manualQuantity: l.manualQuantity ?? '0',
+    siteId: l.siteId ?? '',
+    deviceRoles: (l.deviceRoles ?? []) as Exclude<DeviceRole, 'unknown'>[],
+    deviceGroupId: l.deviceGroupId ?? '',
+    catalogItemId: l.catalogItemId,
+  };
+}
+
+const sameRoleSet = (a: readonly string[], b: readonly string[] | null): boolean => {
+  const other = b ?? [];
+  return a.length === other.length && [...a].sort().join(',') === [...other].sort().join(',');
+};
+
+const MONEY_RE = /^\d+(\.\d{1,2})?$/;
+
+function buildLinePatch(l: ContractLine, d: EditLineDraft): UpdateContractLinePatch {
+  const patch: UpdateContractLinePatch = {};
+  if (d.description.trim() !== l.description) patch.description = d.description.trim();
+
+  if (l.catalogItemId !== null && d.catalogItemId === null) {
+    patch.catalogItemId = null;
+    patch.unitPrice = d.unitPrice;
+    patch.taxable = d.taxable;
+  } else {
+    if (d.catalogItemId === null && d.unitPrice !== l.unitPrice) patch.unitPrice = d.unitPrice;
+    if (d.catalogItemId === null && d.taxable !== l.taxable) patch.taxable = d.taxable;
+  }
+
+  if (l.lineType === 'manual' && d.manualQuantity !== (l.manualQuantity ?? '0')) patch.manualQuantity = d.manualQuantity;
+  if (SITE_SCOPED_TYPES.has(l.lineType) && (d.siteId || null) !== l.siteId) patch.siteId = d.siteId || null;
+  if (l.lineType === 'per_device_role' && !sameRoleSet(d.deviceRoles, l.deviceRoles)) patch.deviceRoles = d.deviceRoles;
+  if (l.lineType === 'per_device_group' && d.deviceGroupId && d.deviceGroupId !== l.deviceGroupId) patch.deviceGroupId = d.deviceGroupId;
+  return patch;
+}
+
+function editDraftIncomplete(l: ContractLine, d: EditLineDraft): boolean {
+  if (!d.description.trim()) return true;
+  if (l.lineType === 'per_device_role' && d.deviceRoles.length === 0) return true;
+  if (l.lineType === 'per_device_group' && !d.deviceGroupId) return true;
+  if (d.catalogItemId === null && !MONEY_RE.test(d.unitPrice)) return true;
+  return false;
+}
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
 
@@ -144,6 +205,12 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
   const [lineSiteId, setLineSiteId] = useState('');
   const [lineRoles, setLineRoles] = useState<Exclude<DeviceRole, 'unknown'>[]>([]);
   const [lineGroupId, setLineGroupId] = useState('');
+  const [editingLineId, setEditingLineId] = useState<string | null>(null);
+  const [editDraft, setEditDraft] = useState<EditLineDraft | null>(null);
+  const [editBase, setEditBase] = useState<ContractLine | null>(null);
+  const editFirstControlRef = useRef<HTMLInputElement>(null);
+  const editButtonRefs = useRef(new Map<string, HTMLButtonElement>());
+  const returnFocusLineId = useRef<string | null>(null);
   // Linked catalog item (optional). A catalog line is priced by the SERVER in
   // the contract's currency (#3775 — price book, no conversion): the editor
   // shows that price read-only and never sends unitPrice/taxable for it.
@@ -160,6 +227,18 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
   const [pax8Active, setPax8Active] = useState(false);
 
   const lines: ContractLine[] = detail?.lines ?? [];
+
+  useEffect(() => {
+    if (editingLineId !== null) {
+      editFirstControlRef.current?.focus();
+      return;
+    }
+    const lineId = returnFocusLineId.current;
+    if (lineId !== null) {
+      editButtonRefs.current.get(lineId)?.focus();
+      returnFocusLineId.current = null;
+    }
+  }, [editingLineId]);
 
   // Line removal is irreversible, so it goes through a confirm step (mirrors the
   // quote/invoice editors) instead of deleting outright.
@@ -420,6 +499,9 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
   const catalogPriceUnresolved = lineCatalogItem != null && catalogPrice == null;
   // #3205: per_device_role requires at least one role picked before Add is allowed.
   const roleLineMissingRoles = lineType === 'per_device_role' && lineRoles.length === 0;
+  // #3205 W03: lines are editable on draft/active only (assertEditable). Remove
+  // was gated on permission ALONE and 409'd on click for cancelled/expired.
+  const linesEditable = canWrite && (contract?.status === 'draft' || contract?.status === 'active');
   const groupLineMissingGroup = lineType === 'per_device_group' && !lineGroupId;
   const effectiveLinePrice = lineCatalogItem ? (catalogPrice?.unitPrice ?? '0') : linePrice;
 
@@ -646,6 +728,32 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
     }, t('contracts.contractEditor.errors.removeLine')),
   [runScoped, contract, refresh, t]);
 
+  const saveLine = useCallback((l: ContractLine, patch: UpdateContractLinePatch) =>
+    runScoped(`edit-${l.id}`, async () => {
+      if (!contract) return;
+      await runAction({
+        request: () => updateContractLine(contract.id, l.id, patch),
+        errorFallback: t('contracts.contractEditor.errors.updateLine'),
+        friendly: (code) => ({
+          NO_PRICE_FOR_CURRENCY: t('contracts.contractEditor.errors.noPriceForCurrency', { currency: contract.currencyCode }),
+          PRICE_NOT_REPRESENTABLE: t('contracts.contractEditor.errors.priceNotRepresentable', { currency: contract.currencyCode }),
+          CATALOG_ITEM_NOT_FOUND: t('contracts.contractEditor.errors.catalogItemNotFound'),
+          INVALID_STATE: t('contracts.contractEditor.errors.contractNotEditable'),
+          LINE_NOT_FOUND: t('contracts.contractEditor.errors.lineNotFound'),
+          SITE_NOT_IN_ORG: t('contracts.contractEditor.errors.siteNotInOrg'),
+          GROUP_NOT_IN_ORG: t('contracts.contractEditor.errors.groupNotInOrg'),
+          INVALID_LINE_PATCH: t('contracts.contractEditor.errors.invalidLinePatch'),
+        } as Record<string, string>)[code],
+        successMessage: t('contracts.contractEditor.toast.lineUpdated'),
+        onUnauthorized: UNAUTHORIZED,
+      });
+      setEditingLineId(null);
+      setEditDraft(null);
+      setEditBase(null);
+      refresh();
+    }, t('contracts.contractEditor.errors.updateLine')),
+  [runScoped, contract, refresh, t]);
+
   const activate = useCallback(async () => {
     if (busy || !contract) return;
     setBusy(true);
@@ -663,11 +771,6 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
       setBusy(false);
     }
   }, [busy, contract, refresh, t]);
-
-  const siteName = useCallback(
-    (id: string | null) => (id ? sites.find((s) => s.id === id)?.name ?? id.slice(0, 8) : null),
-    [sites],
-  );
 
   // Shared field chrome. `transition-colors` pairs with fieldRing's border-color
   // cue (border-color is not in the shadow property set, so `transition-shadow`
@@ -938,49 +1041,237 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
                         </td>
                       </tr>
                     ) : (
-                      lines.map((l, idx) => (
-                        <tr key={l.id} className="border-t" data-testid={`line-row-${idx}`}>
-                          <td className="px-3 py-2">
-                            {t(/* i18n-dynamic */ LINE_TYPE_LABELS[l.lineType])}
-                            {SITE_SCOPED_TYPES.has(l.lineType) && l.siteId
-                              ? <span className="block text-xs text-muted-foreground">{siteName(l.siteId)}</span>
-                              : null}
-                            {l.lineType === 'per_device_role' && l.deviceRoles
-                              ? <span className="block text-xs text-muted-foreground" data-testid={`line-roles-${idx}`}>{l.deviceRoles.map(getDeviceRoleLabel).join(', ')}</span>
-                              : null}
-                            {l.lineType === 'per_device_group'
-                              ? <span className="block text-xs text-muted-foreground" data-testid={`line-group-${idx}`}>
-                                  {l.deviceGroup
-                                    ? `${l.deviceGroup.name}${l.deviceGroup.type === 'dynamic' ? ` · ${t('contracts.shared.dynamicGroup')}` : ''}`
-                                    : t('contracts.shared.deletedGroup', { name: l.deviceGroupName ?? '' })}
-                                </span>
-                              : null}
-                          </td>
-                          <td className="px-3 py-2">{l.description}</td>
-                          <td className="px-3 py-2 text-right">{formatMoney(l.unitPrice, contract?.currencyCode)}</td>
-                          <td className="px-3 py-2 text-right tabular-nums" data-testid={`line-qty-${idx}`}>
-                            {AUTO_QTY_TYPES.has(l.lineType)
-                              ? (estByLine.has(l.id)
-                                  ? (estByLine.get(l.id)?.unresolved === 'group_deleted'
-                                      ? t('contracts.shared.values.groupDeleted')
-                                      : estByLine.get(l.id)?.quantity)
-                                  : <span className="text-muted-foreground">{t('contracts.shared.values.auto')}</span>)
-                              : (l.lineType === 'manual' ? (l.manualQuantity ?? '0') : '1')}
-                          </td>
-                          <td className="px-3 py-2 text-center">{l.taxable ? '✓' : '—'}</td>
-                          <td className="px-3 py-2 text-right">
-                            {canWrite && (
-                              <button
-                                type="button" onClick={() => setPendingRemove(l)} disabled={isPending(`remove-${l.id}`)}
-                                data-testid={`line-remove-${idx}`}
-                                className="rounded-md border border-destructive/40 px-2 py-1 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
-                              >
-                                {t('common:actions.remove')}
-                              </button>
+                      lines.map((l, idx) => {
+                        const editing = editingLineId === l.id;
+                        const d = editing ? editDraft : null;
+                        const base = editing ? editBase : null;
+                        const patch = editing && d && base ? buildLinePatch(base, d) : null;
+                        const saveDisabled = !d || !patch || Object.keys(patch).length === 0
+                          || !base || editDraftIncomplete(base, d) || isPending(`edit-${l.id}`);
+                        return (
+                          <tr key={l.id} className="border-t" data-testid={`line-row-${idx}`}>
+                            {editing && d ? (
+                              <td className="px-3 py-3" colSpan={6}>
+                                <div className="flex flex-col gap-3" data-testid={`line-edit-form-${idx}`}>
+                                  <span className="text-xs text-muted-foreground" data-testid={`line-edit-type-locked-${idx}`}>
+                                    {t(/* i18n-dynamic */ LINE_TYPE_LABELS[l.lineType])} — <span data-testid="line-edit-type-locked">{t('contracts.contractEditor.editLine.typeLocked')}</span>
+                                  </span>
+                                  <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                                    <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+                                      {t('common:labels.description')}
+                                      <input
+                                        ref={editFirstControlRef}
+                                        value={d.description}
+                                        onChange={(e) => setEditDraft({ ...d, description: e.target.value })}
+                                        data-testid={`line-edit-desc-${idx}`}
+                                        className="h-9 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-hidden focus:ring-2 focus:ring-ring"
+                                      />
+                                    </label>
+                                    <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+                                      {t('contracts.contractEditor.lines.unitPrice')}
+                                      <input
+                                        value={d.unitPrice} disabled={d.catalogItemId !== null}
+                                        onChange={(e) => setEditDraft({ ...d, unitPrice: e.target.value })}
+                                        data-testid={`line-edit-price-${idx}`}
+                                        className="h-9 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-50"
+                                      />
+                                      {d.catalogItemId !== null && (
+                                        <span data-testid={`line-edit-price-source-${idx}`}>{t('contracts.contractEditor.editLine.priceFromCatalog')}</span>
+                                      )}
+                                      {d.catalogItemId === null && l.catalogItemId !== null && (
+                                        <span className="text-amber-600 dark:text-amber-500">{t('contracts.contractEditor.editLine.unlinkNeedsPrice')}</span>
+                                      )}
+                                    </label>
+                                    {l.lineType === 'manual' && (
+                                      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+                                        {t('contracts.contractEditor.addLine.quantity')}
+                                        <input
+                                          value={d.manualQuantity}
+                                          onChange={(e) => setEditDraft({ ...d, manualQuantity: e.target.value })}
+                                          data-testid={`line-edit-qty-${idx}`}
+                                          className="h-9 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-hidden focus:ring-2 focus:ring-ring"
+                                        />
+                                      </label>
+                                    )}
+                                    {SITE_SCOPED_TYPES.has(l.lineType) && (
+                                      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+                                        {t('contracts.contractEditor.addLine.siteOptional')}
+                                        <select
+                                          value={d.siteId} onChange={(e) => setEditDraft({ ...d, siteId: e.target.value })}
+                                          data-testid={`line-edit-site-${idx}`}
+                                          className="h-9 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-hidden focus:ring-2 focus:ring-ring"
+                                        >
+                                          <option value="">{t('contracts.contractEditor.addLine.allSites')}</option>
+                                          {sites.map((s) => <option key={s.id} value={s.id}>{s.name}</option>)}
+                                        </select>
+                                      </label>
+                                    )}
+                                    {l.lineType === 'per_device_group' && (
+                                      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+                                        {t('contracts.contractEditor.addLine.deviceGroup')}
+                                        <select
+                                          value={d.deviceGroupId} onChange={(e) => setEditDraft({ ...d, deviceGroupId: e.target.value })}
+                                          data-testid={`line-edit-group-${idx}`}
+                                          className="h-9 rounded-md border bg-background px-3 text-sm text-foreground focus:outline-hidden focus:ring-2 focus:ring-ring"
+                                        >
+                                          <option value="">{t('contracts.contractEditor.addLine.selectGroup')}</option>
+                                          {deviceGroupsList.map((g) => <option key={g.id} value={g.id} data-testid={`line-edit-group-option-${g.id}`}>{g.name}</option>)}
+                                        </select>
+                                        {!d.deviceGroupId && <span className="text-amber-600 dark:text-amber-500">{t('contracts.contractEditor.addLine.deviceGroupRequired')}</span>}
+                                      </label>
+                                    )}
+                                    <label className="flex items-center gap-2 text-xs text-muted-foreground">
+                                      <input
+                                        type="checkbox" checked={d.taxable} disabled={d.catalogItemId !== null}
+                                        onChange={(e) => setEditDraft({ ...d, taxable: e.target.checked })}
+                                        data-testid={`line-edit-taxable-${idx}`}
+                                      />
+                                      {t('contracts.contractEditor.lines.tax')}
+                                    </label>
+                                  </div>
+                                  {l.lineType === 'per_device_role' && (
+                                    <fieldset className="flex flex-col gap-1 text-xs text-muted-foreground" data-testid={`line-edit-roles-${idx}`}>
+                                      <legend className="mb-1">{t('contracts.contractEditor.addLine.deviceRoles')}</legend>
+                                      <div className="flex flex-wrap gap-2">
+                                        {BILLABLE_DEVICE_ROLES.map((role) => {
+                                          const checked = d.deviceRoles.includes(role);
+                                          return (
+                                            <label key={role} className={`inline-flex h-8 cursor-pointer items-center gap-1.5 rounded-md border px-2.5 text-sm ${checked ? 'border-primary bg-primary/10 text-foreground' : 'bg-background text-muted-foreground hover:text-foreground'}`}>
+                                              <input
+                                                type="checkbox" className="sr-only" checked={checked}
+                                                onChange={() => setEditDraft({
+                                                  ...d,
+                                                  deviceRoles: checked ? d.deviceRoles.filter((r) => r !== role) : [...d.deviceRoles, role],
+                                                })}
+                                                data-testid={`line-edit-role-${role}-${idx}`}
+                                              />
+                                              {getDeviceRoleLabel(role)}
+                                            </label>
+                                          );
+                                        })}
+                                      </div>
+                                      {d.deviceRoles.length === 0 && (
+                                        <span className="text-amber-600 dark:text-amber-500">{t('contracts.contractEditor.addLine.deviceRolesRequired')}</span>
+                                      )}
+                                    </fieldset>
+                                  )}
+                                  <div className="flex flex-wrap items-center gap-2">
+                                    <button
+                                      type="button" disabled={saveDisabled}
+                                      onClick={() => { if (patch) void saveLine(l, patch); }}
+                                      data-testid={`line-edit-save-${idx}`}
+                                      className="inline-flex h-8 items-center rounded-md bg-primary px-3 text-xs font-medium text-primary-foreground disabled:opacity-50"
+                                    >
+                                      {t('contracts.contractEditor.editLine.save')}
+                                    </button>
+                                    <button
+                                      type="button" onClick={() => {
+                                        returnFocusLineId.current = l.id;
+                                        setEditingLineId(null);
+                                        setEditDraft(null);
+                                        setEditBase(null);
+                                      }}
+                                      data-testid={`line-edit-cancel-${idx}`}
+                                      className="inline-flex h-8 items-center rounded-md border px-3 text-xs font-medium hover:bg-muted"
+                                    >
+                                      {t('contracts.contractEditor.editLine.cancel')}
+                                    </button>
+                                    {l.catalogItemId !== null && d.catalogItemId !== null && (
+                                      <>
+                                        <button
+                                          type="button" disabled={isPending(`edit-${l.id}`)}
+                                          onClick={() => void saveLine(l, { refreshCatalogPrice: true })}
+                                          data-testid={`line-edit-refresh-${idx}`}
+                                          className="inline-flex h-8 items-center rounded-md border px-3 text-xs font-medium hover:bg-muted disabled:opacity-50"
+                                        >
+                                          {t('contracts.contractEditor.editLine.refreshPrice')}
+                                        </button>
+                                        <button
+                                          type="button" onClick={() => setEditDraft({ ...d, catalogItemId: null })}
+                                          data-testid={`line-edit-unlink-${idx}`}
+                                          className="inline-flex h-8 items-center rounded-md border px-3 text-xs font-medium hover:bg-muted"
+                                        >
+                                          {t('contracts.contractEditor.addLine.clearCatalogLink')}
+                                        </button>
+                                      </>
+                                    )}
+                                    {patch && Object.keys(patch).length === 0 && (
+                                      <span className="text-xs text-muted-foreground">{t('contracts.contractEditor.editLine.noChanges')}</span>
+                                    )}
+                                  </div>
+                                </div>
+                              </td>
+                            ) : (
+                              <>
+                                <td className="px-3 py-2">
+                                  {t(/* i18n-dynamic */ LINE_TYPE_LABELS[l.lineType])}
+                                  {SITE_SCOPED_TYPES.has(l.lineType) && l.site
+                                    ? <span className="block text-xs text-muted-foreground" data-testid={`line-site-${idx}`}>{t('contracts.shared.lineScope.site', { name: l.site.name })}</span>
+                                    : null}
+                                  {l.lineType === 'per_device_role' && l.deviceRoles
+                                    ? <span className="block text-xs text-muted-foreground" data-testid={`line-roles-${idx}`}>{l.deviceRoles.map(getDeviceRoleLabel).join(', ')}</span>
+                                    : null}
+                                  {l.lineType === 'per_device_group'
+                                    ? <span className="block text-xs text-muted-foreground" data-testid={`line-group-${idx}`}>
+                                        {l.deviceGroup
+                                          ? `${l.deviceGroup.name}${l.deviceGroup.type === 'dynamic' ? ` · ${t('contracts.shared.dynamicGroup')}` : ''}`
+                                          : t('contracts.shared.deletedGroup', { name: l.deviceGroupName ?? '' })}
+                                      </span>
+                                    : null}
+                                </td>
+                                <td className="px-3 py-2">{l.description}</td>
+                                <td className="px-3 py-2 text-right">{formatMoney(l.unitPrice, contract?.currencyCode)}</td>
+                                <td className="px-3 py-2 text-right tabular-nums" data-testid={`line-qty-${idx}`}>
+                                  {AUTO_QTY_TYPES.has(l.lineType)
+                                    ? (estByLine.has(l.id)
+                                        ? (estByLine.get(l.id)?.unresolved === 'group_deleted'
+                                            ? t('contracts.shared.values.groupDeleted')
+                                            : estByLine.get(l.id)?.quantity)
+                                        : <span className="text-muted-foreground">{t('contracts.shared.values.auto')}</span>)
+                                    : (l.lineType === 'manual' ? (l.manualQuantity ?? '0') : '1')}
+                                </td>
+                                <td className="px-3 py-2 text-center">{l.taxable ? '✓' : '—'}</td>
+                                <td className="px-3 py-2 text-right">
+                                  {linesEditable && (
+                                    <div className="flex justify-end gap-2">
+                                      <button
+                                        type="button"
+                                        ref={(node) => {
+                                          if (node) editButtonRefs.current.set(l.id, node);
+                                          else editButtonRefs.current.delete(l.id);
+                                        }}
+                                        onClick={() => {
+                                          const snapshot: ContractLine = {
+                                            ...l,
+                                            deviceRoles: l.deviceRoles ? [...l.deviceRoles] : null,
+                                            site: l.site ? { ...l.site } : null,
+                                            deviceGroup: l.deviceGroup ? { ...l.deviceGroup } : null,
+                                          };
+                                          setEditBase(snapshot);
+                                          setEditDraft(draftFromLine(snapshot));
+                                          setEditingLineId(l.id);
+                                        }}
+                                        disabled={editingLineId !== null || isPending(`edit-${l.id}`)}
+                                        data-testid={`line-edit-${idx}`}
+                                        className="rounded-md border px-2 py-1 text-xs font-medium hover:bg-muted disabled:opacity-50"
+                                      >
+                                        {t('contracts.contractEditor.lines.edit')}
+                                      </button>
+                                      <button
+                                        type="button" onClick={() => setPendingRemove(l)} disabled={isPending(`remove-${l.id}`) || editingLineId !== null}
+                                        data-testid={`line-remove-${idx}`}
+                                        className="rounded-md border border-destructive/40 px-2 py-1 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
+                                      >
+                                        {t('common:actions.remove')}
+                                      </button>
+                                    </div>
+                                  )}
+                                </td>
+                              </>
                             )}
-                          </td>
-                        </tr>
-                      ))
+                          </tr>
+                        );
+                      })
                     )}
                   </tbody>
                 </table>

--- a/apps/web/src/lib/api/contracts.ts
+++ b/apps/web/src/lib/api/contracts.ts
@@ -80,6 +80,8 @@ export interface ContractLine {
   manualQuantity: string | null;
   siteId: string | null;
   deviceRoles: string[] | null;
+  /** #3205 W03: resolved server-side so the detail page needs no site lookup. */
+  site: { id: string; name: string } | null;
   deviceGroupId: string | null;
   deviceGroupName: string | null;
   deviceGroup: { id: string; name: string; type: 'static' | 'dynamic' } | null;
@@ -211,6 +213,29 @@ export function addContractLine(id: string, body: unknown): Promise<Response> {
 
 export function removeContractLine(id: string, lineId: string): Promise<Response> {
   return fetchWithAuth(`/contracts/${id}/lines/${lineId}`, { method: 'DELETE' });
+}
+
+/** Body of PATCH /contracts/:id/lines/:lineId (#3205 W03). Omitted keys are
+ *  unchanged; `catalogItemId: null` unlinks (and then unitPrice + taxable are
+ *  required in the same patch); the same id re-sent is a no-op — use
+ *  `refreshCatalogPrice` to re-price an unchanged link. `lineType` is rejected. */
+export interface UpdateContractLinePatch {
+  description?: string;
+  unitPrice?: string;
+  taxable?: boolean;
+  catalogItemId?: string | null;
+  refreshCatalogPrice?: boolean;
+  manualQuantity?: string;
+  siteId?: string | null;
+  deviceRoles?: string[];
+  deviceGroupId?: string;
+  sortOrder?: number;
+}
+
+export function updateContractLine(id: string, lineId: string, body: UpdateContractLinePatch): Promise<Response> {
+  return fetchWithAuth(`/contracts/${id}/lines/${lineId}`, {
+    method: 'PATCH', headers: JSON_HEADERS, body: JSON.stringify(body),
+  });
 }
 
 /** Body of `POST /contracts/:id/currency`. The stamped currency is only ever

--- a/apps/web/src/lib/api/contracts.updateLine.test.ts
+++ b/apps/web/src/lib/api/contracts.updateLine.test.ts
@@ -1,0 +1,25 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchWithAuth } from '../../stores/auth';
+import { updateContractLine } from './contracts';
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+
+describe('updateContractLine', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fetchWithAuth).mockResolvedValue(new Response());
+  });
+
+  it('PATCHes the selected contract line and omits undefined patch keys', () => {
+    void updateContractLine('contract-1', 'line-1', { description: 'x', unitPrice: undefined });
+
+    expect(fetchWithAuth).toHaveBeenCalledWith('/contracts/contract-1/lines/line-1', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ description: 'x' }),
+    });
+    const request = vi.mocked(fetchWithAuth).mock.calls[0][1] as RequestInit;
+    expect(JSON.parse(String(request.body))).not.toHaveProperty('unitPrice');
+  });
+});

--- a/apps/web/src/lib/i18n/translationCoverage.test.ts
+++ b/apps/web/src/lib/i18n/translationCoverage.test.ts
@@ -46,7 +46,7 @@ const namespaceDuplicateBaselines = {
     // this locale already renders the parallel `viaStripe` as "via Stripe",
     // so "via QuickBooks" is the correct wording here, not an untranslated
     // string.
-    'billing.json': 57,
+    'billing.json': 58, // +1 W03: site sub-label "Site: {{name}}" is intentionally identical in pt-BR
     // +1: richTextEditor.link — "Link" is the standard loanword in pt-BR.
     // +3: dashboard.vuln.kevCves — "{{count}} CVE(s)" is a locale-invariant
     // acronym (base/_one/_other).

--- a/apps/web/src/locales/de-DE/billing.json
+++ b/apps/web/src/locales/de-DE/billing.json
@@ -243,6 +243,7 @@
         "typeLocked": "Der Positionstyp kann nicht geändert werden. Entfernen Sie die Position und fügen Sie eine neue hinzu.",
         "priceFromCatalog": "Der Preis stammt aus dem Katalog. Entfernen Sie die Katalogverknüpfung, um ihn manuell zu setzen.",
         "refreshPrice": "Preis aus dem Katalog aktualisieren",
+        "restoreCatalogLink": "Katalogverknüpfung wiederherstellen",
         "unlinkNeedsPrice": "Geben Sie einen Stückpreis und die Steuereinstellung an, um die Katalogverknüpfung zu entfernen.",
         "noChanges": "Noch nichts zu speichern."
       },

--- a/apps/web/src/locales/de-DE/billing.json
+++ b/apps/web/src/locales/de-DE/billing.json
@@ -41,6 +41,9 @@
       "values": {
         "auto": "auto",
         "groupDeleted": "Gruppe gelöscht"
+      },
+      "lineScope": {
+        "site": "Standort: {{name}}"
       }
     },
     "contractDetail": {
@@ -153,13 +156,22 @@
         "addLine": "Die Position konnte nicht hinzugefügt werden.",
         "removeLine": "Die Position konnte nicht entfernt werden.",
         "activateContract": "Der Vertrag konnte nicht aktiviert werden.",
-        "noPriceForCurrency": "Kein Preis in {{currency}} für dieses Element. Legen Sie einen im Katalog an oder heben Sie die Katalogverknüpfung auf."
+        "noPriceForCurrency": "Kein Preis in {{currency}} für dieses Element. Legen Sie einen im Katalog an oder heben Sie die Katalogverknüpfung auf.",
+        "updateLine": "Die Position konnte nicht aktualisiert werden.",
+        "lineNotFound": "Diese Position existiert nicht mehr. Aktualisieren Sie den Vertrag.",
+        "contractNotEditable": "Positionen können nur bei Verträgen im Entwurf oder aktiven Verträgen bearbeitet werden.",
+        "siteNotInOrg": "Dieser Standort gehört zu einer anderen Organisation.",
+        "groupNotInOrg": "Diese Gerätegruppe gehört zu einer anderen Organisation.",
+        "invalidLinePatch": "Diese Änderungen sind für diesen Positionstyp nicht gültig.",
+        "priceNotRepresentable": "Dieser Preis hat zu viele Nachkommastellen für {{currency}}.",
+        "catalogItemNotFound": "Dieser Katalogartikel ist für diesen Vertrag nicht verfügbar."
       },
       "toast": {
         "contractCreated": "Vertrag erstellt",
         "lineAdded": "Position hinzugefügt",
         "lineRemoved": "Position entfernt",
-        "contractActivated": "Vertrag aktiviert"
+        "contractActivated": "Vertrag aktiviert",
+        "lineUpdated": "Position aktualisiert"
       },
       "schedule": {
         "title": "Zeitplan",
@@ -190,7 +202,8 @@
         "unitPrice": "Stückpreis",
         "qty": "Menge",
         "tax": "Steuer",
-        "empty": "Noch keine Positionen. Fügen Sie unten eine wiederkehrende Position hinzu."
+        "empty": "Noch keine Positionen. Fügen Sie unten eine wiederkehrende Position hinzu.",
+        "edit": "Bearbeiten"
       },
       "addLine": {
         "integrationHint": "Aus einer Integration hinzufügen – eine Position wird vorab ausgefüllt.",
@@ -223,6 +236,15 @@
         "priceLookupFailed": "Der {{currency}}-Preis konnte nicht ermittelt werden.",
         "priceNotRepresentable": "Der gespeicherte {{currency}}-Preis dieses Artikels ist in {{currency}} ungültig — korrigieren Sie ihn im Katalog oder heben Sie die Katalogverknüpfung auf und erfassen Sie eine manuelle Position.",
         "priceSourceOrgOverride": "Organisationsspezifischer Preis für {{org}}"
+      },
+      "editLine": {
+        "save": "Position speichern",
+        "cancel": "Abbrechen",
+        "typeLocked": "Der Positionstyp kann nicht geändert werden. Entfernen Sie die Position und fügen Sie eine neue hinzu.",
+        "priceFromCatalog": "Der Preis stammt aus dem Katalog. Entfernen Sie die Katalogverknüpfung, um ihn manuell zu setzen.",
+        "refreshPrice": "Preis aus dem Katalog aktualisieren",
+        "unlinkNeedsPrice": "Geben Sie einen Stückpreis und die Steuereinstellung an, um die Katalogverknüpfung zu entfernen.",
+        "noChanges": "Noch nichts zu speichern."
       },
       "estimate": {
         "title": "Geschätzter Zeitraum",

--- a/apps/web/src/locales/en/billing.json
+++ b/apps/web/src/locales/en/billing.json
@@ -243,6 +243,7 @@
         "typeLocked": "Line type can’t be changed. Remove the line and add a new one.",
         "priceFromCatalog": "Price comes from the catalog. Clear the catalog link to set it by hand.",
         "refreshPrice": "Refresh price from catalog",
+        "restoreCatalogLink": "Restore catalog link",
         "unlinkNeedsPrice": "Enter a unit price and tax setting to clear the catalog link.",
         "noChanges": "Nothing to save yet."
       },

--- a/apps/web/src/locales/en/billing.json
+++ b/apps/web/src/locales/en/billing.json
@@ -41,6 +41,9 @@
       "values": {
         "auto": "auto",
         "groupDeleted": "group deleted"
+      },
+      "lineScope": {
+        "site": "Site: {{name}}"
       }
     },
     "contractDetail": {
@@ -153,13 +156,22 @@
         "addLine": "Could not add the line.",
         "removeLine": "Could not remove the line.",
         "activateContract": "Could not activate the contract.",
-        "noPriceForCurrency": "No {{currency}} price for this item. Add one in the catalog or clear the catalog link."
+        "noPriceForCurrency": "No {{currency}} price for this item. Add one in the catalog or clear the catalog link.",
+        "updateLine": "Could not update the line.",
+        "lineNotFound": "That line no longer exists. Refresh the contract.",
+        "contractNotEditable": "Lines can only be edited on draft or active contracts.",
+        "siteNotInOrg": "That site belongs to a different organization.",
+        "groupNotInOrg": "That device group belongs to a different organization.",
+        "invalidLinePatch": "Those changes aren’t valid for this line type.",
+        "priceNotRepresentable": "That price has too many decimal places for {{currency}}.",
+        "catalogItemNotFound": "That catalog item isn’t available on this contract."
       },
       "toast": {
         "contractCreated": "Contract created",
         "lineAdded": "Line added",
         "lineRemoved": "Line removed",
-        "contractActivated": "Contract activated"
+        "contractActivated": "Contract activated",
+        "lineUpdated": "Line updated"
       },
       "schedule": {
         "title": "Schedule",
@@ -190,7 +202,8 @@
         "unitPrice": "Unit price",
         "qty": "Qty",
         "tax": "Tax",
-        "empty": "No lines yet. Add a recurring line below."
+        "empty": "No lines yet. Add a recurring line below.",
+        "edit": "Edit"
       },
       "addLine": {
         "integrationHint": "Add from an integration — it pre-fills a line.",
@@ -223,6 +236,15 @@
         "priceLookupFailed": "Could not look up the {{currency}} price.",
         "priceNotRepresentable": "The saved {{currency}} price for this item is not valid in {{currency}} — correct it in the catalog, or clear the catalog link and enter a manual line.",
         "priceSourceOrgOverride": "Organization-specific price for {{org}}"
+      },
+      "editLine": {
+        "save": "Save line",
+        "cancel": "Cancel",
+        "typeLocked": "Line type can’t be changed. Remove the line and add a new one.",
+        "priceFromCatalog": "Price comes from the catalog. Clear the catalog link to set it by hand.",
+        "refreshPrice": "Refresh price from catalog",
+        "unlinkNeedsPrice": "Enter a unit price and tax setting to clear the catalog link.",
+        "noChanges": "Nothing to save yet."
       },
       "estimate": {
         "title": "Estimated this period",

--- a/apps/web/src/locales/es-419/billing.json
+++ b/apps/web/src/locales/es-419/billing.json
@@ -243,6 +243,7 @@
         "typeLocked": "El tipo de línea no se puede cambiar. Elimina la línea y agrega una nueva.",
         "priceFromCatalog": "El precio viene del catálogo. Quita el vínculo al catálogo para definirlo manualmente.",
         "refreshPrice": "Actualizar precio desde el catálogo",
+        "restoreCatalogLink": "Restaurar vínculo con el catálogo",
         "unlinkNeedsPrice": "Ingresa un precio unitario y la configuración de impuestos para quitar el vínculo al catálogo.",
         "noChanges": "Aún no hay nada que guardar."
       },

--- a/apps/web/src/locales/es-419/billing.json
+++ b/apps/web/src/locales/es-419/billing.json
@@ -41,6 +41,9 @@
       "values": {
         "auto": "auto",
         "groupDeleted": "grupo eliminado"
+      },
+      "lineScope": {
+        "site": "Sitio: {{name}}"
       }
     },
     "contractDetail": {
@@ -153,13 +156,22 @@
         "addLine": "No se pudo agregar la línea.",
         "removeLine": "No se pudo eliminar la línea.",
         "activateContract": "No se pudo activar el contrato.",
-        "noPriceForCurrency": "Este elemento no tiene precio en {{currency}}. Agregue uno en el catálogo o borre el enlace del catálogo."
+        "noPriceForCurrency": "Este elemento no tiene precio en {{currency}}. Agregue uno en el catálogo o borre el enlace del catálogo.",
+        "updateLine": "No se pudo actualizar la línea.",
+        "lineNotFound": "Esa línea ya no existe. Actualiza el contrato.",
+        "contractNotEditable": "Las líneas solo se pueden editar en contratos en borrador o activos.",
+        "siteNotInOrg": "Ese sitio pertenece a otra organización.",
+        "groupNotInOrg": "Ese grupo de dispositivos pertenece a otra organización.",
+        "invalidLinePatch": "Esos cambios no son válidos para este tipo de línea.",
+        "priceNotRepresentable": "Ese precio tiene demasiados decimales para {{currency}}.",
+        "catalogItemNotFound": "Ese artículo del catálogo no está disponible en este contrato."
       },
       "toast": {
         "contractCreated": "Contrato creado",
         "lineAdded": "Línea agregada",
         "lineRemoved": "Línea eliminada",
-        "contractActivated": "Contrato activado"
+        "contractActivated": "Contrato activado",
+        "lineUpdated": "Línea actualizada"
       },
       "schedule": {
         "title": "Cronograma",
@@ -190,7 +202,8 @@
         "unitPrice": "Precio unitario",
         "qty": "Cantidad",
         "tax": "Impuesto",
-        "empty": "Aún no hay líneas. Agregue una línea recurrente a continuación."
+        "empty": "Aún no hay líneas. Agregue una línea recurrente a continuación.",
+        "edit": "Editar"
       },
       "addLine": {
         "integrationHint": "Agregar desde una integración: rellena previamente una línea.",
@@ -223,6 +236,15 @@
         "priceLookupFailed": "No se pudo obtener el precio en {{currency}}.",
         "priceNotRepresentable": "El precio en {{currency}} guardado para este artículo no es válido en {{currency}}: corríjalo en el catálogo o quite el vínculo con el catálogo e ingrese una línea manual.",
         "priceSourceOrgOverride": "Precio específico de la organización {{org}}"
+      },
+      "editLine": {
+        "save": "Guardar línea",
+        "cancel": "Cancelar",
+        "typeLocked": "El tipo de línea no se puede cambiar. Elimina la línea y agrega una nueva.",
+        "priceFromCatalog": "El precio viene del catálogo. Quita el vínculo al catálogo para definirlo manualmente.",
+        "refreshPrice": "Actualizar precio desde el catálogo",
+        "unlinkNeedsPrice": "Ingresa un precio unitario y la configuración de impuestos para quitar el vínculo al catálogo.",
+        "noChanges": "Aún no hay nada que guardar."
       },
       "estimate": {
         "title": "Estimado este periodo",

--- a/apps/web/src/locales/fr-CA/billing.json
+++ b/apps/web/src/locales/fr-CA/billing.json
@@ -243,6 +243,7 @@
         "typeLocked": "Le type de ligne ne peut pas être modifié. Supprimez la ligne et ajoutez-en une nouvelle.",
         "priceFromCatalog": "Le prix provient du catalogue. Retirez le lien au catalogue pour le définir manuellement.",
         "refreshPrice": "Actualiser le prix depuis le catalogue",
+        "restoreCatalogLink": "Rétablir le lien au catalogue",
         "unlinkNeedsPrice": "Saisissez un prix unitaire et le réglage de taxe pour retirer le lien au catalogue.",
         "noChanges": "Rien à enregistrer pour l’instant."
       },

--- a/apps/web/src/locales/fr-CA/billing.json
+++ b/apps/web/src/locales/fr-CA/billing.json
@@ -41,6 +41,9 @@
       "values": {
         "auto": "auto",
         "groupDeleted": "groupe supprimé"
+      },
+      "lineScope": {
+        "site": "Site : {{name}}"
       }
     },
     "contractDetail": {
@@ -153,13 +156,22 @@
         "addLine": "Impossible d'ajouter la ligne.",
         "removeLine": "Impossible de supprimer la ligne.",
         "activateContract": "Impossible d'activer le contrat.",
-        "noPriceForCurrency": "Aucun prix en {{currency}} pour cet article. Ajoutez-en un au catalogue ou supprimez le lien vers le catalogue."
+        "noPriceForCurrency": "Aucun prix en {{currency}} pour cet article. Ajoutez-en un au catalogue ou supprimez le lien vers le catalogue.",
+        "updateLine": "Impossible de mettre à jour la ligne.",
+        "lineNotFound": "Cette ligne n’existe plus. Actualisez le contrat.",
+        "contractNotEditable": "Les lignes ne peuvent être modifiées que sur les contrats brouillon ou actifs.",
+        "siteNotInOrg": "Ce site appartient à une autre organisation.",
+        "groupNotInOrg": "Ce groupe d’appareils appartient à une autre organisation.",
+        "invalidLinePatch": "Ces modifications ne sont pas valides pour ce type de ligne.",
+        "priceNotRepresentable": "Ce prix comporte trop de décimales pour {{currency}}.",
+        "catalogItemNotFound": "Cet article du catalogue n’est pas disponible sur ce contrat."
       },
       "toast": {
         "contractCreated": "Contrat créé",
         "lineAdded": "Ligne ajoutée",
         "lineRemoved": "Ligne supprimée",
-        "contractActivated": "Contrat activé"
+        "contractActivated": "Contrat activé",
+        "lineUpdated": "Ligne mise à jour"
       },
       "schedule": {
         "title": "Planification",
@@ -190,7 +202,8 @@
         "unitPrice": "Prix unitaire",
         "qty": "Qté",
         "tax": "Taxe",
-        "empty": "Aucune ligne pour le moment. Ajoutez une ligne récurrente ci-dessous."
+        "empty": "Aucune ligne pour le moment. Ajoutez une ligne récurrente ci-dessous.",
+        "edit": "Modifier"
       },
       "addLine": {
         "integrationHint": "Ajouter depuis une intégration : une ligne sera préremplie.",
@@ -223,6 +236,15 @@
         "priceLookupFailed": "Impossible d’obtenir le prix en {{currency}}.",
         "priceNotRepresentable": "Le prix en {{currency}} enregistré pour cet article n’est pas valide en {{currency}} — corrigez-le dans le catalogue, ou retirez le lien au catalogue et saisissez une ligne manuelle.",
         "priceSourceOrgOverride": "Prix propre à l’organisation {{org}}"
+      },
+      "editLine": {
+        "save": "Enregistrer la ligne",
+        "cancel": "Annuler",
+        "typeLocked": "Le type de ligne ne peut pas être modifié. Supprimez la ligne et ajoutez-en une nouvelle.",
+        "priceFromCatalog": "Le prix provient du catalogue. Retirez le lien au catalogue pour le définir manuellement.",
+        "refreshPrice": "Actualiser le prix depuis le catalogue",
+        "unlinkNeedsPrice": "Saisissez un prix unitaire et le réglage de taxe pour retirer le lien au catalogue.",
+        "noChanges": "Rien à enregistrer pour l’instant."
       },
       "estimate": {
         "title": "Estimé pour cette période",

--- a/apps/web/src/locales/fr-FR/billing.json
+++ b/apps/web/src/locales/fr-FR/billing.json
@@ -243,6 +243,7 @@
         "typeLocked": "Le type de ligne ne peut pas être modifié. Supprimez la ligne et ajoutez-en une nouvelle.",
         "priceFromCatalog": "Le prix provient du catalogue. Retirez le lien au catalogue pour le définir manuellement.",
         "refreshPrice": "Actualiser le prix depuis le catalogue",
+        "restoreCatalogLink": "Rétablir le lien au catalogue",
         "unlinkNeedsPrice": "Saisissez un prix unitaire et le réglage de taxe pour retirer le lien au catalogue.",
         "noChanges": "Rien à enregistrer pour l’instant."
       },

--- a/apps/web/src/locales/fr-FR/billing.json
+++ b/apps/web/src/locales/fr-FR/billing.json
@@ -41,6 +41,9 @@
       "values": {
         "auto": "auto",
         "groupDeleted": "groupe supprimé"
+      },
+      "lineScope": {
+        "site": "Site : {{name}}"
       }
     },
     "contractDetail": {
@@ -153,13 +156,22 @@
         "addLine": "Impossible d'ajouter la ligne.",
         "removeLine": "Impossible de supprimer la ligne.",
         "activateContract": "Impossible d'activer le contrat.",
-        "noPriceForCurrency": "Aucun prix en {{currency}} pour cet article. Ajoutez-en un dans le catalogue ou supprimez le lien vers le catalogue."
+        "noPriceForCurrency": "Aucun prix en {{currency}} pour cet article. Ajoutez-en un dans le catalogue ou supprimez le lien vers le catalogue.",
+        "updateLine": "Impossible de mettre à jour la ligne.",
+        "lineNotFound": "Cette ligne n’existe plus. Actualisez le contrat.",
+        "contractNotEditable": "Les lignes ne peuvent être modifiées que sur les contrats brouillon ou actifs.",
+        "siteNotInOrg": "Ce site appartient à une autre organisation.",
+        "groupNotInOrg": "Ce groupe d’appareils appartient à une autre organisation.",
+        "invalidLinePatch": "Ces modifications ne sont pas valides pour ce type de ligne.",
+        "priceNotRepresentable": "Ce prix comporte trop de décimales pour {{currency}}.",
+        "catalogItemNotFound": "Cet article du catalogue n’est pas disponible sur ce contrat."
       },
       "toast": {
         "contractCreated": "Contrat créé",
         "lineAdded": "Ligne ajoutée",
         "lineRemoved": "Ligne supprimée",
-        "contractActivated": "Contrat activé"
+        "contractActivated": "Contrat activé",
+        "lineUpdated": "Ligne mise à jour"
       },
       "schedule": {
         "title": "Planification",
@@ -190,7 +202,8 @@
         "unitPrice": "Prix unitaire",
         "qty": "Qté",
         "tax": "Taxe",
-        "empty": "Aucune ligne pour le moment. Ajoutez une ligne récurrente ci-dessous."
+        "empty": "Aucune ligne pour le moment. Ajoutez une ligne récurrente ci-dessous.",
+        "edit": "Modifier"
       },
       "addLine": {
         "integrationHint": "Ajouter depuis une intégration : une ligne sera préremplie.",
@@ -223,6 +236,15 @@
         "priceLookupFailed": "Impossible de récupérer le prix en {{currency}}.",
         "priceNotRepresentable": "Le prix en {{currency}} enregistré pour cet article n’est pas valide en {{currency}} — corrigez-le dans le catalogue, ou supprimez le lien au catalogue et saisissez une ligne manuelle.",
         "priceSourceOrgOverride": "Prix spécifique à l’organisation {{org}}"
+      },
+      "editLine": {
+        "save": "Enregistrer la ligne",
+        "cancel": "Annuler",
+        "typeLocked": "Le type de ligne ne peut pas être modifié. Supprimez la ligne et ajoutez-en une nouvelle.",
+        "priceFromCatalog": "Le prix provient du catalogue. Retirez le lien au catalogue pour le définir manuellement.",
+        "refreshPrice": "Actualiser le prix depuis le catalogue",
+        "unlinkNeedsPrice": "Saisissez un prix unitaire et le réglage de taxe pour retirer le lien au catalogue.",
+        "noChanges": "Rien à enregistrer pour l’instant."
       },
       "estimate": {
         "title": "Estimé pour cette période",

--- a/apps/web/src/locales/it-IT/billing.json
+++ b/apps/web/src/locales/it-IT/billing.json
@@ -41,6 +41,9 @@
       "values": {
         "auto": "auto",
         "groupDeleted": "gruppo eliminato"
+      },
+      "lineScope": {
+        "site": "Sede: {{name}}"
       }
     },
     "contractDetail": {
@@ -153,13 +156,22 @@
         "addLine": "Impossibile aggiungere la riga.",
         "removeLine": "Impossibile rimuovere la riga.",
         "activateContract": "Impossibile attivare il contratto.",
-        "noPriceForCurrency": "Nessun prezzo in {{currency}} per questo elemento. Aggiungine uno nel catalogo o cancella il collegamento al catalogo."
+        "noPriceForCurrency": "Nessun prezzo in {{currency}} per questo elemento. Aggiungine uno nel catalogo o cancella il collegamento al catalogo.",
+        "updateLine": "Impossibile aggiornare la riga.",
+        "lineNotFound": "Questa riga non esiste più. Aggiorna il contratto.",
+        "contractNotEditable": "Le righe possono essere modificate solo su contratti in bozza o attivi.",
+        "siteNotInOrg": "Questa sede appartiene a un’altra organizzazione.",
+        "groupNotInOrg": "Questo gruppo di dispositivi appartiene a un’altra organizzazione.",
+        "invalidLinePatch": "Queste modifiche non sono valide per questo tipo di riga.",
+        "priceNotRepresentable": "Questo prezzo ha troppi decimali per {{currency}}.",
+        "catalogItemNotFound": "Questo articolo del catalogo non è disponibile su questo contratto."
       },
       "toast": {
         "contractCreated": "Contratto creato",
         "lineAdded": "Riga aggiunta",
         "lineRemoved": "Riga rimossa",
-        "contractActivated": "Contratto attivato"
+        "contractActivated": "Contratto attivato",
+        "lineUpdated": "Riga aggiornata"
       },
       "schedule": {
         "title": "Pianificazione",
@@ -190,7 +202,8 @@
         "unitPrice": "Prezzo unitario",
         "qty": "Qtà",
         "tax": "Imposta",
-        "empty": "Nessuna riga. Aggiungi una riga ricorrente qui sotto."
+        "empty": "Nessuna riga. Aggiungi una riga ricorrente qui sotto.",
+        "edit": "Modifica"
       },
       "addLine": {
         "integrationHint": "Aggiungi da un'integrazione: precompila una riga.",
@@ -223,6 +236,15 @@
         "priceLookupFailed": "Impossibile recuperare il prezzo in {{currency}}.",
         "priceNotRepresentable": "Il prezzo in {{currency}} salvato per questo articolo non è valido in {{currency}}: correggilo nel catalogo oppure rimuovi il collegamento al catalogo e inserisci una riga manuale.",
         "priceSourceOrgOverride": "Prezzo specifico per l’organizzazione {{org}}"
+      },
+      "editLine": {
+        "save": "Salva riga",
+        "cancel": "Annulla",
+        "typeLocked": "Il tipo di riga non può essere modificato. Rimuovi la riga e aggiungine una nuova.",
+        "priceFromCatalog": "Il prezzo proviene dal catalogo. Rimuovi il collegamento al catalogo per impostarlo manualmente.",
+        "refreshPrice": "Aggiorna il prezzo dal catalogo",
+        "unlinkNeedsPrice": "Inserisci un prezzo unitario e l’impostazione fiscale per rimuovere il collegamento al catalogo.",
+        "noChanges": "Non c’è ancora nulla da salvare."
       },
       "estimate": {
         "title": "Stimato per questo periodo",

--- a/apps/web/src/locales/it-IT/billing.json
+++ b/apps/web/src/locales/it-IT/billing.json
@@ -243,6 +243,7 @@
         "typeLocked": "Il tipo di riga non può essere modificato. Rimuovi la riga e aggiungine una nuova.",
         "priceFromCatalog": "Il prezzo proviene dal catalogo. Rimuovi il collegamento al catalogo per impostarlo manualmente.",
         "refreshPrice": "Aggiorna il prezzo dal catalogo",
+        "restoreCatalogLink": "Ripristina il collegamento al catalogo",
         "unlinkNeedsPrice": "Inserisci un prezzo unitario e l’impostazione fiscale per rimuovere il collegamento al catalogo.",
         "noChanges": "Non c’è ancora nulla da salvare."
       },

--- a/apps/web/src/locales/pt-BR/billing.json
+++ b/apps/web/src/locales/pt-BR/billing.json
@@ -243,6 +243,7 @@
         "typeLocked": "O tipo de linha não pode ser alterado. Remova a linha e adicione uma nova.",
         "priceFromCatalog": "O preço vem do catálogo. Remova o vínculo com o catálogo para defini-lo manualmente.",
         "refreshPrice": "Atualizar preço do catálogo",
+        "restoreCatalogLink": "Restaurar vínculo com o catálogo",
         "unlinkNeedsPrice": "Informe um preço unitário e a configuração de imposto para remover o vínculo com o catálogo.",
         "noChanges": "Ainda não há nada para salvar."
       },

--- a/apps/web/src/locales/pt-BR/billing.json
+++ b/apps/web/src/locales/pt-BR/billing.json
@@ -41,6 +41,9 @@
       "values": {
         "auto": "auto",
         "groupDeleted": "grupo excluído"
+      },
+      "lineScope": {
+        "site": "Site: {{name}}"
       }
     },
     "contractDetail": {
@@ -153,13 +156,22 @@
         "addLine": "Não foi possível adicionar a linha.",
         "removeLine": "Não foi possível remover a linha.",
         "activateContract": "Não foi possível ativar o contrato.",
-        "noPriceForCurrency": "Este item não tem preço em {{currency}}. Adicione um no catálogo ou limpe o vínculo do catálogo."
+        "noPriceForCurrency": "Este item não tem preço em {{currency}}. Adicione um no catálogo ou limpe o vínculo do catálogo.",
+        "updateLine": "Não foi possível atualizar a linha.",
+        "lineNotFound": "Essa linha não existe mais. Atualize o contrato.",
+        "contractNotEditable": "As linhas só podem ser editadas em contratos em rascunho ou ativos.",
+        "siteNotInOrg": "Esse site pertence a outra organização.",
+        "groupNotInOrg": "Esse grupo de dispositivos pertence a outra organização.",
+        "invalidLinePatch": "Essas alterações não são válidas para este tipo de linha.",
+        "priceNotRepresentable": "Esse preço tem casas decimais demais para {{currency}}.",
+        "catalogItemNotFound": "Esse item do catálogo não está disponível neste contrato."
       },
       "toast": {
         "contractCreated": "Contrato criado",
         "lineAdded": "Linha adicionada",
         "lineRemoved": "Linha removida",
-        "contractActivated": "Contrato ativado"
+        "contractActivated": "Contrato ativado",
+        "lineUpdated": "Linha atualizada"
       },
       "schedule": {
         "title": "Agenda",
@@ -190,7 +202,8 @@
         "unitPrice": "Preço unitário",
         "qty": "Qtd.",
         "tax": "Imposto",
-        "empty": "Ainda não há linhas. Adicione uma linha recorrente abaixo."
+        "empty": "Ainda não há linhas. Adicione uma linha recorrente abaixo.",
+        "edit": "Editar"
       },
       "addLine": {
         "integrationHint": "Adicione de uma integração — ela preenche uma linha.",
@@ -223,6 +236,15 @@
         "priceLookupFailed": "Não foi possível consultar o preço em {{currency}}.",
         "priceNotRepresentable": "O preço em {{currency}} salvo para este item não é válido em {{currency}} — corrija-o no catálogo ou remova o vínculo com o catálogo e informe uma linha manual.",
         "priceSourceOrgOverride": "Preço específico da organização {{org}}"
+      },
+      "editLine": {
+        "save": "Salvar linha",
+        "cancel": "Cancelar",
+        "typeLocked": "O tipo de linha não pode ser alterado. Remova a linha e adicione uma nova.",
+        "priceFromCatalog": "O preço vem do catálogo. Remova o vínculo com o catálogo para defini-lo manualmente.",
+        "refreshPrice": "Atualizar preço do catálogo",
+        "unlinkNeedsPrice": "Informe um preço unitário e a configuração de imposto para remover o vínculo com o catálogo.",
+        "noChanges": "Ainda não há nada para salvar."
       },
       "estimate": {
         "title": "Estimado neste período",

--- a/apps/web/src/locales/tr-TR/billing.json
+++ b/apps/web/src/locales/tr-TR/billing.json
@@ -243,6 +243,7 @@
         "typeLocked": "Satır türü değiştirilemez. Satırı kaldırıp yenisini ekleyin.",
         "priceFromCatalog": "Fiyat katalogdan gelir. Elle ayarlamak için katalog bağlantısını kaldırın.",
         "refreshPrice": "Fiyatı katalogdan yenile",
+        "restoreCatalogLink": "Katalog bağlantısını geri yükle",
         "unlinkNeedsPrice": "Katalog bağlantısını kaldırmak için birim fiyat ve vergi ayarını girin.",
         "noChanges": "Henüz kaydedilecek bir şey yok."
       },

--- a/apps/web/src/locales/tr-TR/billing.json
+++ b/apps/web/src/locales/tr-TR/billing.json
@@ -41,6 +41,9 @@
       "values": {
         "auto": "otomatik",
         "groupDeleted": "grup silindi"
+      },
+      "lineScope": {
+        "site": "Konum: {{name}}"
       }
     },
     "contractDetail": {
@@ -153,13 +156,22 @@
         "addLine": "Satır eklenemedi.",
         "removeLine": "Satır kaldırılamadı.",
         "activateContract": "Sözleşme etkinleştirilemedi.",
-        "noPriceForCurrency": "Bu öğenin {{currency}} fiyatı yok. Katalogda bir fiyat ekleyin veya katalog bağlantısını temizleyin."
+        "noPriceForCurrency": "Bu öğenin {{currency}} fiyatı yok. Katalogda bir fiyat ekleyin veya katalog bağlantısını temizleyin.",
+        "updateLine": "Satır güncellenemedi.",
+        "lineNotFound": "Bu satır artık mevcut değil. Sözleşmeyi yenileyin.",
+        "contractNotEditable": "Satırlar yalnızca taslak veya etkin sözleşmelerde düzenlenebilir.",
+        "siteNotInOrg": "Bu konum farklı bir kuruluşa ait.",
+        "groupNotInOrg": "Bu cihaz grubu farklı bir kuruluşa ait.",
+        "invalidLinePatch": "Bu değişiklikler bu satır türü için geçerli değil.",
+        "priceNotRepresentable": "Bu fiyatın {{currency}} için çok fazla ondalık basamağı var.",
+        "catalogItemNotFound": "Bu katalog öğesi bu sözleşmede kullanılamıyor."
       },
       "toast": {
         "contractCreated": "Sözleşme oluşturuldu",
         "lineAdded": "Satır eklendi",
         "lineRemoved": "Hat kaldırıldı",
-        "contractActivated": "Sözleşme etkinleştirildi"
+        "contractActivated": "Sözleşme etkinleştirildi",
+        "lineUpdated": "Satır güncellendi"
       },
       "schedule": {
         "title": "Program",
@@ -190,7 +202,8 @@
         "unitPrice": "Birim fiyatı",
         "qty": "Adet",
         "tax": "Vergi",
-        "empty": "Henüz hat yok. Aşağıya yinelenen bir satır ekleyin."
+        "empty": "Henüz hat yok. Aşağıya yinelenen bir satır ekleyin.",
+        "edit": "Düzenle"
       },
       "addLine": {
         "integrationHint": "Entegrasyondan ekleme — bir satırı önceden doldurur.",
@@ -223,6 +236,15 @@
         "priceLookupFailed": "{{currency}} fiyatı alınamadı.",
         "priceNotRepresentable": "Bu ürün için kayıtlı {{currency}} fiyatı {{currency}} para biriminde geçerli değil — katalogda düzeltin ya da katalog bağlantısını kaldırıp elle satır girin.",
         "priceSourceOrgOverride": "{{org}} için kuruluşa özel fiyat"
+      },
+      "editLine": {
+        "save": "Satırı kaydet",
+        "cancel": "İptal",
+        "typeLocked": "Satır türü değiştirilemez. Satırı kaldırıp yenisini ekleyin.",
+        "priceFromCatalog": "Fiyat katalogdan gelir. Elle ayarlamak için katalog bağlantısını kaldırın.",
+        "refreshPrice": "Fiyatı katalogdan yenile",
+        "unlinkNeedsPrice": "Katalog bağlantısını kaldırmak için birim fiyat ve vergi ayarını girin.",
+        "noChanges": "Henüz kaydedilecek bir şey yok."
       },
       "estimate": {
         "title": "Tahmini bu dönem",

--- a/docs/release-notes/next-release-draft.md
+++ b/docs/release-notes/next-release-draft.md
@@ -77,6 +77,34 @@ delete once done:
   switch + router + firewall). `unknown` is never billable. Contract estimates and
   generated invoices now report how many devices no line bills, by role.
 - New contract line type **Per device group** bills the members of a device group. Dynamic groups are evaluated live at estimate and invoice time; a group billed by a draft, active or paused contract cannot be deleted until the line is removed; a group deleted after a contract ended stays on that contract's lines by name.
+
+### Contract line editing (W03)
+
+**Behaviour**
+
+- Contract lines are now **editable in place** on draft and active contracts
+  (`PATCH /api/v1/contracts/:id/lines/:lineId`, and the AI `manage_contracts`
+  action `update_line`). The line keeps its id, so an already-generated draft
+  invoice stays linked to it — deleting and re-adding a line used to wedge that
+  invoice with `SOURCE_NOT_FOUND` on issue. The **line type** cannot be changed;
+  remove the line and add a new one.
+- All three line mutations now write audit events: `contract.line.added`,
+  `contract.line.updated`, `contract.line.removed` (resource type `contract`,
+  resource id the contract). The payload carries the line id, the line type, the
+  names of the changed columns and, for a price change, the old and new unit
+  price — no descriptions, site names or group names.
+
+**Self-Hosting / Upgrade Notes** — three deliberate behaviour changes, no migration:
+
+- `DELETE /api/v1/contracts/:id/lines/:lineId` now returns **404
+  `LINE_NOT_FOUND`** for a line that does not exist (previously a silent 200),
+  and its success body is `{"data":{"ok":true}}` (previously `{}`).
+- `unitPrice`, `manualQuantity` (max 10 digits before the decimal point) and
+  `sortOrder` (max 2147483647) bounds now apply on line **create** as well as
+  update. Input that previously reached Postgres and returned a 500 is now a 400.
+- A stale or foreign `catalogItemId` when **adding** a line is now
+  `400 CATALOG_ITEM_NOT_FOUND` instead of a 500.
+
 ## Partner trust probation (hosted abuse control) — breeze #4567 → #4588 → #4599 → #4603 → #4602 → #4604, breeze-billing #16 + #17
 
 Only fold this in once the whole chain above is merged. It is one feature in

--- a/docs/release-notes/next-release-draft.md
+++ b/docs/release-notes/next-release-draft.md
@@ -94,8 +94,9 @@ delete once done:
   names of the changed columns and, for a price change, the old and new unit
   price — no descriptions, site names or group names.
 
-**Self-Hosting / Upgrade Notes** — three deliberate behaviour changes, no migration:
+**Self-Hosting / Upgrade Notes** — four deliberate behaviour changes, no migration:
 
+- Generated invoice lines now use deterministic `(sortOrder, createdAt, id)` ordering; lines tied on `sortOrder` may appear in a different order.
 - `DELETE /api/v1/contracts/:id/lines/:lineId` now returns **404
   `LINE_NOT_FOUND`** for a line that does not exist (previously a silent 200),
   and its success body is `{"data":{"ok":true}}` (previously `{}`).

--- a/docs/superpowers/specs/billing/2026-09-03-contract-line-editing-design.md
+++ b/docs/superpowers/specs/billing/2026-09-03-contract-line-editing-design.md
@@ -299,7 +299,7 @@ Shared audit type and the three service surfaces:
 export interface ContractLineAudit {
   orgId: string;
   contractId: string;
-  contractName: string;
+  contractName?: string; // The add audit has no contract name in scope.
   contractLineId: string;
   lineType: ContractLineType;
   /** Column NAMES whose persisted value changed. Empty on a no-op patch.

--- a/packages/shared/src/validators/contracts.test.ts
+++ b/packages/shared/src/validators/contracts.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { createContractSchema, contractLineInputSchema, updateContractSchema, changeContractCurrencySchema } from './contracts';
+import {
+  createContractSchema, contractLineInputSchema, updateContractSchema, changeContractCurrencySchema,
+  updateContractLineSchema, contractLineInvariantIssues, mergeContractLinePatch, patchHasKey,
+  type PersistedContractLine,
+} from './contracts';
 
 describe('createContractSchema', () => {
   it('accepts a valid monthly advance contract', () => {
@@ -224,5 +228,278 @@ describe('changeContractCurrencySchema (#3778)', () => {
 
   it('rejects an unsupported currency code', () => {
     expect(changeContractCurrencySchema.safeParse({ currencyCode: 'XXX' }).success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #3205 W03 — contract line editing.
+// ---------------------------------------------------------------------------
+
+// The create-path bounds tighten too (decision 10): unbounded money and
+// sortOrder reached Postgres as a raw 22003 and surfaced as a 500.
+describe('contractLineInputSchema — numeric bounds (#3205 W03)', () => {
+  const base = { lineType: 'flat' as const, description: 'Fee', taxable: true };
+  const parse = (v: unknown) => contractLineInputSchema.safeParse(v).success;
+
+  it('accepts the largest numeric(12,2) unitPrice and rejects an 11-digit one', () => {
+    expect(parse({ ...base, unitPrice: '9999999999.99' })).toBe(true);
+    expect(parse({ ...base, unitPrice: '99999999999.00' })).toBe(false);
+  });
+
+  it('applies the same bound to manualQuantity', () => {
+    const manual = { lineType: 'manual' as const, description: 'Hours', unitPrice: '1.00', taxable: false };
+    expect(parse({ ...manual, manualQuantity: '9999999999.99' })).toBe(true);
+    expect(parse({ ...manual, manualQuantity: '99999999999.00' })).toBe(false);
+  });
+
+  it('bounds sortOrder at int32', () => {
+    expect(parse({ ...base, unitPrice: '1.00', sortOrder: 2147483647 })).toBe(true);
+    expect(parse({ ...base, unitPrice: '1.00', sortOrder: 2147483648 })).toBe(false);
+  });
+});
+
+describe('contractLineInputSchema — pre-W03 issue-array parity', () => {
+  it('preserves the exact path, message and order for multiple create issues', () => {
+    const r = contractLineInputSchema.safeParse({
+      lineType: 'per_seat', description: 'Seats', taxable: true,
+      siteId: '22222222-2222-4222-8222-222222222222', deviceRoles: ['server'],
+    });
+    expect(r.success).toBe(false);
+    expect(r.error!.issues.map(({ path, message }) => ({ path, message }))).toEqual([
+      { path: ['unitPrice'], message: 'unitPrice is required unless catalogItemId is set' },
+      { path: ['siteId'], message: 'siteId is only valid on per_device and per_device_role lines' },
+      { path: ['deviceRoles'], message: 'deviceRoles is required on per_device_role lines and not allowed on other line types' },
+    ]);
+  });
+
+  it('reports only Zod\'s array minimum issue for empty create deviceRoles', () => {
+    const r = contractLineInputSchema.safeParse({
+      lineType: 'per_device_role', description: 'Network gear', unitPrice: '25.00',
+      taxable: true, deviceRoles: [],
+    });
+    expect(r.success).toBe(false);
+    expect(r.error!.issues.map(({ path, message }) => ({ path, message }))).toEqual([
+      { path: ['deviceRoles'], message: 'Too small: expected array to have >=1 items' },
+    ]);
+  });
+});
+
+describe('updateContractLineSchema (#3205 W03)', () => {
+  const GUID = '33333333-3333-4333-8333-333333333333';
+  const parse = (v: unknown) => updateContractLineSchema.safeParse(v);
+
+  // Decision 3's anchor. A NON-strict schema would ACCEPT {lineType:'flat'} and
+  // silently drop it, changing nothing while reporting success.
+  it('rejects lineType with the exact unrecognized-key message', () => {
+    const r = parse({ description: 'x', lineType: 'flat' });
+    expect(r.success).toBe(false);
+    expect(r.error!.issues.map((i) => i.message)).toContain('Unrecognized key: "lineType"');
+  });
+
+  it('rejects any unknown key and an empty patch', () => {
+    expect(parse({ nope: 1 }).success).toBe(false);
+    const empty = parse({});
+    expect(empty.success).toBe(false);
+    expect(empty.error!.issues.map((i) => i.message)).toContain('patch must change at least one field');
+  });
+
+  it('rejects a non-GUID catalogItemId, empty/duplicate deviceRoles and an over-long description', () => {
+    expect(parse({ catalogItemId: 'nope' }).success).toBe(false);
+    expect(parse({ deviceRoles: [] }).success).toBe(false);
+    expect(parse({ deviceRoles: ['server', 'server'] }).success).toBe(false);
+    expect(parse({ description: 'x'.repeat(2001) }).success).toBe(false);
+    expect(parse({ description: '' }).success).toBe(false);
+  });
+
+  it('applies the same money and sortOrder bounds as the create schema', () => {
+    expect(parse({ unitPrice: '9999999999.99' }).success).toBe(true);
+    expect(parse({ unitPrice: '99999999999.00' }).success).toBe(false);
+    expect(parse({ manualQuantity: '99999999999.00' }).success).toBe(false);
+    expect(parse({ sortOrder: 2147483647 }).success).toBe(true);
+    expect(parse({ sortOrder: 2147483648 }).success).toBe(false);
+  });
+
+  // TRI-STATE PIN. This is what catches a Zod upgrade changing absence
+  // semantics — the whole catalog transition table rests on it.
+  it('preserves key absence and an explicit null on catalogItemId', () => {
+    const absent = updateContractLineSchema.parse({ description: 'x' }) as Record<string, unknown>;
+    expect(Object.prototype.hasOwnProperty.call(absent, 'catalogItemId')).toBe(false);
+    const explicit = updateContractLineSchema.parse({ catalogItemId: null }) as Record<string, unknown>;
+    expect(Object.prototype.hasOwnProperty.call(explicit, 'catalogItemId')).toBe(true);
+    expect(explicit.catalogItemId).toBeNull();
+    expect(patchHasKey(absent as never, 'catalogItemId')).toBe(false);
+    expect(patchHasKey(explicit as never, 'catalogItemId')).toBe(true);
+  });
+
+  it('treats an explicit undefined catalogItemId as absent after parsing', () => {
+    const parsed = updateContractLineSchema.parse({ description: 'x', catalogItemId: undefined });
+    expect(patchHasKey(parsed, 'catalogItemId')).toBe(false);
+  });
+
+  // siteId: null widens a site-scoped line to the whole org — legitimate.
+  // deviceRoles/deviceGroupId: null would leave a row the DB rejects, or an
+  // orphan nobody asked for (decision 7).
+  it('accepts siteId null, rejects deviceRoles null and deviceGroupId null', () => {
+    expect(parse({ siteId: null }).success).toBe(true);
+    expect(parse({ siteId: GUID }).success).toBe(true);
+    expect(parse({ deviceRoles: null }).success).toBe(false);
+    expect(parse({ deviceGroupId: null }).success).toBe(false);
+    expect(parse({ deviceGroupId: GUID }).success).toBe(true);
+  });
+
+  it('accepts refreshCatalogPrice alone', () => {
+    expect(parse({ refreshCatalogPrice: true }).success).toBe(true);
+    expect(parse({ refreshCatalogPrice: false }).success).toBe(true);
+  });
+});
+
+// The whole asymmetry matrix of the spec's § Validators, both modes. Every case
+// carries a comment naming which side is the sole guard, so nobody deletes one
+// as redundant with "the CHECK already does it".
+describe('contractLineInvariantIssues (#3205 W03)', () => {
+  const GUID = '33333333-3333-4333-8333-333333333333';
+  const paths = (l: Parameters<typeof contractLineInvariantIssues>[0], mode: 'create' | 'persisted') =>
+    contractLineInvariantIssues(l, { mode }).map((i) => i.path);
+
+  it('manual lines require manualQuantity in both modes', () => {
+    expect(paths({ lineType: 'manual' }, 'create')).toEqual(['manualQuantity']);
+    expect(paths({ lineType: 'manual', manualQuantity: null }, 'persisted')).toEqual(['manualQuantity']);
+    expect(paths({ lineType: 'manual', manualQuantity: '2' }, 'create')).toEqual([]);
+    expect(paths({ lineType: 'manual', manualQuantity: '2' }, 'persisted')).toEqual([]);
+  });
+
+  // THE MODE DIFFERENCE that keeps add behaviour intact: the add writer nulls
+  // manualQuantity on every non-manual type (contractService.ts:904), so create
+  // TOLERATES it; a stored row carrying it is a real defect. NO DB CHECK exists
+  // on manual_quantity at all — the helper is the only guard on both sides.
+  it('tolerates manualQuantity on a flat line in create and rejects it in persisted', () => {
+    expect(paths({ lineType: 'flat', manualQuantity: '5' }, 'create')).toEqual([]);
+    expect(paths({ lineType: 'flat', manualQuantity: '5' }, 'persisted')).toEqual(['manualQuantity']);
+  });
+
+  // The DB constrains site_id only on per_device_group (W02's CHECK). For
+  // flat / manual / per_seat the helper is the ONLY guard.
+  it('allows siteId only on per_device and per_device_role, in both modes', () => {
+    for (const mode of ['create', 'persisted'] as const) {
+      expect(paths({ lineType: 'per_device', siteId: GUID }, mode)).toEqual([]);
+      expect(paths({ lineType: 'per_device_role', siteId: GUID, deviceRoles: ['server'] }, mode)).toEqual([]);
+      for (const lineType of ['flat', 'per_seat'] as const) {
+        expect(paths({ lineType, siteId: GUID }, mode)).toEqual(['siteId']);
+      }
+      expect(paths({ lineType: 'manual', manualQuantity: '1', siteId: GUID }, mode)).toEqual(['siteId']);
+    }
+  });
+
+  it('rejects a siteId on a per_device_group line in both modes', () => {
+    expect(paths({ lineType: 'per_device_group', deviceGroupId: GUID, siteId: GUID }, 'create')).toEqual(['siteId']);
+    expect(paths({ lineType: 'per_device_group', deviceGroupId: GUID, deviceGroupName: 'VIP', siteId: GUID }, 'persisted')).toEqual(['siteId']);
+  });
+
+  it('keeps deviceRoles two-way in both modes and leaves create emptiness to Zod', () => {
+    for (const mode of ['create', 'persisted'] as const) {
+      expect(paths({ lineType: 'per_device_role' }, mode)).toEqual(['deviceRoles']);
+      expect(paths({ lineType: 'per_device', deviceRoles: ['server'] }, mode)).toEqual(['deviceRoles']);
+      expect(paths({ lineType: 'per_device_role', deviceRoles: ['server'] }, mode)).toEqual([]);
+    }
+    expect(paths({ lineType: 'per_device_role', deviceRoles: [] }, 'create')).toEqual([]);
+    expect(paths({ lineType: 'per_device_role', deviceRoles: [] }, 'persisted')).toEqual(['deviceRoles']);
+  });
+
+  // contract_lines_device_roles_chk uses `<@` — CONTAINMENT, not set equality —
+  // so {'server','server'} PASSES the database. The helper is the only guard.
+  it('rejects duplicate deviceRoles in both modes (the DB CHECK accepts them)', () => {
+    expect(paths({ lineType: 'per_device_role', deviceRoles: ['server', 'server'] }, 'create')).toEqual(['deviceRoles']);
+    expect(paths({ lineType: 'per_device_role', deviceRoles: ['server', 'server'] }, 'persisted')).toEqual(['deviceRoles']);
+  });
+
+  it('requires deviceGroupId on a group line in create but allows the orphan state in persisted', () => {
+    expect(paths({ lineType: 'per_device_group' }, 'create')).toEqual(['deviceGroupId']);
+    // The orphaned state the FK produces (ON DELETE SET NULL on device_group_id):
+    // legal, and repairable in place by a patch (decision 7).
+    expect(paths({ lineType: 'per_device_group', deviceGroupId: null, deviceGroupName: 'Retired' }, 'persisted')).toEqual([]);
+  });
+
+  it('rejects deviceGroupId on a non-group line in both modes', () => {
+    expect(paths({ lineType: 'flat', deviceGroupId: GUID }, 'create')).toEqual(['deviceGroupId']);
+    expect(paths({ lineType: 'flat', deviceGroupId: GUID }, 'persisted')).toEqual(['deviceGroupId']);
+  });
+
+  it('ignores deviceGroupName in create and makes it two-way in persisted', () => {
+    // deviceGroupName is not a field of the add schema — the writer stamps it.
+    expect(paths({ lineType: 'per_device_group', deviceGroupId: GUID, deviceGroupName: 'VIP' }, 'create')).toEqual([]);
+    expect(paths({ lineType: 'flat', deviceGroupName: 'VIP' }, 'create')).toEqual([]);
+    expect(paths({ lineType: 'per_device_group', deviceGroupId: GUID }, 'persisted')).toEqual(['deviceGroupName']);
+    expect(paths({ lineType: 'flat', deviceGroupName: 'VIP' }, 'persisted')).toEqual(['deviceGroupName']);
+  });
+
+  it('carries a human message on every issue', () => {
+    const issues = contractLineInvariantIssues({ lineType: 'manual' }, { mode: 'create' });
+    expect(issues[0]!.message.length).toBeGreaterThan(0);
+  });
+});
+
+describe('mergeContractLinePatch (#3205 W03)', () => {
+  const GUID_A = '33333333-3333-4333-8333-333333333333';
+  const GUID_B = '44444444-4444-4444-8444-444444444444';
+  const current: PersistedContractLine = {
+    lineType: 'per_device', description: 'Managed device', unitPrice: '10.00', taxable: true,
+    catalogItemId: null, manualQuantity: null, siteId: GUID_A, deviceRoles: null,
+    deviceGroupId: null, deviceGroupName: null, sortOrder: 3,
+  };
+
+  it('preserves every field an omitted key does not touch', () => {
+    expect(mergeContractLinePatch(current, updateContractLineSchema.parse({ description: 'Renamed' }) as never))
+      .toEqual({ ...current, description: 'Renamed' });
+  });
+
+  it('clears siteId on an explicit null and leaves it alone when the key is absent', () => {
+    expect(mergeContractLinePatch(current, updateContractLineSchema.parse({ siteId: null }) as never).siteId).toBeNull();
+    expect(mergeContractLinePatch(current, updateContractLineSchema.parse({ description: 'x' }) as never).siteId).toBe(GUID_A);
+  });
+
+  it('ignores explicit undefined catalogItemId and siteId keys', () => {
+    const linked: PersistedContractLine = { ...current, catalogItemId: GUID_B };
+    const catalogPatch = updateContractLineSchema.parse({ description: 'x', catalogItemId: undefined });
+    const sitePatch = updateContractLineSchema.parse({ description: 'x', siteId: undefined });
+    expect(mergeContractLinePatch(linked, catalogPatch).catalogItemId).toBe(GUID_B);
+    expect(mergeContractLinePatch(current, sitePatch).siteId).toBe(GUID_A);
+    expect(patchHasKey(sitePatch, 'siteId')).toBe(false);
+  });
+
+  it('applies a client price on an unlinked line', () => {
+    const m = mergeContractLinePatch(current, updateContractLineSchema.parse({ unitPrice: '12.50', taxable: false }) as never);
+    expect(m).toMatchObject({ unitPrice: '12.50', taxable: false, catalogItemId: null });
+  });
+
+  // Transition rows 2 and 4: the resolver is authoritative on a linked line, so
+  // a client price is dropped rather than written.
+  it('ignores a client price while the merged row stays catalog-linked', () => {
+    const linked: PersistedContractLine = { ...current, catalogItemId: GUID_B, unitPrice: '20.00', taxable: false };
+    const m = mergeContractLinePatch(linked, updateContractLineSchema.parse({ unitPrice: '1.00', taxable: true }) as never);
+    expect(m).toMatchObject({ unitPrice: '20.00', taxable: false, catalogItemId: GUID_B });
+  });
+
+  it('lets `resolved` override unitPrice, taxable and catalogItemId', () => {
+    const m = mergeContractLinePatch(
+      current, updateContractLineSchema.parse({ catalogItemId: GUID_B }) as never,
+      { unitPrice: '7.25', taxable: false, catalogItemId: GUID_B },
+    );
+    expect(m).toMatchObject({ unitPrice: '7.25', taxable: false, catalogItemId: GUID_B });
+  });
+
+  // Transition row 6: after an unlink nothing re-resolves the number ever again,
+  // so the patch's own price is what lands.
+  it('applies the patch price when the patch unlinks the catalog item', () => {
+    const linked: PersistedContractLine = { ...current, catalogItemId: GUID_B, unitPrice: '20.00' };
+    const m = mergeContractLinePatch(linked, updateContractLineSchema.parse({ catalogItemId: null, unitPrice: '3.00', taxable: false }) as never);
+    expect(m).toMatchObject({ catalogItemId: null, unitPrice: '3.00', taxable: false });
+  });
+
+  it('never moves lineType or deviceGroupName', () => {
+    const group: PersistedContractLine = {
+      ...current, lineType: 'per_device_group', siteId: null, deviceGroupId: GUID_A, deviceGroupName: 'VIP',
+    };
+    const m = mergeContractLinePatch(group, updateContractLineSchema.parse({ deviceGroupId: GUID_B }) as never);
+    expect(m).toMatchObject({ lineType: 'per_device_group', deviceGroupId: GUID_B, deviceGroupName: 'VIP' });
   });
 });

--- a/packages/shared/src/validators/contracts.ts
+++ b/packages/shared/src/validators/contracts.ts
@@ -3,11 +3,111 @@ import { BULK_ID_LIMIT } from '../constants';
 import { currencyCodeSchema } from './currency';
 import { BILLABLE_DEVICE_ROLES } from './deviceRoles';
 
-const money = z.string().regex(/^\d+(\.\d{1,2})?$/, 'must be a 2-decimal money string');
+// numeric(12,2): ten digits before the point, two after. Unbounded before
+// (#3205 W03); an oversize value reached Postgres as a raw 22003 -> 500.
+// String-length, not Number(), so no float rounding decides a boundary.
+// Sibling validators already bound money (quotes.ts:8, catalog.ts:15).
+const money = z.string()
+  .regex(/^\d+(\.\d{1,2})?$/, 'must be a 2-decimal money string')
+  .refine((v) => v.split('.')[0]!.length <= 10, 'must be at most 10 digits before the decimal point');
+
+const INT32_MAX = 2_147_483_647;  // sort_order is int4
 const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'must be YYYY-MM-DD');
 
 export const CONTRACT_LINE_TYPES = ['flat', 'per_device', 'per_device_role', 'per_device_group', 'per_seat', 'manual'] as const;
 export type ContractLineType = typeof CONTRACT_LINE_TYPES[number];
+
+/** Read layers use null for not-applicable, write layers omit the key (see the
+ *  note on deviceRoles below). One predicate set has to serve both. */
+const present = (v: unknown): boolean => v !== undefined && v !== null;
+
+const SITE_SCOPABLE_LINE_TYPES = new Set<ContractLineType>(['per_device', 'per_device_role']);
+
+export interface ContractLineShape {
+  lineType: ContractLineType;
+  manualQuantity?: string | null;
+  siteId?: string | null;
+  deviceRoles?: readonly string[] | null;
+  deviceGroupId?: string | null;
+  deviceGroupName?: string | null;
+}
+
+export interface ContractLineInvariantIssue {
+  path: keyof ContractLineShape;
+  message: string;
+}
+
+/**
+ * #3205 W03. The contract-line invariants, once, in two modes.
+ *
+ * 'create'    — a NEW line, from contractLineInputSchema. Reproduces the
+ *               pre-W03 add-schema behaviour byte for byte.
+ * 'persisted' — a line that already exists, or a merged (current ⊕ patch) row.
+ *               Differs only where the persisted world legitimately allows
+ *               something a new line may not (a group line orphaned by the FK),
+ *               or requires something only a stored row has (the stamped
+ *               device_group_name).
+ *
+ * NOT a transcription of the DB CHECKs. Three rules here have NO database
+ * counterpart (duplicate roles — `<@` is containment, not set equality;
+ * manualQuantity — there is no CHECK on the column at all; siteId on
+ * flat/manual/per_seat — W02's CHECK covers per_device_group only), and two DB
+ * rules are not expressible here (role-set membership, 1-D array shape). Both
+ * sides are load-bearing; see the asymmetry matrix in the spec.
+ */
+export function contractLineInvariantIssues(
+  l: ContractLineShape, opts: { mode: 'create' | 'persisted' },
+): ContractLineInvariantIssue[] {
+  const issues: ContractLineInvariantIssue[] = [];
+  const isManual = l.lineType === 'manual';
+  const isRoleLine = l.lineType === 'per_device_role';
+  const isGroupLine = l.lineType === 'per_device_group';
+
+  if (isManual && !present(l.manualQuantity)) {
+    issues.push({ path: 'manualQuantity', message: 'manualQuantity is required for manual lines' });
+  } else if (!isManual && opts.mode === 'persisted' && present(l.manualQuantity)) {
+    // create TOLERATES this: the add writer nulls the column on every other
+    // type (contractService.ts:904), so rejecting it would change add behaviour.
+    issues.push({ path: 'manualQuantity', message: 'manualQuantity is only valid on manual lines' });
+  }
+
+  if (present(l.siteId) && !SITE_SCOPABLE_LINE_TYPES.has(l.lineType)) {
+    issues.push({ path: 'siteId', message: 'siteId is only valid on per_device and per_device_role lines' });
+  }
+
+  if (isRoleLine !== present(l.deviceRoles)) {
+    issues.push({ path: 'deviceRoles', message: 'deviceRoles is required on per_device_role lines and not allowed on other line types' });
+  } else if (present(l.deviceRoles)) {
+    const roles = l.deviceRoles!;
+    // The create schema's z.array(...).min(1) owns this issue. Repeating it
+    // here would change the pre-W03 issue array; persisted rows need the helper
+    // to enforce non-empty roles because they do not pass through that schema.
+    if (opts.mode === 'persisted' && roles.length === 0) {
+      issues.push({ path: 'deviceRoles', message: 'deviceRoles must not be empty' });
+    } else if (new Set(roles).size !== roles.length) {
+      issues.push({ path: 'deviceRoles', message: 'deviceRoles must not contain duplicates' });
+    }
+  }
+
+  if (opts.mode === 'create') {
+    // W02's two-way refine: a NEW group line must name its group.
+    if (isGroupLine !== present(l.deviceGroupId)) {
+      issues.push({ path: 'deviceGroupId', message: 'deviceGroupId is required on per_device_group lines and not allowed on other line types' });
+    }
+  } else {
+    // A stored group line may carry a NULL device_group_id: the composite FK is
+    // ON DELETE SET NULL (device_group_id), so deleting the group orphans the
+    // line rather than blocking. That state is legal and repairable in place.
+    if (!isGroupLine && present(l.deviceGroupId)) {
+      issues.push({ path: 'deviceGroupId', message: 'deviceGroupId is not allowed on this line type' });
+    }
+    if (isGroupLine !== present(l.deviceGroupName)) {
+      issues.push({ path: 'deviceGroupName', message: 'deviceGroupName is required on per_device_group lines and not allowed on other line types' });
+    }
+  }
+
+  return issues;
+}
 
 export const contractLineInputSchema = z.object({
   lineType: z.enum(CONTRACT_LINE_TYPES),
@@ -29,31 +129,123 @@ export const contractLineInputSchema = z.object({
   // are evaluated live at estimate/invoice time. No siteId on this type — the
   // group's own site narrows it (contract_lines_device_group_chk).
   deviceGroupId: z.string().guid().optional(),
-  sortOrder: z.number().int().min(0).optional()
+  sortOrder: z.number().int().min(0).max(INT32_MAX).optional()
 }).refine(
   (l) => l.unitPrice !== undefined || l.catalogItemId !== undefined,
   { message: 'unitPrice is required unless catalogItemId is set', path: ['unitPrice'] }
 ).refine(
   (l) => l.taxable !== undefined || l.catalogItemId !== undefined,
   { message: 'taxable is required unless catalogItemId is set', path: ['taxable'] }
+).superRefine((l, ctx) => {
+  // #3205 W03: the shape invariants live in contractLineInvariantIssues so the
+  // update path can run the SAME rules over a merged row. Pricing refinements
+  // remain before these shape checks to preserve the pre-W03 issue ordering.
+  for (const issue of contractLineInvariantIssues(l, { mode: 'create' })) {
+    ctx.addIssue({ code: 'custom', path: [issue.path], message: issue.message });
+  }
+});
+
+/**
+ * PATCH /contracts/:id/lines/:lineId (#3205 W03). Hand-written rather than
+ * contractLineInputSchema.partial(): partial() cannot express the tri-state
+ * catalogItemId, and on this schema it is not even callable — Zod 4.4.3 throws
+ * ".partial() cannot be used on object schemas containing refinements"
+ * (verified), and contractLineInputSchema carries refinements.
+ *
+ * STRICT on purpose. lineType is not editable — changing it crosses
+ * contract_lines_device_roles_chk, contract_lines_device_group_chk and the site
+ * rule at once — and a non-strict schema would ACCEPT {lineType:'flat'} and
+ * silently drop it. Strict also turns a misspelled key into a 400 rather than a
+ * silent no-op patch. Message: Unrecognized key: "lineType".
+ *
+ * catalogItemId is TRI-STATE by key presence (Zod 4 preserves absence, verified
+ * by execution); see the transition table in the spec. refreshCatalogPrice is
+ * the ONLY way to reprice an unchanged link, so a price never moves as a side
+ * effect of another edit.
+ */
+export const updateContractLineSchema = z.object({
+  description: z.string().min(1).max(2000).optional(),
+  unitPrice: money.optional(),
+  taxable: z.boolean().optional(),
+  catalogItemId: z.string().guid().nullable().optional(),
+  refreshCatalogPrice: z.boolean().optional(),      // default false
+  manualQuantity: money.optional(),
+  // null clears the site narrowing on a per_device / per_device_role line.
+  siteId: z.string().guid().nullable().optional(),
+  deviceRoles: z.array(z.enum(BILLABLE_DEVICE_ROLES)).min(1).optional(),
+  // No null: a group line is never deliberately orphaned (decision 7).
+  deviceGroupId: z.string().guid().optional(),
+  sortOrder: z.number().int().min(0).max(INT32_MAX).optional(),
+}).strict().refine(
+  (p) => Object.keys(p).length > 0,
+  { message: 'patch must change at least one field' },
 ).refine(
-  (l) => l.lineType !== 'manual' || l.manualQuantity !== undefined,
-  { message: 'manualQuantity is required for manual lines', path: ['manualQuantity'] }
-).refine(
-  (l) => l.lineType === 'per_device' || l.lineType === 'per_device_role' || l.siteId === undefined,
-  { message: 'siteId is only valid on per_device and per_device_role lines', path: ['siteId'] }
-).refine(
-  // Two-way on purpose (stricter than the manualQuantity rule): the CHECK
-  // constraint rejects roles on any other type, so the validator must too.
-  (l) => (l.lineType === 'per_device_role') === (l.deviceRoles !== undefined),
-  { message: 'deviceRoles is required on per_device_role lines and not allowed on other line types', path: ['deviceRoles'] }
-).refine(
-  (l) => l.deviceRoles === undefined || new Set(l.deviceRoles).size === l.deviceRoles.length,
-  { message: 'deviceRoles must not contain duplicates', path: ['deviceRoles'] }
-).refine(
-  (l) => (l.lineType === 'per_device_group') === (l.deviceGroupId !== undefined),
-  { message: 'deviceGroupId is required on per_device_group lines and not allowed on other line types', path: ['deviceGroupId'] }
+  (p) => p.deviceRoles === undefined || new Set(p.deviceRoles).size === p.deviceRoles.length,
+  { message: 'deviceRoles must not contain duplicates', path: ['deviceRoles'] },
 );
+
+export type UpdateContractLineInput = z.infer<typeof updateContractLineSchema>;
+
+/** Key-presence test for a tri-state patch field. Explicit undefined is the
+ *  same as omission; null alone means clear/unlink. */
+export function patchHasKey(patch: UpdateContractLineInput, key: keyof UpdateContractLineInput): boolean {
+  return key in patch && patch[key] !== undefined;
+}
+
+/** A contract_lines row in read-layer shape (null = not applicable). */
+export interface PersistedContractLine extends ContractLineShape {
+  description: string;
+  unitPrice: string;
+  taxable: boolean;
+  catalogItemId: string | null;
+  manualQuantity: string | null;
+  siteId: string | null;
+  deviceRoles: readonly string[] | null;
+  deviceGroupId: string | null;
+  deviceGroupName: string | null;
+  sortOrder: number;
+}
+
+export type MergedContractLine = PersistedContractLine;
+
+/**
+ * Current persisted line ⊕ patch (#3205 W03). PURE — the service resolves the
+ * catalog price/taxable BEFORE calling this and passes the result in `resolved`,
+ * so the whole rule set can also run in the web editor to disable Save before a
+ * round-trip, with no second copy of the rules.
+ *
+ * Price precedence implements the transition table: a `resolved` wins outright
+ * (rows 3/5 and a refresh); otherwise a merged row that stays LINKED keeps its
+ * stamped price and ignores any client value (rows 2/4), and an UNLINKED merged
+ * row takes the patch's value (rows 1/6/7).
+ *
+ * lineType and deviceGroupName are never merged: the type is not patchable, and
+ * the group name is re-stamped by the service from the resolved group AFTER the
+ * invariants run.
+ */
+export function mergeContractLinePatch(
+  current: PersistedContractLine,
+  patch: UpdateContractLineInput,
+  resolved?: { unitPrice: string; taxable: boolean; catalogItemId: string | null },
+): MergedContractLine {
+  const catalogItemId = resolved
+    ? resolved.catalogItemId
+    : (patchHasKey(patch, 'catalogItemId') ? (patch.catalogItemId ?? null) : current.catalogItemId);
+  const stillLinked = catalogItemId !== null;
+  return {
+    lineType: current.lineType,
+    description: patch.description ?? current.description,
+    unitPrice: resolved ? resolved.unitPrice : (stillLinked ? current.unitPrice : (patch.unitPrice ?? current.unitPrice)),
+    taxable: resolved ? resolved.taxable : (stillLinked ? current.taxable : (patch.taxable ?? current.taxable)),
+    catalogItemId,
+    manualQuantity: patch.manualQuantity ?? current.manualQuantity,
+    siteId: patchHasKey(patch, 'siteId') ? (patch.siteId ?? null) : current.siteId,
+    deviceRoles: patch.deviceRoles ?? current.deviceRoles,
+    deviceGroupId: patch.deviceGroupId ?? current.deviceGroupId,
+    deviceGroupName: current.deviceGroupName,
+    sortOrder: patch.sortOrder ?? current.sortOrder,
+  };
+}
 
 export const createContractSchema = z.object({
   orgId: z.string().guid(),


### PR DESCRIPTION
## Summary

Wave W03 of #3205 (device-set billing): contract lines can be edited in place instead of removed and re-added.

- `PATCH /contracts/:id/lines/:lineId` with a strict, hand-written `updateContractLineSchema`. `catalogItemId` is tri-state by key presence (absent = untouched, `null` = unlink, uuid = relink); `refreshCatalogPrice: true` re-resolves an unchanged link. `lineType` cannot change.
- Shared `contractLineInvariantIssues(line, { mode: 'create' | 'persisted' })` validates the merged row, so a patch can never persist a line the create path would reject.
- `updateContractLine`: contract-first lock, draft/active only, catalog transition table (relink re-prices in the contract currency; unlink requires `unitPrice` + `taxable` in the same patch), site/group ownership re-checks with name re-stamp, `changedFields` audit computed from the persisted before/after rows, zero-row UPDATE surfaces as `LINE_NOT_FOUND`.
- `removeContractLine` pre-reads and 404s instead of silently deleting nothing; all three line mutations write an audit row.
- `withLineRefs` returns `site` and `deviceGroup` on every line read; line reads are ordered `(sortOrder, createdAt, id)`.
- AI parity: `manage_contracts update_line` in all four registration sites with the same validation and error details, plus a registry-parity contract test.
- Web: inline edit on draft/active contracts only (Edit and Remove share one predicate), immutable edit snapshot so a background refresh cannot leak stale values into the PATCH, catalog unlink/refresh affordances, site sub-label on the detail page, eight locales.
- Docs and release-notes draft.

Spec: `docs/superpowers/specs/billing/2026-09-03-contract-line-editing-design.md`. Plan: `docs/superpowers/plans/billing/2026-09-03-contract-line-editing.md`.

## Review

Subagent-driven development: Codex implementers, per-task reviews (Sonnet for service/route, Codex for validators/AI/web), scoped re-reviews after each fix round, final whole-branch Opus review with one fix wave. Rulings are recorded in the wave ledger.

## Test plan

- [x] `packages/shared` + `apps/api` typecheck clean; `apps/web` typecheck clean
- [x] API unit suite green; web suite green (translation-coverage baselines bumped for one intentional pt-BR literal)
- [x] Integration: `contractLineEditing`, `contractService`, `contractDeviceRoles`, `contractDeviceGroups`, `contractQuantities` on a private test DB
- [ ] CI Success on the head SHA (Integration Tests shard must run — no new migrations in this wave)

Closes #4652
Refs #3205

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXFWi7tAV9LWM2UCNMPrpZ
