### PR TITLE
fix(api/ai): dedupe intent outcome notifications by outcome class (#4465)

### DIFF
--- a/apps/api/src/jobs/intentReleaseWorker.test.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.test.ts
@@ -3325,12 +3325,90 @@ describe('outcome notification dedupe identity (#4465)', () => {
       ['cancelled', 'intent-outcome:intent-1:cancelled'],
       ['expired', 'intent-outcome:intent-1:expired'],
       ['pending_approval', 'intent-outcome:intent-1:update'],
+      // Runtime fallback for a value the DB holds that ActionIntentStatus does
+      // not (drift, or a rollback across a status-adding deploy). The Record in
+      // the worker is exhaustive, so a REAL new status is a compile error there
+      // rather than a silent arrival here.
+      ['some_status_added_later', 'intent-outcome:intent-1:update'],
     ])('status %s keys the notification as %s', async (status, expected) => {
       await deliverApprovedObserving(status);
 
       const arg = notifyMock.createNotification.mock.calls[0]?.[0] as { dedupeKey: string };
       expect(arg.dedupeKey).toBe(expected);
     });
+  });
+
+  // The literal shape reported in #4465: an autonomy intent carries BOTH
+  // outbox rows, so these two deliveries are the pair that used to double-ring.
+  describe('the ticket_autonomy delivery pair (the reported shape)', () => {
+    /** `intent_created` on a ticket_autonomy row routes straight to
+     *  releaseAndNotify — it first reads decidedVia, THEN the intent. */
+    async function deliverCreatedObserving(status: string): Promise<void> {
+      intentServiceMock.transitionIntent.mockResolvedValueOnce(false);
+      dbState.selectActionIntentsResults.push([{ decidedVia: 'ticket_autonomy' }]);
+      dbState.selectActionIntentsResults.push([{ ...FOUR_EYES_INTENT, status }]);
+      await processIntentReleaseJob({ intentId: 'intent-1', eventType: 'intent_created' });
+    }
+
+    it('intent_created then intent_approved across a status advance notifies once', async () => {
+      const rows = installNotificationStore();
+
+      // The created-row recovery wins the race and starts executing...
+      await deliverCreatedObserving('executing');
+      // ...and the sibling approved row lands after it settled.
+      await deliverApprovedObserving('completed');
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.dedupeKey).toBe('intent-outcome:intent-1:granted');
+    });
+
+    it('the same pair still delivers the correction when the release actually failed', async () => {
+      const rows = installNotificationStore();
+
+      await deliverCreatedObserving('approved');
+      await deliverApprovedObserving('failed');
+
+      expect(rows).toHaveLength(2);
+      expect(rows[1]!.title).toBe('Action failed');
+    });
+  });
+
+  describe('across DIFFERENT event types', () => {
+    it('an intent_approved and an intent_expired observing the same status notify once', async () => {
+      const rows = installNotificationStore();
+
+      await deliverApprovedObserving('expired');
+      dbState.selectActionIntentsResults.push([{ ...FOUR_EYES_INTENT, status: 'expired' }]);
+      await processIntentReleaseJob({ intentId: 'intent-1', eventType: 'intent_expired' });
+
+      // The key is keyed off the observed STATUS, never the event that
+      // carried it, so two event types reporting one outcome stay one bell.
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.dedupeKey).toBe('intent-outcome:intent-1:expired');
+    });
+
+    it('a granted bell followed by an intent_rejected delivery still corrects the record', async () => {
+      const rows = installNotificationStore();
+
+      await deliverApprovedObserving('approved');
+      dbState.selectActionIntentsResults.push([{ ...FOUR_EYES_INTENT, status: 'rejected' }]);
+      await processIntentReleaseJob({ intentId: 'intent-1', eventType: 'intent_rejected' });
+
+      expect(rows).toHaveLength(2);
+      expect(rows[1]!.dedupeKey).toBe('intent-outcome:intent-1:rejected');
+    });
+  });
+
+  it('collapses only the KEY — metadata still carries the raw status', async () => {
+    // The class exists for dedupe identity. Anything reading the row (the
+    // bell UI, support) must still see which status was actually observed.
+    await deliverApprovedObserving('completed');
+
+    const arg = notifyMock.createNotification.mock.calls[0]?.[0] as {
+      dedupeKey: string; metadata: { status: string };
+    };
+    expect(arg.dedupeKey).toBe('intent-outcome:intent-1:granted');
+    expect(arg.metadata.status).toBe('completed');
   });
 
   describe('agent-originated path', () => {

--- a/apps/api/src/jobs/intentReleaseWorker.test.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.test.ts
@@ -2965,10 +2965,12 @@ describe('processIntentReleaseJob', () => {
     expect(arg.title).toBe('Action failed');
   });
 
-  it('scopes the dedupe key to the STATUS so a later truth can still land', async () => {
+  it('scopes the dedupe key to the OUTCOME CLASS so a later truth can still land', async () => {
     // A per-intent key meant that once a premature "is now running" had been
     // written, the corrected notification deduped to null and the person was
-    // never told.
+    // never told. The class (not the raw status) is what draws that line —
+    // see the truth table on outcomeNotificationClass, and the #4465 block at
+    // the bottom of this file for the other half of the property.
     intentServiceMock.transitionIntent.mockResolvedValueOnce(false);
     dbState.selectActionIntentsResults.push([{ ...FOUR_EYES_INTENT, status: 'expired' }]);
 
@@ -3132,8 +3134,8 @@ describe('agent-originated outcome notifications', () => {
         title: 'Agent proposal denied',
         message: 'Patch triage: run_script(deviceId=d-1) was denied and will not run.',
         metadata: { intentId: 'intent-1', agentId: 'agent-1', agentRunId: 'run-1', status: 'rejected' },
-        // Status-scoped: a later, MORE ACCURATE status must not be suppressed
-        // by the earlier notification's dedupe row.
+        // Outcome-CLASS scoped: a later, materially different outcome must
+        // not be suppressed by the earlier notification's dedupe row (#4465).
         dedupeKey: 'agent-intent-outcome:intent-1:rejected',
       }),
     );
@@ -3206,5 +3208,177 @@ describe('agent-originated outcome notifications', () => {
 
     expect(recipientsMock.resolveRecipientUserIds).not.toHaveBeenCalled();
     expect(notifyMock.createNotification).not.toHaveBeenCalled();
+  });
+});
+
+
+// ---------------------------------------------------------------------------
+// Outcome-notification dedupe identity (#4465)
+// ---------------------------------------------------------------------------
+
+/**
+ * The bug: an autonomy intent gets TWO outbox rows (`intent_created` and
+ * `intent_approved`, both written by `createActionIntent`), so
+ * `releaseAndNotify` runs twice for one intent by design — the second is a
+ * backstop for the first. `releaseApprovedIntent` is CAS-guarded, so the
+ * duplicate release is a safe no-op; the notification's dedupe key is the
+ * only thing that makes the duplicate NOTIFICATION a no-op too. Keying it on
+ * the raw `status` broke that: the loser of the CAS reads `approved` while
+ * the winner is still executing and the winner then reads `completed`, so the
+ * two sends carry different keys and the requester's bell rings twice for one
+ * outcome.
+ *
+ * These tests assert the property the requester actually experiences — how
+ * many notification ROWS survive — so they model the real partial unique
+ * index (`user_notifications_user_dedupe_key_uq` on `(user_id, dedupe_key)`
+ * WHERE `dedupe_key IS NOT NULL`) rather than counting mock calls.
+ */
+describe('outcome notification dedupe identity (#4465)', () => {
+  type NotificationRow = { userId: string; dedupeKey: string | null; title: string };
+
+  /** Stands in for the partial unique index: a second insert on the same
+   *  (user_id, dedupe_key) hits ON CONFLICT DO NOTHING and returns null. */
+  function installNotificationStore(): NotificationRow[] {
+    const rows: NotificationRow[] = [];
+    notifyMock.createNotification.mockImplementation(async (input: Record<string, unknown>) => {
+      const row: NotificationRow = {
+        userId: input.userId as string,
+        dedupeKey: (input.dedupeKey as string | null) ?? null,
+        title: input.title as string,
+      };
+      if (row.dedupeKey !== null
+        && rows.some((r) => r.userId === row.userId && r.dedupeKey === row.dedupeKey)) {
+        return null;
+      }
+      rows.push(row);
+      return `notif-${rows.length}`;
+    });
+    return rows;
+  }
+
+  /** One `intent_approved` delivery whose release loses the CAS (the
+   *  duplicate-delivery case), observing the intent at `status`. */
+  async function deliverApprovedObserving(status: string): Promise<void> {
+    intentServiceMock.transitionIntent.mockResolvedValueOnce(false);
+    dbState.selectActionIntentsResults.push([{ ...FOUR_EYES_INTENT, status }]);
+    await processIntentReleaseJob({ intentId: 'intent-1', eventType: 'intent_approved' });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetDbState();
+  });
+
+  afterEach(() => {
+    // clearAllMocks does NOT drop implementations — restore the file default.
+    notifyMock.createNotification.mockImplementation(async () => 'notif-1');
+  });
+
+  describe('requester path (four_eyes)', () => {
+    it.each([
+      ['approved', 'completed'],
+      ['approved', 'executing'],
+      ['executing', 'completed'],
+    ])('two deliveries that observe %s then %s notify the requester exactly once', async (first, second) => {
+      const rows = installNotificationStore();
+
+      await deliverApprovedObserving(first);
+      await deliverApprovedObserving(second);
+
+      // Same outcome ("approved, and it ran") seen at two moments — one bell.
+      expect(rows).toHaveLength(1);
+      expect(notifyMock.createNotification).toHaveBeenCalledTimes(2);
+      const keys = notifyMock.createNotification.mock.calls.map(
+        (c) => (c[0] as { dedupeKey: string }).dedupeKey,
+      );
+      expect(new Set(keys).size).toBe(1);
+      expect(keys[0]).toBe('intent-outcome:intent-1:granted');
+    });
+
+    it('a genuinely different second outcome (approved -> failed) still notifies once each', async () => {
+      const rows = installNotificationStore();
+
+      await deliverApprovedObserving('approved');
+      await deliverApprovedObserving('failed');
+
+      expect(rows).toHaveLength(2);
+      expect(rows[0]!.title).toBe('Approval granted');
+      expect(rows[1]!.title).toBe('Action failed');
+      expect(rows[1]!.dedupeKey).toBe('intent-outcome:intent-1:failed');
+    });
+
+    it('repeating the SAME terminal outcome notifies once', async () => {
+      const rows = installNotificationStore();
+
+      await deliverApprovedObserving('failed');
+      await deliverApprovedObserving('failed');
+
+      expect(rows).toHaveLength(1);
+    });
+
+    it.each([
+      ['approved', 'intent-outcome:intent-1:granted'],
+      ['executing', 'intent-outcome:intent-1:granted'],
+      ['completed', 'intent-outcome:intent-1:granted'],
+      ['failed', 'intent-outcome:intent-1:failed'],
+      ['rejected', 'intent-outcome:intent-1:rejected'],
+      ['cancelled', 'intent-outcome:intent-1:cancelled'],
+      ['expired', 'intent-outcome:intent-1:expired'],
+      ['pending_approval', 'intent-outcome:intent-1:update'],
+    ])('status %s keys the notification as %s', async (status, expected) => {
+      await deliverApprovedObserving(status);
+
+      const arg = notifyMock.createNotification.mock.calls[0]?.[0] as { dedupeKey: string };
+      expect(arg.dedupeKey).toBe(expected);
+    });
+  });
+
+  describe('agent-originated path', () => {
+    const AGENT_INTENT_4465 = {
+      id: 'intent-1',
+      orgId: 'org-1',
+      requestedByUserId: null,
+      requestingAgentRunId: 'run-1',
+      requestingClientLabel: 'Patch triage',
+      targetSummary: 'run_script(deviceId=d-1)',
+      status: 'approved',
+      approvalScope: 'supervised',
+    };
+    const RUN_ROW_4465 = {
+      id: 'run-1',
+      agentId: 'agent-1',
+      policySnapshot: { effective: { recipients: { userIds: ['user-a'], roleIds: [] } } },
+    };
+    const AGENT_ROW_4465 = { id: 'agent-1', orgId: 'org-1', partnerId: null, recipients: { userIds: ['user-a'] } };
+
+    async function deliverAgentApprovedObserving(status: string): Promise<void> {
+      intentServiceMock.transitionIntent.mockResolvedValueOnce(false);
+      dbState.selectActionIntentsResults.push([{ ...AGENT_INTENT_4465, status }]);
+      dbState.selectAgentRunsResults.push([RUN_ROW_4465]);
+      dbState.selectAgentsResults.push([AGENT_ROW_4465]);
+      recipientsMock.resolveRecipientUserIds.mockResolvedValueOnce(['user-a']);
+      await processIntentReleaseJob({ intentId: 'intent-1', eventType: 'intent_approved' });
+    }
+
+    it('two deliveries across a status advance notify each recipient exactly once', async () => {
+      const rows = installNotificationStore();
+
+      await deliverAgentApprovedObserving('approved');
+      await deliverAgentApprovedObserving('completed');
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.dedupeKey).toBe('agent-intent-outcome:intent-1:granted');
+    });
+
+    it('a genuinely different second outcome (approved -> failed) still notifies once each', async () => {
+      const rows = installNotificationStore();
+
+      await deliverAgentApprovedObserving('approved');
+      await deliverAgentApprovedObserving('failed');
+
+      expect(rows).toHaveLength(2);
+      expect(rows[1]!.dedupeKey).toBe('agent-intent-outcome:intent-1:failed');
+      expect(rows[1]!.title).toBe('Agent action failed');
+    });
   });
 });

--- a/apps/api/src/jobs/intentReleaseWorker.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.ts
@@ -2,7 +2,7 @@ import { Job, Worker } from 'bullmq';
 import type { AiAgentRecipients } from '@breeze/shared';
 import { and, eq } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
-import { actionIntents, type ActionIntent } from '../db/schema/actionIntents';
+import { actionIntents, type ActionIntent, type ActionIntentStatus } from '../db/schema/actionIntents';
 import { aiAgentRuns, aiAgents } from '../db/schema/aiAgents';
 import { approvalRequests } from '../db/schema/approvals';
 import { getBullMQConnection } from '../services/redis';
@@ -1196,10 +1196,19 @@ async function loadRunAndAgent(runId: string): Promise<{
  * | expired         | `expired`   | no                           | terminal, nobody decided                                        |
  * | anything else   | `update`    | no                           | unknown/pending — say only what is certain, and never share a key with a real outcome |
  *
- * "no" means only that the two do not share a key. `rejected`/`cancelled`/
- * `expired` are mutually exclusive with `granted` in practice (a rejected
- * intent is never released), so the sequence that actually produces two bells
- * is `granted` -> `failed`, which is exactly the correction that must survive.
+ * "no" means only that the two do not share a key — not that both bells
+ * normally ring. `rejected` genuinely cannot follow `granted` (a rejected
+ * intent is never released), but `cancelled` CAN:
+ * `cancelActionIntent` transitions from `['pending_approval', 'approved']`
+ * (intentService.ts), so an approver can withdraw an intent that already rang
+ * a `granted` bell. `granted` -> `failed` and `granted` -> `cancelled` are
+ * therefore both real corrections that must survive the dedupe.
+ *
+ * Caveat worth knowing when reading this table: a cancel writes NO outbox row
+ * today, so this worker only ever OBSERVES `cancelled` on a late delivery of
+ * some other event (an `intent_expired` row processed after the cancel
+ * landed). Keeping `cancelled` in its own class is what makes that late
+ * delivery able to correct the record; it is not what makes a cancel notify.
  *
  * Every unknown status shares the one `update` key on purpose: they all render
  * the same "changed state" copy, so a second one is noise, not news.
@@ -1207,20 +1216,27 @@ async function loadRunAndAgent(runId: string): Promise<{
  * Repeating the SAME class always dedupes — that is what makes the intentional
  * duplicate delivery silent.
  */
+const OUTCOME_CLASS_BY_STATUS: Record<ActionIntentStatus, string> = {
+  // Not yet an outcome. Shares the catch-all key so the generic "changed
+  // state" copy can never ring twice.
+  pending_approval: 'update',
+  approved: 'granted',
+  executing: 'granted',
+  completed: 'granted',
+  failed: 'failed',
+  rejected: 'rejected',
+  cancelled: 'cancelled',
+  expired: 'expired',
+};
+
 function outcomeNotificationClass(status: string): string {
-  switch (status) {
-    case 'approved':
-    case 'executing':
-    case 'completed':
-      return 'granted';
-    case 'failed':
-    case 'rejected':
-    case 'cancelled':
-    case 'expired':
-      return status;
-    default:
-      return 'update';
-  }
+  // The Record is exhaustive over ActionIntentStatus ON PURPOSE: a 9th status
+  // added to the enum is a COMPILE error here until somebody decides whether
+  // it corrects an earlier bell or is the same outcome seen again. The runtime
+  // fallback is for a value the DB holds that the type does not (drift, or a
+  // rollback across a status-adding deploy) — not a substitute for that
+  // decision.
+  return OUTCOME_CLASS_BY_STATUS[status as ActionIntentStatus] ?? 'update';
 }
 
 /**

--- a/apps/api/src/jobs/intentReleaseWorker.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.ts
@@ -1166,6 +1166,64 @@ async function loadRunAndAgent(runId: string): Promise<{
 }
 
 /**
+ * The identity of an outcome notification, for dedupe purposes — deliberately
+ * NOT the raw status (#4465).
+ *
+ * One autonomy intent carries TWO outbox rows (`intent_created` and
+ * `intent_approved`, both written by `createActionIntent`), so
+ * `releaseAndNotify` runs twice for it by design — the second is a backstop
+ * for the first — and outbox delivery is at-least-once on top of that. The
+ * release itself is CAS-guarded and safely idempotent; this key is the only
+ * thing that makes the NOTIFICATION idempotent too. Keying it on
+ * `intent.status` broke that the moment the status advanced between the two
+ * reads (the CAS loser observes `approved` while the winner is still
+ * executing; the winner then observes `completed`), ringing the bell twice
+ * for one outcome.
+ *
+ * Collapsing to a class keeps the property the status key was protecting — a
+ * later, MATERIALLY DIFFERENT outcome must still be able to correct an earlier
+ * one — without paying a bell for each intermediate observation of the same
+ * one:
+ *
+ * | status          | class       | shares a key with `granted`? | why                                                             |
+ * |-----------------|-------------|------------------------------|-----------------------------------------------------------------|
+ * | approved        | `granted`   | —                            | approved; execution pending                                     |
+ * | executing       | `granted`   | yes (silent)                 | same outcome, later observation                                 |
+ * | completed       | `granted`   | yes (silent)                 | same outcome, settled as expected                               |
+ * | failed          | `failed`    | no (corrects it)             | approved but did NOT run — the earlier "is now running" was wrong |
+ * | rejected        | `rejected`  | no                           | terminal negative decision                                      |
+ * | cancelled       | `cancelled` | no                           | terminal, withdrawn                                             |
+ * | expired         | `expired`   | no                           | terminal, nobody decided                                        |
+ * | anything else   | `update`    | no                           | unknown/pending — say only what is certain, and never share a key with a real outcome |
+ *
+ * "no" means only that the two do not share a key. `rejected`/`cancelled`/
+ * `expired` are mutually exclusive with `granted` in practice (a rejected
+ * intent is never released), so the sequence that actually produces two bells
+ * is `granted` -> `failed`, which is exactly the correction that must survive.
+ *
+ * Every unknown status shares the one `update` key on purpose: they all render
+ * the same "changed state" copy, so a second one is noise, not news.
+ *
+ * Repeating the SAME class always dedupes — that is what makes the intentional
+ * duplicate delivery silent.
+ */
+function outcomeNotificationClass(status: string): string {
+  switch (status) {
+    case 'approved':
+    case 'executing':
+    case 'completed':
+      return 'granted';
+    case 'failed':
+    case 'rejected':
+    case 'cancelled':
+    case 'expired':
+      return status;
+    default:
+      return 'update';
+  }
+}
+
+/**
  * Same status switch the requester path uses below — the copy MUST derive
  * from the freshly re-read `intent.status`, never the outbox event (see the
  * long rationale in notifyRequesterOfOutcome) — but worded for a recipient
@@ -1267,9 +1325,12 @@ async function notifyRequesterOfOutcome(
             message: `${intent.requestingClientLabel ?? 'AI agent'}: ${message}`,
             link: '/approvals',
             metadata: { intentId: intent.id, agentId: agent.id, agentRunId: run.id, status: intent.status },
-            // Status-scoped: a later, MORE ACCURATE status (approved -> failed)
-            // must not be suppressed by the earlier notification's dedupe row.
-            dedupeKey: `agent-intent-outcome:${intent.id}:${intent.status}`,
+            // Outcome-CLASS scoped, never status-scoped (#4465): a later,
+            // materially different outcome (granted -> failed) must not be
+            // suppressed by the earlier notification's dedupe row, while a
+            // mere status advance between two deliveries of the SAME outcome
+            // must be. Truth table: outcomeNotificationClass.
+            dedupeKey: `agent-intent-outcome:${intent.id}:${outcomeNotificationClass(intent.status)}`,
           })));
     }
     return;
@@ -1341,10 +1402,13 @@ async function notifyRequesterOfOutcome(
       message: copy.message,
       link: '/approvals',
       metadata: { intentId: intent.id, outcome: eventType, status: intent.status },
-      // Scoped to the STATUS, not just the intent. A per-intent key meant that
-      // once a premature "is now running" had been written, the later truthful
-      // notification deduped to null and the person was never corrected.
-      dedupeKey: `intent-outcome:${intent.id}:${intent.status}`,
+      // Scoped to the outcome CLASS, not to the intent alone and not to the raw
+      // status (#4465). A per-intent key meant that once a premature "is now
+      // running" had been written, the later truthful notification deduped to
+      // null and the person was never corrected; a per-status key meant the two
+      // deliveries every autonomy intent gets rang the bell twice for one
+      // outcome. Truth table: outcomeNotificationClass.
+      dedupeKey: `intent-outcome:${intent.id}:${outcomeNotificationClass(intent.status)}`,
     }));
 }
 


### PR DESCRIPTION
## Problem

A ticket-autonomy intent carries **two** outbox rows — `createActionIntent` writes both `intent_created` and `intent_approved` for it (asserted at `apps/api/src/services/actionIntents/intentService.ticketAutonomy.test.ts:351`) — so `releaseAndNotify` runs **twice** for one intent by design; the second delivery is a backstop for the first. `releaseApprovedIntent` is CAS-guarded and safely idempotent, so the duplicate *release* is a no-op. The notification's dedupe key was the only thing making the duplicate *notification* a no-op too.

Keying it on the raw `intent.status` broke that the moment the status advanced between the two reads:

1. Job A wins the `approved -> executing` CAS and starts executing.
2. Job B loses it, returns immediately, reads `status = 'approved'` → writes `intent-outcome:<id>:approved` — "was approved and is now running".
3. Job A finishes, reads `status = 'completed'` → writes `intent-outcome:<id>:completed` — "was approved and has finished".

Two bells, one outcome. At-least-once outbox redelivery reproduces the same thing with no race at all.

## Fix

Key on the outcome **class**, not the raw status — `outcomeNotificationClass(status)`:

| status | class | shares a key with `granted`? | why |
|---|---|---|---|
| `approved` | `granted` | — | approved; execution pending |
| `executing` | `granted` | yes (silent) | same outcome, later observation |
| `completed` | `granted` | yes (silent) | same outcome, settled as expected |
| `failed` | `failed` | **no (corrects it)** | approved but did NOT run — the earlier "is now running" was wrong |
| `rejected` | `rejected` | no | terminal negative decision |
| `cancelled` | `cancelled` | no | terminal, withdrawn |
| `expired` | `expired` | no | terminal, nobody decided |
| anything else | `update` | no | unknown/pending — say only what is certain |

This keeps the property the status-scoped key was originally introduced to protect (a premature "is now running" must not suppress the later truthful "could not run") while dropping the bell for every *intermediate observation of the same outcome*. `rejected`/`cancelled`/`expired` are mutually exclusive with `granted` in practice, so the sequence that legitimately produces two bells is exactly `granted -> failed`.

Every unknown status shares the one `update` key on purpose: they all render the same "changed state" copy, so a second one is noise rather than news.

Both send sites move — the requester path (`intent-outcome:`) and the agent-recipient path (`agent-intent-outcome:`). The `rejected` / `cancelled` / `expired` / `failed` keys are **byte-identical** to before; only the granted trio changes shape.

### Deploy note (deliberate, not an oversight)

An intent that is mid-flight across the deploy and already has an `:approved` / `:executing` row can get one extra bell when it settles under the new `:granted` key. Approval intents are short-lived and the worst case is a single extra notification row, so the new namespace was preferred over reusing `approved` as the class name (which would have made the class segment read as a raw status).

## Tests

Red first — all 8 new assertions failed against the status-scoped key before the change.

The new block models the **real** partial unique index (`user_notifications_user_dedupe_key_uq` on `(user_id, dedupe_key)` WHERE `dedupe_key IS NOT NULL`) with a fake store rather than counting mock calls, so it asserts the number of notification **rows the requester actually ends up with**:

- two deliveries observing `approved`→`completed`, `approved`→`executing`, `executing`→`completed` → **exactly one** row, both calls carrying the same key;
- `approved` → `failed` → **two** rows, "Approval granted" then "Action failed";
- the same terminal outcome twice → one row;
- a status→key table over all eight statuses;
- both of the above repeated on the agent-recipient path.

Two pre-existing test titles/comments that described the key as "status-scoped" were updated to say "outcome class"; their assertions were already class-correct and are unchanged.

## Verification

- `cd apps/api && npx vitest run src/jobs/intentReleaseWorker` — **131 passed** (2 files), was 8 failed / 121 passed before the fix.
- `npx vitest run src/services/actionIntents src/services/userNotifications` — **517 passed** (26 files).
- `npx tsc --noEmit` — clean.
- `npx eslint` on both touched files — clean.

No schema, migration, RLS or cascade surface is touched.

Closes #4465

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBxF7C8E5GxFnNcGf6kBVP