### PR TITLE
feat(agent): extract custom-field markers from raw script stdout (#2698)

### DIFF
--- a/agent/internal/executor/customfields.go
+++ b/agent/internal/executor/customfields.go
@@ -21,8 +21,16 @@ const (
 // deliberately before SanitizeOutput, which rewrites `token=`/`secret=`-shaped
 // substrings and would otherwise corrupt a marker beyond JSON.Unmarshal's
 // reach. Returns the merged map (later lines win) and stdout with the consumed
-// lines removed. Unparseable marker lines are LEFT IN stdout so the operator
-// can see what the script actually printed.
+// lines removed.
+//
+// All three caps (marker-line count, per-marker JSON size, distinct key
+// count) reject at LINE granularity and leave the rejected line in the
+// returned stdout, so a technician reading the persisted output can always
+// see which lines were not applied and why (a syntactically valid marker line
+// is never partially merged then silently discarded key-by-key — that would
+// leave no trace anywhere once the line itself is consumed). This also keeps
+// "later lines win" true without exception: a later line either fully applies
+// or is fully rejected, never partially applies past the key cap.
 func ExtractCustomFields(stdout string) (map[string]any, string) {
 	if !strings.Contains(stdout, CustomFieldMarker) {
 		return nil, stdout
@@ -52,16 +60,26 @@ func ExtractCustomFields(stdout string) (map[string]any, string) {
 			continue
 		}
 
+		// Reject the whole line, deterministically, if merging it would push
+		// the distinct-key count past the cap — rather than partially merging
+		// some of its keys in Go's randomized map-iteration order and dropping
+		// the rest with no trace.
+		newKeys := 0
+		for k := range parsed {
+			if _, exists := fields[k]; !exists {
+				newKeys++
+			}
+		}
+		if len(fields)+newKeys > maxCustomFieldKeys {
+			kept = append(kept, line)
+			continue
+		}
+
 		markerLines++
 		if fields == nil {
 			fields = make(map[string]any, len(parsed))
 		}
 		for k, v := range parsed {
-			if len(fields) >= maxCustomFieldKeys {
-				if _, exists := fields[k]; !exists {
-					continue
-				}
-			}
 			fields[k] = v
 		}
 		// consumed: not appended to kept

--- a/agent/internal/executor/customfields.go
+++ b/agent/internal/executor/customfields.go
@@ -1,0 +1,71 @@
+package executor
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// CustomFieldMarker is the stdout sentinel a script uses to write its own
+// device's custom fields (#2698). Must stay byte-identical to
+// CUSTOM_FIELD_MARKER in
+// apps/api/src/services/customFields/scriptWriteMarkers.ts.
+const CustomFieldMarker = "::breeze:custom-fields::"
+
+const (
+	maxCustomFieldMarkerLines = 20
+	maxCustomFieldKeys        = 50
+	maxCustomFieldJSONBytes   = 8192
+)
+
+// ExtractCustomFields pulls every well-formed marker line out of RAW stdout —
+// deliberately before SanitizeOutput, which rewrites `token=`/`secret=`-shaped
+// substrings and would otherwise corrupt a marker beyond JSON.Unmarshal's
+// reach. Returns the merged map (later lines win) and stdout with the consumed
+// lines removed. Unparseable marker lines are LEFT IN stdout so the operator
+// can see what the script actually printed.
+func ExtractCustomFields(stdout string) (map[string]any, string) {
+	if !strings.Contains(stdout, CustomFieldMarker) {
+		return nil, stdout
+	}
+
+	lines := strings.Split(stdout, "\n")
+	kept := make([]string, 0, len(lines))
+	var fields map[string]any
+	markerLines := 0
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, CustomFieldMarker) || markerLines >= maxCustomFieldMarkerLines {
+			kept = append(kept, line)
+			continue
+		}
+
+		payload := strings.TrimSpace(strings.TrimPrefix(trimmed, CustomFieldMarker))
+		if len(payload) > maxCustomFieldJSONBytes {
+			kept = append(kept, line)
+			continue
+		}
+
+		var parsed map[string]any
+		if err := json.Unmarshal([]byte(payload), &parsed); err != nil || parsed == nil {
+			kept = append(kept, line)
+			continue
+		}
+
+		markerLines++
+		if fields == nil {
+			fields = make(map[string]any, len(parsed))
+		}
+		for k, v := range parsed {
+			if len(fields) >= maxCustomFieldKeys {
+				if _, exists := fields[k]; !exists {
+					continue
+				}
+			}
+			fields[k] = v
+		}
+		// consumed: not appended to kept
+	}
+
+	return fields, strings.Join(kept, "\n")
+}

--- a/agent/internal/executor/customfields_test.go
+++ b/agent/internal/executor/customfields_test.go
@@ -1,0 +1,75 @@
+package executor
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExtractCustomFields(t *testing.T) {
+	tests := []struct {
+		name       string
+		stdout     string
+		wantFields map[string]any
+		wantStdout string
+	}{
+		{
+			name:       "no marker",
+			stdout:     "hello\nworld\n",
+			wantFields: nil,
+			wantStdout: "hello\nworld\n",
+		},
+		{
+			name:       "single marker is extracted and removed",
+			stdout:     "scanning\n::breeze:custom-fields:: {\"a\":\"1\"}\ndone\n",
+			wantFields: map[string]any{"a": "1"},
+			wantStdout: "scanning\ndone\n",
+		},
+		{
+			name:       "later marker wins",
+			stdout:     "::breeze:custom-fields:: {\"a\":1}\n::breeze:custom-fields:: {\"a\":2,\"b\":3}\n",
+			wantFields: map[string]any{"a": float64(2), "b": float64(3)},
+			wantStdout: "",
+		},
+		{
+			name:       "secret-shaped value survives because we run before SanitizeOutput",
+			stdout:     "::breeze:custom-fields:: {\"vault_token_id\":\"abcdefgh\"}\n",
+			wantFields: map[string]any{"vault_token_id": "abcdefgh"},
+			wantStdout: "",
+		},
+		{
+			name:       "unparseable marker is left in stdout for the operator to see",
+			stdout:     "::breeze:custom-fields:: {\"a\":\n",
+			wantFields: nil,
+			wantStdout: "::breeze:custom-fields:: {\"a\":\n",
+		},
+		{
+			name:       "CRLF line endings",
+			stdout:     "::breeze:custom-fields:: {\"a\":\"1\"}\r\nx\r\n",
+			wantFields: map[string]any{"a": "1"},
+			wantStdout: "x\r\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fields, stdout := ExtractCustomFields(tt.stdout)
+			if !reflect.DeepEqual(fields, tt.wantFields) {
+				t.Fatalf("fields = %#v, want %#v", fields, tt.wantFields)
+			}
+			if stdout != tt.wantStdout {
+				t.Fatalf("stdout = %q, want %q", stdout, tt.wantStdout)
+			}
+		})
+	}
+}
+
+func TestExtractCustomFieldsCaps(t *testing.T) {
+	var b []byte
+	for i := 0; i < 25; i++ {
+		b = append(b, []byte("::breeze:custom-fields:: {\"k\":1}\n")...)
+	}
+	fields, _ := ExtractCustomFields(string(b))
+	if len(fields) != 1 {
+		t.Fatalf("expected the merged map to hold 1 key, got %d", len(fields))
+	}
+}

--- a/agent/internal/executor/customfields_test.go
+++ b/agent/internal/executor/customfields_test.go
@@ -1,7 +1,9 @@
 package executor
 
 import (
+	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -63,13 +65,119 @@ func TestExtractCustomFields(t *testing.T) {
 	}
 }
 
+// TestExtractCustomFieldsCaps proves the line count cap actually caps: 25
+// marker lines, each setting a DISTINCT key so the assertion cannot pass by
+// accident (25 identical-key lines would merge to 1 key regardless of
+// whether the cap exists at all — that was the bug in the version of this
+// test this replaces).
 func TestExtractCustomFieldsCaps(t *testing.T) {
-	var b []byte
+	var lines []string
 	for i := 0; i < 25; i++ {
-		b = append(b, []byte("::breeze:custom-fields:: {\"k\":1}\n")...)
+		lines = append(lines, fmt.Sprintf(`::breeze:custom-fields:: {"k%d":%d}`, i, i))
 	}
-	fields, _ := ExtractCustomFields(string(b))
-	if len(fields) != 1 {
-		t.Fatalf("expected the merged map to hold 1 key, got %d", len(fields))
+	stdout := strings.Join(lines, "\n") + "\n"
+
+	fields, remaining := ExtractCustomFields(stdout)
+
+	if len(fields) != maxCustomFieldMarkerLines {
+		t.Fatalf("expected exactly %d keys (one per applied line), got %d: %#v", maxCustomFieldMarkerLines, len(fields), fields)
+	}
+	for i := 0; i < maxCustomFieldMarkerLines; i++ {
+		key := fmt.Sprintf("k%d", i)
+		if fields[key] != float64(i) {
+			t.Errorf("fields[%q] = %#v, want %v (line %d should have been applied)", key, fields[key], i, i)
+		}
+	}
+	for i := maxCustomFieldMarkerLines; i < 25; i++ {
+		key := fmt.Sprintf("k%d", i)
+		if _, present := fields[key]; present {
+			t.Errorf("fields[%q] present, want absent — line %d is past the %d-line cap", key, i, maxCustomFieldMarkerLines)
+		}
+	}
+	// The rejected lines (20-24) must still be visible in the returned
+	// stdout — that's the whole point of rejecting at line granularity.
+	for i := maxCustomFieldMarkerLines; i < 25; i++ {
+		marker := fmt.Sprintf(`{"k%d":%d}`, i, i)
+		if !strings.Contains(remaining, marker) {
+			t.Errorf("expected rejected line %d to remain visible in stdout, got %q", i, remaining)
+		}
+	}
+}
+
+// TestExtractCustomFieldsKeyCapRejectsWholeLine proves the 50-distinct-key
+// cap rejects an over-cap marker line WHOLESALE and deterministically —
+// never partially merging some of its keys per Go's randomized map iteration
+// order and dropping the rest with no trace (the bug this test guards
+// against: the original implementation looped `for k, v := range parsed`
+// and silently `continue`d past the cap key-by-key inside a single line).
+func TestExtractCustomFieldsKeyCapRejectsWholeLine(t *testing.T) {
+	// One marker line establishing exactly 50 keys — fills the cap exactly.
+	first := make([]string, maxCustomFieldKeys)
+	for i := range first {
+		first[i] = fmt.Sprintf(`"a%d":%d`, i, i)
+	}
+	firstLine := "::breeze:custom-fields:: {" + strings.Join(first, ",") + "}"
+
+	// A second marker line with two BRAND NEW keys — merging it would push
+	// the total to 52, over the cap, so it must be rejected in full.
+	secondLine := `::breeze:custom-fields:: {"new1":"x","new2":"y"}`
+
+	stdout := firstLine + "\n" + secondLine + "\n"
+	fields, remaining := ExtractCustomFields(stdout)
+
+	if len(fields) != maxCustomFieldKeys {
+		t.Fatalf("expected exactly %d keys from the first line, got %d", maxCustomFieldKeys, len(fields))
+	}
+	if _, present := fields["new1"]; present {
+		t.Error(`fields["new1"] present, want absent — the whole second line should have been rejected`)
+	}
+	if _, present := fields["new2"]; present {
+		t.Error(`fields["new2"] present, want absent — the whole second line should have been rejected`)
+	}
+	if !strings.Contains(remaining, "new1") {
+		t.Errorf("expected the rejected second line to remain visible in stdout, got %q", remaining)
+	}
+}
+
+// TestExtractCustomFieldsKeyCapAllowsUpdatesToExistingKeys proves that a
+// later line can still freely UPDATE keys already present, even once the
+// cap is full — "later lines win" stays true for existing keys; only NEW
+// keys past the cap are rejected (with the whole line, per the test above).
+func TestExtractCustomFieldsKeyCapAllowsUpdatesToExistingKeys(t *testing.T) {
+	first := make([]string, maxCustomFieldKeys)
+	for i := range first {
+		first[i] = fmt.Sprintf(`"a%d":%d`, i, i)
+	}
+	firstLine := "::breeze:custom-fields:: {" + strings.Join(first, ",") + "}"
+	secondLine := `::breeze:custom-fields:: {"a0":"updated"}`
+
+	stdout := firstLine + "\n" + secondLine + "\n"
+	fields, remaining := ExtractCustomFields(stdout)
+
+	if len(fields) != maxCustomFieldKeys {
+		t.Fatalf("expected exactly %d keys, got %d", maxCustomFieldKeys, len(fields))
+	}
+	if fields["a0"] != "updated" {
+		t.Errorf(`fields["a0"] = %#v, want "updated" — an update-only line must still apply once the cap is full`, fields["a0"])
+	}
+	if strings.Contains(remaining, `"a0":"updated"`) {
+		t.Errorf("the update-only second line should have been consumed, not left in stdout: %q", remaining)
+	}
+}
+
+// TestExtractCustomFieldsJSONSizeCap proves an oversized marker payload is
+// rejected and left visible in stdout, matching the other two caps.
+func TestExtractCustomFieldsJSONSizeCap(t *testing.T) {
+	// One key whose value alone exceeds maxCustomFieldJSONBytes (8192).
+	oversizedValue := strings.Repeat("x", maxCustomFieldJSONBytes)
+	line := fmt.Sprintf(`::breeze:custom-fields:: {"a":"%s"}`, oversizedValue)
+
+	fields, remaining := ExtractCustomFields(line + "\n")
+
+	if fields != nil {
+		t.Fatalf("expected no fields from an oversized marker, got %#v", fields)
+	}
+	if !strings.Contains(remaining, CustomFieldMarker) {
+		t.Errorf("expected the oversized marker line to remain visible in stdout, got %q", remaining)
 	}
 }

--- a/agent/internal/heartbeat/handlers_script.go
+++ b/agent/internal/heartbeat/handlers_script.go
@@ -70,12 +70,45 @@ func handleScript(h *Heartbeat, cmd Command) tools.CommandResult {
 	res.Stdout = redact(res.Stdout)
 	res.Stderr = redact(res.Stderr)
 	res.Error = redact(res.Error)
-	// res.Result is deliberately NOT passed through redact: it only ever
-	// carries the #2698 customFieldWrites envelope, which Wave 1 already
-	// documents as not a secrets channel (the marker rides raw stdout, which
-	// IS redacted above, before extraction). A future Result payload must not
-	// assume this field is scrubbed.
+	// #2698: delivered secretEnv values ride the script's real process
+	// environment, so a script can echo one into a customFieldWrites marker
+	// value — and that value is extracted from stdout BEFORE SanitizeOutput
+	// even runs (that ordering is the entire point of Wave 3), so it is not
+	// caught by the pattern-based sanitizer either. Unlike Stdout/Stderr/
+	// Error, res.Result is never persisted as free-text log output — it is
+	// written into a device's custom fields, a location any org user with
+	// device-read access can see. Redact it with the same exact-value
+	// redactor so a delivered secret cannot be exfiltrated through a custom
+	// field. (secretEnv never reaches the user-helper path at all — see the
+	// #3409 refusal above — so this exclusively covers the local-executor
+	// build site, which is exactly where the risk is.)
+	redactCustomFieldValues(res.Result, redact)
 	return res
+}
+
+// redactCustomFieldValues strips delivered-secret values out of a
+// customFieldWrites envelope's string field values, in place. Non-string
+// values (numbers, booleans) cannot contain an exact-value secret match, and
+// the server rejects non-scalar custom field values outright
+// (validateValue.ts), so only string values need scrubbing.
+func redactCustomFieldValues(result any, redact func(string) string) {
+	envelope, ok := result.(map[string]any)
+	if !ok {
+		return
+	}
+	writes, ok := envelope["customFieldWrites"].(map[string]any)
+	if !ok {
+		return
+	}
+	fields, ok := writes["fields"].(map[string]any)
+	if !ok {
+		return
+	}
+	for k, v := range fields {
+		if s, ok := v.(string); ok {
+			fields[k] = redact(s)
+		}
+	}
 }
 
 // handleScriptInner is the original handler body. Every return it makes flows
@@ -218,6 +251,15 @@ func handleScriptInner(h *Heartbeat, cmd Command, secretEnv executor.SecretEnv) 
 	// closes. The marker lines are stripped so the operator's saved output is
 	// the script's real output.
 	customFields, cleanedStdout := executor.ExtractCustomFields(scriptResult.Stdout)
+	if strings.Contains(cleanedStdout, executor.CustomFieldMarker) {
+		// A marker-prefixed line survived extraction: it was rejected by one of
+		// ExtractCustomFields' caps (line count / key count / payload size) or
+		// failed to parse as JSON. The line itself stays visible in the
+		// persisted stdout by design, but nothing else surfaces the rejection —
+		// log so it's diagnosable without reverse-engineering the caps.
+		log.Warn("script printed a custom-field marker that was not applied (parse failure or cap exceeded)",
+			"commandId", cmd.ID)
+	}
 
 	result := tools.CommandResult{
 		Status:   status,
@@ -431,26 +473,26 @@ func (h *Heartbeat) executeViaUserHelper(session *sessionbroker.Session, cmd Com
 			log.Warn("failed to unmarshal nested result from user helper", "commandId", cmd.ID, "error", err.Error())
 		} else {
 			if stdout, ok := nested["stdout"].(string); ok {
-				// #2698: same RAW-stdout-before-SanitizeOutput ordering as the
-				// local executor build site above — a runAs:user script must
-				// not silently lose the feature just because it ran through
-				// the helper IPC path.
-				customFields, cleanedStdout := executor.ExtractCustomFields(stdout)
-				cmdResult.Stdout = executor.SanitizeOutput(cleanedStdout)
-				if len(customFields) > 0 {
-					cmdResult.Result = map[string]any{
-						"customFieldWrites": map[string]any{
-							"schemaVersion": 1,
-							"fields":        customFields,
-						},
-					}
-				}
+				// #2698: the marker was ALREADY extracted from raw stdout, and
+				// stripped, inside the user-helper process itself (userhelper/
+				// client.go executeScript) — before that process's own
+				// SanitizeOutput call. Re-extracting here would run on stdout
+				// that has already been through SanitizeOutput once (over the
+				// IPC round trip), which would corrupt any marker whose JSON
+				// contains a token/secret/password-shaped key exactly like the
+				// local-executor path is designed to avoid. So this site only
+				// re-sanitizes (idempotent — the helper already sanitized this
+				// text) and does not call ExtractCustomFields again.
+				cmdResult.Stdout = executor.SanitizeOutput(stdout)
 			}
 			if stderr, ok := nested["stderr"].(string); ok {
 				cmdResult.Stderr = executor.SanitizeOutput(stderr)
 			}
 			if exitCode, ok := nested["exitCode"].(float64); ok {
 				cmdResult.ExitCode = int(exitCode)
+			}
+			if writes, ok := nested["customFieldWrites"]; ok && writes != nil {
+				cmdResult.Result = map[string]any{"customFieldWrites": writes}
 			}
 		}
 	}

--- a/agent/internal/heartbeat/handlers_script.go
+++ b/agent/internal/heartbeat/handlers_script.go
@@ -70,6 +70,11 @@ func handleScript(h *Heartbeat, cmd Command) tools.CommandResult {
 	res.Stdout = redact(res.Stdout)
 	res.Stderr = redact(res.Stderr)
 	res.Error = redact(res.Error)
+	// res.Result is deliberately NOT passed through redact: it only ever
+	// carries the #2698 customFieldWrites envelope, which Wave 1 already
+	// documents as not a secrets channel (the marker rides raw stdout, which
+	// IS redacted above, before extraction). A future Result payload must not
+	// assume this field is scrubbed.
 	return res
 }
 
@@ -205,10 +210,19 @@ func handleScriptInner(h *Heartbeat, cmd Command, secretEnv executor.SecretEnv) 
 	if scriptResult.Error != "" && strings.Contains(scriptResult.Error, "timed out") {
 		status = "timeout"
 	}
-	return tools.CommandResult{
+
+	// #2698: pull markers out of RAW stdout, BEFORE SanitizeOutput. The
+	// sanitizer rewrites `token=`/`secret=`-shaped substrings, which corrupts a
+	// marker's JSON past recovery — the server's stdout-scanning fallback
+	// (Wave 1) can only see post-sanitizer text, which is exactly the gap this
+	// closes. The marker lines are stripped so the operator's saved output is
+	// the script's real output.
+	customFields, cleanedStdout := executor.ExtractCustomFields(scriptResult.Stdout)
+
+	result := tools.CommandResult{
 		Status:   status,
 		ExitCode: scriptResult.ExitCode,
-		Stdout:   executor.SanitizeOutput(scriptResult.Stdout),
+		Stdout:   executor.SanitizeOutput(cleanedStdout),
 		Stderr:   executor.SanitizeOutput(scriptResult.Stderr),
 		// Error is deliberately raw here: handleScript sanitizes it for every
 		// exit path, including the NewErrorResult return above that never
@@ -217,6 +231,15 @@ func handleScriptInner(h *Heartbeat, cmd Command, secretEnv executor.SecretEnv) 
 		Error:      scriptResult.Error,
 		DurationMs: time.Since(start).Milliseconds(),
 	}
+	if len(customFields) > 0 {
+		result.Result = map[string]any{
+			"customFieldWrites": map[string]any{
+				"schemaVersion": 1,
+				"fields":        customFields,
+			},
+		}
+	}
+	return result
 }
 
 // isRunningElevated is an indirection over privilege.IsRunningAsRoot so the
@@ -408,7 +431,20 @@ func (h *Heartbeat) executeViaUserHelper(session *sessionbroker.Session, cmd Com
 			log.Warn("failed to unmarshal nested result from user helper", "commandId", cmd.ID, "error", err.Error())
 		} else {
 			if stdout, ok := nested["stdout"].(string); ok {
-				cmdResult.Stdout = executor.SanitizeOutput(stdout)
+				// #2698: same RAW-stdout-before-SanitizeOutput ordering as the
+				// local executor build site above — a runAs:user script must
+				// not silently lose the feature just because it ran through
+				// the helper IPC path.
+				customFields, cleanedStdout := executor.ExtractCustomFields(stdout)
+				cmdResult.Stdout = executor.SanitizeOutput(cleanedStdout)
+				if len(customFields) > 0 {
+					cmdResult.Result = map[string]any{
+						"customFieldWrites": map[string]any{
+							"schemaVersion": 1,
+							"fields":        customFields,
+						},
+					}
+				}
 			}
 			if stderr, ok := nested["stderr"].(string); ok {
 				cmdResult.Stderr = executor.SanitizeOutput(stderr)

--- a/agent/internal/heartbeat/handlers_script_test.go
+++ b/agent/internal/heartbeat/handlers_script_test.go
@@ -813,6 +813,15 @@ func TestHandleScriptSecretShapedMarkerValueSurvivesSanitizer(t *testing.T) {
 	}
 }
 
+// TestExecuteViaUserHelperEmitsCustomFieldEnvelope exercises the MAIN-AGENT
+// side of the runAs:user path: the user-helper process (userhelper/client.go
+// executeScript) is the one that actually extracts markers from raw stdout —
+// see TestExecuteScriptExtractsCustomFieldsBeforeSanitizeOutput in
+// userhelper/client_test.go for that half. This test proves
+// executeViaUserHelper correctly forwards an already-built customFieldWrites
+// envelope from the IPC nested result onto tools.CommandResult, without
+// re-extracting from (by now already-sanitized) stdout — the mock below
+// simulates exactly the JSON shape the real helper now sends.
 func TestExecuteViaUserHelperEmitsCustomFieldEnvelope(t *testing.T) {
 	serverConn, clientConn := createTestSocketPair(t)
 
@@ -829,10 +838,18 @@ func TestExecuteViaUserHelperEmitsCustomFieldEnvelope(t *testing.T) {
 			return
 		}
 
+		// Marker already stripped from stdout and already extracted into
+		// customFieldWrites — this is what userhelper's executeScript now
+		// sends, having done the extraction itself before its own
+		// SanitizeOutput call.
 		resultPayload, _ := json.Marshal(map[string]any{
 			"exitCode": 0,
-			"stdout":   `scanning` + "\n" + `::breeze:custom-fields:: {"a":"1"}` + "\n" + `done`,
+			"stdout":   "scanning\ndone",
 			"stderr":   "",
+			"customFieldWrites": map[string]any{
+				"schemaVersion": 1,
+				"fields":        map[string]any{"a": "1"},
+			},
 		})
 		ipcResult := ipc.IPCCommandResult{
 			CommandID: env.ID,
@@ -870,7 +887,7 @@ func TestExecuteViaUserHelperEmitsCustomFieldEnvelope(t *testing.T) {
 		t.Fatalf("expected completed, got %s (error: %s)", result.Status, result.Error)
 	}
 	if strings.Contains(result.Stdout, "::breeze:custom-fields::") {
-		t.Fatalf("marker line must be stripped from the runAs=user stdout too, got %q", result.Stdout)
+		t.Fatalf("marker line must not reappear in the runAs=user stdout, got %q", result.Stdout)
 	}
 	resultMap, ok := result.Result.(map[string]any)
 	if !ok {
@@ -883,5 +900,164 @@ func TestExecuteViaUserHelperEmitsCustomFieldEnvelope(t *testing.T) {
 	fields, ok := writes["fields"].(map[string]any)
 	if !ok || fields["a"] != "1" {
 		t.Fatalf("fields = %#v", writes["fields"])
+	}
+}
+
+// TestExecuteViaUserHelperNoCustomFieldWritesLeavesResultNil confirms the
+// no-marker case: when the helper's IPC payload carries no customFieldWrites
+// key, Result stays nil rather than becoming an empty envelope.
+func TestExecuteViaUserHelperNoCustomFieldWritesLeavesResultNil(t *testing.T) {
+	serverConn, clientConn := createTestSocketPair(t)
+
+	serverIPC := ipc.NewConn(serverConn)
+	clientIPC := ipc.NewConn(clientConn)
+
+	session := sessionbroker.NewSession(serverIPC, 1000, "1000", "testuser", "quartz", "test-no-custom-fields", []string{"run_as_user"})
+
+	go func() {
+		_ = clientIPC.SetReadDeadline(time.Now().Add(5 * time.Second))
+		env, err := clientIPC.Recv()
+		if err != nil {
+			t.Errorf("client recv: %v", err)
+			return
+		}
+
+		resultPayload, _ := json.Marshal(map[string]any{
+			"exitCode": 0,
+			"stdout":   "hello from breeze",
+			"stderr":   "",
+		})
+		ipcResult := ipc.IPCCommandResult{
+			CommandID: env.ID,
+			Status:    "completed",
+			Result:    resultPayload,
+		}
+		payload, _ := json.Marshal(ipcResult)
+		resp := &ipc.Envelope{
+			ID:      env.ID,
+			Type:    ipc.TypeCommandResult,
+			Payload: payload,
+		}
+		if err := clientIPC.Send(resp); err != nil {
+			t.Errorf("client send: %v", err)
+		}
+	}()
+
+	go session.RecvLoop(func(s *sessionbroker.Session, env *ipc.Envelope) {})
+
+	h := newTestHeartbeat(nil)
+	result := h.executeViaUserHelper(session, Command{
+		ID:   "cmd-user-no-custom-fields",
+		Type: tools.CmdScript,
+		Payload: map[string]any{
+			"content":        "echo hi",
+			"language":       "bash",
+			"timeoutSeconds": 10,
+		},
+	}, 10)
+
+	_ = session.Close()
+	_ = clientIPC.Close()
+
+	if result.Status != "completed" {
+		t.Fatalf("expected completed, got %s (error: %s)", result.Status, result.Error)
+	}
+	if result.Result != nil {
+		t.Fatalf("expected nil Result when the helper sent no customFieldWrites, got %#v", result.Result)
+	}
+}
+
+// TestHandleScriptRedactsSecretEnvValueFromCustomFieldWrites is the
+// regression guard for the security finding in PR #4781's review: a script
+// with delivered secretEnv values echoing one into a customFieldWrites
+// marker must NOT leak it — device custom fields are visible to any org user
+// with device-read access, and ExtractCustomFields deliberately runs before
+// both SanitizeOutput (pattern-based) and BuildSecretRedactor (exact-value),
+// so without the explicit redactCustomFieldValues pass in handleScript this
+// value rides straight through unredacted.
+func TestHandleScriptRedactsSecretEnvValueFromCustomFieldWrites(t *testing.T) {
+	h := newTestHeartbeat(nil)
+	result := handleScript(h, Command{
+		ID:   "cmd-secret-redact",
+		Type: tools.CmdScript,
+		Payload: map[string]any{
+			"content":        `echo "::breeze:custom-fields:: {\"note\":\"$BREEZE_VAR_API_TOKEN\"}"`,
+			"language":       "bash",
+			"timeoutSeconds": 10,
+			"secretEnv": map[string]any{
+				"api_token": "super-secret-delivered-value",
+			},
+		},
+	})
+
+	if result.Status != "completed" {
+		t.Fatalf("expected completed, got %s (error: %s, stderr: %s)", result.Status, result.Error, result.Stderr)
+	}
+	resultMap, ok := result.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("missing customFieldWrites envelope: %#v", result.Result)
+	}
+	writes, ok := resultMap["customFieldWrites"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing customFieldWrites envelope: %#v", result.Result)
+	}
+	fields, ok := writes["fields"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing fields: %#v", writes)
+	}
+	note, _ := fields["note"].(string)
+	if strings.Contains(note, "super-secret-delivered-value") {
+		t.Fatalf("delivered secretEnv value leaked into customFieldWrites unredacted: %q", note)
+	}
+	if note != executor.SecretRedactionMarker {
+		t.Fatalf("fields[note] = %q, want the redaction marker %q", note, executor.SecretRedactionMarker)
+	}
+}
+
+// TestHandleScriptCustomFieldEnvelopeSurvivesNonZeroExit pins the intended
+// design (matches apps/api/src/services/commandResultHandlers.ts, which
+// deliberately applies a script's custom-field markers "outside the exit-code
+// branch": a script that discovers a fact and then exits non-zero has still
+// discovered it): a customFieldWrites envelope must still reach Result even
+// when the command carries a non-zero exit / failed status. A plain `exit 1`
+// leaves tools.CommandResult.Error empty (confirmed: the executor only
+// populates Error for execution failures, not a script's own exit code) —
+// the specific Error!=""-AND-Result!=nil combination is covered precisely by
+// TestToWSCommandResultResultWinsEvenWithErrorSet in result_mapping_test.go.
+func TestHandleScriptCustomFieldEnvelopeSurvivesNonZeroExit(t *testing.T) {
+	h := newTestHeartbeat(nil)
+	result := handleScript(h, Command{
+		ID:   "cmd-fail-with-marker",
+		Type: tools.CmdScript,
+		Payload: map[string]any{
+			"content":        `echo '::breeze:custom-fields:: {"discovered":"yes"}'; exit 1`,
+			"language":       "bash",
+			"timeoutSeconds": 10,
+		},
+	})
+
+	if result.Status != "failed" {
+		t.Fatalf("expected failed status (exit 1), got %s", result.Status)
+	}
+	if result.ExitCode != 1 {
+		t.Fatalf("expected exit code 1, got %d", result.ExitCode)
+	}
+	resultMap, ok := result.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("expected the customFieldWrites envelope to survive a failed exit, got Result=%#v", result.Result)
+	}
+	writes, ok := resultMap["customFieldWrites"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing customFieldWrites envelope: %#v", result.Result)
+	}
+	fields, ok := writes["fields"].(map[string]any)
+	if !ok || fields["discovered"] != "yes" {
+		t.Fatalf("fields = %#v", writes["fields"])
+	}
+
+	// And confirm this survives the WebSocket leg's toWSCommandResult too.
+	wsResult := toWSCommandResult("cmd-fail-with-marker-ws", result)
+	if wsResult.Result == nil {
+		t.Fatal("expected customFieldWrites to survive toWSCommandResult despite a failed status")
 	}
 }

--- a/agent/internal/heartbeat/handlers_script_test.go
+++ b/agent/internal/heartbeat/handlers_script_test.go
@@ -727,3 +727,161 @@ func TestHandleScriptDurationMs(t *testing.T) {
 		t.Fatalf("expected positive DurationMs, got %d", result.DurationMs)
 	}
 }
+
+// --- #2698 custom-field write-back: extraction from RAW stdout, before SanitizeOutput ---
+
+func TestHandleScriptEmitsCustomFieldEnvelopeAndStripsMarker(t *testing.T) {
+	h := newTestHeartbeat(nil)
+	result := handleScript(h, Command{
+		ID:   "cmd-custom-fields",
+		Type: tools.CmdScript,
+		Payload: map[string]any{
+			"content":        `echo '::breeze:custom-fields:: {"a":"1"}'`,
+			"language":       "bash",
+			"timeoutSeconds": 10,
+		},
+	})
+
+	if result.Status != "completed" {
+		t.Fatalf("expected completed, got %s (error: %s, stderr: %s)", result.Status, result.Error, result.Stderr)
+	}
+	if strings.Contains(result.Stdout, "::breeze:custom-fields::") {
+		t.Fatalf("marker line must be stripped from the stdout the server persists, got %q", result.Stdout)
+	}
+
+	resultMap, ok := result.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("missing customFieldWrites envelope: %#v", result.Result)
+	}
+	writes, ok := resultMap["customFieldWrites"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing customFieldWrites envelope: %#v", result.Result)
+	}
+	if writes["schemaVersion"] != 1 {
+		t.Fatalf("schemaVersion = %#v, want 1", writes["schemaVersion"])
+	}
+	fields, ok := writes["fields"].(map[string]any)
+	if !ok || fields["a"] != "1" {
+		t.Fatalf("fields = %#v", writes["fields"])
+	}
+}
+
+func TestHandleScriptNoMarkerLeavesResultNil(t *testing.T) {
+	h := newTestHeartbeat(nil)
+	result := handleScript(h, Command{
+		ID:   "cmd-no-marker",
+		Type: tools.CmdScript,
+		Payload: map[string]any{
+			"content":        "echo 'hello from breeze'",
+			"language":       "bash",
+			"timeoutSeconds": 10,
+		},
+	})
+
+	if result.Status != "completed" {
+		t.Fatalf("expected completed, got %s (error: %s)", result.Status, result.Error)
+	}
+	if result.Result != nil {
+		t.Fatalf("expected nil Result when no marker is present, got %#v", result.Result)
+	}
+}
+
+func TestHandleScriptSecretShapedMarkerValueSurvivesSanitizer(t *testing.T) {
+	// The marker is extracted from RAW stdout, before SanitizeOutput rewrites
+	// token/secret/password-shaped substrings — that ordering is the entire
+	// point of Wave 3 (Channel A, stdout marker, corrupts on a secret-shaped
+	// key; Channel B does not).
+	h := newTestHeartbeat(nil)
+	result := handleScript(h, Command{
+		ID:   "cmd-secret-shaped",
+		Type: tools.CmdScript,
+		Payload: map[string]any{
+			"content":        `echo '::breeze:custom-fields:: {"vault_token_id":"abcdefgh"}'`,
+			"language":       "bash",
+			"timeoutSeconds": 10,
+		},
+	})
+
+	if result.Status != "completed" {
+		t.Fatalf("expected completed, got %s (error: %s, stderr: %s)", result.Status, result.Error, result.Stderr)
+	}
+	resultMap, _ := result.Result.(map[string]any)
+	writes, _ := resultMap["customFieldWrites"].(map[string]any)
+	fields, _ := writes["fields"].(map[string]any)
+	if fields["vault_token_id"] != "abcdefgh" {
+		t.Fatalf("expected the secret-shaped value to survive intact, got fields=%#v", fields)
+	}
+}
+
+func TestExecuteViaUserHelperEmitsCustomFieldEnvelope(t *testing.T) {
+	serverConn, clientConn := createTestSocketPair(t)
+
+	serverIPC := ipc.NewConn(serverConn)
+	clientIPC := ipc.NewConn(clientConn)
+
+	session := sessionbroker.NewSession(serverIPC, 1000, "1000", "testuser", "quartz", "test-custom-fields", []string{"run_as_user"})
+
+	go func() {
+		clientIPC.SetReadDeadline(time.Now().Add(5 * time.Second))
+		env, err := clientIPC.Recv()
+		if err != nil {
+			t.Errorf("client recv: %v", err)
+			return
+		}
+
+		resultPayload, _ := json.Marshal(map[string]any{
+			"exitCode": 0,
+			"stdout":   `scanning` + "\n" + `::breeze:custom-fields:: {"a":"1"}` + "\n" + `done`,
+			"stderr":   "",
+		})
+		ipcResult := ipc.IPCCommandResult{
+			CommandID: env.ID,
+			Status:    "completed",
+			Result:    resultPayload,
+		}
+		payload, _ := json.Marshal(ipcResult)
+		resp := &ipc.Envelope{
+			ID:      env.ID,
+			Type:    ipc.TypeCommandResult,
+			Payload: payload,
+		}
+		if err := clientIPC.Send(resp); err != nil {
+			t.Errorf("client send: %v", err)
+		}
+	}()
+
+	go session.RecvLoop(func(s *sessionbroker.Session, env *ipc.Envelope) {})
+
+	h := newTestHeartbeat(nil)
+	result := h.executeViaUserHelper(session, Command{
+		ID:   "cmd-user-custom-fields",
+		Type: tools.CmdScript,
+		Payload: map[string]any{
+			"content":        "echo hi",
+			"language":       "bash",
+			"timeoutSeconds": 10,
+		},
+	}, 10)
+
+	session.Close()
+	clientIPC.Close()
+
+	if result.Status != "completed" {
+		t.Fatalf("expected completed, got %s (error: %s)", result.Status, result.Error)
+	}
+	if strings.Contains(result.Stdout, "::breeze:custom-fields::") {
+		t.Fatalf("marker line must be stripped from the runAs=user stdout too, got %q", result.Stdout)
+	}
+	resultMap, ok := result.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("missing customFieldWrites envelope on runAs=user path: %#v", result.Result)
+	}
+	writes, ok := resultMap["customFieldWrites"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing customFieldWrites envelope on runAs=user path: %#v", result.Result)
+	}
+	fields, ok := writes["fields"].(map[string]any)
+	if !ok || fields["a"] != "1" {
+		t.Fatalf("fields = %#v", writes["fields"])
+	}
+}

--- a/agent/internal/heartbeat/handlers_script_test.go
+++ b/agent/internal/heartbeat/handlers_script_test.go
@@ -822,7 +822,7 @@ func TestExecuteViaUserHelperEmitsCustomFieldEnvelope(t *testing.T) {
 	session := sessionbroker.NewSession(serverIPC, 1000, "1000", "testuser", "quartz", "test-custom-fields", []string{"run_as_user"})
 
 	go func() {
-		clientIPC.SetReadDeadline(time.Now().Add(5 * time.Second))
+		_ = clientIPC.SetReadDeadline(time.Now().Add(5 * time.Second))
 		env, err := clientIPC.Recv()
 		if err != nil {
 			t.Errorf("client recv: %v", err)
@@ -863,8 +863,8 @@ func TestExecuteViaUserHelperEmitsCustomFieldEnvelope(t *testing.T) {
 		},
 	}, 10)
 
-	session.Close()
-	clientIPC.Close()
+	_ = session.Close()
+	_ = clientIPC.Close()
 
 	if result.Status != "completed" {
 		t.Fatalf("expected completed, got %s (error: %s)", result.Status, result.Error)

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -5736,11 +5736,19 @@ func toWSCommandResult(commandID string, result tools.CommandResult) websocket.C
 		ExitCode:  result.ExitCode,
 		Stdout:    result.Stdout,
 		Stderr:    result.Stderr,
+		Error:     result.Error,
 	}
 
-	if result.Error != "" {
-		wsResult.Error = result.Error
-	} else if result.Stdout != "" {
+	// An explicitly-set Result wins. The stdout reparse below stays for the
+	// handlers that depend on it (discovery, backup, snmp, monitor read
+	// `result`, not stdout) but must never clobber a handler that built a
+	// structured payload on purpose — #2698's customFieldWrites envelope is the
+	// first such payload on the script path. The Error-suppresses-reparse
+	// behavior is unchanged: an errored command's raw stdout must not be
+	// mistaken for a successful structured result.
+	if result.Result != nil {
+		wsResult.Result = result.Result
+	} else if result.Error == "" && result.Stdout != "" {
 		var jsonResult any
 		if err := json.Unmarshal([]byte(result.Stdout), &jsonResult); err == nil {
 			wsResult.Result = jsonResult

--- a/agent/internal/heartbeat/result_mapping_test.go
+++ b/agent/internal/heartbeat/result_mapping_test.go
@@ -2,6 +2,7 @@ package heartbeat
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/breeze-rmm/agent/internal/remote/tools"
@@ -115,5 +116,35 @@ func TestToWSCommandResultPreservesStructuredResult(t *testing.T) {
 	}
 	if obj["devices"].(float64) != 2 {
 		t.Errorf("Result[devices] = %v, want 2", obj["devices"])
+	}
+}
+
+// TestToWSCommandResultPreservesExplicitResult is the #2698 regression guard:
+// a handler that builds a structured Result on purpose (the script handler's
+// customFieldWrites envelope) must win over the generic stdout->JSON reparse,
+// even when stdout is not valid JSON at all.
+func TestToWSCommandResultPreservesExplicitResult(t *testing.T) {
+	explicit := map[string]any{"customFieldWrites": map[string]any{"schemaVersion": 1}}
+	got := toWSCommandResult("cmd-1", tools.CommandResult{
+		Status: "completed",
+		Stdout: "not json at all",
+		Result: explicit,
+	})
+	if !reflect.DeepEqual(got.Result, explicit) {
+		t.Fatalf("Result = %#v, want %#v", got.Result, explicit)
+	}
+}
+
+// TestToWSCommandResultStillReparsesJSONStdoutWhenResultIsNil pins that the
+// pre-existing stdout reparse (discovery/backup/snmp/monitor handlers, which
+// never populate tools.CommandResult.Result) is untouched by the new
+// Result-wins branch above.
+func TestToWSCommandResultStillReparsesJSONStdoutWhenResultIsNil(t *testing.T) {
+	got := toWSCommandResult("cmd-2", tools.CommandResult{
+		Status: "completed",
+		Stdout: `{"hosts":[]}`,
+	})
+	if got.Result == nil {
+		t.Fatal("expected the stdout reparse to still populate Result for discovery/backup/snmp handlers")
 	}
 }

--- a/agent/internal/heartbeat/result_mapping_test.go
+++ b/agent/internal/heartbeat/result_mapping_test.go
@@ -148,3 +148,29 @@ func TestToWSCommandResultStillReparsesJSONStdoutWhenResultIsNil(t *testing.T) {
 		t.Fatal("expected the stdout reparse to still populate Result for discovery/backup/snmp handlers")
 	}
 }
+
+// TestToWSCommandResultResultWinsEvenWithErrorSet is the precise regression
+// guard for the PR #4781 review finding: an explicitly-set Result now wins
+// over the reparse UNCONDITIONALLY — including when Error is also set, a
+// combination that was structurally impossible before this PR (the old code
+// was a single if/else-if keyed on Error != ""). This is intentional and
+// matches the server: apps/api/src/services/commandResultHandlers.ts applies
+// a script's customFieldWrites "outside the exit-code branch" because "a
+// script that discovers a fact and then exits non-zero... has still
+// discovered it." Error must still reach the wire alongside Result — this
+// is additive, not a replacement of the error-reporting path.
+func TestToWSCommandResultResultWinsEvenWithErrorSet(t *testing.T) {
+	explicit := map[string]any{"customFieldWrites": map[string]any{"schemaVersion": 1, "fields": map[string]any{"a": "1"}}}
+	got := toWSCommandResult("cmd-fail-marker", tools.CommandResult{
+		Status: "failed",
+		Error:  "script exited non-zero",
+		Stdout: "not json either",
+		Result: explicit,
+	})
+	if got.Error != "script exited non-zero" {
+		t.Errorf("Error = %q, want it preserved alongside Result", got.Error)
+	}
+	if !reflect.DeepEqual(got.Result, explicit) {
+		t.Fatalf("Result = %#v, want %#v — an explicit Result must win even when Error is set", got.Result, explicit)
+	}
+}

--- a/agent/internal/remote/tools/types.go
+++ b/agent/internal/remote/tools/types.go
@@ -261,8 +261,13 @@ type CommandResult struct {
 	Stderr   string `json:"stderr,omitempty"`
 	Error    string `json:"error,omitempty"`
 	// Result carries structured output for the HTTP command-result transport.
-	// Most handlers leave it nil; WebSocket conversion independently reparses
-	// JSON stdout to avoid duplicating large generic results on that wire.
+	// Most handlers leave it nil, in which case WebSocket conversion
+	// (toWSCommandResult, agent/internal/heartbeat/heartbeat.go) independently
+	// reparses JSON stdout to avoid duplicating large generic results on that
+	// wire. A handler that DOES set Result explicitly (e.g. the script
+	// handler's #2698 customFieldWrites envelope) wins over that reparse on
+	// the WebSocket leg too — set it only for structured output the transport
+	// must carry verbatim, not as a general-purpose duplicate of Stdout.
 	Result     any   `json:"result,omitempty"`
 	DurationMs int64 `json:"durationMs,omitempty"`
 	// RFC3339Nano timestamp captured by the agent at the moment the command's

--- a/agent/internal/userhelper/client.go
+++ b/agent/internal/userhelper/client.go
@@ -787,11 +787,38 @@ func (c *Client) executeScript(cmd ipc.IPCCommand) ipc.IPCCommandResult {
 		status = "failed"
 	}
 
-	resultJSON, err := json.Marshal(map[string]any{
+	// #2698: extract from RAW stdout, BEFORE SanitizeOutput, exactly like the
+	// main-agent local-executor path (handlers_script.go). This IS the raw
+	// output — the helper is the process that actually ran the script — so
+	// doing the extraction here, rather than after the IPC round trip, is
+	// required: forwarding SanitizeOutput'd stdout to the main agent and
+	// extracting there would corrupt any marker whose JSON contains a
+	// token/secret/password-shaped key before extraction ever saw it,
+	// silently degrading every runAs:user script to the pre-Wave-3 gap this
+	// feature exists to close.
+	customFields, cleanedStdout := executor.ExtractCustomFields(result.Stdout)
+	if strings.Contains(cleanedStdout, executor.CustomFieldMarker) {
+		// A marker-prefixed line survived extraction: rejected by one of
+		// ExtractCustomFields' caps or unparseable. Left visible in stdout by
+		// design; logged here too so it's diagnosable from agent logs, not just
+		// by reading persisted script output.
+		log.Warn("script printed a custom-field marker that was not applied (parse failure or cap exceeded)",
+			"commandId", cmd.CommandID)
+	}
+
+	resultPayload := map[string]any{
 		"exitCode": result.ExitCode,
-		"stdout":   executor.SanitizeOutput(result.Stdout),
+		"stdout":   executor.SanitizeOutput(cleanedStdout),
 		"stderr":   executor.SanitizeOutput(result.Stderr),
-	})
+	}
+	if len(customFields) > 0 {
+		resultPayload["customFieldWrites"] = map[string]any{
+			"schemaVersion": 1,
+			"fields":        customFields,
+		}
+	}
+
+	resultJSON, err := json.Marshal(resultPayload)
 	if err != nil {
 		return ipc.IPCCommandResult{
 			CommandID: cmd.CommandID,

--- a/agent/internal/userhelper/client_test.go
+++ b/agent/internal/userhelper/client_test.go
@@ -95,6 +95,93 @@ func TestExecuteScriptListRunningUsesSharedExecutor(t *testing.T) {
 	})
 }
 
+// TestExecuteScriptExtractsCustomFieldsBeforeSanitizeOutput is the
+// regression guard for the Critical finding in PR #4781's review: this
+// executeScript call site is the helper PROCESS that actually runs a
+// runAs:user script, so it is the only place that can extract markers from
+// genuinely raw stdout for that path — extracting after the IPC round trip
+// (in the main agent) would run on stdout this same function has already
+// sanitized, corrupting any marker whose JSON contains a token/secret/
+// password-shaped key exactly like the marker below.
+func TestExecuteScriptExtractsCustomFieldsBeforeSanitizeOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("script execution test requires Unix/macOS shell")
+	}
+
+	c := New("/tmp/test.sock", ipc.HelperRoleUser)
+
+	result := c.executeScript(ipc.IPCCommand{
+		CommandID: "exec-custom-fields",
+		Type:      tools.CmdScript,
+		Payload: marshalPayload(t, map[string]any{
+			"language":       "bash",
+			"content":        `echo 'scanning'; echo '::breeze:custom-fields:: {"vault_token_id":"abcdefgh"}'; echo 'done'`,
+			"timeoutSeconds": 10,
+		}),
+	})
+
+	if result.Status != "completed" {
+		t.Fatalf("expected completed, got %s (%s)", result.Status, result.Error)
+	}
+
+	var payload struct {
+		Stdout            string `json:"stdout"`
+		CustomFieldWrites struct {
+			SchemaVersion int            `json:"schemaVersion"`
+			Fields        map[string]any `json:"fields"`
+		} `json:"customFieldWrites"`
+	}
+	if err := json.Unmarshal(result.Result, &payload); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+
+	if strings.Contains(payload.Stdout, "::breeze:custom-fields::") {
+		t.Fatalf("marker line must be stripped from the helper's own stdout, got %q", payload.Stdout)
+	}
+	if payload.CustomFieldWrites.SchemaVersion != 1 {
+		t.Fatalf("schemaVersion = %d, want 1 (envelope missing entirely: %+v)", payload.CustomFieldWrites.SchemaVersion, payload)
+	}
+	if payload.CustomFieldWrites.Fields["vault_token_id"] != "abcdefgh" {
+		t.Fatalf(
+			"fields[vault_token_id] = %#v, want the intact secret-shaped value — "+
+				"if this is corrupted or missing, extraction ran AFTER SanitizeOutput instead of before it",
+			payload.CustomFieldWrites.Fields["vault_token_id"],
+		)
+	}
+}
+
+// TestExecuteScriptNoMarkerOmitsCustomFieldWrites confirms the no-marker case
+// doesn't add an empty/spurious customFieldWrites key to the IPC payload.
+func TestExecuteScriptNoMarkerOmitsCustomFieldWrites(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("script execution test requires Unix/macOS shell")
+	}
+
+	c := New("/tmp/test.sock", ipc.HelperRoleUser)
+
+	result := c.executeScript(ipc.IPCCommand{
+		CommandID: "exec-no-custom-fields",
+		Type:      tools.CmdScript,
+		Payload: marshalPayload(t, map[string]any{
+			"language":       "bash",
+			"content":        `echo 'hello from breeze'`,
+			"timeoutSeconds": 10,
+		}),
+	})
+
+	if result.Status != "completed" {
+		t.Fatalf("expected completed, got %s (%s)", result.Status, result.Error)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(result.Result, &payload); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if _, present := payload["customFieldWrites"]; present {
+		t.Fatalf("expected no customFieldWrites key when no marker was printed, got %#v", payload["customFieldWrites"])
+	}
+}
+
 func TestExecuteProcessCapturesAccentedUTF8Output(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("accent capture test uses /bin/sh")


### PR DESCRIPTION
## Summary

W03 of #4678 (Script custom-field write-back, origin #2698) — the Go agent's structured channel.

- `agent/internal/executor/customfields.go`: `ExtractCustomFields(stdout string) (map[string]any, string)` pulls `::breeze:custom-fields::` marker lines out of **raw** stdout — before `SanitizeOutput`, which rewrites `token=`/`secret=`-shaped substrings and would otherwise corrupt a marker's JSON past recovery. Caps: 20 marker lines, 50 distinct keys, 8KB payload per marker. Unparseable marker lines are left in stdout for the operator to see.
- `agent/internal/heartbeat/handlers_script.go`: both the local-executor build site (`handleScriptInner`) and the `runAs:user` helper-IPC path (`executeViaUserHelper`) now extract markers, strip them from the persisted stdout, and — when fields were found — set `tools.CommandResult.Result` to a versioned envelope: `{customFieldWrites: {schemaVersion: 1, fields: {...}}}`.
- `agent/internal/heartbeat/heartbeat.go` (`toWSCommandResult`): an explicitly-set `Result` now wins over the stdout→JSON reparse, so the envelope survives the WebSocket leg without disturbing the existing reparse that discovery/backup/snmp/monitor results still depend on. The `Error`-suppresses-reparse behavior is unchanged.

Byte-identical marker constant to the API side (`CUSTOM_FIELD_MARKER` in `apps/api/src/services/customFields/scriptWriteMarkers.ts`, shipped in Wave 1 / #4679).

**This PR is inert without Wave 1 already deployed** — the API only reads `customFieldWrites` from an agent version that sends it. Mixed-version fleets are safe in both directions:
- A pre-Wave-3 agent's markers still work via Channel A (stdout scanning, Wave 1).
- A Wave-3 agent talking to a pre-Wave-1 server just has its envelope ignored (unknown `result` shape).

## Test plan

- [x] `agent/internal/executor/customfields_test.go` — table-driven `ExtractCustomFields` tests (no marker, single marker stripped, later-marker-wins merge, secret-shaped value survives because extraction runs before the sanitizer, unparseable marker left in stdout, CRLF line endings) + a cap test (25 marker lines → 1 merged key).
- [x] `agent/internal/heartbeat/handlers_script_test.go` — `handleScript` end-to-end: envelope emitted + marker stripped from stdout; no envelope when no marker; secret-shaped marker value survives `SanitizeOutput`; the same via `executeViaUserHelper` (`runAs:user` path).
- [x] `agent/internal/heartbeat/result_mapping_test.go` — `toWSCommandResult`: an explicit `Result` wins over the stdout reparse even when stdout isn't valid JSON; the pre-existing reparse-when-`Result`-is-nil path is unchanged.
- [x] `gofmt -l` clean on all changed files.
- [x] `go build ./...` — clean.
- [x] `go test ./internal/executor/... ./internal/heartbeat/...` — full packages green (`CGO_ENABLED=0`; see note below), including all pre-existing tests.

**Note on `-race`:** this dev host's cgo toolchain is independently broken (`go-m1cpu`'s cgo init segfaults on *any* package, unrelated to this change — reproduced on `internal/privilege` with zero local edits, and reproduces on both the installed go1.27.0 and an explicitly-pinned go1.26.6 toolchain). `-race` requires cgo, so it cannot run on this host at all right now. Verified instead with `CGO_ENABLED=0 go build ./...` and `CGO_ENABLED=0 go test ./internal/executor/... ./internal/heartbeat/...` (all green). CI runs `go test -race` in a clean environment and will provide the race-detector signal this box can't right now.

Closes #4681

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEjfwFKmH2HGwCFs15GnyG
