### PR TITLE
fix(shared): promote SweepProposalReason to @breeze/shared (#4458)

### DIFF
--- a/apps/api/src/services/aiAgents/sweepFindings.ts
+++ b/apps/api/src/services/aiAgents/sweepFindings.ts
@@ -91,6 +91,7 @@ import {
   type AiSweepKind,
   type SweepFinding,
   type SweepFindingsOutcome,
+  type SweepProposalReason,
   type SweepProposedAction,
 } from '@breeze/shared';
 import {
@@ -127,20 +128,14 @@ function inSystemDbContext<T>(fn: () => Promise<T>): Promise<T> {
  */
 export type SweepProposalDisposition = 'intent_created' | 'refused' | 'cap_reached' | 'error';
 
-/**
- * Why a proposal did not become a pending intent. Display strings only —
- * NEVER a raw `Error.message` from `createActionIntent` (which could carry
- * tool-input detail); `intent_error` is the whole story a persisted record
- * gets, with the real error logged instead. Same posture as
- * `AlertVerdictSuggestionReason` (P2-1).
- */
-export type SweepProposalReason =
-  | 'device_not_in_evidence'
-  | 'device_not_in_org'
-  | 'not_allowlisted'
-  | 'no_eligible_approvers'
-  | 'intent_error'
-  | 'max_actions_per_run';
+// `SweepProposalReason` — why a proposal did not become a pending intent
+// (display strings only, NEVER a raw `Error.message` from
+// `createActionIntent`; `intent_error` is the whole story a persisted record
+// gets, with the real error logged instead; same posture as
+// `AlertVerdictSuggestionReason`, P2-1) — is declared in `@breeze/shared`
+// (`types/aiAgentRuns.ts`, imported above) rather than here so the web
+// sweep-findings UI can reuse the same union instead of re-deriving it
+// (#4458).
 
 /**
  * One row of `AgentRunOutcome.sweepProposals` — the bookkeeping for ONE

--- a/apps/web/src/components/aiAgents/RunDetailPage.tsx
+++ b/apps/web/src/components/aiAgents/RunDetailPage.tsx
@@ -531,7 +531,7 @@ function sweepSeverityLabel(t: (key: string) => string, severity: AiSweepSeverit
   return t(/* i18n-dynamic */ `aiAgentsPage.runs.sweep.severities.${severity}`);
 }
 
-function sweepReasonLabel(t: (key: string) => string, reason: string | null): string {
+function sweepReasonLabel(t: (key: string) => string, reason: SweepProposalReason | null): string {
   if (!reason) return '—';
   if (!SWEEP_PROPOSAL_REASONS.includes(reason)) return reason;
   return t(/* i18n-dynamic */ `aiAgentsPage.runs.sweep.reasons.${reason}`);

--- a/apps/web/src/components/aiAgents/RunDetailPage.tsx
+++ b/apps/web/src/components/aiAgents/RunDetailPage.tsx
@@ -21,6 +21,7 @@ import type {
   ExposureBudgetDto,
   NarrativeSection,
   OrgNarrativeReportSummary,
+  SweepProposalReason,
   TicketTriageSkip,
 } from '@breeze/shared';
 
@@ -501,18 +502,26 @@ const SWEEP_SEVERITY_BADGE: Record<AiSweepSeverity, string> = {
 
 /**
  * Every `reason` a non-created sweep proposal can carry (the gate order in
- * `projectSweep`/`sweepProposals`, #4189 Task 7). Checked before the dynamic
- * `t()` so an unrecognized token renders as itself rather than as a raw
- * `aiAgentsPage.runs.sweep.reasons.<token>` key path.
+ * `projectSweep`/`sweepProposals`, #4189 Task 7), keyed to itself so `satisfies
+ * Record<SweepProposalReason, true>` fails to compile if this map ever falls
+ * out of sync with the shared union (#4458) — a member added or removed from
+ * `SweepProposalReason` without a matching update here is a missing/excess
+ * property error, not a silent runtime gap.
  */
-const SWEEP_PROPOSAL_REASONS: readonly string[] = [
-  'device_not_in_evidence',
-  'device_not_in_org',
-  'not_allowlisted',
-  'no_eligible_approvers',
-  'intent_error',
-  'max_actions_per_run',
-];
+const SWEEP_PROPOSAL_REASON_TOKENS = {
+  device_not_in_evidence: true,
+  device_not_in_org: true,
+  not_allowlisted: true,
+  no_eligible_approvers: true,
+  intent_error: true,
+  max_actions_per_run: true,
+} satisfies Record<SweepProposalReason, true>;
+
+/**
+ * Checked before the dynamic `t()` so an unrecognized token renders as itself
+ * rather than as a raw `aiAgentsPage.runs.sweep.reasons.<token>` key path.
+ */
+const SWEEP_PROPOSAL_REASONS: readonly string[] = Object.keys(SWEEP_PROPOSAL_REASON_TOKENS);
 
 function sweepKindLabel(t: (key: string) => string, kind: AiSweepKind): string {
   return t(/* i18n-dynamic */ `aiAgentsPage.runs.sweep.kinds.${kind}`);

--- a/packages/shared/src/types/aiAgentRuns.ts
+++ b/packages/shared/src/types/aiAgentRuns.ts
@@ -433,6 +433,24 @@ export interface AiAgentRunAlertVerdictDto {
 }
 
 /**
+ * Why a sweep-finding proposal did not become a pending intent — either a
+ * refusal from one of gates 1-3 or `max_actions_per_run` from gate 4, or
+ * `no_eligible_approvers`/`intent_error` from gate 5's `createActionIntent`
+ * attempt (see `services/aiAgents/sweepFindings.ts`'s gate-order docstring).
+ * Display strings only — never a raw `Error.message` (same posture as
+ * `AlertVerdictSuggestionReason`/`TicketTriageSkipReason`). Shared between
+ * the API's internal `SweepProposalRecord.reason` (sweepFindings.ts) and this
+ * DTO so the two can never drift apart.
+ */
+export type SweepProposalReason =
+  | 'device_not_in_evidence'
+  | 'device_not_in_org'
+  | 'not_allowlisted'
+  | 'no_eligible_approvers'
+  | 'intent_error'
+  | 'max_actions_per_run';
+
+/**
  * Phase 2 wave P2-2 (scheduled sweeps) — the safe projection of one
  * `SweepFinding` for `GET /ai/agents/runs/:runId`'s detail DTO. Same
  * leak-impossible convention as the rest of this file: `evidence` is the
@@ -453,7 +471,7 @@ export interface AiAgentRunSweepFindingDto {
     tool: string;
     action: string | null;
     disposition: 'intent_created' | 'refused' | 'cap_reached' | 'error';
-    reason: string | null;
+    reason: SweepProposalReason | null;
     intentId: string | null;
   } | null;
 }


### PR DESCRIPTION
## Summary

- `SweepProposalReason` (AI agents wave P2-2, sweep-finding gate reasons like `device_not_in_evidence`) was defined API-side only in `apps/api/src/services/aiAgents/sweepFindings.ts`, and independently re-derived as an untyped string array on the web sweep-findings UI in `apps/web/src/components/aiAgents/RunDetailPage.tsx`, so the two could silently drift.
- Moved the union to `packages/shared/src/types/aiAgentRuns.ts`, matching the pattern already used for its two siblings in the same file (`AlertVerdictSuggestionReason` from P2-1, `TicketTriageSkipReason` from the #4462 follow-up). The API service and the web component both now import the same type from `@breeze/shared`; the local API-side declaration is removed.
- Tightened `AiAgentRunSweepFindingDto.proposal.reason` from `string | null` to `SweepProposalReason | null` — it was previously untyped.
- The web-side reason-token map (`SWEEP_PROPOSAL_REASON_TOKENS`) is now declared as `satisfies Record<SweepProposalReason, true>` instead of a plain `readonly string[]` literal, so a member added to or removed from the shared union without updating this map is a compile-time error (missing/excess property), not a silent runtime gap. Verified this actually fires by temporarily removing one key and confirming `tsc` failed with the expected "Property is missing" error, then restoring it.
- Checked the OpenAPI spec (`apps/api/src/openapi.ts`) for this enum — the sweep run-detail route (`GET /ai/agents/runs/:runId`) does not register an OpenAPI schema for this DTO, so there is nothing to repoint there.

## Test plan

- [x] `packages/shared`: `vitest run src/types/aiAgentRuns.test.ts` — 10 passed
- [x] `apps/api`: `vitest run src/services/aiAgents/sweepFindings.test.ts` — 22 passed
- [x] `apps/web`: `vitest run src/components/aiAgents/RunDetailPage.test.tsx` — 101 passed
- [x] `tsc --noEmit` clean in `packages/shared`, `apps/api`, `apps/web` (pre-existing, unrelated `quotes.test.ts` errors in `packages/shared` confirmed present on `origin/main` baseline too)
- [x] `eslint` clean on all three touched files
- [x] Manually verified the new `satisfies Record<SweepProposalReason, true>` guard actually fails to compile when a union member is dropped from the map

Closes #4458

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBxF7C8E5GxFnNcGf6kBVP