### PR TITLE
fix(agent): deliver script parameters on the runAs=user helper path (#4882)

### DIFF
--- a/agent/internal/executor/parameters.go
+++ b/agent/internal/executor/parameters.go
@@ -1,0 +1,48 @@
+package executor
+
+// ParametersFromPayload decodes a script command payload's "parameters" field
+// into the string-only map ScriptExecution.Parameters expects.
+//
+// ONE decoder, deliberately, for the two places that build a ScriptExecution
+// from a server-supplied payload:
+//
+//   - heartbeat.handleScriptInner — the SYSTEM-context local executor, and
+//   - userhelper.Client.executeScript — the runAs=user hop, where the daemon
+//     re-marshals the raw payload over IPC and the helper process rebuilds the
+//     ScriptExecution on the other side.
+//
+// Those two drifted once already (#4882): only the daemon decoded parameters,
+// so every user-context script reached the shell with no BREEZE_PARAM_* and
+// with its {{name}} placeholders unexpanded, while the byte-identical script
+// in SYSTEM context ran fine. A parameterised script therefore failed with the
+// script's own "parameter is required" error and nothing in the agent logs
+// pointed at the cause. Sharing the decode is what makes that divergence
+// impossible to reintroduce by editing one site.
+//
+// Non-string values are dropped rather than coerced: the server only ever
+// sends strings (script_executions.parameters is a string map), and
+// stringifying a JSON number here would make the helper produce a value the
+// SYSTEM path never would — reintroducing drift in the opposite direction.
+//
+// Returns nil when the payload has no "parameters" object at all. nil and an
+// empty map behave identically downstream (SubstituteParameters returns the
+// content untouched; buildEnvironment appends nothing), so callers may assign
+// the result unconditionally.
+//
+// SecretEnv is deliberately NOT handled here. Secrets are parsed and validated
+// by ParseSecretEnv on the daemon only, and runAsSupportsSecrets refuses a
+// secret-bearing runAs=user run outright (#3409) — the helper must never gain a
+// second delivery route for BREEZE_VAR_*.
+func ParametersFromPayload(raw any) map[string]string {
+	params, ok := raw.(map[string]any)
+	if !ok {
+		return nil
+	}
+	decoded := make(map[string]string, len(params))
+	for key, value := range params {
+		if s, ok := value.(string); ok {
+			decoded[key] = s
+		}
+	}
+	return decoded
+}

--- a/agent/internal/executor/parameters.go
+++ b/agent/internal/executor/parameters.go
@@ -1,5 +1,11 @@
 package executor
 
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
 // ParametersFromPayload decodes a script command payload's "parameters" field
 // into the string-only map ScriptExecution.Parameters expects.
 //
@@ -36,13 +42,35 @@ package executor
 func ParametersFromPayload(raw any) map[string]string {
 	params, ok := raw.(map[string]any)
 	if !ok {
+		// Absent is the ordinary case for an unparameterised script and says
+		// nothing. Present-but-not-an-object means a producer broke the wire
+		// contract, and the script is about to run with its placeholders
+		// intact and no BREEZE_PARAM_* — exactly the invisible failure #4882
+		// was. Log the type (never the content) so it is diagnosable from
+		// agent logs instead of only from the script's own error message.
+		if raw != nil {
+			log.Warn("script command carried a non-object `parameters` field; running with no parameters",
+				"payloadType", fmt.Sprintf("%T", raw))
+		}
 		return nil
 	}
 	decoded := make(map[string]string, len(params))
+	var dropped []string
 	for key, value := range params {
 		if s, ok := value.(string); ok {
 			decoded[key] = s
+			continue
 		}
+		dropped = append(dropped, key)
+	}
+	if len(dropped) > 0 {
+		// The server canonicalises every value to a string before dispatch
+		// (canonicalizeScriptParameters), so reaching here means that
+		// chokepoint was bypassed. Keys only — a value is operator-supplied
+		// content that has no business in the agent log.
+		sort.Strings(dropped)
+		log.Warn("dropping non-string script parameter values",
+			"keys", strings.Join(dropped, ","))
 	}
 	return decoded
 }

--- a/agent/internal/executor/parameters_test.go
+++ b/agent/internal/executor/parameters_test.go
@@ -1,8 +1,11 @@
 package executor
 
 import (
+	"bytes"
 	"encoding/json"
+	"log/slog"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -63,4 +66,73 @@ func TestParametersFromPayloadMatchesJSONRoundTrip(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("after a JSON round trip got %#v, want %#v", got, want)
 	}
+}
+
+// captureExecutorLog swaps the package logger for the duration of a test and
+// returns the buffer it writes to. Safe because no test in this package calls
+// t.Parallel(), and the swap is restored on cleanup.
+func captureExecutorLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := log
+	log = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	t.Cleanup(func() { log = prev })
+	return &buf
+}
+
+// TestParametersFromPayloadWarnsOnBrokenWireContract proves the diagnostic
+// actually fires. #4882 was invisible precisely because a dropped parameter
+// produced no agent-side signal at all — a tripwire that silently does not
+// trip would reproduce that, so assert it rather than assume it.
+func TestParametersFromPayloadWarnsOnBrokenWireContract(t *testing.T) {
+	t.Run("non-object parameters field", func(t *testing.T) {
+		buf := captureExecutorLog(t)
+		if got := ParametersFromPayload("GoogleEmail=x"); got != nil {
+			t.Fatalf("got %#v, want nil", got)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "non-object") {
+			t.Fatalf("expected a warning about the non-object payload, got %q", out)
+		}
+		if !strings.Contains(out, "payloadType=string") {
+			t.Errorf("warning should name the offending type, got %q", out)
+		}
+	})
+
+	t.Run("absent parameters field stays silent", func(t *testing.T) {
+		buf := captureExecutorLog(t)
+		if got := ParametersFromPayload(nil); got != nil {
+			t.Fatalf("got %#v, want nil", got)
+		}
+		if out := buf.String(); out != "" {
+			t.Fatalf("an unparameterised script must log nothing, got %q", out)
+		}
+	})
+
+	t.Run("dropped non-string values name their keys only", func(t *testing.T) {
+		buf := captureExecutorLog(t)
+		got := ParametersFromPayload(map[string]any{
+			"keep":    "yes",
+			"retries": float64(3),
+			"flag":    true,
+		})
+		if !reflect.DeepEqual(got, map[string]string{"keep": "yes"}) {
+			t.Fatalf("got %#v", got)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "keys=flag,retries") {
+			t.Fatalf("expected the dropped keys, sorted, got %q", out)
+		}
+		if strings.Contains(out, "keep") {
+			t.Errorf("a kept key must not be reported as dropped, got %q", out)
+		}
+	})
+
+	t.Run("all-string map stays silent", func(t *testing.T) {
+		buf := captureExecutorLog(t)
+		ParametersFromPayload(map[string]any{"GoogleEmail": "user@example.com"})
+		if out := buf.String(); out != "" {
+			t.Fatalf("the ordinary case must log nothing, got %q", out)
+		}
+	})
 }

--- a/agent/internal/executor/parameters_test.go
+++ b/agent/internal/executor/parameters_test.go
@@ -1,0 +1,66 @@
+package executor
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestParametersFromPayload(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  any
+		want map[string]string
+	}{
+		{name: "absent", raw: nil, want: nil},
+		{name: "wrong type", raw: "GoogleEmail=x", want: nil},
+		{name: "empty object", raw: map[string]any{}, want: map[string]string{}},
+		{
+			name: "strings kept",
+			raw:  map[string]any{"GoogleEmail": "user@example.com", "tenant-domain": "example.com"},
+			want: map[string]string{"GoogleEmail": "user@example.com", "tenant-domain": "example.com"},
+		},
+		{
+			name: "non-strings dropped, not coerced",
+			raw:  map[string]any{"keep": "yes", "retries": float64(3), "flag": true, "nested": map[string]any{"a": "b"}, "null": nil},
+			want: map[string]string{"keep": "yes"},
+		},
+		{
+			name: "empty string value is a real value",
+			raw:  map[string]any{"optional": ""},
+			want: map[string]string{"optional": ""},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ParametersFromPayload(tc.raw)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("ParametersFromPayload(%#v) = %#v, want %#v", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParametersFromPayloadMatchesJSONRoundTrip proves the decoder handles the
+// shape it actually sees on the runAs=user path: a payload that has been
+// marshalled to JSON by the daemon and unmarshalled by the helper, where every
+// number has become float64 and nothing carries Go type information.
+func TestParametersFromPayloadMatchesJSONRoundTrip(t *testing.T) {
+	wire, err := json.Marshal(map[string]any{
+		"parameters": map[string]any{"GoogleEmail": "user@example.com", "retries": 3},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(wire, &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	got := ParametersFromPayload(payload["parameters"])
+	want := map[string]string{"GoogleEmail": "user@example.com"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("after a JSON round trip got %#v, want %#v", got, want)
+	}
+}

--- a/agent/internal/executor/parameters_test.go
+++ b/agent/internal/executor/parameters_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -69,15 +70,63 @@ func TestParametersFromPayloadMatchesJSONRoundTrip(t *testing.T) {
 }
 
 // captureExecutorLog swaps the package logger for the duration of a test and
-// returns the buffer it writes to. Safe because no test in this package calls
-// t.Parallel(), and the swap is restored on cleanup.
-func captureExecutorLog(t *testing.T) *bytes.Buffer {
+// returns a reader for the records it emitted. Safe because no test in this
+// package calls t.Parallel(), and the swap is restored on cleanup.
+//
+// JSON rather than text so a test can assert on the ATTRIBUTE SET, not just on
+// substrings. That distinction matters here: the guarantee under test is that
+// a parameter VALUE never reaches the log, and a substring check for a short
+// value like "3" would match the timestamp instead of proving anything.
+func captureExecutorLog(t *testing.T) func() []map[string]any {
 	t.Helper()
 	var buf bytes.Buffer
 	prev := log
-	log = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	log = slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	t.Cleanup(func() { log = prev })
-	return &buf
+
+	return func() []map[string]any {
+		t.Helper()
+		var records []map[string]any
+		for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+			if line == "" {
+				continue
+			}
+			var rec map[string]any
+			if err := json.Unmarshal([]byte(line), &rec); err != nil {
+				t.Fatalf("log line is not JSON (%v): %s", err, line)
+			}
+			records = append(records, rec)
+		}
+		return records
+	}
+}
+
+// attrNames returns a record's attribute names, sorted, so a test can pin the
+// exact shape of a log line. Adding an attribute that carries a value would
+// change this set and redden the assertion.
+//
+// The expected sets below are slog's own three (time/level/msg) plus whatever
+// the call site adds. They deliberately omit the `component=executor`
+// attribute the real package logger carries: captureExecutorLog installs a
+// bare handler, and the guarantee under test is about what
+// ParametersFromPayload itself attaches, not about the logger's own framing.
+func attrNames(rec map[string]any) []string {
+	names := make([]string, 0, len(rec))
+	for k := range rec {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// onlyRecord asserts exactly one log record was emitted and returns it.
+func onlyRecord(t *testing.T, read func() []map[string]any) map[string]any {
+	t.Helper()
+	records := read()
+	if len(records) != 1 {
+		t.Fatalf("expected exactly one log record, got %d: %#v", len(records), records)
+	}
+	return records[0]
 }
 
 // TestParametersFromPayloadWarnsOnBrokenWireContract proves the diagnostic
@@ -86,31 +135,37 @@ func captureExecutorLog(t *testing.T) *bytes.Buffer {
 // trip would reproduce that, so assert it rather than assume it.
 func TestParametersFromPayloadWarnsOnBrokenWireContract(t *testing.T) {
 	t.Run("non-object parameters field", func(t *testing.T) {
-		buf := captureExecutorLog(t)
-		if got := ParametersFromPayload("GoogleEmail=x"); got != nil {
+		read := captureExecutorLog(t)
+		if got := ParametersFromPayload("GoogleEmail=user@example.com"); got != nil {
 			t.Fatalf("got %#v, want nil", got)
 		}
-		out := buf.String()
-		if !strings.Contains(out, "non-object") {
-			t.Fatalf("expected a warning about the non-object payload, got %q", out)
+		rec := onlyRecord(t, read)
+		if !strings.Contains(rec["msg"].(string), "non-object") {
+			t.Fatalf("expected a warning about the non-object payload, got %#v", rec)
 		}
-		if !strings.Contains(out, "payloadType=string") {
-			t.Errorf("warning should name the offending type, got %q", out)
+		if rec["payloadType"] != "string" {
+			t.Errorf("payloadType = %#v, want the offending Go type", rec["payloadType"])
+		}
+		// Pinning the attribute set is the actual content guarantee: the
+		// offending payload was itself operator data, and nothing here may
+		// carry it. A new attribute holding the value would change this set.
+		if got, want := attrNames(rec), []string{"level", "msg", "payloadType", "time"}; !reflect.DeepEqual(got, want) {
+			t.Errorf("log attributes = %v, want exactly %v — an added attribute may be leaking payload content", got, want)
 		}
 	})
 
 	t.Run("absent parameters field stays silent", func(t *testing.T) {
-		buf := captureExecutorLog(t)
+		read := captureExecutorLog(t)
 		if got := ParametersFromPayload(nil); got != nil {
 			t.Fatalf("got %#v, want nil", got)
 		}
-		if out := buf.String(); out != "" {
-			t.Fatalf("an unparameterised script must log nothing, got %q", out)
+		if records := read(); len(records) != 0 {
+			t.Fatalf("an unparameterised script must log nothing, got %#v", records)
 		}
 	})
 
-	t.Run("dropped non-string values name their keys only", func(t *testing.T) {
-		buf := captureExecutorLog(t)
+	t.Run("dropped non-string values name their keys and never their values", func(t *testing.T) {
+		read := captureExecutorLog(t)
 		got := ParametersFromPayload(map[string]any{
 			"keep":    "yes",
 			"retries": float64(3),
@@ -119,20 +174,30 @@ func TestParametersFromPayloadWarnsOnBrokenWireContract(t *testing.T) {
 		if !reflect.DeepEqual(got, map[string]string{"keep": "yes"}) {
 			t.Fatalf("got %#v", got)
 		}
-		out := buf.String()
-		if !strings.Contains(out, "keys=flag,retries") {
-			t.Fatalf("expected the dropped keys, sorted, got %q", out)
+
+		rec := onlyRecord(t, read)
+		if rec["keys"] != "flag,retries" {
+			t.Fatalf("keys = %#v, want the dropped keys sorted", rec["keys"])
 		}
-		if strings.Contains(out, "keep") {
-			t.Errorf("a kept key must not be reported as dropped, got %q", out)
+		// The stated guarantee is keys-only. Assert it structurally rather
+		// than by substring: a dropped value like 3 or true is far too short
+		// to search for in a rendered line without matching the timestamp or
+		// the level, so pin the attribute set instead. A mutation that added
+		// `"values", "3,true"` would satisfy every other assertion here and
+		// only this one catches it.
+		if got, want := attrNames(rec), []string{"keys", "level", "msg", "time"}; !reflect.DeepEqual(got, want) {
+			t.Errorf("log attributes = %v, want exactly %v — a value-bearing attribute must never be added", got, want)
+		}
+		if strings.Contains(rec["keys"].(string), "keep") {
+			t.Errorf("a kept key must not be reported as dropped, got %#v", rec["keys"])
 		}
 	})
 
 	t.Run("all-string map stays silent", func(t *testing.T) {
-		buf := captureExecutorLog(t)
+		read := captureExecutorLog(t)
 		ParametersFromPayload(map[string]any{"GoogleEmail": "user@example.com"})
-		if out := buf.String(); out != "" {
-			t.Fatalf("the ordinary case must log nothing, got %q", out)
+		if records := read(); len(records) != 0 {
+			t.Fatalf("the ordinary case must log nothing, got %#v", records)
 		}
 	})
 }

--- a/agent/internal/heartbeat/handlers_script.go
+++ b/agent/internal/heartbeat/handlers_script.go
@@ -125,14 +125,11 @@ func handleScriptInner(h *Heartbeat, cmd Command, secretEnv executor.SecretEnv) 
 		RunAs:      tools.GetPayloadString(cmd.Payload, "runAs", ""),
 	}
 	script.RunAs = strings.TrimSpace(script.RunAs)
-	if params, ok := cmd.Payload["parameters"].(map[string]any); ok {
-		script.Parameters = make(map[string]string, len(params))
-		for k, v := range params {
-			if s, ok := v.(string); ok {
-				script.Parameters[k] = s
-			}
-		}
-	}
+	// Shared with userhelper.Client.executeScript, which rebuilds this same
+	// struct on the far side of the runAs=user IPC hop — see #4882, where only
+	// this site decoded parameters and every user-context script ran without
+	// them.
+	script.Parameters = executor.ParametersFromPayload(cmd.Payload["parameters"])
 	// Validated by handleScript's ParseSecretEnv. Deliberately set AFTER the
 	// parameters block: secrets ride the process environment (buildEnvironment)
 	// and must never reach SubstituteParameters or validateScript, which would

--- a/agent/internal/heartbeat/handlers_script_parameters_test.go
+++ b/agent/internal/heartbeat/handlers_script_parameters_test.go
@@ -2,6 +2,7 @@ package heartbeat
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -52,6 +53,37 @@ func serveOneHelperCommand(t *testing.T, clientIPC *ipc.Conn) <-chan map[string]
 	return payloads
 }
 
+// newPinnedRunAsUserHelper wires a run_as_user helper session onto a broker
+// whose session-selection path is pinned to `goos`, and returns the heartbeat
+// plus the client end of the IPC pair.
+//
+// The pinning matters and is easy to get wrong. resolveRunAsSession ends in
+// Broker.preferredRunAsUserSessionForOS, which has two entirely different
+// bodies: the non-Windows branch takes the newest run_as_user session and
+// never looks at WinSessionID, while the Windows branch additionally requires
+// the session to sit in the active console session (#1009). Without
+// SetGOOSForTest the branch taken is whatever the test host happens to be, so
+// setting WinSessionID alone is inert on Linux/macOS — it reads as coverage of
+// the console binding while exercising the fallback. Pin both, and drive both
+// values of goos from the caller.
+func newPinnedRunAsUserHelper(t *testing.T, goos, sessionID string) (*Heartbeat, *ipc.Conn) {
+	t.Helper()
+
+	serverConn, clientConn := createTestSocketPair(t)
+	t.Cleanup(func() { _ = clientConn.Close() })
+
+	session := sessionbroker.NewSession(ipc.NewConn(serverConn), 1000, "1000", "testuser", "quartz", sessionID, []string{"run_as_user"})
+	session.WinSessionID = "1"
+	t.Cleanup(func() { _ = session.Close() })
+	go session.RecvLoop(func(*sessionbroker.Session, *ipc.Envelope) {})
+
+	broker := newTestBrokerWithSessions(t, session)
+	broker.SetGOOSForTest(goos)
+	broker.SetConsoleSessionIDFunc(func() string { return "1" })
+
+	return newTestHeartbeat(broker), ipc.NewConn(clientConn)
+}
+
 // TestHandleScriptForwardsParametersToUserHelper is the daemon half of #4882:
 // the fix lives in the helper, but it is only reachable if the re-marshalled
 // payload sendCommandToUserHelper puts on the wire still carries
@@ -59,60 +91,52 @@ func serveOneHelperCommand(t *testing.T, clientIPC *ipc.Conn) <-chan map[string]
 // the daemon side (a whitelist, a DTO, a rename) reddens a test instead of
 // silently re-breaking every runAs=user script.
 func TestHandleScriptForwardsParametersToUserHelper(t *testing.T) {
-	serverConn, clientConn := createTestSocketPair(t)
-	t.Cleanup(func() { _ = clientConn.Close() })
+	// Both session-selection branches, on every host: the console-session
+	// filter is Windows-only, so running just one of these would leave the
+	// other unexercised wherever CI happens to run.
+	for _, goos := range []string{"linux", "windows"} {
+		t.Run(goos, func(t *testing.T) {
+			h, clientIPC := newPinnedRunAsUserHelper(t, goos, "helper-params-"+goos)
+			payloads := serveOneHelperCommand(t, clientIPC)
 
-	serverIPC := ipc.NewConn(serverConn)
-	clientIPC := ipc.NewConn(clientConn)
+			result := handleScript(h, Command{
+				ID:   "cmd-params-" + goos,
+				Type: tools.CmdScript,
+				Payload: map[string]any{
+					"content":        `echo "{{GoogleEmail}}"`,
+					"language":       "bash",
+					"runAs":          "user",
+					"scriptId":       "script-4882",
+					"timeoutSeconds": 10,
+					"parameters":     map[string]any{"GoogleEmail": "gcpw.user@example.com"},
+				},
+			})
+			if result.Status != "completed" {
+				t.Fatalf("expected completed, got %s (%s)", result.Status, result.Error)
+			}
 
-	session := sessionbroker.NewSession(serverIPC, 1000, "1000", "testuser", "quartz", "helper-params", []string{"run_as_user"})
-	// Pin the console-session binding (#1009) so resolveRunAsSession selects
-	// this helper on Windows too, not only on hosts where that binding is a
-	// no-op — otherwise the test is silently platform-dependent.
-	session.WinSessionID = "1"
-	t.Cleanup(func() { _ = session.Close() })
-	go session.RecvLoop(func(*sessionbroker.Session, *ipc.Envelope) {})
+			payload, ok := <-payloads
+			if !ok {
+				t.Fatal("user helper never received the forwarded command")
+			}
 
-	payloads := serveOneHelperCommand(t, clientIPC)
-
-	broker := newTestBrokerWithSessions(t, session)
-	broker.SetConsoleSessionIDFunc(func() string { return "1" })
-	h := newTestHeartbeat(broker)
-	result := handleScript(h, Command{
-		ID:   "cmd-params",
-		Type: tools.CmdScript,
-		Payload: map[string]any{
-			"content":        `echo "{{GoogleEmail}}"`,
-			"language":       "bash",
-			"runAs":          "user",
-			"scriptId":       "script-4882",
-			"timeoutSeconds": 10,
-			"parameters":     map[string]any{"GoogleEmail": "gcpw.user@example.com"},
-		},
-	})
-	if result.Status != "completed" {
-		t.Fatalf("expected completed, got %s (%s)", result.Status, result.Error)
-	}
-
-	payload, ok := <-payloads
-	if !ok {
-		t.Fatal("user helper never received the forwarded command")
-	}
-
-	params, ok := payload["parameters"].(map[string]any)
-	if !ok {
-		t.Fatalf("forwarded payload dropped `parameters`; got keys %v", payloadKeys(payload))
-	}
-	if params["GoogleEmail"] != "gcpw.user@example.com" {
-		t.Errorf("parameters[GoogleEmail] = %#v, want the delivered value", params["GoogleEmail"])
-	}
-	if payload["scriptId"] != "script-4882" {
-		t.Errorf("forwarded payload scriptId = %#v, want script-4882", payload["scriptId"])
-	}
-	// The daemon must not have substituted the placeholder before forwarding —
-	// substitution is the helper executor's job, on the content it received.
-	if payload["content"] != `echo "{{GoogleEmail}}"` {
-		t.Errorf("forwarded content = %#v, want the unsubstituted script", payload["content"])
+			params, ok := payload["parameters"].(map[string]any)
+			if !ok {
+				t.Fatalf("forwarded payload dropped `parameters`; got keys %v", payloadKeys(payload))
+			}
+			if params["GoogleEmail"] != "gcpw.user@example.com" {
+				t.Errorf("parameters[GoogleEmail] = %#v, want the delivered value", params["GoogleEmail"])
+			}
+			if payload["scriptId"] != "script-4882" {
+				t.Errorf("forwarded payload scriptId = %#v, want script-4882", payload["scriptId"])
+			}
+			// The daemon must not have substituted the placeholder before
+			// forwarding — substitution is the helper executor's job, on the
+			// content it received.
+			if payload["content"] != `echo "{{GoogleEmail}}"` {
+				t.Errorf("forwarded content = %#v, want the unsubstituted script", payload["content"])
+			}
+		})
 	}
 }
 
@@ -120,17 +144,15 @@ func TestHandleScriptForwardsParametersToUserHelper(t *testing.T) {
 // place: #4882 forwards `parameters` to the helper, and nothing more. A
 // secret-bearing runAs=user run must still be refused before any forwarding
 // happens, so a credential never reaches the IPC hop at all.
+//
+// The helper is deliberately resolvable (pinned the same way as the test
+// above) so "nothing was forwarded" is a real result rather than the trivial
+// consequence of there being nowhere to forward to. The error text is
+// asserted for the same reason: without it, the generic "no eligible user
+// helper" failure would satisfy the status check and the test would pass for
+// the wrong reason.
 func TestHandleScriptRefusesSecretEnvForRunAsUser(t *testing.T) {
-	serverConn, clientConn := createTestSocketPair(t)
-	t.Cleanup(func() { _ = clientConn.Close() })
-
-	serverIPC := ipc.NewConn(serverConn)
-	clientIPC := ipc.NewConn(clientConn)
-
-	session := sessionbroker.NewSession(serverIPC, 1000, "1000", "testuser", "quartz", "helper-secret", []string{"run_as_user"})
-	session.WinSessionID = "1"
-	t.Cleanup(func() { _ = session.Close() })
-	go session.RecvLoop(func(*sessionbroker.Session, *ipc.Envelope) {})
+	h, clientIPC := newPinnedRunAsUserHelper(t, "windows", "helper-secret")
 
 	forwarded := make(chan struct{}, 1)
 	go func() {
@@ -140,9 +162,6 @@ func TestHandleScriptRefusesSecretEnvForRunAsUser(t *testing.T) {
 		}
 	}()
 
-	broker := newTestBrokerWithSessions(t, session)
-	broker.SetConsoleSessionIDFunc(func() string { return "1" })
-	h := newTestHeartbeat(broker)
 	result := handleScript(h, Command{
 		ID:   "cmd-secret-user",
 		Type: tools.CmdScript,
@@ -160,6 +179,12 @@ func TestHandleScriptRefusesSecretEnvForRunAsUser(t *testing.T) {
 
 	if result.Status != "failed" {
 		t.Fatalf("secret-bearing runAs=user run must be refused, got %s", result.Status)
+	}
+	if !strings.Contains(result.Error, "secret variables") {
+		t.Fatalf("refusal must be the #3409 secret gate, got %q", result.Error)
+	}
+	if strings.Contains(result.Error, "hunter2-not-a-real-credential") {
+		t.Errorf("the refusal leaked the credential: %q", result.Error)
 	}
 	select {
 	case <-forwarded:

--- a/agent/internal/heartbeat/handlers_script_parameters_test.go
+++ b/agent/internal/heartbeat/handlers_script_parameters_test.go
@@ -66,12 +66,18 @@ func TestHandleScriptForwardsParametersToUserHelper(t *testing.T) {
 	clientIPC := ipc.NewConn(clientConn)
 
 	session := sessionbroker.NewSession(serverIPC, 1000, "1000", "testuser", "quartz", "helper-params", []string{"run_as_user"})
+	// Pin the console-session binding (#1009) so resolveRunAsSession selects
+	// this helper on Windows too, not only on hosts where that binding is a
+	// no-op — otherwise the test is silently platform-dependent.
+	session.WinSessionID = "1"
 	t.Cleanup(func() { _ = session.Close() })
 	go session.RecvLoop(func(*sessionbroker.Session, *ipc.Envelope) {})
 
 	payloads := serveOneHelperCommand(t, clientIPC)
 
-	h := newTestHeartbeat(newTestBrokerWithSessions(t, session))
+	broker := newTestBrokerWithSessions(t, session)
+	broker.SetConsoleSessionIDFunc(func() string { return "1" })
+	h := newTestHeartbeat(broker)
 	result := handleScript(h, Command{
 		ID:   "cmd-params",
 		Type: tools.CmdScript,
@@ -122,6 +128,7 @@ func TestHandleScriptRefusesSecretEnvForRunAsUser(t *testing.T) {
 	clientIPC := ipc.NewConn(clientConn)
 
 	session := sessionbroker.NewSession(serverIPC, 1000, "1000", "testuser", "quartz", "helper-secret", []string{"run_as_user"})
+	session.WinSessionID = "1"
 	t.Cleanup(func() { _ = session.Close() })
 	go session.RecvLoop(func(*sessionbroker.Session, *ipc.Envelope) {})
 
@@ -133,7 +140,9 @@ func TestHandleScriptRefusesSecretEnvForRunAsUser(t *testing.T) {
 		}
 	}()
 
-	h := newTestHeartbeat(newTestBrokerWithSessions(t, session))
+	broker := newTestBrokerWithSessions(t, session)
+	broker.SetConsoleSessionIDFunc(func() string { return "1" })
+	h := newTestHeartbeat(broker)
 	result := handleScript(h, Command{
 		ID:   "cmd-secret-user",
 		Type: tools.CmdScript,

--- a/agent/internal/heartbeat/handlers_script_parameters_test.go
+++ b/agent/internal/heartbeat/handlers_script_parameters_test.go
@@ -1,0 +1,168 @@
+package heartbeat
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/executor"
+	"github.com/breeze-rmm/agent/internal/ipc"
+	"github.com/breeze-rmm/agent/internal/remote/tools"
+	"github.com/breeze-rmm/agent/internal/sessionbroker"
+)
+
+// serveOneHelperCommand stands in for a connected user helper: it reads
+// exactly one forwarded IPC command, hands the decoded payload back on the
+// returned channel, and answers with a canned success result so the caller
+// does not block on the IPC wait.
+func serveOneHelperCommand(t *testing.T, clientIPC *ipc.Conn) <-chan map[string]any {
+	t.Helper()
+	payloads := make(chan map[string]any, 1)
+	go func() {
+		defer close(payloads)
+		_ = clientIPC.SetReadDeadline(time.Now().Add(5 * time.Second))
+		env, err := clientIPC.Recv()
+		if err != nil {
+			t.Errorf("helper recv: %v", err)
+			return
+		}
+
+		var ipcCmd ipc.IPCCommand
+		if err := json.Unmarshal(env.Payload, &ipcCmd); err != nil {
+			t.Errorf("unmarshal forwarded command: %v", err)
+			return
+		}
+		var payload map[string]any
+		if err := json.Unmarshal(ipcCmd.Payload, &payload); err != nil {
+			t.Errorf("unmarshal forwarded payload: %v", err)
+			return
+		}
+		payloads <- payload
+
+		resultPayload, _ := json.Marshal(map[string]any{"exitCode": 0, "stdout": "ok", "stderr": ""})
+		respBody, _ := json.Marshal(ipc.IPCCommandResult{
+			CommandID: env.ID,
+			Status:    "completed",
+			Result:    resultPayload,
+		})
+		if err := clientIPC.Send(&ipc.Envelope{ID: env.ID, Type: ipc.TypeCommandResult, Payload: respBody}); err != nil {
+			t.Errorf("helper send: %v", err)
+		}
+	}()
+	return payloads
+}
+
+// TestHandleScriptForwardsParametersToUserHelper is the daemon half of #4882:
+// the fix lives in the helper, but it is only reachable if the re-marshalled
+// payload sendCommandToUserHelper puts on the wire still carries
+// `parameters`. Asserting it here means a future payload-shaping change on
+// the daemon side (a whitelist, a DTO, a rename) reddens a test instead of
+// silently re-breaking every runAs=user script.
+func TestHandleScriptForwardsParametersToUserHelper(t *testing.T) {
+	serverConn, clientConn := createTestSocketPair(t)
+	t.Cleanup(func() { _ = clientConn.Close() })
+
+	serverIPC := ipc.NewConn(serverConn)
+	clientIPC := ipc.NewConn(clientConn)
+
+	session := sessionbroker.NewSession(serverIPC, 1000, "1000", "testuser", "quartz", "helper-params", []string{"run_as_user"})
+	t.Cleanup(func() { _ = session.Close() })
+	go session.RecvLoop(func(*sessionbroker.Session, *ipc.Envelope) {})
+
+	payloads := serveOneHelperCommand(t, clientIPC)
+
+	h := newTestHeartbeat(newTestBrokerWithSessions(t, session))
+	result := handleScript(h, Command{
+		ID:   "cmd-params",
+		Type: tools.CmdScript,
+		Payload: map[string]any{
+			"content":        `echo "{{GoogleEmail}}"`,
+			"language":       "bash",
+			"runAs":          "user",
+			"scriptId":       "script-4882",
+			"timeoutSeconds": 10,
+			"parameters":     map[string]any{"GoogleEmail": "gcpw.user@example.com"},
+		},
+	})
+	if result.Status != "completed" {
+		t.Fatalf("expected completed, got %s (%s)", result.Status, result.Error)
+	}
+
+	payload, ok := <-payloads
+	if !ok {
+		t.Fatal("user helper never received the forwarded command")
+	}
+
+	params, ok := payload["parameters"].(map[string]any)
+	if !ok {
+		t.Fatalf("forwarded payload dropped `parameters`; got keys %v", payloadKeys(payload))
+	}
+	if params["GoogleEmail"] != "gcpw.user@example.com" {
+		t.Errorf("parameters[GoogleEmail] = %#v, want the delivered value", params["GoogleEmail"])
+	}
+	if payload["scriptId"] != "script-4882" {
+		t.Errorf("forwarded payload scriptId = %#v, want script-4882", payload["scriptId"])
+	}
+	// The daemon must not have substituted the placeholder before forwarding —
+	// substitution is the helper executor's job, on the content it received.
+	if payload["content"] != `echo "{{GoogleEmail}}"` {
+		t.Errorf("forwarded content = %#v, want the unsubstituted script", payload["content"])
+	}
+}
+
+// TestHandleScriptRefusesSecretEnvForRunAsUser keeps the #3409 refusal in
+// place: #4882 forwards `parameters` to the helper, and nothing more. A
+// secret-bearing runAs=user run must still be refused before any forwarding
+// happens, so a credential never reaches the IPC hop at all.
+func TestHandleScriptRefusesSecretEnvForRunAsUser(t *testing.T) {
+	serverConn, clientConn := createTestSocketPair(t)
+	t.Cleanup(func() { _ = clientConn.Close() })
+
+	serverIPC := ipc.NewConn(serverConn)
+	clientIPC := ipc.NewConn(clientConn)
+
+	session := sessionbroker.NewSession(serverIPC, 1000, "1000", "testuser", "quartz", "helper-secret", []string{"run_as_user"})
+	t.Cleanup(func() { _ = session.Close() })
+	go session.RecvLoop(func(*sessionbroker.Session, *ipc.Envelope) {})
+
+	forwarded := make(chan struct{}, 1)
+	go func() {
+		_ = clientIPC.SetReadDeadline(time.Now().Add(2 * time.Second))
+		if _, err := clientIPC.Recv(); err == nil {
+			forwarded <- struct{}{}
+		}
+	}()
+
+	h := newTestHeartbeat(newTestBrokerWithSessions(t, session))
+	result := handleScript(h, Command{
+		ID:   "cmd-secret-user",
+		Type: tools.CmdScript,
+		Payload: map[string]any{
+			"content":        `echo "$BREEZE_VAR_API_TOKEN"`,
+			"language":       "bash",
+			"runAs":          "user",
+			"timeoutSeconds": 10,
+			"parameters":     map[string]any{"GoogleEmail": "gcpw.user@example.com"},
+			executor.SecretEnvPayloadKey: map[string]any{
+				"api_token": "hunter2-not-a-real-credential",
+			},
+		},
+	})
+
+	if result.Status != "failed" {
+		t.Fatalf("secret-bearing runAs=user run must be refused, got %s", result.Status)
+	}
+	select {
+	case <-forwarded:
+		t.Fatal("a secret-bearing command was forwarded to the user helper")
+	case <-time.After(300 * time.Millisecond):
+	}
+}
+
+func payloadKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/agent/internal/userhelper/client.go
+++ b/agent/internal/userhelper/client.go
@@ -766,10 +766,33 @@ func (c *Client) executeScript(cmd ipc.IPCCommand) ipc.IPCCommandResult {
 		}
 	}
 
+	// This mirrors heartbeat.handleScriptInner's ScriptExecution — the daemon
+	// re-marshals the raw command payload over IPC and this process rebuilds
+	// the execution, so anything the daemon reads off the payload and this
+	// site does not is silently lost for every runAs=user run.
+	//
+	// #4882: ScriptID and Parameters were exactly that. Without Parameters,
+	// buildEnvironment emitted no BREEZE_PARAM_* and SubstituteParameters had
+	// nothing to substitute, so a parameterised script failed with its own
+	// "parameter is required" error in user context while the identical run in
+	// SYSTEM context succeeded. ParametersFromPayload is the one decoder both
+	// sites now use.
+	//
+	// Two fields are deliberately absent:
+	//
+	//   - SecretEnv. BREEZE_VAR_* is a SYSTEM-context-only capability;
+	//     runAsSupportsSecrets (#3409) refuses a secret-bearing runAs=user run
+	//     on the daemon before it forwards anything, and the helper must not
+	//     become a second delivery route for it.
+	//   - RunAs. This process IS the target user, so the execution is already
+	//     in the right context; forwarding runAs="user" would make
+	//     executor.configureRunAs reject its own delivery.
 	script := executor.ScriptExecution{
 		ID:         cmd.CommandID,
+		ScriptID:   getStringOrDefault(payload, "scriptId", ""),
 		ScriptType: getStringOrDefault(payload, "language", "bash"),
 		Script:     getStringOrDefault(payload, "content", ""),
+		Parameters: executor.ParametersFromPayload(payload["parameters"]),
 		Timeout:    getIntOrDefault(payload, "timeoutSeconds", 300),
 	}
 

--- a/agent/internal/userhelper/client_parameters_test.go
+++ b/agent/internal/userhelper/client_parameters_test.go
@@ -1,0 +1,153 @@
+package userhelper
+
+import (
+	"encoding/json"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/executor"
+	"github.com/breeze-rmm/agent/internal/ipc"
+	"github.com/breeze-rmm/agent/internal/remote/tools"
+)
+
+// decodeHelperScriptStdout pulls the stdout field out of the IPC result
+// payload executeScript marshals.
+func decodeHelperScriptStdout(t *testing.T, result ipc.IPCCommandResult) string {
+	t.Helper()
+	if result.Status != "completed" {
+		t.Fatalf("expected completed, got %s (%s)", result.Status, result.Error)
+	}
+	var payload struct {
+		ExitCode int    `json:"exitCode"`
+		Stdout   string `json:"stdout"`
+		Stderr   string `json:"stderr"`
+	}
+	if err := json.Unmarshal(result.Result, &payload); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if payload.ExitCode != 0 {
+		t.Fatalf("exitCode = %d, stderr = %q", payload.ExitCode, payload.Stderr)
+	}
+	return payload.Stdout
+}
+
+// TestExecuteScriptDeliversParameters is the regression guard for #4882:
+// the helper rebuilt executor.ScriptExecution from the forwarded payload but
+// never decoded `parameters`, so every runAs=user run reached the shell with
+// no BREEZE_PARAM_* environment and with its {{name}} placeholders unexpanded
+// — while the identical script in SYSTEM context worked. Covers all three
+// consequences of the drop: the env var, the template substitution, and the
+// "-" → "_" key folding buildEnvironment applies.
+func TestExecuteScriptDeliversParameters(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("script execution test requires Unix/macOS shell")
+	}
+
+	c := New("/tmp/test.sock", ipc.HelperRoleUser)
+
+	result := c.executeScript(ipc.IPCCommand{
+		CommandID: "exec-params",
+		Type:      tools.CmdScript,
+		Payload: marshalPayload(t, map[string]any{
+			"language":       "bash",
+			"scriptId":       "script-4882",
+			"timeoutSeconds": 10,
+			"content": strings.Join([]string{
+				`echo "env=$BREEZE_PARAM_GOOGLEEMAIL"`,
+				`echo "folded=$BREEZE_PARAM_TENANT_DOMAIN"`,
+				`echo "sub={{GoogleEmail}}"`,
+				`echo "scriptid=$BREEZE_SCRIPT_ID"`,
+			}, "\n"),
+			"parameters": map[string]any{
+				"GoogleEmail":   "gcpw.user@example.com",
+				"tenant-domain": "example.com",
+				// Non-string values are dropped, matching the daemon's
+				// string-only filter in handlers_script.go.
+				"retries": 3,
+			},
+		}),
+	})
+
+	stdout := decodeHelperScriptStdout(t, result)
+
+	if !strings.Contains(stdout, "env=gcpw.user@example.com") {
+		t.Errorf("BREEZE_PARAM_GOOGLEEMAIL missing from the spawned process environment; stdout = %q", stdout)
+	}
+	if !strings.Contains(stdout, "folded=example.com") {
+		t.Errorf("BREEZE_PARAM_TENANT_DOMAIN (dash folded to underscore) missing; stdout = %q", stdout)
+	}
+	if !strings.Contains(stdout, "sub=gcpw.user@example.com") {
+		t.Errorf("{{GoogleEmail}} was not substituted into the script content; stdout = %q", stdout)
+	}
+	if !strings.Contains(stdout, "scriptid=script-4882") {
+		t.Errorf("BREEZE_SCRIPT_ID missing — ScriptID was not decoded from the payload; stdout = %q", stdout)
+	}
+}
+
+// TestExecuteScriptWithoutParametersLeavesPlaceholdersAlone confirms the
+// no-parameters case is unchanged: nothing is substituted and no stray
+// BREEZE_PARAM_* entry appears.
+func TestExecuteScriptWithoutParametersLeavesPlaceholdersAlone(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("script execution test requires Unix/macOS shell")
+	}
+
+	c := New("/tmp/test.sock", ipc.HelperRoleUser)
+
+	result := c.executeScript(ipc.IPCCommand{
+		CommandID: "exec-no-params",
+		Type:      tools.CmdScript,
+		Payload: marshalPayload(t, map[string]any{
+			"language":       "bash",
+			"timeoutSeconds": 10,
+			"content":        `echo "sub={{GoogleEmail}}"; echo "count=$(printenv | grep -c '^BREEZE_PARAM_' || true)"`,
+		}),
+	})
+
+	stdout := decodeHelperScriptStdout(t, result)
+
+	if !strings.Contains(stdout, "sub={{GoogleEmail}}") {
+		t.Errorf("placeholder must be left intact when no parameters were sent; stdout = %q", stdout)
+	}
+	if !strings.Contains(stdout, "count=0") {
+		t.Errorf("expected zero BREEZE_PARAM_* entries; stdout = %q", stdout)
+	}
+}
+
+// TestExecuteScriptNeverDeliversSecretEnv locks in the #3409 refusal from the
+// other side of the IPC hop. handleScript already refuses a secret-bearing
+// runAs=user run before it forwards anything (runAsSupportsSecrets), but the
+// helper must not become a second delivery route if a `secretEnv` key ever
+// reaches it: BREEZE_VAR_* is a SYSTEM-context-only capability, and #4882's
+// fix (decoding `parameters` here) must not be widened into decoding secrets
+// here too.
+func TestExecuteScriptNeverDeliversSecretEnv(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("script execution test requires Unix/macOS shell")
+	}
+
+	c := New("/tmp/test.sock", ipc.HelperRoleUser)
+
+	result := c.executeScript(ipc.IPCCommand{
+		CommandID: "exec-secretenv",
+		Type:      tools.CmdScript,
+		Payload: marshalPayload(t, map[string]any{
+			"language":       "bash",
+			"timeoutSeconds": 10,
+			"content":        `echo "count=$(printenv | grep -c '^BREEZE_VAR_' || true)"; echo "value=[$BREEZE_VAR_API_TOKEN]"`,
+			executor.SecretEnvPayloadKey: map[string]any{
+				"api_token": "hunter2-not-a-real-credential",
+			},
+		}),
+	})
+
+	stdout := decodeHelperScriptStdout(t, result)
+
+	if !strings.Contains(stdout, "count=0") {
+		t.Errorf("user-context runs must never receive BREEZE_VAR_* entries; stdout = %q", stdout)
+	}
+	if strings.Contains(stdout, "hunter2-not-a-real-credential") {
+		t.Errorf("a secretEnv value reached the user-context process environment; stdout = %q", stdout)
+	}
+}

--- a/agent/internal/userhelper/client_parameters_test.go
+++ b/agent/internal/userhelper/client_parameters_test.go
@@ -151,3 +151,81 @@ func TestExecuteScriptNeverDeliversSecretEnv(t *testing.T) {
 		t.Errorf("a secretEnv value reached the user-context process environment; stdout = %q", stdout)
 	}
 }
+
+// TestExecuteScriptDeliversMetacharacterValueLiterallyInEnvironment covers the
+// safe half of parameter delivery. BREEZE_PARAM_* rides Cmd.Env, which is
+// never shell-parsed, so a value full of metacharacters must arrive byte-exact
+// rather than being re-interpreted. This matters now in a way it did not
+// before #4882: this path delivers parameters at all for the first time.
+func TestExecuteScriptDeliversMetacharacterValueLiterallyInEnvironment(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("script execution test requires Unix/macOS shell")
+	}
+
+	const meta = `a;b && c | d $(printf zz) "q" 'r'`
+
+	c := New("/tmp/test.sock", ipc.HelperRoleUser)
+
+	result := c.executeScript(ipc.IPCCommand{
+		CommandID: "exec-meta-env",
+		Type:      tools.CmdScript,
+		Payload: marshalPayload(t, map[string]any{
+			"language":       "bash",
+			"timeoutSeconds": 10,
+			// Read through the environment only — the placeholder is
+			// deliberately absent from the content, since substitution puts a
+			// value into shell SOURCE, where metacharacters are code.
+			"content":    `printf 'raw=%s\n' "$BREEZE_PARAM_META"`,
+			"parameters": map[string]any{"meta": meta},
+		}),
+	})
+
+	stdout := decodeHelperScriptStdout(t, result)
+
+	// Byte-exactness is the whole assertion: any shell evaluation of the
+	// substring `$(printf zz)` would rewrite the line, so an exact match
+	// proves the value was never re-interpreted.
+	if got, want := strings.TrimRight(stdout, "\n"), "raw="+meta; got != want {
+		t.Fatalf("BREEZE_PARAM_META was not delivered byte-exact.\n got: %q\nwant: %q", got, want)
+	}
+}
+
+// TestExecuteScriptValidatesAfterParameterSubstitution is the other half:
+// substitution writes the value into shell SOURCE, so the security validator
+// has to see the resolved text. executor.Execute substitutes first and
+// validates second, and the documented contract (docs/features/scripts.mdx)
+// says a parameter value that injects a dangerous command is caught.
+//
+// Before #4882 the helper path could not reach this at all — nothing was
+// substituted, so a dangerous value was inert here and the parity with the
+// SYSTEM path was untested. Now that parameters are live on this path, prove
+// the validator is live with them.
+//
+// The payload is deliberately harmless if the validator ever fails open: it
+// resolves to `echo Format-Volume`, which matches the PowerShell volume-format
+// pattern as TEXT while doing nothing but printing a word.
+func TestExecuteScriptValidatesAfterParameterSubstitution(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("script execution test requires Unix/macOS shell")
+	}
+
+	c := New("/tmp/test.sock", ipc.HelperRoleUser)
+
+	result := c.executeScript(ipc.IPCCommand{
+		CommandID: "exec-dangerous-param",
+		Type:      tools.CmdScript,
+		Payload: marshalPayload(t, map[string]any{
+			"language":       "bash",
+			"timeoutSeconds": 10,
+			"content":        `echo {{marker}}`,
+			"parameters":     map[string]any{"marker": "Format-Volume"},
+		}),
+	})
+
+	if result.Status != "failed" {
+		t.Fatalf("a parameter value that resolves to a dangerous pattern must be refused, got status %q (result %s)", result.Status, string(result.Result))
+	}
+	if !strings.Contains(result.Error, "script validation failed") {
+		t.Errorf("expected the validator's refusal, got error %q", result.Error)
+	}
+}


### PR DESCRIPTION
## Problem

Scripts executed in the user's session (`runAs=user`, or any run forwarded to the user helper over IPC) never received their runtime parameters. The script saw no `BREEZE_PARAM_*` environment variables and `{{name}}` template substitution never happened, so any parameterised script failed in user context with its own "parameter is required" error while the byte-identical run in SYSTEM context succeeded.

Observed in production (US, API 0.109.0, OliveTech tenant, 2026-09-04): every run of the `GCPW - Map Google Email to Windows User` script that landed in `C:\WINDOWS\SystemTemp\breeze-scripts\` completed; every run that landed in the helper's temp dir (`C:\Users\<user>\AppData\Local\Temp\breeze-scripts\`) failed with `GoogleEmail parameter is required but was not provided.` That split is exactly system-vs-user execution path, not script content.

## Root cause

Two sites build an `executor.ScriptExecution` from a server payload:

| Site | `parameters` | `scriptId` |
|---|---|---|
| `heartbeat.handleScriptInner` (SYSTEM, local executor) | decoded | decoded |
| `userhelper.Client.executeScript` (the process that actually runs a `runAs=user` script) | **dropped** | **dropped** |

The daemon re-marshals the raw payload over IPC (`sendCommandToUserHelper`) and the helper rebuilds the execution on the other side — so anything the daemon reads off the payload and the helper does not is silently lost. `executor.buildEnvironment` therefore emitted no `BREEZE_PARAM_*` and `SubstituteParameters` had nothing to substitute.

Verified: `apps/api/src/services/scriptDispatch.ts` sends `parameters` (canonicalised to a string map) and `scriptId` on every script command regardless of `runAs`, and only `secretEnv` is enveloped for `script` commands — so `parameters` arrives at the helper intact and plaintext. The gap was entirely the helper's decode.

## Fix

- New `executor.ParametersFromPayload` — **one** string-only decoder, called from **both** sites so they cannot drift again. Non-string values are dropped rather than coerced (matching the prior daemon behaviour and the server's own canonicalisation).
- The helper's `ScriptExecution` now sets `Parameters` and `ScriptID`.

### Deliberately unchanged

- **`SecretEnv` is still never decoded by the helper.** `BREEZE_VAR_*` remains SYSTEM-context-only: `runAsSupportsSecrets` (#3409) refuses a secret-bearing `runAs=user` run on the daemon *before* anything is forwarded, and this change must not become a second delivery route. Asserted from both sides.
- **`RunAs` is not forwarded.** The helper process is already the target user; forwarding `runAs="user"` would make `executor.configureRunAs` reject its own delivery.

### Scope

The explicit `targetSessionId` path (`executeScriptInSession`) benefits with no further change — both of its branches end in `executeViaUserHelper`, which forwards the same raw payload. `ScriptExecution{` has exactly two non-test construction sites repo-wide (`grep`-verified); both now share the decoder.

## Tests (red-first)

Written and watched fail before the implementation:

- **`userhelper/client_parameters_test.go`** — a forwarded `script` command carrying `parameters` now produces `BREEZE_PARAM_GOOGLEEMAIL` in the *spawned process environment*, folds `tenant-domain` to `BREEZE_PARAM_TENANT_DOMAIN`, substitutes `{{GoogleEmail}}` into the content, and sets `BREEZE_SCRIPT_ID`. Confirmed red on all four assertions before the fix (`stdout = "env=\nfolded=\nsub={{GoogleEmail}}\nscriptid=\n"`).
- **`userhelper`** — a payload carrying `secretEnv` still yields zero `BREEZE_VAR_*` entries and never leaks the value; and the no-parameters case leaves placeholders intact with zero `BREEZE_PARAM_*` entries.
- **`heartbeat/handlers_script_parameters_test.go`** — `handleScript`'s re-marshalled payload still carries `parameters` (and leaves `content` unsubstituted) across the IPC hop. **Mutation-probed**: deleting the key in `sendCommandToUserHelper` reddens it, so the control is real rather than vacuous.
- **`heartbeat`** — a secret-bearing `runAs=user` run is refused and nothing reaches the wire.
- **`executor/parameters_test.go`** — table tests for `ParametersFromPayload`, including the post-JSON-round-trip shape (`float64` numbers, no Go type info) the helper actually sees.

## Verification

```
cd agent && go test -race ./internal/userhelper/... ./internal/heartbeat/... ./internal/executor/...
ok  github.com/breeze-rmm/agent/internal/userhelper  2.267s
ok  github.com/breeze-rmm/agent/internal/heartbeat  40.865s
ok  github.com/breeze-rmm/agent/internal/executor   2.558s
```

`go build ./...` and `go vet` on all three packages clean. No TypeScript touched.

## Rollout note

This is an agent-side fix, so it takes effect only once the agent fleet rolls to a build containing it — the API needs no change.

Closes #4882

🤖 Generated with [Claude Code](https://claude.com/claude-code)