### PR TITLE
fix(ops): default M365 JWK secret file sources to a placeholder file, not /dev/null (#2991)

### DIFF
--- a/apps/api/src/config/composeSecretFileDefaults.test.ts
+++ b/apps/api/src/config/composeSecretFileDefaults.test.ts
@@ -97,12 +97,32 @@ function collectSecretFileEntries(composeFile: string): SecretFileEntry[] {
   return entries;
 }
 
-/** `${VAR:-default}` -> "default"; a literal (non-interpolated) path is returned as-is. */
-function extractDefault(rawFile: string): string | null {
-  const match = /^\$\{[A-Za-z_][A-Za-z0-9_]*:-(.*)\}$/.exec(rawFile);
-  if (match) return match[1] ?? ''; // may be '' if the author wrote `${VAR:-}` (no default)
-  if (rawFile.includes('$')) return null; // `${VAR}` / `${VAR:?msg}` — no static default to check
-  return rawFile; // literal path, no interpolation at all
+type FileValue =
+  | { kind: 'default'; value: string } // `${VAR:-default}` / `${VAR-default}`, or a literal path
+  | { kind: 'no-default' } // `${VAR}` / `${VAR:?msg}` / `${VAR?msg}` — required, no static default
+  | { kind: 'unrecognized' }; // some other `$`-containing form this parser doesn't know
+
+/**
+ * Classifies a `secrets.<name>.file:` value. Deliberately fails CLOSED: any
+ * `$`-containing form that isn't one of the two recognized shapes above comes
+ * back `unrecognized` rather than being silently skipped, so a typo'd
+ * interpolation (e.g. `${VAR-default}` misread, or a future default-setting
+ * syntax this parser doesn't know) surfaces as a test failure telling a human
+ * to look at it, instead of quietly passing an unchecked default through —
+ * which is exactly how #2991's `/dev/null` default could reappear unnoticed.
+ */
+function classifyFileValue(rawFile: string): FileValue {
+  // `${VAR:-default}` (unset-or-empty) or `${VAR-default}` (unset-only) — both
+  // are real default-providing forms.
+  const withDefault = /^\$\{[A-Za-z_][A-Za-z0-9_]*:?-(.*)\}$/.exec(rawFile);
+  if (withDefault) return { kind: 'default', value: withDefault[1] ?? '' };
+
+  // `${VAR}` (plain) or `${VAR:?msg}` / `${VAR?msg}` (required, fails if
+  // unset/empty) — no static default to check either way.
+  if (/^\$\{[A-Za-z_][A-Za-z0-9_]*(:?\?.*)?\}$/.test(rawFile)) return { kind: 'no-default' };
+
+  if (rawFile.includes('$')) return { kind: 'unrecognized' };
+  return { kind: 'default', value: rawFile }; // literal path, no interpolation at all
 }
 
 const composeFiles = trackedComposeFiles();
@@ -121,8 +141,20 @@ describe('Compose secret file: defaults', () => {
     const problems: string[] = [];
 
     for (const entry of allSecretFileEntries) {
-      const defaultValue = extractDefault(entry.rawFile);
-      if (defaultValue === null || defaultValue === '') continue; // no static default to check
+      const classified = classifyFileValue(entry.rawFile);
+
+      if (classified.kind === 'unrecognized') {
+        problems.push(
+          `${entry.composeFile}: secret "${entry.secretName}" file: value "${entry.rawFile}" ` +
+            `uses an interpolation form this test doesn't recognize as either a static default ` +
+            `or a required (no-default) reference. Update classifyFileValue() in this test to ` +
+            `handle it explicitly, so its default (if any) gets checked rather than skipped.`,
+        );
+        continue;
+      }
+      if (classified.kind === 'no-default') continue; // required var — no static default to check
+      const defaultValue = classified.value;
+      if (defaultValue === '') continue; // `${VAR:-}` — author wrote no default
 
       const composeDir = path.dirname(path.join(REPO_ROOT, entry.composeFile));
       const resolved = defaultValue.startsWith('/')
@@ -158,8 +190,8 @@ describe('Compose secret file: defaults', () => {
     // host made a device-node remount succeed and the generic isFile() check
     // above stopped firing for it.
     const devNullDefaults = allSecretFileEntries
-      .map((e) => ({ ...e, defaultValue: extractDefault(e.rawFile) }))
-      .filter((e) => e.defaultValue === '/dev/null');
+      .map((e) => ({ ...e, classified: classifyFileValue(e.rawFile) }))
+      .filter((e) => e.classified.kind === 'default' && e.classified.value === '/dev/null');
 
     expect(devNullDefaults).toEqual([]);
   });

--- a/apps/api/src/config/composeSecretFileDefaults.test.ts
+++ b/apps/api/src/config/composeSecretFileDefaults.test.ts
@@ -1,0 +1,166 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { CORE_SCHEMA, defineMappingTag, defineScalarTag, defineSequenceTag, load } from 'js-yaml';
+import { describe, expect, it } from 'vitest';
+
+// apps/api/src/config -> repo root is 4 levels up (same as composeBindMounts.test.ts).
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
+
+/**
+ * Why this test exists
+ * --------------------
+ * Docker Compose's standalone (non-swarm) file-secret support bind-mounts a
+ * `secrets.<name>.file:` source into the container's overlay rootfs and
+ * remounts it read-only. `docker-compose.yml` and `deploy/docker-compose.prod.yml`
+ * default three optional M365 executor signing-key secrets'
+ * `${..._SOURCE_FILE:-...}` to a source file when the operator leaves the var
+ * unset — the common case, since these features are documented off-by-default
+ * (`.env.example`).
+ *
+ * That default used to be the `/dev/null` character device. Bind-mounting
+ * `/dev/null` and remounting it read-only inside overlayfs is rejected by the
+ * kernel with EPERM on a number of host kernel/storage-driver combinations,
+ * failing `docker compose up` with `remount-ro ... operation not permitted`
+ * for anyone who never touched the M365 write-actions feature (#2991) — a
+ * regular file has no such restriction. The fix points the default at a
+ * tracked, always-empty regular file (`docker/secrets/.empty-jwk`) instead.
+ *
+ * The guard: every `secrets.<name>.file:` **default** value (the fallback in
+ * `${VAR:-default}`, or a literal un-interpolated path) in a tracked Compose
+ * file must resolve to an existing REGULAR file — not missing, not a
+ * directory, and not a device node like `/dev/null`. This lives in the
+ * required `test-api` job so a reintroduced `/dev/null` (or any other
+ * non-regular-file default) cannot go green.
+ */
+
+// Compose's own merge tags. js-yaml throws on unknown tags, so declare them as
+// pass-throughs — we never inspect their values, we just need the file to parse.
+const passthroughTag = (tag: string) => [
+  defineScalarTag(tag, { resolve: (source: string) => source }),
+  defineSequenceTag<unknown[]>(tag, {
+    create: () => [],
+    addItem: (items, value) => {
+      items.push(value);
+    },
+  }),
+  defineMappingTag<Map<unknown, unknown>>(tag, {
+    create: () => new Map(),
+    addPair: (map, key, value) => {
+      map.set(key, value);
+      return '';
+    },
+    has: (map, key) => map.has(key),
+    keys: (map) => map.keys(),
+    get: (map, key) => map.get(key),
+  }),
+];
+
+const COMPOSE_SCHEMA = CORE_SCHEMA.withTags([
+  ...passthroughTag('!reset'),
+  ...passthroughTag('!override'),
+]);
+
+interface SecretFileEntry {
+  composeFile: string; // repo-root-relative
+  secretName: string;
+  rawFile: string; // exactly as written in the YAML (may contain ${VAR:-default})
+}
+
+function trackedComposeFiles(): string[] {
+  // Tracked files only, same discovery as composeBindMounts.test.ts.
+  const out = execFileSync(
+    'git',
+    ['ls-files', '-z', '*docker-compose*.yml*', '*docker-compose*', '*compose.yml', '*compose.yaml'],
+    { cwd: REPO_ROOT, encoding: 'utf8' },
+  );
+  const files = out.split('\0').filter(Boolean);
+  return [...new Set(files)]
+    .filter((f) => /(^|\/)(docker-)?compose[^/]*\.(yml|yaml)(\.[A-Za-z0-9_-]+)?$/.test(f))
+    .filter((f) => existsSync(path.join(REPO_ROOT, f)))
+    .sort();
+}
+
+function collectSecretFileEntries(composeFile: string): SecretFileEntry[] {
+  const abs = path.join(REPO_ROOT, composeFile);
+  const doc = load(readFileSync(abs, 'utf8'), { schema: COMPOSE_SCHEMA }) as {
+    secrets?: Record<string, { file?: unknown }>;
+  } | null;
+
+  const entries: SecretFileEntry[] = [];
+  for (const [secretName, def] of Object.entries(doc?.secrets ?? {})) {
+    const rawFile = def?.file;
+    if (typeof rawFile !== 'string' || rawFile.length === 0) continue; // e.g. `environment:`-sourced secrets
+    entries.push({ composeFile, secretName, rawFile });
+  }
+  return entries;
+}
+
+/** `${VAR:-default}` -> "default"; a literal (non-interpolated) path is returned as-is. */
+function extractDefault(rawFile: string): string | null {
+  const match = /^\$\{[A-Za-z_][A-Za-z0-9_]*:-(.*)\}$/.exec(rawFile);
+  if (match) return match[1] ?? ''; // may be '' if the author wrote `${VAR:-}` (no default)
+  if (rawFile.includes('$')) return null; // `${VAR}` / `${VAR:?msg}` — no static default to check
+  return rawFile; // literal path, no interpolation at all
+}
+
+const composeFiles = trackedComposeFiles();
+const allSecretFileEntries = composeFiles.flatMap(collectSecretFileEntries);
+
+describe('Compose secret file: defaults', () => {
+  // Fail closed: if discovery silently breaks, the suite must not pass vacuously.
+  it('discovers the tracked compose files and their file-backed secrets', () => {
+    expect(composeFiles).toContain('docker-compose.yml');
+    expect(composeFiles).toContain('deploy/docker-compose.prod.yml');
+    expect(allSecretFileEntries.length).toBeGreaterThanOrEqual(5);
+    expect(allSecretFileEntries.some((e) => e.secretName.includes('m365'))).toBe(true);
+  });
+
+  it('resolves every file: secret default to an existing regular file', () => {
+    const problems: string[] = [];
+
+    for (const entry of allSecretFileEntries) {
+      const defaultValue = extractDefault(entry.rawFile);
+      if (defaultValue === null || defaultValue === '') continue; // no static default to check
+
+      const composeDir = path.dirname(path.join(REPO_ROOT, entry.composeFile));
+      const resolved = defaultValue.startsWith('/')
+        ? defaultValue
+        : path.resolve(composeDir, defaultValue);
+
+      if (!existsSync(resolved)) {
+        problems.push(
+          `${entry.composeFile}: secret "${entry.secretName}" file: default "${defaultValue}" ` +
+            `does not exist (looked for ${resolved}). Docker would fail to bind-mount it, or ` +
+            `create a phantom directory in its place.`,
+        );
+        continue;
+      }
+
+      if (!statSync(resolved).isFile()) {
+        problems.push(
+          `${entry.composeFile}: secret "${entry.secretName}" file: default "${defaultValue}" ` +
+            `(${resolved}) is not a regular file — Compose bind-mounts it and remounts it ` +
+            `read-only, which the kernel rejects for device nodes like /dev/null (EPERM: ` +
+            `"remount-ro ... operation not permitted", #2991) on some host kernel/storage-` +
+            `driver combinations. Point the default at a tracked empty regular file instead ` +
+            `(see docker/secrets/README.md).`,
+        );
+      }
+    }
+
+    expect(problems).toEqual([]);
+  });
+
+  it('never defaults a file: secret straight to /dev/null', () => {
+    // Belt-and-suspenders: catches the literal regression even if some future
+    // host made a device-node remount succeed and the generic isFile() check
+    // above stopped firing for it.
+    const devNullDefaults = allSecretFileEntries
+      .map((e) => ({ ...e, defaultValue: extractDefault(e.rawFile) }))
+      .filter((e) => e.defaultValue === '/dev/null');
+
+    expect(devNullDefaults).toEqual([]);
+  });
+});

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -637,9 +637,14 @@ secrets:
   turn_secret:
     environment: TURN_SECRET
   # Standalone Compose bind-mounts file-backed secrets and ignores uid/gid/mode
-  # target attributes. /dev/null keeps dark deployments optional; when enabled,
-  # the source JWK must already have numeric owner 1001:1001 and mode 0400.
+  # target attributes. docker/secrets/.empty-jwk (a tracked empty regular file)
+  # keeps dark deployments optional; when enabled, the source JWK must already
+  # have numeric owner 1001:1001 and mode 0400. Do NOT default this to
+  # /dev/null: bind-mounting that character device and remounting it read-only
+  # inside overlayfs is rejected by the kernel on some host kernel/storage-
+  # driver combinations, failing `docker compose up` for anyone who never
+  # touched this feature (#2991). See docker/secrets/README.md.
   m365_graph_read_executor_signing_private_jwk:
-    file: ${M365_GRAPH_READ_EXECUTOR_SIGNING_PRIVATE_JWK_SOURCE_FILE:-/dev/null}
+    file: ${M365_GRAPH_READ_EXECUTOR_SIGNING_PRIVATE_JWK_SOURCE_FILE:-../docker/secrets/.empty-jwk}
   m365_graph_actions_executor_signing_private_jwk:
-    file: ${M365_GRAPH_ACTIONS_EXECUTOR_SIGNING_PRIVATE_JWK_SOURCE_FILE:-/dev/null}
+    file: ${M365_GRAPH_ACTIONS_EXECUTOR_SIGNING_PRIVATE_JWK_SOURCE_FILE:-../docker/secrets/.empty-jwk}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -778,11 +778,16 @@ secrets:
   turn_secret:
     environment: TURN_SECRET
   # Standalone Compose bind-mounts file-backed secrets and ignores uid/gid/mode
-  # target attributes. /dev/null keeps dark deployments optional; when enabled,
-  # the source JWK must already have numeric owner 1001:1001 and mode 0400.
+  # target attributes. docker/secrets/.empty-jwk (a tracked empty regular file)
+  # keeps dark deployments optional; when enabled, the source JWK must already
+  # have numeric owner 1001:1001 and mode 0400. Do NOT default this to
+  # /dev/null: bind-mounting that character device and remounting it read-only
+  # inside overlayfs is rejected by the kernel on some host kernel/storage-
+  # driver combinations, failing `docker compose up` for anyone who never
+  # touched this feature (#2991). See docker/secrets/README.md.
   m365_graph_read_executor_signing_private_jwk:
-    file: ${M365_GRAPH_READ_EXECUTOR_SIGNING_PRIVATE_JWK_SOURCE_FILE:-/dev/null}
+    file: ${M365_GRAPH_READ_EXECUTOR_SIGNING_PRIVATE_JWK_SOURCE_FILE:-./docker/secrets/.empty-jwk}
   m365_graph_actions_executor_signing_private_jwk:
-    file: ${M365_GRAPH_ACTIONS_EXECUTOR_SIGNING_PRIVATE_JWK_SOURCE_FILE:-/dev/null}
+    file: ${M365_GRAPH_ACTIONS_EXECUTOR_SIGNING_PRIVATE_JWK_SOURCE_FILE:-./docker/secrets/.empty-jwk}
   m365_comms_executor_signing_private_jwk:
-    file: ${M365_COMMS_EXECUTOR_SIGNING_PRIVATE_JWK_SOURCE_FILE:-/dev/null}
+    file: ${M365_COMMS_EXECUTOR_SIGNING_PRIVATE_JWK_SOURCE_FILE:-./docker/secrets/.empty-jwk}

--- a/docker/secrets/README.md
+++ b/docker/secrets/README.md
@@ -1,0 +1,31 @@
+# `docker/secrets/`
+
+## `.empty-jwk`
+
+An intentionally empty, tracked regular file. It is the default `file:`
+source for the optional M365 executor signing-key secrets in
+`docker-compose.yml` and `deploy/docker-compose.prod.yml`
+(`m365_graph_read_executor_signing_private_jwk`,
+`m365_graph_actions_executor_signing_private_jwk`,
+`m365_comms_executor_signing_private_jwk`) whenever the corresponding
+`M365_*_SIGNING_PRIVATE_JWK_SOURCE_FILE` env var is left unset — which is the
+common case, since these features are off by default.
+
+Docker Compose's standalone (non-swarm) file-secret support bind-mounts the
+source file into the container and remounts it read-only. Before this file
+existed, the default source was `/dev/null`. Bind-mounting the `/dev/null`
+character device and remounting it read-only inside an overlayfs rootfs is
+rejected by the kernel on a number of host kernel/storage-driver combinations,
+failing `docker compose up` with `remount-ro ... operation not permitted` —
+even for deployments that never touch the M365 write-actions feature (issue
+#2991). A regular file has no such restriction, so pointing the default here
+instead of at `/dev/null` avoids the failure while keeping the secret mount
+present (required by
+`scripts/security/check-supply-chain-hardening.sh`) and functionally
+equivalent — an all-zero-length "key" the API's config validator still
+correctly treats as absent.
+
+**Keep this file empty.** `apps/api/src/config/composeSecretFileDefaults.test.ts`
+asserts every `file:` secret default in the tracked Compose files resolves to
+an existing regular file (not a directory, not a device node) — this file is
+what makes that assertion pass for the M365 JWK secrets.

--- a/scripts/guided-setup.sh
+++ b/scripts/guided-setup.sh
@@ -189,6 +189,13 @@ fi
 COMPOSE_FILE="${WORK_DIR}/docker-compose.yml"
 ENV_EXAMPLE_FILE="${WORK_DIR}/.env.example"
 CADDYFILE_FILE="${WORK_DIR}/docker/Caddyfile.prod"
+# Default `file:` source for the optional M365 executor signing-key secrets
+# (docker-compose.yml, secrets: block) once unset — see
+# ensure_m365_jwk_secret_placeholder() and #2991. Not downloaded as a
+# template: it must exist regardless of which release's docker-compose.yml is
+# in play (older releases still default to /dev/null and never read it; this
+# is a harmless no-op for them), so it is created locally instead.
+M365_JWK_PLACEHOLDER_FILE="${WORK_DIR}/docker/secrets/.empty-jwk"
 COMPOSE_PROXY_OVERRIDE_FILE="${WORK_DIR}/docker-compose.byo-proxy.yml"
 PROXY_GUIDE_FILE="${WORK_DIR}/reverse-proxy-setup.md"
 COMPOSE_FILES=("${COMPOSE_FILE}")
@@ -2241,6 +2248,28 @@ apply_proxy_compose_file() {
 
   write_external_proxy_compose_file
   log "Generated ${COMPOSE_FILE} for external reverse proxy mode."
+}
+
+# The installer's WORK_DIR only ever gets docker-compose.yml + .env.example
+# (plus docker/Caddyfile.prod in packaged-Caddy mode) — it is never a full
+# repo checkout. docker-compose.yml's M365 executor signing-key secrets
+# default their `file:` source to ./docker/secrets/.empty-jwk when unset (the
+# common case; see #2991), so that path must exist here too, or `docker
+# compose up` fails with "bind source path does not exist" — a harder,
+# guaranteed failure than the /dev/null bug this placeholder was created to
+# fix in the first place. Create it locally rather than downloading it as a
+# template: an older selected release's docker-compose.yml still defaults to
+# /dev/null and never reads this path, so unconditionally creating an unused
+# empty file is a harmless no-op for it, whereas downloading a
+# release-pinned template that doesn't exist yet in that release would hard
+# fail the installer for every release before this fix ships.
+ensure_m365_jwk_secret_placeholder() {
+  if [[ -e "${M365_JWK_PLACEHOLDER_FILE}" && ! -f "${M365_JWK_PLACEHOLDER_FILE}" ]]; then
+    fail "${M365_JWK_PLACEHOLDER_FILE} exists but is not a regular file. Remove it — it must be an empty, ordinary file."
+  fi
+
+  mkdir -p "$(dirname "${M365_JWK_PLACEHOLDER_FILE}")"
+  : > "${M365_JWK_PLACEHOLDER_FILE}"
 }
 
 ensure_packaged_caddy_assets() {
@@ -4330,6 +4359,7 @@ main() {
   select_breeze_version
   resolve_template_remote_base
   prepare_templates
+  ensure_m365_jwk_secret_placeholder
   prepare_env_file
   preserve_existing_compose_project_name
   materialize_env_from_example

--- a/scripts/prod/deploy.sh
+++ b/scripts/prod/deploy.sh
@@ -97,6 +97,19 @@ docker compose version >/dev/null 2>&1 || {
   exit 1
 }
 
+# deploy/docker-compose.prod.yml's M365 executor signing-key secrets default
+# their file: source to ../docker/secrets/.empty-jwk (relative to deploy/)
+# when unset — the common case; see #2991. This script always runs from a
+# full checkout (REPO_ROOT above, and `pnpm db:migrate` below both require
+# one), so the tracked file is already present; this is a fail-fast guard,
+# not a repair — a missing file here means the checkout is broken/sparse and
+# should be fixed rather than papered over.
+m365_jwk_placeholder="${REPO_ROOT}/docker/secrets/.empty-jwk"
+if [[ ! -f "${m365_jwk_placeholder}" ]]; then
+  echo "[deploy] Missing ${m365_jwk_placeholder} (tracked in git) — this checkout looks incomplete/sparse. A full 'git clone' is required; see docs/operations/DEPLOY_PRODUCTION.md prerequisites." >&2
+  exit 1
+fi
+
 # shellcheck disable=SC1090
 set -a; source "${ENV_FILE}"; set +a
 

--- a/scripts/security/check-m365-graph-actions-runtime.sh
+++ b/scripts/security/check-m365-graph-actions-runtime.sh
@@ -87,8 +87,10 @@ compose=(
 
 export M365_GRAPH_ACTIONS_RUNTIME_PROBE_FILE="$PROBE_BUNDLE"
 
-# The checked production declaration defaults to /dev/null while onboarding is
-# dark. The API's real boot validator must leave the signing file untouched.
+# The checked production declaration defaults to the tracked empty
+# docker/secrets/.empty-jwk placeholder while onboarding is dark (#2991 — a
+# /dev/null default failed docker compose up on some hosts). The API's real
+# boot validator must leave the signing file untouched.
 unset M365_GRAPH_ACTIONS_EXECUTOR_SIGNING_PRIVATE_JWK_SOURCE_FILE
 "${compose[@]}" run --no-deps --rm api
 

--- a/scripts/security/check-m365-graph-read-runtime.sh
+++ b/scripts/security/check-m365-graph-read-runtime.sh
@@ -84,8 +84,10 @@ compose=(
 
 export M365_GRAPH_READ_RUNTIME_PROBE_FILE="$PROBE_BUNDLE"
 
-# The checked production declaration defaults to /dev/null while onboarding is
-# dark. The API's real boot validator must leave the signing file untouched.
+# The checked production declaration defaults to the tracked empty
+# docker/secrets/.empty-jwk placeholder while onboarding is dark (#2991 — a
+# /dev/null default failed docker compose up on some hosts). The API's real
+# boot validator must leave the signing file untouched.
 unset M365_GRAPH_READ_EXECUTOR_SIGNING_PRIVATE_JWK_SOURCE_FILE
 "${compose[@]}" run --no-deps --rm api
 

--- a/scripts/smoke-guided-setup.sh
+++ b/scripts/smoke-guided-setup.sh
@@ -244,6 +244,22 @@ set -e
 [[ "${installer_status}" -eq 0 ]] || fail "guided-setup.sh exited ${installer_status} (see log above)"
 echo "  OK  installer exited 0"
 
+step "Assert the M365 JWK secret placeholder exists (#2991 — bare install dir, not a full checkout)"
+# This WORK_DIR only ever gets docker-compose.yml + .env.example + (in
+# packaged-Caddy mode) docker/Caddyfile.prod staged into it above — it is
+# never a full repo clone. docker-compose.yml's M365 executor signing-key
+# secrets default their file: source to ./docker/secrets/.empty-jwk when
+# unset, so the installer itself must create that file (it is not part of
+# what gets staged/downloaded); otherwise `docker compose up` fails with
+# "bind source path does not exist" instead of starting. If this regresses,
+# the installer run above would already have failed on the api container
+# never starting — this step exists to name the exact cause instead of
+# leaving it to a bisect through installer output.
+placeholder="${WORK_DIR}/docker/secrets/.empty-jwk"
+[[ -f "${placeholder}" ]] || fail "installer did not create ${placeholder}"
+[[ ! -s "${placeholder}" ]] || fail "${placeholder} is not empty"
+echo "  OK  ${placeholder} exists and is empty"
+
 step "Assert the generated .env"
 grep -q "^BREEZE_VERSION=${VERSION}\$" "${WORK_DIR}/.env" || fail "BREEZE_VERSION was not pinned to ${VERSION}"
 grep -q '^BREEZE_DOMAIN=localhost$' "${WORK_DIR}/.env" || fail "BREEZE_DOMAIN default is not localhost"


### PR DESCRIPTION
## Summary

`docker-compose.yml` and `deploy/docker-compose.prod.yml` default the three optional M365 executor signing-key secrets' `file:` source to `/dev/null` when the corresponding `*_SOURCE_FILE` env var is left unset — the common case, since `.env.example` documents these features as off-by-default and safe to leave unset.

Docker Compose's standalone (non-swarm) file-secret support bind-mounts that source into the container's overlay rootfs and remounts it read-only. Doing that to the `/dev/null` character device is rejected by the kernel with `EPERM` on some host kernel/storage-driver combinations, producing exactly the reported error:

```
Error response from daemon: remount-ro /var/lib/docker/rootfs/overlayfs/.../run/secrets/m365_graph_actions_executor_signing_private_jwk, flags: 0x5021: operation not permitted
```

So a user who never touched the M365 write-actions feature could fail `docker compose up` purely because of this default.

## Fix

- Added `docker/secrets/.empty-jwk`, a tracked, always-empty **regular** file, plus `docker/secrets/README.md` explaining why it exists.
- Changed the three `${..._SOURCE_FILE:-/dev/null}` defaults in `docker-compose.yml` to `${..._SOURCE_FILE:-./docker/secrets/.empty-jwk}`, and the two present in `deploy/docker-compose.prod.yml` to `${..._SOURCE_FILE:-../docker/secrets/.empty-jwk}` (path relative to each compose file's own directory — verified with `docker compose config` against both `.env.example` and `deploy/compose-config-test.env`, and with a standalone smoke-test compose file confirming the empty regular file mounts and reads back as a 0-byte secret without error).
- Regular files have no remount-to-read-only restriction, so this avoids the failure while keeping the secret mount present (required by `scripts/check-supply-chain-hardening.sh`) and functionally equivalent — a zero-length "key" the API's config validator still correctly treats as absent.

## Also checked

- `scripts/security/check-supply-chain-hardening.sh` — only asserts the secret mount *lines* exist (`m365_graph_read_executor_signing_private_jwk:` etc.), never inspects the default value, so it needed no change. Confirmed it still passes.
- Guided-setup templates — there isn't a separate template; `scripts/guided-setup.sh` downloads a specific **release tag's** `docker-compose.yml` directly. Per repo precedent (guided-setup is pinned to release tags), **this fix will not reach guided-setup installs until it ships in a release** — flagging per the standing note, not a follow-up needed in this PR.

- `deploy/docker-compose.prod.yml` only defines 2 of the 3 M365 JWK secrets (no `m365_comms_executor_signing_private_jwk` — the comms executor isn't deployed to prod, only in the self-hosted `docker-compose.yml`). That asymmetry predates this PR and is unrelated to the fix; both files' existing secrets got the same placeholder-default treatment.

## Review fixes

- silent-failure-hunter: the test's default-value extractor only recognized `${VAR:-default}` and silently skipped any other `$`-containing form (e.g. `${VAR-default}`, `${VAR:=x}`) as "no default to check" — a future secret using one of those forms could reintroduce the `/dev/null` bug undetected. Replaced with `classifyFileValue()`, which recognizes both default-providing forms and both required/no-default forms, and now **fails the test** on anything else instead of skipping it.
- code-reviewer: `check-m365-graph-read-runtime.sh` / `check-m365-graph-actions-runtime.sh` each had a comment claiming production defaults to `/dev/null` — stale after this fix. Updated both to reference `docker/secrets/.empty-jwk`.

## Tests

- Added `apps/api/src/config/composeSecretFileDefaults.test.ts`: asserts every `secrets.*.file:` default in the tracked Compose files resolves to an existing **regular** file (fails on missing files, directories, or device nodes like `/dev/null`). Verified red-first (temporarily restored the old `/dev/null` defaults — the new test failed with a clear message) then green after restoring the fix.
- `pnpm exec vitest run` (via `npx vitest run` in `apps/api`) on `composeSecretFileDefaults.test.ts`, `composeBindMounts.test.ts`, `envComposeParity.test.ts`, `ciSuccessGatingContract.test.ts` — all green (45/45, then 40/40 after a lint/typecheck fix).
- `npx tsc --noEmit` on `apps/api` — clean.
- `npx eslint` on the new test file — clean.
- `docker compose config` against both compose files with test env files — resolves the secret `file:` to the new placeholder correctly in both.
- `scripts/security/check-supply-chain-hardening.sh` — passes.

Closes #2991

🤖 Generated with [Claude Code](https://claude.com/claude-code)
