### PR TITLE
fix(agent): honest, blocking, process-tree script cancellation (#3525 W04)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1361,7 +1361,7 @@ jobs:
         working-directory: agent
         env:
           CGO_ENABLED: "0"
-        run: go test ./internal/sessionbroker ./internal/eventlog ./internal/elevaccount ./internal/ipc ./internal/logging ./internal/state ./internal/watchdog ./internal/backup/vss ./cmd/breeze-watchdog
+        run: go test ./internal/sessionbroker ./internal/eventlog ./internal/elevaccount ./internal/ipc ./internal/logging ./internal/state ./internal/watchdog ./internal/backup/vss ./internal/executor ./cmd/breeze-watchdog
 
       # The step above runs without -v, so a t.Skip is indistinguishable from a
       # pass in its output. That matters here more than usual: elevaccount's two
@@ -1467,7 +1467,7 @@ jobs:
       # the one that most needs the detector on the OS it actually ships to.
       - name: Run Windows race tests
         working-directory: agent
-        run: go test -race ./internal/sessionbroker ./internal/eventlog ./internal/ipc ./internal/state ./internal/watchdog ./cmd/breeze-watchdog
+        run: go test -race ./internal/sessionbroker ./internal/eventlog ./internal/ipc ./internal/state ./internal/watchdog ./internal/executor ./cmd/breeze-watchdog
 
   # ─── Go agent lint ────────────────────────────────────────────────────
   # The `lint` job above is JS/TS + compose guards only; the Go agent was

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1357,6 +1357,16 @@ jobs:
       # remote/desktop and no cgo. Its two behavioural tests assert against the
       # real netapi32 and skip loudly, rather than pass, on a host where
       # ~breeze_elev exists or local-account queries are not permitted.
+      # ./internal/executor is the fifth instance of the same gap (#3525):
+      # limits_windows.go's setProcessGroup/hideWindow and the new Job Object
+      # containment are Windows-only, and limits_windows_test.go had never
+      # executed anywhere. Verified like logging/ipc/elevaccount: with
+      # GOOS=windows GOARCH=amd64 CGO_ENABLED=0 it vets and its test binary
+      # compiles. It differs from those three in one way that matters — its
+      # Windows dependency graph DOES contain remote/desktop, via
+      # privilege -> remote/tools — which is harmless here (CGO_ENABLED=0 is
+      # exactly the configuration remote/desktop's !cgo files are written for)
+      # but is why it must stay out of the race step below.
       - name: Run Windows Go tests
         working-directory: agent
         env:
@@ -1460,14 +1470,25 @@ jobs:
           if ($passes -ne 14) { throw "expected exactly 14 top-level PASS lines, got $passes - a test in the -run filter was renamed, removed, or added without updating this count" }
 
       # -race requires cgo, which remote/desktop cannot satisfy on Windows, so
-      # this covers only packages that do not import it (heartbeat and agentapp
-      # do, transitively). Same package set as the step above: sessionbroker is
-      # the concurrency-critical one — session-keyed helper admission, the
-      # lifecycle registry, and Job Object ownership all live there — so it is
-      # the one that most needs the detector on the OS it actually ships to.
+      # this covers only packages that do not import it (heartbeat, agentapp and
+      # executor do, transitively). Same package set as the step above MINUS
+      # those: sessionbroker is the concurrency-critical one — session-keyed
+      # helper admission, the lifecycle registry, and Job Object ownership all
+      # live there — so it is the one that most needs the detector on the OS it
+      # actually ships to.
+      #
+      # ./internal/executor belongs to the CGO_ENABLED=0 step above and NOT
+      # here: it reaches remote/desktop via privilege -> remote/tools (#3525
+      # added the package to the list above and briefly to this one, which went
+      # red). The concrete failure is that dxgi_windows.go and
+      # dxgi_capture_windows.go are `//go:build windows && !cgo`, so with cgo ON
+      # their comVtblFn/dxgiCapturer/procDeleteObject definitions vanish while
+      # the plain-`windows` files that reference them stay. Check the import
+      # graph before adding anything else here:
+      #   GOOS=windows go list -deps ./internal/<pkg> | grep remote/desktop
       - name: Run Windows race tests
         working-directory: agent
-        run: go test -race ./internal/sessionbroker ./internal/eventlog ./internal/ipc ./internal/state ./internal/watchdog ./internal/executor ./cmd/breeze-watchdog
+        run: go test -race ./internal/sessionbroker ./internal/eventlog ./internal/ipc ./internal/state ./internal/watchdog ./cmd/breeze-watchdog
 
   # ─── Go agent lint ────────────────────────────────────────────────────
   # The `lint` job above is JS/TS + compose guards only; the Go agent was

--- a/agent/internal/executor/cancel_test.go
+++ b/agent/internal/executor/cancel_test.go
@@ -1,8 +1,10 @@
 package executor
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -68,7 +70,7 @@ func TestCancelBlocksUntilTheProcessIsGone(t *testing.T) {
 	go func() { r, _ := e.Execute(sleepScript("id-1", 60)); done <- r }()
 	waitForRunning(t, e, "id-1")
 
-	outcome, err := e.Cancel("id-1", 0)
+	outcome, err := e.Cancel("id-1", "cc-1", 0)
 	if err != nil {
 		t.Fatalf("Cancel: %v", err)
 	}
@@ -86,7 +88,7 @@ func TestCancelBlocksUntilTheProcessIsGone(t *testing.T) {
 
 func TestCancelReportsNotFoundForAnUnknownID(t *testing.T) {
 	e := newTestExecutor()
-	outcome, err := e.Cancel("nope", 5)
+	outcome, err := e.Cancel("nope", "cc-nope", 5)
 	if err != nil {
 		t.Fatalf("Cancel: %v", err)
 	}
@@ -101,8 +103,7 @@ func TestCancelledResultCarriesTheCancellationMarker(t *testing.T) {
 	done := make(chan *ScriptResult, 1)
 	go func() { r, _ := e.Execute(sleepScript("id-2", 60)); done <- r }()
 	waitForRunning(t, e, "id-2")
-	e.SetCancelCommandID("id-2", "cancel-cmd-7")
-	if _, err := e.Cancel("id-2", 0); err != nil {
+	if _, err := e.Cancel("id-2", "cancel-cmd-7", 0); err != nil {
 		t.Fatal(err)
 	}
 
@@ -130,7 +131,7 @@ func TestGracefulEscalationSendsSIGTERMBeforeSIGKILL(t *testing.T) {
 	go func() { defer close(done); _, _ = e.Execute(sigtermTrapScript("id-3", marker, 60)) }()
 	waitForRunning(t, e, "id-3")
 
-	outcome, err := e.Cancel("id-3", 5)
+	outcome, err := e.Cancel("id-3", "cc-3", 5)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -151,7 +152,7 @@ func TestZeroGraceSkipsStraightToKill(t *testing.T) {
 	go func() { defer close(done); _, _ = e.Execute(sigtermTrapScript("id-5", marker, 60)) }()
 	waitForRunning(t, e, "id-5")
 
-	if _, err := e.Cancel("id-5", 0); err != nil {
+	if _, err := e.Cancel("id-5", "cc-5", 0); err != nil {
 		t.Fatal(err)
 	}
 	<-done
@@ -161,23 +162,31 @@ func TestZeroGraceSkipsStraightToKill(t *testing.T) {
 }
 
 func TestCancelBeforeRegistrationPreventsTheScriptFromStarting(t *testing.T) {
-	skipWithoutBash(t)
-	// Execute validates, writes the script file and calls configureRunAs BEFORE
-	// inserting into e.running, and WebSocket commands are concurrent. A cancel
-	// in that window must not return not_found and let the script start anyway.
+	// Execute validates, writes the script file and calls configureRunAs before
+	// the process exists, and WebSocket commands are concurrent. This walks that
+	// exact window deterministically: reserve (Execute's first action), a cancel,
+	// then the beginStart gate Execute reaches once its setup is done.
 	e := newTestExecutor()
-	e.reserve("id-4", time.Now(), ScriptTypeBash) // pre-start placeholder, inserted first
+	running, preCancelled, duplicate := e.reserve("id-4", time.Now(), ScriptTypeBash)
+	if preCancelled || duplicate {
+		t.Fatalf("a fresh id reported preCancelled=%v duplicate=%v", preCancelled, duplicate)
+	}
 
-	outcome, err := e.Cancel("id-4", 0)
+	outcome, err := e.Cancel("id-4", "cc-4", 0)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if outcome == CancelNotFound {
 		t.Fatal("cancel raced Execute's setup and reported not_found")
 	}
+	// Nothing will ever run, so the only honest answer is a proven stop.
+	if outcome != CancelTerminated {
+		t.Fatalf("outcome = %q, want terminated for a process that can never start", outcome)
+	}
 
-	res, _ := e.Execute(sleepScript("id-4", 60))
-	if !res.Cancelled {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if running.beginStart(exec.CommandContext(ctx, "/bin/sh", "-c", "true"), cancel) {
 		t.Fatal("script started despite a cancel that arrived first")
 	}
 }
@@ -197,7 +206,7 @@ func TestCancelReportsKillFailedWhenContainmentWasNeverEstablished(t *testing.T)
 	r.contained = false
 	r.mu.Unlock()
 
-	outcome, err := e.Cancel("id-6", 0)
+	outcome, err := e.Cancel("id-6", "cc-6", 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -205,6 +214,120 @@ func TestCancelReportsKillFailedWhenContainmentWasNeverEstablished(t *testing.T)
 		t.Fatalf("outcome = %q, want kill_failed for an uncontained execution", outcome)
 	}
 	<-done
+}
+
+func TestDuplicateExecuteCannotUnblockACancelOnTheOriginal(t *testing.T) {
+	skipWithoutBash(t)
+	// The server can redeliver a command id (the dedup window is 2 minutes but a
+	// script may run for an hour). A second Execute must NOT adopt the first
+	// one's reservation: it would close the shared done channel when IT
+	// finished, unblocking a Cancel that is waiting on the ORIGINAL process and
+	// letting it report `terminated` while that process is still running.
+	e := newTestExecutor()
+	first := make(chan *ScriptResult, 1)
+	go func() { r, _ := e.Execute(sleepScript("dup-1", 60)); first <- r }()
+	waitForRunning(t, e, "dup-1")
+
+	dup, err := e.Execute(sleepScript("dup-1", 60))
+	if err == nil {
+		t.Fatal("a duplicate Execute for a running id was accepted")
+	}
+	if dup == nil || dup.ExitCode != -1 {
+		t.Fatalf("duplicate result = %+v, want a failure result", dup)
+	}
+
+	// The original must still be running and still cancellable.
+	select {
+	case r := <-first:
+		t.Fatalf("the duplicate terminated the original execution: %+v", r)
+	default:
+	}
+	if outcome, cancelErr := e.Cancel("dup-1", "cc-dup", 0); cancelErr != nil || outcome != CancelTerminated {
+		t.Fatalf("Cancel on the original = (%q, %v), want terminated", outcome, cancelErr)
+	}
+	<-first
+}
+
+func TestCancelStopsAScriptThatIsStillQueuedInTheWorkerPool(t *testing.T) {
+	skipWithoutBash(t)
+	// The bypass lane makes the CANCEL jump the pool, but the script it targets
+	// can still be sitting in that queue behind another script — the pool floors
+	// at 1 worker, so this is the ordinary case, not an edge. Execute has not run
+	// yet, so the executor has never heard of the id. Answering a bare not_found
+	// and forgetting would let that script start minutes later exactly as if no
+	// cancel had ever been issued.
+	e := newTestExecutor()
+
+	outcome, err := e.Cancel("queued-1", "cc-q1", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Honest: we cannot tell a queued script from an id this device never had,
+	// so the ANSWER stays not_found. The refusal below carries the marker, which
+	// is what closes the execution on the server.
+	if outcome != CancelNotFound {
+		t.Fatalf("outcome = %q, want not_found for an execution we have not seen", outcome)
+	}
+
+	// The pool frees up and the script is finally dispatched.
+	res, err := e.Execute(sleepScript("queued-1", 60))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !res.Cancelled {
+		t.Fatal("a script cancelled while queued ran anyway")
+	}
+	if res.ExitCode != -1 {
+		t.Fatalf("ExitCode = %d, want -1 for a script that never ran", res.ExitCode)
+	}
+	if e.GetRunningCount() != 0 {
+		t.Fatalf("running count = %d after the refusal, want 0", e.GetRunningCount())
+	}
+}
+
+func TestARefusalRecordNamesTheCancelCommandAndIsNotReportedAsRunning(t *testing.T) {
+	e := newTestExecutor()
+	if _, err := e.Cancel("queued-2", "cc-queued", 0); err != nil {
+		t.Fatal(err)
+	}
+
+	// script_list_running must not invent a phantom execution.
+	if got := e.ListRunning(); len(got) != 0 {
+		t.Fatalf("ListRunning reported a phantom execution: %v", got)
+	}
+	if got := e.GetRunningCount(); got != 0 {
+		t.Fatalf("GetRunningCount = %d, want 0", got)
+	}
+
+	res, _ := e.Execute(sleepScript("queued-2", 60))
+	if res.CancelledByCommandID != "cc-queued" {
+		t.Fatalf("CancelledByCommandID = %q, want cc-queued", res.CancelledByCommandID)
+	}
+}
+
+func TestARefusalRecordIsReapedSoItCannotBlockALaterExecutionForever(t *testing.T) {
+	restore := cancelRefusalTTL
+	cancelRefusalTTL = 50 * time.Millisecond
+	t.Cleanup(func() { cancelRefusalTTL = restore })
+
+	e := newTestExecutor()
+	if _, err := e.Cancel("queued-3", "cc-q3", 0); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		e.mu.Lock()
+		_, present := e.running["queued-3"]
+		e.mu.Unlock()
+		if !present {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("the refusal record was never reaped; a command id could be blocked forever")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }
 
 func TestClampGraceBoundsTheRequestedWindow(t *testing.T) {

--- a/agent/internal/executor/cancel_test.go
+++ b/agent/internal/executor/cancel_test.go
@@ -1,0 +1,191 @@
+package executor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// sleepScript builds a long-running bash script used to hold an execution open
+// while a cancel races it.
+func sleepScript(id string, seconds int) ScriptExecution {
+	return ScriptExecution{
+		ID:         id,
+		ScriptID:   "script-" + id,
+		ScriptType: ScriptTypeBash,
+		// A loop of short sleeps rather than one long sleep: bash defers trap
+		// handling until the running command returns, so `sleep 600` would
+		// swallow SIGTERM for ten minutes and make the graceful-escalation
+		// tests below indistinguishable from a hard kill.
+		Script:  fmt.Sprintf("for _ in $(seq 1 %d); do sleep 0.1; done\n", seconds*10),
+		Timeout: 300,
+	}
+}
+
+// sigtermTrapScript traps SIGTERM, writes marker, then exits cleanly. If the
+// marker exists after a cancel, SIGTERM was genuinely delivered before SIGKILL.
+func sigtermTrapScript(id, marker string, seconds int) ScriptExecution {
+	s := sleepScript(id, seconds)
+	s.Script = fmt.Sprintf("trap 'printf caught > %q; exit 0' TERM\n", marker) + s.Script
+	return s
+}
+
+// waitForRunning blocks until the executor has an entry for id whose process
+// has actually been started.
+func waitForRunning(t *testing.T, e *Executor, id string) *runningExecution {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		e.mu.Lock()
+		r, ok := e.running[id]
+		e.mu.Unlock()
+		if ok && r.hasStarted() {
+			return r
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("execution %q never reached a started state", id)
+	return nil
+}
+
+func skipWithoutBash(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("bash-based cancellation tests are Unix-only")
+	}
+	if _, err := os.Stat("/bin/bash"); err != nil {
+		t.Skip("/bin/bash unavailable")
+	}
+}
+
+func TestCancelBlocksUntilTheProcessIsGone(t *testing.T) {
+	skipWithoutBash(t)
+	e := newTestExecutor()
+	done := make(chan *ScriptResult, 1)
+	go func() { r, _ := e.Execute(sleepScript("id-1", 60)); done <- r }()
+	waitForRunning(t, e, "id-1")
+
+	outcome, err := e.Cancel("id-1", 0)
+	if err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	if outcome != CancelTerminated {
+		t.Fatalf("outcome = %q, want terminated", outcome)
+	}
+	// Cancel must not return before the kill is observed: the server's
+	// `confirmed` flag is built on this ack.
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Cancel returned terminated while the process was still running")
+	}
+}
+
+func TestCancelReportsNotFoundForAnUnknownID(t *testing.T) {
+	e := newTestExecutor()
+	outcome, err := e.Cancel("nope", 5)
+	if err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	if outcome != CancelNotFound {
+		t.Fatalf("outcome = %q, want not_found", outcome)
+	}
+}
+
+func TestCancelledResultCarriesTheCancellationMarker(t *testing.T) {
+	skipWithoutBash(t)
+	e := newTestExecutor()
+	done := make(chan *ScriptResult, 1)
+	go func() { r, _ := e.Execute(sleepScript("id-2", 60)); done <- r }()
+	waitForRunning(t, e, "id-2")
+	e.SetCancelCommandID("id-2", "cancel-cmd-7")
+	if _, err := e.Cancel("id-2", 0); err != nil {
+		t.Fatal(err)
+	}
+
+	var res *ScriptResult
+	select {
+	case res = <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("execution never returned a result after cancel")
+	}
+	// Without this the server cannot tell "we killed it" from "it finished on
+	// its own", and OD9-C forces it to preserve the natural outcome.
+	if !res.Cancelled {
+		t.Fatal("result.Cancelled = false, want true")
+	}
+	if res.CancelledByCommandID != "cancel-cmd-7" {
+		t.Fatalf("CancelledByCommandID = %q, want cancel-cmd-7", res.CancelledByCommandID)
+	}
+}
+
+func TestGracefulEscalationSendsSIGTERMBeforeSIGKILL(t *testing.T) {
+	skipWithoutBash(t)
+	marker := filepath.Join(t.TempDir(), "term-marker")
+	e := newTestExecutor()
+	done := make(chan struct{})
+	go func() { defer close(done); _, _ = e.Execute(sigtermTrapScript("id-3", marker, 60)) }()
+	waitForRunning(t, e, "id-3")
+
+	outcome, err := e.Cancel("id-3", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome != CancelTerminated {
+		t.Fatalf("outcome = %q, want terminated", outcome)
+	}
+	<-done
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("SIGTERM was never delivered before SIGKILL: %v", err)
+	}
+}
+
+func TestZeroGraceSkipsStraightToKill(t *testing.T) {
+	skipWithoutBash(t)
+	marker := filepath.Join(t.TempDir(), "term-marker")
+	e := newTestExecutor()
+	done := make(chan struct{})
+	go func() { defer close(done); _, _ = e.Execute(sigtermTrapScript("id-5", marker, 60)) }()
+	waitForRunning(t, e, "id-5")
+
+	if _, err := e.Cancel("id-5", 0); err != nil {
+		t.Fatal(err)
+	}
+	<-done
+	if _, err := os.Stat(marker); err == nil {
+		t.Fatal("graceSeconds=0 still delivered SIGTERM; the trap ran")
+	}
+}
+
+func TestCancelBeforeRegistrationPreventsTheScriptFromStarting(t *testing.T) {
+	skipWithoutBash(t)
+	// Execute validates, writes the script file and calls configureRunAs BEFORE
+	// inserting into e.running, and WebSocket commands are concurrent. A cancel
+	// in that window must not return not_found and let the script start anyway.
+	e := newTestExecutor()
+	e.reserve("id-4", time.Now(), ScriptTypeBash) // pre-start placeholder, inserted first
+
+	outcome, err := e.Cancel("id-4", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome == CancelNotFound {
+		t.Fatal("cancel raced Execute's setup and reported not_found")
+	}
+
+	res, _ := e.Execute(sleepScript("id-4", 60))
+	if !res.Cancelled {
+		t.Fatal("script started despite a cancel that arrived first")
+	}
+}
+
+func TestClampGraceBoundsTheRequestedWindow(t *testing.T) {
+	for _, tc := range []struct{ in, want int }{{-1, 0}, {0, 0}, {5, 5}, {30, 30}, {31, 30}, {9999, 30}} {
+		if got := clampGrace(tc.in); got != tc.want {
+			t.Errorf("clampGrace(%d) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}

--- a/agent/internal/executor/cancel_test.go
+++ b/agent/internal/executor/cancel_test.go
@@ -182,6 +182,31 @@ func TestCancelBeforeRegistrationPreventsTheScriptFromStarting(t *testing.T) {
 	}
 }
 
+func TestCancelReportsKillFailedWhenContainmentWasNeverEstablished(t *testing.T) {
+	skipWithoutBash(t)
+	// The fail-closed rule: on Windows an RDS session job can deny the Job
+	// Object assignment, so the script runs but its children are not ours to
+	// kill. A cancel must never claim `terminated` in that state, even when the
+	// leader itself dies cleanly.
+	e := newTestExecutor()
+	done := make(chan *ScriptResult, 1)
+	go func() { r, _ := e.Execute(sleepScript("id-6", 60)); done <- r }()
+	r := waitForRunning(t, e, "id-6")
+
+	r.mu.Lock()
+	r.contained = false
+	r.mu.Unlock()
+
+	outcome, err := e.Cancel("id-6", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome != CancelKillFailed {
+		t.Fatalf("outcome = %q, want kill_failed for an uncontained execution", outcome)
+	}
+	<-done
+}
+
 func TestClampGraceBoundsTheRequestedWindow(t *testing.T) {
 	for _, tc := range []struct{ in, want int }{{-1, 0}, {0, 0}, {5, 5}, {30, 30}, {31, 30}, {9999, 30}} {
 		if got := clampGrace(tc.in); got != tc.want {

--- a/agent/internal/executor/cancel_test.go
+++ b/agent/internal/executor/cancel_test.go
@@ -29,10 +29,31 @@ func sleepScript(id string, seconds int) ScriptExecution {
 
 // sigtermTrapScript traps SIGTERM, writes marker, then exits cleanly. If the
 // marker exists after a cancel, SIGTERM was genuinely delivered before SIGKILL.
-func sigtermTrapScript(id, marker string, seconds int) ScriptExecution {
+//
+// It touches `ready` only AFTER the trap is installed, and the tests wait for
+// that file rather than for the process merely existing. waitForRunning returns
+// as soon as cmd.Start succeeded, which is well before bash has parsed and run
+// the trap builtin — a SIGTERM landing in that window takes the DEFAULT action
+// and no marker is ever written. That made the graceful test flaky, and worse,
+// made its zero-grace twin pass for the wrong reason (marker absent because the
+// trap was not installed yet, not because SIGKILL beat it).
+func sigtermTrapScript(id, marker, ready string, seconds int) ScriptExecution {
 	s := sleepScript(id, seconds)
-	s.Script = fmt.Sprintf("trap 'printf caught > %q; exit 0' TERM\n", marker) + s.Script
+	s.Script = fmt.Sprintf("trap 'printf caught > %q; exit 0' TERM\nprintf ready > %q\n", marker, ready) + s.Script
 	return s
+}
+
+// waitForNonEmptyFile blocks until path exists with content.
+func waitForNonEmptyFile(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if info, err := os.Stat(path); err == nil && info.Size() > 0 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("file %q never appeared", path)
 }
 
 // waitForRunning blocks until the executor has an entry for id whose process
@@ -125,11 +146,13 @@ func TestCancelledResultCarriesTheCancellationMarker(t *testing.T) {
 
 func TestGracefulEscalationSendsSIGTERMBeforeSIGKILL(t *testing.T) {
 	skipWithoutBash(t)
-	marker := filepath.Join(t.TempDir(), "term-marker")
+	dir := t.TempDir()
+	marker, ready := filepath.Join(dir, "term-marker"), filepath.Join(dir, "ready")
 	e := newTestExecutor()
 	done := make(chan struct{})
-	go func() { defer close(done); _, _ = e.Execute(sigtermTrapScript("id-3", marker, 60)) }()
+	go func() { defer close(done); _, _ = e.Execute(sigtermTrapScript("id-3", marker, ready, 60)) }()
 	waitForRunning(t, e, "id-3")
+	waitForNonEmptyFile(t, ready) // the trap is installed only now
 
 	outcome, err := e.Cancel("id-3", "cc-3", 5)
 	if err != nil {
@@ -146,11 +169,15 @@ func TestGracefulEscalationSendsSIGTERMBeforeSIGKILL(t *testing.T) {
 
 func TestZeroGraceSkipsStraightToKill(t *testing.T) {
 	skipWithoutBash(t)
-	marker := filepath.Join(t.TempDir(), "term-marker")
+	dir := t.TempDir()
+	marker, ready := filepath.Join(dir, "term-marker"), filepath.Join(dir, "ready")
 	e := newTestExecutor()
 	done := make(chan struct{})
-	go func() { defer close(done); _, _ = e.Execute(sigtermTrapScript("id-5", marker, 60)) }()
+	go func() { defer close(done); _, _ = e.Execute(sigtermTrapScript("id-5", marker, ready, 60)) }()
 	waitForRunning(t, e, "id-5")
+	// Without this the marker could be absent merely because the trap was never
+	// installed, and this test would pass without proving anything.
+	waitForNonEmptyFile(t, ready)
 
 	if _, err := e.Cancel("id-5", "cc-5", 0); err != nil {
 		t.Fatal(err)

--- a/agent/internal/executor/executor.go
+++ b/agent/internal/executor/executor.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/breeze-rmm/agent/internal/config"
 	"github.com/breeze-rmm/agent/internal/logging"
-	"github.com/breeze-rmm/agent/internal/procoutput"
 	"github.com/breeze-rmm/agent/internal/privilege"
+	"github.com/breeze-rmm/agent/internal/procoutput"
 )
 
 var log = logging.L("executor")
@@ -28,7 +28,47 @@ const (
 
 	// MaxOutputSize is the maximum size of stdout/stderr to capture
 	MaxOutputSize = 1024 * 1024 // 1MB
+
+	// MaxGraceSeconds is the largest graceful-shutdown window a cancel request
+	// may ask for (spec OD2-B). Every downstream deadline — notably the helper
+	// IPC wait — must exceed it.
+	MaxGraceSeconds = 30
 )
+
+// hardKillBackstop is how long Cancel keeps waiting past the requested grace
+// before giving up and reporting kill_failed. It has to exceed cmd.WaitDelay
+// (5s), which only starts once the cancel callback has already consumed the
+// grace window.
+const hardKillBackstop = 10 * time.Second
+
+// CancelOutcome is what a cancel request actually achieved on the endpoint.
+// The server turns this into `cancel_state`, and only CancelTerminated is
+// allowed to terminalize an execution as `cancelled` (#3525 honesty contract).
+type CancelOutcome string
+
+const (
+	// CancelTerminated means the process (and its tree) is provably gone.
+	CancelTerminated CancelOutcome = "terminated"
+	// CancelNotFound means this executor has no such execution. It is NOT
+	// confirmation of a stop: the agent may have restarted, or the script may
+	// have finished a moment ago with its result still in flight.
+	CancelNotFound CancelOutcome = "not_found"
+	// CancelKillFailed means we asked but cannot prove the tree is gone —
+	// the kill errored, containment was never established, or termination was
+	// not observed inside grace + hardKillBackstop.
+	CancelKillFailed CancelOutcome = "kill_failed"
+)
+
+// clampGrace bounds a server-supplied graceSeconds to 0..MaxGraceSeconds.
+func clampGrace(graceSeconds int) int {
+	if graceSeconds < 0 {
+		return 0
+	}
+	if graceSeconds > MaxGraceSeconds {
+		return MaxGraceSeconds
+	}
+	return graceSeconds
+}
 
 // ScriptExecution represents a script to be executed
 type ScriptExecution struct {
@@ -58,6 +98,16 @@ type ScriptResult struct {
 	StartedAt       string   `json:"startedAt"`
 	CompletedAt     string   `json:"completedAt"`
 	TruncatedFields []string `json:"truncatedFields,omitempty"`
+
+	// #3525. Set when this execution ended because a cancel request killed it.
+	// Without the marker the server cannot tell "we killed it" from "it
+	// finished on its own", and OD9-C requires it to preserve the natural
+	// outcome whenever the original result wins the race.
+	Cancelled bool `json:"cancelled,omitempty"`
+	// CancelledByCommandID is the device_commands.id of the script_cancel
+	// command that caused the kill, so the server can match the marker to the
+	// cancel it issued rather than to an older one.
+	CancelledByCommandID string `json:"cancelledByCommandId,omitempty"`
 }
 
 // Executor handles script execution with security controls
@@ -69,12 +119,187 @@ type Executor struct {
 	mu        sync.Mutex
 }
 
-// runningExecution tracks a running script execution
+// runningExecution tracks a running script execution.
+//
+// It is created by reserve() BEFORE the script is validated or started, so a
+// cancel racing Execute's setup cannot report not_found and then let the script
+// start anyway. Everything mutable is guarded by mu; done is the termination
+// signal Cancel blocks on.
 type runningExecution struct {
-	cmd        *exec.Cmd
-	cancel     context.CancelFunc
 	startedAt  time.Time
 	scriptType string
+
+	// done is closed exactly once, by release(), after cmd.Wait has returned
+	// (or after the execution bailed out before starting). Cancel blocks on it
+	// so its ack means "the process is gone", not "we asked".
+	done     chan struct{}
+	doneOnce sync.Once
+
+	mu     sync.Mutex
+	cmd    *exec.Cmd
+	cancel context.CancelFunc
+
+	// #3525. Captured once at Start: after SIGTERM the leader may already be
+	// gone, so a kill-time syscall.Getpgid fails and the fallback kills a dead
+	// leader while surviving children keep running. Unix only.
+	pgid int
+	// Windows containment handles; zero on Unix. If containment could NOT be
+	// established (an enclosing RDS session job forbids breakaway —
+	// sessionbroker/spawner_windows.go), contained stays false and a cancel can
+	// never report `terminated`.
+	job           jobHandle
+	jobPrimitives windowsJobPrimitives
+	contained     bool
+
+	// startAttempted flips the instant Execute commits to starting the process;
+	// started flips only once Start actually succeeded.
+	startAttempted bool
+	started        bool
+
+	graceSeconds    int
+	cancelRequested bool
+	cancelCommandID string
+	// killErr is set by the cmd.Cancel callback so Cancel can distinguish a
+	// failed kill from a successful one. The async callback error otherwise
+	// surfaces only to cmd.Wait, never to the cancel caller.
+	killErr error
+}
+
+func newRunningExecution(startedAt time.Time, scriptType string) *runningExecution {
+	return &runningExecution{
+		startedAt:  startedAt,
+		scriptType: scriptType,
+		done:       make(chan struct{}),
+	}
+}
+
+func (r *runningExecution) closeDone() {
+	r.doneOnce.Do(func() { close(r.done) })
+}
+
+// hasStarted reports whether the OS process was successfully created.
+func (r *runningExecution) hasStarted() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.started
+}
+
+// beginStart publishes the command and its context canceller, and reports
+// whether Execute may proceed. It returns false when a cancel already landed
+// during validation / file write / configureRunAs, which is the whole point of
+// reserving the id up front.
+func (r *runningExecution) beginStart(cmd *exec.Cmd, cancel context.CancelFunc) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.cancelRequested {
+		return false
+	}
+	r.cmd = cmd
+	r.cancel = cancel
+	r.startAttempted = true
+	return true
+}
+
+func (r *runningExecution) markStarted() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.started = true
+}
+
+// markCancelRequested records the cancel and returns whether Execute has
+// already committed to starting the process, plus the context canceller to
+// fire (nil when there is nothing running yet).
+func (r *runningExecution) markCancelRequested(grace int) (bool, context.CancelFunc) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.cancelRequested = true
+	r.graceSeconds = grace
+	return r.startAttempted, r.cancel
+}
+
+func (r *runningExecution) setCancelCommandID(commandID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.cancelCommandID = commandID
+}
+
+// cancellation reports whether this execution was cancelled and by which
+// script_cancel command id.
+func (r *runningExecution) cancellation() (bool, string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.cancelRequested, r.cancelCommandID
+}
+
+func (r *runningExecution) grace() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.graceSeconds
+}
+
+func (r *runningExecution) setKillErr(err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.killErr = err
+}
+
+// killOutcome snapshots everything Cancel needs to grade the stop once done
+// has closed.
+func (r *runningExecution) killOutcome() (started bool, killErr error, contained bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.started, r.killErr, r.contained
+}
+
+// attachProcessGroup records the pgid captured at Start. A real process group
+// IS the containment primitive on Unix, so a captured pgid marks the execution
+// contained; failing to capture one leaves it uncontained and a later cancel
+// can never report `terminated`.
+func (r *runningExecution) attachProcessGroup(pgid int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.pgid = pgid
+	r.contained = pgid > 0
+}
+
+// attachJob records the Windows containment handles established (or not) by
+// launchContained.
+func (r *runningExecution) attachJob(p windowsJobPrimitives, job jobHandle, process suspendedProcess, contained bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.jobPrimitives = p
+	r.job = job
+	r.contained = contained
+	if r.cmd == nil && process.cmd != nil {
+		r.cmd = process.cmd
+	}
+}
+
+// isContained reports whether a kill of this execution can be trusted to reach
+// the whole process tree.
+func (r *runningExecution) isContained() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.contained
+}
+
+// containment snapshots what terminateProcessTreeWindows needs.
+func (r *runningExecution) containment() (windowsJobPrimitives, jobHandle, *exec.Cmd) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.jobPrimitives, r.job, r.cmd
+}
+
+func (r *runningExecution) processGroup() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.pgid
+}
+
+func (r *runningExecution) command() *exec.Cmd {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.cmd
 }
 
 // New creates a new Executor instance
@@ -101,6 +326,23 @@ func (e *Executor) Execute(script ScriptExecution) (*ScriptResult, error) {
 	result := &ScriptResult{
 		ExecutionID: script.ID,
 		StartedAt:   startTime.UTC().Format(time.RFC3339),
+	}
+
+	// #3525: reserve the id BEFORE validation, file write and configureRunAs. A
+	// cancel racing that setup previously returned not_found and the script
+	// started anyway — WebSocket commands are concurrent
+	// (websocket/client.go dispatch).
+	running, preCancelled := e.reserve(script.ID, startTime, script.ScriptType)
+	defer e.release(script.ID, running)
+	if preCancelled {
+		_, byCmd := running.cancellation()
+		result.ExitCode = -1
+		result.Cancelled = true
+		result.CancelledByCommandID = byCmd
+		result.Error = "cancelled before execution started"
+		result.CompletedAt = time.Now().UTC().Format(time.RFC3339)
+		log.Info("execution cancelled before it started", "executionId", script.ID)
+		return result, nil
 	}
 
 	log.Info("starting execution", "executionId", script.ID, "scriptId", script.ScriptID, "scriptType", script.ScriptType, "timeout", script.Timeout)
@@ -197,15 +439,26 @@ func (e *Executor) Execute(script ScriptExecution) (*ScriptResult, error) {
 	// interactive user desktop every script run.
 	hideWindow(cmd)
 
-	// When the context is cancelled (timeout), kill the entire process group
-	// rather than only the shell leader. Otherwise long-running children like
-	// `sleep` keep the stdout/stderr pipes open and Wait() blocks forever.
+	// When the context is cancelled (timeout OR an explicit cancel), terminate
+	// the entire process tree rather than only the shell leader. Otherwise
+	// long-running children like `sleep` keep the stdout/stderr pipes open and
+	// Wait() blocks forever. The escalation happens INSIDE the callback because
+	// os/exec synchronises it against Start/Wait — that is why we must never
+	// touch cmd.Process from Cancel.
+	//
+	// graceSeconds is 0 for a timeout (today's straight-to-SIGKILL behaviour)
+	// and whatever the cancel request asked for otherwise.
 	cmd.Cancel = func() error {
-		return killProcessGroup(cmd)
+		killErr := terminateProcessTree(running, running.grace())
+		running.setKillErr(killErr)
+		return killErr
 	}
-	// Safety net: if killing the group doesn't cause Wait to return within
-	// this window (e.g. child is in uninterruptible I/O), give up and close
-	// the pipes ourselves.
+	// Safety net: if killing the tree doesn't cause Wait to return within this
+	// window (e.g. child is in uninterruptible I/O), give up and close the
+	// pipes ourselves. It stays at 5s deliberately: WaitDelay only starts AFTER
+	// the callback returns, and the callback has already consumed the grace, so
+	// grace+5s would double-count. It is an independent post-callback backstop,
+	// not proof of termination.
 	cmd.WaitDelay = 5 * time.Second
 
 	// Handle runAs for elevated execution
@@ -219,23 +472,30 @@ func (e *Executor) Execute(script ScriptExecution) (*ScriptResult, error) {
 		}
 	}
 
-	// Track running execution
-	e.mu.Lock()
-	e.running[script.ID] = &runningExecution{
-		cmd:        cmd,
-		cancel:     cancel,
-		startedAt:  startTime,
-		scriptType: script.ScriptType,
+	// Publish the command on the reservation made at the top of Execute. If a
+	// cancel landed while we were validating / writing the script file /
+	// configuring runAs, bail out now instead of starting the process.
+	if !running.beginStart(cmd, cancel) {
+		_, byCmd := running.cancellation()
+		result.ExitCode = -1
+		result.Cancelled = true
+		result.CancelledByCommandID = byCmd
+		result.Error = "cancelled before execution started"
+		result.CompletedAt = time.Now().UTC().Format(time.RFC3339)
+		log.Info("execution cancelled during setup", "executionId", script.ID)
+		return result, nil
 	}
-	e.mu.Unlock()
 
-	// Execute the script
-	err = cmd.Run()
-
-	// Remove from running executions
-	e.mu.Lock()
-	delete(e.running, script.ID)
-	e.mu.Unlock()
+	// Start and wait separately (rather than cmd.Run): the pgid has to be
+	// captured the instant the process exists, and Windows containment must
+	// assign the Job Object between CreateProcess and ResumeThread.
+	if startErr := startContained(running, cmd); startErr != nil {
+		err = startErr
+	} else {
+		running.markStarted()
+		err = cmd.Wait()
+	}
+	releaseContainment(running)
 
 	// Process results
 	result.Stdout = procoutput.BytesToUTF8(stdout.Bytes())
@@ -254,6 +514,15 @@ func (e *Executor) Execute(script ScriptExecution) (*ScriptResult, error) {
 		result.Stderr += "\n[breeze: stderr truncated at 1MB]"
 	}
 
+	// #3525: stamp the cancellation marker regardless of how the process ended.
+	// A script that exits 0 in the same instant it is cancelled still carries
+	// the marker, and the server applies OD9-C to preserve the real outcome.
+	cancelled, cancelledBy := running.cancellation()
+	if cancelled {
+		result.Cancelled = true
+		result.CancelledByCommandID = cancelledBy
+	}
+
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			// Process group was already killed by cmd.Cancel when the context
@@ -262,6 +531,13 @@ func (e *Executor) Execute(script ScriptExecution) (*ScriptResult, error) {
 			log.Warn("execution timed out", "executionId", script.ID, "timeoutSeconds", timeout)
 			result.ExitCode = -1
 			result.Error = fmt.Sprintf("execution timed out after %d seconds", timeout)
+		} else if cancelled {
+			// Checked before the ExitError branch on purpose: a killed shell
+			// reports "signal: killed", which would otherwise be recorded as a
+			// normal non-zero exit.
+			log.Info("execution cancelled", "executionId", script.ID, "cancelledBy", cancelledBy)
+			result.ExitCode = -1
+			result.Error = "execution cancelled"
 		} else if exitErr, ok := err.(*exec.ExitError); ok {
 			result.ExitCode = exitErr.ExitCode()
 			log.Info("execution completed", "executionId", script.ID, "exitCode", result.ExitCode)
@@ -278,24 +554,108 @@ func (e *Executor) Execute(script ScriptExecution) (*ScriptResult, error) {
 	return result, nil
 }
 
-// Cancel terminates a running script execution
-func (e *Executor) Cancel(executionID string) error {
+// reserve claims executionID before the script is validated or started and
+// returns the tracking entry plus whether a cancel already landed on it. An
+// existing entry is returned as-is: that is the cancel-arrived-first case.
+func (e *Executor) reserve(executionID string, startedAt time.Time, scriptType string) (*runningExecution, bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if existing, ok := e.running[executionID]; ok {
+		existing.mu.Lock()
+		cancelled := existing.cancelRequested
+		existing.mu.Unlock()
+		return existing, cancelled
+	}
+	r := newRunningExecution(startedAt, scriptType)
+	e.running[executionID] = r
+	return r, false
+}
+
+// release drops the reservation and closes the done channel a blocked Cancel
+// is waiting on. Safe to call more than once.
+func (e *Executor) release(executionID string, r *runningExecution) {
+	e.mu.Lock()
+	if current, ok := e.running[executionID]; ok && current == r {
+		delete(e.running, executionID)
+	}
+	e.mu.Unlock()
+	r.closeDone()
+}
+
+// SetCancelCommandID records which script_cancel command is responsible for
+// stopping this execution, so the eventual ScriptResult can name it. No-op if
+// the execution is already gone.
+func (e *Executor) SetCancelCommandID(executionID, commandID string) {
 	e.mu.Lock()
 	running, exists := e.running[executionID]
 	e.mu.Unlock()
 	if !exists {
-		return fmt.Errorf("execution %s not found or already completed", executionID)
+		return
+	}
+	running.setCancelCommandID(commandID)
+}
+
+// Cancel terminates a running script execution and BLOCKS until the outcome is
+// known. The returned CancelOutcome is what the server builds `cancel_state`
+// from, so returning before the process is gone would be a lie: the old
+// implementation acked the instant it asked, and its "cancelled: true" proved
+// neither termination nor even a successful kill attempt.
+//
+// graceSeconds is clamped to 0..MaxGraceSeconds. The error return is reserved
+// for future failures that are not about the process itself; today it is
+// always nil, and callers must grade on the outcome.
+func (e *Executor) Cancel(executionID string, graceSeconds int) (CancelOutcome, error) {
+	e.mu.Lock()
+	running, exists := e.running[executionID]
+	e.mu.Unlock()
+	if !exists {
+		// NOT confirmation of a stop. An agent that restarted has an empty map,
+		// and far more often the script finished a moment ago with its result
+		// still in flight.
+		log.Info("cancel found no such execution", "executionId", executionID)
+		return CancelNotFound, nil
 	}
 
-	log.Info("cancelling execution", "executionId", executionID)
+	grace := clampGrace(graceSeconds)
+	log.Info("cancelling execution", "executionId", executionID, "graceSeconds", grace)
 
-	// Cancel the context; this causes cmd.Cancel (set in Execute) to kill
-	// the entire process group. os/exec synchronizes the cancel callback
-	// with cmd.Start/Wait internally, so we don't race with Process field
-	// writes in the execution goroutine.
-	running.cancel()
+	startAttempted, cancelCtx := running.markCancelRequested(grace)
+	if !startAttempted {
+		// Reserved but Execute has not committed to starting yet. beginStart is
+		// contractually required to bail out, so no process will ever exist —
+		// that is a proven stop, not a guess.
+		return CancelTerminated, nil
+	}
+	if cancelCtx != nil {
+		// Cancel the context; this fires cmd.Cancel (set in Execute), which
+		// escalates against the whole process tree. os/exec synchronizes the
+		// callback with cmd.Start/Wait internally, so we don't race with
+		// Process field writes in the execution goroutine.
+		cancelCtx()
+	}
 
-	return nil
+	select {
+	case <-running.done:
+	case <-time.After(time.Duration(grace)*time.Second + hardKillBackstop):
+		log.Warn("cancel gave up waiting for termination",
+			"executionId", executionID, "graceSeconds", grace)
+		return CancelKillFailed, nil
+	}
+
+	started, killErr, contained := running.killOutcome()
+	if !started {
+		// The process never made it past Start, so nothing is running.
+		return CancelTerminated, nil
+	}
+	if killErr != nil || !contained {
+		// Containment was never established (e.g. an RDS session job denied the
+		// Job Object assignment) or the kill itself failed: children may
+		// survive. Never report `terminated`.
+		log.Warn("cancel could not prove the process tree is gone",
+			"executionId", executionID, "contained", contained, "killError", killErr)
+		return CancelKillFailed, nil
+	}
+	return CancelTerminated, nil
 }
 
 // ListRunning returns a list of currently running execution IDs

--- a/agent/internal/executor/executor.go
+++ b/agent/internal/executor/executor.go
@@ -38,8 +38,36 @@ const (
 // hardKillBackstop is how long Cancel keeps waiting past the requested grace
 // before giving up and reporting kill_failed. It has to exceed cmd.WaitDelay
 // (5s), which only starts once the cancel callback has already consumed the
-// grace window.
-const hardKillBackstop = 10 * time.Second
+// grace window. A var, not a const, purely so the give-up branch is testable
+// without a ten-second test.
+var hardKillBackstop = 10 * time.Second
+
+// cancelRefusalTTL bounds how long a cancel for an execution we have never seen
+// keeps its refusal on file. It has to outlast the longest a script command can
+// sit in the worker-pool queue ahead of being dispatched — the pool floors at
+// one worker and a script may run for MaxTimeout (1h) — while still guaranteeing
+// the id is eventually forgotten, so a stale cancel cannot refuse an unrelated
+// future command with the same id. A var only so the reap is testable.
+var cancelRefusalTTL = 2 * time.Hour
+
+// gradeCancelOutcome turns the observed post-termination state into the outcome
+// the server grades on. Pulled out of Cancel so the fail-closed rule is
+// asserted exhaustively on EVERY platform: the Unix path can prove it with a
+// real process, but the Windows case it exists for — an RD Session Host denying
+// the Job Object assignment — cannot be reproduced in a test at all.
+func gradeCancelOutcome(started bool, killErr error, contained bool) CancelOutcome {
+	if !started {
+		// The process never made it past Start, so nothing is running.
+		return CancelTerminated
+	}
+	if killErr != nil || !contained {
+		// Containment was never established (e.g. an RDS session job denied the
+		// Job Object assignment) or the kill itself failed: children may
+		// survive. Never report `terminated`.
+		return CancelKillFailed
+	}
+	return CancelTerminated
+}
 
 // CancelOutcome is what a cancel request actually achieved on the endpoint.
 // The server turns this into `cancel_state`, and only CancelTerminated is
@@ -150,7 +178,17 @@ type runningExecution struct {
 	job           jobHandle
 	jobPrimitives windowsJobPrimitives
 	contained     bool
+	// containmentLost latches once a kill has run without containment, so a
+	// later attachProcessGroup cannot upgrade this execution back to contained
+	// and let the cancel that already happened claim `terminated`.
+	containmentLost bool
 
+	// owned marks that an Execute goroutine has taken responsibility for this
+	// entry — it will eventually release() it and close done. An UNOWNED entry
+	// is a cancel refusal record left by Cancel for an execution that has not
+	// been dispatched yet; it is not running, and a second Execute for an
+	// already-owned id must be refused rather than adopting it.
+	owned bool
 	// startAttempted flips the instant Execute commits to starting the process;
 	// started flips only once Start actually succeeded.
 	startAttempted bool
@@ -206,21 +244,22 @@ func (r *runningExecution) markStarted() {
 	r.started = true
 }
 
-// markCancelRequested records the cancel and returns whether Execute has
-// already committed to starting the process, plus the context canceller to
-// fire (nil when there is nothing running yet).
-func (r *runningExecution) markCancelRequested(grace int) (bool, context.CancelFunc) {
+// markCancelRequested records the cancel and reports whether an Execute
+// goroutine owns this entry, whether it has already committed to starting the
+// process, and the context canceller to fire (nil when nothing is running yet).
+//
+// The command id is recorded in the SAME critical section as the request, so
+// the ScriptResult can never carry a cancellation marker without knowing which
+// script_cancel command earned it.
+func (r *runningExecution) markCancelRequested(cancelCommandID string, grace int) (owned, startAttempted bool, cancel context.CancelFunc) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.cancelRequested = true
 	r.graceSeconds = grace
-	return r.startAttempted, r.cancel
-}
-
-func (r *runningExecution) setCancelCommandID(commandID string) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.cancelCommandID = commandID
+	if cancelCommandID != "" {
+		r.cancelCommandID = cancelCommandID
+	}
+	return r.owned, r.startAttempted, r.cancel
 }
 
 // cancellation reports whether this execution was cancelled and by which
@@ -255,11 +294,28 @@ func (r *runningExecution) killOutcome() (started bool, killErr error, contained
 // IS the containment primitive on Unix, so a captured pgid marks the execution
 // contained; failing to capture one leaves it uncontained and a later cancel
 // can never report `terminated`.
+//
+// It refuses to (re-)establish containment once a kill has already run without
+// a group: a cancel firing in the window between cmd.Start returning and this
+// call kills the leader only, and upgrading contained afterwards would let that
+// cancel report `terminated` while group members survived.
 func (r *runningExecution) attachProcessGroup(pgid int) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.pgid = pgid
+	if r.containmentLost {
+		return
+	}
 	r.contained = pgid > 0
+}
+
+// markContainmentLost permanently downgrades this execution to uncontained. It
+// is called when a kill runs before (or without) containment being established.
+func (r *runningExecution) markContainmentLost() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.contained = false
+	r.containmentLost = true
 }
 
 // attachJob records the Windows containment handles established (or not) by
@@ -332,16 +388,32 @@ func (e *Executor) Execute(script ScriptExecution) (*ScriptResult, error) {
 	// cancel racing that setup previously returned not_found and the script
 	// started anyway — WebSocket commands are concurrent
 	// (websocket/client.go dispatch).
-	running, preCancelled := e.reserve(script.ID, startTime, script.ScriptType)
+	running, preCancelled, duplicate := e.reserve(script.ID, startTime, script.ScriptType)
+	if duplicate {
+		// Deliberately NOT released: we do not own this reservation, and closing
+		// its done channel would unblock a Cancel waiting on the ORIGINAL
+		// execution and let it report `terminated` while that process runs on.
+		err := fmt.Errorf("execution %s is already running", script.ID)
+		result.ExitCode = -1
+		result.Error = err.Error()
+		result.CompletedAt = time.Now().UTC().Format(time.RFC3339)
+		log.Warn("refusing a duplicate execution for an id already running", "executionId", script.ID)
+		return result, err
+	}
 	defer e.release(script.ID, running)
 	if preCancelled {
+		// A cancel landed while this script was still queued in the worker pool.
+		// The marker is what closes the execution on the server: the cancel
+		// itself could only answer not_found, because at that point nothing here
+		// could tell a queued script from an id this device never had.
 		_, byCmd := running.cancellation()
 		result.ExitCode = -1
 		result.Cancelled = true
 		result.CancelledByCommandID = byCmd
 		result.Error = "cancelled before execution started"
 		result.CompletedAt = time.Now().UTC().Format(time.RFC3339)
-		log.Info("execution cancelled before it started", "executionId", script.ID)
+		log.Info("refusing to start a script that was cancelled while queued",
+			"executionId", script.ID, "cancelledBy", byCmd)
 		return result, nil
 	}
 
@@ -443,8 +515,10 @@ func (e *Executor) Execute(script ScriptExecution) (*ScriptResult, error) {
 	// the entire process tree rather than only the shell leader. Otherwise
 	// long-running children like `sleep` keep the stdout/stderr pipes open and
 	// Wait() blocks forever. The escalation happens INSIDE the callback because
-	// os/exec synchronises it against Start/Wait — that is why we must never
-	// touch cmd.Process from Cancel.
+	// os/exec synchronises this callback against Start/Wait, which is what makes
+	// it safe to touch cmd.Process from in here (the uncontained fallback kills
+	// do). Reaching for cmd.Process from Executor.Cancel's own goroutine would
+	// NOT be safe, which is why Cancel only cancels the context.
 	//
 	// graceSeconds is 0 for a timeout (today's straight-to-SIGKILL behaviour)
 	// and whatever the cancel request asked for otherwise.
@@ -491,11 +565,16 @@ func (e *Executor) Execute(script ScriptExecution) (*ScriptResult, error) {
 	// assign the Job Object between CreateProcess and ResumeThread.
 	if startErr := startContained(running, cmd); startErr != nil {
 		err = startErr
+		// The process may EXIST even though the start failed — a Windows
+		// ResumeThread failure leaves it created, contained and suspended, and
+		// cmd.Wait is never reached. Releasing containment there would clear
+		// KILL_ON_JOB_CLOSE and drop the only handle that could ever kill it.
+		abortContainment(running)
 	} else {
 		running.markStarted()
 		err = cmd.Wait()
+		releaseContainment(running)
 	}
-	releaseContainment(running)
 
 	// Process results
 	result.Stdout = procoutput.BytesToUTF8(stdout.Bytes())
@@ -554,21 +633,73 @@ func (e *Executor) Execute(script ScriptExecution) (*ScriptResult, error) {
 	return result, nil
 }
 
-// reserve claims executionID before the script is validated or started and
-// returns the tracking entry plus whether a cancel already landed on it. An
-// existing entry is returned as-is: that is the cancel-arrived-first case.
-func (e *Executor) reserve(executionID string, startedAt time.Time, scriptType string) (*runningExecution, bool) {
+// reserve claims executionID before the script is validated or started, so a
+// cancel racing that setup finds an entry instead of reporting not_found.
+//
+// A second Execute for an id that is already reserved is a DUPLICATE and must
+// be refused, never adopted: the second caller's release would close the shared
+// done channel when IT finished, unblocking a Cancel that is waiting on the
+// FIRST process and letting it report `terminated` while that process is still
+// running. The server can genuinely redeliver a command id — the agent's dedup
+// window is 2 minutes while a script may run for an hour.
+func (e *Executor) reserve(executionID string, startedAt time.Time, scriptType string) (running *runningExecution, preCancelled, duplicate bool) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if existing, ok := e.running[executionID]; ok {
 		existing.mu.Lock()
-		cancelled := existing.cancelRequested
-		existing.mu.Unlock()
-		return existing, cancelled
+		defer existing.mu.Unlock()
+		if existing.owned {
+			return existing, false, true
+		}
+		// An unowned entry is a cancel refusal record: a cancel arrived while
+		// this script was still queued in the worker pool. Adopt it and let
+		// Execute bail out instead of running the script the operator stopped.
+		existing.owned = true
+		return existing, existing.cancelRequested, false
 	}
 	r := newRunningExecution(startedAt, scriptType)
+	r.owned = true
 	e.running[executionID] = r
-	return r, false
+	return r, false, false
+}
+
+// recordCancelRefusal remembers that executionID was cancelled before this
+// executor ever saw it, so the Execute that eventually dequeues it refuses to
+// start. Returns the entry, or the pre-existing one if a concurrent caller won.
+//
+// The record is reaped after cancelRefusalTTL if no Execute ever claims it —
+// the command may have been cancelled server-side and never delivered at all,
+// and an id must not be blocked forever.
+func (e *Executor) recordCancelRefusal(executionID, cancelCommandID string, grace int) *runningExecution {
+	e.mu.Lock()
+	if existing, ok := e.running[executionID]; ok {
+		e.mu.Unlock()
+		return existing
+	}
+	r := newRunningExecution(time.Now(), "")
+	r.cancelRequested = true
+	r.cancelCommandID = cancelCommandID
+	r.graceSeconds = grace
+	e.running[executionID] = r
+	e.mu.Unlock()
+
+	time.AfterFunc(cancelRefusalTTL, func() {
+		e.mu.Lock()
+		defer e.mu.Unlock()
+		current, ok := e.running[executionID]
+		if !ok || current != r {
+			return
+		}
+		current.mu.Lock()
+		owned := current.owned
+		current.mu.Unlock()
+		if owned {
+			return
+		}
+		delete(e.running, executionID)
+		r.closeDone()
+	})
+	return r
 }
 
 // release drops the reservation and closes the done channel a blocked Cancel
@@ -582,46 +713,54 @@ func (e *Executor) release(executionID string, r *runningExecution) {
 	r.closeDone()
 }
 
-// SetCancelCommandID records which script_cancel command is responsible for
-// stopping this execution, so the eventual ScriptResult can name it. No-op if
-// the execution is already gone.
-func (e *Executor) SetCancelCommandID(executionID, commandID string) {
-	e.mu.Lock()
-	running, exists := e.running[executionID]
-	e.mu.Unlock()
-	if !exists {
-		return
-	}
-	running.setCancelCommandID(commandID)
-}
-
 // Cancel terminates a running script execution and BLOCKS until the outcome is
 // known. The returned CancelOutcome is what the server builds `cancel_state`
 // from, so returning before the process is gone would be a lie: the old
 // implementation acked the instant it asked, and its "cancelled: true" proved
 // neither termination nor even a successful kill attempt.
 //
+// cancelCommandID names the script_cancel command responsible; it is stamped
+// onto the eventual ScriptResult so the server can tell which cancel earned the
+// kill, and a stale or retried cancel is never credited with one it did not do.
+//
 // graceSeconds is clamped to 0..MaxGraceSeconds. The error return is reserved
 // for future failures that are not about the process itself; today it is
 // always nil, and callers must grade on the outcome.
-func (e *Executor) Cancel(executionID string, graceSeconds int) (CancelOutcome, error) {
+func (e *Executor) Cancel(executionID, cancelCommandID string, graceSeconds int) (CancelOutcome, error) {
+	grace := clampGrace(graceSeconds)
+
 	e.mu.Lock()
 	running, exists := e.running[executionID]
 	e.mu.Unlock()
 	if !exists {
-		// NOT confirmation of a stop. An agent that restarted has an empty map,
-		// and far more often the script finished a moment ago with its result
-		// still in flight.
-		log.Info("cancel found no such execution", "executionId", executionID)
+		// The script may simply not have been DISPATCHED yet: the bypass lane
+		// gets the cancel past the worker pool, but its target can still be
+		// sitting in that queue behind another script (the pool floors at one
+		// worker), in which case Execute has not run and there is nothing here
+		// to find. Record the refusal so the Execute that eventually dequeues it
+		// bails out instead of running the script the operator stopped.
+		//
+		// The ANSWER stays not_found, and that is deliberate: nothing here can
+		// tell a queued script from an id this device never had, and claiming
+		// `terminated` for a typo'd or stale id would forge a confirmed kill.
+		// If the script really was queued, its refusal result carries the
+		// cancellation marker, which closes the execution honestly.
+		log.Info("cancel found no such execution; recording a refusal in case it is still queued",
+			"executionId", executionID)
+		e.recordCancelRefusal(executionID, cancelCommandID, grace)
 		return CancelNotFound, nil
 	}
 
-	grace := clampGrace(graceSeconds)
 	log.Info("cancelling execution", "executionId", executionID, "graceSeconds", grace)
 
-	startAttempted, cancelCtx := running.markCancelRequested(grace)
+	owned, startAttempted, cancelCtx := running.markCancelRequested(cancelCommandID, grace)
+	if !owned {
+		// An earlier cancel already left a refusal record and no Execute has
+		// claimed it. Same reasoning as above: nothing is running here.
+		return CancelNotFound, nil
+	}
 	if !startAttempted {
-		// Reserved but Execute has not committed to starting yet. beginStart is
+		// Execute owns this id and is still in setup. beginStart is
 		// contractually required to bail out, so no process will ever exist —
 		// that is a proven stop, not a guess.
 		return CancelTerminated, nil
@@ -643,38 +782,48 @@ func (e *Executor) Cancel(executionID string, graceSeconds int) (CancelOutcome, 
 	}
 
 	started, killErr, contained := running.killOutcome()
-	if !started {
-		// The process never made it past Start, so nothing is running.
-		return CancelTerminated, nil
-	}
-	if killErr != nil || !contained {
-		// Containment was never established (e.g. an RDS session job denied the
-		// Job Object assignment) or the kill itself failed: children may
-		// survive. Never report `terminated`.
+	outcome := gradeCancelOutcome(started, killErr, contained)
+	if outcome == CancelKillFailed {
 		log.Warn("cancel could not prove the process tree is gone",
 			"executionId", executionID, "contained", contained, "killError", killErr)
-		return CancelKillFailed, nil
 	}
-	return CancelTerminated, nil
+	return outcome, nil
 }
 
-// ListRunning returns a list of currently running execution IDs
+// ListRunning returns a list of execution IDs whose process is actually
+// running.
+//
+// e.running now also holds entries with no process behind them — a reservation
+// made by Execute before it has started anything, and a cancel refusal record
+// for a script that has not been dispatched (and may never be). Reporting those
+// would have script_list_running invent phantom executions, so "started" is the
+// bar rather than mere presence in the map.
 func (e *Executor) ListRunning() []string {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
 	ids := make([]string, 0, len(e.running))
-	for id := range e.running {
+	for id, r := range e.running {
+		if !r.hasStarted() {
+			continue
+		}
 		ids = append(ids, id)
 	}
 	return ids
 }
 
-// GetRunningCount returns the number of currently running executions
+// GetRunningCount returns how many executions have a process running, on the
+// same basis as ListRunning.
 func (e *Executor) GetRunningCount() int {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	return len(e.running)
+	count := 0
+	for _, r := range e.running {
+		if r.hasStarted() {
+			count++
+		}
+	}
+	return count
 }
 
 // validateScript performs security validation on script content

--- a/agent/internal/executor/job.go
+++ b/agent/internal/executor/job.go
@@ -56,6 +56,8 @@ type windowsJobPrimitives interface {
 	AssignProcess(job jobHandle, process suspendedProcess) error
 	Resume(process suspendedProcess) error
 	TerminateJob(job jobHandle) error
+	// SetJobLimits doubles as the clear: releaseContainment calls it with 0
+	// before CloseJob, and that ORDER is the whole point (see releaseContainment).
 	CloseJob(job jobHandle) error
 }
 
@@ -105,13 +107,59 @@ func launchContained(p windowsJobPrimitives, spec launchSpec, running *runningEx
 
 // releaseContainment drops the Job Object once the script has exited. It is a
 // no-op on Unix, where the process group needs no teardown.
+//
+// KILL_ON_JOB_CLOSE is cleared FIRST, and that order is the entire point:
+// closing the handle with the flag still set would kill exactly the descendants
+// a normally-completed script legitimately left running (an installer, an
+// updater). This fires on EVERY successful completion, not only on cancel, so
+// getting the order wrong would silently kill customer processes fleet-wide on
+// green runs. Same precedent and same reasoning as
+// remote/tools/software_install_process_tree_windows.go's release().
+//
+// If the flag cannot be cleared we LEAK the handle rather than close it — one
+// kernel handle on a path that should never occur, versus taking those
+// descendants down.
 func releaseContainment(running *runningExecution) {
 	primitives, job, _ := running.containment()
 	if primitives == nil || !job.valid() {
 		return
 	}
+	if err := primitives.SetJobLimits(job, 0); err != nil {
+		log.Warn("could not clear job kill-on-close; retaining the handle so any detached children survive",
+			"error", err.Error())
+		return
+	}
 	if err := primitives.CloseJob(job); err != nil {
 		log.Warn("could not release script job object", "error", err.Error())
+	}
+}
+
+// abortContainment is releaseContainment's counterpart for a start that FAILED
+// after the process already existed.
+//
+// The Windows case it exists for: CreateProcessSuspended, CreateJob,
+// SetJobLimits and AssignProcess all succeed and then ResumeThread fails. The
+// process is created, contained and suspended — it has not run an instruction
+// and never will. releaseContainment would clear KILL_ON_JOB_CLOSE and drop the
+// only handle that could ever kill it, stranding a suspended process that no
+// later Cancel can find (Execute's release() has already forgotten the id).
+// Terminate, then close with the flag intact.
+func abortContainment(running *runningExecution) {
+	primitives, job, cmd := running.containment()
+	if primitives != nil && job.valid() {
+		if err := primitives.TerminateJob(job); err != nil {
+			log.Error("could not terminate the job object of a process that never started",
+				"error", err.Error())
+		}
+		if err := primitives.CloseJob(job); err != nil {
+			log.Warn("could not close the job object of a process that never started",
+				"error", err.Error())
+		}
+		return
+	}
+	// Uncontained, or Unix (where a failed cmd.Start leaves no process at all).
+	if cmd != nil && cmd.Process != nil {
+		_ = cmd.Process.Kill()
 	}
 }
 

--- a/agent/internal/executor/job.go
+++ b/agent/internal/executor/job.go
@@ -1,0 +1,135 @@
+package executor
+
+import (
+	"errors"
+	"os/exec"
+)
+
+// This file carries the PORTABLE half of Windows Job Object containment
+// (#3525, spec OD4-B): the primitive interface, the launch sequence and the
+// hard-kill. It deliberately has no build tag so the call-order contract test
+// (job_contract_test.go) runs in the Linux `test-agent` job too — the Windows
+// CI job is a much thinner safety net (`internal/heartbeat` is on its known-red
+// exclusion list, #2523, which is why this lives in internal/executor).
+//
+// The native syscalls live in job_windows.go; on every other platform the
+// primitives are never constructed and containment is the process group
+// instead (tree_kill_unix.go).
+
+// jobObjectLimitKillOnJobClose is JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE. With it
+// set, closing the last handle to the job terminates every process still in it,
+// so an agent crash cannot strand a script's children.
+const jobObjectLimitKillOnJobClose uint32 = 0x00002000
+
+// jobHandle is an opaque Windows Job Object handle. The zero value means "no
+// job" — checked with valid().
+type jobHandle struct {
+	handle uintptr
+	native any
+}
+
+func (j jobHandle) valid() bool { return j.handle != 0 || j.native != nil }
+
+// suspendedProcess is a process created with CREATE_SUSPENDED that has not been
+// resumed yet. It exists only between CreateProcessSuspended and Resume.
+type suspendedProcess struct {
+	pid    int
+	cmd    *exec.Cmd
+	native any
+}
+
+// launchSpec describes the process launchContained should create. Cmd carries
+// the fully configured *exec.Cmd (env, dirs, pipes, CREATE_NO_WINDOW); Path is
+// kept separately so the contract test can exercise the ordering without a real
+// command.
+type launchSpec struct {
+	Path string
+	Cmd  *exec.Cmd
+}
+
+// windowsJobPrimitives is the Win32 surface launchContained needs. Faked in
+// job_contract_test.go, implemented natively in job_windows.go.
+type windowsJobPrimitives interface {
+	CreateProcessSuspended(spec launchSpec) (suspendedProcess, error)
+	CreateJob() (jobHandle, error)
+	SetJobLimits(job jobHandle, flags uint32) error
+	AssignProcess(job jobHandle, process suspendedProcess) error
+	Resume(process suspendedProcess) error
+	TerminateJob(job jobHandle) error
+	CloseJob(job jobHandle) error
+}
+
+// launchContained implements OD4-B: CREATE_SUSPENDED -> CreateJobObject ->
+// KILL_ON_JOB_CLOSE -> AssignProcessToJobObject -> ResumeThread, recording the
+// result on running.
+//
+// Assignment AFTER Start() cannot support a truthful `terminated`: the window
+// covers the timeout path, cancellation, leader exit and child creation. And on
+// an RD Session Host the enclosing session job forbids joining a second job, so
+// AssignProcessToJobObject is denied outright
+// (sessionbroker/spawner_windows.go). Following that precedent we still run the
+// script — refusing would break RDS entirely — but leave contained=false so a
+// later cancel can never claim the tree is gone.
+//
+// A Resume failure IS fatal: the process would sit suspended forever.
+func launchContained(p windowsJobPrimitives, spec launchSpec, running *runningExecution) error {
+	if p == nil {
+		return errors.New("no Windows job primitives available")
+	}
+
+	process, err := p.CreateProcessSuspended(spec)
+	if err != nil {
+		return err
+	}
+
+	contained := false
+	job, err := p.CreateJob()
+	if err != nil {
+		log.Warn("could not create job object for script containment; children may survive a cancel", "error", err.Error())
+	} else if limitErr := p.SetJobLimits(job, jobObjectLimitKillOnJobClose); limitErr != nil {
+		log.Warn("could not set job object limits for script containment", "error", limitErr.Error())
+	} else if assignErr := p.AssignProcess(job, process); assignErr != nil {
+		// Expected on RDS. Degrade, do not fail.
+		log.Warn("job object assignment denied; script runs uncontained", "error", assignErr.Error())
+	} else {
+		contained = true
+	}
+
+	running.attachJob(p, job, process, contained)
+
+	if err := p.Resume(process); err != nil {
+		return err
+	}
+	return nil
+}
+
+// releaseContainment drops the Job Object once the script has exited. It is a
+// no-op on Unix, where the process group needs no teardown.
+func releaseContainment(running *runningExecution) {
+	primitives, job, _ := running.containment()
+	if primitives == nil || !job.valid() {
+		return
+	}
+	if err := primitives.CloseJob(job); err != nil {
+		log.Warn("could not release script job object", "error", err.Error())
+	}
+}
+
+// terminateProcessTreeWindows is the hard kill for a contained script.
+//
+// There is no graceful phase on Windows: GenerateConsoleCtrlEvent needs a
+// shared console and our children are launched CREATE_NO_WINDOW, so
+// graceSeconds is deliberately ignored rather than silently waited out.
+func terminateProcessTreeWindows(running *runningExecution, _ int) error {
+	primitives, job, cmd := running.containment()
+	if primitives != nil && job.valid() {
+		return primitives.TerminateJob(job)
+	}
+	// Uncontained (assignment denied, or job creation failed): the best we can
+	// do is kill the leader. contained is already false, so the caller will
+	// report kill_failed rather than terminated.
+	if cmd != nil && cmd.Process != nil {
+		return cmd.Process.Kill()
+	}
+	return nil
+}

--- a/agent/internal/executor/job.go
+++ b/agent/internal/executor/job.go
@@ -23,19 +23,20 @@ const jobObjectLimitKillOnJobClose uint32 = 0x00002000
 
 // jobHandle is an opaque Windows Job Object handle. The zero value means "no
 // job" — checked with valid().
+//
+// A bare uintptr rather than a windows.Handle so this file stays portable:
+// windows.Handle IS a uintptr, so job_windows.go converts back losslessly.
 type jobHandle struct {
 	handle uintptr
-	native any
 }
 
-func (j jobHandle) valid() bool { return j.handle != 0 || j.native != nil }
+func (j jobHandle) valid() bool { return j.handle != 0 }
 
 // suspendedProcess is a process created with CREATE_SUSPENDED that has not been
 // resumed yet. It exists only between CreateProcessSuspended and Resume.
 type suspendedProcess struct {
-	pid    int
-	cmd    *exec.Cmd
-	native any
+	pid int
+	cmd *exec.Cmd
 }
 
 // launchSpec describes the process launchContained should create. Cmd carries

--- a/agent/internal/executor/job_contract_test.go
+++ b/agent/internal/executor/job_contract_test.go
@@ -1,0 +1,204 @@
+package executor
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+)
+
+// fakeJobPrimitives records the Win32 call order so the containment sequence is
+// asserted on EVERY platform, not only on the Windows CI job. That matters
+// here: internal/heartbeat is on the Windows job's known-red exclusion list
+// (#2523), so this contract deliberately lives in internal/executor and carries
+// no build tag.
+type fakeJobPrimitives struct {
+	order      *[]string
+	limitFlags uint32
+	createErr  error
+	jobErr     error
+	limitErr   error
+	assignErr  error
+	resumeErr  error
+	terminated bool
+	closed     bool
+}
+
+func (f *fakeJobPrimitives) CreateProcessSuspended(spec launchSpec) (suspendedProcess, error) {
+	*f.order = append(*f.order, "CreateProcess(CREATE_SUSPENDED|CREATE_NO_WINDOW)")
+	if f.createErr != nil {
+		return suspendedProcess{}, f.createErr
+	}
+	return suspendedProcess{pid: 4242}, nil
+}
+
+func (f *fakeJobPrimitives) CreateJob() (jobHandle, error) {
+	*f.order = append(*f.order, "CreateJobObjectW")
+	if f.jobErr != nil {
+		return jobHandle{}, f.jobErr
+	}
+	return jobHandle{handle: 0xB0B}, nil
+}
+
+func (f *fakeJobPrimitives) SetJobLimits(job jobHandle, flags uint32) error {
+	*f.order = append(*f.order, "SetInformationJobObject(KILL_ON_JOB_CLOSE)")
+	f.limitFlags = flags
+	return f.limitErr
+}
+
+func (f *fakeJobPrimitives) AssignProcess(job jobHandle, process suspendedProcess) error {
+	*f.order = append(*f.order, "AssignProcessToJobObject")
+	return f.assignErr
+}
+
+func (f *fakeJobPrimitives) Resume(process suspendedProcess) error {
+	*f.order = append(*f.order, "ResumeThread")
+	return f.resumeErr
+}
+
+func (f *fakeJobPrimitives) TerminateJob(job jobHandle) error {
+	*f.order = append(*f.order, "TerminateJobObject")
+	f.terminated = true
+	return nil
+}
+
+func (f *fakeJobPrimitives) CloseJob(job jobHandle) error {
+	*f.order = append(*f.order, "CloseHandle(job)")
+	f.closed = true
+	return nil
+}
+
+func newFakeLaunch(t *testing.T, fake *fakeJobPrimitives) *runningExecution {
+	t.Helper()
+	running := newRunningExecution(time.Now(), ScriptTypePowerShell)
+	if err := launchContained(fake, launchSpec{Path: "powershell.exe"}, running); err != nil {
+		t.Fatalf("launchContained: %v", err)
+	}
+	return running
+}
+
+func contains(order []string, want string) bool {
+	for _, entry := range order {
+		if entry == want {
+			return true
+		}
+	}
+	return false
+}
+
+func last(order []string) string {
+	if len(order) == 0 {
+		return ""
+	}
+	return order[len(order)-1]
+}
+
+func TestScriptIsOwnedByANonEscapableJobBeforeResume(t *testing.T) {
+	var order []string
+	fake := &fakeJobPrimitives{order: &order}
+	running := newFakeLaunch(t, fake)
+
+	want := []string{
+		"CreateProcess(CREATE_SUSPENDED|CREATE_NO_WINDOW)",
+		"CreateJobObjectW",
+		"SetInformationJobObject(KILL_ON_JOB_CLOSE)",
+		"AssignProcessToJobObject",
+		"ResumeThread",
+	}
+	if !reflect.DeepEqual(order, want) {
+		t.Fatalf("order = %v, want %v", order, want)
+	}
+	if !running.isContained() {
+		t.Fatal("contained = false after a successful assignment")
+	}
+	if fake.limitFlags != jobObjectLimitKillOnJobClose {
+		t.Fatalf("limitFlags = %#x, want KILL_ON_JOB_CLOSE (%#x)", fake.limitFlags, jobObjectLimitKillOnJobClose)
+	}
+}
+
+func TestAssignmentDenialFailsClosed(t *testing.T) {
+	// On an RD Session Host the enclosing session job forbids joining a second
+	// job and AssignProcessToJobObject is DENIED
+	// (sessionbroker/spawner_windows.go). Following that precedent we still run
+	// the script — refusing would break RDS entirely — but we mark it
+	// uncontained so a later cancel can NEVER report `terminated`.
+	var order []string
+	fake := &fakeJobPrimitives{order: &order, assignErr: errors.New("access is denied")}
+	running := newRunningExecution(time.Now(), ScriptTypePowerShell)
+	if err := launchContained(fake, launchSpec{Path: "powershell.exe"}, running); err != nil {
+		t.Fatalf("launch must degrade, not fail: %v", err)
+	}
+	if running.isContained() {
+		t.Fatal("contained = true after a denied assignment")
+	}
+	if !contains(order, "ResumeThread") {
+		t.Fatalf("the script was never resumed after a denied assignment: %v", order)
+	}
+}
+
+func TestJobCreationFailureStillRunsTheScriptUncontained(t *testing.T) {
+	var order []string
+	fake := &fakeJobPrimitives{order: &order, jobErr: errors.New("no job objects available")}
+	running := newRunningExecution(time.Now(), ScriptTypePowerShell)
+	if err := launchContained(fake, launchSpec{Path: "powershell.exe"}, running); err != nil {
+		t.Fatalf("launch must degrade, not fail: %v", err)
+	}
+	if running.isContained() {
+		t.Fatal("contained = true after the job could not be created")
+	}
+	if contains(order, "AssignProcessToJobObject") {
+		t.Fatalf("assigned to a job that was never created: %v", order)
+	}
+	if !contains(order, "ResumeThread") {
+		t.Fatalf("the script was never resumed: %v", order)
+	}
+}
+
+func TestResumeFailureIsFatal(t *testing.T) {
+	// A suspended process that cannot be resumed would hang forever holding
+	// the worker; that is the one step launchContained must not degrade past.
+	var order []string
+	fake := &fakeJobPrimitives{order: &order, resumeErr: errors.New("ResumeThread failed")}
+	running := newRunningExecution(time.Now(), ScriptTypePowerShell)
+	if err := launchContained(fake, launchSpec{Path: "powershell.exe"}, running); err == nil {
+		t.Fatal("launchContained returned nil after ResumeThread failed")
+	}
+}
+
+func TestTerminateJobObjectIsUsedForTheHardKill(t *testing.T) {
+	var order []string
+	fake := &fakeJobPrimitives{order: &order}
+	running := newFakeLaunch(t, fake)
+
+	if err := terminateProcessTreeWindows(running, 30); err != nil {
+		t.Fatal(err)
+	}
+	// No graceful phase on Windows: GenerateConsoleCtrlEvent needs a shared
+	// console and our children are CREATE_NO_WINDOW. graceSeconds is ignored.
+	if last(order) != "TerminateJobObject" {
+		t.Fatalf("order = %v", order)
+	}
+	if contains(order, "GenerateConsoleCtrlEvent") {
+		t.Fatal("attempted a graceful phase on Windows")
+	}
+}
+
+func TestReleaseContainmentClosesTheJobAfterTheScriptExits(t *testing.T) {
+	// Leaving the handle open with KILL_ON_JOB_CLOSE set is the agent-crash
+	// backstop while the script runs; leaving it open forever leaks a kernel
+	// handle per execution.
+	var order []string
+	fake := &fakeJobPrimitives{order: &order}
+	running := newFakeLaunch(t, fake)
+
+	releaseContainment(running)
+	if !fake.closed {
+		t.Fatalf("job handle was never released: %v", order)
+	}
+}
+
+func TestReleaseContainmentIsANoOpWithoutAJob(t *testing.T) {
+	// The Unix path never attaches primitives; releaseContainment runs there
+	// on every execution.
+	releaseContainment(newRunningExecution(time.Now(), ScriptTypeBash))
+}

--- a/agent/internal/executor/job_contract_test.go
+++ b/agent/internal/executor/job_contract_test.go
@@ -18,6 +18,7 @@ type fakeJobPrimitives struct {
 	createErr  error
 	jobErr     error
 	limitErr   error
+	clearErr   error
 	assignErr  error
 	resumeErr  error
 	terminated bool
@@ -41,6 +42,11 @@ func (f *fakeJobPrimitives) CreateJob() (jobHandle, error) {
 }
 
 func (f *fakeJobPrimitives) SetJobLimits(job jobHandle, flags uint32) error {
+	if flags == 0 {
+		*f.order = append(*f.order, "SetInformationJobObject(clear)")
+		f.limitFlags = flags
+		return f.clearErr
+	}
 	*f.order = append(*f.order, "SetInformationJobObject(KILL_ON_JOB_CLOSE)")
 	f.limitFlags = flags
 	return f.limitErr
@@ -183,17 +189,147 @@ func TestTerminateJobObjectIsUsedForTheHardKill(t *testing.T) {
 	}
 }
 
-func TestReleaseContainmentClosesTheJobAfterTheScriptExits(t *testing.T) {
-	// Leaving the handle open with KILL_ON_JOB_CLOSE set is the agent-crash
-	// backstop while the script runs; leaving it open forever leaks a kernel
-	// handle per execution.
+func TestReleaseContainmentClearsKillOnCloseBeforeClosingTheHandle(t *testing.T) {
+	// This fires on EVERY successful script completion, not just on cancel.
+	// Closing the handle with KILL_ON_JOB_CLOSE still set would kill exactly the
+	// descendants a completed script legitimately left running (an installer, an
+	// updater) — silently, fleet-wide, on green runs.
 	var order []string
 	fake := &fakeJobPrimitives{order: &order}
 	running := newFakeLaunch(t, fake)
+	order = order[:0]
 
 	releaseContainment(running)
+
+	want := []string{"SetInformationJobObject(clear)", "CloseHandle(job)"}
+	if !reflect.DeepEqual(order, want) {
+		t.Fatalf("order = %v, want %v", order, want)
+	}
+	if fake.limitFlags != 0 {
+		t.Fatalf("limitFlags = %#x at close, want 0", fake.limitFlags)
+	}
+}
+
+func TestReleaseContainmentLeaksTheHandleRatherThanKillDetachedChildren(t *testing.T) {
+	// If the flag cannot be cleared, closing anyway would take the script's
+	// detached children down. One leaked kernel handle is the cheaper failure.
+	var order []string
+	fake := &fakeJobPrimitives{order: &order, clearErr: errors.New("access denied")}
+	running := newFakeLaunch(t, fake)
+
+	releaseContainment(running)
+	if fake.closed {
+		t.Fatalf("closed a job whose kill-on-close could not be cleared: %v", order)
+	}
+}
+
+func TestAFailedResumeTerminatesTheJobInsteadOfReleasingIt(t *testing.T) {
+	// CreateProcess/CreateJob/SetJobLimits/AssignProcess all succeed and then
+	// ResumeThread fails: the process exists, is contained and is suspended, and
+	// cmd.Wait is never reached. Releasing containment here would clear
+	// KILL_ON_JOB_CLOSE and drop the only handle that could ever kill it,
+	// stranding a suspended process no later Cancel can find.
+	var order []string
+	fake := &fakeJobPrimitives{order: &order, resumeErr: errors.New("ResumeThread failed")}
+	running := newRunningExecution(time.Now(), ScriptTypePowerShell)
+	if err := launchContained(fake, launchSpec{Path: "powershell.exe"}, running); err == nil {
+		t.Fatal("launchContained returned nil after ResumeThread failed")
+	}
+	order = order[:0]
+
+	abortContainment(running)
+
+	if !fake.terminated {
+		t.Fatalf("the suspended process was left alive: %v", order)
+	}
+	if contains(order, "SetInformationJobObject(clear)") {
+		t.Fatalf("cleared kill-on-close while aborting; the orphan would survive: %v", order)
+	}
 	if !fake.closed {
-		t.Fatalf("job handle was never released: %v", order)
+		t.Fatalf("the job handle was leaked after termination: %v", order)
+	}
+}
+
+func TestTerminateFallsBackToTheLeaderWhenThereIsNoJob(t *testing.T) {
+	// Job creation failed, so there is nothing to terminate. The fallback must
+	// not panic on the nil command, and must not pretend it terminated a job.
+	var order []string
+	fake := &fakeJobPrimitives{order: &order, jobErr: errors.New("no job objects available")}
+	running := newRunningExecution(time.Now(), ScriptTypePowerShell)
+	if err := launchContained(fake, launchSpec{Path: "powershell.exe"}, running); err != nil {
+		t.Fatal(err)
+	}
+	order = order[:0]
+
+	if err := terminateProcessTreeWindows(running, 0); err != nil {
+		t.Fatalf("uncontained terminate returned an error: %v", err)
+	}
+	if contains(order, "TerminateJobObject") {
+		t.Fatalf("terminated a job that was never created: %v", order)
+	}
+	// releaseContainment must also be inert with no job.
+	releaseContainment(running)
+	if fake.closed {
+		t.Fatal("closed a job that was never created")
+	}
+}
+
+// gradeCancelOutcome is the fail-closed rule itself. The case it exists for —
+// an RD Session Host denying the Job Object assignment — cannot be reproduced
+// in any test, and the Unix process-based kill_failed test skips on Windows, so
+// this table is the only coverage that executes on every platform.
+func TestGradeCancelOutcomeIsFailClosed(t *testing.T) {
+	boom := errors.New("kill failed")
+	for _, tc := range []struct {
+		name      string
+		started   bool
+		killErr   error
+		contained bool
+		want      CancelOutcome
+	}{
+		{"never started", false, nil, false, CancelTerminated},
+		{"never started, stale kill error", false, boom, false, CancelTerminated},
+		{"contained and killed cleanly", true, nil, true, CancelTerminated},
+		{"contained but the kill errored", true, boom, true, CancelKillFailed},
+		{"kill succeeded but containment was denied", true, nil, false, CancelKillFailed},
+		{"uncontained and the kill errored", true, boom, false, CancelKillFailed},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := gradeCancelOutcome(tc.started, tc.killErr, tc.contained); got != tc.want {
+				t.Fatalf("gradeCancelOutcome(%v, %v, %v) = %q, want %q", tc.started, tc.killErr, tc.contained, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCancelGivesUpAndReportsKillFailedWhenTerminationIsNeverObserved(t *testing.T) {
+	// The give-up branch: a process wedged in uninterruptible I/O never closes
+	// `done`. Every other kill_failed test reaches that verdict through
+	// !contained, so without this the grace + backstop arithmetic is untested.
+	restore := hardKillBackstop
+	hardKillBackstop = 150 * time.Millisecond
+	t.Cleanup(func() { hardKillBackstop = restore })
+
+	e := newTestExecutor()
+	running, preCancelled, duplicate := e.reserve("wedged", time.Now(), ScriptTypeBash)
+	if preCancelled || duplicate {
+		t.Fatalf("a fresh id reported preCancelled=%v duplicate=%v", preCancelled, duplicate)
+	}
+	// Look started, but never close done — release is never called.
+	running.beginStart(nil, func() {})
+	running.markStarted()
+	running.attachProcessGroup(1)
+
+	start := time.Now()
+	outcome, err := e.Cancel("wedged", "cc-wedged", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome != CancelKillFailed {
+		t.Fatalf("outcome = %q, want kill_failed when termination is never observed", outcome)
+	}
+	if elapsed := time.Since(start); elapsed < 100*time.Millisecond {
+		t.Fatalf("Cancel returned after %v — it did not actually wait out the backstop", elapsed)
 	}
 }
 

--- a/agent/internal/executor/job_windows.go
+++ b/agent/internal/executor/job_windows.go
@@ -138,22 +138,13 @@ func (nativeWindowsJobPrimitives) TerminateJob(job jobHandle) error {
 	return nil
 }
 
-// CloseJob is called once the script has exited. Clearing KILL_ON_JOB_CLOSE
-// FIRST is what keeps a completed script's legitimately-detached children
-// alive: closing the handle with the flag still set would kill exactly the
-// descendants the script meant to leave running. If the flag cannot be cleared,
-// leak the handle — one kernel handle on a path that should never occur —
-// rather than close it and take those children down.
-//
-// On the cancel and timeout paths TerminateJobObject has already run, so this
-// is a no-op beyond releasing the handle.
+// CloseJob releases the job handle. releaseContainment (job.go) is responsible
+// for clearing KILL_ON_JOB_CLOSE first — that ordering is policy, so it lives
+// in the portable layer where the contract test can assert it.
 func (nativeWindowsJobPrimitives) CloseJob(job jobHandle) error {
 	handle, err := nativeJobHandle(job)
 	if err != nil {
 		return err
-	}
-	if err := setJobLimitFlags(handle, 0); err != nil {
-		return fmt.Errorf("clear job kill-on-close (handle retained): %w", err)
 	}
 	return windows.CloseHandle(handle)
 }

--- a/agent/internal/executor/job_windows.go
+++ b/agent/internal/executor/job_windows.go
@@ -1,0 +1,179 @@
+//go:build windows
+
+package executor
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// nativeWindowsJobPrimitives is the real Win32 implementation of
+// windowsJobPrimitives. The launch ORDER and the degradation policy live in
+// job.go so they are exercised by job_contract_test.go on every platform; only
+// the syscalls are here.
+//
+// Precedent for each call: agent/internal/pamlifetime/job_windows.go and
+// agent/internal/remote/tools/software_install_process_tree_windows.go.
+type nativeWindowsJobPrimitives struct{}
+
+// CreateProcessSuspended starts the command with CREATE_SUSPENDED so the job
+// assignment can happen before a single instruction of the script runs.
+// Assignment after Start() cannot support a truthful `terminated`: the window
+// covers leader exit and child creation.
+func (nativeWindowsJobPrimitives) CreateProcessSuspended(spec launchSpec) (suspendedProcess, error) {
+	cmd := spec.Cmd
+	if cmd == nil {
+		return suspendedProcess{}, errors.New("no command to launch")
+	}
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	// OR, never assign: hideWindow already set CREATE_NO_WINDOW and
+	// overwriting it would pop a console window on every script run.
+	cmd.SysProcAttr.CreationFlags |= windows.CREATE_SUSPENDED
+	if err := cmd.Start(); err != nil {
+		return suspendedProcess{}, err
+	}
+	return suspendedProcess{pid: cmd.Process.Pid, cmd: cmd}, nil
+}
+
+func (nativeWindowsJobPrimitives) CreateJob() (jobHandle, error) {
+	handle, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		return jobHandle{}, fmt.Errorf("CreateJobObject: %w", err)
+	}
+	return jobHandle{handle: uintptr(handle), native: handle}, nil
+}
+
+func (nativeWindowsJobPrimitives) SetJobLimits(job jobHandle, flags uint32) error {
+	handle, err := nativeJobHandle(job)
+	if err != nil {
+		return err
+	}
+	return setJobLimitFlags(handle, flags)
+}
+
+func setJobLimitFlags(handle windows.Handle, flags uint32) error {
+	info := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{}
+	info.BasicLimitInformation.LimitFlags = flags
+	_, err := windows.SetInformationJobObject(
+		handle,
+		windows.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&info)),
+		uint32(unsafe.Sizeof(info)),
+	)
+	return err
+}
+
+// AssignProcess reopens the child by pid — os/exec does not expose its handle —
+// and joins it to the job. On an RD Session Host the enclosing session job
+// forbids joining a second job and this is denied (#2536); job.go degrades
+// rather than failing the script.
+func (nativeWindowsJobPrimitives) AssignProcess(job jobHandle, process suspendedProcess) error {
+	handle, err := nativeJobHandle(job)
+	if err != nil {
+		return err
+	}
+	proc, err := windows.OpenProcess(windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE, false, uint32(process.pid))
+	if err != nil {
+		return fmt.Errorf("OpenProcess: %w", err)
+	}
+	defer func() { _ = windows.CloseHandle(proc) }()
+	if err := windows.AssignProcessToJobObject(handle, proc); err != nil {
+		return fmt.Errorf("AssignProcessToJobObject: %w", err)
+	}
+	return nil
+}
+
+// Resume releases the suspended process. os/exec closes the primary thread
+// handle it got from CreateProcess, so the thread is re-opened by enumerating
+// the process's threads — a CREATE_SUSPENDED process has exactly one.
+func (nativeWindowsJobPrimitives) Resume(process suspendedProcess) error {
+	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPTHREAD, 0)
+	if err != nil {
+		return fmt.Errorf("CreateToolhelp32Snapshot: %w", err)
+	}
+	defer func() { _ = windows.CloseHandle(snapshot) }()
+
+	var entry windows.ThreadEntry32
+	entry.Size = uint32(unsafe.Sizeof(entry))
+	if err := windows.Thread32First(snapshot, &entry); err != nil {
+		return fmt.Errorf("Thread32First: %w", err)
+	}
+	resumed := 0
+	for {
+		if entry.OwnerProcessID == uint32(process.pid) {
+			thread, openErr := windows.OpenThread(windows.THREAD_SUSPEND_RESUME, false, entry.ThreadID)
+			if openErr == nil {
+				count, resumeErr := windows.ResumeThread(thread)
+				_ = windows.CloseHandle(thread)
+				if resumeErr == nil && count != 0xffffffff {
+					resumed++
+				}
+			}
+		}
+		if err := windows.Thread32Next(snapshot, &entry); err != nil {
+			break
+		}
+	}
+	if resumed == 0 {
+		return errors.New("ResumeThread: no thread of the suspended process could be resumed")
+	}
+	return nil
+}
+
+func (nativeWindowsJobPrimitives) TerminateJob(job jobHandle) error {
+	handle, err := nativeJobHandle(job)
+	if err != nil {
+		return err
+	}
+	if err := windows.TerminateJobObject(handle, 1); err != nil {
+		return fmt.Errorf("TerminateJobObject: %w", err)
+	}
+	return nil
+}
+
+// CloseJob is called once the script has exited. Clearing KILL_ON_JOB_CLOSE
+// FIRST is what keeps a completed script's legitimately-detached children
+// alive: closing the handle with the flag still set would kill exactly the
+// descendants the script meant to leave running. If the flag cannot be cleared,
+// leak the handle — one kernel handle on a path that should never occur —
+// rather than close it and take those children down.
+//
+// On the cancel and timeout paths TerminateJobObject has already run, so this
+// is a no-op beyond releasing the handle.
+func (nativeWindowsJobPrimitives) CloseJob(job jobHandle) error {
+	handle, err := nativeJobHandle(job)
+	if err != nil {
+		return err
+	}
+	if err := setJobLimitFlags(handle, 0); err != nil {
+		return fmt.Errorf("clear job kill-on-close (handle retained): %w", err)
+	}
+	return windows.CloseHandle(handle)
+}
+
+func nativeJobHandle(job jobHandle) (windows.Handle, error) {
+	if handle, ok := job.native.(windows.Handle); ok && handle != 0 {
+		return handle, nil
+	}
+	if job.handle != 0 {
+		return windows.Handle(job.handle), nil
+	}
+	return 0, errors.New("job object handle is not available")
+}
+
+// startContained runs the OD4-B launch sequence for a script.
+func startContained(running *runningExecution, cmd *exec.Cmd) error {
+	return launchContained(nativeWindowsJobPrimitives{}, launchSpec{Path: cmd.Path, Cmd: cmd}, running)
+}
+
+// terminateProcessTree kills the script's whole tree via its Job Object.
+func terminateProcessTree(running *runningExecution, graceSeconds int) error {
+	return terminateProcessTreeWindows(running, graceSeconds)
+}

--- a/agent/internal/executor/job_windows.go
+++ b/agent/internal/executor/job_windows.go
@@ -47,7 +47,7 @@ func (nativeWindowsJobPrimitives) CreateJob() (jobHandle, error) {
 	if err != nil {
 		return jobHandle{}, fmt.Errorf("CreateJobObject: %w", err)
 	}
-	return jobHandle{handle: uintptr(handle), native: handle}, nil
+	return jobHandle{handle: uintptr(handle)}, nil
 }
 
 func (nativeWindowsJobPrimitives) SetJobLimits(job jobHandle, flags uint32) error {
@@ -149,14 +149,13 @@ func (nativeWindowsJobPrimitives) CloseJob(job jobHandle) error {
 	return windows.CloseHandle(handle)
 }
 
+// nativeJobHandle converts the portable handle back. windows.Handle is defined
+// as a uintptr, so this is lossless.
 func nativeJobHandle(job jobHandle) (windows.Handle, error) {
-	if handle, ok := job.native.(windows.Handle); ok && handle != 0 {
-		return handle, nil
+	if !job.valid() {
+		return 0, errors.New("job object handle is not available")
 	}
-	if job.handle != 0 {
-		return windows.Handle(job.handle), nil
-	}
-	return 0, errors.New("job object handle is not available")
+	return windows.Handle(job.handle), nil
 }
 
 // startContained runs the OD4-B launch sequence for a script.

--- a/agent/internal/executor/limits_linux.go
+++ b/agent/internal/executor/limits_linux.go
@@ -17,17 +17,5 @@ func setProcessGroup(cmd *exec.Cmd) {
 	}
 }
 
-// killProcessGroup kills the entire process group of the command.
-func killProcessGroup(cmd *exec.Cmd) error {
-	if cmd.Process == nil {
-		return nil
-	}
-	pgid, err := syscall.Getpgid(cmd.Process.Pid)
-	if err != nil {
-		return cmd.Process.Kill()
-	}
-	return syscall.Kill(-pgid, syscall.SIGKILL)
-}
-
 // hideWindow is a no-op on Linux.
 func hideWindow(cmd *exec.Cmd) {}

--- a/agent/internal/executor/limits_unix.go
+++ b/agent/internal/executor/limits_unix.go
@@ -16,17 +16,5 @@ func setProcessGroup(cmd *exec.Cmd) {
 	}
 }
 
-// killProcessGroup kills the entire process group of the command.
-func killProcessGroup(cmd *exec.Cmd) error {
-	if cmd.Process == nil {
-		return nil
-	}
-	pgid, err := syscall.Getpgid(cmd.Process.Pid)
-	if err != nil {
-		return cmd.Process.Kill()
-	}
-	return syscall.Kill(-pgid, syscall.SIGKILL)
-}
-
 // hideWindow is a no-op on non-Windows platforms.
 func hideWindow(cmd *exec.Cmd) {}

--- a/agent/internal/executor/limits_windows.go
+++ b/agent/internal/executor/limits_windows.go
@@ -9,17 +9,13 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-// setProcessGroup is a no-op on Windows. Job Objects could be used for full
-// process tree management but are deferred to a future enhancement.
+// setProcessGroup is a no-op on Windows: process-tree containment is a Job
+// Object, established at launch time by startContained/launchContained
+// (job.go, job_windows.go) rather than by a SysProcAttr flag. #3525 replaced
+// the previous "deferred to a future enhancement" no-op — a PowerShell script
+// that started msiexec used to leave it running on both the cancel AND the
+// timeout path.
 func setProcessGroup(cmd *exec.Cmd) {}
-
-// killProcessGroup kills the process directly on Windows.
-func killProcessGroup(cmd *exec.Cmd) error {
-	if cmd.Process == nil {
-		return nil
-	}
-	return cmd.Process.Kill()
-}
 
 // hideWindow prevents the spawned shell (powershell.exe, cmd.exe, etc.) from
 // allocating a visible console window when the user-helper (linked

--- a/agent/internal/executor/runas_test.go
+++ b/agent/internal/executor/runas_test.go
@@ -296,16 +296,11 @@ func TestExecuteTimestamps(t *testing.T) {
 	}
 }
 
-func TestCancelNonexistentExecution(t *testing.T) {
-	e := newTestExecutor()
-	err := e.Cancel("nonexistent-id")
-	if err == nil {
-		t.Fatal("expected error cancelling nonexistent execution")
-	}
-	if !strings.Contains(err.Error(), "not found") {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
+// An unknown execution id is no longer an error — it is the structured
+// CancelNotFound outcome, asserted by
+// TestCancelReportsNotFoundForAnUnknownID in cancel_test.go. The server needs
+// to tell "we have no such execution" apart from "the kill failed" (#3525),
+// and an error string cannot carry that.
 
 func TestListRunningEmpty(t *testing.T) {
 	e := newTestExecutor()

--- a/agent/internal/executor/tree_kill_test.go
+++ b/agent/internal/executor/tree_kill_test.go
@@ -1,0 +1,99 @@
+//go:build !windows
+
+package executor
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+)
+
+// grandchildHeartbeatScript backgrounds a subshell that keeps appending to
+// beat. The subshell is a child of the script shell and `printf` under it is a
+// grandchild, so the file only stops growing when the kill reaches the whole
+// process GROUP rather than just the shell leader.
+//
+// Its stdio is redirected to /dev/null so a surviving background job cannot
+// hold the captured stdout/stderr pipes open and make cmd.Wait look blocked for
+// reasons unrelated to what this test measures.
+func grandchildHeartbeatScript(id, beat string) ScriptExecution {
+	s := sleepScript(id, 60)
+	s.Script = fmt.Sprintf("(while true; do printf x >> %q; sleep 0.05; done) >/dev/null 2>&1 &\n", beat) + s.Script
+	return s
+}
+
+func waitForNonEmptyFile(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if info, err := os.Stat(path); err == nil && info.Size() > 0 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("heartbeat file %q never appeared", path)
+}
+
+func fileSize(t *testing.T, path string) int64 {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %q: %v", path, err)
+	}
+	return info.Size()
+}
+
+func TestCancelKillsTheWholeProcessTree(t *testing.T) {
+	skipWithoutBash(t)
+	beat := t.TempDir() + "/beat"
+	e := newTestExecutor()
+	go func() { _, _ = e.Execute(grandchildHeartbeatScript("id-t", beat)) }()
+	waitForNonEmptyFile(t, beat)
+
+	outcome, err := e.Cancel("id-t", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome != CancelTerminated {
+		t.Fatalf("outcome = %q, want terminated", outcome)
+	}
+
+	before := fileSize(t, beat)
+	time.Sleep(500 * time.Millisecond)
+	if after := fileSize(t, beat); after != before {
+		t.Fatalf("grandchild survived the cancel: process-group kill did not reach it (%d -> %d bytes)", before, after)
+	}
+}
+
+func TestPgidIsCapturedAtStartNotAtKillTime(t *testing.T) {
+	skipWithoutBash(t)
+	// After SIGTERM the leader may already be gone; a kill-time Getpgid then
+	// fails and the fallback kills a dead leader while children keep running.
+	e := newTestExecutor()
+	go func() { _, _ = e.Execute(sleepScript("id-p", 60)) }()
+	r := waitForRunning(t, e, "id-p")
+	if r.processGroup() == 0 {
+		t.Fatal("pgid was not captured at Start")
+	}
+	if _, err := e.Cancel("id-p", 0); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// terminateProcessTreeUnix must not report failure when the group has already
+// exited: os/exec folds a non-nil cancel error into cmd.Wait's return AND it
+// becomes killErr, which would downgrade a clean kill to kill_failed.
+func TestTerminateProcessTreeTreatsAnAlreadyGoneGroupAsSuccess(t *testing.T) {
+	if err := terminateProcessTreeUnix(0, nil, 0); err != nil {
+		t.Fatalf("no pgid and no process: %v", err)
+	}
+	// A pgid that cannot exist: PID 0 is the caller's own group, so use a large
+	// unlikely one and accept only ESRCH-shaped absence.
+	if err := terminateProcessTreeUnix(1<<21, nil, 0); err != nil {
+		t.Fatalf("vanished group reported as an error: %v", err)
+	}
+	if err := terminateProcessTreeUnix(1<<21, nil, 1); err != nil {
+		t.Fatalf("vanished group reported as an error during the graceful phase: %v", err)
+	}
+}

--- a/agent/internal/executor/tree_kill_test.go
+++ b/agent/internal/executor/tree_kill_test.go
@@ -51,7 +51,7 @@ func TestCancelKillsTheWholeProcessTree(t *testing.T) {
 	go func() { _, _ = e.Execute(grandchildHeartbeatScript("id-t", beat)) }()
 	waitForNonEmptyFile(t, beat)
 
-	outcome, err := e.Cancel("id-t", 0)
+	outcome, err := e.Cancel("id-t", "cc-t", 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -76,8 +76,29 @@ func TestPgidIsCapturedAtStartNotAtKillTime(t *testing.T) {
 	if r.processGroup() == 0 {
 		t.Fatal("pgid was not captured at Start")
 	}
-	if _, err := e.Cancel("id-p", 0); err != nil {
+	if _, err := e.Cancel("id-p", "cc-p", 0); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestAKillBeforeThePgidWasCapturedCannotClaimContainment(t *testing.T) {
+	// os/exec starts its context watchdog inside cmd.Start, so a cancel really
+	// can fire in the window between Start returning and attachProcessGroup.
+	// That kill reaches the leader only; if attachProcessGroup could then set
+	// contained=true, the very cancel that already ran would grade `terminated`
+	// while group members survived.
+	r := newRunningExecution(time.Now(), ScriptTypeBash)
+
+	if err := terminateProcessTree(r, 0); err != nil { // pgid still 0
+		t.Fatalf("terminate with no pgid and no process: %v", err)
+	}
+	r.attachProcessGroup(4242) // the racing capture lands a moment later
+
+	if r.isContained() {
+		t.Fatal("containment was re-established after a leader-only kill had already run")
+	}
+	if got := gradeCancelOutcome(true, nil, r.isContained()); got != CancelKillFailed {
+		t.Fatalf("outcome = %q, want kill_failed", got)
 	}
 }
 

--- a/agent/internal/executor/tree_kill_test.go
+++ b/agent/internal/executor/tree_kill_test.go
@@ -23,18 +23,6 @@ func grandchildHeartbeatScript(id, beat string) ScriptExecution {
 	return s
 }
 
-func waitForNonEmptyFile(t *testing.T, path string) {
-	t.Helper()
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
-		if info, err := os.Stat(path); err == nil && info.Size() > 0 {
-			return
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	t.Fatalf("heartbeat file %q never appeared", path)
-}
-
 func fileSize(t *testing.T, path string) int64 {
 	t.Helper()
 	info, err := os.Stat(path)

--- a/agent/internal/executor/tree_kill_unix.go
+++ b/agent/internal/executor/tree_kill_unix.go
@@ -1,0 +1,103 @@
+//go:build !windows
+
+package executor
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// pgidPollInterval is how often the escalation ladder re-checks whether the
+// process group is gone during the graceful window.
+const pgidPollInterval = 100 * time.Millisecond
+
+// startContained starts the process and captures its process group. On Unix the
+// process group IS the containment primitive (setProcessGroup asked for one
+// with Setpgid), so a captured pgid marks the execution contained.
+func startContained(running *runningExecution, cmd *exec.Cmd) error {
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	running.attachProcessGroup(capturePgid(cmd))
+	return nil
+}
+
+// capturePgid reads the process group id immediately after Start.
+//
+// #3525: looking it up at kill time — the old behaviour — fails once the leader
+// has exited (Getpgid returns ESRCH), and the fallback then kills a corpse via
+// cmd.Process.Kill() while the surviving children keep running. After SIGTERM
+// that is exactly the state we are in.
+func capturePgid(cmd *exec.Cmd) int {
+	if cmd == nil || cmd.Process == nil {
+		return 0
+	}
+	pgid, err := syscall.Getpgid(cmd.Process.Pid)
+	if err != nil {
+		log.Warn("could not capture process group at start; cancellation will not reach children",
+			"pid", cmd.Process.Pid, "error", err.Error())
+		return 0
+	}
+	return pgid
+}
+
+// terminateProcessTree escalates against the whole process tree.
+func terminateProcessTree(running *runningExecution, graceSeconds int) error {
+	return terminateProcessTreeUnix(running.processGroup(), running.command(), graceSeconds)
+}
+
+// terminateProcessTreeUnix escalates SIGTERM -> grace -> SIGKILL against the
+// process GROUP, using the pgid captured at Start.
+//
+// configureRunAs rewrites cmd.Path/cmd.Args to /usr/bin/sudo, so the signal
+// lands on sudo's group — but `sudo -n` children inherit the pgid set by
+// setProcessGroup, so the group kill still reaches them.
+func terminateProcessTreeUnix(pgid int, cmd *exec.Cmd, graceSeconds int) error {
+	if pgid <= 0 {
+		// No group was ever captured. Fall back to the leader only; the caller
+		// already treats this execution as uncontained, so a cancel here can
+		// never report `terminated`.
+		if cmd == nil || cmd.Process == nil {
+			return nil
+		}
+		return normalizeSignalErr(cmd.Process.Kill())
+	}
+
+	if graceSeconds > 0 {
+		if err := syscall.Kill(-pgid, syscall.SIGTERM); err != nil {
+			if errors.Is(err, syscall.ESRCH) {
+				return nil
+			}
+			return err
+		}
+		deadline := time.After(time.Duration(graceSeconds) * time.Second)
+		tick := time.NewTicker(pgidPollInterval)
+		defer tick.Stop()
+		for {
+			select {
+			case <-deadline:
+				return normalizeSignalErr(syscall.Kill(-pgid, syscall.SIGKILL))
+			case <-tick.C:
+				// ESRCH == the whole group is gone; nothing left to escalate to.
+				if err := syscall.Kill(-pgid, 0); errors.Is(err, syscall.ESRCH) {
+					return nil
+				}
+			}
+		}
+	}
+
+	return normalizeSignalErr(syscall.Kill(-pgid, syscall.SIGKILL))
+}
+
+// normalizeSignalErr folds "the process was already gone" into success. Left as
+// an error it would be wrapped by os/exec into cmd.Wait's return AND recorded
+// as killErr, downgrading a clean kill to kill_failed.
+func normalizeSignalErr(err error) error {
+	if err == nil || errors.Is(err, syscall.ESRCH) || errors.Is(err, os.ErrProcessDone) {
+		return nil
+	}
+	return err
+}

--- a/agent/internal/executor/tree_kill_unix.go
+++ b/agent/internal/executor/tree_kill_unix.go
@@ -27,26 +27,41 @@ func startContained(running *runningExecution, cmd *exec.Cmd) error {
 
 // capturePgid reads the process group id immediately after Start.
 //
-// #3525: looking it up at kill time — the old behaviour — fails once the leader
+// #3525: looking it up at KILL time — the old behaviour — fails once the leader
 // has exited (Getpgid returns ESRCH), and the fallback then kills a corpse via
 // cmd.Process.Kill() while the surviving children keep running. After SIGTERM
 // that is exactly the state we are in.
+//
+// setProcessGroup asked for Setpgid with Pgid 0, so the child IS its own group
+// leader and pgid == pid by construction. Getpgid here is therefore a
+// confirmation, not the source of truth: it also returns ESRCH for a script
+// that fails instantly, and treating that as "no group" would mark a perfectly
+// contained execution uncontained and downgrade every later cancel to
+// kill_failed.
 func capturePgid(cmd *exec.Cmd) int {
 	if cmd == nil || cmd.Process == nil {
 		return 0
 	}
-	pgid, err := syscall.Getpgid(cmd.Process.Pid)
-	if err != nil {
-		log.Warn("could not capture process group at start; cancellation will not reach children",
-			"pid", cmd.Process.Pid, "error", err.Error())
-		return 0
+	if pgid, err := syscall.Getpgid(cmd.Process.Pid); err == nil && pgid > 0 {
+		return pgid
 	}
-	return pgid
+	return cmd.Process.Pid
 }
 
 // terminateProcessTree escalates against the whole process tree.
 func terminateProcessTree(running *runningExecution, graceSeconds int) error {
-	return terminateProcessTreeUnix(running.processGroup(), running.command(), graceSeconds)
+	pgid := running.processGroup()
+	if pgid <= 0 {
+		// Either no group was ever captured, or this kill is landing in the
+		// window between cmd.Start returning and attachProcessGroup — os/exec
+		// starts its context watchdog inside Start, so a cancel really can fire
+		// there. Both cases reach the leader only, so latch the execution as
+		// uncontained; otherwise attachProcessGroup would set contained=true a
+		// moment later and let this very cancel claim `terminated` while group
+		// members survived.
+		running.markContainmentLost()
+	}
+	return terminateProcessTreeUnix(pgid, running.command(), graceSeconds)
 }
 
 // terminateProcessTreeUnix escalates SIGTERM -> grace -> SIGKILL against the

--- a/agent/internal/heartbeat/handlers_script.go
+++ b/agent/internal/heartbeat/handlers_script.go
@@ -335,6 +335,31 @@ func resolveRunAsSession(broker *sessionbroker.Broker, runAs string) *sessionbro
 	return broker.SessionForUser(target)
 }
 
+const (
+	// scriptCancelHelperTimeoutSeconds is the per-helper IPC budget for a
+	// script_cancel. helperCommandTimeout adds 5s, and the result MUST exceed
+	// the 30s maximum grace (executor.MaxGraceSeconds, spec OD2-B): the old
+	// value of 10 gave a 15s wait, so a 30s cancel timed the IPC out while the
+	// helper was still escalating and the agent reported a failure for a kill
+	// that was about to succeed.
+	scriptCancelHelperTimeoutSeconds = 40
+
+	// defaultCancelGraceSeconds matches the server's default when a request
+	// omits graceSeconds. executor.Cancel clamps to 0..MaxGraceSeconds.
+	defaultCancelGraceSeconds = 5
+)
+
+// handleScriptCancel stops a running script and reports what actually happened.
+//
+// All three outcomes (terminated / not_found / kill_failed) come back as a
+// SUCCESS result carrying {executionId, outcome, cancelled}: the server closes
+// the execution's cancel_state differently for each, and an error string cannot
+// carry that distinction — the previous implementation returned
+// tools.NewErrorResult for "no such execution" AND for a genuinely failed kill.
+// Only a genuinely malformed payload is still an error result.
+//
+// `cancelled` is true only for `terminated`. It feeds the server's honesty
+// contract: script_executions.status may become 'cancelled' only on proof.
 func handleScriptCancel(h *Heartbeat, cmd Command) tools.CommandResult {
 	start := time.Now()
 	executionID, errResult := tools.RequirePayloadString(cmd.Payload, "executionId")
@@ -342,39 +367,130 @@ func handleScriptCancel(h *Heartbeat, cmd Command) tools.CommandResult {
 		errResult.DurationMs = time.Since(start).Milliseconds()
 		return *errResult
 	}
+	grace := cancelGraceSeconds(cmd.Payload)
 
-	if err := h.executor.Cancel(executionID); err != nil {
-		if h.sessionBroker == nil {
-			return tools.NewErrorResult(err, time.Since(start).Milliseconds())
-		}
-
-		var helperErr error
-		for _, session := range h.runAsHelperSessions() {
-			resp, sendErr := h.sendCommandToUserHelper(session, cmd, 10)
-			if sendErr != nil {
-				helperErr = sendErr
-				continue
-			}
-			if resp.Status == "completed" {
-				return tools.NewSuccessResult(map[string]any{
-					"executionId": executionID,
-					"cancelled":   true,
-				}, time.Since(start).Milliseconds())
-			}
-			if resp.Error != "" {
-				helperErr = errors.New(resp.Error)
-			}
-		}
-
-		if helperErr != nil {
-			return tools.NewErrorResult(helperErr, time.Since(start).Milliseconds())
-		}
+	// Name the responsible command BEFORE asking, so the script's own result
+	// can carry cancelledByCommandId even if it wins the race with our ack.
+	h.executor.SetCancelCommandID(executionID, cmd.ID)
+	outcome, err := h.executor.Cancel(executionID, grace)
+	if err != nil {
 		return tools.NewErrorResult(err, time.Since(start).Milliseconds())
 	}
+
+	// A runAs=user script runs inside a user helper's OWN executor, so our
+	// not_found says nothing about it. Every other outcome is already decided
+	// locally — fanning out then would risk a second kill of an unrelated id.
+	if outcome == executor.CancelNotFound {
+		outcome = h.cancelViaUserHelpers(cmd, executionID, outcome)
+	}
+
+	log.Info("script cancel resolved",
+		"commandId", cmd.ID, "executionId", executionID,
+		"outcome", string(outcome), "graceSeconds", grace)
+
 	return tools.NewSuccessResult(map[string]any{
 		"executionId": executionID,
-		"cancelled":   true,
+		"outcome":     string(outcome),
+		"cancelled":   outcome == executor.CancelTerminated,
 	}, time.Since(start).Milliseconds())
+}
+
+// cancelGraceSeconds reads the requested graceful-shutdown window from the
+// command payload. JSON decoding gives float64; the string arm tolerates a
+// stringified value. executor.Cancel clamps whatever comes back.
+func cancelGraceSeconds(payload map[string]any) int {
+	raw, ok := payload["graceSeconds"]
+	if !ok {
+		return defaultCancelGraceSeconds
+	}
+	switch v := raw.(type) {
+	case float64:
+		return int(v)
+	case int:
+		return v
+	case string:
+		if parsed, err := strconv.Atoi(strings.TrimSpace(v)); err == nil {
+			return parsed
+		}
+	}
+	return defaultCancelGraceSeconds
+}
+
+// cancelViaUserHelpers fans a cancel out to every run_as_user helper and folds
+// their answers into one outcome.
+//
+// not_found is returned ONLY when every helper also reports not_found — an
+// unreachable or erroring helper may still own the process, and the server
+// treats not_found as "revert, nothing proven" rather than "kill failed".
+// Ranking is terminated > kill_failed > not_found: an execution lives in at
+// most one helper, so a single `terminated` is proof.
+func (h *Heartbeat) cancelViaUserHelpers(cmd Command, executionID string, local executor.CancelOutcome) executor.CancelOutcome {
+	sessions := h.runAsHelperSessions()
+	if len(sessions) == 0 {
+		return local
+	}
+
+	outcome := local
+	for _, session := range sessions {
+		resp, sendErr := h.sendCommandToUserHelper(session, cmd, scriptCancelHelperTimeoutSeconds)
+		if sendErr != nil {
+			log.Warn("user-helper script cancel failed",
+				"sessionId", session.SessionID, "executionId", executionID, "error", sendErr.Error())
+			outcome = strongerCancelOutcome(outcome, executor.CancelKillFailed)
+			continue
+		}
+		outcome = strongerCancelOutcome(outcome, decodeHelperCancelOutcome(session.SessionID, resp))
+	}
+	return outcome
+}
+
+// decodeHelperCancelOutcome reads a helper's structured outcome. Anything it
+// cannot positively read as one of the three known outcomes grades as
+// kill_failed: a helper that answered something we do not understand may well
+// still be running the script, and claiming not_found there would let the
+// server revert the execution as if nothing had been running.
+func decodeHelperCancelOutcome(sessionID string, resp *ipc.IPCCommandResult) executor.CancelOutcome {
+	if resp == nil || resp.Status != "completed" {
+		return executor.CancelKillFailed
+	}
+	var nested struct {
+		Outcome string `json:"outcome"`
+	}
+	if len(resp.Result) == 0 || json.Unmarshal(resp.Result, &nested) != nil {
+		log.Warn("user helper returned an undecodable script cancel result", "sessionId", sessionID)
+		return executor.CancelKillFailed
+	}
+	switch executor.CancelOutcome(nested.Outcome) {
+	case executor.CancelTerminated:
+		return executor.CancelTerminated
+	case executor.CancelNotFound:
+		return executor.CancelNotFound
+	case executor.CancelKillFailed:
+		return executor.CancelKillFailed
+	}
+	// A pre-#3525 helper reports {cancelled:true} with no outcome. It acked the
+	// instant it asked, which proves nothing, so it does not earn `terminated`.
+	log.Warn("user helper returned no script cancel outcome; grading as kill_failed",
+		"sessionId", sessionID, "outcome", nested.Outcome)
+	return executor.CancelKillFailed
+}
+
+func strongerCancelOutcome(current, next executor.CancelOutcome) executor.CancelOutcome {
+	if cancelOutcomeRank(next) > cancelOutcomeRank(current) {
+		return next
+	}
+	return current
+}
+
+func cancelOutcomeRank(outcome executor.CancelOutcome) int {
+	switch outcome {
+	case executor.CancelTerminated:
+		return 2
+	case executor.CancelKillFailed:
+		return 1
+	default:
+		return 0
+	}
 }
 
 func handleScriptListRunning(h *Heartbeat, _ Command) tools.CommandResult {

--- a/agent/internal/heartbeat/handlers_script.go
+++ b/agent/internal/heartbeat/handlers_script.go
@@ -269,6 +269,13 @@ func handleScriptInner(h *Heartbeat, cmd Command, secretEnv executor.SecretEnv) 
 		// also needs the unmodified text.
 		Error:      scriptResult.Error,
 		DurationMs: time.Since(start).Milliseconds(),
+		// #3525: the cancellation marker travels with the SCRIPT's own result,
+		// not only with the cancel's ack. It is what lets the server close a
+		// `cancelling` execution as `cancelled` when the script result wins the
+		// race with the cancel ack — without it every such race resolves as
+		// `unconfirmed` and the operator sees a stop that never confirmed.
+		Cancelled:            scriptResult.Cancelled,
+		CancelledByCommandID: scriptResult.CancelledByCommandID,
 	}
 	if len(customFields) > 0 {
 		result.Result = map[string]any{
@@ -606,6 +613,14 @@ func (h *Heartbeat) executeViaUserHelper(session *sessionbroker.Session, cmd Com
 			}
 			if writes, ok := nested["customFieldWrites"]; ok && writes != nil {
 				cmdResult.Result = map[string]any{"customFieldWrites": writes}
+			}
+			// #3525: lift the helper's cancellation marker to the top level of
+			// the command result, where the server reads it.
+			if cancelled, ok := nested["cancelled"].(bool); ok && cancelled {
+				cmdResult.Cancelled = true
+				if by, ok := nested["cancelledByCommandId"].(string); ok {
+					cmdResult.CancelledByCommandID = by
+				}
 			}
 		}
 	}

--- a/agent/internal/heartbeat/handlers_script.go
+++ b/agent/internal/heartbeat/handlers_script.go
@@ -376,10 +376,10 @@ func handleScriptCancel(h *Heartbeat, cmd Command) tools.CommandResult {
 	}
 	grace := cancelGraceSeconds(cmd.Payload)
 
-	// Name the responsible command BEFORE asking, so the script's own result
-	// can carry cancelledByCommandId even if it wins the race with our ack.
-	h.executor.SetCancelCommandID(executionID, cmd.ID)
-	outcome, err := h.executor.Cancel(executionID, grace)
+	// cmd.ID is the script_cancel command's own id: it is stamped onto the
+	// script's result so the server can tell which cancel earned the kill even
+	// when that result wins the race with this ack.
+	outcome, err := h.executor.Cancel(executionID, cmd.ID, grace)
 	if err != nil {
 		return tools.NewErrorResult(err, time.Since(start).Milliseconds())
 	}

--- a/agent/internal/heartbeat/handlers_script_cancel_test.go
+++ b/agent/internal/heartbeat/handlers_script_cancel_test.go
@@ -179,6 +179,103 @@ func TestScriptCancelReportsTerminatedForARunningScript(t *testing.T) {
 	}
 }
 
+func TestCancelledScriptResultCarriesTheMarkerOnTheWire(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash not available on Windows")
+	}
+	// Closer 1 of the server state machine reads result.cancelled and
+	// result.cancelledByCommandId as siblings of status/exitCode. If the marker
+	// stops at the executor boundary, a confirmed cancel can never be proven by
+	// the script's OWN result and every race resolves as `unconfirmed`.
+	h := newTestHeartbeat(nil)
+	scriptDone := make(chan tools.CommandResult, 1)
+	go func() {
+		scriptDone <- handleScript(h, Command{
+			ID:   "cmd-marker",
+			Type: tools.CmdScript,
+			Payload: map[string]any{
+				"content":        "for _ in $(seq 1 600); do sleep 0.1; done",
+				"language":       "bash",
+				"timeoutSeconds": 120,
+			},
+		})
+	}()
+	deadline := time.Now().Add(10 * time.Second)
+	for len(h.executor.ListRunning()) == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("script never registered as running")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if got := outcomeOf(t, handleScriptCancel(h, cancelCommand("cc-1", "cmd-marker", 0))); got != "terminated" {
+		t.Fatalf("cancel outcome = %q, want terminated", got)
+	}
+
+	var scriptResult tools.CommandResult
+	select {
+	case scriptResult = <-scriptDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the script never returned a result")
+	}
+	if !scriptResult.Cancelled {
+		t.Fatalf("script result carries no cancellation marker: %+v", scriptResult)
+	}
+	if scriptResult.CancelledByCommandID != "cc-1" {
+		t.Fatalf("cancelledByCommandId = %q, want cc-1", scriptResult.CancelledByCommandID)
+	}
+
+	ws := toWSCommandResult("cmd-marker", scriptResult)
+	if !ws.Cancelled || ws.CancelledByCommandID != "cc-1" {
+		t.Fatalf("the marker was dropped converting to the WebSocket result: %+v", ws)
+	}
+}
+
+func TestHelperCancellationMarkerCrossesTheIPCHop(t *testing.T) {
+	// A runAs=user script is killed inside the HELPER's executor, so its marker
+	// reaches the server only if executeViaUserHelper lifts it out of the
+	// nested result onto the top-level command result.
+	serverConn, clientConn := createTestSocketPair(t)
+	serverIPC := ipc.NewConn(serverConn)
+	clientIPC := ipc.NewConn(clientConn)
+	session := sessionbroker.NewSession(serverIPC, 1000, "1000", "testuser", "quartz", "marker-hop", []string{"run_as_user"})
+
+	go func() {
+		_ = clientIPC.SetReadDeadline(time.Now().Add(5 * time.Second))
+		env, err := clientIPC.Recv()
+		if err != nil {
+			return
+		}
+		resultPayload, _ := json.Marshal(map[string]any{
+			"exitCode":             -1,
+			"stdout":               "",
+			"stderr":               "",
+			"cancelled":            true,
+			"cancelledByCommandId": "cc-helper",
+		})
+		payload, _ := json.Marshal(ipc.IPCCommandResult{CommandID: env.ID, Status: "failed", Result: resultPayload})
+		_ = clientIPC.Send(&ipc.Envelope{ID: env.ID, Type: ipc.TypeCommandResult, Payload: payload})
+	}()
+	go session.RecvLoop(func(s *sessionbroker.Session, env *ipc.Envelope) {})
+
+	h := newTestHeartbeat(newTestBrokerWithSessions(t, session))
+	result := h.executeViaUserHelper(session, Command{
+		ID:      "cmd-helper-script",
+		Type:    tools.CmdScript,
+		Payload: map[string]any{"content": "sleep 60", "language": "bash", "timeoutSeconds": 120},
+	}, 10)
+
+	_ = session.Close()
+	_ = clientIPC.Close()
+
+	if !result.Cancelled {
+		t.Fatalf("the helper's cancellation marker was dropped at the IPC hop: %+v", result)
+	}
+	if result.CancelledByCommandID != "cc-helper" {
+		t.Fatalf("cancelledByCommandId = %q, want cc-helper", result.CancelledByCommandID)
+	}
+}
+
 func TestScriptCancelMalformedPayloadStaysAnError(t *testing.T) {
 	h := newTestHeartbeat(nil)
 	result := handleScriptCancel(h, Command{ID: "cmd-bad", Type: tools.CmdScriptCancel, Payload: map[string]any{}})

--- a/agent/internal/heartbeat/handlers_script_cancel_test.go
+++ b/agent/internal/heartbeat/handlers_script_cancel_test.go
@@ -1,0 +1,336 @@
+package heartbeat
+
+import (
+	"encoding/json"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/executor"
+	"github.com/breeze-rmm/agent/internal/ipc"
+	"github.com/breeze-rmm/agent/internal/remote/tools"
+	"github.com/breeze-rmm/agent/internal/sessionbroker"
+	"github.com/breeze-rmm/agent/internal/workerpool"
+)
+
+// #3525 script_cancel: bypass lane, structured outcome, helper fan-out.
+
+// newTestHeartbeatWithPool builds a Heartbeat whose worker pool is as small as
+// production can legitimately get: MaxConcurrentCommands clamps to a floor of 1
+// (config/validate.go).
+func newTestHeartbeatWithPool(workers, queue int) *Heartbeat {
+	h := &Heartbeat{
+		executor: executor.New(nil),
+		pool:     workerpool.New(workers, queue),
+	}
+	h.accepting.Store(true)
+	return h
+}
+
+func cancelCommand(id, executionID string, graceSeconds int) Command {
+	return Command{
+		ID:   id,
+		Type: tools.CmdScriptCancel,
+		Payload: map[string]any{
+			"executionId":  executionID,
+			"graceSeconds": float64(graceSeconds),
+		},
+	}
+}
+
+// cancelPayload decodes the structured body tools.NewSuccessResult marshals
+// into Stdout. That is the wire the server reads it off.
+func cancelPayload(t *testing.T, result tools.CommandResult) map[string]any {
+	t.Helper()
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(result.Stdout), &payload); err != nil {
+		t.Fatalf("result carried no structured payload (%v): %+v", err, result)
+	}
+	return payload
+}
+
+func outcomeOf(t *testing.T, result tools.CommandResult) string {
+	t.Helper()
+	outcome, _ := cancelPayload(t, result)["outcome"].(string)
+	return outcome
+}
+
+// saturatePool blocks every worker AND fills the queue, so any further Submit
+// is rejected outright ("command rejected, worker pool full").
+func saturatePool(t *testing.T, h *Heartbeat, slots int) {
+	t.Helper()
+	blocker := make(chan struct{})
+	t.Cleanup(func() { close(blocker) })
+	for i := 0; i < slots; i++ {
+		if !h.pool.Submit(func() { <-blocker }) {
+			t.Fatalf("could not saturate the pool at slot %d", i)
+		}
+		time.Sleep(20 * time.Millisecond) // let a worker pick the blocker up
+	}
+}
+
+func TestScriptCancelBypassesTheWorkerPool(t *testing.T) {
+	// A cancel that goes through the pool queues behind the very script it must
+	// stop — or is rejected outright once the queue is full.
+	h := newTestHeartbeatWithPool(1, 1)
+	saturatePool(t, h, 2)
+
+	done := make(chan tools.CommandResult, 1)
+	go func() { done <- h.executeCommandViaPool(cancelCommand("cmd-bypass", "no-such-exec", 0)) }()
+
+	select {
+	case result := <-done:
+		if result.Status != "completed" {
+			t.Fatalf("cancel starved behind the pool: %+v", result)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("cancel never completed while the worker pool was saturated")
+	}
+}
+
+func TestScriptListRunningBypassesTheWorkerPool(t *testing.T) {
+	h := newTestHeartbeatWithPool(1, 1)
+	saturatePool(t, h, 2)
+
+	done := make(chan tools.CommandResult, 1)
+	go func() {
+		done <- h.executeCommandViaPool(Command{ID: "cmd-list", Type: tools.CmdScriptListRunning})
+	}()
+	select {
+	case result := <-done:
+		if result.Status != "completed" {
+			t.Fatalf("script_list_running starved behind the pool: %+v", result)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("script_list_running never completed while the worker pool was saturated")
+	}
+}
+
+func TestOrdinaryCommandsStillGoThroughTheWorkerPool(t *testing.T) {
+	// The bypass must stay narrow: a saturated pool still rejects a script, or
+	// the pool stops bounding concurrency at all.
+	h := newTestHeartbeatWithPool(1, 1)
+	saturatePool(t, h, 2)
+
+	result := h.executeCommandViaPool(Command{ID: "cmd-script", Type: tools.CmdScript, Payload: map[string]any{"content": "echo hi"}})
+	if result.Status != "failed" || result.Error != "command rejected, worker pool full" {
+		t.Fatalf("a script slipped past the saturated pool: %+v", result)
+	}
+}
+
+func TestScriptCancelReportsNotFoundAsASuccessResult(t *testing.T) {
+	// An unknown id used to return tools.NewErrorResult, which the server cannot
+	// distinguish from a failed kill — and the two close the execution's
+	// cancel_state differently (unconfirmed vs failed).
+	h := newTestHeartbeat(nil)
+	result := handleScriptCancel(h, cancelCommand("cmd-nf", "nonexistent", 5))
+	if result.Status != "completed" {
+		t.Fatalf("want a success result carrying the outcome, got %+v", result)
+	}
+	if got := outcomeOf(t, result); got != "not_found" {
+		t.Fatalf("outcome = %q, want not_found", got)
+	}
+	if payload := cancelPayload(t, result); payload["cancelled"] != false {
+		t.Fatalf("cancelled = %v for not_found; only a proven stop may claim true", payload["cancelled"])
+	}
+}
+
+func TestScriptCancelReportsTerminatedForARunningScript(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash not available on Windows")
+	}
+	h := newTestHeartbeat(nil)
+	scriptDone := make(chan tools.CommandResult, 1)
+	go func() {
+		scriptDone <- handleScript(h, Command{
+			ID:   "cmd-run-1",
+			Type: tools.CmdScript,
+			Payload: map[string]any{
+				"content":        "for _ in $(seq 1 600); do sleep 0.1; done",
+				"language":       "bash",
+				"timeoutSeconds": 120,
+			},
+		})
+	}()
+
+	deadline := time.Now().Add(10 * time.Second)
+	for len(h.executor.ListRunning()) == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("script never registered as running")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	result := handleScriptCancel(h, cancelCommand("cmd-cancel-1", "cmd-run-1", 0))
+	if result.Status != "completed" {
+		t.Fatalf("cancel failed: %+v", result)
+	}
+	if got := outcomeOf(t, result); got != "terminated" {
+		t.Fatalf("outcome = %q, want terminated", got)
+	}
+	if cancelPayload(t, result)["cancelled"] != true {
+		t.Fatal("cancelled = false after a proven termination")
+	}
+
+	select {
+	case <-scriptDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the script kept running after a terminated cancel")
+	}
+}
+
+func TestScriptCancelMalformedPayloadStaysAnError(t *testing.T) {
+	h := newTestHeartbeat(nil)
+	result := handleScriptCancel(h, Command{ID: "cmd-bad", Type: tools.CmdScriptCancel, Payload: map[string]any{}})
+	if result.Status != "failed" {
+		t.Fatalf("a malformed payload must still fail the command, got %+v", result)
+	}
+}
+
+// respondToHelperCancel plays a user helper answering one script_cancel with
+// the given structured outcome.
+func respondToHelperCancel(clientIPC *ipc.Conn, executionID, outcome string, cancelled bool) {
+	go func() {
+		_ = clientIPC.SetReadDeadline(time.Now().Add(5 * time.Second))
+		env, err := clientIPC.Recv()
+		if err != nil {
+			return
+		}
+		resultPayload, _ := json.Marshal(map[string]any{
+			"executionId": executionID,
+			"outcome":     outcome,
+			"cancelled":   cancelled,
+		})
+		payload, _ := json.Marshal(ipc.IPCCommandResult{CommandID: env.ID, Status: "completed", Result: resultPayload})
+		_ = clientIPC.Send(&ipc.Envelope{ID: env.ID, Type: ipc.TypeCommandResult, Payload: payload})
+	}()
+}
+
+func TestNotFoundMeansNoHelperAndNoLocalExecutorHasIt(t *testing.T) {
+	serverConn, clientConn := createTestSocketPair(t)
+	serverIPC := ipc.NewConn(serverConn)
+	clientIPC := ipc.NewConn(clientConn)
+	session := sessionbroker.NewSession(serverIPC, 1000, "1000", "testuser", "quartz", "helper-owns", []string{"run_as_user"})
+
+	respondToHelperCancel(clientIPC, "cmd-9", "terminated", true)
+	go session.RecvLoop(func(s *sessionbroker.Session, env *ipc.Envelope) {})
+
+	h := newTestHeartbeat(newTestBrokerWithSessions(t, session))
+	result := handleScriptCancel(h, cancelCommand("cmd-9", "cmd-9", 0))
+
+	_ = session.Close()
+	_ = clientIPC.Close()
+
+	got := outcomeOf(t, result)
+	if got == "not_found" {
+		t.Fatal("reported not_found while a helper still owned the process")
+	}
+	if got != "terminated" {
+		t.Fatalf("outcome = %q, want the helper's terminated", got)
+	}
+}
+
+func TestHelperNotFoundOnlyWinsWhenEveryHelperAgrees(t *testing.T) {
+	// One helper answers not_found, the other cannot be reached at all. The
+	// unreachable helper may still own the process, so the combined answer must
+	// not be not_found — that would let the server revert the execution as if
+	// nothing had ever been running.
+	serverConn, clientConn := createTestSocketPair(t)
+	serverIPC := ipc.NewConn(serverConn)
+	clientIPC := ipc.NewConn(clientConn)
+	answering := sessionbroker.NewSession(serverIPC, 1000, "1000", "alice", "quartz", "helper-a", []string{"run_as_user"})
+
+	respondToHelperCancel(clientIPC, "cmd-x", "not_found", false)
+	go answering.RecvLoop(func(s *sessionbroker.Session, env *ipc.Envelope) {})
+
+	deadServer, deadClient := createTestSocketPair(t)
+	deadSession := sessionbroker.NewSession(ipc.NewConn(deadServer), 1001, "1001", "bob", "quartz", "helper-dead", []string{"run_as_user"})
+	_ = deadServer.Close()
+	_ = deadClient.Close()
+
+	h := newTestHeartbeat(newTestBrokerWithSessions(t, answering, deadSession))
+	result := handleScriptCancel(h, cancelCommand("cmd-x", "cmd-x", 0))
+
+	_ = answering.Close()
+	_ = clientIPC.Close()
+
+	if got := outcomeOf(t, result); got == "not_found" {
+		t.Fatalf("outcome = not_found although one helper could not be reached: %+v", result)
+	}
+}
+
+func TestEveryHelperSayingNotFoundIsNotFound(t *testing.T) {
+	serverConn, clientConn := createTestSocketPair(t)
+	serverIPC := ipc.NewConn(serverConn)
+	clientIPC := ipc.NewConn(clientConn)
+	session := sessionbroker.NewSession(serverIPC, 1000, "1000", "alice", "quartz", "helper-only", []string{"run_as_user"})
+
+	respondToHelperCancel(clientIPC, "cmd-y", "not_found", false)
+	go session.RecvLoop(func(s *sessionbroker.Session, env *ipc.Envelope) {})
+
+	h := newTestHeartbeat(newTestBrokerWithSessions(t, session))
+	result := handleScriptCancel(h, cancelCommand("cmd-y", "cmd-y", 0))
+
+	_ = session.Close()
+	_ = clientIPC.Close()
+
+	if got := outcomeOf(t, result); got != "not_found" {
+		t.Fatalf("outcome = %q, want not_found when the only helper also has no such execution", got)
+	}
+}
+
+func TestHelperIsNotConsultedWhenTheLocalExecutorHandledTheCancel(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash not available on Windows")
+	}
+	serverConn, clientConn := createTestSocketPair(t)
+	serverIPC := ipc.NewConn(serverConn)
+	clientIPC := ipc.NewConn(clientConn)
+	session := sessionbroker.NewSession(serverIPC, 1000, "1000", "alice", "quartz", "helper-idle", []string{"run_as_user"})
+	consulted := make(chan struct{}, 1)
+	go func() {
+		_ = clientIPC.SetReadDeadline(time.Now().Add(3 * time.Second))
+		if _, err := clientIPC.Recv(); err == nil {
+			consulted <- struct{}{}
+		}
+	}()
+	go session.RecvLoop(func(s *sessionbroker.Session, env *ipc.Envelope) {})
+
+	h := newTestHeartbeat(newTestBrokerWithSessions(t, session))
+	go func() {
+		_, _ = h.executor.Execute(executor.ScriptExecution{
+			ID:         "local-1",
+			ScriptType: executor.ScriptTypeBash,
+			Script:     "for _ in $(seq 1 600); do sleep 0.1; done",
+			Timeout:    120,
+		})
+	}()
+	deadline := time.Now().Add(10 * time.Second)
+	for len(h.executor.ListRunning()) == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("script never registered as running")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	result := handleScriptCancel(h, cancelCommand("cmd-local", "local-1", 0))
+	_ = session.Close()
+	_ = clientIPC.Close()
+
+	if got := outcomeOf(t, result); got != "terminated" {
+		t.Fatalf("outcome = %q, want terminated", got)
+	}
+	select {
+	case <-consulted:
+		t.Fatal("fanned out to a user helper although the local executor owned the execution")
+	default:
+	}
+}
+
+func TestHelperIPCTimeoutExceedsTheMaximumGrace(t *testing.T) {
+	// Max grace is 30s; the helper IPC wait used to be 10s+5s = 15s, so a 30s
+	// grace would time out the IPC before the helper finished escalating.
+	if got := helperCommandTimeout(scriptCancelHelperTimeoutSeconds); got <= executor.MaxGraceSeconds*time.Second {
+		t.Fatalf("helper cancel IPC timeout %v must exceed the %ds max grace", got, executor.MaxGraceSeconds)
+	}
+}

--- a/agent/internal/heartbeat/handlers_script_cancel_test.go
+++ b/agent/internal/heartbeat/handlers_script_cancel_test.go
@@ -57,15 +57,37 @@ func outcomeOf(t *testing.T, result tools.CommandResult) string {
 
 // saturatePool blocks every worker AND fills the queue, so any further Submit
 // is rejected outright ("command rejected, worker pool full").
-func saturatePool(t *testing.T, h *Heartbeat, slots int) {
+//
+// Each worker signals when it has actually picked its task up, rather than the
+// test sleeping and hoping: a fixed sleep under CI contention can leave the
+// pool un-saturated and turn these into false passes (or false failures).
+func saturatePool(t *testing.T, h *Heartbeat, workers, queue int) {
 	t.Helper()
 	blocker := make(chan struct{})
 	t.Cleanup(func() { close(blocker) })
-	for i := 0; i < slots; i++ {
-		if !h.pool.Submit(func() { <-blocker }) {
-			t.Fatalf("could not saturate the pool at slot %d", i)
+
+	picked := make(chan struct{}, workers)
+	for i := 0; i < workers; i++ {
+		if !h.pool.Submit(func() { picked <- struct{}{}; <-blocker }) {
+			t.Fatalf("could not occupy worker %d", i)
 		}
-		time.Sleep(20 * time.Millisecond) // let a worker pick the blocker up
+	}
+	for i := 0; i < workers; i++ {
+		select {
+		case <-picked:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("worker %d never picked up its task", i)
+		}
+	}
+	// Every worker is now parked, so these can only sit in the queue.
+	for i := 0; i < queue; i++ {
+		if !h.pool.Submit(func() { <-blocker }) {
+			t.Fatalf("could not fill queue slot %d", i)
+		}
+	}
+	// Proof the pool really is saturated: the next submit must be rejected.
+	if h.pool.Submit(func() {}) {
+		t.Fatal("the pool accepted another task; it is not saturated and these tests would prove nothing")
 	}
 }
 
@@ -73,7 +95,7 @@ func TestScriptCancelBypassesTheWorkerPool(t *testing.T) {
 	// A cancel that goes through the pool queues behind the very script it must
 	// stop — or is rejected outright once the queue is full.
 	h := newTestHeartbeatWithPool(1, 1)
-	saturatePool(t, h, 2)
+	saturatePool(t, h, 1, 1)
 
 	done := make(chan tools.CommandResult, 1)
 	go func() { done <- h.executeCommandViaPool(cancelCommand("cmd-bypass", "no-such-exec", 0)) }()
@@ -90,7 +112,7 @@ func TestScriptCancelBypassesTheWorkerPool(t *testing.T) {
 
 func TestScriptListRunningBypassesTheWorkerPool(t *testing.T) {
 	h := newTestHeartbeatWithPool(1, 1)
-	saturatePool(t, h, 2)
+	saturatePool(t, h, 1, 1)
 
 	done := make(chan tools.CommandResult, 1)
 	go func() {
@@ -110,7 +132,7 @@ func TestOrdinaryCommandsStillGoThroughTheWorkerPool(t *testing.T) {
 	// The bypass must stay narrow: a saturated pool still rejects a script, or
 	// the pool stops bounding concurrency at all.
 	h := newTestHeartbeatWithPool(1, 1)
-	saturatePool(t, h, 2)
+	saturatePool(t, h, 1, 1)
 
 	result := h.executeCommandViaPool(Command{ID: "cmd-script", Type: tools.CmdScript, Payload: map[string]any{"content": "echo hi"}})
 	if result.Status != "failed" || result.Error != "command rejected, worker pool full" {
@@ -351,8 +373,10 @@ func TestHelperNotFoundOnlyWinsWhenEveryHelperAgrees(t *testing.T) {
 	_ = answering.Close()
 	_ = clientIPC.Close()
 
-	if got := outcomeOf(t, result); got == "not_found" {
-		t.Fatalf("outcome = not_found although one helper could not be reached: %+v", result)
+	// An unreachable helper grades kill_failed, which the server records as
+	// `failed` — not the `unconfirmed` revert that not_found would cause.
+	if got := outcomeOf(t, result); got != "kill_failed" {
+		t.Fatalf("outcome = %q, want kill_failed when one helper could not be reached: %+v", got, result)
 	}
 }
 

--- a/agent/internal/heartbeat/handlers_script_test.go
+++ b/agent/internal/heartbeat/handlers_script_test.go
@@ -326,17 +326,12 @@ func TestHandleScriptCancel(t *testing.T) {
 		t.Fatalf("expected failed for missing executionId, got %s", result.Status)
 	}
 
-	// Cancel nonexistent execution
-	result = handleScriptCancel(h, Command{
-		ID:   "cmd-cancel-nonexist",
-		Type: tools.CmdScriptCancel,
-		Payload: map[string]any{
-			"executionId": "nonexistent",
-		},
-	})
-	if result.Status != "failed" {
-		t.Fatalf("expected failed for nonexistent execution, got %s", result.Status)
-	}
+	// A nonexistent execution is NO LONGER a failed result (#3525): it is the
+	// structured `not_found` outcome on a success result, because the server
+	// closes cancel_state differently for not_found than for a failed kill and
+	// an error string cannot carry that. Asserted by
+	// TestScriptCancelReportsNotFoundAsASuccessResult in
+	// handlers_script_cancel_test.go.
 }
 
 func TestHandleScriptListRunning(t *testing.T) {

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -4609,6 +4609,13 @@ func (h *Heartbeat) processHeartbeatResponse(response *HeartbeatResponse) {
 			break
 		}
 		c := cmd // capture
+		// #3525: the same bypass executeCommandViaPool applies on the WebSocket
+		// side. Without it a cancel delivered by the heartbeat poll would queue
+		// behind the script it is meant to stop.
+		if isLifecycleCommand(c.Type) {
+			go h.processCommand(c)
+			continue
+		}
 		if !h.pool.Submit(func() { h.processCommand(c) }) {
 			log.Warn("command rejected, worker pool full", logging.KeyCommandID, cmd.ID)
 		}
@@ -5898,6 +5905,20 @@ func (h *Heartbeat) HandleCommand(wsCmd websocket.Command) websocket.CommandResu
 }
 
 func (h *Heartbeat) executeCommandViaPool(cmd Command) tools.CommandResult {
+	// #3525: lifecycle commands BYPASS the worker pool. MaxConcurrentCommands
+	// clamps to a floor of 1 (config/validate.go), so a cancel submitted to the
+	// pool queues behind the very script it must stop — and once the queue is
+	// full Submit rejects it outright with "command rejected, worker pool full".
+	// These handlers never spawn long work of their own (a cancel waits at most
+	// grace + backstop), so running them off-pool cannot exhaust the host.
+	//
+	// The caller is already a per-command goroutine: script_cancel is not an
+	// ordered command, so websocket dispatchCommand gives it its own goroutine,
+	// and the heartbeat poll path spawns one explicitly.
+	if isLifecycleCommand(cmd.Type) {
+		return h.runTrackedCommand(cmd)
+	}
+
 	if h.pool == nil {
 		return h.executeCommand(cmd)
 	}
@@ -6052,6 +6073,18 @@ func (h *Heartbeat) inFlightCommandStats(now time.Time) (inFlight, overdue int) 
 		}
 	}
 	return inFlight, overdue
+}
+
+// isLifecycleCommand reports whether a command manages OTHER in-flight
+// commands and therefore must never be scheduled behind them (#3525). A cancel
+// queued behind the script it is meant to stop can only ever fire after that
+// script has already finished on its own.
+func isLifecycleCommand(cmdType string) bool {
+	switch cmdType {
+	case tools.CmdScriptCancel, tools.CmdScriptListRunning:
+		return true
+	}
+	return false
 }
 
 func isEphemeralCommand(cmdType string) bool {

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -5849,6 +5849,11 @@ func toWSCommandResult(commandID string, result tools.CommandResult) websocket.C
 		Stdout:    result.Stdout,
 		Stderr:    result.Stderr,
 		Error:     result.Error,
+		// #3525: the cancellation marker must survive this conversion — the
+		// WebSocket leg is the primary result channel, and the marker is the
+		// only proof that closes a `cancelling` execution as `cancelled`.
+		Cancelled:            result.Cancelled,
+		CancelledByCommandID: result.CancelledByCommandID,
 	}
 
 	// An explicitly-set Result wins. The stdout reparse below stays for the

--- a/agent/internal/remote/tools/types.go
+++ b/agent/internal/remote/tools/types.go
@@ -270,6 +270,16 @@ type CommandResult struct {
 	// must carry verbatim, not as a general-purpose duplicate of Stdout.
 	Result     any   `json:"result,omitempty"`
 	DurationMs int64 `json:"durationMs,omitempty"`
+	// #3525 cancellation marker. Set by the script handler when this execution
+	// ended because a script_cancel killed it. Top-level (a sibling of Status
+	// and ExitCode, not nested under Result) because that is where the server's
+	// result handler reads them: they are the ONLY proof that lets a racing
+	// script result close the execution as `cancelled` rather than preserving
+	// its natural outcome as `unconfirmed` (OD9-C). CancelledByCommandID names
+	// the script_cancel command responsible, so a stale or retried cancel is
+	// never credited with a kill it did not do.
+	Cancelled            bool   `json:"cancelled,omitempty"`
+	CancelledByCommandID string `json:"cancelledByCommandId,omitempty"`
 	// RFC3339Nano timestamp captured by the agent at the moment the command's
 	// primary work began. Set by command handlers that care about the server-
 	// side reconstruction (e.g. software_install). Empty when not applicable.

--- a/agent/internal/userhelper/client.go
+++ b/agent/internal/userhelper/client.go
@@ -842,6 +842,13 @@ func (c *Client) executeScript(cmd ipc.IPCCommand) ipc.IPCCommandResult {
 		"stdout":   executor.SanitizeOutput(cleanedStdout),
 		"stderr":   executor.SanitizeOutput(result.Stderr),
 	}
+	// #3525: a runAs=user script is killed by the HELPER's executor, so its
+	// cancellation marker only reaches the server if it rides back over the IPC
+	// hop. Omitted when absent so an uncancelled run's payload is unchanged.
+	if result.Cancelled {
+		resultPayload["cancelled"] = true
+		resultPayload["cancelledByCommandId"] = result.CancelledByCommandID
+	}
 	if len(customFields) > 0 {
 		resultPayload["customFieldWrites"] = map[string]any{
 			"schemaVersion": 1,

--- a/agent/internal/userhelper/client.go
+++ b/agent/internal/userhelper/client.go
@@ -720,7 +720,13 @@ func (c *Client) executeScript(cmd ipc.IPCCommand) ipc.IPCCommandResult {
 			}
 		}
 
-		if err := c.executor.Cancel(executionID); err != nil {
+		// #3525: mirror the agent-side structured outcome. "no such execution"
+		// used to come back as a failed IPC result, indistinguishable from a
+		// failed kill — and the agent needs the difference to decide whether
+		// not_found is the whole fleet's answer.
+		c.executor.SetCancelCommandID(executionID, cmd.CommandID)
+		outcome, err := c.executor.Cancel(executionID, getIntOrDefault(payload, "graceSeconds", defaultCancelGraceSeconds))
+		if err != nil {
 			return ipc.IPCCommandResult{
 				CommandID: cmd.CommandID,
 				Status:    "failed",
@@ -730,7 +736,8 @@ func (c *Client) executeScript(cmd ipc.IPCCommand) ipc.IPCCommandResult {
 
 		resultJSON, err := json.Marshal(map[string]any{
 			"executionId": executionID,
-			"cancelled":   true,
+			"outcome":     string(outcome),
+			"cancelled":   outcome == executor.CancelTerminated,
 		})
 		if err != nil {
 			return ipc.IPCCommandResult{
@@ -1410,6 +1417,10 @@ func getStringOrDefault(m map[string]any, key, def string) string {
 	}
 	return def
 }
+
+// defaultCancelGraceSeconds mirrors the agent-side default when a script_cancel
+// payload omits graceSeconds. executor.Cancel clamps it to 0..MaxGraceSeconds.
+const defaultCancelGraceSeconds = 5
 
 func getIntOrDefault(m map[string]any, key string, def int) int {
 	if v, ok := m[key].(float64); ok {

--- a/agent/internal/userhelper/client.go
+++ b/agent/internal/userhelper/client.go
@@ -724,8 +724,8 @@ func (c *Client) executeScript(cmd ipc.IPCCommand) ipc.IPCCommandResult {
 		// used to come back as a failed IPC result, indistinguishable from a
 		// failed kill — and the agent needs the difference to decide whether
 		// not_found is the whole fleet's answer.
-		c.executor.SetCancelCommandID(executionID, cmd.CommandID)
-		outcome, err := c.executor.Cancel(executionID, getIntOrDefault(payload, "graceSeconds", defaultCancelGraceSeconds))
+		outcome, err := c.executor.Cancel(executionID, cmd.CommandID,
+			getIntOrDefault(payload, "graceSeconds", defaultCancelGraceSeconds))
 		if err != nil {
 			return ipc.IPCCommandResult{
 				CommandID: cmd.CommandID,

--- a/agent/internal/userhelper/client_test.go
+++ b/agent/internal/userhelper/client_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/breeze-rmm/agent/internal/executor"
 	"github.com/breeze-rmm/agent/internal/helper"
 	"github.com/breeze-rmm/agent/internal/ipc"
 	"github.com/breeze-rmm/agent/internal/remote/tools"
@@ -87,6 +88,28 @@ func TestExecuteScriptListRunningUsesSharedExecutor(t *testing.T) {
 	})
 	if cancelResult.Status != "completed" {
 		t.Fatalf("expected completed cancel status, got %s (%s)", cancelResult.Status, cancelResult.Error)
+	}
+
+	// #3525: the agent grades every helper's STRUCTURED outcome. A helper that
+	// answers `completed` with no recognisable `outcome` is graded kill_failed,
+	// so asserting only the status would let this whole branch regress to the
+	// old always-`cancelled: true` shape without any test noticing.
+	var cancelPayload struct {
+		ExecutionID string `json:"executionId"`
+		Outcome     string `json:"outcome"`
+		Cancelled   bool   `json:"cancelled"`
+	}
+	if err := json.Unmarshal(cancelResult.Result, &cancelPayload); err != nil {
+		t.Fatalf("unmarshal cancel result: %v", err)
+	}
+	if cancelPayload.Outcome != string(executor.CancelTerminated) {
+		t.Fatalf("cancel outcome = %q, want terminated", cancelPayload.Outcome)
+	}
+	if !cancelPayload.Cancelled {
+		t.Fatal("cancelled = false after a proven termination")
+	}
+	if cancelPayload.ExecutionID != "exec-1" {
+		t.Fatalf("executionId = %q, want exec-1", cancelPayload.ExecutionID)
 	}
 
 	<-done

--- a/agent/internal/websocket/client.go
+++ b/agent/internal/websocket/client.go
@@ -81,6 +81,11 @@ type CommandResult struct {
 	Stderr    string `json:"stderr,omitempty"`
 	Result    any    `json:"result,omitempty"`
 	Error     string `json:"error,omitempty"`
+	// #3525 cancellation marker, mirrored from tools.CommandResult. The
+	// WebSocket leg is the primary result channel, so dropping these here would
+	// mean the server only ever saw the marker on the HTTP fallback.
+	Cancelled            bool   `json:"cancelled,omitempty"`
+	CancelledByCommandID string `json:"cancelledByCommandId,omitempty"`
 }
 
 // outboundResult pairs a marshalled command-result frame with the structured


### PR DESCRIPTION
Closes #4765

Wave 04 of 6 for #3525 (feature #4761). Independent of W02/W03 — the agent change is backward-compatible in both directions: an old server ignores the new fields, and a new server treats an old agent's ack exactly as it treats `not_found`/`kill_failed`.

> **AGENT-SHIPPED: canary a small band before fleet promote.** The Windows containment change also alters the TIMEOUT path — watch for customer scripts that legitimately spawn detached children and now die with the parent.

## Why

Four correctness blockers, all verified in the agent on `main`:

1. **Cancellation could starve.** Every command went through one `workerpool`, `MaxConcurrentCommands` clamps to a floor of 1 (`config/validate.go`), and a full queue returns `"command rejected, worker pool full"`. A cancel queued behind the very script it had to stop.
2. **Cancel-before-registration.** `Execute` validated, wrote the script file and ran `configureRunAs` *before* inserting into `e.running`, and WebSocket commands are concurrent — so a cancel in that window returned "not found" and the script then started anyway.
3. **The ack was premature.** `Executor.Cancel` called `running.cancel()` and returned nil immediately; the async `cmd.Cancel` failure surfaced to `cmd.Run`, never to the cancel caller. A `cancelled: true` ack proved neither termination nor a successful kill attempt.
4. **`not_found` was not global, and Windows had no containment at all.** `killProcessGroup` on Windows was `cmd.Process.Kill()`, so a PowerShell script that started `msiexec` left it running — already true on the timeout path.

## What changed

**`Cancel(executionID, graceSeconds) (CancelOutcome, error)`** — `terminated` / `not_found` / `kill_failed`. It blocks on the execution's `done` channel (bounded by grace + a 10s hard-kill backstop) and reports `kill_failed` when `killErr != nil` **or** `!contained`. `not_found` is deliberately *not* confirmation: a restarted agent has an empty map, and it is far more often "the script finished a moment ago".

**Pre-start reservation.** `Execute` reserves the id as its very first action; `beginStart` refuses to start a process whose cancel already landed, and returns a result carrying the cancellation marker. A cancel that arrives before the process exists returns `terminated` immediately — nothing will ever run, which is a proven stop rather than a guess.

**Unix escalation ladder.** The pgid is captured at `Start` (a kill-time `Getpgid` fails once the leader is gone, and the old fallback then killed a corpse while children survived). `SIGTERM` → grace → `SIGKILL` against the **group**, polling every 100 ms for `ESRCH`. `cmd.WaitDelay` deliberately **stays 5s**: it only starts *after* the cancel callback returns and the callback has already consumed the grace, so `grace+5s` would double-count.

**Windows Job Object containment (OD4-B), fail-closed.** `CREATE_SUSPENDED` → `CreateJobObject` → `KILL_ON_JOB_CLOSE` → `AssignProcessToJobObject` → `ResumeThread`. `CREATE_SUSPENDED` is **OR**'d into the existing flags so `hideWindow`'s `CREATE_NO_WINDOW` survives. On an RD Session Host the enclosing session job denies the assignment (`sessionbroker/spawner_windows.go`, #2536); following that precedent we still run the script but leave `contained=false`, so a cancel can never claim `terminated`. No graceful phase on Windows — `GenerateConsoleCtrlEvent` needs a shared console and our children are `CREATE_NO_WINDOW`.

**Bypass lane.** `script_cancel` and `script_list_running` skip the worker pool on **both** delivery paths (the WebSocket dispatch *and* the heartbeat poll loop, which submits to the pool directly). A test asserts the bypass stays narrow — an ordinary script is still rejected by a saturated pool.

**Structured outcome + honest fan-out.** `handleScriptCancel` returns a SUCCESS result carrying `{executionId, outcome, cancelled}` for all three outcomes; only a malformed payload stays an error result, and `cancelled` is true only for `terminated`. Helper fan-out happens **only** on a local `not_found`; each helper's structured outcome is decoded rather than returning on the first `completed`; `not_found` wins only when **every** helper agrees, and an unreachable or undecodable helper grades `kill_failed` (it may still own the process, and `not_found` tells the server to revert as if nothing had run).

**Helper IPC timeout** raised from 10 (→ 15s wait) to `scriptCancelHelperTimeoutSeconds = 40` (→ 45s), so it exceeds the 30s maximum grace. At 15s a 30s cancel timed the IPC out while the helper was still escalating.

**Windows CI.** `./internal/executor` joins both explicit package lists — `limits_windows_test.go` had never executed anywhere. `./internal/heartbeat` is deliberately NOT added (known-red exclusion list, #2523), which is why the Job Object contract test lives in `internal/executor` and carries no build tag.

## Deviations from the plan (code is truth)

1. **The cancellation marker had to be plumbed onto the wire — the plan stops at `executor.ScriptResult`.** That type never leaves the agent process, but the server's closer 1 reads `result.cancelled` / `result.cancelledByCommandId` as siblings of `status`/`exitCode`. As specified, the marker died at the executor boundary and every script-result-wins-the-race case would have resolved `unconfirmed`. Third commit adds the two `omitempty` fields to `tools.CommandResult` and `websocket.CommandResult`, copies them in `toWSCommandResult`, sets them in `handleScriptInner`, and lifts them across the user-helper IPC hop. Purely additive — an API that does not yet know the fields ignores them. **W03 needs no change for this; it is the shape its own tests already assume.**
2. **The Job Object contract lives in an untagged `job.go`, not only in `job_windows.go`.** The plan asked for the portable no-op in a `//go:build !windows` file, but then `job_contract_test.go` (untagged, by design) would have exercised the no-op on Linux and asserted nothing. The launch ORDER and the degradation policy are therefore untagged; only the syscalls carry the `windows` tag.
3. **`terminateProcessTreeUnix` / `capturePgid` live in one `//go:build !windows` file** (`tree_kill_unix.go`) instead of being duplicated into `limits_unix.go` and `limits_linux.go` as the plan's wording implies. Those two files keep only their genuinely platform-specific `setProcessGroup` (Linux adds `Pdeathsig`).
4. **Added `CloseJob` to the primitive interface.** The plan did not say what happens to the job handle on a *successful* run. Closing it with `KILL_ON_JOB_CLOSE` still set would kill exactly the descendants a completed script legitimately left running, so the flag is cleared before the handle is closed — mirroring `software_install_process_tree_windows.go`'s `release()`. While the script runs, the flag stays set as the agent-crash backstop.
5. **`launchContained` takes the `*runningExecution` as a parameter** rather than allocating and returning one, since `Execute` already holds a reserved entry.
6. **`TestCancelNonexistentExecution` (runas_test.go) and half of `TestHandleScriptCancel`** asserted the old "unknown id is an error" contract and were removed, replaced by outcome-based tests with a comment pointing at them.
7. **A cancelled result reports `ExitCode -1` / `Error: "execution cancelled"`**, checked before the `*exec.ExitError` branch — a killed shell reports `signal: killed`, which would otherwise be persisted as a normal non-zero exit.

## Known accepted residual (not fixed here, by design)

`userhelper.NewWithOptions` rebuilds `executor.New(nil)` on **every** reconnect (`client.go`, `supervisor.go`), so a `runAs=user` script that survived an IPC reconnect is structurally unreachable and will correctly report `not_found` → the server records `unconfirmed`. Degraded but honest. Fixing helper executor persistence across reconnects is out of scope for #3525 and should be filed separately.

## Verification

- `cd agent && go test -race ./internal/executor/ ./internal/heartbeat/ ./internal/userhelper/ ./internal/websocket/ ./internal/remote/tools/` — all pass.
- `cd agent && go test ./...` (whole agent module) — all pass.
- `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go vet` clean on every touched package; `go build ./...` clean for darwin, windows/amd64 and linux/amd64.
- `gofmt -l` clean on every touched file.
- **Both new red-first controls were proven to discriminate**, not just asserted: reverting `terminateProcessTree` to the old leader-only `cmd.Process.Kill()` fails `TestCancelKillsTheWholeProcessTree` (`3 -> 11 bytes` of surviving grandchild heartbeat), and stubbing the pgid to 0 fails `TestPgidIsCapturedAtStartNotAtKillTime`.

## NOT verified

- **No Windows box was available.** The Job Object path is covered only by the fake-backed contract test plus a clean `GOOS=windows` vet and test-binary cross-compile. `CREATE_SUSPENDED` + `AssignProcessToJobObject` + resume-by-thread-enumeration (os/exec closes the primary thread handle, so threads are re-opened via `CreateToolhelp32Snapshot`) has **never been executed on a real Windows host in this branch**. The RDS assignment-denial degradation path likewise.
- **`./internal/executor` has never run in the Windows CI job before this PR.** A static audit of every test in the package found no Windows-hostile assertion (everything either self-skips on `runtime.GOOS`/`LookPath` or is pure logic), and the test binary cross-compiles — but the first real evidence is this PR's own Windows job.
- No integration/E2E coverage of the server↔agent round trip: W02/W03 are not merged, so nothing on `main` yet sends a `script_cancel` command.
- macOS/Linux tests requiring `/bin/bash` self-skip where it is absent; they did run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYjgvDNw7Qk8SFaBX6kdEx
