### PR TITLE
fix(scripts): preserve approved content and execution results

### DIFF
--- a/apps/api/src/services/aiAgentSdkTools.verifiedContext.test.ts
+++ b/apps/api/src/services/aiAgentSdkTools.verifiedContext.test.ts
@@ -50,6 +50,8 @@ vi.mock('./aiTools', async (importOriginal) => ({
 }));
 
 import { __test__ } from './aiAgentSdkTools';
+import { buildScriptBuilderTools } from './scriptBuilderTools';
+import type { PreToolUseCallback } from './aiAgentSdkTools';
 import type { ToolExecutionContext } from './toolExecutionContext';
 
 const { makeHandler } = __test__;
@@ -71,7 +73,18 @@ const verifiedContext = {
   },
 } as unknown as ToolExecutionContext;
 
-describe('makeHandler forwards pre-verified release material to executeTool (#3409 PR4c-1)', () => {
+describe.each([
+  { name: 'Fleet AI', makeHandler },
+  {
+    name: 'Script Builder',
+    makeHandler: (toolName: string, getAuth: () => typeof fakeAuth, onPreToolUse?: PreToolUseCallback) => {
+      const exposedName = toolName === 'run_script' ? 'execute_script_on_device' : toolName;
+      const registered = buildScriptBuilderTools(getAuth, onPreToolUse).find(t => t.name === exposedName);
+      if (!registered) throw new Error(`Missing tool: ${exposedName}`);
+      return (args: Record<string, unknown>) => registered.handler(args as never, undefined);
+    },
+  },
+])('$name forwards pre-verified release material to executeTool', ({ makeHandler }) => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockExecuteTool.mockResolvedValue(JSON.stringify({ ok: true }));
@@ -114,9 +127,9 @@ describe('makeHandler forwards pre-verified release material to executeTool (#34
 
   it('forwards the released intent id even when nothing was verified', async () => {
     const onPreToolUse = vi.fn(async () => ({ allowed: true as const, intentId: 'intent-2' }));
-    const handler = makeHandler('manage_ai_agents', () => fakeAuth, onPreToolUse);
+    const handler = makeHandler('run_script', () => fakeAuth, onPreToolUse);
 
-    await handler({ action: 'authorize_supervised_key' });
+    await handler({ scriptId: 'script-1', deviceIds: ['device-1'] });
 
     const call = mockExecuteTool.mock.calls[0]! as unknown as unknown[];
     expect(call).toHaveLength(4);

--- a/apps/api/src/services/scriptBuilderTools.ts
+++ b/apps/api/src/services/scriptBuilderTools.ts
@@ -16,6 +16,7 @@ import { scriptParameterDefinitionsSchema } from '@breeze/shared';
 import { compactToolResultForChat } from './aiToolOutput';
 import { captureException } from './sentry';
 import type { PreToolUseCallback, PostToolUseCallback } from './aiAgentSdkTools';
+import type { ToolExecutionContext } from './toolExecutionContext';
 import { sanitizeThrownToolError } from './aiToolErrors';
 import { normalizeScriptCode } from './scriptCodeNormalize';
 
@@ -113,9 +114,10 @@ function makeExistingHandler(
 
   return async (args: Record<string, unknown>) => {
     const startTime = Date.now();
+    let verifiedContext: ToolExecutionContext | undefined;
 
     if (onPreToolUse) {
-      let check: { allowed: true } | { allowed: false; error: string };
+      let check: Awaited<ReturnType<PreToolUseCallback>>;
       try {
         check = await onPreToolUse(toolName, args, exposedToolName);
       } catch (err) {
@@ -131,6 +133,12 @@ function makeExistingHandler(
         }
         return { content: [{ type: 'text' as const, text: safeError }], isError: true };
       }
+      // Carry the exact script/variable material verified for approval, as
+      // the Fleet AI handler does. Re-reading it would reopen the gap between
+      // verifying the approved digest and dispatching the script.
+      verifiedContext = check.intentId
+        ? { ...check.context, actionIntentId: check.intentId }
+        : check.context;
     }
 
     try {
@@ -152,7 +160,9 @@ function makeExistingHandler(
         runOutsideDbContext(() =>
           withDbAccessContext(
             dbAccessContextFromAuth(auth),
-            () => executeTool(toolName, args, auth),
+            () => verifiedContext
+              ? executeTool(toolName, args, auth, { context: verifiedContext })
+              : executeTool(toolName, args, auth),
           ),
         ),
         TOOL_EXECUTION_TIMEOUT_MS,

--- a/apps/web/src/components/devices/DeviceScriptHistory.test.tsx
+++ b/apps/web/src/components/devices/DeviceScriptHistory.test.tsx
@@ -202,6 +202,33 @@ describe('DeviceScriptHistory highlighted execution (#4886)', () => {
     expect(screen.queryByText('Execution Details')).toBeNull();
   });
 
+  it('updates an open highlighted execution when polling returns completed output', async () => {
+    vi.useFakeTimers();
+    let completed = false;
+    fetchWithAuthMock.mockImplementation(async () => jsonResponse({ data: [{
+      ...executionRow,
+      status: completed ? 'completed' : 'pending',
+      stdout: completed ? 'fresh completion output' : '',
+      exitCode: completed ? 0 : null,
+      completedAt: completed ? executionRow.completedAt : null,
+    }] }));
+    try {
+      render(<DeviceScriptHistory deviceId={DEVICE_ID} highlightExecutionId="exec-1" />);
+      await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+      expect(screen.getByText('Execution Details')).toBeInTheDocument();
+      expect(screen.queryByText('fresh completion output')).toBeNull();
+
+      completed = true;
+      await act(async () => { await vi.advanceTimersByTimeAsync(10000); });
+
+      expect(screen.getByText('Execution Details')).toBeInTheDocument();
+      expect(screen.getByText('fresh completion output')).toBeInTheDocument();
+      expect(screen.getByText('Completed', { selector: 'p' })).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   // Guards `autoOpenedHighlightRef` (DeviceScriptHistory.tsx): the 10s poll
   // refresh must not keep resurrecting a modal the operator already dismissed.
   it('does not reopen the highlighted execution after it is closed once a 10s poll refresh runs', async () => {

--- a/apps/web/src/components/devices/DeviceScriptHistory.tsx
+++ b/apps/web/src/components/devices/DeviceScriptHistory.tsx
@@ -224,7 +224,12 @@ export default function DeviceScriptHistory({ deviceId, timezone, highlightExecu
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string>();
   const [siteTimezone, setSiteTimezone] = useState<string | undefined>(timezone);
-  const [selectedExecution, setSelectedExecution] = useState<ScriptExecution | null>(null);
+  const [selectedExecutionSnapshot, setSelectedExecution] = useState<ScriptExecution | null>(null);
+  // Follow refreshed results while details are open, retaining the last
+  // selected row if it falls outside the history endpoint's latest 50 runs.
+  const selectedExecution = selectedExecutionSnapshot && (
+    executions.find(item => item.id && item.id === selectedExecutionSnapshot.id) ?? selectedExecutionSnapshot
+  );
   // #4885 "Run again" — the fetched script definition (parameters, OS types,
   // runAs) needed to open ScriptExecutionModal, plus the loading/error state
   // for that fetch. Cleared on close so a stale script never lingers across

--- a/apps/web/src/components/scripts/ScriptTestRunner.test.tsx
+++ b/apps/web/src/components/scripts/ScriptTestRunner.test.tsx
@@ -632,7 +632,10 @@ describe('ScriptTestRunner post-run actions (#4885 / #4886)', () => {
 
   async function runToCompletion(execute: () => void) {
     fetchWithAuthMock.mockImplementation(async (url: string, init?: RequestInit) => {
-      if (url.startsWith('/devices')) return jsonResponse({ data: [onlineDevice] });
+      if (url.startsWith('/devices')) return jsonResponse({ data: [
+        onlineDevice,
+        { ...onlineDevice, id: 'second-device', hostname: 'second-box' },
+      ] });
       if (url === `/scripts/${SCRIPT_ID}/execute` && init?.method === 'POST') {
         execute();
         return jsonResponse({
@@ -687,4 +690,15 @@ describe('ScriptTestRunner post-run actions (#4885 / #4886)', () => {
 
     expect(screen.queryByTestId('test-view-on-device')).toBeNull();
   });
+
+  it('keeps the completed execution link on its original device after changing the next target', async () => {
+    await runToCompletion(() => {});
+
+    fireEvent.change(screen.getByTestId('test-device-select'), { target: { value: 'second-device' } });
+
+    expect(screen.getByTestId('test-device-select')).toHaveValue('second-device');
+    expect(screen.getByTestId('test-view-on-device')).toHaveAttribute(
+      'href', `/devices/${DEVICE_ID}#scripts/${EXECUTION_ID}`
+    );
+  }, 10000);
 });

--- a/apps/web/src/components/scripts/ScriptTestRunner.tsx
+++ b/apps/web/src/components/scripts/ScriptTestRunner.tsx
@@ -93,6 +93,7 @@ export default function ScriptTestRunner({
   const [selectedDeviceId, setSelectedDeviceId] = useState<string>('');
   const [phase, setPhase] = useState<'idle' | 'saving' | 'starting' | 'polling'>('idle');
   const [execution, setExecution] = useState<TestRunExecution | null>(null);
+  const [executionDeviceId, setExecutionDeviceId] = useState<string>('');
   const [runError, setRunError] = useState<string | null>(null);
   // Set when polling gave up (permanent poll error / deadline) so the user can
   // re-read THAT execution instead of starting a second run on a real device.
@@ -354,6 +355,7 @@ export default function ScriptTestRunner({
         return;
       }
 
+      setExecutionDeviceId(selectedDeviceId);
       setExecution({ id: executionId, status: 'pending' });
       onExecutionChange?.(executionId);
       setPhase('polling');
@@ -471,9 +473,9 @@ export default function ScriptTestRunner({
             the device's own Scripts tab (same hash convention as the
             post-run redirects elsewhere) rather than only the script-wide
             history list. */}
-        {execution?.id && selectedDeviceId && (
+        {execution?.id && executionDeviceId && (
           <a
-            href={deviceScriptsHref(selectedDeviceId, execution.id)}
+            href={deviceScriptsHref(executionDeviceId, execution.id)}
             data-testid="test-view-on-device"
             className="ml-auto inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
           >
@@ -486,7 +488,7 @@ export default function ScriptTestRunner({
             href={`/scripts/${scriptId}/executions`}
             className={cn(
               'inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground',
-              !(execution?.id && selectedDeviceId) && 'ml-auto'
+              !(execution?.id && executionDeviceId) && 'ml-auto'
             )}
           >
             {t('testRunner.viewHistory')}

--- a/apps/web/src/components/scripts/ScriptsPage.test.tsx
+++ b/apps/web/src/components/scripts/ScriptsPage.test.tsx
@@ -251,4 +251,37 @@ describe('ScriptsPage post-run navigation (#4886)', () => {
     await waitFor(() => expect(fetchWithAuthMock.mock.calls.some(([url]) => String(url) === '/scripts/script-1/execute')).toBe(true));
     expect(navigateTo).not.toHaveBeenCalled();
   });
+
+  it('keeps partial admission results on the page when one target is suppressed', async () => {
+    const { navigateTo } = await import('@/lib/navigation');
+    let scriptsFetchCount = 0;
+    fetchWithAuthMock.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.startsWith('/scripts?')) {
+        scriptsFetchCount += 1;
+        return makeJsonResponse({ data: [baseScript] });
+      }
+      if (url === '/orgs/sites') return makeJsonResponse({ data: [] });
+      if (url === '/scripts/script-1') return makeJsonResponse(baseScript);
+      if (url === '/scripts/script-1/execute') {
+        return makeJsonResponse({
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+          status: 'partially_queued',
+          targets: [
+            { requestedDeviceId: 'device-1', admission: 'admitted', executionId: 'execution-1' },
+            { requestedDeviceId: 'device-2', admission: 'suppressed', reasonCode: 'maintenance_suppressed' },
+          ],
+        }, true, 201);
+      }
+      return makeJsonResponse({}, false, 404);
+    });
+
+    render(<ScriptsPage />);
+    fireEvent.click(await screen.findByText('Run Cleanup Temp Files'));
+    fireEvent.click(await screen.findByText('Confirm Execute Multi'));
+
+    await waitFor(() => expect(scriptsFetchCount).toBe(2));
+    expect(navigateTo).not.toHaveBeenCalled();
+    expect(screen.getByText('Confirm Execute Multi')).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/scripts/ScriptsPage.tsx
+++ b/apps/web/src/components/scripts/ScriptsPage.tsx
@@ -165,6 +165,9 @@ export default function ScriptsPage() {
       // already uses for anomalies), where the new execution is expanded live;
       // a multi-device run has no single "the" device, so it goes to the
       // script's execution-history list instead.
+      // Keep partial admission results visible so the operator can inspect
+      // blocked or suppressed targets before leaving the execute flow.
+      if (admittedTargets.length !== data.targets.length) return data;
       if (deviceIds.length === 1) {
         void navigateTo(deviceScriptsHref(deviceIds[0]!, admittedTargets[0]?.executionId));
       } else {


### PR DESCRIPTION
Script Builder now passes the approval-verified script and variable snapshot, together with the released intent ID, into execution. Previously it discarded that context and reread mutable content after approval verification, reopening the check/use window.

The post-run UI now preserves partial batch results so blocked or suppressed targets remain visible, refreshes open execution details as polling returns status and output, and keeps Test Run's device link attached to the device that actually ran the script when the next target selection changes.

Validation:
- 206 API tests passed, including shared Fleet AI/Script Builder approval-context tests that failed before the fix.
- 39 web tests passed, including partial admissions, pending-to-completed detail updates, and changing the next target after a completed run.
- API and web TypeScript checks passed; API required an 8 GB Node heap.
- ESLint and diff whitespace checks passed.

Clone authorization and name-length fixes are in PR #4897.
