### PR TITLE
fix(api): enforce site scope on maintenance window writes and reads (#3654)

### DIFF
--- a/apps/api/src/routes/maintenance.test.ts
+++ b/apps/api/src/routes/maintenance.test.ts
@@ -747,4 +747,456 @@ describe('maintenance routes', () => {
       });
     });
   });
+
+  // ==========================================================================
+  // Site-scope enforcement (#3654)
+  //
+  // `allowedSiteIds` is an app-layer authz axis that Postgres RLS does NOT
+  // defend. Before this suite, every maintenance-window write gated on org +
+  // partner-wide capability only, so a technician restricted to Site A could
+  // re-time or delete a window that another site's software deployment was
+  // bound to (`softwareDeploymentScheduler.isMaintenanceWindowOpen`).
+  // ==========================================================================
+  describe('site-scope enforcement (#3654)', () => {
+    const SITE_A = '11111111-1111-4111-8111-111111111111';
+    const SITE_B = '22222222-2222-4222-8222-222222222222';
+    const DEV_A = '33333333-3333-4333-8333-333333333333';
+    const DEV_B = '44444444-4444-4444-8444-444444444444';
+    const GRP_1 = '55555555-5555-4555-8555-555555555555';
+    const UNBOUNDED_DENIED =
+      'Site-restricted users cannot manage a maintenance window that targets all devices in the organization';
+    const TARGET_DENIED = 'Access to one or more target sites denied';
+    const UNRESOLVED_DENIED =
+      'A site-restricted user must target at least one site they can access';
+    const PARTNER_WIDE_DENIED =
+      'Site-restricted users cannot manage partner-wide maintenance windows';
+
+    /**
+     * Chainable thenable that answers any Drizzle select shape used by these
+     * routes (`.from().where()`, `.innerJoin()`, `.limit()`, `.orderBy()`) with
+     * the same row batch.
+     */
+    function selectChain(rows: unknown[]): any {
+      const chain: any = Promise.resolve(rows);
+      chain.from = () => selectChain(rows);
+      chain.innerJoin = () => selectChain(rows);
+      chain.leftJoin = () => selectChain(rows);
+      chain.where = () => selectChain(rows);
+      chain.orderBy = () => selectChain(rows);
+      chain.limit = () => Promise.resolve(rows);
+      return chain;
+    }
+
+    /** Answer successive `db.select()` calls with successive row batches. */
+    function queueSelects(...batches: unknown[][]) {
+      let i = 0;
+      vi.mocked(db.select).mockImplementation(((..._a: unknown[]) =>
+        selectChain(batches[i++] ?? [])) as any);
+    }
+
+    /** Auth as an org user restricted to `siteIds` (undefined = unrestricted). */
+    function authAsSiteRestricted(siteIds: string[] | undefined) {
+      vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+        c.set('auth', {
+          user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
+          scope: 'organization',
+          partnerId: null,
+          orgId: 'org-123',
+          token: { sub: 'user-123' },
+          canAccessOrg: (orgId: string) => orgId === 'org-123'
+        });
+        // requirePermission is mocked to a pass-through in this file, so stand
+        // in for the `c.set('permissions', ...)` it normally performs.
+        c.set('permissions', {
+          permissions: [],
+          partnerId: null,
+          orgId: 'org-123',
+          roleId: 'role-1',
+          scope: 'organization',
+          allowedSiteIds: siteIds
+        });
+        return next();
+      });
+    }
+
+    const baseWindowBody = {
+      name: 'Weekly Maintenance',
+      startTime: '2024-01-01T10:00:00.000Z',
+      endTime: '2024-01-01T12:00:00.000Z',
+      timezone: 'UTC',
+      recurrence: 'once',
+      suppressAlerts: true,
+      suppressPatches: true,
+      suppressAutomations: false
+    };
+
+    function post(body: Record<string, unknown>) {
+      return app.request('/maintenance/windows', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({ ...baseWindowBody, ...body })
+      });
+    }
+
+    function mockCreateSucceeds() {
+      const created = { id: 'win-new', orgId: 'org-123', name: 'Weekly Maintenance', status: 'scheduled' };
+      vi.mocked(db.insert)
+        .mockReturnValueOnce({
+          values: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([created]) })
+        } as any)
+        .mockReturnValueOnce({ values: vi.fn().mockResolvedValue(undefined) } as any);
+      return created;
+    }
+
+    // ---- POST /windows ----------------------------------------------------
+
+    it('rejects a site-restricted create that targets ALL devices', async () => {
+      authAsSiteRestricted([SITE_A]);
+      queueSelects();
+
+      const res = await post({ targetType: 'all' });
+
+      expect(res.status).toBe(403);
+      expect((await res.json()).error).toBe(UNBOUNDED_DENIED);
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('rejects a site-restricted create that names an out-of-scope site', async () => {
+      authAsSiteRestricted([SITE_A]);
+      queueSelects();
+
+      const res = await post({ targetType: 'site', siteIds: [SITE_A, SITE_B] });
+
+      expect(res.status).toBe(403);
+      expect((await res.json()).error).toBe(TARGET_DENIED);
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('rejects a site-restricted create whose devices live in an out-of-scope site', async () => {
+      authAsSiteRestricted([SITE_A]);
+      // device lookup for the gate
+      queueSelects([{ id: DEV_B, siteId: SITE_B }]);
+
+      const res = await post({ targetType: 'device', deviceIds: [DEV_B] });
+
+      expect(res.status).toBe(403);
+      expect((await res.json()).error).toBe(TARGET_DENIED);
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('rejects a site-restricted create whose group spans the whole org (null siteId)', async () => {
+      authAsSiteRestricted([SITE_A]);
+      queueSelects([{ id: GRP_1, siteId: null }]);
+
+      const res = await post({ targetType: 'group', groupIds: [GRP_1] });
+
+      expect(res.status).toBe(403);
+      expect((await res.json()).error).toBe(TARGET_DENIED);
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('rejects a site-restricted create that resolves to no site at all', async () => {
+      authAsSiteRestricted([SITE_A]);
+      queueSelects();
+
+      const res = await post({ targetType: 'site', siteIds: [] });
+
+      expect(res.status).toBe(403);
+      expect((await res.json()).error).toBe(UNRESOLVED_DENIED);
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('allows a site-restricted create confined to an in-scope site', async () => {
+      authAsSiteRestricted([SITE_A]);
+      queueSelects();
+      mockCreateSucceeds();
+
+      const res = await post({ targetType: 'site', siteIds: [SITE_A] });
+
+      expect(res.status).toBe(201);
+      expect((await res.json()).id).toBe('win-new');
+    });
+
+    it('allows a site-restricted create whose devices are all in scope', async () => {
+      authAsSiteRestricted([SITE_A]);
+      queueSelects([{ id: DEV_A, siteId: SITE_A }]);
+      mockCreateSucceeds();
+
+      const res = await post({ targetType: 'device', deviceIds: [DEV_A] });
+
+      expect(res.status).toBe(201);
+    });
+
+    it('leaves an unrestricted caller free to create an all-devices window', async () => {
+      authAsSiteRestricted(undefined);
+      queueSelects();
+      mockCreateSucceeds();
+
+      const res = await post({ targetType: 'all' });
+
+      expect(res.status).toBe(201);
+    });
+
+    it('denies a site-restricted caller with an empty site allowlist', async () => {
+      // `organization_users.site_ids = '{}'` means "no sites", not "all sites".
+      authAsSiteRestricted([]);
+      queueSelects();
+
+      const res = await post({ targetType: 'site', siteIds: [SITE_A] });
+
+      expect(res.status).toBe(403);
+      expect((await res.json()).error).toBe(TARGET_DENIED);
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    // ---- PATCH /windows/:id (the headline exploit) ------------------------
+
+    const siteBWindow = {
+      id: 'win-b',
+      orgId: 'org-123',
+      partnerId: null,
+      name: 'Site B patch night',
+      status: 'scheduled',
+      targetType: 'site',
+      siteIds: [SITE_B],
+      groupIds: null,
+      deviceIds: null
+    };
+    const siteAWindow = { ...siteBWindow, id: 'win-a', name: 'Site A patch night', siteIds: [SITE_A] };
+    const allWindow = { ...siteBWindow, id: 'win-all', name: 'Org-wide', targetType: 'all', siteIds: null };
+
+    it('rejects re-timing another site’s window', async () => {
+      authAsSiteRestricted([SITE_A]);
+      queueSelects([siteBWindow]);
+
+      const res = await app.request('/maintenance/windows/win-b', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({ startTime: '2024-06-01T09:00:00.000Z' })
+      });
+
+      expect(res.status).toBe(403);
+      expect((await res.json()).error).toBe(TARGET_DENIED);
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects widening an in-scope window onto an out-of-scope site', async () => {
+      authAsSiteRestricted([SITE_A]);
+      queueSelects([siteAWindow]);
+
+      const res = await app.request('/maintenance/windows/win-a', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({ siteIds: [SITE_A, SITE_B] })
+      });
+
+      expect(res.status).toBe(403);
+      expect((await res.json()).error).toBe(TARGET_DENIED);
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects escalating an in-scope window to targetType all', async () => {
+      authAsSiteRestricted([SITE_A]);
+      queueSelects([siteAWindow]);
+
+      const res = await app.request('/maintenance/windows/win-a', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({ targetType: 'all' })
+      });
+
+      expect(res.status).toBe(403);
+      expect((await res.json()).error).toBe(UNBOUNDED_DENIED);
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('allows editing a window confined to the caller’s own site', async () => {
+      authAsSiteRestricted([SITE_A]);
+      queueSelects([siteAWindow]);
+      vi.mocked(db.update).mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ ...siteAWindow, name: 'Renamed' }])
+          })
+        })
+      } as any);
+
+      const res = await app.request('/maintenance/windows/win-a', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({ name: 'Renamed' })
+      });
+
+      expect(res.status).toBe(200);
+      expect((await res.json()).name).toBe('Renamed');
+    });
+
+    // ---- DELETE / cancel --------------------------------------------------
+
+    it('rejects deleting another site’s window', async () => {
+      authAsSiteRestricted([SITE_A]);
+      queueSelects([siteBWindow]);
+
+      const res = await app.request('/maintenance/windows/win-b', {
+        method: 'DELETE',
+        headers: { Authorization: 'Bearer valid-token' }
+      });
+
+      expect(res.status).toBe(403);
+      expect((await res.json()).error).toBe(TARGET_DENIED);
+      expect(db.delete).not.toHaveBeenCalled();
+    });
+
+    it('rejects deleting an org-wide window', async () => {
+      authAsSiteRestricted([SITE_A]);
+      queueSelects([allWindow]);
+
+      const res = await app.request('/maintenance/windows/win-all', {
+        method: 'DELETE',
+        headers: { Authorization: 'Bearer valid-token' }
+      });
+
+      expect(res.status).toBe(403);
+      expect((await res.json()).error).toBe(UNBOUNDED_DENIED);
+      expect(db.delete).not.toHaveBeenCalled();
+    });
+
+    it('rejects cancelling another site’s window', async () => {
+      authAsSiteRestricted([SITE_A]);
+      queueSelects([siteBWindow]);
+
+      const res = await app.request('/maintenance/windows/win-b/cancel', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer valid-token' }
+      });
+
+      expect(res.status).toBe(403);
+      expect((await res.json()).error).toBe(TARGET_DENIED);
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects mutating a partner-wide window', async () => {
+      authAsSiteRestricted([SITE_A]);
+      vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+        c.set('auth', {
+          user: { id: 'user-p', email: 'p@example.com', name: 'P' },
+          scope: 'partner',
+          partnerId: PARTNER_ID,
+          orgId: 'org-123',
+          partnerOrgAccess: 'all',
+          token: { sub: 'user-p' },
+          canAccessOrg: () => true
+        });
+        c.set('permissions', {
+          permissions: [], partnerId: PARTNER_ID, orgId: 'org-123',
+          roleId: 'role-1', scope: 'organization', allowedSiteIds: [SITE_A]
+        });
+        return next();
+      });
+      queueSelects([{ ...siteAWindow, id: 'win-pw', orgId: null, partnerId: PARTNER_ID }]);
+
+      const res = await app.request('/maintenance/windows/win-pw', {
+        method: 'DELETE',
+        headers: { Authorization: 'Bearer valid-token' }
+      });
+
+      expect(res.status).toBe(403);
+      expect((await res.json()).error).toBe(PARTNER_WIDE_DENIED);
+      expect(db.delete).not.toHaveBeenCalled();
+    });
+
+    // ---- occurrence mutations --------------------------------------------
+
+    const siteBOccurrence = {
+      occurrence: { id: 'occ-b', windowId: 'win-b', status: 'scheduled', overrides: {} },
+      window: siteBWindow
+    };
+
+    it('rejects re-timing an occurrence of another site’s window', async () => {
+      authAsSiteRestricted([SITE_A]);
+      queueSelects([siteBOccurrence]);
+
+      const res = await app.request('/maintenance/occurrences/occ-b', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({ startTime: '2024-06-01T09:00:00.000Z' })
+      });
+
+      expect(res.status).toBe(403);
+      expect((await res.json()).error).toBe(TARGET_DENIED);
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects starting an occurrence of another site’s window early', async () => {
+      authAsSiteRestricted([SITE_A]);
+      queueSelects([siteBOccurrence]);
+
+      const res = await app.request('/maintenance/occurrences/occ-b/start', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer valid-token' }
+      });
+
+      expect(res.status).toBe(403);
+      expect((await res.json()).error).toBe(TARGET_DENIED);
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects ending an occurrence of another site’s window early', async () => {
+      authAsSiteRestricted([SITE_A]);
+      queueSelects([{ ...siteBOccurrence, occurrence: { ...siteBOccurrence.occurrence, status: 'active' } }]);
+
+      const res = await app.request('/maintenance/occurrences/occ-b/end', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer valid-token' }
+      });
+
+      expect(res.status).toBe(403);
+      expect((await res.json()).error).toBe(TARGET_DENIED);
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    // ---- reads ------------------------------------------------------------
+
+    it('hides out-of-scope windows from GET /windows but keeps org-wide ones', async () => {
+      authAsSiteRestricted([SITE_A]);
+      // 1: the window list. No group/device ids present, so no follow-up query.
+      queueSelects([siteAWindow, siteBWindow, allWindow]);
+
+      const res = await app.request('/maintenance/windows', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer valid-token' }
+      });
+
+      expect(res.status).toBe(200);
+      const ids = (await res.json()).data.map((w: { id: string }) => w.id);
+      // `all` windows genuinely suppress the caller's own devices, so they stay
+      // visible (read = intersection) even though they are not mutable.
+      expect(ids).toEqual(['win-a', 'win-all']);
+    });
+
+    it('404s a single out-of-scope window on GET /windows/:id', async () => {
+      authAsSiteRestricted([SITE_A]);
+      queueSelects([siteBWindow]);
+
+      const res = await app.request('/maintenance/windows/win-b', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer valid-token' }
+      });
+
+      expect(res.status).toBe(404);
+    });
+
+    it('leaves the window list untouched for an unrestricted caller', async () => {
+      authAsSiteRestricted(undefined);
+      queueSelects([siteAWindow, siteBWindow, allWindow]);
+
+      const res = await app.request('/maintenance/windows', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer valid-token' }
+      });
+
+      expect(res.status).toBe(200);
+      expect((await res.json()).data).toHaveLength(3);
+    });
+  });
 });

--- a/apps/api/src/routes/maintenance.test.ts
+++ b/apps/api/src/routes/maintenance.test.ts
@@ -1198,5 +1198,161 @@ describe('maintenance routes', () => {
       expect(res.status).toBe(200);
       expect((await res.json()).data).toHaveLength(3);
     });
+
+    // ---- batched group/device resolution on the read path -----------------
+
+    it('resolves group and device targets when deciding list visibility', async () => {
+      authAsSiteRestricted([SITE_A]);
+      const groupTargeted = {
+        ...siteAWindow, id: 'win-grp', targetType: 'group',
+        siteIds: null, groupIds: [GRP_1], deviceIds: null,
+      };
+      const deviceTargeted = {
+        ...siteAWindow, id: 'win-dev', targetType: 'device',
+        siteIds: null, groupIds: null, deviceIds: [DEV_A],
+      };
+      // 1: window list. 2: batched group lookup. 3: batched device lookup.
+      queueSelects(
+        [groupTargeted, deviceTargeted],
+        [{ id: GRP_1, siteId: SITE_B }],
+        [{ id: DEV_A, siteId: SITE_A }],
+      );
+
+      const res = await app.request('/maintenance/windows', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer valid-token' }
+      });
+
+      expect(res.status).toBe(200);
+      // The group lives in Site B, the device in Site A.
+      expect((await res.json()).data.map((w: { id: string }) => w.id)).toEqual(['win-dev']);
+    });
+
+    // ---- redaction of a window that spans beyond the caller ---------------
+
+    it('narrows a spanning window’s target arrays to the caller’s own sites', async () => {
+      authAsSiteRestricted([SITE_A]);
+      const spanning = { ...siteAWindow, id: 'win-span', siteIds: [SITE_A, SITE_B] };
+      queueSelects([spanning], []);
+
+      const res = await app.request('/maintenance/windows/win-span', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer valid-token' }
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      // Visible (it really does suppress the caller's own fleet) but Site B's
+      // id must not come back with it.
+      expect(body.siteIds).toEqual([SITE_A]);
+      expect(JSON.stringify(body)).not.toContain(SITE_B);
+      // targetType is NOT rewritten — the window is not pretended to be theirs.
+      expect(body.targetType).toBe('site');
+    });
+
+    it('leaves a spanning window intact for an unrestricted caller', async () => {
+      authAsSiteRestricted(undefined);
+      queueSelects([{ ...siteAWindow, id: 'win-span', siteIds: [SITE_A, SITE_B] }], []);
+
+      const res = await app.request('/maintenance/windows/win-span', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer valid-token' }
+      });
+
+      expect((await res.json()).siteIds).toEqual([SITE_A, SITE_B]);
+    });
+
+    // ---- siteless DEVICE (the group variant is covered above) -------------
+
+    it('rejects a site-restricted create whose device carries no site', async () => {
+      authAsSiteRestricted([SITE_A]);
+      queueSelects([{ id: DEV_A, siteId: null }]);
+
+      const res = await post({ targetType: 'device', deviceIds: [DEV_A] });
+
+      expect(res.status).toBe(403);
+      expect((await res.json()).error).toBe(TARGET_DENIED);
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('ignores a stale target id as long as one in-scope site remains', async () => {
+      authAsSiteRestricted([SITE_A]);
+      // DEV_B resolves to no row (decommissioned): unreachable by the matcher,
+      // so it must not lock the caller out of their own window.
+      queueSelects([{ id: DEV_A, siteId: SITE_A }]);
+      mockCreateSucceeds();
+
+      const res = await post({ targetType: 'device', deviceIds: [DEV_A, DEV_B] });
+
+      expect(res.status).toBe(201);
+    });
+
+    // ---- the remaining gated read routes ----------------------------------
+
+    it('404s occurrences of an out-of-scope window', async () => {
+      authAsSiteRestricted([SITE_A]);
+      queueSelects([siteBWindow]);
+
+      const res = await app.request('/maintenance/windows/win-b/occurrences', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer valid-token' }
+      });
+
+      expect(res.status).toBe(404);
+      // The occurrence query must never run — it would disclose the window.
+      expect(db.select).toHaveBeenCalledTimes(1);
+    });
+
+    it('excludes out-of-scope windows from the occurrence calendar', async () => {
+      authAsSiteRestricted([SITE_A]);
+      queueSelects([siteBWindow]);
+
+      const res = await app.request('/maintenance/occurrences', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer valid-token' }
+      });
+
+      expect(res.status).toBe(200);
+      expect((await res.json()).data).toEqual([]);
+      // Window set narrowed to empty, so the occurrence query is skipped.
+      expect(db.select).toHaveBeenCalledTimes(1);
+    });
+
+    it('excludes out-of-scope windows from GET /active', async () => {
+      authAsSiteRestricted([SITE_A]);
+      queueSelects([siteBWindow]);
+
+      const res = await app.request('/maintenance/active', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer valid-token' }
+      });
+
+      expect(res.status).toBe(200);
+      expect((await res.json()).data).toEqual([]);
+      expect(db.select).toHaveBeenCalledTimes(1);
+    });
+
+    // ---- unrestricted-caller regression on a WRITE route ------------------
+
+    it('leaves an unrestricted caller free to edit any window', async () => {
+      authAsSiteRestricted(undefined);
+      queueSelects([siteBWindow]);
+      vi.mocked(db.update).mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ ...siteBWindow, name: 'Renamed' }])
+          })
+        })
+      } as any);
+
+      const res = await app.request('/maintenance/windows/win-b', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({ name: 'Renamed' })
+      });
+
+      expect(res.status).toBe(200);
+      expect(db.update).toHaveBeenCalled();
+    });
   });
 });

--- a/apps/api/src/routes/maintenance.ts
+++ b/apps/api/src/routes/maintenance.ts
@@ -17,7 +17,7 @@ import {
   MAINTENANCE_SITE_SCOPE_MESSAGES,
   checkMaintenanceTargetsWithinSiteScope,
   filterWindowsToSiteScope,
-  isWindowVisibleInSiteScope,
+  scopeWindowForRead,
   type MaintenanceWindowTarget,
 } from '../services/maintenanceSiteScope';
 
@@ -511,8 +511,10 @@ maintenanceRoutes.get(
     }
 
     // Site axis (#3654): a window that reaches none of the caller's sites is
-    // not theirs to see.
-    if (!(await isWindowVisibleInSiteScope(window, requestPermissions(c)))) {
+    // not theirs to see, and a visible one is returned with its target arrays
+    // narrowed to what they may see.
+    const scopedWindow = await scopeWindowForRead(window, requestPermissions(c));
+    if (!scopedWindow) {
       return c.json({ error: 'Maintenance window not found' }, 404);
     }
 
@@ -529,7 +531,7 @@ maintenanceRoutes.get(
       .orderBy(asc(maintenanceOccurrences.startTime))
       .limit(10);
 
-    return c.json({ ...window, upcomingOccurrences: occurrences });
+    return c.json({ ...scopedWindow, upcomingOccurrences: occurrences });
   }
 );
 
@@ -783,8 +785,8 @@ maintenanceRoutes.get(
     }
 
     // Site axis (#3654): a window that reaches none of the caller's sites is
-    // not theirs to see.
-    if (!(await isWindowVisibleInSiteScope(window, requestPermissions(c)))) {
+    // not theirs to see, and neither are its occurrences.
+    if (!(await scopeWindowForRead(window, requestPermissions(c)))) {
       return c.json({ error: 'Maintenance window not found' }, 404);
     }
 

--- a/apps/api/src/routes/maintenance.ts
+++ b/apps/api/src/routes/maintenance.ts
@@ -98,8 +98,10 @@ function canAccessWindow(
 async function enforceWindowSiteScope(c: Context, target: MaintenanceWindowTarget) {
   const perms = c.get('permissions') as UserPermissions | undefined;
   const result = await checkMaintenanceTargetsWithinSiteScope(target, perms);
-  if (result.ok || !result.reason) return null;
-  return c.json({ error: MAINTENANCE_SITE_SCOPE_MESSAGES[result.reason] }, 403);
+  if (result.ok) return null;
+  // Fail closed on a denial that somehow carries no reason: only `ok` may open
+  // the gate, never the absence of an explanation for closing it.
+  return c.json({ error: MAINTENANCE_SITE_SCOPE_MESSAGES[result.reason ?? 'out_of_scope'] }, 403);
 }
 
 function requestPermissions(c: Context): UserPermissions | undefined {

--- a/apps/api/src/routes/maintenance.ts
+++ b/apps/api/src/routes/maintenance.ts
@@ -1,4 +1,4 @@
-import { Hono } from 'hono';
+import { Hono, type Context } from 'hono';
 import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { eq, and, or, isNull, lte, gte, inArray, desc, asc, sql, type SQL } from 'drizzle-orm';
@@ -13,6 +13,13 @@ import {
 import { writeRouteAudit } from '../services/auditEvents';
 import { isDeviceInMaintenance } from '../services/maintenanceService';
 import { PERMISSIONS, canAccessSite, type UserPermissions } from '../services/permissions';
+import {
+  MAINTENANCE_SITE_SCOPE_MESSAGES,
+  checkMaintenanceTargetsWithinSiteScope,
+  filterWindowsToSiteScope,
+  isWindowVisibleInSiteScope,
+  type MaintenanceWindowTarget,
+} from '../services/maintenanceSiteScope';
 
 export const maintenanceRoutes = new Hono();
 const requireMaintenanceRead = requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action);
@@ -81,6 +88,22 @@ function canAccessWindow(
   }
   if (auth.scope === 'system') return true;
   return auth.scope === 'partner' && !!auth.partnerId && window.partnerId === auth.partnerId;
+}
+
+// Site-axis gate (#3654). `canAccessWindow` above is org/partner only, and
+// Postgres RLS does not defend the site axis, so a site-restricted technician
+// could otherwise re-time or delete a window another site's deployment is bound
+// to. Returns a 403 response to return as-is, or null to proceed. Unrestricted
+// callers cost zero queries.
+async function enforceWindowSiteScope(c: Context, target: MaintenanceWindowTarget) {
+  const perms = c.get('permissions') as UserPermissions | undefined;
+  const result = await checkMaintenanceTargetsWithinSiteScope(target, perms);
+  if (result.ok || !result.reason) return null;
+  return c.json({ error: MAINTENANCE_SITE_SCOPE_MESSAGES[result.reason] }, 403);
+}
+
+function requestPermissions(c: Context): UserPermissions | undefined {
+  return c.get('permissions') as UserPermissions | undefined;
 }
 
 // Window-set condition for an org view: the org's own windows PLUS — for
@@ -358,7 +381,8 @@ maintenanceRoutes.get(
       .where(and(...conditions))
       .orderBy(desc(maintenanceWindows.createdAt));
 
-    return c.json({ data: windows });
+    // Site axis (#3654): the org filter above discloses every window in the org.
+    return c.json({ data: await filterWindowsToSiteScope(windows, requestPermissions(c)) });
   }
 );
 
@@ -390,6 +414,15 @@ maintenanceRoutes.post(
       }
       owner = { orgId: orgResult.orgId as string, partnerId: null };
     }
+
+    const siteScopeDenied = await enforceWindowSiteScope(c, {
+      orgId: owner.orgId,
+      targetType: body.targetType,
+      siteIds: body.siteIds,
+      groupIds: body.groupIds,
+      deviceIds: body.deviceIds,
+    });
+    if (siteScopeDenied) return siteScopeDenied;
 
     const startTime = new Date(body.startTime);
     const endTime = new Date(body.endTime);
@@ -475,6 +508,12 @@ maintenanceRoutes.get(
       return c.json({ error: 'Maintenance window not found' }, 404);
     }
 
+    // Site axis (#3654): a window that reaches none of the caller's sites is
+    // not theirs to see.
+    if (!(await isWindowVisibleInSiteScope(window, requestPermissions(c)))) {
+      return c.json({ error: 'Maintenance window not found' }, 404);
+    }
+
     // Get upcoming occurrences
     const occurrences = await db
       .select()
@@ -526,6 +565,12 @@ maintenanceRoutes.patch(
       return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
     }
 
+    // Site axis (#3654): authority over the window you are about to change is
+    // established by its CURRENT target set — re-timing or deleting it steers
+    // whatever deployments are bound to it.
+    const siteScopeDenied = await enforceWindowSiteScope(c, window);
+    if (siteScopeDenied) return siteScopeDenied;
+
     // Build update object
     const updateData: Record<string, unknown> = {
       updatedAt: new Date()
@@ -546,6 +591,17 @@ maintenanceRoutes.patch(
     if (updates.suppressPatches !== undefined) updateData.suppressPatching = updates.suppressPatches;
     if (updates.suppressAutomations !== undefined) updateData.suppressAutomations = updates.suppressAutomations;
     // notifyBefore / notifyOnStart / notifyOnEnd retired from the write surface (#3256).
+
+    // ...and again on the RESULTING target set, so a restricted caller cannot
+    // widen a window they legitimately own onto sites they cannot see.
+    const nextTargetDenied = await enforceWindowSiteScope(c, {
+      orgId: window.orgId,
+      targetType: updates.targetType ?? window.targetType,
+      siteIds: updates.siteIds ?? window.siteIds,
+      groupIds: updates.groupIds ?? window.groupIds,
+      deviceIds: updates.deviceIds ?? window.deviceIds,
+    });
+    if (nextTargetDenied) return nextTargetDenied;
 
     const [updated] = await db
       .update(maintenanceWindows)
@@ -599,6 +655,12 @@ maintenanceRoutes.delete(
       return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
     }
 
+    // Site axis (#3654): authority over the window you are about to change is
+    // established by its CURRENT target set — re-timing or deleting it steers
+    // whatever deployments are bound to it.
+    const siteScopeDenied = await enforceWindowSiteScope(c, window);
+    if (siteScopeDenied) return siteScopeDenied;
+
     // Delete only future occurrences (preserve past ones for audit)
     await db
       .delete(maintenanceOccurrences)
@@ -651,6 +713,12 @@ maintenanceRoutes.post(
     if (window.orgId === null && !canManagePartnerWidePolicies(auth)) {
       return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
     }
+
+    // Site axis (#3654): authority over the window you are about to change is
+    // established by its CURRENT target set — re-timing or deleting it steers
+    // whatever deployments are bound to it.
+    const siteScopeDenied = await enforceWindowSiteScope(c, window);
+    if (siteScopeDenied) return siteScopeDenied;
 
     if (window.status === 'cancelled') {
       return c.json({ error: 'Window is already cancelled' }, 400);
@@ -712,6 +780,12 @@ maintenanceRoutes.get(
       return c.json({ error: 'Maintenance window not found' }, 404);
     }
 
+    // Site axis (#3654): a window that reaches none of the caller's sites is
+    // not theirs to see.
+    if (!(await isWindowVisibleInSiteScope(window, requestPermissions(c)))) {
+      return c.json({ error: 'Maintenance window not found' }, 404);
+    }
+
     const occurrences = await db
       .select()
       .from(maintenanceOccurrences)
@@ -737,13 +811,22 @@ maintenanceRoutes.get(
       return c.json({ error: orgResult.error }, orgResult.status);
     }
 
-    // Get all windows for this org first (dual-axis, #2131)
+    // Get all windows for this org first (dual-axis, #2131), then narrow to
+    // the caller's site scope (#3654) — an occurrence discloses its window.
     const windows = await db
-      .select({ id: maintenanceWindows.id })
+      .select({
+        id: maintenanceWindows.id,
+        orgId: maintenanceWindows.orgId,
+        targetType: maintenanceWindows.targetType,
+        siteIds: maintenanceWindows.siteIds,
+        groupIds: maintenanceWindows.groupIds,
+        deviceIds: maintenanceWindows.deviceIds,
+      })
       .from(maintenanceWindows)
       .where(windowOwnershipCondition(auth, orgResult.orgId as string));
 
-    const windowIds = windows.map(w => w.id);
+    const visibleWindows = await filterWindowsToSiteScope(windows, requestPermissions(c));
+    const windowIds = visibleWindows.map(w => w.id);
 
     if (windowIds.length === 0) {
       return c.json({ data: [] });
@@ -825,6 +908,11 @@ maintenanceRoutes.patch(
       return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
     }
 
+    // Site axis (#3654): an occurrence inherits its parent window's target set;
+    // starting/ending/re-timing one steers the same deployments.
+    const siteScopeDenied = await enforceWindowSiteScope(c, occurrence.window);
+    if (siteScopeDenied) return siteScopeDenied;
+
     // Build overrides and update data
     const currentOverrides = (occurrence.occurrence.overrides as Record<string, unknown>) || {};
     const updateData: Record<string, unknown> = {};
@@ -901,6 +989,11 @@ maintenanceRoutes.post(
       return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
     }
 
+    // Site axis (#3654): an occurrence inherits its parent window's target set;
+    // starting/ending/re-timing one steers the same deployments.
+    const siteScopeDenied = await enforceWindowSiteScope(c, occurrence.window);
+    if (siteScopeDenied) return siteScopeDenied;
+
     if (occurrence.occurrence.status !== 'scheduled') {
       return c.json({ error: 'Occurrence is not in scheduled status' }, 400);
     }
@@ -965,6 +1058,11 @@ maintenanceRoutes.post(
       return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
     }
 
+    // Site axis (#3654): an occurrence inherits its parent window's target set;
+    // starting/ending/re-timing one steers the same deployments.
+    const siteScopeDenied = await enforceWindowSiteScope(c, occurrence.window);
+    if (siteScopeDenied) return siteScopeDenied;
+
     if (occurrence.occurrence.status !== 'active') {
       return c.json({ error: 'Occurrence is not currently active' }, 400);
     }
@@ -1014,11 +1112,14 @@ maintenanceRoutes.get(
 
     const now = new Date();
 
-    // Get all windows for this org (dual-axis, #2131)
-    const windows = await db
+    // Get all windows for this org (dual-axis, #2131), then narrow to the
+    // caller's site scope (#3654).
+    const allWindows = await db
       .select()
       .from(maintenanceWindows)
       .where(windowOwnershipCondition(auth, orgResult.orgId as string));
+
+    const windows = await filterWindowsToSiteScope(allWindows, requestPermissions(c));
 
     if (windows.length === 0) {
       return c.json({ data: [] });

--- a/apps/api/src/services/aiToolsFleet.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsFleet.siteScope.test.ts
@@ -703,4 +703,38 @@ describe('manage_maintenance_windows — site-axis read scoping (#3654)', () => 
 
     expect(body.window.id).toBe('w-a');
   });
+
+  it('filters BOTH the active and the scheduled sets in active_now', async () => {
+    // active_now runs two queries and merges them; a filter applied to only one
+    // would leak the other. Forbidden window comes back in the ACTIVE set.
+    let call = 0;
+    mockDb.select.mockImplementation(() => {
+      const rows = call++ === 0 ? [winForbidden] : [winA];
+      return { from: () => ({ where: () => Promise.resolve(rows) }) };
+    });
+
+    const raw = await handlerFor('manage_maintenance_windows')({ action: 'active_now' }, makeAuth(['site-A'])) as string;
+    const body = JSON.parse(raw);
+
+    expect(body.activeWindows.map((w: { id: string }) => w.id)).toEqual(['w-a']);
+    expect(body.count).toBe(1);
+    expect(raw).not.toContain('site-FORBIDDEN');
+    expect(body.activeWindows[0]).not.toHaveProperty('siteIds');
+  });
+
+  it('narrows a spanning window to the caller\u2019s own sites on get', async () => {
+    const spanning = { ...winA, id: 'w-span', siteIds: ['site-A', 'site-FORBIDDEN'] };
+    let call = 0;
+    mockDb.select.mockImplementation(() => {
+      if (call++ === 0) return { from: () => ({ where: () => ({ limit: () => Promise.resolve([spanning]) }) }) };
+      return { from: () => ({ where: () => ({ orderBy: () => ({ limit: () => Promise.resolve([]) }) }) }) };
+    });
+
+    const raw = await handlerFor('manage_maintenance_windows')(
+      { action: 'get', windowId: 'w-span' }, makeAuth(['site-A'])
+    ) as string;
+
+    expect(JSON.parse(raw).window.siteIds).toEqual(['site-A']);
+    expect(raw).not.toContain('site-FORBIDDEN');
+  });
 });

--- a/apps/api/src/services/aiToolsFleet.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsFleet.siteScope.test.ts
@@ -615,3 +615,92 @@ describe('SR5-20 manage_patches — compliance site scoping', () => {
     expect(JSON.parse(r).snapshot.id).toBe('snap1');
   });
 });
+
+// ============================================================================
+// manage_maintenance_windows — site-axis read scoping (#3654)
+//
+// `maintenanceWindowWhere` filters on the org/partner axis only, so before this
+// the tool disclosed every maintenance window in the org to a site-restricted
+// caller — the same enumeration step the HTTP exploit in #3654 starts from.
+// (The tool's create/update/delete actions are disabled upstream, so only the
+// read surface is reachable here.)
+// ============================================================================
+describe('manage_maintenance_windows — site-axis read scoping (#3654)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const winA = {
+    id: 'w-a', name: 'Site A night', orgId: 'org-1', targetType: 'site',
+    siteIds: ['site-A'], groupIds: null, deviceIds: null,
+    startTime: null, endTime: null, recurrence: 'once', status: 'scheduled',
+    suppressAlerts: true, suppressPatching: true,
+  };
+  const winForbidden = { ...winA, id: 'w-b', name: 'Site FORBIDDEN night', siteIds: ['site-FORBIDDEN'] };
+  const winAll = { ...winA, id: 'w-all', name: 'Org wide', targetType: 'all', siteIds: null };
+
+  function mockList(rows: unknown[]) {
+    mockDb.select.mockReturnValue({
+      from: () => ({ where: () => ({ orderBy: () => ({ limit: () => Promise.resolve(rows) }) }) }),
+    });
+  }
+
+  it('hides a window targeting only a forbidden site from list', async () => {
+    mockList([winA, winForbidden, winAll]);
+
+    const raw = await handlerFor('manage_maintenance_windows')({ action: 'list' }, makeAuth(['site-A']));
+    const body = JSON.parse(raw as string);
+
+    // The `all` window really does suppress the caller's own fleet, so it stays
+    // visible; the forbidden-site one must not.
+    expect(body.windows.map((w: { id: string }) => w.id)).toEqual(['w-a', 'w-all']);
+    expect(body.showing).toBe(2);
+    expect(raw).not.toContain('site-FORBIDDEN');
+  });
+
+  it('does not leak the site-axis columns it filters on', async () => {
+    mockList([winA]);
+
+    const body = JSON.parse(await handlerFor('manage_maintenance_windows')({ action: 'list' }, makeAuth(['site-A'])) as string);
+
+    expect(body.windows[0]).not.toHaveProperty('siteIds');
+    expect(body.windows[0]).not.toHaveProperty('groupIds');
+    expect(body.windows[0]).not.toHaveProperty('deviceIds');
+    expect(body.windows[0]).not.toHaveProperty('orgId');
+    expect(body.windows[0].id).toBe('w-a');
+  });
+
+  it('leaves an unrestricted caller seeing every window (no regression)', async () => {
+    mockList([winA, winForbidden, winAll]);
+
+    const body = JSON.parse(await handlerFor('manage_maintenance_windows')({ action: 'list' }, makeAuth(undefined)) as string);
+
+    expect(body.windows.map((w: { id: string }) => w.id)).toEqual(['w-a', 'w-b', 'w-all']);
+  });
+
+  it('refuses to fetch a forbidden-site window by id', async () => {
+    mockDb.select.mockReturnValue({
+      from: () => ({ where: () => ({ limit: () => Promise.resolve([winForbidden]) }) }),
+    });
+
+    const raw = await handlerFor('manage_maintenance_windows')(
+      { action: 'get', windowId: 'w-b' }, makeAuth(['site-A'])
+    ) as string;
+
+    expect(JSON.parse(raw).error).toBe('Maintenance window not found or access denied');
+    // The occurrence read must never happen — it would disclose the window too.
+    expect(mockDb.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('still fetches an in-scope window by id', async () => {
+    let call = 0;
+    mockDb.select.mockImplementation(() => {
+      if (call++ === 0) return { from: () => ({ where: () => ({ limit: () => Promise.resolve([winA]) }) }) };
+      return { from: () => ({ where: () => ({ orderBy: () => ({ limit: () => Promise.resolve([]) }) }) }) };
+    });
+
+    const body = JSON.parse(await handlerFor('manage_maintenance_windows')(
+      { action: 'get', windowId: 'w-a' }, makeAuth(['site-A'])
+    ) as string);
+
+    expect(body.window.id).toBe('w-a');
+  });
+});

--- a/apps/api/src/services/aiToolsFleet.ts
+++ b/apps/api/src/services/aiToolsFleet.ts
@@ -72,7 +72,7 @@ async function scheduleAiGroupPeripheralReconciliation(deviceIds: readonly strin
 import type { AiTool } from './aiTools';
 import type { UserPermissions } from './permissions';
 import { canManagePartnerWidePolicies, PARTNER_WIDE_WRITE_DENIED_MESSAGE } from './partnerWideAccess';
-import { filterWindowsToSiteScope } from './maintenanceSiteScope';
+import { filterWindowsToSiteScope, scopeWindowForRead } from './maintenanceSiteScope';
 import { deviceSiteDenied, deviceIdSiteDenied, resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
 import { checkAutomationTargetsWithinSiteScope } from './automationRuntime';
 import { assertReportExecutionPreflight } from './reportGenerationService';
@@ -1406,6 +1406,11 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
         if (oc) conditions.push(oc);
 
         const limit = Math.min(Math.max(1, Number(input.limit) || 25), 100);
+        // The SQL limit lands before the site filter, so a site-restricted
+        // caller scans a wider (still bounded) page and the result is sliced to
+        // `limit` after filtering — otherwise other sites' windows crowd out the
+        // ones actually suppressing this caller's own fleet (#3654).
+        const scanLimit = auth.allowedSiteIds ? Math.min(Math.max(limit * 5, 100), 500) : limit;
         const rows = await db.select({
           id: maintenanceWindows.id,
           name: maintenanceWindows.name,
@@ -1424,11 +1429,11 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
         }).from(maintenanceWindows)
           .where(conditions.length > 0 ? and(...conditions) : undefined)
           .orderBy(desc(maintenanceWindows.startTime))
-          .limit(limit);
+          .limit(scanLimit);
 
         // `maintenanceWindowWhere` is org/partner only; narrow to the caller's
         // sites the same way GET /maintenance/windows does (#3654).
-        const visibleRows = await filterWindowsToSiteScope(rows, { allowedSiteIds: auth.allowedSiteIds });
+        const visibleRows = (await filterWindowsToSiteScope(rows, { allowedSiteIds: auth.allowedSiteIds })).slice(0, limit);
         const windows = visibleRows.map(({ orgId: _orgId, siteIds: _siteIds, groupIds: _groupIds, deviceIds: _deviceIds, ...rest }) => rest);
 
         return JSON.stringify({ windows, showing: windows.length });
@@ -1444,9 +1449,10 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
         if (!win) return JSON.stringify({ error: 'Maintenance window not found or access denied' });
 
         // Site axis (#3654): a window reaching none of the caller's sites is not
-        // theirs to read, and its occurrences would disclose it too.
-        const [visibleWin] = await filterWindowsToSiteScope([win], { allowedSiteIds: auth.allowedSiteIds });
-        if (!visibleWin) return JSON.stringify({ error: 'Maintenance window not found or access denied' });
+        // theirs to read, and its occurrences would disclose it too. A visible
+        // one comes back with its target arrays narrowed to the caller's scope.
+        const scopedWin = await scopeWindowForRead(win, { allowedSiteIds: auth.allowedSiteIds });
+        if (!scopedWin) return JSON.stringify({ error: 'Maintenance window not found or access denied' });
 
         const occurrences = await db.select()
           .from(maintenanceOccurrences)
@@ -1454,7 +1460,7 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
           .orderBy(desc(maintenanceOccurrences.startTime))
           .limit(10);
 
-        return JSON.stringify({ window: win, occurrences });
+        return JSON.stringify({ window: scopedWin, occurrences });
       }
 
       if (action === 'active_now') {

--- a/apps/api/src/services/aiToolsFleet.ts
+++ b/apps/api/src/services/aiToolsFleet.ts
@@ -72,6 +72,7 @@ async function scheduleAiGroupPeripheralReconciliation(deviceIds: readonly strin
 import type { AiTool } from './aiTools';
 import type { UserPermissions } from './permissions';
 import { canManagePartnerWidePolicies, PARTNER_WIDE_WRITE_DENIED_MESSAGE } from './partnerWideAccess';
+import { filterWindowsToSiteScope } from './maintenanceSiteScope';
 import { deviceSiteDenied, deviceIdSiteDenied, resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
 import { checkAutomationTargetsWithinSiteScope } from './automationRuntime';
 import { assertReportExecutionPreflight } from './reportGenerationService';
@@ -1387,6 +1388,12 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
       const action = input.action as string;
       const orgId = getOrgId(auth);
 
+      // NOTE (#3654): the create/update/delete blocks further down are dead —
+      // this guard and the `action` enum both exclude them. If they are ever
+      // re-enabled they MUST route through
+      // `checkMaintenanceTargetsWithinSiteScope` (services/maintenanceSiteScope),
+      // exactly as routes/maintenance.ts does: `maintenanceWindowWhere` below is
+      // org/partner only and does not defend the site axis.
       if (action === 'create' || action === 'update' || action === 'delete') {
         return JSON.stringify({
           error: `Action "${action}" is disabled. Maintenance windows must be managed through configuration policies. Use manage_policy_feature_link with featureType "maintenance" to configure maintenance windows on a policy.`,
@@ -1409,12 +1416,22 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
           status: maintenanceWindows.status,
           suppressAlerts: maintenanceWindows.suppressAlerts,
           suppressPatching: maintenanceWindows.suppressPatching,
+          // Site-axis inputs (#3654) — stripped from the reply below.
+          orgId: maintenanceWindows.orgId,
+          siteIds: maintenanceWindows.siteIds,
+          groupIds: maintenanceWindows.groupIds,
+          deviceIds: maintenanceWindows.deviceIds,
         }).from(maintenanceWindows)
           .where(conditions.length > 0 ? and(...conditions) : undefined)
           .orderBy(desc(maintenanceWindows.startTime))
           .limit(limit);
 
-        return JSON.stringify({ windows: rows, showing: rows.length });
+        // `maintenanceWindowWhere` is org/partner only; narrow to the caller's
+        // sites the same way GET /maintenance/windows does (#3654).
+        const visibleRows = await filterWindowsToSiteScope(rows, { allowedSiteIds: auth.allowedSiteIds });
+        const windows = visibleRows.map(({ orgId: _orgId, siteIds: _siteIds, groupIds: _groupIds, deviceIds: _deviceIds, ...rest }) => rest);
+
+        return JSON.stringify({ windows, showing: windows.length });
       }
 
       if (action === 'get') {
@@ -1425,6 +1442,11 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
 
         const [win] = await db.select().from(maintenanceWindows).where(and(...conditions)).limit(1);
         if (!win) return JSON.stringify({ error: 'Maintenance window not found or access denied' });
+
+        // Site axis (#3654): a window reaching none of the caller's sites is not
+        // theirs to read, and its occurrences would disclose it too.
+        const [visibleWin] = await filterWindowsToSiteScope([win], { allowedSiteIds: auth.allowedSiteIds });
+        if (!visibleWin) return JSON.stringify({ error: 'Maintenance window not found or access denied' });
 
         const occurrences = await db.select()
           .from(maintenanceOccurrences)
@@ -1453,6 +1475,11 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
           targetType: maintenanceWindows.targetType,
           suppressAlerts: maintenanceWindows.suppressAlerts,
           suppressPatching: maintenanceWindows.suppressPatching,
+          // Site-axis inputs (#3654) — stripped from the reply below.
+          orgId: maintenanceWindows.orgId,
+          siteIds: maintenanceWindows.siteIds,
+          groupIds: maintenanceWindows.groupIds,
+          deviceIds: maintenanceWindows.deviceIds,
         }).from(maintenanceWindows)
           .where(and(...conditions));
 
@@ -1473,10 +1500,25 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
           targetType: maintenanceWindows.targetType,
           suppressAlerts: maintenanceWindows.suppressAlerts,
           suppressPatching: maintenanceWindows.suppressPatching,
+          // Site-axis inputs (#3654) — stripped from the reply below.
+          orgId: maintenanceWindows.orgId,
+          siteIds: maintenanceWindows.siteIds,
+          groupIds: maintenanceWindows.groupIds,
+          deviceIds: maintenanceWindows.deviceIds,
         }).from(maintenanceWindows)
           .where(and(...scheduledConditions));
 
-        return JSON.stringify({ activeWindows: [...active, ...scheduled], count: active.length + scheduled.length });
+        // `maintenanceWindowWhere` is org/partner only; narrow to the caller's
+        // sites (#3654) before reporting what is suppressing their fleet.
+        const visibleActive = await filterWindowsToSiteScope(
+          [...active, ...scheduled],
+          { allowedSiteIds: auth.allowedSiteIds },
+        );
+        const activeWindows = visibleActive.map(
+          ({ orgId: _orgId, siteIds: _siteIds, groupIds: _groupIds, deviceIds: _deviceIds, ...rest }) => rest,
+        );
+
+        return JSON.stringify({ activeWindows, count: activeWindows.length });
       }
 
       if (action === 'create') {

--- a/apps/api/src/services/maintenanceSiteScope.ts
+++ b/apps/api/src/services/maintenanceSiteScope.ts
@@ -1,0 +1,222 @@
+/**
+ * Maintenance windows — site-axis (app-layer authz) enforcement (#3654).
+ *
+ * Site is an app-layer authz axis: Postgres RLS does NOT defend it. Every
+ * maintenance-window write used to gate on the org axis alone
+ * (`canAccessWindow`), so a technician restricted to Site A could re-time or
+ * delete a window that another site's software deployment was bound to
+ * (`softwareDeploymentScheduler.isMaintenanceWindowOpen` joins deployments to
+ * windows by id) — dispatching a 400-machine install into business hours, or
+ * silently stranding it forever.
+ *
+ * The gate mirrors the automation precedent
+ * (`automationRuntime.checkAutomationTargetsWithinSiteScope` +
+ * `routes/automations.ts:enforceAutomationSiteScope`): reject an unbounded
+ * target outright, otherwise resolve the target set to concrete sites and
+ * require every one of them to pass `canAccessSite`.
+ *
+ * Two deliberate asymmetries, both documented at their use site below:
+ *
+ *  - **Writes require containment, reads only intersection.** A window that
+ *    spans Site A and Site B stays *visible* to a Site-A tech (their own fleet
+ *    really is suppressed by it, and hiding that is an operational hazard) but
+ *    is not *mutable* by them.
+ *  - **A target set that resolves to no site is rejected**, where the
+ *    automation precedent passes it. `isDeviceInMaintenance` ORs `siteIds`,
+ *    `groupIds` and `deviceIds` independently of `targetType`, so no single
+ *    array is authoritative; requiring at least one provably in-scope site is
+ *    the only claim that survives a change to that matcher. The window feature
+ *    is deprecated in favour of configuration policies, so the usability cost
+ *    of the stricter rule is nil.
+ */
+
+import { and, eq, inArray } from 'drizzle-orm';
+import { db } from '../db';
+import { deviceGroups, devices } from '../db/schema';
+import { canAccessSite, type UserPermissions } from './permissions';
+
+/** The subset of a maintenance-window row the site gate reasons about. */
+export interface MaintenanceWindowTarget {
+  orgId: string | null;
+  targetType: string | null;
+  siteIds?: string[] | null;
+  groupIds?: string[] | null;
+  deviceIds?: string[] | null;
+}
+
+export type MaintenanceSiteScopeDenial =
+  /** Partner-wide window (org_id NULL): spans every org, containment unprovable. */
+  | 'partner_wide'
+  /** `targetType: 'all'` — reaches every device in the org, now and in future. */
+  | 'unbounded'
+  /** Nothing in the target set resolves to a site the caller could own. */
+  | 'unresolved'
+  /** At least one resolved site is outside the caller's allowlist. */
+  | 'out_of_scope';
+
+export interface MaintenanceSiteScopeCheck {
+  ok: boolean;
+  reason: MaintenanceSiteScopeDenial | null;
+  /** Resolved sites outside the allowlist. Empty for the non-`out_of_scope` denials. */
+  outOfScopeSiteIds: string[];
+}
+
+export const MAINTENANCE_SITE_SCOPE_MESSAGES: Record<MaintenanceSiteScopeDenial, string> = {
+  partner_wide: 'Site-restricted users cannot manage partner-wide maintenance windows',
+  unbounded:
+    'Site-restricted users cannot manage a maintenance window that targets all devices in the organization',
+  unresolved: 'A site-restricted user must target at least one site they can access',
+  out_of_scope: 'Access to one or more target sites denied',
+};
+
+const PERMITTED: MaintenanceSiteScopeCheck = { ok: true, reason: null, outOfScopeSiteIds: [] };
+
+function deny(reason: MaintenanceSiteScopeDenial, outOfScopeSiteIds: string[] = []): MaintenanceSiteScopeCheck {
+  return { ok: false, reason, outOfScopeSiteIds };
+}
+
+function uniqueIds(ids: string[] | null | undefined): string[] {
+  return [...new Set((ids ?? []).filter((id): id is string => typeof id === 'string' && id.length > 0))];
+}
+
+/**
+ * Resolve a window's target set to the concrete sites it can reach.
+ *
+ * `hasSitelessTarget` is true when a referenced group or device carries no
+ * site: such a target spans the whole org, so a site-restricted caller can
+ * never prove containment over it and must be denied (same fail-closed rule as
+ * `aiToolsSiteScope.deviceSiteDenied`).
+ *
+ * Ids that resolve to nothing within `orgId` are ignored rather than denied:
+ * `isDeviceInMaintenance` only ever matches live devices in the window's own
+ * org, so a stale id is genuinely unreachable. It cannot be used to widen
+ * reach either, because the caller must still clear the "at least one resolved
+ * in-scope site" bar below.
+ */
+async function resolveTargetSites(
+  orgId: string,
+  target: MaintenanceWindowTarget,
+): Promise<{ siteIds: string[]; hasSitelessTarget: boolean }> {
+  const siteIds = new Set<string>(uniqueIds(target.siteIds));
+  let hasSitelessTarget = false;
+
+  const groupIds = uniqueIds(target.groupIds);
+  if (groupIds.length > 0) {
+    const rows = await db
+      .select({ siteId: deviceGroups.siteId })
+      .from(deviceGroups)
+      .where(and(eq(deviceGroups.orgId, orgId), inArray(deviceGroups.id, groupIds)));
+    for (const row of rows) {
+      if (typeof row.siteId === 'string') siteIds.add(row.siteId);
+      else hasSitelessTarget = true;
+    }
+  }
+
+  const deviceIds = uniqueIds(target.deviceIds);
+  if (deviceIds.length > 0) {
+    const rows = await db
+      .select({ siteId: devices.siteId })
+      .from(devices)
+      .where(and(eq(devices.orgId, orgId), inArray(devices.id, deviceIds)));
+    for (const row of rows) {
+      if (typeof row.siteId === 'string') siteIds.add(row.siteId);
+      else hasSitelessTarget = true;
+    }
+  }
+
+  return { siteIds: [...siteIds], hasSitelessTarget };
+}
+
+/**
+ * Write gate. A site-restricted caller may only create or mutate a window whose
+ * ENTIRE target set sits inside their site allowlist. Unrestricted callers
+ * (`allowedSiteIds` undefined — every partner- and system-scope caller, plus org
+ * members with no site restriction) pass without a single query.
+ *
+ * Note `allowedSiteIds: []` is "restricted to no sites", not "unrestricted" —
+ * matching `canAccessSite`, which returns false for every site in that state.
+ */
+export async function checkMaintenanceTargetsWithinSiteScope(
+  target: MaintenanceWindowTarget,
+  perms: Pick<UserPermissions, 'allowedSiteIds'> | undefined,
+): Promise<MaintenanceSiteScopeCheck> {
+  if (!perms?.allowedSiteIds) return PERMITTED;
+
+  if (target.orgId === null) return deny('partner_wide');
+  if (target.targetType === 'all') return deny('unbounded');
+
+  const { siteIds, hasSitelessTarget } = await resolveTargetSites(target.orgId, target);
+  if (hasSitelessTarget) return deny('out_of_scope');
+  if (siteIds.length === 0) return deny('unresolved');
+
+  const outOfScopeSiteIds = siteIds.filter(
+    (siteId) => !canAccessSite(perms as UserPermissions, siteId),
+  );
+  return outOfScopeSiteIds.length > 0 ? deny('out_of_scope', outOfScopeSiteIds) : PERMITTED;
+}
+
+/**
+ * Read gate. Narrows a window list to those a site-restricted caller may see:
+ * a window is visible when it can reach at least one of their sites.
+ *
+ * Deliberately INTERSECTION, not the containment the write gate demands. A
+ * window spanning Site A and Site B really does suppress the Site-A tech's own
+ * devices; hiding it would leave them unable to explain why their fleet is in
+ * maintenance. They still cannot mutate it. `targetType: 'all'` windows reach
+ * every site and so stay visible for the same reason.
+ *
+ * Resolution is batched — two queries for the whole list, not two per window.
+ */
+export async function filterWindowsToSiteScope<T extends MaintenanceWindowTarget>(
+  windows: T[],
+  perms: Pick<UserPermissions, 'allowedSiteIds'> | undefined,
+): Promise<T[]> {
+  if (!perms?.allowedSiteIds || windows.length === 0) return windows;
+  const allowed = new Set(perms.allowedSiteIds);
+
+  const groupIds = new Set<string>();
+  const deviceIds = new Set<string>();
+  for (const window of windows) {
+    if (window.targetType === 'all') continue;
+    for (const id of uniqueIds(window.groupIds)) groupIds.add(id);
+    for (const id of uniqueIds(window.deviceIds)) deviceIds.add(id);
+  }
+
+  const groupSite = new Map<string, string | null>();
+  if (groupIds.size > 0) {
+    const rows = await db
+      .select({ id: deviceGroups.id, siteId: deviceGroups.siteId })
+      .from(deviceGroups)
+      .where(inArray(deviceGroups.id, [...groupIds]));
+    for (const row of rows) groupSite.set(row.id, row.siteId);
+  }
+
+  const deviceSite = new Map<string, string | null>();
+  if (deviceIds.size > 0) {
+    const rows = await db
+      .select({ id: devices.id, siteId: devices.siteId })
+      .from(devices)
+      .where(inArray(devices.id, [...deviceIds]));
+    for (const row of rows) deviceSite.set(row.id, row.siteId);
+  }
+
+  const reaches = (siteId: string | null | undefined): boolean =>
+    typeof siteId === 'string' && allowed.has(siteId);
+
+  return windows.filter((window) => {
+    if (window.targetType === 'all') return true;
+    if (uniqueIds(window.siteIds).some(reaches)) return true;
+    if (uniqueIds(window.groupIds).some((id) => reaches(groupSite.get(id)))) return true;
+    if (uniqueIds(window.deviceIds).some((id) => reaches(deviceSite.get(id)))) return true;
+    return false;
+  });
+}
+
+/** Single-row form of {@link filterWindowsToSiteScope}, for detail routes. */
+export async function isWindowVisibleInSiteScope(
+  window: MaintenanceWindowTarget,
+  perms: Pick<UserPermissions, 'allowedSiteIds'> | undefined,
+): Promise<boolean> {
+  const visible = await filterWindowsToSiteScope([window], perms);
+  return visible.length > 0;
+}

--- a/apps/api/src/services/maintenanceSiteScope.ts
+++ b/apps/api/src/services/maintenanceSiteScope.ts
@@ -156,14 +156,23 @@ export async function checkMaintenanceTargetsWithinSiteScope(
 }
 
 /**
- * Read gate. Narrows a window list to those a site-restricted caller may see:
- * a window is visible when it can reach at least one of their sites.
+ * Read gate. Narrows a window list to those a site-restricted caller may see,
+ * AND redacts each surviving window's target arrays down to the entries that
+ * caller can actually see.
  *
- * Deliberately INTERSECTION, not the containment the write gate demands. A
- * window spanning Site A and Site B really does suppress the Site-A tech's own
- * devices; hiding it would leave them unable to explain why their fleet is in
- * maintenance. They still cannot mutate it. `targetType: 'all'` windows reach
- * every site and so stay visible for the same reason.
+ * Visibility is deliberately INTERSECTION, not the containment the write gate
+ * demands. A window spanning Site A and Site B really does suppress the Site-A
+ * tech's own devices; hiding it would leave them unable to explain why their
+ * fleet is in maintenance. They still cannot mutate it. `targetType: 'all'`
+ * windows reach every site and so stay visible for the same reason.
+ *
+ * Redaction closes the other half: visibility alone would hand the Site-A tech
+ * Site B's site/group/device UUIDs, identifiers the site axis exists to keep
+ * from them. `targetType` is left intact, so a window that reaches beyond the
+ * caller still reads as `all`/`site`/`group`/`device` rather than pretending to
+ * be scoped to them — and any attempt to mutate it is refused by the write gate
+ * with "Access to one or more target sites denied", which is where the caller
+ * learns its true reach.
  *
  * Resolution is batched — two queries for the whole list, not two per window.
  */
@@ -203,20 +212,41 @@ export async function filterWindowsToSiteScope<T extends MaintenanceWindowTarget
   const reaches = (siteId: string | null | undefined): boolean =>
     typeof siteId === 'string' && allowed.has(siteId);
 
-  return windows.filter((window) => {
-    if (window.targetType === 'all') return true;
-    if (uniqueIds(window.siteIds).some(reaches)) return true;
-    if (uniqueIds(window.groupIds).some((id) => reaches(groupSite.get(id)))) return true;
-    if (uniqueIds(window.deviceIds).some((id) => reaches(deviceSite.get(id)))) return true;
-    return false;
-  });
+  const scoped: T[] = [];
+  for (const window of windows) {
+    const siteIds = (window.siteIds ?? []).filter(reaches);
+    const groupIds = (window.groupIds ?? []).filter((id) => reaches(groupSite.get(id)));
+    const deviceIds = (window.deviceIds ?? []).filter((id) => reaches(deviceSite.get(id)));
+
+    // `all` reaches every site, so it is visible without matching a target id.
+    const visible =
+      window.targetType === 'all' ||
+      siteIds.length > 0 ||
+      groupIds.length > 0 ||
+      deviceIds.length > 0;
+    if (!visible) continue;
+
+    // Preserve null-vs-empty so a caller cannot tell "window has no site
+    // targets" from "none of its site targets are yours".
+    scoped.push({
+      ...window,
+      siteIds: window.siteIds === null || window.siteIds === undefined ? window.siteIds : siteIds,
+      groupIds: window.groupIds === null || window.groupIds === undefined ? window.groupIds : groupIds,
+      deviceIds: window.deviceIds === null || window.deviceIds === undefined ? window.deviceIds : deviceIds,
+    });
+  }
+  return scoped;
 }
 
-/** Single-row form of {@link filterWindowsToSiteScope}, for detail routes. */
-export async function isWindowVisibleInSiteScope(
-  window: MaintenanceWindowTarget,
+/**
+ * Single-row form of {@link filterWindowsToSiteScope}, for detail routes.
+ * Returns the window with its target arrays redacted to the caller's scope, or
+ * `null` when the window reaches none of their sites.
+ */
+export async function scopeWindowForRead<T extends MaintenanceWindowTarget>(
+  window: T,
   perms: Pick<UserPermissions, 'allowedSiteIds'> | undefined,
-): Promise<boolean> {
-  const visible = await filterWindowsToSiteScope([window], perms);
-  return visible.length > 0;
+): Promise<T | null> {
+  const [scoped] = await filterWindowsToSiteScope([window], perms);
+  return scoped ?? null;
 }


### PR DESCRIPTION
Closes #3654

## The gap

`canAccessWindow` (`routes/maintenance.ts`) gated maintenance windows on the org/partner axis only. Site is an **app-layer** authz axis that Postgres RLS does not defend, so a technician restricted to `allowedSiteIds = [Site-A]` holding the routine `devices:write` permission could reach every window in the org.

The live consequence is not alert suppression (standalone windows never reach `alertService`, as the issue traces) — it is deployment steering. `softwareDeploymentScheduler.isMaintenanceWindowOpen` joins software deployments to windows **by id**:

- `PATCH /maintenance/windows/W {startTime: now}` → an install queued for 400 Site-B workstations at Sunday 02:00 dispatches immediately, during business hours.
- `DELETE /maintenance/windows/W` → the leftJoin nulls, `isDeploymentDue` never fires, and another site's patch rollout is stranded permanently with no alert.

`GET /windows` disclosed every window in the org, which is how the attacker finds `W`.

## The fix

New `apps/api/src/services/maintenanceSiteScope.ts`, mirroring the canonical automation precedent (`automationRuntime.checkAutomationTargetsWithinSiteScope` + `routes/automations.ts:enforceAutomationSiteScope`) rather than inventing a new shape — including its 403 body shape and the verbatim `Access to one or more target sites denied` message.

**Writes require containment.** Rejected for a site-restricted caller: `targetType: 'all'`, partner-wide windows (`org_id NULL` spans every org), and any target that resolves to a site outside the allowlist. `groupIds`/`deviceIds` are resolved to their sites **within the window's own org**; a group or device carrying no `site_id` spans the org and is denied (same fail-closed rule as `aiToolsSiteScope.deviceSiteDenied`). `PATCH` is checked twice — against the window's **current** target set (you must already have authority over it) and against the **resulting** one (you must not widen it onto sites you cannot see). The resulting-set check re-resolves the whole union rather than diffing, so an out-of-scope site cannot be smuggled in through `groupIds` while `targetType`/`siteIds` stay untouched.

Gated: `POST /windows`, `PATCH` / `DELETE` / `cancel` on `/windows/:id`, and `PATCH` / `start` / `end` on `/occurrences/:id`.

**Reads require only intersection.** A window spanning Site-A and Site-B stays *visible* to a Site-A tech — their fleet really is suppressed by it, and hiding that would leave them unable to explain why — but is not *mutable*. `targetType: 'all'` windows stay visible for the same reason. Applied to `GET /windows`, `/windows/:id`, `/windows/:id/occurrences`, `/occurrences` and `/active`. Resolution is batched: two queries for a whole list, not two per row.

**Unrestricted callers are untouched.** Every partner- and system-scope caller, and any org member without a site allowlist, hits an early return and issues zero extra queries. `allowedSiteIds: []` means "restricted to no sites", matching `canAccessSite` — not "unrestricted".

## Second commit: the same gap on the AI tool

A repo-wide sweep of the `maintenance_windows` surface (the "hidden second reader" rule in CLAUDE.md — AI tools are named there as a classic miss) found one more door: `manage_maintenance_windows` in `services/aiToolsFleet.ts` scopes every action with `maintenanceWindowWhere`, which is org/partner only.

- **No second write bypass.** Its `create`/`update`/`delete` blocks are already unreachable — both the action enum and an explicit guard exclude them. A note now sits on that guard so a future re-enable routes through `checkMaintenanceTargetsWithinSiteScope` instead of silently reopening the hole. `deviceArgs: ['deviceIds']` already applies the framework's org+site `verifyDeviceAccess` gate to device ids.
- **The read surface was genuinely exposed.** `list`, `get` and `active_now` disclosed every window in the org to a site-restricted caller — the exact enumeration step the exploit opens with. All three now go through `filterWindowsToSiteScope`. The site-axis columns are selected only to filter on and are stripped before the reply, so the tool's output shape is unchanged.

## Deliberate deviation from the automation precedent

`checkAutomationTargetsWithinSiteScope` passes a target set that resolves to zero devices; this gate **rejects** one that resolves to zero sites. `maintenanceService.isDeviceInMaintenance` ORs `siteIds`, `groupIds` and `deviceIds` independently of `targetType`, so no single array is authoritative — requiring at least one provably in-scope site is the only claim that survives a change to that matcher, which is exactly the "inert today, live tomorrow" risk the issue calls out. Standalone windows are deprecated in favour of configuration policies, so the usability cost is nil. Stale ids that resolve to nothing are ignored rather than denied (they are unreachable by the matcher, which only ever matches live devices in the window's own org), so a decommissioned device does not lock a tech out of their own window — the "at least one resolved in-scope site" bar still catches the degenerate case.

## Why the existing contract test missed it

`site-scope-coverage.integration.test.ts` scans only routes whose **URL pattern names a `:deviceId`**. Maintenance windows are addressed as `/windows/:id`, so the whole file is invisible to it. No allowlist entry was needed or added; the blind spot is worth noting for the next audit.

## Verification

- **28 tests added, written red first.** Route block: against the vulnerable code the 18 negative assertions failed and all 5 positive controls passed. AI-tool block: mutation-checked by reverting `aiToolsFleet.ts` to its pre-fix state — the 3 discriminating tests fail, the 2 positive controls still pass. (One early run failed for the wrong reason — non-GUID fixture ids tripping Zod — and was corrected before the red was trusted.)
- `vitest run src/routes/maintenance.test.ts` — 39 passed, 1 pre-existing skip, single fork.
- `vitest run src/services/aiToolsFleet.siteScope.test.ts src/services/aiToolsFleet.test.ts` — 113 passed.
- Adjacent suites green: `multi-tenant-isolation.test.ts`, `helpers/routeScan.test.ts`, `jobs/softwareDeploymentScheduler.test.ts`, `aiToolsFleetStatus*.test.ts`.
- `tsc --noEmit` clean; `eslint` clean on all five files.

No schema, migration or cascade-list change — this is app-layer authz only.

## Note for reviewers

`allowedSiteIds` is populated only on the **org** axis (`organizationUsers.siteIds`); `partnerUsers` has no such column. The `partner_wide` denial branch is therefore defensive rather than reachable through any current auth path — kept because a partner-wide window spans every org and should never be mutable by a site-restricted caller if that ever changes.

## Follow-up worth filing separately (not fixed here)

The issue also notes `deploymentEngine.filterEligibleDevices` has zero callers repo-wide **and** is inverted (it pushes a device when `inMaintenance` is true). Left alone deliberately to keep this PR to the authorization boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBxF7C8E5GxFnNcGf6kBVP