### PR TITLE
fix(web): stop Connect Desktop from revoking every live remote session (#4090)

### DIFF
--- a/apps/web/src/components/remote/ConnectDesktopButton.denied.test.tsx
+++ b/apps/web/src/components/remote/ConnectDesktopButton.denied.test.tsx
@@ -42,8 +42,6 @@ describe('ConnectDesktopButton — user-denied state', () => {
       hasRemoteAccessLauncher: false,
       remoteAccessLaunchSkipReason: 'no_provider_configured',
     }));
-    // DELETE /remote/sessions/stale (fires in parallel, ignored)
-    fetchMock.mockResolvedValueOnce(jsonRes({}));
     // POST /remote/sessions — returns session id
     fetchMock.mockResolvedValueOnce(jsonRes({ id: 'sess-denied' }));
     // POST /remote/sessions/sess-denied/desktop-connect-code
@@ -68,7 +66,6 @@ describe('ConnectDesktopButton — user-denied state', () => {
       hasRemoteAccessLauncher: false,
       remoteAccessLaunchSkipReason: 'no_provider_configured',
     }));
-    fetchMock.mockResolvedValueOnce(jsonRes({}));
     fetchMock.mockResolvedValueOnce(jsonRes({ id: 'sess-denied-2' }));
     fetchMock.mockResolvedValueOnce(jsonRes({ code: 'code-xyz' }));
     // Poll returns denied

--- a/apps/web/src/components/remote/ConnectDesktopButton.test.tsx
+++ b/apps/web/src/components/remote/ConnectDesktopButton.test.tsx
@@ -341,3 +341,41 @@ describe('ConnectDesktopButton — viewer-not-installed fallback card', () => {
     expect(screen.queryByText(/^Title$/)).toBeNull();
   });
 });
+
+describe('ConnectDesktopButton — session creation (#4090)', () => {
+  beforeEach(() => {
+    _resetToastQueueForTests();
+    fetchMock.mockReset();
+    toastMock.mockReset();
+  });
+
+  it('never fires the unscoped stale-session sweep; the POST does its own device+type cleanup', async () => {
+    // Regression for #4090: DELETE /remote/sessions/stale with no deviceId revoked
+    // every live session the caller could see (the reporter's Terminal socket got
+    // close 4003 "Session revoked"), and racing it against the POST could revoke
+    // the brand-new desktop session too. The server already terminates stale
+    // rows scoped to device+type inside POST /remote/sessions, so the client
+    // sweep is both redundant and destructive.
+    fetchMock.mockResolvedValueOnce(jsonRes({
+      desktopAccess: null,
+      hasRemoteAccessLauncher: false,
+      remoteAccessLaunchSkipReason: 'no_provider_configured',
+    }));
+    fetchMock.mockResolvedValue(jsonRes({ id: 'sess-1', code: 'code-1', status: 'pending' }));
+
+    render(<ConnectDesktopButton deviceId="dev-4090" />);
+    fireEvent.click(screen.getByRole('button', { name: /connect desktop/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/remote/sessions',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+
+    const staleCalls = fetchMock.mock.calls.filter(([url]) =>
+      typeof url === 'string' && url.includes('/remote/sessions/stale'),
+    );
+    expect(staleCalls).toEqual([]);
+  });
+});

--- a/apps/web/src/components/remote/ConnectDesktopButton.tsx
+++ b/apps/web/src/components/remote/ConnectDesktopButton.tsx
@@ -368,17 +368,19 @@ export default function ConnectDesktopButton({ deviceId, className = '', compact
         return;
       }
 
-      // Clean up stale sessions in parallel with creating new one
-      const [, response] = await Promise.all([
-        fetchWithAuth('/remote/sessions/stale', { method: 'DELETE' }).catch(() => {}),
-        fetchWithAuth('/remote/sessions', {
-          method: 'POST',
-          body: JSON.stringify({
-            deviceId,
-            type: 'desktop',
-          }),
+      // Do NOT sweep /remote/sessions/stale here. The unscoped sweep (no
+      // deviceId, no type) revoked every live session the caller could see,
+      // including a Terminal on the same device (close 4003 "Session revoked"),
+      // and racing it against the POST could catch the brand-new desktop row
+      // too (#4090). POST /remote/sessions already terminates stale rows
+      // scoped to this device+type server-side.
+      const response = await fetchWithAuth('/remote/sessions', {
+        method: 'POST',
+        body: JSON.stringify({
+          deviceId,
+          type: 'desktop',
         }),
-      ]);
+      });
 
       if (!response.ok) {
         const err = await response.json();


### PR DESCRIPTION
## Summary

- `ConnectDesktopButton` fired `DELETE /remote/sessions/stale` with no `deviceId` and no `type`, in parallel with `POST /remote/sessions`. That endpoint (`apps/api/src/routes/remote/sessions.ts:60-148`) marks every pending/connecting/active session the caller can see as disconnected and tears each down, so a Terminal on the same device received close `4003 Session revoked` (`terminalWs.ts:448`). Racing the sweep against the POST could also catch the brand-new desktop row, producing the viewer's "This remote session has ended".
- `POST /remote/sessions` already terminates stale rows scoped to device+type server-side (`sessions.ts:216-244`), so the client sweep was redundant and destructive. Removed.
- Regression test: Connect Desktop must never call `/remote/sessions/stale`. Denied-state tests updated for the shorter mock sequence.

Root cause confirmed from the reporter's Firefox WS frame capture on #4090.

## Linked Issues

Closes #4090

## Type of Change

- [x] Bug fix

## Testing

- [x] `vitest run src/components/remote/ConnectDesktopButton` — 20/20 (red first, then green)
- [x] `tsc --noEmit` web, `eslint src` web

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mjv2U8k1mHukRHqkUz93gF