### PR TITLE
fix(billing): record interactive contract line device evidence (#4837)

### DIFF
--- a/apps/api/src/__tests__/integration/billingEvidence.integration.test.ts
+++ b/apps/api/src/__tests__/integration/billingEvidence.integration.test.ts
@@ -20,8 +20,8 @@ import {
   invoiceLineDevices, contractBillingPeriods, contractBillingPeriodOutcomes,
   users, roles, organizationUsers,
 } from '../../db/schema';
-import { generateDueInvoice } from '../../services/contractService';
-import { removeLine, updateLine } from '../../services/invoiceService';
+import { computeContractEstimate, getContract, materializeContractLineOntoInvoice, generateDueInvoice } from '../../services/contractService';
+import { createManualInvoice, removeLine, updateLine } from '../../services/invoiceService';
 import type { DeviceRole } from '@breeze/shared';
 import type { AuthContext } from '../../middleware/auth';
 
@@ -144,6 +144,52 @@ const hosts = (n: number, prefix = 'host') =>
 const runDb = it.runIf(!!process.env.DATABASE_URL);
 
 describe('billing evidence at generation (real DB) #3205 W07', () => {
+  runDb('interactive materialization records devices on manual and generated drafts without changing period outcomes (#4837)', async () => {
+    const f = await seedContract(['zulu', 'alpha'], { lineType: 'per_device', includedQuantity: '1.00', overageMode: 'bill', overageUnitPrice: '12.00' });
+    const generated = await generate(f.contractId);
+    const actor = { ...ACTOR, partnerId: f.partnerId };
+    await withSystemDbAccessContext(async () => {
+      const manual = await createManualInvoice({ orgId: f.orgId }, actor);
+      const before = await db.select().from(contractBillingPeriodOutcomes);
+      const { contract, lines } = await getContract(f.contractId, actor);
+      for (const invoiceId of [manual.id, generated.invoiceId!]) {
+        const evidence = new Map<string, readonly import('../../services/contractQuantities').DeviceSnapshotRow[]>();
+        const estimate = await computeContractEstimate(f.contractId, ACTOR, evidence);
+        const est = estimate.lines[0]!;
+        const added = await materializeContractLineOntoInvoice(actor, {
+          invoiceId, contract, line: lines[0]!, currencyCode: contract.currencyCode,
+          resolved: { counted: est.counted, billed: est.quantity, included: est.included, overage: est.overage, overageMode: est.overageMode },
+          deviceEvidence: evidence.get(lines[0]!.id),
+        });
+        const rows = await db.select().from(invoiceLineDevices).where(eq(invoiceLineDevices.invoiceLineId, added.baseLine.id));
+        expect(rows).toMatchObject([{ hostname: 'alpha', countedAs: 'included', orgId: f.orgId }]);
+        const tail = await db.select().from(invoiceLineDevices).where(eq(invoiceLineDevices.invoiceLineId, added.overageLine!.id));
+        expect(tail).toMatchObject([{ hostname: 'zulu', countedAs: 'overage' }]);
+        const [invoice] = await db.select().from(invoices).where(eq(invoices.id, invoiceId));
+        expect(invoice!.evidenceVersion).toBe(1);
+      }
+      expect(await db.select().from(contractBillingPeriodOutcomes)).toEqual(before);
+    });
+  });
+
+  runDb('interactive evidence failure rolls back the base line and invoice marker (#4837)', async () => {
+    const f = await seedContract(['alpha'], { lineType: 'per_device' });
+    const actor = { ...ACTOR, partnerId: f.partnerId };
+    await withSystemDbAccessContext(async () => {
+      const manual = await createManualInvoice({ orgId: f.orgId }, actor);
+      const { contract, lines } = await getContract(f.contractId, actor);
+      // A nonexistent device violates the FK after the base line was written.
+      await expect(materializeContractLineOntoInvoice(actor, {
+        invoiceId: manual.id, contract, line: lines[0]!, currencyCode: contract.currencyCode,
+        resolved: { counted: 1, billed: 1, included: null, overage: 0, overageMode: null },
+        deviceEvidence: [{ id: '00000000-0000-4000-8000-000000000099', hostname: 'missing', role: 'server', siteId: null }],
+      })).rejects.toThrow();
+      expect(await db.select().from(invoiceLines).where(eq(invoiceLines.invoiceId, manual.id))).toEqual([]);
+      const [invoice] = await db.select().from(invoices).where(eq(invoices.id, manual.id));
+      expect(invoice!.evidenceVersion).toBeNull();
+    });
+  });
+
   runDb('GET evidence pages by (hostname, evidence-row id) without overlap across duplicate hostnames', async () => {
     const f = await seedContract(['dup', 'dup', 'dup'], { lineType: 'per_device' });
     const generated = await generate(f.contractId);

--- a/apps/api/src/__tests__/integration/billingEvidence.integration.test.ts
+++ b/apps/api/src/__tests__/integration/billingEvidence.integration.test.ts
@@ -175,15 +175,17 @@ describe('billing evidence at generation (real DB) #3205 W07', () => {
   runDb('interactive evidence failure rolls back the base line and invoice marker (#4837)', async () => {
     const f = await seedContract(['alpha'], { lineType: 'per_device' });
     const actor = { ...ACTOR, partnerId: f.partnerId };
-    await withSystemDbAccessContext(async () => {
-      const manual = await createManualInvoice({ orgId: f.orgId }, actor);
+    const manual = await withSystemDbAccessContext(() => createManualInvoice({ orgId: f.orgId }, actor));
+    await expect(withSystemDbAccessContext(async () => {
       const { contract, lines } = await getContract(f.contractId, actor);
       // A nonexistent device violates the FK after the base line was written.
-      await expect(materializeContractLineOntoInvoice(actor, {
+      await materializeContractLineOntoInvoice(actor, {
         invoiceId: manual.id, contract, line: lines[0]!, currencyCode: contract.currencyCode,
         resolved: { counted: 1, billed: 1, included: null, overage: 0, overageMode: null },
         deviceEvidence: [{ id: '00000000-0000-4000-8000-000000000099', hostname: 'missing', role: 'server', siteId: null }],
-      })).rejects.toThrow();
+      });
+    })).rejects.toThrow();
+    await withSystemDbAccessContext(async () => {
       expect(await db.select().from(invoiceLines).where(eq(invoiceLines.invoiceId, manual.id))).toEqual([]);
       const [invoice] = await db.select().from(invoices).where(eq(invoices.id, manual.id));
       expect(invoice!.evidenceVersion).toBeNull();

--- a/apps/api/src/__tests__/integration/billingEvidence.integration.test.ts
+++ b/apps/api/src/__tests__/integration/billingEvidence.integration.test.ts
@@ -151,10 +151,10 @@ describe('billing evidence at generation (real DB) #3205 W07', () => {
     await withSystemDbAccessContext(async () => {
       const manual = await createManualInvoice({ orgId: f.orgId }, actor);
       const before = await db.select().from(contractBillingPeriodOutcomes);
-      const { contract, lines } = await getContract(f.contractId, actor);
+      const { contract, lines } = await getContract(f.contractId, { ...actor, userId: '00000000-0000-4000-8000-000000000001' });
       for (const invoiceId of [manual.id, generated.invoiceId!]) {
         const evidence = new Map<string, readonly import('../../services/contractQuantities').DeviceSnapshotRow[]>();
-        const estimate = await computeContractEstimate(f.contractId, ACTOR, evidence);
+        const estimate = await computeContractEstimate(f.contractId, { ...actor, userId: '00000000-0000-4000-8000-000000000001' }, evidence);
         const est = estimate.lines[0]!;
         const added = await materializeContractLineOntoInvoice(actor, {
           invoiceId, contract, line: lines[0]!, currencyCode: contract.currencyCode,
@@ -177,7 +177,7 @@ describe('billing evidence at generation (real DB) #3205 W07', () => {
     const actor = { ...ACTOR, partnerId: f.partnerId };
     const manual = await withSystemDbAccessContext(() => createManualInvoice({ orgId: f.orgId }, actor));
     await expect(withSystemDbAccessContext(async () => {
-      const { contract, lines } = await getContract(f.contractId, actor);
+      const { contract, lines } = await getContract(f.contractId, { ...actor, userId: '00000000-0000-4000-8000-000000000001' });
       // A nonexistent device violates the FK after the base line was written.
       await materializeContractLineOntoInvoice(actor, {
         invoiceId: manual.id, contract, line: lines[0]!, currencyCode: contract.currencyCode,

--- a/apps/api/src/db/schema/invoices.ts
+++ b/apps/api/src/db/schema/invoices.ts
@@ -69,8 +69,8 @@ export const invoices = pgTable('invoices', {
   // reads ONLY this column afterwards, so a later partner-default change cannot
   // alter what a sanctioned re-render produces.
   deviceAppendix: boolean('device_appendix'),
-  // #3205 W07: 1 = billing evidence written at generation. NULL = pre-W07 or
-  // never generated from a contract. Invoice-level `recorded` flag — never
+  // #3205 W07: 1 = billing evidence captured at generation or interactive
+  // contract-line materialization. NULL = no evidence capture recorded. Invoice-level `recorded` flag — never
   // derived from an evidence row count.
   evidenceVersion: smallint('evidence_version'),
   termsAndConditions: text('terms_and_conditions'),

--- a/apps/api/src/services/aiToolsBilling.manageInvoices.test.ts
+++ b/apps/api/src/services/aiToolsBilling.manageInvoices.test.ts
@@ -173,12 +173,20 @@ describe('manage_invoices', () => {
       ],
       periods: [],
     });
-    vi.mocked(contractService.computeContractEstimate).mockResolvedValueOnce({
+    const capturedDevices = [
+      { id: 'd1', hostname: 'one', role: 'server', siteId: null },
+      { id: 'd2', hostname: 'two', role: 'server', siteId: null },
+      { id: 'd3', hostname: 'three', role: 'server', siteId: null },
+    ];
+    vi.mocked(contractService.computeContractEstimate).mockImplementationOnce(async (_id, _actor, evidence) => {
+      evidence!.set('contract-line-1', capturedDevices);
+      return {
       currencyCode: 'USD',
       periodTotal: '37.50',
       lines: [{ lineId: 'contract-line-1', lineType: 'per_device', quantity: 3, value: '37.50', live: true, counted: 3, included: null, overage: 0, overageMode: null, overageValue: '0.00' }],
       uncoveredDevices: null,
       overages: [],
+      };
     });
 
     const out = await getTool().handler(
@@ -198,12 +206,13 @@ describe('manage_invoices', () => {
     );
 
     expect(contractService.getContract).toHaveBeenCalledWith('contract-1', actor);
-    expect(contractService.computeContractEstimate).toHaveBeenCalledWith('contract-1', actor);
+    expect(contractService.computeContractEstimate).toHaveBeenCalledWith('contract-1', actor, expect.any(Map));
     expect(contractService.materializeContractLineOntoInvoice).toHaveBeenCalledWith(actor, {
       invoiceId: 'inv-1',
       contract: expect.objectContaining({ id: 'contract-1', currencyCode: 'USD' }),
       line: expect.objectContaining({ id: 'contract-line-1', catalogItemId: 'catalog-1' }),
       resolved: { counted: 3, billed: 3, included: null, overage: 0, overageMode: null },
+      deviceEvidence: capturedDevices,
       currencyCode: 'USD',
     });
     expect(invoiceService.addContractLine).not.toHaveBeenCalled();

--- a/apps/api/src/services/aiToolsBilling.ts
+++ b/apps/api/src/services/aiToolsBilling.ts
@@ -49,6 +49,7 @@ import {
 import { createInvoicePayLink } from './invoiceCheckout';
 import { InvoiceServiceError, type InvoiceActor } from './invoiceTypes';
 import { db } from '../db';
+import type { DeviceSnapshotRow } from './contractQuantities';
 import { computeContractEstimate, getContract, lockContractRow, materializeContractLineOntoInvoice } from './contractService';
 import { toCents } from './invoiceMath';
 import { missingParamsJson, zodErrorToJson } from './aiToolValidation';
@@ -305,7 +306,8 @@ export function registerBillingTools(aiTools: Map<string, AiTool>): void {
             const line = lines.find((candidate) => candidate.id === contractLineId);
             if (!line) return JSON.stringify({ error: 'Contract line not found for this contract' });
 
-            const estimate = await computeContractEstimate(contractId, contractActor);
+            const deviceEvidence = new Map<string, readonly DeviceSnapshotRow[]>();
+            const estimate = await computeContractEstimate(contractId, contractActor, deviceEvidence);
             const est = estimate.lines.find((candidate) => candidate.lineId === line.id);
             if (!est) return JSON.stringify({ error: 'Contract line estimate not found for this contract' });
 
@@ -320,6 +322,7 @@ export function registerBillingTools(aiTools: Map<string, AiTool>): void {
                 overage: est.overage,
                 overageMode: est.overageMode,
               },
+              deviceEvidence: deviceEvidence.get(line.id),
               currencyCode: estimate.currencyCode,
             });
             return JSON.stringify({

--- a/apps/api/src/services/contractService.test.ts
+++ b/apps/api/src/services/contractService.test.ts
@@ -58,7 +58,8 @@ vi.mock('./catalogPricing', async (importOriginal) => {
 
 import * as svc from './contractService';
 import { db } from '../db';
-import { contractLines } from '../db/schema';
+import { contractLines, invoiceLineDevices, invoices, contractBillingPeriodOutcomes } from '../db/schema';
+import type { DeviceSnapshotRow } from './contractQuantities';
 import { resolvePrice, CatalogServiceError } from './catalogService';
 import { resolvePriceFrom } from './catalogPricing';
 import { createManualInvoice, addContractLine } from './invoiceService';
@@ -1050,6 +1051,18 @@ describe('computeContractEstimate — per_device_role + uncoveredDevices (#3205)
     { id: 'unknown-1', hostname: 'unknown-1', role: 'unknown', siteId: null },
   ];
 
+  it('captures only matched devices from the quantity snapshot without exposing them in the estimate', async () => {
+    vi.mocked(snapshotContractDevices).mockResolvedValue(snapshot);
+    queueResult([contract]);
+    queueResult([lineRow({ lineType: 'per_device_role', deviceRoles: ['server'] })]);
+    const captured = new Map<string, readonly DeviceSnapshotRow[]>();
+    const out = await svc.computeContractEstimate('c1', actor, captured);
+    expect(captured.get('l1')).toEqual(snapshot.filter((row) => row.role === 'server'));
+    expect(captured.get('l1')).toHaveLength(out.lines[0]!.counted);
+    expect(snapshotContractDevices).toHaveBeenCalledExactlyOnceWith('org1');
+    expect(out.lines[0]).not.toHaveProperty('devices');
+  });
+
   it('bills the role set from the snapshot and reports uncovered devices by role', async () => {
     vi.mocked(snapshotContractDevices).mockResolvedValue(snapshot);
     queueResult([contract]); // getOwnedContractOr404
@@ -1861,11 +1874,63 @@ describe('allowance writers (#3205 W04)', () => {
 describe('materializeContractLineOntoInvoice (#3205 W04)', () => {
   beforeEach(() => { results.length = 0; vi.clearAllMocks(); });
 
-  const contract = { id: 'c1', currencyCode: 'USD' };
+  const contract = { id: 'c1', orgId: 'org1', currencyCode: 'USD' };
   const line = {
     id: 'cl1', description: 'Endpoints', unitPrice: '10.00', taxable: true,
     catalogItemId: null, overageUnitPrice: '12.00',
   };
+
+  const evidenceDevices = [
+    { id: 'd2', hostname: 'zulu', role: 'server', siteId: 'site1' },
+    { id: 'd1', hostname: 'alpha', role: 'workstation', siteId: null },
+  ];
+
+  it.each(['bill', 'flag'] as const)('persists interactive %s evidence with stable allowance disposition and no period outcome', async (mode) => {
+    vi.mocked(addContractLine)
+      .mockResolvedValueOnce({ line: { id: 'base', taxable: true, costBasis: null }, pricedFrom: 'contract_snapshot' } as never);
+    if (mode === 'bill') vi.mocked(addContractLine).mockResolvedValueOnce({
+      line: { id: 'overage', lineTotal: '12.00' }, pricedFrom: 'contract_snapshot',
+    } as never);
+    await svc.materializeContractLineOntoInvoice(actor, {
+      invoiceId: 'inv1', contract, line,
+      resolved: { counted: 2, billed: 1, included: 1, overage: 1, overageMode: mode },
+      deviceEvidence: evidenceDevices, currencyCode: 'USD',
+    });
+    expect(db.insert).toHaveBeenCalledExactlyOnceWith(invoiceLineDevices);
+    expect(db.insert).not.toHaveBeenCalledWith(contractBillingPeriodOutcomes);
+    expect((db as any).values).toHaveBeenCalledWith([
+      { invoiceId: 'inv1', orgId: 'org1', invoiceLineId: 'base', deviceId: 'd1', hostname: 'alpha', deviceRole: 'workstation', siteId: null, countedAs: 'included' },
+      { invoiceId: 'inv1', orgId: 'org1', invoiceLineId: mode === 'bill' ? 'overage' : 'base', deviceId: 'd2', hostname: 'zulu', deviceRole: 'server', siteId: 'site1', countedAs: mode === 'bill' ? 'overage' : 'flagged' },
+    ]);
+    expect(db.update).toHaveBeenCalledExactlyOnceWith(invoices);
+    expect((db as any).set).toHaveBeenCalledWith({ evidenceVersion: 1 });
+  });
+
+  it('records an empty interactive device set without inventing evidence for an allowance', async () => {
+    vi.mocked(addContractLine).mockResolvedValueOnce({ line: { id: 'base' }, pricedFrom: 'contract_snapshot' } as never);
+    await svc.materializeContractLineOntoInvoice(actor, {
+      invoiceId: 'inv1', contract, line,
+      resolved: { counted: 0, billed: 1, included: 1, overage: 0, overageMode: 'bill' },
+      deviceEvidence: [], currencyCode: 'USD',
+    });
+    expect(db.insert).not.toHaveBeenCalled();
+    expect((db as any).set).toHaveBeenCalledWith({ evidenceVersion: 1 });
+  });
+
+  it('chunks large interactive evidence and propagates a failed write before stamping the invoice', async () => {
+    vi.mocked(addContractLine).mockResolvedValueOnce({ line: { id: 'base' }, pricedFrom: 'contract_snapshot' } as never);
+    queueResult([]);
+    queueError(new Error('evidence insert failed'));
+    const deviceEvidence = Array.from({ length: 501 }, (_, i) => ({ ...evidenceDevices[0]!, id: `device-${i}` }));
+    await expect(svc.materializeContractLineOntoInvoice(actor, {
+      invoiceId: 'inv1', contract, line,
+      resolved: { counted: 501, billed: 501, included: null, overage: 0, overageMode: null },
+      deviceEvidence, currencyCode: 'USD',
+    })).rejects.toThrow('evidence insert failed');
+    expect(vi.mocked((db as any).values).mock.calls.map(([rows]: unknown[]) => (rows as unknown[]).length)).toEqual([500, 1]);
+    expect(db.update).not.toHaveBeenCalled();
+    expect(db.transaction).toHaveBeenCalledOnce();
+  });
 
   it('writes the bill-mode base and overage sibling and returns its summary', async () => {
     vi.mocked(addContractLine)

--- a/apps/api/src/services/contractService.ts
+++ b/apps/api/src/services/contractService.ts
@@ -573,10 +573,12 @@ type AddedContractInvoiceLine = Awaited<ReturnType<typeof addContractLine>>;
 
 export interface MaterializeContractLineInput {
   invoiceId: string;
-  contract: Pick<typeof contracts.$inferSelect, 'id' | 'currencyCode'>;
+  contract: Pick<typeof contracts.$inferSelect, 'id' | 'orgId' | 'currencyCode'>;
   line: Pick<typeof contractLines.$inferSelect,
     'id' | 'description' | 'unitPrice' | 'taxable' | 'catalogItemId' | 'overageUnitPrice'>;
   resolved: ResolvedQuantity;
+  /** Interactive capture from the same snapshot as resolved; omitted by the period writer. */
+  deviceEvidence?: readonly DeviceSnapshotRow[];
   currencyCode: string;
 }
 
@@ -595,7 +597,7 @@ export interface MaterializedContractLine {
  */
 export async function materializeContractLineOntoInvoice(
   actor: InvoiceActor,
-  { invoiceId, contract, line, resolved, currencyCode }: MaterializeContractLineInput,
+  { invoiceId, contract, line, resolved, deviceEvidence, currencyCode }: MaterializeContractLineInput,
 ): Promise<MaterializedContractLine> {
   // Self-guard like generateDueInvoice: without an ambient context, nested
   // db.transaction() calls would each open their own pooled connection and the
@@ -652,7 +654,22 @@ export async function materializeContractLineOntoInvoice(
         }
       : null;
 
-    return { baseLine, overageLine, overage, pricedFrom };
+    const materialized = { baseLine, overageLine, overage, pricedFrom };
+    if (deviceEvidence !== undefined) {
+      if (deviceEvidence.length !== resolved.counted) {
+        throw new ContractServiceError('Device evidence does not match the resolved count', 500, 'INVALID_STATE');
+      }
+      const evidence = evidenceForLine(deviceEvidence, resolved, materialized);
+      for (const chunk of chunksOf(evidence, EVIDENCE_INSERT_CHUNK)) {
+        await db.insert(invoiceLineDevices).values(
+          chunk.map((row) => ({ ...row, invoiceId, orgId: contract.orgId })),
+        );
+      }
+      // Capture also records a meaningful empty device set. This does not
+      // reconstruct evidence for any older lines already on the draft.
+      await db.update(invoices).set({ evidenceVersion: 1 }).where(eq(invoices.id, invoiceId));
+    }
+    return materialized;
   });
 }
 
@@ -684,7 +701,12 @@ export interface ContractEstimate {
 
 /** Per-line resolved quantities + values + period total for one contract, using
  *  live device/seat counts as of now. Powers the editor sidebar and detail. */
-export async function computeContractEstimate(contractId: string, actor: ContractActor): Promise<ContractEstimate> {
+export async function computeContractEstimate(
+  contractId: string,
+  actor: ContractActor,
+  /** Internal capture for interactive materialization; never part of the public estimate response. */
+  deviceEvidence?: Map<string, readonly DeviceSnapshotRow[]>,
+): Promise<ContractEstimate> {
   const contract = await getOwnedContractOr404(contractId, actor);
   const lines = await db.select().from(contractLines)
     .where(eq(contractLines.contractId, contractId))
@@ -698,6 +720,11 @@ export async function computeContractEstimate(contractId: string, actor: Contrac
   if (groupIds.length > 0) await orgSnapshot(contract.orgId, dc, groupIds);
   for (const l of lines) {
     const r = await resolveLineQty(contract.orgId, l, dc, sc);
+    if (deviceEvidence && isDeviceLine(l)) {
+      deviceEvidence.set(l.id, r.unresolved ? [] : orderDevicesForEvidence(
+        matchingDevicesForLine(await orgSnapshot(contract.orgId, dc), l),
+      ));
+    }
     const value = multiplyToCurrency(r.billed, l.unitPrice, contract.currencyCode);
     const oValue = overageValue(r, l, contract.currencyCode);
     cents += toCents(value) + toCents(oValue);
@@ -1684,9 +1711,8 @@ export interface PriceBookGap {
 }
 
 /**
- * #3205 W07: one device's row of billing evidence, collected during the line
- * loop and written only after the period claim succeeds (the period id does not
- * exist before then, and a lost claim deletes the draft anyway).
+ * One device's row of billing evidence. The period writer collects these until
+ * its claim succeeds; interactive materialization writes them with its lines.
  */
 interface PendingEvidence {
   invoiceLineId: string;
@@ -1695,6 +1721,27 @@ interface PendingEvidence {
   deviceRole: string;
   siteId: string | null;
   countedAs: InvoiceLineDeviceCountedAs;
+}
+
+/** Shared disposition and stable ordering for automated and interactive lines. */
+function evidenceForLine(
+  devices: readonly DeviceSnapshotRow[],
+  resolved: ResolvedQuantity,
+  materialized: MaterializedContractLine,
+): PendingEvidence[] {
+  const ordered = orderDevicesForEvidence(devices);
+  const cut = resolved.included === null ? ordered.length : Math.min(resolved.included, ordered.length);
+  return ordered.map((row, i) => {
+    const countedAs: InvoiceLineDeviceCountedAs =
+      i < cut ? 'included' : resolved.overageMode === 'bill' ? 'overage' : 'flagged';
+    if (countedAs === 'overage' && materialized.overageLine === null) {
+      throw new ContractServiceError('Overage evidence has no overage invoice line', 500, 'INVALID_STATE');
+    }
+    return {
+      invoiceLineId: countedAs === 'overage' ? materialized.overageLine!.id : materialized.baseLine.id,
+      deviceId: row.id, hostname: row.hostname, deviceRole: row.role, siteId: row.siteId, countedAs,
+    };
+  });
 }
 
 /** 500 rows/statement (#3205 W07 decision 16). One statement for a 5,000-device
@@ -1915,29 +1962,8 @@ export async function generateDueInvoice(contractId: string, asOf: Date = new Da
     }
     if (materialized.overage) overages.push(materialized.overage);
 
-    // Evidence for THIS line, from the one array the quantity came from.
-    // With a fixed allowance above the count, the base line bills the allowance
-    // while only existing devices get rows. Rows past the allowance attach to
-    // the overage sibling in bill mode and to the base in flag mode.
     if (ordered) {
-      const cut = r.included === null ? ordered.length : Math.min(r.included, ordered.length);
-      for (const [i, row] of ordered.entries()) {
-        const countedAs: InvoiceLineDeviceCountedAs =
-          i < cut ? 'included' : r.overageMode === 'bill' ? 'overage' : 'flagged';
-        if (countedAs === 'overage' && materialized.overageLine === null) {
-          throw new ContractServiceError(
-            `Overage evidence for contract line ${l.id} has no overage invoice line`, 500, 'INVALID_STATE',
-          );
-        }
-        pendingEvidence.push({
-          invoiceLineId: countedAs === 'overage' ? materialized.overageLine!.id : materialized.baseLine.id,
-          deviceId: row.id,
-          hostname: row.hostname,
-          deviceRole: row.role,
-          siteId: row.siteId,
-          countedAs,
-        });
-      }
+      for (const row of evidenceForLine(ordered, r, materialized)) pendingEvidence.push(row);
     }
   }
 


### PR DESCRIPTION
## Summary

- Interactive `manage_invoices add_contract_line` now records matched devices from the same snapshot used to calculate quantity, including allowance and overage disposition, and stamps `evidence_version` even for an empty device set.
- Evidence and invoice lines share the transaction. Automated generation retains its post-claim evidence writes; interactive edits leave period outcomes unchanged. Existing older lines are not backfilled.

## Linked Issues

Closes #4837

## Type of Change

- [x] Bug fix

## Testing

- [x] Existing affected tests pass: 363 tests across contract service, invoice tools/service, coverage, allowance, and evidence-reader suites (`pnpm --filter @breeze/api exec vitest run ... --maxWorkers=1`).
- [x] Added new tests: same-snapshot capture, bill/flag disposition, empty sets, chunk failure, and real-PostgreSQL manual/generated draft capture and rollback.
- [x] Private PostgreSQL/Redis integration stack: billing evidence suite, 21 tests passed. Application role verified non-superuser and without BYPASSRLS. Vitest reports an open-handle shutdown warning but exits successfully.
- [x] API typecheck: `NODE_OPTIONS=--max-old-space-size=12288 pnpm --filter @breeze/api exec tsc --noEmit`.

## Checklist

- [x] My code follows the project's code style
- [x] I have reviewed my own changes
- [x] I have tested on the relevant platforms
- [x] No secrets, credentials, or personal data included
