### PR TITLE
feat(portal): W10 reports tab — list, generate, PDF/CSV download, badge, e2e (#4562)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2681,7 +2681,7 @@ jobs:
       # session-expired on the contracts tab) and never gets as far as its
       # portal step. Add it here once that is fixed.
       - name: Run the portal hydration specs
-        run: ./e2e-tests/node_modules/.bin/tsx scripts/dev/wt-stack/cli.ts test -- tests/multi-currency.spec.ts
+        run: ./e2e-tests/node_modules/.bin/tsx scripts/dev/wt-stack/cli.ts test -- tests/multi-currency.spec.ts tests/portal-visibility.spec.ts
 
       - name: Upload Playwright report
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2672,14 +2672,18 @@ jobs:
       - name: Show the stack descriptor
         run: cat .breeze-stack.json
 
-      # multi-currency.spec.ts is the only spec whose flow reaches the portal
-      # through `waitForHydration` — its `public-quote-accept` step is the exact
+      # multi-currency.spec.ts is the only `waitForHydration` caller whose flow
+      # reaches the portal — its `public-quote-accept` step is the exact
       # assertion #3906 broke and #4540 fixed.
       # `quote-contract-proposal.spec.ts` is the only other `waitForHydration`
       # caller and is EXCLUDED on purpose: it has a known, unrelated
       # pre-existing failure earlier in the WEB flow (AuthOverlay /
       # session-expired on the contracts tab) and never gets as far as its
       # portal step. Add it here once that is fixed.
+      # portal-visibility.spec.ts (#4562 W10) does not use `waitForHydration`,
+      # but this is the only job that stands up Caddy fronting the portal, so
+      # it is the only place the customer-facing portal is exercised at all.
+      # It depends on the portal rows in e2e-tests/seed-fixtures.sql.
       - name: Run the portal hydration specs
         run: ./e2e-tests/node_modules/.bin/tsx scripts/dev/wt-stack/cli.ts test -- tests/multi-currency.spec.ts tests/portal-visibility.spec.ts
 

--- a/apps/api/src/__tests__/integration/portalReportSelfService.integration.test.ts
+++ b/apps/api/src/__tests__/integration/portalReportSelfService.integration.test.ts
@@ -18,6 +18,7 @@ import {
 } from './db-utils';
 import {
   generatePortalReport,
+  listPortalRuns,
   PortalReportNotFoundError,
   renderRunPdf,
 } from '../../services/portal/reportsSelfService';
@@ -114,6 +115,67 @@ describe('portal report self-service tenancy', () => {
     await expect(
       withDbAccessContext(orgContext(fixture.orgB.id), () =>
         renderRunPdf(generated.id, fixture.orgB.id, 'UTC'),
+      ),
+    ).rejects.toBeInstanceOf(PortalReportNotFoundError);
+  });
+
+  // R10-8: the self-service marker, not org membership alone, is what admits a
+  // run into the portal. A completed run of an MSP-internal definition in the
+  // portal user's OWN org must be neither listed nor downloadable.
+  runDb('hides a non-self-service run from the portal even inside its own org', async () => {
+    const fixture = await withSystemDbAccessContext(async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+
+      const scope = {
+        version: 1,
+        kind: 'unrestricted',
+        orgId: org.id,
+      } as const;
+      const authority: UserReportExecutionAuthority = {
+        principalKind: 'user',
+        principalUserId: crypto.randomUUID(),
+        scope,
+        capturedAt: new Date(),
+        fingerprint: siteScopeFingerprint(scope),
+      };
+
+      const [definition] = await db.insert(reports).values({
+        orgId: org.id,
+        name: 'Internal executive summary',
+        type: 'executive_summary',
+        schedule: 'one_time',
+        format: 'pdf',
+        config: { dateRange: { preset: 'last_30_days' } },
+        portalSelfService: false,
+        ...persistedSiteScopeValues(authority),
+      }).returning({ id: reports.id });
+
+      const [run] = await db.insert(reportRuns).values({
+        reportId: definition!.id,
+        status: 'completed',
+        startedAt: new Date(),
+        completedAt: new Date(),
+        result: { rows: [], summary: {} },
+        rowCount: 0,
+        // Tombstoned staff user: the provenance CHECK only forbids the WRONG id.
+        requestedByKind: 'user',
+        requestedByUserId: null,
+        requestedByPortalUserId: null,
+        ...persistedSiteScopeValues(authority),
+      }).returning({ id: reportRuns.id });
+
+      return { org, runId: run!.id };
+    });
+
+    const listed = await withDbAccessContext(orgContext(fixture.org.id), () =>
+      listPortalRuns(fixture.org.id, 'UTC', { page: 1, limit: 50 }),
+    );
+    expect(listed.data.map((row) => row.id)).not.toContain(fixture.runId);
+
+    await expect(
+      withDbAccessContext(orgContext(fixture.org.id), () =>
+        renderRunPdf(fixture.runId, fixture.org.id, 'UTC'),
       ),
     ).rejects.toBeInstanceOf(PortalReportNotFoundError);
   });

--- a/apps/api/src/__tests__/integration/portalReportSelfService.integration.test.ts
+++ b/apps/api/src/__tests__/integration/portalReportSelfService.integration.test.ts
@@ -89,6 +89,8 @@ describe('portal report self-service tenancy', () => {
       }),
     );
 
+    expect(generated.status).toBe('completed');
+
     const [stored] = await withSystemDbAccessContext(() =>
       db.select({
         requestedByKind: reportRuns.requestedByKind,
@@ -102,6 +104,12 @@ describe('portal report self-service tenancy', () => {
       requestedByUserId: null,
       requestedByPortalUserId: fixture.portalUser.id,
     });
+
+    await expect(
+      withDbAccessContext(orgContext(fixture.orgA.id), () =>
+        renderRunPdf(generated.id, fixture.orgA.id, 'UTC'),
+      ),
+    ).resolves.toBeInstanceOf(Buffer);
 
     await expect(
       withDbAccessContext(orgContext(fixture.orgB.id), () =>

--- a/apps/api/src/__tests__/integration/portalReportSelfService.integration.test.ts
+++ b/apps/api/src/__tests__/integration/portalReportSelfService.integration.test.ts
@@ -1,0 +1,112 @@
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import {
+  db,
+  withDbAccessContext,
+  withSystemDbAccessContext,
+  type DbAccessContext,
+} from '../../db';
+import {
+  portalUsers,
+  reportRuns,
+  reports,
+} from '../../db/schema';
+import {
+  createOrganization,
+  createPartner,
+} from './db-utils';
+import {
+  generatePortalReport,
+  PortalReportNotFoundError,
+  renderRunPdf,
+} from '../../services/portal/reportsSelfService';
+import {
+  persistedSiteScopeValues,
+  siteScopeFingerprint,
+  type UserReportExecutionAuthority,
+} from '../../services/siteScope';
+
+const runDb = it.runIf(Boolean(process.env.DATABASE_URL));
+
+function orgContext(orgId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    currentPartnerId: null,
+    userId: null,
+  };
+}
+
+describe('portal report self-service tenancy', () => {
+  runDb('stores portal provenance and hides org A PDF from org B', async () => {
+    const fixture = await withSystemDbAccessContext(async () => {
+      const partner = await createPartner();
+      const orgA = await createOrganization({ partnerId: partner.id });
+      const orgB = await createOrganization({ partnerId: partner.id });
+
+      const [portalUser] = await db.insert(portalUsers).values({
+        orgId: orgA.id,
+        email: `portal-${crypto.randomUUID()}@example.test`,
+        status: 'active',
+      }).returning({ id: portalUsers.id });
+
+      const scope = {
+        version: 1,
+        kind: 'unrestricted',
+        orgId: orgA.id,
+      } as const;
+      const authority: UserReportExecutionAuthority = {
+        principalKind: 'user',
+        principalUserId: crypto.randomUUID(),
+        scope,
+        capturedAt: new Date(),
+        fingerprint: siteScopeFingerprint(scope),
+      };
+
+      await db.insert(reports).values({
+        orgId: orgA.id,
+        name: 'Customer portal — Executive summary',
+        type: 'executive_summary',
+        schedule: 'one_time',
+        format: 'pdf',
+        config: { dateRange: { preset: 'last_30_days' } },
+        portalSelfService: true,
+        ...persistedSiteScopeValues(authority),
+      });
+
+      return { orgA, orgB, portalUser: portalUser! };
+    });
+
+    const generated = await withDbAccessContext(
+      orgContext(fixture.orgA.id),
+      () => generatePortalReport({
+        orgId: fixture.orgA.id,
+        portalUserId: fixture.portalUser.id,
+        type: 'executive_summary',
+      }),
+    );
+
+    const [stored] = await withSystemDbAccessContext(() =>
+      db.select({
+        requestedByKind: reportRuns.requestedByKind,
+        requestedByUserId: reportRuns.requestedByUserId,
+        requestedByPortalUserId: reportRuns.requestedByPortalUserId,
+      }).from(reportRuns).where(eq(reportRuns.id, generated.id)),
+    );
+
+    expect(stored).toEqual({
+      requestedByKind: 'portal_user',
+      requestedByUserId: null,
+      requestedByPortalUserId: fixture.portalUser.id,
+    });
+
+    await expect(
+      withDbAccessContext(orgContext(fixture.orgB.id), () =>
+        renderRunPdf(generated.id, fixture.orgB.id, 'UTC'),
+      ),
+    ).rejects.toBeInstanceOf(PortalReportNotFoundError);
+  });
+});

--- a/apps/api/src/__tests__/integration/portalVisibilityRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/portalVisibilityRls.integration.test.ts
@@ -24,6 +24,7 @@ import {
 import {
   supportUsageForOrg,
 } from '../../services/portal/supportUsage';
+import { patchesAppliedTile } from '../../services/portal/patchReadModel';
 import {
   createOrganization,
   createPartner,
@@ -474,6 +475,39 @@ describe('portal visibility RLS', () => {
       // boundary is actually computed in the caller's timezone rather
       // than always in UTC.
       expect(utcUsage.totals.billed.minutes).toBe(20);
+    });
+  });
+
+  // #4562 W04 regression, surfaced by the W10 portal e2e: the month-window
+  // anchor was bound as a JS Date inside a raw `sql` fragment, which the
+  // postgres-js driver cannot serialize (`Buffer.byteLength` TypeError at bind
+  // time), so every dashboard request 500ed. Unit tests compile the SQL and
+  // never bind, so only a real database proves this.
+  it('computes the patches tile against a real database', async () => {
+    const partner = await createPartner();
+    const orgA = await createOrganization({
+      partnerId: partner.id,
+    });
+    const portalContext: DbAccessContext = {
+      scope: 'organization',
+      orgId: orgA.id,
+      accessibleOrgIds: [orgA.id],
+      accessiblePartnerIds: [],
+      currentPartnerId: null,
+      userId: null,
+    };
+
+    await expect(
+      withDbAccessContext(portalContext, () =>
+        patchesAppliedTile(orgA.id, {
+          timezone: 'America/Denver',
+          now: new Date('2026-09-02T12:00:00Z'),
+        }),
+      ),
+    ).resolves.toMatchObject({
+      status: 'no_data',
+      month: '2026-09',
+      timezone: 'America/Denver',
     });
   });
 

--- a/apps/api/src/routes/portal/helpers.ts
+++ b/apps/api/src/routes/portal/helpers.ts
@@ -19,15 +19,22 @@ import {
   PORTAL_CSRF_COOKIE_PATH,
   PORTAL_SESSION_CAP,
   PORTAL_RESET_TOKEN_CAP,
-  PORTAL_RATE_BUCKET_CAP,
   STATE_SWEEP_INTERVAL_MS,
-  RATE_LIMIT_SWEEP_INTERVAL_MS,
   PORTAL_USE_REDIS,
   PORTAL_REDIS_KEYS,
   INVITE_TTL_MS,
   INVITE_TTL_SECONDS,
   PORTAL_INVITE_TOKEN_CAP,
 } from './schemas';
+import {
+  capMapByOldest,
+  checkRateLimit,
+  portalRateLimitBuckets,
+} from '../../services/portal/rateLimit';
+
+// The rate limiter moved to services/portal/rateLimit.ts (see its header);
+// re-exported so the auth routes and tests keep importing it from here.
+export { capMapByOldest, checkRateLimit, portalRateLimitBuckets };
 
 // ============================================
 // In-memory state
@@ -36,15 +43,7 @@ import {
 export const portalSessions = new Map<string, PortalSession>();
 export const portalResetTokens = new Map<string, { userId: string; expiresAt: Date; createdAt: Date }>();
 export const portalInviteTokens = new Map<string, { portalUserId: string; expiresAt: Date; createdAt: Date }>();
-export const portalRateLimitBuckets = new Map<string, {
-  count: number;
-  resetAtMs: number;
-  blockedUntilMs: number;
-  lastSeenAtMs: number;
-}>();
-
 let lastStateSweepAtMs = 0;
-let lastRateLimitSweepAtMs = 0;
 
 // ============================================
 // Utility functions
@@ -287,27 +286,6 @@ export function getCookieValue(cookieHeader: string | undefined, name: string): 
 // Map cap / sweep helpers
 // ============================================
 
-export function capMapByOldest<T>(
-  map: Map<string, T>,
-  cap: number,
-  getAgeMs: (value: T) => number
-) {
-  if (map.size <= cap) {
-    return;
-  }
-
-  const overflow = map.size - cap;
-  const entries = Array.from(map.entries())
-    .sort(([, left], [, right]) => getAgeMs(left) - getAgeMs(right));
-
-  for (let i = 0; i < overflow; i++) {
-    const key = entries[i]?.[0];
-    if (key) {
-      map.delete(key);
-    }
-  }
-}
-
 export function sweepPortalState(nowMs: number = Date.now()) {
   if (nowMs - lastStateSweepAtMs < STATE_SWEEP_INTERVAL_MS) {
     return;
@@ -338,103 +316,9 @@ export function sweepPortalState(nowMs: number = Date.now()) {
   capMapByOldest(portalInviteTokens, PORTAL_INVITE_TOKEN_CAP, (token) => token.createdAt.getTime());
 }
 
-function sweepRateLimitBuckets(nowMs: number = Date.now()) {
-  if (nowMs - lastRateLimitSweepAtMs < RATE_LIMIT_SWEEP_INTERVAL_MS) {
-    return;
-  }
-
-  lastRateLimitSweepAtMs = nowMs;
-
-  for (const [key, bucket] of portalRateLimitBuckets.entries()) {
-    const stale = bucket.resetAtMs <= nowMs && bucket.blockedUntilMs <= nowMs;
-    const idleTooLong = nowMs - bucket.lastSeenAtMs > RATE_LIMIT_SWEEP_INTERVAL_MS * 6;
-    if (stale || idleTooLong) {
-      portalRateLimitBuckets.delete(key);
-    }
-  }
-
-  capMapByOldest(portalRateLimitBuckets, PORTAL_RATE_BUCKET_CAP, (bucket) => bucket.lastSeenAtMs);
-}
-
 // ============================================
-// Rate limiting
+// Rate limiting (implementation: services/portal/rateLimit.ts)
 // ============================================
-
-export async function checkRateLimit(
-  key: string,
-  config: { windowMs: number; maxAttempts: number; blockMs: number },
-  nowMs: number = Date.now()
-): Promise<{ allowed: boolean; retryAfterSeconds: number }> {
-  if (PORTAL_USE_REDIS) {
-    const redis = getRedis();
-    if (!redis) {
-      if (process.env.NODE_ENV === 'production') {
-        return { allowed: false, retryAfterSeconds: 60 };
-      }
-      return { allowed: true, retryAfterSeconds: 0 };
-    }
-
-    const blockKey = PORTAL_REDIS_KEYS.rlBlock(key);
-    const blockTtl = await redis.ttl(blockKey);
-    if (blockTtl > 0) {
-      return { allowed: false, retryAfterSeconds: blockTtl };
-    }
-
-    const attemptsKey = PORTAL_REDIS_KEYS.rlAttempts(key);
-    const windowSeconds = Math.ceil(config.windowMs / 1000);
-    const count = await redis.incr(attemptsKey);
-    if (count === 1) {
-      await redis.expire(attemptsKey, windowSeconds);
-    }
-
-    if (count > config.maxAttempts) {
-      const blockSeconds = Math.ceil(config.blockMs / 1000);
-      await redis.setex(blockKey, blockSeconds, '1');
-      return { allowed: false, retryAfterSeconds: blockSeconds };
-    }
-
-    return { allowed: true, retryAfterSeconds: 0 };
-  }
-
-  sweepRateLimitBuckets(nowMs);
-
-  let bucket = portalRateLimitBuckets.get(key);
-  if (!bucket || bucket.resetAtMs <= nowMs) {
-    bucket = {
-      count: 0,
-      resetAtMs: nowMs + config.windowMs,
-      blockedUntilMs: 0,
-      lastSeenAtMs: nowMs
-    };
-  }
-
-  if (bucket.blockedUntilMs > nowMs) {
-    bucket.lastSeenAtMs = nowMs;
-    portalRateLimitBuckets.set(key, bucket);
-    capMapByOldest(portalRateLimitBuckets, PORTAL_RATE_BUCKET_CAP, (entry) => entry.lastSeenAtMs);
-    return {
-      allowed: false,
-      retryAfterSeconds: Math.max(1, Math.ceil((bucket.blockedUntilMs - nowMs) / 1000))
-    };
-  }
-
-  bucket.count += 1;
-  bucket.lastSeenAtMs = nowMs;
-
-  if (bucket.count > config.maxAttempts) {
-    bucket.blockedUntilMs = nowMs + config.blockMs;
-    portalRateLimitBuckets.set(key, bucket);
-    capMapByOldest(portalRateLimitBuckets, PORTAL_RATE_BUCKET_CAP, (entry) => entry.lastSeenAtMs);
-    return {
-      allowed: false,
-      retryAfterSeconds: Math.max(1, Math.ceil(config.blockMs / 1000))
-    };
-  }
-
-  portalRateLimitBuckets.set(key, bucket);
-  capMapByOldest(portalRateLimitBuckets, PORTAL_RATE_BUCKET_CAP, (entry) => entry.lastSeenAtMs);
-  return { allowed: true, retryAfterSeconds: 0 };
-}
 
 export async function clearRateLimitKeys(keys: string[]) {
   if (PORTAL_USE_REDIS) {

--- a/apps/api/src/routes/portal/reports.test.ts
+++ b/apps/api/src/routes/portal/reports.test.ts
@@ -135,6 +135,7 @@ describe('portal report routes', () => {
     const payload = {
       data: [{ id: 'run-1', status: 'completed' }],
       pagination: { page: 1, limit: 20, total: 1 },
+      timezone: 'UTC',
     };
     mocks.listMock.mockResolvedValue(payload);
 
@@ -147,10 +148,11 @@ describe('portal report routes', () => {
       'private, max-age=30',
     );
     expect(response.headers.get('etag')).toMatch(/^W\//);
-    expect(mocks.listMock).toHaveBeenCalledWith(ORG_ID, {
-      page: 1,
-      limit: 20,
-    });
+    expect(mocks.listMock).toHaveBeenCalledWith(
+      ORG_ID,
+      'UTC',
+      { page: 1, limit: 20 },
+    );
   });
 
   it('generates synchronously for the portal user', async () => {

--- a/apps/api/src/routes/portal/reports.test.ts
+++ b/apps/api/src/routes/portal/reports.test.ts
@@ -94,6 +94,7 @@ import {
   PortalReportNotFoundError,
   PortalReportRateLimitError,
 } from '../../services/portal/reportsSelfService';
+import { validatePortalCookieCsrfRequest } from './helpers';
 import { portalRoutes } from './index';
 import { portalReportRoutes } from './reports';
 
@@ -172,6 +173,35 @@ describe('portal report routes', () => {
     });
   });
 
+  it('returns 403 on CSRF failure without generating a report', async () => {
+    vi.mocked(validatePortalCookieCsrfRequest).mockReturnValueOnce(
+      'csrf token mismatch',
+    );
+
+    const response = await isolatedApp().request('/reports/generate', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ type: 'executive_summary' }),
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: 'csrf token mismatch',
+    });
+    expect(mocks.generateMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-portal report types without generating a report', async () => {
+    const response = await isolatedApp().request('/reports/generate', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ type: 'device_inventory' }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(mocks.generateMock).not.toHaveBeenCalled();
+  });
+
   it('returns 404 when the canonical definition or run is absent', async () => {
     mocks.generateMock.mockRejectedValue(new PortalReportNotFoundError());
     const response = await isolatedApp().request('/reports/generate', {
@@ -201,6 +231,11 @@ describe('portal report routes', () => {
     expect(response.status).toBe(200);
     expect(response.headers.get('content-type')).toBe('application/pdf');
     expect(response.headers.get('content-disposition')).toContain('attachment');
+    expect(response.headers.get('cache-control')).toBe(
+      'private, max-age=0, no-store',
+    );
+    expect(response.headers.get('vary')).toContain('Authorization');
+    expect(response.headers.get('vary')).toContain('Cookie');
     expect(await response.text()).toBe('%PDF-test');
     expect(mocks.pdfMock).toHaveBeenCalledWith(RUN_ID, ORG_ID, 'UTC');
   });
@@ -226,8 +261,36 @@ describe('portal report routes', () => {
       'text/csv; charset=utf-8',
     );
     expect(response.headers.get('content-disposition')).toContain('attachment');
+    expect(response.headers.get('cache-control')).toBe(
+      'private, max-age=0, no-store',
+    );
+    expect(response.headers.get('vary')).toContain('Authorization');
+    expect(response.headers.get('vary')).toContain('Cookie');
     expect(await response.text()).toBe('Device,Status\nLaptop,online\n');
     expect(mocks.csvMock).toHaveBeenCalledWith(RUN_ID, ORG_ID);
+  });
+
+  it.each([
+    ['PDF', 'pdf', mocks.pdfMock],
+    ['CSV', 'csv', mocks.csvMock],
+  ] as const)('logs the thrown error when %s rendering fails', async (_label, format, renderMock) => {
+    const error = new Error(`${format} render crashed`);
+    renderMock.mockRejectedValue(error);
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      const response = await isolatedApp().request(
+        `/reports/runs/${RUN_ID}/${format}`,
+      );
+
+      expect(response.status).toBe(500);
+      expect(consoleError).toHaveBeenCalledWith(
+        `[portal] ${format.toUpperCase()} report render failed`,
+        { runId: RUN_ID, error },
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 
   it('returns 422 when a completed run has no tabular data', async () => {

--- a/apps/api/src/routes/portal/reports.test.ts
+++ b/apps/api/src/routes/portal/reports.test.ts
@@ -1,0 +1,276 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+const mocks = vi.hoisted(() => ({
+  listMock: vi.fn(),
+  generateMock: vi.fn(),
+  pdfMock: vi.fn(),
+  csvMock: vi.fn(),
+  reportsEnabled: false,
+}));
+
+vi.mock('../../services/portal/reportsSelfService', async (load) => {
+  const actual = await load<
+    typeof import('../../services/portal/reportsSelfService')
+  >();
+  return {
+    ...actual,
+    listPortalRuns: mocks.listMock,
+    generatePortalReport: mocks.generateMock,
+    renderRunPdf: mocks.pdfMock,
+    renderRunCsv: mocks.csvMock,
+  };
+});
+
+vi.mock('../../db', () => ({
+  db: {
+    select: vi.fn((selection: Record<string, unknown>) => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => {
+          if ('enableReports' in selection) {
+            return {
+              limit: vi.fn(() =>
+                Promise.resolve([{ enableReports: mocks.reportsEnabled }]),
+              ),
+            };
+          }
+          return Promise.resolve([]);
+        }),
+      })),
+    })),
+  },
+  runOutsideDbContext: <T,>(fn: () => T): T => fn(),
+  withSystemDbAccessContext: <T,>(fn: () => Promise<T>): Promise<T> => fn(),
+  withDbAccessContext: <T,>(
+    _context: unknown,
+    fn: () => Promise<T>,
+  ): Promise<T> => fn(),
+}));
+
+vi.mock('./auth', async () => {
+  const { Hono } = await import('hono');
+  return {
+    authRoutes: new Hono(),
+    portalAuthMiddleware: async (
+      c: {
+        req: { header(name: string): string | undefined };
+        json(body: unknown, status: 401): Response;
+        set(key: string, value: unknown): void;
+      },
+      next: () => Promise<void>,
+    ) => {
+      if (!c.req.header('Authorization')) {
+        return c.json({ error: 'Authentication required' }, 401);
+      }
+      c.set('portalAuth', {
+        user: {
+          id: '22222222-2222-4222-8222-222222222222',
+          orgId: '11111111-1111-4111-8111-111111111111',
+          email: 'customer@example.test',
+          name: 'Customer',
+          contactId: null,
+          receiveNotifications: true,
+          status: 'active',
+        },
+        token: 'token',
+        authMethod: 'bearer',
+        timezone: 'UTC',
+      });
+      await next();
+    },
+  };
+});
+
+vi.mock('./helpers', async (load) => {
+  const actual = await load<typeof import('./helpers')>();
+  return {
+    ...actual,
+    validatePortalCookieCsrfRequest: vi.fn(() => null),
+  };
+});
+
+import {
+  PortalReportNoTabularDataError,
+  PortalReportNotFoundError,
+  PortalReportRateLimitError,
+} from '../../services/portal/reportsSelfService';
+import { portalRoutes } from './index';
+import { portalReportRoutes } from './reports';
+
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+const PORTAL_USER_ID = '22222222-2222-4222-8222-222222222222';
+const RUN_ID = '33333333-3333-4333-8333-333333333333';
+
+function isolatedApp() {
+  const hono = new Hono();
+  hono.use('*', async (c, next) => {
+    c.set('portalAuth', {
+      user: {
+        id: PORTAL_USER_ID,
+        orgId: ORG_ID,
+        email: 'customer@example.test',
+        name: 'Customer',
+        contactId: null,
+        receiveNotifications: true,
+        status: 'active',
+      },
+      token: 'token',
+      authMethod: 'bearer',
+      timezone: 'UTC',
+    });
+    await next();
+  });
+  hono.route('/', portalReportRoutes);
+  return hono;
+}
+
+describe('portal report routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.reportsEnabled = false;
+  });
+
+  it('lists only the service result for the session org with private caching', async () => {
+    const payload = {
+      data: [{ id: 'run-1', status: 'completed' }],
+      pagination: { page: 1, limit: 20, total: 1 },
+    };
+    mocks.listMock.mockResolvedValue(payload);
+
+    const response = await isolatedApp().request(
+      '/reports/runs?page=1&limit=20',
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(payload);
+    expect(response.headers.get('cache-control')).toContain(
+      'private, max-age=30',
+    );
+    expect(response.headers.get('etag')).toMatch(/^W\//);
+    expect(mocks.listMock).toHaveBeenCalledWith(ORG_ID, {
+      page: 1,
+      limit: 20,
+    });
+  });
+
+  it('generates synchronously for the portal user', async () => {
+    mocks.generateMock.mockResolvedValue({
+      id: 'run-1',
+      status: 'completed',
+    });
+
+    const response = await isolatedApp().request('/reports/generate', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ type: 'executive_summary' }),
+    });
+
+    expect(response.status).toBe(201);
+    expect(mocks.generateMock).toHaveBeenCalledWith({
+      orgId: ORG_ID,
+      portalUserId: PORTAL_USER_ID,
+      type: 'executive_summary',
+    });
+  });
+
+  it('returns 404 when the canonical definition or run is absent', async () => {
+    mocks.generateMock.mockRejectedValue(new PortalReportNotFoundError());
+    const response = await isolatedApp().request('/reports/generate', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ type: 'executive_summary' }),
+    });
+    expect(response.status).toBe(404);
+  });
+
+  it('returns 429 with Retry-After for either limiter', async () => {
+    mocks.generateMock.mockRejectedValue(new PortalReportRateLimitError(47));
+    const response = await isolatedApp().request('/reports/generate', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ type: 'security_compliance_posture' }),
+    });
+    expect(response.status).toBe(429);
+    expect(response.headers.get('Retry-After')).toBe('47');
+  });
+
+  it('returns PDF bytes as an attachment', async () => {
+    mocks.pdfMock.mockResolvedValue(Buffer.from('%PDF-test'));
+    const response = await isolatedApp().request(
+      `/reports/runs/${RUN_ID}/pdf`,
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toBe('application/pdf');
+    expect(response.headers.get('content-disposition')).toContain('attachment');
+    expect(await response.text()).toBe('%PDF-test');
+    expect(mocks.pdfMock).toHaveBeenCalledWith(RUN_ID, ORG_ID, 'UTC');
+  });
+
+  it('returns 404 when an artifact run is absent', async () => {
+    mocks.pdfMock.mockRejectedValue(new PortalReportNotFoundError());
+    const response = await isolatedApp().request(
+      `/reports/runs/${RUN_ID}/pdf`,
+    );
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Report run not found',
+    });
+  });
+
+  it('returns CSV text as an attachment', async () => {
+    mocks.csvMock.mockResolvedValue('Device,Status\nLaptop,online\n');
+    const response = await isolatedApp().request(
+      `/reports/runs/${RUN_ID}/csv`,
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toBe(
+      'text/csv; charset=utf-8',
+    );
+    expect(response.headers.get('content-disposition')).toContain('attachment');
+    expect(await response.text()).toBe('Device,Status\nLaptop,online\n');
+    expect(mocks.csvMock).toHaveBeenCalledWith(RUN_ID, ORG_ID);
+  });
+
+  it('returns 422 when a completed run has no tabular data', async () => {
+    mocks.csvMock.mockRejectedValue(new PortalReportNoTabularDataError());
+    const response = await isolatedApp().request(
+      `/reports/runs/${RUN_ID}/csv`,
+    );
+    expect(response.status).toBe(422);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Report run has no tabular data to download',
+    });
+  });
+});
+
+describe('real portal router auth and enableReports gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.reportsEnabled = false;
+  });
+
+  it.each([
+    ['GET', '/reports/runs'],
+    ['POST', '/reports/generate'],
+  ])('returns 401 for unauthenticated %s %s', async (method, path) => {
+    const response = await portalRoutes.request(path, { method });
+    expect(response.status).toBe(401);
+    expect(mocks.listMock).not.toHaveBeenCalled();
+    expect(mocks.generateMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['GET', '/reports/runs'],
+    ['POST', '/reports/generate'],
+  ])('returns 403 when enableReports is false for %s %s', async (method, path) => {
+    const response = await portalRoutes.request(path, {
+      method,
+      headers: { Authorization: 'Bearer portal-token' },
+    });
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      code: 'PORTAL_REPORTS_DISABLED',
+    });
+    expect(mocks.listMock).not.toHaveBeenCalled();
+    expect(mocks.generateMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/portal/reports.ts
+++ b/apps/api/src/routes/portal/reports.ts
@@ -34,7 +34,11 @@ portalReportRoutes.get(
   async (c) => {
     const auth = c.get('portalAuth');
     const query = c.req.valid('query');
-    const payload = await listPortalRuns(auth.user.orgId, query);
+    const payload = await listPortalRuns(
+      auth.user.orgId,
+      auth.timezone,
+      query,
+    );
 
     applyPortalCacheHeaders(c, {
       scope: 'private',

--- a/apps/api/src/routes/portal/reports.ts
+++ b/apps/api/src/routes/portal/reports.ts
@@ -1,4 +1,25 @@
 import { Hono } from 'hono';
+import { zValidator } from '../../lib/validation';
+import {
+  generatePortalReport,
+  listPortalRuns,
+  PortalReportNoTabularDataError,
+  PortalReportNotFoundError,
+  PortalReportRateLimitError,
+  renderRunCsv,
+  renderRunPdf,
+} from '../../services/portal/reportsSelfService';
+import {
+  applyPortalCacheHeaders,
+  buildWeakEtag,
+  isEtagFresh,
+  validatePortalCookieCsrfRequest,
+} from './helpers';
+import {
+  portalReportGenerateSchema,
+  portalReportListSchema,
+  portalReportRunParamSchema,
+} from './schemas';
 
 // Route hub for the customer-portal reports surface, gated by the
 // `enableReports` strict flag (Task 3.3). Mounted at root in
@@ -6,3 +27,114 @@ import { Hono } from 'hono';
 // so a later wave can add absolute `/reports/...` handlers here without a
 // second mount.
 export const portalReportRoutes = new Hono();
+
+portalReportRoutes.get(
+  '/reports/runs',
+  zValidator('query', portalReportListSchema),
+  async (c) => {
+    const auth = c.get('portalAuth');
+    const query = c.req.valid('query');
+    const payload = await listPortalRuns(auth.user.orgId, query);
+
+    applyPortalCacheHeaders(c, {
+      scope: 'private',
+      browserMaxAgeSeconds: 30,
+      staleWhileRevalidateSeconds: 30,
+      vary: ['Authorization', 'Cookie'],
+    });
+    const etag = buildWeakEtag(payload);
+    c.header('ETag', etag);
+    if (isEtagFresh(c.req.header('if-none-match'), etag)) {
+      return new Response(null, {
+        status: 304,
+        headers: c.res.headers,
+      });
+    }
+    return c.json(payload);
+  },
+);
+
+portalReportRoutes.post(
+  '/reports/generate',
+  zValidator('json', portalReportGenerateSchema),
+  async (c) => {
+    const csrfError = validatePortalCookieCsrfRequest(c);
+    if (csrfError) return c.json({ error: csrfError }, 403);
+
+    const auth = c.get('portalAuth');
+    try {
+      const run = await generatePortalReport({
+        orgId: auth.user.orgId,
+        portalUserId: auth.user.id,
+        type: c.req.valid('json').type,
+      });
+      return c.json({ data: run }, 201);
+    } catch (error) {
+      if (error instanceof PortalReportNotFoundError) {
+        return c.json({ error: 'Portal report definition not found' }, 404);
+      }
+      if (error instanceof PortalReportRateLimitError) {
+        c.header('Retry-After', String(error.retryAfterSeconds));
+        return c.json(
+          { error: 'Report generation is temporarily limited' },
+          429,
+        );
+      }
+      throw error;
+    }
+  },
+);
+
+portalReportRoutes.get(
+  '/reports/runs/:id/pdf',
+  zValidator('param', portalReportRunParamSchema),
+  async (c) => {
+    const auth = c.get('portalAuth');
+    const runId = c.req.valid('param').id;
+    try {
+      const body = await renderRunPdf(runId, auth.user.orgId, auth.timezone);
+      c.header('Content-Type', 'application/pdf');
+      c.header(
+        'Content-Disposition',
+        `attachment; filename="portal-report-${runId}.pdf"`,
+      );
+      return c.body(new Uint8Array(body));
+    } catch (error) {
+      if (error instanceof PortalReportNotFoundError) {
+        return c.json({ error: 'Report run not found' }, 404);
+      }
+      console.error('[portal] PDF report render failed', { runId });
+      return c.json({ error: 'Could not render report' }, 500);
+    }
+  },
+);
+
+portalReportRoutes.get(
+  '/reports/runs/:id/csv',
+  zValidator('param', portalReportRunParamSchema),
+  async (c) => {
+    const auth = c.get('portalAuth');
+    const runId = c.req.valid('param').id;
+    try {
+      const body = await renderRunCsv(runId, auth.user.orgId);
+      c.header('Content-Type', 'text/csv; charset=utf-8');
+      c.header(
+        'Content-Disposition',
+        `attachment; filename="portal-report-${runId}.csv"`,
+      );
+      return c.body(body);
+    } catch (error) {
+      if (error instanceof PortalReportNotFoundError) {
+        return c.json({ error: 'Report run not found' }, 404);
+      }
+      if (error instanceof PortalReportNoTabularDataError) {
+        return c.json(
+          { error: 'Report run has no tabular data to download' },
+          422,
+        );
+      }
+      console.error('[portal] CSV report render failed', { runId });
+      return c.json({ error: 'Could not render report' }, 500);
+    }
+  },
+);

--- a/apps/api/src/routes/portal/reports.ts
+++ b/apps/api/src/routes/portal/reports.ts
@@ -98,12 +98,14 @@ portalReportRoutes.get(
         'Content-Disposition',
         `attachment; filename="portal-report-${runId}.pdf"`,
       );
+      c.header('Cache-Control', 'private, max-age=0, no-store');
+      c.header('Vary', 'Authorization, Cookie');
       return c.body(new Uint8Array(body));
     } catch (error) {
       if (error instanceof PortalReportNotFoundError) {
         return c.json({ error: 'Report run not found' }, 404);
       }
-      console.error('[portal] PDF report render failed', { runId });
+      console.error('[portal] PDF report render failed', { runId, error });
       return c.json({ error: 'Could not render report' }, 500);
     }
   },
@@ -122,6 +124,8 @@ portalReportRoutes.get(
         'Content-Disposition',
         `attachment; filename="portal-report-${runId}.csv"`,
       );
+      c.header('Cache-Control', 'private, max-age=0, no-store');
+      c.header('Vary', 'Authorization, Cookie');
       return c.body(body);
     } catch (error) {
       if (error instanceof PortalReportNotFoundError) {
@@ -133,7 +137,7 @@ portalReportRoutes.get(
           422,
         );
       }
-      console.error('[portal] CSV report render failed', { runId });
+      console.error('[portal] CSV report render failed', { runId, error });
       return c.json({ error: 'Could not render report' }, 500);
     }
   },

--- a/apps/api/src/routes/portal/schemas.ts
+++ b/apps/api/src/routes/portal/schemas.ts
@@ -1,5 +1,6 @@
 import { PORTAL_TICKET_COMMENT_MAX_CHARS } from '@breeze/shared';
 import { z } from 'zod';
+import { PORTAL_REPORT_TYPES } from '../../services/portal/reportsSelfService';
 
 // ============================================
 // Types
@@ -145,6 +146,22 @@ export const supportUsageQuerySchema = z.object({
     .string()
     .regex(/^\d{4}-(0[1-9]|1[0-2])$/)
     .optional(),
+});
+
+export const portalReportListSchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20)
+});
+
+// reportsSelfService imports the portal state constants above. Deferring this
+// schema's construction avoids eagerly reading its canonical type list while
+// that module cycle is still being initialized.
+export const portalReportGenerateSchema = z.lazy(() => z.object({
+  type: z.enum(PORTAL_REPORT_TYPES)
+}));
+
+export const portalReportRunParamSchema = z.object({
+  id: z.string().guid()
 });
 
 export const ticketPrioritySchema = z.enum(['low', 'normal', 'high', 'urgent']);

--- a/apps/api/src/routes/portal/schemas.ts
+++ b/apps/api/src/routes/portal/schemas.ts
@@ -1,6 +1,7 @@
 import { PORTAL_TICKET_COMMENT_MAX_CHARS } from '@breeze/shared';
 import { z } from 'zod';
 import { PORTAL_REPORT_TYPES } from '../../services/portal/reportsSelfService';
+import { PORTAL_RATE_LIMIT_REDIS_KEYS } from '../../services/portal/rateLimit';
 
 // ============================================
 // Types
@@ -63,9 +64,7 @@ export const SESSION_TTL_SECONDS = Math.floor(SESSION_TTL_MS / 1000);
 export const RESET_TTL_MS = 1000 * 60 * 60;
 export const PORTAL_SESSION_CAP = 20000;
 export const PORTAL_RESET_TOKEN_CAP = 20000;
-export const PORTAL_RATE_BUCKET_CAP = 50000;
 export const STATE_SWEEP_INTERVAL_MS = 60 * 1000;
-export const RATE_LIMIT_SWEEP_INTERVAL_MS = 5 * 60 * 1000;
 export const PORTAL_SESSION_COOKIE_NAME = 'breeze_portal_session';
 export const PORTAL_SESSION_COOKIE_PATH = '/';
 export const CSRF_HEADER_NAME = 'x-breeze-csrf';
@@ -76,16 +75,23 @@ export const INVITE_TTL_MS = 1000 * 60 * 60 * 24 * 7; // 7 days
 export const INVITE_TTL_SECONDS = Math.floor(INVITE_TTL_MS / 1000);
 export const PORTAL_INVITE_TOKEN_CAP = 20000;
 
-export const PORTAL_USE_REDIS =
-  process.env.PORTAL_STATE_BACKEND === 'redis' || process.env.NODE_ENV === 'production';
+// The state-backend switch and the rate limiter live in the services layer
+// (services/portal/rateLimit.ts) so services can use them without importing
+// route modules; re-exported here for the routes that always read them from
+// schemas.
+export {
+  PORTAL_RATE_BUCKET_CAP,
+  PORTAL_USE_REDIS,
+  RATE_LIMIT_SWEEP_INTERVAL_MS,
+} from '../../services/portal/rateLimit';
 
 export const PORTAL_REDIS_KEYS = {
   session: (token: string) => `portal:session:${token}`,
   userSessions: (userId: string) => `portal:user-sessions:${userId}`,
   resetToken: (hash: string) => `portal:reset:${hash}`,
   inviteToken: (hash: string) => `portal:invite:${hash}`,
-  rlAttempts: (key: string) => `portal:rl:attempts:${key}`,
-  rlBlock: (key: string) => `portal:rl:block:${key}`,
+  rlAttempts: PORTAL_RATE_LIMIT_REDIS_KEYS.attempts,
+  rlBlock: PORTAL_RATE_LIMIT_REDIS_KEYS.block,
 };
 
 export const LOGIN_RATE_LIMIT = {

--- a/apps/api/src/routes/reports.test.ts
+++ b/apps/api/src/routes/reports.test.ts
@@ -1534,6 +1534,105 @@ describe('report definition scope enforcement', () => {
     expect(db.delete).toHaveBeenCalledTimes(2);
   });
 
+  it('refuses PUT on a portal self-service definition while portal reports are enabled', async () => {
+    const definition = definitionMetadata({ portalSelfService: true });
+    let brandingCondition: unknown;
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectChain([definition]))
+      .mockReturnValueOnce(selectChain([definition]))
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn((condition) => {
+            brandingCondition = condition;
+            return { limit: vi.fn().mockResolvedValue([{ enableReports: true }]) };
+          })
+        })
+      } as any);
+
+    const response = await app().request(`/reports/${REPORT_ID}`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Renamed by the MSP' })
+    });
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({
+      error: 'portal_self_service_report'
+    });
+    expect(conditionHas(
+      brandingCondition,
+      'eq',
+      'portalBranding.orgId',
+      (value) => value === ORG_ID,
+    )).toBe(true);
+    expect(db.update).not.toHaveBeenCalled();
+    expect(writeRouteAudit).not.toHaveBeenCalled();
+  });
+
+  it('allows PUT on a portal self-service definition while portal reports are disabled', async () => {
+    const definition = definitionMetadata({ portalSelfService: true });
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectChain([definition]))
+      .mockReturnValueOnce(selectChain([definition]))
+      .mockReturnValueOnce(selectChain([{ enableReports: false }]));
+    vi.mocked(db.update).mockReturnValueOnce({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ ...definition, name: 'Renamed by the MSP' }])
+        })
+      })
+    } as any);
+
+    const response = await app().request(`/reports/${REPORT_ID}`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Renamed by the MSP' })
+    });
+
+    expect(response.status).toBe(200);
+    expect(db.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses POST /:id/generate on a portal self-service definition while portal reports are enabled', async () => {
+    const definition = {
+      ...definitionMetadata({ portalSelfService: true }),
+      name: 'Customer portal — Executive summary',
+      type: 'executive_summary',
+      config: {},
+      format: 'pdf',
+    };
+    let brandingCondition: unknown;
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectChain([definition]))
+      .mockReturnValueOnce(selectChain([definition]))
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn((condition) => {
+            brandingCondition = condition;
+            return { limit: vi.fn().mockResolvedValue([{ enableReports: true }]) };
+          })
+        })
+      } as any);
+
+    const response = await app().request(`/reports/${REPORT_ID}/generate`, {
+      method: 'POST'
+    });
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({
+      error: 'portal_self_service_report'
+    });
+    expect(conditionHas(
+      brandingCondition,
+      'eq',
+      'portalBranding.orgId',
+      (value) => value === ORG_ID,
+    )).toBe(true);
+    expect(db.insert).not.toHaveBeenCalled();
+    expect(db.update).not.toHaveBeenCalled();
+    expect(writeRouteAudit).not.toHaveBeenCalled();
+  });
+
   it('reauthorizes with a fresh complete authority snapshot atomically', async () => {
     const metadata = definitionMetadata({
       executionScopeKind: 'legacy_unscoped',

--- a/apps/api/src/routes/reports.test.ts
+++ b/apps/api/src/routes/reports.test.ts
@@ -173,7 +173,12 @@ vi.mock('../db/schema', () => ({
     executionScopeUserId: 'reports.executionScopeUserId',
     executionScopeFingerprint: 'reports.executionScopeFingerprint',
     executionScopeCapturedAt: 'reports.executionScopeCapturedAt',
-    executionScopePrincipalKind: 'reports.executionScopePrincipalKind'
+    executionScopePrincipalKind: 'reports.executionScopePrincipalKind',
+    portalSelfService: 'reports.portalSelfService'
+  },
+  portalBranding: {
+    orgId: 'portalBranding.orgId',
+    enableReports: 'portalBranding.enableReports'
   },
   reportRuns: {
     id: 'reportRuns.id',
@@ -1279,7 +1284,8 @@ describe('report definition scope enforcement', () => {
       'executionScopeUserId',
       'executionScopeFingerprint',
       'executionScopeCapturedAt',
-      'executionScopePrincipalKind'
+      'executionScopePrincipalKind',
+      'portalSelfService'
     ]);
     expect(metadataProjection).not.toHaveProperty('config');
     expect(resolveRequestReportAuthority).toHaveBeenCalledWith(
@@ -1457,6 +1463,75 @@ describe('report definition scope enforcement', () => {
     )).toBe(true);
     expect(rolledBack).toBe(true);
     expect(writeRouteAudit).not.toHaveBeenCalled();
+  });
+
+  it('returns portalSelfService and refuses deletion while portal reports are enabled', async () => {
+    const definition = definitionMetadata({ portalSelfService: true });
+    let brandingCondition: unknown;
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectChain([definition]))
+      .mockReturnValueOnce(selectChain([definition]))
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn((condition) => {
+            brandingCondition = condition;
+            return { limit: vi.fn().mockResolvedValue([{ enableReports: true }]) };
+          })
+        })
+      } as any);
+    vi.mocked(db.delete)
+      .mockReturnValueOnce({
+        where: vi.fn().mockResolvedValue(undefined)
+      } as any)
+      .mockReturnValueOnce({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([definition])
+        })
+      } as any);
+
+    const response = await app().request(`/reports/${REPORT_ID}`, {
+      method: 'DELETE'
+    });
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({
+      error: 'portal_self_service_report'
+    });
+    expect(conditionHas(
+      brandingCondition,
+      'eq',
+      'portalBranding.orgId',
+      (value) => value === ORG_ID,
+    )).toBe(true);
+    expect(db.delete).not.toHaveBeenCalled();
+  });
+
+  it('allows deletion of a portal self-service report while portal reports are disabled', async () => {
+    const definition = definitionMetadata({
+      portalSelfService: true,
+      name: 'Portal report',
+    });
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectChain([definition]))
+      .mockReturnValueOnce(selectChain([definition]))
+      .mockReturnValueOnce(selectChain([{ enableReports: false }]));
+    vi.mocked(db.delete)
+      .mockReturnValueOnce({
+        where: vi.fn().mockResolvedValue(undefined)
+      } as any)
+      .mockReturnValueOnce({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([definition])
+        })
+      } as any);
+
+    const response = await app().request(`/reports/${REPORT_ID}`, {
+      method: 'DELETE'
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true });
+    expect(db.delete).toHaveBeenCalledTimes(2);
   });
 
   it('reauthorizes with a fresh complete authority snapshot atomically', async () => {

--- a/apps/api/src/routes/reports/core.ts
+++ b/apps/api/src/routes/reports/core.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import { zValidator } from '../../lib/validation';
 import { and, eq, sql, desc, inArray, type SQL } from 'drizzle-orm';
 import { db } from '../../db';
-import { reports, reportRuns } from '../../db/schema';
+import { portalBranding, reports, reportRuns } from '../../db/schema';
 import {
   authMiddleware,
   requirePermission,
@@ -627,6 +627,18 @@ coreRoutes.delete(
       if (locked === SYSTEM_MANAGED) return SYSTEM_MANAGED;
       if (!locked) return null;
 
+      if (locked.locked.portalSelfService) {
+        const [branding] = await tx
+          .select({ enableReports: portalBranding.enableReports })
+          .from(portalBranding)
+          .where(eq(portalBranding.orgId, locked.locked.orgId))
+          .limit(1);
+
+        if (branding?.enableReports === true) {
+          return { kind: 'portal_self_service' as const };
+        }
+      }
+
       await tx
         .delete(reportRuns)
         .where(eq(reportRuns.reportId, reportId));
@@ -644,7 +656,7 @@ coreRoutes.delete(
       if (deletedRows.length !== 1) {
         throw new Error('REPORT_DELETE_SCOPE_CHANGED');
       }
-      return deletedRows[0]!;
+      return { kind: 'deleted' as const, report: deletedRows[0]! };
     }).catch((error) => {
       if (
         error instanceof Error &&
@@ -658,15 +670,18 @@ coreRoutes.delete(
     if (deleted === SYSTEM_MANAGED) {
       return c.json(SYSTEM_MANAGED_REPORT, 409);
     }
+    if (deleted?.kind === 'portal_self_service') {
+      return c.json({ error: 'portal_self_service_report' }, 409);
+    }
     if (!deleted) {
       return c.json(REPORT_NOT_FOUND, 404);
     }
     writeRouteAudit(c, {
-      orgId: deleted.orgId,
+      orgId: deleted.report.orgId,
       action: 'report.delete',
       resourceType: 'report',
-      resourceId: deleted.id,
-      resourceName: deleted.name
+      resourceId: deleted.report.id,
+      resourceName: deleted.report.name
     });
 
     return c.json({ success: true });

--- a/apps/api/src/routes/reports/core.ts
+++ b/apps/api/src/routes/reports/core.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import { zValidator } from '../../lib/validation';
 import { and, eq, sql, desc, inArray, type SQL } from 'drizzle-orm';
 import { db } from '../../db';
-import { portalBranding, reports, reportRuns } from '../../db/schema';
+import { reports, reportRuns } from '../../db/schema';
 import {
   authMiddleware,
   requirePermission,
@@ -15,7 +15,9 @@ import {
   getPagination,
   ensureOrgAccess,
   getReportWithOrgCheck,
+  isPortalSelfServiceLocked,
   isSystemManagedReportDefinition,
+  PORTAL_SELF_SERVICE_REPORT,
   reportDefinitionMetadataProjection,
   tenantAuthorizedReportCondition,
 } from './helpers';
@@ -50,6 +52,13 @@ const REPORT_NOT_FOUND = { error: 'Report not found' } as const;
 const SYSTEM_MANAGED_REPORT = { error: 'system_managed_report' } as const;
 /** `loadLockedDefinition`'s third outcome — see its docstring. */
 const SYSTEM_MANAGED = 'system_managed' as const;
+/**
+ * #4562 W10 — the mutation routes' fourth outcome: the definition is the
+ * customer portal's while `enable_reports` is on. See
+ * `isPortalSelfServiceLocked`. Not folded into `loadLockedDefinition` because
+ * it needs the locked row's org and a second table; callers answer 409.
+ */
+const PORTAL_SELF_SERVICE = 'portal_self_service' as const;
 
 type DefinitionListScopeResult =
   | { ok: true; tenantCondition?: SQL<unknown>; definitionScopePredicate: SQL<unknown> }
@@ -485,6 +494,9 @@ coreRoutes.put(
       );
       if (locked === SYSTEM_MANAGED) return SYSTEM_MANAGED;
       if (!locked) return null;
+      if (await isPortalSelfServiceLocked(tx, locked.locked)) {
+        return PORTAL_SELF_SERVICE;
+      }
 
       const effectiveScope = intersectSiteScopes(
         locked.storedScope,
@@ -509,6 +521,9 @@ coreRoutes.put(
 
     if (mutation === SYSTEM_MANAGED) {
       return c.json(SYSTEM_MANAGED_REPORT, 409);
+    }
+    if (mutation === PORTAL_SELF_SERVICE) {
+      return c.json(PORTAL_SELF_SERVICE_REPORT, 409);
     }
     if (!mutation) {
       return c.json(REPORT_NOT_FOUND, 404);
@@ -627,16 +642,8 @@ coreRoutes.delete(
       if (locked === SYSTEM_MANAGED) return SYSTEM_MANAGED;
       if (!locked) return null;
 
-      if (locked.locked.portalSelfService) {
-        const [branding] = await tx
-          .select({ enableReports: portalBranding.enableReports })
-          .from(portalBranding)
-          .where(eq(portalBranding.orgId, locked.locked.orgId))
-          .limit(1);
-
-        if (branding?.enableReports === true) {
-          return { kind: 'portal_self_service' as const };
-        }
+      if (await isPortalSelfServiceLocked(tx, locked.locked)) {
+        return { kind: PORTAL_SELF_SERVICE };
       }
 
       await tx
@@ -670,8 +677,8 @@ coreRoutes.delete(
     if (deleted === SYSTEM_MANAGED) {
       return c.json(SYSTEM_MANAGED_REPORT, 409);
     }
-    if (deleted?.kind === 'portal_self_service') {
-      return c.json({ error: 'portal_self_service_report' }, 409);
+    if (deleted?.kind === PORTAL_SELF_SERVICE) {
+      return c.json(PORTAL_SELF_SERVICE_REPORT, 409);
     }
     if (!deleted) {
       return c.json(REPORT_NOT_FOUND, 404);

--- a/apps/api/src/routes/reports/helpers.ts
+++ b/apps/api/src/routes/reports/helpers.ts
@@ -1,6 +1,6 @@
 import { and, eq, inArray, sql, type SQL } from 'drizzle-orm';
 import { db } from '../../db';
-import { reports, reportRuns } from '../../db/schema';
+import { portalBranding, reports, reportRuns } from '../../db/schema';
 import type { AuthContext } from '../../middleware/auth';
 import {
   decodeSiteScope,
@@ -15,6 +15,43 @@ import {
 } from '../../services/siteScope';
 
 export { getPagination } from '../../utils/pagination';
+
+/**
+ * #4562 W10 — a 409, not a 403, for the same reason as `system_managed_report`:
+ * the caller's permissions are fine, it is the definition's OWNERSHIP that
+ * makes the mutation impossible while the customer portal exposes it.
+ */
+export const PORTAL_SELF_SERVICE_REPORT = {
+  error: 'portal_self_service_report',
+} as const;
+
+/**
+ * #4562 W10 — is this definition the org's canonical customer-portal report
+ * (`portal_self_service`) while that org currently exposes portal reports?
+ *
+ * While `portal_branding.enable_reports` is on, the portal lists EVERY
+ * completed run of the definition and downloads it as the customer's own
+ * report (`portalRunListPredicate` keys on org + marker + status only), so
+ * the MSP must not rewrite its customer-safe config (PUT), generate a run
+ * under a tech's — possibly site-restricted — authority (POST /:id/generate),
+ * or delete it (DELETE). Once the flag is off the definition is an ordinary
+ * MSP-owned report again and every mutation is allowed. Spec §8.2 / R10-3.
+ *
+ * Takes the transaction (or `db`) so the write routes evaluate it on the
+ * same connection that holds the `FOR UPDATE` lock.
+ */
+export async function isPortalSelfServiceLocked(
+  tx: Pick<typeof db, 'select'>,
+  definition: { portalSelfService: boolean; orgId: string },
+): Promise<boolean> {
+  if (!definition.portalSelfService) return false;
+  const [branding] = await tx
+    .select({ enableReports: portalBranding.enableReports })
+    .from(portalBranding)
+    .where(eq(portalBranding.orgId, definition.orgId))
+    .limit(1);
+  return branding?.enableReports === true;
+}
 
 export async function ensureOrgAccess(
   orgId: string,

--- a/apps/api/src/routes/reports/helpers.ts
+++ b/apps/api/src/routes/reports/helpers.ts
@@ -114,6 +114,7 @@ export const reportDefinitionMetadataProjection = {
   executionScopeFingerprint: reports.executionScopeFingerprint,
   executionScopeCapturedAt: reports.executionScopeCapturedAt,
   executionScopePrincipalKind: reports.executionScopePrincipalKind,
+  portalSelfService: reports.portalSelfService,
 };
 
 /**

--- a/apps/api/src/routes/reports/runs.ts
+++ b/apps/api/src/routes/reports/runs.ts
@@ -17,7 +17,8 @@ import {
 } from '../../services/reportGenerationService';
 import { rowsToCsv, rowsToTsv } from '@breeze/shared';
 import {
-  getPagination, getReportWithOrgCheck, getReportRunWithOrgCheck, isSystemManagedReportDefinition,
+  getPagination, getReportWithOrgCheck, getReportRunWithOrgCheck, isPortalSelfServiceLocked,
+  isSystemManagedReportDefinition, PORTAL_SELF_SERVICE_REPORT,
 } from './helpers';
 import { downloadQuerySchema, listRunsSchema } from './schemas';
 import {
@@ -81,6 +82,15 @@ runsRoutes.post(
     // it is the report that cannot be generated on request.
     if (isSystemManagedReportDefinition(report)) {
       return c.json({ error: 'system_managed_report' }, 409);
+    }
+
+    // #4562 W10 — the canonical customer-portal definition is generated only
+    // by the customer, under a `portal_user` authority that is always
+    // org-unrestricted. A run created HERE would carry this caller's (possibly
+    // site-restricted) scope and still be listed by the portal as the
+    // customer's own report. Refused while the portal exposes reports.
+    if (await isPortalSelfServiceLocked(db, report)) {
+      return c.json(PORTAL_SELF_SERVICE_REPORT, 409);
     }
 
     const liveResult = await resolveRequestReportAuthority(

--- a/apps/api/src/services/portal/patchReadModel.test.ts
+++ b/apps/api/src/services/portal/patchReadModel.test.ts
@@ -66,6 +66,29 @@ describe('patchesAppliedTile', () => {
     }
   });
 
+  it('binds the window anchor as an ISO string, never a Date (#4562 W04 regression)', async () => {
+    state.rows.push([{ id: 'patch-source-row' }], [{ applied: 0 }], [{ devicesWithOutstandingCritical: 0 }]);
+
+    await patchesAppliedTile(ORG_ID, {
+      timezone: 'America/Denver',
+      now: new Date('2026-09-02T12:00:00Z'),
+    });
+
+    // Drizzle's postgres-js driver replaces the timestamp serializers with
+    // pass-throughs and relies on column mappers to stringify Dates. A Date
+    // bound inside a raw `sql` fragment skips the mappers and postgres.js
+    // throws `Buffer.byteLength ... Received an instance of Date` at bind
+    // time — against a real database only, which is how the portal e2e
+    // caught every dashboard request 500ing.
+    const compiled = state.wheres.map((where) =>
+      new PgDialect().sqlToQuery(where as SQL),
+    );
+    for (const query of compiled) {
+      expect(query.params.some((param) => param instanceof Date)).toBe(false);
+    }
+    expect(compiled[1]!.params).toContain('2026-09-02T12:00:00.000Z');
+  });
+
   it('returns no_data with null values when the org has no patch source rows', async () => {
     state.rows.push(
       [],

--- a/apps/api/src/services/portal/patchReadModel.ts
+++ b/apps/api/src/services/portal/patchReadModel.ts
@@ -7,8 +7,12 @@ import {
 } from '../../db/schema';
 
 export function portalMonthWindow(now: Date, timezone: string) {
+  // Bind the anchor as an ISO string: Drizzle's postgres-js driver leaves
+  // timestamp serialization to column mappers, which a raw fragment bypasses,
+  // and a bare Date makes postgres.js throw at bind time (#4562 W04 fix).
+  const anchor = now.toISOString();
   const localStart = sql<Date>`
-    date_trunc('month', ${now}::timestamptz at time zone ${timezone})
+    date_trunc('month', ${anchor}::timestamptz at time zone ${timezone})
   `;
   const start = sql<Date>`${localStart} at time zone ${timezone}`;
   const end = sql<Date>`

--- a/apps/api/src/services/portal/rateLimit.ts
+++ b/apps/api/src/services/portal/rateLimit.ts
@@ -1,0 +1,157 @@
+import { getRedis } from '../redis';
+
+/**
+ * Customer-portal state backend + rate limiter.
+ *
+ * Lives in the SERVICES layer on purpose. `services/portal/reportsSelfService`
+ * rate-limits report generation, and a service importing
+ * `routes/portal/helpers` for it dragged `routes/auth/helpers` → the services
+ * barrel → `commandQueue` → `agentWs` → the discovery worker into every module
+ * graph that touches portal flags (#4562 W10 broke `orgPortalSettings.test.ts`
+ * that way). Routes keep importing these names from `routes/portal/helpers` /
+ * `routes/portal/schemas`, which re-export them.
+ */
+
+/** Sessions, tokens and rate-limit buckets live in Redis when set (or in production). */
+export const PORTAL_USE_REDIS =
+  process.env.PORTAL_STATE_BACKEND === 'redis' || process.env.NODE_ENV === 'production';
+
+export const PORTAL_RATE_BUCKET_CAP = 50000;
+export const RATE_LIMIT_SWEEP_INTERVAL_MS = 5 * 60 * 1000;
+
+export const PORTAL_RATE_LIMIT_REDIS_KEYS = {
+  attempts: (key: string) => `portal:rl:attempts:${key}`,
+  block: (key: string) => `portal:rl:block:${key}`,
+};
+
+export const portalRateLimitBuckets = new Map<string, {
+  count: number;
+  resetAtMs: number;
+  blockedUntilMs: number;
+  lastSeenAtMs: number;
+}>();
+
+let lastRateLimitSweepAtMs = 0;
+
+// ============================================
+// Map cap / sweep helpers
+// ============================================
+
+export function capMapByOldest<T>(
+  map: Map<string, T>,
+  cap: number,
+  getAgeMs: (value: T) => number
+) {
+  if (map.size <= cap) {
+    return;
+  }
+
+  const overflow = map.size - cap;
+  const entries = Array.from(map.entries())
+    .sort(([, left], [, right]) => getAgeMs(left) - getAgeMs(right));
+
+  for (let i = 0; i < overflow; i++) {
+    const key = entries[i]?.[0];
+    if (key) {
+      map.delete(key);
+    }
+  }
+}
+
+function sweepRateLimitBuckets(nowMs: number = Date.now()) {
+  if (nowMs - lastRateLimitSweepAtMs < RATE_LIMIT_SWEEP_INTERVAL_MS) {
+    return;
+  }
+
+  lastRateLimitSweepAtMs = nowMs;
+
+  for (const [key, bucket] of portalRateLimitBuckets.entries()) {
+    const stale = bucket.resetAtMs <= nowMs && bucket.blockedUntilMs <= nowMs;
+    const idleTooLong = nowMs - bucket.lastSeenAtMs > RATE_LIMIT_SWEEP_INTERVAL_MS * 6;
+    if (stale || idleTooLong) {
+      portalRateLimitBuckets.delete(key);
+    }
+  }
+
+  capMapByOldest(portalRateLimitBuckets, PORTAL_RATE_BUCKET_CAP, (bucket) => bucket.lastSeenAtMs);
+}
+
+// ============================================
+// Rate limiting
+// ============================================
+
+export async function checkRateLimit(
+  key: string,
+  config: { windowMs: number; maxAttempts: number; blockMs: number },
+  nowMs: number = Date.now()
+): Promise<{ allowed: boolean; retryAfterSeconds: number }> {
+  if (PORTAL_USE_REDIS) {
+    const redis = getRedis();
+    if (!redis) {
+      if (process.env.NODE_ENV === 'production') {
+        return { allowed: false, retryAfterSeconds: 60 };
+      }
+      return { allowed: true, retryAfterSeconds: 0 };
+    }
+
+    const blockKey = PORTAL_RATE_LIMIT_REDIS_KEYS.block(key);
+    const blockTtl = await redis.ttl(blockKey);
+    if (blockTtl > 0) {
+      return { allowed: false, retryAfterSeconds: blockTtl };
+    }
+
+    const attemptsKey = PORTAL_RATE_LIMIT_REDIS_KEYS.attempts(key);
+    const windowSeconds = Math.ceil(config.windowMs / 1000);
+    const count = await redis.incr(attemptsKey);
+    if (count === 1) {
+      await redis.expire(attemptsKey, windowSeconds);
+    }
+
+    if (count > config.maxAttempts) {
+      const blockSeconds = Math.ceil(config.blockMs / 1000);
+      await redis.setex(blockKey, blockSeconds, '1');
+      return { allowed: false, retryAfterSeconds: blockSeconds };
+    }
+
+    return { allowed: true, retryAfterSeconds: 0 };
+  }
+
+  sweepRateLimitBuckets(nowMs);
+
+  let bucket = portalRateLimitBuckets.get(key);
+  if (!bucket || bucket.resetAtMs <= nowMs) {
+    bucket = {
+      count: 0,
+      resetAtMs: nowMs + config.windowMs,
+      blockedUntilMs: 0,
+      lastSeenAtMs: nowMs
+    };
+  }
+
+  if (bucket.blockedUntilMs > nowMs) {
+    bucket.lastSeenAtMs = nowMs;
+    portalRateLimitBuckets.set(key, bucket);
+    capMapByOldest(portalRateLimitBuckets, PORTAL_RATE_BUCKET_CAP, (entry) => entry.lastSeenAtMs);
+    return {
+      allowed: false,
+      retryAfterSeconds: Math.max(1, Math.ceil((bucket.blockedUntilMs - nowMs) / 1000))
+    };
+  }
+
+  bucket.count += 1;
+  bucket.lastSeenAtMs = nowMs;
+
+  if (bucket.count > config.maxAttempts) {
+    bucket.blockedUntilMs = nowMs + config.blockMs;
+    portalRateLimitBuckets.set(key, bucket);
+    capMapByOldest(portalRateLimitBuckets, PORTAL_RATE_BUCKET_CAP, (entry) => entry.lastSeenAtMs);
+    return {
+      allowed: false,
+      retryAfterSeconds: Math.max(1, Math.ceil(config.blockMs / 1000))
+    };
+  }
+
+  portalRateLimitBuckets.set(key, bucket);
+  capMapByOldest(portalRateLimitBuckets, PORTAL_RATE_BUCKET_CAP, (entry) => entry.lastSeenAtMs);
+  return { allowed: true, retryAfterSeconds: 0 };
+}

--- a/apps/api/src/services/portal/reportsSelfService.test.ts
+++ b/apps/api/src/services/portal/reportsSelfService.test.ts
@@ -68,8 +68,9 @@ vi.mock('../reportGenerationService', () => ({
   previousBaselineFor: state.previousBaselineFor,
 }));
 
-vi.mock('../../routes/portal/helpers', () => ({
+vi.mock('./rateLimit', () => ({
   checkRateLimit: state.checkRateLimit,
+  PORTAL_USE_REDIS: false,
 }));
 
 vi.mock('../redis', () => ({ getRedis: vi.fn(() => null) }));

--- a/apps/api/src/services/portal/reportsSelfService.test.ts
+++ b/apps/api/src/services/portal/reportsSelfService.test.ts
@@ -8,6 +8,12 @@ const state = vi.hoisted(() => ({
   selected: vi.fn(),
   where: undefined as SQL | undefined,
   conflict: vi.fn(),
+  insertReturning: vi.fn(),
+  updateReturning: vi.fn(),
+  updated: vi.fn(),
+  generateReport: vi.fn(),
+  previousBaselineFor: vi.fn(),
+  checkRateLimit: vi.fn(),
 }));
 
 vi.mock('../../db', () => ({
@@ -20,27 +26,74 @@ vi.mock('../../db', () => ({
             state.conflict(config);
             return Promise.resolve();
           }),
+          returning: state.insertReturning,
         };
       }),
     })),
-    select: vi.fn(() => ({
-      from: vi.fn(() => ({
-        where: vi.fn((where: SQL) => {
-          state.where = where;
-          return state.selected();
-        }),
-      })),
+    select: vi.fn(() => {
+      const chain: Record<string, unknown> = {};
+      chain.from = vi.fn(() => chain);
+      chain.innerJoin = vi.fn(() => chain);
+      chain.where = vi.fn((where: SQL) => {
+        state.where = where;
+        return chain;
+      });
+      chain.orderBy = vi.fn(() => chain);
+      chain.limit = vi.fn(() => chain);
+      chain.offset = vi.fn(() => chain);
+      chain.then = (
+        resolve: (value: unknown) => unknown,
+        reject: (reason: unknown) => unknown,
+      ) => state.selected().then(resolve, reject);
+      return chain;
+    }),
+    update: vi.fn(() => ({
+      set: vi.fn((values) => {
+        state.updated(values);
+        return {
+          where: vi.fn(() => ({ returning: state.updateReturning })),
+        };
+      }),
     })),
   },
 }));
 
+vi.mock('../reportGenerationService', () => ({
+  generateReport: state.generateReport,
+  previousBaselineFor: state.previousBaselineFor,
+}));
+
+vi.mock('../../routes/portal/helpers', () => ({
+  checkRateLimit: state.checkRateLimit,
+}));
+
+vi.mock('../redis', () => ({ getRedis: vi.fn(() => null) }));
+
+vi.mock('../reportBranding', () => ({
+  getReportBranding: vi.fn(),
+}));
+
+vi.mock('@breeze/shared/reportPdf', () => ({
+  buildReportPdf: vi.fn(),
+}));
+
+vi.mock('@breeze/shared', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@breeze/shared')>(),
+  rowsToCsv: vi.fn(),
+}));
+
 import {
+  generatePortalReport,
+  portalDefinitionPredicate,
   portalReportDefinitionsInsertQuery,
+  portalRunPredicate,
   provisionPortalReportDefinitions,
 } from './reportsSelfService';
 
 const ORG_ID = '11111111-1111-4111-8111-111111111111';
 const USER_ID = '22222222-2222-4222-8222-222222222222';
+const RUN_ID = '33333333-3333-4333-8333-333333333333';
+const PORTAL_USER_ID = '44444444-4444-4444-8444-444444444444';
 
 describe('provisionPortalReportDefinitions', () => {
   beforeEach(() => {
@@ -50,6 +103,16 @@ describe('provisionPortalReportDefinitions', () => {
       { type: 'executive_summary' },
       { type: 'security_compliance_posture' },
     ]);
+    state.insertReturning.mockResolvedValue([]);
+    state.updateReturning.mockResolvedValue([]);
+    state.generateReport.mockReset();
+    state.previousBaselineFor.mockReset();
+    state.previousBaselineFor.mockResolvedValue(undefined);
+    state.checkRateLimit.mockReset();
+    state.checkRateLimit.mockResolvedValue({
+      allowed: true,
+      retryAfterSeconds: 0,
+    });
   });
 
   it('inserts the two fixed customer-safe definitions idempotently', async () => {
@@ -121,5 +184,95 @@ describe('provisionPortalReportDefinitions', () => {
     })).rejects.toThrow(
       'Failed to provision portal report definition security_compliance_posture',
     );
+  });
+});
+
+describe('portal report SQL scope', () => {
+  it('pins canonical definitions to the session org and portal flag', () => {
+    const query = new PgDialect().sqlToQuery(
+      portalDefinitionPredicate(ORG_ID, 'executive_summary'),
+    );
+
+    expect(query.sql).toContain('"reports"."org_id" = $');
+    expect(query.sql).toContain('"reports"."portal_self_service" = $');
+    expect(query.params).toContain(ORG_ID);
+    expect(query.params).toContain(true);
+  });
+
+  it('pins run rendering to run id, org id, and portal flag', () => {
+    const query = new PgDialect().sqlToQuery(
+      portalRunPredicate(RUN_ID, ORG_ID),
+    );
+
+    expect(query.sql).toContain('"report_runs"."id" = $');
+    expect(query.sql).toContain('"reports"."org_id" = $');
+    expect(query.sql).toContain('"reports"."portal_self_service" = $');
+    expect(query.params).toEqual(expect.arrayContaining([
+      RUN_ID,
+      ORG_ID,
+      true,
+    ]));
+  });
+});
+
+describe('generatePortalReport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    state.selected.mockResolvedValueOnce([{
+      id: 'report-1',
+      orgId: ORG_ID,
+      type: 'executive_summary',
+      name: 'Customer portal — Executive summary',
+      config: {},
+    }]);
+    state.checkRateLimit.mockResolvedValue({
+      allowed: true,
+      retryAfterSeconds: 0,
+    });
+    state.previousBaselineFor.mockResolvedValue(undefined);
+  });
+
+  it('stores portal-user provenance and waits for generation', async () => {
+    state.insertReturning.mockResolvedValue([{
+      id: RUN_ID,
+      reportId: 'report-1',
+      status: 'running',
+      startedAt: new Date('2026-09-02T11:59:00.000Z'),
+      completedAt: null,
+      rowCount: null,
+      createdAt: new Date('2026-09-02T11:59:00.000Z'),
+    }]);
+    state.generateReport.mockResolvedValue({
+      rows: [{ name: 'Device 1' }],
+      rowCount: 1,
+      generatedAt: '2026-09-02T12:00:00.000Z',
+    });
+    state.updateReturning.mockResolvedValue([{
+      id: RUN_ID,
+      reportId: 'report-1',
+      status: 'completed',
+      startedAt: new Date('2026-09-02T11:59:00.000Z'),
+      completedAt: new Date('2026-09-02T12:00:00.000Z'),
+      rowCount: 1,
+      createdAt: new Date('2026-09-02T11:59:00.000Z'),
+    }]);
+
+    const result = await generatePortalReport({
+      orgId: ORG_ID,
+      portalUserId: PORTAL_USER_ID,
+      type: 'executive_summary',
+    });
+
+    expect(state.inserted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestedByKind: 'portal_user',
+        requestedByUserId: null,
+        requestedByPortalUserId: PORTAL_USER_ID,
+        executionScopePrincipalKind: 'portal_user',
+        executionScopeUserId: null,
+      }),
+    );
+    expect(state.generateReport).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe('completed');
   });
 });

--- a/apps/api/src/services/portal/reportsSelfService.test.ts
+++ b/apps/api/src/services/portal/reportsSelfService.test.ts
@@ -17,6 +17,7 @@ const state = vi.hoisted(() => ({
   getReportBranding: vi.fn(),
   buildReportPdf: vi.fn(),
   rowsToCsv: vi.fn(),
+  execute: vi.fn(),
 }));
 
 vi.mock('../../db', () => ({
@@ -58,6 +59,7 @@ vi.mock('../../db', () => ({
         };
       }),
     })),
+    execute: state.execute,
   },
 }));
 
@@ -126,6 +128,8 @@ describe('provisionPortalReportDefinitions', () => {
     state.getReportBranding.mockReset();
     state.buildReportPdf.mockReset();
     state.rowsToCsv.mockReset();
+    state.execute.mockReset();
+    state.execute.mockResolvedValue([{ prior_ms: 0 }]);
   });
 
   it('inserts the two fixed customer-safe definitions idempotently', async () => {
@@ -256,6 +260,43 @@ describe('generatePortalReport', () => {
     state.insertReturning.mockReset();
     state.updateReturning.mockReset();
     state.updated.mockReset();
+    state.execute.mockResolvedValue([{ prior_ms: 0 }]);
+  });
+
+  it('tightens the ambient transaction statement timeout before report work', async () => {
+    state.insertReturning.mockResolvedValue([{
+      id: RUN_ID,
+      reportId: 'report-1',
+      status: 'running',
+      startedAt: new Date('2026-09-02T11:59:00.000Z'),
+      completedAt: null,
+      rowCount: null,
+      createdAt: new Date('2026-09-02T11:59:00.000Z'),
+    }]);
+    state.generateReport.mockResolvedValue({ rows: [], rowCount: 0 });
+    state.updateReturning.mockResolvedValue([{
+      id: RUN_ID,
+      reportId: 'report-1',
+      status: 'completed',
+      startedAt: new Date('2026-09-02T11:59:00.000Z'),
+      completedAt: new Date('2026-09-02T12:00:00.000Z'),
+      rowCount: 0,
+      createdAt: new Date('2026-09-02T11:59:00.000Z'),
+    }]);
+
+    await generatePortalReport({
+      orgId: ORG_ID,
+      portalUserId: PORTAL_USER_ID,
+      type: 'executive_summary',
+    });
+
+    expect(state.execute).toHaveBeenCalled();
+    const query = new PgDialect().sqlToQuery(state.execute.mock.calls[0]![0]);
+    expect(query.sql).toMatch(/set_config\(\s*'statement_timeout'/);
+    expect(query.sql).toContain('pg_settings');
+    expect(query.params).toContain(60000);
+    expect(state.execute.mock.invocationCallOrder[0])
+      .toBeLessThan(state.checkRateLimit.mock.invocationCallOrder[0]!);
   });
 
   it('stores portal-user provenance and waits for generation', async () => {
@@ -498,9 +539,14 @@ describe('listPortalRuns', () => {
         createdAt: new Date('2026-09-02T11:59:00.000Z'),
       }]);
 
-    const result = await listPortalRuns(ORG_ID, { page: 0, limit: 500 });
+    const result = await listPortalRuns(
+      ORG_ID,
+      'America/Denver',
+      { page: 0, limit: 500 },
+    );
 
     expect(result.pagination).toEqual({ page: 1, limit: 100, total: 1 });
+    expect(result.timezone).toBe('America/Denver');
     expect(result.data).toEqual([expect.objectContaining({
       id: RUN_ID,
       rowCount: null,
@@ -512,6 +558,8 @@ describe('listPortalRuns', () => {
 describe('portal run rendering', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    state.execute.mockReset();
+    state.execute.mockResolvedValue([{ prior_ms: 0 }]);
     state.getReportBranding.mockResolvedValue({
       name: 'Partner',
       logoDataUrl: null,
@@ -537,6 +585,13 @@ describe('portal run rendering', () => {
       reportType: 'executive_summary',
       timezone: 'America/Denver',
     }));
+    expect(state.execute).toHaveBeenCalled();
+    const query = new PgDialect().sqlToQuery(state.execute.mock.calls[0]![0]);
+    expect(query.sql).toMatch(/set_config\(\s*'statement_timeout'/);
+    expect(query.sql).toContain('pg_settings');
+    expect(query.params).toContain(60000);
+    expect(state.execute.mock.invocationCallOrder[0])
+      .toBeLessThan(state.buildReportPdf.mock.invocationCallOrder[0]!);
   });
 
   it('renders tabular stored results as CSV', async () => {

--- a/apps/api/src/services/portal/reportsSelfService.test.ts
+++ b/apps/api/src/services/portal/reportsSelfService.test.ts
@@ -14,6 +14,9 @@ const state = vi.hoisted(() => ({
   generateReport: vi.fn(),
   previousBaselineFor: vi.fn(),
   checkRateLimit: vi.fn(),
+  getReportBranding: vi.fn(),
+  buildReportPdf: vi.fn(),
+  rowsToCsv: vi.fn(),
 }));
 
 vi.mock('../../db', () => ({
@@ -70,24 +73,31 @@ vi.mock('../../routes/portal/helpers', () => ({
 vi.mock('../redis', () => ({ getRedis: vi.fn(() => null) }));
 
 vi.mock('../reportBranding', () => ({
-  getReportBranding: vi.fn(),
+  getReportBranding: state.getReportBranding,
 }));
 
 vi.mock('@breeze/shared/reportPdf', () => ({
-  buildReportPdf: vi.fn(),
+  buildReportPdf: state.buildReportPdf,
 }));
 
 vi.mock('@breeze/shared', async (importOriginal) => ({
   ...await importOriginal<typeof import('@breeze/shared')>(),
-  rowsToCsv: vi.fn(),
+  rowsToCsv: state.rowsToCsv,
 }));
 
 import {
   generatePortalReport,
+  listPortalRuns,
   portalDefinitionPredicate,
   portalReportDefinitionsInsertQuery,
+  portalRunListPredicate,
   portalRunPredicate,
+  PortalReportNoTabularDataError,
+  PortalReportNotFoundError,
+  PortalReportRateLimitError,
   provisionPortalReportDefinitions,
+  renderRunCsv,
+  renderRunPdf,
 } from './reportsSelfService';
 
 const ORG_ID = '11111111-1111-4111-8111-111111111111';
@@ -113,6 +123,9 @@ describe('provisionPortalReportDefinitions', () => {
       allowed: true,
       retryAfterSeconds: 0,
     });
+    state.getReportBranding.mockReset();
+    state.buildReportPdf.mockReset();
+    state.rowsToCsv.mockReset();
   });
 
   it('inserts the two fixed customer-safe definitions idempotently', async () => {
@@ -213,6 +226,16 @@ describe('portal report SQL scope', () => {
       true,
     ]));
   });
+
+  it('pins run listing to the session org and portal flag', () => {
+    const query = new PgDialect().sqlToQuery(
+      portalRunListPredicate(ORG_ID),
+    );
+
+    expect(query.sql).toContain('"reports"."org_id" = $');
+    expect(query.sql).toContain('"reports"."portal_self_service" = $');
+    expect(query.params).toEqual(expect.arrayContaining([ORG_ID, true]));
+  });
 });
 
 describe('generatePortalReport', () => {
@@ -230,6 +253,9 @@ describe('generatePortalReport', () => {
       retryAfterSeconds: 0,
     });
     state.previousBaselineFor.mockResolvedValue(undefined);
+    state.insertReturning.mockReset();
+    state.updateReturning.mockReset();
+    state.updated.mockReset();
   });
 
   it('stores portal-user provenance and waits for generation', async () => {
@@ -274,5 +300,281 @@ describe('generatePortalReport', () => {
     );
     expect(state.generateReport).toHaveBeenCalledTimes(1);
     expect(result.status).toBe('completed');
+  });
+
+  it('keeps rowCount null when the report has no row concept', async () => {
+    state.insertReturning.mockResolvedValue([{
+      id: RUN_ID,
+      reportId: 'report-1',
+      status: 'running',
+      startedAt: new Date('2026-09-02T11:59:00.000Z'),
+      completedAt: null,
+      rowCount: null,
+      createdAt: new Date('2026-09-02T11:59:00.000Z'),
+    }]);
+    state.generateReport.mockResolvedValue({
+      summary: { deviceCount: 12 },
+      generatedAt: '2026-09-02T12:00:00.000Z',
+    });
+    state.updateReturning.mockResolvedValue([{
+      id: RUN_ID,
+      reportId: 'report-1',
+      status: 'completed',
+      startedAt: new Date('2026-09-02T11:59:00.000Z'),
+      completedAt: new Date('2026-09-02T12:00:00.000Z'),
+      rowCount: null,
+      createdAt: new Date('2026-09-02T11:59:00.000Z'),
+    }]);
+
+    await generatePortalReport({
+      orgId: ORG_ID,
+      portalUserId: PORTAL_USER_ID,
+      type: 'executive_summary',
+    });
+
+    expect(state.updated).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'completed',
+      rowCount: null,
+    }));
+  });
+
+  it('rejects limiter denial with the retry interval', async () => {
+    state.checkRateLimit.mockResolvedValue({
+      allowed: false,
+      retryAfterSeconds: 47,
+    });
+
+    const error = await generatePortalReport({
+      orgId: ORG_ID,
+      portalUserId: PORTAL_USER_ID,
+      type: 'executive_summary',
+    }).catch((caught) => caught);
+
+    expect(error).toBeInstanceOf(PortalReportRateLimitError);
+    expect(error.retryAfterSeconds).toBe(47);
+    expect(state.generateReport).not.toHaveBeenCalled();
+  });
+
+  it('rejects a second concurrent run for the same org and type', async () => {
+    let resolveGeneration!: (value: { rows: unknown[]; rowCount: number }) => void;
+    const generation = new Promise<{ rows: unknown[]; rowCount: number }>((resolve) => {
+      resolveGeneration = resolve;
+    });
+    state.selected.mockReset().mockResolvedValue([{
+      id: 'report-1',
+      orgId: ORG_ID,
+      type: 'executive_summary',
+      name: 'Customer portal — Executive summary',
+      config: {},
+    }]);
+    state.insertReturning.mockResolvedValue([{
+      id: RUN_ID,
+      reportId: 'report-1',
+      status: 'running',
+      startedAt: new Date('2026-09-02T11:59:00.000Z'),
+      completedAt: null,
+      rowCount: null,
+      createdAt: new Date('2026-09-02T11:59:00.000Z'),
+    }]);
+    state.generateReport.mockReturnValue(generation);
+    state.updateReturning.mockResolvedValue([{
+      id: RUN_ID,
+      reportId: 'report-1',
+      status: 'completed',
+      startedAt: new Date('2026-09-02T11:59:00.000Z'),
+      completedAt: new Date('2026-09-02T12:00:00.000Z'),
+      rowCount: 1,
+      createdAt: new Date('2026-09-02T11:59:00.000Z'),
+    }]);
+
+    const first = generatePortalReport({
+      orgId: ORG_ID,
+      portalUserId: PORTAL_USER_ID,
+      type: 'executive_summary',
+    });
+    await vi.waitFor(() => expect(state.generateReport).toHaveBeenCalledOnce());
+
+    await expect(generatePortalReport({
+      orgId: ORG_ID,
+      portalUserId: PORTAL_USER_ID,
+      type: 'executive_summary',
+    })).rejects.toBeInstanceOf(PortalReportRateLimitError);
+
+    resolveGeneration({ rows: [{ id: 1 }], rowCount: 1 });
+    await first;
+  });
+
+  it('releases the in-flight key after generation fails', async () => {
+    state.selected.mockReset().mockResolvedValue([{
+      id: 'report-1',
+      orgId: ORG_ID,
+      type: 'executive_summary',
+      name: 'Customer portal — Executive summary',
+      config: {},
+    }]);
+    state.insertReturning.mockResolvedValue([{
+      id: RUN_ID,
+      reportId: 'report-1',
+      status: 'running',
+      startedAt: new Date('2026-09-02T11:59:00.000Z'),
+      completedAt: null,
+      rowCount: null,
+      createdAt: new Date('2026-09-02T11:59:00.000Z'),
+    }]);
+    state.generateReport
+      .mockRejectedValueOnce(new Error('renderer exploded'))
+      .mockResolvedValueOnce({ rows: [{ id: 1 }], rowCount: 1 });
+    state.updateReturning
+      .mockResolvedValueOnce([{
+        id: RUN_ID,
+        reportId: 'report-1',
+        status: 'failed',
+        startedAt: new Date('2026-09-02T11:59:00.000Z'),
+        completedAt: new Date('2026-09-02T12:00:00.000Z'),
+        rowCount: null,
+        createdAt: new Date('2026-09-02T11:59:00.000Z'),
+      }])
+      .mockResolvedValueOnce([{
+        id: RUN_ID,
+        reportId: 'report-1',
+        status: 'completed',
+        startedAt: new Date('2026-09-02T11:59:00.000Z'),
+        completedAt: new Date('2026-09-02T12:00:00.000Z'),
+        rowCount: 1,
+        createdAt: new Date('2026-09-02T11:59:00.000Z'),
+      }]);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const failed = await generatePortalReport({
+      orgId: ORG_ID,
+      portalUserId: PORTAL_USER_ID,
+      type: 'executive_summary',
+    });
+    const completed = await generatePortalReport({
+      orgId: ORG_ID,
+      portalUserId: PORTAL_USER_ID,
+      type: 'executive_summary',
+    });
+
+    expect(failed.status).toBe('failed');
+    expect(completed.status).toBe('completed');
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[portal-reports] Report generation failed',
+      expect.objectContaining({
+        runId: RUN_ID,
+        orgId: ORG_ID,
+        type: 'executive_summary',
+        error: 'renderer exploded',
+      }),
+    );
+    errorSpy.mockRestore();
+  });
+
+  it('rejects a missing portal definition with the typed not-found error', async () => {
+    state.selected.mockReset().mockResolvedValue([]);
+
+    await expect(generatePortalReport({
+      orgId: ORG_ID,
+      portalUserId: PORTAL_USER_ID,
+      type: 'executive_summary',
+    })).rejects.toBeInstanceOf(PortalReportNotFoundError);
+  });
+});
+
+describe('listPortalRuns', () => {
+  it('returns completed portal runs with clamped pagination', async () => {
+    state.selected
+      .mockReset()
+      .mockResolvedValueOnce([{ total: 1 }])
+      .mockResolvedValueOnce([{
+        id: RUN_ID,
+        reportId: 'report-1',
+        name: 'Customer portal — Executive summary',
+        type: 'executive_summary',
+        status: 'completed',
+        startedAt: new Date('2026-09-02T11:59:00.000Z'),
+        completedAt: new Date('2026-09-02T12:00:00.000Z'),
+        rowCount: null,
+        createdAt: new Date('2026-09-02T11:59:00.000Z'),
+      }]);
+
+    const result = await listPortalRuns(ORG_ID, { page: 0, limit: 500 });
+
+    expect(result.pagination).toEqual({ page: 1, limit: 100, total: 1 });
+    expect(result.data).toEqual([expect.objectContaining({
+      id: RUN_ID,
+      rowCount: null,
+      status: 'completed',
+    })]);
+  });
+});
+
+describe('portal run rendering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    state.getReportBranding.mockResolvedValue({
+      name: 'Partner',
+      logoDataUrl: null,
+      logoAspect: null,
+    });
+  });
+
+  it('renders a stored run as PDF with the requested timezone', async () => {
+    state.selected.mockResolvedValue([{
+      id: RUN_ID,
+      type: 'executive_summary',
+      result: { summary: { deviceCount: 12 } },
+      completedAt: new Date('2026-09-02T12:00:00.000Z'),
+    }]);
+    state.buildReportPdf.mockReturnValue({
+      output: vi.fn(() => Uint8Array.from([1, 2, 3]).buffer),
+    });
+
+    const pdf = await renderRunPdf(RUN_ID, ORG_ID, 'America/Denver');
+
+    expect(pdf).toEqual(Buffer.from([1, 2, 3]));
+    expect(state.buildReportPdf).toHaveBeenCalledWith([], expect.objectContaining({
+      reportType: 'executive_summary',
+      timezone: 'America/Denver',
+    }));
+  });
+
+  it('renders tabular stored results as CSV', async () => {
+    const rows = [{ hostname: 'device-1' }];
+    state.selected.mockResolvedValue([{
+      id: RUN_ID,
+      type: 'security_compliance_posture',
+      result: { rows },
+      completedAt: new Date('2026-09-02T12:00:00.000Z'),
+    }]);
+    state.rowsToCsv.mockReturnValue('hostname\ndevice-1');
+
+    await expect(renderRunCsv(RUN_ID, ORG_ID)).resolves.toBe(
+      'hostname\ndevice-1',
+    );
+    expect(state.rowsToCsv).toHaveBeenCalledWith(rows);
+  });
+
+  it('uses a typed conflict error when a run has no tabular result', async () => {
+    state.selected.mockResolvedValue([{
+      id: RUN_ID,
+      type: 'executive_summary',
+      result: { summary: { deviceCount: 12 } },
+      completedAt: new Date('2026-09-02T12:00:00.000Z'),
+    }]);
+
+    await expect(renderRunCsv(RUN_ID, ORG_ID)).rejects.toBeInstanceOf(
+      PortalReportNoTabularDataError,
+    );
+  });
+
+  it('uses the typed not-found error for an inaccessible run', async () => {
+    state.selected.mockResolvedValue([]);
+
+    await expect(renderRunPdf(
+      RUN_ID,
+      ORG_ID,
+      'America/Denver',
+    )).rejects.toBeInstanceOf(PortalReportNotFoundError);
   });
 });

--- a/apps/api/src/services/portal/reportsSelfService.ts
+++ b/apps/api/src/services/portal/reportsSelfService.ts
@@ -1,8 +1,13 @@
 import { randomUUID } from 'node:crypto';
 import { and, count, desc, eq, sql } from 'drizzle-orm';
 import { buildReportPdf, type BuildOpts } from '@breeze/shared/reportPdf';
-import { rowsToCsv, type PortalRunDto } from '@breeze/shared';
+import {
+  rowsToCsv,
+  type PortalRunDto,
+  type PortalRunsDto,
+} from '@breeze/shared';
 import { db } from '../../db';
+import { tightenStatementTimeout } from '../../db/lockTimeout';
 import { reportRuns, reports } from '../../db/schema';
 import { checkRateLimit } from '../../routes/portal/helpers';
 import { PORTAL_USE_REDIS } from '../../routes/portal/schemas';
@@ -144,6 +149,17 @@ export class PortalReportNoTabularDataError extends Error {
 // the PORTAL_STATE_BACKEND Redis store below for a cross-process guard.
 const inFlightUntil = new Map<string, number>();
 const IN_FLIGHT_TTL_SECONDS = 15 * 60;
+const PORTAL_REPORT_STATEMENT_TIMEOUT_MS = 60_000;
+
+/**
+ * Portal auth holds its organization-scoped RLS transaction through the route
+ * handler (#1105). R10-2 deliberately keeps report generation synchronous, so
+ * tighten (but never widen) the ambient transaction's statement timeout before
+ * the multi-query generation and PDF-render paths can pin that connection.
+ */
+async function tightenPortalReportStatementTimeout(): Promise<void> {
+  await tightenStatementTimeout(db, PORTAL_REPORT_STATEMENT_TIMEOUT_MS);
+}
 
 export function portalDefinitionPredicate(
   orgId: string,
@@ -231,11 +247,9 @@ async function acquireInFlight(key: string): Promise<() => Promise<void>> {
 
 export async function listPortalRuns(
   orgId: string,
+  timezone: string,
   opts: { page: number; limit: number },
-): Promise<{
-  data: PortalRunDto[];
-  pagination: { page: number; limit: number; total: number };
-}> {
+): Promise<PortalRunsDto> {
   const page = Math.max(1, opts.page);
   const limit = Math.min(100, Math.max(1, opts.limit));
   const offset = (page - 1) * limit;
@@ -270,6 +284,7 @@ export async function listPortalRuns(
       limit,
       total: Number(totalRow?.total ?? 0),
     },
+    timezone,
   };
 }
 
@@ -278,6 +293,8 @@ export async function generatePortalReport(args: {
   portalUserId: string;
   type: PortalReportType;
 }): Promise<PortalRunDto> {
+  await tightenPortalReportStatementTimeout();
+
   const [definition] = await db.select({
     id: reports.id,
     orgId: reports.orgId,
@@ -399,6 +416,8 @@ export async function renderRunPdf(
   orgId: string,
   timezone: string,
 ): Promise<Buffer> {
+  await tightenPortalReportStatementTimeout();
+
   const row = await completedRun(runId, orgId);
   const result = row.result as ReportResult | null;
   if (!result) throw new Error('Report result is unavailable');

--- a/apps/api/src/services/portal/reportsSelfService.ts
+++ b/apps/api/src/services/portal/reportsSelfService.ts
@@ -1,8 +1,21 @@
-import { and, eq, sql } from 'drizzle-orm';
+import { randomUUID } from 'node:crypto';
+import { and, count, desc, eq, sql } from 'drizzle-orm';
+import { buildReportPdf, type BuildOpts } from '@breeze/shared/reportPdf';
+import { rowsToCsv, type PortalRunDto } from '@breeze/shared';
 import { db } from '../../db';
-import { reports } from '../../db/schema';
+import { reportRuns, reports } from '../../db/schema';
+import { checkRateLimit } from '../../routes/portal/helpers';
+import { PORTAL_USE_REDIS } from '../../routes/portal/schemas';
+import { getRedis } from '../redis';
+import {
+  generateReport,
+  previousBaselineFor,
+  type ReportResult,
+} from '../reportGenerationService';
+import { getReportBranding } from '../reportBranding';
 import {
   persistedSiteScopeValues,
+  portalUserReportAuthority,
   siteScopeFingerprint,
   type UserReportExecutionAuthority,
 } from '../siteScope';
@@ -97,4 +110,306 @@ export async function provisionPortalReportDefinitions(
       );
     }
   }
+}
+
+export const PORTAL_REPORT_TYPES = [
+  'security_compliance_posture',
+  'executive_summary',
+] as const;
+
+export type PortalReportType = typeof PORTAL_REPORT_TYPES[number];
+
+export class PortalReportNotFoundError extends Error {
+  constructor() {
+    super('Portal report not found');
+    this.name = 'PortalReportNotFoundError';
+  }
+}
+
+export class PortalReportRateLimitError extends Error {
+  constructor(readonly retryAfterSeconds: number) {
+    super('Portal report generation is rate limited');
+    this.name = 'PortalReportRateLimitError';
+  }
+}
+
+// This fallback protects only one API process. Distributed deployments use
+// the PORTAL_STATE_BACKEND Redis store below for a cross-process guard.
+const inFlightUntil = new Map<string, number>();
+const IN_FLIGHT_TTL_SECONDS = 15 * 60;
+
+export function portalDefinitionPredicate(
+  orgId: string,
+  type: PortalReportType,
+) {
+  return and(
+    eq(reports.orgId, orgId),
+    eq(reports.type, type),
+    eq(reports.portalSelfService, true),
+  )!;
+}
+
+export function portalRunPredicate(runId: string, orgId: string) {
+  return and(
+    eq(reportRuns.id, runId),
+    eq(reports.orgId, orgId),
+    eq(reports.portalSelfService, true),
+  )!;
+}
+
+function toDto(row: {
+  id: string;
+  reportId: string;
+  name: string;
+  type: PortalReportType;
+  status: 'pending' | 'running' | 'completed' | 'failed';
+  startedAt: Date | null;
+  completedAt: Date | null;
+  rowCount: number | null;
+  createdAt: Date;
+}): PortalRunDto {
+  return {
+    id: row.id,
+    reportId: row.reportId,
+    name: row.name,
+    type: row.type,
+    status: row.status,
+    startedAt: row.startedAt?.toISOString() ?? null,
+    completedAt: row.completedAt?.toISOString() ?? null,
+    rowCount: row.rowCount,
+    createdAt: row.createdAt.toISOString(),
+  };
+}
+
+async function acquireInFlight(key: string): Promise<() => Promise<void>> {
+  const redis = PORTAL_USE_REDIS ? getRedis() : null;
+  const token = randomUUID();
+
+  if (redis) {
+    const acquired = await redis.set(
+      key,
+      token,
+      'EX',
+      IN_FLIGHT_TTL_SECONDS,
+      'NX',
+    );
+    if (acquired !== 'OK') throw new PortalReportRateLimitError(30);
+    return async () => {
+      await redis.eval(
+        'if redis.call("get", KEYS[1]) == ARGV[1] then '
+          + 'return redis.call("del", KEYS[1]) else return 0 end',
+        1,
+        key,
+        token,
+      );
+    };
+  }
+
+  const now = Date.now();
+  const expiresAt = inFlightUntil.get(key) ?? 0;
+  if (expiresAt > now) throw new PortalReportRateLimitError(30);
+  inFlightUntil.set(key, now + IN_FLIGHT_TTL_SECONDS * 1000);
+  return async () => {
+    inFlightUntil.delete(key);
+  };
+}
+
+export async function listPortalRuns(
+  orgId: string,
+  opts: { page: number; limit: number },
+): Promise<{
+  data: PortalRunDto[];
+  pagination: { page: number; limit: number; total: number };
+}> {
+  const page = Math.max(1, opts.page);
+  const limit = Math.min(100, Math.max(1, opts.limit));
+  const offset = (page - 1) * limit;
+  const where = and(
+    eq(reports.orgId, orgId),
+    eq(reports.portalSelfService, true),
+    eq(reportRuns.status, 'completed'),
+  );
+
+  const [totalRow] = await db.select({ total: count() })
+    .from(reportRuns)
+    .innerJoin(reports, eq(reportRuns.reportId, reports.id))
+    .where(where);
+
+  const rows = await db.select({
+    id: reportRuns.id,
+    reportId: reportRuns.reportId,
+    name: reports.name,
+    type: reports.type,
+    status: reportRuns.status,
+    startedAt: reportRuns.startedAt,
+    completedAt: reportRuns.completedAt,
+    rowCount: reportRuns.rowCount,
+    createdAt: reportRuns.createdAt,
+  }).from(reportRuns)
+    .innerJoin(reports, eq(reportRuns.reportId, reports.id))
+    .where(where)
+    .orderBy(desc(reportRuns.completedAt), desc(reportRuns.id))
+    .limit(limit)
+    .offset(offset);
+
+  return {
+    data: rows.map((row) => toDto(row as Parameters<typeof toDto>[0])),
+    pagination: {
+      page,
+      limit,
+      total: Number(totalRow?.total ?? 0),
+    },
+  };
+}
+
+export async function generatePortalReport(args: {
+  orgId: string;
+  portalUserId: string;
+  type: PortalReportType;
+}): Promise<PortalRunDto> {
+  const [definition] = await db.select({
+    id: reports.id,
+    orgId: reports.orgId,
+    name: reports.name,
+    type: reports.type,
+    config: reports.config,
+  }).from(reports)
+    .where(portalDefinitionPredicate(args.orgId, args.type))
+    .limit(1);
+
+  if (!definition) throw new PortalReportNotFoundError();
+
+  const inFlightKey = `portal:report:in-flight:${args.orgId}:${args.type}`;
+  const release = await acquireInFlight(inFlightKey);
+
+  try {
+    const rate = await checkRateLimit(
+      `report-generation:org:${args.orgId}`,
+      {
+        windowMs: 60 * 60 * 1000,
+        maxAttempts: 5,
+        blockMs: 60 * 60 * 1000,
+      },
+    );
+    if (!rate.allowed) {
+      throw new PortalReportRateLimitError(rate.retryAfterSeconds);
+    }
+
+    const startedAt = new Date();
+    const authority = portalUserReportAuthority(args.orgId, startedAt);
+    const [run] = await db.insert(reportRuns).values({
+      reportId: definition.id,
+      status: 'running',
+      startedAt,
+      requestedByKind: 'portal_user',
+      requestedByUserId: null,
+      requestedByPortalUserId: args.portalUserId,
+      ...persistedSiteScopeValues(authority),
+    }).returning();
+
+    if (!run) throw new Error('Failed to create portal report run');
+
+    try {
+      const result = await generateReport(
+        definition.type,
+        args.orgId,
+        (definition.config ?? {}) as Record<string, unknown>,
+        authority,
+      );
+      const previous = await previousBaselineFor(
+        definition.id,
+        authority.fingerprint,
+      );
+      if (previous) result.previous = previous;
+
+      const completedAt = new Date();
+      const rowCount = result.rowCount
+        ?? (Array.isArray(result.rows) ? result.rows.length : 0);
+      const [completed] = await db.update(reportRuns).set({
+        status: 'completed',
+        completedAt,
+        rowCount,
+        result,
+        outputUrl: `/api/v1/portal/reports/runs/${run.id}/pdf`,
+      }).where(eq(reportRuns.id, run.id)).returning();
+
+      return toDto({
+        ...completed!,
+        name: definition.name,
+        type: definition.type as PortalReportType,
+      });
+    } catch (error) {
+      const [failed] = await db.update(reportRuns).set({
+        status: 'failed',
+        completedAt: new Date(),
+        errorMessage:
+          error instanceof Error ? error.message : 'Report generation failed',
+      }).where(eq(reportRuns.id, run.id)).returning();
+
+      return toDto({
+        ...failed!,
+        name: definition.name,
+        type: definition.type as PortalReportType,
+      });
+    }
+  } finally {
+    await release();
+  }
+}
+
+async function completedRun(runId: string, orgId: string) {
+  const [row] = await db.select({
+    id: reportRuns.id,
+    type: reports.type,
+    result: reportRuns.result,
+    completedAt: reportRuns.completedAt,
+  }).from(reportRuns)
+    .innerJoin(reports, eq(reportRuns.reportId, reports.id))
+    .where(and(
+      portalRunPredicate(runId, orgId),
+      eq(reportRuns.status, 'completed'),
+    ))
+    .limit(1);
+
+  if (!row) throw new PortalReportNotFoundError();
+  return row;
+}
+
+export async function renderRunPdf(
+  runId: string,
+  orgId: string,
+  timezone: string,
+): Promise<Buffer> {
+  const row = await completedRun(runId, orgId);
+  const result = row.result as ReportResult | null;
+  if (!result) throw new Error('Report result is unavailable');
+
+  const branding = await getReportBranding(orgId);
+  const generatedAt = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(row.completedAt ?? new Date());
+
+  const document = buildReportPdf(result.rows ?? [], {
+    reportType: row.type,
+    generatedAt,
+    timezone,
+    summary: result.summary as BuildOpts['summary'],
+    previous: result.previous,
+    branding,
+  });
+  return Buffer.from(document.output('arraybuffer'));
+}
+
+export async function renderRunCsv(
+  runId: string,
+  orgId: string,
+): Promise<string> {
+  const row = await completedRun(runId, orgId);
+  const result = row.result as ReportResult | null;
+  if (!result || !Array.isArray(result.rows)) {
+    throw new Error('Report has no tabular result');
+  }
+  return rowsToCsv(result.rows);
 }

--- a/apps/api/src/services/portal/reportsSelfService.ts
+++ b/apps/api/src/services/portal/reportsSelfService.ts
@@ -9,8 +9,7 @@ import {
 import { db } from '../../db';
 import { tightenStatementTimeout } from '../../db/lockTimeout';
 import { reportRuns, reports } from '../../db/schema';
-import { checkRateLimit } from '../../routes/portal/helpers';
-import { PORTAL_USE_REDIS } from '../../routes/portal/schemas';
+import { checkRateLimit, PORTAL_USE_REDIS } from './rateLimit';
 import { getRedis } from '../redis';
 import {
   generateReport,

--- a/apps/api/src/services/portal/reportsSelfService.ts
+++ b/apps/api/src/services/portal/reportsSelfService.ts
@@ -133,6 +133,13 @@ export class PortalReportRateLimitError extends Error {
   }
 }
 
+export class PortalReportNoTabularDataError extends Error {
+  constructor() {
+    super('Report run has no tabular data to download');
+    this.name = 'PortalReportNoTabularDataError';
+  }
+}
+
 // This fallback protects only one API process. Distributed deployments use
 // the PORTAL_STATE_BACKEND Redis store below for a cross-process guard.
 const inFlightUntil = new Map<string, number>();
@@ -154,6 +161,14 @@ export function portalRunPredicate(runId: string, orgId: string) {
     eq(reportRuns.id, runId),
     eq(reports.orgId, orgId),
     eq(reports.portalSelfService, true),
+  )!;
+}
+
+export function portalRunListPredicate(orgId: string) {
+  return and(
+    eq(reports.orgId, orgId),
+    eq(reports.portalSelfService, true),
+    eq(reportRuns.status, 'completed'),
   )!;
 }
 
@@ -224,11 +239,7 @@ export async function listPortalRuns(
   const page = Math.max(1, opts.page);
   const limit = Math.min(100, Math.max(1, opts.limit));
   const offset = (page - 1) * limit;
-  const where = and(
-    eq(reports.orgId, orgId),
-    eq(reports.portalSelfService, true),
-    eq(reportRuns.status, 'completed'),
-  );
+  const where = portalRunListPredicate(orgId);
 
   const [totalRow] = await db.select({ total: count() })
     .from(reportRuns)
@@ -324,7 +335,7 @@ export async function generatePortalReport(args: {
 
       const completedAt = new Date();
       const rowCount = result.rowCount
-        ?? (Array.isArray(result.rows) ? result.rows.length : 0);
+        ?? (Array.isArray(result.rows) ? result.rows.length : null);
       const [completed] = await db.update(reportRuns).set({
         status: 'completed',
         completedAt,
@@ -339,11 +350,19 @@ export async function generatePortalReport(args: {
         type: definition.type as PortalReportType,
       });
     } catch (error) {
+      const errorMessage = error instanceof Error
+        ? error.message
+        : 'Report generation failed';
+      console.error('[portal-reports] Report generation failed', {
+        runId: run.id,
+        orgId: args.orgId,
+        type: args.type,
+        error: errorMessage,
+      });
       const [failed] = await db.update(reportRuns).set({
         status: 'failed',
         completedAt: new Date(),
-        errorMessage:
-          error instanceof Error ? error.message : 'Report generation failed',
+        errorMessage,
       }).where(eq(reportRuns.id, run.id)).returning();
 
       return toDto({
@@ -409,7 +428,7 @@ export async function renderRunCsv(
   const row = await completedRun(runId, orgId);
   const result = row.result as ReportResult | null;
   if (!result || !Array.isArray(result.rows)) {
-    throw new Error('Report has no tabular result');
+    throw new PortalReportNoTabularDataError();
   }
   return rowsToCsv(result.rows);
 }

--- a/apps/api/src/services/reportBranding.ts
+++ b/apps/api/src/services/reportBranding.ts
@@ -45,3 +45,9 @@ export async function loadReportBrandingForOrg(orgId: string): Promise<ReportBra
     logoAspect: aspect,
   };
 }
+
+export async function getReportBranding(
+  orgId: string,
+): Promise<ReportBranding> {
+  return loadReportBrandingForOrg(orgId);
+}

--- a/apps/portal/src/components/portal/LoginForm.tsx
+++ b/apps/portal/src/components/portal/LoginForm.tsx
@@ -79,6 +79,7 @@ export function LoginForm() {
         </label>
         <input
           id="email"
+          data-testid="portal-login-email"
           type="email"
           autoComplete="email"
           {...register('email')}
@@ -98,6 +99,7 @@ export function LoginForm() {
         </label>
         <input
           id="password"
+          data-testid="portal-login-password"
           type="password"
           autoComplete="current-password"
           {...register('password')}
@@ -122,7 +124,12 @@ export function LoginForm() {
         </a>
       </div>
 
-      <button type="submit" disabled={isLoading} className={cn(BTN_PRIMARY, 'w-full')}>
+      <button
+        type="submit"
+        data-testid="portal-login-submit"
+        disabled={isLoading}
+        className={cn(BTN_PRIMARY, 'w-full')}
+      >
         {isLoading ? (
           <>
             <Loader2 className="h-4 w-4 animate-spin" />

--- a/apps/portal/src/components/portal/ReportRunList.test.tsx
+++ b/apps/portal/src/components/portal/ReportRunList.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ReportRunList } from './ReportRunList';
+
+const { generateMock, listMock } = vi.hoisted(() => ({
+  generateMock: vi.fn(),
+  listMock: vi.fn(),
+}));
+
+vi.mock('@/lib/api', () => ({
+  portalApi: {
+    generateReport: generateMock,
+    getReportRuns: listMock,
+    reportArtifactUrl: (id: string, format: string) =>
+      `/api/v1/portal/reports/runs/${id}/${format}`,
+  },
+}));
+
+const run = {
+  id: 'run-1',
+  reportId: 'report-1',
+  name: 'Customer portal — Executive summary',
+  type: 'executive_summary',
+  status: 'completed',
+  startedAt: '2026-09-02T12:00:00.000Z',
+  completedAt: '2026-09-02T12:01:00.000Z',
+  rowCount: 4,
+  createdAt: '2026-09-02T12:00:00.000Z',
+};
+
+describe('ReportRunList', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('generates a report and renders PDF/CSV download links', async () => {
+    generateMock.mockResolvedValue({ data: run });
+    listMock.mockResolvedValue({ data: [run] });
+
+    render(<ReportRunList initialRuns={[]} />);
+
+    fireEvent.click(
+      screen.getByTestId('portal-reports-generate-executive'),
+    );
+
+    await waitFor(() => {
+      expect(generateMock).toHaveBeenCalledWith('executive_summary');
+    });
+    expect(
+      await screen.findByTestId('portal-report-run-row-run-1'),
+    ).toBeTruthy();
+
+    expect(
+      screen.getByTestId('portal-report-run-pdf-run-1').getAttribute('href'),
+    ).toBe(
+      '/api/v1/portal/reports/runs/run-1/pdf',
+    );
+    expect(
+      screen.getByTestId('portal-report-run-csv-run-1').getAttribute('href'),
+    ).toBe(
+      '/api/v1/portal/reports/runs/run-1/csv',
+    );
+  });
+});

--- a/apps/portal/src/components/portal/ReportRunList.test.tsx
+++ b/apps/portal/src/components/portal/ReportRunList.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { PortalRunDto } from '@breeze/shared';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ReportRunList } from './ReportRunList';
 
@@ -17,7 +18,7 @@ vi.mock('@/lib/api', () => ({
   },
 }));
 
-const run = {
+const run: PortalRunDto = {
   id: 'run-1',
   reportId: 'report-1',
   name: 'Customer portal — Executive summary',
@@ -36,7 +37,7 @@ describe('ReportRunList', () => {
     generateMock.mockResolvedValue({ data: run });
     listMock.mockResolvedValue({ data: [run] });
 
-    render(<ReportRunList initialRuns={[]} />);
+    render(<ReportRunList initialRuns={[]} timezone="America/Denver" />);
 
     fireEvent.click(
       screen.getByTestId('portal-reports-generate-executive'),
@@ -59,5 +60,17 @@ describe('ReportRunList', () => {
     ).toBe(
       '/api/v1/portal/reports/runs/run-1/csv',
     );
+  });
+
+  it('renders generated timestamps in the organization timezone with its label', () => {
+    render(
+      <ReportRunList
+        initialRuns={[run]}
+        timezone="America/Denver"
+      />,
+    );
+
+    expect(screen.getByTestId('portal-report-run-row-run-1').textContent)
+      .toContain('Sep 2, 2026, 06:01 AM (America/Denver)');
   });
 });

--- a/apps/portal/src/components/portal/ReportRunList.tsx
+++ b/apps/portal/src/components/portal/ReportRunList.tsx
@@ -1,0 +1,137 @@
+import { useState } from 'react';
+import type { PortalRunDto } from '@breeze/shared';
+import { portalApi } from '@/lib/api';
+import {
+  EmptyState,
+  ErrorNotice,
+  PageHeader,
+} from './ui';
+
+export function ReportRunList({
+  initialRuns,
+  error,
+}: {
+  initialRuns: PortalRunDto[];
+  error?: string | null;
+}) {
+  const [runs, setRuns] = useState(initialRuns);
+  const [busyType, setBusyType] = useState<string | null>(null);
+  const [message, setMessage] = useState(error ?? null);
+
+  async function generate(
+    type: 'security_compliance_posture' | 'executive_summary',
+  ) {
+    setBusyType(type);
+    setMessage(null);
+    const response = await portalApi.generateReport(type);
+    if (!response.data) {
+      setMessage(response.error ?? 'Could not generate the report.');
+      setBusyType(null);
+      return;
+    }
+
+    const refreshed = await portalApi.getReportRuns({
+      page: 1,
+      limit: 20,
+    });
+    setRuns(
+      refreshed.data
+        ?? (response.data.status === 'completed'
+          ? [response.data, ...runs]
+          : runs),
+    );
+    if (response.data.status === 'failed') {
+      setMessage('The report could not be generated.');
+    }
+    setBusyType(null);
+  }
+
+  return (
+    <div>
+      <PageHeader
+        title="Reports"
+        lede="Generate and download a current summary of your environment."
+      />
+
+      <div className="mb-8 flex flex-wrap gap-3">
+        <button
+          type="button"
+          data-testid="portal-reports-generate-posture"
+          disabled={busyType !== null}
+          onClick={() => void generate('security_compliance_posture')}
+          className="rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground disabled:opacity-50"
+        >
+          {busyType === 'security_compliance_posture'
+            ? 'Generating…'
+            : 'Generate security posture'}
+        </button>
+        <button
+          type="button"
+          data-testid="portal-reports-generate-executive"
+          disabled={busyType !== null}
+          onClick={() => void generate('executive_summary')}
+          className="rounded-md border px-4 py-2 text-sm font-semibold disabled:opacity-50"
+        >
+          {busyType === 'executive_summary'
+            ? 'Generating…'
+            : 'Generate executive summary'}
+        </button>
+      </div>
+
+      {message && <ErrorNotice>{message}</ErrorNotice>}
+
+      {runs.length === 0 ? (
+        <EmptyState title="No reports yet">
+          Generate a report to create the first downloadable snapshot.
+        </EmptyState>
+      ) : (
+        <table
+          className="w-full"
+          data-testid="portal-report-runs-table"
+        >
+          <thead>
+            <tr>
+              <th>Report</th>
+              <th>Generated</th>
+              <th>Downloads</th>
+            </tr>
+          </thead>
+          <tbody>
+            {runs.map((run) => (
+              <tr
+                key={run.id}
+                data-testid={`portal-report-run-row-${run.id}`}
+              >
+                <td>{run.name}</td>
+                <td>
+                  {run.completedAt
+                    ? new Date(run.completedAt).toLocaleString()
+                    : 'Not completed'}
+                </td>
+                <td>
+                  <a
+                    data-testid={`portal-report-run-pdf-${run.id}`}
+                    href={portalApi.reportArtifactUrl(run.id, 'pdf')}
+                    download
+                  >
+                    PDF
+                  </a>
+                  <a
+                    data-testid={`portal-report-run-csv-${run.id}`}
+                    href={portalApi.reportArtifactUrl(run.id, 'csv')}
+                    download
+                    className="ml-3"
+                  >
+                    CSV
+                  </a>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+export default ReportRunList;

--- a/apps/portal/src/components/portal/ReportRunList.tsx
+++ b/apps/portal/src/components/portal/ReportRunList.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import type { PortalRunDto } from '@breeze/shared';
 import { portalApi } from '@/lib/api';
+import { formatDateTime } from '@/lib/utils';
 import {
   EmptyState,
   ErrorNotice,
@@ -9,9 +10,11 @@ import {
 
 export function ReportRunList({
   initialRuns,
+  timezone,
   error,
 }: {
   initialRuns: PortalRunDto[];
+  timezone: string;
   error?: string | null;
 }) {
   const [runs, setRuns] = useState(initialRuns);
@@ -105,7 +108,7 @@ export function ReportRunList({
                 <td>{run.name}</td>
                 <td>
                   {run.completedAt
-                    ? new Date(run.completedAt).toLocaleString()
+                    ? `${formatDateTime(run.completedAt, timezone)} (${timezone})`
                     : 'Not completed'}
                 </td>
                 <td>

--- a/apps/portal/src/components/portal/index.ts
+++ b/apps/portal/src/components/portal/index.ts
@@ -11,3 +11,4 @@ export { default as TicketFormFields } from './TicketFormFields';
 export { TicketDetails } from './TicketDetails';
 export { AssetList } from './AssetList';
 export { ProfileSettings } from './ProfileSettings';
+export { ReportRunList } from './ReportRunList';

--- a/apps/portal/src/layouts/PortalLayout.astro
+++ b/apps/portal/src/layouts/PortalLayout.astro
@@ -77,6 +77,7 @@ const isActive = (href: string) => {
           {navItems.map((item) => (
             <a
               href={withBase(item.href)}
+              data-testid={`portal-nav-${item.href.slice(1) || 'home'}`}
               aria-current={isActive(item.href) ? 'page' : undefined}
               class:list={[
                 'group relative flex items-center rounded-md px-3 py-2 text-sm transition-colors duration-150',

--- a/apps/portal/src/lib/api.test.ts
+++ b/apps/portal/src/lib/api.test.ts
@@ -336,6 +336,7 @@ describe('portalApi customer reports', () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
       data: [run],
       pagination: { page: 2, limit: 5, total: 6 },
+      timezone: 'America/Denver',
     }), { status: 200 }));
     vi.stubGlobal('fetch', fetchMock);
 
@@ -347,6 +348,7 @@ describe('portalApi customer reports', () => {
     expect(result).toMatchObject({
       data: [run],
       pagination: { page: 2, limit: 5, total: 6 },
+      timezone: 'America/Denver',
       statusCode: 200,
     });
   });

--- a/apps/portal/src/lib/api.test.ts
+++ b/apps/portal/src/lib/api.test.ts
@@ -315,3 +315,80 @@ describe('portal security client', () => {
     );
   });
 });
+
+describe('portalApi customer reports', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('lists report runs with pagination and maps the response data', async () => {
+    const run = {
+      id: 'run-1',
+      reportId: 'report-1',
+      type: 'executive_summary',
+      name: 'Customer portal — Executive summary',
+      status: 'completed',
+      startedAt: '2026-09-02T12:00:00.000Z',
+      completedAt: '2026-09-02T12:01:00.000Z',
+      rowCount: 4,
+      createdAt: '2026-09-02T12:00:00.000Z',
+    };
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      data: [run],
+      pagination: { page: 2, limit: 5, total: 6 },
+    }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await portalApi.getReportRuns({ page: 2, limit: 5 });
+
+    expect(String(fetchMock.mock.calls[0][0])).toContain(
+      '/portal/reports/runs?page=2&limit=5',
+    );
+    expect(result).toMatchObject({
+      data: [run],
+      pagination: { page: 2, limit: 5, total: 6 },
+      statusCode: 200,
+    });
+  });
+
+  it('generates a report with the requested type and unwraps the run', async () => {
+    const run = {
+      id: 'run-2',
+      reportId: 'report-2',
+      type: 'security_compliance_posture',
+      name: 'Customer portal — Security compliance posture',
+      status: 'pending',
+      startedAt: null,
+      completedAt: null,
+      rowCount: null,
+      createdAt: '2026-09-02T12:00:00.000Z',
+    };
+    const fetchMock = vi.fn().mockResolvedValue(new Response(
+      JSON.stringify({ data: run }),
+      { status: 200 },
+    ));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await portalApi.generateReport(
+      'security_compliance_posture',
+    );
+
+    expect(String(fetchMock.mock.calls[0][0])).toContain(
+      '/portal/reports/generate',
+    );
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({
+      method: 'POST',
+      body: JSON.stringify({ type: 'security_compliance_posture' }),
+    });
+    expect(result).toMatchObject({ data: run, statusCode: 200 });
+  });
+
+  it('builds same-origin PDF and CSV artifact paths', () => {
+    expect(portalApi.reportArtifactUrl('run-1', 'pdf')).toBe(
+      '/api/v1/portal/reports/runs/run-1/pdf',
+    );
+    expect(portalApi.reportArtifactUrl('run-1', 'csv')).toBe(
+      '/api/v1/portal/reports/runs/run-1/csv',
+    );
+  });
+});

--- a/apps/portal/src/lib/api.ts
+++ b/apps/portal/src/lib/api.ts
@@ -8,6 +8,7 @@ import { navigateTo } from './navigation';
 // into local scope for the InvoiceSummary/InvoiceDetail types below and re-exported
 // (type-only, erased at build) so '@/lib/api' consumers are unaffected.
 import type { BackupDevicesDto, BackupOverviewDto, DashboardDto, DocumentPageSize, DocumentThemeId, EnrichedPortalDevice, InvoiceStatus, PublicQuoteHeader, QuotePresentation, SecurityDevicesDto, SecurityOverviewDto, SlaDto, SupportUsageDto, TicketFormField } from '@breeze/shared';
+import type { PortalRunDto } from '@breeze/shared';
 
 // Client API base. Empty (the default) → same-origin **relative** requests
 // (`/api/v1/...`), which the reverse proxy routes to the API under `/api/*`. This
@@ -1166,5 +1167,52 @@ export const portalApi = {
     apiGet<SupportUsageDto>(
       `/portal/tickets/usage${buildQueryString({ month })}`,
       config
-    )
+    ),
+
+  // W10 — customer reports
+  getReportRuns: async (
+    params: ListParams = {},
+    config: ApiRequestConfig = {},
+  ): Promise<PaginatedResult<PortalRunDto>> => {
+    const query = buildQueryString({
+      page: params.page ?? 1,
+      limit: params.limit ?? 20,
+    });
+    const response = await apiGet<{
+      data: PortalRunDto[];
+      pagination: Pagination;
+    }>(`/portal/reports/runs${query}`, config);
+    return mapPaginatedData(response);
+  },
+
+  generateReport: async (
+    type: 'security_compliance_posture' | 'executive_summary',
+    config: ApiRequestConfig = {},
+  ): Promise<ApiResponse<PortalRunDto>> => {
+    const response = await apiPost<{ data: PortalRunDto }>(
+      '/portal/reports/generate',
+      { type },
+      config,
+    );
+    if (!response.data) {
+      return {
+        error: response.error,
+        code: response.code,
+        errorData: response.errorData,
+        statusCode: response.statusCode,
+        headers: response.headers,
+      };
+    }
+    return {
+      data: response.data.data,
+      statusCode: response.statusCode,
+      headers: response.headers,
+    };
+  },
+
+  reportArtifactUrl: (
+    runId: string,
+    format: 'pdf' | 'csv',
+  ): PublicApiPath =>
+    publicApiPath(`/portal/reports/runs/${runId}/${format}`),
 };

--- a/apps/portal/src/lib/api.ts
+++ b/apps/portal/src/lib/api.ts
@@ -8,7 +8,7 @@ import { navigateTo } from './navigation';
 // into local scope for the InvoiceSummary/InvoiceDetail types below and re-exported
 // (type-only, erased at build) so '@/lib/api' consumers are unaffected.
 import type { BackupDevicesDto, BackupOverviewDto, DashboardDto, DocumentPageSize, DocumentThemeId, EnrichedPortalDevice, InvoiceStatus, PublicQuoteHeader, QuotePresentation, SecurityDevicesDto, SecurityOverviewDto, SlaDto, SupportUsageDto, TicketFormField } from '@breeze/shared';
-import type { PortalRunDto } from '@breeze/shared';
+import type { PortalRunDto, PortalRunsDto } from '@breeze/shared';
 
 // Client API base. Empty (the default) → same-origin **relative** requests
 // (`/api/v1/...`), which the reverse proxy routes to the API under `/api/*`. This
@@ -304,6 +304,10 @@ export interface Pagination {
 
 export interface PaginatedResult<T> extends ApiResponse<T[]> {
   pagination?: Pagination;
+}
+
+export interface PortalRunsResult extends PaginatedResult<PortalRunDto> {
+  timezone?: string;
 }
 
 export type Device = EnrichedPortalDevice;
@@ -1173,16 +1177,19 @@ export const portalApi = {
   getReportRuns: async (
     params: ListParams = {},
     config: ApiRequestConfig = {},
-  ): Promise<PaginatedResult<PortalRunDto>> => {
+  ): Promise<PortalRunsResult> => {
     const query = buildQueryString({
       page: params.page ?? 1,
       limit: params.limit ?? 20,
     });
-    const response = await apiGet<{
-      data: PortalRunDto[];
-      pagination: Pagination;
-    }>(`/portal/reports/runs${query}`, config);
-    return mapPaginatedData(response);
+    const response = await apiGet<PortalRunsDto>(
+      `/portal/reports/runs${query}`,
+      config,
+    );
+    return {
+      ...mapPaginatedData(response),
+      timezone: response.data?.timezone,
+    };
   },
 
   generateReport: async (

--- a/apps/portal/src/pages/reports/index.astro
+++ b/apps/portal/src/pages/reports/index.astro
@@ -1,0 +1,32 @@
+---
+import PortalLayout from '../../layouts/PortalLayout.astro';
+import ReportRunList from '../../components/portal/ReportRunList';
+import { portalApi } from '../../lib/api';
+import { withBase } from '../../lib/basePath';
+import { buildServerApiConfig } from '../../lib/server';
+import { redirectToLoginAfter401 } from '../../lib/session';
+
+const response = await portalApi.getReportRuns(
+  { page: 1, limit: 20 },
+  buildServerApiConfig(Astro.request),
+);
+
+if (response.statusCode === 401) {
+  return redirectToLoginAfter401(Astro);
+}
+
+// enable_reports gate 403s with PORTAL_REPORTS_DISABLED; bounce to the
+// portal home instead of rendering a dead page. Other 403s (e.g. "Account
+// is not active") fall through and render inline via the error prop.
+if (response.statusCode === 403 && response.code === 'PORTAL_REPORTS_DISABLED') {
+  return Astro.redirect(withBase('/devices'));
+}
+---
+
+<PortalLayout title="Reports">
+  <ReportRunList
+    client:load
+    initialRuns={response.data ?? []}
+    error={response.error}
+  />
+</PortalLayout>

--- a/apps/portal/src/pages/reports/index.astro
+++ b/apps/portal/src/pages/reports/index.astro
@@ -27,6 +27,7 @@ if (response.statusCode === 403 && response.code === 'PORTAL_REPORTS_DISABLED') 
   <ReportRunList
     client:load
     initialRuns={response.data ?? []}
+    timezone={response.timezone ?? 'UTC'}
     error={response.error}
   />
 </PortalLayout>

--- a/apps/web/src/components/reports/ReportsList.schedule.test.tsx
+++ b/apps/web/src/components/reports/ReportsList.schedule.test.tsx
@@ -68,7 +68,7 @@ describe('ReportsList schedule cell', () => {
     expect(screen.queryByText(/^Next: .+/)).not.toBeInTheDocument();
   });
 
-  it('shows the portal badge and hides mutation actions', async () => {
+  it('shows the portal badge, offers open-latest, and hides mutation actions', async () => {
     mountWith([{
       ...monthlyReport,
       portalSelfService: true,
@@ -79,6 +79,10 @@ describe('ReportsList schedule cell', () => {
     expect(
       await screen.findByTestId(`report-portal-badge-${monthlyReport.id}`),
     ).toHaveTextContent('Visible in customer portal');
+    // Read-only, not invisible: the MSP can still open what the customer sees.
+    expect(
+      screen.getByTestId(`report-open-latest-${monthlyReport.id}`),
+    ).toBeInTheDocument();
     expect(
       screen.queryByTestId(`report-generate-${monthlyReport.id}`),
     ).not.toBeInTheDocument();

--- a/apps/web/src/components/reports/ReportsList.schedule.test.tsx
+++ b/apps/web/src/components/reports/ReportsList.schedule.test.tsx
@@ -67,4 +67,26 @@ describe('ReportsList schedule cell', () => {
     await waitFor(() => expect(screen.getByText('One-off Alert Summary')).toBeInTheDocument());
     expect(screen.queryByText(/^Next: .+/)).not.toBeInTheDocument();
   });
+
+  it('shows the portal badge and hides mutation actions', async () => {
+    mountWith([{
+      ...monthlyReport,
+      portalSelfService: true,
+    }]);
+
+    render(<ReportsList />);
+
+    expect(
+      await screen.findByTestId(`report-portal-badge-${monthlyReport.id}`),
+    ).toHaveTextContent('Visible in customer portal');
+    expect(
+      screen.queryByTestId(`report-generate-${monthlyReport.id}`),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId(`report-delete-${monthlyReport.id}`),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId(`report-edit-${monthlyReport.id}`),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/reports/ReportsList.tsx
+++ b/apps/web/src/components/reports/ReportsList.tsx
@@ -521,11 +521,16 @@ export default function ReportsList({ onEdit, onGenerate, onDelete, timezone }: 
                       </td>
                       <td className="px-4 py-3">
                         <div className="flex items-center justify-end gap-1">
-                          {isSystemManagedReportType(report.type) ? (
-                            /* Generate/Edit/Delete all return 409 for these,
-                               so the row offers reading the newest run only. */
+                          {isSystemManagedReportType(report.type) || report.portalSelfService ? (
+                            /* Generate/Edit/Delete all return 409 for these —
+                               system-managed always, portal self-service
+                               (#4562) while the customer portal exposes
+                               reports — so the row offers reading the newest
+                               run only. Read-only, not invisible: the MSP can
+                               still open what the customer sees. */
                             <button
                               type="button"
+                              data-testid={`report-open-latest-${report.id}`}
                               onClick={() => handleOpenLatest(report)}
                               disabled={openingReportId === report.id}
                               className="flex h-8 items-center gap-1 rounded-md border px-3 text-sm hover:bg-muted disabled:opacity-50"
@@ -537,7 +542,7 @@ export default function ReportsList({ onEdit, onGenerate, onDelete, timezone }: 
                               )}
                               {t('reports.reportsList.aiNarrative.openLatest')}
                             </button>
-                          ) : !report.portalSelfService ? (
+                          ) : (
                             <>
                               <button
                                 type="button"
@@ -577,7 +582,7 @@ export default function ReportsList({ onEdit, onGenerate, onDelete, timezone }: 
                                 )}
                               </button>
                             </>
-                          ) : null}
+                          )}
                         </div>
                       </td>
                     </tr>

--- a/apps/web/src/components/reports/ReportsList.tsx
+++ b/apps/web/src/components/reports/ReportsList.tsx
@@ -64,6 +64,7 @@ export type Report = {
   schedule: ReportSchedule;
   format: ReportFormat;
   config: Record<string, unknown>;
+  portalSelfService: boolean;
   lastGeneratedAt: string | null;
   createdAt: string;
   updatedAt: string;
@@ -456,6 +457,14 @@ export default function ReportsList({ onEdit, onGenerate, onDelete, timezone }: 
                         <div className="flex items-center gap-2">
                           <FileText className="h-4 w-4 text-muted-foreground" />
                           <span className="font-medium">{report.name}</span>
+                          {report.portalSelfService && (
+                            <span
+                              data-testid={`report-portal-badge-${report.id}`}
+                              className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
+                            >
+                              {t('reports.reportsList.visibleInPortal')}
+                            </span>
+                          )}
                         </div>
                       </td>
                       <td className="px-4 py-3 text-sm">
@@ -528,10 +537,11 @@ export default function ReportsList({ onEdit, onGenerate, onDelete, timezone }: 
                               )}
                               {t('reports.reportsList.aiNarrative.openLatest')}
                             </button>
-                          ) : (
+                          ) : !report.portalSelfService ? (
                             <>
                               <button
                                 type="button"
+                                data-testid={`report-generate-${report.id}`}
                                 onClick={() => handleGenerate(report)}
                                 disabled={generatingIds.has(report.id)}
                                 className="flex h-8 w-8 items-center justify-center rounded-md hover:bg-muted disabled:opacity-50"
@@ -545,6 +555,7 @@ export default function ReportsList({ onEdit, onGenerate, onDelete, timezone }: 
                               </button>
                               <button
                                 type="button"
+                                data-testid={`report-edit-${report.id}`}
                                 onClick={() => onEdit?.(report)}
                                 className="flex h-8 w-8 items-center justify-center rounded-md hover:bg-muted"
                                 title={t('reports.reportsList.actions.edit')}
@@ -553,6 +564,7 @@ export default function ReportsList({ onEdit, onGenerate, onDelete, timezone }: 
                               </button>
                               <button
                                 type="button"
+                                data-testid={`report-delete-${report.id}`}
                                 onClick={() => handleDelete(report)}
                                 disabled={deletingId === report.id}
                                 className="flex h-8 w-8 items-center justify-center rounded-md hover:bg-muted text-destructive disabled:opacity-50"
@@ -565,7 +577,7 @@ export default function ReportsList({ onEdit, onGenerate, onDelete, timezone }: 
                                 )}
                               </button>
                             </>
-                          )}
+                          ) : null}
                         </div>
                       </td>
                     </tr>

--- a/apps/web/src/locales/de-DE/reports.json
+++ b/apps/web/src/locales/de-DE/reports.json
@@ -319,6 +319,7 @@
       },
       "loading": "Berichte werden geladen...",
       "never": "Niemals",
+      "visibleInPortal": "Im Kundenportal sichtbar",
       "newReport": "Neuer Bericht",
       "nextOccurrence": "Weiter: {{next}}",
       "reportTypes": {

--- a/apps/web/src/locales/en/reports.json
+++ b/apps/web/src/locales/en/reports.json
@@ -319,6 +319,7 @@
       },
       "loading": "Loading reports...",
       "never": "Never",
+      "visibleInPortal": "Visible in customer portal",
       "newReport": "New Report",
       "nextOccurrence": "Next: {{next}}",
       "reportTypes": {

--- a/apps/web/src/locales/es-419/reports.json
+++ b/apps/web/src/locales/es-419/reports.json
@@ -319,6 +319,7 @@
       },
       "loading": "Cargando informes...",
       "never": "Nunca",
+      "visibleInPortal": "Visible en el portal del cliente",
       "newReport": "Nuevo informe",
       "nextOccurrence": "Siguiente: {{next}}",
       "reportTypes": {

--- a/apps/web/src/locales/fr-CA/reports.json
+++ b/apps/web/src/locales/fr-CA/reports.json
@@ -319,6 +319,7 @@
       },
       "loading": "Chargement des rapports...",
       "never": "Jamais",
+      "visibleInPortal": "Visible dans le portail client",
       "newReport": "Nouveau rapport",
       "nextOccurrence": "Suite : {{next}}",
       "reportTypes": {

--- a/apps/web/src/locales/fr-FR/reports.json
+++ b/apps/web/src/locales/fr-FR/reports.json
@@ -319,6 +319,7 @@
       },
       "loading": "Chargement des rapports...",
       "never": "Jamais",
+      "visibleInPortal": "Visible dans le portail client",
       "newReport": "Nouveau rapport",
       "nextOccurrence": "Suite : {{next}}",
       "reportTypes": {

--- a/apps/web/src/locales/it-IT/reports.json
+++ b/apps/web/src/locales/it-IT/reports.json
@@ -100,6 +100,7 @@
       "formats": { "csv": "CSV", "excel": "Excel", "pdf": "PDF" },
       "loading": "Caricamento report...",
       "never": "Mai",
+      "visibleInPortal": "Visibile nel portale clienti",
       "newReport": "Nuovo report",
       "nextOccurrence": "Prossimo: {{next}}",
       "reportTypes": { "ai_org_narrative": "Resoconto settimanale delle operazioni AI", "alert_summary": "Riepilogo avvisi", "compliance": "Report conformità", "device_inventory": "Inventario dispositivi", "executive_summary": "Riepilogo direzionale", "performance": "Report prestazioni", "security_compliance_posture": "Stato sicurezza e conformità", "software_inventory": "Inventario software" },

--- a/apps/web/src/locales/pt-BR/reports.json
+++ b/apps/web/src/locales/pt-BR/reports.json
@@ -319,6 +319,7 @@
       },
       "loading": "Carregando relatórios...",
       "never": "Nunca",
+      "visibleInPortal": "Visível no portal do cliente",
       "newReport": "Novo Relatório",
       "nextOccurrence": "Proximo: {{next}}",
       "reportTypes": {

--- a/apps/web/src/locales/tr-TR/reports.json
+++ b/apps/web/src/locales/tr-TR/reports.json
@@ -319,6 +319,7 @@
       },
       "loading": "Raporlar yükleniyor...",
       "never": "Hiçbir zaman",
+      "visibleInPortal": "Müşteri portalında görünür",
       "newReport": "Yeni Rapor",
       "nextOccurrence": "Sonraki: {{next}}",
       "reportTypes": {

--- a/docs/superpowers/specs/portal/2026-09-02-portal-visibility-wave1-design.md
+++ b/docs/superpowers/specs/portal/2026-09-02-portal-visibility-wave1-design.md
@@ -80,7 +80,7 @@ All under `/api/v1/portal`, all behind `portalAuthMiddleware` + the prefix gate.
 | `GET /backups/overview` | Protected/unprotected device counts, last passed verification, last test restore, open RPO/RTO breaches, mean readiness. |
 | `GET /backups/devices?page&limit` | Per-device backup table. |
 | `GET /devices` (existing) | Add the enrichment columns (§7.6). |
-| `GET /devices/export.csv` | Same projection, streamed CSV, filename `<org-slug>-devices-<YYYY-MM-DD>.csv`. |
+| `GET /devices/export.csv` | Same projection, materialized in-transaction, paged 250 rows at a time as CSV, filename `<org-slug>-devices-<YYYY-MM-DD>.csv`. |
 | `GET /tickets` and `GET /tickets/:id` (existing) | Add `sla` object (§7.5). |
 | `GET /tickets/usage?month=YYYY-MM` | Month-to-date support usage (§7.5). Defaults to the current month in the org timezone. |
 | `GET /invoices/:id` (existing) | Customer line DTO gains `ticketNumber: string | null`. |
@@ -129,7 +129,7 @@ See §8.
 
 ### 7.6 Devices enrichment + CSV
 
-Columns added to the portal device projection: `lastPatchAt` (max `installed_at`), `protection` (7.1 state), `encryption`, `lastBackupAt` (7.3 last restore point), `warrantyEndsAt` (`device_warranty.warranty_end_date`). CSV export streams the same rows; header names are the UI labels.
+Columns added to the portal device projection: `lastPatchAt` (max `installed_at`), `protection` (7.1 state), `encryption`, `lastBackupAt` (7.3 last restore point), `warrantyEndsAt` (`device_warranty.warranty_end_date`). CSV export materializes the same rows in-transaction, paged 250 rows at a time; header names are the UI labels.
 
 ## 8. Report self-service
 

--- a/e2e-tests/pages/PortalVisibilityPage.ts
+++ b/e2e-tests/pages/PortalVisibilityPage.ts
@@ -10,9 +10,20 @@ export class PortalVisibilityPage {
     this.page.getByTestId('portal-reports-generate-posture');
   reportRows = () =>
     this.page.getByTestId(/^portal-report-run-row-/);
+  dashboardNav = () => this.page.getByTestId('portal-nav-dashboard');
   reportsNav = () => this.page.getByTestId('portal-nav-reports');
   devicesNav = () => this.page.getByTestId('portal-nav-devices');
+  dashboardTiles = () =>
+    this.page.getByTestId(/^portal-dashboard-tile-/);
+  dashboardSecurity = () =>
+    this.page.getByTestId('portal-dashboard-tile-security');
 
+  /**
+   * Lands on /quotes, not /dashboard: pages/index.astro redirects an
+   * authenticated customer to '/quotes' unconditionally, and enabling the
+   * dashboard adds a nav entry without changing that landing. Asserting
+   * '**\/dashboard' here would fail against the shipped app.
+   */
   async login(email: string, password: string): Promise<void> {
     await this.page.goto('/portal/login');
     await this.email().fill(email);

--- a/e2e-tests/pages/PortalVisibilityPage.ts
+++ b/e2e-tests/pages/PortalVisibilityPage.ts
@@ -19,16 +19,20 @@ export class PortalVisibilityPage {
     this.page.getByTestId('portal-dashboard-tile-security');
 
   /**
-   * Lands on /quotes, not /dashboard: pages/index.astro redirects an
-   * authenticated customer to '/quotes' unconditionally, and enabling the
-   * dashboard adds a nav entry without changing that landing. Asserting
-   * '**\/dashboard' here would fail against the shipped app.
+   * The post-login landing is decided by the portal middleware
+   * (`authenticatedLanding` → `lib/landing.ts`): '/dashboard' when the org's
+   * `enable_dashboard` flag is on, '/quotes' otherwise. The seeded org enables
+   * the dashboard, but accept either so the page object does not encode the
+   * seed. Dev-mode Astro compiles the landing page on first hit, hence the
+   * generous timeout.
    */
   async login(email: string, password: string): Promise<void> {
     await this.page.goto('/portal/login');
     await this.email().fill(email);
     await this.password().fill(password);
     await this.submit().click();
-    await this.page.waitForURL('**/quotes');
+    await this.page.waitForURL(/\/portal\/(dashboard|quotes)(?:[?#]|$)/, {
+      timeout: 60_000,
+    });
   }
 }

--- a/e2e-tests/pages/PortalVisibilityPage.ts
+++ b/e2e-tests/pages/PortalVisibilityPage.ts
@@ -1,0 +1,23 @@
+import type { Page } from '@playwright/test';
+
+export class PortalVisibilityPage {
+  constructor(private page: Page) {}
+
+  email = () => this.page.getByTestId('portal-login-email');
+  password = () => this.page.getByTestId('portal-login-password');
+  submit = () => this.page.getByTestId('portal-login-submit');
+  generatePosture = () =>
+    this.page.getByTestId('portal-reports-generate-posture');
+  reportRows = () =>
+    this.page.getByTestId(/^portal-report-run-row-/);
+  reportsNav = () => this.page.getByTestId('portal-nav-reports');
+  devicesNav = () => this.page.getByTestId('portal-nav-devices');
+
+  async login(email: string, password: string): Promise<void> {
+    await this.page.goto('/portal/login');
+    await this.email().fill(email);
+    await this.password().fill(password);
+    await this.submit().click();
+    await this.page.waitForURL('**/quotes');
+  }
+}

--- a/e2e-tests/seed-fixtures.sql
+++ b/e2e-tests/seed-fixtures.sql
@@ -101,17 +101,25 @@ BEGIN
     WHERE id = v_portal_user_id;
   END IF;
 
+  -- enable_dashboard is opt-in (column default false), so the Dashboard nav
+  -- entry and /dashboard page only exist for this org because it is set here.
+  -- enable_self_service stays false on purpose: portal-visibility.spec.ts
+  -- asserts the Devices nav entry is absent, which is the fail-open flag's
+  -- only negative case.
   INSERT INTO portal_branding (
     org_id,
+    enable_dashboard,
     enable_reports,
     enable_self_service
   ) VALUES (
     v_org_id,
     true,
+    true,
     false
   )
   ON CONFLICT (org_id) DO UPDATE
-    SET enable_reports = EXCLUDED.enable_reports,
+    SET enable_dashboard = EXCLUDED.enable_dashboard,
+        enable_reports = EXCLUDED.enable_reports,
         enable_self_service = EXCLUDED.enable_self_service,
         updated_at = NOW();
 

--- a/e2e-tests/seed-fixtures.sql
+++ b/e2e-tests/seed-fixtures.sql
@@ -145,7 +145,13 @@ BEGIN
         'unrestricted',
         NULL,
         v_user_id,
-        repeat('0', 64),
+        encode(
+          sha256(convert_to(
+            '{"version":1,"kind":"unrestricted","orgId":"' || v_org_id::text || '"}',
+            'UTF8'
+          )),
+          'hex'
+        ),
         NOW(),
         'user',
         true
@@ -162,7 +168,13 @@ BEGIN
         'unrestricted',
         NULL,
         v_user_id,
-        repeat('0', 64),
+        encode(
+          sha256(convert_to(
+            '{"version":1,"kind":"unrestricted","orgId":"' || v_org_id::text || '"}',
+            'UTF8'
+          )),
+          'hex'
+        ),
         NOW(),
         'user',
         true
@@ -172,6 +184,13 @@ BEGIN
       name = EXCLUDED.name,
       config = EXCLUDED.config,
       format = EXCLUDED.format,
+      execution_scope_version = EXCLUDED.execution_scope_version,
+      execution_scope_kind = EXCLUDED.execution_scope_kind,
+      execution_scope_site_ids = EXCLUDED.execution_scope_site_ids,
+      execution_scope_user_id = EXCLUDED.execution_scope_user_id,
+      execution_scope_fingerprint = EXCLUDED.execution_scope_fingerprint,
+      execution_scope_captured_at = EXCLUDED.execution_scope_captured_at,
+      execution_scope_principal_kind = EXCLUDED.execution_scope_principal_kind,
       updated_at = NOW();
   END IF;
 

--- a/e2e-tests/seed-fixtures.sql
+++ b/e2e-tests/seed-fixtures.sql
@@ -22,6 +22,7 @@ DECLARE
   v_org_id UUID;
   v_site_id UUID;
   v_user_id UUID;
+  v_portal_user_id UUID;
   v_macos_device_id  UUID := '42fc7de0-48f5-48f2-846b-6dd95924baf9';
   v_windows_device_id UUID := 'e65460f3-413c-4599-a9a6-90ee71bbc4ff';
   v_baseline_win UUID;
@@ -32,7 +33,11 @@ DECLARE
   v_patch_moderate UUID;
   v_vuln_critical UUID;
 BEGIN
-  SELECT id INTO v_org_id FROM organizations LIMIT 1;
+  SELECT o.id INTO v_org_id
+  FROM organizations o
+  WHERE EXISTS (SELECT 1 FROM sites s WHERE s.org_id = o.id)
+  ORDER BY o.created_at
+  LIMIT 1;
   IF v_org_id IS NULL THEN
     RAISE NOTICE 'No organization found — run autoMigrate seed first.';
     RETURN;
@@ -56,6 +61,118 @@ BEGIN
     SET setup_completed_at = NOW(),
         preferences = preferences - 'bootstrapSetupRequired'
     WHERE id = v_user_id AND setup_completed_at IS NULL;
+  END IF;
+
+  -- ───────────────────────────────────────────────────────────────────
+  -- Customer portal visibility + report self-service
+  -- Password hash generated with apps/api/src/services/password.ts for
+  -- E2E_PORTAL_PASSWORD's default, PortalTest123!; plaintext is never stored.
+  -- ───────────────────────────────────────────────────────────────────
+  SELECT id INTO v_portal_user_id
+  FROM portal_users
+  WHERE org_id = v_org_id AND email = 'portal@breeze.local'
+  ORDER BY created_at
+  LIMIT 1;
+
+  IF v_portal_user_id IS NULL THEN
+    INSERT INTO portal_users (
+      org_id,
+      email,
+      name,
+      password_hash,
+      auth_method,
+      status
+    ) VALUES (
+      v_org_id,
+      'portal@breeze.local',
+      'E2E Portal Customer',
+      '$argon2id$v=19$m=65536,p=4,t=3$q5hKTRQYCXO6bbaMerNeMA$khldmE+NStz0U5xbEZGHFtSp7MVJ8eVmiGMZ0gAj5oE',
+      'password',
+      'active'
+    )
+    RETURNING id INTO v_portal_user_id;
+  ELSE
+    UPDATE portal_users
+    SET name = 'E2E Portal Customer',
+        password_hash = '$argon2id$v=19$m=65536,p=4,t=3$q5hKTRQYCXO6bbaMerNeMA$khldmE+NStz0U5xbEZGHFtSp7MVJ8eVmiGMZ0gAj5oE',
+        auth_method = 'password',
+        status = 'active',
+        updated_at = NOW()
+    WHERE id = v_portal_user_id;
+  END IF;
+
+  INSERT INTO portal_branding (
+    org_id,
+    enable_reports,
+    enable_self_service
+  ) VALUES (
+    v_org_id,
+    true,
+    false
+  )
+  ON CONFLICT (org_id) DO UPDATE
+    SET enable_reports = EXCLUDED.enable_reports,
+        enable_self_service = EXCLUDED.enable_self_service,
+        updated_at = NOW();
+
+  IF v_user_id IS NOT NULL THEN
+    INSERT INTO reports (
+      org_id,
+      name,
+      type,
+      config,
+      schedule,
+      format,
+      created_by,
+      execution_scope_version,
+      execution_scope_kind,
+      execution_scope_site_ids,
+      execution_scope_user_id,
+      execution_scope_fingerprint,
+      execution_scope_captured_at,
+      execution_scope_principal_kind,
+      portal_self_service
+    ) VALUES
+      (
+        v_org_id,
+        'Customer portal — Executive summary',
+        'executive_summary',
+        '{"dateRange":{"preset":"last_30_days"},"filters":{"siteIds":[]}}'::jsonb,
+        'one_time',
+        'pdf',
+        v_user_id,
+        1,
+        'unrestricted',
+        NULL,
+        v_user_id,
+        repeat('0', 64),
+        NOW(),
+        'user',
+        true
+      ),
+      (
+        v_org_id,
+        'Customer portal — Security & compliance posture',
+        'security_compliance_posture',
+        '{"dateRange":{"preset":"last_30_days"},"sites":[],"windowDays":30,"minPasswordLength":8,"maxLocalAdmins":2,"maxAvDefinitionsAgeDays":7,"maxSecurityStatusAgeDays":30,"includeCis":true,"backupRequired":true}'::jsonb,
+        'one_time',
+        'pdf',
+        v_user_id,
+        1,
+        'unrestricted',
+        NULL,
+        v_user_id,
+        repeat('0', 64),
+        NOW(),
+        'user',
+        true
+      )
+    ON CONFLICT (org_id, type) WHERE portal_self_service = true
+    DO UPDATE SET
+      name = EXCLUDED.name,
+      config = EXCLUDED.config,
+      format = EXCLUDED.format,
+      updated_at = NOW();
   END IF;
 
   -- ───────────────────────────────────────────────────────────────────

--- a/e2e-tests/tests/portal-visibility.spec.ts
+++ b/e2e-tests/tests/portal-visibility.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from '../fixtures';
+import { PortalVisibilityPage } from '../pages/PortalVisibilityPage';
+
+const email = process.env.E2E_PORTAL_EMAIL ?? 'portal@breeze.local';
+const password = process.env.E2E_PORTAL_PASSWORD ?? 'PortalTest123!';
+
+test.describe.serial('portal visibility', () => {
+  test('generates and downloads a posture PDF', async ({
+    cleanPage,
+  }) => {
+    const portal = new PortalVisibilityPage(cleanPage);
+    await portal.login(email, password);
+
+    await expect(portal.reportsNav()).toBeVisible();
+    await portal.reportsNav().click();
+    await portal.generatePosture().click();
+
+    const row = portal.reportRows().first();
+    await expect(row).toBeVisible();
+
+    const downloadPromise = cleanPage.waitForEvent('download');
+    await row
+      .getByTestId(/^portal-report-run-pdf-/)
+      .click();
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toMatch(/\.pdf$/);
+  });
+
+  test('hides Devices when self-service is disabled', async ({
+    cleanPage,
+  }) => {
+    const portal = new PortalVisibilityPage(cleanPage);
+    await portal.login(email, password);
+    await expect(portal.devicesNav()).toHaveCount(0);
+  });
+});

--- a/e2e-tests/tests/portal-visibility.spec.ts
+++ b/e2e-tests/tests/portal-visibility.spec.ts
@@ -4,6 +4,11 @@ import { PortalVisibilityPage } from '../pages/PortalVisibilityPage';
 const email = process.env.E2E_PORTAL_EMAIL ?? 'portal@breeze.local';
 const password = process.env.E2E_PORTAL_PASSWORD ?? 'PortalTest123!';
 
+// Dev-mode stack: Astro compiles each portal page on its first request and the
+// posture report generates synchronously, so the default 30 s per-test budget
+// is too tight for the first test in the file.
+test.describe.configure({ timeout: 90_000 });
+
 test.describe.serial('portal visibility', () => {
   // Seeded with enable_dashboard = true. The tiles render for every status —
   // a source with no rows shows honest "not available" copy rather than a

--- a/e2e-tests/tests/portal-visibility.spec.ts
+++ b/e2e-tests/tests/portal-visibility.spec.ts
@@ -16,7 +16,7 @@ test.describe.serial('portal visibility', () => {
     await portal.generatePosture().click();
 
     const row = portal.reportRows().first();
-    await expect(row).toBeVisible();
+    await expect(row).toBeVisible({ timeout: 30_000 });
 
     const downloadPromise = cleanPage.waitForEvent('download');
     await row

--- a/e2e-tests/tests/portal-visibility.spec.ts
+++ b/e2e-tests/tests/portal-visibility.spec.ts
@@ -5,6 +5,23 @@ const email = process.env.E2E_PORTAL_EMAIL ?? 'portal@breeze.local';
 const password = process.env.E2E_PORTAL_PASSWORD ?? 'PortalTest123!';
 
 test.describe.serial('portal visibility', () => {
+  // Seeded with enable_dashboard = true. The tiles render for every status —
+  // a source with no rows shows honest "not available" copy rather than a
+  // fabricated zero — so this assertion does not depend on seeded telemetry.
+  test('shows the dashboard tiles once the flag is on', async ({
+    cleanPage,
+  }) => {
+    const portal = new PortalVisibilityPage(cleanPage);
+    await portal.login(email, password);
+
+    await expect(portal.dashboardNav()).toBeVisible();
+    await portal.dashboardNav().click();
+    await cleanPage.waitForURL('**/dashboard');
+
+    await expect(portal.dashboardSecurity()).toBeVisible();
+    expect(await portal.dashboardTiles().count()).toBeGreaterThan(0);
+  });
+
   test('generates and downloads a posture PDF', async ({
     cleanPage,
   }) => {

--- a/packages/shared/src/types/portalVisibility.ts
+++ b/packages/shared/src/types/portalVisibility.ts
@@ -253,6 +253,7 @@ export interface PortalRunDto {
 export interface PortalRunsDto {
   data: PortalRunDto[];
   pagination: PaginationDto;
+  timezone: string;
 }
 
 export interface EnrichedPortalDevice {


### PR DESCRIPTION
## Summary

This PR delivers **Wave W10 — Portal report self-service** (`#4562` portal
visibility): customers can now list, generate, and download their own
reports from the customer portal, scoped to the two portal-safe report
types (`executive_summary`, `security_compliance_posture`).

- `apps/api/src/services/portal/reportsSelfService.ts`: `listPortalRuns`,
  `generatePortalReport`, `renderRunPdf`, `renderRunCsv`, and
  `getReportBranding`, all synchronous, rate-limited (5 runs/org/hour +
  one-in-flight-per-type guard), and now running under a tightened
  60s `statement_timeout` around the RLS transaction they inherit.
- `apps/api/src/routes/portal/reports.ts`: absolute `/reports/runs`,
  `/reports/generate`, `/reports/runs/:id/pdf`, `/reports/runs/:id/csv`
  routes, root-mounted per controller ruling R10-1, gated by the existing
  `enableReports` `portal_branding` flag with private cache headers and
  `asOf`/`timezone` on every response.
- `apps/portal/src/pages/reports/index.astro` + `ReportRunList.tsx`: the
  customer-facing Reports page (SSR fetch via `portalApi`, 401 redirect,
  honest empty/rate-limited states, org-timezone-labeled timestamps).
- `apps/web`'s MSP-side Reports list now shows a "Visible in portal" badge
  on canonical, portal-self-service-enabled report definitions, and those
  definitions are read-only in the builder while `enable_reports` is on.
- `packages/shared/src/types/portalVisibility.ts` gains `PortalRunDto` /
  `PortalRunsDto` (with `timezone`); `ReportExecutionAuthority` is now a
  discriminated union (`user` | `portal_user`) per the R9-1 advisor-quorum
  ruling, threaded end-to-end through `generateReport`, `siteScope.ts`'s
  SQL visibility predicate, and the scheduled-report worker.
- Integration test + `e2e-tests/tests/portal-visibility.spec.ts` (now
  wired into `.github/workflows/ci.yml`'s wt-stack Playwright step)
  prove org-B-cannot-see-org-A's-run (404, no existence leak) and the
  full portal generate → list → download flow.

## Scope calls / rulings

Verbatim `Ruling:` lines from the SDD ledger
(`.superpowers/sdd/2026-09-02-portal-visibility-wave1-part-c/progress.md`):

> Ruling: R10.5-dashboard-descope — portal visibility Playwright login waits for the real `/portal/quotes` landing; the absent W04 dashboard locator/assertion is deferred, while the reports flow and Devices-nav gating remain in scope.

> ## Ruling: Task 10.5 fix round 2 — portal-visibility.spec.ts CI wiring deferred to controller

(This second one was a deferral, not a final ruling — it was resolved in
the final-review fix wave; see "Parked findings" below for the full story.)

Plus the controller rulings supplied for this wave, applied as binding:

- **R10-1** (route paths): handlers register ABSOLUTE `/reports/runs`,
  `/reports/generate`, `/reports/runs/:id/pdf`, `/reports/runs/:id/csv` on
  `portalReportRoutes` (root-mounted; gate is `use('/reports/*', …)` in
  `routes/portal/index.ts`), overriding the task-10.2 brief's relative
  paths, which would have resolved outside the feature gate.
- **R10-2** (10.1): only runs whose parent report has
  `portal_self_service=true` are listed/downloadable; generation is
  synchronous via `generateReport` + `portalUserReportAuthority`; 404 if
  the canonical definition is missing; 429 + `Retry-After` over 5
  runs/org/hour or an in-flight run of that type; PDF via
  `buildReportPdf` server-side with `reportBranding`; render failure →
  generic 500 + logged run id.
- **R10-3** (10.4): the "Visible in portal" badge key lives under
  `reports.reportsList.visibleInPortal` in every locale file; canonical,
  portal-self-service definitions are read-only in the builder while
  `enable_reports` is on.
- **R10-4** (10.5): the e2e spec selects by `data-testid` only; the
  integration test proves `requested_by_kind='portal_user'` is stored and
  that org B cannot fetch org A's run PDF (404, not 403).
- **R10-5** (doc drift): §6/§7.6 of the design spec updated from
  "streamed CSV" to "materialized in-transaction, paged 250 rows at a
  time," matching the W07 device-CSV implementation.
- **R9-1** (authority typing, advisor quorum Fable + Codex xhigh):
  `ReportExecutionAuthority` widened to a discriminated union
  (`UserReportExecutionAuthority | PortalUserReportExecutionAuthority`),
  `SystemReportExecutionAuthority` kept out of `generateReport`/
  `assertReportExecutionPreflight`; every subordinate generator, the SQL
  visibility predicate, and the scheduled-report worker updated to switch
  exhaustively on `principalKind`.

## Parked findings

- **Task 10.5, Finding 3 (Playwright spec runs nowhere in CI) — the
  parked text supplied to this role for this section was stale.** It
  read: *"NOT ADDRESSED — `.github/workflows/ci.yml:2684` still schedules
  only `tests/multi-currency.spec.ts`; `portal-visibility.spec.ts` is in
  no CI job... requires a controller decision."* That was accurate
  through fix round 4, but the ledger's later **"Final review: fix wave"**
  entry (commit `2c35257c0`) shows this was subsequently resolved: Codex
  task F added `tests/portal-visibility.spec.ts` to the same wt-stack
  Playwright step as `multi-currency.spec.ts` and raised the first test's
  `toBeVisible()` timeout to 30s. Independently verified for this PR:
  `.github/workflows/ci.yml:2684` now reads
  `... test -- tests/multi-currency.spec.ts tests/portal-visibility.spec.ts`,
  and `npx playwright test tests/portal-visibility.spec.ts --list`
  discovers 2 tests / 1 file with zero collection failures. No further
  action needed on this finding — flagging the discrepancy between the
  supplied text and the branch's actual (later) state rather than
  reproducing a since-resolved finding as open.

## Verification

From `.superpowers/sdd/2026-09-02-portal-visibility-wave1-part-c/verify-report.md`
(head `56d9fa0710dc8a41a8820fb5d15be75f881d4caf`, after merging
`origin/main`):

**Result: PASS — all steps green, no failures.**

- `git fetch origin && git merge origin/main --no-edit` — clean auto-merge,
  zero conflicts (33 files, all on the main side).
- Typecheck: `apps/api` tsc — 0 errors. `packages/shared` tsc — only 3
  pre-existing, unrelated `quotes.test.ts` errors. `apps/portal` /
  `apps/web` `astro check` — 0 errors, 0 warnings (pre-existing hints
  only).
- Lint: `apps/api`, `apps/web` `eslint src` — clean.
- Unit suites for every test file touched on this branch: api (5 files,
  187/187 passing), portal (whole-package, 344/344 across 41 files), web
  required suites + touched file (246/246 across 5 files).
- Integration suites against a private test-stack:
  `portalReportSelfService.integration.test.ts` +
  `portalVisibilityRls.integration.test.ts` — auto-migrate applied 584
  migrations cleanly, **2 files / 4 tests passing**.
- Migration-name check: skipped — this branch adds no file under
  `apps/api/migrations/`.
- Final `git status --porcelain` — clean.

## Known follow-ups

- **Residual limitation (final-review fix wave, finding 5):** the new
  `tightenPortalReportStatementTimeout()` bounds every SQL statement in
  the synchronous generate/PDF path to 60s via the existing never-widen
  `tightenStatementTimeout` helper, but Postgres 16 has no session-level
  `transaction_timeout` and this cannot interrupt in-process CPU time
  inside jsPDF rendering itself. Consistent with R10-2's decision to keep
  generation synchronous rather than redesign it; noted next to the
  `#1105` comment in `routes/portal/auth.ts` that this deliberately
  contradicts.
- **R10.5-dashboard-descope:** the Playwright login helper waits on the
  real `/portal/quotes` landing rather than `/portal/dashboard`, and the
  `portal-dashboard-tile-security` assertion is deferred until W04
  (dashboard) is merged onto this line — it is not present on this
  branch. Devices-nav gating and the reports flow remain fully covered.
- `apps/api/src/__tests__/integration/portalReportSelfService.integration.test.ts`
  is `it.runIf(DATABASE_URL)`-gated; it ran clean against the private
  test-stack in verification (see above) and will also run in the CI
  Integration Tests job.

## Advisor fix round (post-open)

- **ee1857f8c** — un-defers the dashboard e2e assertion (R10.5 / R10-6): the
  seeded org now has `enable_dashboard = true`, the spec asserts the Dashboard
  nav entry and tiles, and `ci.yml` documents why this wt-stack job is the
  only place the customer-facing portal is exercised.
- **d3feedbbe — R10-7 (verified) + R10-8.** The MSP Reports list hid
  Generate/Edit/Delete for a `portal_self_service` definition, but only
  DELETE had the matching server guard: `PUT /reports/:id` could rewrite the
  canonical customer-safe config through the API, and
  `POST /reports/:id/generate` could create a run under a site-restricted
  tech's authority that the portal would then list and download as the
  customer's own report (`portalRunListPredicate` keys on org + marker +
  status only). Fix: one shared guard, `isPortalSelfServiceLocked`
  (`routes/reports/helpers.ts`: marker AND `portal_branding.enable_reports`),
  applied to DELETE (refactored), PUT, and POST `/:id/generate` — same 409
  `portal_self_service_report` while the flag is on, pass-through once it is
  off. Reauthorize is deliberately left open: it never touches
  customer-visible config and `loadLockedDefinition` already rejects a
  narrower live scope. Web: portal rows now render the existing "Open latest"
  action instead of nothing (read-only, not invisible). Tests were written
  red-first: PUT/generate 409 with the flag on, PUT pass-through with it off,
  the web row (open-latest present, mutation testids absent), and an
  integration case proving a completed run of a non-self-service definition
  in the portal user's OWN org is neither listed nor downloadable — run
  against a private test stack (2/2, real Postgres). `tsc`, eslint, and the
  four affected API route suites (121 tests) are clean.

- **e078c527a — Test API red, root-caused and fixed (layering).** CI failed
  `orgPortalSettings.test.ts` at import time: that suite `importActual`s the
  real portal-flags module, and on this branch (not on main — verified with a
  runtime import trace on both refs) `reportsSelfService` imported
  `checkRateLimit` from `routes/portal/helpers`, whose graph reaches the
  services barrel → `commandQueue` → `agentWs` → the discovery worker →
  `networkBaseline` reading `discoveredAssetTypeEnum` off the suite's partial
  schema mock. A service must not import from routes. The rate limiter
  (`PORTAL_USE_REDIS`, buckets, sweep, `capMapByOldest`, `checkRateLimit`)
  moved byte-for-byte to `services/portal/rateLimit.ts`; `routes/portal/helpers`
  and `routes/portal/schemas` re-export it so the auth routes and tests are
  unchanged. Also removes the service ↔ `routes/portal/schemas` import cycle.
  Verified: 39 portal/report suites, 531 tests green, including the suite CI
  failed on.
- **07a91e3fa — real W04 bug found by the new Portal E2E run, fixed here.** With
  `enable_dashboard` seeded on for the first time, every `GET /portal/dashboard`
  500ed: `portalMonthWindow` bound `now` as a JS `Date` inside a raw `sql`
  fragment, and Drizzle's postgres-js driver (which leaves timestamp
  serialization to column mappers) let postgres.js throw
  `Buffer.byteLength … Received an instance of Date` at bind time. This shipped
  in W04 and would hit any customer with the dashboard enabled; unit tests
  compile SQL and never bind, so only a real database shows it. Fix binds the
  ISO string. Red-first: unit assertion that no bound param is a `Date`, plus a
  `portalVisibilityRls.integration.test.ts` case computing the tile against
  Postgres (rejected with the TypeError before, resolves `no_data` after; full
  suite 4/4). E2E: the portal middleware lands login on `/dashboard` when the
  flag is on, so the page object now accepts `/dashboard` or `/quotes` (60 s
  wait for the dev-mode compile) and the spec gets a 90 s per-test budget.
  `playwright --list` discovers 3 tests.

Closes #4578

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WvK35ZoQELCL9xdsgWjCaw


