### PR TITLE
fix(agent): run brew cleanup --prune=all after Homebrew upgrade batches (#4912)

### DIFF
--- a/agent/internal/patching/homebrew.go
+++ b/agent/internal/patching/homebrew.go
@@ -38,6 +38,17 @@ type HomebrewProvider struct {
 	cleanupTimer    *time.Timer
 	cleanupDebounce time.Duration // overridden in tests; <=0 means use defaultCleanupDebounce
 	cleanupFunc     func()        // overridden in tests; nil means use h.runBrewCleanup
+
+	// brewMutateMu serializes brew invocations that mutate the
+	// Cellar/Caskroom (upgrade, uninstall, cleanup) against each other.
+	// scheduleCleanup's debounced cleanup fires on its own timer goroutine,
+	// independent of whatever Install/Uninstall call scheduled it — without
+	// this, a cleanup firing mid-batch (e.g. one package's upgrade running
+	// longer than defaultCleanupDebounce, which patchMutateTimeout allows up
+	// to 30 minutes for) could run `brew cleanup --prune=all` concurrently
+	// with an in-flight `brew upgrade`/`brew uninstall`, and Homebrew does
+	// not guarantee that's safe.
+	brewMutateMu sync.Mutex
 }
 
 // defaultCleanupDebounce is how long scheduleCleanup waits after the most
@@ -245,7 +256,9 @@ func (h *HomebrewProvider) Install(patchID string) (InstallResult, error) {
 	}
 	args = append(args, name)
 
+	h.brewMutateMu.Lock()
 	output, err := h.brewCombinedOutput(patchMutateTimeout, args...)
+	h.brewMutateMu.Unlock()
 	if err != nil {
 		return InstallResult{}, fmt.Errorf("brew upgrade failed: %w: %s", err, truncatePatchOutput(output))
 	}
@@ -272,6 +285,12 @@ func brewCleanupArgs() []string {
 // consecutive Install calls (one job upgrading N formulae/casks) triggers
 // exactly one cleanup run, fired shortly after the last package in the
 // batch finishes — not once per package. Safe to call concurrently.
+//
+// The debounce timer is in-memory only: if the agent process exits between
+// an Install and the timer firing, that scheduled cleanup is silently
+// dropped with no persistence or retry-on-restart. This is an accepted
+// best-effort gap (matching the issue's "log but never fail the job"
+// framing) — the next patch batch schedules its own cleanup regardless.
 func (h *HomebrewProvider) scheduleCleanup() {
 	h.cleanupMu.Lock()
 	defer h.cleanupMu.Unlock()
@@ -304,7 +323,11 @@ func (h *HomebrewProvider) runBrewCleanup() {
 		return
 	}
 
+	// Serialized against Install/Uninstall via brewMutateMu — see its
+	// doc comment on HomebrewProvider for why.
+	h.brewMutateMu.Lock()
 	output, err := runCmdCombinedOutputWithTimeout(cmd, patchMutateTimeout)
+	h.brewMutateMu.Unlock()
 	if err != nil {
 		log.Warn("brew cleanup failed", "error", err, "output", truncatePatchOutput(output))
 		return
@@ -325,7 +348,9 @@ func (h *HomebrewProvider) Uninstall(patchID string) error {
 	}
 	args = append(args, name)
 
+	h.brewMutateMu.Lock()
 	output, err := h.brewCombinedOutput(patchMutateTimeout, args...)
+	h.brewMutateMu.Unlock()
 	if err != nil {
 		return fmt.Errorf("brew uninstall failed: %w: %s", err, truncatePatchOutput(output))
 	}

--- a/agent/internal/patching/homebrew.go
+++ b/agent/internal/patching/homebrew.go
@@ -11,6 +11,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -27,7 +28,27 @@ const brewCaskPrefix = "cask:"
 var ErrBrewUnavailable = errors.New("homebrew not installed")
 
 // HomebrewProvider integrates with Homebrew on macOS.
-type HomebrewProvider struct{}
+//
+// A single HomebrewProvider is constructed once and lives for the process
+// lifetime (see NewDefaultManager), which is what makes the cleanup
+// debounce below safe to hold as instance state rather than needing to
+// thread it through the caller.
+type HomebrewProvider struct {
+	cleanupMu       sync.Mutex
+	cleanupTimer    *time.Timer
+	cleanupDebounce time.Duration // overridden in tests; <=0 means use defaultCleanupDebounce
+	cleanupFunc     func()        // overridden in tests; nil means use h.runBrewCleanup
+}
+
+// defaultCleanupDebounce is how long scheduleCleanup waits after the most
+// recent successful Install before actually running `brew cleanup`. Patch
+// jobs install packages one at a time in a tight loop (see
+// executePatchInstallCommand in agent/internal/heartbeat), so a batch of N
+// upgrades calls scheduleCleanup N times in quick succession; each call
+// resets the timer, so only the last one in the batch survives to fire —
+// giving "once per batch" behavior (issue #4912) without the provider
+// interface needing a separate batch-end hook.
+const defaultCleanupDebounce = 30 * time.Second
 
 // NewHomebrewProvider creates a new HomebrewProvider.
 func NewHomebrewProvider() *HomebrewProvider {
@@ -229,10 +250,67 @@ func (h *HomebrewProvider) Install(patchID string) (InstallResult, error) {
 		return InstallResult{}, fmt.Errorf("brew upgrade failed: %w: %s", err, truncatePatchOutput(output))
 	}
 
+	// Cleanup after a successful upgrade only — never per package (see
+	// scheduleCleanup) and never able to fail this job, since it runs
+	// asynchronously after InstallResult has already been returned below.
+	h.scheduleCleanup()
+
 	return InstallResult{
 		PatchID: patchID,
 		Message: truncatePatchOutput(output),
 	}, nil
+}
+
+// brewCleanupArgs builds the `brew cleanup --prune=all` args. Pure and
+// table-testable independent of any process execution, matching the
+// ensureBrewArgs/ensureBrewListArgs convention in this file.
+func brewCleanupArgs() []string {
+	return []string{"cleanup", "--prune=all"}
+}
+
+// scheduleCleanup debounces `brew cleanup --prune=all` so a batch of
+// consecutive Install calls (one job upgrading N formulae/casks) triggers
+// exactly one cleanup run, fired shortly after the last package in the
+// batch finishes — not once per package. Safe to call concurrently.
+func (h *HomebrewProvider) scheduleCleanup() {
+	h.cleanupMu.Lock()
+	defer h.cleanupMu.Unlock()
+
+	fn := h.cleanupFunc
+	if fn == nil {
+		fn = h.runBrewCleanup
+	}
+
+	debounce := h.cleanupDebounce
+	if debounce <= 0 {
+		debounce = defaultCleanupDebounce
+	}
+
+	if h.cleanupTimer != nil {
+		h.cleanupTimer.Stop()
+	}
+	h.cleanupTimer = time.AfterFunc(debounce, fn)
+}
+
+// runBrewCleanup actually runs `brew cleanup --prune=all` through the same
+// brewCommand() path Scan/Install/Uninstall use, so it executes as the
+// console user via sudo -n -H -u when the agent is running as root.
+// Cleanup is best-effort maintenance: any failure is logged (warn) and
+// swallowed, never surfaced to the patch job that triggered it.
+func (h *HomebrewProvider) runBrewCleanup() {
+	cmd, err := h.brewCommand(brewCleanupArgs()...)
+	if err != nil {
+		log.Warn("brew cleanup: could not build command", "error", err)
+		return
+	}
+
+	output, err := runCmdCombinedOutputWithTimeout(cmd, patchMutateTimeout)
+	if err != nil {
+		log.Warn("brew cleanup failed", "error", err, "output", truncatePatchOutput(output))
+		return
+	}
+
+	log.Info("brew cleanup completed", "output", truncatePatchOutput(output))
 }
 
 // Uninstall removes a Homebrew formula or cask.

--- a/agent/internal/patching/homebrew_test.go
+++ b/agent/internal/patching/homebrew_test.go
@@ -10,6 +10,7 @@ import (
 	"os/user"
 	"reflect"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -505,13 +506,17 @@ func TestScheduleCleanupCoalescesABatch(t *testing.T) {
 	h := &HomebrewProvider{}
 	var calls int32
 	h.cleanupFunc = func() { atomic.AddInt32(&calls, 1) }
-	h.cleanupDebounce = 20 * time.Millisecond
+	// The debounce is generously wide relative to the inter-call sleeps
+	// below (20x) so scheduler jitter on a loaded CI runner can't let an
+	// earlier timer fire before a later scheduleCleanup call resets it —
+	// a real flake risk caught in PR review at tighter margins.
+	h.cleanupDebounce = 200 * time.Millisecond
 
 	// Simulate 3 packages finishing install back-to-back within one batch.
 	h.scheduleCleanup()
-	time.Sleep(5 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 	h.scheduleCleanup()
-	time.Sleep(5 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 	h.scheduleCleanup()
 
 	// Nothing should have fired yet — still inside the debounce window.
@@ -519,10 +524,41 @@ func TestScheduleCleanupCoalescesABatch(t *testing.T) {
 		t.Fatalf("cleanup fired before the batch went quiet: got %d calls", got)
 	}
 
-	time.Sleep(80 * time.Millisecond) // well past the debounce window
+	time.Sleep(600 * time.Millisecond) // well past the debounce window
 
 	if got := atomic.LoadInt32(&calls); got != 1 {
 		t.Fatalf("expected exactly 1 coalesced cleanup call for the batch, got %d", got)
+	}
+}
+
+// TestScheduleCleanupConcurrentCallsAreRaceFree proves cleanupMu actually
+// serializes concurrent scheduleCleanup calls under go test -race, rather
+// than only ever being exercised sequentially. This mirrors the real
+// production contention: Install() calling scheduleCleanup while an earlier
+// scheduled cleanup timer may still be pending.
+func TestScheduleCleanupConcurrentCallsAreRaceFree(t *testing.T) {
+	h := &HomebrewProvider{}
+	var calls int32
+	h.cleanupFunc = func() { atomic.AddInt32(&calls, 1) }
+	h.cleanupDebounce = 20 * time.Millisecond
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			h.scheduleCleanup()
+		}()
+	}
+	wg.Wait()
+
+	time.Sleep(200 * time.Millisecond)
+
+	// The race detector is the real assertion here (no data race on
+	// cleanupTimer); the count just confirms the storm still settled to a
+	// cleanup firing rather than being left permanently pending.
+	if got := atomic.LoadInt32(&calls); got < 1 {
+		t.Fatalf("expected at least 1 cleanup call after concurrent scheduling, got %d", got)
 	}
 }
 
@@ -602,6 +638,28 @@ func TestInstallDoesNotScheduleCleanupOnFailure(t *testing.T) {
 	if got := atomic.LoadInt32(&calls); got != 0 {
 		t.Fatalf("a failed Install must not schedule cleanup, got %d calls", got)
 	}
+}
+
+// TestRunBrewCleanupExecutesRealCleanup exercises the actual (non-injected)
+// cleanup path end-to-end against real brew — brewCleanupArgs() ->
+// brewCommand() -> runCmdCombinedOutputWithTimeout — matching this file's
+// existing skip-if-unavailable convention. Every other cleanup test above
+// injects cleanupFunc, so this is the only coverage of runBrewCleanup
+// itself. `brew cleanup --prune=all` is a safe, idempotent maintenance
+// operation to run for real.
+func TestRunBrewCleanupExecutesRealCleanup(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("brew rejects root execution")
+	}
+	if _, err := exec.LookPath("brew"); err != nil {
+		t.Skip("brew not installed")
+	}
+
+	h := &HomebrewProvider{}
+	// runBrewCleanup swallows all its own errors (by design — see its doc
+	// comment), so there's nothing to assert on here beyond "the real path
+	// runs to completion without panicking."
+	h.runBrewCleanup()
 }
 
 func TestBrewInstallCaskCallsUpgradeCask(t *testing.T) {

--- a/agent/internal/patching/homebrew_test.go
+++ b/agent/internal/patching/homebrew_test.go
@@ -10,7 +10,9 @@ import (
 	"os/user"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestSetEnvNewKey(t *testing.T) {
@@ -479,6 +481,126 @@ func TestEnsureBrewInstalledUnknownPackageFailsRatherThanFallback(t *testing.T) 
 	}
 	if errors.Is(err, ErrBrewUnavailable) {
 		t.Fatal("a real brew install failure is not manager-unavailable")
+	}
+}
+
+// --- Post-install cleanup (#4912): brew cleanup --prune=all, once per
+// batch (debounced/coalesced), never per package, never failing the job. ---
+
+func TestBrewCleanupArgs(t *testing.T) {
+	got := brewCleanupArgs()
+	want := []string{"cleanup", "--prune=all"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("brewCleanupArgs() = %v, want %v", got, want)
+	}
+}
+
+// TestScheduleCleanupCoalescesABatch pins the "not per package" contract from
+// #4912: several scheduleCleanup calls fired in quick succession (as would
+// happen for consecutive packages in one Install batch) must coalesce into
+// exactly one cleanup invocation, run once after the batch goes quiet — not
+// once per call. Uses an injected cleanupFunc/cleanupDebounce so it never
+// shells out to real brew and stays fast/deterministic.
+func TestScheduleCleanupCoalescesABatch(t *testing.T) {
+	h := &HomebrewProvider{}
+	var calls int32
+	h.cleanupFunc = func() { atomic.AddInt32(&calls, 1) }
+	h.cleanupDebounce = 20 * time.Millisecond
+
+	// Simulate 3 packages finishing install back-to-back within one batch.
+	h.scheduleCleanup()
+	time.Sleep(5 * time.Millisecond)
+	h.scheduleCleanup()
+	time.Sleep(5 * time.Millisecond)
+	h.scheduleCleanup()
+
+	// Nothing should have fired yet — still inside the debounce window.
+	if got := atomic.LoadInt32(&calls); got != 0 {
+		t.Fatalf("cleanup fired before the batch went quiet: got %d calls", got)
+	}
+
+	time.Sleep(80 * time.Millisecond) // well past the debounce window
+
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("expected exactly 1 coalesced cleanup call for the batch, got %d", got)
+	}
+}
+
+// TestScheduleCleanupRunsAgainForANewBatch verifies coalescing doesn't
+// swallow a *second*, later batch — cleanup must still fire once per batch,
+// not "once ever".
+func TestScheduleCleanupRunsAgainForANewBatch(t *testing.T) {
+	h := &HomebrewProvider{}
+	var calls int32
+	h.cleanupFunc = func() { atomic.AddInt32(&calls, 1) }
+	h.cleanupDebounce = 15 * time.Millisecond
+
+	h.scheduleCleanup()
+	time.Sleep(50 * time.Millisecond)
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("expected 1 call after first batch settled, got %d", got)
+	}
+
+	h.scheduleCleanup()
+	time.Sleep(50 * time.Millisecond)
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Fatalf("expected 2 calls after a second batch settled, got %d", got)
+	}
+}
+
+// TestInstallSchedulesCleanupOnSuccess exercises the real Install() path: a
+// successful upgrade (brew exits 0 even when the formula is already
+// up-to-date — verified against real brew) must schedule cleanup. A failed
+// Install (invalid/nonexistent package) must NOT.
+func TestInstallSchedulesCleanupOnSuccess(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("brew rejects root execution")
+	}
+	if _, err := exec.LookPath("brew"); err != nil {
+		t.Skip("brew not installed")
+	}
+
+	h := &HomebrewProvider{}
+	installed, err := h.GetInstalled()
+	if err != nil || len(installed) == 0 {
+		t.Skip("no installed formula/cask available to probe against")
+	}
+	name, _ := parseBrewID(installed[0].ID)
+
+	var calls int32
+	h.cleanupFunc = func() { atomic.AddInt32(&calls, 1) }
+	h.cleanupDebounce = 10 * time.Millisecond
+
+	if _, err := h.Install(name); err != nil {
+		t.Fatalf("Install(%q) unexpected error: %v", name, err)
+	}
+
+	time.Sleep(60 * time.Millisecond)
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("expected successful Install to schedule exactly 1 cleanup, got %d", got)
+	}
+}
+
+func TestInstallDoesNotScheduleCleanupOnFailure(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("brew rejects root execution")
+	}
+	if _, err := exec.LookPath("brew"); err != nil {
+		t.Skip("brew not installed")
+	}
+
+	h := &HomebrewProvider{}
+	var calls int32
+	h.cleanupFunc = func() { atomic.AddInt32(&calls, 1) }
+	h.cleanupDebounce = 10 * time.Millisecond
+
+	if _, err := h.Install("nonexistent-package-xyz-12345"); err == nil {
+		t.Fatal("expected error installing nonexistent package")
+	}
+
+	time.Sleep(60 * time.Millisecond)
+	if got := atomic.LoadInt32(&calls); got != 0 {
+		t.Fatalf("a failed Install must not schedule cleanup, got %d calls", got)
 	}
 }
 

--- a/apps/docs/src/content/docs/features/patch-management.mdx
+++ b/apps/docs/src/content/docs/features/patch-management.mdx
@@ -62,7 +62,7 @@ Compliance reports give you a point-in-time snapshot of your fleet's patch statu
 
 ## Third-Party Application Patching
 
-Beyond operating-system updates, Breeze patches third-party applications detected via **winget** on Windows devices — browsers, runtimes, and productivity tools such as Chrome, Firefox, Edge, Zoom, Teams, Git, Node.js, Python, and Visual Studio Code. These patches flow through the same approval, deployment, and rollback workflow as OS patches.
+Beyond operating-system updates, Breeze patches third-party applications detected via **winget** on Windows devices — browsers, runtimes, and productivity tools such as Chrome, Firefox, Edge, Zoom, Teams, Git, Node.js, Python, and Visual Studio Code. These patches flow through the same approval, deployment, and rollback workflow as OS patches. On macOS, the equivalent engine upgrades Homebrew formulae and casks, running `brew cleanup --prune=all` after a batch of upgrades to prune outdated kegs and cached downloads instead of leaving that to Homebrew's own periodic cleanup.
 
 ### How Windows Third-Party Patching Runs
 


### PR DESCRIPTION
## Problem

The macOS third-party patch provider (`agent/internal/patching/homebrew.go`) upgrades Homebrew formulae and casks via `Install` but never prunes old kegs and cached downloads. They accumulate until Homebrew's own periodic cleanup fires as a side effect of some later `brew` invocation (every 30 days by default).

## Fix

`HomebrewProvider.Install` now schedules `brew cleanup --prune=all` after a successful upgrade, run through the existing `brewCommand()` path — so it executes as the console user via `sudo -n -H -u` exactly like every other brew invocation in this file. Cleanup failures are logged (`log.Warn`) and never fail the job.

## Design decisions (as asked for in the issue)

- **Batch vs. per-package placement:** `PatchProvider.Install(patchID string)` is per-package with no batch-end hook, and the caller (`executePatchInstallCommand` in `agent/internal/heartbeat/heartbeat.go`) simply loops over `h.patchMgr.Install(installID)` for each patch ref in a job — there's no existing concept of "batch end" to hook into, and neither `apt.go` nor `winget_system.go` (the two providers named in the issue) do any post-install batch-level work to be consistent with. Rather than change the `PatchProvider` interface or the caller (out of scope per the issue's affected-files list), I implemented this entirely inside `homebrew.go`: `Install` calls `scheduleCleanup()`, which debounces on a `*HomebrewProvider`-scoped timer (30s default). A `HomebrewProvider` instance is constructed once and lives for the process lifetime (`NewDefaultManager`), so it's safe to hold this state on the struct. Consecutive `Install` calls for one job's packages arrive well within the debounce window and each resets the timer, so only the last one survives to fire — one `brew cleanup` per batch, not per package. As a side effect, since cleanup runs asynchronously after `Install` already returned, a cleanup failure is structurally incapable of failing the job.
- **No new policy toggle:** the issue's proposed fix optionally suggested a `brewCleanup: true` patch-source setting. There is no existing agent-side patch-source settings slot for Homebrew to hang a toggle off (checked `internal/config` and `internal/patching` — patch policy config lives on the API/server side, not as per-provider agent config), so per the "no new toggle unless there's an obvious slot" guidance, none was added. Cleanup ships unconditionally after a successful upgrade batch.

## Tests

Wrote failing tests first in `agent/internal/patching/homebrew_test.go` (confirmed a compile-failure red before implementing):
- `TestBrewCleanupArgs` — pure arg-construction test for `brew cleanup --prune=all`.
- `TestScheduleCleanupCoalescesABatch` / `TestScheduleCleanupRunsAgainForANewBatch` — deterministic, fast (injected `cleanupFunc`/`cleanupDebounce`, no real `brew`) tests proving the debounce coalesces a batch into exactly one cleanup call, and that a later batch still gets its own call.
- `TestInstallSchedulesCleanupOnSuccess` / `TestInstallDoesNotScheduleCleanupOnFailure` — integration-style tests (skip if brew unavailable / running as root, matching this file's existing convention) exercising the real `Install()` path against an already-installed formula (verified locally that `brew upgrade <up-to-date-formula>` exits 0) and a nonexistent package.

Also added one sentence to `apps/docs/src/content/docs/features/patch-management.mdx` (Third-Party Application Patching section) noting the macOS engine runs `brew cleanup --prune=all` after a batch of upgrades.

## Verification

```
$ cd agent && go vet ./internal/patching/...
(clean, no output)

$ cd agent && go test -race -count=1 ./internal/patching/...
ok  	github.com/breeze-rmm/agent/internal/patching	8.446s
ok  	github.com/breeze-rmm/agent/internal/patching/linuxsession	1.736s
```

Closes #4912

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V51pUwJs69Rmb899D4x8R1