### PR TITLE
fix(web): AI agents UI critique pass 3 — findings on lists, disable vocabulary, mobile runs, policy-key labels

### DIFF
--- a/apps/api/src/routes/aiAgents.test.ts
+++ b/apps/api/src/routes/aiAgents.test.ts
@@ -10,6 +10,7 @@ import {
   AI_AGENT_IMPACT_REBUILD_MAX_ORGS,
   AI_AGENT_LIMIT_DEFAULTS,
   AI_AGENT_RUN_LEAK_TRIPWIRE_KEYS,
+  AI_AGENT_RUN_SUMMARY_EXCERPT_MAX_CHARS,
   DEFAULT_IMPACT_WEIGHTS,
   type AiAgentImpactDto,
 } from '@breeze/shared';
@@ -850,6 +851,9 @@ const runDetailResponseSchema = z.object({
     status: z.string(),
     summary: z.string().nullable(),
     runVerdict: z.string().nullable(),
+    // The server's own answer to the count the detail page derives itself —
+    // carried here so the list and the detail cannot drift.
+    findingsToReview: z.number(),
     turnCount: z.number(),
     costCents: z.number(),
     errorCode: z.string().nullable(),
@@ -991,6 +995,13 @@ const runListResponseSchema = z.object({
     // schedule-triggered SWEEP is not distinguishable from `triggerKind`.
     profile: z.enum(['full', 'verdict', 'sweep']),
     runVerdict: z.string().nullable(),
+    // The verdict-understates-the-run override the DETAIL page already
+    // renders, now answerable by the list too. Counted in Postgres from the
+    // outcome column, which itself never reaches this wire shape — a
+    // regression that started shipping the blob to feed the count would fail
+    // `.strict()` here.
+    findingsToReview: z.number(),
+    summaryExcerpt: z.string().nullable(),
     queuedAt: z.string(),
     finishedAt: z.string().nullable(),
     costCents: z.number(),
@@ -1093,6 +1104,11 @@ describe('GET /ai-agents/runs/:runId (execution-trace detail, #3828)', () => {
     expect(parsed.data.trace).toHaveLength(3);
     expect(parsed.data.ledger).toHaveLength(1);
     expect(parsed.data.intents).toHaveLength(1);
+    // The detail DTO now carries the server's OWN findings count, from the
+    // same helper the list routes use. This fixture's outcome has one
+    // proposed action, one executed and one denied — only the proposed one
+    // is a finding to review, so the list and the detail agree on 1.
+    expect(parsed.data.findingsToReview).toBe(1);
 
     // The leak tripwire: the raw tool input the model proposed
     // (`{ scriptId: 'abc', secretParam: 'do-not-leak-me' }`) must never reach
@@ -1759,6 +1775,98 @@ describe('GET /ai-agents/runs (org-wide keyset list, #3828)', () => {
     expect(body.data[0]).not.toHaveProperty('trace');
     expect(body.data[0]).not.toHaveProperty('outcome');
     expect(body.data[0]).not.toHaveProperty('ledger');
+  });
+
+  // UI critique follow-up: `runVerdict` alone understates a run — a sweep
+  // that found problems and was allowed to execute none of them still rolls
+  // up `no_action`. The DETAIL page already overrides its verdict badge with
+  // "N findings to review"; these two fields are what let the LIST do the
+  // same. Both are derived by the shared helper (runFindings.ts), whose own
+  // suite pins the rule (denied entries excluded) and the SQL that counts it.
+  describe('findingsToReview + summaryExcerpt (verdict-understates-the-run)', () => {
+    const listRow = (overrides: Record<string, unknown> = {}) => ({
+      id: RUN_ID, agentId: AGENT_ID, agentName: 'Sweeper', orgId: ORG_ID, orgName: 'Acme Corp',
+      deviceId: null,
+      status: 'completed', triggerKind: 'schedule', profile: 'sweep', runVerdict: 'no_action',
+      // What `findingsToReviewSql` computes IN POSTGRES for this row.
+      findingsToReview: 6,
+      summary: 'Six hosts are low on disk. Details follow.',
+      queuedAt: new Date('2026-09-02T10:00:00.000Z'),
+      queuedAtRaw: '2026-09-02T10:00:00.000000Z',
+      finishedAt: new Date('2026-09-02T10:00:30.000Z'),
+      costCents: 3,
+      ...overrides,
+    });
+
+    it('carries the Postgres-computed findings count beside a no_action verdict', async () => {
+      selectMock.mockReturnValueOnce(selectChain([listRow()]));
+
+      const res = await buildApp().request('/ai-agents/runs');
+      expect(res.status).toBe(200);
+      const parsed = runListResponseSchema.parse(await res.json());
+      expect(parsed.data[0]).toMatchObject({ runVerdict: 'no_action', findingsToReview: 6 });
+    });
+
+    it('counts the outcome inside Postgres — the SQL names both counted json paths and neither excluded one', async () => {
+      let projection: Record<string, unknown> | undefined;
+      selectMock.mockImplementationOnce((cols: Record<string, unknown>) => {
+        projection = cols;
+        return selectChain([listRow()]);
+      });
+
+      await buildApp().request('/ai-agents/runs');
+
+      // The count must be a SQL expression, not a selected `outcome` column:
+      // a list route shipping up to 50 model-authored findings per row to
+      // count them in JS is exactly what this projection exists to prevent.
+      expect(projection).toBeDefined();
+      expect(projection).not.toHaveProperty('outcome');
+      const compiled = dialect.sqlToQuery(
+        (projection as Record<string, SQL>).findingsToReview!,
+      ).sql;
+      expect(compiled).toContain("->'sweepFindings'->'findings'");
+      expect(compiled).toContain("->'proposedActions'");
+      expect(compiled).not.toContain('deniedActions');
+    });
+
+    it('excerpts the first sentence of the summary with markdown emphasis stripped', async () => {
+      selectMock.mockReturnValueOnce(selectChain([
+        listRow({ summary: '**Six** hosts are low on disk. Details follow.' }),
+      ]));
+
+      const res = await buildApp().request('/ai-agents/runs');
+      const parsed = runListResponseSchema.parse(await res.json());
+      expect(parsed.data[0]!.summaryExcerpt).toBe('Six hosts are low on disk.');
+    });
+
+    it('truncates a long first sentence to the shared cap with an ellipsis', async () => {
+      selectMock.mockReturnValueOnce(selectChain([
+        listRow({ summary: `${'headroom '.repeat(40)}gone.` }),
+      ]));
+
+      const res = await buildApp().request('/ai-agents/runs');
+      const parsed = runListResponseSchema.parse(await res.json());
+      const excerpt = parsed.data[0]!.summaryExcerpt as string;
+      expect(excerpt.length).toBeLessThanOrEqual(AI_AGENT_RUN_SUMMARY_EXCERPT_MAX_CHARS);
+      expect(excerpt).toMatch(/…$/);
+    });
+
+    it('reports a null excerpt for a run with no summary yet', async () => {
+      selectMock.mockReturnValueOnce(selectChain([listRow({ summary: null })]));
+
+      const res = await buildApp().request('/ai-agents/runs');
+      const parsed = runListResponseSchema.parse(await res.json());
+      expect(parsed.data[0]!.summaryExcerpt).toBeNull();
+    });
+
+    it('never puts the full summary on the list item — only the excerpt', async () => {
+      selectMock.mockReturnValueOnce(selectChain([listRow()]));
+
+      const res = await buildApp().request('/ai-agents/runs');
+      const body = await res.json();
+      expect(body.data[0]).not.toHaveProperty('summary');
+      expect(body.data[0].summaryExcerpt).toBe('Six hosts are low on disk.');
+    });
   });
 });
 
@@ -3069,7 +3177,10 @@ describe('GET /ai-agents', () => {
 
   it('projects the latest run per agent from ONE batched query', async () => {
     selectDistinctOnMock.mockReturnValueOnce(distinctChain([
-      { agentId: AGENT_ID, status: 'failed', queuedAt: new Date('2026-08-30T12:00:00.000Z') },
+      {
+        agentId: AGENT_ID, status: 'failed', findingsToReview: 0,
+        queuedAt: new Date('2026-08-30T12:00:00.000Z'),
+      },
     ]));
 
     const res = await buildApp().request('/ai-agents');
@@ -3092,6 +3203,64 @@ describe('GET /ai-agents', () => {
     const body = await res.json();
     expect(body.data[0].lastRunAt).toBeNull();
     expect(body.data[0].lastRunStatus).toBeNull();
+    expect(body.data[0].lastRunFindingsToReview).toBeNull();
+  });
+
+  // `lastRunStatus` alone understates the agent the same way `runVerdict`
+  // understates a run: a sweep that found six problems and could execute none
+  // of them reports `completed`. Counted on the SAME DISTINCT ON row — never
+  // a second query — by the same helper the runs list and run detail use.
+  it('projects lastRunFindingsToReview from the same DISTINCT ON row', async () => {
+    selectDistinctOnMock.mockReturnValueOnce(distinctChain([
+      {
+        agentId: AGENT_ID, status: 'completed', findingsToReview: 6,
+        queuedAt: new Date('2026-09-02T12:00:00.000Z'),
+      },
+    ]));
+
+    const res = await buildApp().request('/ai-agents');
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data[0]).toMatchObject({
+      lastRunStatus: 'completed',
+      lastRunFindingsToReview: 6,
+    });
+    expect(selectDistinctOnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports 0 — not null — for a last run that left nothing to review', async () => {
+    selectDistinctOnMock.mockReturnValueOnce(distinctChain([
+      {
+        agentId: AGENT_ID, status: 'completed', findingsToReview: 0,
+        queuedAt: new Date('2026-09-02T12:00:00.000Z'),
+      },
+    ]));
+
+    const res = await buildApp().request('/ai-agents');
+
+    const body = await res.json();
+    // 0 and null mean different things here: "ran, nothing to review" vs
+    // "no visible run at all".
+    expect(body.data[0].lastRunFindingsToReview).toBe(0);
+  });
+
+  it('counts the last run inside Postgres — never by selecting the outcome column', async () => {
+    let projection: Record<string, unknown> | undefined;
+    selectDistinctOnMock.mockImplementationOnce((_on: unknown, cols: Record<string, unknown>) => {
+      projection = cols;
+      return distinctChain([]);
+    });
+
+    const res = await buildApp().request('/ai-agents');
+
+    expect(res.status).toBe(200);
+    expect(projection).toBeDefined();
+    expect(projection).not.toHaveProperty('outcome');
+    const compiled = dialect.sqlToQuery((projection as Record<string, SQL>).findingsToReview!).sql;
+    expect(compiled).toContain("->'sweepFindings'->'findings'");
+    expect(compiled).toContain("->'proposedActions'");
+    expect(compiled).not.toContain('deniedActions');
   });
 
   it('never touches ai_agent_runs when the caller owns no agents', async () => {

--- a/apps/api/src/routes/aiAgents.ts
+++ b/apps/api/src/routes/aiAgents.ts
@@ -63,6 +63,7 @@ import { computeExposureBudget } from '../services/actionIntents/exposureBudget'
 import { createAndEnqueueAgentRun } from '../services/aiAgents/runService';
 import { InvalidAgentRecipientsError } from '../services/aiAgents/recipients';
 import { SUPPORTED_AGENT_MODES } from '../services/aiAgents/constants';
+import { findingsToReviewSql, summaryExcerpt } from '../services/aiAgents/runFindings';
 import { buildRunTrace } from '../services/aiAgents/runTrace';
 import { recordVerdictFeedback } from '../services/aiAgents/alertVerdicts';
 import { sweepFindingDeviceIds } from '../services/aiAgents/sweepFindings';
@@ -155,6 +156,7 @@ function mapRow(row: AiAgentRow): AiAgentDto {
     // what the type promises rather than a silently missing field.
     lastRunAt: null,
     lastRunStatus: null,
+    lastRunFindingsToReview: null,
   };
 }
 
@@ -272,12 +274,20 @@ export function mapError(c: Context, err: unknown) {
 async function loadLastRuns(
   auth: AuthContextForRuns,
   agentIds: string[],
-): Promise<Map<string, { lastRunAt: string; lastRunStatus: AiAgentRunStatus }>> {
+): Promise<Map<string, LastRunProjection>> {
   if (agentIds.length === 0) return new Map();
   const rows = await db
     .selectDistinctOn([aiAgentRuns.agentId], {
       agentId: aiAgentRuns.agentId,
       status: aiAgentRuns.status,
+      // `lastRunStatus` alone understates the agent the same way `runVerdict`
+      // understates a run: a sweep that found six problems and was allowed to
+      // execute none of them reports `completed`, and the settings list read
+      // as a healthy agent sitting on unread findings. Counted inside
+      // Postgres on the SAME DISTINCT ON row — no extra query, and the
+      // outcome blob still never leaves the database on a list path. Same
+      // rule as the runs list and the run detail (runFindings.ts).
+      findingsToReview: findingsToReviewSql(aiAgentRuns.outcome),
       queuedAt: aiAgentRuns.queuedAt,
     })
     .from(aiAgentRuns)
@@ -286,10 +296,27 @@ async function loadLastRuns(
   return new Map(
     rows.map((row) => [
       row.agentId,
-      { lastRunAt: row.queuedAt.toISOString(), lastRunStatus: row.status },
+      {
+        lastRunAt: row.queuedAt.toISOString(),
+        lastRunStatus: row.status,
+        // `?? 0` for the same reason as `mapRunListItem`'s: a last run that
+        // left nothing to review is 0. `null` on the DTO is reserved for
+        // "this agent has no visible last run at all", which is decided by
+        // the absence of a map entry, not by this value.
+        lastRunFindingsToReview: row.findingsToReview ?? 0,
+      },
     ]),
   );
 }
+
+/** What `loadLastRuns` projects per agent — the three `lastRun*` fields
+ *  `AiAgentDto` declares, kept together so the list mapper cannot answer one
+ *  of them and forget another. */
+type LastRunProjection = {
+  lastRunAt: string;
+  lastRunStatus: AiAgentRunStatus;
+  lastRunFindingsToReview: number;
+};
 
 /** Only the piece of the auth context `loadLastRuns` needs. */
 type AuthContextForRuns = { orgCondition: (column: typeof aiAgentRuns.orgId) => SQL | undefined };
@@ -317,6 +344,7 @@ aiAgentsRoutes.get(
           ...mapRow(row),
           lastRunAt: last?.lastRunAt ?? null,
           lastRunStatus: last?.lastRunStatus ?? null,
+          lastRunFindingsToReview: last?.lastRunFindingsToReview ?? null,
         };
       }),
     });
@@ -865,6 +893,10 @@ function mapRunListItem(row: {
   triggerKind: AiAgentRunListItemDto['triggerKind'];
   profile: AiAgentRunListItemDto['profile'];
   runVerdict: string | null;
+  // Counted BY POSTGRES (`findingsToReviewSql`), not derived from an outcome
+  // payload this projection deliberately never receives — see below.
+  findingsToReview: number | null;
+  summary: string | null;
   queuedAt: Date;
   finishedAt: Date | null;
   costCents: number;
@@ -883,6 +915,17 @@ function mapRunListItem(row: {
     // this; `triggerKind: 'schedule'` alone cannot identify a sweep.
     profile: row.profile,
     runVerdict: (row.runVerdict as AgentRunVerdict | null) ?? null,
+    // `?? 0`, not `!`: the count is a SQL expression, and the DTO promises a
+    // number. A run with nothing to review is 0 — the honest answer — and a
+    // null here would make "nothing to review" indistinguishable from "not
+    // computed" for a client that only has to render a badge.
+    findingsToReview: row.findingsToReview ?? 0,
+    // Derived here rather than in SQL so the list and any future consumer of
+    // the same rule share ONE implementation (runFindings.ts). `summary` is
+    // already display-safe narrative text (never a tool payload) — unlike the
+    // outcome column, which is why THAT one is still counted in Postgres and
+    // never selected.
+    summaryExcerpt: summaryExcerpt(row.summary),
     queuedAt: row.queuedAt.toISOString(),
     finishedAt: row.finishedAt ? row.finishedAt.toISOString() : null,
     costCents: row.costCents,
@@ -957,6 +1000,18 @@ aiAgentsRoutes.get(
         // no business leaving Postgres for a row that isn't the one the
         // caller asked to see in detail.
         runVerdict: sql<string | null>`${aiAgentRuns.outcome}->>'runVerdict'`,
+        // Same posture, one step further: `runVerdict` alone UNDERSTATES the
+        // run (a sweep that found six problems and was allowed to execute
+        // none of them still rolls up `no_action`), so the list needs the
+        // findings count too — but the counting happens INSIDE Postgres,
+        // which returns two bounded integers per row instead of up to 50
+        // model-authored findings. Same rule the detail route counts with;
+        // see services/aiAgents/runFindings.ts.
+        findingsToReview: findingsToReviewSql(aiAgentRuns.outcome),
+        // The typed narrative column — display-safe (never a tool payload),
+        // unlike `outcome`. `mapRunListItem` reduces it to a first-sentence
+        // excerpt; the full text stays detail-only.
+        summary: aiAgentRuns.summary,
         queuedAt: aiAgentRuns.queuedAt,
         // Full microsecond-precision text of the same column, for the
         // cursor only — never put on the DTO. See runsListCursor.ts's
@@ -1474,6 +1529,12 @@ aiAgentsRoutes.get(
         triggerKind: aiAgentRuns.triggerKind,
         profile: aiAgentRuns.profile,
         runVerdict: sql<string | null>`${aiAgentRuns.outcome}->>'runVerdict'`,
+        // Shares `mapRunListItem` with the org-wide list above, so it shares
+        // its wire shape too — including the findings count and the summary
+        // excerpt. Counted in Postgres for the same reason: never select the
+        // outcome blob on a list route.
+        findingsToReview: findingsToReviewSql(aiAgentRuns.outcome),
+        summary: aiAgentRuns.summary,
         queuedAt: aiAgentRuns.queuedAt,
         finishedAt: aiAgentRuns.finishedAt,
         costCents: aiAgentRuns.costCents,

--- a/apps/api/src/services/aiAgents/runFindings.test.ts
+++ b/apps/api/src/services/aiAgents/runFindings.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, it } from 'vitest';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { AI_AGENT_RUN_SUMMARY_EXCERPT_MAX_CHARS } from '@breeze/shared';
+import { aiAgentRuns } from '../../db/schema';
+import {
+  FINDINGS_TO_REVIEW_OUTCOME_PATHS,
+  countFindingsToReview,
+  findingsToReviewSql,
+  summaryExcerpt,
+} from './runFindings';
+import { buildRunTrace, type RunTraceRunInput } from './runTrace';
+
+const RUN_ID = '11111111-1111-4111-8111-111111111111';
+const AGENT_ID = '22222222-2222-4222-8222-222222222222';
+const ORG_ID = '33333333-3333-4333-8333-333333333333';
+
+const dialect = new PgDialect();
+
+/**
+ * The fixture the parity test runs through BOTH derivations: two sweep
+ * findings, one proposed action, one denied action, one executed action.
+ * Expected count is 3 — denied and executed are not findings to review.
+ */
+const MIXED_OUTCOME: Record<string, unknown> = {
+  runVerdict: 'no_action',
+  sweepFindings: {
+    summary: 'Two hosts are missing disk headroom.',
+    findings: [
+      {
+        kind: 'disk_pressure', severity: 'warning', deviceId: null,
+        title: 'Low disk', detail: 'C: is at 94%', evidence: { freePercent: 6 },
+      },
+      {
+        kind: 'disk_pressure', severity: 'critical', deviceId: null,
+        title: 'Low disk', detail: 'C: is at 98%', evidence: { freePercent: 2 },
+      },
+    ],
+  },
+  proposedActions: [{ tool: 'manage_devices', action: 'restart', args: { secret: 'nope' } }],
+  deniedActions: [{ tool: 'run_script', reason: 'not in allowlist' }],
+  executedActions: [{ tool: 'get_device', result: 'ok', durationMs: 12 }],
+};
+
+function baseRun(overrides: Partial<RunTraceRunInput> = {}): RunTraceRunInput {
+  return {
+    id: RUN_ID,
+    agentId: AGENT_ID,
+    orgId: ORG_ID,
+    deviceId: null,
+    alertId: null,
+    anomalyIncidentId: null,
+    triggerKind: 'schedule',
+    modeAtStart: 'shadow',
+    status: 'completed',
+    summary: null,
+    scheduleId: null,
+    triggerRef: {},
+    reportRunId: null,
+    outcome: {},
+    intentIds: [],
+    turnCount: 2,
+    costCents: 4,
+    errorCode: null,
+    queuedAt: new Date('2026-09-02T10:00:00.000Z'),
+    startedAt: new Date('2026-09-02T10:00:01.000Z'),
+    finishedAt: new Date('2026-09-02T10:00:30.000Z'),
+    ...overrides,
+  };
+}
+
+/**
+ * Exactly what `RunDetailPage.tsx` computes from the DETAIL DTO today (search
+ * `findingsToReview` there). The parity test below asserts the server-side
+ * helper agrees with it — if the two ever diverge, the run list and the run
+ * detail page would badge the same run with different numbers, which is the
+ * whole reason this helper exists.
+ */
+function webRuleOverDetailDto(detail: ReturnType<typeof buildRunTrace>): number {
+  return (detail.sweep?.findings.length ?? 0)
+    + detail.trace.filter((entry) => entry.kind === 'proposed').length;
+}
+
+describe('countFindingsToReview', () => {
+  it('counts sweep findings plus proposed trace entries and excludes denied ones', () => {
+    expect(countFindingsToReview(MIXED_OUTCOME)).toBe(3);
+  });
+
+  it('is unchanged when denied actions are added', () => {
+    const withMoreDenials = {
+      ...MIXED_OUTCOME,
+      deniedActions: [
+        { tool: 'run_script', reason: 'not in allowlist' },
+        { tool: 'manage_users', reason: 'read-only profile' },
+        { tool: 'delete_device', reason: 'read-only profile' },
+      ],
+    };
+    expect(countFindingsToReview(withMoreDenials)).toBe(countFindingsToReview(MIXED_OUTCOME));
+  });
+
+  it('is unchanged when executed actions are added', () => {
+    const withMoreExecuted = {
+      ...MIXED_OUTCOME,
+      executedActions: [
+        { tool: 'get_device', result: 'ok', durationMs: 12 },
+        { tool: 'list_alerts', result: 'ok', durationMs: 30 },
+      ],
+    };
+    expect(countFindingsToReview(withMoreExecuted)).toBe(countFindingsToReview(MIXED_OUTCOME));
+  });
+
+  it('returns 0 for an empty outcome', () => {
+    expect(countFindingsToReview({})).toBe(0);
+  });
+
+  it('returns 0 for a null/undefined outcome rather than throwing', () => {
+    expect(countFindingsToReview(null)).toBe(0);
+    expect(countFindingsToReview(undefined)).toBe(0);
+  });
+
+  // `outcome` is a jsonb column with no compile-time shape; a maximally
+  // corrupt row must project a number, never throw inside a read route.
+  it('tolerates a corrupt outcome whose counted keys are the wrong type', () => {
+    expect(countFindingsToReview({
+      sweepFindings: { findings: 'not-an-array' },
+      proposedActions: { nope: true },
+    })).toBe(0);
+    expect(countFindingsToReview({ sweepFindings: 7, proposedActions: null })).toBe(0);
+  });
+
+  // Mirrors `projectSweep`, which returns null (hence 0 findings) when the
+  // outcome carries no `sweepFindings` object at all.
+  it('counts only proposed entries for a non-sweep run', () => {
+    expect(countFindingsToReview({
+      proposedActions: [{ tool: 'a' }, { tool: 'b' }],
+      deniedActions: [{ tool: 'c', reason: 'x' }],
+    })).toBe(2);
+  });
+});
+
+describe('findingsToReviewSql — the list/agent-list derivation', () => {
+  const compiled = () => dialect.sqlToQuery(findingsToReviewSql(aiAgentRuns.outcome)).sql;
+
+  it('emits one array-length term per counted outcome path', () => {
+    const sql = compiled();
+    expect(sql.match(/jsonb_array_length/g)).toHaveLength(FINDINGS_TO_REVIEW_OUTCOME_PATHS.length);
+    expect(sql.match(/jsonb_typeof/g)).toHaveLength(FINDINGS_TO_REVIEW_OUTCOME_PATHS.length);
+  });
+
+  it('names exactly the counted json keys', () => {
+    const sql = compiled();
+    expect(sql).toContain("->'sweepFindings'->'findings'");
+    expect(sql).toContain("->'proposedActions'");
+  });
+
+  // The SQL is the LIST side of the same rule `countFindingsToReview` applies
+  // on the detail side. A denied/executed term appearing here would inflate
+  // the list badge relative to the detail page.
+  it('never counts denied or executed actions', () => {
+    const sql = compiled();
+    expect(sql).not.toContain('deniedActions');
+    expect(sql).not.toContain('executedActions');
+  });
+
+  it('binds no parameters — the counted keys are module constants, never caller input', () => {
+    expect(dialect.sqlToQuery(findingsToReviewSql(aiAgentRuns.outcome)).params).toEqual([]);
+  });
+});
+
+describe('findingsToReview parity — list rule vs detail DTO', () => {
+  it('agrees with what the run-detail page derives from the detail DTO', () => {
+    const detail = buildRunTrace(
+      baseRun({ outcome: MIXED_OUTCOME }),
+      { name: 'Sweeper', kind: 'triage' },
+      null,
+      [],
+      [],
+    );
+
+    // Control: the fixture really does exercise all three trace kinds plus
+    // sweep findings, so an agreement below is not vacuous.
+    expect(detail.sweep?.findings).toHaveLength(2);
+    expect(detail.trace.filter((e) => e.kind === 'proposed')).toHaveLength(1);
+    expect(detail.trace.filter((e) => e.kind === 'denied')).toHaveLength(1);
+
+    expect(webRuleOverDetailDto(detail)).toBe(3);
+    expect(countFindingsToReview(MIXED_OUTCOME)).toBe(webRuleOverDetailDto(detail));
+    expect(detail.findingsToReview).toBe(webRuleOverDetailDto(detail));
+  });
+
+  it('agrees on a run with no findings at all', () => {
+    const detail = buildRunTrace(baseRun(), { name: 'Sweeper', kind: 'triage' }, null, [], []);
+    expect(detail.findingsToReview).toBe(0);
+    expect(countFindingsToReview({})).toBe(webRuleOverDetailDto(detail));
+  });
+});
+
+describe('summaryExcerpt', () => {
+  it('never leaves a lone surrogate before the ellipsis when the cut lands inside an emoji', () => {
+    const head = 'a'.repeat(158);
+    const out = summaryExcerpt(`${head}🎉 and then a long tail that will be cut off`);
+    expect(out).not.toBeNull();
+    expect(out!.length).toBeLessThanOrEqual(160);
+    expect(out!.endsWith('…')).toBe(true);
+    expect(/[\uD800-\uDBFF]…$/.test(out!)).toBe(false);
+  });
+
+  it('returns null for a null or undefined summary', () => {
+    expect(summaryExcerpt(null)).toBeNull();
+    expect(summaryExcerpt(undefined)).toBeNull();
+  });
+
+  it('returns null for a whitespace-only summary', () => {
+    expect(summaryExcerpt('   \n\t  ')).toBeNull();
+  });
+
+  it('takes the first sentence only, keeping its terminator', () => {
+    expect(summaryExcerpt('Restarted the print spooler. It came back healthy.'))
+      .toBe('Restarted the print spooler.');
+    expect(summaryExcerpt('Did the disk fill up? Yes, twice.')).toBe('Did the disk fill up?');
+  });
+
+  it('returns the whole (normalized) text when there is no sentence terminator', () => {
+    expect(summaryExcerpt('no terminator here')).toBe('no terminator here');
+  });
+
+  it('strips markdown emphasis', () => {
+    expect(summaryExcerpt('**x**')).toBe('x');
+    expect(summaryExcerpt('Restarted **spooler** and _verified_ it.'))
+      .toBe('Restarted spooler and verified it.');
+    expect(summaryExcerpt('Ran `Restart-Service` on the host.')).toBe('Ran Restart-Service on the host.');
+    expect(summaryExcerpt('~~Ignored~~ the alert.')).toBe('Ignored the alert.');
+    expect(summaryExcerpt('__Bold__ opener.')).toBe('Bold opener.');
+  });
+
+  it('does not eat an underscore inside a word', () => {
+    expect(summaryExcerpt('The disk_free_percent metric dropped.'))
+      .toBe('The disk_free_percent metric dropped.');
+  });
+
+  it('strips leading block markers and collapses whitespace', () => {
+    expect(summaryExcerpt('## Summary\nDisk is full.')).toBe('Summary Disk is full.');
+    expect(summaryExcerpt('- Disk is full.')).toBe('Disk is full.');
+    expect(summaryExcerpt('> Disk is full.')).toBe('Disk is full.');
+  });
+
+  it('keeps link text and drops the url', () => {
+    expect(summaryExcerpt('See [the report](https://example.com/r/1) for detail.'))
+      .toBe('See the report for detail.');
+  });
+
+  it('does not break a sentence on a common abbreviation', () => {
+    expect(summaryExcerpt('Several hosts, e.g. WKS-042, are low on disk. Next sentence.'))
+      .toBe('Several hosts, e.g. WKS-042, are low on disk.');
+  });
+
+  it('truncates to the cap with an ellipsis', () => {
+    const long = `${'word '.repeat(60)}end.`;
+    const excerpt = summaryExcerpt(long);
+    expect(excerpt).not.toBeNull();
+    expect((excerpt as string).length).toBeLessThanOrEqual(AI_AGENT_RUN_SUMMARY_EXCERPT_MAX_CHARS);
+    expect(excerpt as string).toMatch(/…$/);
+    // Truncation must not leave a dangling half-word.
+    expect(excerpt as string).not.toMatch(/wor…$/);
+  });
+
+  it('does not add an ellipsis when the first sentence already fits', () => {
+    expect(summaryExcerpt('Short and sweet.')).toBe('Short and sweet.');
+  });
+
+  it('truncates a single unbroken token rather than returning it whole', () => {
+    const excerpt = summaryExcerpt('x'.repeat(400));
+    expect((excerpt as string).length).toBe(AI_AGENT_RUN_SUMMARY_EXCERPT_MAX_CHARS);
+    expect(excerpt as string).toMatch(/…$/);
+  });
+});

--- a/apps/api/src/services/aiAgents/runFindings.ts
+++ b/apps/api/src/services/aiAgents/runFindings.ts
@@ -1,0 +1,212 @@
+// apps/api/src/services/aiAgents/runFindings.ts
+/**
+ * "How much did this run leave for a human?" — the ONE definition of
+ * `findingsToReview`, plus the run-summary excerpt the list surfaces render
+ * beside it.
+ *
+ * WHY THIS FILE EXISTS. `runVerdict` understates a run: `no_action` is
+ * computed from the run's own remediation outcome, so a sweep that found six
+ * problems and was permitted to execute none of them still rolls up as "no
+ * action". The run DETAIL page (apps/web/.../RunDetailPage.tsx) already
+ * overrides the verdict badge with "N findings to review" — but it derives N
+ * itself, from the detail DTO. The run LIST and the agents list have no
+ * outcome payload at all (deliberately: see `mapRunListItem`), so they could
+ * not, and rendered "No action" over unread findings.
+ *
+ * Putting the rule here — and using it on BOTH sides — is what stops the two
+ * surfaces from badging the same run with different numbers.
+ *
+ * THE RULE: sweep findings + PROPOSED tool calls. A `denied` action is not a
+ * finding: for a read-only profile it is the guardrail working as intended
+ * (`runLoop.ts`'s `enforceReadOnlyProfile` logs one for every mutating tool
+ * the model merely attempted), so counting it would inflate the badge with
+ * denials nobody needs to act on. An `executed` action is not a finding
+ * either — it already happened.
+ *
+ * TWO REPRESENTATIONS, ONE SOURCE. The detail route has the run's whole
+ * `outcome` jsonb in memory and counts it in TypeScript
+ * (`countFindingsToReview`). The two LIST routes must NOT pull that column —
+ * `sweepFindingsOutcomeSchema` caps a run at 50 model-authored findings, so
+ * shipping the blob for 25 list rows would move megabytes to count integers,
+ * and the full outcome is exactly where this file's siblings' safe-projection
+ * risk lives. They therefore count in Postgres (`findingsToReviewSql`), which
+ * returns two bounded ints per row and no payload.
+ *
+ * Both representations are generated from `FINDINGS_TO_REVIEW_OUTCOME_PATHS`
+ * below, so the part most likely to drift — WHICH outcome arrays count — has
+ * a single definition. `runFindings.test.ts` pins both ends: a parity test
+ * against the detail DTO's own numbers, and a compiled-SQL test asserting one
+ * array-length term per path and no denied/executed term.
+ */
+
+import { sql, type SQL } from 'drizzle-orm';
+import type { AnyColumn } from 'drizzle-orm';
+import { AI_AGENT_RUN_SUMMARY_EXCERPT_MAX_CHARS } from '@breeze/shared';
+
+/**
+ * The `ai_agent_runs.outcome` json paths whose ARRAY LENGTHS make up
+ * `findingsToReview`, innermost key last.
+ *
+ * `sweepFindings.findings` mirrors `projectSweep` (sweepFindings.ts), which
+ * returns `null` — hence zero findings on the detail DTO — when the outcome
+ * carries no `sweepFindings` object at all, and treats a non-array `findings`
+ * as empty. `proposedActions` is 1:1 with the detail DTO's `proposed` trace
+ * entries (`buildTraceEntries` maps every element, filtering none).
+ *
+ * `deniedActions` and `executedActions` are absent ON PURPOSE — see the file
+ * header. Adding a path here changes BOTH the list SQL and the detail count
+ * in one edit, which is the point.
+ */
+export const FINDINGS_TO_REVIEW_OUTCOME_PATHS: readonly (readonly string[])[] = [
+  ['sweepFindings', 'findings'],
+  ['proposedActions'],
+] as const;
+
+/** Guards the `sql.raw` splice below — every key is a module constant, and
+ *  this asserts none can ever become something that needs quoting. */
+const JSON_KEY_PATTERN = /^[A-Za-z][A-Za-z0-9]*$/;
+
+/**
+ * Detail-side derivation: count the configured arrays on an already-loaded
+ * `ai_agent_runs.outcome` object.
+ *
+ * Defensive by design — `outcome` is a jsonb column with no compile-time
+ * shape, and a maximally-corrupt row (a `findings` that is a string, a
+ * `sweepFindings` that is a number) must project a number rather than throw
+ * inside a read route. Anything that is not an array contributes 0, which is
+ * exactly what `projectSweep`/`buildTraceEntries` already do on the same
+ * data.
+ */
+export function countFindingsToReview(outcome: Record<string, unknown> | null | undefined): number {
+  if (!outcome || typeof outcome !== 'object') return 0;
+  let total = 0;
+  for (const path of FINDINGS_TO_REVIEW_OUTCOME_PATHS) {
+    let node: unknown = outcome;
+    for (const key of path) {
+      node = node && typeof node === 'object' ? (node as Record<string, unknown>)[key] : undefined;
+    }
+    if (Array.isArray(node)) total += node.length;
+  }
+  return total;
+}
+
+/**
+ * List-side derivation: the same rule as a scalar SQL expression over an
+ * `ai_agent_runs.outcome` jsonb column, for callers that must not select the
+ * column itself (`GET /ai/agents/runs`, and `loadLastRuns`'s `DISTINCT ON`
+ * probe behind `GET /ai/agents`).
+ *
+ * Each path becomes `case when jsonb_typeof(<path>) = 'array' then
+ * jsonb_array_length(<path>) else 0 end` — the SQL spelling of
+ * `Array.isArray(x) ? x.length : 0`, so a missing key, a null, or a corrupt
+ * non-array value contributes 0 exactly as it does above instead of raising
+ * `cannot get array length of a non-array`.
+ *
+ * The json keys are spliced with `sql.raw` (pattern-asserted module
+ * constants, never caller input) rather than bound as parameters: `jsonb ->
+ * $1` with an untyped parameter is ambiguous between the `-> integer` and
+ * `-> text` operators, and this matches how `GET /runs` already reads
+ * `outcome->>'runVerdict'` inline.
+ */
+export function findingsToReviewSql(outcomeColumn: AnyColumn | SQL): SQL<number> {
+  const terms = FINDINGS_TO_REVIEW_OUTCOME_PATHS.map((path) => {
+    const accessors = path.map((key) => {
+      if (!JSON_KEY_PATTERN.test(key)) {
+        throw new Error(`findingsToReviewSql: unsafe json key ${JSON.stringify(key)}`);
+      }
+      return `->'${key}'`;
+    }).join('');
+    const ref = sql`${outcomeColumn}${sql.raw(accessors)}`;
+    return sql`(case when jsonb_typeof(${ref}) = 'array' then jsonb_array_length(${ref}) else 0 end)`;
+  });
+  return sql<number>`(${sql.join(terms, sql` + `)})`;
+}
+
+/**
+ * Markdown constructs stripped before the first sentence is picked. Applied
+ * in this order so a stripped construct cannot leave a stray marker behind
+ * (`**Done.**` must not excerpt as `**Done.`).
+ *
+ * Emphasis markers only — plus inline code, strikethrough, and link syntax:
+ * a raw `](https://…)` inside a 160-character list cell is worse than no
+ * excerpt at all, so the link TEXT survives and the url does not. Nothing
+ * here is a security control; `summary` is already display-safe narrative
+ * text (never a tool payload — see `AiAgentRunDetailDto.summary`), this is a
+ * legibility pass.
+ */
+function stripMarkdown(text: string): string {
+  return text
+    // Block markers, per line: heading, blockquote, unordered bullet.
+    .replace(/^[ \t]{0,3}#{1,6}[ \t]+/gm, '')
+    .replace(/^[ \t]*>[ \t]?/gm, '')
+    .replace(/^[ \t]*[-*+][ \t]+/gm, '')
+    // [text](url) -> text
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/~~(.+?)~~/g, '$1')
+    .replace(/\*\*(.+?)\*\*/g, '$1')
+    .replace(/__(.+?)__/g, '$1')
+    .replace(/\*(.+?)\*/g, '$1')
+    // Underscore emphasis only when the markers are NOT inside a word —
+    // `disk_free_percent` is an identifier, not italics.
+    .replace(/(^|[^\w])_(.+?)_(?![\w])/g, '$1$2')
+    .replace(/`+/g, '');
+}
+
+/**
+ * Tokens whose trailing `.` is not a sentence end. Not exhaustive and not
+ * meant to be — it covers what actually shows up in run summaries so an
+ * excerpt does not read "Several hosts, e.g." and stop.
+ */
+const NON_TERMINAL_ABBREVIATIONS: ReadonlySet<string> = new Set([
+  'e.g.', 'i.e.', 'etc.', 'vs.', 'approx.', 'no.', 'incl.', 'est.',
+  'dr.', 'mr.', 'mrs.', 'ms.', 'st.', 'inc.', 'ltd.', 'fig.',
+]);
+
+/** First `.`/`!`/`?` followed by whitespace or end-of-text, skipping the
+ *  abbreviations above and single-letter initials. Whole text when none. */
+function firstSentence(text: string): string {
+  const terminator = /[.!?](?=\s|$)/g;
+  let match: RegExpExecArray | null = terminator.exec(text);
+  while (match !== null) {
+    const head = text.slice(0, match.index + 1);
+    const lastToken = (/(\S+)$/.exec(head)?.[1] ?? '').toLowerCase();
+    const isInitial = /(?:^|\s)[A-Za-z]\.$/.test(head);
+    if (!NON_TERMINAL_ABBREVIATIONS.has(lastToken) && !isInitial) return head;
+    match = terminator.exec(text);
+  }
+  return text;
+}
+
+/**
+ * Cap INCLUDING the ellipsis, so the returned string is never longer than
+ * `AI_AGENT_RUN_SUMMARY_EXCERPT_MAX_CHARS`. Breaks on a word boundary when
+ * one exists in the back half of the budget — otherwise (one unbroken token)
+ * it hard-cuts, which is still better than shipping 400 characters to a list
+ * cell.
+ */
+function truncateWithEllipsis(text: string, max: number): string {
+  if (text.length <= max) return text;
+  let head = text.slice(0, max - 1);
+  // `slice` counts UTF-16 code units, so a cut can land between the halves
+  // of a surrogate pair (any astral emoji) and leave a lone high surrogate
+  // that serialises as U+FFFD. Step back one unit when that happens.
+  if (/[\uD800-\uDBFF]$/.test(head)) head = head.slice(0, -1);
+  const lastSpace = head.lastIndexOf(' ');
+  const body = lastSpace > max / 2 ? head.slice(0, lastSpace) : head;
+  return `${body.trimEnd()}…`;
+}
+
+/**
+ * `AiAgentRunListItemDto.summaryExcerpt` — the first sentence of a run's
+ * `summary`, markdown stripped, whitespace collapsed, capped.
+ *
+ * `null` (not `''`) for a run with no summary yet, or one whose summary is
+ * whitespace-only: the list renders a placeholder for "nothing to say yet",
+ * and an empty string would be an ambiguous stand-in for that.
+ */
+export function summaryExcerpt(summary: string | null | undefined): string | null {
+  if (typeof summary !== 'string') return null;
+  const plain = stripMarkdown(summary).replace(/\s+/g, ' ').trim();
+  if (plain.length === 0) return null;
+  return truncateWithEllipsis(firstSentence(plain), AI_AGENT_RUN_SUMMARY_EXCERPT_MAX_CHARS);
+}

--- a/apps/api/src/services/aiAgents/runTrace.ts
+++ b/apps/api/src/services/aiAgents/runTrace.ts
@@ -25,6 +25,7 @@ import type {
 } from './runLoop';
 import { projectAlertVerdict } from './alertVerdicts';
 import { projectNarrative } from './narrativeReport';
+import { countFindingsToReview } from './runFindings';
 import { projectSweep } from './sweepFindings';
 import {
   AI_AGENT_RUN_DTO_SCHEMA_VERSION,
@@ -400,6 +401,13 @@ export function buildRunTrace(
     status: run.status,
     summary: run.summary,
     runVerdict: outcome.runVerdict ?? null,
+    // The SAME helper the runs list and the agents list use — not a second
+    // count derived from `trace`/`sweep` below. `runVerdict` alone understates
+    // a run (a sweep that found six problems and could execute none of them
+    // still rolls up `no_action`), and the detail page's own override was the
+    // only place that knew it; carrying the server's answer here is what lets
+    // the list surfaces say the same thing. See runFindings.ts.
+    findingsToReview: countFindingsToReview(run.outcome),
     turnCount: run.turnCount,
     costCents: run.costCents,
     errorCode: run.errorCode,

--- a/apps/web/src/components/aiAgents/ImpactPage.test.tsx
+++ b/apps/web/src/components/aiAgents/ImpactPage.test.tsx
@@ -520,6 +520,29 @@ describe('ImpactPage', () => {
     );
   });
 
+  it('renders the page title as an h1 via PageHeader', async () => {
+    mockImpact(dto());
+    render(<ImpactPage />);
+    await waitFor(() => expect(screen.getByTestId('ai-impact-tile-alerts-judged')).toBeInTheDocument());
+    expect(screen.getByRole('heading', { level: 1, name: 'AI impact' })).toBeInTheDocument();
+  });
+
+  it('labels the freshness line and places it beside the window switcher, not floating unlabelled', async () => {
+    mockImpact(dto());
+    render(<ImpactPage />);
+
+    await waitFor(() => expect(screen.getByTestId('ai-impact-freshness')).toBeInTheDocument());
+    expect(screen.getByText('Data freshness')).toBeInTheDocument();
+
+    // The freshness label+text and the window-switcher group share the same
+    // "view controls" wrapper (~gh #4187 review: the freshness line used to
+    // float, disconnected from anything explaining what it describes).
+    const viewControls = screen.getByTestId('ai-impact-view-controls');
+    expect(viewControls).toContainElement(screen.getByText('Data freshness'));
+    expect(viewControls).toContainElement(screen.getByTestId('ai-impact-freshness'));
+    expect(viewControls).toContainElement(screen.getByTestId('ai-impact-window-90'));
+  });
+
   it('hides the positive-feedback readout when the rate is null', async () => {
     mockImpact(dto());
     const view = render(<ImpactPage />);

--- a/apps/web/src/components/aiAgents/ImpactPage.tsx
+++ b/apps/web/src/components/aiAgents/ImpactPage.tsx
@@ -29,6 +29,7 @@ import { formatCurrency, formatNumber, formatPercent } from '@/lib/i18n/format';
 import { formatDateTime } from '@/lib/dateTimeFormat';
 import { exportReport } from '../reports/reportExport';
 import { EmptyState } from '../shared/EmptyState';
+import { PageHeader } from '../shared/PageHeader';
 import ImpactWeightsDrawer from './ImpactWeightsDrawer';
 import {
   AI_AGENT_IMPACT_BY_ORG_LIMIT,
@@ -541,130 +542,164 @@ export default function ImpactPage() {
 
   return (
     <div className="space-y-6" data-testid="ai-impact-page">
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-        <div>
-          <h1 className="flex items-center gap-2 text-xl font-semibold tracking-tight">
-            <TrendingUp className="h-5 w-5" />
-            {t('aiAgentsPage.impact.title')}
-          </h1>
-          <p className="text-muted-foreground">{t('aiAgentsPage.impact.description')}</p>
-        </div>
-
-        <div className="flex flex-wrap items-center gap-2">
-          <div
-            className="flex items-center gap-1 rounded-md border p-1"
-            role="group"
-            aria-label={t('aiAgentsPage.impact.windowLabel')}
-          >
-            {AI_AGENT_IMPACT_WINDOWS.map((value) => (
-              <button
-                key={value}
-                type="button"
-                data-testid={`ai-impact-window-${value}`}
-                aria-pressed={value === windowDays}
-                onClick={() => {
-                  setWindowDays(value);
-                  window.location.hash = String(value);
-                }}
-                className={`rounded px-3 py-1 text-sm ${
-                  value === windowDays
-                    ? 'bg-primary text-primary-foreground'
-                    : 'text-muted-foreground hover:bg-muted hover:text-foreground'
-                }`}
+      <PageHeader
+        testId="ai-impact-header"
+        icon={<TrendingUp className="h-5 w-5" />}
+        title={t('aiAgentsPage.impact.title')}
+        description={t('aiAgentsPage.impact.description')}
+        actions={
+          // Two grouped units — "view controls" (window switcher, freshness,
+          // refresh) and "actions" (export/edit weights or the overflow menu
+          // that collapses them) — so a width squeeze wraps them as whole
+          // blocks instead of splitting a single button off alone (the
+          // "orphaned Edit weights at 1440px" review finding: the export
+          // button is hidden whenever the window has no outcomes yet, which
+          // left Edit weights as the SOLE item in its old flex-wrap slot).
+          <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
+            <div
+              className="flex flex-wrap items-center gap-2"
+              data-testid="ai-impact-view-controls"
+            >
+              <div
+                className="flex items-center gap-1 rounded-md border p-1"
+                role="group"
+                aria-label={t('aiAgentsPage.impact.windowLabel')}
               >
-                {windowLabel(t, value)}
-              </button>
-            ))}
-          </div>
+                {AI_AGENT_IMPACT_WINDOWS.map((value) => (
+                  <button
+                    key={value}
+                    type="button"
+                    data-testid={`ai-impact-window-${value}`}
+                    aria-pressed={value === windowDays}
+                    onClick={() => {
+                      setWindowDays(value);
+                      window.location.hash = String(value);
+                    }}
+                    className={`rounded px-3 py-1 text-sm ${
+                      value === windowDays
+                        ? 'bg-primary text-primary-foreground'
+                        : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                    }`}
+                  >
+                    {windowLabel(t, value)}
+                  </button>
+                ))}
+              </div>
 
-          <button
-            type="button"
-            data-testid="ai-impact-refresh"
-            onClick={() => void handleRefresh()}
-            disabled={poll !== null}
-            aria-label={poll ? t('aiAgentsPage.impact.refreshing') : t('aiAgentsPage.impact.refresh')}
-            className="inline-flex h-9 w-9 items-center justify-center rounded-md border hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            <RefreshCw className={`h-4 w-4 ${poll ? 'animate-spin' : ''}`} />
-          </button>
+              {/* Freshness, labelled and kept next to the window switcher it
+                  describes — it used to float unlabelled, disconnected from
+                  the control that determines what "through" means. */}
+              {dto && (
+                <div
+                  className="flex flex-wrap items-baseline gap-x-1.5 gap-y-0.5 text-xs text-muted-foreground"
+                  data-testid="ai-impact-freshness-wrap"
+                >
+                  <span className="font-medium text-foreground">
+                    {t('aiAgentsPage.impact.freshnessLabel')}
+                  </span>
+                  <span data-testid="ai-impact-freshness">
+                    {dto.rebuiltAt
+                      ? t('aiAgentsPage.impact.freshness', {
+                          through: dto.through,
+                          rebuiltAt: formatDateTime(dto.rebuiltAt),
+                        })
+                      : t('aiAgentsPage.impact.freshnessNeverRebuilt', { through: dto.through })}
+                  </span>
+                </div>
+              )}
 
-          {/* Two secondary buttons at md+, collapsed into a single overflow
-              menu below md so the header never wraps to 2-3 rows. */}
-          <div className="hidden items-center gap-2 md:flex">
-            {/* Nothing to export on a window with zero outcomes — Edit weights
-                stays available even then, since there's still a methodology
-                to configure ahead of the first outcome. */}
-            {dto && hasAnyOutcome && (
-              <button
-                type="button"
-                data-testid="ai-impact-export-pdf"
-                onClick={() => void handleExportPdf()}
-                className="inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm hover:bg-muted"
-              >
-                <Download className="h-4 w-4" />
-                {t('aiAgentsPage.impact.exportPdf')}
-              </button>
-            )}
-
-            {/* The server 403s a caller without canManagePartnerWidePolicies —
-                hiding the button for that case is a UX convenience, not the
-                real gate. */}
-            {dto?.canEditWeights && (
               <button
                 type="button"
-                data-testid="ai-impact-edit-weights"
-                onClick={() => setWeightsDrawerOpen(true)}
-                className="inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm hover:bg-muted"
+                data-testid="ai-impact-refresh"
+                onClick={() => void handleRefresh()}
+                disabled={poll !== null}
+                aria-label={poll ? t('aiAgentsPage.impact.refreshing') : t('aiAgentsPage.impact.refresh')}
+                className="inline-flex h-9 w-9 items-center justify-center rounded-md border hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
               >
-                <Settings2 className="h-4 w-4" />
-                {t('aiAgentsPage.impact.editWeights')}
+                <RefreshCw className={`h-4 w-4 ${poll ? 'animate-spin' : ''}`} />
               </button>
-            )}
-          </div>
+            </div>
 
-          {dto && (hasAnyOutcome || dto.canEditWeights) && (
-            <details ref={overflowMenuRef} className="relative md:hidden">
-              <summary
-                data-testid="ai-impact-overflow-menu"
-                aria-label={t('aiAgentsPage.impact.moreActions')}
-                className="flex h-9 w-9 cursor-pointer list-none items-center justify-center rounded-md border hover:bg-muted [&::-webkit-details-marker]:hidden"
-              >
-                <MoreHorizontal className="h-4 w-4" />
-              </summary>
-              <div className="absolute right-0 z-10 mt-1 w-56 rounded-md border bg-popover p-1 shadow-md">
-                {hasAnyOutcome && (
+            <div className="flex flex-wrap items-center gap-2" data-testid="ai-impact-actions">
+              {/* Two secondary buttons at md+, collapsed into a single overflow
+                  menu below md so the actions group never wraps to 2-3 rows. */}
+              <div className="hidden items-center gap-2 md:flex">
+                {/* Nothing to export on a window with zero outcomes — Edit weights
+                    stays available even then, since there's still a methodology
+                    to configure ahead of the first outcome. */}
+                {dto && hasAnyOutcome && (
                   <button
                     type="button"
-                    data-testid="ai-impact-export-pdf-overflow"
-                    onClick={() => {
-                      closeOverflowMenu();
-                      void handleExportPdf();
-                    }}
-                    className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-muted"
+                    data-testid="ai-impact-export-pdf"
+                    onClick={() => void handleExportPdf()}
+                    className="inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm hover:bg-muted"
                   >
                     <Download className="h-4 w-4" />
                     {t('aiAgentsPage.impact.exportPdf')}
                   </button>
                 )}
-                {dto.canEditWeights && (
+
+                {/* The server 403s a caller without canManagePartnerWidePolicies —
+                    hiding the button for that case is a UX convenience, not the
+                    real gate. */}
+                {dto?.canEditWeights && (
                   <button
                     type="button"
-                    data-testid="ai-impact-edit-weights-overflow"
-                    onClick={() => {
-                      closeOverflowMenu();
-                      setWeightsDrawerOpen(true);
-                    }}
-                    className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-muted"
+                    data-testid="ai-impact-edit-weights"
+                    onClick={() => setWeightsDrawerOpen(true)}
+                    className="inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm hover:bg-muted"
                   >
                     <Settings2 className="h-4 w-4" />
                     {t('aiAgentsPage.impact.editWeights')}
                   </button>
                 )}
               </div>
-            </details>
-          )}
-        </div>
-      </div>
+
+              {dto && (hasAnyOutcome || dto.canEditWeights) && (
+                <details ref={overflowMenuRef} className="relative md:hidden">
+                  <summary
+                    data-testid="ai-impact-overflow-menu"
+                    aria-label={t('aiAgentsPage.impact.moreActions')}
+                    className="flex h-9 w-9 cursor-pointer list-none items-center justify-center rounded-md border hover:bg-muted [&::-webkit-details-marker]:hidden"
+                  >
+                    <MoreHorizontal className="h-4 w-4" />
+                  </summary>
+                  <div className="absolute right-0 z-10 mt-1 w-56 rounded-md border bg-popover p-1 shadow-md">
+                    {hasAnyOutcome && (
+                      <button
+                        type="button"
+                        data-testid="ai-impact-export-pdf-overflow"
+                        onClick={() => {
+                          closeOverflowMenu();
+                          void handleExportPdf();
+                        }}
+                        className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-muted"
+                      >
+                        <Download className="h-4 w-4" />
+                        {t('aiAgentsPage.impact.exportPdf')}
+                      </button>
+                    )}
+                    {dto.canEditWeights && (
+                      <button
+                        type="button"
+                        data-testid="ai-impact-edit-weights-overflow"
+                        onClick={() => {
+                          closeOverflowMenu();
+                          setWeightsDrawerOpen(true);
+                        }}
+                        className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-muted"
+                      >
+                        <Settings2 className="h-4 w-4" />
+                        {t('aiAgentsPage.impact.editWeights')}
+                      </button>
+                    )}
+                  </div>
+                </details>
+              )}
+            </div>
+          </div>
+        }
+      />
 
       <ImpactWeightsDrawer
         open={weightsDrawerOpen}
@@ -801,16 +836,12 @@ export default function ImpactPage() {
             </div>
           )}
 
-          <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-muted-foreground">
-            <p data-testid="ai-impact-freshness">
-              {dto.rebuiltAt
-                ? t('aiAgentsPage.impact.freshness', {
-                    through: dto.through,
-                    rebuiltAt: formatDateTime(dto.rebuiltAt),
-                  })
-                : t('aiAgentsPage.impact.freshnessNeverRebuilt', { through: dto.through })}
-            </p>
-            {dto.positiveFeedback.rate !== null && (
+          {/* Freshness now lives in the header, beside the window switcher —
+              see ai-impact-freshness-wrap. Positive feedback is a separate
+              signal (supervision rate, not data recency) and keeps its own
+              line here. */}
+          {dto.positiveFeedback.rate !== null && (
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-muted-foreground">
               <p data-testid="ai-impact-positive-feedback">
                 <span className="font-medium text-foreground">
                   {t('aiAgentsPage.impact.positiveFeedbackRate')}
@@ -821,8 +852,8 @@ export default function ImpactPage() {
                   down: dto.positiveFeedback.down,
                 })}
               </p>
-            )}
-          </div>
+            </div>
+          )}
 
           {hasAnyOutcome ? (
             hasChartOutcome ? (

--- a/apps/web/src/components/aiAgents/ImpactWeightsDrawer.test.tsx
+++ b/apps/web/src/components/aiAgents/ImpactWeightsDrawer.test.tsx
@@ -100,6 +100,34 @@ describe('ImpactWeightsDrawer', () => {
     }
   });
 
+  it('hides the native number-input spinner so it cannot collide with the "min" suffix', () => {
+    renderDrawer();
+
+    for (const key of ['alertJudged', 'noiseFlagged', 'ticketTriaged', 'draftSent', 'fixExecuted', 'narrativeDelivered']) {
+      const input = screen.getByTestId(`ai-impact-weight-${key}`);
+      expect(input.className).toContain('[appearance:textfield]');
+      expect(input.className).toContain('[&::-webkit-inner-spin-button]:appearance-none');
+      expect(input.className).toContain('[&::-webkit-outer-spin-button]:appearance-none');
+    }
+  });
+
+  it('shows each field\'s default value beside the current value', () => {
+    renderDrawer();
+
+    // Defaults (seconds -> minutes): alertJudged 90s=1.5, noiseFlagged 240s=4,
+    // ticketTriaged 360s=6, draftSent 300s=5, fixExecuted 900s=15,
+    // narrativeDelivered 1800s=30.
+    expect(screen.getByTestId('ai-impact-weight-alertJudged-default')).toHaveTextContent('1.5');
+    expect(screen.getByTestId('ai-impact-weight-fixExecuted-default')).toHaveTextContent('15');
+    expect(screen.getByTestId('ai-impact-weight-narrativeDelivered-default')).toHaveTextContent('30');
+  });
+
+  it('shows a visible min/max range hint for the minute fields', () => {
+    renderDrawer();
+    expect(screen.getByTestId('ai-impact-weights-range-hint')).toHaveTextContent('0');
+    expect(screen.getByTestId('ai-impact-weights-range-hint')).toHaveTextContent('1440');
+  });
+
   it('accepts a decimal (0.5-minute step) value', () => {
     renderDrawer();
 
@@ -409,6 +437,27 @@ describe('ImpactWeightsDrawer', () => {
       fireEvent.change(screen.getByTestId('ai-impact-weight-alertJudged'), { target: { value: '3' } });
 
       expect(preview).toHaveTextContent('1 hour → 2 hours');
+    });
+
+    it('replaces the "0 hours → 0 hours" preview with a no-outcomes message when the window has no priced activity', () => {
+      const ZERO_COUNTERS: AiAgentImpactCounters = {
+        alertsJudged: 0,
+        noiseFlagged: 0,
+        suppressionsApplied: 0,
+        ticketsTriaged: 0,
+        draftsSent: 0,
+        fixesProposed: 0,
+        fixesExecuted: 0,
+        fixWatchesHeld: 0,
+        fixWatchesRecurred: 0,
+        narrativesDelivered: 0,
+      };
+      renderDrawer({ counters: ZERO_COUNTERS });
+
+      const preview = screen.getByTestId('ai-impact-weights-preview');
+      expect(preview).toHaveTextContent('No outcomes in this window to preview against');
+      expect(preview).not.toHaveTextContent('0 hours');
+      expect(preview).not.toHaveTextContent('→');
     });
   });
 });

--- a/apps/web/src/components/aiAgents/ImpactWeightsDrawer.tsx
+++ b/apps/web/src/components/aiAgents/ImpactWeightsDrawer.tsx
@@ -70,6 +70,15 @@ function weightLabel(t: (key: string) => string, key: (typeof IMPACT_WEIGHT_KEYS
   }
 }
 
+/** Default minutes text per field, for the "Default N min" helper caption —
+ *  computed once at module scope since `DEFAULT_IMPACT_WEIGHTS` is a constant. */
+const DEFAULT_MINUTES_TEXT: Record<(typeof IMPACT_WEIGHT_KEYS)[number], string> = Object.fromEntries(
+  IMPACT_WEIGHT_KEYS.map((key) => [
+    key,
+    formatNumber(DEFAULT_IMPACT_WEIGHTS[key] / 60, { maximumFractionDigits: 2 }),
+  ]),
+) as Record<(typeof IMPACT_WEIGHT_KEYS)[number], string>;
+
 /** Wire unit -> editor unit. Rounded to a hundredth of a minute (0.6s) purely
  *  for a readable seed value — `minutesToSeconds` below undoes float noise on
  *  the way back out, so this rounding never changes what gets saved. */
@@ -276,6 +285,15 @@ export default function ImpactWeightsDrawer({
         <p className="text-sm text-muted-foreground">
           {t('aiAgentsPage.impact.weightsDrawer.description')}
         </p>
+        <p
+          className="text-xs text-muted-foreground"
+          data-testid="ai-impact-weights-range-hint"
+        >
+          {t('aiAgentsPage.impact.weightsDrawer.rangeHint', {
+            min: 0,
+            max: IMPACT_WEIGHT_MAX_MINUTES,
+          })}
+        </p>
         {IMPACT_WEIGHT_KEYS.map((key) => (
           <label key={key} className="block">
             <span className="text-sm text-muted-foreground">{weightLabel(t, key)}</span>
@@ -300,7 +318,13 @@ export default function ImpactWeightsDrawer({
                 onChange={(e) => handleChange(key, e.target.value)}
                 onBlur={() => handleBlur(key)}
                 disabled={busy !== null}
-                className="w-full rounded-md border bg-background px-3 py-2 pr-12 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+                // The native number-input spinner (Chrome/Safari's up/down
+                // stepper) sits inside the same right-hand padding as the
+                // "min" suffix and visually collides with it — step buttons
+                // aren't needed here (the 0.5 step is set for keyboard
+                // arrow-key nudging, not for the spinner), so the spinner is
+                // hidden outright rather than repositioning the suffix.
+                className="w-full rounded-md border bg-background px-3 py-2 pr-12 text-sm [appearance:textfield] disabled:cursor-not-allowed disabled:opacity-50 [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
               />
               <span
                 id={`ai-impact-weight-${key}-unit`}
@@ -310,6 +334,14 @@ export default function ImpactWeightsDrawer({
                 {t('aiAgentsPage.impact.weightsDrawer.unitSuffix')}
               </span>
             </div>
+            <p
+              className="mt-1 text-xs text-muted-foreground"
+              data-testid={`ai-impact-weight-${key}-default`}
+            >
+              {t('aiAgentsPage.impact.weightsDrawer.defaultValue', {
+                minutes: DEFAULT_MINUTES_TEXT[key],
+              })}
+            </p>
           </label>
         ))}
       </div>
@@ -318,10 +350,16 @@ export default function ImpactWeightsDrawer({
           data-testid="ai-impact-weights-preview"
           className="mb-3 text-sm text-muted-foreground"
         >
-          {t('aiAgentsPage.impact.weightsDrawer.preview', {
-            from: formatHours(currentEstSecondsSaved),
-            to: formatHours(draftEstSecondsSaved),
-          })}
+          {/* Both sides price the SAME counters (see the comment above) — if
+              every priced counter is zero, the estimate is 0 regardless of
+              the weights, and "0 hours -> 0 hours" reads as broken math
+              rather than as "there's nothing to preview yet". */}
+          {currentEstSecondsSaved === 0 && draftEstSecondsSaved === 0
+            ? t('aiAgentsPage.impact.weightsDrawer.noOutcomesPreview')
+            : t('aiAgentsPage.impact.weightsDrawer.preview', {
+                from: formatHours(currentEstSecondsSaved),
+                to: formatHours(draftEstSecondsSaved),
+              })}
         </p>
         <div className="flex items-center justify-end gap-2">
           <button

--- a/apps/web/src/components/aiAgents/RunDetailPage.test.tsx
+++ b/apps/web/src/components/aiAgents/RunDetailPage.test.tsx
@@ -280,7 +280,10 @@ describe('RunDetailPage', () => {
     render(<RunDetailPage runId="run-1" />);
 
     await waitFor(() => expect(screen.getByTestId('run-detail-header')).toBeInTheDocument());
-    expect(screen.getByText('Triage')).toBeInTheDocument();
+    // UI critique finding #7 — the h1 now reads "<agent> run", not the bare
+    // agent name (see the "document title and heading" describe block below
+    // for the rest of that finding's coverage).
+    expect(screen.getByText('Triage run')).toBeInTheDocument();
     expect(screen.getByText('WKS-01')).toBeInTheDocument();
   });
 
@@ -1109,7 +1112,7 @@ describe('RunDetailPage summary', () => {
 // findings/proposals must not claim "No action needed" as the headline.
 describe('RunDetailPage verdict vs findings', () => {
   it('badges the count of findings to review instead of claiming no action', async () => {
-    mockEndpoints({ detail: { ...RUN_DETAIL, runVerdict: 'no_action' as const, sweep: SWEEP } });
+    mockEndpoints({ detail: { ...RUN_DETAIL, runVerdict: 'no_action' as const, sweep: SWEEP, findingsToReview: 7 } });
     render(<RunDetailPage runId="run-1" />);
 
     await waitFor(() => expect(screen.getByTestId('run-detail-header')).toBeInTheDocument());
@@ -1229,6 +1232,40 @@ describe('RunDetailPage evidence rendering', () => {
     expect(evidence.textContent).not.toContain('watchType');
   });
 
+  // Review finding — a critical-CVE row used to render "Cve id:" / "Cvss
+  // score:" because only the plural/aggregate keys (`cveIds`, `cveCount`)
+  // were curated, not the singular per-finding pair.
+  it('curates labels for cveId and cvssScore instead of sentence-casing the acronyms away', async () => {
+    mockEndpoints({ detail: withEvidence({ cveId: 'CVE-2026-12345', cvssScore: 9.8 }) });
+    render(<RunDetailPage runId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('ai-agent-run-sweep-finding-0-evidence')).toBeInTheDocument());
+    const evidence = screen.getByTestId('ai-agent-run-sweep-finding-0-evidence');
+    const terms = Array.from(evidence.querySelectorAll('dt')).map((dt) => dt.textContent);
+    expect(terms).toContain('CVE:');
+    expect(terms).toContain('CVSS score:');
+    expect(terms).not.toContain('Cve id:');
+    expect(terms).not.toContain('Cvss score:');
+  });
+
+  // Review finding — `sentenceCaseKey`'s fallback (for evidence keys with no
+  // curated label at all) must keep a known acronym word upper-cased rather
+  // than folding it into ordinary sentence case.
+  it('keeps known acronym words upper-cased in the sentence-case fallback for keys with no curated label', async () => {
+    mockEndpoints({
+      detail: withEvidence({ ipAddress: '10.0.0.5', macAddress: '00:11:22:33:44:55', smartStatus: 'failing', kev: true }),
+    });
+    render(<RunDetailPage runId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('ai-agent-run-sweep-finding-0-evidence')).toBeInTheDocument());
+    const evidence = screen.getByTestId('ai-agent-run-sweep-finding-0-evidence');
+    const terms = Array.from(evidence.querySelectorAll('dt')).map((dt) => dt.textContent);
+    expect(terms).toContain('IP address:');
+    expect(terms).toContain('MAC address:');
+    expect(terms).toContain('SMART status:');
+    expect(terms).toContain('KEV:');
+  });
+
   it('links the finding device to its device page', async () => {
     mockEndpoints({ detail: { ...RUN_DETAIL, sweep: SWEEP } });
     render(<RunDetailPage runId="run-1" />);
@@ -1332,12 +1369,17 @@ describe('RunDetailPage duration', () => {
 
 // Critique finding #5 — an exposure readout of "0 of 0 devices" is noise.
 describe('RunDetailPage exposure budget gating', () => {
-  it('hides the card entirely for a run that targeted no device', async () => {
+  it('hides the card entirely for a run that targeted no device, and never fetches the budget for it', async () => {
     mockEndpoints({ detail: { ...RUN_DETAIL, deviceId: null, deviceHostname: null, sweep: null } });
     render(<RunDetailPage runId="run-1" />);
 
     await waitFor(() => expect(screen.getByTestId('run-detail-header')).toBeInTheDocument());
     expect(screen.queryByTestId('run-detail-budget-card')).not.toBeInTheDocument();
+    // Review finding: the card being hidden must mean the request never
+    // fired, not just that the response was discarded after a 404.
+    expect(
+      fetchMock.mock.calls.some(([url]) => String(url).startsWith('/ai/agents/exposure-budget')),
+    ).toBe(false);
   });
 
   it('still shows the card for a device-less sweep run that touched devices', async () => {
@@ -1418,5 +1460,375 @@ describe('RunDetailPage findings at narrow widths', () => {
     expect(card).toHaveTextContent('The watched Spooler service has been stopped since 09:12.');
     expect(screen.getByTestId('ai-agent-run-sweep-finding-card-0-evidence')).toBeInTheDocument();
     expect(screen.getByTestId('ai-agent-run-sweep-card-proposal-link-0')).toHaveAttribute('href', '/approvals');
+  });
+
+  // Review finding — the card's proposal line rendered as a bare, unlabelled
+  // fact (just "Approval requested" or a reason, with no name for what kind
+  // of fact it was); a null proposal rendered as a bare, unexplained "—".
+  it('labels the proposal line, and omits it entirely when the finding has no proposal', async () => {
+    mockEndpoints({ detail: { ...RUN_DETAIL, sweep: SWEEP } });
+    render(<RunDetailPage runId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('ai-agent-run-sweep-finding-card-0')).toBeInTheDocument());
+    const labelledCard = screen.getByTestId('ai-agent-run-sweep-finding-card-0');
+    expect(screen.getByTestId('ai-agent-run-sweep-finding-card-0-proposal')).toHaveTextContent('Proposal:');
+    expect(labelledCard).toHaveTextContent('Proposal:');
+
+    // Finding index 2 (disk_pressure) carries `proposal: null` in the SWEEP
+    // fixture above.
+    expect(screen.queryByTestId('ai-agent-run-sweep-finding-card-2-proposal')).not.toBeInTheDocument();
+  });
+});
+
+// Impeccable UI pass (fix/4187-ai-agents-ui-critique-3) — finding #1: the
+// header card ran ~660px of dead space beside a max-w-prose summary at `lg`
+// (~1120px card, prose capped ~660px). Two-column the header body at `lg`:
+// summary left, metadata dl right. Below `lg` the two stack as before.
+describe('RunDetailPage hero layout at lg', () => {
+  it('two-columns the header body at lg when a summary is present', async () => {
+    mockEndpoints();
+    render(<RunDetailPage runId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('run-detail-header-body')).toBeInTheDocument());
+    const body = screen.getByTestId('run-detail-header-body');
+    expect(body.className).toContain('lg:flex');
+    expect(body).toContainElement(screen.getByTestId('run-detail-summary'));
+    expect(body).toContainElement(screen.getByTestId('run-detail-meta'));
+    // The metadata grid gets a bounded width at lg so it reads as a distinct
+    // second column rather than stretching across the newly-freed space.
+    expect(screen.getByTestId('run-detail-meta').className).toContain('lg:w-72');
+  });
+
+  it('does not force the two-column body when there is no summary to sit beside', async () => {
+    mockEndpoints({ detail: { ...RUN_DETAIL, summary: null } });
+    render(<RunDetailPage runId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('run-detail-meta')).toBeInTheDocument());
+    expect(screen.getByTestId('run-detail-meta').className).not.toContain('lg:w-72');
+  });
+
+  it('caps the sweep summary at a readable measure', async () => {
+    mockEndpoints({ detail: { ...RUN_DETAIL, sweep: SWEEP } });
+    render(<RunDetailPage runId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('ai-agent-run-sweep-summary')).toBeInTheDocument());
+    expect(screen.getByTestId('ai-agent-run-sweep-summary').className).toContain('max-w-prose');
+  });
+
+  it('renders the checked kinds as wrapped chips instead of one long comma sentence', async () => {
+    mockEndpoints({ detail: { ...RUN_DETAIL, sweep: SWEEP } });
+    render(<RunDetailPage runId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('ai-agent-run-sweep-kinds')).toBeInTheDocument());
+    const container = screen.getByTestId('ai-agent-run-sweep-kinds');
+    expect(container.className).toContain('flex-wrap');
+    // One chip element per kind rather than a single ~220ch run of text.
+    const chips = container.querySelectorAll('span');
+    expect(chips.length).toBeGreaterThanOrEqual(SWEEP.kinds.length);
+    expect(container).toHaveTextContent('Service down');
+    expect(container).toHaveTextContent('Failed backups');
+    expect(container.textContent).not.toContain('service_down');
+  });
+});
+
+// Finding #2 — "Execution trace" and "Tool executions" can render the same
+// single row under two different status vocabularies. When every ledger row
+// matches an `executed` trace entry 1:1 in order, the ledger collapses under
+// the trace instead of repeating it.
+describe('RunDetailPage ledger/trace duplication collapse', () => {
+  it('collapses the ledger under the trace when every ledger row matches an executed trace entry in order', async () => {
+    const trace = [
+      { kind: 'executed' as const, tool: 'diagnostics.processes', result: 'ok' as const, durationMs: 500 },
+      {
+        kind: 'executed' as const,
+        tool: 'manage_services',
+        action: 'restart',
+        result: 'ok' as const,
+        durationMs: 250,
+      },
+    ];
+    const ledger = [
+      {
+        toolName: 'diagnostics.processes',
+        status: 'completed' as const,
+        durationMs: 500,
+        createdAt: '2026-08-20T10:00:10.000Z',
+        completedAt: '2026-08-20T10:00:10.500Z',
+        errorMessage: null,
+      },
+      {
+        toolName: 'manage_services',
+        status: 'completed' as const,
+        durationMs: 250,
+        createdAt: '2026-08-20T10:00:11.000Z',
+        completedAt: '2026-08-20T10:00:11.250Z',
+        errorMessage: null,
+      },
+    ];
+    mockEndpoints({ detail: { ...RUN_DETAIL, trace, ledger } });
+    render(<RunDetailPage runId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('run-detail-ledger-details')).toBeInTheDocument());
+    const details = screen.getByTestId('run-detail-ledger-details');
+    expect(details.tagName).toBe('DETAILS');
+    expect(details).toHaveTextContent('Tool executions (2)');
+    expect(details).toHaveTextContent('same as the trace above');
+    // The data itself is still there, just collapsed under a <details>.
+    expect(screen.getByTestId('run-detail-ledger')).toBeInTheDocument();
+  });
+
+  it('renders the ledger as its own section when it does not match the trace 1:1', async () => {
+    mockEndpoints();
+    render(<RunDetailPage runId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('run-detail-ledger')).toBeInTheDocument());
+    expect(screen.queryByTestId('run-detail-ledger-details')).not.toBeInTheDocument();
+    expect(screen.getByTestId('run-detail-ledger-description')).toBeInTheDocument();
+  });
+});
+
+// Finding #3 — the ledger's error cell was unconditionally destructive-toned,
+// so a healthy row's em dash read as an error too.
+describe('RunDetailPage ledger error cell tone', () => {
+  it('only applies destructive tone to a row that actually carries an error', async () => {
+    mockEndpoints({
+      detail: {
+        ...RUN_DETAIL,
+        ledger: [
+          {
+            toolName: 'a',
+            status: 'completed' as const,
+            durationMs: 100,
+            createdAt: '2026-08-20T10:00:10.000Z',
+            completedAt: null,
+            errorMessage: null,
+          },
+          {
+            toolName: 'b',
+            status: 'failed' as const,
+            durationMs: 100,
+            createdAt: '2026-08-20T10:00:11.000Z',
+            completedAt: null,
+            errorMessage: 'boom',
+          },
+        ],
+      },
+    });
+    render(<RunDetailPage runId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('run-detail-ledger')).toBeInTheDocument());
+    const rows = screen.getByTestId('run-detail-ledger').querySelectorAll('tbody tr');
+    const okCell = rows[0].querySelectorAll('td')[4];
+    const errorCell = rows[1].querySelectorAll('td')[4];
+    expect(okCell.className).not.toContain('text-destructive');
+    expect(okCell).toHaveTextContent('—');
+    expect(errorCell.className).toContain('text-destructive');
+    expect(errorCell).toHaveTextContent('boom');
+  });
+});
+
+// Finding #4 — a literal string "null"/"undefined"/empty in an evidence value
+// (not a real JS null) leaked as visible text ("Error count: null"). And the
+// Device column showed an em dash even when the evidence carried a name.
+describe('RunDetailPage evidence absent-string leak and device fallback', () => {
+  const withEvidence = (evidence: Record<string, string | number | boolean | null>) => ({
+    ...RUN_DETAIL,
+    sweep: { ...SWEEP, findings: [{ ...SWEEP.findings[0], evidence }] },
+  });
+
+  it('omits a row whose value is the literal string "null", "undefined", or empty', async () => {
+    mockEndpoints({ detail: withEvidence({ errorCount: 'null', note: 'undefined', blank: '', cveCount: 3 }) });
+    render(<RunDetailPage runId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('ai-agent-run-sweep-finding-0-evidence')).toBeInTheDocument());
+    const evidence = screen.getByTestId('ai-agent-run-sweep-finding-0-evidence');
+    expect(evidence.textContent).not.toContain('null');
+    expect(evidence.textContent).not.toContain('undefined');
+    expect(evidence.querySelectorAll('dt')).toHaveLength(1);
+    expect(evidence).toHaveTextContent('CVE count');
+  });
+
+  it('falls back to the evidence deviceName when deviceHostname is null', async () => {
+    mockEndpoints({
+      detail: {
+        ...RUN_DETAIL,
+        sweep: {
+          ...SWEEP,
+          findings: [
+            { ...SWEEP.findings[0], deviceHostname: null, deviceId: 'd9', evidence: { deviceName: 'WKS-99' } },
+          ],
+        },
+      },
+    });
+    render(<RunDetailPage runId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('ai-agent-run-sweep-finding-0-device')).toBeInTheDocument());
+    const cell = screen.getByTestId('ai-agent-run-sweep-finding-0-device');
+    expect(cell).toHaveTextContent('WKS-99');
+    expect(cell.querySelector('a')).toHaveAttribute('href', '/devices/d9');
+  });
+
+  it('falls back to the evidence hostname when neither deviceHostname nor deviceName is present', async () => {
+    mockEndpoints({
+      detail: {
+        ...RUN_DETAIL,
+        sweep: {
+          ...SWEEP,
+          findings: [
+            { ...SWEEP.findings[0], deviceHostname: null, deviceId: null, evidence: { hostname: 'SRV-05' } },
+          ],
+        },
+      },
+    });
+    render(<RunDetailPage runId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('ai-agent-run-sweep-finding-0-device')).toBeInTheDocument());
+    expect(screen.getByTestId('ai-agent-run-sweep-finding-0-device')).toHaveTextContent('SRV-05');
+  });
+});
+
+// Finding #5 [P1 share] — the ledger had no mobile layout at all, unlike the
+// sweep findings table which already splits into cards below `md`.
+describe('RunDetailPage ledger at narrow widths', () => {
+  it('renders one stacked card per ledger entry below md and keeps the table from md up', async () => {
+    mockEndpoints();
+    render(<RunDetailPage runId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('run-detail-ledger-cards')).toBeInTheDocument());
+    const cards = screen.getByTestId('run-detail-ledger-cards');
+    expect(cards.className).toContain('md:hidden');
+    expect(screen.getByTestId('run-detail-ledger-card-0')).toBeInTheDocument();
+
+    const tableWrapper = screen.getByTestId('run-detail-ledger-table-wrapper');
+    expect(tableWrapper.className).toContain('hidden');
+    expect(tableWrapper.className).toContain('md:block');
+  });
+
+  it('carries the tool name, status, duration and error on a ledger card', async () => {
+    mockEndpoints({
+      detail: {
+        ...RUN_DETAIL,
+        ledger: [
+          {
+            toolName: 'diagnostics.processes',
+            status: 'failed' as const,
+            durationMs: 500,
+            createdAt: '2026-08-20T10:00:10.000Z',
+            completedAt: null,
+            errorMessage: 'timed out',
+          },
+        ],
+      },
+    });
+    render(<RunDetailPage runId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('run-detail-ledger-card-0')).toBeInTheDocument());
+    const card = screen.getByTestId('run-detail-ledger-card-0');
+    expect(card).toHaveTextContent('diagnostics.processes');
+    expect(card).toHaveTextContent('Failed');
+    expect(card).toHaveTextContent('500ms');
+    expect(card).toHaveTextContent('timed out');
+  });
+});
+
+// Finding #6 (craft-floor "nested cards are always wrong") — an EmptyState's
+// own dashed-border card was nested inside the section's already-bordered
+// card. The trace/ledger/intents in-card empties render as plain text now.
+describe('RunDetailPage in-card empty states are plain, not nested cards', () => {
+  it('renders the trace/ledger/intents empties without a nested dashed border', async () => {
+    mockEndpoints({ detail: { ...RUN_DETAIL, trace: [], ledger: [], intents: [] } });
+    render(<RunDetailPage runId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('run-detail-trace-empty')).toBeInTheDocument());
+    for (const testId of ['run-detail-trace-empty', 'run-detail-ledger-empty', 'run-detail-intents-empty']) {
+      const el = screen.getByTestId(testId);
+      expect(el.className).not.toContain('border-dashed');
+    }
+    expect(screen.getByText('No linked approvals.')).toBeInTheDocument();
+  });
+});
+
+// Finding #7 — the h1 was the bare agent name and document.title was a
+// static "Run Detail" no matter which run was open.
+describe('RunDetailPage document title and heading', () => {
+  it('sets document.title once the run loads, and names the h1 "<agent> run"', async () => {
+    mockEndpoints();
+    render(<RunDetailPage runId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('run-detail-header')).toBeInTheDocument());
+    const h1 = screen.getByRole('heading', { level: 1 });
+    expect(h1).toHaveTextContent('Triage run');
+    expect(document.title).toContain('Triage');
+    expect(document.title).toContain('Run');
+    expect(document.title).toContain('2026');
+    expect(document.title).not.toBe('Run Detail');
+  });
+
+  it('shows the started time as visible secondary text next to the h1', async () => {
+    mockEndpoints();
+    render(<RunDetailPage runId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('run-detail-header-started')).toBeInTheDocument());
+    expect(screen.getByTestId('run-detail-header-started').textContent?.trim().length).toBeGreaterThan(0);
+    expect(screen.getByTestId('run-detail-header-started').textContent).not.toContain('—');
+  });
+
+  it('shows a dash for the header started text when the run has not started', async () => {
+    mockEndpoints({ detail: { ...RUN_DETAIL, startedAt: null } });
+    render(<RunDetailPage runId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('run-detail-header-started')).toBeInTheDocument());
+    expect(screen.getByTestId('run-detail-header-started')).toHaveTextContent('—');
+  });
+});
+
+// Finding #8 — the verdict badge and the findings-override badge sat on
+// adjacent lines with no connective, reading as two unrelated facts.
+describe('RunDetailPage machine verdict prefix', () => {
+  it('prefixes the demoted verdict with "Machine verdict:" once the findings override fires', async () => {
+    mockEndpoints({ detail: { ...RUN_DETAIL, runVerdict: 'no_action' as const, sweep: SWEEP, findingsToReview: 7 } });
+    render(<RunDetailPage runId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('run-detail-verdict-secondary')).toBeInTheDocument());
+    expect(screen.getByTestId('run-detail-verdict-secondary')).toHaveTextContent('Machine verdict:');
+    expect(screen.getByTestId('run-detail-verdict-secondary')).toHaveTextContent('No action needed');
+  });
+});
+
+// `findingsToReview` is server-computed by the same helper the runs list
+// uses, and the override rule mirrors the list's `findingsOverrideActive`:
+// any verdict that is not already attention-toned understates a run that
+// left findings behind.
+describe('RunDetailPage findingsToReview from the server', () => {
+  it('renders the DTO findingsToReview count rather than recomputing it client-side', async () => {
+    mockEndpoints({
+      detail: {
+        ...RUN_DETAIL,
+        runVerdict: 'no_action' as const,
+        sweep: SWEEP,
+        findingsToReview: 42,
+      },
+    });
+    render(<RunDetailPage runId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('run-detail-findings-badge')).toBeInTheDocument());
+    expect(screen.getByTestId('run-detail-findings-badge')).toHaveTextContent('42 findings to review');
+  });
+
+  it('also overrides a remediated verdict that left findings behind, matching the runs list', async () => {
+    mockEndpoints({ detail: { ...RUN_DETAIL, runVerdict: 'remediated' as const, sweep: SWEEP, findingsToReview: 2 } });
+    render(<RunDetailPage runId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('run-detail-findings-badge')).toBeInTheDocument());
+    expect(screen.getByTestId('run-detail-findings-badge')).toHaveTextContent('2 findings to review');
+    expect(screen.getByTestId('run-detail-verdict-secondary')).toHaveTextContent('Machine verdict:');
+  });
+
+  it('leaves an attention-toned verdict alone even with findings', async () => {
+    mockEndpoints({ detail: { ...RUN_DETAIL, runVerdict: 'needs_attention' as const, sweep: SWEEP, findingsToReview: 2 } });
+    render(<RunDetailPage runId="run-1" />);
+
+    await waitFor(() => expect(screen.getByTestId('run-detail-header')).toBeInTheDocument());
+    expect(screen.queryByTestId('run-detail-findings-badge')).toBeNull();
   });
 });

--- a/apps/web/src/components/aiAgents/RunDetailPage.tsx
+++ b/apps/web/src/components/aiAgents/RunDetailPage.tsx
@@ -5,7 +5,7 @@ import { ArrowLeft, Bot, Clock, Download, ExternalLink, Loader2 } from 'lucide-r
 import ReactMarkdown from 'react-markdown';
 import { fetchWithAuth } from '../../stores/auth';
 import { exportReport, getBrowserTimezone } from '../reports/reportExport';
-import { formatDate, formatDateTime } from '@/lib/dateTimeFormat';
+import { formatDate, formatDateTime, formatTime } from '@/lib/dateTimeFormat';
 import { formatCurrency, formatNumber } from '@/lib/i18n/format';
 import { badgeClass, runStatusTone, verdictTone } from './statusBadge';
 import { EmptyState } from '../shared/EmptyState';
@@ -144,6 +144,104 @@ function ledgerStatusLabel(t: (key: string) => string, value: AiAgentRunLedgerEn
     default:
       return value;
   }
+}
+
+/**
+ * Craft-floor fix (nested cards are always wrong) — every in-card empty
+ * state below (trace/ledger/intents) used to be a dashed-bordered
+ * `EmptyState` nested INSIDE the section's own `rounded-lg border bg-card`
+ * card, a border-on-a-border. Rendered as a plain muted note instead: a
+ * short title line plus its description, no card of its own. Two separate
+ * `<p>` elements (not one concatenated string) so each piece of text is
+ * still independently queryable, matching how `EmptyState` exposed them.
+ */
+function InCardEmpty({ title, description, testId }: { title: string; description: string; testId?: string }) {
+  return (
+    <div className="mt-2" data-testid={testId}>
+      <p className="text-sm font-medium text-foreground">{title}</p>
+      <p className="mt-0.5 text-sm text-muted-foreground">{description}</p>
+    </div>
+  );
+}
+
+/** The same ledger entry, stacked, for viewports below `md` (UI critique
+ *  finding #5 — the ledger had no mobile layout, unlike the sweep findings
+ *  table it sits beside on this page). Mirrors `SweepFindingCard`'s divided
+ *  list, not a nested bordered card. */
+function LedgerEntryCard({
+  entry,
+  index,
+  t,
+}: {
+  entry: AiAgentRunLedgerEntryDto;
+  index: number;
+  t: (key: string) => string;
+}) {
+  return (
+    <li data-testid={`run-detail-ledger-card-${index}`} className="py-3 first:pt-0 last:pb-0">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <span className="text-sm font-medium">{entry.toolName}</span>
+        <span className="text-xs text-muted-foreground">{ledgerStatusLabel(t, entry.status)}</span>
+      </div>
+      <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
+        <span>{formatDuration(entry.durationMs)}</span>
+        <span>{formatDateTime(entry.createdAt)}</span>
+      </div>
+      {/* Finding #3 — destructive tone only when there IS an error; a
+          healthy row's em dash must not read as an error too. */}
+      {entry.errorMessage && (
+        <p className="mt-1 text-xs text-destructive" data-testid={`run-detail-ledger-card-${index}-error`}>
+          {entry.errorMessage}
+        </p>
+      )}
+    </li>
+  );
+}
+
+/**
+ * The ledger's body, rendered twice like the sweep findings above: stacked
+ * cards below `md`, a table from `md` up. Shared by both the collapsed
+ * (`<details>`, finding #2) and plain rendering paths below so the two never
+ * drift from each other.
+ */
+function LedgerTable({ ledger, t }: { ledger: AiAgentRunLedgerEntryDto[]; t: (key: string) => string }) {
+  return (
+    <>
+      <ul className="mt-2 divide-y md:hidden" data-testid="run-detail-ledger-cards">
+        {ledger.map((entry, index) => (
+          <LedgerEntryCard key={index} entry={entry} index={index} t={t} />
+        ))}
+      </ul>
+      <div className="mt-2 hidden overflow-x-auto md:block" data-testid="run-detail-ledger-table-wrapper">
+        <table className="min-w-full divide-y text-sm" data-testid="run-detail-ledger">
+          <thead>
+            <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              <th className="px-2 py-2">{t('aiAgentsPage.runs.detail.ledger.columns.tool')}</th>
+              <th className="px-2 py-2">{t('aiAgentsPage.runs.detail.ledger.columns.status')}</th>
+              <th className="px-2 py-2">{t('aiAgentsPage.runs.detail.ledger.columns.duration')}</th>
+              <th className="px-2 py-2">{t('aiAgentsPage.runs.detail.ledger.columns.started')}</th>
+              <th className="px-2 py-2">{t('aiAgentsPage.runs.detail.ledger.columns.error')}</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y">
+            {ledger.map((entry, index) => (
+              <tr key={index}>
+                <td className="px-2 py-2 font-medium">{entry.toolName}</td>
+                <td className="px-2 py-2 text-muted-foreground">{ledgerStatusLabel(t, entry.status)}</td>
+                <td className="px-2 py-2 text-muted-foreground">{formatDuration(entry.durationMs)}</td>
+                <td className="px-2 py-2 text-muted-foreground">{formatDateTime(entry.createdAt)}</td>
+                {/* Finding #3 — was unconditionally `text-destructive`, so a
+                    healthy row's em dash read as an error too. */}
+                <td className={`px-2 py-2 ${entry.errorMessage ? 'text-destructive' : 'text-muted-foreground'}`}>
+                  {entry.errorMessage ?? '—'}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
 }
 
 /**
@@ -448,17 +546,39 @@ const EVIDENCE_LABELLED_KEYS: ReadonlySet<string> = new Set([
   'usedPercent', 'percentUsed', 'freeGb', 'totalGb',
   'lastSeenAt', 'lastSeenDays', 'checkedAt',
   'cveIds', 'cveCount', 'osType', 'openCriticalCount',
+  // Review finding — a per-finding CVE the model calls out by itself (not
+  // the aggregate `cveIds`/`cveCount` a sweep loader emits) still needs a
+  // curated label: `sentenceCaseKey`'s acronym fallback below cannot turn
+  // "cveId" into "CVE" on its own without also mangling "Id" into "ID",
+  // which the rest of the page spells lower-case (see `isOpaqueIdValue`).
+  'cveId', 'cvssScore',
 ]);
 
-/** `camelCase` / `snake_case` → `Sentence case`. */
+/** Short tokens that read as gibberish once sentence-cased (`Cve`, `Ip`,
+ *  `Mac`) because they are actually acronyms. Used only by the fallback
+ *  below, for evidence keys with no entry in `EVIDENCE_LABELLED_KEYS` — a
+ *  model can author evidence field names freely (see `sweepFindings.ts`),
+ *  so this cannot be an exhaustive dictionary of every possible key, only of
+ *  the short word-stems worth preserving in upper case. Deliberately a small,
+ *  literal set rather than "any short word": acronym-casing an ordinary
+ *  short English word (`auto`, `type`, `name`) would be just as wrong as the
+ *  bug this fixes. */
+const ACRONYM_WORDS: ReadonlySet<string> = new Set(['cve', 'cvss', 'kev', 'ip', 'mac', 'os', 'smart']);
+
+/** `camelCase` / `snake_case` → `Sentence case`, upper-casing any word that
+ *  matches `ACRONYM_WORDS` instead of folding it into the rest of the
+ *  sentence (e.g. `ipAddress` → "IP address", not "Ip address"). */
 function sentenceCaseKey(key: string): string {
   const words = key
     .replace(/[_-]+/g, ' ')
     .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
     .replace(/\s+/g, ' ')
     .trim()
-    .toLowerCase();
-  return words.charAt(0).toUpperCase() + words.slice(1);
+    .toLowerCase()
+    .split(' ')
+    .map((word) => (ACRONYM_WORDS.has(word) ? word.toUpperCase() : word));
+  const sentence = words.join(' ');
+  return sentence.charAt(0).toUpperCase() + sentence.slice(1);
 }
 
 function evidenceLabel(t: (key: string) => string, key: string): string {
@@ -495,6 +615,22 @@ function formatEvidenceValue(t: (key: string) => string, value: string | number 
   return value;
 }
 
+/**
+ * UI critique finding #4 — a sweep loader occasionally hands over the
+ * LITERAL string `"null"`/`"undefined"` (a stringified missing value, not a
+ * real JS `null`) or an empty string. `formatEvidenceValue` above only
+ * special-cases real `null`; these string forms fell through to the raw
+ * `return value` branch and rendered as visible "Error count: null" noise.
+ * The row is dropped entirely rather than shown as "—" — a real `null`
+ * already means "no value" and keeps showing the dash; this is only for the
+ * string forms that were never a value in the first place.
+ */
+function isAbsentEvidenceString(value: string | number | boolean | null): boolean {
+  if (typeof value !== 'string') return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === '' || normalized === 'null' || normalized === 'undefined';
+}
+
 /** The bounded scalar evidence map, rendered as `<dt>`/`<dd>` pairs — never a
  * JSON dump, and never a flattened "k: v" string a screen reader would read
  * as one undifferentiated run of text. */
@@ -508,7 +644,16 @@ function SweepEvidenceList({
   t: (key: string) => string;
 }) {
   const entries = Object.entries(evidence).filter(
-    ([key, value]) => key !== 'deviceId' && !isOpaqueIdValue(value),
+    ([key, value]) =>
+      // `deviceName`/`hostname` are excluded alongside `deviceId`: once
+      // `SweepFindingDevice` falls back to one of them for the Device
+      // column (finding #4 below), repeating it as a generic evidence row
+      // would duplicate the same fact under a raw-looking key.
+      key !== 'deviceId'
+      && key !== 'deviceName'
+      && key !== 'hostname'
+      && !isOpaqueIdValue(value)
+      && !isAbsentEvidenceString(value),
   );
   if (entries.length === 0) return null;
   return (
@@ -561,14 +706,30 @@ const SWEEP_TEST_IDS: Record<SweepVariant, SweepTestIds> = {
   },
 };
 
+/**
+ * UI critique finding #4 — the Device column showed an em dash even when the
+ * sweep's own evidence carried a name for the device (`deviceName`, or
+ * `hostname` for a loader that used the other convention); only the resolved
+ * `finding.deviceHostname` join was ever consulted. Falls back to whichever
+ * evidence key is present before giving up.
+ */
+function evidenceHostnameFallback(evidence: AiAgentRunSweepFindingDto['evidence']): string | null {
+  const deviceName = evidence.deviceName;
+  if (typeof deviceName === 'string' && deviceName.trim() !== '') return deviceName;
+  const hostname = evidence.hostname;
+  if (typeof hostname === 'string' && hostname.trim() !== '') return hostname;
+  return null;
+}
+
 /** A finding's device, as a link to the device itself when the sweep resolved
  *  one — the id is otherwise a dead end (UI critique finding #2). */
 function SweepFindingDevice({ finding }: { finding: AiAgentRunSweepFindingDto }) {
-  if (!finding.deviceHostname) return <>—</>;
-  if (!finding.deviceId) return <>{finding.deviceHostname}</>;
+  const hostname = finding.deviceHostname ?? evidenceHostnameFallback(finding.evidence);
+  if (!hostname) return <>—</>;
+  if (!finding.deviceId) return <>{hostname}</>;
   return (
     <a href={`/devices/${finding.deviceId}`} className="text-primary hover:underline">
-      {finding.deviceHostname}
+      {hostname}
     </a>
   );
 }
@@ -692,9 +853,20 @@ function SweepFindingCard({
       <p className="mt-1.5 text-sm font-medium">{finding.title}</p>
       <p className="mt-0.5 text-sm text-muted-foreground">{finding.detail}</p>
       <SweepEvidenceList evidence={finding.evidence} testId={ids.evidence(index)} t={t} />
-      <p className={`mt-1.5 text-xs ${sweepProposalToneClass(finding.proposal)}`} data-testid={ids.proposal(index)}>
-        <SweepProposalContent finding={finding} index={index} agentId={agentId} ids={ids} t={t} />
-      </p>
+      {/* Review finding — this used to render unconditionally: a bare "—"
+          for a finding with no proposal at all (the table's other columns
+          all sit under a header; this line had none), and no name for what
+          kind of fact it was when a proposal WAS present. Reuse the table's
+          own column header key rather than mint a second "Proposal" string,
+          and drop the line entirely rather than print a dash — a finding
+          the sweep judged fine as-is (`disk_pressure` at 94% is a finding,
+          not necessarily an action) has nothing to report here. */}
+      {finding.proposal !== null && (
+        <p className={`mt-1.5 text-xs ${sweepProposalToneClass(finding.proposal)}`} data-testid={ids.proposal(index)}>
+          <span className="font-medium text-foreground">{t('aiAgentsPage.runs.sweep.columns.proposal')}: </span>
+          <SweepProposalContent finding={finding} index={index} agentId={agentId} ids={ids} t={t} />
+        </p>
+      )}
     </li>
   );
 }
@@ -1164,6 +1336,22 @@ export default function RunDetailPage({ runId }: RunDetailPageProps) {
   }, [run?.status, refreshSilently]);
 
   /**
+   * UI critique finding #7 — the browser tab title was a static "Run Detail"
+   * (set in the Astro page shell) no matter which run was open, so a user
+   * with several run tabs open couldn't tell them apart. Set once the run
+   * has loaded; no [id].astro-level i18n precedent exists for this title to
+   * follow (checked: every AI Agents page passes a hardcoded English
+   * `DashboardLayout title`), so the static shell title is left alone and
+   * this effect overwrites it as soon as data is available.
+   */
+  useEffect(() => {
+    if (!run) return;
+    const agent = run.agentName ?? t('aiAgentsPage.runs.noAgent');
+    const started = run.startedAt ? formatDate(run.startedAt) : '—';
+    document.title = t('aiAgentsRuns.detail.pageTitle', { agent, started });
+  }, [run, t]);
+
+  /**
    * Phase 2 wave P2-3 (#4190) — "Download PDF" on the narrative section.
    *
    * The report-run download route answers JSON (`{ type, format, data }`) and
@@ -1263,10 +1451,35 @@ export default function RunDetailPage({ runId }: RunDetailPageProps) {
    * permission/budget) is the only trace kind that belongs alongside sweep
    * findings.
    */
-  const findingsToReview =
-    (run.sweep?.findings.length ?? 0)
-    + run.trace.filter((entry) => entry.kind === 'proposed').length;
-  const verdictUnderstatesFindings = run.runVerdict === 'no_action' && findingsToReview > 0;
+  // Server-computed by the same helper the runs list uses
+  // (`services/aiAgents/runFindings.ts`), so the two surfaces cannot badge
+  // one run with different numbers.
+  const findingsToReview = run.findingsToReview;
+  // Same rule as the runs list's `findingsOverrideActive`: any verdict that
+  // is not already an attention-tone one understates a run that left
+  // findings behind, so the findings count takes the badge and the verdict
+  // becomes secondary text.
+  const verdictUnderstatesFindings =
+    findingsToReview > 0 && verdictTone(run.runVerdict ?? '') !== 'danger';
+
+  /**
+   * UI critique finding #2 — "Execution trace" and "Tool executions" can
+   * render the exact same single row under two different status
+   * vocabularies (an `executed` trace kind vs. an `AiToolStatus`). When
+   * every ledger row lines up 1:1, in order, with an `executed` trace entry
+   * for the same tool, the ledger collapses under the trace instead of
+   * repeating it. Any mismatch (a ledger row the trace lost, reordering, a
+   * different tool) falls back to rendering both in full — this is a
+   * display-only convenience, never a claim that the two are semantically
+   * identical.
+   */
+  const executedTraceTools = run.trace
+    .filter((entry): entry is Extract<AiAgentRunTraceEntryDto, { kind: 'executed' }> => entry.kind === 'executed')
+    .map((entry) => entry.tool);
+  const ledgerMatchesTrace =
+    run.ledger.length > 0
+    && executedTraceTools.length === run.ledger.length
+    && executedTraceTools.every((tool, index) => tool === run.ledger[index].toolName);
 
   /**
    * UI critique finding #5 — the exposure budget is a per-device allowance.
@@ -1286,7 +1499,16 @@ export default function RunDetailPage({ runId }: RunDetailPageProps) {
       <div data-testid="run-detail-header" className="rounded-lg border bg-card p-4">
         <div className="flex flex-wrap items-center gap-2">
           <Bot className="h-5 w-5 text-muted-foreground" />
-          <h1 className="text-lg font-semibold">{run.agentName ?? t('aiAgentsPage.runs.noAgent')}</h1>
+          {/* UI critique finding #7 — the h1 used to be the bare agent name
+              (indistinguishable from a device/org page's own h1), with no
+              visible sense of WHICH run this is beyond the URL. */}
+          <h1 className="text-xl font-semibold tracking-tight">
+            {t('aiAgentsRuns.detail.header.title', { agent: run.agentName ?? t('aiAgentsPage.runs.noAgent') })}
+          </h1>
+          <span className="text-sm font-normal text-muted-foreground" data-testid="run-detail-header-started">
+            <span className="sr-only">{t('aiAgentsRuns.detail.header.startedLabel')}</span>
+            {run.startedAt ? formatTime(run.startedAt) : '—'}
+          </span>
           <span
             className={badgeClass(runStatusTone(run.status), { size: 'sm' })}
             aria-live={runIsLive ? 'polite' : undefined}
@@ -1331,63 +1553,81 @@ export default function RunDetailPage({ runId }: RunDetailPageProps) {
             <span className="sr-only">{t('aiAgentsPage.runs.detail.labels.duration')}</span>
             {formatDuration(durationMs)}
           </span>
+          {/* UI critique finding #8 — the verdict badge above and this
+              demoted-verdict line sat with no connective, reading as two
+              unrelated facts rather than "the machine's own call, which the
+              findings above override". */}
           {verdictUnderstatesFindings && (
-            <span data-testid="run-detail-verdict-secondary">{verdictLabel(t, run.runVerdict)}</span>
+            <span data-testid="run-detail-verdict-secondary">
+              {t('aiAgentsRuns.detail.header.machineVerdict', { verdict: verdictLabel(t, run.runVerdict) })}
+            </span>
           )}
         </div>
 
-        {/* UI critique finding #1 — the agent's own account of the run leads
-            the card, above the machine-derived metadata grid, at body weight
-            rather than as a muted afterthought below it. */}
-        {run.summary && (
-          <section className="mt-4" aria-labelledby="run-detail-summary-heading">
-            <h2
-              id="run-detail-summary-heading"
-              className="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
-            >
-              {t('aiAgentsRuns.detail.summary.title')}
-            </h2>
-            <div
-              className="mt-1.5 max-w-prose text-sm leading-relaxed text-foreground"
-              data-testid="run-detail-summary"
-            >
-              <RunSummaryMarkdown markdown={run.summary} />
-            </div>
-          </section>
-        )}
+        {/* UI critique finding #1 — the summary at `max-w-prose` inside the
+            full-width header card left ~660px of dead space beside it at
+            `lg`. Two-column the body there: summary left, metadata dl
+            right — only when there IS a summary to sit beside; a
+            summary-less run keeps the dl at full width. */}
+        <div
+          data-testid="run-detail-header-body"
+          className={run.summary ? 'mt-4 lg:flex lg:items-start lg:gap-8' : ''}
+        >
+          {run.summary && (
+            <section className="lg:max-w-prose lg:flex-1" aria-labelledby="run-detail-summary-heading">
+              <h2
+                id="run-detail-summary-heading"
+                className="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+              >
+                {t('aiAgentsRuns.detail.summary.title')}
+              </h2>
+              <div
+                className="mt-1.5 max-w-prose text-sm leading-relaxed text-foreground"
+                data-testid="run-detail-summary"
+              >
+                <RunSummaryMarkdown markdown={run.summary} />
+              </div>
+            </section>
+          )}
 
-        <dl data-testid="run-detail-meta" className="mt-4 grid grid-cols-2 gap-x-6 gap-y-2 text-sm sm:grid-cols-4">
-          <div>
-            <dt className="text-xs text-muted-foreground">{t('aiAgentsPage.runs.detail.labels.device')}</dt>
-            <dd>{run.deviceHostname ?? t('aiAgentsPage.runs.detail.labels.noDevice')}</dd>
-          </div>
-          <div>
-            <dt className="text-xs text-muted-foreground">{t('aiAgentsPage.runs.detail.labels.trigger')}</dt>
-            <dd>{triggerLabel(t, run.triggerKind)}</dd>
-          </div>
-          <div>
-            <dt className="text-xs text-muted-foreground">{t('aiAgentsPage.runs.detail.labels.cost')}</dt>
-            <dd>{formatCurrency(run.costCents / 100)}</dd>
-          </div>
-          {/* Duration lives in the status row above (UI critique finding #4)
-              — repeating it here would double-mark the same fact. */}
-          <div>
-            <dt className="text-xs text-muted-foreground">{t('aiAgentsPage.runs.detail.labels.queuedAt')}</dt>
-            <dd>{formatDateTime(run.queuedAt)}</dd>
-          </div>
-          <div>
-            <dt className="text-xs text-muted-foreground">{t('aiAgentsPage.runs.detail.labels.startedAt')}</dt>
-            <dd>{run.startedAt ? formatDateTime(run.startedAt) : '—'}</dd>
-          </div>
-          <div>
-            <dt className="text-xs text-muted-foreground">{t('aiAgentsPage.runs.detail.labels.finishedAt')}</dt>
-            <dd>{run.finishedAt ? formatDateTime(run.finishedAt) : '—'}</dd>
-          </div>
-          <div>
-            <dt className="text-xs text-muted-foreground">{t('aiAgentsPage.runs.detail.labels.turnCount')}</dt>
-            <dd>{formatNumber(run.turnCount)}</dd>
-          </div>
-        </dl>
+          <dl
+            data-testid="run-detail-meta"
+            className={`grid grid-cols-2 gap-x-6 gap-y-2 text-sm sm:grid-cols-4 ${
+              run.summary ? 'mt-4 lg:mt-0 lg:w-72 lg:flex-none lg:grid-cols-2' : 'mt-4'
+            }`}
+          >
+            <div>
+              <dt className="text-xs text-muted-foreground">{t('aiAgentsPage.runs.detail.labels.device')}</dt>
+              <dd>{run.deviceHostname ?? t('aiAgentsPage.runs.detail.labels.noDevice')}</dd>
+            </div>
+            <div>
+              <dt className="text-xs text-muted-foreground">{t('aiAgentsPage.runs.detail.labels.trigger')}</dt>
+              <dd>{triggerLabel(t, run.triggerKind)}</dd>
+            </div>
+            <div>
+              <dt className="text-xs text-muted-foreground">{t('aiAgentsPage.runs.detail.labels.cost')}</dt>
+              <dd>{formatCurrency(run.costCents / 100)}</dd>
+            </div>
+            {/* Duration lives in the status row above (UI critique finding
+                #4) — repeating it here would double-mark the same fact. */}
+            <div>
+              <dt className="text-xs text-muted-foreground">{t('aiAgentsPage.runs.detail.labels.queuedAt')}</dt>
+              <dd>{formatDateTime(run.queuedAt)}</dd>
+            </div>
+            <div>
+              <dt className="text-xs text-muted-foreground">{t('aiAgentsPage.runs.detail.labels.startedAt')}</dt>
+              <dd>{run.startedAt ? formatDateTime(run.startedAt) : '—'}</dd>
+            </div>
+            <div>
+              <dt className="text-xs text-muted-foreground">{t('aiAgentsPage.runs.detail.labels.finishedAt')}</dt>
+              <dd>{run.finishedAt ? formatDateTime(run.finishedAt) : '—'}</dd>
+            </div>
+            <div>
+              <dt className="text-xs text-muted-foreground">{t('aiAgentsPage.runs.detail.labels.turnCount')}</dt>
+              <dd>{formatNumber(run.turnCount)}</dd>
+            </div>
+          </dl>
+        </div>
 
         {/* Wave 6 PR 4 (#3828, Task 4) — anomaly-triggered runs are
             device-bound (unlike ticket runs), so `deviceId` is always set
@@ -1444,15 +1684,26 @@ export default function RunDetailPage({ runId }: RunDetailPageProps) {
         <section data-testid="ai-agent-run-sweep" className="rounded-lg border bg-card p-4">
           <h2 className="text-sm font-semibold">{t('aiAgentsPage.runs.sweep.title')}</h2>
 
+          {/* UI critique finding #1 — this used to be a single comma-joined
+              sentence ("Checks: a, b, c, …") that ran to ~220ch for a
+              six-check sweep. A wrapped chip row reads at a glance and never
+              needs a measure cap. */}
           {run.sweep.kinds.length > 0 && (
-            <p className="mt-1 text-xs text-muted-foreground" data-testid="ai-agent-run-sweep-kinds">
-              {t('aiAgentsPage.runs.sweep.kindsLabel', {
-                kinds: run.sweep.kinds.map((kind) => sweepKindLabel(t, kind)).join(', '),
-              })}
-            </p>
+            <div className="mt-1 flex flex-wrap items-center gap-1.5" data-testid="ai-agent-run-sweep-kinds">
+              <span className="text-xs font-medium text-muted-foreground">
+                {t('aiAgentsRuns.detail.sweep.checksLabel')}
+              </span>
+              {run.sweep.kinds.map((kind) => (
+                <span key={kind} className={badgeClass('neutral', { size: 'sm' })}>
+                  {sweepKindLabel(t, kind)}
+                </span>
+              ))}
+            </div>
           )}
 
-          <p className="mt-2 text-sm" data-testid="ai-agent-run-sweep-summary">
+          {/* UI critique finding #1 — the summary had no measure cap and ran
+              to ~188ch lines at the header card's full width. */}
+          <p className="mt-2 max-w-prose text-sm" data-testid="ai-agent-run-sweep-summary">
             {run.sweep.summary}
           </p>
 
@@ -1585,9 +1836,8 @@ export default function RunDetailPage({ runId }: RunDetailPageProps) {
           </p>
         )}
         {run.trace.length === 0 ? (
-          <EmptyState
-            size="sm"
-            headingLevel={3}
+          <InCardEmpty
+            testId="run-detail-trace-empty"
             title={t('aiAgentsPage.runs.detail.trace.empty')}
             description={t('aiAgentsRuns.detail.trace.emptyDescription')}
           />
@@ -1602,52 +1852,37 @@ export default function RunDetailPage({ runId }: RunDetailPageProps) {
 
       <div className="rounded-lg border bg-card p-4">
         <h2 className="text-sm font-semibold">{t('aiAgentsPage.runs.detail.ledger.title')}</h2>
-        {run.ledger.length > 0 && (
-          <p className="mt-1 text-xs text-muted-foreground" data-testid="run-detail-ledger-description">
-            {t('aiAgentsRuns.detail.ledger.description')}
-          </p>
-        )}
         {run.ledger.length === 0 ? (
-          <EmptyState
-            size="sm"
-            headingLevel={3}
+          <InCardEmpty
+            testId="run-detail-ledger-empty"
             title={t('aiAgentsPage.runs.detail.ledger.empty')}
             description={t('aiAgentsRuns.detail.ledger.emptyDescription')}
           />
+        ) : ledgerMatchesTrace ? (
+          // Finding #2 — every row here already appeared, in the same
+          // order, as an `executed` trace entry above. Collapsed rather
+          // than duplicated; still fully present for anyone who opens it.
+          <details className="mt-2" data-testid="run-detail-ledger-details">
+            <summary className="cursor-pointer text-sm text-muted-foreground">
+              {t('aiAgentsRuns.detail.ledger.collapsedSummary', { count: run.ledger.length })}
+            </summary>
+            <LedgerTable ledger={run.ledger} t={t} />
+          </details>
         ) : (
-          <div className="mt-2 overflow-x-auto">
-            <table className="min-w-full divide-y text-sm" data-testid="run-detail-ledger">
-              <thead>
-                <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                  <th className="px-2 py-2">{t('aiAgentsPage.runs.detail.ledger.columns.tool')}</th>
-                  <th className="px-2 py-2">{t('aiAgentsPage.runs.detail.ledger.columns.status')}</th>
-                  <th className="px-2 py-2">{t('aiAgentsPage.runs.detail.ledger.columns.duration')}</th>
-                  <th className="px-2 py-2">{t('aiAgentsPage.runs.detail.ledger.columns.started')}</th>
-                  <th className="px-2 py-2">{t('aiAgentsPage.runs.detail.ledger.columns.error')}</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y">
-                {run.ledger.map((entry, index) => (
-                  <tr key={index}>
-                    <td className="px-2 py-2 font-medium">{entry.toolName}</td>
-                    <td className="px-2 py-2 text-muted-foreground">{ledgerStatusLabel(t, entry.status)}</td>
-                    <td className="px-2 py-2 text-muted-foreground">{formatDuration(entry.durationMs)}</td>
-                    <td className="px-2 py-2 text-muted-foreground">{formatDateTime(entry.createdAt)}</td>
-                    <td className="px-2 py-2 text-destructive">{entry.errorMessage ?? '—'}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+          <>
+            <p className="mt-1 text-xs text-muted-foreground" data-testid="run-detail-ledger-description">
+              {t('aiAgentsRuns.detail.ledger.description')}
+            </p>
+            <LedgerTable ledger={run.ledger} t={t} />
+          </>
         )}
       </div>
 
       <div className="rounded-lg border bg-card p-4">
         <h2 className="text-sm font-semibold">{t('aiAgentsPage.runs.detail.intents.title')}</h2>
         {run.intents.length === 0 ? (
-          <EmptyState
-            size="sm"
-            headingLevel={3}
+          <InCardEmpty
+            testId="run-detail-intents-empty"
             title={t('aiAgentsPage.runs.detail.intents.empty')}
             description={t('aiAgentsRuns.detail.intents.emptyDescription')}
           />

--- a/apps/web/src/components/aiAgents/RunsListPage.test.tsx
+++ b/apps/web/src/components/aiAgents/RunsListPage.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
@@ -36,6 +36,8 @@ const RUN_1 = {
   queuedAt: '2026-08-20T10:00:00.000Z',
   finishedAt: '2026-08-20T10:05:00.000Z',
   costCents: 42,
+  findingsToReview: 0,
+  summaryExcerpt: null as string | null,
 };
 
 const RUN_2 = {
@@ -53,6 +55,8 @@ const RUN_2 = {
   queuedAt: '2026-08-19T10:00:00.000Z',
   finishedAt: null,
   costCents: 0,
+  findingsToReview: 0,
+  summaryExcerpt: null as string | null,
 };
 
 function mockEndpoints(opts: {
@@ -123,14 +127,27 @@ describe('RunsListPage', () => {
   });
 
   it('shows a Clear filters action in the filtered-empty state instead of the settings link', async () => {
-    mockEndpoints({ runs: [] });
+    // Filter chrome is only visible once there is something to filter (see
+    // "RunsListPage filter chrome" below) or a filter is already active, so
+    // this starts from a non-empty list and filters it down to zero.
+    mockEndpoints();
     render(<RunsListPage />);
-    await waitFor(() => expect(screen.getByTestId('runs-list-empty')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByTestId('runs-list-row-run-1')).toBeInTheDocument());
 
+    fetchMock.mockImplementation((url: string) => {
+      if (url.startsWith('/ai/agents/runs')) {
+        expect(url).toContain('status=failed');
+        return Promise.resolve(json({ data: [], nextCursor: null }));
+      }
+      return Promise.resolve(json({ data: [] }));
+    });
     fireEvent.change(screen.getByTestId('runs-list-filter-status'), { target: { value: 'failed' } });
     await waitFor(() => expect(screen.getByText('No runs match these filters.')).toBeInTheDocument());
     expect(screen.queryByText('Configure AI agents')).not.toBeInTheDocument();
     expect(screen.getAllByText('Clear filters').length).toBeGreaterThan(0);
+    // The filter select itself must stay visible so the user can change it
+    // back — only a truly empty, unfiltered list hides the filter chrome.
+    expect(screen.getByTestId('runs-list-filter-status')).toBeInTheDocument();
   });
 
   it('shows a Load more button when a nextCursor is returned, and appends on click', async () => {
@@ -198,7 +215,11 @@ describe('RunsListPage', () => {
 
     await waitFor(() => expect(screen.getByTestId('runs-list-row-run-1')).toBeInTheDocument());
     expect(screen.getByRole('columnheader', { name: 'Organization' })).toBeInTheDocument();
-    expect(screen.getAllByText('Acme Corp')).toHaveLength(2);
+    // Scoped to the table: the mobile card view (jsdom renders both markup
+    // blocks regardless of the `hidden`/`md:hidden` CSS that shows only one
+    // per viewport — see "RunsListPage mobile cards") also shows the org
+    // name once per row, so an unscoped count would double.
+    expect(within(screen.getByTestId('runs-list-table-wrapper')).getAllByText('Acme Corp')).toHaveLength(2);
   });
 
   // Phase 2 wave P2-2 (#4189, Task 14) — a sweep-profile run is a fleet-wide
@@ -759,5 +780,227 @@ describe('RunsListPage polling', () => {
     });
 
     expect(fetchMock.mock.calls.length).toBe(callsAfterLoad);
+  });
+});
+
+// UI critique finding #1 — the Verdict cell must not say "No action needed"
+// while findings are still waiting on a human, mirroring RunDetailPage's
+// `verdictUnderstatesFindings` override.
+describe('RunsListPage findings-to-review override', () => {
+  it('shows a warning "findings to review" badge instead of a no_action verdict, with the real verdict demoted to secondary text', async () => {
+    mockEndpoints({
+      runs: [{ ...RUN_1, runVerdict: 'no_action' as const, findingsToReview: 3 }],
+    });
+    render(<RunsListPage />);
+
+    await waitFor(() => expect(screen.getByTestId('runs-list-findings-badge-run-1')).toBeInTheDocument());
+    expect(screen.getByTestId('runs-list-findings-badge-run-1')).toHaveTextContent('3 findings to review');
+    expect(screen.getByTestId('runs-list-verdict-secondary-run-1')).toHaveTextContent('No action needed');
+  });
+
+  it('overrides any non-failure verdict (not just no_action) when findings are outstanding', async () => {
+    mockEndpoints({
+      runs: [{ ...RUN_1, runVerdict: 'remediated' as const, findingsToReview: 1 }],
+    });
+    render(<RunsListPage />);
+
+    await waitFor(() => expect(screen.getByTestId('runs-list-findings-badge-run-1')).toBeInTheDocument());
+    expect(screen.getByTestId('runs-list-findings-badge-run-1')).toHaveTextContent('1 finding to review');
+    expect(screen.getByTestId('runs-list-verdict-secondary-run-1')).toBeInTheDocument();
+  });
+
+  it('does not override a needs_attention (failure) verdict, which already signals review is needed', async () => {
+    mockEndpoints({
+      runs: [{ ...RUN_1, runVerdict: 'needs_attention' as const, findingsToReview: 2 }],
+    });
+    render(<RunsListPage />);
+
+    await waitFor(() => expect(screen.getByTestId('runs-list-row-run-1')).toBeInTheDocument());
+    expect(screen.queryByTestId('runs-list-findings-badge-run-1')).not.toBeInTheDocument();
+    expect(within(screen.getByTestId('runs-list-row-run-1')).getByText('Needs attention')).toBeInTheDocument();
+  });
+
+  it('renders the plain verdict badge with no override when there are no findings to review', async () => {
+    mockEndpoints({
+      runs: [{ ...RUN_1, runVerdict: 'no_action' as const, findingsToReview: 0 }],
+    });
+    render(<RunsListPage />);
+
+    await waitFor(() => expect(screen.getByTestId('runs-list-row-run-1')).toBeInTheDocument());
+    expect(screen.queryByTestId('runs-list-findings-badge-run-1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('runs-list-verdict-secondary-run-1')).not.toBeInTheDocument();
+    expect(within(screen.getByTestId('runs-list-row-run-1')).getByText('No action needed')).toBeInTheDocument();
+  });
+});
+
+// UI critique finding #2 — a one-line muted excerpt of the agent's own
+// summary, so triage can end at the list without opening every run.
+describe('RunsListPage summary excerpt', () => {
+  it('renders the summary excerpt under the agent name, truncated with line-clamp', async () => {
+    mockEndpoints({
+      runs: [{ ...RUN_1, summaryExcerpt: 'Disk usage on WEB-01 crossed 90% and was cleared.' }],
+    });
+    render(<RunsListPage />);
+
+    await waitFor(() => expect(screen.getByTestId('runs-list-summary-run-1')).toBeInTheDocument());
+    expect(screen.getByTestId('runs-list-summary-run-1')).toHaveTextContent(
+      'Disk usage on WEB-01 crossed 90% and was cleared.',
+    );
+    expect(screen.getByTestId('runs-list-summary-run-1').className).toContain('line-clamp-1');
+  });
+
+  it('renders no excerpt line when summaryExcerpt is null', async () => {
+    mockEndpoints({ runs: [{ ...RUN_1, summaryExcerpt: null }] });
+    render(<RunsListPage />);
+
+    await waitFor(() => expect(screen.getByTestId('runs-list-row-run-1')).toBeInTheDocument());
+    expect(screen.queryByTestId('runs-list-summary-run-1')).not.toBeInTheDocument();
+  });
+});
+
+// UI critique finding #3 — below `md`, the table degrades into stacked
+// cards (mirroring RunDetailPage's SweepFindingCard pattern) rather than a
+// horizontally-scrolling table. Exactly one of the two markup blocks is
+// displayed — and therefore in the a11y tree — at any given viewport.
+describe('RunsListPage mobile cards', () => {
+  it('renders a stacked card per run with agent, org, status, excerpt, and a meta line', async () => {
+    mockEndpoints({
+      runs: [
+        {
+          ...RUN_1,
+          summaryExcerpt: 'Disk usage on WEB-01 crossed 90% and was cleared.',
+        },
+      ],
+    });
+    render(<RunsListPage />);
+
+    await waitFor(() => expect(screen.getByTestId('runs-list-card-run-1')).toBeInTheDocument());
+    const card = screen.getByTestId('runs-list-card-run-1');
+    expect(card).toHaveTextContent('Triage');
+    expect(card).toHaveTextContent('Acme Corp');
+    expect(card).toHaveTextContent('Completed');
+    expect(card).toHaveTextContent('Disk usage on WEB-01 crossed 90% and was cleared.');
+  });
+
+  it('keeps the table markup hidden below md and the card markup hidden from md up', async () => {
+    mockEndpoints({ runs: [RUN_1] });
+    render(<RunsListPage />);
+
+    await waitFor(() => expect(screen.getByTestId('runs-list-table')).toBeInTheDocument());
+    const tableWrapper = screen.getByTestId('runs-list-table').closest('[data-testid="runs-list-table-wrapper"]');
+    expect(tableWrapper).not.toBeNull();
+    expect(tableWrapper!.className).toContain('hidden');
+    expect(tableWrapper!.className).toContain('md:block');
+
+    const cardsWrapper = screen.getByTestId('runs-list-cards');
+    expect(cardsWrapper.className).toContain('md:hidden');
+  });
+
+  it('badges a sweep-profile run on its mobile card too', async () => {
+    mockEndpoints({ runs: [{ ...RUN_1, profile: 'sweep' as const }] });
+    render(<RunsListPage />);
+
+    await waitFor(() => expect(screen.getByTestId('runs-list-card-run-1')).toBeInTheDocument());
+    expect(screen.getByTestId('runs-list-card-profile-sweep-run-1')).toHaveTextContent('Sweep');
+  });
+
+  it('navigates to the run detail page when a card is clicked', async () => {
+    mockEndpoints({ runs: [RUN_1] });
+    const realLocation = window.location;
+    const assign = vi.fn();
+    Object.defineProperty(window, 'location', { configurable: true, value: { ...realLocation, assign } });
+    try {
+      render(<RunsListPage />);
+      await waitFor(() => expect(screen.getByTestId('runs-list-card-run-1')).toBeInTheDocument());
+      fireEvent.click(screen.getByTestId('runs-list-card-run-1'));
+      expect(assign).toHaveBeenCalledWith('/ai-agents/runs/run-1');
+    } finally {
+      Object.defineProperty(window, 'location', { configurable: true, value: realLocation });
+    }
+  });
+});
+
+// UI critique finding #4 — nothing to filter yet, so hide the filter chrome
+// above a truly empty, unfiltered list.
+describe('RunsListPage filter chrome visibility', () => {
+  it('hides the agent/status filters and the cost toggle when there are zero runs and no filter is active', async () => {
+    mockEndpoints({ runs: [] });
+    render(<RunsListPage />);
+
+    await waitFor(() => expect(screen.getByTestId('runs-list-empty')).toBeInTheDocument());
+    expect(screen.queryByTestId('runs-list-filter-agent')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('runs-list-filter-status')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('runs-list-toggle-cost')).not.toBeInTheDocument();
+  });
+
+  it('keeps the filter chrome visible once any run exists', async () => {
+    mockEndpoints();
+    render(<RunsListPage />);
+
+    await waitFor(() => expect(screen.getByTestId('runs-list-row-run-1')).toBeInTheDocument());
+    expect(screen.getByTestId('runs-list-filter-agent')).toBeInTheDocument();
+    expect(screen.getByTestId('runs-list-toggle-cost')).toBeInTheDocument();
+  });
+
+  it('keeps the filter chrome visible with zero runs when a deep-linked filter is already active', async () => {
+    window.history.pushState({}, '', '/ai-agents/runs#agent=a1');
+    mockEndpoints({ runs: [] });
+    try {
+      render(<RunsListPage />);
+      await waitFor(() => expect(screen.getByTestId('runs-list-filter-agent')).toHaveValue('a1'));
+    } finally {
+      window.history.pushState({}, '', '/');
+    }
+  });
+});
+
+// UI critique finding #5 — "Show cost" must read as clearly ON, not merely
+// muted/disabled-looking, once pressed, in both themes.
+describe('RunsListPage cost toggle styling', () => {
+  it('applies a distinct pressed style once Show cost is toggled on', async () => {
+    mockEndpoints({ runs: [RUN_1] });
+    render(<RunsListPage />);
+
+    await waitFor(() => expect(screen.getByTestId('runs-list-toggle-cost')).toBeInTheDocument());
+    const toggle = screen.getByTestId('runs-list-toggle-cost');
+    const idleClassName = toggle.className;
+    expect(idleClassName).not.toContain('text-primary');
+
+    fireEvent.click(toggle);
+    await waitFor(() => expect(toggle).toHaveAttribute('aria-pressed', 'true'));
+    expect(toggle.className).not.toBe(idleClassName);
+    expect(toggle.className).toContain('text-primary');
+  });
+});
+
+// UI critique finding #7 — "Running" (status) and "Sweep" (profile) both
+// used the `info` blue tone, so colour no longer singled out status. Profile
+// chips move to `muted` so status alone carries colour.
+describe('RunsListPage profile chip colour semantics', () => {
+  it('does not give the sweep profile chip the info/blue tone used by a running status', async () => {
+    mockEndpoints({ runs: [{ ...RUN_1, profile: 'sweep' as const }] });
+    render(<RunsListPage />);
+
+    await waitFor(() => expect(screen.getByTestId('ai-agent-run-profile-sweep-run-1')).toBeInTheDocument());
+    expect(screen.getByTestId('ai-agent-run-profile-sweep-run-1').className).not.toContain('blue');
+  });
+});
+
+// UI critique finding #6 — a load-more failure must use its own dedicated
+// copy, not the page-1 load error string.
+describe('RunsListPage load-more error copy', () => {
+  it('shows the load-more-specific error message when appending a page fails', async () => {
+    mockEndpoints({ runs: [RUN_1], nextCursor: 'cursor-a' });
+    render(<RunsListPage />);
+    await waitFor(() => expect(screen.getByTestId('runs-list-load-more')).toBeInTheDocument());
+
+    fetchMock.mockImplementation((url: string) => {
+      if (url.startsWith('/ai/agents/runs')) return Promise.resolve(json({}, false, 500));
+      return Promise.resolve(json({ data: [] }));
+    });
+    fireEvent.click(screen.getByTestId('runs-list-load-more'));
+
+    await waitFor(() => expect(screen.getByTestId('runs-list-load-more-error')).toBeInTheDocument());
+    expect(screen.getByTestId('runs-list-load-more-error')).toHaveTextContent('Could not load more runs.');
   });
 });

--- a/apps/web/src/components/aiAgents/RunsListPage.tsx
+++ b/apps/web/src/components/aiAgents/RunsListPage.tsx
@@ -9,6 +9,7 @@ import { formatCurrency } from '@/lib/i18n/format';
 import { formatTimeAgo } from '@/lib/formatTime';
 import { badgeClass, runStatusTone, verdictTone } from './statusBadge';
 import { EmptyState } from '../shared/EmptyState';
+import { PageHeader } from '../shared/PageHeader';
 import type { AiAgentRunListItemDto, AiAgentRunStatus } from '@breeze/shared';
 import { AI_AGENT_RUN_STATUSES } from '@breeze/shared';
 
@@ -133,9 +134,9 @@ const LIST_IDLE_POLL_INTERVAL_MS = 30_000;
  * sr-only label here so an accessibility tree still names what the dot means
  * for a screen-reader user who tabs to it.
  */
-function LiveIndicator({ label }: { label: string }) {
+function LiveIndicator({ label, testId = 'run-live-indicator' }: { label: string; testId?: string }) {
   return (
-    <span className="ml-1.5 inline-flex items-center" data-testid="run-live-indicator">
+    <span className="ml-1.5 inline-flex items-center" data-testid={testId}>
       <span className="relative flex h-2 w-2" aria-hidden="true">
         <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-sky-500 opacity-75" />
         <span className="relative inline-flex h-2 w-2 rounded-full bg-sky-500" />
@@ -200,6 +201,205 @@ function triggerLabel(t: (key: string) => string, value: string): string {
     default:
       return value;
   }
+}
+
+/** Loose local alias — the shared badges/cells below need the optional
+ *  interpolation-options overload (`{{count}}`) that the narrower
+ *  single-arg `t` type used by the literal-key label lookups doesn't carry. */
+type TFn = (key: string, options?: Record<string, unknown>) => string;
+
+/**
+ * UI critique finding #1 — mirrors RunDetailPage's `verdictUnderstatesFindings`:
+ * a `no_action`-and-similar verdict must not read as "nothing to see here"
+ * when the run actually left findings for a human to review. Broadened from
+ * RunDetailPage's `runVerdict === 'no_action'` check to any verdict whose
+ * tone isn't already `danger` — `needs_attention` already signals "this
+ * needs review" on its own, so it's the one verdict the override leaves
+ * alone.
+ */
+function findingsOverrideActive(run: AiAgentRunListItemDto): boolean {
+  return run.findingsToReview > 0 && verdictTone(run.runVerdict ?? '') !== 'danger';
+}
+
+/**
+ * The three mutually-exclusive run-profile chips (sweep/narrative/triage),
+ * shared between the desktop table row and the mobile card so both surfaces
+ * stay in sync. `idPrefix` keeps mobile-card testids distinct from the
+ * desktop table's (`ai-agent-run-profile-*`) so `getByTestId` in tests never
+ * matches two elements at once — only one of the two surfaces is visible at
+ * a given viewport, but both exist in the jsdom tree.
+ *
+ * UI critique finding #7 — all three chips use the `muted` tone (not
+ * `info`), so a blue "Running" status badge is the only blue signal in a
+ * row; without this, "Running" (status) and "Sweep" (profile) both read as
+ * the same blue and colour stopped meaning anything specific.
+ */
+function ProfileBadges({
+  run,
+  t,
+  idPrefix,
+}: {
+  run: AiAgentRunListItemDto;
+  t: TFn;
+  idPrefix: string;
+}) {
+  return (
+    <>
+      {run.profile === 'sweep' && (
+        <span
+          data-testid={`${idPrefix}-profile-sweep-${run.id}`}
+          className={badgeClass('muted', { size: 'sm' })}
+        >
+          {t('aiAgentsPage.runs.profile.sweep')}
+        </span>
+      )}
+      {/* Phase 2 wave P2-3 (#4190) — a narrative-profile run is the weekly
+          org report, not a device outcome; the badge is what tells the two
+          apart in a mixed list. */}
+      {run.profile === 'narrative' && (
+        <span
+          data-testid={`${idPrefix}-profile-narrative-${run.id}`}
+          className={badgeClass('muted', { size: 'sm' })}
+        >
+          {t('aiAgentsPage.runs.profile.narrative')}
+        </span>
+      )}
+      {/* Phase 2 wave P2-4 (#4191, Task 12) — a triage-profile run is a
+          ticket outcome, not a device incident; same "tell the two apart in
+          a mixed list" rationale as the sweep/narrative badges above. */}
+      {run.profile === 'triage' && (
+        <span
+          data-testid={`${idPrefix}-profile-triage-${run.id}`}
+          className={badgeClass('muted', { size: 'sm' })}
+        >
+          {t('aiAgentsPage.runs.profile.triage')}
+        </span>
+      )}
+    </>
+  );
+}
+
+/**
+ * The Verdict badge alone (no layout wrapper) — shared between the desktop
+ * table cell and the mobile card, which each place it in a different
+ * surrounding flex row (the mobile card's combines it with the status
+ * badge; the desktop table cell keeps status in its own column). Renders
+ * the findings-to-review override (finding #1) when active; the caller is
+ * responsible for rendering the demoted verdict as secondary text alongside
+ * it via `findingsOverrideActive` + `verdictLabel`.
+ */
+function VerdictBadge({ run, t, idPrefix }: { run: AiAgentRunListItemDto; t: TFn; idPrefix: string }) {
+  return (
+    <span data-testid={`${idPrefix}-verdict-${run.id}`}>
+      {findingsOverrideActive(run) ? (
+        <span
+          data-testid={`${idPrefix}-findings-badge-${run.id}`}
+          className={badgeClass('warning', { size: 'sm' })}
+        >
+          {t('aiAgentsRuns.detail.findings.badge', { count: run.findingsToReview })}
+        </span>
+      ) : (
+        <span className={badgeClass(verdictTone(run.runVerdict ?? ''), { size: 'sm' })}>
+          {verdictLabel(t, run.runVerdict)}
+        </span>
+      )}
+    </span>
+  );
+}
+
+/** The real verdict, demoted to secondary muted text once the findings
+ *  override above has taken its place as the primary badge (finding #1). */
+function VerdictSecondary({ run, t, idPrefix }: { run: AiAgentRunListItemDto; t: TFn; idPrefix: string }) {
+  if (!findingsOverrideActive(run)) return null;
+  return (
+    <div data-testid={`${idPrefix}-verdict-secondary-${run.id}`} className="mt-1 text-xs text-muted-foreground">
+      {verdictLabel(t, run.runVerdict)}
+    </div>
+  );
+}
+
+/**
+ * UI critique finding #3 — the mobile equivalent of a table row: stacked
+ * card (agent + org / status + verdict + profile chips / excerpt / a muted
+ * meta line), mirroring `SweepFindingCard`'s table→card degradation pattern
+ * in RunDetailPage. Shares `VerdictBadge`/`ProfileBadges` with the desktop
+ * table cell so the two surfaces never drift; `idPrefix` keeps this card's
+ * testids distinct from the table row's so `getByTestId` never matches two
+ * elements — only one of the two surfaces is visible (and in the a11y
+ * tree) at a given viewport, via `hidden`/`md:hidden`, but both exist in
+ * the jsdom tree.
+ */
+function RunCard({
+  run,
+  t,
+  showCost,
+  onNavigate,
+}: {
+  run: AiAgentRunListItemDto;
+  t: TFn;
+  showCost: boolean;
+  onNavigate: (runId: string) => void;
+}) {
+  const live = isLiveRunStatus(run.status);
+  return (
+    <li
+      data-testid={`runs-list-card-${run.id}`}
+      className="cursor-pointer rounded-lg border bg-card p-3 text-sm"
+      onClick={() => onNavigate(run.id)}
+    >
+      {/* Line 1: agent + org. */}
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <a
+          href={`/ai-agents/runs/${run.id}`}
+          data-testid={`runs-list-card-link-${run.id}`}
+          className="font-medium text-primary hover:underline"
+          onClick={(event) => event.stopPropagation()}
+        >
+          {run.agentName ?? t('aiAgentsPage.runs.noAgent')}
+        </a>
+        <span className="text-xs text-muted-foreground">{run.orgName ?? '—'}</span>
+      </div>
+
+      {/* Line 2: status + findings/verdict + profile chips. */}
+      <div className="mt-2 flex flex-wrap items-center gap-1.5">
+        <span
+          className={badgeClass(runStatusTone(run.status), { size: 'sm' })}
+          aria-live={live ? 'polite' : undefined}
+        >
+          {statusLabel(t, run.status)}
+        </span>
+        {live && (
+          <LiveIndicator label={t('aiAgentsRuns.live.label')} testId={`runs-list-card-live-indicator-${run.id}`} />
+        )}
+        <VerdictBadge run={run} t={t} idPrefix="runs-list-card" />
+        <ProfileBadges run={run} t={t} idPrefix="runs-list-card" />
+      </div>
+      <VerdictSecondary run={run} t={t} idPrefix="runs-list-card" />
+
+      {/* Line 3: the agent's own excerpt, when it has one. */}
+      {run.summaryExcerpt && (
+        <p
+          data-testid={`runs-list-card-summary-${run.id}`}
+          className="mt-1.5 line-clamp-1 text-xs text-muted-foreground"
+        >
+          {run.summaryExcerpt}
+        </p>
+      )}
+
+      {/* Muted meta line: started / duration (/ cost when toggled on). */}
+      <div className="mt-2 flex flex-wrap items-center gap-x-1.5 text-xs text-muted-foreground">
+        <StartedCell queuedAt={run.queuedAt} />
+        <span aria-hidden="true">·</span>
+        <span>{formatRunDuration(run.queuedAt, run.finishedAt)}</span>
+        {showCost && (
+          <>
+            <span aria-hidden="true">·</span>
+            <span data-testid={`runs-list-card-cost-${run.id}`}>{formatCurrency(run.costCents / 100)}</span>
+          </>
+        )}
+      </div>
+    </li>
+  );
 }
 
 /**
@@ -380,7 +580,11 @@ export default function RunsListPage() {
         const response = await fetchWithAuth(`/ai/agents/runs?${params.toString()}`);
         if (requestId !== requestIdRef.current) return;
         if (!response.ok) {
-          const message = t('aiAgentsPage.runs.errors.load', { status: response.status });
+          // UI critique finding #6 — a "Load more" failure gets its own
+          // copy, distinct from the page-1 load error it used to reuse.
+          const message = append
+            ? t('aiAgentsPage.runs.errors.loadMore')
+            : t('aiAgentsPage.runs.errors.load', { status: response.status });
           if (append) setLoadMoreError(message);
           else setError(message);
           return;
@@ -390,7 +594,9 @@ export default function RunsListPage() {
         if (!Array.isArray(body.data)) {
           // A body we cannot read is an error, not zero runs — same lesson as
           // AiAgentsPage's `?? []` regression.
-          const message = t('aiAgentsPage.runs.errors.load', { status: response.status });
+          const message = append
+            ? t('aiAgentsPage.runs.errors.loadMore')
+            : t('aiAgentsPage.runs.errors.load', { status: response.status });
           if (append) setLoadMoreError(message);
           else setError(message);
           return;
@@ -400,7 +606,11 @@ export default function RunsListPage() {
         setNextCursor(body.nextCursor ?? null);
       } catch (err) {
         if (requestId !== requestIdRef.current) return;
-        const message = err instanceof Error ? err.message : t('aiAgentsPage.runs.errors.load', { status: 0 });
+        const message = append
+          ? t('aiAgentsPage.runs.errors.loadMore')
+          : err instanceof Error
+            ? err.message
+            : t('aiAgentsPage.runs.errors.load', { status: 0 });
         if (append) setLoadMoreError(message);
         else setError(message);
       } finally {
@@ -493,70 +703,85 @@ export default function RunsListPage() {
     window.location.assign(`/ai-agents/runs/${runId}`);
   }, []);
 
+  // UI critique finding #4 — a truly empty, unfiltered list has nothing to
+  // filter yet, so the agent/status selects and the cost toggle only add
+  // noise above the empty state's own configure-agents CTA. Still shown
+  // while loading (we don't yet know the count) or erroring, and shown the
+  // moment ANY filter is active (e.g. a deep link into a zero-total org) so
+  // the active filter and its Clear affordance stay visible.
+  const showFilterChrome = loading || Boolean(error) || runs.length > 0 || hasActiveFilter;
+
   return (
     <div className="space-y-6" data-testid="runs-list-page">
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <h1 className="flex items-center gap-2 text-xl font-semibold tracking-tight">
-            <History className="h-5 w-5" />
-            {t('aiAgentsPage.runs.title')}
-          </h1>
-          <p className="text-muted-foreground">{t('aiAgentsPage.runs.description')}</p>
-        </div>
+      <PageHeader
+        testId="runs-list-header"
+        icon={<History className="h-5 w-5" />}
+        title={t('aiAgentsPage.runs.title')}
+        description={t('aiAgentsPage.runs.description')}
+        actions={
+          showFilterChrome ? (
+            <>
+              <select
+                data-testid="runs-list-filter-agent"
+                aria-label={t('aiAgentsPage.runs.filters.agent')}
+                value={agentFilter}
+                onChange={(event) => setAgentFilter(event.target.value)}
+                className="rounded-md border bg-background px-3 py-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-primary/20"
+              >
+                <option value="">{t('aiAgentsPage.runs.filters.allAgents')}</option>
+                {agents.map((agent) => (
+                  <option key={agent.id} value={agent.id}>
+                    {agent.name}
+                  </option>
+                ))}
+              </select>
 
-        <div className="flex flex-wrap items-center gap-3">
-          <select
-            data-testid="runs-list-filter-agent"
-            aria-label={t('aiAgentsPage.runs.filters.agent')}
-            value={agentFilter}
-            onChange={(event) => setAgentFilter(event.target.value)}
-            className="rounded-md border bg-background px-3 py-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-primary/20"
-          >
-            <option value="">{t('aiAgentsPage.runs.filters.allAgents')}</option>
-            {agents.map((agent) => (
-              <option key={agent.id} value={agent.id}>
-                {agent.name}
-              </option>
-            ))}
-          </select>
+              <select
+                data-testid="runs-list-filter-status"
+                aria-label={t('aiAgentsPage.runs.filters.status')}
+                value={statusFilter}
+                onChange={(event) => setStatusFilter(event.target.value as AiAgentRunStatus | '')}
+                className="rounded-md border bg-background px-3 py-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-primary/20"
+              >
+                <option value="">{t('aiAgentsPage.runs.filters.allStatuses')}</option>
+                {AI_AGENT_RUN_STATUSES.map((value) => (
+                  <option key={value} value={value}>
+                    {statusLabel(t, value)}
+                  </option>
+                ))}
+              </select>
 
-          <select
-            data-testid="runs-list-filter-status"
-            aria-label={t('aiAgentsPage.runs.filters.status')}
-            value={statusFilter}
-            onChange={(event) => setStatusFilter(event.target.value as AiAgentRunStatus | '')}
-            className="rounded-md border bg-background px-3 py-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-primary/20"
-          >
-            <option value="">{t('aiAgentsPage.runs.filters.allStatuses')}</option>
-            {AI_AGENT_RUN_STATUSES.map((value) => (
-              <option key={value} value={value}>
-                {statusLabel(t, value)}
-              </option>
-            ))}
-          </select>
+              {hasActiveFilter && (
+                <button
+                  type="button"
+                  data-testid="runs-list-clear-filters"
+                  onClick={clearFilters}
+                  className="text-sm text-muted-foreground hover:text-foreground hover:underline"
+                >
+                  {t('aiAgentsRuns.list.clearFilters')}
+                </button>
+              )}
 
-          {hasActiveFilter && (
-            <button
-              type="button"
-              data-testid="runs-list-clear-filters"
-              onClick={clearFilters}
-              className="text-sm text-muted-foreground hover:text-foreground hover:underline"
-            >
-              {t('aiAgentsRuns.list.clearFilters')}
-            </button>
-          )}
-
-          <button
-            type="button"
-            data-testid="runs-list-toggle-cost"
-            aria-pressed={showCost}
-            onClick={toggleShowCost}
-            className="rounded-md border px-3 py-2 text-sm text-muted-foreground hover:bg-muted hover:text-foreground"
-          >
-            {showCost ? t('aiAgentsRuns.list.hideCost') : t('aiAgentsRuns.list.showCost')}
-          </button>
-        </div>
-      </div>
+              {/* UI critique finding #5 — a pressed toggle must read as
+                  clearly ON (not merely muted-foreground, which reads as
+                  disabled in dark mode) in both themes. */}
+              <button
+                type="button"
+                data-testid="runs-list-toggle-cost"
+                aria-pressed={showCost}
+                onClick={toggleShowCost}
+                className={`rounded-md border px-3 py-2 text-sm font-medium transition-colors ${
+                  showCost
+                    ? 'border-primary/50 bg-primary/10 text-primary'
+                    : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                }`}
+              >
+                {showCost ? t('aiAgentsRuns.list.hideCost') : t('aiAgentsRuns.list.showCost')}
+              </button>
+            </>
+          ) : undefined
+        }
+      />
 
       {loading && (
         <p className="text-sm text-muted-foreground" data-testid="runs-list-loading">
@@ -614,112 +839,111 @@ export default function RunsListPage() {
       )}
 
       {!loading && !error && runs.length > 0 && (
-        <div className="overflow-hidden rounded-lg border">
-          <div className="overflow-x-auto">
-            <table className="min-w-full divide-y" data-testid="runs-list-table">
-              <thead className="bg-muted/40">
-                <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                  <th className="px-4 py-3">{t('aiAgentsPage.runs.columns.agent')}</th>
-                  {/* Review finding #2: this column's cell renders `orgName`
-                      — the list DTO has no device hostname to "target" — so
-                      the header says Organization, reusing the shared
-                      vocabulary key rather than a private "Target" label
-                      that never matched what the column actually shows. */}
-                  <th className="px-4 py-3">{t('common:labels.organization')}</th>
-                  <th className="px-4 py-3">{t('aiAgentsPage.runs.columns.status')}</th>
-                  <th className="px-4 py-3">{t('aiAgentsPage.runs.columns.trigger')}</th>
-                  <th className="px-4 py-3">{t('aiAgentsPage.runs.columns.verdict')}</th>
-                  <th className="px-4 py-3">{t('aiAgentsRuns.list.columns.started')}</th>
-                  <th className="px-4 py-3">{t('aiAgentsRuns.list.columns.duration')}</th>
-                  {showCost && <th className="px-4 py-3">{t('aiAgentsPage.runs.columns.cost')}</th>}
-                </tr>
-              </thead>
-              <tbody className="divide-y">
-                {runs.map((run) => {
-                  const live = isLiveRunStatus(run.status);
-                  return (
-                    <tr
-                      key={run.id}
-                      data-testid={`runs-list-row-${run.id}`}
-                      className="cursor-pointer text-sm hover:bg-muted/30"
-                      onClick={() => handleRowNavigate(run.id)}
-                    >
-                      <td className="px-4 py-3 font-medium">
-                        <a
-                          href={`/ai-agents/runs/${run.id}`}
-                          data-testid={`runs-list-row-link-${run.id}`}
-                          className="text-primary hover:underline"
-                          onClick={(event) => event.stopPropagation()}
-                        >
-                          {run.agentName ?? t('aiAgentsPage.runs.noAgent')}
-                        </a>
-                      </td>
-                      <td className="px-4 py-3 text-muted-foreground">{run.orgName ?? '—'}</td>
-                      <td className="px-4 py-3">
-                        <span
-                          className={badgeClass(runStatusTone(run.status), { size: 'sm' })}
-                          aria-live={live ? 'polite' : undefined}
-                        >
-                          {statusLabel(t, run.status)}
-                        </span>
-                        {live && <LiveIndicator label={t('aiAgentsRuns.live.label')} />}
-                      </td>
-                      <td className="px-4 py-3 text-muted-foreground">{triggerLabel(t, run.triggerKind)}</td>
-                      <td className="px-4 py-3">
-                        <span className={badgeClass(verdictTone(run.runVerdict ?? ''), { size: 'sm' })}>
-                          {verdictLabel(t, run.runVerdict)}
-                        </span>
-                        {run.profile === 'sweep' && (
-                          <span
-                            data-testid={`ai-agent-run-profile-sweep-${run.id}`}
-                            className={`ml-1.5 ${badgeClass('info', { size: 'sm' })}`}
+        <>
+          {/* UI critique finding #3 — below `md` the table degrades into
+              stacked cards (mirroring RunDetailPage's sweep-findings
+              table→card pattern) instead of a horizontally-scrolling table.
+              Exactly one of the two blocks is displayed — and therefore in
+              the a11y tree — at a given viewport via `hidden`/`md:hidden`. */}
+          <div
+            data-testid="runs-list-table-wrapper"
+            className="hidden overflow-hidden rounded-lg border md:block"
+          >
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y" data-testid="runs-list-table">
+                <thead className="bg-muted/40">
+                  <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    <th className="px-4 py-3">{t('aiAgentsPage.runs.columns.agent')}</th>
+                    {/* Review finding #2: this column's cell renders `orgName`
+                        — the list DTO has no device hostname to "target" — so
+                        the header says Organization, reusing the shared
+                        vocabulary key rather than a private "Target" label
+                        that never matched what the column actually shows. */}
+                    <th className="px-4 py-3">{t('common:labels.organization')}</th>
+                    <th className="px-4 py-3">{t('aiAgentsPage.runs.columns.status')}</th>
+                    <th className="px-4 py-3">{t('aiAgentsPage.runs.columns.trigger')}</th>
+                    <th className="px-4 py-3">{t('aiAgentsPage.runs.columns.verdict')}</th>
+                    <th className="px-4 py-3">{t('aiAgentsRuns.list.columns.started')}</th>
+                    <th className="px-4 py-3">{t('aiAgentsRuns.list.columns.duration')}</th>
+                    {showCost && <th className="px-4 py-3">{t('aiAgentsPage.runs.columns.cost')}</th>}
+                  </tr>
+                </thead>
+                <tbody className="divide-y">
+                  {runs.map((run) => {
+                    const live = isLiveRunStatus(run.status);
+                    return (
+                      <tr
+                        key={run.id}
+                        data-testid={`runs-list-row-${run.id}`}
+                        className="cursor-pointer text-sm hover:bg-muted/30"
+                        onClick={() => handleRowNavigate(run.id)}
+                      >
+                        <td className="px-4 py-3 font-medium">
+                          <a
+                            href={`/ai-agents/runs/${run.id}`}
+                            data-testid={`runs-list-row-link-${run.id}`}
+                            className="text-primary hover:underline"
+                            onClick={(event) => event.stopPropagation()}
                           >
-                            {t('aiAgentsPage.runs.profile.sweep')}
-                          </span>
-                        )}
-                        {/* Phase 2 wave P2-3 (#4190) — a narrative-profile
-                            run is the weekly org report, not a device
-                            outcome; the badge is what tells the two apart in
-                            a mixed list. */}
-                        {run.profile === 'narrative' && (
-                          <span
-                            data-testid={`ai-agent-run-profile-narrative-${run.id}`}
-                            className={`ml-1.5 ${badgeClass('accent', { size: 'sm' })}`}
-                          >
-                            {t('aiAgentsPage.runs.profile.narrative')}
-                          </span>
-                        )}
-                        {/* Phase 2 wave P2-4 (#4191, Task 12) — a triage-profile
-                            run is a ticket outcome, not a device incident; same
-                            "tell the two apart in a mixed list" rationale as
-                            the sweep/narrative badges above. */}
-                        {run.profile === 'triage' && (
-                          <span
-                            data-testid={`ai-agent-run-profile-triage-${run.id}`}
-                            className={`ml-1.5 ${badgeClass('muted', { size: 'sm' })}`}
-                          >
-                            {t('aiAgentsPage.runs.profile.triage')}
-                          </span>
-                        )}
-                      </td>
-                      <td className="px-4 py-3 whitespace-nowrap text-muted-foreground">
-                        <StartedCell queuedAt={run.queuedAt} />
-                      </td>
-                      <td className="px-4 py-3 whitespace-nowrap text-muted-foreground">
-                        {formatRunDuration(run.queuedAt, run.finishedAt)}
-                      </td>
-                      {showCost && (
-                        <td className="px-4 py-3 whitespace-nowrap text-muted-foreground">
-                          {formatCurrency(run.costCents / 100)}
+                            {run.agentName ?? t('aiAgentsPage.runs.noAgent')}
+                          </a>
+                          {/* UI critique finding #2 — the agent's own
+                              one-line excerpt, so triage can end at the list
+                              without opening every run. */}
+                          {run.summaryExcerpt && (
+                            <p
+                              data-testid={`runs-list-summary-${run.id}`}
+                              className="line-clamp-1 max-w-xs font-normal text-xs text-muted-foreground"
+                            >
+                              {run.summaryExcerpt}
+                            </p>
+                          )}
                         </td>
-                      )}
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
+                        <td className="px-4 py-3 text-muted-foreground">{run.orgName ?? '—'}</td>
+                        <td className="px-4 py-3">
+                          <span
+                            className={badgeClass(runStatusTone(run.status), { size: 'sm' })}
+                            aria-live={live ? 'polite' : undefined}
+                          >
+                            {statusLabel(t, run.status)}
+                          </span>
+                          {live && <LiveIndicator label={t('aiAgentsRuns.live.label')} />}
+                        </td>
+                        <td className="px-4 py-3 text-muted-foreground">{triggerLabel(t, run.triggerKind)}</td>
+                        <td className="px-4 py-3">
+                          <div className="flex flex-wrap items-center gap-1.5">
+                            <VerdictBadge run={run} t={t} idPrefix="runs-list" />
+                            {/* `ai-agent-run` prefix preserved — pre-existing
+                                testids these profile chips have always used. */}
+                            <ProfileBadges run={run} t={t} idPrefix="ai-agent-run" />
+                          </div>
+                          <VerdictSecondary run={run} t={t} idPrefix="runs-list" />
+                        </td>
+                        <td className="px-4 py-3 whitespace-nowrap text-muted-foreground">
+                          <StartedCell queuedAt={run.queuedAt} />
+                        </td>
+                        <td className="px-4 py-3 whitespace-nowrap text-muted-foreground">
+                          {formatRunDuration(run.queuedAt, run.finishedAt)}
+                        </td>
+                        {showCost && (
+                          <td className="px-4 py-3 whitespace-nowrap text-muted-foreground">
+                            {formatCurrency(run.costCents / 100)}
+                          </td>
+                        )}
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
           </div>
-        </div>
+
+          <ul className="space-y-3 md:hidden" data-testid="runs-list-cards">
+            {runs.map((run) => (
+              <RunCard key={run.id} run={run} t={t} showCost={showCost} onNavigate={handleRowNavigate} />
+            ))}
+          </ul>
+        </>
       )}
 
       {!loading && !error && nextCursor && (

--- a/apps/web/src/components/approvals/ApprovalsInbox.test.tsx
+++ b/apps/web/src/components/approvals/ApprovalsInbox.test.tsx
@@ -1223,4 +1223,234 @@ describe('ApprovalsInbox — organization identity, live expiry, paging, and cop
       ),
     );
   });
+
+  it('renders "Expires in under a minute" instead of a misleading unit below 60s', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-23T12:00:00.000Z'));
+    routeFetch([{ ...pendingApproval, expiresAt: '2026-08-23T12:00:45.000Z' }]);
+    render(<ApprovalsInbox />);
+    await act(async () => {});
+
+    expect(screen.getByTestId('approval-expiry-approval-1')).toHaveTextContent(
+      'Expires in under a minute',
+    );
+  });
+});
+
+describe('ApprovalsInbox — organization filter, search, and sort (findings #1)', () => {
+  it('lists distinct organizations with per-org counts, defaulting to "All organizations"', async () => {
+    routeFetch([
+      { ...pendingApproval, id: 'r1', orgId: 'org-1', orgName: 'Acme' },
+      { ...pendingApproval, id: 'r2', orgId: 'org-2', orgName: 'Contoso' },
+      { ...pendingApproval, id: 'r3', orgId: 'org-1', orgName: 'Acme' },
+    ]);
+    render(<ApprovalsInbox />);
+    await screen.findByTestId('approval-row-r3');
+
+    const select = screen.getByTestId('approvals-filter-org') as HTMLSelectElement;
+    const optionTexts = Array.from(select.options).map((option) => option.textContent);
+    expect(optionTexts).toContain('All organizations (3)');
+    expect(optionTexts).toContain('Acme (2 pending)');
+    expect(optionTexts).toContain('Contoso (1 pending)');
+    expect(select.value).toBe('');
+  });
+
+  it('filters to one organization while every other org disappears', async () => {
+    routeFetch([
+      { ...pendingApproval, id: 'r1', orgId: 'org-1', orgName: 'Acme' },
+      { ...pendingApproval, id: 'r2', orgId: 'org-2', orgName: 'Contoso' },
+    ]);
+    render(<ApprovalsInbox />);
+    await screen.findByTestId('approval-row-r2');
+
+    fireEvent.change(screen.getByTestId('approvals-filter-org'), {
+      target: { value: 'org-2' },
+    });
+
+    expect(screen.queryByTestId('approval-row-r1')).not.toBeInTheDocument();
+    expect(screen.getByTestId('approval-row-r2')).toBeInTheDocument();
+  });
+
+  it('searches over the action label, target hostname, and agent name', async () => {
+    routeFetch([
+      {
+        ...pendingApproval,
+        id: 'r1',
+        actionLabel: 'Restart accounting server',
+        targetDevice: null,
+        agentName: null,
+      },
+      {
+        ...pendingApproval,
+        id: 'r2',
+        actionLabel: 'Install patch',
+        targetDevice: { id: 'd2', hostname: 'HOST-42' },
+        agentName: null,
+      },
+      {
+        ...pendingApproval,
+        id: 'r3',
+        actionLabel: 'Deploy script',
+        targetDevice: null,
+        agentName: 'Patch Sweep',
+      },
+    ]);
+    render(<ApprovalsInbox />);
+    await screen.findByTestId('approval-row-r3');
+
+    fireEvent.change(screen.getByTestId('approvals-filter-search'), {
+      target: { value: 'host-42' },
+    });
+    expect(screen.getByTestId('approval-row-r2')).toBeInTheDocument();
+    expect(screen.queryByTestId('approval-row-r1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('approval-row-r3')).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId('approvals-filter-search'), {
+      target: { value: 'patch sweep' },
+    });
+    expect(screen.getByTestId('approval-row-r3')).toBeInTheDocument();
+    expect(screen.queryByTestId('approval-row-r2')).not.toBeInTheDocument();
+  });
+
+  it('honestly shows "Showing N of M loaded" only once a filter narrows the loaded set', async () => {
+    routeFetch([
+      { ...pendingApproval, id: 'r1', orgId: 'org-1', orgName: 'Acme' },
+      { ...pendingApproval, id: 'r2', orgId: 'org-2', orgName: 'Contoso' },
+    ]);
+    render(<ApprovalsInbox />);
+    await screen.findByTestId('approval-row-r2');
+
+    expect(screen.queryByTestId('approvals-filter-summary')).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId('approvals-filter-org'), {
+      target: { value: 'org-1' },
+    });
+
+    expect(screen.getByTestId('approvals-filter-summary')).toHaveTextContent(
+      'Showing 1 of 2 loaded',
+    );
+  });
+
+  it('sorts by expiring soonest (default) and by newest', async () => {
+    routeFetch([
+      {
+        ...pendingApproval,
+        id: 'soon',
+        expiresAt: '2026-08-23T12:05:00.000Z',
+        createdAt: '2026-08-23T11:00:00.000Z',
+      },
+      {
+        ...pendingApproval,
+        id: 'later',
+        expiresAt: '2026-08-23T13:00:00.000Z',
+        createdAt: '2026-08-23T11:30:00.000Z',
+      },
+    ]);
+    render(<ApprovalsInbox />);
+    await screen.findByTestId('approval-row-later');
+
+    let order = screen
+      .getAllByTestId(/^approval-row-/)
+      .map((el) => el.getAttribute('data-testid'));
+    expect(order).toEqual(['approval-row-soon', 'approval-row-later']);
+
+    fireEvent.click(screen.getByTestId('approvals-sort-newest'));
+
+    order = screen.getAllByTestId(/^approval-row-/).map((el) => el.getAttribute('data-testid'));
+    expect(order).toEqual(['approval-row-later', 'approval-row-soon']);
+  });
+
+  it('shows a distinct "no matches" empty state when filters exclude everything, with a working Clear filters', async () => {
+    routeFetch([{ ...pendingApproval, actionLabel: 'Restart accounting server' }]);
+    render(<ApprovalsInbox />);
+    await screen.findByTestId('approval-row-approval-1');
+
+    fireEvent.change(screen.getByTestId('approvals-filter-search'), {
+      target: { value: 'no such action' },
+    });
+
+    const empty = await screen.findByTestId('approvals-filtered-empty');
+    expect(empty).toHaveTextContent('No approvals match your filters');
+    expect(screen.queryByTestId('approvals-empty')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('approvals-filtered-empty-clear'));
+
+    expect(await screen.findByTestId('approval-row-approval-1')).toBeInTheDocument();
+    expect((screen.getByTestId('approvals-filter-search') as HTMLInputElement).value).toBe('');
+  });
+});
+
+describe('ApprovalsInbox — batch scope naming (finding #2)', () => {
+  it('lists the group\'s target hostnames on the header, with a "+K more" tail past the cap', async () => {
+    const members = Array.from({ length: 8 }, (_, i) =>
+      agentCard(`ap-${i}`, { targetDevice: { id: `device-${i}`, hostname: `HOST-${i}` } }),
+    );
+    routeFetch(members);
+    render(<ApprovalsInbox />);
+
+    const hostnames = await screen.findByTestId(`approval-group-hostnames-${GROUP_KEY}`);
+    for (let i = 0; i < 6; i += 1) {
+      expect(hostnames).toHaveTextContent(`HOST-${i}`);
+    }
+    expect(hostnames).not.toHaveTextContent('HOST-6');
+    expect(hostnames).not.toHaveTextContent('HOST-7');
+    expect(hostnames).toHaveTextContent('+2 more');
+  });
+
+  it('restates the count and organization on the group deny confirm step', async () => {
+    routeFetch([
+      agentCard('ap-a', { orgName: 'Acme Dental' }),
+      agentCard('ap-b', { orgName: 'Acme Dental' }),
+    ]);
+    render(<ApprovalsInbox />);
+    await screen.findByTestId(`approval-group-${GROUP_KEY}`);
+
+    fireEvent.click(screen.getByTestId(`approval-group-decline-${GROUP_KEY}`));
+
+    expect(screen.getByTestId(`approval-group-deny-summary-${GROUP_KEY}`)).toHaveTextContent(
+      'This declines 2 requests for Acme Dental.',
+    );
+  });
+});
+
+describe('ApprovalsInbox — client-side expiry refusal at click time (finding #3)', () => {
+  it('refuses an approve click the instant expiry passes, even before the next 10s tick', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-23T12:00:00.000Z'));
+    routeFetch([{ ...pendingApproval, expiresAt: '2026-08-23T12:00:03.000Z' }]);
+    render(<ApprovalsInbox />);
+    await act(async () => {});
+
+    // The wall clock has moved PAST expiry, but by less than
+    // EXPIRY_TICK_MS (10s) — the ticking `now` state has not caught up yet,
+    // so the button's own `disabled` attribute is still stale-enabled.
+    vi.setSystemTime(new Date('2026-08-23T12:00:05.000Z'));
+    expect(screen.getByTestId('approval-approve-approval-1')).toBeEnabled();
+
+    // The guard runs synchronously before `decide`'s first `await`, so the
+    // error state is already committed by the time `fireEvent.click`
+    // returns — asserting via `findByTestId` here would wait on a real
+    // `setTimeout` that fake timers never advance, and time out.
+    fireEvent.click(screen.getByTestId('approval-approve-approval-1'));
+
+    expect(screen.getByTestId('approval-error-approval-1')).toHaveTextContent('expired');
+    expect(intentApprovalsMock.decide).not.toHaveBeenCalled();
+  });
+
+  it('refuses a group approve click the same way when any member has expired', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-23T12:00:00.000Z'));
+    routeFetch([
+      agentCard('ap-a', { expiresAt: '2026-08-23T12:00:03.000Z' }),
+      agentCard('ap-b', { expiresAt: '2026-08-23T12:10:00.000Z' }),
+    ]);
+    render(<ApprovalsInbox />);
+    await act(async () => {});
+
+    vi.setSystemTime(new Date('2026-08-23T12:00:05.000Z'));
+    fireEvent.click(screen.getByTestId(`approval-group-approve-${GROUP_KEY}`));
+
+    expect(screen.getByTestId(`approval-group-error-${GROUP_KEY}`)).toHaveTextContent('expired');
+    expect(batchCalls()).toHaveLength(0);
+  });
 });

--- a/apps/web/src/components/approvals/ApprovalsInbox.tsx
+++ b/apps/web/src/components/approvals/ApprovalsInbox.tsx
@@ -1,6 +1,6 @@
 import '@/lib/i18n';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { AlertTriangle, Bot, Check, CheckCheck, Layers, Loader2, ShieldCheck, X } from 'lucide-react';
+import { AlertTriangle, Bot, Check, CheckCheck, Layers, Loader2, Search, ShieldCheck, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import {
   AI_AGENT_KINDS,
@@ -27,6 +27,7 @@ import { fetchWithAuth } from '../../stores/auth';
 import { badgeClass } from '../aiAgents/statusBadge';
 import { ConfirmDialog } from '../shared/ConfirmDialog';
 import { EmptyState } from '../shared/EmptyState';
+import { PageHeader } from '../shared/PageHeader';
 import { showToast } from '../shared/Toast';
 
 const LIVE_REFETCH_DEBOUNCE_MS = 750;
@@ -210,6 +211,91 @@ function clusterByOrg(rows: PendingApproval[]): PendingApproval[] {
     }
   }
   return order.flatMap((key) => buckets.get(key)!);
+}
+
+type SortOrder = 'expiringSoonest' | 'newest';
+
+/** Case-insensitive substring match over the fields Priya (an MSP tech
+ *  approving across dozens of orgs) scans an inbox by: the action label, the
+ *  target machine's hostname, and the proposing agent's name. An empty or
+ *  whitespace-only query matches every row. */
+function matchesSearch(approval: PendingApproval, query: string): boolean {
+  if (!query) return true;
+  const needle = query.toLowerCase();
+  return (
+    approval.actionLabel.toLowerCase().includes(needle) ||
+    (approval.targetDevice?.hostname.toLowerCase().includes(needle) ?? false) ||
+    (approval.agentName?.toLowerCase().includes(needle) ?? false)
+  );
+}
+
+/** One selectable option in the organization filter, in first-appearance
+ *  order among the currently loaded rows. `key` is what the `<select>`
+ *  stores and compares against — `orgId ?? ''` — so a null-`orgId` row
+ *  groups under one synthetic "Unknown organization" option instead of
+ *  splintering per row. */
+interface OrgFilterOption {
+  key: string;
+  name: string;
+  count: number;
+}
+
+function buildOrgOptions(rows: PendingApproval[], unknownLabel: string): OrgFilterOption[] {
+  const byKey = new Map<string, OrgFilterOption>();
+  const order: string[] = [];
+  for (const row of rows) {
+    const key = row.orgId ?? '';
+    const existing = byKey.get(key);
+    if (existing) {
+      existing.count += 1;
+      continue;
+    }
+    byKey.set(key, { key, name: row.orgName ?? unknownLabel, count: 1 });
+    order.push(key);
+  }
+  return order.map((key) => byKey.get(key)!);
+}
+
+/** Explicit-index stable sort: ties (identical `expiresAt`/`createdAt` — the
+ *  common case across fixtures, and for cards created in the same request)
+ *  keep their original relative order rather than depending on the engine's
+ *  sort-stability guarantee. Runs BEFORE `clusterByOrg` below, not after:
+ *  clustering only reorders which ORG's bucket comes first and preserves
+ *  each bucket's internal order, so sorting the flat list first is what
+ *  actually decides the order approvers see within (and, secondarily,
+ *  across) organizations — org-first clustering (critique #1) is preserved
+ *  either way. */
+function sortRows(rows: PendingApproval[], order: SortOrder): PendingApproval[] {
+  return rows
+    .map((row, index) => ({ row, index }))
+    .sort((a, b) => {
+      const diff =
+        order === 'expiringSoonest'
+          ? new Date(a.row.expiresAt).getTime() - new Date(b.row.expiresAt).getTime()
+          : new Date(b.row.createdAt).getTime() - new Date(a.row.createdAt).getTime();
+      return diff !== 0 ? diff : a.index - b.index;
+    })
+    .map(({ row }) => row);
+}
+
+/** Comma-joined hostnames for a group header, so "Approve all (N)" names its
+ *  own scope instead of leaving the approver to open every card to find out
+ *  which machines it covers. Caps at GROUP_HOSTNAME_MAX_SHOWN names (kept
+ *  short enough that the header's `line-clamp-2` rarely has to truncate
+ *  mid-name) and folds everything past that — including any member with no
+ *  `targetDevice` at all — into one trailing "+K more" count. Returns null
+ *  when nothing in the group carries a hostname, so the caller renders no
+ *  line at all rather than an empty one. */
+const GROUP_HOSTNAME_MAX_SHOWN = 6;
+function groupHostnameSummary(
+  members: PendingApproval[],
+): { shown: string[]; more: number } | null {
+  const hostnames = members
+    .map((member) => member.targetDevice?.hostname)
+    .filter((hostname): hostname is string => Boolean(hostname));
+  if (hostnames.length === 0) return null;
+  const shown = hostnames.slice(0, GROUP_HOSTNAME_MAX_SHOWN);
+  return { shown, more: members.length - shown.length };
 }
 
 /** Whether a card's expiry has already passed as of `now`. `now` is a ticking
@@ -461,6 +547,15 @@ export default function ApprovalsInbox() {
   const [totalCount, setTotalCount] = useState<number | null>(null);
   const [loadingMore, setLoadingMore] = useState(false);
   const [loadMoreError, setLoadMoreError] = useState(false);
+  // Org filter, text search, and sort are ALL client-side over whatever
+  // pages are currently loaded (`approvals`) — the server has no query
+  // params for any of the three today, and adding a per-keystroke round
+  // trip for a filter this cheap would be worse than the honesty cost of
+  // "of N loaded" below. `orgFilter` stores `orgId ?? ''` (see
+  // `buildOrgOptions`); '' means "All organizations".
+  const [orgFilter, setOrgFilter] = useState('');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [sortOrder, setSortOrder] = useState<SortOrder>('expiringSoonest');
 
   const loadApprovals = useCallback(async (options?: { silent?: boolean; withCount?: boolean }) => {
     // Silent reloads (WS nudge, poll, reconnect, post-decision refresh) must
@@ -762,6 +857,16 @@ export default function ApprovalsInbox() {
     reason?: string,
   ) => {
     if (busy) return;
+    // The button's own `disabled` attribute is driven by the ticking `now`
+    // state, which can lag reality by up to EXPIRY_TICK_MS (10s) — a card
+    // can still read enabled, or even "Expires in 1 min", for a few seconds
+    // after it has actually expired. Re-checking against a FRESH
+    // `Date.now()` here (not the stale `now` state) closes that click-time
+    // race instead of letting it round-trip to the server only to 410.
+    if (isExpired(approval.expiresAt, Date.now())) {
+      setDecisionError(approval.id, 'expired');
+      return;
+    }
 
     setDecidingIds(new Set([approval.id]));
     clearRowErrors([approval.id]);
@@ -893,6 +998,15 @@ export default function ApprovalsInbox() {
   ) => {
     if (busy) return;
     const ids = group.members.map((member) => member.id);
+
+    // Same click-time race as the single-card `decide` above, checked
+    // against a fresh `Date.now()` rather than the ticking `now` state: any
+    // member having expired since the last EXPIRY_TICK_MS tick refuses the
+    // WHOLE batch client-side rather than letting the server 410 mid-batch.
+    if (group.members.some((member) => isExpired(member.expiresAt, Date.now()))) {
+      setGroupError(group.identity, 'expired');
+      return;
+    }
 
     // #4460: mirror the server's hard cap (`BATCH_MAX` in
     // services/approvals/batchDecide.ts, sourced from the same
@@ -1197,19 +1311,128 @@ export default function ApprovalsInbox() {
     );
   };
 
+  // Filter → sort → cluster, in that order (see `sortRows`'s own comment for
+  // why sort must run before `clusterByOrg`, not after). All three stages
+  // are client-side over `approvals` alone — whatever pages happen to be
+  // loaded right now — never a fresh fetch, hence the honest "of N loaded"
+  // copy on `filterSummary` below rather than reusing the server-authoritative
+  // `pagination.showing` copy.
+  const orgOptions = buildOrgOptions(approvals, t('unknownOrganization'));
+  const hasActiveFilters = orgFilter !== '' || searchQuery.trim() !== '';
+  const filteredApprovals = approvals
+    .filter((approval) => orgFilter === '' || (approval.orgId ?? '') === orgFilter)
+    .filter((approval) => matchesSearch(approval, searchQuery.trim()));
+  const visibleSections = buildSections(
+    clusterByOrg(sortRows(filteredApprovals, sortOrder)),
+    driftedIds,
+  );
+  const clearFilters = () => {
+    setOrgFilter('');
+    setSearchQuery('');
+  };
+
   return (
-    <div className="mx-auto max-w-5xl space-y-6" data-testid="approvals-inbox">
-      <header className="flex items-start gap-3">
-        <div className="mt-0.5 rounded-xl bg-emerald-100 p-2 text-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-200">
-          <ShieldCheck className="h-5 w-5" aria-hidden="true" />
+    <div className="space-y-6" data-testid="approvals-inbox">
+      <PageHeader
+        testId="approvals-page-header"
+        icon={<ShieldCheck className="h-5 w-5" aria-hidden="true" />}
+        title={t('title')}
+        description={t('description')}
+      />
+
+      {!loading && !loadError && approvals.length > 0 && (
+        <div
+          className="flex flex-col gap-3 rounded-xl border bg-card px-4 py-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between"
+          data-testid="approvals-filters"
+        >
+          <div className="flex flex-1 flex-wrap items-center gap-2">
+            <label className="sr-only" htmlFor="approvals-filter-org">
+              {t('filters.orgLabel')}
+            </label>
+            <select
+              id="approvals-filter-org"
+              value={orgFilter}
+              onChange={(event) => setOrgFilter(event.target.value)}
+              className="h-9 rounded-lg border bg-background px-2 text-sm"
+              data-testid="approvals-filter-org"
+            >
+              <option value="">{t('filters.allOrganizations', { count: approvals.length })}</option>
+              {orgOptions.map((option) => (
+                <option key={option.key} value={option.key}>
+                  {t('filters.orgOption', { name: option.name, count: option.count })}
+                </option>
+              ))}
+            </select>
+
+            <label className="sr-only" htmlFor="approvals-filter-search">
+              {t('filters.searchLabel')}
+            </label>
+            <div className="relative flex-1 sm:max-w-xs">
+              <Search
+                className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+                aria-hidden="true"
+              />
+              <input
+                id="approvals-filter-search"
+                type="search"
+                value={searchQuery}
+                onChange={(event) => setSearchQuery(event.target.value)}
+                placeholder={t('filters.searchPlaceholder')}
+                className="h-9 w-full rounded-lg border bg-background pl-8 pr-3 text-sm"
+                data-testid="approvals-filter-search"
+              />
+            </div>
+
+            {hasActiveFilters && (
+              <button
+                type="button"
+                onClick={clearFilters}
+                className="text-sm font-medium text-muted-foreground underline underline-offset-4 hover:text-foreground"
+                data-testid="approvals-clear-filters"
+              >
+                {t('filters.clearFilters')}
+              </button>
+            )}
+          </div>
+
+          <div className="flex shrink-0 items-center gap-2">
+            <div
+              className="flex items-center gap-1 rounded-md border p-1"
+              role="group"
+              aria-label={t('filters.sortLabel')}
+            >
+              {(['expiringSoonest', 'newest'] as const).map((value) => (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() => setSortOrder(value)}
+                  aria-pressed={sortOrder === value}
+                  className={`rounded px-2.5 py-1 text-sm ${
+                    sortOrder === value
+                      ? 'bg-primary text-primary-foreground'
+                      : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                  }`}
+                  data-testid={`approvals-sort-${value === 'expiringSoonest' ? 'expiring' : 'newest'}`}
+                >
+                  {value === 'expiringSoonest' ? t('filters.sortExpiringSoonest') : t('filters.sortNewest')}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {hasActiveFilters && (
+            <p
+              className="w-full text-xs text-muted-foreground sm:w-auto"
+              data-testid="approvals-filter-summary"
+            >
+              {t('filters.showingLoaded', {
+                shown: filteredApprovals.length,
+                loaded: approvals.length,
+              })}
+            </p>
+          )}
         </div>
-        <div>
-          <h1 className="text-2xl font-semibold tracking-tight">{t('title')}</h1>
-          <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
-            {t('description')}
-          </p>
-        </div>
-      </header>
+      )}
 
       {loading ? (
         <div
@@ -1245,9 +1468,30 @@ export default function ApprovalsInbox() {
           description={t('empty.description')}
           headingLevel={2}
         />
+      ) : filteredApprovals.length === 0 ? (
+        // Every currently-loaded row was filtered out — distinct from the
+        // true empty inbox above, and it must not read as one: nothing
+        // vanished, the filters are just narrower than what's on screen.
+        <EmptyState
+          testId="approvals-filtered-empty"
+          icon={<Search className="h-7 w-7" />}
+          title={t('filters.noMatches.title')}
+          description={t('filters.noMatches.description')}
+          action={
+            <button
+              type="button"
+              onClick={clearFilters}
+              className="inline-flex h-10 items-center rounded-lg border px-4 text-sm font-medium transition-colors hover:bg-muted"
+              data-testid="approvals-filtered-empty-clear"
+            >
+              {t('filters.clearFilters')}
+            </button>
+          }
+          headingLevel={2}
+        />
       ) : (
         <div className="overflow-hidden rounded-xl border bg-card">
-          {buildSections(clusterByOrg(approvals), driftedIds).map((section) =>
+          {visibleSections.map((section) =>
             section.kind === 'row' ? (
               renderRow(section.approval)
             ) : (
@@ -1276,6 +1520,24 @@ export default function ApprovalsInbox() {
                         })}
                       </span>
                     </p>
+                    {(() => {
+                      // Finding #2: "Approve all (N)" never named the
+                      // machines it covers — the approver had to open every
+                      // card to find out. This lists them right on the
+                      // header instead.
+                      const hostnameSummary = groupHostnameSummary(section.group.members);
+                      if (!hostnameSummary) return null;
+                      return (
+                        <p
+                          className="mt-1 line-clamp-2 text-xs text-muted-foreground"
+                          data-testid={`approval-group-hostnames-${section.group.testKey}`}
+                        >
+                          {hostnameSummary.shown.join(', ')}
+                          {hostnameSummary.more > 0 &&
+                            ` ${t('batch.moreHostnames', { count: hostnameSummary.more })}`}
+                        </p>
+                      );
+                    })()}
                   </div>
                   <div className="flex shrink-0 items-center gap-2">
                     <button
@@ -1313,8 +1575,21 @@ export default function ApprovalsInbox() {
                     className="border-b bg-muted/20 px-5 py-3"
                     data-testid={`approval-group-deny-form-${section.group.testKey}`}
                   >
+                    {/* The batch's own confirm step: restates the count and
+                        the org involved (a group is always one org — that's
+                        part of its own batchability key) so the confirm
+                        button isn't the first place scope is named. */}
+                    <p
+                      className="text-sm text-muted-foreground"
+                      data-testid={`approval-group-deny-summary-${section.group.testKey}`}
+                    >
+                      {t('batch.denyConfirmSummary', {
+                        count: section.group.members.length,
+                        org: section.group.members[0]?.orgName ?? t('unknownOrganization'),
+                      })}
+                    </p>
                     <label
-                      className="text-sm font-medium"
+                      className="mt-2 block text-sm font-medium"
                       htmlFor={`approval-group-deny-reason-${section.group.testKey}`}
                     >
                       {t('denyPrompt')}

--- a/apps/web/src/components/settings/AiAgentForm.test.tsx
+++ b/apps/web/src/components/settings/AiAgentForm.test.tsx
@@ -1,0 +1,339 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+
+// Partner scope comes from the JWT claims and the org context from the org
+// store — the same pair `useDefaultOwnerScope` reads (#1724 / #2126).
+const { getJwtClaimsMock, orgState } = vi.hoisted(() => ({
+  getJwtClaimsMock: vi.fn<() => { scope: 'system' | 'partner' | 'organization' | null; partnerId: string | null; orgId: string | null }>(
+    () => ({ scope: 'partner', partnerId: 'p-1', orgId: null }),
+  ),
+  orgState: {
+    current: {
+      currentOrgId: 'org-1' as string | null,
+      allOrgs: false,
+      error: null as string | null,
+      organizationsLoaded: true,
+      organizations: [{ id: 'org-1', name: 'Acme' }],
+    },
+  },
+}));
+vi.mock('@/lib/authScope', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/authScope')>('@/lib/authScope');
+  return { ...actual, getJwtClaims: getJwtClaimsMock };
+});
+vi.mock('../../stores/orgStore', () => ({
+  useOrgStore: (sel?: (s: typeof orgState.current) => unknown) => (sel ? sel(orgState.current) : orgState.current),
+}));
+
+import AiAgentForm, { type AiAgentDto } from './AiAgentForm';
+import { fetchWithAuth } from '../../stores/auth';
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const json = (payload: unknown, ok = true, status = 200): Response =>
+  ({ ok, status, statusText: 'OK', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+/** A registry response shaped exactly like GET /ai/agents/policy-decidable-keys. */
+type RegistryRow = { key: string; toolName: string; action: string | null; note: string };
+
+const REGISTRY: RegistryRow[] = [
+  {
+    key: 'manage_services:restart',
+    toolName: 'manage_services',
+    action: 'restart',
+    note: 'Restarts one named service on one device via the agent command queue.',
+  },
+  {
+    key: 'manage_startup_items:disable',
+    toolName: 'manage_startup_items',
+    action: 'disable',
+    note: 'Disables one named startup item on one device via the agent command queue.',
+  },
+  {
+    key: 'manage_scheduled_tasks:disable',
+    toolName: 'manage_scheduled_tasks',
+    action: 'disable',
+    note: 'Disables one named scheduled task on one device via the agent command queue.',
+  },
+];
+
+function makeAgent(overrides: Partial<AiAgentDto> = {}): AiAgentDto {
+  return {
+    id: 'a1',
+    kind: 'triage',
+    name: 'Triage',
+    enabled: true,
+    mode: 'shadow',
+    model: null,
+    orgId: 'org-1',
+    partnerId: null,
+    ownerScope: 'organization',
+    allOrgs: false,
+    supportedModes: ['off', 'shadow', 'act'],
+    toolAllowlist: [],
+    protectedResources: {},
+    limits: {},
+    triggers: { alertSeverities: ['critical'], respectMaintenanceWindows: true },
+    recipients: { userIds: [], roleIds: [] },
+    actAssets: { supervisedActionKeys: [] },
+    instructions: null,
+    cooldownSeconds: 900,
+    disabledAt: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function mockEndpoints(registry: RegistryRow[] = []): void {
+  fetchMock.mockImplementation((url: string) => {
+    if (url === '/ai/agents/policy-decidable-keys') return Promise.resolve(json({ data: registry }));
+    // The single-org shape AiAgentGraduationPanel's `normalize` accepts — a
+    // body it rejects renders the panel's error state and floods the run with
+    // console noise that has nothing to do with these assertions.
+    if (url.startsWith('/ai/agents/graduation')) {
+      return Promise.resolve(json({
+        data: { rows: [], actOpReliability: [], promoteThreshold: null, policyDecideEnabled: true },
+      }));
+    }
+    if (url.startsWith('/ai/agents/schedules')) return Promise.resolve(json({ data: [] }));
+    if (url === '/roles') return Promise.resolve(json({ data: [{ id: 'r-1', name: 'Org Admin' }] }));
+    return Promise.resolve(json({ data: [] }));
+  });
+}
+
+function renderForm(props: Partial<React.ComponentProps<typeof AiAgentForm>> = {}) {
+  return render(
+    <AiAgentForm
+      agent={null}
+      agents={[]}
+      showOwnerScope={false}
+      defaultOwnerScope="organization"
+      onClose={vi.fn()}
+      onSaved={vi.fn()}
+      {...props}
+    />,
+  );
+}
+
+/** The one PATCH/POST body the form sent, parsed. */
+function writeBody(): Record<string, unknown> {
+  const call = fetchMock.mock.calls.find(([, init]) =>
+    ['POST', 'PATCH'].includes((init as RequestInit | undefined)?.method ?? ''));
+  return JSON.parse((call?.[1] as RequestInit).body as string) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  getJwtClaimsMock.mockReturnValue({ scope: 'partner', partnerId: 'p-1', orgId: null });
+  orgState.current = {
+    currentOrgId: 'org-1',
+    allOrgs: false,
+    error: null,
+    organizationsLoaded: true,
+    organizations: [{ id: 'org-1', name: 'Acme' }],
+  };
+});
+
+describe('AiAgentForm — unattended policy authorization', () => {
+  it('names each authorized operation in words rather than the raw registry token', async () => {
+    // The registry key IS the wire contract, so it stays on the data-testid —
+    // but "manage_startup_items / disable" is a machine token, and the bare
+    // verb "disable" appears against three different objects in this list.
+    mockEndpoints(REGISTRY);
+    renderForm({ agent: makeAgent({ mode: 'act' }) });
+
+    const fieldset = await screen.findByTestId('ai-agent-policy-decide');
+    await within(fieldset).findByText('Services');
+    expect(within(fieldset).getByText('Startup items')).toBeInTheDocument();
+    expect(within(fieldset).getByText('Scheduled tasks')).toBeInTheDocument();
+
+    expect(within(fieldset).getByText('Restart a service')).toBeInTheDocument();
+    expect(within(fieldset).getByText('Disable a startup item')).toBeInTheDocument();
+    expect(within(fieldset).getByText('Disable a scheduled task')).toBeInTheDocument();
+
+    // No raw token survives as a visible label.
+    expect(fieldset.textContent).not.toContain('manage_services');
+    expect(fieldset.textContent).not.toContain('manage_startup_items');
+  });
+
+  it('sentence-cases a key the catalog has no translation for, rather than showing the token', async () => {
+    // The registry is server-owned: a key can land in an API build before the
+    // web catalog knows it. It must still read as words.
+    mockEndpoints([
+      { key: 'manage_widgets:defrag', toolName: 'manage_widgets', action: 'defrag', note: '' },
+    ]);
+    renderForm({ agent: makeAgent({ mode: 'act' }) });
+
+    const fieldset = await screen.findByTestId('ai-agent-policy-decide');
+    await within(fieldset).findByText('Manage widgets');
+    expect(within(fieldset).getByText('Defrag')).toBeInTheDocument();
+  });
+
+  it('describes each operation with the registry note, wired to the checkbox', async () => {
+    mockEndpoints(REGISTRY);
+    renderForm({ agent: makeAgent({ mode: 'act' }) });
+
+    const checkbox = await screen.findByTestId('ai-agent-supervised-key-manage_services:restart');
+    const describedBy = checkbox.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    expect(document.getElementById(describedBy as string)?.textContent).toBe(
+      'Restarts one named service on one device via the agent command queue.',
+    );
+  });
+
+  it('asks for the tool allowlist before it asks who may act on it unattended', async () => {
+    // Authority over a set has to come after the set: the permissions section
+    // is what the authorized operations are drawn from.
+    mockEndpoints(REGISTRY);
+    renderForm({ agent: makeAgent({ mode: 'act' }) });
+
+    const permissions = await screen.findByTestId('ai-agent-permissions');
+    const authorization = screen.getByTestId('ai-agent-policy-decide');
+    expect(
+      permissions.compareDocumentPosition(authorization) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it('collapses a partner-wide ceiling behind a summary that counts it, while the row is not acting', async () => {
+    // A partner row's keys are a CEILING, not authority it exercises — so on a
+    // shadow-mode baseline the whole list is secondary, and only its size is
+    // worth a line.
+    mockEndpoints(REGISTRY);
+    renderForm({
+      agent: makeAgent({
+        id: 'a9',
+        ownerScope: 'partner',
+        orgId: null,
+        partnerId: 'p-1',
+        allOrgs: true,
+        mode: 'shadow',
+        actAssets: { supervisedActionKeys: ['manage_services:restart'] },
+      }),
+    });
+
+    const details = await screen.findByTestId('ai-agent-policy-keys-details');
+    expect(details.tagName).toBe('DETAILS');
+    expect(details).not.toHaveAttribute('open');
+    expect(within(details).getByText(/Ceiling for organizations/)).toHaveTextContent('1 key');
+
+    // Entering act mode is the operator saying the list itself matters now.
+    fireEvent.click(screen.getByTestId('ai-agent-mode-act'));
+    await waitFor(() => expect(screen.queryByTestId('ai-agent-policy-keys-details')).toBeNull());
+    expect(screen.getByTestId('ai-agent-supervised-key-manage_services:restart')).toBeInTheDocument();
+  });
+});
+
+describe('AiAgentForm — alert severities', () => {
+  it('offers alert severities to an alert-triage agent', async () => {
+    mockEndpoints();
+    renderForm({ agent: makeAgent({ kind: 'triage' }) });
+
+    expect(await screen.findByTestId('ai-agent-severity-critical')).toBeInTheDocument();
+  });
+
+  it('hides alert severities from a help desk agent and omits them from the save', async () => {
+    // Ticket-triggered runs carry no alert severity — `evaluateAgentTriggerFilters`
+    // runs only when an `alertContext` is present, and only triage admissions
+    // build one. Asking for a severity here is a decision that can never apply,
+    // and the `.min(1)` client check could block a save on a field the server
+    // never reads for this kind.
+    mockEndpoints();
+    renderForm({ agent: makeAgent({ kind: 'helpdesk', triggers: { respectMaintenanceWindows: true } }) });
+
+    await screen.findByTestId('ai-agent-permissions');
+    expect(screen.queryByTestId('ai-agent-severity-critical')).toBeNull();
+
+    fireEvent.click(screen.getByTestId('ai-agent-save'));
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.some(([, init]) =>
+        (init as RequestInit | undefined)?.method === 'PATCH')).toBe(true));
+
+    const triggers = writeBody().triggers as Record<string, unknown>;
+    expect(triggers).not.toHaveProperty('alertSeverities');
+    expect(screen.queryByTestId('ai-agent-issues')).toBeNull();
+  });
+
+  it('hides alert severities from a patching agent', async () => {
+    mockEndpoints();
+    renderForm({ agent: makeAgent({ kind: 'patch' }) });
+
+    await screen.findByTestId('ai-agent-permissions');
+    expect(screen.queryByTestId('ai-agent-severity-critical')).toBeNull();
+  });
+});
+
+describe('AiAgentForm — mode cards', () => {
+  it('top-aligns the option cards so the three labels share a baseline', async () => {
+    // A <button>'s content box is vertically centred by the UA stylesheet, so
+    // three cards of unequal height put their labels on three different lines.
+    mockEndpoints();
+    renderForm();
+
+    for (const mode of ['off', 'shadow', 'act']) {
+      const card = await screen.findByTestId(`ai-agent-mode-${mode}`);
+      expect(card.className).toContain('flex-col');
+      expect(card.className).toContain('items-start');
+    }
+  });
+});
+
+describe('AiAgentForm — name', () => {
+  it('marks the name as required and says so on blur, not only after a failed save', async () => {
+    mockEndpoints();
+    renderForm();
+
+    const input = await screen.findByTestId('ai-agent-name');
+    expect(input).toBeRequired();
+    // The repo's required marker (ApiKeyForm.tsx) is a destructive-toned
+    // asterisk appended to the label.
+    const label = document.querySelector(`label[for="${input.getAttribute('id')}"]`);
+    expect(label?.textContent).toContain('*');
+
+    expect(screen.queryByTestId('ai-agent-name-error')).toBeNull();
+    fireEvent.blur(input);
+
+    expect(await screen.findByTestId('ai-agent-name-error')).toBeInTheDocument();
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(input.getAttribute('aria-describedby')).toBe(
+      screen.getByTestId('ai-agent-name-error').getAttribute('id'),
+    );
+
+    fireEvent.change(input, { target: { value: 'Triage' } });
+    await waitFor(() => expect(screen.queryByTestId('ai-agent-name-error')).toBeNull());
+    expect(input).not.toHaveAttribute('aria-invalid');
+  });
+});
+
+describe('AiAgentForm — Save button', () => {
+  // Review finding — the disabled Save button was missing the
+  // `disabled:cursor-not-allowed` affordance already used by
+  // `RunsListPage.tsx`'s Load more button.
+  it('shows a not-allowed cursor while disabled, matching the rest of the AI agents UI', async () => {
+    mockEndpoints();
+    // No available kinds on a create form disables Save (see the
+    // `disabled` expression below the button) without needing to wait on
+    // an async validation state.
+    renderForm();
+
+    const save = await screen.findByTestId('ai-agent-save');
+    expect(save.className).toContain('disabled:cursor-not-allowed');
+  });
+});
+
+describe('AiAgentForm — disable confirmation', () => {
+  it('asks with a caution, not a destructive stop sign, for an action that can be undone', async () => {
+    // Disabling is reversible from this very page (`actions.reenable`), so the
+    // red stop octagon overstates it.
+    mockEndpoints();
+    renderForm({ agent: makeAgent() });
+
+    fireEvent.click(await screen.findByTestId('ai-agent-disable'));
+    const dialog = (await screen.findByTestId('ai-agent-disable-confirm')).closest('[role="dialog"]');
+    expect(dialog).not.toBeNull();
+    expect((dialog as HTMLElement).innerHTML).toContain('bg-warning/10');
+    expect((dialog as HTMLElement).innerHTML).not.toContain('bg-destructive/10');
+  });
+});

--- a/apps/web/src/components/settings/AiAgentForm.tsx
+++ b/apps/web/src/components/settings/AiAgentForm.tsx
@@ -54,13 +54,35 @@ function roleScope(role: RoleOption): 'partner' | 'organization' {
 const ROLE_GROUPS = ['partner', 'organization'] as const;
 
 /** GET /ai/agents/policy-decidable-keys — the read-only POLICY_DECIDABLE_TIER3
- *  registry (wave 5 Part B, #3827). `note` is fetched but not currently
- *  rendered; kept on the type for parity with the wire shape. */
+ *  registry (wave 5 Part B, #3827). `note` is the server's one-sentence
+ *  description of what the operation actually does; it is rendered as the
+ *  checkbox's description below. */
 interface PolicyDecidableKeyOption {
   key: string;
   toolName: string;
   action: string | null;
   note: string;
+}
+
+/**
+ * `manage_startup_items` -> "Manage startup items". Last-resort label for a
+ * registry key this catalog has no translation for: the registry is
+ * server-owned, so a key can ship in an API build before the web catalog
+ * knows it, and the operator must still read words rather than an identifier.
+ * Deliberately silent — a missing translation is a catalog gap to fix in the
+ * next extraction pass, not a runtime fault worth a console line on every
+ * render of this form.
+ */
+function sentenceCase(token: string): string {
+  const words = token.replace(/[_:-]+/g, ' ').trim();
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+/** `manage_services:restart` -> `manage_services-restart`, so the key can be
+ *  spliced into a DOM id (`aria-describedby` takes an id list, and a colon in
+ *  an id is legal HTML but a syntax error in any selector that reads it). */
+function idSafe(key: string): string {
+  return key.replace(/[^A-Za-z0-9_-]+/g, '-');
 }
 
 /** Groups registry entries by `toolName`, preserving the server's ordering
@@ -150,6 +172,28 @@ const INSTRUCTIONS_MAX = 2000;
  * arrow-key order.
  */
 const MODE_ORDER: readonly AiAgentMode[] = ['off', 'shadow', 'act'];
+
+/**
+ * Kinds whose runs can ever carry an alert severity — i.e. the only kinds for
+ * which `triggers.alertSeverities` is read at all.
+ *
+ * `runService.ts` evaluates the severity list inside
+ * `evaluateAgentTriggerFilters`, which runs ONLY when the admission input
+ * carries an `alertContext`, and both producers of one
+ * (`alertVerdictSubscriber.ts` and `automationRuntime.ts`) admit with
+ * `kind: 'triage'`. A helpdesk agent is admitted from a ticket
+ * (`ticketHelpdeskSubscriber.ts`, `ticketContext`), a patch agent from a
+ * manual or scheduled trigger — neither carries a severity, so the list is
+ * inert for both.
+ *
+ * Showing the control for those kinds asked the operator to make a choice
+ * that could never take effect, and the client-side `.min(1)` check could
+ * block a save over a field the server never reads for that kind. Hidden AND
+ * omitted from the payload: on PATCH the one-level merge preserves whatever
+ * is stored, and on create the server's `aiAgentTriggersSchema` supplies its
+ * own `['critical', 'high']` default, so omission is never a `.min(1)` 400.
+ */
+const ALERT_SEVERITY_KINDS: ReadonlySet<AiAgentKind> = new Set<AiAgentKind>(['triage']);
 
 /** Newline-separated textarea → trimmed, de-duplicated list. */
 function lines(value: string): string[] {
@@ -364,7 +408,39 @@ export default function AiAgentForm({
   const toolSuggestInputId = useId();
   const toolSuggestListId = useId();
   const rolesGroupBaseId = useId();
+  const severitiesGroupId = useId();
+  const policyKeyNoteBaseId = useId();
+  const nameInputId = useId();
+  const nameErrorId = useId();
   const [toolSuggestion, setToolSuggestion] = useState('');
+  /** Name has been left at least once. Until then an empty Name is "not
+   *  filled in yet", not an error — a form that goes red before the operator
+   *  has reached the field is scolding them for a field they were on their
+   *  way to. */
+  const [nameTouched, setNameTouched] = useState(false);
+  const nameInvalid = nameTouched && draft.name.trim() === '';
+
+  const usesAlertSeverities = ALERT_SEVERITY_KINDS.has(draft.kind);
+
+  /** Registry tool -> translated group heading, falling back to the
+   *  sentence-cased token (see `sentenceCase`). */
+  const policyToolLabel = (toolName: string) =>
+    t(/* i18n-dynamic */ `aiAgentsPage.policyKeys.tools.${toolName}`, {
+      defaultValue: sentenceCase(toolName),
+    });
+
+  /** Registry entry -> translated operation label. Scoped by tool, because the
+   *  bare action verb is ambiguous across the registry: "disable" appears
+   *  against a startup item and a scheduled task, "enable" likewise, and a
+   *  checkbox list of bare verbs cannot say which object it authorizes. A
+   *  bare-tool entry (`action: null`) has no verb of its own, so it reads as
+   *  the tool. */
+  const policyActionLabel = (entry: PolicyDecidableKeyOption) =>
+    entry.action === null
+      ? policyToolLabel(entry.toolName)
+      : t(/* i18n-dynamic */ `aiAgentsPage.policyKeys.actions.${entry.toolName}.${entry.action}`, {
+        defaultValue: sentenceCase(entry.action),
+      });
 
   /**
    * Autocomplete source for the tool allowlist. There is no tool-name
@@ -523,7 +599,17 @@ export default function AiAgentForm({
         const response = await fetchWithAuth('/ai/agents/policy-decidable-keys');
         if (!response.ok) throw new Error(`GET /ai/agents/policy-decidable-keys ${response.status}`);
         const body = (await response.json()) as { data?: PolicyDecidableKeyOption[] };
-        if (!cancelled) setPolicyKeys(Array.isArray(body.data) ? body.data : []);
+        // Defensive, not just a type assertion: `key`/`toolName` drive both
+        // the DOM id splice (`idSafe`) and the translated-label fallback
+        // (`sentenceCase`), and this registry is server-owned — a shape drift
+        // must degrade to "skip the row", never crash the whole form.
+        const rows = Array.isArray(body.data)
+          ? body.data.filter(
+              (row): row is PolicyDecidableKeyOption =>
+                typeof row?.key === 'string' && typeof row?.toolName === 'string',
+            )
+          : [];
+        if (!cancelled) setPolicyKeys(rows);
       } catch (err) {
         console.error('[AiAgentForm] could not load policy-decidable keys', err);
         if (!cancelled) setPolicyKeysFailed(true);
@@ -541,10 +627,19 @@ export default function AiAgentForm({
     // without a word; the footer says why the button is inert.
     if (scheduleDirty) return;
     const problems: string[] = [];
-    if (!draft.name.trim()) problems.push(t('aiAgentsPage.issues.name'));
+    if (!draft.name.trim()) {
+      problems.push(t('aiAgentsPage.issues.name'));
+      // Also mark the field itself, so the summary at the top of the form and
+      // the control it is about say the same thing.
+      setNameTouched(true);
+    }
     // `alertSeverities` is `.min(1)` server-side — an empty list is not
-    // "all severities", it is a 400.
-    if (draft.severities.length === 0) problems.push(t('aiAgentsPage.issues.severities'));
+    // "all severities", it is a 400. Only asked of the kinds that can read it
+    // (ALERT_SEVERITY_KINDS); for the others the field is hidden AND omitted
+    // below, so there is nothing here to be empty.
+    if (ALERT_SEVERITY_KINDS.has(draft.kind) && draft.severities.length === 0) {
+      problems.push(t('aiAgentsPage.issues.severities'));
+    }
     if (isCreate && draft.ownerScope === 'organization' && !orgScope.orgId) {
       problems.push(t('aiAgentsPage.issues.org'));
     }
@@ -568,7 +663,12 @@ export default function AiAgentForm({
       enabled: draft.enabled,
       mode: draft.mode,
       triggers: {
-        alertSeverities: draft.severities,
+        // Omitted, not sent as the draft value, for a kind whose runs can
+        // never carry a severity (see ALERT_SEVERITY_KINDS): the form does not
+        // show the control there, and sending a value the operator was never
+        // offered would silently rewrite a stored list they cannot see. The
+        // PATCH merge keeps what is stored; create takes the server default.
+        ...(ALERT_SEVERITY_KINDS.has(draft.kind) ? { alertSeverities: draft.severities } : {}),
         respectMaintenanceWindows: draft.respectMaintenanceWindows,
         ticketAutonomousWrites: draft.ticketAutonomousWrites,
       },
@@ -797,7 +897,13 @@ export default function AiAgentForm({
               // unattended changes on a customer machine read as no more
               // consequential than "do nothing" — the warning tone is the same
               // one the act warning panel and its icon already use.
-              className={`rounded-lg border p-3 text-left transition-colors focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60 ${
+              // `flex flex-col items-start` overrides the UA stylesheet's
+              // vertical centring of a <button>'s content box. The three cards
+              // stretch to a common height in the grid but carry consequence
+              // lines of different lengths, so centred content put the three
+              // option NAMES on three different baselines — the one line a
+              // reader scans across before choosing.
+              className={`flex flex-col items-start rounded-lg border p-3 text-left transition-colors focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60 ${
                 selected
                   ? mode === 'act'
                     ? 'border-warning-strong bg-warning/10 ring-1 ring-warning-strong'
@@ -806,7 +912,11 @@ export default function AiAgentForm({
               }`}
               data-testid={`ai-agent-mode-${mode}`}
             >
-              <span className="flex items-center gap-2">
+              {/* `w-full`: the card is now a flex COLUMN with `items-start`,
+                  which shrinks its children to their content width — without
+                  this the act card's `ml-auto` warning icon would sit against
+                  the label instead of the card's right edge. */}
+              <span className="flex w-full items-center gap-2">
                 {/* Selection is encoded by SHAPE (a filled ring) as well as by
                     colour, so the choice survives a colourblind read. */}
                 <span
@@ -890,6 +1000,117 @@ export default function AiAgentForm({
     </div>
   );
 
+  /** The registry checkboxes, grouped by tool with translated labels — shared
+   *  between the plain (org, act-only) rendering and the partner-wide
+   *  `<details>` wrapper below, so the two never drift out of sync. */
+  const policyKeysBody = policyKeysFailed ? (
+    <p className="text-sm text-destructive" data-testid="ai-agent-policy-keys-failed">
+      {t('aiAgentsPage.fields.supervisedActionKeysFailed')}
+    </p>
+  ) : policyKeys.length === 0 ? (
+    <p className="text-sm text-muted-foreground" data-testid="ai-agent-policy-keys-empty">
+      {t('aiAgentsPage.fields.supervisedActionKeysEmpty')}
+    </p>
+  ) : (
+    <div className="space-y-3">
+      {[...groupByTool(policyKeys).entries()].map(([toolName, entries]) => (
+        <div key={toolName}>
+          <p className="text-xs font-semibold">{policyToolLabel(toolName)}</p>
+          <div className="space-y-1.5">
+            {entries.map((entry) => {
+              // `idSafe`: a colon in `manage_services:restart` is a legal DOM
+              // id character but a syntax error in a CSS/query selector, so
+              // the registry key can't be spliced into the id raw.
+              const noteId = `${policyKeyNoteBaseId}-${idSafe(entry.key)}`;
+              return (
+                <label key={entry.key} className="flex items-start gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    className="mt-0.5"
+                    checked={draft.supervisedActionKeys.includes(entry.key)}
+                    onChange={() =>
+                      patch({ supervisedActionKeys: toggle(draft.supervisedActionKeys, entry.key) })}
+                    aria-describedby={noteId}
+                    data-testid={`ai-agent-supervised-key-${entry.key}`}
+                  />
+                  <span>
+                    <span className="block">{policyActionLabel(entry)}</span>
+                    {/* The registry's own one-sentence description of what the
+                        operation actually does — wired as the checkbox's
+                        accessible description, not just adjacent text, so a
+                        screen reader announces it as part of the control. */}
+                    <span id={noteId} className="block text-xs text-muted-foreground">
+                      {entry.note}
+                    </span>
+                  </span>
+                </label>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+
+  /* Wave 5 Part B (#3827). Gated the same way as the act-warning block above
+   * (draft.mode === 'act' only) for ORG rows — the "act acknowledgement
+   * pattern": this is additional unattended authority an operator is opting
+   * into only once they are already looking at the act-mode warning, never
+   * offered for shadow/off.
+   * PARTNER rows are the exception (#4583): per P2-5 (#4192) a partner row's
+   * keys are a CEILING on org grants, not authority the partner row exercises
+   * itself — ticking a key here authorizes nothing on its own regardless of
+   * the partner row's own mode, so gating the editor (and its ceiling hint)
+   * behind the partner row's act mode hid the warning precisely when it
+   * mattered: while editing a Shadow-mode baseline.
+   *
+   * A partner row's registry is collapsed behind a native `<details>` while
+   * the row is NOT acting — placed BELOW Permissions rather than above it,
+   * since these checkboxes refine the tool allowlist Permissions already
+   * sets, not precede it. The summary counts the selection rather than
+   * repeating the full ceiling explanation (still given underneath, once
+   * opened), so a shadow-mode baseline reads as one scannable line instead of
+   * a checkbox list that authorizes nothing on its own from this row. The
+   * moment the row enters act mode the list is unwrapped entirely (not just
+   * opened) — that is the one mode where THIS row's own dispatch can be
+   * gated by these keys, so it earns the same plain treatment an org row
+   * always gets; the ceiling caveat still prints beneath it as a fact that
+   * survives the mode, not as something act mode makes disappear. An org row
+   * has no ceiling caveat to begin with and is only ever shown in act mode,
+   * so it renders the list directly with no wrapper at all. */
+  const collapsedForCeiling = draft.ownerScope === 'partner' && draft.mode !== 'act';
+  const ceilingNote = draft.ownerScope === 'partner' && (
+    <p className="text-xs text-muted-foreground" data-testid="ai-agent-supervised-keys-ceiling-hint">
+      {t('aiAgentsPage.graduation.ceilingHint')}
+    </p>
+  );
+  const policyDecideFieldset = (draft.mode === 'act' || draft.ownerScope === 'partner') && (
+    <fieldset className="space-y-2 rounded-md border p-3 md:col-span-2" data-testid="ai-agent-policy-decide">
+      <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
+        {t('aiAgentsPage.sections.policyDecide')}
+      </legend>
+      <p className="text-xs text-muted-foreground">{t('aiAgentsPage.fields.supervisedActionKeysHint')}</p>
+      {collapsedForCeiling ? (
+        <details data-testid="ai-agent-policy-keys-details">
+          <summary className="cursor-pointer text-xs font-medium">
+            {t('aiAgentsPage.fields.supervisedActionKeysCeilingSummary', {
+              count: draft.supervisedActionKeys.length,
+            })}
+          </summary>
+          <div className="mt-1 space-y-2">
+            {ceilingNote}
+            {policyKeysBody}
+          </div>
+        </details>
+      ) : (
+        <>
+          {ceilingNote}
+          {policyKeysBody}
+        </>
+      )}
+    </fieldset>
+  );
+
   return (
     <div className="flex min-h-0 flex-1 flex-col" data-testid="ai-agent-editor">
       <div className="min-h-0 flex-1 space-y-3 overflow-y-auto p-5">
@@ -966,16 +1187,38 @@ export default function AiAgentForm({
             )}
           </label>
 
-          <label className="space-y-1 text-sm">
-            <span className="font-medium">{t('aiAgentsPage.fields.name')}</span>
+          {/* The only required free-text field on the form, and it used to
+              look exactly like the optional ones — the first sign it was
+              required was a Save that refused. Marked with the repo's
+              required convention (the destructive-toned asterisk from
+              ApiKeyForm.tsx) and validated on blur, so the operator learns it
+              at the field rather than at the button.
+              A <div> with `htmlFor` rather than a wrapping <label>: the error
+              paragraph is a sibling of the input, and nesting it inside the
+              label would fold the error text into the input's own accessible
+              name instead of its description. */}
+          <div className="space-y-1 text-sm">
+            <label className="block font-medium" htmlFor={nameInputId}>
+              {t('aiAgentsPage.fields.name')}<span className="text-destructive">*</span>
+            </label>
             <input
-              className={inputCls}
+              id={nameInputId}
+              className={`${inputCls} ${nameInvalid ? 'border-destructive' : ''}`}
               maxLength={120}
+              required
+              aria-invalid={nameInvalid || undefined}
+              aria-describedby={nameInvalid ? nameErrorId : undefined}
               value={draft.name}
               onChange={(e) => patch({ name: e.target.value })}
+              onBlur={() => setNameTouched(true)}
               data-testid="ai-agent-name"
             />
-          </label>
+            {nameInvalid && (
+              <p id={nameErrorId} className="text-xs text-destructive" data-testid="ai-agent-name-error">
+                {t('aiAgentsPage.issues.name')}
+              </p>
+            )}
+          </div>
 
           {/* `enabled` and `mode` are two independent gates, and BOTH have to
               pass: runService's admission skips `agent_disabled` before it ever
@@ -1005,71 +1248,6 @@ export default function AiAgentForm({
             )}
           </div>
 
-          {/* Wave 5 Part B (#3827). Gated the same way as the act-warning block
-              above (draft.mode === 'act' only) for ORG rows — the "act
-              acknowledgement pattern": this is additional unattended authority
-              an operator is opting into only once they are already looking at
-              the act-mode warning, never offered for shadow/off.
-              PARTNER rows are the exception (#4583): per P2-5 (#4192) a
-              partner row's keys are a CEILING on org grants, not authority the
-              partner row exercises itself — ticking a key here authorizes
-              nothing on its own regardless of the partner row's own mode, so
-              gating the editor (and its ceiling hint) behind the partner row's
-              act mode hid the warning precisely when it mattered: while
-              editing a Shadow-mode baseline. */}
-          {(draft.mode === 'act' || draft.ownerScope === 'partner') && (
-            <fieldset className="space-y-2 rounded-md border p-3 md:col-span-2" data-testid="ai-agent-policy-decide">
-              <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
-                {t('aiAgentsPage.sections.policyDecide')}
-              </legend>
-              <p className="text-xs text-muted-foreground">{t('aiAgentsPage.fields.supervisedActionKeysHint')}</p>
-              {/* P2-5 (#4192). A partner row's keys are a CEILING, not an
-                  inherited grant: with no org row the effective key set is empty,
-                  so ticking a key here authorizes nothing on its own. Said only
-                  on the partner form, because that is where the misreading is
-                  possible — an org-owned agent's keys really are the live set. */}
-              {draft.ownerScope === 'partner' && (
-                <p
-                  className="text-xs text-muted-foreground"
-                  data-testid="ai-agent-supervised-keys-ceiling-hint"
-                >
-                  {t('aiAgentsPage.graduation.ceilingHint')}
-                </p>
-              )}
-              {policyKeysFailed ? (
-                <p className="text-sm text-destructive" data-testid="ai-agent-policy-keys-failed">
-                  {t('aiAgentsPage.fields.supervisedActionKeysFailed')}
-                </p>
-              ) : policyKeys.length === 0 ? (
-                <p className="text-sm text-muted-foreground" data-testid="ai-agent-policy-keys-empty">
-                  {t('aiAgentsPage.fields.supervisedActionKeysEmpty')}
-                </p>
-              ) : (
-                <div className="space-y-2">
-                  {[...groupByTool(policyKeys).entries()].map(([toolName, entries]) => (
-                    <div key={toolName}>
-                      <p className="text-xs font-semibold">{toolName}</p>
-                      <div className="flex flex-wrap gap-3">
-                        {entries.map((entry) => (
-                          <label key={entry.key} className="flex items-center gap-1 text-sm">
-                            <input
-                              type="checkbox"
-                              checked={draft.supervisedActionKeys.includes(entry.key)}
-                              onChange={() =>
-                                patch({ supervisedActionKeys: toggle(draft.supervisedActionKeys, entry.key) })}
-                              data-testid={`ai-agent-supervised-key-${entry.key}`}
-                            />
-                            {entry.action ?? entry.toolName}
-                          </label>
-                        ))}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </fieldset>
-          )}
-
           {/* Graduation evidence (P2-5, #4192). Edit-only, for the same reason
               the schedules section is: the evidence ledger is keyed to a
               persisted agent that does not exist until the first save. NOT gated
@@ -1093,19 +1271,28 @@ export default function AiAgentForm({
             <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
               {t('aiAgentsPage.sections.scope')}
             </legend>
-            <div className="flex flex-wrap gap-3">
-              {SEVERITIES.map((severity) => (
-                <label key={severity} className="flex items-center gap-1 text-sm">
-                  <input
-                    type="checkbox"
-                    checked={draft.severities.includes(severity)}
-                    onChange={() => patch({ severities: toggle(draft.severities, severity) })}
-                    data-testid={`ai-agent-severity-${severity}`}
-                  />
-                  {t(/* i18n-dynamic */ `aiAgentsPage.severities.${severity}`)}
-                </label>
-              ))}
-            </div>
+            {/* Hidden — never just left unread — for a kind whose runs can
+                never carry a severity (see ALERT_SEVERITY_KINDS's docstring):
+                runService only evaluates `triggers.alertSeverities` when the
+                admission input carries an `alertContext`, which only a
+                triage-kind run ever does. Offering the control for helpdesk
+                or patch asked the operator to make a choice that could never
+                take effect. */}
+            {usesAlertSeverities && (
+              <div className="flex flex-wrap gap-3">
+                {SEVERITIES.map((severity) => (
+                  <label key={severity} className="flex items-center gap-1 text-sm">
+                    <input
+                      type="checkbox"
+                      checked={draft.severities.includes(severity)}
+                      onChange={() => patch({ severities: toggle(draft.severities, severity) })}
+                      data-testid={`ai-agent-severity-${severity}`}
+                    />
+                    {t(/* i18n-dynamic */ `aiAgentsPage.severities.${severity}`)}
+                  </label>
+                ))}
+              </div>
+            )}
             <label className="flex items-center gap-2 text-sm">
               <input
                 type="checkbox"
@@ -1214,6 +1401,8 @@ export default function AiAgentForm({
               {listField('ai-agent-registrykeys', t('aiAgentsPage.fields.protectedRegistryKeys'), draft.registryKeys, (v) => patch({ registryKeys: v }), 2)}
             </div>
           </section>
+
+          {policyDecideFieldset}
 
           {/* Six unlabelled number inputs in one 3-column grid read as one
               undifferentiated wall. Split into the two questions they actually
@@ -1355,7 +1544,7 @@ export default function AiAgentForm({
               || (isCreate && availableKinds.length === 0)
               || (enteringActMode && !actAck)
             }
-            className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground disabled:opacity-60"
+            className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground disabled:cursor-not-allowed disabled:opacity-60"
             data-testid="ai-agent-save"
           >
             {t('aiAgentsPage.actions.save')}
@@ -1386,12 +1575,17 @@ export default function AiAgentForm({
           disable", stayed armed indefinitely, and never said what disabling
           actually does. Same ConfirmDialog ceremony as every other guarded
           action in the app, and the message names both halves: what stops,
-          and what survives. */}
+          and what survives.
+          `variant="warning"`, not the destructive default: disabling an agent
+          is reversible (re-enabling is one checkbox away, and the retained
+          text below says what survives), so the destructive red/octagon
+          treatment overstated the stakes of a switch, not a deletion. */}
       {agent && (
         <ConfirmDialog
           open={confirmDisable}
           onClose={() => setConfirmDisable(false)}
           onConfirm={() => void disable()}
+          variant="warning"
           title={t('aiAgentsPage.disableDialog.title', { name: agent.name })}
           message={t('aiAgentsPage.disableDialog.message')}
           confirmLabel={t('aiAgentsPage.actions.disable')}

--- a/apps/web/src/components/settings/AiAgentSchedulesSection.test.tsx
+++ b/apps/web/src/components/settings/AiAgentSchedulesSection.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AiAgentEffectiveScheduleDto } from '@breeze/shared';
 
@@ -710,5 +710,116 @@ describe('AiAgentSchedulesSection unsaved-work reporting (#4187 UI critique roun
     fireEvent.click(screen.getByTestId('ai-agent-schedule-edit-s-1'));
     await screen.findByTestId('ai-agent-schedule-editor');
     expect(onDirtyChange).not.toHaveBeenCalledWith(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #4187 UI critique 3 — empty-state/editor overlap, the enabled switch row,
+// grouped/searchable timezone select, and the shared badge idiom on the
+// "All orgs" chip.
+// ---------------------------------------------------------------------------
+
+describe('AiAgentSchedulesSection empty state vs. open create editor (#4187 UI critique 3)', () => {
+  it('does not render "No sweep schedules yet" above an already-open create editor', async () => {
+    mockList([]);
+    render(<AiAgentSchedulesSection {...partnerProps} />);
+
+    await waitFor(() => expect(screen.getByTestId('ai-agent-schedule-add')).toBeInTheDocument());
+    // Before opening a draft, the empty state is the only thing there is to say.
+    expect(screen.getByTestId('ai-agent-schedules-empty')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('ai-agent-schedule-add'));
+
+    expect(await screen.findByTestId('ai-agent-schedule-editor')).toBeInTheDocument();
+    // The empty state used to gate on `schedules.length === 0` alone, so it
+    // kept rendering directly above the create form it was telling the
+    // operator to use.
+    expect(screen.queryByTestId('ai-agent-schedules-empty')).toBeNull();
+  });
+
+  it('shows the empty state again once the open create draft is cancelled', async () => {
+    mockList([]);
+    render(<AiAgentSchedulesSection {...partnerProps} />);
+
+    fireEvent.click(await screen.findByTestId('ai-agent-schedule-add'));
+    await screen.findByTestId('ai-agent-schedule-editor');
+    fireEvent.click(screen.getByTestId('ai-agent-schedule-cancel'));
+
+    expect(await screen.findByTestId('ai-agent-schedules-empty')).toBeInTheDocument();
+  });
+});
+
+describe('AiAgentSchedulesSection enabled switch row (#4187 UI critique 3)', () => {
+  it('renders the enabled control as a labelled switch, not an unlabelled seventh checkbox', async () => {
+    mockList([]);
+    render(<AiAgentSchedulesSection {...partnerProps} />);
+
+    fireEvent.click(await screen.findByTestId('ai-agent-schedule-add'));
+    const toggle = await screen.findByTestId('ai-agent-schedule-enabled');
+
+    expect(toggle.tagName).toBe('BUTTON');
+    expect(toggle).toHaveAttribute('role', 'switch');
+    expect(toggle).toHaveAttribute('aria-checked', 'true');
+    // Named via its own visible label, not left to context the way it sat
+    // among six identically-shaped "Checks to run" checkboxes before.
+    expect(toggle).toHaveAttribute('aria-labelledby');
+    const labelId = toggle.getAttribute('aria-labelledby')!;
+    expect(document.getElementById(labelId)?.textContent).toBe('Enabled');
+
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-checked', 'false');
+  });
+});
+
+describe('AiAgentSchedulesSection timezone picker (#4187 UI critique 3)', () => {
+  it('sets the viewer\'s own IANA zone when "Use my timezone" is clicked', async () => {
+    const originalResolvedOptions = Intl.DateTimeFormat.prototype.resolvedOptions;
+    Intl.DateTimeFormat.prototype.resolvedOptions = () =>
+      ({ ...originalResolvedOptions.call(new Intl.DateTimeFormat()), timeZone: 'Asia/Tokyo' });
+    try {
+      mockList([]);
+      render(<AiAgentSchedulesSection {...partnerProps} />);
+
+      fireEvent.click(await screen.findByTestId('ai-agent-schedule-add'));
+      fireEvent.change(await screen.findByTestId('ai-agent-schedule-timezone'), {
+        target: { value: 'Europe/Paris' },
+      });
+      expect(screen.getByTestId('ai-agent-schedule-timezone')).toHaveValue('Europe/Paris');
+
+      fireEvent.click(screen.getByTestId('ai-agent-schedule-use-my-timezone'));
+      expect(screen.getByTestId('ai-agent-schedule-timezone')).toHaveValue('Asia/Tokyo');
+    } finally {
+      Intl.DateTimeFormat.prototype.resolvedOptions = originalResolvedOptions;
+    }
+  });
+
+  it('groups the timezone options into <optgroup>s by region', async () => {
+    mockList([]);
+    render(<AiAgentSchedulesSection {...partnerProps} />);
+
+    fireEvent.click(await screen.findByTestId('ai-agent-schedule-add'));
+    const select = await screen.findByTestId('ai-agent-schedule-timezone');
+
+    const groups = select.querySelectorAll('optgroup');
+    // A flat 400+ option list, grouped by continent, is necessarily more than
+    // one group — and every option lives inside SOME group, not loose beside them.
+    expect(groups.length).toBeGreaterThan(1);
+    expect(select.querySelectorAll(':scope > option').length).toBe(0);
+    expect([...groups].some((group) => group.getAttribute('label') === 'America')).toBe(true);
+  });
+});
+
+describe('AiAgentSchedulesSection "All orgs" chip (#4187 UI critique 3)', () => {
+  it('renders the schedule row\'s "All orgs" chip through the shared badge idiom', async () => {
+    mockList([BASELINE]);
+    render(<AiAgentSchedulesSection {...partnerProps} />);
+
+    const row = await screen.findByTestId('ai-agent-schedule-s-1');
+    const chip = within(row).getByText('All orgs');
+    // Not the old bespoke `bg-primary/10 text-primary` pill — the same
+    // dark-mode-aware pill idiom as the kind badge beside it.
+    expect(chip.className).toContain('rounded-full');
+    expect(chip.className).toMatch(/dark:/);
+    expect(chip.className).not.toContain('bg-primary/10');
   });
 });

--- a/apps/web/src/components/settings/AiAgentSchedulesSection.tsx
+++ b/apps/web/src/components/settings/AiAgentSchedulesSection.tsx
@@ -360,6 +360,15 @@ function defaultTimezone(): string {
   }
 }
 
+/** The part of an IANA zone name before its first '/' ("America", "Europe",
+ *  "UTC"). Used only to group the 418-option select into `<optgroup>`s — a
+ *  bare list that long forces the operator to scan every option in order to
+ *  find their own continent. */
+function timezoneRegion(zone: string): string {
+  const slash = zone.indexOf('/');
+  return slash === -1 ? zone : zone.slice(0, slash);
+}
+
 type BaselineDraft = {
   mode: 'baseline';
   /** null = creating. */
@@ -422,6 +431,7 @@ export default function AiAgentSchedulesSection({
   const [saving, setSaving] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const allOrgsHintId = useId();
+  const scheduleEnabledLabelId = useId();
 
   // Read through a ref so an inline `onDirtyChange={...}` at the call site
   // cannot re-fire the effect on every parent render — the effect must run on
@@ -488,6 +498,20 @@ export default function AiAgentSchedulesSection({
     // field would silently rewrite it to the first option.
     return draftTimezone && !all.includes(draftTimezone) ? [draftTimezone, ...all] : all;
   }, [draftTimezone]);
+  // `listIanaTimezones()` is already alphabetical, so entries sharing a
+  // region are already contiguous — grouping by insertion order here never
+  // has to re-sort. A Map preserves that order, which is what makes the
+  // `<optgroup>`s below come out in the same order the flat list did.
+  const zoneGroups = useMemo(() => {
+    const groups = new Map<string, string[]>();
+    for (const zone of zones) {
+      const region = timezoneRegion(zone);
+      const list = groups.get(region);
+      if (list) list.push(zone);
+      else groups.set(region, [zone]);
+    }
+    return groups;
+  }, [zones]);
 
   /**
    * A field CHANGE. The only thing that makes this section dirty — kept
@@ -786,18 +810,34 @@ export default function AiAgentSchedulesSection({
           </label>
           <label className="space-y-1 text-sm">
             <span className="font-medium">{t('aiAgentsPage.schedules.timezone')}</span>
-            <select
-              className={inputCls}
-              value={drafted.timezone}
-              onChange={(e) => editDraft({ ...drafted, timezone: e.target.value })}
-              data-testid="ai-agent-schedule-timezone"
-            >
-              {zones.map((zone) => (
-                <option key={zone} value={zone}>
-                  {zone}
-                </option>
-              ))}
-            </select>
+            <div className="flex items-center gap-2">
+              <select
+                className={inputCls}
+                value={drafted.timezone}
+                onChange={(e) => editDraft({ ...drafted, timezone: e.target.value })}
+                data-testid="ai-agent-schedule-timezone"
+              >
+                {/* Grouped by continent — a flat 418-option list forces the
+                    operator to scan every entry to find their own region. */}
+                {[...zoneGroups.entries()].map(([region, regionZones]) => (
+                  <optgroup key={region} label={region}>
+                    {regionZones.map((zone) => (
+                      <option key={zone} value={zone}>
+                        {zone}
+                      </option>
+                    ))}
+                  </optgroup>
+                ))}
+              </select>
+              <button
+                type="button"
+                onClick={() => editDraft({ ...drafted, timezone: defaultTimezone() })}
+                className="shrink-0 whitespace-nowrap rounded-md border px-2.5 py-1.5 text-xs font-medium"
+                data-testid="ai-agent-schedule-use-my-timezone"
+              >
+                {t('aiAgentsPage.schedules.useMyTimezone')}
+              </button>
+            </div>
           </label>
         </div>
       ) : (
@@ -836,15 +876,33 @@ export default function AiAgentSchedulesSection({
         </div>
       )}
 
-      <label className="flex items-center gap-2 text-sm">
-        <input
-          type="checkbox"
-          checked={drafted.enabled}
-          onChange={() => editDraft({ ...drafted, enabled: !drafted.enabled })}
+      {/* A labelled switch row, set apart with its own top border — not an
+          unlabelled seventh checkbox sitting directly under "Checks to run"
+          (six of those, for a sweep draft), which read as one more item in
+          that group rather than the schedule's own on/off gate. */}
+      <div className="flex items-center justify-between gap-3 border-t pt-3">
+        <span className="text-sm font-medium" id={scheduleEnabledLabelId}>
+          {t('aiAgentsPage.schedules.enabled')}
+        </span>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={drafted.enabled}
+          aria-labelledby={scheduleEnabledLabelId}
+          onClick={() => editDraft({ ...drafted, enabled: !drafted.enabled })}
           data-testid="ai-agent-schedule-enabled"
-        />
-        {t('aiAgentsPage.schedules.enabled')}
-      </label>
+          className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full border transition ${
+            drafted.enabled ? 'bg-emerald-500/80' : 'bg-muted'
+          }`}
+        >
+          <span
+            aria-hidden="true"
+            className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition ${
+              drafted.enabled ? 'translate-x-6' : 'translate-x-1'
+            }`}
+          />
+        </button>
+      </div>
 
       <div className="flex flex-wrap items-center gap-2">
         <button
@@ -915,7 +973,11 @@ export default function AiAgentSchedulesSection({
               {t('aiAgentsPage.schedules.loading')}
             </p>
           )}
-          {!loading && !failed && schedules.length === 0 && (
+          {/* `draft === null` too: without it, the empty state rendered ABOVE
+              an already-open create editor the instant the list was empty —
+              "No sweep schedules yet" sitting directly on top of the form
+              that was already fixing that. */}
+          {!loading && !failed && schedules.length === 0 && draft === null && (
             <EmptyState
               size="sm"
               headingLevel={4}
@@ -942,7 +1004,7 @@ export default function AiAgentSchedulesSection({
                       {/* `title=` alone is invisible to touch and keyboard, so
                           the explanation is a real described-by node. */}
                       <span
-                        className="rounded bg-primary/10 px-2 py-0.5 text-xs text-primary"
+                        className={badgeClass('info', { size: 'sm' })}
                         aria-describedby={allOrgsHintId}
                       >
                         {t('aiAgentsPage.allOrgs')}

--- a/apps/web/src/components/settings/AiAgentsPage.test.tsx
+++ b/apps/web/src/components/settings/AiAgentsPage.test.tsx
@@ -1420,3 +1420,121 @@ describe('AiAgentsPage mode roving contract and disable focus (#4187 UI critique
     await waitFor(() => expect(document.activeElement).toBe(screen.getByTestId('ai-agent-edit-a1')));
   });
 });
+
+// ---------------------------------------------------------------------------
+// #4187 UI critique 3 — the running-state badge, the findings-to-review
+// badge, the all-disabled CTA, and the shared PageHeader.
+// ---------------------------------------------------------------------------
+
+describe('AiAgentsPage running-state badge (#4187 UI critique 3)', () => {
+  it('never labels the on/off switch "Enabled"/"Disabled" — that is the Disabled SECTION\'s own name', async () => {
+    mockEndpoints([{ ...PARTNER_AGENT, enabled: false }]);
+    render(<AiAgentsPage />);
+
+    const badge = await screen.findByTestId('ai-agent-running-badge-a1');
+    expect(badge).toHaveTextContent('Not running');
+    expect(badge).not.toHaveTextContent('Disabled');
+  });
+
+  it('labels a live, running agent "Running"', async () => {
+    mockEndpoints([PARTNER_AGENT]);
+    render(<AiAgentsPage />);
+
+    expect(await screen.findByTestId('ai-agent-running-badge-a1')).toHaveTextContent('Running');
+  });
+
+  it('shows a one-time "switched off, review its policy" note on the row a Re-enable just restored', async () => {
+    // A STATEFUL mock, unlike `mockEnableEndpoints` (whose list fetch always
+    // replays the same static fixture): the reload `reenable()` triggers
+    // after a successful POST has to actually observe the row having moved
+    // out of `disabledAt`, or this test could not tell the note apart from
+    // one that just never goes away.
+    let stored: Array<Record<string, unknown>> = [PARTNER_AGENT, DISABLED_AGENT];
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url === '/ai/agents/policy-decidable-keys') return Promise.resolve(json({ data: [] }));
+      if (url === '/ai/agents/a9/enable' && init?.method === 'POST') {
+        stored = stored.map((row) => (row.id === 'a9' ? { ...row, disabledAt: null } : row));
+        return Promise.resolve(json({ data: stored.find((row) => row.id === 'a9') }));
+      }
+      if (url.startsWith('/ai/agents/schedules')) return Promise.resolve(json({ data: [] }));
+      if (url.startsWith('/ai/agents')) return Promise.resolve(json({ data: stored }));
+      if (url === '/roles') return Promise.resolve(json({ data: [] }));
+      return Promise.resolve(json({ data: [] }));
+    });
+    render(<AiAgentsPage />);
+
+    await screen.findByTestId('ai-agents-disabled-section');
+    fireEvent.click(screen.getByTestId('ai-agent-reenable-a9'));
+
+    // The restored row moves into the live list — enabled: false, per the
+    // dialog's own promise ("it comes back switched off") — and carries the note.
+    const note = await screen.findByTestId('ai-agent-reenabled-note-a9');
+    expect(note).toHaveTextContent('Restored, switched off. Review its policy, then turn it on.');
+    expect(within(await screen.findByTestId('ai-agents-list')).getByTestId('ai-agent-row-a9')).toBeInTheDocument();
+
+    // Dismissed by the next state change — opening the editor.
+    fireEvent.click(screen.getByTestId('ai-agent-edit-a9'));
+    await waitFor(() => expect(screen.queryByTestId('ai-agent-reenabled-note-a9')).toBeNull());
+  });
+});
+
+describe('AiAgentsPage findings-to-review badge (#4187 UI critique 3, P0)', () => {
+  it('renders a warning badge naming how many findings need review, linking to the agent\'s runs', async () => {
+    mockEndpoints([{
+      ...PARTNER_AGENT,
+      lastRunAt: '2026-08-30T12:00:00.000Z',
+      lastRunStatus: 'completed',
+      lastRunFindingsToReview: 3,
+    }]);
+    render(<AiAgentsPage />);
+
+    const badge = await screen.findByTestId('ai-agent-findings-badge-a1');
+    expect(badge).toHaveTextContent('3 findings to review');
+    expect(badge).toHaveAttribute('href', '/ai-agents/runs#agent=a1');
+  });
+
+  it('does not render the badge when there is nothing left to review', async () => {
+    mockEndpoints([{
+      ...PARTNER_AGENT,
+      lastRunAt: '2026-08-30T12:00:00.000Z',
+      lastRunStatus: 'completed',
+      lastRunFindingsToReview: 0,
+    }]);
+    render(<AiAgentsPage />);
+
+    await screen.findByTestId('ai-agent-lastrun-a1');
+    expect(screen.queryByTestId('ai-agent-findings-badge-a1')).toBeNull();
+  });
+
+  it('does not render the badge when the list DTO carries no findings count at all', async () => {
+    mockEndpoints([PARTNER_AGENT]);
+    render(<AiAgentsPage />);
+
+    await screen.findByTestId('ai-agent-lastrun-a1');
+    expect(screen.queryByTestId('ai-agent-findings-badge-a1')).toBeNull();
+  });
+});
+
+describe('AiAgentsPage all-disabled primary CTA (#4187 UI critique 3)', () => {
+  it('focuses the first Re-enable button rather than pointing straight at "New agent"', async () => {
+    mockEndpoints([DISABLED_AGENT]);
+    render(<AiAgentsPage />);
+
+    await screen.findByTestId('ai-agents-all-disabled');
+    fireEvent.click(screen.getByTestId('ai-agents-all-disabled-reenable'));
+
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByTestId('ai-agent-reenable-a9')));
+    // "New agent" is still offered, as the secondary action.
+    expect(screen.getByTestId('ai-agents-all-disabled-create')).toBeInTheDocument();
+  });
+});
+
+describe('AiAgentsPage header (#4187 UI critique 3)', () => {
+  it('renders the page title through the shared PageHeader', async () => {
+    mockEndpoints([PARTNER_AGENT]);
+    render(<AiAgentsPage />);
+
+    const header = await screen.findByTestId('ai-agents-page-header');
+    expect(within(header).getByRole('heading', { level: 1, name: 'AI Agents' })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/settings/AiAgentsPage.tsx
+++ b/apps/web/src/components/settings/AiAgentsPage.tsx
@@ -13,6 +13,7 @@ import { navigateTo } from '@/lib/navigation';
 import { badgeClass, modeTone, runStatusTone } from '../aiAgents/statusBadge';
 import { Drawer } from '../shared/Drawer';
 import { EmptyState } from '../shared/EmptyState';
+import { PageHeader } from '../shared/PageHeader';
 import AiAgentForm, { type AiAgentDto } from './AiAgentForm';
 
 type Editing = { agent: AiAgentDto | null } | null;
@@ -53,6 +54,14 @@ export default function AiAgentsPage() {
   const [editorDirty, setEditorDirty] = useState(false);
   const [enablingId, setEnablingId] = useState<string | null>(null);
   const allOrgsHintId = useId();
+  /** The agent a Re-enable just restored, so its live row can show a one-time
+   *  "switched off, review its policy" note (Finding 1). Cleared by any
+   *  further state change — opening or closing the editor — rather than a
+   *  timer, so it never lingers past the moment it stops being news. */
+  const [justReenabledId, setJustReenabledId] = useState<string | null>(null);
+  /** First row's Re-enable button in the Disabled section — the target the
+   *  all-disabled empty state's primary CTA focuses (Finding 4). */
+  const firstDisabledReenableRef = useRef<HTMLButtonElement | null>(null);
 
   // Literal keys, not a dynamic `t()` on the token: the closed three-member
   // union is spelled out so the keyUsage guard verifies every label and hint
@@ -148,8 +157,17 @@ export default function AiAgentsPage() {
    * editor. Both the latch and the fragment are cleared here, together: the
    * latch alone would let the effect re-fire on the hash still in the URL.
    */
+  /** Opens the editor for an existing agent or a new one. The one place that
+   *  starts an edit, so it is also the one place that dismisses a still-open
+   *  re-enable note — opening the editor is unambiguously a "state change". */
+  const openEditor = useCallback((next: Editing) => {
+    setJustReenabledId(null);
+    setEditing(next);
+  }, []);
+
   const closeEditor = useCallback(() => {
     setEditing(null);
+    setJustReenabledId(null);
     appliedHashRef.current = null;
     setHashAgentId(null);
     // replaceState, not `location.hash = ''`: assigning leaves a bare '#' in
@@ -201,6 +219,10 @@ export default function AiAgentsPage() {
         onUnauthorized: UNAUTHORIZED,
       });
       enabled = true;
+      // Set on SUCCESS, before the reload below: the row this note belongs to
+      // is about to move from the Disabled section back into the live list,
+      // and the note has to survive that re-render to land on it there.
+      setJustReenabledId(agent.id);
     } catch (err) {
       handleActionError(err, t('aiAgentsPage.toasts.reenableFailed'));
     } finally {
@@ -214,20 +236,41 @@ export default function AiAgentsPage() {
    *  badge, or a plain sentence when the agent has never run. Both matter —
    *  "enabled, shadow" says nothing about whether the agent is actually
    *  doing anything. */
-  const lastRunCell = (agent: AiAgentDto) => (
-    <span className="inline-flex items-center gap-1.5" data-testid={`ai-agent-lastrun-${agent.id}`}>
-      {agent.lastRunAt && agent.lastRunStatus ? (
-        <>
-          <span className={badgeClass(runStatusTone(agent.lastRunStatus), { size: 'sm' })}>
-            {RUN_STATUS_LABEL[agent.lastRunStatus] ?? agent.lastRunStatus}
-          </span>
-          <span>{t('aiAgentsPage.lastRun.at', { at: formatDateTime(agent.lastRunAt) })}</span>
-        </>
-      ) : (
-        t('aiAgentsPage.lastRun.never')
-      )}
-    </span>
-  );
+  const lastRunCell = (agent: AiAgentDto) => {
+    // P0: a run can complete "successfully" and still leave findings an
+    // operator has not looked at yet — the status badge alone says nothing
+    // about that. The list DTO carries no `lastRunId`, so the badge links to
+    // the runs list filtered to this agent, same as the row's own Runs link,
+    // rather than the run directly.
+    const findings = agent.lastRunFindingsToReview;
+    const runHref = `/ai-agents/runs#agent=${agent.id}`;
+    return (
+      <span className="inline-flex flex-wrap items-center gap-1.5" data-testid={`ai-agent-lastrun-${agent.id}`}>
+        {agent.lastRunAt && agent.lastRunStatus ? (
+          <>
+            <span
+              className={badgeClass(runStatusTone(agent.lastRunStatus), { size: 'sm' })}
+              aria-label={`${t('aiAgentsPage.chipLabels.lastRunStatus')}: ${RUN_STATUS_LABEL[agent.lastRunStatus] ?? agent.lastRunStatus}`}
+            >
+              {RUN_STATUS_LABEL[agent.lastRunStatus] ?? agent.lastRunStatus}
+            </span>
+            <span>{t('aiAgentsPage.lastRun.at', { at: formatDateTime(agent.lastRunAt) })}</span>
+          </>
+        ) : (
+          t('aiAgentsPage.lastRun.never')
+        )}
+        {typeof findings === 'number' && findings > 0 && (
+          <a
+            href={runHref}
+            className={`${badgeClass('warning', { size: 'sm' })} hover:opacity-90`}
+            data-testid={`ai-agent-findings-badge-${agent.id}`}
+          >
+            {t('aiAgentsRuns.detail.findings.badge', { count: findings })}
+          </a>
+        )}
+      </span>
+    );
+  };
 
   const showFirstRun = loaded && !error && agents.length === 0;
   const showAllDisabled = loaded && !error && live.length === 0 && disabled.length > 0;
@@ -235,7 +278,7 @@ export default function AiAgentsPage() {
   const createButton = (testId: string) => (
     <button
       type="button"
-      onClick={() => setEditing({ agent: null })}
+      onClick={() => openEditor({ agent: null })}
       className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:opacity-90"
       data-testid={testId}
     >
@@ -246,19 +289,16 @@ export default function AiAgentsPage() {
 
   return (
     <div className="space-y-6" data-testid="ai-agents-page">
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <h1 className="flex items-center gap-2 text-xl font-semibold tracking-tight">
-            <Bot className="h-5 w-5" />
-            {t('aiAgentsPage.title')}
-          </h1>
-          <p className="text-muted-foreground">{t('aiAgentsPage.description')}</p>
-        </div>
-        {/* One create affordance at a time: while the first-run panel is on
-            screen it owns the call to action, and a second identical button in
-            the header just competes with it. */}
-        {!showFirstRun && !showAllDisabled && createButton('ai-agent-create-button')}
-      </div>
+      <PageHeader
+        testId="ai-agents-page-header"
+        icon={<Bot className="h-5 w-5" />}
+        title={t('aiAgentsPage.title')}
+        description={t('aiAgentsPage.description')}
+        // One create affordance at a time: while the first-run panel is on
+        // screen it owns the call to action, and a second identical button in
+        // the header just competes with it.
+        actions={!showFirstRun && !showAllDisabled ? createButton('ai-agent-create-button') : undefined}
+      />
 
       {error && (
         <div className="rounded-md border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">
@@ -347,7 +387,7 @@ export default function AiAgentsPage() {
           action={
             <button
               type="button"
-              onClick={() => setEditing({ agent: null })}
+              onClick={() => openEditor({ agent: null })}
               className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:opacity-90"
               data-testid="ai-agents-empty-create"
             >
@@ -360,7 +400,11 @@ export default function AiAgentsPage() {
 
       {/* Every agent disabled is a real state with a real recovery, and it is
           NOT the first-run state — saying "No agents yet" here hid both the
-          run history and the way back. */}
+          run history and the way back. The primary CTA is Re-enable-oriented
+          (the Disabled section is already expanded by the effect above; this
+          just moves focus down to it) rather than pointing straight back at
+          "New agent" — creating a duplicate of the very kind that already has
+          one, disabled. */}
       {showAllDisabled && (
         <EmptyState
           testId="ai-agents-all-disabled"
@@ -368,7 +412,33 @@ export default function AiAgentsPage() {
           icon={<PauseCircle className="h-7 w-7" />}
           title={t('aiAgentsPage.allDisabled.title')}
           description={t('aiAgentsPage.allDisabled.description')}
-          action={createButton('ai-agents-all-disabled-create')}
+          action={
+            <button
+              type="button"
+              onClick={() => {
+                setDisabledOpen(true);
+                // Deferred a frame: the section is already open in this state,
+                // but this also has to work the instant `disabledOpen` flips
+                // true from false, before that render has committed.
+                requestAnimationFrame(() => firstDisabledReenableRef.current?.focus());
+              }}
+              className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:opacity-90"
+              data-testid="ai-agents-all-disabled-reenable"
+            >
+              {t('aiAgentsPage.allDisabled.reenableCta')}
+            </button>
+          }
+          secondary={
+            <button
+              type="button"
+              onClick={() => openEditor({ agent: null })}
+              className="inline-flex h-9 items-center gap-1.5 rounded-md border px-3 text-sm font-medium hover:bg-muted"
+              data-testid="ai-agents-all-disabled-create"
+            >
+              <Plus className="h-4 w-4" />
+              {t('aiAgentsPage.actions.add')}
+            </button>
+          }
         />
       )}
 
@@ -387,6 +457,7 @@ export default function AiAgentsPage() {
                       4.2:1 against its own background in light mode. */}
                   <span
                     className={badgeClass('neutral', { size: 'sm' })}
+                    aria-label={`${t('aiAgentsPage.chipLabels.kind')}: ${t(/* i18n-dynamic */ `aiAgentsPage.kinds.${agent.kind}`)}`}
                     data-testid={`ai-agent-kind-badge-${agent.id}`}
                   >
                     {t(/* i18n-dynamic */ `aiAgentsPage.kinds.${agent.kind}`)}
@@ -397,6 +468,7 @@ export default function AiAgentsPage() {
                     <span
                       className={badgeClass('info', { size: 'sm' })}
                       aria-describedby={allOrgsHintId}
+                      aria-label={`${t('aiAgentsPage.chipLabels.ownership')}: ${t('aiAgentsPage.allOrgs')}`}
                       data-testid={`ai-agent-allorgs-${agent.id}`}
                     >
                       {t('aiAgentsPage.allOrgs')}
@@ -404,14 +476,39 @@ export default function AiAgentsPage() {
                   )}
                 </div>
                 <p className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-                  <span className={badgeClass(modeTone(agent.mode), { size: 'sm' })}>
-                    {t(/* i18n-dynamic */ `aiAgentsPage.modes.${agent.mode}`)}
+                  {/* One word, not the editor's full sentence ("Shadow —
+                      investigate and propose only") — this is a row chip
+                      among four others, not the place to re-explain the
+                      mode. */}
+                  <span
+                    className={badgeClass(modeTone(agent.mode), { size: 'sm' })}
+                    aria-label={`${t('aiAgentsPage.chipLabels.mode')}: ${t(/* i18n-dynamic */ `aiAgentsPage.modeChoice.${agent.mode}`)}`}
+                  >
+                    {t(/* i18n-dynamic */ `aiAgentsPage.modeChoice.${agent.mode}`)}
                   </span>
-                  <span className={badgeClass(agent.enabled ? 'success' : 'muted', { size: 'sm' })}>
-                    {agent.enabled ? t('aiAgentsPage.stateEnabled') : t('aiAgentsPage.stateDisabled')}
+                  {/* Deliberately NOT "Enabled"/"Disabled" (Finding 1): those
+                      words are also the Disabled SECTION's own name, so a
+                      just-restored agent — enabled: false by design, see the
+                      re-enable note below — read as if it had landed back in
+                      that section. "Running"/"Not running" names the thing
+                      this badge actually reports. */}
+                  <span
+                    className={badgeClass(agent.enabled ? 'success' : 'muted', { size: 'sm' })}
+                    aria-label={`${t('aiAgentsPage.chipLabels.running')}: ${agent.enabled ? t('aiAgentsPage.runningBadge.running') : t('aiAgentsPage.runningBadge.notRunning')}`}
+                    data-testid={`ai-agent-running-badge-${agent.id}`}
+                  >
+                    {agent.enabled ? t('aiAgentsPage.runningBadge.running') : t('aiAgentsPage.runningBadge.notRunning')}
                   </span>
                   {lastRunCell(agent)}
                 </p>
+                {justReenabledId === agent.id && (
+                  <p
+                    className="mt-1 text-xs text-muted-foreground"
+                    data-testid={`ai-agent-reenabled-note-${agent.id}`}
+                  >
+                    {t('aiAgentsPage.reenableNote')}
+                  </p>
+                )}
               </div>
               {/* A real navigation, not a fragment on this page — a plain
                   anchor, so cmd-click and the browser's own affordances work. */}
@@ -424,7 +521,7 @@ export default function AiAgentsPage() {
               </a>
               <button
                 type="button"
-                onClick={() => setEditing({ agent })}
+                onClick={() => openEditor({ agent })}
                 className="rounded-md border px-3 py-1.5 text-sm font-medium"
                 data-testid={`ai-agent-edit-${agent.id}`}
               >
@@ -457,7 +554,7 @@ export default function AiAgentsPage() {
             {t('aiAgentsPage.disabledSection.hint')}
           </p>
           <ul className="divide-y border-t">
-            {disabled.map((agent) => (
+            {disabled.map((agent, index) => (
               <li
                 key={agent.id}
                 className="flex flex-wrap items-center gap-3 p-3"
@@ -466,11 +563,18 @@ export default function AiAgentsPage() {
                 <div className="min-w-0 flex-1">
                   <div className="flex flex-wrap items-center gap-2">
                     <span className="font-medium">{agent.name}</span>
-                    <span className={badgeClass('neutral', { size: 'sm' })}>
+                    <span
+                      className={badgeClass('neutral', { size: 'sm' })}
+                      aria-label={`${t('aiAgentsPage.chipLabels.kind')}: ${t(/* i18n-dynamic */ `aiAgentsPage.kinds.${agent.kind}`)}`}
+                    >
                       {t(/* i18n-dynamic */ `aiAgentsPage.kinds.${agent.kind}`)}
                     </span>
                     {agent.allOrgs && (
-                      <span className={badgeClass('info', { size: 'sm' })} aria-describedby={allOrgsHintId}>
+                      <span
+                        className={badgeClass('info', { size: 'sm' })}
+                        aria-describedby={allOrgsHintId}
+                        aria-label={`${t('aiAgentsPage.chipLabels.ownership')}: ${t('aiAgentsPage.allOrgs')}`}
+                      >
                         {t('aiAgentsPage.allOrgs')}
                       </span>
                     )}
@@ -493,6 +597,11 @@ export default function AiAgentsPage() {
                 </a>
                 <button
                   type="button"
+                  // The all-disabled empty state's primary CTA focuses THIS
+                  // button on the first row (Finding 4) — only ever the first,
+                  // so re-enabling agents one at a time never leaves the ref
+                  // pointing at a row that has since left the list.
+                  ref={index === 0 ? firstDisabledReenableRef : undefined}
                   onClick={() => void reenable(agent)}
                   disabled={enablingId !== null}
                   className="rounded-md border px-3 py-1.5 text-sm font-medium disabled:opacity-60"

--- a/apps/web/src/components/shared/EmptyState.test.tsx
+++ b/apps/web/src/components/shared/EmptyState.test.tsx
@@ -64,6 +64,20 @@ describe('EmptyState', () => {
     expect(screen.getByTestId('runs-empty').className).toContain('border-dashed');
   });
 
+  it('uses the dashed frame by default (variant="framed")', () => {
+    render(<EmptyState title="No runs yet" testId="runs-empty" />);
+    const container = screen.getByTestId('runs-empty');
+    expect(container.className).toContain('border-dashed');
+    expect(container.className).toContain('border');
+  });
+
+  it('drops the dashed border and background for variant="plain"', () => {
+    render(<EmptyState title="No runs yet" testId="runs-empty" variant="plain" />);
+    const container = screen.getByTestId('runs-empty');
+    expect(container.className).not.toContain('border-dashed');
+    expect(container.className).not.toContain('border-border');
+  });
+
   it('applies a distinct className for the sm size vs md', () => {
     const { container: smContainer } = render(<EmptyState title="Compact" size="sm" testId="sm-empty" />);
     const { container: mdContainer } = render(<EmptyState title="Full" size="md" testId="md-empty" />);

--- a/apps/web/src/components/shared/EmptyState.tsx
+++ b/apps/web/src/components/shared/EmptyState.tsx
@@ -15,6 +15,13 @@ export interface EmptyStateProps {
   secondary?: ReactNode;
   /** `sm` = compact, for inline table/panel empties. `md` = page-level. Defaults to `md`. */
   size?: 'sm' | 'md';
+  /**
+   * `framed` (default) = the dashed-border card, for a standalone empty
+   * section. `plain` = no border/background, for an empty state already
+   * nested inside another card or panel, where a second frame would nest
+   * cards. Both use the same icon/title/description/action layout.
+   */
+  variant?: 'framed' | 'plain';
   /** data-testid passthrough on the outerframed card. */
   testId?: string;
   className?: string;
@@ -58,16 +65,20 @@ export function EmptyState({
   action,
   secondary,
   size = 'md',
+  variant = 'framed',
   testId,
   className,
   headingLevel = 3,
 }: EmptyStateProps): JSX.Element {
   const Heading = (`h${headingLevel}` as const) as 'h2' | 'h3' | 'h4';
   const containerClassName = [
+    'rounded-xl text-center',
     // No `--border-strong` token exists (globals.css) — the plain `--border`
     // dark value (18% lightness) is near-invisible for a 1px dashed line, so
-    // dark mode gets an explicit stronger override.
-    'rounded-xl border border-dashed border-border dark:border-zinc-600 text-center',
+    // dark mode gets an explicit stronger override. `plain` skips the frame
+    // entirely — it's for an empty state already nested inside another
+    // card/panel, where a second dashed border would be a nested card.
+    variant === 'framed' ? 'border border-dashed border-border dark:border-zinc-600' : '',
     SIZE_CONTAINER_CLASSES[size],
     className,
   ]

--- a/apps/web/src/components/shared/PageHeader.test.tsx
+++ b/apps/web/src/components/shared/PageHeader.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { PageHeader } from './PageHeader';
+
+describe('PageHeader', () => {
+  it('renders the title as an h1', () => {
+    render(<PageHeader title="AI impact" />);
+    const heading = screen.getByRole('heading', { name: 'AI impact', level: 1 });
+    expect(heading).toBeInTheDocument();
+  });
+
+  it('renders the description when provided', () => {
+    render(<PageHeader title="AI impact" description="What your AI agents handled." />);
+    expect(screen.getByText('What your AI agents handled.')).toBeInTheDocument();
+  });
+
+  it('omits the description block entirely when not provided', () => {
+    render(<PageHeader title="AI impact" testId="header" />);
+    // No stray empty <p> left behind for a missing description.
+    const header = screen.getByTestId('header');
+    expect(header.querySelector('p')).not.toBeInTheDocument();
+  });
+
+  it('constrains the description to a readable measure', () => {
+    render(<PageHeader title="AI impact" description="What your AI agents handled." />);
+    expect(screen.getByText('What your AI agents handled.').className).toContain('max-w-prose');
+  });
+
+  it('renders the icon inside a muted rounded tile when provided', () => {
+    render(<PageHeader title="AI impact" icon={<svg data-testid="page-header-icon" />} testId="header" />);
+    const icon = screen.getByTestId('page-header-icon');
+    expect(icon).toBeInTheDocument();
+    const tile = icon.parentElement;
+    expect(tile?.className).toContain('bg-muted');
+    expect(tile?.className).toContain('rounded');
+  });
+
+  it('renders no icon tile when icon is omitted', () => {
+    render(<PageHeader title="AI impact" testId="header" />);
+    const header = screen.getByTestId('header');
+    expect(header.querySelector('.bg-muted')).not.toBeInTheDocument();
+  });
+
+  it('renders the actions slot', () => {
+    render(<PageHeader title="AI impact" actions={<button type="button">Refresh</button>} />);
+    expect(screen.getByRole('button', { name: 'Refresh' })).toBeInTheDocument();
+  });
+
+  it('renders no actions container when actions is omitted', () => {
+    render(<PageHeader title="AI impact" testId="header" />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('lets actions wrap onto their own line below md', () => {
+    render(<PageHeader title="AI impact" actions={<button type="button">Refresh</button>} testId="header" />);
+    const button = screen.getByRole('button', { name: 'Refresh' });
+    // Walk up to the actions container (parent of the button).
+    const actionsContainer = button.parentElement;
+    expect(actionsContainer?.className).toContain('flex-wrap');
+  });
+
+  it('passes through data-testid on the outer element', () => {
+    render(<PageHeader title="AI impact" testId="ai-impact-header" />);
+    expect(screen.getByTestId('ai-impact-header')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/shared/PageHeader.tsx
+++ b/apps/web/src/components/shared/PageHeader.tsx
@@ -1,0 +1,53 @@
+import type { JSX, ReactNode } from 'react';
+
+export interface PageHeaderProps {
+  /** A lucide icon element, rendered in a muted rounded tile beside the title. */
+  icon?: ReactNode;
+  title: string;
+  /** Muted supporting copy under the title, clamped to a readable measure. */
+  description?: string;
+  /** Right-aligned action slot (buttons, a window switcher, etc.). Wraps onto
+   *  its own line below `md` rather than crowding the title. */
+  actions?: ReactNode;
+  /** data-testid passthrough on the outer row. */
+  testId?: string;
+}
+
+/**
+ * Shared page-level header row: an optional icon tile, an `h1` title, an
+ * optional description, and a right-aligned actions slot. Extracted from the
+ * pattern duplicated across AI Agents pages (ImpactPage, RunsListPage) so the
+ * title/description/actions layout — and its `md`-breakpoint wrap behavior —
+ * lives in one place.
+ */
+export function PageHeader({ icon, title, description, actions, testId }: PageHeaderProps): JSX.Element {
+  return (
+    <div
+      className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between"
+      data-testid={testId}
+    >
+      <div className="flex min-w-0 items-start gap-3">
+        {icon && (
+          <div
+            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground"
+            aria-hidden="true"
+          >
+            {icon}
+          </div>
+        )}
+        <div className="min-w-0">
+          <h1 className="text-xl font-semibold tracking-tight">{title}</h1>
+          {description && (
+            <p className="mt-1 max-w-prose text-muted-foreground">{description}</p>
+          )}
+        </div>
+      </div>
+
+      {actions && (
+        <div className="flex flex-wrap items-center gap-2 md:justify-end">{actions}</div>
+      )}
+    </div>
+  );
+}
+
+export default PageHeader;

--- a/apps/web/src/lib/i18n/translationCoverage.test.ts
+++ b/apps/web/src/lib/i18n/translationCoverage.test.ts
@@ -88,7 +88,11 @@ const namespaceDuplicateBaselines = {
     // +6: aiAgentsPage.runs (#3828 Task 4) — "Status" and "Manual" are the
     // same cognate in pt-BR (already accepted elsewhere in this namespace),
     // and "OK" is locale-invariant.
-    'settings.json': 120,
+    // +1: aiAgentsPage.chipLabels.running (#4187 UI critique 3) — "Status" is
+    // the same cognate in pt-BR (already accepted above in this namespace).
+    // +1: aiAgentsRuns.detail.evidence.labels.cveId (#4822 review) — "CVE" is
+    // locale-invariant (the acronym is never translated).
+    'settings.json': 122,
     // +1: ticketTimeBilling.noAmount — the em-dash placeholder for a row with
     // no amount is locale-invariant punctuation, identical in every catalog.
     // +1: ticketWorkbench.invoice.missingRateEntry "{{description}} — {{hours}} h" is two
@@ -172,7 +176,9 @@ const namespaceDuplicateBaselines = {
     // +3: contactsCard / bulkContactImport (#3258 W04) — "Roles" is the same
     // word in Spanish (plural of "rol"), and the contacts UI labels it in
     // three places (the list column, the form fieldset and the CSV mapping row).
-    'settings.json': 124,
+    // +1: aiAgentsRuns.detail.evidence.labels.cveId (#4822 review) — "CVE" is
+    // locale-invariant (the acronym is never translated).
+    'settings.json': 125,
     // +1: ticketTimeBilling.noAmount — the em-dash placeholder for a row with
     // no amount is locale-invariant punctuation, identical in every catalog.
     // +1: ticketWorkbench.invoice.missingRateEntry "{{description}} — {{hours}} h" is two
@@ -269,7 +275,11 @@ const namespaceDuplicateBaselines = {
     // — "Contacts" and "Site" are the same words in French, and
     // TERMINOLOGY.md pins site → site for both French locales, so the three
     // site labels plus the tab title and its nav entry stay identical.
-    'settings.json': 165,
+    // +1: aiAgentsPage.chipLabels.mode (#4187 UI critique 3) — "Mode" is the
+    // same word in French (already accepted above in this namespace).
+    // +1: aiAgentsRuns.detail.evidence.labels.cveId (#4822 review) — "CVE" is
+    // locale-invariant (the acronym is never translated).
+    'settings.json': 167,
     // +1: ticketTimeBilling.noAmount — the em-dash placeholder for a row with
     // no amount is locale-invariant punctuation, identical in every catalog.
     // +1: ticketWorkbench.invoice.missingRateEntry "{{description}} — {{hours}} h" is two
@@ -360,7 +370,11 @@ const namespaceDuplicateBaselines = {
     // — "Contacts" and "Site" are the same words in Canadian French, and
     // TERMINOLOGY.md pins site → site for both French locales, so the three
     // site labels plus the tab title and its nav entry stay identical.
-    'settings.json': 170,
+    // +1: aiAgentsPage.chipLabels.mode (#4187 UI critique 3) — "Mode" is the
+    // same word in Canadian French (already accepted above in this namespace).
+    // +1: aiAgentsRuns.detail.evidence.labels.cveId (#4822 review) — "CVE" is
+    // locale-invariant (the acronym is never translated).
+    'settings.json': 172,
     // +1: ticketTimeBilling.noAmount — the em-dash placeholder for a row with
     // no amount is locale-invariant punctuation, identical in every catalog.
     // +1: ticketWorkbench.invoice.missingRateEntry "{{description}} — {{hours}} h" is two
@@ -442,7 +456,11 @@ const namespaceDuplicateBaselines = {
     // — "Name" is the same word in German, and the contacts UI labels it in
     // four places (the list column, the form field, the CSV mapping row and
     // the import preview column).
-    'settings.json': 183,
+    // +1: aiAgentsPage.chipLabels.running (#4187 UI critique 3) — "Status" is
+    // the same word in German (already accepted above in this namespace).
+    // +1: aiAgentsRuns.detail.evidence.labels.cveId (#4822 review) — "CVE" is
+    // locale-invariant (the acronym is never translated).
+    'settings.json': 185,
     // +1: ticketTimeBilling.noAmount — the em-dash placeholder for a row with
     // no amount is locale-invariant punctuation, identical in every catalog.
     // +1: ticketWorkbench.invoice.missingRateEntry "{{description}} — {{hours}} h" is two
@@ -509,7 +527,9 @@ const namespaceDuplicateBaselines = {
     // rather than root-caused here).
     // +4: aiAgentsPage.runs (#3828 Task 4) — "Trigger" and "Ticket" are
     // standard loanwords in it-IT technical UI, and "OK" is locale-invariant.
-    'settings.json': 162,
+    // +1: aiAgentsRuns.detail.evidence.labels.cveId (#4822 review) — "CVE" is
+    // locale-invariant (the acronym is never translated).
+    'settings.json': 163,
     // +1: ticketTimeBilling.noAmount — the em-dash placeholder for a row with
     // no amount is locale-invariant punctuation, identical in every catalog.
     // +1: ticketWorkbench.invoice.missingRateEntry "{{description}} — {{hours}} h" is two
@@ -569,7 +589,9 @@ const namespaceDuplicateBaselines = {
     // +3: contactsCard / bulkContactImport / contactImportPreview (#3258 W04)
     // — "Site" is the established loanword in tr-TR (bulkOrgImport already
     // uses it), so the three site labels stay identical.
-    'settings.json': 68,
+    // +1: aiAgentsRuns.detail.evidence.labels.cveId (#4822 review) — "CVE" is
+    // locale-invariant (the acronym is never translated).
+    'settings.json': 69,
     // +1: ticketTimeBilling.noAmount — the em-dash placeholder for a row with
     // no amount is locale-invariant punctuation, identical in every catalog.
     'tickets.json': 12,

--- a/apps/web/src/locales/de-DE/approvals.json
+++ b/apps/web/src/locales/de-DE/approvals.json
@@ -14,7 +14,25 @@
   "batch": {
     "approveAll": "Alle genehmigen ({{count}})",
     "declineAll": "Alle ablehnen ({{count}})",
-    "groupTitle": "{{count}} ähnliche Anfragen · {{tool}}"
+    "groupTitle": "{{count}} ähnliche Anfragen · {{tool}}",
+    "moreHostnames": "+{{count}} weitere",
+    "denyConfirmSummary": "Dies lehnt {{count}} Anfragen für {{org}} ab."
+  },
+  "filters": {
+    "orgLabel": "Organisation",
+    "allOrganizations": "Alle Organisationen ({{count}})",
+    "orgOption": "{{name}} ({{count}} ausstehend)",
+    "searchLabel": "Suche",
+    "searchPlaceholder": "Suche nach Aktion, Gerät oder Agent…",
+    "sortLabel": "Sortieren nach",
+    "sortExpiringSoonest": "Läuft bald ab",
+    "sortNewest": "Neueste",
+    "showingLoaded": "{{shown}} von {{loaded}} geladenen werden angezeigt",
+    "clearFilters": "Filter zurücksetzen",
+    "noMatches": {
+      "title": "Keine Genehmigungen entsprechen Ihren Filtern",
+      "description": "Versuchen Sie eine andere Organisation oder einen anderen Suchbegriff, oder setzen Sie Ihre Filter zurück."
+    }
   },
   "risk": {
     "low": "Niedriges Risiko",

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -17,6 +17,12 @@
     },
     "detail": {
       "notFoundDescription": "Dieser Lauf wurde möglicherweise gelöscht, oder der Link ist veraltet.",
+      "pageTitle": "{{agent}} · {{started}} · Lauf | Breeze RMM",
+      "header": {
+        "title": "Lauf von {{agent}}",
+        "startedLabel": "Gestartet",
+        "machineVerdict": "Maschinelles Ergebnis: {{verdict}}"
+      },
       "summary": {
         "title": "Was der Agent gefunden hat"
       },
@@ -38,13 +44,16 @@
           "checkedAt": "Geprüft",
           "cveIds": "CVE-IDs",
           "cveCount": "CVE-Anzahl",
+          "cveId": "CVE",
+          "cvssScore": "CVSS-Bewertung",
           "osType": "Betriebssystemtyp",
           "openCriticalCount": "Offene kritische CVEs"
         }
       },
       "sweep": {
         "caption": "Eine Zeile pro Problem, das dieser Durchlauf gefunden hat, mit der jeweils vorgeschlagenen Aktion.",
-        "reviewPermissions": "Agentberechtigungen prüfen"
+        "reviewPermissions": "Agentberechtigungen prüfen",
+        "checksLabel": "Prüfungen:"
       },
       "trace": {
         "description": "Jeder Tool-Aufruf, den der Agent vorgeschlagen, ausgeführt oder abgelehnt bekommen hat, in zeitlicher Reihenfolge.",
@@ -53,6 +62,7 @@
       "ledger": {
         "description": "Nur die tatsächlich ausgeführten Aufrufe, mit Laufzeit und etwaigem Fehler.",
         "emptyDescription": "Tools, die der Agent tatsächlich aufgerufen hat, werden hier aufgelistet.",
+        "collapsedSummary": "Tool-Ausführungen ({{count}}) — wie oben im Trace",
         "statuses": {
           "pending": "Ausstehend",
           "approved": "Genehmigt",
@@ -1475,6 +1485,7 @@
       "nextRun": "Nächster Lauf {{at}} ({{timezone}})",
       "nextRunInvalid": "Ungültiger Zeitplan",
       "nextRunNone": "Im nächsten Jahr fällt kein Lauf an.",
+      "useMyTimezone": "Meine Zeitzone verwenden",
       "kindLabels": {
         "disk_pressure": "Speicherplatzdruck",
         "stale_agents": "Veraltete Agenten",
@@ -1531,6 +1542,18 @@
     "allOrgsHint": "Partnerweit: gilt für jede Organisation, sofern eine Organisation die Richtlinie nicht verschärft.",
     "stateEnabled": "Aktiviert",
     "stateDisabled": "Deaktiviert",
+    "runningBadge": {
+      "running": "Läuft",
+      "notRunning": "Läuft nicht"
+    },
+    "reenableNote": "Wiederhergestellt, aber ausgeschaltet. Prüfen Sie zuerst die Richtlinie, bevor Sie ihn einschalten.",
+    "chipLabels": {
+      "kind": "Art",
+      "ownership": "Zugehörigkeit",
+      "mode": "Modus",
+      "running": "Status",
+      "lastRunStatus": "Ergebnis des letzten Laufs"
+    },
     "lastRun": {
       "never": "Nie ausgeführt",
       "at": "Letzte Ausführung {{at}}"
@@ -1553,7 +1576,8 @@
     },
     "allDisabled": {
       "title": "Alle Agenten sind deaktiviert",
-      "description": "Es läuft nichts. Aktivieren Sie unten einen Agenten wieder oder erstellen Sie einen neuen."
+      "description": "Es läuft gerade nichts.",
+      "reenableCta": "Einen Agenten wieder aktivieren"
     },
     "errors": {
       "load": "Agenten konnten nicht geladen werden.",
@@ -1664,6 +1688,8 @@
       "recipientRolesFailed": "Rollen konnten nicht geladen werden; Benachrichtigungsempfänger lassen sich derzeit nicht ändern.",
       "supervisedActionKeysHint": "Vorgänge, die dieser Agent OHNE einen menschlichen Klick auf Genehmigen ausführen darf, wenn eine passende Richtlinie existiert und im Expositionslimit der Organisation noch Spielraum ist. Jeder Vorgang durchläuft zur Ausführungszeit weiterhin die Live-Schutzmechanismen, den Kill-Switch und die Organisationslimits.",
       "supervisedActionKeysEmpty": "Es sind keine per Richtlinie entscheidbaren Aktionen registriert.",
+      "supervisedActionKeysCeilingSummary_one": "Obergrenze für Organisationen — {{count}} Schlüssel",
+      "supervisedActionKeysCeilingSummary_other": "Obergrenze für Organisationen — {{count}} Schlüssel",
       "supervisedActionKeysFailed": "Die Liste der per Richtlinie entscheidbaren Aktionen konnte nicht geladen werden, daher kann die unbeaufsichtigte Autorisierung derzeit nicht geändert werden.",
       "ticketAutonomousWrites": "Autonome Ticket-Schreibvorgänge",
       "ticketAutonomousWritesHint": "Nur Organisationsüberschreibung — autonome Ticket-Schreibvorgänge erfordern den Aktionsmodus und diese Opt-in-Einstellung auf Organisationsebene",
@@ -1673,6 +1699,35 @@
       "toolSuggestLabel": "Bekanntes Werkzeug hinzufügen",
       "toolSuggestHint": "Die Vorschläge stammen aus dem Register richtlinienentscheidbarer Aktionen und sind nicht die vollständige Werkzeugliste. Alles andere, was dieser Agent nutzen darf, kann oben weiterhin eingetippt werden.",
       "toolSuggestAdd": "Hinzufügen"
+    },
+    "policyKeys": {
+      "tools": {
+        "manage_services": "Dienste",
+        "manage_startup_items": "Autostartelemente",
+        "manage_scheduled_tasks": "Geplante Aufgaben",
+        "security_scan": "Sicherheitsscan"
+      },
+      "actions": {
+        "manage_services": {
+          "start": "Einen Dienst starten",
+          "stop": "Einen Dienst stoppen",
+          "restart": "Einen Dienst neu starten"
+        },
+        "manage_startup_items": {
+          "disable": "Ein Autostartelement deaktivieren",
+          "enable": "Ein Autostartelement aktivieren"
+        },
+        "manage_scheduled_tasks": {
+          "run": "Eine geplante Aufgabe ausführen",
+          "disable": "Eine geplante Aufgabe deaktivieren",
+          "enable": "Eine geplante Aufgabe aktivieren"
+        },
+        "security_scan": {
+          "quarantine": "Eine Bedrohung isolieren",
+          "remove": "Eine Bedrohung entfernen",
+          "restore": "Eine Bedrohung wiederherstellen"
+        }
+      }
     },
     "loading": "Agenten werden geladen …",
     "runs": {
@@ -1689,8 +1744,6 @@
         "status": "Status",
         "trigger": "Auslöser",
         "verdict": "Ergebnis",
-        "queued": "Eingereiht",
-        "finished": "Beendet",
         "cost": "Kosten"
       },
       "statuses": {
@@ -1984,6 +2037,7 @@
           "llmSpend": "LLM-Ausgaben"
         }
       },
+      "freshnessLabel": "Aktualität der Daten",
       "freshness": "Daten bis {{through}} (UTC) · neu aufgebaut {{rebuiltAt}}",
       "freshnessNeverRebuilt": "Noch nicht erstellt — der erste Neuaufbau läuft heute Nacht",
       "positiveFeedbackRate": "Quote positiver Rückmeldungen",
@@ -1994,7 +2048,10 @@
         "title": "Gewichtungen für Zeitersparnis bearbeiten",
         "description": "Legen Sie fest, wie viele Minuten menschlicher Zeit jedem Ergebnis angerechnet werden. Diese Gewichtungen ändern nur die Schätzung — niemals, was Ihre KI-Agenten tun.",
         "unitSuffix": "Min.",
+        "rangeHint": "Geben Sie einen Wert zwischen {{min}} und {{max}} Minuten ein.",
+        "defaultValue": "Standard {{minutes}} Min.",
         "preview": "Geschätzte Zeitersparnis in diesem Zeitraum: {{from}} → {{to}}",
+        "noOutcomesPreview": "Keine Ergebnisse in diesem Zeitraum zur Vorschau",
         "save": "Speichern",
         "saving": "Wird gespeichert…",
         "reset": "Auf Standardwerte zurücksetzen",

--- a/apps/web/src/locales/en/approvals.json
+++ b/apps/web/src/locales/en/approvals.json
@@ -14,7 +14,25 @@
   "batch": {
     "approveAll": "Approve all ({{count}})",
     "declineAll": "Decline all ({{count}})",
-    "groupTitle": "{{count}} similar requests · {{tool}}"
+    "groupTitle": "{{count}} similar requests · {{tool}}",
+    "moreHostnames": "+{{count}} more",
+    "denyConfirmSummary": "This declines {{count}} requests for {{org}}."
+  },
+  "filters": {
+    "orgLabel": "Organization",
+    "allOrganizations": "All organizations ({{count}})",
+    "orgOption": "{{name}} ({{count}} pending)",
+    "searchLabel": "Search",
+    "searchPlaceholder": "Search by action, machine, or agent…",
+    "sortLabel": "Sort by",
+    "sortExpiringSoonest": "Expiring soonest",
+    "sortNewest": "Newest",
+    "showingLoaded": "Showing {{shown}} of {{loaded}} loaded",
+    "clearFilters": "Clear filters",
+    "noMatches": {
+      "title": "No approvals match your filters",
+      "description": "Try a different organization or search term, or clear your filters."
+    }
   },
   "risk": {
     "low": "Low risk",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -17,6 +17,12 @@
     },
     "detail": {
       "notFoundDescription": "This run may have been deleted, or the link may be out of date.",
+      "pageTitle": "{{agent}} · {{started}} · Run | Breeze RMM",
+      "header": {
+        "title": "{{agent}} run",
+        "startedLabel": "Started",
+        "machineVerdict": "Machine verdict: {{verdict}}"
+      },
       "summary": {
         "title": "What the agent found"
       },
@@ -38,13 +44,16 @@
           "checkedAt": "Checked",
           "cveIds": "CVE IDs",
           "cveCount": "CVE count",
+          "cveId": "CVE",
+          "cvssScore": "CVSS score",
           "osType": "OS type",
           "openCriticalCount": "Open critical CVEs"
         }
       },
       "sweep": {
         "caption": "One row per problem this sweep found, with the action it proposed.",
-        "reviewPermissions": "Review agent permissions"
+        "reviewPermissions": "Review agent permissions",
+        "checksLabel": "Checks:"
       },
       "trace": {
         "description": "Every tool call the agent proposed, executed, or was denied, in order.",
@@ -53,6 +62,7 @@
       "ledger": {
         "description": "Only the calls that actually ran, with their timing and any error.",
         "emptyDescription": "Tools the agent actually invoked will be listed here.",
+        "collapsedSummary": "Tool executions ({{count}}) — same as the trace above",
         "statuses": {
           "pending": "Pending",
           "approved": "Approved",
@@ -1475,6 +1485,7 @@
       "nextRun": "Next run {{at}} ({{timezone}})",
       "nextRunInvalid": "Invalid schedule",
       "nextRunNone": "No run falls in the next year.",
+      "useMyTimezone": "Use my timezone",
       "kindLabels": {
         "disk_pressure": "Disk pressure",
         "stale_agents": "Stale agents",
@@ -1531,6 +1542,18 @@
     "allOrgsHint": "Partner-wide: applies to every organization unless an organization tightens it.",
     "stateEnabled": "Enabled",
     "stateDisabled": "Disabled",
+    "runningBadge": {
+      "running": "Running",
+      "notRunning": "Not running"
+    },
+    "reenableNote": "Restored, switched off. Review its policy, then turn it on.",
+    "chipLabels": {
+      "kind": "Kind",
+      "ownership": "Ownership",
+      "mode": "Mode",
+      "running": "Status",
+      "lastRunStatus": "Last run outcome"
+    },
     "lastRun": {
       "never": "Never run",
       "at": "Last run {{at}}"
@@ -1553,7 +1576,8 @@
     },
     "allDisabled": {
       "title": "All agents are disabled",
-      "description": "Nothing is running. Re-enable one below to bring it back, or create a new agent."
+      "description": "Nothing is running right now.",
+      "reenableCta": "Re-enable an agent"
     },
     "errors": {
       "load": "Could not load agents.",
@@ -1664,6 +1688,8 @@
       "recipientRolesFailed": "Couldn't load roles, so notification recipients can't be changed right now.",
       "supervisedActionKeysHint": "Operations this agent may execute WITHOUT a human clicking approve, when a matching policy exists and the org's exposure cap has room. Each one still passes live guardrails, the kill switch, and per-org caps at execution time.",
       "supervisedActionKeysEmpty": "No policy-decidable actions are registered.",
+      "supervisedActionKeysCeilingSummary_one": "Ceiling for organizations — {{count}} key",
+      "supervisedActionKeysCeilingSummary_other": "Ceiling for organizations — {{count}} keys",
       "supervisedActionKeysFailed": "Couldn't load the policy-decidable action list, so unattended authorization can't be changed right now.",
       "ticketAutonomousWrites": "Autonomous ticket writes",
       "ticketAutonomousWritesHint": "Org override only — autonomous ticket writes require act mode and this org-level opt-in",
@@ -1673,6 +1699,35 @@
       "toolSuggestLabel": "Add a known tool",
       "toolSuggestHint": "Suggestions come from the policy-decidable action registry, which is not the full list of tools. Anything else this agent may use can still be typed above.",
       "toolSuggestAdd": "Add"
+    },
+    "policyKeys": {
+      "tools": {
+        "manage_services": "Services",
+        "manage_startup_items": "Startup items",
+        "manage_scheduled_tasks": "Scheduled tasks",
+        "security_scan": "Security scan"
+      },
+      "actions": {
+        "manage_services": {
+          "start": "Start a service",
+          "stop": "Stop a service",
+          "restart": "Restart a service"
+        },
+        "manage_startup_items": {
+          "disable": "Disable a startup item",
+          "enable": "Enable a startup item"
+        },
+        "manage_scheduled_tasks": {
+          "run": "Run a scheduled task",
+          "disable": "Disable a scheduled task",
+          "enable": "Enable a scheduled task"
+        },
+        "security_scan": {
+          "quarantine": "Quarantine a threat",
+          "remove": "Remove a threat",
+          "restore": "Restore a threat"
+        }
+      }
     },
     "loading": "Loading agents…",
     "runs": {
@@ -1689,8 +1744,6 @@
         "status": "Status",
         "trigger": "Trigger",
         "verdict": "Verdict",
-        "queued": "Queued",
-        "finished": "Finished",
         "cost": "Cost"
       },
       "statuses": {
@@ -1984,6 +2037,7 @@
           "llmSpend": "LLM spend"
         }
       },
+      "freshnessLabel": "Data freshness",
       "freshness": "Data through {{through}} (UTC) · rebuilt {{rebuiltAt}}",
       "freshnessNeverRebuilt": "Not built yet — first rebuild runs nightly",
       "positiveFeedbackRate": "Positive feedback rate",
@@ -1994,7 +2048,10 @@
         "title": "Edit time-saved weights",
         "description": "Set how many minutes of human time each outcome is credited with. These weights only change the estimate — they never change what your AI agents do.",
         "unitSuffix": "min",
+        "rangeHint": "Enter a value between {{min}} and {{max}} minutes.",
+        "defaultValue": "Default {{minutes}} min",
         "preview": "Estimated time saved this window: {{from}} → {{to}}",
+        "noOutcomesPreview": "No outcomes in this window to preview against",
         "save": "Save",
         "saving": "Saving…",
         "reset": "Reset to defaults",

--- a/apps/web/src/locales/es-419/approvals.json
+++ b/apps/web/src/locales/es-419/approvals.json
@@ -14,7 +14,25 @@
   "batch": {
     "approveAll": "Aprobar todo ({{count}})",
     "declineAll": "Rechazar todo ({{count}})",
-    "groupTitle": "{{count}} solicitudes similares · {{tool}}"
+    "groupTitle": "{{count}} solicitudes similares · {{tool}}",
+    "moreHostnames": "+{{count}} más",
+    "denyConfirmSummary": "Esto rechaza {{count}} solicitudes de {{org}}."
+  },
+  "filters": {
+    "orgLabel": "Organización",
+    "allOrganizations": "Todas las organizaciones ({{count}})",
+    "orgOption": "{{name}} ({{count}} pendientes)",
+    "searchLabel": "Buscar",
+    "searchPlaceholder": "Buscar por acción, equipo o agente…",
+    "sortLabel": "Ordenar por",
+    "sortExpiringSoonest": "Vence pronto",
+    "sortNewest": "Más recientes",
+    "showingLoaded": "Mostrando {{shown}} de {{loaded}} cargadas",
+    "clearFilters": "Borrar filtros",
+    "noMatches": {
+      "title": "Ninguna aprobación coincide con tus filtros",
+      "description": "Prueba con otra organización o término de búsqueda, o borra tus filtros."
+    }
   },
   "risk": {
     "low": "Riesgo bajo",

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -17,6 +17,12 @@
     },
     "detail": {
       "notFoundDescription": "Es posible que esta ejecución se haya eliminado, o que el enlace esté desactualizado.",
+      "pageTitle": "{{agent}} · {{started}} · Ejecución | Breeze RMM",
+      "header": {
+        "title": "Ejecución de {{agent}}",
+        "startedLabel": "Iniciado",
+        "machineVerdict": "Veredicto de la máquina: {{verdict}}"
+      },
       "summary": {
         "title": "Lo que encontró el agente"
       },
@@ -38,13 +44,16 @@
           "checkedAt": "Comprobado",
           "cveIds": "ID de CVE",
           "cveCount": "Cantidad de CVE",
+          "cveId": "CVE",
+          "cvssScore": "Puntuación CVSS",
           "osType": "Tipo de SO",
           "openCriticalCount": "CVE críticos abiertos"
         }
       },
       "sweep": {
         "caption": "Una fila por cada problema que encontró este barrido, con la acción que propuso.",
-        "reviewPermissions": "Revisar permisos del agente"
+        "reviewPermissions": "Revisar permisos del agente",
+        "checksLabel": "Verificaciones:"
       },
       "trace": {
         "description": "Cada llamada a herramienta que el agente propuso, ejecutó o tuvo denegada, en orden.",
@@ -53,6 +62,7 @@
       "ledger": {
         "description": "Solo las llamadas que realmente se ejecutaron, con su duración y cualquier error.",
         "emptyDescription": "Las herramientas que el agente realmente invocó se mostrarán aquí.",
+        "collapsedSummary": "Ejecuciones de herramientas ({{count}}) — igual que la traza anterior",
         "statuses": {
           "pending": "Pendiente",
           "approved": "Aprobado",
@@ -1475,6 +1485,7 @@
       "nextRun": "Próxima ejecución {{at}} ({{timezone}})",
       "nextRunInvalid": "Programación no válida",
       "nextRunNone": "No hay ninguna ejecución en el próximo año.",
+      "useMyTimezone": "Usar mi zona horaria",
       "kindLabels": {
         "disk_pressure": "Presión de disco",
         "stale_agents": "Agentes obsoletos",
@@ -1531,6 +1542,18 @@
     "allOrgsHint": "Para todo el partner: se aplica a cada organización, salvo que una organización la restrinja.",
     "stateEnabled": "Habilitado",
     "stateDisabled": "Deshabilitado",
+    "runningBadge": {
+      "running": "En ejecución",
+      "notRunning": "No se está ejecutando"
+    },
+    "reenableNote": "Restaurado, pero apagado. Revise su política antes de activarlo.",
+    "chipLabels": {
+      "kind": "Tipo",
+      "ownership": "Propiedad",
+      "mode": "Modo",
+      "running": "Estado",
+      "lastRunStatus": "Resultado de la última ejecución"
+    },
     "lastRun": {
       "never": "Nunca se ejecutó",
       "at": "Última ejecución {{at}}"
@@ -1553,7 +1576,8 @@
     },
     "allDisabled": {
       "title": "Todos los agentes están deshabilitados",
-      "description": "No se está ejecutando nada. Vuelva a habilitar uno abajo o cree un agente nuevo."
+      "description": "No se está ejecutando nada en este momento.",
+      "reenableCta": "Volver a habilitar un agente"
     },
     "errors": {
       "load": "No se pudieron cargar los agentes.",
@@ -1664,6 +1688,8 @@
       "recipientRolesFailed": "No se pudieron cargar los roles, así que por ahora no se pueden cambiar los destinatarios de las notificaciones.",
       "supervisedActionKeysHint": "Operaciones que este agente puede ejecutar SIN que una persona haga clic en aprobar, cuando existe una política coincidente y el límite de exposición de la organización tiene margen. Cada una igual pasa por las protecciones en vivo, el interruptor de apagado y los límites por organización en el momento de la ejecución.",
       "supervisedActionKeysEmpty": "No hay acciones decidibles por política registradas.",
+      "supervisedActionKeysCeilingSummary_one": "Techo para organizaciones — {{count}} clave",
+      "supervisedActionKeysCeilingSummary_other": "Techo para organizaciones — {{count}} claves",
       "supervisedActionKeysFailed": "No se pudo cargar la lista de acciones decidibles por política, así que la autorización no supervisada no se puede cambiar en este momento.",
       "ticketAutonomousWrites": "Escrituras autónomas de tickets",
       "ticketAutonomousWritesHint": "Solo anulación de la organización — las escrituras autónomas de tickets requieren el modo de actuación y esta activación a nivel de organización",
@@ -1673,6 +1699,35 @@
       "toolSuggestLabel": "Agregar una herramienta conocida",
       "toolSuggestHint": "Las sugerencias vienen del registro de acciones decidibles por política, que no es la lista completa de herramientas. Cualquier otra que este agente pueda usar todavía se puede escribir arriba.",
       "toolSuggestAdd": "Agregar"
+    },
+    "policyKeys": {
+      "tools": {
+        "manage_services": "Servicios",
+        "manage_startup_items": "Elementos de inicio",
+        "manage_scheduled_tasks": "Tareas programadas",
+        "security_scan": "Análisis de seguridad"
+      },
+      "actions": {
+        "manage_services": {
+          "start": "Iniciar un servicio",
+          "stop": "Detener un servicio",
+          "restart": "Reiniciar un servicio"
+        },
+        "manage_startup_items": {
+          "disable": "Deshabilitar un elemento de inicio",
+          "enable": "Habilitar un elemento de inicio"
+        },
+        "manage_scheduled_tasks": {
+          "run": "Ejecutar una tarea programada",
+          "disable": "Deshabilitar una tarea programada",
+          "enable": "Habilitar una tarea programada"
+        },
+        "security_scan": {
+          "quarantine": "Poner en cuarentena una amenaza",
+          "remove": "Eliminar una amenaza",
+          "restore": "Restaurar una amenaza"
+        }
+      }
     },
     "loading": "Cargando agentes…",
     "runs": {
@@ -1689,8 +1744,6 @@
         "status": "Estado",
         "trigger": "Disparador",
         "verdict": "Resultado",
-        "queued": "En cola",
-        "finished": "Finalizado",
         "cost": "Costo"
       },
       "statuses": {
@@ -1984,6 +2037,7 @@
           "llmSpend": "Gasto en LLM"
         }
       },
+      "freshnessLabel": "Actualidad de los datos",
       "freshness": "Datos hasta {{through}} (UTC) · reconstruido {{rebuiltAt}}",
       "freshnessNeverRebuilt": "Aún no se generó — la primera reconstrucción se ejecuta esta noche",
       "positiveFeedbackRate": "Tasa de comentarios positivos",
@@ -1994,7 +2048,10 @@
         "title": "Editar ponderaciones de tiempo ahorrado",
         "description": "Define cuántos minutos de tiempo humano se acreditan a cada resultado. Estas ponderaciones solo cambian la estimación, nunca lo que hacen tus agentes de IA.",
         "unitSuffix": "min.",
+        "rangeHint": "Ingrese un valor entre {{min}} y {{max}} minutos.",
+        "defaultValue": "Predeterminado: {{minutes}} min.",
         "preview": "Tiempo estimado ahorrado en esta ventana: {{from}} → {{to}}",
+        "noOutcomesPreview": "No hay resultados en esta ventana para previsualizar",
         "save": "Guardar",
         "saving": "Guardando…",
         "reset": "Restablecer valores predeterminados",

--- a/apps/web/src/locales/fr-CA/approvals.json
+++ b/apps/web/src/locales/fr-CA/approvals.json
@@ -14,7 +14,25 @@
   "batch": {
     "approveAll": "Tout approuver ({{count}})",
     "declineAll": "Tout refuser ({{count}})",
-    "groupTitle": "{{count}} demandes semblables · {{tool}}"
+    "groupTitle": "{{count}} demandes semblables · {{tool}}",
+    "moreHostnames": "+{{count}} de plus",
+    "denyConfirmSummary": "Ceci refuse {{count}} demandes pour {{org}}."
+  },
+  "filters": {
+    "orgLabel": "Organisation",
+    "allOrganizations": "Toutes les organisations ({{count}})",
+    "orgOption": "{{name}} ({{count}} en attente)",
+    "searchLabel": "Recherche",
+    "searchPlaceholder": "Rechercher par action, appareil ou agent…",
+    "sortLabel": "Trier par",
+    "sortExpiringSoonest": "Expire bientôt",
+    "sortNewest": "Plus récentes",
+    "showingLoaded": "{{shown}} sur {{loaded}} chargées affichées",
+    "clearFilters": "Effacer les filtres",
+    "noMatches": {
+      "title": "Aucune approbation ne correspond à vos filtres",
+      "description": "Essayez une autre organisation ou un autre terme de recherche, ou effacez vos filtres."
+    }
   },
   "risk": {
     "low": "Risque faible",

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -17,6 +17,12 @@
     },
     "detail": {
       "notFoundDescription": "Cette exécution a peut-être été supprimée, ou le lien est désuet.",
+      "pageTitle": "{{agent}} · {{started}} · Exécution | Breeze RMM",
+      "header": {
+        "title": "Exécution de {{agent}}",
+        "startedLabel": "Démarré",
+        "machineVerdict": "Verdict de la machine : {{verdict}}"
+      },
       "summary": {
         "title": "Ce que l'agent a constaté"
       },
@@ -38,13 +44,16 @@
           "checkedAt": "Vérifié",
           "cveIds": "ID de CVE",
           "cveCount": "Nombre de CVE",
+          "cveId": "CVE",
+          "cvssScore": "Score CVSS",
           "osType": "Type de SE",
           "openCriticalCount": "CVE critiques ouvertes"
         }
       },
       "sweep": {
         "caption": "Une ligne par problème relevé par ce balayage, avec l'action proposée.",
-        "reviewPermissions": "Examiner les permissions de l'agent"
+        "reviewPermissions": "Examiner les permissions de l'agent",
+        "checksLabel": "Vérifications :"
       },
       "trace": {
         "description": "Chaque appel d'outil proposé, exécuté ou refusé à l'agent, dans l'ordre.",
@@ -53,6 +62,7 @@
       "ledger": {
         "description": "Seulement les appels réellement exécutés, avec leur durée et toute erreur.",
         "emptyDescription": "Les outils réellement invoqués par l'agent seront répertoriés ici.",
+        "collapsedSummary": "Exécutions d'outils ({{count}}) — identiques à la trace ci-dessus",
         "statuses": {
           "pending": "En attente",
           "approved": "Approuvé",
@@ -1475,6 +1485,7 @@
       "nextRun": "Prochaine exécution {{at}} ({{timezone}})",
       "nextRunInvalid": "Horaire invalide",
       "nextRunNone": "Aucune exécution dans la prochaine année.",
+      "useMyTimezone": "Utiliser mon fuseau horaire",
       "kindLabels": {
         "disk_pressure": "Pression sur le disque",
         "stale_agents": "Agents obsolètes",
@@ -1531,6 +1542,18 @@
     "allOrgsHint": "À l’échelle du partenaire : s’applique à chaque organisation, sauf si une organisation la restreint.",
     "stateEnabled": "Activé",
     "stateDisabled": "Désactivé",
+    "runningBadge": {
+      "running": "En cours d’exécution",
+      "notRunning": "Ne s’exécute pas"
+    },
+    "reenableNote": "Restauré, mais désactivé. Consultez sa politique avant de l’activer.",
+    "chipLabels": {
+      "kind": "Type",
+      "ownership": "Propriété",
+      "mode": "Mode",
+      "running": "Statut",
+      "lastRunStatus": "Résultat de la dernière exécution"
+    },
     "lastRun": {
       "never": "Jamais exécuté",
       "at": "Dernière exécution {{at}}"
@@ -1553,7 +1576,8 @@
     },
     "allDisabled": {
       "title": "Tous les agents sont désactivés",
-      "description": "Rien ne s’exécute. Réactivez-en un ci-dessous ou créez un nouvel agent."
+      "description": "Rien ne s’exécute en ce moment.",
+      "reenableCta": "Réactiver un agent"
     },
     "errors": {
       "load": "Impossible de charger les agents.",
@@ -1664,6 +1688,8 @@
       "recipientRolesFailed": "Impossible de charger les rôles ; les destinataires des notifications ne peuvent pas être modifiés pour le moment.",
       "supervisedActionKeysHint": "Opérations que cet agent peut exécuter SANS qu’un humain clique sur approuver, lorsqu’une politique correspondante existe et que le plafond d’exposition de l’organisation le permet. Chacune passe tout de même par les garde-fous en direct, l’interrupteur d’arrêt et les plafonds par organisation au moment de l’exécution.",
       "supervisedActionKeysEmpty": "Aucune action décidable par politique n’est enregistrée.",
+      "supervisedActionKeysCeilingSummary_one": "Plafond pour les organisations — {{count}} clé",
+      "supervisedActionKeysCeilingSummary_other": "Plafond pour les organisations — {{count}} clés",
       "supervisedActionKeysFailed": "Impossible de charger la liste des actions décidables par politique ; l’autorisation sans surveillance ne peut pas être modifiée pour le moment.",
       "ticketAutonomousWrites": "Écritures autonomes de tickets",
       "ticketAutonomousWritesHint": "Dérogation d'organisation seulement — les écritures autonomes de tickets nécessitent le mode action et cette activation au niveau de l'organisation",
@@ -1673,6 +1699,35 @@
       "toolSuggestLabel": "Ajouter un outil connu",
       "toolSuggestHint": "Les suggestions proviennent du registre des actions décidables par politique, qui n’est pas la liste complète des outils. Tout autre outil permis à cet agent peut encore être saisi ci-dessus.",
       "toolSuggestAdd": "Ajouter"
+    },
+    "policyKeys": {
+      "tools": {
+        "manage_services": "Services système",
+        "manage_startup_items": "Éléments de démarrage",
+        "manage_scheduled_tasks": "Tâches planifiées",
+        "security_scan": "Analyse de sécurité"
+      },
+      "actions": {
+        "manage_services": {
+          "start": "Démarrer un service",
+          "stop": "Arrêter un service",
+          "restart": "Redémarrer un service"
+        },
+        "manage_startup_items": {
+          "disable": "Désactiver un élément de démarrage",
+          "enable": "Activer un élément de démarrage"
+        },
+        "manage_scheduled_tasks": {
+          "run": "Exécuter une tâche planifiée",
+          "disable": "Désactiver une tâche planifiée",
+          "enable": "Activer une tâche planifiée"
+        },
+        "security_scan": {
+          "quarantine": "Mettre une menace en quarantaine",
+          "remove": "Supprimer une menace",
+          "restore": "Restaurer une menace"
+        }
+      }
     },
     "loading": "Chargement des agents en cours…",
     "runs": {
@@ -1689,8 +1744,6 @@
         "status": "Statut",
         "trigger": "Déclencheur",
         "verdict": "Résultat",
-        "queued": "En file d'attente",
-        "finished": "Terminé",
         "cost": "Coût"
       },
       "statuses": {
@@ -1984,6 +2037,7 @@
           "llmSpend": "Dépenses LLM"
         }
       },
+      "freshnessLabel": "Fraîcheur des données",
       "freshness": "Données jusqu’au {{through}} (UTC) · reconstruit {{rebuiltAt}}",
       "freshnessNeverRebuilt": "Pas encore généré — la première reconstruction s’exécute cette nuit",
       "positiveFeedbackRate": "Taux d’avis positifs",
@@ -1994,7 +2048,10 @@
         "title": "Modifier les pondérations de temps gagné",
         "description": "Définissez le nombre de minutes de temps humain crédité pour chaque résultat. Ces pondérations ne modifient que l'estimation — jamais ce que font vos agents IA.",
         "unitSuffix": "min.",
+        "rangeHint": "Entrez une valeur entre {{min}} et {{max}} minutes.",
+        "defaultValue": "Par défaut : {{minutes}} min.",
         "preview": "Temps estimé économisé pour cette période : {{from}} → {{to}}",
+        "noOutcomesPreview": "Aucun résultat dans cette période à prévisualiser",
         "save": "Enregistrer",
         "saving": "Enregistrement…",
         "reset": "Rétablir les valeurs par défaut",

--- a/apps/web/src/locales/fr-FR/approvals.json
+++ b/apps/web/src/locales/fr-FR/approvals.json
@@ -14,7 +14,25 @@
   "batch": {
     "approveAll": "Tout approuver ({{count}})",
     "declineAll": "Tout refuser ({{count}})",
-    "groupTitle": "{{count}} demandes similaires · {{tool}}"
+    "groupTitle": "{{count}} demandes similaires · {{tool}}",
+    "moreHostnames": "+{{count}} de plus",
+    "denyConfirmSummary": "Ceci refuse {{count}} demandes pour {{org}}."
+  },
+  "filters": {
+    "orgLabel": "Organisation",
+    "allOrganizations": "Toutes les organisations ({{count}})",
+    "orgOption": "{{name}} ({{count}} en attente)",
+    "searchLabel": "Recherche",
+    "searchPlaceholder": "Rechercher par action, machine ou agent…",
+    "sortLabel": "Trier par",
+    "sortExpiringSoonest": "Expire bientôt",
+    "sortNewest": "Plus récentes",
+    "showingLoaded": "{{shown}} sur {{loaded}} chargées affichées",
+    "clearFilters": "Effacer les filtres",
+    "noMatches": {
+      "title": "Aucune approbation ne correspond à vos filtres",
+      "description": "Essayez une autre organisation ou un autre terme de recherche, ou effacez vos filtres."
+    }
   },
   "risk": {
     "low": "Risque faible",

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -17,6 +17,12 @@
     },
     "detail": {
       "notFoundDescription": "Cette exécution a peut-être été supprimée, ou le lien est obsolète.",
+      "pageTitle": "{{agent}} · {{started}} · Exécution | Breeze RMM",
+      "header": {
+        "title": "Exécution de {{agent}}",
+        "startedLabel": "Démarré",
+        "machineVerdict": "Verdict de la machine : {{verdict}}"
+      },
       "summary": {
         "title": "Ce que l'agent a constaté"
       },
@@ -38,13 +44,16 @@
           "checkedAt": "Vérifié",
           "cveIds": "ID de CVE",
           "cveCount": "Nombre de CVE",
+          "cveId": "CVE",
+          "cvssScore": "Score CVSS",
           "osType": "Type de SE",
           "openCriticalCount": "CVE critiques ouvertes"
         }
       },
       "sweep": {
         "caption": "Une ligne par problème relevé par ce balayage, avec l'action proposée.",
-        "reviewPermissions": "Examiner les autorisations de l'agent"
+        "reviewPermissions": "Examiner les autorisations de l'agent",
+        "checksLabel": "Contrôles :"
       },
       "trace": {
         "description": "Chaque appel d'outil proposé, exécuté ou refusé à l'agent, dans l'ordre.",
@@ -53,6 +62,7 @@
       "ledger": {
         "description": "Seulement les appels réellement exécutés, avec leur durée et toute erreur.",
         "emptyDescription": "Les outils réellement invoqués par l'agent seront répertoriés ici.",
+        "collapsedSummary": "Exécutions d'outils ({{count}}) — identiques à la trace ci-dessus",
         "statuses": {
           "pending": "En attente",
           "approved": "Approuvé",
@@ -1475,6 +1485,7 @@
       "nextRun": "Prochaine exécution {{at}} ({{timezone}})",
       "nextRunInvalid": "Planification invalide",
       "nextRunNone": "Aucune exécution dans l’année qui vient.",
+      "useMyTimezone": "Utiliser mon fuseau horaire",
       "kindLabels": {
         "disk_pressure": "Pression disque",
         "stale_agents": "Agents obsolètes",
@@ -1531,6 +1542,18 @@
     "allOrgsHint": "À l’échelle du partenaire : s’applique à chaque organisation, sauf si une organisation la restreint.",
     "stateEnabled": "Activé",
     "stateDisabled": "Désactivé",
+    "runningBadge": {
+      "running": "En cours d’exécution",
+      "notRunning": "Ne s’exécute pas"
+    },
+    "reenableNote": "Restauré, mais désactivé. Consultez sa politique avant de l’activer.",
+    "chipLabels": {
+      "kind": "Type",
+      "ownership": "Propriété",
+      "mode": "Mode",
+      "running": "Statut",
+      "lastRunStatus": "Résultat de la dernière exécution"
+    },
     "lastRun": {
       "never": "Jamais exécuté",
       "at": "Dernière exécution {{at}}"
@@ -1553,7 +1576,8 @@
     },
     "allDisabled": {
       "title": "Tous les agents sont désactivés",
-      "description": "Rien ne s’exécute. Réactivez-en un ci-dessous ou créez un nouvel agent."
+      "description": "Rien ne s’exécute en ce moment.",
+      "reenableCta": "Réactiver un agent"
     },
     "errors": {
       "load": "Impossible de charger les agents.",
@@ -1664,6 +1688,8 @@
       "recipientRolesFailed": "Impossible de charger les rôles ; les destinataires des notifications ne peuvent pas être modifiés pour le moment.",
       "supervisedActionKeysHint": "Opérations que cet agent peut exécuter SANS qu’un humain clique sur approuver, lorsqu’une politique correspondante existe et que le plafond d’exposition de l’organisation le permet. Chacune passe tout de même par les garde-fous en direct, l’interrupteur d’arrêt et les plafonds par organisation au moment de l’exécution.",
       "supervisedActionKeysEmpty": "Aucune action décidable par politique n’est enregistrée.",
+      "supervisedActionKeysCeilingSummary_one": "Plafond pour les organisations — {{count}} clé",
+      "supervisedActionKeysCeilingSummary_other": "Plafond pour les organisations — {{count}} clés",
       "supervisedActionKeysFailed": "Impossible de charger la liste des actions décidables par politique ; l’autorisation sans surveillance ne peut pas être modifiée pour le moment.",
       "ticketAutonomousWrites": "Écritures autonomes de tickets",
       "ticketAutonomousWritesHint": "Dérogation d'organisation uniquement — les écritures autonomes de tickets nécessitent le mode action et cette activation au niveau de l'organisation",
@@ -1673,6 +1699,35 @@
       "toolSuggestLabel": "Ajouter un outil connu",
       "toolSuggestHint": "Les suggestions proviennent du registre des actions décidables par politique, qui n’est pas la liste complète des outils. Tout autre outil autorisé pour cet agent peut encore être saisi ci-dessus.",
       "toolSuggestAdd": "Ajouter"
+    },
+    "policyKeys": {
+      "tools": {
+        "manage_services": "Services système",
+        "manage_startup_items": "Éléments de démarrage",
+        "manage_scheduled_tasks": "Tâches planifiées",
+        "security_scan": "Analyse de sécurité"
+      },
+      "actions": {
+        "manage_services": {
+          "start": "Démarrer un service",
+          "stop": "Arrêter un service",
+          "restart": "Redémarrer un service"
+        },
+        "manage_startup_items": {
+          "disable": "Désactiver un élément de démarrage",
+          "enable": "Activer un élément de démarrage"
+        },
+        "manage_scheduled_tasks": {
+          "run": "Exécuter une tâche planifiée",
+          "disable": "Désactiver une tâche planifiée",
+          "enable": "Activer une tâche planifiée"
+        },
+        "security_scan": {
+          "quarantine": "Mettre une menace en quarantaine",
+          "remove": "Supprimer une menace",
+          "restore": "Restaurer une menace"
+        }
+      }
     },
     "loading": "Chargement des agents…",
     "runs": {
@@ -1689,8 +1744,6 @@
         "status": "Statut",
         "trigger": "Déclencheur",
         "verdict": "Résultat",
-        "queued": "En file d'attente",
-        "finished": "Terminé",
         "cost": "Coût"
       },
       "statuses": {
@@ -1984,6 +2037,7 @@
           "llmSpend": "Dépenses LLM"
         }
       },
+      "freshnessLabel": "Fraîcheur des données",
       "freshness": "Données jusqu’au {{through}} (UTC) · reconstruit {{rebuiltAt}}",
       "freshnessNeverRebuilt": "Pas encore généré — la première reconstruction s’exécute cette nuit",
       "positiveFeedbackRate": "Taux d’avis positifs",
@@ -1994,7 +2048,10 @@
         "title": "Modifier les pondérations de temps gagné",
         "description": "Définissez le nombre de minutes de temps humain crédité pour chaque résultat. Ces pondérations ne modifient que l'estimation — jamais ce que font vos agents IA.",
         "unitSuffix": "min.",
+        "rangeHint": "Saisissez une valeur entre {{min}} et {{max}} minutes.",
+        "defaultValue": "Par défaut : {{minutes}} min.",
         "preview": "Temps estimé économisé pour cette période : {{from}} → {{to}}",
+        "noOutcomesPreview": "Aucun résultat dans cette période à prévisualiser",
         "save": "Enregistrer",
         "saving": "Enregistrement…",
         "reset": "Rétablir les valeurs par défaut",

--- a/apps/web/src/locales/it-IT/approvals.json
+++ b/apps/web/src/locales/it-IT/approvals.json
@@ -14,7 +14,25 @@
   "batch": {
     "approveAll": "Approva tutto ({{count}})",
     "declineAll": "Rifiuta tutto ({{count}})",
-    "groupTitle": "{{count}} richieste simili · {{tool}}"
+    "groupTitle": "{{count}} richieste simili · {{tool}}",
+    "moreHostnames": "+{{count}} altri",
+    "denyConfirmSummary": "Questo rifiuta {{count}} richieste per {{org}}."
+  },
+  "filters": {
+    "orgLabel": "Organizzazione",
+    "allOrganizations": "Tutte le organizzazioni ({{count}})",
+    "orgOption": "{{name}} ({{count}} in attesa)",
+    "searchLabel": "Cerca",
+    "searchPlaceholder": "Cerca per azione, dispositivo o agente…",
+    "sortLabel": "Ordina per",
+    "sortExpiringSoonest": "In scadenza",
+    "sortNewest": "Più recenti",
+    "showingLoaded": "Mostrando {{shown}} di {{loaded}} caricate",
+    "clearFilters": "Cancella filtri",
+    "noMatches": {
+      "title": "Nessuna approvazione corrisponde ai filtri",
+      "description": "Prova un'altra organizzazione o un altro termine di ricerca, oppure cancella i filtri."
+    }
   },
   "risk": {
     "low": "Rischio basso",

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -17,6 +17,12 @@
     },
     "detail": {
       "notFoundDescription": "Questa esecuzione potrebbe essere stata eliminata, oppure il link non è più valido.",
+      "pageTitle": "{{agent}} · {{started}} · Esecuzione | Breeze RMM",
+      "header": {
+        "title": "Esecuzione di {{agent}}",
+        "startedLabel": "Avviato",
+        "machineVerdict": "Verdetto della macchina: {{verdict}}"
+      },
       "summary": {
         "title": "Che cosa ha rilevato l'agente"
       },
@@ -38,13 +44,16 @@
           "checkedAt": "Verificato",
           "cveIds": "ID CVE",
           "cveCount": "Numero di CVE",
+          "cveId": "CVE",
+          "cvssScore": "Punteggio CVSS",
           "osType": "Tipo di sistema operativo",
           "openCriticalCount": "CVE critiche aperte"
         }
       },
       "sweep": {
         "caption": "Una riga per ogni problema rilevato da questa scansione, con l'azione proposta.",
-        "reviewPermissions": "Esamina le autorizzazioni dell'agente"
+        "reviewPermissions": "Esamina le autorizzazioni dell'agente",
+        "checksLabel": "Controlli:"
       },
       "trace": {
         "description": "Ogni chiamata a strumento proposta, eseguita o negata all'agente, in ordine.",
@@ -53,6 +62,7 @@
       "ledger": {
         "description": "Solo le chiamate effettivamente eseguite, con la durata ed eventuali errori.",
         "emptyDescription": "Gli strumenti effettivamente invocati dall'agente saranno elencati qui.",
+        "collapsedSummary": "Esecuzioni di strumenti ({{count}}) — uguali alla traccia sopra",
         "statuses": {
           "pending": "In sospeso",
           "approved": "Approvato",
@@ -1475,6 +1485,7 @@
       "nextRun": "Prossima esecuzione {{at}} ({{timezone}})",
       "nextRunInvalid": "Pianificazione non valida",
       "nextRunNone": "Nessuna esecuzione nel prossimo anno.",
+      "useMyTimezone": "Usa il mio fuso orario",
       "kindLabels": {
         "disk_pressure": "Pressione sul disco",
         "stale_agents": "Agenti non aggiornati",
@@ -1531,6 +1542,18 @@
     "allOrgsHint": "A livello di partner: vale per ogni organizzazione, salvo che un’organizzazione la restringa.",
     "stateEnabled": "Attivo",
     "stateDisabled": "Disattivato",
+    "runningBadge": {
+      "running": "In esecuzione",
+      "notRunning": "Non in esecuzione"
+    },
+    "reenableNote": "Ripristinato, ma spento. Rivedi la sua policy prima di attivarlo.",
+    "chipLabels": {
+      "kind": "Tipo",
+      "ownership": "Proprietà",
+      "mode": "Modalità",
+      "running": "Stato",
+      "lastRunStatus": "Esito dell’ultima esecuzione"
+    },
     "lastRun": {
       "never": "Mai eseguito",
       "at": "Ultima esecuzione {{at}}"
@@ -1553,7 +1576,8 @@
     },
     "allDisabled": {
       "title": "Tutti gli agenti sono disattivati",
-      "description": "Non è in esecuzione nulla. Riattivane uno qui sotto o crea un nuovo agente."
+      "description": "Al momento non è in esecuzione nulla.",
+      "reenableCta": "Riattiva un agente"
     },
     "errors": {
       "load": "Impossibile caricare gli agenti.",
@@ -1664,6 +1688,8 @@
       "recipientRolesFailed": "Impossibile caricare i ruoli: al momento i destinatari delle notifiche non possono essere modificati.",
       "supervisedActionKeysHint": "Operazioni che questo agente può eseguire SENZA che un essere umano clicchi su approva, quando esiste una policy corrispondente e il limite di esposizione dell'organizzazione ha margine. Ognuna passa comunque attraverso le protezioni live, l'interruttore di emergenza e i limiti per organizzazione al momento dell'esecuzione.",
       "supervisedActionKeysEmpty": "Nessuna azione decidibile tramite policy è registrata.",
+      "supervisedActionKeysCeilingSummary_one": "Limite per le organizzazioni — {{count}} chiave",
+      "supervisedActionKeysCeilingSummary_other": "Limite per le organizzazioni — {{count}} chiavi",
       "supervisedActionKeysFailed": "Impossibile caricare l'elenco delle azioni decidibili tramite policy, quindi l'autorizzazione non presidiata non può essere modificata al momento.",
       "ticketAutonomousWrites": "Scritture autonome dei ticket",
       "ticketAutonomousWritesHint": "Solo override a livello di organizzazione — le scritture autonome dei ticket richiedono la modalità azione e questa attivazione a livello di organizzazione",
@@ -1673,6 +1699,35 @@
       "toolSuggestLabel": "Aggiungi uno strumento noto",
       "toolSuggestHint": "I suggerimenti provengono dal registro delle azioni decidibili dalla policy, che non è l’elenco completo degli strumenti. Qualsiasi altro strumento consentito a questo agente si può comunque digitare qui sopra.",
       "toolSuggestAdd": "Aggiungi"
+    },
+    "policyKeys": {
+      "tools": {
+        "manage_services": "Servizi",
+        "manage_startup_items": "Elementi di avvio",
+        "manage_scheduled_tasks": "Attività pianificate",
+        "security_scan": "Scansione di sicurezza"
+      },
+      "actions": {
+        "manage_services": {
+          "start": "Avvia un servizio",
+          "stop": "Arresta un servizio",
+          "restart": "Riavvia un servizio"
+        },
+        "manage_startup_items": {
+          "disable": "Disabilita un elemento di avvio",
+          "enable": "Abilita un elemento di avvio"
+        },
+        "manage_scheduled_tasks": {
+          "run": "Esegui un'attività pianificata",
+          "disable": "Disabilita un'attività pianificata",
+          "enable": "Abilita un'attività pianificata"
+        },
+        "security_scan": {
+          "quarantine": "Metti in quarantena una minaccia",
+          "remove": "Rimuovi una minaccia",
+          "restore": "Ripristina una minaccia"
+        }
+      }
     },
     "loading": "Caricamento degli agenti…",
     "runs": {
@@ -1689,8 +1744,6 @@
         "status": "Stato",
         "trigger": "Trigger",
         "verdict": "Esito",
-        "queued": "In coda",
-        "finished": "Terminata",
         "cost": "Costo"
       },
       "statuses": {
@@ -1984,6 +2037,7 @@
           "llmSpend": "Spesa LLM"
         }
       },
+      "freshnessLabel": "Aggiornamento dei dati",
       "freshness": "Dati fino al {{through}} (UTC) · ricostruito {{rebuiltAt}}",
       "freshnessNeverRebuilt": "Non ancora generato — la prima ricostruzione viene eseguita stanotte",
       "positiveFeedbackRate": "Percentuale di riscontri positivi",
@@ -1994,7 +2048,10 @@
         "title": "Modifica i pesi del tempo risparmiato",
         "description": "Imposta quanti minuti di tempo umano vengono accreditati a ciascun risultato. Questi pesi modificano solo la stima — mai ciò che fanno i tuoi agenti IA.",
         "unitSuffix": "min.",
+        "rangeHint": "Inserisci un valore compreso tra {{min}} e {{max}} minuti.",
+        "defaultValue": "Predefinito: {{minutes}} min.",
         "preview": "Tempo stimato risparmiato in questa finestra: {{from}} → {{to}}",
+        "noOutcomesPreview": "Nessun risultato in questa finestra da visualizzare in anteprima",
         "save": "Salva",
         "saving": "Salvataggio…",
         "reset": "Ripristina predefiniti",

--- a/apps/web/src/locales/pt-BR/approvals.json
+++ b/apps/web/src/locales/pt-BR/approvals.json
@@ -14,7 +14,25 @@
   "batch": {
     "approveAll": "Aprovar tudo ({{count}})",
     "declineAll": "Recusar tudo ({{count}})",
-    "groupTitle": "{{count}} solicitações semelhantes · {{tool}}"
+    "groupTitle": "{{count}} solicitações semelhantes · {{tool}}",
+    "moreHostnames": "+{{count}} mais",
+    "denyConfirmSummary": "Isso recusa {{count}} solicitações de {{org}}."
+  },
+  "filters": {
+    "orgLabel": "Organização",
+    "allOrganizations": "Todas as organizações ({{count}})",
+    "orgOption": "{{name}} ({{count}} pendentes)",
+    "searchLabel": "Pesquisar",
+    "searchPlaceholder": "Pesquisar por ação, máquina ou agente…",
+    "sortLabel": "Ordenar por",
+    "sortExpiringSoonest": "Expirando em breve",
+    "sortNewest": "Mais recentes",
+    "showingLoaded": "Mostrando {{shown}} de {{loaded}} carregadas",
+    "clearFilters": "Limpar filtros",
+    "noMatches": {
+      "title": "Nenhuma aprovação corresponde aos seus filtros",
+      "description": "Tente outra organização ou termo de pesquisa, ou limpe seus filtros."
+    }
   },
   "risk": {
     "low": "Risco baixo",

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -17,6 +17,12 @@
     },
     "detail": {
       "notFoundDescription": "Esta execução pode ter sido excluída, ou o link pode estar desatualizado.",
+      "pageTitle": "{{agent}} · {{started}} · Execução | Breeze RMM",
+      "header": {
+        "title": "Execução de {{agent}}",
+        "startedLabel": "Iniciado",
+        "machineVerdict": "Veredito da máquina: {{verdict}}"
+      },
       "summary": {
         "title": "O que o agente encontrou"
       },
@@ -38,13 +44,16 @@
           "checkedAt": "Verificado",
           "cveIds": "IDs de CVE",
           "cveCount": "Contagem de CVE",
+          "cveId": "CVE",
+          "cvssScore": "Pontuação CVSS",
           "osType": "Tipo de SO",
           "openCriticalCount": "CVEs críticos em aberto"
         }
       },
       "sweep": {
         "caption": "Uma linha por problema encontrado nesta varredura, com a ação proposta.",
-        "reviewPermissions": "Revisar permissões do agente"
+        "reviewPermissions": "Revisar permissões do agente",
+        "checksLabel": "Verificações:"
       },
       "trace": {
         "description": "Cada chamada de ferramenta que o agente propôs, executou ou teve negada, em ordem.",
@@ -53,6 +62,7 @@
       "ledger": {
         "description": "Somente as chamadas que realmente foram executadas, com a duração e qualquer erro.",
         "emptyDescription": "As ferramentas realmente invocadas pelo agente serão listadas aqui.",
+        "collapsedSummary": "Execuções de ferramentas ({{count}}) — iguais ao trace acima",
         "statuses": {
           "pending": "Pendente",
           "approved": "Aprovado",
@@ -1475,6 +1485,7 @@
       "nextRun": "Próxima execução {{at}} ({{timezone}})",
       "nextRunInvalid": "Agendamento inválido",
       "nextRunNone": "Nenhuma execução no próximo ano.",
+      "useMyTimezone": "Usar meu fuso horário",
       "kindLabels": {
         "disk_pressure": "Pressão de disco",
         "stale_agents": "Agentes desatualizados",
@@ -1531,6 +1542,18 @@
     "allOrgsHint": "Em todo o parceiro: vale para cada organização, a menos que uma organização a restrinja.",
     "stateEnabled": "Ativado",
     "stateDisabled": "Desativado",
+    "runningBadge": {
+      "running": "Em execução",
+      "notRunning": "Não está em execução"
+    },
+    "reenableNote": "Restaurado, mas desligado. Revise a política dele antes de ativá-lo.",
+    "chipLabels": {
+      "kind": "Tipo",
+      "ownership": "Propriedade",
+      "mode": "Modo",
+      "running": "Status",
+      "lastRunStatus": "Resultado da última execução"
+    },
     "lastRun": {
       "never": "Nunca executado",
       "at": "Última execução {{at}}"
@@ -1553,7 +1576,8 @@
     },
     "allDisabled": {
       "title": "Todos os agentes estão desativados",
-      "description": "Nada está em execução. Reative um abaixo ou crie um novo agente."
+      "description": "Nada está em execução no momento.",
+      "reenableCta": "Reativar um agente"
     },
     "errors": {
       "load": "Não foi possível carregar os agentes.",
@@ -1664,6 +1688,8 @@
       "recipientRolesFailed": "Não foi possível carregar as funções, então os destinatários das notificações não podem ser alterados agora.",
       "supervisedActionKeysHint": "Operações que este agente pode executar SEM um humano clicar em aprovar, quando existe uma política correspondente e o limite de exposição da organização tem espaço. Cada uma ainda passa pelas proteções em tempo real, pelo interruptor de interrupção e pelos limites por organização no momento da execução.",
       "supervisedActionKeysEmpty": "Nenhuma ação decidível por política está registrada.",
+      "supervisedActionKeysCeilingSummary_one": "Teto para organizações — {{count}} chave",
+      "supervisedActionKeysCeilingSummary_other": "Teto para organizações — {{count}} chaves",
       "supervisedActionKeysFailed": "Não foi possível carregar a lista de ações decidíveis por política, então a autorização não supervisionada não pode ser alterada agora.",
       "ticketAutonomousWrites": "Gravações autônomas de chamados",
       "ticketAutonomousWritesHint": "Somente substituição da organização — gravações autônomas de chamados exigem o modo de ação e a ativação neste nível de organização",
@@ -1673,6 +1699,35 @@
       "toolSuggestLabel": "Adicionar uma ferramenta conhecida",
       "toolSuggestHint": "As sugestões vêm do registro de ações decidíveis por política, que não é a lista completa de ferramentas. Qualquer outra permitida a este agente ainda pode ser digitada acima.",
       "toolSuggestAdd": "Adicionar"
+    },
+    "policyKeys": {
+      "tools": {
+        "manage_services": "Serviços",
+        "manage_startup_items": "Itens de inicialização",
+        "manage_scheduled_tasks": "Tarefas agendadas",
+        "security_scan": "Verificação de segurança"
+      },
+      "actions": {
+        "manage_services": {
+          "start": "Iniciar um serviço",
+          "stop": "Parar um serviço",
+          "restart": "Reiniciar um serviço"
+        },
+        "manage_startup_items": {
+          "disable": "Desabilitar um item de inicialização",
+          "enable": "Habilitar um item de inicialização"
+        },
+        "manage_scheduled_tasks": {
+          "run": "Executar uma tarefa agendada",
+          "disable": "Desabilitar uma tarefa agendada",
+          "enable": "Habilitar uma tarefa agendada"
+        },
+        "security_scan": {
+          "quarantine": "Colocar uma ameaça em quarentena",
+          "remove": "Remover uma ameaça",
+          "restore": "Restaurar uma ameaça"
+        }
+      }
     },
     "loading": "Carregando agentes…",
     "runs": {
@@ -1689,8 +1744,6 @@
         "status": "Status",
         "trigger": "Gatilho",
         "verdict": "Resultado",
-        "queued": "Na fila",
-        "finished": "Concluída",
         "cost": "Custo"
       },
       "statuses": {
@@ -1984,6 +2037,7 @@
           "llmSpend": "Gasto com LLM"
         }
       },
+      "freshnessLabel": "Atualidade dos dados",
       "freshness": "Dados até {{through}} (UTC) · reconstruído {{rebuiltAt}}",
       "freshnessNeverRebuilt": "Ainda não gerado — a primeira reconstrução roda esta noite",
       "positiveFeedbackRate": "Taxa de retorno positivo",
@@ -1994,7 +2048,10 @@
         "title": "Editar pesos de tempo economizado",
         "description": "Defina quantos minutos de tempo humano cada resultado deve receber de crédito. Esses pesos alteram apenas a estimativa — nunca o que seus agentes de IA fazem.",
         "unitSuffix": "min.",
+        "rangeHint": "Digite um valor entre {{min}} e {{max}} minutos.",
+        "defaultValue": "Padrão: {{minutes}} min.",
         "preview": "Tempo economizado estimado nesta janela: {{from}} → {{to}}",
+        "noOutcomesPreview": "Nenhum resultado nesta janela para pré-visualizar",
         "save": "Salvar",
         "saving": "Salvando…",
         "reset": "Restaurar padrões",

--- a/apps/web/src/locales/tr-TR/approvals.json
+++ b/apps/web/src/locales/tr-TR/approvals.json
@@ -14,7 +14,25 @@
   "batch": {
     "approveAll": "Tümünü onayla ({{count}})",
     "declineAll": "Tümünü reddet ({{count}})",
-    "groupTitle": "{{count}} benzer istek · {{tool}}"
+    "groupTitle": "{{count}} benzer istek · {{tool}}",
+    "moreHostnames": "+{{count}} daha",
+    "denyConfirmSummary": "Bu, {{org}} için {{count}} isteği reddeder."
+  },
+  "filters": {
+    "orgLabel": "Kuruluş",
+    "allOrganizations": "Tüm kuruluşlar ({{count}})",
+    "orgOption": "{{name}} ({{count}} bekliyor)",
+    "searchLabel": "Ara",
+    "searchPlaceholder": "Eylem, cihaz veya aracıya göre ara…",
+    "sortLabel": "Sıralama",
+    "sortExpiringSoonest": "Süresi yakında doluyor",
+    "sortNewest": "En yeni",
+    "showingLoaded": "Yüklenen {{loaded}} kayıttan {{shown}} tanesi gösteriliyor",
+    "clearFilters": "Filtreleri temizle",
+    "noMatches": {
+      "title": "Filtrelerinize uyan onay yok",
+      "description": "Farklı bir kuruluş veya arama terimi deneyin ya da filtrelerinizi temizleyin."
+    }
   },
   "risk": {
     "low": "Düşük risk",

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -17,6 +17,12 @@
     },
     "detail": {
       "notFoundDescription": "Bu çalıştırma silinmiş olabilir veya bağlantı güncel olmayabilir.",
+      "pageTitle": "{{agent}} · {{started}} · Çalıştırma | Breeze RMM",
+      "header": {
+        "title": "{{agent}} çalıştırması",
+        "startedLabel": "Başlatıldı",
+        "machineVerdict": "Makine kararı: {{verdict}}"
+      },
       "summary": {
         "title": "Aracının bulduğu sonuçlar"
       },
@@ -38,13 +44,16 @@
           "checkedAt": "Kontrol edildi",
           "cveIds": "CVE kimlikleri",
           "cveCount": "CVE sayısı",
+          "cveId": "CVE",
+          "cvssScore": "CVSS puanı",
           "osType": "İşletim sistemi türü",
           "openCriticalCount": "Açık kritik CVE'ler"
         }
       },
       "sweep": {
         "caption": "Bu taramanın bulduğu her sorun için bir satır ve önerilen eylem.",
-        "reviewPermissions": "Aracı izinlerini incele"
+        "reviewPermissions": "Aracı izinlerini incele",
+        "checksLabel": "Kontroller:"
       },
       "trace": {
         "description": "Aracının önerdiği, yürüttüğü veya reddedilen her araç çağrısı, sırasıyla.",
@@ -53,6 +62,7 @@
       "ledger": {
         "description": "Yalnızca gerçekten çalışan çağrılar; süreleri ve varsa hatalarıyla.",
         "emptyDescription": "Aracının gerçekten çağırdığı araçlar burada listelenecektir.",
+        "collapsedSummary": "Araç yürütmeleri ({{count}}) — yukarıdaki izle aynı",
         "statuses": {
           "pending": "Beklemede",
           "approved": "Onaylandı",
@@ -1475,6 +1485,7 @@
       "nextRun": "Sonraki çalışma {{at}} ({{timezone}})",
       "nextRunInvalid": "Geçersiz zamanlama",
       "nextRunNone": "Önümüzdeki bir yıl içinde çalışma yok.",
+      "useMyTimezone": "Saat dilimimi kullan",
       "kindLabels": {
         "disk_pressure": "Disk baskısı",
         "stale_agents": "Eskimiş aracılar",
@@ -1531,6 +1542,18 @@
     "allOrgsHint": "İş ortağı genelinde: bir kuruluş daraltmadığı sürece her kuruluş için geçerlidir.",
     "stateEnabled": "Etkin",
     "stateDisabled": "Devre dışı",
+    "runningBadge": {
+      "running": "Çalışıyor",
+      "notRunning": "Çalışmıyor"
+    },
+    "reenableNote": "Geri yüklendi, kapalı durumda. Açmadan önce politikasını gözden geçirin.",
+    "chipLabels": {
+      "kind": "Tür",
+      "ownership": "Sahiplik",
+      "mode": "Mod",
+      "running": "Durum",
+      "lastRunStatus": "Son çalıştırma sonucu"
+    },
     "lastRun": {
       "never": "Hiç çalıştırılmadı",
       "at": "Son çalıştırma {{at}}"
@@ -1553,7 +1576,8 @@
     },
     "allDisabled": {
       "title": "Tüm aracılar devre dışı",
-      "description": "Hiçbir şey çalışmıyor. Aşağıdan birini yeniden etkinleştirin veya yeni bir aracı oluşturun."
+      "description": "Şu anda hiçbir şey çalışmıyor.",
+      "reenableCta": "Bir aracıyı yeniden etkinleştir"
     },
     "errors": {
       "load": "Aracılar yüklenemedi.",
@@ -1664,6 +1688,8 @@
       "recipientRolesFailed": "Roller yüklenemedi, bu nedenle bildirim alıcıları şu anda değiştirilemiyor.",
       "supervisedActionKeysHint": "Eşleşen bir politika varsa ve kuruluşun maruziyet sınırında yer varsa, bu aracının bir insan onaylamadan gerçekleştirebileceği işlemler. Her biri yürütme anında yine de canlı korumalardan, kapatma anahtarından ve kuruluş başına sınırlardan geçer.",
       "supervisedActionKeysEmpty": "Politikayla karar verilebilecek işlem kayıtlı değil.",
+      "supervisedActionKeysCeilingSummary_one": "Kuruluşlar için üst sınır — {{count}} anahtar",
+      "supervisedActionKeysCeilingSummary_other": "Kuruluşlar için üst sınır — {{count}} anahtar",
       "supervisedActionKeysFailed": "Politikayla karar verilebilecek işlem listesi yüklenemedi, bu nedenle gözetimsiz yetkilendirme şu anda değiştirilemiyor.",
       "ticketAutonomousWrites": "Otonom talep yazmaları",
       "ticketAutonomousWritesHint": "Yalnızca organizasyon geçersiz kılması — otonom talep yazmaları eylem modunu ve bu organizasyon düzeyindeki katılımı gerektirir",
@@ -1673,6 +1699,35 @@
       "toolSuggestLabel": "Bilinen bir araç ekle",
       "toolSuggestHint": "Öneriler, araçların tam listesi olmayan politikayla karara bağlanabilir eylemler kaydından gelir. Bu aracının kullanabileceği diğer araçlar yukarıya yine de yazılabilir.",
       "toolSuggestAdd": "Ekle"
+    },
+    "policyKeys": {
+      "tools": {
+        "manage_services": "Hizmetler",
+        "manage_startup_items": "Başlangıç öğeleri",
+        "manage_scheduled_tasks": "Zamanlanmış görevler",
+        "security_scan": "Güvenlik taraması"
+      },
+      "actions": {
+        "manage_services": {
+          "start": "Hizmeti başlat",
+          "stop": "Hizmeti durdur",
+          "restart": "Hizmeti yeniden başlat"
+        },
+        "manage_startup_items": {
+          "disable": "Başlangıç öğesini devre dışı bırak",
+          "enable": "Başlangıç öğesini etkinleştir"
+        },
+        "manage_scheduled_tasks": {
+          "run": "Zamanlanmış görevi çalıştır",
+          "disable": "Zamanlanmış görevi devre dışı bırak",
+          "enable": "Zamanlanmış görevi etkinleştir"
+        },
+        "security_scan": {
+          "quarantine": "Tehdidi karantinaya al",
+          "remove": "Tehdidi kaldır",
+          "restore": "Tehdidi geri yükle"
+        }
+      }
     },
     "loading": "Aracılar yükleniyor…",
     "runs": {
@@ -1689,8 +1744,6 @@
         "status": "Durum",
         "trigger": "Tetikleyici",
         "verdict": "Sonuç",
-        "queued": "Sıraya alındı",
-        "finished": "Tamamlandı",
         "cost": "Maliyet"
       },
       "statuses": {
@@ -1984,6 +2037,7 @@
           "llmSpend": "LLM harcaması"
         }
       },
+      "freshnessLabel": "Veri güncelliği",
       "freshness": "{{through}} tarihine kadar olan veriler (UTC) · yeniden oluşturuldu: {{rebuiltAt}}",
       "freshnessNeverRebuilt": "Henüz oluşturulmadı — ilk yeniden oluşturma bu gece çalışacak",
       "positiveFeedbackRate": "Olumlu geri bildirim oranı",
@@ -1994,7 +2048,10 @@
         "title": "Kazanılan zaman ağırlıklarını düzenle",
         "description": "Her sonuç için kaç dakika insan zamanı kredilendirileceğini belirleyin. Bu ağırlıklar yalnızca tahmini değiştirir — yapay zeka ajanlarınızın yaptıklarını asla değiştirmez.",
         "unitSuffix": "dk",
+        "rangeHint": "{{min}} ile {{max}} dakika arasında bir değer girin.",
+        "defaultValue": "Varsayılan {{minutes}} dk",
         "preview": "Bu pencerede tahmini kazanılan süre: {{from}} → {{to}}",
+        "noOutcomesPreview": "Bu pencerede önizlenecek bir sonuç yok",
         "save": "Kaydet",
         "saving": "Kaydediliyor…",
         "reset": "Varsayılanlara sıfırla",

--- a/packages/shared/src/types/aiAgentRuns.ts
+++ b/packages/shared/src/types/aiAgentRuns.ts
@@ -65,6 +65,15 @@ export const AI_AGENT_RUN_LEAK_TRIPWIRE_KEYS = ['args', 'toolInput', 'toolOutput
 export const AI_AGENT_RUN_DTO_SCHEMA_VERSION = 1 as const;
 
 /**
+ * Hard ceiling on `AiAgentRunListItemDto.summaryExcerpt`, INCLUDING the
+ * single-character ellipsis the API appends when it had to truncate. Shared
+ * rather than duplicated so a consumer sizing a column (or asserting the cap)
+ * reads the same number the API enforces — see `summaryExcerpt` in
+ * `apps/api/src/services/aiAgents/runFindings.ts`.
+ */
+export const AI_AGENT_RUN_SUMMARY_EXCERPT_MAX_CHARS = 160;
+
+/**
  * One row of `GET /ai/agents/runs` — org-wide, keyset-paginated. Deliberately
  * carries NO outcome payload (no trace, no ledger, no intents) — that is the
  * whole point of a list endpoint versus the detail one; a caller that needs
@@ -109,6 +118,43 @@ export interface AiAgentRunListItemDto {
   profile: AiAgentRunProfile;
   /** Absent until `finishRun` computes it (services/aiAgents/runLoop.ts); null for any run that hasn't reached a terminal rollup yet. */
   runVerdict: AgentRunVerdict | null;
+  /**
+   * How many things this run left for a human to look at: its sweep findings
+   * plus the tool calls it PROPOSED but could not run. A `denied` action is
+   * deliberately NOT counted — for a read-only profile that is the guardrail
+   * working as intended, logged for every mutating tool the model merely
+   * attempted, and counting it would inflate the badge with denials nobody
+   * needs to act on.
+   *
+   * Exists because `runVerdict` alone understates a run: a sweep that found
+   * six problems and was allowed to execute none of them still rolls up as
+   * `no_action`. The run DETAIL page already overrides the verdict badge off
+   * this number; without it on the list item the runs list and the agents
+   * list could not, and rendered "No action" over six unread findings.
+   *
+   * Derived by ONE helper shared with the detail route
+   * (`countFindingsToReview` / `findingsToReviewSql`,
+   * apps/api/src/services/aiAgents/runFindings.ts) so the list and the detail
+   * page can never badge the same run with different numbers. Always a
+   * number (0, never null) — a run with nothing to review is a real answer,
+   * not a missing one.
+   *
+   * Additive and always present, so it does NOT bump
+   * `AI_AGENT_RUN_DTO_SCHEMA_VERSION`: no field was removed, renamed, or
+   * changed type/semantics (see the bump rule above).
+   */
+  findingsToReview: number;
+  /**
+   * First sentence of the run's `summary`, markdown emphasis stripped and
+   * capped at `AI_AGENT_RUN_SUMMARY_EXCERPT_MAX_CHARS` (an ellipsis is
+   * appended, within the cap, only when the cap actually truncated).
+   *
+   * `null` when the run has no summary yet (still running, or it failed
+   * before writing one) or when the summary is whitespace-only. The FULL
+   * summary is deliberately still detail-only — this is a one-line list
+   * affordance, not the narrative.
+   */
+  summaryExcerpt: string | null;
   queuedAt: string;
   finishedAt: string | null;
   costCents: number;
@@ -448,6 +494,22 @@ export interface AiAgentRunDetailDto {
   /** `ai_agent_runs.summary` — narrative text, never a tool payload. */
   summary: string | null;
   runVerdict: AgentRunVerdict | null;
+  /**
+   * The same count `AiAgentRunListItemDto.findingsToReview` carries, from the
+   * SAME helper (`countFindingsToReview`,
+   * apps/api/src/services/aiAgents/runFindings.ts) — see that field's
+   * docstring for the rule and why `denied` entries are excluded.
+   *
+   * Carried on the detail DTO too so the two surfaces cannot drift: the run
+   * detail page derives this number itself today (`sweep.findings.length` +
+   * `trace` entries of kind `proposed`), which is fine only for as long as
+   * the client rule and the server rule stay identical. This field is the
+   * server's own answer, and the client is expected to move onto it.
+   *
+   * Additive and always present — does NOT bump
+   * `AI_AGENT_RUN_DTO_SCHEMA_VERSION`.
+   */
+  findingsToReview: number;
   turnCount: number;
   costCents: number;
   errorCode: string | null;

--- a/packages/shared/src/types/aiAgents.ts
+++ b/packages/shared/src/types/aiAgents.ts
@@ -518,6 +518,25 @@ export interface AiAgentDto {
    */
   lastRunAt?: string | null;
   lastRunStatus?: string | null;
+  /**
+   * How many things that most recent run left for a human to look at — the
+   * same number `AiAgentRunListItemDto.findingsToReview` carries, from the
+   * same helper (`countFindingsToReview` / `findingsToReviewSql`,
+   * apps/api/src/services/aiAgents/runFindings.ts), computed over the SAME
+   * `DISTINCT ON` row `lastRunStatus` above comes from.
+   *
+   * `lastRunStatus` alone understates the agent: a sweep that found six
+   * problems and was allowed to execute none of them reports `completed`, so
+   * the settings list showed a healthy-looking agent sitting on unread
+   * findings. `null` — never 0 — when there is no visible last run at all,
+   * matching its two siblings; 0 means "there IS a last run and it left
+   * nothing to review".
+   *
+   * Optional for the same reason as its siblings: only the list route
+   * computes it, and every other route that returns an `AiAgentDto` answers
+   * `null` rather than omitting the key.
+   */
+  lastRunFindingsToReview?: number | null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Third Impeccable fix pass for the AI agents UI, following #4667 and #4729 (critique run 3 scored 29/40; snapshots in `.impeccable/critique/`, not committed).

### Findings reach the lists (was P0)
- New `services/aiAgents/runFindings.ts` counts findings to review in one place (sweep findings + proposed actions, denials excluded): `findingsToReviewSql` for list routes (jsonb expression, parameter-free, `outcome` never selected wholesale) and `countFindingsToReview` for the detail DTO, with a parity test. Run list DTO gains `findingsToReview` and `summaryExcerpt` (markdown stripped, first sentence, ≤160 chars, surrogate-safe truncation). `GET /ai/agents` gains `lastRunFindingsToReview` from the existing DISTINCT ON last-run row.
- Runs list, agents list, and run detail all badge "N findings to review" in warning tone under the same rule (any non-attention verdict understates), with the verdict demoted to "Machine verdict: …".

### Settings (was P1: re-enabled row read "Disabled")
- Enabled switch reads Running / Not running; one-time "Restored, switched off" note; findings badge in the last-run cell; sr-only chip labels; all-disabled state leads with Re-enable.
- Policy keys: translated tool and action labels sourced from `POLICY_DECIDABLE_TIER3`, fieldset moved below Permissions, collapsed behind "Ceiling for organizations — N keys" on partner rows outside act mode. Alert severities hidden and omitted for kinds that don't use them. Name required marker with blur validation. Disable dialog uses the warning variant. Mode cards top-aligned.
- Schedules: empty state hidden while a draft is open, Enabled as a switch row, timezone grouped by region plus "Use my timezone".

### Runs and run detail (was P1: no mobile layout)
- Runs list: stacked cards below `md`, summary excerpt, filter chrome hidden on an empty unfiltered list, cost toggle contrast, profile chips muted, load-more error copy.
- Run detail: two-column hero at `lg` with measure caps, checks as chips, ledger collapsed under the trace when identical, ledger mobile cards, evidence drops `"null"`/`"undefined"` strings and falls back to the evidence hostname, plain in-card empties, "<agent> run" h1 with started time, per-run `document.title`.

### Impact and approvals
- Impact header regrouped (no orphaned "Edit weights" at 1440), labelled freshness line; weights drawer hides the native spinner, shows defaults and the 0–1440 range, explains an empty preview.
- Approvals: client-side org filter, search, and sort over loaded pages with an honest "showing N of M loaded", hostnames on batch headers, click-time expiry refusal, full-width `PageHeader`.

### Shared
- New `shared/PageHeader.tsx` adopted across the AI agents pages and approvals. `EmptyState` gains a `plain` variant.

### Verification
- Web: tsc clean; 857 tests in the touched suites; full suite 732 files / 7998 tests green; i18n parity, key usage, translation coverage (baselines +1 in four locales for genuine cognates), no-silent-mutations green. Impeccable detector 0 findings.
- API: tsc clean; 2241 tests in `routes/aiAgents` + `routes/approvals` + `services/aiAgents`. Shared: 2357.
- One review round: list/detail override rule drift and a surrogate-pair truncation bug fixed in this PR; `findingsToReviewSql` safety, tenancy, form payloads, locale parity reviewed clean.
- Live smoke on a wt-stack at 1440/390, light/dark: all five steps pass.

### Not in this PR
- Astro page `<title>` strings are hardcoded English across the app; `DashboardLayout` has no i18n mechanism, so left as is.
- No stale-run reaper exists for `ai_agent_runs`: a run that starts during an API restart stays "Running" forever (seen once during smoke on a dev hot-reload). Worth its own issue.
- Locale strings for de-DE, es-419, fr-CA, fr-FR, it-IT, pt-BR, tr-TR are machine-drafted pending native review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EDZToQ9YjbpojJorSx28M2
