### PR TITLE
fix(portal): raw-SQL timestamps 500ed Devices and Backups; stamp last_generated_at; label (#4562 QA walk)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2680,10 +2680,11 @@ jobs:
       # pre-existing failure earlier in the WEB flow (AuthOverlay /
       # session-expired on the contracts tab) and never gets as far as its
       # portal step. Add it here once that is fixed.
-      # portal-visibility.spec.ts (#4562 W10) does not use `waitForHydration`,
-      # but this is the only job that stands up Caddy fronting the portal, so
-      # it is the only place the customer-facing portal is exercised at all.
-      # It depends on the portal rows in e2e-tests/seed-fixtures.sql.
+      # portal-visibility.spec.ts (#4562 W10) also waits for hydration (its
+      # login island), and this is the only job that stands up Caddy fronting
+      # the portal, so it is the only place the customer-facing portal is
+      # exercised at all. It depends on the portal rows in
+      # e2e-tests/seed-fixtures.sql.
       - name: Run the portal hydration specs
         run: ./e2e-tests/node_modules/.bin/tsx scripts/dev/wt-stack/cli.ts test -- tests/multi-currency.spec.ts tests/portal-visibility.spec.ts
 

--- a/apps/api/src/__tests__/integration/portalReportSelfService.integration.test.ts
+++ b/apps/api/src/__tests__/integration/portalReportSelfService.integration.test.ts
@@ -92,6 +92,16 @@ describe('portal report self-service tenancy', () => {
 
     expect(generated.status).toBe('completed');
 
+    // The MSP Reports list reads `reports.last_generated_at`; portal-generated
+    // runs must stamp it too, or the MSP sees "Never" next to a definition the
+    // customer has generated five times (portal QA walk, #4562).
+    const [definition] = await withSystemDbAccessContext(() =>
+      db.select({ lastGeneratedAt: reports.lastGeneratedAt })
+        .from(reports)
+        .where(eq(reports.id, generated.reportId)),
+    );
+    expect(definition?.lastGeneratedAt).toBeInstanceOf(Date);
+
     const [stored] = await withSystemDbAccessContext(() =>
       db.select({
         requestedByKind: reportRuns.requestedByKind,

--- a/apps/api/src/__tests__/integration/portalVisibilityRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/portalVisibilityRls.integration.test.ts
@@ -11,7 +11,9 @@ import {
   backupConfigs,
   backupJobs,
   backupVerifications,
+  devicePatches,
   devices,
+  patches,
   portalUsers,
   reports,
   reportRuns,
@@ -25,6 +27,8 @@ import {
   supportUsageForOrg,
 } from '../../services/portal/supportUsage';
 import { patchesAppliedTile } from '../../services/portal/patchReadModel';
+import { backupDevicesPage } from '../../services/portal/backupReadModel';
+import { enrichedDevicesForOrg } from '../../services/portal/deviceReadModel';
 import {
   createOrganization,
   createPartner,
@@ -508,6 +512,92 @@ describe('portal visibility RLS', () => {
       status: 'no_data',
       month: '2026-09',
       timezone: 'America/Denver',
+    });
+  });
+
+  // #4562 portal QA walk: the device and backup read models select raw `sql`
+  // timestamp subqueries (`max(completed_at)`, latest `installed_at`), which
+  // postgres-js returns as STRINGS — Drizzle only maps typed columns. Unit tests
+  // mock Date objects and pass; against a real database every
+  // /portal/devices and /portal/backups/devices request 500ed. The fixtures
+  // here deliberately carry completed timestamps so the raw paths execute.
+  it('serializes raw-SQL timestamps in the device and backup read models', async () => {
+    const admin = getTestDb();
+    const partner = await createPartner();
+    const orgA = await createOrganization({ partnerId: partner.id });
+    const deviceA = await seedDevice(admin, orgA.id, 'ts');
+
+    const [config] = await admin
+      .insert(backupConfigs)
+      .values({ orgId: orgA.id, name: 'A', type: 'file', provider: 'local', providerConfig: {} })
+      .returning({ id: backupConfigs.id });
+    const [job] = await admin
+      .insert(backupJobs)
+      .values({
+        orgId: orgA.id,
+        configId: config!.id,
+        deviceId: deviceA,
+        status: 'completed',
+        completedAt: new Date('2026-09-02T09:00:00Z'),
+      })
+      .returning({ id: backupJobs.id });
+    await admin.insert(backupVerifications).values({
+      orgId: orgA.id,
+      deviceId: deviceA,
+      backupJobId: job!.id,
+      verificationType: 'test_restore',
+      status: 'passed',
+      startedAt: new Date('2026-09-01T09:00:00Z'),
+      completedAt: new Date('2026-09-01T09:05:00Z'),
+      restoreTimeSeconds: 300,
+    });
+    const [patch] = await admin
+      .insert(patches)
+      .values({ source: 'microsoft', externalId: `KB-${randomUUID()}`, title: 'Cumulative update' })
+      .returning({ id: patches.id });
+    await admin.insert(devicePatches).values({
+      orgId: orgA.id,
+      deviceId: deviceA,
+      patchId: patch!.id,
+      status: 'installed',
+      installedAt: new Date('2026-09-01T00:00:00Z'),
+    });
+
+    const portalContext: DbAccessContext = {
+      scope: 'organization',
+      orgId: orgA.id,
+      accessibleOrgIds: [orgA.id],
+      accessiblePartnerIds: [],
+      currentPartnerId: null,
+      userId: null,
+    };
+
+    const devicesPage = await withDbAccessContext(portalContext, () =>
+      enrichedDevicesForOrg(orgA.id, { page: 1, limit: 50, timezone: 'America/Denver' }),
+    );
+    expect(devicesPage.data).toHaveLength(1);
+    expect(devicesPage.data[0]).toMatchObject({
+      lastPatchAt: 'Aug 31, 2026, 6:00 PM MDT',
+      lastBackupAt: 'Sep 2, 2026, 3:00 AM MDT',
+    });
+
+    const backupsPage = await withDbAccessContext(portalContext, () =>
+      backupDevicesPage(orgA.id, {
+        page: 1,
+        limit: 25,
+        timezone: 'America/Denver',
+        now: new Date('2026-09-02T12:00:00Z'),
+      }),
+    );
+    expect(backupsPage.data).toHaveLength(1);
+    expect(backupsPage.data[0]).toMatchObject({
+      configured: true,
+      lastRestorePointAt: '2026-09-02T09:00:00.000Z',
+      lastTestRestore: {
+        status: 'passed',
+        completedAt: '2026-09-01T09:05:00.000Z',
+        restoreTimeSeconds: 300,
+      },
     });
   });
 

--- a/apps/api/src/routes/portal/security.test.ts
+++ b/apps/api/src/routes/portal/security.test.ts
@@ -111,7 +111,7 @@ it('validates days and calls the overview with the session org', async () => {
     score: null,
     band: null,
     scoreHistory: [],
-    threatEvents: { label: 'endpoint threat events', weeks: [] },
+    threatEvents: { label: 'Endpoint threat events', weeks: [] },
     vulnerabilities: {
       openBySeverity: {
         critical: 0, high: 0, medium: 0, low: 0, unknown: 0,
@@ -155,7 +155,7 @@ it('revalidates unchanged security data when only asOf changes', async () => {
     score: 82,
     band: 'strong',
     scoreHistory: [{ capturedAt: '2026-09-01', score: 82 }],
-    threatEvents: { label: 'endpoint threat events', weeks: [] },
+    threatEvents: { label: 'Endpoint threat events', weeks: [] },
     vulnerabilities: {
       openBySeverity: {
         critical: 0, high: 0, medium: 0, low: 0, unknown: 0,

--- a/apps/api/src/services/portal/backupReadModel.test.ts
+++ b/apps/api/src/services/portal/backupReadModel.test.ts
@@ -194,6 +194,47 @@ it('returns overview verification, restore, breach, and readiness evidence', asy
   expect(readinessJoin?.params).toContain(ORG_ID);
 });
 
+it('serializes raw-SQL timestamps that postgres-js returns as strings', async () => {
+  // `lastBackupAt` / `testRestoreAt` are raw `max(...)` subqueries; the driver
+  // returns strings, not Dates. Found by the portal QA walk (#4562): every
+  // /portal/backups/devices request 500ed with
+  // `row.lastBackupAt?.toISOString is not a function`.
+  state.rows.push(
+    [{ count: 1 }],
+    [{
+      id: 'd-1',
+      hostname: 'Laptop',
+      displayName: null,
+      configured: true,
+      lastBackupAt: '2026-09-02 09:00:00+00',
+      lastBackupStatus: 'completed',
+      testRestoreStatus: 'passed',
+      testRestoreAt: '2026-09-01T09:00:00.000Z',
+      restoreTimeSeconds: 120,
+      openBreaches: [],
+      readinessScore: null,
+      estimatedRtoMinutes: null,
+      estimatedRpoMinutes: null,
+    }],
+  );
+
+  const page = await backupDevicesPage(ORG_ID, {
+    page: 1,
+    limit: 25,
+    timezone: 'America/Denver',
+    now: new Date('2026-09-02T12:00:00Z'),
+  });
+
+  expect(page.data[0]).toMatchObject({
+    lastRestorePointAt: '2026-09-02T09:00:00.000Z',
+    lastTestRestore: {
+      status: 'passed',
+      completedAt: '2026-09-01T09:00:00.000Z',
+      restoreTimeSeconds: 120,
+    },
+  });
+});
+
 it('returns every enrolled device, including not configured', async () => {
   state.rows.push(
     [{ count: 2 }],

--- a/apps/api/src/services/portal/backupReadModel.ts
+++ b/apps/api/src/services/portal/backupReadModel.ts
@@ -79,6 +79,7 @@ import type {
   BackupDevicesDto,
   BackupOverviewDto,
 } from '@breeze/shared';
+import { sqlTimestamp } from './sqlTimestamp';
 
 export async function backupOverview(
   orgId: string,
@@ -201,7 +202,7 @@ export async function backupDevicesPage(
               and bj.device_id = ${devices.id}
           )
         `,
-        lastBackupAt: sql<Date | null>`(
+        lastBackupAt: sql<Date | string | null>`(
           select max(bj.completed_at)
           from backup_jobs bj
           where bj.org_id = ${orgId}
@@ -226,7 +227,7 @@ export async function backupDevicesPage(
           order by bv.completed_at desc nulls last
           limit 1
         )`,
-        testRestoreAt: sql<Date | null>`(
+        testRestoreAt: sql<Date | string | null>`(
           select max(bv.completed_at)
           from backup_verifications bv
           where bv.org_id = ${orgId}
@@ -273,12 +274,12 @@ export async function backupDevicesPage(
     id: row.id,
     name: row.displayName ?? row.hostname,
     configured: row.configured,
-    lastRestorePointAt: row.lastBackupAt?.toISOString() ?? null,
+    lastRestorePointAt: sqlTimestamp(row.lastBackupAt)?.toISOString() ?? null,
     lastRestorePointDegraded: row.lastBackupStatus === 'partial',
     lastTestRestore: row.testRestoreStatus
       ? {
           status: row.testRestoreStatus,
-          completedAt: row.testRestoreAt?.toISOString() ?? null,
+          completedAt: sqlTimestamp(row.testRestoreAt)?.toISOString() ?? null,
           restoreTimeSeconds: row.restoreTimeSeconds,
         }
       : null,

--- a/apps/api/src/services/portal/deviceReadModel.test.ts
+++ b/apps/api/src/services/portal/deviceReadModel.test.ts
@@ -46,6 +46,47 @@ describe('deviceReadModel', () => {
     state.orderBys.length = 0;
   });
 
+  it('formats raw-SQL timestamps that postgres-js returns as strings', async () => {
+    // `lastPatchAt` / `lastBackupAt` are raw `sql` subqueries, and Drizzle only
+    // maps typed columns to Date — the driver hands these back as strings.
+    // Found by the portal QA walk (#4562): every /portal/devices request 500ed
+    // with `RangeError: Invalid time value`.
+    state.rows.push(
+      [{ count: 1 }],
+      [{
+        id: 'd-1',
+        hostname: 'Laptop',
+        displayName: null,
+        osType: 'windows',
+        osVersion: '11',
+        status: 'online',
+        lastSeenAt: new Date('2026-09-02T11:00:00Z'),
+        lastPatchAt: '2026-09-01 00:00:00+00',
+        realTimeProtection: null,
+        provider: null,
+        avProducts: null,
+        securityUpdatedAt: null,
+        hasS1Agent: false,
+        hasHuntressAgent: false,
+        encryption: null,
+        lastBackupAt: '2026-09-02T08:00:00.000Z',
+        warrantyEndsAt: null,
+      }],
+    );
+
+    const result = await enrichedDevicesForOrg(ORG_ID, {
+      page: 1,
+      limit: 50,
+      timezone: 'America/Denver',
+    });
+
+    expect(result.data[0]).toMatchObject({
+      lastSeenAt: 'Sep 2, 2026, 5:00 AM MDT',
+      lastPatchAt: 'Aug 31, 2026, 6:00 PM MDT',
+      lastBackupAt: 'Sep 2, 2026, 2:00 AM MDT',
+    });
+  });
+
   it('returns the enriched customer projection with explicit org scoping', async () => {
     state.rows.push(
       [{ count: 1 }],

--- a/apps/api/src/services/portal/deviceReadModel.ts
+++ b/apps/api/src/services/portal/deviceReadModel.ts
@@ -11,6 +11,7 @@ import {
   securityStatus,
 } from '../../db/schema';
 import { classifyDeviceProtection } from './protection';
+import { sqlTimestamp } from './sqlTimestamp';
 
 export async function enrichedDevicesForOrg(
   orgId: string,
@@ -31,7 +32,7 @@ export async function enrichedDevicesForOrg(
         osVersion: devices.osVersion,
         status: devices.status,
         lastSeenAt: devices.lastSeenAt,
-        lastPatchAt: sql<Date | null>`(
+        lastPatchAt: sql<Date | string | null>`(
           select max(${devicePatches.installedAt})
           from ${devicePatches}
           where ${devicePatches.orgId} = ${orgId}
@@ -53,7 +54,7 @@ export async function enrichedDevicesForOrg(
             and ${huntressAgents.deviceId} = ${devices.id}
         )`,
         encryption: securityStatus.encryptionStatus,
-        lastBackupAt: sql<Date | null>`(
+        lastBackupAt: sql<Date | string | null>`(
           select max(${backupJobs.completedAt})
           from ${backupJobs}
           where ${backupJobs.orgId} = ${orgId}
@@ -92,8 +93,10 @@ export async function enrichedDevicesForOrg(
     minute: '2-digit',
     timeZoneName: 'short',
   });
-  const formatTimestamp = (value: Date | null) =>
-    value ? timestampFormatter.format(value) : null;
+  const formatTimestamp = (value: Date | string | null) => {
+    const date = sqlTimestamp(value);
+    return date ? timestampFormatter.format(date) : null;
+  };
 
   const data: EnrichedPortalDevice[] = rows.map((row) => ({
     id: row.id,

--- a/apps/api/src/services/portal/reportsSelfService.test.ts
+++ b/apps/api/src/services/portal/reportsSelfService.test.ts
@@ -378,6 +378,10 @@ describe('generatePortalReport', () => {
       status: 'completed',
       rowCount: null,
     }));
+    // The MSP Reports list reads reports.last_generated_at (#4562 QA walk).
+    expect(state.updated).toHaveBeenCalledWith(expect.objectContaining({
+      lastGeneratedAt: expect.any(Date),
+    }));
   });
 
   it('rejects limiter denial with the retry interval', async () => {

--- a/apps/api/src/services/portal/reportsSelfService.ts
+++ b/apps/api/src/services/portal/reportsSelfService.ts
@@ -360,6 +360,12 @@ export async function generatePortalReport(args: {
         outputUrl: `/api/v1/portal/reports/runs/${run.id}/pdf`,
       }).where(eq(reportRuns.id, run.id)).returning();
 
+      // The MSP Reports list reads this column; the MSP generate path and the
+      // scheduler stamp it, so a portal run must too or the MSP sees "Never".
+      await db.update(reports)
+        .set({ lastGeneratedAt: completedAt, updatedAt: completedAt })
+        .where(eq(reports.id, definition.id));
+
       return toDto({
         ...completed!,
         name: definition.name,

--- a/apps/api/src/services/portal/securityReadModel.test.ts
+++ b/apps/api/src/services/portal/securityReadModel.test.ts
@@ -226,7 +226,7 @@ describe('securityReadModel', () => {
       score: 81,
       band: 'strong',
       scoreHistory: [{ capturedAt: '2026-09-01', score: 81 }],
-      threatEvents: { label: 'endpoint threat events' },
+      threatEvents: { label: 'Endpoint threat events' },
       vulnerabilities: {
         openBySeverity: {
           critical: 1,

--- a/apps/api/src/services/portal/securityReadModel.ts
+++ b/apps/api/src/services/portal/securityReadModel.ts
@@ -285,7 +285,7 @@ export async function securityOverview(
     band: score == null ? null : scoreBand(score),
     scoreHistory,
     threatEvents: {
-      label: 'endpoint threat events',
+      label: 'Endpoint threat events',
       weeks,
     },
     vulnerabilities: {

--- a/apps/api/src/services/portal/sqlTimestamp.test.ts
+++ b/apps/api/src/services/portal/sqlTimestamp.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { sqlTimestamp } from './sqlTimestamp';
+
+describe('sqlTimestamp', () => {
+  it('passes Date instances through', () => {
+    const date = new Date('2026-09-02T09:00:00Z');
+    expect(sqlTimestamp(date)).toBe(date);
+  });
+
+  it('parses postgres timestamptz text (postgres-js form)', () => {
+    expect(sqlTimestamp('2026-09-02 09:00:00+00')?.toISOString())
+      .toBe('2026-09-02T09:00:00.000Z');
+    expect(sqlTimestamp('2026-09-02 03:00:00-06')?.toISOString())
+      .toBe('2026-09-02T09:00:00.000Z');
+    expect(sqlTimestamp('2026-09-02T09:00:00.000Z')?.toISOString())
+      .toBe('2026-09-02T09:00:00.000Z');
+  });
+
+  it('reads a zone-less timestamp (timestamp WITHOUT time zone) as UTC, like the Drizzle column mapper', () => {
+    expect(sqlTimestamp('2026-09-01 00:00:00')?.toISOString())
+      .toBe('2026-09-01T00:00:00.000Z');
+    expect(sqlTimestamp('2026-09-01 00:00:00.123')?.toISOString())
+      .toBe('2026-09-01T00:00:00.123Z');
+  });
+
+  it('maps null and undefined to null', () => {
+    expect(sqlTimestamp(null)).toBeNull();
+    expect(sqlTimestamp(undefined)).toBeNull();
+  });
+
+  it('throws on garbage instead of returning an Invalid Date', () => {
+    expect(() => sqlTimestamp('not a timestamp')).toThrow(TypeError);
+  });
+});

--- a/apps/api/src/services/portal/sqlTimestamp.ts
+++ b/apps/api/src/services/portal/sqlTimestamp.ts
@@ -1,0 +1,36 @@
+/**
+ * Normalize a timestamp that came out of a raw `sql\`...\`` expression.
+ *
+ * Drizzle maps typed columns (`timestamp(...)`) to `Date`, but a raw fragment —
+ * `max(completed_at)`, a correlated `select installed_at ... limit 1` — is handed
+ * back by postgres-js as the server's text form (`2026-09-02 09:00:00+00`, or
+ * `2026-09-01 00:00:00` for a column WITHOUT time zone). Annotating such a
+ * fragment `sql<Date>` is a lie the compiler cannot catch and unit tests (which
+ * mock Date rows) never exercise; against a real database `.toISOString()`
+ * throws and `Intl.DateTimeFormat.format()` raises `RangeError: Invalid time
+ * value`. Both shipped in #4562 (W06, W07) and were caught by the portal QA
+ * walk. Route every raw timestamp through here.
+ *
+ * A value without a zone designator is read as UTC — the same rule Drizzle's
+ * `timestamp` column mapper applies (`new Date(value + '+0000')`) — so the
+ * result does not depend on the API process's local zone.
+ */
+// `2026-09-02 09:00:00[.123][+00|+00:00|Z]` or the ISO `T` form. Anything else
+// is refused up front: V8's legacy Date parser is lenient enough to turn junk
+// into a real date, so a NaN check alone is not a guard.
+const TIMESTAMP_SHAPE =
+  /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?(?<zone>Z|[+-]\d{2}(?::?\d{2})?)?$/i;
+
+export function sqlTimestamp(value: Date | string | null | undefined): Date | null {
+  if (value == null) return null;
+  if (value instanceof Date) return value;
+  const match = TIMESTAMP_SHAPE.exec(value);
+  if (!match) {
+    throw new TypeError(`sqlTimestamp: unparseable timestamp ${JSON.stringify(value)}`);
+  }
+  const date = new Date(match.groups?.zone ? value : `${value}+0000`);
+  if (Number.isNaN(date.getTime())) {
+    throw new TypeError(`sqlTimestamp: unparseable timestamp ${JSON.stringify(value)}`);
+  }
+  return date;
+}

--- a/apps/portal/src/components/portal/SecurityOverview.test.tsx
+++ b/apps/portal/src/components/portal/SecurityOverview.test.tsx
@@ -12,7 +12,7 @@ it('labels threats honestly and displays severity and KEV totals', () => {
     band: 'strong',
     scoreHistory: [{ capturedAt: '2026-09-01', score: 82 }],
     threatEvents: {
-      label: 'endpoint threat events',
+      label: 'Endpoint threat events',
       weeks: [{
         weekStart: '2026-08-31',
         detected: 3,
@@ -29,7 +29,7 @@ it('labels threats honestly and displays severity and KEV totals', () => {
   }} />);
 
   expect(screen.getByTestId('portal-security-overview').textContent).toContain(
-    'endpoint threat events',
+    'Endpoint threat events',
   );
   expect(screen.getByTestId('portal-security-vulnerabilities').textContent).toContain(
     '1 KEV',
@@ -44,7 +44,7 @@ it('explains when observations exist but no security score has been calculated',
     band: null,
     scoreHistory: [],
     threatEvents: {
-      label: 'endpoint threat events',
+      label: 'Endpoint threat events',
       weeks: [],
     },
     vulnerabilities: {
@@ -70,7 +70,7 @@ it('renders medium, low, and unknown vulnerability counts plus the last-detected
       score: 82,
       band: 'strong',
       scoreHistory: [{ capturedAt: '2026-09-01', score: 82 }],
-      threatEvents: { label: 'endpoint threat events', weeks: [] },
+      threatEvents: { label: 'Endpoint threat events', weeks: [] },
       vulnerabilities: {
         openBySeverity: { critical: 1, high: 2, medium: 3, low: 4, unknown: 5 },
         kevCount: 1,
@@ -94,7 +94,7 @@ it('omits the last-detected line when no vulnerability has ever been observed', 
     score: 82,
     band: 'strong',
     scoreHistory: [{ capturedAt: '2026-09-01', score: 82 }],
-    threatEvents: { label: 'endpoint threat events', weeks: [] },
+    threatEvents: { label: 'Endpoint threat events', weeks: [] },
     vulnerabilities: {
       openBySeverity: { critical: 0, high: 0, medium: 0, low: 0, unknown: 0 },
       kevCount: 0,

--- a/e2e-tests/pages/PortalVisibilityPage.ts
+++ b/e2e-tests/pages/PortalVisibilityPage.ts
@@ -1,4 +1,5 @@
 import type { Page } from '@playwright/test';
+import { waitForHydration } from './hydration';
 
 export class PortalVisibilityPage {
   constructor(private page: Page) {}
@@ -28,6 +29,10 @@ export class PortalVisibilityPage {
    */
   async login(email: string, password: string): Promise<void> {
     await this.page.goto('/portal/login');
+    // The login form is a `client:load` island: a fill that lands before React
+    // attaches is discarded by hydration and the submit never posts (seen as
+    // an empty form still on /login after the full navigation timeout).
+    await waitForHydration(this.page, 'portal-login-submit');
     await this.email().fill(email);
     await this.password().fill(password);
     await this.submit().click();

--- a/packages/shared/src/types/portalVisibility.ts
+++ b/packages/shared/src/types/portalVisibility.ts
@@ -127,7 +127,7 @@ export interface SecurityOverviewDto {
   band: SecurityScoreBand | null;
   scoreHistory: SecurityTrendPoint[];
   threatEvents: {
-    label: 'endpoint threat events';
+    label: 'Endpoint threat events';
     weeks: ThreatWeekDto[];
   };
   vulnerabilities: {


### PR DESCRIPTION
## Summary

Hands-on Playwright walk of the customer portal on `main` after all ten #4562 waves landed (login → dashboard → reports generate/PDF/CSV → rate limit → MSP portal-settings editor → MSP Reports list → security → backups → devices + CSV → support usage). Three defects and one copy issue, all fixed here with red-first tests.

**Verified in the browser before the fix (stack on `main` 241f2d75a):**

1. **`GET /portal/devices` 500** — whole Devices page rendered "Internal Server Error". API: `RangeError: Invalid time value` at `deviceReadModel.ts` `formatTimestamp`.
2. **`GET /portal/backups/devices` 500** — Backups page rendered its summary plus an "Internal Server Error" alert. API: `row.lastBackupAt?.toISOString is not a function` at `backupReadModel.ts:276`.
3. **MSP Reports list showed "Last Generated: Never"** for both canonical portal definitions after five portal-generated runs (`reports.last_generated_at` was never stamped by the portal path).
4. Security page section heading rendered the lowercase DTO label `endpoint threat events`.

**Root cause of 1 and 2** (same class as the W04 dashboard bug fixed in #4815): both read models annotate raw `sql` subqueries (`max(completed_at)`, latest `installed_at`) as `sql<Date>`, but Drizzle only maps typed columns; postgres-js returns the server's text form. Unit tests mock `Date` rows, and the W02 RLS integration suite never called these mappers (its backup jobs also carry no `completed_at`), so nothing executed the raw path against a real database until the browser did.

## Changes

- `services/portal/sqlTimestamp.ts` — normalizes driver text to `Date`; a zone-less value (a `timestamp` column without time zone, e.g. `device_patches.installed_at`) is read as UTC, the same rule Drizzle's column mapper applies, so results don't depend on the API process's local zone; shape-checked up front so junk throws instead of V8's lenient parser inventing a date.
- `deviceReadModel.ts`, `backupReadModel.ts` — route `lastPatchAt`, `lastBackupAt`, `testRestoreAt` through it; fragments annotated honestly as `Date | string | null`.
- `reportsSelfService.ts` — `generatePortalReport` stamps `reports.last_generated_at` / `updated_at` on completion, like the MSP and scheduled paths.
- `securityReadModel.ts` + `@breeze/shared` `PortalSecurityOverviewDto` — label `Endpoint threat events`.

## Tests (red first, every one failed for the reason above before the fix)

- `sqlTimestamp.test.ts` (5 cases: Date passthrough, timestamptz text, zone-less as UTC, null, junk throws).
- `deviceReadModel.test.ts`, `backupReadModel.test.ts` — rows with string timestamps as the driver returns them.
- `reportsSelfService.test.ts` — asserts the `lastGeneratedAt` update.
- `portalVisibilityRls.integration.test.ts` — seeds a completed backup job, a passed test-restore verification and an installed patch, then calls `enrichedDevicesForOrg` and `backupDevicesPage` against Postgres (rejected before; resolves with the expected formatted/ISO values after).
- `portalReportSelfService.integration.test.ts` — asserts `last_generated_at` is a Date after a portal run.

Verified locally: `services/portal` + `routes/portal` 32 files / 377 tests; both integration suites 7/7 on a private test stack; API `tsc` clean; portal + shared vitest green. Re-walked in the browser after the fix: Devices renders with last patch/backup, CSV export downloads, Backups renders its device table, Security heading capitalized, MSP list shows a Last Generated time after a new portal run.

## Also: e2e hydration race (second commit)

Running `portal-visibility.spec.ts` against a local wt-stack of this branch failed its first test with the login form still empty and no login POST in the API log — Playwright filled before the `client:load` island hydrated and React discarded the values. CI had passed on timing. The page object now uses the shared `waitForHydration` on the submit button; the spec then passes 3/3 locally (8 s).

## Observed but NOT changed here (UX, for triage)

- Backups page shows the banner "No backup data is available yet." while the table beneath lists a restore point for one device — the banner keys on verification data, not on backups.
- Devices CSV export writes raw enum values (`windows`, `offline`, `unknown`) where the page shows display labels (`Windows`, `Offline`, `Unknown`); its `Cache-Control` is `private, max-age=30` rather than `no-store`.
- Portal report names carry the MSP-side prefix (`Customer portal — Security & compliance posture`) in the customer's own list.
- MSP Reports list: the "Visible in customer portal" pill wraps to three lines.
- Portal settings editor: the customer-facing Devices page depends on "Self-service" under Portal features, which the label copy doesn't say.
- Rate-limit alert "Report generation is temporarily limited" omits the retry window the API returns in `Retry-After`.
- Dev-stack only: portal sessions are in-process, so an API restart signs every customer out (Redis backend in production).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WvK35ZoQELCL9xdsgWjCaw

