### PR TITLE
fix(api): write an intent_outbox row when cancelActionIntent commits (#4798)

### DIFF
--- a/apps/api/migrations/2026-10-08-100300-intent-cancelled-outbox-event.sql
+++ b/apps/api/migrations/2026-10-08-100300-intent-cancelled-outbox-event.sql
@@ -1,0 +1,13 @@
+-- #4798: cancelActionIntent wrote no intent_outbox row, so a requester
+-- already told "approved and is now running" was never told a subsequent
+-- cancel happened. Widens the event_type CHECK to admit 'intent_cancelled',
+-- mirroring the wave-2 (#3823) widening for intent_rejected/intent_expired.
+-- Idempotent: DROP IF EXISTS + re-ADD is safe to replay.
+
+ALTER TABLE intent_outbox DROP CONSTRAINT IF EXISTS intent_outbox_event_type_check;
+ALTER TABLE intent_outbox ADD CONSTRAINT intent_outbox_event_type_check CHECK (
+  event_type IN (
+    'intent_created', 'intent_approved', 'intent_rejected', 'intent_expired',
+    'intent_cancelled', 'pam.desired_state_changed'
+  )
+);

--- a/apps/api/src/db/schema/actionIntents.test.ts
+++ b/apps/api/src/db/schema/actionIntents.test.ts
@@ -38,15 +38,17 @@ describe('actionIntentSourceEnum', () => {
 });
 
 describe('intentOutboxEventEnum', () => {
-  it('has exactly the five outbox events', () => {
+  it('has exactly the six outbox events', () => {
     // Widened in wave 2 (#3823): intent_rejected and intent_expired exist so a
     // requester can be told an outcome their chat turn did not wait for. A
-    // denied intent previously wrote no outbox row at all.
+    // denied intent previously wrote no outbox row at all. Widened again for
+    // #4798: intent_cancelled closes the same gap for cancellation.
     expect(intentOutboxEventEnum).toEqual([
       'intent_created',
       'intent_approved',
       'intent_rejected',
       'intent_expired',
+      'intent_cancelled',
       'pam.desired_state_changed',
     ]);
   });
@@ -56,8 +58,16 @@ describe('intentOutboxEventEnum', () => {
     // written in two different files, so pin them to each other — a value added
     // here but not in SQL becomes a row that silently fails to insert, and one
     // added in SQL but not here becomes an event nothing consumes.
+    //
+    // Points at whichever migration shipped the CONSTRAINT's most recent
+    // DROP+re-ADD (a CHECK constraint has one name and is replaced wholesale,
+    // not appended to — the SQL file is the widest set only if it's the LAST
+    // one to touch this constraint). #4798 moved that to
+    // 2026-10-08-100300-intent-cancelled-outbox-event.sql; update this path
+    // again the next time the constraint is widened, same as the approval-
+    // scope CHECK test below does for its own migration.
     const migration = readFileSync(
-      join(__dirname, '../../../migrations/2026-09-16-pam-actuation-lifecycle.sql'),
+      join(__dirname, '../../../migrations/2026-10-08-100300-intent-cancelled-outbox-event.sql'),
       'utf8',
     );
     const check = migration.slice(migration.indexOf('intent_outbox_event_type_check'));

--- a/apps/api/src/db/schema/actionIntents.ts
+++ b/apps/api/src/db/schema/actionIntents.ts
@@ -86,12 +86,15 @@ export type ActionIntentOriginPrincipalKind =
 // Widened in wave 2 (#3823): a DENIED or EXPIRED intent previously wrote no
 // outbox row at all, so a requester whose chat turn had ended could never be
 // told the outcome. Pinned by a CHECK in SQL — see
-// 2026-09-04-ai-agent-notifications.sql.
+// 2026-09-04-ai-agent-notifications.sql. Widened again for #4798: a
+// CANCELLED intent had the same gap — see
+// 2026-10-08-100300-intent-cancelled-outbox-event.sql.
 export const intentOutboxEventEnum = [
   'intent_created',
   'intent_approved',
   'intent_rejected',
   'intent_expired',
+  'intent_cancelled',
   'pam.desired_state_changed',
 ] as const;
 export type IntentOutboxEvent = (typeof intentOutboxEventEnum)[number];

--- a/apps/api/src/jobs/intentReleaseWorker.test.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.test.ts
@@ -3059,6 +3059,25 @@ describe('processIntentReleaseJob', () => {
     expect(notifyMock.createNotification).toHaveBeenCalled();
   });
 
+  // #4798: cancelActionIntent now writes its own intent_cancelled outbox row
+  // (mirrors intent_rejected/intent_expired — outcome-only, no release).
+  it('notifies the requester on intent_cancelled without releasing anything', async () => {
+    dbState.selectActionIntentsResults.push([{ ...FOUR_EYES_INTENT, status: 'cancelled' }]);
+
+    const result = await processIntentReleaseJob({ intentId: 'intent-1', eventType: 'intent_cancelled' });
+
+    expect(result).toEqual({ released: false });
+    expect(intentServiceMock.transitionIntent).not.toHaveBeenCalled();
+    expect(notifyMock.createNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'requester-1',
+        type: 'approval',
+        link: '/approvals',
+        dedupeKey: 'intent-outcome:intent-1:cancelled',
+      }),
+    );
+  });
+
   it('stays silent for a SUPERVISED intent — the requester watched it in chat', async () => {
     // Otherwise every abandoned 5-minute chat intent rings the bell, which is
     // the highest-volume producer of this type and trains people to ignore it.
@@ -3448,6 +3467,23 @@ describe('outcome notification dedupe identity (#4465)', () => {
 
       expect(rows).toHaveLength(2);
       expect(rows[1]!.dedupeKey).toBe('intent-outcome:intent-1:rejected');
+    });
+
+    // #4798 — the reported gap: a requester told "approved and is now
+    // running" was never told a later cancel happened, because
+    // cancelActionIntent wrote no outbox row at all. Now it does, and this is
+    // exactly one "cancelled" notification landing after the "running" one.
+    it('a granted bell followed by an intent_cancelled delivery still corrects the record', async () => {
+      const rows = installNotificationStore();
+
+      await deliverApprovedObserving('approved');
+      dbState.selectActionIntentsResults.push([{ ...FOUR_EYES_INTENT, status: 'cancelled' }]);
+      await processIntentReleaseJob({ intentId: 'intent-1', eventType: 'intent_cancelled' });
+
+      expect(rows).toHaveLength(2);
+      expect(rows[0]!.dedupeKey).toBe('intent-outcome:intent-1:granted');
+      expect(rows[1]!.dedupeKey).toBe('intent-outcome:intent-1:cancelled');
+      expect(rows[1]!.title).toBe('Request cancelled');
     });
   });
 

--- a/apps/api/src/jobs/intentReleaseWorker.test.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.test.ts
@@ -3218,6 +3218,32 @@ describe('agent-originated outcome notifications', () => {
     expect(vi.mocked(mockedRunOutside).mock.calls.length).toBeGreaterThanOrEqual(3);
   });
 
+  // #4798 review finding: cancelActionIntent explicitly permits an
+  // approvals:decide holder to dismiss an agent-originated proposal with no
+  // human requester (owner decision 2026-08-23, wave 3b) — the agent-
+  // recipient fanout branch above must fire for a cancel exactly as it does
+  // for a reject, and this is the only test in the file that drives
+  // eventType: 'intent_cancelled' through it.
+  it('notifies agent recipients on a cancelled agent-originated intent', async () => {
+    dbState.selectActionIntentsResults.push([{ ...AGENT_INTENT, status: 'cancelled' }]);
+    dbState.selectAgentRunsResults.push([RUN_ROW]);
+    dbState.selectAgentsResults.push([AGENT_ROW]);
+    recipientsMock.resolveRecipientUserIds.mockResolvedValueOnce(['user-a', 'user-b']);
+
+    const result = await processIntentReleaseJob({ intentId: 'intent-1', eventType: 'intent_cancelled' });
+
+    expect(result).toEqual({ released: false });
+    expect(notifyMock.createNotification).toHaveBeenCalledTimes(2);
+    expect(notifyMock.createNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-a',
+        title: 'Agent proposal cancelled',
+        message: 'Patch triage: run_script(deviceId=d-1) was cancelled and will not run.',
+        dedupeKey: 'agent-intent-outcome:intent-1:cancelled',
+      }),
+    );
+  });
+
   it('derives agent copy from the re-read status, never the event type', async () => {
     // intent_approved arrives but the release did not run (lost CAS) and the
     // row now says failed — recipients must hear the truth, at high priority.

--- a/apps/api/src/jobs/intentReleaseWorker.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.ts
@@ -1204,11 +1204,13 @@ async function loadRunAndAgent(runId: string): Promise<{
  * a `granted` bell. `granted` -> `failed` and `granted` -> `cancelled` are
  * therefore both real corrections that must survive the dedupe.
  *
- * Caveat worth knowing when reading this table: a cancel writes NO outbox row
- * today, so this worker only ever OBSERVES `cancelled` on a late delivery of
- * some other event (an `intent_expired` row processed after the cancel
- * landed). Keeping `cancelled` in its own class is what makes that late
- * delivery able to correct the record; it is not what makes a cancel notify.
+ * #4798: `cancelActionIntent` now writes its own `intent_cancelled` outbox row
+ * (in the same transaction as the CAS, mirroring `intent_created` /
+ * `intent_approved`) instead of relying solely on a late delivery of some
+ * OTHER event (e.g. an `intent_expired` row processed after the cancel
+ * landed) to surface the correction. Keeping `cancelled` in its own class is
+ * what makes both paths — the dedicated event and a stale late delivery —
+ * able to correct an earlier `granted` bell without duplicating it.
  *
  * Every unknown status shares the one `update` key on purpose: they all render
  * the same "changed state" copy, so a second one is noise, not news.
@@ -1285,7 +1287,7 @@ function agentOutcomeCopy(intent: { targetSummary: string; status: string }): {
  */
 async function notifyRequesterOfOutcome(
   intentId: string,
-  eventType: 'intent_approved' | 'intent_rejected' | 'intent_expired',
+  eventType: 'intent_approved' | 'intent_rejected' | 'intent_expired' | 'intent_cancelled',
 ): Promise<void> {
   const [intent] = await withSystemDbAccessContext(() =>
     db
@@ -1433,7 +1435,8 @@ async function notifyRequesterOfOutcome(
  * it can be unit tested without spinning up a real BullMQ Worker.
  *
  * `intent_approved` is the release trigger AND an outcome to report.
- * `intent_rejected` / `intent_expired` are outcome-only. `intent_created` is
+ * `intent_rejected` / `intent_expired` / `intent_cancelled` (#4798) are
+ * outcome-only. `intent_created` is
  * the policy-decide recovery hook (wave 5 Part B, #3827) — deliberately NOT
  * flag-gated at this call site (see the comment on that branch below for
  * why) and NOT unconditionally acknowledged: a DETERMINISTIC outcome from
@@ -1445,7 +1448,11 @@ async function notifyRequesterOfOutcome(
  * own per-job retry policy to make that redelivery real.
  */
 export async function processIntentReleaseJob(data: IntentReleaseJobData): Promise<{ released: boolean }> {
-  if (data.eventType === 'intent_rejected' || data.eventType === 'intent_expired') {
+  if (
+    data.eventType === 'intent_rejected' ||
+    data.eventType === 'intent_expired' ||
+    data.eventType === 'intent_cancelled'
+  ) {
     await notifyRequesterOfOutcome(data.intentId, data.eventType);
     return { released: false };
   }

--- a/apps/api/src/services/actionIntents/intentService.test.ts
+++ b/apps/api/src/services/actionIntents/intentService.test.ts
@@ -2181,6 +2181,33 @@ describe('cancelActionIntent', () => {
     const result = await cancelActionIntent(makeAuth(), 'intent-1');
     expect(result).toEqual({ ok: false, status: 'completed' });
   });
+
+  // #4798: a requester who already received the "approved and now running"
+  // outcome notification was never told a subsequent cancel happened — the
+  // CAS committed with no outbox row, so intentReleaseWorker.ts had nothing
+  // to deliver. Mirrors createActionIntent's intent_created/intent_approved
+  // outbox write: an event row in the SAME successful-CAS branch, ids only.
+  it('writes an intent_cancelled outbox row when the CAS succeeds', async () => {
+    dbState.selectActionIntentsResults.push([
+      makeIntentRow({ id: 'intent-1', orgId: ORG_ID, requestedByUserId: REQUESTER_ID }),
+    ]);
+    dbState.updateActionIntentsResults.push([{ id: 'intent-1' }]);
+    const result = await cancelActionIntent(makeAuth(), 'intent-1');
+    expect(result).toEqual({ ok: true, status: 'cancelled' });
+    expect(dbState.insertedOutboxValues).toEqual([
+      { intentId: 'intent-1', eventType: 'intent_cancelled', payload: { intentId: 'intent-1', orgId: ORG_ID } },
+    ]);
+  });
+
+  // Mirrors the "reports the lost race" test above: a lost CAS must not
+  // write an outbox row for a cancellation that never actually happened.
+  it('writes no outbox row when the CAS loses the race', async () => {
+    dbState.selectActionIntentsResults.push([makeIntentRow({ id: 'intent-1', requestedByUserId: REQUESTER_ID })]);
+    dbState.updateActionIntentsResults.push([]); // CAS lost
+    dbState.selectActionIntentsResults.push([{ status: 'completed' }]); // re-read
+    await cancelActionIntent(makeAuth(), 'intent-1');
+    expect(dbState.insertedOutboxValues).toEqual([]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/api/src/services/actionIntents/intentService.test.ts
+++ b/apps/api/src/services/actionIntents/intentService.test.ts
@@ -57,6 +57,11 @@ const { schema, dbState, authMock, guardrailMock, aiToolsState, permState, pushS
       insertedActionIntentValues: [] as Record<string, unknown>[],
       insertedApprovalRequestsValues: [] as unknown[],
       insertedOutboxValues: [] as Record<string, unknown>[],
+      // Set to inject a failure on the NEXT intent_outbox insert only (auto
+      // clears itself) — proves the transaction-catch path in
+      // cancelActionIntent without giving every other outbox-writing test a
+      // footgun to forget to reset.
+      outboxInsertError: null as Error | null,
       updateActionIntentsSets: [] as Record<string, unknown>[],
       updateActionIntentsWheres: [] as unknown[],
       selectAgentRunsResults: [] as unknown[][],
@@ -149,6 +154,11 @@ vi.mock('../../db', () => ({
           };
         }
         if (table === schema.intentOutboxTbl) {
+          if (dbState.outboxInsertError) {
+            const err = dbState.outboxInsertError;
+            dbState.outboxInsertError = null;
+            return Promise.reject(err);
+          }
           dbState.insertedOutboxValues.push(values as Record<string, unknown>);
           return Promise.resolve(undefined);
         }
@@ -347,6 +357,7 @@ function resetDbState() {
   dbState.insertedActionIntentValues.length = 0;
   dbState.insertedApprovalRequestsValues.length = 0;
   dbState.insertedOutboxValues.length = 0;
+  dbState.outboxInsertError = null;
   dbState.updateActionIntentsSets.length = 0;
   dbState.updateActionIntentsWheres.length = 0;
   dbState.selectAgentRunsResults.length = 0;
@@ -2207,6 +2218,30 @@ describe('cancelActionIntent', () => {
     dbState.selectActionIntentsResults.push([{ status: 'completed' }]); // re-read
     await cancelActionIntent(makeAuth(), 'intent-1');
     expect(dbState.insertedOutboxValues).toEqual([]);
+  });
+
+  // Review finding (#4798): a failed outbox insert must surface as a typed,
+  // logged failure — same posture as createActionIntent's transaction catch
+  // — rather than a bare exception. The CAS and the insert share ONE
+  // withSystemDbAccessContext transaction, so Postgres would roll the status
+  // flip back with it; nothing here claims otherwise.
+  it('wraps a failed outbox insert as a typed ActionIntentError, not a bare exception', async () => {
+    dbState.selectActionIntentsResults.push([makeIntentRow({ id: 'intent-1', requestedByUserId: REQUESTER_ID })]);
+    dbState.updateActionIntentsResults.push([{ id: 'intent-1' }]);
+    dbState.outboxInsertError = new Error('connection reset');
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      await expect(cancelActionIntent(makeAuth(), 'intent-1')).rejects.toMatchObject({
+        message: expect.stringContaining('Failed to cancel action intent'),
+        code: 'cancel_failed',
+      });
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '[intentService] cancel action intent transaction failed (rolled back):',
+        expect.any(Error),
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
   });
 });
 

--- a/apps/api/src/services/actionIntents/intentService.ts
+++ b/apps/api/src/services/actionIntents/intentService.ts
@@ -1858,22 +1858,38 @@ export async function cancelActionIntent(
   // requester already told "approved and is now running" was never told a
   // subsequent cancel happened, because intentReleaseWorker.ts's outbox
   // consumer never saw an event for it.
-  const ok = await withSystemDbAccessContext(async () => {
-    const rows = await db
-      .update(actionIntents)
-      .set({ status: 'cancelled' })
-      .where(and(eq(actionIntents.id, intentId), inArray(actionIntents.status, ['pending_approval', 'approved'])))
-      .returning({ id: actionIntents.id });
-    if (rows.length === 0) return false;
-    await db.insert(intentOutbox).values({
-      intentId,
-      eventType: 'intent_cancelled',
-      // Ids only, no argument content (spec §3.2) — matches the
-      // intent_created/intent_approved/intent_rejected/intent_expired rows.
-      payload: { intentId, orgId: intent.orgId },
+  let ok: boolean;
+  try {
+    ok = await withSystemDbAccessContext(async () => {
+      const rows = await db
+        .update(actionIntents)
+        .set({ status: 'cancelled' })
+        .where(and(eq(actionIntents.id, intentId), inArray(actionIntents.status, ['pending_approval', 'approved'])))
+        .returning({ id: actionIntents.id });
+      if (rows.length === 0) return false;
+      await db.insert(intentOutbox).values({
+        intentId,
+        eventType: 'intent_cancelled',
+        // Ids only, no argument content (spec §3.2) — matches the
+        // intent_created/intent_approved/intent_rejected/intent_expired rows.
+        payload: { intentId, orgId: intent.orgId },
+      });
+      return true;
     });
-    return true;
-  });
+  } catch (err) {
+    // Same posture as createActionIntent's transaction catch: the CAS and
+    // the outbox insert share one Postgres transaction (both run through the
+    // same withSystemDbAccessContext callback), so a thrown insert rolls the
+    // status flip back too — there is no committed 'cancelled' row with a
+    // missing outbox event to reconcile. Logged and re-thrown as a typed,
+    // retryable error rather than a bare exception so a caller (once wired
+    // to a route) sees a real failure, never a false success.
+    console.error('[intentService] cancel action intent transaction failed (rolled back):', err);
+    throw new ActionIntentError(
+      `Failed to cancel action intent ${intentId} (CAS / outbox)`,
+      'cancel_failed',
+    );
+  }
   if (ok) {
     return { ok: true, status: 'cancelled' };
   }

--- a/apps/api/src/services/actionIntents/intentService.ts
+++ b/apps/api/src/services/actionIntents/intentService.ts
@@ -1847,7 +1847,33 @@ export async function cancelActionIntent(
     throw new ActionIntentAuthorizationError(`Not authorized to cancel action intent ${intentId}`);
   }
 
-  const ok = await transitionIntent(intentId, ['pending_approval', 'approved'], 'cancelled');
+  // Inlined rather than reusing `transitionIntent` (the shared CAS primitive
+  // below): cancel is the only caller that needs an outbox row written
+  // atomically with the CAS, and `transitionIntent` is shared by
+  // intentReleaseWorker.ts / aiAgentSdk.ts release paths that don't. Same
+  // predicate transitionIntent would apply for this call
+  // (`from: ['pending_approval', 'approved']`, `to: 'cancelled'`, no deadline
+  // fold), just with the outbox write folded into the same
+  // withSystemDbAccessContext transaction (#4798) — without this, a
+  // requester already told "approved and is now running" was never told a
+  // subsequent cancel happened, because intentReleaseWorker.ts's outbox
+  // consumer never saw an event for it.
+  const ok = await withSystemDbAccessContext(async () => {
+    const rows = await db
+      .update(actionIntents)
+      .set({ status: 'cancelled' })
+      .where(and(eq(actionIntents.id, intentId), inArray(actionIntents.status, ['pending_approval', 'approved'])))
+      .returning({ id: actionIntents.id });
+    if (rows.length === 0) return false;
+    await db.insert(intentOutbox).values({
+      intentId,
+      eventType: 'intent_cancelled',
+      // Ids only, no argument content (spec §3.2) — matches the
+      // intent_created/intent_approved/intent_rejected/intent_expired rows.
+      payload: { intentId, orgId: intent.orgId },
+    });
+    return true;
+  });
   if (ok) {
     return { ok: true, status: 'cancelled' };
   }


### PR DESCRIPTION
## Summary

`cancelActionIntent` only performed the `pending_approval|approved -> cancelled` CAS and never wrote an `intent_outbox` row, unlike `createActionIntent` (which writes `intent_created` / `intent_approved` in the same transaction). Because `approved -> cancelled` is a reachable transition, a requester who already received the "was approved and is now running" outcome notification from `intentReleaseWorker.ts` was never told the intent was subsequently cancelled before it ran — the notification dedupe fix in #4785 (#4465) keeps a distinct `cancelled` dedupe class precisely so a later cancel *would* notify, but no event ever reached the worker to trigger it.

## Changes

- `cancelActionIntent` (`apps/api/src/services/actionIntents/intentService.ts`) now inserts an `intent_cancelled` outbox row in the same `withSystemDbAccessContext` transaction as the CAS, mirroring the `intent_created`/`intent_approved` pattern in `createActionIntent`. Inlined the CAS predicate rather than extending the shared `transitionIntent` primitive, since cancel is the only caller that needs the outbox write and `transitionIntent` is shared by `intentReleaseWorker.ts` / `aiAgentSdk.ts` release paths that don't.
- `intentReleaseWorker.ts`'s event-type dispatch (`processIntentReleaseJob`) now routes `intent_cancelled` into the existing outcome-only branch alongside `intent_rejected` / `intent_expired`, notifying the requester (`intent-outcome:` dedupe key) or agent recipients (`agent-intent-outcome:` dedupe key) via the pre-existing paths — no new notification logic needed, since `outcomeNotificationClass` already had a `cancelled` class from #4785.
- Widened the `intent_outbox_event_type_check` CHECK constraint (new migration `2026-10-08-100300-intent-cancelled-outbox-event.sql`) and the `IntentOutboxEvent` schema union (`apps/api/src/db/schema/actionIntents.ts`) to admit `'intent_cancelled'`.
- Updated a stale comment in `intentReleaseWorker.ts` that documented the previous "cancel writes no outbox row" behavior as a caveat.

## Tests

- `apps/api/src/services/actionIntents/intentService.test.ts`: two new `cancelActionIntent` tests — writes the outbox row on a successful CAS, writes nothing when the CAS loses the race. Verified red-then-green (confirmed the first failed against unmodified code before implementing the fix).
- `apps/api/src/jobs/intentReleaseWorker.test.ts`: new test for the `intent_cancelled` outcome-only dispatch, plus the exact scenario from the issue — approved-then-cancelled delivers exactly one "cancelled" notification after the "running" one (`outcome notification dedupe identity` suite). Verified these fail without the worker-side fix (temporarily reverted it to confirm red, then restored).

## Test plan

- [x] `vitest run` on the five affected test files (intentService, intentService.scope, intentService.tier2Agent, intentService.ticketAutonomy, policyDecide, decideApprovalRequest, intentReleaseWorker, intentReleaseWorker.durable.contract, intentExpiryReaper) — 290 passed
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on touched files
- [x] `scripts/check-migration-naming.sh` clean (also enforced by pre-commit hook)

Closes #4798

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBxF7C8E5GxFnNcGf6kBVP