### PR TITLE
feat(api/ai): explain runtime parameter delivery in Script Builder prompt (#4884)

### DIFF
--- a/apps/api/src/services/scriptBuilderPrompt.test.ts
+++ b/apps/api/src/services/scriptBuilderPrompt.test.ts
@@ -84,8 +84,7 @@ describe('buildScriptBuilderSystemPrompt — runtime parameter delivery', () => 
   });
 
   it('tells the assistant never to use a Mandatory param() block for a Breeze parameter', () => {
-    expect(prompt).toMatch(/Mandatory/);
-    expect(prompt).toContain('param()');
+    expect(prompt).toMatch(/Never write a param\(\) block with a Mandatory/);
   });
 
   it('tells the assistant never to read a bare $env:<Name>', () => {
@@ -103,7 +102,7 @@ describe('buildScriptBuilderSystemPrompt — runtime parameter delivery', () => 
   });
 
   it('forbids embedding a real customer value as a fallback in script code', () => {
-    expect(prompt).toMatch(/never embed/i);
+    expect(prompt).toMatch(/[Nn]ever embed a real customer value.*fallback/);
   });
 
   it('renders the derived BREEZE_PARAM_ env var name next to each declared editor parameter', () => {
@@ -118,5 +117,19 @@ describe('buildScriptBuilderSystemPrompt — runtime parameter delivery', () => 
     });
     expect(withParams).toContain('GoogleEmail → $env:BREEZE_PARAM_GOOGLEEMAIL');
     expect(withParams).toContain('log-level → $env:BREEZE_PARAM_LOG_LEVEL');
+  });
+
+  it('passes non-hyphen characters through unchanged (only "-" is folded to "_"), matching the agent executor exactly', () => {
+    // agent/internal/executor/executor.go buildEnvironment only folds "-" to
+    // "_" after upper-casing; a "." or space is NOT sanitized further. This
+    // pins that documented discrepancy from the issue's assumption of a
+    // general non-alphanumeric sanitizer.
+    const withParams = buildScriptBuilderSystemPrompt({
+      editorSnapshot: {
+        content: 'echo hi',
+        parameters: [{ name: 'api.key', type: 'string' }],
+      },
+    });
+    expect(withParams).toContain('api.key → $env:BREEZE_PARAM_API.KEY');
   });
 });

--- a/apps/api/src/services/scriptBuilderPrompt.test.ts
+++ b/apps/api/src/services/scriptBuilderPrompt.test.ts
@@ -55,3 +55,68 @@ describe('buildScriptBuilderSystemPrompt', () => {
     expect(prompt).toContain('echo hi');
   });
 });
+
+/**
+ * #4884 — the prompt never explained how Breeze actually delivers runtime
+ * parameters to a script, so the assistant guessed CLI args / bare $env:Name /
+ * Mandatory param() across multiple customer-visible failed runs before
+ * eventually discovering BREEZE_PARAM_* by trial and error. These pin the
+ * facts (verified against agent/internal/executor/executor.go buildEnvironment
+ * and shell.go SubstituteParameters) into the base prompt so every session
+ * gets them for free.
+ */
+describe('buildScriptBuilderSystemPrompt — runtime parameter delivery', () => {
+  const prompt = buildScriptBuilderSystemPrompt();
+
+  it('explains the BREEZE_PARAM_<NAME> env var derivation, including the hyphen-folding example', () => {
+    expect(prompt).toContain('BREEZE_PARAM_');
+    expect(prompt).toContain('log-level');
+    expect(prompt).toContain('BREEZE_PARAM_LOG_LEVEL');
+  });
+
+  it('explains the {{name}} / ${{name}} literal substitution path', () => {
+    expect(prompt).toContain('{{name}}');
+    expect(prompt).toContain('${{name}}');
+  });
+
+  it('states parameters are never passed as command-line arguments', () => {
+    expect(prompt).toMatch(/never.*(command-line|CLI) argument/i);
+  });
+
+  it('tells the assistant never to use a Mandatory param() block for a Breeze parameter', () => {
+    expect(prompt).toMatch(/Mandatory/);
+    expect(prompt).toContain('param()');
+  });
+
+  it('tells the assistant never to read a bare $env:<Name>', () => {
+    expect(prompt).toContain('$env:<Name>');
+  });
+
+  it('distinguishes BREEZE_VAR_* (tenant secrets, SYSTEM/elevated only) from BREEZE_PARAM_*', () => {
+    expect(prompt).toContain('BREEZE_VAR_');
+    expect(prompt).toMatch(/SYSTEM|elevated/);
+  });
+
+  it('instructs checking the actual execution/runAs before theorising about a missing-parameter report', () => {
+    expect(prompt).toContain('get_script_execution');
+    expect(prompt).toMatch(/runAs/);
+  });
+
+  it('forbids embedding a real customer value as a fallback in script code', () => {
+    expect(prompt).toMatch(/never embed/i);
+  });
+
+  it('renders the derived BREEZE_PARAM_ env var name next to each declared editor parameter', () => {
+    const withParams = buildScriptBuilderSystemPrompt({
+      editorSnapshot: {
+        content: 'Get-ChildItem',
+        parameters: [
+          { name: 'GoogleEmail', type: 'string', required: true },
+          { name: 'log-level', type: 'string' },
+        ],
+      },
+    });
+    expect(withParams).toContain('GoogleEmail → $env:BREEZE_PARAM_GOOGLEEMAIL');
+    expect(withParams).toContain('log-level → $env:BREEZE_PARAM_LOG_LEVEL');
+  });
+});

--- a/apps/api/src/services/scriptBuilderPrompt.ts
+++ b/apps/api/src/services/scriptBuilderPrompt.ts
@@ -1,6 +1,18 @@
 import type { ScriptBuilderContext } from '@breeze/shared/types/ai';
 
 /**
+ * Mirrors the agent's own derivation in `buildEnvironment`
+ * (agent/internal/executor/executor.go): upper-case the parameter name and
+ * fold "-" to "_", prefixed with BREEZE_PARAM_. Any other non-alphanumeric
+ * character is passed through unchanged by the agent, so it is passed
+ * through unchanged here too — keep parameter names alphanumeric-and-hyphen
+ * only in practice.
+ */
+function toBreezeParamEnvVar(name: string): string {
+  return `BREEZE_PARAM_${name.toUpperCase().replaceAll('-', '_')}`;
+}
+
+/**
  * Build the system prompt for a script builder AI session.
  * Includes the base persona, tool usage instructions, and current editor state.
  */
@@ -39,7 +51,19 @@ status output as [OK], [X], [!], -> and * instead. On Windows these characters a
 mis-decoded and silently turn into string delimiters, which breaks the script with
 parse errors that point at the wrong line.
 
-IMPORTANT: Always use apply_script_code to deliver code to the editor, not just a code block in the chat. The chat message should explain the code; the tool applies it to the editor.`;
+IMPORTANT: Always use apply_script_code to deliver code to the editor, not just a code block in the chat. The chat message should explain the code; the tool applies it to the editor.
+
+--- Runtime parameters ---
+Parameters declared via apply_script_metadata are delivered to the running script two ways, simultaneously, by the Breeze agent:
+(a) as an environment variable named BREEZE_PARAM_<NAME>, where <NAME> is the parameter's declared name upper-cased with every "-" folded to "_" (other characters are passed through as-is, so keep parameter names alphanumeric-and-hyphen only). Example: a parameter named "log-level" is read as $env:BREEZE_PARAM_LOG_LEVEL (PowerShell) or "$BREEZE_PARAM_LOG_LEVEL" (Bash).
+(b) by literal text substitution of {{name}} and \${{name}} placeholders directly in the script body, before the script is written to disk.
+Parameters are NEVER passed as command-line arguments to the script. Concretely:
+- Never write a param() block with a Mandatory parameter for a Breeze parameter — the script is invoked with no arguments, so PowerShell's parameter binder fails before your code runs. Instead read the env var and validate it yourself: if it is empty, print a clear "[X] <Name> parameter is required" message and exit non-zero.
+- Never read a bare $env:<Name> (i.e. without the BREEZE_PARAM_ prefix) — that variable does not exist. Always use $env:BREEZE_PARAM_<NAME>.
+- The parameter name shown in metadata and the env var name your code reads must match under the derivation above — double check this when you declare a parameter.
+BREEZE_VAR_* is a separate, unrelated prefix for tenant/secret variables (API keys, credentials) and is only populated when the script runs as SYSTEM or elevated — never conflate it with BREEZE_PARAM_* (runtime parameters), which are always delivered regardless of runAs.
+If a run reports a parameter as missing, read the actual failing execution first (get_script_execution) and check what runAs it used before theorising about which code path ran it — do not guess based on Test Run vs. execute_script_on_device without evidence.
+Never embed a real customer value (email address, hostname, API key, etc.) into script code as a fallback or default — always read it from the BREEZE_PARAM_ / BREEZE_VAR_ environment.`;
 
   const contextParts: string[] = [];
   if (context?.scriptId) {
@@ -67,6 +91,10 @@ IMPORTANT: Always use apply_script_code to deliver code to the editor, not just 
   if (snap.timeoutSeconds) parts.push(`Timeout: ${snap.timeoutSeconds}s`);
   if (snap.parameters?.length) {
     parts.push(`Parameters: ${JSON.stringify(snap.parameters)}`);
+    const derivations = snap.parameters.map(
+      (p) => `${p.name} → $env:${toBreezeParamEnvVar(p.name)}`,
+    );
+    parts.push(`Runtime env vars for these parameters: ${derivations.join(', ')}`);
   }
 
   parts.push(`\nContent:\n\`\`\`\n${snap.content || '(empty)'}\n\`\`\``);


### PR DESCRIPTION
## Summary

The Script Builder system prompt (`apps/api/src/services/scriptBuilderPrompt.ts`) told the assistant it could declare parameters via `apply_script_metadata` but never explained how Breeze actually delivers them to the running script. Left to guess, the assistant cycled through wrong mechanisms (CLI args, bare `$env:Name`, `Mandatory` `param()`) across multiple customer-visible failed runs on the OliveTech tenant before discovering `BREEZE_PARAM_*` by trial and error (see #4884 for the full transcript).

Adds a "Runtime parameters" section to the base prompt, stating as verified fact:

- Parameters are delivered **two ways, simultaneously**: (a) as `BREEZE_PARAM_<NAME>` env vars, where `<NAME>` is the declared parameter name upper-cased with `-` folded to `_`; (b) by literal `{{name}}` / `${{name}}` substitution in the script body before it's written to disk. They are **never** passed as command-line arguments.
- Never write a `Mandatory` `param()` block for a Breeze parameter (the binder fails before the script runs since there are no CLI args) — read the env var and validate manually.
- Never read a bare `$env:<Name>` — always the `BREEZE_PARAM_` prefixed form.
- `BREEZE_VAR_*` is a separate, unrelated prefix for tenant/secret variables, populated only for SYSTEM/elevated runs.
- On a "parameter missing" report, check the actual execution's `runAs` via `get_script_execution` before theorising.
- Never hard-code a real customer value into script code as a fallback.

Also renders the derived `BREEZE_PARAM_` env var name next to each declared parameter in the editor-snapshot section (e.g. `GoogleEmail → $env:BREEZE_PARAM_GOOGLEEMAIL`) so the assistant doesn't have to compute it.

## Facts verified against the executor before writing the prompt

- `agent/internal/executor/executor.go:335-361` (`buildEnvironment`): `envKey := "BREEZE_PARAM_" + strings.ToUpper(strings.ReplaceAll(key, "-", "_"))`. Confirms upper-case + hyphen-folding. **Discrepancy from the issue text:** the issue implies a general "non-alphanumeric" sanitization; the actual code only folds `-` to `_` — any other character (space, dot, etc.) passes through unchanged after upper-casing. The prompt now states this precisely and advises keeping parameter names alphanumeric-and-hyphen.
- `agent/internal/executor/shell.go:174-190` (`SubstituteParameters`): confirms literal `{{key}}` / `${{key}}` replacement in the script body, done before `WriteScriptFile`.
- `agent/internal/executor/executor.go:160-178`: confirmed `cmd.Args` is built from `shellArgs + scriptPath` only — parameters are never appended as CLI args.
- `apps/api/src/services/scriptSecretDelivery.ts` (`runAsSupportsSecretEnv`): confirms `BREEZE_VAR_*` (tenant secrets) is gated to unset/`system`/`elevated` `runAs` — matches the issue's "SYSTEM/elevated only" claim.

## Scope

Per the fan-out plan, this PR only touches `scriptBuilderPrompt.ts` + its test. The issue also suggested updating the general fleet AI's `run_script` tool description in `apps/api/src/services/aiToolsScripts.ts` — that is deliberately left to #4888, which owns that file, to avoid file-level conflicts with sibling PRs (#4883 also touches adjacent script-execution files).

## Test plan

- [x] Red-first: added 9 new assertions to `scriptBuilderPrompt.test.ts` pinning the BREEZE_PARAM_ derivation, the `{{name}}`/`${{name}}` substitution mention, the "never CLI args" / "never Mandatory param()" / "never bare $env:<Name>" instructions, the BREEZE_VAR_* distinction, the runAs-check-first instruction, the no-hardcoded-values instruction, and the editor-snapshot derived-env-var rendering — watched them fail against the unmodified prompt.
- [x] Implemented the prompt section + `toBreezeParamEnvVar` helper; all 13 tests in the file pass: `cd apps/api && npx vitest run src/services/scriptBuilderPrompt.test.ts`
- [x] `cd apps/api && npx tsc --noEmit` clean

Closes #4884

🤖 Generated with [Claude Code](https://claude.com/claude-code)