### PR TITLE
fix(web): seed the AI threshold ladder during render, not from an effect (#4659)

### DIFF
--- a/apps/web/src/components/settings/AiBudgetThresholdsInput.test.tsx
+++ b/apps/web/src/components/settings/AiBudgetThresholdsInput.test.tsx
@@ -1,6 +1,21 @@
 import { render, screen, fireEvent } from '@testing-library/react';
+import { useLayoutEffect } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import AiBudgetThresholdsInput from './AiBudgetThresholdsInput';
+
+/**
+ * Records the input's committed DOM value once per commit. Layout effects run
+ * synchronously in the mutation phase of the very commit that produced the
+ * DOM, so this observes what the box showed at each commit boundary without
+ * depending on when React's scheduler gets around to passive effects.
+ */
+function CommitProbe({ testId, seen }: { testId: string; seen: string[] }) {
+  useLayoutEffect(() => {
+    const el = document.querySelector(`[data-testid="${testId}-input"]`);
+    if (el) seen.push((el as HTMLInputElement).value);
+  });
+  return null;
+}
 
 describe('AiBudgetThresholdsInput', () => {
   it('renders current rungs as chips and emits a normalised list on blur', () => {
@@ -115,5 +130,40 @@ describe('AiBudgetThresholdsInput', () => {
     fireEvent.change(input, { target: { value: '80' } });
     fireEvent.blur(input);
     expect(onChange).not.toHaveBeenCalled();
+  });
+
+  // #4659 / #4601: the box used to seed itself from `value` in a `useEffect`,
+  // i.e. in a commit AFTER the one that delivered the new prop. Because a
+  // passive effect is deferred, its `setText` could land after the user had
+  // already typed, writing the effect's captured string over the keystroke —
+  // the next blur then committed the PRE-EDIT ladder.
+  //
+  // That window is not hypothetical: @testing-library's `asyncWrapper` turns
+  // the act environment OFF for the duration of `waitFor`/`findBy*` and drains
+  // with `setTimeout(0)`, which under CI load loses the race against React's
+  // scheduler. On real CI it surfaced in `AiUsagePage` as a PUT carrying
+  // `[50, 80, 95]` where the test had cleared the field, and `null` where it
+  // had typed `60, 90` — always the value the box held at mount.
+  //
+  // Seeding during render closes the window: there is no commit in which the
+  // box still shows the old ladder, so assert exactly that.
+  it('re-seeds a changed value prop within the same commit, not a later one (#4659)', () => {
+    const seen: string[] = [];
+    const view = (value: number[]) => (
+      <>
+        <AiBudgetThresholdsInput value={value} onChange={vi.fn()} testId="thresholds" />
+        <CommitProbe testId="thresholds" seen={seen} />
+      </>
+    );
+
+    const { rerender } = render(view([50, 80]));
+    seen.length = 0;
+
+    rerender(view([60, 90]));
+
+    // One commit, already showing the new ladder. Two entries starting with
+    // '50, 80' is the old effect-driven seed, and is what made the box
+    // clobberable mid-keystroke.
+    expect(seen).toEqual(['60, 90']);
   });
 });

--- a/apps/web/src/components/settings/AiBudgetThresholdsInput.test.tsx
+++ b/apps/web/src/components/settings/AiBudgetThresholdsInput.test.tsx
@@ -4,15 +4,25 @@ import { describe, expect, it, vi } from 'vitest';
 import AiBudgetThresholdsInput from './AiBudgetThresholdsInput';
 
 /**
- * Records the input's committed DOM value once per commit. Layout effects run
- * synchronously in the mutation phase of the very commit that produced the
- * DOM, so this observes what the box showed at each commit boundary without
- * depending on when React's scheduler gets around to passive effects.
+ * Records the input's committed DOM value. Layout effects run synchronously in
+ * the mutation phase of the very commit that produced the DOM, so this reads
+ * what the box actually showed at that commit without depending on when
+ * React's scheduler gets around to passive effects.
+ *
+ * It appends once per commit that re-renders THIS probe — i.e. once per
+ * `rerender()` from the test, not once per commit anywhere in the tree. That
+ * is exactly the question being asked: did the commit carrying the new prop
+ * already show the new ladder, or did the box need a later, box-local commit
+ * to catch up?
+ *
+ * Deliberately unguarded: if the selector ever stops matching, this throws with
+ * the reason rather than quietly recording one fewer entry.
  */
 function CommitProbe({ testId, seen }: { testId: string; seen: string[] }) {
   useLayoutEffect(() => {
     const el = document.querySelector(`[data-testid="${testId}-input"]`);
-    if (el) seen.push((el as HTMLInputElement).value);
+    if (!el) throw new Error(`CommitProbe: no element matching [data-testid="${testId}-input"]`);
+    seen.push((el as HTMLInputElement).value);
   });
   return null;
 }
@@ -165,5 +175,86 @@ describe('AiBudgetThresholdsInput', () => {
     // '50, 80' is the old effect-driven seed, and is what made the box
     // clobberable mid-keystroke.
     expect(seen).toEqual(['60, 90']);
+  });
+
+  // The seed is compared as the RENDERED string, not by array identity, so a
+  // refetch that returns an equal-but-new `[50, 80]` — which changes nothing on
+  // screen — cannot throw away what the user is still typing. The old `[value]`
+  // effect dependency was identity-based and did exactly that.
+  it('keeps a draft when a refetch hands back an equal-but-new value array (#4659)', () => {
+    const onChange = vi.fn();
+    const view = (value: number[]) => (
+      <AiBudgetThresholdsInput value={value} onChange={onChange} testId="thresholds" />
+    );
+
+    const { rerender } = render(view([50, 80]));
+    const input = screen.getByTestId('thresholds-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '60, 90' } });
+
+    rerender(view([50, 80]));
+
+    expect(input.value).toBe('60, 90');
+    fireEvent.blur(input);
+    expect(onChange).toHaveBeenLastCalledWith([60, 90]);
+  });
+
+  // The other half of the render/effect split this change introduced. The
+  // render-phase reset clears `invalid` but cannot notify the caller from
+  // inside a render, so a reconciling effect does it. Without this test a
+  // future simplification could drop that effect and leave a caller's Save
+  // button disabled forever after a legitimate external reset.
+  it('releases the caller when value resets over unparseable text (#4659)', () => {
+    const onValidityChange = vi.fn();
+    const view = (value: number[]) => (
+      <AiBudgetThresholdsInput value={value} onChange={vi.fn()} onValidityChange={onValidityChange} testId="thresholds" />
+    );
+
+    const { rerender } = render(view([50, 80]));
+    const input = screen.getByTestId('thresholds-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'abc' } });
+    fireEvent.blur(input);
+    expect(onValidityChange).toHaveBeenLastCalledWith(false);
+
+    onValidityChange.mockClear();
+    rerender(view([60, 90]));
+
+    expect(input.value).toBe('60, 90');
+    expect(screen.queryByTestId('thresholds-error')).not.toBeInTheDocument();
+    expect(onValidityChange).toHaveBeenLastCalledWith(true);
+  });
+
+  // The motivating scenario stated positively: `AiUsagePage` re-renders this
+  // box whenever any OTHER budget field is edited, passing the same
+  // `alertThresholdPercents` reference through. An uncommitted keystroke has to
+  // survive that.
+  it('does not clobber uncommitted text across an unrelated re-render (#4659)', () => {
+    const value = [50, 80];
+    const view = (placeholder: string) => (
+      <AiBudgetThresholdsInput value={value} onChange={vi.fn()} placeholder={placeholder} testId="thresholds" />
+    );
+
+    const { rerender } = render(view('first'));
+    const input = screen.getByTestId('thresholds-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '60, 90' } });
+
+    rerender(view('second'));
+
+    expect(input.value).toBe('60, 90');
+  });
+
+  // `value?.join(', ') ?? ''` and the chip list both special-case undefined;
+  // every other prop-transition test here uses a defined array.
+  it('re-seeds to empty when value resets to undefined', () => {
+    const view = (value: number[] | undefined) => (
+      <AiBudgetThresholdsInput value={value} onChange={vi.fn()} testId="thresholds" />
+    );
+
+    const { rerender } = render(view([50, 80]));
+    expect(screen.getByText('50%')).toBeInTheDocument();
+
+    rerender(view(undefined));
+
+    expect((screen.getByTestId('thresholds-input') as HTMLInputElement).value).toBe('');
+    expect(screen.queryByText('50%')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/settings/AiBudgetThresholdsInput.tsx
+++ b/apps/web/src/components/settings/AiBudgetThresholdsInput.tsx
@@ -38,7 +38,7 @@ export function parseThresholds(raw: string): { ok: true; value: number[] | unde
 
 export default function AiBudgetThresholdsInput({ value, onChange, onValidityChange, disabled, placeholder, testId = 'ai-budget-thresholds' }: Props) {
   const { t } = useTranslation('settings');
-  const [text, setText] = useState(value?.join(', ') ?? '');
+  const [text, setText] = useState(() => value?.join(', ') ?? '');
   const [invalid, setInvalid] = useState(false);
   // Mirrors `invalid` so the setter below can compare against the live value
   // from any closure (effects included) without taking it as a dependency.
@@ -56,7 +56,30 @@ export default function AiBudgetThresholdsInput({ value, onChange, onValidityCha
     onValidityChangeRef.current?.(!next);
   }, []);
 
-  useEffect(() => { setText(value?.join(', ') ?? ''); markInvalid(false); }, [value, markInvalid]);
+  // Re-seed from `value` DURING RENDER, never from an effect (#4659). A passive
+  // effect is flushed after the commit, so a queued `setText(value)` could land
+  // *after* the user had typed and silently revert the box to the value it was
+  // last seeded with; the next blur then committed that stale ladder instead of
+  // what was on screen. On CI this reached `AiUsagePage` as a budget PUT
+  // carrying `[50, 80, 95]` where the field had been cleared, and `null` where
+  // `60, 90` had been typed. Deriving during render leaves no window at all:
+  // there is no commit in which the box still shows the previous ladder.
+  const [seededFrom, setSeededFrom] = useState(value);
+  if (!Object.is(seededFrom, value)) {
+    setSeededFrom(value);
+    setText(value?.join(', ') ?? '');
+    setInvalid(false);
+  }
+
+  // The reset above cannot call `markInvalid` (notifying the parent mid-render
+  // is illegal) and must not touch `invalidRef` (a render can be discarded), so
+  // reconcile both here. A no-op for every `markInvalid`-driven change, since
+  // that setter already moved the ref and told the caller synchronously.
+  useEffect(() => {
+    if (invalidRef.current === invalid) return;
+    invalidRef.current = invalid;
+    onValidityChangeRef.current?.(!invalid);
+  }, [invalid]);
 
   const commit = () => {
     if (disabled) return;

--- a/apps/web/src/components/settings/AiBudgetThresholdsInput.tsx
+++ b/apps/web/src/components/settings/AiBudgetThresholdsInput.tsx
@@ -64,10 +64,20 @@ export default function AiBudgetThresholdsInput({ value, onChange, onValidityCha
   // carrying `[50, 80, 95]` where the field had been cleared, and `null` where
   // `60, 90` had been typed. Deriving during render leaves no window at all:
   // there is no commit in which the box still shows the previous ladder.
-  const [seededFrom, setSeededFrom] = useState(value);
-  if (!Object.is(seededFrom, value)) {
-    setSeededFrom(value);
-    setText(value?.join(', ') ?? '');
+  //
+  // Same defect and same remedy as `InvoiceEditor`'s notes/terms drafts, which
+  // this deliberately mirrors — that one was filed five times (#2925, #3219,
+  // #3277, #3980, #4033) before the effect was recognised as the cause.
+  //
+  // Compare the RENDERED string, not the array identity: a refetch that hands
+  // back an equal-but-new `[50, 80, 95]` (or a `[]`/`undefined` round-trip)
+  // changes nothing on screen, and must not throw away a draft the user is
+  // still typing. The old `[value]` effect dependency had exactly that hole.
+  const seed = value?.join(', ') ?? '';
+  const [seededFrom, setSeededFrom] = useState(seed);
+  if (seededFrom !== seed) {
+    setSeededFrom(seed);
+    setText(seed);
     setInvalid(false);
   }
 


### PR DESCRIPTION
## Problem

`AiUsagePage.test.tsx`'s "alert threshold ladder" block has been failing on real CI, three times today alone, always with an API-only diff on the captured budget PUT:

| Run | Test | Expected | Received |
|---|---|---|---|
| 33723866739 (attempts 1 & 2, PR #4784) | `sends alertThresholdPercents: null when the ladder is cleared` | `null` | `[50, 80, 95]` |
| 33733136235 (PR #4741) | `sends the edited ladder` | `[60, 90]` | `null` |

Plus the signature originally filed on #4659: `disables Save while the ladder text does not parse` — the inline error span never appeared after typing `100`.

In every case the value that reached the PUT is **the ladder the box held at mount**, not what the test typed.

## Root cause

`AiBudgetThresholdsInput` re-seeded its local `text` state from the `value` prop inside a `useEffect`:

```tsx
useEffect(() => { setText(value?.join(', ') ?? ''); markInvalid(false); }, [value, markInvalid]);
```

A passive effect is flushed **after** the commit, so a queued `setText` can land *after* the user has already typed, writing the string the effect captured when it was scheduled over the keystroke. The following `commit()` then parses that reverted text and calls `onChange` with the pre-edit ladder.

This is normally invisible. At mount the effect writes exactly what `useState` already holds, so React's eager bailout drops the update without scheduling anything. It only becomes a real write once the fiber has a pending update — which is precisely the case after the user has typed.

The window is opened by `@testing-library`: `asyncWrapper` turns the **act environment off** for the duration of `waitFor`/`findBy*` and then drains with `setTimeout(0)`. Under CI load that loses the race against React's scheduler, so `findByTestId('ai-budget-thresholds-input')` can return while the component's mount effects are still queued — and then `fireEvent.change` runs first, the stale seed second.

One mechanism explains all three signatures:

- cleared field → seed restores `50, 80, 95` → PUT `[50, 80, 95]`
- typed `60, 90` over an empty box → seed restores `''` → PUT `null`
- typed `100` → seed restores `50, 80, 95`, which parses → no error span, Save never disabled

**This is not a new diagnosis in this repo.** `InvoiceEditor`'s notes/terms drafts had the identical defect — an effect-deferred prop→state sync overwriting a keystroke — filed five times (#2925 → #3219 → #3277 → #3980 → #4033) before the effect was recognised as the cause, and fixed by moving the sync into render. This change deliberately mirrors that fix, including its comparison strategy.

## Fix

Derive the seed **during render**, guarded by a `seededFrom` state cell, so there is no commit in which the box still shows the previous ladder and therefore no window in which a keystroke can be overwritten.

The seed is compared as the **rendered string**, not by array identity. Identity comparison would reproduce the same clobber class through a different door — and reachably so: `AiUsagePage.fetchData()` re-runs when the `showFlaggedOnly` checkbox is toggled and unconditionally rebuilds `budget.alertThresholdPercents` from the response, so a user mid-edit would have their draft reverted. `PartnerSettingsPage.fetchPartner` has the same shape.

The render-phase reset cannot call `markInvalid` (notifying the parent mid-render is illegal) or mutate `invalidRef` (a render can be discarded), so a small effect reconciles both. It is a no-op for every `markInvalid`-driven change — those still notify the caller synchronously, so the Save-gate behaviour that `disables Save while the ladder text does not parse` relies on is unchanged.

## Verification

**Deterministic regression tests** (both verified red on the pre-fix component, green after):

- `re-seeds a changed value prop within the same commit, not a later one` — asserts the seed lands in the same commit as the prop change, observed through a layout effect (mutation phase of that commit) so it does not depend on scheduler timing. Red before: `expected [ '50, 80' ] to deeply equal [ '60, 90' ]`.
- `keeps a draft when a refetch hands back an equal-but-new value array` — red against the identity comparison: `expected '50, 80' to be '60, 90'`.

**Contract tests** added from review (these pin behaviour rather than reproducing the flake):

- `releases the caller when value resets over unparseable text` — covers the reconciling effect. Mutation-checked: deleting that effect fails this test and only this test.
- `does not clobber uncommitted text across an unrelated re-render` — the motivating scenario stated positively.
- `re-seeds to empty when value resets to undefined` — the `?.`/`??` branch nothing else reaches.

An earlier attempt at the first test used `flushSync` to leave passive effects pending; its non-vacuity control caught that React 19 flushes them anyway, so that approach was dropped rather than shipped as a test that could never fail.

**Stress reproduction** (18-core box, load average already ~44 from other work):

- baseline, component reverted to `main`: `npx vitest run src/components/settings/AiUsagePage.test.tsx --pool=threads --maxWorkers=1` × 40 under 8 busy-loops → **1 failure**, byte-identical to CI run 33733136235 (`sends the edited ladder`, expected `[60, 90]`, received `null`, same `AiUsagePage.test.tsx:244:49`). A second baseline at 20 busy-loops × 50 was clean — the race is not monotonic in load, which matches the low rate seen on CI and in the original #4659 report (2/120).
- after the fix, same command and same 8-busy-loop load: **80/80 green**, then **40/40 green** again on the final code
- both changed files together, 25 iterations under the same load: **25/25 green**

**Suites and checks**

- `vitest run src/components/settings` → 85 files / 990 tests passed
- `npx tsc --noEmit -p apps/web/tsconfig.json` → clean
- `npx eslint` on both changed files → clean

Closes #4659

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBxF7C8E5GxFnNcGf6kBVP
