### PR TITLE
fix(web): survive a failed xterm stylesheet preload on a cold Terminal mount (#4152)

### DIFF
--- a/apps/web/src/components/remote/RemoteTerminal.initFailure.test.tsx
+++ b/apps/web/src/components/remote/RemoteTerminal.initFailure.test.tsx
@@ -17,18 +17,23 @@ import { fetchWithAuth } from '@/stores/auth';
 //     so their `new Terminal(...)` lands during a later test. Sharing that file
 //     would let a leaked construction consume this file's injected failure.
 //
-// What is reproduced: Vite compiles the component's dynamic CSS import into a
+// What is reproduced: before the fix the component did a bare
+// `await import('@xterm/xterm/css/xterm.css')`, which Vite compiles into a
 // `<link rel=stylesheet>` injection that resolves on `load` and REJECTS on
 // `error`. After an upgrade a stale hashed asset URL comes back as the SPA's
-// index.html, which `nosniff` refuses to treat as a stylesheet — so the
-// promise rejects on a cold mount. Before the fix that single rejection
-// unwound the whole of initTerminal: no terminal instance, no `terminalReady`,
-// therefore no auto-connect and — because the retry overlay is gated on
+// index.html, which `nosniff` refuses to treat as a stylesheet, so the promise
+// rejected on a cold mount. That single rejection unwound the whole of
+// initTerminal: no terminal instance, no `terminalReady`, therefore no
+// auto-connect and — because the retry overlay is gated on
 // `autoConnectAttempted`, which only the auto-connect sets — nothing to click.
 // The pane sat on "Disconnected" until a tab round-trip remounted it.
+//
+// The stylesheet is now inlined into the component's own chunk (`?inline`), so
+// that `<link>` no longer exists. These cases hold the line behind that: the
+// module still has to be unable to take the session down with it.
 const cssImport = { evaluations: 0, threw: false };
 
-vi.mock('@xterm/xterm/css/xterm.css', () => {
+vi.mock('@xterm/xterm/css/xterm.css?inline', () => {
   cssImport.evaluations += 1;
   // Only the first evaluation fails, so the stylesheet-specific case below can
   // prove the rejection reached the component. Vitest caches the outcome
@@ -39,7 +44,7 @@ vi.mock('@xterm/xterm/css/xterm.css', () => {
       "Unable to preload CSS for /assets/xterm-abc123.css (MIME type 'text/html' is not a supported stylesheet MIME type)",
     );
   }
-  return {};
+  return { default: '.xterm { position: relative; }' };
 });
 
 const terminalLifecycle = {
@@ -213,9 +218,44 @@ describe('RemoteTerminal init failure is visible and retryable in place (#4152)'
     // Init succeeding hands off to the ordinary auto-connect path.
     await waitFor(() => expect(sessionPostCount()).toBe(1), { timeout: 3000 });
     await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1), { timeout: 3000 });
+    // And the 'failed' status set by the dead init must not outlive it —
+    // otherwise the overlay would sit on top of a live session.
+    await waitFor(
+      () => expect(screen.queryByTestId('terminal-disconnect-overlay')).not.toBeInTheDocument(),
+      { timeout: 3000 },
+    );
   });
 
-  it('reports the failure to the caller through onError', async () => {
+  it('stays retryable when the retry itself fails', async () => {
+    // The guard that makes a retry possible at all is `initStartedRef` being
+    // released in the catch. It has to be released on EVERY failure, not just
+    // the first, or a second bad attempt wedges the pane exactly as #4152 did.
+    terminalLifecycle.failNextConstructs = 2;
+
+    render(<RemoteTerminal deviceId="device-1" deviceHostname="host-1" />);
+    await screen.findByTestId('terminal-disconnect-overlay', undefined, { timeout: 3000 });
+
+    await userEvent.click(screen.getByTestId('terminal-overlay-reconnect'));
+    await waitFor(() => expect(terminalLifecycle.constructCount).toBe(2), { timeout: 3000 });
+
+    // Still offering a way out, and still no session for a terminal that does
+    // not exist.
+    expect(await screen.findByTestId('terminal-disconnect-overlay', undefined, { timeout: 3000 })).
+      toBeInTheDocument();
+    expect(sessionPostCount()).toBe(0);
+
+    // Third attempt succeeds, proving the guard never latched.
+    await userEvent.click(screen.getByTestId('terminal-overlay-reconnect'));
+    await waitFor(() => expect(terminalLifecycle.constructCount).toBe(3), { timeout: 3000 });
+    await waitFor(() => expect(sessionPostCount()).toBe(1), { timeout: 3000 });
+  });
+
+  // NOT new coverage for #4152 — the catch has always called onError. This
+  // pins that contract because RemoteToolsPage now depends on it to raise a
+  // toast (see RemoteToolsPage.test.tsx); before, the one caller that mattered
+  // passed no handler, so the call had no observable effect and could have
+  // been dropped by a refactor without anything failing.
+  it('reports the failure to the caller through onError (pre-existing contract)', async () => {
     terminalLifecycle.failNextConstructs = 1;
     const onError = vi.fn();
 

--- a/apps/web/src/components/remote/RemoteTerminal.initFailure.test.tsx
+++ b/apps/web/src/components/remote/RemoteTerminal.initFailure.test.tsx
@@ -1,0 +1,227 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import RemoteTerminal from './RemoteTerminal';
+import { fetchWithAuth } from '@/stores/auth';
+
+// Cold-mount init failures for RemoteTerminal (#4152), in a file of their own
+// for two reasons that RemoteTerminal.test.tsx cannot satisfy:
+//
+//  1. A factory-mocked module is evaluated exactly ONCE per test file and the
+//     result is cached for the rest of it — `vi.resetModules()` does not re-run
+//     the factory (verified). Guaranteeing that the component's very first
+//     `await import('@xterm/xterm/css/xterm.css')` is the one that rejects
+//     therefore requires a file where no earlier test has imported it.
+//  2. The layout cases in RemoteTerminal.test.tsx render without awaiting init,
+//     so their `new Terminal(...)` lands during a later test. Sharing that file
+//     would let a leaked construction consume this file's injected failure.
+//
+// What is reproduced: Vite compiles the component's dynamic CSS import into a
+// `<link rel=stylesheet>` injection that resolves on `load` and REJECTS on
+// `error`. After an upgrade a stale hashed asset URL comes back as the SPA's
+// index.html, which `nosniff` refuses to treat as a stylesheet — so the
+// promise rejects on a cold mount. Before the fix that single rejection
+// unwound the whole of initTerminal: no terminal instance, no `terminalReady`,
+// therefore no auto-connect and — because the retry overlay is gated on
+// `autoConnectAttempted`, which only the auto-connect sets — nothing to click.
+// The pane sat on "Disconnected" until a tab round-trip remounted it.
+const cssImport = { evaluations: 0, threw: false };
+
+vi.mock('@xterm/xterm/css/xterm.css', () => {
+  cssImport.evaluations += 1;
+  // Only the first evaluation fails, so the stylesheet-specific case below can
+  // prove the rejection reached the component. Vitest caches the outcome
+  // anyway; the counter is what the assertions actually rely on.
+  if (cssImport.evaluations === 1) {
+    cssImport.threw = true;
+    throw new Error(
+      "Unable to preload CSS for /assets/xterm-abc123.css (MIME type 'text/html' is not a supported stylesheet MIME type)",
+    );
+  }
+  return {};
+});
+
+const terminalLifecycle = {
+  constructCount: 0,
+  /**
+   * Number of upcoming `new Terminal(...)` calls that must throw — a stand-in
+   * for any init failure other than the stylesheet (a rejected xterm chunk, a
+   * constructor blowing up), all of which land in the same catch.
+   */
+  failNextConstructs: 0,
+};
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: function () {
+    terminalLifecycle.constructCount += 1;
+    if (terminalLifecycle.failNextConstructs > 0) {
+      terminalLifecycle.failNextConstructs -= 1;
+      throw new Error('xterm construction failed');
+    }
+    return {
+      loadAddon() {},
+      open() {},
+      write() {},
+      writeln() {},
+      onData() {
+        return { dispose() {} };
+      },
+      onResize() {
+        return { dispose() {} };
+      },
+      dispose() {},
+      focus() {},
+      clear() {},
+      rows: 24,
+      cols: 80,
+    };
+  },
+}));
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: function () {
+    return {
+      fit() {},
+      proposeDimensions() {
+        return { cols: 80, rows: 24 };
+      },
+    };
+  },
+}));
+vi.mock('@xterm/addon-web-links', () => ({
+  WebLinksAddon: function () {
+    return {};
+  },
+}));
+
+vi.mock('@/stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+const makeResponse = (payload: unknown): Response =>
+  ({
+    ok: true,
+    status: 200,
+    json: vi.fn().mockResolvedValue(payload),
+  } as unknown as Response);
+
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSED = 3;
+  static instances: MockWebSocket[] = [];
+
+  readyState: number = MockWebSocket.CONNECTING;
+  onopen: ((ev: unknown) => void) | null = null;
+  onmessage: ((ev: { data: string }) => void) | null = null;
+  onerror: ((ev: unknown) => void) | null = null;
+  onclose: ((ev: { code: number }) => void) | null = null;
+
+  constructor(public url: string) {
+    MockWebSocket.instances.push(this);
+    queueMicrotask(() => {
+      this.readyState = MockWebSocket.OPEN;
+      this.onopen?.({});
+    });
+  }
+
+  send() {}
+
+  close(code?: number) {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.({ code: code ?? 1000 });
+  }
+}
+
+const sessionPostCount = () =>
+  fetchMock.mock.calls.filter(
+    ([url, opts]) => url === '/remote/sessions' && (opts as RequestInit | undefined)?.method === 'POST',
+  ).length;
+
+beforeEach(() => {
+  MockWebSocket.instances = [];
+  terminalLifecycle.constructCount = 0;
+  terminalLifecycle.failNextConstructs = 0;
+  vi.stubGlobal('WebSocket', MockWebSocket);
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+  fetchMock.mockReset();
+  fetchMock.mockImplementation(async (url: string) => {
+    if (/\/ws-ticket$/.test(url)) return makeResponse({ ticket: 'TKT-1' });
+    return makeResponse({ id: 'session-1' });
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('RemoteTerminal cold mount with a broken xterm stylesheet (#4152)', () => {
+  it('treats the failed stylesheet preload as cosmetic and still connects', async () => {
+    render(<RemoteTerminal deviceId="device-1" deviceHostname="host-1" />);
+
+    // Losing the stylesheet must cost styling, never the session: the terminal
+    // is still constructed and the ordinary auto-connect path runs.
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1), { timeout: 3000 });
+    expect(sessionPostCount()).toBe(1);
+    expect(terminalLifecycle.constructCount).toBe(1);
+    expect(screen.queryByTestId('terminal-disconnect-overlay')).not.toBeInTheDocument();
+
+    // Prove the control actually fired — without this the test passes for the
+    // trivial reason that the stylesheet loaded fine.
+    expect(cssImport.evaluations).toBe(1);
+    expect(cssImport.threw).toBe(true);
+  });
+});
+
+describe('RemoteTerminal init failure is visible and retryable in place (#4152)', () => {
+  it('renders the retry overlay instead of an inert empty pane', async () => {
+    terminalLifecycle.failNextConstructs = 1;
+
+    render(<RemoteTerminal deviceId="device-1" deviceHostname="host-1" />);
+
+    // Before the fix nothing rendered here: status stayed 'disconnected' with
+    // `autoConnectAttempted` false, so the overlay's condition was never met.
+    expect(
+      await screen.findByTestId('terminal-disconnect-overlay', undefined, { timeout: 3000 }),
+    ).toBeInTheDocument();
+    expect(terminalLifecycle.constructCount).toBe(1);
+    // Nothing was ever asked of the API for a terminal that does not exist —
+    // this is the reporter's "Disconnected, no session" state.
+    expect(sessionPostCount()).toBe(0);
+  });
+
+  it('re-runs init when the retry button is clicked, then connects', async () => {
+    terminalLifecycle.failNextConstructs = 1;
+
+    render(<RemoteTerminal deviceId="device-1" deviceHostname="host-1" />);
+    await screen.findByTestId('terminal-disconnect-overlay', undefined, { timeout: 3000 });
+
+    await userEvent.click(screen.getByTestId('terminal-overlay-reconnect'));
+
+    // The retry has to re-run init: there is no terminal yet, and connect()
+    // alone early-returns on the null terminalRef, so the button was a no-op.
+    await waitFor(() => expect(terminalLifecycle.constructCount).toBe(2), { timeout: 3000 });
+    // Init succeeding hands off to the ordinary auto-connect path.
+    await waitFor(() => expect(sessionPostCount()).toBe(1), { timeout: 3000 });
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1), { timeout: 3000 });
+  });
+
+  it('reports the failure to the caller through onError', async () => {
+    terminalLifecycle.failNextConstructs = 1;
+    const onError = vi.fn();
+
+    render(<RemoteTerminal deviceId="device-1" deviceHostname="host-1" onError={onError} />);
+
+    await waitFor(() => expect(onError).toHaveBeenCalledTimes(1), { timeout: 3000 });
+    expect(onError.mock.calls[0]![0]).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/remote/RemoteTerminal.test.tsx
+++ b/apps/web/src/components/remote/RemoteTerminal.test.tsx
@@ -98,7 +98,12 @@ vi.mock('@xterm/addon-web-links', () => ({
     return {};
   },
 }));
-vi.mock('@xterm/xterm/css/xterm.css', () => ({}));
+// xterm's stylesheet is inlined into the component's chunk (`?inline`) and
+// injected as a single <style> element — see initTerminal and #4152. The
+// sentinel rule below is what the injection cases assert on.
+const XTERM_CSS_SENTINEL = '.xterm-viewport { position: absolute; }';
+
+vi.mock('@xterm/xterm/css/xterm.css?inline', () => ({ default: XTERM_CSS_SENTINEL }));
 
 vi.mock('@/stores/auth', () => ({
   fetchWithAuth: vi.fn(),
@@ -599,5 +604,30 @@ describe('RemoteTerminal layout fills its flex parent (#4510)', () => {
     const xtermContainer = container.querySelector('.u-min-h-px-400') as HTMLElement | null;
     expect(xtermContainer).not.toBeNull();
     expect(xtermContainer!.className).toMatch(/\bflex-1\b/);
+  });
+});
+
+
+// The stylesheet is not decorative: it positions `.xterm-viewport`, absolutely
+// stacks the `.xterm-screen` canvases and hides `.xterm-helper-textarea` (the
+// offscreen textarea that captures keyboard/IME input). Shipping it inline and
+// attaching it ourselves is what makes a stale hashed .css asset unable to
+// either kill the terminal or silently strip its layout (#4152).
+describe('RemoteTerminal attaches the inlined xterm stylesheet (#4152)', () => {
+  it('injects the stylesheet exactly once, however many times it mounts', async () => {
+    const { unmount } = renderTerminal();
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1), { timeout: 2000 });
+
+    const injected = document.querySelectorAll('style#xterm-css');
+    expect(injected).toHaveLength(1);
+    expect(injected[0]!.textContent).toBe(XTERM_CSS_SENTINEL);
+
+    // Every Remote Tools tab switch is a real unmount/remount, so a duplicate
+    // <style> per mount would accumulate for the whole session.
+    unmount();
+    renderTerminal();
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(2), { timeout: 2000 });
+
+    expect(document.querySelectorAll('style#xterm-css')).toHaveLength(1);
   });
 });

--- a/apps/web/src/components/remote/RemoteTerminal.tsx
+++ b/apps/web/src/components/remote/RemoteTerminal.tsx
@@ -151,8 +151,20 @@ export default function RemoteTerminal({
       const { FitAddon } = await import('@xterm/addon-fit');
       const { WebLinksAddon } = await import('@xterm/addon-web-links');
 
-      // Import CSS
-      await import('@xterm/xterm/css/xterm.css');
+      // The stylesheet is cosmetic, so its load must never be able to fail
+      // the terminal (#4152). Vite compiles this dynamic import into a
+      // `<link rel=stylesheet>` injection that resolves on `load` and REJECTS
+      // on `error` — and it does reject in the field: after an upgrade a stale
+      // hashed asset URL comes back as the SPA's index.html, which `nosniff`
+      // refuses to treat as CSS. Awaited bare, that one rejection unwound the
+      // whole of init, leaving a permanently dead pane. Degrade to an
+      // unstyled terminal instead.
+      await import('@xterm/xterm/css/xterm.css').catch((cssError) => {
+        console.warn(
+          'Terminal stylesheet failed to load; continuing with an unstyled terminal:',
+          cssError
+        );
+      });
 
       const fitAddon = new FitAddon();
       const webLinksAddon = new WebLinksAddon();
@@ -220,6 +232,16 @@ export default function RemoteTerminal({
       setTerminalReady(true);
     } catch (error) {
       console.error('Failed to initialize terminal:', error);
+      // Release the one-shot guard so the user can retry without remounting.
+      // It is only otherwise cleared by unmount cleanup, which is why a failed
+      // cold mount used to need a tab round-trip to recover (#4152).
+      initStartedRef.current = false;
+      // Surface the failure. Without this the pane keeps the initial
+      // 'disconnected' status while `autoConnectAttempted` stays false (the
+      // auto-connect effect is gated on `terminalReady`, which never flips),
+      // so the retry overlay's condition is never satisfied and the user is
+      // left with an empty pane and nothing to click.
+      setStatus('failed');
       onErrorRef.current?.(tRef.current('remoteTerminal.errors.initialize'));
     }
   }, []);
@@ -650,6 +672,22 @@ export default function RemoteTerminal({
     }
   }, [terminalReady, status, sessionId, autoConnectAttempted, connect]);
 
+  // The overlay's button has to serve two different broken states. When a
+  // session died, the terminal object still exists and reconnecting is the
+  // whole job. When init itself failed there is no terminal at all, and
+  // connect() early-returns on the null `terminalRef` — so the button silently
+  // did nothing (#4152). Re-run init in that case; the auto-connect effect
+  // takes it from there once `terminalReady` flips, which is also why the
+  // status has to go back to 'disconnected' (that effect is gated on it).
+  const handleOverlayRetry = useCallback(() => {
+    if (terminalRef.current) {
+      void connect();
+      return;
+    }
+    setStatus('disconnected');
+    void initTerminal();
+  }, [connect, initTerminal]);
+
   // Format connection duration
   const getConnectionDuration = () => {
     if (!connectionTime) return '';
@@ -791,7 +829,7 @@ export default function RemoteTerminal({
               <button
                 type="button"
                 data-testid="terminal-overlay-reconnect"
-                onClick={connect}
+                onClick={handleOverlayRetry}
                 className="flex h-8 items-center gap-1.5 rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground hover:opacity-90"
               >
                 <RefreshCw className="h-4 w-4" />

--- a/apps/web/src/components/remote/RemoteTerminal.tsx
+++ b/apps/web/src/components/remote/RemoteTerminal.tsx
@@ -60,6 +60,12 @@ export type RemoteTerminalProps = {
 // server's 40s deadline, and SERVER_SILENCE_TIMEOUT_MS must stay above the
 // server's ping interval — otherwise healthy idle sessions get killed on
 // whichever side drifted.
+// Identifies the single <style> element carrying xterm's stylesheet. The CSS
+// is inlined into this component's chunk (see initTerminal), so it has to be
+// attached to the document exactly once no matter how many times the terminal
+// mounts.
+const XTERM_STYLE_ELEMENT_ID = 'xterm-css';
+
 const CLIENT_PING_INTERVAL_MS = 20_000;
 const SERVER_SILENCE_TIMEOUT_MS = 45_000;
 const LIVENESS_CHECK_INTERVAL_MS = 5_000;
@@ -151,20 +157,46 @@ export default function RemoteTerminal({
       const { FitAddon } = await import('@xterm/addon-fit');
       const { WebLinksAddon } = await import('@xterm/addon-web-links');
 
-      // The stylesheet is cosmetic, so its load must never be able to fail
-      // the terminal (#4152). Vite compiles this dynamic import into a
-      // `<link rel=stylesheet>` injection that resolves on `load` and REJECTS
-      // on `error` — and it does reject in the field: after an upgrade a stale
-      // hashed asset URL comes back as the SPA's index.html, which `nosniff`
-      // refuses to treat as CSS. Awaited bare, that one rejection unwound the
-      // whole of init, leaving a permanently dead pane. Degrade to an
-      // unstyled terminal instead.
-      await import('@xterm/xterm/css/xterm.css').catch((cssError) => {
+      // xterm's stylesheet ships INSIDE this lazy chunk (`?inline` hands us
+      // the CSS as a string) instead of as a separate hashed .css asset, and
+      // that is the actual fix for #4152.
+      //
+      // A plain `import '@xterm/xterm/css/xterm.css'` compiles to Vite's
+      // preload helper injecting a `<link rel=stylesheet>` and awaiting its
+      // `load` event — a promise that REJECTS on `error`. It does reject in
+      // the field: after an upgrade a stale hashed URL returns the SPA's
+      // index.html, which `nosniff` refuses to treat as CSS. Awaited bare,
+      // that lone rejection unwound the rest of init and left a permanently
+      // dead pane. Worse, the helper memoises attempted deps in a
+      // module-level `seen` map, so the remount that appeared to "fix" it
+      // (a tab round-trip) merely SKIPPED the stylesheet — the terminal came
+      // back styleless, and xterm.css is not decorative: it positions
+      // `.xterm-viewport`, absolutely stacks the `.xterm-screen` canvases and
+      // hides `.xterm-helper-textarea`, the offscreen textarea that captures
+      // keyboard/IME input.
+      //
+      // Inlining removes the whole failure class: there is no second asset to
+      // go stale, and the CSS cannot arrive without the JS that needs it. The
+      // catch is defence in depth only — a styling problem must never again be
+      // able to take the session down with it.
+      try {
+        const { default: xtermCss } = await import('@xterm/xterm/css/xterm.css?inline');
+        // Idempotent: remounts (every Remote Tools tab switch is one) and the
+        // second terminal on a split view must not stack duplicate <style>
+        // elements. Injecting a <style> is CSP-legal here — apps/web already
+        // carries style-src 'unsafe-inline' for xterm's runtime inline styles.
+        if (xtermCss && !document.getElementById(XTERM_STYLE_ELEMENT_ID)) {
+          const style = document.createElement('style');
+          style.id = XTERM_STYLE_ELEMENT_ID;
+          style.textContent = xtermCss;
+          document.head.appendChild(style);
+        }
+      } catch (cssError) {
         console.warn(
           'Terminal stylesheet failed to load; continuing with an unstyled terminal:',
           cssError
         );
-      });
+      }
 
       const fitAddon = new FitAddon();
       const webLinksAddon = new WebLinksAddon();

--- a/apps/web/src/components/remote/RemoteToolsPage.test.tsx
+++ b/apps/web/src/components/remote/RemoteToolsPage.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import RemoteToolsPage from './RemoteToolsPage';
 import { fetchWithAuth } from '@/stores/auth';
+import { showToast } from '@/components/shared/Toast';
 
 vi.mock('@/stores/auth', () => ({
   fetchWithAuth: vi.fn(),
@@ -16,11 +17,22 @@ vi.mock('./ConnectDesktopButton', () => ({
 }));
 
 // RemoteTerminal lazy-imports xterm.js and opens a WebSocket on mount — that
-// machinery is covered by RemoteTerminal.test.tsx. Here we only need proof
-// that RemoteToolsPage mounted the Terminal tab's content, so stub it out
-// with a marker element.
+// machinery is covered by RemoteTerminal.test.tsx / RemoteTerminal.initFailure
+// .test.tsx. Here we only need proof that RemoteToolsPage mounted the Terminal
+// tab's content, so stub it out with a marker element. The stub also captures
+// the props it was handed, which is how the onError wiring below is asserted.
+const terminalStubProps: { onError?: (message: string) => void } = {};
+
 vi.mock('./RemoteTerminal', () => ({
-  default: () => <div data-testid="remote-terminal-stub" />,
+  default: (props: { onError?: (message: string) => void }) => {
+    terminalStubProps.onError = props.onError;
+    return <div data-testid="remote-terminal-stub" />;
+  },
+}));
+
+vi.mock('@/components/shared/Toast', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/components/shared/Toast')>()),
+  showToast: vi.fn(),
 }));
 
 const fetchMock = vi.mocked(fetchWithAuth);
@@ -33,6 +45,8 @@ const makeResponse = (payload: unknown = {}, ok = false): Response =>
   } as unknown as Response);
 
 beforeEach(() => {
+  vi.mocked(showToast).mockClear();
+  terminalStubProps.onError = undefined;
   fetchMock.mockReset();
   // Nothing under test here depends on real device/process/service data —
   // every fetch resolves not-ok so effects bail out quietly.
@@ -113,5 +127,28 @@ describe('RemoteToolsPage tab hash persistence (#4512)', () => {
     });
     const processesButton = await screen.findByRole('button', { name: 'Processes' });
     expect(processesButton.className).toMatch(/border-primary/);
+  });
+});
+
+// The terminal's only channel for reporting a failed initialisation is the
+// onError prop. RemoteToolsPage never passed one, so a terminal that died on
+// mount was completely silent — the defect behind #4152 was invisible to the
+// user and to support.
+describe('RemoteToolsPage surfaces terminal errors (#4152)', () => {
+  it('passes an onError handler that raises a toast', async () => {
+    window.location.hash = '#terminal';
+
+    renderPage();
+    await screen.findByTestId('remote-terminal-stub');
+
+    expect(terminalStubProps.onError).toBeTypeOf('function');
+
+    act(() => {
+      terminalStubProps.onError!('Failed to initialize terminal');
+    });
+
+    expect(showToast).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error', message: 'Failed to initialize terminal' }),
+    );
   });
 });

--- a/apps/web/src/components/remote/RemoteToolsPage.tsx
+++ b/apps/web/src/components/remote/RemoteToolsPage.tsx
@@ -25,6 +25,7 @@ import RegistryEditor from './RegistryEditor';
 import RemoteTerminal from './RemoteTerminal';
 import FileManager from './FileManager';
 import ConnectDesktopButton from './ConnectDesktopButton';
+import { showToast } from '@/components/shared/Toast';
 import { getInitialFilePath } from './filePathUtils';
 import { useTranslation } from 'react-i18next';
 import '@/lib/i18n';
@@ -991,6 +992,15 @@ export default function RemoteToolsPage({
           <RemoteTerminal
             deviceId={deviceId}
             deviceHostname={resolvedDeviceName}
+            // Without this the terminal's only failure report went nowhere: it
+            // calls onError and, before #4152, did nothing else — so a dead
+            // terminal was indistinguishable from an idle one. The in-pane
+            // retry overlay is the primary signal now; the toast is what makes
+            // the failure noticeable if the user is looking elsewhere.
+            onError={(msg) => {
+              console.error('[RemoteToolsPage] Terminal error:', msg);
+              showToast({ type: 'error', message: msg });
+            }}
           />
         )}
         {activeTab === 'files' && (


### PR DESCRIPTION
## Root cause

A first visit to the Remote Tools **Terminal** tab landed on a permanently "Disconnected" pane — no session, no welcome banner, no Reconnect button. Switching to *any* other tab and back fixed it, which is what made this look like a File Browser warm-up problem for several rounds. It is neither: it is a single non-retryable `await` inside terminal init.

`apps/web/src/components/remote/RemoteTerminal.tsx:155` awaited the stylesheet bare:

```ts
await import('@xterm/xterm/css/xterm.css');
```

Vite compiles that dynamic CSS import into a `<link rel=stylesheet>` injection that resolves on `load` and **rejects on `error`**. It does reject in the field: after an upgrade a stale hashed asset URL comes back as the SPA's `index.html`, and `nosniff` refuses to treat `text/html` as a stylesheet. The reporter's console capture on #4090 showed exactly that (`Failed to preload xterm CSS`, MIME `text/html`, `nosniff`).

That rejection unwound the rest of `initTerminal`, into a catch (`:221-224`) that only logged and called an `onError` callback `RemoteToolsPage.tsx:990-995` never passed. Everything after the await was skipped — `terminalRef` (`:199`) was never assigned and `setTerminalReady(true)` (`:220`) never ran — which produces each reported symptom:

- **No session, no network calls.** Auto-connect (`:642-651`) is gated on `terminalReady`.
- **No Reconnect button.** The overlay (`:778`) requires `failed || (disconnected && autoConnectAttempted)`, and `autoConnectAttempted` is only set by the auto-connect that never fired. Empty pane, nothing to click.
- **Any tab round-trip fixes it.** `RemoteToolsPage.tsx:990` renders the terminal only while its tab is active, so leaving and returning is a full remount, and Vite's preload helper memoises attempted deps in a module-level `seen` map:

  ```js
  if (dep in seen) return;   // vite/dist/node/chunks/node.js — `seen` lives for the page's lifetime
  seen[dep] = true;
  ...
  if (isCss) return new Promise((res, rej) => {
    link.addEventListener('load', res);
    link.addEventListener('error', () => rej(new Error(`Unable to preload CSS for ${dep}`)));
  });
  ```

  On the remount the dep is already in `seen`, so the helper returns immediately and init completes — **with the stylesheet still not loaded.** `initStartedRef` (`:146`) is cleared only in unmount cleanup (`:618`), so nothing short of a remount could retry.

Not the `#4161` hostname-prop race (that fixed a re-init race *within* a mount; a tab switch is a remount either way).

## Changes

1. **The stylesheet ships inside the component's chunk** — `import('@xterm/xterm/css/xterm.css?inline')` hands over the CSS as a string, injected once as `<style id="xterm-css">`. This removes the failure class instead of surviving it: there is no separate asset to go stale, and the CSS cannot arrive without the JS that needs it. A `try/catch` remains as defence in depth, so a styling problem can never again take the session down.
2. **An init failure is now visible** — the catch releases `initStartedRef` and sets status `'failed'`, so the existing overlay renders instead of an inert pane.
3. **The overlay button recovers both broken states** — `handleOverlayRetry` re-runs `initTerminal()` when no terminal exists (the old `onClick={connect}` early-returned at `:229` on the null `terminalRef`, so the button was a no-op in exactly this case); auto-connect takes over once `terminalReady` flips. When a terminal does exist it still just reconnects.
4. **`RemoteToolsPage` passes `onError`** — a failure raises an error toast via the shared `showToast` helper (the pattern `ConnectDesktopButton` in the same directory uses). `RemoteTerminalPage` already passed one; `RemoteToolsPage` was the only mount site that did not.

### Why inlining, and not just swallowing the rejection

The first revision of this PR only added `.catch()`. Review established that `xterm.css` (7112 bytes, v6.0.0) is **not** decorative — it positions `.xterm-viewport`, absolutely stacks the `.xterm-screen` canvases so cursor/selection composite over the text, and hides `.xterm-helper-textarea`, the offscreen textarea that captures keyboard/IME input. Swallowing the rejection would have traded a visibly dead terminal for a silently mis-rendered one that still reports "Connected". Note the `seen`-map behaviour above means the reporter's known-good post-round-trip terminal *was* that styleless state.

Verified against real production builds of `apps/web`, grepping for a CSS-only marker (`.xterm-underline-5`):

| build | where the vendor CSS rules land |
|---|---|
| bare `import '…/xterm.css'` | `dist/server/entry.mjs` only — Astro's stylesheet machinery, i.e. the separate `<link>` asset that 404s |
| `import '…/xterm.css?inline'` | `dist/client/_astro/xterm.Bidc9Bbs.js` only — a client JS chunk. **No stylesheet asset is emitted at all.** |

CSP is satisfied: `apps/web/astro.config.mjs` already sets `styleDirective: ["'self'", "'unsafe-inline'"]`, with a comment saying it carries that directive *for* xterm's runtime inline styles.

## Test evidence

New file `apps/web/src/components/remote/RemoteTerminal.initFailure.test.tsx`, plus cases in `RemoteTerminal.test.tsx` and `RemoteToolsPage.test.tsx`.

The init-failure cases live in a separate file for two verified reasons: a factory-mocked module is evaluated **once per test file** and `vi.resetModules()` does **not** re-run the factory (probed directly — an injected rejection never reached the component and the test passed vacuously), and the `#4510` layout cases in `RemoteTerminal.test.tsx` render without awaiting init, so their `new Terminal(...)` lands during a later test and would consume an injected failure.

**Red — against the unfixed component:**

```
 × treats the failed stylesheet preload as cosmetic and still connects
   AssertionError: expected [] to have a length of 1 but got +0
 × renders the retry overlay instead of an inert empty pane
   Unable to find an element by: [data-testid="terminal-disconnect-overlay"]
 × re-runs init when the retry button is clicked, then connects
   Unable to find an element by: [data-testid="terminal-disconnect-overlay"]
 Tests  3 failed | 1 passed (4)
```

```
 × passes an onError handler that raises a toast
   AssertionError: expected undefined to be type of 'function'
 Tests  1 failed | 6 passed (7)      # RemoteToolsPage.test.tsx
```

The stylesheet case asserts `cssImport.evaluations === 1` and `threw === true`, so it cannot pass for the trivial reason that the stylesheet loaded.

**Green — with the fix:**

```
apps/web $ npx vitest run src/components/remote/
 Test Files  21 passed (21)
      Tests  158 passed (158)      # 25 across the two RemoteTerminal files

apps/web $ npx tsc --noEmit               # clean, exit 0
apps/web $ npx eslint <touched files>     # clean, exit 0
apps/web $ npx astro build                # clean, artifacts inspected per the table above
apps/web $ npx vitest run src/lib/__tests__/no-silent-mutations.test.ts
      Tests  130 passed (130)
```

No migrations, no schema, no tenancy surface touched — `apps/web` only.

Closes #4152

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zx46C9kvzFoSNFWS7LZZf