### PR TITLE
fix(api): add remediate_vulnerability to DEVICE_COMPLETE_TARGET_TOOLS (#4452)

### DIFF
--- a/apps/api/src/services/actionIntents/intentApprovers.deviceTargets.contract.test.ts
+++ b/apps/api/src/services/actionIntents/intentApprovers.deviceTargets.contract.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { sweepProposedActionSchema } from '@breeze/shared/validators';
 import { aiTools } from '../aiTools';
 import { DEVICE_COMPLETE_TARGET_TOOLS } from './intentApprovers';
 
@@ -26,6 +27,45 @@ describe('DEVICE_COMPLETE_TARGET_TOOLS contract', () => {
         tool?.deviceArgs?.length ?? 0,
         `"${name}" is listed in DEVICE_COMPLETE_TARGET_TOOLS but declares no deviceArgs`,
       ).toBeGreaterThan(0);
+    }
+  });
+
+  /**
+   * The reverse direction (#4452): every tool a SWEEP FINDING can propose
+   * (`SweepProposedAction`, packages/shared/src/types/aiAgentSchedules.ts —
+   * a CLOSED, discriminated union, currently `manage_services` and
+   * `remediate_vulnerability`) creates a device-SCOPED action intent
+   * (sweepFindings.ts's `createActionIntent(..., { scope: { deviceId } })`).
+   * A sweep-proposable tool missing from `DEVICE_COMPLETE_TARGET_TOOLS` is
+   * exactly the #4452 bug: its scoped intents fall through to the
+   * `{kind:'indirect'}` branch, forcing every fan-out to unrestricted-site
+   * approvers instead of the resolved device's site, on every release/decide.
+   *
+   * Derives the tool names from the real zod schema (not a hardcoded list)
+   * so a THIRD sweep-proposable tool added later trips this test the moment
+   * it lands, without anyone remembering to update this file too.
+   *
+   * Not a claim that `DEVICE_COMPLETE_TARGET_TOOLS` must contain every tool
+   * with non-empty `deviceArgs` in the whole registry — most Tier-3 device
+   * tools (e.g. `s1_isolate_device`, `execute_containment`) are deliberately
+   * OUTSIDE it because their args do not express a complete target (see the
+   * hand-verification block in intentApprovers.ts). This narrower check is
+   * scoped to the one closed, mechanically-derivable category the #4452 bug
+   * actually came from: tools a sweep run can mint a device-scoped intent
+   * for.
+   */
+  it('every SweepProposedAction tool is present in DEVICE_COMPLETE_TARGET_TOOLS', () => {
+    const options = (sweepProposedActionSchema as unknown as { options: Array<{ shape: { tool: { value: string } } }> }).options;
+    const sweepToolNames = options.map((option) => option.shape.tool.value);
+    expect(sweepToolNames.length).toBeGreaterThan(0);
+    for (const name of sweepToolNames) {
+      expect(
+        DEVICE_COMPLETE_TARGET_TOOLS.has(name),
+        `sweep-proposable tool "${name}" (SweepProposedAction) is missing from DEVICE_COMPLETE_TARGET_TOOLS — its ` +
+          'device-scoped intents cannot short-circuit target-scope resolution and fall back to indirect fan-out on ' +
+          'every release/decide. If its deviceArgs genuinely cannot express a complete target, add it here anyway ' +
+          'and document why the resolver, not the tool, must special-case it (see resolveIntentTargetScope).',
+      ).toBe(true);
     }
   });
 });

--- a/apps/api/src/services/actionIntents/intentApprovers.test.ts
+++ b/apps/api/src/services/actionIntents/intentApprovers.test.ts
@@ -32,6 +32,10 @@ vi.mock('../aiTools', () => ({
     ['execute_command', { deviceArgs: ['deviceId'] }],
     ['run_script', { deviceArgs: ['deviceIds'] }],
     ['manage_services', { deviceArgs: ['deviceId'] }],
+    // `deviceId` is OPTIONAL on the real tool (aiToolSchemas.ts) — interactive
+    // chat may omit it and act across devices; only the sweep path always
+    // populates it. See the resolveIntentTargetScope tests below.
+    ['remediate_vulnerability', { deviceArgs: ['deviceId'] }],
     // Registered but NOT in DEVICE_COMPLETE_TARGET_TOOLS — the canonical
     // indirect-target tool (targetType: all/group/filter, no deviceArgs).
     ['manage_deployments', {}],
@@ -533,6 +537,41 @@ describe('resolveIntentTargetScope', () => {
     expect(scope).toEqual({ kind: 'indirect' });
     expect(db.select).not.toHaveBeenCalled();
   });
+
+  // #4452: remediate_vulnerability's `deviceId` arg is OPTIONAL (unlike the
+  // three other DEVICE_COMPLETE_TARGET_TOOLS entries, whose device args are
+  // required). These two cases are the ones that make it safe to add.
+  it('resolves remediate_vulnerability devices when deviceId is pinned (sweep path)', async () => {
+    queueDeviceSiteSelect([{ id: 'dev-1', siteId: 'site-1' }]);
+
+    const scope = await resolveIntentTargetScope(
+      'remediate_vulnerability',
+      { deviceVulnerabilityIds: ['finding-1'], deviceId: 'dev-1' },
+      { deviceId: 'dev-1' },
+      'org-1',
+    );
+    expect(scope).toEqual({ kind: 'devices', siteIds: ['site-1'] });
+  });
+
+  it('fails closed to indirect for remediate_vulnerability when deviceId is omitted, even with a bound run device', async () => {
+    // Interactive chat may call remediate_vulnerability WITHOUT deviceId
+    // (aiToolSchemas.ts: "interactive chat may still omit it and remediate
+    // across devices as before") — the handler then does not restrict which
+    // devices the cited findings live on. A device-bound chat run's OWN
+    // device (`target.deviceId`, the 3rd arg here) must NOT be treated as a
+    // complete stand-in target in that case: the findings can span other
+    // devices/sites the resolved run device tells us nothing about. Before
+    // the #4452 fix this returned {kind:'devices', siteIds:['site-1']} —
+    // silently narrowing approver fan-out to the wrong site.
+    const scope = await resolveIntentTargetScope(
+      'remediate_vulnerability',
+      { deviceVulnerabilityIds: ['finding-1'] },
+      { deviceId: 'dev-1' },
+      'org-1',
+    );
+    expect(scope).toEqual({ kind: 'indirect' });
+    expect(db.select).not.toHaveBeenCalled();
+  });
 });
 
 describe('isAgentIntentDecideAuthorized', () => {
@@ -721,6 +760,7 @@ describe('DEVICE_COMPLETE_TARGET_TOOLS', () => {
     expect([...DEVICE_COMPLETE_TARGET_TOOLS].sort()).toEqual([
       'execute_command',
       'manage_services',
+      'remediate_vulnerability',
       'run_script',
     ]);
   });

--- a/apps/api/src/services/actionIntents/intentApprovers.ts
+++ b/apps/api/src/services/actionIntents/intentApprovers.ts
@@ -82,19 +82,34 @@ export async function resolveIntentApprovers(orgId: string): Promise<string[]> {
  * is treated as having INDIRECT targets — deployments, groups, filters —
  * and only site-UNRESTRICTED humans are eligible for it.
  *
- * Hand-verification record (2026-08-23), re-check the handler before adding
- * an entry — `intentApprovers.deviceTargets.contract.test.ts` only proves a
- * listed tool DECLARES deviceArgs, not that the declaration is complete:
+ * Hand-verification record (2026-08-23, remediate_vulnerability added #4452),
+ * re-check the handler before adding an entry —
+ * `intentApprovers.deviceTargets.contract.test.ts` only proves a listed tool
+ * DECLARES deviceArgs, not that the declaration is complete:
  * - execute_command  (aiToolsScripts.ts): acts on the single required
  *   `deviceId`; nothing else in the input reaches another device.
  * - run_script       (aiToolsScripts.ts): iterates the required `deviceIds`
  *   array only (first 10); scriptId selects content, not targets.
  * - manage_services  (aiToolsScripts.ts): single required `deviceId`;
  *   serviceName is a name on that device, not a target.
+ * - remediate_vulnerability (aiToolsVulnerability.ts): `deviceId` is
+ *   OPTIONAL, unlike the three above — the handler enforces it as a
+ *   COMPLETE pin only when the caller supplies it (every finding cited by
+ *   `deviceVulnerabilityIds` must belong to that one device, or the whole
+ *   call is refused with `finding_device_mismatch`); when omitted, findings
+ *   may legitimately span multiple devices ("interactive chat may still
+ *   omit it and remediate across devices as before", aiToolSchemas.ts). The
+ *   sweep pipeline that scopes this tool's intents always supplies it
+ *   (sweepFindings.ts's `proposalToolInput`), so the resolver below only
+ *   trusts the tool's own `deviceId` when it is actually PRESENT in args —
+ *   never the resolved intent/run device as a lone stand-in — so an
+ *   unscoped, unpinned call still falls closed to `indirect` instead of
+ *   under-representing the true device set.
  */
 export const DEVICE_COMPLETE_TARGET_TOOLS: ReadonlySet<string> = new Set([
   'execute_command',
   'manage_services',
+  'remediate_vulnerability',
   'run_script',
 ]);
 
@@ -106,7 +121,10 @@ export type IntentTargetScope =
  * Resolve the concrete target scope of a proposed agent intent. For a
  * DEVICE_COMPLETE_TARGET_TOOLS tool: the distinct site ids of every device
  * named in the tool's `deviceArgs` inputs, unioned with the intent's OWN
- * target device.
+ * target device — but only once the args themselves have named at least one
+ * device (#4452: a tool with an OPTIONAL device arg, e.g.
+ * remediate_vulnerability, must not have its target manufactured solely from
+ * `target.deviceId` when the arg is omitted — see the union site below).
  *
  * P2-2 (#4189): that third argument used to be the run row itself. It is now
  * the resolved target — `effectiveTargetDeviceId(resolveIntentTargetDevice(
@@ -151,7 +169,21 @@ export async function resolveIntentTargetScope(
     // A present-but-malformed value contributes nothing; if that leaves the
     // union empty we fall through to the fail-closed indirect branch below.
   }
-  if (target.deviceId) deviceIds.add(target.deviceId);
+  // The resolved intent target (the intent's own scope device, or the run's
+  // own device when unscoped) is unioned in ONLY as a widener on top of an
+  // already-nonempty args-derived set — never as the sole source of a
+  // 'devices' resolution. For execute_command/manage_services/run_script
+  // this changes nothing: their device args are REQUIRED, so the loop above
+  // always contributes and this union stays a pure (harmless) widen. It
+  // matters for remediate_vulnerability's OPTIONAL `deviceId`: when a call
+  // omits it, the loop above contributes nothing, and the tool is then free
+  // to touch findings on ANY device the caller can reach (see the hand-
+  // verification comment on DEVICE_COMPLETE_TARGET_TOOLS above) — so
+  // `target.deviceId`, which could be nothing more than an unrelated chat
+  // run's own bound device, must not be treated as a complete stand-in
+  // target in that case. Falling through to `indirect` below is the correct,
+  // fail-closed outcome.
+  if (deviceIds.size > 0 && target.deviceId) deviceIds.add(target.deviceId);
 
   // No resolvable device at all (malformed args + a detached run after a
   // device move, or a tombstoned scope): {kind:'devices', siteIds: []} would


### PR DESCRIPTION
## Summary

`DEVICE_COMPLETE_TARGET_TOOLS` (`apps/api/src/services/actionIntents/intentApprovers.ts`) is the hand-verified allowlist of tools whose device target can be fully resolved from their registered `deviceArgs`, used by `resolveIntentTargetScope` to narrow approver fan-out for agent-proposed action intents to the target device's site. `remediate_vulnerability` was missing from it — sweep-proposed remediation intents (wave P2-2) create device-scoped action intents, but every one of them fell through to `{kind:'indirect'}` and fanned out to unrestricted-site approvers instead of the scoped device's site, on every release/decide.

## The catch

`remediate_vulnerability`'s `deviceId` argument is **optional**, unlike the three tools already in the set (`execute_command`, `manage_services`, `run_script`), whose device args are required. The handler only enforces `deviceId` as a *complete* pin when the caller actually supplies it (every cited `deviceVulnerabilityIds` finding must belong to that device, or the whole call is refused with `finding_device_mismatch`); when omitted — legal for interactive chat — findings can legitimately span multiple devices.

Simply adding the tool to the set would have made `resolveIntentTargetScope` fall back to `target.deviceId` (the resolved intent/run device) as a stand-in "complete" target even when `deviceId` was omitted from the actual call — silently narrowing approver eligibility to the wrong site for a call that could touch other devices/sites.

## The fix

- Added `remediate_vulnerability` to `DEVICE_COMPLETE_TARGET_TOOLS` with a hand-verification entry documenting the optional-arg semantics.
- Adapted `resolveIntentTargetScope`: the resolved intent/run device (`target.deviceId`) is now unioned in only as a *widener* on top of an already non-empty args-derived device set — never as the sole source of a `'devices'` resolution. This is a no-op for the three existing tools (their args are required, so the args-derived set is never empty) and correctly falls back to `indirect` for a `remediate_vulnerability` call that omits `deviceId`.

## Test coverage

- `intentApprovers.deviceTargets.contract.test.ts`: new test derives the tool names from the real `SweepProposedAction` zod schema (`@breeze/shared/validators`, not hardcoded) and asserts every sweep-proposable tool is present in `DEVICE_COMPLETE_TARGET_TOOLS` — the next sweep-proposable tool added without updating this set now fails CI instead of silently degrading to indirect fan-out.
- `intentApprovers.test.ts`: two new cases for `resolveIntentTargetScope` — `remediate_vulnerability` resolves to `{kind:'devices'}` when `deviceId` is pinned (the sweep path), and falls back to `{kind:'indirect'}` when `deviceId` is omitted even though the run has a bound device (the regression this fix closes). Updated the `DEVICE_COMPLETE_TARGET_TOOLS` set-equality test.

Closes #4452

## Test plan

- [x] `cd apps/api && npx vitest run src/services/actionIntents` — 513 tests passed (25 files)
- [x] `npx vitest run src/services/aiToolsVulnerability.test.ts src/services/aiAgents/sweepFindings.test.ts` — 41 tests passed
- [x] `NODE_OPTIONS="--max-old-space-size=8192" npx tsc --noEmit` — clean
- [x] `npx eslint` on all three changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBxF7C8E5GxFnNcGf6kBVP