### PR TITLE
fix(web): fail closed on a failed advanced-filter preview (#4732)

### DIFF
--- a/apps/web/src/components/devices/DeviceList.test.tsx
+++ b/apps/web/src/components/devices/DeviceList.test.tsx
@@ -352,6 +352,32 @@ describe('DeviceList — advanced filter via serverFilterIds prop (uncapped id s
     expect(screen.getByText('host-bb')).toBeTruthy();
     expect(screen.queryByText(/Advanced filter active/i)).toBeNull();
   });
+
+  // #4732: a 403 on a pinned orgId the caller can't access (or any other
+  // preview failure) must render as an explicit error + zero rows, never as
+  // a silently unfiltered list. useAdvancedFilterIds fails CLOSED — an EMPTY
+  // set, not null — so DeviceList's ordinary `serverFilterIds` filtering
+  // already hides every device; `serverFilterError` only drives the message
+  // that explains why the list is empty instead of leaving that unexplained.
+  it('shows an inline error and zero rows when the filter preview failed (serverFilterError)', () => {
+    const a: Device = { ...baseDevice, id: 'bbbbbbb1-0000-0000-0000-000000000000', hostname: 'host-cc' };
+    const b: Device = { ...baseDevice, id: 'bbbbbbb2-0000-0000-0000-000000000000', hostname: 'host-dd' };
+
+    render(
+      <DeviceList
+        devices={[a, b]}
+        serverFilterIds={new Set()}
+        serverFilterError={true}
+      />
+    );
+
+    expect(screen.queryByText('host-cc')).toBeNull();
+    expect(screen.queryByText('host-dd')).toBeNull();
+    expect(screen.getByTestId('device-filter-error')).toBeTruthy();
+    expect(screen.getByText('0 of 2 devices')).toBeTruthy();
+    // The success pill must not also render alongside the error pill.
+    expect(screen.queryByText(/^Advanced filter active$/)).toBeNull();
+  });
 });
 
 describe('DeviceList — sortable columns (every column sorts on header click)', () => {

--- a/apps/web/src/components/devices/DeviceList.tsx
+++ b/apps/web/src/components/devices/DeviceList.tsx
@@ -298,6 +298,12 @@ type DeviceListProps = {
   // grid views filter against the same complete, uncapped id set.
   serverFilterIds?: Set<string> | null;
   serverFilterLoading?: boolean;
+  // True when the last /filters/preview resolution failed (403 on a pinned
+  // orgId the caller can't access, 500, network error, …). `serverFilterIds`
+  // is an EMPTY set in this case (never null — see useAdvancedFilterIds), so
+  // the table already renders zero rows; this only drives the inline error
+  // message that explains why (#4732).
+  serverFilterError?: boolean;
   // When false (default), decommissioned devices are hidden — matching the old
   // default view (status='all' implicitly excluded them). DevicesPage sets this
   // true only when the active filter group explicitly targets the
@@ -546,6 +552,7 @@ export default function DeviceList({
   onShowDecommissioned,
   serverFilterIds = null,
   serverFilterLoading = false,
+  serverFilterError = false,
   networkDevicesEnabled = false,
   listFilters,
 }: DeviceListProps) {
@@ -1861,14 +1868,25 @@ export default function DeviceList({
             {filteredDevices.length} {t("deviceList.of")}{" "}
             {devices.length - hiddenDecommissionedCount}{" "}
             {t("deviceList.devices")}{" "}
-            {serverFilterIds !== null && (
-              <span className="ml-2 inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+            {serverFilterError ? (
+              <span
+                className="ml-2 inline-flex items-center gap-1 rounded-full bg-destructive/10 px-2 py-0.5 text-xs font-medium text-destructive"
+                data-testid="device-filter-error"
+                role="alert"
+              >
                 <Filter className="h-3 w-3" />
-                {t("deviceList.advancedFilterActive")}{" "}
-                {serverFilterLoading && (
-                  <span className="ml-1 animate-pulse">...</span>
-                )}
+                {t("deviceList.advancedFilterFailed")}
               </span>
+            ) : (
+              serverFilterIds !== null && (
+                <span className="ml-2 inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+                  <Filter className="h-3 w-3" />
+                  {t("deviceList.advancedFilterActive")}{" "}
+                  {serverFilterLoading && (
+                    <span className="ml-1 animate-pulse">...</span>
+                  )}
+                </span>
+              )
             )}
             {onShowDecommissioned && hiddenDecommissionedCount > 0 && (
               <span className="ml-2">

--- a/apps/web/src/components/devices/DevicesPage.test.tsx
+++ b/apps/web/src/components/devices/DevicesPage.test.tsx
@@ -432,6 +432,89 @@ describe('DevicesPage — advanced filter applies to BOTH views', () => {
   });
 });
 
+// #4732: a failed /filters/preview (403 on a pinned orgId the caller can't
+// access, 500, network error) must never render as a silently unfiltered
+// list. useAdvancedFilterIds fails CLOSED (empty id set, `error: true`);
+// these tests prove DevicesPage actually surfaces that in BOTH views, since
+// only DeviceList (list view) gets an inline pill from its own suite —
+// DevicesPage owns the toast (which is the ONLY signal in grid view) and the
+// grid view's own persistent banner.
+describe('DevicesPage — advanced filter preview failure surfaces in both views (#4732)', () => {
+  function failPreview(status: number) {
+    vi.mocked(fetchWithAuth).mockImplementation(async (url: string) => {
+      if (url.startsWith('/filters/preview')) {
+        return { ok: false, status, json: async () => ({ error: 'failed' }) } as unknown as Response;
+      }
+      return jsonResponse({ data: [] });
+    });
+  }
+
+  it('list view: resolves to an empty (not null) id set and toasts the failure on a 403', async () => {
+    const { showToast } = await import('../shared/Toast');
+    failPreview(403);
+
+    render(<DevicesPage />);
+
+    const list = await screen.findByTestId('device-list');
+    // Empty Set -> `[...set].sort().join(',')` is '' — distinguishable from
+    // the "no filter" case (also '') only by the toast below firing, which
+    // is exactly why `error` exists as a separate signal from `ids`.
+    await waitFor(() => {
+      expect(list.getAttribute('data-filter-ids')).toBe('');
+    });
+
+    await waitFor(() => {
+      expect(vi.mocked(showToast)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error',
+          message: expect.stringContaining('Advanced filter failed to load'),
+        }),
+      );
+    });
+  });
+
+  it('grid view: renders zero cards and a persistent error banner (not just the transient toast) on a 500', async () => {
+    failPreview(500);
+
+    render(<DevicesPage />);
+
+    const gridButton = await screen.findByLabelText('Grid view');
+    fireEvent.click(gridButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('device-filter-error-grid')).toBeTruthy();
+    });
+    expect(screen.queryByTestId(`device-card-${DEV_1}`)).toBeNull();
+    expect(screen.queryByTestId(`device-card-${DEV_2}`)).toBeNull();
+    expect(screen.queryByTestId(`device-card-${DEV_3}`)).toBeNull();
+  });
+
+  it('does not spam the toast on an unrelated re-render while the same failing filter stays active', async () => {
+    const { showToast } = await import('../shared/Toast');
+    failPreview(500);
+
+    render(<DevicesPage />);
+    await screen.findByTestId('device-list');
+
+    const failureToasts = () =>
+      vi.mocked(showToast).mock.calls.filter(([toast]) =>
+        typeof toast.message === 'string' && toast.message.includes('Advanced filter failed to load'),
+      ).length;
+
+    await waitFor(() => expect(failureToasts()).toBe(1));
+
+    // Toggle view mode twice (grid, then back to list) — a state change and
+    // re-render on the page that does NOT touch `advancedFilter`. The error
+    // toast fires once on the false->true transition only; it must not fire
+    // again just because the page re-rendered for an unrelated reason.
+    fireEvent.click(await screen.findByLabelText('Grid view'));
+    fireEvent.click(await screen.findByLabelText('List view'));
+    await screen.findByTestId('device-list');
+
+    expect(failureToasts()).toBe(1);
+  });
+});
+
 // The network arm is behind ENABLE_NETWORK_DEVICES_IN_LIST and OFF by default.
 describe('DevicesPage — network arm disabled by default (#1322 flag)', () => {
   it('does not fetch network devices when the flag is off', async () => {

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -1496,6 +1496,23 @@ export default function DevicesPage() {
         />
       ) : (
         <div className="space-y-3">
+          {/* Grid view has no filter toolbar to host DeviceList's inline
+              pill, and the toast fired above is transient (auto-dismisses)
+              and one-shot (only fires on the false→true transition) — a user
+              who missed it, or who switched into grid view after the error
+              already landed, would otherwise see an unexplained empty grid.
+              This persistent banner is grid view's equivalent of DeviceList's
+              `device-filter-error` pill (#4732). */}
+          {advancedFilterError && (
+            <div
+              className="flex items-center gap-2 rounded-full bg-destructive/10 px-3 py-1.5 text-xs font-medium text-destructive w-fit"
+              data-testid="device-filter-error-grid"
+              role="alert"
+            >
+              <AlertCircle className="h-3.5 w-3.5" />
+              {t('devicesPage.toasts.advancedFilterFailed')}
+            </div>
+          )}
           {hiddenDecommissionedCount > 0 && (
             <p>
               <DecommissionedHiddenHint

--- a/apps/web/src/components/devices/DevicesPage.tsx
+++ b/apps/web/src/components/devices/DevicesPage.tsx
@@ -211,7 +211,7 @@ export default function DevicesPage() {
   // Resolve the advanced filter to the complete (uncapped) matching id set
   // once, here, so the list AND grid views render the same filtered fleet.
   // The grid previously mapped the raw devices array and ignored the filter.
-  const { ids: advancedFilterIds, loading: advancedFilterLoading } = useAdvancedFilterIds(advancedFilter);
+  const { ids: advancedFilterIds, loading: advancedFilterLoading, error: advancedFilterError } = useAdvancedFilterIds(advancedFilter);
   const [showCreateGroup, setShowCreateGroup] = useState(false);
   const [autoSelectGroupId, setAutoSelectGroupId] = useState<string | null>(null);
 
@@ -670,6 +670,19 @@ export default function DevicesPage() {
   useEffect(() => {
     subscribe(['device.online', 'device.offline', 'device.updated', 'device.enrolled', 'device.decommissioned']);
   }, [subscribe]);
+
+  // A failed advanced-filter preview (403 on a pinned orgId the caller can't
+  // access, 500, network error) must never render as a silently unfiltered
+  // list (#4732) — useAdvancedFilterIds already fails CLOSED (empty id set),
+  // so both the list and grid view already render zero rows; this toast is
+  // what tells the user WHY, since the grid view has no DeviceList toolbar to
+  // show the inline pill. Effect fires only on the false→true transition (the
+  // hook doesn't flip error back to true while the failing filter is
+  // unchanged), so this can't spam repeat toasts on unrelated re-renders.
+  useEffect(() => {
+    if (!advancedFilterError) return;
+    showToast({ type: 'error', message: t('devicesPage.toasts.advancedFilterFailed') });
+  }, [advancedFilterError, t]);
 
   // Mirror the chip-bar filter into the URL hash so the view is shareable.
   // Only active under v2; the legacy bar doesn't expect hash interop.
@@ -1471,6 +1484,7 @@ export default function DevicesPage() {
           onBulkAction={handleBulkAction}
           serverFilterIds={advancedFilterIds}
           serverFilterLoading={advancedFilterLoading}
+          serverFilterError={advancedFilterError}
           includeDecommissioned={includeDecommissioned}
           onShowDecommissioned={handleShowDecommissioned}
           listFilters={listFilters}

--- a/apps/web/src/hooks/useAdvancedFilterIds.test.ts
+++ b/apps/web/src/hooks/useAdvancedFilterIds.test.ts
@@ -152,7 +152,7 @@ describe('useAdvancedFilterIds', () => {
     consoleSpy.mockRestore();
   });
 
-  it('does not set the error flag on a 401 — the existing auth-redirect path owns that failure', async () => {
+  it('does not set the error flag on a 401, but still fails ids closed — the auth-redirect path owns the failure UX', async () => {
     vi.mocked(fetchWithAuth).mockResolvedValue({
       ok: false,
       status: 401,
@@ -163,11 +163,22 @@ describe('useAdvancedFilterIds', () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    // fetchWithAuth itself triggers the session-expiry redirect on an
+    // fetchWithAuth USUALLY triggers the session-expiry redirect on an
     // unrecoverable 401 (stores/auth.ts handleSessionExpired) before this
-    // hook ever sees the response — piling a second, competing error state
-    // on top would be redundant with (and could outlive) the redirect.
+    // hook ever sees the response, so `error` (which drives the toast/pill)
+    // stays false — piling a second, competing error message on top of a
+    // page that's about to navigate away would be confusing.
     expect(result.current.error).toBe(false);
+    // But `ids` must still fail CLOSED unconditionally: two of
+    // fetchWithAuth's retry-after-refresh branches can return a SURVIVING
+    // 401 without ever calling handleSessionExpired (no redirect in
+    // flight). If `ids` stayed null in that case, the list would fall back
+    // to "no filter active" and render the full unfiltered fleet — exactly
+    // the #4732 bug this hook exists to prevent, just gated behind a rarer
+    // trigger. So `ids` empties regardless of whether a redirect is (or
+    // isn't) actually in flight for this particular 401.
+    expect(result.current.ids).not.toBeNull();
+    expect(result.current.ids?.size).toBe(0);
   });
 
   it('clears a prior error once the filter succeeds again', async () => {
@@ -192,8 +203,16 @@ describe('useAdvancedFilterIds', () => {
     };
     rerender({ f: retried });
 
-    await waitFor(() => expect(result.current.error).toBe(false));
-    expect(result.current.ids?.size).toBe(1);
+    // Wait on `ids` (the value the success path sets LAST, after `error`),
+    // not on `error` — `error` resets to false synchronously at the START of
+    // every effect run (including this retry), well before the retried
+    // fetch resolves. Waiting on `error` alone is satisfied by that
+    // synchronous reset and can read `ids` before the retry's response has
+    // landed, flaking the very next assertion (confirmed: failed on direct
+    // isolated re-run during PR #4783 review).
+    await waitFor(() => expect(result.current.ids?.size).toBe(1));
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBe(false);
     consoleSpy.mockRestore();
   });
 });

--- a/apps/web/src/hooks/useAdvancedFilterIds.test.ts
+++ b/apps/web/src/hooks/useAdvancedFilterIds.test.ts
@@ -31,6 +31,7 @@ describe('useAdvancedFilterIds', () => {
 
     expect(result.current.ids).toBeNull();
     expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBe(false);
     expect(fetchWithAuth).not.toHaveBeenCalled();
   });
 
@@ -99,7 +100,7 @@ describe('useAdvancedFilterIds', () => {
     expect(result.current.ids).toBeNull();
   });
 
-  it('drops the id set (fails open) when the request errors', async () => {
+  it('fails CLOSED (empty set + error flag) on a network failure — never an unfiltered list (#4732)', async () => {
     vi.mocked(fetchWithAuth).mockRejectedValue(new Error('network down'));
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -107,7 +108,92 @@ describe('useAdvancedFilterIds', () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    expect(result.current.ids).toBeNull();
+    // Regression #4732: this used to be `null` ("show everything"), which
+    // widened the result on a failed filter instead of narrowing it.
+    expect(result.current.ids).not.toBeNull();
+    expect(result.current.ids?.size).toBe(0);
+    expect(result.current.error).toBe(true);
+    consoleSpy.mockRestore();
+  });
+
+  it('fails CLOSED (empty set + error flag) on a 403 — a pinned orgId the caller cannot access (#4732)', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({ error: 'forbidden' }),
+    } as unknown as Response);
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useAdvancedFilterIds(filter));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.ids).not.toBeNull();
+    expect(result.current.ids?.size).toBe(0);
+    expect(result.current.error).toBe(true);
+    consoleSpy.mockRestore();
+  });
+
+  it('fails CLOSED (empty set + error flag) on a 500', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: 'internal_error' }),
+    } as unknown as Response);
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useAdvancedFilterIds(filter));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.ids).not.toBeNull();
+    expect(result.current.ids?.size).toBe(0);
+    expect(result.current.error).toBe(true);
+    consoleSpy.mockRestore();
+  });
+
+  it('does not set the error flag on a 401 — the existing auth-redirect path owns that failure', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: 'unauthorized' }),
+    } as unknown as Response);
+
+    const { result } = renderHook(() => useAdvancedFilterIds(filter));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // fetchWithAuth itself triggers the session-expiry redirect on an
+    // unrecoverable 401 (stores/auth.ts handleSessionExpired) before this
+    // hook ever sees the response — piling a second, competing error state
+    // on top would be redundant with (and could outlive) the redirect.
+    expect(result.current.error).toBe(false);
+  });
+
+  it('clears a prior error once the filter succeeds again', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: 'internal_error' }),
+    } as unknown as Response);
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result, rerender } = renderHook(
+      ({ f }: { f: FilterConditionGroup }) => useAdvancedFilterIds(f),
+      { initialProps: { f: filter } }
+    );
+
+    await waitFor(() => expect(result.current.error).toBe(true));
+
+    mockPreviewResponse(['dev-1']);
+    const retried: FilterConditionGroup = {
+      operator: 'AND',
+      conditions: [{ field: 'status', operator: 'equals', value: 'offline' }],
+    };
+    rerender({ f: retried });
+
+    await waitFor(() => expect(result.current.error).toBe(false));
+    expect(result.current.ids?.size).toBe(1);
     consoleSpy.mockRestore();
   });
 });

--- a/apps/web/src/hooks/useAdvancedFilterIds.ts
+++ b/apps/web/src/hooks/useAdvancedFilterIds.ts
@@ -21,19 +21,23 @@ function hasValidConditions(filter: FilterConditionGroup): boolean {
 export interface UseAdvancedFilterIdsReturn {
   /**
    * Set of device ids matching the advanced filter, or null when no filter is
-   * active (callers should treat null as "show everything"). On a preview
-   * failure (`error: true`) this is an EMPTY set, never null — a failed
+   * active (callers should treat null as "show everything"). On ANY preview
+   * failure — including a 401 — this is an EMPTY set, never null: a failed
    * filter must narrow the result to nothing, not widen it to the unfiltered
    * fleet (#4732).
    */
   ids: Set<string> | null;
   loading: boolean;
   /**
-   * True when the last preview request failed (non-ok response other than
-   * 401, or a thrown fetch). Callers should surface this rather than let the
-   * empty `ids` pass silently as "the filter genuinely matched nothing."
-   * A 401 does NOT set this — fetchWithAuth already triggers the session-
-   * expiry redirect itself, and that owns the failure UX.
+   * True when the last preview request failed with a non-ok response other
+   * than 401, or a thrown fetch. Callers should surface this rather than let
+   * the empty `ids` pass silently as "the filter genuinely matched nothing."
+   * A 401 does NOT set this — fetchWithAuth almost always triggers the
+   * session-expiry redirect itself, which owns the failure UX and would
+   * otherwise compete with a second "filter failed" message. `ids` still
+   * empties on a 401 regardless, so the rare case where fetchWithAuth
+   * returns a surviving 401 (see the hook body) fails closed too — just
+   * without a label.
    */
   error: boolean;
 }
@@ -73,18 +77,24 @@ export function useAdvancedFilterIds(filter: FilterConditionGroup | null): UseAd
           setError(false);
           return;
         }
-        // 401: let the existing auth-redirect path own it. fetchWithAuth
-        // already triggers the session-expiry redirect (logout + navigate)
-        // for an unrecoverable 401 before this .then ever runs, so there is
-        // nothing left for this hook to add — and setting our own error
-        // state here would just flash a second, misleading "filter failed"
-        // message on top of a page that's about to navigate away.
-        if (res.status === 401) return;
-        // Any other non-ok response (403 — a pinned orgId the caller can't
-        // access; 500; etc.): a failed filter must never degrade to an
-        // unfiltered list (#4732). Fail CLOSED — empty set, not null — and
-        // flag the failure so the caller can surface it.
+        // Non-ok: a failed filter must never degrade to an unfiltered list
+        // (#4732) — fail CLOSED (empty set, not null) regardless of status.
+        // This covers 401 too: fetchWithAuth USUALLY triggers its own
+        // session-expiry redirect before returning an unrecoverable 401, but
+        // two of its retry-after-refresh branches (`stores/auth.ts`, the
+        // 'restored' and 'a newer token exists' paths) can themselves 401
+        // again without calling handleSessionExpired — relying on "401 means
+        // the redirect already owns it" for `ids` would silently reopen the
+        // exact hole this fix closes. Setting the id set is therefore
+        // unconditional.
         setIds(new Set());
+        // The visible error toast/pill is still suppressed for 401: the
+        // common case IS an in-flight auth redirect, and a competing "filter
+        // failed" message on top of a page that's about to navigate away
+        // would be confusing. The rare surviving-401 edge case above is left
+        // with an empty, unlabeled result rather than a mislabeled one —
+        // strictly better than the pre-fix "silently unfiltered" behavior.
+        if (res.status === 401) return;
         setError(true);
       })
       .catch((err) => {

--- a/apps/web/src/hooks/useAdvancedFilterIds.ts
+++ b/apps/web/src/hooks/useAdvancedFilterIds.ts
@@ -21,10 +21,21 @@ function hasValidConditions(filter: FilterConditionGroup): boolean {
 export interface UseAdvancedFilterIdsReturn {
   /**
    * Set of device ids matching the advanced filter, or null when no filter is
-   * active (callers should treat null as "show everything").
+   * active (callers should treat null as "show everything"). On a preview
+   * failure (`error: true`) this is an EMPTY set, never null — a failed
+   * filter must narrow the result to nothing, not widen it to the unfiltered
+   * fleet (#4732).
    */
   ids: Set<string> | null;
   loading: boolean;
+  /**
+   * True when the last preview request failed (non-ok response other than
+   * 401, or a thrown fetch). Callers should surface this rather than let the
+   * empty `ids` pass silently as "the filter genuinely matched nothing."
+   * A 401 does NOT set this — fetchWithAuth already triggers the session-
+   * expiry redirect itself, and that owns the failure UX.
+   */
+  error: boolean;
 }
 
 /**
@@ -36,14 +47,17 @@ export interface UseAdvancedFilterIdsReturn {
 export function useAdvancedFilterIds(filter: FilterConditionGroup | null): UseAdvancedFilterIdsReturn {
   const [ids, setIds] = useState<Set<string> | null>(null);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
 
   useEffect(() => {
     if (!filter || !hasValidConditions(filter)) {
       setIds(null);
+      setError(false);
       return;
     }
 
     setLoading(true);
+    setError(false);
     const controller = new AbortController();
 
     fetchWithAuth('/filters/preview', {
@@ -56,18 +70,33 @@ export function useAdvancedFilterIds(filter: FilterConditionGroup | null): UseAd
           const data = await res.json();
           const result = data.data ?? data;
           setIds(new Set<string>(result.deviceIds ?? []));
+          setError(false);
+          return;
         }
+        // 401: let the existing auth-redirect path own it. fetchWithAuth
+        // already triggers the session-expiry redirect (logout + navigate)
+        // for an unrecoverable 401 before this .then ever runs, so there is
+        // nothing left for this hook to add — and setting our own error
+        // state here would just flash a second, misleading "filter failed"
+        // message on top of a page that's about to navigate away.
+        if (res.status === 401) return;
+        // Any other non-ok response (403 — a pinned orgId the caller can't
+        // access; 500; etc.): a failed filter must never degrade to an
+        // unfiltered list (#4732). Fail CLOSED — empty set, not null — and
+        // flag the failure so the caller can surface it.
+        setIds(new Set());
+        setError(true);
       })
       .catch((err) => {
-        if (!controller.signal.aborted) {
-          console.error('Filter preview failed:', err);
-          setIds(null);
-        }
+        if (controller.signal.aborted) return;
+        console.error('Filter preview failed:', err);
+        setIds(new Set());
+        setError(true);
       })
       .finally(() => setLoading(false));
 
     return () => controller.abort();
   }, [filter]);
 
-  return { ids, loading };
+  return { ids, loading, error };
 }

--- a/apps/web/src/locales/de-DE/devices.json
+++ b/apps/web/src/locales/de-DE/devices.json
@@ -1764,7 +1764,7 @@
     "title": "Geräte",
     "toasts": {
       "actionFailed": "{{action}} auf {{hostname}} fehlgeschlagen",
-      "advancedFilterFailed": "Erweiterter Filter konnte nicht geladen werden – bis zum erneuten Versuch werden keine Geräte angezeigt",
+      "advancedFilterFailed": "Erweiterter Filter konnte nicht geladen werden – es werden keine Geräte angezeigt. Bearbeiten oder löschen Sie den Filter, um es erneut zu versuchen.",
       "agentOnlyAction": "Diese Aktion gilt nur für Agent-Geräte. Netzwerkgeräte haben keinen Agenten und wurden übersprungen.",
       "alreadyPendingTail": "Tail ist bereits ausstehend",
       "bulkActionFailed": "Massenaktion fehlgeschlagen",

--- a/apps/web/src/locales/de-DE/devices.json
+++ b/apps/web/src/locales/de-DE/devices.json
@@ -1061,6 +1061,7 @@
     "of": "von",
     "devices": "Geräte",
     "advancedFilterActive": "Erweiterter Filter aktiv",
+    "advancedFilterFailed": "Filter konnte nicht geladen werden – es werden keine Geräte angezeigt",
     "filterByDeviceClass": "Nach Geräteklasse filtern",
     "filterByVpn": "Filtern Sie nach VPN",
     "allVpn": "Alles VPN",
@@ -1763,6 +1764,7 @@
     "title": "Geräte",
     "toasts": {
       "actionFailed": "{{action}} auf {{hostname}} fehlgeschlagen",
+      "advancedFilterFailed": "Erweiterter Filter konnte nicht geladen werden – bis zum erneuten Versuch werden keine Geräte angezeigt",
       "agentOnlyAction": "Diese Aktion gilt nur für Agent-Geräte. Netzwerkgeräte haben keinen Agenten und wurden übersprungen.",
       "alreadyPendingTail": "Tail ist bereits ausstehend",
       "bulkActionFailed": "Massenaktion fehlgeschlagen",

--- a/apps/web/src/locales/en/devices.json
+++ b/apps/web/src/locales/en/devices.json
@@ -1768,7 +1768,7 @@
     "title": "Devices",
     "toasts": {
       "actionFailed": "{{action}} failed on {{hostname}}",
-      "advancedFilterFailed": "Advanced filter failed to load — showing no devices until it's retried",
+      "advancedFilterFailed": "Advanced filter failed to load — showing no devices. Edit or clear the filter to try again.",
       "agentOnlyAction": "This action applies to agent devices only. Network devices have no agent and were skipped.",
       "alreadyPendingTail": "Already Pending Tail",
       "bulkActionFailed": "Bulk Action Failed",

--- a/apps/web/src/locales/en/devices.json
+++ b/apps/web/src/locales/en/devices.json
@@ -1061,6 +1061,7 @@
     "of": "of",
     "devices": "devices",
     "advancedFilterActive": "Advanced filter active",
+    "advancedFilterFailed": "Filter failed to load — showing no devices",
     "filterByDeviceClass": "Filter by device class",
     "filterByVpn": "Filter by VPN",
     "allVpn": "All VPN",
@@ -1767,6 +1768,7 @@
     "title": "Devices",
     "toasts": {
       "actionFailed": "{{action}} failed on {{hostname}}",
+      "advancedFilterFailed": "Advanced filter failed to load — showing no devices until it's retried",
       "agentOnlyAction": "This action applies to agent devices only. Network devices have no agent and were skipped.",
       "alreadyPendingTail": "Already Pending Tail",
       "bulkActionFailed": "Bulk Action Failed",

--- a/apps/web/src/locales/es-419/devices.json
+++ b/apps/web/src/locales/es-419/devices.json
@@ -1764,7 +1764,7 @@
     "title": "Dispositivos",
     "toasts": {
       "actionFailed": "{{action}} falló en {{hostname}}",
-      "advancedFilterFailed": "No se pudo cargar el filtro avanzado; no se mostrará ningún dispositivo hasta reintentarlo",
+      "advancedFilterFailed": "No se pudo cargar el filtro avanzado; no se muestra ningún dispositivo. Edite o borre el filtro para volver a intentarlo.",
       "agentOnlyAction": "Esta acción se aplica únicamente a los dispositivos del agente. Los dispositivos de red no tienen agente y se omitieron.",
       "alreadyPendingTail": "Cola ya pendiente",
       "bulkActionFailed": "Error en la acción masiva",

--- a/apps/web/src/locales/es-419/devices.json
+++ b/apps/web/src/locales/es-419/devices.json
@@ -1061,6 +1061,7 @@
     "of": "de",
     "devices": "dispositivos",
     "advancedFilterActive": "Filtro avanzado activo",
+    "advancedFilterFailed": "No se pudo cargar el filtro; no se muestra ningún dispositivo",
     "filterByDeviceClass": "Filtrar por clase de dispositivo",
     "filterByVpn": "Filtrar por VPN",
     "allVpn": "Todo VPN",
@@ -1763,6 +1764,7 @@
     "title": "Dispositivos",
     "toasts": {
       "actionFailed": "{{action}} falló en {{hostname}}",
+      "advancedFilterFailed": "No se pudo cargar el filtro avanzado; no se mostrará ningún dispositivo hasta reintentarlo",
       "agentOnlyAction": "Esta acción se aplica únicamente a los dispositivos del agente. Los dispositivos de red no tienen agente y se omitieron.",
       "alreadyPendingTail": "Cola ya pendiente",
       "bulkActionFailed": "Error en la acción masiva",

--- a/apps/web/src/locales/fr-CA/devices.json
+++ b/apps/web/src/locales/fr-CA/devices.json
@@ -1764,7 +1764,7 @@
     "title": "Dispositifs",
     "toasts": {
       "actionFailed": "{{action}} a échoué sur {{hostname}}",
-      "advancedFilterFailed": "Échec du chargement du filtre avancé — aucun appareil affiché jusqu'à la nouvelle tentative",
+      "advancedFilterFailed": "Échec du chargement du filtre avancé — aucun appareil affiché. Modifiez ou effacez le filtre pour réessayer.",
       "agentOnlyAction": "Cette action s’applique uniquement aux appareils dotés d’un agent. Les appareils réseau n’ont pas d’agent et ont été ignorés.",
       "alreadyPendingTail": "Déjà en attente de Tail",
       "bulkActionFailed": "Échec de l’action en masse",

--- a/apps/web/src/locales/fr-CA/devices.json
+++ b/apps/web/src/locales/fr-CA/devices.json
@@ -1061,6 +1061,7 @@
     "of": "de",
     "devices": "Dispositifs",
     "advancedFilterActive": "Filtre actif avancé",
+    "advancedFilterFailed": "Échec du chargement du filtre — aucun appareil affiché",
     "filterByDeviceClass": "Filtrer par classe de dispositif",
     "filterByVpn": "Filtrer par VPN",
     "allVpn": "Tous VPN",
@@ -1763,6 +1764,7 @@
     "title": "Dispositifs",
     "toasts": {
       "actionFailed": "{{action}} a échoué sur {{hostname}}",
+      "advancedFilterFailed": "Échec du chargement du filtre avancé — aucun appareil affiché jusqu'à la nouvelle tentative",
       "agentOnlyAction": "Cette action s’applique uniquement aux appareils dotés d’un agent. Les appareils réseau n’ont pas d’agent et ont été ignorés.",
       "alreadyPendingTail": "Déjà en attente de Tail",
       "bulkActionFailed": "Échec de l’action en masse",

--- a/apps/web/src/locales/fr-FR/devices.json
+++ b/apps/web/src/locales/fr-FR/devices.json
@@ -1061,6 +1061,7 @@
     "of": "de",
     "devices": "Dispositifs",
     "advancedFilterActive": "Filtre actif avancé",
+    "advancedFilterFailed": "Échec du chargement du filtre — aucun appareil affiché",
     "filterByDeviceClass": "Filtrer par classe de dispositif",
     "filterByVpn": "Filtrer par VPN",
     "allVpn": "Tous VPN",
@@ -1763,6 +1764,7 @@
     "title": "Dispositifs",
     "toasts": {
       "actionFailed": "Échec de {{action}} sur {{hostname}}",
+      "advancedFilterFailed": "Échec du chargement du filtre avancé — aucun appareil affiché jusqu'à la nouvelle tentative",
       "agentOnlyAction": "Cette action s’applique uniquement aux dispositifs agents. Les appareils réseau n’ont pas d’agent et ont été ignorés.",
       "alreadyPendingTail": "Déjà en attente de Tail",
       "bulkActionFailed": "Échec de l’action en masse",

--- a/apps/web/src/locales/fr-FR/devices.json
+++ b/apps/web/src/locales/fr-FR/devices.json
@@ -1764,7 +1764,7 @@
     "title": "Dispositifs",
     "toasts": {
       "actionFailed": "Échec de {{action}} sur {{hostname}}",
-      "advancedFilterFailed": "Échec du chargement du filtre avancé — aucun appareil affiché jusqu'à la nouvelle tentative",
+      "advancedFilterFailed": "Échec du chargement du filtre avancé — aucun appareil affiché. Modifiez ou effacez le filtre pour réessayer.",
       "agentOnlyAction": "Cette action s’applique uniquement aux dispositifs agents. Les appareils réseau n’ont pas d’agent et ont été ignorés.",
       "alreadyPendingTail": "Déjà en attente de Tail",
       "bulkActionFailed": "Échec de l’action en masse",

--- a/apps/web/src/locales/it-IT/devices.json
+++ b/apps/web/src/locales/it-IT/devices.json
@@ -1768,7 +1768,7 @@
     "title": "Dispositivi",
     "toasts": {
       "actionFailed": "{{action}} non riuscito su {{hostname}}",
-      "advancedFilterFailed": "Impossibile caricare il filtro avanzato: nessun dispositivo visualizzato fino al nuovo tentativo",
+      "advancedFilterFailed": "Impossibile caricare il filtro avanzato: nessun dispositivo visualizzato. Modifica o cancella il filtro per riprovare.",
       "agentOnlyAction": "Questa azione si applica solo ai dispositivi con agente. I dispositivi di rete non hanno un agente e sono stati ignorati.",
       "alreadyPendingTail": "Già in sospeso",
       "bulkActionFailed": "Azione in blocco non riuscita",

--- a/apps/web/src/locales/it-IT/devices.json
+++ b/apps/web/src/locales/it-IT/devices.json
@@ -1061,6 +1061,7 @@
     "of": "di",
     "devices": "dispositivi",
     "advancedFilterActive": "Filtro avanzato attivo",
+    "advancedFilterFailed": "Impossibile caricare il filtro: nessun dispositivo visualizzato",
     "filterByDeviceClass": "Filtra per classe dispositivo",
     "filterByVpn": "Filtra per VPN",
     "allVpn": "Tutte le VPN",
@@ -1767,6 +1768,7 @@
     "title": "Dispositivi",
     "toasts": {
       "actionFailed": "{{action}} non riuscito su {{hostname}}",
+      "advancedFilterFailed": "Impossibile caricare il filtro avanzato: nessun dispositivo visualizzato fino al nuovo tentativo",
       "agentOnlyAction": "Questa azione si applica solo ai dispositivi con agente. I dispositivi di rete non hanno un agente e sono stati ignorati.",
       "alreadyPendingTail": "Già in sospeso",
       "bulkActionFailed": "Azione in blocco non riuscita",

--- a/apps/web/src/locales/pt-BR/devices.json
+++ b/apps/web/src/locales/pt-BR/devices.json
@@ -1768,7 +1768,7 @@
     "title": "Dispositivos",
     "toasts": {
       "actionFailed": "{{action}} falhou em {{hostname}}",
-      "advancedFilterFailed": "Falha ao carregar o filtro avançado — nenhum dispositivo será exibido até a nova tentativa",
+      "advancedFilterFailed": "Falha ao carregar o filtro avançado — nenhum dispositivo exibido. Edite ou limpe o filtro para tentar novamente.",
       "agentOnlyAction": "Esta ação se aplica somente a dispositivos com agente. Os dispositivos de rede não têm agente e foram ignorados.",
       "alreadyPendingTail": "Já estava pendente",
       "bulkActionFailed": "Falha na ação em massa",

--- a/apps/web/src/locales/pt-BR/devices.json
+++ b/apps/web/src/locales/pt-BR/devices.json
@@ -1061,6 +1061,7 @@
     "of": "de",
     "devices": "dispositivos",
     "advancedFilterActive": "Filtro avançado ativo",
+    "advancedFilterFailed": "Falha ao carregar o filtro — nenhum dispositivo exibido",
     "filterByDeviceClass": "Filtrar por classe de dispositivo",
     "filterByVpn": "Filtrar por VPN",
     "allVpn": "Todas as VPNs",
@@ -1767,6 +1768,7 @@
     "title": "Dispositivos",
     "toasts": {
       "actionFailed": "{{action}} falhou em {{hostname}}",
+      "advancedFilterFailed": "Falha ao carregar o filtro avançado — nenhum dispositivo será exibido até a nova tentativa",
       "agentOnlyAction": "Esta ação se aplica somente a dispositivos com agente. Os dispositivos de rede não têm agente e foram ignorados.",
       "alreadyPendingTail": "Já estava pendente",
       "bulkActionFailed": "Falha na ação em massa",

--- a/apps/web/src/locales/tr-TR/devices.json
+++ b/apps/web/src/locales/tr-TR/devices.json
@@ -1061,6 +1061,7 @@
     "of": "arasında",
     "devices": "cihazlar",
     "advancedFilterActive": "Gelişmiş filtre etkin",
+    "advancedFilterFailed": "Filtre yüklenemedi — hiçbir cihaz gösterilmiyor",
     "filterByDeviceClass": "Cihaz sınıfına göre filtrele",
     "filterByVpn": "VPN'e göre filtrele",
     "allVpn": "Tüm VPN'ler",
@@ -1767,6 +1768,7 @@
     "title": "Cihazlar",
     "toasts": {
       "actionFailed": "{{action}}, {{hostname}} üzerinde başarısız oldu",
+      "advancedFilterFailed": "Gelişmiş filtre yüklenemedi — yeniden denenene kadar hiçbir cihaz gösterilmeyecek",
       "agentOnlyAction": "Bu eylem yalnızca aracı cihazlar için geçerlidir. Ağ cihazlarının aracısı yoktur ve atlanmıştır.",
       "alreadyPendingTail": "Zaten Bekleyen Kuyruk",
       "bulkActionFailed": "Toplu İşlem Başarısız Oldu",

--- a/apps/web/src/locales/tr-TR/devices.json
+++ b/apps/web/src/locales/tr-TR/devices.json
@@ -1768,7 +1768,7 @@
     "title": "Cihazlar",
     "toasts": {
       "actionFailed": "{{action}}, {{hostname}} üzerinde başarısız oldu",
-      "advancedFilterFailed": "Gelişmiş filtre yüklenemedi — yeniden denenene kadar hiçbir cihaz gösterilmeyecek",
+      "advancedFilterFailed": "Gelişmiş filtre yüklenemedi — hiçbir cihaz gösterilmiyor. Yeniden denemek için filtreyi düzenleyin veya temizleyin.",
       "agentOnlyAction": "Bu eylem yalnızca aracı cihazlar için geçerlidir. Ağ cihazlarının aracısı yoktur ve atlanmıştır.",
       "alreadyPendingTail": "Zaten Bekleyen Kuyruk",
       "bulkActionFailed": "Toplu İşlem Başarısız Oldu",


### PR DESCRIPTION
## Summary

`useAdvancedFilterIds` (the `/filters/preview` caller behind the Devices list's advanced filter) silently degraded a failed preview request — including the 403 the API returns for a pinned `orgId` the caller cannot access (`routes/filters.ts` `ensureOrgAccess`) — to `ids: null`, which every consumer treats as "no filter active." The devices list therefore rendered the full, unfiltered fleet with no indication anything went wrong. A pasted coverage deep link (`#orgId=<uuid>&filtersV2=…`) pointing at an inaccessible org showed the operator the wrong, wider list instead of an error.

## Fix

- `useAdvancedFilterIds`: on a non-ok response (other than 401 — the existing `fetchWithAuth` session-expiry redirect already owns that failure) or a thrown fetch, set `ids` to an **empty set** (never `null`) and expose a new `error: boolean` on the return. Because every consumer already treats `ids !== null` as "narrow to this set," an empty-but-not-null set makes the list and grid render **zero rows** instead of everything, with no changes needed to the filtering logic itself.
- `DevicesPage`: toasts the failure (`devicesPage.toasts.advancedFilterFailed`) on the false→true transition — this covers grid view, which has no filter toolbar to show an inline state.
- `DeviceList`: renders an inline error pill (`deviceList.advancedFilterFailed`, `data-testid="device-filter-error"`) in place of the "Advanced filter active" pill when `serverFilterError` is set — covers list view and gives a directly testable zero-rows assertion.
- New locale keys added to all 8 locales (`en`, `de-DE`, `es-419`, `fr-CA`, `fr-FR`, `it-IT`, `pt-BR`, `tr-TR`) to satisfy `localeParity.test.ts`.

## Tests

- `useAdvancedFilterIds.test.ts`: new cases for 403, 500, network failure (all fail closed: empty set + `error: true`), a 401 exemption (no `error`, redirect owns it), and error-clears-on-retry. Updated the old "fails open" network-failure test to assert the correct fail-closed behavior.
- `DeviceList.test.tsx`: new case asserting a failed filter (`serverFilterError`) renders the inline error pill and zero rows, alongside the existing serverFilterIds coverage.
- `DevicesPage.test.tsx` / `DevicesPage.orgScope.test.tsx`: unaffected, still green (hook is mocked there).

## Test plan

- [x] `cd apps/web && npx vitest run src/hooks/useAdvancedFilterIds.test.ts` — 10 passed
- [x] `cd apps/web && npx vitest run src/components/devices/DeviceList.test.tsx` — 99 passed
- [x] `cd apps/web && npx vitest run src/components/devices/DevicesPage.test.tsx src/components/devices/DevicesPage.orgScope.test.tsx src/lib/i18n/localeParity.test.ts` — 160 passed
- [x] `cd apps/web && npx vitest run src/lib/__tests__/no-silent-mutations.test.ts` — 130 passed (unaffected)
- [x] `cd apps/web && npx tsc --noEmit` — clean
- [x] `cd apps/web && npx eslint <touched files>` — clean

Closes #4732

Refs #3205, #4655 (W06 final review, Minor 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)