### PR TITLE
fix(api): wrap loadIntentDecidedVia's per-event SELECT in try/catch (#4464)

### DIFF
--- a/apps/api/src/jobs/intentReleaseWorker.test.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.test.ts
@@ -52,6 +52,12 @@ const { schema, dbState, dbMock, intentServiceMock, actorContextMock, tenantStat
       selectApprovalRequestsResults: [] as unknown[][],
       selectAgentRunsResults: [] as unknown[][],
       selectAgentsResults: [] as unknown[][],
+      /** One-shot override (#4464): the NEXT actionIntents SELECT rejects
+       *  with this instead of resolving from selectActionIntentsResults,
+       *  then clears itself. Lets a test simulate a transient read fault
+       *  (e.g. loadIntentDecidedVia's SELECT) without disturbing every
+       *  other test that relies on the queue-based happy path above. */
+      selectActionIntentsNextError: null as Error | null,
     },
     intentServiceMock: { transitionIntent: vi.fn() },
     actorContextMock: { buildAuthContextForIntent: vi.fn() },
@@ -194,6 +200,11 @@ vi.mock('../db', () => {
       where: vi.fn(() => ({
         limit: vi.fn(() => {
           if (table === schema.actionIntentsTbl) {
+            if (dbState.selectActionIntentsNextError) {
+              const err = dbState.selectActionIntentsNextError;
+              dbState.selectActionIntentsNextError = null;
+              return Promise.reject(err);
+            }
             return Promise.resolve(dbState.selectActionIntentsResults.shift() ?? []);
           }
           if (table === schema.approvalRequestsTbl) {
@@ -492,6 +503,7 @@ function resetDbState() {
   dbState.selectApprovalRequestsResults.length = 0;
   dbState.selectAgentRunsResults.length = 0;
   dbState.selectAgentsResults.length = 0;
+  dbState.selectActionIntentsNextError = null;
 }
 
 /** Clears GOOGLE_HEADLESS_SECRET_ACTIONS keys in place (see the hoisted
@@ -2944,6 +2956,46 @@ describe('processIntentReleaseJob', () => {
       expect(result).toEqual({ released: false });
       expect(policyDecideMock.attemptPolicyDecision).toHaveBeenCalledWith('intent-1');
       expect(intentServiceMock.transitionIntent).not.toHaveBeenCalled();
+    });
+
+    // #4464 — loadIntentDecidedVia's SELECT previously had no try/catch, so
+    // one failing read aborted the whole job (and, since intent_created jobs
+    // are batched per BullMQ delivery, the rest of that batch never ran).
+    it('#4464: a throwing SELECT is caught, logged to Sentry, and treated as a missing row — falls through to attemptPolicyDecision instead of aborting the job', async () => {
+      dbState.selectActionIntentsNextError = new Error('connection terminated unexpectedly');
+
+      const result = await processIntentReleaseJob({ intentId: 'intent-1', eventType: 'intent_created' });
+
+      expect(result).toEqual({ released: false });
+      expect(policyDecideMock.attemptPolicyDecision).toHaveBeenCalledWith('intent-1');
+      expect(intentServiceMock.transitionIntent).not.toHaveBeenCalled();
+      expect(sentryMock.captureException).toHaveBeenCalledTimes(1);
+      expect(sentryMock.captureException).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining('connection terminated unexpectedly') }),
+      );
+    });
+
+    it('#4464: a throwing SELECT does not poison the next call — a later lookup on a different intent still succeeds normally', async () => {
+      dbState.selectActionIntentsNextError = new Error('connection terminated unexpectedly');
+      await processIntentReleaseJob({ intentId: 'intent-1', eventType: 'intent_created' });
+      sentryMock.captureException.mockClear();
+      policyDecideMock.attemptPolicyDecision.mockClear();
+
+      // decidedVia lookup, then the unrelated best-effort outcome-notification
+      // lookup releaseAndNotify always performs afterward (notifyRequesterOfOutcome)
+      // — both queue off the same actionIntents SELECT mock, in call order.
+      dbState.selectActionIntentsResults.push([{ decidedVia: 'ticket_autonomy' }]);
+      dbState.selectActionIntentsResults.push([{ ...FOUR_EYES_INTENT, id: 'intent-2' }]);
+      intentServiceMock.transitionIntent.mockResolvedValueOnce(false);
+
+      const result = await processIntentReleaseJob({ intentId: 'intent-2', eventType: 'intent_created' });
+
+      expect(result).toEqual({ released: true });
+      expect(policyDecideMock.attemptPolicyDecision).not.toHaveBeenCalled();
+      // The earlier read fault must not leak into this unrelated, successful lookup.
+      expect(sentryMock.captureException).not.toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining('connection terminated unexpectedly') }),
+      );
     });
   });
 

--- a/apps/api/src/jobs/intentReleaseWorker.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.ts
@@ -1448,16 +1448,27 @@ export async function processIntentReleaseJob(data: IntentReleaseJobData): Promi
  * branch above — `null` (missing row, or any read fault) falls through to
  * the ordinary `attemptPolicyDecision` call, which is itself a safe no-op
  * for a row it does not recognize as `unattempted`.
+ *
+ * #4464: the SELECT is wrapped rather than left to throw — this runs once
+ * per `intent_created` event in a batch, and an unhandled rejection here
+ * previously aborted the whole batch instead of degrading just this one
+ * event to the existing fail-open path.
  */
 async function loadIntentDecidedVia(intentId: string): Promise<string | null> {
-  const [row] = await withSystemDbAccessContext(() =>
-    db
-      .select({ decidedVia: actionIntents.decidedVia })
-      .from(actionIntents)
-      .where(eq(actionIntents.id, intentId))
-      .limit(1),
-  );
-  return row?.decidedVia ?? null;
+  try {
+    const [row] = await withSystemDbAccessContext(() =>
+      db
+        .select({ decidedVia: actionIntents.decidedVia })
+        .from(actionIntents)
+        .where(eq(actionIntents.id, intentId))
+        .limit(1),
+    );
+    return row?.decidedVia ?? null;
+  } catch (err) {
+    console.error(`[IntentReleaseWorker] loadIntentDecidedVia failed for intent ${intentId}:`, err);
+    captureException(err instanceof Error ? err : new Error(String(err)));
+    return null;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

`loadIntentDecidedVia` in `apps/api/src/jobs/intentReleaseWorker.ts` (the `intent_created` recovery routing read, wave P2-4) issued its per-event SELECT with no try/catch. A transient DB error there previously relied on BullMQ's retry to paper over it rather than being handled explicitly — and since it runs once per `intent_created` event, an unhandled rejection here aborted the whole event/batch processing rather than degrading just this one event.

## Fix

Wrap the SELECT in try/catch. On failure: log via `console.error` with the intent id and the error, report to Sentry via `captureException` (matching the existing pattern used throughout this file), and return `null` — the same value the function already returns for a missing row. The caller (`intent_created` branch, ~line 1419) already fails open on `null` by falling through to the ordinary `attemptPolicyDecision` call, which is itself a safe no-op for a row it doesn't recognize as `unattempted`.

Diff is confined to `loadIntentDecidedVia` (~lines 1452-1461) and its test — kept clear of the unrelated `intentReleaseWorker.ts` edits around lines 1272/1347 from a concurrently in-flight PR for #4465.

## Tests

Added to `apps/api/src/jobs/intentReleaseWorker.test.ts`:
- A throwing SELECT is caught, logged once to Sentry, and treated as a missing row (falls through to `attemptPolicyDecision`, not thrown to the caller).
- The one-shot failure doesn't poison later calls — a subsequent lookup on a different intent still succeeds normally.

Verified red-first: both new tests failed against the pre-fix code (unhandled rejection propagated out of `processIntentReleaseJob`), then passed after the fix.

## Verification

- `cd apps/api && npx vitest run src/jobs/intentReleaseWorker.test.ts` — 116/116 passed
- `cd apps/api && npx vitest run src/jobs/intentReleaseWorker` (both non-integration files) — 118/118 passed
- `cd apps/api && npx tsc --noEmit` — clean (no errors)

Closes #4464

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBxF7C8E5GxFnNcGf6kBVP