### PR TITLE
fix(api/tenancy): sever device_vulnerabilities.ticket_id on either org-move axis (#4645)

### DIFF
--- a/apps/api/migrations/2026-10-08-101000-cascade-device-org-move-vuln-ticket-detach.sql
+++ b/apps/api/migrations/2026-10-08-101000-cascade-device-org-move-vuln-ticket-detach.sql
@@ -1,0 +1,166 @@
+-- #4645 — device_vulnerabilities.ticket_id keeps naming a ticket that moved
+-- to another org (or was left behind by a device move). Decision made in the
+-- issue: option A, mirroring #4642's precedent (null the FK on divergence,
+-- same as every other stale-pointer detach breeze_cascade_device_org_id()
+-- already performs) and covering BOTH axes:
+--
+--   1. TICKET axis (services/ticketService.ts's moveTicketOrg): a finding's
+--      remediation ticket moves to another org via moveTicketOrg while the
+--      finding (device_vulnerabilities row) stays behind with its device —
+--      device_vulnerabilities.org_id is the DEVICE's org and is never
+--      touched by a ticket move. Fixed alongside this migration, in the same
+--      PR, by a `device_vulnerabilities.ticket_id = NULL` statement in
+--      moveTicketOrg itself (not this trigger — moveTicketOrg has no
+--      corresponding SQL trigger the way the device axis does).
+--
+--   2. DEVICE axis (this migration): the reverse direction. `device_id` FK
+--      to `devices.id`, plain (not composite), `org_id` uuid NOT NULL
+--      (`references(() => organizations.id)`, no onDelete clause — a bare FK,
+--      distinct from `ticket_id`'s `ON DELETE SET NULL`).
+--      `device_vulnerabilities` IS in getDeviceOrgDenormalizedTables() /
+--      breeze_device_child_orgid_tables(), so the generic loop below already
+--      re-stamps a finding's org_id to the device's new (target) org — the
+--      finding always travels with its device. Its remediation ticket does
+--      NOT: `POST /vulnerabilities/tickets` (routes/vulnerabilities.ts)
+--      creates the ticket org-scoped only and never sets `tickets.device_id`,
+--      so the `tickets` UPDATE inside this same generic loop (device-bound
+--      tickets only) never reaches it — the ticket stays in whatever org it
+--      was created in. Once the finding's org_id is the target org, a
+--      ticket_id still naming a SOURCE-org ticket resolves to nothing under
+--      RLS for any caller in the target org (a dead `/tickets#...` link
+--      client-side — CveDrawer/SoftwareGroupDrawer render it; nothing
+--      server-side dereferences the column).
+--
+-- `ticket_id` is a PLAIN single-column FK (not the composite
+-- `(x, org_id) -> tickets(id, org_id)` shape the action_intents/tickets
+-- tombstones above exist to satisfy), so this statement can never 23503
+-- either way — unlike those, it is not a correctness-of-transaction
+-- requirement, only a tenancy-hygiene one. Placed AFTER the generic
+-- `breeze_device_child_orgid_tables()` loop (not before, and not mixed in
+-- with the pre-loop tombstones above), specifically so it can compare
+-- against the referenced ticket's ACTUAL (post-restamp) org: a ticket that
+-- happens to be bound to this same device (`tickets.device_id = NEW.id`) is
+-- ALSO re-stamped to the target org by that same loop, and by the time this
+-- statement runs its org_id already matches — so the link is correctly left
+-- alone. Checking before the loop would see that ticket's stale SOURCE org
+-- and wrongly null a link that is about to become valid.
+--
+-- No historical backfill: unlike the scope_device_id/scope_ticket_id
+-- tombstones above, a stale device_vulnerabilities.ticket_id is not a hard
+-- abort (this FK cannot 23503), so pre-existing rows are not blocking
+-- anything — they are exactly the mild, already-shipped symptom (#4524
+-- sweep) this issue reports. Bulk-correcting them retroactively is a
+-- separate, deliberate backfill decision (RLS/system-context concerns per
+-- CLAUDE.md), not something to fold silently into a trigger-definition
+-- migration.
+--
+-- Full function body copied verbatim from
+-- 2026-10-08-100900-cascade-device-org-move-ticket-scope.sql (the newest
+-- definition; no later migration replaces this function) with only the
+-- device_vulnerabilities.ticket_id statement added, after the generic loop.
+-- CREATE OR REPLACE is idempotent by construction — re-applying this file
+-- re-installs the same body. The trigger itself (breeze_cascade_device_org_id
+-- ON devices, AFTER UPDATE OF org_id ... WHEN NEW.org_id IS DISTINCT FROM
+-- OLD.org_id) is unchanged and is NOT redeclared here.
+CREATE OR REPLACE FUNCTION public.breeze_cascade_device_org_id()
+  RETURNS trigger
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = public, pg_catalog
+  AS $$
+DECLARE
+  child_table text;
+BEGIN
+  -- Agent-run history stays with the SOURCE org (owner decision 2026-08-23):
+  -- sever the moved device's lineage links instead of re-stamping org_id.
+  UPDATE public.ai_agent_runs
+    SET device_id = NULL, alert_id = NULL, session_id = NULL, anomaly_incident_id = NULL
+    WHERE device_id = NEW.id;
+  -- ticket_id is device-lineage too, but unreachable from `WHERE device_id`:
+  -- ticket-triggered runs carry a ticket_id with a NULL device_id. Key off the
+  -- ticket's device_id instead (#4215).
+  UPDATE public.ai_agent_runs
+    SET ticket_id = NULL
+    WHERE ticket_id IN (SELECT id FROM public.tickets WHERE device_id = NEW.id);
+  -- Reverse pointer: the incident's back-link to the (now-detached) run must
+  -- not keep naming a source-org run once the incident itself is re-stamped
+  -- to the destination org by the generic loop below.
+  UPDATE public.metric_anomaly_incidents
+    SET agent_run_id = NULL
+    WHERE device_id = NEW.id;
+  -- Reverse pointer: ticket_comments.agent_run_id (#4644). ticket_comments has
+  -- no org_id of its own (child-via-parent tenancy through tickets), so a
+  -- comment on a ticket bound to this device travels to the target org via the
+  -- generic loop below while the run it names stays with the SOURCE org —
+  -- same class as the metric_anomaly_incidents reverse pointer above, and the
+  -- device-axis mirror of moveTicketOrg's ticket_comments detach
+  -- (ticketService.ts, #4642) on the ticket axis.
+  UPDATE public.ticket_comments
+    SET agent_run_id = NULL
+    WHERE agent_run_id IS NOT NULL
+      AND ticket_id IN (SELECT id FROM public.tickets WHERE device_id = NEW.id);
+  -- Typed target scope of a LIVE intent must not keep naming a device that has
+  -- just left the intent's org (#4454). Mirrors moveOrg.ts; see the header for
+  -- the live-status gate, the immutability-trigger transition, and why this one
+  -- takes no merge fence.
+  UPDATE public.action_intents
+    SET scope_device_id = NULL
+    WHERE scope_device_id = NEW.id
+      AND status IN ('pending_approval', 'approved', 'executing');
+  -- The requester CONTACT is org-pinned and does not travel with the device
+  -- (#3258 W03). Skipped while the source org is fenced for a merge, where the
+  -- contact moves to the survivor alongside the ticket — see the header of
+  -- 2026-10-04-100000-ticket-requester-contact.sql.
+  IF NOT EXISTS (
+    SELECT 1 FROM public.organizations o
+     WHERE o.id = OLD.org_id AND o.status::text = 'merging'
+  ) THEN
+    UPDATE public.tickets
+      SET requester_contact_id = NULL
+      WHERE device_id = NEW.id
+        AND requester_contact_id IS NOT NULL
+        AND org_id IS DISTINCT FROM NEW.org_id;
+  END IF;
+  -- Typed target scope of an intent scoped to a TICKET bound to this device
+  -- (#4792) must not keep naming a (ticket, OLD org_id) pair once the ticket
+  -- is re-stamped to the destination org by the generic loop below — every
+  -- status, not just live ones, since action_intents_scope_ticket_org_fk does
+  -- not gate on status and would 23503 the loop's own tickets UPDATE
+  -- otherwise. See this migration's header for the full mechanism; mirrors
+  -- moveOrg.ts and moveTicketOrg (ticketService.ts). Placed after the
+  -- requester-contact detach immediately above (order between the two is not
+  -- itself load-bearing — they touch disjoint tables — but this makes the
+  -- trigger's statement order match moveOrg.ts's exactly, not just
+  -- "before the loop").
+  UPDATE public.action_intents
+    SET scope_ticket_id = NULL
+    WHERE scope_ticket_id IN (SELECT id FROM public.tickets WHERE device_id = NEW.id);
+  FOR child_table IN SELECT public.breeze_device_child_orgid_tables() LOOP
+    EXECUTE format(
+      'UPDATE public.%I SET org_id = $1 WHERE device_id = $2 AND org_id IS DISTINCT FROM $1',
+      child_table
+    ) USING NEW.org_id, NEW.id;
+  END LOOP;
+  -- device_vulnerabilities.ticket_id (#4645): must run AFTER the generic loop
+  -- above, not before — see this migration's header for why the ordering is
+  -- load-bearing here (it is not for any of the tombstones above, which all
+  -- run before the loop precisely because THEIR FK would 23503 otherwise).
+  -- device_vulnerabilities.org_id has just been re-stamped to NEW.org_id by
+  -- that loop (device_vulnerabilities IS a member of
+  -- breeze_device_child_orgid_tables()), so a finding's ticket_id is
+  -- compared against the ticket's own (possibly also just re-stamped) org_id
+  -- rather than the finding's — a ticket bound to this same device was ALSO
+  -- just moved to NEW.org_id by the loop and is correctly left alone; a
+  -- ticket that stayed in the source org (the common case: vulnerability
+  -- remediation tickets are created org-scoped only, never device-bound) is
+  -- correctly detached. Plain FK (`ticket_id` -> `tickets.id` ON DELETE SET
+  -- NULL, not composite), so this can never 23503.
+  UPDATE public.device_vulnerabilities dv
+    SET ticket_id = NULL
+    FROM public.tickets t
+    WHERE dv.device_id = NEW.id
+      AND dv.ticket_id = t.id
+      AND t.org_id IS DISTINCT FROM NEW.org_id;
+  RETURN NULL; -- AFTER trigger; return value ignored
+END;
+$$;

--- a/apps/api/src/__tests__/integration/deviceMoveOrgVulnerabilityTicketDetach.integration.test.ts
+++ b/apps/api/src/__tests__/integration/deviceMoveOrgVulnerabilityTicketDetach.integration.test.ts
@@ -1,0 +1,314 @@
+/**
+ * Live-Postgres coverage for #4645 (device axis): a device org-move must
+ * detach `device_vulnerabilities.ticket_id` when the finding's remediation
+ * ticket does NOT travel with it.
+ *
+ * WHY THIS NEEDS A REAL DATABASE
+ * ------------------------------
+ * `device_vulnerabilities` IS a member of `breeze_device_child_orgid_tables()`
+ * / `getDeviceOrgDenormalizedTables()`, so a device org-move re-stamps a
+ * finding's `org_id` to the destination org unconditionally — the finding
+ * always travels with its device. Its `ticket_id` does not: findings created
+ * via `POST /vulnerabilities/tickets` (routes/vulnerabilities.ts) are
+ * org-scoped only and never set `tickets.device_id`, so the SAME generic loop
+ * that moves the finding never touches that ticket — it stays in the source
+ * org. A mocked suite can only assert the SQL text
+ * (`moveOrg.coverage.test.ts` does that, statically); it cannot prove the
+ * live comparison against the ticket's ACTUAL post-move `org_id`, and it
+ * cannot catch:
+ *
+ *   1. FORCE ROW LEVEL SECURITY on `device_vulnerabilities` silently
+ *      matching zero rows for the detach.
+ *   2. The `org_id IS DISTINCT FROM` precision guard nulling a link that is
+ *      actually still valid (a ticket bound to the SAME moving device, which
+ *      the generic loop also re-stamps to the destination org in the same
+ *      transaction — see the "device-bound ticket" case below).
+ *   3. The reverse: leaving a genuinely stale link because the guard ran
+ *      BEFORE the generic loop instead of after (see moveOrg.ts's placement
+ *      comment).
+ *
+ * TWO CALLERS, both asserted, mirroring the #4792 sibling
+ * (deviceMoveOrgTicketScopeTombstone.integration.test.ts):
+ *
+ *   - `POST /devices/:id/move-org` (the route's own statement) — the primary
+ *     bug report's path.
+ *   - a raw `UPDATE devices SET org_id` under `withSystemDbAccessContext` as
+ *     the unprivileged `breeze_app` role — proves
+ *     `breeze_cascade_device_org_id()`'s mirrored statement, not just the
+ *     route's, and specifically that FORCE RLS on `device_vulnerabilities`
+ *     does not silently no-op it.
+ *
+ * Unlike #4792's gap, this one is NOT a hard abort — `ticket_id` is a plain
+ * single-column `ON DELETE SET NULL` FK, not composite tenant-FK'd — so every
+ * case below asserts the move succeeds AND the pointer ends up correct,
+ * rather than asserting a 23503 is avoided.
+ */
+import './setup';
+
+import { randomUUID } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
+import { eq, sql } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import { devices, tickets, deviceVulnerabilities, vulnerabilities } from '../../db/schema';
+import { createOrganization, createSite, setupTestEnvironment } from './db-utils';
+import { getTestDb } from './setup';
+import { createAccessToken } from '../../services/jwt';
+import { moveOrgRoutes } from '../../routes/devices/moveOrg';
+
+function uid(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function seed() {
+  const adminDb = getTestDb() as never as {
+    insert: (typeof db)['insert'];
+    select: (typeof db)['select'];
+  };
+  const sfx = uid();
+
+  const { partner, organization: sourceOrg, site: sourceSite, user, role } = await setupTestEnvironment({
+    scope: 'partner',
+  });
+  const targetOrg = await createOrganization({ partnerId: partner.id });
+  const targetSite = await createSite({ orgId: targetOrg.id });
+
+  const [device] = await adminDb
+    .insert(devices)
+    .values({
+      orgId: sourceOrg.id,
+      siteId: sourceSite.id,
+      agentId: `vuln-ticket-agent-${sfx}`,
+      hostname: `vuln-ticket-host-${sfx}`,
+      osType: 'linux',
+      osVersion: '22.04',
+      architecture: 'x86_64',
+      agentVersion: '0.0.0-test',
+      status: 'offline',
+    })
+    .returning({ id: devices.id });
+
+  // Negative control device: stays in the source org through every case
+  // below, so its finding/ticket pair must never be touched.
+  const [otherDevice] = await adminDb
+    .insert(devices)
+    .values({
+      orgId: sourceOrg.id,
+      siteId: sourceSite.id,
+      agentId: `vuln-ticket-other-agent-${sfx}`,
+      hostname: `vuln-ticket-other-host-${sfx}`,
+      osType: 'linux',
+      osVersion: '22.04',
+      architecture: 'x86_64',
+      agentVersion: '0.0.0-test',
+      status: 'offline',
+    })
+    .returning({ id: devices.id });
+
+  const [vuln] = await adminDb
+    .insert(vulnerabilities)
+    .values({
+      cveId: `CVE-2099-${sfx.replace(/[^0-9a-z]/gi, '').slice(0, 12)}`,
+      source: 'nvd',
+      description: 'device-move-org test vulnerability',
+      severity: 'high',
+      cvssVersion: '3.1',
+      cvssScore: '8.0',
+      knownExploited: false,
+      patchAvailable: true,
+      rawPayload: { test: true },
+    } as never)
+    .returning({ id: vulnerabilities.id });
+
+  // The realistic shape: a vulnerability-remediation ticket created org-scoped
+  // only (POST /vulnerabilities/tickets never sets tickets.device_id), so the
+  // generic denormalized-table loop never re-stamps it — it stays in the
+  // source org after the device moves.
+  const [orgOnlyTicket] = await adminDb
+    .insert(tickets)
+    .values({
+      orgId: sourceOrg.id,
+      partnerId: partner.id,
+      ticketNumber: `VT-${sfx}`,
+      subject: `remediation ticket ${sfx}`,
+      source: 'manual',
+    } as never)
+    .returning({ id: tickets.id });
+
+  // Edge case: a ticket that IS bound to the SAME moving device. The generic
+  // loop re-stamps `tickets.device_id = device.id` rows to the destination
+  // org in the SAME transaction, so a finding pointing at it must be left
+  // alone — its link is still valid once both rows land in the target org.
+  const [deviceBoundTicket] = await adminDb
+    .insert(tickets)
+    .values({
+      orgId: sourceOrg.id,
+      partnerId: partner.id,
+      deviceId: device!.id,
+      ticketNumber: `VT-BOUND-${sfx}`,
+      subject: `device-bound ticket ${sfx}`,
+      source: 'manual',
+    } as never)
+    .returning({ id: tickets.id });
+
+  const [finding] = await adminDb
+    .insert(deviceVulnerabilities)
+    .values({
+      orgId: sourceOrg.id,
+      deviceId: device!.id,
+      vulnerabilityId: vuln!.id,
+      status: 'open',
+      detectedAt: new Date(),
+      ticketId: orgOnlyTicket!.id,
+    } as never)
+    .returning({ id: deviceVulnerabilities.id });
+
+  const [boundFinding] = await adminDb
+    .insert(deviceVulnerabilities)
+    .values({
+      orgId: sourceOrg.id,
+      deviceId: device!.id,
+      vulnerabilityId: vuln!.id,
+      status: 'open',
+      detectedAt: new Date(),
+      ticketId: deviceBoundTicket!.id,
+    } as never)
+    .returning({ id: deviceVulnerabilities.id });
+
+  // Negative control: same org-only ticket, but the finding is on the
+  // UNRELATED device that never moves.
+  const [otherFinding] = await adminDb
+    .insert(deviceVulnerabilities)
+    .values({
+      orgId: sourceOrg.id,
+      deviceId: otherDevice!.id,
+      vulnerabilityId: vuln!.id,
+      status: 'open',
+      detectedAt: new Date(),
+      ticketId: orgOnlyTicket!.id,
+    } as never)
+    .returning({ id: deviceVulnerabilities.id });
+
+  const token = await createAccessToken({
+    sub: user.id,
+    email: user.email,
+    roleId: role.id,
+    orgId: null,
+    partnerId: partner.id,
+    scope: 'partner',
+    mfa: true,
+    aep: 1,
+    mep: 1,
+    sid: 'it-session',
+  });
+
+  const app = new Hono();
+  app.route('/devices', moveOrgRoutes);
+
+  const post = () =>
+    app.request(`/devices/${device!.id}/move-org`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ orgId: targetOrg.id, siteId: targetSite.id }),
+    });
+
+  return {
+    deviceId: device!.id,
+    otherDeviceId: otherDevice!.id,
+    orgOnlyTicketId: orgOnlyTicket!.id,
+    deviceBoundTicketId: deviceBoundTicket!.id,
+    findingId: finding!.id,
+    boundFindingId: boundFinding!.id,
+    otherFindingId: otherFinding!.id,
+    sourceOrgId: sourceOrg.id,
+    targetOrgId: targetOrg.id,
+    targetSiteId: targetSite.id,
+    post,
+  };
+}
+
+type Fixture = Awaited<ReturnType<typeof seed>>;
+
+async function readFinding(id: string) {
+  const [row] = await getTestDb()
+    .select({ orgId: deviceVulnerabilities.orgId, ticketId: deviceVulnerabilities.ticketId })
+    .from(deviceVulnerabilities)
+    .where(eq(deviceVulnerabilities.id, id));
+  return row;
+}
+
+async function readOrgs(f: Pick<Fixture, 'deviceId' | 'orgOnlyTicketId' | 'deviceBoundTicketId'>) {
+  const [d] = await getTestDb().select({ orgId: devices.orgId }).from(devices).where(eq(devices.id, f.deviceId));
+  const [t] = await getTestDb().select({ orgId: tickets.orgId }).from(tickets).where(eq(tickets.id, f.orgOnlyTicketId));
+  const [bt] = await getTestDb()
+    .select({ orgId: tickets.orgId })
+    .from(tickets)
+    .where(eq(tickets.id, f.deviceBoundTicketId));
+  return { deviceOrgId: d?.orgId, orgOnlyTicketOrgId: t?.orgId, deviceBoundTicketOrgId: bt?.orgId };
+}
+
+async function assertOutcome(f: Fixture) {
+  const afterOrgs = await readOrgs(f);
+  expect(afterOrgs.deviceOrgId).toBe(f.targetOrgId);
+  expect(afterOrgs.orgOnlyTicketOrgId, 'the org-scoped ticket must NOT follow the device').toBe(f.sourceOrgId);
+  expect(afterOrgs.deviceBoundTicketOrgId, 'the device-bound ticket DOES follow the device').toBe(f.targetOrgId);
+
+  const finding = await readFinding(f.findingId);
+  expect(finding?.orgId, 'the finding always travels with its device').toBe(f.targetOrgId);
+  expect(finding?.ticketId, 'stale cross-org pointer must be severed').toBeNull();
+
+  const boundFinding = await readFinding(f.boundFindingId);
+  expect(boundFinding?.orgId).toBe(f.targetOrgId);
+  expect(
+    boundFinding?.ticketId,
+    'a ticket bound to the SAME moving device travels too — the link is still valid and must survive',
+  ).toBe(f.deviceBoundTicketId);
+
+  const otherFinding = await readFinding(f.otherFindingId);
+  expect(otherFinding?.orgId, 'the unrelated device never moved').toBe(f.sourceOrgId);
+  expect(otherFinding?.ticketId, 'a finding on a device that did not move must not be touched').toBe(
+    f.orgOnlyTicketId,
+  );
+}
+
+describe('POST /devices/:id/move-org — device_vulnerabilities.ticket_id detach (#4645)', () => {
+  it('detaches a stale org-scoped remediation ticket, spares a device-bound one, and leaves an unrelated device untouched', async () => {
+    const f: Fixture = await seed();
+
+    expect((await readFinding(f.findingId))?.ticketId).toBe(f.orgOnlyTicketId);
+    expect((await readFinding(f.boundFindingId))?.ticketId).toBe(f.deviceBoundTicketId);
+
+    const res = await f.post();
+    const body = (await res.json()) as { success?: boolean; error?: string };
+    expect(res.status, JSON.stringify(body)).toBe(200);
+    expect(body.success).toBe(true);
+
+    await assertOutcome(f);
+  });
+});
+
+describe('breeze_cascade_device_org_id(): device_vulnerabilities.ticket_id detach (#4645)', () => {
+  it('a raw UPDATE devices under the unprivileged breeze_app role (system context) detaches the stale ticket link', async () => {
+    const f: Fixture = await seed();
+
+    await withSystemDbAccessContext(async () => {
+      await db.execute(sql`
+        UPDATE devices SET org_id = ${f.targetOrgId}::uuid, site_id = ${f.targetSiteId}::uuid
+         WHERE id = ${f.deviceId}::uuid
+      `);
+    });
+
+    await assertOutcome(f);
+  });
+
+  it('a raw superuser UPDATE devices SET org_id also detaches the stale ticket link', async () => {
+    const f: Fixture = await seed();
+
+    await getTestDb().execute(sql`
+      UPDATE devices SET org_id = ${f.targetOrgId}::uuid, site_id = ${f.targetSiteId}::uuid
+       WHERE id = ${f.deviceId}::uuid
+    `);
+
+    await assertOutcome(f);
+  });
+});

--- a/apps/api/src/__tests__/integration/ticket-move-org.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ticket-move-org.integration.test.ts
@@ -1118,4 +1118,59 @@ describe('moveTicketOrg — device_vulnerabilities.ticket_id detach (#4645)', ()
     expect(after?.ticketId, 'the finding already lived in the ticket\'s destination org — not stale').toBe(ticket.id);
     expect(after?.orgId).toBe(orgB.id);
   });
+
+  it('severs the pointer under a REAL partner-scoped RLS context, not just system scope', async () => {
+    // The route runs under withDbAccessContext, never withSystemDbAccessContext.
+    // device_vulnerabilities is FORCE ROW LEVEL SECURITY, so a detach that only
+    // works for `breeze.scope=system` would be a silent zero-row no-op on the
+    // one path that actually matters — same hazard the ai_agent_runs sibling
+    // test above (#4524) exists to catch for that table.
+    const { orgA, orgB, partner, actor, ticket, device } = await seedMoveOrgFixture();
+    const vuln = await seedVulnCatalogEntry();
+    const finding = await seedFinding(orgA.id, device.id, vuln.id, ticket.id);
+
+    const partnerCtx: DbAccessContext = {
+      scope: 'partner',
+      orgId: null,
+      accessibleOrgIds: [orgA.id, orgB.id],
+      accessiblePartnerIds: [partner.id],
+      userId: actor.userId,
+    };
+    await withDbAccessContext(partnerCtx, () => moveTicketOrg(ticket.id, orgB.id, actor));
+
+    expect((await readTicket(ticket.id))?.orgId).toBe(orgB.id);
+    const after = await readFinding(finding.id);
+    expect(after?.ticketId).toBeNull();
+    expect(after?.orgId).toBe(orgA.id);
+  });
+
+  it('rolls the detach back with the rest of the transaction when the currency guard blocks the move', async () => {
+    // The detach runs BEFORE assertTicketMoveCurrencyCompatible (same
+    // placement as the ai_agent_runs detach beside it), so a blocked move
+    // must unwind it along with everything else. Verified discriminating by
+    // mutation, same as the ai_agent_runs rollback test above: hoisting the
+    // detach out of db.transaction would fail ONLY this case.
+    const adminDb = getTestDb() as any;
+    const { orgA, orgB, partner, actor, ticket, device, timeEntry, ticketPart } = await seedMoveOrgFixture();
+    const vuln = await seedVulnCatalogEntry();
+    const finding = await seedFinding(orgA.id, device.id, vuln.id, ticket.id);
+
+    await setOrgCurrency(orgB.id, 'EUR');
+    await adminDb.update(timeEntries)
+      .set({ hourlyRate: '100.00', isBillable: false, billingStatus: 'not_billed' })
+      .where(eq(timeEntries.id, timeEntry.id));
+    await adminDb.delete(ticketParts).where(eq(ticketParts.id, ticketPart.id));
+
+    const err = await withSystemDbAccessContext(() =>
+      moveTicketOrg(ticket.id, orgB.id, actor)
+    ).catch((e) => e);
+    expect(err).toBeInstanceOf(TicketMoveCurrencyBlockedError);
+
+    // Nothing moved — and the pointer is still there, because the ticket is
+    // still the source org's.
+    expect((await readTicket(ticket.id))?.orgId).toBe(orgA.id);
+    const after = await readFinding(finding.id);
+    expect(after?.ticketId).toBe(ticket.id);
+    expect(after?.orgId).toBe(orgA.id);
+  });
 });

--- a/apps/api/src/__tests__/integration/ticket-move-org.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ticket-move-org.integration.test.ts
@@ -44,6 +44,8 @@ import {
   aiAgents,
   aiAgentRuns,
   users,
+  deviceVulnerabilities,
+  vulnerabilities,
 } from '../../db/schema';
 import { moveTicketOrg, TicketServiceError } from '../../services/ticketService';
 import { TicketMoveCurrencyBlockedError } from '../../services/ticketMoveCurrencyGuard';
@@ -992,5 +994,128 @@ describe('moveTicketOrg — ai_agent_runs.ticket_id detach (#4524)', () => {
     const after = await readRun(run.id);
     expect(after?.ticketId).toBe(ticket.id);
     expect(after?.orgId).toBe(orgA.id);
+  });
+});
+
+// ── #4645: device_vulnerabilities.ticket_id must not survive a ticket move ──
+
+/**
+ * Seeds one `vulnerabilities` catalog row (global reference data, not
+ * org-scoped) — a fixture prerequisite `device_vulnerabilities.vulnerability_id`
+ * requires (NOT NULL FK).
+ */
+async function seedVulnCatalogEntry(): Promise<{ id: string }> {
+  const adminDb = getTestDb() as any;
+  const [row] = await adminDb
+    .insert(vulnerabilities)
+    .values({
+      cveId: `CVE-2099-${uid().replace(/[^0-9a-z]/gi, '').slice(0, 12)}`,
+      source: 'nvd',
+      description: 'move-org test vulnerability',
+      severity: 'high',
+      cvssVersion: '3.1',
+      cvssScore: '8.0',
+      knownExploited: false,
+      patchAvailable: true,
+      rawPayload: { test: true },
+    })
+    .returning({ id: vulnerabilities.id });
+  return { id: row.id };
+}
+
+/** Seeds one `device_vulnerabilities` finding for `deviceId`, optionally pointing `ticketId` at a remediation ticket. */
+async function seedFinding(
+  orgId: string,
+  deviceId: string,
+  vulnerabilityId: string,
+  ticketId: string | null,
+): Promise<{ id: string }> {
+  const adminDb = getTestDb() as any;
+  const [row] = await adminDb
+    .insert(deviceVulnerabilities)
+    .values({
+      orgId,
+      deviceId,
+      vulnerabilityId,
+      status: 'open',
+      detectedAt: new Date(),
+      ticketId,
+    })
+    .returning({ id: deviceVulnerabilities.id });
+  return { id: row.id };
+}
+
+async function readFinding(id: string) {
+  const adminDb = getTestDb() as any;
+  const [row] = await adminDb.select().from(deviceVulnerabilities).where(eq(deviceVulnerabilities.id, id)).limit(1);
+  return row as (typeof deviceVulnerabilities.$inferSelect) | undefined;
+}
+
+describe('moveTicketOrg — device_vulnerabilities.ticket_id detach (#4645)', () => {
+  it('nulls ticket_id on a finding whose device stays in the source org, and spares a finding on a sibling ticket', async () => {
+    const { orgA, orgB, partner, actor, ticket, device } = await seedMoveOrgFixture();
+    const vuln = await seedVulnCatalogEntry();
+
+    const finding = await seedFinding(orgA.id, device.id, vuln.id, ticket.id);
+
+    // Control: a second finding, on the SAME device, whose ticket_id points
+    // at a DIFFERENT (sibling) ticket that never moves. Rejects a blanket
+    // "null every ticket_id on this device" — the detach must be keyed on
+    // the moved ticket, not the device.
+    const sibling = await seedSiblingTicket(orgA.id, partner.id);
+    const siblingFinding = await seedFinding(orgA.id, device.id, vuln.id, sibling.id);
+
+    // Fixture guard: pointers are live before the move.
+    expect((await readFinding(finding.id))?.ticketId).toBe(ticket.id);
+    expect((await readFinding(siblingFinding.id))?.ticketId).toBe(sibling.id);
+
+    await withSystemDbAccessContext(() => moveTicketOrg(ticket.id, orgB.id, actor));
+
+    expect((await readTicket(ticket.id))?.orgId).toBe(orgB.id);
+
+    // The finding's own org_id is device-derived and untouched by a ticket
+    // move — only the stale ticket_id link is severed.
+    const after = await readFinding(finding.id);
+    expect(after?.ticketId).toBeNull();
+    expect(after?.orgId).toBe(orgA.id);
+    expect(after?.deviceId).toBe(device.id);
+
+    // The sibling ticket never moved, so its finding keeps its pointer.
+    const siblingAfter = await readFinding(siblingFinding.id);
+    expect(siblingAfter?.ticketId).toBe(sibling.id);
+  });
+
+  it('leaves ticket_id intact when the finding already lives in the destination org', async () => {
+    // Precision check on the `org_id IS DISTINCT FROM targetOrgId` guard: a
+    // finding whose device is ALREADY in the ticket's destination org is not
+    // stale after the move, so its link must survive untouched.
+    const { orgA, orgB, actor, ticket } = await seedMoveOrgFixture();
+    const siteB = await createSite({ orgId: orgB.id });
+    const adminDb = getTestDb() as any;
+    const [deviceB] = await adminDb
+      .insert(devices)
+      .values({
+        orgId: orgB.id,
+        siteId: siteB.id,
+        agentId: `move-org-device-b-${uid()}`,
+        hostname: `host-b-${uid()}`,
+        osType: 'windows',
+        osVersion: '10.0.19041',
+        architecture: 'x64',
+        agentVersion: '0.1.0',
+      })
+      .returning();
+    const vuln = await seedVulnCatalogEntry();
+    const finding = await seedFinding(orgB.id, deviceB.id, vuln.id, ticket.id);
+
+    expect((await readFinding(finding.id))?.ticketId).toBe(ticket.id);
+    expect((await readTicket(ticket.id))?.orgId).toBe(orgA.id);
+
+    await withSystemDbAccessContext(() => moveTicketOrg(ticket.id, orgB.id, actor));
+
+    expect((await readTicket(ticket.id))?.orgId).toBe(orgB.id);
+    const after = await readFinding(finding.id);
+    expect(after?.ticketId, 'the finding already lived in the ticket\'s destination org — not stale').toBe(ticket.id);
+    expect(after?.orgId).toBe(orgB.id);
   });
 });

--- a/apps/api/src/routes/devices/moveOrg.coverage.test.ts
+++ b/apps/api/src/routes/devices/moveOrg.coverage.test.ts
@@ -773,3 +773,85 @@ describe('action_intents.scope_ticket_id detach coverage (#4792)', () => {
     ).toBeLessThan(loop);
   });
 });
+
+/**
+ * device_vulnerabilities.ticket_id detach coverage (#4645, device axis).
+ *
+ * `device_vulnerabilities` IS returned by breeze_device_child_orgid_tables()
+ * / getDeviceOrgDenormalizedTables(), so the generic re-stamp loop already
+ * moves a finding's org_id to the destination org unconditionally — the
+ * finding always travels with its device. Its remediation ticket does not:
+ * `POST /vulnerabilities/tickets` (routes/vulnerabilities.ts) creates the
+ * ticket org-scoped only and never sets tickets.device_id, so the SAME loop
+ * (which also re-stamps `tickets` for any ticket bound to the moved device)
+ * never reaches it — it stays behind in the source org.
+ *
+ * Unlike scope_ticket_id above, `ticket_id` is a PLAIN single-column FK
+ * (`ON DELETE SET NULL`, not composite tenant-FK'd), so this is a tenancy-
+ * hygiene detach, not a 23503-avoidance one — and the ORDERING requirement is
+ * the OPPOSITE of scope_ticket_id's: this statement must run AFTER the
+ * generic loop, not before, because it compares against the referenced
+ * ticket's ACTUAL (possibly just-restamped) org_id. Checked before the loop,
+ * a ticket bound to the SAME moving device (still holding its stale source
+ * org_id at that point) would be wrongly nulled even though it is about to
+ * become valid once the loop restamps it.
+ *
+ * These are STATIC source assertions only. That the statement actually
+ * matches rows (and correctly SPARES a same-device-bound ticket) against a
+ * real server lives in
+ * `src/__tests__/integration/deviceMoveOrgVulnerabilityTicketDetach.integration.test.ts`.
+ * The ticket-axis twin (moveTicketOrg's own detach, services/ticketService.ts)
+ * has no SQL trigger counterpart and is covered only by
+ * `src/__tests__/integration/ticket-move-org.integration.test.ts`.
+ */
+describe('device_vulnerabilities.ticket_id detach coverage (#4645)', () => {
+  it('moveOrg.ts detaches a stale ticket_id, keyed off the ticket\'s own (post-restamp) org_id', () => {
+    const moveOrgPath = fileURLToPath(new URL('./moveOrg.ts', import.meta.url));
+    const src = readFileSync(moveOrgPath, 'utf8');
+
+    const match = src.match(
+      /UPDATE device_vulnerabilities dv SET ticket_id = NULL\s+FROM tickets t\s+WHERE dv\.device_id = \$\{deviceId\}::uuid\s+AND dv\.ticket_id = t\.id\s+AND t\.org_id IS DISTINCT FROM \$\{targetOrgId\}::uuid/,
+    );
+    expect(
+      match,
+      'moveOrg.ts no longer has the expected device_vulnerabilities.ticket_id detach statement — update this test if the statement shape changed intentionally',
+    ).toBeTruthy();
+  });
+
+  it('breeze_cascade_device_org_id() mirrors the detach', () => {
+    const { name, body } = newestCascadeFunctionBody();
+
+    const match = body.match(
+      /UPDATE public\.device_vulnerabilities dv\s+SET ticket_id = NULL\s+FROM public\.tickets t\s+WHERE dv\.device_id = NEW\.id\s+AND dv\.ticket_id = t\.id\s+AND t\.org_id IS DISTINCT FROM NEW\.org_id/,
+    );
+    expect(
+      match,
+      `${name} is the newest definition of breeze_cascade_device_org_id() and its body has no device_vulnerabilities.ticket_id detach statement — a device org-move that bypasses the moveOrg route (e.g. orgMerge's raw UPDATE devices) would leave a stale cross-org ticket_id on every finding whose device moves (#4645)`,
+    ).toBeTruthy();
+  });
+
+  it('places the detach AFTER the generic device-child org re-stamp loop (load-bearing: reversed from scope_ticket_id)', () => {
+    const { name, body } = newestCascadeFunctionBody();
+    const detach = body.indexOf('UPDATE public.device_vulnerabilities dv');
+    const loop = body.indexOf('breeze_device_child_orgid_tables()');
+    expect(detach, `${name}: no device_vulnerabilities.ticket_id detach found`).toBeGreaterThan(-1);
+    expect(loop, `${name}: no device-child re-stamp loop found`).toBeGreaterThan(-1);
+    expect(
+      detach,
+      `${name}: the device_vulnerabilities.ticket_id detach must run AFTER the generic re-stamp loop — it compares against the referenced ticket's post-restamp org_id, so checking earlier would see a same-device-bound ticket's stale SOURCE org and wrongly null a link that the loop is about to make valid`,
+    ).toBeGreaterThan(loop);
+  });
+
+  it('moveOrg.ts places its own detach AFTER the denormalized-table re-stamp loop', () => {
+    const moveOrgPath = fileURLToPath(new URL('./moveOrg.ts', import.meta.url));
+    const src = readFileSync(moveOrgPath, 'utf8');
+    const detach = src.indexOf('UPDATE device_vulnerabilities dv SET ticket_id = NULL');
+    const loop = src.indexOf('for (const table of getDeviceOrgDenormalizedTables())');
+    expect(detach, 'moveOrg.ts: no device_vulnerabilities.ticket_id detach found').toBeGreaterThan(-1);
+    expect(loop, 'moveOrg.ts: no getDeviceOrgDenormalizedTables() loop found').toBeGreaterThan(-1);
+    expect(
+      detach,
+      'moveOrg.ts: the device_vulnerabilities.ticket_id detach must run AFTER the getDeviceOrgDenormalizedTables() loop — see the trigger-ordering comment above for why this is reversed from scope_ticket_id',
+    ).toBeGreaterThan(loop);
+  });
+});

--- a/apps/api/src/routes/devices/moveOrg.ts
+++ b/apps/api/src/routes/devices/moveOrg.ts
@@ -415,6 +415,41 @@ moveOrgRoutes.post(
           );
         }
 
+        // device_vulnerabilities.ticket_id (#4645): `device_vulnerabilities` IS
+        // in getDeviceOrgDenormalizedTables(), so the loop just above already
+        // re-stamped org_id to the TARGET org for every finding on this device
+        // — the finding row itself always travels with the device. Its
+        // remediation ticket does NOT: vulnerability-remediation tickets are
+        // created org-scoped only (`POST /vulnerabilities/tickets` never sets
+        // `tickets.device_id`), so `tickets` denormalized-table loop above
+        // never reaches them and they stay put in whatever org they were
+        // created in. Once the finding's org_id is the target org, a ticket_id
+        // still naming a SOURCE-org ticket resolves to nothing under RLS for
+        // any caller in the target org — the reverse of moveTicketOrg's own
+        // device_vulnerabilities detach (services/ticketService.ts) on the
+        // ticket axis.
+        //
+        // Placement — AFTER the loop above, not before: comparing against
+        // `t.org_id` (rather than the finding's own, already-rewritten
+        // org_id) means a ticket that DOES happen to be bound to this device
+        // (`tickets.device_id = deviceId`, and therefore re-stamped to the
+        // target org by that same loop, since `tickets` is also a member) is
+        // correctly left alone — its org now matches the finding's, so the
+        // link is still valid. Checking before the loop would see the ticket's
+        // stale SOURCE org and wrongly null a link that is about to become
+        // valid. Same `org_id IS DISTINCT FROM` precision as moveTicketOrg's
+        // mirror statement and the tickets.requester_contact_id detach above.
+        //
+        // Plain single-column `ON DELETE SET NULL` FK (not composite
+        // tenant-FK'd), so this can never 23503 either way.
+        await tx.execute(
+          sql`UPDATE device_vulnerabilities dv SET ticket_id = NULL
+              FROM tickets t
+              WHERE dv.device_id = ${deviceId}::uuid
+                AND dv.ticket_id = t.id
+                AND t.org_id IS DISTINCT FROM ${targetOrgId}::uuid`,
+        );
+
         // Extension tables that must be DELETED (not re-stamped) on org-move: their rows
         // FK a source/config row that stays in the old org, so rewriting org_id would
         // corrupt cross-row consistency. See the extension tenancy docs.

--- a/apps/api/src/services/ticketService.test.ts
+++ b/apps/api/src/services/ticketService.test.ts
@@ -216,6 +216,9 @@ vi.mock('../db/schema', () => ({
   ticketComments: { ticketId: 'ticketId', agentRunId: 'agentRunId' },
   // #4524: moveTicketOrg severs ai_agent_runs.ticket_id in the same transaction.
   aiAgentRuns: { id: 'id', orgId: 'orgId', ticketId: 'ticketId' },
+  // #4645: moveTicketOrg severs device_vulnerabilities.ticket_id in the same
+  // transaction (the ticket-axis twin of the ai_agent_runs detach above).
+  deviceVulnerabilities: { id: 'id', orgId: 'orgId', deviceId: 'deviceId', ticketId: 'ticketId' },
   ticketDrafts: {
     id: 'id', ticketId: 'ticketId', orgId: 'orgId', runId: 'runId', intentId: 'intentId',
     kind: 'kind', content: 'content', state: 'state', supersededBy: 'supersededBy',

--- a/apps/api/src/services/ticketService.ts
+++ b/apps/api/src/services/ticketService.ts
@@ -1,8 +1,8 @@
-import { and, asc, desc, eq, gt, inArray, isNotNull, isNull, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, gt, inArray, isNotNull, isNull, ne, sql } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { matchContactByEmail } from './contacts/crud';
-import { tickets, ticketComments, ticketAlertLinks, organizations, alerts, devices, users, ticketCategories, portalUsers, contacts, ticketStatusEnum, ticketSourceEnum, ticketOutbox, ticketDrafts, actionIntents, aiAgentRuns, type TicketOutboxEvent } from '../db/schema';
+import { tickets, ticketComments, ticketAlertLinks, organizations, alerts, devices, users, ticketCategories, portalUsers, contacts, ticketStatusEnum, ticketSourceEnum, ticketOutbox, ticketDrafts, actionIntents, aiAgentRuns, deviceVulnerabilities, type TicketOutboxEvent } from '../db/schema';
 import { allocateInternalTicketNumber } from './ticketNumbers';
 import { emitTicketEvent } from './ticketEvents';
 import { createAuditLogAsync } from './auditService';
@@ -2365,6 +2365,31 @@ export async function moveTicketOrg(
       .update(aiAgentRuns)
       .set({ ticketId: null })
       .where(eq(aiAgentRuns.ticketId, ticketId));
+    // device_vulnerabilities.ticket_id (#4645): the finding's remediation
+    // ticket link, the ticket-axis twin of #4642's ai_agent_runs detach just
+    // above and the reverse of moveOrg.ts's own device_vulnerabilities
+    // detach on the device axis (below). `device_vulnerabilities.org_id` is
+    // the DEVICE's org and does NOT move with the ticket — findings are
+    // device-scoped, and a device never moves as a side effect of a ticket
+    // move — so once `tickets.org_id` changes below, any finding still
+    // pointing at this ticket resolves to a now-foreign org under RLS (the
+    // link renders as a dead `/tickets#...` URL client-side; nothing
+    // dereferences it server-side today). Same plain single-column
+    // `ON DELETE SET NULL` FK shape as ai_agent_runs.ticket_id (not composite
+    // tenant-FK'd), so nothing here can 23503 — placed alongside the other
+    // ticket_id detach for readability, not because ordering is
+    // load-bearing.
+    //
+    // `org_id IS DISTINCT FROM targetOrgId` (device_vulnerabilities.org_id is
+    // NOT NULL, so this is equivalent to `<>`, kept for consistency with the
+    // identical guard on tickets.requester_contact_id below and on the
+    // device-axis mirror in moveOrg.ts): a finding whose device's org
+    // ALREADY equals the ticket's destination is not stale after the move
+    // and its link is left intact.
+    await tx
+      .update(deviceVulnerabilities)
+      .set({ ticketId: null })
+      .where(and(eq(deviceVulnerabilities.ticketId, ticketId), ne(deviceVulnerabilities.orgId, targetOrgId)));
     // The UPDATE takes the ticket row lock; the currency guard then locks the
     // unbilled monetary children, and the org_id rewrites follow. A throw here
     // rolls this UPDATE back — nothing moves on a block.


### PR DESCRIPTION
## Summary

Fixes #4645. Follow-up to #4642, which fixed the sibling `ai_agent_runs.ticket_id`
gap and explicitly deferred `device_vulnerabilities.ticket_id` pending a product
decision on the right behavior. That decision is now made (option A from the
issue): null the FK on divergence, consistent with #4642's precedent and with
the device-id detach `moveTicketOrg` already performs on `tickets.deviceId`.

**FK shape** (confirmed in `apps/api/src/db/schema/vulnerabilityManagement.ts`):
`device_vulnerabilities.ticket_id` is a **plain single-column** FK to
`tickets.id`, `ON DELETE SET NULL` — **not** the composite `(x, org_id) ->
tickets(id, org_id)` tenant-FK shape used elsewhere in this cascade. The table
**does carry a denormalized `org_id`** column (the device's org). Both facts
together mean neither statement below can ever `23503` — this is a
tenancy-hygiene fix, not a transaction-correctness one.

## Both axes, one PR

**Ticket axis** (`moveTicketOrg`, `apps/api/src/services/ticketService.ts`): a
finding's remediation ticket moves to another org while the finding stays with
its device — `device_vulnerabilities.org_id` is the **device's** org and is
never touched by a ticket move. Detach placed alongside the existing
`ai_agent_runs.ticket_id` detach (#4642), guarded by `org_id IS DISTINCT FROM
targetOrgId` so a finding whose device *already* lives in the ticket's
destination org (a legitimate, if unusual, prior state) is left untouched.

**Device axis** (`apps/api/src/routes/devices/moveOrg.ts` +
`breeze_cascade_device_org_id()`): `device_vulnerabilities` is already a
member of `getDeviceOrgDenormalizedTables()` / `breeze_device_child_orgid_tables()`,
so a finding's `org_id` always follows its device. Its remediation ticket does
**not**: `POST /vulnerabilities/tickets` (`apps/api/src/routes/vulnerabilities.ts`)
creates the ticket org-scoped only and never sets `tickets.device_id`, so the
same generic re-stamp loop (which *does* move any ticket bound to the moved
device) never reaches it — it stays behind in the source org.

The device-axis detach is placed **after** the generic re-stamp loop —
opposite the ordering used by the `scope_ticket_id` tombstones in the same
function — specifically so it compares against the referenced ticket's
**actual, post-restamp** `org_id`. A ticket that happens to be bound to the
*same* moving device is *also* re-stamped to the target org by that same
loop; checking before the loop would see its stale source org and wrongly
null a link that is about to become valid.

## Migration

New `2026-10-08-101000-cascade-device-org-move-vuln-ticket-detach.sql`
`CREATE OR REPLACE`s `breeze_cascade_device_org_id()` with the full body
copied verbatim from `2026-10-08-100900-cascade-device-org-move-ticket-scope.sql`
(the newest prior definition, merged minutes before this branch was cut) plus
the new statement appended after the generic loop. Nothing dropped.

No cascade-list or export-policy registration changes: `device_vulnerabilities`
was already fully registered (org cascade, device cascade, device-org-denormalized,
export policy) before this PR — no new table, no new column.

## Tests

- `apps/api/src/routes/devices/moveOrg.coverage.test.ts` — static statement-shape
  + ordering assertions for both callers (moveOrg.ts and the trigger function,
  the latter resolved dynamically against the newest migration that redefines it).
- `apps/api/src/__tests__/integration/ticket-move-org.integration.test.ts` —
  ticket axis, real Postgres: detaches on a sibling-ticket negative control,
  and a second test proving the `org_id IS DISTINCT FROM` guard leaves an
  already-consistent link alone.
- `apps/api/src/__tests__/integration/deviceMoveOrgVulnerabilityTicketDetach.integration.test.ts`
  (new) — device axis, real Postgres, both callers (the route and a raw
  `UPDATE devices` as the unprivileged `breeze_app` role, mirroring
  `deviceMoveOrgTicketScopeTombstone.integration.test.ts`'s pattern): detaches
  the stale org-scoped ticket, spares a same-device-bound ticket (precision
  control), and leaves an unrelated device/ticket/finding untouched (negative
  control).

## Verification

- `npx tsc --noEmit` (apps/api): clean.
- `pnpm exec eslint` on all touched files: clean.
- Affected unit suites: `ticketService.test.ts` (204 passed), `moveOrg.coverage.test.ts`
  (31 passed), `routes/tickets/moveOrg.test.ts` + `routes/devices/moveOrg.test.ts`
  (42 passed) — single-fork, own isolated `test-stack` (not the shared :5433 stack,
  which had drifted).
- Affected integration suites, real Postgres via `pnpm test-stack up`:
  `ticket-move-org.integration.test.ts` (18 passed, includes the 2 new cases),
  `deviceMoveOrgVulnerabilityTicketDetach.integration.test.ts` (3 passed, new file).
- Regression check on the trigger function replacement:
  `deviceMoveOrgTicketScopeTombstone.integration.test.ts`,
  `deviceMoveOrgIntentScopeTombstone.integration.test.ts`,
  `agentRunMoveSemantics.integration.test.ts` (12 passed) — confirms copying
  the full `breeze_cascade_device_org_id()` body forward didn't regress any
  prior fix in that function.

## Test plan

- [x] Real-Postgres integration tests for both axes, with negative/precision controls
- [x] Static coverage tests locking the statement shape + ordering for both callers
- [x] Typecheck + lint clean
- [x] No cascade/export-policy list changes needed (verified, not just assumed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBxF7C8E5GxFnNcGf6kBVP