### PR TITLE
fix(api/rls): make the remote-access launcher's partner read a real escalation (#3419)

### DIFF
--- a/apps/api/src/__tests__/integration/remoteAccessLauncherPartnerVisibility.integration.test.ts
+++ b/apps/api/src/__tests__/integration/remoteAccessLauncherPartnerVisibility.integration.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Real-Postgres integration coverage for the partner-axis RLS gap in the
+ * remote-access launcher (#3419).
+ *
+ * The bug: `loadRemoteAccessLauncherContext` (routes/devices/core.ts) read
+ * `partners.settings` — a partner-axis table whose only SELECT policy is
+ * `breeze_has_partner_access(id)` (migrations/2026-04-11-partners-rls.sql) —
+ * wrapped in a BARE `withSystemDbAccessContext`. That wrapper looks like an
+ * escalation but is inert inside a request: `withDbAccessContext`
+ * early-returns when a context store already exists (db/index.ts) and
+ * authMiddleware has already opened one, so the read silently kept the
+ * caller's own scope. `computeAccessiblePartnerIds` returns `[]` for
+ * `scope === 'organization'` (middleware/auth.ts), so for an org-scoped
+ * technician the join returned ZERO ROWS — without raising — and the
+ * launcher reported `no_provider_configured` for a tenant that had a
+ * provider configured. Both entry points are
+ * `requireScope('organization', 'partner', 'system')`, so org scope is not a
+ * hypothetical caller: it is the default one.
+ *
+ * A mocked-DB unit test cannot catch this. `core.remoteAccessLaunch.test.ts`
+ * stages the partner row its own assertions then read back, with no RLS
+ * evaluation anywhere; the pre-fix code passed every one of those tests.
+ * Only a real Postgres connection through the `breeze_app` role, inside a
+ * real org-scoped `withDbAccessContext` session, can tell the two apart.
+ *
+ * This file therefore reproduces the exact ambient context an org-scoped
+ * HTTP request runs under (see enrollmentDefaultsPartnerCap.integration.test.ts,
+ * the #2776 precedent this is modelled on) and asserts the launcher still
+ * resolves the partner's provider from inside it.
+ */
+import './setup';
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
+import { organizations, partners } from '../../db/schema';
+import { checkRemoteAccessLauncherAvailabilityForDevice } from '../../routes/devices/core';
+import { readPartnerRemoteAccessSettings } from '../../services/remoteAccessProviders';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+/** Mirrors authMiddleware's computeAccessiblePartnerIds for scope 'organization': []. */
+function orgContext(orgId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    userId: null,
+  };
+}
+
+const PROVIDER_ID = 'rustdesk';
+const CUSTOM_FIELD_KEY = 'rustdesk_id';
+
+/** A fully-configured provider: enabled, default, with a URL template. */
+const CONFIGURED_PROVIDERS = {
+  defaultProviderId: PROVIDER_ID,
+  providers: [
+    {
+      id: PROVIDER_ID,
+      name: 'RustDesk',
+      urlTemplate: 'rustdesk://{id}?password={password}',
+      customFieldKey: CUSTOM_FIELD_KEY,
+      password: 'hunter2',
+      enabled: true,
+    },
+  ],
+};
+
+/** The device custom_fields the provider above needs to resolve. */
+const DEVICE_CUSTOM_FIELDS = { [CUSTOM_FIELD_KEY]: '294064193' };
+
+const createdOrgIds: string[] = [];
+const createdPartnerIds: string[] = [];
+
+async function seedTenant(): Promise<{ partnerId: string; orgId: string }> {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const ids = await withSystemDbAccessContext(async () => {
+    const [partner] = await db
+      .insert(partners)
+      .values({
+        name: `Launcher Partner ${unique}`,
+        slug: `launcher-partner-${unique}`,
+        type: 'msp',
+        plan: 'pro',
+        status: 'active',
+        settings: { remoteAccessProviders: CONFIGURED_PROVIDERS },
+      })
+      .returning({ id: partners.id });
+    const [org] = await db
+      .insert(organizations)
+      .values({
+        currencyCode: 'USD',
+        partnerId: partner!.id,
+        name: `Launcher Org ${unique}`,
+        slug: `launcher-org-${unique}`,
+        type: 'customer',
+        status: 'active',
+      })
+      .returning({ id: organizations.id });
+    return { partnerId: partner!.id, orgId: org!.id };
+  });
+  createdPartnerIds.push(ids.partnerId);
+  createdOrgIds.push(ids.orgId);
+  return ids;
+}
+
+afterEach(async () => {
+  if (createdOrgIds.length === 0 && createdPartnerIds.length === 0) return;
+  await withSystemDbAccessContext(async () => {
+    for (const id of createdOrgIds) {
+      await db.delete(organizations).where(eq(organizations.id, id));
+    }
+    for (const id of createdPartnerIds) {
+      await db.delete(partners).where(eq(partners.id, id));
+    }
+  });
+  createdOrgIds.length = 0;
+  createdPartnerIds.length = 0;
+});
+
+describe('remote-access launcher — partner provider visibility under org-scoped RLS (#3419)', () => {
+  runDb(
+    'an org-scoped caller (accessiblePartnerIds: []) still resolves the partner-configured launcher',
+    async () => {
+      const { orgId } = await seedTenant();
+
+      // The crux of the reproduction: call the resolver from INSIDE the same
+      // kind of RLS context an org-scoped HTTP request runs under, not from
+      // withSystemDbAccessContext. Pre-fix, the partner read ran against
+      // whatever context was already ambient — here, the org-scoped one — so
+      // the join returned nothing and this came back
+      // { available: false, skipReason: 'no_provider_configured' }.
+      const availability = await withDbAccessContext(orgContext(orgId), () =>
+        checkRemoteAccessLauncherAvailabilityForDevice(orgId, DEVICE_CUSTOM_FIELDS),
+      );
+
+      expect(availability).toEqual({
+        available: true,
+        providerId: PROVIDER_ID,
+        skipReason: null,
+      });
+    },
+  );
+
+  runDb(
+    'the delegated partner read itself returns the providers under an org-scoped context',
+    async () => {
+      const { orgId } = await seedTenant();
+
+      const providers = await withDbAccessContext(orgContext(orgId), () =>
+        readPartnerRemoteAccessSettings(orgId),
+      );
+
+      expect(providers?.defaultProviderId).toBe(PROVIDER_ID);
+      expect(providers?.providers?.map((p) => p.id)).toEqual([PROVIDER_ID]);
+    },
+  );
+
+  runDb(
+    'sanity check: the raw partners row IS invisible to that org-scoped context (proves the RLS premise, not just the fix)',
+    async () => {
+      const { orgId, partnerId } = await seedTenant();
+
+      const rows = await withDbAccessContext(orgContext(orgId), () =>
+        db.select({ id: partners.id }).from(partners).where(eq(partners.id, partnerId)),
+      );
+
+      // If this ever starts returning the row, the premise of #3419 (and of
+      // the escape the fix relies on) is gone — the partners RLS policy
+      // itself changed, and this file needs re-evaluating, not green-lighting.
+      expect(rows).toHaveLength(0);
+    },
+  );
+
+  runDb(
+    'negative control: a partner with NO providers configured still reports no_provider_configured',
+    async () => {
+      const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const ids = await withSystemDbAccessContext(async () => {
+        const [partner] = await db
+          .insert(partners)
+          .values({
+            name: `Bare Partner ${unique}`,
+            slug: `bare-partner-${unique}`,
+            type: 'msp',
+            plan: 'pro',
+            status: 'active',
+            settings: {},
+          })
+          .returning({ id: partners.id });
+        const [org] = await db
+          .insert(organizations)
+          .values({
+            currencyCode: 'USD',
+            partnerId: partner!.id,
+            name: `Bare Org ${unique}`,
+            slug: `bare-org-${unique}`,
+            type: 'customer',
+            status: 'active',
+          })
+          .returning({ id: organizations.id });
+        return { partnerId: partner!.id, orgId: org!.id };
+      });
+      createdPartnerIds.push(ids.partnerId);
+      createdOrgIds.push(ids.orgId);
+
+      // Discriminating control for the assertion above: it must be the
+      // partner's real configuration that decides the answer, not the fix
+      // hard-coding availability. A genuinely unconfigured tenant must still
+      // report the same skip reason the BUG used to report for a configured
+      // one — otherwise these tests would pass against a resolver that always
+      // said "available".
+      const availability = await withDbAccessContext(orgContext(ids.orgId), () =>
+        checkRemoteAccessLauncherAvailabilityForDevice(ids.orgId, DEVICE_CUSTOM_FIELDS),
+      );
+
+      expect(availability).toEqual({
+        available: false,
+        providerId: null,
+        skipReason: 'no_provider_configured',
+      });
+    },
+  );
+});
+
+/**
+ * AVAILABILITY (#2776 round 4, inherited via readWithPartnerAxisVisibility):
+ * the escape is taken ONLY when it is actually needed. `withDbAccessContext`
+ * opens a real `baseDb.transaction`, pinning one pooled connection for the
+ * whole callback, and `runOutsideDbContext` exits the ALS store — so the
+ * nested system context does not nest, it borrows a SECOND connection while
+ * the first is still held. Since #3419 put this read on GET /devices/:id,
+ * a system-scoped caller taking the escape needlessly would double-hold on a
+ * hot path, and postgres-js has no acquire timeout.
+ *
+ * This asserts the MECHANISM, not the value: both code paths return the same
+ * providers, so only transaction visibility can tell them apart. It writes
+ * the partner+org inside an OPEN system transaction and calls the resolver
+ * from inside that same transaction. Uncommitted rows are invisible to any
+ * other connection, so a read on a SECOND connection sees nothing and the
+ * expectation below fails loudly the moment the skip branch is removed.
+ */
+describe('remote-access launcher — no second pooled connection for a system-scoped caller', () => {
+  runDb(
+    'reads inside the caller’s own system transaction rather than on a second connection',
+    async () => {
+      const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+      const { availability, ids } = await withSystemDbAccessContext(async () => {
+        const [partner] = await db
+          .insert(partners)
+          .values({
+            name: `Ambient Launcher Partner ${unique}`,
+            slug: `ambient-launcher-partner-${unique}`,
+            type: 'msp',
+            plan: 'pro',
+            status: 'active',
+            settings: { remoteAccessProviders: CONFIGURED_PROVIDERS },
+          })
+          .returning({ id: partners.id });
+        const [org] = await db
+          .insert(organizations)
+          .values({
+            currencyCode: 'USD',
+            partnerId: partner!.id,
+            name: `Ambient Launcher Org ${unique}`,
+            slug: `ambient-launcher-org-${unique}`,
+            type: 'customer',
+            status: 'active',
+          })
+          .returning({ id: organizations.id });
+
+        // Still INSIDE the transaction that wrote these rows, and still
+        // uncommitted: only a read on this very connection can see them.
+        const availability = await checkRemoteAccessLauncherAvailabilityForDevice(
+          org!.id,
+          DEVICE_CUSTOM_FIELDS,
+        );
+        return { availability, ids: { partnerId: partner!.id, orgId: org!.id } };
+      });
+
+      createdPartnerIds.push(ids.partnerId);
+      createdOrgIds.push(ids.orgId);
+
+      expect(availability.available).toBe(true);
+      expect(availability.providerId).toBe(PROVIDER_ID);
+    },
+  );
+});

--- a/apps/api/src/__tests__/integration/remoteAccessLauncherPartnerVisibility.integration.test.ts
+++ b/apps/api/src/__tests__/integration/remoteAccessLauncherPartnerVisibility.integration.test.ts
@@ -50,6 +50,27 @@ function orgContext(orgId: string): DbAccessContext {
   };
 }
 
+/**
+ * Mirrors authMiddleware's computeAccessiblePartnerIds for scope 'partner':
+ * `[partnerId]`. This shape needs NO escalation to see its own partner row —
+ * `breeze_has_partner_access` would already grant it — but it takes the escape
+ * anyway, because `readWithPartnerAxisVisibility` skips only for 'system'.
+ * Covered because the launcher's entry points are
+ * `requireScope('organization', 'partner', 'system')`, so this is a real
+ * caller shape, and because it is the one the fix silently changed the
+ * connection behaviour of.
+ */
+function partnerContext(partnerId: string): DbAccessContext {
+  return {
+    scope: 'partner',
+    orgId: null,
+    accessibleOrgIds: [],
+    accessiblePartnerIds: [partnerId],
+    currentPartnerId: partnerId,
+    userId: null,
+  };
+}
+
 const PROVIDER_ID = 'rustdesk';
 const CUSTOM_FIELD_KEY = 'rustdesk_id';
 
@@ -175,6 +196,23 @@ describe('remote-access launcher — partner provider visibility under org-scope
   );
 
   runDb(
+    'a partner-scoped caller resolves the launcher too (the other admitted scope)',
+    async () => {
+      const { orgId, partnerId } = await seedTenant();
+
+      const availability = await withDbAccessContext(partnerContext(partnerId), () =>
+        checkRemoteAccessLauncherAvailabilityForDevice(orgId, DEVICE_CUSTOM_FIELDS),
+      );
+
+      expect(availability).toEqual({
+        available: true,
+        providerId: PROVIDER_ID,
+        skipReason: null,
+      });
+    },
+  );
+
+  runDb(
     'negative control: a partner with NO providers configured still reports no_provider_configured',
     async () => {
       const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -206,12 +244,13 @@ describe('remote-access launcher — partner provider visibility under org-scope
       createdPartnerIds.push(ids.partnerId);
       createdOrgIds.push(ids.orgId);
 
-      // Discriminating control for the assertion above: it must be the
-      // partner's real configuration that decides the answer, not the fix
-      // hard-coding availability. A genuinely unconfigured tenant must still
-      // report the same skip reason the BUG used to report for a configured
-      // one — otherwise these tests would pass against a resolver that always
-      // said "available".
+      // Scope note, so this case is not mistaken for a #3419 regression test:
+      // it does NOT discriminate the bug. Reverting the fix leaves this case
+      // green, because a denied read and a genuinely empty config are
+      // observationally identical here — that indistinguishability is the
+      // whole reason #3419 stayed invisible for so long. What it does guard is
+      // the opposite failure: an over-eager "fix" that hard-codes availability
+      // or defaults a missing config to configured would turn this red.
       const availability = await withDbAccessContext(orgContext(ids.orgId), () =>
         checkRemoteAccessLauncherAvailabilityForDevice(ids.orgId, DEVICE_CUSTOM_FIELDS),
       );

--- a/apps/api/src/routes/devices.test.ts
+++ b/apps/api/src/routes/devices.test.ts
@@ -157,6 +157,16 @@ vi.mock('../db', () => {
   dbMock.transaction = vi.fn((cb: (tx: unknown) => unknown) => cb(dbMock));
 
   return {
+    // `getCurrentDbAccessContext` is listed even though no test here currently
+    // reaches it: GET /devices/:id resolves the remote-access launcher through
+    // `readWithPartnerAxisVisibility` (db/partnerAxisRead.ts), which imports
+    // all four context helpers BY NAME. A factory missing one throws
+    // "No <name> export is defined on the mock" at call time — and the route
+    // swallows that into `remoteAccessLaunchSkipReason: 'config_error'`, so a
+    // test could go on passing while silently exercising the failure branch
+    // instead of the real path. `undefined` models a request-scoped (non-system)
+    // caller, which is the shape these routes actually run in. See #3419.
+    getCurrentDbAccessContext: vi.fn(() => undefined),
     runOutsideDbContext: vi.fn((fn) => fn()),
     withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
     withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),

--- a/apps/api/src/routes/devices/core.remoteAccessLaunch.test.ts
+++ b/apps/api/src/routes/devices/core.remoteAccessLaunch.test.ts
@@ -68,7 +68,15 @@ function makeSelectMock() {
   });
 }
 
+// `getCurrentDbAccessContext` is named on purpose: the partner-settings read
+// now goes through `readWithPartnerAxisVisibility` (db/partnerAxisRead.ts),
+// which imports all three context helpers BY NAME. Omitting any of them makes
+// this suite fail with "No <name> export is defined on the mock" rather than
+// silently skipping the RLS escape and reintroducing #3419. Returning
+// `undefined` models a request-scoped (non-system) caller, so the escape is
+// taken — which is the shape every route under test actually runs in.
 vi.mock('../../db', () => ({
+  getCurrentDbAccessContext: vi.fn(() => undefined),
   runOutsideDbContext: vi.fn((fn) => fn()),
   withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
   withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import { z } from 'zod';
 import { optionalJsonValidator, zValidator } from '../../lib/validation';
 import { and, eq, gte, like, sql, desc, inArray, type SQL } from 'drizzle-orm';
-import { db, withSystemDbAccessContext } from '../../db';
+import { db } from '../../db';
 import { createHash, randomBytes } from 'crypto';
 import { getRedis } from '../../services/redis';
 import { invalidateOrgDeviceCount } from '../../services/agentOrgRateLimit';
@@ -17,7 +17,6 @@ import {
   sites,
   enrollmentKeys,
   organizations,
-  partners,
   users,
 } from '../../db/schema';
 import {
@@ -60,8 +59,9 @@ import {
   type RemoteAccessLaunchAvailability,
   type RemoteAccessLaunchSkipReason,
 } from '../../services/remoteAccessLauncher';
+import { readPartnerRemoteAccessSettings } from '../../services/remoteAccessProviders';
 import { captureException } from '../../services/sentry';
-import type { InheritableRemoteAccessSettings, PartnerSettings } from '@breeze/shared';
+import type { InheritableRemoteAccessSettings } from '@breeze/shared';
 import { hashEnrollmentKey } from '../../services/enrollmentKeySecurity';
 import { sendCommandToAgent, isAgentConnected, disconnectAgent } from '../agentWs';
 import { terminateDeviceRemoteSessions, TEARDOWN_FAILED } from '../../services/remoteSessionTeardown';
@@ -1271,35 +1271,45 @@ async function readPreferredProviderId(auth: AuthContext): Promise<string | null
  * path (POST) so they evaluate the exact same provider selection; see the
  * skew case called out in issue #3402.
  *
- * The partners table has partner-axis RLS, and the request scope is the
- * user's (organization or partner), not the partner whose settings we need.
- * We wrap the lookup in a system-scope DB context so the policy engine
- * doesn't filter the row out. This mirrors how remoteAccessPolicy.ts uses
- * systemAuth for the same reason.
+ * The partner read is DELEGATED to `readPartnerRemoteAccessSettings`
+ * (services/remoteAccessProviders.ts), which is the one place that owns the
+ * privilege escalation `partners`' partner-axis RLS requires. It is not
+ * merely deduplication: this function used to run its own copy of that join
+ * wrapped in a BARE `withSystemDbAccessContext`, which does not escalate
+ * inside a request. `withDbAccessContext` early-returns when a context store
+ * already exists (db/index.ts) and authMiddleware has already opened one, so
+ * the wrapper silently retained the CALLER's scope. For an
+ * organization-scoped caller `computeAccessiblePartnerIds` returns `[]`
+ * (middleware/auth.ts), so `breeze_has_partner_access(id)` denied every
+ * `partners` row, the join returned zero rows without raising, and both the
+ * `hasRemoteAccessLauncher` flag on GET /devices/:id and
+ * POST /:id/remote-access-launch degraded to 'no_provider_configured' for a
+ * tenant that had a provider configured (#3419).
+ *
+ * Do NOT reintroduce a local copy of this read, and do not "simplify" the
+ * delegate's `runOutsideDbContext` away — see partnerAxisRead.ts.
  */
 async function loadRemoteAccessLauncherContext(
   orgId: string,
   auth?: AuthContext,
 ): Promise<{ providers: InheritableRemoteAccessSettings | undefined; preferredProviderId: string | null }> {
-  const partnerSettings = await withSystemDbAccessContext(async () => {
-    const [partnerRow] = await db
-      .select({ settings: partners.settings })
-      .from(partners)
-      .innerJoin(organizations, eq(organizations.partnerId, partners.id))
-      .where(eq(organizations.id, orgId))
-      .limit(1);
-    return (partnerRow?.settings ?? {}) as PartnerSettings;
-  });
+  const providers = await readPartnerRemoteAccessSettings(orgId);
   const preferredProviderId = auth ? await readPreferredProviderId(auth) : null;
-  return { providers: partnerSettings.remoteAccessProviders, preferredProviderId };
+  return { providers, preferredProviderId };
 }
 
 /**
  * Availability-only check: would a launch URL resolve for this device? Never
  * decrypts the provider password or substitutes the template. This is the
  * ONLY launcher entry point GET /devices/:id should call.
+ *
+ * Exported for `remoteAccessLauncherPartnerVisibility.integration.test.ts`,
+ * which drives it against real Postgres from inside an org-scoped RLS
+ * context. That is the only kind of test that can catch #3419: every mocked
+ * suite hands the resolver whatever partner row it staged, with no RLS
+ * evaluation at all, so the pre-fix code passed all of them.
  */
-async function checkRemoteAccessLauncherAvailabilityForDevice(
+export async function checkRemoteAccessLauncherAvailabilityForDevice(
   orgId: string,
   customFields: Record<string, unknown> | null,
   auth?: AuthContext,

--- a/apps/api/src/services/remoteAccessProviders.ts
+++ b/apps/api/src/services/remoteAccessProviders.ts
@@ -1,6 +1,7 @@
 import { eq } from 'drizzle-orm';
 import type { InheritableRemoteAccessSettings, RemoteAccessProvider } from '@breeze/shared';
-import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { db } from '../db';
+import { readWithPartnerAxisVisibility } from '../db/partnerAxisRead';
 import { organizations, partners } from '../db/schema';
 
 /**
@@ -39,27 +40,36 @@ type PartnerSettingsShape = {
  * `withDbAccessContext`, which early-returns when a context store already
  * exists, so inside a request it silently retains the caller's scope. Only
  * exiting the ALS store first opens a genuinely system-scoped transaction.
+ * `readWithPartnerAxisVisibility` (db/partnerAxisRead.ts) is that escape,
+ * plus the availability skip: a caller that is ALREADY system-scoped reads in
+ * its own transaction instead of borrowing a SECOND pooled connection while
+ * the first is still held (#2776 round 4). That skip matters more since
+ * #3419 put this read on GET /devices/:id, which is a hot path.
  *
  * Escalating past RLS is only defensible here because every caller projects
- * the result through `toProviderSummaries` before it leaves the process. Do
+ * the result through `toProviderSummaries` before it leaves the process, or
+ * (the launcher) consumes it in-process and returns one substituted URL. Do
  * not return the raw settings from a route.
  *
- * See #3419 for the same gap in the launcher's own partner read.
+ * The lookup stays keyed on `orgId` alone. Escaping RLS here widens which
+ * COLUMNS of the owning partner are legible; it must never widen WHICH
+ * partner row can be selected, so callers must pass an org id that was
+ * already resolved under the caller's own RLS context (both current callers
+ * pass one that came out of an RLS-filtered device/route lookup) — never a
+ * raw client-supplied id.
  */
 export async function readPartnerRemoteAccessSettings(
   orgId: string,
 ): Promise<InheritableRemoteAccessSettings | undefined> {
-  const settings = await runOutsideDbContext(() =>
-    withSystemDbAccessContext(async () => {
-      const [row] = await db
-        .select({ settings: partners.settings })
-        .from(partners)
-        .innerJoin(organizations, eq(organizations.partnerId, partners.id))
-        .where(eq(organizations.id, orgId))
-        .limit(1);
-      return (row?.settings ?? {}) as PartnerSettingsShape;
-    }),
-  );
+  const settings = await readWithPartnerAxisVisibility(async () => {
+    const [row] = await db
+      .select({ settings: partners.settings })
+      .from(partners)
+      .innerJoin(organizations, eq(organizations.partnerId, partners.id))
+      .where(eq(organizations.id, orgId))
+      .limit(1);
+    return (row?.settings ?? {}) as PartnerSettingsShape;
+  });
   return settings.remoteAccessProviders;
 }
 
@@ -67,16 +77,14 @@ export async function readPartnerRemoteAccessSettings(
 export async function readRemoteAccessSettingsForPartner(
   partnerId: string,
 ): Promise<InheritableRemoteAccessSettings | undefined> {
-  const settings = await runOutsideDbContext(() =>
-    withSystemDbAccessContext(async () => {
-      const [row] = await db
-        .select({ settings: partners.settings })
-        .from(partners)
-        .where(eq(partners.id, partnerId))
-        .limit(1);
-      return (row?.settings ?? {}) as PartnerSettingsShape;
-    }),
-  );
+  const settings = await readWithPartnerAxisVisibility(async () => {
+    const [row] = await db
+      .select({ settings: partners.settings })
+      .from(partners)
+      .where(eq(partners.id, partnerId))
+      .limit(1);
+    return (row?.settings ?? {}) as PartnerSettingsShape;
+  });
   return settings.remoteAccessProviders;
 }
 


### PR DESCRIPTION
Closes #3419

## The defect

`loadRemoteAccessLauncherContext` (`apps/api/src/routes/devices/core.ts`) read `partners.settings` inside a **bare `withSystemDbAccessContext`**. That wrapper looks like a privilege escalation, but it is inert inside a request: `withDbAccessContext` early-returns when a context store already exists (`db/index.ts`), and `authMiddleware` has already opened one — so the read silently retained the **caller's** scope.

`partners`' only SELECT policy is `breeze_has_partner_access(id)` (`migrations/2026-04-11-partners-rls.sql`), and `computeAccessiblePartnerIds` returns `[]` for `scope === 'organization'` (`middleware/auth.ts`). For an org-scoped technician the join therefore returned **zero rows — without raising** — and the launcher reported `no_provider_configured` for a tenant that had a provider configured.

Both entry points are `requireScope('organization', 'partner', 'system')`, so org scope is not a hypothetical caller; it is the default one. User-visible symptoms:

- **GET /devices/:id** → `hasRemoteAccessLauncher: false`, so the *Connect Desktop* button never renders.
- **POST /devices/:id/remote-access-launch** → 404 `no_provider_configured`.

Same defect class as #3391 (`readPreferredProviderId`), where the identical wrapper was inert ceremony and was removed. Here the consequence was worse than cosmetic, because this call genuinely depended on the escalation it appeared to perform.

## The fix

**Reuse, not a second implementation.** `readPartnerRemoteAccessSettings` (`apps/api/src/services/remoteAccessProviders.ts`) already performed exactly this read with the correct `runOutsideDbContext(() => withSystemDbAccessContext(...))` escape — and its own docstring already named this issue:

> `See #3419 for the same gap in the launcher's own partner read.`

So `core.ts` now delegates to it, deleting the duplicated join rather than fixing the same query in two places. That also removes the risk of the two copies drifting on skip-reason semantics — the very thing #3402 fixed for the availability/issuance split.

**Second change (same domain, deliberately in scope):** both reads in `remoteAccessProviders.ts` now go through `readWithPartnerAxisVisibility` (`apps/api/src/db/partnerAxisRead.ts`), the canonical helper for this shape (~15 other call sites). Beyond standardising, this restores the **#2776 round-4 availability skip**: a caller that is *already* system-scoped reads in its own transaction instead of borrowing a **second pooled connection** while the first is still held. That matters more after this PR, because the fix puts this read on `GET /devices/:id` — a hot path — and postgres-js has no acquire timeout.

## Sweep for the same shape

The issue asked for a sweep of other bare `withSystemDbAccessContext` calls on request paths. Verified results:

- **`routes/devices/core.ts` — the fixed call site was the only occurrence.** The one other mention in the file is a comment on the `device_commands` block explaining why that path deliberately does *not* wrap.
- **`partners.settings.remoteAccessProviders` has exactly one other reader, and it was already correct** — `services/remoteAccessProviders.ts`, whose docstring had already flagged `core.ts` as the outstanding sibling. `routes/remote/index.ts` consumes it through that service and projects via `toProviderSummaries`. After this PR there is no remaining broken read of this setting.
- **`services/pamApprovers.ts:39` (`resolveElevationApprovers`) was raised as a same-shape sibling and cleared on inspection.** It does carry a bare `withSystemDbAccessContext` over `partner_users` (a `PARTNER_TENANT_TABLES` member), but its only runtime caller — `routes/agents/elevationRequests.ts:201` — already escalates two lines above with `runOutsideDbContext(() => withSystemDbAccessContext(...))`, so the ambient scope is genuinely system by the time it runs. Not a defect. It is *fragile*, though: a future second caller that did not escalate first would silently drop partner-wide technicians from the PAM approver set.

The general lesson, and why this class keeps recurring: a bare `withSystemDbAccessContext` is neither always-broken nor always-fine. What matters is the **ambient scope at the moment it runs**, which any intermediate `runOutsideDbContext` on the call path changes — so it can only be judged by walking up to every caller, never from the call site alone.

A broader repo-wide sweep produced a longer candidate list in unrelated subsystems, but it is **not trustworthy as it stands and no part of it is claimed here as a defect**. Two of its candidates were spot-checked against the code and **both were false positives**: `services/pamApprovers.ts:39` (documented above) and `routes/partnerApi/provisioning.ts:217`. The remaining candidates were not checked either way and are neither confirmed nor cleared. The recurring error was assuming "inside a request ⇒ an ambient context exists"; that is false wherever an enclosing caller already escalated, and false for the whole partner-API write path, where `middleware/partnerApiAuth.ts:314-316` states outright that "Handlers therefore receive NO ambient DB context and must open their own bounded withDbAccessContext / withSystemDbAccessContext per operation." A bare wrapper there is correct, not inert.

Nothing from that list is folded into this PR, and none of it should be acted on until re-verified caller-by-caller.

## Known trade-off: one extra pooled connection on GET /devices/:id

Worth stating plainly, because the bug and the connection-thrift were **the same line of code**. The old wrapper was inert, so it took no second connection — it was "cheap" precisely because it was broken. A correct escalation cannot be free:

- `readWithPartnerAxisVisibility` exits the ALS store, so the system context does **not** nest — it opens a second transaction on a second pooled connection while the request's own transaction still holds the first.
- `checkRemoteAccessLauncherAvailabilityForDevice` runs on **every** `GET /devices/:id`, including for the majority of tenants who have no launcher providers configured at all — you must read the partner settings to discover that.
- Populations: **system** scope skips the escape (that is what the `readWithPartnerAxisVisibility` swap buys). **Org** scope must take it — that is the bug being fixed. **Partner** scope also takes it, though `breeze_has_partner_access` would already grant it its own partner row.

Assessed as acceptable to ship as-is:

- `DB_POOL_MAX` defaults to **30**, not 10 (`apps/api/src/db/index.ts:23-30`).
- The escaped read is a single indexed one-row join, held for milliseconds.
- `GET /devices/:id` is `requirePermission(DEVICES_READ)` on a human-paced UI path — not an agent/heartbeat firehose. Materially unlike the #2776 case, which was hundreds of concurrent installer bootstraps.
- `routes/remote/index.ts` already takes this exact escape on a user-facing endpoint today and has shipped fine.

**Deliberately not done here:** narrowing the escape so partner-scoped callers skip it too. Doing that correctly needs either an extra org→partner query on the ambient connection, or the assumption `auth.partnerId === device.org.partnerId` — and that assumption is exactly the kind of thing that should not be load-bearing for a cross-tenant read, so the `orgId`-keyed join that derives the partner from the data stays. Deriving the skip from a shared helper also beats reintroducing bespoke escape logic at one call site, which is what `readWithPartnerAxisVisibility` was extracted to prevent. Flagging it as a possible future optimization, not a defect in this PR.

## Verification

`apps/api/src/__tests__/integration/remoteAccessLauncherPartnerVisibility.integration.test.ts` drives the **real** resolver against **real Postgres** from inside an org-scoped `withDbAccessContext` — the same ambient context an org-scoped HTTP request runs under. Modelled on `enrollmentDefaultsPartnerCap.integration.test.ts` (the #2776 precedent the issue pointed at).

**This is the first runtime reproduction of #3419** — the issue was reported, carefully, as a structural defect proven only on paper. Against the pre-fix body the new test fails with exactly the reported symptom:

```
AssertionError: expected { available: false, …(2) } to deeply equal { available: true, …(2) }
-   "available": true,          +   "available": false,
-   "providerId": "rustdesk",   +   "providerId": null,
-   "skipReason": null,         +   "skipReason": "no_provider_configured",
```

Five cases, so the suite can't rot into a vacuous pass:

| Case | What it protects |
|---|---|
| org-scoped resolve | the bug itself (verified red pre-fix) |
| delegated read under org scope | the escape in the service, independently |
| raw `partners` row is invisible to that context | the RLS **premise** — if this ever returns the row, the policy changed and the file needs re-review, not green-lighting |
| unconfigured partner still reports `no_provider_configured` | discriminating negative control — the fix can't be "always available" |
| system-scoped caller reads in its own transaction | the pool-availability skip; **mutation-checked** by disabling the skip branch, which turns it red |

No mocked suite could have caught the original defect: they stage the partner row their own assertions then read back, with no RLS evaluation at all.

**Evidence**

- New integration test — **5 passed** (real Postgres, private test stack).
- `core.remoteAccessLaunch.test.ts` + `remoteAccessProviders.test.ts` — **18 passed**.
- `src/routes/devices/` — **44 files, 592 passed**.
- `src/routes/remote/`, `src/services/remoteAccess*`, `src/db/partnerAxisRead` — **7 files, 114 passed**.
- Every other suite importing `core.ts` while mocking `../../db` (`multi-tenant-isolation`, `core.decommission`, `cascadeDelete`, `systemManaged`, `core.permissions`, `moveOrg*`, `core.list-response-shape`, `ticketOrgMoveLockOrder`) — **9 files, 198 passed**; plus `routes/remote.test.ts` — **21 passed**.
- `enrollmentDefaultsPartnerCap.integration.test.ts` (the precedent suite, to confirm the shared helper is untouched) — **3 passed**.
- `integration-suite-coverage` (#4522 contract) — **5 passed**; the new file is matched by the existing `src/__tests__/integration/**` include, so it really does run in the blocking `integration-test` job.
- `tsc --noEmit` clean; `eslint` clean on all changed files.

## Reviewer notes

- **`core.remoteAccessLaunch.test.ts` gains one mock export.** `readWithPartnerAxisVisibility` imports `getCurrentDbAccessContext` **by name**, so a `vi.mock('../../db')` factory that omits it fails loudly ("No `getCurrentDbAccessContext` export is defined on the mock") rather than silently skipping the escape. That is the documented, intended failure mode (`partnerAxisRead.ts`), and adding the export is the documented remedy. Without it this suite failed 7 tests with `config_error`/500 — the route's `try/catch` converts the throw into a swallowed skip reason, which is worth knowing.
- **`checkRemoteAccessLauncherAvailabilityForDevice` is now exported** solely so the integration test can drive the real chain. The availability path is the safe surface to expose: it never decrypts a password or substitutes a template (#3402). `resolveRemoteAccessLauncherForDevice`, which does, stays unexported.
- **No tenancy widening.** The escaped read stays keyed on `orgId` alone, and both callers pass an org id that came out of `getDeviceWithOrgAndSiteCheck` → `ensureOrgAccess`. Escaping RLS here widens which *columns* of the owning partner are legible; it never widens *which* partner row can be selected. I extended the service docstring to state that contract explicitly.
- **`readPreferredProviderId` is correct as-is** and is not a second instance of this defect: `breeze_user_isolation_select` carries an explicit `OR id = public.breeze_current_user_id()` branch (`apps/api/migrations/2026-04-11-users-rls.sql:225`), so a technician reading their own row needs no escalation.
- **No migration, no schema change, no new table** — so no cascade / export-policy registration applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBxF7C8E5GxFnNcGf6kBVP
