### PR TITLE
fix(api): three silent-failure paths in patch dispatch and desktop finalization (#3945)

### DIFF
--- a/apps/api/src/routes/configurationPolicies/patchJobs.test.ts
+++ b/apps/api/src/routes/configurationPolicies/patchJobs.test.ts
@@ -22,7 +22,7 @@ const {
     needsRepair: rows.filter((row) => row.effectiveStatus === 'needs_repair').length,
     invalidReference: rows.filter((row) => row.effectiveStatus === 'invalid_reference').length,
   })),
-  enqueuePatchJobMock: vi.fn(async () => undefined),
+  enqueuePatchJobMock: vi.fn(async (_jobId?: string, _delayMs?: number) => undefined),
   captureExceptionMock: vi.fn(),
 }));
 
@@ -362,6 +362,7 @@ describe('configurationPolicies patchJob routes', () => {
       // response must not claim success (#3945: a fire-and-forget
       // `.catch(console.error)` previously returned 201/success:true here
       // with zero visibility that the job would never execute).
+      expect(res.status).toBe(201);
       const json = await res.json();
       expect(json.success).toBe(false);
       expect(json.enqueueFailures).toEqual([
@@ -587,6 +588,79 @@ describe('configurationPolicies patchJob routes', () => {
       expect(json.totalDevices).toBe(2);
       // One patch_jobs row per device org (job insert grouped by org).
       expect(insertValuesMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('reports only the failing org while still creating jobs for every org in a partner-wide request (#3945)', async () => {
+      const orgA = ORG_ID;
+      const orgB = '99999999-9999-4999-8999-999999999999';
+      const device2 = '66666666-6666-4666-8666-666666666666';
+      getConfigPolicyMock.mockResolvedValue({
+        id: POLICY_ID,
+        status: 'active',
+        orgId: null,
+        partnerId: PARTNER_ID,
+        name: 'Partner-wide',
+      });
+      loadPolicyLocalPatchConfigMock.mockResolvedValue(makePolicyLocal({ orgId: null }));
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([
+              { id: DEVICE_ID, orgId: orgA, hostname: 'host-a' },
+              { id: device2, orgId: orgB, hostname: 'host-b' },
+            ]),
+          }),
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([
+              { id: orgA, partnerId: PARTNER_ID },
+              { id: orgB, partnerId: PARTNER_ID },
+            ]),
+          }),
+        } as any);
+
+      checkDeviceMaintenanceWindowMock.mockResolvedValue(inactiveMaintenance);
+
+      const insertValuesMock = vi.fn()
+        .mockReturnValueOnce({ returning: vi.fn().mockResolvedValue([{ id: 'job-a' }]) })
+        .mockReturnValueOnce({ returning: vi.fn().mockResolvedValue([{ id: 'job-b' }]) });
+      vi.mocked(db.insert).mockReturnValue({ values: insertValuesMock } as any);
+
+      // Only org B's enqueue is wedged -- org A must still succeed and be
+      // reported as such, not swept up into a blanket failure.
+      enqueuePatchJobMock.mockImplementation(async (jobId?: string) => {
+        if (jobId === 'job-b') throw new Error('queue wedged');
+      });
+
+      app = new Hono();
+      app.use('*', async (c, next) => {
+        c.set('auth', makeAuth({
+          scope: 'partner',
+          partnerId: PARTNER_ID,
+          accessibleOrgIds: [orgA, orgB],
+          canAccessOrg: (orgId: string) => orgId === orgA || orgId === orgB,
+        }));
+        await next();
+      });
+      app.route('/', patchJobRoutes);
+
+      const res = await app.request(`/${POLICY_ID}/patch-job`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ deviceIds: [DEVICE_ID, device2] }),
+      });
+
+      expect(res.status).toBe(201);
+      const json = await res.json();
+      expect(json.success).toBe(false);
+      expect(json.jobs).toEqual(expect.arrayContaining([
+        expect.objectContaining({ jobId: 'job-a', orgId: orgA }),
+        expect.objectContaining({ jobId: 'job-b', orgId: orgB }),
+      ]));
+      expect(json.enqueueFailures).toEqual([
+        { jobId: 'job-b', orgId: orgB, error: 'queue wedged' },
+      ]);
     });
 
     it('denies a partner-wide patch job for a device whose org belongs to another partner', async () => {

--- a/apps/api/src/routes/configurationPolicies/patchJobs.test.ts
+++ b/apps/api/src/routes/configurationPolicies/patchJobs.test.ts
@@ -8,6 +8,8 @@ const {
   loadPolicyLocalPatchConfigMock,
   listPatchInventoryMock,
   summarizePatchInventoryMock,
+  enqueuePatchJobMock,
+  captureExceptionMock,
 } = vi.hoisted(() => ({
   getConfigPolicyMock: vi.fn(),
   checkDeviceMaintenanceWindowMock: vi.fn(),
@@ -20,6 +22,8 @@ const {
     needsRepair: rows.filter((row) => row.effectiveStatus === 'needs_repair').length,
     invalidReference: rows.filter((row) => row.effectiveStatus === 'invalid_reference').length,
   })),
+  enqueuePatchJobMock: vi.fn(async () => undefined),
+  captureExceptionMock: vi.fn(),
 }));
 
 vi.mock('../../services/configurationPolicy', () => ({
@@ -42,7 +46,11 @@ vi.mock('../../services/auditEvents', () => ({
 }));
 
 vi.mock('../../jobs/patchJobExecutor', () => ({
-  enqueuePatchJob: vi.fn(async () => undefined),
+  enqueuePatchJob: enqueuePatchJobMock,
+}));
+
+vi.mock('../../services/sentry', () => ({
+  captureException: captureExceptionMock,
 }));
 
 vi.mock('../../middleware/auth', () => ({
@@ -308,6 +316,58 @@ describe('configurationPolicies patchJob routes', () => {
         apps: [{ source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' }],
       });
       expect(writeRouteAudit).toHaveBeenCalled();
+      expect(json.enqueueFailures).toEqual([]);
+    });
+
+    it('surfaces the failure instead of reporting success when enqueue fails (#3945)', async () => {
+      getConfigPolicyMock.mockResolvedValue({ id: POLICY_ID, status: 'active', orgId: ORG_ID, name: 'P1' });
+      loadPolicyLocalPatchConfigMock.mockResolvedValue(makePolicyLocal({
+        settings: {
+          sources: ['third_party'],
+          autoApprove: true,
+          autoApproveSeverities: ['critical'],
+          autoApproveDeferralDays: 5,
+          apps: [{ source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' }],
+          scheduleFrequency: 'daily',
+          scheduleTime: '02:00',
+          scheduleDayOfWeek: 'sun',
+          scheduleDayOfMonth: 1,
+          rebootPolicy: 'if_required',
+        },
+      }));
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ id: DEVICE_ID, orgId: ORG_ID, hostname: 'host-1' }]),
+          }),
+        } as any);
+
+      checkDeviceMaintenanceWindowMock.mockResolvedValue(inactiveMaintenance);
+
+      const insertValuesMock = vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{ id: 'job-1' }]),
+      });
+      vi.mocked(db.insert).mockReturnValue({
+        values: insertValuesMock,
+      } as any);
+
+      enqueuePatchJobMock.mockRejectedValueOnce(new Error('queue wedged'));
+
+      const res = await app.request(`/${POLICY_ID}/patch-job`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ deviceIds: [DEVICE_ID] }),
+      });
+      // The DB row was created but nothing was actually queued to run — the
+      // response must not claim success (#3945: a fire-and-forget
+      // `.catch(console.error)` previously returned 201/success:true here
+      // with zero visibility that the job would never execute).
+      const json = await res.json();
+      expect(json.success).toBe(false);
+      expect(json.enqueueFailures).toEqual([
+        { jobId: 'job-1', orgId: ORG_ID, error: 'queue wedged' },
+      ]);
+      expect(captureExceptionMock).toHaveBeenCalled();
     });
 
     it('returns 404 when no accessible devices found', async () => {

--- a/apps/api/src/routes/configurationPolicies/patchJobs.ts
+++ b/apps/api/src/routes/configurationPolicies/patchJobs.ts
@@ -5,6 +5,7 @@ import { eq, inArray } from 'drizzle-orm';
 import type { AuthContext } from '../../middleware/auth';
 import { requireMfa, requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
+import { captureException } from '../../services/sentry';
 import { db } from '../../db';
 import { patchJobs, devices, organizations } from '../../db/schema';
 import {
@@ -209,6 +210,7 @@ patchJobRoutes.post(
     }
 
     const createdJobs: Array<{ jobId: string; orgId: string; deviceCount: number }> = [];
+    const enqueueFailures: Array<{ jobId: string; orgId: string; error: string }> = [];
 
     for (const [orgId, deviceIds] of orgGroups) {
       const jobName = data.name ?? `Config Policy Patch Job - ${policy.name}`;
@@ -246,9 +248,22 @@ patchJobRoutes.post(
         const delayMs = data.scheduledAt
           ? Math.max(0, new Date(data.scheduledAt).getTime() - Date.now())
           : 0;
-        enqueuePatchJob(job.id, delayMs || undefined).catch((err) =>
-          console.error(`[PatchJobs] Failed to enqueue job ${job.id}:`, err)
-        );
+        // #3945: this used to be fire-and-forget (`.catch(console.error)`),
+        // so the route always returned 200/201 with `createdJobs` populated
+        // even when nothing was actually queued to run — e.g. a wedged
+        // BullMQ job id that #3912 made `enqueuePatchJob` throw on instead of
+        // swallowing. The reconcile sweep deliberately skips a wedged id
+        // (see patchJobExecutor.ts), so there is no backstop: awaiting here
+        // and surfacing the failure in the response is the only place left
+        // that can report it.
+        try {
+          await enqueuePatchJob(job.id, delayMs || undefined);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          console.error(`[PatchJobs] Failed to enqueue job ${job.id}:`, err);
+          captureException(err, c);
+          enqueueFailures.push({ jobId: job.id, orgId, error: message });
+        }
       }
     }
 
@@ -268,11 +283,19 @@ patchJobRoutes.post(
         missingDeviceIds,
         inaccessibleDeviceIds,
         maintenanceSuppressedDeviceIds,
+        enqueueFailures,
       },
     });
 
+    // `success` reflects whether every created job actually got queued to
+    // run, not just whether the DB rows exist — a partial or total enqueue
+    // failure must not be reported as success (#3945). `enqueueFailures`
+    // (in the audit details above and the response body below) tells the
+    // caller exactly which jobs still need attention.
+    const success = enqueueFailures.length === 0;
+
     return c.json({
-      success: true,
+      success,
       configPolicyId,
       configPolicyName: policy.name,
       policyLocal: {
@@ -284,6 +307,7 @@ patchJobRoutes.post(
         approvalRing: buildApprovalRing(policyLocal.ring),
       },
       jobs: createdJobs,
+      enqueueFailures,
       totalDevices: devicePatchConfigs.length,
       skipped: {
         missingDeviceIds,

--- a/apps/api/src/services/desktopSessionOrphanRecovery.test.ts
+++ b/apps/api/src/services/desktopSessionOrphanRecovery.test.ts
@@ -288,6 +288,35 @@ describe('desktop orphan recovery', () => {
     consoleErrorSpy.mockRestore();
   });
 
+  it('logs and reports a malformed persisted intent instead of swallowing it (#3945)', async () => {
+    const deps = dependencies();
+    vi.mocked(deps.observeSharedState).mockResolvedValue({
+      ownerPresent: false,
+      finalizationId: '66666666-6666-4666-8666-666666666666',
+      // Not valid JSON -- exercises the JSON.parse failure branch of the
+      // bare `catch { return 'retained' }` this used to be (#3945). A
+      // canonicalizeDesktopFinalization shape failure takes the same path.
+      canonicalPayload: '{not-json',
+      consistent: true,
+    });
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    captureExceptionMock.mockClear();
+    const service = createDesktopSessionOrphanRecoveryService(deps);
+
+    // Fail-closed behavior is unchanged: a malformed intent must still be
+    // retained, never reclaimed.
+    await expect(service.recover(session.id, 'background')).resolves.toBe('retained');
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('failed to parse'),
+      expect.objectContaining({ sessionId: session.id }),
+    );
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(captureExceptionMock.mock.calls[0]?.[0]).toBeInstanceOf(Error);
+
+    consoleErrorSpy.mockRestore();
+  });
+
   it('reuses the unique durable pre-intent stop identity after a crash', async () => {
     const deps = dependencies();
     vi.mocked(deps.findExistingStopIdentity).mockResolvedValue({

--- a/apps/api/src/services/desktopSessionOrphanRecovery.test.ts
+++ b/apps/api/src/services/desktopSessionOrphanRecovery.test.ts
@@ -244,7 +244,13 @@ describe('desktop orphan recovery', () => {
       deviceId: session.deviceId,
       reason: 'socket_error' as const,
       terminalStatus: 'failed' as const,
-      endedAt: '2026-07-25T12:01:00.000Z',
+      // On the synthetic clock scale (deps.now() starts near 0 in these
+      // tests), not a real calendar date -- so `ageMs = now - endedAt` lines
+      // up with the STALLED_STOP_PENDING_ESCALATION_MS comparisons below. In
+      // production both `deps.now()` (Date.now()) and `endedAt` (an ISO
+      // string built from Date.now()) are real epoch time, so this is purely
+      // a test-fixture convention, not a behavior difference.
+      endedAt: new Date(0).toISOString(),
       startedAt: '2026-07-25T12:00:00.000Z',
       inputEvents: 4,
       frameBytes: 128,
@@ -286,6 +292,162 @@ describe('desktop orphan recovery', () => {
     expect(captureExceptionMock).toHaveBeenCalledTimes(1);
 
     consoleErrorSpy.mockRestore();
+  });
+
+  it('escalates exactly at the threshold age, derived from endedAt (#3945)', async () => {
+    const deps = dependencies();
+    const persistedInput = {
+      version: 1 as const,
+      finalizationId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      sessionId: session.id,
+      connection: {
+        connectionId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+        generation: 1,
+        instanceId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+        leaseToken: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+      },
+      orgId: session.orgId,
+      userId: session.userId,
+      deviceId: session.deviceId,
+      reason: 'socket_error' as const,
+      terminalStatus: 'failed' as const,
+      endedAt: new Date(0).toISOString(),
+      startedAt: '2026-07-25T12:00:00.000Z',
+      inputEvents: 0,
+      frameBytes: 0,
+    };
+    vi.mocked(deps.observeSharedState).mockResolvedValue({
+      ownerPresent: false,
+      finalizationId: persistedInput.finalizationId,
+      canonicalPayload: JSON.stringify(persistedInput),
+      consistent: true,
+    });
+    captureExceptionMock.mockClear();
+    deps.setNow!(STALLED_STOP_PENDING_ESCALATION_MS);
+    const service = createDesktopSessionOrphanRecoveryService(deps);
+
+    await expect(service.recover(session.id, 'background')).resolves.toBe('retained');
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('survives a process restart: escalation age comes from endedAt, not local first-observation time (#3945)', async () => {
+    // Regression for the review finding that a purely in-memory
+    // "first observed" clock resets on every deploy/restart, silently
+    // restarting the 10-minute window for a session that was ALREADY most
+    // of the way there.
+    const deps = dependencies();
+    const persistedInput = {
+      version: 1 as const,
+      finalizationId: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee',
+      sessionId: session.id,
+      connection: {
+        connectionId: 'ffffffff-ffff-4fff-8fff-ffffffffffff',
+        generation: 1,
+        instanceId: '10101010-1010-4010-8010-101010101010',
+        leaseToken: '20202020-2020-4020-8020-202020202020',
+      },
+      orgId: session.orgId,
+      userId: session.userId,
+      deviceId: session.deviceId,
+      reason: 'socket_error' as const,
+      terminalStatus: 'failed' as const,
+      // Already 9 minutes old when this "process" boots -- e.g. a deploy
+      // happened mid-stall.
+      endedAt: new Date(0).toISOString(),
+      startedAt: '2026-07-25T12:00:00.000Z',
+      inputEvents: 0,
+      frameBytes: 0,
+    };
+    vi.mocked(deps.observeSharedState).mockResolvedValue({
+      ownerPresent: false,
+      finalizationId: persistedInput.finalizationId,
+      canonicalPayload: JSON.stringify(persistedInput),
+      consistent: true,
+    });
+    captureExceptionMock.mockClear();
+
+    // Simulate a brand-new process: a FRESH service instance (no in-memory
+    // history at all) whose very first observation is already 9 minutes past
+    // endedAt.
+    deps.setNow!(9 * 60 * 1000);
+    const restartedService = createDesktopSessionOrphanRecoveryService(deps);
+    await expect(restartedService.recover(session.id, 'background')).resolves.toBe('retained');
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+
+    // One more minute (still within the same process): must escalate on
+    // crossing 10 minutes of real age, not 10 minutes from this process's
+    // own first observation (which would push it to 19 minutes).
+    deps.setNow!(10 * 60 * 1000 + 1);
+    await expect(restartedService.recover(session.id, 'background')).resolves.toBe('retained');
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets a new finalization episode escalate independently after a prior one on the same session resolved (#3945)', async () => {
+    const deps = dependencies();
+    const resolvedFinalizationId = '30303030-3030-4030-8030-303030303030';
+    const newFinalizationId = '40404040-4040-4040-8040-404040404040';
+    // Field order must match desktopSessionFinalizationInputSchema's shape
+    // order exactly: canonicalizeDesktopFinalization round-trips through Zod
+    // (which re-emits keys in schema-declaration order), so the
+    // recover()-internal `persisted.canonicalPayload !== observed.canonicalPayload`
+    // identity check only matches when this literal's key order already
+    // agrees with the schema.
+    function makeInput(finalizationId: string, endedAt: string) {
+      return {
+        version: 1 as const,
+        finalizationId,
+        sessionId: session.id,
+        connection: {
+          connectionId: '50505050-5050-4050-8050-505050505050',
+          generation: 1,
+          instanceId: '60606060-6060-4060-8060-606060606060',
+          leaseToken: '70707070-7070-4070-8070-707070707070',
+        },
+        orgId: session.orgId,
+        userId: session.userId,
+        deviceId: session.deviceId,
+        reason: 'socket_error' as const,
+        terminalStatus: 'failed' as const,
+        endedAt,
+        startedAt: '2026-07-25T12:00:00.000Z',
+        inputEvents: 0,
+        frameBytes: 0,
+      };
+    }
+    const resolvedInput = makeInput(resolvedFinalizationId, new Date(0).toISOString());
+    captureExceptionMock.mockClear();
+    const service = createDesktopSessionOrphanRecoveryService(deps);
+
+    // First episode: escalate past the threshold.
+    vi.mocked(deps.observeSharedState).mockResolvedValue({
+      ownerPresent: false,
+      finalizationId: resolvedFinalizationId,
+      canonicalPayload: JSON.stringify(resolvedInput),
+      consistent: true,
+    });
+    deps.setNow!(STALLED_STOP_PENDING_ESCALATION_MS + 1);
+    await expect(service.recover(session.id, 'background')).resolves.toBe('retained');
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+
+    // That episode resolves (agent finally acked).
+    vi.mocked(deps.finalize).mockResolvedValueOnce('finalized');
+    await expect(service.recover(session.id, 'background')).resolves.toBe('finalized');
+
+    // A brand-new finalization attempt on the SAME session, already past the
+    // threshold at its very first observation, must escalate again --
+    // leftover state from the resolved episode must not suppress it.
+    const newInput = makeInput(
+      newFinalizationId,
+      new Date(deps.now() - STALLED_STOP_PENDING_ESCALATION_MS - 1).toISOString(),
+    );
+    vi.mocked(deps.observeSharedState).mockResolvedValue({
+      ownerPresent: false,
+      finalizationId: newFinalizationId,
+      canonicalPayload: JSON.stringify(newInput),
+      consistent: true,
+    });
+    await expect(service.recover(session.id, 'background')).resolves.toBe('retained');
+    expect(captureExceptionMock).toHaveBeenCalledTimes(2);
   });
 
   it('logs and reports a malformed persisted intent instead of swallowing it (#3945)', async () => {

--- a/apps/api/src/services/desktopSessionOrphanRecovery.test.ts
+++ b/apps/api/src/services/desktopSessionOrphanRecovery.test.ts
@@ -1,8 +1,17 @@
 import { describe, expect, it, vi } from 'vitest';
 
+const { captureExceptionMock } = vi.hoisted(() => ({
+  captureExceptionMock: vi.fn(),
+}));
+
+vi.mock('./sentry', () => ({
+  captureException: captureExceptionMock,
+}));
+
 import {
   __desktopSessionOrphanRecoveryTestOnly,
   createDesktopSessionOrphanRecoveryService,
+  STALLED_STOP_PENDING_ESCALATION_MS,
   type DesktopOrphanRecoveryDependencies,
 } from './desktopSessionOrphanRecovery';
 
@@ -210,6 +219,73 @@ describe('desktop orphan recovery', () => {
       sessionId: session.id,
       finalizationId: persistedInput.finalizationId,
     });
+  });
+
+  it('escalates a stop_pending intent that outlives the BullMQ re-enqueue no-op (#3945)', async () => {
+    // `deps.enqueue` re-adds the same stable jobId every scan, which BullMQ
+    // silently no-ops once that job hash exists in a terminal state
+    // (removeOnFail retention) -- so a permanently offline agent used to
+    // yield one 'retained' result and then zero further signal, forever
+    // (#3945). The scanner itself must escalate once the intent has outlived
+    // that no-op for long enough to mean "not coming back soon".
+    const deps = dependencies();
+    const persistedInput = {
+      version: 1 as const,
+      finalizationId: '66666666-6666-4666-8666-666666666666',
+      sessionId: session.id,
+      connection: {
+        connectionId: '77777777-7777-4777-8777-777777777777',
+        generation: 4,
+        instanceId: '88888888-8888-4888-8888-888888888888',
+        leaseToken: '99999999-9999-4999-8999-999999999999',
+      },
+      orgId: session.orgId,
+      userId: session.userId,
+      deviceId: session.deviceId,
+      reason: 'socket_error' as const,
+      terminalStatus: 'failed' as const,
+      endedAt: '2026-07-25T12:01:00.000Z',
+      startedAt: '2026-07-25T12:00:00.000Z',
+      inputEvents: 4,
+      frameBytes: 128,
+    };
+    vi.mocked(deps.observeSharedState).mockResolvedValue({
+      ownerPresent: false,
+      finalizationId: persistedInput.finalizationId,
+      canonicalPayload: JSON.stringify(persistedInput),
+      consistent: true,
+    });
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    captureExceptionMock.mockClear();
+    deps.setNow!(0);
+    const service = createDesktopSessionOrphanRecoveryService(deps);
+
+    // First observation of this stop_pending episode: too early to escalate.
+    await expect(service.recover(session.id, 'background')).resolves.toBe('retained');
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+
+    // Still under the escalation age on a later scan.
+    deps.setNow!(STALLED_STOP_PENDING_ESCALATION_MS - 1);
+    await expect(service.recover(session.id, 'background')).resolves.toBe('retained');
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+
+    // Past the escalation age: must now report once.
+    deps.setNow!(STALLED_STOP_PENDING_ESCALATION_MS + 1);
+    await expect(service.recover(session.id, 'background')).resolves.toBe('retained');
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('stop_pending'),
+      expect.anything(),
+    );
+
+    // A further scan while still stalled must NOT report again (once per
+    // episode, matching the reportedWedgedJobIds pattern in
+    // jobs/patchJobExecutor.ts).
+    deps.setNow!(STALLED_STOP_PENDING_ESCALATION_MS + 60_000);
+    await expect(service.recover(session.id, 'background')).resolves.toBe('retained');
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+
+    consoleErrorSpy.mockRestore();
   });
 
   it('reuses the unique durable pre-intent stop identity after a crash', async () => {

--- a/apps/api/src/services/desktopSessionOrphanRecovery.ts
+++ b/apps/api/src/services/desktopSessionOrphanRecovery.ts
@@ -15,6 +15,32 @@ import {
 import {
   enqueueDesktopSessionFinalization,
 } from '../jobs/desktopSessionFinalizationWorker';
+import { captureException } from './sentry';
+
+/**
+ * How long a persisted finalization intent may sit in `stop_pending` before
+ * the scanner escalates it (#3945).
+ *
+ * `drivePersistedIntent` re-adds the same stable BullMQ jobId every scan when
+ * the agent has not acked the stop command yet. Once that job hash exists in
+ * a terminal state, BullMQ's `queue.add({ jobId })` is a silent no-op
+ * (`removeOnFail` retains the failed hash) -- no new job, no new attempts, no
+ * further BullMQ-side signal. Recovery still happens (this scanner re-drives
+ * `finalize` directly on every pass), so a short-lived disconnect resolves
+ * fine; the gap is purely observability for the case where the agent never
+ * comes back: before this, that produced exactly one warning and then silence
+ * for as long as the row stayed non-terminal. 10 minutes is well past any
+ * ordinary reconnect blip (the scan cadence is REMOTE_WS_SHARED_LEASE_TTL_MS,
+ * 30s) but short enough that a genuinely abandoned session pages promptly.
+ */
+export const STALLED_STOP_PENDING_ESCALATION_MS = 10 * 60 * 1000;
+
+export class StalledStopPendingFinalizationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'StalledStopPendingFinalizationError';
+  }
+}
 
 export interface DesktopOrphanSession {
   id: string;
@@ -74,6 +100,46 @@ export function createDesktopSessionOrphanRecoveryService(
 ) {
   const firstAbsentObservation = new Map<string, number>();
 
+  // Escalation state for the stalled-stop_pending check (#3945), keyed by
+  // finalizationId rather than sessionId so a fresh finalization attempt on
+  // the same session starts its own episode. Cleared as soon as the intent
+  // resolves off `stop_pending`, which both ends the episode and bounds the
+  // set to ids that are currently stalled -- same shape as
+  // `reportedWedgedJobIds` in jobs/patchJobExecutor.ts.
+  const stopPendingSince = new Map<string, number>();
+  const reportedStalledFinalizations = new Set<string>();
+
+  function noteStopPendingObservation(input: DesktopSessionFinalizationInput): void {
+    const key = input.finalizationId;
+    const now = deps.now();
+    const since = stopPendingSince.get(key);
+    if (since === undefined) {
+      stopPendingSince.set(key, now);
+      return;
+    }
+    const ageMs = now - since;
+    if (ageMs < STALLED_STOP_PENDING_ESCALATION_MS) return;
+    if (reportedStalledFinalizations.has(key)) return;
+    reportedStalledFinalizations.add(key);
+    const message =
+      '[desktopSessionOrphanRecovery] finalization intent stuck in stop_pending '
+      + `past the ${STALLED_STOP_PENDING_ESCALATION_MS}ms escalation window; `
+      + 're-enqueue is a BullMQ no-op on this retained jobId, so recovery now '
+      + 'depends entirely on the agent reconnecting';
+    console.error(message, {
+      sessionId: input.sessionId,
+      finalizationId: input.finalizationId,
+      deviceId: input.deviceId,
+      ageMs,
+    });
+    captureException(new StalledStopPendingFinalizationError(message));
+  }
+
+  function clearStopPendingEscalation(finalizationId: string): void {
+    stopPendingSince.delete(finalizationId);
+    reportedStalledFinalizations.delete(finalizationId);
+  }
+
   async function drivePersistedIntent(
     input: DesktopSessionFinalizationInput,
     canonicalPayload: string,
@@ -84,8 +150,10 @@ export function createDesktopSessionOrphanRecoveryService(
         sessionId: input.sessionId,
         finalizationId: input.finalizationId,
       });
+      noteStopPendingObservation(input);
       return 'retained';
     }
+    clearStopPendingEscalation(input.finalizationId);
     if (!await deps.releaseIntent(
       input.sessionId,
       input.finalizationId,

--- a/apps/api/src/services/desktopSessionOrphanRecovery.ts
+++ b/apps/api/src/services/desktopSessionOrphanRecovery.ts
@@ -35,10 +35,43 @@ import { captureException } from './sentry';
  */
 export const STALLED_STOP_PENDING_ESCALATION_MS = 10 * 60 * 1000;
 
+/**
+ * Upper bound on how long a "we already reported this one" marker survives
+ * (review follow-up on #3945).
+ *
+ * The natural clear point -- `drivePersistedIntent` observing the intent
+ * resolve off `stop_pending` -- does NOT reliably fire: per
+ * jobs/desktopSessionFinalizationWorker.ts, the BullMQ finalization worker
+ * resolves most stop_pending intents directly, on a retry cadence much
+ * faster than this scanner's 30s sweep. Once that happens the session goes
+ * terminal and drops out of scanDesktopSessionOrphans's query entirely, so
+ * `recover()` is never called for that finalizationId again and the "resolved"
+ * branch here never runs. Relying solely on that branch would make this map
+ * grow for the lifetime of the process. Pruning by age on every observation
+ * bounds it independent of whether that branch ever fires: a still-genuinely-
+ * stalled episode simply re-populates its own entry on the next scan, so
+ * pruning can never suppress a real escalation.
+ */
+const REPORTED_STALLED_PRUNE_AGE_MS = 24 * 60 * 60 * 1000;
+
 export class StalledStopPendingFinalizationError extends Error {
   constructor(message: string) {
     super(message);
     this.name = 'StalledStopPendingFinalizationError';
+  }
+}
+
+/**
+ * A persisted finalization intent could not be parsed/canonicalized back into
+ * shape (#3945). Named per the BREEZE-1J convention (see
+ * jobs/desktopSessionFinalizationWorker.ts) so this is triageable in Sentry
+ * by exception type alone -- `scrubEvent` deletes `message` from every
+ * outbound event.
+ */
+export class PersistedFinalizationIntentParseError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'PersistedFinalizationIntentParseError';
   }
 }
 
@@ -100,27 +133,39 @@ export function createDesktopSessionOrphanRecoveryService(
 ) {
   const firstAbsentObservation = new Map<string, number>();
 
-  // Escalation state for the stalled-stop_pending check (#3945), keyed by
-  // finalizationId rather than sessionId so a fresh finalization attempt on
-  // the same session starts its own episode. Cleared as soon as the intent
-  // resolves off `stop_pending`, which both ends the episode and bounds the
-  // set to ids that are currently stalled -- same shape as
-  // `reportedWedgedJobIds` in jobs/patchJobExecutor.ts.
-  const stopPendingSince = new Map<string, number>();
-  const reportedStalledFinalizations = new Set<string>();
+  // "Already reported" markers for the stalled-stop_pending check (#3945),
+  // keyed by finalizationId (finalizationId -> when we reported, deps.now()
+  // ms) rather than sessionId so a fresh finalization attempt on the same
+  // session starts its own episode. Pruned by age on every observation (see
+  // REPORTED_STALLED_PRUNE_AGE_MS) rather than relied upon to be cleared
+  // exactly on resolution, since the resolution path frequently bypasses this
+  // service entirely (see that constant's doc comment).
+  const reportedStalledFinalizations = new Map<string, number>();
+
+  function pruneReportedStalledFinalizations(now: number): void {
+    for (const [key, reportedAt] of reportedStalledFinalizations) {
+      if (now - reportedAt > REPORTED_STALLED_PRUNE_AGE_MS) {
+        reportedStalledFinalizations.delete(key);
+      }
+    }
+  }
 
   function noteStopPendingObservation(input: DesktopSessionFinalizationInput): void {
     const key = input.finalizationId;
     const now = deps.now();
-    const since = stopPendingSince.get(key);
-    if (since === undefined) {
-      stopPendingSince.set(key, now);
-      return;
-    }
-    const ageMs = now - since;
+    pruneReportedStalledFinalizations(now);
+
+    // Age is derived from the persisted intent's own `endedAt` -- set once
+    // when the intent was first created and read back unchanged from Redis
+    // on every scan -- rather than from when THIS process first observed it.
+    // A local first-observation clock resets on every deploy/restart, which
+    // would silently restart the escalation window and could delay it
+    // indefinitely across repeated restarts for exactly the long-lived stall
+    // this check exists to catch (review follow-up on #3945).
+    const ageMs = now - new Date(input.endedAt).getTime();
     if (ageMs < STALLED_STOP_PENDING_ESCALATION_MS) return;
     if (reportedStalledFinalizations.has(key)) return;
-    reportedStalledFinalizations.add(key);
+    reportedStalledFinalizations.set(key, now);
     const message =
       '[desktopSessionOrphanRecovery] finalization intent stuck in stop_pending '
       + `past the ${STALLED_STOP_PENDING_ESCALATION_MS}ms escalation window; `
@@ -136,7 +181,6 @@ export function createDesktopSessionOrphanRecoveryService(
   }
 
   function clearStopPendingEscalation(finalizationId: string): void {
-    stopPendingSince.delete(finalizationId);
     reportedStalledFinalizations.delete(finalizationId);
   }
 
@@ -242,7 +286,10 @@ export function createDesktopSessionOrphanRecoveryService(
               error: error instanceof Error ? error.message : String(error),
             },
           );
-          captureException(error instanceof Error ? error : new Error(String(error)));
+          captureException(new PersistedFinalizationIntentParseError(
+            '[desktopSessionOrphanRecovery] failed to parse/canonicalize the persisted finalization intent',
+            { cause: error },
+          ));
           return 'retained';
         }
       }

--- a/apps/api/src/services/desktopSessionOrphanRecovery.ts
+++ b/apps/api/src/services/desktopSessionOrphanRecovery.ts
@@ -226,7 +226,23 @@ export function createDesktopSessionOrphanRecoveryService(
             persisted.input,
             persisted.canonicalPayload,
           );
-        } catch {
+        } catch (error) {
+          // Fail-closed behavior is unchanged (never reclaim on a parse
+          // failure), but this used to be a bare `catch { return 'retained' }`
+          // with zero logging (#3945) -- a corrupted or unparseable persisted
+          // intent left the session stuck in this branch forever with no
+          // trace of why. Log with context and report it: unlike a genuinely
+          // in-flight stop_pending (handled by the escalation above), this is
+          // a data-integrity fault that will never resolve itself.
+          console.error(
+            '[desktopSessionOrphanRecovery] failed to parse/canonicalize the persisted finalization intent; retaining (fail-closed) instead of reclaiming',
+            {
+              sessionId,
+              finalizationId: observed.finalizationId,
+              error: error instanceof Error ? error.message : String(error),
+            },
+          );
+          captureException(error instanceof Error ? error : new Error(String(error)));
           return 'retained';
         }
       }


### PR DESCRIPTION
## Summary

Closes #3945. Three silent-failure fixes deliberately deferred from #3912 to keep that PR reviewable. Each is a separate commit with a failing test written first.

1. **`routes/configurationPolicies/patchJobs.ts`** — the fire-and-forget `enqueuePatchJob(...).catch(console.error)` returned 201/`success:true` with `createdJobs` populated even when nothing was queued (e.g. a wedged BullMQ job id that #3912 made `enqueuePatchJob` throw on). The enqueue is now awaited per job; failures are logged, reported to Sentry, and collected into an `enqueueFailures` array in both the audit-log details and the response body. `success` is now `false` whenever any created job failed to enqueue.

2. **`services/desktopSessionOrphanRecovery.ts`** — a `stop_pending` finalization intent re-adds the same stable BullMQ jobId every scan; once that job hash is retained in a terminal state, `queue.add({ jobId })` is a silent no-op with no further BullMQ-side signal, so an agent that goes offline permanently produced one warning and then total silence forever. The fix is in the scanner (not the BullMQ job, which can't un-wedge itself): track how long a given `finalizationId` has sat in `stop_pending` and escalate (log + Sentry) once past a 10-minute threshold, once per episode — same shape as `reportedWedgedJobIds` in `jobs/patchJobExecutor.ts`.

3. **`services/desktopSessionOrphanRecovery.ts`** — the bare `catch { return 'retained'; }` around the persisted-intent JSON.parse/canonicalize swallowed any parse failure with zero logging. Fail-closed behavior (retain, never reclaim) is unchanged; the catch now logs with session/finalization context and reports to Sentry, matching sibling reconcile paths.

## Test plan
- [x] `apps/api/src/routes/configurationPolicies/patchJobs.test.ts` — 28/28 passing (new: enqueue-failure surfacing test, written failing first)
- [x] `apps/api/src/services/desktopSessionOrphanRecovery.test.ts` — 14/14 passing (new: stop_pending escalation test + malformed-intent logging test, both written failing first)
- [x] `apps/api/src/jobs/patchJobExecutor.test.ts`, `apps/api/src/jobs/desktopSessionFinalizationWorker.test.ts`, `apps/api/src/services/desktopSessionFinalization.test.ts` — 71/71 passing (sibling suites, unaffected)
- [x] `npx tsc --noEmit` clean on `apps/api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)