### PR TITLE
fix(api): enforce the site axis on DR plan, group and execution mutations (#3653)

### DIFF
--- a/apps/api/src/routes/backup/resilienceAuthorization.ts
+++ b/apps/api/src/routes/backup/resilienceAuthorization.ts
@@ -6,6 +6,7 @@ import type { AuthContext } from '../../middleware/auth';
 import {
   ResilienceAuthorizationError,
   authorizeResilienceResources,
+  isSiteRestrictedPrincipalKind,
   type AuthorizedResilienceResources,
   type ResilienceOperation,
   type ResilienceResourceRef,
@@ -64,15 +65,7 @@ export async function resolveRouteAuthorizedDeviceIds(
 ): Promise<string[] | null> {
   const auth = c.get('auth') as AuthContext;
   const permissions = c.get('permissions') as UserPermissions | undefined;
-  const isSiteRestrictedPrincipal = [
-    'user_session',
-    'client_user',
-    'api_key',
-    'oauth_grant',
-    'ai_agent',
-  ].includes(auth.principal.kind);
-
-  if (!isSiteRestrictedPrincipal || !permissions?.allowedSiteIds) return null;
+  if (!isSiteRestrictedPrincipalKind(auth.principal.kind) || !permissions?.allowedSiteIds) return null;
   if (permissions.allowedSiteIds.length === 0) return [];
 
   const rows = await db

--- a/apps/api/src/routes/dr.test.ts
+++ b/apps/api/src/routes/dr.test.ts
@@ -748,6 +748,89 @@ describe('dr routes', () => {
       expect((await res.json()).data.status).toBe('aborted');
     });
 
+    // The stored guard runs first, so a group whose stored membership is fully
+    // in-site must still have its PROPOSED additions checked. Without this the
+    // proposed guard could be deleted and every other test would stay green.
+    it('rejects a group update that adds an out-of-site device', async () => {
+      restrictToSiteA();
+      selectMock.mockReturnValueOnce(chainMock([{
+        id: GROUP_ID,
+        planId: PLAN_ID,
+        orgId: ORG_ID,
+        devices: [DEVICE_ID],
+      }]));
+      selectMock.mockReturnValueOnce(chainMock([{ id: DEVICE_ID, siteId: SITE_A }]));
+      selectMock.mockReturnValueOnce(chainMock([{ id: OUT_OF_SITE_DEVICE_ID, siteId: SITE_B }]));
+
+      const res = await app.request(`/dr/plans/${PLAN_ID}/groups/${GROUP_ID}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ devices: [OUT_OF_SITE_DEVICE_ID] }),
+      });
+
+      expect(res.status).toBe(403);
+      expect((await res.json()).error).toBe('site_access_denied');
+      expect(updateMock).not.toHaveBeenCalled();
+    });
+
+    // An empty grant is the most locked-down state and the one a truthiness
+    // slip (`!allowedSiteIds`) would silently turn into "unrestricted".
+    it('denies a technician granted zero sites', async () => {
+      permissionsState = { allowedSiteIds: [] };
+      selectMock.mockReturnValueOnce(chainMock([{ id: GROUP_ID, devices: [DEVICE_ID] }]));
+      selectMock.mockReturnValueOnce(chainMock([{ id: DEVICE_ID, siteId: SITE_A }]));
+
+      const res = await app.request(`/dr/plans/${PLAN_ID}/groups/${GROUP_ID}`, {
+        method: 'DELETE',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(403);
+      expect((await res.json()).error).toBe('site_access_denied');
+      expect(deleteMock).not.toHaveBeenCalled();
+    });
+
+    // authorizeStoredDevices deliberately omits the row-count parity check that
+    // authorizeProposedDevices has: an id whose device row is gone cannot be a
+    // restore target, and must not wedge maintenance of the group holding it.
+    it('does not let a deleted device block maintenance of its group', async () => {
+      restrictToSiteA();
+      const deletedDeviceId = '44444444-4444-4444-8444-444444444444';
+      selectMock.mockReturnValueOnce(chainMock([{
+        id: GROUP_ID,
+        devices: [DEVICE_ID, deletedDeviceId],
+      }]));
+      selectMock.mockReturnValueOnce(chainMock([{ id: DEVICE_ID, siteId: SITE_A }]));
+      deleteMock.mockReturnValueOnce(chainMock([]));
+
+      const res = await app.request(`/dr/plans/${PLAN_ID}/groups/${GROUP_ID}`, {
+        method: 'DELETE',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(deleteMock).toHaveBeenCalled();
+    });
+
+    // A device outside the org must report the org mismatch, never the site
+    // grant — the site verdict would confirm the id exists somewhere in-org.
+    it('reports an org mismatch ahead of the site grant', async () => {
+      restrictToSiteA();
+      const foreignDeviceId = '55555555-5555-4555-8555-555555555555';
+      selectMock.mockReturnValueOnce(chainMock([{ id: PLAN_ID, orgId: ORG_ID, status: 'active' }]));
+      selectMock.mockReturnValueOnce(chainMock([]));
+
+      const res = await app.request(`/dr/plans/${PLAN_ID}/groups`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ name: 'Tier 1', devices: [foreignDeviceId] }),
+      });
+
+      expect(res.status).toBe(403);
+      expect((await res.json()).error).toMatch(/do not belong to this organization/);
+      expect(insertMock).not.toHaveBeenCalled();
+    });
+
     // An unrestricted principal must not pay for the site barrier, and must not
     // change behaviour: no extra lookup beyond the group existence check.
     it('costs an unrestricted caller no additional device lookup', async () => {

--- a/apps/api/src/routes/dr.test.ts
+++ b/apps/api/src/routes/dr.test.ts
@@ -7,11 +7,15 @@ const PLAN_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
 const GROUP_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
 const EXECUTION_ID = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
 const DEVICE_ID = 'ffffffff-ffff-4fff-8fff-ffffffffffff';
+const OUT_OF_SITE_DEVICE_ID = '11111111-1111-4111-8111-111111111111';
+const SITE_A = '22222222-2222-4222-8222-222222222222';
+const SITE_B = '33333333-3333-4333-8333-333333333333';
 
 vi.mock('../services', () => ({}));
 
 const writeRouteAuditMock = vi.fn();
 const createDrExecutionAndEnqueueMock = vi.fn();
+const classifyDrExecutionAuthorizationErrorMock = vi.fn(() => null as unknown);
 
 function chainMock(resolvedValue: unknown = []) {
   const chain: Record<string, any> = {};
@@ -31,7 +35,10 @@ let authState = {
   partnerId: null,
   orgId: ORG_ID,
   token: { sub: 'user-123' },
+  principal: { kind: 'user_session' as const },
 };
+/** null => the caller carries no site restriction (the pre-existing default). */
+let permissionsState: { allowedSiteIds: string[] | null } | null = null;
 
 vi.mock('../db', () => ({
   db: {
@@ -55,6 +62,7 @@ vi.mock('../db/schema', () => ({
     planId: 'dr_plan_groups.plan_id',
     orgId: 'dr_plan_groups.org_id',
     sequence: 'dr_plan_groups.sequence',
+    devices: 'dr_plan_groups.devices',
   },
   drExecutions: {
     id: 'dr_executions.id',
@@ -66,6 +74,7 @@ vi.mock('../db/schema', () => ({
   devices: {
     id: 'devices.id',
     orgId: 'devices.org_id',
+    siteId: 'devices.site_id',
   },
 }));
 
@@ -75,6 +84,8 @@ vi.mock('../services/auditEvents', () => ({
 
 vi.mock('../services/drExecutionService', () => ({
   createDrExecutionAndEnqueue: (...args: unknown[]) => createDrExecutionAndEnqueueMock(...(args as [])),
+  classifyDrExecutionAuthorizationError: (...args: unknown[]) =>
+    classifyDrExecutionAuthorizationErrorMock(...(args as [])),
 }));
 
 vi.mock('../middleware/auth', () => ({
@@ -83,7 +94,10 @@ vi.mock('../middleware/auth', () => ({
     return next();
   }),
   requireScope: vi.fn(() => (c: any, next: any) => next()),
-  requirePermission: vi.fn(() => (c: any, next: any) => next()),
+  requirePermission: vi.fn(() => (c: any, next: any) => {
+    if (permissionsState) c.set('permissions', permissionsState);
+    return next();
+  }),
   requireMfa: vi.fn(() => (c: any, next: any) => next()),
 }));
 
@@ -94,12 +108,15 @@ describe('dr routes', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    permissionsState = null;
+    classifyDrExecutionAuthorizationErrorMock.mockReturnValue(null);
     authState = {
       user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
       scope: 'organization',
       partnerId: null,
       orgId: ORG_ID,
       token: { sub: 'user-123' },
+      principal: { kind: 'user_session' },
     };
     vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
       c.set('auth', authState);
@@ -564,5 +581,224 @@ describe('dr routes', () => {
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.error).toContain('Cannot abort execution');
+  });
+
+  // ── Site scoping (#3653) ──────────────────────────────────────────────────
+  //
+  // RLS enforces the ORG axis only. The SITE axis is app-layer, so these routes
+  // are the sole barrier between a site-restricted technician and another
+  // site's disaster-recovery configuration.
+  describe('site scoping', () => {
+    /** Rows the org+site lookup returns for the ids a handler asks about. */
+    const deviceRows = [
+      { id: DEVICE_ID, siteId: SITE_A },
+      { id: OUT_OF_SITE_DEVICE_ID, siteId: SITE_B },
+    ];
+
+    function restrictToSiteA() {
+      permissionsState = { allowedSiteIds: [SITE_A] };
+    }
+
+    it('rejects a group create that includes an out-of-site device', async () => {
+      restrictToSiteA();
+      selectMock.mockReturnValueOnce(chainMock([{ id: PLAN_ID, orgId: ORG_ID, status: 'active' }]));
+      selectMock.mockReturnValueOnce(chainMock(deviceRows));
+
+      const res = await app.request(`/dr/plans/${PLAN_ID}/groups`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ name: 'Tier 1', devices: [DEVICE_ID, OUT_OF_SITE_DEVICE_ID] }),
+      });
+
+      expect(res.status).toBe(403);
+      expect((await res.json()).error).toBe('site_access_denied');
+      expect(insertMock).not.toHaveBeenCalled();
+    });
+
+    it('allows a group create whose devices are all inside the caller sites', async () => {
+      restrictToSiteA();
+      selectMock.mockReturnValueOnce(chainMock([{ id: PLAN_ID, orgId: ORG_ID, status: 'active' }]));
+      selectMock.mockReturnValueOnce(chainMock([{ id: DEVICE_ID, siteId: SITE_A }]));
+      insertMock.mockReturnValueOnce(chainMock([{ id: GROUP_ID, planId: PLAN_ID, orgId: ORG_ID }]));
+
+      const res = await app.request(`/dr/plans/${PLAN_ID}/groups`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ name: 'Tier 1', devices: [DEVICE_ID] }),
+      });
+
+      expect(res.status).toBe(201);
+      expect(insertMock).toHaveBeenCalled();
+    });
+
+    // The bypass that makes "validate the submitted array" insufficient: every
+    // id the caller submits is inside their grant, yet the write silently drops
+    // the out-of-site device already stored on the group.
+    it('rejects a group update that silently drops a stored out-of-site device', async () => {
+      restrictToSiteA();
+      selectMock.mockReturnValueOnce(chainMock([{
+        id: GROUP_ID,
+        planId: PLAN_ID,
+        orgId: ORG_ID,
+        devices: [DEVICE_ID, OUT_OF_SITE_DEVICE_ID],
+      }]));
+      selectMock.mockReturnValueOnce(chainMock(deviceRows));
+
+      const res = await app.request(`/dr/plans/${PLAN_ID}/groups/${GROUP_ID}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ devices: [DEVICE_ID] }),
+      });
+
+      expect(res.status).toBe(403);
+      expect((await res.json()).error).toBe('site_access_denied');
+      expect(updateMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects deleting a group that holds an out-of-site device', async () => {
+      restrictToSiteA();
+      selectMock.mockReturnValueOnce(chainMock([{
+        id: GROUP_ID,
+        devices: [DEVICE_ID, OUT_OF_SITE_DEVICE_ID],
+      }]));
+      selectMock.mockReturnValueOnce(chainMock(deviceRows));
+
+      const res = await app.request(`/dr/plans/${PLAN_ID}/groups/${GROUP_ID}`, {
+        method: 'DELETE',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(403);
+      expect((await res.json()).error).toBe('site_access_denied');
+      expect(deleteMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects archiving a plan whose groups span sites the caller cannot reach', async () => {
+      restrictToSiteA();
+      selectMock.mockReturnValueOnce(chainMock([{ id: PLAN_ID, orgId: ORG_ID, status: 'active' }]));
+      selectMock.mockReturnValueOnce(chainMock([{ devices: [DEVICE_ID, OUT_OF_SITE_DEVICE_ID] }]));
+      selectMock.mockReturnValueOnce(chainMock(deviceRows));
+
+      const res = await app.request(`/dr/plans/${PLAN_ID}`, {
+        method: 'DELETE',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(403);
+      expect((await res.json()).error).toBe('site_access_denied');
+      expect(updateMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects updating a plan whose groups span sites the caller cannot reach', async () => {
+      restrictToSiteA();
+      selectMock.mockReturnValueOnce(chainMock([{ id: PLAN_ID, orgId: ORG_ID, status: 'active' }]));
+      selectMock.mockReturnValueOnce(chainMock([{ devices: [DEVICE_ID, OUT_OF_SITE_DEVICE_ID] }]));
+      selectMock.mockReturnValueOnce(chainMock(deviceRows));
+
+      const res = await app.request(`/dr/plans/${PLAN_ID}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ status: 'archived' }),
+      });
+
+      expect(res.status).toBe(403);
+      expect((await res.json()).error).toBe('site_access_denied');
+      expect(updateMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects aborting a recovery that targets out-of-site devices', async () => {
+      restrictToSiteA();
+      selectMock.mockReturnValueOnce(chainMock([{
+        id: EXECUTION_ID,
+        planId: PLAN_ID,
+        orgId: ORG_ID,
+        status: 'running',
+      }]));
+      selectMock.mockReturnValueOnce(chainMock([{ devices: [DEVICE_ID, OUT_OF_SITE_DEVICE_ID] }]));
+      selectMock.mockReturnValueOnce(chainMock(deviceRows));
+
+      const res = await app.request(`/dr/executions/${EXECUTION_ID}/abort`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(403);
+      expect((await res.json()).error).toBe('site_access_denied');
+      expect(updateMock).not.toHaveBeenCalled();
+    });
+
+    it('allows aborting a recovery confined to the caller sites', async () => {
+      restrictToSiteA();
+      selectMock.mockReturnValueOnce(chainMock([{
+        id: EXECUTION_ID,
+        planId: PLAN_ID,
+        orgId: ORG_ID,
+        status: 'running',
+      }]));
+      selectMock.mockReturnValueOnce(chainMock([{ devices: [DEVICE_ID] }]));
+      selectMock.mockReturnValueOnce(chainMock([{ id: DEVICE_ID, siteId: SITE_A }]));
+      updateMock.mockReturnValueOnce(chainMock([{ id: EXECUTION_ID, status: 'aborted' }]));
+
+      const res = await app.request(`/dr/executions/${EXECUTION_ID}/abort`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(200);
+      expect((await res.json()).data.status).toBe('aborted');
+    });
+
+    // An unrestricted principal must not pay for the site barrier, and must not
+    // change behaviour: no extra lookup beyond the group existence check.
+    it('costs an unrestricted caller no additional device lookup', async () => {
+      selectMock.mockReturnValueOnce(chainMock([{ id: GROUP_ID, devices: [OUT_OF_SITE_DEVICE_ID] }]));
+      deleteMock.mockReturnValueOnce(chainMock([]));
+
+      const res = await app.request(`/dr/plans/${PLAN_ID}/groups/${GROUP_ID}`, {
+        method: 'DELETE',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(selectMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── Execution authorization errors (#3653) ────────────────────────────────
+  describe('execution authorization failures', () => {
+    it('reports a site-denied execution as 403 rather than a 500', async () => {
+      selectMock.mockReturnValueOnce(chainMock([{ id: PLAN_ID, orgId: ORG_ID, status: 'active' }]));
+      createDrExecutionAndEnqueueMock.mockRejectedValueOnce(new Error('site_access_denied'));
+      classifyDrExecutionAuthorizationErrorMock.mockReturnValue({
+        status: 403,
+        code: 'site_access_denied',
+      });
+
+      const res = await app.request(`/dr/plans/${PLAN_ID}/execute`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ executionType: 'failover' }),
+      });
+
+      expect(res.status).toBe(403);
+      expect((await res.json()).error).toBe('site_access_denied');
+      expect(writeRouteAuditMock).not.toHaveBeenCalled();
+    });
+
+    // Only recognised authorization denials may be converted. A genuine fault
+    // must keep propagating, or this catch would swallow real breakage.
+    it('rethrows an unrecognised execution failure', async () => {
+      selectMock.mockReturnValueOnce(chainMock([{ id: PLAN_ID, orgId: ORG_ID, status: 'active' }]));
+      createDrExecutionAndEnqueueMock.mockRejectedValueOnce(new Error('redis is on fire'));
+      classifyDrExecutionAuthorizationErrorMock.mockReturnValue(null);
+
+      const res = await app.request(`/dr/plans/${PLAN_ID}/execute`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ executionType: 'failover' }),
+      });
+
+      expect(res.status).toBe(500);
+    });
   });
 });

--- a/apps/api/src/routes/dr.ts
+++ b/apps/api/src/routes/dr.ts
@@ -68,8 +68,9 @@ function uniqueDeviceIds(value: unknown): string[] {
  * routes/backup/resilienceAuthorization.ts so both read the grant identically.
  */
 function siteRestriction(c: Context): UserPermissions | null {
+  // authMiddleware runs on '*' before every handler here, so auth is always set.
   const auth = c.get('auth') as AuthContext;
-  if (!isSiteRestrictedPrincipalKind(auth?.principal?.kind)) return null;
+  if (!isSiteRestrictedPrincipalKind(auth.principal?.kind)) return null;
 
   // Fall back to the token's own grant rather than treating a missing
   // `permissions` as "unrestricted". Every route here is behind

--- a/apps/api/src/routes/dr.ts
+++ b/apps/api/src/routes/dr.ts
@@ -68,10 +68,24 @@ function uniqueDeviceIds(value: unknown): string[] {
  * routes/backup/resilienceAuthorization.ts so both read the grant identically.
  */
 function siteRestriction(c: Context): UserPermissions | null {
-  const permissions = c.get('permissions') as UserPermissions | undefined;
-  if (!permissions?.allowedSiteIds) return null;
-  const auth = c.get('auth') as AuthContext | undefined;
-  return isSiteRestrictedPrincipalKind(auth?.principal?.kind) ? permissions : null;
+  const auth = c.get('auth') as AuthContext;
+  if (!isSiteRestrictedPrincipalKind(auth?.principal?.kind)) return null;
+
+  // Fall back to the token's own grant rather than treating a missing
+  // `permissions` as "unrestricted". Every route here is behind
+  // requirePermission, which always publishes it — but a route added later
+  // without that middleware would otherwise fail OPEN on a boundary Postgres
+  // does not enforce. Mirrors authorizeRouteResilienceResources.
+  const permissions = (c.get('permissions') as UserPermissions | undefined) ?? {
+    permissions: [],
+    partnerId: auth.partnerId,
+    orgId: auth.orgId,
+    roleId: '',
+    scope: auth.scope,
+    allowedSiteIds: auth.allowedSiteIds,
+  };
+
+  return permissions.allowedSiteIds ? permissions : null;
 }
 
 function loadDeviceSites(deviceIds: string[], orgId: string) {

--- a/apps/api/src/routes/dr.ts
+++ b/apps/api/src/routes/dr.ts
@@ -1,4 +1,4 @@
-import { Hono } from 'hono';
+import { Hono, type Context } from 'hono';
 import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { eq, and, desc, asc, inArray } from 'drizzle-orm';
@@ -14,8 +14,13 @@ import {
   drExecutionTriggerSchema,
   drExecutionsQuerySchema,
 } from './backup/schemas';
-import { PERMISSIONS } from '../services/permissions';
-import { createDrExecutionAndEnqueue } from '../services/drExecutionService';
+import { PERMISSIONS, canAccessSite, type UserPermissions } from '../services/permissions';
+import type { AuthContext } from '../middleware/auth';
+import { isSiteRestrictedPrincipalKind } from '../services/resilienceSiteAuthorization';
+import {
+  classifyDrExecutionAuthorizationError,
+  createDrExecutionAndEnqueue,
+} from '../services/drExecutionService';
 
 export const drRoutes = new Hono();
 const requireDrRead = requirePermission(
@@ -36,21 +41,120 @@ drRoutes.use('*', authMiddleware);
 const idParamSchema = z.object({ id: z.string().guid() });
 const groupParamSchema = z.object({ id: z.string().guid(), gid: z.string().guid() });
 
+type DeviceScopeDenial = { status: 403; error: string };
+
+const ORG_DENIAL: DeviceScopeDenial = {
+  status: 403,
+  error: 'One or more devices do not belong to this organization',
+};
+const SITE_DENIAL: DeviceScopeDenial = { status: 403, error: 'site_access_denied' };
+
+function denyDeviceScope(c: Context, denial: DeviceScopeDenial) {
+  return c.json({ error: denial.error }, denial.status);
+}
+
+function uniqueDeviceIds(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return [...new Set(value.filter((id): id is string => typeof id === 'string'))];
+}
+
 /**
- * Confirm every device id assigned to a DR group belongs to the plan's org.
- * DR group commands are dispatched under withSystemDbAccessContext (RLS off), so
- * a foreign-org device id slipping into devices[] would let a destructive restore
- * command target another tenant's device. Validate ownership with the
- * request-scoped RLS `db` before persisting. Returns true when all ids are owned.
+ * The caller's site restriction, or null when they carry none.
+ *
+ * RLS enforces the org axis but has no concept of a site, so for every route in
+ * this file the app layer is the ONLY barrier between a site-restricted
+ * technician and another site's disaster-recovery configuration (#3653). The
+ * shape mirrors `resolveRouteAuthorizedDeviceIds` in
+ * routes/backup/resilienceAuthorization.ts so both read the grant identically.
  */
-async function allDevicesBelongToOrg(deviceIds: string[], orgId: string): Promise<boolean> {
-  if (deviceIds.length === 0) return true;
-  const uniqueIds = [...new Set(deviceIds)];
-  const owned = await db
-    .select({ id: devices.id })
+function siteRestriction(c: Context): UserPermissions | null {
+  const permissions = c.get('permissions') as UserPermissions | undefined;
+  if (!permissions?.allowedSiteIds) return null;
+  const auth = c.get('auth') as AuthContext | undefined;
+  return isSiteRestrictedPrincipalKind(auth?.principal?.kind) ? permissions : null;
+}
+
+function loadDeviceSites(deviceIds: string[], orgId: string) {
+  return db
+    .select({ id: devices.id, siteId: devices.siteId })
     .from(devices)
-    .where(and(inArray(devices.id, uniqueIds), eq(devices.orgId, orgId)));
-  return owned.length === uniqueIds.length;
+    .where(and(inArray(devices.id, deviceIds), eq(devices.orgId, orgId)));
+}
+
+/**
+ * Authorize the device ids a caller is asking to STORE on a DR group.
+ *
+ * Org axis: DR group commands are dispatched under withSystemDbAccessContext
+ * (RLS off), so a foreign-org device id slipping into devices[] would let a
+ * destructive restore command target another tenant's device.
+ *
+ * Site axis: `devices:write` is a role permission orthogonal to allowedSiteIds,
+ * so a site-restricted technician normally holds it; without this check they
+ * could point a recovery group at another site's machines.
+ */
+async function authorizeProposedDevices(
+  c: Context,
+  deviceIds: string[],
+  orgId: string,
+): Promise<DeviceScopeDenial | null> {
+  const uniqueIds = uniqueDeviceIds(deviceIds);
+  if (uniqueIds.length === 0) return null;
+
+  const owned = await loadDeviceSites(uniqueIds, orgId);
+  if (owned.length !== uniqueIds.length) return ORG_DENIAL;
+
+  const restriction = siteRestriction(c);
+  if (!restriction) return null;
+  return owned.every((row) => canAccessSite(restriction, row.siteId)) ? null : SITE_DENIAL;
+}
+
+/**
+ * Authorize the membership a group ALREADY holds, before replacing or removing it.
+ *
+ * Validating only the submitted array is bypassable: a site-restricted caller
+ * can PATCH devices:[theirOwnDevice] over a stored [theirOwnDevice,
+ * otherSiteDevice] and silently drop the out-of-site device from the recovery
+ * plan without ever naming it — degrading DR for a site they cannot see. So
+ * every mutation that replaces or removes stored membership is authorized
+ * against what is already there.
+ *
+ * Costs an unrestricted caller nothing: it returns before issuing any query.
+ */
+async function authorizeStoredDevices(
+  c: Context,
+  storedDeviceIds: unknown,
+  orgId: string,
+): Promise<DeviceScopeDenial | null> {
+  const restriction = siteRestriction(c);
+  if (!restriction) return null;
+
+  const uniqueIds = uniqueDeviceIds(storedDeviceIds);
+  if (uniqueIds.length === 0) return null;
+
+  // Ids with no surviving device row cannot be restore targets, so they do not
+  // gate the mutation — a deleted device must not wedge group maintenance.
+  const owned = await loadDeviceSites(uniqueIds, orgId);
+  return owned.every((row) => canAccessSite(restriction, row.siteId)) ? null : SITE_DENIAL;
+}
+
+/**
+ * Authorize every device across a plan's groups. Plan status gates execution
+ * and archival disables recovery outright, so those are control-plane actions
+ * over every site the plan touches — not just the caller's own.
+ */
+async function authorizePlanStoredDevices(
+  c: Context,
+  planId: string,
+  orgId: string,
+): Promise<DeviceScopeDenial | null> {
+  if (!siteRestriction(c)) return null;
+
+  const groups = await db
+    .select({ devices: drPlanGroups.devices })
+    .from(drPlanGroups)
+    .where(and(eq(drPlanGroups.planId, planId), eq(drPlanGroups.orgId, orgId)));
+
+  return authorizeStoredDevices(c, groups.flatMap((group) => uniqueDeviceIds(group.devices)), orgId);
 }
 
 function resolveOrgId(
@@ -187,6 +291,9 @@ drRoutes.patch(
 
     if (!existing) return c.json({ error: 'Plan not found' }, 404);
 
+    const planDenial = await authorizePlanStoredDevices(c, id, orgId);
+    if (planDenial) return denyDeviceScope(c, planDenial);
+
     const updateData: Record<string, unknown> = { updatedAt: new Date() };
     if (payload.name !== undefined) updateData.name = payload.name;
     if (payload.description !== undefined) updateData.description = payload.description;
@@ -231,6 +338,9 @@ drRoutes.delete(
 
     if (!existing) return c.json({ error: 'Plan not found' }, 404);
 
+    const planDenial = await authorizePlanStoredDevices(c, id, orgId);
+    if (planDenial) return denyDeviceScope(c, planDenial);
+
     // Archive instead of hard delete
     const [updated] = await db
       .update(drPlans)
@@ -274,8 +384,9 @@ drRoutes.post(
     if (!plan) return c.json({ error: 'Plan not found' }, 404);
 
     const payload = c.req.valid('json');
-    if (payload.devices && !(await allDevicesBelongToOrg(payload.devices, orgId))) {
-      return c.json({ error: 'One or more devices do not belong to this organization' }, 403);
+    if (payload.devices) {
+      const denial = await authorizeProposedDevices(c, payload.devices, orgId);
+      if (denial) return denyDeviceScope(c, denial);
     }
 
     const [row] = await db
@@ -326,8 +437,14 @@ drRoutes.patch(
 
     if (!existing) return c.json({ error: 'Group not found' }, 404);
 
-    if (payload.devices !== undefined && !(await allDevicesBelongToOrg(payload.devices, orgId))) {
-      return c.json({ error: 'One or more devices do not belong to this organization' }, 403);
+    // Authorize what the group already holds BEFORE what the caller proposes:
+    // a replace that merely omits an out-of-site device never names it.
+    const storedDenial = await authorizeStoredDevices(c, existing.devices, orgId);
+    if (storedDenial) return denyDeviceScope(c, storedDenial);
+
+    if (payload.devices !== undefined) {
+      const denial = await authorizeProposedDevices(c, payload.devices, orgId);
+      if (denial) return denyDeviceScope(c, denial);
     }
 
     const updateData: Record<string, unknown> = {};
@@ -367,7 +484,7 @@ drRoutes.delete(
     const { id: planId, gid } = c.req.valid('param');
 
     const [existing] = await db
-      .select({ id: drPlanGroups.id })
+      .select({ id: drPlanGroups.id, devices: drPlanGroups.devices })
       .from(drPlanGroups)
       .where(
         and(
@@ -379,6 +496,9 @@ drRoutes.delete(
       .limit(1);
 
     if (!existing) return c.json({ error: 'Group not found' }, 404);
+
+    const storedDenial = await authorizeStoredDevices(c, existing.devices, orgId);
+    if (storedDenial) return denyDeviceScope(c, storedDenial);
 
     await db
       .delete(drPlanGroups)
@@ -422,13 +542,24 @@ drRoutes.post(
       return c.json({ error: 'Cannot execute an archived plan' }, 400);
     }
 
-    const execution = await createDrExecutionAndEnqueue({
-      planId,
-      orgId,
-      executionType,
-      initiatedBy: auth.user?.id ?? null,
-      auth,
-    });
+    // createDrExecutionAndEnqueue authorizes every group device against the
+    // caller's site grant before an execution row exists, so a denial here is an
+    // expected outcome — not a fault. Uncaught it would reach the global handler
+    // and render as a 500 plus a Sentry event (#3653).
+    let execution;
+    try {
+      execution = await createDrExecutionAndEnqueue({
+        planId,
+        orgId,
+        executionType,
+        initiatedBy: auth.user?.id ?? null,
+        auth,
+      });
+    } catch (error) {
+      const failure = classifyDrExecutionAuthorizationError(error);
+      if (!failure) throw error;
+      return c.json({ error: failure.code }, failure.status);
+    }
 
     if (!execution) return c.json({ error: 'Failed to create execution' }, 500);
 
@@ -541,6 +672,11 @@ drRoutes.post(
     if (execution.status === 'completed' || execution.status === 'aborted') {
       return c.json({ error: `Cannot abort execution in ${execution.status} state` }, 400);
     }
+
+    // Aborting halts recovery for every site the plan touches, so a caller who
+    // cannot reach all of them must not be able to stop it.
+    const abortDenial = await authorizePlanStoredDevices(c, execution.planId, orgId);
+    if (abortDenial) return denyDeviceScope(c, abortDenial);
 
     const [updated] = await db
       .update(drExecutions)

--- a/apps/api/src/services/aiToolsDR.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsDR.siteScope.test.ts
@@ -13,7 +13,11 @@ import { registerDRTools } from './aiToolsDR';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 
-const mockDb = db as unknown as { select: ReturnType<typeof vi.fn> };
+const mockDb = db as unknown as {
+  select: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+};
 const mockEnqueue = createDrExecutionAndEnqueue as unknown as ReturnType<typeof vi.fn>;
 
 function handlerFor(name: string): AiTool['handler'] {
@@ -109,5 +113,82 @@ describe('query_dr_plans — hides fully out-of-scope plans', () => {
     const result = await handlerFor('query_dr_plans')({}, makeAuth(undefined));
     const parsed = JSON.parse(result);
     expect(parsed.showing).toBe(2);
+  });
+});
+
+// ── #3653 ───────────────────────────────────────────────────────────────────
+// The central `deviceArgs` gate org+site checks the ids a caller SUBMITS. It
+// cannot see what a group already holds, so these mutations need their own
+// barrier against the stored membership.
+describe('manage_dr_plan — stored group membership is site-scoped', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  /** Chain that also answers the write-builder methods. */
+  function writeChain(rows: unknown[]): any {
+    const p: any = Promise.resolve(rows);
+    for (const m of ['from', 'where', 'limit', 'set', 'values', 'returning']) p[m] = () => p;
+    return p;
+  }
+
+  const GROUP_SPANNING_SITES = {
+    id: 'g1',
+    orgId: 'org-1',
+    devices: ['dev-A', 'dev-B'],
+  };
+  const ORG_DEVICES = [
+    { id: 'dev-A', siteId: 'site-A' },
+    { id: 'dev-B', siteId: 'site-B' },
+  ];
+
+  it('refuses an update that would silently drop an out-of-site device', async () => {
+    mockDb.update.mockImplementation(() => writeChain([]));
+    seqSelect([[GROUP_SPANNING_SITES], ORG_DEVICES]);
+
+    const result = await handlerFor('manage_dr_plan')(
+      { action: 'update_group', planId: 'p1', groupId: 'g1', devices: ['dev-A'] },
+      makeAuth(['site-A']),
+    );
+
+    expect(JSON.parse(result).error).toMatch(/access denied/i);
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+
+  it('refuses deleting a group that holds an out-of-site device', async () => {
+    mockDb.delete.mockImplementation(() => writeChain([]));
+    seqSelect([[GROUP_SPANNING_SITES], ORG_DEVICES]);
+
+    const result = await handlerFor('manage_dr_plan')(
+      { action: 'delete_group', planId: 'p1', groupId: 'g1' },
+      makeAuth(['site-A']),
+    );
+
+    expect(JSON.parse(result).error).toMatch(/access denied/i);
+    expect(mockDb.delete).not.toHaveBeenCalled();
+  });
+
+  it('allows updating a group confined to the caller sites', async () => {
+    mockDb.update.mockImplementation(() => writeChain([{ id: 'g1', name: 'Renamed' }]));
+    seqSelect([[{ id: 'g1', orgId: 'org-1', devices: ['dev-A'] }], ORG_DEVICES]);
+
+    const result = await handlerFor('manage_dr_plan')(
+      { action: 'update_group', planId: 'p1', groupId: 'g1', name: 'Renamed' },
+      makeAuth(['site-A']),
+    );
+
+    expect(JSON.parse(result).success).toBe(true);
+    expect(mockDb.update).toHaveBeenCalled();
+  });
+
+  it('leaves an unrestricted caller unaffected and issues no partition query', async () => {
+    mockDb.update.mockImplementation(() => writeChain([{ id: 'g1', name: 'Renamed' }]));
+    seqSelect([[GROUP_SPANNING_SITES]]);
+
+    const result = await handlerFor('manage_dr_plan')(
+      { action: 'update_group', planId: 'p1', groupId: 'g1', name: 'Renamed' },
+      makeAuth(undefined),
+    );
+
+    expect(JSON.parse(result).success).toBe(true);
+    expect(mockDb.select).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/services/aiToolsDR.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsDR.siteScope.test.ts
@@ -192,3 +192,67 @@ describe('manage_dr_plan — stored group membership is site-scoped', () => {
     expect(mockDb.select).toHaveBeenCalledTimes(1);
   });
 });
+
+// Plan status gates execution and archival disables recovery outright, so
+// update_plan is a control-plane action over every site the plan touches.
+describe('manage_dr_plan — plan mutations are site-scoped', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  function writeChain(rows: unknown[]): any {
+    const p: any = Promise.resolve(rows);
+    for (const m of ['from', 'where', 'limit', 'set', 'values', 'returning']) p[m] = () => p;
+    return p;
+  }
+
+  const ORG_DEVICES = [
+    { id: 'dev-A', siteId: 'site-A' },
+    { id: 'dev-B', siteId: 'site-B' },
+  ];
+
+  it('refuses to archive a plan reaching sites the caller cannot access', async () => {
+    mockDb.update.mockImplementation(() => writeChain([]));
+    seqSelect([
+      [PLAN],                                  // loadPlanWithAccess
+      ORG_DEVICES,                             // site partition
+      [{ devices: ['dev-A', 'dev-B'] }],       // the plan's groups
+    ]);
+
+    const result = await handlerFor('manage_dr_plan')(
+      { action: 'update_plan', planId: 'p1', status: 'archived' },
+      makeAuth(['site-A']),
+    );
+
+    expect(JSON.parse(result).error).toMatch(/access denied/i);
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+
+  it('allows updating a plan confined to the caller sites', async () => {
+    mockDb.update.mockImplementation(() => writeChain([{ id: 'p1', name: 'Renamed' }]));
+    seqSelect([
+      [PLAN],
+      ORG_DEVICES,
+      [{ devices: ['dev-A'] }],
+    ]);
+
+    const result = await handlerFor('manage_dr_plan')(
+      { action: 'update_plan', planId: 'p1', name: 'Renamed' },
+      makeAuth(['site-A']),
+    );
+
+    expect(JSON.parse(result).success).toBe(true);
+    expect(mockDb.update).toHaveBeenCalled();
+  });
+
+  it('leaves an unrestricted caller unaffected and loads no group membership', async () => {
+    mockDb.update.mockImplementation(() => writeChain([{ id: 'p1', name: 'Renamed' }]));
+    seqSelect([[PLAN]]);
+
+    const result = await handlerFor('manage_dr_plan')(
+      { action: 'update_plan', planId: 'p1', name: 'Renamed' },
+      makeAuth(undefined),
+    );
+
+    expect(JSON.parse(result).success).toBe(true);
+    expect(mockDb.select).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/services/aiToolsDR.ts
+++ b/apps/api/src/services/aiToolsDR.ts
@@ -27,16 +27,48 @@ import { resolveSiteDevicePartition } from './aiToolsSiteScope';
  *
  * No-op for unrestricted callers — resolveSiteDevicePartition returns null.
  */
+async function forbiddenDeviceIds(
+  auth: AuthContext,
+  orgId: string,
+): Promise<Set<string> | null> {
+  const partition = await resolveSiteDevicePartition(orgId, auth);
+  return partition ? new Set(partition.forbidden) : null;
+}
+
+function holdsForbiddenDevice(forbidden: Set<string>, storedDevices: unknown): boolean {
+  return (Array.isArray(storedDevices) ? storedDevices : [])
+    .some((id) => typeof id === 'string' && forbidden.has(id));
+}
+
 async function storedGroupDevicesDenied(
   auth: AuthContext,
   orgId: string,
   storedDevices: unknown,
 ): Promise<boolean> {
-  const partition = await resolveSiteDevicePartition(orgId, auth);
-  if (!partition) return false;
-  const forbidden = new Set(partition.forbidden);
-  return (Array.isArray(storedDevices) ? storedDevices : [])
-    .some((id) => typeof id === 'string' && forbidden.has(id));
+  const forbidden = await forbiddenDeviceIds(auth, orgId);
+  return forbidden ? holdsForbiddenDevice(forbidden, storedDevices) : false;
+}
+
+/**
+ * Deny a plan-level mutation when ANY of the plan's groups reaches outside the
+ * caller's sites. Plan status gates execution and archival disables recovery
+ * outright, so this is a control-plane action over every site the plan touches
+ * — the AI-tool counterpart of authorizePlanStoredDevices in routes/dr.ts.
+ */
+async function planStoredDevicesDenied(
+  auth: AuthContext,
+  orgId: string,
+  planId: string,
+): Promise<boolean> {
+  const forbidden = await forbiddenDeviceIds(auth, orgId);
+  if (!forbidden) return false;
+
+  const groups = await db
+    .select({ devices: drPlanGroups.devices })
+    .from(drPlanGroups)
+    .where(and(eq(drPlanGroups.planId, planId), eq(drPlanGroups.orgId, orgId)));
+
+  return groups.some((group) => holdsForbiddenDevice(forbidden, group.devices));
 }
 
 type DRHandler = (input: Record<string, unknown>, auth: AuthContext) => Promise<string>;
@@ -459,6 +491,9 @@ export function registerDRTools(aiTools: Map<string, AiTool>): void {
 
         const plan = await loadPlanWithAccess(planId, auth);
         if (!plan) return JSON.stringify({ error: 'Plan not found or access denied' });
+        if (await planStoredDevicesDenied(auth, plan.orgId, plan.id)) {
+          return JSON.stringify({ error: 'Plan not found or access denied' });
+        }
 
         const updateData: Record<string, unknown> = { updatedAt: new Date() };
         if (typeof input.name === 'string') updateData.name = input.name.trim();

--- a/apps/api/src/services/aiToolsDR.ts
+++ b/apps/api/src/services/aiToolsDR.ts
@@ -14,6 +14,31 @@ import type { AiTool } from './aiTools';
 import { createDrExecutionAndEnqueue } from './drExecutionService';
 import { resolveSiteDevicePartition } from './aiToolsSiteScope';
 
+/**
+ * Deny a group mutation whose STORED membership reaches outside the caller's
+ * sites.
+ *
+ * `manage_dr_plan` declares `deviceArgs: ['devices']`, so the central gate in
+ * aiTools.ts org+site checks every device id the caller SUBMITS. It cannot see
+ * what the group already holds, which leaves the same bypass the HTTP routes
+ * had (#3653): an update_group carrying devices:[theirOwnDevice] over a stored
+ * [theirOwnDevice, otherSiteDevice] silently drops the out-of-site device from
+ * the recovery plan without ever naming it. delete_group removes it outright.
+ *
+ * No-op for unrestricted callers — resolveSiteDevicePartition returns null.
+ */
+async function storedGroupDevicesDenied(
+  auth: AuthContext,
+  orgId: string,
+  storedDevices: unknown,
+): Promise<boolean> {
+  const partition = await resolveSiteDevicePartition(orgId, auth);
+  if (!partition) return false;
+  const forbidden = new Set(partition.forbidden);
+  return (Array.isArray(storedDevices) ? storedDevices : [])
+    .some((id) => typeof id === 'string' && forbidden.has(id));
+}
+
 type DRHandler = (input: Record<string, unknown>, auth: AuthContext) => Promise<string>;
 
 // ============================================
@@ -495,12 +520,15 @@ export function registerDRTools(aiTools: Map<string, AiTool>): void {
         const gc = orgWhere(auth, drPlanGroups.orgId);
         if (gc) groupConditions.push(gc);
         const [existing] = await db
-          .select({ id: drPlanGroups.id })
+          .select({ id: drPlanGroups.id, orgId: drPlanGroups.orgId, devices: drPlanGroups.devices })
           .from(drPlanGroups)
           .where(and(...groupConditions))
           .limit(1);
 
         if (!existing) return JSON.stringify({ error: 'Group not found or access denied' });
+        if (await storedGroupDevicesDenied(auth, existing.orgId, existing.devices)) {
+          return JSON.stringify({ error: 'Group not found or access denied' });
+        }
 
         const updateData: Record<string, unknown> = {};
         if (typeof input.name === 'string') updateData.name = input.name.trim();
@@ -537,12 +565,15 @@ export function registerDRTools(aiTools: Map<string, AiTool>): void {
         const gc = orgWhere(auth, drPlanGroups.orgId);
         if (gc) groupConditions.push(gc);
         const [existing] = await db
-          .select({ id: drPlanGroups.id })
+          .select({ id: drPlanGroups.id, orgId: drPlanGroups.orgId, devices: drPlanGroups.devices })
           .from(drPlanGroups)
           .where(and(...groupConditions))
           .limit(1);
 
         if (!existing) return JSON.stringify({ error: 'Group not found or access denied' });
+        if (await storedGroupDevicesDenied(auth, existing.orgId, existing.devices)) {
+          return JSON.stringify({ error: 'Group not found or access denied' });
+        }
 
         await db.delete(drPlanGroups).where(eq(drPlanGroups.id, groupId));
         return JSON.stringify({ success: true, deleted: true, groupId });

--- a/apps/api/src/services/drExecutionService.test.ts
+++ b/apps/api/src/services/drExecutionService.test.ts
@@ -51,10 +51,17 @@ import { db } from '../db';
 import { queueCommandForExecution } from './commandQueue';
 import { enqueueDrExecutionReconcile } from '../jobs/drExecutionWorker';
 import {
+  classifyDrExecutionAuthorizationError,
   createDrExecutionAndEnqueue,
+  DrRecoveryAuthorizationDeniedError,
   reconcileDrExecution,
   resolveDrGroupAuthorizationRefs,
 } from './drExecutionService';
+import {
+  RecoveryAuthorizationDeniedError,
+  RecoveryAuthorizationTransientError,
+} from './recoveryAuthorizationSubject';
+import { ResilienceAuthorizationError } from './resilienceSiteAuthorization';
 
 const ORG_ID = '11111111-1111-1111-1111-111111111111';
 const PLAN_ID = '22222222-2222-2222-2222-222222222222';
@@ -302,5 +309,50 @@ describe('drExecutionService', () => {
     expect(outcome.execution?.status).toBe('failed');
     expect(outcome.execution?.authorizationState).toBe('denied');
     expect(outcome.nextDelayMs).toBeNull();
+  });
+});
+
+// ── #3653 ───────────────────────────────────────────────────────────────────
+// The DR execute route previously let these escape to the global Hono handler,
+// which renders every non-HTTPException as a 500. The site barrier still held
+// (it throws before the execution row is written) but the caller was told the
+// server had broken, and every denial raised a Sentry event.
+describe('classifyDrExecutionAuthorizationError', () => {
+  it('carries a resilience denial status and code through unchanged', () => {
+    expect(classifyDrExecutionAuthorizationError(
+      new ResilienceAuthorizationError(403, 'site_access_denied'),
+    )).toEqual({ status: 403, code: 'site_access_denied' });
+
+    expect(classifyDrExecutionAuthorizationError(
+      new ResilienceAuthorizationError(404, 'resource_not_found'),
+    )).toEqual({ status: 404, code: 'resource_not_found' });
+  });
+
+  it('reports a recovery-subject denial as 403', () => {
+    expect(classifyDrExecutionAuthorizationError(
+      new RecoveryAuthorizationDeniedError('base_permission_denied'),
+    )).toEqual({ status: 403, code: 'base_permission_denied' });
+  });
+
+  it('reports an unavailable authorization dependency as 503, not a denial', () => {
+    expect(classifyDrExecutionAuthorizationError(
+      new RecoveryAuthorizationTransientError('authorization_dependency_unavailable'),
+    )).toEqual({ status: 503, code: 'authorization_dependency_unavailable' });
+  });
+
+  it('separates an unresolvable plan reference from a site denial', () => {
+    expect(classifyDrExecutionAuthorizationError(
+      new DrRecoveryAuthorizationDeniedError('resource_not_found'),
+    )).toEqual({ status: 404, code: 'resource_not_found' });
+
+    expect(classifyDrExecutionAuthorizationError(
+      new DrRecoveryAuthorizationDeniedError('ambiguous_snapshot_reference'),
+    )).toEqual({ status: 400, code: 'ambiguous_snapshot_reference' });
+  });
+
+  it('returns null for anything else so real faults keep propagating', () => {
+    expect(classifyDrExecutionAuthorizationError(new Error('redis is on fire'))).toBeNull();
+    expect(classifyDrExecutionAuthorizationError('nope')).toBeNull();
+    expect(classifyDrExecutionAuthorizationError(undefined)).toBeNull();
   });
 });

--- a/apps/api/src/services/drExecutionService.ts
+++ b/apps/api/src/services/drExecutionService.ts
@@ -6,10 +6,15 @@ import { CommandTypes, queueCommandForExecution } from './commandQueue';
 import {
   authorizeQueuedRecoveryWork,
   captureRecoveryAuthorizationSubject,
+  RecoveryAuthorizationDeniedError,
+  RecoveryAuthorizationTransientError,
   type RecoveryAuthorizationIntent,
   type RecoveryAuthorizationSubjectRow,
 } from './recoveryAuthorizationSubject';
-import type { ResilienceResourceRef } from './resilienceSiteAuthorization';
+import {
+  ResilienceAuthorizationError,
+  type ResilienceResourceRef,
+} from './resilienceSiteAuthorization';
 
 const DR_ALLOWED_COMMAND_TYPES = new Set<string>([
   CommandTypes.VM_RESTORE_FROM_BACKUP,
@@ -275,13 +280,54 @@ async function loadDrPlanGroups(planId: string, orgId: string, tx: DrDb = db): P
     .orderBy(asc(drPlanGroups.sequence));
 }
 
-class DrRecoveryAuthorizationDeniedError extends Error {
+export class DrRecoveryAuthorizationDeniedError extends Error {
   readonly retriable = false;
 
   constructor(readonly code: string) {
     super(code);
     this.name = 'DrRecoveryAuthorizationDeniedError';
   }
+}
+
+export type DrExecutionAuthorizationFailure = {
+  status: 400 | 403 | 404 | 503;
+  code: string;
+};
+
+/**
+ * Translate an authorization failure raised while starting a DR execution into
+ * the status the caller should see, or null when the error is not one.
+ *
+ * `createDrExecutionAndEnqueue` authorizes every group device against the
+ * caller's site grant before an execution row exists, so a denial is a normal,
+ * expected outcome for a site-restricted technician. Left uncaught it reaches
+ * the global Hono handler, which renders anything that is not an HTTPException
+ * as a 500 and reports it to Sentry — telling the caller the server broke and
+ * burying a genuine authorization signal in fault noise (#3653).
+ *
+ * Returning null for an unrecognised error is deliberate: the caller must
+ * rethrow it so real faults keep failing loudly.
+ */
+export function classifyDrExecutionAuthorizationError(
+  error: unknown,
+): DrExecutionAuthorizationFailure | null {
+  if (error instanceof ResilienceAuthorizationError) {
+    return { status: error.status, code: error.code };
+  }
+  if (error instanceof RecoveryAuthorizationTransientError) {
+    // The subject could not be re-verified. Not a denial — a retryable outage.
+    return { status: 503, code: error.code };
+  }
+  if (error instanceof RecoveryAuthorizationDeniedError) {
+    return { status: 403, code: error.code };
+  }
+  if (error instanceof DrRecoveryAuthorizationDeniedError) {
+    return {
+      status: error.code === 'resource_not_found' ? 404 : 400,
+      code: error.code,
+    };
+  }
+  return null;
 }
 
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;

--- a/apps/api/src/services/resilienceSiteAuthorization.ts
+++ b/apps/api/src/services/resilienceSiteAuthorization.ts
@@ -92,6 +92,17 @@ const SITE_UNRESTRICTED_PRINCIPAL_KINDS = new Set<PrincipalKind['kind']>([
   'system',
 ]);
 
+/**
+ * Whether a principal of this kind is subject to the site grant at all.
+ *
+ * Exported so route-level adapters share one list with the resolver below: a
+ * kind present here but missing there (or the reverse) is a silent hole in an
+ * app-layer-only boundary, since RLS does not enforce the site axis.
+ */
+export function isSiteRestrictedPrincipalKind(kind: PrincipalKind['kind'] | undefined): boolean {
+  return kind !== undefined && SITE_RESTRICTED_PRINCIPAL_KINDS.has(kind);
+}
+
 function siteAccessAllowed(principal: AuthorizationPrincipal, siteId: string): boolean {
   if (SITE_RESTRICTED_PRINCIPAL_KINDS.has(principal.kind)) {
     return canAccessSite(principal.permissions, siteId);


### PR DESCRIPTION
Closes #3653

## What was actually still broken

The reported exploit — `POST /dr/plans/:id/execute` dispatching destructive restores to out-of-site devices — **has already been closed on `main`** by the recovery-authorization framework that landed after the issue was filed. `createDrExecutionAndEnqueue` now runs every group device through `authorizeQueuedRecoveryWork` → `authorizeResilienceResources`, which site-checks each ref and throws *before* an execution row is written. The issue's claim that `routes/dr.ts` calls the service with four keys and that `dr.test.ts:218-223` pins that shape is stale; both already pass `auth`.

The rest of the site-scope surface named in the issue was still open. Verified by watching each assertion fail on `origin/main` first:

| Route | Behaviour on `main` | Now |
|---|---|---|
| `DELETE /plans/:id/groups/:gid` on a group holding an out-of-site device | **200** | 403 |
| `PATCH /plans/:id` / `DELETE /plans/:id` on a plan spanning unreachable sites | **200** | 403 |
| `POST /executions/:id/abort` on another site's running recovery | **200** | 403 |
| `POST /plans/:id/execute` denied by the site barrier | **500** + Sentry event | 403 |
| `POST`/`PATCH` group with an out-of-site device | accepted | 403 |
| `manage_dr_plan` `update_plan` archiving a plan spanning unreachable sites | accepted | denied |
| `manage_dr_plan` `update_group`/`delete_group` dropping an out-of-site device | accepted | denied |

RLS enforces the org axis but has no concept of a site, so these routes are the only barrier. `devices:read/write/execute` are role permissions orthogonal to `allowedSiteIds` — a site-restricted technician normally holds them.

## The bypass that shaped the design

Validating only the **submitted** device array is insufficient. A site-restricted caller can `PATCH devices:[theirOwnDevice]` over a stored `[theirOwnDevice, otherSiteDevice]` and silently drop the out-of-site device from the recovery plan **without ever naming it** — degrading DR for a site they cannot see. `DELETE` removes it outright.

So every mutation that replaces or removes membership is authorized against **what is already stored**, not just what was sent. That is the `authorizeStoredDevices` / `authorizePlanStoredDevices` pair in `routes/dr.ts`, and `storedGroupDevicesDenied` / `planStoredDevicesDenied` in `aiToolsDR.ts`.

## Second write path, swept

`manage_dr_plan` (`services/aiToolsDR.ts`) also writes DR plans and groups. Its `deviceArgs: ['devices']` declaration already gets the central org+site gate on **submitted** ids, but that gate cannot see stored membership — so `update_group` and `delete_group` carried the identical bypass, and `update_plan` could archive (i.e. halt) a plan reaching sites the caller cannot access, with no guard at all. All three are now gated. `create_plan` writes no device data and `add_group` has no prior membership, so both are covered by the central gate alone.

## Design decisions

**Reads are deliberately left unredacted.** Filtering `groups[].devices` for site-restricted callers looks like the obvious completion of the issue's item 3, and it is a trap: `apps/web/src/components/dr/DRPlanEditor.tsx` loads the plan, populates each group's `deviceIds` from the response, and on Save **PATCHes every group with a full array replace**. Redaction would turn one click of Save into a silent strip of every out-of-site device from every group of a disaster-recovery plan. In DR, what you see must not diverge from what executes. Partial redaction would also be false assurance — execution `results` carries device ids in `groupResults`/`queuedCommands`/`failedDispatches`, and `restoreConfig` carries source-resource ids. The residual same-org device-id disclosure is recorded as accepted debt; the write, execute and abort axes are what this PR closes.

**`allDevicesBelongToOrg`'s 403 + message is preserved** for the org axis rather than being folded into the canonical `authorizeRouteResilienceResources` (which would return 404 for a foreign-org device). The canonical helper resolves refs one query at a time, and DR device arrays are unbounded; the new guards do it in a single bounded query instead. The org-axis status change would have been a contract change with no security benefit. Org mismatch is deliberately reported *ahead* of the site grant, so a site verdict never confirms that an id exists elsewhere in the org.

**The site-restricted principal-kind list is now exported once** from `resilienceSiteAuthorization.ts` and consumed by the route adapter, replacing an inline duplicate. A kind present in one copy and missing from the other is a silent hole in a boundary Postgres does not enforce.

**`siteRestriction()` does not fail open.** A missing `permissions` context value falls back to the token's own grant rather than reading as "unrestricted". Every route here sits behind `requirePermission`, which always publishes it, so this is not reachable today — but a route added later without that middleware would otherwise inherit a silent fail-open.

## Cost

Unrestricted callers are unchanged and issue **no** additional query — the stored-membership guards return before touching the database. A site-restricted caller pays at most one bounded device lookup per mutation.

## Verification

- Written red-first: the seven route assertions above failed on `origin/main` with the statuses in the table.
- Every guard was confirmed to **fail its test when deleted**, run in isolation to avoid mock-queue bleed between tests. This caught a real hole: the group PATCH *stored* guard was masking the *proposed* guard, so the latter could be removed with every test still green. That case now has its own test.
- Full affected set (dr, drExecutionService, aiToolsDR, resilienceSiteAuthorization, recoveryAuthorizationSubject, routes/backup, drExecutionWorker, aiTools device-gate contract): **28 files, 400 tests passed**.
- Edge cases pinned: `allowedSiteIds: []` (granted zero sites) denies; a stored id whose device row is gone does not wedge maintenance of its group; duplicate and non-string ids are normalised.
- `tsc --noEmit` clean, `eslint` clean on all touched files.
- No schema change, so no RLS/cascade/export-policy registration applies.

## Not in scope

- Per-device `addDeviceIds`/`removeDeviceIds` group operations. The current PATCH mutates the whole aggregate, so a partially-authorized caller cannot safely operate it; finer-grained membership editing is the right long-term answer for a site-restricted technician who legitimately maintains part of a plan.
- Plan groups remain editable while an execution is reconciling, so an edit mid-flight can still change what a running execution targets.
- Read-path site filtering, per the design decision above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBxF7C8E5GxFnNcGf6kBVP