### PR TITLE
fix(agent): reboot deferral re-prompt and postponement WARN (#4941)

### DIFF
--- a/agent/internal/patching/reboot_manager.go
+++ b/agent/internal/patching/reboot_manager.go
@@ -219,11 +219,29 @@ func (r *RebootManager) ScheduleWithOptions(delay time.Duration, deadline time.T
 	return r.scheduleLocked(delay, deadline, reason, source, opts)
 }
 
+// leadRung says how a schedule's FIRST warning is delivered. An explicit
+// parameter rather than a flag on the manager: a postponement is the only thing
+// that quiets it, and a flag left set by a schedule that was then refused would
+// silently strip the dialog from the next operator dispatch.
+type leadRung int
+
+const (
+	// leadRungPrompts is an ordinary schedule: every rung the planner made
+	// deferrable offers a postponement, the lead one included.
+	leadRungPrompts leadRung = iota
+	// leadRungWarnsOnly is a schedule the user's own postponement re-planned
+	// (#4941). Its lead rung is armed at offset zero — the instant "not now" was
+	// accepted — so a dialog there hands back the question that was just
+	// answered, with the counter decremented. The warning still goes out; the
+	// next offer arrives with a reminder rung.
+	leadRungWarnsOnly
+)
+
 // scheduleLocked is the whole of ScheduleWithOptions with r.mu already held, so
 // that Defer can run its checks and its re-schedule as ONE atomic step. Callers
 // must hold r.mu.
 func (r *RebootManager) scheduleLocked(delay time.Duration, deadline time.Time, reason, source string, opts RebootOptions) error {
-	return r.scheduleLockedAt(r.nowFn(), delay, deadline, reason, source, opts)
+	return r.scheduleLockedAt(r.nowFn(), delay, deadline, reason, source, opts, leadRungPrompts)
 }
 
 // scheduleLockedAt takes the instant the delay is measured from, so a caller
@@ -232,7 +250,7 @@ func (r *RebootManager) scheduleLocked(delay time.Duration, deadline time.Time, 
 // against the first), which lands just past the deadline whenever the deferral
 // was clamped to it — and arbitrarily past it if the wall clock steps. Callers
 // must hold r.mu.
-func (r *RebootManager) scheduleLockedAt(now time.Time, delay time.Duration, deadline time.Time, reason, source string, opts RebootOptions) error {
+func (r *RebootManager) scheduleLockedAt(now time.Time, delay time.Duration, deadline time.Time, reason, source string, opts RebootOptions, lead leadRung) error {
 	if r.stopped {
 		return fmt.Errorf("reboot manager is stopped")
 	}
@@ -306,7 +324,13 @@ func (r *RebootManager) scheduleLockedAt(now time.Time, delay time.Duration, dea
 		// failure, so the field describes only the most recent attempt.
 	}
 
-	for _, rung := range planRebootRungs(plan) {
+	var rungs []rebootRung
+	if lead == leadRungWarnsOnly {
+		rungs = planRebootRungsQuietLead(plan)
+	} else {
+		rungs = planRebootRungs(plan)
+	}
+	for _, rung := range rungs {
 		rung := rung // capture for closure
 		r.notifyTimers = append(r.notifyTimers, r.afterFunc(rung.notification.After, func() {
 			r.emitNotification(gen, rung)
@@ -413,8 +437,11 @@ func (r *RebootManager) deferSchedule(gen *uint64) (time.Duration, error) {
 
 	// Re-schedule under the same options: it cancels the in-flight timers, bumps
 	// the generation and emits a fresh lead notification quoting the new time —
-	// which is exactly how the user learns the countdown moved.
-	if err := r.scheduleLockedAt(now, outcome.NewDelay, deadline, reason, source, RebootOptions{Deferral: policy}); err != nil {
+	// which is exactly how the user learns the countdown moved. That lead rung
+	// warns WITHOUT opening a dialog (#4941): it fires at offset zero, so a
+	// prompt there would hand back the question the user just answered.
+	if err := r.scheduleLockedAt(now, outcome.NewDelay, deadline, reason, source,
+		RebootOptions{Deferral: policy}, leadRungWarnsOnly); err != nil {
 		return 0, err
 	}
 
@@ -432,7 +459,8 @@ func (r *RebootManager) deferSchedule(gen *uint64) (time.Duration, error) {
 			"path", path, "deadline", deadline, "used", used, "error", err)
 	}
 	log.Info("reboot postponed by user",
-		"newDelay", outcome.NewDelay.String(), "used", used, "max", policy.MaxDeferrals)
+		"newDelay", outcome.NewDelay.String(), "used", used, "max", policy.MaxDeferrals,
+		"leadPromptSuppressed", true)
 	return outcome.NewDelay, nil
 }
 
@@ -707,7 +735,7 @@ func (r *RebootManager) restartNow(gen uint64) error {
 		return fmt.Errorf("the restart was cancelled or rescheduled while the prompt was open")
 	}
 	return r.scheduleLockedAt(r.nowFn(), MinRebootDelay, r.state.Deadline,
-		r.state.Reason, r.state.Source, RebootOptions{Deferral: r.deferral})
+		r.state.Reason, r.state.Source, RebootOptions{Deferral: r.deferral}, leadRungPrompts)
 }
 
 func (r *RebootManager) runOSReboot(gen uint64, grace time.Duration) {

--- a/agent/internal/patching/reboot_manager_prompt_test.go
+++ b/agent/internal/patching/reboot_manager_prompt_test.go
@@ -751,3 +751,139 @@ func TestAShownPromptIsNotFollowedByARedundantToast(t *testing.T) {
 		t.Errorf("notifications = %d, want 0 — the dialog was the warning: %+v", len(*notifications), *notifications)
 	}
 }
+
+// TestAPostponementDoesNotImmediatelyAskAgain is #4941. A postponement re-plans
+// the whole schedule, and the new plan's lead rung is armed at offset zero — the
+// instant the user's "not now" was accepted. While budget remains that rung is
+// deferrable, so the dialog the user just closed reopened in front of them with
+// the counter decremented ("You can postpone this restart 1 more time."). The
+// warning itself must still go out: telling the user the countdown moved is how
+// they learn the new time (#3197).
+func TestAPostponementDoesNotImmediatelyAskAgain(t *testing.T) {
+	rm, timers, notifications, osCalls, clock, prompts := newPromptTestManager(t, 3, rebootActionPostpone(time.Hour))
+	if err := rm.ScheduleWithOptions(60*time.Minute, clock.now().Add(5*time.Hour), "Patch", "patch_job",
+		allowDeferral(2, 60)); err != nil {
+		t.Fatalf("ScheduleWithOptions: %v", err)
+	}
+
+	timers.runAt(0) // the lead rung: the user postpones
+	if len(*prompts) != 1 {
+		t.Fatalf("prompts = %d, want 1", len(*prompts))
+	}
+	if got := rm.State().DeferralsUsed; got != 1 {
+		t.Fatalf("DeferralsUsed = %d, want 1 — the click did not postpone anything", got)
+	}
+
+	warned := len(*notifications)
+	timers.runAt(0) // the RE-PLANNED lead rung, which fires immediately
+
+	if len(*prompts) != 1 {
+		t.Errorf("prompts = %d, want 1 — a user who just postponed was handed the same dialog back (#4941)",
+			len(*prompts))
+	}
+	if len(*notifications) <= warned {
+		t.Error("the re-planned lead rung warned nobody; the user must still be told the new restart time (#3197)")
+	}
+	if len(*osCalls) != 0 {
+		t.Error("a postponement invoked the OS reboot")
+	}
+	if got := rm.State().DeferralsUsed; got != 1 {
+		t.Errorf("DeferralsUsed = %d, want 1 — the re-planned lead rung spent budget nobody asked for", got)
+	}
+}
+
+// TestTheNextPostponementOfferArrivesWithAReminderRung pins the other half of
+// #4941's fix: quieting the re-planned lead rung must not cost the user the rest
+// of their budget. The reminder rungs of the new schedule still offer it.
+func TestTheNextPostponementOfferArrivesWithAReminderRung(t *testing.T) {
+	rm, timers, _, _, clock, prompts := newPromptTestManager(t, 3, rebootActionPostpone(time.Hour))
+	if err := rm.ScheduleWithOptions(15*time.Minute, clock.now().Add(5*time.Hour), "Patch", "patch_job",
+		allowDeferral(2, 60)); err != nil {
+		t.Fatalf("ScheduleWithOptions: %v", err)
+	}
+
+	timers.runAt(0) // the lead rung: postponed, so the schedule is now 75 minutes
+	plan := PlanReboot(75 * time.Minute)
+	if len(plan.Notifications) < 2 {
+		t.Fatalf("the re-planned ladder has %d rungs, want a reminder after the lead", len(plan.Notifications))
+	}
+
+	timers.runAt(0) // the re-planned lead rung warns without a dialog
+	if len(*prompts) != 1 {
+		t.Fatalf("prompts = %d after the re-planned lead rung, want 1 (#4941)", len(*prompts))
+	}
+
+	timers.runAt(plan.Notifications[1].After) // the first reminder rung
+	if len(*prompts) != 2 {
+		t.Fatalf("prompts = %d, want 2 — the reminder rungs must still offer the remaining postponement", len(*prompts))
+	}
+	if got := len((*prompts)[1].actions); got != 2 {
+		t.Errorf("the reminder rung offered %d button(s), want the postponement as well", got)
+	}
+}
+
+// TestAFreshScheduleStillPromptsAtItsLeadRung guards the scope of #4941: the
+// quiet lead rung belongs to the re-plan a postponement caused, not to every
+// schedule that follows one. An operator's next dispatch is a fresh decision and
+// must still offer the postponement the moment it lands.
+func TestAFreshScheduleStillPromptsAtItsLeadRung(t *testing.T) {
+	rm, timers, _, _, clock, prompts := newPromptTestManager(t, 3)
+	if err := rm.ScheduleWithOptions(15*time.Minute, clock.now().Add(5*time.Hour), "Patch", "patch_job",
+		allowDeferral(2, 60)); err != nil {
+		t.Fatalf("ScheduleWithOptions: %v", err)
+	}
+	if _, err := rm.Defer(); err != nil {
+		t.Fatalf("Defer: %v", err)
+	}
+
+	// A second, unrelated dispatch supersedes the postponed schedule.
+	if err := rm.ScheduleWithOptions(30*time.Minute, clock.now().Add(5*time.Hour), "Second", "manual",
+		allowDeferral(2, 60)); err != nil {
+		t.Fatalf("replacement ScheduleWithOptions: %v", err)
+	}
+
+	timers.runAt(0)
+
+	if len(*prompts) != 1 {
+		t.Fatalf("prompts = %d, want 1 — the fresh schedule's lead rung must still offer a postponement", len(*prompts))
+	}
+	if got := len((*prompts)[0].actions); got != 2 {
+		t.Errorf("the fresh lead rung offered %d button(s), want 2", got)
+	}
+}
+
+// TestPlanRebootRungsQuietLead is the pure-data half of #4941: only the lead
+// rung's dialog goes away. Its warning text is untouched, and every later rung —
+// including the closing one, which was never deferrable — is bit-for-bit what
+// planRebootRungs produced.
+func TestPlanRebootRungsQuietLead(t *testing.T) {
+	t.Parallel()
+	for _, delay := range []time.Duration{
+		MinRebootDelay, 4 * time.Minute, 15 * time.Minute, 61 * time.Minute,
+		75 * time.Minute, 4 * time.Hour, 24 * time.Hour,
+	} {
+		t.Run(delay.String(), func(t *testing.T) {
+			plan := PlanReboot(delay)
+			loud := planRebootRungs(plan)
+			quiet := planRebootRungsQuietLead(plan)
+
+			if len(quiet) != len(loud) {
+				t.Fatalf("rungs = %d, want %d", len(quiet), len(loud))
+			}
+			if quiet[0].deferrable {
+				t.Error("the lead rung is still deferrable, so it still opens a dialog")
+			}
+			if quiet[0].promptWindow != 0 {
+				t.Errorf("lead promptWindow = %v, want 0", quiet[0].promptWindow)
+			}
+			if quiet[0].notification != loud[0].notification {
+				t.Errorf("the lead warning changed:\n%+v\nwant\n%+v", quiet[0].notification, loud[0].notification)
+			}
+			for i := 1; i < len(quiet); i++ {
+				if quiet[i] != loud[i] {
+					t.Errorf("rung %d changed:\n%+v\nwant\n%+v", i, quiet[i], loud[i])
+				}
+			}
+		})
+	}
+}

--- a/agent/internal/patching/reboot_prompt.go
+++ b/agent/internal/patching/reboot_prompt.go
@@ -92,6 +92,25 @@ func planRebootRungs(plan RebootPlan) []rebootRung {
 	return rungs
 }
 
+// planRebootRungsQuietLead is planRebootRungs for a schedule that a user's own
+// postponement just re-planned (#4941).
+//
+// The lead rung of any plan fires at offset zero, so re-planning arms it at the
+// instant the postponement was granted. Left deferrable it reopens the very
+// dialog the user just answered — same question, counter decremented — which
+// reads as the click not having worked. The warning itself is untouched: it is
+// how the user learns the new restart time (#3197). Only the dialog goes away,
+// and only on that one rung, so the rest of the budget is still offered by the
+// reminder rungs of the new ladder.
+func planRebootRungsQuietLead(plan RebootPlan) []rebootRung {
+	rungs := planRebootRungs(plan)
+	if len(rungs) > 0 {
+		rungs[0].deferrable = false
+		rungs[0].promptWindow = 0
+	}
+	return rungs
+}
+
 // rebootDeferralNote is the line appended to a deferrable reboot's warning so the
 // user can see where they stand. Empty when the policy is off, which is what
 // keeps a non-deferrable reboot's copy byte-for-byte identical to today's.

--- a/agent/internal/patching/reboot_prompt_desktop.go
+++ b/agent/internal/patching/reboot_prompt_desktop.go
@@ -248,6 +248,23 @@ func zenityPromptArgs(title, body string, actions []string, timeout time.Duratio
 	return append(args, "--timeout="+strconv.Itoa(dialogTimeoutSeconds(timeout)))
 }
 
+// recognisedExtraButton returns the postponement label this dialog offered when
+// the child printed exactly it, and "" otherwise.
+//
+// Only an exact match counts, so an unexpected line on stdout is read as no
+// decision rather than guessed at. Shared by zenityResult and the log decision
+// below: the WARN must never contradict the answer the manager acted on, which
+// is what happened when each of them applied its own reading of exit 1 (#4941).
+func recognisedExtraButton(stdout string, actions []string) string {
+	if len(actions) < 2 {
+		return ""
+	}
+	if printed := strings.TrimSpace(stdout); printed == actions[1] {
+		return actions[1]
+	}
+	return ""
+}
+
 // zenityResult maps one dialog run onto the PromptFunc contract.
 //
 // The two return values answer different questions and the manager branches on
@@ -277,13 +294,11 @@ func zenityResult(run desktopDialogRun, actions []string) (string, bool) {
 		return "", true
 	case zenityExitCancel:
 		// Cancel, ESC and the close box print nothing; an --extra-button prints
-		// its own label. Only an exact match counts, so an unexpected line is
-		// read as no decision rather than guessed at.
-		printed := strings.TrimSpace(run.stdout)
-		if len(actions) > 1 && printed == actions[1] {
+		// its own label.
+		if label := recognisedExtraButton(run.stdout, actions); label != "" {
 			// A button we offered came back. Nothing can print that but a
 			// rendered dialog, so this is positive proof of delivery.
-			return actions[1], true
+			return label, true
 		}
 		// Exit 1 with nothing on stdout is the ambiguous case: a dismissal and
 		// a display failure are indistinguishable on the exit code alone.
@@ -300,6 +315,59 @@ func zenityResult(run desktopDialogRun, actions []string) (string, bool) {
 		// manager still warns the user through the ordinary path.
 		return "", false
 	}
+}
+
+// dialogEndedInCleanDecision reports whether one dialog run ended in a decision
+// this code positively understood, which is the only case the "did not end in a
+// clean decision" WARN stays quiet about (#4941).
+//
+// Exit 1 is zenity's overloaded status: Cancel, the window's close box, ESC and
+// every --extra-button all report it, and only stdout tells them apart. Reading
+// the exit code alone as "not clean" logged a WARN for every postponement on
+// every Linux endpoint — "the dialog did not end in a clean decision" one line
+// above "reboot postponed by user", for a dialog that had just been read and
+// acted on.
+//
+// Everything else keeps warning, including every case where nothing reached a
+// person. That is deliberate and is why shown is an input rather than something
+// this function recomputes: a GTK failure to open the display exits 1 exactly
+// like a Cancel, and leaving a trace of it is the reason this log line exists at
+// all. zenity's own timeout (exit 5) also keeps warning — it ended with no
+// decision, which is what the message says.
+func dialogEndedInCleanDecision(run desktopDialogRun, actions []string, shown bool) bool {
+	if !run.started || run.timedOut || !shown {
+		return false
+	}
+	switch run.exitCode {
+	case zenityExitOK:
+		// "Restart now": unambiguous on the exit code alone.
+		return true
+	case zenityExitCancel:
+		// Ambiguous on the exit code; a recognised label on stdout is what turns
+		// it into the offer the manager then granted.
+		return recognisedExtraButton(run.stdout, actions) != ""
+	default:
+		return false
+	}
+}
+
+// logDialogOutcome leaves the one trace a dialog that did not end cleanly has
+// behind it: session, user, exit code, whether the agent killed it, how long it
+// lived and what the child complained about on stderr — the evidence that tells a
+// display failure apart from a dismissal.
+//
+// Untagged, with the decision it applies, so the rule is asserted by tests that
+// run on every platform; the linux seam that calls it is built only in the linux
+// job (#3019, #3046).
+func logDialogOutcome(sessionID, username string, run desktopDialogRun, actions []string, shown bool) {
+	if dialogEndedInCleanDecision(run, actions, shown) {
+		return
+	}
+	log.Warn("the reboot dialog did not end in a clean decision",
+		"session", sessionID, "user", username,
+		"exitCode", run.exitCode, "timedOut", run.timedOut,
+		"elapsedMs", run.elapsed.Milliseconds(), "shown", shown,
+		"stderr", run.stderr)
 }
 
 // notifySendUrgencies is the set notify-send accepts. Anything else makes it

--- a/agent/internal/patching/reboot_prompt_desktop_linux.go
+++ b/agent/internal/patching/reboot_prompt_desktop_linux.go
@@ -147,17 +147,10 @@ func runZenityPrompt(ctx context.Context, s linuxsession.GraphicalSession, title
 		exitCode, stdout.String(), truncateForLog(stderr.String()), elapsed)
 
 	clicked, shown := zenityResult(run, actions)
-	// Logged on EVERY non-clean exit, not only on codes this code does not
-	// recognise. Exit 1 is a recognised code and is also what a display failure
-	// produces, so restricting the log to "unexpected" codes is exactly how the
-	// failure that matters most ends up with no trace at all.
-	if run.exitCode != zenityExitOK || !shown {
-		log.Warn("the reboot dialog did not end in a clean decision",
-			"session", s.ID, "user", s.Username,
-			"exitCode", run.exitCode, "timedOut", run.timedOut,
-			"elapsedMs", elapsed.Milliseconds(), "shown", shown,
-			"stderr", run.stderr)
-	}
+	// Which outcomes deserve a WARN is a decision about the dialog's semantics,
+	// so it lives in the untagged file with the rest of them and is tested on
+	// every platform (#4941). This file only supplies the evidence.
+	logDialogOutcome(s.ID, s.Username, run, actions, shown)
 	return clicked, shown
 }
 

--- a/agent/internal/patching/reboot_prompt_desktop_test.go
+++ b/agent/internal/patching/reboot_prompt_desktop_test.go
@@ -1,13 +1,17 @@
 package patching
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"reflect"
+	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/breeze-rmm/agent/internal/logging"
 	"github.com/breeze-rmm/agent/internal/patching/linuxsession"
 )
 
@@ -522,3 +526,179 @@ func TestPromptOrNotifyDesktop(t *testing.T) {
 }
 
 var errUnusableLogind = errors.New("loginctl reported sessions but none could be queried")
+
+// syncBuffer is a mutex-guarded bytes.Buffer. The package logger is global, so
+// any goroutine left over from another test in this package can write to it
+// concurrently, which -race would (correctly) flag on a bare buffer.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *syncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+// captureWarnLogs points the package logger at a buffer for the duration of the
+// test, following sessionbroker's captureLogs. Global state, so a test using it
+// must not be parallel.
+func captureWarnLogs(t *testing.T) *syncBuffer {
+	t.Helper()
+	buf := &syncBuffer{}
+	logging.Init("text", "warn", buf)
+	t.Cleanup(func() {
+		logging.Init("text", "info", nil)
+	})
+	return buf
+}
+
+// TestDialogEndedInCleanDecision is the second half of #4941. zenity exits 1 for
+// Cancel, the window's close box, ESC AND every --extra-button; only stdout tells
+// them apart. Treating the exit code alone as "not clean" logged a WARN for every
+// postponement on every Linux endpoint, one line above the line saying the
+// postponement had been granted.
+func TestDialogEndedInCleanDecision(t *testing.T) {
+	const dismissed = 3 * time.Second // long enough that a person could have acted
+	cases := []struct {
+		name string
+		run  desktopDialogRun
+		// actions defaults to testPromptActions when nil.
+		actions []string
+		shown   bool
+		want    bool
+	}{
+		{
+			name: "Restart now", shown: true, want: true,
+			run: desktopDialogRun{started: true, exitCode: 0, elapsed: dismissed},
+		},
+		{
+			// THE fix: an --extra-button press exits 1 like a Cancel, but it
+			// prints the label we offered, which is the decision the manager acts on.
+			name: "a postponement press is a decision, not an ambiguity", shown: true, want: true,
+			run: desktopDialogRun{started: true, exitCode: 1, stdout: "Postpone 1 hour\n", elapsed: dismissed},
+		},
+		{
+			name: "a postponement pressed quickly is still a decision", shown: true, want: true,
+			run: desktopDialogRun{started: true, exitCode: 1, stdout: "Postpone 1 hour", elapsed: 5 * time.Millisecond},
+		},
+		{
+			// Still ambiguous: a dismissal and a display failure are
+			// indistinguishable on the exit code, so this keeps its trace.
+			name: "exit 1 with nothing on stdout", shown: true, want: false,
+			run: desktopDialogRun{started: true, exitCode: 1, elapsed: dismissed},
+		},
+		{
+			name: "an unrecognised stdout is not a decision", shown: true, want: false,
+			run: desktopDialogRun{started: true, exitCode: 1, stdout: "Restart now", elapsed: dismissed},
+		},
+		{
+			// A label we offered, arriving with an action list that never
+			// contained it, is not proof of anything.
+			name: "a postponement label nobody offered", shown: true, want: false,
+			actions: []string{RebootActionRestartNow},
+			run:     desktopDialogRun{started: true, exitCode: 1, stdout: "Postpone 1 hour", elapsed: dismissed},
+		},
+		{
+			name: "a GTK display failure exits 1 as well", shown: false, want: false,
+			run: desktopDialogRun{started: true, exitCode: 1, elapsed: 12 * time.Millisecond,
+				stderr: "Gtk-WARNING **: cannot open display: :0"},
+		},
+		{
+			name: "zenity's own timeout reached no decision", shown: true, want: false,
+			run: desktopDialogRun{started: true, exitCode: 5, elapsed: 90 * time.Second},
+		},
+		{
+			name: "a dialog we had to kill", shown: false, want: false,
+			run: desktopDialogRun{started: true, timedOut: true, exitCode: -1, elapsed: 105 * time.Second},
+		},
+		{
+			name: "zenity never started", shown: false, want: false,
+			run: desktopDialogRun{},
+		},
+		{
+			// classifyDialogRun's "Wait failed with no exit status" branch: exit
+			// code reads as 0, but nothing can be concluded from it.
+			name: "no exit status and nothing shown", shown: false, want: false,
+			run: desktopDialogRun{exitCode: 0},
+		},
+		{
+			name: "an unknown exit code", shown: false, want: false,
+			run: desktopDialogRun{started: true, exitCode: 3, elapsed: dismissed},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actions := tc.actions
+			if actions == nil {
+				actions = testPromptActions
+			}
+			if got := dialogEndedInCleanDecision(tc.run, actions, tc.shown); got != tc.want {
+				t.Errorf("dialogEndedInCleanDecision(%+v, %v, shown=%v) = %v, want %v",
+					tc.run, actions, tc.shown, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLogDialogOutcomeStaysQuietOnAPostponement drives the log line #4941 quotes
+// through the function the linux seam calls, so the WARN itself — not only the
+// predicate underneath it — is asserted on a platform that never runs zenity.
+func TestLogDialogOutcomeStaysQuietOnAPostponement(t *testing.T) {
+	const warned = "the reboot dialog did not end in a clean decision"
+	cases := []struct {
+		name     string
+		run      desktopDialogRun
+		shown    bool
+		wantWarn bool
+	}{
+		{
+			name: "a postponement press", wantWarn: false, shown: true,
+			run: desktopDialogRun{started: true, exitCode: 1, stdout: "Postpone 1 hour\n", elapsed: 4 * time.Second},
+		},
+		{
+			name: "Restart now", wantWarn: false, shown: true,
+			run: desktopDialogRun{started: true, exitCode: 0, elapsed: 4 * time.Second},
+		},
+		{
+			name: "exit 1 with no stdout label", wantWarn: true, shown: true,
+			run: desktopDialogRun{started: true, exitCode: 1, elapsed: 4 * time.Second},
+		},
+		{
+			name: "a display failure the user never saw", wantWarn: true, shown: false,
+			run: desktopDialogRun{started: true, exitCode: 1, elapsed: 12 * time.Millisecond,
+				stderr: "Gtk-WARNING **: cannot open display: :0"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			logs := captureWarnLogs(t)
+
+			logDialogOutcome("c18", "todd", tc.run, testPromptActions, tc.shown)
+
+			got := logs.String()
+			if strings.Contains(got, warned) != tc.wantWarn {
+				t.Fatalf("WARN logged = %v, want %v; logs:\n%s", !tc.wantWarn, tc.wantWarn, got)
+			}
+			if !tc.wantWarn {
+				return
+			}
+			// The warning that does fire still has to carry the evidence a
+			// support engineer needs to tell a display failure from a dismissal.
+			for _, want := range []string{"level=WARN", "session=c18", "user=todd", "exitCode=1", "shown=" + strconv.FormatBool(tc.shown)} {
+				if !strings.Contains(got, want) {
+					t.Errorf("the WARN lost %q; logs:\n%s", want, got)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **Postponing no longer re-opens the dialog.** A postponement re-plans the schedule, and the new plan's lead rung is armed at offset zero — the instant "not now" was accepted — so while budget remained the user was handed the same question back with the counter decremented. The re-planned lead rung now warns *without* a dialog (`planRebootRungsQuietLead`); the next offer arrives with a reminder rung. The closing rung was never deferrable and still is not.
- **The warning itself is untouched.** The user is still told the new restart time at offset zero (#3197) — that is how they learn the countdown moved. Only the dialog goes away, and only on that one rung.
- **Linux no longer logs a WARN for a clean postponement.** zenity exits 1 for Cancel, the close box, ESC *and* every `--extra-button`; only stdout tells them apart. A recognised extra-button label is now a clean decision, so `WARN the reboot dialog did not end in a clean decision` no longer sits directly above `INFO reboot postponed by user`.
- **The WARN decision moved to the untagged file** (`dialogEndedInCleanDecision` + `logDialogOutcome`), next to the `zenityResult` whose answer it must never contradict, and is now covered by tests that run on every platform (#3019, #3046). Both read exit 1 through one shared `recognisedExtraButton`.
- `reboot postponed by user` gains `leadPromptSuppressed=true`, so the log distinguishes a deliberately suppressed lead dialog from a missing one.
- Agent only — no API, schema, migration or web change. Deferral-off schedules (every pre-#3207 call site) take a byte-identical path.

## Root cause

Two independent causes, one per symptom.

**1. The re-plan inherits a lead rung at offset zero.** `PlanReboot` guarantees `Notifications[0].After == 0` (the #3197 always-warn invariant), and `planRebootRungs` marks every non-closing rung deferrable whenever there is room for a dialog. `deferSchedule` re-plans through `scheduleLockedAt`, so the guarantee that makes the ladder safe also armed a *deferrable* rung at the exact instant the postponement was granted:

```
11:37:40 reboot scheduled delay=9m22s notifications=2 …   ← the re-plan
11:37:40 reboot postponed by user newDelay=9m22s used=1 max=2
(new dialog on screen at 11:37:41)
```

Nothing in the manager distinguished "a schedule an operator dispatched" from "a schedule the user's own click produced", so both prompted.

**2. The WARN was gated on the exit code, not on the resolved answer.** `runZenityPrompt` logged when `run.exitCode != zenityExitOK || !shown`. Exit 1 is zenity's documented, deliberately overloaded status, and `zenityResult` had already resolved it correctly from stdout one line earlier — so the log contradicted the decision the manager acted on, for every `--extra-button` press on every Linux endpoint.

## Verification

All commands run from `agent/` in this worktree, in the foreground (`go1.27.0 darwin/arm64`).

**Red first.** New manager tests in place, no production change yet (the pure `planRebootRungsQuietLead` helper was added before it was wired, so it and the scope guard pass from the start):

```
go test -race -count=1 -run 'TestAPostponementDoesNotImmediatelyAskAgain|TestTheNextPostponementOfferArrivesWithAReminderRung|TestAFreshScheduleStillPromptsAtItsLeadRung|TestPlanRebootRungsQuietLead' ./internal/patching/
```

→ 2 failures: `prompts = 2, want 1 — a user who just postponed was handed the same dialog back (#4941)`, `the re-planned lead rung warned nobody; the user must still be told the new restart time (#3197)`, `prompts = 2 after the re-planned lead rung, want 1 (#4941)`. 2 passed (guard + pure helper).

```
go test -race -count=1 -run 'TestDialogEndedInCleanDecision|TestLogDialogOutcomeStaysQuietOnAPostponement' ./internal/patching/
```

→ build failed: `undefined: dialogEndedInCleanDecision`, `undefined: logDialogOutcome` (a new pure seam, so its red is a compile failure; 16 subtests pass once it exists).

**Green:**

| Command | Result |
|---|---|
| `go test -race -count=1 ./internal/patching/` | `ok` 20.8s — **209 top-level tests + 146 subtests, 0 failures** |
| `go test -race -count=1 ./internal/patching/... ./internal/heartbeat/...` | 3 packages `ok` (patching 22.3s, linuxsession 1.2s, heartbeat 50.4s) |
| `go test -race -count=1 ./...` (whole agent) | no `FAIL` lines |
| `go vet ./...` | clean |
| `GOOS=linux go vet ./internal/patching/...` | clean — type-checks the linux zenity seam that calls `logDialogOutcome` |
| `GOOS=windows go vet ./internal/patching/...` | clean |
| `GOOS=linux`, `GOOS=windows`, `GOOS=darwin` `go build ./...` | all OK |
| `gofmt -l ./internal/patching` | clean |

New tests: 6 top-level, 23 subtests — `TestAPostponementDoesNotImmediatelyAskAgain`, `TestTheNextPostponementOfferArrivesWithAReminderRung`, `TestAFreshScheduleStillPromptsAtItsLeadRung`, `TestPlanRebootRungsQuietLead` (7), `TestDialogEndedInCleanDecision` (12), `TestLogDialogOutcomeStaysQuietOnAPostponement` (4). The last drives the real log line through a captured `logging.Init` writer, so the WARN itself is asserted on a platform that never runs zenity.

`agent/internal/heartbeat/consent_test.go` and `handlers_desktop_consent_test.go` were already `gofmt`-dirty on `main`; left untouched.

## Decisions / notes for reviewer

1. **Chose "suppress the lead rung's prompt" over "delay it by the postponement window"** (the issue offers both). Suppression keeps the ladder arithmetic as pure data in one place; a delayed prompt would need a second timer per rung plus a rule for when the postponement window is shorter than the dialog's own 2-minute cap.
2. **Consequence worth stating explicitly:** when the re-planned delay is short enough that the ladder has no reminder rungs — the issue's own `9m22s` is exactly that case (`PlanReboot` yields only a lead and a closing rung, `notifications=2`) — the user gets **no further postponement offer** for that schedule. The budget is not lost, only unoffered until the next dispatch. I judged that better than re-asking instantly and it is what the issue asks for; flagging it in case you want a floor (one quiet period, then prompt).
3. **`leadRung` is a parameter, not a manager flag.** `scheduleLockedAt` refuses early in several places (stopped, an OS invocation in flight, an abort in flight, an OS countdown it cannot abort). A flag set before the call would survive a refusal and silently strip the dialog from the *next* operator dispatch. `TestAFreshScheduleStillPromptsAtItsLeadRung` pins the scope.
4. **The WARN still fires for zenity's own timeout (exit 5) and for every case where nothing reached a person.** The issue asks only for the extra-button press to stop warning; narrowing further would drop the trace that distinguishes a GTK display failure from a dismissal, which is the reason that line exists.
5. **The suppressed lead rung still carries the deferral note** ("You can postpone this restart 1 more time.") in the toast. That is honest — the budget is still there and a later rung or the console will offer it — but say the word if you would rather the toast not mention a button it is not showing.
6. **`restartNow` passes `leadRungPrompts` (unchanged):** `PlanReboot(MinRebootDelay)` collapses to the closing rung alone, which is never deferrable, so there is no dialog to suppress — and its doc comment still promises the policy is carried over.
7. **Sibling PR #4993 (#4940)** is in the same feature area but touches only `agent/internal/sessionbroker/`: no file overlap and no semantic overlap (that one stops two helpers drawing on one Windows screen; this one stops the manager re-asking after a postponement). Either merge order works.
8. **Trailer note:** the dispatch template's `Co-Authored-By` address contained a space (`<noreply @alibabacloud.com>`), which is not a parseable trailer email, so it was committed as `<noreply@alibabacloud.com>` to match the repo's existing trailer style.

Closes #4941

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code) via [Claude Code](https://claude.com/claude-code)