### PR TITLE
perf(db): indexes for four recurring-job predicates with no covering index

### DIFF
--- a/apps/api/migrations/2026-10-11-000300-recurring-job-missing-indexes.sql
+++ b/apps/api/migrations/2026-10-11-000300-recurring-job-missing-indexes.sql
@@ -1,0 +1,54 @@
+-- @no-transaction
+-- Three recurring-job predicates with no covering index, found by the
+-- 2026-09-06 DB deep-dive (issue #5020) after device_process_samples
+-- (#5009) showed the pattern: a hot job filters on columns that no index
+-- leads with, so every call scans the table. All three scale with the fleet.
+--
+-- 1. snmp_metrics (org_id, timestamp)
+--    rollupRawSnmpMetrics (services/metricRollups.ts) filters
+--    `org_id = $1 AND timestamp >= $2 AND timestamp < $3` per org every
+--    5 minutes. Only single-column device_id / oid / timestamp indexes exist
+--    (0001-baseline.sql); the org_id FK is uncovered. Same shape as #5009.
+--
+-- 2. device_group_memberships (group_id, device_id)
+--    patchSchedulerWorker (every 60 s, per group-assigned policy) and the
+--    backup assignment resolver / backupSlaWorker filter `group_id = $1`.
+--    The only index is the primary key (device_id, group_id) — group_id is
+--    the trailing column, unusable for that predicate. device_id second so
+--    member listings can be index-only.
+--
+-- 3. device_disks (device_id)
+--    Every inventory cycle runs DELETE ... WHERE device_id = $1 then
+--    reinserts (routes/agents/inventory.ts); the only index is the PK on id
+--    (US prod: 32k calls / 402 ms mean over 6 days). device_network had the
+--    identical gap fixed on 2026-08-07; this is the sibling that was missed.
+--
+-- CREATE INDEX CONCURRENTLY: all three tables take agent writes continuously.
+-- IF NOT EXISTS keeps re-application a no-op. An interrupted CONCURRENTLY
+-- build leaves an INVALID index that IF NOT EXISTS would silently accept, so
+-- the DO block fails loudly. Recovery: DROP INDEX CONCURRENTLY <name>, then
+-- let autoMigrate re-run this file.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS snmp_metrics_org_ts_idx
+  ON public.snmp_metrics (org_id, "timestamp");
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS device_group_memberships_group_device_idx
+  ON public.device_group_memberships (group_id, device_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS device_disks_device_id_idx
+  ON public.device_disks (device_id);
+
+DO $$
+DECLARE
+  bad text;
+BEGIN
+  SELECT string_agg(c.relname, ', ')
+    INTO bad
+    FROM pg_index i
+    JOIN pg_class c ON c.oid = i.indexrelid
+   WHERE c.relname IN ('snmp_metrics_org_ts_idx', 'device_group_memberships_group_device_idx', 'device_disks_device_id_idx')
+     AND NOT i.indisvalid;
+  IF bad IS NOT NULL THEN
+    RAISE EXCEPTION 'recurring-job index build left INVALID index(es): % — DROP INDEX CONCURRENTLY each and re-apply this migration', bad;
+  END IF;
+END $$;

--- a/apps/api/migrations/2026-10-11-000300-recurring-job-missing-indexes.sql
+++ b/apps/api/migrations/2026-10-11-000300-recurring-job-missing-indexes.sql
@@ -1,5 +1,5 @@
 -- @no-transaction
--- Three recurring-job predicates with no covering index, found by the
+-- Four recurring-job predicates with no covering index, found by the
 -- 2026-09-06 DB deep-dive (issue #5020) after device_process_samples
 -- (#5009) showed the pattern: a hot job filters on columns that no index
 -- leads with, so every call scans the table. All three scale with the fleet.
@@ -23,7 +23,18 @@
 --    (US prod: 32k calls / 402 ms mean over 6 days). device_network had the
 --    identical gap fixed on 2026-08-07; this is the sibling that was missed.
 --
--- CREATE INDEX CONCURRENTLY: all three tables take agent writes continuously.
+-- 4. device_vulnerabilities (device_id)
+--    replaceSoftwareInventoryProjection (every software-inventory sync) locks
+--    the device's findings with SELECT ... FOR UPDATE WHERE device_id = $1.
+--    The only candidate index is (org_id, device_id), which a device_id-only
+--    predicate cannot use, so each sync scanned the table under the row lock
+--    (US prod: 32,657 calls, 789 ms mean, 738 s max). The device_id FK was
+--    uncovered, so device cascade deletes paid the same scan. A device-led
+--    index is preferred over adding an org_id predicate to the query: the
+--    ingest runs in a system-scoped context, and a stale org_id during an org
+--    move would have silently skipped findings.
+--
+-- CREATE INDEX CONCURRENTLY: all four tables take agent writes continuously.
 -- IF NOT EXISTS keeps re-application a no-op. An interrupted CONCURRENTLY
 -- build leaves an INVALID index that IF NOT EXISTS would silently accept, so
 -- the DO block fails loudly. Recovery: DROP INDEX CONCURRENTLY <name>, then
@@ -38,16 +49,26 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS device_group_memberships_group_device_id
 CREATE INDEX CONCURRENTLY IF NOT EXISTS device_disks_device_id_idx
   ON public.device_disks (device_id);
 
+CREATE INDEX CONCURRENTLY IF NOT EXISTS device_vulnerabilities_device_id_idx
+  ON public.device_vulnerabilities (device_id);
+
 DO $$
 DECLARE
   bad text;
 BEGIN
+  -- Pair each index with its table so an unrelated same-named INVALID index
+  -- elsewhere cannot abort this migration.
   SELECT string_agg(c.relname, ', ')
     INTO bad
-    FROM pg_index i
-    JOIN pg_class c ON c.oid = i.indexrelid
-   WHERE c.relname IN ('snmp_metrics_org_ts_idx', 'device_group_memberships_group_device_idx', 'device_disks_device_id_idx')
-     AND NOT i.indisvalid;
+    FROM (VALUES
+      ('public.snmp_metrics'::regclass,             'snmp_metrics_org_ts_idx'),
+      ('public.device_group_memberships'::regclass, 'device_group_memberships_group_device_idx'),
+      ('public.device_disks'::regclass,             'device_disks_device_id_idx'),
+      ('public.device_vulnerabilities'::regclass,   'device_vulnerabilities_device_id_idx')
+    ) AS expected(tbl, idx)
+    JOIN pg_class c ON c.relname = expected.idx AND c.relnamespace = 'public'::regnamespace
+    JOIN pg_index i ON i.indexrelid = c.oid AND i.indrelid = expected.tbl
+   WHERE NOT i.indisvalid;
   IF bad IS NOT NULL THEN
     RAISE EXCEPTION 'recurring-job index build left INVALID index(es): % — DROP INDEX CONCURRENTLY each and re-apply this migration', bad;
   END IF;


### PR DESCRIPTION
## Why

Tier 1 of #5020. Four recurring paths filter on columns no index leads with, so each call scans the table (same shape as #5009):

| table | job | predicate | existing indexes |
|---|---|---|---|
| `snmp_metrics` | `rollupRawSnmpMetrics`, per org every 5 min | `org_id`, `timestamp` range | single-column `device_id` / `oid` / `timestamp` only |
| `device_group_memberships` | `patchSchedulerWorker` (60 s), backup assignment resolver / `backupSlaWorker` | `group_id` | PK `(device_id, group_id)` only, `group_id` trailing |
| `device_disks` | inventory full-replace `DELETE WHERE device_id` every cycle | `device_id` | PK on `id` only (US: 32k calls / 402 ms mean) |
| `device_vulnerabilities` | `replaceSoftwareInventoryProjection` `SELECT ... FOR UPDATE WHERE device_id` every software sync | `device_id` | `(org_id, device_id)` only (US: 32,657 calls, 789 ms mean, 738 s max) |

`device_network` had the identical `device_disks` gap fixed on 2026-08-07. The `device_vulnerabilities` row replaces #5017: that PR added an `org_id` predicate to the query instead, but the ingest runs in a system-scoped context, so a stale `org_id` during an org move would silently skip findings. A device-led index gets the same plan with no semantic change.

## What

`2026-10-11-000300-recurring-job-missing-indexes.sql` (`@no-transaction`): four `CREATE INDEX CONCURRENTLY IF NOT EXISTS`, plus an INVALID-index guard that pairs each index name with its table's regclass.

## Verified

- Naming guard OK; `autoMigrate.test.ts` + `migrationRlsScope.test.ts` 100 passed.
- Applied twice to a local Postgres (second run NOTICE no-op); `EXPLAIN` shows all four predicates using the new indexes, including the `FOR UPDATE` pre-lock.
- Codex medium review of the whole batch: index/predicate correctness and naming clean; its two findings (guard scope, org predicate race) are addressed here.

Already built by hand on US and EU prod (concurrently, all valid); the migration is a no-op there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SBWJSD8QenDKGnnTsKtgs