### PR TITLE
fix(api): align ticket-triage proposal DTO's draft text with draftsWritten (#4467)

### DIFF
--- a/apps/api/src/routes/aiAgents.test.ts
+++ b/apps/api/src/routes/aiAgents.test.ts
@@ -1074,7 +1074,7 @@ describe('GET /ai-agents/runs/:runId (execution-trace detail, #3828)', () => {
         approvalScope: 'auto', decidedVia: 'ticket_autonomy',
       }])) // intents (sessionId is null, so the ledger read is skipped)
       .mockReturnValueOnce(selectChain(
-        [{ id: DRAFT_ID, kind: 'reply', content: 'Hi — please try restarting your computer.' }],
+        [{ id: DRAFT_ID, kind: 'reply', content: 'Hi — please try restarting your computer.', state: 'active' }],
         (predicate) => { draftWhere = predicate; },
       )); // draft rows
 

--- a/apps/api/src/routes/aiAgents.test.ts
+++ b/apps/api/src/routes/aiAgents.test.ts
@@ -1074,7 +1074,7 @@ describe('GET /ai-agents/runs/:runId (execution-trace detail, #3828)', () => {
         approvalScope: 'auto', decidedVia: 'ticket_autonomy',
       }])) // intents (sessionId is null, so the ledger read is skipped)
       .mockReturnValueOnce(selectChain(
-        [{ id: DRAFT_ID, kind: 'reply' }],
+        [{ id: DRAFT_ID, kind: 'reply', content: 'Hi — please try restarting your computer.' }],
         (predicate) => { draftWhere = predicate; },
       )); // draft rows
 
@@ -1085,6 +1085,9 @@ describe('GET /ai-agents/runs/:runId (execution-trace detail, #3828)', () => {
 
     expect(parsed.data.ticketProposal?.intentIds).toEqual([TRIAGE_INTENT_ID]);
     expect(parsed.data.ticketProposal?.draftsWritten).toEqual([{ kind: 'reply', draftId: DRAFT_ID }]);
+    // Issue #4467 — draftReply is sourced live off the same draft-rows read,
+    // never disagreeing with the draftsWritten entry it corresponds to.
+    expect(parsed.data.ticketProposal?.draftReply).toBe('Hi — please try restarting your computer.');
 
     // run row, intents, draft rows — no ledger (sessionId null), no sweep
     // hostname read, no narrative artifact read (reportRunId null).

--- a/apps/api/src/routes/aiAgents.ts
+++ b/apps/api/src/routes/aiAgents.ts
@@ -941,9 +941,17 @@ aiAgentsRoutes.get('/runs/:runId', scopes, requireAiRead, async (c) => {
   // sweep-hostname and narrative-artifact reads above do (a partner-scoped
   // caller's `auth.orgCondition` alone spans every sibling org); that stays
   // as defence-in-depth beside RLS.
+  //
+  // Issue #4467 — also selects `content`: `buildRunTrace`/`mapTicketProposal`
+  // now derive `ticketProposal.draftReply`/`draftResolutionNote` off this
+  // SAME live row (when one exists for the kind) instead of always echoing
+  // the persisted proposal text, so the two representations of a written
+  // draft can't disagree. `content` never reaches `draftsWritten` on the
+  // wire itself — it only feeds that derivation (see the docstrings on
+  // `RunTraceDraftRowInput` and `mapTicketProposal`/`pickDraftText`).
   const draftRows = run.triggerKind === 'ticket'
     ? await db
-      .select({ id: ticketDrafts.id, kind: ticketDrafts.kind })
+      .select({ id: ticketDrafts.id, kind: ticketDrafts.kind, content: ticketDrafts.content })
       .from(ticketDrafts)
       .where(and(
         eq(ticketDrafts.runId, run.id),

--- a/apps/api/src/routes/aiAgents.ts
+++ b/apps/api/src/routes/aiAgents.ts
@@ -942,22 +942,40 @@ aiAgentsRoutes.get('/runs/:runId', scopes, requireAiRead, async (c) => {
   // caller's `auth.orgCondition` alone spans every sibling org); that stays
   // as defence-in-depth beside RLS.
   //
-  // Issue #4467 — also selects `content`: `buildRunTrace`/`mapTicketProposal`
-  // now derive `ticketProposal.draftReply`/`draftResolutionNote` off this
-  // SAME live row (when one exists for the kind) instead of always echoing
-  // the persisted proposal text, so the two representations of a written
-  // draft can't disagree. `content` never reaches `draftsWritten` on the
-  // wire itself — it only feeds that derivation (see the docstrings on
+  // Issue #4467 — also selects `content` and `state`, and orders newest
+  // first: `buildRunTrace`/`mapTicketProposal` now derive
+  // `ticketProposal.draftReply`/`draftResolutionNote` off this SAME live row
+  // (when one exists for the kind) instead of always echoing the persisted
+  // proposal text, so the two representations of a written draft can't
+  // disagree. `content` never reaches `draftsWritten` on the wire itself —
+  // it only feeds that derivation (see the docstrings on
   // `RunTraceDraftRowInput` and `mapTicketProposal`/`pickDraftText`).
+  //
+  // More than one row of the SAME kind can be linked to this run_id — the
+  // `draft` tool executor (aiToolsTicketing.ts, action 'draft') supersedes
+  // the ticket's previously-active draft of that kind and inserts a new row
+  // on every call, including its own unique-violation retry path, and this
+  // query has no per-run uniqueness to lean on (`ticket_drafts_active_uq` is
+  // scoped to `(ticket_id, kind)`, not `(run_id, kind)`). `state` +
+  // `ORDER BY created_at DESC` let `pickDraftText` deterministically prefer
+  // the row that is actually still `active` (falling back to the most
+  // recently written row of that kind if none is), rather than an arbitrary
+  // one — see that function's docstring.
   const draftRows = run.triggerKind === 'ticket'
     ? await db
-      .select({ id: ticketDrafts.id, kind: ticketDrafts.kind, content: ticketDrafts.content })
+      .select({
+        id: ticketDrafts.id,
+        kind: ticketDrafts.kind,
+        content: ticketDrafts.content,
+        state: ticketDrafts.state,
+      })
       .from(ticketDrafts)
       .where(and(
         eq(ticketDrafts.runId, run.id),
         eq(ticketDrafts.orgId, run.orgId),
         auth.orgCondition(ticketDrafts.orgId),
       ))
+      .orderBy(desc(ticketDrafts.createdAt))
     : [];
 
   // Both fields come from the same left-joined ai_agents row, so they are

--- a/apps/api/src/services/aiAgents/runTrace.test.ts
+++ b/apps/api/src/services/aiAgents/runTrace.test.ts
@@ -253,7 +253,7 @@ describe('buildRunTrace — safe projection (#3828)', () => {
       });
 
       it('projects the caller\'s live ticket_drafts rows as draftsWritten', () => {
-        const draftRows = [{ id: 'draft-1', kind: 'reply' as const }];
+        const draftRows = [{ id: 'draft-1', kind: 'reply' as const, content: 'Hi — try restarting your computer.' }];
         const detail = buildRunTrace(
           baseRun({ triggerKind: 'ticket', outcome: PROPOSAL_OUTCOME, intentIds: [] }),
           AGENT, null, [], [], new Map(), null, draftRows,
@@ -266,6 +266,83 @@ describe('buildRunTrace — safe projection (#3828)', () => {
           baseRun({ triggerKind: 'ticket', outcome: PROPOSAL_OUTCOME, intentIds: [] }),
           AGENT, null, [], [], new Map(), null, [],
         );
+        expect(detail.ticketProposal?.draftsWritten).toBeUndefined();
+      });
+
+      // Issue #4467 — draftReply/draftResolutionNote (the proposal's OWN
+      // text, persisted at proposal time) and draftsWritten (a live
+      // ticket_drafts read) are two representations of the same draft and
+      // used to be sourced independently, so they could disagree — e.g. a
+      // technician edits the draft on the ticket's "AI draft" surface after
+      // it's written, and the run-detail page would keep showing the STALE
+      // originally-proposed text under "Draft reply" while draftsWritten
+      // correctly still pointed at the (now-edited) row. Once a
+      // `ticket_drafts` row exists for a kind, its live `content` is the
+      // single source of truth for that kind's text on the DTO — the
+      // proposal's own text is used only as a pre-write preview, before the
+      // intent has released and the row exists at all (see
+      // RunTraceDraftRowInput's docstring). This is a derivation off ONE
+      // source per kind, not two independently-synced copies.
+      it('derives draftReply from the live ticket_drafts content once written, never disagreeing with draftsWritten', () => {
+        const draftRows = [{ id: 'draft-1', kind: 'reply' as const, content: 'EDITED on the ticket after approval.' }];
+        const detail = buildRunTrace(
+          baseRun({
+            triggerKind: 'ticket',
+            outcome: {
+              ticketProposal: {
+                version: 1,
+                summary: 'Restart the spooler.',
+                draftReply: 'Originally proposed text, now stale.',
+                notes: [],
+              },
+            },
+            intentIds: [],
+          }),
+          AGENT, null, [], [], new Map(), null, draftRows,
+        );
+        expect(detail.ticketProposal?.draftReply).toBe('EDITED on the ticket after approval.');
+        expect(detail.ticketProposal?.draftsWritten).toEqual([{ kind: 'reply', draftId: 'draft-1' }]);
+      });
+
+      it('derives draftResolutionNote from the live ticket_drafts content once written', () => {
+        const draftRows = [
+          { id: 'draft-2', kind: 'resolution_note' as const, content: 'Live resolution note content.' },
+        ];
+        const detail = buildRunTrace(
+          baseRun({
+            triggerKind: 'ticket',
+            outcome: {
+              ticketProposal: {
+                version: 1,
+                summary: 'Restart the spooler.',
+                draftResolutionNote: 'Stale proposed resolution note.',
+                notes: [],
+              },
+            },
+            intentIds: [],
+          }),
+          AGENT, null, [], [], new Map(), null, draftRows,
+        );
+        expect(detail.ticketProposal?.draftResolutionNote).toBe('Live resolution note content.');
+      });
+
+      it('falls back to the proposal\'s own draftReply text when no ticket_drafts row has been written yet (pending intent)', () => {
+        const detail = buildRunTrace(
+          baseRun({
+            triggerKind: 'ticket',
+            outcome: {
+              ticketProposal: {
+                version: 1,
+                summary: 'Restart the spooler.',
+                draftReply: 'Proposed but not yet approved.',
+                notes: [],
+              },
+            },
+            intentIds: [],
+          }),
+          AGENT, null, [], [], new Map(), null, [],
+        );
+        expect(detail.ticketProposal?.draftReply).toBe('Proposed but not yet approved.');
         expect(detail.ticketProposal?.draftsWritten).toBeUndefined();
       });
 
@@ -294,14 +371,26 @@ describe('buildRunTrace — safe projection (#3828)', () => {
         expect(detail.ticketProposal?.skipped).toBeUndefined();
       });
 
-      it('never carries draft content — only id/kind — even if the caller\'s row shape somehow had it', () => {
-        const draftRows = [{ id: 'draft-1', kind: 'resolution_note' as const, content: 'leak-marker-zzz' } as never];
+      // Issue #4467 changed what this guards: `content` now legitimately
+      // flows through to `draftReply`/`draftResolutionNote` (that's the
+      // fix — see `pickDraftText`), so the invariant worth a tripwire is
+      // narrower than "content never reaches the DTO at all": the
+      // `draftsWritten` array's OWN entries must still carry id/kind only,
+      // never a `content` key, so a written draft's text is exposed exactly
+      // once on the wire (via draftReply/draftResolutionNote) and not
+      // duplicated a second time inside draftsWritten.
+      it('draftsWritten entries never carry draft content — only id/kind — even though that content now feeds draftReply/draftResolutionNote', () => {
+        const draftRows = [{ id: 'draft-1', kind: 'resolution_note' as const, content: 'leak-marker-zzz' }];
         const detail = buildRunTrace(
           baseRun({ triggerKind: 'ticket', outcome: PROPOSAL_OUTCOME, intentIds: [] }),
           AGENT, null, [], [], new Map(), null, draftRows,
         );
-        const json = JSON.stringify(detail.ticketProposal);
+        // The content DOES legitimately reach draftResolutionNote now.
+        expect(detail.ticketProposal?.draftResolutionNote).toBe('leak-marker-zzz');
+        // ...but never a second time, inside draftsWritten's own entries.
+        const json = JSON.stringify(detail.ticketProposal?.draftsWritten);
         expect(json).not.toContain('leak-marker-zzz');
+        expect(json).not.toContain('"content"');
       });
     });
 

--- a/apps/api/src/services/aiAgents/runTrace.test.ts
+++ b/apps/api/src/services/aiAgents/runTrace.test.ts
@@ -253,7 +253,7 @@ describe('buildRunTrace — safe projection (#3828)', () => {
       });
 
       it('projects the caller\'s live ticket_drafts rows as draftsWritten', () => {
-        const draftRows = [{ id: 'draft-1', kind: 'reply' as const, content: 'Hi — try restarting your computer.' }];
+        const draftRows = [{ id: 'draft-1', kind: 'reply' as const, content: 'Hi — try restarting your computer.', state: 'active' as const }];
         const detail = buildRunTrace(
           baseRun({ triggerKind: 'ticket', outcome: PROPOSAL_OUTCOME, intentIds: [] }),
           AGENT, null, [], [], new Map(), null, draftRows,
@@ -284,7 +284,7 @@ describe('buildRunTrace — safe projection (#3828)', () => {
       // RunTraceDraftRowInput's docstring). This is a derivation off ONE
       // source per kind, not two independently-synced copies.
       it('derives draftReply from the live ticket_drafts content once written, never disagreeing with draftsWritten', () => {
-        const draftRows = [{ id: 'draft-1', kind: 'reply' as const, content: 'EDITED on the ticket after approval.' }];
+        const draftRows = [{ id: 'draft-1', kind: 'reply' as const, content: 'EDITED on the ticket after approval.', state: 'active' as const }];
         const detail = buildRunTrace(
           baseRun({
             triggerKind: 'ticket',
@@ -306,7 +306,7 @@ describe('buildRunTrace — safe projection (#3828)', () => {
 
       it('derives draftResolutionNote from the live ticket_drafts content once written', () => {
         const draftRows = [
-          { id: 'draft-2', kind: 'resolution_note' as const, content: 'Live resolution note content.' },
+          { id: 'draft-2', kind: 'resolution_note' as const, content: 'Live resolution note content.', state: 'active' as const },
         ];
         const detail = buildRunTrace(
           baseRun({
@@ -324,6 +324,60 @@ describe('buildRunTrace — safe projection (#3828)', () => {
           AGENT, null, [], [], new Map(), null, draftRows,
         );
         expect(detail.ticketProposal?.draftResolutionNote).toBe('Live resolution note content.');
+      });
+
+      // Issue #4467 review round 1 — the `draft` tool executor supersedes-
+      // then-inserts on every call (including its own unique-violation retry
+      // path), so more than one `ticket_drafts` row of the SAME kind can end
+      // up linked to one run_id: one `superseded`, one `active`. The route
+      // orders `draftRows` newest-first, but `pickDraftText` must not just
+      // trust ordering — it explicitly prefers the `active` row so a stale
+      // superseded row can never win even if it happened to sort first.
+      it('prefers the active row over a superseded one when two draftRows share the same kind', () => {
+        const draftRows = [
+          { id: 'draft-old', kind: 'reply' as const, content: 'STALE superseded text.', state: 'superseded' as const },
+          { id: 'draft-new', kind: 'reply' as const, content: 'Current active text.', state: 'active' as const },
+        ];
+        const detail = buildRunTrace(
+          baseRun({ triggerKind: 'ticket', outcome: PROPOSAL_OUTCOME, intentIds: [] }),
+          AGENT, null, [], [], new Map(), null, draftRows,
+        );
+        expect(detail.ticketProposal?.draftReply).toBe('Current active text.');
+        // draftsWritten still lists BOTH rows — it is an audit trail of
+        // every write, not just the currently-active one.
+        expect(detail.ticketProposal?.draftsWritten).toEqual([
+          { kind: 'reply', draftId: 'draft-old' },
+          { kind: 'reply', draftId: 'draft-new' },
+        ]);
+      });
+
+      it('derives both draftReply and draftResolutionNote independently when a run wrote one of each kind', () => {
+        const draftRows = [
+          { id: 'draft-reply-1', kind: 'reply' as const, content: 'Live reply text.', state: 'active' as const },
+          { id: 'draft-note-1', kind: 'resolution_note' as const, content: 'Live resolution text.', state: 'active' as const },
+        ];
+        const detail = buildRunTrace(
+          baseRun({
+            triggerKind: 'ticket',
+            outcome: {
+              ticketProposal: {
+                version: 1,
+                summary: 'Restart the spooler.',
+                draftReply: 'Stale proposed reply.',
+                draftResolutionNote: 'Stale proposed note.',
+                notes: [],
+              },
+            },
+            intentIds: [],
+          }),
+          AGENT, null, [], [], new Map(), null, draftRows,
+        );
+        expect(detail.ticketProposal?.draftReply).toBe('Live reply text.');
+        expect(detail.ticketProposal?.draftResolutionNote).toBe('Live resolution text.');
+        expect(detail.ticketProposal?.draftsWritten).toEqual([
+          { kind: 'reply', draftId: 'draft-reply-1' },
+          { kind: 'resolution_note', draftId: 'draft-note-1' },
+        ]);
       });
 
       it('falls back to the proposal\'s own draftReply text when no ticket_drafts row has been written yet (pending intent)', () => {
@@ -380,7 +434,7 @@ describe('buildRunTrace — safe projection (#3828)', () => {
       // once on the wire (via draftReply/draftResolutionNote) and not
       // duplicated a second time inside draftsWritten.
       it('draftsWritten entries never carry draft content — only id/kind — even though that content now feeds draftReply/draftResolutionNote', () => {
-        const draftRows = [{ id: 'draft-1', kind: 'resolution_note' as const, content: 'leak-marker-zzz' }];
+        const draftRows = [{ id: 'draft-1', kind: 'resolution_note' as const, content: 'leak-marker-zzz', state: 'active' as const }];
         const detail = buildRunTrace(
           baseRun({ triggerKind: 'ticket', outcome: PROPOSAL_OUTCOME, intentIds: [] }),
           AGENT, null, [], [], new Map(), null, draftRows,

--- a/apps/api/src/services/aiAgents/runTrace.ts
+++ b/apps/api/src/services/aiAgents/runTrace.ts
@@ -160,6 +160,17 @@ export interface RunTraceNarrativeArtifactInput {
 export interface RunTraceDraftRowInput {
   id: string;
   kind: 'reply' | 'resolution_note';
+  /**
+   * Issue #4467 — the row's live `content`. Read here so `mapTicketProposal`
+   * can derive `draftReply`/`draftResolutionNote` from this SAME query
+   * rather than always echoing `TicketProposalOutcome.draftReply`/
+   * `draftResolutionNote` (the persisted-at-proposal-time text), which could
+   * go stale the moment the draft is edited on the ticket's "AI draft"
+   * surface after it's written. Never placed on the wire DTO's
+   * `draftsWritten` entries themselves (see that field's own docstring) —
+   * it feeds the derivation only, so the content is exposed exactly once.
+   */
+  content: string;
 }
 
 /** The safe-projected subset of one linked `action_intents` row. */
@@ -233,11 +244,36 @@ function mapDenied(action: { tool: string; reason: string }): AiAgentRunTraceEnt
  * live `ticket_drafts` query result (`RunTraceDraftRowInput[]`), same
  * undefined-when-empty treatment.
  *
+ * Issue #4467: `draftReply`/`draftResolutionNote` used to be projected
+ * straight off `proposal` — the text the model proposed, frozen at proposal
+ * time — independently of `draftsWritten`, which reads live off
+ * `ticket_drafts`. The two are two representations of the SAME draft and
+ * could disagree: once a draft is written, a technician can edit its content
+ * on the ticket's "AI draft" surface (`TicketWorkbench.tsx`), or a retry can
+ * supersede it, and the run-detail page would keep showing the now-stale
+ * originally-proposed text forever. `pickDraftText` below makes the live
+ * `ticket_drafts` row (via `draftRows`, the same query `draftsWritten` is
+ * built from) authoritative for its kind whenever one exists — a derivation
+ * off ONE source, not a second copy kept in sync — falling back to the
+ * proposal's own text only pre-write, when no row exists yet (a draft intent
+ * left `pending_approval` hasn't released into a `ticket_drafts` row — see
+ * `RunTraceDraftRowInput`'s docstring — so the proposal text is the only
+ * preview available before a technician approves it).
+ *
  * Issue #4462: `skipped` is `outcome.ticketTriageSkipped` verbatim (already
  * the safe, display-string-only shape `persistTicketTriage` built — see
  * `TicketTriageSkip`'s own docstring), undefined-when-empty like its two
  * siblings above.
  */
+function pickDraftText(
+  proposalText: string | undefined,
+  draftRows: RunTraceDraftRowInput[],
+  kind: 'reply' | 'resolution_note',
+): string | undefined {
+  const written = draftRows.find((row) => row.kind === kind);
+  return written ? written.content : proposalText;
+}
+
 function mapTicketProposal(
   proposal: TicketProposalOutcome,
   intentIds: string[],
@@ -249,8 +285,8 @@ function mapTicketProposal(
     summary: proposal.summary,
     fields: proposal.fields,
     device: proposal.device,
-    draftReply: proposal.draftReply,
-    draftResolutionNote: proposal.draftResolutionNote,
+    draftReply: pickDraftText(proposal.draftReply, draftRows, 'reply'),
+    draftResolutionNote: pickDraftText(proposal.draftResolutionNote, draftRows, 'resolution_note'),
     notes: proposal.notes,
     intentIds: intentIds.length > 0 ? intentIds : undefined,
     draftsWritten: draftRows.length > 0

--- a/apps/api/src/services/aiAgents/runTrace.ts
+++ b/apps/api/src/services/aiAgents/runTrace.ts
@@ -171,6 +171,17 @@ export interface RunTraceDraftRowInput {
    * it feeds the derivation only, so the content is exposed exactly once.
    */
   content: string;
+  /**
+   * Issue #4467 review round 1 — more than one row of the SAME `kind` can be
+   * linked to one run_id (the `draft` tool executor supersedes-then-inserts
+   * on every call, including its own unique-violation retry path; the
+   * `ticket_drafts_active_uq` uniqueness is scoped to `(ticket_id, kind)`,
+   * not `(run_id, kind)`). `state` lets `pickDraftText` prefer the row that
+   * is still `active` over a `superseded`/`consumed`/`discarded` one sharing
+   * this run_id + kind, rather than picking whichever the query happened to
+   * return first.
+   */
+  state: 'active' | 'consumed' | 'discarded' | 'superseded';
 }
 
 /** The safe-projected subset of one linked `action_intents` row. */
@@ -265,12 +276,23 @@ function mapDenied(action: { tool: string; reason: string }): AiAgentRunTraceEnt
  * `TicketTriageSkip`'s own docstring), undefined-when-empty like its two
  * siblings above.
  */
+/**
+ * Issue #4467 review round 1 — more than one `draftRows` entry can share the
+ * same `kind` for a single run (see `RunTraceDraftRowInput.state`'s
+ * docstring), so picking the first match isn't safe by construction. Prefers
+ * the row that is still `active` for this kind; if none is (every write of
+ * that kind was later superseded/consumed/discarded, or the route's query
+ * ordering changes), falls back to `draftRows[0]` of that kind — the route
+ * orders `draftRows` newest-first (`ORDER BY created_at DESC`), so that's
+ * the most recently written row, the next-best approximation of "current".
+ */
 function pickDraftText(
   proposalText: string | undefined,
   draftRows: RunTraceDraftRowInput[],
   kind: 'reply' | 'resolution_note',
 ): string | undefined {
-  const written = draftRows.find((row) => row.kind === kind);
+  const matches = draftRows.filter((row) => row.kind === kind);
+  const written = matches.find((row) => row.state === 'active') ?? matches[0];
   return written ? written.content : proposalText;
 }
 

--- a/packages/shared/src/types/aiAgentRuns.ts
+++ b/packages/shared/src/types/aiAgentRuns.ts
@@ -253,15 +253,28 @@ export interface ExposureBudgetDto {
  * `finishRun` created (`intentIds`) and which `ticket_drafts` rows it wrote
  * (`draftsWritten`). Still text/identifier-only — no `args`/`input`/`output`
  * blob, nothing a raw tool payload could carry.
+ *
+ * Issue #4467 — `draftReply`/`draftResolutionNote` (inherited below from
+ * `TicketTriageProposal`) are no longer always the proposal's own frozen
+ * text: once a `ticket_drafts` row exists for that kind (i.e. once
+ * `draftsWritten` names it), the API sources the text live from that SAME
+ * row instead, so a later edit on the ticket's "AI draft" surface can't
+ * leave this DTO showing stale content next to a `draftsWritten` entry that
+ * still points at the (now different) row. Pre-write — before a draft
+ * intent has released — there is no live row yet, so the proposal's own
+ * text is the only preview available and is used as-is. See
+ * `pickDraftText` in `services/aiAgents/runTrace.ts` for the derivation.
  */
 export interface AiAgentRunTicketProposalDto extends TicketTriageProposal {
   /** Tier-2 `manage_tickets` intent ids `finishRun` created from this
    *  proposal's `fields`/`device`/`comment` writes (act + autonomousWrites,
    *  or an inbox card — either way an intent id, never the raw args). */
   intentIds?: string[];
-  /** `ticket_drafts` rows `finishRun` wrote from `draftReply`/
-   *  `draftResolutionNote` — never the draft's own content, which lives on
-   *  the ticket UI's "AI draft" surface, not this run-trace DTO. */
+  /** `ticket_drafts` rows `finishRun` wrote — id + kind only. The row's own
+   *  `content` never appears on THESE entries (it would duplicate
+   *  `draftReply`/`draftResolutionNote` above, which is exactly the
+   *  duplication issue #4467 removed) — see this interface's own docstring
+   *  for how the two are now kept from disagreeing. */
   draftsWritten?: Array<{ kind: 'reply' | 'resolution_note'; draftId: string }>;
   /** Follow-up to #4191/#4301 (issue #4462) — why a slot this proposal named
    *  did NOT become a write, e.g. a field proposed below


### PR DESCRIPTION
## Summary

Closes #4467.

The ticket-triage run-detail DTO carried the draft text (`ticketProposal.draftReply` / `draftResolutionNote`) via the persisted `TicketTriageProposal` outcome — text frozen at proposal time — while `ticketProposal.draftsWritten` was a separate, live `ticket_drafts` read (id + kind only). These were two independently-sourced representations of the same draft(s) and could disagree: once a draft is actually written, a technician can edit its content on the ticket's "AI draft" surface (`TicketWorkbench.tsx`), or a write can be superseded, and the run-detail page kept showing the stale originally-proposed text forever, next to a `draftsWritten` entry that still pointed at the (now different) live row.

## Fix

`apps/api/src/services/aiAgents/runTrace.ts` (`mapTicketProposal` / new `pickDraftText` helper): derive `draftReply`/`draftResolutionNote` from the **same** live `ticket_drafts` read `draftsWritten` is built from, whenever a row exists for that kind — falling back to the proposal's own text only pre-write (a draft intent left `pending_approval` hasn't released into a `ticket_drafts` row yet, so there's no live truth to prefer, and the proposal preview is the only thing worth showing before a technician approves it).

This is chosen over the DTO's alternative ("carry the ticket_drafts id, have the client fetch content separately") because the run-detail page needs to preview proposed-but-not-yet-approved draft text, which by definition has no `ticket_drafts` row yet — so a client-side fetch-by-id can't cover the pending case, and a "sometimes have an id, sometimes have text" DTO shape is worse than the client always getting the right text at whichever field it already reads. It's also strictly better than syncing two copies (writing `proposal.draftReply`'s value into a new `content` field on `draftsWritten` at write time): that would still leave the DTO with two live-diverging copies after a later edit. Deriving off one source at read time removes the duplication instead of chasing it.

`apps/api/src/routes/aiAgents.ts`: the `ticket_drafts` select now also projects `content` — feeding the derivation only; `draftsWritten`'s own wire entries stay id/kind-only (never a `content` key), so a written draft's text is exposed exactly once on the wire.

`packages/shared/src/types/aiAgentRuns.ts`: docstring update only (no wire-shape change) — the `draftsWritten`/`AiAgentRunTicketProposalDto` comments previously claimed content "never" reaches the DTO via that path, which is now more precisely true of `draftsWritten`'s entries specifically, not `draftReply`/`draftResolutionNote`.

## Tests

- `apps/api/src/services/aiAgents/runTrace.test.ts` — new tests: draftReply/draftResolutionNote derive from the live written row when one exists (never disagreeing with `draftsWritten`), fall back to the proposal's own text pre-write, and `draftsWritten`'s own entries never carry a `content` key even though that content now legitimately reaches `draftReply`/`draftResolutionNote`. Existing tests updated for the new required `content` field on `RunTraceDraftRowInput`.
- `apps/api/src/routes/aiAgents.test.ts` — route-level assertion that `draftReply` matches the live draft-row content it derives from.

Ran red-first: added the alignment tests before the fix, confirmed they failed for the expected reason, then implemented.

```
cd apps/api && npx vitest run src/services/aiAgents/runTrace.test.ts src/routes/aiAgents.test.ts
# 2 files, 150 passed
NODE_OPTIONS="--max-old-space-size=8192" npx tsc --noEmit   # apps/api — clean
NODE_OPTIONS="--max-old-space-size=8192" npx tsc --noEmit   # packages/shared — clean (touched files); pre-existing unrelated errors in validators/quotes.test.ts, confirmed present on origin/main
npx vitest run src/types/aiAgentRuns.test.ts                # packages/shared — 10 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBxF7C8E5GxFnNcGf6kBVP