### PR TITLE
fix(rls): partner-wide SELECT branch for identity-contracts tables (#4959, #4960, #4961, #4962, #4963, #4970)

### DIFF
--- a/apps/api/migrations/2026-10-10-100400-identity-contracts-partner-wide-select.sql
+++ b/apps/api/migrations/2026-10-10-100400-identity-contracts-partner-wide-select.sql
@@ -1,0 +1,85 @@
+-- Partner-wide READ branch on the identity/contracts config tables — the
+-- follow-up group of epic #4673.
+--
+--   #4959 sso_providers
+--   #4960 ticket_forms
+--   #4961 contract_templates
+--   #4962 contract_template_versions
+--   #4963 psa_connections
+--   #4970 access_reviews
+--
+-- All six carry `org_id` XOR `partner_id` directly on the row, so each takes
+-- the direct-column form of the branch. A partner-wide row (`org_id NULL,
+-- partner_id = P`) is invisible to an ORG-scoped session of P today:
+-- `breeze_has_org_access(NULL)` is false, and `breeze_has_partner_access(P)` is
+-- false because org scope carries an empty `accessible_partner_ids`. Readers
+-- therefore escalate through the #1105 pattern
+-- (`runOutsideDbContext(() => withSystemDbAccessContext(...))`), which
+-- double-holds a pooled connection under the request's own transaction and
+-- bypasses RLS entirely.
+--
+-- The fix and every design decision behind it are documented in full in the
+-- template this file follows:
+-- 2026-10-05-110000-config-policy-partner-wide-select.sql. In short — a
+-- SELECT-only own-partner branch keyed on `public.breeze_current_partner_id()`
+-- (created by 2026-06-13-catalog-partner-read-branch.sql; NOT recreated here),
+-- added as a SEPARATE permissive policy per table. Appending the branch to an
+-- existing FOR ALL `USING` would also widen UPDATE/DELETE row targeting, so an
+-- org admin could rewrite or delete their MSP's shared rows; Postgres never
+-- consults a FOR SELECT policy when computing write targets, so a separate
+-- policy ORs into reads and nothing else. Existing policies are left
+-- byte-identical.
+--
+-- Scope behaviour: org scope fires for its own partner's partner-wide rows;
+-- partner scope is already covered by `breeze_has_partner_access` (redundant
+-- but harmless — permissive policies OR); system scope short-circuits earlier;
+-- agent scope leaves the GUC NULL, and `partner_id = NULL` is NULL, never true
+-- (this is why the predicate uses `=` and not `IS NOT DISTINCT FROM`).
+--
+-- Writes no rows, so no `breeze.scope` elevation is needed.
+-- Idempotent: DROP POLICY IF EXISTS then CREATE, so re-applying is a no-op.
+-- No inner BEGIN/COMMIT — autoMigrate wraps each file in a transaction.
+--
+-- Functional proof: identityContractsPartnerWideSelect.integration.test.ts.
+-- Shape contract: rls-coverage.integration.test.ts (these six tables left
+-- PARTNER_WIDE_SELECT_BRANCH_EXEMPT in the same change).
+--
+-- Rollback: a new migration issuing the six matching
+-- `DROP POLICY IF EXISTS <table>_partner_wide_select` statements. The policies
+-- are purely additive and no application code depends on them yet.
+
+DROP POLICY IF EXISTS sso_providers_partner_wide_select ON public.sso_providers;
+CREATE POLICY sso_providers_partner_wide_select
+  ON public.sso_providers
+  FOR SELECT
+  USING (org_id IS NULL AND partner_id = public.breeze_current_partner_id());
+
+DROP POLICY IF EXISTS ticket_forms_partner_wide_select ON public.ticket_forms;
+CREATE POLICY ticket_forms_partner_wide_select
+  ON public.ticket_forms
+  FOR SELECT
+  USING (org_id IS NULL AND partner_id = public.breeze_current_partner_id());
+
+DROP POLICY IF EXISTS contract_templates_partner_wide_select ON public.contract_templates;
+CREATE POLICY contract_templates_partner_wide_select
+  ON public.contract_templates
+  FOR SELECT
+  USING (org_id IS NULL AND partner_id = public.breeze_current_partner_id());
+
+DROP POLICY IF EXISTS contract_template_versions_partner_wide_select ON public.contract_template_versions;
+CREATE POLICY contract_template_versions_partner_wide_select
+  ON public.contract_template_versions
+  FOR SELECT
+  USING (org_id IS NULL AND partner_id = public.breeze_current_partner_id());
+
+DROP POLICY IF EXISTS psa_connections_partner_wide_select ON public.psa_connections;
+CREATE POLICY psa_connections_partner_wide_select
+  ON public.psa_connections
+  FOR SELECT
+  USING (org_id IS NULL AND partner_id = public.breeze_current_partner_id());
+
+DROP POLICY IF EXISTS access_reviews_partner_wide_select ON public.access_reviews;
+CREATE POLICY access_reviews_partner_wide_select
+  ON public.access_reviews
+  FOR SELECT
+  USING (org_id IS NULL AND partner_id = public.breeze_current_partner_id());

--- a/apps/api/src/__tests__/integration/identityContractsPartnerWideSelect.integration.test.ts
+++ b/apps/api/src/__tests__/integration/identityContractsPartnerWideSelect.integration.test.ts
@@ -1,0 +1,423 @@
+/**
+ * Partner-wide READ branch on the identity/contracts config tables
+ * (#4959 sso_providers, #4960 ticket_forms, #4961 contract_templates,
+ * #4962 contract_template_versions, #4963 psa_connections, #4970
+ * access_reviews — the follow-up group of epic #4673).
+ *
+ * Migration under test:
+ * 2026-10-10-100400-identity-contracts-partner-wide-select.sql.
+ *
+ * Every table here is `org_id` XOR `partner_id` carried directly on the row, so
+ * each takes the direct-column form of the branch:
+ *
+ *   <table>_partner_wide_select  FOR SELECT USING (
+ *     org_id IS NULL AND partner_id = public.breeze_current_partner_id()
+ *   )
+ *
+ * Before this migration an ORG-scoped session could not see its own MSP's
+ * partner-wide row at all: `breeze_has_org_access(NULL)` is false, and
+ * `breeze_has_partner_access(P)` is false because org scope carries
+ * `accessiblePartnerIds: []`. Readers therefore escalate through the #1105
+ * pattern (`runOutsideDbContext(() => withSystemDbAccessContext(...))`), which
+ * double-holds a pooled connection and bypasses RLS entirely — see the header
+ * of 2026-10-05-110000-config-policy-partner-wide-select.sql, whose suite
+ * (configPolicyPartnerWideSelect.integration.test.ts) this one mirrors.
+ *
+ * Three properties, per table, none reachable from a mocked unit test (no RLS
+ * runs there) and none proven by rls-coverage either (that is a pg_catalog
+ * shape inspection, not a functional one):
+ *
+ *  (a) an ORG session of the OWNING partner SELECTs BOTH its own org-owned row
+ *      and the partner-wide row;
+ *  (b) an ORG session under a DIFFERENT partner sees NEITHER;
+ *  (c) the branch is READ-ONLY — that same org session cannot UPDATE or DELETE
+ *      the partner-wide row. Note the denial is a silent ZERO-ROWS no-op, not a
+ *      42501: RLS hides the target row from the write command rather than
+ *      raising. A test that only asserted "it threw" would be vacuous, so both
+ *      the returned row count AND a system-scope re-read are asserted.
+ *
+ * Plus the NULL-GUC guard: an agent-shaped context leaves
+ * `breeze_current_partner_id()` NULL, and `partner_id = NULL` is NULL (never
+ * true), so the branch must not fire. That is what keeps the predicate honest
+ * as `=` rather than `IS NOT DISTINCT FROM`.
+ *
+ * Seeding runs under SYSTEM scope on purpose: the write policies these tables
+ * already have are proven by their own `<table>PartnerRls.integration.test.ts`
+ * suites, and seeding here must not depend on them.
+ */
+import './setup';
+import { afterEach, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withDbAccessContext, type DbAccessContext } from '../../db';
+import {
+  accessReviews,
+  contractTemplates,
+  contractTemplateVersions,
+  psaConnections,
+  ssoProviders,
+  ticketForms,
+} from '../../db/schema';
+import { createOrganization, createPartner } from './db-utils';
+
+const SYSTEM_CTX: DbAccessContext = {
+  scope: 'system',
+  orgId: null,
+  accessibleOrgIds: null,
+  accessiblePartnerIds: null,
+  userId: null,
+};
+
+/**
+ * An ORG-scoped session. `currentPartnerId` is populated from the token's
+ * partnerId for org scope too (`buildDbAccessContext`, middleware/auth.ts),
+ * which is exactly what the read branch keys on — so it is set deliberately.
+ * `accessiblePartnerIds` stays EMPTY: an org token never passes
+ * `breeze_has_partner_access`, and that is what keeps the branch read-only.
+ *
+ * Passing `currentPartnerId: null` yields the AGENT session shape.
+ */
+function orgContext(orgId: string, currentPartnerId: string | null): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    userId: null,
+    currentPartnerId,
+  };
+}
+
+const MARKER = 'HIJACKED';
+
+/** Cleanup thunks, run under SYSTEM scope after each test (LIFO: children first). */
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  if (cleanups.length === 0) return;
+  const pending = cleanups.splice(0, cleanups.length).reverse();
+  await withDbAccessContext(SYSTEM_CTX, async () => {
+    for (const run of pending) await run();
+  });
+});
+
+interface SeededPair {
+  /** Row owned by org A (`org_id` set, `partner_id` NULL). */
+  orgOwnedId: string;
+  /** Row owned by partner P (`org_id` NULL, `partner_id` set). */
+  partnerWideId: string;
+}
+
+/**
+ * One table's slice of the contract. Every closure runs inside whatever
+ * `withDbAccessContext` the caller opened, so the assertions below measure RLS
+ * and nothing else.
+ */
+interface TableCase {
+  /** SQL table name — used as the test name and in failure messages. */
+  table: string;
+  seed(partnerId: string, orgId: string): Promise<SeededPair>;
+  selectById(id: string): Promise<unknown[]>;
+  /** UPDATE ... RETURNING; resolves to the rows RLS let the caller touch. */
+  updateById(id: string): Promise<unknown[]>;
+  /** DELETE ... RETURNING; resolves to the rows RLS let the caller touch. */
+  deleteById(id: string): Promise<unknown[]>;
+  /** The field `updateById` would have overwritten, read back under SYSTEM scope. */
+  readMarker(id: string): Promise<string | null | undefined>;
+}
+
+const CASES: TableCase[] = [
+  {
+    table: 'sso_providers',
+    async seed(partnerId, orgId) {
+      return withDbAccessContext(SYSTEM_CTX, async () => {
+        const [orgOwned] = await db
+          .insert(ssoProviders)
+          .values({ orgId, partnerId: null, name: 'Org IdP', type: 'oidc' })
+          .returning({ id: ssoProviders.id });
+        const [partnerWide] = await db
+          .insert(ssoProviders)
+          .values({ orgId: null, partnerId, name: 'Partner IdP', type: 'oidc' })
+          .returning({ id: ssoProviders.id });
+        cleanups.push(async () => {
+          await db.delete(ssoProviders).where(eq(ssoProviders.id, partnerWide!.id));
+          await db.delete(ssoProviders).where(eq(ssoProviders.id, orgOwned!.id));
+        });
+        return { orgOwnedId: orgOwned!.id, partnerWideId: partnerWide!.id };
+      });
+    },
+    selectById: (id) => db.select().from(ssoProviders).where(eq(ssoProviders.id, id)),
+    updateById: (id) =>
+      db.update(ssoProviders).set({ name: MARKER }).where(eq(ssoProviders.id, id)).returning({ id: ssoProviders.id }),
+    deleteById: (id) => db.delete(ssoProviders).where(eq(ssoProviders.id, id)).returning({ id: ssoProviders.id }),
+    readMarker: async (id) =>
+      (await db.select({ name: ssoProviders.name }).from(ssoProviders).where(eq(ssoProviders.id, id)))[0]?.name,
+  },
+  {
+    table: 'ticket_forms',
+    async seed(partnerId, orgId) {
+      return withDbAccessContext(SYSTEM_CTX, async () => {
+        const [orgOwned] = await db
+          .insert(ticketForms)
+          .values({ orgId, partnerId: null, name: 'Org intake form', fields: [], defaultTags: [] })
+          .returning({ id: ticketForms.id });
+        const [partnerWide] = await db
+          .insert(ticketForms)
+          .values({ orgId: null, partnerId, name: 'Partner intake form', fields: [], defaultTags: [] })
+          .returning({ id: ticketForms.id });
+        cleanups.push(async () => {
+          await db.delete(ticketForms).where(eq(ticketForms.id, partnerWide!.id));
+          await db.delete(ticketForms).where(eq(ticketForms.id, orgOwned!.id));
+        });
+        return { orgOwnedId: orgOwned!.id, partnerWideId: partnerWide!.id };
+      });
+    },
+    selectById: (id) => db.select().from(ticketForms).where(eq(ticketForms.id, id)),
+    updateById: (id) =>
+      db.update(ticketForms).set({ name: MARKER }).where(eq(ticketForms.id, id)).returning({ id: ticketForms.id }),
+    deleteById: (id) => db.delete(ticketForms).where(eq(ticketForms.id, id)).returning({ id: ticketForms.id }),
+    readMarker: async (id) =>
+      (await db.select({ name: ticketForms.name }).from(ticketForms).where(eq(ticketForms.id, id)))[0]?.name,
+  },
+  {
+    table: 'contract_templates',
+    async seed(partnerId, orgId) {
+      return withDbAccessContext(SYSTEM_CTX, async () => {
+        const [orgOwned] = await db
+          .insert(contractTemplates)
+          .values({ orgId, partnerId: null, name: 'Org MSA' })
+          .returning({ id: contractTemplates.id });
+        const [partnerWide] = await db
+          .insert(contractTemplates)
+          .values({ orgId: null, partnerId, name: 'Partner MSA' })
+          .returning({ id: contractTemplates.id });
+        cleanups.push(async () => {
+          await db.delete(contractTemplates).where(eq(contractTemplates.id, partnerWide!.id));
+          await db.delete(contractTemplates).where(eq(contractTemplates.id, orgOwned!.id));
+        });
+        return { orgOwnedId: orgOwned!.id, partnerWideId: partnerWide!.id };
+      });
+    },
+    selectById: (id) => db.select().from(contractTemplates).where(eq(contractTemplates.id, id)),
+    updateById: (id) =>
+      db
+        .update(contractTemplates)
+        .set({ name: MARKER })
+        .where(eq(contractTemplates.id, id))
+        .returning({ id: contractTemplates.id }),
+    deleteById: (id) =>
+      db.delete(contractTemplates).where(eq(contractTemplates.id, id)).returning({ id: contractTemplates.id }),
+    readMarker: async (id) =>
+      (await db.select({ name: contractTemplates.name }).from(contractTemplates).where(eq(contractTemplates.id, id)))[0]
+        ?.name,
+  },
+  {
+    // org_id / partner_id are denormalized from the parent template, so each
+    // axis needs its own parent. contract_template_versions_body_chk requires
+    // body_html when source_type = 'authored'.
+    table: 'contract_template_versions',
+    async seed(partnerId, orgId) {
+      return withDbAccessContext(SYSTEM_CTX, async () => {
+        const [orgTemplate] = await db
+          .insert(contractTemplates)
+          .values({ orgId, partnerId: null, name: 'Org template parent' })
+          .returning({ id: contractTemplates.id });
+        const [partnerTemplate] = await db
+          .insert(contractTemplates)
+          .values({ orgId: null, partnerId, name: 'Partner template parent' })
+          .returning({ id: contractTemplates.id });
+        const [orgOwned] = await db
+          .insert(contractTemplateVersions)
+          .values({
+            templateId: orgTemplate!.id,
+            orgId,
+            partnerId: null,
+            versionNumber: 1,
+            sourceType: 'authored',
+            bodyHtml: '<p>Org version</p>',
+          })
+          .returning({ id: contractTemplateVersions.id });
+        const [partnerWide] = await db
+          .insert(contractTemplateVersions)
+          .values({
+            templateId: partnerTemplate!.id,
+            orgId: null,
+            partnerId,
+            versionNumber: 1,
+            sourceType: 'authored',
+            bodyHtml: '<p>Partner version</p>',
+          })
+          .returning({ id: contractTemplateVersions.id });
+        cleanups.push(async () => {
+          await db.delete(contractTemplateVersions).where(eq(contractTemplateVersions.id, partnerWide!.id));
+          await db.delete(contractTemplateVersions).where(eq(contractTemplateVersions.id, orgOwned!.id));
+          await db.delete(contractTemplates).where(eq(contractTemplates.id, partnerTemplate!.id));
+          await db.delete(contractTemplates).where(eq(contractTemplates.id, orgTemplate!.id));
+        });
+        return { orgOwnedId: orgOwned!.id, partnerWideId: partnerWide!.id };
+      });
+    },
+    selectById: (id) => db.select().from(contractTemplateVersions).where(eq(contractTemplateVersions.id, id)),
+    updateById: (id) =>
+      db
+        .update(contractTemplateVersions)
+        .set({ bodyHtml: MARKER })
+        .where(eq(contractTemplateVersions.id, id))
+        .returning({ id: contractTemplateVersions.id }),
+    deleteById: (id) =>
+      db
+        .delete(contractTemplateVersions)
+        .where(eq(contractTemplateVersions.id, id))
+        .returning({ id: contractTemplateVersions.id }),
+    readMarker: async (id) =>
+      (
+        await db
+          .select({ bodyHtml: contractTemplateVersions.bodyHtml })
+          .from(contractTemplateVersions)
+          .where(eq(contractTemplateVersions.id, id))
+      )[0]?.bodyHtml,
+  },
+  {
+    table: 'psa_connections',
+    async seed(partnerId, orgId) {
+      const credentials = { baseUrl: 'https://acme.atlassian.net', apiToken: 'tok' };
+      return withDbAccessContext(SYSTEM_CTX, async () => {
+        const [orgOwned] = await db
+          .insert(psaConnections)
+          .values({ orgId, partnerId: null, name: 'Customer Jira', provider: 'jira', credentials })
+          .returning({ id: psaConnections.id });
+        const [partnerWide] = await db
+          .insert(psaConnections)
+          .values({ orgId: null, partnerId, name: 'MSP Jira', provider: 'jira', credentials })
+          .returning({ id: psaConnections.id });
+        cleanups.push(async () => {
+          await db.delete(psaConnections).where(eq(psaConnections.id, partnerWide!.id));
+          await db.delete(psaConnections).where(eq(psaConnections.id, orgOwned!.id));
+        });
+        return { orgOwnedId: orgOwned!.id, partnerWideId: partnerWide!.id };
+      });
+    },
+    selectById: (id) => db.select().from(psaConnections).where(eq(psaConnections.id, id)),
+    updateById: (id) =>
+      db.update(psaConnections).set({ name: MARKER }).where(eq(psaConnections.id, id)).returning({ id: psaConnections.id }),
+    deleteById: (id) =>
+      db.delete(psaConnections).where(eq(psaConnections.id, id)).returning({ id: psaConnections.id }),
+    readMarker: async (id) =>
+      (await db.select({ name: psaConnections.name }).from(psaConnections).where(eq(psaConnections.id, id)))[0]?.name,
+  },
+  {
+    table: 'access_reviews',
+    async seed(partnerId, orgId) {
+      return withDbAccessContext(SYSTEM_CTX, async () => {
+        const [orgOwned] = await db
+          .insert(accessReviews)
+          .values({ orgId, partnerId: null, name: 'Org access review' })
+          .returning({ id: accessReviews.id });
+        const [partnerWide] = await db
+          .insert(accessReviews)
+          .values({ orgId: null, partnerId, name: 'Partner access review' })
+          .returning({ id: accessReviews.id });
+        cleanups.push(async () => {
+          await db.delete(accessReviews).where(eq(accessReviews.id, partnerWide!.id));
+          await db.delete(accessReviews).where(eq(accessReviews.id, orgOwned!.id));
+        });
+        return { orgOwnedId: orgOwned!.id, partnerWideId: partnerWide!.id };
+      });
+    },
+    selectById: (id) => db.select().from(accessReviews).where(eq(accessReviews.id, id)),
+    updateById: (id) =>
+      db.update(accessReviews).set({ name: MARKER }).where(eq(accessReviews.id, id)).returning({ id: accessReviews.id }),
+    deleteById: (id) =>
+      db.delete(accessReviews).where(eq(accessReviews.id, id)).returning({ id: accessReviews.id }),
+    readMarker: async (id) =>
+      (await db.select({ name: accessReviews.name }).from(accessReviews).where(eq(accessReviews.id, id)))[0]?.name,
+  },
+];
+
+describe('identity-contracts tables — partner-wide SELECT branch (#4673 follow-ups)', () => {
+  describe('(a) an ORG session of the OWNING partner reads its own row AND the partner-wide row', () => {
+    for (const testCase of CASES) {
+      it(testCase.table, async () => {
+        const partner = await createPartner();
+        const orgA = await createOrganization({ partnerId: partner.id });
+        const { orgOwnedId, partnerWideId } = await testCase.seed(partner.id, orgA.id);
+
+        const rows = await withDbAccessContext(orgContext(orgA.id, partner.id), async () => [
+          ...(await testCase.selectById(orgOwnedId)),
+          ...(await testCase.selectById(partnerWideId)),
+        ]);
+
+        expect(
+          rows,
+          `${testCase.table}: an org session of the owning partner must see both its own ` +
+            `org-owned row and the partner-wide row`,
+        ).toHaveLength(2);
+      });
+    }
+  });
+
+  describe('(b) an ORG session under a DIFFERENT partner sees neither row', () => {
+    for (const testCase of CASES) {
+      it(testCase.table, async () => {
+        const owner = await createPartner();
+        const orgA = await createOrganization({ partnerId: owner.id });
+        const { orgOwnedId, partnerWideId } = await testCase.seed(owner.id, orgA.id);
+
+        const other = await createPartner();
+        const otherOrg = await createOrganization({ partnerId: other.id });
+
+        const rows = await withDbAccessContext(orgContext(otherOrg.id, other.id), async () => [
+          ...(await testCase.selectById(orgOwnedId)),
+          ...(await testCase.selectById(partnerWideId)),
+        ]);
+
+        expect(rows, `${testCase.table}: cross-partner leak`).toHaveLength(0);
+      });
+    }
+  });
+
+  describe('(c) the branch is READ-ONLY — no UPDATE, no DELETE of the partner-wide row', () => {
+    for (const testCase of CASES) {
+      it(testCase.table, async () => {
+        const partner = await createPartner();
+        const orgA = await createOrganization({ partnerId: partner.id });
+        const { partnerWideId } = await testCase.seed(partner.id, orgA.id);
+        const ctx = orgContext(orgA.id, partner.id);
+
+        const updated = await withDbAccessContext(ctx, () => testCase.updateById(partnerWideId));
+        expect(updated, `${testCase.table}: org session UPDATEd a partner-wide row`).toHaveLength(0);
+        expect(
+          await withDbAccessContext(SYSTEM_CTX, () => testCase.readMarker(partnerWideId)),
+          `${testCase.table}: partner-wide row was mutated`,
+        ).not.toBe(MARKER);
+
+        const deleted = await withDbAccessContext(ctx, () => testCase.deleteById(partnerWideId));
+        expect(deleted, `${testCase.table}: org session DELETEd a partner-wide row`).toHaveLength(0);
+        expect(
+          await withDbAccessContext(SYSTEM_CTX, () => testCase.selectById(partnerWideId)),
+          `${testCase.table}: partner-wide row was removed`,
+        ).toHaveLength(1);
+      });
+    }
+  });
+
+  // The predicate must stay `partner_id = breeze_current_partner_id()`. Written
+  // as `IS NOT DISTINCT FROM`, a NULL GUC (every agent session today) would
+  // match NULL-partner rows instead of matching nothing.
+  describe('an AGENT-shaped context (currentPartnerId NULL) does not reach the partner-wide row', () => {
+    for (const testCase of CASES) {
+      it(testCase.table, async () => {
+        const partner = await createPartner();
+        const orgA = await createOrganization({ partnerId: partner.id });
+        const { orgOwnedId, partnerWideId } = await testCase.seed(partner.id, orgA.id);
+
+        const rows = await withDbAccessContext(orgContext(orgA.id, null), async () => [
+          ...(await testCase.selectById(orgOwnedId)),
+          ...(await testCase.selectById(partnerWideId)),
+        ]);
+
+        // Only the org-owned row, via the pre-existing breeze_has_org_access arm.
+        expect(rows, `${testCase.table}: NULL partner GUC reached a partner-wide row`).toHaveLength(1);
+      });
+    }
+  });
+});

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -630,7 +630,6 @@ const XOR_OWNERSHIP_DUAL_AXIS_TABLES: ReadonlySet<string> = new Set<string>([
 const PARTNER_WIDE_SELECT_BRANCH_EXEMPT: ReadonlyMap<string, string> = new Map<string, string>([
   ['ai_agents', 'TODO(#4942): no breeze_current_partner_id() SELECT branch yet.'],
   ['ai_agent_schedules', 'TODO(#4943): no breeze_current_partner_id() SELECT branch yet.'],
-  ['access_reviews', 'TODO(#4970): no breeze_current_partner_id() SELECT branch yet.'],
   ['custom_field_definitions', 'TODO(#4944): no breeze_current_partner_id() SELECT branch yet.'],
   ['client_ai_prompt_templates', 'TODO(#4945): no breeze_current_partner_id() SELECT branch yet.'],
   ['software_catalog', 'TODO(#4946): no breeze_current_partner_id() SELECT branch yet.'],
@@ -649,11 +648,6 @@ const PARTNER_WIDE_SELECT_BRANCH_EXEMPT: ReadonlyMap<string, string> = new Map<s
   ['notification_channels', 'TODO(#4956): no breeze_current_partner_id() SELECT branch yet.'],
   ['notification_routing_rules', 'TODO(#4957): no breeze_current_partner_id() SELECT branch yet.'],
   ['escalation_policies', 'TODO(#4958): no breeze_current_partner_id() SELECT branch yet.'],
-  ['sso_providers', 'TODO(#4959): no breeze_current_partner_id() SELECT branch yet.'],
-  ['ticket_forms', 'TODO(#4960): no breeze_current_partner_id() SELECT branch yet.'],
-  ['contract_templates', 'TODO(#4961): no breeze_current_partner_id() SELECT branch yet.'],
-  ['contract_template_versions', 'TODO(#4962): no breeze_current_partner_id() SELECT branch yet.'],
-  ['psa_connections', 'TODO(#4963): no breeze_current_partner_id() SELECT branch yet.'],
 ]);
 
 // Enforced shrink-only ratchet for PARTNER_WIDE_SELECT_BRANCH_EXEMPT (mirrors
@@ -665,11 +659,10 @@ const PARTNER_WIDE_SELECT_BRANCH_EXEMPT: ReadonlyMap<string, string> = new Map<s
 // follow-up issue, not a free ride into an already-frozen exemption. Both
 // constants are asserted by 'the partner-wide SELECT branch exemption map
 // only shrinks' below.
-const PARTNER_WIDE_SELECT_BRANCH_EXEMPT_CEILING = 23;
+const PARTNER_WIDE_SELECT_BRANCH_EXEMPT_CEILING = 17;
 const PARTNER_WIDE_SELECT_BRANCH_EXEMPT_FROZEN_NAMES: ReadonlySet<string> = new Set<string>([
   'ai_agents',
   'ai_agent_schedules',
-  'access_reviews',
   'custom_field_definitions',
   'client_ai_prompt_templates',
   'software_catalog',
@@ -685,11 +678,6 @@ const PARTNER_WIDE_SELECT_BRANCH_EXEMPT_FROZEN_NAMES: ReadonlySet<string> = new 
   'notification_channels',
   'notification_routing_rules',
   'escalation_policies',
-  'sso_providers',
-  'ticket_forms',
-  'contract_templates',
-  'contract_template_versions',
-  'psa_connections',
 ]);
 
 // Tables that carry a `device_id` FK but no denormalized `org_id`. Their


### PR DESCRIPTION
## Summary

- Adds a SELECT-only "own partner" RLS read branch to six identity/contracts config tables — `sso_providers` (#4959), `ticket_forms` (#4960), `contract_templates` (#4961), `contract_template_versions` (#4962), `psa_connections` (#4963), `access_reviews` (#4970) — as one new migration, `apps/api/migrations/2026-10-10-100400-identity-contracts-partner-wide-select.sql`.
- All six carry `org_id` XOR `partner_id` **directly on the row** (verified against `apps/api/src/db/schema/{sso,ticketForms,contractDocuments,integrations,accessReviews}.ts`), so every branch takes the direct-column form: `<table>_partner_wide_select FOR SELECT USING (org_id IS NULL AND partner_id = public.breeze_current_partner_id())`. No EXISTS-join form was needed.
- Each branch is a **separate, additive, permissive FOR SELECT policy**. No existing policy was edited: appending the branch to a `FOR ALL` `USING` would also widen UPDATE/DELETE row targeting, letting an org admin rewrite or delete their MSP's shared rows. Postgres never consults a FOR SELECT policy when computing write targets.
- `rls-coverage.integration.test.ts`: the six tables leave `PARTNER_WIDE_SELECT_BRANCH_EXEMPT` **and** `PARTNER_WIDE_SELECT_BRANCH_EXEMPT_FROZEN_NAMES`; `PARTNER_WIDE_SELECT_BRANCH_EXEMPT_CEILING` drops 23 → 17. Nothing else in that file changed.
- New integration suite `identityContractsPartnerWideSelect.integration.test.ts` proves the branch functionally against real Postgres as `breeze_app` (24 tests, table-driven across all six).
- Follows the epic template `2026-10-05-110000-config-policy-partner-wide-select.sql` and mirrors its suite `configPolicyPartnerWideSelect.integration.test.ts`.

## Root cause

A partner-wide config row is `org_id NULL, partner_id = P`. An ORG-scoped session of P could not see it:

- `breeze_has_org_access(NULL)` → false (the org arm needs a non-NULL `org_id`);
- `breeze_has_partner_access(P)` → false, because org scope carries an empty `accessible_partner_ids` (that GUC governs partner-axis **writes**; an org token never holds it).

So every request-path reader of these tables was blind to its own MSP's partner-wide rows and had to escalate through the #1105 pattern, `runOutsideDbContext(() => withSystemDbAccessContext(...))`, which (1) acquires a **second** pooled connection while the request's own `withDbAccessContext` transaction still holds the first — a hang at concurrency ≥ pool size, since postgres-js queues acquisitions with no timeout — and (2) **bypasses RLS entirely**, so each escalated query must self-tenant or it becomes a cross-tenant hole (#2417 shipped exactly that class in an adjacent path).

`breeze_current_partner_id()` (created by `2026-06-13-catalog-partner-read-branch.sql`, not recreated here) reads the caller's **own** partner from the `breeze.current_partner_id` GUC, which `buildDbAccessContext` populates for every scope including org tokens — so the branch needs no extra connection and no RLS bypass.

Scope behaviour: org scope fires for its own partner's partner-wide rows only; partner scope is already covered by `breeze_has_partner_access` (redundant but harmless — permissive policies OR); system scope short-circuits earlier; agent scope leaves the GUC NULL and `partner_id = NULL` is NULL, never true. That last point is why the predicate uses `=` and not `IS NOT DISTINCT FROM`.

## Verification

Real database via the worktree-private stack (`pnpm test-stack up`, Postgres on :33078), all run in the foreground.

```
pnpm test-stack up
cd apps/api
npx vitest run --config vitest.integration.config.ts \
  src/__tests__/integration/identityContractsPartnerWideSelect.integration.test.ts
#   Test Files 1 passed (1) | Tests 24 passed (24)

npx vitest run --config vitest.config.rls-coverage.ts \
  src/__tests__/integration/rls-coverage.integration.test.ts
#   Test Files 1 passed (1) | Tests 102 passed (102)

npx vitest run src/db/autoMigrate.test.ts src/db/migrationRlsScope.test.ts
#   Test Files 2 passed (2) | Tests 100 passed (100)

npx tsc --noEmit
#   clean (exit 0)
```

TDD order was observed: the suite was written first and run **before** the migration existed — `6 failed | 18 passed (24)`, with exactly the six `(a)` visibility tests failing (`expected [...] to have a length of 2 but got 1`, one per table). After the migration: 24/24.

Extra checks beyond the listed commands:

```
# Regression: the shipped sibling suites for four of these tables + the wave-1 group suite
npx vitest run --config vitest.integration.config.ts \
  src/__tests__/integration/{ssoProviders,ticketForms,contractTemplates,psaConnections}PartnerRls.integration.test.ts \
  src/__tests__/integration/configPolicyPartnerWideSelect.integration.test.ts
#   Test Files 5 passed (5) | Tests 50 passed (50)

# Regression: HTTP-level suites whose org tokens carry a REAL currentPartnerId
npx vitest run --config vitest.integration.config.ts \
  src/__tests__/integration/{ssoPartnerLogin,ssoDiscovery,ssoHardening,ticketFormOrgLinksTxnSeam,psaTicketMappingOrgScoping}.integration.test.ts
#   Test Files 5 passed (5) | Tests 43 passed (43)

# New suite is registered in a vitest config (the suite-coverage contract)
npx vitest run --config vitest.config.integration-suite-coverage.ts
#   Test Files 1 passed (1) | Tests 5 passed (5)
```

Direct catalog + idempotency proof against the test DB (`$PG` = the stack's postgres container, db `breeze_test`):

```
docker exec -i $PG psql -U breeze_test -d breeze_test -c \
  "SELECT tablename, policyname, cmd, permissive, qual FROM pg_policies
   WHERE policyname LIKE '%_partner_wide_select'
     AND tablename IN ('sso_providers','ticket_forms','contract_templates',
                       'contract_template_versions','psa_connections','access_reviews')"
#   6 rows, every one cmd=SELECT, permissive=PERMISSIVE,
#   qual = ((org_id IS NULL) AND (partner_id = breeze_current_partner_id()))

docker exec -i $PG psql -v ON_ERROR_STOP=1 -U breeze_test -d breeze_test \
  < apps/api/migrations/2026-10-10-100400-identity-contracts-partner-wide-select.sql
#   REPLAY_OK — 6 DROP POLICY / 6 CREATE POLICY, no error; policy count still 6
```

Totals: **324 tests passed across 15 files, 0 failures** (24 + 102 + 100 + 50 + 43 + 5); `tsc --noEmit` clean.

## Decisions / notes for reviewer

- **The dispatch's verify command for `rls-coverage` was wrong.** `vitest.integration.config.ts` explicitly **excludes** `rls-coverage.integration.test.ts` (running it there yields "No test files found, exiting with code 1"). It has its own config — `vitest.config.rls-coverage.ts` / `pnpm --filter @breeze/api test:rls-coverage`. I used the correct one; the 102/102 above is a real run.
- **Migration filename kept exactly as specified.** `2026-10-10-100400-…` sorts after the newest shipped file on `main`, which is actually `2026-10-10-100000-device-external-links.sql` (the brief said `2026-10-09-000200-…`); either way 100400 sorts last. The repo's `check-migration-naming` pre-commit hook passed.
- **Seeding runs under SYSTEM scope.** The write policies on these tables are already proven by their own `<table>PartnerRls.integration.test.ts` suites; seeding under system scope keeps this suite measuring the read branch and nothing else. Both RLS helpers short-circuit to TRUE for system scope, so cleanup is unaffected.
- **The write denial is a silent ZERO-ROWS no-op, not a 42501.** RLS hides the target row from UPDATE/DELETE rather than raising, so the suite asserts the returned row count **and** re-reads under system scope to prove the row is unmutated and unremoved. A test that only asserted "it threw" would be vacuous. This matches the shipped `configPolicyPartnerWideSelect` / `cisBaselinesPartnerRls` precedent. The 42501 half of the guarantee stays covered by the existing cross-partner INSERT forge tests in the sibling suites (unchanged, still green).
- **Added one assertion beyond the brief: a NULL-GUC guard.** An agent-shaped context (`currentPartnerId: null`) must see only the org-owned row, not the partner-wide one. This is what keeps the predicate honest as `=` rather than `IS NOT DISTINCT FROM` — a one-character regression there would silently widen agent reads. Six extra tests, no production surface.
- **`ticket_forms` note.** Partner-wide forms also have an app-layer org allowlist (`ticket_form_org_links`, applied by `listTicketFormsForOrg`). The RLS branch is the coarse *tenant* boundary (same MSP), so after this change an org-scoped raw SELECT can reach partner-wide forms that are not allowlisted to it; the allowlist remains the narrowing gate in the service layer. This is the epic's intended division of labour, and #4960 was filed as a real gap rather than a design exception — flagging it so a reviewer who disagrees can say so before merge.
- **`contract_template_versions` seeding** needs a parent template per axis, because `org_id`/`partner_id` are denormalized from the parent and `contract_template_versions_one_owner_chk` enforces XOR. `contract_template_versions_body_chk` also requires `body_html` when `source_type = 'authored'`, so that is the minimal row.
- **No cascade / export-policy registration needed.** This PR adds no table and no column — only policies — so `CORE_ORG_CASCADE_DELETE_ORDER`, `CORE_TENANT_EXPORT_POLICY` and the device-side lists are untouched. `pnpm db:check-drift` was not run for the same reason (Drizzle does not model RLS policies; the Drizzle schema is byte-identical).
- **No reader code changed**, per the brief.
- **Environment deviation:** the brief said to use Node from `$HOME/.nvm/versions/node/v22.20.0/bin`, but no `~/.nvm` exists on this machine. Everything ran on the system Node, homebrew v22.23.2. One note: bare `npx tsc --noEmit` OOM-crashed the heap on this repo; `NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit` completes clean (exit 0). That is a pre-existing repo-size issue, not something this PR introduced.
- The `Co-Authored-By` trailer email was given as `noreply @alibabacloud.com` (with a space) in the dispatch; committed as `noreply@alibabacloud.com` so the trailer parses and GitHub attributes the co-author.

### Follow-up candidates (readers still on the #1105 escalation — NOT changed in this PR)

Sites where the escalated callback genuinely reads one of the six tables, i.e. where the new branch should let the escalation be retired:

| Location | Table(s) | What the escalated read does |
|---|---|---|
| `apps/api/src/services/ticketFormService.ts:44` | `ticket_forms` | `listTicketFormsForOrg` — org rows plus partner-wide allowlisted forms |
| `apps/api/src/services/ticketFormService.ts:84` | `ticket_forms` | `isOrgAllowedForPartnerWideForm` — two EXISTS allowlist probes on one form |
| `apps/api/src/services/ticketFormService.ts:113` | `ticket_forms` | `getTicketFormForOrg` — load a single form, then tenant/allowlist checks in JS |
| `apps/api/src/services/contractTemplateRender.ts:107` | `contract_templates`, `contract_template_versions` | `loadContractBlockRenderData` — pinned version bodies + parent template rows |
| `apps/api/src/services/contractTemplateRender.ts:217` | `contract_template_versions` | `loadContractBlockAuthoring` — pinned version + latest published version |

Two confirmed escalation sites that the branch **cannot** retire, so they are deliberately *not* listed as candidates:

- `apps/api/src/routes/sso.ts:1562` (`computeEnforcementLockoutPreflight`) — its partner-axis arm also selects **org-owned** providers, which `org_id IS NULL` does not cover.
- `apps/api/src/services/ssoBrowserTransition.ts:32` → `:166`/`:182` — a `SELECT … FOR UPDATE` locking read on a pre-auth, contextless caller inside a multi-table system transaction. A SELECT-only branch is not a substitute for a lock.

Ruled out as co-occurrence only (file mentions both the pattern and one of the tables, but the escalated callback does not read it): `routes/accessReviews.ts:464` (escalated callback only *writes*; its SELECTs run under ambient context), `routes/portal/tickets.ts:114` (escalates to read `organizations.partner_id`; the `ticket_forms` read is `listTicketFormsForOrg`'s own escalation), `routes/psa.ts` (no escalation site — its partner-wide `psa_connections` reads are app-layer SQL predicates under ambient context at `:175`/`:448`, which the new branch could simplify), `services/quoteLifecycle.ts:1084` and `services/quoteService.ts:392` (escalations read `quotes`/`organizations`/`partners`; their contract-template reads are on the ambient `db`), `routes/auth/ssoLinkCompletion.ts:533` (bare `withSystemDbAccessContext` on pre-auth paths — no org-scoped ambient context, so no `breeze_current_partner_id()` for the branch to match), and `routes/sso.ts:1357`/`:2109`/`:2231` (escalated *delete* of `sso_providers` and *inserts* into `sso_sessions`).

Closes #4959
Closes #4960
Closes #4961
Closes #4962
Closes #4963
Closes #4970

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code) via [Claude Code](https://claude.com/claude-code)
