### PR TITLE
fix(api): pin org_id on the hideAiNoise verdict correlation (#4446)

### DIFF
--- a/apps/api/src/routes/alerts/alerts.hideAiNoise.sql.test.ts
+++ b/apps/api/src/routes/alerts/alerts.hideAiNoise.sql.test.ts
@@ -51,7 +51,7 @@ vi.mock('./helpers', () => ({
   getPagination: vi.fn(), ensureOrgAccess: vi.fn(), getAlertWithOrgCheck: vi.fn(),
 }));
 
-import { hideAiNoiseCondition } from './alerts';
+import { correlationMetadataCondition, hideAiNoiseCondition } from './alerts';
 
 describe('hideAiNoiseCondition (compiled SQL)', () => {
   const dialect = new PgDialect();
@@ -64,21 +64,90 @@ describe('hideAiNoiseCondition (compiled SQL)', () => {
     // `correlation_group_id` set) counts against a member alert too — the
     // `or (... correlation_group_id in (select group_id from
     // alert_correlation_members where alert_id = alerts.id))` branch.
+    //
+    // #4446: both correlated legs additionally pin `org_id` to the OUTER
+    // alert's own `org_id`, so tenant isolation here is dual-layer (RLS plus
+    // an explicit predicate) rather than RLS-only.
     expect(normalized).toBe(
       'not exists (select 1 from "ai_alert_verdicts" where '
-      + '(("ai_alert_verdicts"."alert_id" = "alerts"."id" or '
+      + '("ai_alert_verdicts"."org_id" = "alerts"."org_id" and '
+      + '("ai_alert_verdicts"."alert_id" = "alerts"."id" or '
       + '"ai_alert_verdicts"."correlation_group_id" in '
       + '(select "group_id" from "alert_correlation_members" where '
-      + '"alert_correlation_members"."alert_id" = "alerts"."id")) and '
+      + '("alert_correlation_members"."org_id" = "alerts"."org_id" and '
+      + '"alert_correlation_members"."alert_id" = "alerts"."id"))) and '
       + '"ai_alert_verdicts"."superseded_by" is null and '
       + '"ai_alert_verdicts"."classification" in ($1, $2, $3)))'
     );
     expect(params).toEqual(['transient_self_healed', 'recurring_pattern', 'duplicate_of_group']);
   });
 
+  // #4446 — tenant isolation must not rest on RLS alone here. These two
+  // assertions are deliberately separate from the whole-string `toBe` above:
+  // that one fails on ANY reformatting of the predicate tree, which makes it
+  // useless as a signal that specifically the ORG pin was dropped. A future
+  // edit that reshapes the subquery has to keep both of these passing.
+  it('pins the verdict row to the outer alert org (dual-layer, not RLS-only)', () => {
+    const { sql } = dialect.sqlToQuery(hideAiNoiseCondition());
+    const normalized = sql.replace(/\s+/g, ' ').trim();
+
+    expect(normalized).toContain('"ai_alert_verdicts"."org_id" = "alerts"."org_id"');
+  });
+
+  it('pins the correlation-member row to the outer alert org too', () => {
+    const { sql } = dialect.sqlToQuery(hideAiNoiseCondition());
+    const normalized = sql.replace(/\s+/g, ' ').trim();
+
+    // The org pin must live INSIDE the correlated member subquery, not just
+    // on the verdict row — the member row is what maps a group verdict onto
+    // this alert, so an unpinned member row would reintroduce the RLS-only
+    // path through the group leg.
+    const memberSubquery = normalized.slice(normalized.indexOf('from "alert_correlation_members"'));
+    expect(memberSubquery).toContain('"alert_correlation_members"."org_id" = "alerts"."org_id"');
+  });
+
   it('never admits actionable or needs_human into the noise list — those alerts must stay visible', () => {
     const { params } = dialect.sqlToQuery(hideAiNoiseCondition());
     expect(params).not.toContain('actionable');
     expect(params).not.toContain('needs_human');
+  });
+});
+
+/**
+ * #4446 — same compiled-SQL treatment for the OTHER correlation read on
+ * `GET /alerts`'s page. The mocked-drizzle suite (`alerts.test.ts`) stubs
+ * `../../db/schema` as bare `{}` objects, so every column reference there is
+ * `undefined`; a `where` assertion in that file literally cannot tell an
+ * org-pinned predicate from an unpinned one. Only compiled SQL can.
+ */
+describe('correlationMetadataCondition (compiled SQL)', () => {
+  const dialect = new PgDialect();
+  const ORG_A = '11111111-1111-4111-8111-111111111111';
+  const ORG_B = '22222222-2222-4222-8222-222222222222';
+  const ALERT_1 = '33333333-3333-4333-8333-333333333333';
+
+  it('pins org_id on BOTH joined rows, not just the member row', () => {
+    const { sql, params } = dialect.sqlToQuery(
+      correlationMetadataCondition([ORG_A, ORG_B], [ALERT_1]),
+    );
+    const normalized = sql.replace(/\s+/g, ' ').trim();
+
+    expect(normalized).toBe(
+      '("alert_correlation_members"."org_id" in ($1, $2) and '
+      + '"alert_correlation_members"."alert_id" in ($3) and '
+      + '"alert_correlation_groups"."org_id" in ($4, $5))'
+    );
+    expect(params).toEqual([ORG_A, ORG_B, ALERT_1, ORG_A, ORG_B]);
+  });
+
+  it('keeps the group-side org pin — the innerJoin on group_id alone is not tenancy', () => {
+    const { sql } = dialect.sqlToQuery(correlationMetadataCondition([ORG_A], [ALERT_1]));
+    const normalized = sql.replace(/\s+/g, ' ').trim();
+
+    // Deliberately separate from the whole-string assertion above: that one
+    // breaks on ANY reshaping of the predicate tree, which makes it useless
+    // as a signal that specifically the group-side pin was dropped.
+    expect(normalized).toContain('"alert_correlation_groups"."org_id" in');
+    expect(normalized).toContain('"alert_correlation_members"."org_id" in');
   });
 });

--- a/apps/api/src/routes/alerts/alerts.test.ts
+++ b/apps/api/src/routes/alerts/alerts.test.ts
@@ -168,6 +168,31 @@ function containsNotExists(predicate: unknown): boolean {
   return false;
 }
 
+/**
+ * #4446 — the correlation-metadata read's WHERE is the ONLY `and(...)` in this
+ * handler whose every arg is an `inArray` leaf (the list-query `whereCondition`
+ * always carries an `ne`/`eq` alongside), so this identifies it without relying
+ * on `whereCalls` ordering. Returns each such node's `vals` arrays in arg order.
+ *
+ * The mocked `../../db/schema` stubs tables as bare `{}`, so `col` is
+ * `undefined` here and this file cannot say WHICH column each leaf pins — that
+ * is what `alerts.hideAiNoise.sql.test.ts` compiles real SQL to prove. What
+ * this file uniquely proves is the ROUTE wiring: that
+ * `correlationMetadataCondition(orgIdsForPage, alertIds)` is the predicate that
+ * actually reaches `.where()`, org array and all, rather than the unpinned
+ * `inArray(alertCorrelationMembers.alertId, alertIds)` it replaced.
+ */
+function inArrayOnlyAndNodes(): unknown[][] {
+  return dbState.whereCalls
+    .filter((predicate): predicate is { op: 'and'; args: { op: string; vals: unknown[] }[] } => {
+      if (!predicate || typeof predicate !== 'object') return false;
+      const node = predicate as { op?: string; args?: unknown[] };
+      if (node.op !== 'and' || !Array.isArray(node.args) || node.args.length === 0) return false;
+      return node.args.every((arg) => (arg as { op?: string } | null)?.op === 'inArray');
+    })
+    .map((node) => node.args.map((arg) => arg.vals));
+}
+
 const ALERT_1 = '11111111-1111-4111-8111-111111111111';
 const ALERT_2 = '22222222-2222-4222-8222-222222222222';
 const ORG_1 = 'org-1';
@@ -353,6 +378,40 @@ describe('GET /alerts — aiVerdict (Task 14)', () => {
     const res = await makeApp().request('/alerts?hideAiNoise=true');
     expect(res.status).toBe(200);
     expect(dbState.whereCalls.some(containsNotExists)).toBe(true);
+  });
+
+  // #4446 — the sibling of the hideAiNoise wiring test above, for the OTHER
+  // correlation read on this page. Before the fix this query's WHERE was a bare
+  // `inArray(alertCorrelationMembers.alertId, alertIds)` with no org pin at
+  // all; a `status === 200` assertion stays green through that revert, and so
+  // would a compiled-SQL test of `correlationMetadataCondition` in isolation.
+  // Only capturing the ROUTE's actual `.where()` argument catches it.
+  it('wires correlationMetadataCondition(orgIdsForPage, alertIds) into the correlation-metadata read', async () => {
+    const ORG_2 = 'org-2';
+    authRef.current = {
+      scope: 'partner',
+      user: { id: 'u-1', name: 'Partner Tech', email: 'tech@partner.example' },
+      partnerId: 'partner-1', orgId: null, accessibleOrgIds: [ORG_1, ORG_2], allowedSiteIds: undefined,
+      canAccessOrg: () => true,
+    };
+    dbState.selectQueue.push([{ count: 2 }]);
+    dbState.selectQueue.push([
+      baseAlertRow(ALERT_1, { orgId: ORG_1 }),
+      baseAlertRow(ALERT_2, { orgId: ORG_2 }),
+    ]);
+    dbState.selectQueue.push([]); // correlationRows
+
+    await makeApp().request('/alerts');
+
+    // Three `inArray` leaves in `correlationMetadataCondition`'s own order:
+    // member org, member alert, group org. The page's org set appearing TWICE
+    // is the load-bearing part — that is the pin the pre-#4446 code lacked on
+    // BOTH joined rows.
+    expect(inArrayOnlyAndNodes()).toContainEqual([
+      [ORG_1, ORG_2],
+      [ALERT_1, ALERT_2],
+      [ORG_1, ORG_2],
+    ]);
   });
 
   it('does NOT add a notExists condition when hideAiNoise is absent', async () => {

--- a/apps/api/src/routes/alerts/alerts.ts
+++ b/apps/api/src/routes/alerts/alerts.ts
@@ -171,19 +171,62 @@ const AI_NOISE_VERDICT_CLASSIFICATIONS = ['transient_self_healed', 'recurring_pa
 export function hideAiNoiseCondition(): SQL {
   return notExists(
     db.select({ one: sql`1` }).from(aiAlertVerdicts).where(and(
+      // #4446 — pin the verdict row to the OUTER alert's own org rather than
+      // trusting `alert_id` / the group membership join alone. Correlating on
+      // `alerts.orgId` (the column) and not an auth-derived value is what makes
+      // this correct for every caller: a system-scope token with no `orgId`
+      // query filter pushes NO app-layer org condition on the outer query at
+      // all (see the scope branch in `GET /alerts`), so before this predicate
+      // the ONLY thing keeping a mis-orged verdict from suppressing another
+      // tenant's alert was the RLS policy. Same defense-in-depth the sibling
+      // reader `latestVerdictsForAlerts` already applies (P2-1 task 16e).
+      // Free bonus: `org_id` is the leading column of both
+      // `ai_alert_verdicts_org_alert_idx` and `ai_alert_verdicts_org_group_idx`,
+      // which the unpinned form could not use.
+      eq(aiAlertVerdicts.orgId, alerts.orgId),
       or(
         eq(aiAlertVerdicts.alertId, alerts.id),
         inArray(
           aiAlertVerdicts.correlationGroupId,
           db.select({ groupId: alertCorrelationMembers.groupId })
             .from(alertCorrelationMembers)
-            .where(eq(alertCorrelationMembers.alertId, alerts.id)),
+            .where(and(
+              // The member row is what maps a GROUP verdict onto this alert,
+              // so it needs the same org pin — otherwise the group leg stays
+              // RLS-only even once the verdict row above is pinned.
+              eq(alertCorrelationMembers.orgId, alerts.orgId),
+              eq(alertCorrelationMembers.alertId, alerts.id),
+            )),
         ),
       )!,
       isNull(aiAlertVerdicts.supersededBy),
       inArray(aiAlertVerdicts.classification, AI_NOISE_VERDICT_CLASSIFICATIONS),
     ))
   );
+}
+
+/**
+ * #4446 (same sweep as `hideAiNoiseCondition` above) — the correlation
+ * metadata decorating each row of `GET /alerts`'s page. `alertIds` comes from
+ * the page that was just fetched, so it is *usually* already org-narrowed by
+ * the scope branch at the top of the handler — but NOT for a system-scope
+ * token with no `orgId` query param, which pushes no app-layer org condition
+ * at all. Pinning `org_id` on BOTH joined rows (rather than trusting the
+ * member→group join alone) is the same defense-in-depth
+ * `latestVerdictsForAlerts` applies to this handler's other correlation read,
+ * and it puts the leading column of `alert_correlation_members_org_alert_idx`
+ * / `alert_correlation_groups_org_status_seen_idx` back in play.
+ *
+ * Exported for the compiled-SQL test, same reason `hideAiNoiseCondition` is:
+ * the mocked-drizzle suite's schema stub has no real columns, so a `where`
+ * assertion there could not tell an org-pinned predicate from an unpinned one.
+ */
+export function correlationMetadataCondition(orgIds: string[], alertIds: string[]): SQL {
+  return and(
+    inArray(alertCorrelationMembers.orgId, orgIds),
+    inArray(alertCorrelationMembers.alertId, alertIds),
+    inArray(alertCorrelationGroups.orgId, orgIds),
+  )!;
 }
 
 // GET /alerts - List alerts with filters
@@ -338,6 +381,12 @@ alertsRoutes.get(
       .offset(offset);
 
     const alertIds = alertsList.map((alert) => alert.id);
+    // The org axis both correlation reads below scope on. Derived per-row from
+    // the already-loaded page (its select projection carries `orgId`) rather
+    // than off `auth`: a partner/system caller with no `orgId` query filter can
+    // see alerts spanning MULTIPLE orgs on one page, and a system-scope caller
+    // gets no app-layer org condition on the outer query at all (#4446).
+    const orgIdsForPage = [...new Set(alertsList.map((alert) => alert.orgId))];
     const correlationRows = alertIds.length > 0
       ? await db
         .select({
@@ -350,7 +399,7 @@ alertsRoutes.get(
         })
         .from(alertCorrelationMembers)
         .innerJoin(alertCorrelationGroups, eq(alertCorrelationMembers.groupId, alertCorrelationGroups.id))
-        .where(inArray(alertCorrelationMembers.alertId, alertIds))
+        .where(correlationMetadataCondition(orgIdsForPage, alertIds))
       : [];
 
     // Resolve acknowledgedBy/resolvedBy user ids to display names so clients
@@ -358,17 +407,13 @@ alertsRoutes.get(
     const alertsWithActorNames = await withAlertActorNames(alertsList);
 
     // Phase 2 wave P2-1 (alert verdicts), Task 14 — attach each alert's
-    // latest live verdict. A partner/system caller with no `orgId` query
-    // filter can see alerts spanning MULTIPLE orgs on one page (the org
-    // scoping above uses `inArray(alerts.orgId, orgIds)` in that case), so
-    // `orgId` is derived per-row from the already-loaded `alertsList`
-    // (its select projection already carries `orgId`) rather than off
-    // `auth` alone. `latestVerdictsForAlerts` takes the org id(s) directly
-    // (widened to accept an array) instead of the route grouping alert ids
-    // per org and issuing one query per org — see that function's own
-    // docstring for why this was the smaller change.
-    const orgIdsForVerdicts = [...new Set(alertsList.map((alert) => alert.orgId))];
-    const verdictMap = await latestVerdictsForAlerts(orgIdsForVerdicts, alertIds);
+    // latest live verdict, scoped on `orgIdsForPage` (see its definition
+    // above for why the org axis comes from the page, not from `auth`).
+    // `latestVerdictsForAlerts` takes the org id(s) directly (widened to
+    // accept an array) instead of the route grouping alert ids per org and
+    // issuing one query per org — see that function's own docstring for why
+    // this was the smaller change.
+    const verdictMap = await latestVerdictsForAlerts(orgIdsForPage, alertIds);
 
     // #4445 — resolve each live verdict's feedbackBy to a display name (same
     // actor-name pattern as acknowledgedBy/resolvedBy above, #3966) so the


### PR DESCRIPTION
## Problem

`hideAiNoiseCondition()` (`apps/api/src/routes/alerts/alerts.ts`) builds the `hideAiNoise=true` `NOT EXISTS` for `GET /alerts`. It correlated `ai_alert_verdicts` to the outer `alerts` row on **id alone**, and its group leg correlated `alert_correlation_members` the same way. Both tables carry a `NOT NULL org_id`, but neither leg carried an org predicate — tenant isolation there rested entirely on the RLS policy.

That is out of step with the sibling reader in the **same handler**: `latestVerdictsForAlerts` (`services/aiAgents/alertVerdicts.ts`) already pins `org_id` on both the verdict row and the member row (added in P2-1 task 16e for exactly this reason). `hideAiNoiseCondition` was the one that got missed.

**Why it is reachable, not theoretical:**
- `GET /alerts` pushes **no app-layer org condition at all** for a `system`-scope token with no `orgId` query param (see the scope branch at the top of the handler) — RLS is the only thing scoping the outer query too.
- `persistAlertVerdict` stamps `ai_alert_verdicts.org_id` from the **run's** org, not from the target alert's org, and run admission does not validate the alert/group's org. A mis-orged verdict row is therefore not structurally prevented today.

A mis-orged live verdict classified as noise could suppress **another tenant's** alert from the noise-filtered list.

## Fix

Both correlated legs now pin the **outer alert's own `org_id` column** (`eq(aiAlertVerdicts.orgId, alerts.orgId)`, and `eq(alertCorrelationMembers.orgId, alerts.orgId)` inside the member subquery). Correlating on the column rather than an auth-derived value is what makes it correct for every scope, including system-with-no-orgId.

Two side benefits:
- The predicate **only narrows the inner EXISTS**, so `NOT EXISTS` can only ever *reveal* an alert that a cross-org verdict was wrongly hiding. It cannot hide anything extra — with `org_id NOT NULL` on both tables there is no NULL-semantics edge.
- `org_id` is the **leading column** of `ai_alert_verdicts_org_alert_idx`, `ai_alert_verdicts_org_group_idx` and `alert_correlation_members_org_alert_idx`. The unpinned form could not use any of them.

### Same-shape sibling in the same handler

The correlation-metadata read that decorates each listed alert joined `alert_correlation_members` → `alert_correlation_groups` with no org pin on either row. Extracted as `correlationMetadataCondition(orgIds, alertIds)` and scoped on the page's own org set — the existing `orgIdsForVerdicts` hoist, renamed `orgIdsForPage` and now shared by both correlation reads. Both joined rows are pinned, not just the member row (same "don't trust the join alone" reasoning as task 16e).

## Why not the composite FK the issue title asks for

Considered and deliberately deferred (I got an independent second opinion here, which agreed: ship the query predicate now, stage the FK separately).

- `alerts` has **no `UNIQUE(id, org_id)`** to reference, and neither does `alert_correlation_groups`. The repo's composite-tenancy-FK pattern is well established (10+ tables reference `devices(id, org_id)`, `invoices(id, org_id)`, `ai_agent_runs(id, org_id)`, …) but `alerts` is not among them — this would be new infrastructure, not a drop-in.
- Adding `UNIQUE(id, org_id)` on `alerts` duplicates most of the PK index on one of the hottest tables in the product, with permanent write amplification.
- A second FK edge into `alerts` widens the `FOR KEY SHARE` lock surface that already produced deadlocks here (#3911), and making `org_id` a *referenced* key adds conflicts for org merge / tenant move.

The structural half is worth doing, but it needs a mismatch audit, `CREATE INDEX CONCURRENTLY`, `NOT VALID` FKs validated separately, and org-merge/deadlock testing — its own change, not a rider on this one. **This PR closes the query-layer half the issue describes ("harden to the repo's dual-layer pattern").**

## Sweep result

Every other reader of these tables was checked:

| Site | Org pin? |
|---|---|
| `services/aiAgents/alertVerdicts.ts` `latestVerdictsForAlerts` | already pinned (task 16e — the precedent this PR mirrors) |
| `services/aiAgents/ticketContext.ts`, `narrativeContext.ts`, `impactRollup.ts`, `runLoop.ts` | already pinned |
| `services/alertCorrelationRca.ts`, `jobs/alertVerdictScheduler.ts`, `jobs/alertCorrelation.ts`, `routes/alerts/correlations.ts` `getPersistedGroupAlerts` | already pinned |
| any `aiTools*.ts` | none read these tables at all |
| `routes/alerts/alerts.ts` correlation-metadata join | **fixed here** |

One observation left out of scope, flagged rather than dropped: `routes/alerts/correlations.ts` `buildPersistedCorrelationGroups` (~L344-350) reads members by `groupId` and member alerts by `alertId` with no org pin on either row, transitively scoped by an earlier `groupOrgConditionsForAuth()` fetch — which also returns `[]` (no condition) for system scope. Same defect class, but that route scopes tenancy through its own helpers (`groupOrgConditionsForAuth`, `getAccessibleAlert`, `filterAlertsBySiteScope`), so it deserves a deliberate audit rather than a blind predicate copy.

## Verification

- `alerts.hideAiNoise.sql.test.ts`: exact compiled-SQL assertion updated, **plus** two targeted assertions kept separate from the whole-string `toBe` (which fails on any reformatting and so is useless as a signal that specifically the org pin was dropped). Written **red first** — all three failed against the unmodified implementation for the right reason.
- New `correlationMetadataCondition` suite **mutation-checked**: removing the org pins turns 2 assertions red; restoring them turns them green.
- `apps/api` alerts routes + `alertVerdicts` service: 26 files / 384 tests passed (`vitest run src/routes/alerts src/services/aiAgents/alertVerdicts`).
- `tsc --noEmit` clean; `eslint` clean on both touched files.
- No migration, no schema change, no new table — no RLS/cascade/export-policy registration applies.

Closes #4446

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBxF7C8E5GxFnNcGf6kBVP
