### PR TITLE
fix(api): make org merge honor the canonical ticket lock order (#4748)

### DIFF
--- a/apps/api/src/services/orgMerge.ts
+++ b/apps/api/src/services/orgMerge.ts
@@ -53,6 +53,7 @@ import {
   type MergeTableOutcome,
 } from './orgMergeCustomExecutors';
 import { getOrgMergePolicies, type OrgMergePolicy } from './orgMergeRegistry';
+import { applyTicketChildLockOrder } from './ticketOrgMoveLockOrder';
 import { topologicalCascadeOrder } from './tenantCascade';
 import { envInt } from '../utils/envInt';
 import { disconnectLiveAgentSocketsForOrgIds } from './tenantLifecycle';
@@ -948,6 +949,18 @@ export function buildMergeWarnings(input: MergeWarningInput): string[] {
   return warnings;
 }
 
+/**
+ * The parents-first table walk both the merge transaction and the preview
+ * use: `topologicalCascadeOrder()` (children-before-parents, i.e. erasure
+ * order) reversed, then corrected so the ticket child tables land in the
+ * SAME relative order the ticket/device org-move axes lock them in
+ * (#4748) — see `applyTicketChildLockOrder` for why the correction is
+ * necessary and why it's always FK-safe to apply here.
+ */
+async function getOrgMergeWalkOrder(): Promise<string[]> {
+  return applyTicketChildLockOrder([...(await topologicalCascadeOrder())].reverse());
+}
+
 // ---------------------------------------------------------------------------
 // Execute
 // ---------------------------------------------------------------------------
@@ -1031,8 +1044,10 @@ export async function executeOrgMerge(input: ExecuteOrgMergeInput): Promise<OrgM
         const policies = getOrgMergePolicies();
         // topologicalCascadeOrder is children-before-parents (erasure order);
         // reversed it is parents-first, with `organizations` (loser-shell,
-        // a no-op) leading.
-        const order = [...(await topologicalCascadeOrder())].reverse();
+        // a no-op) leading. getOrgMergeWalkOrder() then corrects the ticket
+        // child tables' relative order to match the movers' lock order
+        // (#4748) — see its doc comment.
+        const order = await getOrgMergeWalkOrder();
 
         const summary: Record<string, OrgMergeCounts> = {};
         const notes: string[] = [];
@@ -1274,7 +1289,10 @@ export async function previewOrgMerge(
   return dbModule.runOutsideDbContext(() =>
     dbModule.withSystemDbAccessContext(async () => {
       const policies = getOrgMergePolicies();
-      const order = [...(await topologicalCascadeOrder())].reverse();
+      // Same walk order the merge transaction actually applies (#4748) — a
+      // preview computed from a different order could show tables in an
+      // order the real merge would never use.
+      const order = await getOrgMergeWalkOrder();
 
       const tables: OrgMergePreviewTable[] = [];
       const connectionDrops: Array<{ table: string; dropped: number }> = [];

--- a/apps/api/src/services/ticketOrgMoveLockOrder.test.ts
+++ b/apps/api/src/services/ticketOrgMoveLockOrder.test.ts
@@ -1,6 +1,8 @@
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import { CUSTOM_ORG_REWRITE_TABLES } from '../routes/devices/core';
 import {
+  applyTicketChildLockOrder,
   TICKET_CHILD_ORG_REWRITE_LOCK_ORDER,
   TICKET_ORG_DENORMALIZED_TABLES,
 } from './ticketOrgMoveLockOrder';
@@ -106,5 +108,112 @@ describe('ticket child-table org-rewrite lock order (#4657)', () => {
     ] as const) {
       expect(new Set(tables).size, `${axis} contains a duplicate entry`).toBe(tables.length);
     }
+  });
+});
+
+/**
+ * Org-merge third-walker contract (#4748).
+ *
+ * `orgMerge.ts` computes its table walk from `topologicalCascadeOrder()`
+ * (tenantCascade.ts) reversed. That function ties on alphabetical order for
+ * tables with no FK between them, and the six tables above are exactly such
+ * a set (see the FK note in ticketOrgMoveLockOrder.ts) — so left alone, the
+ * merge visits them in reverse-alphabetical order, which disagrees with the
+ * canonical lock order the two movers share. `fenceLoser()`'s app-layer fence
+ * is the only thing keeping a merge and an in-flight move apart; a move that
+ * starts before the fence lands can still contend under AB-BA ordering
+ * (40P01).
+ *
+ * `applyTicketChildLockOrder` is the fix: given any walk order, it leaves
+ * every other table's position untouched and permutes only the ticket child
+ * tables' own slots into canonical relative order. These tests pin its
+ * behavior directly (no DB needed — it's a pure array transform) and then
+ * grep orgMerge.ts's source to prove both of its walk-order computations
+ * actually call it, so a future edit that reintroduces a bare
+ * `[...(await topologicalCascadeOrder())].reverse()` fails here rather than
+ * only under Integration Tests.
+ */
+describe('org-merge walk order honors the canonical ticket child-table lock order (#4748)', () => {
+  it('demonstrates the gap: naive reverse-alphabetical tie-break disagrees with canonical order', () => {
+    // This is exactly what topologicalCascadeOrder() reversed produces for a
+    // set of siblings with no FK between them (alphabetical tie-break,
+    // reversed) — see the SCOPE note in ticketOrgMoveLockOrder.ts. It must
+    // NOT equal the canonical order, or this whole fix would be moot.
+    const naiveMergeOrder = [...canonical].sort().reverse();
+    expect(naiveMergeOrder).not.toEqual(canonical);
+  });
+
+  it('reorders only the ticket child tables, in place, to canonical order', () => {
+    const walkOrder = [
+      'organizations',
+      'tickets',
+      'unrelated_table',
+      'time_entries',
+      'ticket_parts',
+      'ticket_outbox',
+      'ticket_email_links',
+      'ticket_attachments',
+      'ticket_alert_links',
+      'users',
+    ];
+    const fixed = applyTicketChildLockOrder(walkOrder);
+
+    // Every non-ticket-child table stays at its original index.
+    expect(fixed[0]).toBe('organizations');
+    expect(fixed[1]).toBe('tickets');
+    expect(fixed[2]).toBe('unrelated_table');
+    expect(fixed[9]).toBe('users');
+
+    // The six ticket-child slots (indices 3-8) now read out in canonical
+    // relative order.
+    expect(fixed.slice(3, 9)).toEqual(canonical);
+
+    // Same multiset of tables — nothing added, nothing dropped.
+    expect([...fixed].sort()).toEqual([...walkOrder].sort());
+  });
+
+  it('is a no-op when the ticket child tables are already in canonical order', () => {
+    const walkOrder = ['tickets', ...canonical, 'users'];
+    expect(applyTicketChildLockOrder(walkOrder)).toEqual(walkOrder);
+  });
+
+  it('handles a subset of the ticket child tables without touching the rest', () => {
+    const walkOrder = ['tickets', 'ticket_alert_links', 'time_entries', 'users'];
+    // Only time_entries and ticket_alert_links present; canonical says
+    // time_entries comes first.
+    expect(applyTicketChildLockOrder(walkOrder)).toEqual([
+      'tickets',
+      'time_entries',
+      'ticket_alert_links',
+      'users',
+    ]);
+  });
+
+  it('orgMerge.ts routes BOTH of its walk-order computations through applyTicketChildLockOrder', () => {
+    // Static contract, not a behavior test: if a future edit adds a second
+    // raw computation site or has a walk-order consumer bypass
+    // getOrgMergeWalkOrder(), this fails in the unit job instead of only
+    // manifesting as a live 40P01 under load.
+    const source = readFileSync(new URL('./orgMerge.ts', import.meta.url), 'utf8');
+    const bareReverse = /\[\.\.\.\(await topologicalCascadeOrder\(\)\)\]\.reverse\(\)/g;
+    expect(
+      source.match(bareReverse) ?? [],
+      'expected exactly ONE raw `[...(await topologicalCascadeOrder())].reverse()` in ' +
+        'orgMerge.ts — the single definition inside getOrgMergeWalkOrder(). A second raw ' +
+        'occurrence means a walk-order consumer bypassed the applyTicketChildLockOrder fix (#4748).',
+    ).toHaveLength(1);
+
+    const walkOrderCalls = source.match(/await getOrgMergeWalkOrder\(\)/g) ?? [];
+    expect(
+      walkOrderCalls.length,
+      'expected orgMerge.ts to compute its walk order via getOrgMergeWalkOrder() at both ' +
+        'consumption sites (the main merge transaction and the preview) — a different count ' +
+        'means one of them reverted to a raw topologicalCascadeOrder().reverse() (#4748).',
+    ).toBe(2);
+
+    expect(
+      source.includes('applyTicketChildLockOrder('),
+      'getOrgMergeWalkOrder() no longer calls applyTicketChildLockOrder — the #4748 fix was removed.',
+    ).toBe(true);
   });
 });

--- a/apps/api/src/services/ticketOrgMoveLockOrder.test.ts
+++ b/apps/api/src/services/ticketOrgMoveLockOrder.test.ts
@@ -189,6 +189,15 @@ describe('org-merge walk order honors the canonical ticket child-table lock orde
     ]);
   });
 
+  it('throws on a duplicate ticket child-table entry rather than silently mis-permuting', () => {
+    // Practically unreachable in real callers (topologicalCascadeOrder()
+    // lists each table exactly once), but this is the guard's whole reason
+    // for existing — pin that it actually fires rather than, say, silently
+    // dropping or duplicating a value.
+    const walkOrder = ['tickets', 'time_entries', 'time_entries', 'ticket_parts'];
+    expect(() => applyTicketChildLockOrder(walkOrder)).toThrow(/duplicate/i);
+  });
+
   it('orgMerge.ts routes BOTH of its walk-order computations through applyTicketChildLockOrder', () => {
     // Static contract, not a behavior test: if a future edit adds a second
     // raw computation site or has a walk-order consumer bypass

--- a/apps/api/src/services/ticketOrgMoveLockOrder.ts
+++ b/apps/api/src/services/ticketOrgMoveLockOrder.ts
@@ -26,7 +26,7 @@
  * carried its own locally-reasoned comment, and the two reached opposite
  * conclusions without either being wrong on its own terms.
  *
- * SCOPE — two other walkers touch these tables, and neither is governed here:
+ * SCOPE — one other walker touches these tables and is now governed here too:
  *
  *   - Org erasure (`cascadeDeleteOrg`, services/tenantCascade.ts) is NOT a
  *     hazard: it gives each table its OWN system-context transaction, so it
@@ -34,17 +34,20 @@
  *     either mover.
  *   - Org MERGE (services/orgMerge.ts) is a genuine third walker — the whole
  *     merge runs in ONE transaction over `topologicalCascadeOrder()` reversed,
- *     which for these four siblings (alphabetical tie-break, then reversed)
- *     yields time_entries -> ticket_parts -> ticket_attachments ->
- *     ticket_alert_links. That disagrees with the order below on the last
- *     pair. It is held apart from the movers by a FENCE, not by lock order:
- *     `fenceLoser()` stamps the loser org `status='merging'` before the merge
- *     transaction opens, and the device/ticket move routes refuse a fenced
- *     org. That fence is app-layer, so it does not close the window for a
- *     move already in flight when the fence lands. Deliberately left as-is by
- *     #4657, whose scope is the ticket/device pair; reordering the merge walk
- *     means touching orgMergeRegistry's own ordering contract. Do not extend
- *     the order below to cover merge without changing that walk to match.
+ *     which ties on alphabetical order for tables with no FK between them
+ *     (see the FK note below) — exactly the six tables here. Left alone, that
+ *     tie-break disagrees with the order below (#4748: for six siblings it
+ *     yields time_entries -> ticket_parts -> ticket_outbox ->
+ *     ticket_email_links -> ticket_attachments -> ticket_alert_links, not a
+ *     single trailing-pair swap). `fenceLoser()` stamps the loser org
+ *     `status='merging'` before the merge transaction opens and the
+ *     device/ticket move routes refuse a fenced org, but that fence is
+ *     app-layer — it does not close the window for a move already in flight
+ *     when the fence lands. `applyTicketChildLockOrder` below is the fix:
+ *     `orgMerge.ts` routes both of its walk-order computations through it so
+ *     the merge's ticket-child slots always read out in the SAME relative
+ *     order as the movers, closing the AB-BA window rather than merely
+ *     documenting it.
  *
  * Contract enforced by ticketOrgMoveLockOrder.test.ts (both lists agree with
  * this order) and by moveOrg.test.ts (the device path's actual statement
@@ -119,3 +122,50 @@ export const TICKET_ORG_DENORMALIZED_TABLES = [
   'ticket_attachments',
   'ticket_email_links',
 ] as const;
+
+/**
+ * Reorders a merge-style table walk (e.g. a reversed
+ * `topologicalCascadeOrder()`) so the six tables in
+ * {@link TICKET_CHILD_ORG_REWRITE_LOCK_ORDER} occupy their SAME index
+ * positions but in canonical relative order — every other table's position
+ * is left untouched.
+ *
+ * Exists for org merge (#4748): `orgMerge.ts` derives its walk order from
+ * `topologicalCascadeOrder()`, which ties on alphabetical order for tables
+ * with no FK between them. The six ticket child tables are exactly such a
+ * set (see the FK note above — none of the six references another, so
+ * children-before-parents never constrains their relative order), so it is
+ * always safe to permute them into the canonical order without disturbing
+ * FK-safety: we never move a table INTO or OUT OF the slots it already
+ * occupies, only change which of the six values lands in each slot.
+ *
+ * `walkOrder` may contain any subset of the six (a caller doesn't have to
+ * pass all of them) — the ones present are placed in canonical relative
+ * order among themselves; anything absent is simply skipped.
+ */
+export function applyTicketChildLockOrder(walkOrder: readonly string[]): string[] {
+  const canonicalSet = new Set<string>(TICKET_CHILD_ORG_REWRITE_LOCK_ORDER);
+  const slotIndices: number[] = [];
+  walkOrder.forEach((table, index) => {
+    if (canonicalSet.has(table)) slotIndices.push(index);
+  });
+  const present = TICKET_CHILD_ORG_REWRITE_LOCK_ORDER.filter((table) => walkOrder.includes(table));
+  if (slotIndices.length !== present.length) {
+    // Only reachable if walkOrder has a duplicate ticket-child entry — every
+    // real caller (topologicalCascadeOrder() reversed) lists each table
+    // exactly once, so this guards a contract violation rather than a
+    // reachable runtime state.
+    throw new Error(
+      `[ticketOrgMoveLockOrder] applyTicketChildLockOrder: walkOrder contains a duplicate ` +
+        `ticket child-table entry (found ${slotIndices.length} slots for ${present.length} ` +
+        `distinct tables)`,
+    );
+  }
+  const result = [...walkOrder];
+  slotIndices.forEach((index, i) => {
+    // Safe: the length check above guarantees `present` has exactly one
+    // entry per `slotIndices` position.
+    result[index] = present[i] as string;
+  });
+  return result;
+}


### PR DESCRIPTION
## Summary

`orgMerge.ts` walks the org-merge table set in `reversed(topologicalCascadeOrder())` order. That reversal ties on alphabetical order for tables with no FK between each other — and the six ticket child tables that denormalize `org_id` (`time_entries`, `ticket_parts`, `ticket_alert_links`, `ticket_outbox`, `ticket_attachments`, `ticket_email_links`) are exactly such a set (documented FK note in `ticketOrgMoveLockOrder.ts`: none of the six references another).

That alphabetical tie-break disagrees with `TICKET_CHILD_ORG_REWRITE_LOCK_ORDER` — the lock order the ticket-move (`moveTicketOrg`) and device-move (`POST /devices/:id/move-org`) axes already agree on (#4657), for the exact same AB-BA (40P01) reason. The merge is held apart from an in-flight move only by `fenceLoser()`'s app-layer `status='merging'` fence, not by lock order — so a move that starts before the fence lands can still contend with the merge under opposite lock order.

## Fix

- `applyTicketChildLockOrder()` (new, `ticketOrgMoveLockOrder.ts`): given any table walk, permutes only the ticket-child tables' own index slots into `TICKET_CHILD_ORG_REWRITE_LOCK_ORDER`'s relative order — every other table keeps its position. Safe to apply unconditionally because the six share no FK with each other, so permuting them never breaks children-before-parents correctness for anything else in the walk.
- `orgMerge.ts` gets a small `getOrgMergeWalkOrder()` helper that wraps the existing `[...(await topologicalCascadeOrder())].reverse()` with the new function, and both walk-order consumers (the merge transaction and the merge preview) now call it instead of duplicating the raw computation.

## Tests

Added a red-first contract suite to `ticketOrgMoveLockOrder.test.ts` (pure, no DB — same style as the existing #4657 contract in that file):
- Demonstrates the gap: naive reverse-alphabetical tie-break disagrees with the canonical order.
- Pins `applyTicketChildLockOrder`'s behavior directly: reorders only the ticket-child slots, no-ops when already canonical, handles a partial subset.
- A source-grep static contract asserting `orgMerge.ts` has exactly one raw `topologicalCascadeOrder().reverse()` (inside `getOrgMergeWalkOrder()`) and both consumption sites call `getOrgMergeWalkOrder()` — so a future regression back to a bare reversed order fails in the **Test API** unit job instead of only surfacing as a live deadlock.

Verified locally:
- `npx vitest run src/services/ticketOrgMoveLockOrder.test.ts src/services/orgMerge.test.ts src/routes/orgMerge.test.ts src/jobs/orgMerge.test.ts` — 116 passed.
- `npx vitest run src/routes/devices/moveOrg.test.ts src/services/ticketService.test.ts` — 236 passed (unaffected by this change, confirms the two movers still agree).
- `npx tsc --noEmit -p apps/api` — clean.
- `npx eslint` on the three touched files — clean.

Closes #4748

🤖 Generated with [Claude Code](https://claude.com/claude-code)