### PR TITLE
fix(portal): redirect disabled visibility pages instead of erroring (#4932)

### DIFF
--- a/apps/docs/src/content/docs/features/portal.mdx
+++ b/apps/docs/src/content/docs/features/portal.mdx
@@ -61,7 +61,7 @@ To change them:
 You need the **Organizations: write** permission and a multi-factor confirmation to change these.
 
 <Aside type="note" title="Turned off means genuinely off">
-  Visibility is enforced on the server, not just in the portal's navigation. A section that is off is hidden from the menu **and** refused by the API, so a customer who bookmarks the URL or edits it by hand gets an "unavailable" page rather than a partial one. An organization that has never had portal settings saved is treated exactly like one with every toggle off — it fails closed, never open.
+  Visibility is enforced on the server, not just in the portal's navigation. A section that is off is hidden from the menu **and** refused by the API, so a customer who bookmarks the URL or edits it by hand is taken back to their proposals instead of being shown a page that looks like it failed to load. An organization that has never had portal settings saved is treated exactly like one with every toggle off — it fails closed, never open.
 </Aside>
 
 ### Ticket Statuses
@@ -193,7 +193,7 @@ With **Reports** visibility on, the customer can generate and download reports t
 
 A finished run offers both **PDF** and **CSV** downloads. These are the same report types described in [Reports](/features/reports/); only the trigger is different.
 
-With Reports off, a customer who navigates to the reports URL is redirected back to their devices.
+With Reports off, a customer who navigates to the reports URL is redirected to their proposals — the same as every other section that is off.
 
 ---
 

--- a/apps/portal/src/lib/disabledPageCoverage.test.ts
+++ b/apps/portal/src/lib/disabledPageCoverage.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Contract test: a portal page whose data comes from behind a visibility gate
+ * MUST branch on the gate's 403 code in its frontmatter instead of falling
+ * through to its generic "we couldn't load this" copy.
+ *
+ * Without the branch, an MSP switching a toggle off in Settings → Organizations
+ * → Customer Portal hands the customer a page that reads as a transient failure
+ * and invites a support ticket about a switch that was deliberate (#4932). Only
+ * /reports got the branch; Security, Backups, Dashboard, Devices and Equipment
+ * all shipped the misleading copy, and nothing in review caught the fifth one.
+ *
+ * Frontmatter, not the template: the answer to a switched-off page is a 302 the
+ * server returns before it renders anything, so a check written into the markup
+ * would still ship the page shell. The API side is already fail-closed and
+ * unit-tested (apps/api/src/routes/portal/featureFlags.test.ts) — this guards
+ * the half that renders. sessionClearCoverage.test.ts is the same idea for 401s.
+ */
+
+const PAGES = fileURLToPath(new URL('../pages', import.meta.url));
+
+/** portalApi methods that sit behind a visibility/feature gate, and the 403
+ *  code the gate answers with (apps/api/src/routes/portal/index.ts). */
+const GATED_API_METHODS: Record<string, string> = {
+  getDashboard: 'PORTAL_DASHBOARD_DISABLED',
+  getSecurityOverview: 'PORTAL_SECURITY_DISABLED',
+  getSecurityDevices: 'PORTAL_SECURITY_DISABLED',
+  getBackupOverview: 'PORTAL_BACKUPS_DISABLED',
+  getBackupDevices: 'PORTAL_BACKUPS_DISABLED',
+  getReportRuns: 'PORTAL_REPORTS_DISABLED',
+  getSupportUsage: 'PORTAL_SUPPORT_USAGE_DISABLED',
+  getDevices: 'PORTAL_SELF_SERVICE_DISABLED',
+  getAssets: 'PORTAL_ASSET_CHECKOUT_DISABLED',
+  getTickets: 'PORTAL_TICKETS_DISABLED',
+  getTicket: 'PORTAL_TICKETS_DISABLED',
+  getTicketForms: 'PORTAL_TICKETS_DISABLED',
+};
+
+/**
+ * Pages that handle their gate deliberately in some other sanctioned way. Each
+ * entry is a decision, not a gap — say which one.
+ *
+ * - tickets/index.astro: a switched-off Support page is not a dead page. It
+ *   keeps its title and explains that request submission is closed while still
+ *   showing the support-usage panel when that flag is on; the decision lives in
+ *   lib/ticketsPage.ts and is unit-tested by ticketsPage.test.ts.
+ */
+const HANDLES_GATE_ELSEWHERE = new Set(['tickets/index.astro']);
+
+function walk(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) return walk(full);
+    return entry.endsWith('.astro') ? [full] : [];
+  });
+}
+
+/** The server-run frontmatter of an Astro page (undefined if it has none). */
+function frontmatterOf(source: string): string | undefined {
+  return source.match(/^---\r?\n([\s\S]*?)\r?\n---/)?.[1];
+}
+
+function gatedMethodsIn(source: string): string[] {
+  return Object.keys(GATED_API_METHODS).filter((method) =>
+    new RegExp(`portalApi\\.${method}\\b`).test(source),
+  );
+}
+
+describe('visibility-gate handling in portal pages', () => {
+  const pages = walk(PAGES).map((file) => ({
+    path: relative(PAGES, file),
+    source: readFileSync(file, 'utf8'),
+  }));
+
+  it('finds portal pages to scan', () => {
+    expect(pages.length).toBeGreaterThan(10);
+  });
+
+  it('every page fed by a gated API method answers the gate 403 before it renders', () => {
+    const violations: string[] = [];
+
+    for (const { path, source } of pages) {
+      const methods = gatedMethodsIn(source);
+      if (methods.length === 0 || HANDLES_GATE_ELSEWHERE.has(path)) continue;
+
+      const codes = [...new Set(methods.map((method) => GATED_API_METHODS[method]))];
+      const frontmatter = frontmatterOf(source);
+
+      // Sanctioned: bounce through the shared helper, or name the gate's code
+      // explicitly (a page that renders its own "not available" state).
+      const handled =
+        frontmatter !== undefined &&
+        (/redirectToPortalHomeAfterDisabled\(Astro\)/.test(frontmatter) ||
+          codes.some((code) => frontmatter.includes(code)));
+
+      if (!handled) {
+        violations.push(
+          `${path}  calls ${methods.map((m) => `portalApi.${m}`).join(', ')} ` +
+            `but its frontmatter never checks ${codes.join(' / ')}`,
+        );
+      }
+    }
+
+    expect(
+      violations,
+      'A gate 403 means the MSP switched this page off — redirect through ' +
+        'redirectToPortalHomeAfterDisabled instead of rendering a load failure:\n' +
+        violations.join('\n'),
+    ).toEqual([]);
+  });
+
+  it('keeps the allowlist honest — no entry that stopped calling a gated method', () => {
+    const stale = [...HANDLES_GATE_ELSEWHERE].filter((path) => {
+      const page = pages.find((candidate) => candidate.path === path);
+      return !page || gatedMethodsIn(page.source).length === 0;
+    });
+    expect(stale, 'remove these from HANDLES_GATE_ELSEWHERE').toEqual([]);
+  });
+});

--- a/apps/portal/src/lib/visibilityGate.test.ts
+++ b/apps/portal/src/lib/visibilityGate.test.ts
@@ -1,0 +1,99 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+import { BASE_PATH, withBase } from './basePath';
+import {
+  PORTAL_DISABLED_CODES,
+  PORTAL_GATED_PAGES,
+  PORTAL_UNGATED_HOME,
+  isPortalPageDisabled,
+  redirectToPortalHomeAfterDisabled,
+} from './visibilityGate';
+
+// vitest runs without Astro's BASE_URL, so BASE_PATH is '' here and '/portal' in
+// the app. Building both sides through withBase keeps the contract honest in both.
+
+/** The strict fail-closed visibility gates (#4562) and the fail-open feature
+ *  gates (#2345) — every one of them means "the MSP switched this page off". */
+const GATE_CODES = [
+  'PORTAL_DASHBOARD_DISABLED',
+  'PORTAL_SECURITY_DISABLED',
+  'PORTAL_BACKUPS_DISABLED',
+  'PORTAL_REPORTS_DISABLED',
+  'PORTAL_SUPPORT_USAGE_DISABLED',
+  'PORTAL_TICKETS_DISABLED',
+  'PORTAL_SELF_SERVICE_DISABLED',
+  'PORTAL_ASSET_CHECKOUT_DISABLED',
+];
+
+describe('isPortalPageDisabled', () => {
+  it.each(GATE_CODES)('reads a 403 %s as the page being switched off', (code) => {
+    expect(isPortalPageDisabled({ statusCode: 403, code })).toBe(true);
+  });
+
+  it('is true when any of a page\'s parallel calls was refused by a gate', () => {
+    // /security fans out two calls behind the same gate; either one answering
+    // 403 means the page is off.
+    expect(isPortalPageDisabled(
+      { statusCode: 403, code: 'PORTAL_SECURITY_DISABLED' },
+      { statusCode: 200 },
+    )).toBe(true);
+    expect(isPortalPageDisabled(
+      { statusCode: 200 },
+      { statusCode: 403, code: 'PORTAL_SECURITY_DISABLED' },
+    )).toBe(true);
+  });
+
+  it('leaves the 403s that are NOT a switched-off page alone', () => {
+    // portalAuthMiddleware answers "Account is not active" / "Organization is
+    // not available" as a bare 403 with no code — a real refusal the customer
+    // must still be told about, not silently bounced away.
+    expect(isPortalPageDisabled({ statusCode: 403 })).toBe(false);
+    expect(isPortalPageDisabled({ statusCode: 403, code: 'CSRF_FAILED' })).toBe(false);
+  });
+
+  it('is false for every outcome that is a load problem, not a policy one', () => {
+    expect(isPortalPageDisabled({ statusCode: 200 })).toBe(false);
+    expect(isPortalPageDisabled({ statusCode: 500, code: 'PORTAL_SECURITY_DISABLED' })).toBe(false);
+    expect(isPortalPageDisabled({ statusCode: 404, code: 'PORTAL_SECURITY_DISABLED' })).toBe(false);
+    // apiRequest's network-error catch returns a bare { error } — no status, no code.
+    expect(isPortalPageDisabled({})).toBe(false);
+  });
+
+  it('is false when there are no responses at all', () => {
+    expect(isPortalPageDisabled()).toBe(false);
+  });
+});
+
+describe('redirectToPortalHomeAfterDisabled', () => {
+  it('bounces to the ungated home, based and a 302', () => {
+    const redirect = vi.fn((p: string) => new Response(null, { status: 302, headers: { location: p } }));
+    const response = redirectToPortalHomeAfterDisabled({ redirect });
+    expect(redirect).toHaveBeenCalledWith(withBase(PORTAL_UNGATED_HOME), 302);
+    expect(response.headers.get('location')).toBe(`${BASE_PATH}${PORTAL_UNGATED_HOME}`);
+  });
+
+  it('never targets a page a visibility flag can switch off', () => {
+    // A gated target turns one deliberate switch-off into a redirect chain —
+    // or a loop, the moment the page it points at is the page that bounced.
+    expect(PORTAL_GATED_PAGES).not.toContain(PORTAL_UNGATED_HOME);
+    expect(PORTAL_UNGATED_HOME).toBe('/quotes');
+  });
+});
+
+describe('gate-code parity with the API', () => {
+  const apiSources = [
+    '../../../api/src/routes/portal/featureFlags.ts',
+    '../../../api/src/routes/portal/tickets.ts',
+  ].map((rel) => readFileSync(new URL(rel, import.meta.url), 'utf8'));
+
+  it('knows every PORTAL_*_DISABLED code the API can answer with', () => {
+    const emitted = new Set(
+      apiSources.flatMap((src) => [...src.matchAll(/'(PORTAL_[A-Z_]+_DISABLED)'/g)].map((m) => m[1])),
+    );
+    // Guard the guard: if this ever reads zero codes the API moved and the
+    // assertion below passed vacuously.
+    expect(emitted.size).toBeGreaterThan(0);
+    const known: readonly string[] = PORTAL_DISABLED_CODES;
+    expect([...emitted].filter((code) => !known.includes(code))).toEqual([]);
+  });
+});

--- a/apps/portal/src/lib/visibilityGate.ts
+++ b/apps/portal/src/lib/visibilityGate.ts
@@ -1,0 +1,103 @@
+import { withBase } from './basePath';
+
+/**
+ * The 403 codes the API's portal gates answer with when an MSP has switched a
+ * page off (apps/api/src/routes/portal/featureFlags.ts, plus the tickets gate in
+ * routes/portal/tickets.ts). Read as one class: each is a deliberate
+ * configuration decision, NOT a load failure, so none of them may reach a page's
+ * "we couldn't load this just now" copy (#4932).
+ *
+ * Five are the strict fail-closed visibility flags of #4562; three are the older
+ * fail-open feature gates of #2345. visibilityGate.test.ts asserts this list
+ * still covers every code the API can emit.
+ */
+export const PORTAL_DISABLED_CODES = [
+  'PORTAL_DASHBOARD_DISABLED',
+  'PORTAL_SECURITY_DISABLED',
+  'PORTAL_BACKUPS_DISABLED',
+  'PORTAL_REPORTS_DISABLED',
+  'PORTAL_SUPPORT_USAGE_DISABLED',
+  'PORTAL_TICKETS_DISABLED',
+  'PORTAL_SELF_SERVICE_DISABLED',
+  'PORTAL_ASSET_CHECKOUT_DISABLED',
+] as const;
+
+const DISABLED_CODE_SET: ReadonlySet<string> = new Set(PORTAL_DISABLED_CODES);
+
+/** Every portal page a toggle can switch off. Kept next to the target below so
+ *  the "never bounce to a gated page" invariant is checkable, not hoped for. */
+export const PORTAL_GATED_PAGES = [
+  '/dashboard',
+  '/security',
+  '/backups',
+  '/reports',
+  '/devices',
+  '/assets',
+  '/tickets',
+] as const;
+
+/**
+ * Where a switched-off page sends the customer.
+ *
+ * `/quotes` (Proposals) is the one signed-in page no visibility flag can turn
+ * off — the API mounts auth but no gate on `/quotes/*`, `/invoices/*` and
+ * `/profile/*` (apps/api/src/routes/portal/index.ts), and a portal customer
+ * comes to read a proposal or pay a bill. It is also where the middleware
+ * already sends a signed-in customer whose org has not turned the dashboard on
+ * (lib/landing.ts) and the DEFAULT_LANDING in lib/session.ts.
+ *
+ * A fixed target is what makes a redirect loop structurally impossible. "Bounce
+ * to the landing page" is not: the dashboard IS the landing page when
+ * enableDashboard is on, so that rule loops the moment the branding read and the
+ * API gate disagree.
+ */
+export const PORTAL_UNGATED_HOME = '/quotes';
+
+/** The shape of a portalApi response this module reads. */
+interface PortalResponseState {
+  statusCode?: number;
+  code?: string;
+}
+
+/** The slice of Astro's global a page hands us to bounce a switched-off page. */
+interface RedirectContext {
+  redirect: (path: string, status?: 301 | 302 | 303 | 307 | 308) => Response;
+}
+
+/**
+ * True when any of a page's calls was refused because the MSP switched that page
+ * off. Pass only the calls the page's OWN gate covers: /backups also fetches the
+ * dashboard for its timezone, and an org with Backups on but Dashboard off must
+ * keep its backups page — so that ride-along response stays out of the check.
+ *
+ * A 403 without one of these codes is a real refusal (portalAuthMiddleware
+ * answers "Account is not active" / "Organization is not available" as a bare
+ * 403) and must still render inline.
+ *
+ * Not every code here means the whole PAGE is off, which is why /tickets keeps
+ * its own decision in lib/ticketsPage.ts: there, PORTAL_SUPPORT_USAGE_DISABLED
+ * hides one panel and PORTAL_TICKETS_DISABLED alone still renders a page worth
+ * reading.
+ */
+export function isPortalPageDisabled(...responses: PortalResponseState[]): boolean {
+  return responses.some(
+    (response) =>
+      response.statusCode === 403 &&
+      response.code !== undefined &&
+      DISABLED_CODE_SET.has(response.code),
+  );
+}
+
+/**
+ * The one way a gated portal page answers a visibility 403: bounce to
+ * PORTAL_UNGATED_HOME rather than render a shell whose every block is an error
+ * notice about a load that was never attempted.
+ *
+ * Every page fed by a gated portalApi method must call this (or name its gate
+ * code and render its own "not available" state); disabledPageCoverage.test.ts
+ * enforces it the way sessionClearCoverage.test.ts enforces
+ * redirectToLoginAfter401.
+ */
+export function redirectToPortalHomeAfterDisabled(ctx: RedirectContext): Response {
+  return ctx.redirect(withBase(PORTAL_UNGATED_HOME), 302);
+}

--- a/apps/portal/src/pages/assets/index.astro
+++ b/apps/portal/src/pages/assets/index.astro
@@ -2,6 +2,7 @@
 import PortalLayout from '../../layouts/PortalLayout.astro';
 import { withBase } from '../../lib/basePath';
 import { redirectToLoginAfter401 } from '../../lib/session';
+import { isPortalPageDisabled, redirectToPortalHomeAfterDisabled } from '../../lib/visibilityGate';
 import AssetList from '../../components/portal/AssetList';
 import { portalApi } from '../../lib/api';
 import { buildServerApiConfig } from '../../lib/server';
@@ -14,6 +15,14 @@ const response = await portalApi.getAssets(
 if (response.statusCode === 401) {
   // Dead session: clear the stale cookie and come back here after sign-in.
   return redirectToLoginAfter401(Astro);
+}
+
+// Equipment is gated on asset checkout, which 403s with
+// PORTAL_ASSET_CHECKOUT_DISABLED — and AssetList prints `error` verbatim, so the
+// customer used to be shown our own internal wording ("Asset checkout is not
+// enabled for this portal") for a switch the MSP threw deliberately (#4932).
+if (isPortalPageDisabled(response)) {
+  return redirectToPortalHomeAfterDisabled(Astro);
 }
 ---
 

--- a/apps/portal/src/pages/assets/index.test.ts
+++ b/apps/portal/src/pages/assets/index.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const pageSource = readFileSync(new URL('./index.astro', import.meta.url), 'utf8');
+
+describe('equipment page asset-checkout gate', () => {
+  it('bounces a page the MSP switched off instead of reporting a load failure', () => {
+    // #4932 — AssetList prints `error` verbatim, so a gated request used to
+    // show the customer the API's own words: "Asset checkout is not enabled for
+    // this portal". That is our internal copy, not theirs.
+    expect(pageSource).toContain('redirectToPortalHomeAfterDisabled(Astro)');
+    expect(pageSource).toContain('isPortalPageDisabled(response)');
+  });
+});

--- a/apps/portal/src/pages/backups/index.astro
+++ b/apps/portal/src/pages/backups/index.astro
@@ -6,6 +6,7 @@ import { ErrorNotice } from '../../components/portal/ui';
 import { portalApi } from '../../lib/api';
 import { buildServerApiConfig } from '../../lib/server';
 import { redirectToLoginAfter401 } from '../../lib/session';
+import { isPortalPageDisabled, redirectToPortalHomeAfterDisabled } from '../../lib/visibilityGate';
 
 const config = buildServerApiConfig(Astro.request);
 // The dashboard rides along only for `timezone`: neither backups DTO carries
@@ -22,6 +23,15 @@ const [overview, devices, dashboard] = await Promise.all([
 
 if (overview.statusCode === 401 || devices.statusCode === 401) {
   return redirectToLoginAfter401(Astro);
+}
+
+// enable_backups off 403s both backups calls with PORTAL_BACKUPS_DISABLED — a
+// setting, not a load failure, so the page bounces rather than telling the
+// customer their backups "couldn't be loaded" (#4932). The ride-along dashboard
+// response stays out of the check on purpose: it is only here for `timezone`, and
+// an org with Backups on but Dashboard off must keep this page.
+if (isPortalPageDisabled(overview, devices)) {
+  return redirectToPortalHomeAfterDisabled(Astro);
 }
 
 const timezone = dashboard.data?.timezone ?? 'UTC';

--- a/apps/portal/src/pages/backups/index.test.ts
+++ b/apps/portal/src/pages/backups/index.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const pageSource = readFileSync(new URL('./index.astro', import.meta.url), 'utf8');
+
+describe('backups page visibility gate', () => {
+  it('bounces a page the MSP switched off instead of reporting a load failure', () => {
+    // #4932 — "We couldn't load your backups just now. Your IT team can help."
+    // tells the customer something broke when the MSP simply turned Backups off.
+    expect(pageSource).toContain('redirectToPortalHomeAfterDisabled(Astro)');
+  });
+
+  it('reads the gate off the two backups calls only', () => {
+    expect(pageSource).toMatch(/isPortalPageDisabled\(overview, devices\)/);
+  });
+
+  it('never lets the ride-along dashboard call switch this page off', () => {
+    // The dashboard is fetched only for `timezone`; it sits behind its own gate.
+    // An org with Backups on and Dashboard off must keep its backups page — so
+    // the dashboard response cannot be part of the disabled check.
+    expect(pageSource).not.toMatch(/isPortalPageDisabled\([^)]*dashboard/);
+  });
+});

--- a/apps/portal/src/pages/dashboard/index.astro
+++ b/apps/portal/src/pages/dashboard/index.astro
@@ -4,12 +4,23 @@ import { DashboardTiles, DashboardUnavailable } from '../../components/portal/Da
 import { portalApi } from '../../lib/api';
 import { buildServerApiConfig, loadPortalBranding } from '../../lib/server';
 import { redirectToLoginAfter401 } from '../../lib/session';
+import { isPortalPageDisabled, redirectToPortalHomeAfterDisabled } from '../../lib/visibilityGate';
 
 const response = await portalApi.getDashboard(
   buildServerApiConfig(Astro.request),
 );
 if (response.statusCode === 401) {
   return redirectToLoginAfter401(Astro);
+}
+
+// enable_dashboard off 403s with PORTAL_DASHBOARD_DISABLED. DashboardUnavailable
+// below is the concierge state for a dashboard that SHOULD have loaded; a page
+// the org never turned on is not a fault for the customer to escalate, so it
+// bounces instead (#4932). Safe even though the dashboard is the landing page
+// when this flag is ON: the target is a page no flag can switch off, so there is
+// nothing to loop back through.
+if (isPortalPageDisabled(response)) {
+  return redirectToPortalHomeAfterDisabled(Astro);
 }
 
 // The concierge line is the whole point of the failure state, so the support

--- a/apps/portal/src/pages/dashboard/index.test.ts
+++ b/apps/portal/src/pages/dashboard/index.test.ts
@@ -15,3 +15,27 @@ describe('dashboard page failure state', () => {
     expect(pageSource).toContain('supportEmail');
   });
 });
+
+describe('dashboard page visibility gate', () => {
+  it('bounces a dashboard the MSP switched off instead of reporting a load failure', () => {
+    // #4932 — DashboardUnavailable is the concierge state for a page that
+    // SHOULD have loaded. A gate 403 is the org never having turned the
+    // dashboard on, which is not a problem for the customer to escalate.
+    expect(pageSource).toContain('redirectToPortalHomeAfterDisabled(Astro)');
+  });
+
+  it('decides before paying for the support-address round trip', () => {
+    // The branding fetch exists only to explain a failure; a bounced page has
+    // nothing to explain, so the gate check has to come first.
+    expect(pageSource.indexOf('redirectToPortalHomeAfterDisabled(Astro)')).toBeLessThan(
+      pageSource.indexOf('loadPortalBranding(Astro.request)'),
+    );
+  });
+
+  it('cannot bounce to itself', () => {
+    // The dashboard is the landing page whenever enableDashboard is on, so a
+    // "redirect to the landing page" rule would loop here. The shared target is
+    // a page no visibility flag can switch off (lib/visibilityGate.ts).
+    expect(pageSource).not.toMatch(/redirect\([^)]*\/dashboard/);
+  });
+});

--- a/apps/portal/src/pages/devices/index.astro
+++ b/apps/portal/src/pages/devices/index.astro
@@ -1,6 +1,7 @@
 ---
 import PortalLayout from '../../layouts/PortalLayout.astro';
 import { redirectToLoginAfter401 } from '../../lib/session';
+import { isPortalPageDisabled, redirectToPortalHomeAfterDisabled } from '../../lib/visibilityGate';
 import DeviceList from '../../components/portal/DeviceList';
 import { portalApi } from '../../lib/api';
 import { buildServerApiConfig } from '../../lib/server';
@@ -13,6 +14,14 @@ const response = await portalApi.getDevices(
 if (response.statusCode === 401) {
   // Dead session: clear the stale cookie and come back here after sign-in.
   return redirectToLoginAfter401(Astro);
+}
+
+// The list is gated on Self-service, which 403s with PORTAL_SELF_SERVICE_DISABLED.
+// DeviceList answers ANY error with "We couldn't load your devices just now", so
+// a deliberate switch-off used to read as an outage (#4932). Genuine failures
+// still fall through to the list's own copy.
+if (isPortalPageDisabled(response)) {
+  return redirectToPortalHomeAfterDisabled(Astro);
 }
 ---
 

--- a/apps/portal/src/pages/devices/index.test.ts
+++ b/apps/portal/src/pages/devices/index.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const pageSource = readFileSync(new URL('./index.astro', import.meta.url), 'utf8');
+
+describe('devices page self-service gate', () => {
+  it('bounces a list the MSP switched off instead of reporting a load failure', () => {
+    // #4932 — /portal/devices is gated on Self-service, and DeviceList answers
+    // any error with "We couldn't load your devices just now. Your IT team can
+    // help." That is the wrong answer to a deliberate switch-off.
+    expect(pageSource).toContain('redirectToPortalHomeAfterDisabled(Astro)');
+    expect(pageSource).toContain('isPortalPageDisabled(response)');
+  });
+
+  it('still hands a genuine load failure to the list to explain', () => {
+    // The gate branch must not swallow the transport-error path: a 500 or a
+    // network failure is still the customer's page failing, and the list has
+    // the copy for it.
+    expect(pageSource).toMatch(/<DeviceList[\s\S]*error=\{response\.error\}/);
+  });
+});

--- a/apps/portal/src/pages/reports/index.astro
+++ b/apps/portal/src/pages/reports/index.astro
@@ -2,9 +2,9 @@
 import PortalLayout from '../../layouts/PortalLayout.astro';
 import ReportRunList from '../../components/portal/ReportRunList';
 import { portalApi } from '../../lib/api';
-import { withBase } from '../../lib/basePath';
 import { buildServerApiConfig } from '../../lib/server';
 import { redirectToLoginAfter401 } from '../../lib/session';
+import { isPortalPageDisabled, redirectToPortalHomeAfterDisabled } from '../../lib/visibilityGate';
 
 const response = await portalApi.getReportRuns(
   { page: 1, limit: 20 },
@@ -15,11 +15,13 @@ if (response.statusCode === 401) {
   return redirectToLoginAfter401(Astro);
 }
 
-// enable_reports gate 403s with PORTAL_REPORTS_DISABLED; bounce to the
-// portal home instead of rendering a dead page. Other 403s (e.g. "Account
-// is not active") fall through and render inline via the error prop.
-if (response.statusCode === 403 && response.code === 'PORTAL_REPORTS_DISABLED') {
-  return Astro.redirect(withBase('/devices'));
+// enable_reports off 403s with PORTAL_REPORTS_DISABLED; bounce instead of
+// rendering a dead page. This used to target /devices, which is itself gated on
+// Self-service — with both off, one deliberate switch-off became two hops ending
+// in "We couldn't load your devices just now" (#4932). Other 403s (e.g. "Account
+// is not active") still fall through and render inline via the error prop.
+if (isPortalPageDisabled(response)) {
+  return redirectToPortalHomeAfterDisabled(Astro);
 }
 ---
 

--- a/apps/portal/src/pages/reports/index.test.ts
+++ b/apps/portal/src/pages/reports/index.test.ts
@@ -28,3 +28,18 @@ describe('reports page structure', () => {
     expect(listSource).toContain("'Generate security summary'");
   });
 });
+
+describe('reports page visibility gate', () => {
+  it('bounces through the shared helper', () => {
+    expect(pageSource).toContain('isPortalPageDisabled(response)');
+    expect(pageSource).toContain('redirectToPortalHomeAfterDisabled(Astro)');
+  });
+
+  it('no longer bounces to a page a toggle can switch off', () => {
+    // This page was the only one that handled its gate, and it sent the customer
+    // to /devices — itself gated on Self-service. With both off, one deliberate
+    // switch-off became two hops ending in a "couldn't load your devices" error
+    // (#4932). Every gated page now shares one never-gated target.
+    expect(pageSource).not.toContain("withBase('/devices')");
+  });
+});

--- a/apps/portal/src/pages/security/index.astro
+++ b/apps/portal/src/pages/security/index.astro
@@ -6,6 +6,7 @@ import { ErrorNotice, PageHeader } from '../../components/portal/ui';
 import { portalApi } from '../../lib/api';
 import { buildServerApiConfig } from '../../lib/server';
 import { redirectToLoginAfter401 } from '../../lib/session';
+import { isPortalPageDisabled, redirectToPortalHomeAfterDisabled } from '../../lib/visibilityGate';
 
 const config = buildServerApiConfig(Astro.request);
 const [overview, devices] = await Promise.all([
@@ -14,6 +15,14 @@ const [overview, devices] = await Promise.all([
 ]);
 if (overview.statusCode === 401 || devices.statusCode === 401) {
   return redirectToLoginAfter401(Astro);
+}
+
+// enable_security off 403s BOTH calls with PORTAL_SECURITY_DISABLED. That is a
+// setting, not a load failure, so the page bounces instead of asking the customer
+// to chase their IT team about a switch the IT team just threw (#4932). Every
+// other 403 ("Account is not active") still renders inline via the error copy.
+if (isPortalPageDisabled(overview, devices)) {
+  return redirectToPortalHomeAfterDisabled(Astro);
 }
 ---
 

--- a/apps/portal/src/pages/security/index.test.ts
+++ b/apps/portal/src/pages/security/index.test.ts
@@ -7,6 +7,21 @@ const tableSource = readFileSync(
   'utf8',
 );
 
+describe('security page visibility gate', () => {
+  it('bounces a page the MSP switched off instead of reporting a load failure', () => {
+    // #4932 — "We couldn't load your security summary just now. Your IT team can
+    // help." is the wrong answer to a deliberate switch-off: it sends the
+    // customer to raise a ticket about a setting, not a fault.
+    expect(pageSource).toContain('redirectToPortalHomeAfterDisabled(Astro)');
+  });
+
+  it('reads the gate off both calls — either one refusing means the page is off', () => {
+    // /security/overview and /security/devices sit behind the same gate, so a
+    // check on one alone would miss a page that only half-refused.
+    expect(pageSource).toMatch(/isPortalPageDisabled\(overview, devices\)/);
+  });
+});
+
 describe('security page fetch states', () => {
   it('never prints a raw transport error at the customer', () => {
     expect(pageSource).not.toMatch(/\{overview\.error\}/);


### PR DESCRIPTION
## Summary

- Every visibility-gated portal page now answers its gate 403 with a redirect instead of rendering a load-failure page. `security`, `backups`, `dashboard`, `devices` and `assets` join `reports`, which was the only page that already did this.
- The shared logic lives in one new module, `apps/portal/src/lib/visibilityGate.ts`: `isPortalPageDisabled(...responses)` recognises the eight `PORTAL_*_DISABLED` codes and `redirectToPortalHomeAfterDisabled(Astro)` bounces to `/quotes`.
- `/quotes` is the one signed-in page no visibility flag can switch off, so a redirect chain or loop is structurally impossible. `/reports` no longer targets `/devices` — itself gated on Self-service — which turned one deliberate switch-off into two hops ending in a second false "we couldn't load your devices" error.
- `/assets` was the worst case: `AssetList` prints `error` verbatim, so the customer was shown our own internal wording, *"Asset checkout is not enabled for this portal"*.
- New contract test `apps/portal/src/lib/disabledPageCoverage.test.ts` walks every page under `src/pages`, maps its `portalApi.*` calls to the gate they sit behind, and fails on any page that renders instead of branching — the same shape as the existing `sessionClearCoverage.test.ts` guard for 401s. A parity case in `visibilityGate.test.ts` reads the API gate sources and fails if the API grows a `PORTAL_*_DISABLED` code the portal does not know.
- Public docs described the old behaviour in two places (`features/portal.mdx`: the "Turned off means genuinely off" aside and the Reports section) and are updated to match.

## Root cause

The API side of #4562 was correctly fail-closed: `createPortalFeatureGateStrict` answers 403 with a machine-readable `code`, and `apiRequest` propagates that code onto every `ApiResponse`. The pages just did not read it.

Each page branched on `statusCode === 401` (dead session, handled by `redirectToLoginAfter401`) and then treated *every* other failure identically, by passing `response.error` down to a component whose error copy is written for a transport failure — "We couldn't load your security summary just now. Your IT team can help." A 403 caused by a configuration decision therefore rendered as an outage and invited the customer to raise a ticket about a switch their IT team had just thrown.

`reports/index.astro` had the branch (`statusCode === 403 && code === 'PORTAL_REPORTS_DISABLED'`) because it was written together with the gate; the five pages added around it were not, and nothing enforced the pattern — so the omission was invisible to review, exactly the failure mode `basePathCoverage.test.ts` and `sessionClearCoverage.test.ts` were written to prevent for their own contracts.

## Verification

Red first, then green — the new tests were run before the fix existed:

| Command | Result |
|---|---|
| `cd apps/portal && npx vitest run src/pages src/lib/disabledPageCoverage.test.ts src/lib/visibilityGate.test.ts` — **before the fix** | 8 files failed / 10 tests failed. `visibilityGate.test.ts` could not resolve the module, and the coverage test named all five offending pages: `assets`, `backups`, `dashboard`, `devices`, `security` |
| same command — **after the fix** | **9 files, 44 tests passed** |
| `cd apps/portal && npx vitest run` (full portal suite) | **52 files, 465 tests passed** |
| `npx tsc --noEmit -p apps/portal` | **clean, 0 errors** |
| `cd apps/portal && npx astro check` | **133 files, 0 errors, 0 warnings** (43 pre-existing unused-import hints, none in a file this PR touches) |
| `PORTAL_BASE_PATH=/portal pnpm build --filter=@breeze/portal` | **build complete** (only the pre-existing chunk-size warning) |

CI runs these as the `test-portal` (`pnpm test --filter=@breeze/portal`) and `build-portal` jobs.

No API, database, tenancy or agent code is touched — no migration, no RLS surface, no cascade list.

## Decisions / notes for reviewer

- **Redirect rather than a neutral "not available" state, on all six pages.** The issue allows either. Redirect wins here because the nav item is already gone when the toggle is off, so the only way to reach these URLs is a bookmark or a hand-edited address — there is no in-page context worth preserving, and a redirect cannot be mistaken for a fault. `/tickets` is the deliberate exception and keeps its existing neutral state, see below.
- **Fixed target `/quotes`, not "the landing page".** `portalLandingPath()` returns `/dashboard` when `enableDashboard` is on, so a "bounce to the landing page" rule loops on the dashboard page itself the moment the branding read and the API gate disagree. `/quotes` (labelled Proposals) carries auth but no gate in `apps/api/src/routes/portal/index.ts`, is the first always-on nav item, and is already `DEFAULT_LANDING` in `lib/session.ts` and the fail-closed branch of `lib/landing.ts`. `visibilityGate.test.ts` asserts the target is not in `PORTAL_GATED_PAGES`, so the invariant is checked rather than hoped for.
- **`/reports` changed target from `/devices` to `/quotes`.** A behaviour change beyond the five broken pages, made because the old target is itself gated and reproduced the same bug one hop later. This is what the two docs sentences described, hence the docs edit.
- **`/tickets` is intentionally left alone.** It already implements the alternative the issue offers: `decideTicketsPage()` keeps the page up when tickets are off but support-usage is on, and renders "Your IT team hasn't opened request submission in the portal" — a real, actionable state, not a load failure. Its both-off path still redirects to `/devices`; that is now safe (Devices bounces on to `/quotes` when Self-service is off) but the `redirectToDevices` naming in `lib/ticketsPage.ts` is stale. Renaming it would touch a tested module for a case this issue does not report, so it is left as a follow-up. `tickets/index.astro` is the single documented entry in the coverage test allowlist; `tickets/new.astro` and `tickets/[id].astro` already name their gate code and pass unaided.
- **`/assets` was not named in the issue but is the same defect**, on the same fail-closed gate, with the worst copy of the six — included for one line of frontmatter.
- **The backups ride-along dashboard call is excluded from the gate check.** `/backups` also fetches `/portal/dashboard` purely for `timezone`; an org with Backups on and Dashboard off must keep its backups page. `backups/index.test.ts` asserts `dashboard` never appears in the `isPortalPageDisabled(...)` argument list.
- **Non-gate 403s still render inline.** `portalAuthMiddleware` answers "Account is not active" / "Organization is not available" as a bare 403 with no `code`, so keying on the code rather than the status preserves the behaviour the old `/reports` comment called out. Unit-tested.
- **Page tests follow the established source-assertion pattern** already used by the four existing `src/pages/**/index.test.ts` files (read the `.astro`, assert its structure). They are deliberately thin — the general contract lives in the coverage test, and each page test only pins what is page-specific.

### Follow-up: the Playwright e2e cases the issue asks for

Deferred out of this PR by dispatch instruction. `data-testid`-only, per `e2e-tests/README.md`:

1. Security off: `/portal/security` answers **302 to `/portal/quotes`**; `portal-security-error` never renders.
2. Backups off: `/portal/backups` **302 to `/portal/quotes`**; `portal-backup-error` never renders.
3. Backups **on** + Dashboard **off**: `/portal/backups` still answers **200** (guards the ride-along timezone call).
4. Dashboard off: `/portal/dashboard` **302 to `/portal/quotes`**; `portal-dashboard-error` never renders.
5. Reports off: `/portal/reports` **302 to `/portal/quotes`** (previously `/portal/devices`).
6. Self-service off: `/portal/devices` **302 to `/portal/quotes`**.
7. Asset checkout off: `/portal/assets` **302 to `/portal/quotes`**, and the string "Asset checkout is not enabled for this portal" appears nowhere in the body.
8. Reports **and** Self-service off: `/portal/reports` reaches `/portal/quotes` in **one** hop (the chain the old `/devices` target produced).
9. Per toggle, the matching nav item is absent from the portal shell.
10. A non-gate 403 (inactive account) still renders the page's inline error rather than bouncing.

Closes #4932

Refs #4562 — the visibility epic's server-side gating shipped in that epic's waves and is unchanged here; this PR is the presentation half the pre-release sweep found missing.

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code) via [Claude Code](https://claude.com/claude-code)
