### PR TITLE
fix(ai-agents): error on unknown onlyTools names instead of silently dropping them (#4447)

### DIFF
--- a/apps/api/src/services/aiAgentSdkTools.test.ts
+++ b/apps/api/src/services/aiAgentSdkTools.test.ts
@@ -14,12 +14,14 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createBreezeMcpServer, wrapExtraToolWithHooks } from './aiAgentSdkTools';
-import { buildOutcomeSdkTools, type SdkTool } from './aiAgents/outcomeTools';
+import { buildOutcomeSdkTools, isOutcomeTool, type SdkTool } from './aiAgents/outcomeTools';
 import {
   createAgentRunPostToolUse,
   createAgentRunPreToolUse,
   type AgentRunOutcome,
 } from './aiAgents/runLoop';
+import { VERDICT_TOOL_ALLOWLIST } from './aiAgents/verdictProfile';
+import { SWEEP_TOOL_ALLOWLIST } from './aiAgents/sweepProfile';
 import type { AiAgentRunProfile } from '@breeze/shared';
 import { hasDbAccessContext, __runInDbContextForTests } from '../db';
 
@@ -352,13 +354,59 @@ describe('createBreezeMcpServer wraps extraTools with the run hooks (P2-1 fix ro
         expect((caught as Error).message).toContain('this_tool_does_not_exist');
       });
 
+      it('the error message names the nearest valid tool for a typo', () => {
+        const onlyTools = new Set(['manage_alertz']);
+
+        let caught: unknown;
+        try {
+          createBreezeMcpServer(() => ({}) as never, undefined, undefined, undefined, [], { onlyTools });
+        } catch (err) {
+          caught = err;
+        }
+
+        // "manage_alertz" is one edit from the real "manage_alerts" — closer
+        // than any other registered name — so it must be the suggestion.
+        expect((caught as Error).message).toContain('manage_alerts');
+      });
+
+      it('an unmatched name with no close registered name says so rather than suggesting a distant one', () => {
+        const onlyTools = new Set(['zzzzzzzzzzzzzzzzzzzz_not_a_tool']);
+
+        let caught: unknown;
+        try {
+          createBreezeMcpServer(() => ({}) as never, undefined, undefined, undefined, [], { onlyTools });
+        } catch (err) {
+          caught = err;
+        }
+
+        // Not a strict "no suggestions" claim (edit distance always finds
+        // *something*) — this only pins that the helper still runs and
+        // produces readable output for a name with no plausible relative.
+        expect((caught as Error).message).toContain('nearest:');
+      });
+
+      it('multiple unknown names in one call: the message names every one of them', () => {
+        const onlyTools = new Set(['manage_alerts', 'not_a_real_tool_one', 'not_a_real_tool_two']);
+
+        let caught: unknown;
+        try {
+          createBreezeMcpServer(() => ({}) as never, undefined, undefined, undefined, [], { onlyTools });
+        } catch (err) {
+          caught = err;
+        }
+
+        expect((caught as Error).message).toContain('not_a_real_tool_one');
+        expect((caught as Error).message).toContain('not_a_real_tool_two');
+        // The one known-good name must never be reported as unknown.
+        expect((caught as Error).message).not.toContain('"manage_alerts"');
+      });
+
       it('production: does not throw, still narrows to matched names, logs + Sentry-captures', async () => {
-        const originalEnv = process.env.NODE_ENV;
+        vi.stubEnv('NODE_ENV', 'production');
         const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
         const sentry = await import('./sentry');
         const captureSpy = vi.spyOn(sentry, 'captureMessage').mockImplementation(() => {});
         try {
-          process.env.NODE_ENV = 'production';
           const onlyTools = new Set(['manage_alerts', 'this_tool_does_not_exist']);
 
           let server: ReturnType<typeof createBreezeMcpServer> | undefined;
@@ -372,12 +420,37 @@ describe('createBreezeMcpServer wraps extraTools with the run hooks (P2-1 fix ro
           expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('this_tool_does_not_exist'));
           expect(captureSpy).toHaveBeenCalledWith(
             expect.any(String),
-            expect.objectContaining({ eventCode: 'ai_agent_onlytools_unknown_name' }),
+            expect.objectContaining({ eventCode: 'ai_agent_onlytools_unknown_name', level: 'error' }),
           );
         } finally {
-          process.env.NODE_ENV = originalEnv;
           errorSpy.mockRestore();
           captureSpy.mockRestore();
+        }
+      });
+
+      // Silent-failure review (PR #4796): the tests above only ever build
+      // onlyTools from hand-picked names, so a real typo/rename drift in the
+      // ACTUAL production allowlists — VERDICT_TOOL_ALLOWLIST/
+      // SWEEP_TOOL_ALLOWLIST — would never be caught here. Every
+      // runLoop.*.test.ts suite mocks aiAgentSdkTools entirely, so this is
+      // the only place anything calls the real, unmocked createBreezeMcpServer
+      // with the real allowlists. Regression gate: if either list ever drifts
+      // from the tool registry, this fails loudly in CI instead of only
+      // throwing the first time a verdict/sweep run actually executes.
+      it('regression gate: the real VERDICT_TOOL_ALLOWLIST and SWEEP_TOOL_ALLOWLIST are all registered tool names', () => {
+        // Mirrors runLoop.ts's onlyTools computation: bare names (multiplexed
+        // `tool:action` entries collapse to `tool`), outcome tools excluded
+        // (they ride on extraTools, never on the registry `tools` filtered
+        // here).
+        const toOnlyTools = (allowlist: readonly string[]) => new Set(
+          allowlist.map((name) => name.split(':')[0]!).filter((name) => !isOutcomeTool(name)),
+        );
+
+        for (const allowlist of [VERDICT_TOOL_ALLOWLIST, SWEEP_TOOL_ALLOWLIST]) {
+          const onlyTools = toOnlyTools(allowlist);
+          expect(() => createBreezeMcpServer(
+            () => ({}) as never, undefined, undefined, undefined, [], { onlyTools },
+          )).not.toThrow();
         }
       });
     });

--- a/apps/api/src/services/aiAgentSdkTools.test.ts
+++ b/apps/api/src/services/aiAgentSdkTools.test.ts
@@ -309,5 +309,77 @@ describe('createBreezeMcpServer wraps extraTools with the run hooks (P2-1 fix ro
       ]));
       expect(names.length).toBeGreaterThan(50);
     });
+
+    // #4447: onlyTools is populated internally from hardcoded profile
+    // allowlists (see runLoop.ts) — never from request input — so an
+    // unmatched name is always a programming error (a typo, or a tool
+    // renamed in the registry without updating the allowlist). The old
+    // `.filter()` swallowed that error silently, quietly narrowing (or
+    // emptying) the exposed tool set with no signal to the developer.
+    describe('onlyTools containing a name that matches no registered tool (#4447)', () => {
+      it('all-known names: registers exactly that set, unchanged, and does not throw', () => {
+        const onlyTools = new Set(['manage_alerts', 'get_device_details', 'analyze_metrics', 'query_monitors']);
+
+        expect(() => createBreezeMcpServer(
+          () => ({}) as never, undefined, undefined, undefined, [], { onlyTools },
+        )).not.toThrow();
+
+        const server = createBreezeMcpServer(
+          () => ({}) as never, undefined, undefined, undefined, [], { onlyTools },
+        );
+        expect(new Set(registeredToolNames(server))).toEqual(onlyTools);
+      });
+
+      it('one unknown name: throws (NODE_ENV=test) naming the unknown name', () => {
+        const onlyTools = new Set(['manage_alerts', 'manage_alertz']);
+
+        expect(() => createBreezeMcpServer(
+          () => ({}) as never, undefined, undefined, undefined, [], { onlyTools },
+        )).toThrow(/manage_alertz/);
+      });
+
+      it('the error message lists the unknown name', () => {
+        const onlyTools = new Set(['this_tool_does_not_exist']);
+
+        let caught: unknown;
+        try {
+          createBreezeMcpServer(() => ({}) as never, undefined, undefined, undefined, [], { onlyTools });
+        } catch (err) {
+          caught = err;
+        }
+
+        expect(caught).toBeInstanceOf(Error);
+        expect((caught as Error).message).toContain('this_tool_does_not_exist');
+      });
+
+      it('production: does not throw, still narrows to matched names, logs + Sentry-captures', async () => {
+        const originalEnv = process.env.NODE_ENV;
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        const sentry = await import('./sentry');
+        const captureSpy = vi.spyOn(sentry, 'captureMessage').mockImplementation(() => {});
+        try {
+          process.env.NODE_ENV = 'production';
+          const onlyTools = new Set(['manage_alerts', 'this_tool_does_not_exist']);
+
+          let server: ReturnType<typeof createBreezeMcpServer> | undefined;
+          expect(() => {
+            server = createBreezeMcpServer(
+              () => ({}) as never, undefined, undefined, undefined, [], { onlyTools },
+            );
+          }).not.toThrow();
+
+          expect(registeredToolNames(server!)).toEqual(['manage_alerts']);
+          expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('this_tool_does_not_exist'));
+          expect(captureSpy).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({ eventCode: 'ai_agent_onlytools_unknown_name' }),
+          );
+        } finally {
+          process.env.NODE_ENV = originalEnv;
+          errorSpy.mockRestore();
+          captureSpy.mockRestore();
+        }
+      });
+    });
   });
 });

--- a/apps/api/src/services/aiAgentSdkTools.ts
+++ b/apps/api/src/services/aiAgentSdkTools.ts
@@ -30,6 +30,7 @@ import { CONFIG_FEATURE_TYPES } from './configFeatureTypes';
 import { CONTACT_ROLES } from './contacts/types';
 import { ACTOR_TYPES, AI_AGENT_KINDS, INVOICE_STATUSES } from '@breeze/shared';
 import { getToolTimeout, withToolTimeout } from './toolTimeouts';
+import { captureMessage } from './sentry';
 import {
   m365LookupUserHandler, m365RecentSigninsHandler, m365ListGroupMembershipsHandler,
   m365DisableUserHandler, m365ResetPasswordHandler,
@@ -1065,6 +1066,34 @@ function extraToolResultText(result: SdkToolResult): string {
   return JSON.stringify(result);
 }
 
+/** Levenshtein edit distance — cheapest way to surface a likely-intended
+ *  tool name for a typo without pulling in a fuzzy-match dependency. */
+function levenshteinDistance(a: string, b: string): number {
+  const rows = a.length + 1;
+  const cols = b.length + 1;
+  const dp: number[][] = Array.from({ length: rows }, () => new Array<number>(cols).fill(0));
+  for (let i = 0; i < rows; i++) dp[i]![0] = i;
+  for (let j = 0; j < cols; j++) dp[0]![j] = j;
+  for (let i = 1; i < rows; i++) {
+    for (let j = 1; j < cols; j++) {
+      dp[i]![j] = a[i - 1] === b[j - 1]
+        ? dp[i - 1]![j - 1]!
+        : 1 + Math.min(dp[i - 1]![j]!, dp[i]![j - 1]!, dp[i - 1]![j - 1]!);
+    }
+  }
+  return dp[rows - 1]![cols - 1]!;
+}
+
+/** The `limit` registered tool names nearest (by edit distance) to `name` —
+ *  used to make an unmatched `onlyTools` entry's likely typo self-evident. */
+function nearestToolNames(name: string, candidates: readonly string[], limit = 3): string[] {
+  return [...candidates]
+    .map((candidate) => ({ candidate, distance: levenshteinDistance(name, candidate) }))
+    .sort((a, b) => a.distance - b.distance)
+    .slice(0, limit)
+    .map(({ candidate }) => candidate);
+}
+
 /**
  * Creates an SDK MCP server instance with all Breeze tools.
  * Auth context is fetched lazily via the getAuth thunk so all tool handlers
@@ -1087,6 +1116,16 @@ function extraToolResultText(result: SdkToolResult): string {
  * `TOOL_TIERS`, see `outcomeTools.ts`), so there's nothing in `onlyTools` for
  * them to be filtered against. The name-collision guard below is unchanged:
  * it still runs against the full, unfiltered registry.
+ *
+ * `onlyTools` is populated only internally, from hardcoded profile
+ * allowlists (see `aiAgents/runLoop.ts`'s `onlyTools` computation) — never
+ * from request input — so a name in it that matches no registered tool is
+ * always a programming error: a typo in the allowlist, or a tool renamed in
+ * the registry without updating it. (#4447) Since every caller is internal,
+ * that condition throws outside production (test/dev), so the bug is caught
+ * before it ships; in production it degrades to the matched subset rather
+ * than failing a live run, but is loudly logged and Sentry-captured so it
+ * cannot slip by unnoticed the way the old silent `.filter()` did.
  */
 export function createBreezeMcpServer(
   getAuth: () => AuthContext,
@@ -2708,6 +2747,33 @@ export function createBreezeMcpServer(
   const registeredTools = options?.onlyTools
     ? tools.filter((t) => options.onlyTools!.has(t.name))
     : tools;
+
+  // #4447: a name in onlyTools that matches no registered tool used to be
+  // dropped here with no signal at all. See this function's docstring for
+  // why every caller being internal means this is always a bug, not a
+  // runtime condition, and for the throw/log-and-capture split below.
+  if (options?.onlyTools) {
+    const matchedNames = new Set(registeredTools.map((t) => t.name));
+    const unknownNames = [...options.onlyTools].filter((name) => !matchedNames.has(name));
+    if (unknownNames.length > 0) {
+      const allNames = tools.map((t) => t.name);
+      const detail = unknownNames
+        .map((name) => {
+          const nearest = nearestToolNames(name, allNames);
+          return `"${name}" (nearest: ${nearest.length > 0 ? nearest.join(', ') : 'no close match'})`;
+        })
+        .join('; ');
+      const message = `[createBreezeMcpServer] onlyTools referenced unknown tool name(s): ${detail}`;
+      if (process.env.NODE_ENV !== 'production') {
+        throw new Error(message);
+      }
+      console.error(message);
+      captureMessage('onlyTools referenced unknown tool name(s)', {
+        eventCode: 'ai_agent_onlytools_unknown_name',
+        level: 'error',
+      });
+    }
+  }
 
   return createSdkMcpServer({
     name: 'breeze',

--- a/apps/api/src/services/aiAgentSdkTools.ts
+++ b/apps/api/src/services/aiAgentSdkTools.ts
@@ -1124,8 +1124,13 @@ function nearestToolNames(name: string, candidates: readonly string[], limit = 3
  * the registry without updating it. (#4447) Since every caller is internal,
  * that condition throws outside production (test/dev), so the bug is caught
  * before it ships; in production it degrades to the matched subset rather
- * than failing a live run, but is loudly logged and Sentry-captured so it
- * cannot slip by unnoticed the way the old silent `.filter()` did.
+ * than failing a live run, but logs via `console.error` and Sentry-captures
+ * (event code `ai_agent_onlytools_unknown_name`) so it does not vanish the
+ * way the old silent `.filter()` did. The Sentry capture is best-effort, not
+ * guaranteed delivery: on a self-hosted install with no `SENTRY_DSN`,
+ * `captureMessage` is a documented no-op (see `sentry.ts`) and the
+ * `console.error` line is the only surviving signal — an operator has to be
+ * watching API logs, not a Sentry inbox, to catch it there.
  */
 export function createBreezeMcpServer(
   getAuth: () => AuthContext,

--- a/apps/api/src/services/sentryEventCodes.ts
+++ b/apps/api/src/services/sentryEventCodes.ts
@@ -111,6 +111,17 @@ export const SENTRY_EVENT_CODES = [
   /** An AI budget alert event never became visible before its retries ran out. */
   'ai_budget_alert_event_not_visible',
 
+  // --- ai agent tool registry ---------------------------------------------
+  /**
+   * `createBreezeMcpServer`'s `onlyTools` (verdict/sweep tool pinning)
+   * contained a name that matched no registered tool — always a programming
+   * error (a typo in a hardcoded profile allowlist, or a tool renamed
+   * without updating it), never request input (#4447). Thrown in test/dev;
+   * in production the run degrades to the matched subset rather than
+   * failing, so this is the only signal an operator gets.
+   */
+  'ai_agent_onlytools_unknown_name',
+
   // --- backup -----------------------------------------------------------
   /** A backup result matched no job row (deleted, or invisible under RLS). */
   'backup_result_job_not_found',

--- a/apps/api/src/services/sentryEventCodes.ts
+++ b/apps/api/src/services/sentryEventCodes.ts
@@ -111,7 +111,7 @@ export const SENTRY_EVENT_CODES = [
   /** An AI budget alert event never became visible before its retries ran out. */
   'ai_budget_alert_event_not_visible',
 
-  // --- ai agent tool registry ---------------------------------------------
+  // --- ai agent tool registry -------------------------------------------
   /**
    * `createBreezeMcpServer`'s `onlyTools` (verdict/sweep tool pinning)
    * contained a name that matched no registered tool — always a programming


### PR DESCRIPTION
## Summary

`createBreezeMcpServer`'s `options.onlyTools` filter (verdict/sweep tool pinning, F2 fix wave P2-1) used to silently drop any name in `onlyTools` that matched no registered tool:

```ts
const registeredTools = options?.onlyTools
  ? tools.filter((t) => options.onlyTools!.has(t.name))
  : tools;
```

A typo in a hardcoded profile allowlist, or a tool renamed in the registry without updating the allowlist, would quietly narrow (or empty) the exposed tool set for a verdict/sweep run — with no signal to the developer or operator. Source: #4188 rulings comment, part of the #4187 follow-up sweep.

## Fix

After filtering, diff `onlyTools` against the matched tool names. For any unmatched name:

- Build an error message naming the unknown name(s) and, for each, the 3 nearest registered tool names by Levenshtein edit distance (surfaces the likely typo).
- **Choice of throw-everywhere vs. throw-in-dev-only:** `git grep -n onlyTools origin/main -- apps/api/src` shows the only caller is internal (`aiAgents/runLoop.ts`, computed from hardcoded `profileAllowlist`/`SWEEP_TOOL_ALLOWLIST` constants) — never request input. So an unmatched name is always a programming error, not a runtime condition. Given that, I went with **throw outside production (`NODE_ENV !== 'production'`), log + Sentry-capture in production** rather than throwing unconditionally everywhere: throwing in test/dev catches the bug before it ships (and is exercised directly by the new tests, since vitest runs with `NODE_ENV=test`), while in production a live verdict/sweep run degrades to the matched subset instead of hard-failing outright — but it's now loud (console.error + a new bounded Sentry event code `ai_agent_onlytools_unknown_name`), not silent.

## Tests (red first)

Added to `createBreezeMcpServer options.onlyTools (Task 16c F2)` in `aiAgentSdkTools.test.ts`:
- all-known names → registers exactly that set, unchanged, does not throw
- one unknown name → throws (`NODE_ENV=test`) naming the unknown name
- error message contains the unknown name
- production (`NODE_ENV=production`) → does not throw, still narrows to the matched subset, `console.error` + `captureMessage` (with the new event code) both fire

All 3 new assertions were red before the fix (confirmed), green after.

## Verification

- `cd apps/api && npx vitest run src/services/aiAgentSdkTools` — 13/13 passed
- `cd apps/api && npx vitest run src/services/aiAgentSdkTools src/services/sentryEventCodes.test.ts` — 76/76 passed (9 files, substring match also picked up related suites)
- `cd apps/api && npx vitest run src/services/aiAgents/runLoop` — 151/151 passed (the only internal caller of `onlyTools`, unaffected)
- `cd apps/api && npx tsc --noEmit` — clean
- `npx eslint` on the 3 changed files — clean

Closes #4447

🤖 Generated with [Claude Code](https://claude.com/claude-code)