### PR TITLE
perf(api): device activity feed — RLS-promotable two-arm predicate + partial indexes

### DIFF
--- a/apps/api/migrations/2026-10-09-000100-audit-logs-device-feed-partial-indexes.sql
+++ b/apps/api/migrations/2026-10-09-000100-audit-logs-device-feed-partial-indexes.sql
@@ -1,0 +1,45 @@
+-- @no-transaction
+-- Device activity feed under RLS: partial indexes over the non-agent slice of
+-- audit_logs (apps/api/src/routes/devices/events.ts).
+--
+-- Why the 2026-06-21 feed indexes never helped in production: the feed runs as
+-- breeze_app with RLS forced, and under a security qual Postgres only promotes a
+-- clause to an index condition when it is leakproof. The OR arm
+-- `details->>'deviceId' = $device` calls jsonb_object_field_text (not leakproof),
+-- which poisons the whole `(resource_id = X OR details->>... = X)` clause;
+-- `action LIKE ...` (textlike) and `actor_type IN (...)` (enum_eq) are not
+-- leakproof either. The only promotable clause left was `org_id = $org`, so every
+-- device page load walked the org's entire audit history through
+-- audit_logs_org_timestamp_idx: 2.4M rows / 4 GB for the largest US org, 90 s
+-- mean, 13+ min worst case, two parallel workers saturating the 1-vCPU managed
+-- DB and exhausting its connection slots (2026-09-03).
+--
+-- 99% of audit_logs rows are agent telemetry (actor_type 'agent':
+-- agent.logs.submit, agent.sessions.submit, ...) and the feed never wants them:
+-- the largest US org has ~300 non-agent rows per 30 days against 1.67M total.
+--
+-- The route now splits the feed into two arms with `actor_type <> 'agent'` as a
+-- top-level predicate. Partial-index predicate proof is static, so the
+-- non-leakproof enum_ne is fine there; the index *conditions* below are uuid_eq,
+-- which is leakproof:
+--
+--   * (resource_id, timestamp DESC) WHERE actor_type <> 'agent'
+--       deliberate-action feed (device overview): resource_id = device.
+--   * (org_id, timestamp DESC) WHERE actor_type <> 'agent' AND details ? 'deviceId'
+--       rows that reference the device only through details.deviceId
+--       (device.command.queue, remote sessions): org_id = device's org, then
+--       filter. The extra `details ? 'deviceId'` predicate matters: the org's
+--       non-agent history alone was ~700 rows / 500 heap pages on US and cost
+--       66 s under IO saturation; only a handful of those rows carry deviceId.
+--
+-- Both are a fraction of a percent of the table. CREATE INDEX CONCURRENTLY avoids the SHARE lock on
+-- a table every route writes to; IF NOT EXISTS keeps re-application a no-op
+-- (US prod had both created by hand on 2026-09-03, ahead of the release).
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS audit_logs_device_feed_resource_idx
+  ON audit_logs (resource_id, "timestamp" DESC)
+  WHERE actor_type <> 'agent';
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS audit_logs_device_feed_details_idx
+  ON audit_logs (org_id, "timestamp" DESC)
+  WHERE actor_type <> 'agent' AND details ? 'deviceId';

--- a/apps/api/migrations/2026-10-09-000100-audit-logs-device-feed-partial-indexes.sql
+++ b/apps/api/migrations/2026-10-09-000100-audit-logs-device-feed-partial-indexes.sql
@@ -25,16 +25,24 @@
 --
 --   * (resource_id, timestamp DESC) WHERE actor_type <> 'agent'
 --       deliberate-action feed (device overview): resource_id = device.
---   * (org_id, timestamp DESC) WHERE actor_type <> 'agent' AND details ? 'deviceId'
+--   * (org_id, timestamp DESC) WHERE details ? 'deviceId'
 --       rows that reference the device only through details.deviceId
 --       (device.command.queue, remote sessions): org_id = device's org, then
---       filter. The extra `details ? 'deviceId'` predicate matters: the org's
---       non-agent history alone was ~700 rows / 500 heap pages on US and cost
---       66 s under IO saturation; only a handful of those rows carry deviceId.
+--       filter. Keyed on the JSONB key alone, with no actor predicate, so the
+--       arm keeps exactly the old OR's semantics for every actor type. Rows
+--       carrying deviceId in details are rare (51 in the largest US org, 48 kB
+--       index); the org's whole non-agent history, by contrast, was ~700 rows /
+--       500 heap pages and cost 66 s under IO saturation.
 --
--- Both are a fraction of a percent of the table. CREATE INDEX CONCURRENTLY avoids the SHARE lock on
--- a table every route writes to; IF NOT EXISTS keeps re-application a no-op
--- (US prod had both created by hand on 2026-09-03, ahead of the release).
+-- Both are a fraction of a percent of the table. CREATE INDEX CONCURRENTLY
+-- avoids the SHARE lock on a table every route writes to; IF NOT EXISTS keeps
+-- re-application a no-op (US prod had both created by hand on 2026-09-03,
+-- ahead of the release).
+--
+-- An interrupted CONCURRENTLY build leaves an INVALID index behind, which
+-- IF NOT EXISTS would then silently accept, so the final DO block fails the
+-- migration loudly in that state. Recovery: DROP INDEX CONCURRENTLY <name>,
+-- then let autoMigrate re-run this file.
 
 CREATE INDEX CONCURRENTLY IF NOT EXISTS audit_logs_device_feed_resource_idx
   ON audit_logs (resource_id, "timestamp" DESC)
@@ -42,4 +50,20 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS audit_logs_device_feed_resource_idx
 
 CREATE INDEX CONCURRENTLY IF NOT EXISTS audit_logs_device_feed_details_idx
   ON audit_logs (org_id, "timestamp" DESC)
-  WHERE actor_type <> 'agent' AND details ? 'deviceId';
+  WHERE details ? 'deviceId';
+
+DO $$
+DECLARE
+  bad text;
+BEGIN
+  SELECT string_agg(c.relname, ', ')
+    INTO bad
+    FROM pg_index i
+    JOIN pg_class c ON c.oid = i.indexrelid
+   WHERE i.indrelid = 'audit_logs'::regclass
+     AND c.relname IN ('audit_logs_device_feed_resource_idx', 'audit_logs_device_feed_details_idx')
+     AND NOT i.indisvalid;
+  IF bad IS NOT NULL THEN
+    RAISE EXCEPTION 'audit_logs device-feed index build left INVALID index(es): % — run DROP INDEX CONCURRENTLY on each and re-apply this migration', bad;
+  END IF;
+END $$;

--- a/apps/api/src/__tests__/devices.endpoints.test.ts
+++ b/apps/api/src/__tests__/devices.endpoints.test.ts
@@ -87,6 +87,8 @@ vi.mock('../db', () => ({
 }));
 
 vi.mock('../db/schema', () => ({
+  // routes/devices/events.ts builds module-level SQL fragments from auditLogs at import time (#4835).
+  auditLogs: { actorType: 'actorType', details: 'details', timestamp: 'timestamp', action: 'action' },
   users: { id: 'id', email: 'email', name: 'name', status: 'status', mfaEnabled: 'mfaEnabled' },
   devices: { id: 'id', orgId: 'orgId' },
   deviceCommands: { deviceId: 'deviceId', status: 'status', createdAt: 'createdAt' },

--- a/apps/api/src/__tests__/integration/deviceEventsFeedIndexes.integration.test.ts
+++ b/apps/api/src/__tests__/integration/deviceEventsFeedIndexes.integration.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Device activity feed — RLS index promotability contract (2026-09-03 US incident).
+ *
+ * What only a real Postgres, as the unprivileged `breeze_app` role, can prove:
+ * under forced RLS the planner promotes a clause to an index condition only when
+ * it is leakproof. The old one-query feed, `(resource_id = X OR
+ * details->>'deviceId' = X)`, contains jsonb_object_field_text (not leakproof)
+ * and so could only ever use audit_logs_org_timestamp_idx — a walk of the org's
+ * whole audit history per device page load (2.4M rows, 13-minute queries and
+ * connection-slot exhaustion on the US managed DB).
+ *
+ * The route now issues two arms (routes/devices/events.ts). This suite asserts,
+ * with EXPLAIN as breeze_app inside an org-scoped access context and seq scans
+ * disabled, that:
+ *   1. the deliberate-action resource arm is served by the partial index
+ *      audit_logs_device_feed_resource_idx (predicate `actor_type <> 'agent'`);
+ *   2. the details arm is served by audit_logs_device_feed_details_idx
+ *      (predicate `actor_type <> 'agent' AND details ? 'deviceId'`);
+ *   3. the unfiltered resource arm is served by an index keyed on resource_id.
+ * With enable_seqscan off, any usable index beats a seq scan by ~1e10 cost, so
+ * a seq scan in the plan means the clause is NOT promotable under RLS — exactly
+ * the regression this guards against. It also proves the functional contract
+ * that the two arms together still return the details-only rows
+ * (device.command.queue) while the deliberate feed drops agent telemetry.
+ */
+import './setup';
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { and, eq, or, sql } from 'drizzle-orm';
+import { randomUUID } from 'crypto';
+import { db, withDbAccessContext } from '../../db';
+import { getTestDb } from './setup';
+import { auditLogs } from '../../db/schema';
+import { DETAILS_HAS_DEVICE_ID, NON_AGENT_ACTOR, buildActionConditions } from '../../routes/devices/events';
+import { createPartner, createOrganization } from './db-utils';
+
+const SYSTEM_ACTOR = '00000000-0000-0000-0000-000000000000';
+
+function planText(rows: unknown[]): string {
+  return rows.map((r) => Object.values(r as Record<string, unknown>).join(' ')).join('\n');
+}
+
+describe('device events feed — partial indexes are usable under RLS (breeze_app)', () => {
+  let orgId: string;
+  let deviceId: string;
+  let commandId: string;
+
+  // beforeEach, not beforeAll: the harness TRUNCATEs on every test (audit_logs
+  // included, via the organizations cascade).
+  beforeEach(async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    orgId = org.id;
+    deviceId = randomUUID();
+    commandId = randomUUID();
+
+    // Enough rows that the planner's choice is not a coin toss on a tiny
+    // table: the org index sees ~3,800 rows, the device's resource index ~600,
+    // the actor-partial resource index ~200, the details index 1. (Production
+    // is far more skewed still.)
+    const telemetry = (targetDevice: string) => ({
+      orgId,
+      actorType: 'agent' as const,
+      actorId: targetDevice,
+      action: 'agent.logs.submit',
+      resourceType: 'device',
+      resourceId: targetDevice,
+      result: 'success' as const,
+    });
+    const otherDevices = Array.from({ length: 30 }, () => randomUUID());
+    const otherDevice = (i: number) => otherDevices[i % otherDevices.length] as string;
+    // Non-agent rows on other devices, with no deviceId in details: they sit in
+    // the actor-partial resource index but not in the details index, so the
+    // details arm has a reason to prefer its own index.
+    const humanNoise = (i: number) => ({
+      orgId,
+      actorType: 'user' as const,
+      actorId: randomUUID(),
+      action: 'device.settings.update',
+      resourceType: 'device',
+      resourceId: otherDevice(i),
+      details: { field: 'displayName' },
+      result: 'success' as const,
+    });
+    await getTestDb()
+      .insert(auditLogs)
+      .values([
+        ...Array.from({ length: 600 }, () => telemetry(deviceId)),
+        ...Array.from({ length: 3000 }, (_, i) => telemetry(otherDevice(i))),
+        ...Array.from({ length: 200 }, (_, i) => humanNoise(i)),
+      ]);
+
+    await getTestDb()
+      .insert(auditLogs)
+      .values([
+        // Deliberate route audit: resource = device.
+        {
+          orgId,
+          actorType: 'user',
+          actorId: randomUUID(),
+          action: 'script.execute',
+          resourceType: 'device',
+          resourceId: deviceId,
+          result: 'success',
+        },
+        // Details-only linkage: resource = the queued command, device in details.
+        {
+          orgId,
+          actorType: 'user',
+          actorId: randomUUID(),
+          action: 'device.command.queue',
+          resourceType: 'device_command',
+          resourceId: commandId,
+          details: { deviceId, type: 'reboot' },
+          result: 'success',
+        },
+        // Automated dispatch: system actor, resource = device.
+        {
+          orgId,
+          actorType: 'system',
+          actorId: SYSTEM_ACTOR,
+          action: 'agent.command.install_patches',
+          resourceType: 'device',
+          resourceId: deviceId,
+          result: 'success',
+        },
+      ]);
+    await getTestDb().execute(sql`ANALYZE audit_logs`);
+  });
+
+  function inOrgContext<T>(fn: () => Promise<T>): Promise<T> {
+    return withDbAccessContext(
+      { scope: 'organization', orgId, accessibleOrgIds: [orgId], accessiblePartnerIds: [] },
+      fn
+    );
+  }
+
+  const deliberate = () => or(...buildActionConditions(['script.', 'device.command'], true))!;
+
+  const resourceArm = (withActorGuard: boolean) =>
+    and(
+      eq(auditLogs.orgId, orgId),
+      ...(withActorGuard ? [deliberate()] : []),
+      eq(auditLogs.resourceId, deviceId),
+      ...(withActorGuard ? [NON_AGENT_ACTOR] : [])
+    )!;
+
+  const detailsArm = () =>
+    and(
+      eq(auditLogs.orgId, orgId),
+      deliberate(),
+      NON_AGENT_ACTOR,
+      DETAILS_HAS_DEVICE_ID,
+      sql`${auditLogs.details}->>'deviceId' = ${deviceId}`,
+      sql`${auditLogs.resourceId} IS DISTINCT FROM ${deviceId}::uuid`
+    )!;
+
+  async function explain(where: ReturnType<typeof and>): Promise<string> {
+    return inOrgContext(async () => {
+      await db.execute(sql`SET LOCAL enable_seqscan = off`);
+      const q = db
+        .select({ id: auditLogs.id })
+        .from(auditLogs)
+        .where(where)
+        .orderBy(sql`${auditLogs.timestamp} DESC, ${auditLogs.id} DESC`)
+        .limit(10);
+      const rows = await db.execute(sql`EXPLAIN ${q.getSQL()}`);
+      return planText(Array.from(rows as Iterable<unknown>));
+    });
+  }
+
+  it('deliberate resource arm uses the actor-partial index, not a scan of the org', async () => {
+    const plan = await explain(resourceArm(true));
+    expect(plan).toContain('audit_logs_device_feed_resource_idx');
+    expect(plan).not.toContain('Seq Scan on audit_logs');
+    expect(plan).not.toContain('audit_logs_org_timestamp_idx');
+  });
+
+  it('details arm uses the details-partial org index', async () => {
+    const plan = await explain(detailsArm());
+    expect(plan).toContain('audit_logs_device_feed_details_idx');
+    expect(plan).not.toContain('Seq Scan on audit_logs');
+  });
+
+  it('unfiltered resource arm (Activities tab) is served by a resource_id index', async () => {
+    const plan = await explain(resourceArm(false));
+    expect(plan).toMatch(/audit_logs_resource_(type_)?id_timestamp_idx/);
+    expect(plan).not.toContain('Seq Scan on audit_logs');
+  });
+
+  it('the two arms together return the details-only row and drop agent telemetry', async () => {
+    const keys = await inOrgContext(async () => {
+      const [a, b] = await Promise.all([
+        db.select({ action: auditLogs.action }).from(auditLogs).where(resourceArm(true)),
+        db.select({ action: auditLogs.action }).from(auditLogs).where(detailsArm()),
+      ]);
+      return [...a, ...b].map((r) => r.action).sort();
+    });
+    expect(keys).toEqual(['agent.command.install_patches', 'device.command.queue', 'script.execute']);
+  });
+
+  it('the unfiltered resource arm still includes agent rows', async () => {
+    const keys = await inOrgContext(async () => {
+      const rows = await db.select({ action: auditLogs.action }).from(auditLogs).where(resourceArm(false));
+      return rows.map((r) => r.action).sort();
+    });
+    expect(new Set(keys)).toEqual(new Set(['agent.command.install_patches', 'agent.logs.submit', 'script.execute']));
+    expect(keys.filter((k) => k === 'agent.logs.submit')).toHaveLength(600);
+  });
+});

--- a/apps/api/src/__tests__/integration/deviceEventsFeedIndexes.integration.test.ts
+++ b/apps/api/src/__tests__/integration/deviceEventsFeedIndexes.integration.test.ts
@@ -15,7 +15,7 @@
  *   1. the deliberate-action resource arm is served by the partial index
  *      audit_logs_device_feed_resource_idx (predicate `actor_type <> 'agent'`);
  *   2. the details arm is served by audit_logs_device_feed_details_idx
- *      (predicate `actor_type <> 'agent' AND details ? 'deviceId'`);
+ *      (predicate `details ? 'deviceId'`);
  *   3. the unfiltered resource arm is served by an index keyed on resource_id.
  * With enable_seqscan off, any usable index beats a seq scan by ~1e10 cost, so
  * a seq scan in the plan means the clause is NOT promotable under RLS — exactly
@@ -56,7 +56,7 @@ describe('device events feed — partial indexes are usable under RLS (breeze_ap
 
     // Enough rows that the planner's choice is not a coin toss on a tiny
     // table: the org index sees ~3,800 rows, the device's resource index ~600,
-    // the actor-partial resource index ~200, the details index 1. (Production
+    // the actor-partial resource index ~200, the details index 2. (Production
     // is far more skewed still.)
     const telemetry = (targetDevice: string) => ({
       orgId,
@@ -124,6 +124,19 @@ describe('device events feed — partial indexes are usable under RLS (breeze_ap
           resourceId: deviceId,
           result: 'success',
         },
+        // Agent-actor row linked ONLY through details.deviceId (no such writer
+        // exists today; this pins that the details arm does not exclude actors,
+        // so one appearing later still surfaces on the Activities tab).
+        {
+          orgId,
+          actorType: 'agent',
+          actorId: deviceId,
+          action: 'backup.job.result',
+          resourceType: 'backup_job',
+          resourceId: randomUUID(),
+          details: { deviceId, status: 'completed' },
+          result: 'success',
+        },
       ]);
     await getTestDb().execute(sql`ANALYZE audit_logs`);
   });
@@ -145,11 +158,10 @@ describe('device events feed — partial indexes are usable under RLS (breeze_ap
       ...(withActorGuard ? [NON_AGENT_ACTOR] : [])
     )!;
 
-  const detailsArm = () =>
+  const detailsArm = (withActorGuard: boolean) =>
     and(
       eq(auditLogs.orgId, orgId),
-      deliberate(),
-      NON_AGENT_ACTOR,
+      ...(withActorGuard ? [deliberate(), NON_AGENT_ACTOR] : []),
       DETAILS_HAS_DEVICE_ID,
       sql`${auditLogs.details}->>'deviceId' = ${deviceId}`,
       sql`${auditLogs.resourceId} IS DISTINCT FROM ${deviceId}::uuid`
@@ -176,10 +188,12 @@ describe('device events feed — partial indexes are usable under RLS (breeze_ap
     expect(plan).not.toContain('audit_logs_org_timestamp_idx');
   });
 
-  it('details arm uses the details-partial org index', async () => {
-    const plan = await explain(detailsArm());
-    expect(plan).toContain('audit_logs_device_feed_details_idx');
-    expect(plan).not.toContain('Seq Scan on audit_logs');
+  it('details arm uses the details-partial org index (deliberate and unfiltered)', async () => {
+    for (const guard of [true, false]) {
+      const plan = await explain(detailsArm(guard));
+      expect(plan).toContain('audit_logs_device_feed_details_idx');
+      expect(plan).not.toContain('Seq Scan on audit_logs');
+    }
   });
 
   it('unfiltered resource arm (Activities tab) is served by a resource_id index', async () => {
@@ -192,19 +206,24 @@ describe('device events feed — partial indexes are usable under RLS (breeze_ap
     const keys = await inOrgContext(async () => {
       const [a, b] = await Promise.all([
         db.select({ action: auditLogs.action }).from(auditLogs).where(resourceArm(true)),
-        db.select({ action: auditLogs.action }).from(auditLogs).where(detailsArm()),
+        db.select({ action: auditLogs.action }).from(auditLogs).where(detailsArm(true)),
       ]);
       return [...a, ...b].map((r) => r.action).sort();
     });
     expect(keys).toEqual(['agent.command.install_patches', 'device.command.queue', 'script.execute']);
   });
 
-  it('the unfiltered resource arm still includes agent rows', async () => {
+  it('the unfiltered arms still include agent rows, including one linked only via details', async () => {
     const keys = await inOrgContext(async () => {
-      const rows = await db.select({ action: auditLogs.action }).from(auditLogs).where(resourceArm(false));
-      return rows.map((r) => r.action).sort();
+      const [a, b] = await Promise.all([
+        db.select({ action: auditLogs.action }).from(auditLogs).where(resourceArm(false)),
+        db.select({ action: auditLogs.action }).from(auditLogs).where(detailsArm(false)),
+      ]);
+      return [...a, ...b].map((r) => r.action).sort();
     });
-    expect(new Set(keys)).toEqual(new Set(['agent.command.install_patches', 'agent.logs.submit', 'script.execute']));
+    expect(new Set(keys)).toEqual(
+      new Set(['agent.command.install_patches', 'agent.logs.submit', 'backup.job.result', 'device.command.queue', 'script.execute'])
+    );
     expect(keys.filter((k) => k === 'agent.logs.submit')).toHaveLength(600);
   });
 });

--- a/apps/api/src/routes/devices.test.ts
+++ b/apps/api/src/routes/devices.test.ts
@@ -175,6 +175,8 @@ vi.mock('../services/deviceUninstallDrain', () => ({
 }));
 
 vi.mock('../db/schema', () => ({
+  // routes/devices/events.ts builds module-level SQL fragments from auditLogs at import time (#4835).
+  auditLogs: { actorType: 'actorType', details: 'details', timestamp: 'timestamp', action: 'action' },
   devices: { id: 'id', orgId: 'orgId', siteId: 'siteId', status: 'status', hostname: 'hostname', displayName: 'displayName', osType: 'osType', lastSeenAt: 'lastSeenAt', createdAt: 'createdAt', updatedAt: 'updatedAt', tags: 'tags', agentVersion: 'agentVersion' },
   deviceHardware: { deviceId: 'deviceId' },
   deviceReliability: { deviceId: 'deviceId', reliabilityScore: 'reliabilityScore', trendDirection: 'trendDirection' },

--- a/apps/api/src/routes/devices/events.test.ts
+++ b/apps/api/src/routes/devices/events.test.ts
@@ -335,12 +335,13 @@ describe('GET /devices/:id/events — two-arm feed predicate (RLS index promotab
     expect(resource).not.toContain("->>'deviceId'");
   });
 
-  it('details arm carries the JSONB test, the non-agent predicate and the disjointness guard', async () => {
+  it('details arm carries the JSONB key test (the partial-index predicate), the equality, and the disjointness guard', async () => {
     const { details } = await arms('');
-    expect(details).toContain("->>'deviceId'");
     expect(details).toContain("? 'deviceId'");
-    expect(details).toContain("<> 'agent'");
+    expect(details).toContain("->>'deviceId'");
     expect(details).toContain('IS DISTINCT FROM');
+    // Unfiltered feed: no actor is excluded from either arm (old OR semantics).
+    expect(details).not.toContain("<> 'agent'");
   });
 
   it('unfiltered Activities feed keeps agent rows in the resource arm (no actor exclusion)', async () => {
@@ -348,10 +349,11 @@ describe('GET /devices/:id/events — two-arm feed predicate (RLS index promotab
     expect(resource).not.toContain("<> 'agent'");
   });
 
-  it('deliberate-action feed adds actor_type <> agent to the resource arm so the partial index applies', async () => {
-    const { resource } = await arms('?actions=script.,device.command&includeAutomated=true');
+  it('deliberate-action feed adds actor_type <> agent to both arms (partial index on the resource arm)', async () => {
+    const { resource, details } = await arms('?actions=script.,device.command&includeAutomated=true');
     expect(resource).toContain("<> 'agent'");
     expect(resource).toContain('LIKE');
+    expect(details).toContain("<> 'agent'");
   });
 
   it('includeAutomated alone also counts as the deliberate feed', async () => {
@@ -365,24 +367,34 @@ describe('GET /devices/:id/events — two-arm feed predicate (RLS index promotab
 });
 
 describe('mergeFeedPage (two-arm page merge)', () => {
-  const row = (id: string, ts: string) => ({ id, timestamp: new Date(ts) });
+  // sortKey mirrors FEED_SORT_KEY: to_char(timestamp, 'YYYYMMDDHH24MISSUS').
+  const row = (id: string, sortKey: string) => ({ id, sortKey });
 
   it('interleaves both arms newest-first and cuts the page', () => {
-    const a = [row('a3', '2026-01-03T00:00:00Z'), row('a1', '2026-01-01T00:00:00Z')];
-    const b = [row('b2', '2026-01-02T00:00:00Z')];
+    const a = [row('a3', '20260103000000000000'), row('a1', '20260101000000000000')];
+    const b = [row('b2', '20260102000000000000')];
     expect(mergeFeedPage(a, b, 0, 10).map((r) => r.id)).toEqual(['a3', 'b2', 'a1']);
     expect(mergeFeedPage(a, b, 1, 1).map((r) => r.id)).toEqual(['b2']);
     expect(mergeFeedPage(a, b, 2, 5).map((r) => r.id)).toEqual(['a1']);
   });
 
-  it('breaks timestamp ties by id DESC, matching the SQL ORDER BY', () => {
-    const a = [row('aaaa', '2026-01-01T00:00:00Z')];
-    const b = [row('bbbb', '2026-01-01T00:00:00Z')];
+  it('orders by the microsecond key, not the millisecond Date, so it matches SQL', () => {
+    // Same millisecond (…123ms), different microseconds: SQL puts the later
+    // microsecond first. A Date-based merge would see a tie and fall through to
+    // the id tiebreak, putting 'zzzz' first — wrong.
+    const a = [row('zzzz', '20260101000000123400')];
+    const b = [row('aaaa', '20260101000000123900')];
+    expect(mergeFeedPage(a, b, 0, 10).map((r) => r.id)).toEqual(['aaaa', 'zzzz']);
+  });
+
+  it('breaks exact timestamp ties by id DESC, matching the SQL ORDER BY', () => {
+    const a = [row('aaaa', '20260101000000000000')];
+    const b = [row('bbbb', '20260101000000000000')];
     expect(mergeFeedPage(a, b, 0, 10).map((r) => r.id)).toEqual(['bbbb', 'aaaa']);
   });
 
   it('applies the offset even when one arm is empty', () => {
-    const a = [row('a3', '2026-01-03T00:00:00Z'), row('a2', '2026-01-02T00:00:00Z'), row('a1', '2026-01-01T00:00:00Z')];
+    const a = [row('a3', '20260103000000000000'), row('a2', '20260102000000000000'), row('a1', '20260101000000000000')];
     expect(mergeFeedPage(a, [], 1, 1).map((r) => r.id)).toEqual(['a2']);
     expect(mergeFeedPage([], a, 2, 5).map((r) => r.id)).toEqual(['a1']);
   });

--- a/apps/api/src/routes/devices/events.test.ts
+++ b/apps/api/src/routes/devices/events.test.ts
@@ -23,9 +23,9 @@ vi.mock('../../db', () => ({
             feedWhereArgs.push(cond);
             return {
               orderBy: vi.fn(() => ({
-                limit: vi.fn(() => ({
-                  offset: vi.fn().mockResolvedValue([])
-                }))
+                // Each feed arm is a bounded `limit(offset + limit)` read; the
+                // page is cut client-side by mergeFeedPage. No `.offset()`.
+                limit: vi.fn().mockResolvedValue([])
               }))
             };
           })
@@ -86,7 +86,7 @@ vi.mock('./helpers', () => ({
   SITE_ACCESS_DENIED: Symbol('SITE_ACCESS_DENIED'),
 }));
 
-import { eventsRoutes, likePrefixPattern, formatActionMessage } from './events';
+import { eventsRoutes, likePrefixPattern, formatActionMessage, mergeFeedPage } from './events';
 
 describe('likePrefixPattern (action-prefix LIKE escaping)', () => {
   it('appends a trailing wildcard for a clean dotted prefix', () => {
@@ -253,7 +253,8 @@ describe('GET /devices/:id/events validation', () => {
     expect(res.status).toBe(200);
     const json = (await res.json()) as { pagination: { total: number | null } };
     expect(json.pagination.total).toBe(0);
-    expect(countQueryCalls).toHaveBeenCalledTimes(1);
+    // One count per feed arm (resource arm + details arm), summed.
+    expect(countQueryCalls).toHaveBeenCalledTimes(2);
   });
 
   it('rejects an invalid withTotal value with 400', async () => {
@@ -289,9 +290,100 @@ describe("GET /devices/:id/events — org scoping of the audit feed (BREEZE-B)",
     // this predicate). Assert the org column and the device's org id are both
     // in the WHERE, so removing the scoping fails here rather than silently
     // regressing to a seq scan in production.
-    expect(feedWhereArgs).toHaveLength(1);
-    const serialized = JSON.stringify(feedWhereArgs[0]);
-    expect(serialized).toContain('org_id');
-    expect(serialized).toContain('org-123');
+    expect(feedWhereArgs).toHaveLength(2);
+    for (const arm of feedWhereArgs) {
+      const serialized = JSON.stringify(arm);
+      expect(serialized).toContain('org_id');
+      expect(serialized).toContain('org-123');
+    }
+  });
+});
+
+// The feed runs as breeze_app under forced RLS, where only leakproof clauses
+// can become index conditions. These tests pin the SHAPE of each arm's WHERE so
+// a refactor cannot quietly re-merge the arms into the one-query form that
+// walked the whole org (2.4M rows, 13-minute page loads on US, 2026-09-03).
+// The runtime proof that the shapes actually hit the partial indexes lives in
+// __tests__/integration/deviceEventsFeedIndexes.integration.test.ts.
+describe('GET /devices/:id/events — two-arm feed predicate (RLS index promotability)', () => {
+  let app: Hono;
+  const DEVICE = '11111111-1111-1111-1111-111111111111';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    feedWhereArgs.length = 0;
+    app = new Hono();
+    app.route('/devices', eventsRoutes);
+  });
+
+  async function arms(query: string) {
+    const res = await app.request(`/devices/${DEVICE}/events${query}`, {
+      method: 'GET',
+      headers: { Authorization: 'Bearer token' },
+    });
+    expect(res.status).toBe(200);
+    expect(feedWhereArgs).toHaveLength(2);
+    return {
+      resource: JSON.stringify(feedWhereArgs[0]),
+      details: JSON.stringify(feedWhereArgs[1]),
+    };
+  }
+
+  it('resource arm keys on resource_id only — never the non-leakproof details->>deviceId', async () => {
+    const { resource } = await arms('');
+    expect(resource).toContain('resource_id');
+    expect(resource).not.toContain("->>'deviceId'");
+  });
+
+  it('details arm carries the JSONB test, the non-agent predicate and the disjointness guard', async () => {
+    const { details } = await arms('');
+    expect(details).toContain("->>'deviceId'");
+    expect(details).toContain("? 'deviceId'");
+    expect(details).toContain("<> 'agent'");
+    expect(details).toContain('IS DISTINCT FROM');
+  });
+
+  it('unfiltered Activities feed keeps agent rows in the resource arm (no actor exclusion)', async () => {
+    const { resource } = await arms('?limit=50&withTotal=true');
+    expect(resource).not.toContain("<> 'agent'");
+  });
+
+  it('deliberate-action feed adds actor_type <> agent to the resource arm so the partial index applies', async () => {
+    const { resource } = await arms('?actions=script.,device.command&includeAutomated=true');
+    expect(resource).toContain("<> 'agent'");
+    expect(resource).toContain('LIKE');
+  });
+
+  it('includeAutomated alone also counts as the deliberate feed', async () => {
+    const { resource } = await arms('?includeAutomated=true');
+    expect(resource).toContain("<> 'agent'");
+    // The automated arm is system-only; the agent's own command-result rows
+    // are telemetry.
+    expect(resource).toContain("= 'system'");
+    expect(resource).not.toContain("'agent')");
+  });
+});
+
+describe('mergeFeedPage (two-arm page merge)', () => {
+  const row = (id: string, ts: string) => ({ id, timestamp: new Date(ts) });
+
+  it('interleaves both arms newest-first and cuts the page', () => {
+    const a = [row('a3', '2026-01-03T00:00:00Z'), row('a1', '2026-01-01T00:00:00Z')];
+    const b = [row('b2', '2026-01-02T00:00:00Z')];
+    expect(mergeFeedPage(a, b, 0, 10).map((r) => r.id)).toEqual(['a3', 'b2', 'a1']);
+    expect(mergeFeedPage(a, b, 1, 1).map((r) => r.id)).toEqual(['b2']);
+    expect(mergeFeedPage(a, b, 2, 5).map((r) => r.id)).toEqual(['a1']);
+  });
+
+  it('breaks timestamp ties by id DESC, matching the SQL ORDER BY', () => {
+    const a = [row('aaaa', '2026-01-01T00:00:00Z')];
+    const b = [row('bbbb', '2026-01-01T00:00:00Z')];
+    expect(mergeFeedPage(a, b, 0, 10).map((r) => r.id)).toEqual(['bbbb', 'aaaa']);
+  });
+
+  it('applies the offset even when one arm is empty', () => {
+    const a = [row('a3', '2026-01-03T00:00:00Z'), row('a2', '2026-01-02T00:00:00Z'), row('a1', '2026-01-01T00:00:00Z')];
+    expect(mergeFeedPage(a, [], 1, 1).map((r) => r.id)).toEqual(['a2']);
+    expect(mergeFeedPage([], a, 2, 5).map((r) => r.id)).toEqual(['a1']);
   });
 });

--- a/apps/api/src/routes/devices/events.ts
+++ b/apps/api/src/routes/devices/events.ts
@@ -70,13 +70,52 @@ export function buildActionConditions(
     // route-audit twin. Manual commands (actor_type 'user') are excluded —
     // they're already represented by their richer route audit (e.g.
     // script.execute, device.patch.*, device.software.*), so this avoids
-    // double-listing. The 'agent' arm is defensive; only 'system' is emitted
-    // today.
+    // double-listing. 'agent' is excluded too: the device agent's own
+    // `agent.command.result.submit` rows are telemetry (resource = the command,
+    // actor = the agent), and the deliberate feed adds `actor_type <> 'agent'`
+    // at the top level so its partial index applies — see the feed predicate
+    // comment in the route below.
     actionClauses.push(
-      sql`(${auditLogs.action} LIKE ${likePrefixPattern('agent.command.')} AND ${auditLogs.actorType} IN ('system','agent'))`
+      sql`(${auditLogs.action} LIKE ${likePrefixPattern('agent.command.')} AND ${auditLogs.actorType} = 'system')`
     );
   }
   return actionClauses;
+}
+
+// Excludes device-agent telemetry (agent.logs.submit, agent.sessions.submit,
+// ...), which is ~99% of audit_logs. Written as an inline literal on purpose: the
+// partial indexes in 2026-10-09-000100-audit-logs-device-feed-partial-indexes.sql
+// carry this exact predicate, and the planner can only prove them usable when
+// the clause is a constant in the query text (a bound parameter would only be
+// provable under a custom plan).
+export const NON_AGENT_ACTOR: SQL = sql`${auditLogs.actorType} <> 'agent'`;
+
+// Second half of the audit_logs_device_feed_details_idx predicate. Implied by
+// the `details->>'deviceId' = X` test the details arm also applies, but the
+// planner cannot derive one from the other, so it is stated explicitly.
+export const DETAILS_HAS_DEVICE_ID: SQL = sql`${auditLogs.details} ? 'deviceId'`;
+
+// Merge the two feed arms (each already ordered timestamp DESC, id DESC and
+// bounded to offset+limit rows) and cut the requested page. Exact for any
+// offset because the top-(offset+limit) of the union is contained in the union
+// of each arm's top-(offset+limit).
+export function mergeFeedPage<T extends { timestamp: Date; id: string }>(
+  resourceRows: T[],
+  detailsRows: T[],
+  offset: number,
+  limit: number
+): T[] {
+  const merged =
+    detailsRows.length === 0
+      ? resourceRows
+      : resourceRows.length === 0
+        ? detailsRows
+        : [...resourceRows, ...detailsRows].sort(
+            (a, b) =>
+              b.timestamp.getTime() - a.timestamp.getTime() ||
+              (a.id === b.id ? 0 : a.id < b.id ? 1 : -1)
+          );
+  return merged.slice(offset, offset + limit);
 }
 
 const eventsQuerySchema = z.object({
@@ -145,44 +184,61 @@ eventsRoutes.get(
       return c.json({ error: 'Device not found' }, 404);
     }
 
-    // Scope to the device's org FIRST. This is a performance fix, not just
-    // defense-in-depth (BREEZE-B: 25s holds, 5 users).
+    // ---- Feed predicate ---------------------------------------------------
     //
-    // The `details->>'deviceId'` arm below cannot use its index when RLS is
-    // enforced: `jsonb_object_field_text` (`->>`) is NOT leakproof
-    // (pg_proc.proleakproof = false), so Postgres may not evaluate it before the
-    // RLS security qual, which means it can never become an index condition.
-    // audit_logs_details_device_id_idx therefore exists and is simply ignored on
-    // the app's connection. Measured on 800k rows as breeze_app: 11,938ms
-    // (Parallel Seq Scan, 266k rows filtered per worker). The SAME query as a
-    // superuser, where RLS does not apply, uses the index and runs in 0.044ms —
-    // so this is an RLS interaction, not a missing index. `uuid_eq` IS
-    // leakproof, which is why the resource_id arm alone indexes fine (3.9ms).
+    // The feed runs as breeze_app with RLS forced on audit_logs. Under a
+    // security qual Postgres only promotes a clause to an INDEX CONDITION when
+    // it is leakproof; everything else is evaluated after the policy, as a
+    // plain filter. That rules out most of this predicate: `details->>'deviceId'`
+    // (jsonb_object_field_text), `action LIKE ...` (textlike) and
+    // `actor_type IN (...)` (enum_eq) are all non-leakproof, and an OR that
+    // contains one of them is non-leakproof as a whole. Only `org_id = X` and
+    // `resource_id = X` (uuid_eq) can drive an index.
     //
-    // An org_id equality is leakproof and indexable, so it bounds the scan to
-    // one org via audit_logs_org_timestamp_idx: 11,938ms -> 178ms (~67x).
+    // The original single query, `(resource_id = X OR details->>'deviceId' = X)`,
+    // therefore had exactly one index path: audit_logs_org_timestamp_idx, i.e.
+    // the org's ENTIRE audit history filtered row by row. On the largest US org
+    // (2.4M rows, 99% agent telemetry) that was 90 s mean and 13+ minutes worst
+    // case per device page load, and it saturated the managed DB (2026-09-03).
     //
-    // Safe on visibility: breeze_has_org_access(NULL) returns FALSE, so audit
-    // rows written with a null org_id (e.g. writeAuditEvent with `orgId ?? null`
-    // on some agent paths) are ALREADY invisible to every org- and
-    // partner-scope caller — this predicate hides nothing they could see. It
-    // does narrow system-scope callers, which previously saw null-org rows; a
-    // device's activity feed showing only that device's org is the intended
-    // semantics.
-    const conditions: SQL[] = [
-      eq(auditLogs.orgId, device.orgId),
-      // Find audit logs where resourceId matches the device, OR the device is
-      // referenced inside the JSONB details (agent-submitted events use
-      // details.deviceId).
-      or(
-        eq(auditLogs.resourceId, deviceId),
-        sql`${auditLogs.details}->>'deviceId' = ${deviceId}`
-      )!,
-    ];
+    // So the feed is two arms, merged in mergeFeedPage():
+    //
+    //   1. resource arm — `resource_id = device` as a TOP-LEVEL clause, so it is
+    //      an index condition. When the caller asks for the deliberate-action
+    //      feed (`actions` / `includeAutomated`), `actor_type <> 'agent'` is
+    //      added too: those action families are written by route handlers and
+    //      commandQueue, never by the device agent, so the clause changes
+    //      nothing semantically — but it lets the planner prove the partial
+    //      index audit_logs_device_feed_resource_idx (predicate proof is
+    //      static, leakproofness is irrelevant there) and skip the ~99% of the
+    //      device's rows that are telemetry. The unfiltered Activities tab keeps
+    //      the agent rows and uses audit_logs_resource_id_timestamp_idx.
+    //   2. details arm — rows that reference the device only through
+    //      details.deviceId (device.command.queue, remote sessions). Their
+    //      resource is something else, so this arm is keyed on the org via
+    //      audit_logs_device_feed_details_idx, a partial index on
+    //      `actor_type <> 'agent' AND details ? 'deviceId'`. Both predicate
+    //      clauses are stated verbatim here so the proof holds: no agent path
+    //      writes deviceId into details, and only a handful of an org's
+    //      non-agent rows carry the key, so the `->>` equality runs as a filter
+    //      over a few rows instead of the org's whole non-agent history (which
+    //      was ~500 heap pages and 66 s on US under IO saturation).
+    //      `resource_id IS DISTINCT FROM device` keeps the arms disjoint so the
+    //      merged page and the summed count have no duplicates.
+    //
+    // Both arms keep `org_id = device.orgId` (BREEZE-B). It is a leakproof
+    // index-able clause and the visibility semantics are intended: the device's
+    // feed shows only its own org. breeze_has_org_access(NULL) is FALSE, so rows
+    // written with a null org_id were already invisible to org/partner callers.
+    //
+    // Migration: 2026-10-09-000100-audit-logs-device-feed-partial-indexes.sql.
+    // Contract test (real Postgres, as breeze_app):
+    // __tests__/integration/deviceEventsFeedIndexes.integration.test.ts.
+    const commonConditions: SQL[] = [eq(auditLogs.orgId, device.orgId)];
 
     if (search) {
       const term = `%${search}%`;
-      conditions.push(
+      commonConditions.push(
         or(
           ilike(auditLogs.action, term),
           ilike(auditLogs.resourceName, term),
@@ -193,46 +249,50 @@ eventsRoutes.get(
 
     if (category) {
       // Filter by action prefix category
-      conditions.push(ilike(auditLogs.action, `${category}.%`));
+      commonConditions.push(ilike(auditLogs.action, `${category}.%`));
     }
 
     // The overview "deliberate action" filter: any supplied action prefix, plus
     // (opt-in) automated agent-dispatched commands. Both go into one OR group.
     const actionClauses = buildActionConditions(actions, includeAutomated);
-    if (actionClauses.length > 0) {
-      conditions.push(or(...actionClauses)!);
+    const deliberateFeed = actionClauses.length > 0;
+    if (deliberateFeed) {
+      commonConditions.push(or(...actionClauses)!);
     }
 
     if (result) {
-      conditions.push(eq(auditLogs.result, result));
+      commonConditions.push(eq(auditLogs.result, result));
     }
 
     if (initiatedBy) {
-      conditions.push(eq(auditLogs.initiatedBy, initiatedBy));
+      commonConditions.push(eq(auditLogs.initiatedBy, initiatedBy));
     }
 
     if (from) {
-      conditions.push(gte(auditLogs.timestamp, from));
+      commonConditions.push(gte(auditLogs.timestamp, from));
     }
     if (to) {
-      conditions.push(lte(auditLogs.timestamp, to));
+      commonConditions.push(lte(auditLogs.timestamp, to));
     }
 
-    const whereClause = and(...conditions);
+    const resourceArm = and(
+      ...commonConditions,
+      eq(auditLogs.resourceId, deviceId),
+      ...(deliberateFeed ? [NON_AGENT_ACTOR] : [])
+    )!;
+    const detailsArm = and(
+      ...commonConditions,
+      NON_AGENT_ACTOR,
+      DETAILS_HAS_DEVICE_ID,
+      sql`${auditLogs.details}->>'deviceId' = ${deviceId}`,
+      sql`${auditLogs.resourceId} IS DISTINCT FROM ${deviceId}::uuid`
+    )!;
 
-    // The total count is an unbounded count(*) over the device's whole audit
-    // history; only run it when the caller actually renders a total. The feed
-    // read itself is a bounded ORDER BY timestamp DESC LIMIT N (issue #1726).
-    const countPromise = withTotal
-      ? db
-          .select({ count: sql<number>`count(*)::int` })
-          .from(auditLogs)
-          .where(whereClause)
-          .then((r) => r[0]?.count ?? 0)
-      : Promise.resolve(null);
-
-    const [countResult, rows] = await Promise.all([
-      countPromise,
+    // Each arm is a bounded "top offset+limit" read in index order; the page is
+    // cut from the merged result (mergeFeedPage), which is exact because the
+    // union's top-N is contained in the union of each arm's top-N.
+    const fetchLimit = offset + limit;
+    const selectArm = (where: SQL) =>
       db
         .select({
           id: auditLogs.id,
@@ -253,13 +313,29 @@ eventsRoutes.get(
         })
         .from(auditLogs)
         .leftJoin(users, eq(auditLogs.actorId, users.id))
-        .where(whereClause)
+        .where(where)
         .orderBy(desc(auditLogs.timestamp), desc(auditLogs.id))
-        .limit(limit)
-        .offset(offset),
+        .limit(fetchLimit);
+
+    // The total is an unbounded count(*) over the device's whole audit history;
+    // only run it when the caller actually renders a total (issue #1726).
+    const countArm = (where: SQL) =>
+      db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(auditLogs)
+        .where(where)
+        .then((r) => Number(r[0]?.count ?? 0));
+
+    const [resourceRows, detailsRows, resourceCount, detailsCount] = await Promise.all([
+      selectArm(resourceArm),
+      selectArm(detailsArm),
+      withTotal ? countArm(resourceArm) : Promise.resolve(null),
+      withTotal ? countArm(detailsArm) : Promise.resolve(null),
     ]);
 
-    const total = countResult === null ? null : Number(countResult);
+    const rows = mergeFeedPage(resourceRows, detailsRows, offset, limit);
+    const total =
+      resourceCount === null || detailsCount === null ? null : resourceCount + detailsCount;
 
     const data = rows.map((row) => ({
       id: row.id,

--- a/apps/api/src/routes/devices/events.ts
+++ b/apps/api/src/routes/devices/events.ts
@@ -90,30 +90,40 @@ export function buildActionConditions(
 // provable under a custom plan).
 export const NON_AGENT_ACTOR: SQL = sql`${auditLogs.actorType} <> 'agent'`;
 
-// Second half of the audit_logs_device_feed_details_idx predicate. Implied by
-// the `details->>'deviceId' = X` test the details arm also applies, but the
-// planner cannot derive one from the other, so it is stated explicitly.
+// The audit_logs_device_feed_details_idx predicate. Implied by the
+// `details->>'deviceId' = X` test the details arm also applies, but the planner
+// cannot derive one from the other, so it is stated explicitly.
 export const DETAILS_HAS_DEVICE_ID: SQL = sql`${auditLogs.details} ? 'deviceId'`;
 
-// Merge the two feed arms (each already ordered timestamp DESC, id DESC and
-// bounded to offset+limit rows) and cut the requested page. Exact for any
+// Microsecond-precision sort key selected alongside each row. audit_logs.timestamp
+// has microsecond precision and each arm is ordered by it in SQL, but Drizzle
+// hands it back as a JS Date (milliseconds). Merging on the Date would order two
+// rows from different arms that fall in the same millisecond differently from
+// SQL, and a page boundary between them would then skip or repeat a row. The
+// fixed-width text key sorts exactly like the column.
+export const FEED_SORT_KEY: SQL<string> = sql<string>`to_char(${auditLogs.timestamp}, 'YYYYMMDDHH24MISSUS')`;
+
+// Merge the two feed arms (each already ordered timestamp DESC, id DESC in SQL
+// and bounded to offset+limit rows) and cut the requested page. Exact for any
 // offset because the top-(offset+limit) of the union is contained in the union
-// of each arm's top-(offset+limit).
-export function mergeFeedPage<T extends { timestamp: Date; id: string }>(
+// of each arm's top-(offset+limit) — provided the merge order is IDENTICAL to
+// the SQL order, hence the microsecond `sortKey` (FEED_SORT_KEY) rather than the
+// millisecond Date, and the same id DESC tiebreak (uuid text order == uuid
+// byte order for canonical lowercase uuids).
+export function mergeFeedPage<T extends { sortKey: string; id: string }>(
   resourceRows: T[],
   detailsRows: T[],
   offset: number,
   limit: number
 ): T[] {
+  const desc = (a: string, b: string) => (a === b ? 0 : a < b ? 1 : -1);
   const merged =
     detailsRows.length === 0
       ? resourceRows
       : resourceRows.length === 0
         ? detailsRows
         : [...resourceRows, ...detailsRows].sort(
-            (a, b) =>
-              b.timestamp.getTime() - a.timestamp.getTime() ||
-              (a.id === b.id ? 0 : a.id < b.id ? 1 : -1)
+            (a, b) => desc(a.sortKey, b.sortKey) || desc(a.id, b.id)
           );
   return merged.slice(offset, offset + limit);
 }
@@ -217,12 +227,13 @@ eventsRoutes.get(
     //      details.deviceId (device.command.queue, remote sessions). Their
     //      resource is something else, so this arm is keyed on the org via
     //      audit_logs_device_feed_details_idx, a partial index on
-    //      `actor_type <> 'agent' AND details ? 'deviceId'`. Both predicate
-    //      clauses are stated verbatim here so the proof holds: no agent path
-    //      writes deviceId into details, and only a handful of an org's
-    //      non-agent rows carry the key, so the `->>` equality runs as a filter
-    //      over a few rows instead of the org's whole non-agent history (which
-    //      was ~500 heap pages and 66 s on US under IO saturation).
+    //      `details ? 'deviceId'`. That predicate is stated verbatim here so
+    //      the proof holds (the `->>` equality cannot be derived from it). Rows
+    //      carrying the key are rare for every actor type (51 in the largest
+    //      US org), so the JSONB equality runs as a filter over a few rows
+    //      instead of the org's whole history — and the arm keeps the old OR's
+    //      semantics exactly; no actor is excluded from it except, for the
+    //      deliberate feed, the same telemetry exclusion as arm 1.
     //      `resource_id IS DISTINCT FROM device` keeps the arms disjoint so the
     //      merged page and the summed count have no duplicates.
     //
@@ -282,7 +293,7 @@ eventsRoutes.get(
     )!;
     const detailsArm = and(
       ...commonConditions,
-      NON_AGENT_ACTOR,
+      ...(deliberateFeed ? [NON_AGENT_ACTOR] : []),
       DETAILS_HAS_DEVICE_ID,
       sql`${auditLogs.details}->>'deviceId' = ${deviceId}`,
       sql`${auditLogs.resourceId} IS DISTINCT FROM ${deviceId}::uuid`
@@ -297,6 +308,7 @@ eventsRoutes.get(
         .select({
           id: auditLogs.id,
           timestamp: auditLogs.timestamp,
+          sortKey: FEED_SORT_KEY,
           action: auditLogs.action,
           actorType: auditLogs.actorType,
           actorEmail: auditLogs.actorEmail,


### PR DESCRIPTION
## Why

US was slow on 2026-09-03. Live inspection of the managed DB showed device-page Activity feed queries running 13–17 minutes each with two parallel workers in disk reads, the 50-slot connection ceiling reached, and every request queuing behind them.

Root cause: the feed runs as `breeze_app` under forced RLS, and under a security qual Postgres only promotes **leakproof** clauses to index conditions. The feed's `(resource_id = X OR details->>'deviceId' = X)` contains `jsonb_object_field_text` (not leakproof), `action LIKE` (`textlike`) and `actor_type IN` (`enum_eq`) aren't leakproof either, so the only index path was `audit_logs_org_timestamp_idx`: a walk of the org's **entire** audit history per page load. Largest US org = 2.4M rows / 4 GB, and 99% of it is agent telemetry (`agent.logs.submit` etc.) the feed never wants. The 2026-06-21 feed indexes never applied for exactly this reason.

## What

- `GET /devices/:id/events` now issues two arms and merges the page client-side (`mergeFeedPage`):
  1. **resource arm** — `resource_id = device` as a top-level (promotable) clause. The deliberate-action feed (`actions` / `includeAutomated`) also states `actor_type <> 'agent'`, which lets the planner prove the partial index `audit_logs_device_feed_resource_idx (resource_id, timestamp DESC) WHERE actor_type <> 'agent'`. The unfiltered Activities tab keeps agent rows and uses the existing `audit_logs_resource_id_timestamp_idx`.
  2. **details arm** — rows that reference the device only via `details.deviceId` (`device.command.queue`, remote sessions), keyed on `org_id` via `audit_logs_device_feed_details_idx (org_id, timestamp DESC) WHERE details ? 'deviceId'` (48 kB on US: 51 rows in the largest org). No actor predicate, so the two arms return exactly what the old OR returned; the deliberate feed applies the same `actor_type <> 'agent'` filter to both arms.
- The page merge (`mergeFeedPage`) orders on a `to_char(timestamp, 'YYYYMMDDHH24MISSUS')` key selected with each row, so it is identical to the SQL `ORDER BY timestamp DESC, id DESC` (a millisecond JS `Date` could misplace two rows from different arms that share a millisecond across a page boundary).
- The automated `agent.command.*` arm is system-only now. `'agent'` was a dead defensive branch: the agent's own `agent.command.result.submit` rows key on the command id, not the device, so they were never in the feed.
- Migration `2026-10-09-000100-audit-logs-device-feed-partial-indexes.sql` (`@no-transaction`, `CONCURRENTLY`, `IF NOT EXISTS`, plus a final `DO` block that raises if a build left an `INVALID` index behind instead of `IF NOT EXISTS` silently accepting it). Both indexes total ~1.7 MB on US.

## Measured on US prod (as `breeze_app`, largest org, `EXPLAIN (ANALYZE, BUFFERS)`)

| query | before | after |
|---|---|---|
| deliberate feed (device overview) | 90 s mean, 636 s max, 13–17 min observed live | **0.85 s cold**, 62 buffers, `audit_logs_device_feed_resource_idx` |
| Activities tab page 1 (`limit 50`) | same org-walk plan | **63 ms**, `audit_logs_resource_id_timestamp_idx` |
| details arm (both shapes) | n/a (was inside the OR) | **0.68 s cold**, 80 buffers, `audit_logs_device_feed_details_idx` |
| Activities tab `withTotal` count | org walk (2.4M rows) | device's own rows (76k) — still 118 s under IO pressure, follow-up #4834 |

The old shape's plan on the same data: `Parallel Index Scan using audit_logs_org_timestamp_idx, Index Cond: (org_id = …)` with everything else as a filter.

## Ops already done on US (2026-09-03)

- Both indexes created by hand (`CONCURRENTLY`, 3–4 min each); the migration no-ops there.
- `AUDIT_CHAIN_VERIFY_ENABLED=false` set in `/opt/breeze/.env` and mapped in the droplet compose `api` environment block; api recreated. Stop-gap until v0.110 ships #4548 (the full-chain verify was running 11 h after its 04:13 UTC start).

## Tests

- `events.test.ts`: pins the shape of each arm (resource arm never carries the `->>` test; details arm carries the JSONB test, the non-agent predicate and the disjointness guard; actor exclusion only on the deliberate feed) + `mergeFeedPage` ordering/offset.
- `deviceEventsFeedIndexes.integration.test.ts` (real Postgres as `breeze_app`, org-scoped context, `enable_seqscan = off`): each arm's `EXPLAIN` must hit its index. A seq scan there means a clause stopped being promotable under RLS — the regression class this fixes. Also proves the two arms still return the details-only `device.command.queue` row and that the deliberate feed drops telemetry while the unfiltered feed keeps it.
- Ran locally against an isolated `test-stack`: unit 30/30, integration 7/7 (incl. `eventsAutomatedDedup`), tsc clean, eslint clean.
- Codex (medium) review: 3 findings, 2 real (ms-vs-µs merge order; `IF NOT EXISTS` hiding an invalid index) fixed in the second commit; the third (agent-actor rows linked only via `details.deviceId`) has no such writer today but the details index no longer assumes it.

Follow-up: #4834 (Activities tab count). Root fix for all of this remains audit de-telemetry (#4340 / #4021).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016g2n6u6D73cH6HxdLPgM2G
