### PR TITLE
fix(quotes): thread theme fonts through line table/summary + fix multi-run cell alignment (#4438)

### DIFF
--- a/apps/api/src/services/quotePdf.themeFonts.test.ts
+++ b/apps/api/src/services/quotePdf.themeFonts.test.ts
@@ -1,0 +1,163 @@
+// Theme-font coverage for the line-item table + recurring summary (#4438).
+//
+// The rest of quotePdf.test.ts asserts on rendered PDF bytes, which works for
+// the classic theme (WinAnsi Helvetica is decodable straight out of the content
+// stream) but NOT for a themed document: an embedded TTF encodes its text as
+// CID glyph ids, so the drawn string can't be recovered without walking the
+// font's ToUnicode CMap. These assertions need the opposite pairing — WHICH
+// font a KNOWN string was drawn in — so this suite spies on the real pdfkit
+// document's font()/text() pair and records (font in effect, string drawn).
+// The spy only records: every call is forwarded to the real implementation, so
+// the renderer still produces a genuine PDF.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import PDFKitDocument from 'pdfkit';
+import { renderQuotePdf } from './quotePdf';
+import { registerThemeFonts } from './documentThemes';
+
+const state = vi.hoisted(() => ({ draws: [] as { font: string; text: string }[], currentFont: '' }));
+
+let fontSpy: ReturnType<typeof vi.spyOn>;
+let textSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  state.draws = [];
+  state.currentFont = '';
+  const realFont = PDFKitDocument.prototype.font;
+  const realText = PDFKitDocument.prototype.text;
+  fontSpy = vi.spyOn(PDFKitDocument.prototype, 'font').mockImplementation(function (this: PDFKit.PDFDocument, ...args: unknown[]) {
+    state.currentFont = String(args[0]);
+    return (realFont as (...a: unknown[]) => unknown).apply(this, args) as PDFKit.PDFDocument;
+  } as unknown as typeof PDFKitDocument.prototype.font);
+  textSpy = vi.spyOn(PDFKitDocument.prototype, 'text').mockImplementation(function (this: PDFKit.PDFDocument, ...args: unknown[]) {
+    state.draws.push({ font: state.currentFont, text: String(args[0]) });
+    return (realText as (...a: unknown[]) => unknown).apply(this, args) as PDFKit.PDFDocument;
+  } as unknown as typeof PDFKitDocument.prototype.text);
+});
+
+afterEach(() => {
+  fontSpy.mockRestore();
+  textSpy.mockRestore();
+});
+
+// A quote that exercises every draw call in renderLineTable and
+// renderRecurringSummary: a section label, the tax column, a per-table
+// subtotal, a device-set estimate sentence, a two-row category breakdown, and
+// the deposit variant of the summary (bold + emphasis + remaining-balance rows).
+const quote = {
+  id: 'q-theme-fonts', quoteNumber: 'Q-THEME-FONTS', currencyCode: 'USD', documentLocale: 'en',
+  title: 'Managed Services Proposal',
+  oneTimeTotal: '500.00', monthlyRecurringTotal: '1200.00', annualRecurringTotal: '0.00',
+  total: '1700.00', dueOnAcceptanceTotal: '500.00',
+  taxRate: '0.1', taxTotal: '50.00',
+  depositType: 'fixed', depositAmount: '200.00',
+  categoryBreakdown: [
+    { category: 'service', oneTimeTotal: '0.00', monthlyTotal: '1200.00', annualTotal: '0.00' },
+    { category: 'other', oneTimeTotal: '500.00', monthlyTotal: '0.00', annualTotal: '0.00' },
+  ],
+};
+
+const blocks = [
+  { id: 'b1', blockType: 'line_items', sortOrder: 0, content: { label: 'Recurring services', showSubtotal: true } },
+];
+
+const lines = [
+  {
+    id: 'l1', blockId: 'b1', name: 'Managed IT Support', description: 'Monitoring and helpdesk coverage',
+    quantity: '1', unitPrice: '1200.00', lineTotal: '1200.00', recurrence: 'monthly', taxable: true, itemType: 'service',
+  },
+  {
+    id: 'l2', blockId: 'b1', name: 'Onboarding', description: 'One-time setup and documentation',
+    quantity: '1', unitPrice: '500.00', lineTotal: '500.00', recurrence: 'one_time', taxable: false, itemType: 'other',
+  },
+  {
+    id: 'l3', blockId: 'b1', name: 'Endpoint protection', description: 'Per-device licensing',
+    quantity: '10', unitPrice: '0.00', lineTotal: '0.00', recurrence: 'monthly', taxable: true, itemType: 'service',
+    contractLineType: 'per_device', siteName: 'Head Office',
+  },
+];
+
+function render(theme?: 'classic' | 'condensed'): Promise<Buffer> {
+  return renderQuotePdf(
+    quote as never,
+    blocks as never,
+    lines as never,
+    async () => null,
+    theme ? { partnerName: 'Acme', theme } : { partnerName: 'Acme' },
+  );
+}
+
+/** The font in effect when `text` was drawn (first occurrence). */
+function fontFor(text: string): string | undefined {
+  return state.draws.find((d) => d.text === text)?.font;
+}
+
+/** The font in effect for the first drawn string starting with `prefix`. */
+function fontForPrefix(prefix: string): string | undefined {
+  return state.draws.find((d) => d.text.startsWith(prefix))?.font;
+}
+
+describe('quotePdf line table + recurring summary theme fonts (#4438)', () => {
+  it('draws the whole condensed-theme table and summary in the resolved theme fonts', async () => {
+    const condensed = registerThemeFonts(
+      // Throwaway doc: registerThemeFonts needs one to register the TTFs on,
+      // and the returned name table is what the renderer is asserted against.
+      new PDFKitDocument({ size: 'A4', margin: 50 }),
+      'condensed',
+    );
+    await render('condensed');
+
+    // Section label + column headers are document chrome → the heading face.
+    expect(fontFor('Recurring services')).toBe(condensed.heading.bold);
+    for (const header of ['QTY', 'DESCRIPTION', 'UNIT', 'TAX', 'TOTAL']) {
+      expect(fontFor(header), header).toBe(condensed.heading.bold);
+    }
+
+    // Row text is body copy: the title in the body bold face, everything else
+    // (blurb, device-set estimate, money cells) in the body regular face.
+    expect(fontFor('Managed IT Support')).toBe(condensed.body.bold);
+    expect(fontFor('Monitoring and helpdesk coverage')).toBe(condensed.body.regular);
+    expect(fontForPrefix('Estimated quantity —')).toBe(condensed.body.regular);
+    expect(fontFor('$1,200.00')).toBe(condensed.body.regular);
+    expect(fontFor('$120.00')).toBe(condensed.body.regular);
+    expect(fontFor('$1,200.00/mo')).toBe(condensed.body.regular);
+
+    // Per-table subtotal: bold label + bold amount.
+    expect(fontFor('Subtotal')).toBe(condensed.body.bold);
+    expect(fontForPrefix('$500.00  +  $1,200.00/mo')).toBe(condensed.body.bold);
+
+    // Category breakdown rows and the roll-up rows: regular labels/amounts.
+    expect(fontFor('Service')).toBe(condensed.body.regular);
+    expect(fontFor('Other')).toBe(condensed.body.regular);
+    expect(fontFor('One-time')).toBe(condensed.body.regular);
+    expect(fontFor('Monthly')).toBe(condensed.body.regular);
+    expect(fontFor('Tax (10.00%)')).toBe(condensed.body.regular);
+    expect(fontFor('First-period total')).toBe(condensed.body.regular);
+
+    // The deposit summary's three figures are the emphasised rows → body bold.
+    expect(fontFor('Due on acceptance')).toBe(condensed.body.bold);
+    expect(fontFor('Deposit due now')).toBe(condensed.body.bold);
+    expect(fontFor('Remaining balance (due per terms)')).toBe(condensed.body.bold);
+
+    // The blanket version of every assertion above: a themed document must not
+    // contain a single hard-coded Helvetica draw — that is exactly the bug
+    // #4438 is about, and this catches any future literal too.
+    expect(state.draws.filter((d) => /^Helvetica/.test(d.font))).toEqual([]);
+  });
+
+  it('resolves the same draws to the Helvetica faces for the classic theme', async () => {
+    const classic = registerThemeFonts(new PDFKitDocument({ size: 'A4', margin: 50 }), 'classic');
+    await render('classic');
+
+    expect(fontFor('DESCRIPTION')).toBe(classic.heading.bold);
+    expect(fontFor('Managed IT Support')).toBe(classic.body.bold);
+    expect(fontFor('Monitoring and helpdesk coverage')).toBe(classic.body.regular);
+    expect(fontFor('Due on acceptance')).toBe(classic.body.bold);
+    expect(state.draws.filter((d) => !/^Helvetica/.test(d.font))).toEqual([]);
+  });
+
+  it('keeps the un-branded default render on the classic Helvetica faces', async () => {
+    await render();
+    expect(fontFor('DESCRIPTION')).toBe('Helvetica-Bold');
+    expect(fontFor('Monitoring and helpdesk coverage')).toBe('Helvetica');
+  });
+});

--- a/apps/api/src/services/quotePdf.ts
+++ b/apps/api/src/services/quotePdf.ts
@@ -355,6 +355,7 @@ async function renderLineTable(
   startY: number,
   loadCatalogImage: LoadCatalogImage,
   loadQuoteImage: (imageId: string) => Promise<{ data: Buffer } | null>,
+  fonts: PdfThemeFonts,
   taxRate = 0,
   showTax = false,
   showSubtotal = false,
@@ -399,7 +400,7 @@ async function renderLineTable(
     doc.save();
     doc.rect(c.left - 6, headerY - 5, c.contentWidth + 12, 22).fill('#f8fafc');
     doc.restore();
-    doc.fillColor('#6b7280').fontSize(8.5).font('Helvetica-Bold');
+    doc.fillColor('#6b7280').fontSize(8.5).font(fonts.heading.bold);
     doc.text('QTY', c.colQtyX, headerY, { width: c.colQtyW, align: 'left' });
     doc.text('DESCRIPTION', c.colDescX, headerY, { width: c.colDescW, align: 'left' });
     doc.text('UNIT', c.colUnitX, headerY, { width: c.colNumW, align: 'right' });
@@ -425,9 +426,9 @@ async function renderLineTable(
     // Title falls back to description for legacy lines that predate the name/description split.
     const title = (l.name ?? l.description ?? '').trim() || '—';
     const blurb = l.name ? (l.description ?? '').trim() : '';
-    doc.font('Helvetica-Bold').fontSize(10);
+    doc.font(fonts.body.bold).fontSize(10);
     const titleHeight = doc.heightOfString(title, { width: descW });
-    doc.font('Helvetica').fontSize(8.5);
+    doc.font(fonts.body.regular).fontSize(8.5);
     const blurbHeight = blurb ? doc.heightOfString(blurb, { width: descW, lineGap: 1 }) + 2 : 0;
     const deviceSetText = deviceSetCustomerText(l, currency, locale);
     const deviceSetHeight = deviceSetText.length
@@ -443,13 +444,13 @@ async function renderLineTable(
   // got drawn at the foot of the page, then the row-level break moved the row to
   // the next page and stranded them. Reserve the first row's real measured height
   // instead, capped to a page so a taller-than-a-page row can't force a blank one.
-  const labelHeight = label ? (doc.font('Helvetica-Bold').fontSize(11).heightOfString(label, { width: c.contentWidth }) + 6) : 0;
+  const labelHeight = label ? (doc.font(fonts.heading.bold).fontSize(11).heightOfString(label, { width: c.contentWidth }) + 6) : 0;
   const usable = doc.page.height - doc.page.margins.top - doc.page.margins.bottom;
   const firstLine = lines[0];
   const firstRowHeight = firstLine ? measureRow(firstLine).rowHeight + 6 : 0;
   y = ensureSpace(doc, y, Math.min(labelHeight + 24 + firstRowHeight, usable));
   if (label) {
-    doc.fillColor('#111827').fontSize(11).font('Helvetica-Bold').text(label, c.left, y, { width: c.contentWidth });
+    doc.fillColor('#111827').fontSize(11).font(fonts.heading.bold).text(label, c.left, y, { width: c.contentWidth });
     y = doc.y + 6;
   }
 
@@ -463,7 +464,7 @@ async function renderLineTable(
     // description overflow into the footer band. (Old reserve was a flat 30/52pt,
     // so tall rows spilled past the bottom margin.)
     y = ensureRowSpace(y, rowHeight + 6);
-    doc.fillColor('#1f2937').font('Helvetica').fontSize(10);
+    doc.fillColor('#1f2937').font(fonts.body.regular).fontSize(10);
     doc.text(String(Number(l.quantity)), c.colQtyX, y, { width: c.colQtyW, align: 'left' });
     if (img) {
       // A buffer that loaded but pdfkit can't decode: skip the thumbnail (never
@@ -476,15 +477,15 @@ async function renderLineTable(
         captureException(e instanceof Error ? e : new Error(String(e)));
       }
     }
-    doc.fillColor('#1f2937').font('Helvetica-Bold').fontSize(10).text(title, descX + gutter, y, { width: descW });
+    doc.fillColor('#1f2937').font(fonts.body.bold).fontSize(10).text(title, descX + gutter, y, { width: descW });
     if (blurb) {
-      doc.fillColor('#6b7280').fontSize(8.5).font('Helvetica').text(blurb, descX + gutter, y + titleHeight + 2, { width: descW, lineGap: 1 });
+      doc.fillColor('#6b7280').fontSize(8.5).font(fonts.body.regular).text(blurb, descX + gutter, y + titleHeight + 2, { width: descW, lineGap: 1 });
       doc.fillColor('#1f2937').fontSize(10);
     }
     if (deviceSetText.length) {
       let textY = y + titleHeight + blurbHeight + 2;
       for (const text of deviceSetText) {
-        doc.fillColor('#6b7280').fontSize(8.5).font('Helvetica').text(text, descX + gutter, textY, { width: descW, lineGap: 1 });
+        doc.fillColor('#6b7280').fontSize(8.5).font(fonts.body.regular).text(text, descX + gutter, textY, { width: descW, lineGap: 1 });
         textY = doc.y + 2;
       }
       doc.fillColor('#1f2937').fontSize(10);
@@ -496,7 +497,7 @@ async function renderLineTable(
     // sized for ~1M while numeric(12,2) permits 9'999'999'999.99, so every
     // money cell shrinks its font to fit its box (#3777 review F10).
     const unitText = formatMoneyForPdf(l.unitPrice, currency, locale);
-    doc.font('Helvetica');
+    doc.font(fonts.body.regular);
     fitFontSize(doc, unitText, c.colNumW, 10);
     doc.text(unitText, c.colUnitX, y, { width: c.colNumW, align: 'right', lineBreak: false });
     if (showTax) {
@@ -531,7 +532,7 @@ async function renderLineTable(
     if (lines.some((l) => l.recurrence === 'annual')) parts.push(`${formatMoneyForPdf(sums.annual, currency, locale)}/yr`);
     if (parts.length) {
       const subtotalText = parts.join('  +  ');
-      doc.font('Helvetica-Bold').fontSize(9.5);
+      doc.font(fonts.body.bold).fontSize(9.5);
       const subtotalWidth = c.right - c.colUnitX;
       const labelWidth = doc.widthOfString('Subtotal');
       const inlineAmountWidth = subtotalWidth - labelWidth - 10;
@@ -541,7 +542,7 @@ async function renderLineTable(
       y = ensureRowSpace(y, subtotalHeight);
       doc.moveTo(c.colUnitX, y).lineTo(c.right, y).lineWidth(0.5).strokeColor('#e5e7eb').stroke();
       y += 6;
-      doc.font('Helvetica-Bold').fontSize(9.5).fillColor('#374151').text('Subtotal', c.colUnitX, y, { width: c.contentWidth * 0.2, align: 'left' });
+      doc.font(fonts.body.bold).fontSize(9.5).fillColor('#374151').text('Subtotal', c.colUnitX, y, { width: c.contentWidth * 0.2, align: 'left' });
       if (stackAmount) {
         y += 14;
         doc.fillColor('#111827').text(subtotalText, c.colUnitX, y, { width: subtotalWidth, align: 'right' });
@@ -574,6 +575,7 @@ function renderRecurringSummary(
   locale: string,
   primary: string,
   startY: number,
+  fonts: PdfThemeFonts,
   showTax = false,
   recurringLines: { monthly: boolean; annual: boolean } = { monthly: false, annual: false },
   lines: QuoteLine[] = [],
@@ -598,7 +600,7 @@ function renderRecurringSummary(
   const labelW = c.colSummaryAmtX - sumX - 8;
   const categoryAmountX = c.colSummaryAmtX - 60;
   const categoryAmountW = c.right - categoryAmountX;
-  doc.font('Helvetica').fontSize(9);
+  doc.font(fonts.body.regular).fontSize(9);
   const breakdownRows = breakdown.length > 1 ? breakdown.map((b) => {
     const label = b.category === 'other' ? 'Other' : b.category[0]!.toUpperCase() + b.category.slice(1);
     const parts: string[] = [];
@@ -641,7 +643,7 @@ function renderRecurringSummary(
   // category. Drawn above the One-time/Monthly/Annual roll-up.
   if (breakdownRows.length) {
     for (const row of breakdownRows) {
-      doc.font('Helvetica').fontSize(9).fillColor('#9ca3af');
+      doc.font(fonts.body.regular).fontSize(9).fillColor('#9ca3af');
       doc.text(row.label, labelX, y, { width: labelW, align: 'left' });
       if (row.stacked) {
         y += 12;
@@ -663,7 +665,7 @@ function renderRecurringSummary(
     const { bold = false, emphasis = false } = opts;
     const strong = bold || emphasis;
     const size = emphasis ? 14 : strong ? 12 : 10;
-    doc.font(strong ? 'Helvetica-Bold' : 'Helvetica').fontSize(size).fillColor(strong ? '#111827' : '#6b7280');
+    doc.font(strong ? fonts.body.bold : fonts.body.regular).fontSize(size).fillColor(strong ? '#111827' : '#6b7280');
     doc.text(label, labelX, y, { width: labelW, align: 'left' });
     // lineBreak: false — the y advances below are fixed constants shared with
     // the page-break reservation; a wrapped amount would silently break both.
@@ -1031,7 +1033,7 @@ export async function renderQuotePdf(
         // row's real height. Reserving a flat minimum here instead stranded the
         // label + header at the foot of a page whenever the first row was tall.
         const showSubtotal = (b.content as { showSubtotal?: boolean }).showSubtotal === true;
-        y = await renderLineTable(doc, blockLines, currency, locale, y, loadCatalogImage, loadImage, taxRate, showTax, showSubtotal, label);
+        y = await renderLineTable(doc, blockLines, currency, locale, y, loadCatalogImage, loadImage, fonts, taxRate, showTax, showSubtotal, label);
       }
     } else if (b.blockType === 'contract') {
       // contractRenderData[b.id] is pre-fetched by the route (Task 14's
@@ -1076,10 +1078,10 @@ export async function renderQuotePdf(
 
   // ---- Trailing default table for lines with no block ----------------------
   const orphanLines = lines.filter((l) => !l.blockId);
-  if (orphanLines.length) y = await renderLineTable(doc, orphanLines, currency, locale, y, loadCatalogImage, loadImage, taxRate, showTax);
+  if (orphanLines.length) y = await renderLineTable(doc, orphanLines, currency, locale, y, loadCatalogImage, loadImage, fonts, taxRate, showTax);
 
   // ---- Recurring summary footer -------------------------------------------
-  y = renderRecurringSummary(doc, quote, currency, locale, primary, y, showTax, {
+  y = renderRecurringSummary(doc, quote, currency, locale, primary, y, fonts, showTax, {
     monthly: lines.some((line) => line.recurrence === 'monthly'),
     annual: lines.some((line) => line.recurrence === 'annual'),
   }, lines);

--- a/apps/api/src/services/richTextPdf.ts
+++ b/apps/api/src/services/richTextPdf.ts
@@ -659,6 +659,18 @@ function drawRuns(
   forceBold = false,
 ): void {
   const effectiveRuns = runs.length ? runs : [{ text: '', bold: false, italic: false, underline: false }];
+  if (align !== 'left') {
+    // pdfkit applies `align`/`width` to EVERY `continued: true` call, not just
+    // the paragraph as a whole — so the left-align path below (which leans on
+    // pdfkit's own continued-text wrapping) makes each run re-center/re-right-
+    // anchor itself inside `width`, painting every run of a line on top of the
+    // others. Lay the lines out ourselves instead: word-wrap the runs exactly
+    // like countWrappedLines measures them, then position each wrapped LINE
+    // (not each run) against the box.
+    drawAlignedRuns(doc, effectiveRuns, x, y, width, fontSize, bodyFonts, align, color, forceBold);
+    doc.fillColor(TEXT_COLOR);
+    return;
+  }
   effectiveRuns.forEach((run, i) => {
     const isFirst = i === 0;
     const isLast = i === effectiveRuns.length - 1;
@@ -675,6 +687,125 @@ function drawRuns(
     }
   });
   doc.fillColor(TEXT_COLOR);
+}
+
+/** One word/whitespace token from a run, carrying back a reference to its
+ *  source run so wrapping can measure it at the run's own font. `isBreak`
+ *  marks a hard line break (a `\n` inside the run's text, from `<br>`). */
+interface RunToken { text: string; run: RichTextRun; isWhitespace: boolean; isBreak?: boolean }
+
+function tokenizeRunsForWrap(runs: RichTextRun[]): RunToken[] {
+  const tokens: RunToken[] = [];
+  for (const run of runs) {
+    const segments = run.text.split('\n');
+    segments.forEach((segment, segIndex) => {
+      if (segIndex > 0) tokens.push({ text: '', run, isWhitespace: false, isBreak: true });
+      if (!segment.length) return;
+      for (const text of segment.split(/(\s+)/).filter((t) => t.length > 0)) {
+        tokens.push({ text, run, isWhitespace: text.trim().length === 0 });
+      }
+    });
+  }
+  return tokens;
+}
+
+/** Greedy-fills tokens into wrapped lines, mirroring countWrappedLines'
+ *  algorithm exactly (same width check, same drop-trailing-whitespace-at-a-
+ *  wrap rule) so the line count here matches what was already measured and
+ *  charged for via measureInlineRuns/countWrappedLines. Mutates doc.font/
+ *  fontSize as it measures — caller saves/restores. */
+function wrapRunsIntoLines(doc: PDFKit.PDFDocument, runs: RichTextRun[], width: number, fontSize: number, bodyFonts: BodyFonts, forceBold: boolean): RunToken[][] {
+  const lines: RunToken[][] = [[]];
+  let lineWidth = 0;
+  for (const token of tokenizeRunsForWrap(runs)) {
+    if (token.isBreak) {
+      lines.push([]);
+      lineWidth = 0;
+      continue;
+    }
+    doc.font(fontFor(bodyFonts, forceBold || token.run.bold, token.run.italic)).fontSize(fontSize);
+    const tokenWidth = doc.widthOfString(token.text);
+    if (lineWidth > 0 && lineWidth + tokenWidth > width) {
+      if (token.isWhitespace) continue; // drop trailing/would-be-leading space at a wrap point
+      lines.push([]);
+      lineWidth = 0;
+    }
+    lines[lines.length - 1]!.push(token);
+    lineWidth += tokenWidth;
+  }
+  return lines;
+}
+
+/** A maximal same-run chunk of one wrapped line, with its drawn width. */
+interface RunFragment { text: string; run: RichTextRun; width: number }
+
+/** Trims leading/trailing whitespace tokens off one wrapped line (matching
+ *  pdfkit's own line-trimming) and merges consecutive same-run tokens into one
+ *  fragment per draw call — reconstructing e.g. a multi-word link run as a
+ *  single fragment rather than one draw call per word. Mutates doc.font/
+ *  fontSize as it measures — caller saves/restores. */
+function fragmentsForLine(doc: PDFKit.PDFDocument, tokens: RunToken[], fontSize: number, bodyFonts: BodyFonts, forceBold: boolean): RunFragment[] {
+  let start = 0;
+  let end = tokens.length;
+  while (start < end && tokens[start]!.isWhitespace) start++;
+  while (end > start && tokens[end - 1]!.isWhitespace) end--;
+
+  const fragments: RunFragment[] = [];
+  for (const token of tokens.slice(start, end)) {
+    const last = fragments[fragments.length - 1];
+    if (last && last.run === token.run) last.text += token.text;
+    else fragments.push({ text: token.text, run: token.run, width: 0 });
+  }
+  for (const frag of fragments) {
+    doc.font(fontFor(bodyFonts, forceBold || frag.run.bold, frag.run.italic)).fontSize(fontSize);
+    frag.width = doc.widthOfString(frag.text);
+  }
+  return fragments;
+}
+
+/** Draws a run sequence for center/right alignment: wraps the runs into lines
+ *  itself (see wrapRunsIntoLines), then positions each LINE's total width
+ *  against the box and draws its fragments run after run — as opposed to
+ *  pdfkit's continued-text mode, which would align each run independently
+ *  inside `width` and stack every run of a line on top of the others. */
+function drawAlignedRuns(
+  doc: PDFKit.PDFDocument,
+  runs: RichTextRun[],
+  x: number,
+  y: number,
+  width: number,
+  fontSize: number,
+  bodyFonts: BodyFonts,
+  align: 'center' | 'right',
+  color: string,
+  forceBold: boolean,
+): void {
+  const lines = wrapRunsIntoLines(doc, runs, width, fontSize, bodyFonts, forceBold);
+  const lineHeight = maxLineHeightForRuns(doc, runs, fontSize, bodyFonts, forceBold);
+  lines.forEach((lineTokens, i) => {
+    const fragments = fragmentsForLine(doc, lineTokens, fontSize, bodyFonts, forceBold);
+    if (!fragments.length) return;
+    const lineWidth = fragments.reduce((sum, f) => sum + f.width, 0);
+    let curX = align === 'center' ? x + (width - lineWidth) / 2 : x + width - lineWidth;
+    const curY = y + i * lineHeight;
+    for (const frag of fragments) {
+      doc.font(fontFor(bodyFonts, forceBold || frag.run.bold, frag.run.italic)).fontSize(fontSize).fillColor(frag.run.link ? LINK_COLOR : color);
+      // A `width` wide enough that this single fragment never itself wraps —
+      // it already fits by construction (wrapRunsIntoLines wrapped against the
+      // same box width). Needed even though wrapping isn't wanted: without a
+      // `width` option pdfkit takes single-fragment `_line`'s no-wrapper path,
+      // which never populates options.textWidth/wordCount — the exact values
+      // link-annotation placement below reads, so a link run drew as
+      // `unsupported number: NaN` with lineBreak:false instead.
+      doc.text(frag.text, curX, curY, {
+        width,
+        lineBreak: false,
+        underline: frag.run.underline || !!frag.run.link,
+        link: frag.run.link ?? null,
+      });
+      curX += frag.width;
+    }
+  });
 }
 
 /** Same per-run measurement for a single inline-runs string (table cells):

--- a/apps/api/src/services/tablePdf.test.ts
+++ b/apps/api/src/services/tablePdf.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import zlib from 'node:zlib';
 import PDFDocument from 'pdfkit';
-import { PDFDocument as PdfLibDocument, PDFArray, PDFDict, PDFName, PDFRawStream, PDFString, decodePDFRawStream } from 'pdf-lib';
+import { PDFDocument as PdfLibDocument, PDFArray, PDFDict, PDFName, PDFRawStream, PDFStream, PDFString, decodePDFRawStream } from 'pdf-lib';
 import { parseTable, measureTable, renderTableIntoPdf, MIN_COLUMN_WIDTH, CELL_PADDING, type EnsureRoomRich, type TableModel } from './tablePdf';
 import { registerThemeFonts } from './documentThemes';
 import type { QuoteTableContent } from '@breeze/shared';
@@ -528,8 +528,8 @@ describe('renderTableIntoPdf multi-run cells in non-left-aligned columns (#4438)
         }
         const contentsEntry = page.node.get(PDFName.of('Contents'));
         const contents = contentsEntry instanceof PDFArray
-          ? contentsEntry.asArray().map((ref) => lib.context.lookupMaybe(ref as never, PDFRawStream))
-          : [lib.context.lookupMaybe(contentsEntry as never, PDFRawStream)];
+          ? contentsEntry.asArray().map((ref) => lib.context.lookupMaybe(ref as never, PDFStream))
+          : [lib.context.lookupMaybe(contentsEntry as never, PDFStream)];
         for (const stream of contents.filter((s): s is PDFRawStream => s instanceof PDFRawStream)) {
           const body = Buffer.from(decodePDFRawStream(stream).decode()).toString('latin1');
           const textObjectRe = /BT\s+([\s\S]*?)\s+ET/g;

--- a/apps/api/src/services/tablePdf.test.ts
+++ b/apps/api/src/services/tablePdf.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import zlib from 'node:zlib';
 import PDFDocument from 'pdfkit';
-import { PDFDocument as PdfLibDocument } from 'pdf-lib';
+import { PDFDocument as PdfLibDocument, PDFArray, PDFDict, PDFName, PDFRawStream, PDFString, decodePDFRawStream } from 'pdf-lib';
 import { parseTable, measureTable, renderTableIntoPdf, MIN_COLUMN_WIDTH, CELL_PADDING, type EnsureRoomRich, type TableModel } from './tablePdf';
 import { registerThemeFonts } from './documentThemes';
 import type { QuoteTableContent } from '@breeze/shared';
@@ -481,5 +481,238 @@ describe('renderTableIntoPdf', () => {
     // in the (uncompressed) object bodies instead of the content stream).
     const raw = buf.toString('latin1');
     expect(raw).toContain('Helvetica-Bold');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multi-run cells in non-left-aligned columns (#4438).
+//
+// A cell whose HTML carries formatting (`<strong>`, `<a>`) is drawn as several
+// pdfkit `continued: true` runs. pdfkit applies `align` to EVERY text() call —
+// including each continued run — so a multi-run cell in a centered or
+// right-aligned column used to paint each run individually aligned inside the
+// box: all the runs of one line landed on top of each other. drawRuns now lays
+// those lines out itself (richTextPdf.ts); these tests pin the geometry from
+// the rendered bytes rather than trusting the implementation.
+// ---------------------------------------------------------------------------
+describe('renderTableIntoPdf multi-run cells in non-left-aligned columns (#4438)', () => {
+  const ACCENT = '#2563eb';
+  // Column weights 3/2 over an A4 content width (495pt) → 297pt + 198pt boxes.
+  const CENTER_HTML =
+    '<strong>Bold</strong> lead then a <a href="https://example.com/sla">service level link</a> plus enough trailing words that the cell wraps onto a second line';
+  const RIGHT_HTML = 'Base <strong>$1,200.00</strong> per <a href="https://example.com/pricing">month</a>';
+
+  interface Fragment { text: string; x: number; y: number; width: number; baseFont: string; size: number }
+
+  /** Every drawn text run with its origin, font and advance width. pdfkit
+   *  emits one `BT … ET` object per run: a `1 0 0 1 x y Tm` origin, a
+   *  `/Fn size Tf` font selection and a TJ show-text array. Widths are
+   *  re-measured at the fragment's own font+size — the TJ kerning adjustments
+   *  pdfkit interleaves are already included in widthOfString, so adding them
+   *  back would over-measure (verified against the underline rule pdfkit draws
+   *  for the same run, which spans exactly widthOfString). */
+  async function extractTextFragments(pdf: Buffer, pageHeight = 841.89): Promise<Fragment[]> {
+    const lib = await PdfLibDocument.load(pdf);
+    const measurer = new PDFDocument({ size: 'A4', margin: 50 });
+    const fragments: Fragment[] = [];
+    try {
+      for (const page of lib.getPages()) {
+        const fontByResourceName = new Map<string, string>();
+        const resources = page.node.Resources();
+        const fontEntry = resources instanceof PDFDict ? resources.get(PDFName.of('Font')) : undefined;
+        const fontDict = fontEntry instanceof PDFDict ? fontEntry : lib.context.lookupMaybe(fontEntry as never, PDFDict);
+        for (const [name, value] of fontDict?.entries() ?? []) {
+          const fontObj = lib.context.lookupMaybe(value as never, PDFDict);
+          const baseFont = fontObj?.get(PDFName.of('BaseFont'));
+          if (baseFont) fontByResourceName.set(name.toString(), baseFont.toString().replace(/^\//, ''));
+        }
+        const contentsEntry = page.node.get(PDFName.of('Contents'));
+        const contents = contentsEntry instanceof PDFArray
+          ? contentsEntry.asArray().map((ref) => lib.context.lookupMaybe(ref as never, PDFRawStream))
+          : [lib.context.lookupMaybe(contentsEntry as never, PDFRawStream)];
+        for (const stream of contents.filter((s): s is PDFRawStream => s instanceof PDFRawStream)) {
+          const body = Buffer.from(decodePDFRawStream(stream).decode()).toString('latin1');
+          const textObjectRe = /BT\s+([\s\S]*?)\s+ET/g;
+          let textObject: RegExpExecArray | null;
+          while ((textObject = textObjectRe.exec(body))) {
+            const block = textObject[1]!;
+            const tm = /1 0 0 1 ([\d.]+) ([\d.]+) Tm/.exec(block);
+            if (!tm) continue;
+            const tf = /\/(\w+) ([\d.]+) Tf/.exec(block);
+            const tokenRe = /<([0-9a-fA-F]+)>|\(((?:[^()\\]|\\.)*)\)/g;
+            let text = '';
+            let token: RegExpExecArray | null;
+            while ((token = tokenRe.exec(block))) {
+              text += token[1] !== undefined
+                ? Buffer.from(token[1].length % 2 ? `${token[1]}0` : token[1], 'hex').toString('latin1')
+                : token[2]!.replace(/\\([()\\])/g, '$1');
+            }
+            if (!text.length) continue;
+            const size = Number(tf?.[2] ?? 10);
+            const baseFont = fontByResourceName.get(`/${tf?.[1] ?? ''}`) ?? 'Helvetica';
+            measurer.font(baseFont).fontSize(size);
+            fragments.push({ text, x: Number(tm[1]), y: pageHeight - Number(tm[2]), size, baseFont, width: measurer.widthOfString(text) });
+          }
+        }
+      }
+    } finally {
+      measurer.end();
+    }
+    return fragments;
+  }
+
+  /** Link annotations on page 1: URI + rect (PDF user space, y up). */
+  async function extractLinkAnnotations(pdf: Buffer): Promise<{ uri: string; rect: number[] }[]> {
+    const lib = await PdfLibDocument.load(pdf);
+    const annots = lib.getPage(0).node.Annots();
+    const links: { uri: string; rect: number[] }[] = [];
+    for (const ref of annots?.asArray() ?? []) {
+      const annot = lib.context.lookupMaybe(ref as never, PDFDict);
+      if (!annot || annot.get(PDFName.of('Subtype'))?.toString() !== '/Link') continue;
+      const action = lib.context.lookupMaybe(annot.get(PDFName.of('A')) as never, PDFDict);
+      const uri = action?.get(PDFName.of('URI'));
+      const rect = annot.get(PDFName.of('Rect'));
+      links.push({
+        uri: uri instanceof PDFString ? uri.decodeText() : String(uri ?? ''),
+        rect: rect instanceof PDFArray ? rect.asArray().map((n) => Number(String(n))) : [],
+      });
+    }
+    return links;
+  }
+
+  /** Group fragments into drawn lines (same baseline) and sort each left→right. */
+  function toLines(fragments: Fragment[]): Fragment[][] {
+    const lines: Fragment[][] = [];
+    for (const f of [...fragments].sort((a, b) => a.y - b.y || a.x - b.x)) {
+      const line = lines[lines.length - 1];
+      if (line && Math.abs(line[0]!.y - f.y) < 0.5) line.push(f);
+      else lines.push([f]);
+    }
+    return lines;
+  }
+
+  interface ColumnBox { inner: { left: number; right: number }; outer: { left: number; right: number } }
+  interface Rendered { buf: Buffer; columns: ColumnBox[]; rowTop: number }
+
+  async function renderAlignedTable(aligns: ['center' | 'right' | 'left', 'center' | 'right' | 'left']): Promise<Rendered> {
+    const content = {
+      columns: [{ label: 'Item', align: aligns[0], weight: 3 }, { label: 'Amount', align: aligns[1], weight: 2 }],
+      rows: [{ cells: [CENTER_HTML, RIGHT_HTML] }],
+    } as unknown as QuoteTableContent;
+    const captured: Rendered = { buf: Buffer.alloc(0), columns: [], rowTop: 0 };
+    captured.buf = await renderToBuffer((doc) => {
+      const theme = registerThemeFonts(doc, 'classic');
+      const model = measureTable(doc, parseTable(content, doc.page.width - 100)!, theme);
+      let cx = doc.page.margins.left;
+      captured.columns = model.columns.map((col) => {
+        const box = {
+          outer: { left: cx, right: cx + col.width },
+          inner: { left: cx + CELL_PADDING, right: cx + col.width - CELL_PADDING },
+        };
+        cx += col.width;
+        return box;
+      });
+      const yRef = { y: 100 };
+      const ensureRoom = makeEnsureRoomRich(doc, yRef);
+      captured.rowTop = yRef.y + model.headerHeight;
+      renderTableIntoPdf(doc, model, { x: doc.page.margins.left, startY: yRef.y, accent: ACCENT, fonts: theme, ensureRoom });
+    });
+    return captured;
+  }
+
+  /** The row's fragments for one column, grouped into lines. Column membership
+   *  is decided by the fragment's origin against the column's OUTER box, so a
+   *  neighbouring column's runs can't leak in however badly aligned they are. */
+  async function cellLines(rendered: Rendered, columnIndex: number): Promise<Fragment[][]> {
+    const fragments = await extractTextFragments(rendered.buf);
+    const { outer } = rendered.columns[columnIndex]!;
+    const inCell = fragments.filter((f) => f.y > rendered.rowTop && f.x >= outer.left - 0.5 && f.x < outer.right - 0.5);
+    return toLines(inCell);
+  }
+
+  it('lays a bold/link multi-run cell out as one centered line sequence, run after run', async () => {
+    const rendered = await renderAlignedTable(['center', 'left']);
+    const span = rendered.columns[0]!.inner;
+    const center = (span.left + span.right) / 2;
+    const lines = await cellLines(rendered, 0);
+
+    // Non-vacuity: the cell really wrapped, and it really drew in more than one
+    // font (the <strong> run) with the link run present.
+    expect(lines.length).toBeGreaterThanOrEqual(2);
+    expect(lines[0]!.length).toBeGreaterThanOrEqual(2);
+    expect(new Set(lines.flat().map((f) => f.baseFont)).size).toBeGreaterThanOrEqual(2);
+    expect(lines.flat().some((f) => f.text.includes('service level link'))).toBe(true);
+
+    for (const line of lines) {
+      const first = line[0]!;
+      const last = line[line.length - 1]!;
+      const lastRight = last.x + last.width;
+      // Centered as a LINE: the whole line's box is centered in the cell, not
+      // each run on its own.
+      expect((first.x + lastRight) / 2).toBeCloseTo(center, 0);
+      expect(first.x).toBeGreaterThanOrEqual(span.left - 0.5);
+      expect(lastRight).toBeLessThanOrEqual(span.right + 0.5);
+      // Runs of one line follow each other instead of painting over each other.
+      for (let i = 1; i < line.length; i++) {
+        const prev = line[i - 1]!;
+        expect(line[i]!.x, `run ${i} overlaps "${prev.text}"`).toBeGreaterThanOrEqual(prev.x + prev.width - 0.6);
+      }
+    }
+  });
+
+  it('right-aligns every line of a bold/link multi-run cell to the cell\'s inner right edge', async () => {
+    const rendered = await renderAlignedTable(['left', 'right']);
+    const span = rendered.columns[1]!.inner;
+    const lines = await cellLines(rendered, 1);
+
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    expect(lines.flat().length).toBeGreaterThanOrEqual(4); // Base / $1,200.00 / per / month
+    expect(new Set(lines.flat().map((f) => f.baseFont)).size).toBeGreaterThanOrEqual(2);
+
+    for (const line of lines) {
+      const first = line[0]!;
+      const last = line[line.length - 1]!;
+      const lastRight = last.x + last.width;
+      expect(lastRight).toBeCloseTo(span.right, 0);
+      expect(first.x).toBeGreaterThanOrEqual(span.left - 0.5);
+      for (let i = 1; i < line.length; i++) {
+        const prev = line[i - 1]!;
+        expect(line[i]!.x, `run ${i} overlaps "${prev.text}"`).toBeGreaterThanOrEqual(prev.x + prev.width - 0.6);
+      }
+    }
+  });
+
+  it('keeps a left-aligned multi-run cell run after run (control for the two above)', async () => {
+    const rendered = await renderAlignedTable(['left', 'left']);
+    const span = rendered.columns[0]!.inner;
+    const lines = await cellLines(rendered, 0);
+
+    expect(lines.length).toBeGreaterThanOrEqual(2);
+    // Left-aligned: the first run of every line starts at the cell's left padding.
+    for (const line of lines) {
+      expect(line[0]!.x).toBeCloseTo(span.left, 0);
+      for (let i = 1; i < line.length; i++) {
+        const prev = line[i - 1]!;
+        expect(line[i]!.x).toBeGreaterThanOrEqual(prev.x + prev.width - 0.6);
+      }
+    }
+  });
+
+  it('gives each link run exactly one annotation, inside its own cell', async () => {
+    const rendered = await renderAlignedTable(['center', 'right']);
+    const links = await extractLinkAnnotations(rendered.buf);
+
+    expect(links.map((l) => l.uri).sort()).toEqual(['https://example.com/pricing', 'https://example.com/sla']);
+    for (const link of links) {
+      const [x1, , x2] = link.rect;
+      const span = (link.uri.endsWith('/sla') ? rendered.columns[0]! : rendered.columns[1]!).inner;
+      expect(x1!).toBeGreaterThanOrEqual(span.left - 0.5);
+      expect(x2!).toBeLessThanOrEqual(span.right + 0.5);
+      expect(x2!).toBeGreaterThan(x1!);
+    }
+    // And no link bled onto the runs that follow it (pdfkit continued-option
+    // stickiness — the same hazard richTextPdf.test.ts guards for paragraphs).
+    const raw = rendered.buf.toString('latin1');
+    expect((raw.match(/\/Subtype \/Link/g) ?? []).length).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary
- `renderLineTable` and `renderRecurringSummary` in `apps/api/src/services/quotePdf.ts` now take the resolved `PdfThemeFonts` and use `fonts.heading.bold` / `fonts.body.regular` / `fonts.body.bold` for every draw call (column headers + section label → heading; row/summary text → body), replacing every hard-coded `'Helvetica'` / `'Helvetica-Bold'` literal that remained after #4435.
- Fixed a real bug in `richTextPdf.ts`'s `drawRuns`: pdfkit applies `align`/`width` to **every** `continued: true` call, not the paragraph as a whole, so a multi-run cell (e.g. `<strong>Bold</strong> lead then a <a>link</a>...`) in a centered/right-aligned table column had each run re-center/re-right-anchor itself inside the box — painting every run of a line on top of the others. Non-left alignment now wraps the runs itself (mirroring `countWrappedLines`' exact algorithm) and positions each wrapped **line** against the box, drawing its fragments run after run.
- Added `quotePdf.themeFonts.test.ts`: spies on the real pdfkit `font()`/`text()` calls to assert every string drawn in `renderLineTable`/`renderRecurringSummary` uses the correct resolved font, for both the condensed and classic themes, plus a blanket "no Helvetica draw in a themed doc" assertion.
- Extended `tablePdf.test.ts` with coverage for bold/link multi-run cells in centered, right-aligned, and (control) left-aligned columns — asserting real geometry (fragment x-positions, line centering/right-anchoring, no overlap) and link-annotation placement from the rendered PDF bytes.

## Root cause
`renderLineTable`/`renderRecurringSummary` predate the theme-fonts work (#4435 only touched the header block) and were never updated to accept `fonts`. Separately, `drawRuns`'s reliance on pdfkit's own continued-text `align` handling only ever worked for `align: 'left'` — pdfkit does not lay out a continued-run paragraph as one unit for center/right, it re-applies the alignment box per run.

## Verification
```
cd apps/api
npx vitest run src/services/quotePdf.themeFonts.test.ts src/services/tablePdf.test.ts src/services/richTextPdf.test.ts src/services/quotePdf.test.ts src/services/quotePdf.classicRegression.test.ts src/services/calloutPdf.test.ts src/services/invoicePdf.test.ts src/services/invoicePdf.appendix.test.ts src/services/documentThemes.test.ts src/services/richTextSanitize.test.ts
# 10 files, 177 tests passed

NODE_OPTIONS="--max-old-space-size=8192" npx tsc --noEmit -p apps/api
# clean (0 errors)
```

## Decisions / notes for reviewer
- This branch started from a Qwen headless handoff that left only the two new test files (unreviewed, uncommitted-implementation). I verified the tests were real (non-vacuous, exercising actual pdfkit draw calls / rendered PDF bytes) before building the implementation against them TDD-style (confirmed both failed red first).
- Found and fixed one `tsc` error in the qwen-authored `tablePdf.test.ts`: `PDFContext.lookupMaybe` has no `typeof PDFRawStream` overload (only `typeof PDFStream`); switched to looking up `PDFStream` and narrowing via the existing `instanceof PDFRawStream` filter.
- `renderLineTable`/`renderRecurringSummary` are internal (not exported) functions only called from `renderQuotePdf` in the same file — added `fonts: PdfThemeFonts` as a new required parameter (placed before the existing defaulted params) rather than making it optional, since every caller already has `fonts` in scope.
- This worktree's session had an automatic snapshot mechanism commit the finished implementation directly (visible as the two `wip: qwen handoff snapshot` commits already on this branch/pushed to origin) before I could squash it into one commit. Since this repo squash-merges PRs (`gh pr merge --squash --admin`), I left the history as-is rather than force-pushing a rewritten history (force-push is disallowed for this session) — the PR will still land as one clean commit on merge.
- Split off from #3546/#4435 per the issue; does not touch any other document type (invoice/contract) rendering.

Closes #4438

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BvRUzSeEUfd6QMvYYMPUGZ