### PR TITLE
fix(rls): partner-wide SELECT branch for automation tables (#4952, #4950, #4951, #4949)

### DIFF
--- a/apps/api/migrations/2026-10-11-000400-automation-alert-rules-partner-wide-select.sql
+++ b/apps/api/migrations/2026-10-11-000400-automation-alert-rules-partner-wide-select.sql
@@ -1,0 +1,81 @@
+-- Partner-wide READ branch on the automation + alert-rule config tables
+-- (#4952 automations, #4950 automation_policies, #4951
+-- automation_resource_bindings, #4949 alert_rules) — the next group of the
+-- SELECT-only own-partner branch shipped for the configuration-policy chain in
+-- 2026-10-05-110000-config-policy-partner-wide-select.sql (wave 1 of #4673).
+-- Read that file's header for the full rationale; the short version:
+--
+-- A partner-wide row is `org_id NULL, partner_id = P`. An ORG-scoped session
+-- cannot see it — `breeze_has_org_access(NULL)` is false and
+-- `breeze_has_partner_access(P)` is false because org scope carries an empty
+-- `accessible_partner_ids` — so every request-path reader has to escalate
+-- through the #1105 pattern (`runOutsideDbContext(() =>
+-- withSystemDbAccessContext(...))`), which acquires a SECOND pooled connection
+-- while the request's own transaction holds the first and bypasses RLS
+-- entirely. `breeze_current_partner_id()` (created by
+-- 2026-06-13-catalog-partner-read-branch.sql, NOT recreated here) reads the
+-- caller's OWN partner from a GUC that `buildDbAccessContext` populates for
+-- every scope, so the branch needs no extra connection and no RLS bypass.
+--
+-- A SEPARATE FOR SELECT policy per table, never an edit to the existing one:
+-- all four carry a single dual-axis FOR ALL policy (`automations_isolation`,
+-- `automation_policies_isolation`, `automation_resource_bindings_isolation`,
+-- `alert_rules_isolation`), and appending this branch to a FOR ALL `USING`
+-- would also widen UPDATE/DELETE row targeting — an org admin could then
+-- rewrite or delete their MSP's shared automation. Postgres never consults a
+-- FOR SELECT policy when computing UPDATE/DELETE target rows, so a separate
+-- permissive policy ORs into reads and nothing else. The existing policies are
+-- left byte-identical.
+--
+-- All four tables carry `org_id` and `partner_id` directly on the row with an
+-- XOR CHECK (`automations_one_owner_chk`, `automation_policies_one_owner_chk`,
+-- `automation_resource_bindings_one_owner_chk`, `alert_rules_one_owner_chk`),
+-- so all four take the direct-column form — no EXISTS join to a parent.
+-- automation_resource_bindings copies its parent automation's owner axes
+-- (2026-09-25-a), which is why the direct form is correct there too.
+--
+-- The branch is LOAD-BEARING on the agent path. `middleware/agentAuth.ts`
+-- sets `currentPartnerId: device.partnerId` (#4673 W02), so an agent session
+-- gains exactly this read: `buildPolicyProbeConfigUpdate`
+-- (routes/agents/helpers.ts) already asks for partner-wide automation_policies
+-- with an app-layer `org_id IS NULL AND partner_id = <org's partner>` branch on
+-- the heartbeat path, and before this migration RLS silently returned zero rows
+-- for it — the agent never collected registry/config probes for partner-wide
+-- compliance policies, with no error anywhere.
+--
+-- The predicate uses `=` and not `IS NOT DISTINCT FROM`: a context that leaves
+-- the GUC unset reads NULL, and `partner_id = NULL` is NULL, never true. Under
+-- `IS NOT DISTINCT FROM` every such session would see EVERY partner's shared
+-- rows.
+--
+-- Idempotent: DROP POLICY IF EXISTS then CREATE, so re-applying is a no-op.
+-- No inner BEGIN/COMMIT — autoMigrate wraps each file in a transaction. This
+-- migration writes no rows, so it needs no `breeze.scope` elevation.
+--
+-- Rollback: a new migration issuing the four matching
+-- `DROP POLICY IF EXISTS <table>_partner_wide_select` statements. The policies
+-- are purely additive; no reader code is changed here.
+
+DROP POLICY IF EXISTS automations_partner_wide_select ON public.automations;
+CREATE POLICY automations_partner_wide_select
+  ON public.automations
+  FOR SELECT
+  USING (org_id IS NULL AND partner_id = public.breeze_current_partner_id());
+
+DROP POLICY IF EXISTS automation_policies_partner_wide_select ON public.automation_policies;
+CREATE POLICY automation_policies_partner_wide_select
+  ON public.automation_policies
+  FOR SELECT
+  USING (org_id IS NULL AND partner_id = public.breeze_current_partner_id());
+
+DROP POLICY IF EXISTS automation_resource_bindings_partner_wide_select ON public.automation_resource_bindings;
+CREATE POLICY automation_resource_bindings_partner_wide_select
+  ON public.automation_resource_bindings
+  FOR SELECT
+  USING (org_id IS NULL AND partner_id = public.breeze_current_partner_id());
+
+DROP POLICY IF EXISTS alert_rules_partner_wide_select ON public.alert_rules;
+CREATE POLICY alert_rules_partner_wide_select
+  ON public.alert_rules
+  FOR SELECT
+  USING (org_id IS NULL AND partner_id = public.breeze_current_partner_id());

--- a/apps/api/src/__tests__/integration/automationAlertRulesPartnerWideSelect.integration.test.ts
+++ b/apps/api/src/__tests__/integration/automationAlertRulesPartnerWideSelect.integration.test.ts
@@ -1,0 +1,656 @@
+/**
+ * Partner-wide READ branch on the automation + alert-rule config tables
+ * (#4952 automations, #4950 automation_policies, #4951
+ * automation_resource_bindings, #4949 alert_rules) — the group after the
+ * configuration-policy chain (wave 1 of #4673).
+ *
+ * Migration under test:
+ * 2026-10-11-000400-automation-alert-rules-partner-wide-select.sql, whose
+ * rationale is 2026-10-05-110000-config-policy-partner-wide-select.sql.
+ *
+ * A partner-wide row is `org_id NULL, partner_id = P`. Before this migration an
+ * ORG-scoped session could not see it: `breeze_has_org_access(NULL)` is false,
+ * and `breeze_has_partner_access(P)` is false because org scope carries
+ * `accessiblePartnerIds: []`. Every request-path reader therefore had to
+ * escalate into a nested `withSystemDbAccessContext` (the #1105 pattern), which
+ * acquires a SECOND pooled connection while the request's own transaction holds
+ * the first and bypasses RLS entirely.
+ *
+ * All four tables carry both owner axes directly on the row with an XOR CHECK,
+ * so each takes the direct-column branch as its own SEPARATE permissive
+ * `FOR SELECT` policy:
+ *
+ *   <table>_partner_wide_select  FOR SELECT
+ *     USING (org_id IS NULL AND partner_id = public.breeze_current_partner_id())
+ *
+ * Kept separate from each table's single dual-axis `FOR ALL` policy
+ * (`automations_isolation`, `automation_policies_isolation`,
+ * `automation_resource_bindings_isolation`, `alert_rules_isolation`) on purpose:
+ * appending the branch to a FOR ALL `USING` would also widen UPDATE/DELETE row
+ * targeting to the MSP's shared rows. Postgres never consults a FOR SELECT
+ * policy when computing UPDATE/DELETE target rows, so a separate policy ORs into
+ * reads only.
+ *
+ * Three properties this suite proves per table — none reachable from a mocked
+ * unit test (no RLS runs there) and none proven by rls-coverage either (that is
+ * a pg_catalog shape inspection, not a functional one):
+ *
+ *  1. An ORG session of the OWNING partner SELECTs BOTH its own org-owned row
+ *     and the partner-wide row.
+ *  2. An ORG session under a DIFFERENT partner sees NEITHER, and a session
+ *     whose `currentPartnerId` is unset (so `breeze_current_partner_id()`
+ *     returns NULL) sees no partner-wide row — the predicate must use `=`,
+ *     never `IS NOT DISTINCT FROM`, which would make every NULL-GUC session
+ *     read every partner's shared rows.
+ *  3. The branch grants NO write: UPDATE and DELETE of the partner-wide row
+ *     from that same org session affect ZERO rows and leave the row unchanged.
+ *     Note this is a silent no-op, not a 42501 — RLS hides the target row from
+ *     the write command rather than raising — so a test that only asserted "it
+ *     threw" would be vacuous; assert rowCount AND re-read under system scope.
+ *     The 42501 half is proven via the INSERT forge, where WITH CHECK does
+ *     raise.
+ */
+import './setup';
+import { afterEach, describe, expect, it } from 'vitest';
+import { eq, inArray } from 'drizzle-orm';
+import { db, withDbAccessContext, type DbAccessContext } from '../../db';
+import {
+  alertRules,
+  alertTemplates,
+  automationPolicies,
+  automationResourceBindings,
+  automations,
+} from '../../db/schema';
+import { createOrganization, createPartner } from './db-utils';
+
+const SYSTEM_CTX: DbAccessContext = {
+  scope: 'system',
+  orgId: null,
+  accessibleOrgIds: null,
+  accessiblePartnerIds: null,
+  userId: null,
+};
+
+function partnerContext(partnerId: string, orgIds: string[] = []): DbAccessContext {
+  return {
+    scope: 'partner',
+    orgId: null,
+    accessibleOrgIds: orgIds,
+    accessiblePartnerIds: [partnerId],
+    userId: null,
+    currentPartnerId: partnerId,
+  };
+}
+
+/**
+ * An ORG-scoped session. `currentPartnerId` is populated from the token's own
+ * partnerId for org scope too (`buildDbAccessContext`, middleware/auth.ts),
+ * which is exactly what the read branch keys on — so it is set deliberately.
+ * `accessiblePartnerIds` stays EMPTY: an org token never passes
+ * `breeze_has_partner_access`, and that is what keeps the branch read-only.
+ *
+ * Passing `currentPartnerId: null` leaves the GUC empty, which is what
+ * `breeze_current_partner_id()` reads back as NULL.
+ */
+function orgContext(orgId: string, currentPartnerId: string | null): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    userId: null,
+    currentPartnerId,
+  };
+}
+
+/**
+ * Assert a statement failed with a specific SQLSTATE. Drizzle wraps driver
+ * errors in a DrizzleQueryError whose message is only "Failed query: ...", so
+ * a regex on `.message` matches nothing useful — the pg error (with `.code`)
+ * hangs off `.cause`.
+ */
+async function expectSqlState(fn: () => Promise<unknown>, code: string): Promise<void> {
+  let raised: unknown;
+  try {
+    await fn();
+  } catch (err) {
+    raised = err;
+  }
+  expect(raised, `expected SQLSTATE ${code}, but the statement succeeded`).toBeDefined();
+  const cause = (raised as { cause?: { code?: string } })?.cause;
+  const actual = cause?.code ?? (raised as { code?: string })?.code;
+  expect(actual).toBe(code);
+}
+
+const created = {
+  bindings: [] as string[],
+  automations: [] as string[],
+  policies: [] as string[],
+  rules: [] as string[],
+  templates: [] as string[],
+};
+
+afterEach(async () => {
+  const any = Object.values(created).some((ids) => ids.length > 0);
+  if (!any) return;
+  await withDbAccessContext(SYSTEM_CTX, async () => {
+    // Children before parents; the org/partner roots are truncated by the
+    // global beforeEach in ./setup, so this only has to leave no orphans.
+    if (created.bindings.length > 0) {
+      await db.delete(automationResourceBindings).where(inArray(automationResourceBindings.id, created.bindings));
+    }
+    if (created.automations.length > 0) {
+      await db.delete(automations).where(inArray(automations.id, created.automations));
+    }
+    if (created.policies.length > 0) {
+      await db.delete(automationPolicies).where(inArray(automationPolicies.id, created.policies));
+    }
+    if (created.rules.length > 0) {
+      await db.delete(alertRules).where(inArray(alertRules.id, created.rules));
+    }
+    if (created.templates.length > 0) {
+      await db.delete(alertTemplates).where(inArray(alertTemplates.id, created.templates));
+    }
+  });
+  created.bindings.length = 0;
+  created.automations.length = 0;
+  created.policies.length = 0;
+  created.rules.length = 0;
+  created.templates.length = 0;
+});
+
+const AUTOMATION_TRIGGER = { type: 'manual' };
+const AUTOMATION_ACTIONS = [{ type: 'create_alert', alertSeverity: 'medium', alertMessage: 'probe' }];
+const POLICY_TARGETS = { targetType: 'all', targetIds: [] };
+const POLICY_RULES = [{ type: 'prohibited_software', softwareName: 'BitTorrent' }];
+const TEMPLATE = {
+  conditions: { type: 'metric', metric: 'cpu', operator: '>', threshold: 95 },
+  severity: 'high',
+  titleTemplate: 'High CPU on {{hostname}}',
+  messageTemplate: 'CPU exceeded threshold on {{hostname}}',
+} as const;
+
+interface Fixture {
+  partnerId: string;
+  orgId: string;
+  automation: { orgOwnedId: string; partnerWideId: string };
+  automationPolicy: { orgOwnedId: string; partnerWideId: string };
+  resourceBinding: { orgOwnedId: string; partnerWideId: string };
+  alertRule: { orgOwnedId: string; partnerWideId: string };
+  /** alert_rules.template_id is NOT NULL — the forge needs a readable template. */
+  orgTemplateId: string;
+}
+
+/**
+ * Seed one ORG-OWNED row (org A of partner P) and one PARTNER-WIDE row
+ * (`org_id NULL, partner_id P`) per table. Partner-wide rows are written under
+ * a PARTNER context — the only scope that may write them — and org-owned rows
+ * under the ORG context, so the fixture also proves neither write path moved.
+ *
+ * automation_resource_bindings copies its parent automation's owner axes (the
+ * `automation_resource_binding_owner_guard` constraint trigger rejects drift),
+ * so each binding needs a parent automation on the SAME axis, and its
+ * `expected_resource_*` columns have to sit inside that tenant.
+ */
+async function seedFixture(): Promise<Fixture> {
+  const partner = await createPartner();
+  const org = await createOrganization({ partnerId: partner.id });
+  const orgCtx = orgContext(org.id, partner.id);
+  const partnerCtx = partnerContext(partner.id, [org.id]);
+
+  const automationOrg = await withDbAccessContext(orgCtx, async () => {
+    const [row] = await db
+      .insert(automations)
+      .values({
+        orgId: org.id,
+        partnerId: null,
+        name: 'Org-owned automation',
+        trigger: AUTOMATION_TRIGGER,
+        actions: AUTOMATION_ACTIONS,
+      })
+      .returning();
+    created.automations.push(row!.id);
+    return row!.id;
+  });
+
+  const automationPartnerWide = await withDbAccessContext(partnerCtx, async () => {
+    const [row] = await db
+      .insert(automations)
+      .values({
+        orgId: null,
+        partnerId: partner.id,
+        name: 'Partner-wide automation',
+        trigger: AUTOMATION_TRIGGER,
+        actions: AUTOMATION_ACTIONS,
+      })
+      .returning();
+    created.automations.push(row!.id);
+    return row!.id;
+  });
+
+  const bindingOrg = await withDbAccessContext(orgCtx, async () => {
+    const [row] = await db
+      .insert(automationResourceBindings)
+      .values({
+        automationId: automationOrg,
+        orgId: org.id,
+        partnerId: null,
+        resourceKind: 'notification_channel',
+        resourceId: 'org-owned-resource',
+        expectedResourceOrgId: org.id,
+        expectedResourcePartnerId: null,
+        expectedResourceIsSystem: false,
+      })
+      .returning();
+    created.bindings.push(row!.id);
+    return row!.id;
+  });
+
+  const bindingPartnerWide = await withDbAccessContext(partnerCtx, async () => {
+    const [row] = await db
+      .insert(automationResourceBindings)
+      .values({
+        automationId: automationPartnerWide,
+        orgId: null,
+        partnerId: partner.id,
+        resourceKind: 'notification_channel',
+        resourceId: 'partner-wide-resource',
+        expectedResourceOrgId: null,
+        expectedResourcePartnerId: partner.id,
+        expectedResourceIsSystem: false,
+      })
+      .returning();
+    created.bindings.push(row!.id);
+    return row!.id;
+  });
+
+  const policyOrg = await withDbAccessContext(orgCtx, async () => {
+    const [row] = await db
+      .insert(automationPolicies)
+      .values({
+        orgId: org.id,
+        partnerId: null,
+        name: 'Org-owned automation policy',
+        targets: POLICY_TARGETS,
+        rules: POLICY_RULES,
+      })
+      .returning();
+    created.policies.push(row!.id);
+    return row!.id;
+  });
+
+  const policyPartnerWide = await withDbAccessContext(partnerCtx, async () => {
+    const [row] = await db
+      .insert(automationPolicies)
+      .values({
+        orgId: null,
+        partnerId: partner.id,
+        name: 'Partner-wide automation policy',
+        targets: POLICY_TARGETS,
+        rules: POLICY_RULES,
+      })
+      .returning();
+    created.policies.push(row!.id);
+    return row!.id;
+  });
+
+  const orgTemplate = await withDbAccessContext(orgCtx, async () => {
+    const [row] = await db
+      .insert(alertTemplates)
+      .values({ orgId: org.id, partnerId: null, name: 'Org-owned template', ...TEMPLATE })
+      .returning();
+    created.templates.push(row!.id);
+    return row!.id;
+  });
+
+  const partnerTemplate = await withDbAccessContext(partnerCtx, async () => {
+    const [row] = await db
+      .insert(alertTemplates)
+      .values({ orgId: null, partnerId: partner.id, name: 'Partner-wide template', ...TEMPLATE })
+      .returning();
+    created.templates.push(row!.id);
+    return row!.id;
+  });
+
+  const ruleOrg = await withDbAccessContext(orgCtx, async () => {
+    const [row] = await db
+      .insert(alertRules)
+      .values({
+        orgId: org.id,
+        partnerId: null,
+        templateId: orgTemplate,
+        name: 'Org-owned alert rule',
+        targetType: 'org',
+        targetId: org.id,
+      })
+      .returning();
+    created.rules.push(row!.id);
+    return row!.id;
+  });
+
+  // Partner-wide rules always use targetType 'all' with targetId = partnerId
+  // (target_id is NOT NULL; the 'all' match ignores it).
+  const rulePartnerWide = await withDbAccessContext(partnerCtx, async () => {
+    const [row] = await db
+      .insert(alertRules)
+      .values({
+        orgId: null,
+        partnerId: partner.id,
+        templateId: partnerTemplate,
+        name: 'Partner-wide alert rule',
+        targetType: 'all',
+        targetId: partner.id,
+      })
+      .returning();
+    created.rules.push(row!.id);
+    return row!.id;
+  });
+
+  return {
+    partnerId: partner.id,
+    orgId: org.id,
+    automation: { orgOwnedId: automationOrg, partnerWideId: automationPartnerWide },
+    automationPolicy: { orgOwnedId: policyOrg, partnerWideId: policyPartnerWide },
+    resourceBinding: { orgOwnedId: bindingOrg, partnerWideId: bindingPartnerWide },
+    alertRule: { orgOwnedId: ruleOrg, partnerWideId: rulePartnerWide },
+    orgTemplateId: orgTemplate,
+  };
+}
+
+/**
+ * All four tables as uniform (select / update / delete / forge) descriptors, so
+ * every assertion below covers ALL of them instead of a representative sample —
+ * the per-table policies are hand-written and one omission is a silent
+ * zero-rows-forever bug on that feature only.
+ */
+function tableProbes(fixture: Fixture): Array<{
+  label: string;
+  orgOwnedId: string;
+  partnerWideId: string;
+  selectById: (id: string) => Promise<unknown[]>;
+  updateById: (id: string) => Promise<unknown[]>;
+  deleteById: (id: string) => Promise<unknown[]>;
+  forgePartnerWide: () => Promise<unknown>;
+}> {
+  return [
+    {
+      label: 'automations',
+      orgOwnedId: fixture.automation.orgOwnedId,
+      partnerWideId: fixture.automation.partnerWideId,
+      selectById: (id) => db.select({ id: automations.id }).from(automations).where(eq(automations.id, id)),
+      updateById: (id) => db.update(automations).set({ name: 'HIJACKED' }).where(eq(automations.id, id)).returning(),
+      deleteById: (id) => db.delete(automations).where(eq(automations.id, id)).returning(),
+      forgePartnerWide: () =>
+        db
+          .insert(automations)
+          .values({
+            orgId: null,
+            partnerId: fixture.partnerId,
+            name: 'Forged partner-wide automation',
+            trigger: AUTOMATION_TRIGGER,
+            actions: AUTOMATION_ACTIONS,
+          })
+          .returning(),
+    },
+    {
+      label: 'automation_policies',
+      orgOwnedId: fixture.automationPolicy.orgOwnedId,
+      partnerWideId: fixture.automationPolicy.partnerWideId,
+      selectById: (id) =>
+        db.select({ id: automationPolicies.id }).from(automationPolicies).where(eq(automationPolicies.id, id)),
+      updateById: (id) =>
+        db.update(automationPolicies).set({ name: 'HIJACKED' }).where(eq(automationPolicies.id, id)).returning(),
+      deleteById: (id) => db.delete(automationPolicies).where(eq(automationPolicies.id, id)).returning(),
+      forgePartnerWide: () =>
+        db
+          .insert(automationPolicies)
+          .values({
+            orgId: null,
+            partnerId: fixture.partnerId,
+            name: 'Forged partner-wide policy',
+            targets: POLICY_TARGETS,
+            rules: POLICY_RULES,
+          })
+          .returning(),
+    },
+    {
+      label: 'automation_resource_bindings',
+      orgOwnedId: fixture.resourceBinding.orgOwnedId,
+      partnerWideId: fixture.resourceBinding.partnerWideId,
+      selectById: (id) =>
+        db
+          .select({ id: automationResourceBindings.id })
+          .from(automationResourceBindings)
+          .where(eq(automationResourceBindings.id, id)),
+      updateById: (id) =>
+        db
+          .update(automationResourceBindings)
+          .set({ state: 'quarantined', reason: 'HIJACKED' })
+          .where(eq(automationResourceBindings.id, id))
+          .returning(),
+      deleteById: (id) =>
+        db.delete(automationResourceBindings).where(eq(automationResourceBindings.id, id)).returning(),
+      forgePartnerWide: () =>
+        db
+          .insert(automationResourceBindings)
+          .values({
+            automationId: fixture.automation.partnerWideId,
+            orgId: null,
+            partnerId: fixture.partnerId,
+            resourceKind: 'notification_channel',
+            resourceId: 'forged-partner-wide-resource',
+            expectedResourceOrgId: null,
+            expectedResourcePartnerId: fixture.partnerId,
+            expectedResourceIsSystem: false,
+          })
+          .returning(),
+    },
+    {
+      label: 'alert_rules',
+      orgOwnedId: fixture.alertRule.orgOwnedId,
+      partnerWideId: fixture.alertRule.partnerWideId,
+      selectById: (id) => db.select({ id: alertRules.id }).from(alertRules).where(eq(alertRules.id, id)),
+      updateById: (id) =>
+        db.update(alertRules).set({ name: 'HIJACKED', isActive: false }).where(eq(alertRules.id, id)).returning(),
+      deleteById: (id) => db.delete(alertRules).where(eq(alertRules.id, id)).returning(),
+      forgePartnerWide: () =>
+        db
+          .insert(alertRules)
+          .values({
+            orgId: null,
+            partnerId: fixture.partnerId,
+            templateId: fixture.orgTemplateId,
+            name: 'Forged partner-wide rule',
+            targetType: 'all',
+            targetId: fixture.partnerId,
+          })
+          .returning(),
+    },
+  ];
+}
+
+/** Read a row back under system scope (RLS bypassed) to prove it is unchanged. */
+async function reReadUnderSystem(probe: { label: string; selectById: (id: string) => Promise<unknown[]> }, id: string) {
+  return withDbAccessContext(SYSTEM_CTX, () => probe.selectById(id));
+}
+
+describe('automation + alert_rules — partner-wide SELECT branch (#4949, #4950, #4951, #4952)', () => {
+  it('an ORG session of the OWNING partner reads both its own row and the partner-wide row', async () => {
+    const fixture = await seedFixture();
+
+    const visible = await withDbAccessContext(orgContext(fixture.orgId, fixture.partnerId), async () => {
+      const results: Record<string, { orgOwned: number; partnerWide: number }> = {};
+      for (const probe of tableProbes(fixture)) {
+        results[probe.label] = {
+          orgOwned: (await probe.selectById(probe.orgOwnedId)).length,
+          partnerWide: (await probe.selectById(probe.partnerWideId)).length,
+        };
+      }
+      return results;
+    });
+
+    // Reported as one object so a failure names EVERY broken table at once
+    // instead of stopping at the first.
+    expect(visible).toEqual({
+      automations: { orgOwned: 1, partnerWide: 1 },
+      automation_policies: { orgOwned: 1, partnerWide: 1 },
+      automation_resource_bindings: { orgOwned: 1, partnerWide: 1 },
+      alert_rules: { orgOwned: 1, partnerWide: 1 },
+    });
+  });
+
+  it('an ORG session under a DIFFERENT partner sees neither row', async () => {
+    const fixture = await seedFixture();
+    const otherPartner = await createPartner();
+    const otherOrg = await createOrganization({ partnerId: otherPartner.id });
+
+    const visible = await withDbAccessContext(orgContext(otherOrg.id, otherPartner.id), async () => {
+      const results: Record<string, { orgOwned: number; partnerWide: number }> = {};
+      for (const probe of tableProbes(fixture)) {
+        results[probe.label] = {
+          orgOwned: (await probe.selectById(probe.orgOwnedId)).length,
+          partnerWide: (await probe.selectById(probe.partnerWideId)).length,
+        };
+      }
+      return results;
+    });
+
+    expect(visible).toEqual({
+      automations: { orgOwned: 0, partnerWide: 0 },
+      automation_policies: { orgOwned: 0, partnerWide: 0 },
+      automation_resource_bindings: { orgOwned: 0, partnerWide: 0 },
+      alert_rules: { orgOwned: 0, partnerWide: 0 },
+    });
+  });
+
+  // The branch keys on `partner_id = breeze_current_partner_id()`. A NULL GUC
+  // must never match, which is what rules out `IS NOT DISTINCT FROM` — under
+  // that operator every session with an unset partner GUC would read EVERY
+  // partner's shared rows. The org-owned row stays visible here; only the
+  // partner-wide one must not.
+  //
+  // NB this is NOT the agent shape: `middleware/agentAuth.ts` sets
+  // `currentPartnerId: device.partnerId` (#4673 W02), so a real agent session
+  // DOES get the branch — that is the whole point of it on these tables
+  // (buildPolicyProbeConfigUpdate's partner-wide automation_policies read on
+  // the heartbeat path). This case covers contexts that leave the GUC unset.
+  it('a session with no currentPartnerId (NULL GUC) sees no partner-wide row', async () => {
+    const fixture = await seedFixture();
+
+    const visible = await withDbAccessContext(orgContext(fixture.orgId, null), async () => {
+      const results: Record<string, { orgOwned: number; partnerWide: number }> = {};
+      for (const probe of tableProbes(fixture)) {
+        results[probe.label] = {
+          orgOwned: (await probe.selectById(probe.orgOwnedId)).length,
+          partnerWide: (await probe.selectById(probe.partnerWideId)).length,
+        };
+      }
+      return results;
+    });
+
+    expect(visible).toEqual({
+      automations: { orgOwned: 1, partnerWide: 0 },
+      automation_policies: { orgOwned: 1, partnerWide: 0 },
+      automation_resource_bindings: { orgOwned: 1, partnerWide: 0 },
+      alert_rules: { orgOwned: 1, partnerWide: 0 },
+    });
+  });
+
+  it('the OWNING partner session still reads and writes its partner-wide rows', async () => {
+    const fixture = await seedFixture();
+    const ctx = partnerContext(fixture.partnerId, [fixture.orgId]);
+
+    const visible = await withDbAccessContext(ctx, async () => {
+      const results: Record<string, number> = {};
+      for (const probe of tableProbes(fixture)) {
+        results[probe.label] = (await probe.selectById(probe.partnerWideId)).length;
+      }
+      return results;
+    });
+    expect(visible).toEqual({
+      automations: 1,
+      automation_policies: 1,
+      automation_resource_bindings: 1,
+      alert_rules: 1,
+    });
+
+    const updated = await withDbAccessContext(ctx, () =>
+      db
+        .update(automations)
+        .set({ name: 'Renamed by owning partner' })
+        .where(eq(automations.id, fixture.automation.partnerWideId))
+        .returning(),
+    );
+    expect(updated).toHaveLength(1);
+  });
+
+  describe('the read branch grants NO write', () => {
+    it('an ORG session of the owning partner cannot UPDATE or DELETE the partner-wide rows', async () => {
+      const fixture = await seedFixture();
+      const probes = tableProbes(fixture);
+      const ctx = orgContext(fixture.orgId, fixture.partnerId);
+
+      const affected: Record<string, { updated: number; deleted: number }> = {};
+      for (const probe of probes) {
+        const updated = await withDbAccessContext(ctx, () => probe.updateById(probe.partnerWideId));
+        const deleted = await withDbAccessContext(ctx, () => probe.deleteById(probe.partnerWideId));
+        affected[probe.label] = { updated: updated.length, deleted: deleted.length };
+      }
+
+      expect(affected).toEqual({
+        automations: { updated: 0, deleted: 0 },
+        automation_policies: { updated: 0, deleted: 0 },
+        automation_resource_bindings: { updated: 0, deleted: 0 },
+        alert_rules: { updated: 0, deleted: 0 },
+      });
+
+      // Zero rows affected is only half the proof: re-read under system scope
+      // (RLS bypassed) and confirm every partner-wide row is still there and
+      // untouched.
+      const stillThere: Record<string, number> = {};
+      for (const probe of probes) {
+        stillThere[probe.label] = (await reReadUnderSystem(probe, probe.partnerWideId)).length;
+      }
+      expect(stillThere).toEqual({
+        automations: 1,
+        automation_policies: 1,
+        automation_resource_bindings: 1,
+        alert_rules: 1,
+      });
+
+      const names = await withDbAccessContext(SYSTEM_CTX, async () => ({
+        automation: (await db.select({ name: automations.name }).from(automations).where(eq(automations.id, fixture.automation.partnerWideId)))[0]?.name,
+        policy: (await db.select({ name: automationPolicies.name }).from(automationPolicies).where(eq(automationPolicies.id, fixture.automationPolicy.partnerWideId)))[0]?.name,
+        bindingState: (await db.select({ state: automationResourceBindings.state }).from(automationResourceBindings).where(eq(automationResourceBindings.id, fixture.resourceBinding.partnerWideId)))[0]?.state,
+        rule: (await db.select({ name: alertRules.name, isActive: alertRules.isActive }).from(alertRules).where(eq(alertRules.id, fixture.alertRule.partnerWideId)))[0],
+      }));
+      expect(names).toEqual({
+        automation: 'Partner-wide automation',
+        policy: 'Partner-wide automation policy',
+        bindingState: 'active',
+        rule: { name: 'Partner-wide alert rule', isActive: true },
+      });
+
+      // The org-owned rows are still writable — the branch did not freeze the
+      // table's ordinary org path.
+      const orgOwnedUpdate = await withDbAccessContext(ctx, () =>
+        db.update(automations).set({ name: 'Org rename' }).where(eq(automations.id, fixture.automation.orgOwnedId)).returning(),
+      );
+      expect(orgOwnedUpdate).toHaveLength(1);
+    });
+
+    // WITH CHECK (unlike USING) raises rather than filters, so an INSERT forge
+    // is where the write denial is observable as an error — and where a branch
+    // accidentally appended to a FOR ALL policy would show up.
+    it('an ORG session cannot INSERT a partner-wide row for its own partner (42501)', async () => {
+      const fixture = await seedFixture();
+
+      for (const probe of tableProbes(fixture)) {
+        await expectSqlState(
+          () => withDbAccessContext(orgContext(fixture.orgId, fixture.partnerId), () => probe.forgePartnerWide()),
+          '42501',
+        );
+      }
+    });
+  });
+});

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -643,13 +643,6 @@ const PARTNER_WIDE_SELECT_BRANCH_EXEMPT: ReadonlyMap<string, string> = new Map<s
   ['ai_agent_schedules', 'TODO(#4943): no breeze_current_partner_id() SELECT branch yet.'],
   ['custom_field_definitions', 'TODO(#4944): no breeze_current_partner_id() SELECT branch yet.'],
   ['client_ai_prompt_templates', 'TODO(#4945): no breeze_current_partner_id() SELECT branch yet.'],
-  ['alert_rules', 'TODO(#4949): no breeze_current_partner_id() SELECT branch yet.'],
-  // Known gap found during W03 of #4673: automation_policies is read by
-  // buildPolicyProbeConfigUpdate, which is exactly why that resolver still
-  // escalates via the #1105 pattern instead of reading through RLS.
-  ['automation_policies', 'TODO(#4950): no breeze_current_partner_id() SELECT branch yet.'],
-  ['automation_resource_bindings', 'TODO(#4951): no breeze_current_partner_id() SELECT branch yet.'],
-  ['automations', 'TODO(#4952): no breeze_current_partner_id() SELECT branch yet.'],
 ]);
 
 // Enforced shrink-only ratchet for PARTNER_WIDE_SELECT_BRANCH_EXEMPT (mirrors
@@ -661,16 +654,12 @@ const PARTNER_WIDE_SELECT_BRANCH_EXEMPT: ReadonlyMap<string, string> = new Map<s
 // follow-up issue, not a free ride into an already-frozen exemption. Both
 // constants are asserted by 'the partner-wide SELECT branch exemption map
 // only shrinks' below.
-const PARTNER_WIDE_SELECT_BRANCH_EXEMPT_CEILING = 8;
+const PARTNER_WIDE_SELECT_BRANCH_EXEMPT_CEILING = 4;
 const PARTNER_WIDE_SELECT_BRANCH_EXEMPT_FROZEN_NAMES: ReadonlySet<string> = new Set<string>([
   'ai_agents',
   'ai_agent_schedules',
   'custom_field_definitions',
   'client_ai_prompt_templates',
-  'alert_rules',
-  'automation_policies',
-  'automation_resource_bindings',
-  'automations',
 ]);
 
 // Tables that carry a `device_id` FK but no denormalized `org_id`. Their

--- a/apps/api/src/routes/alerts/helpers.partnerWideRuleScope.test.ts
+++ b/apps/api/src/routes/alerts/helpers.partnerWideRuleScope.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// #4952 — getAlertRuleWithOrgCheck granted access to a partner-wide alert rule
+// (org_id NULL, #2128) on `rule.partnerId === auth.partnerId` alone. Org tokens
+// carry a partnerId too (`middleware/auth.ts` feeds it into
+// DbAccessContext.currentPartnerId), so every by-id alert-rule path — GET
+// /alerts/rules/:id, POST /alerts/rules/:id/test, and the PUT/PATCH/DELETE
+// gates that load through this helper — disclosed the partner's partner-wide
+// rules to plain org users.
+//
+// Before the partner-wide SELECT branch landed, RLS hid those rows from an org
+// context and masked the app-layer bug. The branch makes them readable, so the
+// scope gate is now the whole control. It also makes the by-id paths agree with
+// GET /alerts/rules, whose partner-wide arm is already partner-scope only.
+
+const selectMock = vi.fn();
+vi.mock('../../db', () => ({
+  db: { select: (...args: unknown[]) => selectMock(...args) },
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../../db/schema', () => ({
+  alertRules: { id: 'id', orgId: 'orgId', partnerId: 'partnerId' },
+  alertTemplates: {},
+  alerts: {},
+  devices: {},
+  notificationChannels: {},
+  escalationPolicies: {},
+  organizations: { id: 'id', partnerId: 'partnerId' },
+  partners: { id: 'id' },
+}));
+
+vi.mock('../../middleware/auth', () => ({ siteAccessCheck: vi.fn(() => true) }));
+vi.mock('../../services/alertConditions', () => ({ retiredConditionTypeError: vi.fn(() => null) }));
+vi.mock('../../services/notificationSenders', () => ({
+  validateEmailConfig: vi.fn(),
+  validateWebhookConfig: vi.fn(),
+  validateSmsConfig: vi.fn(),
+  validatePagerDutyConfig: vi.fn(),
+  validatePushoverConfig: vi.fn(),
+}));
+
+import { getAlertRuleWithOrgCheck } from './helpers';
+
+const ORG_ID = '11111111-1111-1111-1111-111111111111';
+const PARTNER_ID = '33333333-3333-3333-3333-333333333333';
+const OTHER_PARTNER_ID = '44444444-4444-4444-4444-444444444444';
+const RULE_ID = '5d4c3b2a-1111-4222-8333-444455556666';
+
+const PARTNER_WIDE_RULE = { id: RULE_ID, orgId: null, partnerId: PARTNER_ID, name: 'Partner-wide rule' };
+const ORG_OWNED_RULE = { id: RULE_ID, orgId: ORG_ID, partnerId: null, name: 'Org rule' };
+
+function returnRule(rule: unknown) {
+  selectMock.mockImplementation(() => {
+    const chain: Record<string, unknown> = {};
+    const step = () => chain;
+    chain.from = step;
+    chain.where = step;
+    chain.limit = () => Promise.resolve(rule ? [rule] : []);
+    return chain;
+  });
+}
+
+/** An org token: real partnerId, org scope, org-only canAccessOrg. */
+const orgAuth = {
+  scope: 'organization',
+  partnerId: PARTNER_ID,
+  canAccessOrg: (orgId: string) => orgId === ORG_ID,
+};
+
+beforeEach(() => {
+  selectMock.mockReset();
+});
+
+describe('getAlertRuleWithOrgCheck partner-wide scope gate (#4952)', () => {
+  it('hides a partner-wide rule from an ORG token that carries the same partnerId', async () => {
+    returnRule(PARTNER_WIDE_RULE);
+    await expect(getAlertRuleWithOrgCheck(RULE_ID, orgAuth)).resolves.toBeNull();
+  });
+
+  it('hides a partner-wide rule from a PARTNER token of a different partner', async () => {
+    returnRule(PARTNER_WIDE_RULE);
+    await expect(
+      getAlertRuleWithOrgCheck(RULE_ID, {
+        scope: 'partner',
+        partnerId: OTHER_PARTNER_ID,
+        canAccessOrg: () => true,
+      })
+    ).resolves.toBeNull();
+  });
+
+  it('returns a partner-wide rule to a PARTNER token of the owning partner', async () => {
+    returnRule(PARTNER_WIDE_RULE);
+    await expect(
+      getAlertRuleWithOrgCheck(RULE_ID, {
+        scope: 'partner',
+        partnerId: PARTNER_ID,
+        canAccessOrg: () => true,
+      })
+    ).resolves.toEqual(PARTNER_WIDE_RULE);
+  });
+
+  it('returns a partner-wide rule to a SYSTEM token', async () => {
+    returnRule(PARTNER_WIDE_RULE);
+    await expect(
+      getAlertRuleWithOrgCheck(RULE_ID, { scope: 'system', partnerId: null, canAccessOrg: () => true })
+    ).resolves.toEqual(PARTNER_WIDE_RULE);
+  });
+
+  it('still returns an ORG-OWNED rule to the owning org token', async () => {
+    returnRule(ORG_OWNED_RULE);
+    await expect(getAlertRuleWithOrgCheck(RULE_ID, orgAuth)).resolves.toEqual(ORG_OWNED_RULE);
+  });
+
+  it('returns null when the rule does not exist', async () => {
+    returnRule(null);
+    await expect(getAlertRuleWithOrgCheck(RULE_ID, orgAuth)).resolves.toBeNull();
+  });
+});

--- a/apps/api/src/routes/alerts/helpers.ts
+++ b/apps/api/src/routes/alerts/helpers.ts
@@ -20,6 +20,7 @@ import {
   validatePagerDutyConfig,
   validatePushoverConfig,
 } from '../../services/notificationSenders';
+import { canReadPartnerWideRows } from '../../services/partnerWideAccess';
 
 export type AlertRuleRow = typeof alertRules.$inferSelect;
 export type AlertTemplateRow = typeof alertTemplates.$inferSelect;
@@ -113,11 +114,21 @@ export async function getAlertRuleWithOrgCheck(
   }
 
   // Dual-axis access (#2128): org-owned rules via org access; partner-wide
-  // rules (orgId NULL) via the caller's own partner (or system scope). Writes
-  // are additionally gated on canManagePartnerWidePolicies at the routes.
+  // rules (orgId NULL) only for system scope or the owning partner's own
+  // PARTNER-scoped token.
+  //
+  // Org tokens carry a partnerId too (`middleware/auth.ts` feeds it into
+  // DbAccessContext.currentPartnerId), so matching on partnerId alone handed
+  // every partner-wide rule to every org user under that partner. RLS is not a
+  // backstop here: alert_rules' partner-wide SELECT branch deliberately makes
+  // those rows readable from an org context, so this gate is the whole control
+  // (#4952). It also makes the by-id paths agree with the list route, which
+  // already restricts the partner-wide arm to `auth.scope === 'partner'`
+  // (`rules.ts` GET /alerts/rules). Writes are additionally gated on
+  // canManagePartnerWidePolicies at the routes.
   const hasAccess = rule.orgId !== null
     ? ensureOrgAccess(rule.orgId, auth)
-    : auth.scope === 'system' || (!!auth.partnerId && rule.partnerId === auth.partnerId);
+    : canReadPartnerWideRows({ scope: auth.scope ?? '', partnerId: auth.partnerId ?? null }, rule.partnerId);
   if (!hasAccess) {
     return null;
   }

--- a/apps/api/src/routes/policyManagement/actions.partnerWideAutomation.test.ts
+++ b/apps/api/src/routes/policyManagement/actions.partnerWideAutomation.test.ts
@@ -1,0 +1,307 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+// #4952 — cross-tenant automation execution through policy remediation.
+//
+// Automations are dual-owned (org_id XOR partner_id, #2133). Both policy
+// action routes resolved the remediation automation with a dual-axis
+// condition — `org_id = <policy org> OR (org_id IS NULL AND partner_id =
+// <that org's partner>)` — that was NOT gated on the CALLER's scope. Org
+// tokens carry a partnerId (`middleware/auth.ts` feeds it into
+// DbAccessContext.currentPartnerId), so the arm matched for a plain org user.
+//
+// RLS used to compensate by making partner-wide automation rows invisible to
+// an org context. This PR's partner-wide SELECT branch deliberately makes them
+// readable (it is load-bearing for agent config delivery), which turns the
+// latent app-layer hole into a live one — so these gates are now the only
+// control on the partner axis for these routes.
+//
+// Blast radius on /remediate: the run is enqueued with NO target argument, so
+// `automationRuntime` expands a partner-wide automation across EVERY org under
+// the partner. An org admin holding `devices:write` on their own org-owned
+// policy could therefore run a script on other tenants' devices.
+
+const ORG_ID = '11111111-1111-1111-1111-111111111111';
+const PARTNER_ID = '33333333-3333-3333-3333-333333333333';
+const OTHER_PARTNER_ID = '44444444-4444-4444-4444-444444444444';
+const POLICY_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const AUTOMATION_ID = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+const RUN_ID = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee';
+
+const enqueueAutomationRunMock = vi.fn().mockResolvedValue({ enqueued: true });
+vi.mock('../../jobs/automationWorker', () => ({
+  enqueueAutomationRun: (...args: unknown[]) => enqueueAutomationRunMock(...args),
+}));
+
+vi.mock('../../services', () => ({}));
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+
+const evaluatePolicyMock = vi.fn().mockResolvedValue({
+  policyId: POLICY_ID,
+  devicesEvaluated: 1,
+  summary: { compliant: 1, non_compliant: 0 },
+  evaluatedAt: new Date('2026-10-11').toISOString(),
+});
+const resolveRemediationIdMock = vi.fn().mockResolvedValue(AUTOMATION_ID);
+vi.mock('../../services/policyEvaluationService', () => ({
+  evaluatePolicy: (...args: unknown[]) => evaluatePolicyMock(...args),
+  resolvePolicyRemediationAutomationId: (...args: unknown[]) => resolveRemediationIdMock(...args),
+}));
+
+const selectMock = vi.fn();
+const insertMock = vi.fn();
+const updateMock = vi.fn();
+vi.mock('../../db', () => ({
+  db: {
+    select: (...args: unknown[]) => selectMock(...args),
+    insert: (...args: unknown[]) => insertMock(...args),
+    update: (...args: unknown[]) => updateMock(...args),
+    delete: vi.fn(),
+  },
+  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../../db/schema', () => ({
+  automationPolicies: { id: 'id', orgId: 'orgId', partnerId: 'partnerId' },
+  automationRuns: { id: 'id', status: 'status', startedAt: 'startedAt' },
+  automations: {
+    id: 'id',
+    orgId: 'orgId',
+    partnerId: 'partnerId',
+    enabled: 'enabled',
+    runCount: 'runCount',
+    lastRunAt: 'lastRunAt',
+    updatedAt: 'updatedAt',
+  },
+  organizations: { id: 'id', partnerId: 'partnerId', type: 'type' },
+}));
+
+let currentAuth: Record<string, unknown>;
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn((c: any, next: any) => {
+    c.set('auth', currentAuth);
+    return next();
+  }),
+  requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
+}));
+
+import { actionRoutes } from './actions';
+import { authMiddleware } from '../../middleware/auth';
+
+/** Queue results for the successive `.select()` chains the route performs. */
+function queueSelects(...results: unknown[][]) {
+  const queue = [...results];
+  selectMock.mockImplementation(() => {
+    const chain: Record<string, unknown> = {};
+    const step = () => chain;
+    chain.from = step;
+    chain.where = step;
+    chain.limit = () => Promise.resolve(queue.shift() ?? []);
+    chain.then = (resolve: (v: unknown) => unknown) => resolve(queue.shift() ?? []);
+    return chain;
+  });
+}
+
+const ORG_OWNED_POLICY = {
+  id: POLICY_ID,
+  orgId: ORG_ID,
+  partnerId: null,
+  name: 'Org policy',
+  enabled: true,
+  enforcement: 'enforce',
+  rules: [{ type: 'required_software', softwareName: 'Chrome' }],
+  remediationScriptId: null,
+};
+
+/** A partner-wide automation (org_id NULL) owned by the org's own partner. */
+const PARTNER_WIDE_AUTOMATION = {
+  id: AUTOMATION_ID,
+  orgId: null,
+  partnerId: PARTNER_ID,
+  enabled: true,
+  managedByAgentId: null,
+  name: 'Partner-wide remediation',
+};
+
+function orgScopedAuth() {
+  return {
+    user: { id: 'user-org', email: 'org@example.com', name: 'Org User' },
+    scope: 'organization',
+    orgId: ORG_ID,
+    // Org tokens DO carry the partner id — that is exactly why matching on it
+    // alone is not an authorization decision.
+    partnerId: PARTNER_ID,
+    partnerOrgAccess: null,
+    accessibleOrgIds: [ORG_ID],
+    canAccessOrg: (orgId: string) => orgId === ORG_ID,
+  };
+}
+
+function partnerScopedAuth(partnerId = PARTNER_ID) {
+  return {
+    user: { id: 'user-partner', email: 'partner@example.com', name: 'Partner User' },
+    scope: 'partner',
+    orgId: null,
+    partnerId,
+    partnerOrgAccess: 'all',
+    accessibleOrgIds: [ORG_ID],
+    canAccessOrg: (orgId: string) => orgId === ORG_ID,
+  };
+}
+
+function makeApp() {
+  const app = new Hono();
+  app.use('*', authMiddleware as never);
+  app.route('/policies', actionRoutes);
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  selectMock.mockReset();
+  insertMock.mockReset();
+  updateMock.mockReset();
+  enqueueAutomationRunMock.mockClear();
+  resolveRemediationIdMock.mockResolvedValue(AUTOMATION_ID);
+  evaluatePolicyMock.mockResolvedValue({
+    policyId: POLICY_ID,
+    devicesEvaluated: 1,
+    summary: { compliant: 1, non_compliant: 0 },
+    evaluatedAt: new Date('2026-10-11').toISOString(),
+  });
+  insertMock.mockReturnValue({
+    values: () => ({
+      returning: () => Promise.resolve([{ id: RUN_ID, status: 'running', startedAt: new Date() }]),
+    }),
+  });
+  updateMock.mockReturnValue({ set: () => ({ where: () => Promise.resolve(undefined) }) });
+  currentAuth = orgScopedAuth();
+});
+
+describe('POST /policies/:id/remediate — partner-wide automation visibility (#4952)', () => {
+  it('404s for an ORG-scoped caller whose policy points at a partner-wide automation', async () => {
+    currentAuth = orgScopedAuth();
+    queueSelects(
+      [ORG_OWNED_POLICY],            // getPolicyWithOrgCheck
+      [{ partnerId: PARTNER_ID }],   // the policy org's partner
+      [PARTNER_WIDE_AUTOMATION],     // the automation the (ungated) query returned
+    );
+
+    const res = await makeApp().request(`/policies/${POLICY_ID}/remediate`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(404);
+    // Never enqueued: no run may exist for an automation the caller cannot see.
+    expect(insertMock).not.toHaveBeenCalled();
+    expect(enqueueAutomationRunMock).not.toHaveBeenCalled();
+  });
+
+  it('404s for a PARTNER-scoped caller from a different partner', async () => {
+    currentAuth = partnerScopedAuth(OTHER_PARTNER_ID);
+    queueSelects(
+      [ORG_OWNED_POLICY],
+      [{ partnerId: PARTNER_ID }],
+      [PARTNER_WIDE_AUTOMATION],
+    );
+
+    const res = await makeApp().request(`/policies/${POLICY_ID}/remediate`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(404);
+    expect(enqueueAutomationRunMock).not.toHaveBeenCalled();
+  });
+
+  it('runs for a PARTNER-scoped caller of the owning partner', async () => {
+    currentAuth = partnerScopedAuth(PARTNER_ID);
+    queueSelects(
+      [ORG_OWNED_POLICY],
+      [{ partnerId: PARTNER_ID }],
+      [PARTNER_WIDE_AUTOMATION],
+    );
+
+    const res = await makeApp().request(`/policies/${POLICY_ID}/remediate`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ automationId: AUTOMATION_ID });
+    expect(enqueueAutomationRunMock).toHaveBeenCalledWith(RUN_ID);
+  });
+
+  it('still runs for an ORG-scoped caller against an ORG-OWNED automation', async () => {
+    currentAuth = orgScopedAuth();
+    queueSelects(
+      [ORG_OWNED_POLICY],
+      [{ partnerId: PARTNER_ID }],
+      [{ ...PARTNER_WIDE_AUTOMATION, orgId: ORG_ID, partnerId: null }],
+    );
+
+    const res = await makeApp().request(`/policies/${POLICY_ID}/remediate`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(enqueueAutomationRunMock).toHaveBeenCalledWith(RUN_ID);
+  });
+});
+
+describe('POST /policies/:id/evaluate — caller identity reaches the remediation lookup (#4952)', () => {
+  it('threads the ORG caller auth into evaluatePolicy so the partner-wide arm is gated', async () => {
+    currentAuth = orgScopedAuth();
+    queueSelects([ORG_OWNED_POLICY]);
+
+    const res = await makeApp().request(`/policies/${POLICY_ID}/evaluate`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(evaluatePolicyMock).toHaveBeenCalledTimes(1);
+    const [, options] = evaluatePolicyMock.mock.calls[0] as [unknown, { auth?: { scope?: string } }];
+    // Without this the service defaults to the worker's system visibility and
+    // resolves partner-wide automations for an org caller.
+    expect(options.auth).toBeTruthy();
+    expect(options.auth?.scope).toBe('organization');
+  });
+
+  it('threads the PARTNER caller auth through as partner scope', async () => {
+    currentAuth = partnerScopedAuth(PARTNER_ID);
+    queueSelects([ORG_OWNED_POLICY]);
+
+    const res = await makeApp().request(`/policies/${POLICY_ID}/evaluate`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(200);
+    const [, options] = evaluatePolicyMock.mock.calls[0] as [
+      unknown,
+      { auth?: { scope?: string; partnerId?: string | null } },
+    ];
+    expect(options.auth?.scope).toBe('partner');
+    expect(options.auth?.partnerId).toBe(PARTNER_ID);
+  });
+
+  it('passes the caller auth to resolvePolicyRemediationAutomationId on remediate', async () => {
+    currentAuth = orgScopedAuth();
+    queueSelects([ORG_OWNED_POLICY], [{ partnerId: PARTNER_ID }], []);
+
+    await makeApp().request(`/policies/${POLICY_ID}/remediate`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(resolveRemediationIdMock).toHaveBeenCalledTimes(1);
+    const [, passedAuth] = resolveRemediationIdMock.mock.calls[0] as [unknown, { scope?: string }];
+    expect(passedAuth?.scope).toBe('organization');
+  });
+});

--- a/apps/api/src/routes/policyManagement/actions.ts
+++ b/apps/api/src/routes/policyManagement/actions.ts
@@ -7,6 +7,7 @@ import { requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
 import {
   canManagePartnerWidePolicies,
+  canReadPartnerWideRows,
   PARTNER_WIDE_WRITE_DENIED_MESSAGE,
 } from '../../services/partnerWideAccess';
 import {
@@ -146,6 +147,10 @@ actionRoutes.post(
     const result = await evaluatePolicy(policy, {
       source: 'policies-route',
       requestRemediation: true,
+      // Runs in the CALLER's context, so the remediation-automation lookup must
+      // apply the caller's partner-wide visibility rather than the worker's
+      // system visibility (#4952).
+      auth,
     });
 
     writeRouteAudit(c, {
@@ -182,7 +187,7 @@ actionRoutes.post(
       return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
     }
 
-    const targetAutomationId = await resolvePolicyRemediationAutomationId(policy);
+    const targetAutomationId = await resolvePolicyRemediationAutomationId(policy, auth);
     if (!targetAutomationId) {
       return c.json({
         error: 'No remediation automation is configured on this policy',
@@ -195,6 +200,19 @@ actionRoutes.post(
     // partner-wide policy (org_id NULL, #2129) accepts an explicit automation
     // from any org under the owning partner OR the partner's own
     // partner-wide automations.
+    //
+    // The partner-wide arm is gated on canReadPartnerWideRows (#4952). This
+    // route enqueues with NO target argument, so automationRuntime expands a
+    // partner-wide automation across every org under the partner: without the
+    // gate an org admin holding devices:write on an org-owned policy could run
+    // an automation against OTHER orgs' devices.
+    //
+    // RLS does not backstop this. Org tokens carry a partnerId
+    // (DbAccessContext.currentPartnerId), and automations' partner-wide SELECT
+    // branch deliberately makes those rows readable from an org context, so
+    // this gate is the whole control — mirrors canAccessAutomation in
+    // routes/automations.ts, which already restricts the same rows to partner
+    // and system scope.
     let automationOwnerCondition;
     if (policy.orgId) {
       const [policyOrg] = await db
@@ -202,26 +220,34 @@ actionRoutes.post(
         .from(organizations)
         .where(eq(organizations.id, policy.orgId))
         .limit(1);
-      automationOwnerCondition = policyOrg?.partnerId
+      const partnerWideVisible = canReadPartnerWideRows(auth, policyOrg?.partnerId ?? null);
+      automationOwnerCondition = policyOrg?.partnerId && partnerWideVisible
         ? or(
             eq(automations.orgId, policy.orgId),
             and(isNull(automations.orgId), eq(automations.partnerId, policyOrg.partnerId))
           )
         : eq(automations.orgId, policy.orgId);
     } else {
-      automationOwnerCondition = or(
-        inArray(
-          automations.orgId,
-          db
-            .select({ id: organizations.id })
-            .from(organizations)
-            // The hidden 'quick_support' org never owns automations — keep it out
-            // of the partner-wide ownership set. (The by-id lookup above is left
-            // alone; it resolves one known org.)
-            .where(and(eq(organizations.partnerId, policy.partnerId ?? ''), ne(organizations.type, 'quick_support')))
-        ),
-        and(isNull(automations.orgId), eq(automations.partnerId, policy.partnerId ?? ''))
+      // A partner-wide policy already required partner-wide administration
+      // above (partnerWideWriteDenied), so the caller is system or a full
+      // partner admin; assert the partner match anyway rather than trusting a
+      // second gate to have run.
+      const orgOwnedArm = inArray(
+        automations.orgId,
+        db
+          .select({ id: organizations.id })
+          .from(organizations)
+          // The hidden 'quick_support' org never owns automations — keep it out
+          // of the partner-wide ownership set. (The by-id lookup above is left
+          // alone; it resolves one known org.)
+          .where(and(eq(organizations.partnerId, policy.partnerId ?? ''), ne(organizations.type, 'quick_support')))
       );
+      automationOwnerCondition = canReadPartnerWideRows(auth, policy.partnerId)
+        ? or(
+            orgOwnedArm,
+            and(isNull(automations.orgId), eq(automations.partnerId, policy.partnerId ?? ''))
+          )
+        : orgOwnedArm;
     }
 
     const [automation] = await db
@@ -236,6 +262,15 @@ actionRoutes.post(
       .limit(1);
 
     if (!automation) {
+      return c.json({ error: 'Remediation automation not found for this organization' }, 404);
+    }
+
+    // Defense in depth on the loaded row (#4952). The WHERE above already
+    // drops the partner-wide arm for a caller that may not read it, but this
+    // route is the fleet-fan-out path — re-check the row itself so a future
+    // edit to the condition builder cannot silently reopen it. 404, not 403:
+    // no oracle distinguishing "absent" from "another tenant's".
+    if (automation.orgId === null && !canReadPartnerWideRows(auth, automation.partnerId)) {
       return c.json({ error: 'Remediation automation not found for this organization' }, 404);
     }
 

--- a/apps/api/src/services/partnerWideAccess.ts
+++ b/apps/api/src/services/partnerWideAccess.ts
@@ -38,3 +38,48 @@ export class PartnerWideWriteDeniedError extends Error {
     this.name = 'PartnerWideWriteDeniedError';
   }
 }
+
+/**
+ * Identity a partner-wide READ gate needs. Deliberately structural (scope as a
+ * plain string) so route-local AuthContext shapes — e.g.
+ * `routes/policyManagement/schemas.ts` — can pass without a cast.
+ */
+export type PartnerWideReadAuth = {
+  scope: string;
+  partnerId: string | null;
+};
+
+/**
+ * True when `auth` may READ partner-wide rows (org_id NULL) owned by
+ * `ownerPartnerId`.
+ *
+ * Org-scoped tokens carry a partnerId (`middleware/auth.ts` feeds it into
+ * `DbAccessContext.currentPartnerId` for every org user), so an app-layer
+ * condition of the shape `org_id IS NULL AND partner_id = auth.partnerId`
+ * matches for a plain org user. RLS does NOT catch that: the partner-wide
+ * SELECT branch (`org_id IS NULL AND partner_id =
+ * breeze_current_partner_id()`) deliberately makes those rows readable from an
+ * org context — it is load-bearing for agent config delivery. On background
+ * worker paths the read is system-scoped and unfiltered anyway.
+ *
+ * So on these paths the app-layer gate is the ONLY authorization control on
+ * the partner axis, not a redundant second one (#4952). Use it wherever a
+ * dual-axis read decides what a caller may act on, and mirror it on the loaded
+ * row where the consequence is execution rather than display.
+ *
+ * `null`/absent auth means "no request identity" — the background/system path,
+ * which is genuinely allowed to see partner-wide rows.
+ */
+export function canReadPartnerWideRows(
+  auth: PartnerWideReadAuth | null | undefined,
+  ownerPartnerId: string | null | undefined
+): boolean {
+  if (!auth) return true;
+  if (auth.scope === 'system') return true;
+  return (
+    auth.scope === 'partner' &&
+    !!auth.partnerId &&
+    !!ownerPartnerId &&
+    auth.partnerId === ownerPartnerId
+  );
+}

--- a/apps/api/src/services/policyEvaluationPartnerWideAutomation.test.ts
+++ b/apps/api/src/services/policyEvaluationPartnerWideAutomation.test.ts
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// #4952 — the /policies/:id/evaluate arm of the cross-tenant automation hole.
+//
+// evaluatePolicy runs BOTH on the background worker (system-scoped, genuinely
+// allowed to resolve partner-wide automations) and inside the request that
+// POSTs /policies/:id/evaluate. RLS is not the filter on either: the worker is
+// system-scoped, and in the request path this PR's partner-wide SELECT branch
+// makes partner-wide automation rows readable from an org context too. So the
+// app-layer dual-axis arm `org_id IS NULL AND partner_id = <device org's
+// partner>` IS the access check. Ungated, it let an ORG caller trigger another
+// tenant's partner-wide automation (one run per evaluated device, versus the
+// fleet-wide fan-out on /remediate).
+
+const enqueueAutomationRunMock = vi.fn().mockResolvedValue({ enqueued: true });
+vi.mock('../jobs/automationWorker', () => ({
+  enqueueAutomationRun: (...args: unknown[]) => enqueueAutomationRunMock(...args),
+}));
+
+const selectMock = vi.fn();
+const insertMock = vi.fn();
+const updateMock = vi.fn();
+vi.mock('../db', () => ({
+  db: {
+    select: (...args: unknown[]) => selectMock(...args),
+    insert: (...args: unknown[]) => insertMock(...args),
+    update: (...args: unknown[]) => updateMock(...args),
+  },
+}));
+
+vi.mock('./eventBus', () => ({ publishEvent: vi.fn() }));
+vi.mock('./featureConfigResolver', () => ({
+  resolveComplianceRulesForDevice: vi.fn(),
+  scanDueComplianceChecks: vi.fn(),
+}));
+
+import {
+  __triggerRemediationAutomation,
+  resolvePolicyRemediationAutomationIdForOrg,
+} from './policyEvaluationService';
+
+const ORG_ID = 'oooooooo-oooo-oooo-oooo-oooooooooooo';
+const PARTNER_ID = 'pppppppp-pppp-pppp-pppp-pppppppppppp';
+const OTHER_PARTNER_ID = 'qqqqqqqq-qqqq-qqqq-qqqq-qqqqqqqqqqqq';
+const AUTOMATION_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const RUN_ID = 'rrrrrrrr-rrrr-rrrr-rrrr-rrrrrrrrrrrr';
+const SCRIPT_ID = 'ssssssss-ssss-ssss-ssss-ssssssssssss';
+
+const DEVICE = {
+  id: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+  orgId: ORG_ID,
+  hostname: 'WS-1',
+  osType: 'windows',
+  osVersion: '10.0.19045',
+};
+
+/** A partner-wide automation row (org_id NULL) owned by the device org's partner. */
+const PARTNER_WIDE_AUTOMATION = {
+  id: AUTOMATION_ID,
+  orgId: null,
+  partnerId: PARTNER_ID,
+  enabled: true,
+  managedByAgentId: null,
+};
+
+const ORG_SCOPED_AUTH = { scope: 'organization', partnerId: PARTNER_ID };
+const PARTNER_SCOPED_AUTH = { scope: 'partner', partnerId: PARTNER_ID };
+const FOREIGN_PARTNER_AUTH = { scope: 'partner', partnerId: OTHER_PARTNER_ID };
+
+/** Queue results for the successive `.select()` chains each call performs. */
+function queueSelects(...results: unknown[][]) {
+  const queue = [...results];
+  selectMock.mockImplementation(() => {
+    const chain: Record<string, unknown> = {};
+    const step = () => chain;
+    chain.from = step;
+    chain.where = step;
+    chain.limit = () => Promise.resolve(queue.shift() ?? []);
+    chain.then = (resolve: (v: unknown) => unknown) => resolve(queue.shift() ?? []);
+    return chain;
+  });
+}
+
+beforeEach(() => {
+  selectMock.mockReset();
+  insertMock.mockReset();
+  updateMock.mockReset();
+  enqueueAutomationRunMock.mockClear();
+  insertMock.mockReturnValue({
+    values: () => ({ returning: () => Promise.resolve([{ id: RUN_ID, logs: [] }]) }),
+  });
+  updateMock.mockReturnValue({ set: () => ({ where: () => Promise.resolve(undefined) }) });
+});
+
+describe('policy-evaluation remediation respects the caller partner axis (#4952)', () => {
+  it('does not remediate with a partner-wide automation for an ORG-scoped caller', async () => {
+    queueSelects(
+      [{ partnerId: PARTNER_ID }],  // automationOwnershipConditionForOrg
+      [PARTNER_WIDE_AUTOMATION],    // the automation an ungated query returns
+    );
+
+    const result = await __triggerRemediationAutomation(
+      { id: 'policy-1', name: 'Drift policy' } as never,
+      DEVICE as never,
+      'non_compliant',
+      AUTOMATION_ID,
+      ORG_SCOPED_AUTH,
+    );
+
+    expect(result).toBeNull();
+    expect(insertMock).not.toHaveBeenCalled();
+    expect(enqueueAutomationRunMock).not.toHaveBeenCalled();
+  });
+
+  it('does not remediate with a partner-wide automation of a DIFFERENT partner', async () => {
+    queueSelects([{ partnerId: PARTNER_ID }], [PARTNER_WIDE_AUTOMATION]);
+
+    const result = await __triggerRemediationAutomation(
+      { id: 'policy-1', name: 'Drift policy' } as never,
+      DEVICE as never,
+      'non_compliant',
+      AUTOMATION_ID,
+      FOREIGN_PARTNER_AUTH,
+    );
+
+    expect(result).toBeNull();
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it('remediates for a PARTNER-scoped caller of the owning partner', async () => {
+    queueSelects([{ partnerId: PARTNER_ID }], [PARTNER_WIDE_AUTOMATION]);
+
+    const result = await __triggerRemediationAutomation(
+      { id: 'policy-1', name: 'Drift policy' } as never,
+      DEVICE as never,
+      'non_compliant',
+      AUTOMATION_ID,
+      PARTNER_SCOPED_AUTH,
+    );
+
+    expect(result).toBe(RUN_ID);
+    expect(enqueueAutomationRunMock).toHaveBeenCalledWith(RUN_ID, [DEVICE.id]);
+  });
+
+  it('remediates on the worker path, where no caller identity is supplied', async () => {
+    queueSelects([{ partnerId: PARTNER_ID }], [PARTNER_WIDE_AUTOMATION]);
+
+    const result = await __triggerRemediationAutomation(
+      { id: 'policy-1', name: 'Drift policy' } as never,
+      DEVICE as never,
+      'non_compliant',
+      AUTOMATION_ID,
+    );
+
+    expect(result).toBe(RUN_ID);
+    expect(enqueueAutomationRunMock).toHaveBeenCalledWith(RUN_ID, [DEVICE.id]);
+  });
+
+  it('still remediates an ORG-scoped caller with an ORG-OWNED automation', async () => {
+    queueSelects(
+      [{ partnerId: PARTNER_ID }],
+      [{ ...PARTNER_WIDE_AUTOMATION, orgId: ORG_ID, partnerId: null }],
+    );
+
+    const result = await __triggerRemediationAutomation(
+      { id: 'policy-1', name: 'Drift policy' } as never,
+      DEVICE as never,
+      'non_compliant',
+      AUTOMATION_ID,
+      ORG_SCOPED_AUTH,
+    );
+
+    expect(result).toBe(RUN_ID);
+  });
+});
+
+describe('script-based remediation resolution respects the caller partner axis (#4952)', () => {
+  const policy = {
+    id: 'policy-1',
+    orgId: ORG_ID,
+    partnerId: null,
+    name: 'Drift policy',
+    rules: [],
+    remediationScriptId: SCRIPT_ID,
+  };
+
+  it('skips a partner-wide candidate automation for an ORG-scoped caller', async () => {
+    queueSelects(
+      [{ partnerId: PARTNER_ID }],
+      [{ id: AUTOMATION_ID, actions: [{ scriptId: SCRIPT_ID }], orgId: null, partnerId: PARTNER_ID }],
+    );
+
+    const resolved = await resolvePolicyRemediationAutomationIdForOrg(
+      policy as never,
+      ORG_ID,
+      ORG_SCOPED_AUTH,
+    );
+
+    expect(resolved).toBeNull();
+  });
+
+  it('resolves the same candidate for a PARTNER-scoped caller of that partner', async () => {
+    queueSelects(
+      [{ partnerId: PARTNER_ID }],
+      [{ id: AUTOMATION_ID, actions: [{ scriptId: SCRIPT_ID }], orgId: null, partnerId: PARTNER_ID }],
+    );
+
+    const resolved = await resolvePolicyRemediationAutomationIdForOrg(
+      policy as never,
+      ORG_ID,
+      PARTNER_SCOPED_AUTH,
+    );
+
+    expect(resolved).toBe(AUTOMATION_ID);
+  });
+});

--- a/apps/api/src/services/policyEvaluationService.ts
+++ b/apps/api/src/services/policyEvaluationService.ts
@@ -21,6 +21,7 @@ import {
   scanDueComplianceChecks,
 } from './featureConfigResolver';
 import { isManagedAutomation } from './aiAgents/managedAutomation';
+import { canReadPartnerWideRows, type PartnerWideReadAuth } from './partnerWideAccess';
 
 export type EvaluationStatus = 'compliant' | 'non_compliant' | 'error';
 
@@ -60,6 +61,19 @@ export type PolicyEvaluationResponse = {
 type EvaluatePolicyOptions = {
   source?: string;
   requestRemediation?: boolean;
+  /**
+   * Identity of the requesting caller when evaluatePolicy runs inside a
+   * request (POST /policies/:id/evaluate). Partner-wide remediation
+   * automations (org_id NULL) are reachable only for system scope or the
+   * owning partner's own partner-scoped token; an org token carries a
+   * partnerId, and the partner-wide SELECT branch on `automations` makes those
+   * rows readable from an org RLS context as well, so the app-layer gate IS
+   * the access check (#4952).
+   *
+   * Omitted on the background/worker path (policyEvaluationWorker), which is
+   * genuinely system-scoped.
+   */
+  auth?: PartnerWideReadAuth | null;
 };
 
 type TargetConfig = {
@@ -1022,8 +1036,11 @@ function extractScriptIdFromAction(action: unknown): string | null {
   return null;
 }
 
-export async function resolvePolicyRemediationAutomationId(policy: PolicyRow): Promise<string | null> {
-  return resolvePolicyRemediationAutomationIdForOrg(policy, policy.orgId);
+export async function resolvePolicyRemediationAutomationId(
+  policy: PolicyRow,
+  auth?: PartnerWideReadAuth | null
+): Promise<string | null> {
+  return resolvePolicyRemediationAutomationIdForOrg(policy, policy.orgId, auth);
 }
 
 /**
@@ -1031,15 +1048,26 @@ export async function resolvePolicyRemediationAutomationId(policy: PolicyRow): P
  * OR partner-wide automations (org_id NULL) owned by the org's partner. A
  * plain eq(orgId, ...) silently never matches partner-wide rows — evaluation
  * runs under a system DB context, so RLS is not the filter here.
+ *
+ * The partner-wide arm must therefore carry the CALLER's own visibility when
+ * this runs inside a request (POST /policies/:id/evaluate). An org token
+ * carries a partnerId, and automations' partner-wide SELECT branch makes those
+ * rows readable from an org context too, so nothing below this gate stops an
+ * org caller from remediating with another tenant's partner-wide automation
+ * (#4952). `auth` absent = the system/worker path, which is genuinely
+ * system-scoped.
  */
-async function automationOwnershipConditionForOrg(orgId: string): Promise<SQL> {
+async function automationOwnershipConditionForOrg(
+  orgId: string,
+  auth?: PartnerWideReadAuth | null
+): Promise<SQL> {
   const [org] = await db
     .select({ partnerId: organizations.partnerId })
     .from(organizations)
     .where(eq(organizations.id, orgId))
     .limit(1);
 
-  if (!org?.partnerId) {
+  if (!org?.partnerId || !canReadPartnerWideRows(auth, org.partnerId)) {
     return eq(automations.orgId, orgId);
   }
 
@@ -1057,7 +1085,8 @@ async function automationOwnershipConditionForOrg(orgId: string): Promise<SQL> {
  */
 export async function resolvePolicyRemediationAutomationIdForOrg(
   policy: PolicyRow,
-  orgId: string | null
+  orgId: string | null,
+  auth?: PartnerWideReadAuth | null
 ): Promise<string | null> {
   const explicitAutomationId = extractRemediationAutomationId(policy.rules);
   if (explicitAutomationId) {
@@ -1069,16 +1098,26 @@ export async function resolvePolicyRemediationAutomationIdForOrg(
   }
 
   const candidates = await db
-    .select({ id: automations.id, actions: automations.actions })
+    .select({
+      id: automations.id,
+      actions: automations.actions,
+      orgId: automations.orgId,
+      partnerId: automations.partnerId,
+    })
     .from(automations)
     .where(
       and(
-        await automationOwnershipConditionForOrg(orgId),
+        await automationOwnershipConditionForOrg(orgId, auth),
         eq(automations.enabled, true)
       )
     );
 
   for (const candidate of candidates) {
+    // Defense in depth on each loaded row (#4952) — see
+    // automationOwnershipConditionForOrg.
+    if (candidate.orgId === null && !canReadPartnerWideRows(auth, candidate.partnerId)) {
+      continue;
+    }
     if (!Array.isArray(candidate.actions)) {
       continue;
     }
@@ -1203,7 +1242,8 @@ async function triggerRemediationAutomation(
   policy: PolicyRow,
   device: TargetDevice,
   status: EvaluationStatus,
-  remediationAutomationId: string | null
+  remediationAutomationId: string | null,
+  auth?: PartnerWideReadAuth | null
 ): Promise<string | null> {
   if (status !== 'non_compliant' || !remediationAutomationId) {
     return null;
@@ -1219,7 +1259,7 @@ async function triggerRemediationAutomation(
     .where(
       and(
         eq(automations.id, remediationAutomationId),
-        await automationOwnershipConditionForOrg(device.orgId)
+        await automationOwnershipConditionForOrg(device.orgId, auth)
       )
     )
     .limit(1);
@@ -1227,6 +1267,11 @@ async function triggerRemediationAutomation(
   // Both policy-remediation paths run per evaluated device, so a policy pointed
   // at the managed row would create one agent run per device in the fleet.
   if (!automation || !automation.enabled || isManagedAutomation(automation)) return null;
+
+  // Defense in depth on the loaded row (#4952): re-assert the caller's
+  // partner-wide visibility even though the ownership condition above already
+  // dropped the partner-wide arm for callers that lack it.
+  if (automation.orgId === null && !canReadPartnerWideRows(auth, automation.partnerId)) return null;
 
   const [run] = await db
     .insert(automationRuns)
@@ -1344,7 +1389,7 @@ export async function evaluatePolicy(
     if (!remediationIdByOrg.has(deviceOrgId)) {
       remediationIdByOrg.set(
         deviceOrgId,
-        await resolvePolicyRemediationAutomationIdForOrg(policy, deviceOrgId)
+        await resolvePolicyRemediationAutomationIdForOrg(policy, deviceOrgId, options.auth)
       );
     }
     return remediationIdByOrg.get(deviceOrgId) ?? null;
@@ -1495,7 +1540,13 @@ export async function evaluatePolicy(
     });
 
     const remediationRunId = requestRemediation
-      ? await triggerRemediationAutomation(policy, device, status, await remediationAutomationIdForOrg(device.orgId))
+      ? await triggerRemediationAutomation(
+          policy,
+          device,
+          status,
+          await remediationAutomationIdForOrg(device.orgId),
+          options.auth
+        )
       : null;
 
     evaluationResults.push({
@@ -1856,7 +1907,10 @@ async function triggerConfigPolicyRemediation(
   }
 
   // Find an automation that uses the remediation script — the device org's
-  // own automations plus its partner's partner-wide ones (#2133).
+  // own automations plus its partner's partner-wide ones (#2133). No `auth`
+  // argument: this path is only reachable from scanAndEvaluateConfigPolicyCompliance
+  // on the background worker, which is genuinely system-scoped. If a request
+  // route ever calls it, thread the caller's auth through (#4952).
   const deviceOrgAutomationCondition = await automationOwnershipConditionForOrg(deviceRow.orgId);
   const candidates = await db
     .select({ id: automations.id, actions: automations.actions })


### PR DESCRIPTION
## What

Adds the partner-wide `FOR SELECT`-only read branch — `USING (org_id IS NULL AND partner_id = public.breeze_current_partner_id())` — to four dual-axis config tables, and removes them from `PARTNER_WIDE_SELECT_BRANCH_EXEMPT`:

| Table | Issue |
|---|---|
| `automations` | #4952 |
| `automation_policies` | #4950 |
| `automation_resource_bindings` | #4951 |
| `alert_rules` | #4949 |

Migration: `apps/api/migrations/2026-10-11-000400-automation-alert-rules-partner-wide-select.sql` — sorts after main's newest, `…-000300-recurring-job-missing-indexes.sql` and #5000's `…-000200-software-security-partner-wide-select.sql`. Additive, separate, SELECT-only policies — never appended to an existing `FOR ALL` policy, so UPDATE/DELETE row targeting is unchanged. Idempotent via `pg_policies` existence checks.

`PARTNER_WIDE_SELECT_BRANCH_EXEMPT_CEILING` lowered `8 → 4`. #5000 merged while this round was in flight, taking main's map from 13 to 8; removing these four leaves exactly four (`ai_agents`, `ai_agent_schedules`, `custom_field_definitions`, `client_ai_prompt_templates`), and the frozen name set is trimmed to match.

## Reader code changed — this is the part the first review flagged

**The previous version of this PR changed no reader code, and that was the defect.**

The SELECT branch is deliberately readable from an **org** RLS context: `middleware/auth.ts` feeds every org token's `partnerId` into `DbAccessContext.currentPartnerId`, and that is exactly what makes partner-wide config reach agents (`agentAuth.ts` sets it too, #4673 W02). So adding the branch also removes the *incidental* RLS backstop that several app-layer dual-axis readers had been leaning on. Each of those is gated here:

| File | Path | Change |
|---|---|---|
| `routes/policyManagement/actions.ts` | `POST /policies/:id/remediate` | The partner-wide arm of the automation lookup is gated on the caller's own partner visibility, **and** the loaded row is re-checked (404 on mismatch). This route enqueues with **no target argument**, so `automationRuntime` expands a partner-wide automation across every org under the partner — an org admin with `devices:write` on their own org-owned policy could otherwise have run a script on other tenants' devices. |
| `routes/policyManagement/actions.ts` | `POST /policies/:id/evaluate` | Threads the caller `auth` into `evaluatePolicy`. |
| `services/policyEvaluationService.ts` | `automationOwnershipConditionForOrg`, `resolvePolicyRemediationAutomationId{,ForOrg}`, `triggerRemediationAutomation` | Optional `auth` parameter; partner-wide arm gated on it, and loaded rows/candidates re-checked. `auth` absent = the background worker, which is genuinely system-scoped, so worker behaviour is unchanged. |
| `routes/alerts/helpers.ts` | `getAlertRuleWithOrgCheck` | Was granting on `rule.partnerId === auth.partnerId` with no scope gate, so `GET /alerts/rules/:id` and `/test` disclosed partner-wide rules to plain org users. Now scope-gated, which also makes the by-id paths agree with `GET /alerts/rules`, whose partner-wide arm was already partner-scope only. Stale rationale comment rewritten. |
| `services/partnerWideAccess.ts` | new | `canReadPartnerWideRows(auth, ownerPartnerId)` + `PartnerWideReadAuth` — the single read-side counterpart to `canManagePartnerWidePolicies`. Structural `scope: string` so route-local `AuthContext` shapes pass without a cast. |

`triggerConfigPolicyRemediation` is left system-scoped on purpose: it is reachable only from `scanAndEvaluateConfigPolicyCompliance` on the worker. A comment records that a future request-path caller must thread `auth`.

## Tests

New, all red-first verified by reverting the gate and re-running:

- `routes/policyManagement/actions.partnerWideAutomation.test.ts` — 7 tests. Org caller → **404** on a partner-wide automation via `/remediate` (nothing inserted, nothing enqueued); foreign-partner caller → 404; owning-partner caller → 200 + enqueued; org caller with an **org-owned** automation still → 200; `/evaluate` and `/remediate` thread the caller auth. **5 fail without the fix.**
- `services/policyEvaluationPartnerWideAutomation.test.ts` — 7 tests. `__triggerRemediationAutomation` returns null for org / foreign-partner callers on a partner-wide automation, runs for the owning partner, runs on the worker path (no auth), and still runs for an org caller on an org-owned automation; plus script-based candidate resolution. **3 fail without the fix.**
- `routes/alerts/helpers.partnerWideRuleScope.test.ts` — 6 tests. Org token with the matching `partnerId` → `null` (route 404); foreign partner → null; owning partner and system → the rule; org-owned rule unaffected. **1 fails without the fix.**
- `__tests__/integration/automationAlertRulesPartnerWideSelect.integration.test.ts` — the real-Postgres suite for the four policies (unchanged from the first round apart from the migration filename).

## Verification

- `bash scripts/check-migration-naming.sh --against-ref origin/main` → **OK** (renamed `2026-10-10-110000-…` → `2026-10-11-000400-…` to sort after main's newest, `2026-10-11-000300-recurring-job-missing-indexes.sql`; the one reference in the integration suite swept); re-verified after the second rebase.
- `vitest run` over `routes/policyManagement*`, `routes/alerts*`, `routes/automations*`, `services/policyEvaluation*`, `services/partnerWideAccess*`, `services/configurationPolicy*`, `db/autoMigrate.test.ts`, `db/migrationRlsScope.test.ts`, `middleware/auth*` → **54 files / 837 tests passed**.
- `tsc --noEmit` clean; `eslint` clean on all changed files.
- Rebased onto `7583ca9dc1` (after #5000 merged); `mergeable: MERGEABLE`.

## Repo-wide sweep of the four tables' dual-axis readers

Every `isNull(<table>.orgId)` reader was checked. Already correctly gated: `routes/automations.ts:628`, `routes/alerts/rules.ts:126`, `routes/policyManagement/helpers.ts:90` (all `auth.scope === 'partner'`), `jobs/automationWorker.ts:990` and `routes/agents/helpers.ts:406` (worker / agent config delivery, system-scoped by design). Deliberately org-facing and left alone: `routes/alertTemplates/rules.ts:34` (legacy org-pinned route that shows the partner-wide rules governing *the caller's own* org, writes blocked with an explicit message), `modules/mcpInvites/tools/configureDefaults.ts:128` (dedupe existence check whose partner is derived from the invited org, not from a token), `services/alertCorrelationRca.ts:612` (rule ids already come from that org's own alerts).

Closes #4952, #4950, #4951, #4949

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D8vEM9EyDS1SE68pcZcnFQ
