### PR TITLE
perf(inventory): scope the finding pre-lock by org_id so it hits device_vuln_org_device_idx

### DIFF
--- a/apps/api/src/services/softwareInventoryObservations.test.ts
+++ b/apps/api/src/services/softwareInventoryObservations.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PgDialect } from 'drizzle-orm/pg-core';
 import type { LegacySoftwareInventoryReport, SoftwareInventoryObservationV2 } from '@breeze/shared';
 
 // Hoisted so the `vi.mock` factories below (themselves hoisted above these
@@ -195,6 +196,34 @@ describe('replaceSoftwareInventoryProjection', () => {
     expect(ordered).toHaveBeenCalledTimes(1);
     expect(locked).toHaveBeenCalledWith('update', expect.any(Object));
     expect(updateSets).toEqual([expect.objectContaining({ softwareInventoryId: 'new-row' })]);
+  });
+
+  it('scopes the finding pre-lock by org_id so it can use device_vuln_org_device_idx (device_id alone has no leading index)', async () => {
+    const where = vi.fn().mockReturnValue({ orderBy: vi.fn().mockReturnValue({ for: vi.fn().mockResolvedValue([]) }) });
+    const tx = {
+      select: vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          innerJoin: vi.fn().mockReturnValue({ where }),
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      }),
+      delete: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+      insert: vi.fn().mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) }),
+      update: vi.fn(),
+    };
+
+    await replaceSoftwareInventoryProjection(tx as never, {
+      device: { id: 'device-1', orgId: 'org-1', agentVersion: '1.0.0' },
+      items: [],
+      observationId: '11111111-1111-4111-8111-111111111111',
+      receivedAt: new Date('2026-09-06T00:00:00Z'),
+    });
+
+    expect(where).toHaveBeenCalledTimes(1);
+    const rendered = new PgDialect().sqlToQuery(where.mock.calls[0][0]);
+    expect(rendered.sql).toContain('"device_vulnerabilities"."org_id" = ');
+    expect(rendered.sql).toContain('"device_vulnerabilities"."device_id" = ');
+    expect(rendered.params).toContain('org-1');
   });
 
   it('does not re-link a finding when only the normalized name matches but vendor differs', async () => {

--- a/apps/api/src/services/softwareInventoryObservations.ts
+++ b/apps/api/src/services/softwareInventoryObservations.ts
@@ -187,7 +187,15 @@ export async function replaceSoftwareInventoryProjection(
     .select({ findingId: deviceVulnerabilities.id, name: softwareInventory.name, vendor: softwareInventory.vendor })
     .from(deviceVulnerabilities)
     .innerJoin(softwareInventory, eq(deviceVulnerabilities.softwareInventoryId, softwareInventory.id))
-    .where(and(eq(deviceVulnerabilities.deviceId, device.id), eq(softwareInventory.deviceId, device.id)))
+    // org_id first: device_vulnerabilities has no index led by device_id (only
+    // device_vuln_org_device_idx on (org_id, device_id)), so a device_id-only
+    // predicate scanned the whole table under the row lock on every inventory
+    // sync — 789 ms mean / 738 s max on US prod (2026-09-06).
+    .where(and(
+      eq(deviceVulnerabilities.orgId, device.orgId),
+      eq(deviceVulnerabilities.deviceId, device.id),
+      eq(softwareInventory.deviceId, device.id),
+    ))
     .orderBy(deviceVulnerabilities.id)
     .for('update', { of: deviceVulnerabilities });
 


### PR DESCRIPTION
## Why

`replaceSoftwareInventoryProjection` (every software-inventory sync) locks a device's linked findings with `SELECT ... FOR UPDATE OF device_vulnerabilities WHERE device_vulnerabilities.device_id = $1 AND software_inventory.device_id = $2`.

`device_vulnerabilities` has no index led by `device_id` (its FK is uncovered). The only candidate, `device_vuln_org_device_idx (org_id, device_id)`, cannot serve a `device_id`-only predicate, so the statement scanned the table under the row lock on every sync.

US prod `pg_stat_statements`, 2026-08-30 to 09-06:

| calls | mean | max | shared_blks_read |
|---|---|---|---|
| 32,657 | 789 ms | 738 s | 3.2M |

## What

Add `eq(deviceVulnerabilities.orgId, device.orgId)` to the predicate. The caller already has the org, the index already exists, no migration. Semantics unchanged (a device's findings are always in the device's org).

## Verified

- Red-first: new test renders the `WHERE` with `PgDialect.sqlToQuery` and asserts both `org_id` and `device_id` predicates; failed before the change, passes after.
- `softwareInventoryObservations.test.ts`: 18 passed. `tsc --noEmit` clean.

Part of the DB deep-dive following the US slowness on 2026-09-06 (sibling: #5009).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SBWJSD8QenDKGnnTsKtgs