### PR TITLE
fix(mobile,api,web): approval takeover, chat hang, ticket keyboard, upload errors from iOS test

### DIFF
--- a/apps/api/src/services/actionIntents/actionLabel.test.ts
+++ b/apps/api/src/services/actionIntents/actionLabel.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildActionLabel } from './actionLabel';
+
+describe('buildActionLabel', () => {
+  it('prefers the guardrail description and softens its shouted verb', () => {
+    expect(
+      buildActionLabel({
+        toolName: 'manage_services',
+        input: { deviceId: '6eae0f70-8da9-49ff-9e18-c241698975f3', action: 'restart', serviceName: 'Spooler' },
+        reason: 'RESTART service "Spooler" on device 6eae0f70...',
+      }),
+    ).toBe('Restart service "Spooler" on device 6eae0f70...');
+  });
+
+  it('swaps the device-id stub for the hostname when known', () => {
+    expect(
+      buildActionLabel({
+        toolName: 'execute_command',
+        input: { commandType: 'restart_service' },
+        reason: 'Execute "restart_service" command on device 6eae0f70...',
+        deviceHostname: 'KIT',
+      }),
+    ).toBe('Execute "restart_service" command on KIT');
+  });
+
+  it('never returns the raw call signature when the reason is missing', () => {
+    const label = buildActionLabel({
+      toolName: 'manage_services',
+      input: { deviceId: '6eae0f70-8da9-49ff-9e18-c241698975f3', action: 'restart', serviceName: 'Spooler' },
+      reason: null,
+    });
+    expect(label).toBe('Manage services: restart Spooler');
+    expect(label).not.toContain('deviceId=');
+  });
+
+  it('falls back to the tool name alone when nothing recognisable is present', () => {
+    expect(buildActionLabel({ toolName: 'run_script', input: { scriptId: 'abc' } })).toBe('Run script');
+  });
+
+  it('leaves an already-human M365 summary untouched apart from whitespace', () => {
+    expect(
+      buildActionLabel({
+        toolName: 'm365_reset_password',
+        input: {},
+        reason: '  Reset password for  jane@contoso.com  (Contoso Ltd)  ',
+      }),
+    ).toBe('Reset password for jane@contoso.com (Contoso Ltd)');
+  });
+
+  it('caps runaway descriptions', () => {
+    const label = buildActionLabel({ toolName: 'x', input: {}, reason: 'a'.repeat(400) });
+    expect(label.length).toBeLessThanOrEqual(140);
+    expect(label.endsWith('…')).toBe(true);
+  });
+});

--- a/apps/api/src/services/actionIntents/actionLabel.ts
+++ b/apps/api/src/services/actionIntents/actionLabel.ts
@@ -1,0 +1,63 @@
+/**
+ * The one-line, human headline for an action-intent approval.
+ *
+ * Shown as the 28pt title on the mobile takeover, as the push notification
+ * body, and in the in-app bell. It used to be the raw call signature
+ * (`manage_services(deviceId=6eae0f70-…, action=restart, serviceName=Spooler)`),
+ * which is audit data, not something a technician should have to parse with
+ * their thumb on Approve. The signature is still persisted as
+ * `targetSummary` / `actionArguments` for the details card.
+ */
+
+const MAX_LABEL_LENGTH = 140;
+
+/** `on device 6eae0f70...` as emitted by aiGuardrails.buildApprovalDescription. */
+const DEVICE_ID_STUB = /\bon device [0-9a-f]{8}\.\.\./i;
+
+function titleCaseWords(snake: string): string {
+  return snake
+    .split(/[_\s]+/)
+    .filter(Boolean)
+    .map((w, i) => (i === 0 ? w.charAt(0).toUpperCase() + w.slice(1).toLowerCase() : w.toLowerCase()))
+    .join(' ');
+}
+
+/** `RESTART service "Spooler"` → `Restart service "Spooler"`. */
+function softenLeadingShout(text: string): string {
+  return text.replace(/^([A-Z]{2,})(?=\s)/, (w) => w.charAt(0) + w.slice(1).toLowerCase());
+}
+
+function str(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+/**
+ * Fallback when the guardrail produced no description: the tool name in
+ * words plus the one or two arguments a human would actually recognise.
+ */
+function fallbackLabel(toolName: string, input: Record<string, unknown>): string {
+  const head = titleCaseWords(toolName);
+  const detail = [
+    str(input.action) ?? str(input.commandType),
+    str(input.serviceName) ?? str(input.processName) ?? str(input.scriptName) ?? str(input.name),
+  ].filter((v): v is string => v !== null);
+  return detail.length > 0 ? `${head}: ${detail.join(' ')}` : head;
+}
+
+export interface ActionLabelInput {
+  toolName: string;
+  input: Record<string, unknown>;
+  /** The guardrail's call-specific description (`createActionIntent`'s `reason`). */
+  reason?: string | null;
+  /** Resolved target hostname, so "on device 6eae0f70..." becomes "on KIT". */
+  deviceHostname?: string | null;
+}
+
+export function buildActionLabel(args: ActionLabelInput): string {
+  const base = str(args.reason) ?? fallbackLabel(args.toolName, args.input);
+  let label = softenLeadingShout(base);
+  const host = str(args.deviceHostname);
+  if (host) label = label.replace(DEVICE_ID_STUB, `on ${host}`);
+  label = label.replace(/\s+/g, ' ').trim();
+  return label.length > MAX_LABEL_LENGTH ? `${label.slice(0, MAX_LABEL_LENGTH - 1)}…` : label;
+}

--- a/apps/api/src/services/actionIntents/intentService.ts
+++ b/apps/api/src/services/actionIntents/intentService.ts
@@ -1,3 +1,4 @@
+import { buildActionLabel } from './actionLabel';
 import { randomUUID, createHash } from 'crypto';
 import { and, eq, inArray, sql } from 'drizzle-orm';
 import type { AssuranceLevel } from '@breeze/shared';
@@ -463,6 +464,8 @@ interface HumanFanoutArgs {
   argumentDigest: string;
   requestingClientLabel: string;
   targetSummary: string;
+  /** Human headline for the approval row, push, and bell — never the raw signature. */
+  actionLabel: string;
   riskTier: 'medium' | 'high' | 'critical';
   impactSummary: string;
   expiresAt: Date;
@@ -499,6 +502,7 @@ async function runHumanFanout(args: HumanFanoutArgs): Promise<HumanFanoutResult>
     argumentDigest,
     requestingClientLabel,
     targetSummary,
+    actionLabel,
     riskTier,
     impactSummary,
     expiresAt,
@@ -517,7 +521,7 @@ async function runHumanFanout(args: HumanFanoutArgs): Promise<HumanFanoutResult>
   const approvalRowFor = (userId: string) => ({
     userId,
     requestingClientLabel,
-    actionLabel: targetSummary,
+    actionLabel,
     actionToolName: toolName,
     actionArguments,
     riskTier,
@@ -623,6 +627,7 @@ interface NotifyFannedOutApproversArgs {
   fanOutUserIds: string[];
   requestingClientLabel: string;
   targetSummary: string;
+  actionLabel: string;
   /** Passed to `withDbAccessContext` for the push-token read only — the
    *  in-app notification always runs system-scoped (see the call below).
    *  `userId` on it may be null (agent-originated fan-out has no requester);
@@ -640,7 +645,7 @@ interface NotifyFannedOutApproversArgs {
  * have, instead of a second, drifting copy of this loop.
  */
 async function notifyFannedOutApprovers(args: NotifyFannedOutApproversArgs): Promise<void> {
-  const { orgId, intentId, approvalRequestIds, fanOutUserIds, requestingClientLabel, targetSummary, dbContext } = args;
+  const { orgId, intentId, approvalRequestIds, fanOutUserIds, requestingClientLabel, actionLabel, dbContext } = args;
   for (let i = 0; i < approvalRequestIds.length; i++) {
     const approvalId = approvalRequestIds[i];
     const userId = fanOutUserIds[i];
@@ -661,7 +666,7 @@ async function notifyFannedOutApprovers(args: NotifyFannedOutApproversArgs): Pro
           type: 'approval',
           priority: 'high',
           title: 'Approval requested',
-          message: `${requestingClientLabel}: ${targetSummary}`,
+          message: `${requestingClientLabel}: ${actionLabel}`,
           link: '/approvals',
           metadata: { approvalId, intentId },
           // Survives outbox/BullMQ redelivery: one approver, one intent, one
@@ -686,7 +691,7 @@ async function notifyFannedOutApprovers(args: NotifyFannedOutApproversArgs): Pro
       const tokens = await withDbAccessContext(dbContext, () => getUserPushTokens(userId));
       await dispatchApprovalPushToTokens(tokens, {
         approvalId,
-        actionLabel: targetSummary,
+        actionLabel,
         requestingClientLabel,
       });
     } catch (err) {
@@ -1056,6 +1061,12 @@ export async function createActionIntent(
     );
   const targetSummary = buildTargetSummary(input.toolName, input.input);
   const impactSummary = buildImpactSummary(input.toolName, guardrail);
+  // What the approver READS. `targetSummary` stays the audit signature.
+  const actionLabel = buildActionLabel({
+    toolName: input.toolName,
+    input: input.input,
+    reason: input.reason ?? guardrail.description ?? null,
+  });
   const expiresAt = computeExpiresAt(input.source, approvalScope);
   const requestingClientLabel = input.requestingClientLabel
     ?? (agentRow ? agentRow.name : input.source === 'chat' ? 'Breeze AI' : 'MCP API client');
@@ -1428,6 +1439,7 @@ export async function createActionIntent(
             argumentDigest,
             requestingClientLabel,
             targetSummary,
+            actionLabel,
             riskTier,
             impactSummary,
             expiresAt,
@@ -1543,6 +1555,7 @@ export async function createActionIntent(
       fanOutUserIds: creation.fanOutUserIds,
       requestingClientLabel,
       targetSummary,
+      actionLabel,
       dbContext,
     });
   }

--- a/apps/api/src/services/actionIntents/intentService.ts
+++ b/apps/api/src/services/actionIntents/intentService.ts
@@ -123,7 +123,16 @@ export class ActionIntentAuthorizationError extends ActionIntentError {
 export interface CreateActionIntentInput {
   toolName: string;
   input: Record<string, unknown>;
+  /** Audit justification (an agent's sweep summary, a ticket-triage rationale). */
   reason?: string;
+  /**
+   * Human headline for the approver — "Restart service "Spooler" on KIT".
+   * Distinct from `reason`: callers that pass a justification as `reason`
+   * (agent runs, ticket triage) must not have it surface as the action.
+   * Optional; falls back to the guardrail description, then a label built
+   * from the tool name + recognisable arguments (see actionLabel.ts).
+   */
+  actionLabel?: string;
   /**
    * 'ai_agent' (wave 3b) is valid ONLY for an ai_agent principal — and
    * required for one: createActionIntent enforces the pairing in both
@@ -1065,7 +1074,7 @@ export async function createActionIntent(
   const actionLabel = buildActionLabel({
     toolName: input.toolName,
     input: input.input,
-    reason: input.reason ?? guardrail.description ?? null,
+    reason: input.actionLabel ?? guardrail.description ?? null,
   });
   const expiresAt = computeExpiresAt(input.source, approvalScope);
   const requestingClientLabel = input.requestingClientLabel
@@ -1746,6 +1755,12 @@ export async function runDeferredHumanFanout(intentId: string): Promise<void> {
       argumentDigest: updated.argumentDigest,
       requestingClientLabel: updated.requestingClientLabel ?? 'AI Agent',
       targetSummary: updated.targetSummary,
+      // The guardrail description is not persisted on the intent, so the
+      // deferred path rebuilds a label from the tool + arguments.
+      actionLabel: buildActionLabel({
+        toolName: updated.actionName,
+        input: updated.arguments as Record<string, unknown>,
+      }),
       riskTier: riskTierLabel(updated.riskTier),
       impactSummary: updated.impactSummary,
       // The SAME deadline creation stamped — not a freshly recomputed one; a
@@ -1798,6 +1813,10 @@ export async function runDeferredHumanFanout(intentId: string): Promise<void> {
     fanOutUserIds: fanoutResult.fanOutUserIds,
     requestingClientLabel: intent.requestingClientLabel ?? 'AI Agent',
     targetSummary: intent.targetSummary,
+    actionLabel: buildActionLabel({
+      toolName: intent.actionName,
+      input: intent.arguments as Record<string, unknown>,
+    }),
     dbContext: { scope: 'organization', orgId: intent.orgId, accessibleOrgIds: [intent.orgId], userId: null },
   });
 }

--- a/apps/api/src/services/aiAgentSdk.ts
+++ b/apps/api/src/services/aiAgentSdk.ts
@@ -967,9 +967,13 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
           } catch { /* non-fatal: fall back to default description */ }
           const riskSummary = m365Summary ?? (description.length > 500 ? `${description.slice(0, 497)}...` : description);
           // The guardrail description names the device by an id stub
-          // ("on device 6eae0f70..."); the approver reads the hostname.
-          const approvalReason = deviceContext?.hostname
-            ? riskSummary.replace(/\bon device [0-9a-f]{8}\.\.\./i, `on ${deviceContext.hostname}`)
+          // ("on device 6eae0f70..." — buildApprovalDescription in
+          // aiGuardrails.ts); the approver reads the hostname. Matched on
+          // THIS call's id prefix, literally, so nothing user-supplied that
+          // happens to look like a stub gets rewritten.
+          const deviceStub = deviceId ? `on device ${deviceId.slice(0, 8)}...` : null;
+          const approvalLabel = deviceStub && deviceContext?.hostname
+            ? riskSummary.split(deviceStub).join(`on ${deviceContext.hostname}`)
             : riskSummary;
 
           // Create the durable intent. This fans out to eligible org approvers
@@ -984,7 +988,8 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
               toolName,
               input: input as Record<string, unknown>,
               source: 'chat',
-              reason: approvalReason,
+              reason: riskSummary,
+              actionLabel: approvalLabel,
               orgId: session.orgId,
             });
           } catch (err) {

--- a/apps/api/src/services/aiAgentSdk.ts
+++ b/apps/api/src/services/aiAgentSdk.ts
@@ -966,6 +966,11 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
             }
           } catch { /* non-fatal: fall back to default description */ }
           const riskSummary = m365Summary ?? (description.length > 500 ? `${description.slice(0, 497)}...` : description);
+          // The guardrail description names the device by an id stub
+          // ("on device 6eae0f70..."); the approver reads the hostname.
+          const approvalReason = deviceContext?.hostname
+            ? riskSummary.replace(/\bon device [0-9a-f]{8}\.\.\./i, `on ${deviceContext.hostname}`)
+            : riskSummary;
 
           // Create the durable intent. This fans out to eligible org approvers
           // (or the sole-operator self-approval row), dispatches mobile push, and
@@ -979,7 +984,7 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
               toolName,
               input: input as Record<string, unknown>,
               source: 'chat',
-              reason: riskSummary,
+              reason: approvalReason,
               orgId: session.orgId,
             });
           } catch (err) {

--- a/apps/mobile/src/navigation/ApprovalGate.tsx
+++ b/apps/mobile/src/navigation/ApprovalGate.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { Keyboard, Pressable, StyleSheet, Text, View } from 'react-native';
+import { Keyboard, Modal, Pressable, Text, View } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -146,29 +146,31 @@ export function ApprovalGate({ children }: Props) {
   const showApprover =
     !error && pushRegistration !== 'failed' && approverSeverity !== null && !dismissedApprover;
 
-  if (focused) {
-    return (
-      <>
-        {children}
-        <View
-          style={StyleSheet.absoluteFill}
-          accessibilityViewIsModal
-          testID="approval-takeover"
-        >
-          <ApprovalScreen />
-        </View>
-      </>
-    );
-  }
-
+  // A native Modal, not an absolute-fill View: a sheet the user already had
+  // open (Settings, Sessions, a ticket picker — all RN Modals) would sit ABOVE
+  // a plain overlay and leave the approval hidden behind an interactive
+  // sheet. A Modal presented later always stacks on top. It also gives
+  // TalkBack/VoiceOver a real modal boundary and swallows Android hardware
+  // Back (`onRequestClose` is a deliberate no-op: an approval is dismissed by
+  // deciding it, expiring, or it being decided elsewhere — never by Back).
   return (
     <>
       {children}
-      {error ? (
+      <Modal
+        visible={!!focused}
+        animationType="none"
+        presentationStyle="fullScreen"
+        statusBarTranslucent
+        onRequestClose={() => undefined}
+        testID="approval-takeover"
+      >
+        <ApprovalScreen />
+      </Modal>
+      {focused ? null : error ? (
         <ApprovalErrorBanner message={error} onDismiss={() => dispatch(clearApprovalsError())} />
       ) : null}
-      {showPush ? <PushFailedBanner onDismiss={() => setDismissedPush(true)} /> : null}
-      {showApprover && approverSeverity ? (
+      {!focused && showPush ? <PushFailedBanner onDismiss={() => setDismissedPush(true)} /> : null}
+      {!focused && showApprover && approverSeverity ? (
         <ApproverSetupBanner
           severity={approverSeverity}
           reason={approverReason}

--- a/apps/mobile/src/navigation/ApprovalGate.tsx
+++ b/apps/mobile/src/navigation/ApprovalGate.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from 'react';
-import { Pressable, Text, View } from 'react-native';
+import { useEffect, useRef, useState } from 'react';
+import { Keyboard, Pressable, StyleSheet, Text, View } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { logoutAsync } from '../store/authSlice';
@@ -19,6 +20,7 @@ import {
   removeNotificationSubscription,
 } from '../services/notifications';
 import { ApprovalScreen } from '../screens/approvals/ApprovalScreen';
+import { shouldHandleTap } from './pushRouting';
 import { useApprovalQueueSync } from '../screens/approvals/useApprovalQueueSync';
 import { useApprovalTheme, type, spacing, radii } from '../theme';
 
@@ -26,7 +28,24 @@ interface Props {
   children: React.ReactNode;
 }
 
-// Renders ApprovalScreen as a global takeover whenever there is a focused pending approval.
+/**
+ * AsyncStorage key holding the identifier of the last approval push tap we
+ * acted on. Separate from PushTapRouter's ticket key: the two listeners run
+ * independently and must not clobber each other's dedupe state.
+ */
+export const LAST_HANDLED_APPROVAL_RESPONSE_KEY = 'notif:lastHandledApprovalResponseId';
+
+/**
+ * Renders ApprovalScreen as a global takeover OVER `children` whenever there is
+ * a focused pending approval.
+ *
+ * Over, not instead of: this used to `return <ApprovalScreen />` and unmount
+ * the whole MainNavigator. HomeScreen aborts its SSE stream on unmount, so an
+ * `approval_required` event arriving mid-turn tore down the very chat that was
+ * waiting on the decision — the server kept running the tool after approval,
+ * but the phone was left on "RUNNING …" forever. Keeping the navigator mounted
+ * underneath keeps the stream open, exactly like the web chat's inline card.
+ */
 export function ApprovalGate({ children }: Props) {
   const dispatch = useAppDispatch();
   const focused = useAppSelector((s) =>
@@ -48,9 +67,36 @@ export function ApprovalGate({ children }: Props) {
   // THIS phone decided something.
   useApprovalQueueSync();
 
+  // The takeover covers whatever was on screen; a keyboard left up from the
+  // chat composer or a ticket form would otherwise sit over the Approve/Deny
+  // buttons.
+  useEffect(() => {
+    if (focused) Keyboard.dismiss();
+  }, [focused?.id]);
+
+  /**
+   * Identifier of the last approval push tap acted on in this process. expo
+   * delivers the response that LAUNCHED the app to the response listener as
+   * well, and a JS relaunch (iOS reclaiming memory during the Face ID prompt
+   * or the approve round-trip) re-registers this listener and replays that
+   * same tap — which re-focused an approval the user had just decided, and
+   * showed the takeover a second time. Same guard PushTapRouter uses for
+   * ticket pushes.
+   */
+  const lastHandledTap = useRef<string | null>(null);
+
   useEffect(() => {
     dispatch(hydrateFromCache());
     dispatch(refreshPending());
+
+    void AsyncStorage.getItem(LAST_HANDLED_APPROVAL_RESPONSE_KEY)
+      .then((stored) => {
+        // Do not clobber a live tap that landed while storage was being read.
+        if (lastHandledTap.current === null) lastHandledTap.current = stored;
+      })
+      .catch(() => {
+        // Storage failure costs at most one redundant takeover.
+      });
 
     const recv = addNotificationReceivedListener((n) => {
       const parsed = parseApprovalNotification(n);
@@ -65,6 +111,14 @@ export function ApprovalGate({ children }: Props) {
     const tap = addNotificationResponseReceivedListener((r) => {
       const parsed = parseApprovalNotification(r.notification);
       if (!parsed) return;
+      const identifier = r.notification.request.identifier;
+      if (!shouldHandleTap(identifier, lastHandledTap.current)) return;
+      if (identifier) {
+        lastHandledTap.current = identifier;
+        AsyncStorage.setItem(LAST_HANDLED_APPROVAL_RESPONSE_KEY, identifier).catch(() => {
+          // Storage failure costs at most one redundant takeover.
+        });
+      }
       dispatch(setFocus(parsed.approvalId));
       dispatch(fetchOne(parsed.approvalId))
         .unwrap()
@@ -79,10 +133,6 @@ export function ApprovalGate({ children }: Props) {
     };
   }, []);
 
-  if (focused) {
-    return <ApprovalScreen />;
-  }
-
   // One banner at a time — they share the same absolute slot. Push failure
   // outranks approver failure: an approval that never arrives is worse than one
   // that arrives unsigned.
@@ -95,6 +145,21 @@ export function ApprovalGate({ children }: Props) {
         : null;
   const showApprover =
     !error && pushRegistration !== 'failed' && approverSeverity !== null && !dismissedApprover;
+
+  if (focused) {
+    return (
+      <>
+        {children}
+        <View
+          style={StyleSheet.absoluteFill}
+          accessibilityViewIsModal
+          testID="approval-takeover"
+        >
+          <ApprovalScreen />
+        </View>
+      </>
+    );
+  }
 
   return (
     <>

--- a/apps/mobile/src/screens/approvals/ApprovalScreen.tsx
+++ b/apps/mobile/src/screens/approvals/ApprovalScreen.tsx
@@ -45,7 +45,15 @@ export function ApprovalScreen() {
   const successWash = useSharedValue(0);
   const denyShake = useSharedValue(0);
 
-  const [toast, setToast] = useState<{ kind: 'success' | 'error'; text: string } | null>(null);
+  // Keyed by approval id: ApprovalGate keeps this ONE instance mounted while
+  // focus rolls from request A to request B, and `approve.fulfilled` moves
+  // focus in the same tick the "Approved · …" toast is queued — so without
+  // the key, A's success toast renders over B's Approve/Deny buttons.
+  const [toast, setToast] = useState<{
+    approvalId: string | null;
+    kind: 'success' | 'error';
+    text: string;
+  } | null>(null);
   const [reportSheetOpen, setReportSheetOpen] = useState(false);
   const [reportBusy, setReportBusy] = useState(false);
   const expiredHandledRef = useRef<string | null>(null);
@@ -91,7 +99,7 @@ export function ApprovalScreen() {
       if (focused.status !== 'pending') return;
       expiredHandledRef.current = focused.id;
       dispatch(markExpired(focused.id));
-      setToast({ kind: 'error', text: 'This request expired before you could respond.' });
+      setToast({ approvalId: focused.id, kind: 'error', text: 'This request expired before you could respond.' });
     }, 1000);
     return () => clearInterval(id);
   }, [focused?.id, focused?.expiresAt, focused?.status]);
@@ -116,7 +124,7 @@ export function ApprovalScreen() {
     // different action. See PR #696 Critical #3 / decisionTarget.ts.
     const target = decisionTarget(id, focused);
     if (!target) {
-      setToast({ kind: 'error', text: 'This request changed before you confirmed — review it again.' });
+      setToast({ approvalId: null, kind: 'error', text: 'This request changed before you confirmed — review it again.' });
       return;
     }
     successWash.value = withSequence(
@@ -135,17 +143,17 @@ export function ApprovalScreen() {
           is_recursive: approvalSnap.isRecursive,
           seconds_to_decide: decideSeconds,
         });
-        setToast({ kind: 'success', text: `Approved · ${approvalSnap.actionLabel}` });
+        setToast({ approvalId: approvalSnap.id, kind: 'success', text: `Approved · ${approvalSnap.actionLabel}` });
       })
       .catch((err: Error) => {
-        setToast({ kind: 'error', text: messageForDecisionError(err.message, 'Approve') });
+        setToast({ approvalId: approvalSnap.id, kind: 'error', text: messageForDecisionError(err.message, 'Approve') });
       });
   }
 
   function handleDeny(id: CapturedRequestId, reason?: string) {
     const target = decisionTarget(id, focused);
     if (!target) {
-      setToast({ kind: 'error', text: 'This request changed before you confirmed — review it again.' });
+      setToast({ approvalId: null, kind: 'error', text: 'This request changed before you confirmed — review it again.' });
       return;
     }
     denyShake.value = withSequence(
@@ -165,10 +173,10 @@ export function ApprovalScreen() {
           is_recursive: approvalSnap.isRecursive,
           seconds_to_decide: decideSeconds,
         });
-        setToast({ kind: 'error', text: 'Denied · logged' });
+        setToast({ approvalId: approvalSnap.id, kind: 'error', text: 'Denied · logged' });
       })
       .catch((err: Error) => {
-        setToast({ kind: 'error', text: messageForDecisionError(err.message, 'Deny') });
+        setToast({ approvalId: approvalSnap.id, kind: 'error', text: messageForDecisionError(err.message, 'Deny') });
       });
   }
 
@@ -188,11 +196,11 @@ export function ApprovalScreen() {
         track('approval_reported_suspicious');
         setReportSheetOpen(false);
         setReportBusy(false);
-        setToast({ kind: 'success', text: 'Reported. Session revoked.' });
+        setToast({ approvalId: null, kind: 'success', text: 'Reported. Session revoked.' });
       })
       .catch(() => {
         setReportBusy(false);
-        setToast({ kind: 'error', text: "Couldn't revoke. Try again." });
+        setToast({ approvalId: null, kind: 'error', text: "Couldn't revoke. Try again." });
       });
   }
 
@@ -224,6 +232,9 @@ export function ApprovalScreen() {
   // other flow keeps the existing actionLabel + generic JSON details.
   const flowType = resolveApprovalFlowType(focused);
   const copy = getApprovalCopy(focused);
+  // A toast bound to a request that is no longer on screen is stale; a toast
+  // with no approval id (report outcome, focus-swap guard) is screen-global.
+  const toastVisible = !!toast && (toast.approvalId === null || toast.approvalId === focused.id);
 
   return (
     <View style={{ flex: 1, backgroundColor: theme.bg0 }}>
@@ -308,7 +319,7 @@ export function ApprovalScreen() {
       />
 
       <Toast
-        visible={!!toast}
+        visible={toastVisible}
         text={toast?.text ?? ''}
         kind={toast?.kind ?? 'success'}
         onHidden={() => setToast(null)}

--- a/apps/mobile/src/screens/approvals/ApprovalScreen.tsx
+++ b/apps/mobile/src/screens/approvals/ApprovalScreen.tsx
@@ -48,7 +48,10 @@ export function ApprovalScreen() {
   // Keyed by approval id: ApprovalGate keeps this ONE instance mounted while
   // focus rolls from request A to request B, and `approve.fulfilled` moves
   // focus in the same tick the "Approved · …" toast is queued — so without
-  // the key, A's success toast renders over B's Approve/Deny buttons.
+  // the key, A's success toast renders over B's Approve/Deny buttons. The
+  // success/deny confirmations are therefore deliberately dropped once focus
+  // has moved on (the wash / shake animation is the feedback that survives);
+  // outcome ERRORS use `approvalId: null` and stay visible regardless.
   const [toast, setToast] = useState<{
     approvalId: string | null;
     kind: 'success' | 'error';
@@ -99,7 +102,9 @@ export function ApprovalScreen() {
       if (focused.status !== 'pending') return;
       expiredHandledRef.current = focused.id;
       dispatch(markExpired(focused.id));
-      setToast({ approvalId: focused.id, kind: 'error', text: 'This request expired before you could respond.' });
+      // Screen-global: markExpired rolls focus to the next request in the
+      // same tick, and the user still needs to hear that this one lapsed.
+      setToast({ approvalId: null, kind: 'error', text: 'This request expired before you could respond.' });
     }, 1000);
     return () => clearInterval(id);
   }, [focused?.id, focused?.expiresAt, focused?.status]);
@@ -146,7 +151,7 @@ export function ApprovalScreen() {
         setToast({ approvalId: approvalSnap.id, kind: 'success', text: `Approved · ${approvalSnap.actionLabel}` });
       })
       .catch((err: Error) => {
-        setToast({ approvalId: approvalSnap.id, kind: 'error', text: messageForDecisionError(err.message, 'Approve') });
+        setToast({ approvalId: null, kind: 'error', text: messageForDecisionError(err.message, 'Approve') });
       });
   }
 
@@ -176,7 +181,7 @@ export function ApprovalScreen() {
         setToast({ approvalId: approvalSnap.id, kind: 'error', text: 'Denied · logged' });
       })
       .catch((err: Error) => {
-        setToast({ approvalId: approvalSnap.id, kind: 'error', text: messageForDecisionError(err.message, 'Deny') });
+        setToast({ approvalId: null, kind: 'error', text: messageForDecisionError(err.message, 'Deny') });
       });
   }
 

--- a/apps/mobile/src/screens/approvals/approvalCopy.test.ts
+++ b/apps/mobile/src/screens/approvals/approvalCopy.test.ts
@@ -107,3 +107,36 @@ describe('getApprovalCopy', () => {
     });
   });
 });
+
+describe('getApprovalCopy — raw call-signature labels', () => {
+  // Servers before the actionLabel humanising change stamped the audit
+  // signature onto approval_requests.action_label. Those rows still exist and
+  // still arrive by push, so the phone unpacks them rather than printing a
+  // UUID in 28pt.
+  it('renders tool + recognisable args instead of the signature', () => {
+    const copy = getApprovalCopy({
+      actionToolName: 'manage_services',
+      actionLabel: 'manage_services(deviceId=6eae0f70-8da9-49ff-9e18-c241698975f3, action=restart, serviceName=Spooler)',
+      actionArguments: { deviceId: '6eae0f70-8da9-49ff-9e18-c241698975f3', action: 'restart', serviceName: 'Spooler' },
+    });
+    expect(copy.headline).toBe('Manage services: restart Spooler');
+  });
+
+  it('handles JSON-valued args in the signature', () => {
+    const copy = getApprovalCopy({
+      actionToolName: 'execute_command',
+      actionLabel: 'execute_command(deviceId=6eae0f70-8da9-49ff-9e18-c241698975f3, commandType=list_services, payload={"search":"Spooler"})',
+      actionArguments: { deviceId: '6eae0f70-8da9-49ff-9e18-c241698975f3', commandType: 'list_services', payload: { search: 'Spooler' } },
+    });
+    expect(copy.headline).toBe('Execute command: list_services');
+  });
+
+  it('leaves a human label alone', () => {
+    const copy = getApprovalCopy({
+      actionToolName: 'manage_services',
+      actionLabel: 'Restart service "Spooler" on KIT',
+      actionArguments: {},
+    });
+    expect(copy.headline).toBe('Restart service "Spooler" on KIT');
+  });
+});

--- a/apps/mobile/src/screens/approvals/approvalCopy.ts
+++ b/apps/mobile/src/screens/approvals/approvalCopy.ts
@@ -72,6 +72,42 @@ export interface ApprovalCopyInput extends FlowTypeInput {
   actionArguments: Record<string, unknown>;
 }
 
+/** `tool_name(key=value, …)` — the audit signature older servers used as the label. */
+const RAW_SIGNATURE = /^([a-z][a-z0-9_]*)\((.*)\)$/s;
+
+function titleCaseWords(snake: string): string {
+  return snake
+    .split(/[_\s]+/)
+    .filter(Boolean)
+    .map((w, i) => (i === 0 ? w.charAt(0).toUpperCase() + w.slice(1).toLowerCase() : w.toLowerCase()))
+    .join(' ');
+}
+
+/**
+ * Unpack a raw call-signature label into something a technician can read.
+ *
+ * Servers before the actionLabel humanising change wrote the audit signature
+ * straight onto `approval_requests.action_label`; those rows still arrive by
+ * push for as long as they are pending. The typed `actionArguments` are the
+ * reliable source for the detail — the signature string is only used to
+ * recognise the shape. Returns null for anything that is not a signature.
+ */
+export function humanizeRawActionLabel(
+  label: string,
+  toolName: string,
+  args: Record<string, unknown> | null | undefined,
+): string | null {
+  const match = RAW_SIGNATURE.exec(label.trim());
+  if (!match) return null;
+  const head = titleCaseWords(match[1]! || toolName);
+  const a = args ?? {};
+  const detail = [
+    firstStr(a.action, a.commandType),
+    firstStr(a.serviceName, a.processName, a.scriptName, a.name),
+  ].filter((v): v is string => v !== null);
+  return detail.length > 0 ? `${head}: ${detail.join(' ')}` : head;
+}
+
 export function getApprovalCopy(approval: ApprovalCopyInput): ApprovalCopy {
   if (resolveApprovalFlowType(approval) === 'uac_intercept') {
     const name = executableName(extractUacDetails(approval.actionArguments).exePath);
@@ -82,7 +118,9 @@ export function getApprovalCopy(approval: ApprovalCopyInput): ApprovalCopy {
     };
   }
   return {
-    headline: approval.actionLabel,
+    headline:
+      humanizeRawActionLabel(approval.actionLabel, approval.actionToolName, approval.actionArguments)
+      ?? approval.actionLabel,
     approveLabel: 'Approve',
     holdLabel: 'Hold to approve',
   };

--- a/apps/mobile/src/screens/chat/HomeScreen.tsx
+++ b/apps/mobile/src/screens/chat/HomeScreen.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
+  AppState,
+  type AppStateStatus,
   KeyboardAvoidingView,
   Platform,
   Text,
@@ -19,6 +21,7 @@ import {
   failAssistantMessage,
   finishAssistantMessage,
   loadHistory,
+  reconcileHistory,
   resetChat,
   sessionCreated,
   setError,
@@ -45,6 +48,18 @@ import { ConversationList } from './components/ConversationList';
 import { SessionsSheet } from './components/SessionsSheet';
 import { SettingsSheet } from './components/SettingsSheet';
 import { historyToMessages } from './historyAdapter';
+import { isStreamLostError, isTurnComplete, isTurnSettlingError } from './turnState';
+
+/** Catch-up poll cadence while the server is still writing the turn. */
+const RECONCILE_POLL_MS = 3_000;
+/**
+ * Upper bound on catch-up polls. The server's own approval wait budget is 5
+ * minutes (APPROVAL_WAIT_BUDGET_MS, aiAgentSdk.ts); beyond that the turn has
+ * concluded one way or another and further polling is just battery.
+ */
+const RECONCILE_MAX_POLLS = 100;
+/** How long to wait before retrying a 409 "wrapping up the previous turn". */
+const SETTLE_RETRY_MS = 2_500;
 
 export function HomeScreen() {
   const insets = useSafeAreaInsets();
@@ -60,6 +75,12 @@ export function HomeScreen() {
 
   const streamHandleRef = useRef<SseStreamHandle | null>(null);
   const lastUserContentRef = useRef<string | null>(null);
+  const reconcileTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Read by the mount/foreground effects without re-subscribing on every change.
+  const statusRef = useRef(status);
+  statusRef.current = status;
+  const sessionIdRef = useRef(sessionId);
+  sessionIdRef.current = sessionId;
   const [draft, setDraft] = useState<string | undefined>(undefined);
   const [historyOpen, setHistoryOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -70,8 +91,74 @@ export function HomeScreen() {
     return () => {
       streamHandleRef.current?.abort();
       streamHandleRef.current = null;
+      if (reconcileTimerRef.current) clearTimeout(reconcileTimerRef.current);
+      reconcileTimerRef.current = null;
     };
   }, []);
+
+  /**
+   * Catch up from the server's persisted transcript when the live stream is
+   * gone. The turn keeps running server-side whatever happens to this socket
+   * (the HTTP handler is only a subscriber to the session's event bus), so
+   * everything it produced is in `GET /ai/sessions/:id`. Polls while the
+   * transcript is still partial, e.g. a tool blocked on an approval.
+   */
+  const reconcileFromServer = useCallback(
+    async (sid: string, attempt = 0) => {
+      if (reconcileTimerRef.current) clearTimeout(reconcileTimerRef.current);
+      reconcileTimerRef.current = null;
+      try {
+        const { messages: rows } = await getAiSessionMessages(sid);
+        // A new chat or a different session was opened while we were fetching.
+        if (sessionIdRef.current !== sid) return;
+        const msgs = historyToMessages(rows);
+        const complete = isTurnComplete(msgs);
+        dispatch(reconcileHistory({ sessionId: sid, messages: msgs, complete }));
+        if (complete) return;
+        if (attempt >= RECONCILE_MAX_POLLS) {
+          dispatch(setError('Lost track of this reply. Tap to retry.'));
+          return;
+        }
+        reconcileTimerRef.current = setTimeout(() => {
+          void reconcileFromServer(sid, attempt + 1);
+        }, RECONCILE_POLL_MS);
+      } catch (err) {
+        reportInternalError(err, 'ai-chat-reconcile');
+        dispatch(setError('Could not reconnect to this conversation. Tap to retry.'));
+      }
+    },
+    [dispatch],
+  );
+
+  // A remount mid-turn (the approval takeover used to unmount this screen;
+  // a JS relaunch still can) leaves Redux saying "streaming" with no socket
+  // behind it. Catch up rather than sit on RUNNING forever.
+  useEffect(() => {
+    const sid = sessionIdRef.current;
+    if (statusRef.current === 'streaming' && sid && !streamHandleRef.current) {
+      void reconcileFromServer(sid);
+    }
+    // Mount only.
+  }, []);
+
+  // iOS suspends the XHR after ~30s in the background, and the resume does
+  // not always deliver an `onerror`. On a real background→active transition
+  // (not the 'inactive' blip of a Face ID sheet) drop the socket and catch up
+  // from the transcript — the server never stopped.
+  useEffect(() => {
+    let previous: AppStateStatus = AppState.currentState ?? 'active';
+    const sub = AppState.addEventListener('change', (next) => {
+      const wasBackground = previous === 'background';
+      previous = next;
+      if (!wasBackground || next !== 'active') return;
+      const sid = sessionIdRef.current;
+      if (statusRef.current !== 'streaming' || !sid) return;
+      streamHandleRef.current?.abort();
+      streamHandleRef.current = null;
+      void reconcileFromServer(sid);
+    });
+    return () => sub.remove();
+  }, [reconcileFromServer]);
 
   // Refresh alerts whenever the Home tab gains focus, not just on first
   // mount. Keeps the StatusPill from going stale after a tab switch.
@@ -83,9 +170,11 @@ export function HomeScreen() {
   );
 
   const beginStream = useCallback(
-    async (sid: string, content: string) => {
-      const assistantId = `m-${Date.now()}-a`;
-      dispatch(addPendingAssistantMessage({ id: assistantId, sentAt: new Date().toISOString() }));
+    (sid: string, content: string, retry?: { assistantId: string }) => {
+      const assistantId = retry?.assistantId ?? `m-${Date.now()}-a`;
+      if (!retry) {
+        dispatch(addPendingAssistantMessage({ id: assistantId, sentAt: new Date().toISOString() }));
+      }
 
       streamHandleRef.current = streamChat({
         sessionId: sid,
@@ -155,6 +244,21 @@ export function HomeScreen() {
           }
         },
         onError: (err) => {
+          streamHandleRef.current = null;
+          // 409 while the previous turn settles (≤3s server-side). One quiet
+          // retry instead of a red "Stopped. Tap to retry." for a race the
+          // server documents as expected.
+          if (!retry && isTurnSettlingError(err.message)) {
+            setTimeout(() => {
+              if (sessionIdRef.current === sid) beginStream(sid, content, { assistantId });
+            }, SETTLE_RETRY_MS);
+            return;
+          }
+          // The socket died but the turn did not: catch up from the transcript.
+          if (isStreamLostError(err)) {
+            void reconcileFromServer(sid);
+            return;
+          }
           dispatch(failAssistantMessage({ id: assistantId, error: err.message }));
         },
         onDone: () => {
@@ -167,14 +271,16 @@ export function HomeScreen() {
         },
       });
     },
-    [dispatch],
+    [dispatch, reconcileFromServer],
   );
 
   const handleSend = useCallback(
     async (text: string) => {
-      // Abort any prior stream before starting the next one.
+      // Abort any prior stream (or catch-up poll) before starting the next one.
       streamHandleRef.current?.abort();
       streamHandleRef.current = null;
+      if (reconcileTimerRef.current) clearTimeout(reconcileTimerRef.current);
+      reconcileTimerRef.current = null;
 
       const userMessageId = `m-${Date.now()}-u`;
       lastUserContentRef.current = text;

--- a/apps/mobile/src/screens/chat/HomeScreen.tsx
+++ b/apps/mobile/src/screens/chat/HomeScreen.tsx
@@ -48,7 +48,7 @@ import { ConversationList } from './components/ConversationList';
 import { SessionsSheet } from './components/SessionsSheet';
 import { SettingsSheet } from './components/SettingsSheet';
 import { historyToMessages } from './historyAdapter';
-import { isStreamLostError, isTurnComplete, isTurnSettlingError } from './turnState';
+import { isStreamLostError, isTurnComplete, isTurnSettlingError, transcriptSignature } from './turnState';
 
 /** Catch-up poll cadence while the server is still writing the turn. */
 const RECONCILE_POLL_MS = 3_000;
@@ -76,25 +76,38 @@ export function HomeScreen() {
   const streamHandleRef = useRef<SseStreamHandle | null>(null);
   const lastUserContentRef = useRef<string | null>(null);
   const reconcileTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const settleRetryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  /**
+   * Bumped on every send / new chat / session switch / unmount. Async work
+   * that started under an older generation (a catch-up fetch, a settle
+   * retry) must not write into the turn that replaced it.
+   */
+  const turnGenRef = useRef(0);
   // Read by the mount/foreground effects without re-subscribing on every change.
   const statusRef = useRef(status);
   statusRef.current = status;
   const sessionIdRef = useRef(sessionId);
   sessionIdRef.current = sessionId;
+  const streamingIdRef = useRef(streamingMessageId);
+  streamingIdRef.current = streamingMessageId;
+
+  /** Cancel every pending async continuation of the current turn. */
+  const cancelTurnWork = useCallback(() => {
+    turnGenRef.current += 1;
+    streamHandleRef.current?.abort();
+    streamHandleRef.current = null;
+    if (reconcileTimerRef.current) clearTimeout(reconcileTimerRef.current);
+    reconcileTimerRef.current = null;
+    if (settleRetryTimerRef.current) clearTimeout(settleRetryTimerRef.current);
+    settleRetryTimerRef.current = null;
+  }, []);
   const [draft, setDraft] = useState<string | undefined>(undefined);
   const [historyOpen, setHistoryOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const userName = useAppSelector((s) => s.auth.user?.name);
 
   // Abort any in-flight stream when the screen unmounts (signed out, killed).
-  useEffect(() => {
-    return () => {
-      streamHandleRef.current?.abort();
-      streamHandleRef.current = null;
-      if (reconcileTimerRef.current) clearTimeout(reconcileTimerRef.current);
-      reconcileTimerRef.current = null;
-    };
-  }, []);
+  useEffect(() => cancelTurnWork, [cancelTurnWork]);
 
   /**
    * Catch up from the server's persisted transcript when the live stream is
@@ -104,27 +117,41 @@ export function HomeScreen() {
    * transcript is still partial, e.g. a tool blocked on an approval.
    */
   const reconcileFromServer = useCallback(
-    async (sid: string, attempt = 0) => {
+    async (sid: string, attempt = 0, previousSignature: string | null = null) => {
       if (reconcileTimerRef.current) clearTimeout(reconcileTimerRef.current);
       reconcileTimerRef.current = null;
+      const gen = turnGenRef.current;
+      // Surface a terminal failure on the streaming row itself: the error
+      // strip below the list is hidden while a message is streaming, so a
+      // bare setError would leave a permanent, unretryable RUNNING row.
+      const giveUp = (message: string) => {
+        const streamingId = streamingIdRef.current;
+        if (streamingId) dispatch(failAssistantMessage({ id: streamingId, error: message }));
+        else dispatch(setError(message));
+      };
       try {
         const { messages: rows } = await getAiSessionMessages(sid);
-        // A new chat or a different session was opened while we were fetching.
-        if (sessionIdRef.current !== sid) return;
+        // A send, new chat or session switch superseded this catch-up.
+        if (gen !== turnGenRef.current || sessionIdRef.current !== sid) return;
         const msgs = historyToMessages(rows);
-        const complete = isTurnComplete(msgs);
+        const signature = transcriptSignature(msgs);
+        // "Complete" is only trusted once the transcript has stopped changing
+        // between two polls: a tool_result can be persisted a beat before the
+        // model's follow-up text, and that instant looks finished.
+        const complete = isTurnComplete(msgs) && signature === previousSignature;
         dispatch(reconcileHistory({ sessionId: sid, messages: msgs, complete }));
         if (complete) return;
         if (attempt >= RECONCILE_MAX_POLLS) {
-          dispatch(setError('Lost track of this reply. Tap to retry.'));
+          giveUp('Lost track of this reply. Tap to retry.');
           return;
         }
         reconcileTimerRef.current = setTimeout(() => {
-          void reconcileFromServer(sid, attempt + 1);
+          void reconcileFromServer(sid, attempt + 1, signature);
         }, RECONCILE_POLL_MS);
       } catch (err) {
+        if (gen !== turnGenRef.current) return;
         reportInternalError(err, 'ai-chat-reconcile');
-        dispatch(setError('Could not reconnect to this conversation. Tap to retry.'));
+        giveUp('Could not reconnect to this conversation. Tap to retry.');
       }
     },
     [dispatch],
@@ -247,10 +274,15 @@ export function HomeScreen() {
           streamHandleRef.current = null;
           // 409 while the previous turn settles (≤3s server-side). One quiet
           // retry instead of a red "Stopped. Tap to retry." for a race the
-          // server documents as expected.
+          // server documents as expected. Generation-guarded: a send or new
+          // chat in the meantime cancels it rather than opening a competing
+          // stream for a stale prompt.
           if (!retry && isTurnSettlingError(err.message)) {
-            setTimeout(() => {
-              if (sessionIdRef.current === sid) beginStream(sid, content, { assistantId });
+            const gen = turnGenRef.current;
+            settleRetryTimerRef.current = setTimeout(() => {
+              settleRetryTimerRef.current = null;
+              if (gen !== turnGenRef.current || sessionIdRef.current !== sid) return;
+              beginStream(sid, content, { assistantId });
             }, SETTLE_RETRY_MS);
             return;
           }
@@ -276,11 +308,9 @@ export function HomeScreen() {
 
   const handleSend = useCallback(
     async (text: string) => {
-      // Abort any prior stream (or catch-up poll) before starting the next one.
-      streamHandleRef.current?.abort();
-      streamHandleRef.current = null;
-      if (reconcileTimerRef.current) clearTimeout(reconcileTimerRef.current);
-      reconcileTimerRef.current = null;
+      // Abort any prior stream, catch-up poll or settle retry before starting
+      // the next turn.
+      cancelTurnWork();
 
       const userMessageId = `m-${Date.now()}-u`;
       lastUserContentRef.current = text;
@@ -308,7 +338,7 @@ export function HomeScreen() {
 
       beginStream(sid, text);
     },
-    [beginStream, dispatch, sessionId],
+    [beginStream, cancelTurnWork, dispatch, sessionId],
   );
 
   const handleRetry = useCallback(() => {
@@ -325,11 +355,10 @@ export function HomeScreen() {
   }, []);
 
   const handleNewChat = useCallback(() => {
-    streamHandleRef.current?.abort();
-    streamHandleRef.current = null;
+    cancelTurnWork();
     lastUserContentRef.current = null;
     dispatch(resetChat());
-  }, [dispatch]);
+  }, [cancelTurnWork, dispatch]);
 
   const handleOpenHistory = useCallback(() => {
     setHistoryOpen(true);
@@ -338,8 +367,7 @@ export function HomeScreen() {
   const handleSelectSession = useCallback(
     async (sid: string) => {
       setHistoryOpen(false);
-      streamHandleRef.current?.abort();
-      streamHandleRef.current = null;
+      cancelTurnWork();
       try {
         const { messages: rows } = await getAiSessionMessages(sid);
         const messages = historyToMessages(rows);
@@ -351,7 +379,7 @@ export function HomeScreen() {
         dispatch(setError('Could not load that conversation.'));
       }
     },
-    [dispatch],
+    [cancelTurnWork, dispatch],
   );
 
   const isCold = messages.length === 0 && status !== 'creating-session';

--- a/apps/mobile/src/screens/chat/turnState.test.ts
+++ b/apps/mobile/src/screens/chat/turnState.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ChatMessage, ToolEvent } from '../../store/aiChatSlice';
+import { inFlightToolOf, isStreamLostError, isTurnComplete, isTurnSettlingError } from './turnState';
+
+const user = (id: string): ChatMessage => ({ id, role: 'user', content: 'hi', sentAt: 't' });
+const assistant = (id: string, content: string, toolEvents: ToolEvent[] = []): ChatMessage => ({
+  id,
+  role: 'assistant',
+  content,
+  toolEvents,
+  sentAt: 't',
+  isStreaming: false,
+});
+
+describe('isTurnComplete', () => {
+  it('is false for an empty transcript', () => {
+    expect(isTurnComplete([])).toBe(false);
+  });
+
+  it('is false when the last row is the user message (no reply yet)', () => {
+    expect(isTurnComplete([user('u1')])).toBe(false);
+  });
+
+  it('is false while a tool_use has no tool_result', () => {
+    const msgs = [user('u1'), assistant('a1', '', [{ toolUseId: 't1', toolName: 'execute_command', state: 'started' }])];
+    expect(isTurnComplete(msgs)).toBe(false);
+    expect(inFlightToolOf(msgs)).toEqual({ toolUseId: 't1', toolName: 'execute_command' });
+  });
+
+  it('is false for an assistant row with neither text nor tools', () => {
+    expect(isTurnComplete([user('u1'), assistant('a1', '')])).toBe(false);
+  });
+
+  it('is true once the tool completed and text landed', () => {
+    const msgs = [
+      user('u1'),
+      assistant('a1', 'Restarted the Spooler.', [{ toolUseId: 't1', toolName: 'manage_services', state: 'completed' }]),
+    ];
+    expect(isTurnComplete(msgs)).toBe(true);
+    expect(inFlightToolOf(msgs)).toBeNull();
+  });
+
+  it('is true for a tools-only completed turn', () => {
+    expect(
+      isTurnComplete([user('u1'), assistant('a1', '', [{ toolUseId: 't1', toolName: 'x', state: 'completed' }])]),
+    ).toBe(true);
+  });
+});
+
+describe('error classifiers', () => {
+  it('recognises the 409 settle-race text', () => {
+    expect(isTurnSettlingError('The assistant is wrapping up the previous turn — please try again in a moment')).toBe(true);
+    expect(isTurnSettlingError('HTTP 500')).toBe(false);
+  });
+
+  it('treats a dropped socket or open-timeout as stream-lost, not failed', () => {
+    expect(isStreamLostError(new Error('Network error'))).toBe(true);
+    const timeout = new Error('Request timed out after 15000ms');
+    timeout.name = 'FetchTimeoutError';
+    expect(isStreamLostError(timeout)).toBe(true);
+    expect(isStreamLostError(new Error('HTTP 401'))).toBe(false);
+  });
+});

--- a/apps/mobile/src/screens/chat/turnState.test.ts
+++ b/apps/mobile/src/screens/chat/turnState.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { ChatMessage, ToolEvent } from '../../store/aiChatSlice';
-import { inFlightToolOf, isStreamLostError, isTurnComplete, isTurnSettlingError } from './turnState';
+import { inFlightToolOf, isStreamLostError, isTurnComplete, isTurnSettlingError, transcriptSignature } from './turnState';
 
 const user = (id: string): ChatMessage => ({ id, role: 'user', content: 'hi', sentAt: 't' });
 const assistant = (id: string, content: string, toolEvents: ToolEvent[] = []): ChatMessage => ({
@@ -60,5 +60,16 @@ describe('error classifiers', () => {
     timeout.name = 'FetchTimeoutError';
     expect(isStreamLostError(timeout)).toBe(true);
     expect(isStreamLostError(new Error('HTTP 401'))).toBe(false);
+  });
+});
+
+describe('transcriptSignature', () => {
+  it('changes when the trailing assistant row grows or a tool settles', () => {
+    const a = [user('u1'), assistant('a1', 'Sure', [{ toolUseId: 't1', toolName: 'x', state: 'started' }])];
+    const b = [user('u1'), assistant('a1', 'Sure', [{ toolUseId: 't1', toolName: 'x', state: 'completed' }])];
+    const c = [user('u1'), assistant('a1', 'Sure', [{ toolUseId: 't1', toolName: 'x', state: 'completed' }]), assistant('a2', 'Done')];
+    expect(transcriptSignature(a)).not.toBe(transcriptSignature(b));
+    expect(transcriptSignature(b)).not.toBe(transcriptSignature(c));
+    expect(transcriptSignature(c)).toBe(transcriptSignature(c.map((m) => ({ ...m }))));
   });
 });

--- a/apps/mobile/src/screens/chat/turnState.ts
+++ b/apps/mobile/src/screens/chat/turnState.ts
@@ -1,0 +1,47 @@
+import type { ChatMessage } from '../../store/aiChatSlice';
+
+/**
+ * Whether the server-persisted transcript describes a FINISHED assistant turn.
+ *
+ * Used when the live SSE stream is gone (the app was suspended, or iOS killed
+ * the XHR while an approval was being decided) and the phone has to catch up
+ * from `GET /ai/sessions/:id` instead. The server writes assistant text and
+ * tool rows as they happen, so a mid-turn fetch legitimately returns a partial
+ * transcript: a trailing user row with no reply yet, or a tool_use row whose
+ * tool_result has not landed. Both mean "keep polling".
+ */
+export function isTurnComplete(messages: ChatMessage[]): boolean {
+  const last = messages[messages.length - 1];
+  if (!last || last.role !== 'assistant') return false;
+  if (last.toolEvents.some((t) => t.state === 'started')) return false;
+  return last.content.length > 0 || last.toolEvents.length > 0;
+}
+
+/** The tool still running in a partial transcript, for the RUNNING caption. */
+export function inFlightToolOf(
+  messages: ChatMessage[],
+): { toolUseId: string; toolName: string } | null {
+  const last = messages[messages.length - 1];
+  if (!last || last.role !== 'assistant') return null;
+  const started = last.toolEvents.find((t) => t.state === 'started');
+  return started ? { toolUseId: started.toolUseId, toolName: started.toolName } : null;
+}
+
+/**
+ * The API answers 409 with this text while `settleBlockedTurnForNewMessage`
+ * (apps/api/src/services/aiAgentSdk.ts) gives the previous turn up to 3s to
+ * conclude. It is a transient race, not a failure — retry once, don't surface.
+ */
+export function isTurnSettlingError(message: string): boolean {
+  return /wrapping up the previous turn/i.test(message);
+}
+
+/**
+ * Transport failures where the SERVER-SIDE turn is still running and the right
+ * move is to catch up from the transcript rather than mark the reply failed.
+ * `Network error` is what streamChat's XHR `onerror` reports when iOS drops the
+ * socket on suspend; a timeout at open means the same thing for a cold link.
+ */
+export function isStreamLostError(err: Error): boolean {
+  return err.message === 'Network error' || err.name === 'FetchTimeoutError';
+}

--- a/apps/mobile/src/screens/chat/turnState.ts
+++ b/apps/mobile/src/screens/chat/turnState.ts
@@ -45,3 +45,20 @@ export function isTurnSettlingError(message: string): boolean {
 export function isStreamLostError(err: Error): boolean {
   return err.message === 'Network error' || err.name === 'FetchTimeoutError';
 }
+
+/**
+ * A cheap fingerprint of the transcript, compared across consecutive catch-up
+ * polls. The server writes rows incrementally, and "last row is a finished
+ * assistant turn" is also what the transcript looks like for the instant
+ * between a tool_result landing and the model's follow-up text being
+ * persisted — so completeness is only trusted once the transcript has stopped
+ * changing between two polls.
+ */
+export function transcriptSignature(messages: ChatMessage[]): string {
+  const last = messages[messages.length - 1];
+  if (!last) return '0';
+  const tail = last.role === 'assistant'
+    ? `${last.content.length}:${last.toolEvents.map((t) => `${t.toolUseId}=${t.state}`).join(',')}`
+    : `u:${last.content.length}`;
+  return `${messages.length}|${last.id}|${tail}`;
+}

--- a/apps/mobile/src/screens/tickets/CreateTicketScreen.tsx
+++ b/apps/mobile/src/screens/tickets/CreateTicketScreen.tsx
@@ -100,8 +100,28 @@ export function CreateTicketScreen() {
   const lockedOrg = orgs !== null && orgs.length === 1 && orgId === orgs[0].id;
 
   return (
-    <KeyboardAvoidingView style={styles.screen} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
-      <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
+    <KeyboardAvoidingView
+      style={styles.screen}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      // iOS is handled by `automaticallyAdjustKeyboardInsets` on the
+      // ScrollView below; leaving this enabled too would double-count the
+      // keyboard height and open a blank band above it.
+      enabled={Platform.OS !== 'ios'}
+    >
+      <ScrollView
+        contentContainerStyle={styles.content}
+        keyboardShouldPersistTaps="handled"
+        // Drag the list down to dismiss the keyboard (the chat list already
+        // does this); there is no Done button on a multiline iOS keyboard.
+        keyboardDismissMode="interactive"
+        // iOS: UIScrollView adds the keyboard's height to the bottom content
+        // inset natively, so the composer / submit button — which live at the
+        // END of this scroll content — can always be scrolled clear of it.
+        // KeyboardAvoidingView's padding never gave scroll room, only a
+        // shorter viewport, and with a 32pt bottom pad the last field sat
+        // under a ~300pt keyboard with nowhere to go.
+        automaticallyAdjustKeyboardInsets
+      >
         <Text style={styles.label}>ORGANISATION</Text>
         {orgs === null ? (
           <ActivityIndicator color={palette.dark.textLo} style={styles.spinner} />
@@ -226,7 +246,7 @@ export function CreateTicketScreen() {
 
 const styles = StyleSheet.create({
   screen: { flex: 1, backgroundColor: palette.dark.bg0 },
-  content: { padding: spacing['4'], paddingBottom: spacing['8'] },
+  content: { padding: spacing['4'], paddingBottom: spacing['16'] },
   label: {
     ...type.metaCaps,
     color: palette.dark.textLo,

--- a/apps/mobile/src/screens/tickets/TicketDetailScreen.tsx
+++ b/apps/mobile/src/screens/tickets/TicketDetailScreen.tsx
@@ -586,8 +586,25 @@ export function TicketDetailScreen() {
     <KeyboardAvoidingView
       style={styles.screen}
       behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      // iOS is handled by `automaticallyAdjustKeyboardInsets` on the
+      // ScrollView below; leaving this enabled too would double-count the
+      // keyboard height and open a blank band above it.
+      enabled={Platform.OS !== 'ios'}
     >
-      <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
+      <ScrollView
+        contentContainerStyle={styles.content}
+        keyboardShouldPersistTaps="handled"
+        // Drag the list down to dismiss the keyboard (the chat list already
+        // does this); there is no Done button on a multiline iOS keyboard.
+        keyboardDismissMode="interactive"
+        // iOS: UIScrollView adds the keyboard's height to the bottom content
+        // inset natively, so the composer / submit button — which live at the
+        // END of this scroll content — can always be scrolled clear of it.
+        // KeyboardAvoidingView's padding never gave scroll room, only a
+        // shorter viewport, and with a 32pt bottom pad the last field sat
+        // under a ~300pt keyboard with nowhere to go.
+        automaticallyAdjustKeyboardInsets
+      >
         <View style={styles.header}>
           {ref ? <Text style={styles.ref}>{ref}</Text> : null}
           <View style={[styles.priorityDot, { backgroundColor: priorityColor(ticket.priority) }]} />
@@ -866,7 +883,7 @@ const styles = StyleSheet.create({
     backgroundColor: palette.dark.bg0,
     padding: spacing['6'],
   },
-  content: { padding: spacing['4'], paddingBottom: spacing['8'] },
+  content: { padding: spacing['4'], paddingBottom: spacing['16'] },
   header: { flexDirection: 'row', alignItems: 'center', gap: spacing['2'] },
   ref: { ...type.monoMd, color: palette.dark.textMd },
   priorityDot: { width: 8, height: 8, borderRadius: radii.full },

--- a/apps/mobile/src/services/ticketAttachmentContract.ts
+++ b/apps/mobile/src/services/ticketAttachmentContract.ts
@@ -181,7 +181,8 @@ export function toAttachmentError(err: unknown): AttachmentUploadError {
   // no `code`, but it is a rejection, not a dropped link. Telling the
   // technician to "check your connection" sent them chasing Wi-Fi for a
   // permission problem, and hid the status we needed to diagnose it.
-  if (typeof statusCode === 'number' && statusCode >= 400 && statusCode < 500) {
+  // 408 is the one 4xx that IS transient (request timed out at the proxy).
+  if (typeof statusCode === 'number' && statusCode >= 400 && statusCode < 500 && statusCode !== 408) {
     return new AttachmentUploadError(
       'UPLOAD_FAILED',
       `Upload rejected (HTTP ${statusCode}${detail ? `: ${detail}` : ''}).`,

--- a/apps/mobile/src/services/ticketAttachmentContract.ts
+++ b/apps/mobile/src/services/ticketAttachmentContract.ts
@@ -78,6 +78,7 @@ export type AttachmentErrorCode =
   | 'INVALID_MULTIPART'
   | 'EMPTY_ATTACHMENT'
   | 'SHARING_UNAVAILABLE'
+  | 'ORG_CONTEXT_REQUIRED'
   | 'UPLOAD_FAILED';
 
 /**
@@ -123,6 +124,10 @@ const ERROR_COPY: Record<AttachmentErrorCode, { message: string; retryable: bool
   INVALID_MULTIPART: { message: 'That file could not be read. Pick it again.', retryable: false },
   EMPTY_ATTACHMENT: { message: 'That file is empty.', retryable: false },
   SHARING_UNAVAILABLE: { message: 'This device cannot open that file.', retryable: false },
+  ORG_CONTEXT_REQUIRED: {
+    message: 'Your sign-in has no organisation selected. Sign out and back in.',
+    retryable: false,
+  },
   UPLOAD_FAILED: { message: 'Upload failed. Check your connection and try again.', retryable: true },
 };
 
@@ -170,7 +175,26 @@ export function toAttachmentError(err: unknown): AttachmentUploadError {
   if (typeof statusCode === 'number' && STATUS_FALLBACK[statusCode]) {
     return attachmentError(STATUS_FALLBACK[statusCode]);
   }
-  return attachmentError('UPLOAD_FAILED');
+  const rawMessage = (err as { message?: unknown } | null)?.message;
+  const detail = typeof rawMessage === 'string' && rawMessage.trim() ? rawMessage.trim() : null;
+  // The server ANSWERED — a 401/403/404 from the auth or route layer carries
+  // no `code`, but it is a rejection, not a dropped link. Telling the
+  // technician to "check your connection" sent them chasing Wi-Fi for a
+  // permission problem, and hid the status we needed to diagnose it.
+  if (typeof statusCode === 'number' && statusCode >= 400 && statusCode < 500) {
+    return new AttachmentUploadError(
+      'UPLOAD_FAILED',
+      `Upload rejected (HTTP ${statusCode}${detail ? `: ${detail}` : ''}).`,
+      false,
+    );
+  }
+  // Nothing came back at all: a dropped connection, a timeout, or a runtime
+  // failure before the request was sent (an unreadable file URI, a picker
+  // temp file the OS purged). Keep it retryable, but name the cause so a
+  // support screenshot is worth something.
+  const copy = ERROR_COPY.UPLOAD_FAILED;
+  const message = detail && detail !== copy.message ? `${copy.message} (${detail})` : copy.message;
+  return new AttachmentUploadError('UPLOAD_FAILED', message, copy.retryable);
 }
 
 export function isAllowedMime(mimeType: string): boolean {

--- a/apps/mobile/src/services/ticketAttachments.test.ts
+++ b/apps/mobile/src/services/ticketAttachments.test.ts
@@ -405,3 +405,44 @@ describe('openAttachmentExternally', () => {
     expect(downloadFileAsync).not.toHaveBeenCalled();
   });
 });
+
+describe('uploadTicketAttachment — failures that are NOT a bad connection', () => {
+  const jpeg = { uri: 'file:///tmp/a.jpg', name: 'a.jpg', mimeType: 'image/jpeg', size: 1000, width: 10, height: 10 };
+  const GENERIC = 'Upload failed. Check your connection and try again.';
+
+  it.each([
+    [401, 'Not authenticated'],
+    [403, 'Insufficient permissions'],
+    [404, 'Not Found'],
+  ])('surfaces the server\'s own reason for an HTTP %i instead of blaming the connection', async (status, message) => {
+    coreRequest.mockRejectedValue({ statusCode: status, message });
+
+    const err = (await uploadTicketAttachment('t-1', jpeg).catch((e: unknown) => e)) as AttachmentUploadError;
+
+    expect(err).toBeInstanceOf(AttachmentUploadError);
+    expect(err.message).not.toBe(GENERIC);
+    expect(err.message).toContain(message);
+    expect(err.message).toContain(String(status));
+    // A stale token or a permission gap does not get better by tapping Retry.
+    expect(err.retryable).toBe(false);
+  });
+
+  it('maps ORG_CONTEXT_REQUIRED to its own non-retryable copy', async () => {
+    coreRequest.mockRejectedValue(apiError('ORG_CONTEXT_REQUIRED', 403));
+    const err = (await uploadTicketAttachment('t-1', jpeg).catch((e: unknown) => e)) as AttachmentUploadError;
+    expect(err.code).toBe('ORG_CONTEXT_REQUIRED');
+    expect(err.retryable).toBe(false);
+    expect(err.message).not.toBe(GENERIC);
+  });
+
+  it('names the underlying cause for a failure that never produced a response', async () => {
+    // RN's fetch rejects with a TypeError when it cannot read the file URI or
+    // build the multipart body; that is not a connectivity problem either, and
+    // hiding the message is what made the camera-upload defect undiagnosable.
+    coreRequest.mockRejectedValue(new TypeError('Network request failed'));
+    const err = (await uploadTicketAttachment('t-1', jpeg).catch((e: unknown) => e)) as AttachmentUploadError;
+    expect(err.code).toBe('UPLOAD_FAILED');
+    expect(err.retryable).toBe(true);
+    expect(err.message).toContain('Network request failed');
+  });
+});

--- a/apps/mobile/src/store/aiChatSlice.test.ts
+++ b/apps/mobile/src/store/aiChatSlice.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 import reducer, {
+  reconcileHistory,
+  setInFlightTool,
   addPendingAssistantMessage,
   addUserMessage,
   appendDelta,
@@ -230,5 +232,52 @@ describe('aiChatSlice', () => {
     s = reducer(s, addPendingAssistantMessage({ id: 'a1', sentAt: 't' }));
     s = reducer(s, resetChat());
     expect(s).toEqual(INITIAL);
+  });
+});
+
+describe('reconcileHistory', () => {
+  const started = { toolUseId: 't1', toolName: 'manage_services', state: 'started' as const };
+
+  it('keeps the turn streaming with the running tool captioned when incomplete', () => {
+    let s = reducer(INITIAL, addPendingAssistantMessage({ id: 'local-a', sentAt: 't' }));
+    s = reducer(
+      s,
+      reconcileHistory({
+        sessionId: 's1',
+        messages: [
+          { id: 'u1', role: 'user', content: 'restart spooler', sentAt: 't' },
+          { id: 'a1', role: 'assistant', content: '', toolEvents: [started], sentAt: 't', isStreaming: false },
+        ],
+        complete: false,
+      }),
+    );
+    expect(s.sessionId).toBe('s1');
+    expect(s.status).toBe('streaming');
+    expect(s.streamingMessageId).toBe('a1');
+    expect(s.inFlightTool).toEqual({ toolUseId: 't1', toolName: 'manage_services' });
+    const last = s.messages[s.messages.length - 1];
+    expect(last.role === 'assistant' && last.isStreaming).toBe(true);
+    // The local placeholder is replaced by the server transcript, not appended to.
+    expect(s.messages.map((m) => m.id)).toEqual(['u1', 'a1']);
+  });
+
+  it('settles to idle when the transcript is complete', () => {
+    let s = reducer(INITIAL, addPendingAssistantMessage({ id: 'local-a', sentAt: 't' }));
+    s = reducer(s, setInFlightTool({ toolUseId: 't1', toolName: 'manage_services' }));
+    s = reducer(
+      s,
+      reconcileHistory({
+        sessionId: 's1',
+        messages: [
+          { id: 'u1', role: 'user', content: 'restart spooler', sentAt: 't' },
+          { id: 'a1', role: 'assistant', content: 'Done.', toolEvents: [{ ...started, state: 'completed' }], sentAt: 't', isStreaming: false },
+        ],
+        complete: true,
+      }),
+    );
+    expect(s.status).toBe('idle');
+    expect(s.streamingMessageId).toBeNull();
+    expect(s.inFlightTool).toBeNull();
+    expect(s.error).toBeNull();
   });
 });

--- a/apps/mobile/src/store/aiChatSlice.ts
+++ b/apps/mobile/src/store/aiChatSlice.ts
@@ -153,6 +153,34 @@ const aiChatSlice = createSlice({
       state.status = 'idle';
       state.error = null;
     },
+    /**
+     * Replace the transcript with the server's persisted rows for a turn whose
+     * live stream was lost (app suspended, socket dropped during an approval).
+     * The server keeps running the turn and writing rows regardless, so this
+     * is the phone catching up. `complete: false` keeps the streaming pulse
+     * and the RUNNING caption on the last assistant row so the UI reads as
+     * "still working" rather than "silently finished with a stub".
+     */
+    reconcileHistory(
+      state,
+      action: PayloadAction<{ sessionId: string; messages: ChatMessage[]; complete: boolean }>,
+    ) {
+      state.sessionId = action.payload.sessionId;
+      state.messages = action.payload.messages;
+      state.error = null;
+      const last = state.messages[state.messages.length - 1];
+      if (action.payload.complete || !last || last.role !== 'assistant') {
+        state.streamingMessageId = null;
+        state.inFlightTool = null;
+        state.status = action.payload.complete ? 'idle' : 'streaming';
+        return;
+      }
+      last.isStreaming = true;
+      state.streamingMessageId = last.id;
+      const running = last.toolEvents.find((t) => t.state === 'started');
+      state.inFlightTool = running ? { toolUseId: running.toolUseId, toolName: running.toolName } : null;
+      state.status = 'streaming';
+    },
   },
 });
 
@@ -170,6 +198,7 @@ export const {
   clearError,
   resetChat,
   loadHistory,
+  reconcileHistory,
 } = aiChatSlice.actions;
 
 export default aiChatSlice.reducer;

--- a/apps/web/src/stores/processStreamEvent.test.ts
+++ b/apps/web/src/stores/processStreamEvent.test.ts
@@ -176,3 +176,43 @@ describe('plan-mode step sequencing under approval-gated ordering', () => {
     expect(get().activePlan?.status).toBe('executing');
   });
 });
+
+describe('tool_result clears a pendingApproval decided elsewhere', () => {
+  // The approval can be decided on the phone (mobile push) rather than via
+  // this card. The stream then continues with tool_result for the very tool
+  // the card was waiting on; nothing used to clear `pendingApproval`, so the
+  // card stayed pinned over a conversation that had already moved on.
+  function run(events: Parameters<typeof processStreamEvent>[0][]) {
+    const state = makeState();
+    let patch: Partial<StreamableState> = {};
+    let current: string | null = null;
+    for (const ev of events) {
+      current = processStreamEvent(
+        ev,
+        (fn) => { patch = { ...patch, ...fn({ ...state, ...patch }) }; },
+        () => ({ ...state, ...patch }),
+        current,
+      );
+    }
+    return patch;
+  }
+
+  it('clears pendingApproval when the awaited tool reports its result', () => {
+    const patch = run([
+      { type: 'tool_use_start', toolUseId: 'tu-1', toolName: 'manage_services', input: { action: 'restart' } },
+      { type: 'approval_required', executionId: 'e1', toolName: 'manage_services', input: { action: 'restart' }, description: 'Restart Spooler', intentBacked: true },
+      { type: 'tool_result', toolUseId: 'tu-1', output: 'ok', isError: false },
+    ]);
+    expect(patch.pendingApproval).toBeNull();
+    expect(patch.messages?.some((m) => m.role === 'tool_result')).toBe(true);
+  });
+
+  it('leaves pendingApproval alone for a different tool\'s result', () => {
+    const patch = run([
+      { type: 'tool_use_start', toolUseId: 'tu-0', toolName: 'get_device_context', input: {} },
+      { type: 'approval_required', executionId: 'e1', toolName: 'manage_services', input: {}, description: 'Restart Spooler', intentBacked: true },
+      { type: 'tool_result', toolUseId: 'tu-0', output: 'ctx', isError: false },
+    ]);
+    expect(patch.pendingApproval).toMatchObject({ executionId: 'e1' });
+  });
+});

--- a/apps/web/src/stores/processStreamEvent.ts
+++ b/apps/web/src/stores/processStreamEvent.ts
@@ -123,7 +123,24 @@ export function processStreamEvent(
         isError: event.isError,
         createdAt: new Date()
       };
-      set((s) => ({ messages: [...s.messages, resultMsg] }));
+      set((s) => {
+        // The approval this card is waiting on can be decided somewhere else
+        // (mobile push, the Approvals queue). The server then runs the tool and
+        // this result arrives on the still-open stream — so a result for the
+        // awaited tool IS the decision landing, and the card must go with it.
+        // Matched by tool name via the tool_use row: the event carries no
+        // executionId, and the awaited tool is by construction the one whose
+        // result has not yet arrived.
+        const awaited = s.pendingApproval;
+        const toolUse = awaited
+          ? s.messages.find((m) => m.role === 'tool_use' && m.toolUseId === event.toolUseId)
+          : undefined;
+        const resolvesPending = !!awaited && !!toolUse && toolUse.toolName === awaited.toolName;
+        return {
+          messages: [...s.messages, resultMsg],
+          ...(resolvesPending ? { pendingApproval: null } : {}),
+        };
+      });
       return currentAssistantId;
     }
 

--- a/apps/web/src/stores/processStreamEvent.ts
+++ b/apps/web/src/stores/processStreamEvent.ts
@@ -135,7 +135,15 @@ export function processStreamEvent(
         const toolUse = awaited
           ? s.messages.find((m) => m.role === 'tool_use' && m.toolUseId === event.toolUseId)
           : undefined;
-        const resolvesPending = !!awaited && !!toolUse && toolUse.toolName === awaited.toolName;
+        // Parallel calls to the same tool: the awaited one is the LATEST
+        // tool_use of that name (approval_required is published from the
+        // pre-tool hook, i.e. right after its tool_use_start), so an earlier
+        // sibling's result must not dismiss it.
+        const latestOfName = toolUse
+          ? [...s.messages].reverse().find((m) => m.role === 'tool_use' && m.toolName === toolUse.toolName)
+          : undefined;
+        const resolvesPending =
+          !!awaited && !!toolUse && toolUse.toolName === awaited.toolName && latestOfName?.toolUseId === toolUse.toolUseId;
         return {
           messages: [...s.messages, resultMsg],
           ...(resolvesPending ? { pendingApproval: null } : {}),


### PR DESCRIPTION
## Summary

Six defects from Todd's 2026-09-04 iOS screen recording on the OliveTech tenant (frames saved at `~/Documents/breeze-ios-test-frames-2026-09-04/`).

| # | Defect (as observed) | Root cause | Fix |
|---|---|---|---|
| 1 | AI chat stuck on `RUNNING EXECUTE_COMMAND` after approving on the phone; never completes; later "Stopped. Tap to retry." | `ApprovalGate` **replaced** `MainNavigator` with the takeover. `HomeScreen` aborts its SSE stream on unmount, so the `approval_required` event tore down the chat waiting on the decision. Server-side the turn kept running and persisting rows, but nothing on the phone ever re-fetched. | Takeover renders **over** the navigator (stream stays open, like the web card). `HomeScreen` reconciles from `GET /ai/sessions/:id` on remount / background→active / socket error and polls while the transcript is partial (`reconcileHistory` reducer, `turnState.ts`). One quiet retry on the 409 settle race. |
| 2 | Same approval shown twice after a "Breeze" splash; sometimes doesn't dismiss after Face ID | No replay guard on the approval tap listener. A JS relaunch mid-decision re-registers the listener and expo replays the launching tap → `setFocus` on an already-decided request. `PushTapRouter` already guards this for tickets. | Same identifier dedupe, persisted under its own AsyncStorage key. |
| 3 | "Approved · execute_command(…)" toast from the previous request drawn over the next request's buttons | `ApprovalScreen` is one long-lived instance; `approve.fulfilled` rolls focus to the next request in the same tick the toast is queued. | Toasts keyed by approval id; rendered only for the focused request. |
| 4 | Approval headline is the raw signature `manage_services(deviceId=6eae…, action=restart, serviceName=Spooler)` | `intentService` stamped `targetSummary` (audit signature) onto `action_label`, discarding the guardrail's human description passed as `reason`. | `buildActionLabel()` (API): guardrail description with hostname substituted for the device-id stub, softened verb, capped. Used for the approval row, push body and bell. `targetSummary` unchanged. Mobile unpacks legacy signature labels still arriving from pending rows. |
| 5 | Web chat keeps the pending-approval card after the phone decides | `processStreamEvent` never cleared `pendingApproval` on the resumed stream. | `tool_result` for the awaited tool (matched by tool name via its `tool_use` row) clears it. |
| 6 | Cannot dismiss keyboard / scroll to composer or submit on New ticket + Ticket detail | `KeyboardAvoidingView` padding shrinks the viewport but adds no scroll room; 32pt bottom pad; no `keyboardDismissMode`. | `automaticallyAdjustKeyboardInsets` (iOS), `keyboardDismissMode="interactive"`, 64pt pad. KAV disabled on iOS to avoid double-counting. |
| 7 | Camera photo → "Upload failed. Check your connection and try again." with the network fine | **Not root-caused.** Evidence: zero `ticket_attachments` rows in prod for 3 days, no Caddy log hits, no mobile Sentry, API doesn't log requests. So the request never reached the handler: a pre-send failure (image manipulator / file URI) or a 4xx from the auth/route layer, both of which the client collapsed into the generic connectivity message. | Error mapping now surfaces the cause: 4xx without a code → `Upload rejected (HTTP 403: …)`, non-retryable; no-response failures keep the underlying message; `ORG_CONTEXT_REQUIRED` mapped. The next TestFlight run will show the real reason on the chip. |

## Verification

- `apps/mobile`: tsc clean; vitest 97 files / 1249 tests pass (new: `turnState.test.ts`, `reconcileHistory`, `approvalCopy` signature cases, attachment 401/403/404/TypeError cases — all written red-first).
- `apps/api`: tsc clean (needs `--max-old-space-size=12288`); vitest full unit suite 1857 files pass; eslint clean on touched files. New `actionLabel.test.ts`.
- `apps/web`: tsc clean; `src/stores` 230 tests pass; eslint clean. New `processStreamEvent` cases.
- Not verified on device: the overlay takeover, keyboard insets and the reconcile poll need a TestFlight build to confirm.

## Follow-ups (not in this PR)

- Photo upload root cause once the new error text is seen on device.
- Systems header math (`75 devices · 19 offline.` vs `38 online · 19 offline`), ticket status chips lacking "New", org picker without search, `MANAGE_ALERTS` leaking "All" into the chat, streamed text stitched without spaces ("first.I found") — all observed in the same recording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9aYCUwFojJJzPBt1uBELQ
