### PR TITLE
fix(api): re-revoke UPDATE/DELETE/TRUNCATE on append-only tables missing from ensureAppRole (#4371)

### DIFF
--- a/apps/api/src/__tests__/integration/ensureAppRoleAppendOnlyPrivileges.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ensureAppRoleAppendOnlyPrivileges.integration.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Integration test for #4371: ensureAppRole()'s blanket per-boot GRANT
+ * (`GRANT SELECT, INSERT, UPDATE, DELETE, REFERENCES ON ALL TABLES IN SCHEMA
+ * public TO breeze_app`, step 4 of `src/db/ensureAppRole.ts`) silently
+ * re-permits whatever an append-only table's migration REVOKEd from
+ * breeze_app, unless step 5 re-applies that REVOKE after the blanket GRANT.
+ *
+ * `pam_actuation_results` shipped without a re-revoke block, so its
+ * `BEFORE UPDATE/DELETE` trigger was the *sole* enforcement in production —
+ * the privilege layer of the intended belt-and-suspenders pair never
+ * actually held. The sweep that fixed #4371 found five more tables with the
+ * same gap: ml_feedback_events, peripheral_policy_delivery_events,
+ * agent_rollback_events, automation_action_results, and
+ * device_software_inventory_state.
+ *
+ * `ensureAppRole.appendOnlyCoverage.test.ts` (unit, static analysis) proves
+ * the *source* stays in sync going forward. This test proves the actual
+ * *runtime effect*: that breeze_app really lacks these privileges against a
+ * real Postgres server, after the test setup's autoMigrate -> ensureAppRole
+ * boot sequence has run — mirroring the existing audit_logs privilege check
+ * in `audit-append-only.integration.test.ts`.
+ */
+import './setup';
+import { describe, it, expect } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { db } from '../../db';
+
+interface PrivilegeRow {
+  can_select: boolean;
+  can_insert: boolean;
+  can_update: boolean;
+  can_delete: boolean;
+  can_truncate: boolean;
+}
+
+async function tablePrivileges(table: string): Promise<PrivilegeRow> {
+  // `table` is always one of this file's own hardcoded test parameters
+  // (never external input) — passed as an ordinary bound `text` parameter
+  // to has_table_privilege(), not spliced into the SQL syntax, so no
+  // sql.raw() / identifier-quoting is needed here.
+  const rows = (await db.execute(sql`
+    SELECT
+      has_table_privilege('breeze_app', ${table}, 'SELECT') AS can_select,
+      has_table_privilege('breeze_app', ${table}, 'INSERT') AS can_insert,
+      has_table_privilege('breeze_app', ${table}, 'UPDATE') AS can_update,
+      has_table_privilege('breeze_app', ${table}, 'DELETE') AS can_delete,
+      has_table_privilege('breeze_app', ${table}, 'TRUNCATE') AS can_truncate
+  `)) as unknown as Array<PrivilegeRow>;
+  return rows[0]!;
+}
+
+describe('ensureAppRole append-only re-revoke — runtime privilege check (#4371)', () => {
+  // Tables where the migration revokes the FULL append-only set
+  // (UPDATE, DELETE, TRUNCATE) and breeze_app keeps only SELECT/INSERT.
+  it.each([
+    'pam_actuation_results',
+    'agent_rollback_events',
+  ])('breeze_app has no UPDATE, DELETE, or TRUNCATE on %s after ensureAppRole runs', async (table) => {
+    const p = await tablePrivileges(table);
+    expect(p.can_update).toBe(false);
+    expect(p.can_delete).toBe(false);
+    expect(p.can_truncate).toBe(false);
+    expect(p.can_insert).toBe(true);
+    expect(p.can_select).toBe(true);
+  });
+
+  // ml_feedback_events: migration only revokes UPDATE, DELETE (no INSERT
+  // of TRUNCATE to begin with), but ensureAppRole.ts also re-revokes
+  // TRUNCATE as defense-in-depth, consistent with the file's established
+  // pattern elsewhere (audit_logs, agent_health_observations).
+  it('breeze_app has no UPDATE, DELETE, or TRUNCATE on ml_feedback_events after ensureAppRole runs', async () => {
+    const p = await tablePrivileges('ml_feedback_events');
+    expect(p.can_update).toBe(false);
+    expect(p.can_delete).toBe(false);
+    expect(p.can_truncate).toBe(false);
+    expect(p.can_insert).toBe(true);
+    expect(p.can_select).toBe(true);
+  });
+
+  // peripheral_policy_delivery_events intentionally KEEPS UPDATE granted
+  // (delivery status transitions are ordinary app writes) — only DELETE and
+  // TRUNCATE are revoked.
+  it('breeze_app keeps UPDATE but has no DELETE or TRUNCATE on peripheral_policy_delivery_events', async () => {
+    const p = await tablePrivileges('peripheral_policy_delivery_events');
+    expect(p.can_update).toBe(true);
+    expect(p.can_delete).toBe(false);
+    expect(p.can_truncate).toBe(false);
+    expect(p.can_insert).toBe(true);
+    expect(p.can_select).toBe(true);
+  });
+
+  // automation_action_results and device_software_inventory_state
+  // intentionally KEEP UPDATE and DELETE granted (ordinary mutable state) —
+  // only TRUNCATE is revoked.
+  it.each(['automation_action_results', 'device_software_inventory_state'])(
+    'breeze_app keeps UPDATE/DELETE but has no TRUNCATE on %s',
+    async (table) => {
+      const p = await tablePrivileges(table);
+      expect(p.can_update).toBe(true);
+      expect(p.can_delete).toBe(true);
+      expect(p.can_truncate).toBe(false);
+      expect(p.can_insert).toBe(true);
+      expect(p.can_select).toBe(true);
+    },
+  );
+});

--- a/apps/api/src/__tests__/integration/orgMergeRegistry.integration.test.ts
+++ b/apps/api/src/__tests__/integration/orgMergeRegistry.integration.test.ts
@@ -298,17 +298,25 @@ describe('Org merge policy registry contract', () => {
     expect(extra).toEqual([]);
   });
 
-  it('organizations is loser-shell; the four append-only tables are leave-for-erasure', () => {
+  it('organizations is loser-shell; the five append-only tables are leave-for-erasure', () => {
     expect(policies.get('organizations')).toEqual({ kind: 'loser-shell' });
-    for (const t of ['audit_logs', 'audit_log_chain', 'audit_chain_anchors', 'ml_feedback_events']) {
+    // agent_rollback_events joined this list in the #4371 fixup: breeze_app
+    // has no UPDATE on it (same privilege topology as ml_feedback_events),
+    // so it can never be a live 'repoint' target — see the SPECIAL entry's
+    // note in orgMergeRegistry.ts for the full history.
+    for (const t of ['audit_logs', 'audit_log_chain', 'audit_chain_anchors', 'ml_feedback_events', 'agent_rollback_events']) {
       expect(policies.get(t)?.kind, t).toBe('leave-for-erasure');
     }
   });
 
   it('repoints Track D device-control state and evidence with the device owner', () => {
+    // agent_rollback_events is deliberately NOT in this list (#4371 fixup):
+    // breeze_app has UPDATE revoked on it, so it can't be repointed by the
+    // merge — it's asserted 'leave-for-erasure' above instead.
+    // agent_rollback_directives keeps its own separate 'repoint' policy;
+    // its evidence table just doesn't follow along anymore.
     for (const table of [
       'agent_rollback_directives',
-      'agent_rollback_events',
       'peripheral_policy_delivery_events',
       'peripheral_policy_device_states',
     ]) {

--- a/apps/api/src/db/ensureAppRole.appendOnlyCoverage.test.ts
+++ b/apps/api/src/db/ensureAppRole.appendOnlyCoverage.test.ts
@@ -26,8 +26,18 @@ const ensureAppRolePath = path.resolve(__dirname, './ensureAppRole.ts');
 // Table-level REVOKE ... FROM breeze_app in a migration. Deliberately
 // excludes REVOKE ... ON FUNCTION / SEQUENCE / DATABASE / SCHEMA / ALL —
 // those aren't the blanket-GRANT-on-ALL-TABLES hazard this test guards.
+//
+// Two deliberate tolerances (both exercised by regression cases below):
+// - `[A-Z,\s]+?` (not `[A-Z, ]+?`) so a privilege list wrapped across lines
+//   still matches.
+// - `['"]?` before the terminating `;` so a REVOKE embedded verbatim inside
+//   a `DO $$ ... EXECUTE 'REVOKE ... FROM breeze_app;' ... END $$` dynamic-SQL
+//   string (whose closing quote sits between `breeze_app` and `;`) still
+//   matches. This does NOT resolve a *templated* table name built via
+//   `format('... %I ...', tbl)` — that requires reading the migration by
+//   eye; there is no such case in the migrations directory today.
 const MIGRATION_REVOKE_RE =
-  /REVOKE\s+([A-Z, ]+?)\s+ON\s+(?:TABLE\s+)?(?!FUNCTION\b|SEQUENCE\b|DATABASE\b|SCHEMA\b|ALL\b)(?:public\.)?([a-z][a-z0-9_]*)\s+FROM\s+breeze_app\s*;/gi;
+  /REVOKE\s+([A-Z,\s]+?)\s+ON\s+(?:TABLE\s+)?(?!FUNCTION\b|SEQUENCE\b|DATABASE\b|SCHEMA\b|ALL\b)(?:public\.)?([a-z][a-z0-9_]*)\s+FROM\s+breeze_app\s*['"]?\s*;/gi;
 
 function parsePrivs(rawPrivList: string): Set<string> {
   return new Set(
@@ -80,7 +90,7 @@ function collectEnsureAppRoleRevokes(): Map<string, Set<string>> {
     const block = src.slice(blockStart, blockEnd);
 
     const revokeRe = new RegExp(
-      `REVOKE\\s+([A-Z, ]+?)\\s+ON\\s+TABLE\\s+${table}\\s+FROM\\s+breeze_app`,
+      `REVOKE\\s+([A-Z,\\s]+?)\\s+ON\\s+TABLE\\s+${table}\\s+FROM\\s+breeze_app`,
       'gi',
     );
     const privs = revokes.get(table) ?? new Set<string>();

--- a/apps/api/src/db/ensureAppRole.appendOnlyCoverage.test.ts
+++ b/apps/api/src/db/ensureAppRole.appendOnlyCoverage.test.ts
@@ -125,4 +125,60 @@ describe('ensureAppRole append-only re-revoke coverage (#4371)', () => {
       ).toEqual([]);
     },
   );
+
+  // #4371 writer-path matrix — the executable half of the doc comment above
+  // ensureAppRole.ts's six #4371 re-revoke blocks. Closing the original
+  // privilege gap wasn't enough on its own: every legitimate writer of these
+  // tables (device permanent-delete, device org-move, org merge, org
+  // erasure) had to keep working under the now-real privilege wall too —
+  // see deviceDeletion.ts's DEVICE_CASCADE_AUDIT_ADMIN_TABLES,
+  // routes/devices/core.ts's DEVICE_ORG_FK_CASCADE_TABLES, and
+  // orgMergeRegistry.ts's per-table classification for how each was
+  // reconciled. This asserts EXACT equality (not just "at least"), unlike
+  // the superset check above, so a future PR can't silently OVER-tighten
+  // one of these six and reopen a writer-path conflict the same way #4371's
+  // own fix did for agent_rollback_events/pam_actuation_results — a
+  // narrower re-revoke here should force a conscious update to this table,
+  // not a silent green.
+  //
+  // 'kept' lists privileges intentionally left granted; the reason lives in
+  // ensureAppRole.ts's matrix comment, not duplicated here. A table with an
+  // empty 'kept' array is fully privilege-walled — no app path ever needs
+  // breeze_app to hold UPDATE/DELETE/TRUNCATE on it.
+  const WRITER_PATH_MATRIX: ReadonlyArray<{ table: string; revoked: string[]; kept: string[] }> = [
+    { table: 'pam_actuation_results', revoked: ['UPDATE', 'DELETE', 'TRUNCATE'], kept: [] },
+    { table: 'agent_rollback_events', revoked: ['UPDATE', 'DELETE', 'TRUNCATE'], kept: [] },
+    { table: 'ml_feedback_events', revoked: ['UPDATE', 'DELETE', 'TRUNCATE'], kept: [] },
+    // peripheral_policy_delivery_events keeps UPDATE — residual gap tracked
+    // as issue #4806 (moveOrg.ts's restamp loop still needs it).
+    { table: 'peripheral_policy_delivery_events', revoked: ['DELETE', 'TRUNCATE'], kept: ['UPDATE'] },
+    { table: 'automation_action_results', revoked: ['TRUNCATE'], kept: ['UPDATE', 'DELETE'] },
+    { table: 'device_software_inventory_state', revoked: ['TRUNCATE'], kept: ['UPDATE', 'DELETE'] },
+  ];
+
+  it.each(WRITER_PATH_MATRIX)(
+    'ensureAppRole.ts revokes EXACTLY [$revoked] (not more, not less) on $table',
+    ({ table, revoked }) => {
+      const ensurePrivs = [...(ensureAppRoleRevokes.get(table) ?? new Set<string>())].sort();
+      expect(
+        ensurePrivs,
+        `ensureAppRole.ts's re-revoke for '${table}' no longer matches the documented writer-path ` +
+          `matrix (ensureAppRole.ts's #4371 comment block and this file's WRITER_PATH_MATRIX). If this ` +
+          `is a deliberate change, update BOTH the matrix here and the doc comment there — a narrower ` +
+          `revoke can silently reopen a writer-path conflict (see DEVICE_CASCADE_AUDIT_ADMIN_TABLES / ` +
+          `DEVICE_ORG_FK_CASCADE_TABLES / orgMergeRegistry.ts), and a broader one needs the same writer-path ` +
+          `audit #4371 did before it ships.`,
+      ).toEqual([...revoked].sort());
+    },
+  );
+
+  it('WRITER_PATH_MATRIX accounts for exactly the tables ensureAppRole.ts revokes something from breeze_app for beyond the pre-#4371 baseline', () => {
+    // Sanity check that the matrix itself hasn't drifted from ensureAppRole.ts:
+    // every table the matrix names must actually appear in the source with a
+    // re-revoke block (guards against a stale/renamed table silently making
+    // the it.each above a vacuous no-op).
+    for (const { table } of WRITER_PATH_MATRIX) {
+      expect(ensureAppRoleRevokes.has(table), `ensureAppRole.ts has no re-revoke block for '${table}'`).toBe(true);
+    }
+  });
 });

--- a/apps/api/src/db/ensureAppRole.appendOnlyCoverage.test.ts
+++ b/apps/api/src/db/ensureAppRole.appendOnlyCoverage.test.ts
@@ -1,0 +1,118 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// Static-analysis contract test for #4371: ensureAppRole()'s blanket
+// `GRANT ... UPDATE, DELETE, REFERENCES ON ALL TABLES` (step 4) re-permits
+// whatever an append-only table's migration REVOKEd from breeze_app, on
+// every boot — the migration-time REVOKE is real at apply time but is
+// silently undone the moment the API restarts. Step 5 of ensureAppRole.ts
+// exists specifically to re-apply those per-table REVOKEs after the blanket
+// GRANT, but nothing enforced that every table which revokes a privilege
+// from breeze_app in a migration actually has a matching re-revoke block —
+// pam_actuation_results shipped without one (#4371), and this test found
+// five more tables with the same gap.
+//
+// This reads both sources of truth statically (no DB needed, runs in the
+// unit job): every `REVOKE <privs> ON [TABLE] <table> FROM breeze_app`
+// statement across apps/api/migrations/*.sql, and every per-table re-revoke
+// block in ensureAppRole.ts (keyed off `table_name='<table>'`). For every
+// table+privilege a migration revoked from breeze_app, ensureAppRole.ts must
+// revoke at least that privilege back on every boot.
+
+const migrationsDir = path.resolve(__dirname, '../../migrations');
+const ensureAppRolePath = path.resolve(__dirname, './ensureAppRole.ts');
+
+// Table-level REVOKE ... FROM breeze_app in a migration. Deliberately
+// excludes REVOKE ... ON FUNCTION / SEQUENCE / DATABASE / SCHEMA / ALL —
+// those aren't the blanket-GRANT-on-ALL-TABLES hazard this test guards.
+const MIGRATION_REVOKE_RE =
+  /REVOKE\s+([A-Z, ]+?)\s+ON\s+(?:TABLE\s+)?(?!FUNCTION\b|SEQUENCE\b|DATABASE\b|SCHEMA\b|ALL\b)(?:public\.)?([a-z][a-z0-9_]*)\s+FROM\s+breeze_app\s*;/gi;
+
+function parsePrivs(rawPrivList: string): Set<string> {
+  return new Set(
+    rawPrivList
+      .split(',')
+      .map((p) => p.trim().toUpperCase())
+      .filter(Boolean),
+  );
+}
+
+/** Every table+privilege set REVOKEd from breeze_app across all migrations. */
+function collectMigrationRevokes(): Map<string, Set<string>> {
+  const revokes = new Map<string, Set<string>>();
+  const files = fs.readdirSync(migrationsDir).filter((f) => f.endsWith('.sql'));
+
+  for (const file of files) {
+    const text = fs.readFileSync(path.join(migrationsDir, file), 'utf8');
+    for (const match of text.matchAll(MIGRATION_REVOKE_RE)) {
+      // Both groups are mandatory captures in MIGRATION_REVOKE_RE — a
+      // successful match always populates them.
+      const table = match[2]!.toLowerCase();
+      const privs = parsePrivs(match[1]!);
+      const existing = revokes.get(table) ?? new Set<string>();
+      for (const p of privs) existing.add(p);
+      revokes.set(table, existing);
+    }
+  }
+  return revokes;
+}
+
+/**
+ * Every table+privilege set ensureAppRole.ts re-revokes from breeze_app,
+ * keyed off the `table_name='<table>'` existence-check idiom the file uses
+ * for every per-table override block (see step 5's `DO $$ ... END $$`).
+ */
+function collectEnsureAppRoleRevokes(): Map<string, Set<string>> {
+  const src = fs.readFileSync(ensureAppRolePath, 'utf8');
+  const tableNameRe = /table_name='([a-z_][a-z0-9_]*)'/g;
+  const anchors = [...src.matchAll(tableNameRe)];
+
+  const revokes = new Map<string, Set<string>>();
+  for (let i = 0; i < anchors.length; i++) {
+    const anchor = anchors[i]!;
+    // Group 1 is a mandatory capture in tableNameRe — a successful match
+    // always populates it.
+    const table = anchor[1]!;
+    const blockStart = anchor.index ?? 0;
+    const nextAnchor = anchors[i + 1];
+    const blockEnd = nextAnchor ? (nextAnchor.index ?? src.length) : src.length;
+    const block = src.slice(blockStart, blockEnd);
+
+    const revokeRe = new RegExp(
+      `REVOKE\\s+([A-Z, ]+?)\\s+ON\\s+TABLE\\s+${table}\\s+FROM\\s+breeze_app`,
+      'gi',
+    );
+    const privs = revokes.get(table) ?? new Set<string>();
+    for (const match of block.matchAll(revokeRe)) {
+      for (const p of parsePrivs(match[1]!)) privs.add(p);
+    }
+    revokes.set(table, privs);
+  }
+  return revokes;
+}
+
+describe('ensureAppRole append-only re-revoke coverage (#4371)', () => {
+  const migrationRevokes = collectMigrationRevokes();
+  const ensureAppRoleRevokes = collectEnsureAppRoleRevokes();
+
+  it('found at least one append-only REVOKE in migrations (sanity check that parsing works)', () => {
+    expect(migrationRevokes.size).toBeGreaterThan(0);
+    expect(migrationRevokes.has('audit_logs')).toBe(true);
+  });
+
+  it.each([...migrationRevokes.entries()].sort(([a], [b]) => a.localeCompare(b)))(
+    'ensureAppRole.ts re-revokes every privilege %s revoked from breeze_app in a migration (found: %s)',
+    (table, migrationPrivs) => {
+      const ensurePrivs = ensureAppRoleRevokes.get(table) ?? new Set<string>();
+      const missing = [...migrationPrivs].filter((p) => !ensurePrivs.has(p));
+      expect(
+        missing,
+        `ensureAppRole.ts is missing a re-revoke of [${missing.join(', ')}] on ` +
+          `'${table}' — the blanket GRANT in step 4 re-permits it on every boot. ` +
+          `Add an "IF EXISTS (... table_name='${table}') THEN REVOKE ${[...migrationPrivs].join(', ')} ON TABLE ${table} FROM breeze_app; END IF;" ` +
+          `block following the pattern at ensureAppRole.ts's step 5.`,
+      ).toEqual([]);
+    },
+  );
+});

--- a/apps/api/src/db/ensureAppRole.ts
+++ b/apps/api/src/db/ensureAppRole.ts
@@ -189,53 +189,118 @@ export async function ensureAppRole(): Promise<boolean> {
         IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='llm_egress_events') THEN
           REVOKE UPDATE, TRUNCATE ON TABLE llm_egress_events FROM breeze_app;
         END IF;
-        -- #4371: ml_feedback_events is append-only from breeze_app's
-        -- perspective (migration 2026-06-18-ml-feedback-events.sql). The
-        -- migration REVOKEs UPDATE, DELETE, but the blanket GRANT in step 4
-        -- re-permits both on every boot — re-revoke here so the restriction
-        -- actually sticks. Tenant erasure deletes through breeze_audit_admin
-        -- (see AUDIT_ADMIN_REQUIRED_TABLES in tenantCascade.ts), not breeze_app.
+        -- #4371 — WRITER-PATH MATRIX for the six tables re-revoked below.
+        --
+        -- The original bug: pam_actuation_results shipped a migration REVOKE
+        -- with no matching re-revoke here, so the blanket GRANT in step 4
+        -- silently restored it every boot. Closing that gap is not enough on
+        -- its own: every LEGITIMATE writer of these tables (device permanent-
+        -- delete, device org-move, org merge, org erasure) also has to keep
+        -- working under the now-real privilege wall, or the fix just trades
+        -- one bug for a different one. Below is the audit — table, what
+        -- breeze_app keeps vs loses, and how each writer path copes:
+        --
+        --  pam_actuation_results   UPDATE/DELETE/TRUNCATE all revoked (full
+        --                          append-only). Device delete: DELETE
+        --                          routes through breeze_audit_admin +
+        --                          breeze.allow_audit_retention='1'
+        --                          (DEVICE_CASCADE_AUDIT_ADMIN_TABLES,
+        --                          deviceDeletion.ts). Device org-move:
+        --                          N/A — a device with PAM history cannot
+        --                          move orgs at all (devices_pam_history_
+        --                          move_guard / PamDeviceMoveBlockedError;
+        --                          also excluded from the generic org_id
+        --                          cascade discovery, migrations/2026-09-17-
+        --                          pam-device-move-guard.sql). Org merge:
+        --                          'blocks-merge' (orgMergeRegistry.ts) — a
+        --                          loser org holding any row refuses the
+        --                          merge outright. Org erasure: breeze_
+        --                          audit_admin (AUDIT_ADMIN_REQUIRED_TABLES,
+        --                          tenantCascade.ts). No app path ever needs
+        --                          breeze_app UPDATE/DELETE — full
+        --                          privilege-wall protection.
+        --
+        --  agent_rollback_events   UPDATE/DELETE/TRUNCATE all revoked (full
+        --                          append-only). Device delete: same
+        --                          breeze_audit_admin escalation as above.
+        --                          Device org-move: restamped by the
+        --                          SECURITY DEFINER breeze_cascade_device_
+        --                          org_id() trigger (migrations/2026-05-18-
+        --                          device-child-orgid-cascade.sql), not an
+        --                          app-role UPDATE — DEVICE_ORG_FK_CASCADE_
+        --                          TABLES in routes/devices/core.ts skips
+        --                          the redundant app-level statement. Org
+        --                          merge: 'leave-for-erasure' (orgMerge
+        --                          Registry.ts) — no role can ever UPDATE
+        --                          it, so a repoint was never valid. Org
+        --                          erasure: breeze_audit_admin. Full
+        --                          privilege-wall protection.
+        --
+        --  ml_feedback_events      UPDATE/DELETE revoked (TRUNCATE too, as
+        --                          defense-in-depth — see the audit_logs/
+        --                          agent_health_observations pattern above).
+        --                          No device_id column, so neither device
+        --                          delete nor device org-move ever touch it.
+        --                          Org merge: 'leave-for-erasure'. Org
+        --                          erasure: breeze_audit_admin. Full
+        --                          privilege-wall protection.
+        --
+        --  peripheral_policy_      DELETE/TRUNCATE revoked; UPDATE STAYS
+        --  delivery_events         GRANTED. Device org-move's app-level
+        --                          restamp loop (getDeviceOrgDenormalizedTables,
+        --                          moveOrg.ts) issues a real breeze_app
+        --                          UPDATE against this table, and the
+        --                          append-only trigger's own column-diff +
+        --                          devices-EXISTS check (not a privilege
+        --                          wall) is what limits it to an org-only
+        --                          restamp. Device delete: DELETE routes
+        --                          through breeze_audit_admin (same
+        --                          escalation set as above). Org merge:
+        --                          plain 'repoint' (UPDATE, granted, no
+        --                          conflict). Org erasure: breeze_audit_admin.
+        --                          RESIDUAL GAP: this table's append-only
+        --                          guarantee depends on the trigger alone,
+        --                          not privilege — tracked as issue #4806.
+        --
+        --  automation_action_      Only TRUNCATE revoked; UPDATE/DELETE stay
+        --  results                 granted. NOT an append-only table by
+        --                          design (no append-only trigger exists for
+        --                          it at all) — TRUNCATE-only was always a
+        --                          defense-in-depth bulk-wipe guard, not part
+        --                          of an append-only contract. No writer path
+        --                          needs TRUNCATE (grep confirms no app code
+        --                          issues one), so nothing to reconcile.
+        --
+        --  device_software_        Only TRUNCATE revoked; UPDATE/DELETE stay
+        --  inventory_state         granted. Same as automation_action_results:
+        --                          genuinely mutable current-device-state
+        --                          (unlike its append-only sibling
+        --                          software_inventory_observations above),
+        --                          no append-only trigger, no writer path
+        --                          needs TRUNCATE.
+        --
+        -- Verified against real Postgres: apps/api/src/__tests__/integration/
+        -- ensureAppRoleAppendOnlyPrivileges.integration.test.ts (privilege
+        -- shape) plus the specific writer-path suites (pamActuationLifecycle,
+        -- quickSupportChain, deviceDeleteDiscoveredAssetLink, agentRunMove
+        -- Semantics, deviceMoveOrgCurrency, orgMergeRegistry, ticketDraftsRls,
+        -- inboundEmailContactRequester).
         IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='ml_feedback_events') THEN
           REVOKE UPDATE, DELETE, TRUNCATE ON TABLE ml_feedback_events FROM breeze_app;
         END IF;
-        -- #4371: peripheral_policy_delivery_events keeps UPDATE granted
-        -- intentionally (delivery status transitions), but the migration
-        -- (2026-09-11-peripheral-effective-policy-v2.sql) REVOKEs DELETE and
-        -- TRUNCATE from breeze_app — re-revoke both here so the blanket GRANT
-        -- in step 4 doesn't silently restore them on every boot.
         IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='peripheral_policy_delivery_events') THEN
           REVOKE DELETE, TRUNCATE ON TABLE peripheral_policy_delivery_events FROM breeze_app;
         END IF;
-        -- #4371: agent_rollback_events is append-only evidence (migration
-        -- 2026-09-13-agent-rollback-lifecycle.sql REVOKEs UPDATE, DELETE,
-        -- TRUNCATE from breeze_app). Same re-revoke pattern as the other
-        -- append-only evidence tables above.
         IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='agent_rollback_events') THEN
           REVOKE UPDATE, DELETE, TRUNCATE ON TABLE agent_rollback_events FROM breeze_app;
         END IF;
-        -- #4371: pam_actuation_results is append-only evidence enforced by a
-        -- BEFORE UPDATE/DELETE trigger (migration
-        -- 2026-09-16-pam-actuation-lifecycle.sql REVOKEs UPDATE, DELETE,
-        -- TRUNCATE from breeze_app). The trigger has been the sole
-        -- enforcement in production because this re-revoke was missing —
-        -- the privilege layer of the belt-and-suspenders pair now actually
-        -- holds.
         IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='pam_actuation_results') THEN
           REVOKE UPDATE, DELETE, TRUNCATE ON TABLE pam_actuation_results FROM breeze_app;
         END IF;
-        -- #4371: automation_action_results keeps UPDATE/DELETE granted
-        -- intentionally, but the migration
-        -- (2026-09-28-100001-automation-action-results.sql) REVOKEs TRUNCATE
-        -- from breeze_app (and PUBLIC) — re-revoke it here too.
         IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='automation_action_results') THEN
           REVOKE TRUNCATE ON TABLE automation_action_results FROM breeze_app;
           REVOKE TRUNCATE ON TABLE automation_action_results FROM PUBLIC;
         END IF;
-        -- #4371: device_software_inventory_state keeps UPDATE/DELETE granted
-        -- intentionally (it's mutable device state, unlike the append-only
-        -- software_inventory_observations above), but the migration
-        -- (2026-09-28-100002-software-inventory-observations.sql) REVOKEs
-        -- TRUNCATE from breeze_app (and PUBLIC) — re-revoke it here too.
         IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='device_software_inventory_state') THEN
           REVOKE TRUNCATE ON TABLE device_software_inventory_state FROM breeze_app;
           REVOKE TRUNCATE ON TABLE device_software_inventory_state FROM PUBLIC;

--- a/apps/api/src/db/ensureAppRole.ts
+++ b/apps/api/src/db/ensureAppRole.ts
@@ -189,6 +189,57 @@ export async function ensureAppRole(): Promise<boolean> {
         IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='llm_egress_events') THEN
           REVOKE UPDATE, TRUNCATE ON TABLE llm_egress_events FROM breeze_app;
         END IF;
+        -- #4371: ml_feedback_events is append-only from breeze_app's
+        -- perspective (migration 2026-06-18-ml-feedback-events.sql). The
+        -- migration REVOKEs UPDATE, DELETE, but the blanket GRANT in step 4
+        -- re-permits both on every boot — re-revoke here so the restriction
+        -- actually sticks. Tenant erasure deletes through breeze_audit_admin
+        -- (see AUDIT_ADMIN_REQUIRED_TABLES in tenantCascade.ts), not breeze_app.
+        IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='ml_feedback_events') THEN
+          REVOKE UPDATE, DELETE, TRUNCATE ON TABLE ml_feedback_events FROM breeze_app;
+        END IF;
+        -- #4371: peripheral_policy_delivery_events keeps UPDATE granted
+        -- intentionally (delivery status transitions), but the migration
+        -- (2026-09-11-peripheral-effective-policy-v2.sql) REVOKEs DELETE and
+        -- TRUNCATE from breeze_app — re-revoke both here so the blanket GRANT
+        -- in step 4 doesn't silently restore them on every boot.
+        IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='peripheral_policy_delivery_events') THEN
+          REVOKE DELETE, TRUNCATE ON TABLE peripheral_policy_delivery_events FROM breeze_app;
+        END IF;
+        -- #4371: agent_rollback_events is append-only evidence (migration
+        -- 2026-09-13-agent-rollback-lifecycle.sql REVOKEs UPDATE, DELETE,
+        -- TRUNCATE from breeze_app). Same re-revoke pattern as the other
+        -- append-only evidence tables above.
+        IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='agent_rollback_events') THEN
+          REVOKE UPDATE, DELETE, TRUNCATE ON TABLE agent_rollback_events FROM breeze_app;
+        END IF;
+        -- #4371: pam_actuation_results is append-only evidence enforced by a
+        -- BEFORE UPDATE/DELETE trigger (migration
+        -- 2026-09-16-pam-actuation-lifecycle.sql REVOKEs UPDATE, DELETE,
+        -- TRUNCATE from breeze_app). The trigger has been the sole
+        -- enforcement in production because this re-revoke was missing —
+        -- the privilege layer of the belt-and-suspenders pair now actually
+        -- holds.
+        IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='pam_actuation_results') THEN
+          REVOKE UPDATE, DELETE, TRUNCATE ON TABLE pam_actuation_results FROM breeze_app;
+        END IF;
+        -- #4371: automation_action_results keeps UPDATE/DELETE granted
+        -- intentionally, but the migration
+        -- (2026-09-28-100001-automation-action-results.sql) REVOKEs TRUNCATE
+        -- from breeze_app (and PUBLIC) — re-revoke it here too.
+        IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='automation_action_results') THEN
+          REVOKE TRUNCATE ON TABLE automation_action_results FROM breeze_app;
+          REVOKE TRUNCATE ON TABLE automation_action_results FROM PUBLIC;
+        END IF;
+        -- #4371: device_software_inventory_state keeps UPDATE/DELETE granted
+        -- intentionally (it's mutable device state, unlike the append-only
+        -- software_inventory_observations above), but the migration
+        -- (2026-09-28-100002-software-inventory-observations.sql) REVOKEs
+        -- TRUNCATE from breeze_app (and PUBLIC) — re-revoke it here too.
+        IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='device_software_inventory_state') THEN
+          REVOKE TRUNCATE ON TABLE device_software_inventory_state FROM breeze_app;
+          REVOKE TRUNCATE ON TABLE device_software_inventory_state FROM PUBLIC;
+        END IF;
       END $$;
     `);
 

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -245,15 +245,42 @@ const CORE_DEVICE_ORG_DENORMALIZED_TABLES = [
 ] as const;
 
 /**
- * Registered device/org tables whose org stamp is propagated by a composite
- * foreign key on `devices(id, org_id)`. They remain in the complete registry
- * above, but move-org must not issue its ordinary app-role UPDATE against
- * them. In particular, health observations revoke UPDATE from `breeze_app` so
- * immutable evidence can only be restamped by PostgreSQL's referential action.
+ * Registered device/org tables whose org stamp is propagated by some OTHER
+ * privileged mechanism, so move-org must NOT also issue its ordinary
+ * app-role UPDATE against them (breeze_app lacks UPDATE on some of these,
+ * and for the rest it would just be redundant with what already ran).
+ *
+ * Two different mechanisms populate this list:
+ *  - `agent_health_observations` / `software_inventory_observations`: a
+ *    composite FK on `devices(id, org_id)` declared `ON UPDATE CASCADE`, so
+ *    PostgreSQL's own referential action restamps them the instant the
+ *    `devices` row's org_id changes (line ~234's `.update(devices)` above)
+ *    — immutable evidence can only be restamped this way, never by a
+ *    direct app-role UPDATE.
+ *  - `agent_rollback_events` (#4371 fixup): breeze_app has UPDATE revoked
+ *    entirely (see ensureAppRole.ts's writer-path matrix), so restamping it
+ *    the ordinary way here would 42501. It does NOT have its own `ON
+ *    UPDATE CASCADE` FK (only `ON DELETE CASCADE` — ON UPDATE defaults to
+ *    NO ACTION, so it must actually be re-tenanted, not just left alone).
+ *    That happens via `breeze_cascade_device_org_id()` (migrations/
+ *    2026-05-18-device-child-orgid-cascade.sql) instead: a SECURITY
+ *    DEFINER trigger on `devices` (AFTER UPDATE OF org_id) that discovers
+ *    every ordinary table with both a uuid `device_id` and `org_id` column
+ *    and restamps it under the function owner's privileges, bypassing
+ *    breeze_app's revoke the same way FK actions do. It fires as a row
+ *    trigger on the SAME `.update(devices)` statement above, so by the
+ *    time this loop runs, agent_rollback_events.org_id is already correct
+ *    — verified against real Postgres:
+ *    `SELECT * FROM breeze_device_child_orgid_tables()` includes it.
+ *    (`pam_actuation_results` is deliberately EXCLUDED from that same
+ *    discovery function — migrations/2026-09-17-pam-device-move-guard.sql
+ *    — because a device with PAM history cannot move orgs at all; see
+ *    devices_pam_history_move_guard / PamDeviceMoveBlockedError below.)
  */
 export const DEVICE_ORG_FK_CASCADE_TABLES: readonly string[] = [
   'agent_health_observations',
   'software_inventory_observations',
+  'agent_rollback_events',
 ];
 
 export function getDeviceOrgDenormalizedTables(): readonly string[] {

--- a/apps/api/src/routes/devices/moveOrg.coverage.test.ts
+++ b/apps/api/src/routes/devices/moveOrg.coverage.test.ts
@@ -160,9 +160,14 @@ describe('getDeviceOrgDenormalizedTables() coverage', () => {
   });
 
   it('keeps database-cascade restamps registered in the complete org-denormalized contract', () => {
+    // agent_rollback_events (#4371 fixup): breeze_app has UPDATE revoked
+    // entirely, so its restamp runs via the SECURITY DEFINER
+    // breeze_cascade_device_org_id() trigger instead of an ON UPDATE CASCADE
+    // FK — see the DEVICE_ORG_FK_CASCADE_TABLES doc comment in core.ts.
     expect(DEVICE_ORG_FK_CASCADE_TABLES).toEqual([
       'agent_health_observations',
       'software_inventory_observations',
+      'agent_rollback_events',
     ]);
     expect(deviceOrgDenormalizedTables).toEqual(
       expect.arrayContaining([...DEVICE_ORG_FK_CASCADE_TABLES]),

--- a/apps/api/src/routes/devices/moveOrg.test.ts
+++ b/apps/api/src/routes/devices/moveOrg.test.ts
@@ -385,9 +385,13 @@ describe('POST /devices/:id/move-org', () => {
         ...DEVICE_SITE_DENORMALIZED_TABLES,
       ]);
       expect(getDeviceOrgDenormalizedTables()).toContain('agent_health_observations');
+      // agent_rollback_events (#4371 fixup): restamped by the SECURITY
+      // DEFINER breeze_cascade_device_org_id() trigger, not this loop's
+      // app-role UPDATE — see the doc comment on DEVICE_ORG_FK_CASCADE_TABLES.
       expect(DEVICE_ORG_FK_CASCADE_TABLES).toEqual([
         'agent_health_observations',
         'software_inventory_observations',
+        'agent_rollback_events',
       ]);
 
       expect(statements).toContain(

--- a/apps/api/src/services/deviceDeletion.test.ts
+++ b/apps/api/src/services/deviceDeletion.test.ts
@@ -254,18 +254,45 @@ describe('deleteDeviceCascade lock ordering', () => {
     expect(statements[statements.length - 1]).toBe('__DELETE_DEVICES_ROW__');
   });
 
-  it('uses the guarded audit-retention role only for append-only peripheral delivery events', async () => {
+  // #4371 fixup: agent_rollback_events and pam_actuation_results joined
+  // peripheral_policy_delivery_events under the SAME guarded escalation —
+  // all three have DELETE fully revoked from breeze_app (see
+  // DEVICE_CASCADE_AUDIT_ADMIN_TABLES in deviceDeletion.ts).
+  it.each([
+    'peripheral_policy_delivery_events',
+    'agent_rollback_events',
+    'pam_actuation_results',
+  ])('uses the guarded audit-retention role for append-only table %s', async (table) => {
     const { tx, statements } = captureTx();
 
     await deleteDeviceCascade(tx, 'device-1');
 
-    const eventDelete = statements.findIndex((statement) =>
-      statement.includes('peripheral_policy_delivery_events') && statement.includes('DELETE FROM')
+    const rowDelete = statements.findIndex((statement) =>
+      statement.includes(table) && statement.includes('DELETE FROM')
     );
-    expect(eventDelete).toBeGreaterThan(0);
-    expect(statements[eventDelete - 2]).toContain('SET LOCAL ROLE breeze_audit_admin');
-    expect(statements[eventDelete - 1]).toContain('breeze.allow_audit_retention');
-    expect(statements[eventDelete + 1]).toContain('RESET ROLE');
+    expect(rowDelete, `no DELETE statement found for ${table}`).toBeGreaterThan(0);
+    expect(statements[rowDelete - 2]).toContain('SET LOCAL ROLE breeze_audit_admin');
+    expect(statements[rowDelete - 1]).toContain('breeze.allow_audit_retention');
+    expect(statements[rowDelete + 1]).toContain('RESET ROLE');
+  });
+
+  it('does NOT use the audit-admin escalation for ordinary device-cascade tables', async () => {
+    const { tx, statements } = captureTx();
+
+    await deleteDeviceCascade(tx, 'device-1');
+
+    // automation_action_results and device_software_inventory_state keep
+    // DELETE granted to breeze_app (only TRUNCATE was revoked, and nothing
+    // deletes via TRUNCATE) — they must NOT be routed through the
+    // escalation, or the escalation set has silently over-grown.
+    for (const table of ['automation_action_results', 'device_software_inventory_state']) {
+      const rowDelete = statements.findIndex((statement) =>
+        statement.includes(table) && statement.includes('DELETE FROM')
+      );
+      expect(rowDelete, `no DELETE statement found for ${table}`).toBeGreaterThan(0);
+      expect(statements[rowDelete - 1]).not.toContain('breeze_audit_admin');
+      expect(statements[rowDelete - 1]).not.toContain('breeze.allow_audit_retention');
+    }
   });
 });
 

--- a/apps/api/src/services/deviceDeletion.ts
+++ b/apps/api/src/services/deviceDeletion.ts
@@ -17,6 +17,28 @@ import {
 } from '../routes/devices/core';
 
 /**
+ * Device-cascade tables that are append-only evidence with DELETE fully
+ * revoked from `breeze_app` (#4371 — see `ensureAppRole.ts`'s per-table
+ * writer-path matrix). Permanent device deletion is an audited retention
+ * boundary, so — matching the existing `breeze_audit_admin` pattern this
+ * set generalizes from `peripheral_policy_delivery_events` — arm both the
+ * role and the trigger's retention escape hatch (`breeze.allow_audit_retention`)
+ * only for these statements, immediately restoring the caller's role
+ * afterward, rather than weakening any table's revoke.
+ *
+ * `agent_rollback_events` and `pam_actuation_results` joined this set in
+ * the #4371 fixup: both migrations revoke DELETE from `breeze_app`
+ * entirely (only `breeze_audit_admin` has it), which the blanket per-boot
+ * GRANT this issue fixes had been silently masking — this loop's plain
+ * `DELETE FROM <table>` for them was never actually valid.
+ */
+const DEVICE_CASCADE_AUDIT_ADMIN_TABLES = new Set([
+  'peripheral_policy_delivery_events',
+  'agent_rollback_events',
+  'pam_actuation_results',
+]);
+
+/**
  * Bound on how long the parent-row lock below may wait.
  *
  * Without it, converting a deadlock into a plain lock wait trades a fast 40P01
@@ -240,14 +262,14 @@ export async function deleteDeviceCascade(
   }
 
   for (const table of getDeviceCascadeDeleteTables()) {
-    if (table === 'peripheral_policy_delivery_events') {
-      // Delivery events are append-only and breeze_app has no DELETE grant.
-      // Permanent device deletion is an audited retention boundary, so arm
-      // both layers only for this one statement and immediately restore the
-      // caller's role before continuing through ordinary child tables.
+    if (DEVICE_CASCADE_AUDIT_ADMIN_TABLES.has(table)) {
+      // Append-only evidence: breeze_app has no DELETE grant (see
+      // DEVICE_CASCADE_AUDIT_ADMIN_TABLES above). Arm both layers only for
+      // this one statement and immediately restore the caller's role before
+      // continuing through ordinary child tables.
       await tx.execute(sql`SET LOCAL ROLE breeze_audit_admin`);
       await tx.execute(sql`SET LOCAL breeze.allow_audit_retention = '1'`);
-      await tx.execute(sql`DELETE FROM peripheral_policy_delivery_events WHERE device_id = ${deviceId}`);
+      await tx.execute(sql`DELETE FROM ${sql.identifier(table)} WHERE device_id = ${deviceId}`);
       await tx.execute(sql`RESET ROLE`);
       continue;
     }

--- a/apps/api/src/services/orgMergeRegistry.ts
+++ b/apps/api/src/services/orgMergeRegistry.ts
@@ -113,6 +113,25 @@ const SPECIAL: Record<string, OrgMergePolicy> = {
   audit_log_chain: { kind: 'leave-for-erasure', note: 'genesis-row unique per org' },
   audit_chain_anchors: { kind: 'leave-for-erasure', note: 'append-only' },
   ml_feedback_events: { kind: 'leave-for-erasure', note: 'append-only' },
+  // agent_rollback_events (#4371 fixup): breeze_app has UPDATE, DELETE,
+  // TRUNCATE revoked by migrations/2026-09-13-agent-rollback-lifecycle.sql,
+  // and breeze_audit_admin only gets DELETE for retention — the same
+  // privilege topology as ml_feedback_events above, so no role the merge
+  // could assume can issue the repoint UPDATE. Before #4371,
+  // ensureAppRole.ts's blanket per-boot GRANT silently re-permitted UPDATE
+  // on this table (a gap that predated this table's own migration, not
+  // caused by it), which is what let REPOINT_TABLES membership work by
+  // accident; #4371 closed that gap, which is the correct fix — this entry
+  // reclassifies the merge side to match, rather than reopening the
+  // privilege hole to keep working around it.
+  //
+  // Note the append-only trigger (agent_rollback_events_append_only) DOES
+  // special-case a same-org-as-device org_id-only UPDATE as a "trusted
+  // restamp" — but that branch is presently unreachable by any role able to
+  // even attempt the UPDATE, so it isn't a live repoint path today; wiring
+  // one up (e.g. a SECURITY DEFINER restamp function) is a separate,
+  // deliberate follow-up, not something to back into via this fix.
+  agent_rollback_events: { kind: 'leave-for-erasure', note: 'append-only rollback evidence; breeze_app has no UPDATE (and breeze_audit_admin has none either) — rows die with the loser shell, same as ml_feedback_events' },
 
   // Column-level immutability: a BEFORE UPDATE row trigger RAISEs when
   // `org_id` changes, so these cannot be re-tenanted by ANY role the merge
@@ -436,7 +455,8 @@ const REPOINT_TABLES: readonly string[] = [
   "account_deletion_requests",
   "agent_logs",
   "agent_rollback_directives",
-  "agent_rollback_events",
+  // agent_rollback_events removed (#4371 fixup): reclassified 'leave-for-erasure'
+  // in SPECIAL above — breeze_app has no UPDATE on this append-only table.
   "ai_action_plans",
   "ai_screenshots",
   "ai_sessions",


### PR DESCRIPTION
## Summary

`ensureAppRole()`'s per-boot blanket GRANT (step 4: `GRANT SELECT, INSERT, UPDATE, DELETE, REFERENCES ON ALL TABLES IN SCHEMA public TO breeze_app`) silently re-permits whatever an append-only table's migration `REVOKE`d from `breeze_app` — unless step 5 explicitly re-applies that `REVOKE` after the blanket `GRANT` on every boot. `pam_actuation_results` shipped without a re-revoke block in `ensureAppRole.ts`, so its `BEFORE UPDATE/DELETE` trigger has been the *sole* enforcement in production since `2026-09-16-pam-actuation-lifecycle.sql` landed — the privilege half of the intended belt-and-suspenders pair never actually held.

## The sweep

Per the issue's suggestion, I swept every `REVOKE ... FROM breeze_app` statement across `apps/api/migrations/*.sql` against `ensureAppRole.ts`'s existing re-revoke list and found **five more tables with the same gap**, beyond the reported `pam_actuation_results`: `ml_feedback_events`, `peripheral_policy_delivery_events`, `agent_rollback_events`, `automation_action_results`, `device_software_inventory_state`.

## Writer-path matrix (the real substance of this PR)

Closing the privilege gap is not enough on its own — every *legitimate* writer of these six tables (device permanent-delete, device org-move, org merge, org erasure, retention/prune jobs) has to keep working under the now-real privilege wall, or the fix just trades one bug for a different one. CI caught two classes of this on the branch as I fixed the underlying gap; here's the full audit, enumerated per table:

| Table | breeze_app revoked | breeze_app kept | Device delete | Device org-move | Org merge | Org erasure |
|---|---|---|---|---|---|---|
| `pam_actuation_results` | `UPDATE, DELETE, TRUNCATE` | — | `breeze_audit_admin` escalation | N/A — PAM-history devices can't move orgs at all | `blocks-merge` | `breeze_audit_admin` |
| `agent_rollback_events` | `UPDATE, DELETE, TRUNCATE` | — | `breeze_audit_admin` escalation | `breeze_cascade_device_org_id()` SECURITY DEFINER trigger | `leave-for-erasure` | `breeze_audit_admin` |
| `ml_feedback_events` | `UPDATE, DELETE, TRUNCATE` | — | N/A — no `device_id` column | N/A — no `device_id` column | `leave-for-erasure` | `breeze_audit_admin` |
| `peripheral_policy_delivery_events` | `DELETE, TRUNCATE` | `UPDATE` | `breeze_audit_admin` escalation | real `breeze_app` UPDATE (trigger-gated restamp) | plain `repoint` | `breeze_audit_admin` |
| `automation_action_results` | `TRUNCATE` | `UPDATE, DELETE` | plain `breeze_app` DELETE | real `breeze_app` UPDATE | plain `repoint` | plain `breeze_app` DELETE |
| `device_software_inventory_state` | `TRUNCATE` | `UPDATE, DELETE` | plain `breeze_app` DELETE | real `breeze_app` UPDATE | plain `repoint` | plain `breeze_app` DELETE |

Every cell above is now verified — either by an integration test that was previously red, or by the `orgMergeRegistry.integration.test.ts` contract check, or by a `grep` confirming no writer path exists.

### 1. Org-merge registry conflict (`agent_rollback_events`)

`executeOrgMerge` repointed `agent_rollback_events` with a plain `UPDATE ... SET org_id = survivor` (`REPOINT_TABLES`, `orgMergeRegistry.ts`), which the blanket-GRANT bug had been silently masking. `agent_rollback_events` has the identical privilege topology as `ml_feedback_events` (neither `breeze_app` nor `breeze_audit_admin` can ever `UPDATE` it) — reclassified it `leave-for-erasure` to match, removed it from `REPOINT_TABLES`, updated the two `orgMergeRegistry.integration.test.ts` assertions that hardcoded the old `repoint` classification.

### 2. Device-delete and device-move conflicts (`pam_actuation_results`, `agent_rollback_events`)

- `DELETE FROM pam_actuation_results WHERE device_id = ...` (permanent device-delete cascade, `services/deviceDeletion.ts`) — `breeze_app` has `DELETE` fully revoked. **Fix**: generalized the pre-existing `peripheral_policy_delivery_events` → `breeze_audit_admin` escalation (`SET LOCAL ROLE breeze_audit_admin` + `breeze.allow_audit_retention='1'`, one statement, immediately restored) into `DEVICE_CASCADE_AUDIT_ADMIN_TABLES`, covering `pam_actuation_results` and `agent_rollback_events` too — both have `breeze_audit_admin GRANT SELECT, DELETE` in their own migrations. This follows the existing `audit_logs`-style precedent rather than weakening any revoke.
- `UPDATE agent_rollback_events SET org_id = ... WHERE device_id = ...` (device org-move, `routes/devices/moveOrg.ts`'s app-level denormalized-table loop) — `breeze_app` has `UPDATE` fully revoked. **Fix**: added `agent_rollback_events` to `DEVICE_ORG_FK_CASCADE_TABLES` (`routes/devices/core.ts`) — verified against real Postgres (`SELECT * FROM breeze_device_child_orgid_tables()`) that its org_id is already restamped by the pre-existing `SECURITY DEFINER` `breeze_cascade_device_org_id()` trigger (`migrations/2026-05-18-device-child-orgid-cascade.sql`), which fires on the same `devices` UPDATE this loop follows and bypasses the privilege wall the way FK actions do — the app-level loop's own UPDATE was always redundant with it, never load-bearing.

`pam_actuation_results` has no device org-move conflict: a device with PAM actuation history can't move orgs at all (`devices_pam_history_move_guard`), and it's explicitly excluded from the generic org_id-cascade discovery function (`migrations/2026-09-17-pam-device-move-guard.sql`).

### 3. One residual gap found, deliberately NOT fixed here — filed as **[#4806](https://github.com/LanternOps/breeze/issues/4806)**

`peripheral_policy_delivery_events` keeps `UPDATE` granted because `moveOrg.ts`'s restamp loop genuinely needs it (unlike `agent_rollback_events`, it has no `ON UPDATE CASCADE` FK and wasn't on the SECURITY DEFINER trigger's exclusion list before now). Its append-only guarantee for that write therefore still depends entirely on the trigger's own data-shape check (`(to_jsonb(NEW) - 'org_id') = (to_jsonb(OLD) - 'org_id') AND EXISTS (...)`), not a privilege wall — a real behavior change to a live writer path, so it gets its own PR/review/regression test rather than riding along on this one.

`automation_action_results` and `device_software_inventory_state` are **not** append-only by design (no append-only trigger exists for either) — only `TRUNCATE` was ever restricted, as defense-in-depth, and no writer path issues one.

## Regression tests

- `apps/api/src/db/ensureAppRole.appendOnlyCoverage.test.ts` — static-analysis unit test (no DB): parses every migration `REVOKE` and every `ensureAppRole.ts` re-revoke block and fails on any gap. Extended with a `WRITER_PATH_MATRIX` block asserting **exact** privilege equality (not just "at least") for all six tables, so a future PR can't silently over-tighten one and reopen a writer-path conflict without the test forcing a conscious update. Regex hardened to tolerate multi-line privilege lists and REVOKEs embedded in dynamic SQL.
- `apps/api/src/__tests__/integration/ensureAppRoleAppendOnlyPrivileges.integration.test.ts` — real-Postgres `has_table_privilege()` check for all 6 tables' runtime effect.
- `deviceDeletion.test.ts` — generalized the single-table escalation assertion to `it.each` over all three `DEVICE_CASCADE_AUDIT_ADMIN_TABLES` entries, plus a negative control proving `automation_action_results`/`device_software_inventory_state` do **not** get the escalation.
- `moveOrg.test.ts` / `moveOrg.coverage.test.ts` — updated the two hardcoded `DEVICE_ORG_FK_CASCADE_TABLES` array assertions to include `agent_rollback_events`.

## Testing

- `cd apps/api && npx vitest run src/db/ensureAppRole src/services/orgMerge src/routes/orgMerge src/jobs/orgMerge src/routes/devices/moveOrg src/routes/devices/cascadeDelete src/services/deviceDeletion` — **235/235 passed** (11 unit files).
- Foreground, against the shared integration test DB (`BREEZE_INTEGRATION_ALLOW_LEDGER_DRIFT=1` — a sibling worktree had migrated the shared DB ahead of this branch; the drift guard's own documented escape hatch, safe here since none of these are the schema-enumerating suites it warns about):
  `npx vitest run --config vitest.integration.config.ts src/__tests__/integration/deviceDeleteDiscoveredAssetLink src/__tests__/integration/pamActuationLifecycle src/__tests__/integration/quickSupportChain src/__tests__/integration/agentRunMoveSemantics src/__tests__/integration/deviceMoveOrgCurrency src/__tests__/integration/ensureAppRoleAppendOnly src/__tests__/integration/orgMergeRegistry src/__tests__/integration/inboundEmailContactRequester src/__tests__/integration/ticketDraftsRls` — **9 files, 68/68 passed** (previously red on shards 1–3).
- Typecheck: whole-project `npx tsc --noEmit` in `apps/api` repeatedly OOM-crashed on this host (system-wide memory pressure from concurrent sessions, confirmed via `vm_stat`/`top`, unrelated to this change). Verified type-safety instead via a scoped `tsconfig` extending the real one with `include` restricted to every touched/added file — clean. CI's typecheck job on unloaded runners is authoritative.

Closes #4371

🤖 Generated with [Claude Code](https://claude.com/claude-code)
