### PR TITLE
fix(api/auth): rate-limit current-password guesses on /auth/change-password (#4746)

### DIFF
--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -1262,7 +1262,10 @@ API requests are rate-limited to ensure fair usage. Rate limit headers are inclu
           // 400s for a passwordless account and a too-weak new password. 401
           // is reserved for a dead bearer.
           '400': { $ref: '#/components/responses/BadRequest' },
-          '401': { $ref: '#/components/responses/Unauthorized' }
+          '401': { $ref: '#/components/responses/Unauthorized' },
+          // #4746: current-password guesses are metered per user (5 / 5 min),
+          // the same shared step-up limiter the MFA factor routes use.
+          '429': { $ref: '#/components/responses/TooManyRequests' }
         }
       }
     },

--- a/apps/api/src/routes/auth/helpers.currentPasswordStepUp.test.ts
+++ b/apps/api/src/routes/auth/helpers.currentPasswordStepUp.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// #4746: `requireCurrentPasswordStepUp` is the shared gate for every route that
+// re-verifies a body-supplied password (MFA disable, recovery-code regen,
+// passkey delete, phone enrol/remove, email change, approvals + PAM step-up,
+// and now /auth/change-password). It had no test file of its own — every one of
+// those callers mocks it wholesale — so its DEFAULT rejection contract was
+// asserted nowhere in the repo. That matters now that the helper takes opt-in
+// message overrides: "the eight existing call sites are unchanged" is the claim
+// the whole design rests on, and it needs a test that would notice if a future
+// edit changed what an omitted option does.
+//
+// Mock declarations must precede the import of the unit under test; vi.mock
+// factories are hoisted above module-scope consts, so the shared references go
+// through vi.hoisted (which is hoisted too). Mirrors helpers.mfaStepUp.test.ts.
+const { selectLimit, db, getRedis, rateLimiter, verifyPassword } = vi.hoisted(() => {
+  const selectLimit = vi.fn();
+  const db = {
+    // db.select(...).from(...).where(...).limit(...) → the mocked user row.
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: selectLimit,
+        })),
+      })),
+    })),
+  };
+  return {
+    selectLimit,
+    db,
+    getRedis: vi.fn(),
+    rateLimiter: vi.fn(),
+    verifyPassword: vi.fn(),
+  };
+});
+
+vi.mock('../../db', () => ({
+  db,
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../../db/schema', () => ({
+  users: { id: 'id', passwordHash: 'password_hash' },
+  partnerUsers: {},
+  organizationUsers: {},
+  organizations: {},
+  userPasskeys: {},
+}));
+
+vi.mock('../../services', () => ({
+  verifyToken: vi.fn(),
+  isUserTokenRevoked: vi.fn(),
+  revokeRefreshTokenJti: vi.fn(),
+  getTrustedClientIp: vi.fn(() => 'unknown'),
+  getUserEpochs: vi.fn(),
+  getRedis,
+  rateLimiter,
+  verifyPassword,
+}));
+
+vi.mock('../../services/mfa', () => ({ consumeMFAToken: vi.fn() }));
+vi.mock('../../services/mfaSecretCrypto', () => ({
+  decryptMfaTotpSecret: vi.fn(),
+  decryptMfaTotpSecretForMigration: vi.fn(),
+  encryptMfaTotpSecret: vi.fn(),
+}));
+vi.mock('../../services/auditService', () => ({ createAuditLogAsync: vi.fn() }));
+vi.mock('../../services/anomalyMetrics', () => ({ recordFailedLogin: vi.fn() }));
+vi.mock('../../services/corsOrigins', () => ({
+  DEFAULT_ALLOWED_ORIGINS: [],
+  shouldIncludeDefaultOrigins: vi.fn(() => false),
+}));
+vi.mock('../../services/tenantStatus', () => ({ assertActiveTenantContext: vi.fn() }));
+
+import { requireCurrentPasswordStepUp } from './helpers';
+
+// Minimal Hono Context stub: the helper only ever touches c.json.
+function makeContext() {
+  const json = vi.fn((body: unknown, status?: number) => ({ __body: body, __status: status ?? 200 }));
+  return { json } as never as Parameters<typeof requireCurrentPasswordStepUp>[0] & { json: typeof json };
+}
+
+const USER_ID = 'user-123';
+const OPAQUE = {
+  error: 'Invalid credentials',
+  message: 'Invalid credentials',
+  code: 'invalid_credentials',
+};
+
+function mockUserRow(row: Record<string, unknown> | undefined) {
+  selectLimit.mockResolvedValue(row ? [row] : []);
+}
+
+describe('requireCurrentPasswordStepUp', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getRedis.mockReturnValue({} as never);
+    rateLimiter.mockResolvedValue({ allowed: true, resetAt: new Date(Date.now() + 60_000) });
+    mockUserRow({ passwordHash: '$argon2id$hash' });
+    verifyPassword.mockResolvedValue(true);
+  });
+
+  it('returns null for the correct password', async () => {
+    const c = makeContext();
+    expect(await requireCurrentPasswordStepUp(c, USER_ID, 'right-password')).toBeNull();
+    expect(verifyPassword).toHaveBeenCalledWith('$argon2id$hash', 'right-password');
+    expect(c.json).not.toHaveBeenCalled();
+  });
+
+  describe('default contract — what the eight pre-existing call sites get', () => {
+    it('rejects a wrong password with 401 and the opaque body', async () => {
+      verifyPassword.mockResolvedValue(false);
+      const c = makeContext();
+      const result = await requireCurrentPasswordStepUp(c, USER_ID, 'wrong');
+      expect(c.json).toHaveBeenCalledWith(OPAQUE, 401);
+      expect(result).toEqual({ __body: OPAQUE, __status: 401 });
+    });
+
+    it('rejects a passwordless account INDISTINGUISHABLY from a wrong password', async () => {
+      mockUserRow({ passwordHash: null });
+      const c = makeContext();
+      await requireCurrentPasswordStepUp(c, USER_ID, 'anything');
+      // Byte-identical to the wrong-password rejection above. On a step-up for
+      // a sensitive operation the specific reason is not the caller's to
+      // disclose, so `noPasswordMessage` must keep defaulting to
+      // `invalidMessage` rather than to some distinct string of its own.
+      expect(c.json).toHaveBeenCalledWith(OPAQUE, 401);
+      expect(verifyPassword).not.toHaveBeenCalled();
+    });
+
+    it('rejects a missing user row the same opaque way', async () => {
+      mockUserRow(undefined);
+      const c = makeContext();
+      await requireCurrentPasswordStepUp(c, USER_ID, 'anything');
+      expect(c.json).toHaveBeenCalledWith(OPAQUE, 401);
+      expect(verifyPassword).not.toHaveBeenCalled();
+    });
+
+    it('defaults to the auth:pwd-stepup bucket at 5 attempts / 5 minutes', async () => {
+      const c = makeContext();
+      await requireCurrentPasswordStepUp(c, USER_ID, 'right-password');
+      expect(rateLimiter).toHaveBeenCalledWith(
+        expect.anything(),
+        `auth:pwd-stepup:${USER_ID}`,
+        5,
+        5 * 60,
+      );
+    });
+
+    it('uses the caller-supplied keyPrefix when given one', async () => {
+      const c = makeContext();
+      await requireCurrentPasswordStepUp(c, USER_ID, 'right-password', 'pwd:change');
+      expect(rateLimiter).toHaveBeenCalledWith(expect.anything(), `pwd:change:${USER_ID}`, 5, 5 * 60);
+    });
+  });
+
+  describe('opt-in overrides (#4746)', () => {
+    it('honours rejectionStatus, invalidMessage and noPasswordMessage together', async () => {
+      verifyPassword.mockResolvedValue(false);
+      const c = makeContext();
+      await requireCurrentPasswordStepUp(c, USER_ID, 'wrong', 'pwd:change', {
+        rejectionStatus: 400,
+        invalidMessage: 'Current password is incorrect',
+        noPasswordMessage: 'Password authentication is not available for this account',
+      });
+      expect(c.json).toHaveBeenCalledWith(
+        {
+          error: 'Current password is incorrect',
+          message: 'Current password is incorrect',
+          code: 'invalid_credentials',
+        },
+        400,
+      );
+    });
+
+    it('uses noPasswordMessage only for the passwordless branch', async () => {
+      mockUserRow({ passwordHash: null });
+      const c = makeContext();
+      await requireCurrentPasswordStepUp(c, USER_ID, 'anything', 'pwd:change', {
+        rejectionStatus: 400,
+        invalidMessage: 'Current password is incorrect',
+        noPasswordMessage: 'Password authentication is not available for this account',
+      });
+      expect(c.json).toHaveBeenCalledWith(
+        {
+          error: 'Password authentication is not available for this account',
+          message: 'Password authentication is not available for this account',
+          code: 'invalid_credentials',
+        },
+        400,
+      );
+    });
+
+    it('falls back to invalidMessage when noPasswordMessage is omitted', async () => {
+      mockUserRow({ passwordHash: null });
+      const c = makeContext();
+      await requireCurrentPasswordStepUp(c, USER_ID, 'anything', 'pwd:change', {
+        invalidMessage: 'Current password is incorrect',
+      });
+      // Opting into a specific wrong-password message must NOT silently make
+      // the passwordless branch distinguishable — a caller has to ask for that
+      // separately, as /auth/change-password does above.
+      expect(c.json).toHaveBeenCalledWith(
+        {
+          error: 'Current password is incorrect',
+          message: 'Current password is incorrect',
+          code: 'invalid_credentials',
+        },
+        401,
+      );
+    });
+  });
+
+  describe('service-state failures are not account-state failures', () => {
+    it('returns 429 with both body keys and never reaches argon2', async () => {
+      rateLimiter.mockResolvedValue({ allowed: false, resetAt: new Date(Date.now() + 120_000) });
+      const c = makeContext();
+      const result = await requireCurrentPasswordStepUp(c, USER_ID, 'anything');
+      expect(c.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: 'Too many attempts. Please try again later.',
+          message: 'Too many attempts. Please try again later.',
+        }),
+        429,
+      );
+      expect((result as unknown as { __status: number }).__status).toBe(429);
+      // The throttle is only a real cost ceiling if it short-circuits the hash.
+      expect(verifyPassword).not.toHaveBeenCalled();
+      expect(db.select).not.toHaveBeenCalled();
+    });
+
+    it('fails closed with 503 when redis is unavailable, before the limiter', async () => {
+      getRedis.mockReturnValue(null);
+      const c = makeContext();
+      await requireCurrentPasswordStepUp(c, USER_ID, 'anything');
+      expect(c.json).toHaveBeenCalledWith(
+        { error: 'Service temporarily unavailable', message: 'Service temporarily unavailable' },
+        503,
+      );
+      expect(rateLimiter).not.toHaveBeenCalled();
+      expect(verifyPassword).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/routes/auth/helpers.mfaStepUp.test.ts
+++ b/apps/api/src/routes/auth/helpers.mfaStepUp.test.ts
@@ -198,7 +198,12 @@ describe('requireFreshMfaStepUp', () => {
     getRedis.mockReturnValue(null);
     const c = makeContext();
     await requireFreshMfaStepUp(c, USER_ID, '123456');
-    expect(c.json).toHaveBeenCalledWith({ error: 'Service temporarily unavailable' }, 503);
+    // #4746: `message` mirrors `error` on both non-rejection bodies, because
+    // the web profile form reads `data.message` only.
+    expect(c.json).toHaveBeenCalledWith(
+      { error: 'Service temporarily unavailable', message: 'Service temporarily unavailable' },
+      503,
+    );
     expect(rateLimiter).not.toHaveBeenCalled();
   });
 

--- a/apps/api/src/routes/auth/helpers.ts
+++ b/apps/api/src/routes/auth/helpers.ts
@@ -248,15 +248,21 @@ export function rejectProof(
 }
 
 /**
- * #4746: the step-up throttle body populates `error` AND `message`, exactly as
- * {@link rejectProof} does, because clients are split on which key they read.
- * The web profile form renders `data.message` and falls back to a generic
- * string when it is absent (`apps/web/src/components/settings/ProfilePage.tsx`),
- * so a 429 carrying only `error` would surface as "Failed to change password"
- * rather than the real reason — a throttle the user cannot see is a throttle
- * they will keep hammering.
+ * #4746: both non-rejection failure bodies of the step-up helpers populate
+ * `error` AND `message`, exactly as {@link rejectProof} does, because clients
+ * are split on which key they read. The web profile form renders
+ * `data.message` and — unlike its siblings in the same file — does NOT fall
+ * back to `data.error`, so it shows a generic "Failed to change password" when
+ * `message` is absent (`apps/web/src/components/settings/ProfilePage.tsx`).
+ *
+ * That makes both of these indistinguishable from a mistyped password unless
+ * `message` is set: a throttle the user cannot see is a throttle they will keep
+ * hammering, and a Redis outage the user cannot see is one they will retry as
+ * though they got their own password wrong. `/auth/change-password` acquired
+ * both branches when it moved onto this helper, so both are fixed together.
  */
 const STEP_UP_THROTTLED_MESSAGE = 'Too many attempts. Please try again later.';
+const STEP_UP_UNAVAILABLE_MESSAGE = 'Service temporarily unavailable';
 
 export async function requireCurrentPasswordStepUp(
   c: Context,
@@ -297,7 +303,7 @@ export async function requireCurrentPasswordStepUp(
   const noPasswordMessage = opts.noPasswordMessage ?? invalidMessage;
   const redis = getRedis();
   if (!redis) {
-    return c.json({ error: 'Service temporarily unavailable' }, 503);
+    return c.json({ error: STEP_UP_UNAVAILABLE_MESSAGE, message: STEP_UP_UNAVAILABLE_MESSAGE }, 503);
   }
 
   const rateCheck = await rateLimiter(redis, `${keyPrefix}:${userId}`, 5, 5 * 60);
@@ -348,7 +354,7 @@ export async function requireFreshMfaStepUp(
   const rejectionStatus: ProofRejectionStatus = 401;
   const redis = getRedis();
   if (!redis) {
-    return c.json({ error: 'Service temporarily unavailable' }, 503);
+    return c.json({ error: STEP_UP_UNAVAILABLE_MESSAGE, message: STEP_UP_UNAVAILABLE_MESSAGE }, 503);
   }
 
   const rateCheck = await rateLimiter(redis, `${keyPrefix}:${userId}`, 5, 5 * 60);

--- a/apps/api/src/routes/auth/helpers.ts
+++ b/apps/api/src/routes/auth/helpers.ts
@@ -247,6 +247,17 @@ export function rejectProof(
   return c.json({ error: message, message, code, ...extra }, status);
 }
 
+/**
+ * #4746: the step-up throttle body populates `error` AND `message`, exactly as
+ * {@link rejectProof} does, because clients are split on which key they read.
+ * The web profile form renders `data.message` and falls back to a generic
+ * string when it is absent (`apps/web/src/components/settings/ProfilePage.tsx`),
+ * so a 429 carrying only `error` would surface as "Failed to change password"
+ * rather than the real reason — a throttle the user cannot see is a throttle
+ * they will keep hammering.
+ */
+const STEP_UP_THROTTLED_MESSAGE = 'Too many attempts. Please try again later.';
+
 export async function requireCurrentPasswordStepUp(
   c: Context,
   userId: string,
@@ -258,9 +269,32 @@ export async function requireCurrentPasswordStepUp(
    * Defaults to 401 for every pre-existing caller whose client contract keys
    * on it (approvals/PAM step-up, users email-change, authenticator).
    */
-  opts: { rejectionStatus?: ProofRejectionStatus } = {},
+  opts: {
+    rejectionStatus?: ProofRejectionStatus;
+    /**
+     * #4746: user-facing text for a rejected password. Defaults to the opaque
+     * 'Invalid credentials' every step-up caller has always sent, because on a
+     * step-up the specific reason is not the caller's to disclose.
+     *
+     * `/auth/change-password` overrides it: the request is already
+     * authenticated AS the account being changed, so opacity buys nothing
+     * there, and the web client renders `message` verbatim on the profile form
+     * (`apps/web/src/components/settings/ProfilePage.tsx`). Answering
+     * "Invalid credentials" to a mistyped current password would read as a
+     * dead session — the exact confusion #4660/#4739 just removed.
+     */
+    invalidMessage?: string;
+    /**
+     * Text for an account that has no password hash at all. Defaults to
+     * `invalidMessage`, keeping the two cases indistinguishable for callers
+     * that do not opt in.
+     */
+    noPasswordMessage?: string;
+  } = {},
 ): Promise<Response | null> {
   const rejectionStatus = opts.rejectionStatus ?? 401;
+  const invalidMessage = opts.invalidMessage ?? 'Invalid credentials';
+  const noPasswordMessage = opts.noPasswordMessage ?? invalidMessage;
   const redis = getRedis();
   if (!redis) {
     return c.json({ error: 'Service temporarily unavailable' }, 503);
@@ -269,7 +303,8 @@ export async function requireCurrentPasswordStepUp(
   const rateCheck = await rateLimiter(redis, `${keyPrefix}:${userId}`, 5, 5 * 60);
   if (!rateCheck.allowed) {
     return c.json({
-      error: 'Too many attempts. Please try again later.',
+      error: STEP_UP_THROTTLED_MESSAGE,
+      message: STEP_UP_THROTTLED_MESSAGE,
       retryAfter: Math.ceil((rateCheck.resetAt.getTime() - Date.now()) / 1000)
     }, 429);
   }
@@ -281,12 +316,12 @@ export async function requireCurrentPasswordStepUp(
     .limit(1);
 
   if (!user?.passwordHash) {
-    return rejectProof(c, 'Invalid credentials', INVALID_CREDENTIALS_CODE, rejectionStatus);
+    return rejectProof(c, noPasswordMessage, INVALID_CREDENTIALS_CODE, rejectionStatus);
   }
 
   const valid = await verifyPassword(user.passwordHash, currentPassword);
   if (!valid) {
-    return rejectProof(c, 'Invalid credentials', INVALID_CREDENTIALS_CODE, rejectionStatus);
+    return rejectProof(c, invalidMessage, INVALID_CREDENTIALS_CODE, rejectionStatus);
   }
 
   return null;
@@ -319,7 +354,8 @@ export async function requireFreshMfaStepUp(
   const rateCheck = await rateLimiter(redis, `${keyPrefix}:${userId}`, 5, 5 * 60);
   if (!rateCheck.allowed) {
     return c.json({
-      error: 'Too many attempts. Please try again later.',
+      error: STEP_UP_THROTTLED_MESSAGE,
+      message: STEP_UP_THROTTLED_MESSAGE,
       retryAfter: Math.ceil((rateCheck.resetAt.getTime() - Date.now()) / 1000)
     }, 429);
   }

--- a/apps/api/src/routes/auth/password.test.ts
+++ b/apps/api/src/routes/auth/password.test.ts
@@ -135,7 +135,7 @@ vi.mock('./ssoPolicy', () => ({
 
 import { passwordRoutes } from './password';
 import { db, withSystemDbAccessContext } from '../../db';
-import { invalidateAllUserSessions, verifyPassword } from '../../services';
+import { invalidateAllUserSessions, rateLimiter, verifyPassword } from '../../services';
 import { writeAuthAudit } from './helpers';
 import { getPasswordResetEligibility } from '../../services/passwordResetEligibility';
 import { enqueuePasswordResetRequest } from '../../services/authEmailQueue';
@@ -732,6 +732,85 @@ describe('password reset eligibility (#719)', () => {
       const body = await res.json() as { error: string };
       expect(body.error).toBe('Password authentication is not available for this account');
       expect(db.transaction).not.toHaveBeenCalled();
+    });
+
+    // #4746: every sibling that verifies a body-supplied password is throttled
+    // (account deletion via its own `rateLimiter` call, the MFA/passkey/phone
+    // factor routes via `requireCurrentPasswordStepUp`). This route was the
+    // only one that ran a bare `verifyPassword`, so a stolen access token could
+    // brute-force the current password one argon2 verify per request and, on a
+    // hit, set a new one — takeover with no lockout. It now goes through the
+    // same shared step-up helper.
+    it('throttles current-password guessing and answers 429 BEFORE argon2 runs (#4746)', async () => {
+      vi.mocked(rateLimiter).mockResolvedValueOnce({
+        allowed: false,
+        remaining: 0,
+        resetAt: new Date(Date.now() + 5 * 60 * 1000),
+      } as never);
+
+      const res = await postJson('/change-password', {
+        currentPassword: 'guess-number-six-1234',
+        newPassword: 'new-strong-pw-1234',
+      });
+
+      expect(res.status).toBe(429);
+      const body = await res.json() as { error: string; message: string; retryAfter: number };
+      expect(body.error).toBe('Too many attempts. Please try again later.');
+      // `message` too: the profile form renders `data.message` and would
+      // otherwise show its generic "Failed to change password" fallback, hiding
+      // the throttle from the very user who needs to stop retrying.
+      expect(body.message).toBe('Too many attempts. Please try again later.');
+      expect(body.retryAfter).toBeGreaterThan(0);
+      // The whole point of the fix: the expensive verify is never reached on a
+      // throttled guess, so the limiter is a real cost ceiling rather than a
+      // response-shaping afterthought. Nothing is rotated either.
+      expect(verifyPassword).not.toHaveBeenCalled();
+      expect(db.transaction).not.toHaveBeenCalled();
+      expect(runPostCommitCleanupMock).not.toHaveBeenCalled();
+    });
+
+    it('meters guesses in its own per-user bucket, 5 per 5 minutes (#4746)', async () => {
+      vi.mocked(verifyPassword).mockResolvedValueOnce(false);
+
+      const res = await postJson('/change-password', {
+        currentPassword: 'wrong-old-pw-1234',
+        newPassword: 'new-strong-pw-1234',
+      });
+
+      expect(res.status).toBe(400);
+      // A dedicated `pwd:change` prefix, so change-password guesses neither
+      // spend nor are shielded by the `mfa:pwd` budget the factor routes share.
+      expect(vi.mocked(rateLimiter)).toHaveBeenCalledWith(
+        expect.anything(),
+        'pwd:change:u-1',
+        5,
+        5 * 60,
+      );
+    });
+
+    it('still accepts the correct password after a few wrong guesses under the limit (#4746)', async () => {
+      vi.mocked(verifyPassword).mockResolvedValueOnce(false).mockResolvedValueOnce(false);
+
+      const first = await postJson('/change-password', {
+        currentPassword: 'wrong-1234',
+        newPassword: 'new-strong-pw-1234',
+      });
+      const second = await postJson('/change-password', {
+        currentPassword: 'wrong-again-1234',
+        newPassword: 'new-strong-pw-1234',
+      });
+      const third = await postJson('/change-password', {
+        currentPassword: 'old-strong-pw-1234',
+        newPassword: 'new-strong-pw-1234',
+      });
+
+      expect(first.status).toBe(400);
+      expect(second.status).toBe(400);
+      // The limiter must not lock a legitimate user out of their own password
+      // change for two typos — the throttle only bites past the 5th attempt.
+      expect(third.status).toBe(200);
+      expect(vi.mocked(rateLimiter)).toHaveBeenCalledTimes(3);
+      expect(db.transaction).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/apps/api/src/routes/auth/password.test.ts
+++ b/apps/api/src/routes/auth/password.test.ts
@@ -788,6 +788,35 @@ describe('password reset eligibility (#719)', () => {
       );
     });
 
+    // #4746: routing through the step-up helper gave this route a Redis
+    // dependency it did not have before (the old inline `verifyPassword` needed
+    // none), so it now fails CLOSED on an outage rather than verifying
+    // unthrottled. That is the right posture — an unavailable limiter must not
+    // silently become no limiter — but it is a new failure mode for this
+    // endpoint and needs its own guard.
+    it('fails closed with 503 when Redis is unavailable, without verifying the password (#4746)', async () => {
+      const { getRedis } = await import('../../services');
+      vi.mocked(getRedis).mockReturnValueOnce(null as never);
+
+      const res = await postJson('/change-password', {
+        currentPassword: 'old-strong-pw-1234',
+        newPassword: 'new-strong-pw-1234',
+      });
+
+      expect(res.status).toBe(503);
+      const body = await res.json() as { error: string; message: string };
+      // Both keys: the profile form reads `data.message` and does NOT fall back
+      // to `data.error` (unlike its siblings in that file), so an `error`-only
+      // body would render as the generic "Failed to change password" — an
+      // outage the user cannot tell apart from their own typo, and would retry
+      // as though it were one.
+      expect(body.error).toBe('Service temporarily unavailable');
+      expect(body.message).toBe('Service temporarily unavailable');
+      // Fail CLOSED: no verify, no rotation.
+      expect(verifyPassword).not.toHaveBeenCalled();
+      expect(db.transaction).not.toHaveBeenCalled();
+    });
+
     it('still accepts the correct password after a few wrong guesses under the limit (#4746)', async () => {
       vi.mocked(verifyPassword).mockResolvedValueOnce(false).mockResolvedValueOnce(false);
 

--- a/apps/api/src/routes/auth/password.ts
+++ b/apps/api/src/routes/auth/password.ts
@@ -5,7 +5,6 @@ import * as dbModule from '../../db';
 import { users } from '../../db/schema';
 import {
   hashPassword,
-  verifyPassword,
   isPasswordStrong,
   rateLimiter,
   forgotPasswordLimiter,
@@ -27,8 +26,7 @@ import {
   resolveUserAuditOrgId,
   writeAuthAudit,
   authResponseFloorPromise,
-  rejectProof,
-  INVALID_CREDENTIALS_CODE
+  requireCurrentPasswordStepUp
 } from './helpers';
 import { assertPasswordAuthAllowedBySso, SsoPasswordAuthRequiredError } from './ssoPolicy';
 import { advanceUserEpochs, revokeAllRefreshFamilies, runPostCommitCleanup } from '../../services/authLifecycle';
@@ -295,30 +293,39 @@ passwordRoutes.post('/change-password', authMiddleware, zValidator('json', chang
     }, 403);
   }
 
-  const [user] = await db
-    .select({ passwordHash: users.passwordHash })
-    .from(users)
-    .where(eq(users.id, auth.user.id))
-    .limit(1);
-
-  if (!user?.passwordHash) {
-    const message = 'Password authentication is not available for this account';
-    return c.json({ error: message, message }, 400);
-  }
-
-  const validCurrentPassword = await verifyPassword(user.passwordHash, currentPassword);
-  if (!validCurrentPassword) {
-    // #4660 (extends the #4470 contract): 400, not 401. `currentPassword`
-    // arrived in the request BODY — it is data this handler validates, not the
-    // credential that authenticates the request (that is the bearer, already
-    // checked by `authMiddleware` above). The web client's `fetchWithAuth`
-    // (apps/web/src/stores/auth.ts) funnels every 401 into refresh-and-replay
-    // and then `handleSessionExpired`, so answering 401 here signed the user
-    // out mid-flow for a single typo. The two neighbouring rejections — no
-    // password hash above, weak new password below — are already 400, so this
-    // also makes the endpoint's own statuses consistent.
-    return rejectProof(c, 'Current password is incorrect', INVALID_CREDENTIALS_CODE, 400);
-  }
+  // #4746: the current-password check runs through the SHARED step-up helper
+  // rather than a bare `verifyPassword`, so this route inherits the per-user
+  // rate limit (5 attempts / 5 min) every sibling that validates a
+  // body-supplied password already had — account deletion has its own
+  // `rateLimiter` call, and the MFA/passkey/phone factor routes come through
+  // this same helper. Without it a stolen access token could brute-force the
+  // current password at one argon2 verify per request and, on a hit, set a new
+  // one: account takeover with no lockout and no step-up cost. The limiter
+  // runs BEFORE the hash lookup and the verify, so a throttled guess costs an
+  // attacker a Redis round trip instead of an argon2 evaluation.
+  //
+  // The two rejection bodies are passed in explicitly to preserve this route's
+  // existing contract verbatim (#4660/#4739): both stay 400 with
+  // `code: 'invalid_credentials'`, and each keeps its own specific message —
+  // the helper's default opaque 'Invalid credentials' would surface on the web
+  // profile form, where it reads as a dead session rather than a typo. 400 (not
+  // 401) because `currentPassword` arrived in the request BODY: it is data this
+  // handler validates, not the credential that authenticates the request (that
+  // is the bearer, already checked by `authMiddleware` above), and the web
+  // client's `fetchWithAuth` funnels every 401 into refresh-and-replay and then
+  // `handleSessionExpired`.
+  const passwordError = await requireCurrentPasswordStepUp(
+    c,
+    auth.user.id,
+    currentPassword,
+    'pwd:change',
+    {
+      rejectionStatus: 400,
+      invalidMessage: 'Current password is incorrect',
+      noPasswordMessage: 'Password authentication is not available for this account',
+    },
+  );
+  if (passwordError) return passwordError;
 
   const passwordCheck = isPasswordStrong(newPassword);
   if (!passwordCheck.valid) {


### PR DESCRIPTION
Closes #4746

## The gap

`POST /auth/change-password` (`apps/api/src/routes/auth/password.ts`) inlined a bare `verifyPassword(user.passwordHash, currentPassword)` with **no limiter anywhere on the handler path**. It was the only route in the codebase that validates a body-supplied password without one:

| Route | Throttle |
|---|---|
| `POST /auth/account-deletion` | own `rateLimiter(redis, 'account-deletion:<client>:<user>', 5, 300)` |
| MFA disable / recovery-code regen, passkey delete, phone routes | `requireCurrentPasswordStepUp(…, 'mfa:pwd' \| 'passkey:pwd', …)` |
| `POST /auth/forgot-password` | `forgot:<client>` |
| **`POST /auth/change-password`** | **none** |

A stolen access token could brute-force the current password at one argon2 verify per request and, on a hit, set a new one — account takeover with no lockout and no step-up cost.

## The fix

Route the check through the shared `requireCurrentPasswordStepUp` helper with its own `pwd:change` bucket. The limiter (5 attempts / 5 min, per user) now runs **before** the hash lookup and the verify, so a throttled guess costs an attacker a Redis round trip instead of an argon2 evaluation. A dedicated prefix means change-password guesses neither spend nor hide behind the `mfa:pwd` budget the factor routes share.

## Response contract is preserved verbatim (#4660 / #4739)

The helper hard-coded an opaque `'Invalid credentials'` for both its rejections. That is right for a step-up on a sensitive operation, but wrong on this route: the request is already authenticated **as** the account being changed, so opacity buys nothing, and `ProfilePage.tsx` renders `message` verbatim — "Invalid credentials" on a change-password form reads as a dead session rather than a typo, which is the exact confusion #4739 just removed.

Two **opt-in** overrides (`invalidMessage`, `noPasswordMessage`) were added to the helper. Both default to today's strings, so all eight existing call sites are byte-for-byte unchanged.

| Case | Before | After |
|---|---|---|
| Wrong current password | 400 `{error, message: 'Current password is incorrect', code: 'invalid_credentials'}` | identical |
| Passwordless account | 400 `{error, message: 'Password authentication is not available for this account'}` | same, **plus** the stable `code: 'invalid_credentials'` (additive) |
| 6th guess in 5 min | *(none — 400/200 as if untracked)* | **429** `{error, message, retryAfter}` |

## Two things worth a reviewer's attention

1. **Fail-closed on Redis down.** With Redis unavailable the route now answers 503 instead of proceeding unthrottled. That is what every sibling step-up already does, and it is the correct direction for a credential check, but it is a behaviour change.
2. **`message` added to the step-up 429 body** (both step-up helpers, kept symmetric — the TOTP one documents itself as mirroring the password one). `ProfilePage.tsx` reads `data.message` and falls back to a generic "Failed to change password" when it is absent, so a 429 carrying only `error` would hide the throttle from the very user who needs to stop retrying. Purely additive; the one existing assertion on that body uses `objectContaining`.

Scope held to this route. The mobile client is untouched.

## Tests (red first)

Added to `apps/api/src/routes/auth/password.test.ts`, all three confirmed failing against the unpatched route before the fix (`rateLimiter` called 0 times; the over-limit guess answered 200):

- the over-limit attempt is **429 before argon2 runs** — asserts `verifyPassword` was never called and nothing was rotated
- guesses are metered in a per-user `pwd:change:<user>` bucket at 5 / 5 min
- a correct password **after two wrong guesses still succeeds** while under the limit — the throttle must not lock a legitimate user out of their own password change for two typos

The two pre-existing #4660 contract tests (wrong password → 400 + code; passwordless → its own 400 body) pass unchanged, which is the evidence the response shape survived the move.

**Verification:** `vitest run src/routes/auth/ src/routes/auth.test.ts src/routes/auth.passkeys.test.ts src/routes/authenticator.test.ts src/routes/users.test.ts src/routes/pam.test.ts src/routes/approvals.test.ts src/openapi.scriptAdmission.test.ts` → **28 files / 962 tests passed**. `tsc --noEmit` clean. `eslint` on the four changed files clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBxF7C8E5GxFnNcGf6kBVP
