### PR TITLE
fix(agent/viewer): sync Caps Lock state instead of forwarding it as a key (#3595)

### DIFF
--- a/agent/internal/heartbeat/desktop_validation_test.go
+++ b/agent/internal/heartbeat/desktop_validation_test.go
@@ -123,3 +123,56 @@ func TestNormalizeDesktopInputEventRejectsInvalidFields(t *testing.T) {
 		}
 	}
 }
+
+// The WebSocket fallback transport rebuilds desktop.InputEvent field by field
+// from the raw map, so a field that is not explicitly copied is silently
+// dropped. Caps Lock state has to survive that relay or issue #3595 stays
+// broken on every session that falls back off WebRTC.
+func TestNormalizeDesktopInputEventCarriesCapsLockState(t *testing.T) {
+	t.Parallel()
+
+	for _, want := range []bool{true, false} {
+		event, err := normalizeDesktopInputEvent(map[string]any{
+			"type":     "key_down",
+			"key":      "a",
+			"capsLock": want,
+		})
+		if err != nil {
+			t.Fatalf("normalizeDesktopInputEvent error = %v", err)
+		}
+		if event.CapsLock == nil {
+			t.Fatalf("capsLock=%v was dropped by the relay", want)
+		}
+		if *event.CapsLock != want {
+			t.Fatalf("capsLock = %v, want %v", *event.CapsLock, want)
+		}
+	}
+}
+
+// Absent means "this viewer does not state Caps Lock state", which the agent
+// must be able to tell apart from an explicit false — hence a *bool.
+func TestNormalizeDesktopInputEventLeavesCapsLockUnsetWhenAbsent(t *testing.T) {
+	t.Parallel()
+
+	event, err := normalizeDesktopInputEvent(map[string]any{"type": "key_down", "key": "a"})
+	if err != nil {
+		t.Fatalf("normalizeDesktopInputEvent error = %v", err)
+	}
+	if event.CapsLock != nil {
+		t.Fatalf("capsLock = %v, want nil for a viewer that did not state it", *event.CapsLock)
+	}
+}
+
+func TestNormalizeDesktopInputEventRejectsNonBooleanCapsLock(t *testing.T) {
+	t.Parallel()
+
+	for _, bad := range []any{"true", float64(1), []any{true}} {
+		if _, err := normalizeDesktopInputEvent(map[string]any{
+			"type":     "key_down",
+			"key":      "a",
+			"capsLock": bad,
+		}); err == nil {
+			t.Fatalf("expected capsLock=%#v (%T) to be rejected", bad, bad)
+		}
+	}
+}

--- a/agent/internal/heartbeat/handlers_desktop.go
+++ b/agent/internal/heartbeat/handlers_desktop.go
@@ -631,6 +631,16 @@ func normalizeDesktopInputEvent(raw map[string]any) (desktop.InputEvent, error) 
 	}
 	event.Modifiers = modifiers
 
+	// This relay rebuilds the event field by field, so anything not copied here
+	// is dropped. Caps Lock state has to survive it or issue #3595 would stay
+	// broken on every session that falls back from WebRTC to the WebSocket
+	// transport.
+	capsLock, err := normalizeDesktopCapsLock(raw["capsLock"])
+	if err != nil {
+		return event, err
+	}
+	event.CapsLock = capsLock
+
 	switch event.Type {
 	case "mouse_click", "mouse_down", "mouse_up":
 		if event.Button == "" {
@@ -647,6 +657,20 @@ func normalizeDesktopInputEvent(raw map[string]any) (desktop.InputEvent, error) 
 	}
 
 	return event, nil
+}
+
+// normalizeDesktopCapsLock reads the viewer's Caps Lock assertion. Absent stays
+// absent (nil) rather than collapsing to false — the agent distinguishes "the
+// viewer did not state it" from "the viewer says it is off".
+func normalizeDesktopCapsLock(value any) (*bool, error) {
+	if value == nil {
+		return nil, nil
+	}
+	state, ok := value.(bool)
+	if !ok {
+		return nil, fmt.Errorf("invalid capsLock")
+	}
+	return &state, nil
 }
 
 func readDesktopCoordinate(value any) (int, error) {

--- a/agent/internal/remote/desktop/input.go
+++ b/agent/internal/remote/desktop/input.go
@@ -9,6 +9,14 @@ type InputEvent struct {
 	Key       string   `json:"key,omitempty"`       // Key code or character
 	Modifiers []string `json:"modifiers,omitempty"` // "ctrl", "alt", "shift", "meta"
 	Delta     int      `json:"delta,omitempty"`     // Scroll delta
+
+	// CapsLock is the viewer's Caps Lock state at the moment this event was
+	// produced. A pointer, because "the viewer did not say" (nil) has to be
+	// distinguishable from "the viewer says Caps Lock is off" (false): only the
+	// latter lets the agent take ownership of the AlphaShift bit. Viewers that
+	// predate issue #3595 never set it, and those sessions keep the platform
+	// handler's original behaviour.
+	CapsLock *bool `json:"capsLock,omitempty"`
 }
 
 // InputHandler processes input events

--- a/agent/internal/remote/desktop/input_capslock.go
+++ b/agent/internal/remote/desktop/input_capslock.go
@@ -7,10 +7,15 @@ import "strings"
 // a press the agent has to interpret. See issue #3595.
 //
 // This file is deliberately untagged: the policy below is pure Go and is what
-// the CI unit job can actually execute. The platform job runs
-// `CGO_ENABLED=0 go test ./...` on Linux, so anything living in the
-// `darwin && cgo` input file is compiled by the macOS *build* job and never
-// covered by a test anywhere.
+// CI can actually execute. The blocking agent job runs
+// `CGO_ENABLED=0 go test ./...` on Linux, which never compiles the
+// `darwin && cgo` input file at all. That file IS compiled by two macOS jobs
+// (`build-agent darwin/arm64`, and `test-agent-race`'s
+// `CGO_ENABLED=1 go test -race ./...`), so it is type-checked in CI — but the
+// package has no `_darwin_test.go`, and injecting real CGEvents on a shared
+// runner is not something a test should do, so no test anywhere *executes*
+// the injection glue. Keeping the decisions here rather than there is what
+// puts them under the blocking job.
 const capsLockKeyName = "capslock"
 
 // cgEventFlagMaskAlphaShift is kCGEventFlagMaskAlphaShift from

--- a/agent/internal/remote/desktop/input_capslock.go
+++ b/agent/internal/remote/desktop/input_capslock.go
@@ -1,0 +1,61 @@
+package desktop
+
+import "strings"
+
+// Caps Lock is a toggle at the OS/HID layer, not a key that is "held", so the
+// viewer states the resulting state on every keyboard event instead of sending
+// a press the agent has to interpret. See issue #3595.
+//
+// This file is deliberately untagged: the policy below is pure Go and is what
+// the CI unit job can actually execute. The platform job runs
+// `CGO_ENABLED=0 go test ./...` on Linux, so anything living in the
+// `darwin && cgo` input file is compiled by the macOS *build* job and never
+// covered by a test anywhere.
+const capsLockKeyName = "capslock"
+
+// cgEventFlagMaskAlphaShift is kCGEventFlagMaskAlphaShift from
+// CoreGraphics/CGEventTypes.h — the Caps Lock bit in a CGEventFlags mask.
+// Duplicated as an untyped constant (rather than read through cgo) so the flag
+// arithmetic can be unit-tested off a Mac.
+const cgEventFlagMaskAlphaShift = 0x00010000
+
+// isCapsLockKey reports whether a viewer key name refers to Caps Lock.
+func isCapsLockKey(key string) bool {
+	return strings.ToLower(strings.TrimSpace(key)) == capsLockKeyName
+}
+
+// applyCapsLockFlag folds the viewer's Caps Lock assertion into a CGEventFlags
+// mask.
+//
+// The second return value is what preserves backward compatibility: a viewer
+// that predates issue #3595 sends no state at all, so `capsLock` is nil, and
+// the caller must keep its existing behaviour rather than assuming "off". Only
+// when the viewer actually states the state does the agent take ownership of
+// the bit.
+//
+// Note that "off" CLEARS the bit rather than merely not setting it. The mask
+// the caller passes in can already carry a latched AlphaShift picked up from
+// the remote machine's ambient modifier state — that latch is exactly the
+// desync behind #3595's intermittent uppercase output.
+func applyCapsLockFlag(flags int, capsLock *bool) (int, bool) {
+	if capsLock == nil {
+		return flags, false
+	}
+	if *capsLock {
+		return flags | cgEventFlagMaskAlphaShift, true
+	}
+	return flags &^ cgEventFlagMaskAlphaShift, true
+}
+
+// suppressCapsLockKey reports whether a keyboard event for the Caps Lock key
+// should be swallowed rather than injected.
+//
+// True only when the viewer states its Caps Lock state: that state already
+// rides on every keystroke, so the key itself has nothing left to do, and
+// synthesising macOS keycode 0x39 is what desynced the remote AlphaShift state
+// to begin with (macOS reports Caps Lock via flagsChanged, not as a key press,
+// so a synthetic down/up pair either does nothing or latches a state nothing
+// clears). A viewer that states nothing keeps today's injection.
+func suppressCapsLockKey(key string, capsLock *bool) bool {
+	return capsLock != nil && isCapsLockKey(key)
+}

--- a/agent/internal/remote/desktop/input_capslock_test.go
+++ b/agent/internal/remote/desktop/input_capslock_test.go
@@ -1,0 +1,106 @@
+package desktop
+
+import "testing"
+
+// The reported symptom of issue #3595 is inconsistent casing, so the exact bit
+// matters: kCGEventFlagMaskAlphaShift is 1<<16. A typo here would silently set
+// some other modifier (Shift is 1<<17) and "fix" the bug into a different one.
+func TestAlphaShiftMaskIsTheCoreGraphicsValue(t *testing.T) {
+	t.Parallel()
+
+	if got, want := cgEventFlagMaskAlphaShift, 0x00010000; got != want {
+		t.Fatalf("cgEventFlagMaskAlphaShift = %#x, want %#x", got, want)
+	}
+}
+
+func TestIsCapsLockKey(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"capslock", "CapsLock", "  CAPSLOCK  "} {
+		if !isCapsLockKey(name) {
+			t.Fatalf("isCapsLockKey(%q) = false, want true", name)
+		}
+	}
+	for _, name := range []string{"caps", "a", "numlock", ""} {
+		if isCapsLockKey(name) {
+			t.Fatalf("isCapsLockKey(%q) = true, want false", name)
+		}
+	}
+}
+
+// A viewer that never states the Caps Lock state must keep the agent on its
+// legacy path byte-for-byte. This is the whole backward-compatibility contract:
+// an old viewer talking to a new agent behaves exactly as it does today.
+func TestApplyCapsLockFlagAbsentLeavesFlagsAndReportsNotAuthoritative(t *testing.T) {
+	t.Parallel()
+
+	flags, authoritative := applyCapsLockFlag(0x00040000, nil)
+	if authoritative {
+		t.Fatal("a nil assertion must not be treated as authoritative")
+	}
+	if got, want := flags, 0x00040000; got != want {
+		t.Fatalf("flags = %#x, want them untouched (%#x)", got, want)
+	}
+}
+
+func TestApplyCapsLockFlagSetsAndClearsWithoutDisturbingOtherModifiers(t *testing.T) {
+	t.Parallel()
+
+	const ctrl = 0x00040000
+
+	on, authoritative := applyCapsLockFlag(ctrl, boolPtr(true))
+	if !authoritative {
+		t.Fatal("an explicit assertion must be authoritative")
+	}
+	if got, want := on, ctrl|cgEventFlagMaskAlphaShift; got != want {
+		t.Fatalf("caps-on flags = %#x, want %#x", got, want)
+	}
+
+	// Caps off must CLEAR the bit rather than merely not set it: the incoming
+	// mask can already carry a latched AlphaShift, which is the desync of #3595.
+	off, authoritative := applyCapsLockFlag(ctrl|cgEventFlagMaskAlphaShift, boolPtr(false))
+	if !authoritative {
+		t.Fatal("an explicit assertion must be authoritative")
+	}
+	if got, want := off, ctrl; got != want {
+		t.Fatalf("caps-off flags = %#x, want %#x (AlphaShift cleared, ctrl kept)", got, want)
+	}
+}
+
+func TestApplyCapsLockFlagIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	once, _ := applyCapsLockFlag(0, boolPtr(true))
+	twice, _ := applyCapsLockFlag(once, boolPtr(true))
+	if once != twice {
+		t.Fatalf("re-asserting the same state changed flags: %#x then %#x", once, twice)
+	}
+}
+
+func TestSuppressCapsLockKey(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		key      string
+		capsLock *bool
+		want     bool
+	}{
+		{"asserted caps lock key is suppressed", "capslock", boolPtr(true), true},
+		{"asserted caps lock key is suppressed when off too", "CapsLock", boolPtr(false), true},
+		// The backward-compatibility case: an older viewer states nothing, so
+		// the key keeps being injected exactly as it is today.
+		{"unasserted caps lock key still injects", "capslock", nil, false},
+		{"ordinary keys are never suppressed", "a", boolPtr(true), false},
+		{"other lock keys are never suppressed", "numlock", boolPtr(true), false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := suppressCapsLockKey(tc.key, tc.capsLock); got != tc.want {
+				t.Fatalf("suppressCapsLockKey(%q, %v) = %v, want %v", tc.key, tc.capsLock, got, tc.want)
+			}
+		})
+	}
+}

--- a/agent/internal/remote/desktop/input_capslock_test.go
+++ b/agent/internal/remote/desktop/input_capslock_test.go
@@ -104,3 +104,36 @@ func TestSuppressCapsLockKey(t *testing.T) {
 		})
 	}
 }
+
+// sendKeyDown/sendKeyUp derive two things from one call — the flags to post and
+// whether to call CGEventSetFlags at all (capsLockSetFlags). They only stay in
+// step if "authoritative" means exactly "the viewer stated a state". Pinned as
+// its own invariant so a later simplification of the two-value contract cannot
+// quietly decouple them.
+func TestApplyCapsLockFlagAuthoritativeMeansTheViewerStatedIt(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		capsLock *bool
+	}{
+		{"absent", nil},
+		{"stated on", boolPtr(true)},
+		{"stated off", boolPtr(false)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			const base = 0x00040000 // ctrl, an unrelated modifier
+			got, authoritative := applyCapsLockFlag(base, tc.capsLock)
+			if want := tc.capsLock != nil; authoritative != want {
+				t.Fatalf("authoritative = %v, want %v", authoritative, want)
+			}
+			// Non-authoritative must additionally be a pure pass-through.
+			if !authoritative && got != base {
+				t.Fatalf("non-authoritative call changed flags: %#x -> %#x", base, got)
+			}
+		})
+	}
+}

--- a/agent/internal/remote/desktop/input_darwin.go
+++ b/agent/internal/remote/desktop/input_darwin.go
@@ -643,10 +643,20 @@ func (h *DarwinInputHandler) SendMouseScroll(x, y int, delta int) error {
 }
 
 func (h *DarwinInputHandler) SendKeyPress(key string, modifiers []string) error {
+	return h.sendKeyPress(key, modifiers, nil)
+}
+
+// sendKeyPress is SendKeyPress plus the viewer's Caps Lock assertion. capsLock
+// is nil for callers that have no state to assert (the exported interface
+// method, the AI computer-use paths), and those behave exactly as before.
+func (h *DarwinInputHandler) sendKeyPress(key string, modifiers []string, capsLock *bool) error {
 	if !h.inputAvailable {
 		return errInputUnavailable
 	}
 	key = normalizeKeyName(key)
+	if suppressCapsLockKey(key, capsLock) {
+		return nil
+	}
 	keycode, ok := keyNameToKeycode[key]
 	if !ok {
 		return fmt.Errorf("unknown key: %s", key)
@@ -657,7 +667,12 @@ func (h *DarwinInputHandler) SendKeyPress(key string, modifiers []string) error 
 	// held from an earlier event bleed in, which is the stuck-Shift uppercasing
 	// of issue #4089. The IOHIDPostEvent path already passes flags on every
 	// event, so it needs no equivalent.
-	flags := modifiersToFlags(modifiers)
+	//
+	// modifiersToFlags never carries AlphaShift, so without the fold below a
+	// key_press would strip Caps Lock while a bare key_down (which inherits the
+	// ambient flags) kept it — the inconsistent casing reported in #3595.
+	rawFlags, _ := applyCapsLockFlag(int(modifiersToFlags(modifiers)), capsLock)
+	flags := C.int(rawFlags)
 	switch {
 	case h.shouldUseHID():
 		C.hidKeyDown(C.int(keycode), flags)
@@ -708,43 +723,72 @@ func (h *DarwinInputHandler) TypeChar(ch rune) error {
 }
 
 func (h *DarwinInputHandler) SendKeyDown(key string) error {
+	return h.sendKeyDown(key, nil)
+}
+
+func (h *DarwinInputHandler) sendKeyDown(key string, capsLock *bool) error {
 	if !h.inputAvailable {
 		return errInputUnavailable
 	}
 	key = normalizeKeyName(key)
+	if suppressCapsLockKey(key, capsLock) {
+		return nil
+	}
 	keycode, ok := keyNameToKeycode[key]
 	if !ok {
 		return fmt.Errorf("unknown key: %s", key)
 	}
+	flags, authoritative := applyCapsLockFlag(0, capsLock)
+	setFlags := capsLockSetFlags(authoritative)
 	switch {
 	case h.shouldUseHID():
-		C.hidKeyDown(C.int(keycode), 0)
+		C.hidKeyDown(C.int(keycode), C.int(flags))
 	case h.shouldUseSessionTap():
-		C.sessionKeyDown(C.int(keycode), 0, 0)
+		C.sessionKeyDown(C.int(keycode), C.int(flags), setFlags)
 	default:
-		C.inputKeyDown(C.int(keycode), 0, 0)
+		C.inputKeyDown(C.int(keycode), C.int(flags), setFlags)
 	}
 	return nil
 }
 
 func (h *DarwinInputHandler) SendKeyUp(key string) error {
+	return h.sendKeyUp(key, nil)
+}
+
+func (h *DarwinInputHandler) sendKeyUp(key string, capsLock *bool) error {
 	if !h.inputAvailable {
 		return errInputUnavailable
 	}
 	key = normalizeKeyName(key)
+	if suppressCapsLockKey(key, capsLock) {
+		return nil
+	}
 	keycode, ok := keyNameToKeycode[key]
 	if !ok {
 		return fmt.Errorf("unknown key: %s", key)
 	}
+	flags, authoritative := applyCapsLockFlag(0, capsLock)
+	setFlags := capsLockSetFlags(authoritative)
 	switch {
 	case h.shouldUseHID():
-		C.hidKeyUp(C.int(keycode), 0)
+		C.hidKeyUp(C.int(keycode), C.int(flags))
 	case h.shouldUseSessionTap():
-		C.sessionKeyUp(C.int(keycode), 0, 0)
+		C.sessionKeyUp(C.int(keycode), C.int(flags), setFlags)
 	default:
-		C.inputKeyUp(C.int(keycode), 0, 0)
+		C.inputKeyUp(C.int(keycode), C.int(flags), setFlags)
 	}
 	return nil
+}
+
+// capsLockSetFlags picks the C helpers' setFlags argument. Only a viewer that
+// actually stated its Caps Lock state earns the unconditional CGEventSetFlags
+// call; without one we keep the ambient-flags branch that Shift+Click and
+// friends rely on (see the setFlags contract on inputKeyDown above).
+func capsLockSetFlags(authoritative bool) C.int {
+	if authoritative {
+		return 1
+	}
+	return 0
 }
 
 func (h *DarwinInputHandler) HandleEvent(event InputEvent) error {
@@ -763,11 +807,11 @@ func (h *DarwinInputHandler) HandleEvent(event InputEvent) error {
 	case "mouse_scroll":
 		return h.SendMouseScroll(event.X, event.Y, event.Delta)
 	case "key_press":
-		return h.SendKeyPress(event.Key, event.Modifiers)
+		return h.sendKeyPress(event.Key, event.Modifiers, event.CapsLock)
 	case "key_down":
-		return h.SendKeyDown(event.Key)
+		return h.sendKeyDown(event.Key, event.CapsLock)
 	case "key_up":
-		return h.SendKeyUp(event.Key)
+		return h.sendKeyUp(event.Key, event.CapsLock)
 	default:
 		return fmt.Errorf("unknown event type: %s", event.Type)
 	}

--- a/agent/internal/remote/desktop/input_darwin.go
+++ b/agent/internal/remote/desktop/input_darwin.go
@@ -780,10 +780,17 @@ func (h *DarwinInputHandler) sendKeyUp(key string, capsLock *bool) error {
 	return nil
 }
 
-// capsLockSetFlags picks the C helpers' setFlags argument. Only a viewer that
-// actually stated its Caps Lock state earns the unconditional CGEventSetFlags
-// call; without one we keep the ambient-flags branch that Shift+Click and
-// friends rely on (see the setFlags contract on inputKeyDown above).
+// capsLockSetFlags picks the C helpers' setFlags argument (see the setFlags
+// contract on inputKeyDown above). Only a viewer that actually stated its Caps
+// Lock state earns the unconditional CGEventSetFlags call; without one the
+// ambient-flags branch is preserved unchanged.
+//
+// Worth knowing before assuming this endangers held modifiers: it cannot, on
+// this platform. keyNameToKeycode below has no "shift"/"ctrl"/"alt"/"meta"
+// entries, so the viewer's standalone modifier key_down/key_up return
+// "unknown key" before reaching either branch — the agent never holds a
+// modifier on macOS, and the ambient flags this branch preserves are the
+// remote console's own physical state, not anything the agent set.
 func capsLockSetFlags(authoritative bool) C.int {
 	if authoritative {
 		return 1

--- a/apps/api/src/routes/desktopWs.ts
+++ b/apps/api/src/routes/desktopWs.ts
@@ -94,6 +94,13 @@ export const desktopInputEvent = z.object({
   deltaX: z.number().optional(),
   deltaY: z.number().optional(),
   code: z.string().max(50).optional(),
+  // Viewer's Caps Lock state at the moment the event was produced (issue
+  // #3595). Zod strips undeclared keys, so omitting this would silently drop
+  // the field on the WebSocket fallback transport and leave those sessions
+  // with the desynced-AlphaShift bug that WebRTC sessions no longer have.
+  // Optional, never defaulted: an older Viewer sends nothing and the agent
+  // keeps its previous behaviour.
+  capsLock: z.boolean().optional(),
 });
 
 const desktopMessageSchema = z.discriminatedUnion('type', [

--- a/apps/api/src/routes/desktopWs_inputSchema.test.ts
+++ b/apps/api/src/routes/desktopWs_inputSchema.test.ts
@@ -207,6 +207,14 @@ describe('desktopWs input schema — Viewer coverage', () => {
     expect(result.success && result.data.capsLock).toBeUndefined();
   });
 
+  it('tolerates a stray capsLock on a non-keyboard event', () => {
+    // The schema is one flat object rather than a per-type union. Pinning this
+    // keeps a later refactor into a discriminated union from rejecting mouse
+    // events that happen to carry the field.
+    const result = desktopInputEvent.safeParse({ type: 'mouse_move', x: 1, y: 1, capsLock: true });
+    expect(result.success).toBe(true);
+  });
+
   it('rejects a non-boolean capsLock', () => {
     expect(desktopInputEvent.safeParse({ type: 'key_down', key: 'a', capsLock: 'yes' }).success).toBe(false);
   });

--- a/apps/api/src/routes/desktopWs_inputSchema.test.ts
+++ b/apps/api/src/routes/desktopWs_inputSchema.test.ts
@@ -185,4 +185,29 @@ describe('desktopWs input schema — Viewer coverage', () => {
     const result = desktopInputEvent.safeParse({ type: 'definitely_not_a_real_kind' });
     expect(result.success).toBe(false);
   });
+
+  // Zod strips unknown keys, so a field the Viewer sends but this schema does
+  // not declare is silently dropped on the WebSocket fallback transport —
+  // which is how a WebRTC-only fix for issue #3595 would quietly not apply
+  // to fallback sessions.
+  it.each(['key_down', 'key_up', 'key_press'])(
+    'preserves the Caps Lock state carried on %s',
+    (kind) => {
+      for (const capsLock of [true, false]) {
+        const result = desktopInputEvent.safeParse({ type: kind, key: 'a', capsLock });
+        expect(result.success).toBe(true);
+        expect(result.success && result.data.capsLock).toBe(capsLock);
+      }
+    }
+  );
+
+  it('leaves capsLock undefined when the Viewer does not state it', () => {
+    const result = desktopInputEvent.safeParse({ type: 'key_down', key: 'a' });
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.capsLock).toBeUndefined();
+  });
+
+  it('rejects a non-boolean capsLock', () => {
+    expect(desktopInputEvent.safeParse({ type: 'key_down', key: 'a', capsLock: 'yes' }).success).toBe(false);
+  });
 });

--- a/apps/viewer/src/components/DesktopViewer.capsLock.test.ts
+++ b/apps/viewer/src/components/DesktopViewer.capsLock.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+// Vite's ?raw import hands us the file as a string. Used instead of node:fs
+// because apps/viewer is a browser-targeted package with no @types/node, and
+// pulling those in for one test would change type resolution package-wide.
+import source from './DesktopViewer.tsx?raw';
+
+/**
+ * Source-derived guard for the Caps Lock wiring in DesktopViewer (issue #3595).
+ *
+ * The fix only works if EVERY keyboard event forwarded from a real
+ * KeyboardEvent carries the `capsLock` state. Miss one call site and that key
+ * silently falls back to the agent's legacy path, where it inherits the remote
+ * machine's ambient AlphaShift — i.e. the original bug, reappearing for one
+ * key, intermittently. That is not the kind of regression a reviewer catches by
+ * eye.
+ *
+ * A behavioural test would be better, but apps/viewer has no React test harness
+ * at all (no @testing-library/react, no *.test.tsx), and standing one up for a
+ * 2,200-line component is its own piece of work. So this asserts over the
+ * source text instead — the same approach desktopWs_inputSchema.test.ts already
+ * takes against this very file.
+ */
+
+/**
+ * Emits that legitimately omit `capsLock`, each with the reason it is not a
+ * real keystroke. Adding to this list should require the same justification.
+ */
+const SYNTHETIC_EMITS_WITHOUT_CAPS_STATE = new Map<string, string>([
+  [
+    "sendInputFn({ type: 'key_up', key });",
+    'releaseAllKeys: a bulk release of keys stranded in pressedKeysRef. There ' +
+      'is no KeyboardEvent to read a state from, and releasing a key cannot ' +
+      'change casing.',
+  ],
+  [
+    "sendInputFn({ type: 'key_press', key, modifiers });",
+    'handleSendKeys: toolbar combos (Ctrl+Alt+Del and friends) are pressed by ' +
+      'a button, not typed, so they are deliberately Caps Lock independent.',
+  ],
+]);
+
+function keyboardEmits(): string[] {
+  return source.match(/sendInputFn\(\{ type: 'key_[a-z]+'[^)]*\)/g) ?? [];
+}
+
+describe('DesktopViewer Caps Lock wiring (issue #3595)', () => {
+  const emits = keyboardEmits();
+
+  it('actually found the keyboard emit sites (guards against a vacuous regex)', () => {
+    // If the regex ever matches nothing — a refactor renames sendInputFn, say —
+    // the assertion below would pass over an empty list and this guard would go
+    // silently green while protecting nothing.
+    expect(emits.length).toBeGreaterThanOrEqual(9);
+    expect(emits.some((e) => e.includes("type: 'key_down'"))).toBe(true);
+    expect(emits.some((e) => e.includes("type: 'key_up'"))).toBe(true);
+    expect(emits.some((e) => e.includes("type: 'key_press'"))).toBe(true);
+  });
+
+  it('every keyboard emit either carries capsLock or is a known synthetic emit', () => {
+    const offenders = emits.filter((emit) => {
+      if (emit.includes('capsLock')) return false;
+      return !SYNTHETIC_EMITS_WITHOUT_CAPS_STATE.has(`${emit};`);
+    });
+
+    expect(
+      offenders,
+      'These keyboard events are forwarded without the operator\'s Caps Lock ' +
+        'state, so the agent falls back to inheriting the remote machine\'s ' +
+        'ambient AlphaShift for them (issue #3595). Add `capsLock` to the ' +
+        'emit, or add it to SYNTHETIC_EMITS_WITHOUT_CAPS_STATE with a reason ' +
+        'if it is not a real keystroke.'
+    ).toEqual([]);
+  });
+
+  it('both handlers read the live state rather than a cached one', () => {
+    // Per-event state is what makes this resilient to the input DataChannel
+    // being unreliable (maxRetransmits: 0). A cached "last sent" value would
+    // reintroduce the desync a dropped packet causes.
+    const reads = source.match(/const capsLock = getCapsLockState\(ne\);/g) ?? [];
+    expect(reads).toHaveLength(2); // handleKeyDown + handleKeyUp
+  });
+
+  it('CapsLock never enters the pressed-key bookkeeping', () => {
+    // pressedKeysRef drives releaseAllKeys. Caps Lock is a toggle and is never
+    // "held", so adding it would strand it and emit a release for a key that
+    // was never pressed.
+    expect(source).not.toMatch(/pressedKeysRef\.current\.add\(\s*'capslock'\s*\)/);
+  });
+});

--- a/apps/viewer/src/components/DesktopViewer.tsx
+++ b/apps/viewer/src/components/DesktopViewer.tsx
@@ -12,7 +12,7 @@ import { capabilitiesFor, type TransportCapabilities } from '../lib/transports/t
 import type { VncSessionWrapper } from '../lib/transports/vnc';
 import { createVncTunnel, closeTunnel, retryVncTunnel, type VncTunnelInfo } from '../lib/tunnel';
 import { pollDesktopAccess } from '../lib/desktopAccess';
-import { mapKey, getModifiers, isModifierOnly } from '../lib/keymap';
+import { mapKey, getModifiers, isModifierOnly, isCapsLock, getCapsLockState } from '../lib/keymap';
 import { sendPasteText, pasteFailureMessage } from '../lib/pasteText';
 import { createInputCapabilitiesGate } from '../lib/inputCapabilities';
 import { DEFAULT_WHEEL_ACCUMULATOR, wheelDeltaToSteps } from '../lib/wheel';
@@ -1659,12 +1659,18 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
     e.preventDefault();
 
+    const ne = e.nativeEvent;
+    // Every forwarded keyboard event states the Caps Lock state it was typed
+    // under, so the agent sets the remote modifier flags explicitly instead of
+    // inheriting whatever the remote machine had latched (issue #3595).
+    const capsLock = getCapsLockState(ne);
+
     // Modifier keys pressed alone: forward as key_down so Shift+Click,
     // Ctrl+Click, etc. hold the modifier on the remote machine for
     // multi-select. Skip the rest of the handler (no modifiers bundle,
     // no paste shortcut — those are handled when a non-modifier follows).
-    if (isModifierOnly(e.nativeEvent)) {
-      let modKey = mapKey(e.nativeEvent);
+    if (isModifierOnly(ne)) {
+      let modKey = mapKey(ne);
       if (!modKey) return;
       if (remapCmdCtrl) {
         if (modKey === 'ctrl') modKey = 'meta';
@@ -1673,12 +1679,24 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
       if (e.repeat) return;
       if (pressedKeysRef.current.has(modKey)) return;
       pressedKeysRef.current.add(modKey);
-      sendInputFn({ type: 'key_down', key: modKey });
+      sendInputFn({ type: 'key_down', key: modKey, capsLock });
+      return;
+    }
+
+    // Caps Lock is a toggle, so it is deliberately kept OUT of pressedKeysRef:
+    // it is never "held", and macOS reports it as keydown-on-engage /
+    // keyup-on-disengage rather than a matched pair, so pairing bookkeeping
+    // would strand it in the set and later emit a bogus release. The event is
+    // still forwarded — an agent that predates #3595 keeps doing what it does
+    // today with it, while a current agent reads the capsLock field and skips
+    // injecting the key entirely.
+    if (isCapsLock(ne)) {
+      if (e.repeat) return;
+      sendInputFn({ type: 'key_down', key: 'capslock', capsLock });
       return;
     }
 
     // Ctrl+Shift+V / Cmd+Shift+V → paste as keystrokes
-    const ne = e.nativeEvent;
     if (ne.code === 'KeyV' && ne.shiftKey && (ne.ctrlKey || ne.metaKey)) {
       handlePasteAsKeystrokes();
       return;
@@ -1712,7 +1730,9 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
         );
       }
       const dispatchPaste = () => {
-        if (pasteKey) sendInputFn({ type: 'key_press', key: pasteKey, modifiers: pasteModifiers });
+        // capsLock is captured from the original event: this dispatches after
+        // an await, by which point the live modifier state may have moved on.
+        if (pasteKey) sendInputFn({ type: 'key_press', key: pasteKey, modifiers: pasteModifiers, capsLock });
       };
       const waitForAck = (hash: string, timeoutMs: number): Promise<void> => {
         if (!hash) return Promise.resolve();
@@ -1751,32 +1771,43 @@ export default function DesktopViewer({ params, onDisconnect, onError }: Props) 
     // If any modifier is held, fall back to the agent's key_press (which applies modifiers).
     // Otherwise, use key_down/key_up for proper "held key" semantics.
     if (modifiers.length > 0) {
-      sendInputFn({ type: 'key_press', key, modifiers });
+      sendInputFn({ type: 'key_press', key, modifiers, capsLock });
       return;
     }
 
     if (e.repeat) return;
     if (pressedKeysRef.current.has(key)) return;
     pressedKeysRef.current.add(key);
-    sendInputFn({ type: 'key_down', key });
+    sendInputFn({ type: 'key_down', key, capsLock });
   }, [sendInputFn, handlePasteAsKeystrokes, remapCmdCtrl]);
 
   const handleKeyUp = useCallback((e: React.KeyboardEvent) => {
     e.preventDefault();
 
-    let key = mapKey(e.nativeEvent);
+    const ne = e.nativeEvent;
+    const capsLock = getCapsLockState(ne);
+
+    // Caps Lock never enters pressedKeysRef (see handleKeyDown), so its release
+    // is forwarded unconditionally rather than gated on membership. On macOS
+    // this is the ONLY event fired when Caps Lock is disengaged.
+    if (isCapsLock(ne)) {
+      sendInputFn({ type: 'key_up', key: 'capslock', capsLock });
+      return;
+    }
+
+    let key = mapKey(ne);
     if (!key) return;
 
     // Apply the same ctrl↔meta remap used on key_down so the agent sees
     // the matching release for the key that was pressed.
-    if (isModifierOnly(e.nativeEvent) && remapCmdCtrl) {
+    if (isModifierOnly(ne) && remapCmdCtrl) {
       if (key === 'ctrl') key = 'meta';
       else if (key === 'meta') key = 'ctrl';
     }
 
     if (!pressedKeysRef.current.has(key)) return;
     pressedKeysRef.current.delete(key);
-    sendInputFn({ type: 'key_up', key });
+    sendInputFn({ type: 'key_up', key, capsLock });
   }, [sendInputFn, remapCmdCtrl]);
 
   // ── Toolbar: config changes ────────────────────────────────────────

--- a/apps/viewer/src/lib/keymap.test.ts
+++ b/apps/viewer/src/lib/keymap.test.ts
@@ -38,6 +38,14 @@ describe('caps lock (issue #3595)', () => {
     expect(isCapsLock(evt({ code: 'KeyA', key: 'a' }))).toBe(false);
   });
 
+  it('identifies CapsLock from either code or key alone', () => {
+    // Both halves of the OR are load-bearing: webviews vary in which of the
+    // two they populate, and missing the key means the toggle falls through to
+    // the ordinary-key path that issue #3595 is about.
+    expect(isCapsLock(evt({ code: '', key: 'CapsLock' }))).toBe(true);
+    expect(isCapsLock(evt({ code: 'CapsLock', key: 'Unidentified' }))).toBe(true);
+  });
+
   it('is not classified as a modifier-only key', () => {
     // isModifierOnly gates the "hold this modifier down" branch, which would
     // latch capslock in pressedKeysRef and later emit a bogus key_up.

--- a/apps/viewer/src/lib/keymap.test.ts
+++ b/apps/viewer/src/lib/keymap.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mapKey, getModifiers, isModifierOnly } from './keymap';
+import { mapKey, getModifiers, isModifierOnly, isCapsLock, getCapsLockState } from './keymap';
 
 describe('keymap', () => {
   it('maps known KeyboardEvent.code values', () => {
@@ -30,3 +30,40 @@ describe('keymap', () => {
   });
 });
 
+describe('caps lock (issue #3595)', () => {
+  const evt = (init: KeyboardEventInit) => new KeyboardEvent('keydown', init);
+
+  it('identifies the CapsLock key by physical code', () => {
+    expect(isCapsLock(evt({ code: 'CapsLock', key: 'CapsLock' }))).toBe(true);
+    expect(isCapsLock(evt({ code: 'KeyA', key: 'a' }))).toBe(false);
+  });
+
+  it('is not classified as a modifier-only key', () => {
+    // isModifierOnly gates the "hold this modifier down" branch, which would
+    // latch capslock in pressedKeysRef and later emit a bogus key_up.
+    expect(isModifierOnly(evt({ code: 'CapsLock', key: 'CapsLock' }))).toBe(false);
+  });
+
+  it('reads the live CapsLock state off any key event', () => {
+    expect(getCapsLockState(evt({ code: 'KeyA', key: 'a', modifierCapsLock: true }))).toBe(true);
+    expect(getCapsLockState(evt({ code: 'KeyA', key: 'a' }))).toBe(false);
+  });
+
+  it('reports state on the CapsLock key event itself', () => {
+    // macOS reports CapsLock as keydown-on-engage / keyup-on-disengage rather
+    // than a matched pair, so each event has to carry the resulting state.
+    expect(getCapsLockState(evt({ code: 'CapsLock', key: 'CapsLock', modifierCapsLock: true }))).toBe(true);
+    expect(
+      getCapsLockState(new KeyboardEvent('keyup', { code: 'CapsLock', key: 'CapsLock' }))
+    ).toBe(false);
+  });
+
+  it('does not report caps lock merely because shift is held', () => {
+    expect(getCapsLockState(evt({ code: 'KeyA', key: 'A', shiftKey: true }))).toBe(false);
+  });
+
+  it('falls back to false when the platform has no getModifierState', () => {
+    const stub = { getModifierState: undefined } as unknown as KeyboardEvent;
+    expect(getCapsLockState(stub)).toBe(false);
+  });
+});

--- a/apps/viewer/src/lib/keymap.ts
+++ b/apps/viewer/src/lib/keymap.ts
@@ -89,3 +89,35 @@ export function getModifiers(e: KeyboardEvent): string[] {
 export function isModifierOnly(e: KeyboardEvent): boolean {
   return ['Control', 'Alt', 'Shift', 'Meta'].includes(e.key);
 }
+
+/**
+ * Check if a key event is the Caps Lock key itself.
+ *
+ * Deliberately NOT folded into isModifierOnly: that predicate drives the
+ * "hold this modifier down on the remote machine" branch, and Caps Lock is a
+ * toggle rather than a key that is held. Treating it as held would latch it in
+ * the pressed-key set and emit a release for a key that was never held.
+ */
+export function isCapsLock(e: KeyboardEvent): boolean {
+  return e.code === 'CapsLock' || e.key === 'CapsLock';
+}
+
+/**
+ * Read the Caps Lock state that is in effect for this key event.
+ *
+ * Every keyboard event we forward carries this, so the remote machine's Caps
+ * Lock state is asserted rather than inferred from a synthetic key press
+ * (issue #3595). Two reasons it is per-event rather than sent once on change:
+ *
+ *  - The input DataChannel is ordered but UNRELIABLE (maxRetransmits: 0), so a
+ *    single dropped "caps changed" message would leave the agent applying the
+ *    wrong state to every keystroke for the rest of the session.
+ *  - macOS reports Caps Lock as keydown-on-engage / keyup-on-disengage rather
+ *    than a matched down/up pair, so there is no reliable edge to count.
+ *
+ * getModifierState is guarded because the Viewer also runs against synthetic
+ * events in tests and older webviews.
+ */
+export function getCapsLockState(e: KeyboardEvent): boolean {
+  return typeof e.getModifierState === 'function' && e.getModifierState('CapsLock');
+}


### PR DESCRIPTION
Closes #3595

## The bug

macOS Remote Desktop sessions produced intermittent uppercase output while the operator's Caps Lock was off — and the casing was **inconsistent within a single session**, which is what made it hard to pin down.

Two paths disagreed about the AlphaShift bit:

| Path | Flags behaviour | Result with a latched remote Caps Lock |
|---|---|---|
| bare `key_down`/`key_up` | `inputKeyDown(kc, 0, 0)` never calls `CGEventSetFlags`, so the event inherits the remote machine's **ambient** flags | inherits `kCGEventFlagMaskAlphaShift` → **UPPERCASE** |
| `key_press` (viewer holds a modifier) | sets flags unconditionally from `modifiersToFlags`, which never carries AlphaShift | strips it → lowercase |

Same keyboard, same session, two different answers.

Nothing ever cleared the latch, either. CapsLock was forwarded as an ordinary key and injected as macOS keycode `0x39`, but macOS reports Caps Lock via `flagsChanged` rather than as a key press — so the synthetic down/up pair could not toggle the state it appeared to.

## The fix

**Caps Lock is state, not an event.** The Viewer reads `getModifierState('CapsLock')` and stamps `capsLock` on every keyboard event it forwards. The macOS agent sets the event flags explicitly from that assertion and stops injecting the Caps Lock key itself.

### Why per-event instead of a change notification

The input DataChannel is `{ ordered: true, maxRetransmits: 0 }` — ordered but **unreliable**. A single dropped "caps changed" message would leave the agent applying the wrong state to every later keystroke, turning one lost packet into a session-long casing bug. That is precisely the class of bug being fixed here. Level-triggered state is self-healing; edge counting is not.

It also sidesteps macOS reporting Caps Lock as keydown-on-engage / keyup-on-disengage rather than a matched pair — there is no reliable edge to count in the first place.

### Backward compatibility

`InputEvent.CapsLock` is a `*bool`, and compatibility rides on the field being **absent**:

- `nil` — this viewer does not state Caps Lock state. Every platform keeps its exact current behaviour. Covers both older Viewers and the Windows/Linux agents this change does not touch.
- `true`/`false` — the agent takes ownership of the AlphaShift bit.

No capability handshake is needed. Unlike the `input_capabilities` handshake from #4089, this also works on the **WebSocket fallback transport**, which has no control channel at all.

### Two relays that would have silently dropped the field

Both rebuild input events field by field, so an undeclared field vanishes. Missing either would have limited the fix to WebRTC sessions on a current API:

- `apps/api/src/routes/desktopWs.ts` — Zod strips undeclared keys
- `normalizeDesktopInputEvent` in the agent's WebSocket command relay

Both now carry it, and both are covered by tests.

## Deliberately out of scope

IOKit `IOHIDSetModifierLockState` to move the remote machine's **global** lock state and LED. The per-event flags fully determine the casing of injected keystrokes; the IOKit setter ignores individual property-set failures so success cannot be verified, it has side effects for a physical user at the remote console, and no CI test could exercise it. Worth revisiting only if someone reports a stale LED.

## Note on where the tests live

The **blocking** CI agent job is `CGO_ENABLED=0 go test ./...` on Linux, which never compiles the `darwin && cgo` input file at all. That file *is* compiled by two macOS jobs — `build-agent darwin/arm64` and `test-agent-race` (`CGO_ENABLED=1 go test -race ./...`) — so it is type-checked in CI. But the package has no `_darwin_test.go`, and injecting real CGEvents on a shared runner is not something a test should do, so **no test anywhere executes the injection glue**.

The policy — flag folding, key suppression, the AlphaShift mask value — therefore lives in an untagged `input_capslock.go` with untagged tests, which is what puts those decisions under the job that gates merges. The cgo file is left as thin glue.

## Review round (second commit)

Two independent reviews ran; both flagged the same real gap, and it is now closed.

- **`DesktopViewer.tsx` wiring had no coverage.** `apps/viewer` has no React test harness at all (no `@testing-library/react`, no `*.test.tsx`), so `DesktopViewer.capsLock.test.ts` asserts over the source text — the approach `desktopWs_inputSchema.test.ts` already takes against this same file. It pins that every keyboard emit carries `capsLock` (with two listed synthetic exceptions, each with its reason recorded), that both handlers read the state live rather than from a cache, and that Caps Lock never enters `pressedKeysRef`. Each assertion was **mutation-verified** against a deliberately broken source rather than assumed.
- **A reviewer raised a possible Shift+Click regression** from `key_down`/`key_up` now setting flags explicitly. Resolved: `keyNameToKeycode` has no `shift`/`ctrl`/`alt`/`meta` entries, so the viewer's standalone modifier `key_down` returns `unknown key` *before* reaching either branch. The agent never holds a modifier on macOS — that path was already a no-op error and is unchanged here. (Shift+Click against a macOS *target* is a separate pre-existing limitation, not touched by this PR.)
- **Two comments stated CI facts inaccurately** and were corrected — the note above, and `capsLockSetFlags`.
- Three smaller test gaps closed: `applyCapsLockFlag`'s two return values pinned to agree, both halves of `isCapsLock`'s code/key OR proven load-bearing, and the flat Zod schema pinned to tolerate a stray `capsLock` on a mouse event.

## Verification

- Agent `CGO_ENABLED=0 go test` green — `internal/remote/desktop` + `internal/heartbeat`
- `darwin/arm64` cgo `go vet` **and** `go build` green; also darwin-nocgo, linux, windows builds
- Full Viewer suite: 23 files, **253 passed**
- All 8 `desktopWs` API suites: **99 passed**
- Viewer and API `tsc --noEmit` clean

All new tests were written first and observed failing for the right reason before implementing.

## Human check worth doing before release

This is injected-input behaviour on a real Mac, which no test in this repo can reach. Suggested manual pass on a macOS target: type mixed case with Caps Lock off, engage Caps Lock and confirm the remote uppercases, disengage and confirm it stops, and confirm Shift+letter still inverts correctly while Caps Lock is on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBxF7C8E5GxFnNcGf6kBVP

