### PR TITLE
fix(web): deflake QuoteWorkspace superseded-GET and TicketWorkbench resolve-note prefill

### DIFF
--- a/apps/web/src/components/billing/quotes/QuoteWorkspace.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteWorkspace.test.tsx
@@ -329,5 +329,12 @@ describe('QuoteWorkspace — an older refetch must not clobber a newer one (#351
     // payload wins by arriving last and the canvas goes empty again. (Verified
     // red against the unguarded fetchDetail, so the flush above is sufficient.)
     expect(screen.queryByTestId('quote-blocks-empty')).not.toBeInTheDocument();
-  });
+    // Per-test budget. The two 5000ms waitFor windows above are each allowed to
+    // run long under CI load, but vitest's default per-test timeout is ALSO
+    // 5000ms, so the widened windows alone just moved the flake from
+    // "waitFor timed out" to "Test timed out in 5000ms" (observed twice on
+    // 2026-09-03, both on agent-only PRs, after the windows were widened in
+    // #4704). The test's own timeout has to cover the sum of every window it
+    // contains, not just the largest one: 1s mount + 5s + 5s + 1s + slack.
+  }, 20_000);
 });

--- a/apps/web/src/components/tickets/TicketWorkbench.test.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { configure, fireEvent, getConfig, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import TicketWorkbench from './TicketWorkbench';
@@ -747,6 +747,53 @@ describe('TicketWorkbench AI drafts (#4191, Task 11)', () => {
   // e.g. resolveDraftId survived from a prior ticket's aiDrafts state) used
   // to fall through the `err.status === 409` check and loop forever. The
   // recovery must match the sibling send/discard handlers (any non-401).
+  // Regression for a CI-only flake (I1 below, 2026-09-03 run 33724780964):
+  // the resolve note came up '' although the draft badge was already on
+  // screen. openResolveForm reads aiDraftsRef, which was synced in a PASSIVE
+  // effect — flushed in a later macrotask than the commit that painted the
+  // badge. RTL's findBy* normally hides the window with a setTimeout(0) drain
+  // after the element appears, but under CI load the scheduler's flush can
+  // lose to that drain. Bypassing the drain here reproduces the window
+  // deterministically: red on the useEffect sync, green on useLayoutEffect.
+  it('prefills the resolve note even when the status change lands in the same macrotask as the draft commit', async () => {
+    let resolveAttempts = 0;
+    let consumed = false;
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url === '/tickets/tk-1' && (!init?.method || init.method === 'GET')) {
+        return makeJsonResponse({ data: makeTicket({ id: 'tk-1' }) });
+      }
+      if (url === '/tickets/tk-1/triage-suggestion' && (!init?.method || init.method === 'GET')) {
+        return makeJsonResponse({ enabled: false, flagSource: 'default', suggestion: null });
+      }
+      if (url === '/tickets/tk-1/ai-drafts' && (!init?.method || init.method === 'GET')) {
+        return makeJsonResponse({ data: consumed ? [] : [resolutionDraft] });
+      }
+      if (url === '/tickets/tk-1/status' && init?.method === 'POST') {
+        resolveAttempts += 1;
+        if (resolveAttempts === 1) {
+          consumed = true;
+          return makeJsonResponse({ error: 'Draft not found' }, false, 404);
+        }
+        return makeJsonResponse({ data: makeTicket({ id: 'tk-1', status: 'resolved' }) });
+      }
+      return makeJsonResponse({ success: true });
+    });
+
+    render(<TicketWorkbench ticketId="tk-1" assignees={[]} />);
+    await screen.findByTestId('ticket-workbench');
+    const previousWrapper = getConfig().asyncWrapper;
+    configure({ asyncWrapper: (cb) => cb() });
+    try {
+      await screen.findByTestId('ticket-ai-draft-resolution_note');
+      fireEvent.change(screen.getByTestId('ticket-workbench-status'), { target: { value: 'resolved' } });
+      const note = screen.getByTestId('ticket-workbench-resolve-note') as HTMLTextAreaElement;
+      expect(note.value).toBe(resolutionDraft.content);
+    } finally {
+      configure({ asyncWrapper: previousWrapper });
+    }
+  });
+
   it('I1: on a 404 resolve conflict from a stale aiDraftId, drops it and retries without it (not just 409)', async () => {
     let resolveAttempts = 0;
     let consumed = false;

--- a/apps/web/src/components/tickets/TicketWorkbench.tsx
+++ b/apps/web/src/components/tickets/TicketWorkbench.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, useLayoutEffect } from 'react';
 import '@/lib/i18n';
 import { useTranslation } from 'react-i18next';
 import { ExternalLink, Sparkles } from 'lucide-react';
@@ -217,7 +217,14 @@ export default function TicketWorkbench({ ticketId, onChanged, onTicketPatched, 
   // that helper's identity stays stable across ai-drafts refetches — see the
   // comment above openResolveForm for why that stability matters.
   const aiDraftsRef = useRef<TicketAiDraft[]>([]);
-  useEffect(() => { aiDraftsRef.current = aiDrafts; }, [aiDrafts]);
+  // Synced in a LAYOUT effect, not a passive one. openResolveForm reads this
+  // ref from a discrete event handler, and a passive effect is flushed in a
+  // later macrotask than the commit that painted the draft — so a status
+  // change fired in between (RTL's post-waitFor drain vs React's scheduler
+  // under CI load, or a fast user) saw the pre-fetch [] and opened the resolve
+  // form with an empty note. A layout effect runs inside the same commit, so
+  // there is no window in which the DOM shows the draft but the ref lacks it.
+  useLayoutEffect(() => { aiDraftsRef.current = aiDrafts; }, [aiDrafts]);
   // The resolution_note draft (if any) prefilled into the currently-open
   // resolve form; sent back as `aiDraftId` so the server consumes it in the
   // same transaction as the resolve CAS.


### PR DESCRIPTION
Two Test Web flakes that redded agent-only PRs on 2026-09-03, both root-caused and reproduced red before fixing. Follow-up (d) from the #3207 reboot-deferral handoff; the companion AiUsagePage flake was fixed separately in #4805.

## 1. QuoteWorkspace `drops a superseded GET that resolves last` — `Test timed out in 5000ms`

Runs 33731355738 and 33736493185 (attempt 1). #4704 had widened the test's two `waitFor` budgets to 5000ms each for CI load, but vitest's default *per-test* timeout is also 5000ms, so the widening only moved the flake from "waitFor timed out" to "Test timed out". Fix: a 20s per-test timeout with the arithmetic recorded in a comment. No assertion or component change.

- Red: delaying the PATCH and POST mocks 2.5s each reproduces the exact CI signature on the current code. Green with the timeout. Delay removed, full file 3× green.
- Sweep: every other `apps/web` test with a `>=5000ms` `waitFor` (`ScriptTestRunner`, `DeviceWarrantyCard`) already carries a per-test timeout. This was the only miss.

## 2. TicketWorkbench I1 — `expected '' to be 'Replaced the fuser assembly…'`

Run 33724780964 (attempt 1). `openResolveForm` reads `aiDraftsRef` from the status-change handler, but the ref was synced in a **passive** effect, which flushes in a later macrotask than the commit that painted the draft badge. RTL's `findBy*` normally hides the window with a `setTimeout(0)` drain, but under CI load React's scheduler flush can lose to that drain, so the handler saw the pre-fetch `[]` and opened the form with an empty note. Fix: `useLayoutEffect`, which runs inside the same commit. Component change, one line plus comment.

- Red: a regression test that bypasses RTL's drain (`configure({ asyncWrapper: cb => cb() })`, restored in `finally`) hits the window deterministically. 3/3 red on `useEffect` with the exact CI assertion, 3/3 green on `useLayoutEffect`. Kept in the file so the six synchronous `note.value` assertions can't regress silently.
- Full file 103/103 twice; eslint and tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Ua3dk5TZk7PXWkYR7NipG