### PR TITLE
fix(web): let the SSO failure notice outrun the refresh eviction (#3704)

### DIFF
--- a/apps/web/src/components/auth/AuthOverlay.ssoFailureRace.test.tsx
+++ b/apps/web/src/components/auth/AuthOverlay.ssoFailureRace.test.tsx
@@ -67,6 +67,13 @@ describe('AuthOverlay SSO failure redirect vs. refresh eviction (#3704)', () => 
   beforeEach(async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     fetchCalls = [];
+    // login() is the only reset for two module-level latches these tests trip:
+    // handleSessionExpired's `sessionExpiryInFlight` (which would make a later
+    // test's eviction a silent no-op) and the #3704 SSO verdict.
+    useAuthStore.getState().login(
+      { id: 'u-7', email: 'locked@example.com', name: 'Locked Out', mfaEnabled: false },
+      { accessToken: 'reset', expiresInSeconds: 900 },
+    );
     useAuthStore.setState({ ...STALE_SESSION });
     window.history.replaceState({}, '', '/');
     const { navigateTo } = await import('../../lib/navigation');
@@ -222,5 +229,59 @@ describe('AuthOverlay SSO failure redirect vs. refresh eviction (#3704)', () => 
     await act(async () => {
       await gatedRequest;
     });
+  });
+
+  it('lands the SSO notice even when the redirect is a hard navigation that has not committed yet', async () => {
+    // navigateTo's own fallback: when the Astro transition throws it fires
+    // `window.location.replace` and returns, so the promise resolves with the
+    // address bar STILL on the old path. Awaiting it therefore proves nothing
+    // here, and handleSessionExpired's `/login` pathname guard misses — this is
+    // the residual hole that markSsoExchangeFailed closes.
+    const { navigateTo } = await import('../../lib/navigation');
+    vi.mocked(navigateTo).mockImplementation(async () => {
+      // Resolves without moving the URL, exactly like the fallback branch.
+    });
+
+    // jsdom refuses real navigations, so swap the whole location object and spy
+    // on replace(); the overlay only reads hash/pathname/search off it.
+    const originalLocation = window.location;
+    const replace = vi.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { pathname: '/', search: '', hash: '#ssoCode=stale-grant', replace, reload: vi.fn() },
+    });
+
+    try {
+      stubFetch({
+        '/sso/exchange': () => json(400, { error: 'Invalid or expired token exchange code' }),
+        '/auth/refresh': () => json(401, { error: 'invalid refresh token' }),
+      });
+
+      authStoreModule.armSsoLoginGate();
+      const gatedRequest = authStoreModule.fetchWithAuth('/config').catch(() => null);
+
+      render(<AuthOverlay />);
+      await act(async () => {
+        vi.advanceTimersByTime(60);
+      });
+
+      await waitFor(() => {
+        expect(refreshCalls().length).toBeGreaterThan(0);
+      });
+      await act(async () => {
+        await gatedRequest;
+      });
+
+      // The eviction DID win the race here — and that is fine, because it now
+      // carries the specific reason rather than the generic one.
+      await waitFor(() => {
+        expect(replace).toHaveBeenCalled();
+      });
+      const target = String(replace.mock.calls[0][0]);
+      expect(target).toBe('/login?error=sso_exchange_failed');
+      expect(target).not.toContain('reason=session-expired');
+    } finally {
+      Object.defineProperty(window, 'location', { configurable: true, value: originalLocation });
+    }
   });
 });

--- a/apps/web/src/components/auth/AuthOverlay.ssoFailureRace.test.tsx
+++ b/apps/web/src/components/auth/AuthOverlay.ssoFailureRace.test.tsx
@@ -1,0 +1,226 @@
+import { render, waitFor, act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../lib/navigation', () => ({
+  navigateTo: vi.fn(async () => {}),
+}));
+
+import AuthOverlay from './AuthOverlay';
+import { useAuthStore } from '../../stores/auth';
+import * as authStoreModule from '../../stores/auth';
+
+// Deliberately a FILE of its own rather than another block in
+// AuthOverlay.test.tsx: these cases assert that a refresh queued behind the SSO
+// gate really does reach the network once the gate opens, and the auth store's
+// refresh de-duplication (`tokenRefreshInFlight`) is module-level state that the
+// throttle suite in AuthOverlay.test.tsx leaves parked on a promise its fake
+// timers never resolve. Sharing a file makes these tests read green-or-red on
+// that leftover instead of on the behaviour under test; vitest's per-file module
+// isolation removes the coupling.
+
+// Issue #3704. #3700 gave a failed SSO exchange its own notice
+// (`/login?error=sso_exchange_failed`) and #3702 shipped the copy — but on the
+// failure path the user still read "Your session expired", which points away
+// from SSO and invites an infinite retry loop.
+//
+// The cause is an ordering bug, not a missing feature: `navigateTo` is an
+// ASYNC page transition, so issuing it un-awaited and settling the SSO gate on
+// the next line releases every queued refresh while the redirect is still in
+// flight. Those refreshes 401 against the same dead cookie, and
+// `handleSessionExpired`'s `window.location.replace(…&reason=session-expired)`
+// is a HARD navigation: it aborts the soft one and overwrites the URL.
+//
+// The fix is to settle the gate only once the redirect has COMMITTED. By then
+// the address bar is on /login, where `handleSessionExpired`'s own pathname
+// guard makes its redirect a no-op — so the specific reason survives.
+describe('AuthOverlay SSO failure redirect vs. refresh eviction (#3704)', () => {
+  // The enforce-SSO lockout arrival state: localStorage still says
+  // authenticated (tokens are memory-only), the refresh cookie is dead.
+  const STALE_SESSION = {
+    isAuthenticated: true,
+    isLoading: false,
+    tokens: null,
+    user: { id: 'u-7', email: 'locked@example.com', name: 'Locked Out', mfaEnabled: false },
+    sessionExpiredReason: null,
+    authThrottledUntil: null as number | null,
+  };
+
+  const originalFetch = global.fetch;
+  let fetchCalls: string[];
+
+  const json = (status: number, body: unknown) =>
+    new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+
+  function stubFetch(routes: Record<string, () => Response | Promise<Response>>) {
+    global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      fetchCalls.push(url);
+      for (const [needle, respond] of Object.entries(routes)) {
+        if (url.includes(needle)) return respond();
+      }
+      return json(200, {});
+    }) as typeof fetch;
+  }
+
+  const refreshCalls = () => fetchCalls.filter((u) => u.includes('/auth/refresh'));
+
+  beforeEach(async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    fetchCalls = [];
+    useAuthStore.setState({ ...STALE_SESSION });
+    window.history.replaceState({}, '', '/');
+    const { navigateTo } = await import('../../lib/navigation');
+    vi.mocked(navigateTo).mockReset();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    authStoreModule.settleSsoLoginGate();
+    vi.restoreAllMocks();
+    global.fetch = originalFetch;
+    vi.useRealTimers();
+    useAuthStore.setState({ ...STALE_SESSION, isAuthenticated: false, user: null });
+    window.history.replaceState({}, '', '/');
+    const { navigateTo } = await import('../../lib/navigation');
+    vi.mocked(navigateTo).mockImplementation(async () => {});
+  });
+
+  it('holds the gated refresh until the sso_exchange_failed redirect has committed', async () => {
+    const { navigateTo } = await import('../../lib/navigation');
+    let commitNavigation!: () => void;
+    const navigationCommitted = new Promise<void>((resolve) => {
+      commitNavigation = resolve;
+    });
+    // A real astro transition resolves only once the address bar is already on
+    // the destination. Model exactly that: the URL moves when — and not before
+    // — the navigation promise settles.
+    vi.mocked(navigateTo).mockImplementation(async (path: string) => {
+      await navigationCommitted;
+      window.history.replaceState({}, '', path);
+    });
+
+    stubFetch({
+      '/sso/exchange': () => json(400, { error: 'Invalid or expired token exchange code' }),
+      '/auth/refresh': () => json(401, { error: 'invalid refresh token' }),
+    });
+
+    authStoreModule.armSsoLoginGate();
+    // A sibling island's bootstrap fetch, queued behind the gate. Its 401 is
+    // the eviction that overwrote the URL on main.
+    const gatedRequest = authStoreModule.fetchWithAuth('/config').catch(() => null);
+    window.history.replaceState({}, '', '/#ssoCode=stale-grant');
+
+    render(<AuthOverlay />);
+    await act(async () => {
+      vi.advanceTimersByTime(60);
+    });
+
+    await waitFor(() => {
+      expect(navigateTo).toHaveBeenCalledWith('/login?error=sso_exchange_failed', { replace: true });
+    });
+
+    // THE REGRESSION: while the redirect is still in flight the gate must stay
+    // shut. On main it settled on the very next line, the queued refresh 401'd,
+    // and handleSessionExpired's hard replace won the race.
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(refreshCalls()).toHaveLength(0);
+    expect(useAuthStore.getState().sessionExpiredReason).toBeNull();
+
+    commitNavigation();
+    await act(async () => {
+      await navigationCommitted;
+      vi.advanceTimersByTime(50);
+    });
+
+    // Released now — and the eviction it triggers finds the address bar
+    // already on /login, so handleSessionExpired leaves the SSO reason alone.
+    await waitFor(() => {
+      expect(refreshCalls().length).toBeGreaterThan(0);
+    });
+    await act(async () => {
+      await gatedRequest;
+    });
+    expect(window.location.pathname).toBe('/login');
+    expect(window.location.search).toBe('?error=sso_exchange_failed');
+  });
+
+  it('holds the gate for a malformed grant too, whose bounce skips the exchange entirely', async () => {
+    const { navigateTo } = await import('../../lib/navigation');
+    let commitNavigation!: () => void;
+    const navigationCommitted = new Promise<void>((resolve) => {
+      commitNavigation = resolve;
+    });
+    vi.mocked(navigateTo).mockImplementation(async (path: string) => {
+      await navigationCommitted;
+      window.history.replaceState({}, '', path);
+    });
+
+    stubFetch({ '/auth/refresh': () => json(401, { error: 'invalid refresh token' }) });
+
+    authStoreModule.armSsoLoginGate();
+    const gatedRequest = authStoreModule.fetchWithAuth('/config').catch(() => null);
+    // Truncated link: the grant is present but its percent-encoding is broken,
+    // so there is no exchange to lose the race to — only the redirect.
+    window.history.replaceState({}, '', '/#ssoCode=%E0%A4%A');
+
+    render(<AuthOverlay />);
+    await act(async () => {
+      vi.advanceTimersByTime(60);
+    });
+
+    await waitFor(() => {
+      expect(navigateTo).toHaveBeenCalledWith('/login?error=sso_exchange_failed', { replace: true });
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(refreshCalls()).toHaveLength(0);
+
+    commitNavigation();
+    await act(async () => {
+      await navigationCommitted;
+      vi.advanceTimersByTime(50);
+    });
+    await waitFor(() => {
+      expect(refreshCalls().length).toBeGreaterThan(0);
+    });
+    await act(async () => {
+      await gatedRequest;
+    });
+    expect(window.location.search).toBe('?error=sso_exchange_failed');
+  });
+
+  it('still settles the gate when the redirect itself throws — a queued refresh is never stranded', async () => {
+    // Waiting on the navigation must not become a new way to deadlock: if
+    // navigateTo rejects (its own window.location fallback unavailable), the
+    // queued refreshes must still be released rather than hang until the
+    // gate's 15s timeout backstop.
+    const { navigateTo } = await import('../../lib/navigation');
+    vi.mocked(navigateTo).mockRejectedValue(new Error('navigation unavailable'));
+
+    stubFetch({
+      '/sso/exchange': () => json(400, { error: 'Invalid or expired token exchange code' }),
+      '/auth/refresh': () => json(401, { error: 'invalid refresh token' }),
+    });
+
+    authStoreModule.armSsoLoginGate();
+    const gatedRequest = authStoreModule.fetchWithAuth('/config').catch(() => null);
+    window.history.replaceState({}, '', '/#ssoCode=stale-grant');
+
+    render(<AuthOverlay />);
+    await act(async () => {
+      vi.advanceTimersByTime(60);
+    });
+
+    // Well inside SSO_LOGIN_GATE_TIMEOUT_MS (15s) — the release has to come
+    // from the redirect path settling the gate, not from the timeout.
+    await waitFor(() => {
+      expect(refreshCalls().length).toBeGreaterThan(0);
+    });
+    await act(async () => {
+      await gatedRequest;
+    });
+  });
+});

--- a/apps/web/src/components/auth/AuthOverlay.tsx
+++ b/apps/web/src/components/auth/AuthOverlay.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { bootstrapFromCfAccessRedirect, bootstrapFromSsoCode, restoreAccessTokenFromCookieDetailed, setThrottleMaskMounted, settleSsoLoginGate, useAuthStore } from '../../stores/auth';
+import { bootstrapFromCfAccessRedirect, bootstrapFromSsoCode, markSsoExchangeFailed, restoreAccessTokenFromCookieDetailed, setThrottleMaskMounted, settleSsoLoginGate, SSO_EXCHANGE_FAILED_LOGIN_PATH, useAuthStore } from '../../stores/auth';
 import { Loader2 } from 'lucide-react';
 import { navigateTo } from '../../lib/navigation';
+import * as Sentry from '@sentry/astro';
 // Initializes the shared i18next singleton. Islands hydrate independently, so
 // an island that hydrates before whichever other island happens to pull i18n in
 // would otherwise render raw keys (and mismatch the SSR markup).
@@ -57,29 +58,58 @@ function consumeCfAccessLoginParam(): boolean {
 
 // Single owner of the "the SSO handoff is terminally dead, bounce with the
 // specific notice" redirect. Every failure path below routes through here so
-// the gate-settling order can't drift apart between them.
+// the ordering can't drift apart between them.
 //
-// The ORDER is the whole point (#3704). `navigateTo` is an async page
-// transition; settling the gate before it commits releases every refresh queued
-// behind it, and a dead-cookie refresh's 401 evicts via handleSessionExpired,
-// whose `window.location.replace(…&reason=session-expired)` is a HARD
-// navigation — it aborts the soft one and overwrites the URL. The user then
-// reads "Your session expired", which points away from SSO and invites an
-// infinite retry loop, since signing in again just re-runs the same broken SSO
-// round trip. Awaiting the navigation first closes that race: by the time the
-// gate opens the address bar is already on /login, where handleSessionExpired's
-// own pathname guard makes its redirect a no-op, so the specific reason
-// survives. (The eviction itself is still correct and still runs — the SSO
-// exchange really did fail; only its redirect is redundant here.)
+// The problem (#3704): settling the gate releases every refresh queued behind
+// it, and a dead-cookie refresh's 401 evicts via handleSessionExpired, whose
+// `window.location.replace(…&reason=session-expired)` is a HARD navigation —
+// it aborts an in-flight soft one and overwrites the URL. The user then reads
+// "Your session expired", which points away from SSO and invites an infinite
+// retry loop, since signing in again just re-runs the same broken SSO round
+// trip. `navigateTo` is an async page transition, so issuing it un-awaited and
+// settling on the next line handed that race to the eviction every time.
+//
+// TWO mechanisms close it, because neither is sufficient alone:
+//
+//  1. Order. Awaiting the navigation means that by the time the gate opens the
+//     address bar is already on /login, where handleSessionExpired's own
+//     pathname guard makes its redirect a no-op. This holds whenever navigateTo
+//     completes a real Astro soft transition — `navigate()` resolves only after
+//     `history.replaceState` has moved the URL — which is the live path here,
+//     since AuthOverlay only ever renders under layouts that mount
+//     <ClientRouter />.
+//  2. Precedence. It does NOT hold on navigateTo's own fallback: when the
+//     transition throws, it fires `window.location.replace` and returns, having
+//     merely QUEUED a hard navigation, so the address bar has not moved yet and
+//     the guard in (1) misses. markSsoExchangeFailed() covers that gap by
+//     making the eviction redirect to the same URL instead of racing it.
+//
+// The eviction itself is still correct and still runs — the SSO exchange really
+// did fail. Only its generic *reason* was wrong.
 //
 // `finally`, not a plain sequence: waiting on the navigation must not become a
 // new way to deadlock. If it throws, the queued refreshes still have to be
 // released rather than hang on the gate's 15s timeout backstop.
 async function redirectToSsoExchangeFailed(): Promise<void> {
+  // Claimed BEFORE the navigation is issued, so an eviction that somehow beats
+  // us to the address bar still carries the SSO reason.
+  markSsoExchangeFailed();
   try {
-    await navigateTo('/login?error=sso_exchange_failed', { replace: true });
+    await navigateTo(SSO_EXCHANGE_FAILED_LOGIN_PATH, { replace: true });
   } catch (err) {
+    // Deliberately narrow, and NOT dead code: navigateTo already absorbs a
+    // failed transition and falls back to window.location internally, so
+    // reaching here means that fallback ALSO threw — the document has no
+    // working navigation left. Retrying it here would fail for the same
+    // reason, so the remaining recovery is the eviction above (which now
+    // carries the SSO reason) and the 10s safety net. Report it: this branch
+    // should never fire, and if it does we want to know rather than infer it
+    // from a support ticket about a stuck spinner.
     console.warn('[AuthOverlay] SSO error redirect failed', err);
+    Sentry.captureMessage('[AuthOverlay] SSO error redirect failed — no working navigation path', {
+      level: 'warning',
+      extra: { message: err instanceof Error ? err.message : String(err) },
+    });
   } finally {
     settleSsoLoginGate();
   }

--- a/apps/web/src/components/auth/AuthOverlay.tsx
+++ b/apps/web/src/components/auth/AuthOverlay.tsx
@@ -55,6 +55,36 @@ function consumeCfAccessLoginParam(): boolean {
   return true;
 }
 
+// Single owner of the "the SSO handoff is terminally dead, bounce with the
+// specific notice" redirect. Every failure path below routes through here so
+// the gate-settling order can't drift apart between them.
+//
+// The ORDER is the whole point (#3704). `navigateTo` is an async page
+// transition; settling the gate before it commits releases every refresh queued
+// behind it, and a dead-cookie refresh's 401 evicts via handleSessionExpired,
+// whose `window.location.replace(…&reason=session-expired)` is a HARD
+// navigation — it aborts the soft one and overwrites the URL. The user then
+// reads "Your session expired", which points away from SSO and invites an
+// infinite retry loop, since signing in again just re-runs the same broken SSO
+// round trip. Awaiting the navigation first closes that race: by the time the
+// gate opens the address bar is already on /login, where handleSessionExpired's
+// own pathname guard makes its redirect a no-op, so the specific reason
+// survives. (The eviction itself is still correct and still runs — the SSO
+// exchange really did fail; only its redirect is redundant here.)
+//
+// `finally`, not a plain sequence: waiting on the navigation must not become a
+// new way to deadlock. If it throws, the queued refreshes still have to be
+// released rather than hang on the gate's 15s timeout backstop.
+async function redirectToSsoExchangeFailed(): Promise<void> {
+  try {
+    await navigateTo('/login?error=sso_exchange_failed', { replace: true });
+  } catch (err) {
+    console.warn('[AuthOverlay] SSO error redirect failed', err);
+  } finally {
+    settleSsoLoginGate();
+  }
+}
+
 export default function AuthOverlay() {
   const { t } = useTranslation('auth');
   const { isAuthenticated, isLoading, tokens, sessionExpiredReason, authThrottledUntil } = useAuthStore();
@@ -133,8 +163,7 @@ export default function AuthOverlay() {
         // redirect and strip the error param.
         setIsRecovering(true);
         console.warn('[AuthOverlay] malformed ssoCode fragment; bouncing to login');
-        void navigateTo('/login?error=sso_exchange_failed', { replace: true });
-        settleSsoLoginGate();
+        void redirectToSsoExchangeFailed();
         return () => { cancelled = true; };
       }
       if (fragment.present && fragment.code) {
@@ -158,10 +187,10 @@ export default function AuthOverlay() {
               // dropping it re-arms the final !isAuthenticated branch, whose
               // bare `/login` redirect races this one and strips the error
               // param. The navigation below unmounts the overlay anyway.
-              // Gate settles AFTER the navigation is issued so a queued
-              // refresh's own eviction redirect can't beat this one.
-              void navigateTo('/login?error=sso_exchange_failed', { replace: true });
-              settleSsoLoginGate();
+              // Gate settles once that navigation has COMMITTED — merely
+              // issuing it first is not enough, see
+              // redirectToSsoExchangeFailed (#3704).
+              void redirectToSsoExchangeFailed();
               return;
             }
             settleSsoLoginGate();

--- a/apps/web/src/stores/auth.ssoLoginGate.test.ts
+++ b/apps/web/src/stores/auth.ssoLoginGate.test.ts
@@ -4,6 +4,7 @@ import {
   fetchWithAuth,
   handleSessionExpired,
   markSsoExchangeFailed,
+  restoreAccessTokenFromCookieDetailed,
   settleSsoLoginGate,
   SSO_EXCHANGE_FAILED_LOGIN_PATH,
   useAuthStore,
@@ -136,6 +137,45 @@ describe('a terminally failed SSO exchange outranks the generic expiry (#3704)',
       const target = String(loc.replace.mock.calls[0][0]);
       expect(target).toContain('reason=session-expired');
       expect(target).not.toContain('sso_exchange_failed');
+    } finally {
+      loc.restore();
+    }
+  });
+
+  it('does not let the verdict outlive a session that a plain refresh restored', async () => {
+    // The leak that login()-only clearing misses: every cookie-based recovery
+    // path (restoreAccessTokenFromCookieDetailed, fetchWithAuth's bootstrap and
+    // its 401 replay) lands on setTokens() WITHOUT calling login(). A stray
+    // `#ssoCode=` on a page whose refresh cookie is actually fine sets the
+    // verdict, the refresh then succeeds, and the user is legitimately signed
+    // in — an unrelated idle timeout hours later must not be reported as an SSO
+    // failure, nor drop its `next` deep link.
+    markSsoExchangeFailed();
+
+    global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes('/auth/refresh')) {
+        return new Response(
+          JSON.stringify({ tokens: { accessToken: 'restored', expiresInSeconds: 900 } }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      return new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as typeof fetch;
+    useAuthStore.setState({ isAuthenticated: true, tokens: null });
+
+    await expect(restoreAccessTokenFromCookieDetailed()).resolves.toBe('restored');
+
+    const loc = mockLocation('/tickets/42');
+    try {
+      handleSessionExpired('idle');
+      const target = String(loc.replace.mock.calls[0][0]);
+      expect(target).not.toContain('sso_exchange_failed');
+      expect(target).toContain('reason=idle');
+      // The deep link the SSO branch deliberately drops must survive here.
+      expect(target).toContain('next=');
     } finally {
       loc.restore();
     }

--- a/apps/web/src/stores/auth.ssoLoginGate.test.ts
+++ b/apps/web/src/stores/auth.ssoLoginGate.test.ts
@@ -2,7 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   armSsoLoginGate,
   fetchWithAuth,
+  handleSessionExpired,
+  markSsoExchangeFailed,
   settleSsoLoginGate,
+  SSO_EXCHANGE_FAILED_LOGIN_PATH,
   useAuthStore,
 } from './auth';
 
@@ -66,5 +69,89 @@ describe('SSO login gate holds token refreshes (#3700)', () => {
 
   it('settleSsoLoginGate is a safe no-op when no gate is armed', () => {
     expect(() => settleSsoLoginGate()).not.toThrow();
+  });
+});
+
+// #3704 second line of defence. Ordering (AuthOverlay awaits its redirect
+// before settling the gate) is enough only while `navigateTo` completes a real
+// Astro soft transition. Its fallback fires `window.location.replace` and
+// returns immediately, having merely QUEUED a hard navigation — the address bar
+// has not moved, so handleSessionExpired's `/login` pathname guard misses and
+// the released refresh's eviction would overwrite the notice all over again.
+// markSsoExchangeFailed makes the eviction land on the SAME url instead.
+describe('a terminally failed SSO exchange outranks the generic expiry (#3704)', () => {
+  // jsdom refuses a real navigation, so swap the whole location object (the
+  // same trick stores/auth.test.ts uses) and spy on replace().
+  function mockLocation(pathname: string, search = '') {
+    const originalLocation = window.location;
+    const replace = vi.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { pathname, search, hash: '', replace, reload: vi.fn() },
+    });
+    return {
+      replace,
+      restore: () => {
+        Object.defineProperty(window, 'location', { configurable: true, value: originalLocation });
+      },
+    };
+  }
+
+  const baseUser = { id: 'u-1', email: 'a@b.c', name: 'A', mfaEnabled: false };
+
+  beforeEach(() => {
+    // login() clears both the sessionExpiryInFlight latch and the SSO verdict,
+    // which are module singletons that outlive an individual test.
+    useAuthStore.getState().login(baseUser, { accessToken: 'a', expiresInSeconds: 900 });
+  });
+
+  afterEach(() => {
+    useAuthStore.getState().login(baseUser, { accessToken: 'a', expiresInSeconds: 900 });
+    useAuthStore.setState({ isAuthenticated: false, tokens: null, user: null });
+  });
+
+  it('evicts to the sso_exchange_failed notice instead of reason=session-expired', () => {
+    const loc = mockLocation('/dashboard');
+    try {
+      markSsoExchangeFailed();
+      handleSessionExpired('session-expired');
+
+      expect(loc.replace).toHaveBeenCalledTimes(1);
+      const target = String(loc.replace.mock.calls[0][0]);
+      expect(target).toBe(SSO_EXCHANGE_FAILED_LOGIN_PATH);
+      // The whole point: the generic reason must not be what the user reads.
+      expect(target).not.toContain('reason=session-expired');
+    } finally {
+      loc.restore();
+    }
+  });
+
+  it('leaves the ordinary expiry eviction untouched when no SSO exchange failed', () => {
+    // The positive counterpart: without this, the branch above could swallow
+    // every eviction and the suite would stay green.
+    const loc = mockLocation('/dashboard');
+    try {
+      handleSessionExpired('session-expired');
+
+      const target = String(loc.replace.mock.calls[0][0]);
+      expect(target).toContain('reason=session-expired');
+      expect(target).not.toContain('sso_exchange_failed');
+    } finally {
+      loc.restore();
+    }
+  });
+
+  it('does not let a previous attempt\'s SSO verdict leak into the next session', () => {
+    markSsoExchangeFailed();
+    // A fresh login is a new session — it must not inherit the old verdict.
+    useAuthStore.getState().login(baseUser, { accessToken: 'fresh', expiresInSeconds: 900 });
+
+    const loc = mockLocation('/dashboard');
+    try {
+      handleSessionExpired('session-expired');
+      expect(String(loc.replace.mock.calls[0][0])).toContain('reason=session-expired');
+    } finally {
+      loc.restore();
+    }
   });
 });

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -180,6 +180,9 @@ export const useAuthStore = create<AuthState>()(
         // Re-login clears any stale expiry state and re-arms
         // handleSessionExpired for the new session.
         sessionExpiryInFlight = false;
+        // Same reasoning for the SSO failure reason (#3704): a session that
+        // just logged in must not inherit a previous attempt's verdict.
+        ssoExchangeFailed = false;
         // A fresh login makes any pending throttle-recovery reload stale —
         // the session is already restored, don't reload out from under it.
         cancelThrottleReload();
@@ -772,6 +775,43 @@ export function settleSsoLoginGate(): void {
   ssoLoginGate = null;
 }
 
+/**
+ * Where a terminally failed SSO exchange sends the user.
+ *
+ * Exported so AuthOverlay's redirect and handleSessionExpired's eviction land
+ * on the BYTE-IDENTICAL URL. That is what makes it harmless for either of them
+ * to win the race between the two (#3704) — see markSsoExchangeFailed below.
+ */
+export const SSO_EXCHANGE_FAILED_LOGIN_PATH = '/login?error=sso_exchange_failed';
+
+let ssoExchangeFailed = false;
+
+/**
+ * Record that the `#ssoCode` exchange has terminally failed (#3704).
+ *
+ * Settling the gate releases every refresh queued behind it, and those
+ * refreshes 401 against the very cookie whose deadness sent the user through
+ * SSO in the first place. Their eviction is CORRECT — the session really is
+ * gone — but its generic `reason=session-expired` is the wrong explanation:
+ * it points away from SSO and invites an infinite retry loop, since signing in
+ * again just re-runs the same broken SSO round trip.
+ *
+ * AuthOverlay orders the two so the specific redirect commits first, which on
+ * its own is enough whenever `navigateTo` completes a real soft transition.
+ * This flag is what makes the outcome correct even when that ordering
+ * guarantee does NOT hold — `navigateTo` falls back to a fire-and-forget
+ * `window.location.replace`, which merely QUEUES a hard navigation and then
+ * resolves, so the address bar has not moved yet when the gate opens. Rather
+ * than suppress the eviction (which would strand the user if the SSO redirect
+ * never lands), we make it carry the same destination: whichever navigation
+ * wins, the user gets the same specific explanation.
+ *
+ * Cleared by login(), alongside the sessionExpiryInFlight latch.
+ */
+export function markSsoExchangeFailed(): void {
+  ssoExchangeFailed = true;
+}
+
 // Optional chaining: tests (and some embedders) stub `window.location` with a
 // partial object, and this runs at module load where a throw breaks every
 // importer of the store.
@@ -1177,6 +1217,16 @@ export function handleSessionExpired(reason: SessionExpiredReason = 'session-exp
   useAuthStore.getState().logout();
 
   if (typeof window !== 'undefined' && !window.location.pathname.startsWith('/login')) {
+    // A terminally failed SSO exchange outranks the generic expiry these
+    // refreshes report (#3704): it is the actual reason the session is dead,
+    // and it is the only one of the two the user can act on. Landing on the
+    // exact URL AuthOverlay is already navigating to makes it irrelevant which
+    // of the two wins — and no `next` deep link is dropped, because the SSO
+    // handoff has none to preserve.
+    if (ssoExchangeFailed) {
+      window.location.replace(SSO_EXCHANGE_FAILED_LOGIN_PATH);
+      return;
+    }
     const url = loginPathWithNext();
     window.location.replace(`${url}${url.includes('?') ? '&' : '?'}reason=${reason}`);
   }

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -806,7 +806,10 @@ let ssoExchangeFailed = false;
  * never lands), we make it carry the same destination: whichever navigation
  * wins, the user gets the same specific explanation.
  *
- * Cleared by login(), alongside the sessionExpiryInFlight latch.
+ * Cleared by login(), and — more importantly — by ANY refresh that mints an
+ * access token (see requestTokenRefreshWaitingOutThrottle): a proven-live
+ * session must never carry a previous attempt's SSO verdict into an unrelated
+ * eviction later in the same document.
  */
 export function markSsoExchangeFailed(): void {
   ssoExchangeFailed = true;
@@ -921,6 +924,18 @@ async function requestTokenRefreshWaitingOutThrottle(): Promise<RefreshOutcome> 
     // drop the mask so a wait we entered above can never outlive its cause.
     useAuthStore.getState().setAuthThrottledUntil(null);
     cancelThrottleReload();
+  }
+
+  // A minted access token proves the session is alive, so a previous SSO
+  // exchange failure is no longer the reason for anything (#3704). Clearing it
+  // in login() alone is NOT enough: every cookie-based recovery path lands on
+  // setTokens() without ever calling login(), so the verdict would outlive its
+  // cause and mislabel an unrelated eviction — an idle timeout hours later
+  // reported as "SSO sign-in failed", with its `next` deep link dropped too.
+  // Every refresh in the app funnels through here, so this is the one place
+  // that catches all of them.
+  if (outcome.kind === 'restored') {
+    ssoExchangeFailed = false;
   }
 
   return outcome;
@@ -1221,8 +1236,9 @@ export function handleSessionExpired(reason: SessionExpiredReason = 'session-exp
     // refreshes report (#3704): it is the actual reason the session is dead,
     // and it is the only one of the two the user can act on. Landing on the
     // exact URL AuthOverlay is already navigating to makes it irrelevant which
-    // of the two wins — and no `next` deep link is dropped, because the SSO
-    // handoff has none to preserve.
+    // of the two wins. Dropping `next` is safe precisely BECAUSE the verdict is
+    // cleared by any successful refresh: it can only still be set while the SSO
+    // bounce is the live cause, and that handoff has no deep link to preserve.
     if (ssoExchangeFailed) {
       window.location.replace(SSO_EXCHANGE_FAILED_LOGIN_PATH);
       return;


### PR DESCRIPTION
Closes #3704

## The bug

A failed `#ssoCode` exchange showed **"Your session expired. Please sign in again to continue."** instead of the SSO-specific notice #3702 shipped. That points away from SSO and invites an infinite retry loop — signing in again just re-runs the same broken SSO round trip.

The copy was never unreachable. It lost a race, exactly as the reported trace shows:

```
POST /api/v1/sso/exchange              => 400 Bad Request      (correct rejection)
GET  /login?error=sso_exchange_failed  => FAILED net::ERR_ABORTED   <-- intended redirect, aborted
POST /api/v1/auth/refresh              => 401 Unauthorized      (racing eviction wins)
```

## Root cause

`navigateTo` is an **async** page transition. Both SSO failure paths in `AuthOverlay.tsx` issued it un-awaited and then settled the SSO login gate on the very next line:

```ts
void navigateTo('/login?error=sso_exchange_failed', { replace: true });
settleSsoLoginGate();
```

Settling releases every refresh queued behind the gate. Those refreshes 401 against the same dead cookie that motivated the SSO login in the first place, and `handleSessionExpired`'s `window.location.replace(…&reason=session-expired)` is a **hard** navigation — it aborts the in-flight soft one and overwrites the URL.

This is the mirror image of the race #3702 fixed for the success path.

## The fix — two mechanisms, because neither is sufficient alone

**1. Order.** Both call sites now route through one `redirectToSsoExchangeFailed()` helper that awaits the navigation before settling the gate. By then the address bar is already on `/login`, where `handleSessionExpired`'s own pathname guard makes its redirect a no-op.

Verified against astro 7.2.10's `router.js` rather than assumed: `navigate()` awaits `transition()`, which calls `moveToLocation` → `history.replaceState(..., to.href)` **before** resolving. And this is the live path — `AuthOverlay` only ever renders under layouts that mount `<ClientRouter />` (`Layout.astro`, via `DashboardLayout`), so `transitionEnabledOnThisPage()` is true and the soft-transition branch is taken. No listener in the repo cancels `astro:before-preparation`.

**2. Precedence.** Ordering does **not** hold on `navigateTo`'s own fallback: when the transition throws, it fires `window.location.replace(safePath)` and returns, having merely *queued* a hard navigation — the address bar has not moved, so the pathname guard misses and the race is back. `markSsoExchangeFailed()` records the terminal SSO verdict and `handleSessionExpired` redirects to the *same* `/login?error=sso_exchange_failed` URL while it is set. Both navigations now target a byte-identical destination (hence the shared `SSO_EXCHANGE_FAILED_LOGIN_PATH` constant), so it no longer matters which one wins.

This is the issue's own "Proposed Fix" — *"the more specific reason should win when both are pending"* — with ordering as the primary path and precedence as the backstop.

Deliberately **not** suppressing the eviction redirect: the SSO bounce is not guaranteed to land, and suppression would strand the user with the 10s safety net already dormant (it returns early once `sessionExpiredReason` is set). Making the eviction carry the right reason has no such failure mode. The verdict is cleared by `login()`, alongside the existing `sessionExpiryInFlight` latch.

The eviction itself still runs, which is correct — the exchange really did fail. Only its generic *reason* was wrong.

Swept all `settleSsoLoginGate()` call sites. The others are unaffected: the gate's own timeout backstop, and the fast/success paths, where no navigation is issued or the refresh cookie is fresh so released refreshes succeed.

## Tests

`AuthOverlay.ssoFailureRace.test.tsx` (new, 4 cases):
1. **holds the gated refresh until the redirect has committed** — a slow `navigateTo` that moves the URL only when it resolves; asserts no `/auth/refresh` fires while the redirect is in flight, then that the URL still reads `?error=sso_exchange_failed` after the eviction runs.
2. **same for a malformed grant**, whose bounce skips the exchange entirely.
3. **still settles the gate when the redirect throws** — no queued refresh is stranded (guards the `finally`).
4. **lands the SSO notice even when the redirect is a hard navigation that has not committed** — `navigateTo` resolves *without* moving the URL, i.e. the fallback shape; the eviction wins the race and still lands the right destination.

`auth.ssoLoginGate.test.ts` (3 added): the SSO verdict wins over the generic expiry; the ordinary expiry path is untouched when no SSO exchange failed; the verdict does not leak across a `login()`.

Its own file rather than another block in `AuthOverlay.test.tsx`: these cases assert a gate-queued refresh actually reaches the network once the gate opens, and the store's module-level `tokenRefreshInFlight` is left parked on a promise the throttle suite's fake timers never resolve. Sharing a file made them read green-or-red on that leftover instead of on the behaviour under test.

**Red-first verified, both mechanisms.** Ordering tests fail on the unfixed source with `expected [ '/api/v1/auth/refresh' ] to have a length of +0 but got 1`. With the precedence branch disabled, the two precedence tests fail with the eviction URL carrying `reason=session-expired`.

## Verification

- Full `apps/web` suite: **739 files, 8112 tests passed**
- `tsc --noEmit -p apps/web/tsconfig.json` → clean
- `astro check` → 0 errors, 0 warnings
- `eslint` on all changed files → clean

## Review

Three reviewers ran on the first commit (code-reviewer, silent-failure-hunter, pr-test-analyzer). All three independently found the same gap — that the ordering guarantee degrades on `navigateTo`'s hard-navigation fallback — which is what the second commit closes. Also from review: the helper's comment now states which mechanism covers which path instead of asserting an unconditional guarantee, and the outer catch reports to Sentry (matching the `ConnectDesktopButton` precedent) since it is reached only when `navigateTo`'s own `window.location` fallback *also* threw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBxF7C8E5GxFnNcGf6kBVP
