### PR TITLE
fix(agent): retry secrets.yaml rename on transient destination lock (#2772)

### DIFF
--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	mathrand "math/rand"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -893,6 +894,51 @@ func stripSecretsFromAgentConfig(data []byte) ([]byte, error) {
 	return out, nil
 }
 
+// Rename retry bounds for atomicWriteFile / writeYAMLFile. A rename-over-
+// existing destination can fail transiently — observed in production on
+// Windows Server 2022 as Windows Defender real-time protection (zero
+// exclusions configured) briefly holding secrets.yaml open during the write.
+// A single failed attempt used to be treated as a hard failure:
+// StagePendingCredentials aborts the rotation and discards the staged
+// credential set on ANY write error, so one transient lock permanently lost
+// that rotation attempt. Because the server's staged set then expires and
+// token_issued_at never advances, isAgentTokenRotationDue stays true and the
+// next heartbeat stages again — the stage→expire→re-stage loop in issue
+// #2772 (agent.token.rotate.confirmed has never fired in production).
+//
+// Mirrors the retry/backoff shape in agent/internal/state/state.go (Write),
+// but with a longer schedule: state.go's own comment notes its 4 attempts /
+// ~175ms total still lost on the box that reproduced this bug, and the
+// credential file is the one write that must not be silently dropped.
+const (
+	renameAttempts    = 8
+	renameBackoffBase = 25 * time.Millisecond
+)
+
+// renameFile is a seam for tests to inject rename failures. Defaults to
+// os.Rename in production.
+var renameFile = os.Rename
+
+// renameWithRetry retries a failing rename with jittered exponential backoff.
+// Jitter keeps concurrent callers (the cert-renewal goroutine, the command
+// worker pool, and heartbeat's own SetAndPersist/StagePendingCredentials
+// calls can all reach a rename around the same time) from retrying against
+// the same transient holder in lockstep.
+func renameWithRetry(oldpath, newpath string) error {
+	var err error
+	for attempt := 0; attempt < renameAttempts; attempt++ {
+		if attempt > 0 {
+			backoff := renameBackoffBase << (attempt - 1)
+			sleep := backoff + time.Duration(mathrand.Int63n(int64(backoff)+1))
+			time.Sleep(sleep)
+		}
+		if err = renameFile(oldpath, newpath); err == nil {
+			return nil
+		}
+	}
+	return fmt.Errorf("rename %s to %s after %d attempts: %w", oldpath, newpath, renameAttempts, err)
+}
+
 // atomicWriteFile writes data to path durably: it creates path+".partial" in
 // the same directory with perm requested at open time (still subject to umask
 // on POSIX — defense-in-depth Chmod happens at the call site), writes data,
@@ -933,7 +979,7 @@ func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
 		os.Remove(tmpPath)
 		return err
 	}
-	if err := os.Rename(tmpPath, path); err != nil {
+	if err := renameWithRetry(tmpPath, path); err != nil {
 		os.Remove(tmpPath)
 		return err
 	}
@@ -1116,7 +1162,7 @@ func writeYAMLFile(path string, values map[string]any, mode os.FileMode) error {
 		os.Remove(tmpPath)
 		return err
 	}
-	if err := os.Rename(tmpPath, path); err != nil {
+	if err := renameWithRetry(tmpPath, path); err != nil {
 		os.Remove(tmpPath)
 		return err
 	}

--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -919,6 +919,12 @@ const (
 // os.Rename in production.
 var renameFile = os.Rename
 
+// renameRetrySleep is a seam for tests to skip the real backoff delay.
+// Defaults to time.Sleep in production; the exhausted-retries test overrides
+// it to a no-op so it doesn't burn ~6s of real wall-clock time on every run
+// while still exercising the full attempt-count and cleanup logic.
+var renameRetrySleep = time.Sleep
+
 // renameWithRetry retries a failing rename with jittered exponential backoff.
 // Jitter keeps concurrent callers (the cert-renewal goroutine, the command
 // worker pool, and heartbeat's own SetAndPersist/StagePendingCredentials
@@ -930,7 +936,7 @@ func renameWithRetry(oldpath, newpath string) error {
 		if attempt > 0 {
 			backoff := renameBackoffBase << (attempt - 1)
 			sleep := backoff + time.Duration(mathrand.Int63n(int64(backoff)+1))
-			time.Sleep(sleep)
+			renameRetrySleep(sleep)
 		}
 		if err = renameFile(oldpath, newpath); err == nil {
 			return nil

--- a/agent/internal/config/config_test.go
+++ b/agent/internal/config/config_test.go
@@ -479,7 +479,14 @@ func TestAtomicWriteFileRetriesTransientRenameFailure(t *testing.T) {
 // credential set was NOT written, so it must not confirm the rotation.
 func TestAtomicWriteFileExhaustsRenameRetriesAndCleansUp(t *testing.T) {
 	origRename := renameFile
-	defer func() { renameFile = origRename }()
+	origSleep := renameRetrySleep
+	defer func() {
+		renameFile = origRename
+		renameRetrySleep = origSleep
+	}()
+	// Skip the real backoff delay (worst case ~6s across 8 attempts) — this
+	// test cares about the attempt count and cleanup behavior, not timing.
+	renameRetrySleep = func(time.Duration) {}
 
 	attempts := 0
 	persistentErr := &os.PathError{Op: "rename", Path: "secrets.yaml", Err: os.ErrPermission}

--- a/agent/internal/config/config_test.go
+++ b/agent/internal/config/config_test.go
@@ -431,6 +431,109 @@ func TestAtomicWriteFileCleansUpOnOpenFailure(t *testing.T) {
 	}
 }
 
+// TestAtomicWriteFileRetriesTransientRenameFailure pins issue #2772: a
+// rename-over-existing that fails once (Windows Defender or similar briefly
+// holding the destination open) must not permanently fail the write —
+// StagePendingCredentials treats any error here as "abort and discard the
+// staged rotation," which is exactly the stage→expire→re-stage loop the
+// issue reports. atomicWriteFile must retry the rename and succeed once the
+// transient holder releases the file.
+func TestAtomicWriteFileRetriesTransientRenameFailure(t *testing.T) {
+	origRename := renameFile
+	defer func() { renameFile = origRename }()
+
+	attempts := 0
+	transientErr := &os.PathError{Op: "rename", Path: "secrets.yaml", Err: os.ErrPermission}
+	renameFile = func(oldpath, newpath string) error {
+		attempts++
+		if attempts < 3 {
+			return transientErr
+		}
+		return os.Rename(oldpath, newpath)
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.yaml")
+	if err := atomicWriteFile(path, []byte("token: abc\n"), 0o600); err != nil {
+		t.Fatalf("atomicWriteFile: %v", err)
+	}
+	if attempts != 3 {
+		t.Fatalf("attempts = %d, want 3 (2 transient failures + 1 success)", attempts)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != "token: abc\n" {
+		t.Fatalf("content = %q, want %q", got, "token: abc\n")
+	}
+	if _, statErr := os.Stat(path + ".partial"); !os.IsNotExist(statErr) {
+		t.Fatalf(".partial should not exist after eventual success, stat err=%v", statErr)
+	}
+}
+
+// TestAtomicWriteFileExhaustsRenameRetriesAndCleansUp pins the exhausted-retry
+// path: when the destination lock never releases, atomicWriteFile must give
+// up (not hang forever), return an error, and remove the .partial tmp file —
+// this is the path StagePendingCredentials relies on to know the staged
+// credential set was NOT written, so it must not confirm the rotation.
+func TestAtomicWriteFileExhaustsRenameRetriesAndCleansUp(t *testing.T) {
+	origRename := renameFile
+	defer func() { renameFile = origRename }()
+
+	attempts := 0
+	persistentErr := &os.PathError{Op: "rename", Path: "secrets.yaml", Err: os.ErrPermission}
+	renameFile = func(oldpath, newpath string) error {
+		attempts++
+		return persistentErr
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.yaml")
+	err := atomicWriteFile(path, []byte("token: abc\n"), 0o600)
+	if err == nil {
+		t.Fatalf("expected error from atomicWriteFile after exhausted retries, got nil")
+	}
+	if attempts != renameAttempts {
+		t.Fatalf("attempts = %d, want renameAttempts (%d)", attempts, renameAttempts)
+	}
+	if _, statErr := os.Stat(path + ".partial"); !os.IsNotExist(statErr) {
+		t.Fatalf(".partial should have been cleaned up after exhausted retries, stat err=%v", statErr)
+	}
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Fatalf("destination should not exist after exhausted retries, stat err=%v", statErr)
+	}
+}
+
+// TestWriteYAMLFileRetriesTransientRenameFailure covers writeYAMLFile's
+// separate rename call (the legacy config-write path, still used by
+// SetSecretAndPersist's sibling code paths) — it must share the same retry
+// behavior as atomicWriteFile rather than losing the write on the first
+// transient lock.
+func TestWriteYAMLFileRetriesTransientRenameFailure(t *testing.T) {
+	origRename := renameFile
+	defer func() { renameFile = origRename }()
+
+	attempts := 0
+	transientErr := &os.PathError{Op: "rename", Path: "secrets.yaml", Err: os.ErrPermission}
+	renameFile = func(oldpath, newpath string) error {
+		attempts++
+		if attempts < 2 {
+			return transientErr
+		}
+		return os.Rename(oldpath, newpath)
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.yaml")
+	if err := writeYAMLFile(path, map[string]any{"auth_token": "abc"}, 0o600); err != nil {
+		t.Fatalf("writeYAMLFile: %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2 (1 transient failure + 1 success)", attempts)
+	}
+}
+
 func TestMaxHeartbeatStalenessSecAlias(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "agent.yaml")


### PR DESCRIPTION
## Summary

`atomicWriteFile` and `writeYAMLFile` in `agent/internal/config/config.go` each called `os.Rename` exactly once when swapping their staged tmp file into place. On Windows, anything that briefly holds the destination open — reproduced in release QA as Windows Defender real-time scanning with zero exclusions configured — fails that single attempt outright, with no retry.

`StagePendingCredentials` (the phase-two credential persistence for two-phase token rotation, #2621) treats any write error from this path as "abort and discard the staged rotation." So one transient rename failure permanently loses that rotation attempt: the server's staged credential set then expires via `PENDING_ROTATION_TTL_MS`, `token_issued_at` never advances, `isAgentTokenRotationDue` stays true, and the next heartbeat stages again. This is the stage→expire→re-stage loop reported in this issue — `agent.token.rotate.confirmed` has never fired in production, while `agent.token.rotate.staged` climbs roughly hourly per affected device.

Root-caused and reproduced on a real Windows Server 2022 agent (v0.104.0) during release QA (see issue comment): forcing rotation three times produced the identical failure each time —

```
error="staging pending credentials: rename C:\ProgramData\Breeze\secrets.yaml.partial
C:\ProgramData\Breeze\secrets.yaml: The process cannot access the file because it is being used by another process."
```

## Fix

Adds `renameWithRetry`, a bounded jittered-backoff retry around the rename, mirroring the pattern already used in `agent/internal/state/state.go` (`Write`, `renameAttempts`/`renameBackoffBase`). Both `atomicWriteFile` and `writeYAMLFile` now route their rename through this shared helper instead of calling `os.Rename` directly once.

- **Longer schedule than state.go's:** 8 attempts vs state.go's 4 — state.go's own comment notes its 4 attempts (~175ms total) still lost on the exact machine that reproduced this bug, and the credential file is the one write that must not be silently dropped.
- **Jitter** added on top of the exponential backoff, since multiple goroutines (cert-renewal, command worker pool, heartbeat's own rotation path) can all reach a rename around the same time and would otherwise retry against the same transient holder in lockstep.
- Runs off `handleTokenRotation`'s own goroutine (`go h.handleTokenRotation()`), not the main heartbeat tick, so the added worst-case latency (a few seconds) doesn't block heartbeats.
- `renameFile` is a package-level seam (`var renameFile = os.Rename`) so tests can inject transient and permanent rename failures without touching the real filesystem semantics.

Deliberately scoped to the retry/backoff mirror the issue calls out — did not adopt `state.go`'s Windows POSIX-semantics rename primitive (`renameReplace`/`FILE_RENAME_INFO`), since that solves a different failure mode (a concurrent *reader* blocking `MoveFileEx`) than the one diagnosed here (a transient *exclusive* holder like an AV scanner), which `state.go`'s own comment notes POSIX semantics cannot bypass anyway — retry is the correct and sufficient fix for this failure mode.

## Testing

- `TestAtomicWriteFileRetriesTransientRenameFailure` — 2 injected transient failures then success; asserts content lands and no `.partial` leftover.
- `TestAtomicWriteFileExhaustsRenameRetriesAndCleansUp` — persistent failure; asserts it gives up after exactly `renameAttempts`, returns an error, and cleans up the `.partial` tmp (the signal `StagePendingCredentials` relies on to know the write did NOT land).
- `TestWriteYAMLFileRetriesTransientRenameFailure` — same coverage for the second call site.
- `go test -race ./internal/config/...` — pass.
- `go test -race ./internal/state/...` — pass (unaffected, verifies the pattern being mirrored still works).
- `go vet ./internal/...` — clean.
- `gofmt -l` on changed files — clean.

Closes #2772

🤖 Generated with [Claude Code](https://claude.com/claude-code)