### PR TITLE
fix(i18n): review machine-translated alert-verdict badge copy (#4449)

### DIFF
--- a/apps/web/src/lib/i18n/terminologyQuality.test.ts
+++ b/apps/web/src/lib/i18n/terminologyQuality.test.ts
@@ -59,4 +59,18 @@ describe('product terminology quality', () => {
       }
     }
   });
+
+  it('keeps alert-verdict badge feedback copy in the formal register the rest of alerts.json uses (#4449)', () => {
+    // de-DE and es-419 alerts.json otherwise address the user formally
+    // (Sie / su); the machine-translated feedbackThanks string was the lone
+    // informal (du / tu) outlier in each file.
+    const expected = {
+      'de-DE': 'Danke für Ihr Feedback',
+      'es-419': 'Gracias por su comentario',
+    } as const;
+
+    for (const locale of Object.keys(expected) as (keyof typeof expected)[]) {
+      expect(valueAt(catalog(locale, 'alerts'), 'alertVerdict.feedbackThanks')).toBe(expected[locale]);
+    }
+  });
 });

--- a/apps/web/src/locales/de-DE/alerts.json
+++ b/apps/web/src/locales/de-DE/alerts.json
@@ -533,7 +533,7 @@
     "confidence": "{{pct}} % Konfidenz",
     "feedbackUp": "Diese Einschätzung war hilfreich",
     "feedbackDown": "Diese Einschätzung war nicht hilfreich",
-    "feedbackThanks": "Danke für dein Feedback",
+    "feedbackThanks": "Danke für Ihr Feedback",
     "feedbackTaken": "Für diese Einschätzung wurde bereits Feedback abgegeben",
     "feedbackFailed": "Feedback konnte nicht gespeichert werden",
     "feedbackBy": "Feedback von {{name}}",

--- a/apps/web/src/locales/es-419/alerts.json
+++ b/apps/web/src/locales/es-419/alerts.json
@@ -533,7 +533,7 @@
     "confidence": "{{pct}}% de confianza",
     "feedbackUp": "Este veredicto fue útil",
     "feedbackDown": "Este veredicto no fue útil",
-    "feedbackThanks": "Gracias por tu comentario",
+    "feedbackThanks": "Gracias por su comentario",
     "feedbackTaken": "Alguien ya dejó comentarios sobre este veredicto",
     "feedbackFailed": "No se pudo registrar el comentario",
     "feedbackBy": "Comentario de {{name}}",


### PR DESCRIPTION
## Summary

- Native-quality review of the 15 `alertVerdict.*` i18n keys behind the alert-verdict badge (`AlertVerdictBadge.tsx`, shipped in #4220/#4221) across all 7 non-English locales (de-DE, es-419, fr-CA, fr-FR, it-IT, pt-BR, tr-TR).
- Structural check first (script-diffed against `en/alerts.json`): no missing keys, no untranslated English left over, no `{{placeholder}}` mismatches, no broken plural forms (none of these keys are countable/pluralized).
- Cross-referenced the established, already-shipped translation of "verdict" elsewhere in the app (`security.json` PAM/elevation verdicts, `settings.json` QBO reconciliation verdicts) to sanity-check terminology choices; confirmed each locale's word choice for the AI's alert assessment (vs. a human judgment call) is a defensible distinct term, not a defect.
- Found and fixed a genuine machine-translation register defect in 2 of 7 locales: `feedbackThanks` was informal (T-form) while every other string in that locale's `alerts.json` addresses the user formally (V-form). Verified by counting formal vs. informal address forms across each entire locale file, not just the changed key.
- Added a regression test (`terminologyQuality.test.ts`) pinning the corrected values so this can't silently regress.

## Review table

| locale | key | before | after | reason |
|---|---|---|---|---|
| de-DE | `alertVerdict.feedbackThanks` | "Danke für **dein** Feedback" | "Danke für **Ihr** Feedback" | Informal *du*-form; rest of `de-DE/alerts.json` uses formal *Sie* 94×, informal *du* 0× elsewhere. Classic MT default-to-casual artifact. |
| es-419 | `alertVerdict.feedbackThanks` | "Gracias por **tu** comentario" | "Gracias por **su** comentario" | Informal *tú*-form; rest of `es-419/alerts.json` uses formal *su* 14×, informal *tú* 0× elsewhere in that file. |
| fr-FR | all 15 keys | — | unchanged | Already formal (*votre*) throughout, consistent with the rest of the file; no defects found. |
| fr-CA | all 15 keys | — | unchanged | Same as fr-FR — formal register, consistent, correct. |
| it-IT | all 15 keys | — | unchanged | `feedbackThanks` uses informal *tuo*, but that's the file's own established convention (5 other informal *tuo/tua* instances elsewhere in `it-IT/alerts.json`) — consistent, not a defect. |
| pt-BR | all 15 keys | — | unchanged | Uses *você/seu* throughout (Brazilian neutral register), consistent with the rest of the file. |
| tr-TR | all 15 keys | — | unchanged | Formal suffix forms throughout (no informal *sen* anywhere in the file); percentage placement (`%{{pct}}` before the number) already correctly localized per Turkish convention. |

## Root cause

The `alertVerdict.feedbackThanks` string in de-DE and es-419 was machine-translated independently of its sibling strings in the same file and defaulted to the informal/casual register, rather than matching the formal register the rest of `alerts.json` (and the rest of each locale generally) uses for addressing the user. Every other key in scope was either already correct or already consistent with its file's own established register — this was a narrow, not broad, defect.

## Verification

```
cd apps/web && npx vitest run src/lib/i18n/terminologyQuality.test.ts
# new test fails red before the fix (asserts feedbackThanks == formal wording), passes after

cd apps/web && npx vitest run src/lib/i18n src/components/alerts
# Test Files  29 passed (29)
# Tests       300 passed (300)
```

`python3 -c "import json; json.load(...)"` confirms both edited locale files remain valid JSON.

## Decisions / notes for reviewer

- I did **not** touch it-IT's informal `tuo` in `feedbackThanks` — it matches that file's own established informal convention (5 other `tuo/tua` occurrences in `it-IT/alerts.json`), so changing it to formal would itself be the inconsistency.
- I deliberately did **not** force the `alertVerdict` "verdict" terminology to match the older `security.json`/`settings.json` uses of "verdict" (e.g. de-DE "Urteil", tr-TR "Karar") — those describe a human/policy judgment (PAM elevation approve/deny) or a reconciliation result, a different semantic than an AI's alert-triage assessment. Each locale's existing word choice here (e.g. de-DE "Einschätzung", tr-TR "değerlendirme") reads as an intentional, natural distinction rather than an error, so I left those as-is to avoid unrequested scope creep on a copy-review PR.
- Confidence I have in each locale: **high** for de-DE and es-419 (explicit fixes, verified against surrounding register). **Medium-high** for fr-FR, fr-CA, it-IT, pt-BR, tr-TR — I reviewed all 15 keys per locale for accuracy, register, and placeholder correctness and found them fluent and consistent with their file's conventions, but I'm not a native speaker of any of these seven languages, so a native reviewer may still catch subtler idiom/tone nuances a corpus-consistency check can't surface.

Closes #4449

🤖 Generated with [Claude Code](https://claude.com/claude-code)