### PR TITLE
fix(api): AUDIT_CHAIN_VERIFY_ENABLED=false must stop the sweep, not just the schedule

### DIFF
--- a/apps/api/src/jobs/auditChainVerify.test.ts
+++ b/apps/api/src/jobs/auditChainVerify.test.ts
@@ -385,6 +385,27 @@ describe('auditChainVerify worker', () => {
       expect((result as { orgsChecked: number }).orgsChecked).toBe(1);
     });
 
+    // The kill switch must stop the SWEEP, not just the schedule. A job that
+    // is already in Redis (queued, or active at the moment the container is
+    // recreated — BullMQ hands a stalled job straight back to the next worker)
+    // was re-run in full on US on 2026-09-03 with the flag set, 13 h of DB IO.
+    it('does not consume the queue at all when disabled by env flag', async () => {
+      process.env.AUDIT_CHAIN_VERIFY_ENABLED = 'false';
+      const { initializeAuditChainVerifyWorker } = await import('./auditChainVerify');
+      await initializeAuditChainVerifyWorker();
+      expect(capturedWorkerProcessor.current).toBeNull();
+      expect(workerCloseMock).not.toHaveBeenCalled();
+    });
+
+    it('skips a delivered job without touching the DB when disabled by env flag', async () => {
+      const { createAuditChainVerifyWorker } = await import('./auditChainVerify');
+      createAuditChainVerifyWorker();
+      process.env.AUDIT_CHAIN_VERIFY_ENABLED = 'false';
+      const result = await capturedWorkerProcessor.current!({ name: 'audit-chain-verify' });
+      expect(result).toMatchObject({ skipped: true, orgsChecked: 0 });
+      expect(dbExecuteMock).not.toHaveBeenCalled();
+    });
+
     it('ignores unknown job names', async () => {
       const { createAuditChainVerifyWorker } = await import('./auditChainVerify');
       createAuditChainVerifyWorker();

--- a/apps/api/src/jobs/auditChainVerify.ts
+++ b/apps/api/src/jobs/auditChainVerify.ts
@@ -47,8 +47,11 @@
  * late enough that the nightly retention prune (which re-anchors chain heads)
  * has already settled.
  *
- * Kill switch: `AUDIT_CHAIN_VERIFY_ENABLED=false` skips schedule registration
- * (the worker still drains manual `add()` calls for incident response).
+ * Kill switch: `AUDIT_CHAIN_VERIFY_ENABLED=false` removes the repeatable,
+ * does not start the worker, and makes any delivered job a no-op (see
+ * initializeAuditChainVerifyWorker and the processor guard). While disabled,
+ * manual `add()` calls for incident response park in Redis until re-enabled;
+ * call verifyAuditChains() directly instead.
  */
 
 import { Queue, Worker, Job } from 'bullmq';
@@ -349,6 +352,15 @@ export function createAuditChainVerifyWorker(): Worker {
         console.warn(`[AuditChainVerify] Ignoring unknown job name: ${job.name}`);
         return { skipped: true, orgsChecked: 0 };
       }
+      // Belt and braces for the kill switch: a job can still reach a running
+      // worker (queued before the flag flipped, or re-delivered by BullMQ's
+      // stalled-job recovery). Never start the sweep while disabled.
+      if (!isEnabled()) {
+        console.log(
+          `[AuditChainVerify] AUDIT_CHAIN_VERIFY_ENABLED=false — skipping delivered job ${job.id ?? ''}`.trimEnd(),
+        );
+        return { skipped: true, orgsChecked: 0 };
+      }
       return verifyAuditChains();
     },
     {
@@ -397,6 +409,20 @@ export async function scheduleAuditChainVerify(
 
 export async function initializeAuditChainVerifyWorker(): Promise<void> {
   try {
+    if (!isEnabled()) {
+      // Kill switch: no consumer at all. Registering only the schedule-skip
+      // was not enough — when the US api container was recreated with the
+      // flag set (2026-09-03), BullMQ handed the in-flight sweep back to the
+      // freshly created worker as a stalled job and it re-ran every org from
+      // the start (13 h of DB IO). Still call scheduleAuditChainVerify() so a
+      // previously registered repeatable is removed.
+      await scheduleAuditChainVerify();
+      console.log(
+        '[AuditChainVerify] AUDIT_CHAIN_VERIFY_ENABLED=false — worker not started; queued jobs stay parked until re-enabled',
+      );
+      return;
+    }
+
     createAuditChainVerifyWorker();
 
     verifyWorker?.on('error', (error) => {


### PR DESCRIPTION
## Why

`AUDIT_CHAIN_VERIFY_ENABLED=false` is the documented stop-gap for the full-chain verify saturating the US managed DB until #4548 ships in v0.110. It only skipped repeatable registration. The worker was still created and consumed the queue, so when the US api container was recreated with the flag set today, BullMQ's stalled-job recovery handed the in-flight nightly sweep back to the new worker and it re-ran every org from the start. Found by a follow-up check 2.5 h later: `audit_log_verify_chain` was active again for 1 h+.

Ops recovery on US (done): `docker compose stop api`, `pg_cancel_backend` on the verify query, `DEL` of all `bull:audit-chain-verify:*` keys in Redis, `docker compose up -d api`. Cost ~90 s of API downtime.

## What

When disabled, `initializeAuditChainVerifyWorker` still calls `scheduleAuditChainVerify()` (which removes the repeatable) but does not start a worker, and the worker processor itself returns `{ skipped: true, orgsChecked: 0 }` without touching the DB if a job reaches it anyway (queued before the flag flipped). Queued jobs park in Redis until re-enabled.

## Tests

`auditChainVerify.test.ts`: two new cases, written red first — no processor is registered when disabled; a delivered job is skipped with zero DB calls when disabled. 18/18 green, tsc and eslint clean.

Related: #4548 (incremental verify, unreleased), PR #4835 (today's feed fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016g2n6u6D73cH6HxdLPgM2G
