### PR TITLE
fix(mobile): make ApiError a real Error subclass so instanceof narrowing works (#4747)

### DIFF
--- a/apps/mobile/src/lib/errorReporting.test.ts
+++ b/apps/mobile/src/lib/errorReporting.test.ts
@@ -29,8 +29,11 @@ describe('reportInternalError', () => {
     expect(hint).toEqual({ tags: { area: 'ai-sessions-history' } });
   });
 
-  it('normalizes plain-object ApiError throws into a real Error keyed on area and status', () => {
-    // services/api.ts throws object literals, not Error instances.
+  it('normalizes plain-object throws into a real Error keyed on area and status', () => {
+    // services/api.ts itself now throws a real ApiError (#4747, see the test
+    // below) — this exercises the defensive fallback for anything ELSE that
+    // still throws a plain object shaped like the old ApiError interface (a
+    // stubbed test double, a third-party rejection).
     const apiError = { message: 'An error occurred', statusCode: 500 };
     reportInternalError(apiError, 'device-metrics');
 
@@ -41,6 +44,31 @@ describe('reportInternalError', () => {
     expect(hint).toEqual({
       tags: { area: 'device-metrics' },
       extra: { apiError },
+    });
+  });
+
+  it('attaches code/statusCode as extra for a real Error that carries them (e.g. ApiError)', () => {
+    // A real `ApiError` instance (#4747) is `instanceof Error`, so it takes the
+    // "pass through unchanged" branch above — but Sentry does not auto-serialize
+    // a thrown Error subclass's own `code`/`statusCode` properties. Without this,
+    // the HTTP status/code silently stopped reaching Sentry's tags/extra the
+    // moment ApiError became a real Error (it used to always take the
+    // `extra: { apiError: err }` branch). Simulated here without importing the
+    // real ApiError class, since this file mocks `../services/api` to keep
+    // expo-secure-store out of the node test runtime.
+    const err = Object.assign(new Error('Too many attempts'), {
+      name: 'ApiError',
+      code: 'rate_limited',
+      statusCode: 429,
+    });
+    reportInternalError(err, 'change-password');
+
+    expect(sentry.captureException).toHaveBeenCalledTimes(1);
+    const [captured, hint] = sentry.captureException.mock.calls[0];
+    expect(captured).toBe(err);
+    expect(hint).toEqual({
+      tags: { area: 'change-password' },
+      extra: { code: 'rate_limited', statusCode: 429 },
     });
   });
 

--- a/apps/mobile/src/lib/errorReporting.ts
+++ b/apps/mobile/src/lib/errorReporting.ts
@@ -31,8 +31,22 @@ export function reportInternalError(err: unknown, area: string): void {
           `${area} failed: ${apiErr?.statusCode ?? '?'} ${apiErr?.message ?? String(err)}`.trim(),
         );
 
+  // A real `ApiError` is `instanceof Error` and takes the branch above
+  // unchanged, but Sentry does not auto-serialize a thrown Error subclass's
+  // own `code`/`statusCode` properties (no extraErrorDataIntegration
+  // configured) — attach them explicitly so the HTTP status/code survives
+  // into the event instead of only living in the stack trace.
+  const apiExtra =
+    apiErr && (apiErr.code !== undefined || apiErr.statusCode !== undefined)
+      ? { code: apiErr.code, statusCode: apiErr.statusCode }
+      : null;
+
   Sentry.captureException(normalized, {
     tags: { area },
-    ...(err instanceof Error ? {} : { extra: { apiError: err } }),
+    ...(err instanceof Error
+      ? apiExtra
+        ? { extra: apiExtra }
+        : {}
+      : { extra: { apiError: err } }),
   });
 }

--- a/apps/mobile/src/lib/errorReporting.ts
+++ b/apps/mobile/src/lib/errorReporting.ts
@@ -7,11 +7,14 @@ import { DEVICE_BLOCKED_CODE, type ApiError } from '../services/api';
  * user (issues #3115 / #3141): call sites show static copy on screen and route
  * the detail (function name, HTTP status) here instead.
  *
- * services/api.ts throws plain `ApiError` object literals, not `Error`
- * instances. Captured as-is, those become stackless synthetic Sentry events
- * that all group into one issue ("Object captured as exception…"), so
- * non-Error values are normalized into a real `Error` keyed on the area and
- * status, with the original object preserved in `extra`.
+ * `services/api.ts` throws a real `ApiError extends Error` (#4747), so most
+ * callers hit the `instanceof Error` branch and are captured as-is. This stays
+ * defensive for anything that still throws a plain object or non-Error value
+ * (a caught third-party rejection, a stubbed test double, `throw 'string'`) —
+ * captured as-is those become stackless synthetic Sentry events that all group
+ * into one issue ("Object captured as exception…"), so non-Error values are
+ * normalized into a real `Error` keyed on the area and status, with the
+ * original value preserved in `extra`.
  */
 export function reportInternalError(err: unknown, area: string): void {
   const apiErr = err && typeof err === 'object' ? (err as Partial<ApiError>) : null;

--- a/apps/mobile/src/services/api.changePassword.test.ts
+++ b/apps/mobile/src/services/api.changePassword.test.ts
@@ -74,12 +74,21 @@ describe('changePassword', () => {
       response(429, { error: 'Too many attempts', code: 'rate_limited' }),
     );
 
-    await expect(changePassword('a', 'b')).rejects.toBeInstanceOf(ApiError);
-    await expect(changePassword('a', 'b')).rejects.toBeInstanceOf(Error);
-    fetchWithTimeout.mockResolvedValueOnce(
-      response(429, { error: 'Too many attempts', code: 'rate_limited' }),
-    );
-    await expect(changePassword('a', 'b')).rejects.toMatchObject({
+    // One caught value, asserted three ways — a separate `mockResolvedValueOnce`
+    // per `expect(...).rejects` call would starve the queue after the first
+    // await (vitest's mock queue is consumed per call), leaving later calls to
+    // resolve `undefined` and fail somewhere unrelated (`response.headers` on
+    // `undefined`) rather than re-exercising this path.
+    let caught: unknown;
+    try {
+      await changePassword('a', 'b');
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(ApiError);
+    expect(caught).toBeInstanceOf(Error);
+    expect(caught).toMatchObject({
       message: 'Too many attempts',
       code: 'rate_limited',
       statusCode: 429,

--- a/apps/mobile/src/services/api.changePassword.test.ts
+++ b/apps/mobile/src/services/api.changePassword.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Same harness as api.mfa.test.ts: SecureStore, Sentry, server URL,
+// installation id, fetch and CSRF are stubbed so `changePassword` runs
+// end-to-end through the real `requestWithPrefix`/`coreRequest` machinery
+// against a scripted response, instead of mocking './api' away.
+const fetchWithTimeout = vi.fn();
+
+vi.mock('expo-secure-store', () => ({
+  WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'device-only',
+  getItemAsync: vi.fn(async () => null),
+  setItemAsync: vi.fn(async () => undefined),
+  deleteItemAsync: vi.fn(async () => undefined),
+}));
+vi.mock('@sentry/react-native', () => ({ captureMessage: vi.fn() }));
+vi.mock('./serverConfig', () => ({ getServerUrl: vi.fn(async () => 'https://api.example.test') }));
+vi.mock('./installationId', () => ({
+  getOrCreateInstallationId: vi.fn(async () => 'install-1'),
+}));
+vi.mock('./fetchWithTimeout', () => ({
+  fetchWithTimeout: (...args: unknown[]) => fetchWithTimeout(...args),
+}));
+vi.mock('./csrfToken', () => ({
+  applyCsrfSignal: vi.fn(async () => undefined),
+  forgetCsrfToken: vi.fn(async () => undefined),
+  getCsrfHeaderValue: vi.fn(async () => 'csrf'),
+  readCsrfCookie: vi.fn(() => ({ kind: 'absent' })),
+}));
+
+import { ApiError, changePassword } from './api';
+
+function response(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+beforeEach(() => {
+  fetchWithTimeout.mockReset();
+});
+
+describe('changePassword', () => {
+  // Root cause of #4747: `services/api.ts` used to throw a plain object
+  // literal cast `as ApiError`, so `err instanceof Error` at the
+  // ChangePasswordSheet catch site (screens/chat/components/
+  // ChangePasswordSheet.tsx:176 — `err instanceof Error ? err.message :
+  // 'Could not change password.'`) was always false and the server's message
+  // ("current password is incorrect", rate-limited, etc.) never reached the
+  // user. This test exercises the exact same expression against what
+  // `changePassword` actually throws, since the mobile app has no React
+  // Native test runtime configured (see vitest.config.ts) to render the
+  // sheet itself.
+  it('rejects with a message the ChangePasswordSheet catch handler surfaces verbatim on a 400', async () => {
+    fetchWithTimeout.mockResolvedValueOnce(
+      response(400, { error: 'Current password is incorrect' }),
+    );
+
+    let caught: unknown;
+    try {
+      await changePassword('wrong-current', 'new-password-123');
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeDefined();
+    // The exact ternary from ChangePasswordSheet.tsx's catch block.
+    const msg = caught instanceof Error ? caught.message : 'Could not change password.';
+    expect(msg).toBe('Current password is incorrect');
+  });
+
+  it('rejects with an ApiError that is instanceof both ApiError and Error, carrying status/code', async () => {
+    fetchWithTimeout.mockResolvedValueOnce(
+      response(429, { error: 'Too many attempts', code: 'rate_limited' }),
+    );
+
+    await expect(changePassword('a', 'b')).rejects.toBeInstanceOf(ApiError);
+    await expect(changePassword('a', 'b')).rejects.toBeInstanceOf(Error);
+    fetchWithTimeout.mockResolvedValueOnce(
+      response(429, { error: 'Too many attempts', code: 'rate_limited' }),
+    );
+    await expect(changePassword('a', 'b')).rejects.toMatchObject({
+      message: 'Too many attempts',
+      code: 'rate_limited',
+      statusCode: 429,
+    });
+  });
+});
+
+describe('ApiError', () => {
+  it('is a real Error subclass — instanceof Error and instanceof ApiError both hold', () => {
+    const err = new ApiError({ message: 'boom', code: 'x', statusCode: 500 });
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.message).toBe('boom');
+    expect(err.code).toBe('x');
+    expect(err.statusCode).toBe(500);
+    expect(err.name).toBe('ApiError');
+  });
+});

--- a/apps/mobile/src/services/api.ts
+++ b/apps/mobile/src/services/api.ts
@@ -155,10 +155,24 @@ export type LoginResult =
   | { kind: 'mfaRequired'; challenge: MfaChallenge }
   | { kind: 'mfaEnrollmentRequired'; handoff: MfaEnrollmentRequired };
 
-export interface ApiError {
-  message: string;
+/**
+ * A real `Error` subclass (mirrors `TimeEntryError` in `./timeEntries`) so
+ * `err instanceof Error` narrowing at call sites actually matches. Before
+ * #4747 this was a plain `interface` and every throw site threw an object
+ * literal cast `as ApiError`, so `instanceof Error` was always false and the
+ * server's message never reached the user (ChangePasswordSheet,
+ * errorReporting) — it silently fell back to a generic string instead.
+ */
+export class ApiError extends Error {
   code?: string;
   statusCode?: number;
+
+  constructor(params: { message: string; code?: string; statusCode?: number }) {
+    super(params.message);
+    this.name = 'ApiError';
+    this.code = params.code;
+    this.statusCode = params.statusCode;
+  }
 }
 
 interface ListResponse<T> {
@@ -529,8 +543,7 @@ async function requestWithPrefix<T>(
         assertCurrentSession(capturedGeneration);
       }
 
-      const error: ApiError = { message, code, statusCode: response.status };
-      throw error;
+      throw new ApiError({ message, code, statusCode: response.status });
     }
 
     const text = await response.text();
@@ -543,10 +556,10 @@ async function requestWithPrefix<T>(
 
 function assertCurrentSession(capturedGeneration: number): void {
   if (capturedGeneration === currentSessionGeneration()) return;
-  throw {
+  throw new ApiError({
     message: 'Response belongs to a superseded session',
     code: 'session_superseded',
-  } as ApiError;
+  });
 }
 
 async function request<T>(
@@ -645,14 +658,14 @@ export async function login(email: string, password: string): Promise<LoginResul
   if (response.mfaRequired) {
     const challenge = parseMfaChallengePayload(response);
     if (!challenge) {
-      throw { message: 'Invalid MFA challenge from server' } as ApiError;
+      throw new ApiError({ message: 'Invalid MFA challenge from server' });
     }
     return { kind: 'mfaRequired', challenge };
   }
 
   const token = response.tokens?.accessToken || response.accessToken;
   if (!response.user || !token) {
-    throw { message: response.error || 'Invalid login response' } as ApiError;
+    throw new ApiError({ message: response.error || 'Invalid login response' });
   }
 
   return {
@@ -675,7 +688,7 @@ export async function verifyMfa(
 
   const token = response.tokens?.accessToken || response.accessToken;
   if (!response.user || !token) {
-    throw { message: response.error || 'Invalid MFA response' } as ApiError;
+    throw new ApiError({ message: response.error || 'Invalid MFA response' });
   }
 
   return { token, user: response.user, registerGrant: response.authenticatorRegisterGrantId ?? null };
@@ -747,16 +760,16 @@ export async function refreshToken(): Promise<{ token: string }> {
     });
   const token = response.tokens?.accessToken || response.accessToken;
   if (!token) {
-    throw { message: 'Failed to refresh token' } as ApiError;
+    throw new ApiError({ message: 'Failed to refresh token' });
   }
   // Callers such as aiChat persist the returned token. Refuse to hand them a
   // response that began before logout advanced the generation, otherwise the
   // caller could reinstall access authority after local teardown completed.
   if (generation !== currentSessionGeneration()) {
-    throw {
+    throw new ApiError({
       message: 'Refresh response belongs to a superseded session',
       code: 'session_superseded',
-    } as ApiError;
+    });
   }
   return { token };
 }

--- a/apps/mobile/src/services/connectedApps.ts
+++ b/apps/mobile/src/services/connectedApps.ts
@@ -2,7 +2,7 @@ import * as SecureStore from 'expo-secure-store';
 
 import { getServerUrl } from './serverConfig';
 import { getOrCreateInstallationId } from './installationId';
-import { MOBILE_DEVICE_ID_HEADER } from './api';
+import { ApiError, MOBILE_DEVICE_ID_HEADER } from './api';
 import { fetchWithAuthRefresh } from './authedFetch';
 
 const FALLBACK_API_BASE_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3001';
@@ -16,12 +16,6 @@ export interface ConnectedApp {
   lastUsedAt: string | null;
   lastApprovalDecidedAt: string | null;
   revokedAt: string | null;
-}
-
-interface ApiError {
-  message: string;
-  code?: string;
-  statusCode?: number;
 }
 
 async function call<T>(path: string, init: RequestInit = {}): Promise<T> {
@@ -49,12 +43,11 @@ async function call<T>(path: string, init: RequestInit = {}): Promise<T> {
 
   if (!res.ok) {
     const body = await res.json().catch(() => ({} as Record<string, unknown>));
-    const err: ApiError = {
+    throw new ApiError({
       message: (typeof body.error === 'string' && body.error) || 'Request failed',
       code: typeof body.code === 'string' ? body.code : undefined,
       statusCode: res.status,
-    };
-    throw err;
+    });
   }
 
   const text = await res.text();

--- a/apps/mobile/src/services/mobileDevices.ts
+++ b/apps/mobile/src/services/mobileDevices.ts
@@ -2,7 +2,7 @@ import * as SecureStore from 'expo-secure-store';
 
 import { getServerUrl } from './serverConfig';
 import { getOrCreateInstallationId } from './installationId';
-import { MOBILE_DEVICE_ID_HEADER } from './api';
+import { ApiError, MOBILE_DEVICE_ID_HEADER } from './api';
 import { fetchWithAuthRefresh } from './authedFetch';
 
 const FALLBACK_API_BASE_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3001';
@@ -22,12 +22,6 @@ export interface PairedMobileDevice {
   blockedReason: string | null;
   createdAt: string;
   isCurrent: boolean;
-}
-
-interface ApiError {
-  message: string;
-  code?: string;
-  statusCode?: number;
 }
 
 async function getToken(): Promise<string | null> {
@@ -63,12 +57,11 @@ async function call<T>(path: string, init: RequestInit = {}): Promise<T> {
 
   if (!res.ok) {
     const body = await res.json().catch(() => ({} as Record<string, unknown>));
-    const err: ApiError = {
+    throw new ApiError({
       message: (typeof body.error === 'string' && body.error) || 'Request failed',
       code: typeof body.code === 'string' ? body.code : undefined,
       statusCode: res.status,
-    };
-    throw err;
+    });
   }
 
   const text = await res.text();


### PR DESCRIPTION
## Summary

Closes #4747

`apps/mobile/src/services/api.ts` declared `export interface ApiError { message, code?, statusCode? }` and every throw site threw an object literal cast `as ApiError` — never a real `Error` instance. That made `err instanceof Error` always false at every catch site that used it to decide whether to show the server's message, most visibly `ChangePasswordSheet.tsx:176` (`err instanceof Error ? err.message : 'Could not change password.'`), which always fell back to the generic string even when the server sent a specific one ("current password is incorrect", rate-limited, etc.). `lib/errorReporting.ts:33` had the identical split, driving every ApiError through its non-Error normalization branch instead of being captured as-is.

## Fix

- `ApiError` is now `class ApiError extends Error` (mirrors the existing `TimeEntryError extends Error` pattern already used in `services/timeEntries.ts`), keeping the same `message` / `code?` / `statusCode?` fields plus `name = 'ApiError'`.
- All 7 throw sites in `api.ts` (main request-failure throw, `assertCurrentSession`'s two superseded-session throws, the two invalid-login/MFA-response throws, and the two token-refresh throws) now do `throw new ApiError({...})` instead of `throw {...} as ApiError`.
- Collapsed the two duplicate private `interface ApiError` copies in `services/connectedApps.ts` and `services/mobileDevices.ts` onto the exported class (imported from `./api`), and their throw sites now do `throw new ApiError({...})`.
- Updated the now-stale doc comment on `errorReporting.reportInternalError` (it previously said api.ts "throws plain object literals, not Error instances" — no longer true; the comment now explains the defensive branch is for genuinely non-Error throws, e.g. test doubles or `throw 'string'`).

## Repo-wide sweep for regressions (per the issue's ask)

Grepped `apps/mobile/src` for every `instanceof Error`, `as ApiError`, and `ApiError` reference before and after the change:

- **`instanceof Error` sites** (ChangePasswordSheet, errorReporting, ServerSelectScreen, SettingsSheet, searchCoordinator, AlertDetailScreen, TimeSuggestionsScreen, SystemsScreen, aiChat, notifications, timeEntryQueue, appLockStore, csrfToken) — none assume `ApiError` is *not* an Error; they all treat "not instanceof Error" as the exceptional/fallback case. Making `ApiError` a real Error only makes these sites correct instead of always-fallback; none regress.
- **`services/timeEntries.ts`'s `asTimeEntryError`** and **`timeEntryAccess.ts`'s `classifyTimeEntryDenial`** duck-type on `.message`/`.code`/`.status`/`.statusCode` rather than checking `instanceof`, so they're unaffected by ApiError going from a plain object to a class instance (still has all the same enumerable-looking properties via getters... actually own properties, since they're assigned in the constructor).
- **`as ApiError` casts** — all 7 in `api.ts` were the throw sites already covered above; none remain.
- **`connectedApps.ts` / `mobileDevices.ts`** — no `instanceof` checks on their thrown errors elsewhere in the codebase; both files' own duplicate interfaces are gone.

## Tests

Added `apps/mobile/src/services/api.changePassword.test.ts`:

- A unit test that `new ApiError({...})` is `instanceof Error` **and** `instanceof ApiError`, with `name`/`message`/`code`/`statusCode` set correctly.
- An integration-style test (same harness/mocking pattern as the existing `api.mfa.test.ts`: `expo-secure-store`, `@sentry/react-native`, `serverConfig`, `installationId`, `fetchWithTimeout`, `csrfToken` mocked, real `requestWithPrefix`/`coreRequest` machinery exercised) that mocks a 400 response with `{ error: 'Current password is incorrect' }` from `changePassword`, then evaluates the *exact* ternary from `ChangePasswordSheet.tsx`'s catch block (`err instanceof Error ? err.message : 'Could not change password.'`) against what's thrown, and asserts it resolves to the server's message.

**Why not a component-render test of `ChangePasswordSheet` itself:** `apps/mobile/vitest.config.ts` deliberately scopes `include` to `src/**/*.test.ts` (not `.tsx`) with an explicit comment — "The mobile app has no React Native test runtime configured — we deliberately keep the include pattern at .ts (not .tsx) so component imports never pull RN/Expo modules into Vitest." There is no existing `.test.tsx` file anywhere in the repo, no `@testing-library/react-native` dependency, and no RN test renderer configured. Standing up that infrastructure is out of scope for a mechanical bug fix, so the test above reproduces the exact bug (verified red against the pre-fix code — see below) via the same expression the component uses, against the real thrown value, instead of via a render.

**Red-first verification:** before finalizing, I stashed the `api.ts` fix and re-ran the new test file — both the message test and the `instanceof` tests failed exactly as described (`'Could not change password.'` instead of the server's message; `ApiError is not a constructor`), confirming the test reproduces the reported bug. Then restored the fix and re-ran — green.

## Verification

- `cd apps/mobile && npx vitest run` — **95 files, 1222 passed, 3 skipped, 0 failed** (full mobile suite, not just the affected files, given `api.ts` is imported broadly).
- `cd apps/mobile && npx tsc --noEmit` — clean, no errors.
- Branched off fresh `origin/main` (383a10f9a), fast-forward-merged one intervening unrelated portal commit (458ed6f1b) before final verification — no conflicts, suite re-run green after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBxF7C8E5GxFnNcGf6kBVP