### PR TITLE
fix(admin): resolve AI kill-switch actor to a name (#4931)

### DIFF
--- a/apps/api/src/routes/admin/aiKillState.test.ts
+++ b/apps/api/src/routes/admin/aiKillState.test.ts
@@ -79,6 +79,8 @@ const ROW = {
   epoch: 4,
   reason: 'restored after incident 123',
   updatedBy: 'admin-0',
+  updatedByName: 'Ada Lovelace',
+  updatedByEmail: 'ada@breeze.test',
   updatedAt: new Date('2026-08-28T12:00:00Z'),
 };
 
@@ -139,10 +141,42 @@ describe('admin AI kill-state routes', () => {
           epoch: 4,
           reason: 'restored after incident 123',
           updatedBy: 'admin-0',
+          updatedByName: 'Ada Lovelace',
+          updatedByEmail: 'ada@breeze.test',
           updatedAt: '2026-08-28T12:00:00.000Z',
         },
       });
       expect(readRowMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps updatedBy alongside the resolved actor name (#4931)', async () => {
+      // The UI shows the name and puts the UUID in a tooltip, so both must
+      // survive: dropping `updatedBy` would break the existing client and
+      // leave nothing to disambiguate two admins with the same display name.
+      const res = await buildApp(platformAdmin).request('/admin/ai-kill-state');
+      const { data } = await res.json() as { data: Record<string, unknown> };
+      expect(data.updatedBy).toBe('admin-0');
+      expect(data.updatedByName).toBe('Ada Lovelace');
+      expect(data.updatedByEmail).toBe('ada@breeze.test');
+    });
+
+    it('returns null name/email when the actor no longer resolves (#4931)', async () => {
+      // A deleted user, or a row flipped by ops through the SQL fallback in
+      // docs/deploy/ai-kill-switch.md (updated_by NULL). The route must still
+      // 200 with the kill state — never 500, never a synthesized display name.
+      readRowMock.mockResolvedValue({
+        ...ROW,
+        updatedBy: 'admin-gone',
+        updatedByName: null,
+        updatedByEmail: null,
+      });
+
+      const res = await buildApp(platformAdmin).request('/admin/ai-kill-state');
+      expect(res.status).toBe(200);
+      const { data } = await res.json() as { data: Record<string, unknown> };
+      expect(data.updatedBy).toBe('admin-gone');
+      expect(data.updatedByName).toBeNull();
+      expect(data.updatedByEmail).toBeNull();
     });
   });
 

--- a/apps/api/src/routes/admin/aiKillState.ts
+++ b/apps/api/src/routes/admin/aiKillState.ts
@@ -4,6 +4,10 @@
  *   GET  /api/v1/admin/ai-kill-state          state + epoch + provenance
  *   POST /api/v1/admin/ai-kill-state          flip it (+ MFA, reason required)
  *
+ * The GET's provenance carries the actor as a resolved name/email alongside
+ * the raw `updatedBy` UUID (`readAiKillStateRow`, #4931) — both null when the
+ * user row is gone, which the UI degrades to the UUID rather than a blank.
+ *
  * This is the first AUTHORIZED write surface for `ai_kill_state` — the row
  * shipped in wave 5A with `bumpAiKillState` deliberately uncalled, leaving a
  * direct SQL UPDATE as the only operational path. WHY PLATFORM-ADMIN ONLY:

--- a/apps/api/src/services/aiKillState.test.ts
+++ b/apps/api/src/services/aiKillState.test.ts
@@ -6,12 +6,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 vi.mock('../db', () => {
   const limit = vi.fn();
   const returning = vi.fn();
+  // `from()` answers BOTH chain shapes in this module: the hot-path
+  // `selectGlobalRow` goes straight to `.where()`, while `readAiKillStateRow`
+  // joins `users` first to resolve the actor's UUID (#4931).
+  const leftJoin = vi.fn(() => ({ where: () => ({ limit }) }));
   return {
     db: {
-      select: () => ({ from: () => ({ where: () => ({ limit }) }) }),
+      select: () => ({ from: () => ({ leftJoin, where: () => ({ limit }) }) }),
       update: () => ({ set: () => ({ where: () => ({ returning }) }) }),
       __limit: limit,
       __returning: returning,
+      __leftJoin: leftJoin,
     },
     getCurrentDbAccessContext: vi.fn(() => undefined),
     runOutsideDbContext: vi.fn(<T,>(fn: () => T): T => fn()),
@@ -37,10 +42,16 @@ async function getReturningMock() {
   return (mod.db as unknown as { __returning: ReturnType<typeof vi.fn> }).__returning;
 }
 
+async function getLeftJoinMock() {
+  const mod = await import('../db');
+  return (mod.db as unknown as { __leftJoin: ReturnType<typeof vi.fn> }).__leftJoin;
+}
+
 beforeEach(async () => {
   _resetAiKillStateCacheForTest();
   (await getLimitMock()).mockReset();
   (await getReturningMock()).mockReset();
+  (await getLeftJoinMock()).mockClear();
 });
 
 afterEach(() => {
@@ -68,6 +79,19 @@ describe('readAiKillState', () => {
 
     expect(await readAiKillState()).toEqual({ killed: true, epoch: 3 });
     expect(getCachedAiKillStateSnapshot()).toEqual({ killed: true, epoch: 3 });
+  });
+
+  it('stays join-free: the actor resolution belongs to the admin read only (#4931)', async () => {
+    // readAiKillState is the guardrail hot path (every run admission and every
+    // act-mode dispatch). Resolving a display name there would add a users join
+    // to a query whose only job is killed/epoch — and a deleted actor must
+    // never be able to affect the kill state it returns.
+    const limit = await getLimitMock();
+    const leftJoin = await getLeftJoinMock();
+    limit.mockResolvedValueOnce([{ killed: true, epoch: 3 }]);
+
+    expect(await readAiKillState()).toEqual({ killed: true, epoch: 3 });
+    expect(leftJoin).not.toHaveBeenCalled();
   });
 
   it('fails closed on a DB read error: caches { killed: true, epoch: -1 }, never throws', async () => {
@@ -151,6 +175,58 @@ describe('readAiKillStateRow', () => {
     // The admin read is a side-channel: the guardrail cache must stay at its
     // default until readAiKillState() itself runs.
     expect(getCachedAiKillStateSnapshot()).toEqual({ killed: false, epoch: 0 });
+  });
+
+  it('resolves the actor UUID to a name + email in the same system-scoped read (#4931)', async () => {
+    // The admin page used to render `updatedBy` raw, so the one platform-wide
+    // control whose audit trail justifies its mandatory reason field showed a
+    // UUID as its actor. The resolution rides the existing system-scoped read
+    // (one round trip, and system scope is what makes an actor from ANOTHER
+    // partner's user row visible — `breeze_has_partner_access` short-circuits).
+    const limit = await getLimitMock();
+    const leftJoin = await getLeftJoinMock();
+    limit.mockResolvedValueOnce([{
+      killed: true,
+      epoch: 7,
+      reason: 'incident 42',
+      updatedBy: 'admin-1',
+      updatedByName: 'Ada Lovelace',
+      updatedByEmail: 'ada@breeze.test',
+      updatedAt: new Date('2026-08-28T12:00:00Z'),
+    }]);
+
+    await expect(readAiKillStateRow()).resolves.toMatchObject({
+      updatedBy: 'admin-1',
+      updatedByName: 'Ada Lovelace',
+      updatedByEmail: 'ada@breeze.test',
+    });
+    expect(leftJoin).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes an unresolvable actor through as nulls — no synthesized fallback (#4931)', async () => {
+    // A deleted user, or a row flipped by ops via SQL (updated_by left NULL),
+    // must still return the kill state: the join is a LEFT one, and the service
+    // does not invent a display string. Falling back to the raw UUID is the
+    // UI's job (AiKillSwitch.tsx), which keeps "unresolved" distinguishable
+    // from "a user actually named like a UUID" for every other consumer.
+    const limit = await getLimitMock();
+    limit.mockResolvedValueOnce([{
+      killed: false,
+      epoch: 2,
+      reason: 'sql fallback flip',
+      updatedBy: 'admin-gone',
+      updatedByName: null,
+      updatedByEmail: null,
+      updatedAt: new Date('2026-08-28T12:00:00Z'),
+    }]);
+
+    await expect(readAiKillStateRow()).resolves.toMatchObject({
+      killed: false,
+      epoch: 2,
+      updatedBy: 'admin-gone',
+      updatedByName: null,
+      updatedByEmail: null,
+    });
   });
 
   it('escapes a request-scoped ambient context via runOutsideDbContext (load-bearing)', async () => {

--- a/apps/api/src/services/aiKillState.ts
+++ b/apps/api/src/services/aiKillState.ts
@@ -54,6 +54,7 @@ import {
   withSystemDbAccessContext,
 } from '../db';
 import { aiKillState as aiKillStateTable } from '../db/schema/aiKillState';
+import { users } from '../db/schema/users';
 
 export interface AiKillStateSnapshot {
   killed: boolean;
@@ -145,6 +146,11 @@ export function getCachedAiKillStateSnapshot(): AiKillStateSnapshot {
 export interface AiKillStateAdminRow extends AiKillStateSnapshot {
   reason: string | null;
   updatedBy: string | null;
+  /** Actor's `users.name`, resolved in the same read. NULL when `updatedBy` is
+   *  NULL or its user row no longer exists — never synthesized (#4931). */
+  updatedByName: string | null;
+  /** Actor's `users.email`, same resolution and same NULL contract (#4931). */
+  updatedByEmail: string | null;
   updatedAt: Date;
 }
 
@@ -157,6 +163,18 @@ export interface AiKillStateAdminRow extends AiKillStateSnapshot {
  * by `readAiKillState` alone). No fail-closed synthesis either: a missing
  * seed row here is a deployment bug the admin should see as an error, not a
  * synthetic `killed: true` that reads like a real state.
+ *
+ * ACTOR RESOLUTION (#4931): `updated_by` is a bare UUID with no FK (ops may
+ * flip the row through the SQL fallback in `docs/deploy/ai-kill-switch.md`),
+ * and the admin page used to render it raw — the one platform-wide control
+ * whose audit trail justifies its mandatory reason field showed an anonymous
+ * UUID as its actor. The name/email come from a LEFT JOIN in this same query:
+ * one round trip, and it runs under the system scope this read already opens,
+ * which is load-bearing — the actor is whichever platform admin last flipped
+ * the switch, and their `users` row may sit under a different partner than the
+ * caller's, where `breeze_user_isolation_select` would hide it from an
+ * org/partner-scoped read. LEFT (not inner) so an unresolvable actor degrades
+ * to NULL name/email instead of dropping the kill state itself.
  */
 export async function readAiKillStateRow(): Promise<AiKillStateAdminRow> {
   const query = () =>
@@ -166,9 +184,12 @@ export async function readAiKillStateRow(): Promise<AiKillStateAdminRow> {
         epoch: aiKillStateTable.epoch,
         reason: aiKillStateTable.reason,
         updatedBy: aiKillStateTable.updatedBy,
+        updatedByName: users.name,
+        updatedByEmail: users.email,
         updatedAt: aiKillStateTable.updatedAt,
       })
       .from(aiKillStateTable)
+      .leftJoin(users, eq(users.id, aiKillStateTable.updatedBy))
       .where(eq(aiKillStateTable.id, 'global'))
       .limit(1);
 

--- a/apps/web/src/components/admin/AiKillSwitch.test.tsx
+++ b/apps/web/src/components/admin/AiKillSwitch.test.tsx
@@ -22,7 +22,9 @@ const activeRow = {
   killed: false,
   epoch: 4,
   reason: 'restored after incident 123',
-  updatedBy: 'admin-0',
+  updatedBy: '11111111-1111-4111-8111-111111111111',
+  updatedByName: 'Ada Lovelace',
+  updatedByEmail: 'ada@breeze.test',
   updatedAt: '2026-08-28T12:00:00.000Z',
 };
 
@@ -30,7 +32,9 @@ const killedRow = {
   killed: true,
   epoch: 5,
   reason: 'suspected prompt injection',
-  updatedBy: 'admin-1',
+  updatedBy: '22222222-2222-4222-8222-222222222222',
+  updatedByName: 'Grace Hopper',
+  updatedByEmail: 'grace@breeze.test',
   updatedAt: '2026-09-01T09:00:00.000Z',
 };
 
@@ -62,8 +66,51 @@ describe('AiKillSwitch', () => {
     render(<AiKillSwitch />);
     await waitFor(() => expect(screen.getByTestId('ai-kill-switch-status-badge').textContent).toMatch(/active/i));
     expect(screen.getByTestId('ai-kill-switch-epoch').textContent).toContain('4');
-    expect(screen.getByTestId('ai-kill-switch-updated-by').textContent).toContain('admin-0');
+    expect(screen.getByTestId('ai-kill-switch-updated-by').textContent).toContain('Ada Lovelace');
     expect(screen.getByTestId('ai-kill-switch-last-reason').textContent).toContain('restored after incident 123');
+  });
+
+  it('shows the actor NAME, not the raw UUID, with the UUID in a tooltip (#4931)', async () => {
+    // This is the one platform-wide control whose audit trail justifies its
+    // mandatory reason field, so the actor has to be a human-readable name.
+    // The UUID stays reachable via `title` for disambiguation and for matching
+    // the row against the audit log.
+    mockApi(activeRow);
+    render(<AiKillSwitch />);
+    const updatedBy = await screen.findByTestId('ai-kill-switch-updated-by');
+    await waitFor(() => expect(updatedBy.textContent).toBe('Ada Lovelace'));
+    expect(updatedBy.textContent).not.toContain('11111111-1111-4111-8111-111111111111');
+    expect(updatedBy.getAttribute('title')).toBe('11111111-1111-4111-8111-111111111111');
+  });
+
+  it('falls back to the email when the actor has no usable name (#4931)', async () => {
+    mockApi({ ...activeRow, updatedByName: '   ' });
+    render(<AiKillSwitch />);
+    const updatedBy = await screen.findByTestId('ai-kill-switch-updated-by');
+    await waitFor(() => expect(updatedBy.textContent).toBe('ada@breeze.test'));
+    expect(updatedBy.getAttribute('title')).toBe('11111111-1111-4111-8111-111111111111');
+  });
+
+  it('falls back to the raw UUID when the actor no longer resolves (#4931)', async () => {
+    // A deleted user, or a row flipped by ops through the documented SQL
+    // fallback (updated_by NULL). The API returns nulls rather than inventing a
+    // display string, so the field must degrade to the UUID instead of going
+    // blank — an empty "Last changed by" next to a filled-in reason reads like
+    // a missing audit trail.
+    mockApi({ ...activeRow, updatedByName: null, updatedByEmail: null });
+    render(<AiKillSwitch />);
+    const updatedBy = await screen.findByTestId('ai-kill-switch-updated-by');
+    await waitFor(() => expect(updatedBy.textContent).toBe('11111111-1111-4111-8111-111111111111'));
+    // Nothing to disambiguate — no tooltip duplicating the visible text.
+    expect(updatedBy.getAttribute('title')).toBeNull();
+  });
+
+  it('renders the em-dash placeholder when the switch has never been flipped (#4931)', async () => {
+    mockApi({ ...activeRow, epoch: 0, reason: null, updatedBy: null, updatedByName: null, updatedByEmail: null });
+    render(<AiKillSwitch />);
+    const updatedBy = await screen.findByTestId('ai-kill-switch-updated-by');
+    await waitFor(() => expect(updatedBy.textContent).toBe('—'));
+    expect(updatedBy.getAttribute('title')).toBeNull();
   });
 
   it('renders the killed state', async () => {

--- a/apps/web/src/components/admin/AiKillSwitch.tsx
+++ b/apps/web/src/components/admin/AiKillSwitch.tsx
@@ -13,10 +13,24 @@ interface AiKillStateRow {
   epoch: number;
   reason: string | null;
   updatedBy: string | null;
+  updatedByName: string | null;
+  updatedByEmail: string | null;
   updatedAt: string;
 }
 
 const MIN_REASON_LENGTH = 3;
+
+/**
+ * Actor label for "Last changed by" (#4931). The API resolves `updatedBy` to a
+ * name + email server-side, but both come back null for a deleted user or a row
+ * flipped through the documented SQL fallback (`updated_by` NULL) — so degrade
+ * to the raw UUID rather than showing nothing next to a filled-in reason.
+ * Blank-but-present names are treated as absent; `users.name` is NOT NULL but
+ * not non-empty.
+ */
+function actorLabel(row: AiKillStateRow): string | null {
+  return row.updatedByName?.trim() || row.updatedByEmail?.trim() || row.updatedBy;
+}
 
 /**
  * Platform-admin UI for the global AI kill switch (#4208, follow-up to #3828 /
@@ -137,6 +151,12 @@ export default function AiKillSwitch() {
   }
 
   const canSubmit = reason.trim().length >= MIN_REASON_LENGTH && !submitting;
+  const actor = row ? actorLabel(row) : null;
+  const actorUuid = row?.updatedBy ?? null;
+  // Tooltip carries the UUID only when it is NOT the visible label: two admins
+  // can share a display name, and the UUID is what matches this row against the
+  // audit log. Duplicating it when the actor never resolved adds nothing.
+  const actorTitle = actor && actorUuid && actor !== actorUuid ? actorUuid : undefined;
 
   return (
     <div className="p-6">
@@ -178,7 +198,9 @@ export default function AiKillSwitch() {
             <dt className="text-gray-500">{t('admin.aiKillSwitch.fields.epoch')}</dt>
             <dd data-testid="ai-kill-switch-epoch" className="font-mono">{row.epoch}</dd>
             <dt className="text-gray-500">{t('admin.aiKillSwitch.fields.updatedBy')}</dt>
-            <dd data-testid="ai-kill-switch-updated-by">{row.updatedBy ?? t('admin.aiKillSwitch.fields.none')}</dd>
+            <dd data-testid="ai-kill-switch-updated-by" title={actorTitle}>
+              {actor ?? t('admin.aiKillSwitch.fields.none')}
+            </dd>
             <dt className="text-gray-500">{t('admin.aiKillSwitch.fields.updatedAt')}</dt>
             <dd data-testid="ai-kill-switch-updated-at">
               {row.updatedAt ? new Date(row.updatedAt).toLocaleString() : t('admin.aiKillSwitch.fields.none')}

--- a/docs/deploy/ai-kill-switch.md
+++ b/docs/deploy/ai-kill-switch.md
@@ -36,7 +36,9 @@ Platform admins can flip the switch from **Administration → AI Kill Switch**
 in the web console (`/admin/ai-kill-switch`), backed by the same API as Path
 1a below. The page shows the current state, epoch, and last reason/provenance,
 and requires a reason on every flip (surfaced as a friendly prompt if MFA
-step-up is needed).
+step-up is needed). "Last changed by" shows the actor's **name** (email if they
+have none) with the raw user UUID in a tooltip; a flip made through the SQL
+fallback below leaves `updated_by` NULL, so the field reads `—`.
 
 > **Production caveat (flagged 2026-08-26): production currently has ZERO
 > platform admins in both regions**, so all `/admin/*` surfaces — including


### PR DESCRIPTION
## Summary
- `GET /api/v1/admin/ai-kill-state` now returns `updatedByName` and `updatedByEmail` alongside the existing `updatedBy` UUID, resolved from `users` in the same query.
- `/admin/ai-kill-switch` renders "Last changed by" as the actor's **name** (email when the name is blank/absent) with the raw UUID in a `title` tooltip; it degrades to the UUID, then to an em dash, rather than going blank.
- Resolution rides the **system-scoped** read the admin GET already opens, so an actor whose `users` row belongs to a different partner than the caller still resolves. It is a LEFT JOIN, so a deleted user or an ops SQL flip (`updated_by` NULL) returns nulls instead of dropping the kill-state row.
- The hot-path cached read (`readAiKillState`) is untouched and stays join-free — a deleted actor cannot influence the kill state it hands the guardrails.
- No schema/migration change, no new tenancy surface, no locale-key change (the existing `fields.updatedBy` / `fields.none` keys cover it; a UUID tooltip is not translatable).

## Root cause
`ai_kill_state.updated_by` is a bare UUID with no FK — deliberately, so ops can flip the row through the SQL fallback documented in `docs/deploy/ai-kill-switch.md`. `readAiKillStateRow` selected that column verbatim and `AiKillSwitch.tsx` rendered `row.updatedBy` straight into the `<dd>`, so the only actor attribution on the platform's single most consequential AI control was an opaque identifier.

Nothing in the DTO ever joined `users`, and the web client cannot resolve one itself: `users` is dual-axis RLS (tenancy shape 4), so a partner/org-scoped read under the admin's own session would not reliably see another platform admin's row. The resolution had to happen server-side, under system scope.

## Verification
All commands run in the foreground from the worktree root; Node 22.23.2.

| Command | Result |
|---|---|
| `cd apps/api && npx vitest run src/services/aiKillState.test.ts src/routes/admin/aiKillState.test.ts` | 2 files, **32 passed** |
| `cd apps/api && npx vitest run aiKillState actRevalidation` | 4 files, **78 passed** |
| `cd apps/api && npx vitest run src/routes/admin` | 11 files, **170 passed** |
| `cd apps/web && npx vitest run src/components/admin/AiKillSwitch.test.tsx` | 1 file, **11 passed** |
| `cd apps/web && npx vitest run src/components/admin` | 5 files, **65 passed** |
| `NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit --project apps/api/tsconfig.json` | **clean** (exit 0) |
| `cd apps/web && npx astro check` | **0 errors, 0 warnings** (252 pre-existing hints across 1877 files) |
| `npx eslint` over all 6 changed source/test files | **clean** |

TDD order was followed: the service test (asserting `leftJoin` is called on the admin read) and three web tests (name label, email fallback, UUID tooltip) were written first and observed failing — 1 API failure and 3 web failures — before the implementation landed.

## Decisions / notes for reviewer
- **Field names:** `updatedByName` / `updatedByEmail` rather than the `lastChangedByName` / `lastChangedByEmail` floated in the dispatch note. The existing DTO columns are `updatedBy` / `updatedAt`, and "Last changed by" is already the en label for `fields.updatedBy`, so the new fields follow the column they resolve. `updatedBy` is retained unchanged for compatibility — and the UI still needs it, both for the tooltip and to disambiguate two admins who share a display name.
- **Nulls, not a synthesized fallback:** the API returns `updatedByName: null` for an unresolvable actor instead of echoing the UUID as though it were a name. That keeps "unresolved" distinguishable from "a user actually named like a UUID" for any future consumer (CSV export, AI tools), and puts the display fallback where the display strings live. The UI chain is name, then email, then UUID, then em dash.
- **Blank names count as absent** — `users.name` is `NOT NULL` but not non-empty, so a whitespace-only name falls through to the email rather than rendering an empty field.
- **RLS reasoning was read, not assumed:** `breeze_has_partner_access` short-circuits to `TRUE` when `breeze_current_scope() = 'system'` (`apps/api/migrations/2026-04-11-a-rls-function-bootstrap.sql:111`), which is what makes the joined `users` row visible under `breeze_user_isolation_select`. The exposure is one actor's name and email, to a caller who already passed `platformAdminMiddleware` and who already sees `actorEmail` on the audit-log surface that joins `users` the same way (`apps/api/src/routes/auditLogs.ts:349`).
- **No cascade / export-policy registration needed:** no new table, and no new column on any `org_id`-bearing table. `ai_kill_state` is system-scoped and stays that way; this change is read-side only.
- **No DB-backed integration test.** This route has no integration coverage today and no Postgres was reachable from this worktree, so the LEFT JOIN's null tolerance is pinned at three levels instead: the query chain (mocked `db` — asserts the join happens on the admin read and *not* on the hot path), the route DTO, and the component render. If a maintainer wants real-DB proof, the natural home is a new `aiKillStateAdmin.integration.test.ts`; happy to add it on request.
- **Flagged, deliberately not changed:** `handleFlip` applies the POST's `killed`/`epoch` optimistically and lets provenance lag until the confirmatory refetch. If that refetch fails, the card now shows a stale *human name* where it used to show a stale UUID. That path already renders a red "Failed to load kill switch state" banner directly above the card, and blanking provenance there is a separate behaviour change with its own test surface — out of scope for a display fix, but worth a follow-up if you read it differently.
- **Context:** per `docs/deploy/ai-kill-switch.md`, production currently has zero platform admins, so this page is unreachable there today; the fix lands ahead of that changing. Found in the v0.109.0-to-main pre-release sweep (#4704, Group 3). The runbook's UI section was updated to describe the new label/tooltip behaviour.

Closes #4931

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code) via [Claude Code](https://claude.com/claude-code)
