### PR TITLE
fix(web): add change-currency UI for draft quotes and invoices (#4416)

### DIFF
--- a/apps/web/src/components/billing/ChangeCurrencyDialog.tsx
+++ b/apps/web/src/components/billing/ChangeCurrencyDialog.tsx
@@ -1,0 +1,165 @@
+import { useTranslation } from 'react-i18next';
+import { Dialog } from '../shared/Dialog';
+import { currencyLabel, currencyOptions } from '@/lib/currencies';
+
+/**
+ * Shared change-currency dialog for DRAFT quotes and invoices (#4416).
+ *
+ * Ports the pattern ContractDetail's currency restamp dialog established
+ * (#3778) for the two draft-only document types that share one server
+ * contract: `POST /(quotes|invoices)/:id/currency` (multi-currency wave 2,
+ * #3774) accepts `{ currencyCode, clearLines? | reprice? }` and 409s
+ * `CURRENCY_LOCKED` when priced lines exist and neither is set. Unlike the
+ * contract op (ACTIVE contracts only, blockers keyed by row id), the draft op
+ * has no structured blocker payload — just a human-readable message — so this
+ * dialog surfaces `error` as a single inline string rather than an id list.
+ *
+ * All copy is pre-translated by the caller (quote/invoice-specific i18n
+ * namespaces) so the static i18n key-usage check can verify every key at its
+ * real call site instead of through a dynamic prefix.
+ */
+export type CurrencyChangeMode = 'clear' | 'reprice';
+
+export interface ChangeCurrencyDialogCopy {
+  title: string;
+  description: string;
+  currencyLabel: string;
+  modeLegend: string;
+  modeClearLabel: string;
+  modeClearHint: string;
+  modeRepriceLabel: string;
+  modeRepriceHint: string;
+  confirmLabel: string;
+  submitLabel: string;
+  cancelLabel: string;
+}
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  busy: boolean;
+  currentCurrency: string;
+  targetCurrency: string;
+  onTargetCurrencyChange: (code: string) => void;
+  mode: CurrencyChangeMode | null;
+  onModeChange: (mode: CurrencyChangeMode) => void;
+  confirmed: boolean;
+  onConfirmedChange: (confirmed: boolean) => void;
+  /** Inline 409/CURRENCY_LOCKED message. runAction already toasts it; this
+   *  keeps it visible in the (still-open) dialog too. */
+  error: string | null;
+  onSubmit: () => void;
+  submittable: boolean;
+  copy: ChangeCurrencyDialogCopy;
+  /** data-testid prefix, e.g. "quote-currency" / "invoice-currency" — mirrors
+   *  the "contract-currency-*" ids ContractDetail's dialog established. */
+  testIdPrefix: string;
+}
+
+export default function ChangeCurrencyDialog({
+  open, onClose, busy, currentCurrency, targetCurrency, onTargetCurrencyChange,
+  mode, onModeChange, confirmed, onConfirmedChange, error, onSubmit, submittable,
+  copy, testIdPrefix,
+}: Props) {
+  const { i18n } = useTranslation('billing');
+  return (
+    <Dialog open={open} onClose={onClose} title={copy.title} maxWidth="lg" className="p-6">
+      <div className="space-y-4" data-testid={`${testIdPrefix}-dialog`}>
+        <div>
+          <h3 className="text-base font-semibold">{copy.title}</h3>
+          <p className="mt-1 text-sm text-muted-foreground">{copy.description}</p>
+        </div>
+
+        <div>
+          <label className="text-sm font-medium" htmlFor={`${testIdPrefix}-select`}>
+            {copy.currencyLabel}
+          </label>
+          <select
+            id={`${testIdPrefix}-select`}
+            value={targetCurrency}
+            onChange={(e) => onTargetCurrencyChange(e.target.value)}
+            data-testid={`${testIdPrefix}-select`}
+            className="mt-1 w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+          >
+            {currencyOptions(currentCurrency).map((code) => (
+              <option key={code} value={code}>{currencyLabel(code, i18n.language)}</option>
+            ))}
+          </select>
+        </div>
+
+        {/* clearLines and reprice are mutually exclusive server-side, so the UI
+            models them as one radio group rather than two checkboxes that could
+            be sent together. */}
+        <fieldset className="space-y-2">
+          <legend className="text-sm font-medium">{copy.modeLegend}</legend>
+          <label className="flex items-start gap-2 text-sm">
+            <input
+              type="radio" name={`${testIdPrefix}-mode`} value="clear"
+              checked={mode === 'clear'}
+              onChange={() => onModeChange('clear')}
+              data-testid={`${testIdPrefix}-mode-clear`}
+              className="mt-1"
+            />
+            <span>
+              <span className="font-medium">{copy.modeClearLabel}</span>
+              <span className="block text-muted-foreground">{copy.modeClearHint}</span>
+            </span>
+          </label>
+          <label className="flex items-start gap-2 text-sm">
+            <input
+              type="radio" name={`${testIdPrefix}-mode`} value="reprice"
+              checked={mode === 'reprice'}
+              onChange={() => onModeChange('reprice')}
+              data-testid={`${testIdPrefix}-mode-reprice`}
+              className="mt-1"
+            />
+            <span>
+              <span className="font-medium">{copy.modeRepriceLabel}</span>
+              <span className="block text-muted-foreground">{copy.modeRepriceHint}</span>
+            </span>
+          </label>
+        </fieldset>
+
+        <label className="flex items-start gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={confirmed}
+            onChange={(e) => onConfirmedChange(e.target.checked)}
+            data-testid={`${testIdPrefix}-confirm-check`}
+            className="mt-1"
+          />
+          <span>{copy.confirmLabel}</span>
+        </label>
+
+        {error && (
+          <div
+            className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive"
+            data-testid={`${testIdPrefix}-error`}
+            role="alert"
+          >
+            {error}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted"
+          >
+            {copy.cancelLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onSubmit}
+            disabled={busy || !submittable}
+            data-testid={`${testIdPrefix}-submit`}
+            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+          >
+            {copy.submitLabel}
+          </button>
+        </div>
+      </div>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/billing/InvoiceDetail.currency.test.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.currency.test.tsx
@@ -1,0 +1,176 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import InvoiceDetail from './InvoiceDetail';
+import { fetchWithAuth } from '../../stores/auth';
+import type { InvoiceDetail as InvoiceDetailData, InvoiceStatus } from './invoiceTypes';
+
+// #4416 — the draft-only atomic change-currency op (#3774,
+// changeInvoiceCurrency in invoiceService.ts) has been reachable server-side
+// since multi-currency wave 2, but only ContractDetail ever grew a dialog for
+// it. These tests pin the ported behaviour:
+//   - the action is offered only on a DRAFT invoice, gated on invoices:write;
+//   - a success posts exactly the confirmed payload and reloads the invoice;
+//   - a 409 CURRENCY_LOCKED renders inline (in ADDITION to runAction's own
+//     toast) and keeps the dialog open — never a silent no-op.
+
+type Perm = { resource: string; action: string };
+const state = vi.hoisted(() => ({ permissions: [] as Perm[] }));
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  registerOrgIdProvider: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: Perm[] } }) => unknown) =>
+      selector({ user: { permissions: state.permissions } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const resp = (payload: unknown, status = 200): Response =>
+  ({ ok: status < 400, status, statusText: 'OK', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+function detail(status: InvoiceStatus, currencyCode = 'USD'): InvoiceDetailData {
+  return {
+    invoice: {
+      id: 'inv-1', invoiceNumber: null, orgId: 'org-1', siteId: null, status,
+      currencyCode, issueDate: null, dueDate: null, sentAt: null,
+      subtotal: '0.00', taxRate: null, taxTotal: '0.00', total: '0.00',
+      amountPaid: '0.00', balance: '0.00', billToName: 'Acme',
+      notes: null, termsAndConditions: null, sellerSnapshot: null,
+      createdAt: '2026-06-01T00:00:00Z',
+    },
+    lines: [],
+  };
+}
+
+async function openDialog() {
+  await waitFor(() => expect(screen.getByTestId('invoice-detail')).toBeInTheDocument());
+  fireEvent.click(screen.getByTestId('invoice-currency-open'));
+  await screen.findByTestId('invoice-currency-dialog');
+}
+
+async function confirmWith(mode: 'clear' | 'reprice', currency = 'EUR') {
+  fireEvent.change(screen.getByTestId('invoice-currency-select'), { target: { value: currency } });
+  fireEvent.click(screen.getByTestId(`invoice-currency-mode-${mode}`));
+  fireEvent.click(screen.getByTestId('invoice-currency-confirm-check'));
+  fireEvent.click(screen.getByTestId('invoice-currency-submit'));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.permissions = [{ resource: 'invoices', action: 'write' }];
+  // Default: payments endpoint returns empty list; the currency op succeeds.
+  fetchMock.mockImplementation(async (input: string) => {
+    if (typeof input === 'string' && input.endsWith('/payments')) return resp({ data: [] });
+    if (typeof input === 'string' && input.endsWith('/currency')) return resp({ data: { id: 'inv-1' } });
+    return resp({ data: null });
+  });
+});
+
+describe('InvoiceDetail — draft currency change (#4416)', () => {
+  it('shows the action on a DRAFT invoice with invoices:write', async () => {
+    render(<InvoiceDetail detail={detail('draft')} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-detail')).toBeInTheDocument());
+    expect(screen.getByTestId('invoice-currency-open')).toBeInTheDocument();
+  });
+
+  it('hides the action without invoices:write', async () => {
+    state.permissions = [{ resource: 'invoices', action: 'read' }];
+    render(<InvoiceDetail detail={detail('draft')} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-detail')).toBeInTheDocument());
+    expect(screen.queryByTestId('invoice-currency-open')).not.toBeInTheDocument();
+  });
+
+  it('does not offer the action on a non-draft (sent) invoice', async () => {
+    render(<InvoiceDetail detail={detail('sent')} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-detail')).toBeInTheDocument());
+    expect(screen.queryByTestId('invoice-currency-open')).not.toBeInTheDocument();
+  });
+
+  it('keeps submit disabled until a mode is chosen, confirmed, and the currency differs', async () => {
+    render(<InvoiceDetail detail={detail('draft')} onChanged={vi.fn()} />);
+    await openDialog();
+    const submit = () => screen.getByTestId('invoice-currency-submit') as HTMLButtonElement;
+
+    expect(submit().disabled).toBe(true);
+    fireEvent.change(screen.getByTestId('invoice-currency-select'), { target: { value: 'EUR' } });
+    expect(submit().disabled).toBe(true);
+    fireEvent.click(screen.getByTestId('invoice-currency-mode-clear'));
+    expect(submit().disabled).toBe(true);
+    fireEvent.click(screen.getByTestId('invoice-currency-confirm-check'));
+    expect(submit().disabled).toBe(false);
+
+    fireEvent.change(screen.getByTestId('invoice-currency-select'), { target: { value: 'USD' } });
+    expect(submit().disabled).toBe(true);
+  });
+
+  it('posts exactly the confirmed payload and reloads the invoice on success', async () => {
+    const onChanged = vi.fn();
+    render(<InvoiceDetail detail={detail('draft')} onChanged={onChanged} />);
+    await openDialog();
+    await confirmWith('reprice', 'EUR');
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/invoices/inv-1/currency', {
+      method: 'POST', body: JSON.stringify({ currencyCode: 'EUR', reprice: true }),
+    }));
+    await waitFor(() => expect(onChanged).toHaveBeenCalled());
+    await waitFor(() => expect(screen.queryByTestId('invoice-currency-dialog')).not.toBeInTheDocument());
+  });
+
+  it('sends clearLines (not reprice) when the operator chooses to clear the lines', async () => {
+    render(<InvoiceDetail detail={detail('draft')} onChanged={vi.fn()} />);
+    await openDialog();
+    await confirmWith('clear', 'JPY');
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/invoices/inv-1/currency', {
+      method: 'POST', body: JSON.stringify({ currencyCode: 'JPY', clearLines: true }),
+    }));
+  });
+
+  it('shows a 409 CURRENCY_LOCKED message inline and keeps the dialog open', async () => {
+    fetchMock.mockImplementation(async (input: string) => {
+      if (typeof input === 'string' && input.endsWith('/payments')) return resp({ data: [] });
+      if (typeof input === 'string' && input.endsWith('/currency')) {
+        return resp({
+          error: 'Invoice has 2 line(s) priced in USD — pass clearLines to remove them, or delete the draft',
+          code: 'CURRENCY_LOCKED',
+        }, 409);
+      }
+      return resp({ data: null });
+    });
+
+    const onChanged = vi.fn();
+    render(<InvoiceDetail detail={detail('draft')} onChanged={onChanged} />);
+    await openDialog();
+    await confirmWith('clear');
+
+    const error = await screen.findByTestId('invoice-currency-error');
+    expect(error).toHaveTextContent(/pass clearLines/i);
+    expect(screen.getByTestId('invoice-currency-dialog')).toBeInTheDocument();
+    expect(onChanged).not.toHaveBeenCalled();
+  });
+
+  it('clears a previous inline error when the operator retries', async () => {
+    let first = true;
+    fetchMock.mockImplementation(async (input: string) => {
+      if (typeof input === 'string' && input.endsWith('/payments')) return resp({ data: [] });
+      if (typeof input === 'string' && input.endsWith('/currency')) {
+        if (first) { first = false; return resp({ error: 'locked', code: 'CURRENCY_LOCKED' }, 409); }
+        return resp({ data: { id: 'inv-1' } });
+      }
+      return resp({ data: null });
+    });
+
+    render(<InvoiceDetail detail={detail('draft')} onChanged={vi.fn()} />);
+    await openDialog();
+    await confirmWith('clear');
+    await screen.findByTestId('invoice-currency-error');
+
+    fireEvent.click(screen.getByTestId('invoice-currency-submit'));
+    await waitFor(() => expect(screen.queryByTestId('invoice-currency-dialog')).not.toBeInTheDocument());
+  });
+});

--- a/apps/web/src/components/billing/InvoiceDetail.currency.test.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.currency.test.tsx
@@ -154,7 +154,38 @@ describe('InvoiceDetail — draft currency change (#4416)', () => {
     expect(onChanged).not.toHaveBeenCalled();
   });
 
-  it('clears a previous inline error when the operator retries', async () => {
+  it('replaces a stale inline error with the new one on a second failed retry', async () => {
+    // Two DIFFERENT failures back to back: if the component ever stopped
+    // resetting currencyError before the retry request, the first message
+    // could linger (e.g. a stale closure, or a guard that only sets the error
+    // when it was previously null) and this would still show "first lock
+    // reason" after the second attempt.
+    let attempt = 0;
+    fetchMock.mockImplementation(async (input: string) => {
+      if (typeof input === 'string' && input.endsWith('/payments')) return resp({ data: [] });
+      if (typeof input === 'string' && input.endsWith('/currency')) {
+        attempt += 1;
+        const message = attempt === 1 ? 'first lock reason' : 'second lock reason';
+        return resp({ error: message, code: 'CURRENCY_LOCKED' }, 409);
+      }
+      return resp({ data: null });
+    });
+
+    render(<InvoiceDetail detail={detail('draft')} onChanged={vi.fn()} />);
+    await openDialog();
+    await confirmWith('clear');
+    expect(await screen.findByTestId('invoice-currency-error')).toHaveTextContent('first lock reason');
+
+    fireEvent.click(screen.getByTestId('invoice-currency-submit'));
+    await waitFor(() => {
+      const error = screen.getByTestId('invoice-currency-error');
+      expect(error).toHaveTextContent('second lock reason');
+      expect(error).not.toHaveTextContent('first lock reason');
+    });
+    expect(screen.getByTestId('invoice-currency-dialog')).toBeInTheDocument();
+  });
+
+  it('clears a previous inline error and reloads the invoice on a successful retry', async () => {
     let first = true;
     fetchMock.mockImplementation(async (input: string) => {
       if (typeof input === 'string' && input.endsWith('/payments')) return resp({ data: [] });
@@ -171,6 +202,32 @@ describe('InvoiceDetail — draft currency change (#4416)', () => {
     await screen.findByTestId('invoice-currency-error');
 
     fireEvent.click(screen.getByTestId('invoice-currency-submit'));
+    await waitFor(() => expect(screen.queryByTestId('invoice-currency-dialog')).not.toBeInTheDocument());
+  });
+
+  it('disables submit while the change-currency request is in flight (busy cue)', async () => {
+    // Mirrors the InvoiceEditor "disables the notes textarea while its own
+    // save is in flight" pattern: hold the request open with a deferred
+    // Promise so the busy window is actually observable, not just inferred
+    // from the eventual settled state.
+    let releaseRequest: (v: Response) => void = () => {};
+    fetchMock.mockImplementation(async (input: string) => {
+      if (typeof input === 'string' && input.endsWith('/payments')) return resp({ data: [] });
+      if (typeof input === 'string' && input.endsWith('/currency')) {
+        return new Promise<Response>((resolve) => { releaseRequest = resolve; });
+      }
+      return resp({ data: null });
+    });
+
+    render(<InvoiceDetail detail={detail('draft')} onChanged={vi.fn()} />);
+    await openDialog();
+    fireEvent.change(screen.getByTestId('invoice-currency-select'), { target: { value: 'EUR' } });
+    fireEvent.click(screen.getByTestId('invoice-currency-mode-clear'));
+    fireEvent.click(screen.getByTestId('invoice-currency-confirm-check'));
+    fireEvent.click(screen.getByTestId('invoice-currency-submit'));
+
+    await waitFor(() => expect(screen.getByTestId('invoice-currency-submit')).toBeDisabled());
+    releaseRequest(resp({ data: { id: 'inv-1' } }));
     await waitFor(() => expect(screen.queryByTestId('invoice-currency-dialog')).not.toBeInTheDocument());
   });
 });

--- a/apps/web/src/components/billing/InvoiceDetail.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.tsx
@@ -3,11 +3,12 @@ import { useTranslation } from 'react-i18next';
 import '../../lib/i18n';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
-import { runAction, handleActionError } from '../../lib/runAction';
+import { runAction, handleActionError, ActionError } from '../../lib/runAction';
 import { usePermissions } from '../../lib/permissions';
 import { showToast } from '../shared/Toast';
 import { Dialog } from '../shared/Dialog';
 import { ConfirmDialog } from '../shared/ConfirmDialog';
+import ChangeCurrencyDialog, { type CurrencyChangeMode } from './ChangeCurrencyDialog';
 import {
   type InvoiceDetail as InvoiceDetailData,
   type InvoiceLine,
@@ -84,6 +85,17 @@ export default function InvoiceDetail({ detail, onChanged, actionsInHeader = fal
   const [voidOpen, setVoidOpen] = useState(false);
   const [voidReason, setVoidReason] = useState('');
   const [voidReissue, setVoidReissue] = useState(false);
+
+  // Draft-only currency restamp (#4416, ports the ContractDetail #3778
+  // pattern). The server (changeInvoiceCurrency, invoiceService.ts) is the
+  // authority: it re-checks invoices:write, the draft status and the row
+  // lock, so this dialog is a convenience, never a gate.
+  const [currencyOpen, setCurrencyOpen] = useState(false);
+  const [currencyBusy, setCurrencyBusy] = useState(false);
+  const [targetCurrency, setTargetCurrency] = useState(currency);
+  const [currencyMode, setCurrencyMode] = useState<CurrencyChangeMode | null>(null);
+  const [currencyConfirmed, setCurrencyConfirmed] = useState(false);
+  const [currencyError, setCurrencyError] = useState<string | null>(null);
 
   // Inline due-date editor (issued invoices only). Opens with the current due date;
   // Save PATCHes /invoices/:id/due-date.
@@ -275,6 +287,51 @@ export default function InvoiceDetail({ detail, onChanged, actionsInHeader = fal
       setBusy(false);
     }
   }, [busy, voidReason, voidReissue, invoice.id, refresh, t]);
+
+  const openCurrencyDialog = useCallback(() => {
+    setTargetCurrency(currency);
+    setCurrencyMode(null);
+    setCurrencyConfirmed(false);
+    setCurrencyError(null);
+    setCurrencyOpen(true);
+  }, [currency]);
+
+  const submitCurrency = useCallback(async () => {
+    if (currencyBusy || !currencyMode || !currencyConfirmed || targetCurrency === currency) return;
+    setCurrencyBusy(true);
+    // A retry starts from a clean slate — a stale error would read as a fresh
+    // rejection of the SAME attempt.
+    setCurrencyError(null);
+    try {
+      await runAction({
+        request: () => fetchWithAuth(`/invoices/${invoice.id}/currency`, {
+          method: 'POST',
+          body: JSON.stringify({
+            currencyCode: targetCurrency,
+            ...(currencyMode === 'clear' ? { clearLines: true } : { reprice: true }),
+          }),
+        }),
+        errorFallback: t('invoiceDetail.currency.errors.change'),
+        successMessage: t('invoiceDetail.currency.toast.changed', { currency: targetCurrency }),
+        onUnauthorized: UNAUTHORIZED,
+      });
+      setCurrencyOpen(false);
+      refresh();
+    } catch (err) {
+      // A 409 CURRENCY_LOCKED names why (line count) in its message — keep the
+      // dialog open and show it inline rather than losing it to a toast alone.
+      if (err instanceof ActionError && err.status === 409) {
+        setCurrencyError(err.message);
+      } else {
+        handleActionError(err, t('invoiceDetail.currency.errors.change'));
+      }
+    } finally {
+      setCurrencyBusy(false);
+    }
+  }, [currencyBusy, currencyMode, currencyConfirmed, targetCurrency, currency, invoice.id, refresh, t]);
+
+  const canChangeCurrency = can('invoices', 'write') && invoice.status === 'draft';
+  const currencySubmittable = !!currencyMode && currencyConfirmed && targetCurrency !== currency;
 
   return (
     <div className="space-y-6" data-testid="invoice-detail">
@@ -523,6 +580,20 @@ export default function InvoiceDetail({ detail, onChanged, actionsInHeader = fal
                 {t('invoiceDetail.void.button')}
               </button>
             )}
+            {/* Change stamped currency (DRAFT only, #4416). The server
+                re-checks permission, the draft status and eligibility under
+                the row lock. */}
+            {canChangeCurrency && (
+              <button
+                type="button"
+                onClick={openCurrencyDialog}
+                disabled={currencyBusy}
+                data-testid="invoice-currency-open"
+                className="inline-flex w-full items-center justify-center rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted disabled:opacity-50"
+              >
+                {t('invoiceDetail.currency.actions.change')}
+              </button>
+            )}
           </div>
 
           {/* Payments */}
@@ -751,6 +822,36 @@ export default function InvoiceDetail({ detail, onChanged, actionsInHeader = fal
           </div>
         </div>
       </Dialog>
+
+      <ChangeCurrencyDialog
+        open={currencyOpen}
+        onClose={() => setCurrencyOpen(false)}
+        busy={currencyBusy}
+        currentCurrency={currency}
+        targetCurrency={targetCurrency}
+        onTargetCurrencyChange={setTargetCurrency}
+        mode={currencyMode}
+        onModeChange={setCurrencyMode}
+        confirmed={currencyConfirmed}
+        onConfirmedChange={setCurrencyConfirmed}
+        error={currencyError}
+        onSubmit={() => void submitCurrency()}
+        submittable={currencySubmittable}
+        testIdPrefix="invoice-currency"
+        copy={{
+          title: t('invoiceDetail.currency.dialog.title'),
+          description: t('invoiceDetail.currency.dialog.description', { currency }),
+          currencyLabel: t('invoiceDetail.currency.dialog.currencyLabel'),
+          modeLegend: t('invoiceDetail.currency.dialog.modeLegend'),
+          modeClearLabel: t('invoiceDetail.currency.dialog.modeClear'),
+          modeClearHint: t('invoiceDetail.currency.dialog.modeClearHint'),
+          modeRepriceLabel: t('invoiceDetail.currency.dialog.modeReprice'),
+          modeRepriceHint: t('invoiceDetail.currency.dialog.modeRepriceHint'),
+          confirmLabel: t('invoiceDetail.currency.dialog.confirm'),
+          submitLabel: t('invoiceDetail.currency.dialog.submit'),
+          cancelLabel: t('common:actions.cancel'),
+        }}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/billing/quotes/QuoteDetail.currency.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.currency.test.tsx
@@ -1,0 +1,166 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import QuoteDetail from './QuoteDetail';
+import * as quotesApi from '../../../lib/api/quotes';
+import type { QuoteDetail as QuoteDetailData, QuoteStatus } from './quoteTypes';
+
+// #4416 — the draft-only atomic change-currency op (#3774,
+// changeQuoteCurrency in quoteService.ts) has been reachable server-side
+// since multi-currency wave 2, but only ContractDetail ever grew a dialog for
+// it. These tests pin the ported behaviour:
+//   - the action is offered only on a DRAFT quote, gated on quotes:write;
+//   - a success posts exactly the confirmed payload and reloads the quote;
+//   - a 409 CURRENCY_LOCKED renders inline (in ADDITION to runAction's own
+//     toast) and keeps the dialog open — never a silent no-op.
+
+type Perm = { resource: string; action: string };
+const state = vi.hoisted(() => ({ permissions: [] as Perm[] }));
+
+vi.mock('../../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  registerOrgIdProvider: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: Perm[] } }) => unknown) =>
+      selector({ user: { permissions: state.permissions } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../../shared/Toast', () => ({ showToast: vi.fn() }));
+
+vi.mock('../../../lib/api/quotes', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../lib/api/quotes')>();
+  return { ...actual, changeQuoteCurrency: vi.fn() };
+});
+
+const resp = (payload: unknown, status = 200): Response =>
+  ({ ok: status < 400, status, statusText: 'OK', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+function detail(status: QuoteStatus, currencyCode = 'USD'): QuoteDetailData {
+  return {
+    quote: {
+      id: 'q-1', quoteNumber: null, partnerId: 'p-1', orgId: 'org-1', siteId: null, status,
+      currencyCode, issueDate: null, expiryDate: null, subtotal: '0.00', taxRate: null,
+      taxTotal: '0.00', total: '0.00', oneTimeTotal: '0.00', monthlyRecurringTotal: '0.00',
+      annualRecurringTotal: '0.00', billToName: 'Acme', introNotes: null, terms: null,
+      termsAndConditions: null, sellerSnapshot: null, acceptedAt: null, declinedAt: null,
+      convertedAt: null, convertedInvoiceId: null, sentAt: null, viewedAt: null,
+      createdBy: null, createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+    },
+    blocks: [],
+    lines: [],
+  };
+}
+
+const write = [{ resource: 'quotes', action: 'write' }];
+
+async function openDialog() {
+  await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
+  fireEvent.click(screen.getByTestId('quote-currency-open'));
+  await screen.findByTestId('quote-currency-dialog');
+}
+
+async function confirmWith(mode: 'clear' | 'reprice', currency = 'EUR') {
+  fireEvent.change(screen.getByTestId('quote-currency-select'), { target: { value: currency } });
+  fireEvent.click(screen.getByTestId(`quote-currency-mode-${mode}`));
+  fireEvent.click(screen.getByTestId('quote-currency-confirm-check'));
+  fireEvent.click(screen.getByTestId('quote-currency-submit'));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.permissions = write;
+  (quotesApi.changeQuoteCurrency as ReturnType<typeof vi.fn>).mockResolvedValue(resp({ data: { id: 'q-1' } }));
+});
+
+describe('QuoteDetail — draft currency change (#4416)', () => {
+  it('shows the action on a DRAFT quote with quotes:write', async () => {
+    render(<QuoteDetail detail={detail('draft')} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
+    expect(screen.getByTestId('quote-currency-open')).toBeInTheDocument();
+  });
+
+  it('hides the action without quotes:write', async () => {
+    state.permissions = [{ resource: 'quotes', action: 'read' }];
+    render(<QuoteDetail detail={detail('draft')} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
+    expect(screen.queryByTestId('quote-currency-open')).not.toBeInTheDocument();
+  });
+
+  it('does not offer the action on a non-draft (sent) quote', async () => {
+    render(<QuoteDetail detail={detail('sent')} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
+    expect(screen.queryByTestId('quote-currency-open')).not.toBeInTheDocument();
+  });
+
+  it('keeps submit disabled until a mode is chosen, confirmed, and the currency differs', async () => {
+    render(<QuoteDetail detail={detail('draft')} onChanged={vi.fn()} />);
+    await openDialog();
+    const submit = () => screen.getByTestId('quote-currency-submit') as HTMLButtonElement;
+
+    expect(submit().disabled).toBe(true);
+    fireEvent.change(screen.getByTestId('quote-currency-select'), { target: { value: 'EUR' } });
+    expect(submit().disabled).toBe(true);
+    fireEvent.click(screen.getByTestId('quote-currency-mode-clear'));
+    expect(submit().disabled).toBe(true);
+    fireEvent.click(screen.getByTestId('quote-currency-confirm-check'));
+    expect(submit().disabled).toBe(false);
+
+    fireEvent.change(screen.getByTestId('quote-currency-select'), { target: { value: 'USD' } });
+    expect(submit().disabled).toBe(true);
+  });
+
+  it('posts exactly the confirmed payload and reloads the quote on success', async () => {
+    const onChanged = vi.fn();
+    render(<QuoteDetail detail={detail('draft')} onChanged={onChanged} />);
+    await openDialog();
+    await confirmWith('reprice', 'EUR');
+
+    await waitFor(() => expect(quotesApi.changeQuoteCurrency).toHaveBeenCalledTimes(1));
+    expect(quotesApi.changeQuoteCurrency).toHaveBeenCalledWith('q-1', { currencyCode: 'EUR', reprice: true });
+    await waitFor(() => expect(onChanged).toHaveBeenCalled());
+    await waitFor(() => expect(screen.queryByTestId('quote-currency-dialog')).not.toBeInTheDocument());
+  });
+
+  it('sends clearLines (not reprice) when the operator chooses to clear the lines', async () => {
+    render(<QuoteDetail detail={detail('draft')} onChanged={vi.fn()} />);
+    await openDialog();
+    await confirmWith('clear', 'JPY');
+
+    await waitFor(() => expect(quotesApi.changeQuoteCurrency).toHaveBeenCalledWith('q-1', {
+      currencyCode: 'JPY', clearLines: true,
+    }));
+  });
+
+  it('shows a 409 CURRENCY_LOCKED message inline and keeps the dialog open', async () => {
+    (quotesApi.changeQuoteCurrency as ReturnType<typeof vi.fn>).mockResolvedValue(resp({
+      error: 'Quote has 2 line(s) priced in USD — pass clearLines to remove them, or delete the draft',
+      code: 'CURRENCY_LOCKED',
+    }, 409));
+
+    const onChanged = vi.fn();
+    render(<QuoteDetail detail={detail('draft')} onChanged={onChanged} />);
+    await openDialog();
+    await confirmWith('clear');
+
+    const error = await screen.findByTestId('quote-currency-error');
+    expect(error).toHaveTextContent(/pass clearLines/i);
+    expect(screen.getByTestId('quote-currency-dialog')).toBeInTheDocument();
+    expect(onChanged).not.toHaveBeenCalled();
+  });
+
+  it('clears a previous inline error when the operator retries', async () => {
+    (quotesApi.changeQuoteCurrency as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      resp({ error: 'locked', code: 'CURRENCY_LOCKED' }, 409),
+    );
+    render(<QuoteDetail detail={detail('draft')} onChanged={vi.fn()} />);
+    await openDialog();
+    await confirmWith('clear');
+    await screen.findByTestId('quote-currency-error');
+
+    (quotesApi.changeQuoteCurrency as ReturnType<typeof vi.fn>).mockResolvedValue(resp({ data: { id: 'q-1' } }));
+    fireEvent.click(screen.getByTestId('quote-currency-submit'));
+    await waitFor(() => expect(screen.queryByTestId('quote-currency-dialog')).not.toBeInTheDocument());
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteDetail.currency.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.currency.test.tsx
@@ -150,7 +150,33 @@ describe('QuoteDetail — draft currency change (#4416)', () => {
     expect(onChanged).not.toHaveBeenCalled();
   });
 
-  it('clears a previous inline error when the operator retries', async () => {
+  it('replaces a stale inline error with the new one on a second failed retry', async () => {
+    // Two DIFFERENT failures back to back: if the component ever stopped
+    // resetting currencyError before the retry request, the first message
+    // could linger (e.g. a stale closure, or a guard that only sets the error
+    // when it was previously null) and this would still show "first lock
+    // reason" after the second attempt.
+    (quotesApi.changeQuoteCurrency as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      resp({ error: 'first lock reason', code: 'CURRENCY_LOCKED' }, 409),
+    );
+    render(<QuoteDetail detail={detail('draft')} onChanged={vi.fn()} />);
+    await openDialog();
+    await confirmWith('clear');
+    expect(await screen.findByTestId('quote-currency-error')).toHaveTextContent('first lock reason');
+
+    (quotesApi.changeQuoteCurrency as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      resp({ error: 'second lock reason', code: 'CURRENCY_LOCKED' }, 409),
+    );
+    fireEvent.click(screen.getByTestId('quote-currency-submit'));
+    await waitFor(() => {
+      const error = screen.getByTestId('quote-currency-error');
+      expect(error).toHaveTextContent('second lock reason');
+      expect(error).not.toHaveTextContent('first lock reason');
+    });
+    expect(screen.getByTestId('quote-currency-dialog')).toBeInTheDocument();
+  });
+
+  it('clears a previous inline error and reloads the quote on a successful retry', async () => {
     (quotesApi.changeQuoteCurrency as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
       resp({ error: 'locked', code: 'CURRENCY_LOCKED' }, 409),
     );
@@ -161,6 +187,28 @@ describe('QuoteDetail — draft currency change (#4416)', () => {
 
     (quotesApi.changeQuoteCurrency as ReturnType<typeof vi.fn>).mockResolvedValue(resp({ data: { id: 'q-1' } }));
     fireEvent.click(screen.getByTestId('quote-currency-submit'));
+    await waitFor(() => expect(screen.queryByTestId('quote-currency-dialog')).not.toBeInTheDocument());
+  });
+
+  it('disables submit while the change-currency request is in flight (busy cue)', async () => {
+    // Mirrors the InvoiceEditor "disables the notes textarea while its own
+    // save is in flight" pattern: hold the request open with a deferred
+    // Promise so the busy window is actually observable, not just inferred
+    // from the eventual settled state.
+    let releaseRequest: (v: Response) => void = () => {};
+    (quotesApi.changeQuoteCurrency as ReturnType<typeof vi.fn>).mockReturnValue(
+      new Promise<Response>((resolve) => { releaseRequest = resolve; }),
+    );
+
+    render(<QuoteDetail detail={detail('draft')} onChanged={vi.fn()} />);
+    await openDialog();
+    fireEvent.change(screen.getByTestId('quote-currency-select'), { target: { value: 'EUR' } });
+    fireEvent.click(screen.getByTestId('quote-currency-mode-clear'));
+    fireEvent.click(screen.getByTestId('quote-currency-confirm-check'));
+    fireEvent.click(screen.getByTestId('quote-currency-submit'));
+
+    await waitFor(() => expect(screen.getByTestId('quote-currency-submit')).toBeDisabled());
+    releaseRequest(resp({ data: { id: 'q-1' } }));
     await waitFor(() => expect(screen.queryByTestId('quote-currency-dialog')).not.toBeInTheDocument());
   });
 });

--- a/apps/web/src/components/billing/quotes/QuoteDetail.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.tsx
@@ -3,13 +3,15 @@ import { useTranslation } from 'react-i18next';
 import '../../../lib/i18n';
 import { usePermissions } from '../../../lib/permissions';
 import { useOrgStore } from '../../../stores/orgStore';
-import { quoteImageUrl } from '../../../lib/api/quotes';
+import { quoteImageUrl, changeQuoteCurrency } from '../../../lib/api/quotes';
 import { useReviseQuote } from './useReviseQuote';
 import { navigateTo } from '@/lib/navigation';
+import { runAction, handleActionError, ActionError } from '../../../lib/runAction';
 import { useAuthedImage } from './useQuoteImage';
 import QuoteActions, { QuoteSendOutcomeBanners } from './QuoteActions';
 import QuoteOrderBreakdown, { orderableLines } from './QuoteOrderBreakdown';
 import { RecurringBillingNote, MarginPanel, MarginToggle, useShowMargin } from '../billingUi';
+import ChangeCurrencyDialog, { type CurrencyChangeMode } from '../ChangeCurrencyDialog';
 import { computeQuoteProfit, type QuoteProfit } from '@breeze/shared';
 import {
   type QuoteDetail as QuoteDetailData,
@@ -28,6 +30,8 @@ import {
   sellerLines,
 } from './quoteTypes';
 import { StatusPill } from '../shared/StatusPill';
+
+const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
 
 interface Props {
   detail: QuoteDetailData;
@@ -58,6 +62,59 @@ export default function QuoteDetail({ detail, onChanged, actionsInHeader }: Prop
   const { quote, blocks, lines } = detail;
   const recipients = detail.recipients ?? [];
   const currency = quote.currencyCode;
+
+  // Draft-only currency restamp (#4416, ports the ContractDetail #3778
+  // pattern). The server (changeQuoteCurrency, quoteService.ts) is the
+  // authority: it re-checks quotes:write, the draft status and the row lock,
+  // so this dialog is a convenience, never a gate.
+  const [currencyOpen, setCurrencyOpen] = useState(false);
+  const [currencyBusy, setCurrencyBusy] = useState(false);
+  const [targetCurrency, setTargetCurrency] = useState(currency);
+  const [currencyMode, setCurrencyMode] = useState<CurrencyChangeMode | null>(null);
+  const [currencyConfirmed, setCurrencyConfirmed] = useState(false);
+  const [currencyError, setCurrencyError] = useState<string | null>(null);
+
+  const openCurrencyDialog = useCallback(() => {
+    setTargetCurrency(currency);
+    setCurrencyMode(null);
+    setCurrencyConfirmed(false);
+    setCurrencyError(null);
+    setCurrencyOpen(true);
+  }, [currency]);
+
+  const submitCurrency = useCallback(async () => {
+    if (currencyBusy || !currencyMode || !currencyConfirmed || targetCurrency === currency) return;
+    setCurrencyBusy(true);
+    // A retry starts from a clean slate — a stale error would read as a fresh
+    // rejection of the SAME attempt.
+    setCurrencyError(null);
+    try {
+      await runAction({
+        request: () => changeQuoteCurrency(quote.id, {
+          currencyCode: targetCurrency,
+          ...(currencyMode === 'clear' ? { clearLines: true } : { reprice: true }),
+        }),
+        errorFallback: t('quotes.currency.errors.change'),
+        successMessage: t('quotes.currency.toast.changed', { currency: targetCurrency }),
+        onUnauthorized: UNAUTHORIZED,
+      });
+      setCurrencyOpen(false);
+      onChanged?.();
+    } catch (err) {
+      // A 409 CURRENCY_LOCKED names why (line count) in its message — keep the
+      // dialog open and show it inline rather than losing it to a toast alone.
+      if (err instanceof ActionError && err.status === 409) {
+        setCurrencyError(err.message);
+      } else {
+        handleActionError(err, t('quotes.currency.errors.change'));
+      }
+    } finally {
+      setCurrencyBusy(false);
+    }
+  }, [currencyBusy, currencyMode, currencyConfirmed, targetCurrency, currency, quote.id, onChanged, t]);
+
+  const canChangeCurrency = can('quotes', 'write') && quote.status === 'draft';
+  const currencySubmittable = !!currencyMode && currencyConfirmed && targetCurrency !== currency;
 
   // Same cents math as the editor rail (computeQuoteProfit), fed the read-model
   // strings, so the Detail margin can never diverge from the editor margin.
@@ -329,11 +386,55 @@ export default function QuoteDetail({ detail, onChanged, actionsInHeader }: Prop
             </div>
           )}
 
+          {/* Change stamped currency (DRAFT only, #4416). The server re-checks
+              permission, the draft status and eligibility under the row lock. */}
+          {canChangeCurrency && (
+            <button
+              type="button"
+              onClick={openCurrencyDialog}
+              disabled={currencyBusy}
+              data-testid="quote-currency-open"
+              className="inline-flex w-full items-center justify-center rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted disabled:opacity-50"
+            >
+              {t('quotes.currency.actions.change')}
+            </button>
+          )}
+
           {/* Actions — suppressed here when the workspace header owns them, so the
               primary Send action isn't doubled on the Detail tab. */}
           {!actionsInHeader && <QuoteActions detail={detail} onChanged={onChanged} variant="rail" />}
         </div>
       </div>
+
+      <ChangeCurrencyDialog
+        open={currencyOpen}
+        onClose={() => setCurrencyOpen(false)}
+        busy={currencyBusy}
+        currentCurrency={currency}
+        targetCurrency={targetCurrency}
+        onTargetCurrencyChange={setTargetCurrency}
+        mode={currencyMode}
+        onModeChange={setCurrencyMode}
+        confirmed={currencyConfirmed}
+        onConfirmedChange={setCurrencyConfirmed}
+        error={currencyError}
+        onSubmit={() => void submitCurrency()}
+        submittable={currencySubmittable}
+        testIdPrefix="quote-currency"
+        copy={{
+          title: t('quotes.currency.dialog.title'),
+          description: t('quotes.currency.dialog.description', { currency }),
+          currencyLabel: t('quotes.currency.dialog.currencyLabel'),
+          modeLegend: t('quotes.currency.dialog.modeLegend'),
+          modeClearLabel: t('quotes.currency.dialog.modeClear'),
+          modeClearHint: t('quotes.currency.dialog.modeClearHint'),
+          modeRepriceLabel: t('quotes.currency.dialog.modeReprice'),
+          modeRepriceHint: t('quotes.currency.dialog.modeRepriceHint'),
+          confirmLabel: t('quotes.currency.dialog.confirm'),
+          submitLabel: t('quotes.currency.dialog.submit'),
+          cancelLabel: t('common:actions.cancel'),
+        }}
+      />
     </div>
   );
 }

--- a/apps/web/src/lib/api/quotes.ts
+++ b/apps/web/src/lib/api/quotes.ts
@@ -120,6 +120,24 @@ export function deleteQuote(id: string): Promise<Response> {
   return fetchWithAuth(`/quotes/${id}`, { method: 'DELETE' });
 }
 
+/** Draft-only atomic change-currency op (#3774, mirrors changeContractCurrency
+ *  in lib/api/contracts.ts). `clearLines` and `reprice` are mutually
+ *  exclusive; the server 409s CURRENCY_LOCKED when monetary lines exist and
+ *  neither is set. */
+export interface ChangeQuoteCurrencyBody {
+  currencyCode: string;
+  clearLines?: boolean;
+  reprice?: boolean;
+}
+
+export function changeQuoteCurrency(id: string, body: ChangeQuoteCurrencyBody): Promise<Response> {
+  return fetchWithAuth(`/quotes/${id}/currency`, {
+    method: 'POST',
+    headers: JSON_HEADERS,
+    body: JSON.stringify(body),
+  });
+}
+
 export function addBlock(id: string, body: QuoteBlockInput): Promise<Response> {
   return fetchWithAuth(`/quotes/${id}/blocks`, {
     method: 'POST',

--- a/apps/web/src/locales/de-DE/billing.json
+++ b/apps/web/src/locales/de-DE/billing.json
@@ -1155,6 +1155,29 @@
         "untitled": "eine neuere Version"
       }
     },
+    "currency": {
+      "actions": {
+        "change": "Währung ändern"
+      },
+      "dialog": {
+        "title": "Angebotswährung ändern",
+        "description": "Dieses Entwurfsangebot wird in {{currency}} berechnet.",
+        "currencyLabel": "Neue Währung",
+        "modeLegend": "Was mit den Positionen des Angebots geschieht",
+        "modeClear": "Alle Positionen entfernen",
+        "modeClearHint": "Positionen werden gelöscht. Erforderlich, wenn eine Position manuell oder ein Bündel ist.",
+        "modeReprice": "Katalogpositionen neu bepreisen",
+        "modeRepriceHint": "Jede Katalogposition wird aus der Preisliste der neuen Währung aufgelöst. Nur möglich, wenn alle Positionen aus dem Katalog stammen.",
+        "confirm": "Mir ist bewusst, dass dies die Währung des Angebots ändert.",
+        "submit": "Währung ändern"
+      },
+      "toast": {
+        "changed": "Angebotswährung zu {{currency}} geändert."
+      },
+      "errors": {
+        "change": "Die Angebotswährung konnte nicht geändert werden."
+      }
+    },
     "distributorLookup": {
       "feedPriceCurrencyUnknown": "Währung des Feed-Preises unbekannt — bitte einen Preis in {{currency}} eingeben",
       "feedPriceIn": "Feed-Preis in {{feedCurrency}} — bitte einen Preis in {{currency}} eingeben",
@@ -1575,6 +1598,29 @@
     "unsavedTitle": "„{{field}}“ enthält eine nicht gespeicherte Änderung — Ausstellen wird freigegeben, sobald sie gespeichert ist."
   },
   "invoiceDetail": {
+    "currency": {
+      "actions": {
+        "change": "Währung ändern"
+      },
+      "dialog": {
+        "title": "Rechnungswährung ändern",
+        "description": "Diese Entwurfsrechnung wird in {{currency}} berechnet.",
+        "currencyLabel": "Neue Währung",
+        "modeLegend": "Was mit den Positionen der Rechnung geschieht",
+        "modeClear": "Alle Positionen entfernen",
+        "modeClearHint": "Positionen werden gelöscht. Erforderlich, wenn eine Position manuell oder ein Bündel ist.",
+        "modeReprice": "Katalogpositionen neu bepreisen",
+        "modeRepriceHint": "Jede Katalogposition wird aus der Preisliste der neuen Währung aufgelöst. Nur möglich, wenn alle Positionen aus dem Katalog stammen.",
+        "confirm": "Mir ist bewusst, dass dies die Währung der Rechnung ändert.",
+        "submit": "Währung ändern"
+      },
+      "toast": {
+        "changed": "Rechnungswährung zu {{currency}} geändert."
+      },
+      "errors": {
+        "change": "Die Rechnungswährung konnte nicht geändert werden."
+      }
+    },
     "deposit": {
       "duePrefix": "Anzahlung von",
       "dueSuffix": "fällig – {{paid}} von {{total}} bezahlt.",

--- a/apps/web/src/locales/en/billing.json
+++ b/apps/web/src/locales/en/billing.json
@@ -1155,6 +1155,29 @@
         "untitled": "a newer version"
       }
     },
+    "currency": {
+      "actions": {
+        "change": "Change currency"
+      },
+      "dialog": {
+        "title": "Change quote currency",
+        "description": "This draft quote is priced in {{currency}}.",
+        "currencyLabel": "New currency",
+        "modeLegend": "What happens to the quote's lines",
+        "modeClear": "Remove all lines",
+        "modeClearHint": "Lines are deleted. Required when any line is manual or a bundle.",
+        "modeReprice": "Reprice catalog lines",
+        "modeRepriceHint": "Every catalog line is resolved from the price book of the new currency. Only possible when all lines come from the catalog.",
+        "confirm": "I understand this changes the quote's currency.",
+        "submit": "Change currency"
+      },
+      "toast": {
+        "changed": "Quote currency changed to {{currency}}."
+      },
+      "errors": {
+        "change": "Could not change the quote currency."
+      }
+    },
     "distributorLookup": {
       "feedPriceCurrencyUnknown": "Feed price currency unknown — enter a {{currency}} price",
       "feedPriceIn": "Feed price is {{feedCurrency}} — enter a {{currency}} price",
@@ -1575,6 +1598,29 @@
     "unsavedTitle": "“{{field}}” has an unsaved change — Issue unlocks once it saves."
   },
   "invoiceDetail": {
+    "currency": {
+      "actions": {
+        "change": "Change currency"
+      },
+      "dialog": {
+        "title": "Change invoice currency",
+        "description": "This draft invoice is priced in {{currency}}.",
+        "currencyLabel": "New currency",
+        "modeLegend": "What happens to the invoice's lines",
+        "modeClear": "Remove all lines",
+        "modeClearHint": "Lines are deleted. Required when any line is manual or a bundle.",
+        "modeReprice": "Reprice catalog lines",
+        "modeRepriceHint": "Every catalog line is resolved from the price book of the new currency. Only possible when all lines come from the catalog.",
+        "confirm": "I understand this changes the invoice's currency.",
+        "submit": "Change currency"
+      },
+      "toast": {
+        "changed": "Invoice currency changed to {{currency}}."
+      },
+      "errors": {
+        "change": "Could not change the invoice currency."
+      }
+    },
     "deposit": {
       "duePrefix": "Deposit of",
       "dueSuffix": "due — {{paid}} of {{total}} paid.",

--- a/apps/web/src/locales/es-419/billing.json
+++ b/apps/web/src/locales/es-419/billing.json
@@ -1155,6 +1155,29 @@
         "untitled": "una versión más reciente"
       }
     },
+    "currency": {
+      "actions": {
+        "change": "Cambiar moneda"
+      },
+      "dialog": {
+        "title": "Cambiar la moneda de la cotización",
+        "description": "Esta cotización en borrador está en {{currency}}.",
+        "currencyLabel": "Nueva moneda",
+        "modeLegend": "Qué ocurre con las líneas de la cotización",
+        "modeClear": "Eliminar todas las líneas",
+        "modeClearHint": "Las líneas se eliminan. Obligatorio cuando alguna línea es manual o un paquete.",
+        "modeReprice": "Recalcular precios de las líneas del catálogo",
+        "modeRepriceHint": "Cada línea del catálogo se resuelve con la lista de precios de la nueva moneda. Solo es posible si todas las líneas provienen del catálogo.",
+        "confirm": "Entiendo que esto cambia la moneda de la cotización.",
+        "submit": "Cambiar moneda"
+      },
+      "toast": {
+        "changed": "Moneda de la cotización cambiada a {{currency}}."
+      },
+      "errors": {
+        "change": "No se pudo cambiar la moneda de la cotización."
+      }
+    },
     "distributorLookup": {
       "feedPriceCurrencyUnknown": "Moneda del precio del feed desconocida — ingresa un precio en {{currency}}",
       "feedPriceIn": "El precio del feed está en {{feedCurrency}} — ingresa un precio en {{currency}}",
@@ -1575,6 +1598,29 @@
     "unsavedTitle": "«{{field}}» tiene un cambio sin guardar: emitir se desbloqueará cuando se guarde."
   },
   "invoiceDetail": {
+    "currency": {
+      "actions": {
+        "change": "Cambiar moneda"
+      },
+      "dialog": {
+        "title": "Cambiar la moneda de la factura",
+        "description": "Esta factura en borrador está en {{currency}}.",
+        "currencyLabel": "Nueva moneda",
+        "modeLegend": "Qué ocurre con las líneas de la factura",
+        "modeClear": "Eliminar todas las líneas",
+        "modeClearHint": "Las líneas se eliminan. Obligatorio cuando alguna línea es manual o un paquete.",
+        "modeReprice": "Recalcular precios de las líneas del catálogo",
+        "modeRepriceHint": "Cada línea del catálogo se resuelve con la lista de precios de la nueva moneda. Solo es posible si todas las líneas provienen del catálogo.",
+        "confirm": "Entiendo que esto cambia la moneda de la factura.",
+        "submit": "Cambiar moneda"
+      },
+      "toast": {
+        "changed": "Moneda de la factura cambiada a {{currency}}."
+      },
+      "errors": {
+        "change": "No se pudo cambiar la moneda de la factura."
+      }
+    },
     "deposit": {
       "duePrefix": "Depósito de",
       "dueSuffix": "vencido — {{paid}} de {{total}} pagado.",

--- a/apps/web/src/locales/fr-CA/billing.json
+++ b/apps/web/src/locales/fr-CA/billing.json
@@ -1155,6 +1155,29 @@
         "untitled": "une version plus récente"
       }
     },
+    "currency": {
+      "actions": {
+        "change": "Changer de devise"
+      },
+      "dialog": {
+        "title": "Changer la devise du devis",
+        "description": "Ce devis brouillon est facturé en {{currency}}.",
+        "currencyLabel": "Nouvelle devise",
+        "modeLegend": "Ce qu’il advient des lignes du devis",
+        "modeClear": "Supprimer toutes les lignes",
+        "modeClearHint": "Les lignes sont supprimées. Obligatoire dès qu’une ligne est manuelle ou un lot.",
+        "modeReprice": "Retarifer les lignes du catalogue",
+        "modeRepriceHint": "Chaque ligne du catalogue est résolue depuis la grille tarifaire de la nouvelle devise. Possible uniquement si toutes les lignes proviennent du catalogue.",
+        "confirm": "Je comprends que cette opération change la devise du devis.",
+        "submit": "Changer de devise"
+      },
+      "toast": {
+        "changed": "Devise du devis changée pour {{currency}}."
+      },
+      "errors": {
+        "change": "Impossible de changer la devise du devis."
+      }
+    },
     "distributorLookup": {
       "feedPriceCurrencyUnknown": "Devise du prix du flux inconnue — saisissez un prix en {{currency}}",
       "feedPriceIn": "Le prix du flux est en {{feedCurrency}} — saisissez un prix en {{currency}}",
@@ -1575,6 +1598,29 @@
     "unsavedTitle": "« {{field}} » contient une modification non enregistrée — l'émission sera disponible une fois enregistrée."
   },
   "invoiceDetail": {
+    "currency": {
+      "actions": {
+        "change": "Changer de devise"
+      },
+      "dialog": {
+        "title": "Changer la devise de la facture",
+        "description": "Cette facture brouillon est facturée en {{currency}}.",
+        "currencyLabel": "Nouvelle devise",
+        "modeLegend": "Ce qu’il advient des lignes de la facture",
+        "modeClear": "Supprimer toutes les lignes",
+        "modeClearHint": "Les lignes sont supprimées. Obligatoire dès qu’une ligne est manuelle ou un lot.",
+        "modeReprice": "Retarifer les lignes du catalogue",
+        "modeRepriceHint": "Chaque ligne du catalogue est résolue depuis la grille tarifaire de la nouvelle devise. Possible uniquement si toutes les lignes proviennent du catalogue.",
+        "confirm": "Je comprends que cette opération change la devise de la facture.",
+        "submit": "Changer de devise"
+      },
+      "toast": {
+        "changed": "Devise de la facture changée pour {{currency}}."
+      },
+      "errors": {
+        "change": "Impossible de changer la devise de la facture."
+      }
+    },
     "deposit": {
       "duePrefix": "Acompte de",
       "dueSuffix": "dû — {{paid}} sur {{total}} payé.",

--- a/apps/web/src/locales/fr-FR/billing.json
+++ b/apps/web/src/locales/fr-FR/billing.json
@@ -1155,6 +1155,29 @@
         "untitled": "une version plus récente"
       }
     },
+    "currency": {
+      "actions": {
+        "change": "Changer de devise"
+      },
+      "dialog": {
+        "title": "Changer la devise du devis",
+        "description": "Ce devis brouillon est facturé en {{currency}}.",
+        "currencyLabel": "Nouvelle devise",
+        "modeLegend": "Ce qu’il advient des lignes du devis",
+        "modeClear": "Supprimer toutes les lignes",
+        "modeClearHint": "Les lignes sont supprimées. Obligatoire dès qu’une ligne est manuelle ou un lot.",
+        "modeReprice": "Retarifer les lignes du catalogue",
+        "modeRepriceHint": "Chaque ligne du catalogue est résolue depuis la grille tarifaire de la nouvelle devise. Possible uniquement si toutes les lignes proviennent du catalogue.",
+        "confirm": "Je comprends que cette opération change la devise du devis.",
+        "submit": "Changer de devise"
+      },
+      "toast": {
+        "changed": "Devise du devis changée pour {{currency}}."
+      },
+      "errors": {
+        "change": "Impossible de changer la devise du devis."
+      }
+    },
     "distributorLookup": {
       "feedPriceCurrencyUnknown": "Devise du prix du flux inconnue — saisissez un prix en {{currency}}",
       "feedPriceIn": "Le prix du flux est en {{feedCurrency}} — saisissez un prix en {{currency}}",
@@ -1575,6 +1598,29 @@
     "unsavedTitle": "« {{field}} » contient une modification non enregistrée — l’émission sera disponible une fois enregistrée."
   },
   "invoiceDetail": {
+    "currency": {
+      "actions": {
+        "change": "Changer de devise"
+      },
+      "dialog": {
+        "title": "Changer la devise de la facture",
+        "description": "Cette facture brouillon est facturée en {{currency}}.",
+        "currencyLabel": "Nouvelle devise",
+        "modeLegend": "Ce qu’il advient des lignes de la facture",
+        "modeClear": "Supprimer toutes les lignes",
+        "modeClearHint": "Les lignes sont supprimées. Obligatoire dès qu’une ligne est manuelle ou un lot.",
+        "modeReprice": "Retarifer les lignes du catalogue",
+        "modeRepriceHint": "Chaque ligne du catalogue est résolue depuis la grille tarifaire de la nouvelle devise. Possible uniquement si toutes les lignes proviennent du catalogue.",
+        "confirm": "Je comprends que cette opération change la devise de la facture.",
+        "submit": "Changer de devise"
+      },
+      "toast": {
+        "changed": "Devise de la facture changée pour {{currency}}."
+      },
+      "errors": {
+        "change": "Impossible de changer la devise de la facture."
+      }
+    },
     "deposit": {
       "duePrefix": "Acompte de",
       "dueSuffix": "dû — {{paid}} sur {{total}} payé.",

--- a/apps/web/src/locales/it-IT/billing.json
+++ b/apps/web/src/locales/it-IT/billing.json
@@ -1155,6 +1155,29 @@
         "untitled": "una versione più recente"
       }
     },
+    "currency": {
+      "actions": {
+        "change": "Cambia valuta"
+      },
+      "dialog": {
+        "title": "Cambia la valuta del preventivo",
+        "description": "Questo preventivo in bozza è prezzato in {{currency}}.",
+        "currencyLabel": "Nuova valuta",
+        "modeLegend": "Cosa accade alle righe del preventivo",
+        "modeClear": "Rimuovi tutte le righe",
+        "modeClearHint": "Le righe vengono eliminate. Obbligatorio quando una riga è manuale o un bundle.",
+        "modeReprice": "Riprezza le righe di catalogo",
+        "modeRepriceHint": "Ogni riga di catalogo viene risolta dal listino della nuova valuta. Possibile solo se tutte le righe provengono dal catalogo.",
+        "confirm": "Comprendo che questa operazione cambia la valuta del preventivo.",
+        "submit": "Cambia valuta"
+      },
+      "toast": {
+        "changed": "Valuta del preventivo cambiata in {{currency}}."
+      },
+      "errors": {
+        "change": "Impossibile cambiare la valuta del preventivo."
+      }
+    },
     "distributorLookup": {
       "feedPriceCurrencyUnknown": "Valuta del prezzo del feed sconosciuta — inserisci un prezzo in {{currency}}",
       "feedPriceIn": "Il prezzo del feed è in {{feedCurrency}} — inserisci un prezzo in {{currency}}",
@@ -1575,6 +1598,29 @@
     "unsavedTitle": "\"{{field}}\" contiene una modifica non salvata — l'emissione si sblocca una volta salvata."
   },
   "invoiceDetail": {
+    "currency": {
+      "actions": {
+        "change": "Cambia valuta"
+      },
+      "dialog": {
+        "title": "Cambia la valuta della fattura",
+        "description": "Questa fattura in bozza è prezzata in {{currency}}.",
+        "currencyLabel": "Nuova valuta",
+        "modeLegend": "Cosa accade alle righe della fattura",
+        "modeClear": "Rimuovi tutte le righe",
+        "modeClearHint": "Le righe vengono eliminate. Obbligatorio quando una riga è manuale o un bundle.",
+        "modeReprice": "Riprezza le righe di catalogo",
+        "modeRepriceHint": "Ogni riga di catalogo viene risolta dal listino della nuova valuta. Possibile solo se tutte le righe provengono dal catalogo.",
+        "confirm": "Comprendo che questa operazione cambia la valuta della fattura.",
+        "submit": "Cambia valuta"
+      },
+      "toast": {
+        "changed": "Valuta della fattura cambiata in {{currency}}."
+      },
+      "errors": {
+        "change": "Impossibile cambiare la valuta della fattura."
+      }
+    },
     "deposit": {
       "duePrefix": "Acconto di",
       "dueSuffix": "dovuto — {{paid}} di {{total}} pagati.",

--- a/apps/web/src/locales/pt-BR/billing.json
+++ b/apps/web/src/locales/pt-BR/billing.json
@@ -1155,6 +1155,29 @@
         "untitled": "uma versão mais recente"
       }
     },
+    "currency": {
+      "actions": {
+        "change": "Alterar moeda"
+      },
+      "dialog": {
+        "title": "Alterar a moeda da cotação",
+        "description": "Esta cotação em rascunho está precificada em {{currency}}.",
+        "currencyLabel": "Nova moeda",
+        "modeLegend": "O que acontece com as linhas da cotação",
+        "modeClear": "Remover todas as linhas",
+        "modeClearHint": "As linhas são excluídas. Obrigatório quando alguma linha é manual ou um pacote.",
+        "modeReprice": "Reprecificar as linhas de catálogo",
+        "modeRepriceHint": "Cada linha de catálogo é resolvida pela tabela de preços da nova moeda. Só é possível quando todas as linhas vêm do catálogo.",
+        "confirm": "Entendo que isto altera a moeda da cotação.",
+        "submit": "Alterar moeda"
+      },
+      "toast": {
+        "changed": "Moeda da cotação alterada para {{currency}}."
+      },
+      "errors": {
+        "change": "Não foi possível alterar a moeda da cotação."
+      }
+    },
     "distributorLookup": {
       "feedPriceCurrencyUnknown": "Moeda do preço do feed desconhecida — informe um preço em {{currency}}",
       "feedPriceIn": "O preço do feed está em {{feedCurrency}} — informe um preço em {{currency}}",
@@ -1575,6 +1598,29 @@
     "unsavedTitle": "“{{field}}” tem uma alteração não salva — a emissão será liberada quando ela for salva."
   },
   "invoiceDetail": {
+    "currency": {
+      "actions": {
+        "change": "Alterar moeda"
+      },
+      "dialog": {
+        "title": "Alterar a moeda da fatura",
+        "description": "Esta fatura em rascunho está precificada em {{currency}}.",
+        "currencyLabel": "Nova moeda",
+        "modeLegend": "O que acontece com as linhas da fatura",
+        "modeClear": "Remover todas as linhas",
+        "modeClearHint": "As linhas são excluídas. Obrigatório quando alguma linha é manual ou um pacote.",
+        "modeReprice": "Reprecificar as linhas de catálogo",
+        "modeRepriceHint": "Cada linha de catálogo é resolvida pela tabela de preços da nova moeda. Só é possível quando todas as linhas vêm do catálogo.",
+        "confirm": "Entendo que isto altera a moeda da fatura.",
+        "submit": "Alterar moeda"
+      },
+      "toast": {
+        "changed": "Moeda da fatura alterada para {{currency}}."
+      },
+      "errors": {
+        "change": "Não foi possível alterar a moeda da fatura."
+      }
+    },
     "deposit": {
       "duePrefix": "Entrada de",
       "dueSuffix": "devida — {{paid}} de {{total}} pagos.",

--- a/apps/web/src/locales/tr-TR/billing.json
+++ b/apps/web/src/locales/tr-TR/billing.json
@@ -1155,6 +1155,29 @@
         "untitled": "daha yeni bir sürüm"
       }
     },
+    "currency": {
+      "actions": {
+        "change": "Para birimini değiştir"
+      },
+      "dialog": {
+        "title": "Teklif para birimini değiştir",
+        "description": "Bu taslak teklif {{currency}} ile fiyatlandırılmış.",
+        "currencyLabel": "Yeni para birimi",
+        "modeLegend": "Teklifin satırlarına ne olacak",
+        "modeClear": "Tüm satırları kaldır",
+        "modeClearHint": "Satırlar silinir. Herhangi bir satır manuel veya paket olduğunda zorunludur.",
+        "modeReprice": "Katalog satırlarını yeniden fiyatlandır",
+        "modeRepriceHint": "Her katalog satırı yeni para biriminin fiyat listesinden çözümlenir. Yalnızca tüm satırlar katalogdan geliyorsa mümkündür.",
+        "confirm": "Bunun teklifin para birimini değiştirdiğini anlıyorum.",
+        "submit": "Para birimini değiştir"
+      },
+      "toast": {
+        "changed": "Teklif para birimi {{currency}} olarak değiştirildi."
+      },
+      "errors": {
+        "change": "Teklif para birimi değiştirilemedi."
+      }
+    },
     "distributorLookup": {
       "feedPriceCurrencyUnknown": "Akış fiyatının para birimi bilinmiyor — {{currency}} cinsinden bir fiyat girin",
       "feedPriceIn": "Akış fiyatı {{feedCurrency}} cinsinden — {{currency}} cinsinden bir fiyat girin",
@@ -1575,6 +1598,29 @@
     "unsavedTitle": "“{{field}}” kaydedilmemiş bir değişiklik içeriyor — Sorun kaydedildiğinde kilidi açılıyor."
   },
   "invoiceDetail": {
+    "currency": {
+      "actions": {
+        "change": "Para birimini değiştir"
+      },
+      "dialog": {
+        "title": "Fatura para birimini değiştir",
+        "description": "Bu taslak fatura {{currency}} ile fiyatlandırılmış.",
+        "currencyLabel": "Yeni para birimi",
+        "modeLegend": "Faturanın satırlarına ne olacak",
+        "modeClear": "Tüm satırları kaldır",
+        "modeClearHint": "Satırlar silinir. Herhangi bir satır manuel veya paket olduğunda zorunludur.",
+        "modeReprice": "Katalog satırlarını yeniden fiyatlandır",
+        "modeRepriceHint": "Her katalog satırı yeni para biriminin fiyat listesinden çözümlenir. Yalnızca tüm satırlar katalogdan geliyorsa mümkündür.",
+        "confirm": "Bunun faturanın para birimini değiştirdiğini anlıyorum.",
+        "submit": "Para birimini değiştir"
+      },
+      "toast": {
+        "changed": "Fatura para birimi {{currency}} olarak değiştirildi."
+      },
+      "errors": {
+        "change": "Fatura para birimi değiştirilemedi."
+      }
+    },
     "deposit": {
       "duePrefix": "Depozito",
       "dueSuffix": "ödenmesi gereken — {{total}} tutarından {{paid}} ödendi.",


### PR DESCRIPTION
## Summary

The server's draft-only atomic change-currency op (`POST /:id/currency`, #3774) has worked for quotes (`apps/api/src/routes/quotes/quotes.ts:195`) and invoices (`apps/api/src/routes/invoices/invoices.ts:99`) since multi-currency wave 2 — but only `ContractDetail.tsx` ever grew a dialog to call it (#3778). A draft quote or invoice created under the wrong org currency could only be deleted and rebuilt from scratch.

This ports the ContractDetail change-currency dialog pattern into a new shared `ChangeCurrencyDialog` component (`apps/web/src/components/billing/ChangeCurrencyDialog.tsx`), reused by both `QuoteDetail.tsx` and `InvoiceDetail.tsx` (contracts keep their own richer version — active-only, with id-keyed 409 blockers — which doesn't fit the draft-only, blocker-less quote/invoice case).

- **Draft-only, mirrors the server's lock**: the action only renders when `status === 'draft'` (matching `lockDraftQuote`/`lockDraftInvoice`) and the actor has `quotes:write` / `invoices:write`.
- **runAction + refetch**: the mutation goes through `runAction` (`changeQuoteCurrency` added to `lib/api/quotes.ts`; invoice uses the file's existing inline `fetchWithAuth` convention) and calls `onChanged`/`refresh` on success.
- **Inline 409 handling**: `CURRENCY_LOCKED` (monetary lines exist, `clearLines`/`reprice` not chosen) is shown inline in the still-open dialog, in addition to the toast `runAction` already raises — so the operator sees *why*, not just a generic failure toast.
- **i18n**: added `quotes.currency.*` and `invoiceDetail.currency.*` to `apps/web/src/locales/en/billing.json`, mirroring the existing `contracts.currency.*` shape.

## Test plan

- [x] New component tests: dialog present on draft / absent on non-draft / hidden without write permission, submit disabled until mode+confirm+currency-changed, success payload + refetch (clear vs reprice), 409 inline error + dialog stays open + no refetch, error clears on retry — `QuoteDetail.currency.test.tsx` (8 tests) and `InvoiceDetail.currency.test.tsx` (8 tests), both written red-first against the pre-fix tree.
- [x] `cd apps/web && npx vitest run QuoteDetail InvoiceDetail no-silent-mutations` — 16 files / 279 tests passed, including `no-silent-mutations` confirming every mutating `fetchWithAuth` call in `InvoiceDetail.tsx` is `runAction`-wrapped.
- [x] `npx vitest run src/lib/i18n/keyUsage.test.ts` — 4/4 passed (validates the new locale keys are actually reachable from the `t()` call sites).
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint` on all changed/added files — clean.

Closes #4416

🤖 Generated with [Claude Code](https://claude.com/claude-code)