### PR TITLE
feat(patches): unrated-patch warning note + opt-in toggle on ring form

### DIFF
--- a/apps/web/src/components/patches/UpdateRingForm.test.tsx
+++ b/apps/web/src/components/patches/UpdateRingForm.test.tsx
@@ -48,6 +48,7 @@ describe('UpdateRingForm — ring auto-approve (#1317)', () => {
       deferralDays: 7,
       thirdPartyApps: false,
       thirdPartyDeferralDays: 0,
+      autoApproveUnrated: false,
     });
   });
 
@@ -301,5 +302,69 @@ describe('UpdateRingForm — third-party app auto-approve', () => {
     );
 
     expect(screen.getByTestId('ring-third-party-enabled')).not.toBeChecked();
+  });
+});
+
+// #3758: unrated patches (no severity, or the 'unknown' sentinel) never
+// auto-approve on severity alone. This opt-in lets an admin explicitly
+// include them too.
+describe('UpdateRingForm — unrated-patch opt-in (#3758)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the unrated-patches warning note and an opt-in toggle once auto-approve is enabled', () => {
+    render(<UpdateRingForm onSubmit={vi.fn()} />);
+
+    fireEvent.click(screen.getByTestId('ring-auto-approve-enabled'));
+
+    expect(screen.getByTestId('ring-unrated-severity-note')).toHaveTextContent(/unrated patches/i);
+    expect(screen.getByTestId('ring-auto-approve-unrated-toggle')).toBeInTheDocument();
+    expect(screen.getByTestId('ring-auto-approve-unrated-toggle')).not.toBeChecked();
+  });
+
+  it('submits autoApproveUnrated: true when the opt-in toggle is checked', async () => {
+    const onSubmit = vi.fn();
+    render(<UpdateRingForm onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByPlaceholderText('e.g. Pilot, Broad'), { target: { value: 'Pilot' } });
+    fireEvent.click(screen.getByTestId('ring-auto-approve-enabled'));
+    fireEvent.click(screen.getByTestId('ring-auto-approve-severity-critical'));
+    fireEvent.click(screen.getByTestId('ring-auto-approve-unrated-toggle'));
+    fireEvent.click(screen.getByRole('button', { name: /save ring/i }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    const values = onSubmit.mock.calls[0][0] as UpdateRingFormValues;
+    expect(values.autoApprove.autoApproveUnrated).toBe(true);
+  });
+
+  it('hydrates the opt-in toggle from edit defaults', () => {
+    render(
+      <UpdateRingForm
+        onSubmit={vi.fn()}
+        defaultValues={{
+          name: 'Broad',
+          autoApprove: { enabled: true, severities: ['critical'], deferralDays: 3, autoApproveUnrated: true },
+        }}
+      />
+    );
+
+    expect(screen.getByTestId('ring-auto-approve-unrated-toggle')).toBeChecked();
+  });
+
+  it('offers the same opt-in toggle on a category override and submits it', async () => {
+    const onSubmit = vi.fn();
+    render(<UpdateRingForm onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByPlaceholderText('e.g. Pilot, Broad'), { target: { value: 'Pilot' } });
+    fireEvent.click(screen.getByTestId('ring-auto-approve-enabled'));
+    fireEvent.click(screen.getByTestId('ring-auto-approve-severity-critical'));
+    fireEvent.click(screen.getByRole('button', { name: /add override/i }));
+    fireEvent.click(screen.getByTestId('ring-category-0-auto-approve-unrated-toggle'));
+    fireEvent.click(screen.getByRole('button', { name: /save ring/i }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    const values = onSubmit.mock.calls[0][0] as UpdateRingFormValues;
+    expect(values.categoryRules?.[0]).toMatchObject({ autoApproveUnrated: true });
   });
 });

--- a/apps/web/src/components/patches/UpdateRingForm.test.tsx
+++ b/apps/web/src/components/patches/UpdateRingForm.test.tsx
@@ -367,4 +367,66 @@ describe('UpdateRingForm — unrated-patch opt-in (#3758)', () => {
     const values = onSubmit.mock.calls[0][0] as UpdateRingFormValues;
     expect(values.categoryRules?.[0]).toMatchObject({ autoApproveUnrated: true });
   });
+
+  // A legacy category override row saved before this opt-in existed has no
+  // autoApproveUnrated key at all — must hydrate to an unchecked toggle, not a
+  // crash or an uncontrolled-input warning.
+  it('hydrates a legacy category override (no autoApproveUnrated key) to an unchecked toggle', () => {
+    render(
+      <UpdateRingForm
+        onSubmit={vi.fn()}
+        defaultValues={{
+          name: 'Legacy',
+          autoApprove: { enabled: true, severities: ['critical'], deferralDays: 0 },
+          categoryRules: [{ category: 'security', autoApprove: true, autoApproveSeverities: ['critical'] }],
+        }}
+      />
+    );
+
+    expect(screen.getByTestId('ring-category-0-auto-approve-unrated-toggle')).not.toBeChecked();
+  });
+
+  // addOverride pre-fills a new override from the default rule's CURRENT
+  // values (mirrors the existing autoApproveSeverities pre-fill) — cover the
+  // pre-fill-true branch, not just the click-to-true branch above.
+  it('pre-fills a new override from a default rule that already has the opt-in on', async () => {
+    const onSubmit = vi.fn();
+    render(<UpdateRingForm onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByPlaceholderText('e.g. Pilot, Broad'), { target: { value: 'Pilot' } });
+    fireEvent.click(screen.getByTestId('ring-auto-approve-enabled'));
+    fireEvent.click(screen.getByTestId('ring-auto-approve-severity-critical'));
+    fireEvent.click(screen.getByTestId('ring-auto-approve-unrated-toggle'));
+    fireEvent.click(screen.getByRole('button', { name: /add override/i }));
+
+    expect(screen.getByTestId('ring-category-0-auto-approve-unrated-toggle')).toBeChecked();
+
+    fireEvent.click(screen.getByRole('button', { name: /save ring/i }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    const values = onSubmit.mock.calls[0][0] as UpdateRingFormValues;
+    expect(values.categoryRules?.[0]).toMatchObject({ autoApproveUnrated: true });
+  });
+
+  // The evaluator treats autoApproveUnrated as strictly additive: an empty
+  // severity set (and third-party off) approves nothing even with the opt-in
+  // on (apps/api/.../patchApprovalEvaluator.ts — "OS path" severities.length
+  // === 0 short-circuit runs before the unrated check). The form must keep
+  // blocking submit in that state so a save can't silently configure a
+  // no-op ring — this is not a bug, but it needs a regression test so nobody
+  // "fixes" the validation to exempt autoApproveUnrated later.
+  it('still blocks submit when autoApproveUnrated is on but no severities are selected', async () => {
+    const onSubmit = vi.fn();
+    render(<UpdateRingForm onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByPlaceholderText('e.g. Pilot, Broad'), { target: { value: 'Pilot' } });
+    fireEvent.click(screen.getByTestId('ring-auto-approve-enabled'));
+    fireEvent.click(screen.getByTestId('ring-auto-approve-unrated-toggle'));
+    fireEvent.click(screen.getByRole('button', { name: /save ring/i }));
+
+    await screen.findByText(
+      'Select at least one severity or enable third-party app auto-approval.'
+    );
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/components/patches/UpdateRingForm.tsx
+++ b/apps/web/src/components/patches/UpdateRingForm.tsx
@@ -252,6 +252,7 @@ export default function UpdateRingForm({
       categoryRules: (merged.categoryRules ?? []).map((r) => ({
         ...r,
         autoApproveSeverities: r.autoApproveSeverities ?? [],
+        autoApproveUnrated: r.autoApproveUnrated ?? false,
         deferralDaysOverride: r.deferralDaysOverride ?? inheritedHold,
       })),
     };

--- a/apps/web/src/components/patches/UpdateRingForm.tsx
+++ b/apps/web/src/components/patches/UpdateRingForm.tsx
@@ -12,6 +12,7 @@ function makeRingSchema(t: TFunction<'patches'>) {
     category: z.string().min(1, t('updateRingForm.validation.selectCategory')),
     autoApprove: z.boolean(),
     autoApproveSeverities: z.array(z.enum(['critical', 'important', 'moderate', 'low'])).optional(),
+    autoApproveUnrated: z.boolean().optional(),
     deferralDaysOverride: z.coerce.number().int().min(0).max(365).nullable().optional(),
   });
 
@@ -23,6 +24,10 @@ function makeRingSchema(t: TFunction<'patches'>) {
     // Always a concrete number in the form (pre-filled from the ring hold);
     // null "inherit" is an API-writer concept, mirroring deferralDaysOverride.
     thirdPartyDeferralDays: z.coerce.number().int().min(0).max(365),
+    // Opt-in: also auto-approve patches with no severity rating (#3758). Always
+    // a concrete boolean in the form (unlike the API's optional-for-merge
+    // shape) — the form always has an explicit checked/unchecked state.
+    autoApproveUnrated: z.boolean(),
   }).superRefine((data, ctx) => {
     if (data.enabled && data.severities.length === 0 && !data.thirdPartyApps) {
       ctx.addIssue({
@@ -223,7 +228,7 @@ export default function UpdateRingForm({
       deferralDays: 0,
       deadlineDays: null,
       gracePeriodHours: 4,
-      autoApprove: { enabled: false, severities: [], deferralDays: 0, thirdPartyApps: false, thirdPartyDeferralDays: 0 },
+      autoApprove: { enabled: false, severities: [], deferralDays: 0, thirdPartyApps: false, thirdPartyDeferralDays: 0, autoApproveUnrated: false },
       categoryRules: [],
       ...defaultValues,
     } satisfies UpdateRingFormDefaults;
@@ -237,6 +242,7 @@ export default function UpdateRingForm({
       severities: [],
       deferralDays: inheritedHold,
       thirdPartyApps: false,
+      autoApproveUnrated: false,
       ...aa,
       thirdPartyDeferralDays: aa.thirdPartyDeferralDays ?? inheritedHold,
     };
@@ -296,6 +302,7 @@ export default function UpdateRingForm({
       category: availableCategories[0].value,
       autoApprove: true,
       autoApproveSeverities: autoApprove?.severities ?? [],
+      autoApproveUnrated: autoApprove?.autoApproveUnrated ?? false,
       // Pre-fill from the default rule's hold so the override is explicit and
       // never blank — the old `—` placeholder read as broken.
       deferralDaysOverride: autoApprove?.deferralDays ?? 0,
@@ -427,6 +434,21 @@ export default function UpdateRingForm({
                   >
                     {t('updateRingForm.approvalPolicy.severityNote')}
                   </p>
+                  <p
+                    className="mt-1.5 max-w-md text-xs text-muted-foreground"
+                    data-testid="ring-unrated-severity-note"
+                  >
+                    {t('updateRingForm.approvalPolicy.unratedSeverityNote')}
+                  </p>
+                  <div className="mt-2 flex items-center gap-2">
+                    <ApproveToggle
+                      checked={!!autoApprove?.autoApproveUnrated}
+                      field={register('autoApprove.autoApproveUnrated')}
+                      testId="ring-auto-approve-unrated-toggle"
+                      t={t}
+                    />
+                    <span className="text-xs text-muted-foreground">{t('updateRingForm.approvalPolicy.autoApproveUnratedLabel')}</span>
+                  </div>
                 </div>
                 <HoldField field={register('autoApprove.deferralDays')} testId="ring-auto-approve-deferral" t={t} />
 
@@ -521,6 +543,15 @@ export default function UpdateRingForm({
                       </div>
                     </div>
                     <HoldField field={register(`categoryRules.${index}.deferralDaysOverride`)} t={t} />
+                    <div className="mt-3 flex w-full items-center gap-2">
+                      <ApproveToggle
+                        checked={!!rule?.autoApproveUnrated}
+                        field={register(`categoryRules.${index}.autoApproveUnrated`)}
+                        testId={`ring-category-${index}-auto-approve-unrated-toggle`}
+                        t={t}
+                      />
+                      <span className="text-xs text-muted-foreground">{t('updateRingForm.approvalPolicy.autoApproveUnratedLabel')}</span>
+                    </div>
                   </div>
                 ) : (
                   <p className="mt-2 text-xs text-muted-foreground">

--- a/apps/web/src/components/patches/UpdateRingList.tsx
+++ b/apps/web/src/components/patches/UpdateRingList.tsx
@@ -17,6 +17,10 @@ export type CategoryRule = {
   category: string;
   autoApprove: boolean;
   autoApproveSeverities?: Array<'critical' | 'important' | 'moderate' | 'low'>;
+  /** Opt-in: also auto-approve patches with no severity rating in this
+   *  category override (#3758). Absent on rules saved before the opt-in
+   *  existed. */
+  autoApproveUnrated?: boolean;
   deferralDaysOverride?: number | null;
 };
 
@@ -31,6 +35,9 @@ export type RingAutoApprove = {
   thirdPartyApps?: boolean;
   /** null = inherit the ring's hold. */
   thirdPartyDeferralDays?: number | null;
+  /** Opt-in: also auto-approve patches with no severity rating (#3758).
+   *  Absent on rings saved before the opt-in existed. */
+  autoApproveUnrated?: boolean;
 };
 
 export type UpdateRingItem = {

--- a/apps/web/src/components/patches/patchHelpers.test.ts
+++ b/apps/web/src/components/patches/patchHelpers.test.ts
@@ -81,6 +81,7 @@ describe('normalizeRing — autoApprove normalization (#1317)', () => {
       deferralDays: 0,
       thirdPartyApps: false,
       thirdPartyDeferralDays: null,
+      autoApproveUnrated: false,
     });
   });
 
@@ -92,6 +93,7 @@ describe('normalizeRing — autoApprove normalization (#1317)', () => {
       deferralDays: 0,
       thirdPartyApps: false,
       thirdPartyDeferralDays: null,
+      autoApproveUnrated: false,
     });
   });
 
@@ -103,6 +105,7 @@ describe('normalizeRing — autoApprove normalization (#1317)', () => {
       deferralDays: 0,
       thirdPartyApps: false,
       thirdPartyDeferralDays: null,
+      autoApproveUnrated: false,
     });
   });
 
@@ -124,6 +127,7 @@ describe('normalizeRing — autoApprove normalization (#1317)', () => {
       deferralDays: 5,
       thirdPartyApps: false,
       thirdPartyDeferralDays: null,
+      autoApproveUnrated: false,
     });
   });
 
@@ -133,11 +137,11 @@ describe('normalizeRing — autoApprove normalization (#1317)', () => {
     expect(
       normalizeRing({ id: 'r1', name: 'x', autoApprove: { enabled: true, severities: ['low'], deferralDays: -3, thirdPartyApps: false } })
         .autoApprove
-    ).toEqual({ enabled: false, severities: [], deferralDays: 0, thirdPartyApps: false, thirdPartyDeferralDays: null });
+    ).toEqual({ enabled: false, severities: [], deferralDays: 0, thirdPartyApps: false, thirdPartyDeferralDays: null, autoApproveUnrated: false });
     expect(
       normalizeRing({ id: 'r1', name: 'x', autoApprove: { enabled: true, severities: ['low'], deferralDays: 1.5, thirdPartyApps: false } })
         .autoApprove
-    ).toEqual({ enabled: false, severities: [], deferralDays: 0, thirdPartyApps: false, thirdPartyDeferralDays: null });
+    ).toEqual({ enabled: false, severities: [], deferralDays: 0, thirdPartyApps: false, thirdPartyDeferralDays: null, autoApproveUnrated: false });
     // Absent stays fine (0 = no hold).
     expect(
       normalizeRing({ id: 'r1', name: 'x', autoApprove: { enabled: true, severities: ['low'], thirdPartyApps: false } })
@@ -173,6 +177,7 @@ describe('normalizeRing — autoApprove normalization (#1317)', () => {
       deferralDays: 0,
       thirdPartyApps: true,
       thirdPartyDeferralDays: 3,
+      autoApproveUnrated: false,
     });
 
     expect(
@@ -193,6 +198,7 @@ describe('normalizeRing — autoApprove normalization (#1317)', () => {
       deferralDays: 2,
       thirdPartyApps: false,
       thirdPartyDeferralDays: 0,
+      autoApproveUnrated: false,
     });
   });
 
@@ -252,7 +258,7 @@ describe('normalizeRing — autoApprove normalization (#1317)', () => {
             thirdPartyDeferralDays: bad,
           },
         }).autoApprove
-      ).toEqual({ enabled: false, severities: [], deferralDays: 0, thirdPartyApps: false, thirdPartyDeferralDays: null });
+      ).toEqual({ enabled: false, severities: [], deferralDays: 0, thirdPartyApps: false, thirdPartyDeferralDays: null, autoApproveUnrated: false });
     }
     expect(
       normalizeRing({
@@ -260,6 +266,21 @@ describe('normalizeRing — autoApprove normalization (#1317)', () => {
         name: 'x',
         autoApprove: { enabled: true, severities: [], deferralDays: 0, thirdPartyApps: true, thirdPartyDeferralDays: null },
       }).autoApprove
-    ).toEqual({ enabled: true, severities: [], deferralDays: 0, thirdPartyApps: true, thirdPartyDeferralDays: null });
+    ).toEqual({ enabled: true, severities: [], deferralDays: 0, thirdPartyApps: true, thirdPartyDeferralDays: null, autoApproveUnrated: false });
+  });
+});
+
+describe('normalizeRing autoApprove.autoApproveUnrated (#3758)', () => {
+  it('defaults to false when absent from the stored auto_approve object', () => {
+    const ring = normalizeRing({ id: 'r1', name: 'Ring 1', autoApprove: { enabled: true, severities: ['critical'] } });
+    expect(ring.autoApprove?.autoApproveUnrated).toBe(false);
+  });
+
+  it('passes through an explicit true', () => {
+    const ring = normalizeRing({
+      id: 'r1', name: 'Ring 1',
+      autoApprove: { enabled: true, severities: ['critical'], autoApproveUnrated: true },
+    });
+    expect(ring.autoApprove?.autoApproveUnrated).toBe(true);
   });
 });

--- a/apps/web/src/components/patches/patchHelpers.ts
+++ b/apps/web/src/components/patches/patchHelpers.ts
@@ -98,6 +98,7 @@ type RingSeverity = (typeof RING_SEVERITIES)[number];
 
 const DISABLED_RING_AUTO_APPROVE: NonNullable<UpdateRingItem['autoApprove']> = {
   enabled: false, severities: [], deferralDays: 0, thirdPartyApps: false, thirdPartyDeferralDays: null,
+  autoApproveUnrated: false,
 };
 
 /**
@@ -128,7 +129,7 @@ const DISABLED_RING_AUTO_APPROVE: NonNullable<UpdateRingItem['autoApprove']> = {
  */
 function normalizeRingAutoApprove(raw: unknown): UpdateRingItem['autoApprove'] {
   if (raw === true) {
-    return { enabled: true, severities: [], deferralDays: 0, thirdPartyApps: false, thirdPartyDeferralDays: null };
+    return { enabled: true, severities: [], deferralDays: 0, thirdPartyApps: false, thirdPartyDeferralDays: null, autoApproveUnrated: false };
   }
   if (!raw || typeof raw !== 'object') {
     return { ...DISABLED_RING_AUTO_APPROVE };
@@ -160,7 +161,9 @@ function normalizeRingAutoApprove(raw: unknown): UpdateRingItem['autoApprove'] {
     }
     thirdPartyDeferralDays = rawThirdPartyHold;
   }
-  return { enabled: obj.enabled === true, severities, deferralDays, thirdPartyApps, thirdPartyDeferralDays };
+  const autoApproveUnrated = obj.autoApproveUnrated === true;
+
+  return { enabled: obj.enabled === true, severities, deferralDays, thirdPartyApps, thirdPartyDeferralDays, autoApproveUnrated };
 }
 
 export function normalizeRing(raw: Record<string, unknown>): UpdateRingItem {

--- a/apps/web/src/locales/de-DE/patches.json
+++ b/apps/web/src/locales/de-DE/patches.json
@@ -431,6 +431,8 @@
       "allCategories": "Alle Kategorien",
       "default": "Standard",
       "severityNote": "Schweregrade gelten nur für Betriebssystem-Updates. Drittanbieter-App-Updates werden über den Schalter unten gesteuert — sie sind nicht schweregradbasiert.",
+      "unratedSeverityNote": "Nicht bewertete Patches (ohne Schweregradbewertung) sind von dieser Schweregradauswahl ausgeschlossen und werden nicht automatisch freigegeben, selbst wenn alle Schweregrade ausgewählt sind, es sei denn, Sie aktivieren den Schalter unten.",
+      "autoApproveUnratedLabel": "Auch nicht bewertete Patches automatisch freigeben",
       "manualDefault": "Jeder Patch in diesem Ring muss manuell freigegeben werden.",
       "manualCategory": "Patches in dieser Kategorie müssen manuell freigegeben werden.",
       "noOverrides": "Alle Kategorien verwenden den Standard. Mit einer Überschreibung kann eine Kategorie abweichend behandelt werden."

--- a/apps/web/src/locales/en/patches.json
+++ b/apps/web/src/locales/en/patches.json
@@ -431,6 +431,8 @@
       "allCategories": "All categories",
       "default": "Default",
       "severityNote": "Severities apply to OS updates only. Third-party app updates are controlled by the toggle below — they are not severity-controlled.",
+      "unratedSeverityNote": "Unrated patches (no severity rating) are excluded from this severity selection and will not auto-approve, even with every severity checked, unless you turn on the toggle below.",
+      "autoApproveUnratedLabel": "Also auto-approve unrated patches",
       "manualDefault": "Every patch in this ring needs manual approval.",
       "manualCategory": "Patches in this category need manual approval.",
       "noOverrides": "All categories follow the default. Add an override to treat one differently."

--- a/apps/web/src/locales/es-419/patches.json
+++ b/apps/web/src/locales/es-419/patches.json
@@ -431,6 +431,8 @@
       "allCategories": "Todas las categorias",
       "default": "Por defecto",
       "severityNote": "Las severidades aplican solo a las actualizaciones del sistema operativo. Las actualizaciones de apps de terceros se controlan con el interruptor de abajo — no se controlan por severidad.",
+      "unratedSeverityNote": "Los parches sin calificación (sin severidad asignada) quedan excluidos de esta selección de severidad y no se aprobarán automáticamente, incluso si se marcan todas las severidades, a menos que active el interruptor de abajo.",
+      "autoApproveUnratedLabel": "También aprobar automáticamente los parches sin calificación",
       "manualDefault": "Cada parche de este anillo necesita aprobación manual.",
       "manualCategory": "Los parches de esta categoría necesitan aprobación manual.",
       "noOverrides": "Todas las categorías siguen el valor predeterminado. Agregue una anulación para tratar uno de manera diferente."

--- a/apps/web/src/locales/fr-CA/patches.json
+++ b/apps/web/src/locales/fr-CA/patches.json
@@ -431,6 +431,8 @@
       "allCategories": "Toutes les catégories",
       "default": "Par défaut",
       "severityNote": "Les sévérités ne s'appliquent qu'aux mises à jour du système d'exploitation. Les mises à jour d'applications tierces sont contrôlées par l'interrupteur ci-dessous — elles ne sont pas contrôlées par sévérité.",
+      "unratedSeverityNote": "Les correctifs non évalués (sans niveau de gravité) sont exclus de cette sélection de gravité et ne seront pas approuvés automatiquement, même si toutes les gravités sont cochées, sauf si vous activez l'interrupteur ci-dessous.",
+      "autoApproveUnratedLabel": "Approuver aussi automatiquement les correctifs non évalués",
       "manualDefault": "Chaque correctif de cet anneau nécessite une approbation manuelle.",
       "manualCategory": "Les correctifs de cette catégorie nécessitent une approbation manuelle.",
       "noOverrides": "Toutes les catégories suivent la norme par défaut. Ajoutez une dérogation pour traiter un autre type différemment."

--- a/apps/web/src/locales/fr-FR/patches.json
+++ b/apps/web/src/locales/fr-FR/patches.json
@@ -431,6 +431,8 @@
       "allCategories": "Toutes les catégories",
       "default": "Par défaut",
       "severityNote": "Les sévérités ne s'appliquent qu'aux mises à jour du système d'exploitation. Les mises à jour d'applications tierces sont contrôlées par l'interrupteur ci-dessous — elles ne sont pas contrôlées par sévérité.",
+      "unratedSeverityNote": "Les correctifs non évalués (sans niveau de gravité) sont exclus de cette sélection de gravité et ne seront pas approuvés automatiquement, même si toutes les gravités sont cochées, sauf si vous activez l'interrupteur ci-dessous.",
+      "autoApproveUnratedLabel": "Approuver aussi automatiquement les correctifs non évalués",
       "manualDefault": "Chaque correctif de cet anneau nécessite une approbation manuelle.",
       "manualCategory": "Les correctifs de cette catégorie nécessitent une approbation manuelle.",
       "noOverrides": "Toutes les catégories suivent la norme par défaut. Ajoutez une dérogation pour traiter un autre type différemment."

--- a/apps/web/src/locales/it-IT/patches.json
+++ b/apps/web/src/locales/it-IT/patches.json
@@ -431,6 +431,8 @@
       "allCategories": "Tutte le categorie",
       "default": "Predefinito",
       "severityNote": "Le gravità si applicano solo agli aggiornamenti del sistema operativo. Gli aggiornamenti delle app di terze parti sono controllati dall'interruttore qui sotto — non sono controllati per gravità.",
+      "unratedSeverityNote": "Le patch non valutate (senza una valutazione di gravità) sono escluse da questa selezione di gravità e non verranno approvate automaticamente, anche se sono selezionate tutte le gravità, a meno che non si attivi l'interruttore qui sotto.",
+      "autoApproveUnratedLabel": "Approva automaticamente anche le patch non valutate",
       "manualDefault": "Ogni patch in questo anello richiede l'approvazione manuale.",
       "manualCategory": "Le patch in questa categoria richiedono l'approvazione manuale.",
       "noOverrides": "Tutte le categorie seguono l'impostazione predefinita. Aggiungi un override per gestirne una diversamente."

--- a/apps/web/src/locales/pt-BR/patches.json
+++ b/apps/web/src/locales/pt-BR/patches.json
@@ -431,6 +431,8 @@
       "allCategories": "Todas as categorias",
       "default": "Padrão",
       "severityNote": "As severidades se aplicam apenas às atualizações do sistema operacional. Atualizações de apps de terceiros são controladas pelo botão abaixo — não são controladas por severidade.",
+      "unratedSeverityNote": "Patches sem classificação (sem severidade atribuída) são excluídos desta seleção de severidade e não serão aprovados automaticamente, mesmo com todas as severidades marcadas, a menos que você ative o botão abaixo.",
+      "autoApproveUnratedLabel": "Também aprovar automaticamente patches sem classificação",
       "manualDefault": "Todos os patches neste anel precisam de aprovação manual.",
       "manualCategory": "Patches nesta categoria precisam de aprovação manual.",
       "noOverrides": "Todas as categorias seguem o padrão. Adicione uma substituição para tratar uma delas de forma diferente."

--- a/apps/web/src/locales/tr-TR/patches.json
+++ b/apps/web/src/locales/tr-TR/patches.json
@@ -431,6 +431,8 @@
       "allCategories": "Tüm kategoriler",
       "default": "Varsayılan",
       "severityNote": "Önem dereceleri yalnızca işletim sistemi güncellemeleri için geçerlidir. Üçüncü taraf uygulama güncellemeleri aşağıdaki geçişle kontrol edilir; ciddiyet kontrollü değildir.",
+      "unratedSeverityNote": "Derecesiz yamalar (önem derecesi olmayan) bu önem derecesi seçiminin dışında tutulur ve aşağıdaki geçişi açmadığınız sürece, tüm önem dereceleri işaretli olsa bile otomatik olarak onaylanmaz.",
+      "autoApproveUnratedLabel": "Derecesiz yamaları da otomatik onayla",
       "manualDefault": "Bu halkadaki her yamanın manuel olarak onaylanması gerekiyor.",
       "manualCategory": "Bu kategorideki yamaların manuel olarak onaylanması gerekir.",
       "noOverrides": "Tüm kategoriler varsayılanı takip eder. Birine farklı davranmak için geçersiz kılma ekleyin."


### PR DESCRIPTION
Closes #4715

## What changed

Wave 3 of feature #4712 (unrated-patch auto-approve signaling). Web-only: builds on the `autoApproveUnrated` field already shipped in W02 (#4714, merged on main).

- `patchHelpers.ts`: `normalizeRingAutoApprove` now reads/round-trips `autoApproveUnrated` from a ring's stored `auto_approve` JSONB (defaults to `false` for legacy rows, mirroring the `thirdPartyApps` precedent).
- `UpdateRingList.tsx`: added `autoApproveUnrated?: boolean` to the `RingAutoApprove` and `CategoryRule` types (needed by `patchHelpers.ts`/`UpdateRingForm.tsx`; this file isn't in either wave's explicit file list, but the type lives here and W04 doesn't touch it).
- `UpdateRingForm.tsx`:
  - `ringAutoApproveFormSchema` and `categoryRuleSchema` gained `autoApproveUnrated` (required boolean on the ring default rule; optional on category overrides, matching the API's optional-for-merge shape).
  - Added a warning note ("Unrated patches (no severity rating) are excluded from this severity selection...") plus an opt-in toggle (`ApproveToggle`, not modified) to both the default-rule panel and each category override row. Per the plan, `ApproveToggle`'s own "Auto-approve"/"Manual" label text is left as-is; an adjacent `<span>` supplies the specific "Also auto-approve unrated patches" label.
  - `addOverride` now pre-fills a new override's `autoApproveUnrated` from the default rule, matching the existing `autoApproveSeverities` pre-fill pattern.
- `apps/web/src/locales/en/patches.json` (+ all 7 other locales): added `approvalPolicy.unratedSeverityNote` and `approvalPolicy.autoApproveUnratedLabel` keys — required by `localeParity.test.ts`, which asserts every locale carries the same key set as `en`.

## Deviations from the plan

- **Note copy changed from the plan's literal text.** The plan's own failing test asserts `toHaveTextContent(/unrated patches/i)` on the note, but the plan's proposed copy ("Patches with no severity rating are excluded...") never contains the literal phrase "unrated patches" — a latent inconsistency in the plan doc. Reworded to "Unrated patches (no severity rating) are excluded from this severity selection..." so the copy is self-consistent with its own test and reads clearly to admins. All 8 locale translations follow this reworded copy.
- **Added `UpdateRingList.tsx` to the touched-file set.** Not listed in the wave-3 brief's owned files, but `RingAutoApprove`/`CategoryRule` are defined there and consumed by both `patchHelpers.ts` and `UpdateRingForm.tsx` — typechecking the new `autoApproveUnrated` field through those consumers required extending the type at its source. W04 does not touch this file (owns `compliance.ts` / `dashboard/*` / `common.json`), so no conflict expected.
- **Extra test coverage beyond the plan's two specified tests**: added a "hydrates the opt-in toggle from edit defaults" test and a category-override submit test, since the toggle is wired into both the default rule and per-category overrides (Task 3.2 Step 5) but the plan only specified failing tests for the default-rule case.
- The plan's failing-test scaffolding used `userEvent`; the existing `UpdateRingForm.test.tsx` file uses `fireEvent` throughout, so new tests follow the file's established convention instead (per the plan's own guidance to "copy the setup block from an existing test in the same file").

## Not verified

- No RLS/integration/cascade impact (web-only change, no schema/migration) — the plan's tenancy section confirms this and Wave 2 already covered the API-side contract tests.
- Did not visually verify the rendered form in a browser; relied on RTL assertions (`toBeChecked`, `toHaveTextContent`, testid presence) and the existing render/interact test patterns in the file.
- Did not re-run W02's or W01's test suites — out of scope, already merged and covered by their own PRs.
- Base branch is `main` (W02 already merged), so the plan's "stacked PR / dispatch CI per branch" caveat doesn't apply here.

## Test plan

- `cd apps/web && npx vitest run src/components/patches/patchHelpers.test.ts src/components/patches/UpdateRingForm.test.tsx` — pass
- `cd apps/web && npx vitest run src/components/patches/` (11 files, 138 tests) — pass
- `cd apps/web && npx vitest run src/lib/i18n/localeParity.test.ts` (79 tests) — pass
- `pnpm --filter @breeze/web exec tsc --noEmit` — clean
- `pnpm lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SivE9p5bwyubSViy3jQPkZ