### PR TITLE
fix(api/tenancy): tombstone action_intents.scope_ticket_id on device org-move (#4792)

### DIFF
--- a/apps/api/migrations/2026-10-08-100900-cascade-device-org-move-ticket-scope.sql
+++ b/apps/api/migrations/2026-10-08-100900-cascade-device-org-move-ticket-scope.sql
@@ -1,0 +1,141 @@
+-- #4792 — mirror moveOrg's action_intents.scope_ticket_id tombstone into
+-- breeze_cascade_device_org_id().
+--
+-- Found while fixing #4454/#4790, which mirrored the scope_device_id
+-- tombstone into this same function. The TICKET axis of the same typed
+-- target scope has a worse version of the same gap, and it was missing from
+-- BOTH sites (the route and this trigger) until now — not just the trigger.
+--
+-- `tickets` IS returned by breeze_device_child_orgid_tables(), so a device
+-- org-move re-stamps tickets.org_id for every ticket bound to the moved
+-- device via the generic loop below. `action_intents.org_id` is immutable
+-- (action_intents_block_content_update() raises on any change to it).
+-- `action_intents_scope_ticket_org_fk`
+-- (migrations/2026-09-25-ai-agents-ticket-triage.sql:216-219) is:
+--
+--   FOREIGN KEY (scope_ticket_id, org_id) REFERENCES tickets (id, org_id)
+--     ON DELETE SET NULL DEFERRABLE INITIALLY IMMEDIATE
+--
+-- No ON UPDATE clause, so it defaults to NO ACTION and is checked at the end
+-- of the statement that fires it (the generic loop's tickets UPDATE — the
+-- FK is not named in this transaction's SET CONSTRAINTS, and this function
+-- runs under whatever constraint mode the calling statement's transaction
+-- is in). Re-stamping tickets.org_id therefore leaves any intent scoped to
+-- that ticket holding a pair (scope_ticket_id, OLD org_id) that no longer
+-- exists in `tickets` — a 23503 that aborts the whole device move.
+--
+-- Unlike the scope_device_id tombstone (#4454) this reaches intents of
+-- EVERY status, not just live ones: the FK does not care about `status`, and
+-- a terminal-status intent still carries the same composite pair and would
+-- still 23503 the moment the ticket's org_id changes. Same reasoning
+-- ticketService.ts's moveTicketOrg already documents for the ticket-level
+-- move (its own identical detach, all statuses, run before the ticket
+-- UPDATE that would otherwise trip this same constraint).
+--
+-- The immutability trigger (action_intents_block_content_update(), see
+-- 2026-09-25-ai-agents-ticket-triage.sql) permits exactly this non-null ->
+-- NULL transition for scope_ticket_id (mirroring the scope_device_id
+-- carve-out it already had), so this UPDATE is the tombstone path, not a
+-- bypass.
+--
+-- Placement: immediately after the scope_device_id tombstone and the
+-- tickets requester-contact detach, and BEFORE the generic
+-- breeze_device_child_orgid_tables() re-stamp loop — same "before the
+-- statement that trips the constraint" ordering the requester-contact
+-- detach already requires, matching moveOrg.ts's own statement order.
+--
+-- No historical backfill: same reasoning as the scope_device_id tombstone's
+-- migration header (2026-10-06-124500) — action_intents is FORCE ROW LEVEL
+-- SECURITY, so a contextless migration-time cleanup would match zero rows on
+-- a managed Postgres and report a silent "0 cleaned". Unlike scope_device_id
+-- this gap is a hard abort (23503), not a silently-stale pointer, so there is
+-- nothing pre-existing to clean up: a device org-move carrying a
+-- ticket-scoped intent could not have succeeded before this fix, on either
+-- the route (which never had this statement either) or this trigger.
+--
+-- Full function body copied verbatim from
+-- 2026-10-08-100500-detach-ticket-comment-runs-on-device-org-move.sql (the
+-- newest definition; no later migration replaces this function) with only
+-- the action_intents.scope_ticket_id statement added. CREATE OR REPLACE is
+-- idempotent by construction — re-applying this file re-installs the same
+-- body. The trigger itself (breeze_cascade_device_org_id ON devices, AFTER
+-- UPDATE OF org_id ... WHEN NEW.org_id IS DISTINCT FROM OLD.org_id) is
+-- unchanged and is NOT redeclared here.
+CREATE OR REPLACE FUNCTION public.breeze_cascade_device_org_id()
+  RETURNS trigger
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = public, pg_catalog
+  AS $$
+DECLARE
+  child_table text;
+BEGIN
+  -- Agent-run history stays with the SOURCE org (owner decision 2026-08-23):
+  -- sever the moved device's lineage links instead of re-stamping org_id.
+  UPDATE public.ai_agent_runs
+    SET device_id = NULL, alert_id = NULL, session_id = NULL, anomaly_incident_id = NULL
+    WHERE device_id = NEW.id;
+  -- ticket_id is device-lineage too, but unreachable from `WHERE device_id`:
+  -- ticket-triggered runs carry a ticket_id with a NULL device_id. Key off the
+  -- ticket's device_id instead (#4215).
+  UPDATE public.ai_agent_runs
+    SET ticket_id = NULL
+    WHERE ticket_id IN (SELECT id FROM public.tickets WHERE device_id = NEW.id);
+  -- Reverse pointer: the incident's back-link to the (now-detached) run must
+  -- not keep naming a source-org run once the incident itself is re-stamped
+  -- to the destination org by the generic loop below.
+  UPDATE public.metric_anomaly_incidents
+    SET agent_run_id = NULL
+    WHERE device_id = NEW.id;
+  -- Reverse pointer: ticket_comments.agent_run_id (#4644). ticket_comments has
+  -- no org_id of its own (child-via-parent tenancy through tickets), so a
+  -- comment on a ticket bound to this device travels to the target org via the
+  -- generic loop below while the run it names stays with the SOURCE org —
+  -- same class as the metric_anomaly_incidents reverse pointer above, and the
+  -- device-axis mirror of moveTicketOrg's ticket_comments detach
+  -- (ticketService.ts, #4642) on the ticket axis.
+  UPDATE public.ticket_comments
+    SET agent_run_id = NULL
+    WHERE agent_run_id IS NOT NULL
+      AND ticket_id IN (SELECT id FROM public.tickets WHERE device_id = NEW.id);
+  -- Typed target scope of a LIVE intent must not keep naming a device that has
+  -- just left the intent's org (#4454). Mirrors moveOrg.ts; see the header for
+  -- the live-status gate, the immutability-trigger transition, and why this one
+  -- takes no merge fence.
+  UPDATE public.action_intents
+    SET scope_device_id = NULL
+    WHERE scope_device_id = NEW.id
+      AND status IN ('pending_approval', 'approved', 'executing');
+  -- Typed target scope of an intent scoped to a TICKET bound to this device
+  -- (#4792) must not keep naming a (ticket, OLD org_id) pair once the ticket
+  -- is re-stamped to the destination org by the generic loop below — every
+  -- status, not just live ones, since action_intents_scope_ticket_org_fk does
+  -- not gate on status and would 23503 the loop's own tickets UPDATE
+  -- otherwise. See this migration's header for the full mechanism; mirrors
+  -- moveOrg.ts and moveTicketOrg (ticketService.ts).
+  UPDATE public.action_intents
+    SET scope_ticket_id = NULL
+    WHERE scope_ticket_id IN (SELECT id FROM public.tickets WHERE device_id = NEW.id);
+  -- The requester CONTACT is org-pinned and does not travel with the device
+  -- (#3258 W03). Skipped while the source org is fenced for a merge, where the
+  -- contact moves to the survivor alongside the ticket — see the header of
+  -- 2026-10-04-100000-ticket-requester-contact.sql.
+  IF NOT EXISTS (
+    SELECT 1 FROM public.organizations o
+     WHERE o.id = OLD.org_id AND o.status::text = 'merging'
+  ) THEN
+    UPDATE public.tickets
+      SET requester_contact_id = NULL
+      WHERE device_id = NEW.id
+        AND requester_contact_id IS NOT NULL
+        AND org_id IS DISTINCT FROM NEW.org_id;
+  END IF;
+  FOR child_table IN SELECT public.breeze_device_child_orgid_tables() LOOP
+    EXECUTE format(
+      'UPDATE public.%I SET org_id = $1 WHERE device_id = $2 AND org_id IS DISTINCT FROM $1',
+      child_table
+    ) USING NEW.org_id, NEW.id;
+  END LOOP;
+  RETURN NULL; -- AFTER trigger; return value ignored
+END;
+$$;

--- a/apps/api/migrations/2026-10-08-100900-cascade-device-org-move-ticket-scope.sql
+++ b/apps/api/migrations/2026-10-08-100900-cascade-device-org-move-ticket-scope.sql
@@ -106,16 +106,6 @@ BEGIN
     SET scope_device_id = NULL
     WHERE scope_device_id = NEW.id
       AND status IN ('pending_approval', 'approved', 'executing');
-  -- Typed target scope of an intent scoped to a TICKET bound to this device
-  -- (#4792) must not keep naming a (ticket, OLD org_id) pair once the ticket
-  -- is re-stamped to the destination org by the generic loop below — every
-  -- status, not just live ones, since action_intents_scope_ticket_org_fk does
-  -- not gate on status and would 23503 the loop's own tickets UPDATE
-  -- otherwise. See this migration's header for the full mechanism; mirrors
-  -- moveOrg.ts and moveTicketOrg (ticketService.ts).
-  UPDATE public.action_intents
-    SET scope_ticket_id = NULL
-    WHERE scope_ticket_id IN (SELECT id FROM public.tickets WHERE device_id = NEW.id);
   -- The requester CONTACT is org-pinned and does not travel with the device
   -- (#3258 W03). Skipped while the source org is fenced for a merge, where the
   -- contact moves to the survivor alongside the ticket — see the header of
@@ -130,6 +120,20 @@ BEGIN
         AND requester_contact_id IS NOT NULL
         AND org_id IS DISTINCT FROM NEW.org_id;
   END IF;
+  -- Typed target scope of an intent scoped to a TICKET bound to this device
+  -- (#4792) must not keep naming a (ticket, OLD org_id) pair once the ticket
+  -- is re-stamped to the destination org by the generic loop below — every
+  -- status, not just live ones, since action_intents_scope_ticket_org_fk does
+  -- not gate on status and would 23503 the loop's own tickets UPDATE
+  -- otherwise. See this migration's header for the full mechanism; mirrors
+  -- moveOrg.ts and moveTicketOrg (ticketService.ts). Placed after the
+  -- requester-contact detach immediately above (order between the two is not
+  -- itself load-bearing — they touch disjoint tables — but this makes the
+  -- trigger's statement order match moveOrg.ts's exactly, not just
+  -- "before the loop").
+  UPDATE public.action_intents
+    SET scope_ticket_id = NULL
+    WHERE scope_ticket_id IN (SELECT id FROM public.tickets WHERE device_id = NEW.id);
   FOR child_table IN SELECT public.breeze_device_child_orgid_tables() LOOP
     EXECUTE format(
       'UPDATE public.%I SET org_id = $1 WHERE device_id = $2 AND org_id IS DISTINCT FROM $1',

--- a/apps/api/src/__tests__/integration/deviceMoveOrgTicketScopeTombstone.integration.test.ts
+++ b/apps/api/src/__tests__/integration/deviceMoveOrgTicketScopeTombstone.integration.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Live-Postgres coverage for #4792: a device org-move must not 23503 on
+ * `action_intents_scope_ticket_org_fk` and abort, when the moving device has
+ * a bound ticket that some intent is scoped to.
+ *
+ * WHY THIS NEEDS A REAL DATABASE
+ * ------------------------------
+ * `tickets` IS returned by `breeze_device_child_orgid_tables()`, so a device
+ * org-move re-stamps `tickets.org_id` for every ticket bound to the moved
+ * device. `action_intents_scope_ticket_org_fk` is a composite FK
+ * `(scope_ticket_id, org_id) -> tickets(id, org_id)`, `DEFERRABLE INITIALLY
+ * IMMEDIATE`, with no `ON UPDATE` clause (defaults to `NO ACTION`) — so
+ * without the tombstone this file exercises, the tickets re-stamp itself
+ * raises `23503` and the WHOLE move transaction rolls back. A mocked suite
+ * can only assert the shape of the SQL text (`moveOrg.coverage.test.ts` does
+ * that, statically, in the unit job); it cannot prove the move actually
+ * *succeeds* against a real FK, and it cannot catch any of:
+ *
+ *   1. FORCE ROW LEVEL SECURITY on `action_intents` silently matching zero
+ *      rows for the tombstone UPDATE.
+ *   2. `action_intents_block_content_update()` rejecting the non-null ->
+ *      NULL transition on `scope_ticket_id`.
+ *   3. `action_intents_scope_ticket_chk` (`scope_ticket_id IS NULL OR
+ *      scope_kind = 'ticket'`) — satisfied trivially once nulled, but worth
+ *      a real-server pass since a bad statement could violate it instead.
+ *
+ * UNLIKE #4454's scope_device_id gap (silently stale, not fatal), this gap is
+ * a hard abort: before the fix, a device org-move carrying a ticket-scoped
+ * intent could not succeed at all, on either the route or a direct-SQL
+ * caller. So every case below asserts the move SUCCEEDS, not just that the
+ * pointer ends up null.
+ *
+ * TWO CALLERS, both asserted, mirroring the #4454 sibling
+ * (deviceMoveOrgIntentScopeTombstone.integration.test.ts):
+ *
+ *   - `POST /devices/:id/move-org` (the route's own tombstone statement) —
+ *     the primary bug report's exact path.
+ *   - a raw `UPDATE devices SET org_id` under `withSystemDbAccessContext` as
+ *     the unprivileged `breeze_app` role (the shape orgMerge's `devices`
+ *     repoint has) — proves `breeze_cascade_device_org_id()`'s mirrored
+ *     tombstone, not just the route's.
+ *
+ * TERMINAL STATUS IS NOT A CONTROL HERE, unlike #4454: this FK does not gate
+ * on `status`, so a terminal-status intent is not a "must survive" case — it
+ * is a "must ALSO be tombstoned, or it still 23503s the very next unrelated
+ * write to that row" case. Both a live and a completed intent are seeded and
+ * both must end up nulled.
+ */
+import './setup';
+
+import { randomUUID } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
+import { eq, sql } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import { actionIntents, devices, tickets } from '../../db/schema';
+import { createOrganization, createSite, setupTestEnvironment } from './db-utils';
+import { getTestDb } from './setup';
+import { createAccessToken } from '../../services/jwt';
+import { moveOrgRoutes } from '../../routes/devices/moveOrg';
+
+function uid(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function seed() {
+  const adminDb = getTestDb() as never as {
+    insert: (typeof db)['insert'];
+    select: (typeof db)['select'];
+  };
+  const sfx = uid();
+
+  const { partner, organization: sourceOrg, site: sourceSite, user, role } = await setupTestEnvironment({
+    scope: 'partner',
+  });
+  const targetOrg = await createOrganization({ partnerId: partner.id });
+  const targetSite = await createSite({ orgId: targetOrg.id });
+
+  const [device] = await adminDb
+    .insert(devices)
+    .values({
+      orgId: sourceOrg.id,
+      siteId: sourceSite.id,
+      agentId: `ticket-scope-agent-${sfx}`,
+      hostname: `ticket-scope-host-${sfx}`,
+      osType: 'linux',
+      osVersion: '22.04',
+      architecture: 'x86_64',
+      agentVersion: '0.0.0-test',
+      status: 'offline',
+    })
+    .returning({ id: devices.id });
+
+  const [ticket] = await adminDb
+    .insert(tickets)
+    .values({
+      orgId: sourceOrg.id,
+      partnerId: partner.id,
+      deviceId: device!.id,
+      ticketNumber: `TS-${sfx}`,
+      subject: `ticket-scope intent coverage ${sfx}`,
+      source: 'manual',
+    } as never)
+    .returning({ id: tickets.id });
+
+  // A human-originated intent satisfies action_intents_one_actor_chk (exactly
+  // one of the three actor columns), action_intents_agent_origin_chk and
+  // action_intents_agent_source_chk (source and origin_principal_kind move
+  // together, neither is the agent value).
+  const intentValues = (status: string, index: number) => ({
+    orgId: sourceOrg.id,
+    partnerId: partner.id,
+    requestedByUserId: user.id,
+    requestingApiKeyId: null,
+    requestingAgentRunId: null,
+    source: 'chat' as const,
+    originPrincipalKind: 'user_session' as const,
+    originPrincipalId: user.id,
+    actionName: 'ticket.comment.add',
+    actionVersion: 1,
+    arguments: { ticketId: ticket!.id } as never,
+    argumentDigest: 'c'.repeat(64),
+    targetSummary: `Comment on ticket ${ticket!.id}`,
+    impactSummary: 'Adds a comment to the target ticket',
+    reason: 'Integration coverage for #4792',
+    riskTier: 1,
+    connectionId: null,
+    tenantId: null,
+    // The live-status partial unique index is (org_id, idempotency_key), so
+    // every LIVE row in this org needs a distinct key.
+    idempotencyKey: `idem-ts-${sfx}-${index}`,
+    correlationId: randomUUID(),
+    expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    status,
+    scopeKind: 'ticket' as const,
+    scopeTicketId: ticket!.id,
+  });
+
+  const [live] = await adminDb
+    .insert(actionIntents)
+    .values(intentValues('pending_approval', 0) as never)
+    .returning({ id: actionIntents.id });
+
+  const [terminal] = await adminDb
+    .insert(actionIntents)
+    .values({
+      ...intentValues('completed', 1),
+      decidedAt: new Date(),
+      decidedByUserId: user.id,
+      executedAt: new Date(),
+    } as never)
+    .returning({ id: actionIntents.id });
+
+  const token = await createAccessToken({
+    sub: user.id,
+    email: user.email,
+    roleId: role.id,
+    orgId: null,
+    partnerId: partner.id,
+    scope: 'partner',
+    mfa: true,
+    aep: 1,
+    mep: 1,
+    sid: 'it-session',
+  });
+
+  const app = new Hono();
+  app.route('/devices', moveOrgRoutes);
+
+  const post = () =>
+    app.request(`/devices/${device!.id}/move-org`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ orgId: targetOrg.id, siteId: targetSite.id }),
+    });
+
+  return {
+    deviceId: device!.id,
+    ticketId: ticket!.id,
+    sourceOrgId: sourceOrg.id,
+    targetOrgId: targetOrg.id,
+    targetSiteId: targetSite.id,
+    liveIntentId: live!.id,
+    terminalIntentId: terminal!.id,
+    post,
+  };
+}
+
+type Fixture = Awaited<ReturnType<typeof seed>>;
+
+async function readScopeTicketIds(ids: string[]): Promise<Array<string | null>> {
+  const adminDb = getTestDb();
+  const out: Array<string | null> = [];
+  for (const id of ids) {
+    const [row] = await adminDb
+      .select({ scopeTicketId: actionIntents.scopeTicketId })
+      .from(actionIntents)
+      .where(eq(actionIntents.id, id));
+    out.push(row!.scopeTicketId);
+  }
+  return out;
+}
+
+async function readOrgs(f: Pick<Fixture, 'deviceId' | 'ticketId'>) {
+  const [d] = await getTestDb().select({ orgId: devices.orgId }).from(devices).where(eq(devices.id, f.deviceId));
+  const [t] = await getTestDb().select({ orgId: tickets.orgId }).from(tickets).where(eq(tickets.id, f.ticketId));
+  return { deviceOrgId: d?.orgId, ticketOrgId: t?.orgId };
+}
+
+describe('POST /devices/:id/move-org — action_intents.scope_ticket_id tombstone (#4792)', () => {
+  it('moves a device with a ticket-scoped intent (any status) without 23503, and tombstones scope_ticket_id', async () => {
+    const f: Fixture = await seed();
+
+    // Control: the pointers are live BEFORE the move, so a green assertion
+    // below cannot be an artifact of a seed that never set them.
+    expect(await readScopeTicketIds([f.liveIntentId, f.terminalIntentId])).toEqual([f.ticketId, f.ticketId]);
+
+    const res = await f.post();
+    const body = (await res.json()) as { success?: boolean; error?: string };
+
+    // The bug report's exact symptom: without the fix this is a 500 with a
+    // pg 23503 error, not a graceful 4xx — the move must succeed outright.
+    expect(res.status, JSON.stringify(body)).toBe(200);
+    expect(body.success).toBe(true);
+
+    const afterOrgs = await readOrgs(f);
+    expect(afterOrgs.deviceOrgId).toBe(f.targetOrgId);
+    expect(afterOrgs.ticketOrgId, 'the bound ticket must have moved with the device').toBe(f.targetOrgId);
+
+    expect(
+      await readScopeTicketIds([f.liveIntentId, f.terminalIntentId]),
+      'BOTH a live and a terminal-status intent must be tombstoned — this FK does not gate on status',
+    ).toEqual([null, null]);
+  });
+});
+
+describe('breeze_cascade_device_org_id(): action_intents.scope_ticket_id tombstone (#4792)', () => {
+  it('a raw UPDATE devices under the unprivileged breeze_app role (system context) does not 23503 and tombstones both statuses', async () => {
+    const f: Fixture = await seed();
+
+    expect(await readScopeTicketIds([f.liveIntentId, f.terminalIntentId])).toEqual([f.ticketId, f.ticketId]);
+
+    // The shape every real non-route, direct-SQL caller has — orgMerge's
+    // `devices` repoint included. If FORCE RLS on action_intents made the
+    // trigger's tombstone UPDATE match zero rows, this is the case that would
+    // surface it as a 23503 thrown out of this very statement.
+    await withSystemDbAccessContext(async () => {
+      await db.execute(sql`
+        UPDATE devices SET org_id = ${f.targetOrgId}::uuid, site_id = ${f.targetSiteId}::uuid
+         WHERE id = ${f.deviceId}::uuid
+      `);
+    });
+
+    const afterOrgs = await readOrgs(f);
+    expect(afterOrgs.deviceOrgId).toBe(f.targetOrgId);
+    expect(afterOrgs.ticketOrgId).toBe(f.targetOrgId);
+    expect(await readScopeTicketIds([f.liveIntentId, f.terminalIntentId])).toEqual([null, null]);
+  });
+
+  it('a raw superuser UPDATE devices SET org_id also tombstones the ticket-scoped intents', async () => {
+    const f: Fixture = await seed();
+
+    await getTestDb().execute(sql`
+      UPDATE devices SET org_id = ${f.targetOrgId}::uuid, site_id = ${f.targetSiteId}::uuid
+       WHERE id = ${f.deviceId}::uuid
+    `);
+
+    const afterOrgs = await readOrgs(f);
+    expect(afterOrgs.deviceOrgId).toBe(f.targetOrgId);
+    expect(afterOrgs.ticketOrgId).toBe(f.targetOrgId);
+    expect(await readScopeTicketIds([f.liveIntentId, f.terminalIntentId])).toEqual([null, null]);
+  });
+});

--- a/apps/api/src/__tests__/integration/deviceMoveOrgTicketScopeTombstone.integration.test.ts
+++ b/apps/api/src/__tests__/integration/deviceMoveOrgTicketScopeTombstone.integration.test.ts
@@ -103,6 +103,40 @@ async function seed() {
     } as never)
     .returning({ id: tickets.id });
 
+  // Negative control (#4792 review): a SECOND device, staying in the source
+  // org, with its OWN ticket and its OWN ticket-scoped intent. The fix's
+  // precision comes entirely from the subselect
+  // `WHERE scope_ticket_id IN (SELECT id FROM tickets WHERE device_id = ...)`
+  // — this proves that scoping is exact (keyed off the MOVING device) rather
+  // than accidentally broad (e.g. a future edit that widens or drops the
+  // device_id filter). This intent must survive every case below untouched.
+  const [otherDevice] = await adminDb
+    .insert(devices)
+    .values({
+      orgId: sourceOrg.id,
+      siteId: sourceSite.id,
+      agentId: `ticket-scope-other-agent-${sfx}`,
+      hostname: `ticket-scope-other-host-${sfx}`,
+      osType: 'linux',
+      osVersion: '22.04',
+      architecture: 'x86_64',
+      agentVersion: '0.0.0-test',
+      status: 'offline',
+    })
+    .returning({ id: devices.id });
+
+  const [otherTicket] = await adminDb
+    .insert(tickets)
+    .values({
+      orgId: sourceOrg.id,
+      partnerId: partner.id,
+      deviceId: otherDevice!.id,
+      ticketNumber: `TS-OTHER-${sfx}`,
+      subject: `unrelated device's ticket — must not be touched ${sfx}`,
+      source: 'manual',
+    } as never)
+    .returning({ id: tickets.id });
+
   // A human-originated intent satisfies action_intents_one_actor_chk (exactly
   // one of the three actor columns), action_intents_agent_origin_chk and
   // action_intents_agent_source_chk (source and origin_principal_kind move
@@ -151,6 +185,16 @@ async function seed() {
     } as never)
     .returning({ id: actionIntents.id });
 
+  // The negative-control intent, scoped to otherTicket (bound to otherDevice,
+  // which never moves in any test below).
+  const [unrelated] = await adminDb
+    .insert(actionIntents)
+    .values({
+      ...intentValues('pending_approval', 2),
+      scopeTicketId: otherTicket!.id,
+    } as never)
+    .returning({ id: actionIntents.id });
+
   const token = await createAccessToken({
     sub: user.id,
     email: user.email,
@@ -182,6 +226,9 @@ async function seed() {
     targetSiteId: targetSite.id,
     liveIntentId: live!.id,
     terminalIntentId: terminal!.id,
+    otherDeviceId: otherDevice!.id,
+    otherTicketId: otherTicket!.id,
+    unrelatedIntentId: unrelated!.id,
     post,
   };
 }
@@ -231,6 +278,19 @@ describe('POST /devices/:id/move-org — action_intents.scope_ticket_id tombston
       await readScopeTicketIds([f.liveIntentId, f.terminalIntentId]),
       'BOTH a live and a terminal-status intent must be tombstoned — this FK does not gate on status',
     ).toEqual([null, null]);
+
+    // Negative control: an intent scoped to an UNRELATED device's ticket must
+    // survive untouched — proves the fix's subselect is keyed off the moving
+    // device, not accidentally broad.
+    expect(
+      await readScopeTicketIds([f.unrelatedIntentId]),
+      'an intent scoped to a ticket on a DIFFERENT device must not be touched by this move',
+    ).toEqual([f.otherTicketId]);
+    const [otherDeviceAfter] = await getTestDb()
+      .select({ orgId: devices.orgId })
+      .from(devices)
+      .where(eq(devices.id, f.otherDeviceId));
+    expect(otherDeviceAfter?.orgId, 'the unrelated device must not have moved').toBe(f.sourceOrgId);
   });
 });
 
@@ -255,6 +315,10 @@ describe('breeze_cascade_device_org_id(): action_intents.scope_ticket_id tombsto
     expect(afterOrgs.deviceOrgId).toBe(f.targetOrgId);
     expect(afterOrgs.ticketOrgId).toBe(f.targetOrgId);
     expect(await readScopeTicketIds([f.liveIntentId, f.terminalIntentId])).toEqual([null, null]);
+    expect(
+      await readScopeTicketIds([f.unrelatedIntentId]),
+      'an intent scoped to a ticket on a DIFFERENT device must not be touched by this move',
+    ).toEqual([f.otherTicketId]);
   });
 
   it('a raw superuser UPDATE devices SET org_id also tombstones the ticket-scoped intents', async () => {
@@ -269,5 +333,9 @@ describe('breeze_cascade_device_org_id(): action_intents.scope_ticket_id tombsto
     expect(afterOrgs.deviceOrgId).toBe(f.targetOrgId);
     expect(afterOrgs.ticketOrgId).toBe(f.targetOrgId);
     expect(await readScopeTicketIds([f.liveIntentId, f.terminalIntentId])).toEqual([null, null]);
+    expect(
+      await readScopeTicketIds([f.unrelatedIntentId]),
+      'an intent scoped to a ticket on a DIFFERENT device must not be touched by this move',
+    ).toEqual([f.otherTicketId]);
   });
 });

--- a/apps/api/src/routes/devices/moveOrg.coverage.test.ts
+++ b/apps/api/src/routes/devices/moveOrg.coverage.test.ts
@@ -747,4 +747,27 @@ describe('action_intents.scope_ticket_id detach coverage (#4792)', () => {
       `${name}: the scope_ticket_id tombstone must run before the generic re-stamp loop — unlike scope_device_id's placement (a convention guard only), THIS ordering is load-bearing: tickets IS in breeze_device_child_orgid_tables(), so the loop's own tickets UPDATE is the statement that trips action_intents_scope_ticket_org_fk if the tombstone hasn't run first`,
     ).toBeLessThan(loop);
   });
+
+  // moveOrg.ts's OWN copy of this statement is just as load-bearing as the
+  // trigger's: `tickets` is in getDeviceOrgDenormalizedTables(), which the
+  // route's "Rewrite the denormalized org_id" loop below iterates too. A
+  // reorder that moved the route's UPDATE below that loop would 23503 in
+  // exactly the same way the trigger would, but nothing short of the (slower,
+  // integration-job-only) real-Postgres test would have caught it without
+  // this check.
+  it('moveOrg.ts places its own tombstone BEFORE the denormalized-table re-stamp loop', () => {
+    const moveOrgPath = fileURLToPath(new URL('./moveOrg.ts', import.meta.url));
+    const src = readFileSync(moveOrgPath, 'utf8');
+    const tombstone = src.indexOf('UPDATE action_intents SET scope_ticket_id = NULL');
+    // NOT a bare `indexOf('getDeviceOrgDenormalizedTables()')` — that also
+    // matches the top-of-file `import { getDeviceOrgDenormalizedTables, ... }`
+    // statement, which always precedes everything. Anchor on the actual loop.
+    const loop = src.indexOf('for (const table of getDeviceOrgDenormalizedTables())');
+    expect(tombstone, 'moveOrg.ts: no scope_ticket_id tombstone found').toBeGreaterThan(-1);
+    expect(loop, 'moveOrg.ts: no getDeviceOrgDenormalizedTables() loop found').toBeGreaterThan(-1);
+    expect(
+      tombstone,
+      'moveOrg.ts: the scope_ticket_id tombstone must run before the getDeviceOrgDenormalizedTables() loop — that loop is what re-stamps tickets.org_id and trips action_intents_scope_ticket_org_fk if the tombstone has not run first',
+    ).toBeLessThan(loop);
+  });
 });

--- a/apps/api/src/routes/devices/moveOrg.coverage.test.ts
+++ b/apps/api/src/routes/devices/moveOrg.coverage.test.ts
@@ -673,3 +673,78 @@ describe('action_intents.scope_device_id detach coverage', () => {
     ).toBeLessThan(loop);
   });
 });
+
+/**
+ * action_intents.scope_ticket_id detach coverage (#4792).
+ *
+ * Worse version of the scope_device_id gap above: `tickets` IS returned by
+ * breeze_device_child_orgid_tables(), so the generic re-stamp loop rewrites
+ * tickets.org_id for every ticket bound to the moved device.
+ * `action_intents_scope_ticket_org_fk` (composite FK (scope_ticket_id, org_id)
+ * -> tickets(id, org_id), DEFERRABLE INITIALLY IMMEDIATE, no ON UPDATE clause)
+ * does not gate on status, so ANY remaining scope_ticket_id pointer — live or
+ * terminal — 23503s the instant the loop's own tickets UPDATE runs, aborting
+ * the whole move. Unlike scope_device_id this is unconditional: no status
+ * filter, matching moveTicketOrg's identical ticket-axis detach
+ * (services/ticketService.ts).
+ *
+ * Both sites are asserted below, same "a future edit that fixes one and
+ * forgets the other goes red" contract as the scope_device_id block above.
+ *
+ * These are STATIC source assertions only. That the statement actually
+ * matches rows and the move no longer 23503s needs a real server and lives in
+ * `src/__tests__/integration/deviceMoveOrgTicketScopeTombstone.integration.test.ts`.
+ */
+describe('action_intents.scope_ticket_id detach coverage (#4792)', () => {
+  it('moveOrg.ts tombstones scope_ticket_id for tickets bound to the moved device, all statuses', () => {
+    const moveOrgPath = fileURLToPath(new URL('./moveOrg.ts', import.meta.url));
+    const src = readFileSync(moveOrgPath, 'utf8');
+
+    const match = src.match(
+      /UPDATE action_intents SET scope_ticket_id = NULL\s+WHERE scope_ticket_id IN \(SELECT id FROM tickets WHERE device_id = \$\{deviceId\}::uuid\)/,
+    );
+    expect(
+      match,
+      'moveOrg.ts no longer has the expected "UPDATE action_intents SET scope_ticket_id = NULL ... WHERE scope_ticket_id IN (SELECT id FROM tickets WHERE device_id = ...)" statement — update this test if the statement shape changed intentionally',
+    ).toBeTruthy();
+
+    // Unlike scope_device_id, this FK does not gate on status — a status
+    // filter here would leave a terminal-status intent's pointer in place to
+    // 23503 on the very next unrelated UPDATE. Assert the absence explicitly
+    // so a copy-paste of the scope_device_id statement (which DOES filter by
+    // status) is caught.
+    expect(
+      match![0],
+      'the scope_ticket_id tombstone must be unconditional (no status filter) — action_intents_scope_ticket_org_fk does not gate on status',
+    ).not.toMatch(/status/i);
+  });
+
+  it('breeze_cascade_device_org_id() mirrors the tombstone, unconditionally (#4792)', () => {
+    const { name, body } = newestCascadeFunctionBody();
+
+    const match = body.match(
+      /UPDATE public\.action_intents\s+SET scope_ticket_id = NULL\s+WHERE scope_ticket_id IN \(SELECT id FROM public\.tickets WHERE device_id = NEW\.id\)/,
+    );
+    expect(
+      match,
+      `${name} is the newest definition of breeze_cascade_device_org_id() and its body has no "UPDATE public.action_intents SET scope_ticket_id = NULL WHERE scope_ticket_id IN (SELECT id FROM public.tickets WHERE device_id = NEW.id)" statement — a device org-move that bypasses the moveOrg route (e.g. orgMerge's raw UPDATE devices) would 23503 on action_intents_scope_ticket_org_fk and abort the move whenever the device has a ticket-scoped intent (#4792)`,
+    ).toBeTruthy();
+
+    expect(
+      match![0],
+      `${name}'s action_intents scope_ticket_id tombstone must be unconditional (no status filter), matching moveOrg.ts`,
+    ).not.toMatch(/status/i);
+  });
+
+  it('places the tombstone BEFORE the generic device-child org re-stamp loop (load-bearing: tickets IS in that loop)', () => {
+    const { name, body } = newestCascadeFunctionBody();
+    const tombstone = body.indexOf('SET scope_ticket_id = NULL');
+    const loop = body.indexOf('breeze_device_child_orgid_tables()');
+    expect(tombstone, `${name}: no scope_ticket_id tombstone found`).toBeGreaterThan(-1);
+    expect(loop, `${name}: no device-child re-stamp loop found`).toBeGreaterThan(-1);
+    expect(
+      tombstone,
+      `${name}: the scope_ticket_id tombstone must run before the generic re-stamp loop — unlike scope_device_id's placement (a convention guard only), THIS ordering is load-bearing: tickets IS in breeze_device_child_orgid_tables(), so the loop's own tickets UPDATE is the statement that trips action_intents_scope_ticket_org_fk if the tombstone hasn't run first`,
+    ).toBeLessThan(loop);
+  });
+});

--- a/apps/api/src/routes/devices/moveOrg.ts
+++ b/apps/api/src/routes/devices/moveOrg.ts
@@ -379,6 +379,30 @@ moveOrgRoutes.post(
                 AND org_id IS DISTINCT FROM ${targetOrgId}::uuid`,
         );
 
+        // action_intents.scope_ticket_id (#4792): composite FK (scope_ticket_id,
+        // org_id) -> tickets(id, org_id) (action_intents_scope_ticket_org_fk,
+        // migrations/2026-09-25-ai-agents-ticket-triage.sql), DEFERRABLE
+        // INITIALLY IMMEDIATE and deliberately NOT named in the SET CONSTRAINTS
+        // above (by-name, never ALL — see that comment): a newly added
+        // referencing row type must still fail fast, not silently at COMMIT.
+        // `tickets` IS in getDeviceOrgDenormalizedTables(), so the loop below
+        // re-stamps tickets.org_id for every ticket bound to this device — the
+        // instant that statement completes, ANY remaining scope_ticket_id
+        // pointer (regardless of status; unlike scope_device_id above, this FK
+        // does not care about status) names a (ticketId, OLD org_id) pair that
+        // no longer exists in `tickets`, and the tickets UPDATE itself 23503s
+        // and aborts the whole move. Same invariant, same fix, as
+        // moveTicketOrg's identical detach for the ticket-level move
+        // (services/ticketService.ts) — ALL statuses, unconditionally, and run
+        // BEFORE the re-stamp that would otherwise trip the constraint. The
+        // immutability trigger (action_intents_block_content_update()) permits
+        // exactly this non-null -> NULL transition regardless of scope_ticket_id
+        // vs scope_device_id, so this is the tombstone path, not a bypass.
+        await tx.execute(
+          sql`UPDATE action_intents SET scope_ticket_id = NULL
+              WHERE scope_ticket_id IN (SELECT id FROM tickets WHERE device_id = ${deviceId}::uuid)`,
+        );
+
         // Rewrite the denormalized org_id on every device-scoped table.
         // Skipping any of these strands pre-existing rows under RLS.
         for (const table of getDeviceOrgDenormalizedTables()) {


### PR DESCRIPTION
## What

A device org-move can `23503` on `action_intents_scope_ticket_org_fk` and abort the whole move when the moving device has a ticket that some intent is scoped to.

`tickets` IS returned by `breeze_device_child_orgid_tables()`, so a device org-move re-stamps `tickets.org_id` for every ticket bound to the moved device — both via `apps/api/src/routes/devices/moveOrg.ts`'s generic denormalized-table loop and via the equivalent loop in `breeze_cascade_device_org_id()`. `action_intents_scope_ticket_org_fk` (`apps/api/migrations/2026-09-25-ai-agents-ticket-triage.sql:216-219`) is:

```sql
FOREIGN KEY (scope_ticket_id, org_id) REFERENCES tickets (id, org_id) ON DELETE SET NULL
  DEFERRABLE INITIALLY IMMEDIATE
```

No `ON UPDATE` clause, so it defaults to `NO ACTION` and is checked at the end of the tickets re-stamp statement (this FK is deliberately NOT named in the transaction's `SET CONSTRAINTS ... DEFERRED` — see the "BY NAME, never ALL" comment in `moveOrg.ts`). Any remaining `scope_ticket_id` pointer at that instant names a `(ticketId, OLD org_id)` pair that no longer exists in `tickets`, and the whole move transaction rolls back with a `23503`.

Unlike the sibling `scope_device_id` gap (#4454, fixed in #4790), this FK does not gate on `status` — every intent status, not just live ones, must be tombstoned, or a terminal-status intent still 23503s the very next org-move that touches its ticket.

## How

Mirrors `ticketService.ts`'s `moveTicketOrg` — which already handles exactly this for the ticket-level move via an unconditional (all-statuses) detach run before the ticket `org_id` UPDATE — into both sites the device-move axis needs:

- `apps/api/src/routes/devices/moveOrg.ts`: adds the `scope_ticket_id` tombstone immediately after the `scope_device_id` tombstone and the tickets requester-contact detach, and BEFORE the generic `getDeviceOrgDenormalizedTables()` re-stamp loop — the loop is what re-stamps `tickets.org_id` and trips the constraint if the tombstone hasn't run first.
- New migration `apps/api/migrations/2026-10-08-100900-cascade-device-org-move-ticket-scope.sql`: `CREATE OR REPLACE FUNCTION breeze_cascade_device_org_id()`, function body copied verbatim from the newest prior definition (`2026-10-08-100500-detach-ticket-comment-runs-on-device-org-move.sql`, merged minutes before this branch was cut) with the one statement added, placed before the generic re-stamp loop for the same reason. No inner `BEGIN`/`COMMIT`; the trigger itself is unchanged and not redeclared.

No historical backfill: unlike the silently-stale `scope_device_id` gap, this one is a hard abort — a device org-move carrying a ticket-scoped intent could not have succeeded before this fix, on either site, so there is nothing pre-existing to clean up.

## Tests

**Red first, both halves**, verified locally against an isolated `pnpm test-stack` instance:

- With the migration's added statement and the route's added statement both temporarily removed: the real-Postgres integration test's route case failed with the exact reported `23503` on `action_intents_scope_ticket_org_fk` via a raw `UPDATE devices` (500 from the route, `PostgresError: update or delete on table "tickets" violates foreign key constraint...`), and both trigger-path cases failed the same way. With both statements restored, all 3 pass.
- **`moveOrg.coverage.test.ts`** (blocking `test-api` job): new `describe` block asserts BOTH sites — the route source and the newest migration's function body — including that the statement is unconditional (no status filter, unlike `scope_device_id`'s) and that it runs before the generic re-stamp loop (load-bearing here, since `tickets` IS in that loop, unlike `scope_device_id`'s equivalent placement guard which is a convention-only check).
- **`deviceMoveOrgTicketScopeTombstone.integration.test.ts`** (new, blocking `integration-test` job): drives the fix three ways — the actual `POST /devices/:id/move-org` route, a raw `UPDATE devices` under the unprivileged `breeze_app` role via `withSystemDbAccessContext` (the shape orgMerge's `devices` repoint has), and a raw superuser `UPDATE devices`. Every case seeds one live (`pending_approval`) and one `completed` intent scoped to a ticket bound to the moving device and asserts the move succeeds (200 / no thrown error) and BOTH intents end up tombstoned — this FK's lack of a status gate means the terminal-status intent must ALSO be nulled, not left alone the way `scope_device_id`'s live-only tombstone leaves it.

Verified:

| Check | Result |
|---|---|
| `deviceMoveOrgTicketScopeTombstone.integration.test.ts` | 3 passed (all 3 red before restoring the fix) |
| `moveOrg.coverage.test.ts` | 29 passed |
| `moveOrg.test.ts` | 33 passed |
| `deviceMoveOrgIntentScopeTombstone`, `deviceMoveOrgCurrency`, `agentRunMoveSemantics`, `ticket-move-org`, `actionIntentsImmutabilityTrigger` (integration) | 61 passed |
| `autoMigrate.test.ts` | 67 passed |
| `pnpm db:check-drift` | no drift |
| `npx tsc --noEmit` (apps/api) | clean |
| `npx eslint` on touched files | clean |
| `scripts/check-migration-naming.sh` | OK |

No schema change (no new table/column), so no cascade / export-policy / RLS-allowlist registration applies.

Closes #4792

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBxF7C8E5GxFnNcGf6kBVP