### PR TITLE
chore(web): What's New 0.110.0 — script cancellation is not user-facing yet

### DIFF
--- a/apps/web/src/lib/whatsNew.ts
+++ b/apps/web/src/lib/whatsNew.ts
@@ -26,7 +26,7 @@ export const WHATS_NEW_ENTRIES: WhatsNewEntry[] = [
       'Contracts can bill by device role or device group, with included quantities and overage. Every generated invoice records exactly which devices it billed, and an optional "Billed devices" appendix can print on the PDF. Quotes price by device set too.',
       'QuickBooks Online: push issued invoices, and payments recorded in QuickBooks flow back onto the Breeze invoice automatically.',
       'The customer portal grew Security, Backups, Devices, Tickets with SLA badges, and Reports pages, each behind a per-organization visibility toggle you control.',
-      'Cancel a running script or automation from Executions, set AI budget alert thresholds, and see AI agent impact and graduation evidence before widening an agent\'s autonomy.',
+      'Run a script again from its history, run scripts as the logged-in user, write device custom fields from script output, set AI budget alert thresholds, and see AI agent impact and graduation evidence before widening an agent\'s autonomy.',
     ],
     learnMoreUrl: 'https://breezermm.com/release-notes',
   },


### PR DESCRIPTION
Follow-up to #4975. The 0.110.0 What's New highlight claimed "Cancel a running script or automation from Executions"; only the cancellation foundation (#4788 status maps, #4799 schema + `script_cancel` command registration) shipped in v0.110.0 — there is no Cancel control yet. Reworded to what actually shipped. The v0.110.0 web image already carries the old text; this lands for the next build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018KGxWJkgKPTuLdjANQAfMs