### PR TITLE
fix(api): log and surface QuickBooks reconcile skip reasons (#4543)

### DIFF
--- a/apps/api/src/jobs/accountingReconcileWorker.test.ts
+++ b/apps/api/src/jobs/accountingReconcileWorker.test.ts
@@ -364,7 +364,10 @@ describe('processReconcileConnectionJob: gating', () => {
     // The one reason with no other visible signal: stamp it on last_error
     // (finding-H mechanism) so the sync-status surface shows it too.
     expect(stampReconcileRunErrorMock).toHaveBeenCalledWith(
-      {}, CONN_ID, PARTNER_ID, expect.stringMatching(/pull.*disabled/i),
+      // The mock captures the RAW message — `stampReconcileRunError`'s own
+      // `RECONCILE_RUN_ERROR_PREFIX` ("Payment pull: ") is applied inside the
+      // (mocked-out) real function, not visible here.
+      {}, CONN_ID, PARTNER_ID, expect.stringMatching(/disabled/i),
     );
   });
 
@@ -380,6 +383,9 @@ describe('processReconcileConnectionJob: gating', () => {
       `connectionId=${CONN_ID}`,
       `partnerId=${PARTNER_ID}`,
       'trigger=sweep',
+      // The live connection that superseded the job's stale target — lets a
+      // debugger correlate without a separate query (review finding).
+      'liveConnectionId=some-other-connection',
     );
     // The live connection is a DIFFERENT row than this stale job named —
     // nothing to safely stamp.

--- a/apps/api/src/jobs/accountingReconcileWorker.test.ts
+++ b/apps/api/src/jobs/accountingReconcileWorker.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 /**
  * The Phase-D QuickBooks CDC reconcile worker (Task 4 —
@@ -294,24 +294,57 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 
 describe('processReconcileConnectionJob: gating', () => {
-  it('returns null and never calls the provider when there is no QuickBooks connection', async () => {
+  // Issue #4543: all four short-circuits used to collapse into one silent
+  // `return null` — indistinguishable from the outside. Each must now log a
+  // structured `reason=` line, and `logSpy` asserts on the exact call shape
+  // so a future short-circuit that forgets to log fails these tests.
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('returns null, logs reason=missing, and never calls the provider when there is no QuickBooks connection', async () => {
     getConnectionMock.mockResolvedValue(null);
 
     await expect(processReconcileConnectionJob(JOB)).resolves.toBeNull();
 
     expect(reconcileChangesMock).not.toHaveBeenCalled();
     expect(advanceReconcileCursorMock).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('run skipped'),
+      'reason=missing',
+      `connectionId=${CONN_ID}`,
+      `partnerId=${PARTNER_ID}`,
+      'trigger=sweep',
+    );
+    // No live connection row to stamp.
+    expect(stampReconcileRunErrorMock).not.toHaveBeenCalled();
   });
 
-  it('returns null and never calls the provider when the connection is not status=connected', async () => {
+  it('returns null, logs reason=not_connected, and never calls the provider when the connection is not status=connected', async () => {
     getConnectionMock.mockResolvedValue(connectionRow({ status: 'reauth_required' }));
 
     await expect(processReconcileConnectionJob(JOB)).resolves.toBeNull();
 
     expect(reconcileChangesMock).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('run skipped'),
+      'reason=not_connected',
+      `connectionId=${CONN_ID}`,
+      `partnerId=${PARTNER_ID}`,
+      'trigger=sweep',
+    );
+    // `status` already surfaces this on the existing status route — no
+    // separate last_error stamp needed.
+    expect(stampReconcileRunErrorMock).not.toHaveBeenCalled();
   });
 
-  it('returns null without even resolving a token when pull_payments is off', async () => {
+  it('returns null, logs reason=pull_disabled, stamps the connection, and never resolves a token when pull_payments is off', async () => {
     getConnectionMock.mockResolvedValue(connectionRow({ pullPayments: false }));
 
     await expect(processReconcileConnectionJob(JOB)).resolves.toBeNull();
@@ -321,14 +354,36 @@ describe('processReconcileConnectionJob: gating', () => {
     // QuickBooks round trip and a write, and doing it here would keep a
     // disabled connection's tokens alive forever.
     expect(resolveConnectionAndTokenMock).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('run skipped'),
+      'reason=pull_disabled',
+      `connectionId=${CONN_ID}`,
+      `partnerId=${PARTNER_ID}`,
+      'trigger=sweep',
+    );
+    // The one reason with no other visible signal: stamp it on last_error
+    // (finding-H mechanism) so the sync-status surface shows it too.
+    expect(stampReconcileRunErrorMock).toHaveBeenCalledWith(
+      {}, CONN_ID, PARTNER_ID, expect.stringMatching(/pull.*disabled/i),
+    );
   });
 
-  it('returns null when the resolved connection is not the one the job names', async () => {
+  it('returns null, logs reason=connection_mismatch, and never calls the provider when the resolved connection is not the one the job names', async () => {
     getConnectionMock.mockResolvedValue(connectionRow({ id: 'some-other-connection' }));
 
     await expect(processReconcileConnectionJob(JOB)).resolves.toBeNull();
 
     expect(reconcileChangesMock).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('run skipped'),
+      'reason=connection_mismatch',
+      `connectionId=${CONN_ID}`,
+      `partnerId=${PARTNER_ID}`,
+      'trigger=sweep',
+    );
+    // The live connection is a DIFFERENT row than this stale job named —
+    // nothing to safely stamp.
+    expect(stampReconcileRunErrorMock).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/jobs/accountingReconcileWorker.ts
+++ b/apps/api/src/jobs/accountingReconcileWorker.ts
@@ -242,14 +242,25 @@ function classifyReconcileSkip(
   return null;
 }
 
-/** One structured line per short-circuit reason (issue #4543) — see `classifyReconcileSkip`. */
-function logReconcileSkip(data: ReconcileConnectionJobData, reason: ReconcileSkipReason): void {
+/**
+ * One structured line per short-circuit reason (issue #4543) — see
+ * `classifyReconcileSkip`. On `connection_mismatch` also logs the LIVE
+ * connection id that superseded the job's stale target (review finding:
+ * without it, a debugger sees "this job's target is dead" but not what
+ * replaced it, and has to go query the connection row separately).
+ */
+function logReconcileSkip(
+  data: ReconcileConnectionJobData,
+  reason: ReconcileSkipReason,
+  conn: Pick<AccountingConnection, 'id'> | null,
+): void {
   console.log(
     '[AccountingReconcileWorker] run skipped',
     `reason=${reason}`,
     `connectionId=${data.connectionId}`,
     `partnerId=${data.partnerId}`,
     `trigger=${data.trigger}`,
+    ...(reason === 'connection_mismatch' && conn ? [`liveConnectionId=${conn.id}`] : []),
   );
 }
 
@@ -278,16 +289,16 @@ export async function processReconcileConnectionJob(
     const conn = await runInDbContext(() => getConnection(db, data.partnerId, 'quickbooks'));
     const skipReason = classifyReconcileSkip(conn, data);
     if (skipReason) {
-      logReconcileSkip(data, skipReason);
+      logReconcileSkip(data, skipReason, conn);
       // `pull_disabled` is the one reason with no OTHER visible signal:
       // `status` already surfaces `not_connected`, and `missing` /
       // `connection_mismatch` name a job whose target isn't (or is no longer)
       // the live connection, so there is nothing safe to stamp. Reuses the
-      // finding-H mechanism (`stampReconcileRunError`) so the same
-      // sync-status surface the "Sync now" card already reads shows this too.
+      // finding-H mechanism (`stampReconcileRunError`) — rendered on the
+      // connected-state "Sync now" card in QuickbooksIntegration.tsx.
       if (skipReason === 'pull_disabled' && conn) {
         await runInDbContext(() =>
-          stampReconcileRunError(db, conn.id, data.partnerId, 'skipped this run — payment pull is disabled for this connection'),
+          stampReconcileRunError(db, conn.id, data.partnerId, 'run skipped — disabled for this connection'),
         );
       }
       return null;

--- a/apps/api/src/jobs/accountingReconcileWorker.ts
+++ b/apps/api/src/jobs/accountingReconcileWorker.ts
@@ -61,6 +61,7 @@ import {
   listReconcilableConnections,
   stampReconcileRunError,
 } from '../services/accounting/accountingConnectionService';
+import type { AccountingConnection } from '../services/accounting/accountingConnectionService';
 import { resolveConnectionAndToken } from '../services/accounting/accountingMappingService';
 import { getAccountingProvider } from '../services/accounting/providerRegistry';
 import type { ChangeSetPaymentLine } from '../services/accounting/types';
@@ -213,6 +214,45 @@ function logRunLine(data: ReconcileConnectionJobData, summary: ReconcileRunSumma
   );
 }
 
+/**
+ * Why a `reconcile-connection` job is a no-op (issue #4543). Before this, all
+ * four conditions below collapsed into one silent `return null` — a
+ * switched-off connection, a lost connection, a stale job target and a
+ * genuine connectivity problem were indistinguishable from the outside.
+ *
+ *   - `missing`: no QuickBooks connection exists for this partner at all.
+ *   - `connection_mismatch`: a connection exists, but it is not the row this
+ *     job named (the partner reconnected under a new connection id between
+ *     enqueue and processing — the job's target is simply stale).
+ *   - `not_connected`: the connection exists and matches, but its `status`
+ *     is not `connected` (e.g. `reauth_required`, `error`).
+ *   - `pull_disabled`: the connection is live and matches, but the operator
+ *     has switched `pull_payments` off.
+ */
+type ReconcileSkipReason = 'missing' | 'connection_mismatch' | 'not_connected' | 'pull_disabled';
+
+function classifyReconcileSkip(
+  conn: Pick<AccountingConnection, 'id' | 'status' | 'pullPayments'> | null,
+  data: ReconcileConnectionJobData,
+): ReconcileSkipReason | null {
+  if (!conn) return 'missing';
+  if (conn.id !== data.connectionId) return 'connection_mismatch';
+  if (conn.status !== 'connected') return 'not_connected';
+  if (!conn.pullPayments) return 'pull_disabled';
+  return null;
+}
+
+/** One structured line per short-circuit reason (issue #4543) — see `classifyReconcileSkip`. */
+function logReconcileSkip(data: ReconcileConnectionJobData, reason: ReconcileSkipReason): void {
+  console.log(
+    '[AccountingReconcileWorker] run skipped',
+    `reason=${reason}`,
+    `connectionId=${data.connectionId}`,
+    `partnerId=${data.partnerId}`,
+    `trigger=${data.trigger}`,
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Job handlers (exported for direct unit testing)
 // ---------------------------------------------------------------------------
@@ -220,12 +260,12 @@ function logRunLine(data: ReconcileConnectionJobData, summary: ReconcileRunSumma
 /**
  * Reconcile ONE connection's CDC window.
  *
- * Returns `null` when the job is a no-op (no connection, a connection that is
- * not the one the job names, one that is not `connected`, or one whose
- * `pull_payments` switch is off). A switched-off connection short-circuits
- * BEFORE `resolveConnectionAndToken`: that call is itself a QuickBooks round
- * trip plus a token write, and refreshing tokens for a connection the operator
- * has disabled is work nobody asked for.
+ * Returns `null` when the job is a no-op — see `classifyReconcileSkip` for the
+ * four distinct reasons, each logged via `logReconcileSkip` (issue #4543). A
+ * switched-off connection short-circuits BEFORE `resolveConnectionAndToken`:
+ * that call is itself a QuickBooks round trip plus a token write, and
+ * refreshing tokens for a connection the operator has disabled is work nobody
+ * asked for.
  */
 export async function processReconcileConnectionJob(
   data: ReconcileConnectionJobData,
@@ -236,7 +276,22 @@ export async function processReconcileConnectionJob(
       withSystemDbAccessContext(fn, `accountingReconcile.${data.trigger}`);
 
     const conn = await runInDbContext(() => getConnection(db, data.partnerId, 'quickbooks'));
-    if (!conn || conn.id !== data.connectionId || conn.status !== 'connected' || !conn.pullPayments) return null;
+    const skipReason = classifyReconcileSkip(conn, data);
+    if (skipReason) {
+      logReconcileSkip(data, skipReason);
+      // `pull_disabled` is the one reason with no OTHER visible signal:
+      // `status` already surfaces `not_connected`, and `missing` /
+      // `connection_mismatch` name a job whose target isn't (or is no longer)
+      // the live connection, so there is nothing safe to stamp. Reuses the
+      // finding-H mechanism (`stampReconcileRunError`) so the same
+      // sync-status surface the "Sync now" card already reads shows this too.
+      if (skipReason === 'pull_disabled' && conn) {
+        await runInDbContext(() =>
+          stampReconcileRunError(db, conn.id, data.partnerId, 'skipped this run — payment pull is disabled for this connection'),
+        );
+      }
+      return null;
+    }
 
     const { conn: fresh, liveConn } = await resolveConnectionAndToken(data.partnerId, 'quickbooks', runInDbContext);
     // The realm generation this ENTIRE run is staked on (finding C). Reconnecting

--- a/apps/api/src/routes/accounting/index.ts
+++ b/apps/api/src/routes/accounting/index.ts
@@ -784,6 +784,18 @@ accountingRoutes.post('/:provider/reconcile', authMiddleware, partnerScopes, req
   const connection = await getConnection(db, partner.partnerId, provider);
   if (!connection) return c.json({ error: 'Accounting connection not found' }, 404);
 
+  // Issue #4543: refuse rather than answer `{ enqueued: true }` honestly-but-
+  // uselessly. Before this check, a connection with pull_payments off still
+  // got a 200/queued response — the reconcile worker then silently no-oped
+  // (accountingReconcileWorker.ts's `pull_disabled` short-circuit) and the
+  // operator had no way to tell "switch is off" apart from "it's syncing".
+  // 409 + a stable `code`, matching the `{ error, code }` shape
+  // AccountingConnectionError/AccountingMappingError already use elsewhere in
+  // this file, rather than adding a new response shape.
+  if (!connection.pullPayments) {
+    return c.json({ error: 'Payment pull is disabled for this connection', code: 'pull_disabled' }, 409);
+  }
+
   const enqueued = await enqueueAccountingReconcile(connection.id, partner.partnerId, 'manual');
 
   writeRouteAudit(c, {

--- a/apps/api/src/routes/accounting/reconcile.test.ts
+++ b/apps/api/src/routes/accounting/reconcile.test.ts
@@ -198,6 +198,26 @@ describe('POST /accounting/:provider/reconcile', () => {
     expect(writeRouteAuditMock).not.toHaveBeenCalled();
   });
 
+  // Issue #4543: before this, POST /reconcile always answered
+  // `{ enqueued: true }` without checking `pull_payments` — the worker then
+  // silently no-oped, so a connection with pull disabled looked like it
+  // synced but never did. Refuses with 409 + a stable `code` (matching the
+  // `{ error, code }` shape `AccountingConnectionError`/`AccountingMappingError`
+  // already use elsewhere in this file) instead of a false "queued" toast.
+  it('409 { code: "pull_disabled" } when pull_payments is off, and never enqueues', async () => {
+    getConnectionMock.mockResolvedValue(connectionRow({ pullPayments: false }));
+
+    const res = await reconcile();
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({
+      error: expect.stringMatching(/payment pull.*disabled/i),
+      code: 'pull_disabled',
+    });
+    expect(enqueueAccountingReconcileMock).not.toHaveBeenCalled();
+    expect(writeRouteAuditMock).not.toHaveBeenCalled();
+  });
+
   it('denies an org-scoped token (403) before touching the connection', async () => {
     authState.scope = 'organization';
 

--- a/apps/web/src/components/integrations/QuickbooksIntegration.test.tsx
+++ b/apps/web/src/components/integrations/QuickbooksIntegration.test.tsx
@@ -355,6 +355,29 @@ describe("QuickbooksIntegration — payment pull-back (Phase D)", () => {
     expect(line).not.toHaveTextContent("Never");
   });
 
+  // Issue #4543 (silent-failure-hunter review finding): the reconcile worker
+  // stamps a skip/failure reason onto `last_error` even while `status` stays
+  // "connected" — e.g. the 15-minute sweep racing a pull_payments toggle-off.
+  // Before this test (and the render it pins down) that stamp was DB-only:
+  // the connected-state card read `lastReconcileAt` but never `lastError`.
+  it("renders last_error on the connected-state card (not just the reauth banner)", async () => {
+    fetchWithAuth.mockImplementation(async (url: string) => {
+      if (url === "/accounting/quickbooks") {
+        return jsonResponse({
+          ...connected,
+          lastError: "Payment pull: run skipped — disabled for this connection",
+        });
+      }
+      return jsonResponse({}, 404);
+    });
+
+    render(<QuickbooksIntegration />);
+
+    expect(
+      await screen.findByTestId("quickbooks-reconcile-last-error"),
+    ).toHaveTextContent("disabled for this connection");
+  });
+
   it("Sync now POSTs the reconcile route and reports a queued job as a success", async () => {
     fetchWithAuth.mockImplementation(
       async (url: string, init?: RequestInit) => {

--- a/apps/web/src/components/integrations/QuickbooksIntegration.test.tsx
+++ b/apps/web/src/components/integrations/QuickbooksIntegration.test.tsx
@@ -415,6 +415,40 @@ describe("QuickbooksIntegration — payment pull-back (Phase D)", () => {
     );
   });
 
+  it("issue #4543 — shows the pull-disabled reason (not a generic failure) on a 409 pull_disabled reconcile response", async () => {
+    fetchWithAuth.mockImplementation(
+      async (url: string, init?: RequestInit) => {
+        if (
+          url === "/accounting/quickbooks/reconcile" &&
+          init?.method === "POST"
+        ) {
+          return jsonResponse(
+            { error: "Payment pull is disabled for this connection", code: "pull_disabled" },
+            409,
+          );
+        }
+        if (url === "/accounting/quickbooks") return jsonResponse(connected);
+        return jsonResponse({}, 404);
+      },
+    );
+
+    render(<QuickbooksIntegration />);
+    fireEvent.click(await screen.findByTestId("quickbooks-reconcile-now"));
+
+    await waitFor(() =>
+      expect(showToast).toHaveBeenCalledWith({
+        type: "error",
+        message: "Payment sync is turned off for this connection. Turn on Payment sync to sync now.",
+      }),
+    );
+    expect(showToast).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "success" }),
+    );
+    expect(showToast).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "warning" }),
+    );
+  });
+
   it("hides the pull-payments switch and the push-mode row without invoices:write", async () => {
     canWriteInvoices = false;
     fetchWithAuth.mockImplementation(async (url: string) =>

--- a/apps/web/src/components/integrations/QuickbooksIntegration.tsx
+++ b/apps/web/src/components/integrations/QuickbooksIntegration.tsx
@@ -627,6 +627,23 @@ export default function QuickbooksIntegration() {
             </p>
           </div>
 
+          {/* Issue #4543 (silent-failure-hunter finding): the reconcile
+              worker stamps a skip/failure reason onto `last_error` even while
+              `status` stays "connected" (pull_disabled, run failures,
+              a truncated CDC window). Without rendering it here, that stamp
+              was DB-only — invisible to anyone who only clicks "Sync now"
+              (the route's 409 already covers that click; this covers the
+              15-minute sweep / webhook triggers racing a toggle-off). Mirrors
+              the `needsReauth` block above. */}
+          {status.lastError && (
+            <p
+              className="text-xs text-amber-700"
+              data-testid="quickbooks-reconcile-last-error"
+            >
+              {status.lastError}
+            </p>
+          )}
+
           <div className="flex items-center gap-3 border-t pt-4">
             <button
               type="button"

--- a/apps/web/src/components/integrations/QuickbooksIntegration.tsx
+++ b/apps/web/src/components/integrations/QuickbooksIntegration.tsx
@@ -294,6 +294,11 @@ export default function QuickbooksIntegration() {
   // the toast is chosen from the boolean, and `false` gets a warning. Toasting
   // "queued" on `enqueued: false` would leave the operator waiting on a sync
   // that will never run.
+  //
+  // Issue #4543 — a connection with pull_payments off gets a distinct 409
+  // `{ code: 'pull_disabled' }` (not a `{ enqueued: false }` 200), so runAction
+  // treats it as a failure and `friendly` swaps in the translated copy instead
+  // of the route's raw English message.
   const handleReconcileNow = useCallback(async () => {
     setReconciling(true);
     try {
@@ -303,6 +308,10 @@ export default function QuickbooksIntegration() {
             method: "POST",
           }),
         errorFallback: t("quickbooksIntegration.failedToSyncNow"),
+        friendly: (code) =>
+          code === "pull_disabled"
+            ? t("quickbooksIntegration.syncNowPullDisabled")
+            : undefined,
         onUnauthorized,
       });
       showToast(

--- a/apps/web/src/locales/de-DE/integrations.json
+++ b/apps/web/src/locales/de-DE/integrations.json
@@ -787,6 +787,7 @@
     "syncNow": "Jetzt abgleichen",
     "syncNowQueued": "Zahlungsabgleich eingereiht.",
     "syncNowNotQueued": "Der Zahlungsabgleich konnte nicht eingereiht werden. Bitte in Kürze erneut versuchen.",
+    "syncNowPullDisabled": "Der Zahlungsabgleich ist für diese Verbindung deaktiviert. Aktivieren Sie den Zahlungsabgleich, um jetzt zu synchronisieren.",
     "failedToSyncNow": "Der Zahlungsabgleich konnte nicht gestartet werden."
   },
   "securityIntegration": {

--- a/apps/web/src/locales/en/integrations.json
+++ b/apps/web/src/locales/en/integrations.json
@@ -787,6 +787,7 @@
     "syncNow": "Sync now",
     "syncNowQueued": "Payment sync queued.",
     "syncNowNotQueued": "Payment sync could not be queued. Try again shortly.",
+    "syncNowPullDisabled": "Payment sync is turned off for this connection. Turn on Payment sync to sync now.",
     "failedToSyncNow": "Failed to start a payment sync."
   },
   "securityIntegration": {

--- a/apps/web/src/locales/es-419/integrations.json
+++ b/apps/web/src/locales/es-419/integrations.json
@@ -787,6 +787,7 @@
     "syncNow": "Sincronizar ahora",
     "syncNowQueued": "Sincronización de pagos en cola.",
     "syncNowNotQueued": "No se pudo poner en cola la sincronización de pagos. Inténtalo de nuevo en unos momentos.",
+    "syncNowPullDisabled": "La sincronización de pagos está desactivada para esta conexión. Activa la sincronización de pagos para sincronizar ahora.",
     "failedToSyncNow": "No se pudo iniciar la sincronización de pagos."
   },
   "securityIntegration": {

--- a/apps/web/src/locales/fr-CA/integrations.json
+++ b/apps/web/src/locales/fr-CA/integrations.json
@@ -787,6 +787,7 @@
     "syncNow": "Synchroniser maintenant",
     "syncNowQueued": "Synchronisation des paiements mise en file d'attente.",
     "syncNowNotQueued": "Impossible de mettre la synchronisation des paiements en file d'attente. Réessayez sous peu.",
+    "syncNowPullDisabled": "La synchronisation des paiements est désactivée pour cette connexion. Activez la synchronisation des paiements pour synchroniser maintenant.",
     "failedToSyncNow": "Impossible de démarrer la synchronisation des paiements."
   },
   "securityIntegration": {

--- a/apps/web/src/locales/fr-FR/integrations.json
+++ b/apps/web/src/locales/fr-FR/integrations.json
@@ -787,6 +787,7 @@
     "syncNow": "Synchroniser maintenant",
     "syncNowQueued": "Synchronisation des paiements mise en file d'attente.",
     "syncNowNotQueued": "Impossible de mettre la synchronisation des paiements en file d'attente. Réessayez dans un instant.",
+    "syncNowPullDisabled": "La synchronisation des paiements est désactivée pour cette connexion. Activez la synchronisation des paiements pour synchroniser maintenant.",
     "failedToSyncNow": "Impossible de lancer la synchronisation des paiements."
   },
   "securityIntegration": {

--- a/apps/web/src/locales/it-IT/integrations.json
+++ b/apps/web/src/locales/it-IT/integrations.json
@@ -787,6 +787,7 @@
     "syncNow": "Sincronizza ora",
     "syncNowQueued": "Sincronizzazione dei pagamenti in coda.",
     "syncNowNotQueued": "Impossibile mettere in coda la sincronizzazione dei pagamenti. Riprova tra poco.",
+    "syncNowPullDisabled": "La sincronizzazione dei pagamenti è disattivata per questa connessione. Attiva la sincronizzazione dei pagamenti per sincronizzare ora.",
     "failedToSyncNow": "Impossibile avviare la sincronizzazione dei pagamenti."
   },
   "securityIntegration": {

--- a/apps/web/src/locales/pt-BR/integrations.json
+++ b/apps/web/src/locales/pt-BR/integrations.json
@@ -787,6 +787,7 @@
     "syncNow": "Sincronizar agora",
     "syncNowQueued": "Sincronização de pagamentos na fila.",
     "syncNowNotQueued": "Não foi possível colocar a sincronização de pagamentos na fila. Tente novamente em instantes.",
+    "syncNowPullDisabled": "A sincronização de pagamentos está desativada para esta conexão. Ative a sincronização de pagamentos para sincronizar agora.",
     "failedToSyncNow": "Não foi possível iniciar a sincronização de pagamentos."
   },
   "securityIntegration": {

--- a/apps/web/src/locales/tr-TR/integrations.json
+++ b/apps/web/src/locales/tr-TR/integrations.json
@@ -787,6 +787,7 @@
     "syncNow": "Şimdi eşitle",
     "syncNowQueued": "Ödeme eşitlemesi kuyruğa alındı.",
     "syncNowNotQueued": "Ödeme eşitlemesi kuyruğa alınamadı. Kısa süre sonra yeniden deneyin.",
+    "syncNowPullDisabled": "Bu bağlantı için ödeme eşitlemesi kapalı. Şimdi eşitlemek için ödeme eşitlemesini açın.",
     "failedToSyncNow": "Ödeme eşitlemesi başlatılamadı."
   },
   "securityIntegration": {


### PR DESCRIPTION
## Summary

`processReconcileConnectionJob` (`apps/api/src/jobs/accountingReconcileWorker.ts`) collapsed four distinct no-op conditions into one silent `return null`:

- no connection for the partner (`missing`)
- a connection exists but doesn't match the job's target (`connection_mismatch` — a stale job after a reconnect)
- the connection exists and matches but isn't `status=connected` (`not_connected`)
- the connection is connected but `pull_payments` is off (`pull_disabled`)

None of these logged anything or left a trace an operator could see. `POST /:provider/reconcile` ("Sync now") compounded this by always answering `{ enqueued: true }` without checking `pull_payments`, so toggling payment pull off and pressing "Sync now" produced a success toast for a sync that would never run — surfaced by the Phase D sandbox walk (#4537).

## Fix

- **Worker**: `classifyReconcileSkip` names the reason, and `logReconcileSkip` writes one structured `console.log` line per reason (`reason`, `connectionId`, `partnerId`, `trigger`). `pull_disabled` is additionally stamped onto `accounting_connections.last_error` via the existing `stampReconcileRunError` mechanism (finding H) — the one reason with no other visible signal on the connection: `status` already surfaces `not_connected`, and `missing`/`connection_mismatch` name a job whose target isn't (or is no longer) the live connection, so there's nothing safe to stamp.
- **Route**: `POST /:provider/reconcile` now refuses with `409 { error, code: 'pull_disabled' }` when `pull_payments` is off, before ever calling `enqueueAccountingReconcile`. This matches the `{ error, code }` shape `AccountingConnectionError`/`AccountingMappingError` already use elsewhere in this file (see `handleImportError`), rather than inventing a new response shape.
- **Web**: `handleReconcileNow` passes a `friendly` mapper to `runAction` so a `pull_disabled` 409 shows a translated, specific toast ("Payment sync is turned off for this connection...") instead of the generic failure fallback. New locale key `quickbooksIntegration.syncNowPullDisabled` added to all 8 locales (parity-tested by `localeParity.test.ts`).

### One deliberate deviation from the issue's literal log-field list
The issue text says `connectionId, trigger` for the log fields (my working brief additionally said `orgId`); I logged `connectionId, partnerId, trigger` instead. `accounting_connections` has no `org_id` column — it's a partner-scoped table (Shape 3 in the tenancy model) — so `partnerId` is the correct field, and `data.partnerId` is exactly the value the job carries and the connection is looked up by.

## Tests

- `apps/api/src/jobs/accountingReconcileWorker.test.ts` — one test per skip reason (`missing`, `connection_mismatch`, `not_connected`, `pull_disabled`), asserting the exact log call shape and that `stampReconcileRunError` fires only for `pull_disabled`.
- `apps/api/src/routes/accounting/reconcile.test.ts` — new test for the `409 { code: 'pull_disabled' }` response, asserting the job is never enqueued and no audit is written.
- `apps/web/src/components/integrations/QuickbooksIntegration.test.tsx` — new test asserting the specific translated toast (not a generic failure) on the 409.
- Confirmed red-first: ran each new/changed test file against the pre-fix code and watched it fail before implementing (including reverting only the web `friendly` wiring to confirm that test discriminates).

**Evidence (this worktree, fresh `pnpm install` off `origin/main`):**
- `cd apps/api && npx vitest run src/jobs/accountingReconcileWorker.test.ts src/routes/accounting/reconcile.test.ts src/routes/accounting/index.test.ts` → 82 passed
- `cd apps/web && npx vitest run src/components/integrations/QuickbooksIntegration.test.tsx src/lib/i18n/localeParity.test.ts` → 98 passed
- `apps/api` and `apps/web`: `tsc --noEmit` clean
- `eslint` clean on all touched files

## Residuals / not in scope

- The route does **not** additionally refuse when `status !== 'connected'` — only `pull_payments`, per the issue's literal ask. The worker still logs `not_connected` as a skip reason, and `status` is already surfaced on the existing GET /:provider status route, so there's no visibility gap there today.
- PR #4624 (open, QuickBooks Phase D2 payment push — unmerged, "DO NOT MERGE without Todd" per prior session notes) mentions #4543 as "partially addressed" via a per-run log line; that PR is unmerged and its approach differs from this one (once-per-run vs. once-per-reason with a stable `reason` enum), so there's no overlap on `origin/main` today. Worth a glance when #4624 rebases.

Closes #4543

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBxF7C8E5GxFnNcGf6kBVP