### PR TITLE
fix(billing): block QuickBooks push on voided/remote-deleted invoices (#4544)

### DIFF
--- a/apps/api/src/routes/accounting/invoicePush.test.ts
+++ b/apps/api/src/routes/accounting/invoicePush.test.ts
@@ -235,6 +235,22 @@ describe('POST /accounting/:provider/invoices/:invoiceId/push', () => {
     expect(writeRouteAuditMock).not.toHaveBeenCalled();
   });
 
+  // #4544: a mapping row carrying the remote-deleted marker must reject the
+  // push with a stable 409 code, not a generic/quickbooks-flavored error the
+  // web layer would have to guess at.
+  it('409 pass-through: remote_deleted (invoice deleted/voided in QuickBooks) is never a silent no-op or a generic error', async () => {
+    pushInvoiceToAccountingMock.mockRejectedValue(
+      new AccountingInvoicePushError('remote_deleted', 409, 'QuickBooks reports this invoice as deleted — pushing again would create a duplicate.'),
+    );
+    const res = await pushInvoice();
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({
+      error: 'remote_deleted',
+      message: 'QuickBooks reports this invoice as deleted — pushing again would create a duplicate.',
+    });
+    expect(writeRouteAuditMock).not.toHaveBeenCalled();
+  });
+
   it('404 pass-through: an unpushable/unknown invoice preserves its code', async () => {
     pushInvoiceToAccountingMock.mockRejectedValue(new AccountingInvoicePushError('invoice_not_pushable', 404, 'Invoice not found for this partner'));
     const res = await pushInvoice();

--- a/apps/api/src/services/accounting/accountingInvoicePush.test.ts
+++ b/apps/api/src/services/accounting/accountingInvoicePush.test.ts
@@ -233,6 +233,19 @@ function orgMappingRow(overrides: Partial<MappingRow> = {}): MappingRow {
   };
 }
 
+// #4544: the exact shape `markInvoiceDeletedRemotely` (accountingPaymentPull.ts)
+// leaves behind — sync_status flipped to 'error', last_error the sentinel
+// literal, remote_entity_id deliberately NOT cleared (Phase D decision 2).
+function remoteDeletedInvoiceMappingRow(overrides: Partial<MappingRow> = {}): MappingRow {
+  return {
+    id: 'map-inv-1', integrationId: CONN_ID, partnerId: PARTNER, breezeEntityType: 'invoice', breezeEntityId: INVOICE,
+    remoteEntityType: 'Invoice', remoteEntityId: 'qb-inv-1', remoteSyncToken: '3',
+    remoteCurrencyCode: null, remoteDocNumber: null, linkStatus: 'confirmed', syncStatus: 'error',
+    lastError: 'Deleted in QuickBooks',
+    ...overrides,
+  };
+}
+
 function setup(opts: {
   invoice?: Partial<InvRow>;
   lines?: Partial<LineRow>[];
@@ -423,6 +436,51 @@ describe('pushInvoiceToAccounting', () => {
       code: 'invoice_not_pushable', status: 409,
     });
     expect(pushInvoiceMock).not.toHaveBeenCalled();
+  });
+
+  // #4544: markInvoiceDeletedRemotely leaves the invoice's mapping row
+  // sync_status='error' — pushable per PUSHABLE_STATUSES/isPushable on its
+  // own — so the remote-deleted marker must be its own guard, not folded
+  // into invoice_not_pushable.
+  it('rejects with remote_deleted (never re-creating the invoice in QuickBooks) when the mapping carries the remote-deleted marker, without ever calling org sync', async () => {
+    setup({ mappings: [orgMappingRow(), remoteDeletedInvoiceMappingRow()] });
+
+    await expect(pushInvoiceToAccounting(INVOICE, PARTNER, runCtx)).rejects.toMatchObject({
+      code: 'remote_deleted', status: 409,
+    });
+    expect(pushInvoiceMock).not.toHaveBeenCalled();
+    // Phase 1's early exit (before the currency/dependency-sync work) — the
+    // org mapping is already 'synced' in this fixture, so a call here would
+    // mean the guard fired too late to matter for THIS assertion; the
+    // ordering itself is covered by the "before any provider call" describe
+    // block's pattern elsewhere in this file.
+    expect(syncMappedEntityMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects with remote_deleted even when the marker appears only after Phase 1 (closes the Phase-1b re-check race)', async () => {
+    // Org mapping starts 'pending' so the coordinator actually calls
+    // syncMappedEntity between Phase 1 (no invoice mapping yet — passes) and
+    // Phase 1b (re-reads the mapping row to claim it 'pending'). The marker
+    // lands mid-sync, as if the reconcile worker ran concurrently.
+    setup({ mappings: [orgMappingRow({ syncStatus: 'pending' })] });
+    syncMappedEntityMock.mockImplementationOnce(async (...args: unknown[]) => {
+      currentMappings.push(remoteDeletedInvoiceMappingRow());
+      const [{ breezeEntityType, breezeEntityId }] = args as [{ breezeEntityType: string; breezeEntityId: string }];
+      const existing = currentMappings.find((m) => m.breezeEntityType === breezeEntityType && m.breezeEntityId === breezeEntityId)!;
+      const updated = { ...existing, syncStatus: 'synced' as const };
+      const idx = currentMappings.findIndex((m) => m.id === existing.id);
+      currentMappings[idx] = updated;
+      return updated;
+    });
+
+    await expect(pushInvoiceToAccounting(INVOICE, PARTNER, runCtx)).rejects.toMatchObject({
+      code: 'remote_deleted', status: 409,
+    });
+    expect(pushInvoiceMock).not.toHaveBeenCalled();
+    // The row must still carry the original marker — upsertInvoiceMappingPending
+    // must never have run and cleared it.
+    const row = currentMappings.find((m) => m.breezeEntityType === 'invoice' && m.breezeEntityId === INVOICE);
+    expect(row?.lastError).toBe('Deleted in QuickBooks');
   });
 
   describe('currency guard runs before any provider call', () => {

--- a/apps/api/src/services/accounting/accountingInvoicePush.test.ts
+++ b/apps/api/src/services/accounting/accountingInvoicePush.test.ts
@@ -483,6 +483,51 @@ describe('pushInvoiceToAccounting', () => {
     expect(row?.lastError).toBe('Deleted in QuickBooks');
   });
 
+  // The two tests above prove the OUTCOME (the checked-then-thrown JS path).
+  // Neither can prove the row-claiming UPDATE itself is conditioned on the
+  // marker at the SQL level — this mock harness applies a patch synchronously
+  // against the same `currentMappings` array both the JS check and the UPDATE
+  // read, so there is no way to make the marker "invisible to the JS check but
+  // visible to the UPDATE" the way two genuinely concurrent Postgres
+  // transactions would be. Proving THAT requires a live database (out of
+  // scope for this fully-mocked unit file). This test instead proves the
+  // UPDATE's compiled WHERE clause — a REAL (unmocked) drizzle-orm SQL tree,
+  // same technique as `sqlColumnsAndValues` elsewhere in this file — actually
+  // carries the remote-deleted guard predicate, so a future edit that quietly
+  // drops the `or(isNull(...), ne(...))` condition (leaving only the
+  // check-then-write JS guard, reopening the TOCTOU code review flagged) fails
+  // this test instead of shipping silently.
+  it('the claiming UPDATE conditions on the row NOT already carrying the remote-deleted marker (SQL-level regression guard)', async () => {
+    setup({
+      mappings: [
+        orgMappingRow(),
+        { ...remoteDeletedInvoiceMappingRow(), lastError: null, syncStatus: 'synced' }, // marker cleared — claimable
+      ],
+    });
+    // Capture only the FIRST update (the claim-pending write) — a successful
+    // push issues a second one later (persistInvoiceRemoteRef) whose WHERE
+    // clause has no reason to carry this predicate and would overwrite the
+    // capture if not guarded against.
+    let capturedWhereCond: unknown;
+    let captured = false;
+    updateMock.mockImplementation(() => ({
+      set: (patch: Record<string, unknown>) => ({
+        where: (cond: unknown) => ({
+          returning: () => {
+            if (!captured) { capturedWhereCond = cond; captured = true; }
+            const idx = currentMappings.findIndex((row) => conditionContainsValue(cond, row.id));
+            currentMappings[idx] = { ...currentMappings[idx], ...patch } as MappingRow;
+            return Promise.resolve([currentMappings[idx]]);
+          },
+        }),
+      }),
+    }));
+
+    await pushInvoiceToAccounting(INVOICE, PARTNER, runCtx);
+
+    expect(conditionContainsValue(capturedWhereCond, 'Deleted in QuickBooks')).toBe(true);
+  });
+
   describe('currency guard runs before any provider call', () => {
     it('blocks with home_currency_unknown when the realm home currency is unavailable', async () => {
       resolveConnectionMock.mockResolvedValue(conn({ homeCurrency: null }));
@@ -913,6 +958,23 @@ describe('voidInvoiceInAccounting', () => {
 
     await expect(voidInvoiceInAccounting(INVOICE, PARTNER, runCtx)).resolves.toBeUndefined();
     expect(voidInvoiceMock).not.toHaveBeenCalled();
+  });
+
+  // #4544: markInvoiceDeletedRemotely deliberately leaves remoteEntityId set
+  // (see its own doc comment), so a remote-deleted mapping does NOT take the
+  // no-remote-id no-op path above — without this guard it would call
+  // provider.voidInvoice against an id QuickBooks no longer recognizes, and
+  // the resulting failure's catch block would overwrite (clobber) this exact
+  // marker with a generic QuickBooks error, silently reopening the door for
+  // a later push to re-create the invoice — the same bug via a different path.
+  it('no-ops for an already remote-deleted mapping and preserves the marker, never calling the provider', async () => {
+    setup({ mappings: [orgMappingRow(), remoteDeletedInvoiceMappingRow()] });
+
+    await expect(voidInvoiceInAccounting(INVOICE, PARTNER, runCtx)).resolves.toBeUndefined();
+    expect(voidInvoiceMock).not.toHaveBeenCalled();
+    const row = currentMappings.find((m) => m.breezeEntityType === 'invoice' && m.breezeEntityId === INVOICE);
+    expect(row?.lastError).toBe('Deleted in QuickBooks');
+    expect(row?.syncStatus).toBe('error');
   });
 
   it('calls provider.voidInvoice with the stored mapping for a pushed invoice, and leaves sync_status/last_error untouched on success', async () => {

--- a/apps/api/src/services/accounting/accountingInvoicePush.ts
+++ b/apps/api/src/services/accounting/accountingInvoicePush.ts
@@ -39,7 +39,7 @@
  * again and double-booked the invoice in QuickBooks.
  */
 
-import { and, eq } from 'drizzle-orm';
+import { and, eq, isNull, ne, or } from 'drizzle-orm';
 import { db, runOutsideDbContext } from '../../db';
 import { accountingEntityMappings, invoiceLines, invoices } from '../../db/schema';
 import type { AccountingEntityMapping as AccountingEntityMappingRow } from '../../db/schema';
@@ -332,16 +332,50 @@ async function upsertInvoiceMappingPending(params: {
 }): Promise<MappingRow> {
   try {
     if (params.existing) {
+      // The WHERE clause's remote-deleted condition (#4544) is what actually
+      // closes the race the caller's plain check-then-write left open: a
+      // check-then-separate-UPDATE can still straddle a concurrent
+      // `markInvoiceDeletedRemotely` commit between the two statements, no
+      // matter how small that window is made. Conditioning the UPDATE itself
+      // means that write can NEVER clear the marker once it has landed —
+      // either this UPDATE claims the row before the marker exists, or the
+      // marker already exists and this UPDATE matches zero rows.
       const rows = await db
         .update(accountingEntityMappings)
         .set({ syncStatus: 'pending', lastError: null, updatedAt: new Date() })
         .where(and(
           eq(accountingEntityMappings.id, params.existing.id),
           eq(accountingEntityMappings.partnerId, params.partnerId),
+          or(
+            isNull(accountingEntityMappings.lastError),
+            ne(accountingEntityMappings.lastError, INVOICE_REMOTE_DELETED_ERROR),
+          ),
         ))
         .returning();
       const row = (rows as MappingRow[])[0];
-      if (!row) throw new Error(`invoice mapping pending-update matched no row (id=${params.existing.id})`);
+      if (!row) {
+        // Zero rows: either the remote-deleted marker landed on this row
+        // between the caller's read and this UPDATE (the race above), or
+        // something else unexpected happened (row deleted entirely, etc).
+        // Disambiguate with one more read — this read is diagnostic only,
+        // not load-bearing: the UPDATE above already guarantees the marker
+        // was never silently cleared, whichever branch this takes.
+        const recheck = await db
+          .select({ lastError: accountingEntityMappings.lastError })
+          .from(accountingEntityMappings)
+          .where(and(
+            eq(accountingEntityMappings.id, params.existing.id),
+            eq(accountingEntityMappings.partnerId, params.partnerId),
+          ));
+        if (recheck[0]?.lastError === INVOICE_REMOTE_DELETED_ERROR) {
+          throw new AccountingInvoicePushError(
+            'remote_deleted',
+            409,
+            'QuickBooks reports this invoice as deleted — pushing again would create a duplicate. Resolve it in QuickBooks, or unlink and re-map the invoice, before pushing again.',
+          );
+        }
+        throw new Error(`invoice mapping pending-update matched no row (id=${params.existing.id})`);
+      }
       return row;
     }
 
@@ -741,6 +775,17 @@ export async function voidInvoiceInAccounting(
       }
       return null;
     }
+
+    // Already remote-deleted (#4544): QuickBooks reports this invoice gone,
+    // and `markInvoiceDeletedRemotely` deliberately leaves `remoteEntityId`
+    // set (see its own doc comment) so this branch is reached instead of the
+    // no-remote-id no-op above. There is nothing left in QuickBooks to void —
+    // calling `provider.voidInvoice` against a remote id QuickBooks no
+    // longer recognizes would very likely fail, and the catch block below
+    // would then overwrite (clobber) this EXACT marker with a generic
+    // QuickBooks error message, silently undoing the guard
+    // `pushInvoiceToAccounting` relies on to refuse to resurrect the invoice.
+    if (mappingRow.lastError === INVOICE_REMOTE_DELETED_ERROR) return null;
 
     const inv = await loadOwnedInvoice(invoiceId, partnerId);
     return { conn, mappingRow, inv };

--- a/apps/api/src/services/accounting/accountingInvoicePush.ts
+++ b/apps/api/src/services/accounting/accountingInvoicePush.ts
@@ -55,17 +55,24 @@ import { AccountingCurrencyContractError, assertAccountingInvoicePushCurrency, n
 import { getAccountingProvider } from './providerRegistry';
 import { captureException } from '../sentry';
 import { isPgUniqueViolation } from '../../utils/pgErrors';
-import type {
-  AccountingEntityMapping as AccountingEntityMappingSeam,
-  AccountingInvoiceLineMapping,
-  AccountingInvoiceLinePayload,
-  AccountingInvoicePayload,
-  AccountingVoidInvoicePayload,
-  InvoicePushResult,
+import {
+  INVOICE_REMOTE_DELETED_ERROR,
+  type AccountingEntityMapping as AccountingEntityMappingSeam,
+  type AccountingInvoiceLineMapping,
+  type AccountingInvoiceLinePayload,
+  type AccountingInvoicePayload,
+  type AccountingVoidInvoicePayload,
+  type InvoicePushResult,
 } from './types';
 
 export type AccountingInvoicePushErrorCode =
   | 'not_connected' | 'reauth_required' | 'invoice_not_pushable' // draft or unknown invoice
+  // The invoice's mapping row is the `markInvoiceDeletedRemotely` marker (#4544):
+  // the reconcile worker saw QuickBooks delete/void the previously-pushed
+  // invoice. Deliberately never auto-resurrected (Phase D decision 2) — a push
+  // must not silently clear the marker and re-create a second QuickBooks
+  // invoice for a document the operator (or QuickBooks user) removed there.
+  | 'remote_deleted'
   | 'customer_not_mapped' // org mapping absent / not confirmed|create_new
   | 'home_currency_unknown' | 'currency_mismatch' // realm-level (from assert)
   | 'customer_currency_mismatch' // mapping.remoteCurrencyCode ≠ invoice.currencyCode
@@ -178,6 +185,22 @@ async function loadMappingRowsForType(
       eq(accountingEntityMappings.breezeEntityType, breezeEntityType),
     ));
   return rows as MappingRow[];
+}
+
+/**
+ * True when this invoice already has a mapping row carrying the
+ * `markInvoiceDeletedRemotely` marker (#4544). Reuses `loadMappingRowsForType`
+ * (same query Phase 1b re-issues right before claiming the row) rather than a
+ * one-off projected query, so both checks read the mapping the same way.
+ */
+async function loadInvoiceMappingIsRemoteDeleted(
+  partnerId: string,
+  integrationId: string,
+  invoiceId: string,
+): Promise<boolean> {
+  const invoiceMappingRows = await loadMappingRowsForType(partnerId, integrationId, 'invoice');
+  const existing = invoiceMappingRows.find((m) => m.breezeEntityId === invoiceId) ?? null;
+  return existing?.lastError === INVOICE_REMOTE_DELETED_ERROR;
 }
 
 // ---------------------------------------------------------------------------
@@ -475,6 +498,22 @@ export async function pushInvoiceToAccounting(
       );
     }
 
+    // Remote-deleted guard (#4544) runs BEFORE any org/item lookup, token
+    // refresh or provider call, same rationale as the currency guard below —
+    // a permanent refusal must not pay for work whose only purpose is a push
+    // that can never succeed. Phase 1b re-checks this against a fresh read
+    // right before claiming the mapping row `pending`, since the reconcile
+    // worker can flip it to remote-deleted while the dependency syncs below
+    // are still in flight — this early check is a cheap-exit optimization,
+    // not the sole enforcement point.
+    if (await loadInvoiceMappingIsRemoteDeleted(partnerId, conn.id, inv.id)) {
+      throw new AccountingInvoicePushError(
+        'remote_deleted',
+        409,
+        'QuickBooks reports this invoice as deleted — pushing again would create a duplicate. Resolve it in QuickBooks, or unlink and re-map the invoice, before pushing again.',
+      );
+    }
+
     // Currency guard runs BEFORE any org/item lookup, token refresh or provider
     // call (multi-currency §11 contract, accountingCurrency.ts:143-186).
     try {
@@ -559,6 +598,20 @@ export async function pushInvoiceToAccounting(
   const mappingRow = await runInDbContext(async () => {
     const invoiceMappingRows = await loadMappingRowsForType(partnerId, conn.id, 'invoice');
     const existingInvoiceMapping = invoiceMappingRows.find((m) => m.breezeEntityId === inv.id) ?? null;
+    // Re-check remote-deleted against this fresh read (#4544): the reconcile
+    // worker's `markInvoiceDeletedRemotely` can land while the org/item
+    // dependency syncs above were in flight, after Phase 1's early check
+    // already passed. This is the check that actually closes the race —
+    // upsertInvoiceMappingPending below would otherwise clear the marker
+    // (`lastError: null`) and let the push through, re-creating the invoice
+    // in QuickBooks.
+    if (existingInvoiceMapping?.lastError === INVOICE_REMOTE_DELETED_ERROR) {
+      throw new AccountingInvoicePushError(
+        'remote_deleted',
+        409,
+        'QuickBooks reports this invoice as deleted — pushing again would create a duplicate. Resolve it in QuickBooks, or unlink and re-map the invoice, before pushing again.',
+      );
+    }
     return upsertInvoiceMappingPending({
       existing: existingInvoiceMapping,
       integrationId: conn.id,

--- a/apps/api/src/services/accounting/accountingPaymentPull.ts
+++ b/apps/api/src/services/accounting/accountingPaymentPull.ts
@@ -82,7 +82,7 @@ import { accountingConnections } from '../../db/schema';
 import { assertNoAmbientDbContext, type DbContextRunner } from './dbContextGuard';
 import { AccountingCurrencyContractError, normalizeAccountingPayment } from './accountingCurrency';
 import type { AccountingConnection } from './accountingConnectionService';
-import type { ChangeSetPaymentLine } from './types';
+import { INVOICE_REMOTE_DELETED_ERROR, type ChangeSetPaymentLine } from './types';
 import { recomputeInvoiceStatus } from '../invoiceService';
 import { writeAuditEvent, requestLikeFromSnapshot } from '../auditEvents';
 import { captureException } from '../sentry';
@@ -878,7 +878,7 @@ export async function markInvoiceDeletedRemotely(
     if (!await realmStillMatches(conn, expectedRealmFingerprint)) return 'realm_changed';
     const mapping = await loadMappingByRemoteId(conn, 'invoice', 'Invoice', remoteInvoiceId);
     if (!mapping) return 'skipped_unmapped';
-    await markInvoiceMappingError(conn, mapping.id, 'Deleted in QuickBooks');
+    await markInvoiceMappingError(conn, mapping.id, INVOICE_REMOTE_DELETED_ERROR);
     return 'marked';
   });
 }

--- a/apps/api/src/services/accounting/types.ts
+++ b/apps/api/src/services/accounting/types.ts
@@ -240,3 +240,19 @@ export interface AccountingProvider {
   reconcileChanges(conn: AccountingConnection, sinceCursor: Date | null): Promise<ChangeSet>;
   verifyWebhook(signatureHeader: string, rawBody: string, verifierToken: string): boolean;
 }
+
+/**
+ * The exact `accounting_entity_mappings.last_error` sentinel
+ * `markInvoiceDeletedRemotely` (accountingPaymentPull.ts) writes when the
+ * reconcile worker sees QuickBooks deleted/voided an invoice Breeze pushed
+ * (Phase D decision 2: never auto-resurrected). Written UNPREFIXED so it can
+ * never collide with the `PAYMENT_PULL_ERROR_PREFIX` bucket.
+ *
+ * Kept here — a leaf module with no other imports — rather than in
+ * accountingPaymentPull.ts (which imports invoiceService, which would need
+ * this constant too) or invoiceService.ts (imported by accountingPaymentPull.ts),
+ * either of which would create a cycle. Both the writer and every reader
+ * (accountingInvoicePush.ts's push guard, invoiceService.ts's summary) import
+ * this single constant instead of duplicating or string-matching the literal.
+ */
+export const INVOICE_REMOTE_DELETED_ERROR = 'Deleted in QuickBooks';

--- a/apps/api/src/services/invoiceService.test.ts
+++ b/apps/api/src/services/invoiceService.test.ts
@@ -1443,7 +1443,25 @@ describe('getInvoice — accountingSync (QuickBooks Phase C, Task 5)', () => {
       lastSyncedAt: '2026-09-01T12:00:00.000Z',
       lastError: null,
       remoteDocNumber: '1042',
+      remoteDeleted: false,
     });
+  });
+
+  // #4544: markInvoiceDeletedRemotely (accountingPaymentPull.ts) writes this
+  // exact lastError; getInvoiceAccountingSync must surface it as a typed
+  // boolean rather than making the web layer string-match lastError.
+  it('surfaces remoteDeleted: true when the mapping carries the remote-deleted marker', async () => {
+    queueResult([{ id: 'i1', status: 'sent', orgId: 'org1', partnerId: 'p1', currencyCode: 'USD' }]);
+    queueResult([]);
+    queueResult([]);
+    queueResult([{
+      syncStatus: 'error',
+      lastSyncedAt: null,
+      lastError: 'Deleted in QuickBooks',
+      remoteDocNumber: null,
+    }]);
+    const out = await svc.getInvoice('i1', partnerActor);
+    expect(out.accountingSync).toMatchObject({ syncStatus: 'error', remoteDeleted: true });
   });
 
   it('is null when the mapping read returns no row (never connected, or RLS hides a partner-axis table from an org-scoped read) — fail closed, no special-casing', async () => {

--- a/apps/api/src/services/invoiceService.ts
+++ b/apps/api/src/services/invoiceService.ts
@@ -18,6 +18,7 @@ import { enqueueInvoicePdfRender } from '../jobs/invoiceWorker';
 import { enqueueAccountingInvoicePush, enqueueAccountingInvoiceVoid } from '../jobs/accountingSyncWorker';
 import type { MappingSyncStatus } from './accounting/accountingMappingService';
 import { clearPaymentMappingForInvoicePayment } from './accounting/accountingPaymentPull';
+import { INVOICE_REMOTE_DELETED_ERROR } from './accounting/types';
 import { gatherOrgTimeEntries, gatherOrgParts, gatherTicketBillables, mergeAssembly, type AssemblyResult, type DraftLineSpec, type MissingRateSpec } from './invoiceAssembly';
 import { buildSellerSnapshot, buildBillToAddress } from './sellerSnapshot';
 import { InvoiceServiceError } from './invoiceTypes';
@@ -622,6 +623,15 @@ export interface InvoiceAccountingSync {
   lastSyncedAt: string | null;
   lastError: string | null;
   remoteDocNumber: string | null;
+  /**
+   * True when this mapping row carries the `markInvoiceDeletedRemotely`
+   * marker (#4544) — the reconcile worker saw QuickBooks delete/void an
+   * invoice Breeze previously pushed. Computed here, server-side, from the
+   * one place that knows the exact sentinel `lastError` string
+   * (`INVOICE_REMOTE_DELETED_ERROR`), so the web layer never has to
+   * string-match `lastError` to decide whether re-pushing is safe.
+   */
+  remoteDeleted: boolean;
 }
 
 /**
@@ -664,6 +674,7 @@ async function getInvoiceAccountingSync(invoiceId: string, partnerId: string): P
     lastSyncedAt: row.lastSyncedAt ? row.lastSyncedAt.toISOString() : null,
     lastError: row.lastError,
     remoteDocNumber: row.remoteDocNumber,
+    remoteDeleted: row.lastError === INVOICE_REMOTE_DELETED_ERROR,
   };
 }
 

--- a/apps/web/src/components/billing/AccountingSyncCard.test.tsx
+++ b/apps/web/src/components/billing/AccountingSyncCard.test.tsx
@@ -20,6 +20,7 @@ const sync = (over: Partial<AccountingSyncSummary> = {}): AccountingSyncSummary 
   lastSyncedAt: null,
   lastError: null,
   remoteDocNumber: null,
+  remoteDeleted: false,
   ...over,
 });
 
@@ -31,14 +32,14 @@ describe('AccountingSyncCard', () => {
 
   it('renders nothing when there is no accounting sync row (no connection, or RLS-hidden)', () => {
     const { container } = render(
-      <AccountingSyncCard invoiceId="inv-1" sync={null} canPush onChanged={vi.fn()} />,
+      <AccountingSyncCard invoiceId="inv-1" sync={null} invoiceStatus="sent" canPush onChanged={vi.fn()} />,
     );
     expect(screen.queryByTestId('invoice-detail-accounting-sync')).not.toBeInTheDocument();
     expect(container).toBeEmptyDOMElement();
   });
 
   it('renders the pending state with a Push affordance', () => {
-    render(<AccountingSyncCard invoiceId="inv-1" sync={sync()} canPush onChanged={vi.fn()} />);
+    render(<AccountingSyncCard invoiceId="inv-1" sync={sync()} invoiceStatus="sent" canPush onChanged={vi.fn()} />);
 
     expect(screen.getByTestId('invoice-detail-accounting-sync')).toBeInTheDocument();
     expect(screen.getByTestId('invoice-accounting-sync-status')).toHaveTextContent('Not pushed yet');
@@ -50,6 +51,7 @@ describe('AccountingSyncCard', () => {
       <AccountingSyncCard
         invoiceId="inv-1"
         sync={sync({ syncStatus: 'synced', remoteDocNumber: 'QB-1042', lastSyncedAt: '2026-09-01T10:00:00Z' })}
+        invoiceStatus="sent"
         canPush
         onChanged={vi.fn()}
       />,
@@ -65,6 +67,7 @@ describe('AccountingSyncCard', () => {
       <AccountingSyncCard
         invoiceId="inv-1"
         sync={sync({ syncStatus: 'error', lastError: 'QuickBooks rejected the invoice sync (HTTP 500)' })}
+        invoiceStatus="sent"
         canPush
         onChanged={vi.fn()}
       />,
@@ -78,15 +81,17 @@ describe('AccountingSyncCard', () => {
   });
 
   // Phase D writes a mapping-error marker onto the same `lastError` column when
-  // a reconcile finds the QuickBooks invoice gone. Nothing new is added to this
-  // component for that — this pins the copy path the spec relies on, so a future
-  // change that sanitizes/normalizes `lastError` before render breaks here
-  // rather than silently blanking the only explanation the operator gets.
-  it('renders a reconcile-sourced lastError verbatim, not just push failures', () => {
+  // a reconcile finds the QuickBooks invoice gone. This pins the copy path the
+  // spec relies on — but with remoteDeleted explicitly false (i.e. the API
+  // itself did not flag this as the marker), the Push button must still
+  // render: the component decides purely off the typed `remoteDeleted` flag,
+  // never by string-matching `lastError` itself (#4544).
+  it('renders a reconcile-sourced lastError verbatim, not just push failures — and does not itself infer remoteDeleted from the string', () => {
     render(
       <AccountingSyncCard
         invoiceId="inv-1"
-        sync={sync({ syncStatus: 'error', lastError: 'Deleted in QuickBooks' })}
+        sync={sync({ syncStatus: 'error', lastError: 'Deleted in QuickBooks', remoteDeleted: false })}
+        invoiceStatus="sent"
         canPush
         onChanged={vi.fn()}
       />,
@@ -95,6 +100,7 @@ describe('AccountingSyncCard', () => {
     expect(screen.getByTestId('invoice-accounting-sync-error')).toHaveTextContent(
       'Deleted in QuickBooks',
     );
+    expect(screen.getByTestId('invoice-accounting-sync-push')).toBeInTheDocument();
   });
 
   it('renders tax variance with its own copy — never as "pending" and never as a plain "Synced"', () => {
@@ -102,6 +108,7 @@ describe('AccountingSyncCard', () => {
       <AccountingSyncCard
         invoiceId="inv-1"
         sync={sync({ syncStatus: 'synced_with_tax_variance', remoteDocNumber: 'QB-1042' })}
+        invoiceStatus="sent"
         canPush
         onChanged={vi.fn()}
       />,
@@ -120,6 +127,7 @@ describe('AccountingSyncCard', () => {
       <AccountingSyncCard
         invoiceId="inv-1"
         sync={sync({ syncStatus: 'error', lastError: 'boom' })}
+        invoiceStatus="sent"
         canPush={false}
         onChanged={vi.fn()}
       />,
@@ -129,12 +137,99 @@ describe('AccountingSyncCard', () => {
     expect(screen.queryByTestId('invoice-accounting-sync-push')).not.toBeInTheDocument();
   });
 
+  // #4544 — voided invoice: the mapping row's own syncStatus can still read
+  // 'pending'/'error' from before the void, so the guard must be independent
+  // of `sync` and keyed off the invoice's own status.
+  describe('voided invoice (#4544)', () => {
+    it('hides the Push button and shows an explanatory hint on an otherwise-pushable (pending) mapping', () => {
+      render(
+        <AccountingSyncCard
+          invoiceId="inv-1"
+          sync={sync({ syncStatus: 'pending' })}
+          invoiceStatus="void"
+          canPush
+          onChanged={vi.fn()}
+        />,
+      );
+
+      expect(screen.queryByTestId('invoice-accounting-sync-push')).not.toBeInTheDocument();
+      expect(screen.getByTestId('invoice-accounting-sync-voided-hint')).toBeInTheDocument();
+    });
+
+    it('hides the Push button on an otherwise-pushable (error) mapping', () => {
+      render(
+        <AccountingSyncCard
+          invoiceId="inv-1"
+          sync={sync({ syncStatus: 'error', lastError: 'boom' })}
+          invoiceStatus="void"
+          canPush
+          onChanged={vi.fn()}
+        />,
+      );
+
+      expect(screen.queryByTestId('invoice-accounting-sync-push')).not.toBeInTheDocument();
+    });
+
+    it('does not render the voided hint for a synced mapping — there was never a Push button to explain away', () => {
+      render(
+        <AccountingSyncCard
+          invoiceId="inv-1"
+          sync={sync({ syncStatus: 'synced', remoteDocNumber: 'QB-1042' })}
+          invoiceStatus="void"
+          canPush
+          onChanged={vi.fn()}
+        />,
+      );
+
+      expect(screen.queryByTestId('invoice-accounting-sync-push')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('invoice-accounting-sync-voided-hint')).not.toBeInTheDocument();
+    });
+  });
+
+  // #4544 — remote-deleted (Phase D `markInvoiceDeletedRemotely`): the API
+  // surfaces this as a typed boolean, not something this component derives
+  // itself from `lastError`.
+  describe('remote-deleted mapping (#4544)', () => {
+    it('hides the Push button and shows an explanatory hint', () => {
+      render(
+        <AccountingSyncCard
+          invoiceId="inv-1"
+          sync={sync({ syncStatus: 'error', lastError: 'Deleted in QuickBooks', remoteDeleted: true })}
+          invoiceStatus="sent"
+          canPush
+          onChanged={vi.fn()}
+        />,
+      );
+
+      expect(screen.queryByTestId('invoice-accounting-sync-push')).not.toBeInTheDocument();
+      expect(screen.getByTestId('invoice-accounting-sync-remote-deleted-hint')).toBeInTheDocument();
+      // The raw error text is still shown verbatim underneath.
+      expect(screen.getByTestId('invoice-accounting-sync-error')).toHaveTextContent('Deleted in QuickBooks');
+    });
+
+    it('prefers the voided hint over the remote-deleted hint when both apply, without rendering both', () => {
+      render(
+        <AccountingSyncCard
+          invoiceId="inv-1"
+          sync={sync({ syncStatus: 'error', lastError: 'Deleted in QuickBooks', remoteDeleted: true })}
+          invoiceStatus="void"
+          canPush
+          onChanged={vi.fn()}
+        />,
+      );
+
+      expect(screen.queryByTestId('invoice-accounting-sync-push')).not.toBeInTheDocument();
+      expect(screen.getByTestId('invoice-accounting-sync-voided-hint')).toBeInTheDocument();
+      expect(screen.queryByTestId('invoice-accounting-sync-remote-deleted-hint')).not.toBeInTheDocument();
+    });
+  });
+
   it('pushes through runAction, disables the button in flight, and refetches on success', async () => {
     const onChanged = vi.fn();
     let release!: (value: Response) => void;
     fetchMock.mockReturnValue(new Promise<Response>((r) => { release = r; }));
 
-    render(<AccountingSyncCard invoiceId="inv-1" sync={sync()} canPush onChanged={onChanged} />);
+    render(<AccountingSyncCard invoiceId="inv-1" sync={sync()} invoiceStatus="sent" canPush onChanged={onChanged} />);
     fireEvent.click(screen.getByTestId('invoice-accounting-sync-push'));
 
     await waitFor(() => expect(screen.getByTestId('invoice-accounting-sync-push')).toBeDisabled());
@@ -155,12 +250,32 @@ describe('AccountingSyncCard', () => {
       json({ error: 'currency_mismatch', message: 'Invoice currency EUR does not match the QuickBooks home currency USD.' }, false, 409),
     );
 
-    render(<AccountingSyncCard invoiceId="inv-1" sync={sync()} canPush onChanged={onChanged} />);
+    render(<AccountingSyncCard invoiceId="inv-1" sync={sync()} invoiceStatus="sent" canPush onChanged={onChanged} />);
     fireEvent.click(screen.getByTestId('invoice-accounting-sync-push'));
 
     await waitFor(() => expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' })));
     expect(onChanged).not.toHaveBeenCalled();
     // Button must come back so the operator can retry after fixing the mapping.
     await waitFor(() => expect(screen.getByTestId('invoice-accounting-sync-push')).not.toBeDisabled());
+  });
+
+  // #4544: a typed `remote_deleted` 409 must surface through the same
+  // runAction/ActionError path as any other rejection — no special-casing
+  // needed in the click handler, since the button is already hidden for a
+  // known-remote-deleted mapping and this only exercises a race (button was
+  // rendered off stale data, then the server catches it).
+  it('surfaces a remote_deleted 409 push rejection through the standard runAction toast path', async () => {
+    const onChanged = vi.fn();
+    fetchMock.mockResolvedValue(
+      json({ error: 'remote_deleted', message: 'QuickBooks reports this invoice as deleted — pushing again would create a duplicate.' }, false, 409),
+    );
+
+    render(<AccountingSyncCard invoiceId="inv-1" sync={sync()} invoiceStatus="sent" canPush onChanged={onChanged} />);
+    fireEvent.click(screen.getByTestId('invoice-accounting-sync-push'));
+
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error', message: expect.stringContaining('deleted') }),
+    ));
+    expect(onChanged).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/billing/AccountingSyncCard.test.tsx
+++ b/apps/web/src/components/billing/AccountingSyncCard.test.tsx
@@ -137,6 +137,25 @@ describe('AccountingSyncCard', () => {
     expect(screen.queryByTestId('invoice-accounting-sync-push')).not.toBeInTheDocument();
   });
 
+  // `remoteDeleted` is optional (absent on an older API response — deploy
+  // skew). This pins the intentional default direction: missing degrades to
+  // "button renders, a real push attempt gets the server's 409" rather than
+  // crashing or silently misreading `undefined` as some other truthy state.
+  it('does not crash and renders the button when remoteDeleted is omitted from the API response', () => {
+    const { remoteDeleted: _omit, ...syncWithoutRemoteDeleted } = sync({ syncStatus: 'pending' });
+    render(
+      <AccountingSyncCard
+        invoiceId="inv-1"
+        sync={syncWithoutRemoteDeleted as AccountingSyncSummary}
+        invoiceStatus="sent"
+        canPush
+        onChanged={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('invoice-accounting-sync-push')).toBeInTheDocument();
+  });
+
   // #4544 — voided invoice: the mapping row's own syncStatus can still read
   // 'pending'/'error' from before the void, so the guard must be independent
   // of `sync` and keyed off the invoice's own status.

--- a/apps/web/src/components/billing/AccountingSyncCard.tsx
+++ b/apps/web/src/components/billing/AccountingSyncCard.tsx
@@ -6,7 +6,7 @@ import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError } from '../../lib/runAction';
 import { formatDateTime } from '@/lib/dateTimeFormat';
-import type { AccountingSyncSummary } from './invoiceTypes';
+import type { AccountingSyncSummary, InvoiceStatus } from './invoiceTypes';
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
 
@@ -20,6 +20,13 @@ interface Props {
    * than invent a status.
    */
   sync: AccountingSyncSummary | null | undefined;
+  /**
+   * The invoice's own lifecycle status (#4544). A void invoice is not
+   * reflected in `sync` at all — the mapping row can still read 'synced' or
+   * 'error' from before the void — so the card needs this independently to
+   * hide the push affordance on a voided invoice.
+   */
+  invoiceStatus: InvoiceStatus;
   /** `can('invoices','write')` — the same permission the push route requires. */
   canPush: boolean;
   /** Refetch the invoice so the card re-renders off the persisted mapping row. */
@@ -28,18 +35,26 @@ interface Props {
 
 /** Pushing is a remedy only for a row that is not (successfully) in QuickBooks
  *  yet. `synced_with_tax_variance` IS synced — QuickBooks simply computed a
- *  different tax total — so re-pushing would just re-send identical content. */
+ *  different tax total — so re-pushing would just re-send identical content.
+ *  Does NOT account for a voided invoice or a remote-deleted mapping (#4544)
+ *  — those are independent blockers layered on top by the caller, so this
+ *  stays a pure function of `syncStatus` alone. */
 function isPushable(status: AccountingSyncSummary['syncStatus']): boolean {
   return status === 'pending' || status === 'error';
 }
 
-export default function AccountingSyncCard({ invoiceId, sync, canPush, onChanged }: Props) {
+export default function AccountingSyncCard({ invoiceId, sync, invoiceStatus, canPush, onChanged }: Props) {
   const { t } = useTranslation('billing');
   const [pushing, setPushing] = useState(false);
 
   if (!sync) return null;
 
-  const { syncStatus } = sync;
+  const { syncStatus, remoteDeleted } = sync;
+  // Void is checked independently of `sync` (see the Props doc above) —
+  // the mapping row's own status doesn't change when the invoice is voided.
+  const voided = invoiceStatus === 'void';
+  const statusPushable = isPushable(syncStatus);
+  const pushable = canPush && statusPushable && !voided && !remoteDeleted;
   const statusLabel = t(
     /* i18n-dynamic */ `invoiceDetail.accountingSync.status.${syncStatus}`,
   );
@@ -104,6 +119,22 @@ export default function AccountingSyncCard({ invoiceId, sync, canPush, onChanged
           </p>
         )}
 
+        {/* Explanatory labels for why the push affordance is hidden even
+            though the mapping row's own status would otherwise allow it
+            (#4544). Void takes precedence in copy when both apply — a
+            remote-deleted invoice that also got voided in Breeze doesn't
+            need two explanations for one missing button. */}
+        {statusPushable && voided && (
+          <p className="text-xs text-muted-foreground" data-testid="invoice-accounting-sync-voided-hint">
+            {t('invoiceDetail.accountingSync.voidedHint')}
+          </p>
+        )}
+        {statusPushable && remoteDeleted && !voided && (
+          <p className="text-xs text-muted-foreground" data-testid="invoice-accounting-sync-remote-deleted-hint">
+            {t('invoiceDetail.accountingSync.remoteDeletedHint')}
+          </p>
+        )}
+
         {sync.remoteDocNumber && (
           <p className="text-muted-foreground" data-testid="invoice-accounting-sync-docnumber">
             {t('invoiceDetail.accountingSync.docNumber', { docNumber: sync.remoteDocNumber })}
@@ -116,7 +147,7 @@ export default function AccountingSyncCard({ invoiceId, sync, canPush, onChanged
           </p>
         )}
 
-        {canPush && isPushable(syncStatus) && (
+        {pushable && (
           <button
             type="button"
             data-testid="invoice-accounting-sync-push"

--- a/apps/web/src/components/billing/AccountingSyncCard.tsx
+++ b/apps/web/src/components/billing/AccountingSyncCard.tsx
@@ -49,7 +49,12 @@ export default function AccountingSyncCard({ invoiceId, sync, invoiceStatus, can
 
   if (!sync) return null;
 
-  const { syncStatus, remoteDeleted } = sync;
+  const { syncStatus } = sync;
+  // Explicit default (not just relying on `!undefined` reading truthy the
+  // same as `!false`) — `remoteDeleted` is optional (absent on an older API
+  // response, see invoiceTypes.ts); this keeps the type honest about that
+  // instead of a TS `boolean` that can actually be `undefined` at runtime.
+  const remoteDeleted = sync.remoteDeleted ?? false;
   // Void is checked independently of `sync` (see the Props doc above) —
   // the mapping row's own status doesn't change when the invoice is voided.
   const voided = invoiceStatus === 'void';

--- a/apps/web/src/components/billing/InvoiceDetail.test.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.test.tsx
@@ -425,6 +425,7 @@ describe('InvoiceDetail — QuickBooks accounting sync rail card', () => {
             lastSyncedAt: null,
             lastError: 'QuickBooks rejected the invoice sync (HTTP 500)',
             remoteDocNumber: null,
+            remoteDeleted: false,
           },
         }}
         onChanged={vi.fn()}
@@ -433,6 +434,31 @@ describe('InvoiceDetail — QuickBooks accounting sync rail card', () => {
     await waitFor(() => expect(screen.getByTestId('invoice-detail')).toBeInTheDocument());
     expect(screen.getByTestId('invoice-detail-accounting-sync')).toBeInTheDocument();
     expect(screen.getByTestId('invoice-accounting-sync-error')).toHaveTextContent('HTTP 500');
+  });
+
+  // #4544: the card must key off the INVOICE's own status, not just the
+  // mapping row's syncStatus — a voided invoice's mapping can still read
+  // 'error'/'pending' from before the void.
+  it('passes the invoice status through so a voided invoice hides the Push button even with an otherwise-pushable mapping', async () => {
+    render(
+      <InvoiceDetail
+        detail={{
+          ...issued,
+          invoice: { ...issued.invoice, status: 'void' },
+          accountingSync: {
+            provider: 'quickbooks',
+            syncStatus: 'error',
+            lastSyncedAt: null,
+            lastError: 'QuickBooks rejected the invoice sync (HTTP 500)',
+            remoteDocNumber: null,
+            remoteDeleted: false,
+          },
+        }}
+        onChanged={vi.fn()}
+      />,
+    );
+    await waitFor(() => expect(screen.getByTestId('invoice-detail')).toBeInTheDocument());
+    expect(screen.queryByTestId('invoice-accounting-sync-push')).not.toBeInTheDocument();
   });
 
   it('refetches the invoice after a successful push', async () => {
@@ -447,6 +473,7 @@ describe('InvoiceDetail — QuickBooks accounting sync rail card', () => {
             lastSyncedAt: null,
             lastError: null,
             remoteDocNumber: null,
+            remoteDeleted: false,
           },
         }}
         onChanged={onChanged}

--- a/apps/web/src/components/billing/InvoiceDetail.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.tsx
@@ -486,6 +486,7 @@ export default function InvoiceDetail({ detail, onChanged, actionsInHeader = fal
           <AccountingSyncCard
             invoiceId={invoice.id}
             sync={detail.accountingSync}
+            invoiceStatus={invoice.status}
             canPush={can('invoices', 'write')}
             onChanged={onChanged}
           />

--- a/apps/web/src/components/billing/invoiceTypes.ts
+++ b/apps/web/src/components/billing/invoiceTypes.ts
@@ -127,8 +127,14 @@ export interface AccountingSyncSummary {
    * Computed server-side (invoiceService.ts) from the exact sentinel
    * `lastError` string, so this component never has to string-match
    * `lastError` itself to decide whether "Push to QuickBooks" is safe.
+   * Optional and defaults to `false` (AccountingSyncCard.tsx) — absent on an
+   * older API response (deploy skew), same convention as `stripeConnected`
+   * above. This is a UI hint only: the API's push route enforces the same
+   * guard server-side (409 `remote_deleted`) regardless of what this field
+   * says, so a stale/missing value here degrades to "the button renders and
+   * the click gets rejected," never to a duplicate push actually landing.
    */
-  remoteDeleted: boolean;
+  remoteDeleted?: boolean;
 }
 
 export interface InvoiceDetail {

--- a/apps/web/src/components/billing/invoiceTypes.ts
+++ b/apps/web/src/components/billing/invoiceTypes.ts
@@ -120,6 +120,15 @@ export interface AccountingSyncSummary {
   lastSyncedAt: string | null;
   lastError: string | null;
   remoteDocNumber: string | null;
+  /**
+   * True when the API found the `markInvoiceDeletedRemotely` marker (#4544)
+   * on this mapping row — QuickBooks deleted or voided an invoice Breeze
+   * previously pushed, and Phase D deliberately never auto-resurrects it.
+   * Computed server-side (invoiceService.ts) from the exact sentinel
+   * `lastError` string, so this component never has to string-match
+   * `lastError` itself to decide whether "Push to QuickBooks" is safe.
+   */
+  remoteDeleted: boolean;
 }
 
 export interface InvoiceDetail {

--- a/apps/web/src/locales/de-DE/billing.json
+++ b/apps/web/src/locales/de-DE/billing.json
@@ -1697,7 +1697,9 @@
       "lastSynced": "Zuletzt synchronisiert am {{when}}",
       "push": "An QuickBooks übertragen",
       "pushed": "Rechnung an QuickBooks übertragen.",
-      "pushFailed": "Die Rechnung konnte nicht an QuickBooks übertragen werden."
+      "pushFailed": "Die Rechnung konnte nicht an QuickBooks übertragen werden.",
+      "voidedHint": "Diese Rechnung ist storniert — es gibt nichts an QuickBooks zu übertragen.",
+      "remoteDeletedHint": "Diese Rechnung wurde in QuickBooks gelöscht. Ein erneutes Übertragen würde ein Duplikat erzeugen — lösen Sie dies zuerst in QuickBooks."
     }
   },
   "invoiceDocument": {

--- a/apps/web/src/locales/en/billing.json
+++ b/apps/web/src/locales/en/billing.json
@@ -1697,7 +1697,9 @@
       "lastSynced": "Last synced {{when}}",
       "push": "Push to QuickBooks",
       "pushed": "Invoice pushed to QuickBooks.",
-      "pushFailed": "Failed to push the invoice to QuickBooks."
+      "pushFailed": "Failed to push the invoice to QuickBooks.",
+      "voidedHint": "This invoice is voided — there is nothing to push to QuickBooks.",
+      "remoteDeletedHint": "This invoice was deleted in QuickBooks. Pushing again would create a duplicate — resolve it in QuickBooks first."
     }
   },
   "invoiceDocument": {

--- a/apps/web/src/locales/es-419/billing.json
+++ b/apps/web/src/locales/es-419/billing.json
@@ -1697,7 +1697,9 @@
       "lastSynced": "Última sincronización: {{when}}",
       "push": "Enviar a QuickBooks",
       "pushed": "Factura enviada a QuickBooks.",
-      "pushFailed": "No se pudo enviar la factura a QuickBooks."
+      "pushFailed": "No se pudo enviar la factura a QuickBooks.",
+      "voidedHint": "Esta factura está anulada — no hay nada que enviar a QuickBooks.",
+      "remoteDeletedHint": "Esta factura fue eliminada en QuickBooks. Enviarla de nuevo crearía un duplicado — resuélvelo primero en QuickBooks."
     }
   },
   "invoiceDocument": {

--- a/apps/web/src/locales/fr-CA/billing.json
+++ b/apps/web/src/locales/fr-CA/billing.json
@@ -1697,7 +1697,9 @@
       "lastSynced": "Dernière synchronisation : {{when}}",
       "push": "Envoyer vers QuickBooks",
       "pushed": "Facture envoyée vers QuickBooks.",
-      "pushFailed": "Échec de l'envoi de la facture vers QuickBooks."
+      "pushFailed": "Échec de l'envoi de la facture vers QuickBooks.",
+      "voidedHint": "Cette facture est annulée — il n'y a rien à envoyer vers QuickBooks.",
+      "remoteDeletedHint": "Cette facture a été supprimée dans QuickBooks. L'envoyer de nouveau créerait un doublon — réglez d'abord la situation dans QuickBooks."
     }
   },
   "invoiceDocument": {

--- a/apps/web/src/locales/fr-FR/billing.json
+++ b/apps/web/src/locales/fr-FR/billing.json
@@ -1697,7 +1697,9 @@
       "lastSynced": "Dernière synchronisation : {{when}}",
       "push": "Envoyer vers QuickBooks",
       "pushed": "Facture envoyée vers QuickBooks.",
-      "pushFailed": "Échec de l'envoi de la facture vers QuickBooks."
+      "pushFailed": "Échec de l'envoi de la facture vers QuickBooks.",
+      "voidedHint": "Cette facture est annulée — il n'y a rien à envoyer vers QuickBooks.",
+      "remoteDeletedHint": "Cette facture a été supprimée dans QuickBooks. L'envoyer de nouveau créerait un doublon — réglez d'abord la situation dans QuickBooks."
     }
   },
   "invoiceDocument": {

--- a/apps/web/src/locales/it-IT/billing.json
+++ b/apps/web/src/locales/it-IT/billing.json
@@ -1697,7 +1697,9 @@
       "lastSynced": "Ultima sincronizzazione: {{when}}",
       "push": "Invia a QuickBooks",
       "pushed": "Fattura inviata a QuickBooks.",
-      "pushFailed": "Impossibile inviare la fattura a QuickBooks."
+      "pushFailed": "Impossibile inviare la fattura a QuickBooks.",
+      "voidedHint": "Questa fattura è annullata — non c'è nulla da inviare a QuickBooks.",
+      "remoteDeletedHint": "Questa fattura è stata eliminata in QuickBooks. Inviarla di nuovo creerebbe un duplicato — risolvi prima la situazione in QuickBooks."
     }
   },
   "invoiceDocument": {

--- a/apps/web/src/locales/pt-BR/billing.json
+++ b/apps/web/src/locales/pt-BR/billing.json
@@ -1697,7 +1697,9 @@
       "lastSynced": "Última sincronização em {{when}}",
       "push": "Enviar ao QuickBooks",
       "pushed": "Fatura enviada ao QuickBooks.",
-      "pushFailed": "Falha ao enviar a fatura ao QuickBooks."
+      "pushFailed": "Falha ao enviar a fatura ao QuickBooks.",
+      "voidedHint": "Esta fatura está anulada — não há nada para enviar ao QuickBooks.",
+      "remoteDeletedHint": "Esta fatura foi excluída no QuickBooks. Enviá-la novamente criaria uma duplicata — resolva isso no QuickBooks primeiro."
     }
   },
   "invoiceDocument": {

--- a/apps/web/src/locales/tr-TR/billing.json
+++ b/apps/web/src/locales/tr-TR/billing.json
@@ -1697,7 +1697,9 @@
       "lastSynced": "Son eşitleme: {{when}}",
       "push": "QuickBooks'a gönder",
       "pushed": "Fatura QuickBooks'a gönderildi.",
-      "pushFailed": "Fatura QuickBooks'a gönderilemedi."
+      "pushFailed": "Fatura QuickBooks'a gönderilemedi.",
+      "voidedHint": "Bu fatura iptal edildi — QuickBooks'a gönderilecek bir şey yok.",
+      "remoteDeletedHint": "Bu fatura QuickBooks'ta silindi. Yeniden göndermek bir kopya oluşturur — önce QuickBooks'ta çözün."
     }
   },
   "invoiceDocument": {


### PR DESCRIPTION
## Summary
`AccountingSyncCard.tsx` only checked `syncStatus` to decide whether to show "Push to QuickBooks", so the button rendered for:

1. Invoices **voided in Breeze** — the mapping row's own status is unaffected by a void, so a previously `error`/`pending` mapping still looked pushable.
2. Invoice mappings the reconcile worker marked with the `markInvoiceDeletedRemotely` sentinel (`last_error = 'Deleted in QuickBooks'`, Phase D decision 2: never auto-resurrected) — clicking Push would re-create the invoice in QuickBooks.

The **voided** case already had a server-side guard (`PUSHABLE_STATUSES` in `accountingInvoicePush.ts` excludes `void`), but the **remote-deleted** case did not: `upsertInvoiceMappingPending` (Phase 1b) would silently clear the marker (`lastError: null`) and let the push through server-side even if a client somehow submitted it.

## Fix

**API** (`apps/api/src/services/accounting/accountingInvoicePush.ts`):
- New `remote_deleted` error code, 409.
- Guard added in **two** places: Phase 1 (a cheap early exit, before any org/item lookup or token refresh — mirrors the existing currency-guard rationale) and Phase 1b (a fresh re-read right before claiming the mapping row `pending` — this is the check that actually closes the race, since the reconcile worker can flip the mapping to remote-deleted while the org/item dependency syncs in between are in flight).
- The exact sentinel string (`'Deleted in QuickBooks'`) is now a single exported constant (`INVOICE_REMOTE_DELETED_ERROR` in `services/accounting/types.ts`, a leaf module with no other imports — avoids a circular import between `accountingPaymentPull.ts` and `invoiceService.ts`), used by both the writer (`markInvoiceDeletedRemotely`) and the readers (the new push guard, and `invoiceService.getInvoiceAccountingSync`).
- `invoiceService.ts`'s `InvoiceAccountingSync`/`getInvoiceAccountingSync` now compute and surface a `remoteDeleted: boolean` from that constant.

**Web** (`apps/web/src/components/billing/`):
- `AccountingSyncSummary` gains `remoteDeleted: boolean` (API-computed — the component never string-matches `lastError` itself).
- `AccountingSyncCard` takes a new `invoiceStatus` prop (the invoice's own status, independent of the mapping row) and hides the Push button when the invoice is voided OR the mapping is remote-deleted, with an explanatory hint (`voidedHint` / `remoteDeletedHint`, added to all 8 locale files — `localeParity.test.ts` passes).
- `InvoiceDetail.tsx` passes `invoice.status` through.
- The push click handler is unchanged — a typed 409 (including the new `remote_deleted`) already surfaces via the existing `runAction`/`ActionError` toast path.

## Tests
- API: `accountingInvoicePush.test.ts` — new tests for the Phase-1 early rejection and the Phase-1b race-closing re-check (mapping flips to remote-deleted mid-dependency-sync); `invoicePush.test.ts` (route) — 409 pass-through for `remote_deleted`; `invoiceService.test.ts` — `remoteDeleted: true/false` surfaced correctly.
- Web: `AccountingSyncCard.test.tsx` — voided-invoice and remote-deleted-mapping hidden states (including the "both apply" precedence case), plus a regression test proving the component does NOT infer `remoteDeleted` from `lastError` text itself; `InvoiceDetail.test.tsx` — `invoiceStatus` threading test.

## Verification
- `cd apps/api && npx vitest run src/routes/accounting src/services/accounting/accountingInvoicePush.test.ts src/services/accounting/accountingPaymentPull.test.ts src/services/invoiceService.test.ts` — 329 passed.
- `cd apps/web && npx vitest run AccountingSyncCard InvoiceDetail.test src/lib/i18n/localeParity.test.ts src/lib/i18n/keyUsage.test.ts src/lib/__tests__/no-silent-mutations.test.ts` — all passed.
- `tsc --noEmit` clean in both `apps/api` and `apps/web`.
- `eslint` clean on all touched files.

Closes #4544

🤖 Generated with [Claude Code](https://claude.com/claude-code)