### PR TITLE
fix(api): mirror moveOrg's intent scope tombstone into the device org cascade trigger (#4454)

### DIFF
--- a/apps/api/migrations/2026-10-06-124500-cascade-device-org-move-intent-scope.sql
+++ b/apps/api/migrations/2026-10-06-124500-cascade-device-org-move-intent-scope.sql
@@ -55,6 +55,30 @@
 -- check). Tombstoning is the strictly safer of the two: it leaves no
 -- cross-tenant device id behind at all.
 --
+-- THE STATEMENT RUNS UNDER THE CALLER'S ACCESS CONTEXT, not the definer's.
+-- SECURITY DEFINER switches the ROLE; it does not touch the `breeze.*` GUCs
+-- that breeze_current_scope() reads, and action_intents is FORCE ROW LEVEL
+-- SECURITY. Both callers that exist today set a context that satisfies
+-- breeze_has_org_access(org_id): the moveOrg route's request context spans
+-- source and target orgs (the devices UPDATE that fired this trigger already
+-- proved that), and orgMerge Phase B wraps its whole transaction in
+-- withSystemDbAccessContext, where the helper short-circuits TRUE. A future
+-- contextless caller -- an ad hoc psql fix, or a script that forgets the
+-- wrapper -- would land on scope='none' and this UPDATE would match zero rows
+-- silently.
+--
+-- Deliberately NOT instrumented with GET DIAGNOSTICS + RAISE WARNING, unlike a
+-- migration cleanup statement. Zero rows is the OVERWHELMINGLY common normal
+-- case here: the trigger fires on every device org-move and most moved devices
+-- have no intent scoped to them at all, so a warning would fire constantly and
+-- train readers to ignore it. Worse, the "did we miss rows?" probe would have
+-- to read action_intents under the SAME context that just hid them, so it
+-- cannot detect the one case it exists for. The real backstop is at release:
+-- services/actionIntents/agentReleaseAuthority.ts refuses a device whose
+-- CURRENT org_id no longer matches the intent's, so a tombstone that never
+-- fired still fails closed. This statement is defense in depth and data
+-- hygiene, not the security boundary.
+--
 -- NO HISTORICAL BACKFILL, for the reason 2026-09-29's header gives for the same
 -- omission: action_intents is FORCE ROW LEVEL SECURITY, so a bare cleanup
 -- statement here — run without a `breeze.scope` access context — is subject to

--- a/apps/api/migrations/2026-10-06-124500-cascade-device-org-move-intent-scope.sql
+++ b/apps/api/migrations/2026-10-06-124500-cascade-device-org-move-intent-scope.sql
@@ -1,0 +1,130 @@
+-- #4454 — mirror moveOrg's action_intents scope tombstone into
+-- breeze_cascade_device_org_id().
+--
+-- `apps/api/src/routes/devices/moveOrg.ts` tombstones the typed target scope of
+-- every LIVE intent aimed at a device that is leaving its org:
+--
+--     UPDATE action_intents SET scope_device_id = NULL
+--       WHERE scope_device_id = <deviceId>
+--         AND status IN ('pending_approval','approved','executing')
+--
+-- The DB-side cascade — breeze_cascade_device_org_id(), the path taken by
+-- direct-SQL / non-route callers such as orgMerge's `devices` repoint — never
+-- mirrored it. P2-2 review round 1 scoped that fix to the route only and
+-- recorded the hole as a known gap in moveOrg.coverage.test.ts. A raw
+-- `UPDATE devices SET org_id = ...` therefore left a LIVE intent still naming a
+-- device that now belongs to a different tenant: exactly the cross-tenant
+-- dangling-pointer class #3828 closed for metric_anomaly_incidents.agent_run_id
+-- and #4215 closed for ai_agent_runs.ticket_id, both of which were carried the
+-- same way until they were mirrored into this function.
+--
+-- Placement: immediately after the metric_anomaly_incidents reverse pointer and
+-- BEFORE the tickets requester detach and the generic
+-- breeze_device_child_orgid_tables() re-stamp loop — the same internal order
+-- the route uses. `action_intents` is NOT returned by that function (its device
+-- pointer is `scope_device_id`, not `device_id`, deliberately so —
+-- cascadeDelete.test.ts keys on `device_id`), so the loop can never reach these
+-- rows; and action_intents.org_id is immutable
+-- (action_intents_block_content_update()), so the intent can never follow the
+-- device. Tombstoning the pointer is the only available correct outcome.
+--
+-- LIVE STATUSES ONLY, matching the route and the schema comment on
+-- actionIntents.scopeDeviceId: a terminal-status intent is a historical record
+-- of an action already decided, and its target device at decision time is a
+-- fact, not something a future release path re-validates. Only a LIVE intent
+-- can still reach release (services/actionIntents/intentTargetScope.ts), which
+-- fails closed on a NULL scope_device_id.
+--
+-- PERMITTED BY THE IMMUTABILITY TRIGGER. action_intents_block_content_update()
+-- (newest definition: 2026-09-25-ai-agents-ticket-triage.sql) rejects a
+-- scope_device_id change only when `NEW.scope_device_id IS NOT NULL`, so
+-- non-null -> NULL is the one transition it allows — the same transition the
+-- FK's ON DELETE SET NULL makes on a device delete. This UPDATE is the
+-- tombstone path, not a bypass. `action_intents_scope_device_chk`
+-- (`scope_device_id IS NULL OR scope_kind = 'device'`) is likewise satisfied:
+-- scope_kind is left alone and a kind without an id IS the tombstone.
+--
+-- NO MERGE FENCE, deliberately — unlike the tickets requester detach directly
+-- below it, which skips itself while `organizations.status = 'merging'` because
+-- the contact travels to the survivor org alongside the ticket. An intent never
+-- travels: services/orgMergeRegistry.ts classifies `action_intents` as
+-- `leave-for-erasure` precisely because org_id is trigger-immutable, so a
+-- repoint would raise and abort the merge. A live intent in a merging loser org
+-- is therefore erased with the loser shell no matter what this trigger does,
+-- and both outcomes fail closed at release (tombstone, or the org-mismatch
+-- check). Tombstoning is the strictly safer of the two: it leaves no
+-- cross-tenant device id behind at all.
+--
+-- NO HISTORICAL BACKFILL, for the reason 2026-09-29's header gives for the same
+-- omission: action_intents is FORCE ROW LEVEL SECURITY, so a bare cleanup
+-- statement here — run without a `breeze.scope` access context — is subject to
+-- policy even for the table owner and would match zero rows on a managed
+-- Postgres, reporting a silent "0 cleaned" while leaving the rows in place.
+-- Pre-fix rows are already failed closed by the release path's org-mismatch
+-- check (intentTargetScope.ts), so they are not exploitable; a sweep, if ever
+-- wanted, belongs in a scripted backfill under a known access context.
+--
+-- Full function body copied from 2026-10-04-100000-ticket-requester-contact.sql
+-- (the newest definition; no later migration replaces this function) with only
+-- the action_intents statement added. CREATE OR REPLACE is idempotent by
+-- construction — re-applying this file re-installs the same body. The trigger
+-- itself (breeze_cascade_device_org_id ON devices, AFTER UPDATE OF org_id ...
+-- WHEN NEW.org_id IS DISTINCT FROM OLD.org_id) is unchanged and is NOT
+-- redeclared here.
+CREATE OR REPLACE FUNCTION public.breeze_cascade_device_org_id()
+  RETURNS trigger
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = public, pg_catalog
+  AS $$
+DECLARE
+  child_table text;
+BEGIN
+  -- Agent-run history stays with the SOURCE org (owner decision 2026-08-23):
+  -- sever the moved device's lineage links instead of re-stamping org_id.
+  UPDATE public.ai_agent_runs
+    SET device_id = NULL, alert_id = NULL, session_id = NULL, anomaly_incident_id = NULL
+    WHERE device_id = NEW.id;
+  -- ticket_id is device-lineage too, but unreachable from `WHERE device_id`:
+  -- ticket-triggered runs carry a ticket_id with a NULL device_id. Key off the
+  -- ticket's device_id instead (#4215).
+  UPDATE public.ai_agent_runs
+    SET ticket_id = NULL
+    WHERE ticket_id IN (SELECT id FROM public.tickets WHERE device_id = NEW.id);
+  -- Reverse pointer: the incident's back-link to the (now-detached) run must
+  -- not keep naming a source-org run once the incident itself is re-stamped
+  -- to the destination org by the generic loop below.
+  UPDATE public.metric_anomaly_incidents
+    SET agent_run_id = NULL
+    WHERE device_id = NEW.id;
+  -- Typed target scope of a LIVE intent must not keep naming a device that has
+  -- just left the intent's org (#4454). Mirrors moveOrg.ts; see the header for
+  -- the live-status gate, the immutability-trigger transition, and why this one
+  -- takes no merge fence.
+  UPDATE public.action_intents
+    SET scope_device_id = NULL
+    WHERE scope_device_id = NEW.id
+      AND status IN ('pending_approval', 'approved', 'executing');
+  -- The requester CONTACT is org-pinned and does not travel with the device
+  -- (#3258 W03). Skipped while the source org is fenced for a merge, where the
+  -- contact moves to the survivor alongside the ticket — see the header of
+  -- 2026-10-04-100000-ticket-requester-contact.sql.
+  IF NOT EXISTS (
+    SELECT 1 FROM public.organizations o
+     WHERE o.id = OLD.org_id AND o.status::text = 'merging'
+  ) THEN
+    UPDATE public.tickets
+      SET requester_contact_id = NULL
+      WHERE device_id = NEW.id
+        AND requester_contact_id IS NOT NULL
+        AND org_id IS DISTINCT FROM NEW.org_id;
+  END IF;
+  FOR child_table IN SELECT public.breeze_device_child_orgid_tables() LOOP
+    EXECUTE format(
+      'UPDATE public.%I SET org_id = $1 WHERE device_id = $2 AND org_id IS DISTINCT FROM $1',
+      child_table
+    ) USING NEW.org_id, NEW.id;
+  END LOOP;
+  RETURN NULL; -- AFTER trigger; return value ignored
+END;
+$$;

--- a/apps/api/src/__tests__/integration/deviceMoveOrgIntentScopeTombstone.integration.test.ts
+++ b/apps/api/src/__tests__/integration/deviceMoveOrgIntentScopeTombstone.integration.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Live-Postgres coverage for #4454: `breeze_cascade_device_org_id()` must
+ * tombstone `action_intents.scope_device_id` for every LIVE intent aimed at a
+ * device that is leaving its org — not only when the move goes through the
+ * `POST /devices/:id/move-org` route.
+ *
+ * WHY THIS NEEDS A REAL DATABASE
+ * ------------------------------
+ * The behaviour under test lives entirely inside a Postgres trigger function.
+ * No TypeScript executes: `UPDATE devices SET org_id = ...` is the whole input,
+ * and the tombstone is a side effect of the AFTER-UPDATE trigger. A mocked
+ * suite can only assert the *shape* of the SQL text in the migration — which is
+ * what `routes/devices/moveOrg.coverage.test.ts` does, statically, in the unit
+ * job. It cannot catch any of the three ways this statement could be present
+ * and still not work:
+ *
+ *   1. FORCE ROW LEVEL SECURITY on `action_intents` silently matching zero rows
+ *      (the exact failure mode 2026-09-29's header warns about for a bare
+ *      migration-time cleanup, and the one recorded for managed Postgres
+ *      backfills that omit `breeze.scope`). A tombstone that reports success
+ *      while updating nothing is indistinguishable from the bug it fixes.
+ *   2. `action_intents_block_content_update()` — the BEFORE UPDATE immutability
+ *      trigger — rejecting the write. It permits `scope_device_id` non-null ->
+ *      NULL and nothing else, so a trigger-on-trigger ordering problem or a
+ *      future tightening of that deny-list would raise
+ *      `action_intents content is immutable` and abort the whole device move.
+ *   3. `action_intents_scope_device_chk` rejecting a NULL id under a surviving
+ *      `scope_kind = 'device'`.
+ *
+ * The two suites are complementary and deliberately both exist: the static one
+ * fails fast in the blocking `test-api` job when the statement is deleted or
+ * drifts from the route, this one proves the statement actually does something
+ * against a real server.
+ *
+ * TWO CALLERS, ONE TRIGGER. The move is driven twice, because the two
+ * non-route paths reach the trigger through different privilege levels and
+ * only the second can expose failure mode 1:
+ *
+ *   - as the SUPERUSER admin client (`getTestDb()`) — the literal "somebody ran
+ *     UPDATE in psql" path, RLS-exempt;
+ *   - as the unprivileged `breeze_app` role under `withSystemDbAccessContext`
+ *     — the shape every real non-route caller has, orgMerge's `devices` repoint
+ *     included. `breeze_has_org_access()` grants system scope, so the trigger's
+ *     UPDATE must match here too; if it silently matched zero rows this case is
+ *     the one that goes red.
+ *
+ * THE TERMINAL-STATUS CONTROL IS NOT OPTIONAL. Every case also seeds a
+ * `completed` intent pointing at the same device and asserts it is left ALONE.
+ * A tombstone that fired unconditionally would rewrite the historical target of
+ * an action that was already decided and executed — which the schema comment on
+ * `actionIntents.scopeDeviceId` explicitly forbids, and which an assertion that
+ * only checked the live row would happily pass.
+ *
+ * FIXTURES ARE PER-TEST. The shared integration setup (`./setup`) TRUNCATEs the
+ * core tenant tables in a global `beforeEach`, so seeding in `beforeAll` would
+ * be CASCADE-deleted before the second case runs.
+ */
+import './setup';
+
+import { randomUUID } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { eq, sql } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import { actionIntents, devices } from '../../db/schema';
+import { createOrganization, createSite, setupTestEnvironment } from './db-utils';
+import { getTestDb } from './setup';
+
+const LIVE_STATUSES = ['pending_approval', 'approved', 'executing'] as const;
+
+interface Fixture {
+  deviceId: string;
+  sourceOrgId: string;
+  targetOrgId: string;
+  targetSiteId: string;
+  /** One id per LIVE status, all scoped to `deviceId`. */
+  liveIntentIds: string[];
+  /** `completed` intent scoped to the same device — must survive untouched. */
+  terminalIntentId: string;
+}
+
+async function seed(): Promise<Fixture> {
+  const adminDb = getTestDb() as never as {
+    insert: (typeof db)['insert'];
+    select: (typeof db)['select'];
+  };
+  const sfx = randomUUID().slice(0, 8);
+
+  const { partner, organization: sourceOrg, site: sourceSite, user } = await setupTestEnvironment({
+    scope: 'partner',
+  });
+  const targetOrg = await createOrganization({ partnerId: partner.id });
+  const targetSite = await createSite({ orgId: targetOrg.id });
+
+  const [device] = await adminDb
+    .insert(devices)
+    .values({
+      orgId: sourceOrg.id,
+      siteId: sourceSite.id,
+      agentId: `intent-scope-agent-${sfx}`,
+      hostname: `intent-scope-host-${sfx}`,
+      osType: 'linux',
+      osVersion: '22.04',
+      architecture: 'x86_64',
+      agentVersion: '0.0.0-test',
+      status: 'offline',
+    })
+    .returning({ id: devices.id });
+
+  // A human-originated intent satisfies action_intents_one_actor_chk (exactly
+  // one of the three actor columns), action_intents_agent_origin_chk and
+  // action_intents_agent_source_chk (source and origin_principal_kind move
+  // together, neither is the agent value).
+  const intentValues = (status: string, index: number) => ({
+    orgId: sourceOrg.id,
+    partnerId: partner.id,
+    requestedByUserId: user.id,
+    requestingApiKeyId: null,
+    requestingAgentRunId: null,
+    source: 'chat' as const,
+    originPrincipalKind: 'user_session' as const,
+    originPrincipalId: user.id,
+    actionName: 'device.script.run',
+    actionVersion: 1,
+    arguments: { scriptId: randomUUID() } as never,
+    argumentDigest: 'b'.repeat(64),
+    targetSummary: `Run script on ${device!.id}`,
+    impactSummary: 'Executes a script on the target device',
+    reason: 'Integration coverage for #4454',
+    riskTier: 2,
+    connectionId: null,
+    tenantId: null,
+    // The live-status partial unique index is (org_id, idempotency_key), so
+    // every LIVE row in this org needs a distinct key.
+    idempotencyKey: `idem-${sfx}-${index}`,
+    correlationId: randomUUID(),
+    expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    status,
+    scopeKind: 'device' as const,
+    scopeDeviceId: device!.id,
+  });
+
+  const liveIntentIds: string[] = [];
+  for (const [index, status] of LIVE_STATUSES.entries()) {
+    const [row] = await adminDb
+      .insert(actionIntents)
+      .values(intentValues(status, index) as never)
+      .returning({ id: actionIntents.id });
+    liveIntentIds.push(row!.id);
+  }
+
+  const [terminal] = await adminDb
+    .insert(actionIntents)
+    .values({
+      ...intentValues('completed', LIVE_STATUSES.length),
+      decidedAt: new Date(),
+      decidedByUserId: user.id,
+      executedAt: new Date(),
+    } as never)
+    .returning({ id: actionIntents.id });
+
+  return {
+    deviceId: device!.id,
+    sourceOrgId: sourceOrg.id,
+    targetOrgId: targetOrg.id,
+    targetSiteId: targetSite.id,
+    liveIntentIds,
+    terminalIntentId: terminal!.id,
+  };
+}
+
+async function readScopes(ids: string[]): Promise<Array<string | null>> {
+  const adminDb = getTestDb();
+  const out: Array<string | null> = [];
+  for (const id of ids) {
+    const [row] = await adminDb
+      .select({ scopeDeviceId: actionIntents.scopeDeviceId, status: actionIntents.status })
+      .from(actionIntents)
+      .where(eq(actionIntents.id, id));
+    out.push(row!.scopeDeviceId);
+  }
+  return out;
+}
+
+async function readDeviceOrg(deviceId: string): Promise<string | undefined> {
+  const [row] = await getTestDb()
+    .select({ orgId: devices.orgId })
+    .from(devices)
+    .where(eq(devices.id, deviceId));
+  return row?.orgId;
+}
+
+describe('breeze_cascade_device_org_id(): action_intents scope tombstone (#4454)', () => {
+  it('a raw superuser UPDATE devices SET org_id tombstones every LIVE intent scoped to the device', async () => {
+    const f = await seed();
+
+    // Control: the pointers are live BEFORE the move, so a green assertion
+    // below cannot be an artifact of a seed that never set them.
+    expect(await readScopes(f.liveIntentIds)).toEqual([f.deviceId, f.deviceId, f.deviceId]);
+    expect(await readScopes([f.terminalIntentId])).toEqual([f.deviceId]);
+
+    await getTestDb().execute(sql`
+      UPDATE devices SET org_id = ${f.targetOrgId}::uuid, site_id = ${f.targetSiteId}::uuid
+       WHERE id = ${f.deviceId}::uuid
+    `);
+
+    expect(await readDeviceOrg(f.deviceId)).toBe(f.targetOrgId);
+    expect(
+      await readScopes(f.liveIntentIds),
+      'every pending_approval/approved/executing intent must be tombstoned by the trigger, not just the route',
+    ).toEqual([null, null, null]);
+  });
+
+  it('leaves a terminal-status intent pointing at the moved device', async () => {
+    const f = await seed();
+
+    await getTestDb().execute(sql`
+      UPDATE devices SET org_id = ${f.targetOrgId}::uuid, site_id = ${f.targetSiteId}::uuid
+       WHERE id = ${f.deviceId}::uuid
+    `);
+
+    expect(
+      await readScopes([f.terminalIntentId]),
+      'a completed intent is a historical record of an already-decided action — its target at decision time must survive the move',
+    ).toEqual([f.deviceId]);
+  });
+
+  it('tombstones under the unprivileged breeze_app role in a system access context (forced RLS does not swallow the UPDATE)', async () => {
+    const f = await seed();
+
+    // The shape every real non-route caller has — orgMerge's `devices` repoint
+    // included. If FORCE RLS on action_intents made the trigger's UPDATE match
+    // zero rows, ONLY this case would catch it: the superuser case above is
+    // RLS-exempt and would stay green.
+    await withSystemDbAccessContext(async () => {
+      await db.execute(sql`
+        UPDATE devices SET org_id = ${f.targetOrgId}::uuid, site_id = ${f.targetSiteId}::uuid
+         WHERE id = ${f.deviceId}::uuid
+      `);
+    });
+
+    expect(await readDeviceOrg(f.deviceId)).toBe(f.targetOrgId);
+    expect(await readScopes(f.liveIntentIds)).toEqual([null, null, null]);
+    expect(await readScopes([f.terminalIntentId])).toEqual([f.deviceId]);
+  });
+});

--- a/apps/api/src/__tests__/integration/deviceMoveOrgIntentScopeTombstone.integration.test.ts
+++ b/apps/api/src/__tests__/integration/deviceMoveOrgIntentScopeTombstone.integration.test.ts
@@ -21,11 +21,15 @@
  *      while updating nothing is indistinguishable from the bug it fixes.
  *   2. `action_intents_block_content_update()` — the BEFORE UPDATE immutability
  *      trigger — rejecting the write. It permits `scope_device_id` non-null ->
- *      NULL and nothing else, so a trigger-on-trigger ordering problem or a
- *      future tightening of that deny-list would raise
- *      `action_intents content is immutable` and abort the whole device move.
- *   3. `action_intents_scope_device_chk` rejecting a NULL id under a surviving
- *      `scope_kind = 'device'`.
+ *      NULL and nothing else, so a future tightening of that deny-list would
+ *      raise `action_intents content is immutable` and abort the whole device
+ *      move.
+ *
+ * `action_intents_scope_device_chk` is deliberately NOT on that list, though it
+ * sits right beside the trigger: `scope_device_id IS NULL OR scope_kind =
+ * 'device'` is satisfied by ANY row whose id is NULL, so the tombstone cannot
+ * violate it and no test here proves anything about it. Naming it as a third
+ * guarded hazard would be a claim this suite does not earn.
  *
  * The two suites are complementary and deliberately both exist: the static one
  * fails fast in the blocking `test-api` job when the statement is deleted or
@@ -226,6 +230,10 @@ describe('breeze_cascade_device_org_id(): action_intents scope tombstone (#4454)
 
   it('tombstones under the unprivileged breeze_app role in a system access context (forced RLS does not swallow the UPDATE)', async () => {
     const f = await seed();
+
+    // Its OWN before-state control, rather than leaning on the first case's:
+    // this test must still mean something when run alone under `-t` filtering.
+    expect(await readScopes(f.liveIntentIds)).toEqual([f.deviceId, f.deviceId, f.deviceId]);
 
     // The shape every real non-route caller has — orgMerge's `devices` repoint
     // included. If FORCE RLS on action_intents made the trigger's UPDATE match

--- a/apps/api/src/routes/devices/moveOrg.coverage.test.ts
+++ b/apps/api/src/routes/devices/moveOrg.coverage.test.ts
@@ -640,6 +640,14 @@ describe('action_intents.scope_device_id detach coverage', () => {
     ).toEqual(['approved', 'executing', 'pending_approval']);
   });
 
+  // A CONVENTION guard, not a behavioural one — worth being honest about.
+  // `action_intents` is not returned by breeze_device_child_orgid_tables() (its
+  // device pointer is `scope_device_id`, not `device_id`), so the generic loop
+  // cannot reach these rows and moving the statement after it would not change
+  // what the trigger does today. What this pins is that the trigger's internal
+  // order keeps mirroring moveOrg.ts's, which is the property that made the
+  // tickets requester detach — where placement IS load-bearing, because the
+  // re-stamp is the statement that trips its constraint — easy to get right.
   it('places the tombstone BEFORE the generic device-child org re-stamp loop', () => {
     const { name, body } = newestCascadeFunctionBody();
     const tombstone = body.indexOf('UPDATE public.action_intents');

--- a/apps/api/src/routes/devices/moveOrg.coverage.test.ts
+++ b/apps/api/src/routes/devices/moveOrg.coverage.test.ts
@@ -332,6 +332,46 @@ describe('DEVICE_SITE_DENORMALIZED_TABLES coverage', () => {
   });
 });
 
+const MIGRATIONS_DIR = fileURLToPath(new URL('../../../migrations/', import.meta.url));
+
+/**
+ * Newest migration that (re)defines breeze_cascade_device_org_id(), resolved
+ * the same way autoMigrate applies files — filename `localeCompare` order,
+ * last definition wins — and sliced down to that function's body so an
+ * unrelated `UPDATE public.ai_agent_runs` elsewhere in the same file (e.g. a
+ * scripted backfill) cannot stand in for a statement the body dropped.
+ *
+ * Resolved dynamically rather than by hardcoded filename so a later migration
+ * replacing the function again cannot leave this contract silently asserting
+ * a superseded definition. `CREATE FUNCTION` is matched as well as
+ * `CREATE OR REPLACE FUNCTION`: a DROP + plain CREATE redefinition counts.
+ */
+const DEFINES_CASCADE_FN = /CREATE (OR REPLACE )?FUNCTION (public\.)?breeze_cascade_device_org_id/;
+
+let cachedCascadeFn: { name: string; body: string } | undefined;
+
+function newestCascadeFunctionBody(): { name: string; body: string } {
+  if (cachedCascadeFn) return cachedCascadeFn;
+  const definitions = readdirSync(MIGRATIONS_DIR)
+    .filter((name) => /^\d{4}-.*\.sql$/.test(name))
+    .sort((a, b) => a.localeCompare(b))
+    .filter((name) => DEFINES_CASCADE_FN.test(readFileSync(`${MIGRATIONS_DIR}${name}`, 'utf8')));
+  const name = definitions.at(-1);
+  expect(name, 'no migration defines breeze_cascade_device_org_id()').toBeTruthy();
+
+  const src = readFileSync(`${MIGRATIONS_DIR}${name}`, 'utf8');
+  const body = src.match(
+    /CREATE (?:OR REPLACE )?FUNCTION (?:public\.)?breeze_cascade_device_org_id[\s\S]*?\n\$\$;/,
+  );
+  expect(
+    body,
+    `${name} matched the function-definition pattern but its "AS $$ ... $$;" body could not be sliced out`,
+  ).toBeTruthy();
+
+  cachedCascadeFn = { name: name!, body: body![0] };
+  return cachedCascadeFn;
+}
+
 /**
  * ai_agent_runs run-lineage detach coverage (#3828 branch-review blocker 2).
  *
@@ -380,7 +420,6 @@ describe('DEVICE_SITE_DENORMALIZED_TABLES coverage', () => {
 describe('ai_agent_runs run-lineage detach coverage', () => {
   const runsCfg = getTableConfig(aiAgentRuns);
   const denormTableSet = new Set<string>(getDeviceOrgDenormalizedTables());
-  const MIGRATIONS_DIR = fileURLToPath(new URL('../../../migrations/', import.meta.url));
 
   // Columns that reference the run's OWN identity, not a row that moves WITH
   // the device — must stay untouched by device-lineage detach.
@@ -466,44 +505,6 @@ describe('ai_agent_runs run-lineage detach coverage', () => {
     }
   }
 
-  /**
-   * Newest migration that (re)defines breeze_cascade_device_org_id(), resolved
-   * the same way autoMigrate applies files — filename `localeCompare` order,
-   * last definition wins — and sliced down to that function's body so an
-   * unrelated `UPDATE public.ai_agent_runs` elsewhere in the same file (e.g. a
-   * scripted backfill) cannot stand in for a statement the body dropped.
-   *
-   * Resolved dynamically rather than by hardcoded filename so a later migration
-   * replacing the function again cannot leave this contract silently asserting
-   * a superseded definition. `CREATE FUNCTION` is matched as well as
-   * `CREATE OR REPLACE FUNCTION`: a DROP + plain CREATE redefinition counts.
-   */
-  const DEFINES_CASCADE_FN = /CREATE (OR REPLACE )?FUNCTION (public\.)?breeze_cascade_device_org_id/;
-
-  let cachedCascadeFn: { name: string; body: string } | undefined;
-
-  function newestCascadeFunctionBody(): { name: string; body: string } {
-    if (cachedCascadeFn) return cachedCascadeFn;
-    const definitions = readdirSync(MIGRATIONS_DIR)
-      .filter((name) => /^\d{4}-.*\.sql$/.test(name))
-      .sort((a, b) => a.localeCompare(b))
-      .filter((name) => DEFINES_CASCADE_FN.test(readFileSync(`${MIGRATIONS_DIR}${name}`, 'utf8')));
-    const name = definitions.at(-1);
-    expect(name, 'no migration defines breeze_cascade_device_org_id()').toBeTruthy();
-
-    const src = readFileSync(`${MIGRATIONS_DIR}${name}`, 'utf8');
-    const body = src.match(
-      /CREATE (?:OR REPLACE )?FUNCTION (?:public\.)?breeze_cascade_device_org_id[\s\S]*?\n\$\$;/,
-    );
-    expect(
-      body,
-      `${name} matched the function-definition pattern but its "AS $$ ... $$;" body could not be sliced out`,
-    ).toBeTruthy();
-
-    cachedCascadeFn = { name: name!, body: body![0] };
-    return cachedCascadeFn;
-  }
-
   const moveOrgSource = () =>
     readFileSync(fileURLToPath(new URL('./moveOrg.ts', import.meta.url)), 'utf8');
 
@@ -578,13 +579,21 @@ describe('ai_agent_runs run-lineage detach coverage', () => {
  * left alone) — a source-text regex assertion on the WHERE clause, not a
  * schema-FK-derived set, since there is only the one column to check.
  *
- * Deliberately NOT mirrored into breeze_cascade_device_org_id() (the DB-side
- * trigger for direct-SQL/non-route callers) in this round — the controller
- * ruling scoped this fix to the moveOrg route only. A direct
- * `UPDATE devices SET org_id = ...` that bypasses the route would still leave
- * a stale scope_device_id; tracked as a known gap for a follow-up, the same
- * way the ai_agent_runs `ticket_id` gap above was carried as a documented
- * hole until #4215 closed it in both sites.
+ * MIRRORED INTO breeze_cascade_device_org_id() SINCE #4454. P2-2 review round 1
+ * scoped the original fix to the moveOrg route only, leaving the DB-side
+ * trigger — the path every direct-SQL / non-route caller takes, orgMerge's
+ * `devices` repoint included — able to move a device out from under a LIVE
+ * intent while that intent kept naming it. That is the same documented hole the
+ * ai_agent_runs `ticket_id` gap was carried as until #4215 closed it in both
+ * sites, and it is closed the same way here. Both sites are asserted below, so
+ * a future edit that fixes one and forgets the other goes red.
+ *
+ * The two cases below are STATIC source assertions and prove only that the
+ * statement is present and correctly gated. That the statement actually matches
+ * rows — through FORCE ROW LEVEL SECURITY on action_intents, past the
+ * `action_intents_block_content_update()` immutability trigger, and past
+ * `action_intents_scope_device_chk` — needs a real server and lives in
+ * `src/__tests__/integration/deviceMoveOrgIntentScopeTombstone.integration.test.ts`.
  */
 describe('action_intents.scope_device_id detach coverage', () => {
   it('moveOrg.ts tombstones scope_device_id for the moved device, scoped to live statuses', () => {
@@ -607,5 +616,39 @@ describe('action_intents.scope_device_id detach coverage', () => {
       .split(',')
       .map((s) => s.trim().replace(/^'|'$/g, ''));
     expect(statuses.sort()).toEqual(['approved', 'executing', 'pending_approval']);
+  });
+
+  it('breeze_cascade_device_org_id() mirrors the tombstone, scoped to the same live statuses (#4454)', () => {
+    const { name, body } = newestCascadeFunctionBody();
+
+    const match = body.match(
+      /UPDATE public\.action_intents\s+SET scope_device_id = NULL\s+WHERE scope_device_id = NEW\.id\s+AND status IN \(([^)]+)\)/,
+    );
+    expect(
+      match,
+      `${name} is the newest definition of breeze_cascade_device_org_id() and its body has no "UPDATE public.action_intents SET scope_device_id = NULL WHERE scope_device_id = NEW.id AND status IN (...)" statement — a device org-move that bypasses the moveOrg route would leave a LIVE intent pointing at a device now in another tenant (#4454)`,
+    ).toBeTruthy();
+
+    // Same reasoning as the route assertion above: an unconditional detach
+    // would rewrite a COMPLETED intent's historical target.
+    const statuses = match![1]!
+      .split(',')
+      .map((s) => s.trim().replace(/^'|'$/g, ''));
+    expect(
+      statuses.sort(),
+      `${name}'s action_intents tombstone has drifted from moveOrg.ts's status gate`,
+    ).toEqual(['approved', 'executing', 'pending_approval']);
+  });
+
+  it('places the tombstone BEFORE the generic device-child org re-stamp loop', () => {
+    const { name, body } = newestCascadeFunctionBody();
+    const tombstone = body.indexOf('UPDATE public.action_intents');
+    const loop = body.indexOf('breeze_device_child_orgid_tables()');
+    expect(tombstone, `${name}: no action_intents tombstone found`).toBeGreaterThan(-1);
+    expect(loop, `${name}: no device-child re-stamp loop found`).toBeGreaterThan(-1);
+    expect(
+      tombstone,
+      `${name}: the action_intents tombstone must run before the generic re-stamp loop, mirroring moveOrg.ts's internal order`,
+    ).toBeLessThan(loop);
   });
 });


### PR DESCRIPTION
## What

`apps/api/src/routes/devices/moveOrg.ts` tombstones `action_intents.scope_device_id` for every **live** intent aimed at a device that is leaving its org. The DB-side cascade — `breeze_cascade_device_org_id()`, the path every direct-SQL / non-route caller takes, including orgMerge's `devices` repoint — never mirrored it.

P2-2 review round 1 deliberately scoped that fix to the route only and carried the hole as a documented known gap in `moveOrg.coverage.test.ts`. Consequence: a raw `UPDATE devices SET org_id = ...` left a live intent still naming a device that now belongs to a **different tenant**.

Same cross-tenant dangling-pointer class as #3828 (`metric_anomaly_incidents.agent_run_id`) and #4215 (`ai_agent_runs.ticket_id`) — both carried the same way until they were mirrored into this same function. Closed here the same way.

## How

**Migration** `apps/api/migrations/2026-10-06-124500-cascade-device-org-move-intent-scope.sql` — `CREATE OR REPLACE FUNCTION`, body copied from the newest definition (`2026-10-04-100000-ticket-requester-contact.sql`) with one statement added. No inner `BEGIN`/`COMMIT`; the trigger itself is unchanged and not redeclared.

```sql
UPDATE public.action_intents
  SET scope_device_id = NULL
  WHERE scope_device_id = NEW.id
    AND status IN ('pending_approval', 'approved', 'executing');
```

Placed between the `metric_anomaly_incidents` reverse pointer and the tickets requester detach, so the trigger's internal order matches the route's.

Three judgement calls, each cross-checked against an independent read of the repo before implementing:

- **Live statuses only**, matching the route and the `actionIntents.scopeDeviceId` schema comment. A terminal-status intent is a historical record of an already-decided action; its target at decision time is a fact, not something release re-validates. An unconditional detach would rewrite it.
- **No merge fence**, deliberately unlike the tickets requester detach directly below it. That one skips itself while `organizations.status = 'merging'` because the contact travels to the survivor org alongside the ticket. An intent never travels: `services/orgMergeRegistry.ts` classifies `action_intents` as `leave-for-erasure` precisely because `org_id` is trigger-immutable, so a repoint would raise and abort the merge. A live intent in a merging loser org is erased with the loser shell either way, and both outcomes fail closed at release — tombstoning is the strictly safer one, leaving no cross-tenant device id behind at all.
- **No historical backfill**, for the reason `2026-09-29`'s header gives for the same omission: `action_intents` is `FORCE ROW LEVEL SECURITY`, so a contextless migration-time cleanup would match zero rows on a managed Postgres and report a silent "0 cleaned". Pre-fix rows are already failed closed by the release path's org-mismatch check (`intentTargetScope.ts`), so they are not exploitable.

The route's own statement is **unchanged**. Like the other mirrored detaches, it now normally matches nothing (the AFTER trigger on the `devices` flip has already run) and is kept so the route stays correct on its own if the trigger is ever absent.

## Tests

**Red first, both halves.** With the migration moved aside: the two new static cases failed on the unfixed trigger body, and the integration suite failed on real Postgres with the live intents still pointing at the moved device. With the migration in place, all pass.

- **`moveOrg.coverage.test.ts`** (blocking `test-api` job) now asserts **both** sites — the route source *and* the newest migration's function body — plus that the tombstone precedes the generic re-stamp loop. A future edit that fixes one site and forgets the other goes red. The newest-definition resolver was hoisted to module scope so exactly one place decides which migration is authoritative.
- **`deviceMoveOrgIntentScopeTombstone.integration.test.ts`** (new, blocking `integration-test` job) drives a raw `UPDATE devices SET org_id` twice: once as the superuser admin client (the literal "somebody ran it in psql" path) and once as the unprivileged `breeze_app` role under `withSystemDbAccessContext` — the shape orgMerge has, and **the only case that would catch FORCE RLS silently swallowing the UPDATE**. Static assertions cannot reach any of the three ways this statement could be present and still not work (forced RLS, the `action_intents_block_content_update()` immutability trigger, `action_intents_scope_device_chk`). Every case carries a `completed`-status control that must still point at the moved device.

Verified locally against an isolated test stack (`pnpm test-stack up`):

| Check | Result |
|---|---|
| `deviceMoveOrgIntentScopeTombstone.integration.test.ts` | 3 passed (2 red before the migration) |
| `moveOrg.coverage.test.ts` + `autoMigrate.test.ts` | 88 passed (2 red before the migration) |
| `deviceMoveOrgCurrency`, `agentRunMoveSemantics`, `pamDeviceMoveGuard`, `actionIntentsImmutabilityTrigger` | 53 passed |
| `orgMerge`, `orgMergeRegistry`, `ticket-move-org`, `tenantCascade` | 45 passed |
| `integration-suite-coverage` | 5 passed |
| Migration re-applied twice via `psql` | idempotent, no error |
| `tsc --noEmit` (apps/api) | clean |
| `eslint` (changed files) | clean |

No schema change: no new table and no new column, so no cascade / export-policy / RLS-allowlist registration applies.

## Follow-up filed separately (not fixed here) — #4792

`action_intents.scope_ticket_id` has the same class of gap in **both** sites, and it is worse than a dangling pointer: the generic loop re-stamps `tickets.org_id` for the moved device while `action_intents.org_id` is immutable, and `action_intents_scope_ticket_org_fk` is `(scope_ticket_id, org_id) -> tickets(id, org_id)` with **no `ON UPDATE`** clause and `DEFERRABLE INITIALLY IMMEDIATE`. A device org-move carrying a ticket that any intent (live *or* terminal) is scoped to should raise `23503` and abort the move outright. `ticketService.moveTicketOrg` already handles exactly this for the ticket-level move by tombstoning all statuses first. Left out of this PR to keep the change to the one mirror the issue asks for; filed as #4792 with the mechanism, the suggested scope, and a note that the 23503 has not been reproduced against a live server yet.

Closes #4454

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBxF7C8E5GxFnNcGf6kBVP

