### PR TITLE
fix(api): persist an error mapping row on currency_mismatch invoice push (#4498)

### DIFF
--- a/apps/api/src/__tests__/integration/accountingInvoicePushCurrency.integration.test.ts
+++ b/apps/api/src/__tests__/integration/accountingInvoicePushCurrency.integration.test.ts
@@ -1,21 +1,21 @@
 /**
  * Real-DB proof for the Phase-C invoice-push currency contract (multi-currency
- * §11, bug B8). This is the exact file the trailing contract comment in
- * `accountingCurrency.ts:143-186` mandates by name — that comment is the
- * authoritative spec for what this suite proves, and this file follows it
- * verbatim rather than a looser paraphrase:
+ * §11, bug B8), UPDATED by #4498 to invert the "no trace" half of that
+ * contract for `currency_mismatch` specifically. The trailing contract
+ * comment in `accountingCurrency.ts:143-186` still describes the ORIGINAL
+ * shape (no mapping row for either currency failure) — that comment is
+ * stale for `currency_mismatch` as of this change; `home_currency_unknown`
+ * is unaffected and still persists nothing (see #4498's own scoping: it is a
+ * rarer connection-setup problem, not this issue's complaint):
  *
  *  - EUR invoice + USD-home connection: `pushInvoiceToAccounting` throws
  *    `ACCOUNTING_INVOICE_CURRENCY_MISMATCH` (typed here as the coordinator's
- *    `currency_mismatch`), NO QBO request is made, and NO sync/mapping state
- *    is persisted — no `accounting_entity_mappings` row for the invoice
- *    exists at all, because the currency guard
- *    (`assertAccountingInvoicePushCurrency`) runs before the coordinator ever
- *    reads/writes the invoice's mapping row (see `accountingInvoicePush.ts`'s
- *    `pushInvoiceToAccounting`: the guard sits immediately after the
- *    draft/void check and strictly before the org mapping load, the line
- *    load, and `upsertInvoiceMappingPending`).
- *  - NULL home currency: same treatment, `home_currency_unknown`.
+ *    `currency_mismatch`), NO QBO request is made, and the invoice's
+ *    `accounting_entity_mappings` row now lands `sync_status:'error'` with
+ *    no `remoteEntityId` and both currencies named in `lastError` — so the
+ *    invoice detail card has something to show instead of nothing (#4498).
+ *  - NULL home currency: `home_currency_unknown`, NO QBO request, and NO
+ *    mapping row persisted — unchanged from before #4498.
  *  - USD invoice against a USD-home connection with the provider transport
  *    mocked at the `fetch` boundary: the invoice's mapping row lands
  *    `sync_status:'synced'`, and a second push against the now-existing
@@ -44,7 +44,7 @@ import {
 } from '../../db/schema';
 import { createOrganization, createPartner } from './db-utils';
 import { upsertConnection } from '../../services/accounting/accountingConnectionService';
-import { pushInvoiceToAccounting } from '../../services/accounting/accountingInvoicePush';
+import { pushInvoiceToAccounting, voidInvoiceInAccounting } from '../../services/accounting/accountingInvoicePush';
 
 const runDb = it.runIf(!!process.env.DATABASE_URL);
 
@@ -180,7 +180,7 @@ describe('pushInvoiceToAccounting currency contract — real Postgres', () => {
     vi.restoreAllMocks();
   });
 
-  runDb('EUR invoice against a USD-home connection: currency_mismatch, no QBO request, no mapping row persisted', async () => {
+  runDb('EUR invoice against a USD-home connection: currency_mismatch, no QBO request, error-only mapping row persisted with both currencies named (#4498)', async () => {
     const fx = await seedFixture({ homeCurrency: 'USD', multiCurrencyEnabled: false });
     const invoiceId = await seedInvoice(fx, { currencyCode: 'EUR' });
     const fetchSpy = vi.spyOn(globalThis, 'fetch');
@@ -190,7 +190,42 @@ describe('pushInvoiceToAccounting currency contract — real Postgres', () => {
     ).rejects.toMatchObject({ code: 'currency_mismatch', status: 409 });
 
     expect(fetchSpy).not.toHaveBeenCalled();
-    expect(await loadInvoiceMappingRows(fx, invoiceId)).toEqual([]);
+
+    const rows = await loadInvoiceMappingRows(fx, invoiceId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      syncStatus: 'error',
+      remoteEntityId: null,
+      linkStatus: 'create_new',
+    });
+    expect(rows[0]!.lastError).toContain('EUR');
+    expect(rows[0]!.lastError).toContain('USD');
+
+    // Retrying the same push re-throws the same terminal error and merely
+    // UPDATEs the existing row in place (idempotent) rather than inserting a
+    // second one — proves a manual retry loop cannot spin up duplicate rows
+    // or duplicate QuickBooks calls against a mapping that can never succeed.
+    const fetchSpy2 = vi.spyOn(globalThis, 'fetch');
+    await expect(
+      pushInvoiceToAccounting(invoiceId, fx.partnerId, (fn) => withDbAccessContext(partnerCtx(fx.partnerId, fx.orgId), fn))
+    ).rejects.toMatchObject({ code: 'currency_mismatch', status: 409 });
+    expect(fetchSpy2).not.toHaveBeenCalled();
+    const rowsAfterRetry = await loadInvoiceMappingRows(fx, invoiceId);
+    expect(rowsAfterRetry).toHaveLength(1);
+    expect(rowsAfterRetry[0]!.id).toBe(rows[0]!.id);
+
+    // The mapping row this currency guard just persisted must not trip
+    // `voidInvoiceInAccounting`'s in-flight-marker assumption: that push
+    // never reached QuickBooks (syncStatus:'error', no remoteEntityId), so a
+    // void must no-op rather than misreading it as a mid-flight `pending`
+    // push (which would throw the non-terminal `sync_in_progress`) or trying
+    // to void a QuickBooks invoice that was never created.
+    await expect(
+      voidInvoiceInAccounting(invoiceId, fx.partnerId, (fn) => withDbAccessContext(partnerCtx(fx.partnerId, fx.orgId), fn))
+    ).resolves.toBeUndefined();
+    const rowsAfterVoid = await loadInvoiceMappingRows(fx, invoiceId);
+    expect(rowsAfterVoid).toHaveLength(1);
+    expect(rowsAfterVoid[0]).toMatchObject({ syncStatus: 'error', remoteEntityId: null });
   });
 
   runDb('NULL home currency: home_currency_unknown, no QBO request, no mapping row persisted', async () => {

--- a/apps/api/src/services/accounting/accountingCurrency.ts
+++ b/apps/api/src/services/accounting/accountingCurrency.ts
@@ -159,14 +159,22 @@ export function normalizeAccountingPayment(
  *     an AccountingProvider, and fails unless the enclosing module is the
  *     coordinator itself. That is what makes the guard unbypassable rather
  *     than merely available.
- *  3. DELIVERED. `apps/api/src/__tests__/integration/accountingInvoicePushCurrency.integration.test.ts` —
+ *  3. DELIVERED, UPDATED BY #4498. `apps/api/src/__tests__/integration/accountingInvoicePushCurrency.integration.test.ts` —
  *     seeds a USD QBO connection + an EUR invoice, calls the real coordinator,
- *     asserts `currency_mismatch` (ACCOUNTING_INVOICE_CURRENCY_MISMATCH),
- *     asserts NO QBO request was made (a `fetch` spy) and NO sync/mapping
- *     state was persisted (no `accounting_entity_mappings` row for the
- *     invoice at all); a null-home-currency case asserting
+ *     asserts `currency_mismatch` (ACCOUNTING_INVOICE_CURRENCY_MISMATCH) and
+ *     that NO QBO request was made (a `fetch` spy). Through #4498, no
+ *     sync/mapping state was persisted either (no `accounting_entity_mappings`
+ *     row for the invoice at all) — a tech had no signal that an auto-push
+ *     had failed short of retrying it manually. As of #4498, `currency_mismatch`
+ *     specifically now persists an ERROR-ONLY mapping row (`sync_status:'error'`,
+ *     no `remoteEntityId`, both currencies named in `lastError`) so the
+ *     invoice detail card's existing `syncStatus:'error'`-is-pushable branch
+ *     surfaces it with no new UI plumbing — see `persistInvoiceCurrencyMismatchErrorInOwnContext`
+ *     in `accountingInvoicePush.ts`. `home_currency_unknown` is UNCHANGED and
+ *     still persists nothing (a rarer connection-setup problem, out of #4498's
+ *     scope); the suite also proves a null-home-currency case asserting
  *     `home_currency_unknown` (ACCOUNTING_HOME_CURRENCY_UNKNOWN) the same
- *     way; and a same-currency happy-path case (provider transport mocked at
+ *     way, and a same-currency happy-path case (provider transport mocked at
  *     the `fetch` boundary) proving the mapping row lands `synced` and a
  *     second push against the same invoice UPDATEs the existing mapping row
  *     rather than inserting a second one, against the real

--- a/apps/api/src/services/accounting/accountingInvoicePush.test.ts
+++ b/apps/api/src/services/accounting/accountingInvoicePush.test.ts
@@ -574,6 +574,117 @@ describe('pushInvoiceToAccounting', () => {
     });
   });
 
+  // #4498: the currency guard used to throw with no trace at all — no
+  // accounting_entity_mappings row for the invoice, so getInvoiceAccountingSync
+  // had nothing to read and the AccountingSyncCard showed nothing. It now
+  // persists an error-only mapping row so the card's existing
+  // syncStatus:'error' branch (no new UI plumbing) surfaces it.
+  describe('currency_mismatch persists an error-only mapping row (#4498)', () => {
+    it('inserts a new error-only mapping row (no remoteEntityId) naming both currencies, in a FRESH context opened AFTER Phase 1 rolled back', async () => {
+      setup({ invoice: { currencyCode: 'EUR' } });
+      resolveConnectionMock.mockResolvedValue(conn({ homeCurrency: 'USD', multiCurrencyEnabled: false }));
+
+      await expect(pushInvoiceToAccounting(INVOICE, PARTNER, runCtx)).rejects.toMatchObject({
+        code: 'currency_mismatch', status: 409,
+      });
+      expect(pushInvoiceMock).not.toHaveBeenCalled();
+
+      // Phase 1 enters/exits (and throws inside), THEN a separate context opens
+      // for the persist — never inside the same enter/exit pair Phase 1 used,
+      // which is exactly the shape that would roll back on a real Postgres
+      // transaction (see the DB ACCESS CONTRACT doc comment).
+      expect(ctx.events).toEqual(['ctx:enter', 'ctx:exit', 'ctx:enter', 'ctx:exit']);
+
+      const row = currentMappings.find((m) => m.breezeEntityType === 'invoice' && m.breezeEntityId === INVOICE);
+      expect(row).toMatchObject({
+        integrationId: CONN_ID, partnerId: PARTNER, breezeEntityType: 'invoice', breezeEntityId: INVOICE,
+        remoteEntityType: 'Invoice', linkStatus: 'create_new', syncStatus: 'error',
+      });
+      expect(row?.remoteEntityId ?? null).toBeNull(); // omitted from the insert -> nullable column, no remote id
+      expect(row?.lastError).toContain('EUR');
+      expect(row?.lastError).toContain('USD');
+    });
+
+    it('does NOT persist any mapping row for home_currency_unknown (scoped to currency_mismatch only)', async () => {
+      resolveConnectionMock.mockResolvedValue(conn({ homeCurrency: null }));
+
+      await expect(pushInvoiceToAccounting(INVOICE, PARTNER, runCtx)).rejects.toMatchObject({
+        code: 'home_currency_unknown', status: 409,
+      });
+
+      expect(currentMappings.find((m) => m.breezeEntityType === 'invoice')).toBeUndefined();
+      expect(insertedValues).toHaveLength(0);
+    });
+
+    it('UPDATEs an existing invoice mapping row in place (never a duplicate insert) and never touches remoteEntityId/linkStatus of an already-synced row', async () => {
+      // Simulates the invoice having synced successfully in the past, then the
+      // connection's home currency changing so this push attempt now 409s.
+      setup({
+        invoice: { currencyCode: 'EUR' },
+        mappings: [
+          orgMappingRow(),
+          {
+            id: 'map-inv-old', integrationId: CONN_ID, partnerId: PARTNER, breezeEntityType: 'invoice', breezeEntityId: INVOICE,
+            remoteEntityType: 'Invoice', remoteEntityId: 'qb-inv-old', remoteSyncToken: '2',
+            remoteCurrencyCode: null, remoteDocNumber: 'INV-QBO-1', linkStatus: 'confirmed', syncStatus: 'synced', lastError: null,
+          },
+        ],
+      });
+      resolveConnectionMock.mockResolvedValue(conn({ homeCurrency: 'GBP', multiCurrencyEnabled: false }));
+
+      await expect(pushInvoiceToAccounting(INVOICE, PARTNER, runCtx)).rejects.toMatchObject({ code: 'currency_mismatch' });
+
+      expect(insertedValues).toHaveLength(0); // updated in place, never inserted a second row
+      const row = currentMappings.find((m) => m.breezeEntityType === 'invoice' && m.breezeEntityId === INVOICE);
+      expect(row).toMatchObject({
+        id: 'map-inv-old', syncStatus: 'error', remoteEntityId: 'qb-inv-old', remoteDocNumber: 'INV-QBO-1', linkStatus: 'confirmed',
+      });
+      expect(row?.lastError).toContain('EUR');
+    });
+
+    // Same rationale/technique as the remote-deleted claiming-UPDATE test above:
+    // the mock harness can't fake a genuine concurrent-transaction race, but it
+    // CAN prove the compiled WHERE clause carries the same never-clobber guard,
+    // so a future edit that quietly drops it fails this test instead of shipping
+    // a currency-guard write that can resurrect a remote-deleted invoice.
+    it('the error-row UPDATE conditions on the row NOT already carrying the remote-deleted marker (SQL-level regression guard)', async () => {
+      setup({
+        invoice: { currencyCode: 'EUR' },
+        mappings: [orgMappingRow(), { ...remoteDeletedInvoiceMappingRow(), lastError: null, syncStatus: 'synced' }],
+      });
+      resolveConnectionMock.mockResolvedValue(conn({ homeCurrency: 'USD', multiCurrencyEnabled: false }));
+
+      let capturedWhereCond: unknown;
+      updateMock.mockImplementation(() => ({
+        set: (patch: Record<string, unknown>) => ({
+          where: (cond: unknown) => ({
+            returning: () => {
+              capturedWhereCond = cond;
+              const idx = currentMappings.findIndex((row) => conditionContainsValue(cond, row.id));
+              if (idx !== -1) currentMappings[idx] = { ...currentMappings[idx], ...patch } as MappingRow;
+              return Promise.resolve(idx === -1 ? [] : [currentMappings[idx]]);
+            },
+          }),
+        }),
+      }));
+
+      await expect(pushInvoiceToAccounting(INVOICE, PARTNER, runCtx)).rejects.toMatchObject({ code: 'currency_mismatch' });
+
+      expect(conditionContainsValue(capturedWhereCond, 'Deleted in QuickBooks')).toBe(true);
+    });
+
+    it('is best-effort: a failure persisting the error row still raises the original currency_mismatch, and reports to Sentry', async () => {
+      setup({ invoice: { currencyCode: 'EUR' } });
+      resolveConnectionMock.mockResolvedValue(conn({ homeCurrency: 'USD', multiCurrencyEnabled: false }));
+      insertMock.mockImplementation(() => ({ values: () => ({ returning: () => Promise.reject(new Error('db down')) }) }));
+
+      await expect(pushInvoiceToAccounting(INVOICE, PARTNER, runCtx)).rejects.toMatchObject({
+        code: 'currency_mismatch', status: 409,
+      });
+      expect(captureExceptionMock).toHaveBeenCalled();
+    });
+  });
+
   it('rejects with customer_currency_mismatch when the mapped customer currency differs from the invoice', async () => {
     setup({ mappings: [orgMappingRow({ remoteCurrencyCode: 'EUR' })] });
 

--- a/apps/api/src/services/accounting/accountingInvoicePush.test.ts
+++ b/apps/api/src/services/accounting/accountingInvoicePush.test.ts
@@ -683,6 +683,39 @@ describe('pushInvoiceToAccounting', () => {
       });
       expect(captureExceptionMock).toHaveBeenCalled();
     });
+
+    it('a concurrent-insert race (unique violation) on the error-row insert is swallowed silently — NOT reported to Sentry — since another write already owns the row', async () => {
+      // Two auto-push attempts for the same invoice racing to insert the
+      // FIRST invoice mapping row: whichever loses the race must not treat
+      // "someone else already recorded a row here" as a failure worth paging
+      // on, distinct from a genuine DB error (covered by the test above).
+      setup({ invoice: { currencyCode: 'EUR' } });
+      resolveConnectionMock.mockResolvedValue(conn({ homeCurrency: 'USD', multiCurrencyEnabled: false }));
+      insertMock.mockImplementation(() => ({
+        values: () => ({ returning: () => Promise.reject(pgUniqueViolation('accounting_entity_mappings_breeze_uniq')) }),
+      }));
+
+      await expect(pushInvoiceToAccounting(INVOICE, PARTNER, runCtx)).rejects.toMatchObject({
+        code: 'currency_mismatch', status: 409,
+      });
+      expect(captureExceptionMock).not.toHaveBeenCalled();
+    });
+
+    it('a DIFFERENT insert failure (not the unique-violation race) still reports to Sentry rather than being swallowed like the race above', async () => {
+      // Guards the `isPgUniqueViolation` branch from silently widening: only
+      // THIS exact constraint name is treated as benign; any other error
+      // (wrong constraint, or no constraint at all) must still surface.
+      setup({ invoice: { currencyCode: 'EUR' } });
+      resolveConnectionMock.mockResolvedValue(conn({ homeCurrency: 'USD', multiCurrencyEnabled: false }));
+      insertMock.mockImplementation(() => ({
+        values: () => ({ returning: () => Promise.reject(pgUniqueViolation('some_other_unrelated_constraint')) }),
+      }));
+
+      await expect(pushInvoiceToAccounting(INVOICE, PARTNER, runCtx)).rejects.toMatchObject({
+        code: 'currency_mismatch', status: 409,
+      });
+      expect(captureExceptionMock).toHaveBeenCalled();
+    });
   });
 
   it('rejects with customer_currency_mismatch when the mapped customer currency differs from the invoice', async () => {

--- a/apps/api/src/services/accounting/accountingInvoicePush.ts
+++ b/apps/api/src/services/accounting/accountingInvoicePush.ts
@@ -37,6 +37,13 @@
  * mapping row were savepoints that rolled back the instant this coordinator
  * threw: the operator saw no error at all, and the retry took the CREATE path
  * again and double-booked the invoice in QuickBooks.
+ *
+ * The currency guard inside Phase 1 is the SAME trap in miniature (#4498): it
+ * throws from inside that one transaction, so a write made in that same
+ * callback would roll back with it. `persistInvoiceCurrencyMismatchErrorInOwnContext`
+ * therefore runs from the OUTER catch around Phase 1 — AFTER Phase 1's
+ * transaction has already rolled back — in its own short, separately-committed
+ * context, exactly like `markInvoiceMappingErrorInOwnContext` does for Phase 2.
  */
 
 import { and, eq, isNull, ne, or } from 'drizzle-orm';
@@ -226,6 +233,90 @@ function translateCurrencyError(err: unknown, conn: AccountingConnection): never
     : `Enable multi-currency in ${label} or invoice in ${home ?? 'the connected home currency'}.`;
 
   throw new AccountingInvoicePushError('currency_mismatch', 409, `${err.message} ${guidance}`);
+}
+
+/**
+ * Persists a `currency_mismatch` pre-flight refusal onto the invoice's own
+ * mapping row (#4498). Before this, the currency guard threw before Phase 1b
+ * ever claims/creates that row, so `getInvoiceAccountingSync` had nothing to
+ * read and the invoice detail card showed no trace of a failed auto-push — a
+ * tech had no signal short of retrying the push manually and reading the 409.
+ * Deliberately scoped to `currency_mismatch` only (not `home_currency_unknown`,
+ * a rarer connection-setup problem that is not this issue's complaint).
+ *
+ * MUST be called from OUTSIDE the Phase 1 `runInDbContext` call whose guard
+ * just threw — that transaction has already rolled back by the time this
+ * runs (see the DB ACCESS CONTRACT doc comment above), so this opens its own
+ * short, separately-committed context and re-resolves the connection itself
+ * rather than threading `conn.id` through the thrown error.
+ *
+ * Best-effort and NEVER throws: a failure here must not replace the typed
+ * `currency_mismatch` error the caller is about to (re)raise regardless of
+ * whether this write lands. Sentry has the original either way.
+ *
+ * Never clobbers a `remote-deleted` marker (same WHERE guard as
+ * `upsertInvoiceMappingPending`) and, on an existing row, never touches
+ * `remoteEntityId`/`linkStatus` — if this invoice was already pushed
+ * successfully before the connection's home currency changed, that remote
+ * link must survive; only `syncStatus`/`lastError` move to reflect this
+ * attempt's failure.
+ */
+async function persistInvoiceCurrencyMismatchErrorInOwnContext(
+  runInDbContext: DbContextRunner,
+  partnerId: string,
+  invoiceId: string,
+  message: string,
+): Promise<void> {
+  try {
+    await runInDbContext(async () => {
+      const conn = await resolveConnection(partnerId, 'quickbooks');
+      const existingRows = await loadMappingRowsForType(partnerId, conn.id, 'invoice');
+      const existing = existingRows.find((m) => m.breezeEntityId === invoiceId) ?? null;
+
+      if (existing) {
+        // Zero rows back is not an error worth surfacing here: it means the
+        // remote-deleted marker landed on this row concurrently (the WHERE
+        // guard below) or the row was deleted entirely — either way there is
+        // nothing this best-effort write should do about it.
+        await db
+          .update(accountingEntityMappings)
+          .set({ syncStatus: 'error', lastError: message, updatedAt: new Date() })
+          .where(and(
+            eq(accountingEntityMappings.id, existing.id),
+            eq(accountingEntityMappings.partnerId, partnerId),
+            or(
+              isNull(accountingEntityMappings.lastError),
+              ne(accountingEntityMappings.lastError, INVOICE_REMOTE_DELETED_ERROR),
+            ),
+          ))
+          .returning();
+        return;
+      }
+
+      try {
+        await db.insert(accountingEntityMappings).values({
+          integrationId: conn.id,
+          partnerId,
+          breezeEntityType: 'invoice',
+          breezeEntityId: invoiceId,
+          remoteEntityType: 'Invoice',
+          linkStatus: 'create_new',
+          syncStatus: 'error',
+          lastError: message,
+        }).returning();
+      } catch (err) {
+        // A concurrent push (or a concurrent currency-error write for the
+        // same invoice) claimed the row first between our read and this
+        // insert; that write owns the row's current state now — nothing to
+        // reconcile, and nothing worth reporting.
+        if (!isPgUniqueViolation(err, 'accounting_entity_mappings_breeze_uniq')) throw err;
+      }
+    });
+  } catch (err) {
+    captureException(err instanceof Error ? err : new Error(String(err)), undefined, {
+      service: 'accountingInvoicePush', invoiceId, partnerId,
+    });
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -518,69 +609,91 @@ export async function pushInvoiceToAccounting(
   // No token is resolved here: the currency guard (and every other permanent
   // refusal) must be able to fire WITHOUT triggering a QuickBooks token
   // refresh for an invoice that can never be pushed.
-  const prep = await runInDbContext(async () => {
-    const conn = await resolveConnection(partnerId, 'quickbooks').catch(translateMappingError);
+  //
+  // Wrapped in try/catch: a throw FROM INSIDE this callback rolls the whole
+  // transaction back (DB ACCESS CONTRACT above), so a currency_mismatch write
+  // cannot happen in here — it happens in the outer catch below, in its own
+  // context, AFTER this one has already rolled back.
+  let prep: {
+    conn: AccountingConnection;
+    inv: InvoiceRow;
+    lines: InvoiceLineRow[];
+    orgMapping: MappingRow;
+    itemMappingRows: MappingRow[];
+  };
+  try {
+    prep = await runInDbContext(async () => {
+      const conn = await resolveConnection(partnerId, 'quickbooks').catch(translateMappingError);
 
-    const inv = await loadOwnedInvoice(invoiceId, partnerId);
-    if (inv.invoiceNumber === null || !PUSHABLE_STATUSES.has(inv.status)) {
-      // Covers both a draft (never issued) and a void invoice — void pushes go
-      // through voidInvoiceInAccounting, never this entrypoint.
-      throw new AccountingInvoicePushError(
-        'invoice_not_pushable',
-        409,
-        'Invoice must be issued and not void before it can be pushed to QuickBooks',
-      );
+      const inv = await loadOwnedInvoice(invoiceId, partnerId);
+      if (inv.invoiceNumber === null || !PUSHABLE_STATUSES.has(inv.status)) {
+        // Covers both a draft (never issued) and a void invoice — void pushes go
+        // through voidInvoiceInAccounting, never this entrypoint.
+        throw new AccountingInvoicePushError(
+          'invoice_not_pushable',
+          409,
+          'Invoice must be issued and not void before it can be pushed to QuickBooks',
+        );
+      }
+
+      // Remote-deleted guard (#4544) runs BEFORE any org/item lookup, token
+      // refresh or provider call, same rationale as the currency guard below —
+      // a permanent refusal must not pay for work whose only purpose is a push
+      // that can never succeed. Phase 1b re-checks this against a fresh read
+      // right before claiming the mapping row `pending`, since the reconcile
+      // worker can flip it to remote-deleted while the dependency syncs below
+      // are still in flight — this early check is a cheap-exit optimization,
+      // not the sole enforcement point.
+      if (await loadInvoiceMappingIsRemoteDeleted(partnerId, conn.id, inv.id)) {
+        throw new AccountingInvoicePushError(
+          'remote_deleted',
+          409,
+          'QuickBooks reports this invoice as deleted — pushing again would create a duplicate. Resolve it in QuickBooks, or unlink and re-map the invoice, before pushing again.',
+        );
+      }
+
+      // Currency guard runs BEFORE any org/item lookup, token refresh or provider
+      // call (multi-currency §11 contract, accountingCurrency.ts:143-186).
+      try {
+        assertAccountingInvoicePushCurrency(conn, { currencyCode: inv.currencyCode });
+      } catch (err) {
+        translateCurrencyError(err, conn);
+      }
+
+      const lines = await loadInvoiceLinesOrdered(inv.id);
+
+      const orgMappingRows = await loadMappingRowsForType(partnerId, conn.id, 'org');
+      const orgMapping = orgMappingRows.find((m) => m.breezeEntityId === inv.orgId) ?? null;
+      if (!orgMapping || orgMapping.linkStatus === 'unlinked' || orgMapping.linkStatus === 'suggested') {
+        throw new AccountingInvoicePushError(
+          'customer_not_mapped',
+          409,
+          'This organization is not mapped to a QuickBooks customer yet — confirm or create a mapping first',
+        );
+      }
+      if (
+        orgMapping.remoteCurrencyCode
+        && normalizeCurrencyCode(orgMapping.remoteCurrencyCode) !== normalizeCurrencyCode(inv.currencyCode)
+      ) {
+        throw new AccountingInvoicePushError(
+          'customer_currency_mismatch',
+          409,
+          `The QuickBooks customer for this organization is stamped in ${orgMapping.remoteCurrencyCode}, which does not match this invoice's ${inv.currencyCode} currency`,
+        );
+      }
+
+      const itemMappingRows = await loadMappingRowsForType(partnerId, conn.id, 'catalog_item');
+      return { conn, inv, lines, orgMapping, itemMappingRows };
+    });
+  } catch (err) {
+    if (err instanceof AccountingInvoicePushError && err.code === 'currency_mismatch') {
+      // Phase 1's transaction above already rolled back on this throw — this
+      // persists in its own, separately-committed context (see the comment
+      // on `persistInvoiceCurrencyMismatchErrorInOwnContext`).
+      await persistInvoiceCurrencyMismatchErrorInOwnContext(runInDbContext, partnerId, invoiceId, err.message);
     }
-
-    // Remote-deleted guard (#4544) runs BEFORE any org/item lookup, token
-    // refresh or provider call, same rationale as the currency guard below —
-    // a permanent refusal must not pay for work whose only purpose is a push
-    // that can never succeed. Phase 1b re-checks this against a fresh read
-    // right before claiming the mapping row `pending`, since the reconcile
-    // worker can flip it to remote-deleted while the dependency syncs below
-    // are still in flight — this early check is a cheap-exit optimization,
-    // not the sole enforcement point.
-    if (await loadInvoiceMappingIsRemoteDeleted(partnerId, conn.id, inv.id)) {
-      throw new AccountingInvoicePushError(
-        'remote_deleted',
-        409,
-        'QuickBooks reports this invoice as deleted — pushing again would create a duplicate. Resolve it in QuickBooks, or unlink and re-map the invoice, before pushing again.',
-      );
-    }
-
-    // Currency guard runs BEFORE any org/item lookup, token refresh or provider
-    // call (multi-currency §11 contract, accountingCurrency.ts:143-186).
-    try {
-      assertAccountingInvoicePushCurrency(conn, { currencyCode: inv.currencyCode });
-    } catch (err) {
-      translateCurrencyError(err, conn);
-    }
-
-    const lines = await loadInvoiceLinesOrdered(inv.id);
-
-    const orgMappingRows = await loadMappingRowsForType(partnerId, conn.id, 'org');
-    const orgMapping = orgMappingRows.find((m) => m.breezeEntityId === inv.orgId) ?? null;
-    if (!orgMapping || orgMapping.linkStatus === 'unlinked' || orgMapping.linkStatus === 'suggested') {
-      throw new AccountingInvoicePushError(
-        'customer_not_mapped',
-        409,
-        'This organization is not mapped to a QuickBooks customer yet — confirm or create a mapping first',
-      );
-    }
-    if (
-      orgMapping.remoteCurrencyCode
-      && normalizeCurrencyCode(orgMapping.remoteCurrencyCode) !== normalizeCurrencyCode(inv.currencyCode)
-    ) {
-      throw new AccountingInvoicePushError(
-        'customer_currency_mismatch',
-        409,
-        `The QuickBooks customer for this organization is stamped in ${orgMapping.remoteCurrencyCode}, which does not match this invoice's ${inv.currencyCode} currency`,
-      );
-    }
-
-    const itemMappingRows = await loadMappingRowsForType(partnerId, conn.id, 'catalog_item');
-    return { conn, inv, lines, orgMapping, itemMappingRows };
-  });
+    throw err;
+  }
 
   const { conn, inv, lines } = prep;
 


### PR DESCRIPTION
## Summary

When the accounting-sync worker auto-pushes an issued invoice whose currency differs from the connected QuickBooks home currency, `pushInvoiceToAccounting`'s currency guard throws `currency_mismatch` **before** any `accounting_entity_mappings` row exists — by design of the Phase C currency contract (`accountingCurrency.ts`). The worker logs a terminal failure and doesn't retry. Result: `GET /invoices/:id` returns `accountingSync: null`, so `AccountingSyncCard` renders nothing — a tech has no signal that the push failed short of retrying manually and reading the 409.

This inverts that one piece of the contract for `currency_mismatch` specifically: the coordinator now persists an **error-only mapping row** (`sync_status: 'error'`, no `remoteEntityId`, both currencies named in `lastError`) so the existing `getInvoiceAccountingSync` read path and `AccountingSyncCard`'s `syncStatus:'error'`-is-pushable branch surface it — **no new UI plumbing**. `home_currency_unknown` is unchanged (a rarer connection-setup problem, out of this issue's scope) and still persists nothing.

## The tricky part

`pushInvoiceToAccounting`'s Phase 1 currency guard throws from *inside* one `runInDbContext` transaction. Per the file's own DB ACCESS CONTRACT doc comment, that transaction rolls back the instant the callback throws — so writing the error row inside that same callback would have vanished with the throw (the exact "lost sync state" class the file already warns about for the provider-call failure path). The fix instead:

- Wraps the whole Phase 1 `runInDbContext` call in a `try`/`catch` in `pushInvoiceToAccounting`.
- On a `currency_mismatch` catch, calls a new `persistInvoiceCurrencyMismatchErrorInOwnContext` — its own short, separately-committed context, opened *after* Phase 1 has already rolled back — which re-resolves the connection and upserts the mapping row (insert if none exists, update-in-place if one does, never touching `remoteEntityId`/`linkStatus` on an existing row, never clobbering a `remote-deleted` marker).
- The write is best-effort and never replaces the typed `currency_mismatch` error being (re)thrown.

## Verification

- **Real Postgres integration test** (updated `accountingInvoicePushCurrency.integration.test.ts`): EUR-vs-USD push now asserts a persisted error-only row naming both currencies; a second consecutive push proves idempotent UPDATE-in-place (no duplicate row, no duplicate QuickBooks call); `voidInvoiceInAccounting` against that row resolves as a no-op (proves it doesn't trip the in-flight `pending` marker check). `home_currency_unknown` case unchanged (still asserts no row).
- **New mocked unit tests** in `accountingInvoicePush.test.ts`: insert shape, scoped-to-`currency_mismatch`-only (not `home_currency_unknown`), update-in-place preserving an already-synced row's `remoteEntityId`/`linkStatus`, SQL-level remote-deleted-guard regression test, and a best-effort/Sentry-capture test for a failed persist.
- `pnpm exec vitest run` on the touched files: 44 + 25 (worker/call-sites) + 176 (invoiceService/accountingMappingService) unit tests green; 3 integration tests green against real Postgres.
- `npx tsc --noEmit` clean; `npx eslint` clean on all four touched files.
- `AccountingSyncCard.test.tsx` (16 tests) unchanged and still green — confirms no UI changes were needed.

## Files

- `apps/api/src/services/accounting/accountingInvoicePush.ts`
- `apps/api/src/services/accounting/accountingInvoicePush.test.ts`
- `apps/api/src/services/accounting/accountingCurrency.ts` (contract comment)
- `apps/api/src/__tests__/integration/accountingInvoicePushCurrency.integration.test.ts`

Closes #4498

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBxF7C8E5GxFnNcGf6kBVP