### PR TITLE
fix(tests): preserve current functions after migration replay (#4881)

### DIFF
--- a/apps/api/src/__tests__/integration/inboundEmailContactRequester.integration.test.ts
+++ b/apps/api/src/__tests__/integration/inboundEmailContactRequester.integration.test.ts
@@ -23,8 +23,6 @@
  * tenancy boundary — nothing here re-derives an org from the sender.
  */
 import './setup';
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { and, eq, sql } from 'drizzle-orm';
 
@@ -54,18 +52,16 @@ import { processInboundEmail } from '../../services/inboundEmail/inboundEmailSer
 import type { NormalizedInboundEmail } from '../../services/inboundEmail/types';
 import { createOrganization, createPartner, createSite } from './db-utils';
 import { getTestDb } from './setup';
+import { replayMigration } from './replayMigration';
 import { randomUUID } from 'node:crypto';
 import * as orgMergeModule from '../../services/orgMerge';
 import { devices, sites } from '../../db/schema';
 
-const MIGRATION_FILE = join(__dirname, '../../../migrations/2026-10-04-100000-ticket-requester-contact.sql');
+const MIGRATION_FILE = '2026-10-04-100000-ticket-requester-contact.sql';
 // The follow-up that made portal_users.contact_id same-org (#3258). Needed here
 // only to RESTORE that constraint after the drift-tolerance test forges a row
 // it forbids.
-const PORTAL_USER_FK_MIGRATION_FILE = join(
-  __dirname,
-  '../../../migrations/2026-10-04-100002-portal-users-contact-composite-fk.sql',
-);
+const PORTAL_USER_FK_MIGRATION_FILE = '2026-10-04-100002-portal-users-contact-composite-fk.sql';
 
 const uniqueSuffix = () => `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 const admin = () => getTestDb() as any;
@@ -477,9 +473,10 @@ describe('org merge KEEPS the requester link', () => {
 
 describe('2026-10-04-100000-ticket-requester-contact.sql', () => {
   it('is idempotent — a second apply is a no-op, not a duplicate-constraint abort', async () => {
-    const text = readFileSync(MIGRATION_FILE, 'utf8');
-    await admin().execute(sql.raw(text));
-    await admin().execute(sql.raw(text));
+    const definitionBefore = await admin().execute(sql`SELECT pg_get_functiondef('public.breeze_cascade_device_org_id()'::regprocedure) AS definition`);
+    await replayMigration(MIGRATION_FILE);
+    await replayMigration(MIGRATION_FILE);
+    expect(await admin().execute(sql`SELECT pg_get_functiondef('public.breeze_cascade_device_org_id()'::regprocedure) AS definition`)).toEqual(definitionBefore);
 
     const [{ count: fkCount }] = await admin().execute(
       sql`SELECT count(*)::int AS count FROM pg_constraint WHERE conname = 'tickets_requester_contact_org_fk'`,
@@ -516,7 +513,7 @@ describe('2026-10-04-100000-ticket-requester-contact.sql', () => {
       })
       .returning({ id: tickets.id });
 
-    await admin().execute(sql.raw(readFileSync(MIGRATION_FILE, 'utf8')));
+    await replayMigration(MIGRATION_FILE);
 
     const [row] = await admin()
       .select({ requesterContactId: tickets.requesterContactId })
@@ -567,12 +564,12 @@ describe('2026-10-04-100000-ticket-requester-contact.sql', () => {
         .returning({ id: tickets.id });
       ticketId = ticket.id;
 
-      await expect(admin().execute(sql.raw(readFileSync(MIGRATION_FILE, 'utf8')))).resolves.toBeDefined();
+      await expect(replayMigration(MIGRATION_FILE)).resolves.toBeUndefined();
     } finally {
       // Restore the constraint for the rest of the shard. Replaying the later
       // migration is the honest way to do it — it nulls the forged link on its
       // way past, which is the cleanup that file exists to perform.
-      await admin().execute(sql.raw(readFileSync(PORTAL_USER_FK_MIGRATION_FILE, 'utf8')));
+      await replayMigration(PORTAL_USER_FK_MIGRATION_FILE);
     }
 
     // Assert the restore landed HERE, at its source. Leaving portal_users

--- a/apps/api/src/__tests__/integration/pamActuationLifecycle.integration.test.ts
+++ b/apps/api/src/__tests__/integration/pamActuationLifecycle.integration.test.ts
@@ -1,8 +1,7 @@
 import './setup';
 
-import { readFile } from 'node:fs/promises';
 import { randomUUID } from 'node:crypto';
-import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { sql } from 'drizzle-orm';
 import {
   db,
@@ -12,6 +11,7 @@ import {
   type DbAccessContext,
 } from '../../db';
 import { getAppDb, getTestDb } from './setup';
+import { replayMigration } from './replayMigration';
 import { createOrganization, createPartner } from './db-utils';
 import { CORE_TENANT_EXPORT_POLICY } from '../../services/tenantExportPolicyRegistry';
 import { deleteDeviceCascade, type DeviceDeletionTx } from '../../services/deviceDeletion';
@@ -120,33 +120,6 @@ describe('PAM actuation lifecycle schema governance', () => {
   beforeEach(async () => {
     fixtureA = await createFixture();
     fixtureB = await createFixture();
-  });
-
-  // The 'idempotently quarantines legacy...' case below re-executes
-  // 2026-09-16-pam-actuation-lifecycle.sql's raw SQL directly (via
-  // sql.raw) to prove that file's own idempotency. That file's
-  // CREATE OR REPLACE FUNCTION pam_actuations_transition_guard() body
-  // predates the org_id-immutability hardening added in
-  // 2026-09-25-pam-actuation-org-immutable.sql, so replaying it reverts
-  // the trigger function to its pre-hardening (org_id-mutable) body as a
-  // side effect on the live database — regardless of which test runs it
-  // or in what order. That's harmless within THIS file (the immutability
-  // test above runs earlier in declaration order, and
-  // vitest.integration.config.ts pins fileParallelism/sequence.concurrent
-  // to false, so ordering here is deterministic) — but it leaves the
-  // shared database un-hardened for whatever runs against it afterward in
-  // the same process, including other test files in the same CI job/shard
-  // (e.g. Task 4's org-merge trigger-classification tests, which depend on
-  // this trigger actually being BLOCKING). Re-apply the hardening migration
-  // unconditionally once after all tests in this file have run (afterAll,
-  // not afterEach) so the database is left hardened no matter which tests
-  // ran or in what order.
-  afterAll(async () => {
-    const hardening = await readFile(
-      new URL('../../../migrations/2026-09-25-pam-actuation-org-immutable.sql', import.meta.url),
-      'utf8',
-    );
-    await getTestDb().execute(sql.raw(hardening));
   });
 
   it('persists capability and request revision with fail-closed defaults', async () => {
@@ -315,11 +288,10 @@ describe('PAM actuation lifecycle schema governance', () => {
 
   it('idempotently quarantines legacy approved and actuating requests without fabricating cleanup evidence', async () => {
     const legacyActuating = await createFixture('actuating');
-    const migration = await readFile(
-      new URL('../../../migrations/2026-09-16-pam-actuation-lifecycle.sql', import.meta.url),
-      'utf8',
-    );
-    await getTestDb().execute(sql.raw(migration));
+    const definitionBefore = await getTestDb().execute(sql`SELECT pg_get_functiondef('public.pam_actuations_transition_guard()'::regprocedure) AS definition`);
+    // Restore later guard definitions immediately, including org immutability.
+    await replayMigration('2026-09-16-pam-actuation-lifecycle.sql');
+    expect(await getTestDb().execute(sql`SELECT pg_get_functiondef('public.pam_actuations_transition_guard()'::regprocedure) AS definition`)).toEqual(definitionBefore);
 
     const rows = await getTestDb().execute(sql`
       SELECT elevation_request_id AS "requestId", desired_state AS "desiredState",

--- a/apps/api/src/__tests__/integration/ticketCommentsAgentRunBackfill.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ticketCommentsAgentRunBackfill.integration.test.ts
@@ -29,21 +29,16 @@
  *     src/__tests__/integration/ticketCommentsAgentRunBackfill.integration.test.ts
  */
 import './setup';
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
-import { eq } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import { describe, expect, it } from 'vitest';
 import { db, withDbAccessContext, type DbAccessContext } from '../../db';
 import { aiAgentRuns, aiAgents, ticketComments, tickets } from '../../db/schema';
 import { createOrganization, createPartner, createSite, createUser } from './db-utils';
 import { getTestDb } from './setup';
-import { sql } from 'drizzle-orm';
+import { replayMigration } from './replayMigration';
 
-const MIGRATION_FILE = join(
-  __dirname,
-  '../../../migrations/2026-10-08-100500-detach-ticket-comment-runs-on-device-org-move.sql',
-);
+const MIGRATION_FILE = '2026-10-08-100500-detach-ticket-comment-runs-on-device-org-move.sql';
 
 const SYSTEM_CTX: DbAccessContext = {
   scope: 'system',
@@ -52,11 +47,6 @@ const SYSTEM_CTX: DbAccessContext = {
   accessiblePartnerIds: null,
   userId: null,
 };
-
-/** Replays the migration file as the privileged test role (idempotent: CREATE OR REPLACE + a re-runnable backfill). */
-async function replayMigration() {
-  await getTestDb().execute(sql.raw(readFileSync(MIGRATION_FILE, 'utf8')));
-}
 
 async function readComment(id: string) {
   const adminDb = getTestDb() as any;
@@ -169,7 +159,8 @@ describe('ticket_comments.agent_run_id backfill (#4644 migration replay)', () =>
     expect((await readComment(staleComment.id)).agentRunId).toBe(staleRun!.id);
     expect((await readComment(liveComment.id)).agentRunId).toBe(liveRun!.id);
 
-    await replayMigration();
+    const definitionBefore = await getTestDb().execute(sql`SELECT pg_get_functiondef('public.breeze_cascade_device_org_id()'::regprocedure) AS definition`);
+    await replayMigration(MIGRATION_FILE);
 
     expect((await readComment(staleComment.id)).agentRunId, 'stale cross-org pointer must be severed').toBeNull();
     expect(
@@ -179,7 +170,8 @@ describe('ticket_comments.agent_run_id backfill (#4644 migration replay)', () =>
 
     // Idempotent replay: re-running must not error and must not touch the
     // already-corrected rows (there is nothing left to backfill).
-    await replayMigration();
+    await replayMigration(MIGRATION_FILE);
+    expect(await getTestDb().execute(sql`SELECT pg_get_functiondef('public.breeze_cascade_device_org_id()'::regprocedure) AS definition`)).toEqual(definitionBefore);
     expect((await readComment(staleComment.id)).agentRunId).toBeNull();
     expect((await readComment(liveComment.id)).agentRunId).toBe(liveRun!.id);
   });


### PR DESCRIPTION
## Summary

- Integration tests that replayed older migrations left current database functions downgraded, causing later device-move tests to fail depending on suite order. Switch the ticket-comment backfill, inbound-email requester, and PAM lifecycle suites to the shared `replayMigration` helper so later function definitions are restored immediately.
- Remove PAM's manual end-of-suite restoration and compare `pg_get_functiondef` before and after replay to catch future regressions. Preserve the inbound-email drift fixture's explicit foreign-key restoration.

## Linked Issues

Closes #4881

## Type of Change

- [x] Bug fix

## Testing

- [x] Relevant existing tests pass
- [x] Added regression assertions to existing tests

Validated 41 PostgreSQL integration tests across seven suites using a fresh, isolated test stack: `ticketCommentsAgentRunBackfill`, `inboundEmailContactRequester`, `pamActuationLifecycle`, `deviceMoveOrgIntentScopeTombstone`, `deviceMoveOrgVulnerabilityTicketDetach`, `deviceMoveOrgTicketScopeTombstone`, and `pamDeviceMoveGuard`. Six suites passed together; the inbound-email suite passed on rerun after correcting a test assertion.

`git diff --check` passed. Temporary test containers were removed afterward.

## Checklist

- [x] My code follows the project's code style
- [x] I have reviewed my own changes
- [x] I have tested on the relevant platforms
- [x] No secrets, credentials, or personal data included
