### PR TITLE
fix(groups): wire dynamic device group re-evaluation to device change (#4630)

### DIFF
--- a/apps/api/src/events/deviceEvents.test.ts
+++ b/apps/api/src/events/deviceEvents.test.ts
@@ -1,0 +1,156 @@
+/**
+ * #4630 — dynamic device group membership never re-evaluated on device
+ * change because this module's handlers were registered nowhere. Covers:
+ *   - initializeDeviceEventHandlers wires one handler per DeviceChangeEventType
+ *     to the correct groupMembership.ts function.
+ *   - emitDeviceChange fans out to every registered handler and never lets one
+ *     handler's rejection stop another (Promise.allSettled).
+ *   - mapChangedFieldsToFilterFields's field-name mapping used by the
+ *     heartbeat/enrollment/provision emit sites.
+ */
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockUpdateDeviceMemberships,
+  mockEvaluateDeviceMembershipForGroup,
+  mockRemoveDeviceFromAllGroups,
+  mockSelect,
+} = vi.hoisted(() => ({
+  mockUpdateDeviceMemberships: vi.fn().mockResolvedValue({ evaluatedGroups: 0, added: 0, removed: 0 }),
+  mockEvaluateDeviceMembershipForGroup: vi.fn().mockResolvedValue({ evaluatedGroups: 1, added: 0, removed: 0 }),
+  mockRemoveDeviceFromAllGroups: vi.fn().mockResolvedValue(undefined),
+  mockSelect: vi.fn(),
+}));
+
+vi.mock('../services/groupMembership', () => ({
+  updateDeviceMemberships: mockUpdateDeviceMemberships,
+  evaluateDeviceMembershipForGroup: mockEvaluateDeviceMembershipForGroup,
+  removeDeviceFromAllGroups: mockRemoveDeviceFromAllGroups,
+}));
+
+vi.mock('../db', () => ({
+  db: { select: mockSelect },
+}));
+
+vi.mock('../db/schema', () => ({
+  deviceGroups: { id: 'id', orgId: 'orgId', type: 'type', filterConditions: 'filterConditions', filterFieldsUsed: 'filterFieldsUsed' },
+}));
+
+import {
+  createDeviceChangeEvent,
+  emitDeviceChange,
+  initializeDeviceEventHandlers,
+  mapChangedFieldsToFilterFields,
+  onDeviceChange,
+  type DeviceChangeEventType,
+} from './deviceEvents';
+
+const DEVICE_ID = 'dddd0001-dddd-dddd-dddd-dddddddddddd';
+const ORG_ID = 'aaaa0000-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
+function chainSelect(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(rows),
+    }),
+  };
+}
+
+describe('deviceEvents', () => {
+  // eventHandlers is a module-scope singleton with no reset hook, so this
+  // must register exactly once for the whole suite — calling it per-test
+  // would stack duplicate handlers on every DeviceChangeEventType.
+  beforeAll(() => {
+    initializeDeviceEventHandlers();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSelect.mockReturnValue(chainSelect([]));
+  });
+
+  it('wires device.updated to updateDeviceMemberships with mapped filter fields', async () => {
+    await emitDeviceChange(createDeviceChangeEvent('device.updated', DEVICE_ID, ORG_ID, ['hostname', 'deviceRole']));
+
+    expect(mockUpdateDeviceMemberships).toHaveBeenCalledWith(DEVICE_ID, ORG_ID, ['hostname', 'deviceRole']);
+  });
+
+  it('does not call updateDeviceMemberships for device.updated with no changed fields', async () => {
+    await emitDeviceChange(createDeviceChangeEvent('device.updated', DEVICE_ID, ORG_ID, []));
+
+    expect(mockUpdateDeviceMemberships).not.toHaveBeenCalled();
+  });
+
+  it('wires device.hardware_updated to updateDeviceMemberships with hardware-prefixed fields', async () => {
+    await emitDeviceChange(createDeviceChangeEvent('device.hardware_updated', DEVICE_ID, ORG_ID, ['cpuModel']));
+
+    expect(mockUpdateDeviceMemberships).toHaveBeenCalledWith(DEVICE_ID, ORG_ID, ['hardware.cpuModel']);
+  });
+
+  it('wires device.network_updated to updateDeviceMemberships with network-prefixed fields', async () => {
+    await emitDeviceChange(createDeviceChangeEvent('device.network_updated', DEVICE_ID, ORG_ID, ['ipAddress']));
+
+    expect(mockUpdateDeviceMemberships).toHaveBeenCalledWith(DEVICE_ID, ORG_ID, ['network.ipAddress']);
+  });
+
+  it('wires device.software_changed to updateDeviceMemberships with the fixed software fields', async () => {
+    await emitDeviceChange(createDeviceChangeEvent('device.software_changed', DEVICE_ID, ORG_ID, []));
+
+    expect(mockUpdateDeviceMemberships).toHaveBeenCalledWith(
+      DEVICE_ID,
+      ORG_ID,
+      ['software.installed', 'software.notInstalled'],
+    );
+  });
+
+  it('wires device.created to evaluate every dynamic group with a filter in the org', async () => {
+    mockSelect.mockReturnValue(chainSelect([{ id: 'group-1' }, { id: 'group-2' }]));
+
+    await emitDeviceChange(createDeviceChangeEvent('device.created', DEVICE_ID, ORG_ID, []));
+
+    expect(mockEvaluateDeviceMembershipForGroup).toHaveBeenCalledWith('group-1', DEVICE_ID);
+    expect(mockEvaluateDeviceMembershipForGroup).toHaveBeenCalledWith('group-2', DEVICE_ID);
+  });
+
+  it('wires device.deleted to removeDeviceFromAllGroups', async () => {
+    await emitDeviceChange(createDeviceChangeEvent('device.deleted', DEVICE_ID, ORG_ID, []));
+
+    expect(mockRemoveDeviceFromAllGroups).toHaveBeenCalledWith(DEVICE_ID);
+  });
+
+  it('runs every handler for an event type and does not let one rejection stop another', async () => {
+    const failing = vi.fn().mockRejectedValue(new Error('boom'));
+    const succeeding = vi.fn().mockResolvedValue(undefined);
+    const eventType: DeviceChangeEventType = 'device.updated';
+    onDeviceChange(eventType, failing);
+    onDeviceChange(eventType, succeeding);
+
+    await emitDeviceChange(createDeviceChangeEvent(eventType, DEVICE_ID, ORG_ID, ['hostname']));
+
+    expect(failing).toHaveBeenCalled();
+    expect(succeeding).toHaveBeenCalled();
+    // The pre-existing initializeDeviceEventHandlers handler for device.updated
+    // also ran, alongside both of these ad hoc ones.
+    expect(mockUpdateDeviceMemberships).toHaveBeenCalled();
+  });
+
+  it('is a no-op for an event type with no registered handlers', async () => {
+    await expect(
+      emitDeviceChange(createDeviceChangeEvent('device.metrics_updated', DEVICE_ID, ORG_ID, ['cpuPercent'])),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('mapChangedFieldsToFilterFields', () => {
+  it('maps known device fields to their filter field names unprefixed', () => {
+    expect(mapChangedFieldsToFilterFields(['hostname', 'tags'], 'device')).toEqual(['hostname', 'tags']);
+  });
+
+  it('prefixes unmapped fields by source', () => {
+    expect(mapChangedFieldsToFilterFields(['someNewField'], 'hardware')).toEqual(['hardware.someNewField']);
+  });
+
+  it('leaves already-prefixed fields untouched', () => {
+    expect(mapChangedFieldsToFilterFields(['hardware.cpuModel'], 'device')).toEqual(['hardware.cpuModel']);
+  });
+});

--- a/apps/api/src/events/deviceEvents.ts
+++ b/apps/api/src/events/deviceEvents.ts
@@ -2,6 +2,11 @@ import { db } from '../db';
 import { deviceGroups } from '../db/schema';
 import { eq, or } from 'drizzle-orm';
 import { sql } from 'drizzle-orm';
+import {
+  evaluateDeviceMembershipForGroup,
+  removeDeviceFromAllGroups,
+  updateDeviceMemberships,
+} from '../services/groupMembership';
 
 /**
  * Event types that can trigger device change processing
@@ -168,9 +173,6 @@ export function createDeviceChangeEvent(
  * This should be called during app startup
  */
 export function initializeDeviceEventHandlers(): void {
-  // Import here to avoid circular dependencies
-  const { updateDeviceMemberships } = require('../services/groupMembership');
-
   // Handler for device updates - re-evaluate group memberships
   onDeviceChange('device.updated', async (event) => {
     if (event.changedFields.length > 0) {
@@ -224,7 +226,6 @@ export function initializeDeviceEventHandlers(): void {
     for (const group of groups) {
       try {
         // Evaluate if device matches the group's filter
-        const { evaluateDeviceMembershipForGroup } = require('../services/groupMembership');
         await evaluateDeviceMembershipForGroup(group.id, event.deviceId);
       } catch (error) {
         console.error(`Failed to evaluate membership for group ${group.id}:`, error);
@@ -234,7 +235,6 @@ export function initializeDeviceEventHandlers(): void {
 
   // Handler for device deletion - remove from all groups
   onDeviceChange('device.deleted', async (event) => {
-    const { removeDeviceFromAllGroups } = require('../services/groupMembership');
     await removeDeviceFromAllGroups(event.deviceId);
   });
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -217,6 +217,7 @@ import { startRegisteredWorkers, buildWorkerShutdownTasks } from './services/wor
 import { registerAiAgentEnqueuer } from './jobs/aiAgentEnqueuer';
 import { backfillC2cConnectionSecrets } from './services/c2cSecrets';
 import { registerAllEventSubscribers } from './services/eventSubscribers';
+import { initializeDeviceEventHandlers } from './events/deviceEvents';
 import { buildWebhookFanoutDeps } from './services/webhookFanoutDeps';
 import { closeRedis, getRedis, isRedisAvailable } from './services/redis';
 import { shutdownEventDispatcher } from './services/eventDispatcher';
@@ -1748,6 +1749,11 @@ async function bootstrap(): Promise<void> {
   // installed before the queue-mode dispatch worker — or any event published
   // during worker boot — can reach it (codex Q3 hole #2, #4085).
   registerAllEventSubscribers(buildWebhookFanoutDeps());
+
+  // #4630 — dynamic device group membership re-evaluation. Purely in-process
+  // handler registration (no Redis/queue), so it runs unconditionally in
+  // every role, same as registerAllEventSubscribers above.
+  initializeDeviceEventHandlers();
 
   await initializeWorkers();
 

--- a/apps/api/src/routes/agents/enrollment.test.ts
+++ b/apps/api/src/routes/agents/enrollment.test.ts
@@ -383,6 +383,25 @@ describe('POST /agents/enroll — dynamic device group re-evaluation emit (#4630
     process.env.NODE_ENV = 'test';
   });
 
+  it('emits device.created INSIDE a system DB access context (RLS denies contextless reads)', async () => {
+    // Outside withSystemDbAccessContext the handler's dynamic-group SELECT
+    // runs with breeze.scope='none' and silently returns zero rows, so the
+    // enrollment-time evaluation would be a no-op in production.
+    let insideContext = 0;
+    vi.mocked(withSystemDbAccessContext).mockImplementation(async (fn: any) => {
+      insideContext++;
+      try { return await fn(); } finally { insideContext--; }
+    });
+    let emittedInside: number | null = null;
+    emitDeviceChangeMock.mockImplementationOnce(async () => { emittedInside = insideContext; });
+
+    await enrollOk();
+
+    expect(emitDeviceChangeMock).toHaveBeenCalledTimes(1);
+    expect(emittedInside).toBeGreaterThan(0);
+    vi.mocked(withSystemDbAccessContext).mockImplementation(async (fn: any) => fn());
+  });
+
   it('emits device.created for the freshly enrolled device', async () => {
     await enrollOk();
 

--- a/apps/api/src/routes/agents/enrollment.test.ts
+++ b/apps/api/src/routes/agents/enrollment.test.ts
@@ -152,6 +152,13 @@ vi.mock('../../services/partnerTrust', () => ({
   })),
 }));
 
+// #4630 — dynamic device group re-evaluation emit on enrollment.
+const emitDeviceChangeMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+vi.mock('../../events/deviceEvents', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../events/deviceEvents')>();
+  return { ...actual, emitDeviceChange: emitDeviceChangeMock };
+});
+
 // ---------- imports after mocks ----------
 
 import { db, withSystemDbAccessContext } from '../../db';
@@ -365,6 +372,27 @@ describe('POST /agents/enroll — backup server URL delivery (#2288)', () => {
   it('omits/empty backupServerUrl when env unset', async () => {
     const body = await enrollOk();
     expect(body.backupServerUrl ?? '').toBe('');
+  });
+});
+
+describe('POST /agents/enroll — dynamic device group re-evaluation emit (#4630)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.AGENT_ENROLLMENT_SECRET;
+    delete process.env.AGENT_BACKUP_SERVER_URL;
+    process.env.NODE_ENV = 'test';
+  });
+
+  it('emits device.created for the freshly enrolled device', async () => {
+    await enrollOk();
+
+    expect(emitDeviceChangeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'device.created',
+        deviceId: 'device-backup-url',
+        orgId: 'org-backup-url',
+      }),
+    );
   });
 });
 

--- a/apps/api/src/routes/agents/enrollment.ts
+++ b/apps/api/src/routes/agents/enrollment.ts
@@ -40,6 +40,7 @@ import {
 import { partnerTrustMode } from '../../config/partnerTrustMode';
 import { evaluateCapability, trustDenyBody, unresolvedPartnerDecision } from '../../services/partnerTrust';
 import { enqueueIpClassify } from '../../services/ipClassify';
+import { emitDeviceChange, createDeviceChangeEvent } from '../../events/deviceEvents';
 
 export const enrollmentRoutes = new Hono();
 const ENROLLMENT_RATE_LIMIT = 10;
@@ -1050,6 +1051,14 @@ enrollmentRoutes.post('/enroll', zValidator('json', enrollSchema), async (c) => 
       }
       throw err;
     }
+
+    // #4630 — a freshly enrolled device must be evaluated against every
+    // dynamic group in its org immediately, not just on its next filterable
+    // heartbeat change (hostname/OS are already correct at insert, so no
+    // later heartbeat diff would ever fire for a device that matched from
+    // day one). Runs inside this handler's existing withSystemDbAccessContext
+    // wrapper (see the top of this handler), self-tenanted by key.orgId.
+    await emitDeviceChange(createDeviceChangeEvent('device.created', device.id, key.orgId, []));
 
     const mtlsCert = await issueMtlsCertForDevice(device.id, key.orgId);
 

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -277,6 +277,15 @@ vi.mock('../metrics', () => ({
   resolveResponseStatus: (c: any) => (c?.finalized ? (c.res?.status ?? 500) : 500),
 }));
 
+// #4630 — the heartbeat's dynamic-group re-evaluation emit site. Real
+// createDeviceChangeEvent (pure), mocked emitDeviceChange so tests can assert
+// on the event shape without pulling in groupMembership.ts's DB graph.
+const emitDeviceChangeMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+vi.mock('../../events/deviceEvents', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../events/deviceEvents')>();
+  return { ...actual, emitDeviceChange: emitDeviceChangeMock };
+});
+
 import { and, eq, notInArray } from 'drizzle-orm';
 import { heartbeatRoutes } from './heartbeat';
 import { devices } from '../../db/schema';
@@ -3727,6 +3736,86 @@ describe('POST /agents/:id/heartbeat — watchdogVersion telemetry (#1802)', () 
     expect(resp.status).toBe(200);
     const body = await resp.json() as { watchdogUpgradeTo?: string | null };
     expect(body.watchdogUpgradeTo).toBe('0.66.0');
+  });
+});
+
+describe('POST /agents/:id/heartbeat — dynamic device group re-evaluation emit (#4630)', () => {
+  const deviceRow = {
+    id: 'device-1', orgId: 'org-1', siteId: 'site-1', hostname: 'old-host',
+    osType: 'windows', osVersion: '10.0.19045', osBuild: '19045',
+    architecture: 'amd64', agentVersion: '0.66.0', deviceRole: 'workstation',
+    deviceRoleSource: 'auto', lastSeenAt: new Date(), mainAgentSilentSince: null,
+  };
+
+  function arrange() {
+    vi.clearAllMocks();
+    getActiveTrustKeysetMock.mockResolvedValue([]);
+    selectMock.mockReturnValueOnce(selectChainResolving([deviceRow]));
+    selectMock.mockReturnValue(selectChainResolving([]));
+    updateMock.mockReturnValue({ set: vi.fn(() => ({ where: vi.fn(() => whereResultWithReturning()) })) });
+    insertMock.mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) });
+  }
+
+  async function post(body: Record<string, unknown>) {
+    return buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ role: 'agent', metrics: minimalHeartbeatBody.metrics, ...body }),
+    });
+  }
+
+  it('emits device.updated with the changed filterable fields when hostname changes', async () => {
+    arrange();
+
+    const resp = await post({ agentVersion: '0.66.0', hostname: 'new-host' });
+
+    expect(resp.status).toBe(200);
+    expect(emitDeviceChangeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'device.updated',
+        deviceId: 'device-1',
+        orgId: 'org-1',
+        changedFields: ['hostname'],
+      }),
+    );
+  });
+
+  it('reports every changed filterable field at once', async () => {
+    arrange();
+
+    const resp = await post({
+      agentVersion: '0.66.0',
+      hostname: 'new-host',
+      osVersion: '10.0.22631',
+      osBuild: '22631',
+      deviceRole: 'server',
+    });
+
+    expect(resp.status).toBe(200);
+    const [event] = emitDeviceChangeMock.mock.calls.find(
+      (call: unknown[]) => (call[0] as { type: string }).type === 'device.updated',
+    ) ?? [];
+    expect(event?.changedFields).toEqual(
+      expect.arrayContaining(['hostname', 'osVersion', 'osBuild', 'deviceRole']),
+    );
+  });
+
+  it('does not emit when no filterable field changes (steady-state heartbeat)', async () => {
+    arrange();
+
+    const resp = await post({ agentVersion: '0.66.0' });
+
+    expect(resp.status).toBe(200);
+    expect(emitDeviceChangeMock).not.toHaveBeenCalled();
+  });
+
+  it('does not emit for a non-filterable-only change (agentServerUrl)', async () => {
+    arrange();
+
+    const resp = await post({ agentVersion: '0.66.0', serverUrl: 'https://api.example.com' });
+
+    expect(resp.status).toBe(200);
+    expect(emitDeviceChangeMock).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -3809,6 +3809,24 @@ describe('POST /agents/:id/heartbeat — dynamic device group re-evaluation emit
     expect(emitDeviceChangeMock).not.toHaveBeenCalled();
   });
 
+  it('does not emit when the agent re-reports its unchanged auto deviceRole (real steady state)', async () => {
+    // The Go agent sends deviceRole on EVERY heartbeat (heartbeat.go
+    // sendHeartbeat), and deviceRoleSource defaults to 'auto' fleet-wide, so a
+    // body that omits deviceRole is not the steady state — this is.
+    arrange();
+
+    const resp = await post({
+      agentVersion: '0.66.0',
+      hostname: 'old-host',
+      osVersion: '10.0.19045',
+      osBuild: '19045',
+      deviceRole: 'workstation',
+    });
+
+    expect(resp.status).toBe(200);
+    expect(emitDeviceChangeMock).not.toHaveBeenCalled();
+  });
+
   it('does not emit for a non-filterable-only change (agentServerUrl)', async () => {
     arrange();
 

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -838,8 +838,12 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
     deviceUpdates.mainAgentSilentSince = null;
   }
 
-  // Only update deviceRole if agent provides one and current source is 'auto'
-  if (data.deviceRole && device.deviceRoleSource === 'auto') {
+  // Only update deviceRole if agent provides one, current source is 'auto',
+  // and it actually differs. The agent sends deviceRole on EVERY heartbeat and
+  // 'auto' is the fleet-wide default, so without the inequality check every
+  // steady-state heartbeat would look like a filterable change and trigger a
+  // dynamic-group re-evaluation (#4630 review).
+  if (data.deviceRole && device.deviceRoleSource === 'auto' && data.deviceRole !== device.deviceRole) {
     deviceUpdates.deviceRole = data.deviceRole;
   }
 

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -38,6 +38,7 @@ import {
 } from './helpers';
 import { shouldSendAgentUpgrade } from './agentUpdatePolicy';
 import { processDeviceIPHistoryUpdate } from '../../services/deviceIpHistory';
+import { emitDeviceChange, createDeviceChangeEvent } from '../../events/deviceEvents';
 import { claimPendingCommandsForDevice } from '../../services/commandDispatch';
 import { publishEvent } from '../../services/eventBus';
 import { DRAIN_CLAIM_TYPE_ALLOWLIST, isAgentTokenRotationDue } from '../../middleware/agentAuth';
@@ -1089,6 +1090,21 @@ heartbeatRoutes.post('/:id/heartbeat', bodyLimit({ maxSize: 5 * 1024 * 1024, onE
         resourceId: device.id,
         details: { changes },
       });
+    }
+
+    // #4630 — dynamic device group membership re-evaluation. Only the fields
+    // a filter can actually key on; must be awaited so the DB work it triggers
+    // (groupMembership.ts) runs inside this request's still-open
+    // withDbAccessContext, not after the response has released it.
+    const filterableChangedFields = (['hostname', 'osVersion', 'osBuild', 'deviceRole'] as const)
+      .filter((field) => deviceUpdates[field] !== undefined);
+    if (filterableChangedFields.length > 0) {
+      await emitDeviceChange(createDeviceChangeEvent(
+        'device.updated',
+        device.id,
+        device.orgId,
+        filterableChangedFields,
+      ));
     }
   }
 

--- a/apps/api/src/routes/devices/groups.test.ts
+++ b/apps/api/src/routes/devices/groups.test.ts
@@ -69,6 +69,7 @@ vi.mock('../../services/auditEvents', () => ({
 
 vi.mock('../../services/groupMembership', () => ({
   pruneGroupMembershipsOutsideSite: vi.fn().mockResolvedValue({ removed: 0 }),
+  evaluateGroupMembership: vi.fn().mockResolvedValue({ evaluatedGroups: 1, added: 0, removed: 0 }),
 }));
 
 vi.mock('../../jobs/peripheralJobs', () => ({
@@ -109,7 +110,7 @@ vi.mock('@hono/zod-validator', () => ({
 
 import { groupsRoutes } from './groups';
 import { writeRouteAudit } from '../../services/auditEvents';
-import { pruneGroupMembershipsOutsideSite } from '../../services/groupMembership';
+import { pruneGroupMembershipsOutsideSite, evaluateGroupMembership } from '../../services/groupMembership';
 import { DeviceGroupDeleteError } from '../../services/deviceGroupDelete';
 
 // ---------------------------------------------------------------------------
@@ -360,6 +361,29 @@ describe('Device Groups routes — multi-tenant isolation', () => {
       const json = await res.json();
       expect(json.id).toBe(GROUP_ID);
       expect(writeRouteAudit).toHaveBeenCalled();
+      expect(evaluateGroupMembership).not.toHaveBeenCalled();
+    });
+
+    // #4630 — parity with POST /groups (routes/groups.ts): a dynamic group's
+    // filter must be evaluated immediately on create, on this route too.
+    it('evaluates membership for a dynamic group carrying filterConditions', async () => {
+      const created = {
+        id: GROUP_ID,
+        orgId: ORG_A,
+        name: 'Servers',
+        type: 'dynamic',
+        filterConditions: { operator: 'AND', conditions: [] },
+      };
+      mockInsert.mockReturnValue(chainInsert([created]));
+
+      const res = await app.request('/devices/groups', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ orgId: ORG_A, name: 'Servers', type: 'dynamic' }),
+      });
+
+      expect(res.status).toBe(201);
+      expect(evaluateGroupMembership).toHaveBeenCalledWith(GROUP_ID);
     });
 
     it('returns 403 when org-scoped user targets a different org', async () => {
@@ -585,6 +609,49 @@ describe('Device Groups routes — multi-tenant isolation', () => {
         DEVICE_1,
         'dynamic_membership_changed',
       );
+    });
+
+    // #4630 — parity with PATCH /groups/:id (routes/groups.ts): a dynamic
+    // group's filter must be re-evaluated when its site changes.
+    it('evaluates membership for a dynamic group with filterConditions when its site changes', async () => {
+      const oldSiteId = 'eeee0001-eeee-eeee-eeee-eeeeeeeeeeee';
+      const group = {
+        ...groupInOrgA,
+        type: 'dynamic',
+        siteId: oldSiteId,
+        filterConditions: { operator: 'AND', conditions: [] },
+      };
+      mockSelect
+        .mockReturnValueOnce(chainSelect([group]))
+        .mockReturnValueOnce(chainSelect([{ id: SITE_ID }]));
+      mockUpdate.mockReturnValue(chainUpdate([{ ...group, siteId: SITE_ID }]));
+
+      const res = await app.request(`/devices/groups/${GROUP_ID}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ siteId: SITE_ID }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(evaluateGroupMembership).toHaveBeenCalledWith(GROUP_ID);
+    });
+
+    it('does not evaluate membership for a static group whose site changes', async () => {
+      const oldSiteId = 'eeee0001-eeee-eeee-eeee-eeeeeeeeeeee';
+      const group = { ...groupInOrgA, siteId: oldSiteId };
+      mockSelect
+        .mockReturnValueOnce(chainSelect([group]))
+        .mockReturnValueOnce(chainSelect([{ id: SITE_ID }]));
+      mockUpdate.mockReturnValue(chainUpdate([{ ...group, siteId: SITE_ID }]));
+
+      const res = await app.request(`/devices/groups/${GROUP_ID}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ siteId: SITE_ID }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(evaluateGroupMembership).not.toHaveBeenCalled();
     });
 
     it('rolls back a legacy site reassignment when membership pruning fails', async () => {

--- a/apps/api/src/routes/devices/groups.ts
+++ b/apps/api/src/routes/devices/groups.ts
@@ -9,7 +9,7 @@ import { getPagination, ensureOrgAccess } from './helpers';
 import { PG_UUID_REGEX } from '../../utils/uuid';
 import { createGroupSchema, updateGroupSchema } from './schemas';
 import { writeRouteAudit } from '../../services/auditEvents';
-import { pruneGroupMembershipsOutsideSite } from '../../services/groupMembership';
+import { evaluateGroupMembership, pruneGroupMembershipsOutsideSite } from '../../services/groupMembership';
 import { schedulePeripheralPolicyDevice } from '../../jobs/peripheralJobs';
 import { deleteDeviceGroup, DeviceGroupDeleteError } from '../../services/deviceGroupDelete';
 
@@ -179,6 +179,20 @@ groupsRoutes.post(
       resourceName: group?.name
     });
 
+    // #4630 — same materialization path as POST /groups (routes/groups.ts):
+    // a dynamic group must never be created without evaluating its filter.
+    // This endpoint's schema has no filterConditions field today, so
+    // group.filterConditions is always null and this is currently a no-op —
+    // kept for structural parity so it activates automatically if/when this
+    // route gains filter support.
+    if (group?.type === 'dynamic' && group.filterConditions) {
+      try {
+        await evaluateGroupMembership(group.id);
+      } catch (err) {
+        console.error(`Failed to evaluate membership for new group ${group.id}:`, err);
+      }
+    }
+
     return c.json(group, 201);
   }
 );
@@ -299,6 +313,17 @@ groupsRoutes.patch(
       resourceName: updated?.name ?? group.name,
       details: { changedFields: Object.keys(data) }
     });
+
+    // #4630 — same materialization path as PATCH /groups/:id. See the create
+    // handler above for why this is currently a no-op on this route.
+    const effectiveType = data.type ?? group.type;
+    if (effectiveType === 'dynamic' && siteChanged && updated?.filterConditions) {
+      try {
+        await evaluateGroupMembership(updated.id);
+      } catch (err) {
+        console.error(`Failed to evaluate membership for group ${updated.id}:`, err);
+      }
+    }
 
     return c.json(updated);
   }

--- a/apps/api/src/routes/devices/provision.test.ts
+++ b/apps/api/src/routes/devices/provision.test.ts
@@ -83,6 +83,13 @@ vi.mock('../../services/provisionCredentialHandle', () => ({
   provisionHandleExpiresAt: vi.fn(() => new Date('2030-01-01T00:00:00.000Z')),
 }));
 
+// #4630 — dynamic device group re-evaluation emit on provisioning.
+const emitDeviceChangeMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+vi.mock('../../events/deviceEvents', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../events/deviceEvents')>();
+  return { ...actual, emitDeviceChange: emitDeviceChangeMock };
+});
+
 import { db } from '../../db';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { provisionRoutes } from './provision';
@@ -397,6 +404,16 @@ describe('POST /devices/provision', () => {
         expect.objectContaining({
           action: 'device.provision',
           resourceId: 'device-prov-id',
+          orgId: ORG_ID,
+        }),
+      );
+
+      // #4630 — the new device is evaluated against every dynamic group in
+      // its org immediately, not just on its next heartbeat.
+      expect(emitDeviceChangeMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'device.created',
+          deviceId: 'device-prov-id',
           orgId: ORG_ID,
         }),
       );

--- a/apps/api/src/routes/devices/provision.ts
+++ b/apps/api/src/routes/devices/provision.ts
@@ -24,6 +24,7 @@ import {
   generateProvisionHandleToken,
   provisionHandleExpiresAt,
 } from '../../services/provisionCredentialHandle';
+import { emitDeviceChange, createDeviceChangeEvent } from '../../events/deviceEvents';
 
 export const provisionRoutes = new Hono();
 
@@ -296,6 +297,14 @@ provisionRoutes.post(
       captureException(err instanceof Error ? err : new Error(String(err)));
       return c.json({ error: 'Failed to provision device' }, 500);
     }
+
+    // #4630 — evaluate the new device against every dynamic group in its org
+    // immediately, so a group filtering on hostname/site (already correct at
+    // insert) doesn't have to wait for a heartbeat that would never report a
+    // diff for those fields. Runs inside this request's own org-scoped
+    // withDbAccessContext, matching evaluateGroupMembership's usage in
+    // routes/groups.ts.
+    await emitDeviceChange(createDeviceChangeEvent('device.created', device.id, data.orgId, []));
 
     // ----------- mTLS cert + manifest trust keys for the config blob -----------
     const mtlsCert = await issueMtlsCertForDevice(device.id, data.orgId);


### PR DESCRIPTION
## Summary

Dynamic device group membership was only ever (re)materialized on group create/update — nothing re-evaluated a group when the *device* changed. The per-device re-evaluation pipeline in `apps/api/src/events/deviceEvents.ts` existed but was never wired to anything (no caller of `initializeDeviceEventHandlers`, no caller of `emitDeviceChange` outside its own module). This wires it up:

- `apps/api/src/index.ts`: calls `initializeDeviceEventHandlers()` at boot, alongside `registerAllEventSubscribers` (in-process handler registration, no Redis dependency, so it runs in every role).
- `apps/api/src/routes/agents/heartbeat.ts`: emits `device.updated` with the changed filterable fields (`hostname`, `osVersion`, `osBuild`, `deviceRole`) whenever the heartbeat's own device UPDATE actually changed one of them.
- `apps/api/src/routes/agents/enrollment.ts`: emits `device.created` for a freshly enrolled (or re-enrolled) device, so a group filtering on hostname/OS/role that's already correct at insert doesn't have to wait for a heartbeat diff that will never fire.
- `apps/api/src/routes/devices/provision.ts`: same `device.created` emit for the pre-registration/pending-device provisioning path.
- `apps/api/src/routes/devices/groups.ts` (the `/devices/groups` duplicate of `/groups`): now calls `evaluateGroupMembership` on dynamic-group create/update, matching `routes/groups.ts`. This route's schema has no `filterConditions` field today, so the call is presently a no-op — kept for structural parity per the issue's explicit ask, and it activates automatically if/when this route gains filter support.

## Root cause

`deviceEvents.ts`'s exports (`emitDeviceChange`, `onDeviceChange`, `initializeDeviceEventHandlers`) had zero callers repo-wide outside their own file and tests. The module also used `require('../services/groupMembership')` inside `initializeDeviceEventHandlers` for circular-dependency avoidance that groupMembership.ts never actually created (it doesn't import deviceEvents.ts) — that `require()` call is unreachable/untested code in this package's ESM (`"type": "module"`) source, and fails outright under vitest, which is presumably why this dead code was never caught. Converted to static imports; verified this doesn't introduce the cycle the comment worried about.

## What was already fixed on `main` (verified, not touched here)

- **Org-move membership drop** (issue's closing comment): already handled, both at the DB level (`breeze_cascade_device_org_id()` trigger, migration `2026-10-09-000200-device-group-memberships-composite-tenant-fks.sql`) and at the app level (`routes/devices/moveOrg.ts:451`, explicit `DELETE FROM device_group_memberships WHERE device_id = ...`).
- Composite tenant FKs on `device_group_memberships` (group_id, org_id) and (device_id, org_id) already exist and already reject the cross-tenant shape the issue described.

## Left out of scope (documented, not silently dropped)

- **Software-change emission**: `deviceEvents.ts` already has a `device.software_changed` handler wired to `updateDeviceMemberships(..., ['software.installed', 'software.notInstalled'])`, but I did not wire an `emitDeviceChange` call from the actual software-inventory ingest path (`routes/agents/inventory.ts` → `ingestSoftwareInventoryReport`). That function's return shape has no "did the installed-software set actually change" signal, so emitting unconditionally on every accepted report risks re-evaluating every dynamic group in the org on every routine software-inventory sync, not just on a real diff. Needs a real diff signal from `ingestSoftwareInventoryReport` first; flagging as a follow-up rather than wiring it blind.
- **`routes/agents/enrollment.ts`'s big transactional insert**: the `device.created` emit is placed right after the transaction commits (using the confirmed non-`Response` `device` row), not inside the transaction — this handler has multiple early-return branches (race-lost, HTTPException) that made touching the transaction body itself too risky for this change's blast radius.
- **`device.deleted` wiring**: intentionally not wired. The hard-delete path (`DELETE /:id/permanent`) already cascades `device_group_memberships` rows away via `CORE_DEVICE_CASCADE_DELETE_TABLES`, so emitting there would be a redundant no-op. The soft-decommission path (`DELETE /:id`) does NOT delete the device row, and force-removing it from every dynamic group via `removeDeviceFromAllGroups` would incorrectly evict a decommissioned device whose non-status attributes still match the group's filter — that's a behavior change, not a bug fix, so left alone.
- **Periodic reconciliation sweep** (the issue's suggested backstop #2): not in this PR's scope per the dispatch brief's minimum-scope list.
- No boot-order unit test asserting `initializeDeviceEventHandlers()` fires from `index.ts` specifically (there's no `index.boot.test.ts` equivalent to `worker.boot.test.ts` to extend, and building one for a single call site felt disproportionate). Verified instead via `tsc`, targeted vitest runs, and direct grep.

## Verification

```
cd apps/api
NODE_OPTIONS="--max-old-space-size=8192" npx tsc --noEmit -p .          # clean
npx vitest run src/events                                               # 12 passed
npx vitest run src/routes/devices/groups.test.ts                        # 60 passed
npx vitest run src/routes/devices/provision.test.ts                     # 24 passed
npx vitest run src/routes/agents/heartbeat.test.ts                      # 187 passed
npx vitest run src/routes/agents/enrollment.test.ts                     # 65 passed
npx vitest run src/routes/groups.test.ts                                # 14 passed
npx eslint <all changed files>                                          # clean
```
Total: 362 tests passed across the affected files, tsc clean, eslint clean.

## Decisions / notes for reviewer

- `routes/devices/groups.ts`'s `evaluateGroupMembership` wiring is currently inert (see above) because that route's `createGroupSchema`/`updateGroupSchema` never accepted `filterConditions`. I did not expand the schema — that's a separate, larger decision (whether this duplicate route should gain full filter support or just be deleted in favor of `/groups`) that the issue itself flags as an open question ("fold ... or delete the duplicate route file").
- Heartbeat's emit is `await`ed (not fire-and-forget) so it runs inside the request's still-open `withDbAccessContext`, per the exact bug class documented in `routes/groups.ts`'s comments for the same reason.
- `initializeDeviceEventHandlers()` is only called from `index.ts`, not `worker.ts` — the latter never serves the heartbeat/enrollment/provision HTTP routes that call `emitDeviceChange`, so registering handlers there would be dead weight.

Closes #4630

🤖 Generated with [Claude Code](https://claude.com/claude-code)