### PR TITLE
fix(api): extend non-UTC TZ CI coverage to tokenRevocation.ts (#4059)

### DIFF
--- a/apps/api/src/services/tokenRevocation.test.ts
+++ b/apps/api/src/services/tokenRevocation.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { Redis } from 'ioredis';
+import { pgOffsetlessTimestamp } from '../testUtils/pgOffsetlessTimestamp';
 
 const dbMocks = vi.hoisted(() => ({
   update: vi.fn(),
@@ -336,20 +337,73 @@ describe('tokenRevocation', () => {
   });
 
   describe('isTokenIssuedBeforePasswordChange', () => {
+    // #4059 gap 1: `passwordChangedAt` arrives from `users.password_changed_at`,
+    // a `timestamp` (no tz) column (apps/api/src/db/schema/users.ts). postgres.js
+    // parses that offsetless wire value with a bare `new Date(...)`, so the Date
+    // object handed to this function carries the UTC wall clock re-read as the
+    // HOST's local time — wrong by exactly the process's UTC offset on any
+    // non-UTC host. A fixture built from a literal `new Date(ms)` is unfaithful
+    // to that: it carries the true instant, which coincides with the misparsed
+    // value only when the host runs UTC. `pgOffsetlessTimestamp` (below)
+    // reproduces the actual driver round-trip using the process's real TZ, so
+    // these cases have teeth under `vitest.config.tz.ts` (TZ=America/Denver)
+    // and are a no-op under the default UTC CI run — same pattern already used
+    // for `sso_sessions.created_at` in routes/sso.reauth.test.ts (#4041).
     it('rejects tokens issued before passwordChangedAt', () => {
       expect(
-        isTokenIssuedBeforePasswordChange(1_700_000_000, new Date(1_700_000_010_000))
+        isTokenIssuedBeforePasswordChange(1_700_000_000, pgOffsetlessTimestamp(1_700_000_010_000))
       ).toBe(true);
     });
 
     it('allows tokens issued in the same second as passwordChangedAt', () => {
       expect(
-        isTokenIssuedBeforePasswordChange(1_700_000_010, new Date(1_700_000_010_500))
+        isTokenIssuedBeforePasswordChange(1_700_000_010, pgOffsetlessTimestamp(1_700_000_010_500))
       ).toBe(false);
     });
 
     it('fails closed for missing iat after a password change', () => {
-      expect(isTokenIssuedBeforePasswordChange(undefined, new Date())).toBe(true);
+      expect(isTokenIssuedBeforePasswordChange(undefined, pgOffsetlessTimestamp(Date.now()))).toBe(true);
+    });
+
+    // The two cases above are only non-vacuous under the real TZ pin
+    // (vitest.config.tz.ts), and only in the direction that pin's offset
+    // happens to exercise. `offsetlessTimestampFromHostAt` (mirroring the
+    // override-based simulation #4041 introduced in services/sso.test.ts)
+    // fakes an arbitrary host offset directly on the Date instance, so both
+    // directions of the bug are proven regardless of the process's actual TZ
+    // — these two pass or fail identically whether run via `vitest run` (UTC)
+    // or `vitest.config.tz.ts` (America/Denver).
+    function offsetlessTimestampFromHostAt(trueUtcMs: number, offsetMinutes: number): Date {
+      const naive = new Date(trueUtcMs + offsetMinutes * 60_000);
+      Object.defineProperty(naive, 'getTimezoneOffset', {
+        value: () => offsetMinutes,
+        configurable: true,
+      });
+      return naive;
+    }
+
+    it('rejects a token genuinely issued before the password change on a host east of UTC (auth-bypass direction)', () => {
+      const trueChangeMs = Date.UTC(2026, 0, 1, 12, 0, 0);
+      const tokenIssuedAt = Math.floor(trueChangeMs / 1000) - 3600; // truly 1h before the change
+
+      // Europe/Berlin (CET, UTC+1) -> getTimezoneOffset() = -60. An
+      // uncorrected read is 1h EARLIER than the true instant, which would
+      // make a stale token (issued before the real change) look like it was
+      // issued after it — the exact auth-bypass direction #4018 was filed for.
+      const east = offsetlessTimestampFromHostAt(trueChangeMs, -60);
+      expect(isTokenIssuedBeforePasswordChange(tokenIssuedAt, east)).toBe(true);
+    });
+
+    it('does not falsely revoke a token issued well after the password change on a host west of UTC', () => {
+      const trueChangeMs = Date.UTC(2026, 0, 1, 12, 0, 0);
+      const tokenIssuedAt = Math.floor(trueChangeMs / 1000) + 3 * 3600; // truly 3h after the change
+
+      // America/Denver (MDT, UTC-6) -> getTimezoneOffset() = 360. An
+      // uncorrected read is 6h LATER than the true instant, which would make
+      // a fresh token (issued after the real change) look stale and force a
+      // spurious logout.
+      const west = offsetlessTimestampFromHostAt(trueChangeMs, 360);
+      expect(isTokenIssuedBeforePasswordChange(tokenIssuedAt, west)).toBe(false);
     });
   });
 

--- a/apps/api/src/services/tokenRevocation.ts
+++ b/apps/api/src/services/tokenRevocation.ts
@@ -186,6 +186,20 @@ export async function revokeAllRefreshTokenFamiliesForUser(
   });
 }
 
+// `users.passwordChangedAt` is a `timestamp` (no tz) column
+// (apps/api/src/db/schema/users.ts). postgres.js parses that offsetless wire
+// value with a bare `new Date(...)`, so the Date object Drizzle hands back
+// carries the UTC wall clock re-read as THIS PROCESS's local time — wrong by
+// exactly the host's UTC offset on any non-UTC host. A caller-supplied string
+// (e.g. an already-serialized `toISOString()` value) is not affected: it
+// carries an explicit 'Z' offset, so `new Date(string).getTime()` is already
+// correct and must NOT be re-corrected here. Same defect class as #4018; see
+// services/sso.ts's `utcMsFromOffsetlessTimestamp` for the canonical writeup
+// and testUtils/pgOffsetlessTimestamp.ts for the test-side simulation.
+function utcMsFromOffsetlessDbTimestamp(value: Date): number {
+  return value.getTime() - value.getTimezoneOffset() * 60_000;
+}
+
 export function isTokenIssuedBeforePasswordChange(
   tokenIssuedAt: number | undefined,
   passwordChangedAt: Date | string | null | undefined
@@ -193,7 +207,7 @@ export function isTokenIssuedBeforePasswordChange(
   if (!passwordChangedAt) return false;
 
   const changedAtMs = passwordChangedAt instanceof Date
-    ? passwordChangedAt.getTime()
+    ? utcMsFromOffsetlessDbTimestamp(passwordChangedAt)
     : new Date(passwordChangedAt).getTime();
   if (!Number.isFinite(changedAtMs)) return false;
 

--- a/apps/api/vitest.config.tz.ts
+++ b/apps/api/vitest.config.tz.ts
@@ -36,17 +36,18 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    // MAINTENANCE (as of this PR, #4041 is still open): once #4041 merges,
-    // it adds two new TZ-sensitive test files that belong in this list and
-    // are NOT auto-discovered (this is a manual allowlist, not a broad
-    // glob) — add both when that PR lands:
-    //   'src/routes/sso.reauth.test.ts'
-    //   'src/testUtils/pgOffsetlessTimestamp.test.ts'
+    // This is a manual allowlist, not a broad glob — a new TZ-sensitive test
+    // file must be added here explicitly or it runs under UTC only.
     include: [
       'src/routes/auth.test.ts',
       'src/routes/auth.passkeys.test.ts',
       'src/routes/authenticator.test.ts',
       'src/routes/auth/**/*.test.ts',
+      // #4041's two offsetless-timestamp-simulation suites — previously
+      // missing from this list despite the PR merging (stale MAINTENANCE
+      // note caught during #4059).
+      'src/routes/sso.reauth.test.ts',
+      'src/testUtils/pgOffsetlessTimestamp.test.ts',
       'src/services/sso.test.ts',
       'src/services/ssoDomainVerification.test.ts',
       'src/services/mfa.test.ts',
@@ -62,6 +63,10 @@ export default defineConfig({
       'src/services/apiKeyAuthorization.test.ts',
       'src/services/approverWebAuthn.test.ts',
       'src/services/authEmailQueue.test.ts',
+      // #4059 gap 1: the last hop before a request is authorized/rejected on
+      // password-change revocation, same offsetless-timestamp bug shape as
+      // #4018 (see tokenRevocation.ts's isTokenIssuedBeforePasswordChange).
+      'src/services/tokenRevocation.test.ts',
       // Canary asserting the pin itself is active — see its own file
       // header. Deliberately excluded from vitest.config.ts (main) so it
       // fails loudly there if it's ever accidentally run under UTC.


### PR DESCRIPTION
## Summary

Gap 1 from #4059 only (see that issue for Gap 2, the repo-wide timestamp audit — explicitly out of scope here).

`isTokenIssuedBeforePasswordChange` (`apps/api/src/services/tokenRevocation.ts:189`, called from `middleware/auth.ts` and `routes/auth/login.ts` on every authenticated request) compared a JWT `iat` (UTC epoch) against `users.passwordChangedAt` — a `timestamp` column with no timezone — by calling `.getTime()` directly on the Date object. postgres.js parses that offsetless wire value with a bare `new Date(...)`, so the Date handed back carries the UTC wall clock re-read as the host's local time. This is the same bug shape as #4018:

- **East of UTC**: a stale token genuinely issued *before* the password change can read as issued *after* it — an auth-bypass.
- **West of UTC**: a fresh token genuinely issued *after* the password change can read as issued *before* it — a spurious forced logout.

`tokenRevocation.test.ts`'s existing fixtures passed literal `new Date(ms)` instants rather than simulating the driver's local-time misparse, and the file wasn't in `vitest.config.tz.ts`'s include list — so this couldn't have been caught either way.

## Changes

1. **`tokenRevocation.ts`**: added `utcMsFromOffsetlessDbTimestamp` and apply it on the `passwordChangedAt instanceof Date` branch only (a caller-supplied ISO string with an explicit offset is left alone).
2. **`tokenRevocation.test.ts`**: reshaped the `isTokenIssuedBeforePasswordChange` fixtures to use `pgOffsetlessTimestamp` (real-host-TZ simulation, matching `routes/sso.reauth.test.ts`) and added two new cases using a local `offsetlessTimestampFromHostAt`-style helper (arbitrary-offset simulation, matching `services/sso.test.ts`) that directly prove both bug directions independent of the process's actual TZ — both new cases were verified **red** against the pre-fix code under `TZ=America/Denver` before the production fix was applied, and are green now under both the main (UTC) and tz-pinned configs.
3. **`vitest.config.tz.ts`**: registered `tokenRevocation.test.ts`. Also added two files (`sso.reauth.test.ts`, `testUtils/pgOffsetlessTimestamp.test.ts`) that #4041 had already merged but never added despite the file's own MAINTENANCE comment saying to — removed the now-stale comment.

## Verification

```
TZ=America/Denver npx vitest run --config vitest.config.tz.ts src/services/tokenRevocation.test.ts
# before fix: 3 failed, 40 passed (both reshaped existing cases + both new bypass/revocation cases)
# after fix:  43 passed
```

- `npx vitest run --config vitest.config.tz.ts` (full config, 44 files): 1050 passed
- `npx vitest run src/services/tokenRevocation.test.ts` (main/UTC config): 43 passed
- Callers: `middleware/auth.test.ts`, `middleware/auth.epoch.test.ts`, `__tests__/authenticated.example.test.ts`, `__tests__/devices.endpoints.test.ts`, `routes/auth.test.ts`, `routes/auth/login.test.ts` — all green (322 tests)
- `npx tsc --noEmit` — clean

Refs #4059

🤖 Generated with [Claude Code](https://claude.com/claude-code)