### PR TITLE
refactor(approvals): share the batch-grouping rule via @breeze/shared and extract the inbox helpers (#4457, #4456)

### DIFF
--- a/apps/api/src/services/approvals/batchDecide.test.ts
+++ b/apps/api/src/services/approvals/batchDecide.test.ts
@@ -377,6 +377,35 @@ describe('decideApprovalBatch', () => {
     expect(vi.mocked(db.transaction)).not.toHaveBeenCalled();
   });
 
+  // (b3) same tool AND action, but a DIFFERENT customer org. This axis is the
+  // one a drift would hurt most — a fleet sweep proposes the identical
+  // `(tool, action)` across every org a partner manages, so if `orgId` ever
+  // fell out of the key the whole 422 would silently become "approve all of
+  // these, everywhere" off ONE ceremony. Covered end-to-end here, not just as
+  // a key-equality unit check, so the org axis has the same defence in depth
+  // the tool and action axes already have.
+  it('422s for the same tool and action under a DIFFERENT org', async () => {
+    const batchRows = [
+      { approval: buildApproval(1), intent: buildIntent(1) },
+      { approval: buildApproval(2), intent: buildIntent(2, { orgId: 'org-other' }) },
+    ];
+    mockDb({ batchRows });
+    mockDecideTx();
+
+    const res = await decideApprovalBatch(AUTH, {
+      approvalRequestIds: ['appr-1', 'appr-2'],
+      decision: 'approved',
+    });
+
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.httpStatus).toBe(422);
+    expect(res.body).toEqual({ error: 'batch_not_homogeneous', offending: ['appr-2'] });
+    // Nothing decided, and no assertion ceremony consumed.
+    expect(vi.mocked(assertApprovalAssurance)).not.toHaveBeenCalled();
+    expect(vi.mocked(db.transaction)).not.toHaveBeenCalled();
+  });
+
   // (c)
   it('422s when a FOUR-EYES card is in the set', async () => {
     const batchRows = [

--- a/apps/api/src/services/approvals/batchDecide.test.ts
+++ b/apps/api/src/services/approvals/batchDecide.test.ts
@@ -113,7 +113,14 @@ import { approvalRequests } from '../../db/schema/approvals';
 import { actionIntents } from '../../db/schema/actionIntents';
 import { assertApprovalAssurance, StepUpRequiredError } from '../authenticatorAssurance';
 import { isAgentIntentDecideAuthorized } from '../actionIntents/intentApprovers';
-import { BATCH_MAX, batchAssertionKey, decideApprovalBatch } from './batchDecide';
+import { approvalBatchGroupKey } from '@breeze/shared';
+import { serialize } from './decideApprovalRequest';
+import {
+  BATCH_MAX,
+  batchAssertionKey,
+  batchGroupKey,
+  decideApprovalBatch,
+} from './batchDecide';
 
 const USER_ID = '00000000-0000-0000-0000-000000000001';
 
@@ -612,5 +619,105 @@ describe('decideApprovalBatch', () => {
     expect(res.httpStatus).toBe(422);
     expect(res.body).toEqual({ error: 'batch_not_homogeneous', offending: ['appr-2'] });
     expect(vi.mocked(assertApprovalAssurance)).not.toHaveBeenCalled();
+  });
+});
+
+
+/**
+ * #4457 — the batch-grouping rule now has ONE definition
+ * (`approvalBatchGroupKey` in `@breeze/shared`) and two consumers: this
+ * service, which refuses a heterogeneous set, and the web inbox, which offers
+ * "Approve all (N)" over rows it believes share a key.
+ *
+ * The web never sees a DB row — it sees the DTO `serialize` projects. So the
+ * contract that actually has to hold is: **the key the server enforces off a
+ * loaded row equals the key the shared helper produces from that same row's
+ * serialized DTO.** That is what these cases drive, end to end through the real
+ * `serialize`, rather than re-asserting the shared unit tests.
+ *
+ * A regression here is not cosmetic: a looser server key would let ONE
+ * assertion ceremony cover a set of approvals the approver never read as a
+ * single decision.
+ */
+describe('batchGroupKey cross-equivalence with the inbox DTO (#4457)', () => {
+  /** Exactly what `GET /approvals/pending` hands the inbox for this row, then
+   *  exactly what the inbox does with it (`groupIdentity` in
+   *  `components/approvals/approvalGrouping.ts` calls the shared helper with
+   *  the DTO itself). */
+  function inboxKey(approval: any, intent: any): string {
+    const dto = serialize(
+      approval,
+      null,
+      intent.approvalScope,
+      {
+        id: intent.id,
+        requestingAgentRunId: intent.requestingAgentRunId,
+        requestingClientLabel: intent.requestingClientLabel,
+      },
+      null,
+      intent.orgId,
+      'Acme Corp',
+    );
+    return approvalBatchGroupKey(dto);
+  }
+
+  const cases: Array<{ name: string; args: Record<string, unknown> }> = [
+    { name: 'an ordinary multiplexed action', args: { deviceId: 'dev-1', action: 'restart' } },
+    {
+      name: 'an action spelled with stray case and whitespace',
+      args: { deviceId: 'dev-1', action: '  ReStart ' },
+    },
+    { name: 'a tool with no action discriminator', args: { deviceId: 'dev-1' } },
+    { name: 'an explicit null action', args: { deviceId: 'dev-1', action: null } },
+    { name: 'a non-string action', args: { deviceId: 'dev-1', action: { nested: 'restart' } } },
+    { name: 'an empty-string action', args: { deviceId: 'dev-1', action: '' } },
+  ];
+
+  for (const { name, args } of cases) {
+    it(`agrees with the inbox for ${name}`, () => {
+      const intent = buildIntent(1);
+      const approval = buildApproval(1, { actionArguments: args });
+      expect(batchGroupKey({ approval, intent } as any)).toBe(inboxKey(approval, intent));
+    });
+  }
+
+  it('collapses two cosmetically different spellings of the same action into ONE key', () => {
+    const intent = buildIntent(1);
+    const plain = buildApproval(1, { actionArguments: { action: 'restart' } });
+    const noisy = buildApproval(2, { actionArguments: { action: '  RESTART  ' } });
+    expect(batchGroupKey({ approval: noisy, intent } as any)).toBe(
+      batchGroupKey({ approval: plain, intent } as any),
+    );
+    expect(inboxKey(noisy, intent)).toBe(inboxKey(plain, intent));
+  });
+
+  it('keeps a DIFFERENT action in a different group — on BOTH sides', () => {
+    const intent = buildIntent(1);
+    const restart = buildApproval(1, { actionArguments: { action: 'restart' } });
+    const stop = buildApproval(2, { actionArguments: { action: 'stop' } });
+    expect(batchGroupKey({ approval: stop, intent } as any)).not.toBe(
+      batchGroupKey({ approval: restart, intent } as any),
+    );
+    expect(inboxKey(stop, intent)).not.toBe(inboxKey(restart, intent));
+  });
+
+  it('keys off the LINKED INTENT org, so two orgs never share a group', () => {
+    const approval = buildApproval(1);
+    const orgA = buildIntent(1, { orgId: 'org-a' });
+    const orgB = buildIntent(1, { orgId: 'org-b' });
+    expect(batchGroupKey({ approval, intent: orgB } as any)).not.toBe(
+      batchGroupKey({ approval, intent: orgA } as any),
+    );
+    expect(inboxKey(approval, orgB)).not.toBe(inboxKey(approval, orgA));
+  });
+
+  it('keeps a different tool in a different group', () => {
+    const intent = buildIntent(1);
+    const services = buildApproval(1, { actionToolName: 'manage_services' });
+    const patches = buildApproval(2, { actionToolName: 'manage_patches' });
+    expect(batchGroupKey({ approval: patches, intent } as any)).not.toBe(
+      batchGroupKey({ approval: services, intent } as any),
+    );
+    expect(inboxKey(patches, intent)).not.toBe(inboxKey(services, intent));
   });
 });

--- a/apps/api/src/services/approvals/batchDecide.ts
+++ b/apps/api/src/services/approvals/batchDecide.ts
@@ -13,7 +13,12 @@ import {
   type AssuranceDecision,
 } from '../authenticatorAssurance';
 import { decideApprovalRequest, type DecideApprovalResult } from './decideApprovalRequest';
-import { APPROVAL_BATCH_MAX, type ApprovalProof, type RiskTier } from '@breeze/shared';
+import {
+  APPROVAL_BATCH_MAX,
+  approvalBatchGroupKey,
+  type ApprovalProof,
+  type RiskTier,
+} from '@breeze/shared';
 
 /**
  * P2-2 (#4189): decide MANY approval cards with ONE assertion ceremony.
@@ -91,30 +96,28 @@ export type DecideApprovalBatchResult =
 const RISK_TIER_ORDER: RiskTier[] = ['low', 'medium', 'high', 'critical'];
 
 /**
- * The multiplexed tools' `action` discriminator (`manage_services:restart`,
- * `manage_patches:install`, …), lower-cased and trimmed so a purely cosmetic
- * difference in how two intents spelled the same action does not split an
- * otherwise identical set. Null for a tool that is not action-multiplexed —
- * which is itself a group of its own, so a set that mixes "has an action" with
- * "has none" is heterogeneous.
+ * `(orgId, actionToolName, normalized action)` — the whole homogeneity key, for
+ * ONE loaded batch member.
  *
- * Deliberately the same projection `serialize` emits as `action`: the group the
- * server enforces is the group the approver saw on the cards.
+ * The rule itself lives in `@breeze/shared`'s `approvalBatchGroupKey` (#4457),
+ * NOT here: the web inbox groups its cards with that exact function, so the set
+ * the server will accept and the set the approver was offered can no longer
+ * drift apart. This wrapper only says which fields of a loaded row feed it — in
+ * particular that `action` comes from the row's RAW `action_arguments`, which is
+ * deliberately the same value `serialize` projects as the DTO's `action`, so the
+ * group the server enforces is the group the approver saw on the cards.
+ *
+ * Exported for the cross-equivalence cases in `batchDecide.test.ts`, which
+ * drive one fixture through this AND through `serialize` -> the shared key, and
+ * assert the two agree.
  */
-function normalizedAction(row: typeof approvalRequests.$inferSelect): string | null {
-  const args = row.actionArguments as Record<string, unknown> | null;
-  const action = args?.action;
-  return typeof action === 'string' ? action.trim().toLowerCase() : null;
-}
-
-/** `(orgId, actionToolName, normalized action)` — the whole homogeneity key.
- *  NUL-separated so no value can forge a boundary. */
-function groupKey(row: BatchRow): string {
-  return [
-    row.intent.orgId,
-    row.approval.actionToolName,
-    normalizedAction(row.approval) ?? '',
-  ].join('\u0000');
+export function batchGroupKey(row: BatchRow): string {
+  const args = row.approval.actionArguments as Record<string, unknown> | null;
+  return approvalBatchGroupKey({
+    orgId: row.intent.orgId,
+    actionToolName: row.approval.actionToolName,
+    action: args?.action,
+  });
 }
 
 /**
@@ -203,9 +206,9 @@ export async function loadHomogeneousBatch(
   // reported so the client can deselect precisely.
   const anchor = rows[0];
   if (anchor) {
-    const anchorKey = groupKey(anchor);
+    const anchorKey = batchGroupKey(anchor);
     for (const row of rows) {
-      if (groupKey(row) !== anchorKey) offending.push(row.approval.id);
+      if (batchGroupKey(row) !== anchorKey) offending.push(row.approval.id);
     }
   }
 

--- a/apps/web/src/components/approvals/ApprovalsInbox.tsx
+++ b/apps/web/src/components/approvals/ApprovalsInbox.tsx
@@ -29,6 +29,20 @@ import { ConfirmDialog } from '../shared/ConfirmDialog';
 import { EmptyState } from '../shared/EmptyState';
 import { PageHeader } from '../shared/PageHeader';
 import { showToast } from '../shared/Toast';
+import {
+  buildOrgOptions,
+  buildSections,
+  clusterByOrg,
+  groupHostnameSummary,
+  isExpired,
+  isGroupable,
+  matchesSearch,
+  sortRows,
+  type ApprovalGroup,
+  type PendingApproval,
+  type RiskTier,
+  type SortOrder,
+} from './approvalGrouping';
 
 const LIVE_REFETCH_DEBOUNCE_MS = 750;
 /** WS is only a nudge; polling is the guarantee. useEventStream gives up
@@ -57,7 +71,6 @@ const ALWAYS_ALLOW_ORG_BATCH_SIZE = 5;
 const APPROVAL_EVENTS = ['notification.created'];
 const UNAUTHORIZED = () => void navigateTo(loginPathWithNext(), { replace: true });
 
-type RiskTier = 'low' | 'medium' | 'high' | 'critical';
 type DecisionErrorKind =
   | 'noApproverDevice'
   | 'notSoleApprover'
@@ -74,291 +87,12 @@ type DecisionErrorKind =
  *  nothing was decided, so they belong above the cards, not on one of them. */
 type GroupErrorKind = DecisionErrorKind | 'batchStepUp' | 'batchNotHomogeneous' | 'batchTooLarge';
 
-interface PendingApproval {
-  id: string;
-  requestingClientLabel: string;
-  requestingMachineLabel: string | null;
-  actionLabel: string;
-  actionToolName: string;
-  actionArguments: Record<string, unknown>;
-  riskTier: RiskTier;
-  riskSummary: string;
-  customerTenant: string | null;
-  status: 'pending';
-  expiresAt: string;
-  decidedAt: null;
-  decisionReason: null;
-  executionId: string | null;
-  intentId: string | null;
-  approvalScope: string | null;
-  isRecursive: boolean;
-  createdAt: string;
-  /** Wave 3b: who proposed this intent. Serialize emits it on every row;
-   *  anything but 'ai_agent' renders the classic requester attribution. */
-  origin: 'human' | 'ai_agent';
-  agentName: string | null;
-  /** P2-2: the linked intent's org, the multiplexed tools' `action`
-   *  discriminator, and the resolved target device. All three are null for a
-   *  row with no intent; `action` is also null for a non-multiplexed tool. */
-  orgId: string | null;
-  /** The `orgId` organization's display name, resolved server-side. Null for
-   *  a row with no intent (no orgId) or when the org row no longer exists —
-   *  either way the UI falls back to the "Unknown organization" copy. */
-  orgName: string | null;
-  action: string | null;
-  targetDevice: { id: string; hostname: string } | null;
-}
-
-/** One header + its cards: a set the server would accept as ONE decision. */
-interface ApprovalGroup {
-  /** Raw `(orgId, tool, action)` triple — the identity all state is keyed by. */
-  identity: string;
-  /** DOM-safe projection of the same triple, used only for `data-testid`. */
-  testKey: string;
-  /** What the header names the group after. */
-  tool: string;
-  members: PendingApproval[];
-}
-
-type Section =
-  | { kind: 'row'; approval: PendingApproval }
-  | { kind: 'group'; group: ApprovalGroup };
-
 const riskClass: Record<RiskTier, string> = {
   low: 'bg-sky-100 text-sky-800 dark:bg-sky-950/50 dark:text-sky-200',
   medium: 'bg-amber-100 text-amber-800 dark:bg-amber-950/50 dark:text-amber-200',
   high: 'bg-orange-100 text-orange-800 dark:bg-orange-950/50 dark:text-orange-200',
   critical: 'bg-red-100 text-red-800 dark:bg-red-950/50 dark:text-red-200',
 };
-
-/**
- * Exactly the server's batch eligibility rule (`loadHomogeneousBatch` in
- * `services/approvals/batchDecide.ts`): a SUPERVISED, AGENT-ORIGINATED, still
- * pending card. Four-eyes cards are excluded structurally — they are never
- * `supervised` — so the two-person rule can never be satisfied by a batch tap.
- *
- * The UI must only ever offer a batch the server would accept; a looser
- * predicate here does not weaken the server (it 422s the whole set), but it
- * does hand the approver a button that always fails.
- */
-function isGroupable(approval: PendingApproval): boolean {
-  return (
-    approval.origin === 'ai_agent' &&
-    approval.approvalScope === 'supervised' &&
-    approval.orgId !== null &&
-    // A CRITICAL card can never be batched. The batch route deliberately does
-    // not plumb `reauthVerified` (batchDecide.ts), so the L4 ladder a critical
-    // card has to clear is unsatisfiable in a batch and the whole set 401s
-    // `reauth_required` — a permanent dead end, since re-auth is collected per
-    // decision. The ceremony runs at the HIGHEST tier present, so ONE critical
-    // card would sink an otherwise decidable group; excluding it here leaves
-    // every critical card on the single-card path, which can collect re-auth.
-    approval.riskTier !== 'critical'
-  );
-}
-
-/** The server's `(orgId, actionToolName, normalized action)` homogeneity key,
- *  normalized the same way (trimmed, lower-cased) so a cosmetic difference in
- *  how two intents spelled the same action does not split the group. */
-function groupParts(approval: PendingApproval): string[] {
-  return [
-    approval.orgId ?? '',
-    approval.actionToolName,
-    (approval.action ?? '').trim().toLowerCase(),
-  ];
-}
-
-/** NUL-separated, exactly as the server joins it, so no value can forge a
- *  boundary between two fields. */
-function groupIdentity(approval: PendingApproval): string {
-  return groupParts(approval).join('\u0000');
-}
-
-/** DOM-safe rendering of the same triple. Lossy (distinct triples could in
- *  principle collapse), which is why it is used ONLY for `data-testid` while
- *  every decision keys off `groupIdentity`. */
-function groupTestKey(approval: PendingApproval): string {
-  return groupParts(approval)
-    .map((part) => part.replace(/[^A-Za-z0-9_-]+/g, '-'))
-    .join('--');
-}
-
-/**
- * Org is the OUTERMOST grouping (critique #1): two cards for different orgs
- * that happen to share a `(tool, action)` must never render adjacent to each
- * other as if they were the same request. This stable-sorts the rows so every
- * org's cards sit together, in the org's own first-appearance order, WITHOUT
- * touching each org's internal relative order — `buildSections` below still
- * decides tool/action grouping exactly as before, it just runs over rows
- * that are already clustered by org.
- *
- * Known, accepted trade-off: the server pages strictly by `createdAt`, but
- * this reclusters by org (first-appearance order). A "Load more" page's rows
- * can therefore land ABOVE some already-visible rows if they belong to an
- * org that appeared earlier in the list — no row is ever lost or hidden,
- * just not always appended at the visual bottom.
- */
-function clusterByOrg(rows: PendingApproval[]): PendingApproval[] {
-  const buckets = new Map<string, PendingApproval[]>();
-  const order: string[] = [];
-  for (const row of rows) {
-    const key = row.orgId ?? '';
-    const bucket = buckets.get(key);
-    if (bucket) bucket.push(row);
-    else {
-      buckets.set(key, [row]);
-      order.push(key);
-    }
-  }
-  return order.flatMap((key) => buckets.get(key)!);
-}
-
-type SortOrder = 'expiringSoonest' | 'newest';
-
-/** Case-insensitive substring match over the fields Priya (an MSP tech
- *  approving across dozens of orgs) scans an inbox by: the action label, the
- *  target machine's hostname, and the proposing agent's name. An empty or
- *  whitespace-only query matches every row. */
-function matchesSearch(approval: PendingApproval, query: string): boolean {
-  if (!query) return true;
-  const needle = query.toLowerCase();
-  return (
-    approval.actionLabel.toLowerCase().includes(needle) ||
-    (approval.targetDevice?.hostname.toLowerCase().includes(needle) ?? false) ||
-    (approval.agentName?.toLowerCase().includes(needle) ?? false)
-  );
-}
-
-/** One selectable option in the organization filter, in first-appearance
- *  order among the currently loaded rows. `key` is what the `<select>`
- *  stores and compares against — `orgId ?? ''` — so a null-`orgId` row
- *  groups under one synthetic "Unknown organization" option instead of
- *  splintering per row. */
-interface OrgFilterOption {
-  key: string;
-  name: string;
-  count: number;
-}
-
-function buildOrgOptions(rows: PendingApproval[], unknownLabel: string): OrgFilterOption[] {
-  const byKey = new Map<string, OrgFilterOption>();
-  const order: string[] = [];
-  for (const row of rows) {
-    const key = row.orgId ?? '';
-    const existing = byKey.get(key);
-    if (existing) {
-      existing.count += 1;
-      continue;
-    }
-    byKey.set(key, { key, name: row.orgName ?? unknownLabel, count: 1 });
-    order.push(key);
-  }
-  return order.map((key) => byKey.get(key)!);
-}
-
-/** Explicit-index stable sort: ties (identical `expiresAt`/`createdAt` — the
- *  common case across fixtures, and for cards created in the same request)
- *  keep their original relative order rather than depending on the engine's
- *  sort-stability guarantee. Runs BEFORE `clusterByOrg` below, not after:
- *  clustering only reorders which ORG's bucket comes first and preserves
- *  each bucket's internal order, so sorting the flat list first is what
- *  actually decides the order approvers see within (and, secondarily,
- *  across) organizations — org-first clustering (critique #1) is preserved
- *  either way. */
-function sortRows(rows: PendingApproval[], order: SortOrder): PendingApproval[] {
-  return rows
-    .map((row, index) => ({ row, index }))
-    .sort((a, b) => {
-      const diff =
-        order === 'expiringSoonest'
-          ? new Date(a.row.expiresAt).getTime() - new Date(b.row.expiresAt).getTime()
-          : new Date(b.row.createdAt).getTime() - new Date(a.row.createdAt).getTime();
-      return diff !== 0 ? diff : a.index - b.index;
-    })
-    .map(({ row }) => row);
-}
-
-/** Comma-joined hostnames for a group header, so "Approve all (N)" names its
- *  own scope instead of leaving the approver to open every card to find out
- *  which machines it covers. Caps at GROUP_HOSTNAME_MAX_SHOWN names (kept
- *  short enough that the header's `line-clamp-2` rarely has to truncate
- *  mid-name) and folds everything past that — including any member with no
- *  `targetDevice` at all — into one trailing "+K more" count. Returns null
- *  when nothing in the group carries a hostname, so the caller renders no
- *  line at all rather than an empty one. */
-const GROUP_HOSTNAME_MAX_SHOWN = 6;
-function groupHostnameSummary(
-  members: PendingApproval[],
-): { shown: string[]; more: number } | null {
-  const hostnames = members
-    .map((member) => member.targetDevice?.hostname)
-    .filter((hostname): hostname is string => Boolean(hostname));
-  if (hostnames.length === 0) return null;
-  const shown = hostnames.slice(0, GROUP_HOSTNAME_MAX_SHOWN);
-  return { shown, more: members.length - shown.length };
-}
-
-/** Whether a card's expiry has already passed as of `now`. `now` is a ticking
- *  state value (not a fresh `Date.now()` read) so every card in the list
- *  re-evaluates together on the same 10s tick instead of drifting apart. */
-function isExpired(expiresAt: string, now: number): boolean {
-  const remainingMs = new Date(expiresAt).getTime() - now;
-  return Number.isFinite(remainingMs) && remainingMs <= 0;
-}
-
-/**
- * Cards in first-appearance order, with every ≥2-member eligible group pulled
- * together under one header and everything else left as a standalone row.
- * A group of one is deliberately NOT a group: a header offering "Approve all
- * (1)" is noise, and the single-card path already covers it.
- *
- * `driftedIds` (issue #4459): a card the server just reported as `offending`
- * on a `batch_not_homogeneous` 422 is excluded from grouping here — same
- * treatment as `!isGroupable`. This is what "deselects" it: it renders as a
- * standalone row (single-card decide) on the very next render, while its
- * former groupmates re-group (possibly as a smaller batch) and are
- * immediately re-batchable without the approver redoing the selection.
- */
-function buildSections(rows: PendingApproval[], driftedIds: ReadonlySet<string>): Section[] {
-  const groupable = (row: PendingApproval) => isGroupable(row) && !driftedIds.has(row.id);
-  const membersByIdentity = new Map<string, PendingApproval[]>();
-  for (const row of rows) {
-    if (!groupable(row)) continue;
-    const identity = groupIdentity(row);
-    const bucket = membersByIdentity.get(identity);
-    if (bucket) bucket.push(row);
-    else membersByIdentity.set(identity, [row]);
-  }
-
-  const emitted = new Set<string>();
-  const sections: Section[] = [];
-  for (const row of rows) {
-    if (!groupable(row)) {
-      sections.push({ kind: 'row', approval: row });
-      continue;
-    }
-    const identity = groupIdentity(row);
-    const members = membersByIdentity.get(identity) ?? [row];
-    if (members.length < 2) {
-      sections.push({ kind: 'row', approval: row });
-      continue;
-    }
-    if (emitted.has(identity)) continue;
-    emitted.add(identity);
-    sections.push({
-      kind: 'group',
-      group: {
-        identity,
-        testKey: groupTestKey(row),
-        // Two groups from the same tool differ only by their action, so the
-        // header has to carry it or they render identically.
-        tool: row.action ? `${row.actionToolName}:${row.action}` : row.actionToolName,
-        members,
-      },
-    });
-  }
-  return sections;
-}
 
 /**
  * P2-5 (#4192, Task 21) — "Approve and always allow". Eligibility for a

--- a/apps/web/src/components/approvals/approvalGrouping.test.ts
+++ b/apps/web/src/components/approvals/approvalGrouping.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect } from 'vitest';
+import { approvalBatchGroupKey } from '@breeze/shared';
+
+import {
+  buildOrgOptions,
+  buildSections,
+  clusterByOrg,
+  GROUP_HOSTNAME_MAX_SHOWN,
+  groupHostnameSummary,
+  groupIdentity,
+  groupTestKey,
+  isExpired,
+  isGroupable,
+  matchesSearch,
+  sortRows,
+  type PendingApproval,
+} from './approvalGrouping';
+
+const NO_DRIFT: ReadonlySet<string> = new Set<string>();
+
+let seq = 0;
+function makeApproval(overrides: Partial<PendingApproval> = {}): PendingApproval {
+  seq += 1;
+  return {
+    id: `appr-${seq}`,
+    requestingClientLabel: 'Patch Hygiene Agent',
+    requestingMachineLabel: null,
+    actionLabel: `Restart spooler on dev-${seq}`,
+    actionToolName: 'manage_services',
+    actionArguments: { deviceId: `dev-${seq}`, action: 'restart' },
+    riskTier: 'medium',
+    riskSummary: 'Restarts a Windows service.',
+    customerTenant: null,
+    status: 'pending',
+    expiresAt: new Date(Date.now() + 300_000).toISOString(),
+    decidedAt: null,
+    decisionReason: null,
+    executionId: null,
+    intentId: `intent-${seq}`,
+    approvalScope: 'supervised',
+    isRecursive: false,
+    createdAt: new Date().toISOString(),
+    origin: 'ai_agent',
+    agentName: 'Patch Hygiene Agent',
+    orgId: 'org-1',
+    orgName: 'Acme Corp',
+    action: 'restart',
+    targetDevice: { id: `dev-${seq}`, hostname: `host-${seq}` },
+    ...overrides,
+  };
+}
+
+describe('isGroupable', () => {
+  it('accepts a supervised, agent-originated, non-critical card with an org', () => {
+    expect(isGroupable(makeApproval())).toBe(true);
+  });
+
+  it.each([
+    ['a human-originated card', { origin: 'human' as const }],
+    ['a four-eyes card', { approvalScope: 'four_eyes' }],
+    ['a card with no linked intent org', { orgId: null }],
+    // The batch route deliberately does not plumb `reauthVerified`, so a
+    // critical card can never clear the L4 ladder inside a batch.
+    ['a critical card', { riskTier: 'critical' as const }],
+  ])('refuses %s', (_name, overrides) => {
+    expect(isGroupable(makeApproval(overrides as Partial<PendingApproval>))).toBe(false);
+  });
+});
+
+describe('groupIdentity', () => {
+  /**
+   * The inbox and the server (`batchGroupKey` in
+   * `services/approvals/batchDecide.ts`) must derive the SAME key or the UI
+   * offers batches the server refuses (#4457). Both now call the shared helper,
+   * and this pins that the inbox side really does — a re-inlined local copy
+   * here would be exactly the drift the issue was about.
+   */
+  it('is the shared batch-grouping key, applied to the DTO itself', () => {
+    for (const approval of [
+      makeApproval(),
+      makeApproval({ action: '  ReStart ' }),
+      makeApproval({ action: null }),
+      makeApproval({ orgId: null }),
+      makeApproval({ actionToolName: 'manage_patches', action: 'install' }),
+    ]) {
+      expect(groupIdentity(approval)).toBe(approvalBatchGroupKey(approval));
+    }
+  });
+
+  it('separates a differing action into a different identity', () => {
+    expect(groupIdentity(makeApproval({ action: 'stop' }))).not.toBe(
+      groupIdentity(makeApproval({ action: 'restart' })),
+    );
+  });
+});
+
+describe('groupTestKey', () => {
+  it('renders the same triple DOM-safely', () => {
+    expect(groupTestKey(makeApproval({ orgId: 'org-1', action: 'restart' }))).toBe(
+      'org-1--manage_services--restart',
+    );
+  });
+
+  it('strips anything a DOM attribute selector could not carry', () => {
+    expect(groupTestKey(makeApproval({ orgId: 'org 1/x', action: 'Re Start' }))).toBe(
+      'org-1-x--manage_services--re-start',
+    );
+  });
+});
+
+describe('buildSections', () => {
+  it('pulls two cards sharing the (org, tool, action) triple under one group', () => {
+    const rows = [makeApproval(), makeApproval()];
+    const sections = buildSections(rows, NO_DRIFT);
+    expect(sections).toHaveLength(1);
+    expect(sections[0]!.kind).toBe('group');
+    if (sections[0]!.kind !== 'group') return;
+    expect(sections[0]!.group.members.map((m) => m.id)).toEqual(rows.map((r) => r.id));
+    expect(sections[0]!.group.tool).toBe('manage_services:restart');
+  });
+
+  it('still groups two cards whose actions differ only in case and whitespace', () => {
+    // The behavioural proof that the shared normalization is what runs here.
+    const sections = buildSections(
+      [makeApproval({ action: 'restart' }), makeApproval({ action: '  RESTART ' })],
+      NO_DRIFT,
+    );
+    expect(sections).toHaveLength(1);
+    expect(sections[0]!.kind).toBe('group');
+  });
+
+  it('leaves cards with different actions as standalone rows', () => {
+    const sections = buildSections(
+      [makeApproval({ action: 'restart' }), makeApproval({ action: 'stop' })],
+      NO_DRIFT,
+    );
+    expect(sections.map((s) => s.kind)).toEqual(['row', 'row']);
+  });
+
+  it('leaves cards from different orgs as standalone rows', () => {
+    const sections = buildSections(
+      [makeApproval({ orgId: 'org-1' }), makeApproval({ orgId: 'org-2' })],
+      NO_DRIFT,
+    );
+    expect(sections.map((s) => s.kind)).toEqual(['row', 'row']);
+  });
+
+  it('never makes a group of one', () => {
+    const sections = buildSections([makeApproval()], NO_DRIFT);
+    expect(sections.map((s) => s.kind)).toEqual(['row']);
+  });
+
+  it('drops a drifted card out of its group and leaves the rest batchable', () => {
+    const rows = [makeApproval(), makeApproval(), makeApproval()];
+    const sections = buildSections(rows, new Set([rows[1]!.id]));
+    expect(sections.map((s) => s.kind)).toEqual(['group', 'row']);
+    if (sections[0]!.kind !== 'group') return;
+    expect(sections[0]!.group.members.map((m) => m.id)).toEqual([rows[0]!.id, rows[2]!.id]);
+  });
+
+  it('keeps an ungroupable card as a row even among groupable siblings', () => {
+    const rows = [makeApproval(), makeApproval(), makeApproval({ origin: 'human' })];
+    const sections = buildSections(rows, NO_DRIFT);
+    expect(sections.map((s) => s.kind)).toEqual(['group', 'row']);
+  });
+});
+
+describe('clusterByOrg', () => {
+  it('gathers each org together in first-appearance order without reordering within', () => {
+    const a1 = makeApproval({ orgId: 'org-a' });
+    const b1 = makeApproval({ orgId: 'org-b' });
+    const a2 = makeApproval({ orgId: 'org-a' });
+    expect(clusterByOrg([a1, b1, a2]).map((r) => r.id)).toEqual([a1.id, a2.id, b1.id]);
+  });
+
+  it('treats every null-org row as one bucket rather than splintering per row', () => {
+    const n1 = makeApproval({ orgId: null });
+    const a1 = makeApproval({ orgId: 'org-a' });
+    const n2 = makeApproval({ orgId: null });
+    expect(clusterByOrg([n1, a1, n2]).map((r) => r.id)).toEqual([n1.id, n2.id, a1.id]);
+  });
+});
+
+describe('sortRows', () => {
+  it('orders by soonest expiry, keeping ties in their original order', () => {
+    const same = new Date(Date.now() + 60_000).toISOString();
+    const later = new Date(Date.now() + 600_000).toISOString();
+    const a = makeApproval({ expiresAt: same });
+    const b = makeApproval({ expiresAt: later });
+    const c = makeApproval({ expiresAt: same });
+    expect(sortRows([b, a, c], 'expiringSoonest').map((r) => r.id)).toEqual([a.id, c.id, b.id]);
+  });
+
+  it('orders newest-first by createdAt', () => {
+    const old = makeApproval({ createdAt: new Date(Date.now() - 60_000).toISOString() });
+    const fresh = makeApproval({ createdAt: new Date().toISOString() });
+    expect(sortRows([old, fresh], 'newest').map((r) => r.id)).toEqual([fresh.id, old.id]);
+  });
+});
+
+describe('matchesSearch', () => {
+  const row = makeApproval({
+    actionLabel: 'Restart Print Spooler',
+    targetDevice: { id: 'd1', hostname: 'WS-ACCT-04' },
+    agentName: 'Patch Hygiene Agent',
+  });
+
+  it('matches an empty query', () => {
+    expect(matchesSearch(row, '')).toBe(true);
+  });
+
+  it.each(['spooler', 'ws-acct', 'hygiene'])('matches %s case-insensitively', (q) => {
+    expect(matchesSearch(row, q)).toBe(true);
+  });
+
+  it('does not match an unrelated needle', () => {
+    expect(matchesSearch(row, 'defrag')).toBe(false);
+  });
+});
+
+describe('buildOrgOptions', () => {
+  it('counts rows per org in first-appearance order', () => {
+    const rows = [
+      makeApproval({ orgId: 'org-a', orgName: 'Acme' }),
+      makeApproval({ orgId: 'org-b', orgName: 'Beta' }),
+      makeApproval({ orgId: 'org-a', orgName: 'Acme' }),
+    ];
+    expect(buildOrgOptions(rows, 'Unknown organization')).toEqual([
+      { key: 'org-a', name: 'Acme', count: 2 },
+      { key: 'org-b', name: 'Beta', count: 1 },
+    ]);
+  });
+
+  it('folds null-org rows under one synthetic option', () => {
+    const rows = [makeApproval({ orgId: null, orgName: null }), makeApproval({ orgId: null, orgName: null })];
+    expect(buildOrgOptions(rows, 'Unknown organization')).toEqual([
+      { key: '', name: 'Unknown organization', count: 2 },
+    ]);
+  });
+});
+
+describe('groupHostnameSummary', () => {
+  it('returns null when no member carries a hostname', () => {
+    expect(groupHostnameSummary([makeApproval({ targetDevice: null })])).toBeNull();
+  });
+
+  it('caps the shown names and folds the remainder into a count', () => {
+    const members = Array.from({ length: GROUP_HOSTNAME_MAX_SHOWN + 3 }, (_, i) =>
+      makeApproval({ targetDevice: { id: `d${i}`, hostname: `host-${i}` } }),
+    );
+    const summary = groupHostnameSummary(members);
+    expect(summary?.shown).toHaveLength(GROUP_HOSTNAME_MAX_SHOWN);
+    expect(summary?.more).toBe(3);
+  });
+
+  it('counts a member with no hostname toward "+K more" rather than dropping it', () => {
+    const summary = groupHostnameSummary([
+      makeApproval({ targetDevice: { id: 'd1', hostname: 'host-1' } }),
+      makeApproval({ targetDevice: null }),
+    ]);
+    expect(summary).toEqual({ shown: ['host-1'], more: 1 });
+  });
+});
+
+describe('isExpired', () => {
+  const now = Date.parse('2026-09-03T12:00:00.000Z');
+
+  it('is true once the deadline has passed', () => {
+    expect(isExpired('2026-09-03T11:59:59.000Z', now)).toBe(true);
+  });
+
+  it('is false while time remains', () => {
+    expect(isExpired('2026-09-03T12:00:01.000Z', now)).toBe(false);
+  });
+
+  it('is false for an unparseable timestamp rather than treating it as expired', () => {
+    expect(isExpired('not-a-date', now)).toBe(false);
+  });
+});

--- a/apps/web/src/components/approvals/approvalGrouping.ts
+++ b/apps/web/src/components/approvals/approvalGrouping.ts
@@ -1,0 +1,295 @@
+import { approvalBatchGroupKey, approvalBatchGroupParts } from '@breeze/shared';
+
+/**
+ * Pure list-shaping helpers for the AI-agent approvals inbox — issue #4456.
+ *
+ * `ApprovalsInbox.tsx` renders; this module decides WHAT it renders: which
+ * cards may be batched, which of them form a group, and how a flat page of rows
+ * is filtered, sorted and clustered before any of that. Everything here is a
+ * pure function of its arguments (no hooks, no fetches, no i18n), so each rule
+ * can be tested directly instead of through the component.
+ *
+ * The one rule that is NOT defined here is the batch-grouping key itself: it
+ * lives in `@breeze/shared`'s `approvalBatchGroupKey` because the server
+ * enforces the same rule, and the two used to be copies kept in step only by
+ * matching comments (#4457).
+ */
+
+export type RiskTier = 'low' | 'medium' | 'high' | 'critical';
+
+export interface PendingApproval {
+  id: string;
+  requestingClientLabel: string;
+  requestingMachineLabel: string | null;
+  actionLabel: string;
+  actionToolName: string;
+  actionArguments: Record<string, unknown>;
+  riskTier: RiskTier;
+  riskSummary: string;
+  customerTenant: string | null;
+  status: 'pending';
+  expiresAt: string;
+  decidedAt: null;
+  decisionReason: null;
+  executionId: string | null;
+  intentId: string | null;
+  approvalScope: string | null;
+  isRecursive: boolean;
+  createdAt: string;
+  /** Wave 3b: who proposed this intent. Serialize emits it on every row;
+   *  anything but 'ai_agent' renders the classic requester attribution. */
+  origin: 'human' | 'ai_agent';
+  agentName: string | null;
+  /** P2-2: the linked intent's org, the multiplexed tools' `action`
+   *  discriminator, and the resolved target device. All three are null for a
+   *  row with no intent; `action` is also null for a non-multiplexed tool. */
+  orgId: string | null;
+  /** The `orgId` organization's display name, resolved server-side. Null for
+   *  a row with no intent (no orgId) or when the org row no longer exists —
+   *  either way the UI falls back to the "Unknown organization" copy. */
+  orgName: string | null;
+  action: string | null;
+  targetDevice: { id: string; hostname: string } | null;
+}
+
+/** One header + its cards: a set the server would accept as ONE decision. */
+export interface ApprovalGroup {
+  /** Raw `(orgId, tool, action)` triple — the identity all state is keyed by. */
+  identity: string;
+  /** DOM-safe projection of the same triple, used only for `data-testid`. */
+  testKey: string;
+  /** What the header names the group after. */
+  tool: string;
+  members: PendingApproval[];
+}
+
+export type Section =
+  | { kind: 'row'; approval: PendingApproval }
+  | { kind: 'group'; group: ApprovalGroup };
+
+/**
+ * Exactly the server's batch eligibility rule (`loadHomogeneousBatch` in
+ * `services/approvals/batchDecide.ts`): a SUPERVISED, AGENT-ORIGINATED, still
+ * pending card. Four-eyes cards are excluded structurally — they are never
+ * `supervised` — so the two-person rule can never be satisfied by a batch tap.
+ *
+ * The UI must only ever offer a batch the server would accept; a looser
+ * predicate here does not weaken the server (it 422s the whole set), but it
+ * does hand the approver a button that always fails.
+ */
+export function isGroupable(approval: PendingApproval): boolean {
+  return (
+    approval.origin === 'ai_agent' &&
+    approval.approvalScope === 'supervised' &&
+    approval.orgId !== null &&
+    // A CRITICAL card can never be batched. The batch route deliberately does
+    // not plumb `reauthVerified` (batchDecide.ts), so the L4 ladder a critical
+    // card has to clear is unsatisfiable in a batch and the whole set 401s
+    // `reauth_required` — a permanent dead end, since re-auth is collected per
+    // decision. The ceremony runs at the HIGHEST tier present, so ONE critical
+    // card would sink an otherwise decidable group; excluding it here leaves
+    // every critical card on the single-card path, which can collect re-auth.
+    approval.riskTier !== 'critical'
+  );
+}
+
+/**
+ * The batch homogeneity key for one card — `(orgId, actionToolName, normalized
+ * action)`, NUL-joined.
+ *
+ * Delegates to `@breeze/shared` (#4457) so this is literally the same function
+ * the server's `loadHomogeneousBatch` runs: the inbox can no longer offer an
+ * "Approve all (N)" over a set the server would refuse, nor split a set it
+ * would have accepted. A `PendingApproval` satisfies the shared input shape
+ * structurally — `orgId`, `actionToolName` and `action` are exactly the DTO
+ * fields `serialize` projects for that purpose.
+ */
+export function groupIdentity(approval: PendingApproval): string {
+  return approvalBatchGroupKey(approval);
+}
+
+/** DOM-safe rendering of the same triple. Lossy (distinct triples could in
+ *  principle collapse), which is why it is used ONLY for `data-testid` while
+ *  every decision keys off `groupIdentity`. */
+export function groupTestKey(approval: PendingApproval): string {
+  return approvalBatchGroupParts(approval)
+    .map((part) => part.replace(/[^A-Za-z0-9_-]+/g, '-'))
+    .join('--');
+}
+
+/**
+ * Org is the OUTERMOST grouping (critique #1): two cards for different orgs
+ * that happen to share a `(tool, action)` must never render adjacent to each
+ * other as if they were the same request. This stable-sorts the rows so every
+ * org's cards sit together, in the org's own first-appearance order, WITHOUT
+ * touching each org's internal relative order — `buildSections` below still
+ * decides tool/action grouping exactly as before, it just runs over rows
+ * that are already clustered by org.
+ *
+ * Known, accepted trade-off: the server pages strictly by `createdAt`, but
+ * this reclusters by org (first-appearance order). A "Load more" page's rows
+ * can therefore land ABOVE some already-visible rows if they belong to an
+ * org that appeared earlier in the list — no row is ever lost or hidden,
+ * just not always appended at the visual bottom.
+ */
+export function clusterByOrg(rows: PendingApproval[]): PendingApproval[] {
+  const buckets = new Map<string, PendingApproval[]>();
+  const order: string[] = [];
+  for (const row of rows) {
+    const key = row.orgId ?? '';
+    const bucket = buckets.get(key);
+    if (bucket) bucket.push(row);
+    else {
+      buckets.set(key, [row]);
+      order.push(key);
+    }
+  }
+  return order.flatMap((key) => buckets.get(key)!);
+}
+
+export type SortOrder = 'expiringSoonest' | 'newest';
+
+/** Case-insensitive substring match over the fields Priya (an MSP tech
+ *  approving across dozens of orgs) scans an inbox by: the action label, the
+ *  target machine's hostname, and the proposing agent's name. An empty or
+ *  whitespace-only query matches every row. */
+export function matchesSearch(approval: PendingApproval, query: string): boolean {
+  if (!query) return true;
+  const needle = query.toLowerCase();
+  return (
+    approval.actionLabel.toLowerCase().includes(needle) ||
+    (approval.targetDevice?.hostname.toLowerCase().includes(needle) ?? false) ||
+    (approval.agentName?.toLowerCase().includes(needle) ?? false)
+  );
+}
+
+/** One selectable option in the organization filter, in first-appearance
+ *  order among the currently loaded rows. `key` is what the `<select>`
+ *  stores and compares against — `orgId ?? ''` — so a null-`orgId` row
+ *  groups under one synthetic "Unknown organization" option instead of
+ *  splintering per row. */
+export interface OrgFilterOption {
+  key: string;
+  name: string;
+  count: number;
+}
+
+export function buildOrgOptions(rows: PendingApproval[], unknownLabel: string): OrgFilterOption[] {
+  const byKey = new Map<string, OrgFilterOption>();
+  const order: string[] = [];
+  for (const row of rows) {
+    const key = row.orgId ?? '';
+    const existing = byKey.get(key);
+    if (existing) {
+      existing.count += 1;
+      continue;
+    }
+    byKey.set(key, { key, name: row.orgName ?? unknownLabel, count: 1 });
+    order.push(key);
+  }
+  return order.map((key) => byKey.get(key)!);
+}
+
+/** Explicit-index stable sort: ties (identical `expiresAt`/`createdAt` — the
+ *  common case across fixtures, and for cards created in the same request)
+ *  keep their original relative order rather than depending on the engine's
+ *  sort-stability guarantee. Runs BEFORE `clusterByOrg` below, not after:
+ *  clustering only reorders which ORG's bucket comes first and preserves
+ *  each bucket's internal order, so sorting the flat list first is what
+ *  actually decides the order approvers see within (and, secondarily,
+ *  across) organizations — org-first clustering (critique #1) is preserved
+ *  either way. */
+export function sortRows(rows: PendingApproval[], order: SortOrder): PendingApproval[] {
+  return rows
+    .map((row, index) => ({ row, index }))
+    .sort((a, b) => {
+      const diff =
+        order === 'expiringSoonest'
+          ? new Date(a.row.expiresAt).getTime() - new Date(b.row.expiresAt).getTime()
+          : new Date(b.row.createdAt).getTime() - new Date(a.row.createdAt).getTime();
+      return diff !== 0 ? diff : a.index - b.index;
+    })
+    .map(({ row }) => row);
+}
+
+/** Comma-joined hostnames for a group header, so "Approve all (N)" names its
+ *  own scope instead of leaving the approver to open every card to find out
+ *  which machines it covers. Caps at GROUP_HOSTNAME_MAX_SHOWN names (kept
+ *  short enough that the header's `line-clamp-2` rarely has to truncate
+ *  mid-name) and folds everything past that — including any member with no
+ *  `targetDevice` at all — into one trailing "+K more" count. Returns null
+ *  when nothing in the group carries a hostname, so the caller renders no
+ *  line at all rather than an empty one. */
+export const GROUP_HOSTNAME_MAX_SHOWN = 6;
+export function groupHostnameSummary(
+  members: PendingApproval[],
+): { shown: string[]; more: number } | null {
+  const hostnames = members
+    .map((member) => member.targetDevice?.hostname)
+    .filter((hostname): hostname is string => Boolean(hostname));
+  if (hostnames.length === 0) return null;
+  const shown = hostnames.slice(0, GROUP_HOSTNAME_MAX_SHOWN);
+  return { shown, more: members.length - shown.length };
+}
+
+/** Whether a card's expiry has already passed as of `now`. `now` is a ticking
+ *  state value (not a fresh `Date.now()` read) so every card in the list
+ *  re-evaluates together on the same 10s tick instead of drifting apart. */
+export function isExpired(expiresAt: string, now: number): boolean {
+  const remainingMs = new Date(expiresAt).getTime() - now;
+  return Number.isFinite(remainingMs) && remainingMs <= 0;
+}
+
+/**
+ * Cards in first-appearance order, with every ≥2-member eligible group pulled
+ * together under one header and everything else left as a standalone row.
+ * A group of one is deliberately NOT a group: a header offering "Approve all
+ * (1)" is noise, and the single-card path already covers it.
+ *
+ * `driftedIds` (issue #4459): a card the server just reported as `offending`
+ * on a `batch_not_homogeneous` 422 is excluded from grouping here — same
+ * treatment as `!isGroupable`. This is what "deselects" it: it renders as a
+ * standalone row (single-card decide) on the very next render, while its
+ * former groupmates re-group (possibly as a smaller batch) and are
+ * immediately re-batchable without the approver redoing the selection.
+ */
+export function buildSections(rows: PendingApproval[], driftedIds: ReadonlySet<string>): Section[] {
+  const groupable = (row: PendingApproval) => isGroupable(row) && !driftedIds.has(row.id);
+  const membersByIdentity = new Map<string, PendingApproval[]>();
+  for (const row of rows) {
+    if (!groupable(row)) continue;
+    const identity = groupIdentity(row);
+    const bucket = membersByIdentity.get(identity);
+    if (bucket) bucket.push(row);
+    else membersByIdentity.set(identity, [row]);
+  }
+
+  const emitted = new Set<string>();
+  const sections: Section[] = [];
+  for (const row of rows) {
+    if (!groupable(row)) {
+      sections.push({ kind: 'row', approval: row });
+      continue;
+    }
+    const identity = groupIdentity(row);
+    const members = membersByIdentity.get(identity) ?? [row];
+    if (members.length < 2) {
+      sections.push({ kind: 'row', approval: row });
+      continue;
+    }
+    if (emitted.has(identity)) continue;
+    emitted.add(identity);
+    sections.push({
+      kind: 'group',
+      group: {
+        identity,
+        testKey: groupTestKey(row),
+        // Two groups from the same tool differ only by their action, so the
+        // header has to carry it or they render identically.
+        tool: row.action ? `${row.actionToolName}:${row.action}` : row.actionToolName,
+        members,
+      },
+    });
+  }
+  return sections;
+}

--- a/packages/shared/src/utils/approvalBatchGrouping.test.ts
+++ b/packages/shared/src/utils/approvalBatchGrouping.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  APPROVAL_BATCH_GROUP_SEPARATOR,
+  approvalBatchGroupKey,
+  approvalBatchGroupParts,
+  normalizeApprovalBatchAction,
+} from './approvalBatchGrouping';
+
+const base = {
+  orgId: 'org-1',
+  actionToolName: 'manage_services',
+  action: 'restart' as unknown,
+};
+
+describe('normalizeApprovalBatchAction', () => {
+  it('trims and lower-cases a string action', () => {
+    expect(normalizeApprovalBatchAction('  ReStart  ')).toBe('restart');
+  });
+
+  it('returns null for anything that is not a string', () => {
+    for (const value of [null, undefined, 42, true, {}, ['restart']]) {
+      expect(normalizeApprovalBatchAction(value)).toBeNull();
+    }
+  });
+
+  it('returns an empty string (not null) for a whitespace-only action', () => {
+    expect(normalizeApprovalBatchAction('   ')).toBe('');
+  });
+});
+
+describe('approvalBatchGroupKey', () => {
+  it('is the NUL-joined (orgId, tool, normalized action) triple', () => {
+    expect(APPROVAL_BATCH_GROUP_SEPARATOR).toBe('\u0000');
+    expect(approvalBatchGroupKey(base)).toBe(
+      ['org-1', 'manage_services', 'restart'].join('\u0000'),
+    );
+  });
+
+  it('ignores cosmetic differences in how the action was spelled', () => {
+    expect(approvalBatchGroupKey({ ...base, action: ' RESTART ' })).toBe(
+      approvalBatchGroupKey(base),
+    );
+  });
+
+  it('separates a different action into a different group', () => {
+    expect(approvalBatchGroupKey({ ...base, action: 'stop' })).not.toBe(
+      approvalBatchGroupKey(base),
+    );
+  });
+
+  it('separates a different org into a different group', () => {
+    expect(approvalBatchGroupKey({ ...base, orgId: 'org-2' })).not.toBe(
+      approvalBatchGroupKey(base),
+    );
+  });
+
+  it('separates a different tool into a different group', () => {
+    expect(approvalBatchGroupKey({ ...base, actionToolName: 'manage_patches' })).not.toBe(
+      approvalBatchGroupKey(base),
+    );
+  });
+
+  it('treats a null org and a null action as their own empty-valued group', () => {
+    expect(approvalBatchGroupKey({ orgId: null, actionToolName: 'run_script', action: null })).toBe(
+      ['', 'run_script', ''].join('\u0000'),
+    );
+  });
+
+  it('groups a non-string action with a missing one — both are "not multiplexed"', () => {
+    expect(approvalBatchGroupKey({ ...base, action: { nested: 'restart' } })).toBe(
+      approvalBatchGroupKey({ ...base, action: null }),
+    );
+  });
+
+  it('cannot be forged across field boundaries by concatenating two fields', () => {
+    // With a plain separator a value could reach, ('a', 'b<sep>c', '') and
+    // ('a', 'b', 'c') would collide. NUL is not representable in a tool name
+    // or in a Postgres text value, so the two stay distinct.
+    expect(approvalBatchGroupKey({ orgId: 'a', actionToolName: 'b', action: 'c' })).not.toBe(
+      approvalBatchGroupKey({ orgId: 'a', actionToolName: 'b', action: null }),
+    );
+  });
+});
+
+describe('approvalBatchGroupParts', () => {
+  it('exposes the same three parts the key is built from', () => {
+    expect(approvalBatchGroupParts(base)).toEqual(['org-1', 'manage_services', 'restart']);
+  });
+
+  it('substitutes empty strings for a null org and a non-string action', () => {
+    expect(
+      approvalBatchGroupParts({ orgId: null, actionToolName: 'run_script', action: 7 }),
+    ).toEqual(['', 'run_script', '']);
+  });
+});

--- a/packages/shared/src/utils/approvalBatchGrouping.ts
+++ b/packages/shared/src/utils/approvalBatchGrouping.ts
@@ -1,0 +1,94 @@
+/**
+ * The ONE definition of the AI-agent approvals batch-grouping ("homogeneity")
+ * rule — issue #4457.
+ *
+ * P2-2 (#4189) lets an approver decide MANY pending approval cards with ONE
+ * assertion ceremony. Collapsing N ceremonies into one is only safe because the
+ * set is provably a single decision, and *this* key is what "a single decision"
+ * means: every member must share the same
+ * `(orgId, actionToolName, normalized action)` triple.
+ *
+ * Two independent call sites derive that key, and they must never disagree:
+ *
+ *  - the SERVER (`services/approvals/batchDecide.ts`, `loadHomogeneousBatch`),
+ *    which 422s `batch_not_homogeneous` and decides NOTHING when a set spans
+ *    more than one key, deriving `action` from the row's raw
+ *    `action_arguments`; and
+ *  - the WEB inbox (`components/approvals/approvalGrouping.ts`), which offers
+ *    an "Approve all (N)" header only over rows that share a key, deriving
+ *    `action` from the DTO field `serialize` projects out of that same
+ *    `action_arguments`.
+ *
+ * They used to be two copies kept in step by matching comments. A drift in the
+ * *loosening* direction on the server is a real authorization hazard: one batch
+ * ceremony would then cover a heterogeneous set the approver never read as one
+ * decision. A drift in the *tightening* direction on the web is a dead button.
+ * Neither is possible while both import from here, so do not re-implement this
+ * rule at a call site — extend it here and let both surfaces move together.
+ *
+ * Pure and dependency-free (no Node builtins) so it is safe in the browser
+ * bundle via the root barrel.
+ */
+
+/**
+ * The minimum an approval must expose to be placed in a batch group. Both a
+ * loaded DB row (`intent.orgId` + `approval.actionToolName` +
+ * `approval.actionArguments.action`) and a serialized inbox DTO satisfy this
+ * shape structurally.
+ */
+export interface ApprovalBatchGroupSource {
+  /** The LINKED INTENT's org — not the approval row's. Null for a row with no
+   *  intent, which is never batchable but still needs a stable key. */
+  orgId: string | null;
+  /** The tool the intent proposes calling. */
+  actionToolName: string;
+  /**
+   * The multiplexed tools' `action` discriminator (`manage_services:restart`,
+   * `manage_patches:install`, …), RAW: pass `action_arguments.action` straight
+   * through, or the serialized `action` field. Typed `unknown` on purpose —
+   * `action_arguments` is jsonb, so a non-string is representable and must be
+   * classified here rather than at each call site.
+   */
+  action: unknown;
+}
+
+/**
+ * NUL. Chosen because no value that reaches the key can contain it — a tool
+ * name is an identifier and Postgres `text` cannot hold a NUL byte — so no
+ * field value can forge a boundary and make `(a, "b:c", "")` collide with
+ * `(a, "b", "c")`.
+ */
+export const APPROVAL_BATCH_GROUP_SEPARATOR = '\u0000';
+
+/**
+ * The action discriminator, trimmed and lower-cased so a purely cosmetic
+ * difference in how two intents spelled the same action does not split an
+ * otherwise identical set.
+ *
+ * Null — meaning "this tool is not action-multiplexed" — for anything that is
+ * not a string. That is itself a group of its own, so a set mixing "has an
+ * action" with "has none" is heterogeneous and gets refused.
+ */
+export function normalizeApprovalBatchAction(action: unknown): string | null {
+  return typeof action === 'string' ? action.trim().toLowerCase() : null;
+}
+
+/**
+ * The three parts the key is built from, in order. Exposed separately only so
+ * the web inbox can render a DOM-safe `data-testid` from the same triple; every
+ * decision — client and server — keys off {@link approvalBatchGroupKey}.
+ */
+export function approvalBatchGroupParts(
+  source: ApprovalBatchGroupSource,
+): [string, string, string] {
+  return [
+    source.orgId ?? '',
+    source.actionToolName,
+    normalizeApprovalBatchAction(source.action) ?? '',
+  ];
+}
+
+/** `(orgId, actionToolName, normalized action)` — the whole homogeneity key. */
+export function approvalBatchGroupKey(source: ApprovalBatchGroupSource): string {
+  return approvalBatchGroupParts(source).join(APPROVAL_BATCH_GROUP_SEPARATOR);
+}

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -15,6 +15,7 @@ export * from './s3Region';
 export * from './s3Endpoint';
 export * from './softwareFileType';
 export * from './cron';
+export * from './approvalBatchGrouping';
 // Deliberately NOT `export *`. `compileExcludeMatcher` is a code-point port of
 // the agent's matcher and knowingly diverges from Go on mid-rune byte offsets
 // and Unicode special-casing (see matcherPortLimitations in


### PR DESCRIPTION
## What

The AI-agent approvals **batch-grouping rule** — the `(orgId, actionToolName, normalized action)` homogeneity key that decides which pending cards may be decided with ONE assertion ceremony — was implemented **twice**, independently:

- `apps/web/src/components/approvals/ApprovalsInbox.tsx` (`groupParts` / `groupIdentity`), and
- `apps/api/src/services/approvals/batchDecide.ts` (`normalizedAction` / `groupKey`).

They were kept in step only by matching comments. This PR gives the rule **one definition** in `@breeze/shared` and imports it at both call sites, and — same underlying logic, so one PR — lifts the web-only grouping helpers out of the 1,714-line inbox component into their own module.

Closes #4457
Closes #4456

## Why it matters

Drift in the **loosening** direction on the server is a real authorization hazard: one ceremony would then cover a heterogeneous set of approvals the approver never read as a single decision. Drift in the **tightening** direction on the web is a dead "Approve all (N)" button. Neither is expressible now that both surfaces call the same function.

## Changes

**New — `packages/shared/src/utils/approvalBatchGrouping.ts`**
- `normalizeApprovalBatchAction(action: unknown)` — trims + lower-cases a string action; `null` for anything else (a jsonb `action_arguments` can hold a non-string, and "not action-multiplexed" is its own group).
- `approvalBatchGroupParts(source)` / `approvalBatchGroupKey(source)` — the NUL-joined triple. `APPROVAL_BATCH_GROUP_SEPARATOR` is exported so the choice of NUL (unforgeable by any field value) is stated once.
- Pure and dependency-free, so it stays browser-safe in the root barrel (`browserSafeBarrel.test.ts` passes).

**API — `services/approvals/batchDecide.ts`**
- Local `normalizedAction` + `groupKey` deleted. New exported `batchGroupKey(row)` is a thin wrapper that only says *which fields of a loaded row* feed the shared rule — `intent.orgId`, `approval.actionToolName`, and the raw `action_arguments.action`.
- `loadHomogeneousBatch`'s anchor comparison is unchanged apart from the call.

**Web — `components/approvals/approvalGrouping.ts` (new, 295 lines)**
- Receives `PendingApproval` / `ApprovalGroup` / `Section` / `RiskTier` / `SortOrder` / `OrgFilterOption` and the pure list-shaping helpers: `isGroupable`, `groupIdentity`, `groupTestKey`, `buildSections`, `clusterByOrg`, `sortRows`, `matchesSearch`, `buildOrgOptions`, `groupHostnameSummary`, `isExpired`.
- `groupIdentity` now returns `approvalBatchGroupKey(approval)` — a `PendingApproval` satisfies the shared input shape structurally, because `orgId`/`actionToolName`/`action` are exactly the DTO fields `serialize` projects for this purpose.
- `ApprovalsInbox.tsx` **1,714 -> 1,448 lines**; its diff is deletions plus one import. The extraction was verified line-by-line against the removed block — the only content change is the dedupe above.

## Tests

- **Cross-equivalence (`batchDecide.test.ts`)** — the contract that actually has to hold is *server key off a loaded row == shared key off that same row's serialized DTO*, since the inbox never sees a DB row. Six fixtures (ordinary action, stray case/whitespace, no discriminator, explicit null, non-string, empty string) are driven through `batchGroupKey` **and** through the real `serialize` -> `approvalBatchGroupKey`, plus negatives proving a differing **action**, **org** and **tool** land in different groups on both sides.
- **`packages/shared/.../approvalBatchGrouping.test.ts`** — 13 unit cases including the separator-forgery case.
- **`apps/web/.../approvalGrouping.test.ts`** — 33 cases over the extracted module, including that `groupIdentity` *is* the shared key and that two cards differing only in action casing/whitespace still form one group.
- **Cross-org rejection end to end** (added in `c3ec2234d` after review) — `decideApprovalBatch` already 422'd a differing **tool** and a differing **action** through the full load-and-refuse path, but the **org** axis was pinned only by key equality. That is the axis a drift would hurt most (a fleet sweep proposes the identical `(tool, action)` across every org a partner manages), so it now has the same end-to-end case: same tool, same action, different `intent.orgId` → `422 batch_not_homogeneous`, no ceremony consumed, no transaction opened.
- **Mutation-checked, not just green:** dropping `.toLowerCase()` from the shared normalizer fails 2 shared cases; pointing the API wrapper at the wrong argument field fails 4 cross-equivalence cases; re-inlining a local key in the web module fails 2 web cases. The suites discriminate.

## Verification (local, this branch)

| Check | Result |
|---|---|
| `packages/shared` — `approvalBatchGrouping.test.ts` + `browserSafeBarrel.test.ts` | 17 passed |
| `apps/api` — `services/approvals/batchDecide.test.ts` + `routes/approvals.test.ts` | 139 passed (26 in batchDecide, 12 of them new) |
| `apps/api` — `routes/mcpServer.approvalGate.test.ts` | 18 passed |
| `apps/web` — `ApprovalsInbox.test.tsx` (unchanged component suite) | 64 passed |
| `apps/web` — `approvalGrouping.test.ts` (new) | 33 passed |
| `npx tsc --noEmit` — `apps/api`, `apps/web` | clean |
| `npx tsc --noEmit` — `packages/shared` | 3 errors in `validators/quotes.test.ts`, **confirmed identical on the base commit** (stashed and re-ran); none from this change |
| `npx eslint` on all 7 touched/added files | clean |

No migrations, no schema, no tenancy surface touched — no cascade/export-policy registration applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBxF7C8E5GxFnNcGf6kBVP
