### PR TITLE
fix(web): reseed quote/invoice drafts during render, not from a passive effect (#4807)

### DIFF
--- a/apps/web/src/components/billing/InvoiceDetail.test.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useLayoutEffect } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import InvoiceDetail from './InvoiceDetail';
@@ -47,6 +48,22 @@ const issued: InvoiceDetailData = {
   },
   lines,
 };
+
+/**
+ * Records the due-date input's committed DOM value. A layout effect runs
+ * synchronously in the mutation phase of the very commit that produced the
+ * DOM, so it reads what the field actually showed at that commit without
+ * depending on when React's scheduler gets around to passive effects — same
+ * technique used to pin down #4659 (AiBudgetThresholdsInput).
+ */
+function CommitProbe({ testId, seen }: { testId: string; seen: string[] }) {
+  useLayoutEffect(() => {
+    const el = document.querySelector(`[data-testid="${testId}"]`) as HTMLInputElement | null;
+    if (!el) throw new Error(`CommitProbe: no element matching [data-testid="${testId}"]`);
+    seen.push(el.value);
+  });
+  return null;
+}
 
 describe('InvoiceDetail', () => {
   beforeEach(() => {
@@ -496,5 +513,59 @@ describe('InvoiceDetail — QuickBooks accounting sync rail card', () => {
       '/accounting/quickbooks/invoices/inv-1/push',
       expect.objectContaining({ method: 'POST' }),
     );
+  });
+
+  // #4807 (mirrors #4659/#4033): `dueDateDraft` used to re-seed from
+  // `invoice.dueDate` in a `useEffect`, i.e. in a commit AFTER the one that
+  // delivered the new prop. Because a passive effect is deferred, a keystroke
+  // landing in that window was silently reverted by the stale date the
+  // effect had captured. Re-seeding during render (this fix) leaves no such
+  // commit — assert exactly that.
+  it('re-seeds a changed dueDate prop within the same commit, not a later one (#4807)', async () => {
+    const seen: string[] = [];
+    // The inline editor (and thus the input the probe reads) only mounts
+    // after "Edit" is clicked, so the probe is added to the tree in a
+    // SEPARATE rerender from the one that opens it — otherwise its layout
+    // effect would fire before the input exists.
+    const bare = (dueDate: string) => <InvoiceDetail detail={{ ...issued, invoice: { ...issued.invoice, dueDate } }} onChanged={vi.fn()} />;
+    const probed = (dueDate: string) => (
+      <>
+        {bare(dueDate)}
+        <CommitProbe testId="invoice-due-date-input" seen={seen} />
+      </>
+    );
+
+    const { rerender } = render(bare('2026-06-30'));
+    await waitFor(() => expect(screen.getByTestId('invoice-detail')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('invoice-due-date-edit'));
+    await waitFor(() => expect(screen.getByTestId('invoice-due-date-input')).toBeInTheDocument());
+
+    rerender(probed('2026-06-30')); // add the probe once the field exists
+    seen.length = 0;
+
+    rerender(probed('2026-07-15'));
+
+    // One commit, already showing the new due date. An earlier entry still
+    // reading '2026-06-30' is the old effect-driven seed — the window that
+    // made the field clobberable mid-keystroke.
+    expect(seen).toEqual(['2026-07-15']);
+  });
+
+  // Discriminating test per the issue's required pattern: type a draft, then
+  // let an unrelated (equal-valued) prop refetch land — the draft must
+  // survive rather than being discarded by a resync that changed nothing.
+  it('keeps a typed due-date draft when an unrelated refetch hands back the same dueDate', async () => {
+    const { rerender } = render(<InvoiceDetail detail={issued} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-detail')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('invoice-due-date-edit'));
+
+    const input = screen.getByTestId('invoice-due-date-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '2026-08-01' } });
+
+    // A fresh detail object, same persisted due date — an unrelated resync
+    // (e.g. the payments-list refresh on the same page).
+    rerender(<InvoiceDetail detail={{ ...issued, invoice: { ...issued.invoice } }} onChanged={vi.fn()} />);
+
+    expect(screen.getByTestId('invoice-due-date-input')).toHaveValue('2026-08-01');
   });
 });

--- a/apps/web/src/components/billing/InvoiceDetail.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.tsx
@@ -101,7 +101,18 @@ export default function InvoiceDetail({ detail, onChanged, actionsInHeader = fal
   // Save PATCHes /invoices/:id/due-date.
   const [dueDateEditing, setDueDateEditing] = useState(false);
   const [dueDateDraft, setDueDateDraft] = useState(invoice.dueDate ?? '');
-  useEffect(() => { setDueDateDraft(invoice.dueDate ?? ''); }, [invoice.dueDate]);
+  // Re-seed from the prop DURING RENDER, never from a passive effect (#4807;
+  // same defect and remedy as InvoiceEditor's notes/terms drafts — #2925,
+  // #3219, #3277, #3980, #4033 — and AiBudgetThresholdsInput, #4659/#4805). A
+  // passive effect flushes AFTER commit, so a keystroke landing between the
+  // prop's commit and the effect's later run gets silently overwritten by the
+  // stale date the effect captured.
+  const dueDateSeed = invoice.dueDate ?? '';
+  const [dueDateSeededFrom, setDueDateSeededFrom] = useState(dueDateSeed);
+  if (dueDateSeededFrom !== dueDateSeed) {
+    setDueDateSeededFrom(dueDateSeed);
+    setDueDateDraft(dueDateSeed);
+  }
 
   const loadPayments = useCallback(async () => {
     const res = await fetchWithAuth(`/invoices/${invoice.id}/payments`);

--- a/apps/web/src/components/billing/quotes/QuoteEditor.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.test.tsx
@@ -267,6 +267,46 @@ describe('QuoteEditor', () => {
     expect(textarea.value).toBe('Net 30 — draft in progress');
   });
 
+  // Review finding: the reseed must also reset `termsDirty` when the prop
+  // GENUINELY changes mid-edit (not just an equal-value refetch) — matching
+  // what the old effect did — otherwise a stale "Unsaved" badge would linger
+  // over text that was just replaced with the (already-persisted) new value.
+  it('clears the Unsaved badge when a genuinely different termsAndConditions prop lands mid-edit', async () => {
+    const { rerender } = render(<QuoteEditor detail={draftDetail({ termsAndConditions: 'Net 30' })} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    const textarea = screen.getByTestId('quote-terms') as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: 'Net 30 draft' } });
+    expect(screen.getByTestId('unsaved-badge')).toBeInTheDocument();
+
+    // A genuinely different persisted value lands (e.g. another session's edit).
+    rerender(<QuoteEditor detail={draftDetail({ termsAndConditions: 'Net 60' })} onChanged={vi.fn()} />);
+
+    expect(textarea.value).toBe('Net 60');
+    expect(screen.queryByTestId('unsaved-badge')).not.toBeInTheDocument();
+  });
+
+  // Review finding: the deposit-percent reseed clears `depositPctError` too
+  // (new behavior vs. the old effect, which never touched it) — a stale
+  // "out of range" message must not linger once the field has been replaced
+  // with a fresh, valid, server-confirmed value.
+  it('clears the inline deposit-percent range error when a genuinely different depositPercent prop lands', async () => {
+    const { rerender } = render(
+      <QuoteEditor detail={draftDetail({ depositType: 'percent', depositPercent: '10' })} onChanged={vi.fn()} />,
+    );
+    await waitFor(() => expect(screen.getByTestId('deposit-percent-input')).toBeInTheDocument());
+
+    const input = screen.getByTestId('deposit-percent-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '150' } });
+    fireEvent.blur(input);
+    expect(screen.getByTestId('deposit-percent-error')).toBeInTheDocument();
+
+    rerender(<QuoteEditor detail={draftDetail({ depositType: 'percent', depositPercent: '30' })} onChanged={vi.fn()} />);
+
+    expect(input.value).toBe('30');
+    expect(screen.queryByTestId('deposit-percent-error')).not.toBeInTheDocument();
+  });
+
   it('toasts the currency-gap message when the catalog add answers NO_PRICE_FOR_CURRENCY (#3775)', async () => {
     const catItem = {
       id: 'cat-1', partnerId: 'p-1', itemType: 'hardware', name: 'NVMe 1TB', sku: 'NV-1', description: null,

--- a/apps/web/src/components/billing/quotes/QuoteEditor.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.test.tsx
@@ -1,4 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useLayoutEffect } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import QuoteEditor from './QuoteEditor';
@@ -45,6 +46,27 @@ vi.mock('../../../lib/api/quotes', () => ({
 const fetchMock = vi.mocked(fetchWithAuth);
 const json = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
   ({ ok, status, statusText: ok ? 'OK' : 'ERR', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+/**
+ * Records a probed element's committed DOM value. Layout effects run
+ * synchronously in the mutation phase of the very commit that produced the
+ * DOM, so this reads what the field actually showed at that commit without
+ * depending on when React's scheduler gets around to passive effects — the
+ * same technique used to pin down #4659 (AiBudgetThresholdsInput). It only
+ * appends when THIS probe re-renders (a sibling of the field under test), so
+ * an unconditional passive `useEffect` prop-sync — which re-seeds one commit
+ * AFTER the render that already delivered the new prop — shows up as the
+ * probe's commit still holding the STALE value; the render-phase reseed this
+ * fix uses shows the new value already, in that same commit.
+ */
+function CommitProbe({ testId, seen }: { testId: string; seen: string[] }) {
+  useLayoutEffect(() => {
+    const el = document.querySelector(`[data-testid="${testId}"]`) as HTMLInputElement | HTMLTextAreaElement | null;
+    if (!el) throw new Error(`CommitProbe: no element matching [data-testid="${testId}"]`);
+    seen.push(el.value);
+  });
+  return null;
+}
 
 function draftDetail(extra: Partial<QuoteDetailData['quote']> = {}): QuoteDetailData {
   return {
@@ -179,6 +201,70 @@ describe('QuoteEditor', () => {
 
     const textarea = screen.getByTestId('quote-terms') as HTMLTextAreaElement;
     expect(textarea.value).toBe('Payment due in 30 days');
+  });
+
+  // #4807 (mirrors #4659/#4033): `terms` used to re-seed from
+  // `quote.termsAndConditions` in a `useEffect`, i.e. in a commit AFTER the
+  // one that delivered the new prop. Because a passive effect is deferred, a
+  // keystroke landing in that window was silently reverted by the stale
+  // string the effect had captured. Re-seeding during render (this fix)
+  // leaves no such commit — assert exactly that.
+  it('re-seeds a changed termsAndConditions prop within the same commit, not a later one (#4807)', async () => {
+    const seen: string[] = [];
+    const view = (terms: string | null) => (
+      <>
+        <QuoteEditor detail={draftDetail({ termsAndConditions: terms })} onChanged={vi.fn()} />
+        <CommitProbe testId="quote-terms" seen={seen} />
+      </>
+    );
+
+    const { rerender } = render(view('Net 30'));
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+    seen.length = 0;
+
+    rerender(view('Net 45'));
+
+    // One commit, already showing the new terms. An earlier entry still
+    // reading 'Net 30' is the old effect-driven seed — the window that made
+    // the field clobberable mid-keystroke.
+    expect(seen).toEqual(['Net 45']);
+  });
+
+  // The deposit-percent draft has the identical shape: a live-typed numeric
+  // field re-seeded from `quote.depositPercent` in a passive effect (#4807).
+  it('re-seeds a changed depositPercent prop within the same commit, not a later one (#4807)', async () => {
+    const seen: string[] = [];
+    const view = (depositPercent: string | null) => (
+      <>
+        <QuoteEditor detail={draftDetail({ depositType: 'percent', depositPercent })} onChanged={vi.fn()} />
+        <CommitProbe testId="deposit-percent-input" seen={seen} />
+      </>
+    );
+
+    const { rerender } = render(view('10'));
+    await waitFor(() => expect(screen.getByTestId('deposit-percent-input')).toBeInTheDocument());
+    seen.length = 0;
+
+    rerender(view('25'));
+
+    expect(seen).toEqual(['25']);
+  });
+
+  // Discriminating test per the issue's required pattern: type a draft, then
+  // let an unrelated (equal-valued) prop refetch land — the draft must
+  // survive rather than being discarded by a resync that changed nothing.
+  it('keeps a typed terms draft when an unrelated refetch hands back the same termsAndConditions', async () => {
+    const detail = draftDetail({ termsAndConditions: 'Net 30' });
+    const { rerender } = render(<QuoteEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-editor')).toBeInTheDocument());
+
+    const textarea = screen.getByTestId('quote-terms') as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: 'Net 30 — draft in progress' } });
+
+    // A fresh detail object, same persisted terms — an unrelated resync.
+    rerender(<QuoteEditor detail={draftDetail({ termsAndConditions: 'Net 30' })} onChanged={vi.fn()} />);
+
+    expect(textarea.value).toBe('Net 30 — draft in progress');
   });
 
   it('toasts the currency-gap message when the catalog add answers NO_PRICE_FOR_CURRENCY (#3775)', async () => {

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -416,7 +416,21 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
   const [contractVarErrors, setContractVarErrors] = useState<Record<string, string>>({});
   const [contractLabel, setContractLabel] = useState('');
 
-  useEffect(() => { setTerms(quote.termsAndConditions ?? ''); setTermsDirty(false); }, [quote.termsAndConditions]);
+  // Re-seed from the prop DURING RENDER, never from a passive effect (#4807;
+  // same defect and remedy as InvoiceEditor's notes/terms drafts — #2925,
+  // #3219, #3277, #3980, #4033 — and AiBudgetThresholdsInput, #4659/#4805). A
+  // passive effect is flushed AFTER commit, so a keystroke landing between the
+  // prop's commit and the effect's later run gets silently overwritten by the
+  // stale string the effect captured. Comparing the rendered STRING (not the
+  // prop's identity) means a refetch that hands back an equal-but-unchanged
+  // value changes nothing on screen and can't discard an in-progress edit.
+  const termsSeed = quote.termsAndConditions ?? '';
+  const [termsSeededFrom, setTermsSeededFrom] = useState(termsSeed);
+  if (termsSeededFrom !== termsSeed) {
+    setTermsSeededFrom(termsSeed);
+    setTerms(termsSeed);
+    setTermsDirty(false);
+  }
 
   // ---- deposit controls ----------------------------------------------------
   // Local mirrors of the persisted deposit config so the type select + percent
@@ -434,7 +448,17 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
   // selected_lines block further down for the rationale.
   const stagedSelectedLines = useRef(false);
   useEffect(() => { if (!stagedSelectedLines.current) setDepositType(quote.depositType ?? 'none'); }, [quote.depositType]);
-  useEffect(() => { setDepositPercentDraft(quote.depositPercent ?? ''); }, [quote.depositPercent]);
+  // Same render-phase reseed as `terms` above (#4807) — the percent field is a
+  // live-typed draft, so a passive effect here is the identical clobber
+  // window. Resetting the inline range error too: it described the draft this
+  // reseed just replaced.
+  const depositPercentSeed = quote.depositPercent ?? '';
+  const [depositPercentSeededFrom, setDepositPercentSeededFrom] = useState(depositPercentSeed);
+  if (depositPercentSeededFrom !== depositPercentSeed) {
+    setDepositPercentSeededFrom(depositPercentSeed);
+    setDepositPercentDraft(depositPercentSeed);
+    setDepositPctError(null);
+  }
 
   // Coalesce re-pulls: each mutation calls refresh(), but tab-through editing
   // would otherwise fire one full GET /quotes/:id per field. This is a LEADING +

--- a/apps/web/src/components/billing/quotes/QuoteHeaderMeta.customer.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteHeaderMeta.customer.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useLayoutEffect } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { QuoteCustomerSwitcher } from './QuoteHeaderMeta';
@@ -62,6 +63,23 @@ function detail(): QuoteDetailData {
 const customerPatchCalls = () =>
   fetchMock.mock.calls.filter((c) => c[0] === '/quotes/q-1' && (c[1] as RequestInit | undefined)?.method === 'PATCH'
     && String((c[1] as RequestInit).body).includes('orgId'));
+
+/**
+ * Records the customer trigger's committed `title` attribute (the selected
+ * org's full name). A layout effect runs synchronously in the mutation phase
+ * of the very commit that produced the DOM, so it reads what the trigger
+ * actually showed at that commit without depending on when React's scheduler
+ * gets around to passive effects — same technique used to pin down #4659
+ * (AiBudgetThresholdsInput).
+ */
+function CommitProbe({ seen }: { seen: string[] }) {
+  useLayoutEffect(() => {
+    const el = document.querySelector('[data-testid="quote-customer-trigger"]');
+    if (!el) throw new Error('CommitProbe: no element matching [data-testid="quote-customer-trigger"]');
+    seen.push(el.getAttribute('title') ?? '');
+  });
+  return null;
+}
 
 describe('QuoteCustomerSwitcher customer reassignment', () => {
   beforeEach(() => {
@@ -154,5 +172,34 @@ describe('QuoteCustomerSwitcher customer reassignment', () => {
 
     await waitFor(() => expect(customerPatchCalls()).toHaveLength(1));
     await waitFor(() => expect(screen.getByTestId('quote-customer-trigger')).toHaveTextContent('Acme'));
+  });
+
+  // #4807 (mirrors #4659/#4033): `customerOrgId` used to re-seed from
+  // `quote.orgId` in a `useEffect`, i.e. in a commit AFTER the one that
+  // delivered the new prop. Because a passive effect is deferred, an
+  // optimistic `setCustomerOrgId` (from `saveCustomer`, or any local
+  // selection) landing in that one-commit window would be reverted by the
+  // stale org id the effect had captured. Mirroring during render (this fix)
+  // leaves no such commit — assert the trigger already shows the new
+  // customer in the very commit that delivers the new `orgId` prop, using
+  // the same layout-effect probe technique as #4659.
+  it('re-seeds a changed quote.orgId prop within the same commit, not a later one (#4807)', () => {
+    const seen: string[] = [];
+    const view = (orgId: string) => (
+      <>
+        <QuoteCustomerSwitcher detail={{ ...detail(), quote: { ...detail().quote, orgId } }} onChanged={vi.fn()} />
+        <CommitProbe seen={seen} />
+      </>
+    );
+
+    const { rerender } = render(view('org-1'));
+    seen.length = 0;
+
+    rerender(view('org-2'));
+
+    // One commit, already showing the new customer's name. An earlier entry
+    // still reading 'Acme' is the old effect-driven seed — the window that
+    // made the selection clobberable by a stale local optimistic update.
+    expect(seen).toEqual(['Beta Corp']);
   });
 });

--- a/apps/web/src/components/billing/quotes/QuoteHeaderMeta.title.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteHeaderMeta.title.test.tsx
@@ -4,6 +4,7 @@
 // "Saving changes… Send unlocks when everything is saved." over the Send button
 // for the rest of the session, describing a save that had already given up.
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useLayoutEffect } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { QuoteHeaderMeta } from './QuoteHeaderMeta';
@@ -43,6 +44,22 @@ function detail(): QuoteDetailData {
     blocks: [],
     lines: [],
   };
+}
+
+/**
+ * Records the title input's committed DOM value. A layout effect runs
+ * synchronously in the mutation phase of the very commit that produced the
+ * DOM, so it reads what the box actually showed at that commit without
+ * depending on when React's scheduler gets around to passive effects — same
+ * technique used to pin down #4659 (AiBudgetThresholdsInput).
+ */
+function CommitProbe({ testId, seen }: { testId: string; seen: string[] }) {
+  useLayoutEffect(() => {
+    const el = document.querySelector(`[data-testid="${testId}"]`) as HTMLInputElement | null;
+    if (!el) throw new Error(`CommitProbe: no element matching [data-testid="${testId}"]`);
+    seen.push(el.value);
+  });
+  return null;
 }
 
 beforeEach(() => vi.clearAllMocks());
@@ -114,5 +131,46 @@ describe('QuoteHeaderMeta — title save reporting', () => {
     fireEvent.blur(input);
     await waitFor(() => expect(screen.getByTestId('quote-title')).not.toBeDisabled());
     expect(onSaveFailure).toHaveBeenCalledTimes(1);
+  });
+
+  // #4807 (mirrors #4659/#4033): `title` used to re-seed from `quote.title` in
+  // a `useEffect`, i.e. in a commit AFTER the one that delivered the new
+  // prop. Because a passive effect is deferred, a keystroke landing in that
+  // window was silently reverted by the stale string the effect had
+  // captured. Re-seeding during render (this fix) leaves no such commit —
+  // assert exactly that.
+  it('re-seeds a changed title prop within the same commit, not a later one (#4807)', () => {
+    const seen: string[] = [];
+    const view = (title: string | null) => (
+      <>
+        <QuoteHeaderMeta detail={{ ...detail(), quote: { ...detail().quote, title } }} onChanged={vi.fn()} />
+        <CommitProbe testId="quote-title" seen={seen} />
+      </>
+    );
+
+    const { rerender } = render(view('Original title'));
+    seen.length = 0;
+
+    rerender(view('Server-updated title'));
+
+    // One commit, already showing the new title. An earlier entry still
+    // reading 'Original title' is the old effect-driven seed — the window
+    // that made the field clobberable mid-keystroke.
+    expect(seen).toEqual(['Server-updated title']);
+  });
+
+  // Discriminating test per the issue's required pattern: type a draft, then
+  // let an unrelated (equal-valued) prop refetch land — the draft must
+  // survive rather than being discarded by a resync that changed nothing.
+  it('keeps a typed title draft when an unrelated refetch hands back the same title', () => {
+    const d = { ...detail(), quote: { ...detail().quote, title: 'Original title' } };
+    const { rerender } = render(<QuoteHeaderMeta detail={d} onChanged={vi.fn()} />);
+
+    const input = screen.getByTestId('quote-title') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Original title — draft in progress' } });
+
+    rerender(<QuoteHeaderMeta detail={{ ...detail(), quote: { ...detail().quote, title: 'Original title' } }} onChanged={vi.fn()} />);
+
+    expect(input.value).toBe('Original title — draft in progress');
   });
 });

--- a/apps/web/src/components/billing/quotes/QuoteHeaderMeta.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteHeaderMeta.tsx
@@ -51,7 +51,19 @@ export function QuoteHeaderMeta({ detail, onChanged, onPendingChange, onUnsavedC
   const [titleBusy, setTitleBusy] = useState(false);
   const [titleFailed, setTitleFailed] = useState(false);
   const [titleSaved, flashTitleSaved] = useSavedFlash();
-  useEffect(() => { setTitle(quote.title ?? ''); setTitleDirty(false); }, [quote.title]);
+  // Re-seed from the prop DURING RENDER, never from a passive effect (#4807;
+  // same defect and remedy as InvoiceEditor's notes/terms drafts — #2925,
+  // #3219, #3277, #3980, #4033 — and AiBudgetThresholdsInput, #4659/#4805). A
+  // passive effect flushes AFTER commit, so a keystroke landing between the
+  // prop's commit and the effect's later run gets silently overwritten by the
+  // stale string the effect captured.
+  const titleSeed = quote.title ?? '';
+  const [titleSeededFrom, setTitleSeededFrom] = useState(titleSeed);
+  if (titleSeededFrom !== titleSeed) {
+    setTitleSeededFrom(titleSeed);
+    setTitle(titleSeed);
+    setTitleDirty(false);
+  }
 
   const saveTitle = useCallback(async () => {
     if (!titleDirty) return;
@@ -132,7 +144,16 @@ export function QuoteCustomerSwitcher({ detail, onChanged, onPendingChange }: Pr
 
   const [customerOrgId, setCustomerOrgId] = useState(quote.orgId);
   const [customerBusy, setCustomerBusy] = useState(false);
-  useEffect(() => { setCustomerOrgId(quote.orgId); }, [quote.orgId]);
+  // Mirror `quote.orgId` DURING RENDER, never from a passive effect (#4807) —
+  // same class of bug as the title field above, just via a select instead of
+  // free text: a passive effect flushes AFTER commit, so an optimistic
+  // `setCustomerOrgId` from `saveCustomer` (below) landing in that window
+  // would be overwritten by the stale org id the effect captured.
+  const [orgSeededFrom, setOrgSeededFrom] = useState(quote.orgId);
+  if (orgSeededFrom !== quote.orgId) {
+    setOrgSeededFrom(quote.orgId);
+    setCustomerOrgId(quote.orgId);
+  }
   // Reassignment clears site + bill-to and re-resolves tax, so a select change
   // stages here and a confirm step commits — a dropdown mis-click must never
   // silently rewrite the quote's tax basis.


### PR DESCRIPTION
Closes #4807

## Same clobber race as #4659 / #2925

An unconditional `useEffect(() => setState(prop), [prop])` re-syncs a
live-edit draft from a prop **after commit**. When the prop's persisted value
genuinely changes (a background refetch, a sibling field's save triggering
`refresh()`, etc.), the render that delivers the new prop still shows the
*old* draft; only the deferred passive effect corrects it, one commit later.
A keystroke landing in that one-commit window is silently reverted by the
stale value the effect captured — reproduced and fixed the same way for
`AiBudgetThresholdsInput` in #4805.

## What changed

Applied the #4805 / #4033 render-phase reseed pattern (compare the rendered
value against a `xSeededFrom` sentinel; update state **during render**, not
in an effect, when it differs) to 5 of the 6 sites the #4659 fixer flagged:

- `apps/web/src/components/billing/quotes/QuoteEditor.tsx` — `terms`/`termsDirty` (was line 419), `depositPercentDraft` (was line 437)
- `apps/web/src/components/billing/quotes/QuoteHeaderMeta.tsx` — `title`/`titleDirty` (was line 54), `customerOrgId` (was line 135)
- `apps/web/src/components/billing/InvoiceDetail.tsx` — `dueDateDraft` (was line 104)

## `QuoteLineRows.tsx` — verified, left untouched

The issue also listed `QuoteLineRows.tsx:697-699` (qty/price/cost, plus
sku/partNumber and name/desc share the same shape). I verified this site
before touching it, per the issue's caveat, and concluded it is **not**
exposed to the same race, so I left it alone:

- Each of those fields is guarded by a `*Edited` ref (`qtyEdited`,
  `priceEdited`, `costEdited`, `skuEdited`, `partEdited`, plus
  `nameEdited`/`descEdited`) that the resync effect checks before reseeding.
- The guard is cleared **synchronously at commit-time** (inside `commitQty`/
  `commitPrice`/etc., which run on blur, immediately — not gated on the
  async PATCH's resolution as I'd initially been told). That's a correction
  worth noting: the guard is *not* "cleared only on confirmed save."
- What actually closes the race: any subsequent keystroke's `onChange`
  handler flips the guard back to `true` **synchronously**, before any
  passive effect gets a chance to run. Since a real user keystroke can't
  land inside the sub-millisecond window between a commit and its passive
  effect flush, there's no realistic window left for the effect to fire
  while a ref is `false` AND the user is mid-typing a value the effect would
  clobber. This is structurally different from the fixed sites, which had no
  guard ref at all.
- I did not find a way to write a test that goes red against the current
  `QuoteLineRows.tsx` code (i.e. a discriminating test), which is itself
  evidence the guard closes the window in practice.

## Tests

Each fixed site gets a **commit-timing regression test** — a sibling
`useLayoutEffect` probe (the same technique #4805 introduced for
`AiBudgetThresholdsInput`) that reads the field's live DOM value at every
commit the probe participates in. The assertion is that a `rerender()` with
a genuinely-changed prop shows the **new** value in that single commit, with
no earlier commit still showing the stale one:

- `QuoteEditor.test.tsx`: `re-seeds a changed termsAndConditions prop within the same commit...`, `re-seeds a changed depositPercent prop within the same commit...`
- `QuoteHeaderMeta.title.test.tsx`: `re-seeds a changed title prop within the same commit...`
- `QuoteHeaderMeta.customer.test.tsx`: `re-seeds a changed quote.orgId prop within the same commit...`
- `InvoiceDetail.test.tsx`: `re-seeds a changed dueDate prop within the same commit...`

I verified each of these five tests is genuinely discriminating: I
temporarily reverted each fix back to the old passive-`useEffect` code and
confirmed the corresponding new test goes **red** (e.g. `expected ['Net 30'] to
deeply equal ['Net 45']`), then restored the fix and confirmed green again.

Also added, per the issue's requested pattern (type a draft, let a prop
refetch land, assert the draft survives): "keeps a typed terms/title/due-date
draft when an unrelated refetch hands back the same [unchanged] value" tests
for the terms and title and due-date fields. (Being upfront: because these
props are plain strings, an *unchanged* value never triggers the old effect
either — Object.is already short-circuits it — so these particular tests
don't discriminate old vs. new code on their own. They're included as
baseline regression coverage since the issue explicitly asked for this
pattern; the commit-timing tests above are what actually pins down the bug
and fails on the old code.)

## Verification

- `apps/web`: affected suites green — `QuoteEditor.test.tsx` (8), 
  `QuoteHeaderMeta.title.test.tsx` (5), `QuoteHeaderMeta.customer.test.tsx`
  (7), `InvoiceDetail.test.tsx` (24). 44/44 passed.
- `npx tsc --noEmit -p apps/web` — clean, exit 0.
- `npx eslint` on all 7 changed files — clean, no output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
