### PR TITLE
fix(api): stop act-verify reads pinning a pooled connection across device round-trips (#4150)

### DIFF
--- a/apps/api/src/services/aiAgents/actVerify.dbcontext.test.ts
+++ b/apps/api/src/services/aiAgents/actVerify.dbcontext.test.ts
@@ -1,0 +1,164 @@
+/**
+ * actVerify DB-context scoping (#4150, #1105 class).
+ *
+ * The regression this locks down: `verifyServiceRunning` and
+ * `verifyProcessAbsent` wrapped their `executeCommand` call — a device-command
+ * round-trip bounded at VERIFY_READ_TIMEOUT_MS — in `inSystemDbContext`, so a
+ * pooled Postgres connection sat idle-in-transaction for the whole wait.
+ * Exactly the shape #4133/3ec0439d2 removed from the BullMQ workers.
+ *
+ * `actVerify.test.ts` mocks the context helpers as identity passthroughs, so
+ * it can assert *that* a system context was used but never *how long* it was
+ * held. This suite tracks real enter/exit DEPTH and asserts which depth each
+ * dispatch and each DB write ran at.
+ *
+ * `runOutsideDbContext` is deliberately mocked as a depth-PRESERVING
+ * passthrough: that is what it really is (it exits the AsyncLocalStorage but
+ * cannot release an outer `withDbAccessContext` transaction's connection).
+ * Modelling it as a depth reset would make this suite pass against the very
+ * bug it exists for.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { dbMockState, ctxState, commandQueueMock } = vi.hoisted(() => ({
+  dbMockState: {
+    ambientContext: undefined as { scope: string } | undefined,
+    insertedRows: [] as unknown[],
+  },
+  ctxState: { depth: 0, events: [] as string[] },
+  commandQueueMock: {
+    executeCommandWithSystemPrecheck: vi.fn(),
+  },
+}));
+
+vi.mock('../../db', () => ({
+  db: {
+    insert: vi.fn(() => ({
+      values: vi.fn(async (row: unknown) => {
+        ctxState.events.push(`alertInsert@depth${ctxState.depth}`);
+        dbMockState.insertedRows.push(row);
+      }),
+    })),
+  },
+  getCurrentDbAccessContext: vi.fn(() => dbMockState.ambientContext),
+  // Depth-preserving on purpose — see the file header.
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => {
+    const previous = dbMockState.ambientContext;
+    dbMockState.ambientContext = { scope: 'system' };
+    ctxState.depth++;
+    ctxState.events.push('ctx:enter');
+    try {
+      return await fn();
+    } finally {
+      ctxState.depth--;
+      ctxState.events.push('ctx:exit');
+      dbMockState.ambientContext = previous;
+    }
+  }),
+}));
+
+vi.mock('../commandQueue', () => commandQueueMock);
+
+import { ACT_MANIFEST, type ActOperation } from './actManifest';
+import { recordActVerifyFailureAlert, verifyActExecution } from './actVerify';
+import type { ActAssetPin } from './actRevalidation';
+
+const RUN = { id: 'run-1', orgId: 'org-1', agentId: 'agent-1', deviceId: 'device-1' };
+const AGENT_USER_ID = 'agent-1';
+
+const restartOp = ACT_MANIFEST.find((op) => op.key === 'manage_services.restart')!;
+// Mirrors actVerify.test.ts: manage_processes.kill is not in ACT_MANIFEST, but
+// `verifyProcessAbsent` is still live code and carries the same #1105 shape.
+const processAbsentOp: ActOperation = {
+  key: 'manage_processes.kill',
+  toolName: 'manage_processes',
+  matches: () => false,
+  normalizeTarget: () => ({ ok: false, reason: 'unreachable — not in ACT_MANIFEST' }),
+  verifySpec: { kind: 'process_absent' },
+};
+
+function recordingResult(stdout: string) {
+  return vi.fn(async () => {
+    ctxState.events.push(`executeCommand@depth${ctxState.depth}`);
+    return { status: 'completed' as const, stdout };
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dbMockState.ambientContext = undefined;
+  dbMockState.insertedRows = [];
+  ctxState.depth = 0;
+  ctxState.events = [];
+});
+
+describe('verifyActExecution DB-context scoping (#4150/#1105)', () => {
+  it('runs the service_running read-back with NO DB context held', async () => {
+    commandQueueMock.executeCommandWithSystemPrecheck = recordingResult(
+      JSON.stringify({ services: [{ name: 'Spooler', status: 'Running' }] }),
+    );
+
+    const outcome = await verifyActExecution({
+      pin: { op: restartOp, target: { kind: 'service', serviceName: 'Spooler' } } as ActAssetPin,
+      toolOutput: JSON.stringify({ status: 'completed' }),
+      isError: false,
+      run: RUN,
+      agentUserId: AGENT_USER_ID,
+    });
+
+    expect(outcome.verification).toBe('passed');
+    // THE assertion: before the #4150 fix this read `executeCommand@depth1`.
+    expect(ctxState.events).toEqual(['executeCommand@depth0']);
+  });
+
+  it('runs the process_absent read-back with NO DB context held', async () => {
+    commandQueueMock.executeCommandWithSystemPrecheck = recordingResult(
+      JSON.stringify({ processes: [{ pid: 999 }] }),
+    );
+
+    const outcome = await verifyActExecution({
+      pin: { op: processAbsentOp, target: { kind: 'process', processName: 'bad.exe', pid: '4242' } } as ActAssetPin,
+      toolOutput: JSON.stringify({ status: 'completed' }),
+      isError: false,
+      run: RUN,
+      agentUserId: AGENT_USER_ID,
+    });
+
+    expect(outcome.verification).toBe('passed');
+    expect(ctxState.events).toEqual(['executeCommand@depth0']);
+  });
+
+  it('holds no context when the read-back throws', async () => {
+    commandQueueMock.executeCommandWithSystemPrecheck = vi.fn(async () => {
+      ctxState.events.push(`executeCommand@depth${ctxState.depth}`);
+      throw new Error('relay down');
+    });
+
+    const outcome = await verifyActExecution({
+      pin: { op: restartOp, target: { kind: 'service', serviceName: 'Spooler' } } as ActAssetPin,
+      toolOutput: JSON.stringify({ status: 'completed' }),
+      isError: false,
+      run: RUN,
+      agentUserId: AGENT_USER_ID,
+    });
+
+    expect(outcome.verification).toBe('inconclusive');
+    expect(ctxState.events).toEqual(['executeCommand@depth0']);
+  });
+});
+
+describe('recordActVerifyFailureAlert DB-context scoping (#4150/#1105)', () => {
+  it('keeps its short system context around the alert insert', async () => {
+    await recordActVerifyFailureAlert({
+      run: RUN,
+      op: { key: 'manage_services.restart' },
+      target: { kind: 'service', serviceName: 'Spooler' },
+      detail: 'service status is "Stopped"',
+    });
+
+    // A short context around a pure DB write is correct and must stay.
+    expect(ctxState.events).toEqual(['ctx:enter', 'alertInsert@depth1', 'ctx:exit']);
+    expect(dbMockState.insertedRows).toHaveLength(1);
+  });
+});

--- a/apps/api/src/services/aiAgents/actVerify.test.ts
+++ b/apps/api/src/services/aiAgents/actVerify.test.ts
@@ -28,10 +28,14 @@ vi.mock('../../db', () => ({
   }),
 }));
 
-const executeCommand = vi.hoisted(() =>
+// #4150: the verification reads go through the depth-0-safe entry point, which
+// opens the short system context its own precheck needs instead of the caller
+// holding one across the whole device round-trip. `actVerify.dbcontext.test.ts`
+// asserts the depth; this suite asserts the read semantics.
+const executeCommandWithSystemPrecheck = vi.hoisted(() =>
   vi.fn<(deviceId: string, type: string, payload: Record<string, unknown>, options: Record<string, unknown>) =>
     Promise<{ status: string; stdout?: string; error?: string }>>());
-vi.mock('../commandQueue', () => ({ executeCommand }));
+vi.mock('../commandQueue', () => ({ executeCommandWithSystemPrecheck }));
 
 import { ACT_MANIFEST } from './actManifest';
 import type { ActOperation } from './actManifest';
@@ -79,7 +83,7 @@ describe('verifyActExecution — manage_services.restart (service_running)', () 
   const target = { kind: 'service' as const, serviceName: 'Spooler' };
 
   it('completed + running read-back → succeeded/passed', async () => {
-    executeCommand.mockResolvedValue({
+    executeCommandWithSystemPrecheck.mockResolvedValue({
       status: 'completed',
       stdout: JSON.stringify({ services: [{ name: 'Spooler', status: 'Running' }] }),
     });
@@ -88,13 +92,13 @@ describe('verifyActExecution — manage_services.restart (service_running)', () 
       isError: false, run: RUN, agentUserId: AGENT_USER_ID,
     });
     expect(result).toEqual({ execution: 'succeeded', verification: 'passed' });
-    expect(executeCommand).toHaveBeenCalledWith('device-1', 'list_services', { search: 'Spooler' }, {
+    expect(executeCommandWithSystemPrecheck).toHaveBeenCalledWith('device-1', 'list_services', { search: 'Spooler' }, {
       userId: AGENT_USER_ID, timeoutMs: 8_000,
     });
   });
 
   it('service found but not running → failed with detail', async () => {
-    executeCommand.mockResolvedValue({
+    executeCommandWithSystemPrecheck.mockResolvedValue({
       status: 'completed',
       stdout: JSON.stringify({ services: [{ name: 'Spooler', status: 'Stopped' }] }),
     });
@@ -106,7 +110,7 @@ describe('verifyActExecution — manage_services.restart (service_running)', () 
   });
 
   it('service missing from the read-back entirely → failed', async () => {
-    executeCommand.mockResolvedValue({ status: 'completed', stdout: JSON.stringify({ services: [] }) });
+    executeCommandWithSystemPrecheck.mockResolvedValue({ status: 'completed', stdout: JSON.stringify({ services: [] }) });
     const result = await verifyActExecution({
       pin: pin(restartOp, target), toolOutput: JSON.stringify({ status: 'completed', exitCode: 0 }),
       isError: false, run: RUN, agentUserId: AGENT_USER_ID,
@@ -115,7 +119,7 @@ describe('verifyActExecution — manage_services.restart (service_running)', () 
   });
 
   it('the read-back itself times out → inconclusive, not failed', async () => {
-    executeCommand.mockResolvedValue({ status: 'timeout', error: 'Command timed out after 30000ms' });
+    executeCommandWithSystemPrecheck.mockResolvedValue({ status: 'timeout', error: 'Command timed out after 30000ms' });
     const result = await verifyActExecution({
       pin: pin(restartOp, target), toolOutput: JSON.stringify({ status: 'completed', exitCode: 0 }),
       isError: false, run: RUN, agentUserId: AGENT_USER_ID,
@@ -124,7 +128,7 @@ describe('verifyActExecution — manage_services.restart (service_running)', () 
   });
 
   it('the restart command itself timed out → execution: timeout', async () => {
-    executeCommand.mockResolvedValue({ status: 'completed', stdout: JSON.stringify({ services: [] }) });
+    executeCommandWithSystemPrecheck.mockResolvedValue({ status: 'completed', stdout: JSON.stringify({ services: [] }) });
     const result = await verifyActExecution({
       pin: pin(restartOp, target),
       toolOutput: JSON.stringify({ status: 'timeout', error: 'Command timed out after 30000ms' }),
@@ -134,7 +138,7 @@ describe('verifyActExecution — manage_services.restart (service_running)', () 
   });
 
   it('an unparseable execution output falls back to the SDK isError flag, not unknown', async () => {
-    executeCommand.mockResolvedValue({ status: 'completed', stdout: JSON.stringify({ services: [] }) });
+    executeCommandWithSystemPrecheck.mockResolvedValue({ status: 'completed', stdout: JSON.stringify({ services: [] }) });
     const okResult = await verifyActExecution({
       pin: pin(restartOp, target), toolOutput: 'not json', isError: false, run: RUN, agentUserId: AGENT_USER_ID,
     });
@@ -146,7 +150,7 @@ describe('verifyActExecution — manage_services.restart (service_running)', () 
   });
 
   it('a thrown verification read degrades to inconclusive, never throws', async () => {
-    executeCommand.mockRejectedValue(new Error('WS connection lost'));
+    executeCommandWithSystemPrecheck.mockRejectedValue(new Error('WS connection lost'));
     const result = await verifyActExecution({
       pin: pin(restartOp, target), toolOutput: JSON.stringify({ status: 'completed', exitCode: 0 }),
       isError: false, run: RUN, agentUserId: AGENT_USER_ID,
@@ -159,7 +163,7 @@ describe('verifyActExecution — process_absent (manage_processes.kill is deferr
   const target = { kind: 'process' as const, pid: '4242', processName: 'notepad.exe' };
 
   it('pid still present in the read-back → failed', async () => {
-    executeCommand.mockResolvedValue({
+    executeCommandWithSystemPrecheck.mockResolvedValue({
       status: 'completed',
       stdout: JSON.stringify({ processes: [{ pid: 4242, name: 'notepad.exe' }] }),
     });
@@ -168,13 +172,13 @@ describe('verifyActExecution — process_absent (manage_processes.kill is deferr
       isError: false, run: RUN, agentUserId: AGENT_USER_ID,
     });
     expect(result).toEqual({ execution: 'succeeded', verification: 'failed', verifyDetail: 'process with the pinned pid is still present' });
-    expect(executeCommand).toHaveBeenCalledWith('device-1', 'list_processes', { search: 'notepad.exe', limit: 200 }, {
+    expect(executeCommandWithSystemPrecheck).toHaveBeenCalledWith('device-1', 'list_processes', { search: 'notepad.exe', limit: 200 }, {
       userId: AGENT_USER_ID, timeoutMs: 8_000,
     });
   });
 
   it('pid absent from the read-back → passed', async () => {
-    executeCommand.mockResolvedValue({ status: 'completed', stdout: JSON.stringify({ processes: [] }) });
+    executeCommandWithSystemPrecheck.mockResolvedValue({ status: 'completed', stdout: JSON.stringify({ processes: [] }) });
     const result = await verifyActExecution({
       pin: pin(processAbsentOp, target), toolOutput: JSON.stringify({ status: 'completed', exitCode: 0 }),
       isError: false, run: RUN, agentUserId: AGENT_USER_ID,
@@ -186,7 +190,7 @@ describe('verifyActExecution — process_absent (manage_processes.kill is deferr
   // proven" — that is absence of evidence, not evidence of absence, and the
   // sibling verifyServiceRunning already treats it conservatively.
   it('read-back stdout is not JSON at all → inconclusive, not passed', async () => {
-    executeCommand.mockResolvedValue({ status: 'completed', stdout: 'not json' });
+    executeCommandWithSystemPrecheck.mockResolvedValue({ status: 'completed', stdout: 'not json' });
     const result = await verifyActExecution({
       pin: pin(processAbsentOp, target), toolOutput: JSON.stringify({ status: 'completed', exitCode: 0 }),
       isError: false, run: RUN, agentUserId: AGENT_USER_ID,
@@ -199,7 +203,7 @@ describe('verifyActExecution — process_absent (manage_processes.kill is deferr
   });
 
   it('read-back stdout parses but carries no `processes` array → inconclusive, not passed', async () => {
-    executeCommand.mockResolvedValue({ status: 'completed', stdout: '{}' });
+    executeCommandWithSystemPrecheck.mockResolvedValue({ status: 'completed', stdout: '{}' });
     const result = await verifyActExecution({
       pin: pin(processAbsentOp, target), toolOutput: JSON.stringify({ status: 'completed', exitCode: 0 }),
       isError: false, run: RUN, agentUserId: AGENT_USER_ID,
@@ -223,7 +227,7 @@ describe('verifyActExecution — disk_cleanup.execute (disk_usage_improved)', ()
     });
     expect(result).toEqual({ execution: 'succeeded', verification: 'passed' });
     // Purely output-derived — no extra read for this op family.
-    expect(executeCommand).not.toHaveBeenCalled();
+    expect(executeCommandWithSystemPrecheck).not.toHaveBeenCalled();
   });
 
   it('failed status → failed/failed', async () => {

--- a/apps/api/src/services/aiAgents/actVerify.ts
+++ b/apps/api/src/services/aiAgents/actVerify.ts
@@ -31,6 +31,13 @@ import { alerts } from '../../db/schema/alerts';
 import type { ActAssetPin } from './actRevalidation';
 import type { ActTarget } from './actManifest';
 
+/**
+ * Short system context for this module's own DB writes. Deliberately NOT used
+ * around the verification reads: those await a device-command round-trip, and
+ * holding a context across one pins a pooled connection idle-in-transaction
+ * (#1105/#4150). `commandQueue.executeCommandWithSystemPrecheck` owns the
+ * context those reads actually need.
+ */
 function inSystemDbContext<T>(fn: () => Promise<T>): Promise<T> {
   if (getCurrentDbAccessContext()?.scope === 'system') return fn();
   return runOutsideDbContext(() => withSystemDbAccessContext(fn));
@@ -110,11 +117,16 @@ async function verifyServiceRunning(
   run: VerifyActExecutionArgs['run'],
   agentUserId: string,
 ): Promise<{ verification: ActVerificationVerdict; detail?: string }> {
-  const { executeCommand } = await getCommandQueue();
-  const result = await inSystemDbContext(() =>
-    executeCommand(run.deviceId, 'list_services', { search: target.serviceName }, {
+  const { executeCommandWithSystemPrecheck } = await getCommandQueue();
+  // NO DB context held across this call (#4150): it is a device round-trip
+  // bounded at VERIFY_READ_TIMEOUT_MS, and `executeCommandWithSystemPrecheck`
+  // opens the system context its own RLS-gated precheck needs and closes it
+  // before the wait. Wrapping this in `inSystemDbContext` — as it used to be —
+  // pinned a pooled connection idle-in-transaction for the whole read (#1105).
+  const result = await executeCommandWithSystemPrecheck(
+    run.deviceId, 'list_services', { search: target.serviceName }, {
       userId: agentUserId, timeoutMs: VERIFY_READ_TIMEOUT_MS,
-    }));
+    });
 
   if (result.status !== 'completed') {
     return { verification: 'inconclusive', detail: `service status read did not complete (${result.status})` };
@@ -137,11 +149,12 @@ async function verifyProcessAbsent(
   run: VerifyActExecutionArgs['run'],
   agentUserId: string,
 ): Promise<{ verification: ActVerificationVerdict; detail?: string }> {
-  const { executeCommand } = await getCommandQueue();
-  const result = await inSystemDbContext(() =>
-    executeCommand(run.deviceId, 'list_processes', { search: target.processName, limit: 200 }, {
+  const { executeCommandWithSystemPrecheck } = await getCommandQueue();
+  // No DB context held across the round-trip — see `verifyServiceRunning`.
+  const result = await executeCommandWithSystemPrecheck(
+    run.deviceId, 'list_processes', { search: target.processName, limit: 200 }, {
       userId: agentUserId, timeoutMs: VERIFY_READ_TIMEOUT_MS,
-    }));
+    });
 
   if (result.status !== 'completed') {
     return { verification: 'inconclusive', detail: `process list read did not complete (${result.status})` };

--- a/apps/api/src/services/aiAgents/playbookActExecutor.dbcontext.test.ts
+++ b/apps/api/src/services/aiAgents/playbookActExecutor.dbcontext.test.ts
@@ -1,0 +1,176 @@
+/**
+ * playbookActExecutor DB-context scoping (#4150, #1105 class).
+ *
+ * The regression this locks down: `readServiceStatus` wrapped its
+ * `executeCommandFn` call — a device-command round-trip bounded at
+ * SERVICE_STATUS_READ_TIMEOUT_MS (30s) — in `inSystemDbContext`, so a pooled
+ * Postgres connection sat idle-in-transaction for the whole wait. Exactly the
+ * shape #4133/3ec0439d2 removed from monitorWorker/discoveryWorker/backupWorker.
+ *
+ * An identity `fn => fn()` mock of the context helpers can never catch that,
+ * so the mock below tracks real enter/exit DEPTH and the tests assert WHICH
+ * depth each DB read and the command dispatch happened at — mirroring
+ * `jobs/monitorWorker.dbcontext.test.ts`'s ctxState.events harness.
+ *
+ * Critically, `runOutsideDbContext` is mocked as a depth-PRESERVING
+ * passthrough, because that is what it really is: it exits the
+ * AsyncLocalStorage so `db` resolves to the bare pool, but it cannot release
+ * an outer `withDbAccessContext` transaction's connection. Modelling it as a
+ * depth reset would make this suite pass against the very bug it exists for.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AiAgentKind } from '@breeze/shared';
+import type { PlaybookStep } from '../../db/schema/playbooks';
+import type { AuthContext } from '../../middleware/auth';
+
+const { dbMockState, ctxState } = vi.hoisted(() => ({
+  dbMockState: {
+    diskRows: [] as unknown[],
+    ambientContext: undefined as { scope: string } | undefined,
+  },
+  ctxState: { depth: 0, events: [] as string[] },
+}));
+
+vi.mock('../../db', () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn((table: unknown) => {
+        const tableName = String((table as Record<symbol, unknown>)[Symbol.for('drizzle:Name')]);
+        const builder: Record<string, unknown> = {
+          where: vi.fn(() => builder),
+          orderBy: vi.fn(() => builder),
+          limit: vi.fn(async () => {
+            ctxState.events.push(`select:${tableName}@depth${ctxState.depth}`);
+            if (tableName === 'device_disks') return dbMockState.diskRows;
+            throw new Error(`Unexpected table: ${tableName}`);
+          }),
+        };
+        return builder;
+      }),
+    })),
+    insert: vi.fn(),
+    update: vi.fn(),
+  },
+  getCurrentDbAccessContext: vi.fn(() => dbMockState.ambientContext),
+  // Depth-preserving on purpose — see the file header.
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => {
+    const previous = dbMockState.ambientContext;
+    dbMockState.ambientContext = { scope: 'system' };
+    ctxState.depth++;
+    ctxState.events.push('ctx:enter');
+    try {
+      return await fn();
+    } finally {
+      ctxState.depth--;
+      ctxState.events.push('ctx:exit');
+      dbMockState.ambientContext = previous;
+    }
+  }),
+  withDbAccessContext: vi.fn(async (ctx: unknown, fn: () => Promise<unknown>) => {
+    const previous = dbMockState.ambientContext;
+    dbMockState.ambientContext = ctx as { scope: string };
+    ctxState.depth++;
+    ctxState.events.push('ctx:enter');
+    try {
+      return await fn();
+    } finally {
+      ctxState.depth--;
+      ctxState.events.push('ctx:exit');
+      dbMockState.ambientContext = previous;
+    }
+  }),
+}));
+
+import { runPlaybookSteps, type PlaybookExecutorDeps } from './playbookActExecutor';
+
+const RUN = {
+  id: 'run-1',
+  orgId: 'org-1',
+  agentId: 'agent-1',
+  agentKind: 'triage' as AiAgentKind,
+  deviceId: 'device-1',
+  deviceSiteId: 'site-1',
+};
+const AGENT_AUTH = { user: { id: 'agent-1' } } as unknown as AuthContext;
+const FAR_FUTURE_DEADLINE = Date.now() + 60_000;
+
+function makeDeps(overrides: Partial<PlaybookExecutorDeps> = {}): PlaybookExecutorDeps {
+  return {
+    revalidate: vi.fn(),
+    executeToolFn: vi.fn(async () => JSON.stringify({ status: 'completed' })),
+    executeCommandFn: vi.fn(async () => {
+      ctxState.events.push(`executeCommand@depth${ctxState.depth}`);
+      return { status: 'completed' as const, stdout: JSON.stringify({ services: [{ name: 'Spooler', status: 'Running' }] }) };
+    }),
+    sleepFn: vi.fn(async () => undefined),
+    ...overrides,
+  } as PlaybookExecutorDeps;
+}
+
+function serviceVerifyStep(): PlaybookStep {
+  return {
+    type: 'verify', name: 'check running', description: '', tool: 'manage_services',
+    toolInput: { deviceId: 'device-1', action: 'list', serviceName: 'Spooler' },
+    verifyCondition: { metric: 'service_status', operator: 'eq', value: 'running' },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dbMockState.diskRows = [];
+  dbMockState.ambientContext = undefined;
+  ctxState.depth = 0;
+  ctxState.events = [];
+});
+
+describe('readServiceStatus DB-context scoping (#4150/#1105)', () => {
+  it('runs the up-to-30s device-command read-back with NO DB context held', async () => {
+    const deps = makeDeps();
+
+    const outcome = await runPlaybookSteps([serviceVerifyStep()], {
+      run: RUN, agentAuth: AGENT_AUTH, deps, reserved: { count: 0 }, deadlineMs: FAR_FUTURE_DEADLINE,
+    });
+
+    expect(outcome.verification).toBe('passed');
+    // THE assertion: the command round-trip must happen at depth 0. Before the
+    // #4150 fix this read `executeCommand@depth1`, i.e. a pooled connection
+    // pinned idle-in-transaction for the whole wait.
+    expect(ctxState.events).toEqual(['executeCommand@depth0']);
+  });
+
+  it('still holds NO context when the read-back does not complete', async () => {
+    const deps = makeDeps({
+      executeCommandFn: vi.fn(async () => {
+        ctxState.events.push(`executeCommand@depth${ctxState.depth}`);
+        return { status: 'timeout' as const, error: 'timed out' };
+      }),
+    });
+
+    const outcome = await runPlaybookSteps([serviceVerifyStep()], {
+      run: RUN, agentAuth: AGENT_AUTH, deps, reserved: { count: 0 }, deadlineMs: FAR_FUTURE_DEADLINE,
+    });
+
+    expect(outcome.verification).toBe('inconclusive');
+    expect(ctxState.events).toEqual(['executeCommand@depth0']);
+  });
+
+  it('leaves the pure-DB disk read in its own short context (unchanged by #4150)', async () => {
+    dbMockState.diskRows = [{ usedPercent: 42 }];
+    const deps = makeDeps();
+    const step: PlaybookStep = {
+      type: 'verify', name: 'disk', description: '', tool: 'disk_cleanup',
+      toolInput: { deviceId: 'device-1' },
+      verifyCondition: { metric: 'disk_usage_percent', operator: 'lt', value: 90 },
+    };
+
+    const outcome = await runPlaybookSteps([step], {
+      run: RUN, agentAuth: AGENT_AUTH, deps, reserved: { count: 0 }, deadlineMs: FAR_FUTURE_DEADLINE,
+    });
+
+    expect(outcome.verification).toBe('passed');
+    // A short context around a pure DB read is correct and must stay.
+    expect(ctxState.events).toEqual(['ctx:enter', 'select:device_disks@depth1', 'ctx:exit']);
+    expect(deps.executeCommandFn).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/aiAgents/playbookActExecutor.ts
+++ b/apps/api/src/services/aiAgents/playbookActExecutor.ts
@@ -119,14 +119,14 @@ export interface PlaybookExecutorDeps {
    *  through `commandQueue.executeCommand`); this dep lets the playbook
    *  executor's read-back use the exact same call shape so the two act
    *  paths cannot drift on the same postcondition again. */
-  executeCommandFn: typeof import('../commandQueue').executeCommand;
+  executeCommandFn: typeof import('../commandQueue').executeCommandWithSystemPrecheck;
   sleepFn: (ms: number) => Promise<void>;
 }
 
 const REAL_DEPS: PlaybookExecutorDeps = {
   revalidate: revalidateActExecution,
   executeToolFn: executeTool,
-  executeCommandFn: async (...args) => (await getCommandQueue()).executeCommand(...args),
+  executeCommandFn: async (...args) => (await getCommandQueue()).executeCommandWithSystemPrecheck(...args),
   sleepFn: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
 };
 
@@ -439,10 +439,16 @@ async function readServiceStatus(
   // Bypasses the `manage_services` TOOL deliberately — see the
   // `executeCommandFn` doc comment on `PlaybookExecutorDeps` for why going
   // through the tool cannot find the service on a real device.
-  const result = await inSystemDbContext(() =>
-    deps.executeCommandFn(run.deviceId, 'list_services', { search: serviceName }, {
+  // NO DB context held across this call (#4150): it is a device round-trip
+  // bounded at SERVICE_STATUS_READ_TIMEOUT_MS (30s), and
+  // `executeCommandWithSystemPrecheck` opens the system context its own
+  // RLS-gated precheck needs and closes it before the wait. Wrapping this in
+  // `inSystemDbContext` — as it used to be — pinned a pooled connection
+  // idle-in-transaction for the whole read (#1105).
+  const result = await deps.executeCommandFn(
+    run.deviceId, 'list_services', { search: serviceName }, {
       userId: agentAuth.user.id, timeoutMs: SERVICE_STATUS_READ_TIMEOUT_MS,
-    }));
+    });
   if (result.status !== 'completed') {
     return { ok: false, detail: `service status read did not complete (${result.status})` };
   }

--- a/apps/api/src/services/aiAgents/playbookActExecutor.ts
+++ b/apps/api/src/services/aiAgents/playbookActExecutor.ts
@@ -107,8 +107,9 @@ async function getCommandQueue() {
 export interface PlaybookExecutorDeps {
   revalidate: typeof revalidateActExecution;
   executeToolFn: typeof executeTool;
-  /** Direct `commandQueue.executeCommand` access for the `service_status`
-   *  verify metric read — review fix (#3826 Task 5 follow-up): the
+  /** Direct `commandQueue.executeCommandWithSystemPrecheck` access for the
+   *  `service_status` verify metric read — review fix (#3826 Task 5
+   *  follow-up): the
    *  `manage_services` TOOL only forwards `{ name: serviceName }` to the
    *  agent (aiToolsScripts.ts), but the agent's `ListServices` command reads
    *  `search`/`status`/`page`/`limit`, not `name` (agent/internal/remote/
@@ -116,9 +117,14 @@ export interface PlaybookExecutorDeps {
    *  50-row-paginated list on every real device, and the target service is
    *  usually not on page one. actVerify.ts's `verifyServiceRunning` already
    *  does this read correctly (`{ search: target.serviceName }` straight
-   *  through `commandQueue.executeCommand`); this dep lets the playbook
+   *  through the same commandQueue entry point); this dep lets the playbook
    *  executor's read-back use the exact same call shape so the two act
-   *  paths cannot drift on the same postcondition again. */
+   *  paths cannot drift on the same postcondition again.
+   *
+   *  The `WithSystemPrecheck` variant is load-bearing, not incidental: this
+   *  read is awaited for up to SERVICE_STATUS_READ_TIMEOUT_MS, so the DB
+   *  context its RLS-gated precheck needs has to close before the wait
+   *  (#4150/#1105). */
   executeCommandFn: typeof import('../commandQueue').executeCommandWithSystemPrecheck;
   sleepFn: (ms: number) => Promise<void>;
 }

--- a/apps/api/src/services/commandQueue.dbcontext.test.ts
+++ b/apps/api/src/services/commandQueue.dbcontext.test.ts
@@ -1,0 +1,238 @@
+/**
+ * commandQueue DB-context scoping for the background dispatch entry point
+ * (#4150, #1105 class).
+ *
+ * `executeCommand` needs an RLS context for its PRECHECK (the `devices` SELECT
+ * and `assertDeviceExecuteAllowed`) and then runs the queue/dispatch/poll
+ * phase inside `runOutsideDbContext`. That inner escape exits the
+ * AsyncLocalStorage so `db` resolves to the bare pool — but it CANNOT release
+ * an outer `withDbAccessContext` transaction's pooled connection. A background
+ * caller that opened a system context just to satisfy the precheck therefore
+ * pinned a connection idle-in-transaction for the whole `waitForCommandResult`
+ * poll (up to 30s). That is what #4150 fixes.
+ *
+ * `executeCommandWithSystemPrecheck` is the depth-0-safe entry point: it opens
+ * a SHORT system context for the precheck, closes it, and only then queues,
+ * dispatches and waits.
+ *
+ * The `runOutsideDbContext` mock below is a depth-PRESERVING passthrough on
+ * purpose — modelling it as a depth reset would make this suite pass against
+ * the very bug it exists for.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { ctxState, dbState, partnerTrustMocks, agentWsMocks, commandDispatchMocks } = vi.hoisted(() => ({
+  ctxState: { depth: 0, events: [] as string[], ambient: undefined as { scope: string } | undefined },
+  dbState: {
+    deviceRows: [] as unknown[],
+    commandRows: [] as unknown[],
+    insertedCommand: null as Record<string, unknown> | null,
+  },
+  partnerTrustMocks: { assertDeviceExecuteAllowed: vi.fn(async () => undefined) },
+  agentWsMocks: { sendCommandToAgent: vi.fn(), isAgentConnected: vi.fn(() => true) },
+  commandDispatchMocks: {
+    claimPendingCommandForDelivery: vi.fn(),
+    releaseClaimedCommandDelivery: vi.fn(async () => undefined),
+  },
+}));
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn((table: unknown) => {
+        const name = String((table as Record<symbol, unknown>)[Symbol.for('drizzle:Name')] ?? table);
+        const builder: Record<string, unknown> = {
+          where: vi.fn(() => builder),
+          orderBy: vi.fn(() => builder),
+          limit: vi.fn(async () => {
+            ctxState.events.push(`select:${name}@depth${ctxState.depth}`);
+            if (name === 'devices') return dbState.deviceRows;
+            if (name === 'device_commands') return dbState.commandRows;
+            return [];
+          }),
+        };
+        return builder;
+      }),
+    })),
+    insert: vi.fn(() => ({
+      values: vi.fn((row: Record<string, unknown>) => ({
+        returning: vi.fn(async () => {
+          ctxState.events.push(`insert:device_commands@depth${ctxState.depth}`);
+          dbState.insertedCommand = { ...row, id: 'cmd-1' };
+          return [dbState.insertedCommand];
+        }),
+        execute: vi.fn(async () => undefined),
+      })),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({ returning: vi.fn(async () => []) })),
+      })),
+    })),
+  },
+  getCurrentDbAccessContext: vi.fn(() => ctxState.ambient),
+  // Depth-preserving on purpose — see the file header.
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withDbAccessContext: vi.fn(async (ctx: unknown, fn: () => Promise<unknown>) => {
+    const previous = ctxState.ambient;
+    ctxState.ambient = ctx as { scope: string };
+    ctxState.depth++;
+    ctxState.events.push('ctx:enter');
+    try {
+      return await fn();
+    } finally {
+      ctxState.depth--;
+      ctxState.events.push('ctx:exit');
+      ctxState.ambient = previous;
+    }
+  }),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => {
+    const previous = ctxState.ambient;
+    ctxState.ambient = { scope: 'system' };
+    ctxState.depth++;
+    ctxState.events.push('ctx:enter');
+    try {
+      return await fn();
+    } finally {
+      ctxState.depth--;
+      ctxState.events.push('ctx:exit');
+      ctxState.ambient = previous;
+    }
+  }),
+}));
+
+vi.mock('../routes/agentWs', () => ({
+  sendCommandToAgent: (...args: unknown[]) => {
+    ctxState.events.push(`wsSend@depth${ctxState.depth}`);
+    return agentWsMocks.sendCommandToAgent(...args);
+  },
+  isAgentConnected: (...args: unknown[]) => agentWsMocks.isAgentConnected(...(args as [])),
+}));
+
+vi.mock('./commandDispatch', () => ({
+  claimPendingCommandForDelivery: (...args: unknown[]) => {
+    ctxState.events.push(`claim@depth${ctxState.depth}`);
+    return commandDispatchMocks.claimPendingCommandForDelivery(...args);
+  },
+  releaseClaimedCommandDelivery: (...args: unknown[]) =>
+    commandDispatchMocks.releaseClaimedCommandDelivery(...(args as [])),
+}));
+
+vi.mock('./partnerTrust.commands', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./partnerTrust.commands')>();
+  return {
+    ...actual,
+    assertDeviceExecuteAllowed: async (...args: unknown[]) => {
+      ctxState.events.push(`trustCheck@depth${ctxState.depth}`);
+      return partnerTrustMocks.assertDeviceExecuteAllowed(...(args as []));
+    },
+  };
+});
+
+vi.mock('./sentry', () => ({ captureException: vi.fn() }));
+vi.mock('./backupMetrics', () => ({
+  recordBackupCommandTimeout: vi.fn(),
+  recordRestoreTimeout: vi.fn(),
+}));
+
+import { executeCommand, executeCommandWithSystemPrecheck } from './commandQueue';
+
+const ONLINE_DEVICE = {
+  id: 'device-1',
+  status: 'online',
+  agentId: 'agent-1',
+  orgId: 'org-1',
+  hostname: 'host-1',
+  watchdogLastSeen: null,
+  agentEdition: null,
+  agentVersion: null,
+  watchdogVersion: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  ctxState.depth = 0;
+  ctxState.events = [];
+  ctxState.ambient = undefined;
+  dbState.deviceRows = [ONLINE_DEVICE];
+  dbState.insertedCommand = null;
+  // First poll of waitForCommandResult sees a terminal row, so the test never
+  // sleeps and the event log stays deterministic.
+  dbState.commandRows = [{ id: 'cmd-1', status: 'completed', type: 'list_services', result: { status: 'completed', stdout: '{}' } }];
+  agentWsMocks.sendCommandToAgent.mockReturnValue(true);
+  agentWsMocks.isAgentConnected.mockReturnValue(true);
+  commandDispatchMocks.claimPendingCommandForDelivery.mockResolvedValue({ executedAt: new Date() });
+});
+
+describe('executeCommandWithSystemPrecheck (#4150/#1105)', () => {
+  it('closes the precheck context BEFORE dispatching and waiting', async () => {
+    const result = await executeCommandWithSystemPrecheck('device-1', 'list_services', { search: 'Spooler' }, {
+      timeoutMs: 5_000,
+    });
+
+    expect(result.status).toBe('completed');
+    expect(ctxState.events).toEqual([
+      // Phase 1 — precheck in its OWN short system context.
+      'ctx:enter',
+      'select:devices@depth1',
+      'trustCheck@depth1',
+      'ctx:exit',
+      // Phase 2 — the insert takes its own short context (device_commands is
+      // system-scoped, #1375); everything that waits on the device runs at
+      // depth 0 with no connection held.
+      'ctx:enter',
+      'insert:device_commands@depth1',
+      'ctx:exit',
+      'claim@depth0',
+      'wsSend@depth0',
+      'select:device_commands@depth0',
+    ]);
+    // Nothing may still be open once the call returns.
+    expect(ctxState.depth).toBe(0);
+  });
+
+  it('opens no context at all past the precheck when the device is missing', async () => {
+    dbState.deviceRows = [];
+
+    const result = await executeCommandWithSystemPrecheck('device-1', 'list_services', {}, { timeoutMs: 5_000 });
+
+    expect(result).toEqual({ status: 'failed', error: 'Device not found' });
+    expect(ctxState.events).toEqual(['ctx:enter', 'select:devices@depth1', 'ctx:exit']);
+    expect(agentWsMocks.sendCommandToAgent).not.toHaveBeenCalled();
+  });
+
+  it('opens no context past the precheck when the device is offline', async () => {
+    dbState.deviceRows = [{ ...ONLINE_DEVICE, status: 'offline' }];
+
+    const result = await executeCommandWithSystemPrecheck('device-1', 'list_services', {}, { timeoutMs: 5_000 });
+
+    expect(result).toEqual({ status: 'failed', error: 'Device is offline, cannot execute command' });
+    expect(ctxState.events).toEqual([
+      'ctx:enter',
+      'select:devices@depth1',
+      'trustCheck@depth1',
+      'ctx:exit',
+    ]);
+  });
+});
+
+describe('executeCommand (unchanged by #4150)', () => {
+  it('still runs its precheck in the CALLER’s context and opens none of its own', async () => {
+    const result = await executeCommand('device-1', 'list_services', {}, { timeoutMs: 5_000 });
+
+    expect(result.status).toBe('completed');
+    // No leading ctx:enter/ctx:exit pair: the precheck reads at the caller's
+    // depth exactly as before. Callers inside a request transaction keep
+    // today's RLS-gated behaviour.
+    expect(ctxState.events).toEqual([
+      'select:devices@depth0',
+      'trustCheck@depth0',
+      'ctx:enter',
+      'insert:device_commands@depth1',
+      'ctx:exit',
+      'claim@depth0',
+      'wsSend@depth0',
+      'select:device_commands@depth0',
+    ]);
+  });
+});

--- a/apps/api/src/services/commandQueue.dbcontext.test.ts
+++ b/apps/api/src/services/commandQueue.dbcontext.test.ts
@@ -136,6 +136,7 @@ vi.mock('./backupMetrics', () => ({
 }));
 
 import { executeCommand, executeCommandWithSystemPrecheck } from './commandQueue';
+import { TrustDeniedError } from './partnerTrust.commands';
 
 const ONLINE_DEVICE = {
   id: 'device-1',
@@ -198,6 +199,57 @@ describe('executeCommandWithSystemPrecheck (#4150/#1105)', () => {
 
     expect(result).toEqual({ status: 'failed', error: 'Device not found' });
     expect(ctxState.events).toEqual(['ctx:enter', 'select:devices@depth1', 'ctx:exit']);
+    expect(agentWsMocks.sendCommandToAgent).not.toHaveBeenCalled();
+  });
+
+  it('joins an ambient system context instead of opening a SECOND one', async () => {
+    // A nested withSystemDbAccessContext would check out a second pooled
+    // connection while the caller's is still held — strictly worse than the
+    // bug being fixed. The precheck must run in the context that is already
+    // open, adding no ctx:enter of its own.
+    ctxState.ambient = { scope: 'system' };
+    ctxState.depth = 1;
+
+    const result = await executeCommandWithSystemPrecheck('device-1', 'list_services', {}, { timeoutMs: 5_000 });
+
+    expect(result.status).toBe('completed');
+    // No leading ctx:enter — the precheck read is the very first event.
+    expect(ctxState.events[0]).toBe('select:devices@depth1');
+    // Exactly one ctx:enter in the whole call, and it belongs to the dispatch
+    // phase's insert, not to the precheck.
+    expect(ctxState.events.filter((e) => e === 'ctx:enter')).toHaveLength(1);
+    expect(ctxState.events).toContain('insert:device_commands@depth2');
+  });
+
+  it('surfaces a trust denial as a terminal result and dispatches nothing', async () => {
+    partnerTrustMocks.assertDeviceExecuteAllowed.mockRejectedValueOnce(
+      new TrustDeniedError('TRUST_PROBATION', 'probation_default_deny', 'device-1', 'list_services'),
+    );
+
+    const result = await executeCommandWithSystemPrecheck('device-1', 'list_services', {}, { timeoutMs: 5_000 });
+
+    expect(result).toEqual({
+      status: 'failed',
+      error: 'TRUST_PROBATION',
+      trust: { capability: 'device_execute', reason: 'probation_default_deny' },
+    });
+    expect(ctxState.events).toEqual([
+      'ctx:enter',
+      'select:devices@depth1',
+      'trustCheck@depth1',
+      'ctx:exit',
+    ]);
+    expect(agentWsMocks.sendCommandToAgent).not.toHaveBeenCalled();
+  });
+
+  it('rethrows a non-trust precheck error rather than reporting a failed command', async () => {
+    partnerTrustMocks.assertDeviceExecuteAllowed.mockRejectedValueOnce(new Error('trust store unreachable'));
+
+    await expect(
+      executeCommandWithSystemPrecheck('device-1', 'list_services', {}, { timeoutMs: 5_000 }),
+    ).rejects.toThrow('trust store unreachable');
+    // The context must still have closed on the throw path.
+    expect(ctxState.depth).toBe(0);
     expect(agentWsMocks.sendCommandToAgent).not.toHaveBeenCalled();
   });
 

--- a/apps/api/src/services/commandQueue.dbcontext.test.ts
+++ b/apps/api/src/services/commandQueue.dbcontext.test.ts
@@ -205,32 +205,70 @@ describe('executeCommandWithSystemPrecheck (#4150/#1105)', () => {
     expect(agentWsMocks.sendCommandToAgent).not.toHaveBeenCalled();
   });
 
-  it('joins an ambient system context instead of opening a SECOND one', async () => {
-    // A nested withSystemDbAccessContext would check out a second pooled
-    // connection while the caller's is still held — strictly worse than the
-    // bug being fixed. The precheck must run in the context that is already
-    // open, adding no ctx:enter of its own.
-    ctxState.ambient = { scope: 'system' };
-    ctxState.depth = 1;
+  // A nested withSystemDbAccessContext would check out a second pooled
+  // connection while the caller's is still held, and escaping a tenant-scoped
+  // caller to open a system one would run the precheck with FULL cross-tenant
+  // visibility. Every ambient scope must therefore be JOINED, not nested.
+  it.each(['system', 'organization', 'partner'])(
+    'joins an ambient %s context instead of opening a SECOND one',
+    async (scope) => {
+      ctxState.ambient = { scope };
+      ctxState.depth = 1;
 
-    const result = await executeCommandWithSystemPrecheck('device-1', 'list_services', {}, { timeoutMs: 5_000 });
+      const result = await executeCommandWithSystemPrecheck('device-1', 'list_services', {}, { timeoutMs: 5_000 });
 
-    expect(result.status).toBe('completed');
-    // No leading ctx:enter — the precheck read is the very first event.
-    expect(ctxState.events[0]).toBe('select:devices@depth1');
-    // Exactly one ctx:enter in the whole call, and it belongs to the dispatch
-    // phase's insert, not to the precheck.
-    expect(ctxState.events.filter((e) => e === 'ctx:enter')).toHaveLength(1);
-    expect(ctxState.events).toContain('insert:device_commands@depth2');
-    // The precondition is broken here and cannot be recovered from, so it must
-    // be REPORTED rather than silently tolerated — see the guard's comment.
-    expect(sentryMocks.captureMessage).toHaveBeenCalledTimes(1);
-    expect(sentryMocks.captureMessage.mock.calls[0]![0]).toContain(
-      "called from inside a 'system' DB access context",
-    );
-    expect(sentryMocks.captureMessage.mock.calls[0]![1]).toMatchObject({
-      eventCode: 'db_operation_inside_held_context',
-    });
+      expect(result.status).toBe('completed');
+      // No leading ctx:enter — the precheck read is the very first event, so it
+      // ran in the context that was already open.
+      expect(ctxState.events[0]).toBe('select:devices@depth1');
+      // Exactly one ctx:enter in the whole call, and it belongs to the dispatch
+      // phase's insert (depth 2 = the ambient context plus its own), not to the
+      // precheck. A second connection for the precheck would make this 2.
+      expect(ctxState.events.filter((e) => e === 'ctx:enter')).toHaveLength(1);
+      expect(ctxState.events).toContain('insert:device_commands@depth2');
+      // The precondition is broken here and cannot be recovered from, so it
+      // must be REPORTED rather than silently tolerated.
+      expect(sentryMocks.captureMessage).toHaveBeenCalledTimes(1);
+      expect(sentryMocks.captureMessage.mock.calls[0]![0]).toContain(
+        'called from inside an existing DB access context',
+      );
+      // `scope` is in sentry.ts's ALLOWED_TAG_NAMES, so it survives the
+      // scrubber — the varying detail must ride a tag, not the message, which
+      // is the Sentry grouping key.
+      expect(sentryMocks.captureMessage.mock.calls[0]![1]).toEqual({
+        eventCode: 'db_operation_inside_held_context',
+        tags: { scope },
+      });
+    },
+  );
+
+  it('throttles the Sentry capture per scope but never the console warning', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    // The throttle map is module state that outlives `vi.clearAllMocks()`, and
+    // the cases above already captured for every scope. Jump the clock past the
+    // window so this test starts from a known-unthrottled state, then FREEZE it
+    // so the three calls below are unambiguously inside one window.
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + 60 * 60 * 1000);
+    try {
+      ctxState.ambient = { scope: 'organization' };
+      ctxState.depth = 1;
+
+      await executeCommandWithSystemPrecheck('device-1', 'list_services', {}, { timeoutMs: 5_000 });
+      await executeCommandWithSystemPrecheck('device-1', 'list_services', {}, { timeoutMs: 5_000 });
+      await executeCommandWithSystemPrecheck('device-1', 'list_services', {}, { timeoutMs: 5_000 });
+
+      // The same eventCode has burned thousands of events/day off the org
+      // quota when emitted per call — see the throttle's comment.
+      expect(sentryMocks.captureMessage).toHaveBeenCalledTimes(1);
+      // The log line carries the deviceId/type a Sentry tag cannot, so it is
+      // the attribution channel and must fire every time.
+      expect(warn).toHaveBeenCalledTimes(3);
+      expect(warn.mock.calls[2]![1]).toMatchObject({ deviceId: 'device-1', scope: 'organization' });
+    } finally {
+      vi.useRealTimers();
+      warn.mockRestore();
+    }
   });
 
   it('surfaces a trust denial as a terminal result and dispatches nothing', async () => {

--- a/apps/api/src/services/commandQueue.dbcontext.test.ts
+++ b/apps/api/src/services/commandQueue.dbcontext.test.ts
@@ -21,7 +21,7 @@
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { ctxState, dbState, partnerTrustMocks, agentWsMocks, commandDispatchMocks } = vi.hoisted(() => ({
+const { ctxState, dbState, partnerTrustMocks, agentWsMocks, commandDispatchMocks, sentryMocks } = vi.hoisted(() => ({
   ctxState: { depth: 0, events: [] as string[], ambient: undefined as { scope: string } | undefined },
   dbState: {
     deviceRows: [] as unknown[],
@@ -34,6 +34,7 @@ const { ctxState, dbState, partnerTrustMocks, agentWsMocks, commandDispatchMocks
     claimPendingCommandForDelivery: vi.fn(),
     releaseClaimedCommandDelivery: vi.fn(async () => undefined),
   },
+  sentryMocks: { captureMessage: vi.fn() },
 }));
 
 vi.mock('../db', () => ({
@@ -129,7 +130,7 @@ vi.mock('./partnerTrust.commands', async (importOriginal) => {
   };
 });
 
-vi.mock('./sentry', () => ({ captureException: vi.fn() }));
+vi.mock('./sentry', () => ({ captureException: vi.fn(), captureMessage: sentryMocks.captureMessage }));
 vi.mock('./backupMetrics', () => ({
   recordBackupCommandTimeout: vi.fn(),
   recordRestoreTimeout: vi.fn(),
@@ -190,6 +191,8 @@ describe('executeCommandWithSystemPrecheck (#4150/#1105)', () => {
     ]);
     // Nothing may still be open once the call returns.
     expect(ctxState.depth).toBe(0);
+    // Called correctly (depth 0), so the held-context guard must stay quiet.
+    expect(sentryMocks.captureMessage).not.toHaveBeenCalled();
   });
 
   it('opens no context at all past the precheck when the device is missing', async () => {
@@ -219,6 +222,15 @@ describe('executeCommandWithSystemPrecheck (#4150/#1105)', () => {
     // phase's insert, not to the precheck.
     expect(ctxState.events.filter((e) => e === 'ctx:enter')).toHaveLength(1);
     expect(ctxState.events).toContain('insert:device_commands@depth2');
+    // The precondition is broken here and cannot be recovered from, so it must
+    // be REPORTED rather than silently tolerated — see the guard's comment.
+    expect(sentryMocks.captureMessage).toHaveBeenCalledTimes(1);
+    expect(sentryMocks.captureMessage.mock.calls[0]![0]).toContain(
+      "called from inside a 'system' DB access context",
+    );
+    expect(sentryMocks.captureMessage.mock.calls[0]![1]).toMatchObject({
+      eventCode: 'db_operation_inside_held_context',
+    });
   });
 
   it('surfaces a trust denial as a terminal result and dispatches nothing', async () => {

--- a/apps/api/src/services/commandQueue.ts
+++ b/apps/api/src/services/commandQueue.ts
@@ -1351,6 +1351,47 @@ export async function executeCommand(
 }
 
 /**
+ * At most one Sentry event per scope per window for the held-context guard
+ * below. The same `db_operation_inside_held_context` code is deduped by call
+ * site in `db/index.ts` for exactly this reason: a hot path emitting it per
+ * call has previously burned thousands of events/day off the org quota, and
+ * the Nth event from a scope you have already seen tells you nothing the first
+ * did not. Bounded by construction — there are three scopes.
+ *
+ * The console line is deliberately NOT throttled: it carries the deviceId and
+ * command type that attribute the violation to a caller, neither of which can
+ * ride a Sentry tag (`commandType` is not in `ALLOWED_TAG_NAMES` and would be
+ * scrubbed; a device id never belongs in one). Logs have no quota. So the
+ * Sentry event is the alert and the log line is the attribution — the same
+ * division of labour `reportContextlessWrite` uses.
+ */
+const HELD_CONTEXT_DISPATCH_CAPTURE_THROTTLE_MS = 15 * 60 * 1000;
+const heldContextDispatchLastCapture = new Map<string, number>();
+
+function reportHeldContextDispatch(
+  scope: string,
+  deviceId: string,
+  type: CommandType | string,
+): void {
+  // Invariant text: it is the Sentry grouping key, so the varying part rides
+  // the allowlisted `scope` tag rather than the message.
+  const message = '[commandQueue] executeCommandWithSystemPrecheck was called from inside an '
+    + "existing DB access context. The caller's pooled connection stays pinned "
+    + 'idle-in-transaction for the whole device round-trip (#1105/#4150) — call it at depth 0, '
+    + 'or use executeCommand if the caller genuinely wants its own context to gate the precheck.';
+  console.warn(message, { deviceId, type, scope });
+
+  const now = Date.now();
+  const last = heldContextDispatchLastCapture.get(scope);
+  if (last !== undefined && now - last < HELD_CONTEXT_DISPATCH_CAPTURE_THROTTLE_MS) return;
+  heldContextDispatchLastCapture.set(scope, now);
+  captureMessage(message, {
+    eventCode: 'db_operation_inside_held_context',
+    tags: { scope },
+  });
+}
+
+/**
  * `executeCommand` for callers that hold NO DB access context of their own —
  * BullMQ workers, schedulers, and the AI-agent run loop (which deliberately
  * runs contextless; see jobs/aiAgentRunner.ts).
@@ -1383,31 +1424,26 @@ export async function executeCommandWithSystemPrecheck(
 ): Promise<CommandResult> {
   const ambient = getCurrentDbAccessContext();
   if (ambient) {
-    // The precondition is broken, and this function CANNOT recover from it:
-    // `runOutsideDbContext` exits the AsyncLocalStorage but cannot release a
-    // transaction somebody further up the stack opened, so the caller's pooled
-    // connection stays pinned for the whole round-trip below no matter what we
-    // do here. Report it instead of throwing — this runs inside the AI run
-    // loop's postToolUse hook, where a throw downgrades a real verification to
-    // `inconclusive`, and a slow dispatch beats a lost one. The db-layer
-    // `db_context_held_too_long` tripwire fires on the same hold but attributes
-    // it to whoever OPENED the context; this line names the dispatch that made
-    // it long, which is the half that is actionable.
-    const message = '[commandQueue] executeCommandWithSystemPrecheck was called from inside a '
-      + `'${ambient.scope}' DB access context. The caller's pooled connection stays pinned `
-      + 'idle-in-transaction for the whole device round-trip (#1105/#4150) — call it at depth 0, '
-      + 'or use executeCommand if the caller genuinely wants its own context to gate the precheck.';
-    console.warn(message, { deviceId, type, scope: ambient.scope });
-    captureMessage(message, {
-      eventCode: 'db_operation_inside_held_context',
-      tags: { commandType: String(type) },
-    });
+    reportHeldContextDispatch(ambient.scope, deviceId, type);
   }
 
-  // Joins an ambient system context rather than opening a second one: a nested
-  // withSystemDbAccessContext would check out a SECOND pooled connection while
-  // the first is still held, which is strictly worse than the bug being fixed.
-  const precheck = ambient?.scope === 'system'
+  // ANY ambient context is joined, never nested inside. Two reasons, and the
+  // second is why this is not just `scope === 'system'`:
+  //
+  //  - A nested `withSystemDbAccessContext` checks out a SECOND pooled
+  //    connection while the caller's is still held for the whole round-trip —
+  //    strictly worse than the bug this entry point exists to fix.
+  //  - Escaping a caller's 'organization'/'partner' context to open a system
+  //    one would run the precheck's `devices` read and trust check with FULL
+  //    cross-tenant visibility, i.e. more permissively than the caller's own
+  //    scope allows. Joining instead degrades toward "Device not found" — the
+  //    fail-CLOSED direction, and the repo's standing contract that too little
+  //    context denies rather than bypasses.
+  //
+  // Reaching here with an ambient context is a caller bug either way; the
+  // guard above says so out loud. It must not also widen what the caller can
+  // reach while it is being wrong.
+  const precheck = ambient
     ? await precheckCommandExecution(deviceId, type, options)
     : await runOutsideDbContextSafe(() =>
       withSystemDbAccessContext(

--- a/apps/api/src/services/commandQueue.ts
+++ b/apps/api/src/services/commandQueue.ts
@@ -1,5 +1,11 @@
 import { eq, and, inArray } from 'drizzle-orm';
-import { db, runOutsideDbContext, withDbAccessContext, withSystemDbAccessContext } from '../db';
+import {
+  db,
+  getCurrentDbAccessContext,
+  runOutsideDbContext,
+  withDbAccessContext,
+  withSystemDbAccessContext,
+} from '../db';
 import { deviceCommands, devices, auditLogs, users } from '../db/schema';
 import { sendCommandToAgent, isAgentConnected } from '../routes/agentWs';
 import { captureException } from './sentry';
@@ -935,59 +941,88 @@ export async function queueBackupStopCommand(
   );
 }
 
+export interface ExecuteCommandOptions {
+  userId?: string;
+  timeoutMs?: number;
+  preferHeartbeat?: boolean;
+  /**
+   * Which polling consumer on the device picks up this command.
+   * - 'agent' (default): the long-lived Go agent. Has a WS connection, so
+   *   executeCommand dispatches over WS for low latency.
+   * - 'watchdog': the separate breeze-watchdog process. Has NO WebSocket —
+   *   it polls via heartbeat (`claimPendingCommandsForDevice(..., 'watchdog')`
+   *   in routes/agents/heartbeat.ts). When targetRole is 'watchdog' we
+   *   MUST skip the WS dispatch path entirely and just write the row;
+   *   otherwise the command is sent to the agent WS (wrong consumer) and
+   *   the row's default target_role='agent' hides it from the heartbeat
+   *   claim query, leaving it pending forever.
+   *
+   * NOTE: because the watchdog polls every heartbeat (~5–10s per device,
+   * sometimes slower), callers targeting the watchdog should pass a larger
+   * timeoutMs than they would for an agent command.
+   */
+  targetRole?: 'agent' | 'watchdog';
+}
+
 /**
- * Execute a command and wait for result (convenience wrapper).
- *
- * When called from routes protected by authMiddleware, the entire request
- * handler runs inside a long-lived PostgreSQL transaction (via
- * withDbAccessContext).  If the device_commands INSERT stays inside that
- * transaction it is invisible to the WebSocket handler that processes the
- * agent's response (separate transaction) — so the result is silently
- * dropped and waitForCommandResult times out after 30 s.
- *
- * Fix: fetch the device (needs RLS → runs in the auth transaction), then
- * break out of the DB context for the device_commands lifecycle.
- * device_commands has no org_id column so RLS does not apply.
+ * Watchdog-targeted commands have no WS consumer; the WS pre-check and the
+ * dispatch path must be skipped entirely for them. The heartbeat poll path in
+ * routes/agents/heartbeat.ts picks them up. Derived in ONE place so the
+ * precheck and the dispatch phase can never disagree about it.
  */
-export async function executeCommand(
+function dispatchesViaWs(options: ExecuteCommandOptions): boolean {
+  return (options.targetRole ?? 'agent') === 'agent' && !(options.preferHeartbeat ?? false);
+}
+
+/**
+ * The columns of the device row the dispatch phase still needs once the
+ * precheck's DB context has closed. Named explicitly so the two phases cannot
+ * silently start depending on a column the precheck stopped selecting.
+ */
+interface PreparedCommandDevice {
+  id: string;
+  status: string;
+  agentId: string | null;
+  orgId: string;
+  hostname: string | null;
+  watchdogLastSeen: Date | null;
+  agentEdition: string | null;
+  agentVersion: string | null;
+  watchdogVersion: string | null;
+}
+
+type CommandPrecheckOutcome =
+  | { ok: true; device: PreparedCommandDevice }
+  | { ok: false; result: CommandResult };
+
+/**
+ * Phase 1 of `executeCommand` — every gate that must clear BEFORE a
+ * `device_commands` row exists: the device lookup, the partner-trust
+ * capability check, the artifact-edition gate, the liveness gates and the
+ * interactive WS fast-fail, in exactly that order.
+ *
+ * Reads `devices` and evaluates partner trust, so it needs an RLS access
+ * context — and deliberately does NOT open one of its own, because which
+ * context is correct belongs to the caller: a request route runs this inside
+ * its auth transaction (RLS-gated, the security property `executeCommand` has
+ * always had), while a background caller uses
+ * `executeCommandWithSystemPrecheck` to get a short system context that closes
+ * before anything waits on the device.
+ *
+ * Every terminal `CommandResult` returned here predates the row, so none of
+ * them carries a `commandId` — that preserves the "commandId present ⇔ row
+ * exists" contract the dispatch phase relies on.
+ */
+async function precheckCommandExecution(
   deviceId: string,
   type: CommandType | string,
-  payload: CommandPayload = {},
-  options: {
-    userId?: string;
-    timeoutMs?: number;
-    preferHeartbeat?: boolean;
-    /**
-     * Which polling consumer on the device picks up this command.
-     * - 'agent' (default): the long-lived Go agent. Has a WS connection, so
-     *   executeCommand dispatches over WS for low latency.
-     * - 'watchdog': the separate breeze-watchdog process. Has NO WebSocket —
-     *   it polls via heartbeat (`claimPendingCommandsForDevice(..., 'watchdog')`
-     *   in routes/agents/heartbeat.ts). When targetRole is 'watchdog' we
-     *   MUST skip the WS dispatch path entirely and just write the row;
-     *   otherwise the command is sent to the agent WS (wrong consumer) and
-     *   the row's default target_role='agent' hides it from the heartbeat
-     *   claim query, leaving it pending forever.
-     *
-     * NOTE: because the watchdog polls every heartbeat (~5–10s per device,
-     * sometimes slower), callers targeting the watchdog should pass a larger
-     * timeoutMs than they would for an agent command.
-     */
-    targetRole?: 'agent' | 'watchdog';
-  } = {}
-): Promise<CommandResult> {
-  const {
-    timeoutMs = 30000,
-    userId,
-    preferHeartbeat = false,
-    targetRole = 'agent',
-  } = options;
-  // Watchdog-targeted commands have no WS consumer; the WS pre-check /
-  // dispatch path below must be skipped entirely for them. The heartbeat
-  // poll path in routes/agents/heartbeat.ts picks them up.
-  const dispatchViaWs = targetRole === 'agent' && !preferHeartbeat;
+  options: ExecuteCommandOptions,
+): Promise<CommandPrecheckOutcome> {
+  const { userId } = options;
+  const targetRole = options.targetRole ?? 'agent';
+  const dispatchViaWs = dispatchesViaWs(options);
 
-  // 1. Verify device inside the auth transaction (RLS-protected).
+  // 1. Verify device inside the caller's transaction (RLS-protected).
   // agentEdition/agentVersion/watchdogVersion feed the artifact-edition gate
   // below (#4093) — cheap here because this SELECT already runs.
   const [device] = await db
@@ -1007,7 +1042,7 @@ export async function executeCommand(
     .limit(1);
 
   if (!device) {
-    return { status: 'failed', error: 'Device not found' };
+    return { ok: false, result: { status: 'failed', error: 'Device not found' } };
   }
 
   try {
@@ -1015,9 +1050,12 @@ export async function executeCommand(
   } catch (e) {
     if (e instanceof TrustDeniedError) {
       return {
-        status: 'failed',
-        error: e.code,
-        trust: { capability: e.capability, reason: e.reason },
+        ok: false,
+        result: {
+          status: 'failed',
+          error: e.code,
+          trust: { capability: e.capability, reason: e.reason },
+        },
       };
     }
     throw e;
@@ -1038,7 +1076,7 @@ export async function executeCommand(
     console.warn(
       `[commandQueue] ${type} dispatch refused for device ${deviceId} (#4093): ${editionRefusal}`,
     );
-    return { status: 'failed', error: editionRefusal };
+    return { ok: false, result: { status: 'failed', error: editionRefusal } };
   }
 
   if (targetRole === 'watchdog') {
@@ -1057,12 +1095,18 @@ export async function executeCommand(
       : Infinity;
     if (watchdogAgeMs > WATCHDOG_STALE_MS) {
       return {
-        status: 'failed',
-        error: 'Watchdog is not reporting; cannot dispatch watchdog command',
+        ok: false,
+        result: {
+          status: 'failed',
+          error: 'Watchdog is not reporting; cannot dispatch watchdog command',
+        },
       };
     }
   } else if (device.status !== 'online') {
-    return { status: 'failed', error: `Device is ${device.status}, cannot execute command` };
+    return {
+      ok: false,
+      result: { status: 'failed', error: `Device is ${device.status}, cannot execute command` },
+    };
   }
 
   // Fast-fail interactive commands when the WS is known-dead. The user is
@@ -1084,11 +1128,35 @@ export async function executeCommand(
       agentId: device.agentId,
       type,
     });
-    return { status: 'failed' as const, error: DEVICE_UNREACHABLE_ERROR };
+    return { ok: false, result: { status: 'failed' as const, error: DEVICE_UNREACHABLE_ERROR } };
   }
 
-  // 2. Queue, dispatch, and poll OUTSIDE the auth transaction so the
-  //    INSERT commits immediately and is visible to the WS handler.
+  return { ok: true, device };
+}
+
+/**
+ * Phase 2 of `executeCommand` — queue, dispatch, and poll. Runs entirely
+ * OUTSIDE the caller's DB context so the INSERT commits immediately and is
+ * visible to the WebSocket handler that processes the agent's response
+ * (a separate transaction); its own short system contexts cover the writes
+ * that would otherwise be contextless bare-pool writes (#1375).
+ *
+ * `device` is the snapshot the precheck resolved. Re-reading it here would
+ * defeat the point of the split, and there was never an atomic
+ * authorisation-to-insert guarantee to lose: the precheck's SELECT has always
+ * been a non-locking read.
+ */
+async function dispatchPreparedCommand(
+  device: PreparedCommandDevice,
+  deviceId: string,
+  type: CommandType | string,
+  payload: CommandPayload,
+  options: ExecuteCommandOptions,
+): Promise<CommandResult> {
+  const { timeoutMs = 30000, userId } = options;
+  const targetRole = options.targetRole ?? 'agent';
+  const dispatchViaWs = dispatchesViaWs(options);
+
   return runOutsideDbContextSafe(async () => {
     // Validate userId for the created_by FK. Shared with queueCommand — see
     // `resolveCommandCreatedBy` for why synthetic-auth ids degrade to NULL and
@@ -1250,6 +1318,80 @@ export async function executeCommand(
     };
     return { ...finalResult, commandId: command.id };
   });
+}
+
+/**
+ * Execute a command and wait for result (convenience wrapper).
+ *
+ * When called from routes protected by authMiddleware, the entire request
+ * handler runs inside a long-lived PostgreSQL transaction (via
+ * withDbAccessContext).  If the device_commands INSERT stays inside that
+ * transaction it is invisible to the WebSocket handler that processes the
+ * agent's response (separate transaction) — so the result is silently
+ * dropped and waitForCommandResult times out after 30 s.
+ *
+ * Fix: fetch the device (needs RLS → runs in the auth transaction), then
+ * break out of the DB context for the device_commands lifecycle.
+ * device_commands has no org_id column so RLS does not apply.
+ *
+ * NOTE for background callers (workers, schedulers, AI-agent runs): the
+ * `runOutsideDbContext` inside the dispatch phase exits the AsyncLocalStorage,
+ * but it CANNOT release a transaction the caller opened — so wrapping this
+ * call in `withSystemDbAccessContext` just to satisfy the precheck pins a
+ * pooled connection idle-in-transaction for the whole `timeoutMs` wait (#1105).
+ * Use `executeCommandWithSystemPrecheck` instead.
+ */
+export async function executeCommand(
+  deviceId: string,
+  type: CommandType | string,
+  payload: CommandPayload = {},
+  options: ExecuteCommandOptions = {}
+): Promise<CommandResult> {
+  const precheck = await precheckCommandExecution(deviceId, type, options);
+  if (!precheck.ok) return precheck.result;
+  return dispatchPreparedCommand(precheck.device, deviceId, type, payload, options);
+}
+
+/**
+ * `executeCommand` for callers that hold NO DB access context of their own —
+ * BullMQ workers, schedulers, and the AI-agent run loop (which deliberately
+ * runs contextless; see jobs/aiAgentRunner.ts).
+ *
+ * Such a caller cannot invoke `executeCommand` directly: the precheck's
+ * `devices` SELECT would run on the bare pool, RLS would deny it, and every
+ * dispatch would report "Device not found". Wrapping the whole call in a
+ * system context makes it work — and pins a pooled Postgres connection
+ * idle-in-transaction for the entire device round-trip, which is the #1105
+ * pool-exhaustion shape (#4150, and #4133/3ec0439d2 before it in the workers).
+ *
+ * This entry point opens a system context for the PRECHECK ONLY and closes it
+ * before anything waits on the device. The dispatch phase — the WS send and
+ * the `waitForCommandResult` poll — runs at depth 0, holding nothing.
+ *
+ * Scope is system, matching what the background callers already passed. A
+ * caller that needs the command gated by a specific tenant's RLS must open
+ * that context itself and call `executeCommand` — but see the note there
+ * about how long it will then hold a connection.
+ */
+export async function executeCommandWithSystemPrecheck(
+  deviceId: string,
+  type: CommandType | string,
+  payload: CommandPayload = {},
+  options: ExecuteCommandOptions = {}
+): Promise<CommandResult> {
+  // Joins an ambient system context rather than opening a second one: a nested
+  // withSystemDbAccessContext would check out a SECOND pooled connection while
+  // the first is still held, which is strictly worse than the bug being fixed.
+  const precheck = getCurrentDbAccessContext()?.scope === 'system'
+    ? await precheckCommandExecution(deviceId, type, options)
+    : await runOutsideDbContextSafe(() =>
+      withSystemDbAccessContext(
+        () => precheckCommandExecution(deviceId, type, options),
+        'commandQueue.executeCommandWithSystemPrecheck',
+      ));
+
+  if (!precheck.ok) return precheck.result;
+  return dispatchPreparedCommand(precheck.device, deviceId, type, payload, options);
 }
 
 /**

--- a/apps/api/src/services/commandQueue.ts
+++ b/apps/api/src/services/commandQueue.ts
@@ -1364,6 +1364,13 @@ export async function executeCommand(
  * scrubbed; a device id never belongs in one). Logs have no quota. So the
  * Sentry event is the alert and the log line is the attribution — the same
  * division of labour `reportContextlessWrite` uses.
+ *
+ * Deliberately NOT `db/index.ts`'s exported `shouldCaptureHeldContext`, even
+ * though it is the same per-scope shape: its map is shared with the
+ * `db_context_held_too_long` capture, so one signal would silently suppress the
+ * other for a whole window. These are different problems — "a context was held
+ * too long" vs "this dispatch was made from inside one" — and an operator needs
+ * to see both. The cost of keeping them apart is the six lines below.
  */
 const HELD_CONTEXT_DISPATCH_CAPTURE_THROTTLE_MS = 15 * 60 * 1000;
 const heldContextDispatchLastCapture = new Map<string, number>();

--- a/apps/api/src/services/commandQueue.ts
+++ b/apps/api/src/services/commandQueue.ts
@@ -8,7 +8,7 @@ import {
 } from '../db';
 import { deviceCommands, devices, auditLogs, users } from '../db/schema';
 import { sendCommandToAgent, isAgentConnected } from '../routes/agentWs';
-import { captureException } from './sentry';
+import { captureException, captureMessage } from './sentry';
 import { recordBackupCommandTimeout, recordRestoreTimeout } from './backupMetrics';
 import {
   claimPendingCommandForDelivery,
@@ -976,19 +976,17 @@ function dispatchesViaWs(options: ExecuteCommandOptions): boolean {
 
 /**
  * The columns of the device row the dispatch phase still needs once the
- * precheck's DB context has closed. Named explicitly so the two phases cannot
- * silently start depending on a column the precheck stopped selecting.
+ * precheck's DB context has closed — the WS target, and the org/hostname the
+ * audit row is stamped with. Deliberately just these three: everything else
+ * the precheck selects (status, the watchdog freshness fields, the
+ * agent-edition triple) is consumed by a gate that runs BEFORE the context
+ * closes, and carrying it forward would invite the dispatch phase to start
+ * reasoning about a snapshot whose gate has already passed.
  */
 interface PreparedCommandDevice {
-  id: string;
-  status: string;
-  agentId: string | null;
+  agentId: string;
   orgId: string;
-  hostname: string | null;
-  watchdogLastSeen: Date | null;
-  agentEdition: string | null;
-  agentVersion: string | null;
-  watchdogVersion: string | null;
+  hostname: string;
 }
 
 type CommandPrecheckOutcome =
@@ -1372,6 +1370,10 @@ export async function executeCommand(
  * caller that needs the command gated by a specific tenant's RLS must open
  * that context itself and call `executeCommand` — but see the note there
  * about how long it will then hold a connection.
+ *
+ * PRECONDITION: no ambient DB access context. It is reported (not thrown) when
+ * broken, because from inside someone else's transaction the no-held-context
+ * promise is unrecoverable — see the guard below.
  */
 export async function executeCommandWithSystemPrecheck(
   deviceId: string,
@@ -1379,10 +1381,33 @@ export async function executeCommandWithSystemPrecheck(
   payload: CommandPayload = {},
   options: ExecuteCommandOptions = {}
 ): Promise<CommandResult> {
+  const ambient = getCurrentDbAccessContext();
+  if (ambient) {
+    // The precondition is broken, and this function CANNOT recover from it:
+    // `runOutsideDbContext` exits the AsyncLocalStorage but cannot release a
+    // transaction somebody further up the stack opened, so the caller's pooled
+    // connection stays pinned for the whole round-trip below no matter what we
+    // do here. Report it instead of throwing — this runs inside the AI run
+    // loop's postToolUse hook, where a throw downgrades a real verification to
+    // `inconclusive`, and a slow dispatch beats a lost one. The db-layer
+    // `db_context_held_too_long` tripwire fires on the same hold but attributes
+    // it to whoever OPENED the context; this line names the dispatch that made
+    // it long, which is the half that is actionable.
+    const message = '[commandQueue] executeCommandWithSystemPrecheck was called from inside a '
+      + `'${ambient.scope}' DB access context. The caller's pooled connection stays pinned `
+      + 'idle-in-transaction for the whole device round-trip (#1105/#4150) — call it at depth 0, '
+      + 'or use executeCommand if the caller genuinely wants its own context to gate the precheck.';
+    console.warn(message, { deviceId, type, scope: ambient.scope });
+    captureMessage(message, {
+      eventCode: 'db_operation_inside_held_context',
+      tags: { commandType: String(type) },
+    });
+  }
+
   // Joins an ambient system context rather than opening a second one: a nested
   // withSystemDbAccessContext would check out a SECOND pooled connection while
   // the first is still held, which is strictly worse than the bug being fixed.
-  const precheck = getCurrentDbAccessContext()?.scope === 'system'
+  const precheck = ambient?.scope === 'system'
     ? await precheckCommandExecution(deviceId, type, options)
     : await runOutsideDbContextSafe(() =>
       withSystemDbAccessContext(


### PR DESCRIPTION
Closes #4150

## The bug

`readServiceStatus` (`playbookActExecutor.ts`) and `verifyServiceRunning` / `verifyProcessAbsent` (`actVerify.ts`) wrapped their `commandQueue.executeCommand` call in `inSystemDbContext`, then awaited a device-command round-trip of up to **30s** (`SERVICE_STATUS_READ_TIMEOUT_MS`) / **8s** (`VERIFY_READ_TIMEOUT_MS`).

`withDbAccessContext` opens a real `baseDb.transaction(...)`, so that held a pooled Postgres connection **idle-in-transaction for the whole wait** — the #1105 pool-exhaustion shape that #4133 / 3ec0439d2 already removed from `monitorWorker`, `discoveryWorker` and `backupWorker`.

## Why the callers couldn't fix it alone

`executeCommand`'s dispatch phase already runs inside `runOutsideDbContext` — but that only exits the AsyncLocalStorage so `db` resolves to the bare pool. It **cannot release a transaction the caller opened**, so the connection stayed pinned regardless.

And the callers can't just drop the wrapper: `executeCommand`'s precheck SELECTs `devices`, which forced-RLS denies on the bare pool, so every dispatch would come back `"Device not found"`.

So the phase split has to happen inside `commandQueue.ts`.

## The change

| | |
|---|---|
| `precheckCommandExecution` (private) | device lookup, partner-trust check, artifact-edition gate, liveness gates, interactive WS fast-fail — **in exactly the previous order**. Needs an RLS context; deliberately opens none of its own, because which context is correct is the caller's decision. |
| `dispatchPreparedCommand` (private) | today's `runOutsideDbContextSafe` body **verbatim** (insert, audit, WS dispatch, `waitForCommandResult`), taking the device snapshot the precheck resolved. |
| `executeCommand` | composes the two. **Behaviour unchanged** for its ~40 request-route callers: the precheck still runs in the caller's auth transaction (the RLS gating it has always had), and every terminal result still predates the row — the "`commandId` present ⇔ row exists" contract holds. |
| `executeCommandWithSystemPrecheck` **(new)** | the depth-0-safe entry point for background callers: a **short** system context around the precheck only, closed before anything waits on the device. Joins **any** ambient context rather than nesting (see below). |

The three AI-agent call sites now use it and hold nothing across the wait. `jobs/aiAgentRunner.ts` already runs the agent loop contextless by design ("*Deliberately NOT wrapped in withSystemDbAccessContext*"), and `runPlaybookSteps` is invoked unwrapped — so the dispatch genuinely lands at depth 0 rather than merely one level shallower.

### Ambient-context handling (both halves came out of review)

`executeCommandWithSystemPrecheck`'s whole value is that nothing is held across the round-trip — and from inside an ambient context it is **powerless** to keep that promise, since `runOutsideDbContext` cannot release someone else's transaction. Two things follow.

**It reports the precondition violation** (`console.warn` + Sentry `db_operation_inside_held_context`, an already-registered code for exactly this) rather than tolerating it silently. Reports rather than throws deliberately: this runs inside the AI run loop's `postToolUse` hook, where a throw downgrades a real verification to `inconclusive` — a slow dispatch beats a lost one. The db-layer `db_context_held_too_long` tripwire fires on the same hold but attributes it to whoever *opened* the context; this line names the dispatch that made it long, which is the actionable half. Throttled to one Sentry event per scope per 15 min (the sibling guards on this eventCode all dedup, each citing a real quota-flood incident); the console line is unthrottled because it carries the `deviceId`/`type` no Sentry tag can — `commandType` is absent from `ALLOWED_TAG_NAMES` and would be scrubbed.

**And it joins ANY ambient context, never nests inside one.** A first pass only joined when the ambient scope was already `system`; review caught that an `organization`/`partner` caller — the realistic violation, a request handler's RLS transaction reaching this function — fell through to `runOutsideDbContext(() => withSystemDbAccessContext(...))` and did *both* things the code's own comments call unacceptable: a **second** pooled connection checked out while the caller's is still held, and the precheck's `devices` read + trust check running with **full cross-tenant visibility** instead of the caller's narrower scope. `withDbAccessContext` already reuses any active transaction regardless of requested scope — that is what made the `system` join work — so dropping the escape makes the same reuse cover the tenant scopes. A tenant-scoped caller now degrades toward "Device not found" instead of seeing another tenant's device: the **fail-closed** direction, and the repo's standing contract that too little context denies rather than bypasses.

### Deliberately not done

Making `executeCommand` auto-open a system context when no ambient context exists. That would turn a forgotten-context bug in a request route into a **silent tenancy bypass at the dispatch chokepoint**. Contextless access must keep denying.

## Tests

Three new `*.dbcontext.test.ts` suites mirroring `jobs/monitorWorker.dbcontext.test.ts`'s `ctxState.events` harness — they track real enter/exit **depth** and assert which depth each DB touch and each command dispatch runs at:

- `services/commandQueue.dbcontext.test.ts` — the precheck runs at depth 1, the context **exits**, then `claim` / `wsSend` / the result poll all run at depth 0. Plus: `executeCommand` still opens **no** context of its own; the ambient **join** is exercised across all three scopes (`system` / `organization` / `partner`) and asserts no second context is opened in each (via `insert:device_commands@depth2` — a second connection would make the `ctx:enter` count 2) while the guard fires with the right event code and `scope` tag; the Sentry throttle holds across three calls while the console warning fires every time; a `TrustDeniedError` still surfaces as a terminal result with its `trust` payload; a non-trust precheck error still **propagates** rather than degrading into a failed-command result.
- `services/aiAgents/actVerify.dbcontext.test.ts` — both verify read-backs dispatch at depth 0 (including the throwing path); `recordActVerifyFailureAlert` keeps its short context around the insert.
- `services/aiAgents/playbookActExecutor.dbcontext.test.ts` — `readServiceStatus` dispatches at depth 0; `readDiskUsagePercent` keeps its short context (a correct short context around a pure DB read must stay).

`runOutsideDbContext` is mocked as a **depth-preserving** passthrough on purpose, because that is what it really is. Modelling it as a depth reset would make these suites pass against the very bug they exist for.

**Mutation-verified**, not just asserted. Against the pre-fix shape, and again by re-introducing `inSystemDbContext` around the fixed call:

```
- "executeCommand@depth0"
+ "ctx:enter"
+ "executeCommand@depth1"
+ "ctx:exit"
```

`actVerify.test.ts` is updated for the renamed entry point (1:1 substitution, no assertion loosened — its identity-mocked context helpers can assert *that* a system context was used, never *how long* it was held, hence the new suites).

## Verification

- `vitest run src/services/aiAgents src/routes/systemTools src/services/commandQueueTransitions.test.ts` — **78 files / 2123 tests pass**
- `vitest run src/services/commandQueue.dbcontext.test.ts src/services/commandQueue.test.ts` — 59 pass
- The 9 `jobs/*` + 18 route suites that consume `commandQueue` — 347 pass
- A normalized statement-level diff of the old `executeCommand` body against `precheckCommandExecution` + `dispatchPreparedCommand` shows **no logic line dropped** — only the signature/doc relocation and the `{ ok, result }` wrapping of the terminal returns
- `npx tsc --noEmit` clean; `eslint` on all changed files clean

## Out of scope (noted, not fixed)

Every ordinary `executeCommand` call from an authenticated route is still wrapped request-wide by `authMiddleware`'s transaction, and the system-tools routes are not in `SELF_MANAGED_DB_CONTEXT_ROUTES` — so those retain the same connection hold across their own round-trips. Same for the AI tool path, where `aiAgentSdkTools.ts`'s `makeHandler` re-enters a tenant context around every `executeTool`. Both need a middleware opt-out plus caller-scoped prechecks and are a materially larger change than #4150; flagging rather than expanding scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBxF7C8E5GxFnNcGf6kBVP
