### PR TITLE
perf(db): (org_id, timestamp) index on device_process_samples for the per-org rollup

### DIFF
--- a/apps/api/migrations/2026-10-11-000100-device-process-samples-org-ts-idx.sql
+++ b/apps/api/migrations/2026-10-11-000100-device-process-samples-org-ts-idx.sql
@@ -1,0 +1,46 @@
+-- @no-transaction
+-- device_process_samples: (org_id, timestamp) index for the per-org metric
+-- rollup (apps/api/src/services/metricRollups.ts, rollupRawProcessSampleMetrics).
+--
+-- The rollup runs once per org every 5 minutes over a 15-minute window and
+-- filters `WHERE org_id = $1 AND timestamp >= $2 AND timestamp < $3`. The table
+-- only had (device_id, timestamp) indexes, so neither column order lets the
+-- planner seek on org + time: it walks the ENTIRE primary-key index applying
+-- the timestamp range as a condition and org_id as a filter (US prod
+-- 2026-09-06: 2,182 buffers, "Rows Removed by Filter" > rows kept, 2-3.5 s per
+-- scan, IO-bound in DataFileRead). The statement scans the window twice
+-- (`process_devices` DISTINCT + `sample_values`), 30 orgs x 2 workers back to
+-- back, so the rollup alone burned ~1.5 DB-seconds per wall-second on the
+-- 1-vCPU managed instance and read ~6 GB of buffers per 90 s -- the queue
+-- never drained and interactive queries were starved (v0.110.0 was already
+-- deployed; #4419 single-pass rollup made each call cheaper but not the scan).
+--
+-- With (org_id, timestamp) the same 15-minute window is a ~100-row range seek
+-- (index ~17 MB for 190k rows, sits in shared_buffers). device_metrics already
+-- has the equivalent device_metrics_org_id_timestamp_idx (2026-04-11).
+--
+-- CREATE INDEX CONCURRENTLY: the agent heartbeat path inserts into this table
+-- continuously. IF NOT EXISTS keeps re-application a no-op (prod may get the
+-- index by hand ahead of the release). An interrupted CONCURRENTLY build leaves
+-- an INVALID index that IF NOT EXISTS would silently accept, so the DO block
+-- fails loudly in that state. Recovery: DROP INDEX CONCURRENTLY
+-- device_process_samples_org_ts_idx, then let autoMigrate re-run this file.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS device_process_samples_org_ts_idx
+  ON public.device_process_samples (org_id, "timestamp");
+
+DO $$
+DECLARE
+  bad text;
+BEGIN
+  SELECT string_agg(c.relname, ', ')
+    INTO bad
+    FROM pg_index i
+    JOIN pg_class c ON c.oid = i.indexrelid
+   WHERE i.indrelid = 'public.device_process_samples'::regclass
+     AND c.relname = 'device_process_samples_org_ts_idx'
+     AND NOT i.indisvalid;
+  IF bad IS NOT NULL THEN
+    RAISE EXCEPTION 'device_process_samples org/timestamp index build left INVALID index: % — DROP INDEX CONCURRENTLY it and re-apply this migration', bad;
+  END IF;
+END $$;


### PR DESCRIPTION
## Why

US prod is sluggish after the v0.110.0 deploy. Live `pg_stat_statements` delta (90 s window, 2026-09-06 01:05 UTC):

| | |
|---|---|
| DB busy | ~310 exec-seconds per 90 s (3.4 CPU-s per wall-second on a 1-vCPU instance) |
| top statement | `WITH process_devices AS (...)` — the per-org `device_process_samples` rollup |
| its share | 110–152 s per 90 s, 26–34 calls, ~800k–1M shared buffer reads (~6–8 GB) |
| queue | both rollup workers busy nonstop, 16 jobs waiting |

`EXPLAIN (ANALYZE, BUFFERS)` for one org's 15-minute window: full walk of `device_process_samples_pkey` (`(device_id, timestamp)`) with the timestamp range as the only index condition and `org_id` as a post-filter — 2,182 buffers, "Rows Removed by Filter" > rows kept, 2–3.5 s per scan, IO-bound. The statement scans the window twice.

`device_metrics` already has the equivalent `device_metrics_org_id_timestamp_idx`; `device_process_samples` (2026-06-13) never got one.

## What

New migration `2026-10-11-000100-device-process-samples-org-ts-idx.sql` (`@no-transaction`): `CREATE INDEX CONCURRENTLY IF NOT EXISTS device_process_samples_org_ts_idx ON device_process_samples (org_id, timestamp)` plus the INVALID-index guard pattern from `2026-10-09-000100`.

## Verified

- `check-migration-naming.sh --against-ref origin/main`: OK
- `autoMigrate.test.ts` + `migrationRlsScope.test.ts`: 100 passed
- Applied twice to a local Postgres: second run is a NOTICE no-op; `EXPLAIN` uses the new index with `org_id` and both timestamp bounds as index conditions.

## Rollout

Prod can get the index by hand ahead of the release (`CREATE INDEX CONCURRENTLY IF NOT EXISTS ...`, same statement); the migration is then a no-op there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SBWJSD8QenDKGnnTsKtgs