### PR TITLE
fix(api): make mobile cursor pagination reachable and keyset-safe (#3770)

### DIFF
--- a/apps/api/src/__tests__/integration/mobileCursorPagination.integration.test.ts
+++ b/apps/api/src/__tests__/integration/mobileCursorPagination.integration.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Real-Postgres proof for the two raw-SQL fragments introduced by #3770's
+ * fix to GET /mobile/alerts/inbox and GET /mobile/devices
+ * (apps/api/src/routes/mobile.ts).
+ *
+ * apps/api/src/routes/mobile.test.ts already covers the route's BEHAVIOR
+ * (nextCursor reachability, ordering-mode split, response shape) against a
+ * mocked `db.select` — but a mock cannot catch a typo in a `to_char` format
+ * string, an invalid `::timestamp`/`::uuid` cast, or Postgres's actual tuple-
+ * comparison / NULL-ordering semantics; it would happily return whatever rows
+ * the test tells it to. This file executes the SAME query fragments the
+ * route builds (select projection, cursor predicate, ORDER BY) against a
+ * real table, so a cast or syntax mistake fails here instead of in
+ * production. See `devicesCursorRls.integration.test.ts` for the identical
+ * rationale applied to routes/devices/core.ts's cursor.
+ *
+ * Prerequisites:
+ *   docker compose -f docker-compose.test.yml up -d
+ *
+ * Run:
+ *   pnpm test:integration -- src/__tests__/integration/mobileCursorPagination.integration.test.ts
+ */
+import './setup';
+
+import { describe, it, expect } from 'vitest';
+import { and, asc, desc, eq, sql } from 'drizzle-orm';
+import { getTestDb } from './setup';
+import { alerts, devices } from '../../db/schema';
+import { createOrganization, createPartner, createSite } from './db-utils';
+import { encodeCursor, decodeCursor, decodeTimestampCursor } from '../../routes/mobile';
+
+let agentIdCounter = 0;
+async function insertDevice(opts: { orgId: string; siteId: string; hostname: string }): Promise<string> {
+  const db = getTestDb();
+  agentIdCounter++;
+  const [row] = await db
+    .insert(devices)
+    .values({
+      orgId: opts.orgId,
+      siteId: opts.siteId,
+      agentId: `agent-mobile-cursor-${agentIdCounter}-${Date.now()}`,
+      hostname: opts.hostname,
+      displayName: opts.hostname,
+      osType: 'windows',
+      osVersion: '11',
+      osBuild: '22000',
+      architecture: 'x86_64',
+      agentVersion: '0.0.0-test',
+      status: 'online',
+      enrolledAt: new Date(),
+    })
+    .returning({ id: devices.id });
+  if (!row) throw new Error('insertDevice: insert returned no row');
+  return row.id;
+}
+
+/**
+ * Insert an alert with a `triggered_at` carrying a specific fractional-second
+ * suffix (up to 6 digits) that a JS `Date` cannot represent — using raw SQL
+ * rather than Drizzle's `.values({ triggeredAt: someDate })`, because a plain
+ * `Date` object can only ever contribute millisecond precision. That's the
+ * whole point of this test: proving the fix survives the values a `Date`
+ * cannot even construct.
+ */
+async function insertAlertAt(opts: { orgId: string; deviceId: string; triggeredAt: string }): Promise<string> {
+  const db = getTestDb();
+  const rows = await db.execute<{ id: string }>(sql`
+    INSERT INTO alerts (device_id, org_id, severity, title, triggered_at)
+    VALUES (${opts.deviceId}, ${opts.orgId}, 'critical', 'test alert', ${opts.triggeredAt}::timestamp)
+    RETURNING id
+  `);
+  const row = rows[0];
+  if (!row) throw new Error('insertAlertAt: insert returned no row');
+  return row.id;
+}
+
+describe('mobile cursor pagination — real SQL (#3770)', () => {
+  it('/alerts/inbox: to_char + ::timestamp round-trips full microsecond precision and does not skip the boundary row', async () => {
+    const db = getTestDb();
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const site = await createSite({ orgId: org.id });
+    const deviceId = await insertDevice({ orgId: org.id, siteId: site.id, hostname: 'host-1' });
+
+    // A sits just above B on the SAME millisecond, differing only in the
+    // fractional digits a JS Date cannot hold. The historical bug: encoding
+    // A's cursor via `Date.toISOString()` truncates '.123999' to '.123',
+    // and `triggered_at < '.123'` then wrongly excludes B ('.123500' is NOT
+    // less than the truncated '.123000').
+    const idA = await insertAlertAt({ orgId: org.id, deviceId, triggeredAt: '2026-07-28 12:00:00.123999' });
+    const idB = await insertAlertAt({ orgId: org.id, deviceId, triggeredAt: '2026-07-28 12:00:00.123500' });
+
+    // ---- Page 1: exactly what the route selects/orders, limit=1 ----
+    const page1 = await db
+      .select({
+        id: alerts.id,
+        triggeredAtKey: sql<string>`to_char(${alerts.triggeredAt}, 'YYYY-MM-DD"T"HH24:MI:SS.US')`,
+      })
+      .from(alerts)
+      .where(eq(alerts.orgId, org.id))
+      .orderBy(desc(alerts.triggeredAt), desc(alerts.id))
+      .limit(1);
+
+    expect(page1.map(r => r.id)).toEqual([idA]);
+    const last = page1[0]!;
+    // Full 6-digit microsecond precision preserved end to end.
+    expect(last.triggeredAtKey).toBe('2026-07-28T12:00:00.123999');
+
+    const token = encodeCursor(last.triggeredAtKey, last.id);
+    expect(token).not.toBeNull();
+    const cursor = decodeTimestampCursor(token ?? undefined);
+    expect(cursor).toEqual({ key: '2026-07-28T12:00:00.123999', id: idA });
+
+    // ---- Page 2: the exact keyset predicate the route builds ----
+    const page2 = await db
+      .select({ id: alerts.id })
+      .from(alerts)
+      .where(
+        and(
+          eq(alerts.orgId, org.id),
+          sql`(${alerts.triggeredAt} < ${cursor!.key}::timestamp OR (${alerts.triggeredAt} = ${cursor!.key}::timestamp AND ${alerts.id} < ${cursor!.id}::uuid))`,
+        ),
+      )
+      .orderBy(desc(alerts.triggeredAt), desc(alerts.id))
+      .limit(1);
+
+    // With the fix: B is returned (no skip). Against the old
+    // `.toISOString()`-truncated cursor this would come back empty.
+    expect(page2.map(r => r.id)).toEqual([idB]);
+  });
+
+  it('/devices: hostname ASC tuple predicate walks with no duplicates or gaps, including a never-checked-in (NULL last_seen_at) device', async () => {
+    const db = getTestDb();
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const site = await createSite({ orgId: org.id });
+
+    // Interleaved insert order so a naive scan wouldn't accidentally match
+    // the expected walk order. 'zzz-never-seen' has NULL last_seen_at,
+    // which the OLD `last_seen_at DESC` keyset would have sorted FIRST
+    // (Postgres puts NULLs first on DESC with no NULLS LAST) — the new
+    // hostname-keyed walk isn't sensitive to that column at all.
+    const hostnames = ['ccc-host', 'aaa-host', 'zzz-never-seen', 'bbb-host'];
+    const idByHostname = new Map<string, string>();
+    for (const hostname of hostnames) {
+      idByHostname.set(hostname, await insertDevice({ orgId: org.id, siteId: site.id, hostname }));
+    }
+    // Never checked in: NULL last_seen_at.
+    await db.execute(sql`UPDATE devices SET last_seen_at = NULL WHERE id = ${idByHostname.get('zzz-never-seen')}`);
+
+    const walked: string[] = [];
+    let cursor: { key: string; id: string } | null = null;
+    const limit = 1;
+
+    for (let step = 0; step < 10; step++) {
+      const whereCursor = cursor
+        ? sql`(${devices.hostname}, ${devices.id}) > (${cursor.key}, ${cursor.id}::uuid)`
+        : undefined;
+      const rows = await db
+        .select({ id: devices.id, hostname: devices.hostname })
+        .from(devices)
+        .where(whereCursor ? and(eq(devices.orgId, org.id), whereCursor) : eq(devices.orgId, org.id))
+        .orderBy(asc(devices.hostname), asc(devices.id))
+        .limit(limit + 1);
+
+      const page = rows.slice(0, limit);
+      for (const r of page) walked.push(r.hostname);
+
+      if (rows.length <= limit) {
+        cursor = null;
+        break;
+      }
+      const lastRow = page[page.length - 1]!;
+      const token = encodeCursor(lastRow.hostname, lastRow.id);
+      cursor = decodeCursor(token ?? undefined);
+      expect(cursor).not.toBeNull();
+    }
+
+    // Alphabetical order, every device exactly once, walk terminated.
+    expect(walked).toEqual(['aaa-host', 'bbb-host', 'ccc-host', 'zzz-never-seen']);
+    expect(cursor).toBeNull();
+  });
+});

--- a/apps/api/src/routes/mobile.cursor.test.ts
+++ b/apps/api/src/routes/mobile.cursor.test.ts
@@ -1,30 +1,34 @@
 import { describe, it, expect } from 'vitest';
-import { encodeCursor, decodeCursor } from './mobile';
+import { encodeCursor, decodeCursor, decodeTimestampCursor } from './mobile';
 
 describe('mobile route cursor helpers', () => {
-  it('round-trips a valid (Date, id) pair', () => {
-    const ts = new Date('2026-05-17T23:45:00.000Z');
+  it('round-trips a (key, id) pair verbatim — never re-parses key', () => {
+    // A 6-digit-microsecond string is the whole point (#3770): a JS `Date`
+    // only holds milliseconds, so this only stays intact if encode/decode
+    // never routes `key` through one.
+    const key = '2026-05-17T23:45:00.123456';
     const id = 'd1f8e0c4-9c5d-4f8e-9c5d-4f8e9c5d4f8e';
-    const encoded = encodeCursor(ts, id);
+    const encoded = encodeCursor(key, id);
     expect(encoded).not.toBeNull();
     const decoded = decodeCursor(encoded ?? undefined);
-    expect(decoded).not.toBeNull();
-    expect(decoded?.id).toBe(id);
-    expect(decoded?.ts.toISOString()).toBe(ts.toISOString());
+    expect(decoded).toEqual({ key, id });
   });
 
-  it('accepts an ISO string for ts and re-emits the same timestamp', () => {
-    const iso = '2026-05-17T23:45:00.000Z';
+  it('round-trips a non-timestamp key (e.g. hostname) verbatim', () => {
+    const key = 'zz-last-host';
     const id = 'd1f8e0c4-9c5d-4f8e-9c5d-4f8e9c5d4f8e';
-    const encoded = encodeCursor(iso, id);
+    const encoded = encodeCursor(key, id);
     const decoded = decodeCursor(encoded ?? undefined);
-    expect(decoded?.ts.toISOString()).toBe(iso);
+    expect(decoded).toEqual({ key, id });
   });
 
-  it('returns null when ts or id is missing on encode', () => {
+  it('returns null when key or id is missing/empty on encode', () => {
     expect(encodeCursor(null, 'x')).toBeNull();
     expect(encodeCursor(undefined, 'x')).toBeNull();
-    expect(encodeCursor(new Date(), '')).toBeNull();
+    expect(encodeCursor('', 'x')).toBeNull();
+    expect(encodeCursor('k', null)).toBeNull();
+    expect(encodeCursor('k', undefined)).toBeNull();
+    expect(encodeCursor('k', '')).toBeNull();
   });
 
   it('returns null on undefined/empty input to decode', () => {
@@ -32,25 +36,42 @@ describe('mobile route cursor helpers', () => {
     expect(decodeCursor('')).toBeNull();
   });
 
-  it('returns null on garbage input', () => {
+  it('returns null on garbage or structurally-invalid input', () => {
     expect(decodeCursor('not-base64')).toBeNull();
     expect(decodeCursor(Buffer.from('not json', 'utf8').toString('base64url'))).toBeNull();
-    expect(decodeCursor(Buffer.from('{"ts":"not-a-date","id":"x"}', 'utf8').toString('base64url'))).toBeNull();
-    expect(decodeCursor(Buffer.from('{"ts":1234,"id":"x"}', 'utf8').toString('base64url'))).toBeNull();
-    expect(decodeCursor(Buffer.from('{"ts":"2026-05-17T00:00:00Z"}', 'utf8').toString('base64url'))).toBeNull();
+    expect(decodeCursor(Buffer.from('{"key":"","id":"x"}', 'utf8').toString('base64url'))).toBeNull();
+    expect(decodeCursor(Buffer.from('{"key":1234,"id":"x"}', 'utf8').toString('base64url'))).toBeNull();
+    expect(decodeCursor(Buffer.from('{"key":"2026-05-17T00:00:00Z"}', 'utf8').toString('base64url'))).toBeNull();
   });
 
   it('rejects a non-uuid id rather than letting it reach a uuid column', () => {
-    const encoded = encodeCursor(new Date('2026-05-17T23:45:00.000Z'), 'not-a-uuid');
+    const encoded = encodeCursor('2026-05-17T23:45:00.000Z', 'not-a-uuid');
     expect(decodeCursor(encoded ?? undefined)).toBeNull();
   });
 
   it('uses base64url (no + or /) so cursors are URL-safe', () => {
     // Force a payload likely to produce + and / in standard base64
-    const ts = new Date('2026-05-17T23:45:00.000Z');
+    const key = '2026-05-17T23:45:00.000Z';
     const id = '////++++>>>>!@#$';
-    const encoded = encodeCursor(ts, id);
+    const encoded = encodeCursor(key, id);
     expect(encoded).not.toBeNull();
     expect(encoded ?? '').not.toMatch(/[+/=]/);
+  });
+
+  describe('decodeTimestampCursor', () => {
+    it('accepts a structurally-valid cursor whose key parses as a timestamp', () => {
+      const id = '11111111-1111-4111-8111-111111111111';
+      const encoded = encodeCursor('2026-07-28T12:00:00.123456', id);
+      expect(decodeTimestampCursor(encoded ?? undefined)).toEqual({
+        key: '2026-07-28T12:00:00.123456',
+        id,
+      });
+    });
+
+    it('rejects a structurally-valid cursor whose key is not a timestamp — e.g. a hostname cursor replayed on the wrong route', () => {
+      const id = '11111111-1111-4111-8111-111111111111';
+      const encoded = encodeCursor('not-a-timestamp', id);
+      expect(decodeTimestampCursor(encoded ?? undefined)).toBeNull();
+    });
   });
 });

--- a/apps/api/src/routes/mobile.cursor.test.ts
+++ b/apps/api/src/routes/mobile.cursor.test.ts
@@ -73,5 +73,20 @@ describe('mobile route cursor helpers', () => {
       const encoded = encodeCursor('not-a-timestamp', id);
       expect(decodeTimestampCursor(encoded ?? undefined)).toBeNull();
     });
+
+    it('rejects a key that is a valid JS Date but out of Postgres timestamp range', () => {
+      // `new Date(-8640000000000000).toISOString()` — JS's own minimum
+      // representable date — parses fine as a `Date` (not NaN), but sits
+      // nowhere near Postgres `timestamp`'s actual range and would 500 the
+      // route on the `::timestamp` cast instead of failing cleanly here.
+      // A `Number.isNaN(new Date(key).getTime())` check alone does not catch
+      // this; the regex on the exact `to_char` output shape does.
+      const id = '11111111-1111-4111-8111-111111111111';
+      const extreme = new Date(-8640000000000000).toISOString();
+      expect(extreme).toBe('-271821-04-20T00:00:00.000Z');
+      expect(Number.isNaN(new Date(extreme).getTime())).toBe(false);
+      const encoded = encodeCursor(extreme, id);
+      expect(decodeTimestampCursor(encoded ?? undefined)).toBeNull();
+    });
   });
 });

--- a/apps/api/src/routes/mobile.test.ts
+++ b/apps/api/src/routes/mobile.test.ts
@@ -178,6 +178,57 @@ const mockSelectLeftJoinChain = (result: unknown) => {
   };
 };
 
+// Same shape as `mockSelectOrderChain`, but records the `where` condition and
+// the `orderBy` args the route actually passed — used by the #3770 cursor
+// tests to assert the keyset predicate carries the right anchor and that
+// legacy vs. cursor mode order by different columns.
+const mockSelectOrderChainCapturing = (
+  result: unknown,
+  capture: { where?: unknown; orderByArgs?: unknown[] }
+) => ({
+  from: vi.fn().mockReturnValue({
+    where: vi.fn((where: unknown) => {
+      capture.where = where;
+      return {
+        orderBy: vi.fn((...args: unknown[]) => {
+          capture.orderByArgs = args;
+          return {
+            limit: vi.fn().mockReturnValue({
+              offset: vi.fn().mockResolvedValue(result)
+            })
+          };
+        })
+      };
+    })
+  })
+});
+
+// Same idea as `mockSelectOrderChainCapturing`, for the inbox query's
+// leftJoin-then-where-then-orderBy shape.
+const mockSelectLeftJoinChainCapturing = (
+  result: unknown,
+  capture: { where?: unknown; orderByArgs?: unknown[] }
+) => {
+  const joinable: { leftJoin: unknown; where: unknown } = {} as never;
+  joinable.leftJoin = vi.fn().mockReturnValue(joinable);
+  joinable.where = vi.fn((where: unknown) => {
+    capture.where = where;
+    return {
+      orderBy: vi.fn((...args: unknown[]) => {
+        capture.orderByArgs = args;
+        return {
+          limit: vi.fn().mockReturnValue({
+            offset: vi.fn().mockResolvedValue(result)
+          })
+        };
+      })
+    };
+  });
+  return {
+    from: vi.fn().mockReturnValue(joinable)
+  };
+};
+
 const objectContains = (value: unknown, needle: string, seen = new WeakSet<object>()): boolean => {
   if (typeof value === 'string') return value === needle;
   if (!value || typeof value !== 'object') return false;
@@ -217,19 +268,19 @@ const mockDeleteReturning = (result: unknown) => ({
 describe('mobile cursor decoding', () => {
   it('returns null when the cursor id is not a UUID', () => {
     const cursor = Buffer.from(JSON.stringify({
-      ts: '2026-07-28T12:00:00.000Z',
+      key: '2026-07-28T12:00:00.000Z',
       id: 'not-a-uuid',
     })).toString('base64url');
 
     expect(decodeCursor(cursor)).toBeNull();
   });
 
-  it('decodes a cursor with a valid UUID id', () => {
+  it('decodes a cursor with a valid UUID id, key kept verbatim', () => {
     const id = '11111111-1111-4111-8111-111111111111';
-    const cursor = encodeCursor('2026-07-28T12:00:00.000Z', id);
+    const cursor = encodeCursor('2026-07-28T12:00:00.123456', id);
 
     expect(decodeCursor(cursor!)).toEqual({
-      ts: new Date('2026-07-28T12:00:00.000Z'),
+      key: '2026-07-28T12:00:00.123456',
       id,
     });
   });
@@ -901,6 +952,106 @@ describe('mobile routes', () => {
       ]);
       expect(db.select).toHaveBeenCalledTimes(2);
     });
+
+    // #3770: nextCursor used to be computed only inside `if (cursor)`, so a
+    // cold-start caller (no cursor to send) could never obtain one, and the
+    // Date round-trip truncated triggered_at to millisecond precision, which
+    // could skip rows sitting between the truncated cursor and the real
+    // boundary.
+    describe('cursor pagination (#3770)', () => {
+      const row = (id: string, triggeredAtIso: string, triggeredAtKey: string) => ({
+        id,
+        orgId: 'org-123',
+        status: 'active',
+        severity: 'critical',
+        title: `Alert ${id}`,
+        message: 'msg',
+        triggeredAt: new Date(triggeredAtIso),
+        triggeredAtKey,
+        acknowledgedAt: null,
+        resolvedAt: null,
+        deviceId: null,
+        deviceHostname: null,
+        deviceOsType: null,
+        deviceStatus: null,
+        category: null
+      });
+
+      it('a cold-start request (no cursor) returns a usable nextCursor when more rows exist', async () => {
+        // Deliberately give `triggeredAt` (the millisecond-capped Date) a
+        // DIFFERENT value than `triggeredAtKey` (the full-precision text) on
+        // the boundary row — if the route ever regresses to building the
+        // cursor from `triggeredAt` instead of `triggeredAtKey`, this proves
+        // it by asserting the exact string that comes back.
+        const rows = [
+          row('aaaaaaaa-0000-4000-8000-000000000001', '2026-07-28T12:00:00.999Z', '2026-07-28T12:00:00.999999'),
+          row('aaaaaaaa-0000-4000-8000-000000000002', '2026-07-28T11:00:00.111Z', '2026-07-28T11:00:00.111111'),
+          row('aaaaaaaa-0000-4000-8000-000000000003', '2026-07-28T10:00:00.000Z', '2026-07-28T10:00:00.000000')
+        ];
+        vi.mocked(db.select)
+          .mockReturnValueOnce(mockSelectWhereChain([{ count: 3 }]) as any)
+          .mockReturnValueOnce(mockSelectLeftJoinChain(rows) as any); // 3 rows for limit=2 => hasMore
+
+        const res = await app.request('/mobile/alerts/inbox?limit=2', { method: 'GET' });
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.data).toHaveLength(2);
+        expect(body.data.map((a: { id: string }) => a.id)).toEqual(['aaaaaaaa-0000-4000-8000-000000000001', 'aaaaaaaa-0000-4000-8000-000000000002']);
+        expect(body.pagination.total).toBe(3);
+        expect(body.pagination.nextCursor).not.toBeNull();
+
+        const decoded = decodeCursor(body.pagination.nextCursor);
+        // Full microsecond precision from `triggeredAtKey` — NOT the
+        // millisecond-truncated `triggeredAt.toISOString()` value.
+        expect(decoded).toEqual({ key: '2026-07-28T11:00:00.111111', id: 'aaaaaaaa-0000-4000-8000-000000000002' });
+      });
+
+      it('following nextCursor reaches the next page and terminates with nextCursor: null on the last page', async () => {
+        const page1Rows = [
+          row('aaaaaaaa-0000-4000-8000-000000000001', '2026-07-28T12:00:00.999Z', '2026-07-28T12:00:00.999999'),
+          row('aaaaaaaa-0000-4000-8000-000000000002', '2026-07-28T11:00:00.111Z', '2026-07-28T11:00:00.111111'),
+          row('aaaaaaaa-0000-4000-8000-000000000003', '2026-07-28T10:00:00.000Z', '2026-07-28T10:00:00.000000')
+        ];
+        vi.mocked(db.select)
+          .mockReturnValueOnce(mockSelectWhereChain([{ count: 3 }]) as any)
+          .mockReturnValueOnce(mockSelectLeftJoinChain(page1Rows) as any);
+
+        const page1 = await app.request('/mobile/alerts/inbox?limit=2', { method: 'GET' });
+        const page1Body = await page1.json();
+        const cursor: string = page1Body.pagination.nextCursor;
+        expect(cursor).toBeTruthy();
+
+        const captured: { where?: unknown; orderByArgs?: unknown[] } = {};
+        vi.mocked(db.select)
+          .mockReturnValueOnce(mockSelectWhereChain([{ count: 3 }]) as any)
+          .mockReturnValueOnce(
+            mockSelectLeftJoinChainCapturing(
+              [row('aaaaaaaa-0000-4000-8000-000000000003', '2026-07-28T10:00:00.000Z', '2026-07-28T10:00:00.000000')],
+              captured
+            ) as any
+          );
+
+        const page2 = await app.request(`/mobile/alerts/inbox?limit=2&cursor=${encodeURIComponent(cursor)}`, {
+          method: 'GET'
+        });
+        const page2Body = await page2.json();
+
+        // No overlap with page 1, no gap before alert-3 — the walk continued
+        // from exactly where it left off.
+        expect(page2Body.data.map((a: { id: string }) => a.id)).toEqual(['aaaaaaaa-0000-4000-8000-000000000003']);
+        // Last page: only 1 row came back for limit=2, so there is nothing more.
+        expect(page2Body.pagination.nextCursor).toBeNull();
+
+        // The keyset predicate must carry the cursor's FULL-precision key,
+        // untruncated — this is the actual #3770 regression check. A
+        // `.toISOString()` round-trip would have collapsed it to
+        // '2026-07-28T11:00:00.111Z' and could skip real rows between the
+        // truncated value and the true boundary.
+        expect(objectContains(captured.where, '2026-07-28T11:00:00.111111')).toBe(true);
+        expect(objectContains(captured.where, '2026-07-28T11:00:00.111Z')).toBe(false);
+      });
+    });
   });
 
   describe('POST /mobile/alerts/:id/acknowledge', () => {
@@ -1368,6 +1519,100 @@ describe('mobile routes', () => {
       expect(body.data.map((row: { siteId: string }) => row.siteId)).toEqual([SITE_ALLOWED, SITE_DENIED]);
       expect(objectContains(captured.countWhere, SITE_ALLOWED)).toBe(false);
       expect(objectContains(captured.rowsWhere, SITE_ALLOWED)).toBe(false);
+    });
+
+    // #3770: nextCursor used to be computed only inside `if (cursor)`, so a
+    // cold-start caller (no cursor to send) could never obtain one. The
+    // keyset also used to run on the nullable, mutable `last_seen_at` column;
+    // it now keys cursor mode on the NOT NULL, immutable `hostname` instead
+    // (ported from `routes/devices/core.ts`), and only cursor mode (no
+    // explicit `?page=`, or a `cursor` present) ever returns a nextCursor —
+    // legacy `?page=N` keeps its old `last_seen_at DESC` order and never
+    // upgrades into the keyset mid-walk.
+    describe('cursor pagination (#3770)', () => {
+      const row = (id: string, hostname: string) => ({
+        id,
+        orgId: 'org-123',
+        siteId: 'site-1',
+        hostname,
+        displayName: hostname,
+        osType: 'linux',
+        status: 'online',
+        lastSeenAt: new Date()
+      });
+
+      it('a cold-start request (no page, no cursor) orders by hostname ASC and returns a nextCursor when more rows exist', async () => {
+        const captured: { orderByArgs?: unknown[] } = {};
+        const rows = [row('dddddddd-0000-4000-8000-00000000000a', 'a-host'), row('dddddddd-0000-4000-8000-00000000000b', 'b-host'), row('dddddddd-0000-4000-8000-00000000000c', 'c-host')];
+        vi.mocked(db.select)
+          .mockReturnValueOnce(mockSelectWhereChain([{ count: 3 }]) as any)
+          .mockReturnValueOnce(mockSelectOrderChainCapturing(rows, captured) as any); // 3 rows for limit=2 => hasMore
+
+        const res = await app.request('/mobile/devices?limit=2', { method: 'GET' });
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.data.map((d: { id: string }) => d.id)).toEqual(['dddddddd-0000-4000-8000-00000000000a', 'dddddddd-0000-4000-8000-00000000000b']);
+        expect(body.pagination.total).toBe(3);
+        expect(body.pagination.nextCursor).not.toBeNull();
+
+        const decoded = decodeCursor(body.pagination.nextCursor);
+        expect(decoded).toEqual({ key: 'b-host', id: 'dddddddd-0000-4000-8000-00000000000b' });
+
+        // Cursor mode orders by hostname ASC, id ASC — not last_seen_at.
+        expect(captured.orderByArgs?.length).toBe(2);
+        expect(objectContains(captured.orderByArgs, 'hostname')).toBe(true);
+      });
+
+      it('following nextCursor reaches the next page (no duplicates/gaps) and returns nextCursor: null once exhausted', async () => {
+        vi.mocked(db.select)
+          .mockReturnValueOnce(mockSelectWhereChain([{ count: 3 }]) as any)
+          .mockReturnValueOnce(
+            mockSelectOrderChain([row('dddddddd-0000-4000-8000-00000000000a', 'a-host'), row('dddddddd-0000-4000-8000-00000000000b', 'b-host'), row('dddddddd-0000-4000-8000-00000000000c', 'c-host')]) as any
+          );
+
+        const page1 = await app.request('/mobile/devices?limit=2', { method: 'GET' });
+        const page1Body = await page1.json();
+        const cursor: string = page1Body.pagination.nextCursor;
+        expect(cursor).toBeTruthy();
+
+        const captured: { where?: unknown; orderByArgs?: unknown[] } = {};
+        vi.mocked(db.select)
+          .mockReturnValueOnce(mockSelectWhereChain([{ count: 3 }]) as any)
+          .mockReturnValueOnce(mockSelectOrderChainCapturing([row('dddddddd-0000-4000-8000-00000000000c', 'c-host')], captured) as any);
+
+        const page2 = await app.request(`/mobile/devices?limit=2&cursor=${encodeURIComponent(cursor)}`, {
+          method: 'GET'
+        });
+        const page2Body = await page2.json();
+
+        // No overlap with page 1 ([dev-a, dev-b]), no gap before dev-c.
+        expect(page2Body.data.map((d: { id: string }) => d.id)).toEqual(['dddddddd-0000-4000-8000-00000000000c']);
+        // Only 1 row came back for limit=2 — nothing more to walk.
+        expect(page2Body.pagination.nextCursor).toBeNull();
+
+        // The keyset predicate anchors on page 1's last row (b-host / dev-b).
+        expect(objectContains(captured.where, 'b-host')).toBe(true);
+        expect(objectContains(captured.where, 'dddddddd-0000-4000-8000-00000000000b')).toBe(true);
+      });
+
+      it('an explicit ?page=N request keeps the legacy last_seen_at order and never returns a nextCursor', async () => {
+        const captured: { orderByArgs?: unknown[] } = {};
+        vi.mocked(db.select)
+          .mockReturnValueOnce(mockSelectWhereChain([{ count: 3 }]) as any)
+          .mockReturnValueOnce(
+            mockSelectOrderChainCapturing([row('dddddddd-0000-4000-8000-00000000000a', 'a-host'), row('dddddddd-0000-4000-8000-00000000000b', 'b-host')], captured) as any
+          );
+
+        const res = await app.request('/mobile/devices?page=1&limit=1', { method: 'GET' });
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        // Legacy contract: never mints a cursor, even though 2 rows came back
+        // for limit=1 (hasMore would be true in cursor mode).
+        expect(body.pagination.nextCursor).toBeNull();
+        expect(objectContains(captured.orderByArgs, 'last_seen_at')).toBe(true);
+      });
     });
   });
 

--- a/apps/api/src/routes/mobile.ts
+++ b/apps/api/src/routes/mobile.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { scriptParametersSchema } from '@breeze/shared';
-import { and, desc, eq, gte, ilike, inArray, like, ne, or, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, gte, ilike, inArray, like, ne, or, sql } from 'drizzle-orm';
 import { createHash } from 'crypto';
 import { db } from '../db';
 import {
@@ -71,28 +71,46 @@ function getPagination(query: { page?: string; limit?: string }) {
   return { page, limit, offset: (page - 1) * limit };
 }
 
-// Keyset cursor: opaque base64url JSON {ts,id}. Optional and additive — when
+// Keyset cursor: opaque base64url JSON {key,id}. Optional and additive — when
 // not supplied, page/limit semantics are unchanged. When supplied, paginates
-// past the (timestamp,id) pair on the ordering column.
+// past the (key,id) pair on the route's chosen ordering column.
+//
+// `key` is carried as a raw, already-serialized string and never re-parsed
+// into a JS `Date` here — `Date` only holds millisecond precision, so
+// round-tripping a Postgres `timestamp` (microsecond precision) through one
+// truncates it and can skip rows whose actual value sits between the
+// truncated cursor and the next real boundary (#3770). Callers that key on a
+// timestamp column are responsible for reading it back as raw text (see
+// `/alerts/inbox`'s `triggeredAtKey`) rather than a parsed `Date`; callers
+// that key on a NOT NULL string column (e.g. `/devices`'s `hostname`, ported
+// from `routes/devices/core.ts`) just pass the string through.
 // Exported for unit testing.
-export type CursorTuple = { ts: Date; id: string };
-export function encodeCursor(ts: Date | string | null | undefined, id: string): string | null {
-  if (!ts || !id) return null;
-  const iso = ts instanceof Date ? ts.toISOString() : ts;
-  return Buffer.from(JSON.stringify({ ts: iso, id }), 'utf8').toString('base64url');
+export type CursorTuple = { key: string; id: string };
+export function encodeCursor(key: string | null | undefined, id: string | null | undefined): string | null {
+  if (!key || !id) return null;
+  return Buffer.from(JSON.stringify({ key, id }), 'utf8').toString('base64url');
 }
 export function decodeCursor(raw: string | undefined): CursorTuple | null {
   if (!raw) return null;
   try {
     const json = Buffer.from(raw, 'base64url').toString('utf8');
-    const parsed = JSON.parse(json) as { ts?: unknown; id?: unknown };
-    if (typeof parsed.ts !== 'string' || typeof parsed.id !== 'string' || !UUID_REGEX.test(parsed.id)) return null;
-    const ts = new Date(parsed.ts);
-    if (Number.isNaN(ts.getTime())) return null;
-    return { ts, id: parsed.id };
+    const parsed = JSON.parse(json) as { key?: unknown; id?: unknown };
+    if (typeof parsed.key !== 'string' || parsed.key.length === 0) return null;
+    if (typeof parsed.id !== 'string' || !UUID_REGEX.test(parsed.id)) return null;
+    return { key: parsed.key, id: parsed.id };
   } catch {
     return null;
   }
+}
+
+// `/alerts/inbox` keys on a timestamp column, so on top of the structural
+// checks above, reject a cursor whose `key` doesn't even parse as a
+// timestamp — otherwise it reaches the raw SQL comparison in the route and
+// Postgres 500s on the bad cast instead of a clean "start over".
+export function decodeTimestampCursor(raw: string | undefined): CursorTuple | null {
+  const cursor = decodeCursor(raw);
+  if (!cursor) return null;
+  return Number.isNaN(new Date(cursor.key).getTime()) ? null : cursor;
 }
 
 /**
@@ -785,6 +803,18 @@ mobileRoutes.delete(
 //   - Cursor: opaque `cursor` from a prior response's `nextCursor`; keyset on
 //     (triggered_at DESC, id DESC). Stable under concurrent inserts and cheap
 //     on deep pages. When `cursor` is supplied, `page` is ignored.
+//
+// `nextCursor` is computed on EVERY response, cursor or not — including the
+// very first page/limit request (#3770). `triggered_at` is NOT NULL and
+// write-once (never updated after insert), so ordering never needs a
+// NULLS-LAST branch or an immutable-column swap the way `/devices` does
+// below. It DOES need full precision: Postgres keeps six fractional digits,
+// but a JS `Date` — what a plain Drizzle column read produces — only holds
+// three, so round-tripping the cursor through one can truncate a boundary
+// and skip rows sitting between the truncated value and the next real one.
+// `triggeredAtKey` reads the same column back as raw microsecond text via
+// `to_char` instead, and that text — never a `Date` — is what goes into the
+// token and the keyset predicate.
 mobileRoutes.get(
   '/alerts/inbox',
   requireScope('organization', 'partner', 'system'),
@@ -794,7 +824,7 @@ mobileRoutes.get(
     const auth = c.get('auth');
     const query = c.req.valid('query');
     const { page, limit, offset } = getPagination(query);
-    const cursor = decodeCursor(query.cursor);
+    const cursor = decodeTimestampCursor(query.cursor);
 
     const orgCheck = await getOrgIdsForAuth(auth, query.orgId);
     if (orgCheck.error) {
@@ -827,7 +857,7 @@ mobileRoutes.get(
 
     if (cursor) {
       conditions.push(
-        sql`(${alerts.triggeredAt} < ${cursor.ts.toISOString()} OR (${alerts.triggeredAt} = ${cursor.ts.toISOString()} AND ${alerts.id} < ${cursor.id}))`
+        sql`(${alerts.triggeredAt} < ${cursor.key}::timestamp OR (${alerts.triggeredAt} = ${cursor.key}::timestamp AND ${alerts.id} < ${cursor.id}::uuid))`
       );
     }
 
@@ -839,7 +869,10 @@ mobileRoutes.get(
       .where(whereCondition);
     const total = Number(countResult[0]?.count ?? 0);
 
-    const fetchLimit = cursor ? limit + 1 : limit;
+    // Always over-fetch by one to know whether another page exists — not
+    // gated on `cursor`, or a cold-start caller's first response could never
+    // carry a usable `nextCursor` (#3770).
+    const fetchLimit = limit + 1;
     const alertRows = await db
       .select({
         id: alerts.id,
@@ -849,6 +882,9 @@ mobileRoutes.get(
         title: alerts.title,
         message: alerts.message,
         triggeredAt: alerts.triggeredAt,
+        // Full microsecond-precision text of the same column, for the cursor
+        // only — see the route comment above. Never surfaced in `data`.
+        triggeredAtKey: sql<string>`to_char(${alerts.triggeredAt}, 'YYYY-MM-DD"T"HH24:MI:SS.US')`,
         acknowledgedAt: alerts.acknowledgedAt,
         resolvedAt: alerts.resolvedAt,
         deviceId: alerts.deviceId,
@@ -870,15 +906,12 @@ mobileRoutes.get(
       .limit(fetchLimit)
       .offset(cursor ? 0 : offset);
 
-    let trimmedRows = alertRows;
+    const hasMore = alertRows.length > limit;
+    const trimmedRows = hasMore ? alertRows.slice(0, limit) : alertRows;
     let nextCursor: string | null = null;
-    if (cursor) {
-      const hasMore = alertRows.length > limit;
-      trimmedRows = hasMore ? alertRows.slice(0, limit) : alertRows;
-      const last = trimmedRows[trimmedRows.length - 1];
-      if (hasMore && last) {
-        nextCursor = encodeCursor(last.triggeredAt, last.id);
-      }
+    const last = trimmedRows[trimmedRows.length - 1];
+    if (hasMore && last) {
+      nextCursor = encodeCursor(last.triggeredAtKey, last.id);
     }
 
     const data = trimmedRows.map(alert => ({
@@ -1120,10 +1153,23 @@ mobileRoutes.post(
 // GET /devices - Get simplified device list for mobile
 //
 // Pagination is dual-mode (additive):
-//   - Legacy: page+limit; response carries `total` so callers can show "N of M".
-//   - Cursor: opaque `cursor` from a prior response's `nextCursor`; keyset on
-//     (last_seen_at DESC, id DESC). Stable under concurrent inserts and cheap
-//     on deep pages. When `cursor` is supplied, `page` is ignored.
+//   - Legacy: an EXPLICIT `?page=N` (no `cursor`); response carries `total`
+//     so callers can show "N of M". Keeps the pre-existing `last_seen_at
+//     DESC` order, and never returns a `nextCursor` — this contract doesn't
+//     upgrade into cursor mode mid-walk (ordering differs — see below).
+//   - Cursor: the DEFAULT — no `page` given, or an explicit `cursor` from a
+//     prior response's `nextCursor`. Keyset on `(hostname ASC, id ASC)`,
+//     ported from `routes/devices/core.ts`'s cursor mode rather than
+//     `last_seen_at`, because `last_seen_at` is both nullable (Postgres
+//     sorts NULLs first on DESC with no NULLS LAST clause, so never-checked-
+//     in devices would lead the walk) and mutable (every heartbeat rewrites
+//     it, so a device can cross the page boundary mid-walk and be skipped
+//     entirely). `hostname` is NOT NULL and effectively immutable, so the
+//     keyset is stable under concurrent heartbeats. This is a genuine
+//     ordering change for any caller that doesn't pass `page` (#3770) —
+//     intentional; the mobile client already re-sorts this list client-side
+//     (see `screens/devices/deviceListFilters.ts`) and never reads
+//     `nextCursor` today, so it is unaffected either way.
 mobileRoutes.get(
   '/devices',
   requireScope('organization', 'partner', 'system'),
@@ -1133,6 +1179,9 @@ mobileRoutes.get(
     const auth = c.get('auth');
     const query = c.req.valid('query');
     const { page, limit, offset } = getPagination(query);
+    // Cursor mode is the default (matches `routes/devices/core.ts`): an
+    // explicit `?page=N` with no `cursor` opts into the legacy contract.
+    const isCursorMode = query.page === undefined || query.cursor !== undefined;
     const cursor = decodeCursor(query.cursor);
 
     const orgCheck = await getOrgIdsForAuth(auth, query.orgId);
@@ -1169,8 +1218,10 @@ mobileRoutes.get(
     }
 
     if (cursor) {
+      // Tuple comparison on a NOT NULL pair needs no NULLS branch — unlike
+      // the previous `last_seen_at` keyset, there's only one phase to walk.
       conditions.push(
-        sql`(${devices.lastSeenAt} < ${cursor.ts.toISOString()} OR (${devices.lastSeenAt} = ${cursor.ts.toISOString()} AND ${devices.id} < ${cursor.id}))`
+        sql`(${devices.hostname}, ${devices.id}) > (${cursor.key}, ${cursor.id}::uuid)`
       );
     }
 
@@ -1182,7 +1233,10 @@ mobileRoutes.get(
       .where(whereCondition);
     const total = Number(countResult[0]?.count ?? 0);
 
-    const fetchLimit = cursor ? limit + 1 : limit;
+    // Always over-fetch by one to know whether another page exists — not
+    // gated on `cursor`, or a cold-start caller's first response could never
+    // carry a usable `nextCursor` (#3770).
+    const fetchLimit = limit + 1;
     const deviceRows = await db
       .select({
         id: devices.id,
@@ -1196,18 +1250,20 @@ mobileRoutes.get(
       })
       .from(devices)
       .where(whereCondition)
-      .orderBy(desc(devices.lastSeenAt), desc(devices.id))
+      .orderBy(...(isCursorMode ? [asc(devices.hostname), asc(devices.id)] : [desc(devices.lastSeenAt), desc(devices.id)]))
       .limit(fetchLimit)
       .offset(cursor ? 0 : offset);
 
-    let items = deviceRows;
+    const hasMore = deviceRows.length > limit;
+    const items = hasMore ? deviceRows.slice(0, limit) : deviceRows;
+    // Legacy `?page=N` never returns a nextCursor — its order (`last_seen_at
+    // DESC`) doesn't match the keyset above, so a cursor minted from it would
+    // silently switch a walking client onto a different ordering (#3770).
     let nextCursor: string | null = null;
-    if (cursor) {
-      const hasMore = deviceRows.length > limit;
-      items = hasMore ? deviceRows.slice(0, limit) : deviceRows;
+    if (isCursorMode) {
       const last = items[items.length - 1];
       if (hasMore && last) {
-        nextCursor = encodeCursor(last.lastSeenAt, last.id);
+        nextCursor = encodeCursor(last.hostname, last.id);
       }
     }
 

--- a/apps/api/src/routes/mobile.ts
+++ b/apps/api/src/routes/mobile.ts
@@ -1243,10 +1243,12 @@ mobileRoutes.get(
       .where(whereCondition);
     const total = Number(countResult[0]?.count ?? 0);
 
-    // Always over-fetch by one to know whether another page exists — not
-    // gated on `cursor`, or a cold-start caller's first response could never
-    // carry a usable `nextCursor` (#3770).
-    const fetchLimit = limit + 1;
+    // Over-fetch by one to know whether another page exists — not gated on
+    // `cursor` (a cold-start caller's first response could otherwise never
+    // carry a usable `nextCursor`, #3770), but legacy `?page=N` never mints
+    // one anyway (see above), so there's nothing to gain from the extra row
+    // there. Matches devices/core.ts's identical guard.
+    const fetchLimit = isCursorMode ? limit + 1 : limit;
     const deviceRows = await db
       .select({
         id: devices.id,

--- a/apps/api/src/routes/mobile.ts
+++ b/apps/api/src/routes/mobile.ts
@@ -107,10 +107,20 @@ export function decodeCursor(raw: string | undefined): CursorTuple | null {
 // checks above, reject a cursor whose `key` doesn't even parse as a
 // timestamp — otherwise it reaches the raw SQL comparison in the route and
 // Postgres 500s on the bad cast instead of a clean "start over".
+//
+// Matches the EXACT shape `to_char(..., 'YYYY-MM-DD"T"HH24:MI:SS.US')` emits
+// on the encode side (4-digit year, fixed-width fields, 6-digit
+// microseconds) rather than deferring to `new Date(...)` parseability —
+// `Date` accepts a much wider grammar than Postgres `timestamp` does, so a
+// crafted `key` like `-271821-04-20T00:00:00.000Z` parses fine as a `Date`
+// (round-trips through `.getTime()` with no NaN) but sits nowhere near
+// Postgres's actual range and 500s on `::timestamp` instead of failing this
+// check.
+const TIMESTAMP_CURSOR_KEY_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}$/;
 export function decodeTimestampCursor(raw: string | undefined): CursorTuple | null {
   const cursor = decodeCursor(raw);
   if (!cursor) return null;
-  return Number.isNaN(new Date(cursor.key).getTime()) ? null : cursor;
+  return TIMESTAMP_CURSOR_KEY_RE.test(cursor.key) ? cursor : null;
 }
 
 /**

--- a/apps/mobile/src/services/api.ts
+++ b/apps/mobile/src/services/api.ts
@@ -1033,27 +1033,25 @@ export interface PagedResult<T> {
  * Fetch ONE page of a mobile list endpoint and report how much of the set it
  * represents.
  *
- * Deliberately one request, not a walk. Neither pagination mode on
- * `/mobile/devices` or `/mobile/alerts/inbox` can produce a trustworthy
- * full-set walk today:
+ * Deliberately one request, not a walk — even though the server-side bug that
+ * originally justified this (#3770) is now fixed: `/mobile/devices` and
+ * `/mobile/alerts/inbox` both compute `nextCursor` on every response,
+ * including a cold-start caller's first one, and — for `/devices` — the
+ * default (no `?page=`) request now runs on the immutable, NOT NULL
+ * `hostname` keyset instead of the mutable, nullable `last_seen_at` one, so a
+ * caller that walks `nextCursor` no longer risks the skip/dup hazards
+ * described below for that path. `/alerts/inbox` additionally used to
+ * truncate its cursor to millisecond precision, which could skip rows sitting
+ * between the truncated boundary and the real one; the cursor now carries the
+ * full microsecond value.
  *
- *  - CURSOR mode is unreachable. The routes compute `nextCursor` only inside
- *    `if (cursor)`, so a cold-start caller — which has no cursor to send — gets
- *    `nextCursor: null` on its first response and can never obtain the token
- *    for page two. The previous walk here treated that null as clean
- *    exhaustion, so it stopped after one page AND suppressed its own truncation
- *    warning.
- *  - OFFSET mode is reachable but skews. Both routes order by a MUTABLE key
- *    (`last_seen_at`, rewritten by every heartbeat), so rows reorder between
- *    page requests: page two can repeat rows page one already returned and
- *    never return the ones that moved ahead of the offset. A row-count check
- *    cannot detect that, because the duplicates make the count come out right.
- *
- * So the walk is not the fix — the honest claim is. One page, plus the server's
- * exact `total`, lets the caller say "showing N of M" instead of presenting a
- * sample as the whole set. Fixing the underlying keyset (the way
- * `routes/devices/core.ts` did, by keying cursor mode on the NOT NULL,
- * immutable `hostname`) is filed separately.
+ * None of that makes a client-side walk trustworthy on its own — it only
+ * removes the server-side reasons one couldn't be. Implementing the walk
+ * (retry/backoff, mid-walk auth/network failure, cancellation, resuming a
+ * mid-flight session) is real client work nobody has done, so this still
+ * fetches one page and reports honestly whether it's the whole set: the
+ * server's exact `total`, plus this page, lets the caller say "showing N of
+ * M" instead of presenting a sample as the whole thing.
  */
 async function fetchPage<TRow>(
   buildPath: (params: URLSearchParams) => string,

--- a/apps/mobile/src/services/listPaging.test.ts
+++ b/apps/mobile/src/services/listPaging.test.ts
@@ -25,11 +25,16 @@ const row = (id: string) => ({ id, hostname: id, status: 'online', orgId: 'o1' }
 const rows = (n: number) => Array.from({ length: n }, (_, i) => row(`d${i}`));
 
 /**
- * A response shaped like the REAL server: `nextCursor` is always null for a
- * caller that sent no cursor, because the route computes the token only inside
- * `if (cursor)`. An earlier version of this file returned a cursor on page one
- * — a contract the server has never had — and so certified a client walk that
- * in production stopped after a single page and called it a whole fleet.
+ * `nextCursor: null` here regardless of input is deliberate, not a claim
+ * about what the real server returns today: the server now DOES mint a
+ * `nextCursor` on a cold-start caller's first response (#3770). `fetchPage`
+ * below never reads `nextCursor` at all — it fetches exactly one page and
+ * reports honestly off `total` — so these fixtures are only proving that
+ * behavior is nextCursor-agnostic, not asserting the token's value. An
+ * earlier version of this file returned a cursor on page one and asserted the
+ * client walked it, which certified a walk that in production stopped after a
+ * single page (because the server-side bug made that cursor unobtainable) and
+ * called it a whole fleet.
  */
 function page(data: unknown[], total: number | null) {
   return () =>


### PR DESCRIPTION
## Summary

`GET /mobile/alerts/inbox` and `GET /mobile/devices` both computed `nextCursor` only inside `if (cursor)`. A cold-start caller has no cursor to send, so its first response always carried `nextCursor: null` — there was no path from "first request" to "a cursor", making cursor mode documented, unit-tested at the encode/decode layer, and unreachable end to end (#3770).

Making it reachable exposed two real keyset hazards once actually walked, both described in the issue:

- **`/mobile/devices`** keyed on `last_seen_at`, which is nullable (Postgres sorts NULLs first on `DESC` with no `NULLS LAST`) and mutable (every heartbeat rewrites it, so a device can cross the page boundary mid-walk and be skipped). Cursor mode now keys on `(hostname ASC, id ASC)` instead — NOT NULL and effectively immutable — porting the pattern already used by `routes/devices/core.ts`. Legacy `?page=N` keeps the pre-existing `last_seen_at DESC` order and never mints a `nextCursor`, since the two orders aren't interchangeable mid-walk (mirrors `core.ts`'s own mode split).
- **`/mobile/alerts/inbox`** round-tripped `triggered_at` through a JS `Date` to build the cursor. Postgres keeps six fractional digits; `Date` only holds three (milliseconds), so a truncated cursor's `<` comparison could skip real rows sitting between the truncated boundary and the true one. The route now reads the same column back as raw microsecond text via `to_char(...)` for the cursor only (`triggeredAtKey`, never surfaced in `data`), and the cursor codec (`encodeCursor`/`decodeCursor`) never re-parses `key` into a `Date` at all — it's carried as an opaque string end to end.

Both routes always over-fetch by `limit + 1` now (not gated on `cursor`) so `nextCursor` is available on the first page/limit request, and `total` is still returned in every response as before.

Per `apps/mobile/src/services/api.ts`, the mobile client already deliberately fetches only one page and never reads `nextCursor` (a separate, intentional mitigation from #3769) — so it's unaffected by either the reachability fix or the devices ordering change. Updated its stale doc comments (and a test-fixture comment in `listPaging.test.ts`) that described the now-fixed server bug as current.

## Changes

- `apps/api/src/routes/mobile.ts`:
  - Cursor codec (`CursorTuple`, `encodeCursor`, `decodeCursor`) now carries a generic `key: string` instead of `ts: Date` — never round-trips through `Date`. Added `decodeTimestampCursor` for the alerts route, which additionally rejects a structurally-valid cursor whose `key` doesn't parse as a timestamp (so a bad cast can't 500 the route).
  - `/alerts/inbox`: always computes `nextCursor`; selects `triggeredAtKey` (raw `to_char` text) for the cursor instead of the `Date`-typed `triggeredAt`.
  - `/devices`: `isCursorMode` (mirrors `devices/core.ts`) — no `page` given, or a `cursor` present — switches ordering to `hostname ASC, id ASC` and only then mints a `nextCursor`; an explicit `?page=N` keeps `last_seen_at DESC` and never returns one.
- `apps/api/src/routes/mobile.cursor.test.ts`, `apps/api/src/routes/mobile.test.ts`: updated existing cursor-codec tests for the new `{key, id}` shape, and added coverage for the issue's three scenarios — first page returns `nextCursor`, following it yields the next page with no duplicates/gaps (verified via the captured keyset predicate), and the last page returns `nextCursor: null` — for both routes, plus a legacy `?page=N` regression test for `/devices` and `decodeTimestampCursor` coverage.
- `apps/mobile/src/services/api.ts`, `apps/mobile/src/services/listPaging.test.ts`: doc-comment updates only, no behavior change.

## Test plan

- [x] `cd apps/api && npx vitest run src/routes/mobile.cursor.test.ts src/routes/mobile.test.ts` — 84 passed, 2 skipped
- [x] `cd apps/api && npx vitest run src/routes/mobile.ackCas.test.ts src/routes/mobile.resolveCas.test.ts src/__tests__/helpers/routeScan.test.ts src/services/mobileDeviceIdentity.test.ts` — 51 passed (other mobile.ts consumers, unaffected)
- [x] `cd apps/mobile && npx vitest run src/services/listPaging.test.ts` — 8 passed
- [x] `cd apps/api && npx tsc --noEmit -p .` — clean
- [x] `cd apps/mobile && npx tsc --noEmit` — clean
- [x] `cd apps/api && npx eslint src/routes/mobile.ts src/routes/mobile.test.ts src/routes/mobile.cursor.test.ts` — clean

Closes #3770

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBxF7C8E5GxFnNcGf6kBVP