### PR TITLE
fix(agent/macos): stop churning code-signing identity in the updater and helper install (#3458, #3457)

### DIFF
--- a/agent/Makefile
+++ b/agent/Makefile
@@ -227,6 +227,11 @@ lint:
 #   identity is used across builds, macOS will treat all dev pushes as the
 #   "same app" and TCC grants persist across iterations.
 #
+#   Darwin dev pushes are ALWAYS signed: without CODESIGN_IDENTITY the binary is
+#   ad-hoc signed instead, because the agent refuses to install a macOS binary
+#   that fails `codesign --verify` (#3458). Ad-hoc identities differ per build,
+#   so TCC grants are re-prompted on every push until you set an identity.
+#
 #   Setup:
 #     1. Keychain Access > Certificate Assistant > Create a Certificate
 #        Name: BreezeDevSigning, Identity Type: Self Signed Root, Type: Code Signing
@@ -263,12 +268,23 @@ endif
 	$(eval CGO_FLAG := $(if $(and $(filter $(BUILD_GOOS),$(TARGET_GOOS)),$(filter $(BUILD_GOARCH),$(TARGET_GOARCH))),,CGO_ENABLED=0))
 	@echo "Building for $(TARGET_GOOS)/$(TARGET_GOARCH) version=$(DEV_VERSION) (cgo=$(if $(CGO_FLAG),off,on))..."
 	GOOS=$(TARGET_GOOS) GOARCH=$(TARGET_GOARCH) $(CGO_FLAG) go build -ldflags "-X main.version=$(DEV_VERSION)" -o bin/breeze-agent-dev ./cmd/breeze-agent
-ifneq ($(CODESIGN_IDENTITY),)
-ifeq ($(TARGET_GOOS),darwin)
-	@echo "Codesigning with identity '$(CODESIGN_IDENTITY)'..."
-	codesign --force --sign "$(CODESIGN_IDENTITY)" --options runtime --timestamp=none --entitlements dev-entitlements.plist bin/breeze-agent-dev
-endif
-endif
+	@if [ "$(TARGET_GOOS)" = "darwin" ]; then \
+		if ! command -v codesign >/dev/null 2>&1; then \
+			echo "WARNING: codesign not found on this host; the darwin dev binary will be unsigned"; \
+			echo "  and the agent will REFUSE to install it (see #3458). Build the push from a Mac."; \
+		elif [ -n "$(CODESIGN_IDENTITY)" ]; then \
+			echo "Codesigning with identity '$(CODESIGN_IDENTITY)'..."; \
+			codesign --force --sign "$(CODESIGN_IDENTITY)" --options runtime --timestamp=none --entitlements dev-entitlements.plist bin/breeze-agent-dev; \
+		else \
+			echo "CODESIGN_IDENTITY not set - ad-hoc signing the dev binary."; \
+			echo "  The agent refuses to install a macOS binary that fails 'codesign --verify' (#3458),"; \
+			echo "  and a cross-compiled darwin/amd64 build carries no signature at all, so signing"; \
+			echo "  here is what makes the push installable. Ad-hoc identities change on every build,"; \
+			echo "  so macOS re-prompts for Screen Recording / Accessibility / Full Disk Access after"; \
+			echo "  each push - set CODESIGN_IDENTITY (see the comment above this target) to keep them."; \
+			codesign --force --sign - bin/breeze-agent-dev; \
+		fi; \
+	fi
 	@echo "Uploading binary to API..."
 	@curl -sf -X POST "$(API_URL)/api/v1/dev/push" \
 		-H "$(AUTH_HEADER)" \
@@ -315,12 +331,10 @@ endif
 	$(eval CGO_FLAG := $(if $(and $(filter $(BUILD_GOOS),$(TARGET_GOOS)),$(filter $(BUILD_GOARCH),$(TARGET_GOARCH))),,CGO_ENABLED=0))
 	@echo "Building watchdog for $(TARGET_GOOS)/$(TARGET_GOARCH) version=$(DEV_VERSION) (cgo=$(if $(CGO_FLAG),off,on))..."
 	GOOS=$(TARGET_GOOS) GOARCH=$(TARGET_GOARCH) $(CGO_FLAG) go build -ldflags "-X main.version=$(DEV_VERSION)" -o bin/breeze-watchdog-dev ./cmd/breeze-watchdog
-ifneq ($(CODESIGN_IDENTITY),)
-ifeq ($(TARGET_GOOS),darwin)
-	@echo "Codesigning with identity '$(CODESIGN_IDENTITY)'..."
-	codesign --force --sign "$(CODESIGN_IDENTITY)" --options runtime --timestamp=none --entitlements dev-entitlements.plist bin/breeze-watchdog-dev
-endif
-endif
+	@if [ "$(TARGET_GOOS)" = "darwin" ] && [ -n "$(CODESIGN_IDENTITY)" ] && command -v codesign >/dev/null 2>&1; then \
+		echo "Codesigning with identity '$(CODESIGN_IDENTITY)'..."; \
+		codesign --force --sign "$(CODESIGN_IDENTITY)" --options runtime --timestamp=none --entitlements dev-entitlements.plist bin/breeze-watchdog-dev; \
+	fi
 	@echo "Uploading watchdog binary to API..."
 	@curl -sf -X POST "$(API_URL)/api/v1/dev/push" \
 		-H "$(AUTH_HEADER)" \

--- a/agent/Makefile
+++ b/agent/Makefile
@@ -331,9 +331,17 @@ endif
 	$(eval CGO_FLAG := $(if $(and $(filter $(BUILD_GOOS),$(TARGET_GOOS)),$(filter $(BUILD_GOARCH),$(TARGET_GOARCH))),,CGO_ENABLED=0))
 	@echo "Building watchdog for $(TARGET_GOOS)/$(TARGET_GOARCH) version=$(DEV_VERSION) (cgo=$(if $(CGO_FLAG),off,on))..."
 	GOOS=$(TARGET_GOOS) GOARCH=$(TARGET_GOARCH) $(CGO_FLAG) go build -ldflags "-X main.version=$(DEV_VERSION)" -o bin/breeze-watchdog-dev ./cmd/breeze-watchdog
-	@if [ "$(TARGET_GOOS)" = "darwin" ] && [ -n "$(CODESIGN_IDENTITY)" ] && command -v codesign >/dev/null 2>&1; then \
-		echo "Codesigning with identity '$(CODESIGN_IDENTITY)'..."; \
-		codesign --force --sign "$(CODESIGN_IDENTITY)" --options runtime --timestamp=none --entitlements dev-entitlements.plist bin/breeze-watchdog-dev; \
+	@if [ "$(TARGET_GOOS)" = "darwin" ]; then \
+		if ! command -v codesign >/dev/null 2>&1; then \
+			echo "WARNING: codesign not found on this host; the darwin watchdog dev binary will be unsigned"; \
+			echo "  and the updater will REFUSE to install it (see #3458). Build the push from a Mac."; \
+		elif [ -n "$(CODESIGN_IDENTITY)" ]; then \
+			echo "Codesigning with identity '$(CODESIGN_IDENTITY)'..."; \
+			codesign --force --sign "$(CODESIGN_IDENTITY)" --options runtime --timestamp=none --entitlements dev-entitlements.plist bin/breeze-watchdog-dev; \
+		else \
+			echo "CODESIGN_IDENTITY not set - ad-hoc signing the watchdog dev binary (see the dev-push comment)."; \
+			codesign --force --sign - bin/breeze-watchdog-dev; \
+		fi; \
 	fi
 	@echo "Uploading watchdog binary to API..."
 	@curl -sf -X POST "$(API_URL)/api/v1/dev/push" \

--- a/agent/internal/agentapp/desktop_helper_bootstrap.go
+++ b/agent/internal/agentapp/desktop_helper_bootstrap.go
@@ -126,7 +126,10 @@ func desktopHelperUnavailableWarning(err error, version, goos, goarch string) st
 // executable at path. downloadReleaseAsset does the same for the network path;
 // the sibling copy must not be the weaker of the two.
 func writeBinaryAtomically(path string, data []byte) error {
-	tmpPath := path + ".staging"
+	// Per-process temp name: two concurrent `service install` runs must not
+	// share a staging file, where one's cleanup would delete the other's
+	// in-flight write.
+	tmpPath := fmt.Sprintf("%s.staging.%d", path, os.Getpid())
 	if err := os.WriteFile(tmpPath, data, 0o755); err != nil {
 		_ = os.Remove(tmpPath)
 		return err

--- a/agent/internal/agentapp/desktop_helper_bootstrap.go
+++ b/agent/internal/agentapp/desktop_helper_bootstrap.go
@@ -65,7 +65,7 @@ func stageDesktopHelper(opts desktopHelperStageOptions) error {
 	data, readErr := os.ReadFile(sibling)
 	switch {
 	case readErr == nil:
-		if err := os.WriteFile(opts.destPath, data, 0o755); err != nil {
+		if err := writeBinaryAtomically(opts.destPath, data); err != nil {
 			return fmt.Errorf("copy desktop helper to %s: %w", opts.destPath, err)
 		}
 		return nil
@@ -119,4 +119,50 @@ func desktopHelperUnavailableWarning(err error, version, goos, goarch string) st
 			"  2. Download %s, place it next to breeze-agent,\n"+
 			"     then re-run `sudo breeze-agent service install`.\n",
 		err, desktopHelperDownloadURL(version, goos, goarch))
+}
+
+// writeBinaryAtomically writes data to path via a sibling temp file and an
+// atomic rename, so a failure part-way through can never leave a truncated
+// executable at path. downloadReleaseAsset does the same for the network path;
+// the sibling copy must not be the weaker of the two.
+func writeBinaryAtomically(path string, data []byte) error {
+	tmpPath := path + ".staging"
+	if err := os.WriteFile(tmpPath, data, 0o755); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	return nil
+}
+
+// desktopHelperInstalled reports whether a usable helper binary sits at path.
+func desktopHelperInstalled(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir() && info.Size() > 0
+}
+
+// desktopHelperLaunchAgentsWanted reports whether install-service should write
+// and bootstrap the helper's LaunchAgent plists.
+//
+// The plists name /usr/local/bin/breeze-desktop-helper as their Program. Handing
+// launchd a job whose program does not exist makes it retry a doomed
+// posix_spawn on its KeepAlive schedule indefinitely, and that failure is
+// invisible from the agent — it shows up only in launchctl/Console on the box.
+// Before #3457 this could not happen, because install-service always left
+// *something* at that path: the agent binary itself. Now that the substitution
+// is gone, the plists have to be gated.
+//
+// A staging failure on a host that still has a helper from an earlier install is
+// NOT a reason to skip them — that binary may be a pre-#3457 substituted agent
+// binary, but it works, and tearing down its LaunchAgents would turn a
+// wrong-identity helper into no helper at all. It is corrected on the next
+// install that can reach a real helper.
+func desktopHelperLaunchAgentsWanted(stageErr error, helperPath string) bool {
+	if stageErr == nil {
+		return true
+	}
+	return desktopHelperInstalled(helperPath)
 }

--- a/agent/internal/agentapp/desktop_helper_bootstrap.go
+++ b/agent/internal/agentapp/desktop_helper_bootstrap.go
@@ -1,0 +1,122 @@
+package agentapp
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// desktopHelperBinaryName is the on-disk name of the per-user desktop helper.
+// The agent dispatches into the helper implementation when argv[0] has this
+// basename (see main.go), which is exactly why the agent binary must never be
+// installed under this name — see stageDesktopHelper.
+const desktopHelperBinaryName = "breeze-desktop-helper"
+
+// desktopHelperDownloadURL returns the GitHub release download URL for the
+// desktop helper matching the given agent version / OS / arch. The release
+// workflow publishes and notarizes this asset alongside the agent and the
+// watchdog, and lists it in the release's checksums.txt.
+func desktopHelperDownloadURL(version, goos, goarch string) string {
+	ext := ""
+	if goos == "windows" {
+		ext = ".exe"
+	}
+	return fmt.Sprintf("%s/v%s/%s-%s-%s%s",
+		releasesBase, version, desktopHelperBinaryName, goos, goarch, ext)
+}
+
+// desktopHelperStageOptions is the input for stageDesktopHelper. Kept as a
+// struct so the OS callers stay short and tests don't need long arg lists.
+type desktopHelperStageOptions struct {
+	agentPath string // absolute path to the currently running agent binary
+	destPath  string // where the helper must end up, e.g. /usr/local/bin/breeze-desktop-helper
+	version   string // agent version (main.version), e.g. "0.109.0" or "dev"
+	goos      string // runtime.GOOS
+	goarch    string // runtime.GOARCH
+
+	// urlOverride, if non-empty, replaces the full download URL. Test-only.
+	urlOverride string
+
+	// checksumOverride, if non-empty, replaces the checksums.txt lookup. Test-only.
+	checksumOverride string
+}
+
+// stageDesktopHelper installs the real desktop-helper binary at opts.destPath:
+// the copy staged next to the agent (what the .pkg and every build lane ship)
+// if present, otherwise the matching-version, checksum-verified asset from the
+// GitHub release.
+//
+// It must NEVER fall back to installing the agent binary under the helper's
+// name, which is what it used to do (#3457). The agent is a multi-call binary,
+// so argv[0] dispatch made that substitute *work* — but the installed "helper"
+// then carried the AGENT's code-signing identifier and designated requirement.
+// macOS keys TCC grants (Screen Recording, Accessibility) to that identity, so
+// the moment a real helper arrived — a .pkg install, an update — the identity
+// flipped, the grants stopped matching, and every user was re-prompted. A
+// missing helper is a visible, fixable install gap; a silently mis-identified
+// one is a permission bug that surfaces days later on an unrelated upgrade.
+//
+// All errors are returned. Callers are expected to downgrade them to a warning
+// so a helper problem never aborts the agent install, matching bootstrapWatchdog.
+func stageDesktopHelper(opts desktopHelperStageOptions) error {
+	sibling := filepath.Join(filepath.Dir(opts.agentPath), desktopHelperBinaryName)
+	data, readErr := os.ReadFile(sibling)
+	switch {
+	case readErr == nil:
+		if err := os.WriteFile(opts.destPath, data, 0o755); err != nil {
+			return fmt.Errorf("copy desktop helper to %s: %w", opts.destPath, err)
+		}
+		return nil
+	case !errors.Is(readErr, fs.ErrNotExist):
+		// Present but unreadable (permissions, a directory, I/O error). Report
+		// it rather than reaching for the network and masking a local problem.
+		return fmt.Errorf("read desktop helper at %s: %w", sibling, readErr)
+	}
+
+	if isDevBuildVersion(opts.version) {
+		return fmt.Errorf("no desktop helper found at %s and the agent is a dev build (version=%q); build it with `make build` and place it next to the agent binary", sibling, opts.version)
+	}
+
+	url := opts.urlOverride
+	if url == "" {
+		url = desktopHelperDownloadURL(opts.version, opts.goos, opts.goarch)
+	}
+	checksum := opts.checksumOverride
+	if checksum == "" {
+		if opts.urlOverride != "" {
+			return fmt.Errorf("desktop helper checksum required when urlOverride is set")
+		}
+		var err error
+		checksum, err = fetchReleaseAssetChecksum(releaseChecksumsURL(opts.version), filepath.Base(url))
+		if err != nil {
+			return fmt.Errorf("fetch desktop helper checksum: %w", err)
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "Downloading desktop helper from %s ...\n", url)
+	if err := downloadReleaseAsset(url, opts.destPath, checksum); err != nil {
+		return fmt.Errorf("download desktop helper: %w", err)
+	}
+	return nil
+}
+
+// desktopHelperUnavailableWarning is the operator-facing message for a failed
+// stageDesktopHelper. It says what is degraded, why the agent binary is not
+// substituted, and how to fix it — the install itself continues.
+func desktopHelperUnavailableWarning(err error, version, goos, goarch string) string {
+	return fmt.Sprintf(
+		"Warning: desktop helper not installed: %v\n"+
+			"The agent service is installed and will run. Features that need the\n"+
+			"per-user desktop helper (screen sharing, the logged-in-user session)\n"+
+			"stay unavailable until the helper is present.\n"+
+			"Breeze does NOT substitute the agent binary for the helper: that would\n"+
+			"install it under the agent's code-signing identity, and macOS drops the\n"+
+			"Screen Recording / Accessibility grants once the real helper replaces it.\n"+
+			"To fix, choose one of:\n"+
+			"  1. Install with the macOS .pkg, which ships the signed helper.\n"+
+			"  2. Download %s, place it next to breeze-agent,\n"+
+			"     then re-run `sudo breeze-agent service install`.\n",
+		err, desktopHelperDownloadURL(version, goos, goarch))
+}

--- a/agent/internal/agentapp/desktop_helper_bootstrap_test.go
+++ b/agent/internal/agentapp/desktop_helper_bootstrap_test.go
@@ -257,6 +257,9 @@ func TestServiceInstallDarwin_DelegatesHelperStaging(t *testing.T) {
 	if strings.Contains(text, "os.WriteFile(darwinDesktopHelperBinaryPath") {
 		t.Fatal("service_cmd_darwin.go writes the desktop helper path directly — helper bytes must only ever come from stageDesktopHelper (#3457)")
 	}
+	if !strings.Contains(text, "desktopHelperLaunchAgentsWanted(") {
+		t.Fatal("service_cmd_darwin.go no longer gates the helper LaunchAgents on a helper binary being present")
+	}
 }
 
 func TestDesktopHelperDownloadURL(t *testing.T) {
@@ -314,5 +317,109 @@ func TestDesktopHelperUnavailableWarning_IsActionable(t *testing.T) {
 		if !strings.Contains(msg, want) {
 			t.Errorf("warning does not mention %q:\n%s", want, msg)
 		}
+	}
+}
+
+// The helper's LaunchAgent plists name /usr/local/bin/breeze-desktop-helper as
+// their Program. Registering them for a binary that is not there makes launchd
+// retry a doomed posix_spawn on its KeepAlive schedule forever, and that failure
+// is invisible from the agent. Before #3457 it could not happen — install-service
+// always left the agent binary at that path — so removing the substitution is
+// exactly what makes this gate necessary.
+func TestDesktopHelperLaunchAgentsWanted(t *testing.T) {
+	dir := t.TempDir()
+	present := filepath.Join(dir, "present")
+	if err := os.WriteFile(present, []byte("helper"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	empty := filepath.Join(dir, "empty")
+	if err := os.WriteFile(empty, nil, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	asDir := filepath.Join(dir, "as-dir")
+	if err := os.MkdirAll(asDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name     string
+		stageErr error
+		path     string
+		want     bool
+	}{
+		{name: "staging succeeded", stageErr: nil, path: present, want: true},
+		{
+			name:     "staging failed but an earlier install left a helper behind",
+			stageErr: os.ErrNotExist,
+			path:     present,
+			want:     true,
+		},
+		{
+			name:     "staging failed and no helper exists",
+			stageErr: os.ErrNotExist,
+			path:     filepath.Join(dir, "missing"),
+			want:     false,
+		},
+		{
+			name:     "staging failed and the path is an empty file",
+			stageErr: os.ErrNotExist,
+			path:     empty,
+			want:     false,
+		},
+		{
+			name:     "staging failed and the path is a directory",
+			stageErr: os.ErrNotExist,
+			path:     asDir,
+			want:     false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := desktopHelperLaunchAgentsWanted(tc.stageErr, tc.path); got != tc.want {
+				t.Fatalf("desktopHelperLaunchAgentsWanted(%v, %s) = %v, want %v", tc.stageErr, tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+// The sibling copy must be as safe as the download path: a failure part-way
+// through must not leave a truncated executable where a working one was.
+func TestWriteBinaryAtomically(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "breeze-desktop-helper")
+	if err := os.WriteFile(dest, []byte("previous helper"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := writeBinaryAtomically(dest, []byte("new helper")); err != nil {
+		t.Fatalf("writeBinaryAtomically: %v", err)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "new helper" {
+		t.Fatalf("dest = %q, want %q", string(got), "new helper")
+	}
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		t.Fatalf("dest mode = %v, want it executable", info.Mode().Perm())
+	}
+	if _, err := os.Stat(dest + ".staging"); !os.IsNotExist(err) {
+		t.Fatalf("staging temp file left behind at %s", dest+".staging")
+	}
+
+	// A destination whose directory does not exist fails without touching a
+	// pre-existing file elsewhere, and leaves no temp behind.
+	missingDir := filepath.Join(dir, "nope", "helper")
+	if err := writeBinaryAtomically(missingDir, []byte("x")); err == nil {
+		t.Fatal("expected an error writing into a missing directory")
+	}
+	if _, err := os.Stat(missingDir + ".staging"); !os.IsNotExist(err) {
+		t.Fatal("staging temp file left behind after a failed write")
 	}
 }

--- a/agent/internal/agentapp/desktop_helper_bootstrap_test.go
+++ b/agent/internal/agentapp/desktop_helper_bootstrap_test.go
@@ -1,0 +1,318 @@
+package agentapp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Issue #3457: `install-service` used to fall back to copying the AGENT binary
+// to /usr/local/bin/breeze-desktop-helper when no real helper was staged
+// alongside it. argv[0] dispatch made that run, but the installed helper then
+// carried the agent's code-signing identifier and designated requirement, so
+// macOS TCC grants made against it stopped matching the moment a real helper
+// arrived. The staging path must resolve a genuine helper or fail — never
+// substitute.
+
+// agentBinaryBody is the stand-in for the running agent binary. Every failure
+// case asserts these bytes never reach the helper's install path.
+var agentBinaryBody = []byte("AGENT BINARY - must never be installed as the desktop helper")
+
+func writeLargeBody(seed byte) []byte {
+	body := make([]byte, 2*1024*1024) // above releaseAssetMinSize
+	for i := range body {
+		body[i] = byte(int(seed)+i) % 255
+	}
+	return body
+}
+
+type helperFixture struct {
+	agentPath string
+	destPath  string
+	dir       string
+}
+
+func newHelperFixture(t *testing.T) helperFixture {
+	t.Helper()
+	dir := t.TempDir()
+	stageDir := filepath.Join(dir, "stage")
+	if err := os.MkdirAll(stageDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	agentPath := filepath.Join(stageDir, "breeze-agent")
+	if err := os.WriteFile(agentPath, agentBinaryBody, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return helperFixture{
+		agentPath: agentPath,
+		destPath:  filepath.Join(dir, "breeze-desktop-helper"),
+		dir:       dir,
+	}
+}
+
+// assertAgentBinaryNotInstalled is the regression assertion for #3457.
+func (f helperFixture) assertAgentBinaryNotInstalled(t *testing.T) {
+	t.Helper()
+	got, err := os.ReadFile(f.destPath)
+	if os.IsNotExist(err) {
+		return
+	}
+	if err != nil {
+		t.Fatalf("read %s: %v", f.destPath, err)
+	}
+	if string(got) == string(agentBinaryBody) {
+		t.Fatalf("the agent binary was installed as the desktop helper at %s — that is exactly the #3457 code-identity bug", f.destPath)
+	}
+}
+
+func TestStageDesktopHelper_PrefersSiblingBinary(t *testing.T) {
+	f := newHelperFixture(t)
+	helperBody := []byte("REAL DESKTOP HELPER BINARY")
+	if err := os.WriteFile(filepath.Join(filepath.Dir(f.agentPath), desktopHelperBinaryName), helperBody, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// urlOverride points at a dead address: a sibling hit must not touch the network.
+	err := stageDesktopHelper(desktopHelperStageOptions{
+		agentPath:        f.agentPath,
+		destPath:         f.destPath,
+		version:          "0.109.0",
+		goos:             "darwin",
+		goarch:           "arm64",
+		urlOverride:      "http://127.0.0.1:1/never-called",
+		checksumOverride: strings.Repeat("0", 64),
+	})
+	if err != nil {
+		t.Fatalf("stageDesktopHelper: %v", err)
+	}
+
+	got, err := os.ReadFile(f.destPath)
+	if err != nil {
+		t.Fatalf("read installed helper: %v", err)
+	}
+	if string(got) != string(helperBody) {
+		t.Fatalf("installed helper = %q, want the sibling helper binary", string(got))
+	}
+	f.assertAgentBinaryNotInstalled(t)
+
+	info, err := os.Stat(f.destPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		t.Fatalf("installed helper mode = %v, want it executable", info.Mode().Perm())
+	}
+}
+
+func TestStageDesktopHelper_DownloadsWhenNoSibling(t *testing.T) {
+	f := newHelperFixture(t)
+	helperBody := writeLargeBody(7)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(helperBody)
+	}))
+	defer srv.Close()
+
+	err := stageDesktopHelper(desktopHelperStageOptions{
+		agentPath:        f.agentPath,
+		destPath:         f.destPath,
+		version:          "0.109.0",
+		goos:             "darwin",
+		goarch:           "arm64",
+		urlOverride:      srv.URL,
+		checksumOverride: testSHA256Hex(helperBody),
+	})
+	if err != nil {
+		t.Fatalf("stageDesktopHelper: %v", err)
+	}
+
+	got, err := os.ReadFile(f.destPath)
+	if err != nil {
+		t.Fatalf("read installed helper: %v", err)
+	}
+	if len(got) != len(helperBody) {
+		t.Fatalf("installed helper size = %d, want %d", len(got), len(helperBody))
+	}
+	f.assertAgentBinaryNotInstalled(t)
+}
+
+// The table of failure modes. Every one of them must (a) return an error and
+// (b) leave the agent binary uninstalled at the helper path.
+func TestStageDesktopHelper_NeverSubstitutesTheAgentBinary(t *testing.T) {
+	tests := []struct {
+		name        string
+		version     string
+		wantErrPart string
+		// handler is the release-asset server; nil means "no server, use a
+		// dead address".
+		handler http.HandlerFunc
+		// checksum overrides the checksum handed to the downloader.
+		checksum func(body []byte) string
+		// prepare optionally seeds the staging dir before the call.
+		prepare func(t *testing.T, f helperFixture)
+	}{
+		{
+			name:        "dev build with no sibling helper",
+			version:     "dev",
+			wantErrPart: "dev build",
+		},
+		{
+			name:        "empty version is treated as a dev build",
+			version:     "",
+			wantErrPart: "dev build",
+		},
+		{
+			name:        "release asset returns 404",
+			version:     "0.109.0",
+			wantErrPart: "download desktop helper",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+			},
+		},
+		{
+			name:        "release asset is an error page, not a binary",
+			version:     "0.109.0",
+			wantErrPart: "download desktop helper",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte("<html>404 Not Found</html>"))
+			},
+		},
+		{
+			name:        "downloaded asset fails its checksum",
+			version:     "0.109.0",
+			wantErrPart: "download desktop helper",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write(writeLargeBody(3))
+			},
+			checksum: func([]byte) string { return testSHA256Hex([]byte("something else")) },
+		},
+		{
+			name:        "sibling path exists but is a directory",
+			version:     "0.109.0",
+			wantErrPart: "read desktop helper",
+			prepare: func(t *testing.T, f helperFixture) {
+				t.Helper()
+				if err := os.MkdirAll(filepath.Join(filepath.Dir(f.agentPath), desktopHelperBinaryName), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newHelperFixture(t)
+			if tc.prepare != nil {
+				tc.prepare(t, f)
+			}
+
+			url := "http://127.0.0.1:1/unreachable"
+			if tc.handler != nil {
+				srv := httptest.NewServer(tc.handler)
+				defer srv.Close()
+				url = srv.URL
+			}
+			checksum := testSHA256Hex([]byte("placeholder"))
+			if tc.checksum != nil {
+				checksum = tc.checksum(nil)
+			}
+
+			err := stageDesktopHelper(desktopHelperStageOptions{
+				agentPath:        f.agentPath,
+				destPath:         f.destPath,
+				version:          tc.version,
+				goos:             "darwin",
+				goarch:           "arm64",
+				urlOverride:      url,
+				checksumOverride: checksum,
+			})
+			if err == nil {
+				t.Fatal("stageDesktopHelper: expected an error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.wantErrPart) {
+				t.Fatalf("error %q does not mention %q", err.Error(), tc.wantErrPart)
+			}
+			f.assertAgentBinaryNotInstalled(t)
+		})
+	}
+}
+
+// service_cmd_darwin.go is darwin-tagged, so the behavioural table above cannot
+// reach it from a linux CI runner. Pin structurally that the install command
+// delegates helper staging to stageDesktopHelper and never writes the helper's
+// install path itself — writing it directly is how the agent-binary
+// substitution got there in the first place.
+func TestServiceInstallDarwin_DelegatesHelperStaging(t *testing.T) {
+	source, err := os.ReadFile("service_cmd_darwin.go")
+	if err != nil {
+		t.Fatalf("read service_cmd_darwin.go: %v", err)
+	}
+	text := string(source)
+	if !strings.Contains(text, "stageDesktopHelper(desktopHelperStageOptions{") {
+		t.Fatal("service_cmd_darwin.go no longer stages the desktop helper via stageDesktopHelper")
+	}
+	if strings.Contains(text, "os.WriteFile(darwinDesktopHelperBinaryPath") {
+		t.Fatal("service_cmd_darwin.go writes the desktop helper path directly — helper bytes must only ever come from stageDesktopHelper (#3457)")
+	}
+}
+
+func TestDesktopHelperDownloadURL(t *testing.T) {
+	tests := []struct {
+		version, goos, goarch, want string
+	}{
+		{
+			"0.109.0", "darwin", "arm64",
+			"https://github.com/LanternOps/breeze/releases/download/v0.109.0/breeze-desktop-helper-darwin-arm64",
+		},
+		{
+			"0.109.0", "darwin", "amd64",
+			"https://github.com/LanternOps/breeze/releases/download/v0.109.0/breeze-desktop-helper-darwin-amd64",
+		},
+		{
+			"0.109.0", "windows", "amd64",
+			"https://github.com/LanternOps/breeze/releases/download/v0.109.0/breeze-desktop-helper-windows-amd64.exe",
+		},
+	}
+	for _, tc := range tests {
+		if got := desktopHelperDownloadURL(tc.version, tc.goos, tc.goarch); got != tc.want {
+			t.Errorf("desktopHelperDownloadURL(%q,%q,%q) = %q, want %q",
+				tc.version, tc.goos, tc.goarch, got, tc.want)
+		}
+	}
+}
+
+func TestIsDevBuildVersion(t *testing.T) {
+	tests := []struct {
+		version string
+		want    bool
+	}{
+		{"", true},
+		{"dev", true},
+		{"dev-abc123", true},
+		{"0.109.0", false},
+		{"0.109.0-rc.1", false},
+	}
+	for _, tc := range tests {
+		if got := isDevBuildVersion(tc.version); got != tc.want {
+			t.Errorf("isDevBuildVersion(%q) = %v, want %v", tc.version, got, tc.want)
+		}
+	}
+}
+
+func TestDesktopHelperUnavailableWarning_IsActionable(t *testing.T) {
+	msg := desktopHelperUnavailableWarning(os.ErrNotExist, "0.109.0", "darwin", "arm64")
+	for _, want := range []string{
+		"desktop helper not installed",
+		"agent service is installed",
+		"does NOT substitute the agent binary",
+		"breeze-desktop-helper-darwin-arm64",
+		"service install",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("warning does not mention %q:\n%s", want, msg)
+		}
+	}
+}

--- a/agent/internal/agentapp/desktop_helper_bootstrap_test.go
+++ b/agent/internal/agentapp/desktop_helper_bootstrap_test.go
@@ -409,8 +409,12 @@ func TestWriteBinaryAtomically(t *testing.T) {
 	if info.Mode().Perm()&0o111 == 0 {
 		t.Fatalf("dest mode = %v, want it executable", info.Mode().Perm())
 	}
-	if _, err := os.Stat(dest + ".staging"); !os.IsNotExist(err) {
-		t.Fatalf("staging temp file left behind at %s", dest+".staging")
+	leftovers, globErr := filepath.Glob(dest + ".staging*")
+	if globErr != nil {
+		t.Fatal(globErr)
+	}
+	if len(leftovers) != 0 {
+		t.Fatalf("staging temp files left behind: %v", leftovers)
 	}
 
 	// A destination whose directory does not exist fails without touching a
@@ -419,7 +423,11 @@ func TestWriteBinaryAtomically(t *testing.T) {
 	if err := writeBinaryAtomically(missingDir, []byte("x")); err == nil {
 		t.Fatal("expected an error writing into a missing directory")
 	}
-	if _, err := os.Stat(missingDir + ".staging"); !os.IsNotExist(err) {
-		t.Fatal("staging temp file left behind after a failed write")
+	leftovers, globErr = filepath.Glob(missingDir + ".staging*")
+	if globErr != nil {
+		t.Fatal(globErr)
+	}
+	if len(leftovers) != 0 {
+		t.Fatalf("staging temp files left behind after a failed write: %v", leftovers)
 	}
 }

--- a/agent/internal/agentapp/service_cmd_darwin.go
+++ b/agent/internal/agentapp/service_cmd_darwin.go
@@ -207,18 +207,22 @@ var serviceInstallCmd = &cobra.Command{
 		}
 		fmt.Printf("LaunchDaemon plist installed to %s\n", darwinPlistDst)
 
-		desktopHelperSource := filepath.Join(filepath.Dir(exePath), "breeze-desktop-helper")
-		desktopHelperBytes, desktopHelperErr := os.ReadFile(desktopHelperSource)
-		if desktopHelperErr != nil {
-			desktopHelperBytes, desktopHelperErr = os.ReadFile(exePath)
+		// Stage the REAL desktop helper — sibling binary first, matching-version
+		// signed release asset second. It must never be substituted with the
+		// agent binary: see stageDesktopHelper for why (#3457). A failure here
+		// is a warning, not a fatal error, so an offline or air-gapped install
+		// still gets a working agent service (same policy as the watchdog).
+		if err := stageDesktopHelper(desktopHelperStageOptions{
+			agentPath: exePath,
+			destPath:  darwinDesktopHelperBinaryPath,
+			version:   version,
+			goos:      runtime.GOOS,
+			goarch:    runtime.GOARCH,
+		}); err != nil {
+			fmt.Fprint(os.Stderr, desktopHelperUnavailableWarning(err, version, runtime.GOOS, runtime.GOARCH))
+		} else {
+			fmt.Printf("Desktop helper installed to %s\n", darwinDesktopHelperBinaryPath)
 		}
-		if desktopHelperErr != nil {
-			return fmt.Errorf("failed to stage desktop helper binary: %w", desktopHelperErr)
-		}
-		if err := os.WriteFile(darwinDesktopHelperBinaryPath, desktopHelperBytes, 0755); err != nil {
-			return fmt.Errorf("failed to copy desktop helper to %s: %w", darwinDesktopHelperBinaryPath, err)
-		}
-		fmt.Printf("Desktop helper installed to %s\n", darwinDesktopHelperBinaryPath)
 
 		if err := os.WriteFile(darwinDesktopUserPlistDst, []byte(darwinDesktopUserPlist), 0644); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to write desktop-helper user plist: %v\n", err)

--- a/agent/internal/agentapp/service_cmd_darwin.go
+++ b/agent/internal/agentapp/service_cmd_darwin.go
@@ -212,27 +212,38 @@ var serviceInstallCmd = &cobra.Command{
 		// agent binary: see stageDesktopHelper for why (#3457). A failure here
 		// is a warning, not a fatal error, so an offline or air-gapped install
 		// still gets a working agent service (same policy as the watchdog).
-		if err := stageDesktopHelper(desktopHelperStageOptions{
+		stageHelperErr := stageDesktopHelper(desktopHelperStageOptions{
 			agentPath: exePath,
 			destPath:  darwinDesktopHelperBinaryPath,
 			version:   version,
 			goos:      runtime.GOOS,
 			goarch:    runtime.GOARCH,
-		}); err != nil {
-			fmt.Fprint(os.Stderr, desktopHelperUnavailableWarning(err, version, runtime.GOOS, runtime.GOARCH))
+		})
+		if stageHelperErr != nil {
+			fmt.Fprint(os.Stderr, desktopHelperUnavailableWarning(stageHelperErr, version, runtime.GOOS, runtime.GOARCH))
 		} else {
 			fmt.Printf("Desktop helper installed to %s\n", darwinDesktopHelperBinaryPath)
 		}
 
-		if err := os.WriteFile(darwinDesktopUserPlistDst, []byte(darwinDesktopUserPlist), 0644); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to write desktop-helper user plist: %v\n", err)
+		// Only register the helper's LaunchAgents when a helper binary is
+		// actually there — see desktopHelperLaunchAgentsWanted.
+		helperLaunchAgents := desktopHelperLaunchAgentsWanted(stageHelperErr, darwinDesktopHelperBinaryPath)
+		if helperLaunchAgents {
+			if err := os.WriteFile(darwinDesktopUserPlistDst, []byte(darwinDesktopUserPlist), 0644); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: failed to write desktop-helper user plist: %v\n", err)
+			} else {
+				fmt.Printf("LaunchAgent plist installed to %s\n", darwinDesktopUserPlistDst)
+			}
+			if err := os.WriteFile(darwinDesktopLoginWindowPlistDst, []byte(darwinDesktopLoginWindowPlist), 0644); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: failed to write desktop-helper loginwindow plist: %v\n", err)
+			} else {
+				fmt.Printf("LaunchAgent plist installed to %s\n", darwinDesktopLoginWindowPlistDst)
+			}
 		} else {
-			fmt.Printf("LaunchAgent plist installed to %s\n", darwinDesktopUserPlistDst)
-		}
-		if err := os.WriteFile(darwinDesktopLoginWindowPlistDst, []byte(darwinDesktopLoginWindowPlist), 0644); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to write desktop-helper loginwindow plist: %v\n", err)
-		} else {
-			fmt.Printf("LaunchAgent plist installed to %s\n", darwinDesktopLoginWindowPlistDst)
+			fmt.Fprintf(os.Stderr,
+				"Skipping desktop-helper LaunchAgent setup: no helper binary at %s.\n"+
+					"  launchd would otherwise retry a missing program indefinitely.\n",
+				darwinDesktopHelperBinaryPath)
 		}
 
 		// Create the breeze group, put the logged-in console users in it, and only
@@ -242,10 +253,17 @@ var serviceInstallCmd = &cobra.Command{
 		// would not be in the group that owns the IPC socket and would be denied
 		// (#3133/#3134/#3137). This ordering was previously reversed; it is
 		// pinned by TestInstallIPCPrereqsThenHelpersOrdering.
+		// The breeze group is set up regardless — the agent's own IPC socket
+		// belongs to it — but the helper bootstrap is skipped when there is no
+		// helper binary to bootstrap.
+		bootstrapHelpers := bootstrapDesktopHelperPlists
+		if !helperLaunchAgents {
+			bootstrapHelpers = func() {}
+		}
 		if err := installIPCPrereqsThenHelpers(
 			ensureDarwinBreezeGroup,
 			ensureDarwinBreezeGroupConsoleMembers,
-			bootstrapDesktopHelperPlists,
+			bootstrapHelpers,
 		); err != nil {
 			return err
 		}

--- a/agent/internal/agentapp/watchdog_bootstrap.go
+++ b/agent/internal/agentapp/watchdog_bootstrap.go
@@ -15,10 +15,15 @@ import (
 	"time"
 )
 
+// releasesBase, releaseChecksumsURL, fetchReleaseAssetChecksum,
+// verifyFileSHA256 and downloadReleaseAsset are shared release-asset
+// primitives: the watchdog bootstrap below and the desktop-helper bootstrap in
+// desktop_helper_bootstrap.go both consume them.
+//
 // NOTE: Keep this URL base in sync with agent/internal/updater/pkg_darwin.go.
 // Both point at the same GitHub releases. If one ever moves to an env var,
 // migrate both call sites together.
-const watchdogReleasesBase = "https://github.com/LanternOps/breeze/releases/download"
+const releasesBase = "https://github.com/LanternOps/breeze/releases/download"
 
 // watchdogBinaryName returns the filename for the watchdog binary on the given GOOS.
 func watchdogBinaryName(goos string) string {
@@ -36,11 +41,18 @@ func watchdogDownloadURL(version, goos, goarch string) string {
 		ext = ".exe"
 	}
 	return fmt.Sprintf("%s/v%s/breeze-watchdog-%s-%s%s",
-		watchdogReleasesBase, version, goos, goarch, ext)
+		releasesBase, version, goos, goarch, ext)
 }
 
-func watchdogChecksumsURL(version string) string {
-	return fmt.Sprintf("%s/v%s/checksums.txt", watchdogReleasesBase, version)
+func releaseChecksumsURL(version string) string {
+	return fmt.Sprintf("%s/v%s/checksums.txt", releasesBase, version)
+}
+
+// isDevBuildVersion reports whether version names a locally built agent rather
+// than a published release. Dev builds have no matching GitHub release, so any
+// companion binary must be staged next to the agent by hand.
+func isDevBuildVersion(version string) bool {
+	return version == "" || version == "dev" || strings.HasPrefix(version, "dev-")
 }
 
 // locateSiblingWatchdog checks for the watchdog binary in the same directory
@@ -55,16 +67,16 @@ func locateSiblingWatchdog(agentPath string) (string, bool) {
 }
 
 const (
-	watchdogMinSize         = 1 * 1024 * 1024 // 1 MB sanity check (real binary is several MB)
-	watchdogDownloadTimeout = 60 * time.Second
+	releaseAssetMinSize    = 1 * 1024 * 1024 // 1 MB sanity check (real binary is several MB)
+	releaseDownloadTimeout = 60 * time.Second
 )
 
 // downloadWatchdog fetches the watchdog binary from url and writes it to destPath.
 // The file is streamed to a sibling temp file and atomically renamed on success,
 // so a partial download never leaves a broken binary behind. On unix the file is
 // marked executable (0755).
-func fetchWatchdogChecksum(checksumsURL, assetName string) (string, error) {
-	client := &http.Client{Timeout: watchdogDownloadTimeout}
+func fetchReleaseAssetChecksum(checksumsURL, assetName string) (string, error) {
+	client := &http.Client{Timeout: releaseDownloadTimeout}
 	resp, err := client.Get(checksumsURL)
 	if err != nil {
 		return "", fmt.Errorf("http get %s: %w", checksumsURL, err)
@@ -122,8 +134,12 @@ func verifyFileSHA256(path, expected string) error {
 	return nil
 }
 
-func downloadWatchdog(url, destPath, expectedSHA256 string) error {
-	client := &http.Client{Timeout: watchdogDownloadTimeout}
+// downloadReleaseAsset fetches a release asset from url and writes it to
+// destPath. The file is streamed to a sibling temp file and atomically renamed
+// on success, so a partial download never leaves a broken binary behind. It is
+// written executable (0755).
+func downloadReleaseAsset(url, destPath, expectedSHA256 string) error {
+	client := &http.Client{Timeout: releaseDownloadTimeout}
 	resp, err := client.Get(url)
 	if err != nil {
 		return fmt.Errorf("http get %s: %w", url, err)
@@ -149,7 +165,7 @@ func downloadWatchdog(url, destPath, expectedSHA256 string) error {
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("close %s: %w", tmpPath, closeErr)
 	}
-	if n < watchdogMinSize {
+	if n < releaseAssetMinSize {
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("downloaded body too small (%d bytes); URL likely returned an error page", n)
 	}
@@ -187,7 +203,7 @@ type bootstrapOptions struct {
 func bootstrapWatchdog(opts bootstrapOptions) error {
 	watchdogPath, ok := locateSiblingWatchdog(opts.agentPath)
 	if !ok {
-		if opts.version == "" || opts.version == "dev" || strings.HasPrefix(opts.version, "dev-") {
+		if isDevBuildVersion(opts.version) {
 			return fmt.Errorf("no sibling watchdog found and agent is a dev build (version=%q); run `breeze-watchdog service install` manually", opts.version)
 		}
 		url := opts.urlOverride
@@ -201,14 +217,14 @@ func bootstrapWatchdog(opts bootstrapOptions) error {
 			}
 			assetName := filepath.Base(url)
 			var err error
-			checksum, err = fetchWatchdogChecksum(watchdogChecksumsURL(opts.version), assetName)
+			checksum, err = fetchReleaseAssetChecksum(releaseChecksumsURL(opts.version), assetName)
 			if err != nil {
 				return fmt.Errorf("fetch watchdog checksum: %w", err)
 			}
 		}
 		watchdogPath = filepath.Join(filepath.Dir(opts.agentPath), watchdogBinaryName(opts.goos))
 		fmt.Fprintf(os.Stderr, "Downloading watchdog from %s ...\n", url)
-		if err := downloadWatchdog(url, watchdogPath, checksum); err != nil {
+		if err := downloadReleaseAsset(url, watchdogPath, checksum); err != nil {
 			return fmt.Errorf("download watchdog: %w", err)
 		}
 	}

--- a/agent/internal/agentapp/watchdog_bootstrap_test.go
+++ b/agent/internal/agentapp/watchdog_bootstrap_test.go
@@ -60,10 +60,10 @@ func TestWatchdogDownloadURL(t *testing.T) {
 }
 
 func TestWatchdogChecksumsURL(t *testing.T) {
-	got := watchdogChecksumsURL("0.62.24")
+	got := releaseChecksumsURL("0.62.24")
 	want := "https://github.com/LanternOps/breeze/releases/download/v0.62.24/checksums.txt"
 	if got != want {
-		t.Errorf("watchdogChecksumsURL() = %q, want %q", got, want)
+		t.Errorf("releaseChecksumsURL() = %q, want %q", got, want)
 	}
 }
 
@@ -117,8 +117,8 @@ func TestDownloadWatchdog_Success(t *testing.T) {
 	destDir := t.TempDir()
 	destPath := filepath.Join(destDir, "breeze-watchdog")
 
-	if err := downloadWatchdog(srv.URL, destPath, testSHA256Hex(body)); err != nil {
-		t.Fatalf("downloadWatchdog: %v", err)
+	if err := downloadReleaseAsset(srv.URL, destPath, testSHA256Hex(body)); err != nil {
+		t.Fatalf("downloadReleaseAsset: %v", err)
 	}
 
 	got, err := os.ReadFile(destPath)
@@ -146,12 +146,12 @@ func TestDownloadWatchdog_404(t *testing.T) {
 	defer srv.Close()
 
 	destPath := filepath.Join(t.TempDir(), "breeze-watchdog")
-	err := downloadWatchdog(srv.URL, destPath, testSHA256Hex([]byte("unused")))
+	err := downloadReleaseAsset(srv.URL, destPath, testSHA256Hex([]byte("unused")))
 	if err == nil {
-		t.Fatalf("downloadWatchdog: expected error on 404, got nil")
+		t.Fatalf("downloadReleaseAsset: expected error on 404, got nil")
 	}
 	if _, statErr := os.Stat(destPath); statErr == nil {
-		t.Errorf("downloadWatchdog: dest file should not exist after failure")
+		t.Errorf("downloadReleaseAsset: dest file should not exist after failure")
 	}
 }
 
@@ -163,12 +163,12 @@ func TestDownloadWatchdog_TooSmall(t *testing.T) {
 	defer srv.Close()
 
 	destPath := filepath.Join(t.TempDir(), "breeze-watchdog")
-	err := downloadWatchdog(srv.URL, destPath, testSHA256Hex([]byte("not a real binary")))
+	err := downloadReleaseAsset(srv.URL, destPath, testSHA256Hex([]byte("not a real binary")))
 	if err == nil {
-		t.Fatalf("downloadWatchdog: expected error on too-small body, got nil")
+		t.Fatalf("downloadReleaseAsset: expected error on too-small body, got nil")
 	}
 	if _, statErr := os.Stat(destPath); statErr == nil {
-		t.Errorf("downloadWatchdog: dest file should not exist after failure")
+		t.Errorf("downloadReleaseAsset: dest file should not exist after failure")
 	}
 }
 
@@ -184,12 +184,12 @@ func TestDownloadWatchdog_ChecksumMismatch(t *testing.T) {
 	defer srv.Close()
 
 	destPath := filepath.Join(t.TempDir(), "breeze-watchdog")
-	err := downloadWatchdog(srv.URL, destPath, testSHA256Hex([]byte("different body")))
+	err := downloadReleaseAsset(srv.URL, destPath, testSHA256Hex([]byte("different body")))
 	if err == nil {
-		t.Fatalf("downloadWatchdog: expected checksum mismatch, got nil")
+		t.Fatalf("downloadReleaseAsset: expected checksum mismatch, got nil")
 	}
 	if _, statErr := os.Stat(destPath); statErr == nil {
-		t.Errorf("downloadWatchdog: dest file should not exist after checksum failure")
+		t.Errorf("downloadReleaseAsset: dest file should not exist after checksum failure")
 	}
 }
 
@@ -202,13 +202,13 @@ func TestFetchWatchdogChecksum(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	got, err := fetchWatchdogChecksum(srv.URL, "breeze-watchdog-linux-arm64")
+	got, err := fetchReleaseAssetChecksum(srv.URL, "breeze-watchdog-linux-arm64")
 	if err != nil {
-		t.Fatalf("fetchWatchdogChecksum: %v", err)
+		t.Fatalf("fetchReleaseAssetChecksum: %v", err)
 	}
 	want := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 	if got != want {
-		t.Errorf("fetchWatchdogChecksum = %q, want %q", got, want)
+		t.Errorf("fetchReleaseAssetChecksum = %q, want %q", got, want)
 	}
 }
 

--- a/agent/internal/heartbeat/code_signature_backoff_test.go
+++ b/agent/internal/heartbeat/code_signature_backoff_test.go
@@ -1,0 +1,143 @@
+package heartbeat
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/updater"
+)
+
+// Issue #3458: the updater refuses to install a macOS binary that fails
+// `codesign --verify` rather than ad-hoc re-signing it (which would give the
+// agent a fresh code identity and drop its TCC grants). The refusal is terminal
+// for that target version — the bytes are already checksum-verified against the
+// signed manifest, so re-downloading reproduces the same failure — but not
+// permanent: republishing a correctly signed build must recover the fleet on
+// its own. doUpgrade therefore backs off per target version. These tests pin
+// that policy on the decision helpers doUpgrade delegates to.
+
+func TestCodeSignatureBackoff_InactiveBeforeAnyRejection(t *testing.T) {
+	h := &Heartbeat{}
+	if h.codeSignatureBackoffActive("0.109.0") {
+		t.Fatal("a target that never failed verification must not be backed off")
+	}
+}
+
+func TestCodeSignatureBackoff_ActiveAfterRejection(t *testing.T) {
+	h := &Heartbeat{}
+	h.noteCodeSignatureFailure("0.109.0")
+	if !h.codeSignatureBackoffActive("0.109.0") {
+		t.Fatal("a just-rejected target must be backed off, not retried next heartbeat")
+	}
+}
+
+// Without the cooldown every macOS device re-downloads the same doomed binary
+// every ~60s, which is the storm #3544 fixed for untrusted releases.
+func TestCodeSignatureBackoff_SuppressesRepeatedHeartbeats(t *testing.T) {
+	h := &Heartbeat{}
+	attempts := 0
+	for i := 0; i < 60; i++ { // an hour of heartbeats at ~60s
+		if h.codeSignatureBackoffActive("0.109.0") {
+			continue
+		}
+		attempts++
+		h.noteCodeSignatureFailure("0.109.0")
+	}
+	if attempts != 1 {
+		t.Fatalf("expected 1 attempt across 60 heartbeats, got %d", attempts)
+	}
+}
+
+// Publishing a different (correctly signed) version is the operator's fix, so
+// it must be attempted on the very next heartbeat.
+func TestCodeSignatureBackoff_NewTargetIsNotThrottled(t *testing.T) {
+	h := &Heartbeat{}
+	h.noteCodeSignatureFailure("0.109.0")
+	if h.codeSignatureBackoffActive("0.109.1") {
+		t.Fatal("a different target version must not inherit the cooldown")
+	}
+}
+
+// Re-publishing the SAME version with a good signature must recover without
+// restarting the agent.
+func TestCodeSignatureBackoff_ExpiresAfterCooldown(t *testing.T) {
+	h := &Heartbeat{}
+	h.noteCodeSignatureFailure("0.109.0")
+
+	h.badSignatureMu.Lock()
+	h.badSignatureAt = time.Now().Add(-2 * codeSignatureRetryCooldown)
+	h.badSignatureMu.Unlock()
+
+	if h.codeSignatureBackoffActive("0.109.0") {
+		t.Fatal("the cooldown must expire so a republished build recovers on its own")
+	}
+}
+
+// The two cooldowns are independent: a signature failure must not silence a
+// different, unrelated upgrade target refused as untrusted, or vice versa.
+func TestCodeSignatureBackoff_IndependentOfUntrustedReleaseBackoff(t *testing.T) {
+	h := &Heartbeat{}
+	h.noteCodeSignatureFailure("0.109.0")
+	if h.untrustedReleaseBackoffActive("0.109.0") {
+		t.Fatal("a signature failure must not start the untrusted-release cooldown")
+	}
+
+	other := &Heartbeat{}
+	other.noteUntrustedRelease("0.109.0")
+	if other.codeSignatureBackoffActive("0.109.0") {
+		t.Fatal("an untrusted release must not start the signature cooldown")
+	}
+}
+
+// doUpgrade runs on a goroutine per heartbeat, so the state must be safe under
+// concurrent access (-race makes this meaningful).
+func TestCodeSignatureBackoff_ConcurrentAccess(t *testing.T) {
+	h := &Heartbeat{}
+	done := make(chan struct{})
+	for i := 0; i < 8; i++ {
+		go func() {
+			defer func() { done <- struct{}{} }()
+			for j := 0; j < 200; j++ {
+				h.noteCodeSignatureFailure("0.109.0")
+				_ = h.codeSignatureBackoffActive("0.109.0")
+			}
+		}()
+	}
+	for i := 0; i < 8; i++ {
+		<-done
+	}
+}
+
+// doUpgrade classifies the updater's failure by sentinel. Pin that a wrapped
+// ErrCodeSignatureInvalid is still recognised, and that neighbouring updater
+// sentinels are not confused with it — misclassifying one as the other would
+// either disable auto-update permanently or retry a doomed download forever.
+func TestCodeSignatureErrorClassification(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "bare sentinel", err: updater.ErrCodeSignatureInvalid, want: true},
+		{
+			name: "wrapped sentinel",
+			err:  fmt.Errorf("failed to replace binary: %w", updater.ErrCodeSignatureInvalid),
+			want: true,
+		},
+		{name: "read-only filesystem", err: updater.ErrReadOnlyFS, want: false},
+		{name: "text file busy", err: updater.ErrTextBusy, want: false},
+		{name: "file locked", err: updater.ErrFileLocked, want: false},
+		{name: "untrusted release", err: updater.ErrUntrustedRelease, want: false},
+		{name: "unrelated error", err: errors.New("connection reset"), want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := errors.Is(tc.err, updater.ErrCodeSignatureInvalid); got != tc.want {
+				t.Fatalf("errors.Is(%v, ErrCodeSignatureInvalid) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -584,6 +584,14 @@ type Heartbeat struct {
 	untrustedReleaseVer string
 	untrustedReleaseAt  time.Time
 
+	// Cooldown state for an upgrade target whose staged binary failed macOS
+	// code-signature verification (updater.ErrCodeSignatureInvalid). Same
+	// shape and rationale as the untrustedRelease trio above — terminal for
+	// that version, recoverable once a good artifact is published. Issue #3458.
+	badSignatureMu  sync.Mutex
+	badSignatureVer string
+	badSignatureAt  time.Time
+
 	// Path to the agent state file, set by main after startup.
 	statePath                   string
 	pamLifetimeManager          pamlifetime.Manager
@@ -6826,6 +6834,35 @@ func (h *Heartbeat) noteUntrustedRelease(targetVersion string) {
 	h.untrustedReleaseAt = time.Now()
 }
 
+// codeSignatureRetryCooldown bounds how often an upgrade target whose staged
+// binary failed macOS code-signature verification is retried. Like
+// untrustedReleaseRetryCooldown this is terminal-per-version but not permanent:
+// the artifact is already checksum-verified against the signed manifest, so
+// re-downloading it on the device can only reproduce the same failure, yet a
+// re-published (correctly signed) build must recover automatically. Without the
+// cooldown every macOS device in a fleet would re-download the same doomed
+// binary every ~60s — the exact storm #3544 fixed for untrusted releases.
+// Issue #3458.
+const codeSignatureRetryCooldown = 30 * time.Minute
+
+// codeSignatureBackoffActive reports whether targetVersion already failed
+// signature verification within the cooldown window. Tracked per version so a
+// NEW upgrade target is always attempted immediately.
+func (h *Heartbeat) codeSignatureBackoffActive(targetVersion string) bool {
+	h.badSignatureMu.Lock()
+	defer h.badSignatureMu.Unlock()
+	return h.badSignatureVer == targetVersion &&
+		time.Since(h.badSignatureAt) < codeSignatureRetryCooldown
+}
+
+// noteCodeSignatureFailure starts (or restarts) the cooldown for targetVersion.
+func (h *Heartbeat) noteCodeSignatureFailure(targetVersion string) {
+	h.badSignatureMu.Lock()
+	defer h.badSignatureMu.Unlock()
+	h.badSignatureVer = targetVersion
+	h.badSignatureAt = time.Now()
+}
+
 // doUpgrade contains the actual upgrade logic, called by handleUpgrade.
 func (h *Heartbeat) doUpgrade(targetVersion string) {
 	// Checked before sendUpdateStatus and before any download work: the server
@@ -6835,6 +6872,14 @@ func (h *Heartbeat) doUpgrade(targetVersion string) {
 	// refuse again.
 	if h.untrustedReleaseBackoffActive(targetVersion) {
 		log.Debug("upgrade skipped: server recently refused this version as untrusted; backing off",
+			"targetVersion", targetVersion)
+		return
+	}
+	// Same reason as above: the server re-sends the same upgradeTo every
+	// heartbeat, so without this gate a version whose binary cannot pass
+	// macOS code-signature verification is re-downloaded in full every cycle.
+	if h.codeSignatureBackoffActive(targetVersion) {
+		log.Debug("upgrade skipped: this version's binary recently failed macOS code signature verification; backing off",
 			"targetVersion", targetVersion)
 		return
 	}
@@ -6953,6 +6998,20 @@ func (h *Heartbeat) doUpgrade(targetVersion string) {
 				"targetVersion", targetVersion,
 				"error", err.Error(),
 				"retryAfter", untrustedReleaseRetryCooldown.String())
+			return
+		}
+		// macOS refused to install the staged binary because it fails
+		// `codesign --verify`. The installed binary was never touched (the
+		// gate runs before any write), so the device keeps running the build
+		// its TCC grants are keyed to. Terminal for this target until a
+		// correctly signed artifact is published, so back off rather than
+		// re-download it every heartbeat. Issue #3458.
+		if errors.Is(err, updater.ErrCodeSignatureInvalid) {
+			h.noteCodeSignatureFailure(targetVersion)
+			log.Error("auto-update blocked: the binary published for this version fails macOS code signature verification — republish a Developer ID signed, notarized build; the agent is still running its previous, correctly signed binary",
+				"targetVersion", targetVersion,
+				"error", err.Error(),
+				"retryAfter", codeSignatureRetryCooldown.String())
 			return
 		}
 		// A download failure here may carry a *netpolicy.PolicyError, or be a

--- a/agent/internal/updater/replace_binary_signature_darwin_test.go
+++ b/agent/internal/updater/replace_binary_signature_darwin_test.go
@@ -1,0 +1,118 @@
+//go:build darwin
+
+// Platform-truth coverage for the real `codesign --verify` gate. The
+// cross-platform tests in replace_binary_signature_test.go stub the seam; these
+// exercise the actual implementation on the only OS where it does anything.
+package updater
+
+import (
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func copyFileForTest(t *testing.T, src, dst string) {
+	t.Helper()
+	in, err := os.Open(src)
+	if err != nil {
+		t.Fatalf("open %s: %v", src, err)
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o755)
+	if err != nil {
+		t.Fatalf("create %s: %v", dst, err)
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		t.Fatalf("copy %s -> %s: %v", src, dst, err)
+	}
+	if err := out.Close(); err != nil {
+		t.Fatalf("close %s: %v", dst, err)
+	}
+}
+
+func TestDefaultStagedSignatureCheck_Darwin(t *testing.T) {
+	if _, err := exec.LookPath("codesign"); err != nil {
+		t.Skip("codesign not available")
+	}
+
+	dir := t.TempDir()
+
+	// A genuinely signed Mach-O: a copy of this test binary, ad-hoc signed so
+	// the case is deterministic on both amd64 (where the Go linker does not
+	// sign) and arm64 (where it does).
+	signed := filepath.Join(dir, "signed-macho")
+	copyFileForTest(t, os.Args[0], signed)
+	if out, err := exec.Command("codesign", "--force", "--sign", "-", signed).CombinedOutput(); err != nil {
+		t.Skipf("could not ad-hoc sign the test fixture: %v: %s", err, out)
+	}
+
+	// Not a Mach-O at all: `codesign --verify` reports "not signed at all".
+	unsigned := filepath.Join(dir, "not-a-macho")
+	if err := os.WriteFile(unsigned, []byte("#!/bin/sh\necho hi\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{name: "validly signed Mach-O is accepted", path: signed, wantErr: false},
+		{name: "file with no signature is rejected", path: unsigned, wantErr: true},
+		{name: "missing file is rejected", path: filepath.Join(dir, "does-not-exist"), wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := defaultStagedSignatureCheck(tc.path)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("defaultStagedSignatureCheck(%s) = nil, want an error", tc.path)
+				}
+				if !errors.Is(err, ErrCodeSignatureInvalid) {
+					t.Fatalf("error %v does not wrap ErrCodeSignatureInvalid", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("defaultStagedSignatureCheck(%s) = %v, want nil", tc.path, err)
+			}
+		})
+	}
+}
+
+// TestReplaceBinary_RealSignatureGateKeepsInstalledBinary drives the whole
+// replaceBinary path with the REAL gate: an unsigned staged binary must be
+// refused and the installed binary left byte-identical (#3458).
+func TestReplaceBinary_RealSignatureGateKeepsInstalledBinary(t *testing.T) {
+	if _, err := exec.LookPath("codesign"); err != nil {
+		t.Skip("codesign not available")
+	}
+
+	dir := t.TempDir()
+	binaryPath := filepath.Join(dir, "breeze-agent")
+	stagedPath := filepath.Join(dir, "staged")
+	if err := os.WriteFile(binaryPath, []byte("installed binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(stagedPath, []byte("not a signed mach-o"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	u := New(&Config{BinaryPath: binaryPath})
+	err := u.replaceBinary(stagedPath)
+	if !errors.Is(err, ErrCodeSignatureInvalid) {
+		t.Fatalf("replaceBinary error = %v, want ErrCodeSignatureInvalid", err)
+	}
+	content, readErr := os.ReadFile(binaryPath)
+	if readErr != nil {
+		t.Fatalf("read installed binary: %v", readErr)
+	}
+	if string(content) != "installed binary" {
+		t.Fatalf("installed binary = %q, want it untouched", string(content))
+	}
+}

--- a/agent/internal/updater/replace_binary_signature_test.go
+++ b/agent/internal/updater/replace_binary_signature_test.go
@@ -1,11 +1,17 @@
 package updater
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/breeze-rmm/agent/internal/secmem"
 )
 
 // stubStagedSignatureCheck replaces the code-signature gate for the duration of
@@ -45,8 +51,8 @@ func TestReplaceBinary_SignatureGate(t *testing.T) {
 			wantContent: installed,
 		},
 		{
-			name:        "wrapped signature error is still refused",
-			verifyErr:   errors.New("codesign: " + ErrCodeSignatureInvalid.Error()),
+			name:        "any non-sentinel verify failure is still refused",
+			verifyErr:   errors.New("codesign: exit status 1"),
 			wantErr:     true,
 			wantContent: installed,
 		},
@@ -134,13 +140,132 @@ func TestReplaceBinary_SignatureRejectionIsClassifiable(t *testing.T) {
 // hash, so applying one to a shipped build changes the agent's code identity on
 // every update and macOS drops the TCC grants keyed to the previous identity.
 func TestReplaceBinary_NoAdHocSigning(t *testing.T) {
-	source, err := os.ReadFile("updater.go")
+	entries, err := os.ReadDir(".")
 	if err != nil {
-		t.Fatalf("read updater.go: %v", err)
+		t.Fatalf("read package dir: %v", err)
 	}
-	for _, forbidden := range []string{`"--force", "--sign", "-"`, `"--sign", "-"`} {
-		if strings.Contains(string(source), forbidden) {
-			t.Fatalf("updater.go still ad-hoc signs the binary (found %s); see #3458", forbidden)
+	scanned := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
 		}
+		source, readErr := os.ReadFile(name)
+		if readErr != nil {
+			t.Fatalf("read %s: %v", name, readErr)
+		}
+		scanned++
+		for _, forbidden := range []string{`"--force", "--sign", "-"`, `"--sign", "-"`, `"--sign", adHoc`} {
+			if strings.Contains(string(source), forbidden) {
+				t.Fatalf("%s ad-hoc signs the binary (found %s); the updater must never manufacture a signature — see #3458", name, forbidden)
+			}
+		}
+	}
+	if scanned == 0 {
+		t.Fatal("scanned no source files — the guard would pass vacuously")
+	}
+}
+
+// TestUpdateFromURL_SignatureRejectionSurvivesToTheCaller drives the public
+// entry point, not just replaceBinary. heartbeat.doUpgrade matches on
+// errors.Is(err, ErrCodeSignatureInvalid), so a future re-wrap that loses the
+// sentinel (errors.New(err.Error()), say) would silently disable the
+// classification, the actionable log line and the retry cooldown. It also pins
+// that the refusal does NOT roll back: nothing was written, so rewriting the
+// live binary from the backup would be pure risk.
+func TestUpdateFromURL_SignatureRejectionSurvivesToTheCaller(t *testing.T) {
+	const installed = "installed binary v1"
+	staged := []byte("staged binary v2")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(staged)
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	binaryPath := filepath.Join(dir, "breeze-agent")
+	backupPath := filepath.Join(dir, "breeze-agent.backup")
+	if err := os.WriteFile(binaryPath, []byte(installed), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	stubStagedSignatureCheck(t, func(string) error { return ErrCodeSignatureInvalid })
+
+	u := New(&Config{
+		ServerURL:  staticServerURL(srv.URL),
+		AuthToken:  secmem.NewSecureString("tok"),
+		BinaryPath: binaryPath,
+		BackupPath: backupPath,
+	})
+	u.client = srv.Client()
+
+	sum := sha256.Sum256(staged)
+	err := u.UpdateFromURL(srv.URL, hex.EncodeToString(sum[:]), UpdateOptions{})
+	if !errors.Is(err, ErrCodeSignatureInvalid) {
+		t.Fatalf("UpdateFromURL error = %v, want it to wrap ErrCodeSignatureInvalid", err)
+	}
+
+	content, readErr := os.ReadFile(binaryPath)
+	if readErr != nil {
+		t.Fatalf("read installed binary: %v", readErr)
+	}
+	if string(content) != installed {
+		t.Fatalf("installed binary = %q, want it untouched", string(content))
+	}
+}
+
+// The two remedy branches differ by which entry point refused the update, and a
+// swapped one would only surface mid-incident in an agent log.
+func TestCodeSignatureRejectionFields(t *testing.T) {
+	tests := []struct {
+		name          string
+		targetVersion string
+		wantPairs     map[string]string
+		wantRemedy    string
+		wantNoKey     string
+	}{
+		{
+			name:          "control-plane upgrade names the version",
+			targetVersion: "0.109.0",
+			wantPairs:     map[string]string{"targetVersion": "0.109.0"},
+			wantRemedy:    "republish this version",
+		},
+		{
+			name:          "dev push has no version and points at the build",
+			targetVersion: "",
+			wantRemedy:    "sign the dev binary",
+			wantNoKey:     "targetVersion",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fields := codeSignatureRejectionFields(tc.targetVersion, ErrCodeSignatureInvalid)
+			if len(fields)%2 != 0 {
+				t.Fatalf("fields must be key/value pairs, got %d entries", len(fields))
+			}
+			got := map[string]string{}
+			for i := 0; i < len(fields); i += 2 {
+				key, _ := fields[i].(string)
+				value, _ := fields[i+1].(string)
+				got[key] = value
+			}
+			for key, want := range tc.wantPairs {
+				if got[key] != want {
+					t.Errorf("field %q = %q, want %q", key, got[key], want)
+				}
+			}
+			if tc.wantNoKey != "" {
+				if _, present := got[tc.wantNoKey]; present {
+					t.Errorf("field %q should not be present, got %q", tc.wantNoKey, got[tc.wantNoKey])
+				}
+			}
+			if !strings.Contains(got["remedy"], tc.wantRemedy) {
+				t.Errorf("remedy = %q, want it to mention %q", got["remedy"], tc.wantRemedy)
+			}
+			if got["action"] == "" {
+				t.Error("action field missing")
+			}
+		})
 	}
 }

--- a/agent/internal/updater/replace_binary_signature_test.go
+++ b/agent/internal/updater/replace_binary_signature_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -174,6 +175,13 @@ func TestReplaceBinary_NoAdHocSigning(t *testing.T) {
 // that the refusal does NOT roll back: nothing was written, so rewriting the
 // live binary from the backup would be pure risk.
 func TestUpdateFromURL_SignatureRejectionSurvivesToTheCaller(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// UpdateFromURL hands the swap to RestartWithHelper on Windows and
+		// never reaches replaceBinary, so there is no signature gate to assert.
+		// internal/updater is currently excluded from the test-agent-windows
+		// job (#2523); this guard is here so re-enabling it does not surprise.
+		t.Skip("UpdateFromURL does not call replaceBinary on Windows")
+	}
 	const installed = "installed binary v1"
 	staged := []byte("staged binary v2")
 

--- a/agent/internal/updater/replace_binary_signature_test.go
+++ b/agent/internal/updater/replace_binary_signature_test.go
@@ -1,0 +1,146 @@
+package updater
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// stubStagedSignatureCheck replaces the code-signature gate for the duration of
+// a test and restores the real implementation afterwards.
+func stubStagedSignatureCheck(t *testing.T, fn func(path string) error) {
+	t.Helper()
+	prev := verifyStagedBinarySignature
+	verifyStagedBinarySignature = fn
+	t.Cleanup(func() { verifyStagedBinarySignature = prev })
+}
+
+// TestReplaceBinary_SignatureGate pins the #3458 contract: a staged binary that
+// fails code-signature verification is REFUSED, and the refusal leaves the
+// installed binary byte-for-byte untouched. The updater used to "repair" this
+// by ad-hoc signing the new binary in place, which gave the agent a fresh code
+// identity on every update and silently invalidated its macOS TCC grants.
+func TestReplaceBinary_SignatureGate(t *testing.T) {
+	const installed = "installed binary v1"
+	const staged = "staged binary v2"
+
+	tests := []struct {
+		name        string
+		verifyErr   error
+		wantErr     bool
+		wantContent string
+	}{
+		{
+			name:        "valid signature installs the staged binary",
+			verifyErr:   nil,
+			wantErr:     false,
+			wantContent: staged,
+		},
+		{
+			name:        "invalid signature refuses the update and keeps the installed binary",
+			verifyErr:   ErrCodeSignatureInvalid,
+			wantErr:     true,
+			wantContent: installed,
+		},
+		{
+			name:        "wrapped signature error is still refused",
+			verifyErr:   errors.New("codesign: " + ErrCodeSignatureInvalid.Error()),
+			wantErr:     true,
+			wantContent: installed,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			binaryPath := filepath.Join(dir, "breeze-agent")
+			stagedPath := filepath.Join(dir, "staged")
+			if err := os.WriteFile(binaryPath, []byte(installed), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(stagedPath, []byte(staged), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			var gotPath string
+			stubStagedSignatureCheck(t, func(path string) error {
+				gotPath = path
+				return tc.verifyErr
+			})
+
+			u := New(&Config{BinaryPath: binaryPath})
+			err := u.replaceBinary(stagedPath)
+
+			if tc.wantErr && err == nil {
+				t.Fatalf("replaceBinary: expected an error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("replaceBinary: unexpected error: %v", err)
+			}
+			// The gate must inspect the STAGED file, never the installed one:
+			// checking after the copy is what made the old code ad-hoc sign a
+			// binary it had already put live.
+			if gotPath != stagedPath {
+				t.Fatalf("signature gate inspected %q, want the staged path %q", gotPath, stagedPath)
+			}
+			content, readErr := os.ReadFile(binaryPath)
+			if readErr != nil {
+				t.Fatalf("read installed binary: %v", readErr)
+			}
+			if string(content) != tc.wantContent {
+				t.Fatalf("installed binary = %q, want %q", string(content), tc.wantContent)
+			}
+		})
+	}
+}
+
+// TestReplaceBinary_SignatureRejectionIsClassifiable pins that the refusal is
+// reported with the ErrCodeSignatureInvalid sentinel, which is what
+// heartbeat.doUpgrade matches on to log the actionable message and start the
+// per-version retry cooldown instead of re-downloading every heartbeat.
+func TestReplaceBinary_SignatureRejectionIsClassifiable(t *testing.T) {
+	dir := t.TempDir()
+	binaryPath := filepath.Join(dir, "breeze-agent")
+	stagedPath := filepath.Join(dir, "staged")
+	if err := os.WriteFile(binaryPath, []byte("installed"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(stagedPath, []byte("staged"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stubStagedSignatureCheck(t, func(string) error {
+		return ErrCodeSignatureInvalid
+	})
+
+	u := New(&Config{BinaryPath: binaryPath})
+	err := u.replaceBinary(stagedPath)
+	if !errors.Is(err, ErrCodeSignatureInvalid) {
+		t.Fatalf("replaceBinary error = %v, want it to wrap ErrCodeSignatureInvalid", err)
+	}
+	if !isCodeSignatureErr(err) {
+		t.Fatalf("isCodeSignatureErr(%v) = false, want true", err)
+	}
+	if isCodeSignatureErr(errors.New("some other failure")) {
+		t.Fatal("isCodeSignatureErr matched an unrelated error")
+	}
+}
+
+// TestReplaceBinary_NoAdHocSigning is the direct regression guard for #3458:
+// the updater must not shell out to `codesign --force --sign -` anywhere. An
+// ad-hoc signature's designated requirement is the per-build code-directory
+// hash, so applying one to a shipped build changes the agent's code identity on
+// every update and macOS drops the TCC grants keyed to the previous identity.
+func TestReplaceBinary_NoAdHocSigning(t *testing.T) {
+	source, err := os.ReadFile("updater.go")
+	if err != nil {
+		t.Fatalf("read updater.go: %v", err)
+	}
+	for _, forbidden := range []string{`"--force", "--sign", "-"`, `"--sign", "-"`} {
+		if strings.Contains(string(source), forbidden) {
+			t.Fatalf("updater.go still ad-hoc signs the binary (found %s); see #3458", forbidden)
+		}
+	}
+}

--- a/agent/internal/updater/updater.go
+++ b/agent/internal/updater/updater.go
@@ -316,19 +316,28 @@ func isCodeSignatureErr(err error) bool {
 // rewrite the live, correctly signed binary. targetVersion is "" for the
 // dev-push path, which has no version to name.
 func logCodeSignatureRejection(targetVersion string, err error) {
+	log.Error(codeSignatureRejectionMessage, codeSignatureRejectionFields(targetVersion, err)...)
+}
+
+// codeSignatureRejectionMessage is the log line for a refused update.
+const codeSignatureRejectionMessage = "staged binary failed macOS code signature verification — refusing to install it"
+
+// codeSignatureRejectionFields builds the structured fields for that line. Split
+// out from logCodeSignatureRejection so the two remedy branches are assertable:
+// a swapped remedy would otherwise only be discovered mid-incident, by an
+// operator reading agent logs.
+func codeSignatureRejectionFields(targetVersion string, err error) []any {
 	fields := []any{
 		"error", err.Error(),
 		"action", "update refused; keeping the currently installed binary",
 	}
 	if targetVersion != "" {
-		fields = append(fields,
+		return append(fields,
 			"targetVersion", targetVersion,
 			"remedy", "republish this version as a Developer ID signed, notarized macOS build")
-	} else {
-		fields = append(fields,
-			"remedy", "sign the dev binary before pushing it (`make dev-push` signs darwin targets; set CODESIGN_IDENTITY to keep TCC grants across pushes)")
 	}
-	log.Error("staged binary failed macOS code signature verification — refusing to install it", fields...)
+	return append(fields,
+		"remedy", "sign the dev binary before pushing it (`make dev-push` signs darwin targets; set CODESIGN_IDENTITY to keep TCC grants across pushes)")
 }
 
 // downloadInfoError is the control plane's error body for a refused
@@ -901,6 +910,19 @@ func writeUpdateMarker(version string) {
 	}
 }
 
+// removeUpdateMarker clears a marker written for an update that then refused to
+// proceed. The marker tells the next agent start to skip its heartbeat jitter,
+// which is only correct when the process actually restarted for an update —
+// leaving a stale one behind means an unrelated restart (crash, reboot, launchd
+// respawn) also skips jitter, which is the thundering-herd case jitter exists
+// for.
+func removeUpdateMarker() {
+	markerPath := filepath.Join(config.ConfigDir(), ".update-restart")
+	if err := os.Remove(markerPath); err != nil && !os.IsNotExist(err) {
+		log.Warn("failed to remove update marker", "path", markerPath, "error", err.Error())
+	}
+}
+
 // UpdateTo is a thin shim around UpdateToWithOptions for the common case of
 // an agent-only upgrade. New code (and any caller that needs to thread a
 // companion binary like breeze-user-helper.exe through the Windows restart
@@ -1058,6 +1080,10 @@ func (u *Updater) updateTo(version string, opts UpdateOptions) error {
 	// 6. Non-macOS or pkg fallback: replace binary inline and restart
 	if err := u.replaceBinary(tempPath); err != nil {
 		if isCodeSignatureErr(err) {
+			// The darwin branch above already wrote the update marker before
+			// attempting the .pkg install; this update is not happening, so it
+			// must not tell the next restart that it did.
+			removeUpdateMarker()
 			logCodeSignatureRejection(version, err)
 			return err
 		}

--- a/agent/internal/updater/updater.go
+++ b/agent/internal/updater/updater.go
@@ -916,6 +916,13 @@ func writeUpdateMarker(version string) {
 // leaving a stale one behind means an unrelated restart (crash, reboot, launchd
 // respawn) also skips jitter, which is the thundering-herd case jitter exists
 // for.
+//
+// The marker is process-shared state and TryBeginProcessMutation's lease is
+// in-process only, so a watchdog-driven failover update of the agent
+// (cmd/breeze-watchdog doUpdateAgent, a separate process against the same
+// BinaryPath) racing an agent self-update could clear a marker the other just
+// wrote. The cost is bounded to that restart losing its jitter skip; the
+// write-side of the same race predates this function.
 func removeUpdateMarker() {
 	markerPath := filepath.Join(config.ConfigDir(), ".update-restart")
 	if err := os.Remove(markerPath); err != nil && !os.IsNotExist(err) {

--- a/agent/internal/updater/updater.go
+++ b/agent/internal/updater/updater.go
@@ -286,6 +286,51 @@ var ErrTextBusy = fmt.Errorf("binary is currently executing")
 // rather than retry every heartbeat (issue #3544).
 var ErrUntrustedRelease = fmt.Errorf("release is not trusted by the server")
 
+// ErrCodeSignatureInvalid is returned on macOS when the binary staged for
+// installation fails `codesign --verify`. It is TERMINAL for the current
+// target version: the bytes are already checksum-verified against the signed
+// release manifest, so a verification failure means the artifact itself is
+// unsigned or its signature is broken, and no amount of retrying on the device
+// will change that.
+//
+// The updater deliberately does NOT repair this by ad-hoc signing the binary
+// (`codesign --force --sign -`). An ad-hoc signature has no stable identity —
+// its designated requirement is the code-directory hash, which differs for
+// every build — so ad-hoc signing a shipped build gives the agent a brand-new
+// code identity on every update. macOS TCC grants (Screen Recording,
+// Accessibility, Full Disk Access) are keyed to the previous identity, so they
+// silently stop matching and the user is re-prompted after each update
+// (issue #3458). Refusing the update and keeping the working, correctly signed
+// binary is strictly better than installing one whose identity we just churned.
+var ErrCodeSignatureInvalid = fmt.Errorf("binary failed macOS code signature verification")
+
+// isCodeSignatureErr reports whether err came from the macOS signature gate in
+// replaceBinary.
+func isCodeSignatureErr(err error) bool {
+	return errors.Is(err, ErrCodeSignatureInvalid)
+}
+
+// logCodeSignatureRejection records a refused update loudly. The gate runs
+// before replaceBinary writes anything, so the installed binary is untouched
+// and there is nothing to roll back — a Rollback() here would pointlessly
+// rewrite the live, correctly signed binary. targetVersion is "" for the
+// dev-push path, which has no version to name.
+func logCodeSignatureRejection(targetVersion string, err error) {
+	fields := []any{
+		"error", err.Error(),
+		"action", "update refused; keeping the currently installed binary",
+	}
+	if targetVersion != "" {
+		fields = append(fields,
+			"targetVersion", targetVersion,
+			"remedy", "republish this version as a Developer ID signed, notarized macOS build")
+	} else {
+		fields = append(fields,
+			"remedy", "sign the dev binary before pushing it (`make dev-push` signs darwin targets; set CODESIGN_IDENTITY to keep TCC grants across pushes)")
+	}
+	log.Error("staged binary failed macOS code signature verification — refusing to install it", fields...)
+}
+
 // downloadInfoError is the control plane's error body for a refused
 // download-info request. `reason` is a machine-readable enum produced by
 // validateReleaseManifest in apps/api/src/routes/agentVersions.ts (e.g.
@@ -1012,6 +1057,10 @@ func (u *Updater) updateTo(version string, opts UpdateOptions) error {
 
 	// 6. Non-macOS or pkg fallback: replace binary inline and restart
 	if err := u.replaceBinary(tempPath); err != nil {
+		if isCodeSignatureErr(err) {
+			logCodeSignatureRejection(version, err)
+			return err
+		}
 		// Catch TOCTOU race: pre-flight passed but FS became read-only before write
 		if isReadOnlyErr(err) {
 			return fmt.Errorf("%w: %v", ErrReadOnlyFS, err)
@@ -1489,8 +1538,52 @@ func (u *Updater) backupCurrentBinary() error {
 	return os.Chmod(u.config.BackupPath, info.Mode())
 }
 
-// replaceBinary replaces the current binary with a new one
+// verifyStagedBinarySignature checks that a binary staged for installation
+// carries a code signature the OS will accept. macOS is the only platform where
+// the agent's code identity — and therefore every TCC grant keyed to it —
+// depends on that signature, so it is a no-op elsewhere.
+//
+// It is a package variable so tests can drive replaceBinary's rejection path on
+// any platform, and so the existing replaceBinary tests can use plain-text
+// stand-in "binaries" (not Mach-O, so the real check would always reject them).
+// Matches the seam style already used in this package
+// (missingSigningKeyIDWarner, unusableTrustSetLogger).
+var verifyStagedBinarySignature = defaultStagedSignatureCheck
+
+// defaultStagedSignatureCheck runs `codesign --verify` on macOS.
+//
+// Release binaries are Apple Developer ID signed, notarized, and
+// codesign-verified by the release workflow before upload, and locally built
+// darwin/arm64 binaries carry the Go linker's own signature, so this passes for
+// every artifact the updater is expected to install. A failure means the staged
+// artifact is genuinely unsigned or its signature is broken.
+func defaultStagedSignatureCheck(path string) error {
+	if runtime.GOOS != "darwin" {
+		return nil
+	}
+	out, err := exec.Command("codesign", "--verify", "--verbose", path).CombinedOutput()
+	if err == nil {
+		return nil
+	}
+	detail := strings.TrimSpace(string(out))
+	if detail == "" {
+		detail = err.Error()
+	}
+	return fmt.Errorf("%w: %s", ErrCodeSignatureInvalid, detail)
+}
+
+// replaceBinary replaces the current binary with a new one.
+//
+// On macOS the incoming binary's code signature is verified BEFORE anything is
+// written, so a rejected update leaves the installed binary completely
+// untouched — there is nothing to roll back, and the agent keeps running the
+// identity its TCC grants are keyed to. See ErrCodeSignatureInvalid for why the
+// old ad-hoc re-sign fallback was removed (#3458).
 func (u *Updater) replaceBinary(newPath string) error {
+	if err := verifyStagedBinarySignature(newPath); err != nil {
+		return err
+	}
+
 	// On Unix, we can rename over the existing file
 	// On Windows, we need to rename the existing file first
 	if runtime.GOOS == "windows" {
@@ -1530,20 +1623,6 @@ func (u *Updater) replaceBinary(newPath string) error {
 	if runtime.GOOS != "windows" {
 		if err := os.Chmod(u.config.BinaryPath, 0755); err != nil {
 			return err
-		}
-	}
-
-	// macOS: only ad-hoc sign if the binary isn't already properly signed.
-	// Release binaries are Apple Developer ID signed — re-signing with adhoc
-	// destroys the signature, which invalidates TCC permission grants.
-	if runtime.GOOS == "darwin" {
-		verifyCmd := exec.Command("codesign", "--verify", "--verbose", u.config.BinaryPath)
-		if err := verifyCmd.Run(); err != nil {
-			// Not signed or signature invalid — apply adhoc signature so macOS allows execution
-			cmd := exec.Command("codesign", "--force", "--sign", "-", u.config.BinaryPath)
-			if err := cmd.Run(); err != nil {
-				log.Warn("ad-hoc codesign failed, binary may not launch", "error", err.Error())
-			}
 		}
 	}
 
@@ -1638,6 +1717,10 @@ func (u *Updater) UpdateFromURL(rawURL, expectedChecksum string, opts UpdateOpti
 	// 5. Non-Windows: replace binary inline and restart
 	defer removeCleanup(tempPath)
 	if err := u.replaceBinary(tempPath); err != nil {
+		if isCodeSignatureErr(err) {
+			logCodeSignatureRejection("", err)
+			return err
+		}
 		if isReadOnlyErr(err) {
 			return fmt.Errorf("%w: %v", ErrReadOnlyFS, err)
 		}

--- a/agent/internal/updater/updater_test.go
+++ b/agent/internal/updater/updater_test.go
@@ -343,6 +343,11 @@ func TestBackupCurrentBinary(t *testing.T) {
 }
 
 func TestReplaceBinary(t *testing.T) {
+	// These tests use plain-text stand-in "binaries", which are not Mach-O and
+	// would always fail the real macOS code-signature gate added in #3458. The
+	// gate has its own coverage in replace_binary_signature_test.go.
+	stubStagedSignatureCheck(t, func(string) error { return nil })
+
 	tmpDir := t.TempDir()
 	binaryPath := filepath.Join(tmpDir, "breeze-agent")
 	newBinaryPath := filepath.Join(tmpDir, "new-binary")
@@ -842,6 +847,7 @@ func TestEndToEndUpdateWithoutRestart(t *testing.T) {
 		t.Fatalf("backup: %v", err)
 	}
 
+	stubStagedSignatureCheck(t, func(string) error { return nil })
 	if err := u.replaceBinary(tempPath); err != nil {
 		t.Fatalf("replace: %v", err)
 	}

--- a/agent/internal/updater/updater_unix_test.go
+++ b/agent/internal/updater/updater_unix_test.go
@@ -52,6 +52,11 @@ func TestRollback_UnlinksBeforeWrite(t *testing.T) {
 }
 
 func TestReplaceBinary_UnlinksBeforeWrite(t *testing.T) {
+	// These tests use plain-text stand-in "binaries", which are not Mach-O and
+	// would always fail the real macOS code-signature gate added in #3458. The
+	// gate has its own coverage in replace_binary_signature_test.go.
+	stubStagedSignatureCheck(t, func(string) error { return nil })
+
 	tmpDir := t.TempDir()
 	binaryPath := filepath.Join(tmpDir, "breeze-agent")
 	newBinaryPath := filepath.Join(tmpDir, "new-binary")

--- a/apps/docs/src/content/docs/agents/installation.mdx
+++ b/apps/docs/src/content/docs/agents/installation.mdx
@@ -182,12 +182,13 @@ Pre-provisioned devices land in `status: 'pending'` and stay there until the age
 
 ## What Gets Installed
 
-All platform installers (MSI, PKG, and manual service install) include two components:
+All platform installers (MSI, PKG, and manual service install) include these components:
 
 | Component | Description |
 |-----------|-------------|
 | **Breeze Agent** | The main service that communicates with the Breeze server, runs commands, and reports device status. |
 | **Watchdog** | A companion service that monitors the agent and automatically restarts it after crashes or hangs. |
+| **Desktop helper** (macOS) | A per-user helper that runs in the logged-in user's session so features like screen sharing work. Installed at `/usr/local/bin/breeze-desktop-helper`. |
 
 The watchdog runs alongside the agent as a separate process. You do not need to configure it -- it starts automatically with the agent service. See the [Watchdog documentation](/features/watchdog) for details.
 
@@ -205,6 +206,8 @@ When running `breeze-agent service install` manually, the agent fetches the matc
     ```
   </TabItem>
 </Tabs>
+
+On macOS the desktop helper is resolved the same way: `breeze-agent service install` uses a `breeze-desktop-helper` binary staged next to the agent if there is one, and otherwise downloads the matching-version signed binary from GitHub releases. If neither is available (for example on an air-gapped host), the install prints a warning and continues -- the agent service is still installed and running, and only the helper's features are unavailable until you place the binary next to `breeze-agent` and re-run `service install`. The agent binary is never installed under the helper's name: doing so would give the helper the agent's code-signing identity, and macOS would drop the Screen Recording and Accessibility grants once a real helper replaced it. The macOS `.pkg` always ships the signed helper, so this only affects raw-binary installs.
 
 If a previously agent-only install needs the watchdog added, re-run `breeze-agent service install`. This reinstalls the agent binary and restarts the agent service (safe for upgrades) and registers the missing watchdog. To add *only* the watchdog without touching the agent service, run `breeze-watchdog service install` directly.
 


### PR DESCRIPTION
Both issues are the same class of bug: a macOS path that silently changes a binary's code-signing identity, which invalidates the TCC grants (Screen Recording, Accessibility, Full Disk Access) keyed to the previous identity and re-prompts the user. Fixed together because the reasoning, the tests and the "never manufacture a signature at install time" rule are shared.

## #3458 — updater ad-hoc re-sign fallback

`updater.replaceBinary` ad-hoc signed (`codesign --force --sign -`) on **any** `codesign --verify` failure, *after* it had already put the new binary live. An ad-hoc signature's designated requirement is the per-build code-directory hash, so every update through that path gave the agent a brand-new code identity.

Verified against the release pipeline: `release.yml` Developer ID signs, notarizes **and** `codesign --verify`s the raw darwin binary before upload (and hard-fails a tag release when `ENABLE_MACOS_SIGNING` is unset), so the fallback was never rescuing a legitimate artifact — it was converting "this artifact is broken" into "the agent's permissions silently reset".

**Now:** the signature is verified **before anything is written**, so a rejected update leaves the installed binary completely untouched — there is nothing to roll back and the agent keeps running the build its grants are keyed to. The refusal surfaces as a new `updater.ErrCodeSignatureInvalid` sentinel, which `heartbeat.doUpgrade` classifies alongside the existing ones: it logs an actionable error and starts a **30-minute per-version cooldown**, mirroring the `ErrUntrustedRelease` policy added in #3544, so one bad artifact cannot make every macOS device re-download it every ~60s.

## #3457 — install-service substituting the agent binary for the helper

macOS `service install` copied the **agent binary** to `/usr/local/bin/breeze-desktop-helper` when no real helper was staged next to it. argv[0] dispatch made it *run*, but the installed "helper" carried the agent's signing identifier and designated requirement, so grants made against it stopped matching the moment a real helper arrived via `.pkg` or update.

Hard-failing was not an option: the fallback is load-bearing for two **documented** raw-binary lanes (`agents/installation.mdx` quick-start and the MDM / golden-image flow in `advanced-install.mdx`), and failing there aborts `service install` before the LaunchDaemon is even loaded.

**Now:** helper staging resolves a *genuine* helper — the sibling binary first, otherwise the matching-version, checksum-verified signed asset from the GitHub release. The release already publishes `breeze-desktop-helper-darwin-{amd64,arm64}` (signed + notarized in the same darwin loop as the agent) and lists it in `checksums.txt`, so this consumes an asset that already exists. It never substitutes the agent binary. A failure is a **warning, not fatal** — same policy as `bootstrapWatchdog` — so an offline or air-gapped raw-binary install still gets a working agent service, with an actionable message explaining what is degraded and why the agent binary is not used.

The shared release-asset download primitives were renamed off "watchdog" (`downloadReleaseAsset`, `fetchReleaseAssetChecksum`, `releaseChecksumsURL`, `releasesBase`) since the helper bootstrap now consumes them too, and the dev-build check was extracted as `isDevBuildVersion`.

## Dev lane (found while checking nothing legitimately relied on the fallback)

`make dev-push`'s `ifeq ($(TARGET_GOOS),darwin)` guard was **dead**: `TARGET_GOOS` is assigned by `$(eval)` at recipe-execution time while `ifeq` is evaluated at parse time, so dev pushes were **never** codesigned — even with `CODESIGN_IDENTITY` set, which is exactly the documented knob for keeping TCC grants across pushes. Moved to a shell conditional, and darwin dev pushes are now always signed (ad-hoc when no identity is configured). That is the right layer for manufacturing a signature: the build, not the updater. Without it, a cross-compiled `darwin/amd64` dev push would be unsigned and the new gate would refuse it. The same dead guard is fixed in `dev-push-watchdog`.

Verified end to end: an unsigned `darwin/amd64` Go build fails `codesign --verify`; after `codesign --force --sign -` it passes. (Also verified that `darwin/arm64` Go builds already carry the linker's own signature and pass, so same-arch dev pushes were never relying on the updater's fallback.)

## Tests

- `agent/internal/updater/replace_binary_signature_test.go` — table-driven: valid signature installs, invalid signature refuses **and leaves the installed binary byte-identical**, wrapped errors still refused, the gate inspects the *staged* path (not the installed one), plus a guard that `--force --sign -` never comes back.
- `agent/internal/updater/replace_binary_signature_darwin_test.go` (`//go:build darwin`) — platform truth against the real `codesign --verify`: an ad-hoc-signed Mach-O is accepted, an unsigned file and a missing file are rejected, and the full `replaceBinary` path keeps the installed binary.
- `agent/internal/heartbeat/code_signature_backoff_test.go` — cooldown policy (suppresses 60 heartbeats to 1 attempt, new target not throttled, expires, independent of the untrusted-release cooldown, race-safe) and sentinel classification against every neighbouring updater error.
- `agent/internal/agentapp/desktop_helper_bootstrap_test.go` — sibling preferred (and no network touched), download path, and a failure table (dev build, 404, error page, checksum mismatch, unreadable sibling) where **every case asserts the agent binary was not installed as the helper**. Plus a structural guard on the darwin-only install command, which a linux CI runner cannot reach behaviourally.

Every new assertion was mutation-checked: reinstating the pre-fix behaviour turns them red.

**Verification run:** `go test -race` green on `internal/updater`, `internal/agentapp`, `internal/heartbeat` on darwin/arm64, and `CGO_ENABLED=0 go test` green on the same three packages under `golang:1.26.6` on linux (matching the `test-agent` job). `go vet` clean on darwin and linux for all three packages. `gofmt` clean on every touched file.

## Docs

`apps/docs/.../agents/installation.mdx` now lists the desktop helper in "What Gets Installed" and documents how it is resolved on a manual `service install`, including the offline behaviour and why the agent binary is never used in its place.

## Not done here

No new WS message type for update failures — the agent's `update_status` message is start-only with no failure field, and adding one touches the agent WS protocol and the API. The refusal is loud in the agent log with an explicit remedy, and the device simply stays on its previous version. Worth a follow-up if operators need it in the dashboard.

Closes #3458
Closes #3457

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBxF7C8E5GxFnNcGf6kBVP