### PR TITLE
feat(web): Run again + post-run navigation for script executions (#4885, #4886)

### DIFF
--- a/apps/api/src/routes/devices/scripts.test.ts
+++ b/apps/api/src/routes/devices/scripts.test.ts
@@ -19,6 +19,7 @@ vi.mock('../../db/schema', () => ({
     stdout: 'stdout',
     stderr: 'stderr',
     errorMessage: 'errorMessage',
+    parameters: 'parameters',
     startedAt: 'startedAt',
     completedAt: 'completedAt',
     createdAt: 'createdAt',
@@ -143,6 +144,55 @@ describe('device scripts routes', () => {
     expect(body.data[0].completedAt).toBe('2026-02-08T00:00:03.000Z');
     expect(getDeviceWithOrgCheck).toHaveBeenCalledWith('device-1', expect.any(Object));
     expect(limit).toHaveBeenCalledWith(50);
+  });
+
+  it('includes the run parameters so the web UI can offer "Run again" (#4885)', async () => {
+    vi.mocked(getDeviceWithOrgCheck).mockResolvedValueOnce({
+      id: 'device-1',
+      orgId: 'org-123',
+      hostname: 'host-1'
+    } as never);
+
+    const executionRows = [
+      {
+        id: 'exec-1',
+        scriptId: 'script-1',
+        scriptName: 'Collect Inventory',
+        status: 'completed',
+        exitCode: 0,
+        stdout: 'ok',
+        stderr: '',
+        errorMessage: null,
+        parameters: { target: 'C:\\Temp' },
+        startedAt: new Date('2026-02-08T00:00:00.000Z'),
+        completedAt: new Date('2026-02-08T00:00:03.000Z'),
+        createdAt: new Date('2026-02-08T00:00:00.000Z')
+      }
+    ];
+
+    const limit = vi.fn().mockResolvedValue(executionRows);
+    const orderBy = vi.fn().mockReturnValue({ limit });
+    const where = vi.fn().mockReturnValue({ orderBy });
+    const leftJoin = vi.fn().mockReturnValue({ where });
+    const from = vi.fn().mockReturnValue({ leftJoin });
+
+    vi.mocked(db.select).mockReturnValueOnce({ from } as never);
+
+    const res = await app.request('/devices/device-1/scripts', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer token' }
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data[0].parameters).toEqual({ target: 'C:\\Temp' });
+
+    // The real assertion: the route must actually SELECT the parameters
+    // column, not merely pass through whatever the mock returns. db.select
+    // is mocked here (real Drizzle needs a live DB), so the only way to prove
+    // the production query changed is to inspect what it was called with.
+    const selectArg = vi.mocked(db.select).mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(selectArg.parameters).toBe('parameters');
   });
 
   it('returns 404 when the device is not accessible', async () => {

--- a/apps/api/src/routes/devices/scripts.ts
+++ b/apps/api/src/routes/devices/scripts.ts
@@ -37,6 +37,12 @@ scriptsRoutes.get(
         stdout: scriptExecutions.stdout,
         stderr: scriptExecutions.stderr,
         errorMessage: scriptExecutions.errorMessage,
+        // #4885 — the "Run again" action needs the runtime values the
+        // execution was submitted with. Already exposed at the same
+        // SCRIPTS_READ permission level by GET /scripts/:id/executions and
+        // GET /scripts/executions/:id, so this adds no new exposure — just
+        // parity for the device-scoped history list.
+        parameters: scriptExecutions.parameters,
         startedAt: scriptExecutions.startedAt,
         completedAt: scriptExecutions.completedAt,
         createdAt: scriptExecutions.createdAt

--- a/apps/web/src/components/devices/DeviceDetailPage.scriptAdmission.test.tsx
+++ b/apps/web/src/components/devices/DeviceDetailPage.scriptAdmission.test.tsx
@@ -44,6 +44,7 @@ const DEVICE_ID = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
 describe('DeviceDetailPage script admission', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.location.hash = '';
     vi.mocked(fetchWithAuth).mockResolvedValue(new Response(JSON.stringify({
       id: DEVICE_ID,
       hostname: 'alpha-01',
@@ -68,5 +69,26 @@ describe('DeviceDetailPage script admission', () => {
     await waitFor(() => expect(vi.mocked(executeScript)).toHaveBeenCalledTimes(1));
     expect(vi.mocked(showToast)).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
     expect(vi.mocked(showToast)).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+    // #4886 — a rejected admission must not redirect the operator anywhere.
+    expect(window.location.hash).toBe('');
+  });
+
+  // #4886 — after a successful queue, the operator should land where the
+  // result appears (the device's own Scripts tab) instead of staying wherever
+  // they happened to trigger the run from.
+  it('switches to the Scripts tab, highlighting the new execution, once the run is admitted', async () => {
+    vi.mocked(executeScript).mockResolvedValue({
+      requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      status: 'queued',
+      targets: [{ requestedDeviceId: DEVICE_ID, admission: 'admitted', executionId: 'execution-1' }],
+    } as never);
+
+    render(<DeviceDetailPage deviceId={DEVICE_ID} />);
+    fireEvent.click(await screen.findByText('Run Script'));
+    fireEvent.click(await screen.findByText('Choose Cleanup'));
+
+    await waitFor(() => expect(vi.mocked(executeScript)).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(window.location.hash).toBe('#scripts/execution-1'));
+    expect(vi.mocked(showToast)).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
   });
 });

--- a/apps/web/src/components/devices/DeviceDetailPage.tsx
+++ b/apps/web/src/components/devices/DeviceDetailPage.tsx
@@ -26,6 +26,7 @@ import {
 } from "../../services/deviceActions";
 import { useAiStore } from "@/stores/aiStore";
 import { navigateTo } from "@/lib/navigation";
+import { deviceScriptsHash } from "@/lib/deviceScriptsLink";
 import { runAction, ActionError } from "@/lib/runAction";
 import Breadcrumbs from "../layout/Breadcrumbs";
 import { useTranslation } from "react-i18next";
@@ -494,9 +495,7 @@ export default function DeviceDetailPage({ deviceId }: DeviceDetailPageProps) {
         // happened to trigger the run from (often Overview). Same page, so a
         // direct hash write is enough — DeviceDetails' useHashState picks up
         // the resulting hashchange (the CLAUDE.md tab-state convention).
-        window.location.hash = target.executionId
-          ? `scripts/${target.executionId}`
-          : "scripts";
+        window.location.hash = deviceScriptsHash(target.executionId);
       } else {
         showToast({
           type: "error",

--- a/apps/web/src/components/devices/DeviceDetailPage.tsx
+++ b/apps/web/src/components/devices/DeviceDetailPage.tsx
@@ -489,6 +489,14 @@ export default function DeviceDetailPage({ deviceId }: DeviceDetailPageProps) {
           type: "success",
           message: `Script "${script.name}" queued for ${device.hostname}`,
         });
+        // #4886 — land on the Scripts tab with the new execution highlighted,
+        // so the operator watches the result instead of staying wherever they
+        // happened to trigger the run from (often Overview). Same page, so a
+        // direct hash write is enough — DeviceDetails' useHashState picks up
+        // the resulting hashchange (the CLAUDE.md tab-state convention).
+        window.location.hash = target.executionId
+          ? `scripts/${target.executionId}`
+          : "scripts";
       } else {
         showToast({
           type: "error",

--- a/apps/web/src/components/devices/DeviceDetails.scriptHighlight.test.tsx
+++ b/apps/web/src/components/devices/DeviceDetails.scriptHighlight.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * #4886 — a script run redirects the operator to the device's Scripts tab
+ * with the new execution highlighted, using the same `#<tab>/<id>` hash
+ * convention DeviceDetails already uses for `#anomalies/<id>`.
+ */
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import DeviceDetails from './DeviceDetails';
+import type { Device } from './DeviceList';
+
+const fetchWithAuthMock = vi.hoisted(() => vi.fn());
+vi.mock('../../stores/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../stores/auth')>();
+  return { ...actual, fetchWithAuth: fetchWithAuthMock };
+});
+
+const useExtensionSlotDescriptorsMock = vi.hoisted(() => vi.fn());
+vi.mock('../extensions/ExtensionSlotHost', () => ({
+  useExtensionSlotDescriptors: (...a: unknown[]) => useExtensionSlotDescriptorsMock(...a),
+  default: () => <div data-testid="extension-slot-host-stub" />,
+}));
+
+vi.mock('./DeviceScriptHistory', () => ({
+  default: ({ deviceId, highlightExecutionId }: { deviceId: string; highlightExecutionId?: string }) => (
+    <div
+      data-testid="device-script-history-stub"
+      data-device-id={deviceId}
+      data-highlight-execution-id={highlightExecutionId ?? ''}
+    />
+  ),
+}));
+
+const device: Device = {
+  id: 'device-1',
+  hostname: 'edge-01',
+  os: 'windows',
+  osVersion: '11',
+  status: 'online',
+  cpuPercent: 12,
+  ramPercent: 34,
+  uptimeSeconds: 3600,
+  lastSeen: '2026-02-09T10:00:00.000Z',
+  orgId: 'org-1',
+  orgName: 'Org One',
+  siteId: 'site-1',
+  siteName: 'HQ',
+  agentVersion: '1.0.0',
+  pendingReboot: false,
+  displayName: 'Edge 01',
+} as Device;
+
+beforeEach(() => {
+  window.location.hash = '';
+  useExtensionSlotDescriptorsMock.mockReturnValue([]);
+  fetchWithAuthMock.mockResolvedValue(
+    new Response(JSON.stringify({}), { status: 404 }) as unknown as Response
+  );
+});
+
+describe('DeviceDetails script execution highlight (#4886)', () => {
+  it('passes the execution id from "#scripts/<id>" down to DeviceScriptHistory', async () => {
+    window.location.hash = '#scripts/execution-42';
+    render(<DeviceDetails device={device} />);
+
+    const stub = await screen.findByTestId('device-script-history-stub');
+    expect(stub.dataset.deviceId).toBe('device-1');
+    expect(stub.dataset.highlightExecutionId).toBe('execution-42');
+  });
+
+  it('passes no highlight id for a plain "#scripts" hash', async () => {
+    window.location.hash = '#scripts';
+    render(<DeviceDetails device={device} />);
+
+    const stub = await screen.findByTestId('device-script-history-stub');
+    expect(stub.dataset.highlightExecutionId).toBe('');
+  });
+
+  it('does not treat an anomaly id on a different tab as a script highlight', async () => {
+    window.location.hash = '#anomalies/execution-42';
+    render(<DeviceDetails device={device} />);
+
+    // The scripts panel isn't even mounted on the anomalies tab.
+    expect(screen.queryByTestId('device-script-history-stub')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/devices/DeviceDetails.tsx
+++ b/apps/web/src/components/devices/DeviceDetails.tsx
@@ -67,6 +67,7 @@ import DeviceUserIdleStat from "./DeviceUserIdleStat";
 import MacOSPermissionsBanner from "./MacOSPermissionsBanner";
 import PossibleReplacementBanner from "./PossibleReplacementBanner";
 import { navigateTo } from "@/lib/navigation";
+import { decodeScriptExecutionId } from "@/lib/deviceScriptsLink";
 import { OverflowTabs } from "../shared/OverflowTabs";
 import DeviceBackupTab from "../backup/DeviceBackupTab";
 import DeviceTicketsTab from "../tickets/DeviceTicketsTab";
@@ -234,10 +235,12 @@ function anomalyIdFromHash(hash: string): string | undefined {
 // Scripts tab (via tabFromHash, which only looks at the first segment) and
 // tells DeviceScriptHistory which execution to auto-open/highlight, so a
 // post-run redirect lands the operator watching the right row rather than a
-// generic tab switch.
+// generic tab switch. The segment is percent-decoded — deviceScriptsHash()
+// (the only writer) percent-encodes it, so this must reverse that or a
+// highlight for any id needing an escape would silently never match.
 function scriptExecutionIdFromHash(hash: string): string | undefined {
   const [tab, executionId] = hash.split("/");
-  return tab === "scripts" && executionId ? executionId : undefined;
+  return tab === "scripts" ? decodeScriptExecutionId(executionId) : undefined;
 }
 
 type LinkedNetworkAsset = { id: string; label: string };

--- a/apps/web/src/components/devices/DeviceDetails.tsx
+++ b/apps/web/src/components/devices/DeviceDetails.tsx
@@ -230,6 +230,16 @@ function anomalyIdFromHash(hash: string): string | undefined {
   return tab === "anomalies" && anomalyId ? anomalyId : undefined;
 }
 
+// #4886 — mirrors anomalyIdFromHash: `#scripts/<executionId>` both selects the
+// Scripts tab (via tabFromHash, which only looks at the first segment) and
+// tells DeviceScriptHistory which execution to auto-open/highlight, so a
+// post-run redirect lands the operator watching the right row rather than a
+// generic tab switch.
+function scriptExecutionIdFromHash(hash: string): string | undefined {
+  const [tab, executionId] = hash.split("/");
+  return tab === "scripts" && executionId ? executionId : undefined;
+}
+
 type LinkedNetworkAsset = { id: string; label: string };
 
 // Back-link to any discovered assets identity-linked to this device (#3261
@@ -321,6 +331,9 @@ export default function DeviceDetails({
   const [focusedAnomalyId, setFocusedAnomalyId] = useHashState<
     string | undefined
   >(undefined, anomalyIdFromHash);
+  const [highlightedExecutionId, setHighlightedExecutionId] = useHashState<
+    string | undefined
+  >(undefined, scriptExecutionIdFromHash);
   // Whether the Overview Activity rail is collapsed to its thin vertical bar.
   // Starts collapsed so the page paints at full width during the async load and
   // never flashes a rail that then vanishes (the v0.85.0 stretch bug). Once the
@@ -353,6 +366,7 @@ export default function DeviceDetails({
     window.location.hash = tab;
     setActiveTab(tab);
     setFocusedAnomalyId(undefined);
+    setHighlightedExecutionId(undefined);
   };
 
   // Use provided timezone or browser default
@@ -836,6 +850,7 @@ export default function DeviceDetails({
         <DeviceScriptHistory
           deviceId={device.id}
           timezone={effectiveTimezone}
+          highlightExecutionId={highlightedExecutionId}
         />
       )}
 

--- a/apps/web/src/components/devices/DeviceScriptHistory.test.tsx
+++ b/apps/web/src/components/devices/DeviceScriptHistory.test.tsx
@@ -1,11 +1,13 @@
 import '@/lib/i18n';
 
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import DeviceScriptHistory from './DeviceScriptHistory';
 import { fetchWithAuth } from '../../stores/auth';
+import { showToast } from '../shared/Toast';
 
 vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
 
 type MockExecuteModalProps = {
   script: { id: string; name: string };
@@ -131,6 +133,48 @@ describe('DeviceScriptHistory "Run again" (#4885)', () => {
       expect(historyCalls.length).toBeGreaterThanOrEqual(2);
     });
   });
+
+  it('toasts an error and does not open the execute modal when the script definition fails to load', async () => {
+    fetchWithAuthMock.mockImplementation(async (input: string) => {
+      const url = String(input);
+      if (url === `/devices/${DEVICE_ID}/scripts`) {
+        return jsonResponse({ data: [executionRow] });
+      }
+      if (url === '/scripts/script-1') {
+        return jsonResponse({ error: 'not found' }, 404);
+      }
+      return jsonResponse({}, 404);
+    });
+
+    await openDetails();
+    fireEvent.click(screen.getByTestId('device-script-run-again'));
+
+    await waitFor(() => expect(vi.mocked(showToast)).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error' })
+    ));
+    expect(screen.queryByTestId('mock-execution-modal')).not.toBeInTheDocument();
+  });
+
+  it('toasts an error when the script-detail request itself rejects (network failure)', async () => {
+    fetchWithAuthMock.mockImplementation(async (input: string) => {
+      const url = String(input);
+      if (url === `/devices/${DEVICE_ID}/scripts`) {
+        return jsonResponse({ data: [executionRow] });
+      }
+      if (url === '/scripts/script-1') {
+        throw new Error('network unreachable');
+      }
+      return jsonResponse({}, 404);
+    });
+
+    await openDetails();
+    fireEvent.click(screen.getByTestId('device-script-run-again'));
+
+    await waitFor(() => expect(vi.mocked(showToast)).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error', message: 'network unreachable' })
+    ));
+    expect(screen.queryByTestId('mock-execution-modal')).not.toBeInTheDocument();
+  });
 });
 
 describe('DeviceScriptHistory highlighted execution (#4886)', () => {
@@ -156,5 +200,28 @@ describe('DeviceScriptHistory highlighted execution (#4886)', () => {
 
     await screen.findByText('Collect Inventory');
     expect(screen.queryByText('Execution Details')).toBeNull();
+  });
+
+  // Guards `autoOpenedHighlightRef` (DeviceScriptHistory.tsx): the 10s poll
+  // refresh must not keep resurrecting a modal the operator already dismissed.
+  it('does not reopen the highlighted execution after it is closed once a 10s poll refresh runs', async () => {
+    vi.useFakeTimers();
+    const flush = (ms = 0) => act(async () => { await vi.advanceTimersByTimeAsync(ms); });
+    try {
+      render(<DeviceScriptHistory deviceId={DEVICE_ID} highlightExecutionId="exec-1" />);
+      await flush();
+      expect(screen.getByText('Execution Details')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByText('Close'));
+      expect(screen.queryByText('Execution Details')).toBeNull();
+
+      // One full poll interval — fetchHistory(true) runs again with the same
+      // (still-matching) execution row.
+      await flush(10000);
+
+      expect(screen.queryByText('Execution Details')).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/web/src/components/devices/DeviceScriptHistory.test.tsx
+++ b/apps/web/src/components/devices/DeviceScriptHistory.test.tsx
@@ -1,0 +1,160 @@
+import '@/lib/i18n';
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import DeviceScriptHistory from './DeviceScriptHistory';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+
+type MockExecuteModalProps = {
+  script: { id: string; name: string };
+  initialDeviceIds?: string[];
+  initialParameters?: Record<string, string | number | boolean>;
+  onExecute: (
+    scriptId: string,
+    deviceIds: string[],
+    parameters: Record<string, string | number | boolean>,
+    runAs: 'system' | 'user'
+  ) => Promise<unknown>;
+  onClose: () => void;
+};
+
+vi.mock('../scripts/ScriptExecutionModal', () => ({
+  default: ({ script, initialDeviceIds, initialParameters, onExecute, onClose }: MockExecuteModalProps) => (
+    <div data-testid="mock-execution-modal">
+      <div data-testid="mock-script-name">{script.name}</div>
+      <div data-testid="mock-initial-device-ids">{JSON.stringify(initialDeviceIds ?? null)}</div>
+      <div data-testid="mock-initial-parameters">{JSON.stringify(initialParameters ?? null)}</div>
+      <button type="button" onClick={() => void onExecute(script.id, initialDeviceIds ?? [], initialParameters ?? {}, 'system')}>
+        Confirm Run Again
+      </button>
+      <button type="button" onClick={onClose}>Close Modal</button>
+    </div>
+  ),
+}));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+const DEVICE_ID = 'device-1';
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status });
+}
+
+const executionRow = {
+  id: 'exec-1',
+  scriptId: 'script-1',
+  scriptName: 'Collect Inventory',
+  status: 'completed',
+  exitCode: 0,
+  stdout: 'ok',
+  stderr: '',
+  parameters: { target: 'C:\\Temp' },
+  startedAt: '2026-02-08T00:00:00.000Z',
+  completedAt: '2026-02-08T00:00:03.000Z',
+};
+
+const scriptDetail = {
+  id: 'script-1',
+  name: 'Collect Inventory',
+  language: 'powershell',
+  category: 'Maintenance',
+  osTypes: ['windows'],
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+describe('DeviceScriptHistory "Run again" (#4885)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchWithAuthMock.mockImplementation(async (input: string) => {
+      const url = String(input);
+      if (url === `/devices/${DEVICE_ID}/scripts`) {
+        return jsonResponse({ data: [executionRow] });
+      }
+      if (url === '/scripts/script-1') {
+        return jsonResponse(scriptDetail);
+      }
+      return jsonResponse({}, 404);
+    });
+  });
+
+  async function openDetails() {
+    render(<DeviceScriptHistory deviceId={DEVICE_ID} />);
+    fireEvent.click(await screen.findByText('Collect Inventory'));
+    return screen.findByText('Execution Details');
+  }
+
+  it('fetches the script definition and opens the execute modal pre-filled on "Run again"', async () => {
+    await openDetails();
+
+    fireEvent.click(screen.getByTestId('device-script-run-again'));
+
+    expect(await screen.findByTestId('mock-execution-modal')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-script-name')).toHaveTextContent('Collect Inventory');
+    expect(screen.getByTestId('mock-initial-device-ids')).toHaveTextContent(JSON.stringify([DEVICE_ID]));
+    expect(screen.getByTestId('mock-initial-parameters')).toHaveTextContent(JSON.stringify({ target: 'C:\\Temp' }));
+    // The details view closed in favor of the execute flow.
+    expect(screen.queryByText('Execution Details')).toBeNull();
+  });
+
+  it('refreshes history after a successful "Run again" submission', async () => {
+    let executeCalls = 0;
+    fetchWithAuthMock.mockImplementation(async (input: string, init?: RequestInit) => {
+      const url = String(input);
+      if (url === `/devices/${DEVICE_ID}/scripts`) {
+        return jsonResponse({ data: [executionRow] });
+      }
+      if (url === '/scripts/script-1') return jsonResponse(scriptDetail);
+      if (url === '/scripts/script-1/execute' && init?.method === 'POST') {
+        executeCalls += 1;
+        return jsonResponse({
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+          status: 'queued',
+          targets: [{ requestedDeviceId: DEVICE_ID, admission: 'admitted', executionId: 'exec-2' }],
+        }, 201);
+      }
+      return jsonResponse({}, 404);
+    });
+
+    await openDetails();
+    fireEvent.click(screen.getByTestId('device-script-run-again'));
+    await screen.findByTestId('mock-execution-modal');
+    fireEvent.click(screen.getByText('Confirm Run Again'));
+
+    await waitFor(() => expect(executeCalls).toBe(1));
+    // Two GETs to the history endpoint: the initial mount fetch, plus the
+    // post-run refresh.
+    await waitFor(() => {
+      const historyCalls = fetchWithAuthMock.mock.calls.filter(([url]) => String(url) === `/devices/${DEVICE_ID}/scripts`);
+      expect(historyCalls.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+});
+
+describe('DeviceScriptHistory highlighted execution (#4886)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchWithAuthMock.mockImplementation(async (input: string) => {
+      const url = String(input);
+      if (url === `/devices/${DEVICE_ID}/scripts`) {
+        return jsonResponse({ data: [executionRow] });
+      }
+      return jsonResponse({}, 404);
+    });
+  });
+
+  it('auto-opens the details modal for the highlighted execution once it loads', async () => {
+    render(<DeviceScriptHistory deviceId={DEVICE_ID} highlightExecutionId="exec-1" />);
+
+    expect(await screen.findByText('Execution Details')).toBeInTheDocument();
+  });
+
+  it('does not auto-open anything when the highlighted id matches no execution', async () => {
+    render(<DeviceScriptHistory deviceId={DEVICE_ID} highlightExecutionId="exec-does-not-exist" />);
+
+    await screen.findByText('Collect Inventory');
+    expect(screen.queryByText('Execution Details')).toBeNull();
+  });
+});

--- a/apps/web/src/components/devices/DeviceScriptHistory.tsx
+++ b/apps/web/src/components/devices/DeviceScriptHistory.tsx
@@ -1,9 +1,15 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Terminal, RefreshCw, Eye, X, ChevronDown, ChevronUp, Copy, Check, CheckCircle, XCircle, Loader2, AlertTriangle, Clock, AlertOctagon } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Terminal, RefreshCw, Eye, X, ChevronDown, ChevronUp, Copy, Check, CheckCircle, XCircle, Loader2, AlertTriangle, Clock, AlertOctagon, RotateCcw } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
 import { formatDateTime as formatUserDateTime } from '@/lib/dateTimeFormat';
 import { fetchWithAuth } from '../../stores/auth';
+import { extractApiError } from '@/lib/apiError';
+import { showToast } from '../shared/Toast';
+import ScriptExecutionModal from '../scripts/ScriptExecutionModal';
+import type { Script } from '../scripts/ScriptList';
+import type { ScriptParameter } from '../scripts/ScriptForm';
+import type { ScriptAdmissionResult } from '@breeze/shared';
 
 type ScriptExecution = {
   id?: string;
@@ -20,11 +26,24 @@ type ScriptExecution = {
   createdAt?: string;
   durationMs?: number;
   durationSeconds?: number;
+  // #4885 — the runtime values this execution was submitted with. See the
+  // same field on ExecutionHistory's ScriptExecution; the API's SELECT was
+  // extended for this device-scoped endpoint alongside this change.
+  parameters?: Record<string, string | number | boolean> | null;
+};
+
+type ScriptWithDetails = Script & {
+  parameters?: ScriptParameter[];
+  content?: string;
 };
 
 type DeviceScriptHistoryProps = {
   deviceId: string;
   timezone?: string;
+  // #4886 — highlight (and auto-open) the execution a post-run redirect sent
+  // the operator here to watch. Comes from the `#scripts/<executionId>` hash
+  // (DeviceDetails.tsx); undefined for an ordinary tab visit.
+  highlightExecutionId?: string;
 };
 
 const statusStyles: Record<string, string> = {
@@ -197,14 +216,26 @@ function OutputSection({
   );
 }
 
-export default function DeviceScriptHistory({ deviceId, timezone }: DeviceScriptHistoryProps) {
+export default function DeviceScriptHistory({ deviceId, timezone, highlightExecutionId }: DeviceScriptHistoryProps) {
   const { t } = useTranslation('devices');
+  const { t: tScripts } = useTranslation('scripts');
   const [executions, setExecutions] = useState<ScriptExecution[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string>();
   const [siteTimezone, setSiteTimezone] = useState<string | undefined>(timezone);
   const [selectedExecution, setSelectedExecution] = useState<ScriptExecution | null>(null);
+  // #4885 "Run again" — the fetched script definition (parameters, OS types,
+  // runAs) needed to open ScriptExecutionModal, plus the loading/error state
+  // for that fetch. Cleared on close so a stale script never lingers across
+  // two different "Run again" clicks.
+  const [runAgainScript, setRunAgainScript] = useState<ScriptWithDetails | null>(null);
+  const [runAgainParameters, setRunAgainParameters] = useState<Record<string, string | number | boolean>>({});
+  const [runAgainLoading, setRunAgainLoading] = useState(false);
+  // #4886 — only auto-open the highlighted execution once per id, so closing
+  // it (or a routine 10s poll refresh) doesn't keep re-opening it in the
+  // operator's face.
+  const autoOpenedHighlightRef = useRef<string | undefined>(undefined);
 
   const effectiveTimezone = timezone ?? siteTimezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
 
@@ -248,6 +279,74 @@ export default function DeviceScriptHistory({ deviceId, timezone }: DeviceScript
       };
     });
   }, [executions, effectiveTimezone]);
+
+  // #4886 — once the highlighted execution shows up in the fetched list, open
+  // its details automatically so a post-run redirect actually lands the
+  // operator watching the result, not just staring at a list.
+  useEffect(() => {
+    if (!highlightExecutionId) {
+      autoOpenedHighlightRef.current = undefined;
+      return;
+    }
+    if (autoOpenedHighlightRef.current === highlightExecutionId) return;
+    const match = executions.find(item => item.id === highlightExecutionId);
+    if (!match) return;
+    autoOpenedHighlightRef.current = highlightExecutionId;
+    setSelectedExecution(match);
+  }, [highlightExecutionId, executions]);
+
+  // #4885 "Run again" — fetch the script's current parameter definitions
+  // (osTypes/runAs/parameters) so ScriptExecutionModal has what it needs, then
+  // open it pre-filled with this device and the execution's runtime values.
+  const handleRunAgain = async (execution: ScriptExecution) => {
+    if (!execution.scriptId) return;
+    setSelectedExecution(null);
+    setRunAgainLoading(true);
+    try {
+      const response = await fetchWithAuth(`/scripts/${execution.scriptId}`);
+      if (!response.ok) {
+        throw new Error(tScripts('scriptExecutionsPage.errors.fetchScript'));
+      }
+      const data = await response.json();
+      setRunAgainScript(data.script ?? data);
+      setRunAgainParameters(execution.parameters ?? {});
+    } catch (err) {
+      showToast({
+        type: 'error',
+        message: err instanceof Error ? err.message : tScripts('scriptExecutionsPage.errors.fetchScript'),
+      });
+    } finally {
+      setRunAgainLoading(false);
+    }
+  };
+
+  const handleCloseRunAgain = () => {
+    setRunAgainScript(null);
+    setRunAgainParameters({});
+  };
+
+  const handleExecuteRunAgain = async (
+    scriptId: string,
+    deviceIds: string[],
+    parameters: Record<string, string | number | boolean>,
+    runAs: 'system' | 'user'
+  ): Promise<ScriptAdmissionResult> => {
+    const response = await fetchWithAuth(`/scripts/${scriptId}/execute`, {
+      method: 'POST',
+      body: JSON.stringify({ deviceIds, parameters, runAs })
+    });
+
+    const data = await response.json().catch(() => ({})) as ScriptAdmissionResult & { error?: string };
+
+    if (!response.ok) {
+      throw new Error(extractApiError(data, tScripts('scriptExecutionsPage.errors.execute')));
+    }
+
+    if (data.targets.some(target => target.admission === 'admitted')) {
+      await fetchHistory(true);
+    }
+    return data;
+  };
 
   if (loading) {
     return (
@@ -322,7 +421,13 @@ export default function DeviceScriptHistory({ deviceId, timezone }: DeviceScript
                 rows.map(row => (
                   <tr
                     key={row.id}
-                    className="text-sm cursor-pointer hover:bg-muted/40 transition"
+                    className={cn(
+                      'text-sm cursor-pointer hover:bg-muted/40 transition',
+                      // #4886 — the row a post-run redirect sent the operator
+                      // here to watch, so it's findable even after they close
+                      // the auto-opened details modal.
+                      row.id === highlightExecutionId && 'bg-primary/5 ring-1 ring-inset ring-primary/40'
+                    )}
                     onClick={() => setSelectedExecution(row.raw)}
                   >
                     <td className="px-4 py-3 font-medium">{row.name}</td>
@@ -458,7 +563,23 @@ export default function DeviceScriptHistory({ deviceId, timezone }: DeviceScript
             </div>
 
             {/* Footer */}
-            <div className="flex items-center justify-end border-t px-6 py-4">
+            <div className="flex items-center justify-end gap-3 border-t px-6 py-4">
+              {selectedExecution.scriptId && (
+                <button
+                  type="button"
+                  data-testid="device-script-run-again"
+                  disabled={runAgainLoading}
+                  onClick={() => void handleRunAgain(selectedExecution)}
+                  className="inline-flex h-10 items-center gap-1.5 rounded-md border px-4 text-sm font-medium transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {runAgainLoading ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <RotateCcw className="h-4 w-4" />
+                  )}
+                  {t('deviceScriptHistory.runAgain')}
+                </button>
+              )}
               <button
                 type="button"
                 onClick={() => setSelectedExecution(null)}
@@ -471,6 +592,18 @@ export default function DeviceScriptHistory({ deviceId, timezone }: DeviceScript
         </div>
         );
       })()}
+
+      {/* #4885 "Run again" — pre-filled execute flow */}
+      {runAgainScript && (
+        <ScriptExecutionModal
+          script={runAgainScript}
+          isOpen
+          onClose={handleCloseRunAgain}
+          onExecute={handleExecuteRunAgain}
+          initialDeviceIds={[deviceId]}
+          initialParameters={runAgainParameters}
+        />
+      )}
     </>
   );
 }

--- a/apps/web/src/components/scripts/ExecutionDetails.test.tsx
+++ b/apps/web/src/components/scripts/ExecutionDetails.test.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
 import ExecutionDetails from './ExecutionDetails';
 import type { ScriptExecution } from './ExecutionHistory';
 
@@ -19,12 +20,16 @@ function baseExecution(overrides: Partial<ScriptExecution> = {}): ScriptExecutio
   };
 }
 
-function renderExecution(overrides: Partial<ScriptExecution> = {}) {
+function renderExecution(
+  overrides: Partial<ScriptExecution> = {},
+  extraProps: Partial<ComponentProps<typeof ExecutionDetails>> = {}
+) {
   return render(
     <ExecutionDetails
       execution={baseExecution(overrides)}
       isOpen={true}
       onClose={() => {}}
+      {...extraProps}
     />
   );
 }
@@ -89,5 +94,29 @@ describe('ExecutionDetails custom-field write summary', () => {
 
     expect(screen.getByTestId('exec-custom-fields-applied')).toHaveTextContent('ram_slot_type');
     expect(screen.queryByTestId('exec-custom-fields-rejected')).not.toBeInTheDocument();
+  });
+});
+
+describe('ExecutionDetails "Run again" (#4885)', () => {
+  it('does not render a Run again button when no handler is supplied', () => {
+    renderExecution();
+
+    expect(screen.queryByTestId('execution-run-again')).not.toBeInTheDocument();
+  });
+
+  it('invokes onRunAgain with the full execution record when clicked', () => {
+    const onRunAgain = vi.fn();
+    const execution = baseExecution({ parameters: { target: 'C:\\Temp' } });
+    renderExecution({ parameters: { target: 'C:\\Temp' } }, { onRunAgain });
+
+    fireEvent.click(screen.getByTestId('execution-run-again'));
+
+    expect(onRunAgain).toHaveBeenCalledTimes(1);
+    expect(onRunAgain).toHaveBeenCalledWith(expect.objectContaining({
+      id: execution.id,
+      scriptId: execution.scriptId,
+      deviceId: execution.deviceId,
+      parameters: { target: 'C:\\Temp' },
+    }));
   });
 });

--- a/apps/web/src/components/scripts/ExecutionDetails.tsx
+++ b/apps/web/src/components/scripts/ExecutionDetails.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { X, ChevronDown, ChevronUp, Copy, Check, Loader2, Terminal, AlertOctagon, ListChecks } from 'lucide-react';
+import { X, ChevronDown, ChevronUp, Copy, Check, Loader2, Terminal, AlertOctagon, ListChecks, RotateCcw } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { formatDateTime as formatUserDateTime } from '@/lib/dateTimeFormat';
 import type { ScriptExecution, ScriptCustomFieldWriteResult } from './ExecutionHistory';
@@ -11,6 +11,10 @@ type ExecutionDetailsProps = {
   isOpen: boolean;
   onClose: () => void;
   timezone?: string;
+  // #4885 — "Run again": re-open the execute flow pre-filled with this
+  // execution's device + parameters. Omitted entirely (no button rendered)
+  // where the host page has nowhere to send it.
+  onRunAgain?: (execution: ScriptExecution) => void;
 };
 
 function formatDuration(seconds?: number): string {
@@ -238,7 +242,8 @@ export default function ExecutionDetails({
   execution,
   isOpen,
   onClose,
-  timezone
+  timezone,
+  onRunAgain
 }: ExecutionDetailsProps) {
   const { t } = useTranslation('scripts');
   if (!isOpen) return null;
@@ -363,7 +368,18 @@ export default function ExecutionDetails({
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-end border-t px-6 py-4">
+        <div className="flex items-center justify-end gap-3 border-t px-6 py-4">
+          {onRunAgain && (
+            <button
+              type="button"
+              data-testid="execution-run-again"
+              onClick={() => onRunAgain(execution)}
+              className="inline-flex h-10 items-center gap-1.5 rounded-md border px-4 text-sm font-medium transition hover:bg-muted"
+            >
+              <RotateCcw className="h-4 w-4" />
+              {t('executionDetails.actions.runAgain')}
+            </button>
+          )}
           <button
             type="button"
             onClick={onClose}

--- a/apps/web/src/components/scripts/ExecutionHistory.tsx
+++ b/apps/web/src/components/scripts/ExecutionHistory.tsx
@@ -37,6 +37,11 @@ export type ScriptExecution = {
   // marker. Only present once the execution-detail endpoint has been fetched
   // (the list endpoint omits it, same as stdout/stderr).
   customFieldResult?: ScriptCustomFieldWriteResult | null;
+  // #4885 — the runtime values this execution was submitted with. Both
+  // GET /scripts/:id/executions and GET /scripts/executions/:id already
+  // return `script_executions.parameters` on the wire; this was simply never
+  // declared on the type any consumer read through. Powers "Run again".
+  parameters?: Record<string, string | number | boolean> | null;
 };
 
 type ExecutionHistoryProps = {

--- a/apps/web/src/components/scripts/ScriptExecutionModal.test.tsx
+++ b/apps/web/src/components/scripts/ScriptExecutionModal.test.tsx
@@ -523,3 +523,97 @@ describe('ScriptExecutionModal empty state on the server options path', () => {
     expect(probeUrl).toContain('osType=windows');
   });
 });
+
+// #4885 — "Run again": the modal accepts the previous execution's device and
+// parameter values so the operator doesn't re-pick either from scratch.
+describe('ScriptExecutionModal initial values (#4885 Run again)', () => {
+  const twoDevices: Device[] = [
+    { id: 'd-1', hostname: 'ws-01', os: 'windows', status: 'online', siteId: 's-1', siteName: 'HQ' },
+    { id: 'd-2', hostname: 'ws-02', os: 'windows', status: 'online', siteId: 's-1', siteName: 'HQ' },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('pre-selects the device from initialDeviceIds without the operator touching the picker', async () => {
+    const onExecute = vi.fn().mockResolvedValue(admittedResult);
+    render(
+      <ScriptExecutionModal
+        script={{ ...baseScript, parameters: [] }}
+        devices={twoDevices}
+        initialDeviceIds={['d-2']}
+        isOpen
+        onClose={vi.fn()}
+        onExecute={onExecute}
+      />
+    );
+
+    // Seeded before any click — proves the selection came from the prop, not
+    // from the operator checking a box.
+    expect(screen.getByText('1 device(s) selected')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Execute'));
+    fireEvent.click(await screen.findByText('Confirm Execute'));
+
+    await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(1));
+    // The exact target must be the pre-filled device, not merely "some device"
+    // — ws-01 (d-1) is also on screen and must NOT have been picked instead.
+    expect(onExecute).toHaveBeenCalledWith('sc-1', ['d-2'], {}, 'system');
+  });
+
+  it('pre-fills runtime parameter values from initialParameters, overriding the definition default', async () => {
+    const onExecute = vi.fn().mockResolvedValue(admittedResult);
+    render(
+      <ScriptExecutionModal
+        script={{
+          ...baseScript,
+          parameters: [{ name: 'message', type: 'string', defaultValue: 'hello' }],
+        }}
+        devices={twoDevices}
+        initialDeviceIds={['d-1']}
+        initialParameters={{ message: 'previous run value' }}
+        isOpen
+        onClose={vi.fn()}
+        onExecute={onExecute}
+      />
+    );
+
+    // The stored run value wins over the script's own definition default.
+    expect(screen.getByDisplayValue('previous run value')).toBeInTheDocument();
+    expect(screen.queryByDisplayValue('hello')).toBeNull();
+
+    fireEvent.click(screen.getByText('Execute'));
+    fireEvent.click(await screen.findByText('Confirm Execute'));
+
+    await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(1));
+    expect(onExecute).toHaveBeenCalledWith('sc-1', ['d-1'], { message: 'previous run value' }, 'system');
+  });
+
+  it('ignores an initialParameters key the current script definition no longer has', async () => {
+    const onExecute = vi.fn().mockResolvedValue(admittedResult);
+    render(
+      <ScriptExecutionModal
+        script={{
+          ...baseScript,
+          parameters: [{ name: 'message', type: 'string' }],
+        }}
+        devices={twoDevices}
+        initialDeviceIds={['d-1']}
+        initialParameters={{ message: 'kept', removedParam: 'stale-value' }}
+        isOpen
+        onClose={vi.fn()}
+        onExecute={onExecute}
+      />
+    );
+
+    expect(screen.getByDisplayValue('kept')).toBeInTheDocument();
+    expect(screen.queryByDisplayValue('stale-value')).toBeNull();
+
+    fireEvent.click(screen.getByText('Execute'));
+    fireEvent.click(await screen.findByText('Confirm Execute'));
+
+    await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(1));
+    expect(onExecute).toHaveBeenCalledWith('sc-1', ['d-1'], { message: 'kept' }, 'system');
+  });
+});

--- a/apps/web/src/components/scripts/ScriptExecutionModal.tsx
+++ b/apps/web/src/components/scripts/ScriptExecutionModal.tsx
@@ -39,6 +39,12 @@ type ScriptExecutionModalProps = {
     parameters: Record<string, string | number | boolean>,
     runAs: 'system' | 'user'
   ) => Promise<ScriptAdmissionResult>;
+  // #4885 "Run again" — pre-fill the picker/form from a past execution instead
+  // of opening blank. Both are read once at mount (the modal is remounted
+  // fresh on every open by every caller today), so a parent re-render with a
+  // new object identity does not fight the operator's in-progress edits.
+  initialDeviceIds?: string[];
+  initialParameters?: Record<string, string | number | boolean>;
 };
 
 type ExecutionState = 'idle' | 'submitting' | 'admitted' | 'partially_admitted' | 'rejected' | 'transport_error';
@@ -49,13 +55,17 @@ export default function ScriptExecutionModal({
   sites = [],
   isOpen,
   onClose,
-  onExecute
+  onExecute,
+  initialDeviceIds,
+  initialParameters
 }: ScriptExecutionModalProps) {
   const { t } = useTranslation('scripts');
   const [query, setQuery] = useState('');
   const [siteFilter, setSiteFilter] = useState<string>('all');
   const [statusFilter, setStatusFilter] = useState<string>('online');
-  const [selectedDeviceIds, setSelectedDeviceIds] = useState<Set<string>>(new Set());
+  const [selectedDeviceIds, setSelectedDeviceIds] = useState<Set<string>>(
+    () => new Set(initialDeviceIds ?? [])
+  );
   const [parameters, setParameters] = useState<Record<string, string | number | boolean>>({});
   const [runAs, setRunAs] = useState<'system' | 'user'>('system');
   const [executionState, setExecutionState] = useState<ExecutionState>('idle');
@@ -201,11 +211,20 @@ export default function ScriptExecutionModal({
   // a bound parameter is resolved per target device by the server, so it is
   // neither prompted for nor seeded — a value supplied for one is ignored and
   // reported in `ignoredParameters`.
+  //
+  // #4885 "Run again": `initialParameters` (the previous execution's runtime
+  // values) wins over the definition's own default when both are present for
+  // the same name. A key in `initialParameters` that no longer matches a
+  // runtime parameter (the script was edited since that run) is silently
+  // dropped rather than smuggled into the submitted payload.
   useEffect(() => {
     if (script.parameters) {
       const defaults: Record<string, string | number | boolean> = {};
       runtimeParameters(script.parameters).forEach(param => {
-        if (param.defaultValue !== undefined) {
+        const carriedOver = initialParameters?.[param.name];
+        if (carriedOver !== undefined) {
+          defaults[param.name] = carriedOver;
+        } else if (param.defaultValue !== undefined) {
           if (param.type === 'number') {
             defaults[param.name] = Number(param.defaultValue) || 0;
           } else if (param.type === 'boolean') {
@@ -219,6 +238,9 @@ export default function ScriptExecutionModal({
       });
       setParameters(defaults);
     }
+    // `initialParameters` is deliberately NOT a dep — it is read once at mount
+    // (see the prop doc comment) so a parent re-render never resets an
+    // in-progress edit. Only a script.parameters change re-derives defaults.
   }, [script.parameters]);
 
   useEffect(() => {

--- a/apps/web/src/components/scripts/ScriptExecutionsPage.test.tsx
+++ b/apps/web/src/components/scripts/ScriptExecutionsPage.test.tsx
@@ -10,14 +10,23 @@ vi.mock('../../stores/auth', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../stores/auth')>();
   return { ...actual, fetchWithAuth: fetchWithAuthMock };
 });
+
+type MockExecuteModalProps = {
+  onExecute: (scriptId: string, deviceIds: string[], parameters: Record<string, string | number | boolean>, runAs: 'system' | 'user') => Promise<ScriptAdmissionResult>;
+  script: { id: string };
+  initialDeviceIds?: string[];
+  initialParameters?: Record<string, string | number | boolean>;
+};
+
 vi.mock('./ScriptExecutionModal', () => ({
-  default: ({ onExecute, script }: {
-    onExecute: (scriptId: string, deviceIds: string[], parameters: Record<string, string | number | boolean>, runAs: 'system' | 'user') => Promise<ScriptAdmissionResult>;
-    script: { id: string };
-  }) => (
-    <button type="button" onClick={() => void onExecute(script.id, ['device-1'], {}, 'system')}>
-      Confirm Execute
-    </button>
+  default: ({ onExecute, script, initialDeviceIds, initialParameters }: MockExecuteModalProps) => (
+    <div>
+      <div data-testid="mock-initial-device-ids">{JSON.stringify(initialDeviceIds ?? null)}</div>
+      <div data-testid="mock-initial-parameters">{JSON.stringify(initialParameters ?? null)}</div>
+      <button type="button" onClick={() => void onExecute(script.id, ['device-1'], {}, 'system')}>
+        Confirm Execute
+      </button>
+    </div>
   ),
 }));
 
@@ -169,6 +178,34 @@ describe('ScriptExecutionsPage', () => {
     fireEvent.click(await screen.findByText('Confirm Execute'));
 
     await waitFor(() => expect(executionListCalls).toBeGreaterThanOrEqual(2));
+  });
+
+  // #4885 — "Run again" from the execution-details modal.
+  it('opens the execute modal pre-filled with the clicked execution\'s device and parameters', async () => {
+    mockApi(() =>
+      jsonResponse({
+        ...listRow,
+        stdout: 'FULL STDOUT FROM DETAIL',
+        stderr: '',
+        parameters: { target: 'C:\\Temp', force: true },
+      })
+    );
+
+    await openDetails();
+    await screen.findByText('FULL STDOUT FROM DETAIL');
+
+    fireEvent.click(screen.getByTestId('execution-run-again'));
+
+    // The details view is gone (replaced by the execute flow), and the
+    // execute modal received exactly this execution's device + parameters —
+    // not an empty/blank form.
+    expect(screen.queryByText('Execution Details')).toBeNull();
+    expect(await screen.findByTestId('mock-initial-device-ids')).toHaveTextContent(
+      JSON.stringify([listRow.deviceId])
+    );
+    expect(screen.getByTestId('mock-initial-parameters')).toHaveTextContent(
+      JSON.stringify({ target: 'C:\\Temp', force: true })
+    );
   });
 
   it('does not refresh executions for a typed all-target rejection', async () => {

--- a/apps/web/src/components/scripts/ScriptExecutionsPage.tsx
+++ b/apps/web/src/components/scripts/ScriptExecutionsPage.tsx
@@ -35,6 +35,14 @@ export default function ScriptExecutionsPage({ scriptId }: ScriptExecutionsPageP
   const [error, setError] = useState<string>();
   const [selectedExecution, setSelectedExecution] = useState<ScriptExecution | null>(null);
   const [showExecuteModal, setShowExecuteModal] = useState(false);
+  // #4885 "Run again" — carries the clicked execution's device + parameters
+  // into the next open of the execute modal. Cleared on close so a later
+  // "Run Script" from the toolbar (not tied to any past execution) opens
+  // blank again.
+  const [runAgainSeed, setRunAgainSeed] = useState<{
+    deviceIds: string[];
+    parameters: Record<string, string | number | boolean>;
+  } | null>(null);
 
   const fetchScript = useCallback(async () => {
     try {
@@ -115,6 +123,23 @@ export default function ScriptExecutionsPage({ scriptId }: ScriptExecutionsPageP
 
   const handleCloseDetails = () => {
     setSelectedExecution(null);
+  };
+
+  // #4885 — re-open the execute flow pre-filled with this execution's device
+  // and the runtime parameters it was submitted with, instead of the operator
+  // re-picking both from scratch.
+  const handleRunAgain = (execution: ScriptExecution) => {
+    setSelectedExecution(null);
+    setRunAgainSeed({
+      deviceIds: [execution.deviceId],
+      parameters: execution.parameters ?? {}
+    });
+    setShowExecuteModal(true);
+  };
+
+  const handleCloseExecuteModal = () => {
+    setShowExecuteModal(false);
+    setRunAgainSeed(null);
   };
 
   const handleExecute = async (
@@ -206,7 +231,7 @@ export default function ScriptExecutionsPage({ scriptId }: ScriptExecutionsPageP
         {script && (
           <button
             type="button"
-            onClick={() => setShowExecuteModal(true)}
+            onClick={() => { setRunAgainSeed(null); setShowExecuteModal(true); }}
             className="inline-flex h-10 items-center justify-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:bg-primary/90"
           >
             <Play className="h-4 w-4" />
@@ -259,6 +284,7 @@ export default function ScriptExecutionsPage({ scriptId }: ScriptExecutionsPageP
           execution={selectedExecution}
           isOpen={true}
           onClose={handleCloseDetails}
+          onRunAgain={handleRunAgain}
         />
       )}
 
@@ -268,8 +294,10 @@ export default function ScriptExecutionsPage({ scriptId }: ScriptExecutionsPageP
           script={script}
           sites={sites}
           isOpen={true}
-          onClose={() => setShowExecuteModal(false)}
+          onClose={handleCloseExecuteModal}
           onExecute={handleExecute}
+          initialDeviceIds={runAgainSeed?.deviceIds}
+          initialParameters={runAgainSeed?.parameters}
         />
       )}
     </div>

--- a/apps/web/src/components/scripts/ScriptTestRunner.test.tsx
+++ b/apps/web/src/components/scripts/ScriptTestRunner.test.tsx
@@ -618,3 +618,73 @@ describe('ScriptTestRunner', () => {
     expect(onTestDeviceChange).not.toHaveBeenCalledWith(null);
   });
 });
+
+// #4885/#4886 — once a test run completes, offer an explicit "Run again" next
+// to the result and a link straight to where the full record lives.
+describe('ScriptTestRunner post-run actions (#4885 / #4886)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  async function runToCompletion(execute: () => void) {
+    fetchWithAuthMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url.startsWith('/devices')) return jsonResponse({ data: [onlineDevice] });
+      if (url === `/scripts/${SCRIPT_ID}/execute` && init?.method === 'POST') {
+        execute();
+        return jsonResponse({
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+          status: 'queued',
+          targets: [{ requestedDeviceId: DEVICE_ID, admission: 'admitted', executionId: EXECUTION_ID }],
+        }, 201);
+      }
+      if (url === `/scripts/executions/${EXECUTION_ID}`) {
+        return jsonResponse({
+          id: EXECUTION_ID,
+          status: 'completed',
+          exitCode: 0,
+          stdout: 'hello from test-box',
+          stderr: '',
+        });
+      }
+      return jsonResponse({}, 404);
+    });
+
+    render(
+      <ScriptTestRunner scriptId={SCRIPT_ID} osTypes={['windows']} isDirty={false} onSaveChanges={async () => true} />
+    );
+
+    await waitFor(() => expect(screen.getByText('test-box')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('test-device-select'), { target: { value: DEVICE_ID } });
+    fireEvent.click(screen.getByTestId('test-run-button'));
+    await waitFor(() => expect(screen.getByText('hello from test-box')).toBeInTheDocument(), { timeout: 5000 });
+  }
+
+  it('offers a "Run again" action next to a completed run\'s output, which starts a new execution', async () => {
+    let executeCalls = 0;
+    await runToCompletion(() => { executeCalls += 1; });
+    expect(executeCalls).toBe(1);
+
+    fireEvent.click(screen.getByTestId('test-run-again'));
+
+    await waitFor(() => expect(executeCalls).toBe(2));
+  }, 10000);
+
+  it('links straight to the device\'s Scripts tab for the execution once it has run', async () => {
+    await runToCompletion(() => {});
+
+    const link = screen.getByTestId('test-view-on-device') as HTMLAnchorElement;
+    expect(link).toHaveAttribute('href', `/devices/${DEVICE_ID}#scripts/${EXECUTION_ID}`);
+  }, 10000);
+
+  it('does not render the device link before any run has started', () => {
+    render(
+      <ScriptTestRunner scriptId={SCRIPT_ID} osTypes={['windows']} isDirty={false} onSaveChanges={async () => true} />
+    );
+
+    expect(screen.queryByTestId('test-view-on-device')).toBeNull();
+  });
+});

--- a/apps/web/src/components/scripts/ScriptTestRunner.tsx
+++ b/apps/web/src/components/scripts/ScriptTestRunner.tsx
@@ -466,10 +466,27 @@ export default function ScriptTestRunner({
             {t('testRunner.exitCode', { code: execution.exitCode })}
           </span>
         )}
+        {/* #4886 — once this run has an execution id, link straight to it on
+            the device's own Scripts tab (same hash convention as the
+            post-run redirects elsewhere) rather than only the script-wide
+            history list. */}
+        {execution?.id && selectedDeviceId && (
+          <a
+            href={`/devices/${selectedDeviceId}#scripts/${execution.id}`}
+            data-testid="test-view-on-device"
+            className="ml-auto inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+          >
+            {t('testRunner.viewOnDevice')}
+            <ExternalLink className="h-3 w-3" />
+          </a>
+        )}
         {scriptId && (
           <a
             href={`/scripts/${scriptId}/executions`}
-            className="ml-auto inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+            className={cn(
+              'inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground',
+              !(execution?.id && selectedDeviceId) && 'ml-auto'
+            )}
           >
             {t('testRunner.viewHistory')}
             <ExternalLink className="h-3 w-3" />
@@ -512,9 +529,24 @@ export default function ScriptTestRunner({
 
       {execution && !running && TERMINAL_STATUSES.includes(execution.status) && (
         <div className="space-y-3 border-t p-3">
-          {execution.errorMessage && (
-            <p className="text-sm text-destructive">{execution.errorMessage}</p>
-          )}
+          <div className="flex items-center justify-between gap-2">
+            {execution.errorMessage ? (
+              <p className="text-sm text-destructive">{execution.errorMessage}</p>
+            ) : <span />}
+            {/* #4885 — an explicit action beside the result, rather than
+                relying on the operator noticing the header's Run button is
+                enabled again. */}
+            <button
+              type="button"
+              onClick={handleRun}
+              disabled={busy || !selectedDeviceId || missingRequiredParams.length > 0}
+              data-testid="test-run-again"
+              className="inline-flex shrink-0 items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-medium transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              <RefreshCw className="h-3 w-3" />
+              {t('testRunner.runAgain')}
+            </button>
+          </div>
           <OutputSection
             title={t('executionDetails.output.stdout')}
             content={execution.stdout ?? undefined}

--- a/apps/web/src/components/scripts/ScriptTestRunner.tsx
+++ b/apps/web/src/components/scripts/ScriptTestRunner.tsx
@@ -6,6 +6,7 @@ import { fetchWithAuth } from '../../stores/auth';
 import { runAction, ActionError } from '@/lib/runAction';
 import { navigateTo } from '@/lib/navigation';
 import { asList } from '@/lib/asList';
+import { deviceScriptsHref } from '@/lib/deviceScriptsLink';
 import { OutputSection } from './ExecutionDetails';
 import type { OSType } from './ScriptList';
 import { runtimeParameters, type ScriptParameter } from './ScriptFormSchema';
@@ -472,7 +473,7 @@ export default function ScriptTestRunner({
             history list. */}
         {execution?.id && selectedDeviceId && (
           <a
-            href={`/devices/${selectedDeviceId}#scripts/${execution.id}`}
+            href={deviceScriptsHref(selectedDeviceId, execution.id)}
             data-testid="test-view-on-device"
             className="ml-auto inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
           >

--- a/apps/web/src/components/scripts/ScriptsPage.test.tsx
+++ b/apps/web/src/components/scripts/ScriptsPage.test.tsx
@@ -42,18 +42,28 @@ vi.mock('./ScriptExecutionModal', () => ({
     script: { id: string };
   }) =>
     isOpen ? (
-      <button
-        type="button"
-        onClick={() => void onExecute(script.id, ['device-1'], {}, 'system')}
-      >
-        Confirm Execute
-      </button>
+      <>
+        <button
+          type="button"
+          onClick={() => void onExecute(script.id, ['device-1'], {}, 'system')}
+        >
+          Confirm Execute
+        </button>
+        <button
+          type="button"
+          onClick={() => void onExecute(script.id, ['device-1', 'device-2'], {}, 'system')}
+        >
+          Confirm Execute Multi
+        </button>
+      </>
     ) : null
 }));
 
 vi.mock('./ExecutionDetails', () => ({
   default: () => null
 }));
+
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
 
 const fetchWithAuthMock = vi.mocked(fetchWithAuth);
 
@@ -153,5 +163,92 @@ describe('ScriptsPage admission refresh', () => {
 
     await waitFor(() => expect(fetchWithAuthMock.mock.calls.some(([url]) => String(url) === '/scripts/script-1/execute')).toBe(true));
     expect(scriptsFetchCount).toBe(1);
+  });
+});
+
+// #4886 — running a script from the library must land the operator where the
+// result appears, instead of leaving them on the (now stale) scripts list.
+describe('ScriptsPage post-run navigation (#4886)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('navigates to the device Scripts tab, highlighting the new execution, for a single-device run', async () => {
+    const { navigateTo } = await import('@/lib/navigation');
+    fetchWithAuthMock.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.startsWith('/scripts?')) return makeJsonResponse({ data: [baseScript] });
+      if (url === '/orgs/sites') return makeJsonResponse({ data: [] });
+      if (url === '/scripts/script-1') return makeJsonResponse(baseScript);
+      if (url === '/scripts/script-1/execute') {
+        return makeJsonResponse({
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+          status: 'queued',
+          targets: [{ requestedDeviceId: 'device-1', admission: 'admitted', executionId: 'execution-1' }],
+        }, true, 201);
+      }
+      return makeJsonResponse({}, false, 404);
+    });
+
+    render(<ScriptsPage />);
+    await screen.findByText('Run Cleanup Temp Files');
+    fireEvent.click(screen.getByText('Run Cleanup Temp Files'));
+    fireEvent.click(await screen.findByText('Confirm Execute'));
+
+    await waitFor(() => expect(navigateTo).toHaveBeenCalledWith('/devices/device-1#scripts/execution-1'));
+  });
+
+  it('navigates to the script execution-history page for a multi-device run', async () => {
+    const { navigateTo } = await import('@/lib/navigation');
+    fetchWithAuthMock.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.startsWith('/scripts?')) return makeJsonResponse({ data: [baseScript] });
+      if (url === '/orgs/sites') return makeJsonResponse({ data: [] });
+      if (url === '/scripts/script-1') return makeJsonResponse(baseScript);
+      if (url === '/scripts/script-1/execute') {
+        return makeJsonResponse({
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+          status: 'queued',
+          targets: [
+            { requestedDeviceId: 'device-1', admission: 'admitted', executionId: 'execution-1' },
+            { requestedDeviceId: 'device-2', admission: 'admitted', executionId: 'execution-2' },
+          ],
+        }, true, 201);
+      }
+      return makeJsonResponse({}, false, 404);
+    });
+
+    render(<ScriptsPage />);
+    await screen.findByText('Run Cleanup Temp Files');
+    fireEvent.click(screen.getByText('Run Cleanup Temp Files'));
+    fireEvent.click(await screen.findByText('Confirm Execute Multi'));
+
+    await waitFor(() => expect(navigateTo).toHaveBeenCalledWith('/scripts/script-1/executions'));
+  });
+
+  it('does not navigate when every target was rejected', async () => {
+    const { navigateTo } = await import('@/lib/navigation');
+    fetchWithAuthMock.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.startsWith('/scripts?')) return makeJsonResponse({ data: [baseScript] });
+      if (url === '/orgs/sites') return makeJsonResponse({ data: [] });
+      if (url === '/scripts/script-1') return makeJsonResponse(baseScript);
+      if (url === '/scripts/script-1/execute') {
+        return makeJsonResponse({
+          requestId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+          status: 'rejected',
+          targets: [{ requestedDeviceId: 'device-1', admission: 'suppressed', reasonCode: 'maintenance_suppressed' }],
+        }, true, 201);
+      }
+      return makeJsonResponse({}, false, 404);
+    });
+
+    render(<ScriptsPage />);
+    await screen.findByText('Run Cleanup Temp Files');
+    fireEvent.click(screen.getByText('Run Cleanup Temp Files'));
+    fireEvent.click(await screen.findByText('Confirm Execute'));
+
+    await waitFor(() => expect(fetchWithAuthMock.mock.calls.some(([url]) => String(url) === '/scripts/script-1/execute')).toBe(true));
+    expect(navigateTo).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/scripts/ScriptsPage.tsx
+++ b/apps/web/src/components/scripts/ScriptsPage.tsx
@@ -155,8 +155,21 @@ export default function ScriptsPage() {
       throw new Error(extractApiError(data, t('scriptsPage.errors.execute')));
     }
 
-    if (data.targets.some(target => target.admission === 'admitted')) {
+    const admittedTargets = data.targets.filter(target => target.admission === 'admitted');
+    if (admittedTargets.length > 0) {
       await fetchScripts();
+      // #4886 — a library run left the operator stranded on this (now stale)
+      // list with no way to see the result land. A single-device run goes to
+      // that device's Scripts tab (same hash-highlight convention DeviceDetails
+      // already uses for anomalies), where the new execution is expanded live;
+      // a multi-device run has no single "the" device, so it goes to the
+      // script's execution-history list instead.
+      if (deviceIds.length === 1) {
+        const executionId = admittedTargets[0]?.executionId;
+        void navigateTo(`/devices/${deviceIds[0]}#scripts${executionId ? `/${executionId}` : ''}`);
+      } else {
+        void navigateTo(`/scripts/${scriptId}/executions`);
+      }
     }
     return data;
   };

--- a/apps/web/src/components/scripts/ScriptsPage.tsx
+++ b/apps/web/src/components/scripts/ScriptsPage.tsx
@@ -15,6 +15,7 @@ import { showToast } from '../shared/Toast';
 import { cn } from '@/lib/utils';
 import { navigateTo } from '@/lib/navigation';
 import { asList } from '@/lib/asList';
+import { deviceScriptsHref, scriptExecutionsHref } from '@/lib/deviceScriptsLink';
 import type { ScriptAdmissionResult } from '@breeze/shared';
 // Initializes the shared i18next singleton. Islands hydrate independently, so
 // an island that hydrates before whichever other island happens to pull i18n in
@@ -165,10 +166,9 @@ export default function ScriptsPage() {
       // a multi-device run has no single "the" device, so it goes to the
       // script's execution-history list instead.
       if (deviceIds.length === 1) {
-        const executionId = admittedTargets[0]?.executionId;
-        void navigateTo(`/devices/${deviceIds[0]}#scripts${executionId ? `/${executionId}` : ''}`);
+        void navigateTo(deviceScriptsHref(deviceIds[0]!, admittedTargets[0]?.executionId));
       } else {
-        void navigateTo(`/scripts/${scriptId}/executions`);
+        void navigateTo(scriptExecutionsHref(scriptId));
       }
     }
     return data;

--- a/apps/web/src/lib/deviceScriptsLink.test.ts
+++ b/apps/web/src/lib/deviceScriptsLink.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import {
+  decodeScriptExecutionId,
+  deviceScriptsHash,
+  deviceScriptsHref,
+  scriptExecutionsHref,
+} from './deviceScriptsLink';
+
+describe('deviceScriptsHref', () => {
+  it('links to the device Scripts tab with no highlight when no execution id is given', () => {
+    expect(deviceScriptsHref('device-1')).toBe('/devices/device-1#scripts');
+  });
+
+  it('links to the device Scripts tab highlighting one execution', () => {
+    expect(deviceScriptsHref('device-1', 'execution-1')).toBe('/devices/device-1#scripts/execution-1');
+  });
+
+  it('percent-encodes both segments — this is the fix for the CodeQL js/xss-through-dom finding', () => {
+    const url = deviceScriptsHref('a b/c', 'x#y');
+
+    expect(url).toBe('/devices/a%20b%2Fc#scripts/x%23y');
+    // A raw '#' or '/' from either id must never be able to reopen a new
+    // fragment or path segment.
+    expect(url.indexOf('#')).toBe(url.lastIndexOf('#'));
+  });
+});
+
+describe('deviceScriptsHash', () => {
+  it('returns the bare tab hash with no execution id', () => {
+    expect(deviceScriptsHash()).toBe('scripts');
+  });
+
+  it('returns the highlighted-execution hash, percent-encoded', () => {
+    expect(deviceScriptsHash('exec/1')).toBe('scripts/exec%2F1');
+  });
+});
+
+describe('scriptExecutionsHref', () => {
+  it('percent-encodes the script id', () => {
+    expect(scriptExecutionsHref('script one')).toBe('/scripts/script%20one/executions');
+  });
+});
+
+describe('decodeScriptExecutionId', () => {
+  it('round-trips whatever deviceScriptsHash encoded', () => {
+    const hash = deviceScriptsHash('exec/1 #2');
+    const [, ...rest] = hash.split('/');
+    expect(decodeScriptExecutionId(rest.join('/'))).toBe('exec/1 #2');
+  });
+
+  it('returns undefined for an empty or missing segment', () => {
+    expect(decodeScriptExecutionId(undefined)).toBeUndefined();
+    expect(decodeScriptExecutionId('')).toBeUndefined();
+  });
+
+  it('returns undefined instead of throwing on a malformed percent-sequence', () => {
+    expect(decodeScriptExecutionId('%')).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/deviceScriptsLink.ts
+++ b/apps/web/src/lib/deviceScriptsLink.ts
@@ -1,0 +1,47 @@
+/**
+ * The device-Scripts-tab link shape (`/devices/:id#scripts[/:executionId]`)
+ * introduced for #4885/#4886, and the script execution-history link. One
+ * chokepoint for both so the percent-encoding can't drift between call sites
+ * — CodeQL's `js/xss-through-dom` flagged the first inline template-literal
+ * `href` this PR wrote (ScriptTestRunner.tsx) because an unescaped
+ * interpolation into a URL/HTML sink is exactly its taint pattern, regardless
+ * of whether the source value can practically carry anything dangerous.
+ * `deviceId`/`executionId` are always server-issued UUIDs today, so this adds
+ * no behavior change for real values — it's correctness (a path/fragment
+ * segment should be percent-encoded on principle) and it satisfies the
+ * scanner, which does not reason about what a UUID can contain.
+ */
+
+/** Full href to a device's Scripts tab, optionally highlighting one execution. */
+export function deviceScriptsHref(deviceId: string, executionId?: string): string {
+  return `/devices/${encodeURIComponent(deviceId)}#${deviceScriptsHash(executionId)}`;
+}
+
+/**
+ * Just the `#scripts[/executionId]` fragment, for a same-page hash write
+ * (the caller is already on that device's page and knows it).
+ */
+export function deviceScriptsHash(executionId?: string): string {
+  return executionId ? `scripts/${encodeURIComponent(executionId)}` : 'scripts';
+}
+
+/** Href to a script's execution-history page. */
+export function scriptExecutionsHref(scriptId: string): string {
+  return `/scripts/${encodeURIComponent(scriptId)}/executions`;
+}
+
+/**
+ * Reverses `deviceScriptsHash`'s executionId encoding. Pass the raw
+ * `window.location.hash` segment (the part after `scripts/`, `#` and the
+ * `scripts` tab segment already stripped by the caller). Returns undefined
+ * for an unparseable/empty segment rather than throwing — a malformed or
+ * externally-edited hash must fall back to "no highlight", not crash the tab.
+ */
+export function decodeScriptExecutionId(rawSegment: string | undefined): string | undefined {
+  if (!rawSegment) return undefined;
+  try {
+    return decodeURIComponent(rawSegment);
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/web/src/locales/de-DE/devices.json
+++ b/apps/web/src/locales/de-DE/devices.json
@@ -1519,6 +1519,7 @@
     "output": "Ausgabe",
     "refreshing": "Wird aktualisiert...",
     "running": "Wird ausgeführt...",
+    "runAgain": "Erneut ausführen",
     "scriptFallback": "Skript",
     "status": {
       "cancelled": "Abgesagt",

--- a/apps/web/src/locales/de-DE/scripts.json
+++ b/apps/web/src/locales/de-DE/scripts.json
@@ -644,7 +644,8 @@
       }
     },
     "actions": {
-      "copyToClipboard": "In die Zwischenablage kopieren"
+      "copyToClipboard": "In die Zwischenablage kopieren",
+      "runAgain": "Erneut ausführen"
     },
     "title": "Ausführungsdetails",
     "statusDescription": {
@@ -1331,6 +1332,8 @@
     "offlineWarning": "Das ausgewählte Gerät ist offline — der Lauf wartet, bis es sich wieder verbindet.",
     "exitCode": "Exit {{code}}",
     "viewHistory": "Verlauf anzeigen",
+    "runAgain": "Erneut ausführen",
+    "viewOnDevice": "Auf Gerät anzeigen",
     "status": {
       "pending": "In Warteschlange",
       "running": "Läuft",

--- a/apps/web/src/locales/en/devices.json
+++ b/apps/web/src/locales/en/devices.json
@@ -1519,6 +1519,7 @@
     "output": "Output",
     "refreshing": "Refreshing...",
     "running": "Running...",
+    "runAgain": "Run again",
     "scriptFallback": "Script",
     "status": {
       "cancelled": "Cancelled",

--- a/apps/web/src/locales/en/scripts.json
+++ b/apps/web/src/locales/en/scripts.json
@@ -644,7 +644,8 @@
       }
     },
     "actions": {
-      "copyToClipboard": "Copy to clipboard"
+      "copyToClipboard": "Copy to clipboard",
+      "runAgain": "Run again"
     },
     "title": "Execution Details",
     "statusDescription": {
@@ -1331,6 +1332,8 @@
     "offlineWarning": "The selected device is offline — the run will wait until it reconnects.",
     "exitCode": "exit {{code}}",
     "viewHistory": "View history",
+    "runAgain": "Run again",
+    "viewOnDevice": "View on device",
     "status": {
       "pending": "Queued",
       "running": "Running",

--- a/apps/web/src/locales/es-419/devices.json
+++ b/apps/web/src/locales/es-419/devices.json
@@ -1519,6 +1519,7 @@
     "output": "Salida",
     "refreshing": "Actualizando...",
     "running": "En ejecución...",
+    "runAgain": "Ejecutar de nuevo",
     "scriptFallback": "Script",
     "status": {
       "cancelled": "Cancelado",

--- a/apps/web/src/locales/es-419/scripts.json
+++ b/apps/web/src/locales/es-419/scripts.json
@@ -644,7 +644,8 @@
       }
     },
     "actions": {
-      "copyToClipboard": "Copiar al portapapeles"
+      "copyToClipboard": "Copiar al portapapeles",
+      "runAgain": "Ejecutar de nuevo"
     },
     "title": "Detalles de ejecución",
     "statusDescription": {
@@ -1331,6 +1332,8 @@
     "offlineWarning": "El dispositivo seleccionado está desconectado — la ejecución esperará hasta que se reconecte.",
     "exitCode": "salida {{code}}",
     "viewHistory": "Ver historial",
+    "runAgain": "Ejecutar de nuevo",
+    "viewOnDevice": "Ver en el dispositivo",
     "status": {
       "pending": "En cola",
       "running": "En ejecución",

--- a/apps/web/src/locales/fr-CA/devices.json
+++ b/apps/web/src/locales/fr-CA/devices.json
@@ -1519,6 +1519,7 @@
     "output": "Production",
     "refreshing": "Rafraîchissant...",
     "running": "En cours…",
+    "runAgain": "Exécuter à nouveau",
     "scriptFallback": "Script",
     "status": {
       "cancelled": "Annulé",

--- a/apps/web/src/locales/fr-CA/scripts.json
+++ b/apps/web/src/locales/fr-CA/scripts.json
@@ -644,7 +644,8 @@
       }
     },
     "actions": {
-      "copyToClipboard": "Copier dans le presse-papiers"
+      "copyToClipboard": "Copier dans le presse-papiers",
+      "runAgain": "Exécuter à nouveau"
     },
     "title": "Détails d’exécution",
     "statusDescription": {
@@ -1331,6 +1332,8 @@
     "offlineWarning": "L'appareil sélectionné est hors ligne — l'exécution attendra sa reconnexion.",
     "exitCode": "sortie {{code}}",
     "viewHistory": "Voir l'historique",
+    "runAgain": "Exécuter à nouveau",
+    "viewOnDevice": "Voir sur l'appareil",
     "status": {
       "pending": "En attente",
       "running": "En cours",

--- a/apps/web/src/locales/fr-FR/devices.json
+++ b/apps/web/src/locales/fr-FR/devices.json
@@ -1519,6 +1519,7 @@
     "output": "Production",
     "refreshing": "Rafraîchissant...",
     "running": "En cours…",
+    "runAgain": "Exécuter à nouveau",
     "scriptFallback": "Script",
     "status": {
       "cancelled": "Annulé",

--- a/apps/web/src/locales/fr-FR/scripts.json
+++ b/apps/web/src/locales/fr-FR/scripts.json
@@ -644,7 +644,8 @@
       }
     },
     "actions": {
-      "copyToClipboard": "Copier dans le presse-papiers"
+      "copyToClipboard": "Copier dans le presse-papiers",
+      "runAgain": "Exécuter à nouveau"
     },
     "title": "Détails d’exécution",
     "statusDescription": {
@@ -1331,6 +1332,8 @@
     "offlineWarning": "L'appareil sélectionné est hors ligne — l'exécution attendra sa reconnexion.",
     "exitCode": "sortie {{code}}",
     "viewHistory": "Voir l'historique",
+    "runAgain": "Exécuter à nouveau",
+    "viewOnDevice": "Voir sur l'appareil",
     "status": {
       "pending": "En attente",
       "running": "En cours",

--- a/apps/web/src/locales/it-IT/devices.json
+++ b/apps/web/src/locales/it-IT/devices.json
@@ -1519,6 +1519,7 @@
     "output": "Output",
     "refreshing": "Aggiornamento...",
     "running": "In esecuzione...",
+    "runAgain": "Esegui di nuovo",
     "scriptFallback": "Script",
     "status": {
       "cancelled": "Annullato",

--- a/apps/web/src/locales/it-IT/scripts.json
+++ b/apps/web/src/locales/it-IT/scripts.json
@@ -644,7 +644,8 @@
       }
     },
     "actions": {
-      "copyToClipboard": "Copia negli appunti"
+      "copyToClipboard": "Copia negli appunti",
+      "runAgain": "Esegui di nuovo"
     },
     "title": "Dettagli esecuzione",
     "statusDescription": {
@@ -1331,6 +1332,8 @@
     "offlineWarning": "Il dispositivo selezionato è offline — l'esecuzione attenderà la riconnessione.",
     "exitCode": "codice {{code}}",
     "viewHistory": "Vedi cronologia",
+    "runAgain": "Esegui di nuovo",
+    "viewOnDevice": "Visualizza sul dispositivo",
     "status": {
       "pending": "In coda",
       "running": "In esecuzione",

--- a/apps/web/src/locales/pt-BR/devices.json
+++ b/apps/web/src/locales/pt-BR/devices.json
@@ -1519,6 +1519,7 @@
     "output": "Saída",
     "refreshing": "Atualizando...",
     "running": "Em execução...",
+    "runAgain": "Executar novamente",
     "scriptFallback": "Script",
     "status": {
       "cancelled": "Cancelado",

--- a/apps/web/src/locales/pt-BR/scripts.json
+++ b/apps/web/src/locales/pt-BR/scripts.json
@@ -644,7 +644,8 @@
       }
     },
     "actions": {
-      "copyToClipboard": "Copiar para a área de transferência"
+      "copyToClipboard": "Copiar para a área de transferência",
+      "runAgain": "Executar novamente"
     },
     "title": "Detalhes da execução",
     "statusDescription": {
@@ -1331,6 +1332,8 @@
     "offlineWarning": "O dispositivo selecionado está offline — a execução aguardará até que ele reconecte.",
     "exitCode": "saída {{code}}",
     "viewHistory": "Ver histórico",
+    "runAgain": "Executar novamente",
+    "viewOnDevice": "Ver no dispositivo",
     "status": {
       "pending": "Na fila",
       "running": "Em execução",

--- a/apps/web/src/locales/tr-TR/devices.json
+++ b/apps/web/src/locales/tr-TR/devices.json
@@ -1519,6 +1519,7 @@
     "output": "Çıkış",
     "refreshing": "Yenileniyor...",
     "running": "Koşuyor...",
+    "runAgain": "Tekrar çalıştır",
     "scriptFallback": "Komut Dosyası",
     "status": {
       "cancelled": "İptal edildi",

--- a/apps/web/src/locales/tr-TR/scripts.json
+++ b/apps/web/src/locales/tr-TR/scripts.json
@@ -644,7 +644,8 @@
       }
     },
     "actions": {
-      "copyToClipboard": "Panoya kopyala"
+      "copyToClipboard": "Panoya kopyala",
+      "runAgain": "Tekrar çalıştır"
     },
     "title": "Yürütme Ayrıntıları",
     "statusDescription": {
@@ -1330,6 +1331,8 @@
     "offlineWarning": "Seçilen cihaz çevrimdışı — çalıştırma, cihaz yeniden bağlanana kadar bekleyecek.",
     "exitCode": "çıkış {{code}}",
     "viewHistory": "Geçmişi görüntüle",
+    "runAgain": "Tekrar çalıştır",
+    "viewOnDevice": "Cihazda görüntüle",
     "status": {
       "pending": "Kuyrukta",
       "running": "Çalışıyor",


### PR DESCRIPTION
## Summary

Combines two related "what happens after you run a script" fixes into one PR, per the orchestrator's brief — both edit the same four components and are one coherent change; splitting them would conflict.

**#4885 — no "Run again" on a script execution.** Retrying a failed/completed run required going back to the library or device page, re-opening the full run modal, and re-selecting the target device and every parameter from scratch. Now every execution-details surface (script library history, device Scripts tab, Script Builder test runner) offers "Run again", which re-opens the execute flow pre-filled with the original device and parameter values.

**#4886 — running a script leaves the user where they started.** A script run gave no way to see where the result would show up. Now a run lands the operator where they can watch it:
- Single-device run (device page, or a library run targeting one device) → navigates to `/devices/:id#scripts/:executionId`, which auto-opens and highlights the new execution on the device's Scripts tab.
- Multi-device library run → navigates to `/scripts/:id/executions`.
- Script Builder's inline test runner gets an explicit "Run again" beside the result and a "View on device" link.

This reuses the existing `#anomalies/<id>` hash-based sub-state convention already in `DeviceDetails.tsx` (no query params, per CLAUDE.md).

## What changed

- `apps/api/src/routes/devices/scripts.ts` — the device-scoped execution-history endpoint now selects `parameters` (already returned at the same `SCRIPTS_READ` permission level by the two script-scoped execution endpoints — no new exposure, just parity so "Run again" has something to pre-fill from).
- `ExecutionHistory.tsx` — declares `ScriptExecution.parameters` on the type (it was already on the wire, just never typed).
- `ScriptExecutionModal.tsx` — accepts `initialDeviceIds` / `initialParameters`, read once at mount so a parent re-render can't clobber an in-progress edit. A stale `initialParameters` key with no matching runtime parameter is dropped rather than smuggled into the submitted payload.
- `ExecutionDetails.tsx` — adds a "Run again" footer button behind an optional `onRunAgain` prop (no-op/hidden where a caller doesn't wire it).
- `ScriptExecutionsPage.tsx` — wires "Run again" through to the execute modal. (Not in the original file list handed to me, but it's the actual page hosting `ExecutionDetails` for the script-library execution history — the feature would have no working home there otherwise. Confirmed no overlap with the sibling run-as-selector PR (#4888), which touches `ScriptTestRunner.tsx`, `ExecutionDetails.tsx`, and `DeviceScriptHistory.tsx` only.)
- `DeviceScriptHistory.tsx` — "Run again" (fetches the script definition, opens the execute modal pre-filled) plus a `highlightExecutionId` prop that highlights the row and auto-opens its details once.
- `DeviceDetails.tsx` — new `scriptExecutionIdFromHash` parser (mirrors `anomalyIdFromHash`) feeding `highlightExecutionId` into `DeviceScriptHistory`.
- `DeviceDetailPage.tsx` / `ScriptsPage.tsx` — post-run redirect.
- `ScriptTestRunner.tsx` — explicit "Run again" button beside a completed run's output, and a "View on device" link.
- Locale files (all 8) — `executionDetails.actions.runAgain`, `testRunner.runAgain`, `testRunner.viewOnDevice`, `deviceScriptHistory.runAgain` (parity-tested).

## Design decisions worth a look

- **"Run again" re-opens the execute modal pre-filled rather than firing an instant one-click re-run.** The issue's proposed fix mentioned both a direct-POST "Run again" and a modal-based "Edit and run" as separate variants; I implemented only the modal-based flow. Reasoning: it already fully solves "don't make me re-pick the device and parameters," it reuses the existing confirm-before-run step (worth keeping for a tool that executes scripts on customer machines), and it avoids duplicating admission-handling/error-UI logic across three call sites. Also sidesteps a real gap: `runAs` isn't stored per execution at all (no DB column), so an instant re-run would have to guess it — the modal already defaults sensibly from the script's own `runAs`.
- **Redirect is not (yet) suppressible.** The issue allowed for either a suppressible redirect or a toast "View" link as the escape hatch; I implemented neither — this is worth a look if operators find the auto-navigation surprising when running a script from a tab they wanted to stay on. Flagging in case it should be revisited.

## Test plan

- [x] Red-first: every new behavior (run-again wiring, initial-value seeding, navigation, highlight) has a test that failed before the corresponding implementation change.
- [x] `cd apps/web && npx vitest run src/components/scripts src/components/devices` — 83 files, 984 tests, all green (confirmed file count matches `find` for those dirs, per the substring-match trap).
- [x] `cd apps/web && npx vitest run src/lib/__tests__/no-silent-mutations.test.ts` — 130 tests green (touched files aren't in the AST-checked target set, so this doesn't gate them, but nothing regressed).
- [x] `cd apps/web && npx vitest run src/lib/i18n/localeParity.test.ts` — green across all 8 locales.
- [x] `cd apps/api && npx vitest run src/routes/devices/scripts.test.ts` — 5 tests green, including one that inspects the actual `db.select()` call argument (not just the mocked return) to prove the SELECT itself changed, not just the response shape.
- [x] `apps/web`: `npx tsc --noEmit` clean.
- [x] `apps/api`: `NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit` clean (plain `tsc --noEmit -p .` OOM-crashed on this host regardless of my changes).
- [x] `eslint` clean on every changed file in both packages.

Closes #4885
Closes #4886

🤖 Generated with [Claude Code](https://claude.com/claude-code)