### PR TITLE
feat(auth): surface org-level enforceSSO on the login page (#3229)

### DIFF
--- a/apps/api/src/__tests__/integration/ssoDiscovery.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ssoDiscovery.integration.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Real-DB integration coverage for the public POST /auth/sso-discovery
+ * endpoint (#3229 review follow-up).
+ *
+ * WHY THIS FILE EXISTS. The existing unit suite
+ * (apps/api/src/routes/auth/ssoDiscovery.test.ts) mocks Drizzle with a chain
+ * that never inspects the argument passed to `.where()`. That means the
+ * security-critical SQL predicates the handler builds — `isNotNull(verifiedAt)`,
+ * `eq(status, 'active')`, `eq(enforceSSO, true)`, and the
+ * `orderBy(createdAt, id)` that decides which provider is named — are not
+ * actually proven by that suite: any of them could be deleted from
+ * routes/auth/ssoDiscovery.ts and all of its unit tests would still pass.
+ * Only a real-Postgres run can prove the predicates are wired into the SQL
+ * that actually executes. This file is that proof, structured like the
+ * sibling public pre-auth route's integration test
+ * (loginContext.integration.test.ts): build a bare Hono app around the real
+ * route, seed genuine rows via the superuser test client (getTestDb(),
+ * bypasses RLS — same posture as loginContext's fixtures), and assert on the
+ * real HTTP response.
+ *
+ * Redis: the route calls rateLimiter unconditionally and fails CLOSED without
+ * Redis (same posture as GET /auth/login-context). setup.ts's per-test
+ * beforeEach flushes the shared test Redis DB, so every test here starts with
+ * a clean 20-per-5-minutes bucket for its one request — no limiter mock
+ * needed.
+ *
+ * Wire contract under test: packages/shared/src/types/ssoDiscovery.ts.
+ * `sso` is `{ providerName, loginUrl, enforceSSO: true } | null` — presence of
+ * `sso` IS the availability signal.
+ *
+ * Run:
+ *   pnpm --filter @breeze/api exec vitest run --config vitest.integration.config.ts \
+ *     src/__tests__/integration/ssoDiscovery.integration.test.ts
+ */
+import './setup';
+import { randomUUID } from 'crypto';
+import { describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
+import { getTestDb } from './setup';
+import { ssoProviders, ssoVerifiedDomains } from '../../db/schema';
+import { createOrganization, createPartner } from './db-utils';
+import { ssoDiscoveryRoutes } from '../../routes/auth/ssoDiscovery';
+
+/** Suffix every seeded domain with a random token so cases within a single
+ * test (e.g. the two-orgs-same-domain collision case) and across tests can
+ * never bleed into each other via a stray unique-index collision. */
+function uniqueDomain(label: string): string {
+  return `${label}-${randomUUID().slice(0, 8)}.sso-discovery.example.test`;
+}
+
+async function createVerifiedDomain(
+  orgId: string,
+  domain: string,
+  opts: { verified?: boolean } = {},
+) {
+  const db = getTestDb();
+  const [row] = await db
+    .insert(ssoVerifiedDomains)
+    .values({
+      orgId,
+      domain,
+      verificationToken: `seed-token-${randomUUID()}`,
+      verifiedAt: opts.verified === false ? null : new Date(),
+    })
+    .returning();
+  if (!row) throw new Error('failed to create sso_verified_domains fixture');
+  return row;
+}
+
+async function createOrgProvider(
+  orgId: string,
+  opts: {
+    status?: 'active' | 'inactive' | 'testing';
+    enforceSSO?: boolean;
+    name?: string;
+    type?: 'oidc' | 'saml';
+    createdAt?: Date;
+  } = {},
+) {
+  const db = getTestDb();
+  const [row] = await db
+    .insert(ssoProviders)
+    .values({
+      orgId,
+      partnerId: null,
+      name: opts.name ?? 'Test SSO Provider',
+      type: opts.type ?? 'oidc',
+      status: opts.status ?? 'active',
+      enforceSSO: opts.enforceSSO ?? false,
+      ...(opts.createdAt ? { createdAt: opts.createdAt } : {}),
+    })
+    .returning();
+  if (!row) throw new Error('failed to create sso_providers fixture');
+  return row;
+}
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.route('/auth', ssoDiscoveryRoutes);
+  return app;
+}
+
+async function postDiscovery(app: Hono, email: string) {
+  return app.request('/auth/sso-discovery', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email }),
+  });
+}
+
+describe('POST /auth/sso-discovery — real-DB e2e (#3229)', () => {
+  it('happy path: verified domain + active enforcing oidc provider names that provider and sets Cache-Control: no-store', async () => {
+    const app = buildApp();
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const domain = uniqueDomain('happy');
+    await createVerifiedDomain(org.id, domain);
+    await createOrgProvider(org.id, { status: 'active', enforceSSO: true, name: 'Acme Okta' });
+
+    const res = await postDiscovery(app, `user@${domain}`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('cache-control')).toBe('no-store');
+    const body = await res.json();
+    expect(body).toEqual({
+      sso: {
+        providerName: 'Acme Okta',
+        loginUrl: `/api/v1/sso/login/${org.id}`,
+        enforceSSO: true,
+      },
+    });
+  });
+
+  it('unverified domain (verified_at IS NULL): sso is null even though the org otherwise fully qualifies — proves the isNotNull filter is real', async () => {
+    const app = buildApp();
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const domain = uniqueDomain('unverified');
+    await createVerifiedDomain(org.id, domain, { verified: false });
+    await createOrgProvider(org.id, { status: 'active', enforceSSO: true, name: 'Should Never Be Named' });
+
+    const res = await postDiscovery(app, `user@${domain}`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ sso: null });
+  });
+
+  it('two different orgs each verify the SAME domain: the (org_id, domain) unique index permits the collision, and discovery refuses to guess which org owns it', async () => {
+    const app = buildApp();
+    const partnerA = await createPartner();
+    const orgA = await createOrganization({ partnerId: partnerA.id });
+    const partnerB = await createPartner();
+    const orgB = await createOrganization({ partnerId: partnerB.id });
+    const domain = uniqueDomain('collision');
+    // Both inserts must succeed — if the unique index were on `domain` alone
+    // (not `(org_id, domain)`), the second insert would throw here and fail
+    // the test before the assertion below is ever reached.
+    await createVerifiedDomain(orgA.id, domain);
+    await createVerifiedDomain(orgB.id, domain);
+    await createOrgProvider(orgA.id, { status: 'active', enforceSSO: true, name: 'Org A IdP' });
+    await createOrgProvider(orgB.id, { status: 'active', enforceSSO: true, name: 'Org B IdP' });
+
+    const res = await postDiscovery(app, `user@${domain}`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ sso: null });
+  });
+
+  it('org whose only active provider has enforce_sso=false: sso is null — proves the enforceSSO predicate is real', async () => {
+    const app = buildApp();
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const domain = uniqueDomain('no-enforce');
+    await createVerifiedDomain(org.id, domain);
+    await createOrgProvider(org.id, { status: 'active', enforceSSO: false, name: 'Optional SSO Provider' });
+
+    const res = await postDiscovery(app, `user@${domain}`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ sso: null });
+  });
+
+  it('the enforcing provider is status=inactive with no other active enforcing provider: sso is null — proves the status predicate is real', async () => {
+    const app = buildApp();
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const domain = uniqueDomain('inactive-enforcer');
+    await createVerifiedDomain(org.id, domain);
+    await createOrgProvider(org.id, { status: 'inactive', enforceSSO: true, name: 'Disabled Enforcer' });
+
+    const res = await postDiscovery(app, `user@${domain}`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ sso: null });
+  });
+
+  it('ordering: names the OLDEST active provider (the one GET /sso/login/:orgId actually launches), not the one that enforces', async () => {
+    const app = buildApp();
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const domain = uniqueDomain('ordering');
+    await createVerifiedDomain(org.id, domain);
+    const older = await createOrgProvider(org.id, {
+      status: 'active',
+      enforceSSO: false,
+      name: 'Oldest Non-Enforcing Provider',
+      createdAt: new Date('2020-01-01T00:00:00Z'),
+    });
+    await createOrgProvider(org.id, {
+      status: 'active',
+      enforceSSO: true,
+      name: 'Newer Enforcing Provider',
+      createdAt: new Date('2024-01-01T00:00:00Z'),
+    });
+
+    const res = await postDiscovery(app, `user@${domain}`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      sso: {
+        providerName: older.name,
+        loginUrl: `/api/v1/sso/login/${org.id}`,
+        enforceSSO: true,
+      },
+    });
+  });
+
+  it('the oldest active provider is type=saml (a newer active oidc provider enforces): sso is null — the entry route only supports OIDC', async () => {
+    const app = buildApp();
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const domain = uniqueDomain('saml-oldest');
+    await createVerifiedDomain(org.id, domain);
+    await createOrgProvider(org.id, {
+      status: 'active',
+      enforceSSO: false,
+      type: 'saml',
+      name: 'Oldest SAML Provider',
+      createdAt: new Date('2020-01-01T00:00:00Z'),
+    });
+    await createOrgProvider(org.id, {
+      status: 'active',
+      enforceSSO: true,
+      type: 'oidc',
+      name: 'Newer OIDC Enforcer',
+      createdAt: new Date('2024-01-01T00:00:00Z'),
+    });
+
+    const res = await postDiscovery(app, `user@${domain}`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ sso: null });
+  });
+});

--- a/apps/api/src/routes/auth/index.ts
+++ b/apps/api/src/routes/auth/index.ts
@@ -11,6 +11,7 @@ import { testApprovalRoutes } from './testApproval';
 import { cfAccessRedirectLoginRoutes } from './cfAccessRedirectLogin';
 import { passkeyRoutes } from './passkeys';
 import { loginContextRoutes } from './loginContext';
+import { ssoDiscoveryRoutes } from './ssoDiscovery';
 import { authBindingRoutes } from './binding';
 import { authTransitionTestControlRoutes } from './authTransitionTestControl';
 
@@ -31,5 +32,6 @@ authRoutes.route('/', accountDeletionRoutes);
 authRoutes.route('/', testApprovalRoutes);
 authRoutes.route('/', cfAccessRedirectLoginRoutes);
 authRoutes.route('/', loginContextRoutes);
+authRoutes.route('/', ssoDiscoveryRoutes);
 authRoutes.route('/', authBindingRoutes);
 authRoutes.route('/', authTransitionTestControlRoutes);

--- a/apps/api/src/routes/auth/ssoDiscovery.test.ts
+++ b/apps/api/src/routes/auth/ssoDiscovery.test.ts
@@ -55,13 +55,16 @@ const ORG_UUID_2 = '00000000-0000-4000-8000-0000000000a2';
  *  3. entry-route provider     `.from(t).where(c).orderBy(...).limit(1)`
  * This helper answers whichever shape the call under test uses.
  */
+const orderByCalls: unknown[][] = [];
+
 function selectChain(rows: unknown[]) {
   return {
     from: vi.fn().mockReturnValue({
       where: vi.fn().mockReturnValue({
         limit: vi.fn().mockResolvedValue(rows),
-        orderBy: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue(rows),
+        orderBy: vi.fn((...args: unknown[]) => {
+          orderByCalls.push(args);
+          return { limit: vi.fn().mockResolvedValue(rows) };
         }),
       }),
     }),
@@ -70,6 +73,7 @@ function selectChain(rows: unknown[]) {
 
 /** Queue per-call results in the order the route reads them. */
 function queueSelects(...results: unknown[][]) {
+  orderByCalls.length = 0;
   const mock = vi.mocked(db.select).mockReset();
   for (const rows of results) mock.mockReturnValueOnce(selectChain(rows) as never);
   mock.mockReturnValue(selectChain([]) as never);
@@ -142,6 +146,26 @@ describe('POST /auth/sso-discovery (#3229)', () => {
 
       expect((await res.json()).sso.providerName).toBe('Legacy Okta');
     });
+
+    // The mock cannot execute SQL, so the ONLY unit-level way to catch a
+    // dropped or reordered ORDER BY is to assert the columns it was handed.
+    // The real ordering behaviour is proved in ssoDiscovery.integration.test.ts.
+    it('orders the entry-route lookup by createdAt then id, like every other SSO-discovery surface', async () => {
+      queueSelects(VERIFIED_DOMAIN, ENFORCING_PROVIDER, OIDC_ENTRY_PROVIDER);
+
+      await discover({ email: 'tech@acme.example' });
+
+      const schema = await import('../../db/schema');
+      expect(orderByCalls).toEqual([[schema.ssoProviders.createdAt, schema.ssoProviders.id]]);
+    });
+
+    it('strips the FQDN root dot so `user@example.com.` matches the stored domain', async () => {
+      queueSelects(VERIFIED_DOMAIN, ENFORCING_PROVIDER, OIDC_ENTRY_PROVIDER);
+
+      const res = await discover({ email: 'tech@acme.example.' });
+
+      expect((await res.json()).sso).not.toBeNull();
+    });
   });
 
   // The whole point of the contract: the answer is a function of the DOMAIN and
@@ -193,6 +217,16 @@ describe('POST /auth/sso-discovery (#3229)', () => {
 
     it('returns the negative answer when the org has SSO but does not mandate it', async () => {
       queueSelects(VERIFIED_DOMAIN, []);
+      const res = await discover({ email: 'tech@acme.example' });
+      expect(await res.json()).toEqual(NONE);
+    });
+
+    // Distinct from the non-OIDC case below: here the enforcement probe found a
+    // provider but the entry-route lookup came back empty. Should be impossible
+    // (enforcing implies active), but the route defends against it, so the
+    // defence is exercised rather than assumed.
+    it('returns the negative answer when the entry-route lookup finds nothing', async () => {
+      queueSelects(VERIFIED_DOMAIN, ENFORCING_PROVIDER, []);
       const res = await discover({ email: 'tech@acme.example' });
       expect(await res.json()).toEqual(NONE);
     });

--- a/apps/api/src/routes/auth/ssoDiscovery.test.ts
+++ b/apps/api/src/routes/auth/ssoDiscovery.test.ts
@@ -1,0 +1,271 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../db', () => ({
+  db: { select: vi.fn() },
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../../db/schema', () => ({
+  ssoProviders: {
+    id: 'ssoProviders.id',
+    orgId: 'ssoProviders.orgId',
+    name: 'ssoProviders.name',
+    type: 'ssoProviders.type',
+    status: 'ssoProviders.status',
+    enforceSSO: 'ssoProviders.enforceSSO',
+    createdAt: 'ssoProviders.createdAt',
+  },
+  ssoVerifiedDomains: {
+    orgId: 'ssoVerifiedDomains.orgId',
+    domain: 'ssoVerifiedDomains.domain',
+    verifiedAt: 'ssoVerifiedDomains.verifiedAt',
+  },
+  users: { id: 'users.id', email: 'users.email' },
+}));
+
+vi.mock('../../services', () => ({
+  rateLimiter: vi.fn(async () => ({ allowed: true, remaining: 19, resetAt: new Date() })),
+  getRedis: vi.fn(() => ({})),
+  getTrustedClientIp: vi.fn(() => '203.0.113.7'),
+}));
+
+vi.mock('../../services/clientIp', () => ({
+  getTrustedClientIp: vi.fn(() => '203.0.113.7'),
+  getImmediatePeerIpOrUndefined: vi.fn(() => '203.0.113.7'),
+  rateLimitIpKey: vi.fn((ip: string) => ip),
+  trustsForwardedHeadersFrom: vi.fn(() => true),
+}));
+
+vi.mock('../../services/sentry', () => ({
+  captureException: vi.fn(),
+}));
+
+import { ssoDiscoveryRoutes } from './ssoDiscovery';
+import { db } from '../../db';
+import { rateLimiter, getRedis } from '../../services';
+import { captureException } from '../../services/sentry';
+
+const ORG_UUID = '00000000-0000-4000-8000-0000000000a1';
+const ORG_UUID_2 = '00000000-0000-4000-8000-0000000000a2';
+
+/**
+ * The route issues up to three reads, each a distinct chain shape:
+ *  1. verified-domain lookup   `.from(t).where(c).limit(2)`
+ *  2. enforcement probe        `.from(t).where(c).limit(1)`
+ *  3. entry-route provider     `.from(t).where(c).orderBy(...).limit(1)`
+ * This helper answers whichever shape the call under test uses.
+ */
+function selectChain(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(rows),
+        orderBy: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue(rows),
+        }),
+      }),
+    }),
+  };
+}
+
+/** Queue per-call results in the order the route reads them. */
+function queueSelects(...results: unknown[][]) {
+  const mock = vi.mocked(db.select).mockReset();
+  for (const rows of results) mock.mockReturnValueOnce(selectChain(rows) as never);
+  mock.mockReturnValue(selectChain([]) as never);
+}
+
+const VERIFIED_DOMAIN = [{ orgId: ORG_UUID }];
+const ENFORCING_PROVIDER = [{ id: 'p-enforcing' }];
+const OIDC_ENTRY_PROVIDER = [{ name: 'Authentik', type: 'oidc' }];
+
+async function discover(body: unknown) {
+  return ssoDiscoveryRoutes.request('/sso-discovery', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /auth/sso-discovery (#3229)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getRedis).mockReturnValue({} as never);
+    vi.mocked(rateLimiter).mockResolvedValue({ allowed: true, remaining: 19, resetAt: new Date() } as never);
+    queueSelects();
+  });
+
+  describe('positive resolution', () => {
+    it('names the org SSO provider when a verified domain maps to an SSO-mandating org', async () => {
+      queueSelects(VERIFIED_DOMAIN, ENFORCING_PROVIDER, OIDC_ENTRY_PROVIDER);
+
+      const res = await discover({ email: 'tech@acme.example' });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        sso: {
+          providerName: 'Authentik',
+          loginUrl: `/api/v1/sso/login/${ORG_UUID}`,
+          enforceSSO: true,
+        },
+      });
+    });
+
+    it('never caches the answer', async () => {
+      queueSelects(VERIFIED_DOMAIN, ENFORCING_PROVIDER, OIDC_ENTRY_PROVIDER);
+
+      const res = await discover({ email: 'tech@acme.example' });
+
+      expect(res.headers.get('cache-control')).toBe('no-store');
+    });
+
+    it('matches the domain case-insensitively and ignores address casing', async () => {
+      queueSelects(VERIFIED_DOMAIN, ENFORCING_PROVIDER, OIDC_ENTRY_PROVIDER);
+
+      const res = await discover({ email: '  Tech@ACME.Example  ' });
+
+      expect(res.status).toBe(200);
+      expect((await res.json()).sso).not.toBeNull();
+    });
+
+    // The entry route GET /sso/login/:orgId picks the OLDEST ACTIVE provider
+    // regardless of enforce_sso (sso.ts). Discovery must name that same
+    // provider or the button says one thing and launches another.
+    it('names the oldest active provider, not the enforcing one', async () => {
+      queueSelects(
+        VERIFIED_DOMAIN,
+        [{ id: 'newer-enforcing-provider' }],
+        [{ name: 'Legacy Okta', type: 'oidc' }],
+      );
+
+      const res = await discover({ email: 'tech@acme.example' });
+
+      expect((await res.json()).sso.providerName).toBe('Legacy Okta');
+    });
+  });
+
+  // The whole point of the contract: the answer is a function of the DOMAIN and
+  // the tenant's own published config, never of whether an ACCOUNT exists.
+  describe('no account-existence oracle', () => {
+    it('answers identically for a real-looking and a nonsense local part on the same domain', async () => {
+      queueSelects(VERIFIED_DOMAIN, ENFORCING_PROVIDER, OIDC_ENTRY_PROVIDER);
+      const known = await discover({ email: 'tech@acme.example' });
+      const knownBody = await known.json();
+
+      queueSelects(VERIFIED_DOMAIN, ENFORCING_PROVIDER, OIDC_ENTRY_PROVIDER);
+      const unknown = await discover({ email: 'no-such-person-9f2a@acme.example' });
+
+      expect(known.status).toBe(unknown.status);
+      expect(await unknown.json()).toEqual(knownBody);
+    });
+
+    it('never reads the users table', async () => {
+      queueSelects(VERIFIED_DOMAIN, ENFORCING_PROVIDER, OIDC_ENTRY_PROVIDER);
+
+      await discover({ email: 'tech@acme.example' });
+
+      const schema = await import('../../db/schema');
+      const readTables = vi
+        .mocked(db.select)
+        .mock.results.map((r) => (r.value as { from: ReturnType<typeof vi.fn> }).from.mock.calls[0]?.[0]);
+      expect(readTables).not.toContain(schema.users);
+    });
+  });
+
+  describe('uniform negative answer', () => {
+    const NONE = { sso: null };
+
+    it('returns the negative answer for an unrecognized domain', async () => {
+      queueSelects([]);
+      const res = await discover({ email: 'someone@unknown.example' });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual(NONE);
+    });
+
+    // Two orgs can each verify the same domain (the unique index is on
+    // (org_id, domain), not domain alone). Attributing the login to either one
+    // would be a guess, and a wrong guess sends the user to a stranger's IdP.
+    it('returns the negative answer when two orgs claim the same domain', async () => {
+      queueSelects([{ orgId: ORG_UUID }, { orgId: ORG_UUID_2 }]);
+      const res = await discover({ email: 'someone@shared.example' });
+      expect(await res.json()).toEqual(NONE);
+    });
+
+    it('returns the negative answer when the org has SSO but does not mandate it', async () => {
+      queueSelects(VERIFIED_DOMAIN, []);
+      const res = await discover({ email: 'tech@acme.example' });
+      expect(await res.json()).toEqual(NONE);
+    });
+
+    // The entry route rejects a non-OIDC provider with 400 (sso.ts). Advertising
+    // a button that is guaranteed to fail is worse than showing none.
+    it('returns the negative answer when the entry-route provider is not OIDC', async () => {
+      queueSelects(VERIFIED_DOMAIN, ENFORCING_PROVIDER, [{ name: 'Shibboleth', type: 'saml' }]);
+      const res = await discover({ email: 'tech@acme.example' });
+      expect(await res.json()).toEqual(NONE);
+    });
+
+    it('degrades to the negative answer when the database read throws', async () => {
+      vi.mocked(db.select).mockReset().mockImplementation(() => {
+        throw new Error('connection terminated');
+      });
+
+      const res = await discover({ email: 'tech@acme.example' });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual(NONE);
+      expect(res.headers.get('cache-control')).toBe('no-store');
+      expect(captureException).toHaveBeenCalled();
+    });
+  });
+
+  describe('rate limiting', () => {
+    it('keys the bucket on the client, never on the email', async () => {
+      queueSelects(VERIFIED_DOMAIN, ENFORCING_PROVIDER, OIDC_ENTRY_PROVIDER);
+
+      await discover({ email: 'tech@acme.example' });
+
+      const key = vi.mocked(rateLimiter).mock.calls[0]?.[1] as string;
+      expect(key).toMatch(/^sso-discovery:/);
+      expect(key).not.toContain('acme.example');
+      expect(key).not.toContain('tech@');
+    });
+
+    it('rejects with 429 once the client bucket is exhausted, without touching the DB', async () => {
+      vi.mocked(rateLimiter).mockResolvedValue({
+        allowed: false,
+        remaining: 0,
+        resetAt: new Date(Date.now() + 60_000),
+      } as never);
+
+      const res = await discover({ email: 'tech@acme.example' });
+
+      expect(res.status).toBe(429);
+      expect(db.select).not.toHaveBeenCalled();
+    });
+
+    // rateLimiter fails CLOSED when Redis is missing, so an unavailable Redis
+    // denies rather than silently serving an unlimited discovery oracle.
+    it('is denied when Redis is unavailable', async () => {
+      vi.mocked(getRedis).mockReturnValue(null as never);
+      vi.mocked(rateLimiter).mockResolvedValue({ allowed: false, remaining: 0, resetAt: new Date() } as never);
+
+      const res = await discover({ email: 'tech@acme.example' });
+
+      expect(res.status).toBe(429);
+    });
+  });
+
+  describe('input validation', () => {
+    it('rejects a body that is not an email address', async () => {
+      const res = await discover({ email: 'not-an-email' });
+      expect(res.status).toBe(400);
+      expect(db.select).not.toHaveBeenCalled();
+    });
+
+    it('rejects a missing email', async () => {
+      const res = await discover({});
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/apps/api/src/routes/auth/ssoDiscovery.ts
+++ b/apps/api/src/routes/auth/ssoDiscovery.ts
@@ -1,0 +1,185 @@
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { and, eq, isNotNull } from 'drizzle-orm';
+import type { SsoDiscoveryResult } from '@breeze/shared';
+import { zValidator } from '../../lib/validation';
+import { db, withSystemDbAccessContext } from '../../db';
+import { ssoProviders, ssoVerifiedDomains } from '../../db/schema';
+import { getRedis, rateLimiter } from '../../services';
+import { captureException } from '../../services/sentry';
+import { authResponseFloorPromise, getClientRateLimitKey } from './helpers';
+
+export const ssoDiscoveryRoutes = new Hono();
+
+// A login page fires at most one of these per address the user types. 20 per
+// 5 minutes is far above any human's rate and far below what a scripted domain
+// sweep needs. Keyed on the CLIENT, never on the submitted address.
+const SSO_DISCOVERY_RATE_LIMIT = { limit: 20, windowSeconds: 300 };
+
+const ssoDiscoverySchema = z.object({
+  email: z.string().trim().email().max(320),
+});
+
+const NO_SSO: SsoDiscoveryResult = { sso: null };
+
+function emailDomain(email: string): string | null {
+  const at = email.lastIndexOf('@');
+  if (at < 1 || at === email.length - 1) return null;
+  return email.slice(at + 1).toLowerCase();
+}
+
+/**
+ * POST /auth/sso-discovery — public, unauthenticated home-realm discovery for
+ * ORG-axis SSO (#3229).
+ *
+ * WHY THIS IS KEYED ON THE DOMAIN AND NOT THE ADDRESS.
+ * The obvious implementation looks the address up in `users`, resolves that
+ * user's tenant, and reports its enforcement. That endpoint would be a flat
+ * account-existence oracle: a distinguishable answer for "this exact address is
+ * registered here" is precisely the signal SR2-22 (forgot-password) and SR2-23
+ * (the login lockout 429) were rewritten to destroy. Re-introducing it on a new
+ * route to save the user a click is not a trade this codebase makes.
+ *
+ * So discovery never touches `users`. The answer is a pure function of
+ *   (email domain) x (the tenant's own DNS-proven, admin-published config),
+ * and is identical for a real address, a typo, and an address that has never
+ * existed. `sso_verified_domains` is the right source because ownership there
+ * is proven by a DNS TXT record (services/ssoDomainVerification.ts) — the
+ * provider's free-text `allowed_domains` list is NOT, so on a shared instance a
+ * hostile tenant could list someone else's domain and have this route point
+ * their users at an attacker-controlled IdP. Only `verified_at IS NOT NULL`
+ * rows count, for the same reason: an unverified row is an unproven claim.
+ *
+ * RESIDUAL DISCLOSURE, stated honestly: a positive answer confirms that the
+ * domain the caller already typed is federated on this instance and names the
+ * provider. That is domain-granular, it is configuration the tenant's own
+ * admin deliberately published, and it enumerates nothing — the caller must
+ * already know the domain to ask. It is the same disclosure every IdP
+ * home-realm-discovery page makes.
+ *
+ * COVERAGE, stated honestly: an org that has NOT verified a domain gets the
+ * negative answer and its users see the password form exactly as they do
+ * today — server-side ssoPolicy still refuses the password, so this is the
+ * pre-existing behaviour, not a regression this route introduces.
+ */
+ssoDiscoveryRoutes.post('/sso-discovery', zValidator('json', ssoDiscoverySchema), async (c) => {
+  // Started before any branch and awaited before every return: the handler
+  // below is NOT branch-free (unlike forgot-password it must actually read the
+  // config it reports), so the shared floor is what keeps a fast negative and a
+  // slow positive in the same latency class. Same equalizer as login/H-4 and
+  // forgot-password/SR2-22 — deliberately not a second one.
+  const floorPromise = authResponseFloorPromise();
+  // Never cacheable: a shared cache in front of the API must not be able to
+  // answer one tenant's discovery request out of another's stored response.
+  c.header('Cache-Control', 'no-store');
+
+  const { email } = c.req.valid('json');
+
+  // Called unconditionally (no `if (redis)` guard) — rateLimiter fails CLOSED
+  // when redis is null, so a missing Redis denies rather than silently serving
+  // an unlimited discovery endpoint. Same posture as GET /auth/login-context.
+  const check = await rateLimiter(
+    getRedis(),
+    `sso-discovery:${getClientRateLimitKey(c)}`,
+    SSO_DISCOVERY_RATE_LIMIT.limit,
+    SSO_DISCOVERY_RATE_LIMIT.windowSeconds
+  );
+  if (!check.allowed) {
+    // A real 429, NOT a `{ sso: null }` 200. The bucket is keyed on the client
+    // and can never be entered by naming a particular address, so it discloses
+    // nothing about any account — while answering "no SSO here" to a throttled
+    // SSO-only user would walk them into a password form the server always
+    // rejects.
+    await floorPromise;
+    return c.json({
+      error: 'Too many requests',
+      retryAfter: Math.max(1, Math.ceil((check.resetAt.getTime() - Date.now()) / 1000)),
+    }, 429);
+  }
+
+  const domain = emailDomain(email.trim().toLowerCase());
+  if (!domain) {
+    await floorPromise;
+    return c.json(NO_SSO);
+  }
+
+  let result: SsoDiscoveryResult;
+  try {
+    result = await withSystemDbAccessContext(async () => {
+      // Pre-auth: there is no request RLS context, so an org-scoped read under
+      // `breeze_app` would return zero rows and silently disable the feature.
+      const domainRows = await db
+        .select({ orgId: ssoVerifiedDomains.orgId })
+        .from(ssoVerifiedDomains)
+        .where(and(
+          eq(ssoVerifiedDomains.domain, domain),
+          isNotNull(ssoVerifiedDomains.verifiedAt)
+        ))
+        .limit(2);
+
+      // The unique index is (org_id, domain), not domain alone, so two orgs can
+      // each prove the same domain. Picking either would be a guess, and a
+      // wrong guess hands the user to a stranger's IdP — refuse to attribute.
+      const [domainRow] = domainRows;
+      if (domainRows.length !== 1 || !domainRow) return NO_SSO;
+      const orgId = domainRow.orgId;
+
+      // Mirrors isPasswordAuthDisabledBySso's org branch exactly (ssoPolicy.ts):
+      // password login is refused if ANY active provider enforces SSO. Asking
+      // the same question the login path asks is what keeps the UI and the
+      // server from disagreeing.
+      const [enforcing] = await db
+        .select({ id: ssoProviders.id })
+        .from(ssoProviders)
+        .where(and(
+          eq(ssoProviders.orgId, orgId),
+          eq(ssoProviders.status, 'active'),
+          eq(ssoProviders.enforceSSO, true)
+        ))
+        .limit(1);
+      if (!enforcing) return NO_SSO;
+
+      // WHICH provider gets named is a separate question from WHETHER SSO is
+      // enforced, and the two can resolve to different rows. GET
+      // /sso/login/:orgId launches the OLDEST ACTIVE provider and does not look
+      // at enforce_sso at all (sso.ts), so naming the enforcing provider found
+      // above would let the button say "Okta" and then start an Authentik flow.
+      // Same ORDER BY as every other SSO-discovery surface (#2195).
+      const [entry] = await db
+        .select({ name: ssoProviders.name, type: ssoProviders.type })
+        .from(ssoProviders)
+        .where(and(
+          eq(ssoProviders.orgId, orgId),
+          eq(ssoProviders.status, 'active')
+        ))
+        .orderBy(ssoProviders.createdAt, ssoProviders.id)
+        .limit(1);
+      if (!entry) return NO_SSO;
+
+      // The entry route rejects anything but OIDC with a 400. A tenant whose
+      // oldest active provider is SAML is already in a locked-out state that
+      // discovery cannot repair; advertising a button that is guaranteed to
+      // fail would only make it harder to diagnose.
+      if (entry.type !== 'oidc') return NO_SSO;
+
+      return {
+        sso: {
+          providerName: entry.name,
+          loginUrl: `/api/v1/sso/login/${orgId}`,
+          enforceSSO: true as const,
+        },
+      };
+    });
+  } catch (err) {
+    // This gates login-page RENDERING on a public route — a DB blip must
+    // degrade to the password form, never surface a 500 (and never a distinct
+    // status that would itself be observable). Same degrade as login-context.
+    console.error('[auth] sso-discovery DB read failed, degrading to no-sso:', err);
+    captureException(err, c);
+    await floorPromise;
+    return c.json(NO_SSO);
+  }
+
+  await floorPromise;
+  return c.json(result);
+});

--- a/apps/api/src/routes/auth/ssoDiscovery.ts
+++ b/apps/api/src/routes/auth/ssoDiscovery.ts
@@ -25,7 +25,12 @@ const NO_SSO: SsoDiscoveryResult = { sso: null };
 function emailDomain(email: string): string | null {
   const at = email.lastIndexOf('@');
   if (at < 1 || at === email.length - 1) return null;
-  return email.slice(at + 1).toLowerCase();
+  // Strip the FQDN root dot: `user@example.com.` is a valid address whose
+  // domain resolves identically to `example.com`, but sso_verified_domains
+  // stores the normalized form (services/ssoDomainVerification.ts), so leaving
+  // the dot on would silently miss a real match.
+  const domain = email.slice(at + 1).toLowerCase().replace(/\.+$/, '');
+  return domain || null;
 }
 
 /**

--- a/apps/docs/src/content/docs/reference/sso.mdx
+++ b/apps/docs/src/content/docs/reference/sso.mdx
@@ -209,8 +209,8 @@ Breeze automatically maps common SAML attribute URIs to user fields:
 The OIDC login flow follows the Authorization Code + PKCE pattern:
 
 <Steps>
-1. **User visits login page.** The frontend calls `GET /api/v1/sso/check/:orgId` to determine if SSO is enabled for the organization.
-2. **User clicks "Sign in with SSO".** The browser navigates to `GET /api/v1/sso/login/:orgId`.
+1. **User types their email and tabs away.** The login page has no `orgId` to check yet, so it calls `POST /api/v1/auth/sso-discovery` with the address instead (see [Login Page Discovery](#login-page-discovery)). A positive answer replaces the password field with a **"Sign in with \{provider\}"** button.
+2. **User clicks "Sign in with \{provider\}".** The browser navigates to `GET /api/v1/sso/login/:orgId`.
 3. **Breeze generates PKCE challenge and state.** A cryptographic `state`, `nonce`, and PKCE `codeVerifier`/`codeChallenge` pair are generated. The PKCE verifier, nonce, and redirect path are stored server-side in the `sso_sessions` table (10-minute TTL); the `state` is additionally bound to the initiating browser via a signed, HttpOnly cookie (`breeze_sso_state`, `SameSite=Lax`, `Secure` in production, scoped to the callback path, 10-minute Max-Age). The cookie carries an HMAC-SHA256 signature of the state (keyed on `APP_ENCRYPTION_KEY`/`SECRET_ENCRYPTION_KEY`, distinct from the JWT secret).
 4. **Redirect to IdP.** Breeze redirects the user to the IdP's authorization endpoint with the PKCE challenge, state, nonce, and redirect URI.
 5. **User authenticates at IdP.** The user signs in at the identity provider.
@@ -373,25 +373,36 @@ This link is updated on every SSO login, keeping the profile and tokens current.
 
 ## SSO Enforcement
 
-When `enforceSSO` is set to `true` on a provider, the organization's login page should disable password-based authentication. The `GET /api/v1/sso/check/:orgId` endpoint returns `enforceSSO: true` so the frontend can hide the password form and redirect users directly to the IdP.
-
-```json
-// GET /api/v1/sso/check/ORG_UUID
-{
-  "ssoEnabled": true,
-  "provider": {
-    "id": "uuid",
-    "name": "Azure AD",
-    "type": "oidc"
-  },
-  "enforceSSO": true,
-  "loginUrl": "/api/v1/sso/login/ORG_UUID"
-}
-```
+When `enforceSSO` is set to `true` on an **active** provider, password-based login is refused for the organization. This is enforced **server-side**, on every password attempt, regardless of what the login page shows — it is not something the frontend can opt out of by not checking first.
 
 <Aside type="caution">
   Before enabling SSO enforcement, ensure that at least one administrator account can still access the system. Consider keeping a break-glass account with password login or testing the SSO flow thoroughly in `testing` status first.
 </Aside>
+
+### Login Page Discovery
+
+The dashboard login page does not know an organization's `orgId` (and so cannot call `GET /sso/check/:orgId`) until a user has already picked that organization — which, for a first-time visitor typing an email address, hasn't happened yet. When a user tabs out of the email field, the page instead calls the public, unauthenticated `POST /api/v1/auth/sso-discovery` with the address. If it names a provider, the password field and submit button are replaced with a **"Sign in with \{provider\}"** button and a **"Sign in with password instead"** link — the password path stays reachable, since discovery is a convenience, not the enforcement point.
+
+```json
+// POST /api/v1/auth/sso-discovery
+// { "email": "user@example.com" }
+{
+  "sso": {
+    "providerName": "Azure AD",
+    "loginUrl": "/api/v1/sso/login/ORG_UUID",
+    "enforceSSO": true
+  }
+}
+```
+
+Discovery answers `{ "sso": null }` whenever it can't give a safe, unambiguous answer:
+
+- **It is keyed on the email's domain, never on the address itself**, and never reads the `users` table — a real address and a made-up one at the same domain get the identical answer. This is deliberate: a distinguishable answer per address would be an account-existence oracle.
+- **The domain must be verified.** Only a domain the organization has proven ownership of via DNS (the same domain-verification mechanism behind [Verified Email Required](#verified-email-required), `sso_verified_domains`) is eligible. An org with `allowedDomains` configured but no *verified* domain gets `{ "sso": null }` — `allowedDomains` is unverified free text and is deliberately not used here, since a hostile tenant on a shared instance could otherwise claim someone else's domain and have discovery point their users at an attacker-controlled IdP.
+- **If two organizations have verified the same domain, discovery refuses to guess** and returns `{ "sso": null }`.
+- **The named provider is the org's oldest active provider** — the same one `GET /api/v1/sso/login/:orgId` launches — not necessarily the one with `enforceSSO` set. If that provider is SAML rather than OIDC, discovery also returns `{ "sso": null }`, since the login entry route only supports OIDC today.
+
+An organization that hasn't verified a domain sees the password form exactly as before — this is pre-existing behavior, not a regression introduced by discovery.
 
 ---
 
@@ -563,6 +574,7 @@ All routes are prefixed with `/api/v1/sso`, except where a full path starting wi
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
 | `GET` | `/sso/check/:orgId` | None | Check if SSO is enabled for an organization. Returns provider name, type, enforcement status, and login URL. |
+| `POST` | `/api/v1/auth/sso-discovery` | None | Home-realm discovery by email domain (see [Login Page Discovery](#login-page-discovery)). Body: `{ "email": "..." }`. Always returns `{ "sso": null }` or `{ "sso": { "providerName", "loginUrl", "enforceSSO": true } }` — never an account-existence signal. Rate-limited per client. |
 | `GET` | `/sso/login/:orgId` | None | Initiate SSO login for an organization. Generates PKCE + state and redirects to the IdP. |
 | `GET` | `/sso/login/partner/:partnerId` | None | Initiate partner-wide SSO login (technician sign-in). Uses the oldest active partner provider. |
 | `GET` | `/api/v1/auth/login-context` | None | Login-page context: partner login branding and the partner SSO button target. Returns empty values on hosted or multi-partner deployments. |

--- a/apps/docs/src/content/docs/reference/users-and-roles.mdx
+++ b/apps/docs/src/content/docs/reference/users-and-roles.mdx
@@ -318,7 +318,7 @@ Provider status can be `active`, `inactive`, or `testing`. Only `active` provide
 
 ### SSO Check
 
-The frontend can check whether an organisation has SSO enabled by calling the public endpoint `GET /sso/check/:orgId`. This returns the provider name, type, and whether SSO is enforced.
+The frontend can check whether an organisation has SSO enabled by calling the public endpoint `GET /sso/check/:orgId`. This returns the provider name, type, and whether SSO is enforced. The dashboard login page does not have an `orgId` to pass this endpoint until after a user has chosen an organisation, so it instead discovers SSO from the typed email address via `POST /auth/sso-discovery` — see [Login Page Discovery](/reference/sso/#login-page-discovery) in the SSO reference.
 
 ---
 

--- a/apps/web/src/components/auth/LoginForm.tsx
+++ b/apps/web/src/components/auth/LoginForm.tsx
@@ -10,18 +10,36 @@ type LoginFormValues = {
   password: string;
 };
 
+// Org-axis SSO discovered from the address the user typed (#3229). When set,
+// the form collapses its PASSWORD controls only and keeps the email field
+// visible — unlike the partner-axis collapse in LoginPage, which happens at
+// page load and can drop the whole form because nothing has been typed yet.
+// Collapsing the email field here would delete the very input the discovery
+// keys on, and the user could no longer correct a typo'd address.
+type LoginFormSsoPrompt = {
+  providerName: string;
+  onSelect: () => void;
+  onUsePassword: () => void;
+  busy?: boolean;
+};
+
 type LoginFormProps = {
   onSubmit?: (values: LoginFormValues) => void | Promise<void>;
   errorMessage?: string;
   submitLabel?: string;
   loading?: boolean;
+  /** Fired with the raw field value when the email input loses focus. */
+  onEmailSettled?: (email: string) => void;
+  ssoPrompt?: LoginFormSsoPrompt | null;
 };
 
 export default function LoginForm({
   onSubmit,
   errorMessage,
   submitLabel,
-  loading
+  loading,
+  onEmailSettled,
+  ssoPrompt
 }: LoginFormProps) {
   const { t } = useTranslation('auth');
   const loginSchema = useMemo(
@@ -51,11 +69,26 @@ export default function LoginForm({
   // the server would reject.
   const { enabled: registrationEnabled } = useRegistrationGate();
 
+  // Collapsed: the password controls are replaced by the SSO button. Enter in
+  // the email field and a click on the button must do the same thing, so the
+  // button IS the submit control and the form's submit handler is swapped —
+  // otherwise implicit submission would run the password validator against a
+  // field that isn't rendered and surface a "password must be 8 characters"
+  // error for a flow that has no password.
+  const emailField = register('email');
+
   return (
     <form
-      onSubmit={handleSubmit(async values => {
-        await onSubmit?.(values);
-      })}
+      onSubmit={
+        ssoPrompt
+          ? (event) => {
+              event.preventDefault();
+              ssoPrompt.onSelect();
+            }
+          : handleSubmit(async values => {
+              await onSubmit?.(values);
+            })
+      }
       className="space-y-6"
     >
       <div className="space-y-2">
@@ -69,35 +102,43 @@ export default function LoginForm({
           placeholder={t('placeholders.email', { defaultValue: 'you@company.com' })}
           data-testid="login-email-input"
           className="h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
-          {...register('email')}
+          {...emailField}
+          onBlur={(event) => {
+            // Compose, never replace: react-hook-form's own onBlur is what marks
+            // the field touched and runs its validation.
+            void emailField.onBlur(event);
+            onEmailSettled?.(event.target.value);
+          }}
         />
         {errors.email && (
           <p data-testid="login-email-error" className="text-sm text-destructive">{errors.email.message}</p>
         )}
       </div>
 
-      <div className="space-y-2">
-        <div className="flex items-center justify-between">
-          <label htmlFor="password" className="text-sm font-medium">
-            {t('fields.password', { defaultValue: 'Password' })}
-          </label>
-          <a href="/forgot-password" className="text-sm text-primary hover:underline">
-            {t('login.forgotPassword', { defaultValue: 'Forgot password?' })}
-          </a>
+      {!ssoPrompt && (
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <label htmlFor="password" className="text-sm font-medium">
+              {t('fields.password', { defaultValue: 'Password' })}
+            </label>
+            <a href="/forgot-password" className="text-sm text-primary hover:underline">
+              {t('login.forgotPassword', { defaultValue: 'Forgot password?' })}
+            </a>
+          </div>
+          <input
+            id="password"
+            type="password"
+            autoComplete="current-password"
+            placeholder={t('placeholders.currentPassword', { defaultValue: 'Enter your password' })}
+            data-testid="login-password-input"
+            className="h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+            {...register('password')}
+          />
+          {errors.password && (
+            <p data-testid="login-password-error" className="text-sm text-destructive">{errors.password.message}</p>
+          )}
         </div>
-        <input
-          id="password"
-          type="password"
-          autoComplete="current-password"
-          placeholder={t('placeholders.currentPassword', { defaultValue: 'Enter your password' })}
-          data-testid="login-password-input"
-          className="h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
-          {...register('password')}
-        />
-        {errors.password && (
-          <p data-testid="login-password-error" className="text-sm text-destructive">{errors.password.message}</p>
-        )}
-      </div>
+      )}
 
       {errorMessage && (
         <div
@@ -108,14 +149,44 @@ export default function LoginForm({
         </div>
       )}
 
-      <button
-        type="submit"
-        disabled={isLoading}
-        data-testid="login-submit"
-        className="flex h-11 w-full items-center justify-center rounded-md bg-primary text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
-      >
-        {isLoading ? t('login.signingIn', { defaultValue: 'Signing in...' }) : submitLabel ?? t('common.signIn', { defaultValue: 'Sign in' })}
-      </button>
+      {ssoPrompt ? (
+        <div className="space-y-3">
+          <button
+            type="submit"
+            disabled={ssoPrompt.busy}
+            data-testid="org-sso-button"
+            className="flex h-11 w-full items-center justify-center rounded-md bg-primary text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {t('login.signInWithProvider', {
+              defaultValue: `Sign in with ${ssoPrompt.providerName}`,
+              providerName: ssoPrompt.providerName,
+            })}
+          </button>
+          {/*
+            The reveal is NOT a bypass: the server refuses the password anyway
+            (ssoPolicy). It exists so a user whose IdP is down, or who reached a
+            shared login page from a different tenant, is never trapped in a
+            dead end with no way back to the form — the #4067 lockout lesson.
+          */}
+          <button
+            type="button"
+            data-testid="org-sso-use-password"
+            onClick={ssoPrompt.onUsePassword}
+            className="w-full text-center text-sm text-muted-foreground hover:text-foreground hover:underline"
+          >
+            {t('login.signInWithPasswordInstead', { defaultValue: 'Sign in with password instead' })}
+          </button>
+        </div>
+      ) : (
+        <button
+          type="submit"
+          disabled={isLoading}
+          data-testid="login-submit"
+          className="flex h-11 w-full items-center justify-center rounded-md bg-primary text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {isLoading ? t('login.signingIn', { defaultValue: 'Signing in...' }) : submitLabel ?? t('common.signIn', { defaultValue: 'Sign in' })}
+        </button>
+      )}
 
       {registrationEnabled && (
         <div className="space-y-2 text-center text-sm text-muted-foreground">

--- a/apps/web/src/components/auth/LoginPage.orgSso.test.tsx
+++ b/apps/web/src/components/auth/LoginPage.orgSso.test.tsx
@@ -38,6 +38,7 @@ beforeEach(() => {
 
 import LoginPage from './LoginPage';
 import { discoverOrgSso } from '../../lib/ssoDiscovery';
+import { getLoginContext } from '../../lib/loginContext';
 
 const AUTHENTIK = {
   providerName: 'Authentik',
@@ -58,6 +59,7 @@ describe('LoginPage org-level SSO discovery (#3229)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(discoverOrgSso).mockResolvedValue(null);
+    vi.mocked(getLoginContext).mockResolvedValue({ branding: null, partnerSso: null });
   });
 
   it('collapses the password field and offers the IdP once the address resolves to an SSO-mandating org', async () => {
@@ -116,6 +118,115 @@ describe('LoginPage org-level SSO discovery (#3229)', () => {
     await enterEmail('tech@other.example');
 
     expect(await screen.findByTestId('org-sso-button')).toHaveTextContent(/Keycloak/);
+  });
+
+  describe('starting the SSO flow', () => {
+    it('bootstraps the browser binding, then navigates to the org entry route with the redirect', async () => {
+      vi.mocked(discoverOrgSso).mockResolvedValue(AUTHENTIK);
+
+      const calls: string[] = [];
+      vi.mocked(fetch).mockImplementation(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        calls.push(url);
+        if (url.endsWith('/api/v1/config')) {
+          return new Response(JSON.stringify({ cfAccessLogin: { enabled: false } }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+        return new Response(null, { status: 204 });
+      });
+      const realLocation = window.location;
+      const assign = vi.fn((url: string) => { calls.push(url); });
+      Object.defineProperty(window, 'location', { configurable: true, value: { ...realLocation, assign } });
+
+      try {
+        render(<LoginPage next="/devices" />);
+        await enterEmail('tech@acme.example');
+        fireEvent.click(await screen.findByTestId('org-sso-button'));
+
+        await waitFor(() => expect(assign).toHaveBeenCalledWith(
+          `${AUTHENTIK.loginUrl}?redirect=%2Fdevices`,
+        ));
+        // The binding bootstrap must PRECEDE the navigation, or the SSO
+        // callback lands with no browser transition to recover.
+        expect(calls.slice(-2)).toEqual([
+          '/api/v1/auth/browser-binding/bootstrap',
+          `${AUTHENTIK.loginUrl}?redirect=%2Fdevices`,
+        ]);
+      } finally {
+        Object.defineProperty(window, 'location', { configurable: true, value: realLocation });
+      }
+    });
+
+    // Enter in the email field must start the SSO flow, not run the password
+    // validator against a field that is no longer rendered.
+    it('starts the SSO flow on implicit form submission', async () => {
+      vi.mocked(discoverOrgSso).mockResolvedValue(AUTHENTIK);
+
+      const realLocation = window.location;
+      const assign = vi.fn();
+      Object.defineProperty(window, 'location', { configurable: true, value: { ...realLocation, assign } });
+
+      try {
+        render(<LoginPage />);
+        await enterEmail('tech@acme.example');
+        const button = await screen.findByTestId('org-sso-button');
+        fireEvent.submit(button.closest('form')!);
+
+        // `?redirect=%2F` because getSafeNext() defaults to "/" — same URL the
+        // partner-axis button builds when no `next` is present.
+        await waitFor(() => expect(assign).toHaveBeenCalledWith(`${AUTHENTIK.loginUrl}?redirect=%2F`));
+        expect(screen.queryByTestId('login-password-error')).not.toBeInTheDocument();
+      } finally {
+        Object.defineProperty(window, 'location', { configurable: true, value: realLocation });
+      }
+    });
+
+    it('disables the button while bootstrapping and surfaces a bootstrap failure', async () => {
+      vi.mocked(discoverOrgSso).mockResolvedValue(AUTHENTIK);
+
+      let resolveBootstrap!: (response: Response) => void;
+      const bootstrap = new Promise<Response>((resolve) => { resolveBootstrap = resolve; });
+      vi.mocked(fetch).mockImplementation(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith('/api/v1/config')) {
+          return new Response(JSON.stringify({ cfAccessLogin: { enabled: false } }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+        return bootstrap;
+      });
+
+      render(<LoginPage />);
+      await enterEmail('tech@acme.example');
+      const button = await screen.findByTestId('org-sso-button');
+      fireEvent.click(button);
+
+      expect(button).toBeDisabled();
+      resolveBootstrap(new Response(JSON.stringify({ error: 'unavailable' }), { status: 503 }));
+
+      expect(await screen.findByText('Authentication bootstrap failed')).toBeInTheDocument();
+      expect(button).not.toBeDisabled();
+    });
+  });
+
+  // Partner-axis enforcement collapses the whole form at page load, so there is
+  // no email field to discover from. Locking this in: it is the one shape where
+  // org discovery deliberately never runs, and a future change that made the
+  // partner collapse keep the form would silently start firing discovery.
+  it('never runs discovery when partner-axis enforcement has already collapsed the form', async () => {
+    vi.mocked(getLoginContext).mockResolvedValue({
+      branding: null,
+      partnerSso: { providerName: 'Okta', loginUrl: '/api/v1/sso/login/partner/p1', enforceSSO: true },
+    });
+
+    render(<LoginPage />);
+
+    await screen.findByTestId('show-password-form');
+    expect(screen.queryByLabelText(/email/i)).not.toBeInTheDocument();
+    expect(discoverOrgSso).not.toHaveBeenCalled();
   });
 
   describe('request discipline', () => {

--- a/apps/web/src/components/auth/LoginPage.orgSso.test.tsx
+++ b/apps/web/src/components/auth/LoginPage.orgSso.test.tsx
@@ -1,0 +1,164 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../stores/auth', () => ({
+  useAuthStore: Object.assign(
+    (selector: (s: { login: ReturnType<typeof vi.fn> }) => unknown) => selector({ login: vi.fn() }),
+    {},
+  ),
+  apiLogin: vi.fn(),
+  apiVerifyMFA: vi.fn(),
+  apiVerifyPasskeyMFA: vi.fn(),
+  apiSendSmsMfaCode: vi.fn(),
+  fetchAndApplyPreferences: vi.fn(),
+  fetchWithAuth: vi.fn(async () => new Response('{}', { status: 200 })),
+}));
+
+vi.mock('../../lib/navigation', () => ({ navigateTo: vi.fn() }));
+
+vi.mock('../../lib/loginContext', () => ({
+  getLoginContext: vi.fn(async () => ({ branding: null, partnerSso: null })),
+}));
+
+vi.mock('../../lib/ssoDiscovery', () => ({
+  discoverOrgSso: vi.fn(async () => null),
+}));
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () =>
+      new Response(JSON.stringify({ cfAccessLogin: { enabled: false } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    )
+  );
+});
+
+import LoginPage from './LoginPage';
+import { discoverOrgSso } from '../../lib/ssoDiscovery';
+
+const AUTHENTIK = {
+  providerName: 'Authentik',
+  loginUrl: '/api/v1/sso/login/00000000-0000-4000-8000-0000000000a1',
+  enforceSSO: true as const,
+};
+
+async function enterEmail(email: string) {
+  const field = await screen.findByLabelText(/email/i);
+  fireEvent.change(field, { target: { value: email } });
+  fireEvent.blur(field);
+  return field;
+}
+
+// #3229: an org with enforce_sso=true used to render the plain password form —
+// the user was never offered SSO and the server rejected every password.
+describe('LoginPage org-level SSO discovery (#3229)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(discoverOrgSso).mockResolvedValue(null);
+  });
+
+  it('collapses the password field and offers the IdP once the address resolves to an SSO-mandating org', async () => {
+    vi.mocked(discoverOrgSso).mockResolvedValue(AUTHENTIK);
+
+    render(<LoginPage />);
+    await enterEmail('tech@acme.example');
+
+    expect(await screen.findByTestId('org-sso-button')).toHaveTextContent(/Authentik/);
+    await waitFor(() => expect(screen.queryByTestId('login-password-input')).not.toBeInTheDocument());
+    expect(screen.queryByTestId('login-submit')).not.toBeInTheDocument();
+  });
+
+  // The email field is the input discovery keys on: unmounting it would strand
+  // a user who typo'd the address with no way to correct it.
+  it('keeps the email field visible while the password controls are collapsed', async () => {
+    vi.mocked(discoverOrgSso).mockResolvedValue(AUTHENTIK);
+
+    render(<LoginPage />);
+    await enterEmail('tech@acme.example');
+
+    await screen.findByTestId('org-sso-button');
+    expect(screen.getByLabelText(/email/i)).toHaveValue('tech@acme.example');
+  });
+
+  it('leaves the password form untouched when the address resolves to nothing', async () => {
+    render(<LoginPage />);
+    await enterEmail('someone@unknown.example');
+
+    await waitFor(() => expect(discoverOrgSso).toHaveBeenCalledWith('someone@unknown.example'));
+    expect(screen.getByTestId('login-password-input')).toBeInTheDocument();
+    expect(screen.queryByTestId('org-sso-button')).not.toBeInTheDocument();
+  });
+
+  it('restores the password form when the user asks for it', async () => {
+    vi.mocked(discoverOrgSso).mockResolvedValue(AUTHENTIK);
+
+    render(<LoginPage />);
+    await enterEmail('tech@acme.example');
+
+    fireEvent.click(await screen.findByTestId('org-sso-use-password'));
+
+    expect(await screen.findByTestId('login-password-input')).toBeInTheDocument();
+    expect(screen.queryByTestId('org-sso-button')).not.toBeInTheDocument();
+  });
+
+  it('re-collapses when the user then types an address at a different SSO-mandating org', async () => {
+    vi.mocked(discoverOrgSso).mockResolvedValue(AUTHENTIK);
+
+    render(<LoginPage />);
+    await enterEmail('tech@acme.example');
+    fireEvent.click(await screen.findByTestId('org-sso-use-password'));
+    expect(await screen.findByTestId('login-password-input')).toBeInTheDocument();
+
+    vi.mocked(discoverOrgSso).mockResolvedValue({ ...AUTHENTIK, providerName: 'Keycloak' });
+    await enterEmail('tech@other.example');
+
+    expect(await screen.findByTestId('org-sso-button')).toHaveTextContent(/Keycloak/);
+  });
+
+  describe('request discipline', () => {
+    it('does not ask about a half-typed address', async () => {
+      render(<LoginPage />);
+      await enterEmail('tech@');
+
+      expect(discoverOrgSso).not.toHaveBeenCalled();
+    });
+
+    it('asks once per address, not once per blur', async () => {
+      render(<LoginPage />);
+      const field = await enterEmail('tech@acme.example');
+      fireEvent.blur(field);
+      fireEvent.blur(field);
+
+      expect(discoverOrgSso).toHaveBeenCalledTimes(1);
+    });
+
+    it('normalizes the address before asking', async () => {
+      render(<LoginPage />);
+      await enterEmail('  Tech@ACME.Example  ');
+
+      expect(discoverOrgSso).toHaveBeenCalledWith('tech@acme.example');
+    });
+
+    // A slow answer for an address the user has already replaced must not
+    // resurrect an SSO button for a tenant they are no longer signing in to.
+    it('ignores a stale answer that lands after the address changed', async () => {
+      let resolveFirst: (v: typeof AUTHENTIK | null) => void = () => {};
+      vi.mocked(discoverOrgSso)
+        .mockImplementationOnce(() => new Promise((resolve) => { resolveFirst = resolve; }))
+        .mockResolvedValueOnce(null);
+
+      render(<LoginPage />);
+      await enterEmail('tech@acme.example');
+      await enterEmail('someone@unknown.example');
+      await waitFor(() => expect(discoverOrgSso).toHaveBeenCalledTimes(2));
+
+      resolveFirst(AUTHENTIK);
+
+      await waitFor(() => expect(screen.getByTestId('login-password-input')).toBeInTheDocument());
+      expect(screen.queryByTestId('org-sso-button')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/auth/LoginPage.tsx
+++ b/apps/web/src/components/auth/LoginPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import LoginForm from './LoginForm';
 import MFAVerifyForm from './MFAVerifyForm';
@@ -15,6 +15,7 @@ import type { MfaChallenge, MfaMethod } from '../../stores/auth';
 import { navigateTo } from '../../lib/navigation';
 import { getSafeNext } from '../../lib/authNext';
 import { getLoginContext } from '../../lib/loginContext';
+import { discoverOrgSso, type SsoDiscoveryProvider } from '../../lib/ssoDiscovery';
 import { parseMfaChallengeResponse } from '../../lib/mfaChallenge';
 // Initializes the shared i18next singleton. This page's layout has no Sidebar
 // (which is what pulls i18n in elsewhere), so without this every t() call here
@@ -187,6 +188,18 @@ export default function LoginPage({ next }: LoginPageProps = {}) {
   // form that's collapsed behind it (see the enforceSSO comment below).
   const [showPasswordForm, setShowPasswordForm] = useState(false);
   const [ssoBootstrapping, setSsoBootstrapping] = useState(false);
+  // Org-axis SSO for the address currently in the email field (#3229). Null
+  // until an entered address resolves to an org that MANDATES SSO; the server
+  // answers null for every other case, so this is only ever set when the
+  // password form would be refused anyway.
+  const [orgSso, setOrgSso] = useState<SsoDiscoveryProvider | null>(null);
+  const [orgSsoDismissed, setOrgSsoDismissed] = useState(false);
+  // The address the in-flight/last discovery was for, so retyping the same
+  // address (tab out, tab back) does not re-spend the rate-limit budget.
+  const lastDiscoveredEmail = useRef<string | null>(null);
+  // Monotonic request id. A slow answer for an address the user has already
+  // replaced must never overwrite the answer for the address on screen.
+  const discoverySeq = useRef(0);
 
   const login = useAuthStore((state) => state.login);
 
@@ -358,6 +371,38 @@ export default function LoginPage({ next }: LoginPageProps = {}) {
     return true;
   };
 
+  const handleEmailSettled = useCallback((raw: string) => {
+    const email = raw.trim().toLowerCase();
+    // Cheap syntactic gate: the API 400s anything that isn't an address, and a
+    // half-typed one is a wasted request against a limited budget.
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) return;
+    if (lastDiscoveredEmail.current === email) return;
+    lastDiscoveredEmail.current = email;
+
+    const seq = ++discoverySeq.current;
+    void discoverOrgSso(email).then((provider) => {
+      if (seq !== discoverySeq.current) return;
+      setOrgSso(provider);
+      // A newly discovered tenant re-collapses the password controls: the
+      // previous "show me the password form anyway" was about the previous
+      // address, not this one.
+      setOrgSsoDismissed(false);
+    });
+  }, []);
+
+  const handleOrgSso = async () => {
+    if (!orgSso || ssoBootstrapping) return;
+    const url = `${orgSso.loginUrl}${safeNext ? `?redirect=${encodeURIComponent(safeNext)}` : ''}`;
+    setSsoBootstrapping(true);
+    setError(undefined);
+    try {
+      await bootstrapThenNavigate(url);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Authentication bootstrap failed');
+      setSsoBootstrapping(false);
+    }
+  };
+
   const handlePartnerSso = async () => {
     if (!partnerSso || ssoBootstrapping) return;
     const url = `${partnerSso.loginUrl}${safeNext ? `?redirect=${encodeURIComponent(safeNext)}` : ''}`;
@@ -471,6 +516,17 @@ export default function LoginPage({ next }: LoginPageProps = {}) {
           onSubmit={handleLogin}
           errorMessage={error}
           loading={loading}
+          onEmailSettled={handleEmailSettled}
+          ssoPrompt={
+            orgSso && !orgSsoDismissed
+              ? {
+                  providerName: orgSso.providerName,
+                  onSelect: () => { void handleOrgSso(); },
+                  onUsePassword: () => setOrgSsoDismissed(true),
+                  busy: ssoBootstrapping,
+                }
+              : null
+          }
         />
       )}
       <McpUrlCard variant="compact" requireOAuth className="mt-8" />

--- a/apps/web/src/lib/ssoDiscovery.test.ts
+++ b/apps/web/src/lib/ssoDiscovery.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { discoverOrgSso } from './ssoDiscovery';
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+const VALID = {
+  providerName: 'Authentik',
+  loginUrl: '/api/v1/sso/login/00000000-0000-4000-8000-0000000000a1',
+  enforceSSO: true,
+};
+
+describe('discoverOrgSso (#3229)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  it('POSTs the address to the discovery endpoint', async () => {
+    const fetchMock = vi.fn(async (_url: string, _init: RequestInit) => jsonResponse({ sso: null }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await discoverOrgSso('tech@acme.example');
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toContain('/api/v1/auth/sso-discovery');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toEqual({ email: 'tech@acme.example' });
+  });
+
+  it('returns the provider on a positive answer', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ sso: VALID })));
+
+    await expect(discoverOrgSso('tech@acme.example')).resolves.toEqual(VALID);
+  });
+
+  it('returns null on the negative answer', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ sso: null })));
+
+    await expect(discoverOrgSso('nobody@unknown.example')).resolves.toBeNull();
+  });
+
+  // Every non-200 (429 rate limited, 400 validation, 5xx) must leave the
+  // password form in place rather than throwing into the login page.
+  it.each([400, 429, 500, 503])('returns null on HTTP %i', async (status) => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ error: 'nope' }, status)));
+
+    await expect(discoverOrgSso('tech@acme.example')).resolves.toBeNull();
+  });
+
+  it('returns null and warns when the request fails outright', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('network down'); }));
+
+    await expect(discoverOrgSso('tech@acme.example')).resolves.toBeNull();
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  // loginUrl is handed to a top-level navigation, so a response that does not
+  // look like the org SSO entry route must be discarded, not followed.
+  describe('rejects a loginUrl that is not the org SSO entry route', () => {
+    it.each([
+      ['an absolute URL to another origin', 'https://evil.example/api/v1/sso/login/x'],
+      ['a protocol-relative URL', '//evil.example'],
+      ['a protocol-relative URL smuggled under the prefix', '/api/v1/sso/login//evil.example'],
+      ['an unrelated path', '/settings'],
+      ['a non-string', 42],
+    ])('%s', async (_label, loginUrl) => {
+      vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ sso: { ...VALID, loginUrl } })));
+
+      await expect(discoverOrgSso('tech@acme.example')).resolves.toBeNull();
+    });
+  });
+
+  it('rejects a response with no provider name', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ sso: { loginUrl: VALID.loginUrl } })));
+
+    await expect(discoverOrgSso('tech@acme.example')).resolves.toBeNull();
+  });
+});

--- a/apps/web/src/lib/ssoDiscovery.ts
+++ b/apps/web/src/lib/ssoDiscovery.ts
@@ -1,0 +1,53 @@
+import type { SsoDiscoveryProvider, SsoDiscoveryResult } from '@breeze/shared';
+
+export type { SsoDiscoveryProvider, SsoDiscoveryResult };
+
+// The API always builds this as `/api/v1/sso/login/${orgId}`. The value is
+// handed straight to a top-level navigation, so re-assert the shape client-side
+// rather than trusting whatever came back: a same-origin absolute path under
+// the org SSO entry route, nothing else. Cheap, and it means a malformed or
+// tampered response degrades to the password form instead of navigating away.
+const ORG_SSO_LOGIN_PREFIX = '/api/v1/sso/login/';
+
+function isUsableLoginUrl(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    value.startsWith(ORG_SSO_LOGIN_PREFIX) &&
+    // `//evil.example` and `/api/v1/sso/login//evil.example` are protocol-
+    // relative URLs, not paths — reject anything with a second slash run.
+    !value.slice(1).includes('//')
+  );
+}
+
+/**
+ * Home-realm discovery for the address the user just entered (#3229).
+ *
+ * Returns the org's SSO provider only when that org MANDATES SSO; every other
+ * outcome — unknown domain, no SSO, optional SSO, rate limited, network
+ * failure — is `null`, which leaves the password form exactly as it is. The
+ * server is the only enforcement point (ssoPolicy); this call is presentation.
+ */
+export async function discoverOrgSso(email: string): Promise<SsoDiscoveryProvider | null> {
+  try {
+    const apiHost = import.meta.env.PUBLIC_API_URL || '';
+    // Same timeout rationale as getLoginContext: a hung request must never
+    // stall the login page. It is a progressive enhancement on a form that
+    // already works without it.
+    const res = await fetch(`${apiHost}/api/v1/auth/sso-discovery`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email }),
+      signal: AbortSignal.timeout(4000),
+    });
+    if (!res.ok) return null;
+    const body = (await res.json()) as Partial<SsoDiscoveryResult>;
+    const sso = body.sso;
+    if (!sso || typeof sso.providerName !== 'string' || !isUsableLoginUrl(sso.loginUrl)) return null;
+    return { providerName: sso.providerName, loginUrl: sso.loginUrl, enforceSSO: true };
+  } catch (err) {
+    // Fail open to the password form — but leave a trace, or a deployment-wide
+    // config/CORS regression silently disables org SSO discovery with no signal.
+    console.warn('[login] SSO discovery failed; leaving the password form in place', err);
+    return null;
+  }
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -840,6 +840,7 @@ export * from './portalVisibility';
 // ============================================
 
 export * from './loginContext';
+export * from './ssoDiscovery';
 export * from './publicQuote';
 
 // ============================================

--- a/packages/shared/src/types/ssoDiscovery.ts
+++ b/packages/shared/src/types/ssoDiscovery.ts
@@ -1,0 +1,29 @@
+// Wire contract for the public POST /auth/sso-discovery endpoint (#3229).
+// Single source of truth shared by the API route (apps/api/src/routes/auth/
+// ssoDiscovery.ts) and the web client (apps/web/src/lib/ssoDiscovery.ts) so
+// the two sides cannot silently drift — same arrangement as LoginContext.
+
+export type SsoDiscoveryProvider = {
+  providerName: string;
+  /** Org-axis SSO entry route: `/api/v1/sso/login/${orgId}`. */
+  loginUrl: string;
+  /**
+   * Always `true` when present. The endpoint only answers with a provider for
+   * a tenant that MANDATES SSO — a tenant with optional SSO is indistinguishable
+   * from an unrecognized domain (see the route's disclosure comment). Kept as an
+   * explicit field so the shape mirrors LoginContextPartnerSso and so a future
+   * "optional SSO" answer is an additive change, not a breaking one.
+   */
+  enforceSSO: true;
+};
+
+/**
+ * `sso: null` is the ONLY negative answer, and it is returned for every
+ * negative case alike: unrecognized domain, a domain claimed by more than one
+ * organization, a tenant without SSO, a tenant with SSO but no enforcement, a
+ * tenant whose entry-route provider cannot actually start a login, and a
+ * transient database failure. Callers cannot tell those apart, by design.
+ */
+export type SsoDiscoveryResult = {
+  sso: SsoDiscoveryProvider | null;
+};


### PR DESCRIPTION
Closes #3229 (remaining scope — the nginx `/portal` docs half shipped in #3569).

## The bug

An organization with `enforce_sso = true` was invisible to the dashboard login page. `LoginPage` only ever read `GET /auth/login-context`, which is **partner-axis and single-partner-only**, so those users got a plain email/password form and the server answered every attempt with a generic 401 — no SSO button, no explanation. That is exactly what the reporter hit: *"I've set SSO as mandatory after confirming successful connection with Authentik, however I'm never prompted for SSO."*

`GET /sso/check/:orgId` already existed, but it needs an `orgId` a pre-auth browser does not have.

## The fix

`POST /api/v1/auth/sso-discovery` — public home-realm discovery for the address the user just typed. On a positive answer the login form swaps its password controls for a **"Sign in with {provider}"** button plus a **"Sign in with password instead"** link.

### Discovery is keyed on the email DOMAIN, and never reads `users`

The obvious implementation — look the address up, resolve its tenant, report enforcement — would be a flat **account-existence oracle**. That is precisely the signal SR2-22 (forgot-password) and SR2-23 (the login lockout 429) were rewritten to destroy, and re-introducing it on a new route to save a click is not a trade this codebase makes.

So the answer is a pure function of `(email domain) × (the tenant's own DNS-proven config)`, identical for a real address, a typo, and an address that has never existed. Source is `sso_verified_domains` with `verified_at IS NOT NULL` — **not** the provider's `allowed_domains`, which is unverified free text: on a shared instance a hostile tenant could list someone else's domain and have discovery point their users at an attacker-controlled IdP.

**Residual disclosure, stated plainly:** a positive answer confirms that the domain the caller *already typed* is federated on this instance, and names the provider. Domain-granular, deliberately published by the tenant's own admin, enumerates nothing. Same disclosure as any IdP home-realm-discovery page.

**Coverage, stated plainly:** an org that has not verified a domain gets the negative answer and its users see the password form exactly as they do today. That is pre-existing behaviour, not a regression this route introduces.

### Two details that keep the UI and the server from disagreeing

- **Whether SSO is mandated and which provider gets named are separate queries.** `isPasswordAuthDisabledBySso` blocks on *any* active enforcing provider; `GET /sso/login/:orgId` launches the **oldest active** provider without consulting `enforce_sso` at all. Filtering to `enforce_sso` before ordering would let the button say "Okta" and then start an Authentik flow.
- **A non-OIDC oldest-active provider yields the negative answer**, because the entry route rejects it with a 400. A button guaranteed to fail is worse than no button — and it would make an already-locked-out tenant harder to diagnose.

### Anti-enumeration discipline (mirrors `/auth/forgot-password`)

| Control | Behaviour |
|---|---|
| Timing | `authResponseFloorPromise()` started before any branch, awaited before **every** return — the shared H-4 / SR2-22 equalizer, not a second one |
| Rate limit | Keyed on the **client** (`getClientRateLimitKey`), never the email. 20 / 5 min. Fails **closed** when Redis is unavailable |
| Rate-limit exceeded | A real **429** — the bucket cannot be entered by naming an address, so it discloses nothing, while a `{ sso: null }` 200 would walk a throttled SSO-only user into a form the server always rejects |
| Caching | `Cache-Control: no-store` on every response |
| DB failure | Degrades to `{ sso: null }` + Sentry, never a 500 and never a distinct status |
| RLS | `withSystemDbAccessContext` — pre-auth, so an org-scoped read would silently return zero rows |

### UI

The password path stays reachable behind a reveal link (the #4067 lockout lesson: enforcement is server-side, the UI only de-emphasizes). The **email field stays mounted** while the password controls are collapsed — the partner-axis collapse in `LoginPage` drops the whole form, which is fine there because it fires at page load, but here it would delete the very input discovery keys on. Stale answers are discarded by request sequence, and one request is spent per distinct address, not per blur.

## Docs

`sso.mdx` claimed *"The `GET /api/v1/sso/check/:orgId` endpoint returns `enforceSSO: true` so the frontend can hide the password form"* — never true. Corrected, and the new endpoint documented with its verified-domain prerequisite.

## Design note

The design deviates from the brief on one point, deliberately: an independent review (Codex, `xhigh`) and I converged on domain-keyed rather than address-keyed resolution, because address-keyed lookup would be an account-existence oracle. Codex also caught the enforcement-vs-entry-route provider mismatch above. Trade-off: coverage now depends on the org having verified a domain.

## Verification

- `apps/api` — `ssoDiscovery.test.ts` 16 passed; full `src/routes/auth/` suite 23 files / 480 passed
- `apps/web` — `LoginPage.orgSso.test.tsx` 9 passed, `lib/ssoDiscovery.test.ts` 14 passed; `src/components/auth/` 16 files / 145 passed
- Red-first control verified: reverting `LoginPage.tsx` + `LoginForm.tsx` fails 8 of the 9 new UI tests
- `tsc --noEmit` — API 0 errors, web 0 errors, shared unchanged (3 pre-existing errors in `quotes.test.ts`, untouched)
- `astro check` in `apps/docs` — 0 errors / 0 warnings
- `eslint` clean on all changed files

## Not merged / not closed

No migration, no new table, no cascade-list impact. Leaving merge and issue closure to you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBxF7C8E5GxFnNcGf6kBVP