### PR TITLE
fix(web): Processes tab must not read a 503 as "0 processes / No Data" (#4935)

### DIFF
--- a/apps/web/src/components/remote/ProcessManager.tsx
+++ b/apps/web/src/components/remote/ProcessManager.tsx
@@ -5,6 +5,7 @@ import {
   X,
   ChevronUp,
   ChevronDown,
+  AlertCircle,
   AlertTriangle,
   Cpu,
   HardDrive,
@@ -38,6 +39,13 @@ export type ProcessManagerProps = {
   deviceName?: string;
   processes?: Process[];
   loading?: boolean;
+  /**
+   * Why the last fetch failed, or null/undefined when it succeeded. Set this
+   * whenever `processes` is empty because of a failure rather than because the
+   * device reported none — otherwise the two render identically as "No Data"
+   * (#4935: an offline device's 503 looked like an idle box).
+   */
+  loadError?: string | null;
   onRefresh?: () => void;
   onKillProcess?: (pid: number) => Promise<void>;
   onGetProcess?: (pid: number) => Promise<Process>;
@@ -86,6 +94,7 @@ export default function ProcessManager({
   deviceName = 'Device',
   processes: externalProcesses,
   loading: externalLoading,
+  loadError,
   onRefresh,
   onKillProcess,
   onGetProcess
@@ -291,7 +300,9 @@ export default function ProcessManager({
         </div>
       </div>
 
-      {/* Resource Summary */}
+      {/* Resource Summary — a failed fetch yields no counts, so the tiles must
+          not print the zeroes they are initialised with: "Processes 0" next to
+          an offline device is the exact misread #4935 is about. */}
       <div className="grid grid-cols-3 gap-4 border-b px-4 py-3">
         <div className="flex items-center gap-3">
           <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-500/10">
@@ -299,7 +310,9 @@ export default function ProcessManager({
           </div>
           <div>
             <p className="text-sm text-muted-foreground">{t('processManager.processes')}</p>
-            <p className="text-lg font-semibold">{resourceSummary.totalProcesses}</p>
+            <p className="text-lg font-semibold">
+              {loadError ? '-' : resourceSummary.totalProcesses}
+            </p>
           </div>
         </div>
         <div className="flex items-center gap-3">
@@ -308,7 +321,9 @@ export default function ProcessManager({
           </div>
           <div>
             <p className="text-sm text-muted-foreground">{t('processManager.totalCpu')}</p>
-            <p className="text-lg font-semibold">{resourceSummary.totalCpu}%</p>
+            <p className="text-lg font-semibold">
+              {loadError ? '-' : `${resourceSummary.totalCpu}%`}
+            </p>
           </div>
         </div>
         <div className="flex items-center gap-3">
@@ -317,7 +332,9 @@ export default function ProcessManager({
           </div>
           <div>
             <p className="text-sm text-muted-foreground">{t('processManager.processMemory')}</p>
-            <p className="text-lg font-semibold">{resourceSummary.totalMemory}</p>
+            <p className="text-lg font-semibold">
+              {loadError ? '-' : resourceSummary.totalMemory}
+            </p>
           </div>
         </div>
       </div>
@@ -379,6 +396,26 @@ export default function ProcessManager({
                 <tr>
                   <td colSpan={8} className="px-4 py-8 text-center">
                     <Loader2 className="mx-auto h-6 w-6 animate-spin text-muted-foreground" />
+                  </td>
+                </tr>
+              ) : loadError ? (
+                // Same shape and ordering as the File Browser tab's failure
+                // pane (loading → error → empty → rows). Checked BEFORE the
+                // empty state so a failed fetch can never fall through to
+                // "No Data" (#4935).
+                <tr>
+                  <td colSpan={8} className="px-4 py-8 text-center">
+                    <div className="flex flex-col items-center gap-2">
+                      <AlertCircle className="h-6 w-6 text-red-500" />
+                      <p className="text-sm text-red-500">{loadError}</p>
+                      <button
+                        type="button"
+                        onClick={handleRefresh}
+                        className="text-xs text-primary hover:underline"
+                      >
+                        {t('common:actions.retry')}
+                      </button>
+                    </div>
                   </td>
                 </tr>
               ) : processes.length === 0 ? (
@@ -516,12 +553,15 @@ export default function ProcessManager({
         </div>
       </div>
 
-      {/* Results count */}
-      <div className="border-t px-4 py-3">
-        <p className="text-sm text-muted-foreground">
-          {t('processManager.showing', { shown: filteredProcesses.length, total: processes.length })}
-        </p>
-      </div>
+      {/* Results count — suppressed on a failed fetch, where "Showing 0 of 0"
+          would restate the zero the error pane above is contradicting. */}
+      {!loadError && (
+        <div className="border-t px-4 py-3">
+          <p className="text-sm text-muted-foreground">
+            {t('processManager.showing', { shown: filteredProcesses.length, total: processes.length })}
+          </p>
+        </div>
+      )}
 
       {/* Kill Confirmation Modal */}
       {showKillModal && processToKill && (

--- a/apps/web/src/components/remote/RemoteToolsPage.test.tsx
+++ b/apps/web/src/components/remote/RemoteToolsPage.test.tsx
@@ -130,6 +130,115 @@ describe('RemoteToolsPage tab hash persistence (#4512)', () => {
   });
 });
 
+// #4935: on an offline device the API answers 503 for the process list, and
+// fetchProcesses swallowed that into `processes = []` — so the tab rendered
+// "Processes 0 / No Data", indistinguishable from a genuinely idle box. The
+// empty state must stay reserved for a real 200 with zero rows.
+describe('RemoteToolsPage Processes tab surfaces an unavailable device (#4935)', () => {
+  const OFFLINE_BODY = { error: 'The device is offline.', code: 'device_offline' };
+
+  const makeStatusResponse = (payload: unknown, ok: boolean, status: number): Response =>
+    ({
+      ok,
+      status,
+      json: vi.fn().mockResolvedValue(payload),
+    } as unknown as Response);
+
+  // Only the process-list route is under test; every other call (device info)
+  // resolves not-ok so those effects bail out quietly.
+  const mockProcessListResponse = (response: Response) => {
+    fetchMock.mockImplementation(async (url: string) =>
+      url.includes('/system-tools/devices/device-1/processes')
+        ? response
+        : makeResponse(),
+    );
+  };
+
+  it('renders the offline reason instead of "No Data" when the API answers 503', async () => {
+    mockProcessListResponse(makeStatusResponse(OFFLINE_BODY, false, 503));
+
+    renderPage();
+
+    expect(await screen.findByText('The device is offline.')).toBeInTheDocument();
+    expect(screen.queryByText('No Data')).not.toBeInTheDocument();
+    // The tiles must not report counts that were never fetched, and the footer
+    // must not restate them — "Processes 0" was half of the reported symptom.
+    expect(screen.getAllByText('-')).toHaveLength(3);
+    expect(screen.queryByText(/Showing \d+ of \d+ processes/)).not.toBeInTheDocument();
+  });
+
+  it('offers a retry that re-requests the process list', async () => {
+    const user = userEvent.setup();
+    mockProcessListResponse(makeStatusResponse(OFFLINE_BODY, false, 503));
+
+    renderPage();
+    await screen.findByText('The device is offline.');
+
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
+
+    await waitFor(() => {
+      const calls = fetchMock.mock.calls.filter(([url]) =>
+        String(url).includes('/system-tools/devices/device-1/processes'),
+      );
+      expect(calls.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  it('keeps the "No Data" empty state for a genuine 200 with zero rows', async () => {
+    mockProcessListResponse(makeStatusResponse({ data: [] }, true, 200));
+
+    renderPage();
+
+    expect(await screen.findByText('No Data')).toBeInTheDocument();
+    expect(screen.queryByText('The device is offline.')).not.toBeInTheDocument();
+    // A real zero is a real count: the tiles and footer stay as they were.
+    expect(screen.getByText('Showing 0 of 0 processes')).toBeInTheDocument();
+    expect(screen.queryByText('Retry')).not.toBeInTheDocument();
+  });
+
+  it('renders rows and no error for a 200 with processes', async () => {
+    mockProcessListResponse(
+      makeStatusResponse(
+        {
+          data: [
+            { pid: 4242, name: 'svchost.exe', user: 'SYSTEM', cpuPercent: 1.5, memoryMB: 32 },
+          ],
+        },
+        true,
+        200,
+      ),
+    );
+
+    renderPage();
+
+    expect(await screen.findByText('svchost.exe')).toBeInTheDocument();
+    expect(screen.queryByText('No Data')).not.toBeInTheDocument();
+    expect(screen.queryByText('The device is offline.')).not.toBeInTheDocument();
+  });
+
+  it('clears the error once a retry succeeds', async () => {
+    const user = userEvent.setup();
+    mockProcessListResponse(makeStatusResponse(OFFLINE_BODY, false, 503));
+
+    renderPage();
+    await screen.findByText('The device is offline.');
+
+    mockProcessListResponse(
+      makeStatusResponse(
+        { data: [{ pid: 7, name: 'explorer.exe', user: 'alice', cpuPercent: 0, memoryMB: 8 }] },
+        true,
+        200,
+      ),
+    );
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
+
+    expect(await screen.findByText('explorer.exe')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText('The device is offline.')).not.toBeInTheDocument();
+    });
+  });
+});
+
 // The terminal's only channel for reporting a failed initialisation is the
 // onError prop. RemoteToolsPage never passed one, so a terminal that died on
 // mount was completely silent — the defect behind #4152 was invisible to the

--- a/apps/web/src/components/remote/RemoteToolsPage.tsx
+++ b/apps/web/src/components/remote/RemoteToolsPage.tsx
@@ -13,6 +13,7 @@ import {
   ShieldOff
 } from 'lucide-react';
 import { fetchWithAuth } from '@/stores/auth';
+import { extractApiError } from '@/lib/apiError';
 import { navigateTo } from '@/lib/navigation';
 import { useHashTab } from '@/lib/useHashState';
 
@@ -420,6 +421,10 @@ export default function RemoteToolsPage({
   // Process state
   const [processes, setProcesses] = useState<Process[]>([]);
   const [processLoading, setProcessLoading] = useState(false);
+  // Reason the last process-list fetch failed, or null. Kept separate from
+  // `processes` because an empty list and a failed fetch must not render the
+  // same thing (#4935).
+  const [processError, setProcessError] = useState<string | null>(null);
 
   // Services state
   const [services, setServices] = useState<WindowsService[]>([]);
@@ -524,12 +529,28 @@ export default function RemoteToolsPage({
     setProcessLoading(true);
     try {
       const res = await fetchWithAuth(`/system-tools/devices/${deviceId}/processes?limit=500`);
-      if (!res.ok) throw new Error(t('remoteToolsPage.errors.fetchProcesses'));
+      if (!res.ok) {
+        // An offline device answers 503 with
+        // `{ error: 'The device is offline.', code: 'device_offline' }`
+        // (apps/api/src/routes/systemTools/fileBrowserHelpers.ts). Discarding
+        // that body and logging in the catch below is what made this tab read
+        // "Processes 0 / No Data" — indistinguishable from a genuinely idle
+        // box (#4935). Keep the server's reason so the pane says why.
+        const body = await res.json().catch(() => null);
+        throw new Error(extractApiError(body, t('remoteToolsPage.errors.fetchProcesses')));
+      }
       const json = await res.json();
       const data: ApiProcess[] = Array.isArray(json.data) ? json.data : [];
       setProcesses(data.map(mapProcess));
+      setProcessError(null);
     } catch (err) {
       console.error('Failed to fetch processes:', err);
+      // Drop any rows from an earlier successful fetch: leaving them beside the
+      // error banner would show a stale list as if it were current.
+      setProcesses([]);
+      setProcessError(
+        err instanceof Error ? err.message : t('remoteToolsPage.errors.fetchProcesses')
+      );
     } finally {
       setProcessLoading(false);
     }
@@ -923,6 +944,7 @@ export default function RemoteToolsPage({
             deviceName={resolvedDeviceName}
             processes={processes}
             loading={processLoading}
+            loadError={processError}
             onRefresh={fetchProcesses}
             onKillProcess={handleKillProcess}
             onGetProcess={handleGetProcess}


### PR DESCRIPTION
## Summary

- Remote Tools → **Processes** on an offline device rendered `Processes 0 · No Data`, indistinguishable from a genuinely idle box, while the Terminal tab one click away explained why nothing was coming back.
- `RemoteToolsPage` now keeps the failure reason in a new `processError` state instead of swallowing it into `console.error`, reading the server's own message with the existing `extractApiError` helper (a 503 carries `{ error: 'The device is offline.', code: 'device_offline' }`).
- `ProcessManager` gains an optional `loadError` prop rendered as a failure pane with a Retry action, checked **before** the empty state — so "fetch failed" and "device reported zero processes" are mutually exclusive by construction, not by convention.
- The summary tiles show `-` and the `Showing 0 of 0 processes` footer is suppressed while the fetch is in a failed state; both were printing their initial zeroes as though they were measurements.
- The `No Data` empty state is untouched for a real 200 with zero rows, and is now pinned by a test.
- No new i18n keys, so all 8 locale files are unchanged.

## Root cause

`fetchProcesses` did `if (!res.ok) throw new Error(t('remoteToolsPage.errors.fetchProcesses'))` inside a `try` whose `catch` did nothing but `console.error`. The thrown message never reached state, so `processes` stayed at its `useState([])` initial value and `ProcessManager` — which only had `processes.length === 0` to go on — rendered `processManager.noData`. The API's 503 body from `apps/api/src/routes/systemTools/fileBrowserHelpers.ts` was discarded unread.

The zero-valued tiles and footer compounded it: they report counts derived from the same empty array, so the pane asserted "0 processes" three more times.

## Verification

Red first — the three failure-path tests were written before the fix and confirmed failing (9 passed / 3 failed), then all 12 passed after:

```
cd apps/web && npx vitest run src/components/remote/RemoteToolsPage.test.tsx
```
→ **12 passed / 0 failed**

```
cd apps/web && npx vitest run src/components/remote src/lib/i18n
```
→ **300 passed / 0 failed** across 28 files (includes `localeParity`, `translationCoverage`, `keyUsage`, `extractionQuality`, `terminologyQuality`)

```
cd apps/web && npx vitest run
```
→ **8369 passed / 0 failed** (full `apps/web` suite)

```
cd apps/web && npx tsc --noEmit -p tsconfig.json
```
→ clean, exit 0

```
cd apps/web && npx eslint src
```
→ clean, exit 0

New tests added to `apps/web/src/components/remote/RemoteToolsPage.test.tsx` (alongside source, per repo convention):

| Test | Pins |
|---|---|
| renders the offline reason instead of "No Data" when the API answers 503 | the fix; also asserts tiles show `-` and the count footer is gone |
| offers a retry that re-requests the process list | Retry re-issues the fetch |
| clears the error once a retry succeeds | recovery path, error does not stick |
| keeps the "No Data" empty state for a genuine 200 with zero rows | **guard** — pre-existing correct behaviour must not regress |
| renders rows and no error for a 200 with processes | **guard** — happy path |

One note on the full-suite run: the first invocation reported 2 failures in `LinkSubscriptionPicker.test.tsx` and `SoftwareGroupDrawer.test.tsx`. Both are unrelated components (Pax8 billing picker, vulnerability drawer) and both pass in isolation on a stashed clean `origin/main` **and** in isolation with this change; a second full run was 8369/8369 green. They are load-related async flakes, not caused by this diff.

## Decisions / notes for reviewer

- **The dispatch hint's premise was wrong, so I did not follow it literally.** It said to reuse "that exact banner/component" from the Terminal tab. There is no such thing: the Terminal tab (`RemoteTerminal.tsx`, the component actually mounted by `RemoteToolsPage`) has no offline banner — it writes errors into the xterm pane and fires `onError` → toast. The yellow banner in `RemoteTerminalPage.tsx` belongs to a component that **no Astro route mounts** (only re-exported from `components/remote/index.ts`; the real route `pages/remote/terminal/[deviceId].astro` imports `RemoteToolsPage`), i.e. effectively dead code. `deviceActions.unavailable.notOnline` ("Device is not online") is used only as a tooltip `title`, never as a banner. A repo-wide search found **no** `DeviceOfflineBanner`/`OfflineBanner`/`UnavailableBanner` component at all.
- **I reused the File Browser tab's pattern instead** — `FileManager.tsx:1471-1492`, a sibling tab inside this very page, already does exactly what the issue asks (`loading → error → empty → rows`, red `AlertCircle` + server message + `common:actions.retry`). Matching the neighbour that already got it right seemed better than inventing a new banner or resurrecting unrouted code. Flagging in case a maintainer would rather I extract that shared pane into a real component — I kept it inline to stay minimal, which also matches the 12 other inline `border-yellow-500/40` banners in the codebase.
- **Server message passthrough rather than a new translated key.** Copying English text into the 7 non-en locales would have broken `translationCoverage.test.ts`, which enforces *per-namespace per-locale* caps on exact-English duplicates (`remote.json`: pt-BR 12, es-419 12, fr-FR 18, fr-CA 17, de-DE 14, it-IT 14, tr-TR 4). Surfacing the API's own string (what `FileManager` already does) with the already-translated `remoteToolsPage.errors.fetchProcesses` as fallback avoids touching locale files entirely. Trade-off: the offline sentence itself is server-authored and therefore English-only. If maintainers want it localised, the right follow-up is to branch on the 503's `code` (`device_offline` / `device_unreachable` / `agent_timeout`) and map each to a genuinely translated key — no web code reads that `code` field today.
- **`setProcesses([])` on failure.** Without it, a device that goes offline while rows are on screen would show a stale list next to the error banner. Mirrors `FileManager`'s `setEntries([])`.
- **Scope: Processes only, as the issue specifies.** The same swallow-into-empty-list shape exists in `fetchServices`, `fetchEventLogs` and `fetchTasks` in this same file (identical `throw` → `console.error` → `useState([])`), so Services / Event Log / Scheduled Tabs have the same defect on an offline device. I left them alone to keep this reviewable and did not want to widen a release-sweep fix; `loadError` is now the pattern to copy if a maintainer wants them done. **Suggest filing a follow-up.**
- `fetchProcesses`'s `useCallback` deps stay `[deviceId]` (not adding `t`) to match the four sibling fetchers in this file; adding `t` would change effect re-run semantics on locale switch, which is out of scope here.
- No API, schema, migration, tenancy/RLS or agent surface touched, so no contract-suite or `db:check-drift` run applies.

Closes #4935

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code) via [Claude Code](https://claude.com/claude-code)