### PR TITLE
fix(api/portal): rate-limit password-change guesses, stop 401ing wrong ones (#4797)

### DIFF
--- a/apps/api/src/routes/portal/profile.password.test.ts
+++ b/apps/api/src/routes/portal/profile.password.test.ts
@@ -1,0 +1,251 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+// #4797: POST /profile/password had no rate limit on current-password guesses
+// and answered a wrong guess with 401, which the portal client funnels into a
+// forced logout. This suite covers both fixes: the dedicated portal-native
+// rate limiter (checkRateLimit, in-memory mode here since PORTAL_USE_REDIS is
+// false outside production/PORTAL_STATE_BACKEND=redis) and the 401 -> 400
+// + stable `code` change.
+
+const verifyPasswordMock = vi.fn(async (_hash: string, _plaintext: string) => true);
+const hashPasswordMock = vi.fn(async (_plaintext: string) => 'new-hash');
+
+const dbState: { userRow: unknown } = {
+  userRow: {
+    id: 'pu-1',
+    passwordHash: 'argon2-hash',
+    email: 'customer@example.com',
+    orgId: 'org-1',
+    name: 'Customer',
+  },
+};
+
+const updateReturningMock = vi.fn(async () => [dbState.userRow]);
+
+vi.mock('../../db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../db')>();
+  return {
+    ...actual,
+    db: {
+      select: vi.fn(),
+      update: vi.fn(),
+    },
+  };
+});
+
+vi.mock('../../db/schema', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../db/schema')>();
+  return {
+    ...actual,
+    portalUsers: {
+      id: 'portal_users.id',
+      orgId: 'portal_users.org_id',
+      email: 'portal_users.email',
+      name: 'portal_users.name',
+      passwordHash: 'portal_users.password_hash',
+      receiveNotifications: 'portal_users.receive_notifications',
+      status: 'portal_users.status',
+    },
+  };
+});
+
+vi.mock('../../services/password', () => ({
+  hashPassword: (plaintext: string) => hashPasswordMock(plaintext),
+  verifyPassword: (hash: string, plaintext: string) => verifyPasswordMock(hash, plaintext),
+  isPasswordStrong: () => ({ valid: true, errors: [] }),
+}));
+
+vi.mock('../../services/redis', () => ({
+  getRedis: vi.fn(() => null),
+}));
+
+vi.mock('./helpers', async () => {
+  const actual = await vi.importActual<typeof import('./helpers')>('./helpers');
+  return {
+    ...actual,
+    validatePortalCookieCsrfRequest: vi.fn(() => null),
+    writePortalAudit: vi.fn(),
+  };
+});
+
+import { profileRoutes } from './profile';
+import { db } from '../../db';
+import { portalRateLimitBuckets, writePortalAudit } from './helpers';
+
+const AUTH_USER = {
+  id: 'pu-1',
+  orgId: 'org-1',
+  email: 'customer@example.com',
+  name: 'Customer',
+  contactId: null,
+  receiveNotifications: true,
+  status: 'active',
+};
+
+function app() {
+  const hono = new Hono();
+  hono.use('*', async (c, next) => {
+    c.set('portalAuth', { user: AUTH_USER, token: 'token', authMethod: 'bearer', timezone: 'UTC' });
+    await next();
+  });
+  hono.route('/', profileRoutes);
+  return hono;
+}
+
+function buildSelectChain() {
+  vi.mocked(db.select as any).mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockImplementation(() =>
+          Promise.resolve(dbState.userRow ? [dbState.userRow] : [])
+        ),
+      }),
+    }),
+  });
+}
+
+function buildUpdateChain() {
+  vi.mocked(db.update as any).mockReturnValue({
+    set: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(undefined),
+    }),
+  });
+}
+
+async function postPasswordChange(body: unknown) {
+  return app().request('/profile/password', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /profile/password', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    portalRateLimitBuckets.clear();
+    verifyPasswordMock.mockResolvedValue(true);
+    dbState.userRow = {
+      id: 'pu-1',
+      passwordHash: 'argon2-hash',
+      email: 'customer@example.com',
+      orgId: 'org-1',
+      name: 'Customer',
+    };
+    buildSelectChain();
+    buildUpdateChain();
+    updateReturningMock.mockClear();
+  });
+
+  it('happy path: a correct current password still succeeds', async () => {
+    const res = await postPasswordChange({
+      currentPassword: 'correct-horse',
+      newPassword: 'battery-staple-9',
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ success: true, message: 'Password changed successfully' });
+    expect(verifyPasswordMock).toHaveBeenCalledWith('argon2-hash', 'correct-horse');
+    expect(writePortalAudit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'portal.profile.password.change' })
+    );
+  });
+
+  // The core #4797 fix: a wrong guess must never collide with the session
+  // guard's 401, or the portal client's default fetch handler
+  // (apps/portal/src/lib/api.ts) clears auth and redirects to /login —
+  // signing the user out over a typo instead of showing the error.
+  it('returns 400 with the stable invalid_credentials code on a wrong guess (#4797)', async () => {
+    verifyPasswordMock.mockResolvedValueOnce(false);
+    const res = await postPasswordChange({
+      currentPassword: 'wrong',
+      newPassword: 'battery-staple-9',
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toEqual({
+      error: 'Current password is incorrect',
+      message: 'Current password is incorrect',
+      code: 'invalid_credentials',
+    });
+  });
+
+  it('never answers a wrong guess with 401', async () => {
+    verifyPasswordMock.mockResolvedValueOnce(false);
+    const res = await postPasswordChange({
+      currentPassword: 'wrong',
+      newPassword: 'battery-staple-9',
+    });
+    expect(res.status).not.toBe(401);
+  });
+
+  // N+1 guesses (the config allows 5) throttle the 6th request — before the
+  // account is even looked up.
+  it('rate-limits after maxAttempts guesses, regardless of correctness', async () => {
+    verifyPasswordMock.mockResolvedValue(false);
+    let last!: Response;
+    for (let i = 0; i < 6; i += 1) {
+      last = await postPasswordChange({
+        currentPassword: `wrong-${i}`,
+        newPassword: 'battery-staple-9',
+      });
+    }
+    expect(last.status).toBe(429);
+    expect(last.headers.get('retry-after')).toBeTruthy();
+    // Only the first 5 attempts should have reached password verification —
+    // the 6th was throttled before the DB lookup / argon2 verify ran.
+    expect(verifyPasswordMock).toHaveBeenCalledTimes(5);
+  });
+
+  // A 429 must not leak whether the guess would have been right — throttling
+  // has to happen before verifyPassword is ever called for the blocked
+  // request, for both a correct and an incorrect guess.
+  it('a 429 does not leak whether the password was right', async () => {
+    for (let i = 0; i < 5; i += 1) {
+      await postPasswordChange({ currentPassword: `wrong-${i}`, newPassword: 'battery-staple-9' });
+    }
+    verifyPasswordMock.mockClear();
+
+    const blockedWithCorrect = await postPasswordChange({
+      currentPassword: 'correct-horse',
+      newPassword: 'battery-staple-9',
+    });
+    expect(blockedWithCorrect.status).toBe(429);
+    expect(verifyPasswordMock).not.toHaveBeenCalled();
+
+    const blockedBody = await blockedWithCorrect.json();
+    // The blocked response carries no trace of the invalid_credentials
+    // contract — it is a distinct shape from both the 200 and 400 bodies.
+    expect(blockedBody).not.toHaveProperty('code');
+  });
+
+  it('throttles per portal user id, not globally', async () => {
+    verifyPasswordMock.mockResolvedValue(false);
+    for (let i = 0; i < 5; i += 1) {
+      await postPasswordChange({ currentPassword: `wrong-${i}`, newPassword: 'battery-staple-9' });
+    }
+    const blocked = await postPasswordChange({ currentPassword: 'wrong-6', newPassword: 'battery-staple-9' });
+    expect(blocked.status).toBe(429);
+
+    // A different portal user's bucket is untouched.
+    const otherApp = new Hono();
+    otherApp.use('*', async (c, next) => {
+      c.set('portalAuth', {
+        user: { ...AUTH_USER, id: 'pu-2' },
+        token: 'token',
+        authMethod: 'bearer',
+        timezone: 'UTC',
+      });
+      await next();
+    });
+    otherApp.route('/', profileRoutes);
+    const otherUserRes = await otherApp.request('/profile/password', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ currentPassword: 'wrong', newPassword: 'battery-staple-9' }),
+    });
+    expect(otherUserRes.status).toBe(400); // rejected on password, not throttled
+  });
+});

--- a/apps/api/src/routes/portal/profile.ts
+++ b/apps/api/src/routes/portal/profile.ts
@@ -5,17 +5,20 @@ import { db } from '../../db';
 import { portalUsers } from '../../db/schema';
 import { hashPassword, isPasswordStrong, verifyPassword } from '../../services/password';
 import { getRedis } from '../../services/redis';
+import { rejectProof, INVALID_CREDENTIALS_CODE } from '../auth/helpers';
 import {
   updateProfileSchema,
   changePasswordSchema,
   PORTAL_USE_REDIS,
   PORTAL_REDIS_KEYS,
+  PASSWORD_CHANGE_RATE_LIMIT,
 } from './schemas';
 import {
   applyPortalCacheHeaders,
   buildWeakEtag,
   portalSessions,
   buildPortalUserPayload,
+  checkRateLimit,
   isEtagFresh,
   validatePortalCookieCsrfRequest,
   writePortalAudit,
@@ -119,6 +122,21 @@ profileRoutes.post('/profile/password', zValidator('json', changePasswordSchema)
   const auth = c.get('portalAuth');
   const { currentPassword, newPassword } = c.req.valid('json');
 
+  // #4797: throttle current-password guesses BEFORE looking the account up or
+  // verifying anything, keyed on the portal user id alone — this route is
+  // already session-authed (portalAuthMiddleware), so unlike the anonymous
+  // login/reset limiters there is no IP axis to also key on. Without this a
+  // stolen portal session could brute-force the current password at one
+  // argon2 verify per request with no lockout (the #4746 class). Uses the
+  // portal's own dual-mode limiter so self-hosted deployments without Redis
+  // keep working, exactly like every other portal auth rate limit.
+  const rateKey = `portal:profile-password:${auth.user.id}`;
+  const rate = await checkRateLimit(rateKey, PASSWORD_CHANGE_RATE_LIMIT);
+  if (!rate.allowed) {
+    c.header('Retry-After', String(rate.retryAfterSeconds));
+    return c.json({ error: 'Too many attempts. Please try again later.' }, 429);
+  }
+
   const [user] = await db
     .select({
       id: portalUsers.id,
@@ -137,7 +155,16 @@ profileRoutes.post('/profile/password', zValidator('json', changePasswordSchema)
 
   const validCurrentPassword = await verifyPassword(user.passwordHash, currentPassword);
   if (!validCurrentPassword) {
-    return c.json({ error: 'Current password is incorrect' }, 401);
+    // #4797 (follows #4470/#4651/#4660): `currentPassword` is body data this
+    // handler validates, not the credential authenticating the request (the
+    // portal session cookie/bearer, already checked by portalAuthMiddleware).
+    // A 401 here collided with the session guard and the portal client
+    // (apps/portal/src/lib/api.ts) funnelled it into clearAuth() + a redirect
+    // to /login — a mistyped current password signed the user out mid-flow.
+    // 400 + a stable code matches the neighbouring rejections on this same
+    // route (passwordless account above, weak new password below), which
+    // were already 400.
+    return rejectProof(c, 'Current password is incorrect', INVALID_CREDENTIALS_CODE, 400);
   }
 
   const passwordCheck = isPasswordStrong(newPassword);

--- a/apps/api/src/routes/portal/schemas.ts
+++ b/apps/api/src/routes/portal/schemas.ts
@@ -105,6 +105,17 @@ export const RESET_PASSWORD_RATE_LIMIT = {
   blockMs: 30 * 60 * 1000
 } as const;
 
+// #4797: throttles POST /profile/password's current-password guesses. Unlike
+// the anonymous login/reset limits above, this route is already
+// session-authed, so the key is the portal user id alone (see profile.ts) —
+// mirrors the 5-attempts/5-min bucket `requireCurrentPasswordStepUp` uses for
+// the equivalent /auth/* surface (apps/api/src/routes/auth/helpers.ts).
+export const PASSWORD_CHANGE_RATE_LIMIT = {
+  windowMs: 5 * 60 * 1000,
+  maxAttempts: 5,
+  blockMs: 15 * 60 * 1000
+} as const;
+
 // ============================================
 // Zod Schemas
 // ============================================


### PR DESCRIPTION
## Summary

Two defects on `POST /portal/profile/password`, both already fixed on the equivalent partner/tech route (`/auth/change-password`, #4782/#4739):

1. **No rate limit on current-password guesses** (the #4746 class). `verifyPassword` was called inline with no throttle anywhere on the handler path — `grep -rn "rateLimiter" apps/api/src/routes/portal/` returned nothing. A stolen portal session could brute-force the current password at one argon2 verify per request and, on a hit, set a new one. `requireCurrentPasswordStepUp` isn't directly reusable here since it looks up `users`, not `portal_users`.

2. **A wrong guess answered 401**, which the portal client (`apps/portal/src/lib/api.ts`) funnels into `clearAuth()` + a redirect to `/login` — signing the user out over a typo instead of showing the error (the #4660 class, missed when #4739 fixed `/auth/change-password`).

## Fix

- Adds `PASSWORD_CHANGE_RATE_LIMIT` (5 attempts / 5 min) and throttles on it via the portal's own `checkRateLimit` helper (`apps/api/src/routes/portal/helpers.ts`) — the same dual-mode (Redis / in-memory) limiter every other portal auth route (login, forgot-password, reset-password) already uses, keyed on the portal user id since this route is already session-authed. Chose this over introducing the Redis-only, fail-closed `rateLimiter` from `apps/api/src/routes/auth/helpers.ts` so self-hosted deployments without Redis keep working, consistent with every sibling portal rate limit.
- Changes the wrong-password rejection from `401` to `400` with the stable `code: 'invalid_credentials'` contract (`rejectProof` from `apps/api/src/routes/auth/helpers.ts`), matching #4470/#4651/#4660 and the two neighbouring rejections on this same route (passwordless account, weak new password) which were already 400.
- No portal client changes needed: `apps/portal/src/lib/api.ts`'s generic `!response.ok` path already surfaces `body.error`/`body.code` for any non-401 status, so the fix is purely server-side.

## Test plan

- [x] New suite `apps/api/src/routes/portal/profile.password.test.ts`: happy path still succeeds; wrong guess → 400 with the stable code (never 401); 6th guess in a window → 429 with `Retry-After`; a 429 never calls `verifyPassword` (doesn't leak correctness); throttling is per portal-user-id, not global.
- [x] `npx vitest run src/routes/portal/` — 15 files / 213 tests passed (no regressions).
- [x] `npx tsc --noEmit` on `apps/api` — clean.

Closes #4797

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBxF7C8E5GxFnNcGf6kBVP