### PR TITLE
fix(auth): keep the caller's session when MFA is disabled (#4934)

### DIFF
--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -1062,7 +1062,7 @@ API requests are rate-limited to ensure fair usage. Rate limit headers are inclu
         operationId: 'disableMfa',
         tags: ['Auth'],
         summary: 'Disable MFA',
-        description: 'Disable MFA for the current user. Requires a valid MFA code (TOTP or SMS). May be blocked by organization policy requiring MFA.',
+        description: 'Disable MFA for the current user. Requires a valid MFA code (TOTP or SMS) plus the current password. May be blocked by organization policy requiring MFA. Disabling advances the user\'s MFA epoch and revokes every refresh token family, so all OTHER sessions are signed out; the calling session is replaced in the same response (new refresh/CSRF cookies plus `tokens.accessToken`) and must adopt it.',
         requestBody: {
           required: true,
           content: {
@@ -1070,24 +1070,42 @@ API requests are rate-limited to ensure fair usage. Rate limit headers are inclu
               schema: {
                 type: 'object',
                 properties: {
-                  code: { type: 'string', minLength: 6, maxLength: 6 }
+                  code: { type: 'string', minLength: 6, maxLength: 6 },
+                  currentPassword: { type: 'string', description: 'The account password, re-verified so a stolen access token alone cannot strip the second factor.' }
                 },
-                required: ['code']
+                required: ['code', 'currentPassword']
               }
             }
           }
         },
         responses: {
           '200': {
-            description: 'MFA disabled',
+            description: 'MFA disabled and the calling session replaced',
             content: {
               'application/json': {
-                schema: { $ref: '#/components/schemas/Success' }
+                schema: {
+                  type: 'object',
+                  properties: {
+                    success: { type: 'boolean' },
+                    message: { type: 'string' },
+                    tokens: {
+                      type: 'object',
+                      description: 'Replacement session for the caller. Install it before the next request — the previous access token is invalid from this point. Withheld on the rare post-commit install failure, in which case the client must re-authenticate.',
+                      properties: {
+                        accessToken: { type: 'string' },
+                        expiresInSeconds: { type: 'integer' }
+                      }
+                    }
+                  }
+                }
               }
             }
           },
           '400': { $ref: '#/components/responses/BadRequest' },
-          '401': { $ref: '#/components/responses/Unauthorized' }
+          '401': { $ref: '#/components/responses/Unauthorized' },
+          '403': { description: 'Organization or partner policy still requires MFA for this user.' },
+          '409': { description: 'Another authentication issuance is in flight, or MFA was disabled concurrently. No factor was removed.' },
+          '428': { description: 'The client auth binding must be rotated before a session can be issued. Retry after re-bootstrapping the binding.' }
         }
       }
     },

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -139,10 +139,12 @@ vi.mock('../services', () => {
         }),
       }),
     };
-    await input.persistFactor(tx, input.recoveryCodeHashes);
+    // A factor REMOVAL (#4934 /mfa/disable) omits the code pair entirely — the
+    // real service defaults both to [], so the mock must too.
+    await input.persistFactor(tx, input.recoveryCodeHashes ?? []);
     return {
       value: undefined,
-      recoveryCodes: [...input.recoveryCodes],
+      recoveryCodes: [...(input.recoveryCodes ?? [])],
       issued: {
         accessToken: 'replacement-access-token',
         refreshToken: 'replacement-refresh-token',
@@ -390,6 +392,7 @@ import {
 } from '../services';
 import { assertActiveTenantContext, TenantInactiveError } from '../services/tenantStatus';
 import { performOrdinaryTerminalLogout } from '../services/terminalLogout';
+import type { AuthorizedUserSession } from '../services/userSession';
 import { assertPasswordAuthAllowedBySso, SsoPasswordAuthRequiredError } from './auth/ssoPolicy';
 import {
   getPasswordResetEligibility,
@@ -3893,6 +3896,262 @@ describe('auth routes', () => {
       });
 
       expect(res.status).toBe(400);
+    });
+
+    // #4934: turning MFA OFF used to route through
+    // invalidateMfaAssuranceAfterFactorChange, which bumps mfa_epoch and revokes
+    // every refresh family WITHOUT re-issuing the actor — so the caller's own
+    // next request 401s on the stale `mep`, its refresh fails against a revoked
+    // family, and the web client hard-redirects to /login?reason=session-expired.
+    // Same class #4480/#4646 fixed for recovery-code rotation: evict everyone
+    // else, keep the caller.
+    describe('#4934 MFA disable keeps the calling session', () => {
+      // The two reads /auth/mfa/disable makes, in order: the password step-up
+      // hash, then the factor row it is about to remove. One mock serves both
+      // because the row carries every field either read asks for.
+      function mockProtectedTotpUser() {
+        vi.mocked(db.select).mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([{
+                passwordHash: '$argon2id$hash',
+                mfaEnabled: true,
+                mfaMethod: 'totp',
+                mfaSecret: encryptMfaSecret('PLAINTEXTSECRET'),
+                phoneNumber: null,
+              }]),
+            }),
+          }),
+        } as any);
+      }
+
+      function mockSuccessfulDisable() {
+        mockProtectedTotpUser();
+        vi.mocked(verifyPassword).mockResolvedValue(true);
+        vi.mocked(consumeMFAToken).mockResolvedValue(true);
+      }
+
+      // The self-disable gate resolves the EFFECTIVE policy and 403s while MFA is
+      // still mandated. Spied (and restored inline, per the idiom above) so these
+      // tests never depend on the resolver's own role-join/settings reads.
+      function allowSelfDisable() {
+        return vi.spyOn(mfaPolicyModule, 'getEffectiveMfaPolicy').mockResolvedValue({
+          required: false,
+          allowedMethods: { totp: true, sms: true, passkey: true },
+          source: { roleForceMfa: false, settingsRequireMfa: false, killSwitchOff: true },
+        });
+      }
+
+      function postDisable(body: Record<string, unknown>, headers: Record<string, string> = {}) {
+        return app.request('/auth/mfa/disable', {
+          method: 'POST',
+          headers: {
+            'Authorization': 'Bearer valid-token',
+            'Content-Type': 'application/json',
+            ...headers,
+          },
+          body: JSON.stringify(body),
+        });
+      }
+
+      const proof = { code: '123456', currentPassword: 'OldStrongPass123' };
+
+      it('re-issues the caller session instead of evicting it', async () => {
+        mockSuccessfulDisable();
+        const policySpy = allowSelfDisable();
+
+        const res = await postDisable(proof);
+        policySpy.mockRestore();
+
+        expect(res.status).toBe(200);
+        expect(await res.json()).toMatchObject({
+          success: true,
+          message: 'MFA disabled successfully',
+          // The replacement access token is what keeps the caller authenticated
+          // past its own epoch bump.
+          tokens: { accessToken: 'replacement-access-token', expiresInSeconds: 900 },
+        });
+        // ...and the rotated refresh cookie is what survives the family revoke.
+        expect(res.headers.get('set-cookie') ?? '').toContain('replacement-refresh-token');
+
+        expect(replaceSessionOnMfaFactorWrite).toHaveBeenCalledTimes(1);
+        const input = vi.mocked(replaceSessionOnMfaFactorWrite).mock.calls[0]?.[0] as any;
+        expect(input).toMatchObject({
+          userId: 'user-123',
+          // Every OTHER session still dies, and the removal is predicated on the
+          // factor still existing when the bump lands — a concurrent second
+          // disable loses with a 409 rather than bumping the epoch twice and
+          // evicting the session the first one just issued.
+          expectedMfaEnabled: true,
+          revokeReason: 'mfa-disable',
+        });
+        // A removal installs NO code set — the account must be left holding none.
+        expect(input.recoveryCodes ?? []).toHaveLength(0);
+        expect(input.recoveryCodeHashes ?? []).toHaveLength(0);
+      });
+
+      it('does not clear the session cookies', async () => {
+        mockSuccessfulDisable();
+        const policySpy = allowSelfDisable();
+
+        const res = await postDisable(proof);
+        policySpy.mockRestore();
+
+        expect(res.status).toBe(200);
+        const cookies = res.headers.getSetCookie?.() ?? [];
+        expect(cookies.length).toBeGreaterThan(0);
+        for (const cookie of cookies) {
+          // A cleared cookie is `<name>=; ... Max-Age=0` — the shape the eviction
+          // path used to leave the browser with.
+          expect(cookie).not.toContain('Max-Age=0');
+          expect(cookie).not.toMatch(/breeze_(refresh|csrf)_token=;/);
+        }
+        expect(cookies.find((cookie) => cookie.startsWith('breeze_refresh_token=')))
+          .toContain('replacement-refresh-token');
+      });
+
+      it('still clears the factor inside the replacement transaction', async () => {
+        mockSuccessfulDisable();
+        const policySpy = allowSelfDisable();
+        const capturedSets: Array<Record<string, unknown>> = [];
+        vi.mocked(replaceSessionOnMfaFactorWrite).mockImplementationOnce(async (input: any) => {
+          const tx = {
+            update: () => ({
+              set: (values: Record<string, unknown>) => {
+                capturedSets.push(values);
+                return { where: () => ({ returning: async () => [{ id: input.userId }] }) };
+              },
+            }),
+          };
+          await input.persistFactor(tx, input.recoveryCodeHashes ?? []);
+          return {
+            value: undefined,
+            recoveryCodes: [],
+            issued: {
+              accessToken: 'replacement-access-token',
+              refreshToken: 'replacement-refresh-token',
+              refreshJti: 'replacement-jti',
+              expiresInSeconds: 900,
+              familyId: 'replacement-family',
+              transitionId: 'transition-1',
+              generation: 1,
+            } as unknown as AuthorizedUserSession,
+            mfaEpoch: 2,
+            cleanup: { redisOk: true, permissionCacheOk: true, oauthOk: true, remoteSessionsTerminated: 0 },
+          };
+        });
+
+        const res = await postDisable(proof);
+        policySpy.mockRestore();
+
+        expect(res.status).toBe(200);
+        expect(capturedSets).toHaveLength(1);
+        expect(capturedSets[0]).toMatchObject({
+          mfaEnabled: false,
+          mfaSecret: null,
+          mfaMethod: null,
+          mfaRecoveryCodes: null,
+          phoneNumber: null,
+          phoneVerified: false,
+        });
+      });
+
+      // SR-001 + the "carry forward, never elevate" rule the rotation path
+      // follows: the replacement inherits the SIGNED `mdid` binding (never the
+      // forgeable header) and the caller's own assurance claim.
+      it('carries the signed binding and the caller assurance into the replacement', async () => {
+        mockSuccessfulDisable();
+        const policySpy = allowSelfDisable();
+        vi.mocked(authMiddleware).mockImplementationOnce(((c: any, next: any) => {
+          c.set('auth', {
+            user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
+            token: {
+              sid: 'family-123', sub: 'user-123', type: 'access',
+              aep: 4, mep: 9, mfa: true, mdid: 'signed-device-1', roleId: 'role-7',
+            },
+            orgId: 'org-5',
+            partnerId: 'partner-2',
+            scope: 'organization',
+          });
+          return next();
+        }) as never);
+
+        const res = await postDisable(proof, { 'x-breeze-mobile-device-id': 'forged-device-header' });
+        policySpy.mockRestore();
+
+        expect(res.status).toBe(200);
+        const input = vi.mocked(replaceSessionOnMfaFactorWrite).mock.calls[0]?.[0] as any;
+        expect(input.expectedAuthEpoch).toBe(4);
+        expect(input.expectedMfaEpoch).toBe(9);
+        expect(input.identity).toMatchObject({
+          userId: 'user-123',
+          roleId: 'role-7',
+          orgId: 'org-5',
+          partnerId: 'partner-2',
+          scope: 'organization',
+          mfa: true,
+          mobileDeviceId: 'signed-device-1',
+        });
+        expect(input.identity.mobileDeviceId).not.toBe('forged-device-header');
+      });
+
+      // The mutation check for the assurance rule: removing a factor must NOT
+      // upgrade a session that was never MFA-assured. Hard-coding `mfa: true`
+      // (what a post-disable login mints vacuously) would pass the test above
+      // and fail this one.
+      it('does not elevate an unassured caller into an MFA-assured session', async () => {
+        mockSuccessfulDisable();
+        const policySpy = allowSelfDisable();
+        vi.mocked(authMiddleware).mockImplementationOnce(((c: any, next: any) => {
+          c.set('auth', {
+            user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
+            token: { sid: 'family-123', sub: 'user-123', type: 'access', aep: 4, mep: 9, mfa: false },
+            orgId: null,
+            partnerId: 'partner-2',
+            scope: 'partner',
+          });
+          return next();
+        }) as never);
+
+        const res = await postDisable(proof);
+        policySpy.mockRestore();
+
+        expect(res.status).toBe(200);
+        const input = vi.mocked(replaceSessionOnMfaFactorWrite).mock.calls[0]?.[0] as any;
+        expect(input.identity.mfa).toBe(false);
+      });
+
+      // Post-commit: the factor is already gone, so a failure installing the
+      // replacement must not turn a completed disable into an error the user
+      // retries against an account that no longer has MFA (a retry answers 400
+      // 'MFA is not enabled').
+      it('still reports success when the replacement session install fails', async () => {
+        mockSuccessfulDisable();
+        const policySpy = allowSelfDisable();
+        vi.mocked(bindIssuedUserSession).mockRejectedValueOnce(new Error('redis down'));
+
+        const res = await postDisable(proof);
+        policySpy.mockRestore();
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.success).toBe(true);
+        // The refresh JTI was never bound, so the access token would die at its
+        // first refresh — withhold it rather than sell the caller a few minutes.
+        expect(body.tokens).toBeUndefined();
+      });
+
+      it('surfaces a lost issuance race as 409 and cancels the issuance', async () => {
+        mockSuccessfulDisable();
+        const policySpy = allowSelfDisable();
+        vi.mocked(replaceSessionOnMfaFactorWrite).mockRejectedValueOnce(new AuthIssuanceConflictError());
+
+        const res = await postDisable(proof);
+        policySpy.mockRestore();
+
+        expect(res.status).toBe(409);
+        expect(cancelAuthIssuance).toHaveBeenCalledTimes(1);
+      });
     });
 
     it('POST /auth/mfa/sms/enable should reject missing currentPassword', async () => {

--- a/apps/api/src/routes/auth/mfa.ts
+++ b/apps/api/src/routes/auth/mfa.ts
@@ -39,7 +39,6 @@ import { readMobileDeviceId, carryForwardBinding } from '../../services/mobileDe
 import { authMiddleware, type AuthContext } from '../../middleware/auth';
 import { ENABLE_2FA, mfaVerifySchema, mfaEnableSchema, mfaStepUpSchema } from './schemas';
 import { getEffectiveMfaPolicy } from '../../services/mfaPolicy';
-import { invalidateMfaAssuranceAfterFactorChange } from '../../services/mfaAssurance';
 import { TEARDOWN_FAILED } from '../../services/remoteSessionTeardown';
 import { mintStepUpGrant, rollbackResourceDigest } from '../../services/mfaStepUpGrant';
 import { verifyStepUpPasskeyAssertion } from './passkeys';
@@ -903,20 +902,101 @@ mfaRoutes.post('/mfa/disable', authMiddleware, zValidator('json', mfaDisableSche
     }
   }
 
-  const result = await invalidateMfaAssuranceAfterFactorChange(auth.user.id, 'mfa-disable', async (tx) => {
-    await tx
-      .update(users)
-      .set({
-        mfaSecret: null,
-        mfaEnabled: false,
-        mfaMethod: null,
-        mfaRecoveryCodes: null,
-        phoneNumber: null,
-        phoneVerified: false,
-        updatedAt: new Date()
-      })
-      .where(eq(users.id, auth.user.id));
-  });
+  // SR2-07 keeps its teeth: removing the factor advances mfa_epoch and revokes
+  // every refresh family, so no OTHER live session survives the account losing
+  // its second factor. What it must not do is evict the ACTOR — the caller's
+  // access token goes stale on that bump and the refresh cookie it would retry
+  // with belongs to a family revoked in the same transaction, so fetchWithAuth's
+  // refresh fails and the web client hard-redirects to
+  // /login?reason=session-expired the moment the user turns MFA off (#4934).
+  // Same road /mfa/enable and /mfa/recovery-codes already take: one transaction
+  // bumps the epoch, revokes every family, mints a REPLACEMENT session bound to
+  // the post-bump epochs, and clears the factor.
+  let capability: AuthIssuanceCapability;
+  try {
+    capability = await beginAuthIssuance(requestAuthBinding(c));
+  } catch (error) {
+    const response = authIssuanceAdmissionError(c, error);
+    if (!response) throw error;
+    return response;
+  }
+  let result;
+  try {
+    result = await replaceSessionOnMfaFactorWrite({
+      userId: auth.user.id,
+      identity: {
+        userId: auth.user.id,
+        email: auth.user.email,
+        roleId: auth.token?.roleId ?? null,
+        orgId: auth.orgId ?? null,
+        partnerId: auth.partnerId ?? null,
+        scope: auth.scope,
+        // Carry the caller's OWN assurance forward, never elevate it: removing a
+        // factor must not upgrade a session that was not MFA-assured. (An
+        // already-assured caller — every session on a protected account — keeps
+        // full access, which is also what a fresh post-disable login would mint:
+        // `mfaSatisfied` in routes/auth/login.ts is vacuously true once
+        // mfa_enabled is false and policy does not mandate a factor.)
+        mfa: auth.token?.mfa === true,
+        // SR-001: this is a RE-MINT of an existing session, so the device binding
+        // comes from the previously-signed `mdid` claim, never from the forgeable
+        // request header — the same rule /auth/refresh follows. A bound mobile
+        // session must not be silently un-bound by a disable call.
+        mobileDeviceId: carryForwardBinding(auth.token ?? {}),
+      },
+      capability,
+      expectedAuthEpoch: auth.token?.aep as number,
+      expectedMfaEpoch: auth.token?.mep as number,
+      // The `mfaEnabled` read above is advisory (it answers with a friendly
+      // 400); this is the real check, folded into the epoch bump's WHERE so a
+      // concurrent second /mfa/disable loses with a 409 instead of bumping the
+      // epoch again and evicting the session the first one just issued.
+      expectedMfaEnabled: true,
+      revokeReason: 'mfa-disable',
+      // A removal supplies no code pair: the account must be left holding no
+      // recovery codes at all.
+      persistFactor: async (tx) => {
+        const rows = await tx
+          .update(users)
+          .set({
+            mfaSecret: null,
+            mfaEnabled: false,
+            mfaMethod: null,
+            mfaRecoveryCodes: null,
+            phoneNumber: null,
+            phoneVerified: false,
+            updatedAt: new Date()
+          })
+          .where(eq(users.id, auth.user.id))
+          .returning({ id: users.id });
+        if (rows.length !== 1) throw new Error('MFA disable user disappeared');
+        return undefined;
+      },
+    });
+  } catch (error) {
+    await cancelAuthIssuance(capability).catch(() => undefined);
+    const response = authIssuanceAdmissionError(c, error);
+    if (!response) throw error;
+    return response;
+  }
+
+  // POST-COMMIT from here: the factor is already gone and every other session is
+  // already dead, so a failure installing the replacement must not turn a
+  // completed disable into an error the user retries against an account that no
+  // longer has MFA (the retry answers 400 'MFA is not enabled'). Report it and
+  // step over, exactly like /mfa/recovery-codes.
+  let sessionInstalled = true;
+  try {
+    await bindIssuedUserSession(result.issued);
+    installAuthorizedUserSessionCookies(c, result.issued);
+  } catch (error) {
+    sessionInstalled = false;
+    captureException(error, c, { factorChange: 'mfa_disable' });
+    console.error('[auth] MFA disabled but the replacement session could not be installed', {
+      userId: auth.user.id,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 
   writeAuthAudit(c, {
     orgId: auth.orgId ?? undefined,
@@ -924,10 +1004,22 @@ mfaRoutes.post('/mfa/disable', authMiddleware, zValidator('json', mfaDisableSche
     result: 'success',
     userId: auth.user.id,
     email: auth.user.email,
-    details: { method: currentMethod, mfaEpoch: result.mfaEpoch, teardownFailed: result.remoteSessionsTerminated === TEARDOWN_FAILED }
+    details: {
+      method: currentMethod,
+      mfaEpoch: result.mfaEpoch,
+      teardownFailed: result.cleanup.remoteSessionsTerminated === TEARDOWN_FAILED,
+      sessionInstalled,
+    }
   });
 
-  return c.json({ success: true, message: 'MFA disabled successfully' });
+  return c.json({
+    success: true,
+    message: 'MFA disabled successfully',
+    // Withheld when the install above failed: the refresh JTI was never bound, so
+    // the access token would die at its first refresh. Better the client
+    // re-authenticates knowingly than holds a token with minutes left.
+    ...(sessionInstalled ? { tokens: toPublicTokens(result.issued) } : {}),
+  });
 });
 
 // MFA enable compatibility endpoint for frontend settings flow

--- a/apps/api/src/services/mfaEnrollmentSession.test.ts
+++ b/apps/api/src/services/mfaEnrollmentSession.test.ts
@@ -399,3 +399,136 @@ describe('replaceSessionOnMfaFactorWrite — rotation on an already-protected ac
     expect(runPostCommitCleanupMock).not.toHaveBeenCalled();
   });
 });
+
+// #4934: a factor REMOVAL is the third shape this primitive has to serve. It
+// bumps the epoch and revokes every family exactly like enrollment and rotation
+// do — no other session may survive the account losing its second factor — but
+// there is no code set to install and nothing one-time to reveal, so the codes
+// are omitted rather than faked.
+describe('replaceSessionOnMfaFactorWrite — factor removal with no recovery codes (#4934)', () => {
+  const tx = { marker: 'transaction' } as never;
+  const capability = { marker: 'capability' } as unknown as AuthIssuanceCapability;
+  const identity: UserSessionIdentity = {
+    userId: 'user-123',
+    email: 'user@example.com',
+    roleId: 'role-123',
+    orgId: 'org-123',
+    partnerId: 'partner-123',
+    scope: 'organization',
+    mfa: true,
+  };
+  const issued = {
+    accessToken: 'access',
+    refreshToken: 'refresh',
+    refreshJti: 'refresh-jti',
+    expiresInSeconds: 900,
+    familyId: 'family-new',
+    transitionId: 'transition-123',
+    generation: 4,
+  } as unknown as AuthorizedUserSession;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    finishAuthIssuanceMock.mockImplementation(
+      async (_capability: unknown, callback: (value: unknown) => Promise<unknown>) => callback(tx),
+    );
+    advanceUserEpochsMock.mockResolvedValue({
+      authEpoch: 3,
+      mfaEpoch: 8,
+      emailEpoch: 1,
+      passwordResetEpoch: 1,
+    });
+    revokeAllRefreshFamiliesMock.mockResolvedValue(undefined);
+    issueUserSessionMock.mockResolvedValue(issued);
+    runPostCommitCleanupMock.mockResolvedValue({ redisOk: true, permissionCacheOk: true, oauthOk: true });
+    terminateUserRemoteSessionsMock.mockResolvedValue(0);
+  });
+
+  it('revokes every family and re-issues the caller while installing no codes', async () => {
+    const persistFactor = vi.fn(async (suppliedTx: unknown, hashes: readonly string[]) => {
+      expect(suppliedTx).toBe(tx);
+      expect(hashes).toEqual([]);
+      return undefined;
+    });
+
+    const result = await replaceSessionOnMfaFactorWrite({
+      userId: identity.userId,
+      identity,
+      capability,
+      expectedAuthEpoch: 3,
+      expectedMfaEpoch: 7,
+      expectedMfaEnabled: true,
+      revokeReason: 'mfa-disable',
+      persistFactor,
+    });
+
+    expect(persistFactor).toHaveBeenCalledTimes(1);
+    // Every OTHER session still dies: the removal is predicated on the factor
+    // still existing when the bump lands, so a concurrent second removal loses.
+    expect(advanceUserEpochsMock).toHaveBeenCalledWith(
+      tx,
+      identity.userId,
+      { mfa: true },
+      { authEpoch: 3, mfaEpoch: 7, mfaEnabled: true, status: 'active' },
+    );
+    expect(revokeAllRefreshFamiliesMock).toHaveBeenCalledWith(tx, identity.userId, 'mfa-disable');
+    expect(issueUserSessionMock).toHaveBeenCalledWith(identity, {
+      tx,
+      capability,
+      expectedEpochs: { authEpoch: 3, mfaEpoch: 8 },
+    });
+    expect(result.recoveryCodes).toEqual([]);
+    expect(result.issued).toBe(issued);
+    // The replacement token must survive its own post-commit revocation cutoff.
+    expect(runPostCommitCleanupMock).toHaveBeenCalledTimes(1);
+    expect(runPostCommitCleanupMock.mock.calls[0]?.[1]?.preserveTokensIssuedAtOrAfter)
+      .toBeLessThanOrEqual(Math.floor(Date.now() / 1000));
+  });
+
+  it('still rejects a supplied-but-empty code set', async () => {
+    await expect(replaceSessionOnMfaFactorWrite({
+      userId: identity.userId,
+      identity,
+      capability,
+      expectedAuthEpoch: 3,
+      expectedMfaEpoch: 7,
+      expectedMfaEnabled: true,
+      revokeReason: 'mfa-recovery-rotate',
+      recoveryCodes: [],
+      recoveryCodeHashes: [],
+      persistFactor: vi.fn(),
+    })).rejects.toThrow(/count/i);
+
+    expect(finishAuthIssuanceMock).not.toHaveBeenCalled();
+  });
+
+  it('still rejects codes supplied without their hashes', async () => {
+    await expect(replaceSessionOnMfaFactorWrite({
+      userId: identity.userId,
+      identity,
+      capability,
+      expectedAuthEpoch: 3,
+      expectedMfaEpoch: 7,
+      expectedMfaEnabled: true,
+      revokeReason: 'mfa-recovery-rotate',
+      recoveryCodes: ['code-1'],
+      persistFactor: vi.fn(),
+    })).rejects.toThrow(/count/i);
+
+    expect(finishAuthIssuanceMock).not.toHaveBeenCalled();
+  });
+
+  it('refuses an initial enrollment that installs no recovery codes', async () => {
+    await expect(completeInitialMfaEnrollment({
+      userId: identity.userId,
+      identity,
+      capability,
+      expectedAuthEpoch: 3,
+      expectedMfaEpoch: 7,
+      revokeReason: 'initial-mfa-enrollment',
+      persistFactor: vi.fn(),
+    })).rejects.toThrow(/recovery-code/i);
+
+    expect(finishAuthIssuanceMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/mfaEnrollmentSession.ts
+++ b/apps/api/src/services/mfaEnrollmentSession.ts
@@ -37,8 +37,17 @@ export interface ReplaceSessionOnMfaFactorWriteInput<T> {
    */
   expectedMfaEnabled: boolean;
   revokeReason: string;
-  recoveryCodes: readonly string[];
-  recoveryCodeHashes: readonly string[];
+  /**
+   * The plaintext codes to hand back to the caller, paired one-for-one with
+   * `recoveryCodeHashes` (which is what actually lands in the row). OMIT both
+   * for a factor REMOVAL (#4934 `/mfa/disable`): the account must be left
+   * holding no code set at all, and there is no one-time secret to reveal, so
+   * faking an empty pair would only obscure the caller's intent. Supplying one
+   * without the other, supplying an empty pair, or mismatching the counts is a
+   * caller bug and throws before finalization opens.
+   */
+  recoveryCodes?: readonly string[];
+  recoveryCodeHashes?: readonly string[];
   persistFactor: (tx: Tx, recoveryCodeHashes: readonly string[]) => Promise<T>;
 }
 
@@ -64,13 +73,20 @@ export interface MfaFactorSessionReplacement<T> {
  * when the response body carries a one-time secret the user has to read
  * (recovery codes, #4480): a caller signed out by its own request never sees it.
  *
+ * Three shapes call this, differing only in `expectedMfaEnabled` and whether a
+ * code set accompanies the write: initial enrollment (factor must not exist yet,
+ * codes required), rotation on a protected account (factor must still exist,
+ * codes required), and factor REMOVAL (factor must still exist, no codes — a
+ * self-disable that evicted its own caller bounced the user to
+ * /login?reason=session-expired the moment they turned MFA off, #4934).
+ *
  * Expensive recovery-code generation and hashing belong before this call; every
  * authority-bearing write happens inside finishAuthIssuance's supplied
  * transaction and plaintext codes are returned only after it commits.
  *
  * The replacement identity is the CALLER's — assurance is carried forward, never
  * elevated. Enrollment passes `mfa: true` because it just installed the factor;
- * a rotation passes whatever the caller's own token carried.
+ * a rotation or a removal passes whatever the caller's own token carried.
  */
 export async function replaceSessionOnMfaFactorWrite<T>(
   input: ReplaceSessionOnMfaFactorWriteInput<T>,
@@ -78,13 +94,20 @@ export async function replaceSessionOnMfaFactorWrite<T>(
   if (input.identity.userId !== input.userId) {
     throw new Error('Factor-write identity does not match the target user');
   }
+  const recoveryCodes = input.recoveryCodes ?? [];
+  const recoveryCodeHashes = input.recoveryCodeHashes ?? [];
   if (
     !Number.isInteger(input.expectedAuthEpoch)
     || input.expectedAuthEpoch < 0
     || !Number.isInteger(input.expectedMfaEpoch)
     || input.expectedMfaEpoch < 0
-    || input.recoveryCodes.length === 0
-    || input.recoveryCodes.length !== input.recoveryCodeHashes.length
+    // The pair is all-or-nothing: a caller that generated codes must hand over
+    // the hashes too, and a removal omits both.
+    || (input.recoveryCodes === undefined) !== (input.recoveryCodeHashes === undefined)
+    || recoveryCodes.length !== recoveryCodeHashes.length
+    // A SUPPLIED set is the account's only valid one from this commit on, so an
+    // empty pair would be a silent lockout. A removal omits the fields instead.
+    || (input.recoveryCodes !== undefined && recoveryCodes.length === 0)
   ) {
     throw new Error('Expected auth/MFA epochs and recovery-code counts must be valid');
   }
@@ -123,7 +146,7 @@ export async function replaceSessionOnMfaFactorWrite<T>(
       capability: input.capability,
       expectedEpochs: { authEpoch: epochs.authEpoch, mfaEpoch: epochs.mfaEpoch },
     });
-    const value = await input.persistFactor(tx, input.recoveryCodeHashes);
+    const value = await input.persistFactor(tx, recoveryCodeHashes);
     return { value, issued, mfaEpoch: epochs.mfaEpoch };
   });
 
@@ -134,7 +157,7 @@ export async function replaceSessionOnMfaFactorWrite<T>(
 
   return {
     ...committed,
-    recoveryCodes: [...input.recoveryCodes],
+    recoveryCodes: [...recoveryCodes],
     cleanup: { ...cleanup, remoteSessionsTerminated },
   };
 }
@@ -150,6 +173,13 @@ export async function completeInitialMfaEnrollment<T>(
 ): Promise<MfaFactorSessionReplacement<T>> {
   if (input.identity.mfa !== true) {
     throw new Error('Replacement enrollment identity must be MFA-assured');
+  }
+  // Enrollment is the one factor write that must never omit its code set: the
+  // codes it returns are the only escape hatch a user locked out of their own
+  // factor has, and they exist exactly once. (`replaceSessionOnMfaFactorWrite`
+  // itself allows an omitted pair — that is the removal shape, #4934.)
+  if (input.recoveryCodes === undefined || input.recoveryCodes.length === 0) {
+    throw new Error('Initial MFA enrollment must install a recovery-code set');
   }
   return replaceSessionOnMfaFactorWrite({ ...input, expectedMfaEnabled: false });
 }

--- a/apps/api/src/services/userSession.callers.test.ts
+++ b/apps/api/src/services/userSession.callers.test.ts
@@ -36,7 +36,11 @@ const expectedSingleBoundaryFiles = new Map([
 const expectedLegacyIssuerFiles = new Map(expectedSingleBoundaryFiles);
 const expectedGuardedCookieInstallerFiles = new Map([
   ...expectedSingleBoundaryFiles,
-  ['routes/auth/mfa.ts', 5],
+  // /mfa/verify (two issuance branches), /mfa/setup confirm, /mfa/enable,
+  // /mfa/recovery-codes, and /mfa/disable (#4934 — a self-disable that evicted
+  // its own caller bounced the user to /login?reason=session-expired, so it now
+  // installs a replacement too).
+  ['routes/auth/mfa.ts', 6],
   ['routes/auth/passkeys.ts', 3],
   ['routes/auth/phone.ts', 1],
   ['routes/sso.ts', 1],

--- a/apps/web/src/components/settings/ProfilePage.mfaDisable.test.tsx
+++ b/apps/web/src/components/settings/ProfilePage.mfaDisable.test.tsx
@@ -1,0 +1,156 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ProfilePage from './ProfilePage';
+import { fetchWithAuth } from '../../stores/auth';
+
+/**
+ * #4934 — disabling MFA rotates the caller's SESSION too.
+ *
+ * Removing the factor advances `mfa_epoch` and revokes every refresh family (no
+ * other live session may survive the account losing its second factor), then
+ * hands the actor a replacement session back in the same response. The page has
+ * to ADOPT that replacement: keeping the pre-disable access token means the next
+ * request 401s on the stale `mep` claim, the refresh cookie it would retry with
+ * belongs to a revoked family, and the user is bounced to
+ * /login?reason=session-expired by the very action they just took. Same contract
+ * recovery-code rotation adopted in #4480/#4646.
+ */
+
+const { commitReissuedSessionIfCurrentMock, sessionGeneration } = vi.hoisted(() => ({
+  commitReissuedSessionIfCurrentMock: vi.fn(() => true),
+  sessionGeneration: 7,
+}));
+
+vi.mock('../../stores/auth', () => ({
+  createPasskeyCredential: vi.fn(),
+  fetchWithAuth: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (state: Record<string, unknown>) => unknown) =>
+      selector({ updateUser: vi.fn() }),
+    {
+      getState: () => ({
+        updateUser: vi.fn(),
+        sessionGeneration,
+        commitReissuedSessionIfCurrent: commitReissuedSessionIfCurrentMock,
+      }),
+    },
+  ),
+}));
+
+const { showToastMock } = vi.hoisted(() => ({ showToastMock: vi.fn() }));
+vi.mock('../shared/Toast', () => ({ showToast: showToastMock }));
+
+vi.mock('@/lib/avatarBlobCache', () => ({
+  useAvatarBlobUrl: (url: string | null | undefined) => url ?? null,
+}));
+
+vi.mock('./ApproverDevicesSection', () => ({
+  default: () => null,
+}));
+
+const fetchWithAuthMock = vi.mocked(fetchWithAuth);
+
+const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  }) as unknown as Response;
+
+const MFA_USER = {
+  id: 'user-1',
+  name: 'Casey Admin',
+  email: 'casey@example.com',
+  mfaEnabled: true,
+  mfaMethod: 'totp',
+  hasPassword: true,
+};
+
+/** Open the disable panel, fill the six code digits plus the password, submit. */
+async function disableMfa() {
+  fireEvent.click(await screen.findByRole('button', { name: /^Disable$/i }));
+  const digits = document.querySelectorAll<HTMLInputElement>('input[inputmode="numeric"]');
+  digits.forEach((input, index) => {
+    fireEvent.change(input, { target: { value: String(index + 1) } });
+  });
+  const password = document.getElementById('mfa-disable-password') as HTMLInputElement;
+  fireEvent.change(password, { target: { value: 'hunter2-pw' } });
+  fireEvent.click(screen.getByRole('button', { name: /^Disable MFA$/i }));
+}
+
+describe('ProfilePage — disabling MFA adopts the replacement session (#4934)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    commitReissuedSessionIfCurrentMock.mockReturnValue(true);
+    window.history.replaceState(null, '', '/settings/profile');
+  });
+
+  it('installs the replacement access token and still reports the disable', async () => {
+    fetchWithAuthMock.mockImplementation(async (url) => {
+      if (String(url) === '/auth/passkeys') return makeJsonResponse({ passkeys: [] });
+      if (String(url) === '/auth/mfa/disable') {
+        return makeJsonResponse({
+          success: true,
+          message: 'MFA disabled successfully',
+          tokens: { accessToken: 'reissued-access-token', expiresInSeconds: 900 },
+        });
+      }
+      return undefined as unknown as Response;
+    });
+
+    render(<ProfilePage initialUser={MFA_USER} />);
+    await disableMfa();
+
+    await waitFor(() => {
+      expect(commitReissuedSessionIfCurrentMock).toHaveBeenCalledWith(
+        sessionGeneration,
+        { accessToken: 'reissued-access-token', expiresInSeconds: 900 },
+      );
+    });
+    expect(await screen.findByText(/Multi-factor authentication disabled/i)).toBeTruthy();
+  });
+
+  it('still reports the disable when the session moved on and the replacement is refused', async () => {
+    // A logout/re-login raced the request: the store refuses the stale-generation
+    // commit. MFA is already off server-side, so the outcome still has to be
+    // shown rather than surfaced as a failure the user would retry.
+    commitReissuedSessionIfCurrentMock.mockReturnValue(false);
+    fetchWithAuthMock.mockImplementation(async (url) => {
+      if (String(url) === '/auth/passkeys') return makeJsonResponse({ passkeys: [] });
+      if (String(url) === '/auth/mfa/disable') {
+        return makeJsonResponse({
+          success: true,
+          tokens: { accessToken: 'reissued-access-token', expiresInSeconds: 900 },
+        });
+      }
+      return undefined as unknown as Response;
+    });
+
+    render(<ProfilePage initialUser={MFA_USER} />);
+    await disableMfa();
+
+    expect(await screen.findByText(/Multi-factor authentication disabled/i)).toBeTruthy();
+  });
+
+  // Covers both ways the API can omit `tokens`: an older build that never
+  // returned one, and the post-commit install failure where it deliberately
+  // withholds the replacement (the refresh JTI was never bound, so the access
+  // token would die at its first refresh).
+  it('does not try to adopt a session the API did not return', async () => {
+    fetchWithAuthMock.mockImplementation(async (url) => {
+      if (String(url) === '/auth/passkeys') return makeJsonResponse({ passkeys: [] });
+      if (String(url) === '/auth/mfa/disable') {
+        return makeJsonResponse({ success: true, message: 'MFA disabled successfully' });
+      }
+      return undefined as unknown as Response;
+    });
+
+    render(<ProfilePage initialUser={MFA_USER} />);
+    await disableMfa();
+
+    expect(await screen.findByText(/Multi-factor authentication disabled/i)).toBeTruthy();
+    expect(commitReissuedSessionIfCurrentMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/settings/ProfilePage.tsx
+++ b/apps/web/src/components/settings/ProfilePage.tsx
@@ -688,6 +688,8 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
   const handleMfaDisable = async (code: string, currentPassword: string): Promise<boolean> => {
     setMfaError(undefined);
     setMfaSuccess(undefined);
+    // Captured before the request so a logout that races it is detectable.
+    const generation = useAuthStore.getState().sessionGeneration;
     try {
       setMfaLoading(true);
       const response = await fetchWithAuth('/auth/mfa/disable', {
@@ -702,6 +704,19 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
         );
       }
 
+      const data = await response.json();
+      // #4934: disabling MFA rotates the SESSION too — the API advances mfa_epoch
+      // and revokes every refresh family so no OTHER session survives the factor
+      // removal, and hands this caller a replacement in the same response. Adopt
+      // it before rendering success (the refresh/CSRF cookies came with it);
+      // keeping the pre-disable token means the next request 401s, its refresh
+      // fails against a revoked family, and the user is bounced to
+      // /login?reason=session-expired by the very action they just took.
+      // A refused commit (a logout raced the request) is not an error: MFA is
+      // already off, so the success message still has to be shown.
+      if (data.tokens?.accessToken) {
+        useAuthStore.getState().commitReissuedSessionIfCurrent(generation, data.tokens);
+      }
       setUser(prev => (prev ? { ...prev, mfaEnabled: false } : null));
       setRecoveryCodes(undefined);
       setMfaSuccess(t('profilePage.multiFactorAuthenticationDisabled'));


### PR DESCRIPTION
## Summary

- `POST /auth/mfa/disable` used to route its write through `invalidateMfaAssuranceAfterFactorChange`, which advances `mfa_epoch` and revokes every refresh family **without re-issuing the actor** — the caller's own next request 401s on the stale `mep` claim, its refresh fails against a revoked family, and the web client hard-redirects to `/login?reason=session-expired` the moment a user turns off their own MFA.
- Mirrors the fix `#4646` applied to recovery-code rotation for the same eviction class: the disable route now goes through `beginAuthIssuance` → `replaceSessionOnMfaFactorWrite` → `bindIssuedUserSession` + `installAuthorizedUserSessionCookies`. Every OTHER session for the user is still revoked; the actor gets a replacement session in the same response.
- `replaceSessionOnMfaFactorWrite`'s `recoveryCodes`/`recoveryCodeHashes` are now optional to support this third call shape ("removal" — no code set to install, nothing one-time to reveal). `completeInitialMfaEnrollment` still requires them (enrollment behavior unchanged).
- `apps/web` `ProfilePage.handleMfaDisable` adopts the replacement session (`commitReissuedSessionIfCurrent`) before showing the success message, same pattern as `handleGenerateRecoveryCodes` from `#4646`.
- `openapi.ts` documents the corrected request/response shape for `disableMfa` (currentPassword was already required by the zod schema but undocumented; response now documents the replacement `tokens` and the 403/409/428 statuses the shared issuance path can return).

## Root cause

`/mfa/disable`'s factor write went through the "evict everyone, including the caller" path (`invalidateMfaAssuranceAfterFactorChange`) instead of the "evict everyone else, replace the caller's own session" path already built for `/mfa/enable` and `/mfa/recovery-codes` (`replaceSessionOnMfaFactorWrite`, from `#4480`/`#4646`). The MFA-disable route was simply never migrated when that primitive was introduced.

## Verification

```
cd apps/api && npx vitest run src/routes/auth.test.ts src/services/mfaEnrollmentSession.test.ts src/services/userSession.callers.test.ts
# Test Files  3 passed (3) / Tests  153 passed (153)

cd apps/api && npx vitest run src/routes/auth.passkeys.test.ts src/routes/users.test.ts src/routes/auth/phone.test.ts
# Test Files  3 passed (3) / Tests  171 passed (171)  (no regressions in sibling MFA/factor-change routes)

cd apps/web && npx vitest run src/components/settings/ProfilePage.mfaDisable.test.tsx
# Test Files  1 passed (1) / Tests  3 passed (3)

NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit -p apps/api   # clean
NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit -p apps/web   # clean

npx eslint <every changed file>   # clean
```

New coverage: response does not clear session cookies (asserts no `Max-Age=0` / cleared `breeze_refresh_token`/`breeze_csrf_token` on a successful disable, and that the rotated refresh cookie IS present); factor is still cleared inside the replacement transaction; signed `mdid` binding carried forward (never the forgeable header); caller assurance never elevated; success is still reported when the post-commit session install fails (tokens withheld); a lost issuance race surfaces as 409 and cancels the issuance. Web: adopts the replacement token, still reports success if the commit is refused by a raced generation bump, and doesn't try to adopt a session the API didn't return.

## Decisions / notes for reviewer

- Checked `#4920` (open, admin-initiated `POST /users/:id/mfa/reset` — passkey-revoking factor reset via `services/mfaFactorReset.ts`). It is a disjoint code path from this self-service `/mfa/disable` route (different service module, different route file) — no overlap, no rebase risk once either merges.
- `openapi.ts`'s request-body doc also now lists `currentPassword` as required — that was already true of the underlying zod schema (`mfaDisableSchema`) before this PR; the doc was simply stale. Included here since this PR already rewrites this exact response block.
- This branch's starting commit was produced by an earlier automated pass and was reviewed file-by-file, re-verified against `#4646`'s actual diff, and had one real defect fixed before this PR was opened: a TS2345 type error in a new test (`auth.test.ts`) from an untyped mock return missing the branded `AuthorizedUserSession` marker — fixed with an explicit `as unknown as AuthorizedUserSession` cast plus the missing type import, matching the existing pattern in `mfaEnrollmentSession.test.ts`.

Closes #4934

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHw2i34ficqHcncKr1aMLF