### PR TITLE
fix(web): quote editor paper cuts — title collapse, illegal reprice offer, triple label (#4937)

### DIFF
--- a/apps/web/src/components/billing/ChangeCurrencyDialog.tsx
+++ b/apps/web/src/components/billing/ChangeCurrencyDialog.tsx
@@ -51,6 +51,12 @@ interface Props {
   onSubmit: () => void;
   submittable: boolean;
   copy: ChangeCurrencyDialogCopy;
+  /** When set, the `reprice` radio is disabled and this reason REPLACES its
+   *  hint. Callers pass it when the document's own lines make `reprice`
+   *  illegal — the server refuses the whole op with 409 CURRENCY_LOCKED, so
+   *  offering a choice that can only fail costs a round-trip to be told no
+   *  (#4937). `clear` is always legal, so the operator is never dead-ended. */
+  repriceUnavailableReason?: string | null;
   /** data-testid prefix, e.g. "quote-currency" / "invoice-currency" — mirrors
    *  the "contract-currency-*" ids ContractDetail's dialog established. */
   testIdPrefix: string;
@@ -59,7 +65,7 @@ interface Props {
 export default function ChangeCurrencyDialog({
   open, onClose, busy, currentCurrency, targetCurrency, onTargetCurrencyChange,
   mode, onModeChange, confirmed, onConfirmedChange, error, onSubmit, submittable,
-  copy, testIdPrefix,
+  copy, repriceUnavailableReason, testIdPrefix,
 }: Props) {
   const { i18n } = useTranslation('billing');
   return (
@@ -105,17 +111,27 @@ export default function ChangeCurrencyDialog({
               <span className="block text-muted-foreground">{copy.modeClearHint}</span>
             </span>
           </label>
-          <label className="flex items-start gap-2 text-sm">
+          <label className={`flex items-start gap-2 text-sm${repriceUnavailableReason ? ' opacity-60' : ''}`}>
             <input
               type="radio" name={`${testIdPrefix}-mode`} value="reprice"
               checked={mode === 'reprice'}
               onChange={() => onModeChange('reprice')}
+              disabled={!!repriceUnavailableReason}
               data-testid={`${testIdPrefix}-mode-reprice`}
               className="mt-1"
             />
             <span>
               <span className="font-medium">{copy.modeRepriceLabel}</span>
-              <span className="block text-muted-foreground">{copy.modeRepriceHint}</span>
+              {repriceUnavailableReason ? (
+                <span
+                  className="block text-muted-foreground"
+                  data-testid={`${testIdPrefix}-mode-reprice-unavailable`}
+                >
+                  {repriceUnavailableReason}
+                </span>
+              ) : (
+                <span className="block text-muted-foreground">{copy.modeRepriceHint}</span>
+              )}
             </span>
           </label>
         </fieldset>

--- a/apps/web/src/components/billing/quotes/QuoteBlockCard.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteBlockCard.tsx
@@ -927,8 +927,14 @@ export function BlockCard({
                           )}
                           <p className="text-xs text-muted-foreground">{t('quotes.editor.deviceSet.quantityAuto')}</p>
                           <fieldset className="space-y-2" data-testid={`quote-manual-device-set-allowance-group-${block.id}`}>
-                            <legend className="sr-only">{t('quotes.editor.deviceSet.includedLabel')}</legend>
-                            <label className="flex items-center gap-2 text-xs"><input type="checkbox" checked={allowanceOn} onChange={(e) => setAllowanceOn(e.target.checked)} data-testid={`quote-manual-device-set-allowance-${block.id}`} />{t('quotes.editor.deviceSet.includedLabel')}</label>
+                            {/* Three different jobs, three different strings (#4937 — all three
+                                used to render deviceSet.includedLabel, so the form read
+                                "Included quantity ☐ / Included quantity [ ]" and a screen reader
+                                heard it three times). Mirrors the contract editor's allowance
+                                block: the legend names the GROUP, the checkbox names the ACTION,
+                                and only the number input below is "Included quantity". */}
+                            <legend className="sr-only">{t('quotes.editor.deviceSet.allowanceGroupLabel')}</legend>
+                            <label className="flex items-center gap-2 text-xs"><input type="checkbox" checked={allowanceOn} onChange={(e) => setAllowanceOn(e.target.checked)} data-testid={`quote-manual-device-set-allowance-${block.id}`} />{t('quotes.editor.deviceSet.allowanceToggle')}</label>
                             {allowanceOn && <div className="grid gap-2 sm:grid-cols-3">
                               <label className="text-xs text-muted-foreground">{t('quotes.editor.deviceSet.includedLabel')}<input type="number" min="1" step="1" value={includedQuantity} onChange={(e) => setIncludedQuantity(e.target.value)} className="mt-1 h-9 w-full rounded-md border bg-background px-2 text-foreground" /></label>
                               <fieldset className="space-y-1 text-xs text-muted-foreground">

--- a/apps/web/src/components/billing/quotes/QuoteDetail.currency.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.currency.test.tsx
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import QuoteDetail from './QuoteDetail';
 import * as quotesApi from '../../../lib/api/quotes';
-import type { QuoteDetail as QuoteDetailData, QuoteStatus } from './quoteTypes';
+import type { QuoteDetail as QuoteDetailData, QuoteLine, QuoteStatus } from './quoteTypes';
 
 // #4416 — the draft-only atomic change-currency op (#3774,
 // changeQuoteCurrency in quoteService.ts) has been reachable server-side
@@ -37,7 +37,7 @@ vi.mock('../../../lib/api/quotes', async (importOriginal) => {
 const resp = (payload: unknown, status = 200): Response =>
   ({ ok: status < 400, status, statusText: 'OK', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
 
-function detail(status: QuoteStatus, currencyCode = 'USD'): QuoteDetailData {
+function detail(status: QuoteStatus, currencyCode = 'USD', lines: QuoteLine[] = []): QuoteDetailData {
   return {
     quote: {
       id: 'q-1', quoteNumber: null, partnerId: 'p-1', orgId: 'org-1', siteId: null, status,
@@ -49,7 +49,22 @@ function detail(status: QuoteStatus, currencyCode = 'USD'): QuoteDetailData {
       createdBy: null, createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
     },
     blocks: [],
-    lines: [],
+    lines,
+  };
+}
+
+// A standalone catalog line is the only shape `reprice` can re-resolve from the
+// price book (repriceQuoteCatalogLines, quoteService.ts).
+function quoteLine(over: Partial<QuoteLine> = {}): QuoteLine {
+  return {
+    id: 'l-1', quoteId: 'q-1', blockId: null, orgId: 'org-1', sourceType: 'catalog',
+    catalogItemId: 'cat-1', parentLineId: null, unitCost: null, sku: null, partNumber: null,
+    name: 'Managed workstation', description: null, quantity: '2.00', unitPrice: '49.00',
+    taxable: false, customerVisible: true, lineTotal: '98.00', recurrence: 'monthly',
+    termMonths: null, billingFrequency: null, sortOrder: 0, createdAt: '',
+    contractLineType: null, deviceRoles: null, deviceGroupId: null, deviceGroupName: null,
+    siteId: null, siteName: null, includedQuantity: null, overageMode: null,
+    overageUnitPrice: null, descriptorUnresolved: false, ...over,
   };
 }
 
@@ -210,5 +225,57 @@ describe('QuoteDetail — draft currency change (#4416)', () => {
     await waitFor(() => expect(screen.getByTestId('quote-currency-submit')).toBeDisabled());
     releaseRequest(resp({ data: { id: 'q-1' } }));
     await waitFor(() => expect(screen.queryByTestId('quote-currency-dialog')).not.toBeInTheDocument());
+  });
+
+  // #4937 — the dialog offered a mode the data forbids. `reprice` re-resolves
+  // every line from the price book, so the server refuses the whole op with 409
+  // CURRENCY_LOCKED unless EVERY line is a standalone catalog line
+  // (repriceQuoteCatalogLines). The dialog already stated the rule in its own
+  // hint; now it enforces it, so an illegal choice costs no round-trip.
+  describe('reprice availability (#4937)', () => {
+    const reprice = () => screen.getByTestId('quote-currency-mode-reprice') as HTMLInputElement;
+    const clear = () => screen.getByTestId('quote-currency-mode-clear') as HTMLInputElement;
+
+    it('disables reprice and names the reason when a manual line exists', async () => {
+      render(<QuoteDetail detail={detail('draft', 'USD', [quoteLine({ sourceType: 'manual', catalogItemId: null })])} onChanged={vi.fn()} />);
+      await openDialog();
+      expect(reprice().disabled).toBe(true);
+      expect(screen.getByTestId('quote-currency-mode-reprice-unavailable')).toBeInTheDocument();
+      // The legal mode stays available, so the operator is not dead-ended.
+      expect(clear().disabled).toBe(false);
+    });
+
+    it('disables reprice for a bundle line and for a bundle child', async () => {
+      const { unmount } = render(<QuoteDetail detail={detail('draft', 'USD', [quoteLine({ sourceType: 'bundle' })])} onChanged={vi.fn()} />);
+      await openDialog();
+      expect(reprice().disabled).toBe(true);
+      unmount();
+
+      render(<QuoteDetail detail={detail('draft', 'USD', [quoteLine({ id: 'l-2', parentLineId: 'l-1' })])} onChanged={vi.fn()} />);
+      await openDialog();
+      expect(reprice().disabled).toBe(true);
+    });
+
+    it('disables reprice when a catalog line lost its catalog item', async () => {
+      render(<QuoteDetail detail={detail('draft', 'USD', [quoteLine({ catalogItemId: null })])} onChanged={vi.fn()} />);
+      await openDialog();
+      expect(reprice().disabled).toBe(true);
+    });
+
+    it('keeps reprice enabled when every line is a standalone catalog line', async () => {
+      render(<QuoteDetail detail={detail('draft', 'USD', [quoteLine(), quoteLine({ id: 'l-2' })])} onChanged={vi.fn()} />);
+      await openDialog();
+      expect(reprice().disabled).toBe(false);
+      expect(screen.queryByTestId('quote-currency-mode-reprice-unavailable')).not.toBeInTheDocument();
+    });
+
+    it('still submits reprice for an all-catalog quote', async () => {
+      render(<QuoteDetail detail={detail('draft', 'USD', [quoteLine()])} onChanged={vi.fn()} />);
+      await openDialog();
+      await confirmWith('reprice', 'EUR');
+      await waitFor(() => expect(quotesApi.changeQuoteCurrency).toHaveBeenCalledWith('q-1', {
+        currencyCode: 'EUR', reprice: true,
+      }));
+    });
   });
 });

--- a/apps/web/src/components/billing/quotes/QuoteDetail.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.tsx
@@ -116,6 +116,21 @@ export default function QuoteDetail({ detail, onChanged, actionsInHeader }: Prop
   const canChangeCurrency = can('quotes', 'write') && quote.status === 'draft';
   const currencySubmittable = !!currencyMode && currencyConfirmed && targetCurrency !== currency;
 
+  // `reprice` re-resolves every line from the price book in the TARGET currency,
+  // so the server refuses the whole op with 409 CURRENCY_LOCKED unless every
+  // line is a standalone catalog line — manual lines, bundle parents and bundle
+  // children all carry amounts the price book cannot re-derive
+  // (repriceQuoteCatalogLines, quoteService.ts). The dialog already stated the
+  // rule in its hint but only the server enforced it, so an illegal choice cost
+  // a round-trip to be told no (#4937). Mirror the server predicate and disable
+  // the mode; `clear` is always legal, so nobody is dead-ended.
+  const repriceUnavailableReason = useMemo(
+    () => lines.some((l) => l.sourceType !== 'catalog' || l.catalogItemId === null || l.parentLineId !== null)
+      ? t('quotes.currency.dialog.modeRepriceUnavailable')
+      : null,
+    [lines, t],
+  );
+
   // Same cents math as the editor rail (computeQuoteProfit), fed the read-model
   // strings, so the Detail margin can never diverge from the editor margin.
   const profit = useMemo<QuoteProfit>(
@@ -420,6 +435,7 @@ export default function QuoteDetail({ detail, onChanged, actionsInHeader }: Prop
         error={currencyError}
         onSubmit={() => void submitCurrency()}
         submittable={currencySubmittable}
+        repriceUnavailableReason={repriceUnavailableReason}
         testIdPrefix="quote-currency"
         copy={{
           title: t('quotes.currency.dialog.title'),

--- a/apps/web/src/components/billing/quotes/QuoteEditor.deviceSet.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.deviceSet.test.tsx
@@ -128,6 +128,36 @@ describe('QuoteEditor device-set lines', () => {
     expect(within(allowance).getByRole('spinbutton', { name: 'Overage price' })).toBeInTheDocument();
   });
 
+  // #4937 — the sr-only legend, the *enable-the-allowance* checkbox and the
+  // number input all rendered `deviceSet.includedLabel`, so the visible form
+  // read "Included quantity ☐ / Included quantity [ ]" and a screen reader
+  // heard the same string three times. Mirrors the contract editor: the
+  // checkbox names the ACTION, the legend names the GROUP, and only the number
+  // input is "Included quantity".
+  it('gives the create-form allowance group, toggle and quantity input three distinct names', () => {
+    mount();
+    fireEvent.click(screen.getByTestId('quote-block-add-line-toggle-b1'));
+    fireEvent.click(screen.getByTestId('quote-line-mode-b1-manual'));
+    fireEvent.change(screen.getByTestId('quote-manual-recurrence-b1'), { target: { value: 'monthly' } });
+    fireEvent.click(screen.getByTestId('quote-manual-device-set-toggle-b1'));
+    fireEvent.click(screen.getByTestId('quote-manual-device-set-allowance-b1'));
+
+    const createAllowance = screen.getByTestId('quote-manual-device-set-allowance-group-b1');
+    expect(screen.getByRole('group', { name: 'Quantity allowance' })).toBe(createAllowance);
+    expect(within(createAllowance).getByRole('checkbox', { name: 'Include a fixed quantity, then handle extras' })).toBeChecked();
+    expect(within(createAllowance).getByRole('spinbutton', { name: 'Included quantity' })).toBeInTheDocument();
+    expect(within(createAllowance).getAllByText('Included quantity')).toHaveLength(1);
+  });
+
+  it('gives an existing line allowance group, toggle and quantity input three distinct names', async () => {
+    mount([line({ includedQuantity: '25', overageMode: 'bill', overageUnitPrice: '12' })]);
+    const allowance = await screen.findByTestId('quote-line-device-set-allowance-l1');
+    expect(screen.getByRole('group', { name: 'Quantity allowance' })).toBe(allowance);
+    expect(within(allowance).getByRole('checkbox', { name: 'Include a fixed quantity, then handle extras' })).toBeChecked();
+    expect(within(allowance).getByRole('spinbutton', { name: 'Included quantity' })).toBeInTheDocument();
+    expect(within(allowance).getAllByText('Included quantity')).toHaveLength(1);
+  });
+
   it('shows an inline error and manual runAction refresh when the live count check fails', async () => {
     vi.mocked(fetchWithAuth).mockImplementation(async (path, init) => {
       if (String(path).includes('device-set-estimate')) throw new Error('offline');

--- a/apps/web/src/components/billing/quotes/QuoteHeaderMeta.title.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteHeaderMeta.title.test.tsx
@@ -173,4 +173,18 @@ describe('QuoteHeaderMeta — title save reporting', () => {
 
     expect(input.value).toBe('Original title — draft in progress');
   });
+
+  // #4937 — the slot is a flex child of DocumentWorkspace's title cluster, and
+  // `min-w-0` let the header row shrink it below its own content: at a 1280px
+  // viewport the input measured 102px against 208px of text. jsdom has no
+  // layout engine, so this pins the flex contract (a real min-width floor, not
+  // `min-w-0`) that makes the cluster wrap the status pill instead of starving
+  // the title.
+  it('keeps a width floor on the title slot so the header row cannot collapse it (#4937)', () => {
+    render(<QuoteHeaderMeta detail={detail()} onChanged={vi.fn()} />);
+    const slot = screen.getByTestId('quote-header-meta');
+    expect(slot.className).toMatch(/\bmin-w-52\b/);
+    expect(slot.className).not.toMatch(/\bmin-w-0\b/);
+    expect(screen.getByTestId('quote-title').className).toMatch(/\bw-full\b/);
+  });
 });

--- a/apps/web/src/components/billing/quotes/QuoteHeaderMeta.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteHeaderMeta.tsx
@@ -105,7 +105,12 @@ export function QuoteHeaderMeta({ detail, onChanged, onPendingChange, onUnsavedC
   useEffect(() => () => onUnsavedChange?.(null), [onUnsavedChange]);
 
   return (
-    <div className="flex min-w-0 flex-1 items-center gap-2" data-testid="quote-header-meta">
+    // min-w-52, not min-w-0: this slot is a flex child of DocumentWorkspace's
+    // title cluster, and a zero floor let the header row shrink it below its own
+    // content — the input measured 102px against 208px of text at a 1280px
+    // viewport (#4937). The floor is what makes the cluster wrap the status pill
+    // onto the next line instead of taking the title's last pixels.
+    <div className="flex min-w-52 flex-1 items-center gap-2" data-testid="quote-header-meta">
       {/* NOT an <h1> wrapper: "heading level 1, edit text" is a confusing AT
           announcement. DocumentWorkspace renders an sr-only h1 with the
           document identity whenever a titleSlot replaces the visual heading. */}

--- a/apps/web/src/components/billing/quotes/QuoteLineRows.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteLineRows.tsx
@@ -382,11 +382,13 @@ function DeviceSetEditorSummary({ line, quoteId, editable, onEdit }: {
       )}
       {editable && (
         <fieldset className="space-y-1 rounded border border-border/60 p-2" data-testid={`quote-line-device-set-allowance-${line.id}`}>
-          <legend className="sr-only">{t('quotes.editor.deviceSet.includedLabel')}</legend>
+          {/* Group / action / field get three distinct strings — see the same
+              block in QuoteBlockCard's create form (#4937). */}
+          <legend className="sr-only">{t('quotes.editor.deviceSet.allowanceGroupLabel')}</legend>
           <label className="flex items-center gap-1"><input type="checkbox" checked={allowanceOn} onChange={(e) => {
             const next = e.target.checked; setAllowanceOn(next);
             if (!next) void onEdit?.({ includedQuantity: null, overageMode: null, overageUnitPrice: null }, 'allowance');
-          }} />{t('quotes.editor.deviceSet.includedLabel')}</label>
+          }} />{t('quotes.editor.deviceSet.allowanceToggle')}</label>
           {allowanceOn && <div className="flex flex-wrap items-end gap-2">
             <label>{t('quotes.editor.deviceSet.includedLabel')}<input type="number" min="1" step="1" value={included} onChange={(e) => setIncluded(e.target.value)} className="ml-1 h-7 w-20 rounded border bg-background px-1 text-foreground" /></label>
             <fieldset className="space-y-1">

--- a/apps/web/src/components/billing/shared/DocumentWorkspace.test.tsx
+++ b/apps/web/src/components/billing/shared/DocumentWorkspace.test.tsx
@@ -119,4 +119,34 @@ describe('DocumentWorkspace', () => {
     expect(h1).toHaveAttribute('data-testid', 'doc-workspace-title');
     expect(h1).not.toHaveClass('sr-only');
   });
+
+  it('gives the title cluster a width floor and lets the pill wrap instead of squeezing it (#4937)', () => {
+    // jsdom has no layout engine, so this pins the flex CONTRACT that produces
+    // the measured behaviour rather than the measurement itself. The header row
+    // is `back link · title · status pill · meta · actions`; with `min-w-0` on
+    // the title cluster, flexbox shrank it below its content first — at a
+    // 1280px viewport the quote title input measured 102px against 208px of
+    // content ("QA Swee…"). A min-width floor makes the cluster's hypothetical
+    // main size real, so `flex-wrap` moves the pill (and then the meta slot) to
+    // the next line instead of starving the title.
+    renderWs({
+      titleSlot: <input data-testid="title-input" defaultValue="THING-1" />,
+      statusPill: <span data-testid="doc-status">Draft</span>,
+      actions: <button data-testid="doc-action">Do it</button>,
+    });
+    const cluster = screen.getByTestId('title-input').parentElement!;
+    expect(cluster.className).toMatch(/\bmin-w-52\b/);
+    expect(cluster.className).not.toMatch(/\bmin-w-0\b/);
+    expect(cluster.className).toMatch(/\bflex-wrap\b/);
+    // The pill stays a sibling of the slot inside the cluster — it is what
+    // wraps, so it must not be hoisted out of the wrapping context.
+    expect(screen.getByTestId('doc-status').parentElement).toBe(cluster);
+    // The wrapping left group needs the same floor, or the outer row (which the
+    // actions cluster shares) can still squeeze the whole identity side below
+    // the title's floor and overflow it instead of dropping the actions.
+    const identitySide = cluster.parentElement!;
+    expect(identitySide.className).toMatch(/\bmin-w-52\b/);
+    expect(identitySide.className).not.toMatch(/\bmin-w-0\b/);
+    expect(identitySide.className).toMatch(/\bflex-wrap\b/);
+  });
 });

--- a/apps/web/src/components/billing/shared/DocumentWorkspace.tsx
+++ b/apps/web/src/components/billing/shared/DocumentWorkspace.tsx
@@ -114,7 +114,16 @@ export function DocumentWorkspace({
             header is pinned, so every vertical pixel here is stolen from the
             working canvas below — keep it short. */}
         <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1">
-          <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-3 gap-y-1">
+          {/* min-w-52 (not min-w-0) on both the left group and the title cluster:
+              the header row is `back link · title · status pill · meta · actions`,
+              and with a zero floor flexbox shrank the TITLE first — at a 1280px
+              viewport the quote title input measured 102px against 208px of
+              content (#4937). A real floor makes each cluster's hypothetical main
+              size count toward line breaking, so the wrapping already designed
+              into these rows moves the actions (outer) and then the meta slot and
+              status pill (inner) onto their own lines instead of starving the
+              title. 13rem ≈ the title input's own content width. */}
+          <div className="flex min-w-52 flex-1 flex-wrap items-center gap-x-3 gap-y-1">
             <a
               href={backHref}
               aria-label={t('shared.documentWorkspace.backAria', { label: backLabel.toLowerCase() })}
@@ -122,7 +131,7 @@ export function DocumentWorkspace({
             >
               <span aria-hidden="true">←</span> {backLabel}
             </a>
-            <div className="flex min-w-0 flex-1 items-center gap-2">
+            <div className="flex min-w-52 flex-1 flex-wrap items-center gap-2">
               {titleSlot ? (
                 <>
                   {/* The slot replaces the VISUAL heading (e.g. with an editable
@@ -144,7 +153,10 @@ export function DocumentWorkspace({
           {actions && (
             // Right-aligned cluster; the caller renders any disabled-reason hint on
             // its own full-basis line below the buttons (never inline between them).
-            <div className="flex items-center gap-2 flex-wrap justify-end">{actions}</div>
+            // `ml-auto` keeps it right-aligned when the identity side's width floor
+            // pushes it onto its own line — `justify-between` alone would leave a
+            // lone item on a wrapped line sitting at the start edge.
+            <div className="ml-auto flex items-center gap-2 flex-wrap justify-end">{actions}</div>
           )}
         </div>
 

--- a/apps/web/src/locales/de-DE/billing.json
+++ b/apps/web/src/locales/de-DE/billing.json
@@ -599,6 +599,7 @@
         "driftChip": "Anzahl geändert: {{stored}} → {{live}}", "refresh": "Anzahl aktualisieren", "estimateError": "Die aktuelle Geräteanzahl konnte nicht geprüft werden.", "pickerError": "Gerätegruppen oder Standorte konnten nicht geladen werden. Aktualisieren Sie die Seite und versuchen Sie es erneut.",
         "groupDeleted": "Gerätegruppe „{{name}}“ wurde gelöscht — bitte eine andere wählen", "siteDeleted": "Standort „{{name}}“ wurde gelöscht — bitte einen anderen wählen",
         "typeLocked": "Ein Gerätesatz kann nach dem Anlegen der Position nicht geändert werden — Position entfernen und neu hinzufügen.",
+        "allowanceGroupLabel": "Mengenkontingent", "allowanceToggle": "Feste Menge einschließen, Rest separat behandeln",
         "includedLabel": "Enthaltene Menge", "overageModeLabel": "Über dem Kontingent", "overageBill": "Jede zusätzliche Einheit berechnen", "overageFlag": "Zur Prüfung melden", "overagePriceLabel": "Preis für Zusatzeinheiten",
         "driftToast": "{{count}} Position(en) entsprechen nicht mehr der aktuellen Geräteanzahl: {{lines}}",
         "retargetToast": "{{count}} Position(en) benötigen eine neu gewählte Gerätegruppe oder einen Standort für diese Organisation"
@@ -1241,6 +1242,7 @@
         "modeClearHint": "Positionen werden gelöscht. Erforderlich, wenn eine Position manuell oder ein Bündel ist.",
         "modeReprice": "Katalogpositionen neu bepreisen",
         "modeRepriceHint": "Jede Katalogposition wird aus der Preisliste der neuen Währung aufgelöst. Nur möglich, wenn alle Positionen aus dem Katalog stammen.",
+        "modeRepriceUnavailable": "Nicht verfügbar — mindestens eine Position ist manuell oder ein Bündel und kann nicht aus der Preisliste neu bepreist werden. Positionen stattdessen löschen.",
         "confirm": "Mir ist bewusst, dass dies die Währung des Angebots ändert.",
         "submit": "Währung ändern"
       },

--- a/apps/web/src/locales/en/billing.json
+++ b/apps/web/src/locales/en/billing.json
@@ -599,6 +599,7 @@
         "driftChip": "count changed: {{stored}} → {{live}}", "refresh": "Refresh counts", "estimateError": "Couldn’t check the live device count.", "pickerError": "Couldn’t load device groups or sites. Refresh and try again.",
         "groupDeleted": "Device group “{{name}}” was deleted — pick another", "siteDeleted": "Site “{{name}}” was deleted — pick another",
         "typeLocked": "A device set cannot be changed after the line is created — remove the line and add it again.",
+        "allowanceGroupLabel": "Quantity allowance", "allowanceToggle": "Include a fixed quantity, then handle extras",
         "includedLabel": "Included quantity", "overageModeLabel": "Above the allowance", "overageBill": "Bill each extra unit", "overageFlag": "Report for review", "overagePriceLabel": "Overage price",
         "driftToast": "{{count}} line(s) no longer match the live device count: {{lines}}",
         "retargetToast": "{{count}} line(s) need a device group or site re-picked for this organization"
@@ -1241,6 +1242,7 @@
         "modeClearHint": "Lines are deleted. Required when any line is manual or a bundle.",
         "modeReprice": "Reprice catalog lines",
         "modeRepriceHint": "Every catalog line is resolved from the price book of the new currency. Only possible when all lines come from the catalog.",
+        "modeRepriceUnavailable": "Not available — at least one line is manual or a bundle, so the price book cannot reprice it. Remove all lines instead.",
         "confirm": "I understand this changes the quote's currency.",
         "submit": "Change currency"
       },

--- a/apps/web/src/locales/es-419/billing.json
+++ b/apps/web/src/locales/es-419/billing.json
@@ -599,6 +599,7 @@
         "driftChip": "el conteo cambió: {{stored}} → {{live}}", "refresh": "Actualizar conteos", "estimateError": "No se pudo comprobar el conteo actual de dispositivos.", "pickerError": "No se pudieron cargar los grupos de dispositivos ni los sitios. Actualiza la página e inténtalo de nuevo.",
         "groupDeleted": "El grupo de dispositivos “{{name}}” fue eliminado: elige otro", "siteDeleted": "El sitio “{{name}}” fue eliminado: elige otro",
         "typeLocked": "Un conjunto de dispositivos no se puede cambiar después de crear la línea: elimina la línea y agrégala de nuevo.",
+        "allowanceGroupLabel": "Límite de cantidad", "allowanceToggle": "Incluir una cantidad fija y gestionar los extras",
         "includedLabel": "Cantidad incluida", "overageModeLabel": "Por encima del límite incluido", "overageBill": "Facturar cada unidad adicional", "overageFlag": "Informar para revisión", "overagePriceLabel": "Precio por excedente",
         "driftToast": "{{count}} línea(s) ya no coinciden con el conteo actual de dispositivos: {{lines}}",
         "retargetToast": "{{count}} línea(s) necesitan que se vuelva a elegir un grupo de dispositivos o sitio para esta organización"
@@ -1241,6 +1242,7 @@
         "modeClearHint": "Las líneas se eliminan. Obligatorio cuando alguna línea es manual o un paquete.",
         "modeReprice": "Recalcular precios de las líneas del catálogo",
         "modeRepriceHint": "Cada línea del catálogo se resuelve con la lista de precios de la nueva moneda. Solo es posible si todas las líneas provienen del catálogo.",
+        "modeRepriceUnavailable": "No disponible: al menos una línea es manual o un paquete, por lo que la lista de precios no puede recalcularla. Elimina todas las líneas en su lugar.",
         "confirm": "Entiendo que esto cambia la moneda de la cotización.",
         "submit": "Cambiar moneda"
       },

--- a/apps/web/src/locales/fr-CA/billing.json
+++ b/apps/web/src/locales/fr-CA/billing.json
@@ -599,6 +599,7 @@
         "driftChip": "le nombre a changé : {{stored}} → {{live}}", "refresh": "Actualiser les nombres", "estimateError": "Impossible de vérifier le nombre actuel d’appareils.", "pickerError": "Impossible de charger les groupes d’appareils ou les sites. Actualisez la page et réessayez.",
         "groupDeleted": "Le groupe d'appareils « {{name}} » a été supprimé — choisissez-en un autre", "siteDeleted": "Le site « {{name}} » a été supprimé — choisissez-en un autre",
         "typeLocked": "Un ensemble d'appareils ne peut pas être modifié après la création de la ligne — retirez la ligne et ajoutez-la de nouveau.",
+        "allowanceGroupLabel": "Forfait de quantité", "allowanceToggle": "Inclure une quantité fixe, puis gérer les extras",
         "includedLabel": "Quantité incluse", "overageModeLabel": "Au-delà du forfait", "overageBill": "Facturer chaque unité supplémentaire", "overageFlag": "Signaler pour révision", "overagePriceLabel": "Prix des unités supplémentaires",
         "driftToast": "{{count}} ligne(s) ne correspondent plus au nombre d'appareils actuel : {{lines}}",
         "retargetToast": "{{count}} ligne(s) nécessitent de resélectionner un groupe d'appareils ou un site pour cette organisation"
@@ -1241,6 +1242,7 @@
         "modeClearHint": "Les lignes sont supprimées. Obligatoire dès qu’une ligne est manuelle ou un lot.",
         "modeReprice": "Retarifer les lignes du catalogue",
         "modeRepriceHint": "Chaque ligne du catalogue est résolue depuis la grille tarifaire de la nouvelle devise. Possible uniquement si toutes les lignes proviennent du catalogue.",
+        "modeRepriceUnavailable": "Non disponible — au moins une ligne est manuelle ou un lot, la grille tarifaire ne peut donc pas la retarifer. Supprimez plutôt toutes les lignes.",
         "confirm": "Je comprends que cette opération change la devise du devis.",
         "submit": "Changer de devise"
       },

--- a/apps/web/src/locales/fr-FR/billing.json
+++ b/apps/web/src/locales/fr-FR/billing.json
@@ -599,6 +599,7 @@
         "driftChip": "le nombre a changé : {{stored}} → {{live}}", "refresh": "Actualiser les nombres", "estimateError": "Impossible de vérifier le nombre actuel d’appareils.", "pickerError": "Impossible de charger les groupes d’appareils ou les sites. Actualisez la page et réessayez.",
         "groupDeleted": "Le groupe d'appareils « {{name}} » a été supprimé — choisissez-en un autre", "siteDeleted": "Le site « {{name}} » a été supprimé — choisissez-en un autre",
         "typeLocked": "Un ensemble d'appareils ne peut pas être modifié après la création de la ligne — supprimez la ligne et ajoutez-la à nouveau.",
+        "allowanceGroupLabel": "Forfait de quantité", "allowanceToggle": "Inclure une quantité fixe, puis gérer les extras",
         "includedLabel": "Quantité incluse", "overageModeLabel": "Au-delà du forfait", "overageBill": "Facturer chaque unité supplémentaire", "overageFlag": "Signaler pour révision", "overagePriceLabel": "Prix des unités supplémentaires",
         "driftToast": "{{count}} ligne(s) ne correspondent plus au nombre d'appareils actuel : {{lines}}",
         "retargetToast": "{{count}} ligne(s) nécessitent de resélectionner un groupe d'appareils ou un site pour cette organisation"
@@ -1241,6 +1242,7 @@
         "modeClearHint": "Les lignes sont supprimées. Obligatoire dès qu’une ligne est manuelle ou un lot.",
         "modeReprice": "Retarifer les lignes du catalogue",
         "modeRepriceHint": "Chaque ligne du catalogue est résolue depuis la grille tarifaire de la nouvelle devise. Possible uniquement si toutes les lignes proviennent du catalogue.",
+        "modeRepriceUnavailable": "Non disponible — au moins une ligne est manuelle ou un lot, la grille tarifaire ne peut donc pas la retarifer. Supprimez plutôt toutes les lignes.",
         "confirm": "Je comprends que cette opération change la devise du devis.",
         "submit": "Changer de devise"
       },

--- a/apps/web/src/locales/it-IT/billing.json
+++ b/apps/web/src/locales/it-IT/billing.json
@@ -599,6 +599,7 @@
         "driftChip": "conteggio cambiato: {{stored}} → {{live}}", "refresh": "Aggiorna conteggi", "estimateError": "Impossibile verificare il conteggio attuale dei dispositivi.", "pickerError": "Impossibile caricare i gruppi di dispositivi o i siti. Aggiorna la pagina e riprova.",
         "groupDeleted": "Il gruppo di dispositivi “{{name}}” è stato eliminato — scegline un altro", "siteDeleted": "La sede “{{name}}” è stata eliminata — scegline un'altra",
         "typeLocked": "Un insieme di dispositivi non può essere modificato dopo la creazione della riga — rimuovi la riga e aggiungila di nuovo.",
+        "allowanceGroupLabel": "Soglia di quantità", "allowanceToggle": "Includi una quantità fissa e gestisci le eccedenze",
         "includedLabel": "Quantità inclusa", "overageModeLabel": "Oltre la soglia inclusa", "overageBill": "Fattura ogni unità aggiuntiva", "overageFlag": "Segnala per revisione", "overagePriceLabel": "Prezzo eccedenza",
         "driftToast": "{{count}} riga/righe non corrispondono più al conteggio dispositivi attuale: {{lines}}",
         "retargetToast": "{{count}} riga/righe richiedono di riselezionare un gruppo di dispositivi o una sede per questa organizzazione"
@@ -1241,6 +1242,7 @@
         "modeClearHint": "Le righe vengono eliminate. Obbligatorio quando una riga è manuale o un bundle.",
         "modeReprice": "Riprezza le righe di catalogo",
         "modeRepriceHint": "Ogni riga di catalogo viene risolta dal listino della nuova valuta. Possibile solo se tutte le righe provengono dal catalogo.",
+        "modeRepriceUnavailable": "Non disponibile — almeno una riga è manuale o un bundle, quindi il listino non può riprezzarla. Rimuovi invece tutte le righe.",
         "confirm": "Comprendo che questa operazione cambia la valuta del preventivo.",
         "submit": "Cambia valuta"
       },

--- a/apps/web/src/locales/pt-BR/billing.json
+++ b/apps/web/src/locales/pt-BR/billing.json
@@ -599,6 +599,7 @@
         "driftChip": "contagem alterada: {{stored}} → {{live}}", "refresh": "Atualizar contagens", "estimateError": "Não foi possível verificar a contagem atual de dispositivos.", "pickerError": "Não foi possível carregar os grupos de dispositivos ou os locais. Atualize a página e tente novamente.",
         "groupDeleted": "O grupo de dispositivos “{{name}}” foi excluído — escolha outro", "siteDeleted": "O site “{{name}}” foi excluído — escolha outro",
         "typeLocked": "Um conjunto de dispositivos não pode ser alterado após a criação da linha — remova a linha e adicione-a novamente.",
+        "allowanceGroupLabel": "Franquia de quantidade", "allowanceToggle": "Incluir uma quantidade fixa e tratar os excedentes",
         "includedLabel": "Quantidade incluída", "overageModeLabel": "Acima da franquia", "overageBill": "Cobrar cada unidade adicional", "overageFlag": "Reportar para revisão", "overagePriceLabel": "Preço de excedente",
         "driftToast": "{{count}} linha(s) não correspondem mais à contagem atual de dispositivos: {{lines}}",
         "retargetToast": "{{count}} linha(s) precisam que um grupo de dispositivos ou site seja escolhido novamente para esta organização"
@@ -1241,6 +1242,7 @@
         "modeClearHint": "As linhas são excluídas. Obrigatório quando alguma linha é manual ou um pacote.",
         "modeReprice": "Reprecificar as linhas de catálogo",
         "modeRepriceHint": "Cada linha de catálogo é resolvida pela tabela de preços da nova moeda. Só é possível quando todas as linhas vêm do catálogo.",
+        "modeRepriceUnavailable": "Indisponível — pelo menos uma linha é manual ou um pacote, então a tabela de preços não consegue reprificá-la. Em vez disso, exclua todas as linhas.",
         "confirm": "Entendo que isto altera a moeda da cotação.",
         "submit": "Alterar moeda"
       },

--- a/apps/web/src/locales/tr-TR/billing.json
+++ b/apps/web/src/locales/tr-TR/billing.json
@@ -599,6 +599,7 @@
         "driftChip": "sayı değişti: {{stored}} → {{live}}", "refresh": "Sayıları yenile", "estimateError": "Güncel cihaz sayısı denetlenemedi.", "pickerError": "Cihaz grupları veya siteler yüklenemedi. Sayfayı yenileyip tekrar deneyin.",
         "groupDeleted": "“{{name}}” cihaz grubu silindi — başka bir tane seçin", "siteDeleted": "“{{name}}” konumu silindi — başka bir tane seçin",
         "typeLocked": "Cihaz grubu, satır oluşturulduktan sonra değiştirilemez — satırı kaldırıp yeniden ekleyin.",
+        "allowanceGroupLabel": "Miktar limiti", "allowanceToggle": "Sabit bir miktar dahil et, fazlasını ayrıca yönet",
         "includedLabel": "Dahil miktar", "overageModeLabel": "Dahil miktarın üstü", "overageBill": "Her ek birimi faturala", "overageFlag": "İnceleme için raporla", "overagePriceLabel": "Aşım fiyatı",
         "driftToast": "{{count}} satır artık güncel cihaz sayısıyla eşleşmiyor: {{lines}}",
         "retargetToast": "{{count}} satır için bu kuruluşa ait cihaz grubu veya konum yeniden seçilmeli"
@@ -1241,6 +1242,7 @@
         "modeClearHint": "Satırlar silinir. Herhangi bir satır manuel veya paket olduğunda zorunludur.",
         "modeReprice": "Katalog satırlarını yeniden fiyatlandır",
         "modeRepriceHint": "Her katalog satırı yeni para biriminin fiyat listesinden çözümlenir. Yalnızca tüm satırlar katalogdan geliyorsa mümkündür.",
+        "modeRepriceUnavailable": "Kullanılamaz — en az bir satır manuel veya paket olduğundan fiyat listesi onu yeniden fiyatlandıramaz. Bunun yerine tüm satırları kaldırın.",
         "confirm": "Bunun teklifin para birimini değiştirdiğini anlıyorum.",
         "submit": "Para birimini değiştir"
       },


### PR DESCRIPTION
## Summary
- Quote title input no longer collapses below its content at 1280px: `DocumentWorkspace`'s title cluster and left group now carry a `min-w-52` floor (was `min-w-0`), so `flex-wrap` moves the status pill/actions to their own line instead of starving the title.
- `ChangeCurrencyDialog` disables "Reprice catalog lines" client-side when any line is manual, a bundle, or a catalog line missing its catalog item — mirroring the same predicate the server enforces (409 `CURRENCY_LOCKED`) — and swaps in a reason string instead of leaving a silently-failing option.
- `QuoteBlockCard`'s device-set allowance fieldset and `QuoteLineRows`' equivalent now use three distinct strings (group legend / enable toggle / quantity input) instead of "Included quantity" three times, mirroring the contract editor's existing labelling.
- New i18n keys (`allowanceGroupLabel`, `allowanceToggle`, `modeRepriceUnavailable`) added to all 8 locales.

## Root cause
All three are UI-only gaps: a zero min-width flex floor, a client dialog that never mirrored a server-side legality rule already stated in its own hint text, and a copy-pasted label reused for three different form roles.

## Verification
- `cd apps/web && npx vitest run src/components/billing/quotes src/components/billing/shared src/components/billing/InvoiceDetail --pool=threads --maxWorkers=2` → **76 files / 694 tests passed**
- `npx tsc --noEmit -p apps/web` → clean

## Decisions / notes for reviewer
- Skipped the "Custom Fields modal has two help texts" note from the issue — it's explicitly flagged "not a defect" in the issue and lives outside the quote editor (`apps/web/src/components/scripts`), out of scope for this paper-cut fix.
- `InvoiceDetail` also renders `ChangeCurrencyDialog` but doesn't pass `repriceUnavailableReason` (the prop is optional) — invoice reprice legality wasn't part of this issue, so its dialog behavior is unchanged.

Closes #4937

🤖 Generated with [Claude Code](https://claude.com/claude-code)