### PR TITLE
fix(api): deliver empty watch list instead of null on zero enabled watches (#2949)

### DIFF
--- a/apps/api/src/routes/agents/helpers.partnerWidePolicies.test.ts
+++ b/apps/api/src/routes/agents/helpers.partnerWidePolicies.test.ts
@@ -448,3 +448,40 @@ describe('partner-owned policies actually reach the agent payload', () => {
     expect(systemEscapeMock).not.toHaveBeenCalled();
   });
 });
+
+describe('monitoring: a matched policy with zero enabled watches (#2949)', () => {
+  // A winning policy row with no enabled watches ("clear all watches") is a
+  // different fact than "no policy matched at all" — collapsing both to `null`
+  // means heartbeat.ts omits monitoring_settings from the payload entirely, and
+  // the agent (which handles an empty watches array fine — see
+  // agent/internal/monitoring/monitor.go ApplyConfig) never learns to clear out
+  // watches it was told about on a previous heartbeat.
+  it('returns an object with an empty watches array, not null', async () => {
+    dbMock._resetQueue([
+      deviceRow,
+      orgWithPartner,
+      [],
+      [{ level: 'organization', assignmentPriority: 1, settingsId: 'set-1', checkIntervalSeconds: 90 }],
+      [], // no enabled watches for the winning settings row
+    ]);
+
+    const result = await buildMonitoringConfigUpdate(DEVICE_ID);
+
+    expect(result).not.toBeNull();
+    expect(result?.check_interval_seconds).toBe(90);
+    expect(result?.watches).toEqual([]);
+  });
+
+  it('still returns null when no policy row matches at all', async () => {
+    dbMock._resetQueue([
+      deviceRow,
+      orgWithPartner,
+      [],
+      [], // no assignment/policy rows matched
+    ]);
+
+    const result = await buildMonitoringConfigUpdate(DEVICE_ID);
+
+    expect(result).toBeNull();
+  });
+});

--- a/apps/api/src/routes/agents/helpers.partnerWidePolicies.test.ts
+++ b/apps/api/src/routes/agents/helpers.partnerWidePolicies.test.ts
@@ -484,4 +484,29 @@ describe('monitoring: a matched policy with zero enabled watches (#2949)', () =>
 
     expect(result).toBeNull();
   });
+
+  it('caches the empty-watches result via redis.set, same as any other match', async () => {
+    // `buildMonitoringConfigUpdate` only skips caching on a null resolution
+    // ("quick policy activation"); an empty-watches object is a real match and
+    // must be cached like any other, or a rapid heartbeat retry would re-run
+    // the resolver queries needlessly.
+    getRedisImpl.mockReturnValue(redisMock);
+    dbMock._resetQueue([
+      deviceRow,
+      orgWithPartner,
+      [],
+      [{ level: 'organization', assignmentPriority: 1, settingsId: 'set-1', checkIntervalSeconds: 90 }],
+      [], // no enabled watches for the winning settings row
+    ]);
+
+    const result = await buildMonitoringConfigUpdate(DEVICE_ID);
+
+    expect(result?.watches).toEqual([]);
+    expect(redisMock.set).toHaveBeenCalledWith(
+      `monitoring:settings:device:${DEVICE_ID}`,
+      JSON.stringify({ check_interval_seconds: 90, watches: [] }),
+      'EX',
+      120,
+    );
+  });
 });

--- a/apps/api/src/routes/agents/helpers.ts
+++ b/apps/api/src/routes/agents/helpers.ts
@@ -2060,8 +2060,14 @@ async function resolveDeviceMonitoringSettings(deviceId: string): Promise<Monito
     ))
     .orderBy(configPolicyMonitoringWatches.sortOrder);
 
-  if (watches.length === 0) return null;
-
+  // A winning policy row with zero enabled watches is a valid resolution — it
+  // means "clear whatever watches were previously delivered", not "no policy
+  // matched" (that case already returned null above at the empty-rows check).
+  // Collapsing both to null used to make heartbeat.ts omit monitoring_settings
+  // from the payload, so the agent (which handles an empty array fine — see
+  // agent/internal/monitoring/monitor.go ApplyConfig) could never be told to
+  // stop watching something it was configured to watch on a prior heartbeat
+  // (#2949).
   return {
     check_interval_seconds: winner.checkIntervalSeconds,
     watches: watches.map((w) => {


### PR DESCRIPTION
## Summary

`resolveDeviceMonitoringSettings` in `apps/api/src/routes/agents/helpers.ts` conflated two different outcomes into a single `null` return:

- **No monitoring policy matched this device** (correctly `null`).
- **A policy matched but has zero enabled watches** (previously *also* `null`).

`heartbeat.ts` only sets `monitoring_settings` on a non-null result, so the second case silently dropped the field from the heartbeat payload entirely. An MSP who removed all watches from a policy (intending to clear them) could never get that "clear" instruction delivered to an already-configured agent — the agent just kept running whatever watches it was told about on a previous heartbeat.

The agent side already handles an empty watches array correctly: `agent/internal/monitoring/monitor.go`'s `ApplyConfig`/`runChecks` early-return on `len(watches) == 0`, so no agent-side change is needed.

## Fix

`resolveDeviceMonitoringSettings` now returns `{ check_interval_seconds: winner.checkIntervalSeconds, watches: [] }` when a winning policy row exists but has no enabled watches. `null` is still returned only when no policy row matched at all (the earlier `rows.length === 0` check, unchanged).

## Scope (per issue #2949)

This addresses **item 1 only**:

1. ✅ Zero enabled watches now yields `{ watches: [] }`, not `null` — fixed here.
2. Partner-wide monitoring policy visibility — already fixed by #4673 / #3665 (confirmed present on `origin/main`, code comments in `helpers.ts` reference the fix).
3. `alertSeverity` delivery / alert-creation audit — **out of scope for this PR**. There is no corresponding field on the Go agent side yet (`agent/internal/monitoring`), so this needs its own design/implementation pass. Left open on the issue.

Refs #2949 (not closing — items 2 addressed elsewhere, item 3 still open).

## Testing

- Added a red-first regression test to `helpers.partnerWidePolicies.test.ts`: a winning policy with zero enabled watches now asserts a non-null `{ watches: [] }` result, and a companion test pins that "no policy matched at all" still returns `null`.
- `apps/api`: `npx vitest run src/routes/agents/helpers.partnerWidePolicies.test.ts src/routes/agents/heartbeat.test.ts` — 204 passed.
- `apps/api`: `npx vitest run src/routes/agents/helpers` (all helpers*.test.ts in the dir) — 128 passed.
- `apps/api`: `npx tsc --noEmit` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)