### PR TITLE
fix(api): device diagnose 500s on bigint metric columns (#4974)

### DIFF
--- a/apps/api/src/routes/devices/diagnose.test.ts
+++ b/apps/api/src/routes/devices/diagnose.test.ts
@@ -46,6 +46,39 @@ import { getDeviceWithOrgAndSiteCheck, SITE_ACCESS_DENIED } from './helpers';
 import { executeCommand } from '../../services/commandQueue';
 import { diagnoseRoutes } from './diagnose';
 
+/** Fluent mock for db.select(...).from(t).where(...)[.orderBy(...)].limit(n) */
+function mockSelectChain(result: unknown) {
+  const terminal = { limit: vi.fn().mockResolvedValue(result) };
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({ orderBy: vi.fn().mockReturnValue(terminal), ...terminal }),
+    }),
+  } as any;
+}
+
+const DEVICE_ID = '11111111-2222-4333-8444-555555555555';
+
+/**
+ * A device_metrics row as Drizzle actually returns it: the throughput columns
+ * are `bigint(..., { mode: 'bigint' })`, so they arrive as native BigInt.
+ */
+function metricsRow(capturedAt: string) {
+  return {
+    timestamp: new Date(capturedAt),
+    cpuPercent: 12.5,
+    ramPercent: 48.25,
+    ramUsedMb: 7900,
+    diskPercent: 61.5,
+    diskUsedGb: 310.25,
+    diskActivityAvailable: true,
+    processCount: 312,
+    diskReadBps: 2048n,
+    diskWriteBps: 4096n,
+    bandwidthInBps: 1200n,
+    bandwidthOutBps: 900n,
+  };
+}
+
 describe('device diagnose route', () => {
   let app: Hono;
 
@@ -66,5 +99,94 @@ describe('device diagnose route', () => {
     expect(res.status).toBe(403);
     expect(executeCommand).not.toHaveBeenCalled();
     expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('serialises recent metrics whose bigint counters arrive as native BigInt', async () => {
+    vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({
+      id: DEVICE_ID,
+      hostname: 'macbook-pro',
+      osType: 'darwin',
+      osVersion: '15.3',
+      status: 'online',
+    } as never);
+    vi.mocked(executeCommand).mockResolvedValue({
+      status: 'completed',
+      stdout: JSON.stringify({
+        imageBase64: 'zXNlZw==',
+        width: 1920,
+        height: 1080,
+        capturedAt: '2026-09-05T12:00:00.000Z',
+      }),
+    } as never);
+    vi.mocked(db.select)
+      .mockReturnValueOnce(mockSelectChain([{ cpuModel: 'Apple M3', cpuCores: 8 }]))
+      .mockReturnValueOnce(mockSelectChain([
+        metricsRow('2026-09-05T12:00:00.000Z'),
+        metricsRow('2026-09-05T11:55:00.000Z'),
+      ]))
+      .mockReturnValueOnce(mockSelectChain([]));
+
+    const res = await app.request(`/devices/${DEVICE_ID}/diagnose`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.screenshot.imageBase64).toBe('zXNlZw==');
+    expect(body.recentMetrics).toHaveLength(2);
+    expect(body.recentMetrics[0]).toMatchObject({
+      cpuPercent: 12.5,
+      ramPercent: 48.25,
+      diskPercent: 61.5,
+      diskReadBps: 2048,
+      diskWriteBps: 4096,
+      bandwidthInBps: 1200,
+      bandwidthOutBps: 900,
+    });
+
+    for (const metric of body.recentMetrics) {
+      for (const [field, value] of Object.entries(metric)) {
+        expect(typeof value, `${field} must not reach the response as BigInt`).not.toBe('bigint');
+      }
+    }
+  });
+
+  it('tolerates null throughput counters', async () => {
+    vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({
+      id: DEVICE_ID,
+      hostname: 'macbook-pro',
+      osType: 'darwin',
+      osVersion: '15.3',
+      status: 'online',
+    } as never);
+    vi.mocked(executeCommand).mockResolvedValue({ status: 'completed', stdout: '{}' } as never);
+    vi.mocked(db.select)
+      .mockReturnValueOnce(mockSelectChain([]))
+      .mockReturnValueOnce(mockSelectChain([{
+        ...metricsRow('2026-09-05T12:00:00.000Z'),
+        diskActivityAvailable: null,
+        diskReadBps: null,
+        diskWriteBps: null,
+        bandwidthInBps: null,
+        bandwidthOutBps: null,
+      }]))
+      .mockReturnValueOnce(mockSelectChain([]));
+
+    const res = await app.request(`/devices/${DEVICE_ID}/diagnose`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.hardware).toBeNull();
+    expect(body.recentMetrics[0]).toMatchObject({
+      diskReadBps: null,
+      diskWriteBps: null,
+      bandwidthInBps: null,
+      bandwidthOutBps: null,
+    });
   });
 });

--- a/apps/api/src/routes/devices/diagnose.ts
+++ b/apps/api/src/routes/devices/diagnose.ts
@@ -53,8 +53,14 @@ diagnoseRoutes.post(
         return c.json({ error: 'Failed to parse screenshot data' }, 500);
       }
 
-      // Gather device context in parallel
-      const [hardware, recentMetrics, activeAlerts] = await Promise.all([
+      // Gather device context in parallel.
+      // device_metrics' throughput columns are bigint, so Drizzle hands back
+      // native BigInt values that JSON.stringify cannot serialise — c.json()
+      // would throw and collapse the whole diagnosis into a 500. Project the
+      // snapshot columns explicitly and widen the bigint rates to number.
+      // Cumulative byte/ops counters and per-interface stats remain available
+      // on GET /devices/:id, which already converts them (see core.ts).
+      const [hardware, recentMetricsRaw, activeAlerts] = await Promise.all([
         db.select({
           cpuModel: deviceHardware.cpuModel,
           cpuCores: deviceHardware.cpuCores,
@@ -62,7 +68,20 @@ diagnoseRoutes.post(
           diskTotalGb: deviceHardware.diskTotalGb,
           gpuModel: deviceHardware.gpuModel,
         }).from(deviceHardware).where(eq(deviceHardware.deviceId, deviceId)).limit(1),
-        db.select().from(deviceMetrics)
+        db.select({
+          timestamp: deviceMetrics.timestamp,
+          cpuPercent: deviceMetrics.cpuPercent,
+          ramPercent: deviceMetrics.ramPercent,
+          ramUsedMb: deviceMetrics.ramUsedMb,
+          diskPercent: deviceMetrics.diskPercent,
+          diskUsedGb: deviceMetrics.diskUsedGb,
+          diskActivityAvailable: deviceMetrics.diskActivityAvailable,
+          processCount: deviceMetrics.processCount,
+          diskReadBps: deviceMetrics.diskReadBps,
+          diskWriteBps: deviceMetrics.diskWriteBps,
+          bandwidthInBps: deviceMetrics.bandwidthInBps,
+          bandwidthOutBps: deviceMetrics.bandwidthOutBps,
+        }).from(deviceMetrics)
           .where(eq(deviceMetrics.deviceId, deviceId))
           .orderBy(desc(deviceMetrics.timestamp))
           .limit(3),
@@ -81,6 +100,15 @@ diagnoseRoutes.post(
           .orderBy(desc(alerts.triggeredAt))
           .limit(5),
       ]);
+
+      // Convert BigInt fields to numbers for JSON serialization
+      const recentMetrics = recentMetricsRaw.map(m => ({
+        ...m,
+        diskReadBps: m.diskReadBps != null ? Number(m.diskReadBps) : null,
+        diskWriteBps: m.diskWriteBps != null ? Number(m.diskWriteBps) : null,
+        bandwidthInBps: m.bandwidthInBps != null ? Number(m.bandwidthInBps) : null,
+        bandwidthOutBps: m.bandwidthOutBps != null ? Number(m.bandwidthOutBps) : null,
+      }));
 
       return c.json({
         screenshot: {


### PR DESCRIPTION
## Summary

- `POST /api/v1/devices/:id/diagnose` now projects the `device_metrics` columns it actually returns instead of `db.select()`-ing whole rows, and widens the four bigint throughput rates through `Number()` before `c.json(...)`.
- The endpoint 500'd for **every** device that had metrics rows. `device_metrics` declares ten `bigint(..., { mode: 'bigint' })` columns, Drizzle returns them as native `BigInt`, and Hono's `c.json()` calls `JSON.stringify` with no replacer.
- The throw happened *inside* the route's `try`, so the generic `catch` swallowed it and returned `500 Diagnosis failed. Please try again.` The `take_screenshot` command had already completed successfully, so the captured JPEG was discarded with it.
- `diagnose.test.ts` gains a happy-path test whose mocked metric rows carry real `BigInt` values (`2048n`, `4096n`, `1200n`, `900n`) and asserts the body serialises, plus a null-counter case. The pre-existing test mocked Drizzle with plain numbers, so it never saw a `BigInt` — that is why the route was green in CI and 500'd against a real database.
- Audited every other `device_metrics` reader under `apps/api/src/routes/`: **zero** additional at-risk sites (table in the notes below). No file other than `diagnose.ts` and its test changed.

## Root cause

`apps/api/src/routes/devices/diagnose.ts` fetched the last three metric samples with a bare `db.select().from(deviceMetrics)` and returned the rows verbatim in the response body. Ten `device_metrics` columns are declared `bigint(..., { mode: 'bigint' })` (`apps/api/src/db/schema/devices.ts:376-385`), so Drizzle's `PgBigInt.mapFromDriverValue` turns them into native `BigInt`. `JSON.stringify` has no representation for `BigInt` and throws `TypeError: Do not know how to serialize a BigInt`; Hono's `Context#json` (`hono@4.13.5`, `dist/context.js:377`) calls it with no replacer. Because that `c.json(...)` sat inside the handler's `try`, the failure was re-caught and reported as an opaque 500 — the exact frame in the issue (`diagnose.ts:85`) is the `c.json` call, not the query.

The sibling route `GET /devices/:id` (`apps/api/src/routes/devices/core.ts:1138-1163`) already does a `select()` on the same table but maps all ten bigint columns through `Number()` first, which is why only `diagnose` broke.

## Verification

All commands run in the foreground from the worktree root.

| Command | Result |
|---|---|
| `cd apps/api && npx vitest run src/routes/devices/diagnose.test.ts` (before the source fix) | **1 failed \| 2 passed (3)** — fails with `expected 500 to be 200`, and stderr reproduces the production error verbatim: `[Diagnose] Failed to diagnose device 11111111-…: TypeError: Do not know how to serialize a BigInt at JSON.stringify … at apps/api/src/routes/devices/diagnose.ts:85` |
| `cd apps/api && npx vitest run src/routes/devices/diagnose.test.ts` (after the fix) | **3 passed (3)**, 1 file |
| `cd apps/api && npx vitest run src/routes/devices/` | **632 passed (632)**, 45 files — no regression in the sibling device routes |
| `NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit -p apps/api` | **clean**, exit 0 |
| `npx eslint apps/api/src/routes/devices/diagnose.ts apps/api/src/routes/devices/diagnose.test.ts` | **clean**, exit 0, no findings |

No migration, no schema change, no tenancy/RLS surface touched, so the RLS and integration contract suites are not implicated.

## Decisions / notes for reviewer

**1. Narrowed projection rather than a full-row `Number()` map.** The issue offered either. I took the projection because it is rot-proof in the right direction: a bigint column added to `device_metrics` later simply does not appear in this response, whereas a hand-maintained conversion list silently omits it (that is how this bug shipped). Columns kept: `timestamp`, `cpuPercent`, `ramPercent`, `ramUsedMb`, `diskPercent`, `diskUsedGb`, `diskActivityAvailable`, `processCount`, and `diskReadBps` / `diskWriteBps` / `bandwidthInBps` / `bandwidthOutBps` (converted). Columns dropped: the cumulative counters `diskReadBytes`, `diskWriteBytes`, `diskReadOps`, `diskWriteOps`, `networkInBytes`, `networkOutBytes` (running totals are not interpretable across a 3-sample window), the jsonb blobs `interfaceStats` and `customMetrics`, and the identity echo `deviceId` / tenant id `orgId`.

**This is the one review-worthy judgement call.** It narrows the response shape of an endpoint with **no in-repo consumer** — I grepped `apps/web`, `apps/mobile`, `apps/portal`, `apps/viewer`, `e2e-tests`, `apps/docs` and `apps/api/src/openapi.ts` for `/diagnose` and found nothing (the route is mounted at `apps/api/src/routes/devices/index.ts:58` but is undocumented and uncalled by first-party clients). Everything dropped remains available, fully BigInt-converted, on `GET /devices/:id`, which returns 24h of samples rather than 3. If you would rather keep byte-for-byte response parity for unknown external callers, the alternative is to revert to `db.select()` and copy the ten-field `Number()` map from `core.ts:1151-1163` — say the word and I will switch it.

**2. Did not flip the schema to `mode: 'number'`** (the fix used for `software_versions.file_size` in #630). Those `device_metrics` columns are consumed as genuine `BigInt` by the agent heartbeat write path (`routes/agents/heartbeat.ts:1109`), the `alertConditions` handlers, and the `devices/metrics.ts` aggregates. Changing the mode is a far larger blast radius than a single broken endpoint warrants.

**3. `Number()` precision.** Lossless below 2^53 (~9 PB). These four fields are bytes-per-second *rates*, so no realistic value approaches that bound — the same tradeoff `core.ts` already makes for the cumulative counters.

### Audit: other `device_metrics` readers under `apps/api/src/routes/`

Requested by the issue. **No additional at-risk site found**; nothing else was changed.

Key finding that makes most of these safe: the driver is `drizzle-orm/postgres-js` (`apps/api/src/db/index.ts:8-9`) and there is **no int8 type-parser override anywhere** in `apps/api/src` (grepped `setTypeParser` / `parseInt8` — zero hits). `postgres` registers number parsers only for OIDs 21/23/26/700/701, so OID 20 (`int8`) aggregate results arrive as JS **strings**, not `BigInt`. Drizzle's bigint mapper only fires for `bigint({mode:'bigint'})` *table columns* selected through the column object, never for `sql<bigint>\`…\`` fragments. So the 500 risk is exclusive to full-row / bigint-column selects.

| Site | Route | Verdict | Why |
|---|---|---|---|
| `devices/diagnose.ts:65` | POST `/devices/:id/diagnose` | **was AT-RISK — fixed here** | bare `select()` returned ten BigInt columns verbatim |
| `devices/core.ts:1138-1163` | GET `/devices/:id` | SAFE | `select()` but all ten bigint keys overridden with `Number()` |
| `devices/metrics.ts:126-160` | GET `/devices/:id/metrics` | SAFE | `sql<bigint>` sums ⇒ strings; both raw and rollup paths funnel through `aggregateMetricsByInterval`, which `Number()`s every `total*` field (`:196-203`, `:253-260`) |
| `analytics.ts:474-511` | POST `/analytics/query` | SAFE | metric map includes bigint columns but aggregation is in `sql<>` and output is `Number(row.value)` |
| `analytics.ts:1444-1485` | GET `/analytics/capacity` | SAFE | cpu/ram/disk percent only, `Number(row.value)` |
| `reports/data.ts:675-700` | GET `/reports/data/metrics` | SAFE | explicit projection of non-bigint columns only |
| `metrics.ts:1449-1457` | GET `/metrics/trends` | SAFE | `avg(cpuPercent)` / `avg(ramPercent)` only |
| `agents/heartbeat.ts:1109` | agent heartbeat | SAFE | insert-only; BigInt values written, never echoed in a response |
| `monitoring.ts:363` | GET `/monitoring/assets/:id/snmp` | SAFE (false positive) | reads `snmpMetrics`, not `deviceMetrics`; `monitoring.ts` has zero `deviceMetrics` references and `snmp_metrics.value` is `text` |

`metricRollups` (`db/schema/analytics.ts:33-51`) has no bigint columns, so rollup-sourced responses are BigInt-free by construction.

**One latent item worth a follow-up issue (not fixed here, out of scope):** `services/tenantExport.ts:97` dumps `device_metrics` rows — all ten int8 columns are in the export policy (`services/tenantExportPolicyRegistry.ts:188`) — through a bare `JSON.stringify(rows, null, 2)` with no bigint replacer. It survives today only because `readOrgRows` uses `db.execute(sql\`SELECT …\`)` raw SQL, so int8 arrives as strings. Converting that read to a Drizzle column select would 500 the tenant export. Same bug class, different trigger.

### Toolchain note

The dispatch instructions said to use Node from `$HOME/.nvm/versions/node/v22.20.0/bin`, but that directory does not exist on this machine (`ls` returns no such file). Everything above ran on the available Homebrew Node v22.23.2. `tsc -p apps/api` aborts with a V8 heap OOM (exit 134) on the default heap, so it needs `NODE_OPTIONS=--max-old-space-size=8192` — that is a pre-existing property of the workspace, not something this PR introduces.

Closes #4974

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code) via [Claude Code](https://claude.com/claude-code)