### PR TITLE
fix(alerts): rewrite alert-axis org_id children on device org-move (#4867)

### DIFF
--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -359,6 +359,48 @@ export const CUSTOM_ORG_REWRITE_TABLES = [
 ] as const;
 
 /**
+ * Alert-axis sibling of {@link CUSTOM_ORG_REWRITE_TABLES} (#4867): tables that
+ * denormalize `org_id` and hang off `alerts`, but have NO `device_id` column —
+ * so the generic {@link getDeviceOrgDenormalizedTables} loop in moveOrg.ts
+ * (which keys on `WHERE device_id = ...`) cannot reach them, and neither can
+ * the DB-side `breeze_cascade_device_org_id()` trigger, whose
+ * `breeze_device_child_orgid_tables()` discovery finds tables BY that same
+ * device_id column. Each gets a dedicated hand-written UPDATE inside the
+ * move-org transaction, keyed on the alert (or, for a group-level verdict, on
+ * the correlation group).
+ *
+ * Leaving them behind is not a neutral no-op: every alert-facing reader pins
+ * these rows to the ALERT's own org — `hideAiNoiseCondition` and
+ * `correlationMetadataCondition` (routes/alerts/alerts.ts), plus
+ * `latestVerdictsForAlerts` / `latestVerdictForGroup`
+ * (services/aiAgents/alertVerdicts.ts) — so a row still stamped with the
+ * source org is invisible to the org that now owns the alert, and that alert
+ * permanently loses its AI-noise suppression and correlation badge. Nothing
+ * regenerates them: the verdict scheduler is event-driven off `alert.triggered`
+ * (jobs/alertVerdictScheduler.ts) and never re-scans existing alerts.
+ *
+ * ORDER IS LOAD-BEARING, but for a different reason than the ticket list's:
+ * member -> group -> verdict, because each later statement's predicate reads
+ * the rows the earlier one just re-stamped (the group's "every member alert is
+ * now in the target org" test reads `alerts.org_id` from the generic loop, and
+ * the verdict's group leg reads `alert_correlation_groups.org_id` from the
+ * group statement). None of the three carries a composite tenant FK, so there
+ * is no 23503 ordering hazard of the kind the ticket chain above is ordered
+ * for. These statements run AFTER that chain, extending — never reordering —
+ * services/ticketOrgMoveLockOrder.ts's documented order.
+ *
+ * moveOrg.coverage.test.ts DERIVES the expected membership from the schema
+ * (org_id + no device_id + an FK path to `alerts`), so the next alert child
+ * cannot skip both paths the way these three did; moveOrg.test.ts pins the real
+ * statement sequence to this array's order.
+ */
+export const ALERT_CHILD_ORG_REWRITE_TABLES = [
+  'alert_correlation_members',
+  'alert_correlation_groups',
+  'ai_alert_verdicts',
+] as const;
+
+/**
  * Tables that are both device-id scoped AND denormalize site_id for query-perf.
  * EVERY write path that changes devices.site_id must rewrite each row's
  * site_id in the same transaction, or those rows strand under the OLD

--- a/apps/api/src/routes/devices/moveOrg.coverage.test.ts
+++ b/apps/api/src/routes/devices/moveOrg.coverage.test.ts
@@ -6,6 +6,7 @@ import { getTableConfig, PgTable } from 'drizzle-orm/pg-core';
 import * as schema from '../../db/schema';
 import { aiAgentRuns } from '../../db/schema';
 import {
+  ALERT_CHILD_ORG_REWRITE_TABLES,
   CUSTOM_ORG_REWRITE_TABLES,
   getDeviceCascadeDeleteTables,
   DEVICE_DETACH_DEVICE_ID_TABLES,
@@ -274,6 +275,215 @@ describe('CUSTOM_ORG_REWRITE_TABLES coverage', () => {
     }
 
     expect(invalid, `Stale or misplaced entries in CUSTOM_ORG_REWRITE_TABLES (core.ts).`).toEqual([]);
+  });
+});
+
+/**
+ * ALERT_CHILD_ORG_REWRITE_TABLES (#4867) — the alert-axis sibling of the
+ * ticket-axis CUSTOM_ORG_REWRITE_TABLES block above.
+ *
+ * These tables denormalize `org_id` and hang off `alerts`, but have NO
+ * `device_id` column, so the generic getDeviceOrgDenormalizedTables() loop in
+ * moveOrg.ts cannot reach them — and neither can the DB-side
+ * breeze_cascade_device_org_id() trigger, which discovers its table set BY the
+ * device_id column (`breeze_device_child_orgid_tables()`). Each gets a
+ * dedicated hand-written UPDATE keyed on the alert (or the correlation group)
+ * instead.
+ *
+ * Unlike the ticket-axis list, the expected membership here is DERIVED from
+ * the schema rather than hand-enumerated: any org-scoped table that references
+ * `alerts` (directly, or one hop through another such table) without carrying
+ * its own device_id belongs in this list, so the next alert child cannot
+ * repeat #4867 by skipping both paths. `ticket_alert_links` is the one derived
+ * name that is deliberately NOT here — it is the ticket axis's row and is
+ * already rewritten by CUSTOM_ORG_REWRITE_TABLES.
+ */
+describe('ALERT_CHILD_ORG_REWRITE_TABLES coverage (#4867)', () => {
+  const alertChildSet = new Set<string>(ALERT_CHILD_ORG_REWRITE_TABLES);
+  const customSet = new Set<string>(CUSTOM_ORG_REWRITE_TABLES);
+
+  const allTables = Object.values(schema).filter(
+    (v) => v instanceof PgTable,
+  ) as PgTable<any>[];
+  const tableByName = new Map(allTables.map((t) => [getTableName(t), t] as const));
+
+  /** org-scoped (has org_id) and NOT reachable by the generic device loop. */
+  const isOrgScopedWithoutDeviceId = (table: PgTable<any>): boolean => {
+    const cols = getColumns(table);
+    return cols.some((c) => c.name === 'org_id') && !cols.some((c) => c.name === 'device_id');
+  };
+
+  const referencesTable = (table: PgTable<any>, targets: ReadonlySet<string>): boolean =>
+    getTableConfig(table).foreignKeys.some((fk) => targets.has(getTableName(fk.reference().foreignTable)));
+
+  /**
+   * Org-scoped tables that reference `alerts` but are NOT alert children: for
+   * these, `alert_id` is an OUTPUT pointer to the alert the row RAISED, not the
+   * row's tenancy axis.
+   *
+   *  - `log_correlations` belongs to its org's log-correlation RULE and
+   *    aggregates logs across MANY devices (`affected_devices` jsonb).
+   *  - `network_change_events` belongs to its org+site network BASELINE
+   *    (`baseline_id`, `site_id` both NOT NULL).
+   *
+   * Neither may follow one device's alert into another org — that would hand
+   * the source org's log/network history to an org that owns a single device
+   * out of the many the row summarises. (The mirror image of
+   * `alert_correlation_members`, which describes exactly ONE alert and so has
+   * no org-level meaning without it.)
+   *
+   * Their `alert_id` does become a cross-org pointer after a move. That is
+   * benign and deliberately left alone here: both are plain single-column FKs
+   * with no composite tenant leg, and every dereference runs under RLS, so the
+   * pointer resolves to nothing rather than leaking — the same fail-closed
+   * staleness #4867 describes, on the other side of the link.
+   */
+  const ALERT_PRODUCERS_NOT_CHILDREN: ReadonlySet<string> = new Set([
+    'log_correlations',
+    'network_change_events',
+  ]);
+
+  function deriveAlertChildOrgTables(): string[] {
+    const direct = allTables
+      .filter((t) => isOrgScopedWithoutDeviceId(t) && referencesTable(t, new Set(['alerts'])))
+      .map(getTableName)
+      .filter((name) => !customSet.has(name) && !ALERT_PRODUCERS_NOT_CHILDREN.has(name));
+    const directSet = new Set(direct);
+    // One hop further, so a future child keyed only on `group_id` (with no
+    // alert_id of its own) is still caught.
+    const indirect = allTables
+      .filter((t) => {
+        const name = getTableName(t);
+        return !directSet.has(name) && isOrgScopedWithoutDeviceId(t) && referencesTable(t, directSet);
+      })
+      .map(getTableName);
+    return [...direct, ...indirect].sort();
+  }
+
+  it('still describes the tables it excludes as alert PRODUCERS, not alert children', () => {
+    // Guards the exclusion set above against rot: if one of these ever stops
+    // matching the producer shape (drops alert_id, gains a device_id, or is
+    // deleted), the exclusion is stale and must be revisited rather than left
+    // to silently suppress a real alert child.
+    const stale = [...ALERT_PRODUCERS_NOT_CHILDREN].filter((name) => {
+      const table = tableByName.get(name);
+      return !table || !isOrgScopedWithoutDeviceId(table) || !referencesTable(table, new Set(['alerts']));
+    });
+    expect(
+      stale,
+      `These ALERT_PRODUCERS_NOT_CHILDREN entries no longer match the producer shape (org_id, no ` +
+        `device_id, an FK to alerts) — remove them from the exclusion set, or re-check whether they ` +
+        `now belong in ALERT_CHILD_ORG_REWRITE_TABLES: ${stale.join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it('covers every org-scoped alert child the generic loop and the DB trigger both cannot reach', () => {
+    const derived = deriveAlertChildOrgTables();
+    expect(
+      derived,
+      'sanity: the derived set should at least contain the three tables #4867 was filed for',
+    ).toEqual(expect.arrayContaining([
+      'ai_alert_verdicts',
+      'alert_correlation_groups',
+      'alert_correlation_members',
+    ]));
+
+    const missing = derived.filter((name) => !alertChildSet.has(name));
+    expect(
+      missing,
+      `These tables are org-scoped, hang off \`alerts\`, and have no device_id column, so neither ` +
+        `getDeviceOrgDenormalizedTables() nor breeze_cascade_device_org_id() can re-stamp them on a ` +
+        `device org-move — their rows would stay under the SOURCE org while their alert reads the ` +
+        `TARGET's (#4867). Add each to ALERT_CHILD_ORG_REWRITE_TABLES in core.ts AND a dedicated ` +
+        `UPDATE in moveOrg.ts. If the table only POINTS at an alert it raised (its tenancy axis is ` +
+        `something else — a rule, a baseline, a ticket), add it to ALERT_PRODUCERS_NOT_CHILDREN ` +
+        `in this block instead, with the reason.\n\n` +
+        `Missing: ${missing.join(', ')}`,
+    ).toEqual([]);
+
+    const stale = [...alertChildSet].filter((name) => !derived.includes(name));
+    expect(
+      stale,
+      `These entries no longer match the derived alert-child shape (dropped org_id, gained a ` +
+        `device_id, or stopped referencing alerts) — remove them from ALERT_CHILD_ORG_REWRITE_TABLES ` +
+        `or move them to the list that fits: ${stale.join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it('is ordered member -> group -> verdict, the order moveOrg.ts issues them in', () => {
+    // Load-bearing, not cosmetic: the group statement's "every member alert is
+    // now in the target org" predicate reads alerts.org_id as re-stamped by the
+    // generic loop, and the verdict statement's group leg reads
+    // alert_correlation_groups.org_id as re-stamped by the group statement.
+    // moveOrg.test.ts pins the real statement sequence to this array.
+    expect(ALERT_CHILD_ORG_REWRITE_TABLES).toEqual([
+      'alert_correlation_members',
+      'alert_correlation_groups',
+      'ai_alert_verdicts',
+    ]);
+  });
+
+  it('is disjoint from every other move-org list', () => {
+    const overlapping = [
+      ...deviceOrgDenormalizedTables.filter((t) => alertChildSet.has(t)).map(
+        (t) => `${t} (also in getDeviceOrgDenormalizedTables())`,
+      ),
+      ...deviceCascadeDeleteTables.filter((t) => alertChildSet.has(t)).map(
+        (t) => `${t} (also in getDeviceCascadeDeleteTables())`,
+      ),
+      ...DEVICE_DETACH_DEVICE_ID_TABLES.filter((t) => alertChildSet.has(t)).map(
+        (t) => `${t} (also in DEVICE_DETACH_DEVICE_ID_TABLES)`,
+      ),
+      ...CUSTOM_ORG_REWRITE_TABLES.filter((t) => alertChildSet.has(t)).map(
+        (t) => `${t} (also in CUSTOM_ORG_REWRITE_TABLES — the ticket axis already rewrites it)`,
+      ),
+      ...[...INTENTIONALLY_NO_ORG_ID].filter((t) => alertChildSet.has(t)).map(
+        (t) => `${t} (also in INTENTIONALLY_NO_ORG_ID)`,
+      ),
+    ];
+    expect(
+      overlapping,
+      `ALERT_CHILD_ORG_REWRITE_TABLES must be disjoint from the other move-org lists — a table is ` +
+        `rewritten by exactly one path.`,
+    ).toEqual([]);
+  });
+
+  it('only lists tables that exist with an org_id column and WITHOUT a device_id column', () => {
+    const invalid: string[] = [];
+
+    for (const name of ALERT_CHILD_ORG_REWRITE_TABLES) {
+      const table = tableByName.get(name);
+      if (!table) {
+        invalid.push(`${name} (table no longer exists in the schema)`);
+        continue;
+      }
+      const cols = getColumns(table);
+      if (!cols.some((c) => c.name === 'org_id')) {
+        invalid.push(`${name} (has no org_id column — nothing to rewrite)`);
+      }
+      if (cols.some((c) => c.name === 'device_id')) {
+        invalid.push(
+          `${name} (has a device_id column — move it to getDeviceOrgDenormalizedTables(); ` +
+            `the generic loop can reach it)`,
+        );
+      }
+    }
+
+    expect(invalid, `Stale or misplaced entries in ALERT_CHILD_ORG_REWRITE_TABLES (core.ts).`).toEqual([]);
+  });
+
+  it('moveOrg.ts issues a hand-written org_id rewrite per entry', () => {
+    // The list is data; this proves the route consumes it (the same gap the
+    // DEVICE_SITE_DENORMALIZED_TABLES note above calls out).
+    const src = readFileSync(fileURLToPath(new URL('./moveOrg.ts', import.meta.url)), 'utf8');
+    const missing = ALERT_CHILD_ORG_REWRITE_TABLES.filter(
+      (name) => !new RegExp(`UPDATE \\$\\{sql\\.identifier\\('${name}'\\)\\}[^]*?SET org_id`).test(src),
+    );
+    expect(
+      missing,
+      `moveOrg.ts has no \`UPDATE \${sql.identifier('<table>')} ... SET org_id\` statement for these ` +
+        `ALERT_CHILD_ORG_REWRITE_TABLES entries — the list is not self-applying: ${missing.join(', ')}`,
+    ).toEqual([]);
   });
 });
 

--- a/apps/api/src/routes/devices/moveOrg.test.ts
+++ b/apps/api/src/routes/devices/moveOrg.test.ts
@@ -98,6 +98,7 @@ import { moveOrgRoutes } from './moveOrg';
 import { TicketMoveCurrencyBlockedError } from '../../services/ticketMoveCurrencyGuard';
 import { PamDeviceMoveBlockedError } from '../../services/pamDeviceMoveGuard';
 import {
+  ALERT_CHILD_ORG_REWRITE_TABLES,
   CUSTOM_ORG_REWRITE_TABLES,
   getDeviceOrgDenormalizedTables,
   DEVICE_ORG_FK_CASCADE_TABLES,
@@ -172,6 +173,19 @@ let currentOrgRows: Array<{ id: string; partnerId: string; name?: string; curren
  *  between the two reads. readOrgStampingDefaultsMany omits such ids from its
  *  map by design, so the route must guard instead of `!`-asserting. */
 let barrierMissingOrgIds = new Set<string>();
+
+/**
+ * Per-test override for what a `tx.execute()` resolves to, keyed on the
+ * whitespace-collapsed statement text. `null` (the default) keeps the
+ * harness's empty-array answer. Needed by #4867: the alert-child re-stamp
+ * counts its `RETURNING` rows, so a test that asserts those counts has to
+ * hand the route something to count.
+ */
+let executeResultFor: ((stmtText: string) => unknown[] | null) | null = null;
+
+/** Collapse a captured statement to one line (multi-line `sql` templates keep
+ *  their source newlines in the harness's raw text). */
+const collapseStmt = (s: string) => s.replace(/\s+/g, ' ').trim();
 
 function rigOrgAndSiteSelects(opts: {
   orgRows: Array<{ id: string; partnerId: string; name?: string; currencyCode?: string }>;
@@ -254,8 +268,9 @@ function rigTransactionSuccess(
         if (tableChunk && typeof tableChunk.value === 'string') {
           updatedTables.push(tableChunk.value);
         }
-        statements.push(sqlToText(sqlVal));
-        return [];
+        const text = sqlToText(sqlVal);
+        statements.push(text);
+        return executeResultFor?.(collapseStmt(text)) ?? [];
       }),
       // #3776 — the ticket-id lookup feeding the currency guard
       // (`tx.select({id}).from(tickets).where(deviceId = …)`). Records the
@@ -295,6 +310,7 @@ describe('POST /devices/:id/move-org', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     barrierMissingOrgIds = new Set<string>();
+    executeResultFor = null;
     guardMock.mockReset();
     guardMock.mockResolvedValue(null);
     pamGuardMock.mockReset();
@@ -376,15 +392,20 @@ describe('POST /devices/:id/move-org', () => {
       // ticket_email_links — no device_id column, each rewritten via a
       // ticket_id or alert_id join) follow the generic org loop, and this
       // spread is what pins the hand-written statements to that array's
-      // ORDER, which is the cross-axis lock order (#4657, #4743, #4643). The SITE
-      // loop runs last and any table in DEVICE_SITE_DENORMALIZED_TABLES
-      // appears in updatedTables a second time for the site_id rewrite.
+      // ORDER, which is the cross-axis lock order (#4657, #4743, #4643).
+      // ALERT_CHILD_ORG_REWRITE_TABLES (#4867 — the alert-axis children with
+      // no device_id) come next, pinned to their array's order the same way:
+      // member -> group -> verdict, because each later predicate reads the
+      // rows the earlier statement just re-stamped. The SITE loop runs last
+      // and any table in DEVICE_SITE_DENORMALIZED_TABLES appears in
+      // updatedTables a second time for the site_id rewrite.
       expect(updatedTables).toEqual([
         ...getDeviceOrgDenormalizedTables().filter(
           (table) => !DEVICE_ORG_FK_CASCADE_TABLES.includes(table as never),
         ),
         ...getDeviceOrgMoveDeleteTables(),
         ...CUSTOM_ORG_REWRITE_TABLES,
+        ...ALERT_CHILD_ORG_REWRITE_TABLES,
         ...DEVICE_SITE_DENORMALIZED_TABLES,
       ]);
       expect(getDeviceOrgDenormalizedTables()).toContain('agent_health_observations');
@@ -795,6 +816,215 @@ describe('POST /devices/:id/move-org', () => {
 
       // No WS disconnect on failure (device never actually moved)
       expect(disconnectAgent).not.toHaveBeenCalled();
+    });
+  });
+
+  /**
+   * Alert-axis children with no device_id column (#4867).
+   *
+   * `alerts` IS in getDeviceOrgDenormalizedTables(), so the generic loop
+   * re-stamps it — but `alert_correlation_members`, `alert_correlation_groups`
+   * and `ai_alert_verdicts` denormalize `org_id` WITHOUT a `device_id` column,
+   * so neither that loop nor the DB-side breeze_cascade_device_org_id()
+   * trigger (which discovers tables BY their device_id column) can reach them.
+   * Left behind, they keep the SOURCE org's id while their alert reads the
+   * TARGET's — and every alert-facing reader pins these rows to the alert's
+   * own org (`hideAiNoiseCondition` / `correlationMetadataCondition` in
+   * routes/alerts/alerts.ts, `latestVerdictsForAlerts` /
+   * `latestVerdictForGroup` in services/aiAgents/alertVerdicts.ts), so the
+   * moved alert permanently loses its AI-noise suppression and correlation
+   * badge. Nothing regenerates them: the verdict scheduler is event-driven off
+   * `alert.triggered` and never re-scans existing alerts.
+   *
+   * These are statement-shape assertions against the mocked tx (the repo's
+   * unit-level proxy for "the rewrite happens in the same transaction"); that
+   * the predicates match the right ROWS against a real server is the
+   * integration suite's job.
+   */
+  describe('alert-axis children with no device_id (#4867)', () => {
+    async function moveDevice() {
+      vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue(SAMPLE_DEVICE as never);
+      rigOrgAndSiteSelects({
+        orgRows: [
+          { id: SOURCE_ORG, partnerId: 'partner-1' },
+          { id: TARGET_ORG, partnerId: 'partner-1' },
+        ],
+        siteRow: { id: TARGET_SITE },
+      });
+      const rigged = rigTransactionSuccess();
+      const res = await app.request(`/devices/${DEVICE_ID}/move-org`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ orgId: TARGET_ORG, siteId: TARGET_SITE }),
+      });
+      expect(res.status).toBe(200);
+      return rigged;
+    }
+
+    /** The one statement issued against `table`, collapsed to a single line. */
+    function onlyStatement(statements: string[], table: string): string {
+      const matches = statements.map(collapseStmt).filter((s) => s.startsWith(`UPDATE ${table} `));
+      expect(
+        matches.length,
+        `Expected exactly one ${table} org_id rewrite.\nStatements:\n${statements.join('\n')}`,
+      ).toBe(1);
+      return matches[0]!;
+    }
+
+    it('re-stamps alert_correlation_members via the alert join — a member row always follows its alert', async () => {
+      const { statements } = await moveDevice();
+
+      expect(onlyStatement(statements, 'alert_correlation_members')).toBe(collapseStmt(`
+        UPDATE alert_correlation_members SET org_id = ${TARGET_ORG}::uuid
+        WHERE alert_id IN (SELECT id FROM alerts WHERE device_id = ${DEVICE_ID}::uuid)
+        RETURNING id
+      `));
+    });
+
+    it('re-stamps alert_correlation_groups only when EVERY member alert reached the target org and the (org_id, group_key) slot is free', async () => {
+      const { statements } = await moveDevice();
+
+      // Three guards, all load-bearing:
+      //  - `g.org_id IS DISTINCT FROM <target>` — never touch a group that is
+      //    already there (keeps the statement idempotent under a retry);
+      //  - the first EXISTS — the group must actually involve this device, so
+      //    an unrelated source-org group is never dragged along;
+      //  - NOT EXISTS over member alerts still outside the target org — a group
+      //    spanning several devices only travels once its LAST device does, so
+      //    it is never handed to an org that owns just part of it;
+      //  - NOT EXISTS over the target org's (org_id, group_key) — that pair is
+      //    `alert_correlation_groups_org_key_uq`, and the target org can
+      //    already hold the key because the correlation job mints it as
+      //    `root:<rootAlertId>` per org. Skipping beats a 23505 that would roll
+      //    the whole move back over derived state.
+      expect(onlyStatement(statements, 'alert_correlation_groups')).toBe(collapseStmt(`
+        UPDATE alert_correlation_groups g SET org_id = ${TARGET_ORG}::uuid
+        WHERE g.org_id IS DISTINCT FROM ${TARGET_ORG}::uuid
+        AND EXISTS (
+        SELECT 1 FROM alert_correlation_members m
+        JOIN alerts a ON a.id = m.alert_id
+        WHERE m.group_id = g.id AND a.device_id = ${DEVICE_ID}::uuid)
+        AND NOT EXISTS (
+        SELECT 1 FROM alert_correlation_members m2
+        JOIN alerts a2 ON a2.id = m2.alert_id
+        WHERE m2.group_id = g.id AND a2.org_id IS DISTINCT FROM ${TARGET_ORG}::uuid)
+        AND NOT EXISTS (
+        SELECT 1 FROM alert_correlation_groups existing
+        WHERE existing.org_id = ${TARGET_ORG}::uuid AND existing.group_key = g.group_key)
+        RETURNING g.id
+      `));
+    });
+
+    it('re-stamps ai_alert_verdicts on BOTH legs — an alert-level verdict follows its alert, a group-level verdict follows its group', async () => {
+      const { statements } = await moveDevice();
+
+      // The OR is the point: a `duplicate_of_group` verdict is persisted with
+      // alert_id NULL and correlation_group_id set, so the alert leg alone
+      // never reaches it and every member alert of a moved group would keep
+      // its noise classification stranded in the source org. The group leg is
+      // narrowed to groups this device's alerts belong to, so it cannot
+      // re-stamp a verdict on some unrelated group that merely sits in the
+      // target org.
+      expect(onlyStatement(statements, 'ai_alert_verdicts')).toBe(collapseStmt(`
+        UPDATE ai_alert_verdicts SET org_id = ${TARGET_ORG}::uuid
+        WHERE alert_id IN (SELECT id FROM alerts WHERE device_id = ${DEVICE_ID}::uuid)
+        OR correlation_group_id IN (
+        SELECT g.id FROM alert_correlation_groups g
+        WHERE g.org_id = ${TARGET_ORG}::uuid
+        AND EXISTS (
+        SELECT 1 FROM alert_correlation_members m
+        JOIN alerts a ON a.id = m.alert_id
+        WHERE m.group_id = g.id AND a.device_id = ${DEVICE_ID}::uuid))
+        RETURNING id
+      `));
+    });
+
+    it('orders the three AFTER the generic alerts re-stamp, and the group before the verdict', async () => {
+      const { statements } = await moveDevice();
+
+      const idx = (prefix: string) => {
+        const found = statements.map(collapseStmt).findIndex((s) => s.startsWith(prefix));
+        expect(found, `no statement starting with "${prefix}"`).toBeGreaterThanOrEqual(0);
+        return found;
+      };
+
+      // Load-bearing: the group predicate reads `alerts.org_id` AS RE-STAMPED
+      // by the generic loop, so running earlier would see every moved alert
+      // still in the source org and hold every group back.
+      const alertsRestamp = idx('UPDATE alerts SET org_id');
+      expect(idx('UPDATE alert_correlation_members ')).toBeGreaterThan(alertsRestamp);
+      expect(idx('UPDATE alert_correlation_groups ')).toBeGreaterThan(alertsRestamp);
+      expect(idx('UPDATE ai_alert_verdicts ')).toBeGreaterThan(alertsRestamp);
+
+      // Load-bearing: the verdict's group leg selects groups already sitting in
+      // the TARGET org, which is only true of a group this move just re-stamped
+      // once the group statement has run.
+      expect(idx('UPDATE ai_alert_verdicts ')).toBeGreaterThan(idx('UPDATE alert_correlation_groups '));
+
+      // Extends — never reorders — the documented ticket-child lock order
+      // (services/ticketOrgMoveLockOrder.ts): the alert-axis statements all
+      // follow the last ticket-chain table.
+      expect(idx('UPDATE alert_correlation_members ')).toBeGreaterThan(idx('UPDATE ticket_email_links '));
+    });
+
+    it('counts the groups it touched but held back, for the audit trail', async () => {
+      const { statements } = await moveDevice();
+
+      // A held group is one this device's alerts belong to that is still not in
+      // the target org after the re-stamp — i.e. split across orgs, or blocked
+      // by an occupied group_key. Counted so an operator asking "why did the
+      // correlation badge not follow this device?" has the number in the audit
+      // row instead of having to reconstruct it.
+      const held = statements.map(collapseStmt).filter((s) => s.startsWith('SELECT count(*)::int AS held '));
+      expect(
+        held,
+        `Expected exactly one held-group count.\nStatements:\n${statements.join('\n')}`,
+      ).toEqual([
+        collapseStmt(`
+          SELECT count(*)::int AS held
+          FROM alert_correlation_groups g
+          WHERE g.org_id IS DISTINCT FROM ${TARGET_ORG}::uuid
+          AND EXISTS (
+          SELECT 1 FROM alert_correlation_members m
+          JOIN alerts a ON a.id = m.alert_id
+          WHERE m.group_id = g.id AND a.device_id = ${DEVICE_ID}::uuid)
+        `),
+      ]);
+    });
+
+    it('records the alert-axis rewrite counts on BOTH audit rows', async () => {
+      executeResultFor = (text) => {
+        if (text.startsWith('UPDATE alert_correlation_members ')) return [{ id: 'm1' }, { id: 'm2' }];
+        if (text.startsWith('UPDATE alert_correlation_groups ')) return [{ id: 'g1' }];
+        if (text.startsWith('UPDATE ai_alert_verdicts ')) return [{ id: 'v1' }, { id: 'v2' }, { id: 'v3' }];
+        if (text.startsWith('SELECT count(*)::int AS held ')) return [{ held: 4 }];
+        return null;
+      };
+      await moveDevice();
+
+      const expected = {
+        correlationMembers: 2,
+        correlationGroups: 1,
+        correlationGroupsHeld: 4,
+        alertVerdicts: 3,
+      };
+      const auditRows = vi.mocked(writeRouteAudit).mock.calls.map((call) => call[1] as any);
+      expect(auditRows).toHaveLength(2);
+      for (const row of auditRows) {
+        expect(row.details.alertChildRewrite).toEqual(expected);
+      }
+      // One row per org, as everywhere else in this route.
+      expect(auditRows.map((row) => row.orgId).sort()).toEqual([SOURCE_ORG, TARGET_ORG].sort());
+    });
+
+    it('omits the alert-axis counts when the device had no alert-axis rows', async () => {
+      await moveDevice();
+
+      const auditRows = vi.mocked(writeRouteAudit).mock.calls.map((call) => call[1] as any);
+      expect(auditRows).toHaveLength(2);
+      for (const row of auditRows) {
+        expect(row.details).not.toHaveProperty('alertChildRewrite');
+      }
     });
   });
 

--- a/apps/api/src/routes/devices/moveOrg.ts
+++ b/apps/api/src/routes/devices/moveOrg.ts
@@ -52,6 +52,20 @@ class OrgVanishedDuringMoveError extends Error {
   }
 }
 
+/**
+ * How much alert-axis derived state a device org-move carried over (#4867),
+ * recorded on BOTH audit rows so the source and target feeds agree.
+ * `correlationGroupsHeld` counts the groups the move touched but deliberately
+ * left in the source org — still spanning two orgs, or their
+ * (org_id, group_key) slot already taken in the target org.
+ */
+interface AlertChildOrgRewriteCounts {
+  correlationMembers: number;
+  correlationGroups: number;
+  correlationGroupsHeld: number;
+  alertVerdicts: number;
+}
+
 export const moveOrgRoutes = new Hono();
 
 moveOrgRoutes.use('*', authMiddleware);
@@ -186,6 +200,10 @@ moveOrgRoutes.post(
     // #3776 — non-null only when the caller accepted a cross-currency move
     // that stranded unbilled monetary ticket rows in the source currency.
     let currencyGuard: MoveCurrencyGuardDetails | null = null;
+    // #4867 — non-null only when the moved device actually had alert-axis
+    // derived state (correlation members / groups, AI alert verdicts) to carry
+    // over. See AlertChildOrgRewriteCounts.
+    let alertChildRewrite: AlertChildOrgRewriteCounts | null = null;
     try {
       await db.transaction(async (tx) => {
         // #4596 W2. `time_entries_ticket_org_fk` and `ticket_parts_ticket_org_fk`
@@ -606,6 +624,126 @@ moveOrgRoutes.post(
           sql`UPDATE ${sql.identifier('ticket_email_links')} SET org_id = ${targetOrgId}::uuid WHERE ticket_id IN (SELECT id FROM tickets WHERE device_id = ${deviceId}::uuid)`,
         );
 
+        // #4867 — the ALERT-axis children (ALERT_CHILD_ORG_REWRITE_TABLES in
+        // core.ts): alert_correlation_members, alert_correlation_groups and
+        // ai_alert_verdicts all denormalize org_id but have NO device_id
+        // column, so neither the generic loop above nor the DB-side
+        // breeze_cascade_device_org_id() trigger (which discovers its tables BY
+        // that device_id column) can reach them. Every alert-facing reader pins
+        // these rows to the ALERT's org — hideAiNoiseCondition /
+        // correlationMetadataCondition (routes/alerts/alerts.ts) and
+        // latestVerdictsForAlerts / latestVerdictForGroup
+        // (services/aiAgents/alertVerdicts.ts) — so a row left behind is
+        // invisible to the org that now owns the alert: the moved alert
+        // silently loses its AI-noise suppression and its correlation badge,
+        // and nothing regenerates either (the verdict scheduler is event-driven
+        // off `alert.triggered` and never re-scans).
+        //
+        // Placement is load-bearing twice: AFTER the generic loop, because the
+        // group predicate below reads alerts.org_id AS RE-STAMPED by it; and
+        // AFTER the ticket chain above, so this extends — never reorders — the
+        // documented ticket-child lock order
+        // (services/ticketOrgMoveLockOrder.ts). The three run member -> group ->
+        // verdict because each later predicate reads what the earlier one just
+        // wrote. None of them carries a composite tenant FK, so there is no
+        // 23503 hazard of the kind the ticket chain is ordered for.
+        //
+        // A member row describes ONE alert's membership, so it always follows
+        // that alert — even when its group does not (next statement).
+        const movedCorrelationMembers = (await tx.execute(
+          sql`UPDATE ${sql.identifier('alert_correlation_members')} SET org_id = ${targetOrgId}::uuid
+              WHERE alert_id IN (SELECT id FROM alerts WHERE device_id = ${deviceId}::uuid)
+              RETURNING id`,
+        )) as unknown as Array<{ id: string }>;
+
+        // A GROUP can span alerts from several devices, so it travels only once
+        // EVERY member alert shares the target org — handing a group to an org
+        // that owns part of it would make its member_count / noise_reduction_
+        // percent claims wrong for both orgs. A group still spanning two orgs
+        // is left behind and counted below instead.
+        //
+        // The third guard is `alert_correlation_groups_org_key_uq (org_id,
+        // group_key)`: the correlation job mints group_key as
+        // `root:<rootAlertId>` PER ORG (services/alertCorrelationGroups.ts), so
+        // the target org can already hold the same key — reachable precisely
+        // because this gap let a previously-moved alert grow a second group
+        // there. Skipping is deliberate: derived correlation state must not be
+        // able to fail an admin's device move with a 23505, and merging two
+        // groups (which one's status/score/metadata wins?) is not this route's
+        // call to make silently.
+        const movedCorrelationGroups = (await tx.execute(
+          sql`UPDATE ${sql.identifier('alert_correlation_groups')} g SET org_id = ${targetOrgId}::uuid
+              WHERE g.org_id IS DISTINCT FROM ${targetOrgId}::uuid
+                AND EXISTS (
+                  SELECT 1 FROM alert_correlation_members m
+                  JOIN alerts a ON a.id = m.alert_id
+                  WHERE m.group_id = g.id AND a.device_id = ${deviceId}::uuid)
+                AND NOT EXISTS (
+                  SELECT 1 FROM alert_correlation_members m2
+                  JOIN alerts a2 ON a2.id = m2.alert_id
+                  WHERE m2.group_id = g.id AND a2.org_id IS DISTINCT FROM ${targetOrgId}::uuid)
+                AND NOT EXISTS (
+                  SELECT 1 FROM alert_correlation_groups existing
+                  WHERE existing.org_id = ${targetOrgId}::uuid AND existing.group_key = g.group_key)
+              RETURNING g.id`,
+        )) as unknown as Array<{ id: string }>;
+
+        // A verdict follows the row it judges. The OR is the point: a
+        // `duplicate_of_group` classification is persisted with alert_id NULL
+        // and correlation_group_id set, so the alert leg alone never reaches it
+        // and every member alert of a moved group would keep its noise verdict
+        // stranded. The group leg is narrowed to groups this device's alerts
+        // belong to, so it cannot re-stamp a verdict on an unrelated group that
+        // merely happens to sit in the target org. Runs after the group
+        // statement because "g.org_id = target" is what "this move just took
+        // the group with it" means here.
+        //
+        // Provenance note: verdict.run_id is NOT NULL and `ai_agent_runs`
+        // deliberately stays in the SOURCE org (owner decision 2026-08-23), so
+        // after this re-stamp a verdict's org_id and its run's org_id differ.
+        // Nothing dereferences that pair except recordVerdictFeedback's
+        // op-evidence write, whose composite FK (run_id, org_id) ->
+        // ai_agent_runs(id, org_id) forces the EVIDENCE row to carry the RUN's
+        // org — see the fix in services/aiAgents/alertVerdicts.ts.
+        const movedAlertVerdicts = (await tx.execute(
+          sql`UPDATE ${sql.identifier('ai_alert_verdicts')} SET org_id = ${targetOrgId}::uuid
+              WHERE alert_id IN (SELECT id FROM alerts WHERE device_id = ${deviceId}::uuid)
+                 OR correlation_group_id IN (
+                   SELECT g.id FROM alert_correlation_groups g
+                   WHERE g.org_id = ${targetOrgId}::uuid
+                     AND EXISTS (
+                       SELECT 1 FROM alert_correlation_members m
+                       JOIN alerts a ON a.id = m.alert_id
+                       WHERE m.group_id = g.id AND a.device_id = ${deviceId}::uuid))
+              RETURNING id`,
+        )) as unknown as Array<{ id: string }>;
+
+        // Groups this move touched but deliberately left behind (still spanning
+        // two orgs, or blocked by an occupied group_key). Counted so an operator
+        // asking "why didn't the correlation badge follow this device?" finds
+        // the number in the audit row instead of reconstructing it from SQL.
+        const [heldCorrelationGroups] = (await tx.execute(
+          sql`SELECT count(*)::int AS held
+              FROM alert_correlation_groups g
+              WHERE g.org_id IS DISTINCT FROM ${targetOrgId}::uuid
+                AND EXISTS (
+                  SELECT 1 FROM alert_correlation_members m
+                  JOIN alerts a ON a.id = m.alert_id
+                  WHERE m.group_id = g.id AND a.device_id = ${deviceId}::uuid)`,
+        )) as unknown as Array<{ held: number }>;
+
+        const alertChildCounts = {
+          correlationMembers: movedCorrelationMembers.length,
+          correlationGroups: movedCorrelationGroups.length,
+          correlationGroupsHeld: Number(heldCorrelationGroups?.held ?? 0),
+          alertVerdicts: movedAlertVerdicts.length,
+        };
+        // Only audit the block when the device actually had alert-axis rows, so
+        // a move of a quiet device adds no noise to either org's audit feed.
+        alertChildRewrite = Object.values(alertChildCounts).some((n) => n > 0)
+          ? alertChildCounts
+          : null;
+
         // Rewrite denormalized site_id on every device-scoped table that has
         // one (currently elevation_requests — see DEVICE_SITE_DENORMALIZED_TABLES
         // in core.ts). Skipping any of these strands rows under the OLD
@@ -686,6 +824,7 @@ moveOrgRoutes.post(
     // Audit on BOTH orgs so the move shows up in source and target feeds.
     // (Cast: TS narrows the closure-assigned `let` to its initial null.)
     const acceptedGuard = currencyGuard as MoveCurrencyGuardDetails | null;
+    const alertChildCounts = alertChildRewrite as AlertChildOrgRewriteCounts | null;
     const auditDetails = {
       deviceId,
       sourceOrgId,
@@ -702,6 +841,10 @@ moveOrgRoutes.post(
       // #3776 — the caller knowingly left unbilled ticket money in the source
       // currency; record the counts so the stranded snapshots are traceable.
       ...(acceptedGuard?.accepted ? { currencyMismatchAccepted: acceptedGuard } : {}),
+      // #4867 — how much alert-axis derived state travelled with the device,
+      // and how many correlation groups were held back on purpose. Omitted
+      // entirely for a device with no alerts, so a quiet move adds no noise.
+      ...(alertChildCounts ? { alertChildRewrite: alertChildCounts } : {}),
     } as const;
 
     writeRouteAudit(c, {

--- a/apps/api/src/services/aiAgents/alertVerdicts.test.ts
+++ b/apps/api/src/services/aiAgents/alertVerdicts.test.ts
@@ -19,6 +19,9 @@ const OTHER_USER_ID = '00000000-0000-4000-8000-0000000000ec';
 const AGENT_ID = '00000000-0000-4000-8000-0000000000ed';
 const RULE_ID = '00000000-0000-4000-8000-0000000000ee';
 const ROOT_ALERT_ID = '00000000-0000-4000-8000-0000000000ef';
+// The run's org after a device org-move re-stamps the verdict's org_id to the
+// target org (#4867) but leaves ai_agent_runs behind in the source org.
+const SOURCE_RUN_ORG_ID = '00000000-0000-4000-8000-0000000000f0';
 
 const state = vi.hoisted(() => ({
   selectQueue: [] as unknown[][],
@@ -879,7 +882,7 @@ describe('recordVerdictFeedback', () => {
 
   it('an up-vote writes the update and one feedback_up evidence row keyed to the verdict\'s own createdAt', async () => {
     state.selectQueue.push([verdictRow()]);
-    state.selectQueue.push([{ agentId: AGENT_ID }]);
+    state.selectQueue.push([{ agentId: AGENT_ID, orgId: ORG_ID }]);
     state.selectQueue.push([{ ruleId: RULE_ID }]);
 
     const result = await recordVerdictFeedback(agentAuth, VERDICT_ROW_ID, 'up');
@@ -902,6 +905,36 @@ describe('recordVerdictFeedback', () => {
       runId: RUN_ID,
       // The FIXED bucket — the verdict's own creation, not the vote's.
       occurredAt: new Date('2026-08-15T00:00:00.000Z'),
+    });
+  });
+
+  it('stamps the evidence row with the RUN\'s org, not the verdict\'s, once the verdict\'s alert has moved org (#4867)', async () => {
+    // A device org-move re-stamps `ai_alert_verdicts.org_id` to the target org
+    // (routes/devices/moveOrg.ts, ALERT_CHILD_ORG_REWRITE_TABLES) so the moved
+    // alert keeps its noise classification, but `ai_agent_runs` deliberately
+    // stays in the SOURCE org (owner decision 2026-08-23) and `run_id` is NOT
+    // NULL — so the two orgs diverge. `ai_agent_op_evidence_run_org_fk` is the
+    // COMPOSITE (run_id, org_id) -> ai_agent_runs(id, org_id): writing the
+    // VERDICT's org next to the RUN's id is a 23503 that rolls the whole
+    // feedback request back as a 500. The run's own org is the only value that
+    // FK accepts, and it is also the honest one — the evidence describes what
+    // the agent did, and the agent belongs to the org that ran it.
+    state.selectQueue.push([verdictRow({ orgId: ORG_ID })]);
+    state.selectQueue.push([{ agentId: AGENT_ID, orgId: SOURCE_RUN_ORG_ID }]);
+    state.selectQueue.push([{ ruleId: RULE_ID }]);
+
+    const result = await recordVerdictFeedback(agentAuth, VERDICT_ROW_ID, 'up');
+
+    // The vote itself still resolves against the verdict, in the verdict's org
+    // (the route audits that org) — only the evidence row's tenant stamp
+    // follows the run.
+    expect(result).toEqual({ status: 'ok', orgId: ORG_ID });
+    expect(state.updateCount).toBe(1);
+    expect(state.insertValues[0]).toMatchObject({
+      orgId: SOURCE_RUN_ORG_ID,
+      agentId: AGENT_ID,
+      runId: RUN_ID,
+      metric: 'feedback_up',
     });
   });
 

--- a/apps/api/src/services/aiAgents/alertVerdicts.ts
+++ b/apps/api/src/services/aiAgents/alertVerdicts.ts
@@ -649,7 +649,7 @@ export async function recordVerdictFeedback(
     .set({ feedback, feedbackBy: auth.user.id, feedbackAt: new Date() })
     .where(eq(aiAlertVerdicts.id, verdictId));
 
-  const [run] = await db.select({ agentId: aiAgentRuns.agentId })
+  const [run] = await db.select({ agentId: aiAgentRuns.agentId, orgId: aiAgentRuns.orgId })
     .from(aiAgentRuns)
     .where(eq(aiAgentRuns.id, verdict.runId))
     .limit(1);
@@ -660,8 +660,16 @@ export async function recordVerdictFeedback(
   // row is guaranteed to exist whenever the verdict row does, so `run` is
   // only undefined in a test double that forgot to queue it.
   if (run) {
+    // The evidence row's tenant stamp follows the RUN, not the verdict: a
+    // device org-move re-stamps `ai_alert_verdicts.org_id` to the target org
+    // (routes/devices/moveOrg.ts, ALERT_CHILD_ORG_REWRITE_TABLES, #4867) but
+    // deliberately leaves `ai_agent_runs` in the source org, so the two can
+    // diverge. `ai_agent_op_evidence_run_org_fk` is the composite
+    // (run_id, org_id) -> ai_agent_runs(id, org_id); writing the verdict's org
+    // next to the run's id would be a 23503 for any verdict whose alert has
+    // moved since the run happened.
     await upsertVerdictFeedbackEvidence({
-      orgId: verdict.orgId,
+      orgId: run.orgId,
       agentId: run.agentId,
       namespace: 'alert_verdict',
       opKey: AI_AGENT_ALERT_VERDICT_OP_KEY,


### PR DESCRIPTION
## Summary
- `alert_correlation_members`, `alert_correlation_groups`, and `ai_alert_verdicts` denormalize `org_id` but have no `device_id` column, so neither the generic device org-move rewrite loop nor the DB-side `breeze_cascade_device_org_id()` trigger can reach them on a device org-move.
- Adds `ALERT_CHILD_ORG_REWRITE_TABLES` (`core.ts`) and three hand-written `UPDATE`s inside the move-org transaction, run after the generic org rewrite and the ticket chain, in order: member -> group -> verdict, since each predicate reads what the prior statement just re-stamped.
- A correlation group only travels once **every** member alert has reached the target org, and only if the target's `(org_id, group_key)` slot is free; otherwise it is held back (never a fail-the-move 23505) and counted for the audit trail.
- `ai_alert_verdicts` rewrites on both its `alert_id` and `correlation_group_id` legs, since a `duplicate_of_group` verdict has `alert_id NULL`.
- Rewrite counts land on both audit rows (source + target org), and are omitted entirely for a device with no alert-axis rows so a quiet move stays quiet.

## Root cause
`alerts` is in `CORE_DEVICE_ORG_DENORMALIZED_TABLES`, so `alerts.org_id` is rewritten on move — but its AI/correlation children were never wired into `moveOrg.ts` at all. Every alert-facing reader (`hideAiNoiseCondition`, `correlationMetadataCondition`, `latestVerdictsForAlerts`, `latestVerdictForGroup`) pins these rows to the alert's own org, so a stranded row is invisible to the org that now owns the alert — permanently losing AI-noise suppression and its correlation badge, with no regeneration path (the verdict scheduler is event-driven off `alert.triggered` and never re-scans).

Fixing the rewrite exposed a second, latent bug: `recordVerdictFeedback` (`services/aiAgents/alertVerdicts.ts`) wrote the **verdict's** `org_id` onto the `ai_agent_op_evidence` row it inserts, but that table's `ai_agent_op_evidence_run_org_fk` is a **composite** `(run_id, org_id) -> ai_agent_runs(id, org_id)`, and `ai_agent_runs` deliberately stays in the source org after a device move (owner decision 2026-08-23). Once this PR lets a verdict's `org_id` diverge from its run's, giving feedback on a post-move verdict would hit a `23503` FK violation. Fixed by stamping the evidence row with the run's own `org_id` instead — also the more honest value, since the evidence describes what the agent did, and the agent belongs to the org that ran it.

## Verification
```
cd apps/api
npx vitest run src/routes/devices/moveOrg.test.ts src/routes/devices/moveOrg.coverage.test.ts src/services/aiAgents/alertVerdicts.test.ts
# Test Files  3 passed (3)
# Tests  122 passed (122)

NODE_OPTIONS="--max-old-space-size=8192" npx tsc --noEmit -p apps/api
# exit code 0, no output

npx eslint apps/api/src/services/aiAgents/alertVerdicts.ts apps/api/src/services/aiAgents/alertVerdicts.test.ts \
  apps/api/src/routes/devices/moveOrg.ts apps/api/src/routes/devices/moveOrg.test.ts \
  apps/api/src/routes/devices/moveOrg.coverage.test.ts apps/api/src/routes/devices/core.ts
# clean, no output
```

## Decisions / notes for reviewer
- Followed the issue's Option 1 (rewrite, don't delete/accept staleness) since `moveOrg.coverage.test.ts` already existed with the pattern for deriving expected membership from the schema, and the group-key collision rule was explicitly called out as needing a decision: **a group only follows the device if every one of its member alerts is now in the target org, and the target `(org_id, group_key)` slot is free; otherwise it's held back and counted, never merged and never a hard failure.**
- `ai_alert_verdicts` is not registered in `CORE_ORG_CASCADE_DELETE_ORDER` / the other cascade lists per `CLAUDE.md` — these are pre-existing tables getting a bug fix, not new tables being introduced, so no new cascade/RLS-allowlist registration applies.
- This work was started by a prior (Qwen) session in this branch. Its `moveOrg.ts`/`core.ts`/test scaffolding was well-reasoned and verified correct against the live schema (table names, columns, unique constraints, RLS policies all checked against the actual migrations). However it left one gap: a comment in `moveOrg.ts` claimed a fix had been applied to `services/aiAgents/alertVerdicts.ts` (the run-vs-verdict org divergence above) and a matching test was written, but the actual source fix was never made — the test was red. I applied the fix (`alertVerdicts.ts`) and squashed everything into this single commit.

Closes #4867

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWo4rHCQpKQkSkUiH8srjr