### PR TITLE
fix(tenancy): detach restore commands during org erasure (#4871)

### DIFF
--- a/apps/api/migrations/2026-10-09-000200-restore-job-command-set-null.sql
+++ b/apps/api/migrations/2026-10-09-000200-restore-job-command-set-null.sql
@@ -1,0 +1,8 @@
+-- Org erasure clears device_commands before walking org-scoped tables (#4871).
+-- Retain the restore job until its own cascade step, detaching the command.
+ALTER TABLE public.restore_jobs
+  DROP CONSTRAINT IF EXISTS restore_jobs_command_id_fkey,
+  DROP CONSTRAINT IF EXISTS restore_jobs_command_id_device_commands_id_fk;
+ALTER TABLE public.restore_jobs
+  ADD CONSTRAINT restore_jobs_command_id_fkey
+  FOREIGN KEY (command_id) REFERENCES public.device_commands(id) ON DELETE SET NULL;

--- a/apps/api/src/__tests__/integration/tenantExportErasureRoundtrip.integration.test.ts
+++ b/apps/api/src/__tests__/integration/tenantExportErasureRoundtrip.integration.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { sql } from 'drizzle-orm';
 import JSZip from 'jszip';
 import { getTestDb } from './setup';
+import { replayMigration } from './replayMigration';
 import { buildOrgExportZip } from '../../services/tenantExport';
 import { cascadeDeleteOrg } from '../../services/tenantCascade';
 
@@ -39,6 +40,42 @@ interface SeededOrgs {
   siteId: string;
   siteName: string;
   prohibitedSentinels: string[];
+}
+
+// Seed the real backup dependency chain, including the command FK that used
+// to abort org erasure before restore_jobs reached its cascade step (#4871).
+async function seedRestore(orgId: string) {
+  const db = getTestDb();
+  const [site] = await db.execute(sql`SELECT id FROM sites WHERE org_id = ${orgId} LIMIT 1`);
+  let [device] = await db.execute(sql`SELECT id FROM devices WHERE org_id = ${orgId} LIMIT 1`);
+  if (!device) {
+    [device] = await db.execute(sql`
+      INSERT INTO devices (org_id, site_id, agent_id, hostname, os_type, os_version, architecture, agent_version)
+      VALUES (${orgId}, ${site!.id as string}, ${crypto.randomUUID()}, 'restore-fixture', 'windows', '11', 'amd64', '1.0.0')
+      RETURNING id
+    `);
+  }
+  const deviceId = device!.id as string;
+  const [config] = await db.execute(sql`
+    INSERT INTO backup_configs (org_id, name, type, provider, provider_config)
+    VALUES (${orgId}, 'Restore fixture', 'file', 'local', '{}') RETURNING id
+  `);
+  const [job] = await db.execute(sql`
+    INSERT INTO backup_jobs (org_id, config_id, device_id)
+    VALUES (${orgId}, ${config!.id as string}, ${deviceId}) RETURNING id
+  `);
+  const [snapshot] = await db.execute(sql`
+    INSERT INTO backup_snapshots (org_id, job_id, device_id, snapshot_id)
+    VALUES (${orgId}, ${job!.id as string}, ${deviceId}, ${crypto.randomUUID()}) RETURNING id
+  `);
+  const [command] = await db.execute(sql`
+    INSERT INTO device_commands (device_id, type) VALUES (${deviceId}, 'restore_backup') RETURNING id
+  `);
+  const [restore] = await db.execute(sql`
+    INSERT INTO restore_jobs (org_id, snapshot_id, device_id, restore_type, command_id)
+    VALUES (${orgId}, ${snapshot!.id as string}, ${deviceId}, 'full', ${command!.id as string}) RETURNING id
+  `);
+  return { restoreId: restore!.id as string, commandId: command!.id as string };
 }
 
 async function seedTwoOrgs(): Promise<SeededOrgs> {
@@ -410,9 +447,22 @@ describe('tenant export + erasure round-trip (live DB)', () => {
     }
   });
 
+  it('detaches a deleted command without deleting its restore job, including after migration replay', async () => {
+    const db = getTestDb();
+    const { orgA } = await seedTwoOrgs();
+    const { restoreId, commandId } = await seedRestore(orgA);
+    await replayMigration('2026-10-09-000200-restore-job-command-set-null.sql');
+    await replayMigration('2026-10-09-000200-restore-job-command-set-null.sql');
+    await db.execute(sql`DELETE FROM device_commands WHERE id = ${commandId}`);
+    const rows = await db.execute(sql`SELECT command_id FROM restore_jobs WHERE id = ${restoreId}`);
+    expect([...rows]).toEqual([{ command_id: null }]);
+  });
+
   it('cascade erases the target org and leaves the other org intact', async () => {
     const db = getTestDb();
     const { orgA, orgB } = await seedTwoOrgs();
+    const restoreA = await seedRestore(orgA);
+    const restoreB = await seedRestore(orgB);
 
     // Sanity: both orgs populated before erasure.
     expect(await rowCount(db, 'sites', orgA)).toBe(2);
@@ -425,7 +475,17 @@ describe('tenant export + erasure round-trip (live DB)', () => {
     expect(await rowCount(db, 'invoice_line_devices', orgA)).toBe(1);
     expect(await rowCount(db, 'contract_billing_period_outcomes', orgA)).toBe(1);
 
+    expect(await rowCount(db, 'restore_jobs', orgA)).toBe(1);
+    expect(await rowCount(db, 'restore_jobs', orgB)).toBe(1);
     const stats = await cascadeDeleteOrg(orgA, PERFORMED_BY, PERFORMED_EMAIL);
+    expect(await rowCount(db, 'restore_jobs', orgA)).toBe(0);
+    expect(stats.tablesDeleted.restore_jobs).toBe(1);
+    expect([...(await db.execute(sql`SELECT id FROM device_commands WHERE id = ${restoreA.commandId}`))]).toEqual([]);
+    expect([...(await db.execute(sql`SELECT command_id FROM restore_jobs WHERE id = ${restoreB.restoreId}`))])
+      .toEqual([{ command_id: restoreB.commandId }]);
+    expect([...(await db.execute(sql`SELECT id FROM device_commands WHERE id = ${restoreB.commandId}`))])
+      .toEqual([{ id: restoreB.commandId }]);
+
 
     // Target org fully wiped.
     expect(await rowCount(db, 'sites', orgA)).toBe(0);

--- a/apps/api/src/db/schema/backup.ts
+++ b/apps/api/src/db/schema/backup.ts
@@ -374,7 +374,7 @@ export const restoreJobs = pgTable(
     initiatedBy: uuid('initiated_by').references(() => users.id),
     targetConfig: jsonb('target_config'),
     recoveryTokenId: uuid('recovery_token_id'),
-    commandId: uuid('command_id').references(() => deviceCommands.id),
+    commandId: uuid('command_id').references(() => deviceCommands.id, { onDelete: 'set null' }),
     createdAt: timestamp('created_at').defaultNow().notNull(),
     updatedAt: timestamp('updated_at').defaultNow().notNull(),
     ...recoveryAuthorizationSubjectColumns(),


### PR DESCRIPTION
## Summary

- Organization erasure clears device commands before deleting restore jobs. A restore job referencing one of those commands previously blocked erasure with SQLSTATE 23503. Change its command foreign key to `ON DELETE SET NULL` in an idempotent forward migration and match the Drizzle schema.
- Extend the real-PostgreSQL export/erasure suite with command-linked restores in two organizations. Verify erasure removes the target organization's restore and command while preserving the other organization's data. Also verify direct command deletion retains the restore job with a null reference after replaying the migration twice.

## Linked Issues

Closes #4871

The FK allowlist mentioned in the issue is introduced by pending PR #4863 and is not on the base branch. If that PR lands first, its restore-command exception must be removed during integration.

## Type of Change

- [x] Bug fix

## Testing

- [x] Relevant existing tests pass
- [x] Added new tests

- PostgreSQL: all 3 tests in `tenantExportErasureRoundtrip.integration.test.ts` passed on a fresh private test stack.
- Migration regression suite: all 75 tests in `autoMigrate.test.ts` passed.
- `db:check-drift`: all 667 migration files match the ledger.
- `git diff --check` passed.

Vitest exited successfully but reported a teardown timeout after the PostgreSQL tests passed. The private test stack was removed afterward.

## Checklist

- [x] My code follows the project's code style
- [x] I have reviewed my own changes
- [x] I have tested on the relevant platforms
- [x] No secrets, credentials, or personal data included
