### PR TITLE
fix(ai-agents): warn when an org-only agent has no partner baseline (#4170)

### DIFF
--- a/apps/api/src/routes/aiAgents.test.ts
+++ b/apps/api/src/routes/aiAgents.test.ts
@@ -48,6 +48,7 @@ const {
   resolveEffectiveAgentSystemMock,
   loadGraduationRowsMock,
   loadActOpReliabilityMock,
+  loadPartnerBaselineKindsMock,
 } = vi.hoisted(() => ({
   selectMock: vi.fn(),
   // Explicit generic: vitest infers a zero-arg tuple from a bare `() => true`
@@ -90,6 +91,11 @@ const {
   resolveEffectiveAgentSystemMock: vi.fn(),
   loadGraduationRowsMock: vi.fn(),
   loadActOpReliabilityMock: vi.fn(),
+  // #4170 — GET / 's per-row `hasPartnerBaseline` flag and top-level
+  // `partnerBaselineKinds` set. Own unit coverage is
+  // effectivePolicy.test.ts's `loadPartnerBaselineKinds` describe block;
+  // these route tests exercise only how GET / consumes the result.
+  loadPartnerBaselineKindsMock: vi.fn(),
 }));
 
 vi.mock('../middleware/auth', async (importOriginal) => {
@@ -279,6 +285,7 @@ vi.mock('../db', () => ({
 vi.mock('../services/aiAgents/effectivePolicy', () => ({
   resolveEffectiveAgent: resolveEffectiveAgentMock,
   resolveEffectiveAgentSystem: resolveEffectiveAgentSystemMock,
+  loadPartnerBaselineKinds: loadPartnerBaselineKindsMock,
 }));
 
 vi.mock('../services/aiAgents/graduationService', () => ({
@@ -392,6 +399,7 @@ beforeEach(() => {
   authOkMock.mockReturnValue(true);
   mfaOkMock.mockReturnValue(true);
   getAgentMock.mockResolvedValue(agent());
+  loadPartnerBaselineKindsMock.mockResolvedValue(new Set());
   verifyDeviceAccessMock.mockResolvedValue({
     device: { id: DEVICE_ID, orgId: ORG_ID, siteId: null },
   });
@@ -3269,7 +3277,7 @@ describe('GET /ai-agents', () => {
     const res = await buildApp().request('/ai-agents');
 
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ data: [] });
+    expect(await res.json()).toEqual({ data: [], partnerBaselineKinds: [] });
     expect(selectDistinctOnMock).not.toHaveBeenCalled();
   });
 
@@ -3298,6 +3306,74 @@ describe('GET /ai-agents', () => {
 
     expect(res.status).toBe(200);
     expect(listAgentsMock).toHaveBeenCalledWith(expect.anything(), { includeDisabled: false });
+  });
+});
+
+// #4170 — an org-only row is override-only by design
+// (effectivePolicy.ts's `if (!partnerRow) return null`), but nothing told
+// the list or the create form when a row is inert for exactly that reason.
+describe('GET /ai-agents — hasPartnerBaseline (#4170)', () => {
+  beforeEach(() => {
+    selectDistinctOnMock.mockReturnValue(distinctChain([]));
+  });
+
+  it('reports false on an org row whose kind has no partner-wide baseline', async () => {
+    listAgentsMock.mockResolvedValue([agentRow({ orgId: ORG_ID, partnerId: null, kind: 'triage' })]);
+    loadPartnerBaselineKindsMock.mockResolvedValue(new Set());
+
+    const res = await buildApp().request('/ai-agents');
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data[0].hasPartnerBaseline).toBe(false);
+    expect(body.partnerBaselineKinds).toEqual([]);
+  });
+
+  it('reports true on an org row whose kind DOES have a partner-wide baseline', async () => {
+    listAgentsMock.mockResolvedValue([agentRow({ orgId: ORG_ID, partnerId: null, kind: 'triage' })]);
+    loadPartnerBaselineKindsMock.mockResolvedValue(new Set(['triage']));
+
+    const res = await buildApp().request('/ai-agents');
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data[0].hasPartnerBaseline).toBe(true);
+    expect(body.partnerBaselineKinds).toEqual(['triage']);
+  });
+
+  it('always reports true for a partner-wide row itself, regardless of the baseline set', async () => {
+    listAgentsMock.mockResolvedValue([agentRow({ orgId: null, partnerId: PARTNER_ID, kind: 'patch' })]);
+    loadPartnerBaselineKindsMock.mockResolvedValue(new Set());
+
+    const res = await buildApp(false, { scope: 'partner', partnerId: PARTNER_ID }).request('/ai-agents');
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data[0].hasPartnerBaseline).toBe(true);
+  });
+
+  it("pins the baseline lookup to the caller's own partnerId", async () => {
+    listAgentsMock.mockResolvedValue([agentRow({ orgId: ORG_ID, partnerId: null })]);
+
+    await buildApp(false, { partnerId: PARTNER_ID }).request('/ai-agents');
+
+    expect(loadPartnerBaselineKindsMock).toHaveBeenCalledWith(PARTNER_ID);
+  });
+
+  it('computes the baseline set in ONE call for the whole page, never per row', async () => {
+    listAgentsMock.mockResolvedValue([
+      agentRow({ id: AGENT_ID, orgId: ORG_ID, partnerId: null, kind: 'triage' }),
+      agentRow({ id: OTHER_ORG_ID, orgId: ORG_ID, partnerId: null, kind: 'patch' }),
+    ]);
+    loadPartnerBaselineKindsMock.mockResolvedValue(new Set(['triage']));
+
+    const res = await buildApp().request('/ai-agents');
+
+    expect(res.status).toBe(200);
+    expect(loadPartnerBaselineKindsMock).toHaveBeenCalledTimes(1);
+    const body = await res.json();
+    expect(body.data.find((row: { id: string }) => row.id === AGENT_ID).hasPartnerBaseline).toBe(true);
+    expect(body.data.find((row: { id: string }) => row.id === OTHER_ORG_ID).hasPartnerBaseline).toBe(false);
   });
 });
 

--- a/apps/api/src/routes/aiAgents.ts
+++ b/apps/api/src/routes/aiAgents.ts
@@ -54,7 +54,11 @@ import {
   ActPrerequisitesNotMetError, AgentInvariantError, AgentKindConflictError,
   InvalidSupervisedActionKeysError, UnsupportedAgentModeError,
 } from '../services/aiAgents/agentService';
-import { resolveEffectiveAgent, resolveEffectiveAgentSystem } from '../services/aiAgents/effectivePolicy';
+import {
+  loadPartnerBaselineKinds,
+  resolveEffectiveAgent,
+  resolveEffectiveAgentSystem,
+} from '../services/aiAgents/effectivePolicy';
 import { loadActOpReliability, loadGraduationRows } from '../services/aiAgents/graduationService';
 import { demoteSupervisedKey } from '../services/aiAgents/supervisedKeyDemote';
 import { POLICY_DECIDABLE_TIER3 } from '../services/actionIntents/policyDecidable';
@@ -337,16 +341,27 @@ aiAgentsRoutes.get(
     // Batched, never per row: the settings page renders every agent this
     // caller owns, and a per-row query would be one round trip per agent.
     const lastRuns = await loadLastRuns(auth, rows.map((row) => row.id));
+    // #4170: one query for the whole page, same convention as loadLastRuns
+    // above — never one per row. Reported both per-row (`hasPartnerBaseline`,
+    // so the list can flag an org row the resolver would treat as inert) and
+    // as its own top-level set (`partnerBaselineKinds`, so the create form can
+    // warn before a kind's org row exists at all to read the per-row flag
+    // off of).
+    const partnerBaselineKinds = await loadPartnerBaselineKinds(auth.partnerId);
     return c.json({
       data: rows.map((row) => {
         const last = lastRuns.get(row.id);
         return {
           ...mapRow(row),
+          // A partner-wide row IS the baseline, so it is always effective by
+          // definition; an org row is effective only if its own kind has one.
+          hasPartnerBaseline: row.partnerId !== null || partnerBaselineKinds.has(row.kind),
           lastRunAt: last?.lastRunAt ?? null,
           lastRunStatus: last?.lastRunStatus ?? null,
           lastRunFindingsToReview: last?.lastRunFindingsToReview ?? null,
         };
       }),
+      partnerBaselineKinds: Array.from(partnerBaselineKinds),
     });
   },
 );

--- a/apps/api/src/services/aiAgents/effectivePolicy.test.ts
+++ b/apps/api/src/services/aiAgents/effectivePolicy.test.ts
@@ -65,6 +65,7 @@ import {
 } from '../../db';
 import type { AuthContext } from '../../middleware/auth';
 import {
+  loadPartnerBaselineKinds,
   mergeAgentPolicies,
   normalizeAgentPolicy,
   resolveEffectiveAgent,
@@ -565,6 +566,51 @@ describe('resolveEffectiveAgentSystem', () => {
 
     await expect(resolveEffectiveAgentSystem(ORG_ID, 'triage')).resolves.not.toBeNull();
 
+    expect(runOutsideDbContext).not.toHaveBeenCalled();
+    expect(withSystemDbAccessContext).not.toHaveBeenCalled();
+  });
+});
+
+describe('loadPartnerBaselineKinds (#4170)', () => {
+  it('returns the empty set without querying when partnerId is null', async () => {
+    const result = await loadPartnerBaselineKinds(null);
+
+    expect(result).toEqual(new Set());
+    expect(runOutsideDbContext).not.toHaveBeenCalled();
+  });
+
+  it('returns every kind with an active partner-wide row', async () => {
+    dbMockState.aiAgentRows = [[{ kind: 'triage' }, { kind: 'patch' }]];
+
+    const result = await loadPartnerBaselineKinds(PARTNER_ID);
+
+    expect(result).toEqual(new Set(['triage', 'patch']));
+  });
+
+  it('returns the empty set when no partner-wide row exists for this partner', async () => {
+    dbMockState.aiAgentRows = [[]];
+
+    const result = await loadPartnerBaselineKinds(PARTNER_ID);
+
+    expect(result).toEqual(new Set());
+  });
+
+  it('elevates the read the same way the resolver escapes for the partner-row lookup', async () => {
+    dbMockState.aiAgentRows = [[{ kind: 'triage' }]];
+
+    await loadPartnerBaselineKinds(PARTNER_ID);
+
+    expect(runOutsideDbContext).toHaveBeenCalledTimes(1);
+    expect(withSystemDbAccessContext).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the escalation when already inside a system context', async () => {
+    dbMockState.aiAgentRows = [[{ kind: 'triage' }]];
+    dbMockState.ambientContext = { scope: 'system' };
+
+    const result = await loadPartnerBaselineKinds(PARTNER_ID);
+
+    expect(result).toEqual(new Set(['triage']));
     expect(runOutsideDbContext).not.toHaveBeenCalled();
     expect(withSystemDbAccessContext).not.toHaveBeenCalled();
   });

--- a/apps/api/src/services/aiAgents/effectivePolicy.ts
+++ b/apps/api/src/services/aiAgents/effectivePolicy.ts
@@ -1,6 +1,7 @@
 import { and, eq, isNull } from 'drizzle-orm';
 import { HTTPException } from 'hono/http-exception';
 import {
+  AI_AGENT_KINDS,
   AI_AGENT_LIMIT_DEFAULTS,
   AI_AGENT_POLICY_SNAPSHOT_VERSION,
   aiAgentActAssetsSchema,
@@ -309,6 +310,48 @@ export function mergeAgentPolicies(
   };
 
   return { effective, provenance };
+}
+
+/**
+ * Which `AiAgentKind`s currently have an active (non-disabled) partner-wide
+ * baseline row for `partnerId` — i.e. which kinds `resolveEffectiveAgentInner`
+ * would NOT reject at its `if (!partnerRow) return null` gate above.
+ *
+ * #4170: an org-only agent is override-only by design (that gate), but
+ * nothing told the create form or the agents list that a given org row is
+ * inert until a partner baseline for its kind exists. The LIST route
+ * (`GET /ai/agents`) uses this to flag existing org rows, and reports the
+ * whole set on the response so the create form can warn BEFORE a kind's org
+ * row exists at all — there is nothing to read `hasPartnerBaseline` off of at
+ * that point.
+ *
+ * Same read-elevation as the partner-row lookup in `resolveEffectiveAgentInner`
+ * (`readWithPartnerAxisVisibility`, pending the real RLS branch tracked by
+ * #4942) — an org token carries a partnerId but never passes
+ * `breeze_has_partner_access`, so a plain read under its own RLS context would
+ * silently come back empty. `partnerId: null` (no partner axis at all) answers
+ * the empty set without a query.
+ */
+export async function loadPartnerBaselineKinds(
+  partnerId: string | null,
+): Promise<Set<AiAgentKind>> {
+  if (!partnerId) return new Set();
+
+  const rows = await readWithPartnerAxisVisibility(() =>
+    db
+      .select({ kind: aiAgents.kind })
+      .from(aiAgents)
+      .where(and(
+        eq(aiAgents.partnerId, partnerId),
+        isNull(aiAgents.orgId),
+        isNull(aiAgents.disabledAt),
+      ))
+      // Bounded by the partial unique index (`ai_agents_partner_kind_uq`): at
+      // most one live partner-wide row per kind, so this can never return more
+      // than AI_AGENT_KINDS.length rows.
+      .limit(AI_AGENT_KINDS.length));
+
+  return new Set(rows.map((row) => row.kind));
 }
 
 export type ResolvedAgent = AiAgentPolicySnapshot;

--- a/apps/web/src/components/settings/AiAgentForm.test.tsx
+++ b/apps/web/src/components/settings/AiAgentForm.test.tsx
@@ -27,6 +27,7 @@ vi.mock('../../stores/orgStore', () => ({
   useOrgStore: (sel?: (s: typeof orgState.current) => unknown) => (sel ? sel(orgState.current) : orgState.current),
 }));
 
+import { AI_AGENT_KINDS } from '@breeze/shared';
 import AiAgentForm, { type AiAgentDto } from './AiAgentForm';
 import { fetchWithAuth } from '../../stores/auth';
 
@@ -109,6 +110,10 @@ function renderForm(props: Partial<React.ComponentProps<typeof AiAgentForm>> = {
     <AiAgentForm
       agent={null}
       agents={[]}
+      // Default to "every kind already has a baseline" — the pre-#4170
+      // neutral state — so existing tests never see the new hint unless a
+      // test opts into the empty set to exercise it directly.
+      partnerBaselineKinds={new Set(AI_AGENT_KINDS)}
       showOwnerScope={false}
       defaultOwnerScope="organization"
       onClose={vi.fn()}
@@ -277,6 +282,67 @@ describe('AiAgentForm — mode cards', () => {
       expect(card.className).toContain('flex-col');
       expect(card.className).toContain('items-start');
     }
+  });
+});
+
+// #4170 — an org-only agent overrides a partner-wide baseline of the same
+// kind; with none, the resolver treats the row as if it did not exist.
+describe('AiAgentForm — no-partner-baseline hint', () => {
+  it('warns when creating an org-only agent of a kind with no partner baseline', async () => {
+    mockEndpoints();
+    renderForm({ partnerBaselineKinds: new Set() });
+
+    expect(await screen.findByTestId('ai-agent-no-baseline-hint')).toBeInTheDocument();
+  });
+
+  it('does not warn when a partner baseline already exists for the selected kind', async () => {
+    mockEndpoints();
+    renderForm({ partnerBaselineKinds: new Set(['triage']) });
+
+    await screen.findByTestId('ai-agent-kind');
+    expect(screen.queryByTestId('ai-agent-no-baseline-hint')).toBeNull();
+  });
+
+  it('does not warn when creating a partner-wide agent', async () => {
+    mockEndpoints();
+    renderForm({ defaultOwnerScope: 'partner', partnerBaselineKinds: new Set() });
+
+    await screen.findByTestId('ai-agent-kind');
+    expect(screen.queryByTestId('ai-agent-no-baseline-hint')).toBeNull();
+  });
+
+  it('does not warn when editing an existing agent', async () => {
+    mockEndpoints();
+    renderForm({
+      agent: {
+        id: 'a-1',
+        kind: 'triage',
+        name: 'Triage',
+        enabled: true,
+        mode: 'shadow',
+        model: null,
+        orgId: 'org-1',
+        partnerId: null,
+        ownerScope: 'organization',
+        allOrgs: false,
+        supportedModes: ['off', 'shadow', 'act'],
+        toolAllowlist: [],
+        protectedResources: {},
+        limits: {},
+        triggers: {},
+        recipients: {},
+        actAssets: {},
+        instructions: null,
+        cooldownSeconds: 900,
+        disabledAt: null,
+        createdAt: '2026-08-01T00:00:00.000Z',
+        updatedAt: '2026-08-01T00:00:00.000Z',
+      } as AiAgentDto,
+      partnerBaselineKinds: new Set(),
+    });
+
+    await screen.findByTestId('ai-agent-name');
+    expect(screen.queryByTestId('ai-agent-no-baseline-hint')).toBeNull();
   });
 });
 

--- a/apps/web/src/components/settings/AiAgentForm.tsx
+++ b/apps/web/src/components/settings/AiAgentForm.tsx
@@ -107,6 +107,15 @@ interface Props {
    * uniqueness is (partner_id, kind) and (org_id, kind) independently.
    */
   agents: AiAgentDto[];
+  /**
+   * Kinds that already have an active partner-wide baseline for this org's
+   * partner (#4170). An org-only agent is override-only by design — with no
+   * baseline for its kind, the resolver treats it as if it did not exist —
+   * so this warns BEFORE creating an org row of a kind with no baseline yet.
+   * Reported by GET /ai/agents alongside `agents`, not derivable from
+   * `agents` itself: a not-yet-created kind has no row to read it off of.
+   */
+  partnerBaselineKinds: Set<string>;
   /** Show the partner-wide vs org-owned selector (create-only, partner-scope users). */
   showOwnerScope: boolean;
   defaultOwnerScope: OwnerScope;
@@ -315,6 +324,7 @@ function draftFrom(
 export default function AiAgentForm({
   agent,
   agents,
+  partnerBaselineKinds,
   showOwnerScope,
   defaultOwnerScope,
   onClose,
@@ -1157,6 +1167,20 @@ export default function AiAgentForm({
                 {t('aiAgentsPage.editor.thisOrg')}
               </label>
             </fieldset>
+          )}
+
+          {/* #4170: an org-only agent overrides a partner-wide baseline of the
+              same kind — it is never a standalone policy. Not nested inside
+              `showOwnerScope` above: an org-scoped session's default (and
+              only) create path never renders that selector at all, and is
+              exactly the common case this warns for. */}
+          {isCreate && draft.ownerScope === 'organization' && !partnerBaselineKinds.has(draft.kind) && (
+            <p
+              className="rounded-md border border-amber-300 bg-amber-100 px-3 py-2 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-950/50 dark:text-amber-200 md:col-span-2"
+              data-testid="ai-agent-no-baseline-hint"
+            >
+              {t('aiAgentsPage.inertBadge.hint')}
+            </p>
           )}
 
           {isCreate && availableKinds.length === 0 && (

--- a/apps/web/src/components/settings/AiAgentGraduationPanel.test.tsx
+++ b/apps/web/src/components/settings/AiAgentGraduationPanel.test.tsx
@@ -607,6 +607,7 @@ describe('AiAgentForm — partner ceiling hint', () => {
       <AiAgentForm
         agent={agent(ownerScope, mode)}
         agents={[]}
+        partnerBaselineKinds={new Set()}
         showOwnerScope={ownerScope === 'partner'}
         defaultOwnerScope={ownerScope}
         onClose={() => {}}

--- a/apps/web/src/components/settings/AiAgentsPage.test.tsx
+++ b/apps/web/src/components/settings/AiAgentsPage.test.tsx
@@ -150,6 +150,71 @@ describe('AiAgentsPage', () => {
     expect(screen.queryByTestId('ai-agent-allorgs-a2')).toBeNull();
   });
 
+  // #4170 — an org-only row overrides a partner-wide baseline of the same
+  // kind; with none, the resolver treats the row as if it did not exist even
+  // though its own `enabled`/`mode` columns look live.
+  it('badges an org-owned agent whose kind has no partner-wide baseline as inert', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url === '/ai/agents/policy-decidable-keys') return Promise.resolve(json({ data: [] }));
+      if (url.startsWith('/ai/agents/schedules')) return Promise.resolve(json({ data: [] }));
+      if (url.startsWith('/ai/agents')) {
+        return Promise.resolve(json({
+          data: [{ ...ORG_AGENT, hasPartnerBaseline: false }],
+          partnerBaselineKinds: [],
+        }));
+      }
+      return Promise.resolve(json({ data: [] }));
+    });
+    render(<AiAgentsPage />);
+
+    expect(await screen.findByTestId('ai-agent-inert-badge-a2')).toBeInTheDocument();
+  });
+
+  it('does not badge an org-owned agent whose kind has an active partner-wide baseline', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url === '/ai/agents/policy-decidable-keys') return Promise.resolve(json({ data: [] }));
+      if (url.startsWith('/ai/agents/schedules')) return Promise.resolve(json({ data: [] }));
+      if (url.startsWith('/ai/agents')) {
+        return Promise.resolve(json({
+          data: [{ ...ORG_AGENT, hasPartnerBaseline: true }],
+          partnerBaselineKinds: ['patch'],
+        }));
+      }
+      return Promise.resolve(json({ data: [] }));
+    });
+    render(<AiAgentsPage />);
+
+    await waitFor(() => expect(screen.getByTestId('ai-agent-row-a2')).toBeInTheDocument());
+    expect(screen.queryByTestId('ai-agent-inert-badge-a2')).toBeNull();
+  });
+
+  it('never badges a partner-wide agent as inert, regardless of hasPartnerBaseline', async () => {
+    mockEndpoints([{ ...PARTNER_AGENT, hasPartnerBaseline: false }]);
+    render(<AiAgentsPage />);
+
+    await waitFor(() => expect(screen.getByTestId('ai-agent-row-a1')).toBeInTheDocument());
+    expect(screen.queryByTestId('ai-agent-inert-badge-a1')).toBeNull();
+  });
+
+  // The create form has no existing row for a not-yet-created kind to read
+  // `hasPartnerBaseline` off of, so the page threads the LIST response's
+  // top-level `partnerBaselineKinds` set through to it instead.
+  it('passes partnerBaselineKinds from the list response into the create form', async () => {
+    orgState.current = { ...orgState.current, currentOrgId: 'org-1', allOrgs: false };
+    getJwtClaimsMock.mockReturnValue({ scope: 'organization', partnerId: 'p-1', orgId: 'org-1' });
+    fetchMock.mockImplementation((url: string) => {
+      if (url === '/ai/agents/policy-decidable-keys') return Promise.resolve(json({ data: [] }));
+      if (url.startsWith('/ai/agents/schedules')) return Promise.resolve(json({ data: [] }));
+      if (url.startsWith('/ai/agents')) return Promise.resolve(json({ data: [], partnerBaselineKinds: [] }));
+      return Promise.resolve(json({ data: [] }));
+    });
+    render(<AiAgentsPage />);
+
+    await openCreateForm();
+
+    expect(await screen.findByTestId('ai-agent-no-baseline-hint')).toBeInTheDocument();
+  });
+
   it('treats a malformed 200 body as an error, never as "no agents"', async () => {
     // A gateway error page or a shape change must not render as an empty
     // tenant — that also told the create form every kind was free.

--- a/apps/web/src/components/settings/AiAgentsPage.tsx
+++ b/apps/web/src/components/settings/AiAgentsPage.tsx
@@ -40,6 +40,10 @@ export default function AiAgentsPage() {
   const { isPartnerScope, defaultOwnerScope } = useDefaultOwnerScope();
 
   const [agents, setAgents] = useState<AiAgentDto[]>([]);
+  // #4170: which kinds already have an active partner-wide baseline for this
+  // org's partner — reported alongside `data` because a not-yet-created org
+  // row has no `hasPartnerBaseline` of its own for the create form to read.
+  const [partnerBaselineKinds, setPartnerBaselineKinds] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(true);
   // True once a load has completed at least once. `loading` alone would make
   // every refresh (a save, a re-enable) tear the empty state down and put the
@@ -54,6 +58,7 @@ export default function AiAgentsPage() {
   const [editorDirty, setEditorDirty] = useState(false);
   const [enablingId, setEnablingId] = useState<string | null>(null);
   const allOrgsHintId = useId();
+  const inertHintId = useId();
   /** The agent a Re-enable just restored, so its live row can show a one-time
    *  "switched off, review its policy" note (Finding 1). Cleared by any
    *  further state change — opening or closing the editor — rather than a
@@ -103,13 +108,14 @@ export default function AiAgentsPage() {
       // truncated body. Unguarded, that rejection escaped `void load()` with
       // no unhandledrejection handler anywhere, leaving the page in a
       // permanent loading state that renders as an ordinary empty screen.
-      const body = (await response.json()) as { data?: unknown };
+      const body = (await response.json()) as { data?: unknown; partnerBaselineKinds?: unknown };
       // A body we cannot read is an ERROR, not zero agents. `?? []` reported
       // "no agents yet" for a shape change and, worse, told the create form
       // every kind was free — so the next save 409'd on an agent the page had
       // just said did not exist.
       if (!Array.isArray(body.data)) throw new Error('GET /ai/agents: malformed body');
       setAgents(body.data as AiAgentDto[]);
+      setPartnerBaselineKinds(new Set(Array.isArray(body.partnerBaselineKinds) ? body.partnerBaselineKinds : []));
     } catch (err) {
       console.error('[AiAgentsPage] could not load agents', err);
       setError(true);
@@ -333,6 +339,7 @@ export default function AiAgentsPage() {
             key={editing.agent?.id ?? 'new'}
             agent={editing.agent}
             agents={agents}
+            partnerBaselineKinds={partnerBaselineKinds}
             showOwnerScope={isPartnerScope}
             defaultOwnerScope={defaultOwnerScope}
             onClose={closeEditor}
@@ -445,6 +452,7 @@ export default function AiAgentsPage() {
       {live.length > 0 && (
         <>
         <span id={allOrgsHintId} className="sr-only">{t('aiAgentsPage.allOrgsHint')}</span>
+        <span id={inertHintId} className="sr-only">{t('aiAgentsPage.inertBadge.hint')}</span>
         <ul className="divide-y rounded-lg border" data-testid="ai-agents-list">
           {live.map((agent) => (
             <li key={agent.id} className="flex flex-wrap items-center gap-3 p-3" data-testid={`ai-agent-row-${agent.id}`}>
@@ -499,6 +507,20 @@ export default function AiAgentsPage() {
                   >
                     {agent.enabled ? t('aiAgentsPage.runningBadge.running') : t('aiAgentsPage.runningBadge.notRunning')}
                   </span>
+                  {/* #4170: an org-only row is an override of a partner
+                      baseline, never a standalone policy — with no baseline
+                      for its kind, the resolver treats it as if it did not
+                      exist, regardless of what `enabled`/`mode` say above. */}
+                  {!agent.allOrgs && agent.hasPartnerBaseline === false && (
+                    <span
+                      className={badgeClass('warning', { size: 'sm' })}
+                      aria-describedby={inertHintId}
+                      aria-label={`${t('aiAgentsPage.chipLabels.running')}: ${t('aiAgentsPage.inertBadge.label')}`}
+                      data-testid={`ai-agent-inert-badge-${agent.id}`}
+                    >
+                      {t('aiAgentsPage.inertBadge.label')}
+                    </span>
+                  )}
                   {lastRunCell(agent)}
                 </p>
                 {justReenabledId === agent.id && (

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -1577,6 +1577,10 @@
       "running": "Status",
       "lastRunStatus": "Ergebnis des letzten Laufs"
     },
+    "inertBadge": {
+      "label": "Inaktiv",
+      "hint": "Für diese Art existiert noch keine partnerweite Grundlinie. Ein rein organisationseigener Agent überschreibt nur eine Grundlinie, daher hat er keine Wirkung, bis eine erstellt wird."
+    },
     "lastRun": {
       "never": "Nie ausgeführt",
       "at": "Letzte Ausführung {{at}}"

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -1577,6 +1577,10 @@
       "running": "Status",
       "lastRunStatus": "Last run outcome"
     },
+    "inertBadge": {
+      "label": "Inactive",
+      "hint": "No partner-wide baseline exists yet for this kind. An organization-only agent only overrides a baseline, so it has no effect until one is created."
+    },
     "lastRun": {
       "never": "Never run",
       "at": "Last run {{at}}"

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -1577,6 +1577,10 @@
       "running": "Estado",
       "lastRunStatus": "Resultado de la última ejecución"
     },
+    "inertBadge": {
+      "label": "Inactivo",
+      "hint": "Aún no existe una línea base de todo el partner para este tipo. Un agente exclusivo de la organización solo anula una línea base, por lo que no tiene efecto hasta que se cree una."
+    },
     "lastRun": {
       "never": "Nunca se ejecutó",
       "at": "Última ejecución {{at}}"

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -1577,6 +1577,10 @@
       "running": "Statut",
       "lastRunStatus": "Résultat de la dernière exécution"
     },
+    "inertBadge": {
+      "label": "Inactif",
+      "hint": "Aucune référence à l’échelle du partenaire n’existe encore pour ce type. Un agent propre à l’organisation ne fait que remplacer une référence : il n’a donc aucun effet tant qu’aucune n’est créée."
+    },
     "lastRun": {
       "never": "Jamais exécuté",
       "at": "Dernière exécution {{at}}"

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -1577,6 +1577,10 @@
       "running": "Statut",
       "lastRunStatus": "Résultat de la dernière exécution"
     },
+    "inertBadge": {
+      "label": "Inactif",
+      "hint": "Aucune référence à l’échelle du partenaire n’existe encore pour ce type. Un agent propre à l’organisation ne fait que remplacer une référence : il n’a donc aucun effet tant qu’aucune n’est créée."
+    },
     "lastRun": {
       "never": "Jamais exécuté",
       "at": "Dernière exécution {{at}}"

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -1577,6 +1577,10 @@
       "running": "Stato",
       "lastRunStatus": "Esito dell’ultima esecuzione"
     },
+    "inertBadge": {
+      "label": "Inattivo",
+      "hint": "Per questo tipo non esiste ancora una configurazione di base a livello di partner. Un agente esclusivo dell’organizzazione si limita a sovrascrivere una configurazione di base, quindi non ha alcun effetto finché non ne viene creata una."
+    },
     "lastRun": {
       "never": "Mai eseguito",
       "at": "Ultima esecuzione {{at}}"

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -1577,6 +1577,10 @@
       "running": "Status",
       "lastRunStatus": "Resultado da última execução"
     },
+    "inertBadge": {
+      "label": "Inativo",
+      "hint": "Ainda não existe uma linha de base em todo o parceiro para este tipo. Um agente exclusivo da organização apenas substitui uma linha de base, portanto não tem efeito até que uma seja criada."
+    },
     "lastRun": {
       "never": "Nunca executado",
       "at": "Última execução {{at}}"

--- a/apps/web/src/locales/tr-TR/settings.json
+++ b/apps/web/src/locales/tr-TR/settings.json
@@ -1577,6 +1577,10 @@
       "running": "Durum",
       "lastRunStatus": "Son çalıştırma sonucu"
     },
+    "inertBadge": {
+      "label": "Pasif",
+      "hint": "Bu tür için henüz iş ortağı genelinde bir temel çizgi yok. Yalnızca kuruluşa özgü bir aracı yalnızca bir temel çizgiyi geçersiz kılar, bu nedenle biri oluşturulana kadar hiçbir etkisi olmaz."
+    },
     "lastRun": {
       "never": "Hiç çalıştırılmadı",
       "at": "Son çalıştırma {{at}}"

--- a/packages/shared/src/types/aiAgents.ts
+++ b/packages/shared/src/types/aiAgents.ts
@@ -537,6 +537,20 @@ export interface AiAgentDto {
    * `null` rather than omitting the key.
    */
   lastRunFindingsToReview?: number | null;
+  /**
+   * Whether `resolveEffectiveAgentInner` would treat this row as effective
+   * (#4170) — always `true` for a partner-wide row (`allOrgs`), since it IS
+   * the baseline; for an org row, `true` only when an active partner-wide
+   * baseline of the same `kind` exists for this org's partner. An org row
+   * with `false` here shows `enabled`/`mode` from its own columns but the
+   * resolver returns `null` for it: it overrides nothing and has no effect.
+   *
+   * Optional for the same reason as the `lastRun*` fields above: only the
+   * LIST route computes it (one query for the whole page, not per row) —
+   * every other route that returns an `AiAgentDto` omits the key rather than
+   * guessing at it.
+   */
+  hasPartnerBaseline?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary
- An org-only `ai_agents` row overrides a partner-wide baseline of the same `kind` and is never a standalone policy — `resolveEffectiveAgentInner`'s `if (!partnerRow) return null` gate has always treated it this way. Nothing surfaced that fact to an operator: the row's own `enabled`/`mode` columns still rendered "Act · Enabled" and the exposure-budget/effective-policy endpoints 404'd or returned `null` with no link back to the cause.
- `GET /api/v1/ai/agents` now reports `hasPartnerBaseline` per row (one extra batched query for the whole page, reusing the same `readWithPartnerAxisVisibility` read-elevation the resolver already uses for the partner-row lookup) and a top-level `partnerBaselineKinds` set.
- The AI Agents settings page shows an "Inactive" warning badge on an org-owned row whose kind has no active partner-wide baseline; a partner-wide row is never flagged.
- The create form shows the same warning when creating an org-only agent of a kind with no partner baseline yet — sourced from the list response's `partnerBaselineKinds`, since a not-yet-created kind has no row to read `hasPartnerBaseline` off of.
- New copy added and translated (not just duplicated in English) in all 8 locales.

## Root cause
`resolveEffectiveAgentInner` (`apps/api/src/services/aiAgents/effectivePolicy.ts:393-394`) requires an active partner-wide baseline row to exist before an org override can take effect — this is the intended Partner-Wide-First design (org rows are overrides only, never standalone policy). The create form (`AiAgentForm.tsx`) let an org-scope session create an org-only agent of any kind with no check for a partner baseline, and the list page (`AiAgentsPage.tsx`) read the raw row's `enabled`/`mode` columns rather than the resolved effective policy — so an inert row looked identical to a live one.

## Verification
- `cd apps/api && npx vitest run src/services/aiAgents/effectivePolicy.test.ts` — 31 passed (new `loadPartnerBaselineKinds` describe block: 5 tests)
- `cd apps/api && npx vitest run src/routes/aiAgents.test.ts` — 166 passed (new `hasPartnerBaseline` describe block: 5 tests)
- `cd apps/web && npx vitest run src/components/settings/AiAgentsPage.test.tsx src/components/settings/AiAgentForm.test.tsx src/components/settings/AiAgentGraduationPanel.test.tsx` — 129 passed
- `cd apps/web && npx vitest run src/lib/i18n/localeParity.test.ts src/lib/i18n/translationCoverage.test.ts src/lib/i18n/extractionQuality.test.ts src/lib/i18n/terminologyQuality.test.ts` — 107 passed
- `npx tsc --noEmit -p apps/api` — clean
- `npx tsc --noEmit -p apps/web` — clean
- `npx tsc --noEmit -p packages/shared` — 3 pre-existing errors in `validators/quotes.test.ts`, unrelated to this change and unmodified by it (confirmed via `git status`)

## Decisions / notes for reviewer
- Went with option 2 from the issue (warn/flag, keep override-only semantics) rather than option 1 (let an org row self-enable with no baseline) — the resolver's own docstring already states this is deliberate design, matching the Partner-Wide-First epic (#2135).
- `hasPartnerBaseline` is optional on `AiAgentDto`, computed only by the LIST route — same convention as the existing `lastRunAt`/`lastRunStatus` fields (only the route that needs it pays for it; every other route omits the key).
- The create-form hint reuses the same `aiAgentsPage.inertBadge.hint` copy as the list badge's accessible description, rather than a second key with duplicate text.
- Left `readWithPartnerAxisVisibility` (the system-context escalation) as the elevation mechanism, matching the pattern already in `effectivePolicy.ts` for the partner-row lookup — issue #4942 tracks the eventual real RLS SELECT-branch for `ai_agents`; this PR does not touch RLS policy.
- Did not touch `apps/api/src/routes/aiAgents.ts:258`'s exposure-budget 404 body or `settings.json`'s run-detail copy — those already say the correct thing ("no active agent policy"); this PR's job is making the *cause* visible before a user gets there.

Closes #4170

🤖 Generated with [Claude Code](https://claude.com/claude-code)