### PR TITLE
feat(api): validate custom-field values on both shipped write paths (#3257 W04)

### DIFF
--- a/apps/api/src/routes/devices/core.customFieldValidation.test.ts
+++ b/apps/api/src/routes/devices/core.customFieldValidation.test.ts
@@ -1,0 +1,225 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+// #3257 W04: PATCH /devices/:id validates a `customFields` payload against
+// its definition too, sharing services/customFields/validateValueMap.ts with
+// PATCH /devices/:id/custom-fields (customFieldValues.ts). Isolated from
+// core.permissions.test.ts's larger gate suite so this wave's tests don't
+// collide with unrelated work on that file.
+
+vi.mock('../../db', () => ({
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    select: vi.fn(),
+    execute: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    transaction: vi.fn(),
+  },
+}));
+
+vi.mock('../../db/schema', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../db/schema')>();
+  return { ...actual };
+});
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => {
+    c.set('auth', {
+      user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
+      scope: 'organization',
+      orgId: 'org-123',
+      partnerId: null,
+      accessibleOrgIds: ['org-123'],
+      canAccessOrg: (orgId: string) => orgId === 'org-123',
+      orgCondition: () => undefined,
+      token: { mfa: false },
+    });
+    return next();
+  }),
+  requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermission: vi.fn((resource: string, action: string) => async (c: any, next: any) => {
+    c.set('permissions', {
+      permissions: [{ resource, action }],
+      partnerId: null,
+      orgId: 'org-123',
+      roleId: 'role-123',
+      scope: 'organization',
+    });
+    return next();
+  }),
+  requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
+}));
+
+vi.mock('../../services/auditEvents', () => ({
+  writeRouteAudit: vi.fn(),
+}));
+
+vi.mock('../../jobs/peripheralJobs', () => ({
+  schedulePeripheralPolicyDevice: vi.fn().mockResolvedValue('job-id'),
+}));
+
+vi.mock('../../services/sentry', () => ({
+  captureException: vi.fn(),
+}));
+
+vi.mock('../../services/remoteAccessPolicy', () => ({
+  resolveRemoteAccessForDevice: vi.fn().mockResolvedValue({ policyId: null, settings: {} }),
+}));
+
+vi.mock('../../services/remoteAccessLauncher', () => ({
+  resolveRemoteAccessLaunch: vi.fn().mockReturnValue({ launchUrl: null, skipReason: 'no_provider_configured' }),
+}));
+
+vi.mock('../agentWs', () => ({
+  sendCommandToAgent: vi.fn(),
+  isAgentConnected: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('../../services/commandQueue', () => ({
+  CommandTypes: { SELF_UNINSTALL: 'self_uninstall' },
+  queueCommandForExecution: vi.fn(),
+}));
+
+vi.mock('../agents/enrollment', () => ({
+  getGlobalEnrollmentSecret: vi.fn().mockReturnValue(null),
+}));
+
+// The PATCH handler now runs every `customFields` map through
+// validateCustomFieldMap, which calls loadVisibleCustomFieldDefinitions under
+// a SYSTEM db context. Mocked at the module boundary (see
+// customFieldValues.test.ts for the same pattern).
+vi.mock('../../services/customFields/queries', () => ({
+  loadVisibleCustomFieldDefinitions: vi.fn(),
+}));
+
+import { coreRoutes } from './core';
+import { db } from '../../db';
+import { loadVisibleCustomFieldDefinitions } from '../../services/customFields/queries';
+import type { VisibleCustomFieldDefinition } from '../../services/customFields/queries';
+
+const ORG_ID = 'org-123';
+const DEVICE_ID = '11111111-1111-4111-8111-111111111111';
+
+const ACCESSIBLE_DEVICE: Record<string, unknown> = {
+  id: DEVICE_ID,
+  orgId: ORG_ID,
+  siteId: 'site-1',
+  hostname: 'host-1',
+  status: 'online' as const,
+  customFields: null,
+  managementPosture: null,
+};
+
+function rigDeviceLookup(device: unknown) {
+  const limit = vi.fn().mockResolvedValue(device ? [device] : []);
+  const where = vi.fn().mockReturnValue({ limit });
+  const from = vi.fn().mockReturnValue({ where });
+  vi.mocked(db.select).mockReturnValue({ from } as never);
+}
+
+function rigPlainUpdate(updatedRow: unknown) {
+  const returning = vi.fn().mockResolvedValue([updatedRow]);
+  const where = vi.fn().mockReturnValue({ returning });
+  const set = vi.fn().mockReturnValue({ where });
+  vi.mocked(db.update).mockReturnValue({ set } as never);
+  return { set };
+}
+
+function mockVisibleDefinitions(defs: Array<Partial<VisibleCustomFieldDefinition> & { fieldKey: string }>) {
+  const full: VisibleCustomFieldDefinition[] = defs.map((d) => ({
+    id: d.id ?? `def-${d.fieldKey}`,
+    fieldKey: d.fieldKey,
+    name: d.name ?? d.fieldKey,
+    type: d.type ?? 'text',
+    options: d.options ?? null,
+    deviceTypes: d.deviceTypes ?? null,
+    required: d.required ?? false,
+    scriptWrite: d.scriptWrite ?? false,
+    orgId: d.orgId ?? ORG_ID,
+    partnerId: d.partnerId ?? null,
+  }));
+  vi.mocked(loadVisibleCustomFieldDefinitions).mockResolvedValue(full);
+}
+
+describe('PATCH /devices/:id — custom field value validation (#3257 W04)', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = new Hono();
+    app.route('/devices', coreRoutes);
+  });
+
+  it('rejects an invalid custom field on PATCH /devices/:id and writes nothing', async () => {
+    mockVisibleDefinitions([{ fieldKey: 'purchase_date', type: 'date' }]);
+    rigDeviceLookup(ACCESSIBLE_DEVICE);
+    const updateSpy = rigPlainUpdate(ACCESSIBLE_DEVICE);
+
+    const res = await app.request(`/devices/${DEVICE_ID}`, {
+      method: 'PATCH',
+      headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ customFields: { purchase_date: 'never' } }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe('invalid-custom-field-value');
+    expect(body.fields).toEqual([{ fieldKey: 'purchase_date', reason: 'invalid_date' }]);
+    expect(updateSpy.set).not.toHaveBeenCalled();
+    expect(db.transaction).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown custom field key on PATCH /devices/:id', async () => {
+    mockVisibleDefinitions([]);
+    rigDeviceLookup(ACCESSIBLE_DEVICE);
+    rigPlainUpdate(ACCESSIBLE_DEVICE);
+
+    const res = await app.request(`/devices/${DEVICE_ID}`, {
+      method: 'PATCH',
+      headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ customFields: { nope: 'x' } }),
+    });
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).fields).toEqual([{ fieldKey: 'nope', reason: 'unknown_field' }]);
+  });
+
+  it('accepts a valid custom field value and stores the coerced value on PATCH /devices/:id', async () => {
+    mockVisibleDefinitions([{ fieldKey: 'rack_units', type: 'number' }]);
+    rigDeviceLookup(ACCESSIBLE_DEVICE);
+    let written: Record<string, unknown> | undefined;
+    vi.mocked(db.update).mockReturnValue({
+      set: (v: Record<string, unknown>) => {
+        written = v;
+        return { where: () => ({ returning: async () => [{ ...ACCESSIBLE_DEVICE, ...v }] }) };
+      },
+    } as never);
+
+    const res = await app.request(`/devices/${DEVICE_ID}`, {
+      method: 'PATCH',
+      headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ customFields: { rack_units: '4' } }),
+    });
+
+    expect(res.status).toBe(200);
+    expect((written?.customFields as Record<string, unknown> | undefined)?.rack_units).toBe(4);
+  });
+
+  it('does not touch definitions or validation when the PATCH has no customFields key', async () => {
+    rigDeviceLookup(ACCESSIBLE_DEVICE);
+    rigPlainUpdate({ ...ACCESSIBLE_DEVICE, displayName: 'renamed' });
+
+    const res = await app.request(`/devices/${DEVICE_ID}`, {
+      method: 'PATCH',
+      headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ displayName: 'renamed' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(loadVisibleCustomFieldDefinitions).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/devices/core.customFieldValidation.test.ts
+++ b/apps/api/src/routes/devices/core.customFieldValidation.test.ts
@@ -170,7 +170,58 @@ describe('PATCH /devices/:id — custom field value validation (#3257 W04)', () 
     expect(body.code).toBe('invalid-custom-field-value');
     expect(body.fields).toEqual([{ fieldKey: 'purchase_date', reason: 'invalid_date' }]);
     expect(updateSpy.set).not.toHaveBeenCalled();
-    expect(db.transaction).not.toHaveBeenCalled();
+  });
+
+  it('rejects the WHOLE PATCH — including a valid displayName — when customFields fails', async () => {
+    // The 400 must fire before `updates` is even built, so a valid sibling
+    // field in the same PATCH must not sneak through either.
+    mockVisibleDefinitions([{ fieldKey: 'purchase_date', type: 'date' }]);
+    rigDeviceLookup(ACCESSIBLE_DEVICE);
+    const updateSpy = rigPlainUpdate(ACCESSIBLE_DEVICE);
+
+    const res = await app.request(`/devices/${DEVICE_ID}`, {
+      method: 'PATCH',
+      headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ displayName: 'renamed', customFields: { purchase_date: 'never' } }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(updateSpy.set).not.toHaveBeenCalled();
+  });
+
+  it('is all-or-nothing on a MIXED valid+invalid customFields map', async () => {
+    mockVisibleDefinitions([
+      { fieldKey: 'rack_units', type: 'number' },
+      { fieldKey: 'notes', type: 'text' },
+    ]);
+    rigDeviceLookup(ACCESSIBLE_DEVICE);
+    const updateSpy = rigPlainUpdate(ACCESSIBLE_DEVICE);
+
+    const res = await app.request(`/devices/${DEVICE_ID}`, {
+      method: 'PATCH',
+      headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ customFields: { rack_units: 'abc', notes: 'a perfectly valid note' } }),
+    });
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).fields).toEqual([{ fieldKey: 'rack_units', reason: 'invalid_type' }]);
+    expect(updateSpy.set).not.toHaveBeenCalled();
+  });
+
+  it('rejects a value for a definition scoped to a device type the device is not', async () => {
+    mockVisibleDefinitions([{ fieldKey: 'rustdesk_id', type: 'text', deviceTypes: ['windows'] }]);
+    rigDeviceLookup({ ...ACCESSIBLE_DEVICE, osType: 'macos' });
+    const updateSpy = rigPlainUpdate(ACCESSIBLE_DEVICE);
+
+    const res = await app.request(`/devices/${DEVICE_ID}`, {
+      method: 'PATCH',
+      headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ customFields: { rustdesk_id: 'abc123' } }),
+    });
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).fields).toEqual([{ fieldKey: 'rustdesk_id', reason: 'not_applicable_to_device' }]);
+    expect(updateSpy.set).not.toHaveBeenCalled();
   });
 
   it('rejects an unknown custom field key on PATCH /devices/:id', async () => {

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -1534,7 +1534,7 @@ coreRoutes.patch(
     // All-or-nothing per request; nothing else in this PATCH is written when
     // a custom field fails (#3257 W04).
     if (data.customFields !== undefined) {
-      const validation = await validateCustomFieldMap(device.orgId, data.customFields);
+      const validation = await validateCustomFieldMap(device.orgId, device.osType, data.customFields);
       if (!validation.ok) {
         return c.json(
           {

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -75,6 +75,7 @@ import {
   withExtensionDeviceOrgMoveDelete,
 } from '../../extensions/tenancyRegistry';
 import { pgErrorCode, pgErrorNode } from '../../utils/pgErrors';
+import { validateCustomFieldMap, INVALID_CUSTOM_FIELD_VALUE_MESSAGE } from '../../services/customFields/validateValueMap';
 import { schedulePeripheralPolicyDevice } from '../../jobs/peripheralJobs';
 import { requireCapability } from '../../services/partnerTrust';
 
@@ -1527,6 +1528,26 @@ coreRoutes.patch(
       }
     }
 
+    // Validate any custom-field values against their definition BEFORE
+    // building the update set — see customFieldValues.ts (PATCH
+    // /devices/:id/custom-fields) for why this must hold on both write paths.
+    // All-or-nothing per request; nothing else in this PATCH is written when
+    // a custom field fails (#3257 W04).
+    if (data.customFields !== undefined) {
+      const validation = await validateCustomFieldMap(device.orgId, data.customFields);
+      if (!validation.ok) {
+        return c.json(
+          {
+            error: INVALID_CUSTOM_FIELD_VALUE_MESSAGE,
+            code: 'invalid-custom-field-value',
+            fields: validation.rejected,
+          },
+          400,
+        );
+      }
+      data.customFields = validation.values;
+    }
+
     const updates: Record<string, unknown> = { updatedAt: new Date() };
     if (data.displayName !== undefined) updates.displayName = data.displayName;
     if (data.siteId !== undefined) updates.siteId = data.siteId;
@@ -1536,7 +1557,7 @@ coreRoutes.patch(
       updates.deviceRoleSource = 'manual';
     }
     if (data.customFields !== undefined) {
-      // Merge with existing custom fields rather than replacing
+      // Merge with existing (coerced) custom fields rather than replacing
       const raw = device.customFields;
       const existing: Record<string, unknown> =
         raw !== null && typeof raw === 'object' && !Array.isArray(raw)

--- a/apps/api/src/routes/devices/customFieldValues.mountorder.test.ts
+++ b/apps/api/src/routes/devices/customFieldValues.mountorder.test.ts
@@ -87,6 +87,26 @@ vi.mock('../../services/auditService', () => ({
   createAuditLog: vi.fn().mockResolvedValue(undefined),
 }));
 
+// #3257 W04: the PATCH handler now validates against the bounded definition
+// lookup before merging. Mocked here too (see customFieldValues.test.ts) so
+// this mount-order guard keeps exercising mount order, not validation.
+vi.mock('../../services/customFields/queries', () => ({
+  loadVisibleCustomFieldDefinitions: vi.fn().mockResolvedValue([
+    {
+      id: 'def-note',
+      fieldKey: 'note',
+      name: 'note',
+      type: 'text',
+      options: null,
+      deviceTypes: null,
+      required: false,
+      scriptWrite: false,
+      orgId: '11111111-1111-4111-8111-111111111111',
+      partnerId: null,
+    },
+  ]),
+}));
+
 // Other device sub-routers pulled in by the assembled router import them at
 // module load; stub the heavy ones so the import succeeds.
 vi.mock('../../services/auditEvents', async (importOriginal) => {

--- a/apps/api/src/routes/devices/customFieldValues.test.ts
+++ b/apps/api/src/routes/devices/customFieldValues.test.ts
@@ -121,9 +121,37 @@ vi.mock('../../services/auditService', () => ({
   createAuditLog: vi.fn().mockResolvedValue(undefined),
 }));
 
+// #3257 W04: every write now validates against the bounded, SYSTEM-context
+// definition lookup BEFORE merging. Mocked at the module boundary rather than
+// standing up the two-select db.select chain it drives internally (see
+// services/customFields/queries.test.ts for that).
+vi.mock('../../services/customFields/queries', () => ({
+  loadVisibleCustomFieldDefinitions: vi.fn(),
+}));
+
 import { customFieldValuesRoutes } from './customFieldValues';
 import { db } from '../../db';
 import { createAuditLog } from '../../services/auditService';
+import { loadVisibleCustomFieldDefinitions } from '../../services/customFields/queries';
+import type { VisibleCustomFieldDefinition } from '../../services/customFields/queries';
+
+const ORG_A_ID = ORG_A;
+
+function mockVisibleDefinitions(defs: Array<Partial<VisibleCustomFieldDefinition> & { fieldKey: string }>) {
+  const full: VisibleCustomFieldDefinition[] = defs.map((d) => ({
+    id: d.id ?? `def-${d.fieldKey}`,
+    fieldKey: d.fieldKey,
+    name: d.name ?? d.fieldKey,
+    type: d.type ?? 'text',
+    options: d.options ?? null,
+    deviceTypes: d.deviceTypes ?? null,
+    required: d.required ?? false,
+    scriptWrite: d.scriptWrite ?? false,
+    orgId: d.orgId ?? ORG_A_ID,
+    partnerId: d.partnerId ?? null,
+  }));
+  vi.mocked(loadVisibleCustomFieldDefinitions).mockResolvedValue(full);
+}
 
 function makeDevice(overrides: Record<string, unknown> = {}) {
   return {
@@ -159,6 +187,11 @@ describe('device custom-field value routes (#2066)', () => {
     vi.clearAllMocks();
     app = new Hono();
     app.route('/devices', customFieldValuesRoutes);
+    // Default: the free-form field keys used by the pre-existing tests below
+    // (predating per-value validation) resolve to a permissive text
+    // definition, so those tests keep asserting the merge/audit/isolation
+    // behaviour they were written for rather than becoming validation tests.
+    mockVisibleDefinitions([{ fieldKey: 'bitlocker_recovery_key' }, { fieldKey: 'note' }]);
   });
 
   describe('API-key write path', () => {
@@ -411,6 +444,100 @@ describe('device custom-field value routes (#2066)', () => {
       });
 
       expect(res.status).toBe(401);
+    });
+  });
+
+  describe('value validation against the definition (#3257 W04)', () => {
+    it('rejects a value whose type does not match its definition', async () => {
+      mockVisibleDefinitions([{ fieldKey: 'rack_units', type: 'number' }]);
+      rigDeviceLookup(makeDevice());
+      const updateSpy = rigUpdate(makeDevice());
+
+      const res = await app.request(`/devices/${DEVICE_ID}/custom-fields`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer session-token' },
+        body: JSON.stringify({ rack_units: 'abc' }),
+      });
+
+      expect(res.status).toBe(400);
+      expect(await res.json()).toMatchObject({
+        code: 'invalid-custom-field-value',
+        fields: [{ fieldKey: 'rack_units', reason: 'invalid_type' }],
+      });
+      expect(updateSpy.set).not.toHaveBeenCalled();
+    });
+
+    it('rejects a key with no visible definition', async () => {
+      mockVisibleDefinitions([]);
+      rigDeviceLookup(makeDevice());
+      const updateSpy = rigUpdate(makeDevice());
+
+      const res = await app.request(`/devices/${DEVICE_ID}/custom-fields`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer session-token' },
+        body: JSON.stringify({ nope: 'x' }),
+      });
+
+      expect(res.status).toBe(400);
+      expect((await res.json()).fields).toEqual([{ fieldKey: 'nope', reason: 'unknown_field' }]);
+      expect(updateSpy.set).not.toHaveBeenCalled();
+    });
+
+    it('rejects a dropdown value outside options.choices', async () => {
+      mockVisibleDefinitions([
+        { fieldKey: 'tier', type: 'dropdown', options: { choices: [{ label: 'Gold', value: 'gold' }] } },
+      ]);
+      rigDeviceLookup(makeDevice());
+
+      const res = await app.request(`/devices/${DEVICE_ID}/custom-fields`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer session-token' },
+        body: JSON.stringify({ tier: 'bronze' }),
+      });
+
+      expect((await res.json()).fields).toEqual([{ fieldKey: 'tier', reason: 'not_a_choice' }]);
+    });
+
+    it('stores the COERCED value, not the raw string', async () => {
+      mockVisibleDefinitions([{ fieldKey: 'rack_units', type: 'number' }]);
+      rigDeviceLookup(makeDevice());
+      let written: { customFields?: Record<string, unknown> } | undefined;
+      vi.mocked(db.update).mockReturnValue({
+        set: (v: { customFields: Record<string, unknown> }) => {
+          written = v;
+          return { where: () => ({ returning: async () => [{ customFields: v.customFields }] }) };
+        },
+      } as never);
+
+      await app.request(`/devices/${DEVICE_ID}/custom-fields`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer session-token' },
+        body: JSON.stringify({ rack_units: '4' }),
+      });
+
+      expect(written?.customFields?.rack_units).toBe(4);
+    });
+
+    it('rejects an API-key write that fails validation, same as a session write', async () => {
+      // The API-key branch is the trivially scriptable one; validating only
+      // the JWT branch would leave the interesting path open.
+      mockVisibleDefinitions([{ fieldKey: 'rack_units', type: 'number' }]);
+      rigDeviceLookup(makeDevice());
+      const updateSpy = rigUpdate(makeDevice());
+
+      const res = await app.request(`/devices/${DEVICE_ID}/custom-fields`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-API-Key': 'brz_test',
+          'x-test-org': ORG_A,
+          'x-test-scopes': 'devices:write',
+        },
+        body: JSON.stringify({ rack_units: 'abc' }),
+      });
+
+      expect(res.status).toBe(400);
+      expect(updateSpy.set).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/routes/devices/customFieldValues.test.ts
+++ b/apps/api/src/routes/devices/customFieldValues.test.ts
@@ -488,6 +488,7 @@ describe('device custom-field value routes (#2066)', () => {
         { fieldKey: 'tier', type: 'dropdown', options: { choices: [{ label: 'Gold', value: 'gold' }] } },
       ]);
       rigDeviceLookup(makeDevice());
+      const updateSpy = rigUpdate(makeDevice());
 
       const res = await app.request(`/devices/${DEVICE_ID}/custom-fields`, {
         method: 'PATCH',
@@ -496,6 +497,77 @@ describe('device custom-field value routes (#2066)', () => {
       });
 
       expect((await res.json()).fields).toEqual([{ fieldKey: 'tier', reason: 'not_a_choice' }]);
+      expect(updateSpy.set).not.toHaveBeenCalled();
+    });
+
+    it('rejects an out-of-range number', async () => {
+      mockVisibleDefinitions([{ fieldKey: 'rack_units', type: 'number', options: { min: 0, max: 8 } }]);
+      rigDeviceLookup(makeDevice());
+      const updateSpy = rigUpdate(makeDevice());
+
+      const res = await app.request(`/devices/${DEVICE_ID}/custom-fields`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer session-token' },
+        body: JSON.stringify({ rack_units: 99 }),
+      });
+
+      expect(res.status).toBe(400);
+      expect((await res.json()).fields).toEqual([{ fieldKey: 'rack_units', reason: 'out_of_range' }]);
+      expect(updateSpy.set).not.toHaveBeenCalled();
+    });
+
+    it('is all-or-nothing on a MIXED valid+invalid payload: one bad key rejects the whole PATCH', async () => {
+      // The single-key tests above can't distinguish "atomic across the whole
+      // map" from "the one field it saw happened to fail" — this is the case
+      // that actually exercises the all-or-nothing contract.
+      mockVisibleDefinitions([
+        { fieldKey: 'rack_units', type: 'number' },
+        { fieldKey: 'notes', type: 'text' },
+      ]);
+      rigDeviceLookup(makeDevice());
+      const updateSpy = rigUpdate(makeDevice());
+
+      const res = await app.request(`/devices/${DEVICE_ID}/custom-fields`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer session-token' },
+        body: JSON.stringify({ rack_units: 'abc', notes: 'a perfectly valid note' }),
+      });
+
+      expect(res.status).toBe(400);
+      expect((await res.json()).fields).toEqual([{ fieldKey: 'rack_units', reason: 'invalid_type' }]);
+      // The valid `notes` key must not be written even though it validated fine.
+      expect(updateSpy.set).not.toHaveBeenCalled();
+    });
+
+    it('rejects a value for a definition scoped to a device type the device is not', async () => {
+      mockVisibleDefinitions([{ fieldKey: 'rustdesk_id', type: 'text', deviceTypes: ['windows'] }]);
+      rigDeviceLookup(makeDevice({ osType: 'macos' }));
+      const updateSpy = rigUpdate(makeDevice());
+
+      const res = await app.request(`/devices/${DEVICE_ID}/custom-fields`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer session-token' },
+        body: JSON.stringify({ rustdesk_id: 'abc123' }),
+      });
+
+      expect(res.status).toBe(400);
+      expect((await res.json()).fields).toEqual([{ fieldKey: 'rustdesk_id', reason: 'not_applicable_to_device' }]);
+      expect(updateSpy.set).not.toHaveBeenCalled();
+    });
+
+    it('treats an empty string as a clear for a dropdown field, not a rejection', async () => {
+      // Regression: the device-edit UI's <select> reports a clear as ''.
+      mockVisibleDefinitions([{ fieldKey: 'tier', type: 'dropdown', options: { choices: ['gold'] } }]);
+      rigDeviceLookup(makeDevice());
+      rigUpdate(makeDevice({ customFields: { existing_field: 'keep-me', tier: null } }));
+
+      const res = await app.request(`/devices/${DEVICE_ID}/custom-fields`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer session-token' },
+        body: JSON.stringify({ tier: '' }),
+      });
+
+      expect(res.status).toBe(200);
     });
 
     it('stores the COERCED value, not the raw string', async () => {

--- a/apps/api/src/routes/devices/customFieldValues.ts
+++ b/apps/api/src/routes/devices/customFieldValues.ts
@@ -60,6 +60,14 @@ import { validateCustomFieldMap, INVALID_CUSTOM_FIELD_VALUE_MESSAGE } from '../.
  * AFTER it, so mounting after `coreRoutes` would re-introduce the session-only
  * `authMiddleware` ahead of our API-key branch and resurrect the 401. See the
  * `hono_router_use_wildcard_root_mount_auth_leak` lesson.
+ *
+ * #3257 W04: a PATCH now requires a matching `custom_field_definitions` row —
+ * a key with no visible definition is rejected `400 unknown_field`, and a
+ * value that doesn't match the definition's declared type is rejected
+ * `400 invalid-custom-field-value`. The `bitlocker_recovery_key` example above
+ * is pre-#3257 framing kept for the auth-flavour narrative; a caller must now
+ * create the field's definition first (`routes/customFields.ts`) before a
+ * PATCH here will accept it.
  */
 export const customFieldValuesRoutes = new Hono();
 
@@ -233,7 +241,7 @@ customFieldValuesRoutes.patch(
     // Record<string, string|number|boolean|null> was the wrong contract on
     // both branches of dualAuth (#3257 W04). All-or-nothing: one PATCH is one
     // operator action, unlike the importer's partial-apply bulk load.
-    const validation = await validateCustomFieldMap(device.orgId, updates);
+    const validation = await validateCustomFieldMap(device.orgId, device.osType, updates);
     if (!validation.ok) {
       return c.json(
         {

--- a/apps/api/src/routes/devices/customFieldValues.ts
+++ b/apps/api/src/routes/devices/customFieldValues.ts
@@ -18,6 +18,7 @@ import { canAccessSite, PERMISSIONS, type UserPermissions } from '../../services
 import { createAuditLog } from '../../services/auditService';
 import { ANONYMOUS_ACTOR_ID } from '../../services/auditEvents';
 import { getTrustedClientIpOrUndefined } from '../../services/clientIp';
+import { validateCustomFieldMap, INVALID_CUSTOM_FIELD_VALUE_MESSAGE } from '../../services/customFields/validateValueMap';
 
 /**
  * Device custom-field VALUE read/write API.
@@ -225,9 +226,28 @@ customFieldValuesRoutes.patch(
       return c.json({ error: 'Device not found' }, 404);
     }
 
+    // Validate every key against its definition BEFORE merging. Custom-field
+    // values are an execution sink (installerVariables substitutes them into
+    // installer command lines) and a targeting control (filterEngine's
+    // custom.<key> selects deployment targets), so an unconstrained
+    // Record<string, string|number|boolean|null> was the wrong contract on
+    // both branches of dualAuth (#3257 W04). All-or-nothing: one PATCH is one
+    // operator action, unlike the importer's partial-apply bulk load.
+    const validation = await validateCustomFieldMap(device.orgId, updates);
+    if (!validation.ok) {
+      return c.json(
+        {
+          error: INVALID_CUSTOM_FIELD_VALUE_MESSAGE,
+          code: 'invalid-custom-field-value',
+          fields: validation.rejected,
+        },
+        400,
+      );
+    }
+
     // Merge with existing values rather than replacing the whole object, matching
     // the PATCH /devices/:id semantics.
-    const merged = { ...readExistingCustomFields(device.customFields), ...updates };
+    const merged = { ...readExistingCustomFields(device.customFields), ...validation.values };
 
     const [updated] = await db
       .update(devices)

--- a/apps/api/src/services/customFields/queries.test.ts
+++ b/apps/api/src/services/customFields/queries.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Generalises the bounded, SYSTEM-context definition lookup so both the
+// script write-back path AND the two device-PATCH write paths (#3257 W04)
+// can see org-owned + partner-wide custom-field definitions from one loader.
+
+vi.mock('../../db', () => ({
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withSystemDbAccessContext: vi.fn((fn: () => unknown, _label?: string) => fn()),
+  db: {
+    select: vi.fn(),
+  },
+}));
+
+vi.mock('../../db/schema', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../db/schema')>();
+  return { ...actual };
+});
+
+import { db } from '../../db';
+import {
+  loadScriptWritableDefinitions,
+  loadVisibleCustomFieldDefinitions,
+} from './queries';
+
+interface FixtureDefinition {
+  id: string;
+  fieldKey: string;
+  orgId: string | null;
+  partnerId: string | null;
+  type: 'text' | 'number' | 'boolean' | 'dropdown' | 'date';
+  options: unknown;
+  deviceTypes: string[] | null;
+  required: boolean;
+  scriptWrite: boolean;
+  name: string;
+}
+
+const ORG_ID = 'org-1';
+
+function mockOrgPartner(partnerId: string | null) {
+  const limit = vi.fn().mockResolvedValue([{ partnerId }]);
+  const where = vi.fn().mockReturnValue({ limit });
+  const from = vi.fn().mockReturnValue({ where });
+  vi.mocked(db.select).mockReturnValueOnce({ from } as never);
+}
+
+function mockDefinitions(defs: FixtureDefinition[]) {
+  const where = vi.fn().mockResolvedValue(defs);
+  const from = vi.fn().mockReturnValue({ where });
+  vi.mocked(db.select).mockReturnValueOnce({ from } as never);
+}
+
+describe('loadVisibleCustomFieldDefinitions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns org-owned AND partner-wide definitions for the org', async () => {
+    mockOrgPartner('partner-1');
+    mockDefinitions([
+      {
+        id: 'd1',
+        fieldKey: 'asset_tag',
+        orgId: 'org-1',
+        partnerId: null,
+        type: 'text',
+        options: null,
+        deviceTypes: null,
+        required: false,
+        scriptWrite: false,
+        name: 'Asset Tag',
+      },
+      {
+        id: 'd2',
+        fieldKey: 'udf7',
+        orgId: null,
+        partnerId: 'partner-1',
+        type: 'number',
+        options: null,
+        deviceTypes: null,
+        required: false,
+        scriptWrite: false,
+        name: 'UDF 7',
+      },
+    ]);
+
+    const defs = await loadVisibleCustomFieldDefinitions(ORG_ID);
+
+    expect(defs.map((d) => d.fieldKey).sort()).toEqual(['asset_tag', 'udf7']);
+    expect(defs.find((d) => d.fieldKey === 'udf7')!.id).toBe('d2');
+    // Widened projection: id, name and required must be present, not dropped.
+    expect(defs.find((d) => d.fieldKey === 'asset_tag')).toMatchObject({
+      id: 'd1',
+      name: 'Asset Tag',
+      required: false,
+      orgId: 'org-1',
+      partnerId: null,
+    });
+  });
+
+  it('scopes to the org alone when the org has no partner', async () => {
+    mockOrgPartner(null);
+    mockDefinitions([
+      {
+        id: 'd1',
+        fieldKey: 'asset_tag',
+        orgId: 'org-1',
+        partnerId: null,
+        type: 'text',
+        options: null,
+        deviceTypes: null,
+        required: false,
+        scriptWrite: false,
+        name: 'Asset Tag',
+      },
+    ]);
+
+    const defs = await loadVisibleCustomFieldDefinitions(ORG_ID);
+    expect(defs.map((d) => d.fieldKey)).toEqual(['asset_tag']);
+  });
+});
+
+describe('loadScriptWritableDefinitions (retained alias)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('still returns both script_write and non-script_write rows — the caller applies that gate', async () => {
+    // note: the CALLER (scriptWriteBack) applies the script_write gate per
+    // field, so this loader intentionally returns both — assert the existing
+    // contract, do not silently change it. See scriptWriteBack.ts:104-107.
+    mockOrgPartner('partner-1');
+    mockDefinitions([
+      {
+        id: 'd1',
+        fieldKey: 'a',
+        orgId: 'org-1',
+        partnerId: null,
+        scriptWrite: true,
+        type: 'text',
+        options: null,
+        deviceTypes: null,
+        required: false,
+        name: 'A',
+      },
+      {
+        id: 'd2',
+        fieldKey: 'b',
+        orgId: 'org-1',
+        partnerId: null,
+        scriptWrite: false,
+        type: 'text',
+        options: null,
+        deviceTypes: null,
+        required: false,
+        name: 'B',
+      },
+    ]);
+
+    const defs = await loadScriptWritableDefinitions(ORG_ID);
+    expect(defs.map((d) => d.fieldKey)).toEqual(['a', 'b']);
+  });
+
+  it('is the same function reference as loadVisibleCustomFieldDefinitions', () => {
+    expect(loadScriptWritableDefinitions).toBe(loadVisibleCustomFieldDefinitions);
+  });
+});

--- a/apps/api/src/services/customFields/queries.ts
+++ b/apps/api/src/services/customFields/queries.ts
@@ -20,6 +20,19 @@ export interface ScriptWritableDefinition {
   scriptWrite: boolean;
 }
 
+export interface VisibleCustomFieldDefinition {
+  id: string;
+  fieldKey: string;
+  name: string;
+  type: 'text' | 'number' | 'boolean' | 'dropdown' | 'date';
+  options: unknown;
+  deviceTypes: string[] | null;
+  required: boolean;
+  scriptWrite: boolean;
+  orgId: string | null;
+  partnerId: string | null;
+}
+
 /** Ambient ORG context — `devices` is shape 1 and RLS is a real backstop here. */
 export async function loadDeviceForWriteBack(deviceId: string): Promise<WriteBackDevice | null> {
   const [row] = await db
@@ -54,9 +67,9 @@ export async function loadDeviceForWriteBack(deviceId: string): Promise<WriteBac
  * narrow, and the context is released immediately (it holds a second pooled
  * connection for its duration — #1105).
  */
-export async function loadScriptWritableDefinitions(
+export async function loadVisibleCustomFieldDefinitions(
   orgId: string,
-): Promise<ScriptWritableDefinition[]> {
+): Promise<VisibleCustomFieldDefinition[]> {
   return runOutsideDbContext(() =>
     withSystemDbAccessContext(async () => {
       const [org] = await db
@@ -77,17 +90,31 @@ export async function loadScriptWritableDefinitions(
 
       return db
         .select({
+          id: customFieldDefinitions.id,
           fieldKey: customFieldDefinitions.fieldKey,
+          name: customFieldDefinitions.name,
           type: customFieldDefinitions.type,
           options: customFieldDefinitions.options,
           deviceTypes: customFieldDefinitions.deviceTypes,
+          required: customFieldDefinitions.required,
           scriptWrite: customFieldDefinitions.scriptWrite,
+          orgId: customFieldDefinitions.orgId,
+          partnerId: customFieldDefinitions.partnerId,
         })
         .from(customFieldDefinitions)
         .where(ownerCondition);
     }, 'customFields.scriptWriteBack.definitions'),
   );
 }
+
+/**
+ * The script write-back loader, kept as a named alias so callers that only
+ * care about script-writable fields keep reading as they did. The script_write
+ * gate itself stays where it is — applied per field by scriptWriteBack.ts, so
+ * a field that exists but is not writable is REJECTED with
+ * 'not_script_writable' rather than reported as 'unknown_field'.
+ */
+export const loadScriptWritableDefinitions = loadVisibleCustomFieldDefinitions;
 
 /**
  * Ambient ORG context. The org predicate is redundant under RLS but pins the

--- a/apps/api/src/services/customFields/queries.ts
+++ b/apps/api/src/services/customFields/queries.ts
@@ -12,14 +12,6 @@ export interface WriteBackDevice {
   customFields: unknown;
 }
 
-export interface ScriptWritableDefinition {
-  fieldKey: string;
-  type: 'text' | 'number' | 'boolean' | 'dropdown' | 'date';
-  options: unknown;
-  deviceTypes: string[] | null;
-  scriptWrite: boolean;
-}
-
 export interface VisibleCustomFieldDefinition {
   id: string;
   fieldKey: string;
@@ -53,19 +45,24 @@ export async function loadDeviceForWriteBack(deviceId: string): Promise<WriteBac
 /**
  * SYSTEM context, deliberately.
  *
- * `custom_field_definitions` is dual-axis (org OR partner). The caller runs
- * under `runWithAgentOrgDbAccess`, which sets accessiblePartnerIds: [] and
- * currentPartnerId: null, so `breeze_has_partner_access(partner_id)` is false
- * and every partner-wide definition (org_id IS NULL) is INVISIBLE from there.
- * A partner that defines one field for all its orgs would silently have no
- * script-writable fields at all. See CLAUDE.md, Partner-Wide First §3.
+ * `custom_field_definitions` is dual-axis (org OR partner). Every caller of
+ * this function — the script write-back path's `runWithAgentOrgDbAccess`
+ * context, and the two device-PATCH write paths' ordinary org-scoped request
+ * context — sets accessiblePartnerIds: [] and currentPartnerId: null, so
+ * `breeze_has_partner_access(partner_id)` is false and every partner-wide
+ * definition (org_id IS NULL) is INVISIBLE from there. A partner that defines
+ * one field for all its orgs would silently have no fields visible from any
+ * of these paths. See CLAUDE.md, Partner-Wide First §3.
  *
  * `runOutsideDbContext(() => withSystemDbAccessContext(...))` is the only form
  * that genuinely opens a second context — a bare nested
  * `withSystemDbAccessContext` early-returns and runs under the ORG context
  * instead. The scope is app-layer: an explicit org/partner predicate, kept
  * narrow, and the context is released immediately (it holds a second pooled
- * connection for its duration — #1105).
+ * connection for its duration — #1105). This now runs on every custom-field
+ * PATCH, not just script write-back — if this becomes a per-request cost
+ * worth caring about, cache the definition set per org/request rather than
+ * re-querying it per PATCH.
  */
 export async function loadVisibleCustomFieldDefinitions(
   orgId: string,
@@ -103,7 +100,7 @@ export async function loadVisibleCustomFieldDefinitions(
         })
         .from(customFieldDefinitions)
         .where(ownerCondition);
-    }, 'customFields.scriptWriteBack.definitions'),
+    }, 'customFields.loadVisibleCustomFieldDefinitions'),
   );
 }
 

--- a/apps/api/src/services/customFields/validateValue.test.ts
+++ b/apps/api/src/services/customFields/validateValue.test.ts
@@ -98,6 +98,21 @@ describe('validateCustomFieldValue', () => {
     }
   });
 
+  it('treats an empty string as a clear for dropdown and date, not a rejection', () => {
+    // The device-edit UI's <select> and <input type="date"> editors report a
+    // clear as '' (the blank option / an emptied date input), unlike the
+    // number editor which already normalises its clear to `null` before
+    // submitting. Without this, clearing either field 400s instead of clearing.
+    const dd = { fieldKey: 'tier', type: 'dropdown' as const, options: { choices: ['gold', 'silver'] } };
+    expect(validateCustomFieldValue(dd, '')).toEqual({ ok: true, value: null });
+    expect(validateCustomFieldValue(date, '')).toEqual({ ok: true, value: null });
+  });
+
+  it('still rejects an empty string for number and boolean (no clear convention there)', () => {
+    expect(validateCustomFieldValue(num, '')).toEqual({ ok: false, reason: 'invalid_type' });
+    expect(validateCustomFieldValue(bool, '')).toEqual({ ok: false, reason: 'invalid_type' });
+  });
+
   it('rejects objects and arrays outright', () => {
     expect(validateCustomFieldValue(text, { a: 1 })).toEqual({ ok: false, reason: 'invalid_type' });
     expect(validateCustomFieldValue(text, [1])).toEqual({ ok: false, reason: 'invalid_type' });

--- a/apps/api/src/services/customFields/validateValue.ts
+++ b/apps/api/src/services/customFields/validateValue.ts
@@ -65,6 +65,16 @@ export function validateCustomFieldValue(
 ): CustomFieldValueResult {
   if (raw === null || raw === undefined) return { ok: true, value: null };
 
+  // An empty string is the browser's native "cleared" value for a <select>
+  // (the blank option) or an <input type="date">, and is how the device-edit
+  // UI's dropdown/date editors report a clear (the number editor already
+  // normalises its own clear gesture to `null` before it reaches here — see
+  // DeviceInfoTab.tsx). Without this, clearing either field type would fail
+  // dropdown's `not_a_choice` or date's `invalid_date` instead of clearing.
+  if (raw === '' && (definition.type === 'dropdown' || definition.type === 'date')) {
+    return { ok: true, value: null };
+  }
+
   const isScalar = typeof raw === 'string' || typeof raw === 'number' || typeof raw === 'boolean';
   if (!isScalar) return { ok: false, reason: 'invalid_type' };
 

--- a/apps/api/src/services/customFields/validateValueMap.test.ts
+++ b/apps/api/src/services/customFields/validateValueMap.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./queries', () => ({
+  loadVisibleCustomFieldDefinitions: vi.fn(),
+}));
+
+import { validateCustomFieldMap } from './validateValueMap';
+import { loadVisibleCustomFieldDefinitions } from './queries';
+import type { VisibleCustomFieldDefinition } from './queries';
+
+const ORG_ID = 'org-1';
+
+function def(overrides: Partial<VisibleCustomFieldDefinition> & { fieldKey: string }): VisibleCustomFieldDefinition {
+  return {
+    id: `def-${overrides.fieldKey}`,
+    fieldKey: overrides.fieldKey,
+    name: overrides.fieldKey,
+    type: overrides.type ?? 'text',
+    options: overrides.options ?? null,
+    deviceTypes: overrides.deviceTypes ?? null,
+    required: overrides.required ?? false,
+    scriptWrite: overrides.scriptWrite ?? false,
+    orgId: overrides.orgId ?? ORG_ID,
+    partnerId: overrides.partnerId ?? null,
+  };
+}
+
+describe('validateCustomFieldMap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('is all-or-nothing on a MIXED valid+invalid map: collects every rejection, applies none', async () => {
+    // The whole point of this file existing is atomic behaviour across a
+    // multi-key map — a single-key test can't distinguish "atomic" from
+    // "the one field it saw happened to fail".
+    vi.mocked(loadVisibleCustomFieldDefinitions).mockResolvedValue([
+      def({ fieldKey: 'rack_units', type: 'number' }),
+      def({ fieldKey: 'tier', type: 'dropdown', options: { choices: ['gold'] } }),
+      def({ fieldKey: 'notes', type: 'text' }),
+    ]);
+
+    const result = await validateCustomFieldMap(ORG_ID, null, {
+      rack_units: 'abc', // invalid_type
+      tier: 'bronze', // not_a_choice
+      notes: 'a valid note', // would be fine on its own
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected ok:false');
+    expect(result.rejected.sort((a, b) => a.fieldKey.localeCompare(b.fieldKey))).toEqual([
+      { fieldKey: 'rack_units', reason: 'invalid_type' },
+      { fieldKey: 'tier', reason: 'not_a_choice' },
+    ]);
+    // The valid `notes` key must NOT sneak into a partial result — there is no
+    // `values` key at all when `ok: false`.
+    expect(result).not.toHaveProperty('values');
+  });
+
+  it('applies every field, all coerced, when the whole map is valid', async () => {
+    vi.mocked(loadVisibleCustomFieldDefinitions).mockResolvedValue([
+      def({ fieldKey: 'rack_units', type: 'number' }),
+      def({ fieldKey: 'ready', type: 'boolean' }),
+    ]);
+
+    const result = await validateCustomFieldMap(ORG_ID, null, { rack_units: '4', ready: 'true' });
+
+    expect(result).toEqual({ ok: true, values: { rack_units: 4, ready: true } });
+  });
+
+  it('rejects a key with no visible definition as unknown_field', async () => {
+    vi.mocked(loadVisibleCustomFieldDefinitions).mockResolvedValue([]);
+    const result = await validateCustomFieldMap(ORG_ID, null, { nope: 'x' });
+    expect(result).toEqual({ ok: false, rejected: [{ fieldKey: 'nope', reason: 'unknown_field' }] });
+  });
+
+  describe('deviceTypes applicability gate', () => {
+    it('rejects a value for a definition scoped to a different device type', async () => {
+      vi.mocked(loadVisibleCustomFieldDefinitions).mockResolvedValue([
+        def({ fieldKey: 'rustdesk_id', type: 'text', deviceTypes: ['windows'] }),
+      ]);
+
+      const result = await validateCustomFieldMap('org-1', 'macos', { rustdesk_id: 'abc123' });
+
+      expect(result).toEqual({
+        ok: false,
+        rejected: [{ fieldKey: 'rustdesk_id', reason: 'not_applicable_to_device' }],
+      });
+    });
+
+    it('rejects when the device osType is unknown (null) and the definition is device-type-scoped', async () => {
+      vi.mocked(loadVisibleCustomFieldDefinitions).mockResolvedValue([
+        def({ fieldKey: 'rustdesk_id', type: 'text', deviceTypes: ['windows'] }),
+      ]);
+
+      const result = await validateCustomFieldMap('org-1', null, { rustdesk_id: 'abc123' });
+
+      expect(result).toEqual({
+        ok: false,
+        rejected: [{ fieldKey: 'rustdesk_id', reason: 'not_applicable_to_device' }],
+      });
+    });
+
+    it('applies the value when the device osType matches one of deviceTypes', async () => {
+      vi.mocked(loadVisibleCustomFieldDefinitions).mockResolvedValue([
+        def({ fieldKey: 'rustdesk_id', type: 'text', deviceTypes: ['windows', 'macos'] }),
+      ]);
+
+      const result = await validateCustomFieldMap('org-1', 'macos', { rustdesk_id: 'abc123' });
+
+      expect(result).toEqual({ ok: true, values: { rustdesk_id: 'abc123' } });
+    });
+
+    it('does not gate at all when deviceTypes is null or empty (applies to every device)', async () => {
+      vi.mocked(loadVisibleCustomFieldDefinitions).mockResolvedValue([
+        def({ fieldKey: 'a', type: 'text', deviceTypes: null }),
+        def({ fieldKey: 'b', type: 'text', deviceTypes: [] }),
+      ]);
+
+      const result = await validateCustomFieldMap('org-1', null, { a: '1', b: '2' });
+
+      expect(result).toEqual({ ok: true, values: { a: '1', b: '2' } });
+    });
+  });
+});

--- a/apps/api/src/services/customFields/validateValueMap.ts
+++ b/apps/api/src/services/customFields/validateValueMap.ts
@@ -1,0 +1,52 @@
+import { loadVisibleCustomFieldDefinitions } from './queries';
+import { validateCustomFieldValue, type CustomFieldValueRejection } from './validateValue';
+
+export type CustomFieldMapRejection = {
+  fieldKey: string;
+  reason: CustomFieldValueRejection | 'unknown_field';
+};
+
+export type CustomFieldMapResult =
+  | { ok: true; values: Record<string, string | number | boolean | null> }
+  | { ok: false; rejected: CustomFieldMapRejection[] };
+
+export const INVALID_CUSTOM_FIELD_VALUE_MESSAGE =
+  'One or more custom field values are invalid for their definition';
+
+/**
+ * Validate and coerce a whole custom-field map for ONE device's org, against
+ * the bounded (org + partner-wide) set of visible definitions.
+ *
+ * All-or-nothing by design: shared by both `PATCH /devices/:id/custom-fields`
+ * and `PATCH /devices/:id`. A single PATCH is one operator action, not a bulk
+ * load — the importer (#3257) applies partially instead, because a 30-column
+ * row IS a bulk load.
+ */
+export async function validateCustomFieldMap(
+  orgId: string,
+  updates: Record<string, unknown>,
+): Promise<CustomFieldMapResult> {
+  const definitions = await loadVisibleCustomFieldDefinitions(orgId);
+  const byKey = new Map(definitions.map((d) => [d.fieldKey, d]));
+  const rejected: CustomFieldMapRejection[] = [];
+  const values: Record<string, string | number | boolean | null> = {};
+
+  for (const [fieldKey, raw] of Object.entries(updates)) {
+    const definition = byKey.get(fieldKey);
+    if (!definition) {
+      rejected.push({ fieldKey, reason: 'unknown_field' });
+      continue;
+    }
+    const result = validateCustomFieldValue(definition, raw);
+    if (!result.ok) {
+      rejected.push({ fieldKey, reason: result.reason });
+      continue;
+    }
+    values[fieldKey] = result.value;
+  }
+
+  if (rejected.length > 0) {
+    return { ok: false, rejected };
+  }
+  return { ok: true, values };
+}

--- a/apps/api/src/services/customFields/validateValueMap.ts
+++ b/apps/api/src/services/customFields/validateValueMap.ts
@@ -3,7 +3,7 @@ import { validateCustomFieldValue, type CustomFieldValueRejection } from './vali
 
 export type CustomFieldMapRejection = {
   fieldKey: string;
-  reason: CustomFieldValueRejection | 'unknown_field';
+  reason: CustomFieldValueRejection | 'unknown_field' | 'not_applicable_to_device';
 };
 
 export type CustomFieldMapResult =
@@ -14,16 +14,21 @@ export const INVALID_CUSTOM_FIELD_VALUE_MESSAGE =
   'One or more custom field values are invalid for their definition';
 
 /**
- * Validate and coerce a whole custom-field map for ONE device's org, against
- * the bounded (org + partner-wide) set of visible definitions.
+ * Validate and coerce a whole custom-field map for ONE device, against the
+ * bounded (org + partner-wide) set of visible definitions.
  *
  * All-or-nothing by design: shared by both `PATCH /devices/:id/custom-fields`
  * and `PATCH /devices/:id`. A single PATCH is one operator action, not a bulk
  * load — the importer (#3257) applies partially instead, because a 30-column
  * row IS a bulk load.
+ *
+ * `deviceOsType` mirrors the `not_applicable_to_device` gate scriptWriteBack.ts
+ * already applies for a definition scoped to specific `deviceTypes` — a null
+ * (unknown) osType is treated as non-matching, same as scriptWriteBack.
  */
 export async function validateCustomFieldMap(
   orgId: string,
+  deviceOsType: string | null,
   updates: Record<string, unknown>,
 ): Promise<CustomFieldMapResult> {
   const definitions = await loadVisibleCustomFieldDefinitions(orgId);
@@ -35,6 +40,14 @@ export async function validateCustomFieldMap(
     const definition = byKey.get(fieldKey);
     if (!definition) {
       rejected.push({ fieldKey, reason: 'unknown_field' });
+      continue;
+    }
+    if (
+      Array.isArray(definition.deviceTypes) &&
+      definition.deviceTypes.length > 0 &&
+      (deviceOsType === null || !definition.deviceTypes.includes(deviceOsType))
+    ) {
+      rejected.push({ fieldKey, reason: 'not_applicable_to_device' });
       continue;
     }
     const result = validateCustomFieldValue(definition, raw);


### PR DESCRIPTION
Closes #4772

## What changed

Neither shipped custom-field VALUE write path validated a value against its definition's declared `type` before this PR. Values are both an execution sink (`installerVariables.ts` substitutes `{{device.customField.<key>}}` into installer command lines that reach `sendCommandToAgent`) and a targeting control (`filterEngine`'s `custom.<key>` feeds `groupMembership.ts` / `deploymentTargetResolver.ts`). The script write-back path (#4692) already validated; this wave brings the two older, user-facing paths up to the same bar.

1. **Generalised the bounded definition lookup** (`services/customFields/queries.ts`): `loadScriptWritableDefinitions` renamed to `loadVisibleCustomFieldDefinitions`, projection widened to include `id`, `name`, `required`, `orgId`, `partnerId`. `loadScriptWritableDefinitions` is retained as a plain alias so `scriptWriteBack.ts` is untouched (same system-context doc comment preserved verbatim).
2. **New `services/customFields/validateValueMap.ts`**: `validateCustomFieldMap(orgId, updates)` runs a whole field map through the existing `validateCustomFieldValue` (from `#4692`) against the bounded definition lookup, all-or-nothing, and returns either the coerced value map or a rejection list.
3. **`PATCH /devices/:id/custom-fields`** (`routes/devices/customFieldValues.ts`): validates on BOTH the JWT-session and API-key (dualAuth) branches before merging. Stores the coerced value, not the raw input.
4. **`PATCH /devices/:id`** (`routes/devices/core.ts`): same treatment, same shared helper, same error shape, applied to the `customFields` branch only (a PATCH with no `customFields` key never touches the definition lookup).

Error shape on rejection (both routes): `400 { error, code: 'invalid-custom-field-value', fields: [{ fieldKey, reason }] }`, where `reason` is one of `unknown_field | invalid_type | out_of_range | not_a_choice | too_long | invalid_date`.

## ⚠️ Release note — behaviour change on a shipped API

`PATCH /devices/:id` and `PATCH /devices/:id/custom-fields` now **reject** a custom-field value that does not match its definition's declared type, with `code: 'invalid-custom-field-value'` and a per-field reason list. Callers that were previously storing free-form strings under a `number` or `dropdown` field will start getting `400`s. A field with no visible definition at all is also now rejected (`unknown_field`) rather than silently stored. A value for a field whose definition is scoped to specific `deviceTypes` (e.g. a Windows-only field) is now also rejected (`not_applicable_to_device`) when written onto a device of a different OS — previously only the script write-back path enforced this.

Post-review addendum: `routes/partnerApi/devices.ts` reads `assetTag`/`asset_tag`, `inventoryId`, `externalId` out of `custom_fields` for the partner API's `stableIdentifiers`. A tenant that previously wrote one of those keys via PATCH with no matching `custom_field_definitions` row will now get `400 unknown_field` on any future rewrite of that key (existing stored values are untouched — this only affects new writes).

## Deviations from the plan

- The plan's Task 2 → Task 3 split (inline loop in `customFieldValues.ts`, then extract to `validateValueMap.ts` in a follow-up commit) was collapsed: `validateValueMap.ts` was written once and both routes call it from the start. Net behaviour and test coverage are identical to the plan's end state; this just avoids a throwaway inline-then-extract diff.
- `queries.test.ts` and `core.customFieldValidation.test.ts` are new files per the brief; `customFieldValues.test.ts` and its sibling `customFieldValues.mountorder.test.ts` were both updated — the latter wasn't explicitly named in the brief's file list but broke once the route started calling the real `loadVisibleCustomFieldDefinitions` (mocked there now, matching the pattern in the primary test file).
- Pre-existing "free-form" write tests in `customFieldValues.test.ts` (`bitlocker_recovery_key`, `note`) now get a permissive default `text` definition mocked in `beforeEach` so they keep testing merge/audit/isolation behaviour rather than becoming validation tests.

## Not verified

- No migration in this wave (none needed — validation only, no schema change).
- Did not run the RLS/integration suites locally (no DB in this sandbox); this wave touches no tenancy-shaped surface (no new tables, no cascade/export-policy registration), so I don't expect them to be affected, but CI's `integration-test` job will be the first real check.
- `filterEngine.ts` / `installerVariables.ts` (the two consumers this wave is motivated by) are unchanged and untested here — this wave only prevents bad values from being written, it doesn't touch the read side.

## Test plan

```
cd apps/api && npx vitest run src/services/customFields/ src/routes/devices/customFieldValues src/routes/devices/core.customFieldValidation.test.ts
# 10 files, 153 tests passed
npx tsc --noEmit   # 0 errors
pnpm lint          # clean
```

## Review

`/pr-review-toolkit:review-pr` ran three agents in parallel (code-reviewer, pr-test-analyzer, silent-failure-hunter). See the review-summary comment on this PR for the full findings list and disposition — one critical, two important, and several minor findings were fixed in a follow-up commit; the rest were confirmed non-issues or accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
