### PR TITLE
fix(api): cap the device Activities-tab audit count at 10,000 (#4834)

### DIFF
--- a/apps/api/src/routes/devices/events.test.ts
+++ b/apps/api/src/routes/devices/events.test.ts
@@ -1,41 +1,75 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
 
-// Tracks how many times the count(*) query (db.select({ count })...where()) is
-// issued, so tests can prove the unbounded count is skipped unless withTotal is
-// set. The count select is distinguishable from the row select by its shape:
-// the count projection has a `count` key; the row projection does not.
+// Tracks how many times the capped count query (the OUTER `select({ count
+// })...from(<capped derived table>)`) is issued, so tests can prove the count
+// is skipped unless withTotal is set. Distinguished from the row select by
+// its projection shape: the count projection has a `count` key, the row
+// projection does not.
 const countQueryCalls = vi.fn();
 // Captures the WHERE condition handed to the feed query so tests can prove the
 // org_id scoping is present (BREEZE-B — it is load-bearing for performance, not
 // cosmetic; see the comment in events.ts).
 const feedWhereArgs: unknown[] = [];
+// Captures the WHERE/LIMIT the capped-count derived table builds (#4834), so
+// tests can prove (a) it reuses the arm's `where` unchanged — same predicate,
+// same index — and (b) the count is genuinely bounded, never an unbounded
+// count(*). `mockCappedCounts` is consumed FIFO in build order (resource arm,
+// then details arm) so a test can drive below-cap / above-cap scenarios.
+const cappedCountWhereArgs: unknown[] = [];
+const cappedCountLimitArgs: { limit: number }[] = [];
+let mockCappedCounts: number[] = [];
 
 vi.mock('../../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
   withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
   withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: {
-    select: vi.fn((projection?: Record<string, unknown>) => ({
-      from: vi.fn(() => ({
-        leftJoin: vi.fn(() => ({
-          where: vi.fn((cond: unknown) => {
-            feedWhereArgs.push(cond);
-            return {
-              orderBy: vi.fn(() => ({
-                // Each feed arm is a bounded `limit(offset + limit)` read; the
-                // page is cut client-side by mergeFeedPage. No `.offset()`.
-                limit: vi.fn().mockResolvedValue([])
-              }))
-            };
+    select: vi.fn((projection?: Record<string, unknown>) => {
+      // Inner capped-count derived table: `SELECT 1 FROM audit_logs WHERE
+      // <arm predicate> LIMIT (cap + 1)`, later wrapped in `.as(...)`.
+      if (projection && 'one' in projection) {
+        return {
+          from: vi.fn(() => ({
+            where: vi.fn((cond: unknown) => {
+              cappedCountWhereArgs.push(cond);
+              return {
+                limit: vi.fn((n: number) => {
+                  cappedCountLimitArgs.push({ limit: n });
+                  return { as: vi.fn(() => ({ __cappedSubquery: true })) };
+                })
+              };
+            })
+          }))
+        };
+      }
+      // Outer `SELECT count(*) FROM (<capped derived table>) t`.
+      if (projection && 'count' in projection) {
+        return {
+          from: vi.fn(() => {
+            countQueryCalls();
+            return Promise.resolve([{ count: mockCappedCounts.shift() ?? 0 }]);
           })
-        })),
-        where: vi.fn(() => {
-          if (projection && 'count' in projection) countQueryCalls();
-          return Promise.resolve([{ count: 0 }]);
-        }),
-      }))
-    })),
+        };
+      }
+      // Row-projection feed-arm read (unchanged).
+      return {
+        from: vi.fn(() => ({
+          leftJoin: vi.fn(() => ({
+            where: vi.fn((cond: unknown) => {
+              feedWhereArgs.push(cond);
+              return {
+                orderBy: vi.fn(() => ({
+                  // Each feed arm is a bounded `limit(offset + limit)` read; the
+                  // page is cut client-side by mergeFeedPage. No `.offset()`.
+                  limit: vi.fn().mockResolvedValue([])
+                }))
+              };
+            })
+          }))
+        }))
+      };
+    }),
   }
 }));
 
@@ -86,7 +120,7 @@ vi.mock('./helpers', () => ({
   SITE_ACCESS_DENIED: Symbol('SITE_ACCESS_DENIED'),
 }));
 
-import { eventsRoutes, likePrefixPattern, formatActionMessage, mergeFeedPage } from './events';
+import { eventsRoutes, likePrefixPattern, formatActionMessage, mergeFeedPage, FEED_TOTAL_CAP } from './events';
 
 describe('likePrefixPattern (action-prefix LIKE escaping)', () => {
   it('appends a trailing wildcard for a clean dotted prefix', () => {
@@ -136,6 +170,9 @@ describe('GET /devices/:id/events validation', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCappedCounts = [];
+    cappedCountWhereArgs.length = 0;
+    cappedCountLimitArgs.length = 0;
     app = new Hono();
     app.route('/devices', eventsRoutes);
   });
@@ -257,6 +294,57 @@ describe('GET /devices/:id/events validation', () => {
     expect(countQueryCalls).toHaveBeenCalledTimes(2);
   });
 
+  // #4834 stop-gap: cap the withTotal count instead of walking the device's
+  // whole audit history (option 2 of the three the issue lays out).
+  it('reports the exact sum and totalIsLowerBound=false when both arms are below the cap', async () => {
+    mockCappedCounts = [40, 10];
+    const res = await app.request(
+      '/devices/11111111-1111-1111-1111-111111111111/events?limit=10&withTotal=true',
+      { method: 'GET', headers: { Authorization: 'Bearer token' } }
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      pagination: { total: number; totalIsLowerBound: boolean };
+    };
+    expect(json.pagination.total).toBe(50);
+    expect(json.pagination.totalIsLowerBound).toBe(false);
+  });
+
+  it('clamps total to FEED_TOTAL_CAP and sets totalIsLowerBound=true when the summed raw count exceeds the cap', async () => {
+    mockCappedCounts = [8000, 3000]; // sum 11000 > FEED_TOTAL_CAP (10000)
+    const res = await app.request(
+      '/devices/11111111-1111-1111-1111-111111111111/events?limit=10&withTotal=true',
+      { method: 'GET', headers: { Authorization: 'Bearer token' } }
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      pagination: { total: number; totalIsLowerBound: boolean };
+    };
+    expect(json.pagination.total).toBe(FEED_TOTAL_CAP);
+    expect(json.pagination.totalIsLowerBound).toBe(true);
+  });
+
+  it('caps the count query per arm at FEED_TOTAL_CAP + 1 and reuses the arm predicate unchanged', async () => {
+    feedWhereArgs.length = 0;
+    mockCappedCounts = [5, 5];
+    const res = await app.request(
+      '/devices/11111111-1111-1111-1111-111111111111/events?withTotal=true',
+      { method: 'GET', headers: { Authorization: 'Bearer token' } }
+    );
+    expect(res.status).toBe(200);
+    // The count query is genuinely bounded — never an unbounded count(*).
+    expect(JSON.stringify(cappedCountLimitArgs)).toContain('limit');
+    expect(cappedCountLimitArgs).toEqual([
+      { limit: FEED_TOTAL_CAP + 1 },
+      { limit: FEED_TOTAL_CAP + 1 },
+    ]);
+    // Same predicate as the row read, arm for arm, so the count hits the same
+    // index the row read for that arm uses.
+    expect(cappedCountWhereArgs).toHaveLength(2);
+    expect(JSON.stringify(cappedCountWhereArgs[0])).toBe(JSON.stringify(feedWhereArgs[0]));
+    expect(JSON.stringify(cappedCountWhereArgs[1])).toBe(JSON.stringify(feedWhereArgs[1]));
+  });
+
   it('rejects an invalid withTotal value with 400', async () => {
     const res = await app.request(
       '/devices/11111111-1111-1111-1111-111111111111/events?withTotal=maybe',
@@ -272,6 +360,9 @@ describe("GET /devices/:id/events — org scoping of the audit feed (BREEZE-B)",
   beforeEach(() => {
     vi.clearAllMocks();
     feedWhereArgs.length = 0;
+    mockCappedCounts = [];
+    cappedCountWhereArgs.length = 0;
+    cappedCountLimitArgs.length = 0;
     app = new Hono();
     app.route('/devices', eventsRoutes);
   });
@@ -312,6 +403,9 @@ describe('GET /devices/:id/events — two-arm feed predicate (RLS index promotab
   beforeEach(() => {
     vi.clearAllMocks();
     feedWhereArgs.length = 0;
+    mockCappedCounts = [];
+    cappedCountWhereArgs.length = 0;
+    cappedCountLimitArgs.length = 0;
     app = new Hono();
     app.route('/devices', eventsRoutes);
   });

--- a/apps/api/src/routes/devices/events.ts
+++ b/apps/api/src/routes/devices/events.ts
@@ -103,6 +103,14 @@ export const DETAILS_HAS_DEVICE_ID: SQL = sql`${auditLogs.details} ? 'deviceId'`
 // fixed-width text key sorts exactly like the column.
 export const FEED_SORT_KEY: SQL<string> = sql<string>`to_char(${auditLogs.timestamp}, 'YYYYMMDDHH24MISSUS')`;
 
+// Stop-gap cap for the Activities-tab `withTotal` count (#4834, option 2 of
+// the three the issue lays out). Past this many matching rows in an arm, the
+// count query stops instead of walking the rest of the device's audit
+// history, and the UI renders "10,000+" instead of an exact total. The root
+// fix — de-telemetrying audit_logs so the count is cheap outright — is
+// #4340 / #4021.
+export const FEED_TOTAL_CAP = 10000;
+
 // Merge the two feed arms (each already ordered timestamp DESC, id DESC in SQL
 // and bounded to offset+limit rows) and cut the requested page. Exact for any
 // offset because the top-(offset+limit) of the union is contained in the union
@@ -329,14 +337,31 @@ eventsRoutes.get(
         .orderBy(desc(auditLogs.timestamp), desc(auditLogs.id))
         .limit(fetchLimit);
 
-    // The total is an unbounded count(*) over the device's whole audit history;
-    // only run it when the caller actually renders a total (issue #1726).
-    const countArm = (where: SQL) =>
-      db
-        .select({ count: sql<number>`count(*)::int` })
+    // Only run the count when the caller actually renders a total (issue
+    // #1726); when it does run, cap it (issue #4834 stop-gap — option 2 of
+    // the three in that issue; the root fix, de-telemetrying audit_logs, is
+    // #4340 / #4021). An uncapped count(*) over a device's whole audit
+    // history read 76k rows (99% agent telemetry) in 118s on US prod, because
+    // the RLS org_id filter forces a heap fetch per row and the table is
+    // never vacuumed (no visibility map for an index-only count). Capping
+    // each arm's count at FEED_TOTAL_CAP + 1 rows via a LIMIT inside a
+    // derived table makes the query stop after that many matches instead of
+    // scanning the rest of the device's history — cost is now bounded
+    // regardless of how large that history grows. The inner SELECT stays on
+    // auditLogs alone (no join to `users`) and reuses the arm's `where`
+    // unchanged, so it hits the same index the row read for that arm uses.
+    const countArm = (where: SQL) => {
+      const cappedRows = db
+        .select({ one: sql`1` })
         .from(auditLogs)
         .where(where)
+        .limit(FEED_TOTAL_CAP + 1)
+        .as('capped_rows');
+      return db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(cappedRows)
         .then((r) => Number(r[0]?.count ?? 0));
+    };
 
     const [resourceRows, detailsRows, resourceCount, detailsCount] = await Promise.all([
       selectArm(resourceArm),
@@ -346,8 +371,19 @@ eventsRoutes.get(
     ]);
 
     const rows = mergeFeedPage(resourceRows, detailsRows, offset, limit);
-    const total =
-      resourceCount === null || detailsCount === null ? null : resourceCount + detailsCount;
+
+    // Each arm's count is itself capped at FEED_TOTAL_CAP + 1, so the raw sum
+    // can read anywhere up to 2 * (FEED_TOTAL_CAP + 1) — that's fine, since
+    // all we need past the cap is the boolean "more than FEED_TOTAL_CAP rows
+    // matched", not a precise number. When the sum is at or under the cap,
+    // neither arm could have hit its own +1 ceiling, so the sum is exact.
+    let total: number | null = null;
+    let totalIsLowerBound = false;
+    if (resourceCount !== null && detailsCount !== null) {
+      const rawTotal = resourceCount + detailsCount;
+      totalIsLowerBound = rawTotal > FEED_TOTAL_CAP;
+      total = totalIsLowerBound ? FEED_TOTAL_CAP : rawTotal;
+    }
 
     const data = rows.map((row) => ({
       id: row.id,
@@ -374,7 +410,10 @@ eventsRoutes.get(
 
     return c.json({
       data,
-      pagination: { page, limit, total },
+      pagination:
+        total === null
+          ? { page, limit, total }
+          : { page, limit, total, totalIsLowerBound },
     });
   }
 );

--- a/apps/web/src/components/devices/DeviceEventLogViewer.test.tsx
+++ b/apps/web/src/components/devices/DeviceEventLogViewer.test.tsx
@@ -107,4 +107,31 @@ describe('DeviceEventLogViewer — capped total (#4834)', () => {
     await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalledTimes(2));
     await waitFor(() => expect(screen.getByTestId('event-log-next-page')).toBeDisabled());
   });
+
+  it('handles an empty page past the cap without an inverted range, and disables Next', async () => {
+    // The true total lands exactly on a page-size boundary above the cap
+    // (e.g. 10,050 with a 50-row page): the last full page (page 1 here)
+    // still reports totalIsLowerBound, so Next stays enabled and the tech
+    // pages to page 2, which is genuinely past the end and comes back empty.
+    fetchWithAuthMock.mockImplementation((url: string) => {
+      const page = pageFromUrl(url);
+      const rows = page === 1 ? 50 : 0;
+      return Promise.resolve(
+        jsonResponse({
+          data: Array.from({ length: rows }, (_, i) => activity(`p${page}-${i}`)),
+          pagination: { page, limit: 50, total: 10000, totalIsLowerBound: true },
+        }),
+      );
+    });
+    render(<DeviceEventLogViewer deviceId="dev-1" />);
+    await screen.findByTestId('event-log-total');
+    await userEvent.click(screen.getByTestId('event-log-next-page'));
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalledTimes(2));
+
+    const status = await screen.findByTestId('event-log-pagination-status');
+    // No inverted "10051–10050 of 10,000+" range on the empty page.
+    await waitFor(() => expect(status).toHaveTextContent('No more activity'));
+    expect(status).not.toHaveTextContent('–');
+    await waitFor(() => expect(screen.getByTestId('event-log-next-page')).toBeDisabled());
+  });
 });

--- a/apps/web/src/components/devices/DeviceEventLogViewer.test.tsx
+++ b/apps/web/src/components/devices/DeviceEventLogViewer.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import DeviceEventLogViewer from './DeviceEventLogViewer';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+const jsonResponse = (payload: unknown, ok = true): Response =>
+  ({ ok, status: ok ? 200 : 500, json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const activity = (id: string) => ({
+  id,
+  timestamp: new Date().toISOString(),
+  action: 'device.update',
+  message: `Event ${id}`,
+  category: 'device',
+  result: 'success',
+  actor: { type: 'user', name: 'Ada', email: null },
+  resource: { type: 'device', id: 'dev-1', name: 'host-1' },
+  initiatedBy: 'manual',
+  details: null,
+  errorMessage: null,
+  ipAddress: null,
+});
+
+function pageFromUrl(url: string): number {
+  return Number(new URL(url, 'http://example.test').searchParams.get('page') ?? '1');
+}
+
+// #4834: the API caps the withTotal count at FEED_TOTAL_CAP and reports
+// pagination.totalIsLowerBound instead of walking a device's whole audit
+// history. This viewer is the only caller that renders a total (it always
+// sends withTotal=true; DeviceActivityFeed does not and is untouched by this
+// change) and must (a) show "10,000+" instead of an exact-looking number past
+// the cap, and (b) let the tech keep paging past the cap when the last page
+// came back full — the only signal there might be more.
+describe('DeviceEventLogViewer — capped total (#4834)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders the exact total when totalIsLowerBound is false', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      jsonResponse({
+        data: [activity('e1'), activity('e2'), activity('e3')],
+        pagination: { page: 1, limit: 50, total: 3, totalIsLowerBound: false },
+      }),
+    );
+    render(<DeviceEventLogViewer deviceId="dev-1" />);
+    const total = await screen.findByTestId('event-log-total');
+    expect(total).toHaveTextContent('3');
+    expect(total).not.toHaveTextContent('+');
+  });
+
+  it('renders "10,000+" instead of an exact number when totalIsLowerBound is true', async () => {
+    fetchWithAuthMock.mockResolvedValue(
+      jsonResponse({
+        data: Array.from({ length: 50 }, (_, i) => activity(`e${i}`)),
+        pagination: { page: 1, limit: 50, total: 10000, totalIsLowerBound: true },
+      }),
+    );
+    render(<DeviceEventLogViewer deviceId="dev-1" />);
+    const total = await screen.findByTestId('event-log-total');
+    expect(total).toHaveTextContent('10,000+');
+  });
+
+  it('keeps Next enabled past the reported total when the last page came back full', async () => {
+    fetchWithAuthMock.mockImplementation((url: string) => {
+      const page = pageFromUrl(url);
+      return Promise.resolve(
+        jsonResponse({
+          // Both pages come back full — the API can't say whether there is a
+          // page 3, only that page 2 wasn't the end.
+          data: Array.from({ length: 50 }, (_, i) => activity(`p${page}-${i}`)),
+          pagination: { page, limit: 50, total: 100, totalIsLowerBound: true },
+        }),
+      );
+    });
+    render(<DeviceEventLogViewer deviceId="dev-1" />);
+    await screen.findByTestId('event-log-total');
+    const next = screen.getByTestId('event-log-next-page');
+    expect(next).not.toBeDisabled();
+
+    await userEvent.click(next);
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalledTimes(2));
+    // page is now 2 === totalPages (ceil(100/50)); a plain page<totalPages
+    // check would disable Next here. It must stay enabled because the
+    // just-fetched page 2 came back full and totalIsLowerBound is true.
+    await waitFor(() => expect(screen.getByTestId('event-log-next-page')).not.toBeDisabled());
+  });
+
+  it('disables Next once a page comes back partial, even when totalIsLowerBound is true', async () => {
+    fetchWithAuthMock.mockImplementation((url: string) => {
+      const page = pageFromUrl(url);
+      const rows = page === 1 ? 50 : 20; // page 2 is the true end of the feed
+      return Promise.resolve(
+        jsonResponse({
+          data: Array.from({ length: rows }, (_, i) => activity(`p${page}-${i}`)),
+          pagination: { page, limit: 50, total: 100, totalIsLowerBound: true },
+        }),
+      );
+    });
+    render(<DeviceEventLogViewer deviceId="dev-1" />);
+    await screen.findByTestId('event-log-total');
+    await userEvent.click(screen.getByTestId('event-log-next-page'));
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.getByTestId('event-log-next-page')).toBeDisabled());
+  });
+});

--- a/apps/web/src/components/devices/DeviceEventLogViewer.tsx
+++ b/apps/web/src/components/devices/DeviceEventLogViewer.tsx
@@ -349,13 +349,18 @@ export default function DeviceEventLogViewer({
       })
     : formatNumber(pagination.total);
 
-  // totalPages is derived from the (possibly capped) total, so once the user
-  // pages past it the button must stay enabled as long as the last page came
-  // back full — that's the only signal there could be more rows beyond the
-  // cap, since the exact remaining count isn't known.
-  const canGoNext =
-    page < totalPages ||
-    (pagination.totalIsLowerBound && activities.length === pagination.limit);
+  // A page is short (fewer than `limit` rows) only when it is genuinely the
+  // last one — the API always fills a page to `limit` until the underlying
+  // result set runs out (mergeFeedPage slices a top-N union). That holds
+  // whether or not a total was even requested, so it's a more reliable "is
+  // there more" signal than comparing `page` to `totalPages`, which is
+  // derived from a total that's clamped past FEED_TOTAL_CAP (#4834) — a
+  // page<totalPages check would misfire exactly when the true count lands on
+  // a page-size boundary above the cap (e.g. true total 10,050 with a 50-row
+  // page: the last full page still reports totalIsLowerBound, so Next must
+  // stay enabled there and only disable once the following, empty page comes
+  // back).
+  const canGoNext = activities.length === pagination.limit;
 
   if (error) {
     return (
@@ -718,12 +723,26 @@ export default function DeviceEventLogViewer({
         {/* Pagination */}
         {!loading && pagination.total > pagination.limit && (
           <div className="flex items-center justify-between border-t px-4 py-3">
-            <p className="text-xs text-muted-foreground">
-              {t("deviceEventLogViewer.showing")}{" "}
-              {(page - 1) * pagination.limit + 1}
-              {t("deviceEventLogViewer.text")}
-              {(page - 1) * pagination.limit + activities.length}{" "}
-              {t("deviceEventLogViewer.of")} {formattedTotal}
+            <p
+              className="text-xs text-muted-foreground"
+              data-testid="event-log-pagination-status"
+            >
+              {/* Past FEED_TOTAL_CAP (#4834) the true total is unknown, so
+                  paging can overshoot the real end by one page — that page
+                  comes back empty. Compute the range from the rows actually
+                  returned rather than from `limit`, or the trailing page
+                  renders an inverted "10051–10050" range. */}
+              {activities.length === 0 ? (
+                t("deviceEventLogViewer.noMoreActivity")
+              ) : (
+                <>
+                  {t("deviceEventLogViewer.showing")}{" "}
+                  {(page - 1) * pagination.limit + 1}
+                  {t("deviceEventLogViewer.text")}
+                  {(page - 1) * pagination.limit + activities.length}{" "}
+                  {t("deviceEventLogViewer.of")} {formattedTotal}
+                </>
+              )}
             </p>
             <div className="flex items-center gap-1">
               <button
@@ -735,7 +754,7 @@ export default function DeviceEventLogViewer({
                 <ChevronLeft className="h-4 w-4" />
               </button>
               <span className="px-2 text-xs text-muted-foreground">
-                {page} / {totalPages}
+                {page} / {Math.max(totalPages, page)}
               </span>
               <button
                 type="button"

--- a/apps/web/src/components/devices/DeviceEventLogViewer.tsx
+++ b/apps/web/src/components/devices/DeviceEventLogViewer.tsx
@@ -265,6 +265,11 @@ export default function DeviceEventLogViewer({
     page: 1,
     limit: 50,
     total: 0,
+    // Stop-gap for #4834: past FEED_TOTAL_CAP (10,000) matching rows the API
+    // stops counting and reports a lower bound instead of an exact total.
+    // This view always sends withTotal=true, so the field is always present
+    // on a real response.
+    totalIsLowerBound: false,
   });
 
   const effectiveTimezone =
@@ -335,6 +340,23 @@ export default function DeviceEventLogViewer({
     Math.ceil(pagination.total / pagination.limit),
   );
 
+  // #4834: past FEED_TOTAL_CAP the API clamps `total` and sets
+  // totalIsLowerBound, so render "10,000+" instead of a number that looks
+  // precise but isn't.
+  const formattedTotal = pagination.totalIsLowerBound
+    ? t("deviceEventLogViewer.totalAtLeast", {
+        count: formatNumber(pagination.total),
+      })
+    : formatNumber(pagination.total);
+
+  // totalPages is derived from the (possibly capped) total, so once the user
+  // pages past it the button must stay enabled as long as the last page came
+  // back full — that's the only signal there could be more rows beyond the
+  // cap, since the exact remaining count isn't known.
+  const canGoNext =
+    page < totalPages ||
+    (pagination.totalIsLowerBound && activities.length === pagination.limit);
+
   if (error) {
     return (
       <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-6 text-center">
@@ -362,8 +384,11 @@ export default function DeviceEventLogViewer({
               {t("deviceEventLogViewer.activities")}
             </h3>
             {!loading && (
-              <span className="ml-1 text-sm text-muted-foreground">
-                ({formatNumber(pagination.total)}{" "}
+              <span
+                className="ml-1 text-sm text-muted-foreground"
+                data-testid="event-log-total"
+              >
+                ({formattedTotal}{" "}
                 {t("deviceEventLogViewer.total")}{" "}
               </span>
             )}
@@ -697,8 +722,8 @@ export default function DeviceEventLogViewer({
               {t("deviceEventLogViewer.showing")}{" "}
               {(page - 1) * pagination.limit + 1}
               {t("deviceEventLogViewer.text")}
-              {Math.min(page * pagination.limit, pagination.total)}{" "}
-              {t("deviceEventLogViewer.of")} {formatNumber(pagination.total)}
+              {(page - 1) * pagination.limit + activities.length}{" "}
+              {t("deviceEventLogViewer.of")} {formattedTotal}
             </p>
             <div className="flex items-center gap-1">
               <button
@@ -714,8 +739,9 @@ export default function DeviceEventLogViewer({
               </span>
               <button
                 type="button"
-                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
-                disabled={page >= totalPages}
+                data-testid="event-log-next-page"
+                onClick={() => setPage((p) => p + 1)}
+                disabled={!canGoNext}
                 className="inline-flex h-7 w-7 items-center justify-center rounded-md border text-muted-foreground transition hover:bg-muted disabled:opacity-40"
               >
                 <ChevronRight className="h-4 w-4" />

--- a/apps/web/src/locales/de-DE/devices.json
+++ b/apps/web/src/locales/de-DE/devices.json
@@ -664,6 +664,7 @@
     "retry": "Versuchen Sie es noch einmal",
     "activities": "Aktivitäten",
     "total": "insgesamt)",
+    "totalAtLeast": "{{count}}+",
     "searchActivities": "Aktivitäten suchen...",
     "all": "Alle",
     "success": "Erfolg",

--- a/apps/web/src/locales/de-DE/devices.json
+++ b/apps/web/src/locales/de-DE/devices.json
@@ -664,7 +664,7 @@
     "retry": "Versuchen Sie es noch einmal",
     "activities": "Aktivitäten",
     "total": "insgesamt)",
-    "totalAtLeast": "{{count}}+",
+    "totalAtLeast": "{{count}} oder mehr",
     "searchActivities": "Aktivitäten suchen...",
     "all": "Alle",
     "success": "Erfolg",
@@ -684,7 +684,8 @@
     "details": "Details",
     "showing": "Zeigt",
     "text": "–",
-    "of": "von"
+    "of": "von",
+    "noMoreActivity": "Keine weitere Aktivität"
   },
   "deviceFilesystemTab": {
     "failedToFetchFilesystemStatus": "Dateisystemstatus konnte nicht abgerufen werden",

--- a/apps/web/src/locales/en/devices.json
+++ b/apps/web/src/locales/en/devices.json
@@ -684,7 +684,8 @@
     "details": "Details",
     "showing": "Showing",
     "text": "–",
-    "of": "of"
+    "of": "of",
+    "noMoreActivity": "No more activity"
   },
   "deviceFilesystemTab": {
     "failedToFetchFilesystemStatus": "Failed to fetch filesystem status",

--- a/apps/web/src/locales/en/devices.json
+++ b/apps/web/src/locales/en/devices.json
@@ -664,6 +664,7 @@
     "retry": "Retry",
     "activities": "Activities",
     "total": "total)",
+    "totalAtLeast": "{{count}}+",
     "searchActivities": "Search activities...",
     "all": "All",
     "success": "Success",

--- a/apps/web/src/locales/es-419/devices.json
+++ b/apps/web/src/locales/es-419/devices.json
@@ -664,7 +664,7 @@
     "retry": "Reintentar",
     "activities": "Actividades",
     "total": "total)",
-    "totalAtLeast": "{{count}}+",
+    "totalAtLeast": "{{count}} o más",
     "searchActivities": "Buscar actividades...",
     "all": "Todo",
     "success": "Éxito",
@@ -684,7 +684,8 @@
     "details": "Detalles",
     "showing": "Mostrando",
     "text": "–",
-    "of": "de"
+    "of": "de",
+    "noMoreActivity": "No hay más actividad"
   },
   "deviceFilesystemTab": {
     "failedToFetchFilesystemStatus": "No se pudo recuperar el estado del sistema de archivos",

--- a/apps/web/src/locales/es-419/devices.json
+++ b/apps/web/src/locales/es-419/devices.json
@@ -664,6 +664,7 @@
     "retry": "Reintentar",
     "activities": "Actividades",
     "total": "total)",
+    "totalAtLeast": "{{count}}+",
     "searchActivities": "Buscar actividades...",
     "all": "Todo",
     "success": "Éxito",

--- a/apps/web/src/locales/fr-CA/devices.json
+++ b/apps/web/src/locales/fr-CA/devices.json
@@ -664,7 +664,7 @@
     "retry": "Réessayer",
     "activities": "Activités",
     "total": "total)",
-    "totalAtLeast": "{{count}}+",
+    "totalAtLeast": "{{count}} ou plus",
     "searchActivities": "Rechercher des activités...",
     "all": "Tous",
     "success": "Succès",
@@ -684,7 +684,8 @@
     "details": "Détails",
     "showing": "Affichage",
     "text": "–",
-    "of": "de"
+    "of": "de",
+    "noMoreActivity": "Plus aucune activité"
   },
   "deviceFilesystemTab": {
     "failedToFetchFilesystemStatus": "Impossible de récupérer l’état du système de fichiers",

--- a/apps/web/src/locales/fr-CA/devices.json
+++ b/apps/web/src/locales/fr-CA/devices.json
@@ -664,6 +664,7 @@
     "retry": "Réessayer",
     "activities": "Activités",
     "total": "total)",
+    "totalAtLeast": "{{count}}+",
     "searchActivities": "Rechercher des activités...",
     "all": "Tous",
     "success": "Succès",

--- a/apps/web/src/locales/fr-FR/devices.json
+++ b/apps/web/src/locales/fr-FR/devices.json
@@ -664,7 +664,7 @@
     "retry": "Réessayer",
     "activities": "Activités",
     "total": "total)",
-    "totalAtLeast": "{{count}}+",
+    "totalAtLeast": "{{count}} ou plus",
     "searchActivities": "Rechercher des activités...",
     "all": "Tous",
     "success": "Succès",
@@ -684,7 +684,8 @@
     "details": "Détails",
     "showing": "Affichage",
     "text": "–",
-    "of": "de"
+    "of": "de",
+    "noMoreActivity": "Plus aucune activité"
   },
   "deviceFilesystemTab": {
     "failedToFetchFilesystemStatus": "Impossible de récupérer l’état du système de fichiers",

--- a/apps/web/src/locales/fr-FR/devices.json
+++ b/apps/web/src/locales/fr-FR/devices.json
@@ -664,6 +664,7 @@
     "retry": "Réessayer",
     "activities": "Activités",
     "total": "total)",
+    "totalAtLeast": "{{count}}+",
     "searchActivities": "Rechercher des activités...",
     "all": "Tous",
     "success": "Succès",

--- a/apps/web/src/locales/it-IT/devices.json
+++ b/apps/web/src/locales/it-IT/devices.json
@@ -664,7 +664,7 @@
     "retry": "Riprova",
     "activities": "Attività",
     "total": "in totale)",
-    "totalAtLeast": "{{count}}+",
+    "totalAtLeast": "{{count}} o più",
     "searchActivities": "Cerca attività...",
     "all": "Tutte",
     "success": "Riuscito",
@@ -684,7 +684,8 @@
     "details": "Dettagli",
     "showing": "Visualizzati",
     "text": "–",
-    "of": "di"
+    "of": "di",
+    "noMoreActivity": "Nessun’altra attività"
   },
   "deviceFilesystemTab": {
     "failedToFetchFilesystemStatus": "Impossibile recuperare lo stato del filesystem",

--- a/apps/web/src/locales/it-IT/devices.json
+++ b/apps/web/src/locales/it-IT/devices.json
@@ -664,6 +664,7 @@
     "retry": "Riprova",
     "activities": "Attività",
     "total": "in totale)",
+    "totalAtLeast": "{{count}}+",
     "searchActivities": "Cerca attività...",
     "all": "Tutte",
     "success": "Riuscito",

--- a/apps/web/src/locales/pt-BR/devices.json
+++ b/apps/web/src/locales/pt-BR/devices.json
@@ -664,6 +664,7 @@
     "retry": "Tentar novamente",
     "activities": "Atividades",
     "total": "total)",
+    "totalAtLeast": "{{count}}+",
     "searchActivities": "Pesquisar atividades...",
     "all": "Todos",
     "success": "Sucesso",

--- a/apps/web/src/locales/pt-BR/devices.json
+++ b/apps/web/src/locales/pt-BR/devices.json
@@ -664,7 +664,7 @@
     "retry": "Tentar novamente",
     "activities": "Atividades",
     "total": "total)",
-    "totalAtLeast": "{{count}}+",
+    "totalAtLeast": "{{count}} ou mais",
     "searchActivities": "Pesquisar atividades...",
     "all": "Todos",
     "success": "Sucesso",
@@ -684,7 +684,8 @@
     "details": "Detalhes",
     "showing": "Exibindo",
     "text": "–",
-    "of": "de"
+    "of": "de",
+    "noMoreActivity": "Não há mais atividade"
   },
   "deviceFilesystemTab": {
     "failedToFetchFilesystemStatus": "Falha ao buscar o status do sistema de arquivos",

--- a/apps/web/src/locales/tr-TR/devices.json
+++ b/apps/web/src/locales/tr-TR/devices.json
@@ -664,7 +664,7 @@
     "retry": "Tekrar dene",
     "activities": "Faaliyetler",
     "total": "toplam)",
-    "totalAtLeast": "{{count}}+",
+    "totalAtLeast": "{{count}} ve üzeri",
     "searchActivities": "Arama etkinlikleri...",
     "all": "Hepsi",
     "success": "Başarılı",
@@ -684,7 +684,8 @@
     "details": "Ayrıntılar",
     "showing": "Gösteriliyor",
     "text": "–",
-    "of": "arasında"
+    "of": "arasında",
+    "noMoreActivity": "Başka etkinlik yok"
   },
   "deviceFilesystemTab": {
     "failedToFetchFilesystemStatus": "Dosya sistemi durumu getirilemedi",

--- a/apps/web/src/locales/tr-TR/devices.json
+++ b/apps/web/src/locales/tr-TR/devices.json
@@ -664,6 +664,7 @@
     "retry": "Tekrar dene",
     "activities": "Faaliyetler",
     "total": "toplam)",
+    "totalAtLeast": "{{count}}+",
     "searchActivities": "Arama etkinlikleri...",
     "all": "Hepsi",
     "success": "Başarılı",


### PR DESCRIPTION
## Why

Stacked on #4835 (open). `GET /devices/:id/events?withTotal=true` (the device
**Activities** tab) ran an unbounded `count(*)` per feed arm — even after
#4835 bounded the *arm predicate* to the device's own rows, the count still
walked the device's whole audit history: 76k rows / 118s on US prod, because
~99% of `audit_logs` is agent telemetry the feed never renders, RLS's `org_id`
filter forces a heap fetch per row, and the table is never vacuumed (no
visibility map for an index-only count).

This is the **stop-gap (option 2)** from #4834, not option 1 (de-telemetry) or
option 3 (index-only path). Partially addresses #4834; root fix remains
#4340 / #4021.

## What

- `countArm` now caps each arm's count at `FEED_TOTAL_CAP` (10,000, exported)
  rows via `SELECT count(*) FROM (SELECT 1 FROM audit_logs WHERE <arm
  predicate> LIMIT 10001) capped_rows` — a Drizzle derived-table subquery.
  Postgres stops scanning once the LIMIT is hit instead of walking the rest of
  the device's history, so cost is now bounded regardless of how large that
  history grows. Verified the compiled SQL directly:
  ```sql
  select count(*)::int from (select 1 from "audit_logs" where "audit_logs"."org_id" = $1 limit $2) "capped_rows"
  ```
  The inner SELECT stays on `auditLogs` alone (no join to `users`) and reuses
  each arm's `where` unchanged, so it hits the same index the row read for
  that arm already uses. `mergeFeedPage`, `NON_AGENT_ACTOR`,
  `DETAILS_HAS_DEVICE_ID`, and `FEED_SORT_KEY` are untouched.
- The two capped arm counts are summed as before. `pagination` gains
  `totalIsLowerBound: boolean` — true when the summed raw count exceeds
  `FEED_TOTAL_CAP`, in which case `total` is clamped to the cap. When
  `withTotal` is false the response is byte-for-byte unchanged (`total: null`,
  no count query, no `totalIsLowerBound` key).
- Web: `DeviceEventLogViewer.tsx` (the only caller that sends
  `withTotal=true`) renders `10,000+` via a new i18n key
  (`deviceEventLogViewer.totalAtLeast`, added to all 8 locale catalogs) when
  `totalIsLowerBound` is true, and keeps "next page" enabled past the
  (possibly capped) `totalPages` whenever the just-fetched page came back full
  (`data.length === limit`) — the only signal there might be more rows beyond
  the cap. `DeviceActivityFeed.tsx` never sends `withTotal` and is untouched.

## Tests

- `apps/api/src/routes/devices/events.test.ts`: extended the `db` mock to
  distinguish the inner capped-count derived-table select (`{ one }`
  projection) from the outer `count(*)` select (`{ count }` projection) and
  made the resolved count configurable per test. New cases: below-cap sum is
  exact with `totalIsLowerBound=false`; above-cap sum clamps to
  `FEED_TOTAL_CAP` with `totalIsLowerBound=true`; the count SQL is provably
  bounded (`LIMIT FEED_TOTAL_CAP + 1` captured and asserted) and reuses each
  arm's `where` unchanged (byte-identical to the row read's `where`, via
  `JSON.stringify`). The existing "no count query when withTotal is omitted"
  case stays green. 34/34 passing.
- `apps/web/src/components/devices/DeviceEventLogViewer.test.tsx` (new):
  exact total render when `totalIsLowerBound=false`; `10,000+` render when
  true; Next stays enabled past the reported total when the last page came
  back full; Next disables once a page comes back partial even when
  `totalIsLowerBound` is true. 4/4 passing. Locale parity suite (all 8
  catalogs) still green with the new key.
- `tsc --noEmit` clean on both `apps/api` and `apps/web`. `eslint` clean on
  every touched file.
- Did **not** run integration tests (need a live Postgres stack) — the arm
  predicates/indexes this reuses are unchanged, so #4835's
  `deviceEventsFeedIndexes.integration.test.ts` is unaffected by this diff.

## Note

This branch targets `db-performance` (PR #4835, open) since the count logic
depends on the two-arm predicate that PR introduces. **This PR needs to be
rebased onto `main` after #4835 squash-merges** — the follow-up rebase is
`git rebase --onto main <old-parent-sha>`. Because the base isn't `main`, GitHub
runs no CI here automatically; dispatching `CI` manually against this branch
per the tenancy-doc guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016g2n6u6D73cH6HxdLPgM2G