### PR TITLE
fix(api/ai): check the session allowlist against the exposed MCP tool name (#4883)

### DIFF
--- a/apps/api/src/routes/scriptAi.ts
+++ b/apps/api/src/routes/scriptAi.ts
@@ -26,7 +26,11 @@ import {
   approveToolSchema,
   scriptBuilderContextSchema,
 } from '@breeze/shared/validators/ai';
-import { createScriptBuilderMcpServer, SCRIPT_BUILDER_MCP_TOOL_NAMES } from '../services/scriptBuilderTools';
+import {
+  createScriptBuilderMcpServer,
+  SCRIPT_BUILDER_MCP_SERVER_NAME,
+  SCRIPT_BUILDER_MCP_TOOL_NAMES,
+} from '../services/scriptBuilderTools';
 import { captureException } from '../services/sentry';
 import { db } from '../db';
 import { aiSessions, aiMessages } from '../db/schema';
@@ -237,7 +241,7 @@ scriptAiRoutes.post(
         // Custom MCP server factory for script builder tools
         (getAuth, onPreToolUse, onPostToolUse) => ({
           server: createScriptBuilderMcpServer(getAuth, onPreToolUse, onPostToolUse),
-          name: 'script_builder',
+          name: SCRIPT_BUILDER_MCP_SERVER_NAME,
         }),
       );
     } catch (err) {

--- a/apps/api/src/services/actionIntents/secretBearingTools.ts
+++ b/apps/api/src/services/actionIntents/secretBearingTools.ts
@@ -12,6 +12,7 @@
  * enumerate it for fail-closed contract tests without gaining a mutable
  * security registry.
  */
+import { stripMcpPrefix } from '../mcpToolNames';
 import { encryptSecret } from '../secretCrypto';
 import {
   ACTION_INTENT_RESULT_AAD,
@@ -52,22 +53,6 @@ export const SECRET_UNAVAILABLE_TEXT =
 
 /** Prose tripwire for the shape that caused the original Google leak. */
 const PROSE_CREDENTIAL_PATTERN = /Temporary password:\s*(?!\[REDACTED\]|\[redacted\])\S/;
-
-/**
- * Local copy of aiAgentSdk's stripMcpPrefix. Duplicated rather than imported
- * to avoid an import cycle (aiAgentSdk imports this module). Must stay in
- * sync with the canonical algorithm: this predicate gates both the
- * pre-execution refusal (aiAgentSdkTools.ts) and assertNoPlaintextSecret
- * below, so a narrower normalization here (e.g. only literal
- * "mcp__breeze__") lets a differently-prefixed tool name slip past both
- * checks and fails OPEN — reinstating the plaintext-leak class this module
- * exists to close.
- */
-function stripMcpPrefix(toolName: string): string {
-  if (!toolName.startsWith('mcp__')) return toolName;
-  const separatorIndex = toolName.indexOf('__', 'mcp__'.length);
-  return separatorIndex === -1 ? toolName : toolName.slice(separatorIndex + 2);
-}
 
 export function isSecretBearingTool(toolName: string): boolean {
   const bare = stripMcpPrefix(toolName);

--- a/apps/api/src/services/aiAgentSdk.test.ts
+++ b/apps/api/src/services/aiAgentSdk.test.ts
@@ -93,6 +93,8 @@ vi.mock('./aiAgentSdkTools', () => ({
     // tests below stub via checkGuardrails, not this map.
     file_operations: 1,
     get_device_details: 1,
+    // #4883: the handler behind script builder's `execute_script_on_device`.
+    run_script: 3,
   },
   BREEZE_MCP_TOOL_NAMES: [],
 }));
@@ -1622,6 +1624,87 @@ describe('createSessionPreToolUse', () => {
       toolName: 'take_screenshot',
       status: 'executing',
     }));
+  });
+
+  // #4883: script builder exposes `execute_script_on_device` but dispatches to
+  // the `run_script` handler. The session allowlist only ever holds the exposed
+  // MCP name, so the gate must be told which name the session actually granted
+  // — checking the handler name denied every Script Builder test run before
+  // tier/approval logic ran at all.
+  describe('#4883: tools exposed under a different name than their handler', () => {
+    const SCRIPT_BUILDER_ALLOWLIST = ['mcp__script_builder__execute_script_on_device'];
+
+    it('allows the call when the EXPOSED MCP name is on the allowlist', async () => {
+      vi.mocked(checkGuardrails).mockReturnValue({
+        allowed: true,
+        tier: 2,
+        requiresApproval: false,
+        description: 'Run script on device',
+      } as any);
+      const values = mockInsertValues();
+      const session = makeActiveSession({
+        approvalMode: 'auto_approve',
+        allowedTools: SCRIPT_BUILDER_ALLOWLIST,
+      });
+
+      const result = await createSessionPreToolUse(session)(
+        'run_script',
+        { scriptId: 'script-1' },
+        'mcp__script_builder__execute_script_on_device',
+      );
+
+      expect(result).toEqual({ allowed: true });
+      // Only the allowlist check moved to the exposed name. Tier, RBAC and the
+      // audit row still describe the capability that actually runs.
+      expect(checkGuardrails).toHaveBeenCalledWith('run_script', { scriptId: 'script-1' });
+      expect(checkToolPermission).toHaveBeenCalledWith(
+        'run_script',
+        { scriptId: 'script-1' },
+        session.auth,
+      );
+      expect(values).toHaveBeenCalledWith(expect.objectContaining({
+        toolName: 'run_script',
+        status: 'executing',
+      }));
+    });
+
+    it('does not widen the allowlist — the bare handler name alone is still denied', async () => {
+      const session = makeActiveSession({
+        approvalMode: 'auto_approve',
+        allowedTools: SCRIPT_BUILDER_ALLOWLIST,
+      });
+
+      const result = await createSessionPreToolUse(session)('run_script', {});
+
+      expect(result).toEqual({
+        allowed: false,
+        error: "Tool 'run_script' is not allowed for this session",
+      });
+      expect(checkGuardrails).not.toHaveBeenCalled();
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('rejects an exposed name the session never granted', async () => {
+      const session = makeActiveSession({
+        approvalMode: 'auto_approve',
+        allowedTools: SCRIPT_BUILDER_ALLOWLIST,
+      });
+
+      const result = await createSessionPreToolUse(session)(
+        'take_screenshot',
+        {},
+        'mcp__script_builder__take_screenshot',
+      );
+
+      // Named by the model-facing tool, not the internal handler, so the
+      // assistant can tell the user which capability it lacks.
+      expect(result).toEqual({
+        allowed: false,
+        error: "Tool 'take_screenshot' is not allowed for this session",
+      });
+      expect(checkGuardrails).not.toHaveBeenCalled();
+      expect(db.insert).not.toHaveBeenCalled();
+    });
   });
 
   describe('plan-step shortcut is gated on effective tier', () => {

--- a/apps/api/src/services/aiAgentSdk.test.ts
+++ b/apps/api/src/services/aiAgentSdk.test.ts
@@ -1684,6 +1684,31 @@ describe('createSessionPreToolUse', () => {
       expect(db.insert).not.toHaveBeenCalled();
     });
 
+    // The exposed name is AUTHORITATIVE. A session that somehow granted only
+    // the handler alias must not thereby gain the tool the model actually
+    // calls — this is the case that goes green if createSessionPreToolUse
+    // reverts to checking `toolName`, so it pins the direction of the fix and
+    // not just its effect.
+    it('denies when only the HANDLER name is granted and the exposed name is not', async () => {
+      const session = makeActiveSession({
+        approvalMode: 'auto_approve',
+        allowedTools: ['mcp__script_builder__run_script'],
+      });
+
+      const result = await createSessionPreToolUse(session)(
+        'run_script',
+        { scriptId: 'script-1' },
+        'mcp__script_builder__execute_script_on_device',
+      );
+
+      expect(result).toEqual({
+        allowed: false,
+        error: "Tool 'execute_script_on_device' is not allowed for this session",
+      });
+      expect(checkGuardrails).not.toHaveBeenCalled();
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
     it('rejects an exposed name the session never granted', async () => {
       const session = makeActiveSession({
         approvalMode: 'auto_approve',

--- a/apps/api/src/services/aiAgentSdk.ts
+++ b/apps/api/src/services/aiAgentSdk.ts
@@ -507,15 +507,30 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
     }
 
     // Allowlist check runs on the EXPOSED name, not the handler name. The two
-    // coincide for every tool except script builder's
-    // `execute_script_on_device`, which dispatches to the `run_script`
-    // handler; comparing that handler name against an allowlist of
+    // coincide for every tool the `breeze` MCP server registers; script
+    // builder's `execute_script_on_device` dispatches to the `run_script`
+    // handler, and comparing THAT against an allowlist of
     // `mcp__script_builder__*` names denied every call before tier/approval
-    // logic ran (#4883). Nothing below this line uses `exposedToolName` — the
-    // capability being gated is the handler's, so tier, RBAC, rate limits,
-    // approval and audit all stay on `toolName`.
+    // logic ran (#4883). Once this gate resolves, nothing further in this
+    // function reads `exposedToolName` — the capability being gated is the
+    // handler's, so tier, RBAC, rate limits, approval and audit all stay on
+    // `toolName`.
     const exposedToolName = mcpToolName ?? toolName;
     if (session.allowedTools && !isAllowedForSession(exposedToolName, session.allowedTools)) {
+      // The SDK is handed the SAME list as `allowedTools` on `query()`, so it
+      // should never offer the model a tool this branch then refuses. Reaching
+      // here means the two views disagree — a wiring bug, not a user-permission
+      // outcome — and #4883 proves that failure is invisible without a signal:
+      // it read as an ordinary tool refusal in chat for weeks while every
+      // Script Builder test run was dead.
+      const wiringError = new Error(
+        `Session allowlist denied '${exposedToolName}' (handler '${toolName}') — `
+        + 'the SDK exposed a tool the app-layer guard refuses',
+      );
+      console.error(`[AI-SDK] ${wiringError.message} (session ${session.breezeSessionId})`);
+      // Detail rides in the message, not in tags: the Sentry scrubber's tag
+      // allowlist silently voids tag keys it does not know.
+      captureException(wiringError, undefined, { service: 'aiAgentSdk', orgId: session.orgId });
       return {
         allowed: false,
         error: `Tool '${stripMcpPrefix(exposedToolName)}' is not allowed for this session`,

--- a/apps/api/src/services/aiAgentSdk.ts
+++ b/apps/api/src/services/aiAgentSdk.ts
@@ -20,6 +20,7 @@ import { checkBudget, checkAiRateLimit, getRemainingBudgetUsd } from './aiCostTr
 import { sanitizeUserMessage, sanitizePageContext } from './aiInputSanitizer';
 import { getSession, buildSystemPrompt, waitForApproval } from './aiAgent';
 import { TOOL_TIERS, type PreToolUseCallback, type PostToolUseCallback } from './aiAgentSdkTools';
+import { isAllowedForSession, stripMcpPrefix } from './mcpToolNames';
 import { writeAuditEvent, requestLikeFromSnapshot, type RequestLike } from './auditEvents';
 import type { ActiveSession, AuditSnapshot } from './streamingSessionManager';
 import { compactToolResultForChat } from './aiToolOutput';
@@ -277,12 +278,6 @@ const INLINE_TOOL_EXECUTION_FAILED_ERROR_CODE = 'tool_execution_failed';
 // than declared independently here, so the two paths cannot drift apart —
 // see the doc comments at their declaration site.
 
-function stripMcpPrefix(toolName: string): string {
-  if (!toolName.startsWith('mcp__')) return toolName;
-  const separatorIndex = toolName.indexOf('__', 'mcp__'.length);
-  return separatorIndex === -1 ? toolName : toolName.slice(separatorIndex + 2);
-}
-
 /**
  * Human-readable verbs for the two M365 mutation tools that hit per-step
  * approval. The three read tools are tier 1 and never create an approval card,
@@ -309,11 +304,6 @@ export function buildM365RiskSummary(
   const user = String(input.userIdentifier ?? 'a user');
   const reason = input.reason ? ` Reason: ${String(input.reason)}.` : '';
   return `${verb} ${user} on ${conn.customerDisplayName}.${reason}`;
-}
-
-function isAllowedForSession(toolName: string, allowedTools: readonly string[]): boolean {
-  const bareToolName = stripMcpPrefix(toolName);
-  return allowedTools.some((allowedTool) => stripMcpPrefix(allowedTool) === bareToolName);
 }
 
 // ============================================
@@ -496,7 +486,7 @@ export async function runPreFlightChecks(
  * server tools.
  */
 export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallback {
-  return async (toolName, input) => {
+  return async (toolName, input, mcpToolName) => {
     // Set only by the tier-3 branch below when it creates a durable intent;
     // carried on the terminal `return` so postToolUse can seal against the
     // right intent without relying solely on pendingIntentBySession.
@@ -516,8 +506,20 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
       return { allowed: false, error: `Unknown tool: ${toolName}` };
     }
 
-    if (session.allowedTools && !isAllowedForSession(toolName, session.allowedTools)) {
-      return { allowed: false, error: `Tool '${toolName}' is not allowed for this session` };
+    // Allowlist check runs on the EXPOSED name, not the handler name. The two
+    // coincide for every tool except script builder's
+    // `execute_script_on_device`, which dispatches to the `run_script`
+    // handler; comparing that handler name against an allowlist of
+    // `mcp__script_builder__*` names denied every call before tier/approval
+    // logic ran (#4883). Nothing below this line uses `exposedToolName` — the
+    // capability being gated is the handler's, so tier, RBAC, rate limits,
+    // approval and audit all stay on `toolName`.
+    const exposedToolName = mcpToolName ?? toolName;
+    if (session.allowedTools && !isAllowedForSession(exposedToolName, session.allowedTools)) {
+      return {
+        allowed: false,
+        error: `Tool '${stripMcpPrefix(exposedToolName)}' is not allowed for this session`,
+      };
     }
 
     // Guardrails (tier check + action-based escalation)

--- a/apps/api/src/services/aiAgentSdkTools.ts
+++ b/apps/api/src/services/aiAgentSdkTools.ts
@@ -96,10 +96,15 @@ export type PreToolUseCallback = (
    * names. Everything downstream (tier, RBAC, rate limit, approval, audit)
    * stays on `toolName`, because that is where the capability actually lives.
    *
-   * Omit it whenever the two coincide, which is every tool except script
-   * builder's `execute_script_on_device` -> `run_script`. Passing the handler
-   * name to the allowlist gate is what denied every Script Builder test run
-   * with "Tool 'run_script' is not allowed for this session" (#4883).
+   * Pass the FULLY-QUALIFIED, non-empty `mcp__<server>__<tool>` string, not a
+   * bare name. Omit it whenever the two identities coincide — as of writing
+   * that is every tool this file's `breeze` server registers, and every
+   * script-builder tool except `execute_script_on_device` -> `run_script`.
+   * Only script builder's registrations are pinned against drift (see
+   * `scriptBuilderTools.guard.test.ts`); a NEW tool registered here under a
+   * name that differs from its handler must wire this argument, or the
+   * session allowlist will refuse it the way it refused every Script Builder
+   * test run with "Tool 'run_script' is not allowed for this session" (#4883).
    */
   mcpToolName?: string,
 ) => Promise<

--- a/apps/api/src/services/aiAgentSdkTools.ts
+++ b/apps/api/src/services/aiAgentSdkTools.ts
@@ -88,6 +88,20 @@ const SECRET_ACTION_REFUSED_TEXT =
 export type PreToolUseCallback = (
   toolName: string,
   input: Record<string, unknown>,
+  /**
+   * The `mcp__<server>__<tool>` name this call was EXPOSED to the model as,
+   * when it differs from the `executeTool` handler `toolName` above. Used for
+   * one thing only: the session-allowlist check, which compares against the
+   * names the caller put in `allowedTools` — i.e. exposed names, not handler
+   * names. Everything downstream (tier, RBAC, rate limit, approval, audit)
+   * stays on `toolName`, because that is where the capability actually lives.
+   *
+   * Omit it whenever the two coincide, which is every tool except script
+   * builder's `execute_script_on_device` -> `run_script`. Passing the handler
+   * name to the allowlist gate is what denied every Script Builder test run
+   * with "Tool 'run_script' is not allowed for this session" (#4883).
+   */
+  mcpToolName?: string,
 ) => Promise<
   | { allowed: true; intentId?: string; context?: ToolExecutionContext }
   | { allowed: false; error: string }

--- a/apps/api/src/services/mcpToolNames.test.ts
+++ b/apps/api/src/services/mcpToolNames.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { isAllowedForSession, stripMcpPrefix } from './mcpToolNames';
+
+/**
+ * These two pure helpers gate two security decisions — which tools a session
+ * may invoke (`isAllowedForSession`, aiAgentSdk.createSessionPreToolUse) and
+ * which tool results must be sealed (`stripMcpPrefix`, via
+ * secretBearingTools.isSecretBearingTool). Both fail OPEN if the
+ * normalization is ever narrowed to a single hard-coded server prefix, so the
+ * leaf's contract is pinned here rather than only inferred from its callers.
+ */
+describe('stripMcpPrefix', () => {
+  it('strips the prefix for ANY MCP server, not just mcp__breeze__', () => {
+    expect(stripMcpPrefix('mcp__breeze__run_script')).toBe('run_script');
+    expect(stripMcpPrefix('mcp__script_builder__execute_script_on_device'))
+      .toBe('execute_script_on_device');
+    expect(stripMcpPrefix('mcp__some_future_server__m365_reset_password'))
+      .toBe('m365_reset_password');
+  });
+
+  it('leaves an already-bare name alone', () => {
+    expect(stripMcpPrefix('run_script')).toBe('run_script');
+    expect(stripMcpPrefix('')).toBe('');
+  });
+
+  it('leaves a malformed prefix alone rather than guessing', () => {
+    // No second separator: there is no server segment to remove, and inventing
+    // one would let `mcp__run_script` masquerade as the bare `run_script`.
+    expect(stripMcpPrefix('mcp__run_script')).toBe('mcp__run_script');
+    expect(stripMcpPrefix('notmcp__breeze__run_script')).toBe('notmcp__breeze__run_script');
+  });
+
+  it('keeps only the first server segment, so a nested-looking name is not over-stripped', () => {
+    expect(stripMcpPrefix('mcp__breeze__mcp__evil__run_script')).toBe('mcp__evil__run_script');
+  });
+});
+
+describe('isAllowedForSession', () => {
+  const allowlist = [
+    'mcp__script_builder__query_devices',
+    'mcp__script_builder__execute_script_on_device',
+  ];
+
+  it('matches regardless of which side carries the prefix', () => {
+    expect(isAllowedForSession('mcp__script_builder__query_devices', allowlist)).toBe(true);
+    expect(isAllowedForSession('query_devices', allowlist)).toBe(true);
+    expect(isAllowedForSession('mcp__breeze__query_devices', allowlist)).toBe(true);
+  });
+
+  it('denies anything the allowlist does not name', () => {
+    for (const denied of [
+      'run_script',                    // the handler behind execute_script_on_device (#4883)
+      'mcp__script_builder__run_script',
+      'execute_command',
+      'mcp__breeze__execute_command',
+      'query_device',                  // near-miss, not a prefix match
+      'query_devices_extra',
+    ]) {
+      expect(isAllowedForSession(denied, allowlist), `${denied} must be denied`).toBe(false);
+    }
+  });
+
+  it('denies everything against an empty allowlist, including the empty name', () => {
+    expect(isAllowedForSession('query_devices', [])).toBe(false);
+    expect(isAllowedForSession('', [])).toBe(false);
+    // Fails CLOSED: no real allowlist entry normalizes to the empty string.
+    expect(isAllowedForSession('', allowlist)).toBe(false);
+  });
+});

--- a/apps/api/src/services/mcpToolNames.ts
+++ b/apps/api/src/services/mcpToolNames.ts
@@ -1,12 +1,19 @@
 /**
  * Canonical MCP tool-name normalization and the session-allowlist predicate.
  *
- * Deliberately a dependency-free leaf module. Both helpers gate security
- * decisions (which tools a session may invoke, and which results must be
- * sealed), and both were previously copy-pasted into the modules that needed
- * them — `aiAgentSdk.ts` and `actionIntents/secretBearingTools.ts` — because
- * importing either of those from the other is a cycle. A narrower or drifted
- * copy of `stripMcpPrefix` fails OPEN, so it lives here once.
+ * Deliberately a dependency-free leaf module, for two different reasons:
+ *
+ * - `stripMcpPrefix` was duplicated — `aiAgentSdk.ts` and
+ *   `actionIntents/secretBearingTools.ts` each carried a hand-synced copy,
+ *   because `aiAgentSdk.ts` imports `secretBearingTools.ts` and neither could
+ *   import the other. It gates `isAllowedForSession` below,
+ *   `secretBearingTools.isSecretBearingTool` (and through it the
+ *   pre-execution refusal in `aiAgentSdkTools.ts` and
+ *   `assertNoPlaintextSecret`), so a narrower or drifted copy fails OPEN and
+ *   reinstates the plaintext-secret leak class. One implementation, here.
+ * - `isAllowedForSession` was never duplicated; it lived unexported in
+ *   `aiAgentSdk.ts` and moved here so the script-builder guard test can
+ *   exercise the real predicate without pulling in that module's graph.
  *
  * (Unrelated to `aiToolNames.ts`, which owns the core AI tool *registry* and
  * the extension reserved-name guard.)
@@ -35,6 +42,9 @@ export function stripMcpPrefix(toolName: string): string {
  * (script builder's `execute_script_on_device` -> `run_script`, #4883), the
  * caller must pass the exposed name here; checking the handler name against
  * an allowlist of exposed names denies a tool the session explicitly granted.
+ *
+ * `toolName` must be non-empty. An empty string fails CLOSED (nothing in an
+ * allowlist strips to `''`), but it is never a meaningful question to ask.
  */
 export function isAllowedForSession(toolName: string, allowedTools: readonly string[]): boolean {
   const bareToolName = stripMcpPrefix(toolName);

--- a/apps/api/src/services/mcpToolNames.ts
+++ b/apps/api/src/services/mcpToolNames.ts
@@ -1,0 +1,42 @@
+/**
+ * Canonical MCP tool-name normalization and the session-allowlist predicate.
+ *
+ * Deliberately a dependency-free leaf module. Both helpers gate security
+ * decisions (which tools a session may invoke, and which results must be
+ * sealed), and both were previously copy-pasted into the modules that needed
+ * them — `aiAgentSdk.ts` and `actionIntents/secretBearingTools.ts` — because
+ * importing either of those from the other is a cycle. A narrower or drifted
+ * copy of `stripMcpPrefix` fails OPEN, so it lives here once.
+ *
+ * (Unrelated to `aiToolNames.ts`, which owns the core AI tool *registry* and
+ * the extension reserved-name guard.)
+ */
+
+/**
+ * Reduce `mcp__<server>__<tool>` to the bare `<tool>`. Any server segment is
+ * accepted (not just `mcp__breeze__`): the SDK prefixes in-process MCP tools
+ * with whichever server registered them, so a check that only understood one
+ * server name would let a differently-prefixed name slip past.
+ */
+export function stripMcpPrefix(toolName: string): string {
+  if (!toolName.startsWith('mcp__')) return toolName;
+  const separatorIndex = toolName.indexOf('__', 'mcp__'.length);
+  return separatorIndex === -1 ? toolName : toolName.slice(separatorIndex + 2);
+}
+
+/**
+ * Is `toolName` covered by this session's `allowedTools`?
+ *
+ * Both sides are normalized, so a session that allowed
+ * `mcp__script_builder__query_devices` also permits the bare `query_devices`.
+ * The comparison is on the *exposed* tool name — the name the SDK advertised
+ * to the model, which is what the allowlist was built from. Where a tool's
+ * model-facing name differs from the `executeTool` handler that runs it
+ * (script builder's `execute_script_on_device` -> `run_script`, #4883), the
+ * caller must pass the exposed name here; checking the handler name against
+ * an allowlist of exposed names denies a tool the session explicitly granted.
+ */
+export function isAllowedForSession(toolName: string, allowedTools: readonly string[]): boolean {
+  const bareToolName = stripMcpPrefix(toolName);
+  return allowedTools.some((allowedTool) => stripMcpPrefix(allowedTool) === bareToolName);
+}

--- a/apps/api/src/services/scriptBuilderTools.guard.test.ts
+++ b/apps/api/src/services/scriptBuilderTools.guard.test.ts
@@ -1,9 +1,18 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { z } from 'zod';
 import { TOOL_TIERS } from './aiAgentSdkTools';
 import { TOOL_PERMISSIONS, checkGuardrails } from './aiGuardrails';
-import { applyScriptMetadataInputShape, SCRIPT_BUILDER_TOOL_TIERS } from './scriptBuilderTools';
+import {
+  applyScriptMetadataInputShape,
+  buildScriptBuilderTools,
+  SCRIPT_BUILDER_HANDLER_BY_MCP_TOOL,
+  SCRIPT_BUILDER_MCP_TOOL_NAMES,
+  SCRIPT_BUILDER_TOOL_TIERS,
+  scriptBuilderMcpToolName,
+} from './scriptBuilderTools';
+import { isAllowedForSession } from './mcpToolNames';
 import { toolInputSchemas, validateToolInput } from './aiToolSchemas';
+import type { AuthContext } from '../middleware/auth';
 
 /**
  * Guard against the "Unknown tool" regression (script-builder could not search
@@ -27,11 +36,11 @@ import { toolInputSchemas, validateToolInput } from './aiToolSchemas';
 const APPLY_TOOLS = new Set(['apply_script_code', 'apply_script_metadata']);
 
 // A few MCP tool names dispatch to a differently-named executeTool handler;
-// preToolUse / checkToolPermission see the HANDLER name. Keep in sync with the
-// makeExistingHandler(...) call sites in createScriptBuilderMcpServer.
-const MCP_NAME_TO_HANDLER: Record<string, string> = {
-  execute_script_on_device: 'run_script',
-};
+// preToolUse's tier/RBAC/schema lookups see the HANDLER name. Imported rather
+// than restated here so the test cannot drift from the map the registration
+// itself resolves through — the "still dispatches each tool to its executeTool
+// handler name" case below pins the map against the real handlers.
+const MCP_NAME_TO_HANDLER = SCRIPT_BUILDER_HANDLER_BY_MCP_TOOL;
 
 const SCRIPT_BUILDER_CONTEXT_HANDLER_TOOLS = Object.keys(SCRIPT_BUILDER_TOOL_TIERS)
   .filter((name) => !APPLY_TOOLS.has(name))
@@ -108,6 +117,141 @@ describe('script-builder context tools are fully wired for the session guardrail
         limit: 10,
       }).success,
     ).toBe(true);
+  });
+});
+
+// ============================================
+// #4883: the session allowlist must see the EXPOSED tool name
+// ============================================
+
+/**
+ * The three maps above are about the *handler* identity. This block is about
+ * the other identity every tool has — the `mcp__script_builder__<name>` the
+ * SDK exposes to the model, which is also what `scriptAi.ts` puts in the
+ * session's `allowedTools`.
+ *
+ * `createSessionPreToolUse` gates on `isAllowedForSession(<name>,
+ * session.allowedTools)`. `execute_script_on_device` dispatches to the
+ * `run_script` handler, so passing the handler name to that gate compared
+ * `run_script` against an allowlist that only ever holds
+ * `mcp__script_builder__execute_script_on_device` — every Script Builder test
+ * run came back `Tool 'run_script' is not allowed for this session`, before
+ * tier/approval logic ran at all (#4883).
+ *
+ * These tests drive the REAL registered handlers, so they fail if the two
+ * identities are ever conflated again — including for a future renamed tool.
+ */
+describe('#4883: script-builder tools reach the session guardrail under the name the session granted', () => {
+  const GUARD_TEST_BLOCK = 'blocked-by-guard-test';
+
+  /**
+   * Invoke every registered context tool's handler with a pre-hook that
+   * records what the guardrail was asked about and then blocks, so nothing
+   * reaches executeTool / the database.
+   */
+  async function capturePreToolUseCalls() {
+    const calls: Array<{ toolName: string; mcpToolName: string | undefined }> = [];
+    const onPreToolUse = vi.fn(
+      async (toolName: string, _input: Record<string, unknown>, mcpToolName?: string) => {
+        calls.push({ toolName, mcpToolName });
+        return { allowed: false as const, error: GUARD_TEST_BLOCK };
+      },
+    );
+
+    const getAuth = () => {
+      throw new Error('getAuth must not be reached — the pre-hook blocks first');
+    };
+    const tools = buildScriptBuilderTools(getAuth as unknown as () => AuthContext, onPreToolUse);
+    const contextTools = tools.filter((t) => !APPLY_TOOLS.has(t.name));
+
+    for (const t of contextTools) {
+      await t.handler({} as never, undefined);
+    }
+
+    return { contextTools, calls };
+  }
+
+  it('asks the guardrail about a name the session allowlist actually contains', async () => {
+    const { contextTools, calls } = await capturePreToolUseCalls();
+
+    expect(calls).toHaveLength(contextTools.length);
+    contextTools.forEach((t, i) => {
+      const { toolName, mcpToolName } = calls[i]!;
+      const checkedName = mcpToolName ?? toolName;
+      expect(
+        isAllowedForSession(checkedName, SCRIPT_BUILDER_MCP_TOOL_NAMES),
+        `${t.name}: the guard checks '${checkedName}' against a session allowlist that holds `
+          + `'${scriptBuilderMcpToolName(t.name)}' — it will deny a tool the session granted`,
+      ).toBe(true);
+    });
+  });
+
+  it('still dispatches each tool to its executeTool handler name', async () => {
+    const { contextTools, calls } = await capturePreToolUseCalls();
+
+    contextTools.forEach((t, i) => {
+      // Handler identity: what TOOL_TIERS / TOOL_PERMISSIONS / the rate limits
+      // are keyed on. Pins SCRIPT_BUILDER_HANDLER_BY_MCP_TOOL against the real
+      // registration, so the map the three tests above derive from cannot
+      // quietly disagree with what actually runs.
+      expect(calls[i]!.toolName).toBe(MCP_NAME_TO_HANDLER[t.name] ?? t.name);
+      // Exposed identity: it must be THIS tool's MCP name, not some other
+      // allowlisted tool's — otherwise the gate could be satisfied by a name
+      // the model never called.
+      expect(calls[i]!.mcpToolName).toBe(scriptBuilderMcpToolName(t.name));
+    });
+  });
+
+  it('registers exactly the tools the session allowlist is built from', async () => {
+    const registered = buildScriptBuilderTools(
+      (() => {
+        throw new Error('getAuth must not be reached');
+      }) as unknown as () => AuthContext,
+    ).map((t) => t.name);
+
+    // SCRIPT_BUILDER_MCP_TOOL_NAMES is derived from SCRIPT_BUILDER_TOOL_TIERS,
+    // so a tool registered without a tier entry is exposed to the model but
+    // absent from the session allowlist — denied on every call, exactly the
+    // #4883 failure mode by a different route.
+    expect(registered.slice().sort()).toEqual(Object.keys(SCRIPT_BUILDER_TOOL_TIERS).sort());
+  });
+
+  // The allowlist must not have been WIDENED to make the above pass. A bare
+  // handler alias in SCRIPT_BUILDER_MCP_TOOL_NAMES would satisfy the first
+  // test while also granting `run_script` to every session that only ever
+  // asked for `execute_script_on_device`.
+  it('does not grant the bare run_script handler name', () => {
+    expect(isAllowedForSession('run_script', SCRIPT_BUILDER_MCP_TOOL_NAMES)).toBe(false);
+    expect(isAllowedForSession('mcp__breeze__run_script', SCRIPT_BUILDER_MCP_TOOL_NAMES)).toBe(false);
+  });
+
+  it('still rejects tools the script-builder session never granted', () => {
+    for (const denied of [
+      'execute_command',
+      'mcp__breeze__execute_command',
+      'mcp__script_builder__execute_command',
+      'manage_devices',
+      'm365_reset_password',
+    ]) {
+      expect(
+        isAllowedForSession(denied, SCRIPT_BUILDER_MCP_TOOL_NAMES),
+        `${denied} is not a script-builder tool and must stay denied`,
+      ).toBe(false);
+    }
+  });
+
+  it('returns the guardrail denial to the model instead of executing', async () => {
+    const onPreToolUse = vi.fn(async () => ({ allowed: false as const, error: GUARD_TEST_BLOCK }));
+    const getAuth = () => {
+      throw new Error('getAuth must not be reached');
+    };
+    const tools = buildScriptBuilderTools(getAuth as unknown as () => AuthContext, onPreToolUse);
+    const exec = tools.find((t) => t.name === 'execute_script_on_device');
+    expect(exec).toBeDefined();
+
+    const result = await exec!.handler({} as never, undefined);
+    expect(result.isError).toBe(true);
+    expect(JSON.stringify(result.content)).toContain(GUARD_TEST_BLOCK);
   });
 });
 

--- a/apps/api/src/services/scriptBuilderTools.guard.test.ts
+++ b/apps/api/src/services/scriptBuilderTools.guard.test.ts
@@ -35,7 +35,7 @@ import type { AuthContext } from '../middleware/auth';
 // (and must not require) TOOL_TIERS / TOOL_PERMISSIONS entries.
 const APPLY_TOOLS = new Set(['apply_script_code', 'apply_script_metadata']);
 
-// A few MCP tool names dispatch to a differently-named executeTool handler;
+// One MCP tool name dispatches to a differently-named executeTool handler;
 // preToolUse's tier/RBAC/schema lookups see the HANDLER name. Imported rather
 // than restated here so the test cannot drift from the map the registration
 // itself resolves through — the "still dispatches each tool to its executeTool

--- a/apps/api/src/services/scriptBuilderTools.ts
+++ b/apps/api/src/services/scriptBuilderTools.ts
@@ -63,18 +63,24 @@ export const SCRIPT_BUILDER_MCP_TOOL_NAMES = Object.keys(SCRIPT_BUILDER_TOOL_TIE
 );
 
 /**
- * MCP tool name -> the `executeTool` handler that actually runs it, for the
- * tools whose model-facing name differs from their handler.
+ * Registered tool name -> the `executeTool` handler that actually runs it, for
+ * the tools whose model-facing name differs from their handler.
+ *
+ * Keys are the BARE names the `tool()` calls register (`execute_script_on_device`),
+ * not the `mcp__script_builder__`-prefixed form — `scriptBuilderMcpToolName`
+ * adds the prefix where the allowlist needs it.
  *
  * The two identities are NOT interchangeable and must not be conflated:
- *   - the MCP name is what the model calls and what `scriptAi.ts` puts in the
- *     session's `allowedTools` (`SCRIPT_BUILDER_MCP_TOOL_NAMES`);
+ *   - the registered name is what the model calls, and prefixed, what
+ *     `scriptAi.ts` puts in the session's `allowedTools`
+ *     (`SCRIPT_BUILDER_MCP_TOOL_NAMES`);
  *   - the handler name is what `TOOL_TIERS`, `TOOL_PERMISSIONS`,
  *     `toolInputSchemas` and the per-tool rate limits are keyed on.
- * `makeExistingHandler` below resolves through this map so a call site names
- * only its MCP tool once — the earlier arrangement passed the handler name at
- * the `tool()` registration, which is how the session guardrail ended up
- * checking `run_script` against an allowlist that only holds
+ * `makeExistingHandler` below resolves through this map so each call site
+ * names only its own tool. Previously the handler name was passed into
+ * `makeExistingHandler` instead (the `tool()` name itself never changed),
+ * which is how the session guardrail ended up checking `run_script` against
+ * an allowlist that only holds
  * `mcp__script_builder__execute_script_on_device` (#4883).
  */
 export const SCRIPT_BUILDER_HANDLER_BY_MCP_TOOL: Record<string, string> = {
@@ -86,21 +92,24 @@ export const SCRIPT_BUILDER_HANDLER_BY_MCP_TOOL: Record<string, string> = {
 // ============================================
 
 /**
- * @param mcpToolName the tool's model-facing MCP name, i.e. the key the
- *   session allowlist and `SCRIPT_BUILDER_TOOL_TIERS` use. The `executeTool`
+ * @param registeredToolName the BARE name this tool is registered under in the
+ *   `tool()` call below — the key `SCRIPT_BUILDER_TOOL_TIERS` uses and, once
+ *   prefixed, what the session allowlist holds. (Not to be confused with
+ *   `PreToolUseCallback`'s `mcpToolName`, which is the fully-qualified
+ *   `mcp__script_builder__…` form this derives from it.) The `executeTool`
  *   handler it dispatches to is resolved from
  *   `SCRIPT_BUILDER_HANDLER_BY_MCP_TOOL`, and everything keyed on the handler
  *   (tier, RBAC, rate limit, schema, result compaction, audit) stays on that
  *   name — only the session-allowlist check gets the exposed name (#4883).
  */
 function makeExistingHandler(
-  mcpToolName: string,
+  registeredToolName: string,
   getAuth: () => AuthContext,
   onPreToolUse?: PreToolUseCallback,
   onPostToolUse?: PostToolUseCallback,
 ) {
-  const toolName = SCRIPT_BUILDER_HANDLER_BY_MCP_TOOL[mcpToolName] ?? mcpToolName;
-  const exposedToolName = scriptBuilderMcpToolName(mcpToolName);
+  const toolName = SCRIPT_BUILDER_HANDLER_BY_MCP_TOOL[registeredToolName] ?? registeredToolName;
+  const exposedToolName = scriptBuilderMcpToolName(registeredToolName);
 
   return async (args: Record<string, unknown>) => {
     const startTime = Date.now();

--- a/apps/api/src/services/scriptBuilderTools.ts
+++ b/apps/api/src/services/scriptBuilderTools.ts
@@ -49,27 +49,66 @@ export const SCRIPT_BUILDER_TOOL_TIERS: Record<string, AiToolTier> = {
   execute_script_on_device: 3,
 };
 
+/** SDK MCP server name — the `<server>` in the `mcp__<server>__<tool>` names
+ *  the model sees and the session allowlist is built from. */
+export const SCRIPT_BUILDER_MCP_SERVER_NAME = 'script_builder';
+
+/** The name a script-builder tool is exposed to the model (and allowlisted) as. */
+export function scriptBuilderMcpToolName(toolName: string): string {
+  return `mcp__${SCRIPT_BUILDER_MCP_SERVER_NAME}__${toolName}`;
+}
+
 export const SCRIPT_BUILDER_MCP_TOOL_NAMES = Object.keys(SCRIPT_BUILDER_TOOL_TIERS).map(
-  name => `mcp__script_builder__${name}`
+  scriptBuilderMcpToolName
 );
+
+/**
+ * MCP tool name -> the `executeTool` handler that actually runs it, for the
+ * tools whose model-facing name differs from their handler.
+ *
+ * The two identities are NOT interchangeable and must not be conflated:
+ *   - the MCP name is what the model calls and what `scriptAi.ts` puts in the
+ *     session's `allowedTools` (`SCRIPT_BUILDER_MCP_TOOL_NAMES`);
+ *   - the handler name is what `TOOL_TIERS`, `TOOL_PERMISSIONS`,
+ *     `toolInputSchemas` and the per-tool rate limits are keyed on.
+ * `makeExistingHandler` below resolves through this map so a call site names
+ * only its MCP tool once — the earlier arrangement passed the handler name at
+ * the `tool()` registration, which is how the session guardrail ended up
+ * checking `run_script` against an allowlist that only holds
+ * `mcp__script_builder__execute_script_on_device` (#4883).
+ */
+export const SCRIPT_BUILDER_HANDLER_BY_MCP_TOOL: Record<string, string> = {
+  execute_script_on_device: 'run_script',
+};
 
 // ============================================
 // Handler factory for existing tools
 // ============================================
 
+/**
+ * @param mcpToolName the tool's model-facing MCP name, i.e. the key the
+ *   session allowlist and `SCRIPT_BUILDER_TOOL_TIERS` use. The `executeTool`
+ *   handler it dispatches to is resolved from
+ *   `SCRIPT_BUILDER_HANDLER_BY_MCP_TOOL`, and everything keyed on the handler
+ *   (tier, RBAC, rate limit, schema, result compaction, audit) stays on that
+ *   name — only the session-allowlist check gets the exposed name (#4883).
+ */
 function makeExistingHandler(
-  toolName: string,
+  mcpToolName: string,
   getAuth: () => AuthContext,
   onPreToolUse?: PreToolUseCallback,
   onPostToolUse?: PostToolUseCallback,
 ) {
+  const toolName = SCRIPT_BUILDER_HANDLER_BY_MCP_TOOL[mcpToolName] ?? mcpToolName;
+  const exposedToolName = scriptBuilderMcpToolName(mcpToolName);
+
   return async (args: Record<string, unknown>) => {
     const startTime = Date.now();
 
     if (onPreToolUse) {
       let check: { allowed: true } | { allowed: false; error: string };
       try {
-        check = await onPreToolUse(toolName, args);
+        check = await onPreToolUse(toolName, args, exposedToolName);
       } catch (err) {
         captureException(err);
         console.error(`[ScriptBuilder] PreToolUse threw for ${toolName}:`, err);
@@ -195,14 +234,21 @@ export const applyScriptMetadataInputShape = {
   timeoutSeconds: z.number().int().min(1).max(3600).optional(),
 };
 
-export function createScriptBuilderMcpServer(
+/**
+ * The tool definitions this MCP server exposes.
+ *
+ * Exported so scriptBuilderTools.guard.test.ts can drive each registered
+ * handler and pin what it hands the session guardrail — the wiring that
+ * silently denied every execute_script_on_device call (#4883).
+ */
+export function buildScriptBuilderTools(
   getAuth: () => AuthContext,
   onPreToolUse?: PreToolUseCallback,
   onPostToolUse?: PostToolUseCallback,
 ) {
   const uuid = z.string().guid();
 
-  const tools = [
+  return [
     // --- Apply tools (script-builder-only) ---
     tool(
       'apply_script_code',
@@ -314,9 +360,18 @@ export function createScriptBuilderMcpServer(
         deviceIds: z.array(uuid).min(1).max(10).describe('Target device IDs'),
         parameters: z.record(z.string(), z.unknown()).optional(),
       },
-      makeExistingHandler('run_script', getAuth, onPreToolUse, onPostToolUse)
+      makeExistingHandler('execute_script_on_device', getAuth, onPreToolUse, onPostToolUse)
     ),
   ];
+}
 
-  return createSdkMcpServer({ name: 'script_builder', tools });
+export function createScriptBuilderMcpServer(
+  getAuth: () => AuthContext,
+  onPreToolUse?: PreToolUseCallback,
+  onPostToolUse?: PostToolUseCallback,
+) {
+  return createSdkMcpServer({
+    name: SCRIPT_BUILDER_MCP_SERVER_NAME,
+    tools: buildScriptBuilderTools(getAuth, onPreToolUse, onPostToolUse),
+  });
 }


### PR DESCRIPTION
## Problem

Every Script Builder `execute_script_on_device` call in production came back

```json
{"error": "Tool 'run_script' is not allowed for this session"}
```

so the chat's only execution tool was dead and the assistant fell back to asking the user to run the script by hand. Observed on the OliveTech tenant (US, API 0.109.0).

Two tool identities were conflated:

| Identity | Value | Keyed on |
|---|---|---|
| **Exposed** (what the model calls, what the session allowlist holds) | `mcp__script_builder__execute_script_on_device` | `SCRIPT_BUILDER_MCP_TOOL_NAMES` → `session.allowedTools` |
| **Handler** (what actually runs) | `run_script` | `TOOL_TIERS`, `TOOL_PERMISSIONS`, `toolInputSchemas`, per-tool rate limits |

`makeExistingHandler` passed the **handler** name to `onPreToolUse`, so `createSessionPreToolUse` ran `isAllowedForSession('run_script', ['mcp__script_builder__execute_script_on_device', …])` — no match, denied before tier, RBAC or approval logic ran at all.

## Approach — option 1 from the issue

The issue offered two fixes. This takes **option 1** (make the guard see what the session actually granted) rather than **option 2** (alias `run_script` into the allowlist), because widening an allowlist is the wrong direction for a security guard: option 2 would have granted the bare `run_script` capability to every Script Builder session, not just the one exposed tool.

- **`PreToolUseCallback` gains an optional third argument** — the `mcp__<server>__<tool>` name the call was *exposed* as. `createSessionPreToolUse` uses it for the session-allowlist check **only**. Tier, RBAC, rate limits, approval and the audit row all stay on `toolName`, because the handler is where the capability lives. Every other caller omits it and behaves exactly as before.
- **`makeExistingHandler` now takes the MCP tool name** and resolves the handler through a single exported `SCRIPT_BUILDER_HANDLER_BY_MCP_TOOL` map, so a `tool()` registration names its tool once. The previous arrangement — passing the handler name at the registration site — is what let the two identities drift apart in the first place.
- **The denial message now names the model-facing tool.** A genuinely-refused assistant says which capability it lacks instead of naming an internal handler (which is what led it to tell the user it "lacks permission").
- **`stripMcpPrefix` / `isAllowedForSession` move to a dependency-free leaf, `services/mcpToolNames.ts`.** `actionIntents/secretBearingTools.ts` was keeping a hand-synced copy of `stripMcpPrefix` purely to dodge an import cycle, with a comment noting that a drifted copy **fails OPEN** on the plaintext-secret guard. Both now share one implementation; the leaf has no imports, so there is no cycle to dodge.
- **`scriptAi.ts` takes the MCP server name from the same constant** that builds the allowlist and the exposed names, so the SDK's `mcp__<name>__` prefix cannot drift from either.

## The allowlist is not widened

This is the risk inherent in option 1, so it is pinned directly rather than argued:

- `isAllowedForSession('run_script', SCRIPT_BUILDER_MCP_TOOL_NAMES)` is still **`false`** — and so is `mcp__breeze__run_script`.
- Through `createSessionPreToolUse`: a session whose allowlist holds only `mcp__script_builder__execute_script_on_device` still denies `('run_script', {})` called **without** an exposed name, and still denies an exposed name it never granted (`mcp__script_builder__take_screenshot`), with `checkGuardrails` and `db.insert` never reached in either case.
- Guard-test cases for `execute_command`, `mcp__breeze__execute_command`, `manage_devices`, `m365_reset_password`.

No capability change: `run_script`'s input schema (`scriptId`, `deviceIds` ≤ 10, `parameters`) is identical to the `execute_script_on_device` shape the model was already constrained to, and the tool stays tier 3 / approval-gated.

## Tests (red first)

`scriptBuilderTools.guard.test.ts` now drives the **real registered handlers** — the tool array is exported for exactly this — with a recording pre-hook, and asserts per tool that the name handed to the guardrail is one the session allowlist contains. On the pre-fix code this fails with:

```
execute_script_on_device: the guard checks 'run_script' against a session allowlist
that holds 'mcp__script_builder__execute_script_on_device' — it will deny a tool the
session granted: expected false to be true
```

It also pins, against the real registration, each tool's handler identity *and* its exposed identity, plus that the registered tool set matches the tier map the allowlist is derived from — so a future renamed tool cannot reintroduce this silently. `aiAgentSdk.test.ts` covers the same contract at the `createSessionPreToolUse` level.

A repo sweep of all 111 `tool(…)`/`makeHandler(…)` registrations across `aiAgentSdkTools.ts` and `scriptBuilderTools.ts` found no other exposed/handler mismatch.

**Verification** (worktree off `origin/main`, merged with latest `main`):
- `vitest run src/services/scriptBuilderTools src/services/aiAgentSdk.test.ts src/routes/scriptAi` — 5 files, 199 passed
- Wider affected surface (`aiToolNames`, `secretBearingTools`, `aiAgentSdkTools`, `aiAgents/runLoop`, `clientSessionTools`, `helperToolFilter`) — 22 files, 481 passed
- `npx tsc --noEmit` on `apps/api` — clean
- `npx eslint` on all changed files — clean

## Out of scope

PR #4888 (held) adds a `runAs` field to the `execute_script_on_device` schema in this same file. Deliberately not touched here.

Closes #4883

🤖 Generated with [Claude Code](https://claude.com/claude-code)
