### PR TITLE
refactor(api/tenancy): remove the partner-wide system-context escalations (#4676)

### DIFF
--- a/apps/api/src/__tests__/integration/agentPolicyResolversPartnerWide.integration.test.ts
+++ b/apps/api/src/__tests__/integration/agentPolicyResolversPartnerWide.integration.test.ts
@@ -16,27 +16,46 @@
  *      `accessiblePartnerIds: []` — so the read silently returns ZERO ROWS,
  *      not an error.
  *
- * The fix (services/configPolicyOwnership.ts) is a matched pair:
- * `policyOwnershipCondition` (dual-axis join predicate) plus
- * `withPartnerWideVisibility` (a scoped system-context escape around ONLY the
- * policy join). This test proves both halves for all four resolvers by
- * invoking them exactly as the agent heartbeat path does: inside a real
- * org-scoped `withDbAccessContext`, against the real breeze_app RLS-forced
- * connection.
+ * The original fix (#2930) was a matched pair: `policyOwnershipCondition` (the
+ * dual-axis join predicate) plus `withPartnerWideVisibility`, a scoped
+ * system-context escape around ONLY the policy join.
+ *
+ * **#4673 W03 replaced the second half.** The escape is deleted. Its job is now
+ * done by the database: `<table>_partner_wide_select` (W01) adds a SELECT-ONLY
+ * policy `org_id IS NULL AND partner_id = public.breeze_current_partner_id()`
+ * across the configuration-policy chain, and W02 populates
+ * `breeze.current_partner_id` on agent contexts from the device org's partner.
+ * So the agent reads its own MSP's partner-wide config on its OWN connection —
+ * no second pooled connection (the #1105 starvation shape) and no RLS bypass
+ * (the #2417 cross-tenant shape).
+ *
+ * This test proves both halves for all four resolvers by invoking them exactly
+ * as the agent heartbeat path does: inside a real org-scoped
+ * `withDbAccessContext`, against the real breeze_app RLS-forced connection.
+ *
+ * The `partnerWideBlindContext` cases are what make it a real proof rather than
+ * a tautology. They run the same resolvers under a context with
+ * `currentPartnerId: null` and require the partner-wide policy to be INVISIBLE.
+ * That fails if the system-context escape is ever reintroduced — under an
+ * escape the GUC is irrelevant and the row resolves regardless. Together the
+ * two halves pin: visible with the GUC, invisible without it, therefore the
+ * RLS branch (not an escape) is what is doing the work.
  *
  * If this test file were deleted: a regression that reintroduces a bare
- * `eq(configurationPolicies.orgId, device.orgId)` join, or that drops the
- * `withPartnerWideVisibility` escape, would compile fine, pass every unit
- * test (which mock the DB and never exercise RLS), and pass
+ * `eq(configurationPolicies.orgId, device.orgId)` join, that drops
+ * `currentPartnerId` from the agent context, or that reintroduces the escape,
+ * would compile fine, pass every unit test (which mock the DB and never
+ * exercise RLS), and pass
  * configurationPolicyPartnerResolution.integration.test.ts (which resolves
- * under a SYSTEM-scope AuthContext, so the RLS escape is never exercised).
- * Partner-wide policies would silently stop reaching agents for event_log,
- * monitoring, PAM, and patch-source config — exactly the bug #2930 fixed.
+ * under a SYSTEM-scope AuthContext, where every RLS branch short-circuits
+ * true). Partner-wide policies would silently stop reaching agents for
+ * event_log, monitoring, PAM, and patch-source config — exactly the bug #2930
+ * fixed — or would keep reaching them through a connection-doubling bypass.
  */
 import './setup';
 import { afterEach, describe, expect, it } from 'vitest';
 import { randomUUID } from 'crypto';
-import { eq } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import { db, withDbAccessContext, type DbAccessContext } from '../../db';
 import {
   configurationPolicies,
@@ -67,18 +86,41 @@ const SYSTEM_CTX: DbAccessContext = {
   userId: null,
 };
 
-// The realistic agent-facing shape: an org-scoped request context.
-// accessiblePartnerIds: [] is the crux of the bug — an org token never
-// carries partner-axis access, so breeze_has_partner_access is false and a
-// partner-owned policy is invisible unless the resolver escapes to a system
-// context for the policy join (withPartnerWideVisibility).
-function orgContext(orgId: string): DbAccessContext {
+// The realistic agent-facing shape, as `agentAuthMiddleware` builds it since
+// #4673 W02: an org-scoped request context that carries the DEVICE ORG'S OWN
+// partner in `currentPartnerId` while `accessiblePartnerIds` stays [].
+//
+// The two fields are different axes and must not be conflated.
+// `accessiblePartnerIds` gates `breeze_has_partner_access`, which admits
+// partner-axis WRITES — an agent never gets it. `currentPartnerId` feeds the
+// `breeze.current_partner_id` GUC, which only the SELECT-only
+// `<table>_partner_wide_select` policies read. That branch is now the ONLY
+// thing making a partner-owned policy legible here: W03 deleted the nested
+// system-context escape (`withPartnerWideVisibility`) these resolvers used to
+// take. `partnerWideBlindContext` below pins that by omitting the GUC.
+function orgContext(orgId: string, partnerId: string): DbAccessContext {
   return {
     scope: 'organization',
     orgId,
     accessibleOrgIds: [orgId],
     accessiblePartnerIds: [],
     userId: null,
+    currentPartnerId: partnerId,
+  };
+}
+
+// The SAME context minus `currentPartnerId` — i.e. what an agent context looked
+// like BEFORE W02. Used by the "the RLS branch is load-bearing" cases below: if
+// a system-context escape were ever reintroduced (or survived), a partner-owned
+// policy would resolve under this context too, and those assertions fail.
+function partnerWideBlindContext(orgId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    userId: null,
+    currentPartnerId: null,
   };
 }
 
@@ -245,7 +287,7 @@ async function purgeCaches(deviceId: string) {
 }
 
 describe('agent-facing config-policy resolvers honour partner-wide policies (#2930)', () => {
-  describe('partner-owned policy resolves under an ORG-SCOPED context (the RLS escape)', () => {
+  describe('partner-owned policy resolves under an ORG-SCOPED context (the *_partner_wide_select RLS branch)', () => {
     it('buildEventLogConfigUpdate resolves a partner-owned policy', async () => {
       const partner = await createPartner();
       const org = await createOrganization({ partnerId: partner.id });
@@ -256,7 +298,7 @@ describe('agent-facing config-policy resolvers honour partner-wide policies (#29
       const policyId = await seedEventLogPolicy({ orgId: null, partnerId: partner.id }, 555);
       await assign(policyId, 'partner', partner.id);
 
-      const result = await withDbAccessContext(orgContext(org!.id), () => buildEventLogConfigUpdate(device.id));
+      const result = await withDbAccessContext(orgContext(org!.id, partner.id), () => buildEventLogConfigUpdate(device.id));
 
       // 555 is not the default (100) — proves the partner-owned policy
       // resolved rather than a silent fallback to EVENT_LOG_DEFAULTS.
@@ -274,7 +316,7 @@ describe('agent-facing config-policy resolvers honour partner-wide policies (#29
       const policyId = await seedMonitoringPolicy({ orgId: null, partnerId: partner.id }, 999);
       await assign(policyId, 'partner', partner.id);
 
-      const result = await withDbAccessContext(orgContext(org!.id), () => buildMonitoringConfigUpdate(device.id));
+      const result = await withDbAccessContext(orgContext(org!.id, partner.id), () => buildMonitoringConfigUpdate(device.id));
 
       expect(result).not.toBeNull();
       expect(result!.check_interval_seconds).toBe(999);
@@ -292,7 +334,7 @@ describe('agent-facing config-policy resolvers honour partner-wide policies (#29
       const policyId = await seedPamPolicy({ orgId: null, partnerId: partner.id }, true);
       await assign(policyId, 'partner', partner.id);
 
-      const result = await withDbAccessContext(orgContext(org!.id), () => buildPamConfigUpdate(device.id));
+      const result = await withDbAccessContext(orgContext(org!.id, partner.id), () => buildPamConfigUpdate(device.id));
 
       expect(result.uacInterceptionEnabled).toBe(true);
     });
@@ -307,7 +349,7 @@ describe('agent-facing config-policy resolvers honour partner-wide policies (#29
       const policyId = await seedPatchPolicy({ orgId: null, partnerId: partner.id }, true);
       await assign(policyId, 'partner', partner.id);
 
-      const result = await withDbAccessContext(orgContext(org!.id), () => buildPatchSourceConfigUpdate(device.id));
+      const result = await withDbAccessContext(orgContext(org!.id, partner.id), () => buildPatchSourceConfigUpdate(device.id));
 
       expect(result.exclusiveWindowsUpdate).toBe(true);
     });
@@ -334,14 +376,14 @@ describe('agent-facing config-policy resolvers honour partner-wide policies (#29
       const patchPolicyId = await seedPatchPolicy({ orgId: null, partnerId: partner.id }, true);
       await assign(patchPolicyId, 'partner', partner.id);
 
-      const eventLogA = await withDbAccessContext(orgContext(orgA!.id), () => buildEventLogConfigUpdate(deviceA.id));
-      const eventLogB = await withDbAccessContext(orgContext(orgB!.id), () => buildEventLogConfigUpdate(deviceB.id));
-      const monitoringA = await withDbAccessContext(orgContext(orgA!.id), () => buildMonitoringConfigUpdate(deviceA.id));
-      const monitoringB = await withDbAccessContext(orgContext(orgB!.id), () => buildMonitoringConfigUpdate(deviceB.id));
-      const pamA = await withDbAccessContext(orgContext(orgA!.id), () => buildPamConfigUpdate(deviceA.id));
-      const pamB = await withDbAccessContext(orgContext(orgB!.id), () => buildPamConfigUpdate(deviceB.id));
-      const patchA = await withDbAccessContext(orgContext(orgA!.id), () => buildPatchSourceConfigUpdate(deviceA.id));
-      const patchB = await withDbAccessContext(orgContext(orgB!.id), () => buildPatchSourceConfigUpdate(deviceB.id));
+      const eventLogA = await withDbAccessContext(orgContext(orgA!.id, partner.id), () => buildEventLogConfigUpdate(deviceA.id));
+      const eventLogB = await withDbAccessContext(orgContext(orgB!.id, partner.id), () => buildEventLogConfigUpdate(deviceB.id));
+      const monitoringA = await withDbAccessContext(orgContext(orgA!.id, partner.id), () => buildMonitoringConfigUpdate(deviceA.id));
+      const monitoringB = await withDbAccessContext(orgContext(orgB!.id, partner.id), () => buildMonitoringConfigUpdate(deviceB.id));
+      const pamA = await withDbAccessContext(orgContext(orgA!.id, partner.id), () => buildPamConfigUpdate(deviceA.id));
+      const pamB = await withDbAccessContext(orgContext(orgB!.id, partner.id), () => buildPamConfigUpdate(deviceB.id));
+      const patchA = await withDbAccessContext(orgContext(orgA!.id, partner.id), () => buildPatchSourceConfigUpdate(deviceA.id));
+      const patchB = await withDbAccessContext(orgContext(orgB!.id, partner.id), () => buildPatchSourceConfigUpdate(deviceB.id));
 
       expect(eventLogA.max_events_per_cycle).toBe(555);
       expect(eventLogB.max_events_per_cycle).toBe(555);
@@ -367,7 +409,7 @@ describe('agent-facing config-policy resolvers honour partner-wide policies (#29
       const orgPolicyId = await seedEventLogPolicy({ orgId: org!.id, partnerId: null }, 222);
       await assign(orgPolicyId, 'organization', org!.id);
 
-      const result = await withDbAccessContext(orgContext(org!.id), () => buildEventLogConfigUpdate(device.id));
+      const result = await withDbAccessContext(orgContext(org!.id, partner.id), () => buildEventLogConfigUpdate(device.id));
 
       expect(result.max_events_per_cycle).toBe(222);
     });
@@ -385,7 +427,7 @@ describe('agent-facing config-policy resolvers honour partner-wide policies (#29
       const orgPolicyId = await seedPamPolicy({ orgId: org!.id, partnerId: null }, false);
       await assign(orgPolicyId, 'organization', org!.id);
 
-      const result = await withDbAccessContext(orgContext(org!.id), () => buildPamConfigUpdate(device.id));
+      const result = await withDbAccessContext(orgContext(org!.id, partner.id), () => buildPamConfigUpdate(device.id));
 
       expect(result.uacInterceptionEnabled).toBe(false);
     });
@@ -414,10 +456,10 @@ describe('agent-facing config-policy resolvers honour partner-wide policies (#29
       const patchPolicyId = await seedPatchPolicy({ orgId: null, partnerId: partnerP1.id }, true);
       await assign(patchPolicyId, 'partner', partnerP1.id);
 
-      const eventLogQ = await withDbAccessContext(orgContext(orgQ!.id), () => buildEventLogConfigUpdate(deviceQ.id));
-      const monitoringQ = await withDbAccessContext(orgContext(orgQ!.id), () => buildMonitoringConfigUpdate(deviceQ.id));
-      const pamQ = await withDbAccessContext(orgContext(orgQ!.id), () => buildPamConfigUpdate(deviceQ.id));
-      const patchQ = await withDbAccessContext(orgContext(orgQ!.id), () => buildPatchSourceConfigUpdate(deviceQ.id));
+      const eventLogQ = await withDbAccessContext(orgContext(orgQ!.id, partnerQ.id), () => buildEventLogConfigUpdate(deviceQ.id));
+      const monitoringQ = await withDbAccessContext(orgContext(orgQ!.id, partnerQ.id), () => buildMonitoringConfigUpdate(deviceQ.id));
+      const pamQ = await withDbAccessContext(orgContext(orgQ!.id, partnerQ.id), () => buildPamConfigUpdate(deviceQ.id));
+      const patchQ = await withDbAccessContext(orgContext(orgQ!.id, partnerQ.id), () => buildPatchSourceConfigUpdate(deviceQ.id));
 
       // No policy of Q's own partner matched -> defaults across the board,
       // NOT partner P1's values (555 / 999 / true / true).
@@ -470,10 +512,154 @@ describe('agent-facing config-policy resolvers honour partner-wide policies (#29
       });
       await assign(policyId, 'partner', partner.id);
 
-      const result = await withDbAccessContext(orgContext(org!.id), () => buildEventLogConfigUpdate(device.id));
+      const result = await withDbAccessContext(orgContext(org!.id, partner.id), () => buildEventLogConfigUpdate(device.id));
 
       expect(result.max_events_per_cycle).toBe(EVENT_LOG_DEFAULTS.maxEventsPerCycle);
       expect(result.max_events_per_cycle).not.toBe(DISTINCTIVE_MAX_EVENTS);
+    });
+  });
+
+  describe('the *_partner_wide_select branch is what makes it work — not a system escape (#4673 W03)', () => {
+    // RED-FIRST GATE. Before W03 these four resolvers wrapped their policy join
+    // in `withPartnerWideVisibility`, a nested
+    // `runOutsideDbContext(() => withSystemDbAccessContext(...))`. Under that
+    // escape `breeze.current_partner_id` is irrelevant — the query runs as
+    // scope 'system' on a second connection and sees EVERY tenant's rows — so
+    // every "INVISIBLE" assertion below would have failed (the partner-wide
+    // policy would resolve anyway). They pass only because the read now happens
+    // on the caller's own RLS-forced connection, where the SELECT-only branch
+    // is the sole grant and a NULL GUC makes `partner_id = NULL` never true.
+    //
+    // This is also the regression gate for W02: drop `currentPartnerId` from
+    // agentAuth's context and the positive cases above go red, instead of
+    // silently degrading real agents to defaults with no error.
+    it('event_log: a partner-wide policy is INVISIBLE without breeze.current_partner_id', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const site = await createSite({ orgId: org!.id });
+      const device = await seedDevice(org!.id, site!.id);
+      await purgeCaches(device.id);
+
+      const policyId = await seedEventLogPolicy({ orgId: null, partnerId: partner.id }, 555);
+      await assign(policyId, 'partner', partner.id);
+
+      const blind = await withDbAccessContext(partnerWideBlindContext(org!.id), () =>
+        buildEventLogConfigUpdate(device.id),
+      );
+      expect(blind.max_events_per_cycle).toBe(EVENT_LOG_DEFAULTS.maxEventsPerCycle);
+      expect(blind.max_events_per_cycle).not.toBe(555);
+
+      // Same device, same policy, same process — only the GUC differs.
+      await purgeCaches(device.id);
+      const sighted = await withDbAccessContext(orgContext(org!.id, partner.id), () =>
+        buildEventLogConfigUpdate(device.id),
+      );
+      expect(sighted.max_events_per_cycle).toBe(555);
+    });
+
+    it('monitoring: a partner-wide policy is INVISIBLE without breeze.current_partner_id', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const site = await createSite({ orgId: org!.id });
+      const device = await seedDevice(org!.id, site!.id);
+      await purgeCaches(device.id);
+
+      const policyId = await seedMonitoringPolicy({ orgId: null, partnerId: partner.id }, 999);
+      await assign(policyId, 'partner', partner.id);
+
+      const blind = await withDbAccessContext(partnerWideBlindContext(org!.id), () =>
+        buildMonitoringConfigUpdate(device.id),
+      );
+      expect(blind).toBeNull();
+
+      await purgeCaches(device.id);
+      const sighted = await withDbAccessContext(orgContext(org!.id, partner.id), () =>
+        buildMonitoringConfigUpdate(device.id),
+      );
+      // The watches read is a SEPARATE query, chained through settings_id ->
+      // feature link -> configuration_policies. It used to share one escape
+      // with the policy join; now it needs its own
+      // `config_policy_monitoring_watches_partner_wide_select` branch. A
+      // non-empty watches array is the proof that branch exists and matches —
+      // without it this resolves the settings row and then returns null.
+      expect(sighted).not.toBeNull();
+      expect(sighted!.check_interval_seconds).toBe(999);
+      expect(sighted!.watches).toHaveLength(1);
+    });
+
+    it('pam: a partner-wide policy is INVISIBLE without breeze.current_partner_id', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const site = await createSite({ orgId: org!.id });
+      const device = await seedDevice(org!.id, site!.id);
+      await purgeCaches(device.id);
+
+      const policyId = await seedPamPolicy({ orgId: null, partnerId: partner.id }, true);
+      await assign(policyId, 'partner', partner.id);
+
+      const blind = await withDbAccessContext(partnerWideBlindContext(org!.id), () =>
+        buildPamConfigUpdate(device.id),
+      );
+      expect(blind.uacInterceptionEnabled).toBe(PAM_DEFAULTS.uacInterceptionEnabled);
+
+      await purgeCaches(device.id);
+      const sighted = await withDbAccessContext(orgContext(org!.id, partner.id), () =>
+        buildPamConfigUpdate(device.id),
+      );
+      expect(sighted.uacInterceptionEnabled).toBe(true);
+    });
+
+    it('patch source: a partner-wide policy is INVISIBLE without breeze.current_partner_id', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const site = await createSite({ orgId: org!.id });
+      const device = await seedDevice(org!.id, site!.id);
+
+      const policyId = await seedPatchPolicy({ orgId: null, partnerId: partner.id }, true);
+      await assign(policyId, 'partner', partner.id);
+
+      const blind = await withDbAccessContext(partnerWideBlindContext(org!.id), () =>
+        buildPatchSourceConfigUpdate(device.id),
+      );
+      expect(blind.exclusiveWindowsUpdate).toBe(false);
+
+      const sighted = await withDbAccessContext(orgContext(org!.id, partner.id), () =>
+        buildPatchSourceConfigUpdate(device.id),
+      );
+      expect(sighted.exclusiveWindowsUpdate).toBe(true);
+    });
+
+    it('writes stay locked: the org context still cannot UPDATE or DELETE the partner-wide policy', async () => {
+      // The branch is FOR SELECT only. Postgres never consults FOR SELECT
+      // policies when computing UPDATE/DELETE target rows, so the row stays
+      // untargetable — it is HIDDEN from the write, which is a silent 0 rows,
+      // not a 42501. Asserting the row count is the only way to see that; an
+      // `expect(...).rejects` here would be vacuous.
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+
+      const policyId = await seedEventLogPolicy({ orgId: null, partnerId: partner.id }, 555);
+
+      await withDbAccessContext(orgContext(org!.id, partner.id), async () => {
+        const updated = await db.execute(
+          sql`update configuration_policies set name = 'hijacked' where id = ${policyId}`,
+        );
+        expect((updated as unknown as { count: number }).count).toBe(0);
+
+        const deleted = await db.execute(
+          sql`delete from configuration_policies where id = ${policyId}`,
+        );
+        expect((deleted as unknown as { count: number }).count).toBe(0);
+      });
+
+      // ...and the row is still there, unchanged.
+      const [row] = await withDbAccessContext(SYSTEM_CTX, () =>
+        db
+          .select({ name: configurationPolicies.name })
+          .from(configurationPolicies)
+          .where(eq(configurationPolicies.id, policyId)),
+      );
+      expect(row?.name).not.toBe('hijacked');
     });
   });
 });

--- a/apps/api/src/__tests__/integration/agentPolicyResolversPartnerWide.integration.test.ts
+++ b/apps/api/src/__tests__/integration/agentPolicyResolversPartnerWide.integration.test.ts
@@ -57,6 +57,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { randomUUID } from 'crypto';
 import { eq, sql } from 'drizzle-orm';
 import { db, withDbAccessContext, type DbAccessContext } from '../../db';
+import { extractRowCount } from '../../db/rowCount';
 import {
   configurationPolicies,
   configPolicyFeatureLinks,
@@ -69,6 +70,7 @@ import {
 } from '../../db/schema';
 import {
   buildEventLogConfigUpdate,
+  buildHelperConfigUpdate,
   buildMonitoringConfigUpdate,
   buildPamConfigUpdate,
   buildPatchSourceConfigUpdate,
@@ -248,6 +250,25 @@ async function seedPamPolicy(
   });
 }
 
+async function seedHelperPolicy(
+  owner: { orgId: string | null; partnerId: string | null },
+  inlineSettings: Record<string, unknown>,
+) {
+  return withDbAccessContext(SYSTEM_CTX, async () => {
+    const [policy] = await db
+      .insert(configurationPolicies)
+      .values({ orgId: owner.orgId, partnerId: owner.partnerId, name: `helper policy ${randomUUID()}`, status: 'active' })
+      .returning();
+    createdPolicies.push(policy!.id);
+    await db.insert(configPolicyFeatureLinks).values({
+      configPolicyId: policy!.id,
+      featureType: 'helper',
+      inlineSettings,
+    });
+    return policy!.id;
+  });
+}
+
 async function seedPatchPolicy(
   owner: { orgId: string | null; partnerId: string | null },
   exclusiveWindowsUpdate: boolean,
@@ -283,6 +304,7 @@ async function purgeCaches(deviceId: string) {
     `eventlog:settings:device:${deviceId}`,
     `monitoring:settings:device:${deviceId}`,
     `pam:settings:device:${deviceId}`,
+    `helper:settings:device:${deviceId}`,
   );
 }
 
@@ -629,6 +651,41 @@ describe('agent-facing config-policy resolvers honour partner-wide policies (#29
       expect(sighted.exclusiveWindowsUpdate).toBe(true);
     });
 
+    it('helper settings: a partner-wide policy resolves, and is INVISIBLE without breeze.current_partner_id', async () => {
+      // buildHelperConfigUpdate is the FIFTH agent-facing resolver whose escape
+      // W03 removed, and the only one this suite did not already cover. Its
+      // settings live in `config_policy_feature_links.inlineSettings` (JSONB) —
+      // there is no `config_policy_helper_settings` table — so the grant comes
+      // from `config_policy_feature_links_partner_wide_select`.
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const site = await createSite({ orgId: org!.id });
+      const device = await seedDevice(org!.id, site!.id);
+      await purgeCaches(device.id);
+
+      // Both fields differ from what the no-policy path produces: that path
+      // returns HELPER_DEFAULTS with `enabled` from organizations.settings.helper
+      // (unset here, so false) and `showTrayIcon: true`.
+      const policyId = await seedHelperPolicy(
+        { orgId: null, partnerId: partner.id },
+        { enabled: true, showTrayIcon: false },
+      );
+      await assign(policyId, 'partner', partner.id);
+
+      const blind = await withDbAccessContext(partnerWideBlindContext(org!.id), () =>
+        buildHelperConfigUpdate(device.id, org!.id),
+      );
+      expect(blind.enabled).toBe(false);
+      expect(blind.showTrayIcon).toBe(true);
+
+      await purgeCaches(device.id);
+      const sighted = await withDbAccessContext(orgContext(org!.id, partner.id), () =>
+        buildHelperConfigUpdate(device.id, org!.id),
+      );
+      expect(sighted.enabled).toBe(true);
+      expect(sighted.showTrayIcon).toBe(false);
+    });
+
     it('writes stay locked: the org context still cannot UPDATE or DELETE the partner-wide policy', async () => {
       // The branch is FOR SELECT only. Postgres never consults FOR SELECT
       // policies when computing UPDATE/DELETE target rows, so the row stays
@@ -644,12 +701,12 @@ describe('agent-facing config-policy resolvers honour partner-wide policies (#29
         const updated = await db.execute(
           sql`update configuration_policies set name = 'hijacked' where id = ${policyId}`,
         );
-        expect((updated as unknown as { count: number }).count).toBe(0);
+        expect(extractRowCount(updated)).toBe(0);
 
         const deleted = await db.execute(
           sql`delete from configuration_policies where id = ${policyId}`,
         );
-        expect((deleted as unknown as { count: number }).count).toBe(0);
+        expect(extractRowCount(deleted)).toBe(0);
       });
 
       // ...and the row is still there, unchanged.

--- a/apps/api/src/__tests__/integration/backupProfilesPartnerRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/backupProfilesPartnerRls.integration.test.ts
@@ -38,7 +38,11 @@ import {
   sites,
 } from '../../db/schema';
 import { resolveAllBackupAssignedDevices } from '../../services/featureConfigResolver';
-import { updateFeatureLink } from '../../services/configurationPolicy';
+import {
+  isBackupProfileReference,
+  updateFeatureLink,
+  validateFeaturePolicyExists,
+} from '../../services/configurationPolicy';
 import { createOrganization, createPartner } from './db-utils';
 import { getTestDb } from './setup';
 
@@ -1260,9 +1264,18 @@ describe('config_policy_backup_settings RLS — dual-axis mirror of the parent p
       return { deviceId: device!.id, configId: config!.id };
     });
 
-    // The org token carries NO partner access — exactly what a tech's session
-    // looks like. Before the system-context fix this resolved to [].
-    const entries = await withDbAccessContext(orgContext(org.id), () =>
+    // The org token carries NO partner-AXIS access (`accessiblePartnerIds: []`)
+    // but DOES carry its own partner in `currentPartnerId` — exactly what a
+    // tech's session looks like: `buildDbAccessContext` sets it from the JWT's
+    // partnerId for every scope, org tokens included (middleware/auth.ts).
+    //
+    // Before #2930 this resolved to []. #2930 fixed it with a nested
+    // system-context escape; #4673 W03 removed that escape, so what makes it
+    // resolve now is the SELECT-only `*_partner_wide_select` RLS branch keyed
+    // on `breeze_current_partner_id()`. The blind case immediately below pins
+    // that this is the mechanism — under the old escape it would resolve with
+    // or without the GUC.
+    const entries = await withDbAccessContext(orgContext(org.id, partner.id), () =>
       resolveAllBackupAssignedDevices(org.id),
     );
 
@@ -1275,6 +1288,62 @@ describe('config_policy_backup_settings RLS — dual-axis mirror of the parent p
       'mssql',
     ]);
     expect(entry!.selectionError).toBeNull();
+  });
+
+  // The negative half of the fan-out proof (#4673 W03). Same seed, same
+  // resolver, same org — only `currentPartnerId` differs. If the resolver ever
+  // reopens a nested system context, the partner-wide policy resolves here too
+  // and this goes red: an escape ignores the GUC by construction.
+  it('FAN-OUT PROOF (blind): the same partner-wide policy is INVISIBLE without breeze.current_partner_id', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const profileId = await seedPartnerProfile(partner.id);
+    const { policy } = await seedPartnerPolicyWithLink(partner.id, profileId);
+
+    const { deviceId } = await withDbAccessContext(SYSTEM_CTX, async () => {
+      const [config] = await db
+        .insert(backupConfigs)
+        .values({
+          orgId: org.id,
+          name: 'Org default S3 (blind)',
+          type: 'file',
+          provider: 's3',
+          providerConfig: { bucket: 'b', region: 'us-east-1' },
+          isDefault: true,
+        })
+        .returning();
+      createdConfigs.push(config!.id);
+
+      await db.insert(configPolicyAssignments).values({
+        configPolicyId: policy.id,
+        level: 'partner',
+        targetId: partner.id,
+        priority: 100,
+      });
+      const [site] = await db.insert(sites).values({ orgId: org.id, name: 'HQ' }).returning();
+      createdSites.push(site!.id);
+      const [device] = await db
+        .insert(devices)
+        .values({
+          orgId: org.id,
+          siteId: site!.id,
+          agentId: `agent-${site!.id.slice(0, 18)}`,
+          hostname: 'srv-03',
+          osType: 'windows',
+          osVersion: '10.0',
+          architecture: 'x64',
+          agentVersion: '1.0.0',
+        })
+        .returning();
+      createdDevices.push(device!.id);
+      return { deviceId: device!.id };
+    });
+
+    const entries = await withDbAccessContext(orgContext(org.id, null), () =>
+      resolveAllBackupAssignedDevices(org.id),
+    );
+
+    expect(entries.find((e) => e.deviceId === deviceId)).toBeUndefined();
   });
 
   // A partner-wide policy is visible to EVERY org under the partner, so its
@@ -1761,5 +1830,121 @@ describe('backup feature-link / normalized-settings parity', () => {
         'organizations.ab_backup_refs_org_update',
       ],
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #4673 W03 — the two feature-link validators no longer escape to a system
+// context. Proof that the SELECT-only RLS branch replaces the escape.
+// ---------------------------------------------------------------------------
+//
+// `isBackupProfileReference` and the `backup` branch of
+// `validateFeaturePolicyExists` both used to run
+// `runOutsideDbContext(() => withSystemDbAccessContext(...))`, for one stated
+// reason: a partner-wide profile (`org_id NULL`) was RLS-invisible to the
+// org-scoped token of the tech doing the linking, so an org policy → partner
+// profile link was misclassified as a legacy `backup_configs` destination id
+// and rejected with a nonsense error.
+//
+// `backup_profiles_partner_wide_select` (W01) grants exactly that read to the
+// profile's OWN partner, and `buildDbAccessContext` sets
+// `breeze.current_partner_id` from the JWT partnerId for every scope, org
+// tokens included — so the escape is gone.
+//
+// These are the only real-DB tests of that path: every other test of these two
+// functions mocks the database and therefore evaluates no RLS at all. Without
+// them, W03 removed an escape on a code path with no RLS-level coverage.
+describe('#4673 W03 — feature-link validation resolves partner-wide profiles without a system escape', () => {
+  it('isBackupProfileReference sees the partner-wide profile from an ORG-scoped context', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const profileId = await seedPartnerProfile(partner.id);
+
+    const seen = await withDbAccessContext(orgContext(org.id, partner.id), () =>
+      isBackupProfileReference(profileId),
+    );
+    expect(seen).toBe(true);
+  });
+
+  it('...and is BLIND to it without breeze.current_partner_id — the branch, not an escape, is doing the work', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const profileId = await seedPartnerProfile(partner.id);
+
+    // Under the removed system escape this would still be `true`: the escape
+    // ran as scope 'system' and saw every tenant's profiles regardless of any
+    // GUC. `false` here is what proves the escape is gone.
+    const seen = await withDbAccessContext(orgContext(org.id, null), () =>
+      isBackupProfileReference(profileId),
+    );
+    expect(seen).toBe(false);
+  });
+
+  it('a FOREIGN partner\'s profile is invisible — the deliberate tightening', async () => {
+    // Previously this probe saw every tenant's rows and leaned on
+    // validateFeaturePolicyExists to re-tenant the link afterwards. Now the id
+    // simply reads as absent, falls through to the legacy-destination branch,
+    // and is rejected there. Same outcome, one step earlier, no RLS bypass.
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+    const orgB = await createOrganization({ partnerId: partnerB.id });
+    const foreignProfileId = await seedPartnerProfile(partnerA.id);
+
+    const seen = await withDbAccessContext(orgContext(orgB.id, partnerB.id), () =>
+      isBackupProfileReference(foreignProfileId),
+    );
+    expect(seen).toBe(false);
+  });
+
+  it('validateFeaturePolicyExists accepts an ORG policy linking its PARTNER\'s partner-wide profile', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const profileId = await seedPartnerProfile(partner.id);
+
+    const result = await withDbAccessContext(orgContext(org.id, partner.id), () =>
+      validateFeaturePolicyExists('backup', profileId, { orgId: org.id, partnerId: null }),
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  it('validateFeaturePolicyExists rejects a FOREIGN partner\'s profile', async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+    const orgB = await createOrganization({ partnerId: partnerB.id });
+    const foreignProfileId = await seedPartnerProfile(partnerA.id);
+
+    const result = await withDbAccessContext(orgContext(orgB.id, partnerB.id), () =>
+      validateFeaturePolicyExists('backup', foreignProfileId, { orgId: orgB.id, partnerId: null }),
+    );
+    expect(result.valid).toBe(false);
+  });
+
+  it('validateFeaturePolicyExists still accepts a legacy org-owned backup_configs destination', async () => {
+    // `backup_configs` is org-only — no partner axis, no partner-wide branch —
+    // and its lookup was escaping too. Under the org context the plain
+    // `breeze_has_org_access(org_id)` policy admits it, which is why dropping
+    // that escape needed no migration.
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+
+    const configId = await withDbAccessContext(SYSTEM_CTX, async () => {
+      const [config] = await db
+        .insert(backupConfigs)
+        .values({
+          orgId: org.id,
+          name: 'Legacy destination',
+          type: 'file',
+          provider: 's3',
+          providerConfig: { bucket: 'b', region: 'us-east-1' },
+        })
+        .returning();
+      createdConfigs.push(config!.id);
+      return config!.id;
+    });
+
+    const result = await withDbAccessContext(orgContext(org.id, partner.id), () =>
+      validateFeaturePolicyExists('backup', configId, { orgId: org.id, partnerId: null }),
+    );
+    expect(result.valid).toBe(true);
   });
 });

--- a/apps/api/src/__tests__/integration/featureConfigResolverPartnerWide.integration.test.ts
+++ b/apps/api/src/__tests__/integration/featureConfigResolverPartnerWide.integration.test.ts
@@ -1,0 +1,731 @@
+/**
+ * Per-device config-policy resolvers in services/featureConfigResolver.ts honour
+ * partner-wide policies (#2930) after #4673 W03.
+ *
+ * #4673 Wave 3 deleted `withPartnerWideVisibility` — a nested
+ * `runOutsideDbContext(() => withSystemDbAccessContext(...))` escape — from
+ * every per-device resolver in featureConfigResolver.ts. Those resolvers now
+ * read partner-wide config rows (`org_id NULL, partner_id = P`) through the
+ * SELECT-only RLS branch `<table>_partner_wide_select`
+ * (`USING (org_id IS NULL AND partner_id = public.breeze_current_partner_id())`,
+ * migration 2026-10-05-110000-config-policy-partner-wide-select.sql), which
+ * reads the `breeze.current_partner_id` GUC set from
+ * `DbAccessContext.currentPartnerId`.
+ *
+ * Eight of those resolvers had NO real-database test under a non-system
+ * context, so nothing proved they still return partner-wide rows after the
+ * escape was removed. Their only tests mock Drizzle and evaluate no RLS at
+ * all. This file closes that gap for:
+ *
+ *   resolveAlertRulesForDevice, resolveGoverningAlertRulePolicyForDevice,
+ *   resolveAutomationsForDevice, resolveComplianceRulesForDevice,
+ *   resolveMaintenanceConfigForDevice, resolveSoftwarePolicyForDevice,
+ *   resolveVulnerabilityEnabledForDevice, resolveBackupConfigForDevice,
+ *   resolveBackupProtectionForDevice
+ *
+ * Model: agentPolicyResolversPartnerWide.integration.test.ts (same pattern,
+ * for the four agent-facing resolvers in routes/agents/helpers.ts).
+ *
+ * Each resolver gets a POSITIVE case (partner-wide policy resolves under a
+ * real org-scoped context, via `orgContext`) and a BLIND case (the same seed,
+ * but under a context with `currentPartnerId: null` — `partnerWideBlindContext`
+ * — must return the default/empty result). The blind case is the load-bearing
+ * negative control: under a reintroduced system-context escape,
+ * `breeze.current_partner_id` would be irrelevant and the positive result
+ * would appear regardless of the GUC. Only failing blind + passing positive
+ * together pin that the SELECT-only RLS branch — not an escape — is what
+ * grants the read.
+ */
+import './setup';
+import { afterEach, describe, expect, it } from 'vitest';
+import { randomUUID } from 'crypto';
+import { eq } from 'drizzle-orm';
+import { db, withDbAccessContext, type DbAccessContext } from '../../db';
+import {
+  configurationPolicies,
+  configPolicyFeatureLinks,
+  configPolicyAssignments,
+  configPolicyAlertRules,
+  configPolicyAutomations,
+  configPolicyComplianceRules,
+  configPolicyMaintenanceSettings,
+  configPolicyBackupSettings,
+  softwarePolicies,
+  devices,
+} from '../../db/schema';
+import {
+  resolveAlertRulesForDevice,
+  resolveGoverningAlertRulePolicyForDevice,
+  resolveAutomationsForDevice,
+  resolveComplianceRulesForDevice,
+  resolveMaintenanceConfigForDevice,
+  resolveSoftwarePolicyForDevice,
+  resolveVulnerabilityEnabledForDevice,
+  resolveBackupConfigForDevice,
+  resolveBackupProtectionForDevice,
+} from '../../services/featureConfigResolver';
+import { createPartner, createOrganization, createSite } from './db-utils';
+
+const SYSTEM_CTX: DbAccessContext = {
+  scope: 'system',
+  orgId: null,
+  accessibleOrgIds: null,
+  accessiblePartnerIds: null,
+  userId: null,
+};
+
+// The realistic non-agent request shape too: an org-scoped context carrying
+// the org's own partner in `currentPartnerId` (the field the SELECT-only
+// `*_partner_wide_select` policies read via breeze_current_partner_id()),
+// while `accessiblePartnerIds` stays [] (that field gates partner-axis
+// WRITES via breeze_has_partner_access and is a different axis entirely).
+function orgContext(orgId: string, partnerId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    userId: null,
+    currentPartnerId: partnerId,
+  };
+}
+
+// The SAME context minus `currentPartnerId` — what a hand-built org context
+// looked like before the GUC was wired up, or what a reintroduced escape would
+// make irrelevant. Used by every BLIND case below: if a system-context escape
+// were ever reintroduced, the partner-wide policy would resolve here too, and
+// these assertions would fail.
+function partnerWideBlindContext(orgId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    userId: null,
+    currentPartnerId: null,
+  };
+}
+
+const createdPolicies: string[] = [];
+const createdDevices: string[] = [];
+const createdSoftwarePolicies: string[] = [];
+
+afterEach(async () => {
+  await withDbAccessContext(SYSTEM_CTX, async () => {
+    for (const id of createdDevices) {
+      await db.delete(devices).where(eq(devices.id, id));
+    }
+    for (const id of createdPolicies) {
+      await db.delete(configurationPolicies).where(eq(configurationPolicies.id, id));
+    }
+    for (const id of createdSoftwarePolicies) {
+      await db.delete(softwarePolicies).where(eq(softwarePolicies.id, id));
+    }
+  });
+  createdDevices.length = 0;
+  createdPolicies.length = 0;
+  createdSoftwarePolicies.length = 0;
+});
+
+async function seedDevice(orgId: string, siteId: string) {
+  return withDbAccessContext(SYSTEM_CTX, async () => {
+    const [d] = await db
+      .insert(devices)
+      .values({
+        orgId,
+        siteId,
+        agentId: `agent-${randomUUID()}`,
+        hostname: `host-${randomUUID().slice(0, 8)}`,
+        osType: 'windows',
+        osVersion: '1.0',
+        architecture: 'amd64',
+        agentVersion: '1.0.0',
+        status: 'online',
+        deviceRole: 'workstation',
+      })
+      .returning();
+    createdDevices.push(d!.id);
+    return d!;
+  });
+}
+
+async function assign(configPolicyId: string, level: 'partner' | 'organization', targetId: string) {
+  return withDbAccessContext(SYSTEM_CTX, async () => {
+    await db.insert(configPolicyAssignments).values({
+      configPolicyId,
+      level,
+      targetId,
+      priority: 0,
+    });
+  });
+}
+
+type Owner = { orgId: string | null; partnerId: string | null };
+
+async function createPolicy(owner: Owner, namePrefix: string): Promise<string> {
+  const [policy] = await db
+    .insert(configurationPolicies)
+    .values({ orgId: owner.orgId, partnerId: owner.partnerId, name: `${namePrefix} ${randomUUID()}`, status: 'active' })
+    .returning();
+  createdPolicies.push(policy!.id);
+  return policy!.id;
+}
+
+// alert rule condition/severity are arbitrary but valid; `name` is the field
+// each test asserts on to prove THIS row resolved.
+async function seedAlertRulePolicy(owner: Owner, ruleName: string): Promise<string> {
+  return withDbAccessContext(SYSTEM_CTX, async () => {
+    const policyId = await createPolicy(owner, 'alert rule policy');
+    const [link] = await db
+      .insert(configPolicyFeatureLinks)
+      .values({ configPolicyId: policyId, featureType: 'alert_rule' })
+      .returning();
+    await db.insert(configPolicyAlertRules).values({
+      featureLinkId: link!.id,
+      name: ruleName,
+      severity: 'critical',
+      conditions: { metric: 'cpu_percent', operator: 'gt', value: 90 },
+    });
+    return policyId;
+  });
+}
+
+async function seedAutomationPolicy(owner: Owner, automationName: string): Promise<string> {
+  return withDbAccessContext(SYSTEM_CTX, async () => {
+    const policyId = await createPolicy(owner, 'automation policy');
+    const [link] = await db
+      .insert(configPolicyFeatureLinks)
+      .values({ configPolicyId: policyId, featureType: 'automation' })
+      .returning();
+    await db.insert(configPolicyAutomations).values({
+      featureLinkId: link!.id,
+      name: automationName,
+      triggerType: 'manual',
+      actions: [{ type: 'run_script' }],
+    });
+    return policyId;
+  });
+}
+
+async function seedComplianceRulePolicy(owner: Owner, ruleName: string): Promise<string> {
+  return withDbAccessContext(SYSTEM_CTX, async () => {
+    const policyId = await createPolicy(owner, 'compliance policy');
+    const [link] = await db
+      .insert(configPolicyFeatureLinks)
+      .values({ configPolicyId: policyId, featureType: 'compliance' })
+      .returning();
+    await db.insert(configPolicyComplianceRules).values({
+      featureLinkId: link!.id,
+      name: ruleName,
+      rules: { requiredSetting: 'disk_encryption_enabled' },
+    });
+    return policyId;
+  });
+}
+
+// durationHours default is 2 (schema default) — every seed here uses a
+// different value so a resolved row is unmistakable from the column default.
+async function seedMaintenancePolicy(owner: Owner, durationHours: number): Promise<string> {
+  return withDbAccessContext(SYSTEM_CTX, async () => {
+    const policyId = await createPolicy(owner, 'maintenance policy');
+    const [link] = await db
+      .insert(configPolicyFeatureLinks)
+      .values({ configPolicyId: policyId, featureType: 'maintenance' })
+      .returning();
+    await db.insert(configPolicyMaintenanceSettings).values({
+      featureLinkId: link!.id,
+      durationHours,
+    });
+    return policyId;
+  });
+}
+
+// No settings child for software_policy — the id lives directly on the
+// feature link's featurePolicyId column. But `config_policy_feature_links`
+// carries a trigger-enforced FK (`config_policy_feature_links_reference_owner_fk`,
+// migration 2026-07-27-a) requiring feature_policy_id to name a REAL
+// software_policies row owned by the SAME axis as the parent policy — a bare
+// random uuid is rejected with 23503. So this seeds the target row too, and
+// returns its id as the distinctive value the resolver must echo back.
+async function seedSoftwarePolicyLink(owner: Owner): Promise<{ configPolicyId: string; featurePolicyId: string }> {
+  return withDbAccessContext(SYSTEM_CTX, async () => {
+    const [target] = await db
+      .insert(softwarePolicies)
+      .values({
+        orgId: owner.orgId,
+        partnerId: owner.partnerId,
+        name: `software policy target ${randomUUID()}`,
+        mode: 'allowlist',
+        rules: { software: [] },
+      })
+      .returning();
+    createdSoftwarePolicies.push(target!.id);
+
+    const policyId = await createPolicy(owner, 'software policy link');
+    await db.insert(configPolicyFeatureLinks).values({
+      configPolicyId: policyId,
+      featureType: 'software_policy',
+      featurePolicyId: target!.id,
+    });
+    return { configPolicyId: policyId, featurePolicyId: target!.id };
+  });
+}
+
+// No settings child for vulnerability either — the flag lives in the feature
+// link's inlineSettings JSONB.
+async function seedVulnerabilityPolicy(owner: Owner, enabled: boolean): Promise<string> {
+  return withDbAccessContext(SYSTEM_CTX, async () => {
+    const policyId = await createPolicy(owner, 'vulnerability policy');
+    await db.insert(configPolicyFeatureLinks).values({
+      configPolicyId: policyId,
+      featureType: 'vulnerability',
+      inlineSettings: { enabled },
+    });
+    return policyId;
+  });
+}
+
+// config_policy_backup_settings carries a DB-trigger-enforced
+// `config_policy_backup_settings_owner_match` constraint
+// (migration 2026-07-26-a): its org_id/partner_id must match the PARENT
+// policy's ownership exactly — hence `owner` is threaded onto the settings
+// row too, not just the policy. backupMode default is 'file'; every seed
+// below uses 'system_image' so a resolved row is unmistakable from the
+// column default.
+async function seedBackupSettingsPolicy(
+  owner: Owner,
+  opts: { retention?: Record<string, unknown> } = {},
+): Promise<string> {
+  return withDbAccessContext(SYSTEM_CTX, async () => {
+    const policyId = await createPolicy(owner, 'backup policy');
+    const [link] = await db
+      .insert(configPolicyFeatureLinks)
+      .values({ configPolicyId: policyId, featureType: 'backup' })
+      .returning();
+    await db.insert(configPolicyBackupSettings).values({
+      featureLinkId: link!.id,
+      orgId: owner.orgId,
+      partnerId: owner.partnerId,
+      backupMode: 'system_image',
+      ...(opts.retention ? { retention: opts.retention } : {}),
+    });
+    return policyId;
+  });
+}
+
+describe('per-device config-policy resolvers honour partner-wide policies (#2930, #4673 W03)', () => {
+  describe('resolveAlertRulesForDevice', () => {
+    // Default (no visible policy) is []. Any resolved row is non-empty and
+    // named — the seeded name proves it is THIS row, not a coincidence.
+    it('resolves a partner-wide alert rule under an org-scoped context', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const site = await createSite({ orgId: org!.id });
+      const device = await seedDevice(org!.id, site!.id);
+
+      const ruleName = `Partner-Wide High CPU ${randomUUID()}`;
+      const policyId = await seedAlertRulePolicy({ orgId: null, partnerId: partner.id }, ruleName);
+      await assign(policyId, 'partner', partner.id);
+
+      const result = await withDbAccessContext(orgContext(org!.id, partner.id), () =>
+        resolveAlertRulesForDevice(device.id),
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0]?.name).toBe(ruleName);
+    });
+
+    it('a partner-wide alert rule is INVISIBLE without breeze.current_partner_id', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const site = await createSite({ orgId: org!.id });
+      const device = await seedDevice(org!.id, site!.id);
+
+      const ruleName = `Partner-Wide High CPU ${randomUUID()}`;
+      const policyId = await seedAlertRulePolicy({ orgId: null, partnerId: partner.id }, ruleName);
+      await assign(policyId, 'partner', partner.id);
+
+      const blind = await withDbAccessContext(partnerWideBlindContext(org!.id), () =>
+        resolveAlertRulesForDevice(device.id),
+      );
+      expect(blind).toEqual([]); // default: no visible assignment -> []
+
+      const sighted = await withDbAccessContext(orgContext(org!.id, partner.id), () =>
+        resolveAlertRulesForDevice(device.id),
+      );
+      expect(sighted).toHaveLength(1);
+    });
+  });
+
+  describe('resolveGoverningAlertRulePolicyForDevice', () => {
+    // Default (device has hierarchy but the candidate policy is not among the
+    // visible assigned policies) is {outcome:'unassigned'}. 'governs' requires
+    // the row to be BOTH assigned AND resolvable -> proves visibility.
+    it("a partner-wide policy 'governs' when it is the candidate under an org-scoped context", async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const site = await createSite({ orgId: org!.id });
+      const device = await seedDevice(org!.id, site!.id);
+
+      const policyId = await seedAlertRulePolicy(
+        { orgId: null, partnerId: partner.id },
+        `governs-candidate-${randomUUID()}`,
+      );
+      await assign(policyId, 'partner', partner.id);
+
+      const result = await withDbAccessContext(orgContext(org!.id, partner.id), () =>
+        resolveGoverningAlertRulePolicyForDevice(device.id, policyId),
+      );
+
+      expect(result).toEqual({ outcome: 'governs' });
+    });
+
+    it("a partner-wide policy is 'unassigned' without breeze.current_partner_id", async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const site = await createSite({ orgId: org!.id });
+      const device = await seedDevice(org!.id, site!.id);
+
+      const policyId = await seedAlertRulePolicy(
+        { orgId: null, partnerId: partner.id },
+        `governs-candidate-${randomUUID()}`,
+      );
+      await assign(policyId, 'partner', partner.id);
+
+      const blind = await withDbAccessContext(partnerWideBlindContext(org!.id), () =>
+        resolveGoverningAlertRulePolicyForDevice(device.id, policyId),
+      );
+      // Default: the candidate is invisible under RLS, so it never lands in
+      // the `assigned` set -> unassigned, NOT governs.
+      expect(blind).toEqual({ outcome: 'unassigned' });
+
+      const sighted = await withDbAccessContext(orgContext(org!.id, partner.id), () =>
+        resolveGoverningAlertRulePolicyForDevice(device.id, policyId),
+      );
+      expect(sighted).toEqual({ outcome: 'governs' });
+    });
+  });
+
+  describe('resolveAutomationsForDevice', () => {
+    // Default (no visible policy) is [].
+    it('resolves a partner-wide automation under an org-scoped context', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const site = await createSite({ orgId: org!.id });
+      const device = await seedDevice(org!.id, site!.id);
+
+      const automationName = `Partner-Wide Restart Service ${randomUUID()}`;
+      const policyId = await seedAutomationPolicy({ orgId: null, partnerId: partner.id }, automationName);
+      await assign(policyId, 'partner', partner.id);
+
+      const result = await withDbAccessContext(orgContext(org!.id, partner.id), () =>
+        resolveAutomationsForDevice(device.id),
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0]?.name).toBe(automationName);
+    });
+
+    it('a partner-wide automation is INVISIBLE without breeze.current_partner_id', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const site = await createSite({ orgId: org!.id });
+      const device = await seedDevice(org!.id, site!.id);
+
+      const automationName = `Partner-Wide Restart Service ${randomUUID()}`;
+      const policyId = await seedAutomationPolicy({ orgId: null, partnerId: partner.id }, automationName);
+      await assign(policyId, 'partner', partner.id);
+
+      const blind = await withDbAccessContext(partnerWideBlindContext(org!.id), () =>
+        resolveAutomationsForDevice(device.id),
+      );
+      expect(blind).toEqual([]);
+
+      const sighted = await withDbAccessContext(orgContext(org!.id, partner.id), () =>
+        resolveAutomationsForDevice(device.id),
+      );
+      expect(sighted).toHaveLength(1);
+    });
+  });
+
+  describe('resolveComplianceRulesForDevice', () => {
+    // Default (no visible policy) is [].
+    it('resolves a partner-wide compliance rule under an org-scoped context', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const site = await createSite({ orgId: org!.id });
+      const device = await seedDevice(org!.id, site!.id);
+
+      const ruleName = `Partner-Wide Disk Encryption ${randomUUID()}`;
+      const policyId = await seedComplianceRulePolicy({ orgId: null, partnerId: partner.id }, ruleName);
+      await assign(policyId, 'partner', partner.id);
+
+      const result = await withDbAccessContext(orgContext(org!.id, partner.id), () =>
+        resolveComplianceRulesForDevice(device.id),
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0]?.name).toBe(ruleName);
+    });
+
+    it('a partner-wide compliance rule is INVISIBLE without breeze.current_partner_id', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const site = await createSite({ orgId: org!.id });
+      const device = await seedDevice(org!.id, site!.id);
+
+      const ruleName = `Partner-Wide Disk Encryption ${randomUUID()}`;
+      const policyId = await seedComplianceRulePolicy({ orgId: null, partnerId: partner.id }, ruleName);
+      await assign(policyId, 'partner', partner.id);
+
+      const blind = await withDbAccessContext(partnerWideBlindContext(org!.id), () =>
+        resolveComplianceRulesForDevice(device.id),
+      );
+      expect(blind).toEqual([]);
+
+      const sighted = await withDbAccessContext(orgContext(org!.id, partner.id), () =>
+        resolveComplianceRulesForDevice(device.id),
+      );
+      expect(sighted).toHaveLength(1);
+    });
+  });
+
+  describe('resolveMaintenanceConfigForDevice', () => {
+    // Default (no visible policy) is null. resolveMaintenanceConfigForDevice
+    // does NOT call resolveDeviceTimezone (verified by reading the source) so
+    // no partner-axis escape dependency to worry about here.
+    it('resolves a partner-wide maintenance window under an org-scoped context', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const site = await createSite({ orgId: org!.id });
+      const device = await seedDevice(org!.id, site!.id);
+
+      const DISTINCTIVE_DURATION_HOURS = 9; // schema default is 2
+      const policyId = await seedMaintenancePolicy(
+        { orgId: null, partnerId: partner.id },
+        DISTINCTIVE_DURATION_HOURS,
+      );
+      await assign(policyId, 'partner', partner.id);
+
+      const result = await withDbAccessContext(orgContext(org!.id, partner.id), () =>
+        resolveMaintenanceConfigForDevice(device.id),
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.durationHours).toBe(DISTINCTIVE_DURATION_HOURS);
+    });
+
+    it('a partner-wide maintenance window is INVISIBLE without breeze.current_partner_id', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const site = await createSite({ orgId: org!.id });
+      const device = await seedDevice(org!.id, site!.id);
+
+      const policyId = await seedMaintenancePolicy({ orgId: null, partnerId: partner.id }, 9);
+      await assign(policyId, 'partner', partner.id);
+
+      const blind = await withDbAccessContext(partnerWideBlindContext(org!.id), () =>
+        resolveMaintenanceConfigForDevice(device.id),
+      );
+      expect(blind).toBeNull();
+
+      const sighted = await withDbAccessContext(orgContext(org!.id, partner.id), () =>
+        resolveMaintenanceConfigForDevice(device.id),
+      );
+      expect(sighted).not.toBeNull();
+      expect(sighted!.durationHours).toBe(9);
+    });
+  });
+
+  describe('resolveSoftwarePolicyForDevice', () => {
+    // Default (no visible policy) is null. There is no settings child for
+    // software_policy — the id lives on the feature link's featurePolicyId —
+    // so the seeded UUID itself is the distinctive value.
+    it('resolves a partner-wide software policy link under an org-scoped context', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const site = await createSite({ orgId: org!.id });
+      const device = await seedDevice(org!.id, site!.id);
+
+      const { configPolicyId, featurePolicyId } = await seedSoftwarePolicyLink({ orgId: null, partnerId: partner.id });
+      await assign(configPolicyId, 'partner', partner.id);
+
+      const result = await withDbAccessContext(orgContext(org!.id, partner.id), () =>
+        resolveSoftwarePolicyForDevice(device.id),
+      );
+
+      expect(result).toBe(featurePolicyId);
+    });
+
+    it('a partner-wide software policy link is INVISIBLE without breeze.current_partner_id', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const site = await createSite({ orgId: org!.id });
+      const device = await seedDevice(org!.id, site!.id);
+
+      const { configPolicyId, featurePolicyId } = await seedSoftwarePolicyLink({ orgId: null, partnerId: partner.id });
+      await assign(configPolicyId, 'partner', partner.id);
+
+      const blind = await withDbAccessContext(partnerWideBlindContext(org!.id), () =>
+        resolveSoftwarePolicyForDevice(device.id),
+      );
+      expect(blind).toBeNull();
+
+      const sighted = await withDbAccessContext(orgContext(org!.id, partner.id), () =>
+        resolveSoftwarePolicyForDevice(device.id),
+      );
+      expect(sighted).toBe(featurePolicyId);
+    });
+  });
+
+  describe('resolveVulnerabilityEnabledForDevice', () => {
+    // Default (no visible policy) is false. There is no settings child — the
+    // flag lives in the feature link's inlineSettings JSONB.
+    it('resolves a partner-wide vulnerability opt-in under an org-scoped context', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const site = await createSite({ orgId: org!.id });
+      const device = await seedDevice(org!.id, site!.id);
+
+      const policyId = await seedVulnerabilityPolicy({ orgId: null, partnerId: partner.id }, true);
+      await assign(policyId, 'partner', partner.id);
+
+      const result = await withDbAccessContext(orgContext(org!.id, partner.id), () =>
+        resolveVulnerabilityEnabledForDevice(device.id),
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('a partner-wide vulnerability opt-in is INVISIBLE without breeze.current_partner_id', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const site = await createSite({ orgId: org!.id });
+      const device = await seedDevice(org!.id, site!.id);
+
+      const policyId = await seedVulnerabilityPolicy({ orgId: null, partnerId: partner.id }, true);
+      await assign(policyId, 'partner', partner.id);
+
+      const blind = await withDbAccessContext(partnerWideBlindContext(org!.id), () =>
+        resolveVulnerabilityEnabledForDevice(device.id),
+      );
+      expect(blind).toBe(false); // default: hidden -> not enabled
+
+      const sighted = await withDbAccessContext(orgContext(org!.id, partner.id), () =>
+        resolveVulnerabilityEnabledForDevice(device.id),
+      );
+      expect(sighted).toBe(true);
+    });
+  });
+
+  describe('resolveBackupConfigForDevice', () => {
+    // Default (no visible policy) is null. Reaches resolveDeviceTimezone ->
+    // resolvePartnerTimezoneForDeviceRow -> readWithPartnerAxisVisibility,
+    // which opens its OWN system context internally, so it resolves fine
+    // under both an org context and the blind context — not worked around.
+    it('resolves a partner-wide backup config under an org-scoped context', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const site = await createSite({ orgId: org!.id });
+      const device = await seedDevice(org!.id, site!.id);
+
+      const policyId = await seedBackupSettingsPolicy({ orgId: null, partnerId: partner.id });
+      await assign(policyId, 'partner', partner.id);
+
+      const result = await withDbAccessContext(orgContext(org!.id, partner.id), () =>
+        resolveBackupConfigForDevice(device.id),
+      );
+
+      expect(result).not.toBeNull();
+      // 'system_image' is not the schema default ('file') — proves the
+      // partner-wide settings row resolved rather than a coincidental match.
+      expect(result!.settings?.backupMode).toBe('system_image');
+      expect(result!.settings?.backupMode).not.toBe('file');
+    });
+
+    it('a partner-wide backup config is INVISIBLE without breeze.current_partner_id', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const site = await createSite({ orgId: org!.id });
+      const device = await seedDevice(org!.id, site!.id);
+
+      const policyId = await seedBackupSettingsPolicy({ orgId: null, partnerId: partner.id });
+      await assign(policyId, 'partner', partner.id);
+
+      const blind = await withDbAccessContext(partnerWideBlindContext(org!.id), () =>
+        resolveBackupConfigForDevice(device.id),
+      );
+      expect(blind).toBeNull();
+
+      const sighted = await withDbAccessContext(orgContext(org!.id, partner.id), () =>
+        resolveBackupConfigForDevice(device.id),
+      );
+      expect(sighted).not.toBeNull();
+      expect(sighted!.settings?.backupMode).toBe('system_image');
+    });
+  });
+
+  describe('resolveBackupProtectionForDevice', () => {
+    // Default (no visible policy) is null. The distinctive value is the whole
+    // `retention` shape: legalHold true / a reason / an immutability mode+days
+    // — every field differs from "no protection" (legalHold:false,
+    // legalHoldReason:null, immutabilityMode:null, immutableDays:null).
+    const DISTINCTIVE_RETENTION = {
+      legalHold: true,
+      legalHoldReason: 'Litigation hold — matter 2026-CV-4471',
+      immutabilityMode: 'provider' as const,
+      immutableDays: 45,
+    };
+
+    it('resolves partner-wide backup protection under an org-scoped context', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const site = await createSite({ orgId: org!.id });
+      const device = await seedDevice(org!.id, site!.id);
+
+      const policyId = await seedBackupSettingsPolicy(
+        { orgId: null, partnerId: partner.id },
+        { retention: DISTINCTIVE_RETENTION },
+      );
+      await assign(policyId, 'partner', partner.id);
+
+      const result = await withDbAccessContext(orgContext(org!.id, partner.id), () =>
+        resolveBackupProtectionForDevice(device.id),
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.legalHold).toBe(true);
+      expect(result!.legalHoldReason).toBe(DISTINCTIVE_RETENTION.legalHoldReason);
+      expect(result!.immutabilityMode).toBe('provider');
+      expect(result!.immutableDays).toBe(45);
+    });
+
+    it('partner-wide backup protection is INVISIBLE without breeze.current_partner_id', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const site = await createSite({ orgId: org!.id });
+      const device = await seedDevice(org!.id, site!.id);
+
+      const policyId = await seedBackupSettingsPolicy(
+        { orgId: null, partnerId: partner.id },
+        { retention: DISTINCTIVE_RETENTION },
+      );
+      await assign(policyId, 'partner', partner.id);
+
+      const blind = await withDbAccessContext(partnerWideBlindContext(org!.id), () =>
+        resolveBackupProtectionForDevice(device.id),
+      );
+      // Default: no visible assignment at all -> null (not merely
+      // legalHold:false — the resolver returns null outright when rows.length
+      // is 0, before any retention parsing happens).
+      expect(blind).toBeNull();
+
+      const sighted = await withDbAccessContext(orgContext(org!.id, partner.id), () =>
+        resolveBackupProtectionForDevice(device.id),
+      );
+      expect(sighted).not.toBeNull();
+      expect(sighted!.legalHold).toBe(true);
+      expect(sighted!.immutableDays).toBe(45);
+    });
+  });
+});

--- a/apps/api/src/db/partnerAxisRead.ts
+++ b/apps/api/src/db/partnerAxisRead.ts
@@ -33,8 +33,18 @@ import {
  * (partner-axis tables are fully visible to it) and would double-hold
  * connections against the 25-connection US ceiling, where postgres-js has no
  * acquire timeout. Same skip branch as `getEnrollmentDefaultsForOrg`
- * (services/enrollmentDefaults.ts, #2818) and `withPartnerWideVisibility`
- * (services/featureConfigResolver.ts).
+ * (services/enrollmentDefaults.ts, #2818).
+ *
+ * WHY THIS ONE SURVIVED #4673 W03, which deleted the config-policy sibling
+ * (`withPartnerWideVisibility`): that sibling's rows are PARTNER-WIDE — they
+ * live on org-axis tables with `org_id IS NULL`, so a SELECT-only RLS branch
+ * (`org_id IS NULL AND partner_id = breeze_current_partner_id()`) can grant
+ * them without touching write targeting. These rows are on PARTNER-AXIS tables
+ * (`partners`, PARTNER_TENANT_TABLES): there is no `org_id IS NULL` shape to
+ * key a branch on, and the only gate is `breeze_has_partner_access`, which also
+ * governs WRITES. Granting it to org scope would widen UPDATE/DELETE, so the
+ * escape stays until #2822 designs a read-only partner-axis branch. Do not
+ * "clean this up" by analogy with W03.
  */
 export async function readWithPartnerAxisVisibility<T>(fn: () => Promise<T>): Promise<T> {
   // `getCurrentDbAccessContext()` reflects the GUCs actually SET LOCAL on the

--- a/apps/api/src/middleware/agentAuth.ts
+++ b/apps/api/src/middleware/agentAuth.ts
@@ -948,12 +948,14 @@ export async function agentAuthMiddleware(c: Context, next: Next) {
       // across the configuration-policy chain, plus the pre-existing catalog /
       // cis_baselines / tenant_variables branches.
       //
-      // This lets an agent SEE its own MSP's partner-wide config directly,
-      // which is what removes the need for the nested system-context escapes
-      // on agent paths (`withPartnerWideVisibility`) in Wave 3. Because every
-      // consuming policy is FOR SELECT, it grants no write targeting: a
-      // foreign partner's rows stay invisible, and UPDATE/DELETE still see
-      // only the org-owned rows they saw before.
+      // This lets an agent SEE its own MSP's partner-wide config directly. Wave
+      // 3 then deleted the nested system-context escapes on the agent paths
+      // that used to compensate, so this field is now LOAD-BEARING: drop it and
+      // partner-wide event-log / monitoring / PAM / patch-source / CIS config
+      // silently stops reaching agents, with no error. Because every consuming
+      // policy is FOR SELECT, it grants no write targeting: a foreign partner's
+      // rows stay invisible, and UPDATE/DELETE still see only the org-owned
+      // rows they saw before.
       currentPartnerId: device.partnerId
     },
     async () => {

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -397,15 +397,33 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
     // rather than inherited. Without it the `breeze.current_partner_id` GUC is
     // empty here and Wave 1's SELECT-only partner-wide branches can never match.
     //
-    // Scope note, so nobody over-reads this: as of W02 the field is INERT on
-    // this route. Every config-delivery read the heartbeat performs
-    // (event-log, monitoring, PAM, patch-source, OneDrive, helper settings,
-    // the update-policy gate) still runs in its own withSystemDbAccessContext,
-    // which bypasses RLS and already saw partner-wide rows. Nothing inside the
-    // org-scoped block below reads a partner-wide-branched table directly.
-    // It becomes load-bearing in Wave 3, when those escapes are removed and
-    // this GUC is the only thing keeping partner-wide config reaching agents.
-    // Set it now so Wave 3 is a deletion, not a deletion plus a scavenger hunt.
+    // Scope note, so nobody over-reads this: the field is still INERT on THIS
+    // route, and W03 did not change that — read the paragraph below before
+    // "cleaning up" the hoisted system contexts further down.
+    //
+    // W03 deleted the NESTED escapes (`withPartnerWideVisibility` and the
+    // direct `runOutsideDbContext(() => withSystemDbAccessContext(...))`
+    // wraps), so on every OTHER caller of these resolvers — agents/eventlogs,
+    // agents/commands, the backup routes, alertService, policyEvaluationService,
+    // pamBridge, the feature-link routes — the read now happens in the caller's
+    // own context and this GUC is exactly what carries it. The heartbeat is the
+    // one path where it does not, because the reads below are HOISTED into
+    // their own top-level system contexts (this route opts out of the
+    // request-long wrap). Those are not nested and cost no second connection,
+    // so W03 had no reason to touch them.
+    //
+    // Converting them to org-scoped contexts is a real follow-up — it would
+    // close the last RLS-bypass surface on the hottest path — but it is NOT a
+    // drop-in swap, which is why it is not in this wave:
+    // `buildPatchSourceConfigUpdate` reaches `resolveDeviceTimezone`, whose
+    // `partners` read is partner-AXIS and escapes through
+    // `readWithPartnerAxisVisibility` (#2822). Under a system wrapper that
+    // escape short-circuits; under an org wrapper it fires, uncached, once per
+    // heartbeat — turning one hoisted context into a genuinely NESTED
+    // double-hold on the fleet's hottest path, which is the #1105 shape this
+    // whole epic exists to remove. The timezone read has to be hoisted or
+    // batched first. Track it separately; do not do it by analogy with W03.
+    //
     // Read-only widening to the device's own MSP; see agentAuth.ts.
     currentPartnerId: agent.partnerId,
   };
@@ -1727,7 +1745,17 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
   // #2930 — event_log / monitoring / pam / patch_source policy readers. These
   // used to run inside the org transaction, where a partner-wide policy
   // (org_id NULL) is RLS-invisible, so a partner-authored policy for any of the
-  // four never reached an agent. Same treatment as policyProbeConfig /
+  // four never reached an agent.
+  //
+  // #4673 W03 kept this hoist deliberately. The resolvers themselves no longer
+  // escape internally — they read partner-wide rows through the
+  // `*_partner_wide_select` branch in whatever context they are given — so an
+  // org-scoped wrapper here WOULD work for event_log / monitoring / pam. It is
+  // not applied because `buildPatchSourceConfigUpdate` shares this wrapper and
+  // reaches the partner-AXIS `partners` read in `resolveDeviceTimezone`, which
+  // would then take a nested `readWithPartnerAxisVisibility` escape once per
+  // heartbeat (see the long note at the `currentPartnerId` assignment above).
+  // Same treatment as policyProbeConfig /
   // onedriveSettings / helperSettings above: resolved after the org tx is
   // released, under a system context anchored to `scoped.deviceId` — an id
   // derived from the device the agent already authenticated as, so this cannot
@@ -1845,11 +1873,19 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
 
   // #1105 — helper settings resolved OUTSIDE the org context too (same
   // guarantee as policyProbeConfig/onedriveSettings above): a partner-wide
-  // helper policy (org_id NULL) is invisible under the org-scoped RLS context
-  // (accessiblePartnerIds: [] there), so it must resolve under a system
-  // context anchored to this authenticated device's own org — cannot pivot
-  // tenants since both ids come from `scoped`, derived from the device the
-  // agent already authenticated as.
+  // helper policy (org_id NULL) was invisible under the org-scoped RLS context
+  // (accessiblePartnerIds: [] there), so it resolved under a system context
+  // anchored to this authenticated device's own org — cannot pivot tenants
+  // since both ids come from `scoped`, derived from the device the agent
+  // already authenticated as.
+  //
+  // #4673 W03: the invisibility half of that reason is gone —
+  // `config_policy_feature_links_partner_wide_select` covers the JSONB
+  // `inlineSettings` this resolves, and `buildHelperConfigUpdate` touches no
+  // partner-AXIS table, so this one IS a safe drop-in swap to an org-scoped
+  // context. It is left alone only so the heartbeat's five hoists are converted
+  // as ONE reviewable change with one integration proof each, rather than
+  // piecemeal. See the note at the `currentPartnerId` assignment above.
   let helperSettings: HelperSettings | null = null;
   try {
     helperSettings = await withSystemDbAccessContext(() =>

--- a/apps/api/src/routes/agents/helpers.partnerWidePolicies.test.ts
+++ b/apps/api/src/routes/agents/helpers.partnerWidePolicies.test.ts
@@ -15,10 +15,28 @@
  *  - it passes the DEVICE ORG'S PARTNER into `policyOwnershipCondition` (so the
  *    emitted predicate admits `org_id NULL` rows — the SQL itself is pinned in
  *    services/configPolicyOwnership.test.ts), and
- *  - it runs the policy join inside `withPartnerWideVisibility` (the RLS
- *    escape).
+ *  - it runs the policy join in the CALLER'S OWN DB CONTEXT, with no escape.
+ *
+ * That second assertion INVERTED in #4673 W03. It used to require the opposite:
+ * that the join ran inside `withPartnerWideVisibility`, a nested
+ * `runOutsideDbContext(() => withSystemDbAccessContext(...))` that took a second
+ * pooled connection (#1105) and bypassed RLS wholesale (#2417). W01 added the
+ * SELECT-only `<table>_partner_wide_select` policies and W02 populates
+ * `breeze.current_partner_id` on agent contexts, so the database now grants the
+ * read and the escape is a liability rather than the fix.
+ *
+ * The gate is built to fail LOUDLY if anyone reintroduces it:
+ *  - `runOutsideDbContext` / `withSystemDbAccessContext` are mocked to THROW,
+ *    and each resolver additionally asserts they were never called; and
+ *  - the `configPolicyOwnership` mock factory intentionally omits
+ *    `withPartnerWideVisibility`, so re-importing it fails with
+ *    "No withPartnerWideVisibility export is defined on the mock".
+ *
  * End-to-end proof against real Postgres lives in
- * __tests__/integration/configurationPolicyPartnerResolution.integration.test.ts.
+ * __tests__/integration/configurationPolicyPartnerResolution.integration.test.ts
+ * and __tests__/integration/agentPolicyResolversPartnerWide.integration.test.ts
+ * (the latter proves the RLS half: the same resolvers under a REAL org-scoped
+ * context, with and without `currentPartnerId`).
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -26,7 +44,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // Hoisted mocks
 // ---------------------------------------------------------------------------
 
-const { dbMock, redisMock, getRedisImpl, ownershipMock, partnerWideVisibilityMock } = vi.hoisted(() => {
+const { dbMock, redisMock, getRedisImpl, ownershipMock, systemEscapeMock } = vi.hoisted(() => {
   let selectCallQueue: unknown[][] = [];
   let selectCallIdx = 0;
 
@@ -65,21 +83,33 @@ const { dbMock, redisMock, getRedisImpl, ownershipMock, partnerWideVisibilityMoc
     redisMock,
     getRedisImpl: vi.fn(() => redisMock as any),
     ownershipMock: vi.fn(() => 'OWNERSHIP_CONDITION' as any),
-    partnerWideVisibilityMock: vi.fn(<T>(fn: () => Promise<T>) => fn()),
+    // #4673 W03: any system-context escape on these paths is now a regression.
+    // Throwing (rather than transparently delegating) means a reintroduced
+    // escape fails the suite even in a test that forgets the explicit
+    // `not.toHaveBeenCalled()` assertion below.
+    systemEscapeMock: vi.fn(() => {
+      throw new Error(
+        'routes/agents/helpers.ts must not open a nested system DB context: ' +
+          'partner-wide config rows are granted by the *_partner_wide_select ' +
+          'RLS branch (#4673 W01/W02). See configPolicyOwnership.ts.',
+      );
+    }),
   };
 });
 
 vi.mock('../../db', () => ({
-  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  runOutsideDbContext: systemEscapeMock,
   withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
-  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: systemEscapeMock,
   getCurrentDbAccessContext: vi.fn(() => undefined),
   db: dbMock,
 }));
 
+// `withPartnerWideVisibility` is deliberately ABSENT from this factory (#4673
+// W03 deleted it). Re-importing it in helpers.ts fails loudly here rather than
+// silently reintroducing the nested system context.
 vi.mock('../../services/configPolicyOwnership', () => ({
   policyOwnershipCondition: ownershipMock,
-  withPartnerWideVisibility: partnerWideVisibilityMock,
 }));
 
 vi.mock('../../db/schema', () => ({
@@ -231,7 +261,6 @@ beforeEach(() => {
   vi.clearAllMocks();
   getRedisImpl.mockReturnValue(null); // no cache — always resolve from "DB"
   ownershipMock.mockReturnValue('OWNERSHIP_CONDITION' as any);
-  partnerWideVisibilityMock.mockImplementation(<T>(fn: () => Promise<T>) => fn());
 });
 
 /**
@@ -285,12 +314,15 @@ describe.each([
     expect(ownershipMock).toHaveBeenCalledWith({ orgId: ORG_ID, partnerId: PARTNER_ID });
   });
 
-  it('runs the policy join inside the partner-wide RLS escape', async () => {
+  it('runs the policy join in the caller\'s own DB context — no system escape (#4673 W03)', async () => {
     dbMock._resetQueue(queue(orgWithPartner));
 
+    // Completing at all is half the assertion: the db mock throws from
+    // runOutsideDbContext / withSystemDbAccessContext, so a reintroduced escape
+    // rejects here rather than reporting a passing resolve.
     await run();
 
-    expect(partnerWideVisibilityMock).toHaveBeenCalledTimes(1);
+    expect(systemEscapeMock).not.toHaveBeenCalled();
   });
 
   it('passes partnerId null when the device org has no partner', async () => {
@@ -335,7 +367,7 @@ describe('onedrive_helper stays org-only — do not "fix" it like the others', (
     await buildOnedriveHelperConfigUpdate(DEVICE_ID);
 
     expect(ownershipMock).not.toHaveBeenCalled();
-    expect(partnerWideVisibilityMock).not.toHaveBeenCalled();
+    expect(systemEscapeMock).not.toHaveBeenCalled();
   });
 });
 
@@ -413,6 +445,6 @@ describe('partner-owned policies actually reach the agent payload', () => {
 
     await buildMonitoringConfigUpdate(DEVICE_ID);
 
-    expect(partnerWideVisibilityMock).toHaveBeenCalledTimes(1);
+    expect(systemEscapeMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/agents/helpers.ts
+++ b/apps/api/src/routes/agents/helpers.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { and, desc, eq, gte, inArray, isNull, or, sql } from 'drizzle-orm';
 import { randomBytes } from 'crypto';
-import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
+import { db } from '../../db';
 import type { AgentAuthContext } from '../../middleware/agentAuth';
 import {
   devices,
@@ -55,7 +55,7 @@ import {
 } from '../../services/filesystemAnalysis';
 import { recordSoftwarePolicyAudit } from '../../services/softwarePolicyService';
 import { resolvePatchConfigForDevice } from '../../services/featureConfigResolver';
-import { policyOwnershipCondition, withPartnerWideVisibility } from '../../services/configPolicyOwnership';
+import { policyOwnershipCondition } from '../../services/configPolicyOwnership';
 import { resolveUserGroupMembershipCached } from '../../services/onedriveGraph';
 import { captureException } from '../../services/sentry';
 import { getBinaryEdition } from '../../services/binaryEdition';
@@ -1165,35 +1165,32 @@ export async function handleCisCommandResult(
       return;
     }
 
-    // Resolve the baseline in a SYSTEM context.
+    // Resolve the baseline in the AGENT'S OWN context (#4673 W03).
     //
-    // This escape originally existed because the agent's ORG-scoped RLS
-    // context had breeze_current_partner_id() NULL, making a partner-wide
-    // baseline (org_id NULL) invisible and this lookup return nothing. As of
-    // #4673 W02 that is no longer true — agent contexts now carry the device
-    // org's partner, so `cis_baselines_partner_wide_select` would match here.
-    // The escape is kept only because #4673 Wave 3 owns removing it together
-    // with the other `withPartnerWideVisibility` sites, as one reviewable
-    // change; do not read this comment as evidence that the GUC is still null.
+    // This read used to escape to a system context because the agent's
+    // ORG-scoped RLS context had breeze_current_partner_id() NULL, making a
+    // partner-wide baseline (org_id NULL) invisible. W02 populates that GUC
+    // from the device org's partner, and `cis_baselines_partner_wide_select`
+    // (2026-08-10-cis-baselines-partner-ownership.sql) grants exactly the
+    // SELECT branch this needs — so the escape is now dead weight: a second
+    // pooled connection and a full RLS bypass for a by-primary-key read.
     //
-    // Why it stays safe meanwhile: both callers swallow the error, so the
-    // failure mode of a miss is every scheduled scan result silently discarded
-    // with only a log line. The read is by primary key and the result is
-    // immediately re-checked against the device's own org below.
-    const [baseline] = await runOutsideDbContext(() =>
-      withSystemDbAccessContext(() =>
-        db
-          .select({
-            id: cisBaselines.id,
-            orgId: cisBaselines.orgId,
-            partnerId: cisBaselines.partnerId,
-            name: cisBaselines.name,
-          })
-          .from(cisBaselines)
-          .where(eq(cisBaselines.id, baselineId))
-          .limit(1)
-      )
-    );
+    // This is a deliberate TIGHTENING. The escaped read returned EVERY
+    // tenant's baselines and leaned on the org/partner re-check below; under
+    // the agent's own context a foreign tenant's baseline now reads as absent
+    // and takes the same "not found" branch. Both callers swallow that, so a
+    // miss is a discarded scan result plus a log line, never a wrong-tenant
+    // write. The re-check below stays as defense in depth.
+    const [baseline] = await db
+      .select({
+        id: cisBaselines.id,
+        orgId: cisBaselines.orgId,
+        partnerId: cisBaselines.partnerId,
+        name: cisBaselines.name,
+      })
+      .from(cisBaselines)
+      .where(eq(cisBaselines.id, baselineId))
+      .limit(1);
 
     if (!baseline) {
       console.warn(`[agents/helpers] cis_benchmark command ${command.id}: baseline ${baselineId} not found`);
@@ -1819,31 +1816,29 @@ async function resolveDeviceEventLogSettings(deviceId: string): Promise<EventLog
   }
 
   // 5. Single query: assignments → active policies → event_log feature link → settings
-  const rows = await withPartnerWideVisibility(() =>
-    db
-      .select({
-        level: configPolicyAssignments.level,
-        assignmentPriority: configPolicyAssignments.priority,
-        retentionDays: configPolicyEventLogSettings.retentionDays,
-        maxEventsPerCycle: configPolicyEventLogSettings.maxEventsPerCycle,
-        collectCategories: configPolicyEventLogSettings.collectCategories,
-        minimumLevel: configPolicyEventLogSettings.minimumLevel,
-        collectionIntervalMinutes: configPolicyEventLogSettings.collectionIntervalMinutes,
-        rateLimitPerHour: configPolicyEventLogSettings.rateLimitPerHour,
-      })
-      .from(configPolicyAssignments)
-      .innerJoin(configurationPolicies, eq(configPolicyAssignments.configPolicyId, configurationPolicies.id))
-      .innerJoin(configPolicyFeatureLinks, and(
-        eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
-        eq(configPolicyFeatureLinks.featureType, 'event_log'),
-      ))
-      .innerJoin(configPolicyEventLogSettings, eq(configPolicyEventLogSettings.featureLinkId, configPolicyFeatureLinks.id))
-      .where(and(
-        eq(configurationPolicies.status, 'active'),
-        policyOwnershipCondition({ orgId: device.orgId, partnerId: org?.partnerId ?? null }),
-        or(...targetConditions),
-      ))
-  );
+  const rows = await db
+    .select({
+      level: configPolicyAssignments.level,
+      assignmentPriority: configPolicyAssignments.priority,
+      retentionDays: configPolicyEventLogSettings.retentionDays,
+      maxEventsPerCycle: configPolicyEventLogSettings.maxEventsPerCycle,
+      collectCategories: configPolicyEventLogSettings.collectCategories,
+      minimumLevel: configPolicyEventLogSettings.minimumLevel,
+      collectionIntervalMinutes: configPolicyEventLogSettings.collectionIntervalMinutes,
+      rateLimitPerHour: configPolicyEventLogSettings.rateLimitPerHour,
+    })
+    .from(configPolicyAssignments)
+    .innerJoin(configurationPolicies, eq(configPolicyAssignments.configPolicyId, configurationPolicies.id))
+    .innerJoin(configPolicyFeatureLinks, and(
+      eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
+      eq(configPolicyFeatureLinks.featureType, 'event_log'),
+    ))
+    .innerJoin(configPolicyEventLogSettings, eq(configPolicyEventLogSettings.featureLinkId, configPolicyFeatureLinks.id))
+    .where(and(
+      eq(configurationPolicies.status, 'active'),
+      policyOwnershipCondition({ orgId: device.orgId, partnerId: org?.partnerId ?? null }),
+      or(...targetConditions),
+    ));
 
   if (rows.length === 0) return EVENT_LOG_DEFAULTS;
 
@@ -2013,61 +2008,57 @@ async function resolveDeviceMonitoringSettings(deviceId: string): Promise<Monito
     );
   }
 
-  // 5-7. Policy join + the winning row's watches, both under one partner-wide
-  // escape (#2930). The watches table's RLS walks settings_id → feature link →
-  // configuration_policies and needs breeze_has_partner_access for a
-  // partner-owned policy, so splitting the two reads across contexts would find
-  // the policy and then silently resolve zero watches (returning null here).
-  // Both reads are pinned to this device's own hierarchy.
-  const resolved = await withPartnerWideVisibility(async () => {
-    // 5. Single query: assignments → active policies → monitoring feature link → settings
-    const rows = await db
-      .select({
-        level: configPolicyAssignments.level,
-        assignmentPriority: configPolicyAssignments.priority,
-        settingsId: configPolicyMonitoringSettings.id,
-        checkIntervalSeconds: configPolicyMonitoringSettings.checkIntervalSeconds,
-      })
-      .from(configPolicyAssignments)
-      .innerJoin(configurationPolicies, eq(configPolicyAssignments.configPolicyId, configurationPolicies.id))
-      .innerJoin(configPolicyFeatureLinks, and(
-        eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
-        eq(configPolicyFeatureLinks.featureType, 'monitoring'),
-      ))
-      .innerJoin(configPolicyMonitoringSettings, eq(configPolicyMonitoringSettings.featureLinkId, configPolicyFeatureLinks.id))
-      .where(and(
-        eq(configurationPolicies.status, 'active'),
-        policyOwnershipCondition({ orgId: device.orgId, partnerId: org?.partnerId ?? null }),
-        or(...targetConditions),
-      ));
+  // 5-7. Policy join + the winning row's watches, both in the CALLER'S OWN
+  // context (#4673 W03). config_policy_monitoring_watches' RLS walks
+  // settings_id → feature link → configuration_policies; for a partner-owned
+  // policy that chain used to need breeze_has_partner_access, which no agent or
+  // org context carries, so the read escaped to a system context. Wave 1's
+  // `config_policy_monitoring_watches_partner_wide_select` now grants exactly
+  // that chain on SELECT via breeze_current_partner_id(), and Wave 2 sets the
+  // GUC on agent contexts — so both reads resolve here without a second pooled
+  // connection. Both are pinned to this device's own hierarchy.
+  // 5. Single query: assignments → active policies → monitoring feature link → settings
+  const rows = await db
+    .select({
+      level: configPolicyAssignments.level,
+      assignmentPriority: configPolicyAssignments.priority,
+      settingsId: configPolicyMonitoringSettings.id,
+      checkIntervalSeconds: configPolicyMonitoringSettings.checkIntervalSeconds,
+    })
+    .from(configPolicyAssignments)
+    .innerJoin(configurationPolicies, eq(configPolicyAssignments.configPolicyId, configurationPolicies.id))
+    .innerJoin(configPolicyFeatureLinks, and(
+      eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
+      eq(configPolicyFeatureLinks.featureType, 'monitoring'),
+    ))
+    .innerJoin(configPolicyMonitoringSettings, eq(configPolicyMonitoringSettings.featureLinkId, configPolicyFeatureLinks.id))
+    .where(and(
+      eq(configurationPolicies.status, 'active'),
+      policyOwnershipCondition({ orgId: device.orgId, partnerId: org?.partnerId ?? null }),
+      or(...targetConditions),
+    ));
 
-    if (rows.length === 0) return null;
+  if (rows.length === 0) return null;
 
-    // 6. Sort by level priority DESC, then assignment priority ASC — first match wins
-    rows.sort((a, b) => {
-      const levelDiff = (LEVEL_PRIORITY[b.level] ?? 0) - (LEVEL_PRIORITY[a.level] ?? 0);
-      if (levelDiff !== 0) return levelDiff;
-      return a.assignmentPriority - b.assignmentPriority;
-    });
-
-    const winner = rows[0];
-    if (!winner) return null;
-
-    // 7. Load watches for the winning settings row
-    const watches = await db
-      .select()
-      .from(configPolicyMonitoringWatches)
-      .where(and(
-        eq(configPolicyMonitoringWatches.settingsId, winner.settingsId),
-        eq(configPolicyMonitoringWatches.enabled, true),
-      ))
-      .orderBy(configPolicyMonitoringWatches.sortOrder);
-
-    return { winner, watches };
+  // 6. Sort by level priority DESC, then assignment priority ASC — first match wins
+  rows.sort((a, b) => {
+    const levelDiff = (LEVEL_PRIORITY[b.level] ?? 0) - (LEVEL_PRIORITY[a.level] ?? 0);
+    if (levelDiff !== 0) return levelDiff;
+    return a.assignmentPriority - b.assignmentPriority;
   });
 
-  if (!resolved) return null;
-  const { winner, watches } = resolved;
+  const winner = rows[0];
+  if (!winner) return null;
+
+  // 7. Load watches for the winning settings row
+  const watches = await db
+    .select()
+    .from(configPolicyMonitoringWatches)
+    .where(and(
+      eq(configPolicyMonitoringWatches.settingsId, winner.settingsId),
+      eq(configPolicyMonitoringWatches.enabled, true),
+    ))
+    .orderBy(configPolicyMonitoringWatches.sortOrder);
 
   if (watches.length === 0) return null;
 
@@ -2553,25 +2544,23 @@ export async function resolveDeviceHelperSettings(deviceId: string): Promise<Hel
   }
 
   // 5. Single query: assignments → active policies → helper feature link (pure JSONB)
-  const rows = await withPartnerWideVisibility(() =>
-    db
-      .select({
-        level: configPolicyAssignments.level,
-        assignmentPriority: configPolicyAssignments.priority,
-        inlineSettings: configPolicyFeatureLinks.inlineSettings,
-      })
-      .from(configPolicyAssignments)
-      .innerJoin(configurationPolicies, eq(configPolicyAssignments.configPolicyId, configurationPolicies.id))
-      .innerJoin(configPolicyFeatureLinks, and(
-        eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
-        eq(configPolicyFeatureLinks.featureType, 'helper'),
-      ))
-      .where(and(
-        eq(configurationPolicies.status, 'active'),
-        policyOwnershipCondition({ orgId: device.orgId, partnerId: org?.partnerId ?? null }),
-        or(...targetConditions),
-      ))
-  );
+  const rows = await db
+    .select({
+      level: configPolicyAssignments.level,
+      assignmentPriority: configPolicyAssignments.priority,
+      inlineSettings: configPolicyFeatureLinks.inlineSettings,
+    })
+    .from(configPolicyAssignments)
+    .innerJoin(configurationPolicies, eq(configPolicyAssignments.configPolicyId, configurationPolicies.id))
+    .innerJoin(configPolicyFeatureLinks, and(
+      eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
+      eq(configPolicyFeatureLinks.featureType, 'helper'),
+    ))
+    .where(and(
+      eq(configurationPolicies.status, 'active'),
+      policyOwnershipCondition({ orgId: device.orgId, partnerId: org?.partnerId ?? null }),
+      or(...targetConditions),
+    ));
 
   if (rows.length === 0) return null;
 
@@ -2713,25 +2702,23 @@ async function resolveDevicePamSettings(deviceId: string): Promise<PamSettings> 
   }
 
   // 5. Single query: assignments → active policies → pam feature link (pure JSONB)
-  const rows = await withPartnerWideVisibility(() =>
-    db
-      .select({
-        level: configPolicyAssignments.level,
-        assignmentPriority: configPolicyAssignments.priority,
-        inlineSettings: configPolicyFeatureLinks.inlineSettings,
-      })
-      .from(configPolicyAssignments)
-      .innerJoin(configurationPolicies, eq(configPolicyAssignments.configPolicyId, configurationPolicies.id))
-      .innerJoin(configPolicyFeatureLinks, and(
-        eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
-        eq(configPolicyFeatureLinks.featureType, 'pam'),
-      ))
-      .where(and(
-        eq(configurationPolicies.status, 'active'),
-        policyOwnershipCondition({ orgId: device.orgId, partnerId: org?.partnerId ?? null }),
-        or(...targetConditions),
-      ))
-  );
+  const rows = await db
+    .select({
+      level: configPolicyAssignments.level,
+      assignmentPriority: configPolicyAssignments.priority,
+      inlineSettings: configPolicyFeatureLinks.inlineSettings,
+    })
+    .from(configPolicyAssignments)
+    .innerJoin(configurationPolicies, eq(configPolicyAssignments.configPolicyId, configurationPolicies.id))
+    .innerJoin(configPolicyFeatureLinks, and(
+      eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
+      eq(configPolicyFeatureLinks.featureType, 'pam'),
+    ))
+    .where(and(
+      eq(configurationPolicies.status, 'active'),
+      policyOwnershipCondition({ orgId: device.orgId, partnerId: org?.partnerId ?? null }),
+      or(...targetConditions),
+    ));
 
   if (rows.length === 0) return resolveOrgPamFallback(device.orgId);
 

--- a/apps/api/src/services/configPolicyOwnership.test.ts
+++ b/apps/api/src/services/configPolicyOwnership.test.ts
@@ -1,12 +1,19 @@
 /**
  * Unit tests for the config-policy partner-wide ownership primitives (#2930).
  *
- * These assert the two things that, when missing, make a partner-authored
- * policy silently never reach an agent:
- *   1. the emitted SQL admits `org_id IS NULL AND partner_id = <device partner>`
- *      rows, not just `org_id = <device org>`;
- *   2. the read escapes to a system RLS context, because partner-owned rows are
- *      invisible under every agent-facing (org-scoped) context.
+ * These assert the app-layer half of "a partner-authored policy reaches an
+ * agent": the emitted SQL admits `org_id IS NULL AND partner_id = <device
+ * partner>` rows, not just `org_id = <device org>`.
+ *
+ * The RLS half is no longer app code. It used to be `withPartnerWideVisibility`,
+ * a nested system-context escape, tested here; #4673 W03 deleted it because
+ * `<table>_partner_wide_select` (W01) grants the read directly and W02 populates
+ * `breeze.current_partner_id` on agent contexts. There is nothing left to
+ * unit-test about it — the guarantee now lives in Postgres, so its regression
+ * gates are the RLS/integration suites
+ * (`__tests__/integration/configPolicyPartnerWideSelect.integration.test.ts`,
+ * `agentPolicyResolversPartnerWide.integration.test.ts`) and the mocked
+ * no-escape assertions in `routes/agents/helpers.partnerWidePolicies.test.ts`.
  *
  * The SQL is compiled with the real PgDialect rather than inspected as an AST —
  * a regression that drops the partner branch changes the compiled text and the
@@ -15,24 +22,22 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { PgDialect } from 'drizzle-orm/pg-core';
 
-const { getCurrentDbAccessContextMock, runOutsideDbContextMock, withSystemDbAccessContextMock } =
-  vi.hoisted(() => ({
-    getCurrentDbAccessContextMock: vi.fn<
-      () => { scope: string; accessiblePartnerIds?: string[] | null } | undefined
-    >(() => undefined),
-    runOutsideDbContextMock: vi.fn(<T>(fn: () => T): T => fn()),
-    withSystemDbAccessContextMock: vi.fn(async <T>(fn: () => Promise<T>): Promise<T> => fn()),
-  }));
+const { getCurrentDbAccessContextMock } = vi.hoisted(() => ({
+  getCurrentDbAccessContextMock: vi.fn<
+    () => { scope: string; accessiblePartnerIds?: string[] | null } | undefined
+  >(() => undefined),
+}));
 
+// Deliberately a MINIMAL db mock. `runOutsideDbContext` / `withSystemDbAccessContext`
+// are absent, so if this module ever reintroduces a system-context escape the
+// import fails loudly with "No <name> export is defined on the mock" instead of
+// silently escaping again (#4673 W03).
 vi.mock('../db', () => ({
   getCurrentDbAccessContext: getCurrentDbAccessContextMock,
-  runOutsideDbContext: runOutsideDbContextMock,
-  withSystemDbAccessContext: withSystemDbAccessContextMock,
 }));
 
 import {
   policyOwnershipCondition,
-  withPartnerWideVisibility,
   withDevicePartnerPolicyVisibility,
 } from './configPolicyOwnership';
 
@@ -79,49 +84,6 @@ describe('policyOwnershipCondition', () => {
     expect(sql).not.toMatch(/IS NULL/i);
     expect(sql).not.toMatch(/partner_id/i);
     expect(params).toEqual([ORG_ID]);
-  });
-});
-
-describe('withPartnerWideVisibility', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    getCurrentDbAccessContextMock.mockReturnValue(undefined);
-  });
-
-  it('escapes to a system context when the caller is org-scoped', async () => {
-    getCurrentDbAccessContextMock.mockReturnValue({ scope: 'organization' });
-
-    await expect(withPartnerWideVisibility(async () => 'rows')).resolves.toBe('rows');
-
-    expect(runOutsideDbContextMock).toHaveBeenCalledTimes(1);
-    expect(withSystemDbAccessContextMock).toHaveBeenCalledTimes(1);
-  });
-
-  it('escapes when there is no ambient context at all', async () => {
-    getCurrentDbAccessContextMock.mockReturnValue(undefined);
-
-    await withPartnerWideVisibility(async () => null);
-
-    expect(withSystemDbAccessContextMock).toHaveBeenCalledTimes(1);
-  });
-
-  it('is a no-op when already system-scoped — never double-holds a connection (#1105)', async () => {
-    getCurrentDbAccessContextMock.mockReturnValue({ scope: 'system' });
-
-    await expect(withPartnerWideVisibility(async () => 'rows')).resolves.toBe('rows');
-
-    expect(runOutsideDbContextMock).not.toHaveBeenCalled();
-    expect(withSystemDbAccessContextMock).not.toHaveBeenCalled();
-  });
-
-  it('propagates the callback error rather than swallowing it', async () => {
-    getCurrentDbAccessContextMock.mockReturnValue({ scope: 'organization' });
-
-    await expect(
-      withPartnerWideVisibility(async () => {
-        throw new Error('boom');
-      })
-    ).rejects.toThrow('boom');
   });
 });
 

--- a/apps/api/src/services/configPolicyOwnership.ts
+++ b/apps/api/src/services/configPolicyOwnership.ts
@@ -1,36 +1,45 @@
 import { sql, type SQL } from 'drizzle-orm';
 import { configurationPolicies } from '../db/schema';
-import {
-  getCurrentDbAccessContext,
-  runOutsideDbContext,
-  withSystemDbAccessContext,
-} from '../db';
+import { getCurrentDbAccessContext } from '../db';
 import { captureException } from './sentry';
 
 /**
- * The two halves of "a per-device resolver honours partner-wide policies".
+ * The app-layer half of "a per-device resolver honours partner-wide policies".
  *
  * A `configuration_policies` row is either ORG-owned (`org_id` set,
  * `partner_id NULL`) or PARTNER-owned / "partner-wide" (`org_id NULL`,
  * `partner_id` set) — the XOR is enforced by `<table>_one_owner_chk`. Every
- * per-device resolver therefore needs BOTH of the following, and fixing only
- * one of them leaves the feature just as broken:
+ * per-device resolver needs {@link policyOwnershipCondition}: a bare
+ * `eq(configurationPolicies.orgId, device.orgId)` never matches an
+ * `org_id NULL` row, so a partner-wide policy is authorable in the UI and
+ * silently never reaches an agent.
  *
- *  1. {@link policyOwnershipCondition} — the app-layer join predicate. A bare
- *     `eq(configurationPolicies.orgId, device.orgId)` never matches an
- *     `org_id NULL` row, so a partner-wide policy is authorable in the UI and
- *     silently never reaches an agent.
- *  2. {@link withPartnerWideVisibility} — the RLS context. Partner-owned rows
- *     are gated by `breeze_has_partner_access`, and every agent-facing context
- *     (agentAuth, org-scoped user tokens, portal, org-scoped OAuth bearers)
- *     carries `accessiblePartnerIds: []`. Under those the read returns ZERO
- *     ROWS — it does not raise — so a correct predicate still resolves nothing.
+ * The RLS half used to live here too, as `withPartnerWideVisibility` — a
+ * nested `runOutsideDbContext(() => withSystemDbAccessContext(...))` escape
+ * taken because partner-owned rows were gated only by
+ * `breeze_has_partner_access`, which every org-scoped and agent context fails
+ * (`accessiblePartnerIds: []`). **That escape is gone as of #4673 W03.** The
+ * database now grants the read directly: `<table>_partner_wide_select`
+ * (#4673 W01, `2026-10-05-110000-config-policy-partner-wide-select.sql`) adds a
+ * SELECT-ONLY branch `org_id IS NULL AND partner_id =
+ * public.breeze_current_partner_id()` across the whole configuration-policy
+ * chain, and W02 populates `breeze.current_partner_id` on agent contexts as it
+ * already was on every user/bearer/partner-API context. So a resolver running
+ * in the CALLER'S OWN context now sees its own partner's partner-wide rows —
+ * with no second pooled connection (the #1105 starvation shape) and no
+ * RLS bypass (the #2417 cross-tenant shape).
+ *
+ * Consequence for new code: **do not reintroduce a system-context escape for
+ * partner-wide config reads.** If a partner-wide row is invisible, the cause is
+ * a missing `currentPartnerId` on the DbAccessContext or a table that never got
+ * a `*_partner_wide_select` policy — fix that, not the caller.
  *
  * Extracted here (issue #2930) because the predicate had been re-derived inline
  * in four places and three of the five agent resolvers had drifted back to the
- * org-only form. Siblings: `readWithPartnerAxisVisibility` (`db/partnerAxisRead.ts`)
- * does the same job for partner-AXIS tables; this module is the config-policy
- * partner-WIDE equivalent.
+ * org-only form. Sibling: `readWithPartnerAxisVisibility`
+ * (`db/partnerAxisRead.ts`) still escapes, but for partner-AXIS tables
+ * (`partners`, `PARTNER_TENANT_TABLES`), which have no `org_id IS NULL` branch
+ * to grant — a different problem, tracked by #2822.
  */
 
 /** The owning org + partner of the device a policy is being resolved for. */
@@ -58,52 +67,34 @@ export function policyOwnershipCondition(owner: ConfigPolicyOwner): SQL {
   return sql`${configurationPolicies.orgId} = ${owner.orgId}`;
 }
 
-/**
- * Run a config-policy lookup where partner-wide rows must be visible.
- *
- * Wrap ONLY the policy join. Device/site/group reads belong in the caller's own
- * context so RLS keeps gating which devices a caller may see; the policy join
- * is self-tenanted by the device hierarchy already resolved there.
- *
- * AVAILABILITY: the escape is taken only when it is actually needed. A caller
- * that is already system-scoped gains nothing and would double-hold pooled
- * connections — `withDbAccessContext` pins one connection for its whole
- * callback, and the nested `withSystemDbAccessContext` opens a SECOND
- * transaction on a SECOND connection. Against the 25-connection US ceiling,
- * with no acquire timeout in postgres-js, that is the #1105 self-deadlock
- * shape. Hot paths (the agent heartbeat) should additionally hoist the whole
- * resolve out of the org transaction so this escape has nothing to double-hold;
- * it then degrades to the single system context it opens itself.
- *
- * The three `db` imports are NAMED on purpose: a unit suite whose
- * `vi.mock('../db')` factory omits one fails loudly with "No <name> export is
- * defined on the mock" rather than silently skipping the escape.
- */
-export async function withPartnerWideVisibility<T>(fn: () => Promise<T>): Promise<T> {
-  if (getCurrentDbAccessContext()?.scope === 'system') return fn();
-  return runOutsideDbContext(() => withSystemDbAccessContext(fn));
-}
-
 /** Minimal shape of a drizzle executor this module needs: `db` or an open `tx`. */
 export interface PartnerVisibilityExecutor {
   execute(query: SQL): Promise<unknown>;
 }
 
 /**
- * The SAME-CONNECTION variant of {@link withPartnerWideVisibility}, for resolvers
- * that must run their policy join through a CALLER-SUPPLIED executor (#3493).
+ * Widen partner visibility IN PLACE on a CALLER-SUPPLIED executor (#3493).
  *
- * `withPartnerWideVisibility` escapes by opening a fresh system context, which
- * means a fresh transaction on a SECOND pooled connection. That is fine when the
- * read runs on the ambient `db`, but it is wrong — silently, in the worst
- * direction — when the caller passed an open `tx`:
+ * Kept after #4673 W03 removed the system-context escapes, because this one is
+ * a different mechanism solving a different problem. The removed escape opened
+ * a fresh system context — a fresh transaction on a SECOND pooled connection —
+ * which is wrong, silently and in the worst direction, when the caller passed
+ * an open `tx`:
  *
  *  - the second connection cannot see the tx's UNCOMMITTED rows, so a
  *    preview/diff that inserted proposed assignments would resolve as if they
  *    did not exist; and
- *  - wrapping `withPartnerWideVisibility(() => tx.select()...)` does not even
- *    retarget the query — `tx` is bound to its own connection, so the escape
- *    becomes a no-op that merely double-holds a connection.
+ *  - wrapping an escape around `tx.select()...` does not even retarget the
+ *    query — `tx` is bound to its own connection, so the escape becomes a
+ *    no-op that merely double-holds a connection.
+ *
+ * SCOPE NOTE (#4673): for the configuration-policy chain specifically, the
+ * `*_partner_wide_select` RLS branch now makes partner-wide rows legible to the
+ * caller's own context without any widening, so this helper is largely
+ * redundant there. It is NOT redundant in general — it widens
+ * `breeze.accessible_partner_ids`, which admits partner-AXIS rows the
+ * SELECT-only branch never grants — so removing it is a separate, reviewable
+ * change and deliberately out of W03's scope.
  *
  * So instead of switching connections, this widens visibility IN PLACE on the
  * caller's own transaction, and by the smallest possible amount: it appends

--- a/apps/api/src/services/configurationPolicy.ts
+++ b/apps/api/src/services/configurationPolicy.ts
@@ -1,4 +1,4 @@
-import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { db } from '../db';
 import { readWithPartnerAxisVisibility } from '../db/partnerAxisRead';
 import { withDevicePartnerPolicyVisibility } from './configPolicyOwnership';
 import {
@@ -1871,13 +1871,20 @@ async function resolveEffectiveConfigWithExecutor(
   // join returns ZERO partner-wide policies, which is exactly the "partner-wide
   // policy never reaches the device" symptom.
   //
-  // The SAME-CONNECTION variant is required here, not `withPartnerWideVisibility`:
+  // The SAME-CONNECTION widening is required here, not a system-context escape:
   // `executor` is a transaction on the preview/diff path, and a system escape
   // would run on a different connection that cannot see that transaction's
   // uncommitted proposed assignments. `org.partnerId` was read one step above
   // under the CALLER's own RLS context, so this widens by exactly the device's
   // own partner and nothing else. Steps 1-3 stay in the caller's context on
   // purpose — they are the tenancy boundary.
+  //
+  // #4673 W03 note: the `*_partner_wide_select` branches would now cover this
+  // read on their own for callers whose context carries `currentPartnerId`.
+  // The widening is kept because it is not equivalent — it also admits
+  // partner-AXIS rows, and it is what makes the contract hold for a
+  // hand-built context that omits `currentPartnerId`. Retiring it is a
+  // separate, reviewable change.
   const rows = await withDevicePartnerPolicyVisibility(
     executor,
     org?.partnerId ?? null,
@@ -2110,25 +2117,31 @@ export const PARTNER_LINKABLE_FEATURE_TYPES: ReadonlySet<ConfigFeatureType> = ne
  * backup_configs destination id). Routes use this to pick the right inline
  * settings schema for backup links.
  *
- * Pure existence probe, deliberately run in a system context: a PARTNER-WIDE
- * profile is RLS-invisible to an org-scoped token, so under the caller's context
- * an org admin linking one would have it misclassified as a legacy destination
- * id and rejected with a nonsense error. Tenancy of the link is enforced
- * separately by validateFeaturePolicyExists, which matches on the owner axis.
+ * Existence probe, run in the CALLER'S OWN context (#4673 W03). It used to
+ * escape to a system context because a PARTNER-WIDE profile (org_id NULL) was
+ * RLS-invisible to an org-scoped token, so an org admin linking one would have
+ * it misclassified as a legacy destination id and rejected with a nonsense
+ * error. `backup_profiles_partner_wide_select` (W01) now grants that read to the
+ * profile's own partner, and `breeze.current_partner_id` is set on every user,
+ * bearer and partner-API context — so the escape is no longer needed.
+ *
+ * Deliberate TIGHTENING: escaped, this probe saw EVERY tenant's profiles and
+ * relied on validateFeaturePolicyExists to re-tenant the link. Under the
+ * caller's own context a FOREIGN partner's profile now reads as absent, so the
+ * id falls through to the legacy-destination branch and
+ * validateFeaturePolicyExists rejects it — the same outcome, reached one step
+ * earlier and without an RLS bypass. Tenancy of the link is still enforced
+ * there, on the owner axis; this probe only picks the inline settings schema.
  */
 export async function isBackupProfileReference(
   featurePolicyId: string | null | undefined
 ): Promise<boolean> {
   if (!featurePolicyId) return false;
-  const [row] = await runOutsideDbContext(() =>
-    withSystemDbAccessContext(() =>
-      db
-        .select({ id: backupProfiles.id })
-        .from(backupProfiles)
-        .where(eq(backupProfiles.id, featurePolicyId))
-        .limit(1)
-    )
-  );
+  const [row] = await db
+    .select({ id: backupProfiles.id })
+    .from(backupProfiles)
+    .where(eq(backupProfiles.id, featurePolicyId))
+    .limit(1);
   return !!row;
 }
 
@@ -2197,35 +2210,34 @@ export async function validateFeaturePolicyExists(
         sql`(${backupProfiles.orgId} IS NULL AND ${backupProfiles.partnerId} = ${partnerId})`
       );
     }
-    // Both lookups are self-tenanted by the owner axis above, and run in a
-    // system context: a partner-wide profile (org_id NULL) is RLS-invisible to
-    // an org-scoped token, so validating in the caller's context would reject a
+    // Both lookups run in the CALLER'S OWN context (#4673 W03) and are
+    // self-tenanted by the owner axis above. They used to escape to a system
+    // context because a partner-wide profile (org_id NULL) was RLS-invisible to
+    // an org-scoped token, so validating in the caller's context rejected a
     // legitimate org-policy → partner-wide-profile link as "not found".
+    // `backup_profiles_partner_wide_select` (W01) grants exactly that read to
+    // the profile's own partner, which is the only partner these conditions can
+    // name: `owner.partnerId` comes from the config policy the caller already
+    // loaded under RLS, or from that policy's org via resolvePartnerIdForOrg.
+    // `backup_configs` is org-only and needs no branch — the org-equality
+    // condition already matches what breeze_has_org_access admits.
     if (profileConditions.length > 0) {
-      const [profile] = await runOutsideDbContext(() =>
-        withSystemDbAccessContext(() =>
-          db
-            .select({ id: backupProfiles.id })
-            .from(backupProfiles)
-            .where(and(eq(backupProfiles.id, featurePolicyId), or(...profileConditions)))
-            .limit(1)
-        )
-      );
+      const [profile] = await db
+        .select({ id: backupProfiles.id })
+        .from(backupProfiles)
+        .where(and(eq(backupProfiles.id, featurePolicyId), or(...profileConditions)))
+        .limit(1);
       if (profile) {
         return { valid: true };
       }
     }
     const ownerOrgId = owner.orgId;
     if (ownerOrgId) {
-      const [config] = await runOutsideDbContext(() =>
-        withSystemDbAccessContext(() =>
-          db
-            .select({ id: backupConfigs.id })
-            .from(backupConfigs)
-            .where(and(eq(backupConfigs.id, featurePolicyId), eq(backupConfigs.orgId, ownerOrgId)))
-            .limit(1)
-        )
-      );
+      const [config] = await db
+        .select({ id: backupConfigs.id })
+        .from(backupConfigs)
+        .where(and(eq(backupConfigs.id, featurePolicyId), eq(backupConfigs.orgId, ownerOrgId)))
+        .limit(1);
       if (config) {
         return { valid: true };
       }

--- a/apps/api/src/services/featureConfigResolver.backupAssignments.test.ts
+++ b/apps/api/src/services/featureConfigResolver.backupAssignments.test.ts
@@ -343,21 +343,25 @@ describe('resolveAllBackupAssignedDevices tenancy scoping', () => {
     const result = await resolveAllBackupAssignedDevices(orgId);
 
     expect(result).toHaveLength(1);
-    // TWO escapes, not one (#2822): the config-policy join, plus the single
-    // context that wraps the whole timezone fan-out (resolveDeviceTimezone's
-    // `partners` join is partner-axis and was silently resolving to UTC for
-    // org-scoped callers). Never 1 + N — see the two-device test below.
-    expect(dbMock.withSystemDbAccessContext).toHaveBeenCalledTimes(2);
-    expect(dbMock.runOutsideDbContext).toHaveBeenCalledTimes(2);
+    // ONE escape, down from two (#4673 W03). The config-policy join no longer
+    // escapes: `<table>_partner_wide_select` grants partner-wide rows to the
+    // caller's own context, so the only remaining system context is the single
+    // one wrapping the timezone fan-out (resolveDeviceTimezone's `partners`
+    // join is partner-AXIS, which no SELECT-only branch covers — see
+    // db/partnerAxisRead.ts and #2822). Never 1 + N — see the two-device test
+    // below.
+    expect(dbMock.withSystemDbAccessContext).toHaveBeenCalledTimes(1);
+    expect(dbMock.runOutsideDbContext).toHaveBeenCalledTimes(1);
     // Exact topology, asserted as a whole array rather than by index: a
     // `.slice(...).every(...)` goes vacuously true if a select is ever removed,
     // which would silently retire this guard.
-    // #0 org→partner lookup | #1 config-policy join (SYSTEM) | #2 org default
-    // destination | #3 device expansion | #4 the batch org lookup | #5 the ONE
-    // shared partners read (SYSTEM) | #6 the per-device site/org read.
-    // Everything except the two partner-axis reads is caller-scoped — device
-    // EXPANSION (#3) especially, since that is the read RLS must keep guarding.
-    expect(selectDepths).toEqual([0, 1, 0, 0, 0, 1, 0]);
+    // #0 org→partner lookup | #1 config-policy join (CALLER — W03) | #2 org
+    // default destination | #3 device expansion | #4 the batch org lookup |
+    // #5 the ONE shared partners read (SYSTEM) | #6 the per-device site/org
+    // read. Everything except the partner-AXIS read is caller-scoped — device
+    // EXPANSION (#3) especially, since that is the read RLS must keep guarding,
+    // and now the config-policy join (#1) too.
+    expect(selectDepths).toEqual([0, 0, 0, 0, 0, 1, 0]);
     expect(systemStats.maxDepth).toBe(1);
     // Context must be closed again once the read completes.
     expect(systemDepth.value).toBe(0);
@@ -423,23 +427,24 @@ describe('resolveAllBackupAssignedDevices tenancy scoping', () => {
     const result = await resolveAllBackupAssignedDevices(orgId);
 
     expect(result).toHaveLength(2);
-    // Still 2 with two devices — the count does not scale with N. Pre-fix this
-    // was 3 (1 policy join + 1 per device) and would keep climbing. The partner
-    // timezone is now resolved once for the whole batch, so there is also only
-    // ONE `partners` read rather than N identical ones.
-    expect(dbMock.withSystemDbAccessContext).toHaveBeenCalledTimes(2);
-    expect(dbMock.runOutsideDbContext).toHaveBeenCalledTimes(2);
+    // Still 1 with two devices — the count does not scale with N. It was 3
+    // (1 policy join + 1 per device) before the timezone batching, 2 after it,
+    // and 1 since #4673 W03 dropped the policy join's escape. The partner
+    // timezone is resolved once for the whole batch, so there is exactly ONE
+    // `partners` read rather than N identical ones.
+    expect(dbMock.withSystemDbAccessContext).toHaveBeenCalledTimes(1);
+    expect(dbMock.runOutsideDbContext).toHaveBeenCalledTimes(1);
     // The real assertion: never more than one system transaction — and
     // therefore never more than one extra pooled connection — at any instant.
     expect(systemStats.maxDepth).toBe(1);
-    // #0 org→partner | #1 policy join (SYSTEM) | #2 org default destination |
-    // #3 device expansion (CALLER — the read RLS must keep guarding) | #4 the
-    // batch org lookup | #5 the ONE shared partners read (SYSTEM) | #6,#7 the
-    // per-device site/org reads (CALLER).
+    // #0 org→partner | #1 policy join (CALLER — W03) | #2 org default
+    // destination | #3 device expansion (CALLER — the read RLS must keep
+    // guarding) | #4 the batch org lookup | #5 the ONE shared partners read
+    // (SYSTEM) | #6,#7 the per-device site/org reads (CALLER).
     //
     // The key property: exactly ONE depth-1 select in the timezone tail no
     // matter how many devices there are. Pre-fix this was one per device.
-    expect(selectDepths.slice(0, 4)).toEqual([0, 1, 0, 0]);
+    expect(selectDepths.slice(0, 4)).toEqual([0, 0, 0, 0]);
     expect(selectDepths.slice(4).filter((d) => d === 1)).toHaveLength(1);
     expect(systemDepth.value).toBe(0);
   });
@@ -473,7 +478,7 @@ describe('resolveBackupConfigForDevice partner-wide visibility', () => {
       )
       .mockReturnValueOnce(makeSelectChain([{ partnerId: 'partner-1' }]))
       .mockReturnValueOnce(makeSelectChain([]))
-      // the config-policy join (must be system-scoped)
+      // the config-policy join (runs in the CALLER's context since W03)
       .mockReturnValueOnce(
         makeSelectChain([
           {
@@ -502,15 +507,17 @@ describe('resolveBackupConfigForDevice partner-wide visibility', () => {
     const resolved = await resolveBackupConfigForDevice('device-1');
 
     expect(resolved).toMatchObject({ featureLinkId: 'feature-1', configId: 'config-1' });
-    // Two escapes: the policy join and resolveDeviceTimezone's partner-axis
-    // read (#2822), taken one after the other — never nested.
-    expect(dbMock.withSystemDbAccessContext).toHaveBeenCalledTimes(2);
-    expect(dbMock.runOutsideDbContext).toHaveBeenCalledTimes(2);
+    // ONE escape: resolveDeviceTimezone's partner-AXIS read (#2822). The policy
+    // join no longer takes one — #4673 W03 removed it once
+    // `<table>_partner_wide_select` made partner-wide rows legible to the
+    // caller's own context.
+    expect(dbMock.withSystemDbAccessContext).toHaveBeenCalledTimes(1);
+    expect(dbMock.runOutsideDbContext).toHaveBeenCalledTimes(1);
     expect(systemStats.maxDepth).toBe(1);
-    // 0-2 device hierarchy (caller) | 3 policy join (system) | 4 timezone
+    // 0-2 device hierarchy (caller) | 3 policy join (CALLER — W03) | 4 timezone
     // device/org/site read (CALLER — RLS still selects the device) | 5 the
     // partner-axis read (system).
-    expect(selectDepths).toEqual([0, 0, 0, 1, 0, 1]);
+    expect(selectDepths).toEqual([0, 0, 0, 0, 0, 1]);
     expect(systemDepth.value).toBe(0);
   });
 });

--- a/apps/api/src/services/featureConfigResolver.ts
+++ b/apps/api/src/services/featureConfigResolver.ts
@@ -1,6 +1,6 @@
 import { db } from '../db';
 import { readWithPartnerAxisVisibility } from '../db/partnerAxisRead';
-import { policyOwnershipCondition, withPartnerWideVisibility } from './configPolicyOwnership';
+import { policyOwnershipCondition } from './configPolicyOwnership';
 import {
   configurationPolicies,
   configPolicyFeatureLinks,
@@ -257,10 +257,10 @@ export type GoverningAlertRulePolicy =
  * hierarchy sort (level, then assignment priority, then age) picks the winner.
  * Assignment status, ownership, and the role/OS filters are unchanged.
  *
- * Runs under {@link withPartnerWideVisibility} (a system RLS context) like every
- * sibling resolver, so it is NOT a tenancy boundary: it is self-tenanted by the
- * device's own hierarchy, and the caller must have already authorized both the
- * device and the candidate policy.
+ * Runs in the CALLER'S OWN RLS context like every sibling resolver (#4673 W03 —
+ * the former system-context escape is gone). It is NOT a tenancy boundary: it is
+ * self-tenanted by the device's own hierarchy, and the caller must have already
+ * authorized both the device and the candidate policy.
  */
 export async function resolveGoverningAlertRulePolicyForDevice(
   deviceId: string,
@@ -272,72 +272,71 @@ export async function resolveGoverningAlertRulePolicyForDevice(
   const targetConditions = buildTargetConditions(hierarchy);
   const roleOsConditions = buildRoleOsFilterConditions(hierarchy);
 
-  // Both reads share one elevated context: splitting them would run the second
-  // under the caller's RLS, where a partner-wide policy is invisible and its
-  // rules would look absent.
-  return withPartnerWideVisibility(async () => {
-    const assigned = await db
-      .select({
-        configPolicyId: configurationPolicies.id,
-        assignmentLevel: configPolicyAssignments.level,
-        assignmentPriority: configPolicyAssignments.priority,
-        assignmentCreatedAt: configPolicyAssignments.createdAt,
-      })
-      .from(configPolicyAssignments)
-      .innerJoin(
-        configurationPolicies,
-        and(
-          eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
-          eq(configurationPolicies.status, 'active'),
-          policyOwnershipCondition(hierarchy)
-        )
+  // Both reads run in the CALLER'S OWN context (#4673 W03). Partner-wide rows
+  // are legible there through the `*_partner_wide_select` RLS branch, so the
+  // former system-context escape is gone — no second pooled connection, no RLS
+  // bypass. Self-tenanted by this device's own hierarchy either way.
+  const assigned = await db
+    .select({
+      configPolicyId: configurationPolicies.id,
+      assignmentLevel: configPolicyAssignments.level,
+      assignmentPriority: configPolicyAssignments.priority,
+      assignmentCreatedAt: configPolicyAssignments.createdAt,
+    })
+    .from(configPolicyAssignments)
+    .innerJoin(
+      configurationPolicies,
+      and(
+        eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
+        eq(configurationPolicies.status, 'active'),
+        policyOwnershipCondition(hierarchy)
       )
-      .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
-      // sortByHierarchy re-sorts in JS, but ordering here too pins the outcome
-      // of a genuine three-way tie (same level, priority AND createdAt), which
-      // unordered Postgres output would otherwise decide arbitrarily. Matches
-      // resolveAlertRulesForDevice.
-      .orderBy(
-        configPolicyAssignments.level,
-        configPolicyAssignments.priority,
-        configPolicyAssignments.createdAt
-      );
-
-    if (!assigned.some((row) => row.configPolicyId === candidatePolicyId)) {
-      return { outcome: 'unassigned' };
-    }
-
-    // Which of the assigned policies actually hold alert rules today. The
-    // candidate is exempt: its rules are the draft being tested.
-    const policyIdsWithRules = await db
-      .select({ configPolicyId: configPolicyFeatureLinks.configPolicyId })
-      .from(configPolicyFeatureLinks)
-      .innerJoin(
-        configPolicyAlertRules,
-        eq(configPolicyAlertRules.featureLinkId, configPolicyFeatureLinks.id)
-      )
-      .where(
-        and(
-          eq(configPolicyFeatureLinks.featureType, 'alert_rule'),
-          inArray(
-            configPolicyFeatureLinks.configPolicyId,
-            [...new Set(assigned.map((row) => row.configPolicyId))]
-          )
-        )
-      );
-    const haveRules = new Set(policyIdsWithRules.map((row) => row.configPolicyId));
-
-    // The candidate is always a contender here — it is assigned, and its draft
-    // counts as a rule — so `contenders` can never be empty at this point.
-    const contenders = assigned.filter(
-      (row) => row.configPolicyId === candidatePolicyId || haveRules.has(row.configPolicyId)
+    )
+    .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
+    // sortByHierarchy re-sorts in JS, but ordering here too pins the outcome
+    // of a genuine three-way tie (same level, priority AND createdAt), which
+    // unordered Postgres output would otherwise decide arbitrarily. Matches
+    // resolveAlertRulesForDevice.
+    .orderBy(
+      configPolicyAssignments.level,
+      configPolicyAssignments.priority,
+      configPolicyAssignments.createdAt
     );
-    const winningPolicyId = sortByHierarchy(contenders)[0]!.configPolicyId;
 
-    return winningPolicyId === candidatePolicyId
-      ? { outcome: 'governs' }
-      : { outcome: 'outranked', winningPolicyId };
-  });
+  if (!assigned.some((row) => row.configPolicyId === candidatePolicyId)) {
+    return { outcome: 'unassigned' };
+  }
+
+  // Which of the assigned policies actually hold alert rules today. The
+  // candidate is exempt: its rules are the draft being tested.
+  const policyIdsWithRules = await db
+    .select({ configPolicyId: configPolicyFeatureLinks.configPolicyId })
+    .from(configPolicyFeatureLinks)
+    .innerJoin(
+      configPolicyAlertRules,
+      eq(configPolicyAlertRules.featureLinkId, configPolicyFeatureLinks.id)
+    )
+    .where(
+      and(
+        eq(configPolicyFeatureLinks.featureType, 'alert_rule'),
+        inArray(
+          configPolicyFeatureLinks.configPolicyId,
+          [...new Set(assigned.map((row) => row.configPolicyId))]
+        )
+      )
+    );
+  const haveRules = new Set(policyIdsWithRules.map((row) => row.configPolicyId));
+
+  // The candidate is always a contender here — it is assigned, and its draft
+  // counts as a rule — so `contenders` can never be empty at this point.
+  const contenders = assigned.filter(
+    (row) => row.configPolicyId === candidatePolicyId || haveRules.has(row.configPolicyId)
+  );
+  const winningPolicyId = sortByHierarchy(contenders)[0]!.configPolicyId;
+
+  return winningPolicyId === candidatePolicyId
+    ? { outcome: 'governs' }
+    : { outcome: 'outranked', winningPolicyId };
 }
 
 /**
@@ -353,48 +352,48 @@ export async function resolveAlertRulesForDevice(
   const targetConditions = buildTargetConditions(hierarchy);
   const roleOsConditions = buildRoleOsFilterConditions(hierarchy);
 
-  // #2930 — the ownership predicate below already admits partner-owned rows,
-  // but under an org-scoped RLS context those rows are invisible and the join
-  // silently returns nothing. Self-tenanted by this device's own hierarchy.
-  const rows = await withPartnerWideVisibility(() =>
-    db
-      .select({
-        alertRule: configPolicyAlertRules,
-        assignmentLevel: configPolicyAssignments.level,
-        assignmentPriority: configPolicyAssignments.priority,
-        assignmentCreatedAt: configPolicyAssignments.createdAt,
-        assignmentId: configPolicyAssignments.id,
-      })
-      .from(configPolicyAssignments)
-      .innerJoin(
-        configurationPolicies,
-        and(
-          eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
-          eq(configurationPolicies.status, 'active'),
-          policyOwnershipCondition(hierarchy)
-        )
+  // #2930 — the ownership predicate below admits partner-owned rows; #4673 W01
+  // makes RLS agree, via the SELECT-only `*_partner_wide_select` branch keyed on
+  // breeze_current_partner_id(). So this runs in the CALLER'S OWN context (W03
+  // deleted the system-context escape). Self-tenanted by this device's own
+  // hierarchy on top of RLS.
+  const rows = await db
+    .select({
+      alertRule: configPolicyAlertRules,
+      assignmentLevel: configPolicyAssignments.level,
+      assignmentPriority: configPolicyAssignments.priority,
+      assignmentCreatedAt: configPolicyAssignments.createdAt,
+      assignmentId: configPolicyAssignments.id,
+    })
+    .from(configPolicyAssignments)
+    .innerJoin(
+      configurationPolicies,
+      and(
+        eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
+        eq(configurationPolicies.status, 'active'),
+        policyOwnershipCondition(hierarchy)
       )
-      .innerJoin(
-        configPolicyFeatureLinks,
-        and(
-          eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
-          // Server-evaluated rules live exclusively under alert_rule links since the
-          // 2026-07-30 ownership consolidation migration.
-          eq(configPolicyFeatureLinks.featureType, 'alert_rule')
-        )
+    )
+    .innerJoin(
+      configPolicyFeatureLinks,
+      and(
+        eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
+        // Server-evaluated rules live exclusively under alert_rule links since the
+        // 2026-07-30 ownership consolidation migration.
+        eq(configPolicyFeatureLinks.featureType, 'alert_rule')
       )
-      .innerJoin(
-        configPolicyAlertRules,
-        eq(configPolicyAlertRules.featureLinkId, configPolicyFeatureLinks.id)
-      )
-      .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
-      .orderBy(
-        configPolicyAssignments.level,
-        configPolicyAssignments.priority,
-        configPolicyAssignments.createdAt,
-        asc(configPolicyAlertRules.sortOrder)
-      )
-  );
+    )
+    .innerJoin(
+      configPolicyAlertRules,
+      eq(configPolicyAlertRules.featureLinkId, configPolicyFeatureLinks.id)
+    )
+    .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
+    .orderBy(
+      configPolicyAssignments.level,
+      configPolicyAssignments.priority,
+      configPolicyAssignments.createdAt,
+      asc(configPolicyAlertRules.sortOrder)
+    );
 
   if (rows.length === 0) return [];
 
@@ -421,46 +420,46 @@ export async function resolveAutomationsForDevice(
   const targetConditions = buildTargetConditions(hierarchy);
   const roleOsConditions = buildRoleOsFilterConditions(hierarchy);
 
-  // #2930 — the ownership predicate below already admits partner-owned rows,
-  // but under an org-scoped RLS context those rows are invisible and the join
-  // silently returns nothing. Self-tenanted by this device's own hierarchy.
-  const rows = await withPartnerWideVisibility(() =>
-    db
-      .select({
-        automation: configPolicyAutomations,
-        assignmentLevel: configPolicyAssignments.level,
-        assignmentPriority: configPolicyAssignments.priority,
-        assignmentCreatedAt: configPolicyAssignments.createdAt,
-        assignmentId: configPolicyAssignments.id,
-      })
-      .from(configPolicyAssignments)
-      .innerJoin(
-        configurationPolicies,
-        and(
-          eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
-          eq(configurationPolicies.status, 'active'),
-          policyOwnershipCondition(hierarchy)
-        )
+  // #2930 — the ownership predicate below admits partner-owned rows; #4673 W01
+  // makes RLS agree, via the SELECT-only `*_partner_wide_select` branch keyed on
+  // breeze_current_partner_id(). So this runs in the CALLER'S OWN context (W03
+  // deleted the system-context escape). Self-tenanted by this device's own
+  // hierarchy on top of RLS.
+  const rows = await db
+    .select({
+      automation: configPolicyAutomations,
+      assignmentLevel: configPolicyAssignments.level,
+      assignmentPriority: configPolicyAssignments.priority,
+      assignmentCreatedAt: configPolicyAssignments.createdAt,
+      assignmentId: configPolicyAssignments.id,
+    })
+    .from(configPolicyAssignments)
+    .innerJoin(
+      configurationPolicies,
+      and(
+        eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
+        eq(configurationPolicies.status, 'active'),
+        policyOwnershipCondition(hierarchy)
       )
-      .innerJoin(
-        configPolicyFeatureLinks,
-        and(
-          eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
-          eq(configPolicyFeatureLinks.featureType, 'automation')
-        )
+    )
+    .innerJoin(
+      configPolicyFeatureLinks,
+      and(
+        eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
+        eq(configPolicyFeatureLinks.featureType, 'automation')
       )
-      .innerJoin(
-        configPolicyAutomations,
-        eq(configPolicyAutomations.featureLinkId, configPolicyFeatureLinks.id)
-      )
-      .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
-      .orderBy(
-        configPolicyAssignments.level,
-        configPolicyAssignments.priority,
-        configPolicyAssignments.createdAt,
-        asc(configPolicyAutomations.sortOrder)
-      )
-  );
+    )
+    .innerJoin(
+      configPolicyAutomations,
+      eq(configPolicyAutomations.featureLinkId, configPolicyFeatureLinks.id)
+    )
+    .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
+    .orderBy(
+      configPolicyAssignments.level,
+      configPolicyAssignments.priority,
+      configPolicyAssignments.createdAt,
+      asc(configPolicyAutomations.sortOrder)
+    );
 
   if (rows.length === 0) return [];
 
@@ -646,52 +645,50 @@ export async function resolvePatchConfigDetailsForDevice(
   const roleOsConditions = buildRoleOsFilterConditions(hierarchy);
 
   // #2930 — the ownership predicate below already admits partner-owned rows,
-  // but under an org-scoped RLS context (the agent heartbeat, an org user
-  // token) those rows are invisible and the join silently returns nothing.
-  // Self-tenanted by this device's own hierarchy, so the escape cannot pivot
-  // tenants. Callers on hot paths hoist the whole resolve out of their org
-  // transaction so this opens no second connection.
-  const rows = await withPartnerWideVisibility(() =>
-    db
-      .select({
-        patchSettings: configPolicyPatchSettings,
-        featureLinkId: configPolicyFeatureLinks.id,
-        configPolicyId: configurationPolicies.id,
-        configPolicyName: configurationPolicies.name,
-        featurePolicyId: configPolicyFeatureLinks.featurePolicyId,
-        assignmentTargetId: configPolicyAssignments.targetId,
-        assignmentLevel: configPolicyAssignments.level,
-        assignmentPriority: configPolicyAssignments.priority,
-        assignmentCreatedAt: configPolicyAssignments.createdAt,
-        assignmentId: configPolicyAssignments.id,
-      })
-      .from(configPolicyAssignments)
-      .innerJoin(
-        configurationPolicies,
-        and(
-          eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
-          eq(configurationPolicies.status, 'active'),
-          policyOwnershipCondition(hierarchy)
-        )
+  // and #4673 W01 makes RLS agree via the SELECT-only `*_partner_wide_select`
+  // branch keyed on breeze_current_partner_id(), which W02 populates on agent
+  // contexts. So this runs in the CALLER'S OWN context (the agent heartbeat, an
+  // org user token) with no second pooled connection — W03 deleted the escape.
+  // Self-tenanted by this device's own hierarchy on top of RLS.
+  const rows = await db
+    .select({
+      patchSettings: configPolicyPatchSettings,
+      featureLinkId: configPolicyFeatureLinks.id,
+      configPolicyId: configurationPolicies.id,
+      configPolicyName: configurationPolicies.name,
+      featurePolicyId: configPolicyFeatureLinks.featurePolicyId,
+      assignmentTargetId: configPolicyAssignments.targetId,
+      assignmentLevel: configPolicyAssignments.level,
+      assignmentPriority: configPolicyAssignments.priority,
+      assignmentCreatedAt: configPolicyAssignments.createdAt,
+      assignmentId: configPolicyAssignments.id,
+    })
+    .from(configPolicyAssignments)
+    .innerJoin(
+      configurationPolicies,
+      and(
+        eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
+        eq(configurationPolicies.status, 'active'),
+        policyOwnershipCondition(hierarchy)
       )
-      .innerJoin(
-        configPolicyFeatureLinks,
-        and(
-          eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
-          eq(configPolicyFeatureLinks.featureType, 'patch')
-        )
+    )
+    .innerJoin(
+      configPolicyFeatureLinks,
+      and(
+        eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
+        eq(configPolicyFeatureLinks.featureType, 'patch')
       )
-      .innerJoin(
-        configPolicyPatchSettings,
-        eq(configPolicyPatchSettings.featureLinkId, configPolicyFeatureLinks.id)
-      )
-      .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
-      .orderBy(
-        configPolicyAssignments.level,
-        configPolicyAssignments.priority,
-        configPolicyAssignments.createdAt
-      )
-  );
+    )
+    .innerJoin(
+      configPolicyPatchSettings,
+      eq(configPolicyPatchSettings.featureLinkId, configPolicyFeatureLinks.id)
+    )
+    .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
+    .orderBy(
+      configPolicyAssignments.level,
+      configPolicyAssignments.priority,
+      configPolicyAssignments.createdAt
+    );
 
   if (rows.length === 0) return null;
 
@@ -736,56 +733,54 @@ export async function resolveBackupConfigForDevice(
 
   // Partner-wide policies + profiles are RLS-invisible to org tokens — resolve
   // them in a system context (self-tenanted by this device's hierarchy).
-  const rows = await withPartnerWideVisibility(() =>
-    db
-      .select({
-        backupSettings: configPolicyBackupSettings,
-        featureLinkId: configPolicyFeatureLinks.id,
-        featurePolicyId: configPolicyFeatureLinks.featurePolicyId,
-        inlineSettings: configPolicyFeatureLinks.inlineSettings,
-        profileSelections: backupProfiles.selections,
-        assignmentLevel: configPolicyAssignments.level,
-        assignmentPriority: configPolicyAssignments.priority,
-        assignmentCreatedAt: configPolicyAssignments.createdAt,
-        assignmentId: configPolicyAssignments.id,
-      })
-      .from(configPolicyAssignments)
-      .innerJoin(
-        configurationPolicies,
-        and(
-          eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
-          eq(configurationPolicies.status, 'active'),
-          policyOwnershipCondition(hierarchy)
-        )
+  const rows = await db
+    .select({
+      backupSettings: configPolicyBackupSettings,
+      featureLinkId: configPolicyFeatureLinks.id,
+      featurePolicyId: configPolicyFeatureLinks.featurePolicyId,
+      inlineSettings: configPolicyFeatureLinks.inlineSettings,
+      profileSelections: backupProfiles.selections,
+      assignmentLevel: configPolicyAssignments.level,
+      assignmentPriority: configPolicyAssignments.priority,
+      assignmentCreatedAt: configPolicyAssignments.createdAt,
+      assignmentId: configPolicyAssignments.id,
+    })
+    .from(configPolicyAssignments)
+    .innerJoin(
+      configurationPolicies,
+      and(
+        eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
+        eq(configurationPolicies.status, 'active'),
+        policyOwnershipCondition(hierarchy)
       )
-      .innerJoin(
-        configPolicyFeatureLinks,
-        and(
-          eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
-          eq(configPolicyFeatureLinks.featureType, 'backup')
-        )
+    )
+    .innerJoin(
+      configPolicyFeatureLinks,
+      and(
+        eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
+        eq(configPolicyFeatureLinks.featureType, 'backup')
       )
-      .leftJoin(
-        configPolicyBackupSettings,
-        eq(configPolicyBackupSettings.featureLinkId, configPolicyFeatureLinks.id)
-      )
-      // Deliberately NOT filtered on backupProfiles.isActive: deactivating a
-      // profile removes it from the pickers (the list API hides inactive rows)
-      // but must NOT silently stop backups on policies that already link it —
-      // that would be a data-protection change disguised as a UI toggle. The
-      // profile editor's helper text states this contract. To stop backups,
-      // unlink the profile or deactivate the policy.
-      .leftJoin(
-        backupProfiles,
-        eq(backupProfiles.id, configPolicyBackupSettings.backupProfileId)
-      )
-      .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
-      .orderBy(
-        configPolicyAssignments.level,
-        configPolicyAssignments.priority,
-        configPolicyAssignments.createdAt
-      )
-  );
+    )
+    .leftJoin(
+      configPolicyBackupSettings,
+      eq(configPolicyBackupSettings.featureLinkId, configPolicyFeatureLinks.id)
+    )
+    // Deliberately NOT filtered on backupProfiles.isActive: deactivating a
+    // profile removes it from the pickers (the list API hides inactive rows)
+    // but must NOT silently stop backups on policies that already link it —
+    // that would be a data-protection change disguised as a UI toggle. The
+    // profile editor's helper text states this contract. To stop backups,
+    // unlink the profile or deactivate the policy.
+    .leftJoin(
+      backupProfiles,
+      eq(backupProfiles.id, configPolicyBackupSettings.backupProfileId)
+    )
+    .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
+    .orderBy(
+      configPolicyAssignments.level,
+      configPolicyAssignments.priority,
+      configPolicyAssignments.createdAt
+    );
 
   if (rows.length === 0) return null;
 
@@ -833,45 +828,45 @@ export async function resolveMaintenanceConfigForDevice(
   const targetConditions = buildTargetConditions(hierarchy);
   const roleOsConditions = buildRoleOsFilterConditions(hierarchy);
 
-  // #2930 — the ownership predicate below already admits partner-owned rows,
-  // but under an org-scoped RLS context those rows are invisible and the join
-  // silently returns nothing. Self-tenanted by this device's own hierarchy.
-  const rows = await withPartnerWideVisibility(() =>
-    db
-      .select({
-        maintenanceSettings: configPolicyMaintenanceSettings,
-        assignmentLevel: configPolicyAssignments.level,
-        assignmentPriority: configPolicyAssignments.priority,
-        assignmentCreatedAt: configPolicyAssignments.createdAt,
-        assignmentId: configPolicyAssignments.id,
-      })
-      .from(configPolicyAssignments)
-      .innerJoin(
-        configurationPolicies,
-        and(
-          eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
-          eq(configurationPolicies.status, 'active'),
-          policyOwnershipCondition(hierarchy)
-        )
+  // #2930 — the ownership predicate below admits partner-owned rows; #4673 W01
+  // makes RLS agree, via the SELECT-only `*_partner_wide_select` branch keyed on
+  // breeze_current_partner_id(). So this runs in the CALLER'S OWN context (W03
+  // deleted the system-context escape). Self-tenanted by this device's own
+  // hierarchy on top of RLS.
+  const rows = await db
+    .select({
+      maintenanceSettings: configPolicyMaintenanceSettings,
+      assignmentLevel: configPolicyAssignments.level,
+      assignmentPriority: configPolicyAssignments.priority,
+      assignmentCreatedAt: configPolicyAssignments.createdAt,
+      assignmentId: configPolicyAssignments.id,
+    })
+    .from(configPolicyAssignments)
+    .innerJoin(
+      configurationPolicies,
+      and(
+        eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
+        eq(configurationPolicies.status, 'active'),
+        policyOwnershipCondition(hierarchy)
       )
-      .innerJoin(
-        configPolicyFeatureLinks,
-        and(
-          eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
-          eq(configPolicyFeatureLinks.featureType, 'maintenance')
-        )
+    )
+    .innerJoin(
+      configPolicyFeatureLinks,
+      and(
+        eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
+        eq(configPolicyFeatureLinks.featureType, 'maintenance')
       )
-      .innerJoin(
-        configPolicyMaintenanceSettings,
-        eq(configPolicyMaintenanceSettings.featureLinkId, configPolicyFeatureLinks.id)
-      )
-      .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
-      .orderBy(
-        configPolicyAssignments.level,
-        configPolicyAssignments.priority,
-        configPolicyAssignments.createdAt
-      )
-  );
+    )
+    .innerJoin(
+      configPolicyMaintenanceSettings,
+      eq(configPolicyMaintenanceSettings.featureLinkId, configPolicyFeatureLinks.id)
+    )
+    .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
+    .orderBy(
+      configPolicyAssignments.level,
+      configPolicyAssignments.priority,
+      configPolicyAssignments.createdAt
+    );
 
   if (rows.length === 0) return null;
 
@@ -892,46 +887,46 @@ export async function resolveComplianceRulesForDevice(
   const targetConditions = buildTargetConditions(hierarchy);
   const roleOsConditions = buildRoleOsFilterConditions(hierarchy);
 
-  // #2930 — the ownership predicate below already admits partner-owned rows,
-  // but under an org-scoped RLS context those rows are invisible and the join
-  // silently returns nothing. Self-tenanted by this device's own hierarchy.
-  const rows = await withPartnerWideVisibility(() =>
-    db
-      .select({
-        complianceRule: configPolicyComplianceRules,
-        assignmentLevel: configPolicyAssignments.level,
-        assignmentPriority: configPolicyAssignments.priority,
-        assignmentCreatedAt: configPolicyAssignments.createdAt,
-        assignmentId: configPolicyAssignments.id,
-      })
-      .from(configPolicyAssignments)
-      .innerJoin(
-        configurationPolicies,
-        and(
-          eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
-          eq(configurationPolicies.status, 'active'),
-          policyOwnershipCondition(hierarchy)
-        )
+  // #2930 — the ownership predicate below admits partner-owned rows; #4673 W01
+  // makes RLS agree, via the SELECT-only `*_partner_wide_select` branch keyed on
+  // breeze_current_partner_id(). So this runs in the CALLER'S OWN context (W03
+  // deleted the system-context escape). Self-tenanted by this device's own
+  // hierarchy on top of RLS.
+  const rows = await db
+    .select({
+      complianceRule: configPolicyComplianceRules,
+      assignmentLevel: configPolicyAssignments.level,
+      assignmentPriority: configPolicyAssignments.priority,
+      assignmentCreatedAt: configPolicyAssignments.createdAt,
+      assignmentId: configPolicyAssignments.id,
+    })
+    .from(configPolicyAssignments)
+    .innerJoin(
+      configurationPolicies,
+      and(
+        eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
+        eq(configurationPolicies.status, 'active'),
+        policyOwnershipCondition(hierarchy)
       )
-      .innerJoin(
-        configPolicyFeatureLinks,
-        and(
-          eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
-          eq(configPolicyFeatureLinks.featureType, 'compliance')
-        )
+    )
+    .innerJoin(
+      configPolicyFeatureLinks,
+      and(
+        eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
+        eq(configPolicyFeatureLinks.featureType, 'compliance')
       )
-      .innerJoin(
-        configPolicyComplianceRules,
-        eq(configPolicyComplianceRules.featureLinkId, configPolicyFeatureLinks.id)
-      )
-      .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
-      .orderBy(
-        configPolicyAssignments.level,
-        configPolicyAssignments.priority,
-        configPolicyAssignments.createdAt,
-        asc(configPolicyComplianceRules.sortOrder)
-      )
-  );
+    )
+    .innerJoin(
+      configPolicyComplianceRules,
+      eq(configPolicyComplianceRules.featureLinkId, configPolicyFeatureLinks.id)
+    )
+    .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
+    .orderBy(
+      configPolicyAssignments.level,
+      configPolicyAssignments.priority,
+      configPolicyAssignments.createdAt,
+      asc(configPolicyComplianceRules.sortOrder)
+    );
 
   if (rows.length === 0) return [];
 
@@ -956,43 +951,42 @@ export async function resolveSoftwarePolicyForDevice(
   const targetConditions = buildTargetConditions(hierarchy);
   const roleOsConditions = buildRoleOsFilterConditions(hierarchy);
 
-  // #2930 — the ownership predicate below already admits partner-owned rows,
-  // but under an org-scoped RLS context (e.g. the PAM UAC elevation decision
-  // path, resolved inside the agent request's org-scoped context) those rows
-  // are invisible and the join silently returns nothing. Self-tenanted by this
-  // device's own hierarchy.
-  const rows = await withPartnerWideVisibility(() =>
-    db
-      .select({
-        featurePolicyId: configPolicyFeatureLinks.featurePolicyId,
-        assignmentLevel: configPolicyAssignments.level,
-        assignmentPriority: configPolicyAssignments.priority,
-        assignmentCreatedAt: configPolicyAssignments.createdAt,
-        assignmentId: configPolicyAssignments.id,
-      })
-      .from(configPolicyAssignments)
-      .innerJoin(
-        configurationPolicies,
-        and(
-          eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
-          eq(configurationPolicies.status, 'active'),
-          policyOwnershipCondition(hierarchy)
-        )
+  // #2930 — the ownership predicate below admits partner-owned rows; #4673 W01
+  // makes RLS agree via the SELECT-only `*_partner_wide_select` branch keyed on
+  // breeze_current_partner_id(), which W02 populates on agent contexts. So the
+  // PAM UAC elevation decision path resolves this inside the agent request's own
+  // org-scoped context (W03 deleted the system-context escape). Self-tenanted by
+  // this device's own hierarchy on top of RLS.
+  const rows = await db
+    .select({
+      featurePolicyId: configPolicyFeatureLinks.featurePolicyId,
+      assignmentLevel: configPolicyAssignments.level,
+      assignmentPriority: configPolicyAssignments.priority,
+      assignmentCreatedAt: configPolicyAssignments.createdAt,
+      assignmentId: configPolicyAssignments.id,
+    })
+    .from(configPolicyAssignments)
+    .innerJoin(
+      configurationPolicies,
+      and(
+        eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
+        eq(configurationPolicies.status, 'active'),
+        policyOwnershipCondition(hierarchy)
       )
-      .innerJoin(
-        configPolicyFeatureLinks,
-        and(
-          eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
-          eq(configPolicyFeatureLinks.featureType, 'software_policy')
-        )
+    )
+    .innerJoin(
+      configPolicyFeatureLinks,
+      and(
+        eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
+        eq(configPolicyFeatureLinks.featureType, 'software_policy')
       )
-      .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
-      .orderBy(
-        configPolicyAssignments.level,
-        configPolicyAssignments.priority,
-        configPolicyAssignments.createdAt
-      )
-  );
+    )
+    .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
+    .orderBy(
+      configPolicyAssignments.level,
+      configPolicyAssignments.priority,
+      configPolicyAssignments.createdAt
+    );
 
   if (rows.length === 0) return null;
 
@@ -1162,40 +1156,40 @@ export async function resolveVulnerabilityEnabledForDevice(deviceId: string): Pr
   const targetConditions = buildTargetConditions(hierarchy);
   const roleOsConditions = buildRoleOsFilterConditions(hierarchy);
 
-  // #2930 — the ownership predicate below already admits partner-owned rows,
-  // but under an org-scoped RLS context those rows are invisible and the join
-  // silently returns nothing. Self-tenanted by this device's own hierarchy.
-  const rows = await withPartnerWideVisibility(() =>
-    db
-      .select({
-        inlineSettings: configPolicyFeatureLinks.inlineSettings,
-        assignmentLevel: configPolicyAssignments.level,
-        assignmentPriority: configPolicyAssignments.priority,
-        assignmentCreatedAt: configPolicyAssignments.createdAt,
-      })
-      .from(configPolicyAssignments)
-      .innerJoin(
-        configurationPolicies,
-        and(
-          eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
-          eq(configurationPolicies.status, 'active'),
-          policyOwnershipCondition(hierarchy)
-        )
+  // #2930 — the ownership predicate below admits partner-owned rows; #4673 W01
+  // makes RLS agree, via the SELECT-only `*_partner_wide_select` branch keyed on
+  // breeze_current_partner_id(). So this runs in the CALLER'S OWN context (W03
+  // deleted the system-context escape). Self-tenanted by this device's own
+  // hierarchy on top of RLS.
+  const rows = await db
+    .select({
+      inlineSettings: configPolicyFeatureLinks.inlineSettings,
+      assignmentLevel: configPolicyAssignments.level,
+      assignmentPriority: configPolicyAssignments.priority,
+      assignmentCreatedAt: configPolicyAssignments.createdAt,
+    })
+    .from(configPolicyAssignments)
+    .innerJoin(
+      configurationPolicies,
+      and(
+        eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
+        eq(configurationPolicies.status, 'active'),
+        policyOwnershipCondition(hierarchy)
       )
-      .innerJoin(
-        configPolicyFeatureLinks,
-        and(
-          eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
-          eq(configPolicyFeatureLinks.featureType, 'vulnerability')
-        )
+    )
+    .innerJoin(
+      configPolicyFeatureLinks,
+      and(
+        eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
+        eq(configPolicyFeatureLinks.featureType, 'vulnerability')
       )
-      .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
-      .orderBy(
-        configPolicyAssignments.level,
-        configPolicyAssignments.priority,
-        configPolicyAssignments.createdAt
-      )
-  );
+    )
+    .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
+    .orderBy(
+      configPolicyAssignments.level,
+      configPolicyAssignments.priority,
+      configPolicyAssignments.createdAt
+    );
 
   if (rows.length === 0) return false;
 
@@ -1650,49 +1644,49 @@ export async function resolveAllBackupAssignedDevices(
   // 1. Load all active backup feature links + settings + assignments for this org
   // LEFT JOIN backup settings so devices are still found even when the
   // normalized settings row is missing (e.g. feature link predates migration).
-  // Runs in a system context: partner-wide policies/profiles (org_id NULL) are
-  // RLS-invisible to org tokens, and this query is self-tenanted by ownershipCondition.
-  const rows = await withPartnerWideVisibility(() =>
-    db
-      .select({
-        backupSettings: configPolicyBackupSettings,
-        featureLinkId: configPolicyFeatureLinks.id,
-        featurePolicyId: configPolicyFeatureLinks.featurePolicyId,
-        profileSelections: backupProfiles.selections,
-        assignmentLevel: configPolicyAssignments.level,
-        assignmentTargetId: configPolicyAssignments.targetId,
-        assignmentPriority: configPolicyAssignments.priority,
-        assignmentCreatedAt: configPolicyAssignments.createdAt,
-      })
-      .from(configPolicyFeatureLinks)
-      .innerJoin(
-        configurationPolicies,
-        and(
-          eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
-          eq(configurationPolicies.status, 'active'),
-          ownershipCondition
-        )
+  // Runs in the caller's own context (#4673 W03): partner-wide policies and
+  // profiles (org_id NULL) are legible through the `*_partner_wide_select`
+  // branches on configuration_policies / config_policy_* / backup_profiles, and
+  // the query is self-tenanted by ownershipCondition on top of that.
+  const rows = await db
+    .select({
+      backupSettings: configPolicyBackupSettings,
+      featureLinkId: configPolicyFeatureLinks.id,
+      featurePolicyId: configPolicyFeatureLinks.featurePolicyId,
+      profileSelections: backupProfiles.selections,
+      assignmentLevel: configPolicyAssignments.level,
+      assignmentTargetId: configPolicyAssignments.targetId,
+      assignmentPriority: configPolicyAssignments.priority,
+      assignmentCreatedAt: configPolicyAssignments.createdAt,
+    })
+    .from(configPolicyFeatureLinks)
+    .innerJoin(
+      configurationPolicies,
+      and(
+        eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
+        eq(configurationPolicies.status, 'active'),
+        ownershipCondition
       )
-      .innerJoin(
-        configPolicyAssignments,
-        eq(configPolicyAssignments.configPolicyId, configurationPolicies.id)
-      )
-      .leftJoin(
-        configPolicyBackupSettings,
-        eq(configPolicyBackupSettings.featureLinkId, configPolicyFeatureLinks.id)
-      )
-      // Deliberately NOT filtered on backupProfiles.isActive: deactivating a
-      // profile removes it from the pickers (the list API hides inactive rows)
-      // but must NOT silently stop backups on policies that already link it —
-      // that would be a data-protection change disguised as a UI toggle. The
-      // profile editor's helper text states this contract. To stop backups,
-      // unlink the profile or deactivate the policy.
-      .leftJoin(
-        backupProfiles,
-        eq(backupProfiles.id, configPolicyBackupSettings.backupProfileId)
-      )
-      .where(eq(configPolicyFeatureLinks.featureType, 'backup'))
-  );
+    )
+    .innerJoin(
+      configPolicyAssignments,
+      eq(configPolicyAssignments.configPolicyId, configurationPolicies.id)
+    )
+    .leftJoin(
+      configPolicyBackupSettings,
+      eq(configPolicyBackupSettings.featureLinkId, configPolicyFeatureLinks.id)
+    )
+    // Deliberately NOT filtered on backupProfiles.isActive: deactivating a
+    // profile removes it from the pickers (the list API hides inactive rows)
+    // but must NOT silently stop backups on policies that already link it —
+    // that would be a data-protection change disguised as a UI toggle. The
+    // profile editor's helper text states this contract. To stop backups,
+    // unlink the profile or deactivate the policy.
+    .leftJoin(
+      backupProfiles,
+      eq(backupProfiles.id, configPolicyBackupSettings.backupProfileId)
+    )
+    .where(eq(configPolicyFeatureLinks.featureType, 'backup'));
 
   if (rows.length === 0) return [];
 
@@ -1870,48 +1864,48 @@ export async function resolveBackupProtectionForDevice(
   const targetConditions = buildTargetConditions(hierarchy);
   const roleOsConditions = buildRoleOsFilterConditions(hierarchy);
 
-  // #2930 — the ownership predicate below already admits partner-owned rows,
-  // but under an org-scoped RLS context those rows are invisible and the join
-  // silently returns nothing. Self-tenanted by this device's own hierarchy.
+  // #2930 — the ownership predicate below admits partner-owned rows; #4673 W01
+  // makes RLS agree, via the SELECT-only `*_partner_wide_select` branch keyed on
+  // breeze_current_partner_id(). So this runs in the CALLER'S OWN context (W03
+  // deleted the system-context escape). Self-tenanted by this device's own
+  // hierarchy on top of RLS.
   // The leftJoin to configPolicyBackupSettings is RLS-chained to
-  // configuration_policies (same feature-link id), so it must stay inside
-  // this same escape rather than resolving separately.
-  const rows = await withPartnerWideVisibility(() =>
-    db
-      .select({
-        featureLinkId: configPolicyFeatureLinks.id,
-        retention: configPolicyBackupSettings.retention,
-        assignmentLevel: configPolicyAssignments.level,
-        assignmentPriority: configPolicyAssignments.priority,
-        assignmentCreatedAt: configPolicyAssignments.createdAt,
-      })
-      .from(configPolicyAssignments)
-      .innerJoin(
-        configurationPolicies,
-        and(
-          eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
-          eq(configurationPolicies.status, 'active'),
-          policyOwnershipCondition(hierarchy)
-        )
+  // configuration_policies (same feature-link id); it resolves here because
+  // config_policy_backup_settings carries its own partner-wide SELECT branch.
+  const rows = await db
+    .select({
+      featureLinkId: configPolicyFeatureLinks.id,
+      retention: configPolicyBackupSettings.retention,
+      assignmentLevel: configPolicyAssignments.level,
+      assignmentPriority: configPolicyAssignments.priority,
+      assignmentCreatedAt: configPolicyAssignments.createdAt,
+    })
+    .from(configPolicyAssignments)
+    .innerJoin(
+      configurationPolicies,
+      and(
+        eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
+        eq(configurationPolicies.status, 'active'),
+        policyOwnershipCondition(hierarchy)
       )
-      .innerJoin(
-        configPolicyFeatureLinks,
-        and(
-          eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
-          eq(configPolicyFeatureLinks.featureType, 'backup')
-        )
+    )
+    .innerJoin(
+      configPolicyFeatureLinks,
+      and(
+        eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
+        eq(configPolicyFeatureLinks.featureType, 'backup')
       )
-      .leftJoin(
-        configPolicyBackupSettings,
-        eq(configPolicyBackupSettings.featureLinkId, configPolicyFeatureLinks.id)
-      )
-      .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
-      .orderBy(
-        configPolicyAssignments.level,
-        configPolicyAssignments.priority,
-        configPolicyAssignments.createdAt
-      )
-  );
+    )
+    .leftJoin(
+      configPolicyBackupSettings,
+      eq(configPolicyBackupSettings.featureLinkId, configPolicyFeatureLinks.id)
+    )
+    .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
+    .orderBy(
+      configPolicyAssignments.level,
+      configPolicyAssignments.priority,
+      configPolicyAssignments.createdAt
+    );
 
   if (rows.length === 0) return null;
 

--- a/apps/api/src/services/featureConfigResolver.ts
+++ b/apps/api/src/services/featureConfigResolver.ts
@@ -731,8 +731,18 @@ export async function resolveBackupConfigForDevice(
   const targetConditions = buildTargetConditions(hierarchy);
   const roleOsConditions = buildRoleOsFilterConditions(hierarchy);
 
-  // Partner-wide policies + profiles are RLS-invisible to org tokens — resolve
-  // them in a system context (self-tenanted by this device's hierarchy).
+  // Partner-wide policies + profiles used to be RLS-invisible to org tokens, so
+  // this resolved in a system context. #4673 W01 grants them directly —
+  // `configuration_policies_partner_wide_select`,
+  // `config_policy_backup_settings_partner_wide_select` and
+  // `backup_profiles_partner_wide_select` — so W03 deleted that escape and this
+  // runs in the CALLER'S OWN context.
+  //
+  // That makes `DbAccessContext.currentPartnerId` load-bearing for every caller:
+  // a hand-built org context that omits it resolves ZERO partner-wide rows, with
+  // no error, and the device silently falls back to no backup config. Build
+  // contexts with `buildDbAccessContext` / `dbAccessContextFromAuth`, never by
+  // hand. Still self-tenanted by this device's hierarchy on top of RLS.
   const rows = await db
     .select({
       backupSettings: configPolicyBackupSettings,

--- a/docs/superpowers/plans/tenancy-rls/2026-08-16-2468-partner-current-partner-id-select-branch.md
+++ b/docs/superpowers/plans/tenancy-rls/2026-08-16-2468-partner-current-partner-id-select-branch.md
@@ -274,6 +274,30 @@ policies restores exact pre-wave behavior.
   request (the #1105 pool-starvation shape) and N RLS-bypass surfaces.
 - **Rollback:** revert the PR; Wave 1 policies are additive so reverting code alone is safe.
 
+**Implementation notes (as shipped, wave #4676):**
+
+- `routes/agents/heartbeat.ts` was deliberately NOT converted. Its five
+  config-delivery reads sit in their own TOP-LEVEL `withSystemDbAccessContext`
+  blocks (the route opts out of the request-long wrap), so they are not nested
+  and cost no second connection — W03's target was the nested escapes.
+  Converting them is a worthwhile follow-up but not a drop-in swap:
+  `buildPatchSourceConfigUpdate` reaches `resolveDeviceTimezone`, whose
+  `partners` read is partner-AXIS and escapes via `readWithPartnerAxisVisibility`
+  (#2822). Under a system wrapper that escape short-circuits; under an
+  org-scoped wrapper it fires, uncached, once per heartbeat — converting one
+  hoisted context into a genuinely nested double-hold on the fleet's hottest
+  path. Hoist or batch the timezone read first. The stale W02 comment on that
+  route was corrected to say this.
+- `buildPolicyProbeConfigUpdate` must keep its escape: it reads
+  `automation_policies`, which has **no** `*_partner_wide_select` branch.
+  `getOrgAgentUpdateConfig` and `services/enrollmentDefaults.ts` likewise —
+  both read the partner-AXIS `partners` table. Same keep-list rationale as
+  `readWithPartnerAxisVisibility`.
+- `withDevicePartnerPolicyVisibility` (#3493, same-connection widening) was
+  kept. It is not a system-context escape, and it widens
+  `breeze.accessible_partner_ids`, which also admits partner-AXIS rows the
+  SELECT-only branch never grants. Retiring it is a separate change.
+
 ### Wave 4 — docs + guardrails
 
 - CLAUDE.md "Partner-Wide First" playbook step 3: replace "move them to a system context
@@ -288,6 +312,9 @@ policies restores exact pre-wave behavior.
   #2417 blindness again. If the assertion turns up already-shipped dual-axis tables without
   the branch (e.g. `software_policies`, patch rings, tenant variables' siblings), file a
   follow-up issue per table rather than growing this change.
+  **Known gap found during W03:** `automation_policies` is dual-axis
+  (`org_id NULL AND partner_id = P`, read by `buildPolicyProbeConfigUpdate`) and has no
+  branch — which is exactly why that resolver still escapes. The assertion should catch it.
 - Update `apps/api/migrations/README.md` only if it documents the read-branch pattern.
 
 ## Key risks


### PR DESCRIPTION
Closes #4676

Wave W03 of #4673 (origin #2468). Plan: `docs/superpowers/plans/tenancy-rls/2026-08-16-2468-partner-current-partner-id-select-branch.md`.

## What this does

W01 (#4690) shipped the SELECT-only `<table>_partner_wide_select` RLS branches across the configuration-policy chain. W02 (#4725) populates `breeze.current_partner_id` on agent contexts. **The database now grants partner-wide reads directly, so this PR deletes the app-layer escapes that existed only to compensate for the old blindness.**

Every removal drops, per affected request:

- one **second pooled-connection acquisition** while the request's own connection is still held — the #1105 starvation shape (postgres-js queues acquisitions with no timeout; at concurrency ≥ pool size, ~25 on the hosted DBs, that is a hang); and
- one **wholesale RLS bypass** — the #2417 cross-tenant shape.

## Removed

| Site | What it was |
|---|---|
| `services/configPolicyOwnership.ts` | `withPartnerWideVisibility` — deleted, plus its 15 call sites: 11 in `services/featureConfigResolver.ts`, 4 in `routes/agents/helpers.ts` |
| `routes/agents/helpers.ts` (`handleCisCommandResult`) | `cis_baselines` PK escalation — its own comment already handed it to W03 |
| `services/configurationPolicy.ts` ×3 | the direct `runOutsideDbContext(() => withSystemDbAccessContext(...))` wraps in `isBackupProfileReference` and the two `validateFeaturePolicyExists` backup lookups |

## Kept — with a justification comment on each

| Site | Why it stays |
|---|---|
| `db/partnerAxisRead.ts`, `services/enrollmentDefaults.ts` | **partner-AXIS** tables (`partners`, `PARTNER_TENANT_TABLES`). There is no `org_id IS NULL` shape to key a SELECT branch on, and the only gate is `breeze_has_partner_access`, which also governs WRITES. Granting it to org scope would widen UPDATE/DELETE. #2822's territory. |
| `buildPolicyProbeConfigUpdate` | reads `automation_policies`, which is dual-axis but has **no** `*_partner_wide_select` branch. Converting it would silently zero out partner-wide compliance probe config. Flagged in the plan doc as a gap for W04's contract assertion to catch. |
| `getOrgAgentUpdateConfig` | reads the partner-AXIS `partners` table. |
| `withDevicePartnerPolicyVisibility` (#3493) | not a system escape — a same-connection widening of `breeze.accessible_partner_ids`, which also admits partner-AXIS rows the SELECT-only branch never grants. Retiring it is a separate change. |
| `services/vulnerabilityFleetQueries.ts`, `ticketConfigService.ts`, `commandQueue.ts` | different problems entirely (global catalog, cross-org worker reads, transaction-isolation semantics) — unchanged from the plan's keep-list. |

### `routes/agents/heartbeat.ts` — deliberately not converted (read this before "cleaning it up")

W02 left a comment saying W03 would remove heartbeat's config-delivery escapes. It doesn't, and the comment has been corrected in place to say why.

Those five reads sit in their own **top-level** `withSystemDbAccessContext` blocks (the route opts out of the request-long wrap), so they are not nested and cost no second connection — W03's target was the nested escapes. Converting them is a genuine follow-up, but **not** a drop-in swap: `buildPatchSourceConfigUpdate` reaches `resolveDeviceTimezone`, whose `partners` read is partner-AXIS and escapes through `readWithPartnerAxisVisibility`. Under a system wrapper that escape short-circuits; under an org-scoped wrapper it fires, **uncached, once per heartbeat** — converting one hoisted context into a genuinely nested double-hold on the fleet's hottest path, i.e. the exact shape this epic exists to remove. The timezone read has to be hoisted or batched first.

Recorded in the plan doc; recommend a separate sub-issue rather than growing this PR.

## Behavioural change to review

**A deliberate tightening on the two bare-id probes** (`isBackupProfileReference`, the `cis_baselines` PK lookup). Escaped, they saw **every tenant's** rows and relied on post-hoc self-tenanting. Under the caller's own context a foreign partner's row now reads as absent and takes the existing "not found" branch — same outcome, reached one step earlier, without the bypass. The post-checks stay as defense in depth. Both callers of the CIS read already swallow a miss (log line, discarded scan result), never a wrong-tenant write.

**Reads widen** for org-scoped tokens to their own partner's partner-wide rows — but only to exactly the rows the system escape already showed them, minus everyone else's. Writes are untouched: every branch is `FOR SELECT`, and Postgres never consults FOR SELECT policies when computing UPDATE/DELETE target rows (asserted below).

## Tests — red-first and mutation-verified

Every removed escalation has a test proving the partner-wide rows are still returned, and the negative half proving the **RLS branch** (not a surviving escape) is what returns them.

- **`featureConfigResolverPartnerWide.integration.test.ts`** (new, added after review) — 9 `featureConfigResolver.ts` resolvers × (positive, blind) against real Postgres: alert rules, governing alert-rule policy, automations, compliance rules, maintenance config, software policy, vulnerability-enabled, backup config, backup protection. Every one of these had its escape removed with no real-RLS coverage before; their only tests mock Drizzle.
- **`agentPolicyResolversPartnerWide.integration.test.ts`** — `orgContext` now carries `currentPartnerId` (the real post-W02 agent shape). New `partnerWideBlindContext` cases run the same four resolvers with `currentPartnerId: null` and require the partner-wide policy to be **INVISIBLE**. Under an escape the GUC is irrelevant and the row resolves regardless, so these can only pass with no escape. Plus a `FOR SELECT`-only write-lock case asserting UPDATE/DELETE affect **0 rows** (RLS hides the target — a silent no-op, not a 42501, so rowCount is the only non-vacuous assertion).
- **`backupProfilesPartnerRls.integration.test.ts`** — the plan's required org-scoped fan-out proof still passes (now with the real `currentPartnerId`), plus a blind counterpart. Six new tests give `isBackupProfileReference` / `validateFeaturePolicyExists` their **first real-DB coverage under org RLS** — every other test of them mocks the database and evaluates no RLS at all.
- **`helpers.partnerWidePolicies.test.ts`** — inverted. `runOutsideDbContext` / `withSystemDbAccessContext` are now mocked to **throw**, and the `configPolicyOwnership` mock factory omits `withPartnerWideVisibility` so re-importing it fails with "No … export is defined on the mock".
- **`buildHelperConfigUpdate`** — the fifth agent resolver, previously uncovered, added to `agentPolicyResolversPartnerWide` with its blind control.
- **`featureConfigResolver.backupAssignments.test.ts`** — escape count 2 → 1; only the partner-AXIS timezone read remains, and the config-policy join is asserted at caller depth.

**Mutation checks run** (reintroduce the escape → confirm red, then revert):

| Mutation | Result |
|---|---|
| escape re-added to `resolveDeviceEventLogSettings` | `event_log: … INVISIBLE without breeze.current_partner_id` → **FAIL** (`expected 555 to be 100`) |
| same | `helpers.partnerWidePolicies` → **5 FAIL** on the throwing mock |
| escape re-added to `isBackupProfileReference` | blind + foreign-partner cases → **2 FAIL** |
| escape re-added to `resolveAlertRulesForDevice` | new resolver suite's blind case → **FAIL** |

## Verification

- `tsc --noEmit` (apps/api) — clean.
- `eslint` on all changed files — clean.
- Unit: 60 files / 1184 tests green (`configPolicyOwnership`, `helpers.*`, `featureConfigResolver*`, `configurationPolicy*`, all of `routes/agents/`); plus a wider caller sweep of 91 files / 1440 tests green (`jobs/backupWorker`, `automationWorker`, `maintenanceRebootWorker`, `routes/backup`, `alertService`, `pamBridge`, `policyEvaluationService`, `commandResultHandlers`).
- Integration against a real Postgres (`pnpm test-stack`): 11 files / 134 tests green — `agentPolicyResolversPartnerWide`, `backupProfilesPartnerRls`, `configPolicyPartnerWideSelect`, `agentContextPartnerWideFanout`, `configurationPolicyOrgScopedPartnerWide`, `normalizedConfigPolicyRls`, `configurationPoliciesPartnerRls`, `partnerAxisSystemContext`, `configurationPolicyPartnerResolution`, `helperPolicyResolution`, `cisBaselinesPartnerRls`. Plus batches covering `helperPolicyResolution`, `onedrive-helper-config-delivery`, `configPolicyFeatureReferenceIntegrity`, `configPolicyReference{,Gate}Concurrency`, `configPolicyAutomationRunRls`, `backupFeatureLinkCascade`, `patchSchedulerPartnerResolution`, `automationWorkerPartnerResolution`, `vulnerabilityCorrelationGating`, `agentUpdatePolicyEffective`, `pamUacGrandfather`, `maintenanceWindowsPartnerRls`, `softwarePoliciesPartnerRls`, `staleBackupReaper`, `backupResultTenantScope`.
- RLS contracts: `vitest.config.rls.ts` (26 passed / 5 pre-existing skips) and `vitest.config.rls-coverage.ts` (100 passed).
- **No schema change**, so no cascade / export-policy / migration-naming surface is touched.

## Follow-ups (not in this PR)

1. Convert heartbeat's five hoisted system contexts, after hoisting/batching the partner-axis timezone read (see above).
2. `automation_policies` is dual-axis with no `*_partner_wide_select` branch — W04's contract assertion should catch it.
3. Pre-existing gaps found during the plan's step-7 sweep, unchanged by this PR (bare org-equality that structurally cannot match `org_id IS NULL`, so RLS is not the cause):
   - `routes/policyManagement/compliance.ts:83-90,217-225` — config-policy counts **undercount** partner-wide policies, while the sibling automation-policy count right above deliberately ORs them in.
   - `services/aiToolsConfigPolicy.ts:517-527` and `routes/softwareInventory.ts:186-198` — name-uniqueness/dedup lookups ignore a same-named partner-wide policy, so the duplicate-name error never fires for that case.

   Left out because fixing them changes user-visible counts and needs product sign-off, not because they're unimportant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YPYSuYeNtq9SRmVv1ELgYN
