### PR TITLE
feat(patches): surface unratedSummary on compliance endpoint + dashboard callout

### DIFF
--- a/apps/api/src/routes/patches/compliance.test.ts
+++ b/apps/api/src/routes/patches/compliance.test.ts
@@ -207,3 +207,69 @@ describe('patch compliance site scope', () => {
     expect(conditionText(getDeviceWhere())).not.toContain('devices.siteId');
   });
 });
+
+describe('patch compliance unrated summary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    permissionsState = undefined;
+  });
+
+  it('includes unratedSummary counting both NULL and \'unknown\' severity as unrated', async () => {
+    vi.mocked(db.select)
+      // org device IDs
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ id: DEVICE_ID }]),
+        }),
+      } as never)
+      // status counts
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              groupBy: vi.fn().mockResolvedValue([]),
+            }),
+          }),
+        }),
+      } as never)
+      // device breakdown
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          innerJoin: vi.fn().mockReturnValue({
+            innerJoin: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                groupBy: vi.fn().mockReturnValue({
+                  having: vi.fn().mockReturnValue({
+                    orderBy: vi.fn().mockResolvedValue([]),
+                  }),
+                }),
+              }),
+            }),
+          }),
+        }),
+      } as never)
+      // severity counts: one NULL-severity outstanding row, one 'unknown'-severity
+      // row (1 installed + 1 outstanding) — both must coalesce into unratedSummary.
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              groupBy: vi.fn().mockResolvedValue([
+                { severity: null, installed: 0, outstanding: 1 },
+                { severity: 'unknown', installed: 1, outstanding: 1 },
+              ]),
+            }),
+          }),
+        }),
+      } as never);
+
+    const res = await mountApp().request('/patches/compliance', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer t' },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.unratedSummary).toEqual({ total: 3, patched: 1, pending: 2 });
+  });
+});

--- a/apps/api/src/routes/patches/compliance.ts
+++ b/apps/api/src/routes/patches/compliance.ts
@@ -91,6 +91,7 @@ complianceRoutes.get(
             compliantDevices: 0,
             criticalSummary: { total: 0, patched: 0, pending: 0 },
             importantSummary: { total: 0, patched: 0, pending: 0 },
+            unratedSummary: { total: 0, patched: 0, pending: 0 },
             devicesNeedingPatches: []
           }
         });
@@ -114,6 +115,7 @@ complianceRoutes.get(
           compliantDevices: 0,
           criticalSummary: { total: 0, patched: 0, pending: 0 },
           importantSummary: { total: 0, patched: 0, pending: 0 },
+          unratedSummary: { total: 0, patched: 0, pending: 0 },
           devicesNeedingPatches: []
         }
       });
@@ -193,6 +195,7 @@ complianceRoutes.get(
             compliantDevices: deviceIds.length,
             criticalSummary: { total: 0, patched: 0, pending: 0 },
             importantSummary: { total: 0, patched: 0, pending: 0 },
+            unratedSummary: { total: 0, patched: 0, pending: 0 },
             devicesNeedingPatches: [],
             ringId: query.ringId ?? null
           }
@@ -345,10 +348,21 @@ complianceRoutes.get(
 
     const severityMap: Record<string, { total: number; patched: number; pending: number }> = {};
     for (const row of severityCounts) {
+      // NULL severity and the literal 'unknown' sentinel both coalesce to the
+      // 'unknown' key here, but Postgres GROUP BY emits them as separate rows
+      // (NULL != 'unknown'), so this must accumulate rather than overwrite or
+      // whichever row is processed last silently wins and undercounts.
       const key = row.severity ?? 'unknown';
       const patched = Number(row.installed);
       const pending = Number(row.outstanding);
-      severityMap[key] = { total: patched + pending, patched, pending };
+      const existing = severityMap[key];
+      severityMap[key] = existing
+        ? {
+            total: existing.total + patched + pending,
+            patched: existing.patched + patched,
+            pending: existing.pending + pending
+          }
+        : { total: patched + pending, patched, pending };
     }
 
     // Device-level compliance: a device is compliant if it has zero outstanding
@@ -363,6 +377,7 @@ complianceRoutes.get(
         compliantDevices: compliantDeviceCount,
         criticalSummary: severityMap['critical'] ?? { total: 0, patched: 0, pending: 0 },
         importantSummary: severityMap['important'] ?? { total: 0, patched: 0, pending: 0 },
+        unratedSummary: severityMap['unknown'] ?? { total: 0, patched: 0, pending: 0 },
         devicesNeedingPatches,
         filters: {
           source: query.source ?? null,

--- a/apps/web/src/components/dashboard/KpiStrip.test.tsx
+++ b/apps/web/src/components/dashboard/KpiStrip.test.tsx
@@ -39,6 +39,8 @@ const patchData: PatchCompliance = {
   totalDevices: 42,
   compliantDevices: 38,
   criticalSummary: { total: 5, patched: 4, pending: 1 },
+  importantSummary: { total: 0, patched: 0, pending: 0 },
+  unratedSummary: { total: 0, patched: 0, pending: 0 },
 };
 
 describe('KpiStrip', () => {

--- a/apps/web/src/components/dashboard/PatchComplianceCard.test.tsx
+++ b/apps/web/src/components/dashboard/PatchComplianceCard.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { vi } from 'vitest';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      const count = (opts as { count?: number } | undefined)?.count;
+      return count !== undefined ? `${key}:${count}` : key;
+    },
+  }),
+}));
+
+import PatchComplianceCard from './PatchComplianceCard';
+import type { DashboardQueryState } from '../../hooks/useDashboardQuery';
+import type { PatchCompliance } from './types';
+
+function loaded(data: PatchCompliance): DashboardQueryState<PatchCompliance> {
+  return { data, error: null, isLoading: false, isFetching: false, unavailable: false, staleScope: false };
+}
+
+const basePatch: PatchCompliance = {
+  summary: { total: 10, pending: 5, installed: 5, failed: 0, missing: 0, skipped: 0 },
+  compliancePercent: 50,
+  totalDevices: 3,
+  compliantDevices: 1,
+  criticalSummary: { total: 0, patched: 0, pending: 0 },
+  importantSummary: { total: 0, patched: 0, pending: 0 },
+  unratedSummary: { total: 0, patched: 0, pending: 0 },
+};
+
+describe('PatchComplianceCard', () => {
+  it('shows an unrated-pending note when unratedSummary.pending > 0', () => {
+    render(
+      <PatchComplianceCard
+        patch={loaded({
+          ...basePatch,
+          unratedSummary: { total: 4, patched: 0, pending: 4 },
+        })}
+      />
+    );
+
+    expect(screen.getByText('dashboard.patch.unratedPending:4')).toBeInTheDocument();
+  });
+
+  it('does not show the unrated-pending note when unratedSummary.pending is 0', () => {
+    render(<PatchComplianceCard patch={loaded(basePatch)} />);
+
+    expect(screen.queryByText(/unratedPending/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/dashboard/PatchComplianceCard.tsx
+++ b/apps/web/src/components/dashboard/PatchComplianceCard.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { getErrorMessage } from '@/lib/errorMessages';
+import { cn } from '@/lib/utils';
 import SegmentedBar from './SegmentedBar';
 import type { DashboardQueryState } from '../../hooks/useDashboardQuery';
 import type { PatchCompliance } from './types';
@@ -81,6 +82,16 @@ export default function PatchComplianceCard({
           {data.criticalSummary.pending > 0 && (
             <p className="mt-3 border-t border-border/60 pt-3 text-xs font-medium text-destructive">
               {t('dashboard.patch.criticalPending', { count: data.criticalSummary.pending })}
+            </p>
+          )}
+          {data.unratedSummary.pending > 0 && (
+            <p
+              className={cn(
+                'text-xs font-medium text-muted-foreground',
+                data.criticalSummary.pending > 0 ? 'mt-1' : 'mt-3 border-t border-border/60 pt-3'
+              )}
+            >
+              {t('dashboard.patch.unratedPending', { count: data.unratedSummary.pending })}
             </p>
           )}
         </>

--- a/apps/web/src/components/dashboard/types.ts
+++ b/apps/web/src/components/dashboard/types.ts
@@ -48,6 +48,8 @@ export interface PatchCompliance {
   totalDevices: number;
   compliantDevices: number;
   criticalSummary: { total: number; patched: number; pending: number };
+  importantSummary: { total: number; patched: number; pending: number };
+  unratedSummary: { total: number; patched: number; pending: number };
 }
 
 /** GET /security/dashboard — apps/api/src/routes/security/dashboard.ts */

--- a/apps/web/src/locales/de-DE/common.json
+++ b/apps/web/src/locales/de-DE/common.json
@@ -371,6 +371,9 @@
       "criticalPending": "{{count}} kritische Patches ausstehend",
       "criticalPending_one": "{{count}} kritischer Patch ausstehend",
       "criticalPending_other": "{{count}} kritische Patches ausstehend",
+      "unratedPending": "{{count}} unbewertete Patches ausstehend (werden nicht automatisch genehmigt)",
+      "unratedPending_one": "{{count}} unbewerteter Patch ausstehend (wird nicht automatisch genehmigt)",
+      "unratedPending_other": "{{count}} unbewertete Patches ausstehend (werden nicht automatisch genehmigt)",
       "empty": "Noch keine Patch-Daten"
     },
     "vuln": {

--- a/apps/web/src/locales/en/common.json
+++ b/apps/web/src/locales/en/common.json
@@ -373,6 +373,9 @@
       "criticalPending": "{{count}} critical patches pending",
       "criticalPending_one": "{{count}} critical patch pending",
       "criticalPending_other": "{{count}} critical patches pending",
+      "unratedPending": "{{count}} unrated patches pending (won't auto-approve)",
+      "unratedPending_one": "{{count}} unrated patch pending (won't auto-approve)",
+      "unratedPending_other": "{{count}} unrated patches pending (won't auto-approve)",
       "empty": "No patch data yet"
     },
     "vuln": {

--- a/apps/web/src/locales/es-419/common.json
+++ b/apps/web/src/locales/es-419/common.json
@@ -371,6 +371,9 @@
       "criticalPending": "{{count}} parches críticos pendientes",
       "criticalPending_one": "{{count}} parche crítico pendiente",
       "criticalPending_other": "{{count}} parches críticos pendientes",
+      "unratedPending": "{{count}} parches sin calificar pendientes (no se aprobarán automáticamente)",
+      "unratedPending_one": "{{count}} parche sin calificar pendiente (no se aprobará automáticamente)",
+      "unratedPending_other": "{{count}} parches sin calificar pendientes (no se aprobarán automáticamente)",
       "empty": "Aún no hay datos de parches"
     },
     "vuln": {

--- a/apps/web/src/locales/fr-CA/common.json
+++ b/apps/web/src/locales/fr-CA/common.json
@@ -371,6 +371,9 @@
       "criticalPending": "{{count}} correctifs critiques en attente",
       "criticalPending_one": "{{count}} correctif critique en attente",
       "criticalPending_other": "{{count}} correctifs critiques en attente",
+      "unratedPending": "{{count}} correctifs non évalués en attente (ne seront pas approuvés automatiquement)",
+      "unratedPending_one": "{{count}} correctif non évalué en attente (ne sera pas approuvé automatiquement)",
+      "unratedPending_other": "{{count}} correctifs non évalués en attente (ne seront pas approuvés automatiquement)",
       "empty": "Aucune donnée de correctifs pour l'instant"
     },
     "vuln": {

--- a/apps/web/src/locales/fr-FR/common.json
+++ b/apps/web/src/locales/fr-FR/common.json
@@ -371,6 +371,9 @@
       "criticalPending": "{{count}} correctifs critiques en attente",
       "criticalPending_one": "{{count}} correctif critique en attente",
       "criticalPending_other": "{{count}} correctifs critiques en attente",
+      "unratedPending": "{{count}} correctifs non évalués en attente (ne seront pas approuvés automatiquement)",
+      "unratedPending_one": "{{count}} correctif non évalué en attente (ne sera pas approuvé automatiquement)",
+      "unratedPending_other": "{{count}} correctifs non évalués en attente (ne seront pas approuvés automatiquement)",
       "empty": "Pas encore de données de correctifs"
     },
     "vuln": {

--- a/apps/web/src/locales/it-IT/common.json
+++ b/apps/web/src/locales/it-IT/common.json
@@ -371,6 +371,9 @@
       "criticalPending": "{{count}} patch critiche in sospeso",
       "criticalPending_one": "{{count}} patch critica in sospeso",
       "criticalPending_other": "{{count}} patch critiche in sospeso",
+      "unratedPending": "{{count}} patch non valutate in sospeso (non verranno approvate automaticamente)",
+      "unratedPending_one": "{{count}} patch non valutata in sospeso (non verrà approvata automaticamente)",
+      "unratedPending_other": "{{count}} patch non valutate in sospeso (non verranno approvate automaticamente)",
       "empty": "Nessun dato sulle patch ancora"
     },
     "vuln": {

--- a/apps/web/src/locales/pt-BR/common.json
+++ b/apps/web/src/locales/pt-BR/common.json
@@ -371,6 +371,9 @@
       "criticalPending": "{{count}} patches críticos pendentes",
       "criticalPending_one": "{{count}} patch crítico pendente",
       "criticalPending_other": "{{count}} patches críticos pendentes",
+      "unratedPending": "{{count}} patches não avaliados pendentes (não serão aprovados automaticamente)",
+      "unratedPending_one": "{{count}} patch não avaliado pendente (não será aprovado automaticamente)",
+      "unratedPending_other": "{{count}} patches não avaliados pendentes (não serão aprovados automaticamente)",
       "empty": "Ainda sem dados de patches"
     },
     "vuln": {

--- a/apps/web/src/locales/tr-TR/common.json
+++ b/apps/web/src/locales/tr-TR/common.json
@@ -371,6 +371,9 @@
       "criticalPending": "{{count}} kritik yamalar beklemede",
       "criticalPending_one": "{{count}} kritik yama bekleniyor",
       "criticalPending_other": "{{count}} kritik yamalar beklemede",
+      "unratedPending": "{{count}} derecelendirilmemiş yama beklemede (otomatik onaylanmayacak)",
+      "unratedPending_one": "{{count}} derecelendirilmemiş yama beklemede (otomatik onaylanmayacak)",
+      "unratedPending_other": "{{count}} derecelendirilmemiş yama beklemede (otomatik onaylanmayacak)",
       "empty": "Henüz yama verisi yok"
     },
     "vuln": {


### PR DESCRIPTION
Closes #4716

## Summary
Wave 4 of #4712 (unrated-patch auto-approve signaling). Independent of Wave 3 (#4715); Waves 1/2 merged.

- `GET /patches/compliance` now returns `unratedSummary: { total, patched, pending }`, coalescing `NULL` and `'unknown'` severity rows — both mean "unrated" and never auto-approve (unchanged fail-closed behavior; this just makes the count visible).
- Added `unratedSummary` (and the pre-existing `importantSummary` gap the API already returned but the web type never declared) to the `PatchCompliance` web type.
- `PatchComplianceCard` on the dashboard now shows a "N unrated patches pending (won't auto-approve)" callout when `unratedSummary.pending > 0`, next to the existing critical-pending callout.
- Locale strings added to all 8 locales (`localeParity.test.ts` asserts full key parity, not just `en`).

## Deviations from the plan (code is truth)

1. **`severityMap` accumulation bug fixed.** The plan claimed the existing loop (`severityMap[key] = { total: patched + pending, patched, pending }`) already "sums" NULL and `'unknown'` rows into the same key. It doesn't — it's a plain assignment, so when both a NULL-severity row and an `'unknown'`-severity row exist for the same query (Postgres emits them as separate `GROUP BY` rows), whichever is processed last silently overwrites the other instead of summing, undercounting `unratedSummary`. Fixed the loop to accumulate onto an existing key. Caught by the plan's own example test case (2 rows, expected `total: 3`) — it failed with `total: 2` before the fix.
2. **Added `unratedSummary` to the three early-return response branches** (empty site allowlist, zero devices, empty ring-approved scope) that the plan's task didn't mention, since the web type declares the field non-optional and `PatchComplianceCard` dereferences `data.unratedSummary.pending` unconditionally — an early-return response missing the field would throw client-side in those edge-case org states.
3. **`PatchComplianceCard.test.tsx` created fresh** (didn't exist yet, despite being listed as "modify" in the plan).

## Tests
- `cd apps/api && npx vitest run src/routes/patches/compliance.test.ts` — pass (3/3)
- `cd apps/web && npx vitest run src/components/dashboard` — pass (24/24, 3 files)
- `cd apps/web && npx vitest run src/lib/i18n/localeParity.test.ts` — pass (79/79)
- `apps/api` typecheck (`tsc --noEmit`) — clean
- `apps/web` typecheck (`astro check`) — clean (0 errors; fixed one pre-existing fixture in `KpiStrip.test.tsx` that needed the two new required fields)
- `pnpm --filter @breeze/api lint` / `pnpm --filter @breeze/web lint` — clean

## Not verified
- No RLS/integration suites run — this wave touches no tenancy-scoped table or column (pure read aggregation + web display), per plan's "Tenancy / RLS / cascade impact" section.
- No manual browser verification of the dashboard card.
- Non-English locale translations are literal, not reviewed by a native speaker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L64WmaANVn7qNZHTaoEnxy