### PR TITLE
fix(api): qualify columns in admin trust-queue device-count subquery (500: column "id" is ambiguous)

### DIFF
--- a/apps/api/src/__tests__/integration/adminTrustQueueDeviceCount.integration.test.ts
+++ b/apps/api/src/__tests__/integration/adminTrustQueueDeviceCount.integration.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Admin trust-queue deviceCount subquery (#4603 pre-release sweep)
+ *
+ * `GET /admin/trust/queue`'s deviceCount correlated subquery interpolated
+ * Drizzle Column objects (`${devices.orgId}`, `${organizations.id}`, ...)
+ * directly into a raw `sql` template. Drizzle renders an interpolated Column
+ * as a BARE, unqualified identifier ("id") rather than a table-qualified one
+ * ("organizations"."id") — the same lesson already documented next to
+ * routes/software.ts's versionCount subquery. With two joined tables each
+ * having an `id` column, Postgres raised `column reference "id" is
+ * ambiguous`, so this endpoint 500'd on every request, even with zero
+ * partners in probation (the ambiguity is a parse/plan-time error, not a
+ * row-count-dependent one).
+ *
+ * This test drives the real route handler against real Postgres — the
+ * Drizzle-mock unit suite (routes/admin/trust.test.ts) mocks `db.select(...)`
+ * entirely and so never executes real SQL text, which is why it could not
+ * have caught this.
+ *
+ * Prerequisites: `pnpm test-stack up` (or docker compose -f
+ * docker-compose.test.yml up -d) for a real Postgres instance.
+ * Run: pnpm test:integration -- src/__tests__/integration/adminTrustQueueDeviceCount.integration.test.ts
+ */
+import './setup';
+
+import { describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { Hono } from 'hono';
+
+import { db, withSystemDbAccessContext } from '../../db';
+import { devices, partners } from '../../db/schema';
+import { trustAdminRoutes } from '../../routes/admin/trust';
+import { getTestDb } from './setup';
+import { createOrganization, createPartner, createSite } from './db-utils';
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.route('/admin', trustAdminRoutes);
+  return app;
+}
+
+function uniq(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+describe('GET /admin/trust/queue deviceCount subquery (#4603)', () => {
+  it('returns 200 with an empty list when no partners are outside "trusted" (empty probation set)', async () => {
+    // No fixtures at all — createPartner() defaults trustState to 'trusted'
+    // (the schema default), so the queue's WHERE trust_state <> 'trusted'
+    // naturally excludes it. Before the fix, this 500'd anyway: the ambiguous
+    // column error is raised during query planning, independent of how many
+    // rows partners/organizations/devices actually contain.
+    await createPartner();
+
+    const response = await buildApp().request('/admin/trust/queue');
+    expect(response.status).toBe(200);
+
+    const body = await response.json() as { partners: unknown[]; nextCursor: string | null };
+    expect(body.partners).toEqual([]);
+    expect(body.nextCursor).toBeNull();
+  });
+
+  it('counts devices correctly (not zero, not every device in the DB) for a non-trusted partner', async () => {
+    const partner = await createPartner();
+    await withSystemDbAccessContext(() =>
+      db.update(partners).set({ trustState: 'restricted' }).where(eq(partners.id, partner.id)),
+    );
+    const org = await createOrganization({ partnerId: partner.id });
+    const site = await createSite({ orgId: org.id });
+
+    // A second, unrelated trusted partner/org/device proves the join is
+    // correlated to the RIGHT partner and doesn't just count every device
+    // in the database (which the ambiguous-column bug, if it silently
+    // resolved to the wrong side instead of erroring, could have masked).
+    const otherPartner = await createPartner();
+    const otherOrg = await createOrganization({ partnerId: otherPartner.id });
+    const otherSite = await createSite({ orgId: otherOrg.id });
+
+    await getTestDb().insert(devices).values([
+      {
+        orgId: org.id,
+        siteId: site.id,
+        agentId: uniq('agent'),
+        hostname: uniq('host'),
+        osType: 'linux',
+        osVersion: '22.04',
+        architecture: 'x86_64',
+        agentVersion: '0.0.0-test',
+      },
+      {
+        orgId: org.id,
+        siteId: site.id,
+        agentId: uniq('agent'),
+        hostname: uniq('host'),
+        osType: 'linux',
+        osVersion: '22.04',
+        architecture: 'x86_64',
+        agentVersion: '0.0.0-test',
+      },
+      {
+        orgId: otherOrg.id,
+        siteId: otherSite.id,
+        agentId: uniq('agent'),
+        hostname: uniq('host'),
+        osType: 'linux',
+        osVersion: '22.04',
+        architecture: 'x86_64',
+        agentVersion: '0.0.0-test',
+      },
+    ]);
+
+    const response = await buildApp().request('/admin/trust/queue');
+    expect(response.status).toBe(200);
+
+    const body = await response.json() as { partners: Array<{ id: string; deviceCount: number }> };
+    const row = body.partners.find((p) => p.id === partner.id);
+    expect(row).toBeDefined();
+    expect(row?.deviceCount).toBe(2);
+    expect(body.partners.some((p) => p.id === otherPartner.id)).toBe(false);
+  });
+});

--- a/apps/api/src/routes/admin/trust.ts
+++ b/apps/api/src/routes/admin/trust.ts
@@ -2,7 +2,7 @@ import { Hono, type Context } from 'hono';
 import { and, desc, eq, isNull, lt, ne, or, sql, type SQL } from 'drizzle-orm';
 import { z } from 'zod';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
-import { devices, organizations, partners } from '../../db/schema';
+import { partners } from '../../db/schema';
 import type { PartnerTrustState } from '../../db/schema/orgs';
 import { zValidator } from '../../lib/validation';
 import { requireMfa } from '../../middleware/auth';
@@ -166,11 +166,20 @@ trustAdminRoutes.get('/trust/queue', zValidator('query', queueQuerySchema), asyn
       signupIp: partners.signupIp,
       signupIpClass: partners.signupIpClass,
       signupIpAsn: partners.signupIpAsn,
+      // NOTE: the inner correlated sub-select MUST reference its own tables
+      // and columns as plain SQL text, never as interpolated Drizzle Column
+      // objects (`${organizations.id}`) — Drizzle renders a bare column
+      // reference UNqualified ("id"), so both sides of the join collapse to
+      // the same unqualified name and Postgres raises "column reference
+      // \"id\" is ambiguous". Only the outer correlation to `partners` is
+      // interpolated (`${partners}.id`), which renders the Table object as
+      // its quoted, qualified name. Same pattern/lesson as
+      // routes/software.ts's versionCount subquery.
       deviceCount: sql<number>`(
         SELECT count(*)::int
-        FROM ${devices}
-        INNER JOIN ${organizations} ON ${devices.orgId} = ${organizations.id}
-        WHERE ${organizations.partnerId} = ${partners.id}
+        FROM devices
+        INNER JOIN organizations ON organizations.id = devices.org_id
+        WHERE organizations.partner_id = ${partners}.id
       )`,
     })
     .from(partners)


### PR DESCRIPTION
## Root cause

`GET /admin/trust/queue` (`apps/api/src/routes/admin/trust.ts`) 500'd on **every** request, even with zero partners in probation.

The `deviceCount` correlated subquery interpolated Drizzle `Column` objects directly into a raw ``sql`` `` template:

```ts
deviceCount: sql<number>`(
  SELECT count(*)::int
  FROM ${devices}
  INNER JOIN ${organizations} ON ${devices.orgId} = ${organizations.id}
  WHERE ${organizations.partnerId} = ${partners.id}
)`,
```

Drizzle renders an interpolated `Column` object as a **bare, unqualified** identifier (`"id"`), not a table-qualified one (`"organizations"."id"`). With two joined tables that both have an `id` column, this collapsed to:

```sql
INNER JOIN "organizations" ON "org_id" = "id"
WHERE "partner_id" = "id"
```

...which Postgres rejects with `column reference "id" is ambiguous` (`42702`). This is a parse/plan-time error, so it fires regardless of row counts — an empty probation queue 500s exactly the same as a populated one.

This is the same failure mode already documented next to `routes/software.ts`'s `versionCount` subquery (see the comment there), which was fixed the same way: write the inner correlated sub-select's own tables/columns as **plain SQL text**, and only interpolate the **outer** `Table` object (not a `Column`) for the correlation — a `Table` interpolation renders its quoted, qualified name correctly.

## Fix

```ts
deviceCount: sql<number>`(
  SELECT count(*)::int
  FROM devices
  INNER JOIN organizations ON organizations.id = devices.org_id
  WHERE organizations.partner_id = ${partners}.id
)`,
```

Verified via `.toSQL()` before/after:

- Before: `... INNER JOIN "organizations" ON "org_id" = "id" WHERE "partner_id" = "id"`
- After: `... INNER JOIN organizations ON organizations.id = devices.org_id WHERE organizations.partner_id = "partners".id`

Removed the now-unused `devices`/`organizations` schema imports from the route file. Swept the rest of `trust.ts` for the same interpolation pattern — this was the only occurrence.

## Repro

Reproduced standalone: building the exact query with Drizzle and running it against a real Postgres instance raises `PostgresError: column reference "id" is ambiguous` (`code: '42702'`) both with fixture rows present and with an empty probation set.

## Test plan

- Added `apps/api/src/__tests__/integration/adminTrustQueueDeviceCount.integration.test.ts`, a real-Postgres integration test (the existing `routes/admin/trust.test.ts` unit suite mocks `db.select(...)` entirely and never executes real SQL text, so it could not have caught this):
  - `GET /admin/trust/queue` returns 200 + `partners: []` with an empty probation set.
  - `deviceCount` correctly counts only the queried partner's devices (not zero, not every device in the DB).
- Confirmed **red → green**: reverted the fix, ran the new integration test against a real Postgres instance (`pnpm test-stack up`) — both cases failed with `column reference "id" is ambiguous` / the resulting 500. Reapplied the fix — both pass.
- `npx vitest run src/routes/admin/trust.test.ts` — 8/8 pass (unchanged).
- `npx eslint` on both changed files — clean.
- `npx tsc --noEmit -p apps/api/tsconfig.json` — clean (~63s, `NODE_OPTIONS=--max-old-space-size=8192`).

Refs #4603

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018KGxWJkgKPTuLdjANQAfMs