### PR TITLE
fix(psa): anchor getConnectionById on the caller's access axis (#4959 follow-up)

### DIFF
--- a/apps/api/src/routes/psa.test.ts
+++ b/apps/api/src/routes/psa.test.ts
@@ -1046,6 +1046,35 @@ describe('psa routes', () => {
       expect(countChain.where).toHaveBeenCalled();
     });
 
+    it('GET /connections/:id anchors the lookup on the access axis, not id alone', async () => {
+      // Review finding (#4998): with the partner-wide SELECT branch in RLS, an
+      // org caller can now fetch a partner-wide row by id and relies solely on
+      // ensureConnectionAccess to reject it. The lookup must carry the same
+      // axis filter the list route uses so a future caller that forgets the
+      // gate gets "not found" rather than the row.
+      const orgCondition = vi.fn((col: unknown) => ({ orgEq: col, value: 'org-123' }));
+      vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+        c.set('auth', {
+          scope: 'organization',
+          partnerId: null,
+          partnerOrgAccess: null,
+          orgId: 'org-123',
+          user: { id: 'user-123', email: 'test@example.com' },
+          canAccessOrg: (orgId: string) => orgId === 'org-123',
+          accessibleOrgIds: ['org-123'],
+          orgCondition
+        });
+        return next();
+      });
+      const chain = makeChain([connectionRow({ partnerId: null })]);
+      selectMock.mockReturnValueOnce(chain as never);
+
+      const res = await app.request('/psa/connections/conn-1', { method: 'GET' });
+
+      expect(res.status).toBe(200);
+      expect(orgCondition).toHaveBeenCalledWith('psa_connections.org_id');
+    });
+
     it('serializes ownerScope organization for an org-owned row', async () => {
       selectMock.mockReturnValueOnce(makeChain([connectionRow({ partnerId: null })]) as never);
 
@@ -1066,7 +1095,8 @@ describe('psa routes', () => {
         orgId: null,
         user: { id: 'user-123', email: 'test@example.com' },
         canAccessOrg: () => false,
-        accessibleOrgIds: []
+        accessibleOrgIds: [],
+        orgCondition: (col: unknown) => ({ orgIn: col, value: [] })
       });
       return next();
     });

--- a/apps/api/src/routes/psa.ts
+++ b/apps/api/src/routes/psa.ts
@@ -393,7 +393,17 @@ function mapTicketRow(row: {
 // psaTicketMappingOrgCondition (ticket data), so the helper is deleted rather
 // than left around for the next endpoint to copy.
 
-async function getConnectionById(id: string) {
+// Anchored on the caller's access axis, not id alone: since the partner-wide
+// SELECT branch landed in RLS (#4959), an org caller CAN fetch its MSP's
+// partner-wide row by id, and ensureConnectionAccess became the only thing
+// standing between it and the row. Filtering here keeps "not found" as the
+// answer for anything outside the caller's axis, so a future call site that
+// forgets the gate degrades to a 404 instead of a leak.
+async function getConnectionById(
+  id: string,
+  auth: Pick<AuthContext, 'scope' | 'partnerId' | 'orgCondition'>
+) {
+  const accessCondition = psaConnectionAccessCondition(auth);
   const [connection] = await db
     .select({
       id: psaConnectionsTable.id,
@@ -409,7 +419,7 @@ async function getConnectionById(id: string) {
       lastSyncAt: psaConnectionsTable.lastSyncAt
     })
     .from(psaConnectionsTable)
-    .where(eq(psaConnectionsTable.id, id))
+    .where(accessCondition ? and(eq(psaConnectionsTable.id, id), accessCondition) : eq(psaConnectionsTable.id, id))
     .limit(1);
 
   return connection ?? null;
@@ -625,7 +635,7 @@ psaRoutes.get(
     const auth = c.get('auth');
     const connectionId = c.req.param('id')!;
 
-    const connection = await getConnectionById(connectionId);
+    const connection = await getConnectionById(connectionId, auth);
     if (!connection) {
       return c.json({ error: 'PSA connection not found' }, 404);
     }
@@ -672,7 +682,7 @@ psaRoutes.patch(
       return c.json({ error: 'No updates provided' }, 400);
     }
 
-    const existing = await getConnectionById(connectionId);
+    const existing = await getConnectionById(connectionId, auth);
     if (!existing) {
       return c.json({ error: 'PSA connection not found' }, 404);
     }
@@ -784,7 +794,7 @@ psaRoutes.delete(
     const auth = c.get('auth');
     const connectionId = c.req.param('id')!;
 
-    const existing = await getConnectionById(connectionId);
+    const existing = await getConnectionById(connectionId, auth);
     if (!existing) {
       return c.json({ error: 'PSA connection not found' }, 404);
     }
@@ -832,7 +842,7 @@ psaRoutes.post(
     const connectionId = c.req.param('id')!;
 
     // Short, explicit DB context — no ambient request transaction here (#1448).
-    const existing = await withAuthDbAccessContext(auth, () => getConnectionById(connectionId));
+    const existing = await withAuthDbAccessContext(auth, () => getConnectionById(connectionId, auth));
     if (!existing) {
       return c.json({ error: 'PSA connection not found' }, 404);
     }
@@ -944,7 +954,7 @@ psaRoutes.post(
     const auth = c.get('auth');
     const connectionId = c.req.param('id')!;
 
-    const existing = await getConnectionById(connectionId);
+    const existing = await getConnectionById(connectionId, auth);
     if (!existing) {
       return c.json({ error: 'PSA connection not found' }, 404);
     }
@@ -1062,7 +1072,7 @@ psaRoutes.get(
     const query = c.req.valid('query');
     const { page, limit, offset } = getPagination(query);
 
-    const connection = await getConnectionById(connectionId);
+    const connection = await getConnectionById(connectionId, auth);
     if (!connection) {
       return c.json({ error: 'PSA connection not found' }, 404);
     }
@@ -1200,7 +1210,7 @@ async function resolveImportConnection(
   connectionId: string
 ): Promise<ImportResolution> {
   // Short, explicit DB context — no ambient request transaction here (#1448).
-  const connection = await withAuthDbAccessContext(auth, () => getConnectionById(connectionId));
+  const connection = await withAuthDbAccessContext(auth, () => getConnectionById(connectionId, auth));
   if (!connection) {
     return { ok: false, error: 'PSA connection not found', status: 404 };
   }


### PR DESCRIPTION
## Summary
Follow-up from the post-merge review of #4998 (partner-wide SELECT branch for identity-contracts tables).

`getConnectionById` in `routes/psa.ts` filtered on `eq(id)` only and relied on RLS to hide partner-wide rows from org callers. After #4998 the row is fetched and rejected only by `ensureConnectionAccess`, at 7 call sites. This adds the same access-axis filter the list route uses (`psaConnectionAccessCondition`) so a future caller that forgets the gate gets a 404 instead of the row.

Not exploitable today (credentials encrypted, never decrypted on read) — defence in depth.

## Not changed
- The #4998 migration header says "agent scope leaves the GUC NULL". Reviewer noted on-device **Helper** sessions (`middleware/helperAuth.ts`) DO set `currentPartnerId`, so helper sessions satisfy the branch. No helper/extension route reads the six tables today. The migration is shipped and immutable, so this is recorded here rather than edited.

## Tests
- New: `GET /connections/:id anchors the lookup on the access axis` — red before, green after.
- Fixed an incomplete partner-auth mock (`orgCondition` missing) that only passed because the lookup ignored auth.
- `psa.test.ts` + `psaCompanyImport.test.ts`: 74 passed. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUsfUH7smCCDiSVrGFTasC