### PR TITLE
test(api): contract-test FK ON DELETE actions against org erasure (#4519)

### DIFF
--- a/apps/api/src/__tests__/integration/orgCascadeFkOnDelete.integration.test.ts
+++ b/apps/api/src/__tests__/integration/orgCascadeFkOnDelete.integration.test.ts
@@ -293,16 +293,30 @@ describe('org-erasure FK ON DELETE contract', () => {
     ).toEqual([]);
   });
 
-  it('every pre-cleared entry names a table with an ASSOCIATED_SYSTEM_SCOPED_TABLES pre-clear', () => {
-    const misfiled = ORG_CASCADE_FK_PRE_CLEARED.filter(
+  it('the two ledger lists agree with ASSOCIATED_SYSTEM_SCOPED_TABLES on which is which', () => {
+    // Both directions, so the lists stay mutually exclusive and each one keeps
+    // meaning what its name says. Without the second half, adding a pre-clear
+    // for a table would leave its FKs sitting in the DEBT list forever, and the
+    // burn-down test would not notice: they are still NO ACTION edges into the
+    // cascade set, so they still look "unresolved".
+    const misfiledAsPreCleared = ORG_CASCADE_FK_PRE_CLEARED.filter(
       (ref) => !preClearedTables.has(ref.childTable),
     );
-
     expect(
-      misfiled.map(refKey).sort(),
+      misfiledAsPreCleared.map(refKey).sort(),
       'ORG_CASCADE_FK_PRE_CLEARED claims these FKs are handled by a step-1b pre-clear, but '
       + 'their table is not in ASSOCIATED_SYSTEM_SCOPED_TABLES (services/tenantCascade.ts). '
       + 'Either add the pre-clear, or move the entry to ORG_CASCADE_FK_KNOWN_UNSAFE.',
+    ).toEqual([]);
+
+    const misfiledAsDebt = ORG_CASCADE_FK_KNOWN_UNSAFE.filter(
+      (ref) => preClearedTables.has(ref.childTable),
+    );
+    expect(
+      misfiledAsDebt.map(refKey).sort(),
+      'These FKs are logged as debt in ORG_CASCADE_FK_KNOWN_UNSAFE, but their table now has '
+      + 'an ASSOCIATED_SYSTEM_SCOPED_TABLES pre-clear. Check that the pre-clear\'s clearSql '
+      + 'actually reaches these rows, then move the entries to ORG_CASCADE_FK_PRE_CLEARED.',
     ).toEqual([]);
   });
 

--- a/apps/api/src/__tests__/integration/orgCascadeFkOnDelete.integration.test.ts
+++ b/apps/api/src/__tests__/integration/orgCascadeFkOnDelete.integration.test.ts
@@ -3,8 +3,9 @@ import { sql } from 'drizzle-orm';
 import { db } from '../../db';
 import { getOrgCascadeDeleteOrder, __testOnly } from '../../services/tenantCascade';
 import {
-  ORG_CASCADE_FK_KNOWN_UNSAFE,
+  ORG_CASCADE_FK_UNSAFE,
   ORG_CASCADE_FK_PRE_CLEARED,
+  type OrgCascadeFkReason,
   type OrgCascadeFkRef,
 } from './orgCascadeFkOnDeleteAllowlist';
 
@@ -13,57 +14,92 @@ import {
  *
  * WHAT BREAKS WITHOUT THIS
  *
- * `cascadeDeleteOrg()` erases a tenant by running a plain
- * `DELETE FROM <t> WHERE org_id = $1` over every table in
- * `getOrgCascadeDeleteOrder()`, ordered children-before-parents by
- * `topologicalCascadeOrder()`'s live `pg_constraint` read. Each table's DELETE
- * is its own statement in its own system context -- the cascade is NOT one big
- * deferred transaction -- so Postgres checks every referencing FK as that
- * statement runs.
+ * `cascadeDeleteOrg()` erases a tenant with a sequence of ordinary DELETE
+ * statements, each in its own system context -- it is NOT one big deferred
+ * transaction, so Postgres checks every referencing FK as each statement runs:
  *
- * A foreign key POINTING AT a cascade table is therefore only safe if one of
- * these holds:
+ *   step 1b  each `ASSOCIATED_SYSTEM_SCOPED_TABLES` entry, in array order,
+ *            with its own hand-written WHERE join;
+ *   step 2   every table in `getOrgCascadeDeleteOrder()`, ordered
+ *            children-before-parents by `topologicalCascadeOrder()`'s live
+ *            `pg_constraint` read, as `DELETE ... WHERE org_id = $1`
+ *            (`organizations` itself is keyed on `id`).
  *
- *   a) it declares `ON DELETE CASCADE` or `ON DELETE SET NULL`, so Postgres
- *      clears the child itself;
- *   b) the referencing table is ALSO in `getOrgCascadeDeleteOrder()`, so the
- *      topological walk empties it first;
- *   c) the referencing table is emptied by an
- *      `ASSOCIATED_SYSTEM_SCOPED_TABLES` pre-clear (step 1b of
- *      `cascadeDeleteOrg`), which runs ahead of the whole walk;
- *   d) it is self-referential -- one statement removes the org's whole row set
- *      and NO ACTION is checked at end-of-statement. (RESTRICT is checked per
- *      row and would NOT be safe here; the test rejects it.)
+ * A foreign key pointing at any table those statements touch is a latent
+ * erasure failure unless something clears the referencing rows first. Erasure
+ * then works right up until a customer creates the first row in the
+ * referencing table, and after that aborts mid-way and leaves the tenant
+ * half-deleted. That is exactly how #4100 shipped
+ * (`webhook_deliveries.webhook_id -> webhooks.id`, fixed in #4412), and the
+ * sweep on that PR found ~73 more edges with the same shape. Nothing guarded
+ * it: `tenantCascade.integration.test.ts` checks list membership and
+ * topological ordering *within* the cascade set, but never looks at inbound
+ * edges from outside it or at `confdeltype` at all; neither does the RLS
+ * coverage contract or the export-policy roundtrip.
  *
- * Anything else is a latent `23503 foreign_key_violation`: erasure works right
- * up until a customer creates the first row in the child table, then aborts
- * mid-way and leaves the tenant half-deleted. That is exactly how #4100
- * shipped (`webhook_deliveries.webhook_id -> webhooks.id`, fixed in #4412) --
- * and the sweep on that PR found ~73 more edges with the same shape. Nothing
- * in `tenantCascade.integration.test.ts` (which only checks LIST membership),
- * the RLS coverage contract, or the export-policy roundtrip looks at
- * `confdeltype` at all.
+ * THE SAFETY MODEL
  *
- * WHAT THIS TEST DOES NOT PROVE
+ * `protectedTables` is every table erasure deletes rows from: the cascade set,
+ * the step-1b pre-clear targets, and -- transitively -- everything reachable
+ * from those by an `ON DELETE CASCADE` edge, since a cascading delete makes
+ * that table's own inbound FKs get checked too.
  *
- * It is a catalog contract, not a data one. Two gaps, deliberately:
+ * For an edge `child -> parent` with `parent` in that set, `classifyEdge()`
+ * calls it safe when:
  *
- *   - A CROSS-TENANT row (org B's child row pointing at org A's parent row)
- *     still breaks erasure even under (b), because `DELETE ... WHERE org_id =
- *     $1` only removes org A's children. Detecting that needs data; RLS is
- *     what is supposed to make it impossible.
- *   - Under (c) it checks that the pre-clear table is registered and that the
- *     specific FK is pinned in `ORG_CASCADE_FK_PRE_CLEARED` -- it cannot read
- *     the hand-written `clearSql` and confirm the join actually reaches those
- *     rows. Pinning per FK (rather than per table) is what forces a human to
- *     go look when a new FK lands on one of those tables.
+ *   a) the action is `CASCADE` -- Postgres removes the child rows, and the
+ *      child is itself in `protectedTables` by the closure above, so its own
+ *      inbound edges are audited on their own;
+ *   b) the action is `SET NULL` AND every column Postgres would actually null
+ *      (`confdelsetcols`, else the whole `conkey`) is nullable. A `SET NULL`
+ *      onto a NOT NULL column is accepted at DDL time and fails at delete time
+ *      with 23502 -- `action_intents -> tickets` does exactly this today;
+ *   c) the child is a step-1b pre-clear target and that pre-clear runs before
+ *      the parent's DELETE -- always true when the parent is only in the
+ *      cascade set, and otherwise decided by array order;
+ *   d) both ends are in the cascade set, so `topologicalCascadeOrder()` puts
+ *      the child first;
+ *   e) the edge is self-referential AND the table's `org_id` is NOT NULL.
+ *
+ * (e) is the subtle one. A self-reference is normally safe because one
+ * statement removes the org's whole row set and NO ACTION is checked at
+ * end-of-statement -- and, verified empirically against Postgres 16, RESTRICT
+ * behaves the same way here: it is an AFTER-ROW trigger, not a per-row
+ * immediate check, so it too tolerates a row set closed under the FK. What
+ * actually matters is that closure. A nullable `org_id` breaks it: under the
+ * partner-wide config shape (epic #2135) `WHERE org_id = $1` leaves the
+ * partner-owned rows behind, and a surviving row pointing at a deleted one
+ * raises 23503 regardless of the action. `script_categories` is in exactly
+ * that state today.
+ *
+ * WHAT THIS DOES NOT PROVE
+ *
+ * It is a catalog contract, not a data one:
+ *
+ *   - a CROSS-TENANT row (org B's child pointing at org A's parent) still
+ *     breaks erasure under (c) and (d), because those DELETEs only remove org
+ *     A's rows. Detecting it needs data; RLS is what is supposed to make it
+ *     impossible. Two pre-clear entries carry notes where the pre-clear's join
+ *     column differs from the FK's, which is where that assumption is loadest;
+ *   - under (c) it cannot read the hand-written `clearSql` to confirm the join
+ *     reaches the rows a given FK pins. Pinning per FK rather than per table is
+ *     what forces a human to go look when a new FK lands on such a table.
+ *
+ * WHY IT LIVES HERE
+ *
+ * Under `src/__tests__/integration/`, so the shared glob in
+ * `vitest.integration.config.ts` carries it into the blocking Integration
+ * Tests shard with no CI wiring of its own to fall out of date. That does mean
+ * it inherits setup.ts's per-test TRUNCATE CASCADE, which a read-only catalog
+ * read has no use for; the alternative (the dedicated-runner pattern
+ * `rls-coverage.integration.test.ts` uses, which needs its own config plus a
+ * hand-maintained CI step) was weighed and rejected -- measured overhead here
+ * is well under a second per test against a 25-minute shard budget.
  *
  * Scope is the ORG cascade. The device cascade
  * (`CORE_DEVICE_CASCADE_DELETE_TABLES`) and the partner purge are separate
- * contracts.
- *
- * The seeded debt lives in `orgCascadeFkOnDeleteAllowlist.ts`; read its header
- * before adding a line to it.
+ * contracts. The seeded ledger lives in `orgCascadeFkOnDeleteAllowlist.ts`;
+ * read its header before adding a line.
  */
 
 /** `pg_constraint.confdeltype` codes. */
@@ -75,16 +111,6 @@ const DELETE_ACTION_LABELS: Record<string, string> = {
   d: 'SET DEFAULT',
 };
 
-/**
- * Actions under which Postgres clears the reference for us.
- *
- * SET DEFAULT ('d') is NOT here on purpose: it is only safe when the column
- * default is NULL, which would take another catalog read to know, and no FK in
- * this schema uses it. If one ever appears it should land in the ledger with a
- * note rather than be waved through.
- */
-const SELF_CLEARING_DELETE_ACTIONS = new Set(['c', 'n']);
-
 interface FkRow {
   // postgres-js does not camel-case aliases.
   constraint_name: string;
@@ -92,35 +118,47 @@ interface FkRow {
   parent_table: string;
   delete_action: string;
   child_columns: string[];
-  any_not_null: boolean;
+  /** Every referencing column is nullable, so a plain SET NULL would be legal. */
+  all_columns_nullable: boolean;
+  /** Every column SET NULL would actually null (confdelsetcols, else conkey) is nullable. */
+  nulled_columns_nullable: boolean;
 }
 
 /**
  * Every foreign key in `public`, with both ends normalised to their partition
  * ROOT.
  *
- * `conparentid = 0` drops the per-partition copies Postgres clones onto each
- * partition, and `pg_partition_root` folds a constraint declared directly on a
- * partition back onto the root name. Both matter for `metric_rollups`, which
- * is in the cascade list and gains a fresh monthly partition: without this the
- * ledger would need a new line every month and would spontaneously redden CI
- * when one appeared.
+ * `conparentid = 0` drops the per-partition constraint copies Postgres clones
+ * onto each partition; without it `metric_rollups` -- which is in the cascade
+ * list and gains a partition every month -- would need a fresh ledger line
+ * monthly and would spontaneously redden CI when one appeared. The
+ * `pg_partition_root` folding covers the remaining case of a constraint
+ * declared directly ON a partition, which a separate test asserts does not
+ * exist (see that test for why folding alone would not be enough).
+ *
+ * Namespaces are checked on both the physical relations and their roots, so a
+ * partition rooted outside `public` can neither slip in nor be attributed to a
+ * `public` table by name.
  */
 async function readForeignKeys(): Promise<FkRow[]> {
   return (await db.execute(sql`
     SELECT
-      c.conname          AS constraint_name,
-      child_root.relname AS child_table,
+      c.conname           AS constraint_name,
+      child_root.relname  AS child_table,
       parent_root.relname AS parent_table,
-      c.confdeltype      AS delete_action,
+      c.confdeltype       AS delete_action,
       (SELECT array_agg(a.attname ORDER BY k.ord)
          FROM unnest(c.conkey) WITH ORDINALITY AS k(attnum, ord)
          JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = k.attnum)
-                         AS child_columns,
-      (SELECT bool_or(a.attnotnull)
+                          AS child_columns,
+      (SELECT bool_and(NOT a.attnotnull)
          FROM unnest(c.conkey) AS k(attnum)
          JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = k.attnum)
-                         AS any_not_null
+                          AS all_columns_nullable,
+      (SELECT bool_and(NOT a.attnotnull)
+         FROM unnest(COALESCE(c.confdelsetcols, c.conkey)) AS k(attnum)
+         JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = k.attnum)
+                          AS nulled_columns_nullable
     FROM pg_constraint c
     JOIN pg_class child ON child.oid = c.conrelid
     JOIN pg_class parent ON parent.oid = c.confrelid
@@ -130,199 +168,277 @@ async function readForeignKeys(): Promise<FkRow[]> {
       ON parent_root.oid = COALESCE(pg_partition_root(c.confrelid), c.confrelid)
     JOIN pg_namespace child_ns ON child_ns.oid = child.relnamespace
     JOIN pg_namespace parent_ns ON parent_ns.oid = parent.relnamespace
+    JOIN pg_namespace child_root_ns ON child_root_ns.oid = child_root.relnamespace
+    JOIN pg_namespace parent_root_ns ON parent_root_ns.oid = parent_root.relnamespace
     WHERE c.contype = 'f'
+      AND c.conparentid = 0
       AND child_ns.nspname = 'public'
       AND parent_ns.nspname = 'public'
-      AND c.conparentid = 0
+      AND child_root_ns.nspname = 'public'
+      AND parent_root_ns.nspname = 'public'
   `)) as unknown as FkRow[];
 }
 
+/** Public tables that have an `org_id` column, and whether it is NOT NULL. */
+async function readOrgIdNotNull(): Promise<Map<string, boolean>> {
+  const rows = (await db.execute(sql`
+    SELECT t.relname AS table_name, a.attnotnull AS not_null
+    FROM pg_class t
+    JOIN pg_namespace n ON n.oid = t.relnamespace
+    JOIN pg_attribute a ON a.attrelid = t.oid AND a.attname = 'org_id' AND a.attnum > 0
+    WHERE n.nspname = 'public' AND t.relkind IN ('r', 'p') AND NOT a.attisdropped
+  `)) as unknown as Array<{ table_name: string; not_null: boolean }>;
+  return new Map(rows.map((row) => [row.table_name, row.not_null]));
+}
+
 const cascadeTables = new Set(getOrgCascadeDeleteOrder());
-const preClearedTables = new Set(
-  __testOnly.ASSOCIATED_SYSTEM_SCOPED_TABLES.map((entry) => entry.table),
+/** Pre-clear table -> its index in ASSOCIATED_SYSTEM_SCOPED_TABLES (the run order). */
+const preClearOrder = new Map(
+  __testOnly.ASSOCIATED_SYSTEM_SCOPED_TABLES.map((entry, index) => [entry.table, index]),
 );
+
+/**
+ * Every table erasure removes rows from, including everything an
+ * `ON DELETE CASCADE` reaches transitively. A cascading delete triggers the
+ * FK checks on the table it reaches, so those tables need auditing as parents
+ * too -- otherwise an un-cleared grandchild aborts the original DELETE.
+ */
+function protectedTables(rows: FkRow[]): Set<string> {
+  const reached = new Set<string>([...cascadeTables, ...preClearOrder.keys()]);
+  for (let changed = true; changed;) {
+    changed = false;
+    for (const row of rows) {
+      if (row.delete_action === 'c' && reached.has(row.parent_table) && !reached.has(row.child_table)) {
+        reached.add(row.child_table);
+        changed = true;
+      }
+    }
+  }
+  return reached;
+}
+
+/**
+ * `null` when erasure handles the edge; otherwise the reason it must be
+ * pinned. See the header for the argument behind each branch.
+ */
+function classifyEdge(
+  row: FkRow,
+  reached: Set<string>,
+  orgIdNotNull: Map<string, boolean>,
+): OrgCascadeFkReason | null {
+  if (!reached.has(row.parent_table)) return null;
+
+  if (row.child_table === row.parent_table) {
+    if (row.delete_action === 'c' || row.delete_action === 'n') return null;
+    return orgIdNotNull.get(row.child_table) === true ? null : 'self-ref-open-row-set';
+  }
+  if (row.delete_action === 'n') {
+    return row.nulled_columns_nullable ? null : 'set-null-onto-not-null';
+  }
+  if (row.delete_action === 'c') return null;
+  if (row.delete_action === 'd') return 'set-default';
+
+  // NO ACTION / RESTRICT: someone else has to empty the child first.
+  const childStep = preClearOrder.get(row.child_table);
+  const parentStep = preClearOrder.get(row.parent_table);
+  if (childStep !== undefined) {
+    // Every pre-clear runs ahead of the whole cascade walk, so a parent that is
+    // only in the cascade set is always later than this child.
+    if (parentStep === undefined || childStep < parentStep) return 'pre-cleared';
+    return 'child-deleted-after-parent';
+  }
+  if (cascadeTables.has(row.child_table)) {
+    // Both in the cascade set -> topologicalCascadeOrder puts the child first.
+    // Otherwise the parent is emptied outside the walk (a pre-clear, or as the
+    // far end of an ON DELETE CASCADE) while the child waits for it.
+    return cascadeTables.has(row.parent_table) ? null : 'child-deleted-after-parent';
+  }
+  return 'child-not-deleted';
+}
 
 const refKey = (ref: Pick<OrgCascadeFkRef, 'childTable' | 'constraint'>) =>
   `${ref.childTable}.${ref.constraint}`;
 const rowKey = (row: FkRow) => `${row.child_table}.${row.constraint_name}`;
 
-const describeRow = (row: FkRow) =>
+const describeRow = (row: FkRow, reason: OrgCascadeFkReason) =>
   `${row.child_table}(${row.child_columns.join(', ')}) -> ${row.parent_table} `
   + `[${row.constraint_name}, ON DELETE ${DELETE_ACTION_LABELS[row.delete_action] ?? row.delete_action}`
-  + `${row.any_not_null ? ', NOT NULL' : ''}]`;
+  + `, ${reason}]`;
 
-/**
- * Edges that need an explicit answer: they point INTO the cascade set, are not
- * self-referential, Postgres will not clear them, and the referencing table is
- * not emptied by the cascade walk itself.
- */
-function unresolvedEdges(rows: FkRow[]): FkRow[] {
-  return rows.filter(
-    (row) =>
-      cascadeTables.has(row.parent_table)
-      && row.child_table !== row.parent_table
-      && !SELF_CLEARING_DELETE_ACTIONS.has(row.delete_action)
-      && !cascadeTables.has(row.child_table),
-  );
+const compareRefs = (a: string[], b: string[]) =>
+  a[0]!.localeCompare(b[0]!) || a[1]!.localeCompare(b[1]!) || a[2]!.localeCompare(b[2]!);
+
+/** Every edge erasure does NOT handle, keyed for lookup. */
+async function classifyAll(): Promise<Map<string, { row: FkRow; reason: OrgCascadeFkReason }>> {
+  const [rows, orgIdNotNull] = await Promise.all([readForeignKeys(), readOrgIdNotNull()]);
+  const reached = protectedTables(rows);
+  const out = new Map<string, { row: FkRow; reason: OrgCascadeFkReason }>();
+  for (const row of rows) {
+    const reason = classifyEdge(row, reached, orgIdNotNull);
+    if (reason !== null) out.set(rowKey(row), { row, reason });
+  }
+  return out;
 }
 
 describe('org-erasure FK ON DELETE contract', () => {
-  it('reads a live, non-trivial FK graph (guards against a vacuously green run)', async () => {
-    const rows = await readForeignKeys();
+  it('reads a live FK graph in which every classifier branch is exercised', async () => {
+    const [rows, orgIdNotNull] = await Promise.all([readForeignKeys(), readOrgIdNotNull()]);
+    const reached = protectedTables(rows);
 
-    // A catalog query that quietly returns nothing would make every other
-    // assertion in this file pass while proving nothing at all.
+    // A catalog query that quietly returned nothing, or a cascade list that
+    // failed to load, would make every other assertion in this file pass while
+    // proving nothing at all.
     expect(rows.length).toBeGreaterThan(500);
     expect(cascadeTables.size).toBeGreaterThan(100);
-    expect(preClearedTables.size).toBeGreaterThan(0);
+    expect(preClearOrder.size).toBeGreaterThan(0);
+    expect(orgIdNotNull.size).toBeGreaterThan(100);
+    expect(reached.size).toBeGreaterThan(cascadeTables.size);
 
-    const intoCascade = rows.filter((row) => cascadeTables.has(row.parent_table));
-    expect(intoCascade.length).toBeGreaterThan(100);
-    // Every branch the classifier discriminates on must actually be present,
-    // or a broken classifier would still read green.
-    expect(intoCascade.some((row) => row.delete_action === 'c')).toBe(true);
-    expect(intoCascade.some((row) => row.delete_action === 'n')).toBe(true);
-    expect(intoCascade.some((row) => row.delete_action === 'a')).toBe(true);
+    // Each input the classifier discriminates on must actually occur, or a
+    // branch could be broken (or dead) and still read green.
+    const inbound = rows.filter((row) => reached.has(row.parent_table));
+    for (const [label, present] of [
+      ['inbound edges', inbound.length > 100],
+      ['ON DELETE CASCADE', inbound.some((row) => row.delete_action === 'c')],
+      ['ON DELETE SET NULL', inbound.some((row) => row.delete_action === 'n')],
+      ['ON DELETE NO ACTION', inbound.some((row) => row.delete_action === 'a')],
+      ['ON DELETE RESTRICT', inbound.some((row) => row.delete_action === 'r')],
+      ['self-referential', inbound.some((row) => row.child_table === row.parent_table)],
+      ['child inside the cascade set', inbound.some((row) => cascadeTables.has(row.child_table))],
+      ['child with a pre-clear', inbound.some((row) => preClearOrder.has(row.child_table))],
+      ['composite (multi-column)', inbound.some((row) => row.child_columns.length > 1)],
+    ] as const) {
+      expect(present, `no inbound FK of kind "${label}" in the catalog`).toBe(true);
+    }
 
-    // The ledger is keyed on (table, constraint name) pairs, so prove that
-    // shape resolves against the real catalog for at least one known FK.
+    // The ledger keys on (table, constraint name); prove that shape resolves.
     expect(new Set(rows.map(rowKey)).has('sessions.sessions_user_id_users_id_fk')).toBe(true);
   });
 
-  it('every FK into an org-cascade table is FK-safe, pre-cleared, or in the ledger', async () => {
-    const rows = await readForeignKeys();
+  it('has no FK constraint declared directly on a partition', async () => {
+    // Such a constraint would survive the `conparentid = 0` filter and then be
+    // folded onto its root's name, where it could both collide with the root's
+    // own constraint name (making the ledger key ambiguous) and disagree with
+    // production: `topologicalCascadeOrder()` reads raw `relname`s, so it would
+    // never see the edge at all. There are none today; assert it stays that way
+    // rather than modelling a case that does not exist.
+    const rows = (await db.execute(sql`
+      SELECT c.conname, t.relname AS partition_name
+      FROM pg_constraint c
+      JOIN pg_class t ON t.oid = c.conrelid
+      JOIN pg_namespace n ON n.oid = t.relnamespace
+      WHERE c.contype = 'f' AND c.conparentid = 0
+        AND t.relispartition AND n.nspname = 'public'
+    `)) as unknown as Array<{ conname: string; partition_name: string }>;
+
+    expect(
+      rows.map((row) => `${row.partition_name}.${row.conname}`).sort(),
+      'Declare the FK on the partitioned PARENT so every partition inherits it, otherwise this '
+      + "contract's partition-root folding and topologicalCascadeOrder() disagree about the edge.",
+    ).toEqual([]);
+  });
+
+  it('every FK erasure does not handle is pinned in the ledger', async () => {
+    const unhandled = await classifyAll();
     const pinned = new Set([
-      ...ORG_CASCADE_FK_KNOWN_UNSAFE.map(refKey),
+      ...ORG_CASCADE_FK_UNSAFE.map(refKey),
       ...ORG_CASCADE_FK_PRE_CLEARED.map(refKey),
     ]);
 
-    const unaccounted = unresolvedEdges(rows).filter((row) => !pinned.has(rowKey(row)));
+    const unaccounted = [...unhandled.values()].filter(({ row }) => !pinned.has(rowKey(row)));
 
     expect(
-      unaccounted.map(describeRow).sort(),
-      'Foreign key(s) reference a table in the org-erasure cascade without an ON DELETE '
-      + 'action, and nothing empties the referencing table first. Each one aborts GDPR org '
-      + 'erasure with 23503 as soon as a customer creates a row in it (that is #4100).\n'
-      + 'Fix forward, in order of preference: (1) give the FK ON DELETE CASCADE / SET NULL in '
-      + 'a NEW idempotent migration; (2) register the child table in '
-      + 'CORE_ORG_CASCADE_DELETE_ORDER plus every other list CLAUDE.md requires; (3) add an '
-      + 'ASSOCIATED_SYSTEM_SCOPED_TABLES pre-clear and pin the FK in '
-      + 'ORG_CASCADE_FK_PRE_CLEARED. Only if none of those fit, add it to '
-      + 'ORG_CASCADE_FK_KNOWN_UNSAFE with a note saying why. See '
-      + 'orgCascadeFkOnDeleteAllowlist.ts.',
+      unaccounted.map(({ row, reason }) => describeRow(row, reason)).sort(),
+      'Foreign key(s) reference a table that GDPR org erasure deletes rows from, and nothing in '
+      + 'the erasure path clears the referencing rows first. Each one aborts erasure part-way '
+      + 'through as soon as a customer creates a row (that is #4100).\n'
+      + 'Fix forward, in order of preference: (1) give the FK ON DELETE CASCADE / SET NULL in a '
+      + 'NEW idempotent migration; (2) register the child table in CORE_ORG_CASCADE_DELETE_ORDER '
+      + 'plus every other list CLAUDE.md requires; (3) add an ASSOCIATED_SYSTEM_SCOPED_TABLES '
+      + 'pre-clear and pin the FK in ORG_CASCADE_FK_PRE_CLEARED. Only if none of those fit, add '
+      + 'it to ORG_CASCADE_FK_UNSAFE. See orgCascadeFkOnDeleteAllowlist.ts.',
     ).toEqual([]);
   });
 
-  it('no self-referential FK on a cascade table uses RESTRICT or SET DEFAULT', async () => {
-    const rows = await readForeignKeys();
+  it('every ledger entry still names a live, still-unhandled FK (burn-down)', async () => {
+    const unhandled = await classifyAll();
 
-    // This closes the one hole exemption (d) opens. A self-referential edge is
-    // waved through on the argument that `DELETE ... WHERE org_id = $1` removes
-    // the org's whole row set in ONE statement, and NO ACTION is checked at
-    // end-of-statement -- by which point both ends are gone.
-    //
-    // That argument is specific to NO ACTION. RESTRICT is checked immediately,
-    // per row, and no amount of deferral rescues it: a parent row referenced by
-    // a sibling row in the same org aborts the DELETE even though the sibling
-    // is going away in that very statement. SET DEFAULT is only safe when the
-    // column default is NULL, which this catalog read does not establish.
-    //
-    // Non-self-referential RESTRICT is NOT flagged here: it is either handled
-    // by unresolvedEdges() above (child outside the cascade set) or genuinely
-    // safe (child inside it, emptied first by its own earlier statement) --
-    // ten such edges exist today, all in the ai_agents / contracts stacks.
-    const offenders = rows.filter(
-      (row) =>
-        cascadeTables.has(row.parent_table)
-        && row.child_table === row.parent_table
-        && (row.delete_action === 'r' || row.delete_action === 'd'),
-    );
-
-    expect(
-      offenders.map(describeRow).sort(),
-      'A self-referential ON DELETE RESTRICT / SET DEFAULT on an org-cascade table aborts '
-      + 'erasure the moment two rows in the same org reference each other. Use CASCADE, '
-      + 'SET NULL, or plain NO ACTION.',
-    ).toEqual([]);
-  });
-
-  it('every ledger entry still names a live, still-unsafe FK (burn-down)', async () => {
-    const rows = await readForeignKeys();
-    const stillUnresolved = new Set(unresolvedEdges(rows).map(rowKey));
-
-    const stale = [...ORG_CASCADE_FK_KNOWN_UNSAFE, ...ORG_CASCADE_FK_PRE_CLEARED].filter(
-      (ref) => !stillUnresolved.has(refKey(ref)),
+    const stale = [...ORG_CASCADE_FK_UNSAFE, ...ORG_CASCADE_FK_PRE_CLEARED].filter(
+      (ref) => !unhandled.has(refKey(ref)),
     );
 
     expect(
       stale.map((ref) => `${ref.childTable}.${ref.constraint} -> ${ref.parentTable}`).sort(),
       'These ledger entries no longer describe a real problem -- the FK was dropped, renamed, '
-      + 'given an ON DELETE action, or its child table joined the cascade set. Delete the '
-      + 'line(s) from orgCascadeFkOnDeleteAllowlist.ts in the same PR as the migration that '
-      + 'fixed them. A ledger that overstates the debt is how an allowlist turns into '
-      + 'permanent scar tissue.',
+      + 'given an ON DELETE action, or its child table joined the cascade set. Delete the line(s) '
+      + 'from orgCascadeFkOnDeleteAllowlist.ts in the same PR as the migration that fixed them. A '
+      + 'ledger that overstates the debt is how an allowlist turns into permanent scar tissue.',
     ).toEqual([]);
   });
 
-  it('ledger entries agree with the catalog on parent table and NOT NULL', async () => {
-    const rows = await readForeignKeys();
-    const byKey = new Map(rows.map((row) => [rowKey(row), row]));
+  it('every ledger entry agrees with the catalog on parent, reason and nullability', async () => {
+    const unhandled = await classifyAll();
 
     const drifted: string[] = [];
-    for (const ref of [...ORG_CASCADE_FK_KNOWN_UNSAFE, ...ORG_CASCADE_FK_PRE_CLEARED]) {
-      const row = byKey.get(refKey(ref));
-      if (!row) continue; // the burn-down test above owns the missing case
-      if (row.parent_table !== ref.parentTable) {
+    for (const ref of [...ORG_CASCADE_FK_UNSAFE, ...ORG_CASCADE_FK_PRE_CLEARED]) {
+      const hit = unhandled.get(refKey(ref));
+      if (!hit) continue; // the burn-down test above owns the missing case
+      if (hit.row.parent_table !== ref.parentTable) {
         drifted.push(
           `${refKey(ref)}: ledger says parentTable '${ref.parentTable}', `
-          + `catalog says '${row.parent_table}'`,
+          + `catalog says '${hit.row.parent_table}'`,
         );
       }
-      if (row.any_not_null !== ref.notNull) {
+      if (hit.reason !== ref.reason) {
         drifted.push(
-          `${refKey(ref)}: ledger says notNull ${ref.notNull}, catalog says ${row.any_not_null}`,
+          `${refKey(ref)}: ledger says reason '${ref.reason}', catalog says '${hit.reason}'`,
+        );
+      }
+      if (hit.row.all_columns_nullable !== ref.allColumnsNullable) {
+        drifted.push(
+          `${refKey(ref)}: ledger says allColumnsNullable ${ref.allColumnsNullable}, `
+          + `catalog says ${hit.row.all_columns_nullable}`,
         );
       }
     }
 
     expect(
       drifted.sort(),
-      'A ledger entry drifted from the catalog. `notNull` is the triage signal that decides '
-      + 'whether ON DELETE SET NULL is even available, so it is verified rather than trusted: '
-      + 'update the entry, and re-read whether the edge is now cheaply fixable.',
+      'A ledger entry drifted from the catalog. `reason` and `allColumnsNullable` are recomputed '
+      + 'rather than trusted, because they are what a burn-down reads to decide the fix: the '
+      + 'reason says which failure this is, and allColumnsNullable says whether plain '
+      + 'ON DELETE SET NULL is even legal. Update the entry, and re-read whether the edge is now '
+      + 'cheaply fixable.',
     ).toEqual([]);
   });
 
-  it('the two ledger lists agree with ASSOCIATED_SYSTEM_SCOPED_TABLES on which is which', () => {
-    // Both directions, so the lists stay mutually exclusive and each one keeps
-    // meaning what its name says. Without the second half, adding a pre-clear
-    // for a table would leave its FKs sitting in the DEBT list forever, and the
-    // burn-down test would not notice: they are still NO ACTION edges into the
-    // cascade set, so they still look "unresolved".
-    const misfiledAsPreCleared = ORG_CASCADE_FK_PRE_CLEARED.filter(
-      (ref) => !preClearedTables.has(ref.childTable),
+  it('the two ledger lists agree with the erasure path on which is which', () => {
+    // Both directions, so the lists stay mutually exclusive and each keeps
+    // meaning what its name says. Without the second half, an FK whose table
+    // later gained a pre-clear would sit in the DEBT list forever.
+    const notActuallyPreCleared = ORG_CASCADE_FK_PRE_CLEARED.filter(
+      (ref) => ref.reason !== 'pre-cleared',
     );
     expect(
-      misfiledAsPreCleared.map(refKey).sort(),
-      'ORG_CASCADE_FK_PRE_CLEARED claims these FKs are handled by a step-1b pre-clear, but '
-      + 'their table is not in ASSOCIATED_SYSTEM_SCOPED_TABLES (services/tenantCascade.ts). '
-      + 'Either add the pre-clear, or move the entry to ORG_CASCADE_FK_KNOWN_UNSAFE.',
+      notActuallyPreCleared.map(refKey).sort(),
+      'ORG_CASCADE_FK_PRE_CLEARED may only hold entries whose reason is `pre-cleared`. Anything '
+      + 'else is unhandled and belongs in ORG_CASCADE_FK_UNSAFE.',
     ).toEqual([]);
 
-    const misfiledAsDebt = ORG_CASCADE_FK_KNOWN_UNSAFE.filter(
-      (ref) => preClearedTables.has(ref.childTable),
+    const preClearedFiledAsDebt = ORG_CASCADE_FK_UNSAFE.filter(
+      (ref) => ref.reason === 'pre-cleared',
     );
     expect(
-      misfiledAsDebt.map(refKey).sort(),
-      'These FKs are logged as debt in ORG_CASCADE_FK_KNOWN_UNSAFE, but their table now has '
-      + 'an ASSOCIATED_SYSTEM_SCOPED_TABLES pre-clear. Check that the pre-clear\'s clearSql '
-      + 'actually reaches these rows, then move the entries to ORG_CASCADE_FK_PRE_CLEARED.',
+      preClearedFiledAsDebt.map(refKey).sort(),
+      'These FKs are logged as debt in ORG_CASCADE_FK_UNSAFE, but a step-1b pre-clear now empties '
+      + "their table ahead of the parent's DELETE. Check that the pre-clear's clearSql actually "
+      + 'reaches these rows, then move the entries to ORG_CASCADE_FK_PRE_CLEARED.',
     ).toEqual([]);
   });
 
-  it('the ledger has no duplicates and stays sorted for reviewable diffs', () => {
+  it('the ledger is duplicate-free, sorted, and explains its unusual entries', () => {
     for (const [name, list] of [
-      ['ORG_CASCADE_FK_KNOWN_UNSAFE', ORG_CASCADE_FK_KNOWN_UNSAFE],
+      ['ORG_CASCADE_FK_UNSAFE', ORG_CASCADE_FK_UNSAFE],
       ['ORG_CASCADE_FK_PRE_CLEARED', ORG_CASCADE_FK_PRE_CLEARED],
     ] as const) {
       const keys = list.map(refKey);
@@ -331,26 +447,35 @@ describe('org-erasure FK ON DELETE contract', () => {
       // Field-wise, not a concatenated string: collation of the separator
       // against '_' would otherwise make "sorted" mean something subtly
       // different from how a human orders the columns.
-      const sortKeys: Array<[string, string, string]> = list.map(
-        (ref) => [ref.parentTable, ref.childTable, ref.constraint],
-      );
-      const sorted = [...sortKeys].sort(
-        (a, b) =>
-          a[0].localeCompare(b[0]) || a[1].localeCompare(b[1]) || a[2].localeCompare(b[2]),
-      );
+      const sortKeys = list.map((ref) => [ref.parentTable, ref.childTable, ref.constraint]);
       expect(
         sortKeys,
         `${name} must stay sorted by (parentTable, childTable, constraint) so that adding or `
         + 'burning down an entry produces a one-line diff.',
-      ).toEqual(sorted);
+      ).toEqual([...sortKeys].sort(compareRefs));
     }
 
-    // A note is optional (entries seeded from the #4519 sweep are plain debt),
-    // but an empty one is worse than none: it reads as "reviewed" without
-    // saying anything.
-    for (const ref of [...ORG_CASCADE_FK_KNOWN_UNSAFE, ...ORG_CASCADE_FK_PRE_CLEARED]) {
+    // `child-not-deleted` and `pre-cleared` are self-explanatory shapes and
+    // make up the bulk of the seeded ledger. Every other reason is unusual
+    // enough that a future reader needs to be told what is going on -- and it
+    // is exactly those that turn out to be live failures rather than latent
+    // ones, so they must not be filed silently.
+    const unexplained = [...ORG_CASCADE_FK_UNSAFE, ...ORG_CASCADE_FK_PRE_CLEARED].filter(
+      (ref) =>
+        ref.reason !== 'child-not-deleted'
+        && ref.reason !== 'pre-cleared'
+        && (ref.note ?? '').trim().length < 40,
+    );
+    expect(
+      unexplained.map((ref) => `${refKey(ref)} (${ref.reason})`).sort(),
+      'A ledger entry whose reason is not the ordinary `child-not-deleted` shape must carry a '
+      + '`note` saying what actually goes wrong and how to fix it.',
+    ).toEqual([]);
+
+    // An empty-ish note anywhere reads as "reviewed" without saying anything.
+    for (const ref of [...ORG_CASCADE_FK_UNSAFE, ...ORG_CASCADE_FK_PRE_CLEARED]) {
       if (ref.note !== undefined) {
-        expect(ref.note.trim().length, `${refKey(ref)} has an empty note`).toBeGreaterThan(20);
+        expect(ref.note.trim().length, `${refKey(ref)} has a near-empty note`).toBeGreaterThan(40);
       }
     }
   });

--- a/apps/api/src/__tests__/integration/orgCascadeFkOnDelete.integration.test.ts
+++ b/apps/api/src/__tests__/integration/orgCascadeFkOnDelete.integration.test.ts
@@ -1,0 +1,343 @@
+import { describe, it, expect } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { db } from '../../db';
+import { getOrgCascadeDeleteOrder, __testOnly } from '../../services/tenantCascade';
+import {
+  ORG_CASCADE_FK_KNOWN_UNSAFE,
+  ORG_CASCADE_FK_PRE_CLEARED,
+  type OrgCascadeFkRef,
+} from './orgCascadeFkOnDeleteAllowlist';
+
+/**
+ * Contract test: no foreign key silently blocks GDPR org erasure (#4519).
+ *
+ * WHAT BREAKS WITHOUT THIS
+ *
+ * `cascadeDeleteOrg()` erases a tenant by running a plain
+ * `DELETE FROM <t> WHERE org_id = $1` over every table in
+ * `getOrgCascadeDeleteOrder()`, ordered children-before-parents by
+ * `topologicalCascadeOrder()`'s live `pg_constraint` read. Each table's DELETE
+ * is its own statement in its own system context -- the cascade is NOT one big
+ * deferred transaction -- so Postgres checks every referencing FK as that
+ * statement runs.
+ *
+ * A foreign key POINTING AT a cascade table is therefore only safe if one of
+ * these holds:
+ *
+ *   a) it declares `ON DELETE CASCADE` or `ON DELETE SET NULL`, so Postgres
+ *      clears the child itself;
+ *   b) the referencing table is ALSO in `getOrgCascadeDeleteOrder()`, so the
+ *      topological walk empties it first;
+ *   c) the referencing table is emptied by an
+ *      `ASSOCIATED_SYSTEM_SCOPED_TABLES` pre-clear (step 1b of
+ *      `cascadeDeleteOrg`), which runs ahead of the whole walk;
+ *   d) it is self-referential -- one statement removes the org's whole row set
+ *      and NO ACTION is checked at end-of-statement. (RESTRICT is checked per
+ *      row and would NOT be safe here; the test rejects it.)
+ *
+ * Anything else is a latent `23503 foreign_key_violation`: erasure works right
+ * up until a customer creates the first row in the child table, then aborts
+ * mid-way and leaves the tenant half-deleted. That is exactly how #4100
+ * shipped (`webhook_deliveries.webhook_id -> webhooks.id`, fixed in #4412) --
+ * and the sweep on that PR found ~73 more edges with the same shape. Nothing
+ * in `tenantCascade.integration.test.ts` (which only checks LIST membership),
+ * the RLS coverage contract, or the export-policy roundtrip looks at
+ * `confdeltype` at all.
+ *
+ * WHAT THIS TEST DOES NOT PROVE
+ *
+ * It is a catalog contract, not a data one. Two gaps, deliberately:
+ *
+ *   - A CROSS-TENANT row (org B's child row pointing at org A's parent row)
+ *     still breaks erasure even under (b), because `DELETE ... WHERE org_id =
+ *     $1` only removes org A's children. Detecting that needs data; RLS is
+ *     what is supposed to make it impossible.
+ *   - Under (c) it checks that the pre-clear table is registered and that the
+ *     specific FK is pinned in `ORG_CASCADE_FK_PRE_CLEARED` -- it cannot read
+ *     the hand-written `clearSql` and confirm the join actually reaches those
+ *     rows. Pinning per FK (rather than per table) is what forces a human to
+ *     go look when a new FK lands on one of those tables.
+ *
+ * Scope is the ORG cascade. The device cascade
+ * (`CORE_DEVICE_CASCADE_DELETE_TABLES`) and the partner purge are separate
+ * contracts.
+ *
+ * The seeded debt lives in `orgCascadeFkOnDeleteAllowlist.ts`; read its header
+ * before adding a line to it.
+ */
+
+/** `pg_constraint.confdeltype` codes. */
+const DELETE_ACTION_LABELS: Record<string, string> = {
+  a: 'NO ACTION',
+  r: 'RESTRICT',
+  c: 'CASCADE',
+  n: 'SET NULL',
+  d: 'SET DEFAULT',
+};
+
+/**
+ * Actions under which Postgres clears the reference for us.
+ *
+ * SET DEFAULT ('d') is NOT here on purpose: it is only safe when the column
+ * default is NULL, which would take another catalog read to know, and no FK in
+ * this schema uses it. If one ever appears it should land in the ledger with a
+ * note rather than be waved through.
+ */
+const SELF_CLEARING_DELETE_ACTIONS = new Set(['c', 'n']);
+
+interface FkRow {
+  // postgres-js does not camel-case aliases.
+  constraint_name: string;
+  child_table: string;
+  parent_table: string;
+  delete_action: string;
+  child_columns: string[];
+  any_not_null: boolean;
+}
+
+/**
+ * Every foreign key in `public`, with both ends normalised to their partition
+ * ROOT.
+ *
+ * `conparentid = 0` drops the per-partition copies Postgres clones onto each
+ * partition, and `pg_partition_root` folds a constraint declared directly on a
+ * partition back onto the root name. Both matter for `metric_rollups`, which
+ * is in the cascade list and gains a fresh monthly partition: without this the
+ * ledger would need a new line every month and would spontaneously redden CI
+ * when one appeared.
+ */
+async function readForeignKeys(): Promise<FkRow[]> {
+  return (await db.execute(sql`
+    SELECT
+      c.conname          AS constraint_name,
+      child_root.relname AS child_table,
+      parent_root.relname AS parent_table,
+      c.confdeltype      AS delete_action,
+      (SELECT array_agg(a.attname ORDER BY k.ord)
+         FROM unnest(c.conkey) WITH ORDINALITY AS k(attnum, ord)
+         JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = k.attnum)
+                         AS child_columns,
+      (SELECT bool_or(a.attnotnull)
+         FROM unnest(c.conkey) AS k(attnum)
+         JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = k.attnum)
+                         AS any_not_null
+    FROM pg_constraint c
+    JOIN pg_class child ON child.oid = c.conrelid
+    JOIN pg_class parent ON parent.oid = c.confrelid
+    JOIN pg_class child_root
+      ON child_root.oid = COALESCE(pg_partition_root(c.conrelid), c.conrelid)
+    JOIN pg_class parent_root
+      ON parent_root.oid = COALESCE(pg_partition_root(c.confrelid), c.confrelid)
+    JOIN pg_namespace child_ns ON child_ns.oid = child.relnamespace
+    JOIN pg_namespace parent_ns ON parent_ns.oid = parent.relnamespace
+    WHERE c.contype = 'f'
+      AND child_ns.nspname = 'public'
+      AND parent_ns.nspname = 'public'
+      AND c.conparentid = 0
+  `)) as unknown as FkRow[];
+}
+
+const cascadeTables = new Set(getOrgCascadeDeleteOrder());
+const preClearedTables = new Set(
+  __testOnly.ASSOCIATED_SYSTEM_SCOPED_TABLES.map((entry) => entry.table),
+);
+
+const refKey = (ref: Pick<OrgCascadeFkRef, 'childTable' | 'constraint'>) =>
+  `${ref.childTable}.${ref.constraint}`;
+const rowKey = (row: FkRow) => `${row.child_table}.${row.constraint_name}`;
+
+const describeRow = (row: FkRow) =>
+  `${row.child_table}(${row.child_columns.join(', ')}) -> ${row.parent_table} `
+  + `[${row.constraint_name}, ON DELETE ${DELETE_ACTION_LABELS[row.delete_action] ?? row.delete_action}`
+  + `${row.any_not_null ? ', NOT NULL' : ''}]`;
+
+/**
+ * Edges that need an explicit answer: they point INTO the cascade set, are not
+ * self-referential, Postgres will not clear them, and the referencing table is
+ * not emptied by the cascade walk itself.
+ */
+function unresolvedEdges(rows: FkRow[]): FkRow[] {
+  return rows.filter(
+    (row) =>
+      cascadeTables.has(row.parent_table)
+      && row.child_table !== row.parent_table
+      && !SELF_CLEARING_DELETE_ACTIONS.has(row.delete_action)
+      && !cascadeTables.has(row.child_table),
+  );
+}
+
+describe('org-erasure FK ON DELETE contract', () => {
+  it('reads a live, non-trivial FK graph (guards against a vacuously green run)', async () => {
+    const rows = await readForeignKeys();
+
+    // A catalog query that quietly returns nothing would make every other
+    // assertion in this file pass while proving nothing at all.
+    expect(rows.length).toBeGreaterThan(500);
+    expect(cascadeTables.size).toBeGreaterThan(100);
+    expect(preClearedTables.size).toBeGreaterThan(0);
+
+    const intoCascade = rows.filter((row) => cascadeTables.has(row.parent_table));
+    expect(intoCascade.length).toBeGreaterThan(100);
+    // Every branch the classifier discriminates on must actually be present,
+    // or a broken classifier would still read green.
+    expect(intoCascade.some((row) => row.delete_action === 'c')).toBe(true);
+    expect(intoCascade.some((row) => row.delete_action === 'n')).toBe(true);
+    expect(intoCascade.some((row) => row.delete_action === 'a')).toBe(true);
+
+    // The ledger is keyed on (table, constraint name) pairs, so prove that
+    // shape resolves against the real catalog for at least one known FK.
+    expect(new Set(rows.map(rowKey)).has('sessions.sessions_user_id_users_id_fk')).toBe(true);
+  });
+
+  it('every FK into an org-cascade table is FK-safe, pre-cleared, or in the ledger', async () => {
+    const rows = await readForeignKeys();
+    const pinned = new Set([
+      ...ORG_CASCADE_FK_KNOWN_UNSAFE.map(refKey),
+      ...ORG_CASCADE_FK_PRE_CLEARED.map(refKey),
+    ]);
+
+    const unaccounted = unresolvedEdges(rows).filter((row) => !pinned.has(rowKey(row)));
+
+    expect(
+      unaccounted.map(describeRow).sort(),
+      'Foreign key(s) reference a table in the org-erasure cascade without an ON DELETE '
+      + 'action, and nothing empties the referencing table first. Each one aborts GDPR org '
+      + 'erasure with 23503 as soon as a customer creates a row in it (that is #4100).\n'
+      + 'Fix forward, in order of preference: (1) give the FK ON DELETE CASCADE / SET NULL in '
+      + 'a NEW idempotent migration; (2) register the child table in '
+      + 'CORE_ORG_CASCADE_DELETE_ORDER plus every other list CLAUDE.md requires; (3) add an '
+      + 'ASSOCIATED_SYSTEM_SCOPED_TABLES pre-clear and pin the FK in '
+      + 'ORG_CASCADE_FK_PRE_CLEARED. Only if none of those fit, add it to '
+      + 'ORG_CASCADE_FK_KNOWN_UNSAFE with a note saying why. See '
+      + 'orgCascadeFkOnDeleteAllowlist.ts.',
+    ).toEqual([]);
+  });
+
+  it('no self-referential FK on a cascade table uses RESTRICT or SET DEFAULT', async () => {
+    const rows = await readForeignKeys();
+
+    // This closes the one hole exemption (d) opens. A self-referential edge is
+    // waved through on the argument that `DELETE ... WHERE org_id = $1` removes
+    // the org's whole row set in ONE statement, and NO ACTION is checked at
+    // end-of-statement -- by which point both ends are gone.
+    //
+    // That argument is specific to NO ACTION. RESTRICT is checked immediately,
+    // per row, and no amount of deferral rescues it: a parent row referenced by
+    // a sibling row in the same org aborts the DELETE even though the sibling
+    // is going away in that very statement. SET DEFAULT is only safe when the
+    // column default is NULL, which this catalog read does not establish.
+    //
+    // Non-self-referential RESTRICT is NOT flagged here: it is either handled
+    // by unresolvedEdges() above (child outside the cascade set) or genuinely
+    // safe (child inside it, emptied first by its own earlier statement) --
+    // ten such edges exist today, all in the ai_agents / contracts stacks.
+    const offenders = rows.filter(
+      (row) =>
+        cascadeTables.has(row.parent_table)
+        && row.child_table === row.parent_table
+        && (row.delete_action === 'r' || row.delete_action === 'd'),
+    );
+
+    expect(
+      offenders.map(describeRow).sort(),
+      'A self-referential ON DELETE RESTRICT / SET DEFAULT on an org-cascade table aborts '
+      + 'erasure the moment two rows in the same org reference each other. Use CASCADE, '
+      + 'SET NULL, or plain NO ACTION.',
+    ).toEqual([]);
+  });
+
+  it('every ledger entry still names a live, still-unsafe FK (burn-down)', async () => {
+    const rows = await readForeignKeys();
+    const stillUnresolved = new Set(unresolvedEdges(rows).map(rowKey));
+
+    const stale = [...ORG_CASCADE_FK_KNOWN_UNSAFE, ...ORG_CASCADE_FK_PRE_CLEARED].filter(
+      (ref) => !stillUnresolved.has(refKey(ref)),
+    );
+
+    expect(
+      stale.map((ref) => `${ref.childTable}.${ref.constraint} -> ${ref.parentTable}`).sort(),
+      'These ledger entries no longer describe a real problem -- the FK was dropped, renamed, '
+      + 'given an ON DELETE action, or its child table joined the cascade set. Delete the '
+      + 'line(s) from orgCascadeFkOnDeleteAllowlist.ts in the same PR as the migration that '
+      + 'fixed them. A ledger that overstates the debt is how an allowlist turns into '
+      + 'permanent scar tissue.',
+    ).toEqual([]);
+  });
+
+  it('ledger entries agree with the catalog on parent table and NOT NULL', async () => {
+    const rows = await readForeignKeys();
+    const byKey = new Map(rows.map((row) => [rowKey(row), row]));
+
+    const drifted: string[] = [];
+    for (const ref of [...ORG_CASCADE_FK_KNOWN_UNSAFE, ...ORG_CASCADE_FK_PRE_CLEARED]) {
+      const row = byKey.get(refKey(ref));
+      if (!row) continue; // the burn-down test above owns the missing case
+      if (row.parent_table !== ref.parentTable) {
+        drifted.push(
+          `${refKey(ref)}: ledger says parentTable '${ref.parentTable}', `
+          + `catalog says '${row.parent_table}'`,
+        );
+      }
+      if (row.any_not_null !== ref.notNull) {
+        drifted.push(
+          `${refKey(ref)}: ledger says notNull ${ref.notNull}, catalog says ${row.any_not_null}`,
+        );
+      }
+    }
+
+    expect(
+      drifted.sort(),
+      'A ledger entry drifted from the catalog. `notNull` is the triage signal that decides '
+      + 'whether ON DELETE SET NULL is even available, so it is verified rather than trusted: '
+      + 'update the entry, and re-read whether the edge is now cheaply fixable.',
+    ).toEqual([]);
+  });
+
+  it('every pre-cleared entry names a table with an ASSOCIATED_SYSTEM_SCOPED_TABLES pre-clear', () => {
+    const misfiled = ORG_CASCADE_FK_PRE_CLEARED.filter(
+      (ref) => !preClearedTables.has(ref.childTable),
+    );
+
+    expect(
+      misfiled.map(refKey).sort(),
+      'ORG_CASCADE_FK_PRE_CLEARED claims these FKs are handled by a step-1b pre-clear, but '
+      + 'their table is not in ASSOCIATED_SYSTEM_SCOPED_TABLES (services/tenantCascade.ts). '
+      + 'Either add the pre-clear, or move the entry to ORG_CASCADE_FK_KNOWN_UNSAFE.',
+    ).toEqual([]);
+  });
+
+  it('the ledger has no duplicates and stays sorted for reviewable diffs', () => {
+    for (const [name, list] of [
+      ['ORG_CASCADE_FK_KNOWN_UNSAFE', ORG_CASCADE_FK_KNOWN_UNSAFE],
+      ['ORG_CASCADE_FK_PRE_CLEARED', ORG_CASCADE_FK_PRE_CLEARED],
+    ] as const) {
+      const keys = list.map(refKey);
+      expect(new Set(keys).size, `${name} has duplicate entries`).toBe(keys.length);
+
+      // Field-wise, not a concatenated string: collation of the separator
+      // against '_' would otherwise make "sorted" mean something subtly
+      // different from how a human orders the columns.
+      const sortKeys: Array<[string, string, string]> = list.map(
+        (ref) => [ref.parentTable, ref.childTable, ref.constraint],
+      );
+      const sorted = [...sortKeys].sort(
+        (a, b) =>
+          a[0].localeCompare(b[0]) || a[1].localeCompare(b[1]) || a[2].localeCompare(b[2]),
+      );
+      expect(
+        sortKeys,
+        `${name} must stay sorted by (parentTable, childTable, constraint) so that adding or `
+        + 'burning down an entry produces a one-line diff.',
+      ).toEqual(sorted);
+    }
+
+    // A note is optional (entries seeded from the #4519 sweep are plain debt),
+    // but an empty one is worse than none: it reads as "reviewed" without
+    // saying anything.
+    for (const ref of [...ORG_CASCADE_FK_KNOWN_UNSAFE, ...ORG_CASCADE_FK_PRE_CLEARED]) {
+      if (ref.note !== undefined) {
+        expect(ref.note.trim().length, `${refKey(ref)} has an empty note`).toBeGreaterThan(20);
+      }
+    }
+  });
+});

--- a/apps/api/src/__tests__/integration/orgCascadeFkOnDeleteAllowlist.ts
+++ b/apps/api/src/__tests__/integration/orgCascadeFkOnDeleteAllowlist.ts
@@ -1,209 +1,327 @@
 /**
- * Known-unsafe FK ledger for the GDPR org-erasure cascade (#4519).
+ * Foreign-key ledger for the GDPR org-erasure cascade (#4519).
  *
- * Enforced by `orgCascadeFkOnDelete.integration.test.ts`. Read that file's
- * header for the full safety argument; the short version:
+ * Enforced by `orgCascadeFkOnDelete.integration.test.ts`; that file's header
+ * carries the full execution model. The short version: erasure empties a
+ * tenant with a sequence of ordinary `DELETE` statements, so a foreign key
+ * pointing at any table those statements touch is only safe if Postgres
+ * clears it for us, or the referencing rows are already gone by the time that
+ * statement runs. Anything else is an erasure failure that lies dormant until
+ * a customer creates the first row in the referencing table -- exactly how
+ * #4100 shipped.
  *
- *   `cascadeDeleteOrg()` empties every table in `getOrgCascadeDeleteOrder()`
- *   with a plain `DELETE ... WHERE org_id = $1`, children first. A foreign key
- *   POINTING AT one of those tables is only safe if Postgres clears it for us
- *   (`ON DELETE CASCADE` / `SET NULL`) or the referencing table is itself
- *   emptied first — by the cascade walk, or by an
- *   `ASSOCIATED_SYSTEM_SCOPED_TABLES` pre-clear. Anything else is a latent
- *   `23503 foreign_key_violation` that only fires once a customer actually
- *   creates a row in the child table (exactly how #4100 shipped).
+ * HOW TO USE THIS FILE
  *
- * ── HOW TO USE THIS FILE ────────────────────────────────────────────────────
- *
- * You are here because the contract test failed. Do NOT reflexively add a line.
- * In order of preference:
+ * You are here because the contract test failed. Do NOT reflexively add a
+ * line. In order of preference:
  *
  *   1. Give the FK an explicit `ON DELETE` in a NEW, idempotent, fix-forward
  *      migration (never edit a shipped one). `CASCADE` when the child row is
  *      meaningless without the parent; `SET NULL` when it is an optional
- *      back-reference and the column is nullable. This is the answer for
+ *      back-reference and `allColumnsNullable` is true. This is the answer for
  *      nearly every new FK.
- *   2. Register the child table in `CORE_ORG_CASCADE_DELETE_ORDER` — plus
- *      every other list CLAUDE.md's cascade-registration table demands
- *      (device cascade, export policy, ...). Only valid if the child has its
- *      own `org_id`.
+ *   2. Register the child table in `CORE_ORG_CASCADE_DELETE_ORDER` -- plus
+ *      every other list CLAUDE.md's cascade-registration table demands (device
+ *      cascade, export policy, ...). Only valid if the child has its own
+ *      `org_id`.
  *   3. Add an `ASSOCIATED_SYSTEM_SCOPED_TABLES` pre-clear in
  *      `services/tenantCascade.ts`, then record the FK in
  *      `ORG_CASCADE_FK_PRE_CLEARED` below. For child tables with no tenancy
  *      column of their own.
  *   4. Only if none of the above fits, add a line to
- *      `ORG_CASCADE_FK_KNOWN_UNSAFE` with a `note` recording WHY.
+ *      `ORG_CASCADE_FK_UNSAFE` -- and if its `reason` is anything other than
+ *      `child-not-deleted`, the test requires a `note` explaining it.
  *
- * ── BURN-DOWN ───────────────────────────────────────────────────────────────
+ * BURN-DOWN
  *
- * `ORG_CASCADE_FK_KNOWN_UNSAFE` is a debt ledger seeded from a live database
- * on 2026-09-03 so the contract could land green (68 entries). It is expected
- * to SHRINK. Entries come off it by fix-forward migration — never by relaxing
- * the test. The test refuses a stale entry (one whose FK no longer exists, or
- * is no longer unsafe), so a migration that fixes an edge forces the matching
- * line to be deleted in the same PR and the ledger can never quietly overstate
- * the debt.
+ * `ORG_CASCADE_FK_UNSAFE` is a debt ledger seeded from a live migrated
+ * database on 2026-09-03 so the contract could land green. It is expected to
+ * SHRINK. Entries come off it by fix-forward migration -- never by relaxing
+ * the test. A stale entry (the FK was dropped, renamed, given an ON DELETE, or
+ * its child table joined the cascade set) fails the burn-down test, so a
+ * migration that fixes an edge forces the matching line out in the same PR.
  *
- * A `note` is NOT a fix. Three entries below carry a reviewed argument about
- * the edge rather than plain debt; the two `partner_export_*` ones stay pinned
- * precisely because their safety argument is transitive and nothing enforces
- * it, and the `device_commands` one records a gap in an existing pre-clear.
+ * Three entries are NOT latent shapes but erasure failures that fire today for
+ * any tenant with the relevant rows -- `restore_jobs`, `action_intents` and
+ * `script_categories`, each carrying a note with its SQLSTATE and fix. They
+ * are pinned rather than fixed because #4519 is explicitly scoped to making
+ * the debt visible; the migrations are follow-up work.
+ *
+ * A `note` is not a fix. The two `partner_export_*` entries carry a reviewed
+ * argument for why their edge is unreachable in practice, so they are not debt
+ * in the ordinary sense -- but they stay pinned precisely because that
+ * argument is transitive and nothing enforces it.
  *
  * Scope: the ORG cascade only. The device cascade
  * (`CORE_DEVICE_CASCADE_DELETE_TABLES`) and the partner purge have their own
  * contracts.
  */
 
+/**
+ * Why an edge is on the ledger. Recomputed from the catalog on every run and
+ * checked against the stored value, so a `reason` cannot rot into a lie.
+ */
+export type OrgCascadeFkReason =
+  /**
+   * Ordinary debt, and the bulk of the ledger. No `ON DELETE` action, and
+   * nothing in the erasure path empties the referencing table -- it has no
+   * `org_id`, no cascade-list entry, and no pre-clear.
+   */
+  | 'child-not-deleted'
+  /**
+   * Both ends are emptied, in the wrong order: the parent goes first. Either
+   * the parent is a step-1b pre-clear target while the child waits for the
+   * cascade walk, or both are pre-cleared and the child sorts later in
+   * `ASSOCIATED_SYSTEM_SCOPED_TABLES`.
+   */
+  | 'child-deleted-after-parent'
+  /**
+   * `ON DELETE SET NULL` over a column Postgres cannot null. Postgres accepts
+   * such a constraint at DDL time and only fails when the delete runs -- with
+   * 23502, not the 23503 everything else in this file produces.
+   */
+  | 'set-null-onto-not-null'
+  /**
+   * A self-referential edge whose deleted row set is not closed under it. The
+   * end-of-statement exemption self-references normally get requires that
+   * every row referencing a deleted row is deleted by the SAME statement;
+   * a nullable `org_id` (partner-wide rows, epic #2135) breaks that, because
+   * `WHERE org_id = $1` leaves the partner-owned rows behind.
+   */
+  | 'self-ref-open-row-set'
+  /**
+   * `ON DELETE SET DEFAULT`. Unused in this schema; safe only if the column
+   * default happens to name a row that survives, which this contract does not
+   * try to establish.
+   */
+  | 'set-default'
+  /**
+   * Not debt: the referencing table is emptied by an
+   * `ASSOCIATED_SYSTEM_SCOPED_TABLES` pre-clear that runs before the parent's
+   * DELETE. Only valid in `ORG_CASCADE_FK_PRE_CLEARED`.
+   */
+  | 'pre-cleared';
+
 /** One FK edge, keyed the way `pg_constraint` keys it: (table, constraint name). */
 export interface OrgCascadeFkRef {
-  /** Referencing (child) table — `pg_class` name of `pg_constraint.conrelid`. */
+  /** Referencing (child) table -- `pg_class` name of `pg_constraint.conrelid`. */
   childTable: string;
   /** `pg_constraint.conname`. Unique per table, not globally. */
   constraint: string;
-  /** Referenced (parent) table; always a member of `getOrgCascadeDeleteOrder()`. */
+  /** Referenced (parent) table. */
   parentTable: string;
+  /** Recomputed and verified on every run; see `OrgCascadeFkReason`. */
+  reason: OrgCascadeFkReason;
   /**
-   * True when EVERY referencing column is `NOT NULL`. Verified against the
-   * catalog by the contract test, so it cannot rot. It is the triage signal
-   * that matters: a NOT NULL edge cannot be fixed with `ON DELETE SET NULL`,
-   * so it needs `CASCADE` (or a pre-clear) instead.
+   * True when EVERY referencing column is nullable, i.e. a plain
+   * `ON DELETE SET NULL` is a valid fix for this edge. Verified against the
+   * catalog rather than trusted, because it is the triage signal that decides
+   * whether the cheap fix is even available: `false` means the edge needs
+   * `CASCADE`, a pre-clear, or a column-list `SET NULL`.
    */
-  notNull: boolean;
-  /** Why this edge is still here. Required for anything that is not plain debt. */
+  allColumnsNullable: boolean;
+  /**
+   * Why this entry is here beyond its `reason`. Required for every reason
+   * except `child-not-deleted` and `pre-cleared`, whose shapes speak for
+   * themselves.
+   */
   note?: string;
 }
 
 /**
- * FKs into org-cascade tables that carry no `ON DELETE` action AND whose child
- * table is reached by neither the cascade walk nor a pre-clear.
+ * Edges the erasure path does not handle. Debt. Expected to shrink.
  *
- * Sorted by (parentTable, childTable, constraint) — keep it that way; the
+ * Sorted by (parentTable, childTable, constraint) -- keep it that way; the
  * contract test enforces the order so diffs stay reviewable.
  */
-export const ORG_CASCADE_FK_KNOWN_UNSAFE: ReadonlyArray<OrgCascadeFkRef> = Object.freeze([
-  { childTable: 'ai_messages', constraint: 'ai_messages_session_id_ai_sessions_id_fk', parentTable: 'ai_sessions', notNull: true },
-  { childTable: 'ai_tool_executions', constraint: 'ai_tool_executions_session_id_ai_sessions_id_fk', parentTable: 'ai_sessions', notNull: true },
-  { childTable: 'alert_correlations', constraint: 'alert_correlations_child_alert_id_alerts_id_fk', parentTable: 'alerts', notNull: true },
-  { childTable: 'alert_correlations', constraint: 'alert_correlations_parent_alert_id_alerts_id_fk', parentTable: 'alerts', notNull: true },
-  { childTable: 'alert_notifications', constraint: 'alert_notifications_alert_id_alerts_id_fk', parentTable: 'alerts', notNull: true },
-  { childTable: 'dashboard_widgets', constraint: 'dashboard_widgets_dashboard_id_analytics_dashboards_id_fk', parentTable: 'analytics_dashboards', notNull: true },
-  { childTable: 'automation_policy_compliance', constraint: 'automation_policy_compliance_policy_id_automation_policies_id_f', parentTable: 'automation_policies', notNull: false },
-  { childTable: 'automation_runs', constraint: 'automation_runs_automation_id_automations_id_fk', parentTable: 'automations', notNull: false },
-  { childTable: 'deployment_devices', constraint: 'deployment_devices_deployment_id_deployments_id_fk', parentTable: 'deployments', notNull: true },
-  { childTable: 'automation_policy_compliance', constraint: 'automation_policy_compliance_device_id_devices_id_fk', parentTable: 'devices', notNull: true },
-  { childTable: 'deployment_devices', constraint: 'deployment_devices_device_id_devices_id_fk', parentTable: 'devices', notNull: true },
-  { childTable: 'device_software', constraint: 'device_software_device_id_devices_id_fk', parentTable: 'devices', notNull: true },
-  { childTable: 'patch_job_results', constraint: 'patch_job_results_device_id_devices_id_fk', parentTable: 'devices', notNull: true },
-  { childTable: 'patch_rollbacks', constraint: 'patch_rollbacks_device_id_devices_id_fk', parentTable: 'devices', notNull: true },
-  { childTable: 'software_compliance_status', constraint: 'software_compliance_status_device_id_devices_id_fk', parentTable: 'devices', notNull: true },
-  { childTable: 'maintenance_occurrences', constraint: 'maintenance_occurrences_window_id_maintenance_windows_id_fk', parentTable: 'maintenance_windows', notNull: true },
-  { childTable: 'alert_notifications', constraint: 'alert_notifications_channel_id_notification_channels_id_fk', parentTable: 'notification_channels', notNull: true },
+export const ORG_CASCADE_FK_UNSAFE: ReadonlyArray<OrgCascadeFkRef> = Object.freeze([
+  { childTable: 'ai_messages', constraint: 'ai_messages_session_id_ai_sessions_id_fk', parentTable: 'ai_sessions', reason: 'child-not-deleted', allColumnsNullable: false },
+  { childTable: 'ai_tool_executions', constraint: 'ai_tool_executions_session_id_ai_sessions_id_fk', parentTable: 'ai_sessions', reason: 'child-not-deleted', allColumnsNullable: false },
+  { childTable: 'alert_correlations', constraint: 'alert_correlations_child_alert_id_alerts_id_fk', parentTable: 'alerts', reason: 'child-not-deleted', allColumnsNullable: false },
+  { childTable: 'alert_correlations', constraint: 'alert_correlations_parent_alert_id_alerts_id_fk', parentTable: 'alerts', reason: 'child-not-deleted', allColumnsNullable: false },
+  { childTable: 'alert_notifications', constraint: 'alert_notifications_alert_id_alerts_id_fk', parentTable: 'alerts', reason: 'child-not-deleted', allColumnsNullable: false },
+  { childTable: 'dashboard_widgets', constraint: 'dashboard_widgets_dashboard_id_analytics_dashboards_id_fk', parentTable: 'analytics_dashboards', reason: 'child-not-deleted', allColumnsNullable: false },
+  { childTable: 'automation_policy_compliance', constraint: 'automation_policy_compliance_policy_id_automation_policies_id_f', parentTable: 'automation_policies', reason: 'child-not-deleted', allColumnsNullable: true },
+  { childTable: 'automation_runs', constraint: 'automation_runs_automation_id_automations_id_fk', parentTable: 'automations', reason: 'child-not-deleted', allColumnsNullable: true },
+  { childTable: 'deployment_devices', constraint: 'deployment_devices_deployment_id_deployments_id_fk', parentTable: 'deployments', reason: 'child-not-deleted', allColumnsNullable: false },
+  {
+    childTable: 'restore_jobs',
+    constraint: 'restore_jobs_command_id_fkey',
+    parentTable: 'device_commands',
+    reason: 'child-deleted-after-parent',
+    allColumnsNullable: true,
+    note:
+      'LIVE ERASURE FAILURE, not a latent shape. device_commands is emptied in step 1b, BEFORE the '
+      + 'cascade walk that empties restore_jobs -- so any org that has ever run a restore driven by a '
+      + 'device command aborts erasure at step 1b with 23503. Fix forward with ON DELETE SET NULL on '
+      + 'command_id (it is nullable), or move the restore_jobs clear into '
+      + 'ASSOCIATED_SYSTEM_SCOPED_TABLES ahead of device_commands.',
+  },
+  { childTable: 'automation_policy_compliance', constraint: 'automation_policy_compliance_device_id_devices_id_fk', parentTable: 'devices', reason: 'child-not-deleted', allColumnsNullable: false },
+  { childTable: 'deployment_devices', constraint: 'deployment_devices_device_id_devices_id_fk', parentTable: 'devices', reason: 'child-not-deleted', allColumnsNullable: false },
+  { childTable: 'device_software', constraint: 'device_software_device_id_devices_id_fk', parentTable: 'devices', reason: 'child-not-deleted', allColumnsNullable: false },
+  { childTable: 'patch_job_results', constraint: 'patch_job_results_device_id_devices_id_fk', parentTable: 'devices', reason: 'child-not-deleted', allColumnsNullable: false },
+  { childTable: 'patch_rollbacks', constraint: 'patch_rollbacks_device_id_devices_id_fk', parentTable: 'devices', reason: 'child-not-deleted', allColumnsNullable: false },
+  { childTable: 'software_compliance_status', constraint: 'software_compliance_status_device_id_devices_id_fk', parentTable: 'devices', reason: 'child-not-deleted', allColumnsNullable: false },
+  { childTable: 'maintenance_occurrences', constraint: 'maintenance_occurrences_window_id_maintenance_windows_id_fk', parentTable: 'maintenance_windows', reason: 'child-not-deleted', allColumnsNullable: false },
+  { childTable: 'alert_notifications', constraint: 'alert_notifications_channel_id_notification_channels_id_fk', parentTable: 'notification_channels', reason: 'child-not-deleted', allColumnsNullable: false },
+  { childTable: 'approval_requests', constraint: 'approval_requests_requesting_session_id_fkey', parentTable: 'oauth_sessions', reason: 'child-not-deleted', allColumnsNullable: true },
   {
     childTable: 'partner_export_device_material_state',
     constraint: 'partner_export_device_material_state_org_id_fkey',
     parentTable: 'organizations',
-    notNull: true,
+    reason: 'child-not-deleted',
+    allColumnsNullable: false,
     note:
-      'Reviewed, not debt. The table is deliberately excluded from the cascade list (its rows '
-      + 'are written only by SECURITY DEFINER triggers, so breeze_app cannot DELETE them at '
-      + 'all). Erasure reaches them through device_id, which IS ON DELETE CASCADE, and devices '
-      + 'is emptied long before organizations. Still pinned because that argument is '
-      + 'transitive: it would silently stop holding if the device_id edge ever changed.',
+      'Reviewed, not plain debt. The table is deliberately outside the cascade list (its rows are '
+      + 'written only by SECURITY DEFINER triggers, so breeze_app cannot DELETE them at all). Erasure '
+      + 'reaches them through device_id, which IS ON DELETE CASCADE, and devices is emptied long '
+      + 'before organizations. Pinned anyway because that argument is transitive: it would stop '
+      + 'holding, silently, if the device_id edge ever changed.',
   },
   {
     childTable: 'partner_export_site_material_state',
     constraint: 'partner_export_site_material_state_org_id_fkey',
     parentTable: 'organizations',
-    notNull: true,
+    reason: 'child-not-deleted',
+    allColumnsNullable: false,
     note:
-      'Reviewed, not debt. Same shape as partner_export_device_material_state above, reached '
+      'Reviewed, not plain debt. Same shape as partner_export_device_material_state above, reached '
       + 'through its ON DELETE CASCADE site_id edge instead.',
   },
-  { childTable: 'patch_job_results', constraint: 'patch_job_results_job_id_patch_jobs_id_fk', parentTable: 'patch_jobs', notNull: true },
-  { childTable: 'patch_rollbacks', constraint: 'patch_rollbacks_original_job_id_patch_jobs_id_fk', parentTable: 'patch_jobs', notNull: false },
-  { childTable: 'plugin_logs', constraint: 'plugin_logs_installation_id_plugin_installations_id_fk', parentTable: 'plugin_installations', notNull: true },
-  { childTable: 'ticket_comments', constraint: 'ticket_comments_portal_user_id_portal_users_id_fk', parentTable: 'portal_users', notNull: false },
-  { childTable: 'access_review_items', constraint: 'access_review_items_role_id_roles_id_fk', parentTable: 'roles', notNull: true },
-  { childTable: 'partner_users', constraint: 'partner_users_role_id_roles_id_fk', parentTable: 'roles', notNull: true },
-  { childTable: 'role_permissions', constraint: 'role_permissions_role_id_roles_id_fk', parentTable: 'roles', notNull: true },
-  { childTable: 'script_to_tags', constraint: 'script_to_tags_tag_id_script_tags_id_fk', parentTable: 'script_tags', notNull: true },
-  { childTable: 'config_policy_compliance_rules', constraint: 'config_policy_compliance_rules_remediation_script_id_scripts_id', parentTable: 'scripts', notNull: false },
-  { childTable: 'patch_policies', constraint: 'patch_policies_post_install_script_id_scripts_id_fk', parentTable: 'scripts', notNull: false },
-  { childTable: 'patch_policies', constraint: 'patch_policies_pre_install_script_id_scripts_id_fk', parentTable: 'scripts', notNull: false },
-  { childTable: 'script_to_tags', constraint: 'script_to_tags_script_id_scripts_id_fk', parentTable: 'scripts', notNull: true },
-  { childTable: 'script_versions', constraint: 'script_versions_script_id_scripts_id_fk', parentTable: 'scripts', notNull: true },
-  { childTable: 'snmp_alert_thresholds', constraint: 'snmp_alert_thresholds_device_id_snmp_devices_id_fk', parentTable: 'snmp_devices', notNull: true },
-  { childTable: 'ticket_comments', constraint: 'ticket_comments_ticket_id_tickets_id_fk', parentTable: 'tickets', notNull: true },
-  { childTable: 'access_review_items', constraint: 'access_review_items_reviewed_by_users_id_fk', parentTable: 'users', notNull: false },
-  { childTable: 'access_review_items', constraint: 'access_review_items_user_id_users_id_fk', parentTable: 'users', notNull: true },
-  { childTable: 'accounting_connections', constraint: 'accounting_connections_connected_by_fkey', parentTable: 'users', notNull: false },
-  { childTable: 'ai_tool_executions', constraint: 'ai_tool_executions_approved_by_users_id_fk', parentTable: 'users', notNull: false },
-  { childTable: 'authenticator_policies', constraint: 'authenticator_policies_updated_by_user_id_fkey', parentTable: 'users', notNull: false },
-  { childTable: 'catalog_items', constraint: 'catalog_items_created_by_fkey', parentTable: 'users', notNull: false },
-  { childTable: 'config_policy_assignments', constraint: 'config_policy_assignments_assigned_by_users_id_fk', parentTable: 'users', notNull: false },
-  { childTable: 'mobile_devices', constraint: 'mobile_devices_user_id_users_id_fk', parentTable: 'users', notNull: true },
-  { childTable: 'mobile_sessions', constraint: 'mobile_sessions_user_id_users_id_fk', parentTable: 'users', notNull: true },
-  { childTable: 'network_known_guests', constraint: 'network_known_guests_added_by_users_id_fk', parentTable: 'users', notNull: false },
-  { childTable: 'office_addin_user_bindings', constraint: 'office_addin_bindings_user_partner_fk', parentTable: 'users', notNull: true },
-  { childTable: 'office_addin_user_bindings', constraint: 'office_addin_user_bindings_revoked_by_fkey', parentTable: 'users', notNull: false },
-  { childTable: 'office_addin_user_bindings', constraint: 'office_addin_user_bindings_user_id_fkey', parentTable: 'users', notNull: true },
-  { childTable: 'partner_service_principal_keys', constraint: 'partner_service_principal_keys_created_by_fkey', parentTable: 'users', notNull: true },
-  { childTable: 'partner_service_principals', constraint: 'partner_service_principals_created_by_fkey', parentTable: 'users', notNull: true },
-  { childTable: 'partner_service_principals', constraint: 'partner_service_principals_updated_by_fkey', parentTable: 'users', notNull: true },
-  { childTable: 'partner_users', constraint: 'partner_users_user_id_users_id_fk', parentTable: 'users', notNull: true },
-  { childTable: 'patch_approvals', constraint: 'patch_approvals_approved_by_users_id_fk', parentTable: 'users', notNull: false },
-  { childTable: 'patch_policies', constraint: 'patch_policies_created_by_users_id_fk', parentTable: 'users', notNull: false },
-  { childTable: 'patch_rollbacks', constraint: 'patch_rollbacks_initiated_by_users_id_fk', parentTable: 'users', notNull: false },
-  { childTable: 'pax8_integrations', constraint: 'pax8_integrations_created_by_fkey', parentTable: 'users', notNull: false },
-  { childTable: 'push_notifications', constraint: 'push_notifications_user_id_users_id_fk', parentTable: 'users', notNull: true },
-  { childTable: 'script_versions', constraint: 'script_versions_created_by_users_id_fk', parentTable: 'users', notNull: false },
-  { childTable: 'sessions', constraint: 'sessions_user_id_users_id_fk', parentTable: 'users', notNull: true },
-  { childTable: 'stripe_connect_accounts', constraint: 'stripe_connect_accounts_connected_by_fkey', parentTable: 'users', notNull: false },
-  { childTable: 'td_synnex_digital_bridge_integrations', constraint: 'td_synnex_digital_bridge_integrations_created_by_fkey', parentTable: 'users', notNull: false },
-  { childTable: 'td_synnex_ec_express_integrations', constraint: 'td_synnex_ec_express_integrations_created_by_fkey', parentTable: 'users', notNull: false },
-  { childTable: 'td_synnex_sftp_integrations', constraint: 'td_synnex_sftp_integrations_created_by_fkey', parentTable: 'users', notNull: false },
-  { childTable: 'ticket_comments', constraint: 'ticket_comments_user_id_users_id_fk', parentTable: 'users', notNull: false },
-  { childTable: 'ticket_mailbox_connections', constraint: 'ticket_mailbox_connections_created_by_fkey', parentTable: 'users', notNull: false },
-  { childTable: 'ticket_mailbox_consent_sessions', constraint: 'ticket_mailbox_consent_sessions_user_id_fkey', parentTable: 'users', notNull: false },
-  { childTable: 'ticket_mailbox_tenant_ownerships', constraint: 'ticket_mailbox_tenant_ownerships_verified_by_fkey', parentTable: 'users', notNull: false },
-  { childTable: 'ticket_response_templates', constraint: 'ticket_response_templates_created_by_fkey', parentTable: 'users', notNull: false },
-  { childTable: 'unifi_integrations', constraint: 'unifi_integrations_created_by_fkey', parentTable: 'users', notNull: false },
+  { childTable: 'patch_job_results', constraint: 'patch_job_results_job_id_patch_jobs_id_fk', parentTable: 'patch_jobs', reason: 'child-not-deleted', allColumnsNullable: false },
+  { childTable: 'patch_rollbacks', constraint: 'patch_rollbacks_original_job_id_patch_jobs_id_fk', parentTable: 'patch_jobs', reason: 'child-not-deleted', allColumnsNullable: true },
+  { childTable: 'plugin_logs', constraint: 'plugin_logs_installation_id_plugin_installations_id_fk', parentTable: 'plugin_installations', reason: 'child-not-deleted', allColumnsNullable: false },
+  { childTable: 'ticket_comments', constraint: 'ticket_comments_portal_user_id_portal_users_id_fk', parentTable: 'portal_users', reason: 'child-not-deleted', allColumnsNullable: true },
+  { childTable: 'auth_browser_transitions', constraint: 'auth_browser_transitions_current_family_owner_fk', parentTable: 'refresh_token_families', reason: 'child-not-deleted', allColumnsNullable: true },
+  { childTable: 'sso_token_exchange_grants', constraint: 'sso_token_exchange_grants_family_owner_fk', parentTable: 'refresh_token_families', reason: 'child-not-deleted', allColumnsNullable: false },
+  { childTable: 'access_review_items', constraint: 'access_review_items_role_id_roles_id_fk', parentTable: 'roles', reason: 'child-not-deleted', allColumnsNullable: false },
+  { childTable: 'partner_users', constraint: 'partner_users_role_id_roles_id_fk', parentTable: 'roles', reason: 'child-not-deleted', allColumnsNullable: false },
+  { childTable: 'role_permissions', constraint: 'role_permissions_role_id_roles_id_fk', parentTable: 'roles', reason: 'child-not-deleted', allColumnsNullable: false },
+  {
+    childTable: 'script_categories',
+    constraint: 'script_categories_parent_id_script_categories_id_fk',
+    parentTable: 'script_categories',
+    reason: 'self-ref-open-row-set',
+    allColumnsNullable: true,
+    note:
+      'LIVE ERASURE FAILURE. script_categories.org_id is NULLABLE (partner-wide categories, epic '
+      + '#2135), so DELETE ... WHERE org_id = $1 does NOT remove a row set closed under this '
+      + 'self-reference: a surviving partner-wide category whose parent_id points at an org-owned one '
+      + 'raises 23503. Verified empirically against Postgres 16. Fix forward with ON DELETE SET NULL '
+      + 'on parent_id.',
+  },
+  { childTable: 'script_to_tags', constraint: 'script_to_tags_tag_id_script_tags_id_fk', parentTable: 'script_tags', reason: 'child-not-deleted', allColumnsNullable: false },
+  { childTable: 'config_policy_compliance_rules', constraint: 'config_policy_compliance_rules_remediation_script_id_scripts_id', parentTable: 'scripts', reason: 'child-not-deleted', allColumnsNullable: true },
+  { childTable: 'patch_policies', constraint: 'patch_policies_post_install_script_id_scripts_id_fk', parentTable: 'scripts', reason: 'child-not-deleted', allColumnsNullable: true },
+  { childTable: 'patch_policies', constraint: 'patch_policies_pre_install_script_id_scripts_id_fk', parentTable: 'scripts', reason: 'child-not-deleted', allColumnsNullable: true },
+  { childTable: 'script_to_tags', constraint: 'script_to_tags_script_id_scripts_id_fk', parentTable: 'scripts', reason: 'child-not-deleted', allColumnsNullable: false },
+  { childTable: 'script_versions', constraint: 'script_versions_script_id_scripts_id_fk', parentTable: 'scripts', reason: 'child-not-deleted', allColumnsNullable: false },
+  { childTable: 'snmp_alert_thresholds', constraint: 'snmp_alert_thresholds_device_id_snmp_devices_id_fk', parentTable: 'snmp_devices', reason: 'child-not-deleted', allColumnsNullable: false },
+  {
+    childTable: 'action_intents',
+    constraint: 'action_intents_scope_ticket_org_fk',
+    parentTable: 'tickets',
+    reason: 'set-null-onto-not-null',
+    allColumnsNullable: false,
+    note:
+      'LIVE ERASURE FAILURE, and it fails with 23502 rather than 23503. The FK is ON DELETE SET '
+      + 'NULL over (scope_ticket_id, org_id) with no confdelsetcols, and action_intents.org_id is NOT '
+      + 'NULL -- so deleting a ticket tries to null a NOT NULL column. Fix forward by restricting the '
+      + 'action to SET NULL (scope_ticket_id).',
+  },
+  { childTable: 'ticket_comments', constraint: 'ticket_comments_ticket_id_tickets_id_fk', parentTable: 'tickets', reason: 'child-not-deleted', allColumnsNullable: false },
+  { childTable: 'access_review_items', constraint: 'access_review_items_reviewed_by_users_id_fk', parentTable: 'users', reason: 'child-not-deleted', allColumnsNullable: true },
+  { childTable: 'access_review_items', constraint: 'access_review_items_user_id_users_id_fk', parentTable: 'users', reason: 'child-not-deleted', allColumnsNullable: false },
+  { childTable: 'accounting_connections', constraint: 'accounting_connections_connected_by_fkey', parentTable: 'users', reason: 'child-not-deleted', allColumnsNullable: true },
+  { childTable: 'ai_tool_executions', constraint: 'ai_tool_executions_approved_by_users_id_fk', parentTable: 'users', reason: 'child-not-deleted', allColumnsNullable: true },
+  { childTable: 'authenticator_policies', constraint: 'authenticator_policies_updated_by_user_id_fkey', parentTable: 'users', reason: 'child-not-deleted', allColumnsNullable: true },
+  { childTable: 'catalog_items', constraint: 'catalog_items_created_by_fkey', parentTable: 'users', reason: 'child-not-deleted', allColumnsNullable: true },
+  { childTable: 'config_policy_assignments', constraint: 'config_policy_assignments_assigned_by_users_id_fk', parentTable: 'users', reason: 'child-not-deleted', allColumnsNullable: true },
+  { childTable: 'mobile_devices', constraint: 'mobile_devices_user_id_users_id_fk', parentTable: 'users', reason: 'child-not-deleted', allColumnsNullable: false },
+  { childTable: 'mobile_sessions', constraint: 'mobile_sessions_user_id_users_id_fk', parentTable: 'users', reason: 'child-not-deleted', allColumnsNullable: false },
+  { childTable: 'network_known_guests', constraint: 'network_known_guests_added_by_users_id_fk', parentTable: 'users', reason: 'child-not-deleted', allColumnsNullable: true },
+  { childTable: 'office_addin_user_bindings', constraint: 'office_addin_bindings_user_partner_fk', parentTable: 'users', reason: 'child-not-deleted', allColumnsNullable: false },
+  { childTable: 'office_addin_user_bindings', constraint: 'office_addin_user_bindings_revoked_by_fkey', parentTable: 'users', reason: 'child-not-deleted', allColumnsNullable: true },
+  { childTable: 'office_addin_user_bindings', constraint: 'office_addin_user_bindings_user_id_fkey', parentTable: 'users', reason: 'child-not-deleted', allColumnsNullable: false },
+  { childTable: 'partner_service_principal_keys', constraint: 'partner_service_principal_keys_created_by_fkey', parentTable: 'users', reason: 'child-not-deleted', allColumnsNullable: false },
+  { childTable: 'partner_service_principals', constraint: 'partner_service_principals_created_by_fkey', parentTable: 'users', reason: 'child-not-deleted', allColumnsNullable: false },
+  { childTable: 'partner_service_principals', constraint: 'partner_service_principals_updated_by_fkey', parentTable: 'users', reason: 'child-not-deleted', allColumnsNullable: false },
+  { childTable: 'partner_users', constraint: 'partner_users_user_id_users_id_fk', parentTable: 'users', reason: 'child-not-deleted', allColumnsNullable: false },
+  { childTable: 'patch_approvals', constraint: 'patch_approvals_approved_by_users_id_fk', parentTable: 'users', reason: 'child-not-deleted', allColumnsNullable: true },
+  { childTable: 'patch_policies', constraint: 'patch_policies_created_by_users_id_fk', parentTable: 'users', reason: 'child-not-deleted', allColumnsNullable: true },
+  { childTable: 'patch_rollbacks', constraint: 'patch_rollbacks_initiated_by_users_id_fk', parentTable: 'users', reason: 'child-not-deleted', allColumnsNullable: true },
+  { childTable: 'pax8_integrations', constraint: 'pax8_integrations_created_by_fkey', parentTable: 'users', reason: 'child-not-deleted', allColumnsNullable: true },
+  { childTable: 'push_notifications', constraint: 'push_notifications_user_id_users_id_fk', parentTable: 'users', reason: 'child-not-deleted', allColumnsNullable: false },
+  { childTable: 'script_versions', constraint: 'script_versions_created_by_users_id_fk', parentTable: 'users', reason: 'child-not-deleted', allColumnsNullable: true },
+  { childTable: 'sessions', constraint: 'sessions_user_id_users_id_fk', parentTable: 'users', reason: 'child-not-deleted', allColumnsNullable: false },
+  { childTable: 'stripe_connect_accounts', constraint: 'stripe_connect_accounts_connected_by_fkey', parentTable: 'users', reason: 'child-not-deleted', allColumnsNullable: true },
+  { childTable: 'td_synnex_digital_bridge_integrations', constraint: 'td_synnex_digital_bridge_integrations_created_by_fkey', parentTable: 'users', reason: 'child-not-deleted', allColumnsNullable: true },
+  { childTable: 'td_synnex_ec_express_integrations', constraint: 'td_synnex_ec_express_integrations_created_by_fkey', parentTable: 'users', reason: 'child-not-deleted', allColumnsNullable: true },
+  { childTable: 'td_synnex_sftp_integrations', constraint: 'td_synnex_sftp_integrations_created_by_fkey', parentTable: 'users', reason: 'child-not-deleted', allColumnsNullable: true },
+  { childTable: 'ticket_comments', constraint: 'ticket_comments_user_id_users_id_fk', parentTable: 'users', reason: 'child-not-deleted', allColumnsNullable: true },
+  { childTable: 'ticket_mailbox_connections', constraint: 'ticket_mailbox_connections_created_by_fkey', parentTable: 'users', reason: 'child-not-deleted', allColumnsNullable: true },
+  { childTable: 'ticket_mailbox_consent_sessions', constraint: 'ticket_mailbox_consent_sessions_user_id_fkey', parentTable: 'users', reason: 'child-not-deleted', allColumnsNullable: true },
+  { childTable: 'ticket_mailbox_tenant_ownerships', constraint: 'ticket_mailbox_tenant_ownerships_verified_by_fkey', parentTable: 'users', reason: 'child-not-deleted', allColumnsNullable: true },
+  { childTable: 'ticket_response_templates', constraint: 'ticket_response_templates_created_by_fkey', parentTable: 'users', reason: 'child-not-deleted', allColumnsNullable: true },
+  { childTable: 'unifi_integrations', constraint: 'unifi_integrations_created_by_fkey', parentTable: 'users', reason: 'child-not-deleted', allColumnsNullable: true },
 ]);
 
 /**
- * FKs into org-cascade tables with no `ON DELETE`, whose child table IS
- * emptied first by an `ASSOCIATED_SYSTEM_SCOPED_TABLES` pre-clear in
- * `services/tenantCascade.ts`. These are handled, not debt.
+ * Edges with no self-clearing `ON DELETE` whose referencing table IS emptied
+ * first by an `ASSOCIATED_SYSTEM_SCOPED_TABLES` pre-clear. Handled, not debt.
  *
- * They are still pinned one-by-one rather than waved through per table,
- * because the pre-clear is hand-written SQL: `psa_ticket_mappings` needs three
- * separate arms to cover its three FKs, and a FOURTH FK added to that table
+ * Pinned one-by-one rather than waved through per table, because the pre-clear
+ * is hand-written SQL with its own WHERE join: `psa_ticket_mappings` needs
+ * three separate arms to cover its three FKs, and a FOURTH FK on that table
  * would be silently uncovered if table membership alone satisfied the
- * contract. Adding an FK to a pre-clear table therefore reds this test and
- * forces the author to open `clearSql` and check it.
+ * contract. Listing every FK means a new one reds this test and sends the
+ * author to read `clearSql`.
+ *
+ * What membership here does and does not assert: the test verifies the table
+ * has a pre-clear and that the pre-clear runs before this parent's DELETE. It
+ * cannot read the `clearSql` and confirm the join actually reaches the rows
+ * this particular FK pins -- two entries below carry a note where the arm
+ * demonstrably keys off a different column than the FK.
  *
  * Sorted by (parentTable, childTable, constraint), same as above.
  */
 export const ORG_CASCADE_FK_PRE_CLEARED: ReadonlyArray<OrgCascadeFkRef> = Object.freeze([
-  { childTable: 'psa_ticket_mappings', constraint: 'psa_ticket_mappings_alert_id_alerts_id_fk', parentTable: 'alerts', notNull: false },
-  { childTable: 'deployment_results', constraint: 'deployment_results_device_id_devices_id_fk', parentTable: 'devices', notNull: true },
-  { childTable: 'device_commands', constraint: 'device_commands_device_id_devices_id_fk', parentTable: 'devices', notNull: true },
-  { childTable: 'psa_ticket_mappings', constraint: 'psa_ticket_mappings_device_id_devices_id_fk', parentTable: 'devices', notNull: false },
-  { childTable: 'psa_ticket_mappings', constraint: 'psa_ticket_mappings_connection_id_psa_connections_id_fk', parentTable: 'psa_connections', notNull: true },
-  { childTable: 'report_runs', constraint: 'report_runs_report_id_reports_id_fk', parentTable: 'reports', notNull: true },
-  { childTable: 'software_versions', constraint: 'software_versions_catalog_id_software_catalog_id_fk', parentTable: 'software_catalog', notNull: true },
-  { childTable: 'deployment_results', constraint: 'deployment_results_deployment_id_software_deployments_id_fk', parentTable: 'software_deployments', notNull: true },
-  { childTable: 'sso_sessions', constraint: 'sso_sessions_provider_id_sso_providers_id_fk', parentTable: 'sso_providers', notNull: true },
-  { childTable: 'user_sso_identities', constraint: 'user_sso_identities_provider_id_sso_providers_id_fk', parentTable: 'sso_providers', notNull: true },
+  { childTable: 'psa_ticket_mappings', constraint: 'psa_ticket_mappings_alert_id_alerts_id_fk', parentTable: 'alerts', reason: 'pre-cleared', allColumnsNullable: true },
+  {
+    childTable: 'deployment_results',
+    constraint: 'deployment_results_device_id_devices_id_fk',
+    parentTable: 'devices',
+    reason: 'pre-cleared',
+    allColumnsNullable: false,
+    note:
+      'The deployment_results pre-clear keys off deployment_id only. A row pairing THIS org\'s '
+      + 'device with another org\'s deployment would survive it and then pin `devices`. Cross-org '
+      + 'pairing should be impossible, but nothing here proves it.',
+  },
+  { childTable: 'device_commands', constraint: 'device_commands_device_id_devices_id_fk', parentTable: 'devices', reason: 'pre-cleared', allColumnsNullable: false },
+  { childTable: 'psa_ticket_mappings', constraint: 'psa_ticket_mappings_device_id_devices_id_fk', parentTable: 'devices', reason: 'pre-cleared', allColumnsNullable: true },
+  { childTable: 'software_deployments', constraint: 'software_deployments_maintenance_window_id_maintenance_windows_', parentTable: 'maintenance_windows', reason: 'pre-cleared', allColumnsNullable: true },
+  { childTable: 'software_deployments', constraint: 'software_deployments_org_id_organizations_id_fk', parentTable: 'organizations', reason: 'pre-cleared', allColumnsNullable: false },
+  { childTable: 'psa_ticket_mappings', constraint: 'psa_ticket_mappings_connection_id_psa_connections_id_fk', parentTable: 'psa_connections', reason: 'pre-cleared', allColumnsNullable: false },
+  { childTable: 'report_runs', constraint: 'report_runs_report_id_reports_id_fk', parentTable: 'reports', reason: 'pre-cleared', allColumnsNullable: false },
+  { childTable: 'software_versions', constraint: 'software_versions_catalog_id_software_catalog_id_fk', parentTable: 'software_catalog', reason: 'pre-cleared', allColumnsNullable: false },
+  { childTable: 'deployment_results', constraint: 'deployment_results_deployment_id_software_deployments_id_fk', parentTable: 'software_deployments', reason: 'pre-cleared', allColumnsNullable: false },
+  { childTable: 'software_deployments', constraint: 'software_deployments_install_method_id_fkey', parentTable: 'software_install_methods', reason: 'pre-cleared', allColumnsNullable: true },
+  { childTable: 'software_deployments', constraint: 'software_deployments_software_version_id_software_versions_id_f', parentTable: 'software_versions', reason: 'pre-cleared', allColumnsNullable: true },
+  { childTable: 'sso_sessions', constraint: 'sso_sessions_provider_id_sso_providers_id_fk', parentTable: 'sso_providers', reason: 'pre-cleared', allColumnsNullable: false },
+  { childTable: 'user_sso_identities', constraint: 'user_sso_identities_provider_id_sso_providers_id_fk', parentTable: 'sso_providers', reason: 'pre-cleared', allColumnsNullable: false },
   {
     childTable: 'device_commands',
     constraint: 'device_commands_created_by_users_id_fk',
     parentTable: 'users',
-    notNull: false,
+    reason: 'pre-cleared',
+    allColumnsNullable: true,
     note:
       'The device_commands pre-clear keys off device_id only, so a command a user of THIS org '
-      + 'queued against ANOTHER org\'s device would survive the pre-clear and then pin `users`. '
-      + 'Cross-org queuing should be impossible under RLS, but nothing here proves it.',
+      + 'queued against ANOTHER org\'s device would survive it and then pin `users`. Cross-org queuing '
+      + 'should be impossible, but nothing here proves it.',
   },
-  { childTable: 'user_sso_identities', constraint: 'user_sso_identities_user_id_users_id_fk', parentTable: 'users', notNull: true },
+  { childTable: 'software_deployments', constraint: 'software_deployments_created_by_users_id_fk', parentTable: 'users', reason: 'pre-cleared', allColumnsNullable: true },
+  { childTable: 'user_sso_identities', constraint: 'user_sso_identities_user_id_users_id_fk', parentTable: 'users', reason: 'pre-cleared', allColumnsNullable: false },
 ]);

--- a/apps/api/src/__tests__/integration/orgCascadeFkOnDeleteAllowlist.ts
+++ b/apps/api/src/__tests__/integration/orgCascadeFkOnDeleteAllowlist.ts
@@ -1,0 +1,209 @@
+/**
+ * Known-unsafe FK ledger for the GDPR org-erasure cascade (#4519).
+ *
+ * Enforced by `orgCascadeFkOnDelete.integration.test.ts`. Read that file's
+ * header for the full safety argument; the short version:
+ *
+ *   `cascadeDeleteOrg()` empties every table in `getOrgCascadeDeleteOrder()`
+ *   with a plain `DELETE ... WHERE org_id = $1`, children first. A foreign key
+ *   POINTING AT one of those tables is only safe if Postgres clears it for us
+ *   (`ON DELETE CASCADE` / `SET NULL`) or the referencing table is itself
+ *   emptied first — by the cascade walk, or by an
+ *   `ASSOCIATED_SYSTEM_SCOPED_TABLES` pre-clear. Anything else is a latent
+ *   `23503 foreign_key_violation` that only fires once a customer actually
+ *   creates a row in the child table (exactly how #4100 shipped).
+ *
+ * ── HOW TO USE THIS FILE ────────────────────────────────────────────────────
+ *
+ * You are here because the contract test failed. Do NOT reflexively add a line.
+ * In order of preference:
+ *
+ *   1. Give the FK an explicit `ON DELETE` in a NEW, idempotent, fix-forward
+ *      migration (never edit a shipped one). `CASCADE` when the child row is
+ *      meaningless without the parent; `SET NULL` when it is an optional
+ *      back-reference and the column is nullable. This is the answer for
+ *      nearly every new FK.
+ *   2. Register the child table in `CORE_ORG_CASCADE_DELETE_ORDER` — plus
+ *      every other list CLAUDE.md's cascade-registration table demands
+ *      (device cascade, export policy, ...). Only valid if the child has its
+ *      own `org_id`.
+ *   3. Add an `ASSOCIATED_SYSTEM_SCOPED_TABLES` pre-clear in
+ *      `services/tenantCascade.ts`, then record the FK in
+ *      `ORG_CASCADE_FK_PRE_CLEARED` below. For child tables with no tenancy
+ *      column of their own.
+ *   4. Only if none of the above fits, add a line to
+ *      `ORG_CASCADE_FK_KNOWN_UNSAFE` with a `note` recording WHY.
+ *
+ * ── BURN-DOWN ───────────────────────────────────────────────────────────────
+ *
+ * `ORG_CASCADE_FK_KNOWN_UNSAFE` is a debt ledger seeded from a live database
+ * on 2026-09-03 so the contract could land green (68 entries). It is expected
+ * to SHRINK. Entries come off it by fix-forward migration — never by relaxing
+ * the test. The test refuses a stale entry (one whose FK no longer exists, or
+ * is no longer unsafe), so a migration that fixes an edge forces the matching
+ * line to be deleted in the same PR and the ledger can never quietly overstate
+ * the debt.
+ *
+ * A `note` is NOT a fix. Three entries below carry a reviewed argument about
+ * the edge rather than plain debt; the two `partner_export_*` ones stay pinned
+ * precisely because their safety argument is transitive and nothing enforces
+ * it, and the `device_commands` one records a gap in an existing pre-clear.
+ *
+ * Scope: the ORG cascade only. The device cascade
+ * (`CORE_DEVICE_CASCADE_DELETE_TABLES`) and the partner purge have their own
+ * contracts.
+ */
+
+/** One FK edge, keyed the way `pg_constraint` keys it: (table, constraint name). */
+export interface OrgCascadeFkRef {
+  /** Referencing (child) table — `pg_class` name of `pg_constraint.conrelid`. */
+  childTable: string;
+  /** `pg_constraint.conname`. Unique per table, not globally. */
+  constraint: string;
+  /** Referenced (parent) table; always a member of `getOrgCascadeDeleteOrder()`. */
+  parentTable: string;
+  /**
+   * True when EVERY referencing column is `NOT NULL`. Verified against the
+   * catalog by the contract test, so it cannot rot. It is the triage signal
+   * that matters: a NOT NULL edge cannot be fixed with `ON DELETE SET NULL`,
+   * so it needs `CASCADE` (or a pre-clear) instead.
+   */
+  notNull: boolean;
+  /** Why this edge is still here. Required for anything that is not plain debt. */
+  note?: string;
+}
+
+/**
+ * FKs into org-cascade tables that carry no `ON DELETE` action AND whose child
+ * table is reached by neither the cascade walk nor a pre-clear.
+ *
+ * Sorted by (parentTable, childTable, constraint) — keep it that way; the
+ * contract test enforces the order so diffs stay reviewable.
+ */
+export const ORG_CASCADE_FK_KNOWN_UNSAFE: ReadonlyArray<OrgCascadeFkRef> = Object.freeze([
+  { childTable: 'ai_messages', constraint: 'ai_messages_session_id_ai_sessions_id_fk', parentTable: 'ai_sessions', notNull: true },
+  { childTable: 'ai_tool_executions', constraint: 'ai_tool_executions_session_id_ai_sessions_id_fk', parentTable: 'ai_sessions', notNull: true },
+  { childTable: 'alert_correlations', constraint: 'alert_correlations_child_alert_id_alerts_id_fk', parentTable: 'alerts', notNull: true },
+  { childTable: 'alert_correlations', constraint: 'alert_correlations_parent_alert_id_alerts_id_fk', parentTable: 'alerts', notNull: true },
+  { childTable: 'alert_notifications', constraint: 'alert_notifications_alert_id_alerts_id_fk', parentTable: 'alerts', notNull: true },
+  { childTable: 'dashboard_widgets', constraint: 'dashboard_widgets_dashboard_id_analytics_dashboards_id_fk', parentTable: 'analytics_dashboards', notNull: true },
+  { childTable: 'automation_policy_compliance', constraint: 'automation_policy_compliance_policy_id_automation_policies_id_f', parentTable: 'automation_policies', notNull: false },
+  { childTable: 'automation_runs', constraint: 'automation_runs_automation_id_automations_id_fk', parentTable: 'automations', notNull: false },
+  { childTable: 'deployment_devices', constraint: 'deployment_devices_deployment_id_deployments_id_fk', parentTable: 'deployments', notNull: true },
+  { childTable: 'automation_policy_compliance', constraint: 'automation_policy_compliance_device_id_devices_id_fk', parentTable: 'devices', notNull: true },
+  { childTable: 'deployment_devices', constraint: 'deployment_devices_device_id_devices_id_fk', parentTable: 'devices', notNull: true },
+  { childTable: 'device_software', constraint: 'device_software_device_id_devices_id_fk', parentTable: 'devices', notNull: true },
+  { childTable: 'patch_job_results', constraint: 'patch_job_results_device_id_devices_id_fk', parentTable: 'devices', notNull: true },
+  { childTable: 'patch_rollbacks', constraint: 'patch_rollbacks_device_id_devices_id_fk', parentTable: 'devices', notNull: true },
+  { childTable: 'software_compliance_status', constraint: 'software_compliance_status_device_id_devices_id_fk', parentTable: 'devices', notNull: true },
+  { childTable: 'maintenance_occurrences', constraint: 'maintenance_occurrences_window_id_maintenance_windows_id_fk', parentTable: 'maintenance_windows', notNull: true },
+  { childTable: 'alert_notifications', constraint: 'alert_notifications_channel_id_notification_channels_id_fk', parentTable: 'notification_channels', notNull: true },
+  {
+    childTable: 'partner_export_device_material_state',
+    constraint: 'partner_export_device_material_state_org_id_fkey',
+    parentTable: 'organizations',
+    notNull: true,
+    note:
+      'Reviewed, not debt. The table is deliberately excluded from the cascade list (its rows '
+      + 'are written only by SECURITY DEFINER triggers, so breeze_app cannot DELETE them at '
+      + 'all). Erasure reaches them through device_id, which IS ON DELETE CASCADE, and devices '
+      + 'is emptied long before organizations. Still pinned because that argument is '
+      + 'transitive: it would silently stop holding if the device_id edge ever changed.',
+  },
+  {
+    childTable: 'partner_export_site_material_state',
+    constraint: 'partner_export_site_material_state_org_id_fkey',
+    parentTable: 'organizations',
+    notNull: true,
+    note:
+      'Reviewed, not debt. Same shape as partner_export_device_material_state above, reached '
+      + 'through its ON DELETE CASCADE site_id edge instead.',
+  },
+  { childTable: 'patch_job_results', constraint: 'patch_job_results_job_id_patch_jobs_id_fk', parentTable: 'patch_jobs', notNull: true },
+  { childTable: 'patch_rollbacks', constraint: 'patch_rollbacks_original_job_id_patch_jobs_id_fk', parentTable: 'patch_jobs', notNull: false },
+  { childTable: 'plugin_logs', constraint: 'plugin_logs_installation_id_plugin_installations_id_fk', parentTable: 'plugin_installations', notNull: true },
+  { childTable: 'ticket_comments', constraint: 'ticket_comments_portal_user_id_portal_users_id_fk', parentTable: 'portal_users', notNull: false },
+  { childTable: 'access_review_items', constraint: 'access_review_items_role_id_roles_id_fk', parentTable: 'roles', notNull: true },
+  { childTable: 'partner_users', constraint: 'partner_users_role_id_roles_id_fk', parentTable: 'roles', notNull: true },
+  { childTable: 'role_permissions', constraint: 'role_permissions_role_id_roles_id_fk', parentTable: 'roles', notNull: true },
+  { childTable: 'script_to_tags', constraint: 'script_to_tags_tag_id_script_tags_id_fk', parentTable: 'script_tags', notNull: true },
+  { childTable: 'config_policy_compliance_rules', constraint: 'config_policy_compliance_rules_remediation_script_id_scripts_id', parentTable: 'scripts', notNull: false },
+  { childTable: 'patch_policies', constraint: 'patch_policies_post_install_script_id_scripts_id_fk', parentTable: 'scripts', notNull: false },
+  { childTable: 'patch_policies', constraint: 'patch_policies_pre_install_script_id_scripts_id_fk', parentTable: 'scripts', notNull: false },
+  { childTable: 'script_to_tags', constraint: 'script_to_tags_script_id_scripts_id_fk', parentTable: 'scripts', notNull: true },
+  { childTable: 'script_versions', constraint: 'script_versions_script_id_scripts_id_fk', parentTable: 'scripts', notNull: true },
+  { childTable: 'snmp_alert_thresholds', constraint: 'snmp_alert_thresholds_device_id_snmp_devices_id_fk', parentTable: 'snmp_devices', notNull: true },
+  { childTable: 'ticket_comments', constraint: 'ticket_comments_ticket_id_tickets_id_fk', parentTable: 'tickets', notNull: true },
+  { childTable: 'access_review_items', constraint: 'access_review_items_reviewed_by_users_id_fk', parentTable: 'users', notNull: false },
+  { childTable: 'access_review_items', constraint: 'access_review_items_user_id_users_id_fk', parentTable: 'users', notNull: true },
+  { childTable: 'accounting_connections', constraint: 'accounting_connections_connected_by_fkey', parentTable: 'users', notNull: false },
+  { childTable: 'ai_tool_executions', constraint: 'ai_tool_executions_approved_by_users_id_fk', parentTable: 'users', notNull: false },
+  { childTable: 'authenticator_policies', constraint: 'authenticator_policies_updated_by_user_id_fkey', parentTable: 'users', notNull: false },
+  { childTable: 'catalog_items', constraint: 'catalog_items_created_by_fkey', parentTable: 'users', notNull: false },
+  { childTable: 'config_policy_assignments', constraint: 'config_policy_assignments_assigned_by_users_id_fk', parentTable: 'users', notNull: false },
+  { childTable: 'mobile_devices', constraint: 'mobile_devices_user_id_users_id_fk', parentTable: 'users', notNull: true },
+  { childTable: 'mobile_sessions', constraint: 'mobile_sessions_user_id_users_id_fk', parentTable: 'users', notNull: true },
+  { childTable: 'network_known_guests', constraint: 'network_known_guests_added_by_users_id_fk', parentTable: 'users', notNull: false },
+  { childTable: 'office_addin_user_bindings', constraint: 'office_addin_bindings_user_partner_fk', parentTable: 'users', notNull: true },
+  { childTable: 'office_addin_user_bindings', constraint: 'office_addin_user_bindings_revoked_by_fkey', parentTable: 'users', notNull: false },
+  { childTable: 'office_addin_user_bindings', constraint: 'office_addin_user_bindings_user_id_fkey', parentTable: 'users', notNull: true },
+  { childTable: 'partner_service_principal_keys', constraint: 'partner_service_principal_keys_created_by_fkey', parentTable: 'users', notNull: true },
+  { childTable: 'partner_service_principals', constraint: 'partner_service_principals_created_by_fkey', parentTable: 'users', notNull: true },
+  { childTable: 'partner_service_principals', constraint: 'partner_service_principals_updated_by_fkey', parentTable: 'users', notNull: true },
+  { childTable: 'partner_users', constraint: 'partner_users_user_id_users_id_fk', parentTable: 'users', notNull: true },
+  { childTable: 'patch_approvals', constraint: 'patch_approvals_approved_by_users_id_fk', parentTable: 'users', notNull: false },
+  { childTable: 'patch_policies', constraint: 'patch_policies_created_by_users_id_fk', parentTable: 'users', notNull: false },
+  { childTable: 'patch_rollbacks', constraint: 'patch_rollbacks_initiated_by_users_id_fk', parentTable: 'users', notNull: false },
+  { childTable: 'pax8_integrations', constraint: 'pax8_integrations_created_by_fkey', parentTable: 'users', notNull: false },
+  { childTable: 'push_notifications', constraint: 'push_notifications_user_id_users_id_fk', parentTable: 'users', notNull: true },
+  { childTable: 'script_versions', constraint: 'script_versions_created_by_users_id_fk', parentTable: 'users', notNull: false },
+  { childTable: 'sessions', constraint: 'sessions_user_id_users_id_fk', parentTable: 'users', notNull: true },
+  { childTable: 'stripe_connect_accounts', constraint: 'stripe_connect_accounts_connected_by_fkey', parentTable: 'users', notNull: false },
+  { childTable: 'td_synnex_digital_bridge_integrations', constraint: 'td_synnex_digital_bridge_integrations_created_by_fkey', parentTable: 'users', notNull: false },
+  { childTable: 'td_synnex_ec_express_integrations', constraint: 'td_synnex_ec_express_integrations_created_by_fkey', parentTable: 'users', notNull: false },
+  { childTable: 'td_synnex_sftp_integrations', constraint: 'td_synnex_sftp_integrations_created_by_fkey', parentTable: 'users', notNull: false },
+  { childTable: 'ticket_comments', constraint: 'ticket_comments_user_id_users_id_fk', parentTable: 'users', notNull: false },
+  { childTable: 'ticket_mailbox_connections', constraint: 'ticket_mailbox_connections_created_by_fkey', parentTable: 'users', notNull: false },
+  { childTable: 'ticket_mailbox_consent_sessions', constraint: 'ticket_mailbox_consent_sessions_user_id_fkey', parentTable: 'users', notNull: false },
+  { childTable: 'ticket_mailbox_tenant_ownerships', constraint: 'ticket_mailbox_tenant_ownerships_verified_by_fkey', parentTable: 'users', notNull: false },
+  { childTable: 'ticket_response_templates', constraint: 'ticket_response_templates_created_by_fkey', parentTable: 'users', notNull: false },
+  { childTable: 'unifi_integrations', constraint: 'unifi_integrations_created_by_fkey', parentTable: 'users', notNull: false },
+]);
+
+/**
+ * FKs into org-cascade tables with no `ON DELETE`, whose child table IS
+ * emptied first by an `ASSOCIATED_SYSTEM_SCOPED_TABLES` pre-clear in
+ * `services/tenantCascade.ts`. These are handled, not debt.
+ *
+ * They are still pinned one-by-one rather than waved through per table,
+ * because the pre-clear is hand-written SQL: `psa_ticket_mappings` needs three
+ * separate arms to cover its three FKs, and a FOURTH FK added to that table
+ * would be silently uncovered if table membership alone satisfied the
+ * contract. Adding an FK to a pre-clear table therefore reds this test and
+ * forces the author to open `clearSql` and check it.
+ *
+ * Sorted by (parentTable, childTable, constraint), same as above.
+ */
+export const ORG_CASCADE_FK_PRE_CLEARED: ReadonlyArray<OrgCascadeFkRef> = Object.freeze([
+  { childTable: 'psa_ticket_mappings', constraint: 'psa_ticket_mappings_alert_id_alerts_id_fk', parentTable: 'alerts', notNull: false },
+  { childTable: 'deployment_results', constraint: 'deployment_results_device_id_devices_id_fk', parentTable: 'devices', notNull: true },
+  { childTable: 'device_commands', constraint: 'device_commands_device_id_devices_id_fk', parentTable: 'devices', notNull: true },
+  { childTable: 'psa_ticket_mappings', constraint: 'psa_ticket_mappings_device_id_devices_id_fk', parentTable: 'devices', notNull: false },
+  { childTable: 'psa_ticket_mappings', constraint: 'psa_ticket_mappings_connection_id_psa_connections_id_fk', parentTable: 'psa_connections', notNull: true },
+  { childTable: 'report_runs', constraint: 'report_runs_report_id_reports_id_fk', parentTable: 'reports', notNull: true },
+  { childTable: 'software_versions', constraint: 'software_versions_catalog_id_software_catalog_id_fk', parentTable: 'software_catalog', notNull: true },
+  { childTable: 'deployment_results', constraint: 'deployment_results_deployment_id_software_deployments_id_fk', parentTable: 'software_deployments', notNull: true },
+  { childTable: 'sso_sessions', constraint: 'sso_sessions_provider_id_sso_providers_id_fk', parentTable: 'sso_providers', notNull: true },
+  { childTable: 'user_sso_identities', constraint: 'user_sso_identities_provider_id_sso_providers_id_fk', parentTable: 'sso_providers', notNull: true },
+  {
+    childTable: 'device_commands',
+    constraint: 'device_commands_created_by_users_id_fk',
+    parentTable: 'users',
+    notNull: false,
+    note:
+      'The device_commands pre-clear keys off device_id only, so a command a user of THIS org '
+      + 'queued against ANOTHER org\'s device would survive the pre-clear and then pin `users`. '
+      + 'Cross-org queuing should be impossible under RLS, but nothing here proves it.',
+  },
+  { childTable: 'user_sso_identities', constraint: 'user_sso_identities_user_id_users_id_fk', parentTable: 'users', notNull: true },
+]);


### PR DESCRIPTION
## Problem

`cascadeDeleteOrg()` erases a tenant with a sequence of ordinary DELETE statements, each in its own system context — **not** one big deferred transaction, so Postgres checks every referencing FK as each statement runs:

- **step 1b** — each `ASSOCIATED_SYSTEM_SCOPED_TABLES` entry, in array order, with its own hand-written WHERE join;
- **step 2** — every table in `getOrgCascadeDeleteOrder()`, ordered children-before-parents by `topologicalCascadeOrder()`'s live `pg_constraint` read (`organizations` itself keyed on `id`).

A foreign key pointing at any table those statements touch is a latent erasure failure unless something clears the referencing rows first. Erasure then works right up until a customer creates the first row in the referencing table, and after that aborts mid-way leaving the tenant half-deleted. That is exactly how #4100 shipped (`webhook_deliveries.webhook_id → webhooks.id`, fixed in #4412), and the sweep on that PR found ~73 more edges with the same shape.

Nothing guarded it. `tenantCascade.integration.test.ts` checks list membership and topological ordering *within* the cascade set, but never looks at inbound edges from outside it, or at `confdeltype` at all. Neither does the RLS coverage contract or the export-policy roundtrip.

## What this adds

A read-only `pg_constraint` contract test at `apps/api/src/__tests__/integration/orgCascadeFkOnDelete.integration.test.ts`, plus a seeded ledger (`orgCascadeFkOnDeleteAllowlist.ts`) generated from a live migrated database so it lands green on day one.

`protectedTables` = the cascade set + the step-1b pre-clear targets + everything transitively reachable from those by an `ON DELETE CASCADE` edge (301 + 9 + 34 = 343 tables). For an edge `child → parent` with `parent` in that set, the edge is safe when:

| | Condition |
|---|---|
| a | `ON DELETE CASCADE` — and the child is itself protected by the closure, so its own inbound edges get audited |
| b | `ON DELETE SET NULL` **and** every column Postgres would actually null (`confdelsetcols`, else `conkey`) is nullable |
| c | the child is a pre-clear target whose pre-clear runs before the parent's DELETE |
| d | both ends are in the cascade set, so the topo sort puts the child first |
| e | self-referential **and** the table's `org_id` is NOT NULL |

Everything else must be pinned:

| List | Count | Meaning |
|---|---|---|
| `ORG_CASCADE_FK_UNSAFE` | 74 | Debt. Expected to **shrink**. |
| `ORG_CASCADE_FK_PRE_CLEARED` | 17 | Handled by a step-1b pre-clear. Not debt. |

## Three live erasure bugs this surfaced

Not latent shapes — these fire today for any tenant with the relevant rows. All three are pinned with their SQLSTATE and fix rather than repaired here, since #4519 is explicitly scoped to making the debt visible.

1. **`restore_jobs.command_id → device_commands`** (NO ACTION). `device_commands` is emptied in **step 1b**, before the cascade walk that empties `restore_jobs` — so any org that has run a restore driven by a device command aborts erasure at step 1b with **23503**.
2. **`action_intents_scope_ticket_org_fk → tickets`** (SET NULL). Nulls `(scope_ticket_id, org_id)` with no `confdelsetcols`, and `action_intents.org_id` is **NOT NULL**. Postgres accepts that at DDL time and fails at delete time with **23502** — a different SQLSTATE from everything else in the ledger.
3. **`script_categories.parent_id`** (self-referential, NO ACTION). `script_categories.org_id` is **nullable** (partner-wide categories, epic #2135), so `DELETE ... WHERE org_id = $1` does not remove a row set closed under the self-reference: a surviving partner-wide category pointing at an org-owned one raises **23503**. Reproduced directly against Postgres 16.

## Anti-rot — so the ledger can't become permanent scar tissue

- A **stale entry** (FK dropped, renamed, given an `ON DELETE`, or its child table joined the cascade set) fails the burn-down test, so a migration that fixes an edge forces the matching line out in the same PR.
- Each entry's `parentTable`, `reason` and `allColumnsNullable` are **recomputed and verified** against the catalog, never trusted. `reason` says which failure this is; `allColumnsNullable` answers the question a burn-down actually asks — is a plain `ON DELETE SET NULL` even legal here.
- A **`note` is required** for any reason other than the ordinary `child-not-deleted` shape. That is what makes the three findings above impossible to file silently.
- The two lists are mutually exclusive by contract, in both directions.
- Lists stay sorted and duplicate-free, so adding or burning down an entry is a one-line diff.
- A non-vacuity control asserts the graph is large and that **all nine** inputs the classifier discriminates on are actually present (each delete action, self-reference, child-in-cascade, child-with-pre-clear, composite FK) — a broken or dead branch cannot read green.

## Review round

`codex exec` (gpt-5.6, read-only, `high`) — the subagent pool was saturated, so the independent review went through Codex. It raised 6 blockers, 8 should-fix, 3 nits. Every substantive claim was verified against the live database before acting; four were real and are fixed:

- **only cascade-list tables audited as parents** → pre-clear targets are DELETE targets too (found bug 1);
- **`SET NULL` waved through unconditionally** → now checks the nulled columns (found bug 2);
- **self-references exempted outright** → the argument needs row-set *closure*, which nullable `org_id` breaks (found bug 3);
- **`CASCADE` treated as terminal** → cascading into a table makes that table's inbound FKs get checked, hence the transitive closure (+34 tables, +3 pinned edges).

One review finding corrected me on Postgres semantics: my first cut asserted no FK into a cascade table may use `RESTRICT`, on the theory that RESTRICT is checked per row. That is **wrong** — RESTRICT is an AFTER ROW trigger, and a single-statement delete of a closed self-referential row set succeeds under RESTRICT exactly as under NO ACTION (verified empirically). The assertion is gone; row-set closure, modelled directly by (e), is what actually decides it. Also fixed from review: namespace filters now apply to partition **roots** as well as physical relations; a new test asserts no FK is declared directly on a partition (which would make the `(table, constraint)` ledger key ambiguous after root-folding *and* disagree with `topologicalCascadeOrder()`, which reads raw relnames); two pre-clear entries whose `clearSql` keys off a different column than the FK now say so; and several header claims were corrected.

Declined: moving to the `rls-coverage`-style dedicated runner. Measured setup overhead is well under a second per test against a 25-minute shard budget, and the shared glob means no hand-maintained CI step to fall out of date. The trade-off is now recorded in the test header.

## Scope

The **org** cascade only — `CORE_DEVICE_CASCADE_DELETE_TABLES` and the partner purge are separate contracts. **No migrations, no production code change.**

Two gaps the header states plainly: it cannot see a cross-tenant row (org B's child pointing at org A's parent still breaks erasure under (c)/(d); RLS is what prevents that), and it cannot read a pre-clear's `clearSql` to confirm the join reaches the rows a given FK pins — which is why pre-clear FKs are pinned per constraint, not per table, so a fourth FK on `psa_ticket_mappings` reds the test instead of slipping through.

## Verification (local, real Postgres 16)

- New suite: **7 passed**; with `tenantCascade.integration.test.ts`: **12 passed**.
- `test:integration-suite-coverage`: **5 passed** — confirms the file is matched by an include glob and really runs in the blocking shard.
- `tsc --noEmit` clean; `eslint` clean on both files.
- **Mutation-proved every assertion discriminates.** Each of these reds the expected test and only that test:
  - drop a ledger entry → main contract fails naming it;
  - bogus entry → burn-down fails; corrupt a `reason` → drift fails;
  - unsort / duplicate an entry → hygiene fails; strip a required note → hygiene fails;
  - misfile an entry between the two lists → mutual-exclusion fails;
  - **real DDL:** a new table with a NO ACTION FK into `devices` → fails naming it (`ON DELETE CASCADE` version stays green); a NO ACTION FK into a **CASCADE-closure-only** table (`webhook_deliveries`) → fails, proving the closure branch is live; a `SET NULL` FK onto a NOT NULL column → fails as `set-null-onto-not-null`; an FK declared directly on a partition → partition guard fails;
  - **partition control:** creating `metric_rollups_y2099m01` keeps the suite green, so the monthly partitions cannot rot the ledger.

Closes #4519
Refs #4100, #4412, #3880

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBxF7C8E5GxFnNcGf6kBVP
